### PR TITLE
Improve GetArgumentName in MonoOptions. Fixes bug-60904

### DIFF
--- a/mcs/class/Mono.Options/Mono.Options/Options.cs
+++ b/mcs/class/Mono.Options/Mono.Options/Options.cs
@@ -1390,28 +1390,30 @@ namespace Mono.Options
 			o.Write (s);
 		}
 
-		private static string GetArgumentName (int index, int maxIndex, string description)
+		static string GetArgumentName (int index, int maxIndex, string description)
 		{
-			if (description == null)
-				return maxIndex == 1 ? "VALUE" : "VALUE" + (index + 1);
-			string[] nameStart;
-			if (maxIndex == 1)
-				nameStart = new string[]{"{0:", "{"};
-			else
-				nameStart = new string[]{"{" + index + ":"};
-			for (int i = 0; i < nameStart.Length; ++i) {
-				int start, j = 0;
-				do {
-					start = description.IndexOf (nameStart [i], j);
-				} while (start >= 0 && j != 0 ? description [j++ - 1] == '{' : false);
-				if (start == -1)
-					continue;
-				int end = description.IndexOf ("}", start);
-				if (end == -1)
-					continue;
-				return description.Substring (start + nameStart [i].Length, end - start - nameStart [i].Length);
+			var matches = Regex.Matches (description ?? "", @"(?<=(?<!\{)\{)[^{}]*(?=\}(?!\}))"); // ignore double braces 
+			string argName = "";
+			foreach (Match match in matches)
+			{
+				var parts = match.Value.Split (':');
+				if (maxIndex == 1)
+				{
+					// for maxIndex=1 it can be {foo} or {0:foo}
+					argName = parts[parts.Length - 1];
+				}
+				// look for {i:foo} if maxIndex > 1
+				if (maxIndex > 1 && parts.Length == 2 && parts[0] == index.ToString ())
+				{
+					argName = parts[1];
+				}
 			}
-			return maxIndex == 1 ? "VALUE" : "VALUE" + (index + 1);
+
+			if (string.IsNullOrEmpty (argName))
+			{
+				argName = maxIndex == 1 ? "VALUE" : "VALUE" + (index + 1);
+			}
+			return argName;
 		}
 
 		private static string GetDescription (string description)

--- a/mcs/class/Mono.Options/Mono.Options/Options.cs
+++ b/mcs/class/Mono.Options/Mono.Options/Options.cs
@@ -1402,12 +1402,12 @@ namespace Mono.Options
 				}
 				// look for {i:foo} if maxIndex > 1
 				if (maxIndex > 1 && parts.Length == 2 && 
-					parts[0] == index.ToString (CultureInfo.InvariantCulture))	{
+					parts[0] == index.ToString (CultureInfo.InvariantCulture)) {
 					argName = parts[1];
 				}
 			}
 
-			if (string.IsNullOrEmpty (argName))	{
+			if (string.IsNullOrEmpty (argName)) {
 				argName = maxIndex == 1 ? "VALUE" : "VALUE" + (index + 1);
 			}
 			return argName;

--- a/mcs/class/Mono.Options/Mono.Options/Options.cs
+++ b/mcs/class/Mono.Options/Mono.Options/Options.cs
@@ -1394,23 +1394,20 @@ namespace Mono.Options
 		{
 			var matches = Regex.Matches (description ?? "", @"(?<=(?<!\{)\{)[^{}]*(?=\}(?!\}))"); // ignore double braces 
 			string argName = "";
-			foreach (Match match in matches)
-			{
+			foreach (Match match in matches) {
 				var parts = match.Value.Split (':');
-				if (maxIndex == 1)
-				{
-					// for maxIndex=1 it can be {foo} or {0:foo}
+				// for maxIndex=1 it can be {foo} or {0:foo}
+				if (maxIndex == 1) {
 					argName = parts[parts.Length - 1];
 				}
 				// look for {i:foo} if maxIndex > 1
-				if (maxIndex > 1 && parts.Length == 2 && parts[0] == index.ToString ())
-				{
+				if (maxIndex > 1 && parts.Length == 2 && 
+					parts[0] == index.ToString (CultureInfo.InvariantCulture))	{
 					argName = parts[1];
 				}
 			}
 
-			if (string.IsNullOrEmpty (argName))
-			{
+			if (string.IsNullOrEmpty (argName))	{
 				argName = maxIndex == 1 ? "VALUE" : "VALUE" + (index + 1);
 			}
 			return argName;

--- a/mcs/class/Mono.Options/Test/Mono.Options/OptionSetTest.cs
+++ b/mcs/class/Mono.Options/Test/Mono.Options/OptionSetTest.cs
@@ -413,6 +413,8 @@ namespace MonoTests.Mono.Options
 				{ "color2:",            "set {color}",                          v => {} },
 				{ "rk=",                "required key/value option",            (k, v) => {} },
 				{ "rk2=",               "required {{foo}} {0:key}/{1:value} option",    (k, v) => {} },
+				{ "rk3=",               "required {{foo}} {}",    k => {} },
+				{ "rk4=",               "required {{foo}} {0:val}",    k => {} },
 				{ "ok:",                "optional key/value option",            (k, v) => {} },
 				{ "long-desc",
 					"This has a really\nlong, multi-line description that also\ntests\n" +
@@ -456,6 +458,8 @@ namespace MonoTests.Mono.Options
 			expected.WriteLine ("      --color2[=color]       set color");
 			expected.WriteLine ("      --rk=VALUE1:VALUE2     required key/value option");
 			expected.WriteLine ("      --rk2=key:value        required {foo} key/value option");
+			expected.WriteLine ("      --rk3=VALUE            required {foo}");
+			expected.WriteLine ("      --rk4=val              required {foo} val");
 			expected.WriteLine ("      --ok[=VALUE1:VALUE2]   optional key/value option");
 			expected.WriteLine ("      --long-desc            This has a really");
 			expected.WriteLine ("                               long, multi-line description that also");


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=60904
GetArgumentName didn't properly handle double braces (escaped braces)