### PR TITLE
[jit] Convert stores into sign/zero extensions for small ints during alias-analysis. Fixes #6414.

### DIFF
--- a/mono/mini/alias-analysis.c
+++ b/mono/mini/alias-analysis.c
@@ -93,7 +93,11 @@ lower_store (MonoCompile *cfg, MonoInst *store, MonoInst *ldaddr)
 		if (cfg->verbose_level > 2) { printf ("mem2reg replacing: "); mono_print_ins (store); }
 	}
 
-	store->opcode = mono_type_to_regmove (cfg, type);
+	int coerce_op = mono_type_to_stloc_coerce (type);
+	if (coerce_op)
+		store->opcode = coerce_op;
+	else
+		store->opcode = mono_type_to_regmove (cfg, type);
 	type_to_eval_stack_type (cfg, type, store);
 	store->dreg = var->dreg;
 	InterlockedIncrement (&mono_jit_stats.stores_eliminated);

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -6611,7 +6611,7 @@ set_exception_type_from_invalid_il (MonoCompile *cfg, MonoMethod *method, unsign
 	cfg->headers_to_free = g_slist_prepend_mempool (cfg->mempool, cfg->headers_to_free, header);
 }
 
-static guint32
+guint32
 mono_type_to_stloc_coerce (MonoType *type)
 {
 	if (type->byref)

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2454,6 +2454,7 @@ int       mono_op_imm_to_op                 (int opcode);
 int       mono_load_membase_to_load_mem     (int opcode);
 guint     mono_type_to_load_membase         (MonoCompile *cfg, MonoType *type);
 guint     mono_type_to_store_membase        (MonoCompile *cfg, MonoType *type);
+guint32   mono_type_to_stloc_coerce         (MonoType *type);
 guint     mini_type_to_stind                (MonoCompile* cfg, MonoType *type);
 MonoJitInfo* mini_lookup_method             (MonoDomain *domain, MonoMethod *method, MonoMethod *shared);
 guint32   mono_reverse_branch_op            (guint32 opcode);

--- a/mono/mini/objects.cs
+++ b/mono/mini/objects.cs
@@ -1829,6 +1829,19 @@ ncells ) {
 
 		return 0;
 	}
+
+	static void decode (out sbyte v) {
+		byte tmp = 134;
+		v = (sbyte)tmp;
+	}
+
+	// gh #6414
+	public static int test_0_alias_analysis_sign_extend () {
+	  sbyte t;
+	  decode (out t);
+
+	  return t == -122 ? 0 : 1;
+	}
 }
 
 #if __MOBILE__


### PR DESCRIPTION
(cherry picked from commit d32dfaad8fdd4a3a765aa4f2739f3df566d62a4f)