### PR TITLE
[runtime] Fix some default interface method problems. (#6484)

### DIFF
--- a/mcs/class/PEAPI/Metadata.cs
+++ b/mcs/class/PEAPI/Metadata.cs
@@ -1331,6 +1331,10 @@ namespace PEAPI {
 			output.WriteCodedIndex(CIx.MethodDefOrRef,header);
 		}
 
+		internal override uint SortKey()
+		{
+			return parent.Row;
+		}
 	}
 
 	/**************************************************************************/  
@@ -5549,6 +5553,7 @@ namespace PEAPI {
 			SortTable(metaDataTables[(int)MDTable.FieldMarshal]);
 			SortTable(metaDataTables[(int)MDTable.DeclSecurity]);
 			SortTable(metaDataTables[(int)MDTable.MethodSemantics]);
+			SortTable(metaDataTables[(int)MDTable.MethodImpl]);
 			SortTable(metaDataTables[(int)MDTable.ImplMap]);
 			if (metaDataTables[(int)MDTable.GenericParam] != null) {
 				SortTable(metaDataTables[(int)MDTable.GenericParam]);

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -3962,7 +3962,7 @@ mono_class_verify_vtable (MonoClass *klass)
 	if (!klass->methods)
 		return;
 
-	count = mono_class_method_count (klass);
+	count = mono_class_get_method_count (klass);
 	for (i = 0; i < count; ++i) {
 		MonoMethod *cm = klass->methods [i];
 		int slot;
@@ -10179,8 +10179,14 @@ mono_class_has_parent_and_ignore_generics (MonoClass *klass, MonoClass *parent)
 static gboolean
 is_valid_family_access (MonoClass *access_klass, MonoClass *member_klass, MonoClass *context_klass)
 {
-	if (!mono_class_has_parent_and_ignore_generics (access_klass, member_klass))
-		return FALSE;
+	if (MONO_CLASS_IS_INTERFACE (member_klass) && !MONO_CLASS_IS_INTERFACE (access_klass)) {
+		/* Can happen with default interface methods */
+		if (!mono_class_implements_interface (access_klass, member_klass))
+			return FALSE;
+	} else {
+		if (!mono_class_has_parent_and_ignore_generics (access_klass, member_klass))
+			return FALSE;
+	}
 
 	if (context_klass == NULL)
 		return TRUE;

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -2582,8 +2582,13 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 			child_frame.retval = sp;
 			/* decrement by the actual number of args */
 			sp -= child_frame.imethod->param_count;
-			if (child_frame.imethod->hasthis)
+			if (child_frame.imethod->hasthis) {
 				--sp;
+				MonoObject *this_arg = sp->data.p;
+				if (!this_arg && (child_frame.imethod->method->flags & METHOD_ATTRIBUTE_VIRTUAL))
+					THROW_EX (mono_get_exception_null_reference(), ip - 2);
+			}
+
 			child_frame.stack_args = sp;
 
 			interp_exec_method (&child_frame, context);
@@ -3655,6 +3660,15 @@ array_constructed:
 				THROW_EX (mono_get_exception_null_reference (), ip);
 			++ip;
 			MINT_IN_BREAK;
+		MINT_IN_CASE(MINT_CKNULL_N) {
+			/* Same as CKNULL, but further down the stack */
+			int n = *(guint16*)(ip + 1);
+			o = sp [-n].data.p;
+			if (!o)
+				THROW_EX (mono_get_exception_null_reference (), ip);
+			ip += 2;
+			MINT_IN_BREAK;
+		}
 
 #define LDFLD(datamem, fieldtype) \
 	o = sp [-1].data.p; \

--- a/mono/mini/interp/mintops.def
+++ b/mono/mini/interp/mintops.def
@@ -517,6 +517,7 @@ OPDEF(MINT_REFANYTYPE, "refanytype", 1, MintOpNoArgs)
 OPDEF(MINT_REFANYVAL, "refanyval", 1, MintOpNoArgs)
 
 OPDEF(MINT_CKNULL, "cknull", 1, MintOpNoArgs)
+OPDEF(MINT_CKNULL_N, "cknull_n", 2, MintOpInt)
 
 OPDEF(MINT_GETCHR, "getchr", 1, MintOpNoArgs)
 OPDEF(MINT_STRLEN, "strlen", 1, MintOpNoArgs)

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -794,6 +794,7 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 	int op = -1;
 	int native = 0;
 	int is_void = 0;
+	int need_null_check = 0;
 
 	guint32 token = read32 (td->ip + 1);
 
@@ -1057,6 +1058,19 @@ no_intrinsic:
 	if (target_method)
 		mono_class_init (target_method->klass);
 
+	if (!virtual && target_method && (target_method->flags & METHOD_ATTRIBUTE_ABSTRACT))
+		/* MS.NET seems to silently convert this to a callvirt */
+		virtual = TRUE;
+
+	if (virtual && target_method && (!(target_method->flags & METHOD_ATTRIBUTE_VIRTUAL) ||
+		(MONO_METHOD_IS_FINAL (target_method) &&
+		 target_method->wrapper_type != MONO_WRAPPER_REMOTING_INVOKE_WITH_CHECK)) &&
+		!(mono_class_is_marshalbyref (target_method->klass))) {
+		/* Not really virtual, just needs a null check */
+		virtual = FALSE;
+		need_null_check = TRUE;
+	}
+
 	CHECK_STACK (td, csignature->param_count + csignature->hasthis);
 	if (!calli && op == -1 && (!virtual || (target_method->flags & METHOD_ATTRIBUTE_VIRTUAL) == 0) &&
 		(target_method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL) == 0 && 
@@ -1098,8 +1112,8 @@ no_intrinsic:
 					ADD_CODE (td, 0);
 				}
 				if (csignature->hasthis) {
-					if (virtual)
-						ADD_CODE(td, MINT_CKNULL);
+					if (virtual || need_null_check)
+						ADD_CODE (td, MINT_CKNULL);
 					ADD_CODE (td, MINT_POP);
 					ADD_CODE (td, 0);
 				}
@@ -1136,6 +1150,11 @@ no_intrinsic:
 			size = (size + 7) & ~7;
 			vt_stack_used += size;
 		}
+	}
+
+	if (need_null_check) {
+		ADD_CODE (td, MINT_CKNULL_N);
+		ADD_CODE (td, csignature->param_count + 1);
 	}
 
 	/* need to handle typedbyref ... */


### PR DESCRIPTION
* [runtime] Allow access to protected default interface methods from classes which implement the interface.

* [interp] Add some automatic conversations between virtual and non-virtual calls that .net has. Fixes dim-valuetype.il.

* [bcl] Sort the MethodImpl table in PEAPI.

* [runtime] Enable dim-methodimpl.exe test.

* [runtime] Fix vtable construction tracing.

* [interp] Fix null checks on the receiver when converting virtual calls to non-virtual.