### PR TITLE
Add System.ServiceModel.Description.UseRequestHeadersForMetadataAddressBehavior.

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel.dll.sources
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.dll.sources
@@ -620,6 +620,7 @@ System.ServiceModel.Description/ServiceTimeoutsBehavior.cs
 System.ServiceModel.Description/SynchronousReceiveBehavior.cs
 System.ServiceModel.Description/TransactedBatchingBehavior.cs
 System.ServiceModel.Description/TypedMessageConverter.cs
+../referencesource/System.ServiceModel/System/ServiceModel/Description/UseRequestHeadersForMetadataAddressBehavior.cs
 System.ServiceModel.Description/WSTrustMessageConverters.cs
 System.ServiceModel.Description/WSTrustSTSContract.cs
 System.ServiceModel.Description/WsdlContractConversionContext.cs


### PR DESCRIPTION
This type makes it possible to start JetBrains [dotMemory](https://www.jetbrains.com/dotmemory/) Remote Agent that [allows](https://www.jetbrains.com/help/dotmemory/Starting_Remote_Profiling_Process.html) to capture memory profiles of .NET Framework apps running on remote machines.

Without it, starting Remote Agent was resulting in a following error (both on the latest stable version of Mono (5.4.1.6) and the master branch):

```
$ mono RemoteAgent.exe
Profiler Remote Agent 2017.3.1  build 111.0.20171221.150619 (C) 2015 JetBrains s.r.o
Error: Could not resolve type with token 01000045 (from typeref, class/assembly System.ServiceModel.Description.UseRequestHeadersForMetadataAddressBehavior, System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
```

This PR fixes this issue and the app is able to start successfully.