### PR TITLE
Fix bug 60848: Incorrect unicode custom attribute decoding

### DIFF
--- a/mono/eglib/giconv.c
+++ b/mono/eglib/giconv.c
@@ -833,15 +833,19 @@ g_utf8_to_ucs4_fast (const gchar *str, glong len, glong *items_written)
 }
 
 static gunichar2 *
-eg_utf8_to_utf16_general (const gchar *str, glong len, glong *items_read, glong *items_written, gboolean include_nuls, GError **err)
-{
+eg_utf8_to_utf16_general (
+	const gchar *str, glong len, 
+	glong *items_read, glong *items_written, 
+	gboolean include_nuls, gboolean replace_invalid_codepoints,
+	GError **err
+) {
 	gunichar2 *outbuf, *outptr;
 	size_t outlen = 0;
 	size_t inleft;
 	char *inptr;
 	gunichar c;
 	int u, n;
-	
+
 	g_return_val_if_fail (str != NULL, NULL);
 	
 	if (len < 0) {
@@ -864,8 +868,12 @@ eg_utf8_to_utf16_general (const gchar *str, glong len, glong *items_read, glong 
 			break;
 		
 		if ((u = g_unichar_to_utf16 (c, NULL)) < 0) {
-			errno = EILSEQ;
-			goto error;
+			if (replace_invalid_codepoints) {
+				u = 2;
+			} else {
+				errno = EILSEQ;
+				goto error;
+			}
 		}
 		
 		outlen += u;
@@ -890,7 +898,14 @@ eg_utf8_to_utf16_general (const gchar *str, glong len, glong *items_read, glong 
 		if (c == 0 && !include_nuls)
 			break;
 		
-		outptr += g_unichar_to_utf16 (c, outptr);
+		u = g_unichar_to_utf16 (c, outptr);
+		if ((u < 0) && replace_invalid_codepoints) {
+			outptr[0] = 0xFFFD;
+			outptr[1] = 0xFFFD;
+			u = 2;
+		}
+
+		outptr += u;
 		inleft -= n;
 		inptr += n;
 	}
@@ -922,13 +937,19 @@ eg_utf8_to_utf16_general (const gchar *str, glong len, glong *items_read, glong 
 gunichar2 *
 g_utf8_to_utf16 (const gchar *str, glong len, glong *items_read, glong *items_written, GError **err)
 {
-	return eg_utf8_to_utf16_general (str, len, items_read, items_written, FALSE, err);
+	return eg_utf8_to_utf16_general (str, len, items_read, items_written, FALSE, FALSE, err);
 }
 
 gunichar2 *
 eg_utf8_to_utf16_with_nuls (const gchar *str, glong len, glong *items_read, glong *items_written, GError **err)
 {
-	return eg_utf8_to_utf16_general (str, len, items_read, items_written, TRUE, err);
+	return eg_utf8_to_utf16_general (str, len, items_read, items_written, TRUE, FALSE, err);
+}
+
+gunichar2 *
+eg_wtf8_to_utf16 (const gchar *str, glong len, glong *items_read, glong *items_written, GError **err)
+{
+	return eg_utf8_to_utf16_general (str, len, items_read, items_written, TRUE, TRUE, err);
 }
 
 gunichar *

--- a/mono/eglib/giconv.c
+++ b/mono/eglib/giconv.c
@@ -833,19 +833,15 @@ g_utf8_to_ucs4_fast (const gchar *str, glong len, glong *items_written)
 }
 
 static gunichar2 *
-eg_utf8_to_utf16_general (
-	const gchar *str, glong len, 
-	glong *items_read, glong *items_written, 
-	gboolean include_nuls, gboolean replace_invalid_codepoints,
-	GError **err
-) {
+eg_utf8_to_utf16_general (const gchar *str, glong len, glong *items_read, glong *items_written, gboolean include_nuls, gboolean replace_invalid_codepoints,	GError **err) 
+{
 	gunichar2 *outbuf, *outptr;
 	size_t outlen = 0;
 	size_t inleft;
 	char *inptr;
 	gunichar c;
 	int u, n;
-
+	
 	g_return_val_if_fail (str != NULL, NULL);
 	
 	if (len < 0) {

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -746,6 +746,7 @@ gunichar  *g_utf8_to_ucs4_fast (const gchar *str, glong len, glong *items_writte
 gunichar  *g_utf8_to_ucs4 (const gchar *str, glong len, glong *items_read, glong *items_written, GError **err);
 gunichar2 *g_utf8_to_utf16 (const gchar *str, glong len, glong *items_read, glong *items_written, GError **err);
 gunichar2 *eg_utf8_to_utf16_with_nuls (const gchar *str, glong len, glong *items_read, glong *items_written, GError **err);
+gunichar2 *eg_wtf8_to_utf16 (const gchar *str, glong len, glong *items_read, glong *items_written, GError **err);
 gchar     *g_utf16_to_utf8 (const gunichar2 *str, glong len, glong *items_read, glong *items_written, GError **err);
 gunichar  *g_utf16_to_ucs4 (const gunichar2 *str, glong len, glong *items_read, glong *items_written, GError **err);
 gchar     *g_ucs4_to_utf8  (const gunichar *str, glong len, glong *items_read, glong *items_written, GError **err);

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1845,6 +1845,9 @@ mono_string_new_len_checked (MonoDomain *domain, const char *text, guint length,
 MonoString*
 mono_string_new_checked (MonoDomain *domain, const char *text, MonoError *merror);
 
+MonoString*
+mono_string_new_wtf8_len_checked (MonoDomain *domain, const char *text, guint length, MonoError *error);
+
 MonoString *
 mono_string_new_utf16_checked (MonoDomain *domain, const guint16 *text, gint32 len, MonoError *error);
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -6380,6 +6380,38 @@ leave:
 }
 
 /**
+ * mono_string_new_wtf8_len_checked:
+ * \param text a pointer to an wtf8 string (see https://simonsapin.github.io/wtf-8/)
+ * \param length number of bytes in \p text to consider
+ * \param merror set on error
+ * \returns A newly created string object which contains \p text.
+ * On error returns NULL and sets \p merror.
+ */
+MonoString*
+mono_string_new_wtf8_len_checked (MonoDomain *domain, const char *text, guint length, MonoError *error)
+{
+	MONO_REQ_GC_UNSAFE_MODE;
+
+	error_init (error);
+
+	GError *eg_error = NULL;
+	MonoString *o = NULL;
+	guint16 *ut = NULL;
+	glong items_written;
+
+	ut = eg_wtf8_to_utf16 (text, length, NULL, &items_written, &eg_error);
+
+	if (!eg_error)
+		o = mono_string_new_utf16_checked (domain, ut, items_written, error);
+	else 
+		g_error_free (eg_error);
+
+	g_free (ut);
+
+	return o;
+}
+
+/**
  * mono_string_new_wrapper:
  * \param text pointer to UTF-8 characters.
  * Helper function to create a string object from \p text in the current domain.

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -532,7 +532,8 @@ TESTS_CS_SRC=		\
 	init_array_with_lazy_type.cs \
 	weak-fields.cs \
 	threads-leak.cs	\
-	threads-init.cs
+	threads-init.cs \
+	bug-60848.cs
 
 if AMD64
 TESTS_CS_SRC += async-exc-compilation.cs finally_guard.cs finally_block_ending_in_dead_bb.cs

--- a/mono/tests/bug-60848.cs
+++ b/mono/tests/bug-60848.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Text;
+
+[Obsolete("test")]
+public static class Program
+{
+    public const string UnicodeLowSurrogate = "l\uDC00";
+    public const string UnicodeHighSurrogate = "h\uD800";
+    public const string UnicodeReplacementCharacter = "\uFFFD";
+
+    public static int Main ()
+    {
+        int exitCode = 0;
+
+        var tuples = new [] {
+            ( typeof (Program), "0074 0065 0073 0074" ),
+            ( typeof (A), "0068 FFFD FFFD" ), 
+            ( typeof (B), "006C FFFD FFFD" ),
+            ( typeof (C), "006C FFFD FFFD 0068 FFFD FFFD" ),
+            ( typeof (D), "0068 FFFD FFFD 006C FFFD FFFD" )
+        };
+
+        foreach (var tup in tuples) {
+            var type = tup.Item1;
+            var a = ((ObsoleteAttribute)type.GetCustomAttributes(true)[0]);
+            var m = a.Message;
+
+            var sb = new StringBuilder();
+
+            if (m != null) {
+                foreach (var ch in m)
+                    sb.AppendFormat("{0:X4} ", (uint)ch);
+            } else {
+                sb.Append("null");
+            }
+
+            var expected = tup.Item2;
+            var actual = sb.ToString().Trim();
+            if (actual != expected) {
+                Console.WriteLine("Attribute on type {0} failed to decode:", type);
+                Console.WriteLine(" expected '{0}' but got '{1}'", expected, actual);
+                exitCode += 1;
+            } else {
+                Console.WriteLine("{0} {1}", type, actual);
+            }
+        }
+
+        return exitCode;
+    }
+}
+
+[Obsolete(Program.UnicodeHighSurrogate)]
+public class A {
+}
+
+[Obsolete(Program.UnicodeLowSurrogate)]
+public class B {
+}
+
+[Obsolete(Program.UnicodeLowSurrogate + Program.UnicodeHighSurrogate)]
+public class C {
+}
+
+[Obsolete(Program.UnicodeHighSurrogate + Program.UnicodeLowSurrogate)]
+public class D {
+}


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=60848

Some possible C# string literals are valid UCS-2 but invalid UTF-16. If one of these literals is passed as an argument to a custom attribute, the resulting assembly will contain invalid UTF-8 strings (because the literal was invalid UTF-16). Windows .NET Framework and .NET Core both handle this by decoding any valid portions of the string as-is, and replacing invalid portions of the string with the unicode replacement character. Presently, we just give up and abort our attempt to decode the string.

This PR updates our string decoding logic for custom attributes to try and match the expected behavior. As far as I can tell, the encoding being used here is effectively WTF-8 (https://simonsapin.github.io/wtf-8/) and it's not meaningful to apply UTF-8 decoding or encoding rules to custom attribute strings. The custom attribute string may not have originally been UTF-8, or even unicode text at all, so we can't make any assumptions when trying to decode it.

After this fix there still remain cases where a custom attribute string will silently fail to decode (and become null), but those cases should be reduced to ones where the data is not even valid if treated as WTF-8 (truncated sequences, etc).