### PR TITLE
Remove ampersands on MonoError variables name "error", but not on the others.

### DIFF
--- a/mono/dis/get.c
+++ b/mono/dis/get.c
@@ -1748,7 +1748,6 @@ get_fieldref_signature (MonoImage *m, int idx, MonoGenericContainer *container)
 {
 	guint32 cols [MONO_MEMBERREF_SIZE];
 	ERROR_DECL (error);
-	error_init (&error);
 	MonoGenericContainer *new_container;
 	char *type, *esname;
         char *sig;
@@ -1757,8 +1756,8 @@ get_fieldref_signature (MonoImage *m, int idx, MonoGenericContainer *container)
         mono_metadata_decode_row (&m->tables [MONO_TABLE_MEMBERREF],
 				  idx - 1, cols, MONO_MEMBERREF_SIZE);
 
-	new_container = get_memberref_container (m, cols [MONO_MEMBERREF_CLASS], container, &error);
-	mono_error_assert_ok (&error);
+	new_container = get_memberref_container (m, cols [MONO_MEMBERREF_CLASS], container, error);
+	mono_error_assert_ok (error);
         sig = get_field_signature (m, cols [MONO_MEMBERREF_SIGNATURE], new_container);
 
 	type = get_memberref_parent (m, cols [MONO_MEMBERREF_CLASS], container);

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -189,41 +189,41 @@ create_domain_objects (MonoDomain *domain)
 	 * Initialize String.Empty. This enables the removal of
 	 * the static cctor of the String class.
 	 */
-	string_vt = mono_class_vtable_checked (domain, mono_defaults.string_class, &error);
-	mono_error_assert_ok (&error);
+	string_vt = mono_class_vtable_checked (domain, mono_defaults.string_class, error);
+	mono_error_assert_ok (error);
 	string_empty_fld = mono_class_get_field_from_name (mono_defaults.string_class, "Empty");
 	g_assert (string_empty_fld);
-	MonoString *empty_str = mono_string_new_checked (domain, "", &error);
-	mono_error_assert_ok (&error);
-	empty_str = mono_string_intern_checked (empty_str, &error);
-	mono_error_assert_ok (&error);
+	MonoString *empty_str = mono_string_new_checked (domain, "", error);
+	mono_error_assert_ok (error);
+	empty_str = mono_string_intern_checked (empty_str, error);
+	mono_error_assert_ok (error);
 	mono_field_static_set_value (string_vt, string_empty_fld, empty_str);
 	domain->empty_string = empty_str;
 
 	/*
 	 * Create an instance early since we can't do it when there is no memory.
 	 */
-	arg = mono_string_new_checked (domain, "Out of memory", &error);
-	mono_error_assert_ok (&error);
-	domain->out_of_memory_ex = mono_exception_from_name_two_strings_checked (mono_defaults.corlib, "System", "OutOfMemoryException", arg, NULL, &error);
-	mono_error_assert_ok (&error);
+	arg = mono_string_new_checked (domain, "Out of memory", error);
+	mono_error_assert_ok (error);
+	domain->out_of_memory_ex = mono_exception_from_name_two_strings_checked (mono_defaults.corlib, "System", "OutOfMemoryException", arg, NULL, error);
+	mono_error_assert_ok (error);
 
 	/* 
 	 * These two are needed because the signal handlers might be executing on
 	 * an alternate stack, and Boehm GC can't handle that.
 	 */
-	arg = mono_string_new_checked (domain, "A null value was found where an object instance was required", &error);
-	mono_error_assert_ok (&error);
-	domain->null_reference_ex = mono_exception_from_name_two_strings_checked (mono_defaults.corlib, "System", "NullReferenceException", arg, NULL, &error);
-	mono_error_assert_ok (&error);
-	arg = mono_string_new_checked (domain, "The requested operation caused a stack overflow.", &error);
-	mono_error_assert_ok (&error);
-	domain->stack_overflow_ex = mono_exception_from_name_two_strings_checked (mono_defaults.corlib, "System", "StackOverflowException", arg, NULL, &error);
-	mono_error_assert_ok (&error);
+	arg = mono_string_new_checked (domain, "A null value was found where an object instance was required", error);
+	mono_error_assert_ok (error);
+	domain->null_reference_ex = mono_exception_from_name_two_strings_checked (mono_defaults.corlib, "System", "NullReferenceException", arg, NULL, error);
+	mono_error_assert_ok (error);
+	arg = mono_string_new_checked (domain, "The requested operation caused a stack overflow.", error);
+	mono_error_assert_ok (error);
+	domain->stack_overflow_ex = mono_exception_from_name_two_strings_checked (mono_defaults.corlib, "System", "StackOverflowException", arg, NULL, error);
+	mono_error_assert_ok (error);
 
 	/*The ephemeron tombstone i*/
-	domain->ephemeron_tombstone = mono_object_new_checked (domain, mono_defaults.object_class, &error);
-	mono_error_assert_ok (&error);
+	domain->ephemeron_tombstone = mono_object_new_checked (domain, mono_defaults.object_class, error);
+	mono_error_assert_ok (error);
 
 	if (domain != old_domain) {
 		mono_thread_pop_appdomain_ref ();
@@ -253,8 +253,8 @@ void
 mono_runtime_init (MonoDomain *domain, MonoThreadStartCB start_cb, MonoThreadAttachCB attach_cb)
 {
 	ERROR_DECL (error);
-	mono_runtime_init_checked (domain, start_cb, attach_cb, &error);
-	mono_error_cleanup (&error);
+	mono_runtime_init_checked (domain, start_cb, attach_cb, error);
+	mono_error_cleanup (error);
 }
 
 void
@@ -349,8 +349,8 @@ mono_get_corlib_version (void)
 		return -1;
 	if (! (field->type->attrs & FIELD_ATTRIBUTE_STATIC))
 		return -1;
-	value = mono_field_get_value_object_checked (mono_domain_get (), field, NULL, &error);
-	mono_error_assert_ok (&error);
+	value = mono_field_get_value_object_checked (mono_domain_get (), field, NULL, error);
+	mono_error_assert_ok (error);
 	return *(gint32*)((gchar*)value + sizeof (MonoObject));
 }
 
@@ -385,8 +385,8 @@ void
 mono_context_init (MonoDomain *domain)
 {
 	ERROR_DECL (error);
-	mono_context_init_checked (domain, &error);
-	mono_error_cleanup (&error);
+	mono_context_init_checked (domain, error);
+	mono_error_cleanup (error);
 }
 
 void
@@ -469,8 +469,8 @@ mono_domain_create_appdomain (char *friendly_name, char *configuration_file)
 {
 	HANDLE_FUNCTION_ENTER ();
 	ERROR_DECL (error);
-	MonoDomain *domain = mono_domain_create_appdomain_checked (friendly_name, configuration_file, &error);
-	mono_error_cleanup (&error);
+	MonoDomain *domain = mono_domain_create_appdomain_checked (friendly_name, configuration_file, error);
+	mono_error_cleanup (error);
 	HANDLE_FUNCTION_RETURN_VAL (domain);
 }
 
@@ -526,8 +526,8 @@ mono_domain_set_config (MonoDomain *domain, const char *base_dir, const char *co
 {
 	HANDLE_FUNCTION_ENTER ();
 	ERROR_DECL (error);
-	mono_domain_set_config_checked (domain, base_dir, config_file_name, &error);
-	mono_error_cleanup (&error);
+	mono_domain_set_config_checked (domain, base_dir, config_file_name, error);
+	mono_error_cleanup (error);
 	HANDLE_FUNCTION_RETURN ();
 }
 
@@ -723,13 +723,13 @@ mono_domain_try_type_resolve (MonoDomain *domain, char *name, MonoObject *typebu
 	g_assert (name || typebuilder);
 
 	ERROR_DECL (error);
-	error_init (&error);
+	error_init (error);
 
 	MonoReflectionAssembly * const ret = name
-		? mono_domain_try_type_resolve_name (domain, name, &error)
-		: mono_domain_try_type_resolve_typebuilder (domain, (MonoReflectionTypeBuilder *)typebuilder, &error);
+		? mono_domain_try_type_resolve_name (domain, name, error)
+		: mono_domain_try_type_resolve_typebuilder (domain, (MonoReflectionTypeBuilder *)typebuilder, error);
 
-	mono_error_cleanup (&error);
+	mono_error_cleanup (error);
 	return ret;
 }
 
@@ -1073,9 +1073,9 @@ mono_domain_set_options_from_config (MonoDomain *domain)
 	if (!domain || !domain->setup || !domain->setup->configuration_file)
 		return;
 
-	config_file_name = mono_string_to_utf8_checked (domain->setup->configuration_file, &error);
-	if (!mono_error_ok (&error)) {
-		mono_error_cleanup (&error);
+	config_file_name = mono_string_to_utf8_checked (domain->setup->configuration_file, error);
+	if (!mono_error_ok (error)) {
+		mono_error_cleanup (error);
 		goto free_and_out;
 	}
 
@@ -1250,9 +1250,9 @@ mono_domain_assembly_postload_search (MonoAssemblyName *aname, MonoAssembly *req
 
 	/* FIXME: We invoke managed code here, so there is a potential for deadlocks */
 
-	assembly = mono_try_assembly_resolve (domain, aname_str, requesting, refonly, &error);
+	assembly = mono_try_assembly_resolve (domain, aname_str, requesting, refonly, error);
 	g_free (aname_str);
-	mono_error_cleanup (&error);
+	mono_error_cleanup (error);
 
 	return assembly;
 }
@@ -1320,7 +1320,7 @@ mono_domain_fire_assembly_load (MonoAssembly *assembly, gpointer user_data)
 #endif
 	klass = domain->domain->mbr.obj.vtable->klass;
 
-	error_init (&error);
+	error_init (error);
 
 	mono_domain_assemblies_lock (domain);
 	add_assemblies_to_domain (domain, assembly, NULL);
@@ -1337,18 +1337,18 @@ mono_domain_fire_assembly_load (MonoAssembly *assembly, gpointer user_data)
 		goto leave;
 	}
 
-	MonoReflectionAssemblyHandle ref_assembly = mono_assembly_get_object_handle (domain, assembly, &error);
-	mono_error_assert_ok (&error);
+	MonoReflectionAssemblyHandle ref_assembly = mono_assembly_get_object_handle (domain, assembly, error);
+	mono_error_assert_ok (error);
 
 	if (assembly_load_method == NULL) {
-		assembly_load_method = mono_class_get_method_from_name_checked (klass, "DoAssemblyLoad", -1, 0, &error);
+		assembly_load_method = mono_class_get_method_from_name_checked (klass, "DoAssemblyLoad", -1, 0, error);
 		g_assert (assembly_load_method);
 	}
 
 	*params = MONO_HANDLE_RAW(ref_assembly);
 
-	mono_runtime_invoke_checked (assembly_load_method, domain->domain, params, &error);
-	mono_error_cleanup (&error);
+	mono_runtime_invoke_checked (assembly_load_method, domain->domain, params, error);
+	mono_error_cleanup (error);
 leave:
 	HANDLE_FUNCTION_RETURN ();
 }
@@ -1393,10 +1393,10 @@ set_domain_search_path (MonoDomain *domain)
 	npaths++;
 	
 	if (setup->private_bin_path) {
-		search_path = mono_string_to_utf8_checked (setup->private_bin_path, &error);
-		if (!mono_error_ok (&error)) { /*FIXME maybe we should bubble up the error.*/
+		search_path = mono_string_to_utf8_checked (setup->private_bin_path, error);
+		if (!mono_error_ok (error)) { /*FIXME maybe we should bubble up the error.*/
 			g_warning ("Could not decode AppDomain search path since it contains invalid characters");
-			mono_error_cleanup (&error);
+			mono_error_cleanup (error);
 			mono_domain_assemblies_unlock (domain);
 			return;
 		}
@@ -1458,9 +1458,9 @@ set_domain_search_path (MonoDomain *domain)
 	tmp = (gchar **)g_malloc ((npaths + 1) * sizeof (gchar *));
 	tmp [npaths] = NULL;
 
-	*tmp = mono_string_to_utf8_checked (setup->application_base, &error);
-	if (!mono_error_ok (&error)) {
-		mono_error_cleanup (&error);
+	*tmp = mono_string_to_utf8_checked (setup->application_base, error);
+	if (!mono_error_ok (error)) {
+		mono_error_cleanup (error);
 		g_strfreev (pvt_split);
 		g_free (tmp);
 
@@ -1779,9 +1779,9 @@ mono_is_shadow_copy_enabled (MonoDomain *domain, const gchar *dir_name)
 	if (setup == NULL || setup->shadow_copy_files == NULL)
 		return FALSE;
 
-	shadow_status_string = mono_string_to_utf8_checked (setup->shadow_copy_files, &error);
-	if (!mono_error_ok (&error)) {
-		mono_error_cleanup (&error);
+	shadow_status_string = mono_string_to_utf8_checked (setup->shadow_copy_files, error);
+	if (!mono_error_ok (error)) {
+		mono_error_cleanup (error);
 		return FALSE;
 	}
 	shadow_enabled = !g_ascii_strncasecmp (shadow_status_string, "true", 4);
@@ -1794,9 +1794,9 @@ mono_is_shadow_copy_enabled (MonoDomain *domain, const gchar *dir_name)
 		return TRUE;
 
 	/* Is dir_name a shadow_copy destination already? */
-	base_dir = get_shadow_assembly_location_base (domain, &error);
-	if (!mono_error_ok (&error)) {
-		mono_error_cleanup (&error);
+	base_dir = get_shadow_assembly_location_base (domain, error);
+	if (!mono_error_ok (error)) {
+		mono_error_cleanup (error);
 		return FALSE;
 	}
 
@@ -1806,9 +1806,9 @@ mono_is_shadow_copy_enabled (MonoDomain *domain, const gchar *dir_name)
 	}
 	g_free (base_dir);
 
-	all_dirs = mono_string_to_utf8_checked (setup->shadow_copy_directories, &error);
-	if (!mono_error_ok (&error)) {
-		mono_error_cleanup (&error);
+	all_dirs = mono_string_to_utf8_checked (setup->shadow_copy_directories, error);
+	if (!mono_error_ok (error)) {
+		mono_error_cleanup (error);
 		return FALSE;
 	}
 
@@ -1860,9 +1860,9 @@ mono_make_shadow_copy (const char *filename, MonoError *oerror)
 	}
 
 	/* Is dir_name a shadow_copy destination already? */
-	shadow_dir = get_shadow_assembly_location_base (domain, &error);
-	if (!mono_error_ok (&error)) {
-		mono_error_cleanup (&error);
+	shadow_dir = get_shadow_assembly_location_base (domain, error);
+	if (!mono_error_ok (error)) {
+		mono_error_cleanup (error);
 		g_free (dir_name);
 		mono_error_set_execution_engine (oerror, "Failed to create shadow copy (invalid characters in shadow directory name).");
 		return NULL;
@@ -1876,9 +1876,9 @@ mono_make_shadow_copy (const char *filename, MonoError *oerror)
 	g_free (shadow_dir);
 	g_free (dir_name);
 
-	shadow = get_shadow_assembly_location (filename, &error);
-	if (!mono_error_ok (&error)) {
-		mono_error_cleanup (&error);
+	shadow = get_shadow_assembly_location (filename, error);
+	if (!mono_error_ok (error)) {
+		mono_error_cleanup (error);
 		mono_error_set_execution_engine (oerror, "Failed to create shadow copy (invalid characters in file name).");
 		return NULL;
 	}
@@ -2597,12 +2597,12 @@ unload_thread_main (void *arg)
 
 	internal = mono_thread_internal_current ();
 
-	MonoString *thread_name_str = mono_string_new_checked (mono_domain_get (), "Domain unloader", &error);
-	if (is_ok (&error))
-		mono_thread_set_name_internal (internal, thread_name_str, TRUE, FALSE, &error);
-	if (!is_ok (&error)) {
-		data->failure_reason = g_strdup (mono_error_get_message (&error));
-		mono_error_cleanup (&error);
+	MonoString *thread_name_str = mono_string_new_checked (mono_domain_get (), "Domain unloader", error);
+	if (is_ok (error))
+		mono_thread_set_name_internal (internal, thread_name_str, TRUE, FALSE, error);
+	if (!is_ok (error)) {
+		data->failure_reason = g_strdup (mono_error_get_message (error));
+		mono_error_cleanup (error);
 		goto failure;
 	}
 
@@ -2731,7 +2731,7 @@ mono_domain_try_unload (MonoDomain *domain, MonoObject **exc)
 	MonoInternalThread *internal;
 	MonoDomain *caller_domain = mono_domain_get ();
 
-	error_init(&error);
+	error_init(error);
 
 	/* printf ("UNLOAD STARTING FOR %s (%p) IN THREAD 0x%x.\n", domain->friendly_name, domain, mono_native_thread_id_get ()); */
 
@@ -2756,16 +2756,16 @@ mono_domain_try_unload (MonoDomain *domain, MonoObject **exc)
 
 	mono_domain_set (domain, FALSE);
 	/* Notify OnDomainUnload listeners */
-	method = mono_class_get_method_from_name_checked (domain->domain->mbr.obj.vtable->klass, "DoDomainUnload", -1, 0, &error);
+	method = mono_class_get_method_from_name_checked (domain->domain->mbr.obj.vtable->klass, "DoDomainUnload", -1, 0, error);
 	g_assert (method);
 
-	mono_runtime_try_invoke (method, domain->domain, NULL, exc, &error);
+	mono_runtime_try_invoke (method, domain->domain, NULL, exc, error);
 
-	if (!mono_error_ok (&error)) {
+	if (!mono_error_ok (error)) {
 		if (*exc)
-			mono_error_cleanup (&error);
+			mono_error_cleanup (error);
 		else
-			*exc = (MonoObject*)mono_error_convert_to_exception (&error);
+			*exc = (MonoObject*)mono_error_convert_to_exception (error);
 	}
 
 	if (*exc) {
@@ -2792,8 +2792,8 @@ mono_domain_try_unload (MonoDomain *domain, MonoObject **exc)
 	 *
 	 * Force it to be attached to avoid racing during shutdown.
 	 */
-	internal = mono_thread_create_internal (mono_get_root_domain (), unload_thread_main, thread_data, MONO_THREAD_CREATE_FLAGS_FORCE_CREATE, &error);
-	mono_error_assert_ok (&error);
+	internal = mono_thread_create_internal (mono_get_root_domain (), unload_thread_main, thread_data, MONO_THREAD_CREATE_FLAGS_FORCE_CREATE, error);
+	mono_error_assert_ok (error);
 
 	thread_handle = mono_threads_open_thread_handle (internal->handle);
 

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1879,7 +1879,7 @@ mono_assembly_open_predicate (const char *filename, gboolean refonly,
 	*status = MONO_IMAGE_OK;
 
 	if (strncmp (filename, "file://", 7) == 0) {
-		GError *error = NULL;
+		GError *gerror = NULL;
 		gchar *uri = (gchar *) filename;
 		gchar *tmpuri;
 
@@ -1892,15 +1892,15 @@ mono_assembly_open_predicate (const char *filename, gboolean refonly,
 	
 		tmpuri = uri;
 		uri = mono_escape_uri_string (tmpuri);
-		fname = g_filename_from_uri (uri, NULL, &error);
+		fname = g_filename_from_uri (uri, NULL, &gerror);
 		g_free (uri);
 
 		if (tmpuri != filename)
 			g_free (tmpuri);
 
-		if (error != NULL) {
-			g_warning ("%s\n", error->message);
-			g_error_free (error);
+		if (gerror != NULL) {
+			g_warning ("%s\n", gerror->message);
+			g_error_free (gerror);
 			fname = g_strdup (filename);
 		}
 	} else {

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1913,11 +1913,11 @@ mono_assembly_open_predicate (const char *filename, gboolean refonly,
 	new_fname = NULL;
 	if (!mono_assembly_is_in_gac (fname)) {
 		ERROR_DECL (error);
-		new_fname = mono_make_shadow_copy (fname, &error);
-		if (!is_ok (&error)) {
+		new_fname = mono_make_shadow_copy (fname, error);
+		if (!is_ok (error)) {
 			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY,
-				    "Assembly Loader shadow copy error: %s.", mono_error_get_message (&error));
-			mono_error_cleanup (&error);
+				    "Assembly Loader shadow copy error: %s.", mono_error_get_message (error));
+			mono_error_cleanup (error);
 			*status = MONO_IMAGE_IMAGE_INVALID;
 			g_free (fname);
 			return NULL;
@@ -2019,8 +2019,8 @@ mono_assembly_load_friends (MonoAssembly* ass)
 	if (ass->friend_assembly_names_inited)
 		return;
 
-	attrs = mono_custom_attrs_from_assembly_checked (ass, FALSE, &error);
-	mono_error_assert_ok (&error);
+	attrs = mono_custom_attrs_from_assembly_checked (ass, FALSE, error);
+	mono_error_assert_ok (error);
 	if (!attrs) {
 		mono_assemblies_lock ();
 		ass->friend_assembly_names_inited = TRUE;
@@ -2269,7 +2269,7 @@ mono_assembly_load_from_predicate (MonoImage *image, const char *fname,
 	 * candidate. */
 
 	if (!refonly) {
-		ERROR_DECL (refasm_error);
+		ERROR_DECL_VALUE (refasm_error);
 		if (mono_assembly_has_reference_assembly_attribute (ass, &refasm_error)) {
 			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Image for assembly '%s' (%s) has ReferenceAssemblyAttribute, skipping", ass->aname.name, image->name);
 			g_free (ass);
@@ -2993,9 +2993,9 @@ mono_assembly_load_with_partial_name (const char *name, MonoImageOpenStatus *sta
 	else {
 		MonoDomain *domain = mono_domain_get ();
 
-		res = mono_try_assembly_resolve (domain, name, NULL, FALSE, &error);
-		if (!is_ok (&error)) {
-			mono_error_cleanup (&error);
+		res = mono_try_assembly_resolve (domain, name, NULL, FALSE, error);
+		if (!is_ok (error)) {
+			mono_error_cleanup (error);
 			if (*status == MONO_IMAGE_OK)
 				*status = MONO_IMAGE_IMAGE_INVALID;
 		}
@@ -3327,10 +3327,10 @@ mono_assembly_apply_binding (MonoAssemblyName *aname, MonoAssemblyName *dest_nam
 	}
 
 	if (domain && domain->setup && domain->setup->configuration_file) {
-		gchar *domain_config_file_name = mono_string_to_utf8_checked (domain->setup->configuration_file, &error);
+		gchar *domain_config_file_name = mono_string_to_utf8_checked (domain->setup->configuration_file, error);
 		/* expect this to succeed because mono_domain_set_options_from_config () did
 		 * the same thing when the domain was created. */
-		mono_error_assert_ok (&error);
+		mono_error_assert_ok (error);
 		mono_domain_parse_assembly_bindings (domain, aname->major, aname->minor, domain_config_file_name);
 		g_free (domain_config_file_name);
 
@@ -3511,7 +3511,7 @@ return_corlib_and_facades:
 static MonoAssembly*
 prevent_reference_assembly_from_running (MonoAssembly* candidate, gboolean refonly)
 {
-	ERROR_DECL (refasm_error);
+	ERROR_DECL_VALUE (refasm_error);
 	error_init (&refasm_error);
 	if (candidate && !refonly) {
 		/* .NET Framework seems to not check for ReferenceAssemblyAttribute on dynamic assemblies */
@@ -3864,8 +3864,8 @@ MonoImage*
 mono_assembly_load_module (MonoAssembly *assembly, guint32 idx)
 {
 	ERROR_DECL (error);
-	MonoImage *result = mono_assembly_load_module_checked (assembly, idx, &error);
-	mono_error_assert_ok (&error);
+	MonoImage *result = mono_assembly_load_module_checked (assembly, idx, error);
+	mono_error_assert_ok (error);
 	return result;
 }
 

--- a/mono/metadata/attach.c
+++ b/mono/metadata/attach.c
@@ -295,28 +295,28 @@ mono_attach_load_agent (MonoDomain *domain, char *agent, char *args, MonoObject 
 		return 1;
 	}
 
-	method = mono_get_method_checked (image, entry, NULL, NULL, &error);
+	method = mono_get_method_checked (image, entry, NULL, NULL, error);
 	if (method == NULL){
-		g_print ("The entry point method of assembly '%s' could not be loaded due to %s\n", agent, mono_error_get_message (&error));
-		mono_error_cleanup (&error);
+		g_print ("The entry point method of assembly '%s' could not be loaded due to %s\n", agent, mono_error_get_message (error));
+		mono_error_cleanup (error);
 		g_free (agent);
 		return 1;
 	}
 	
 	
-	main_args = (MonoArray*)mono_array_new_checked (domain, mono_defaults.string_class, (args == NULL) ? 0 : 1, &error);
+	main_args = (MonoArray*)mono_array_new_checked (domain, mono_defaults.string_class, (args == NULL) ? 0 : 1, error);
 	if (main_args == NULL) {
-		g_print ("Could not allocate main method args due to %s\n", mono_error_get_message (&error));
-		mono_error_cleanup (&error);
+		g_print ("Could not allocate main method args due to %s\n", mono_error_get_message (error));
+		mono_error_cleanup (error);
 		g_free (agent);
 		return 1;
 	}
 
 	if (args) {
-		MonoString *args_str = mono_string_new_checked (domain, args, &error);
-		if (!is_ok (&error)) {
-			g_print ("Could not allocate main method arg string due to %s\n", mono_error_get_message (&error));
-			mono_error_cleanup (&error);
+		MonoString *args_str = mono_string_new_checked (domain, args, error);
+		if (!is_ok (error)) {
+			g_print ("Could not allocate main method arg string due to %s\n", mono_error_get_message (error));
+			mono_error_cleanup (error);
 			g_free (agent);
 			return 1;
 		}
@@ -325,10 +325,10 @@ mono_attach_load_agent (MonoDomain *domain, char *agent, char *args, MonoObject 
 
 
 	pa [0] = main_args;
-	mono_runtime_try_invoke (method, NULL, pa, exc, &error);
-	if (!is_ok (&error)) {
-		g_print ("The entry point method of assembly '%s' could not be executed due to %s\n", agent, mono_error_get_message (&error));
-		mono_error_cleanup (&error);
+	mono_runtime_try_invoke (method, NULL, pa, exc, error);
+	if (!is_ok (error)) {
+		g_print ("The entry point method of assembly '%s' could not be executed due to %s\n", agent, mono_error_get_message (error));
+		mono_error_cleanup (error);
 		g_free (agent);
 		return 1;
 	}
@@ -491,8 +491,8 @@ transport_start_receive (void)
 	if (!listen_fd)
 		return;
 
-	internal = mono_thread_create_internal (mono_get_root_domain (), receiver_thread, NULL, MONO_THREAD_CREATE_FLAGS_NONE, &error);
-	mono_error_assert_ok (&error);
+	internal = mono_thread_create_internal (mono_get_root_domain (), receiver_thread, NULL, MONO_THREAD_CREATE_FLAGS_NONE, error);
+	mono_error_assert_ok (error);
 
 	receiver_thread_handle = mono_threads_open_thread_handle (internal->handle);
 	g_assert (receiver_thread_handle);
@@ -509,10 +509,10 @@ receiver_thread (void *arg)
 	MonoInternalThread *internal;
 
 	internal = mono_thread_internal_current ();
-	MonoString *attach_str = mono_string_new_checked (mono_domain_get (), "Attach receiver", &error);
-	mono_error_assert_ok (&error);
-	mono_thread_set_name_internal (internal, attach_str, TRUE, FALSE, &error);
-	mono_error_assert_ok (&error);
+	MonoString *attach_str = mono_string_new_checked (mono_domain_get (), "Attach receiver", error);
+	mono_error_assert_ok (error);
+	mono_thread_set_name_internal (internal, attach_str, TRUE, FALSE, error);
+	mono_error_assert_ok (error);
 	/* Ask the runtime to not abort this thread */
 	//internal->flags |= MONO_THREAD_FLAG_DONT_MANAGE;
 	/* Ask the runtime to not wait for this thread */

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -7557,7 +7557,7 @@ mono_type_get_checked (MonoImage *image, guint32 type_token, MonoGenericContext 
 MonoClass *
 mono_class_get (MonoImage *image, guint32 type_token)
 {
-	MonoError error;
+	ERROR_DECL (error);
 	error_init (&error);
 	MonoClass *result = mono_class_get_checked (image, type_token, &error);
 	mono_error_assert_ok (&error);

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -181,8 +181,8 @@ MonoClass *
 mono_class_from_typeref (MonoImage *image, guint32 type_token)
 {
 	ERROR_DECL (error);
-	MonoClass *klass = mono_class_from_typeref_checked (image, type_token, &error);
-	g_assert (mono_error_ok (&error)); /*FIXME proper error handling*/
+	MonoClass *klass = mono_class_from_typeref_checked (image, type_token, error);
+	g_assert (mono_error_ok (error)); /*FIXME proper error handling*/
 	return klass;
 }
 
@@ -889,8 +889,8 @@ mono_class_inflate_generic_type (MonoType *type, MonoGenericContext *context)
 {
 	ERROR_DECL (error);
 	MonoType *result;
-	result = mono_class_inflate_generic_type_checked (type, context, &error);
-	mono_error_cleanup (&error);
+	result = mono_class_inflate_generic_type_checked (type, context, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -996,10 +996,10 @@ MonoMethod *
 mono_class_inflate_generic_method (MonoMethod *method, MonoGenericContext *context)
 {
 	ERROR_DECL (error);
-	error_init (&error);
-	MonoMethod *res = mono_class_inflate_generic_method_full_checked (method, NULL, context, &error);
-	if (!is_ok (&error))
-		g_error ("Could not inflate generic method due to %s", mono_error_get_message (&error));
+	error_init (error);
+	MonoMethod *res = mono_class_inflate_generic_method_full_checked (method, NULL, context, error);
+	if (!is_ok (error))
+		g_error ("Could not inflate generic method due to %s", mono_error_get_message (error));
 	return res;
 }
 
@@ -1485,7 +1485,7 @@ static gboolean
 mono_class_set_type_load_failure_causedby_class (MonoClass *klass, const MonoClass *caused_by, const gchar* msg)
 {
 	if (mono_class_has_failure (caused_by)) {
-		ERROR_DECL (cause_error);
+		ERROR_DECL_VALUE (cause_error);
 		error_init (&cause_error);
 		mono_error_set_for_class_failure (&cause_error, caused_by);
 		mono_class_set_type_load_failure (klass, "%s, due to: %s", msg, mono_error_get_message (&cause_error));
@@ -1586,10 +1586,10 @@ mono_class_setup_fields (MonoClass *klass)
 		field = &klass->fields [i];
 
 		if (!field->type) {
-			mono_field_resolve_type (field, &error);
-			if (!mono_error_ok (&error)) {
+			mono_field_resolve_type (field, error);
+			if (!mono_error_ok (error)) {
 				/*mono_field_resolve_type already failed class*/
-				mono_error_cleanup (&error);
+				mono_error_cleanup (error);
 				break;
 			}
 			if (!field->type)
@@ -1858,7 +1858,7 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 				if (field_class) {
 					mono_class_setup_fields (field_class);
 					if (mono_class_has_failure (field_class)) {
-						ERROR_DECL (field_error);
+						ERROR_DECL_VALUE (field_error);
 						error_init (&field_error);
 						mono_error_set_for_class_failure (&field_error, field_class);
 						mono_class_set_type_load_failure (klass, "Could not set up field '%s' due to: %s", field->name, mono_error_get_message (&field_error));
@@ -2298,13 +2298,13 @@ mono_class_setup_methods (MonoClass *klass)
 
 		for (i = 0; i < count; i++) {
 			methods [i] = mono_class_inflate_generic_method_full_checked (
-				gklass->methods [i], klass, mono_class_get_context (klass), &error);
-			if (!mono_error_ok (&error)) {
+				gklass->methods [i], klass, mono_class_get_context (klass), error);
+			if (!mono_error_ok (error)) {
 				char *method = mono_method_full_name (gklass->methods [i], TRUE);
-				mono_class_set_type_load_failure (klass, "Could not inflate method %s due to %s", method, mono_error_get_message (&error));
+				mono_class_set_type_load_failure (klass, "Could not inflate method %s due to %s", method, mono_error_get_message (error));
 
 				g_free (method);
-				mono_error_cleanup (&error);
+				mono_error_cleanup (error);
 				return;				
 			}
 		}
@@ -2318,8 +2318,8 @@ mono_class_setup_methods (MonoClass *klass)
 
 		count = 3 + (klass->rank > 1? 2: 1);
 
-		mono_class_setup_interfaces (klass, &error);
-		g_assert (mono_error_ok (&error)); /*FIXME can this fail for array types?*/
+		mono_class_setup_interfaces (klass, error);
+		g_assert (mono_error_ok (error)); /*FIXME can this fail for array types?*/
 
 		if (klass->rank == 1 && klass->element_class->rank) {
 			jagged_ctor = TRUE;
@@ -2408,10 +2408,10 @@ mono_class_setup_methods (MonoClass *klass)
 		methods = (MonoMethod **)mono_class_alloc (klass, sizeof (MonoMethod*) * count);
 		for (i = 0; i < count; ++i) {
 			int idx = mono_metadata_translate_token_index (klass->image, MONO_TABLE_METHOD, first_idx + i + 1);
-			methods [i] = mono_get_method_checked (klass->image, MONO_TOKEN_METHOD_DEF | idx, klass, NULL, &error);
+			methods [i] = mono_get_method_checked (klass->image, MONO_TOKEN_METHOD_DEF | idx, klass, NULL, error);
 			if (!methods [i]) {
-				mono_class_set_type_load_failure (klass, "Could not load method %d due to %s", i, mono_error_get_message (&error));
-				mono_error_cleanup (&error);
+				mono_class_set_type_load_failure (klass, "Could not load method %d due to %s", i, mono_error_get_message (error));
+				mono_error_cleanup (error);
 			}
 		}
 	} else {
@@ -2460,8 +2460,8 @@ mono_class_get_method_by_index (MonoClass *klass, int index)
 		MonoMethod *m;
 
 		m = mono_class_inflate_generic_method_full_checked (
-				gklass->container_class->methods [index], klass, mono_class_get_context (klass), &error);
-		g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+				gklass->container_class->methods [index], klass, mono_class_get_context (klass), error);
+		g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 		/*
 		 * If setup_methods () is called later for this class, no duplicates are created,
 		 * since inflate_generic_method guarantees that only one instance of a method
@@ -2552,8 +2552,8 @@ mono_class_get_vtable_entry (MonoClass *klass, int offset)
 		mono_class_setup_vtable (gklass);
 		m = gklass->vtable [offset];
 
-		m = mono_class_inflate_generic_method_full_checked (m, klass, mono_class_get_context (klass), &error);
-		g_assert (mono_error_ok (&error)); /* FIXME don't swallow this error */
+		m = mono_class_inflate_generic_method_full_checked (m, klass, mono_class_get_context (klass), error);
+		g_assert (mono_error_ok (error)); /* FIXME don't swallow this error */
 	} else {
 		mono_class_setup_vtable (klass);
 		if (mono_class_has_failure (klass))
@@ -2618,12 +2618,12 @@ mono_class_setup_properties (MonoClass *klass)
 
 			if (prop->get)
 				prop->get = mono_class_inflate_generic_method_full_checked (
-					prop->get, klass, mono_class_get_context (klass), &error);
+					prop->get, klass, mono_class_get_context (klass), error);
 			if (prop->set)
 				prop->set = mono_class_inflate_generic_method_full_checked (
-					prop->set, klass, mono_class_get_context (klass), &error);
+					prop->set, klass, mono_class_get_context (klass), error);
 
-			g_assert (mono_error_ok (&error)); /*FIXME proper error handling*/
+			g_assert (mono_error_ok (error)); /*FIXME proper error handling*/
 			prop->parent = klass;
 		}
 
@@ -2656,8 +2656,8 @@ mono_class_setup_properties (MonoClass *klass)
 				if (klass->image->uncompressed_metadata) {
 					ERROR_DECL (error);
 					/* It seems like the MONO_METHOD_SEMA_METHOD column needs no remapping */
-					method = mono_get_method_checked (klass->image, MONO_TOKEN_METHOD_DEF | cols [MONO_METHOD_SEMA_METHOD], klass, NULL, &error);
-					mono_error_cleanup (&error); /* FIXME don't swallow this error */
+					method = mono_get_method_checked (klass->image, MONO_TOKEN_METHOD_DEF | cols [MONO_METHOD_SEMA_METHOD], klass, NULL, error);
+					mono_error_cleanup (error); /* FIXME don't swallow this error */
 				} else {
 					method = klass->methods [cols [MONO_METHOD_SEMA_METHOD] - 1 - first_idx];
 				}
@@ -2699,8 +2699,8 @@ inflate_method_listz (MonoMethod **methods, MonoClass *klass, MonoGenericContext
 	count = 0;
 	for (om = methods, count = 0; *om; ++om, ++count) {
 		ERROR_DECL (error);
-		retval [count] = mono_class_inflate_generic_method_full_checked (*om, klass, context, &error);
-		g_assert (mono_error_ok (&error)); /*FIXME proper error handling*/
+		retval [count] = mono_class_inflate_generic_method_full_checked (*om, klass, context, error);
+		g_assert (mono_error_ok (error)); /*FIXME proper error handling*/
 	}
 
 	return retval;
@@ -2743,16 +2743,16 @@ mono_class_setup_events (MonoClass *klass)
 			MonoEvent *event = &events [i];
 			MonoEvent *gevent = &ginfo->events [i];
 
-			error_init (&error); //since we do conditional calls, we must ensure the default value is ok
+			error_init (error); //since we do conditional calls, we must ensure the default value is ok
 
 			event->parent = klass;
 			event->name = gevent->name;
-			event->add = gevent->add ? mono_class_inflate_generic_method_full_checked (gevent->add, klass, context, &error) : NULL;
-			g_assert (mono_error_ok (&error)); /*FIXME proper error handling*/
-			event->remove = gevent->remove ? mono_class_inflate_generic_method_full_checked (gevent->remove, klass, context, &error) : NULL;
-			g_assert (mono_error_ok (&error)); /*FIXME proper error handling*/
-			event->raise = gevent->raise ? mono_class_inflate_generic_method_full_checked (gevent->raise, klass, context, &error) : NULL;
-			g_assert (mono_error_ok (&error)); /*FIXME proper error handling*/
+			event->add = gevent->add ? mono_class_inflate_generic_method_full_checked (gevent->add, klass, context, error) : NULL;
+			g_assert (mono_error_ok (error)); /*FIXME proper error handling*/
+			event->remove = gevent->remove ? mono_class_inflate_generic_method_full_checked (gevent->remove, klass, context, error) : NULL;
+			g_assert (mono_error_ok (error)); /*FIXME proper error handling*/
+			event->raise = gevent->raise ? mono_class_inflate_generic_method_full_checked (gevent->raise, klass, context, error) : NULL;
+			g_assert (mono_error_ok (error)); /*FIXME proper error handling*/
 
 #ifndef MONO_SMALL_CONFIG
 			event->other = gevent->other ? inflate_method_listz (gevent->other, klass, context) : NULL;
@@ -2789,8 +2789,8 @@ mono_class_setup_events (MonoClass *klass)
 				if (klass->image->uncompressed_metadata) {
 					ERROR_DECL (error);
 					/* It seems like the MONO_METHOD_SEMA_METHOD column needs no remapping */
-					method = mono_get_method_checked (klass->image, MONO_TOKEN_METHOD_DEF | cols [MONO_METHOD_SEMA_METHOD], klass, NULL, &error);
-					mono_error_cleanup (&error); /* FIXME don't swallow this error */
+					method = mono_get_method_checked (klass->image, MONO_TOKEN_METHOD_DEF | cols [MONO_METHOD_SEMA_METHOD], klass, NULL, error);
+					mono_error_cleanup (error); /* FIXME don't swallow this error */
 				} else {
 					method = klass->methods [cols [MONO_METHOD_SEMA_METHOD] - 1 - first_idx];
 				}
@@ -3106,10 +3106,10 @@ print_implemented_interfaces (MonoClass *klass)
 	printf ("\n");
 	while (klass != NULL) {
 		printf ("[LEVEL %d] Implemented interfaces by class %s:\n", ancestor_level, klass->name);
-		ifaces = mono_class_get_implemented_interfaces (klass, &error);
-		if (!mono_error_ok (&error)) {
-			printf ("  Type failed due to %s\n", mono_error_get_message (&error));
-			mono_error_cleanup (&error);
+		ifaces = mono_class_get_implemented_interfaces (klass, error);
+		if (!mono_error_ok (error)) {
+			printf ("  Type failed due to %s\n", mono_error_get_message (error));
+			mono_error_cleanup (error);
 		} else if (ifaces) {
 			for (i = 0; i < ifaces->len; i++) {
 				MonoClass *ic = (MonoClass *)g_ptr_array_index (ifaces, i);
@@ -3359,12 +3359,12 @@ setup_interface_offsets (MonoClass *klass, int cur_slot, gboolean overwrite)
 			if (max_iid < ic->interface_id)
 				max_iid = ic->interface_id;
 		}
-		ifaces = mono_class_get_implemented_interfaces (k, &error);
-		if (!mono_error_ok (&error)) {
+		ifaces = mono_class_get_implemented_interfaces (k, error);
+		if (!mono_error_ok (error)) {
 			char *name = mono_type_get_full_name (k);
-			mono_class_set_type_load_failure (klass, "Error getting the interfaces of %s due to %s", name, mono_error_get_message (&error));
+			mono_class_set_type_load_failure (klass, "Error getting the interfaces of %s due to %s", name, mono_error_get_message (error));
 			g_free (name);
-			mono_error_cleanup (&error);
+			mono_error_cleanup (error);
 			cur_slot = -1;
 			goto end;
 		}
@@ -3643,17 +3643,17 @@ mono_class_setup_vtable_full (MonoClass *klass, GList *in_setup)
 		 * This is true since we don't do layout all over again for them, we simply inflate
 		 * the layout of the parent.
 		 */
-		mono_reflection_get_dynamic_overrides (klass, &overrides, &onum, &error);
-		if (!is_ok (&error)) {
-			mono_class_set_type_load_failure (klass, "Could not load list of method overrides due to %s", mono_error_get_message (&error));
+		mono_reflection_get_dynamic_overrides (klass, &overrides, &onum, error);
+		if (!is_ok (error)) {
+			mono_class_set_type_load_failure (klass, "Could not load list of method overrides due to %s", mono_error_get_message (error));
 			goto done;
 		}
 	} else {
 		/* The following call fails if there are missing methods in the type */
 		/* FIXME it's probably a good idea to avoid this for generic instances. */
-		mono_class_get_overrides_full (klass->image, type_token, &overrides, &onum, context, &error);
-		if (!is_ok (&error)) {
-			mono_class_set_type_load_failure (klass, "Could not load list of method overrides due to %s", mono_error_get_message (&error));
+		mono_class_get_overrides_full (klass->image, type_token, &overrides, &onum, context, error);
+		if (!is_ok (error)) {
+			mono_class_set_type_load_failure (klass, "Could not load list of method overrides due to %s", mono_error_get_message (error));
 			goto done;
 		}
 	}
@@ -3662,7 +3662,7 @@ mono_class_setup_vtable_full (MonoClass *klass, GList *in_setup)
 
 done:
 	g_free (overrides);
-	mono_error_cleanup (&error);
+	mono_error_cleanup (error);
 
 	mono_loader_unlock ();
 	g_list_remove (in_setup, klass);
@@ -4137,7 +4137,7 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 	GSList *virt_methods = NULL, *l;
 	int stelemref_slot = 0;
 
-	error_init (&error);
+	error_init (error);
 
 	if (klass->vtable)
 		return;
@@ -4145,12 +4145,12 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 	if (overrides && !verify_class_overrides (klass, overrides, onum))
 		return;
 
-	ifaces = mono_class_get_implemented_interfaces (klass, &error);
-	if (!mono_error_ok (&error)) {
+	ifaces = mono_class_get_implemented_interfaces (klass, error);
+	if (!mono_error_ok (error)) {
 		char *name = mono_type_get_full_name (klass);
-		mono_class_set_type_load_failure (klass, "Could not resolve %s interfaces due to %s", name, mono_error_get_message (&error));
+		mono_class_set_type_load_failure (klass, "Could not resolve %s interfaces due to %s", name, mono_error_get_message (error));
 		g_free (name);
-		mono_error_cleanup (&error);
+		mono_error_cleanup (error);
 		return;
 	} else if (ifaces) {
 		for (i = 0; i < ifaces->len; i++) {
@@ -4204,8 +4204,8 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 		klass->vtable_size = gklass->vtable_size;
 		for (i = 0; i < gklass->vtable_size; ++i)
 			if (gklass->vtable [i]) {
-				MonoMethod *inflated = mono_class_inflate_generic_method_full_checked (gklass->vtable [i], klass, mono_class_get_context (klass), &error);
-				goto_if_nok (&error, fail);
+				MonoMethod *inflated = mono_class_inflate_generic_method_full_checked (gklass->vtable [i], klass, mono_class_get_context (klass), error);
+				goto_if_nok (error, fail);
 				tmp [i] = inflated;
 				tmp [i]->slot = gklass->vtable [i]->slot;
 			}
@@ -4284,8 +4284,8 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 
 		MonoMethod **iface_overrides;
 		int iface_onum;
-		mono_class_get_overrides_full (ic->image, ic->type_token, &iface_overrides, &iface_onum, mono_class_get_context (ic), &error);
-		goto_if_nok (&error, fail);
+		mono_class_get_overrides_full (ic->image, ic->type_token, &iface_overrides, &iface_onum, mono_class_get_context (ic), error);
+		goto_if_nok (error, fail);
 		for (int i = 0; i < iface_onum; i++) {
 			MonoMethod *decl = iface_overrides [i*2];
 			MonoMethod *override = iface_overrides [i*2 + 1];
@@ -4672,11 +4672,11 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 fail:
 	{
 	char *name = mono_type_get_full_name (klass);
-	if (!is_ok (&error))
-		mono_class_set_type_load_failure (klass, "VTable setup of type %s failed due to: %s", name, mono_error_get_message (&error));
+	if (!is_ok (error))
+		mono_class_set_type_load_failure (klass, "VTable setup of type %s failed due to: %s", name, mono_error_get_message (error));
 	else
 		mono_class_set_type_load_failure (klass, "VTable setup of type %s failed", name);
-	mono_error_cleanup (&error);
+	mono_error_cleanup (error);
 	g_free (name);
 	g_free (vtable);
 	if (override_map)
@@ -4863,8 +4863,8 @@ setup_generic_array_ifaces (MonoClass *klass, MonoClass *iface, MonoMethod **met
 		MonoMethod *m = generic_array_method_info [i].array_method;
 		MonoMethod *inflated, *helper;
 
-		inflated = mono_class_inflate_generic_method_checked (m, &tmp_context, &error);
-		mono_error_assert_ok (&error);
+		inflated = mono_class_inflate_generic_method_checked (m, &tmp_context, error);
+		mono_error_assert_ok (error);
 		helper = g_hash_table_lookup (cache, inflated);
 		if (!helper) {
 			helper = mono_marshal_get_generic_array_helper (klass, generic_array_method_info [i].name, inflated);
@@ -5869,12 +5869,12 @@ mono_generic_class_setup_parent (MonoClass *klass, MonoClass *gtd)
 		ERROR_DECL (error);
 		MonoGenericClass *gclass = mono_class_get_generic_class (klass);
 
-		klass->parent = mono_class_inflate_generic_class_checked (gtd->parent, mono_generic_class_get_context (gclass), &error);
-		if (!mono_error_ok (&error)) {
+		klass->parent = mono_class_inflate_generic_class_checked (gtd->parent, mono_generic_class_get_context (gclass), error);
+		if (!mono_error_ok (error)) {
 			/*Set parent to something safe as the runtime doesn't handle well this kind of failure.*/
 			klass->parent = mono_defaults.object_class;
-			mono_class_set_type_load_failure (klass, "Parent is a generic type instantiation that failed due to: %s", mono_error_get_message (&error));
-			mono_error_cleanup (&error);
+			mono_class_set_type_load_failure (klass, "Parent is a generic type instantiation that failed due to: %s", mono_error_get_message (error));
+			mono_error_cleanup (error);
 		}
 	}
 	mono_loader_lock ();
@@ -6695,7 +6695,7 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 
 	if (eclass->byval_arg.type == MONO_TYPE_TYPEDBYREF) {
 		/*Arrays of those two types are invalid.*/
-		ERROR_DECL (prepared_error);
+		ERROR_DECL_VALUE (prepared_error);
 		error_init (&prepared_error);
 		mono_error_set_invalid_program (&prepared_error, "Arrays of System.TypedReference types are invalid.");
 		mono_class_set_failure (klass, mono_error_box (&prepared_error, klass->image));
@@ -6771,7 +6771,7 @@ mono_bounded_array_class_get (MonoClass *eclass, guint32 rank, gboolean bounded)
 	klass->this_arg.byref = 1;
 
 	if (rank > 32) {
-		ERROR_DECL (prepared_error);
+		ERROR_DECL_VALUE (prepared_error);
 		error_init (&prepared_error);
 		name = mono_type_get_full_name (klass);
 		mono_error_set_type_load_class (&prepared_error, klass, "%s has too many dimensions.", name);
@@ -7319,9 +7319,9 @@ mono_class_name_from_token (MonoImage *image, guint32 type_token)
 		if (tidx > t->rows)
 			return g_strdup_printf ("Invalid type token 0x%08x", type_token);
 
-		if (!mono_verifier_verify_typeref_row (image, tidx - 1, &error)) {
-			char *msg = g_strdup_printf ("Invalid type token 0x%08x due to '%s'", type_token, mono_error_get_message (&error));
-			mono_error_cleanup (&error);
+		if (!mono_verifier_verify_typeref_row (image, tidx - 1, error)) {
+			char *msg = g_strdup_printf ("Invalid type token 0x%08x due to '%s'", type_token, mono_error_get_message (error));
+			mono_error_cleanup (error);
 			return msg;
 		}
 
@@ -7364,9 +7364,9 @@ mono_assembly_name_from_token (MonoImage *image, guint32 type_token)
 		if (idx > t->rows)
 			return g_strdup_printf ("Invalid type token 0x%08x", type_token);
 	
-		if (!mono_verifier_verify_typeref_row (image, idx - 1, &error)) {
-			char *msg = g_strdup_printf ("Invalid type token 0x%08x due to '%s'", type_token, mono_error_get_message (&error));
-			mono_error_cleanup (&error);
+		if (!mono_verifier_verify_typeref_row (image, idx - 1, error)) {
+			char *msg = g_strdup_printf ("Invalid type token 0x%08x due to '%s'", type_token, mono_error_get_message (error));
+			mono_error_cleanup (error);
 			return msg;
 		}
 		mono_metadata_decode_row (t, idx-1, cols, MONO_TYPEREF_SIZE);
@@ -7413,12 +7413,12 @@ mono_class_get_full (MonoImage *image, guint32 type_token, MonoGenericContext *c
 {
 	ERROR_DECL (error);
 	MonoClass *klass;
-	klass = mono_class_get_checked (image, type_token, &error);
+	klass = mono_class_get_checked (image, type_token, error);
 
 	if (klass && context && mono_metadata_token_table (type_token) == MONO_TABLE_TYPESPEC)
-		klass = mono_class_inflate_generic_class_checked (klass, context, &error);
+		klass = mono_class_inflate_generic_class_checked (klass, context, error);
 
-	mono_error_assert_ok (&error);
+	mono_error_assert_ok (error);
 	return klass;
 }
 
@@ -7558,9 +7558,9 @@ MonoClass *
 mono_class_get (MonoImage *image, guint32 type_token)
 {
 	ERROR_DECL (error);
-	error_init (&error);
-	MonoClass *result = mono_class_get_checked (image, type_token, &error);
-	mono_error_assert_ok (&error);
+	error_init (error);
+	MonoClass *result = mono_class_get_checked (image, type_token, error);
+	mono_error_assert_ok (error);
 	return result;
 }
 
@@ -7724,8 +7724,8 @@ MonoClass *
 mono_class_from_name_case (MonoImage *image, const char* name_space, const char *name)
 {
 	ERROR_DECL (error);
-	MonoClass *res = mono_class_from_name_case_checked (image, name_space, name, &error);
-	mono_error_cleanup (&error);
+	MonoClass *res = mono_class_from_name_case_checked (image, name_space, name, error);
+	mono_error_cleanup (error);
 
 	return res;
 }
@@ -8025,8 +8025,8 @@ mono_class_from_name (MonoImage *image, const char* name_space, const char *name
 	ERROR_DECL (error);
 	MonoClass *klass;
 
-	klass = mono_class_from_name_checked (image, name_space, name, &error);
-	mono_error_cleanup (&error); /* FIXME Don't swallow the error */
+	klass = mono_class_from_name_checked (image, name_space, name, error);
+	mono_error_cleanup (error); /* FIXME Don't swallow the error */
 
 	return klass;
 }
@@ -8047,11 +8047,11 @@ mono_class_load_from_name (MonoImage *image, const char* name_space, const char 
 	ERROR_DECL (error);
 	MonoClass *klass;
 
-	klass = mono_class_from_name_checked (image, name_space, name, &error);
+	klass = mono_class_from_name_checked (image, name_space, name, error);
 	if (!klass)
 		g_error ("Runtime critical type %s.%s not found", name_space, name);
-	if (!mono_error_ok (&error))
-		g_error ("Could not load runtime critical type %s.%s due to %s", name_space, name, mono_error_get_message (&error));
+	if (!mono_error_ok (error))
+		g_error ("Could not load runtime critical type %s.%s due to %s", name_space, name, mono_error_get_message (error));
 	return klass;
 }
 
@@ -8074,9 +8074,9 @@ mono_class_try_load_from_name (MonoImage *image, const char* name_space, const c
 	ERROR_DECL (error);
 	MonoClass *klass;
 
-	klass = mono_class_from_name_checked (image, name_space, name, &error);
-	if (!mono_error_ok (&error))
-		g_error ("Could not load runtime critical type %s.%s due to %s", name_space, name, mono_error_get_message (&error));
+	klass = mono_class_from_name_checked (image, name_space, name, error);
+	if (!mono_error_ok (error))
+		g_error ("Could not load runtime critical type %s.%s due to %s", name_space, name, mono_error_get_message (error));
 	return klass;
 }
 
@@ -8390,9 +8390,9 @@ mono_class_is_assignable_from (MonoClass *klass, MonoClass *oklass)
 			 * oklass might be a generic type parameter but they have 
 			 * interface_offsets set.
 			 */
- 			gboolean result = mono_reflection_call_is_assignable_to (oklass, klass, &error);
-			if (!is_ok (&error)) {
-				mono_error_cleanup (&error);
+			gboolean result = mono_reflection_call_is_assignable_to (oklass, klass, error);
+			if (!is_ok (error)) {
+				mono_error_cleanup (error);
 				return FALSE;
 			}
 			return result;
@@ -8422,9 +8422,9 @@ mono_class_is_assignable_from (MonoClass *klass, MonoClass *oklass)
 
 		if (mono_class_has_variant_generic_params (klass)) {
 			int i;
-			mono_class_setup_interfaces (oklass, &error);
-			if (!mono_error_ok (&error)) {
-				mono_error_cleanup (&error);
+			mono_class_setup_interfaces (oklass, error);
+			if (!mono_error_ok (error)) {
+				mono_error_cleanup (error);
 				return FALSE;
 			}
 
@@ -8561,9 +8561,9 @@ mono_class_implement_interface_slow (MonoClass *target, MonoClass *candidate)
 			ICollection<sbyte> x byte [] won't work because candidate->interfaces, for byte[], won't have IList<sbyte>.
 			A possible way to fix this would be to move that to setup_interfaces from setup_interface_offsets.
 			*/
-			mono_class_setup_interfaces (candidate, &error);
-			if (!mono_error_ok (&error)) {
-				mono_error_cleanup (&error);
+			mono_class_setup_interfaces (candidate, error);
+			if (!mono_error_ok (error)) {
+				mono_error_cleanup (error);
 				return FALSE;
 			}
 
@@ -8664,18 +8664,18 @@ mono_class_get_cctor (MonoClass *klass)
 
 	if (mono_class_is_ginst (klass) && !klass->methods) {
 		ERROR_DECL (error);
-		error_init (&error);
-		MonoMethod *result = mono_class_get_inflated_method (klass, mono_class_get_cctor (mono_class_get_generic_class (klass)->container_class), &error);
-		if (!is_ok (&error))
-			g_error ("Could not lookup inflated class cctor due to %s", mono_error_get_message (&error)); /* FIXME do proper error handling */
+		error_init (error);
+		MonoMethod *result = mono_class_get_inflated_method (klass, mono_class_get_cctor (mono_class_get_generic_class (klass)->container_class), error);
+		if (!is_ok (error))
+			g_error ("Could not lookup inflated class cctor due to %s", mono_error_get_message (error)); /* FIXME do proper error handling */
 		return result;
 	}
 
 	if (mono_class_get_cached_class_info (klass, &cached_info)) {
 		ERROR_DECL (error);
-		MonoMethod *result = mono_get_method_checked (klass->image, cached_info.cctor_token, klass, NULL, &error);
-		if (!mono_error_ok (&error))
-			g_error ("Could not lookup class cctor from cached metadata due to %s", mono_error_get_message (&error));
+		MonoMethod *result = mono_get_method_checked (klass->image, cached_info.cctor_token, klass, NULL, error);
+		if (!mono_error_ok (error))
+			g_error ("Could not lookup class cctor from cached metadata due to %s", mono_error_get_message (error));
 		return result;
 	}
 
@@ -8700,9 +8700,9 @@ mono_class_get_finalizer (MonoClass *klass)
 
 	if (mono_class_get_cached_class_info (klass, &cached_info)) {
 		ERROR_DECL (error);
-		MonoMethod *result = mono_get_method_checked (cached_info.finalize_image, cached_info.finalize_token, NULL, NULL, &error);
-		if (!mono_error_ok (&error))
-			g_error ("Could not lookup finalizer from cached metadata due to %s", mono_error_get_message (&error));
+		MonoMethod *result = mono_get_method_checked (cached_info.finalize_image, cached_info.finalize_token, NULL, NULL, error);
+		if (!mono_error_ok (error))
+			g_error ("Could not lookup finalizer from cached metadata due to %s", mono_error_get_message (error));
 		return result;
 	}else {
 		mono_class_setup_vtable (klass);
@@ -8819,8 +8819,8 @@ mono_ldtoken (MonoImage *image, guint32 token, MonoClass **handle_class,
 	      MonoGenericContext *context)
 {
 	ERROR_DECL (error);
-	gpointer res = mono_ldtoken_checked (image, token, handle_class, context, &error);
-	mono_error_assert_ok (&error);
+	gpointer res = mono_ldtoken_checked (image, token, handle_class, context, error);
+	mono_error_assert_ok (error);
 	return res;
 }
 
@@ -9348,8 +9348,8 @@ mono_class_get_virtual_methods (MonoClass* klass, gpointer *iter)
 
 		if (i < mcount) {
 			ERROR_DECL (error);
-			res = mono_get_method_checked (klass->image, MONO_TOKEN_METHOD_DEF | (first_idx + i + 1), klass, NULL, &error);
-			mono_error_cleanup (&error); /* FIXME don't swallow the error */
+			res = mono_get_method_checked (klass->image, MONO_TOKEN_METHOD_DEF | (first_idx + i + 1), klass, NULL, error);
+			mono_error_cleanup (error); /* FIXME don't swallow the error */
 
 			/* Add 1 here so the if (*iter) check fails */
 			*iter  = GUINT_TO_POINTER (((i + 1) << 1) | 1);
@@ -9463,9 +9463,9 @@ mono_class_get_interfaces (MonoClass* klass, gpointer *iter)
 		if (!klass->inited)
 			mono_class_init (klass);
 		if (!klass->interfaces_inited) {
-			mono_class_setup_interfaces (klass, &error);
-			if (!mono_error_ok (&error)) {
-				mono_error_cleanup (&error);
+			mono_class_setup_interfaces (klass, error);
+			if (!mono_error_ok (error)) {
+				mono_error_cleanup (error);
 				return NULL;
 			}
 		}
@@ -9510,10 +9510,10 @@ setup_nested_types (MonoClass *klass)
 		MonoClass* nclass;
 		guint32 cols [MONO_NESTED_CLASS_SIZE];
 		mono_metadata_decode_row (&klass->image->tables [MONO_TABLE_NESTEDCLASS], i - 1, cols, MONO_NESTED_CLASS_SIZE);
-		nclass = mono_class_create_from_typedef (klass->image, MONO_TOKEN_TYPE_DEF | cols [MONO_NESTED_CLASS_NESTED], &error);
-		if (!mono_error_ok (&error)) {
+		nclass = mono_class_create_from_typedef (klass->image, MONO_TOKEN_TYPE_DEF | cols [MONO_NESTED_CLASS_NESTED], error);
+		if (!mono_error_ok (error)) {
 			/*FIXME don't swallow the error message*/
-			mono_error_cleanup (&error);
+			mono_error_cleanup (error);
 
 			i = mono_metadata_nesting_typedef (klass->image, klass->type_token, i + 1);
 			continue;
@@ -9628,10 +9628,10 @@ MonoType*
 mono_field_get_type (MonoClassField *field)
 {
 	ERROR_DECL (error);
-	MonoType *type = mono_field_get_type_checked (field, &error);
-	if (!mono_error_ok (&error)) {
-		mono_trace_warning (MONO_TRACE_TYPE, "Could not load field's type due to %s", mono_error_get_message (&error));
-		mono_error_cleanup (&error);
+	MonoType *type = mono_field_get_type_checked (field, error);
+	if (!mono_error_ok (error)) {
+		mono_trace_warning (MONO_TRACE_TYPE, "Could not load field's type due to %s", mono_error_get_message (error));
+		mono_error_cleanup (error);
 	}
 	return type;
 }
@@ -9908,18 +9908,18 @@ find_method_in_metadata (MonoClass *klass, const char *name, int param_count, in
 		mono_metadata_decode_table_row (klass->image, MONO_TABLE_METHOD, first_idx + i, cols, MONO_METHOD_SIZE);
 
 		if (!strcmp (mono_metadata_string_heap (klass->image, cols [MONO_METHOD_NAME]), name)) {
-			method = mono_get_method_checked (klass->image, MONO_TOKEN_METHOD_DEF | (first_idx + i + 1), klass, NULL, &error);
+			method = mono_get_method_checked (klass->image, MONO_TOKEN_METHOD_DEF | (first_idx + i + 1), klass, NULL, error);
 			if (!method) {
-				mono_error_cleanup (&error); /* FIXME don't swallow the error */
+				mono_error_cleanup (error); /* FIXME don't swallow the error */
 				continue;
 			}
 			if (param_count == -1) {
 				res = method;
 				break;
 			}
-			sig = mono_method_signature_checked (method, &error);
+			sig = mono_method_signature_checked (method, error);
 			if (!sig) {
-				mono_error_cleanup (&error); /* FIXME don't swallow the error */
+				mono_error_cleanup (error); /* FIXME don't swallow the error */
 				continue;
 			}
 			if (sig->param_count == param_count) {
@@ -9946,11 +9946,11 @@ MonoMethod *
 mono_class_get_method_from_name_flags (MonoClass *klass, const char *name, int param_count, int flags)
 {
 	ERROR_DECL (error);
-	error_init (&error);
+	error_init (error);
 
-	MonoMethod * const method = mono_class_get_method_from_name_checked (klass, name, param_count, flags, &error);
+	MonoMethod * const method = mono_class_get_method_from_name_checked (klass, name, param_count, flags, error);
 
-	mono_error_cleanup (&error);
+	mono_error_cleanup (error);
 	return method;
 }
 
@@ -10063,7 +10063,7 @@ mono_class_has_failure (const MonoClass *klass)
 gboolean
 mono_class_set_type_load_failure (MonoClass *klass, const char * fmt, ...)
 {
-	ERROR_DECL (prepare_error);
+	ERROR_DECL_VALUE (prepare_error);
 	va_list args;
 
 	if (mono_class_has_failure (klass))
@@ -10145,7 +10145,7 @@ mono_class_get_exception_for_failure (MonoClass *klass)
 {
 	if (!mono_class_has_failure (klass))
 		return NULL;
-	ERROR_DECL (unboxed_error);
+	ERROR_DECL_VALUE (unboxed_error);
 	error_init (&unboxed_error);
 	mono_error_set_for_class_failure (&unboxed_error, klass);
 	return mono_error_convert_to_exception (&unboxed_error);

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -323,11 +323,11 @@ cominterop_get_com_slot_begin (MonoClass* klass)
 	MonoCustomAttrInfo *cinfo = NULL;
 	MonoInterfaceTypeAttribute* itf_attr = NULL; 
 
-	cinfo = mono_custom_attrs_from_class_checked (klass, &error);
-	mono_error_assert_ok (&error);
+	cinfo = mono_custom_attrs_from_class_checked (klass, error);
+	mono_error_assert_ok (error);
 	if (cinfo) {
-		itf_attr = (MonoInterfaceTypeAttribute*)mono_custom_attrs_get_attr_checked (cinfo, mono_class_get_interface_type_attribute_class (), &error);
-		g_assert (mono_error_ok (&error)); /*FIXME proper error handling*/
+		itf_attr = (MonoInterfaceTypeAttribute*)mono_custom_attrs_get_attr_checked (cinfo, mono_class_get_interface_type_attribute_class (), error);
+		g_assert (mono_error_ok (error)); /*FIXME proper error handling*/
 		if (!cinfo->cached)
 			mono_custom_attrs_free (cinfo);
 	}
@@ -353,8 +353,8 @@ cominterop_get_method_interface (MonoMethod* method)
 
 	/* if method is on a class, we need to look up interface method exists on */
 	if (!MONO_CLASS_IS_INTERFACE(method->klass)) {
-		GPtrArray *ifaces = mono_class_get_implemented_interfaces (method->klass, &error);
-		g_assert (mono_error_ok (&error));
+		GPtrArray *ifaces = mono_class_get_implemented_interfaces (method->klass, error);
+		g_assert (mono_error_ok (error));
 		if (ifaces) {
 			int i;
 			mono_class_setup_vtable (method->klass);
@@ -439,11 +439,11 @@ cominterop_class_guid (MonoClass* klass, guint8* guid)
 	ERROR_DECL (error);
 	MonoCustomAttrInfo *cinfo;
 
-	cinfo = mono_custom_attrs_from_class_checked (klass, &error);
-	mono_error_assert_ok (&error);
+	cinfo = mono_custom_attrs_from_class_checked (klass, error);
+	mono_error_assert_ok (error);
 	if (cinfo) {
-		MonoReflectionGuidAttribute *attr = (MonoReflectionGuidAttribute*)mono_custom_attrs_get_attr_checked (cinfo, mono_class_get_guid_attribute_class (), &error);
-		g_assert (mono_error_ok (&error)); /*FIXME proper error handling*/
+		MonoReflectionGuidAttribute *attr = (MonoReflectionGuidAttribute*)mono_custom_attrs_get_attr_checked (cinfo, mono_class_get_guid_attribute_class (), error);
+		g_assert (mono_error_ok (error)); /*FIXME proper error handling*/
 
 		if (!attr)
 			return FALSE;
@@ -464,11 +464,11 @@ cominterop_com_visible (MonoClass* klass)
 	GPtrArray *ifaces;
 	MonoBoolean visible = 1;
 
-	cinfo = mono_custom_attrs_from_class_checked (klass, &error);
-	mono_error_assert_ok (&error);
+	cinfo = mono_custom_attrs_from_class_checked (klass, error);
+	mono_error_assert_ok (error);
 	if (cinfo) {
-		MonoReflectionComVisibleAttribute *attr = (MonoReflectionComVisibleAttribute*)mono_custom_attrs_get_attr_checked (cinfo, mono_class_get_guid_attribute_class (), &error);
-		g_assert (mono_error_ok (&error)); /*FIXME proper error handling*/
+		MonoReflectionComVisibleAttribute *attr = (MonoReflectionComVisibleAttribute*)mono_custom_attrs_get_attr_checked (cinfo, mono_class_get_guid_attribute_class (), error);
+		g_assert (mono_error_ok (error)); /*FIXME proper error handling*/
 
 		if (attr)
 			visible = attr->visible;
@@ -478,8 +478,8 @@ cominterop_com_visible (MonoClass* klass)
 			return TRUE;
 	}
 
-	ifaces = mono_class_get_implemented_interfaces (klass, &error);
-	g_assert (mono_error_ok (&error));
+	ifaces = mono_class_get_implemented_interfaces (klass, error);
+	g_assert (mono_error_ok (error));
 	if (ifaces) {
 		int i;
 		for (i = 0; i < ifaces->len; ++i) {
@@ -505,8 +505,8 @@ static void cominterop_set_hr_error (MonoError *oerror, int hr)
 	if (!throw_exception_for_hr)
 		throw_exception_for_hr = mono_class_get_method_from_name (mono_defaults.marshal_class, "GetExceptionForHR", 1);
 
-	ex = (MonoException*)mono_runtime_invoke_checked (throw_exception_for_hr, NULL, params, &error);
-	mono_error_assert_ok (&error);
+	ex = (MonoException*)mono_runtime_invoke_checked (throw_exception_for_hr, NULL, params, error);
+	mono_error_assert_ok (error);
 
 	mono_error_set_exception_instance (oerror, ex);
 }
@@ -567,13 +567,13 @@ static gpointer
 cominterop_get_interface (MonoComObject *obj, MonoClass *ic, gboolean throw_exception)
 {
 	ERROR_DECL (error);
-	gpointer itf = cominterop_get_interface_checked (obj, ic, &error);
-	if (!is_ok (&error)) {
+	gpointer itf = cominterop_get_interface_checked (obj, ic, error);
+	if (!is_ok (error)) {
 		if (throw_exception) {
-			mono_error_set_pending_exception (&error);
+			mono_error_set_pending_exception (error);
 			return NULL;
 		} else {
-			mono_error_cleanup (&error);
+			mono_error_cleanup (error);
 		}
 	}
 
@@ -600,8 +600,8 @@ cominterop_type_from_handle (MonoType *handle)
 
 	mono_class_init (klass);
 
-	ret = mono_type_get_object_checked (domain, handle, &error);
-	mono_error_set_pending_exception (&error);
+	ret = mono_type_get_object_checked (domain, handle, error);
+	mono_error_set_pending_exception (error);
 
 	return ret;
 }
@@ -656,16 +656,16 @@ mono_mb_emit_cominterop_get_function_pointer (MonoMethodBuilder *mb, MonoMethod 
 	ERROR_DECL (error);
 	// get function pointer from 1st arg, the COM interface pointer
 	mono_mb_emit_ldarg (mb, 0);
-	slot = cominterop_get_com_slot_for_method (method, &error);
-	if (is_ok (&error)) {
+	slot = cominterop_get_com_slot_for_method (method, error);
+	if (is_ok (error)) {
 		mono_mb_emit_icon (mb, slot);
 		mono_mb_emit_icall (mb, cominterop_get_function_pointer);
 		/* Leaves the function pointer on top of the stack */
 	}
 	else {
-		mono_mb_emit_exception_for_error (mb, &error);
+		mono_mb_emit_exception_for_error (mb, error);
 	}
-	mono_error_cleanup (&error);
+	mono_error_cleanup (error);
 #endif
 }
 
@@ -1020,10 +1020,10 @@ mono_cominterop_get_native_wrapper (MonoMethod *method)
 			 * Thus, calling it should invariably lead to an exception.
 			 */
 			ERROR_DECL (error);
-			error_init (&error);
-			mono_cominterop_get_interface_missing_error (&error, method);
-			mono_mb_emit_exception_for_error (mb, &error);
-			mono_error_cleanup (&error);
+			error_init (error);
+			mono_cominterop_get_interface_missing_error (error, method);
+			mono_mb_emit_exception_for_error (mb, error);
+			mono_error_cleanup (error);
 		}
 		else {
 			static MonoMethod * ThrowExceptionForHR = NULL;
@@ -1628,8 +1628,8 @@ ves_icall_System_Runtime_InteropServices_Marshal_GetIUnknownForObjectInternal (M
 		return ((MonoComInteropProxy*)real_proxy)->com_object->iunknown;
 	}
 	else {
-		void* ccw_entry = cominterop_get_ccw_checked (object, mono_class_get_iunknown_class (), &error);
-		mono_error_set_pending_exception (&error);
+		void* ccw_entry = cominterop_get_ccw_checked (object, mono_class_get_iunknown_class (), error);
+		mono_error_set_pending_exception (error);
 		return ccw_entry;
 	}
 #else
@@ -1660,8 +1660,8 @@ ves_icall_System_Runtime_InteropServices_Marshal_GetIDispatchForObjectInternal (
 {
 #ifndef DISABLE_COM
 	ERROR_DECL (error);
-	void* idisp = cominterop_get_idispatch_for_object (object, &error);
-	mono_error_set_pending_exception (&error);
+	void* idisp = cominterop_get_idispatch_for_object (object, error);
+	mono_error_set_pending_exception (error);
 	return idisp;
 #else
 	g_assert_not_reached ();
@@ -1684,8 +1684,8 @@ ves_icall_System_Runtime_InteropServices_Marshal_GetCCW (MonoObject* object, Mon
 		return NULL;
 	}
 
-	itf = cominterop_get_ccw_checked (object, klass, &error);
-	mono_error_set_pending_exception (&error);
+	itf = cominterop_get_ccw_checked (object, klass, error);
+	mono_error_set_pending_exception (error);
 	return itf;
 #else
 	g_assert_not_reached ();
@@ -1737,8 +1737,8 @@ ves_icall_System_Runtime_InteropServices_Marshal_GetComSlotForMethodInfoInternal
 {
 #ifndef DISABLE_COM
 	ERROR_DECL (error);
-	int slot = cominterop_get_com_slot_for_method (m->method, &error);
-	mono_error_assert_ok (&error);
+	int slot = cominterop_get_com_slot_for_method (m->method, error);
+	mono_error_assert_ok (error);
 	return slot;
 #else
 	g_assert_not_reached ();
@@ -1763,11 +1763,11 @@ ves_icall_System_ComObject_CreateRCW (MonoReflectionType *type)
 	 * is called by the corresponding real proxy to create the real RCW.
 	 * Constructor does not need to be called. Will be called later.
 	*/
-	MonoVTable *vtable = mono_class_vtable_checked (domain, klass, &error);
-	if (mono_error_set_pending_exception (&error))
+	MonoVTable *vtable = mono_class_vtable_checked (domain, klass, error);
+	if (mono_error_set_pending_exception (error))
 		return NULL;
-	obj = mono_object_new_alloc_specific_checked (vtable, &error);
-	if (mono_error_set_pending_exception (&error))
+	obj = mono_object_new_alloc_specific_checked (vtable, error);
+	if (mono_error_set_pending_exception (error))
 		return NULL;
 
 	return obj;
@@ -1854,11 +1854,11 @@ ves_icall_System_ComObject_GetInterfaceInternal (MonoComObject* obj, MonoReflect
 		return NULL;
 	}
 
-	gpointer itf = cominterop_get_interface_checked (obj, klass, &error);
+	gpointer itf = cominterop_get_interface_checked (obj, klass, error);
 	if (throw_exception)
-		mono_error_set_pending_exception (&error);
+		mono_error_set_pending_exception (error);
 	else
-		mono_error_cleanup (&error);
+		mono_error_cleanup (error);
 	return itf;
 #else
 	g_assert_not_reached ();
@@ -2214,8 +2214,8 @@ static gpointer
 cominterop_get_ccw (MonoObject* object, MonoClass* itf)
 {
 	ERROR_DECL (error);
-	gpointer ccw_entry = cominterop_get_ccw_checked (object, itf, &error);
-	mono_error_set_pending_exception (&error);
+	gpointer ccw_entry = cominterop_get_ccw_checked (object, itf, error);
+	mono_error_set_pending_exception (error);
 	return ccw_entry;
 }
 
@@ -2539,8 +2539,8 @@ cominterop_ccw_queryinterface (MonoCCWInterface* ccwe, guint8* riid, gpointer* p
 
 	/* handle IUnknown special */
 	if (cominterop_class_guid_equal (riid, mono_class_get_iunknown_class ())) {
-		*ppv = cominterop_get_ccw_checked (object, mono_class_get_iunknown_class (), &error);
-		mono_error_assert_ok (&error);
+		*ppv = cominterop_get_ccw_checked (object, mono_class_get_iunknown_class (), error);
+		mono_error_assert_ok (error);
 		/* remember to addref on QI */
 		cominterop_ccw_addref ((MonoCCWInterface *)*ppv);
 		return MONO_S_OK;
@@ -2551,8 +2551,8 @@ cominterop_ccw_queryinterface (MonoCCWInterface* ccwe, guint8* riid, gpointer* p
 		if (!cominterop_can_support_dispatch (klass))
 			return MONO_E_NOINTERFACE;
 		
-		*ppv = cominterop_get_ccw_checked (object, mono_class_get_idispatch_class (), &error);
-		mono_error_assert_ok (&error);
+		*ppv = cominterop_get_ccw_checked (object, mono_class_get_idispatch_class (), error);
+		mono_error_assert_ok (error);
 		/* remember to addref on QI */
 		cominterop_ccw_addref ((MonoCCWInterface *)*ppv);
 		return MONO_S_OK;
@@ -2561,15 +2561,15 @@ cominterop_ccw_queryinterface (MonoCCWInterface* ccwe, guint8* riid, gpointer* p
 #ifdef HOST_WIN32
 	/* handle IMarshal special */
 	if (0 == memcmp (riid, &MONO_IID_IMarshal, sizeof (IID))) {
-		int res = cominterop_ccw_getfreethreadedmarshaler (ccw, object, ppv, &error);
-		mono_error_assert_ok (&error);
+		int res = cominterop_ccw_getfreethreadedmarshaler (ccw, object, ppv, error);
+		mono_error_assert_ok (error);
 		return res;
 	}
 #endif
 	klass_iter = klass;
 	while (klass_iter && klass_iter != mono_defaults.object_class) {
-		ifaces = mono_class_get_implemented_interfaces (klass_iter, &error);
-		g_assert (mono_error_ok (&error));
+		ifaces = mono_class_get_implemented_interfaces (klass_iter, error);
+		g_assert (mono_error_ok (error));
 		if (ifaces) {
 			for (i = 0; i < ifaces->len; ++i) {
 				MonoClass *ic = NULL;
@@ -2588,9 +2588,9 @@ cominterop_ccw_queryinterface (MonoCCWInterface* ccwe, guint8* riid, gpointer* p
 		klass_iter = klass_iter->parent;
 	}
 	if (itf) {
-		*ppv = cominterop_get_ccw_checked (object, itf, &error);
-		if (!is_ok (&error)) {
-			mono_error_cleanup (&error); /* FIXME don't swallow the error */
+		*ppv = cominterop_get_ccw_checked (object, itf, error);
+		if (!is_ok (error)) {
+			mono_error_cleanup (error); /* FIXME don't swallow the error */
 			return MONO_E_NOINTERFACE;
 		}
 		/* remember to addref on QI */
@@ -2648,11 +2648,11 @@ cominterop_ccw_get_ids_of_names (MonoCCWInterface* ccwe, gpointer riid,
 
 		method = mono_class_get_method_from_name(klass, methodname, -1);
 		if (method) {
-			cinfo = mono_custom_attrs_from_method_checked (method, &error);
-			mono_error_assert_ok (&error); /* FIXME what's reasonable to do here */
+			cinfo = mono_custom_attrs_from_method_checked (method, error);
+			mono_error_assert_ok (error); /* FIXME what's reasonable to do here */
 			if (cinfo) {
-				MonoObject *result = mono_custom_attrs_get_attr_checked (cinfo, ComDispIdAttribute, &error);
-				g_assert (mono_error_ok (&error)); /*FIXME proper error handling*/;
+				MonoObject *result = mono_custom_attrs_get_attr_checked (cinfo, ComDispIdAttribute, error);
+				g_assert (mono_error_ok (error)); /*FIXME proper error handling*/;
 
 				if (result)
 					rgDispId[i] = *(gint32*)mono_object_unbox (result);
@@ -2848,8 +2848,8 @@ MonoString *
 mono_string_from_bstr (gpointer bstr)
 {
 	ERROR_DECL (error);
-	MonoString *result = mono_string_from_bstr_checked (bstr, &error);
-	mono_error_cleanup (&error);
+	MonoString *result = mono_string_from_bstr_checked (bstr, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -2857,8 +2857,8 @@ MonoString *
 mono_string_from_bstr_icall (gpointer bstr)
 {
 	ERROR_DECL (error);
-	MonoString *result = mono_string_from_bstr_checked (bstr, &error);
-	mono_error_set_pending_exception (&error);
+	MonoString *result = mono_string_from_bstr_checked (bstr, error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 
@@ -3293,16 +3293,16 @@ mono_marshal_safearray_begin (gpointer safearray, MonoArray **result, gpointer *
 
 				hr = mono_marshal_safe_array_get_lbound (safearray, i+1, &lbound);
 				if (hr < 0) {
-					cominterop_set_hr_error (&error, hr);
-					if (mono_error_set_pending_exception (&error))
+					cominterop_set_hr_error (error, hr);
+					if (mono_error_set_pending_exception (error))
 						return FALSE;
 				}
 				if (lbound != 0)
 					bounded = TRUE;
 				hr = mono_marshal_safe_array_get_ubound (safearray, i+1, &ubound);
 				if (hr < 0) {
-					cominterop_set_hr_error (&error, hr);
-					if (mono_error_set_pending_exception (&error))
+					cominterop_set_hr_error (error, hr);
+					if (mono_error_set_pending_exception (error))
 						return FALSE;
 				}
 				cursize = ubound-lbound+1;
@@ -3317,8 +3317,8 @@ mono_marshal_safearray_begin (gpointer safearray, MonoArray **result, gpointer *
 
 			if (allocateNewArray) {
 				aklass = mono_bounded_array_class_get (mono_defaults.object_class, dim, bounded);
-				*result = mono_array_new_full_checked (mono_domain_get (), aklass, sizes, bounds, &error);
-				if (mono_error_set_pending_exception (&error))
+				*result = mono_array_new_full_checked (mono_domain_get (), aklass, sizes, bounds, error);
+				if (mono_error_set_pending_exception (error))
 					return FALSE;
 			} else {
 				*result = (MonoArray *)parameter;
@@ -3346,8 +3346,8 @@ mono_marshal_safearray_get_value (gpointer safearray, gpointer indices)
 
 	int hr = mono_marshal_win_safearray_get_value (safearray, indices, &result);
 	if (hr < 0) {
-			cominterop_set_hr_error (&error, hr);
-			mono_error_set_pending_exception (&error);
+			cominterop_set_hr_error (error, hr);
+			mono_error_set_pending_exception (error);
 			result = NULL;
 	}
 
@@ -3365,8 +3365,8 @@ mono_marshal_safearray_get_value (gpointer safearray, gpointer indices)
 	if (com_provider == MONO_COM_MS && init_com_provider_ms ()) {
 		int hr = safe_array_ptr_of_index_ms (safearray, (glong *)indices, &result);
 		if (hr < 0) {
-			cominterop_set_hr_error (&error, hr);
-			mono_error_set_pending_exception (&error);
+			cominterop_set_hr_error (error, hr);
+			mono_error_set_pending_exception (error);
 			return NULL;
 		}
 	} else {
@@ -3393,8 +3393,8 @@ gboolean mono_marshal_safearray_next (gpointer safearray, gpointer indices)
 
 		hr = mono_marshal_safe_array_get_ubound (safearray, i+1, &ubound);
 		if (hr < 0) {
-			cominterop_set_hr_error (&error, hr);
-			mono_error_set_pending_exception (&error);
+			cominterop_set_hr_error (error, hr);
+			mono_error_set_pending_exception (error);
 			return FALSE;
 		}
 
@@ -3404,8 +3404,8 @@ gboolean mono_marshal_safearray_next (gpointer safearray, gpointer indices)
 
 		hr = mono_marshal_safe_array_get_lbound (safearray, i+1, &lbound);
 		if (hr < 0) {
-			cominterop_set_hr_error (&error, hr);
-			mono_error_set_pending_exception (&error);
+			cominterop_set_hr_error (error, hr);
+			mono_error_set_pending_exception (error);
 			return FALSE;
 		}
 
@@ -3530,8 +3530,8 @@ mono_marshal_safearray_set_value (gpointer safearray, gpointer indices, gpointer
 	ERROR_DECL (error);
 	int hr = mono_marshal_win_safearray_set_value (safearray, indices, value);
 	if (hr < 0) {
-		cominterop_set_hr_error (&error, hr);
-		mono_error_set_pending_exception (&error);
+		cominterop_set_hr_error (error, hr);
+		mono_error_set_pending_exception (error);
 		return;
 	}
 }
@@ -3545,8 +3545,8 @@ mono_marshal_safearray_set_value (gpointer safearray, gpointer indices, gpointer
 	if (com_provider == MONO_COM_MS && init_com_provider_ms ()) {
 		int hr = safe_array_put_element_ms (safearray, (glong *)indices, (void **)value);
 		if (hr < 0) {
-			cominterop_set_hr_error (&error, hr);
-			mono_error_set_pending_exception (&error);
+			cominterop_set_hr_error (error, hr);
+			mono_error_set_pending_exception (error);
 			return;
 		}
 	} else
@@ -3618,8 +3618,8 @@ MonoString *
 mono_string_from_bstr (gpointer bstr)
 {
 	ERROR_DECL (error);
-	MonoString *result = mono_string_from_bstr_checked (bstr, &error);
-	mono_error_cleanup (&error);
+	MonoString *result = mono_string_from_bstr_checked (bstr, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -3627,8 +3627,8 @@ MonoString *
 mono_string_from_bstr_icall (gpointer bstr)
 {
 	ERROR_DECL (error);
-	MonoString *result = mono_string_from_bstr_checked (bstr, &error);
-	mono_error_set_pending_exception (&error);
+	MonoString *result = mono_string_from_bstr_checked (bstr, error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 
@@ -3692,8 +3692,8 @@ MonoString *
 ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringBSTR (gpointer ptr)
 {
 	ERROR_DECL (error);
-	MonoString *result = mono_string_from_bstr_checked (ptr, &error);
-	mono_error_set_pending_exception (&error);
+	MonoString *result = mono_string_from_bstr_checked (ptr, error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 

--- a/mono/metadata/console-unix.c
+++ b/mono/metadata/console-unix.c
@@ -230,8 +230,8 @@ do_console_cancel_event (void)
 	if (System_Console_DoConsoleCancelEventBackground_method == NULL)
 		return;
 
-	mono_runtime_invoke_checked (System_Console_DoConsoleCancelEventBackground_method, NULL, NULL, &error);
-	mono_error_assert_ok (&error);
+	mono_runtime_invoke_checked (System_Console_DoConsoleCancelEventBackground_method, NULL, NULL, error);
+	mono_error_assert_ok (error);
 }
 
 static int need_cancel = FALSE;
@@ -448,8 +448,8 @@ ves_icall_System_ConsoleDriver_TtySetup (MonoString *keypad, MonoString *teardow
 
 	/* 17 is the number of entries set in set_control_chars() above.
 	 * NCCS is the total size, but, by now, we only care about those 17 values*/
-	MonoArray *control_chars_arr = mono_array_new_checked (mono_domain_get (), mono_defaults.byte_class, 17, &error);
-	if (mono_error_set_pending_exception (&error))
+	MonoArray *control_chars_arr = mono_array_new_checked (mono_domain_get (), mono_defaults.byte_class, 17, error);
+	if (mono_error_set_pending_exception (error))
 		return FALSE;
 	mono_gc_wbarrier_generic_store (control_chars, (MonoObject*) control_chars_arr);
 	if (tcgetattr (STDIN_FILENO, &initial_attr) == -1)
@@ -474,8 +474,8 @@ ves_icall_System_ConsoleDriver_TtySetup (MonoString *keypad, MonoString *teardow
 
 	keypad_xmit_str = NULL;
 	if (keypad != NULL) {
-		keypad_xmit_str = mono_string_to_utf8_checked (keypad, &error);
-		if (mono_error_set_pending_exception (&error))
+		keypad_xmit_str = mono_string_to_utf8_checked (keypad, error);
+		if (mono_error_set_pending_exception (error))
 			return FALSE;
 	}
 	
@@ -483,8 +483,8 @@ ves_icall_System_ConsoleDriver_TtySetup (MonoString *keypad, MonoString *teardow
 	setup_finished = TRUE;
 	if (!atexit_called) {
 		if (teardown != NULL) {
-			teardown_str = mono_string_to_utf8_checked (teardown, &error);
-			if (mono_error_set_pending_exception (&error))
+			teardown_str = mono_string_to_utf8_checked (teardown, error);
+			if (mono_error_set_pending_exception (error))
 				return FALSE;
 		}
 

--- a/mono/metadata/console-win32-uwp.c
+++ b/mono/metadata/console-win32-uwp.c
@@ -16,7 +16,7 @@
 MonoBoolean
 ves_icall_System_ConsoleDriver_Isatty (HANDLE handle)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("Console");
@@ -32,7 +32,7 @@ ves_icall_System_ConsoleDriver_Isatty (HANDLE handle)
 MonoBoolean
 ves_icall_System_ConsoleDriver_SetEcho (MonoBoolean want_echo)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("Console");
@@ -48,7 +48,7 @@ ves_icall_System_ConsoleDriver_SetEcho (MonoBoolean want_echo)
 MonoBoolean
 ves_icall_System_ConsoleDriver_SetBreak (MonoBoolean want_break)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("Console");
@@ -64,7 +64,7 @@ ves_icall_System_ConsoleDriver_SetBreak (MonoBoolean want_break)
 gint32
 ves_icall_System_ConsoleDriver_InternalKeyAvailable (gint32 timeout)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("Console");
@@ -80,7 +80,7 @@ ves_icall_System_ConsoleDriver_InternalKeyAvailable (gint32 timeout)
 MonoBoolean
 ves_icall_System_ConsoleDriver_TtySetup (MonoString *keypad, MonoString *teardown, MonoArray **control_chars, int **size)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("Console");

--- a/mono/metadata/coree.c
+++ b/mono/metadata/coree.c
@@ -189,10 +189,10 @@ __int32 STDMETHODCALLTYPE _CorExeMain(void)
 		ExitProcess (1);
 	}
 
-	method = mono_get_method_checked (image, entry, NULL, NULL, &error);
+	method = mono_get_method_checked (image, entry, NULL, NULL, error);
 	if (method == NULL) {
 		g_free (file_name);
-		mono_error_cleanup (&error); /* FIXME don't swallow the error */
+		mono_error_cleanup (error); /* FIXME don't swallow the error */
 		MessageBox (NULL, L"The entry point method could not be loaded.", NULL, MB_ICONERROR);
 		mono_runtime_quit ();
 		ExitProcess (1);
@@ -205,8 +205,8 @@ __int32 STDMETHODCALLTYPE _CorExeMain(void)
 		argv [i] = g_utf16_to_utf8 (argvw [i], -1, NULL, NULL, NULL);
 	LocalFree (argvw);
 
-	mono_runtime_run_main_checked (method, argc, argv, &error);
-	mono_error_raise_exception_deprecated (&error); /* OK, triggers unhandled exn handler */
+	mono_runtime_run_main_checked (method, argc, argv, error);
+	mono_error_raise_exception_deprecated (error); /* OK, triggers unhandled exn handler */
 	mono_thread_manage ();
 
 	mono_runtime_quit ();

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -176,7 +176,7 @@ find_event_index (MonoClass *klass, MonoEvent *event)
 static MonoType*
 cattr_type_from_name (char *n, MonoImage *image, gboolean is_enum, MonoError *error)
 {
-	ERROR_DECL (inner_error);
+	ERROR_DECL_VALUE (inner_error);
 	MonoType *t = mono_reflection_type_from_name_checked (n, image, &inner_error);
 	if (!t) {
 		mono_error_set_type_load_name (error, g_strdup(n), NULL,
@@ -1145,8 +1145,8 @@ void
 ves_icall_System_Reflection_CustomAttributeData_ResolveArgumentsInternal (MonoReflectionMethod *ref_method, MonoReflectionAssembly *assembly, gpointer data, guint32 len, MonoArray **ctor_args, MonoArray **named_args)
 {
 	ERROR_DECL (error);
-	(void) reflection_resolve_custom_attribute_data (ref_method, assembly, data, len, ctor_args, named_args, &error);
-	mono_error_set_pending_exception (&error);
+	(void) reflection_resolve_custom_attribute_data (ref_method, assembly, data, len, ctor_args, named_args, error);
+	mono_error_set_pending_exception (error);
 }
 
 static MonoObjectHandle
@@ -1246,8 +1246,8 @@ MonoArray*
 mono_custom_attrs_construct (MonoCustomAttrInfo *cinfo)
 {
 	ERROR_DECL (error);
-	MonoArray *result = mono_custom_attrs_construct_by_type (cinfo, NULL, &error);
-	mono_error_assert_ok (&error); /*FIXME proper error handling*/
+	MonoArray *result = mono_custom_attrs_construct_by_type (cinfo, NULL, error);
+	mono_error_assert_ok (error); /*FIXME proper error handling*/
 
 	return result;
 }
@@ -1279,8 +1279,8 @@ MonoCustomAttrInfo*
 mono_custom_attrs_from_index (MonoImage *image, guint32 idx)
 {
 	ERROR_DECL (error);
-	MonoCustomAttrInfo *result = mono_custom_attrs_from_index_checked (image, idx, FALSE, &error);
-	mono_error_cleanup (&error);
+	MonoCustomAttrInfo *result = mono_custom_attrs_from_index_checked (image, idx, FALSE, error);
+	mono_error_cleanup (error);
 	return result;
 }
 /**
@@ -1369,8 +1369,8 @@ MonoCustomAttrInfo*
 mono_custom_attrs_from_method (MonoMethod *method)
 {
 	ERROR_DECL (error);
-	MonoCustomAttrInfo* result = mono_custom_attrs_from_method_checked  (method, &error);
-	mono_error_cleanup (&error); /* FIXME want a better API that doesn't swallow the error */
+	MonoCustomAttrInfo* result = mono_custom_attrs_from_method_checked  (method, error);
+	mono_error_cleanup (error); /* FIXME want a better API that doesn't swallow the error */
 	return result;
 }
 
@@ -1410,8 +1410,8 @@ MonoCustomAttrInfo*
 mono_custom_attrs_from_class (MonoClass *klass)
 {
 	ERROR_DECL (error);
-	MonoCustomAttrInfo *result = mono_custom_attrs_from_class_checked (klass, &error);
-	mono_error_cleanup (&error);
+	MonoCustomAttrInfo *result = mono_custom_attrs_from_class_checked (klass, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -1447,8 +1447,8 @@ MonoCustomAttrInfo*
 mono_custom_attrs_from_assembly (MonoAssembly *assembly)
 {
 	ERROR_DECL (error);
-	MonoCustomAttrInfo *result = mono_custom_attrs_from_assembly_checked (assembly, FALSE, &error);
-	mono_error_cleanup (&error);
+	MonoCustomAttrInfo *result = mono_custom_attrs_from_assembly_checked (assembly, FALSE, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -1489,8 +1489,8 @@ MonoCustomAttrInfo*
 mono_custom_attrs_from_property (MonoClass *klass, MonoProperty *property)
 {
 	ERROR_DECL (error);
-	MonoCustomAttrInfo * result = mono_custom_attrs_from_property_checked (klass, property, &error);
-	mono_error_cleanup (&error);
+	MonoCustomAttrInfo * result = mono_custom_attrs_from_property_checked (klass, property, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -1518,8 +1518,8 @@ MonoCustomAttrInfo*
 mono_custom_attrs_from_event (MonoClass *klass, MonoEvent *event)
 {
 	ERROR_DECL (error);
-	MonoCustomAttrInfo * result = mono_custom_attrs_from_event_checked (klass, event, &error);
-	mono_error_cleanup (&error);
+	MonoCustomAttrInfo * result = mono_custom_attrs_from_event_checked (klass, event, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -1547,8 +1547,8 @@ MonoCustomAttrInfo*
 mono_custom_attrs_from_field (MonoClass *klass, MonoClassField *field)
 {
 	ERROR_DECL (error);
-	MonoCustomAttrInfo * result = mono_custom_attrs_from_field_checked (klass, field, &error);
-	mono_error_cleanup (&error);
+	MonoCustomAttrInfo * result = mono_custom_attrs_from_field_checked (klass, field, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -1581,8 +1581,8 @@ MonoCustomAttrInfo*
 mono_custom_attrs_from_param (MonoMethod *method, guint32 param)
 {
 	ERROR_DECL (error);
-	MonoCustomAttrInfo *result = mono_custom_attrs_from_param_checked (method, param, &error);
-	mono_error_cleanup (&error);
+	MonoCustomAttrInfo *result = mono_custom_attrs_from_param_checked (method, param, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -1689,8 +1689,8 @@ MonoObject*
 mono_custom_attrs_get_attr (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass)
 {
 	ERROR_DECL (error);
-	MonoObject *res = mono_custom_attrs_get_attr_checked (ainfo, attr_klass, &error);
-	mono_error_assert_ok (&error); /*FIXME proper error handling*/
+	MonoObject *res = mono_custom_attrs_get_attr_checked (ainfo, attr_klass, error);
+	mono_error_assert_ok (error); /*FIXME proper error handling*/
 	return res;
 }
 
@@ -1733,8 +1733,8 @@ mono_reflection_get_custom_attrs_info (MonoObject *obj_raw)
 	HANDLE_FUNCTION_ENTER ();
 	ERROR_DECL (error);
 	MONO_HANDLE_DCL (MonoObject, obj);
-	MonoCustomAttrInfo *result = mono_reflection_get_custom_attrs_info_checked (obj, &error);
-	mono_error_assert_ok (&error);
+	MonoCustomAttrInfo *result = mono_reflection_get_custom_attrs_info_checked (obj, error);
+	mono_error_assert_ok (error);
 	HANDLE_FUNCTION_RETURN_VAL (result);
 }
 
@@ -1930,8 +1930,8 @@ mono_reflection_get_custom_attrs (MonoObject *obj_raw)
 	HANDLE_FUNCTION_ENTER ();
 	ERROR_DECL (error);
 	MONO_HANDLE_DCL (MonoObject, obj);
-	MonoArrayHandle result = mono_reflection_get_custom_attrs_by_type_handle (obj, NULL, &error);
-	mono_error_cleanup (&error);
+	MonoArrayHandle result = mono_reflection_get_custom_attrs_by_type_handle (obj, NULL, error);
+	mono_error_cleanup (error);
 	HANDLE_FUNCTION_RETURN_OBJ (result);
 }
 
@@ -1948,8 +1948,8 @@ mono_reflection_get_custom_attrs_data (MonoObject *obj_raw)
 	HANDLE_FUNCTION_ENTER ();
 	ERROR_DECL (error);
 	MONO_HANDLE_DCL (MonoObject, obj);
-	MonoArrayHandle result = mono_reflection_get_custom_attrs_data_checked (obj, &error);
-	mono_error_cleanup (&error);
+	MonoArrayHandle result = mono_reflection_get_custom_attrs_data_checked (obj, error);
+	mono_error_cleanup (error);
 	HANDLE_FUNCTION_RETURN_OBJ (result);
 }
 
@@ -2168,9 +2168,9 @@ init_weak_fields_inner (MonoImage *image, GHashTable *indexes)
 
 	if (image == mono_get_corlib ()) {
 		/* Typedef */
-		klass = mono_class_from_name_checked (image, "System", "WeakAttribute", &error);
-		if (!is_ok (&error)) {
-			mono_error_cleanup (&error);
+		klass = mono_class_from_name_checked (image, "System", "WeakAttribute", error);
+		if (!is_ok (error)) {
+			mono_error_cleanup (error);
 			return;
 		}
 		if (!klass)
@@ -2238,9 +2238,9 @@ init_weak_fields_inner (MonoImage *image, GHashTable *indexes)
 				const char *nspace = mono_metadata_string_heap (image, cols [MONO_TYPEREF_NAMESPACE]);
 
 				if (!strcmp (nspace, "System") && !strcmp (name, "WeakAttribute")) {
-					MonoClass *klass = mono_class_from_typeref_checked (image, MONO_TOKEN_TYPE_REF | nindex, &error);
-					if (!is_ok (&error)) {
-						mono_error_cleanup (&error);
+					MonoClass *klass = mono_class_from_typeref_checked (image, MONO_TOKEN_TYPE_REF | nindex, error);
+					if (!is_ok (error)) {
+						mono_error_cleanup (error);
 						return;
 					}
 					g_assert (!strcmp (klass->name, "WeakAttribute"));

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -644,9 +644,9 @@ mono_method_desc_search_in_image (MonoMethodDesc *desc, MonoImage *image)
 
 		if (strcmp (n, desc->name))
 			continue;
-		method = mono_get_method_checked (image, MONO_TOKEN_METHOD_DEF | (i + 1), NULL, NULL, &error);
+		method = mono_get_method_checked (image, MONO_TOKEN_METHOD_DEF | (i + 1), NULL, NULL, error);
 		if (!method) {
-			mono_error_cleanup (&error);
+			mono_error_cleanup (error);
 			continue;
 		}
 		if (mono_method_desc_full_match (desc, method))
@@ -659,7 +659,7 @@ static const unsigned char*
 dis_one (GString *str, MonoDisHelper *dh, MonoMethod *method, const unsigned char *ip, const unsigned char *end)
 {
 	ERROR_DECL (error);
-	MonoMethodHeader *header = mono_method_get_header_checked (method, &error);
+	MonoMethodHeader *header = mono_method_get_header_checked (method, error);
 	const MonoOpcode *opcode;
 	guint32 label, token;
 	gint32 sval;
@@ -668,8 +668,8 @@ dis_one (GString *str, MonoDisHelper *dh, MonoMethod *method, const unsigned cha
 	const unsigned char* il_code;
 
 	if (!header) {
-		g_string_append_printf (str, "could not disassemble, bad header due to %s", mono_error_get_message (&error));
-		mono_error_cleanup (&error);
+		g_string_append_printf (str, "could not disassemble, bad header due to %s", mono_error_get_message (error));
+		mono_error_cleanup (error);
 		return end;
 	}
 	il_code = mono_method_header_get_code (header, NULL, NULL);
@@ -954,12 +954,12 @@ mono_method_get_name_full (MonoMethod *method, gboolean signature, gboolean ret,
 		strcpy (wrapper, "");
 
 	if (signature) {
-		MonoMethodSignature *sig = mono_method_signature_checked (method, &error);
+		MonoMethodSignature *sig = mono_method_signature_checked (method, error);
 		char *tmpsig;
 
-		if (!is_ok (&error)) {
+		if (!is_ok (error)) {
 			tmpsig = g_strdup_printf ("<unable to load signature>");
-			mono_error_cleanup (&error);
+			mono_error_cleanup (error);
 		} else {
 			tmpsig = mono_signature_get_desc (sig, TRUE);
 		}
@@ -1051,8 +1051,8 @@ mono_object_describe (MonoObject *obj)
 	}
 	klass = mono_object_class (obj);
 	if (klass == mono_defaults.string_class) {
-		char *utf8 = mono_string_to_utf8_checked ((MonoString*)obj, &error);
-		mono_error_cleanup (&error); /* FIXME don't swallow the error */
+		char *utf8 = mono_string_to_utf8_checked ((MonoString*)obj, error);
+		mono_error_cleanup (error); /* FIXME don't swallow the error */
 		if (utf8 && strlen (utf8) > 60) {
 			utf8 [57] = '.';
 			utf8 [58] = '.';
@@ -1225,11 +1225,11 @@ mono_class_describe_statics (MonoClass* klass)
 	MonoClassField *field;
 	MonoClass *p;
 	const char *field_ptr;
-	MonoVTable *vtable = mono_class_vtable_checked (mono_domain_get (), klass, &error);
+	MonoVTable *vtable = mono_class_vtable_checked (mono_domain_get (), klass, error);
 	const char *addr;
 
-	if (!vtable || !is_ok (&error)) {
-		mono_error_cleanup (&error);
+	if (!vtable || !is_ok (error)) {
+		mono_error_cleanup (error);
 		return;
 	}
 
@@ -1264,10 +1264,10 @@ mono_method_print_code (MonoMethod *method)
 {
 	ERROR_DECL (error);
 	char *code;
-	MonoMethodHeader *header = mono_method_get_header_checked (method, &error);
+	MonoMethodHeader *header = mono_method_get_header_checked (method, error);
 	if (!header) {
-		printf ("METHOD HEADER NOT FOUND DUE TO: %s\n", mono_error_get_message (&error));
-		mono_error_cleanup (&error);
+		printf ("METHOD HEADER NOT FOUND DUE TO: %s\n", mono_error_get_message (error));
+		mono_error_cleanup (error);
 		return;
 	}
 	code = mono_disasm_code (0, method, header->code, header->code + header->code_size);

--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -75,13 +75,13 @@ mono_exception_from_name_domain (MonoDomain *domain, MonoImage *image,
 
 	klass = mono_class_load_from_name (image, name_space, name);
 
-	o = mono_object_new_checked (domain, klass, &error);
-	mono_error_assert_ok (&error);
+	o = mono_object_new_checked (domain, klass, error);
+	mono_error_assert_ok (error);
 
 	if (domain != caller_domain)
 		mono_domain_set_internal (domain);
-	mono_runtime_object_init_checked (o, &error);
-	mono_error_assert_ok (&error);
+	mono_runtime_object_init_checked (o, error);
+	mono_error_assert_ok (error);
 
 	if (domain != caller_domain)
 		mono_domain_set_internal (caller_domain);
@@ -106,14 +106,14 @@ mono_exception_from_token (MonoImage *image, guint32 token)
 	MonoClass *klass;
 	MonoObject *o;
 
-	klass = mono_class_get_checked (image, token, &error);
-	mono_error_assert_ok (&error);
+	klass = mono_class_get_checked (image, token, error);
+	mono_error_assert_ok (error);
 
-	o = mono_object_new_checked (mono_domain_get (), klass, &error);
-	mono_error_assert_ok (&error);
+	o = mono_object_new_checked (mono_domain_get (), klass, error);
+	mono_error_assert_ok (error);
 	
-	mono_runtime_object_init_checked (o, &error);
-	mono_error_assert_ok (&error);
+	mono_runtime_object_init_checked (o, error);
+	mono_error_assert_ok (error);
 
 	return (MonoException *)o;
 }
@@ -182,8 +182,8 @@ mono_exception_from_name_two_strings (MonoImage *image, const char *name_space,
 	ERROR_DECL (error);
 	MonoException *ret;
 
-	ret = mono_exception_from_name_two_strings_checked (image, name_space, name, a1, a2, &error);
-	mono_error_cleanup (&error);
+	ret = mono_exception_from_name_two_strings_checked (image, name_space, name, a1, a2, error);
+	mono_error_cleanup (error);
 	return ret;
 }
 
@@ -236,8 +236,8 @@ mono_exception_from_name_msg (MonoImage *image, const char *name_space,
 	ex = mono_exception_from_name (image, name_space, name);
 
 	if (msg) {
-		MonoString  *msg_str = mono_string_new_checked (mono_object_get_domain ((MonoObject*)ex), msg, &error);
-		mono_error_assert_ok (&error);
+		MonoString  *msg_str = mono_string_new_checked (mono_object_get_domain ((MonoObject*)ex), msg, error);
+		mono_error_assert_ok (error);
 		MONO_OBJECT_SETREF (ex, message, msg_str);
 	}
 
@@ -256,8 +256,8 @@ mono_exception_from_token_two_strings (MonoImage *image, guint32 token,
 {
 	ERROR_DECL (error);
 	MonoException *ret;
-	ret = mono_exception_from_token_two_strings_checked (image, token, a1, a2, &error);
-	mono_error_cleanup (&error);
+	ret = mono_exception_from_token_two_strings_checked (image, token, a1, a2, error);
+	mono_error_cleanup (error);
 	return ret;
 }
 
@@ -437,14 +437,14 @@ mono_get_exception_type_load (MonoString *class_name, char *assembly_name)
 	ERROR_DECL (error);
 	MonoString *s = NULL;
 	if (assembly_name) {
-		s = mono_string_new_checked (mono_domain_get (), assembly_name, &error);
-		mono_error_assert_ok (&error);
+		s = mono_string_new_checked (mono_domain_get (), assembly_name, error);
+		mono_error_assert_ok (error);
 	} else
 		s = mono_string_empty (mono_domain_get ());
 
 	MonoException *ret = mono_exception_from_name_two_strings_checked (mono_get_corlib (), "System",
-								   "TypeLoadException", class_name, s, &error);
-	mono_error_assert_ok (&error);
+								   "TypeLoadException", class_name, s, error);
+	mono_error_assert_ok (error);
 	return ret;
 }
 
@@ -480,14 +480,14 @@ MonoException *
 mono_get_exception_missing_method (const char *class_name, const char *member_name)
 {
 	ERROR_DECL (error);
-	MonoString *s1 = mono_string_new_checked (mono_domain_get (), class_name, &error);
-	mono_error_assert_ok (&error);
-	MonoString *s2 = mono_string_new_checked (mono_domain_get (), member_name, &error);
-	mono_error_assert_ok (&error);
+	MonoString *s1 = mono_string_new_checked (mono_domain_get (), class_name, error);
+	mono_error_assert_ok (error);
+	MonoString *s2 = mono_string_new_checked (mono_domain_get (), member_name, error);
+	mono_error_assert_ok (error);
 
 	MonoException *ret = mono_exception_from_name_two_strings_checked (mono_get_corlib (), "System",
-									   "MissingMethodException", s1, s2, &error);
-	mono_error_assert_ok (&error);
+									   "MissingMethodException", s1, s2, error);
+	mono_error_assert_ok (error);
 	return ret;
 }
 
@@ -501,14 +501,14 @@ MonoException *
 mono_get_exception_missing_field (const char *class_name, const char *member_name)
 {
 	ERROR_DECL (error);
-	MonoString *s1 = mono_string_new_checked (mono_domain_get (), class_name, &error);
-	mono_error_assert_ok (&error);
-	MonoString *s2 = mono_string_new_checked (mono_domain_get (), member_name, &error);
-	mono_error_assert_ok (&error);
+	MonoString *s1 = mono_string_new_checked (mono_domain_get (), class_name, error);
+	mono_error_assert_ok (error);
+	MonoString *s2 = mono_string_new_checked (mono_domain_get (), member_name, error);
+	mono_error_assert_ok (error);
 
 	MonoException *ret = mono_exception_from_name_two_strings_checked (mono_get_corlib (), "System",
-								   "MissingFieldException", s1, s2, &error);
-	mono_error_assert_ok (&error);
+								   "MissingFieldException", s1, s2, error);
+	mono_error_assert_ok (error);
 	return ret;
 }
 
@@ -528,8 +528,8 @@ mono_get_exception_argument_null (const char *arg)
 	if (arg) {
 		ERROR_DECL (error);
 		MonoArgumentException *argex = (MonoArgumentException *)ex;
-		MonoString *arg_str = mono_string_new_checked (mono_object_get_domain ((MonoObject*)ex), arg, &error);
-		mono_error_assert_ok (&error);
+		MonoString *arg_str = mono_string_new_checked (mono_object_get_domain ((MonoObject*)ex), arg, error);
+		mono_error_assert_ok (error);
 		MONO_OBJECT_SETREF (argex, param_name, arg_str);
 	}
 	
@@ -552,8 +552,8 @@ mono_get_exception_argument (const char *arg, const char *msg)
 	if (arg) {
 		ERROR_DECL (error);
 		MonoArgumentException *argex = (MonoArgumentException *)ex;
-		MonoString *arg_str = mono_string_new_checked (mono_object_get_domain ((MonoObject*)ex), arg, &error);
-		mono_error_assert_ok (&error);
+		MonoString *arg_str = mono_string_new_checked (mono_object_get_domain ((MonoObject*)ex), arg, error);
+		mono_error_assert_ok (error);
 		MONO_OBJECT_SETREF (argex, param_name, arg_str);
 	}
 	
@@ -576,8 +576,8 @@ mono_get_exception_argument_out_of_range (const char *arg)
 	if (arg) {
 		ERROR_DECL (error);
 		MonoArgumentException *argex = (MonoArgumentException *)ex;
-		MonoString *arg_str = mono_string_new_checked (mono_object_get_domain ((MonoObject*)ex), arg, &error);
-		mono_error_assert_ok (&error);
+		MonoString *arg_str = mono_string_new_checked (mono_object_get_domain ((MonoObject*)ex), arg, error);
+		mono_error_assert_ok (error);
 		MONO_OBJECT_SETREF (argex, param_name, arg_str);
 	}
 	
@@ -618,8 +618,8 @@ mono_get_exception_file_not_found (MonoString *fname)
 {
 	ERROR_DECL (error);
 	MonoException *ret = mono_exception_from_name_two_strings_checked (
-		mono_get_corlib (), "System.IO", "FileNotFoundException", fname, fname, &error);
-	mono_error_assert_ok (&error);
+		mono_get_corlib (), "System.IO", "FileNotFoundException", fname, fname, error);
+	mono_error_assert_ok (error);
 	return ret;
 }
 
@@ -635,13 +635,13 @@ mono_get_exception_file_not_found2 (const char *msg, MonoString *fname)
 	ERROR_DECL (error);
 	MonoString *s = NULL;
 	if (msg) {
-		s = mono_string_new_checked (mono_domain_get (), msg, &error);
-		mono_error_assert_ok (&error);
+		s = mono_string_new_checked (mono_domain_get (), msg, error);
+		mono_error_assert_ok (error);
 	}
 
 	MonoException *ret = mono_exception_from_name_two_strings_checked (
-		mono_get_corlib (), "System.IO", "FileNotFoundException", s, fname, &error);
-	mono_error_assert_ok (&error);
+		mono_get_corlib (), "System.IO", "FileNotFoundException", s, fname, error);
+	mono_error_assert_ok (error);
 	return ret;
 }
 
@@ -655,9 +655,9 @@ MonoException *
 mono_get_exception_type_initialization (const gchar *type_name, MonoException *inner)
 {
 	ERROR_DECL (error);
-	MonoException *ret = mono_get_exception_type_initialization_checked (type_name, inner, &error);
-	if (!is_ok (&error)) {
-		mono_error_cleanup (&error);
+	MonoException *ret = mono_get_exception_type_initialization_checked (type_name, inner, error);
+	if (!is_ok (error)) {
+		mono_error_cleanup (error);
 		return NULL;
 	}
 
@@ -761,13 +761,13 @@ mono_get_exception_bad_image_format2 (const char *msg, MonoString *fname)
 	MonoString *s = NULL;
 
 	if (msg) {
-		s = mono_string_new_checked (mono_domain_get (), msg, &error);
-		mono_error_assert_ok (&error);
+		s = mono_string_new_checked (mono_domain_get (), msg, error);
+		mono_error_assert_ok (error);
 	}
 
 	MonoException *ret = mono_exception_from_name_two_strings_checked (
-		mono_get_corlib (), "System", "BadImageFormatException", s, fname, &error);
-	mono_error_assert_ok (&error);
+		mono_get_corlib (), "System", "BadImageFormatException", s, fname, error);
+	mono_error_assert_ok (error);
 	return ret;
 }
 
@@ -846,9 +846,9 @@ mono_get_exception_reflection_type_load (MonoArray *types_raw, MonoArray *except
 	ERROR_DECL (error);
 	MONO_HANDLE_DCL (MonoArray, types);
 	MONO_HANDLE_DCL (MonoArray, exceptions);
-	MonoExceptionHandle ret = mono_get_exception_reflection_type_load_checked (types, exceptions, &error);
-	if (is_ok (&error)) {
-		mono_error_cleanup (&error);
+	MonoExceptionHandle ret = mono_get_exception_reflection_type_load_checked (types, exceptions, error);
+	if (is_ok (error)) {
+		mono_error_cleanup (error);
 		ret = MONO_HANDLE_CAST (MonoException, NULL_HANDLE);
 		goto leave;
 	}
@@ -904,9 +904,9 @@ MonoException *
 mono_get_exception_runtime_wrapped (MonoObject *wrapped_exception)
 {
 	ERROR_DECL (error);
-	MonoException *ret = mono_get_exception_runtime_wrapped_checked (wrapped_exception, &error);
-	if (!is_ok (&error)) {
-		mono_error_cleanup (&error);
+	MonoException *ret = mono_get_exception_runtime_wrapped_checked (wrapped_exception, error);
+	if (!is_ok (error)) {
+		mono_error_cleanup (error);
 		return NULL;
 	}
 
@@ -1084,7 +1084,7 @@ mono_invoke_unhandled_exception_hook (MonoObject *exc)
 	if (unhandled_exception_hook) {
 		unhandled_exception_hook (exc, unhandled_exception_hook_data);
 	} else {
-		ERROR_DECL (inner_error);
+		ERROR_DECL_VALUE (inner_error);
 		MonoObject *other = NULL;
 		MonoString *str = mono_object_try_to_string (exc, &other, &inner_error);
 		char *msg = NULL;

--- a/mono/metadata/file-mmap-posix.c
+++ b/mono/metadata/file-mmap-posix.c
@@ -386,16 +386,16 @@ mono_mmap_open_file (MonoString *path, int mode, MonoString *mapName, gint64 *ca
 	g_assert (path || mapName);
 
 	if (!mapName) {
-		char * c_path = mono_string_to_utf8_checked (path, &error);
-		if (mono_error_set_pending_exception (&error))
+		char * c_path = mono_string_to_utf8_checked (path, error);
+		if (mono_error_set_pending_exception (error))
 			return NULL;
 		handle = open_file_map (c_path, -1, mode, capacity, access, options, ioerror);
 		g_free (c_path);
 		return handle;
 	}
 
-	char *c_mapName = mono_string_to_utf8_checked (mapName, &error);
-	if (mono_error_set_pending_exception (&error))
+	char *c_mapName = mono_string_to_utf8_checked (mapName, error);
+	if (mono_error_set_pending_exception (error))
 		return NULL;
 
 	if (path) {
@@ -405,8 +405,8 @@ mono_mmap_open_file (MonoString *path, int mode, MonoString *mapName, gint64 *ca
 			*ioerror = FILE_ALREADY_EXISTS;
 			handle = NULL;
 		} else {
-			char *c_path = mono_string_to_utf8_checked (path, &error);
-			if (is_ok (&error)) {
+			char *c_path = mono_string_to_utf8_checked (path, error);
+			if (is_ok (error)) {
 				handle = (MmapHandle *)open_file_map (c_path, -1, mode, capacity, access, options, ioerror);
 				if (handle) {
 					handle->name = g_strdup (c_mapName);
@@ -434,8 +434,8 @@ mono_mmap_open_handle (void *input_fd, MonoString *mapName, gint64 *capacity, in
 	if (!mapName) {
 		handle = (MmapHandle *)open_file_map (NULL, GPOINTER_TO_INT (input_fd), FILE_MODE_OPEN, capacity, access, options, ioerror);
 	} else {
-		char *c_mapName = mono_string_to_utf8_checked (mapName, &error);
-		if (mono_error_set_pending_exception (&error))
+		char *c_mapName = mono_string_to_utf8_checked (mapName, error);
+		if (mono_error_set_pending_exception (error))
 			return NULL;
 
 		named_regions_lock ();

--- a/mono/metadata/filewatcher.c
+++ b/mono/metadata/filewatcher.c
@@ -115,10 +115,10 @@ ves_icall_System_IO_FAMW_InternalFAMNextEvent (gpointer conn,
 	FAMEvent ev;
 
 	if (FAMNextEvent (conn, &ev) == 1) {
-		*filename = mono_string_new_checked (mono_domain_get (), ev.filename, &error);
+		*filename = mono_string_new_checked (mono_domain_get (), ev.filename, error);
 		*code = ev.code;
 		*reqnum = ev.fr.reqnum;
-		if (mono_error_set_pending_exception (&error))
+		if (mono_error_set_pending_exception (error))
 			return FALSE;
 		return TRUE;
 	}
@@ -162,8 +162,8 @@ ves_icall_System_IO_InotifyWatcher_AddWatch (int fd, MonoString *name, gint32 ma
 	if (name == NULL)
 		return -1;
 
-	str = mono_string_to_utf8_checked (name, &error);
-	if (mono_error_set_pending_exception (&error))
+	str = mono_string_to_utf8_checked (name, error);
+	if (mono_error_set_pending_exception (error))
 		return -1;
 	path = mono_portability_find_file (str, TRUE);
 	if (!path)

--- a/mono/metadata/handle.c
+++ b/mono/metadata/handle.c
@@ -41,7 +41,7 @@ TODO (things to explore):
 
 There's no convenient way to wrap the object allocation function.
 Right now we do this:
-	MonoCultureInfoHandle culture = MONO_HANDLE_NEW (MonoCultureInfo, mono_object_new_checked (domain, klass, &error));
+	MonoCultureInfoHandle culture = MONO_HANDLE_NEW (MonoCultureInfo, mono_object_new_checked (domain, klass, error));
 
 Maybe what we need is a round of cleanup around all exposed types in the runtime to unify all helpers under the same hoof.
 Combine: MonoDefaults, GENERATE_GET_CLASS_WITH_CACHE, TYPED_HANDLE_DECL and friends.

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -182,10 +182,10 @@ Icall macros
 	do { \
 		ERROR_DECL (error);	\
 		MonoThreadInfo *__info = mono_thread_info_current ();	\
-		error_init (&error);	\
+		error_init (error);	\
 
 #define CLEAR_ICALL_COMMON	\
-	mono_error_set_pending_exception (&error);
+	mono_error_set_pending_exception (error);
 
 #define SETUP_ICALL_FRAME	\
 	HandleStackMark __mark;	\

--- a/mono/metadata/icall-windows-uwp.c
+++ b/mono/metadata/icall-windows-uwp.c
@@ -31,7 +31,7 @@ mono_icall_get_windows_folder_path (int folder, MonoError *error)
 MonoArray *
 mono_icall_get_logical_drives (void)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("GetLogicalDriveStrings");
@@ -61,7 +61,7 @@ mono_icall_broadcast_setting_change (MonoError *error)
 guint32
 mono_icall_drive_info_get_drive_type (MonoString *root_path_name)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("GetDriveType");
@@ -75,7 +75,7 @@ mono_icall_drive_info_get_drive_type (MonoString *root_path_name)
 gint32
 mono_icall_wait_for_input_idle (gpointer handle, gint32 milliseconds)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("WaitForInputIdle");

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -168,8 +168,8 @@ ves_icall_System_Array_GetValueImpl (MonoArray *arr, guint32 pos)
 	ea = (gpointer*)((char*)arr->vector + (pos * esize));
 
 	if (ac->element_class->valuetype) {
-		result = mono_value_box_checked (arr->obj.vtable->domain, ac->element_class, ea, &error);
-		mono_error_set_pending_exception (&error);
+		result = mono_value_box_checked (arr->obj.vtable->domain, ac->element_class, ea, error);
+		mono_error_set_pending_exception (error);
 	} else
 		result = (MonoObject *)*ea;
 	return result;
@@ -611,8 +611,8 @@ ves_icall_System_Array_CreateInstanceImpl (MonoReflectionType *type, MonoArray *
 	}
 
 	klass = mono_class_from_mono_type (type->type);
-	mono_class_init_checked (klass, &error);
-	if (mono_error_set_pending_exception (&error))
+	mono_class_init_checked (klass, error);
+	if (mono_error_set_pending_exception (error))
 		return NULL;
 
 	if (klass->element_class->byval_arg.type == MONO_TYPE_VOID) {
@@ -637,8 +637,8 @@ ves_icall_System_Array_CreateInstanceImpl (MonoReflectionType *type, MonoArray *
 			sizes [i + aklass->rank] = 0;
 	}
 
-	array = mono_array_new_full_checked (mono_object_domain (type), aklass, sizes, (intptr_t*)sizes + aklass->rank, &error);
-	mono_error_set_pending_exception (&error);
+	array = mono_array_new_full_checked (mono_object_domain (type), aklass, sizes, (intptr_t*)sizes + aklass->rank, error);
+	mono_error_set_pending_exception (error);
 
 	return array;
 }
@@ -668,8 +668,8 @@ ves_icall_System_Array_CreateInstanceImpl64 (MonoReflectionType *type, MonoArray
 	}
 
 	klass = mono_class_from_mono_type (type->type);
-	mono_class_init_checked (klass, &error);
-	if (mono_error_set_pending_exception (&error))
+	mono_class_init_checked (klass, error);
+	if (mono_error_set_pending_exception (error))
 		return NULL;
 
 	if (bounds && (mono_array_length (bounds) == 1) && (mono_array_get (bounds, gint64, 0) != 0))
@@ -689,8 +689,8 @@ ves_icall_System_Array_CreateInstanceImpl64 (MonoReflectionType *type, MonoArray
 			sizes [i + aklass->rank] = 0;
 	}
 
-	array = mono_array_new_full_checked (mono_object_domain (type), aklass, sizes, (intptr_t*)sizes + aklass->rank, &error);
-	mono_error_set_pending_exception (&error);
+	array = mono_array_new_full_checked (mono_object_domain (type), aklass, sizes, (intptr_t*)sizes + aklass->rank, error);
+	mono_error_set_pending_exception (error);
 
 	return array;
 }
@@ -957,8 +957,8 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_GetObjectValue (MonoObj
 		return obj;
 	else {
 		ERROR_DECL (error);
-		MonoObject *ret = mono_object_clone_checked (obj, &error);
-		mono_error_set_pending_exception (&error);
+		MonoObject *ret = mono_object_clone_checked (obj, error);
+		mono_error_set_pending_exception (error);
 
 		return ret;
 	}
@@ -979,15 +979,15 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_RunClassConstructor (Mo
 	if (mono_class_is_gtd (klass))
 		return;
 
-	vtable = mono_class_vtable_checked (mono_domain_get (), klass, &error);
-	if (!is_ok (&error)) {
-		mono_error_set_pending_exception (&error);
+	vtable = mono_class_vtable_checked (mono_domain_get (), klass, error);
+	if (!is_ok (error)) {
+		mono_error_set_pending_exception (error);
 		return;
 	}
 
 	/* This will call the type constructor */
-	if (!mono_runtime_class_init_full (vtable, &error))
-		mono_error_set_pending_exception (&error);
+	if (!mono_runtime_class_init_full (vtable, error))
+		mono_error_set_pending_exception (error);
 }
 
 ICALL_EXPORT void
@@ -997,19 +997,19 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_RunModuleConstructor (M
 
 	mono_image_check_for_module_cctor (image);
 	if (image->has_module_cctor) {
-		MonoClass *module_klass = mono_class_get_checked (image, MONO_TOKEN_TYPE_DEF | 1, &error);
-		if (!mono_error_ok (&error)) {
-			mono_error_set_pending_exception (&error);
+		MonoClass *module_klass = mono_class_get_checked (image, MONO_TOKEN_TYPE_DEF | 1, error);
+		if (!mono_error_ok (error)) {
+			mono_error_set_pending_exception (error);
 			return;
 		}
 		/*It's fine to raise the exception here*/
-		MonoVTable * vtable = mono_class_vtable_checked (mono_domain_get (), module_klass, &error);
-		if (!is_ok (&error)) {
-			mono_error_set_pending_exception (&error);
+		MonoVTable * vtable = mono_class_vtable_checked (mono_domain_get (), module_klass, error);
+		if (!is_ok (error)) {
+			mono_error_set_pending_exception (error);
 			return;
 		}
-		if (!mono_runtime_class_init_full (vtable, &error))
-			mono_error_set_pending_exception (&error);
+		if (!mono_runtime_class_init_full (vtable, error))
+			mono_error_set_pending_exception (error);
 	}
 }
 
@@ -1056,8 +1056,8 @@ ICALL_EXPORT MonoObject *
 ves_icall_System_Object_MemberwiseClone (MonoObject *this_obj)
 {
 	ERROR_DECL (error);
-	MonoObject *ret = mono_object_clone_checked (this_obj, &error);
-	mono_error_set_pending_exception (&error);
+	MonoObject *ret = mono_object_clone_checked (this_obj, error);
+	mono_error_set_pending_exception (error);
 
 	return ret;
 }
@@ -1105,9 +1105,9 @@ ves_icall_System_ValueType_InternalGetHashCode (MonoObject *this_obj, MonoArray 
 		default:
 			if (!values)
 				values = g_newa (MonoObject*, mono_class_num_fields (klass));
-			o = mono_field_get_value_object_checked (mono_object_domain (this_obj), field, this_obj, &error);
-			if (!is_ok (&error)) {
-				mono_error_set_pending_exception (&error);
+			o = mono_field_get_value_object_checked (mono_object_domain (this_obj), field, this_obj, error);
+			if (!is_ok (error)) {
+				mono_error_set_pending_exception (error);
 				return 0;
 			}
 			values [count++] = o;
@@ -1116,8 +1116,8 @@ ves_icall_System_ValueType_InternalGetHashCode (MonoObject *this_obj, MonoArray 
 
 	if (values) {
 		int i;
-		MonoArray *fields_arr = mono_array_new_checked (mono_domain_get (), mono_defaults.object_class, count, &error);
-		if (mono_error_set_pending_exception (&error))
+		MonoArray *fields_arr = mono_array_new_checked (mono_domain_get (), mono_defaults.object_class, count, error);
+		if (mono_error_set_pending_exception (error))
 			return 0;
 		mono_gc_wbarrier_generic_store (fields, (MonoObject*) fields_arr);
 		for (i = 0; i < count; ++i)
@@ -1252,15 +1252,15 @@ ves_icall_System_ValueType_Equals (MonoObject *this_obj, MonoObject *that, MonoA
 		default:
 			if (!values)
 				values = g_newa (MonoObject*, mono_class_num_fields (klass) * 2);
-			o = mono_field_get_value_object_checked (mono_object_domain (this_obj), field, this_obj, &error);
-			if (!is_ok (&error)) {
-				mono_error_set_pending_exception (&error);
+			o = mono_field_get_value_object_checked (mono_object_domain (this_obj), field, this_obj, error);
+			if (!is_ok (error)) {
+				mono_error_set_pending_exception (error);
 				return FALSE;
 			}
 			values [count++] = o;
-			o = mono_field_get_value_object_checked (mono_object_domain (this_obj), field, that, &error);
-			if (!is_ok (&error)) {
-				mono_error_set_pending_exception (&error);
+			o = mono_field_get_value_object_checked (mono_object_domain (this_obj), field, that, error);
+			if (!is_ok (error)) {
+				mono_error_set_pending_exception (error);
 				return FALSE;
 			}
 			values [count++] = o;
@@ -1275,8 +1275,8 @@ ves_icall_System_ValueType_Equals (MonoObject *this_obj, MonoObject *that, MonoA
 
 	if (values) {
 		int i;
-		MonoArray *fields_arr = mono_array_new_checked (mono_domain_get (), mono_defaults.object_class, count, &error);
-		if (mono_error_set_pending_exception (&error))
+		MonoArray *fields_arr = mono_array_new_checked (mono_domain_get (), mono_defaults.object_class, count, error);
+		if (mono_error_set_pending_exception (error))
 			return FALSE;
 		mono_gc_wbarrier_generic_store (fields, (MonoObject*) fields_arr);
 		for (i = 0; i < count; ++i)
@@ -1559,8 +1559,8 @@ ICALL_EXPORT char*
 ves_icall_Mono_SafeStringMarshal_StringToUtf8 (MonoString *s)
 {
 	ERROR_DECL (error);
-	char *res = mono_string_to_utf8_checked (s, &error);
-	mono_error_set_pending_exception (&error);
+	char *res = mono_string_to_utf8_checked (s, error);
+	mono_error_set_pending_exception (error);
 	return res;
 }
 
@@ -1975,8 +1975,8 @@ ves_icall_MonoField_GetValueInternal (MonoReflectionField *field, MonoObject *ob
 	}
 
 	if (mono_security_core_clr_enabled () &&
-	    !mono_security_core_clr_ensure_reflection_access_field (cf, &error)) {
-		mono_error_set_pending_exception (&error);
+	    !mono_security_core_clr_ensure_reflection_access_field (cf, error)) {
+		mono_error_set_pending_exception (error);
 		return NULL;
 	}
 
@@ -1986,14 +1986,14 @@ ves_icall_MonoField_GetValueInternal (MonoReflectionField *field, MonoObject *ob
 		 * System.Reflection.FieldInfo:GetValue on a
 		 * ContextBoundObject's or cross-domain MarshalByRefObject's
 		 * transparent proxy. */
-		MonoObject *result = mono_load_remote_field_new_checked (obj, fklass, cf, &error);
-		mono_error_set_pending_exception (&error);
+		MonoObject *result = mono_load_remote_field_new_checked (obj, fklass, cf, error);
+		mono_error_set_pending_exception (error);
 		return result;
 	}
 #endif
 
-	MonoObject * result = mono_field_get_value_object_checked (domain, cf, obj, &error);
-	mono_error_set_pending_exception (&error);
+	MonoObject * result = mono_field_get_value_object_checked (domain, cf, obj, error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 
@@ -2167,9 +2167,9 @@ ves_icall_MonoField_GetRawConstantValue (MonoReflectionField *rfield)
 
 	mono_class_init (field->parent);
 
-	t = mono_field_get_type_checked (field, &error);
-	if (!mono_error_ok (&error)) {
-		mono_error_set_pending_exception (&error);
+	t = mono_field_get_type_checked (field, error);
+	if (!mono_error_ok (error)) {
+		mono_error_set_pending_exception (error);
 		return NULL;
 	}
 
@@ -2223,21 +2223,21 @@ ves_icall_MonoField_GetRawConstantValue (MonoReflectionField *rfield)
 		t->type = def_type;
 		klass = mono_class_from_mono_type (t);
 		g_free (t);
-		o = mono_object_new_checked (domain, klass, &error);
-		if (!mono_error_ok (&error)) {
-			mono_error_set_pending_exception (&error);
+		o = mono_object_new_checked (domain, klass, error);
+		if (!mono_error_ok (error)) {
+			mono_error_set_pending_exception (error);
 			return NULL;
 		}
 		v = ((gchar *) o) + sizeof (MonoObject);
-		mono_get_constant_value_from_blob (domain, def_type, def_value, v, &error);
-		if (mono_error_set_pending_exception (&error))
+		mono_get_constant_value_from_blob (domain, def_type, def_value, v, error);
+		if (mono_error_set_pending_exception (error))
 			return NULL;
 		break;
 	}
 	case MONO_TYPE_STRING:
 	case MONO_TYPE_CLASS:
-		mono_get_constant_value_from_blob (domain, def_type, def_value, &o, &error);
-		if (mono_error_set_pending_exception (&error))
+		mono_get_constant_value_from_blob (domain, def_type, def_value, &o, error);
+		if (mono_error_set_pending_exception (error))
 			return NULL;
 		break;
 	default:
@@ -3260,22 +3260,22 @@ ves_icall_InternalInvoke (MonoReflectionMethod *method, MonoObject *this_arg, Mo
 	*exc = NULL;
 
 	if (mono_security_core_clr_enabled () &&
-	    !mono_security_core_clr_ensure_reflection_access_method (m, &error)) {
-		mono_error_set_pending_exception (&error);
+	    !mono_security_core_clr_ensure_reflection_access_method (m, error)) {
+		mono_error_set_pending_exception (error);
 		return NULL;
 	}
 
 	if (!(m->flags & METHOD_ATTRIBUTE_STATIC)) {
-		if (!mono_class_vtable_checked (mono_object_domain (method), m->klass, &error)) {
-			mono_error_cleanup (&error); /* FIXME does this make sense? */
+		if (!mono_class_vtable_checked (mono_object_domain (method), m->klass, error)) {
+			mono_error_cleanup (error); /* FIXME does this make sense? */
 			mono_gc_wbarrier_generic_store (exc, (MonoObject*) mono_class_get_exception_for_failure (m->klass));
 			return NULL;
 		}
 
 		if (this_arg) {
-			if (!mono_object_isinst_checked (this_arg, m->klass, &error)) {
-				if (!is_ok (&error)) {
-					mono_gc_wbarrier_generic_store (exc, (MonoObject*) mono_error_convert_to_exception (&error));
+			if (!mono_object_isinst_checked (this_arg, m->klass, error)) {
+				if (!is_ok (error)) {
+					mono_gc_wbarrier_generic_store (exc, (MonoObject*) mono_error_convert_to_exception (error));
 					return NULL;
 				}
 				char *this_name = mono_type_get_full_name (mono_object_get_class (this_arg));
@@ -3337,16 +3337,16 @@ ves_icall_InternalInvoke (MonoReflectionMethod *method, MonoObject *this_arg, Mo
 
 		if (m->klass->rank == 1 && sig->param_count == 2 && m->klass->element_class->rank) {
 			/* This is a ctor for jagged arrays. MS creates an array of arrays. */
-			arr = mono_array_new_full_checked (mono_object_domain (params), m->klass, lengths, NULL, &error);
-			if (!mono_error_ok (&error)) {
-				mono_error_set_pending_exception (&error);
+			arr = mono_array_new_full_checked (mono_object_domain (params), m->klass, lengths, NULL, error);
+			if (!mono_error_ok (error)) {
+				mono_error_set_pending_exception (error);
 				return NULL;
 			}
 
 			for (i = 0; i < mono_array_length (arr); ++i) {
-				MonoArray *subarray = mono_array_new_full_checked (mono_object_domain (params), m->klass->element_class, &lengths [1], NULL, &error);
-				if (!mono_error_ok (&error)) {
-					mono_error_set_pending_exception (&error);
+				MonoArray *subarray = mono_array_new_full_checked (mono_object_domain (params), m->klass->element_class, &lengths [1], NULL, error);
+				if (!mono_error_ok (error)) {
+					mono_error_set_pending_exception (error);
 					return NULL;
 				}
 				mono_array_setref_fast (arr, i, subarray);
@@ -3356,9 +3356,9 @@ ves_icall_InternalInvoke (MonoReflectionMethod *method, MonoObject *this_arg, Mo
 
 		if (m->klass->rank == pcount) {
 			/* Only lengths provided. */
-			arr = mono_array_new_full_checked (mono_object_domain (params), m->klass, lengths, NULL, &error);
-			if (!mono_error_ok (&error)) {
-				mono_error_set_pending_exception (&error);
+			arr = mono_array_new_full_checked (mono_object_domain (params), m->klass, lengths, NULL, error);
+			if (!mono_error_ok (error)) {
+				mono_error_set_pending_exception (error);
 				return NULL;
 			}
 
@@ -3373,17 +3373,17 @@ ves_icall_InternalInvoke (MonoReflectionMethod *method, MonoObject *this_arg, Mo
 				lengths [i] = *(int32_t*) ((char*)mono_array_get (params, gpointer, (i * 2) + 1) + sizeof (MonoObject));
 			}
 
-			arr = mono_array_new_full_checked (mono_object_domain (params), m->klass, lengths, lower_bounds, &error);
-			if (!mono_error_ok (&error)) {
-				mono_error_set_pending_exception (&error);
+			arr = mono_array_new_full_checked (mono_object_domain (params), m->klass, lengths, lower_bounds, error);
+			if (!mono_error_ok (error)) {
+				mono_error_set_pending_exception (error);
 				return NULL;
 			}
 
 			return (MonoObject*)arr;
 		}
 	}
-	MonoObject *result = mono_runtime_invoke_array_checked (m, obj, params, &error);
-	mono_error_set_pending_exception (&error);
+	MonoObject *result = mono_runtime_invoke_array_checked (m, obj, params, error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 
@@ -3498,12 +3498,12 @@ ves_icall_InternalExecute (MonoReflectionMethod *method, MonoObject *this_arg, M
 
 	if (m->klass == mono_defaults.object_class) {
 		if (!strcmp (m->name, "FieldGetter")) {
-			internal_execute_field_getter (domain, this_arg, params, outArgs, &error);
-			mono_error_set_pending_exception (&error);
+			internal_execute_field_getter (domain, this_arg, params, outArgs, error);
+			mono_error_set_pending_exception (error);
 			return NULL;
 		} else if (!strcmp (m->name, "FieldSetter")) {
-			internal_execute_field_setter (domain, this_arg, params, outArgs, &error);
-			mono_error_set_pending_exception (&error);
+			internal_execute_field_setter (domain, this_arg, params, outArgs, error);
+			mono_error_set_pending_exception (error);
 			return NULL;
 		}
 	}
@@ -3513,8 +3513,8 @@ ves_icall_InternalExecute (MonoReflectionMethod *method, MonoObject *this_arg, M
 			outarg_count++;
 	}
 
-	out_args = mono_array_new_checked (domain, mono_defaults.object_class, outarg_count, &error);
-	if (mono_error_set_pending_exception (&error))
+	out_args = mono_array_new_checked (domain, mono_defaults.object_class, outarg_count, error);
+	if (mono_error_set_pending_exception (error))
 		return NULL;
 
 	/* handle constructors only for objects already allocated */
@@ -3523,8 +3523,8 @@ ves_icall_InternalExecute (MonoReflectionMethod *method, MonoObject *this_arg, M
 
 	/* This can be called only on MBR objects, so no need to unbox for valuetypes. */
 	g_assert (!method->method->klass->valuetype);
-	result = mono_runtime_invoke_array_checked (method->method, this_arg, params, &error);
-	if (mono_error_set_pending_exception (&error))
+	result = mono_runtime_invoke_array_checked (method->method, this_arg, params, error);
+	if (mono_error_set_pending_exception (error))
 		return NULL;
 
 	for (i = 0, j = 0; i < mono_array_length (params); i++) {
@@ -3616,14 +3616,14 @@ ves_icall_System_Enum_ToObject (MonoReflectionType *enumType, guint64 value)
 	domain = mono_object_domain (enumType); 
 	enumc = mono_class_from_mono_type (enumType->type);
 
-	mono_class_init_checked (enumc, &error);
-	if (mono_error_set_pending_exception (&error))
+	mono_class_init_checked (enumc, error);
+	if (mono_error_set_pending_exception (error))
 		return NULL;
 
 	etype = mono_class_enum_basetype (enumc);
 
-	res = mono_object_new_checked (domain, enumc, &error);
-	if (mono_error_set_pending_exception (&error))
+	res = mono_object_new_checked (domain, enumc, error);
+	if (mono_error_set_pending_exception (error))
 		return NULL;
 	write_enum_value ((char *)res + sizeof (MonoObject), etype->type, value);
 
@@ -3658,8 +3658,8 @@ ves_icall_System_Enum_get_value (MonoObject *eobj)
 	g_assert (eobj->vtable->klass->enumtype);
 	
 	enumc = mono_class_from_mono_type (mono_class_enum_basetype (eobj->vtable->klass));
-	res = mono_object_new_checked (mono_object_domain (eobj), enumc, &error);
-	if (mono_error_set_pending_exception (&error))
+	res = mono_object_new_checked (mono_object_domain (eobj), enumc, error);
+	if (mono_error_set_pending_exception (error))
 		return NULL;
 	dst = (char *)res + sizeof (MonoObject);
 	src = (char *)eobj + sizeof (MonoObject);
@@ -3679,8 +3679,8 @@ ves_icall_System_Enum_get_underlying_type (MonoReflectionType *type)
 	MonoClass *klass;
 
 	klass = mono_class_from_mono_type (type->type);
-	mono_class_init_checked (klass, &error);
-	if (mono_error_set_pending_exception (&error))
+	mono_class_init_checked (klass, error);
+	if (mono_error_set_pending_exception (error))
 		return NULL;
 
 	etype = mono_class_enum_basetype (klass);
@@ -3689,8 +3689,8 @@ ves_icall_System_Enum_get_underlying_type (MonoReflectionType *type)
 		return NULL;
 	}
 
-	ret = mono_type_get_object_checked (mono_object_domain (type), etype, &error);
-	mono_error_set_pending_exception (&error);
+	ret = mono_type_get_object_checked (mono_object_domain (type), etype, error);
+	mono_error_set_pending_exception (error);
 
 	return ret;
 }
@@ -4484,7 +4484,7 @@ ves_icall_System_Reflection_Assembly_InternalGetType (MonoReflectionAssemblyHand
 	goto_if_nok (error, fail);
 
 	/*g_print ("requested type %s in %s\n", str, assembly->assembly->aname.name);*/
-	ERROR_DECL (parse_error);
+	ERROR_DECL_VALUE (parse_error);
 	if (!mono_reflection_parse_type_checked (str, &info, &parse_error)) {
 		g_free (str);
 		mono_reflection_free_type_info (&info);
@@ -4578,7 +4578,7 @@ ves_icall_System_Reflection_Assembly_InternalGetType (MonoReflectionAssemblyHand
 
 	if (!type) {
 		if (throwOnError) {
-			ERROR_DECL (inner_error);
+			ERROR_DECL_VALUE (inner_error);
 			char *typename = mono_string_handle_to_utf8 (name, &inner_error);
 			mono_error_assert_ok (&inner_error);
 			MonoAssembly *assembly = MONO_HANDLE_GETVAL (assembly_h, assembly);
@@ -5200,8 +5200,8 @@ mono_method_get_equivalent_method (MonoMethod *method, MonoClass *klass)
 			ctx.class_inst = mono_class_get_generic_class (klass)->context.class_inst;
 		else if (mono_class_is_gtd (klass))
 			ctx.class_inst = mono_class_get_generic_container (klass)->context.class_inst;
-		result = mono_class_inflate_generic_method_full_checked (inflated->declaring, klass, &ctx, &error);
-		g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+		result = mono_class_inflate_generic_method_full_checked (inflated->declaring, klass, &ctx, error);
+		g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 		return result;
 	}
 
@@ -5485,7 +5485,7 @@ image_get_type (MonoDomain *domain, MonoImage *image, MonoTableInfo *tdef, int t
 {
 	error_init (error);
 	HANDLE_FUNCTION_ENTER ();
-	ERROR_DECL (klass_error);
+	ERROR_DECL_VALUE (klass_error);
 	MonoClass *klass = mono_class_get_checked (image, table_idx | MONO_TOKEN_TYPE_DEF, &klass_error);
 
 	if (klass) {
@@ -5572,7 +5572,7 @@ static void
 set_class_failure_in_array (MonoArrayHandle exl, int i, MonoClass *klass)
 {
 	HANDLE_FUNCTION_ENTER ();
-	ERROR_DECL (unboxed_error);
+	ERROR_DECL_VALUE (unboxed_error);
 	error_init (&unboxed_error);
 	mono_error_set_for_class_failure (&unboxed_error, klass);
 
@@ -5812,8 +5812,8 @@ mono_memberref_is_method (MonoImage *image, guint32 token)
 		ERROR_DECL (error);
 		MonoClass *handle_class;
 
-		if (!mono_lookup_dynamic_token_class (image, token, FALSE, &handle_class, NULL, &error)) {
-			mono_error_cleanup (&error); /* just probing, ignore error */
+		if (!mono_lookup_dynamic_token_class (image, token, FALSE, &handle_class, NULL, error)) {
+			mono_error_cleanup (error); /* just probing, ignore error */
 			return FALSE;
 		}
 
@@ -5882,7 +5882,7 @@ module_resolve_type_token (MonoImage *image, guint32 token, MonoArrayHandle type
 
 	if (image_is_dynamic (image)) {
 		if ((table == MONO_TABLE_TYPEDEF) || (table == MONO_TABLE_TYPEREF)) {
-			ERROR_DECL (inner_error);
+			ERROR_DECL_VALUE (inner_error);
 			klass = (MonoClass *)mono_lookup_dynamic_token_class (image, token, FALSE, NULL, NULL, &inner_error);
 			mono_error_cleanup (&inner_error);
 			result = klass ? &klass->byval_arg : NULL;
@@ -5890,7 +5890,7 @@ module_resolve_type_token (MonoImage *image, guint32 token, MonoArrayHandle type
 		}
 
 		init_generic_context_from_args_handles (&context, type_args, method_args);
-		ERROR_DECL (inner_error);
+		ERROR_DECL_VALUE (inner_error);
 		klass = (MonoClass *)mono_lookup_dynamic_token_class (image, token, FALSE, NULL, &context, &inner_error);
 		mono_error_cleanup (&inner_error);
 		result = klass ? &klass->byval_arg : NULL;
@@ -5941,7 +5941,7 @@ module_resolve_method_token (MonoImage *image, guint32 token, MonoArrayHandle ty
 
 	if (image_is_dynamic (image)) {
 		if (table == MONO_TABLE_METHOD) {
-			ERROR_DECL (inner_error);
+			ERROR_DECL_VALUE (inner_error);
 			method = (MonoMethod *)mono_lookup_dynamic_token_class (image, token, FALSE, NULL, NULL, &inner_error);
 			mono_error_cleanup (&inner_error);
 			goto leave;
@@ -5953,7 +5953,7 @@ module_resolve_method_token (MonoImage *image, guint32 token, MonoArrayHandle ty
 		}
 
 		init_generic_context_from_args_handles (&context, type_args, method_args);
-		ERROR_DECL (inner_error);
+		ERROR_DECL_VALUE (inner_error);
 		method = (MonoMethod *)mono_lookup_dynamic_token_class (image, token, FALSE, NULL, &context, &inner_error);
 		mono_error_cleanup (&inner_error);
 		goto leave;
@@ -5996,8 +5996,8 @@ ves_icall_System_Reflection_Module_ResolveStringToken (MonoImage *image, guint32
 	}
 
 	if (image_is_dynamic (image)) {
-		MonoString * result = (MonoString *)mono_lookup_dynamic_token_class (image, token, FALSE, NULL, NULL, &error);
-		mono_error_cleanup (&error);
+		MonoString * result = (MonoString *)mono_lookup_dynamic_token_class (image, token, FALSE, NULL, NULL, error);
+		mono_error_cleanup (error);
 		return result;
 	}
 
@@ -6008,8 +6008,8 @@ ves_icall_System_Reflection_Module_ResolveStringToken (MonoImage *image, guint32
 
 	/* FIXME: What to do if the index points into the middle of a string ? */
 
-	MonoString *result = mono_ldstr_checked (mono_domain_get (), image, index, &error);
-	mono_error_set_pending_exception (&error);
+	MonoString *result = mono_ldstr_checked (mono_domain_get (), image, index, error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 
@@ -6034,7 +6034,7 @@ module_resolve_field_token (MonoImage *image, guint32 token, MonoArrayHandle typ
 
 	if (image_is_dynamic (image)) {
 		if (table == MONO_TABLE_FIELD) {
-			ERROR_DECL (inner_error);
+			ERROR_DECL_VALUE (inner_error);
 			field = (MonoClassField *)mono_lookup_dynamic_token_class (image, token, FALSE, NULL, NULL, &inner_error);
 			mono_error_cleanup (&inner_error);
 			goto leave;
@@ -6046,7 +6046,7 @@ module_resolve_field_token (MonoImage *image, guint32 token, MonoArrayHandle typ
 		}
 
 		init_generic_context_from_args_handles (&context, type_args, method_args);
-		ERROR_DECL (inner_error);
+		ERROR_DECL_VALUE (inner_error);
 		field = (MonoClassField *)mono_lookup_dynamic_token_class (image, token, FALSE, NULL, &context, &inner_error);
 		mono_error_cleanup (&inner_error);
 		goto leave;
@@ -6283,7 +6283,7 @@ ves_icall_System_Delegate_CreateDelegate_internal (MonoReflectionTypeHandle ref_
 	}
 
 	if (mono_security_core_clr_enabled ()) {
-		ERROR_DECL (security_error);
+		ERROR_DECL_VALUE (security_error);
 		if (!mono_security_core_clr_ensure_delegate_creation (method, &security_error)) {
 			if (throwOnBindFailure)
 				mono_error_move (error, &security_error);
@@ -6492,8 +6492,8 @@ ves_icall_Remoting_RealProxy_InternalGetProxyType (MonoTransparentProxy *tp)
 	ERROR_DECL (error);
 	g_assert (tp != NULL && mono_object_class (tp) == mono_defaults.transparent_proxy_class);
 	g_assert (tp->remote_class != NULL && tp->remote_class->proxy_class != NULL);
-	MonoReflectionType *ret = mono_type_get_object_checked (mono_object_domain (tp), &tp->remote_class->proxy_class->byval_arg, &error);
-	mono_error_set_pending_exception (&error);
+	MonoReflectionType *ret = mono_type_get_object_checked (mono_object_domain (tp), &tp->remote_class->proxy_class->byval_arg, error);
+	mono_error_set_pending_exception (error);
 
 	return ret;
 }
@@ -6707,8 +6707,8 @@ ICALL_EXPORT MonoArray *
 ves_icall_System_Environment_GetEnvironmentVariableNames (void)
 {
 	ERROR_DECL (error);
-	MonoArray *result = mono_icall_get_environment_variable_names (&error);
-	mono_error_set_pending_exception (&error);
+	MonoArray *result = mono_icall_get_environment_variable_names (error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 
@@ -6719,8 +6719,8 @@ mono_icall_set_environment_variable (MonoString *name, MonoString *value)
 	gchar *utf8_name, *utf8_value;
 	ERROR_DECL (error);
 
-	utf8_name = mono_string_to_utf8_checked (name, &error);	/* FIXME: this should be ascii */
-	if (mono_error_set_pending_exception (&error))
+	utf8_name = mono_string_to_utf8_checked (name, error);	/* FIXME: this should be ascii */
+	if (mono_error_set_pending_exception (error))
 		return;
 
 	if ((value == NULL) || (mono_string_length (value) == 0) || (mono_string_chars (value)[0] == 0)) {
@@ -6729,10 +6729,10 @@ mono_icall_set_environment_variable (MonoString *name, MonoString *value)
 		return;
 	}
 
-	utf8_value = mono_string_to_utf8_checked (value, &error);
-	if (!mono_error_ok (&error)) {
+	utf8_value = mono_string_to_utf8_checked (value, error);
+	if (!mono_error_ok (error)) {
 		g_free (utf8_name);
-		mono_error_set_pending_exception (&error);
+		mono_error_set_pending_exception (error);
 		return;
 	}
 	g_setenv (utf8_name, utf8_value, TRUE);
@@ -6824,8 +6824,8 @@ mono_icall_get_logical_drives (void)
 	} while (*dname);
 
 	dname = ptr;
-	result = mono_array_new_checked (domain, mono_defaults.string_class, ndrives, &error);
-	if (mono_error_set_pending_exception (&error))
+	result = mono_array_new_checked (domain, mono_defaults.string_class, ndrives, error);
+	if (mono_error_set_pending_exception (error))
 		goto leave;
 
 	ndrives = 0;
@@ -6833,8 +6833,8 @@ mono_icall_get_logical_drives (void)
 		len = 0;
 		u16 = dname;
 		while (*u16) { u16++; len ++; }
-		drivestr = mono_string_new_utf16_checked (domain, dname, len, &error);
-		if (mono_error_set_pending_exception (&error))
+		drivestr = mono_string_new_utf16_checked (domain, dname, len, error);
+		if (mono_error_set_pending_exception (error))
 			goto leave;
 
 		mono_array_setref (result, ndrives++, drivestr);
@@ -6863,8 +6863,8 @@ ves_icall_System_IO_DriveInfo_GetDriveFormat (MonoString *path)
 	
 	if (mono_w32file_get_volume_information (mono_string_chars (path), NULL, 0, NULL, NULL, NULL, volume_name, MAX_PATH + 1) == FALSE)
 		return NULL;
-	MonoString *result = mono_string_from_utf16_checked (volume_name, &error);
-	mono_error_set_pending_exception (&error);
+	MonoString *result = mono_string_from_utf16_checked (volume_name, error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 
@@ -7508,8 +7508,8 @@ mono_TypedReference_ToObject (MonoTypedRef* tref)
 		return *objp;
 	}
 
-	result = mono_value_box_checked (mono_domain_get (), tref->klass, tref->value, &error);
-	mono_error_set_pending_exception (&error);
+	result = mono_value_box_checked (mono_domain_get (), tref->klass, tref->value, error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 
@@ -7774,9 +7774,9 @@ property_info_get_default_value (MonoReflectionProperty *property)
 	def_value = mono_class_get_property_default_value (prop, &def_type);
 
 	mono_type_from_blob_type (&blob_type, def_type, type);
-	o = mono_get_object_from_blob (domain, &blob_type, def_value, &error);
+	o = mono_get_object_from_blob (domain, &blob_type, def_value, error);
 
-	mono_error_set_pending_exception (&error);
+	mono_error_set_pending_exception (error);
 	return o;
 }
 

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -766,8 +766,8 @@ MonoImage*
 mono_image_load_module (MonoImage *image, int idx)
 {
 	ERROR_DECL (error);
-	MonoImage *result = mono_image_load_module_checked (image, idx, &error);
-	mono_error_assert_ok (&error);
+	MonoImage *result = mono_image_load_module_checked (image, idx, error);
+	mono_error_assert_ok (error);
 	return result;
 }
 
@@ -2500,8 +2500,8 @@ MonoImage*
 mono_image_load_file_for_image (MonoImage *image, int fileidx)
 {
 	ERROR_DECL (error);
-	MonoImage *result = mono_image_load_file_for_image_checked (image, fileidx, &error);
-	mono_error_assert_ok (&error);
+	MonoImage *result = mono_image_load_file_for_image_checked (image, fileidx, error);
+	mono_error_assert_ok (error);
 	return result;
 }
 

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -235,7 +235,7 @@ field_from_memberref (MonoImage *image, guint32 token, MonoClass **retklass,
 	 */
 	sig_type = (MonoType *)find_cached_memberref_sig (image, cols [MONO_MEMBERREF_SIGNATURE]);
 	if (!sig_type) {
-		ERROR_DECL (inner_error);
+		ERROR_DECL_VALUE (inner_error);
 		sig_type = mono_metadata_parse_type_checked (image, NULL, 0, FALSE, ptr, &ptr, &inner_error);
 		if (sig_type == NULL) {
 			mono_error_set_field_load (error, klass, fname, "Could not parse field '%s' signature %08x due to: %s", fname, token, mono_error_get_message (&inner_error));
@@ -266,8 +266,8 @@ MonoClassField*
 mono_field_from_token (MonoImage *image, guint32 token, MonoClass **retklass, MonoGenericContext *context)
 {
 	ERROR_DECL (error);
-	MonoClassField *res = mono_field_from_token_checked (image, token, retklass, context, &error);
-	mono_error_assert_ok (&error);
+	MonoClassField *res = mono_field_from_token_checked (image, token, retklass, context, error);
+	mono_error_assert_ok (error);
 	return res;
 }
 
@@ -285,7 +285,7 @@ mono_field_from_token_checked (MonoImage *image, guint32 token, MonoClass **retk
 		MonoClass *handle_class;
 
 		*retklass = NULL;
-		ERROR_DECL (inner_error);
+		ERROR_DECL_VALUE (inner_error);
 		result = (MonoClassField *)mono_lookup_dynamic_token_class (image, token, TRUE, &handle_class, context, &inner_error);
 		mono_error_cleanup (&inner_error);
 		// This checks the memberref type as well
@@ -318,7 +318,7 @@ mono_field_from_token_checked (MonoImage *image, guint32 token, MonoClass **retk
 		if (retklass)
 			*retklass = k;
 		if (mono_class_has_failure (k)) {
-			ERROR_DECL (causedby_error);
+			ERROR_DECL_VALUE (causedby_error);
 			error_init (&causedby_error);
 			mono_error_set_for_class_failure (&causedby_error, k);
 			mono_error_set_bad_image (error, image, "Could not resolve field token 0x%08x, due to: %s", token, mono_error_get_message (&causedby_error));
@@ -650,8 +650,8 @@ MonoMethodSignature*
 mono_method_get_signature_full (MonoMethod *method, MonoImage *image, guint32 token, MonoGenericContext *context)
 {
 	ERROR_DECL (error);
-	MonoMethodSignature *res = mono_method_get_signature_checked (method, image, token, context, &error);
-	mono_error_cleanup (&error);
+	MonoMethodSignature *res = mono_method_get_signature_checked (method, image, token, context, error);
+	mono_error_cleanup (error);
 	return res;
 }
 
@@ -752,8 +752,8 @@ MonoMethodSignature*
 mono_method_get_signature (MonoMethod *method, MonoImage *image, guint32 token)
 {
 	ERROR_DECL (error);
-	MonoMethodSignature *res = mono_method_get_signature_checked (method, image, token, NULL, &error);
-	mono_error_cleanup (&error);
+	MonoMethodSignature *res = mono_method_get_signature_checked (method, image, token, NULL, error);
+	mono_error_cleanup (error);
 	return res;
 }
 
@@ -1742,8 +1742,8 @@ MonoMethod *
 mono_get_method (MonoImage *image, guint32 token, MonoClass *klass)
 {
 	ERROR_DECL (error);
-	MonoMethod *result = mono_get_method_checked (image, token, klass, NULL, &error);
-	mono_error_cleanup (&error);
+	MonoMethod *result = mono_get_method_checked (image, token, klass, NULL, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -1755,8 +1755,8 @@ mono_get_method_full (MonoImage *image, guint32 token, MonoClass *klass,
 		      MonoGenericContext *context)
 {
 	ERROR_DECL (error);
-	MonoMethod *result = mono_get_method_checked (image, token, klass, context, &error);
-	mono_error_cleanup (&error);
+	MonoMethod *result = mono_get_method_checked (image, token, klass, context, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -1929,8 +1929,8 @@ mono_get_method_constrained (MonoImage *image, guint32 token, MonoClass *constra
 			     MonoGenericContext *context, MonoMethod **cil_method)
 {
 	ERROR_DECL (error);
-	MonoMethod *result = mono_get_method_constrained_checked (image, token, constrained_class, context, cil_method, &error);
-	mono_error_cleanup (&error);
+	MonoMethod *result = mono_get_method_constrained_checked (image, token, constrained_class, context, cil_method, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -2582,12 +2582,12 @@ mono_method_signature (MonoMethod *m)
 	ERROR_DECL (error);
 	MonoMethodSignature *sig;
 
-	sig = mono_method_signature_checked (m, &error);
+	sig = mono_method_signature_checked (m, error);
 	if (!sig) {
 		char *type_name = mono_type_get_full_name (m->klass);
-		g_warning ("Could not load signature of %s:%s due to: %s", type_name, m->name, mono_error_get_message (&error));
+		g_warning ("Could not load signature of %s:%s due to: %s", type_name, m->name, mono_error_get_message (error));
 		g_free (type_name);
-		mono_error_cleanup (&error);
+		mono_error_cleanup (error);
 	}
 
 	return sig;
@@ -2696,8 +2696,8 @@ MonoMethodHeader*
 mono_method_get_header (MonoMethod *method)
 {
 	ERROR_DECL (error);
-	MonoMethodHeader *header = mono_method_get_header_checked (method, &error);
-	mono_error_cleanup (&error);
+	MonoMethodHeader *header = mono_method_get_header_checked (method, error);
+	mono_error_cleanup (error);
 	return header;
 }
 

--- a/mono/metadata/locales.c
+++ b/mono/metadata/locales.c
@@ -184,8 +184,8 @@ ves_icall_System_Globalization_CalendarData_fill_calendar_data (MonoCalendarData
 	const CultureInfoEntry *ci;
 	char *n;
 
-	n = mono_string_to_utf8_checked (name, &error);
-	if (mono_error_set_pending_exception (&error))
+	n = mono_string_to_utf8_checked (name, error);
+	if (mono_error_set_pending_exception (error))
 		return FALSE;
 	ne = (const CultureInfoNameEntry *)mono_binary_search (n, culture_name_entries, NUM_CULTURE_ENTRIES,
 			sizeof (CultureInfoNameEntry), culture_name_locator);
@@ -199,56 +199,56 @@ ves_icall_System_Globalization_CalendarData_fill_calendar_data (MonoCalendarData
 
 	domain = mono_domain_get ();
 
-	MonoString *native_name = mono_string_new_checked (domain, idx2string (ci->nativename), &error);
-	return_val_and_set_pending_if_nok (&error, FALSE);
+	MonoString *native_name = mono_string_new_checked (domain, idx2string (ci->nativename), error);
+	return_val_and_set_pending_if_nok (error, FALSE);
 	MONO_OBJECT_SETREF (this_obj, NativeName, native_name);
 	MonoArray *short_date_patterns = create_names_array_idx_dynamic (dfe->short_date_patterns,
-									 NUM_SHORT_DATE_PATTERNS, &error);
-	return_val_and_set_pending_if_nok (&error, FALSE);
+									 NUM_SHORT_DATE_PATTERNS, error);
+	return_val_and_set_pending_if_nok (error, FALSE);
 	MONO_OBJECT_SETREF (this_obj, ShortDatePatterns, short_date_patterns);
 	MonoArray *year_month_patterns =create_names_array_idx_dynamic (dfe->year_month_patterns,
-									NUM_YEAR_MONTH_PATTERNS, &error);
-	return_val_and_set_pending_if_nok (&error, FALSE);
+									NUM_YEAR_MONTH_PATTERNS, error);
+	return_val_and_set_pending_if_nok (error, FALSE);
 	MONO_OBJECT_SETREF (this_obj, YearMonthPatterns, year_month_patterns);
 
 	MonoArray *long_date_patterns = create_names_array_idx_dynamic (dfe->long_date_patterns,
-									NUM_LONG_DATE_PATTERNS, &error);
-	return_val_and_set_pending_if_nok (&error, FALSE);
+									NUM_LONG_DATE_PATTERNS, error);
+	return_val_and_set_pending_if_nok (error, FALSE);
 	MONO_OBJECT_SETREF (this_obj, LongDatePatterns, long_date_patterns);
 
-	MonoString *month_day_pattern = mono_string_new_checked (domain, pattern2string (dfe->month_day_pattern), &error);
-	return_val_and_set_pending_if_nok (&error, FALSE);
+	MonoString *month_day_pattern = mono_string_new_checked (domain, pattern2string (dfe->month_day_pattern), error);
+	return_val_and_set_pending_if_nok (error, FALSE);
 	MONO_OBJECT_SETREF (this_obj, MonthDayPattern, month_day_pattern);
 
-	MonoArray *day_names = create_names_array_idx (dfe->day_names, NUM_DAYS, &error);
-	return_val_and_set_pending_if_nok (&error, FALSE);
+	MonoArray *day_names = create_names_array_idx (dfe->day_names, NUM_DAYS, error);
+	return_val_and_set_pending_if_nok (error, FALSE);
 	MONO_OBJECT_SETREF (this_obj, DayNames, day_names);
 
 	MonoArray *abbr_day_names = create_names_array_idx (dfe->abbreviated_day_names, 
-							    NUM_DAYS, &error);
-	return_val_and_set_pending_if_nok (&error, FALSE);
+							    NUM_DAYS, error);
+	return_val_and_set_pending_if_nok (error, FALSE);
 	MONO_OBJECT_SETREF (this_obj, AbbreviatedDayNames, abbr_day_names);
 
-	MonoArray *ss_day_names = create_names_array_idx (dfe->shortest_day_names, NUM_DAYS, &error);
-	return_val_and_set_pending_if_nok (&error, FALSE);
+	MonoArray *ss_day_names = create_names_array_idx (dfe->shortest_day_names, NUM_DAYS, error);
+	return_val_and_set_pending_if_nok (error, FALSE);
 	MONO_OBJECT_SETREF (this_obj, SuperShortDayNames, ss_day_names);
 
-	MonoArray *month_names = create_names_array_idx (dfe->month_names, NUM_MONTHS, &error);
-	return_val_and_set_pending_if_nok (&error, FALSE);
+	MonoArray *month_names = create_names_array_idx (dfe->month_names, NUM_MONTHS, error);
+	return_val_and_set_pending_if_nok (error, FALSE);
 	MONO_OBJECT_SETREF (this_obj, MonthNames, month_names);
 
 	MonoArray *abbr_mon_names = create_names_array_idx (dfe->abbreviated_month_names,
-							    NUM_MONTHS, &error);
-	return_val_and_set_pending_if_nok (&error, FALSE);
+							    NUM_MONTHS, error);
+	return_val_and_set_pending_if_nok (error, FALSE);
 	MONO_OBJECT_SETREF (this_obj, AbbreviatedMonthNames, abbr_mon_names);
 
 	
-	MonoArray *gen_month_names = create_names_array_idx (dfe->month_genitive_names, NUM_MONTHS, &error);
-	return_val_and_set_pending_if_nok (&error, FALSE);
+	MonoArray *gen_month_names = create_names_array_idx (dfe->month_genitive_names, NUM_MONTHS, error);
+	return_val_and_set_pending_if_nok (error, FALSE);
 	MONO_OBJECT_SETREF (this_obj, GenitiveMonthNames, gen_month_names);
 
-	MonoArray *gen_abbr_mon_names = create_names_array_idx (dfe->abbreviated_month_genitive_names, NUM_MONTHS, &error);
-	return_val_and_set_pending_if_nok (&error, FALSE);
+	MonoArray *gen_abbr_mon_names = create_names_array_idx (dfe->abbreviated_month_genitive_names, NUM_MONTHS, error);
+	return_val_and_set_pending_if_nok (error, FALSE);
 	MONO_OBJECT_SETREF (this_obj, GenitiveAbbreviatedMonthNames, gen_abbr_mon_names);
 
 	return TRUE;
@@ -274,20 +274,20 @@ ves_icall_System_Globalization_CultureData_fill_culture_data (MonoCultureData *t
 		MONO_OBJECT_SETREF((obj), field, _tmp_str);		\
 	} while (0)
 
-	SET_STR (this_obj, AMDesignator, domain, idx2string (dfe->am_designator), &error);
-	SET_STR (this_obj, PMDesignator, domain, idx2string (dfe->pm_designator), &error);
-	SET_STR (this_obj, TimeSeparator, domain, idx2string (dfe->time_separator), &error);
+	SET_STR (this_obj, AMDesignator, domain, idx2string (dfe->am_designator), error);
+	SET_STR (this_obj, PMDesignator, domain, idx2string (dfe->pm_designator), error);
+	SET_STR (this_obj, TimeSeparator, domain, idx2string (dfe->time_separator), error);
 #undef SET_STR
 
 	MonoArray *long_time_patterns = create_names_array_idx_dynamic (dfe->long_time_patterns,
-									NUM_LONG_TIME_PATTERNS, &error);
-	if (mono_error_set_pending_exception (&error))
+									NUM_LONG_TIME_PATTERNS, error);
+	if (mono_error_set_pending_exception (error))
 		return;
 	MONO_OBJECT_SETREF (this_obj, LongTimePatterns, long_time_patterns);
 
 	MonoArray *short_time_patterns = create_names_array_idx_dynamic (dfe->short_time_patterns,
-									 NUM_SHORT_TIME_PATTERNS, &error);
-	if (mono_error_set_pending_exception (&error))
+									 NUM_SHORT_TIME_PATTERNS, error);
+	if (mono_error_set_pending_exception (error))
 		return;
 	MONO_OBJECT_SETREF (this_obj, ShortTimePatterns, short_time_patterns);
 	this_obj->FirstDayOfWeek = dfe->first_day_of_week;
@@ -316,36 +316,36 @@ ves_icall_System_Globalization_CultureData_fill_number_data (MonoNumberFormatInf
 		MONO_OBJECT_SETREF((obj), field, _tmp_str);		\
 	} while (0)
 
-	SET_STR (number, currencyDecimalSeparator, domain, idx2string (nfe->currency_decimal_separator), &error);
-	SET_STR (number, currencyGroupSeparator, domain, idx2string (nfe->currency_group_separator), &error);
+	SET_STR (number, currencyDecimalSeparator, domain, idx2string (nfe->currency_decimal_separator), error);
+	SET_STR (number, currencyGroupSeparator, domain, idx2string (nfe->currency_group_separator), error);
 
 	MonoArray *currency_sizes_arr = create_group_sizes_array (nfe->currency_group_sizes,
-								  GROUP_SIZE, &error);
-	if (mono_error_set_pending_exception (&error))
+								  GROUP_SIZE, error);
+	if (mono_error_set_pending_exception (error))
 		return;
 	MONO_OBJECT_SETREF (number, currencyGroupSizes, currency_sizes_arr);
 	number->currencyNegativePattern = nfe->currency_negative_pattern;
 	number->currencyPositivePattern = nfe->currency_positive_pattern;
 
-	SET_STR (number, currencySymbol, domain, idx2string (nfe->currency_symbol), &error);
-	SET_STR (number, naNSymbol, domain, idx2string (nfe->nan_symbol), &error);
-	SET_STR (number, negativeInfinitySymbol, domain, idx2string (nfe->negative_infinity_symbol), &error);
-	SET_STR (number, negativeSign, domain, idx2string (nfe->negative_sign), &error);
+	SET_STR (number, currencySymbol, domain, idx2string (nfe->currency_symbol), error);
+	SET_STR (number, naNSymbol, domain, idx2string (nfe->nan_symbol), error);
+	SET_STR (number, negativeInfinitySymbol, domain, idx2string (nfe->negative_infinity_symbol), error);
+	SET_STR (number, negativeSign, domain, idx2string (nfe->negative_sign), error);
 	number->numberDecimalDigits = nfe->number_decimal_digits;
-	SET_STR (number, numberDecimalSeparator, domain, idx2string (nfe->number_decimal_separator), &error);
-	SET_STR (number, numberGroupSeparator, domain, idx2string (nfe->number_group_separator), &error);
+	SET_STR (number, numberDecimalSeparator, domain, idx2string (nfe->number_decimal_separator), error);
+	SET_STR (number, numberGroupSeparator, domain, idx2string (nfe->number_group_separator), error);
 	MonoArray *number_sizes_arr = create_group_sizes_array (nfe->number_group_sizes,
-								GROUP_SIZE, &error);
-	if (mono_error_set_pending_exception (&error))
+								GROUP_SIZE, error);
+	if (mono_error_set_pending_exception (error))
 		return;
 	MONO_OBJECT_SETREF (number, numberGroupSizes, number_sizes_arr);
 	number->numberNegativePattern = nfe->number_negative_pattern;
 	number->percentNegativePattern = nfe->percent_negative_pattern;
 	number->percentPositivePattern = nfe->percent_positive_pattern;
-	SET_STR (number, percentSymbol, domain, idx2string (nfe->percent_symbol), &error);
-	SET_STR (number, perMilleSymbol, domain, idx2string (nfe->per_mille_symbol), &error);
-	SET_STR (number, positiveInfinitySymbol, domain, idx2string (nfe->positive_infinity_symbol), &error);
-	SET_STR (number, positiveSign, domain, idx2string (nfe->positive_sign), &error);
+	SET_STR (number, percentSymbol, domain, idx2string (nfe->percent_symbol), error);
+	SET_STR (number, perMilleSymbol, domain, idx2string (nfe->per_mille_symbol), error);
+	SET_STR (number, positiveInfinitySymbol, domain, idx2string (nfe->positive_infinity_symbol), error);
+	SET_STR (number, positiveSign, domain, idx2string (nfe->positive_sign), error);
 #undef SET_STR
 }
 
@@ -613,8 +613,8 @@ ves_icall_System_Globalization_CultureInfo_construct_internal_locale_from_lcid (
 	if(ci == NULL)
 		return FALSE;
 
-	if (!construct_culture (this_obj, ci, &error)) {
-		mono_error_set_pending_exception (&error);
+	if (!construct_culture (this_obj, ci, error)) {
+		mono_error_set_pending_exception (error);
 		return FALSE;
 	}
 	return TRUE;
@@ -628,8 +628,8 @@ ves_icall_System_Globalization_CultureInfo_construct_internal_locale_from_name (
 	const CultureInfoNameEntry *ne;
 	char *n;
 	
-	n = mono_string_to_utf8_checked (name, &error);
-	if (mono_error_set_pending_exception (&error))
+	n = mono_string_to_utf8_checked (name, error);
+	if (mono_error_set_pending_exception (error))
 		return FALSE;
 	ne = (const CultureInfoNameEntry *)mono_binary_search (n, culture_name_entries, NUM_CULTURE_ENTRIES,
 			sizeof (CultureInfoNameEntry), culture_name_locator);
@@ -641,8 +641,8 @@ ves_icall_System_Globalization_CultureInfo_construct_internal_locale_from_name (
 	}
 	g_free (n);
 
-	if (!construct_culture (this_obj, &culture_entries [ne->culture_entry_index], &error)) {
-		mono_error_set_pending_exception (&error);
+	if (!construct_culture (this_obj, &culture_entries [ne->culture_entry_index], error)) {
+		mono_error_set_pending_exception (error);
 		return FALSE;
 	}
 	return TRUE;
@@ -673,8 +673,8 @@ ves_icall_System_Globalization_RegionInfo_construct_internal_region_from_lcid (M
 	if(ri == NULL)
 		return FALSE;
 
-	MonoBoolean result = construct_region (this_obj, ri, &error);
-	mono_error_set_pending_exception (&error);
+	MonoBoolean result = construct_region (this_obj, ri, error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 
@@ -686,8 +686,8 @@ ves_icall_System_Globalization_RegionInfo_construct_internal_region_from_name (M
 	const RegionInfoNameEntry *ne;
 	char *n;
 	
-	n = mono_string_to_utf8_checked (name, &error);
-	if (mono_error_set_pending_exception (&error))
+	n = mono_string_to_utf8_checked (name, error);
+	if (mono_error_set_pending_exception (error))
 		return FALSE;
 	ne = (const RegionInfoNameEntry *)mono_binary_search (n, region_name_entries, NUM_REGION_ENTRIES,
 		sizeof (RegionInfoNameEntry), region_name_locator);
@@ -699,8 +699,8 @@ ves_icall_System_Globalization_RegionInfo_construct_internal_region_from_name (M
 	}
 	g_free (n);
 
-	MonoBoolean result = construct_region (this_obj, &region_entries [ne->region_entry_index], &error);
-	mono_error_set_pending_exception (&error);
+	MonoBoolean result = construct_region (this_obj, &region_entries [ne->region_entry_index], error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 
@@ -734,8 +734,8 @@ ves_icall_System_Globalization_CultureInfo_internal_get_cultures (MonoBoolean ne
 	if (neutral)
 		len++;
 
-	ret = mono_array_new_checked (domain, klass, len, &error);
-	goto_if_nok (&error, fail);
+	ret = mono_array_new_checked (domain, klass, len, error);
+	goto_if_nok (error, fail);
 
 	if (len == 0)
 		return ret;
@@ -748,11 +748,11 @@ ves_icall_System_Globalization_CultureInfo_internal_get_cultures (MonoBoolean ne
 		ci = &culture_entries [i];
 		is_neutral = ci->territory == 0;
 		if ((neutral && is_neutral) || (specific && !is_neutral)) {
-			culture = (MonoCultureInfo *) mono_object_new_checked (domain, klass, &error);
-			goto_if_nok (&error, fail);
-			mono_runtime_object_init_checked ((MonoObject *) culture, &error);
-			goto_if_nok (&error, fail);
-			if (!construct_culture (culture, ci, &error))
+			culture = (MonoCultureInfo *) mono_object_new_checked (domain, klass, error);
+			goto_if_nok (error, fail);
+			mono_runtime_object_init_checked ((MonoObject *) culture, error);
+			goto_if_nok (error, fail);
+			if (!construct_culture (culture, ci, error))
 				goto fail;
 			culture->use_user_override = TRUE;
 			mono_array_setref (ret, len++, culture);
@@ -762,7 +762,7 @@ ves_icall_System_Globalization_CultureInfo_internal_get_cultures (MonoBoolean ne
 	return ret;
 
 fail:
-	mono_error_set_pending_exception (&error);
+	mono_error_set_pending_exception (error);
 	return ret;
 }
 
@@ -784,8 +784,8 @@ void ves_icall_System_Globalization_CompareInfo_assign_sortkey (MonoCompareInfo 
 	keylen=mono_string_length (source);
 	
 	arr=mono_array_new_checked (mono_domain_get (), mono_get_byte_class (),
-				    keylen, &error);
-	if (mono_error_set_pending_exception (&error))
+				    keylen, error);
+	if (mono_error_set_pending_exception (error))
 		return;
 
 	for(i=0; i<keylen; i++) {

--- a/mono/metadata/marshal-windows.c
+++ b/mono/metadata/marshal-windows.c
@@ -60,8 +60,8 @@ ves_icall_System_Runtime_InteropServices_Marshal_StringToHGlobalAnsi (MonoString
 	ERROR_DECL (error);
 	char* tres, *ret;
 	size_t len;
-	tres = mono_string_to_utf8_checked (string, &error);
-	if (mono_error_set_pending_exception (&error))
+	tres = mono_string_to_utf8_checked (string, error);
+	if (mono_error_set_pending_exception (error))
 		return NULL;
 	if (!tres)
 		return tres;

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -301,8 +301,8 @@ mono_object_isinst_icall (MonoObject *obj, MonoClass *klass)
 	}
 
 	ERROR_DECL (error);
-	MonoObject *result = mono_object_isinst_checked (obj, klass, &error);
-	mono_error_set_pending_exception (&error);
+	MonoObject *result = mono_object_isinst_checked (obj, klass, error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 
@@ -310,8 +310,8 @@ static MonoString*
 ves_icall_mono_string_from_utf16 (gunichar2 *data)
 {
 	ERROR_DECL (error);
-	MonoString *result = mono_string_from_utf16_checked (data, &error);
-	mono_error_set_pending_exception (&error);
+	MonoString *result = mono_string_from_utf16_checked (data, error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 
@@ -319,8 +319,8 @@ static char*
 ves_icall_mono_string_to_utf8 (MonoString *str)
 {
 	ERROR_DECL (error);
-	char *result = mono_string_to_utf8_checked (str, &error);
-	mono_error_set_pending_exception (&error);
+	char *result = mono_string_to_utf8_checked (str, error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 
@@ -329,8 +329,8 @@ ves_icall_string_new_wrapper (const char *text)
 {
 	if (text) {
 		ERROR_DECL (error);
-		MonoString *res = mono_string_new_checked (mono_domain_get (), text, &error);
-		mono_error_set_pending_exception (&error);
+		MonoString *res = mono_string_new_checked (mono_domain_get (), text, error);
+		mono_error_set_pending_exception (error);
 		return res;
 	}
 
@@ -442,8 +442,8 @@ mono_delegate_to_ftnptr (MonoDelegate *delegate_raw)
 	HANDLE_FUNCTION_ENTER ();
 	ERROR_DECL (error);
 	MONO_HANDLE_DCL (MonoDelegate, delegate);
-	gpointer result = mono_delegate_handle_to_ftnptr (delegate, &error);
-	mono_error_set_pending_exception (&error);
+	gpointer result = mono_delegate_handle_to_ftnptr (delegate, error);
+	mono_error_set_pending_exception (error);
 	HANDLE_FUNCTION_RETURN_VAL (result);
 }
 
@@ -589,19 +589,19 @@ parse_unmanaged_function_pointer_attr (MonoClass *klass, MonoMethodPInvoke *piin
 		 * The pinvoke attributes are stored in a real custom attribute so we have to
 		 * construct it.
 		 */
-		cinfo = mono_custom_attrs_from_class_checked (klass, &error);
-		if (!mono_error_ok (&error)) {
-			g_warning ("Could not load UnmanagedFunctionPointerAttribute due to %s", mono_error_get_message (&error));
-			mono_error_cleanup (&error);
+		cinfo = mono_custom_attrs_from_class_checked (klass, error);
+		if (!mono_error_ok (error)) {
+			g_warning ("Could not load UnmanagedFunctionPointerAttribute due to %s", mono_error_get_message (error));
+			mono_error_cleanup (error);
 		}
 		if (cinfo && !mono_runtime_get_no_exec ()) {
-			attr = (MonoReflectionUnmanagedFunctionPointerAttribute*)mono_custom_attrs_get_attr_checked (cinfo, mono_class_try_get_unmanaged_function_pointer_attribute_class (), &error);
+			attr = (MonoReflectionUnmanagedFunctionPointerAttribute*)mono_custom_attrs_get_attr_checked (cinfo, mono_class_try_get_unmanaged_function_pointer_attribute_class (), error);
 			if (attr) {
 				piinfo->piflags = (attr->call_conv << 8) | (attr->charset ? (attr->charset - 1) * 2 : 1) | attr->set_last_error;
 			} else {
-				if (!mono_error_ok (&error)) {
-					g_warning ("Could not load UnmanagedFunctionPointerAttribute due to %s", mono_error_get_message (&error));
-					mono_error_cleanup (&error);
+				if (!mono_error_ok (error)) {
+					g_warning ("Could not load UnmanagedFunctionPointerAttribute due to %s", mono_error_get_message (error));
+					mono_error_cleanup (error);
 				}
 			}
 			if (!cinfo->cached)
@@ -616,8 +616,8 @@ mono_ftnptr_to_delegate (MonoClass *klass, gpointer ftn)
 {
 	HANDLE_FUNCTION_ENTER ();
 	ERROR_DECL (error);
-	MonoDelegateHandle result = mono_ftnptr_to_delegate_handle (klass, ftn, &error);
-	mono_error_set_pending_exception (&error);
+	MonoDelegateHandle result = mono_ftnptr_to_delegate_handle (klass, ftn, error);
+	mono_error_set_pending_exception (error);
 	HANDLE_FUNCTION_RETURN_OBJ (result);
 }
 
@@ -746,8 +746,8 @@ mono_string_from_byvalstr (const char *data, int max_len)
 	while (len < max_len - 1 && data [len])
 		len++;
 
-	MonoString *result = mono_string_new_len_checked (domain, data, len, &error);
-	mono_error_set_pending_exception (&error);
+	MonoString *result = mono_string_new_len_checked (domain, data, len, error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 
@@ -765,9 +765,9 @@ mono_string_from_byvalwstr (gunichar2 *data, int max_len)
 
 	while (data [len]) len++;
 
-	res = mono_string_new_utf16_checked (domain, data, MIN (len, max_len), &error);
-	if (!mono_error_ok (&error)) {
-		mono_error_set_pending_exception (&error);
+	res = mono_string_new_utf16_checked (domain, data, MIN (len, max_len), error);
+	if (!mono_error_ok (error)) {
+		mono_error_set_pending_exception (error);
 		return NULL;
 	}
 	return res;
@@ -798,7 +798,7 @@ mono_array_to_lparray (MonoArray *array)
 	if (!array)
 		return NULL;
 #ifndef DISABLE_COM
-	error_init (&error);
+	error_init (error);
 	klass = array->obj.vtable->klass;
 
 	switch (klass->element_class->byval_arg.type) {
@@ -809,8 +809,8 @@ mono_array_to_lparray (MonoArray *array)
 		nativeArraySize = array->max_length;
 		nativeArray = (void **)g_malloc (sizeof(gpointer) * nativeArraySize);
 		for(i = 0; i < nativeArraySize; ++i) {
-			nativeArray[i] = mono_cominterop_get_com_interface (((MonoObject **)array->vector)[i], klass->element_class, &error);
-			if (mono_error_set_pending_exception (&error))
+			nativeArray[i] = mono_cominterop_get_com_interface (((MonoObject **)array->vector)[i], klass->element_class, error);
+			if (mono_error_set_pending_exception (error))
 				break;
 		}
 		return nativeArray;
@@ -953,13 +953,13 @@ mono_string_builder_new (int starting_string_length)
 	// array will always be garbage collected.
 	args [0] = &initial_len;
 
-	MonoStringBuilder *sb = (MonoStringBuilder*)mono_object_new_checked (mono_domain_get (), string_builder_class, &error);
-	mono_error_assert_ok (&error);
+	MonoStringBuilder *sb = (MonoStringBuilder*)mono_object_new_checked (mono_domain_get (), string_builder_class, error);
+	mono_error_assert_ok (error);
 
 	MonoObject *exc;
-	mono_runtime_try_invoke (sb_ctor, sb, args, &exc, &error);
+	mono_runtime_try_invoke (sb_ctor, sb, args, &exc, error);
 	g_assert (exc == NULL);
-	mono_error_assert_ok (&error);
+	mono_error_assert_ok (error);
 
 	g_assert (sb->chunkChars->max_length >= initial_len);
 
@@ -1078,11 +1078,11 @@ mono_string_builder_to_utf8 (MonoStringBuilder *sb)
 		return NULL;
 	} else {
 		guint len = mono_string_builder_capacity (sb) + 1;
-		gchar *res = (gchar *)mono_marshal_alloc (MAX (byte_count+1, len * sizeof (gchar)), &error);
-		if (!mono_error_ok (&error)) {
+		gchar *res = (gchar *)mono_marshal_alloc (MAX (byte_count+1, len * sizeof (gchar)), error);
+		if (!mono_error_ok (error)) {
 			mono_marshal_free (str_utf16);
 			g_free (tmp);
-			mono_error_set_pending_exception (&error);
+			mono_error_set_pending_exception (error);
 			return NULL;
 		}
 
@@ -1122,9 +1122,9 @@ mono_string_builder_to_utf16 (MonoStringBuilder *sb)
 	if (len == 0)
 		len = 1;
 
-	gunichar2 *str = (gunichar2 *)mono_marshal_alloc ((len + 1) * sizeof (gunichar2), &error);
-	if (!mono_error_ok (&error)) {
-		mono_error_set_pending_exception (&error);
+	gunichar2 *str = (gunichar2 *)mono_marshal_alloc ((len + 1) * sizeof (gunichar2), error);
+	if (!mono_error_ok (error)) {
+		mono_error_set_pending_exception (error);
 		return NULL;
 	}
 
@@ -1159,8 +1159,8 @@ static gpointer
 mono_string_to_utf8str (MonoString *s)
 {
 	ERROR_DECL (error);
-	char *result = mono_string_to_utf8_checked (s, &error);
-	mono_error_set_pending_exception (&error);
+	char *result = mono_string_to_utf8_checked (s, error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 #endif
@@ -1195,8 +1195,8 @@ mono_string_to_byvalstr (gpointer dst, MonoString *src, int size)
 	if (!src)
 		return;
 
-	s = mono_string_to_utf8_checked (src, &error);
-	if (mono_error_set_pending_exception (&error))
+	s = mono_string_to_utf8_checked (src, error);
+	if (mono_error_set_pending_exception (error))
 		return;
 	len = MIN (size, strlen (s));
 	if (len >= size)
@@ -1240,8 +1240,8 @@ static MonoString*
 mono_string_new_len_wrapper (const char *text, guint length)
 {
 	ERROR_DECL (error);
-	MonoString *result = mono_string_new_len_checked (mono_domain_get (), text, length, &error);
-	mono_error_set_pending_exception (&error);
+	MonoString *result = mono_string_new_len_checked (mono_domain_get (), text, length, error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 
@@ -2020,8 +2020,8 @@ get_fixed_buffer_attr (MonoClassField *field, MonoType **out_etype, int *out_len
 	MonoCustomAttrEntry *attr;
 	int aindex;
 
-	cinfo = mono_custom_attrs_from_field_checked (field->parent, field, &error);
-	if (!is_ok (&error))
+	cinfo = mono_custom_attrs_from_field_checked (field->parent, field, error);
+	if (!is_ok (error))
 		return FALSE;
 	attr = NULL;
 	if (cinfo) {
@@ -2038,8 +2038,8 @@ get_fixed_buffer_attr (MonoClassField *field, MonoType **out_etype, int *out_len
 		CattrNamedArg *arginfo;
 		MonoObject *o;
 
-		mono_reflection_create_custom_attr_data_args (mono_defaults.corlib, attr->ctor, attr->data, attr->data_size, &typed_args, &named_args, &arginfo, &error);
-		if (!is_ok (&error))
+		mono_reflection_create_custom_attr_data_args (mono_defaults.corlib, attr->ctor, attr->data, attr->data_size, &typed_args, &named_args, &arginfo, error);
+		if (!is_ok (error))
 			return FALSE;
 		g_assert (mono_array_length (typed_args) == 2);
 
@@ -2489,11 +2489,11 @@ mono_delegate_begin_invoke (MonoDelegate *delegate, gpointer *params)
 			MonoArray *out_args;
 			method = delegate->method;
 
-			msg = mono_method_call_message_new (mono_marshal_method_from_wrapper (method), params, NULL, &async_callback, &state, &error);
-			if (mono_error_set_pending_exception (&error))
+			msg = mono_method_call_message_new (mono_marshal_method_from_wrapper (method), params, NULL, &async_callback, &state, error);
+			if (mono_error_set_pending_exception (error))
 				return NULL;
-			ares = mono_async_result_new (mono_domain_get (), NULL, state, NULL, NULL, &error);
-			if (mono_error_set_pending_exception (&error))
+			ares = mono_async_result_new (mono_domain_get (), NULL, state, NULL, NULL, error);
+			if (mono_error_set_pending_exception (error))
 				return NULL;
 			MONO_OBJECT_SETREF (ares, async_delegate, (MonoObject *)delegate);
 			MONO_OBJECT_SETREF (ares, async_callback, (MonoObject *)async_callback);
@@ -2501,9 +2501,9 @@ mono_delegate_begin_invoke (MonoDelegate *delegate, gpointer *params)
 			msg->call_type = CallType_BeginInvoke;
 
 			exc = NULL;
-			mono_remoting_invoke ((MonoObject *)tp->rp, msg, &exc, &out_args, &error);
-			if (!mono_error_ok (&error)) {
-				mono_error_set_pending_exception (&error);
+			mono_remoting_invoke ((MonoObject *)tp->rp, msg, &exc, &out_args, error);
+			if (!mono_error_ok (error)) {
+				mono_error_set_pending_exception (error);
 				return NULL;
 			}
 			if (exc)
@@ -2520,8 +2520,8 @@ mono_delegate_begin_invoke (MonoDelegate *delegate, gpointer *params)
 		method = mono_get_delegate_invoke (klass);
 	g_assert (method);
 
-	MonoAsyncResult *result = mono_threadpool_begin_invoke (mono_domain_get (), (MonoObject*) delegate, method, params, &error);
-	mono_error_set_pending_exception (&error);
+	MonoAsyncResult *result = mono_threadpool_begin_invoke (mono_domain_get (), (MonoObject*) delegate, method, params, error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 
@@ -2884,8 +2884,8 @@ mono_marshal_method_from_wrapper (MonoMethod *wrapper)
 			 * A method cannot be inflated and a wrapper at the same time, so the wrapper info
 			 * contains an uninflated method.
 			 */
-			result = mono_class_inflate_generic_method_checked (m, mono_method_get_context (wrapper), &error);
-			g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+			result = mono_class_inflate_generic_method_checked (m, mono_method_get_context (wrapper), error);
+			g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 			return result;
 		}
 		return m;
@@ -2894,8 +2894,8 @@ mono_marshal_method_from_wrapper (MonoMethod *wrapper)
 		if (wrapper->is_inflated) {
 			ERROR_DECL (error);
 			MonoMethod *result;
-			result = mono_class_inflate_generic_method_checked (m, mono_method_get_context (wrapper), &error);
-			g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+			result = mono_class_inflate_generic_method_checked (m, mono_method_get_context (wrapper), error);
+			g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 			return result;
 		}
 		return m;
@@ -2989,8 +2989,8 @@ get_wrapper_target_class (MonoImage *image)
 	if (image_is_dynamic (image)) {
 		klass = ((MonoDynamicImage*)image)->wrappers_type;
 	} else {
-		klass = mono_class_get_checked (image, mono_metadata_make_token (MONO_TABLE_TYPEDEF, 1), &error);
-		g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+		klass = mono_class_get_checked (image, mono_metadata_make_token (MONO_TABLE_TYPEDEF, 1), error);
+		g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 	}
 	g_assert (klass);
 
@@ -3032,8 +3032,8 @@ check_generic_wrapper_cache (GHashTable *cache, MonoMethod *orig_method, gpointe
 	def = mono_marshal_find_in_cache (cache, def_key);
 	if (def) {
 		ERROR_DECL (error);
-		inst = mono_class_inflate_generic_method_checked (def, ctx, &error);
-		g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+		inst = mono_class_inflate_generic_method_checked (def, ctx, error);
+		g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 		/* Cache it */
 		mono_memory_barrier ();
 		mono_marshal_lock ();
@@ -3057,8 +3057,8 @@ cache_generic_wrapper (GHashTable *cache, MonoMethod *orig_method, MonoMethod *d
 	/*
 	 * We use the same cache for the generic definition and the instances.
 	 */
-	inst = mono_class_inflate_generic_method_checked (def, ctx, &error);
-	g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+	inst = mono_class_inflate_generic_method_checked (def, ctx, error);
+	g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 	mono_memory_barrier ();
 	mono_marshal_lock ();
 	res = (MonoMethod *)g_hash_table_lookup (cache, key);
@@ -3089,8 +3089,8 @@ check_generic_delegate_wrapper_cache (GHashTable *cache, MonoMethod *orig_method
 	 */
 	def = mono_marshal_find_in_cache (cache, def_method->klass);
 	if (def) {
-		inst = mono_class_inflate_generic_method_checked (def, ctx, &error);
-		g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+		inst = mono_class_inflate_generic_method_checked (def, ctx, error);
+		g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 
 		/* Cache it */
 		mono_memory_barrier ();
@@ -3116,16 +3116,16 @@ cache_generic_delegate_wrapper (GHashTable *cache, MonoMethod *orig_method, Mono
 	/*
 	 * We use the same cache for the generic definition and the instances.
 	 */
-	inst = mono_class_inflate_generic_method_checked (def, ctx, &error);
-	g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+	inst = mono_class_inflate_generic_method_checked (def, ctx, error);
+	g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 
 	ginfo = mono_marshal_get_wrapper_info (def);
 	if (ginfo) {
 		info = (WrapperInfo *)mono_image_alloc0 (def->klass->image, sizeof (WrapperInfo));
 		info->subtype = ginfo->subtype;
 		if (info->subtype == WRAPPER_SUBTYPE_NONE) {
-			info->d.delegate_invoke.method = mono_class_inflate_generic_method_checked (ginfo->d.delegate_invoke.method, ctx, &error);
-			mono_error_assert_ok (&error);
+			info->d.delegate_invoke.method = mono_class_inflate_generic_method_checked (ginfo->d.delegate_invoke.method, ctx, error);
+			mono_error_assert_ok (error);
 		}
 	}
 
@@ -3233,9 +3233,9 @@ mono_delegate_end_invoke (MonoDelegate *delegate, gpointer *params)
 
 	if (!delegate->method_info) {
 		g_assert (delegate->method);
-		MonoReflectionMethod *rm = mono_method_get_object_checked (domain, delegate->method, NULL, &error);
-		if (!mono_error_ok (&error)) {
-			mono_error_set_pending_exception (&error);
+		MonoReflectionMethod *rm = mono_method_get_object_checked (domain, delegate->method, NULL, error);
+		if (!mono_error_ok (error)) {
+			mono_error_set_pending_exception (error);
 			return NULL;
 		}
 		MONO_OBJECT_SETREF (delegate, method_info, rm);
@@ -3251,8 +3251,8 @@ mono_delegate_end_invoke (MonoDelegate *delegate, gpointer *params)
 
 	sig = mono_signature_no_pinvoke (method);
 
-	msg = mono_method_call_message_new (method, params, NULL, NULL, NULL, &error);
-	if (mono_error_set_pending_exception (&error))
+	msg = mono_method_call_message_new (method, params, NULL, NULL, NULL, error);
+	if (mono_error_set_pending_exception (error))
 		return NULL;
 
 	ares = (MonoAsyncResult *)mono_array_get (msg->args, gpointer, sig->param_count - 1);
@@ -3270,32 +3270,32 @@ mono_delegate_end_invoke (MonoDelegate *delegate, gpointer *params)
 #ifndef DISABLE_REMOTING
 	if (delegate->target && mono_object_is_transparent_proxy (delegate->target)) {
 		MonoTransparentProxy* tp = (MonoTransparentProxy *)delegate->target;
-		msg = (MonoMethodMessage *)mono_object_new_checked (domain, mono_defaults.mono_method_message_class, &error);
-		if (!mono_error_ok (&error)) {
-			mono_error_set_pending_exception (&error);
+		msg = (MonoMethodMessage *)mono_object_new_checked (domain, mono_defaults.mono_method_message_class, error);
+		if (!mono_error_ok (error)) {
+			mono_error_set_pending_exception (error);
 			return NULL;
 		}
-		mono_message_init (domain, msg, delegate->method_info, NULL, &error);
-		if (mono_error_set_pending_exception (&error))
+		mono_message_init (domain, msg, delegate->method_info, NULL, error);
+		if (mono_error_set_pending_exception (error))
 			return NULL;
 		msg->call_type = CallType_EndInvoke;
 		MONO_OBJECT_SETREF (msg, async_result, ares);
-		res = mono_remoting_invoke ((MonoObject *)tp->rp, msg, &exc, &out_args, &error);
-		if (!mono_error_ok (&error)) {
-			mono_error_set_pending_exception (&error);
+		res = mono_remoting_invoke ((MonoObject *)tp->rp, msg, &exc, &out_args, error);
+		if (!mono_error_ok (error)) {
+			mono_error_set_pending_exception (error);
 			return NULL;
 		}
 	} else
 #endif
 	{
-		res = mono_threadpool_end_invoke (ares, &out_args, &exc, &error);
-		if (mono_error_set_pending_exception (&error))
+		res = mono_threadpool_end_invoke (ares, &out_args, &exc, error);
+		if (mono_error_set_pending_exception (error))
 			return NULL;
 	}
 
 	if (exc) {
 		if (((MonoException*)exc)->stack_trace) {
-			ERROR_DECL (inner_error);
+			ERROR_DECL_VALUE (inner_error);
 			char *strace = mono_string_to_utf8_checked (((MonoException*)exc)->stack_trace, &inner_error);
 			if (is_ok (&inner_error)) {
 				char  *tmp;
@@ -3312,8 +3312,8 @@ mono_delegate_end_invoke (MonoDelegate *delegate, gpointer *params)
 		mono_set_pending_exception ((MonoException*)exc);
 	}
 
-	mono_method_return_message_restore (method, params, out_args, &error);
-	mono_error_set_pending_exception (&error);
+	mono_method_return_message_restore (method, params, out_args, error);
+	mono_error_set_pending_exception (error);
 	return res;
 }
 
@@ -3540,8 +3540,8 @@ mono_marshal_get_delegate_invoke_internal (MonoMethod *method, gboolean callvirt
 
 			g_assert (method->signature->hasthis);
 			target_type = mono_class_inflate_generic_type_checked (method->signature->params [0],
-				mono_method_get_context (method), &error);
-			mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+				mono_method_get_context (method), error);
+			mono_error_assert_ok (error); /* FIXME don't swallow the error */
 			target_class = mono_class_from_mono_type (target_type);
 		} else {
 			target_class = target_method->klass;
@@ -3785,8 +3785,8 @@ mono_marshal_get_delegate_invoke_internal (MonoMethod *method, gboolean callvirt
 		mono_mb_emit_op (mb, CEE_CALLVIRT, method);
 	} else {
 		ERROR_DECL (error);
-		mono_mb_emit_op (mb, CEE_CALLVIRT, mono_class_inflate_generic_method_checked (method, &container->context, &error));
-		g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+		mono_mb_emit_op (mb, CEE_CALLVIRT, mono_class_inflate_generic_method_checked (method, &container->context, error));
+		g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 	}
 	if (!void_ret)
 		mono_mb_emit_stloc (mb, local_res);
@@ -4023,8 +4023,8 @@ emit_invoke_call (MonoMethodBuilder *mb, MonoMethod *method,
 	if (!string_dummy) {
 		ERROR_DECL (error);
 		MONO_GC_REGISTER_ROOT_SINGLE (string_dummy, MONO_ROOT_SOURCE_MARSHAL, NULL, "Marshal Dummy String");
-		string_dummy = mono_string_new_checked (mono_get_root_domain (), "dummy", &error);
-		mono_error_assert_ok (&error);
+		string_dummy = mono_string_new_checked (mono_get_root_domain (), "dummy", error);
+		mono_error_assert_ok (error);
 	}
 
 	if (virtual_) {
@@ -4825,11 +4825,11 @@ emit_marshal_custom (EmitMarshalContext *m, int argnum, MonoType *t,
 	}
 
 	if (spec->data.custom_data.image)
-		mtype = mono_reflection_type_from_name_checked (spec->data.custom_data.custom_name, spec->data.custom_data.image, &error);
+		mtype = mono_reflection_type_from_name_checked (spec->data.custom_data.custom_name, spec->data.custom_data.image, error);
 	else
-		mtype = mono_reflection_type_from_name_checked (spec->data.custom_data.custom_name, m->image, &error);
+		mtype = mono_reflection_type_from_name_checked (spec->data.custom_data.custom_name, m->image, error);
 	g_assert (mtype != NULL);
-	mono_error_assert_ok (&error);
+	mono_error_assert_ok (error);
 	mklass = mono_class_from_mono_type (mtype);
 	g_assert (mklass != NULL);
 
@@ -8855,8 +8855,8 @@ mono_marshal_set_callconv_from_modopt (MonoMethod *method, MonoMethodSignature *
 	if (sig->ret && sig->ret->num_mods) {
 		for (i = 0; i < sig->ret->num_mods; ++i) {
 			ERROR_DECL (error);
-			MonoClass *cmod_class = mono_class_get_checked (method->klass->image, sig->ret->modifiers [i].token, &error);
-			g_assert (mono_error_ok (&error));
+			MonoClass *cmod_class = mono_class_get_checked (method->klass->image, sig->ret->modifiers [i].token, error);
+			g_assert (mono_error_ok (error));
 			if ((cmod_class->image == mono_defaults.corlib) && !strcmp (cmod_class->name_space, "System.Runtime.CompilerServices")) {
 				if (!strcmp (cmod_class->name, "CallConvCdecl"))
 					csig->call_convention = MONO_CALL_C;
@@ -8969,8 +8969,8 @@ mono_marshal_get_managed_wrapper (MonoMethod *method, MonoClass *delegate_klass,
 			MonoBoolean set_last_error = 0;
 			ERROR_DECL (error);
 
-			mono_reflection_create_custom_attr_data_args (mono_defaults.corlib, attr->ctor, attr->data, attr->data_size, &typed_args, &named_args, &arginfo, &error);
-			g_assert (mono_error_ok (&error));
+			mono_reflection_create_custom_attr_data_args (mono_defaults.corlib, attr->ctor, attr->data, attr->data_size, &typed_args, &named_args, &arginfo, error);
+			g_assert (mono_error_ok (error));
 			g_assert (mono_array_length (typed_args) == 1);
 
 			/* typed args */
@@ -9052,9 +9052,9 @@ mono_marshal_get_vtfixup_ftnptr (MonoImage *image, guint32 token, guint16 type)
 
 	g_assert (token);
 
-	method = mono_get_method_checked (image, token, NULL, NULL, &error);
+	method = mono_get_method_checked (image, token, NULL, NULL, error);
 	if (!method)
-		g_error ("Could not load vtfixup token 0x%x due to %s", token, mono_error_get_message (&error));
+		g_error ("Could not load vtfixup token 0x%x due to %s", token, mono_error_get_message (error));
 	g_assert (method);
 
 	if (type & (VTFIXUP_TYPE_FROM_UNMANAGED | VTFIXUP_TYPE_FROM_UNMANAGED_RETAIN_APPDOMAIN)) {
@@ -9098,8 +9098,8 @@ mono_marshal_get_vtfixup_ftnptr (MonoImage *image, guint32 token, guint16 type)
 				mono_metadata_free_marshal_spec (mspecs [i]);
 		g_free (mspecs);
 
-		gpointer compiled_ptr = mono_compile_method_checked (method, &error);
-		mono_error_assert_ok (&error);
+		gpointer compiled_ptr = mono_compile_method_checked (method, error);
+		mono_error_assert_ok (error);
 		return compiled_ptr;
 	}
 
@@ -9123,8 +9123,8 @@ mono_marshal_get_vtfixup_ftnptr (MonoImage *image, guint32 token, guint16 type)
 	method = mono_mb_create (mb, sig, param_count, NULL);
 	mono_mb_free (mb);
 
-	gpointer compiled_ptr = mono_compile_method_checked (method, &error);
-	mono_error_assert_ok (&error);
+	gpointer compiled_ptr = mono_compile_method_checked (method, error);
+	mono_error_assert_ok (error);
 	return compiled_ptr;
 }
 
@@ -9261,8 +9261,8 @@ static MonoObject *
 mono_marshal_isinst_with_cache (MonoObject *obj, MonoClass *klass, uintptr_t *cache)
 {
 	ERROR_DECL (error);
-	MonoObject *isinst = mono_object_isinst_checked (obj, klass, &error);
-	if (mono_error_set_pending_exception (&error))
+	MonoObject *isinst = mono_object_isinst_checked (obj, klass, error);
+	if (mono_error_set_pending_exception (error))
 		return NULL;
 
 	if (mono_object_is_transparent_proxy (obj))
@@ -9530,8 +9530,8 @@ mono_marshal_get_synchronized_inner_wrapper (MonoMethod *method)
 	mono_mb_free (mb);
 	if (ctx) {
 		ERROR_DECL (error);
-		res = mono_class_inflate_generic_method_checked (res, ctx, &error);
-		g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+		res = mono_class_inflate_generic_method_checked (res, ctx, error);
+		g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 	}
 	return res;
 }
@@ -9684,8 +9684,8 @@ mono_marshal_get_synchronized_wrapper (MonoMethod *method)
 
 	if (ctx) {
 		ERROR_DECL (error);
-		mono_mb_emit_managed_call (mb, mono_class_inflate_generic_method_checked (method, &container->context, &error), NULL);
-		g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+		mono_mb_emit_managed_call (mb, mono_class_inflate_generic_method_checked (method, &container->context, error), NULL);
+		g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 	} else {
 		mono_mb_emit_managed_call (mb, method, NULL);
 	}
@@ -10812,8 +10812,8 @@ mono_marshal_get_array_accessor_wrapper (MonoMethod *method)
 
 	if (ctx) {
 		ERROR_DECL (error);
-		mono_mb_emit_managed_call (mb, mono_class_inflate_generic_method_checked (method, &container->context, &error), NULL);
-		g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+		mono_mb_emit_managed_call (mb, mono_class_inflate_generic_method_checked (method, &container->context, error), NULL);
+		g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 	} else {
 		mono_mb_emit_managed_call (mb, method, NULL);
 	}
@@ -10871,9 +10871,9 @@ static void*
 ves_icall_marshal_alloc (gsize size)
 {
 	ERROR_DECL (error);
-	void *ret = mono_marshal_alloc (size, &error);
-	if (!mono_error_ok (&error)) {
-		mono_error_set_pending_exception (&error);
+	void *ret = mono_marshal_alloc (size, error);
+	if (!mono_error_ok (error)) {
+		mono_error_set_pending_exception (error);
 		return NULL;
 	}
 
@@ -10928,9 +10928,9 @@ mono_marshal_string_to_utf16_copy (MonoString *s)
 		return NULL;
 	} else {
 		ERROR_DECL (error);
-		gunichar2 *res = (gunichar2 *)mono_marshal_alloc ((mono_string_length (s) * 2) + 2, &error);
-		if (!mono_error_ok (&error)) {
-			mono_error_set_pending_exception (&error);
+		gunichar2 *res = (gunichar2 *)mono_marshal_alloc ((mono_string_length (s) * 2) + 2, error);
+		if (!mono_error_ok (error)) {
+			mono_error_set_pending_exception (error);
 			return NULL;
 		}
 		memcpy (res, mono_string_chars (s), mono_string_length (s) * 2);
@@ -11053,12 +11053,12 @@ ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringAnsi_len (char *ptr,
 {
 	ERROR_DECL (error);
 	MonoString *result = NULL;
-	error_init (&error);
+	error_init (error);
 	if (ptr == NULL)
-		mono_error_set_argument_null (&error, "ptr", "");
+		mono_error_set_argument_null (error, "ptr", "");
 	else
-		result = mono_string_new_len_checked (mono_domain_get (), ptr, len, &error);
-	mono_error_set_pending_exception (&error);
+		result = mono_string_new_len_checked (mono_domain_get (), ptr, len, error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 
@@ -11077,9 +11077,9 @@ ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringUni (guint16 *ptr)
 	while (*t++)
 		len++;
 
-	res = mono_string_new_utf16_checked (domain, ptr, len, &error);
-	if (!mono_error_ok (&error)) {
-		mono_error_set_pending_exception (&error);
+	res = mono_string_new_utf16_checked (domain, ptr, len, error);
+	if (!mono_error_ok (error)) {
+		mono_error_set_pending_exception (error);
 		return NULL;
 	}
 	return res;
@@ -11092,17 +11092,17 @@ ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringUni_len (guint16 *pt
 	MonoString *res = NULL;
 	MonoDomain *domain = mono_domain_get (); 
 
-	error_init (&error);
+	error_init (error);
 
 	if (ptr == NULL) {
 		res = NULL;
-		mono_error_set_argument_null (&error, "ptr", "");
+		mono_error_set_argument_null (error, "ptr", "");
 	} else {
-		res = mono_string_new_utf16_checked (domain, ptr, len, &error);
+		res = mono_string_new_utf16_checked (domain, ptr, len, error);
 	}
 
-	if (!mono_error_ok (&error))
-		mono_error_set_pending_exception (&error);
+	if (!mono_error_ok (error))
+		mono_error_set_pending_exception (error);
 	return res;
 }
 
@@ -11161,9 +11161,9 @@ ves_icall_System_Runtime_InteropServices_Marshal_StructureToPtr (MonoObject *obj
 	pa [1] = &dst;
 	pa [2] = &delete_old;
 
-	mono_runtime_invoke_checked (method, NULL, pa, &error);
-	if (!mono_error_ok (&error))
-		mono_error_set_pending_exception (&error);
+	mono_runtime_invoke_checked (method, NULL, pa, error);
+	if (!mono_error_ok (error))
+		mono_error_set_pending_exception (error);
 }
 
 static void
@@ -11205,9 +11205,9 @@ ves_icall_System_Runtime_InteropServices_Marshal_PtrToStructure (gpointer src, M
 		return;
 	}
 
-	ptr_to_structure (src, dst, &error);
-	if (!mono_error_ok (&error))
-		mono_error_set_pending_exception (&error);
+	ptr_to_structure (src, dst, error);
+	if (!mono_error_ok (error))
+		mono_error_set_pending_exception (error);
 }
 
 MonoObject *
@@ -11228,15 +11228,15 @@ ves_icall_System_Runtime_InteropServices_Marshal_PtrToStructure_type (gpointer s
 		return NULL;
 	}
 
-	res = mono_object_new_checked (domain, klass, &error);
-	if (!mono_error_ok (&error)) {
-		mono_error_set_pending_exception (&error);
+	res = mono_object_new_checked (domain, klass, error);
+	if (!mono_error_ok (error)) {
+		mono_error_set_pending_exception (error);
 		return NULL;
 	}
 
-	ptr_to_structure (src, res, &error);
-	if (!mono_error_ok (&error)) {
-		mono_error_set_pending_exception (&error);
+	ptr_to_structure (src, res, error);
+	if (!mono_error_ok (error)) {
+		mono_error_set_pending_exception (error);
 		return NULL;
 	}
 
@@ -11304,8 +11304,8 @@ gpointer
 ves_icall_System_Runtime_InteropServices_Marshal_StringToHGlobalAnsi (MonoString *string)
 {
 	ERROR_DECL (error);
-	char *ret = mono_string_to_utf8_checked (string, &error);
-	mono_error_set_pending_exception (&error);
+	char *ret = mono_string_to_utf8_checked (string, error);
+	mono_error_set_pending_exception (error);
 	return ret;
 }
 
@@ -11991,9 +11991,9 @@ mono_marshal_asany (MonoObject *o, MonoMarshalNative string_encoding, int param_
 		if (klass->valuetype && (mono_class_is_explicit_layout (klass) || klass->blittable || klass->enumtype))
 			return mono_object_unbox (o);
 
-		res = mono_marshal_alloc (mono_class_native_size (klass, NULL), &error);
-		if (!mono_error_ok (&error)) {
-			mono_error_set_pending_exception (&error);
+		res = mono_marshal_alloc (mono_class_native_size (klass, NULL), error);
+		if (!mono_error_ok (error)) {
+			mono_error_set_pending_exception (error);
 			return NULL;
 		}
 
@@ -12004,9 +12004,9 @@ mono_marshal_asany (MonoObject *o, MonoMarshalNative string_encoding, int param_
 			pa [1] = &res;
 			pa [2] = &delete_old;
 
-			mono_runtime_invoke_checked (method, NULL, pa, &error);
-			if (!mono_error_ok (&error)) {
-				mono_error_set_pending_exception (&error);
+			mono_runtime_invoke_checked (method, NULL, pa, error);
+			if (!mono_error_ok (error)) {
+				mono_error_set_pending_exception (error);
 				return NULL;
 			}
 		}
@@ -12062,9 +12062,9 @@ mono_marshal_free_asany (MonoObject *o, gpointer ptr, MonoMarshalNative string_e
 			pa [0] = &ptr;
 			pa [1] = o;
 
-			mono_runtime_invoke_checked (method, NULL, pa, &error);
-			if (!mono_error_ok (&error)) {
-				mono_error_set_pending_exception (&error);
+			mono_runtime_invoke_checked (method, NULL, pa, error);
+			if (!mono_error_ok (error)) {
+				mono_error_set_pending_exception (error);
 				return;
 			}
 		}

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -999,19 +999,19 @@ mono_string_utf8_to_builder (MonoStringBuilder *sb, char *text)
 	if (!sb || !text)
 		return;
 
-	GError *error = NULL;
+	GError *gerror = NULL;
 	glong copied;
-	gunichar2* ut = g_utf8_to_utf16 (text, strlen (text), NULL, &copied, &error);
+	gunichar2* ut = g_utf8_to_utf16 (text, strlen (text), NULL, &copied, &gerror);
 	int capacity = mono_string_builder_capacity (sb);
 
 	if (copied > capacity)
 		copied = capacity;
 
-	if (!error) {
+	if (!gerror) {
 		MONO_OBJECT_SETREF (sb, chunkPrevious, NULL);
 		mono_string_utf16_to_builder_copy (sb, ut, copied);
 	} else
-		g_error_free (error);
+		g_error_free (gerror);
 
 	g_free (ut);
 }

--- a/mono/metadata/metadata-verify.c
+++ b/mono/metadata/metadata-verify.c
@@ -1802,11 +1802,11 @@ get_enum_by_encoded_name (VerifyContext *ctx, const char **_ptr, const char *end
 
 	enum_name = (char *)g_memdup (str_start, str_len + 1);
 	enum_name [str_len] = 0;
-	type = mono_reflection_type_from_name_checked (enum_name, ctx->image, &error);
-	if (!type || !is_ok (&error)) {
-		ADD_ERROR_NO_RETURN (ctx, g_strdup_printf ("CustomAttribute: Invalid enum class %s, due to %s", enum_name, mono_error_get_message (&error)));
+	type = mono_reflection_type_from_name_checked (enum_name, ctx->image, error);
+	if (!type || !is_ok (error)) {
+		ADD_ERROR_NO_RETURN (ctx, g_strdup_printf ("CustomAttribute: Invalid enum class %s, due to %s", enum_name, mono_error_get_message (error)));
 		g_free (enum_name);
-		mono_error_cleanup (&error);
+		mono_error_cleanup (error);
 		return NULL;
 	}
 	g_free (enum_name);
@@ -1965,10 +1965,10 @@ is_valid_cattr_content (VerifyContext *ctx, MonoMethod *ctor, const char *ptr, g
 	if (!ctor)
 		FAIL (ctx, g_strdup ("CustomAttribute: Invalid constructor"));
 
-	sig = mono_method_signature_checked (ctor, &error);
-	if (!mono_error_ok (&error)) {
-		ADD_ERROR_NO_RETURN (ctx, g_strdup_printf ("CustomAttribute: Invalid constructor signature %s", mono_error_get_message (&error)));
-		mono_error_cleanup (&error);
+	sig = mono_method_signature_checked (ctor, error);
+	if (!mono_error_ok (error)) {
+		ADD_ERROR_NO_RETURN (ctx, g_strdup_printf ("CustomAttribute: Invalid constructor signature %s", mono_error_get_message (error)));
+		mono_error_cleanup (error);
 		return FALSE;
 	}
 
@@ -2409,8 +2409,8 @@ verify_typeref_table (VerifyContext *ctx)
 	guint32 i;
 
 	for (i = 0; i < table->rows; ++i) {
-		mono_verifier_verify_typeref_row (ctx->image, i, &error);
-		add_from_mono_error (ctx, &error);
+		mono_verifier_verify_typeref_row (ctx->image, i, error);
+		add_from_mono_error (ctx, error);
 	}
 }
 
@@ -2969,11 +2969,11 @@ verify_cattr_table_full (VerifyContext *ctx)
 			ADD_ERROR (ctx, g_strdup_printf ("Invalid CustomAttribute constructor row %d Token 0x%08x", i, data [MONO_CUSTOM_ATTR_TYPE]));
 		}
 
-		ctor = mono_get_method_checked (ctx->image, mtoken, NULL, NULL, &error);
+		ctor = mono_get_method_checked (ctx->image, mtoken, NULL, NULL, error);
 
 		if (!ctor) {
-			ADD_ERROR (ctx, g_strdup_printf ("Invalid CustomAttribute content row %d Could not load ctor due to %s", i, mono_error_get_message (&error)));
-			mono_error_cleanup (&error);
+			ADD_ERROR (ctx, g_strdup_printf ("Invalid CustomAttribute content row %d Could not load ctor due to %s", i, mono_error_get_message (error)));
+			mono_error_cleanup (error);
 		}
 
 		/*This can't fail since this is checked in is_valid_cattr_blob*/

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -6278,7 +6278,7 @@ mono_class_get_overrides_full (MonoImage *image, guint32 type_token, MonoMethod 
 	guint32 cols [MONO_METHODIMPL_SIZE];
 	MonoMethod **result;
 	
-	error_init (error)
+	error_init (error);
 
 	*overrides = NULL;
 	if (num_overrides)

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -1452,8 +1452,8 @@ MonoArrayType *
 mono_metadata_parse_array (MonoImage *m, const char *ptr, const char **rptr)
 {
 	ERROR_DECL (error);
-	MonoArrayType *ret = mono_metadata_parse_array_internal (m, NULL, FALSE, ptr, rptr, &error);
-	mono_error_cleanup (&error);
+	MonoArrayType *ret = mono_metadata_parse_array_internal (m, NULL, FALSE, ptr, rptr, error);
+	mono_error_cleanup (error);
 
 	return ret;
 }
@@ -1857,8 +1857,8 @@ mono_metadata_parse_type (MonoImage *m, MonoParseTypeMode mode, short opt_attrs,
 			  const char *ptr, const char **rptr)
 {
 	ERROR_DECL (error);
-	MonoType * type = mono_metadata_parse_type_internal (m, NULL, opt_attrs, FALSE, ptr, rptr, &error);
-	mono_error_cleanup (&error);
+	MonoType * type = mono_metadata_parse_type_internal (m, NULL, opt_attrs, FALSE, ptr, rptr, error);
+	mono_error_cleanup (error);
 	return type;
 }
 
@@ -1940,8 +1940,8 @@ mono_metadata_parse_signature (MonoImage *image, guint32 token)
 {
 	ERROR_DECL (error);
 	MonoMethodSignature *ret;
-	ret = mono_metadata_parse_signature_checked (image, token, &error);
-	mono_error_cleanup (&error);
+	ret = mono_metadata_parse_signature_checked (image, token, error);
+	mono_error_cleanup (error);
 	return ret;
 }
 
@@ -2242,8 +2242,8 @@ mono_metadata_parse_method_signature (MonoImage *m, int def, const char *ptr, co
 	 */
 	ERROR_DECL (error);
 	MonoMethodSignature *ret;
-	ret = mono_metadata_parse_method_signature_full (m, NULL, def, ptr, rptr, &error);
-	mono_error_assert_ok (&error);
+	ret = mono_metadata_parse_method_signature_full (m, NULL, def, ptr, rptr, error);
+	mono_error_assert_ok (error);
 
 	return ret;
 }
@@ -4093,8 +4093,8 @@ MonoMethodHeader *
 mono_metadata_parse_mh (MonoImage *m, const char *ptr)
 {
 	ERROR_DECL (error);
-	MonoMethodHeader *header = mono_metadata_parse_mh_full (m, NULL, ptr, &error);
-	mono_error_cleanup (&error);
+	MonoMethodHeader *header = mono_metadata_parse_mh_full (m, NULL, ptr, error);
+	mono_error_cleanup (error);
 	return header;
 }
 
@@ -4231,8 +4231,8 @@ MonoType *
 mono_metadata_parse_field_type (MonoImage *m, short field_flags, const char *ptr, const char **rptr)
 {
 	ERROR_DECL (error);
-	MonoType * type = mono_metadata_parse_type_internal (m, NULL, field_flags, FALSE, ptr, rptr, &error);
-	mono_error_cleanup (&error);
+	MonoType * type = mono_metadata_parse_type_internal (m, NULL, field_flags, FALSE, ptr, rptr, error);
+	mono_error_cleanup (error);
 	return type;
 }
 
@@ -4250,8 +4250,8 @@ MonoType *
 mono_metadata_parse_param (MonoImage *m, const char *ptr, const char **rptr)
 {
 	ERROR_DECL (error);
-	MonoType * type = mono_metadata_parse_type_internal (m, NULL, 0, FALSE, ptr, rptr, &error);
-	mono_error_cleanup (&error);
+	MonoType * type = mono_metadata_parse_type_internal (m, NULL, 0, FALSE, ptr, rptr, error);
+	mono_error_cleanup (error);
 	return type;
 }
 
@@ -4586,8 +4586,8 @@ mono_metadata_interfaces_from_typedef (MonoImage *meta, guint32 index, guint *co
 	MonoClass **interfaces = NULL;
 	gboolean rv;
 
-	rv = mono_metadata_interfaces_from_typedef_full (meta, index, &interfaces, count, TRUE, NULL, &error);
-	mono_error_assert_ok (&error);
+	rv = mono_metadata_interfaces_from_typedef_full (meta, index, &interfaces, count, TRUE, NULL, error);
+	mono_error_assert_ok (error);
 	if (rv)
 		return interfaces;
 	else
@@ -5848,9 +5848,9 @@ MonoType *
 mono_type_create_from_typespec (MonoImage *image, guint32 type_spec)
 {
 	ERROR_DECL (error);
-	MonoType *type = mono_type_create_from_typespec_checked (image, type_spec, &error);
+	MonoType *type = mono_type_create_from_typespec_checked (image, type_spec, error);
 	if (!type)
-		 g_error ("Could not create typespec %x due to %s", type_spec, mono_error_get_message (&error));
+		 g_error ("Could not create typespec %x due to %s", type_spec, mono_error_get_message (error));
 	return type;
 }
 

--- a/mono/metadata/mono-mlist.c
+++ b/mono/metadata/mono-mlist.c
@@ -46,8 +46,8 @@ MonoMList*
 mono_mlist_alloc (MonoObject *data)
 {
 	ERROR_DECL (error);
-	MonoMList *result = mono_mlist_alloc_checked (data, &error);
-	mono_error_cleanup (&error);
+	MonoMList *result = mono_mlist_alloc_checked (data, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -172,8 +172,8 @@ MonoMList*
 mono_mlist_prepend (MonoMList* list, MonoObject *data)
 {
 	ERROR_DECL (error);
-	MonoMList *result = mono_mlist_prepend_checked (list, data, &error);
-	mono_error_cleanup (&error);
+	MonoMList *result = mono_mlist_prepend_checked (list, data, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -210,8 +210,8 @@ MonoMList*
 mono_mlist_append (MonoMList* list, MonoObject *data)
 {
 	ERROR_DECL (error);
-	MonoMList *result = mono_mlist_append_checked (list, data, &error);
-	mono_error_cleanup (&error);
+	MonoMList *result = mono_mlist_append_checked (list, data, error);
+	mono_error_cleanup (error);
 	return result;
 }
 

--- a/mono/metadata/mono-route.c
+++ b/mono/metadata/mono-route.c
@@ -34,8 +34,8 @@ extern MonoBoolean ves_icall_System_Net_NetworkInformation_MacOsIPInterfacePrope
 
 	MonoDomain *domain = mono_domain_get ();
 
-	ifacename = mono_string_to_utf8_checked(iface, &error);
-	if (mono_error_set_pending_exception (&error))
+	ifacename = mono_string_to_utf8_checked(iface, error);
+	if (mono_error_set_pending_exception (error))
 		return FALSE;
 
 	if ((ifindex = if_nametoindex(ifacename)) == 0)
@@ -76,8 +76,8 @@ extern MonoBoolean ves_icall_System_Net_NetworkInformation_MacOsIPInterfacePrope
 		num_gws++;
 	}
 
-	*gw_addr_list = mono_array_new_checked (domain, mono_get_string_class (), num_gws, &error);
-	goto_if_nok (&error, leave);
+	*gw_addr_list = mono_array_new_checked (domain, mono_get_string_class (), num_gws, error);
+	goto_if_nok (error, leave);
 
 	for (next = buf; next < lim; next += rtm->rtm_msglen) {
 		rtm = (struct rt_msghdr *)next;
@@ -103,14 +103,14 @@ extern MonoBoolean ves_icall_System_Net_NetworkInformation_MacOsIPInterfacePrope
 			// snprintf output truncated
 			continue;
 
-		addr_string = mono_string_new_checked (domain, addr, &error);
-		goto_if_nok (&error, leave);
+		addr_string = mono_string_new_checked (domain, addr, error);
+		goto_if_nok (error, leave);
 		mono_array_setref (*gw_addr_list, gwnum, addr_string);
 		gwnum++;
 	}
 leave:
 	g_free (buf);
-	return is_ok (&error);
+	return is_ok (error);
 }
 
 in_addr_t gateway_from_rtm(struct rt_msghdr *rtm)

--- a/mono/metadata/mono-security-windows-uwp.c
+++ b/mono/metadata/mono-security-windows-uwp.c
@@ -34,7 +34,7 @@ ves_icall_System_Security_Principal_WindowsIdentity_GetCurrentToken (MonoError *
 MonoArray*
 ves_icall_System_Security_Principal_WindowsIdentity_GetRoles (gpointer token)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("GetTokenInformation");
@@ -50,7 +50,7 @@ ves_icall_System_Security_Principal_WindowsIdentity_GetRoles (gpointer token)
 gpointer
 ves_icall_System_Security_Principal_WindowsImpersonationContext_DuplicateToken (gpointer token)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("DuplicateToken");
@@ -66,7 +66,7 @@ ves_icall_System_Security_Principal_WindowsImpersonationContext_DuplicateToken (
 gboolean
 ves_icall_System_Security_Principal_WindowsImpersonationContext_SetCurrentToken (gpointer token)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("ImpersonateLoggedOnUser");
@@ -82,7 +82,7 @@ ves_icall_System_Security_Principal_WindowsImpersonationContext_SetCurrentToken 
 gboolean
 ves_icall_System_Security_Principal_WindowsImpersonationContext_RevertToSelf (void)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("RevertToSelf");
@@ -98,7 +98,7 @@ ves_icall_System_Security_Principal_WindowsImpersonationContext_RevertToSelf (vo
 gint32
 mono_security_win_get_token_name (gpointer token, gunichar2 ** uniname)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("GetTokenInformation");
@@ -114,7 +114,7 @@ mono_security_win_get_token_name (gpointer token, gunichar2 ** uniname)
 gboolean
 mono_security_win_is_machine_protected (gunichar2 *path)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("GetNamedSecurityInfo, LocalFree");
@@ -130,7 +130,7 @@ mono_security_win_is_machine_protected (gunichar2 *path)
 gboolean
 mono_security_win_is_user_protected (gunichar2 *path)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("GetNamedSecurityInfo, LocalFree");
@@ -146,7 +146,7 @@ mono_security_win_is_user_protected (gunichar2 *path)
 gboolean
 mono_security_win_protect_machine (gunichar2 *path)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("BuildTrusteeWithSid, SetEntriesInAcl, SetNamedSecurityInfo, LocalFree, FreeSid");
@@ -162,7 +162,7 @@ mono_security_win_protect_machine (gunichar2 *path)
 gboolean
 mono_security_win_protect_user (gunichar2 *path)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("BuildTrusteeWithSid, SetEntriesInAcl, SetNamedSecurityInfo, LocalFree");

--- a/mono/metadata/mono-security-windows.c
+++ b/mono/metadata/mono-security-windows.c
@@ -165,8 +165,8 @@ ves_icall_System_Security_Principal_WindowsIdentity_GetRoles (gpointer token)
 			int i=0;
 			int num = tg->GroupCount;
 
-			array = mono_array_new_checked (domain, mono_get_string_class (), num, &error);
-			if (mono_error_set_pending_exception (&error)) {
+			array = mono_array_new_checked (domain, mono_get_string_class (), num, error);
+			if (mono_error_set_pending_exception (error)) {
 				g_free (tg);
 				return NULL;
 			}
@@ -176,11 +176,11 @@ ves_icall_System_Security_Principal_WindowsIdentity_GetRoles (gpointer token)
 				gunichar2 *uniname = GetSidName (NULL, tg->Groups [i].Sid, &size);
 
 				if (uniname) {
-					MonoString *str = mono_string_new_utf16_checked (domain, uniname, size, &error);
-					if (!is_ok (&error)) {
+					MonoString *str = mono_string_new_utf16_checked (domain, uniname, size, error);
+					if (!is_ok (error)) {
 						g_free (uniname);
 						g_free (tg);
-						mono_error_set_pending_exception (&error);
+						mono_error_set_pending_exception (error);
 						return NULL;
 					}
 					mono_array_setref (array, i, str);
@@ -193,8 +193,8 @@ ves_icall_System_Security_Principal_WindowsIdentity_GetRoles (gpointer token)
 
 	if (!array) {
 		/* return empty array of string, i.e. string [0] */
-		array = mono_array_new_checked (domain, mono_get_string_class (), 0, &error);
-		mono_error_set_pending_exception (&error);
+		array = mono_array_new_checked (domain, mono_get_string_class (), 0, error);
+		mono_error_set_pending_exception (error);
 	}
 	return array;
 }

--- a/mono/metadata/mono-security.c
+++ b/mono/metadata/mono-security.c
@@ -338,8 +338,8 @@ ves_icall_System_Security_Principal_WindowsIdentity_GetRoles (gpointer token)
 
 	if (!array) {
 		/* return empty array of string, i.e. string [0] */
-		array = mono_array_new_checked (domain, mono_get_string_class (), 0, &error);
-		mono_error_set_pending_exception (&error);
+		array = mono_array_new_checked (domain, mono_get_string_class (), 0, error);
+		mono_error_set_pending_exception (error);
 	}
 	return array;
 }
@@ -610,15 +610,15 @@ void
 ves_icall_System_Security_SecureString_DecryptInternal (MonoArray *data, MonoObject *scope)
 {
 	ERROR_DECL (error);
-	invoke_protected_memory_method (data, scope, FALSE, &error);
-	mono_error_set_pending_exception (&error);
+	invoke_protected_memory_method (data, scope, FALSE, error);
+	mono_error_set_pending_exception (error);
 }
 void
 ves_icall_System_Security_SecureString_EncryptInternal (MonoArray* data, MonoObject *scope)
 {
 	ERROR_DECL (error);
-	invoke_protected_memory_method (data, scope, TRUE, &error);
-	mono_error_set_pending_exception (&error);
+	invoke_protected_memory_method (data, scope, TRUE, error);
+	mono_error_set_pending_exception (error);
 }
 
 void invoke_protected_memory_method (MonoArray *data, MonoObject *scope, gboolean encrypt, MonoError *error)

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -97,8 +97,8 @@ void
 mono_runtime_object_init (MonoObject *this_obj)
 {
 	ERROR_DECL (error);
-	mono_runtime_object_init_checked (this_obj, &error);
-	mono_error_assert_ok (&error);
+	mono_runtime_object_init_checked (this_obj, error);
+	mono_error_assert_ok (error);
 }
 
 /**
@@ -301,9 +301,9 @@ get_type_init_exception_for_vtable (MonoVTable *vtable)
 			full_name = g_strdup_printf ("%s.%s", klass->name_space, klass->name);
 		else
 			full_name = g_strdup (klass->name);
-		ex = mono_get_exception_type_initialization_checked (full_name, NULL, &error);
+		ex = mono_get_exception_type_initialization_checked (full_name, NULL, error);
 		g_free (full_name);
-		return_val_if_nok (&error, NULL);
+		return_val_if_nok (error, NULL);
 	}
 
 	return ex;
@@ -320,8 +320,8 @@ mono_runtime_class_init (MonoVTable *vtable)
 	MONO_REQ_GC_UNSAFE_MODE;
 	ERROR_DECL (error);
 
-	mono_runtime_class_init_full (vtable, &error);
-	mono_error_assert_ok (&error);
+	mono_runtime_class_init_full (vtable, error);
+	mono_error_assert_ok (error);
 }
 
 /*
@@ -664,8 +664,8 @@ gpointer
 mono_compile_method (MonoMethod *method)
 {
 	ERROR_DECL (error);
-	gpointer result = mono_compile_method_checked (method, &error);
-	mono_error_cleanup (&error);
+	gpointer result = mono_compile_method_checked (method, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -1012,8 +1012,8 @@ MonoString*
 ves_icall_string_alloc (int length)
 {
 	ERROR_DECL (error);
-	MonoString *str = mono_string_new_size_checked (mono_domain_get (), length, &error);
-	mono_error_set_pending_exception (&error);
+	MonoString *str = mono_string_new_size_checked (mono_domain_get (), length, error);
+	mono_error_set_pending_exception (error);
 
 	return str;
 }
@@ -1135,8 +1135,8 @@ field_is_special_static (MonoClass *fklass, MonoClassField *field)
 	ERROR_DECL (error);
 	MonoCustomAttrInfo *ainfo;
 	int i;
-	ainfo = mono_custom_attrs_from_field_checked (fklass, field, &error);
-	mono_error_cleanup (&error); /* FIXME don't swallow the error? */
+	ainfo = mono_custom_attrs_from_field_checked (fklass, field, error);
+	mono_error_cleanup (error); /* FIXME don't swallow the error? */
 	if (!ainfo)
 		return FALSE;
 	for (i = 0; i < ainfo->num_attrs; ++i) {
@@ -1795,8 +1795,8 @@ MonoVTable *
 mono_class_vtable (MonoDomain *domain, MonoClass *klass)
 {
 	ERROR_DECL (error);
-	MonoVTable* vtable = mono_class_vtable_checked (domain, klass, &error);
-	mono_error_cleanup (&error);
+	MonoVTable* vtable = mono_class_vtable_checked (domain, klass, error);
+	mono_error_cleanup (error);
 	return vtable;
 }
 
@@ -2812,8 +2812,8 @@ mono_object_get_virtual_method (MonoObject *obj_raw, MonoMethod *method)
 	HANDLE_FUNCTION_ENTER ();
 	ERROR_DECL (error);
 	MONO_HANDLE_DCL (MonoObject, obj);
-	MonoMethod *result = mono_object_handle_get_virtual_method (obj, method, &error);
-	mono_error_assert_ok (&error);
+	MonoMethod *result = mono_object_handle_get_virtual_method (obj, method, error);
+	mono_error_assert_ok (error);
 	HANDLE_FUNCTION_RETURN_VAL (result);
 }
 
@@ -2967,14 +2967,14 @@ mono_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **
 	ERROR_DECL (error);
 	MonoObject *res;
 	if (exc) {
-		res = mono_runtime_try_invoke (method, obj, params, exc, &error);
-		if (*exc == NULL && !mono_error_ok(&error)) {
-			*exc = (MonoObject*) mono_error_convert_to_exception (&error);
+		res = mono_runtime_try_invoke (method, obj, params, exc, error);
+		if (*exc == NULL && !mono_error_ok(error)) {
+			*exc = (MonoObject*) mono_error_convert_to_exception (error);
 		} else
-			mono_error_cleanup (&error);
+			mono_error_cleanup (error);
 	} else {
-		res = mono_runtime_invoke_checked (method, obj, params, &error);
-		mono_error_raise_exception_deprecated (&error); /* OK to throw, external only without a good alternative */
+		res = mono_runtime_invoke_checked (method, obj, params, error);
+		mono_error_raise_exception_deprecated (error); /* OK to throw, external only without a good alternative */
 	}
 	return res;
 }
@@ -3145,8 +3145,8 @@ mono_method_get_unmanaged_thunk (MonoMethod *method)
 
 	MONO_ENTER_GC_UNSAFE;
 	method = mono_marshal_get_thunk_invoke_wrapper (method);
-	res = mono_compile_method_checked (method, &error);
-	mono_error_cleanup (&error);
+	res = mono_compile_method_checked (method, error);
+	mono_error_cleanup (error);
 	MONO_EXIT_GC_UNSAFE;
 
 	return res;
@@ -3395,8 +3395,8 @@ MonoObject *
 mono_field_get_value_object (MonoDomain *domain, MonoClassField *field, MonoObject *obj)
 {	
 	ERROR_DECL (error);
-	MonoObject* result = mono_field_get_value_object_checked (domain, field, obj, &error);
-	mono_error_assert_ok (&error);
+	MonoObject* result = mono_field_get_value_object_checked (domain, field, obj, error);
+	mono_error_assert_ok (error);
 	return result;
 }
 
@@ -3667,8 +3667,8 @@ mono_field_static_get_value (MonoVTable *vt, MonoClassField *field, void *value)
 	MONO_REQ_GC_NEUTRAL_MODE;
 
 	ERROR_DECL (error);
-	mono_field_static_get_value_checked (vt, field, value, &error);
-	mono_error_cleanup (&error);
+	mono_field_static_get_value_checked (vt, field, value, error);
+	mono_error_cleanup (error);
 }
 
 /**
@@ -3718,11 +3718,11 @@ mono_property_set_value (MonoProperty *prop, void *obj, void **params, MonoObjec
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	ERROR_DECL (error);
-	do_runtime_invoke (prop->set, obj, params, exc, &error);
-	if (exc && *exc == NULL && !mono_error_ok (&error)) {
-		*exc = (MonoObject*) mono_error_convert_to_exception (&error);
+	do_runtime_invoke (prop->set, obj, params, exc, error);
+	if (exc && *exc == NULL && !mono_error_ok (error)) {
+		*exc = (MonoObject*) mono_error_convert_to_exception (error);
 	} else {
-		mono_error_cleanup (&error);
+		mono_error_cleanup (error);
 	}
 }
 
@@ -3773,11 +3773,11 @@ mono_property_get_value (MonoProperty *prop, void *obj, void **params, MonoObjec
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	ERROR_DECL (error);
-	MonoObject *val = do_runtime_invoke (prop->get, obj, params, exc, &error);
-	if (exc && *exc == NULL && !mono_error_ok (&error)) {
-		*exc = (MonoObject*) mono_error_convert_to_exception (&error);
+	MonoObject *val = do_runtime_invoke (prop->get, obj, params, exc, error);
+	if (exc && *exc == NULL && !mono_error_ok (error)) {
+		*exc = (MonoObject*) mono_error_convert_to_exception (error);
 	} else {
-		mono_error_cleanup (&error); /* FIXME don't raise here */
+		mono_error_cleanup (error); /* FIXME don't raise here */
 	}
 
 	return val;
@@ -4010,18 +4010,18 @@ mono_runtime_delegate_invoke (MonoObject *delegate, void **params, MonoObject **
 
 	ERROR_DECL (error);
 	if (exc) {
-		MonoObject *result = mono_runtime_delegate_try_invoke (delegate, params, exc, &error);
+		MonoObject *result = mono_runtime_delegate_try_invoke (delegate, params, exc, error);
 		if (*exc) {
-			mono_error_cleanup (&error);
+			mono_error_cleanup (error);
 			return NULL;
 		} else {
-			if (!is_ok (&error))
-				*exc = (MonoObject*)mono_error_convert_to_exception (&error);
+			if (!is_ok (error))
+				*exc = (MonoObject*)mono_error_convert_to_exception (error);
 			return result;
 		}
 	} else {
-		MonoObject *result = mono_runtime_delegate_invoke_checked (delegate, params, &error);
-		mono_error_raise_exception_deprecated (&error); /* OK to throw, external only without a good alternative */
+		MonoObject *result = mono_runtime_delegate_invoke_checked (delegate, params, error);
+		mono_error_raise_exception_deprecated (error); /* OK to throw, external only without a good alternative */
 		return result;
 	}
 }
@@ -4093,13 +4093,13 @@ mono_runtime_get_main_args (void)
 	MONO_REQ_GC_UNSAFE_MODE;
 	ERROR_DECL (error);
 	MonoArrayHandle result = MONO_HANDLE_NEW (MonoArray, NULL);
-	error_init (&error);
-	MonoArrayHandle arg_array = mono_runtime_get_main_args_handle (&error);
-	goto_if_nok (&error, leave);
+	error_init (error);
+	MonoArrayHandle arg_array = mono_runtime_get_main_args_handle (error);
+	goto_if_nok (error, leave);
 	MONO_HANDLE_ASSIGN (result, arg_array);
 leave:
 	/* FIXME: better external API that doesn't swallow the error */
-	mono_error_cleanup (&error);
+	mono_error_cleanup (error);
 	HANDLE_FUNCTION_RETURN_OBJ (result);
 }
 
@@ -4270,22 +4270,22 @@ prepare_run_main (MonoMethod *method, int argc, char *argv[])
 	}
 
 	if (sig->param_count) {
-		args = (MonoArray*)mono_array_new_checked (domain, mono_defaults.string_class, argc, &error);
-		mono_error_assert_ok (&error);
+		args = (MonoArray*)mono_array_new_checked (domain, mono_defaults.string_class, argc, error);
+		mono_error_assert_ok (error);
 		for (i = 0; i < argc; ++i) {
 			/* The encodings should all work, given that
 			 * we've checked all these args for the
 			 * main_args array.
 			 */
 			gchar *str = mono_utf8_from_external (argv [i]);
-			MonoString *arg = mono_string_new_checked (domain, str, &error);
-			mono_error_assert_ok (&error);
+			MonoString *arg = mono_string_new_checked (domain, str, error);
+			mono_error_assert_ok (error);
 			mono_array_setref (args, i, arg);
 			g_free (str);
 		}
 	} else {
-		args = (MonoArray*)mono_array_new_checked (domain, mono_defaults.string_class, 0, &error);
-		mono_error_assert_ok (&error);
+		args = (MonoArray*)mono_array_new_checked (domain, mono_defaults.string_class, 0, error);
+		mono_error_assert_ok (error);
 	}
 	
 	mono_assembly_set_main (method->klass->image->assembly);
@@ -4315,8 +4315,8 @@ mono_runtime_run_main (MonoMethod *method, int argc, char* argv[],
 	if (exc) {
 		res = mono_runtime_try_exec_main (method, args, exc);
 	} else {
-		res = mono_runtime_exec_main_checked (method, args, &error);
-		mono_error_raise_exception_deprecated (&error); /* OK to throw, external only without a better alternative */
+		res = mono_runtime_exec_main_checked (method, args, error);
+		mono_error_raise_exception_deprecated (error); /* OK to throw, external only without a better alternative */
 	}
 	return res;
 }
@@ -4387,11 +4387,11 @@ serialize_object (MonoObject *obj, gboolean *failure, MonoObject **exc)
 	params [0] = obj;
 	*exc = NULL;
 
-	array = mono_runtime_try_invoke (serialize_method, NULL, params, exc, &error);
-	if (*exc == NULL && !mono_error_ok (&error))
-		*exc = (MonoObject*) mono_error_convert_to_exception (&error); /* FIXME convert serialize_object to MonoError */
+	array = mono_runtime_try_invoke (serialize_method, NULL, params, exc, error);
+	if (*exc == NULL && !mono_error_ok (error))
+		*exc = (MonoObject*) mono_error_convert_to_exception (error); /* FIXME convert serialize_object to MonoError */
 	else
-		mono_error_cleanup (&error);
+		mono_error_cleanup (error);
 
 	if (*exc)
 		*failure = TRUE;
@@ -4422,11 +4422,11 @@ deserialize_object (MonoObject *obj, gboolean *failure, MonoObject **exc)
 	params [0] = obj;
 	*exc = NULL;
 
-	result = mono_runtime_try_invoke (deserialize_method, NULL, params, exc, &error);
-	if (*exc == NULL && !mono_error_ok (&error))
-		*exc = (MonoObject*) mono_error_convert_to_exception (&error); /* FIXME convert deserialize_object to MonoError */
+	result = mono_runtime_try_invoke (deserialize_method, NULL, params, exc, error);
+	if (*exc == NULL && !mono_error_ok (error))
+		*exc = (MonoObject*) mono_error_convert_to_exception (error); /* FIXME convert deserialize_object to MonoError */
 	else
-		mono_error_cleanup (&error);
+		mono_error_cleanup (error);
 
 	if (*exc)
 		*failure = TRUE;
@@ -4567,11 +4567,11 @@ call_unhandled_exception_delegate (MonoDomain *domain, MonoObject *delegate, Mon
 
 	if (mono_object_domain (exc) != domain) {
 
-		exc = mono_object_xdomain_representation (exc, domain, &error);
+		exc = mono_object_xdomain_representation (exc, domain, error);
 		if (!exc) {
-			if (!is_ok (&error)) {
-				ERROR_DECL (inner_error);
-				MonoException *serialization_exc = mono_error_convert_to_exception (&error);
+			if (!is_ok (error)) {
+				ERROR_DECL_VALUE (inner_error);
+				MonoException *serialization_exc = mono_error_convert_to_exception (error);
 				exc = mono_object_xdomain_representation ((MonoObject*)serialization_exc, domain, &inner_error);
 				mono_error_assert_ok (&inner_error);
 			} else {
@@ -4584,24 +4584,24 @@ call_unhandled_exception_delegate (MonoDomain *domain, MonoObject *delegate, Mon
 	g_assert (mono_object_domain (exc) == domain);
 
 	pa [0] = domain->domain;
-	pa [1] = create_unhandled_exception_eventargs (exc, &error);
-	mono_error_assert_ok (&error);
-	mono_runtime_delegate_try_invoke (delegate, pa, &e, &error);
-	if (!is_ok (&error)) {
+	pa [1] = create_unhandled_exception_eventargs (exc, error);
+	mono_error_assert_ok (error);
+	mono_runtime_delegate_try_invoke (delegate, pa, &e, error);
+	if (!is_ok (error)) {
 		if (e == NULL)
-			e = (MonoObject*)mono_error_convert_to_exception (&error);
+			e = (MonoObject*)mono_error_convert_to_exception (error);
 		else
-			mono_error_cleanup (&error);
+			mono_error_cleanup (error);
 	}
 
 	if (domain != current_domain)
 		mono_domain_set_internal_with_options (current_domain, FALSE);
 
 	if (e) {
-		gchar *msg = mono_string_to_utf8_checked (((MonoException *) e)->message, &error);
-		if (!mono_error_ok (&error)) {
+		gchar *msg = mono_string_to_utf8_checked (((MonoException *) e)->message, error);
+		if (!mono_error_ok (error)) {
 			g_warning ("Exception inside UnhandledException handler with invalid message (Invalid characters)\n");
-			mono_error_cleanup (&error);
+			mono_error_cleanup (error);
 		} else {
 			g_warning ("exception inside UnhandledException handler: %s\n", msg);
 			g_free (msg);
@@ -4651,9 +4651,9 @@ mono_unhandled_exception (MonoObject *exc_raw)
 	ERROR_DECL (error);
 	HANDLE_FUNCTION_ENTER ();
 	MONO_HANDLE_DCL (MonoObject, exc);
-	error_init (&error);
-	mono_unhandled_exception_checked (exc, &error);
-	mono_error_assert_ok (&error);
+	error_init (error);
+	mono_unhandled_exception_checked (exc, error);
+	mono_error_assert_ok (error);
 	HANDLE_FUNCTION_RETURN ();
 }
 
@@ -4744,8 +4744,8 @@ mono_runtime_exec_managed_code (MonoDomain *domain,
 				gpointer main_args)
 {
 	ERROR_DECL (error);
-	mono_thread_create_checked (domain, main_func, main_args, &error);
-	mono_error_assert_ok (&error);
+	mono_thread_create_checked (domain, main_func, main_args, error);
+	mono_error_assert_ok (error);
 
 	mono_thread_manage ();
 }
@@ -4766,22 +4766,22 @@ prepare_thread_to_exec_main (MonoDomain *domain, MonoMethod *method)
 		domain->entry_assembly = assembly;
 		/* Domains created from another domain already have application_base and configuration_file set */
 		if (domain->setup->application_base == NULL) {
-			MonoString *basedir = mono_string_new_checked (domain, assembly->basedir, &error);
-			mono_error_assert_ok (&error);
+			MonoString *basedir = mono_string_new_checked (domain, assembly->basedir, error);
+			mono_error_assert_ok (error);
 			MONO_OBJECT_SETREF (domain->setup, application_base, basedir);
 		}
 
 		if (domain->setup->configuration_file == NULL) {
 			str = g_strconcat (assembly->image->name, ".config", NULL);
-			MonoString *config_file = mono_string_new_checked (domain, str, &error);
-			mono_error_assert_ok (&error);
+			MonoString *config_file = mono_string_new_checked (domain, str, error);
+			mono_error_assert_ok (error);
 			MONO_OBJECT_SETREF (domain->setup, configuration_file, config_file);
 			g_free (str);
 			mono_domain_set_options_from_config (domain);
 		}
 	}
 
-	ERROR_DECL (cattr_error);
+	ERROR_DECL_VALUE (cattr_error);
 	cinfo = mono_custom_attrs_from_method_checked (method, &cattr_error);
 	mono_error_cleanup (&cattr_error); /* FIXME warn here? */
 	if (cinfo) {
@@ -4849,7 +4849,7 @@ do_try_exec_main (MonoMethod *method, MonoArray *args, MonoObject **exc)
 
 	/* FIXME: check signature of method */
 	if (mono_method_signature (method)->ret->type == MONO_TYPE_I4) {
-		ERROR_DECL (inner_error);
+		ERROR_DECL_VALUE (inner_error);
 		MonoObject *res;
 		res = mono_runtime_try_invoke (method, NULL, pa, exc, &inner_error);
 		if (*exc == NULL && !mono_error_ok (&inner_error))
@@ -4864,7 +4864,7 @@ do_try_exec_main (MonoMethod *method, MonoArray *args, MonoObject **exc)
 
 		mono_environment_exitcode_set (rval);
 	} else {
-		ERROR_DECL (inner_error);
+		ERROR_DECL_VALUE (inner_error);
 		mono_runtime_try_invoke (method, NULL, pa, exc, &inner_error);
 		if (*exc == NULL && !mono_error_ok (&inner_error))
 			*exc = (MonoObject*) mono_error_convert_to_exception (&inner_error);
@@ -4900,8 +4900,8 @@ mono_runtime_exec_main (MonoMethod *method, MonoArray *args, MonoObject **exc)
 		int rval = do_try_exec_main (method, args, exc);
 		return rval;
 	} else {
-		int rval = do_exec_main_checked (method, args, &error);
-		mono_error_raise_exception_deprecated (&error); /* OK to throw, external only with no better option */
+		int rval = do_exec_main_checked (method, args, error);
+		mono_error_raise_exception_deprecated (error); /* OK to throw, external only with no better option */
 		return rval;
 	}
 }
@@ -5081,18 +5081,18 @@ mono_runtime_invoke_array (MonoMethod *method, void *obj, MonoArray *params,
 {
 	ERROR_DECL (error);
 	if (exc) {
-		MonoObject *result = mono_runtime_try_invoke_array (method, obj, params, exc, &error);
+		MonoObject *result = mono_runtime_try_invoke_array (method, obj, params, exc, error);
 		if (*exc) {
-			mono_error_cleanup (&error);
+			mono_error_cleanup (error);
 			return NULL;
 		} else {
-			if (!is_ok (&error))
-				*exc = (MonoObject*)mono_error_convert_to_exception (&error);
+			if (!is_ok (error))
+				*exc = (MonoObject*)mono_error_convert_to_exception (error);
 			return result;
 		}
 	} else {
-		MonoObject *result = mono_runtime_try_invoke_array (method, obj, params, NULL, &error);
-		mono_error_raise_exception_deprecated (&error); /* OK to throw, external only without a good alternative */
+		MonoObject *result = mono_runtime_try_invoke_array (method, obj, params, NULL, error);
+		mono_error_raise_exception_deprecated (error); /* OK to throw, external only without a good alternative */
 		return result;
 	}
 }
@@ -5321,9 +5321,9 @@ mono_object_new (MonoDomain *domain, MonoClass *klass)
 
 	ERROR_DECL (error);
 
-	MonoObject * result = mono_object_new_checked (domain, klass, &error);
+	MonoObject * result = mono_object_new_checked (domain, klass, error);
 
-	mono_error_cleanup (&error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -5334,9 +5334,9 @@ ves_icall_object_new (MonoDomain *domain, MonoClass *klass)
 
 	ERROR_DECL (error);
 
-	MonoObject * result = mono_object_new_checked (domain, klass, &error);
+	MonoObject * result = mono_object_new_checked (domain, klass, error);
 
-	mono_error_set_pending_exception (&error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 
@@ -5404,8 +5404,8 @@ MonoObject *
 mono_object_new_specific (MonoVTable *vtable)
 {
 	ERROR_DECL (error);
-	MonoObject *o = mono_object_new_specific_checked (vtable, &error);
-	mono_error_cleanup (&error);
+	MonoObject *o = mono_object_new_specific_checked (vtable, error);
+	mono_error_cleanup (error);
 
 	return o;
 }
@@ -5458,8 +5458,8 @@ MonoObject *
 ves_icall_object_new_specific (MonoVTable *vtable)
 {
 	ERROR_DECL (error);
-	MonoObject *o = mono_object_new_specific_checked (vtable, &error);
-	mono_error_set_pending_exception (&error);
+	MonoObject *o = mono_object_new_specific_checked (vtable, error);
+	mono_error_set_pending_exception (error);
 
 	return o;
 }
@@ -5481,8 +5481,8 @@ MonoObject *
 mono_object_new_alloc_specific (MonoVTable *vtable)
 {
 	ERROR_DECL (error);
-	MonoObject *o = mono_object_new_alloc_specific_checked (vtable, &error);
-	mono_error_cleanup (&error);
+	MonoObject *o = mono_object_new_alloc_specific_checked (vtable, error);
+	mono_error_cleanup (error);
 
 	return o;
 }
@@ -5544,8 +5544,8 @@ MonoObject*
 mono_object_new_fast (MonoVTable *vtable)
 {
 	ERROR_DECL (error);
-	MonoObject *o = mono_object_new_fast_checked (vtable, &error);
-	mono_error_cleanup (&error);
+	MonoObject *o = mono_object_new_fast_checked (vtable, error);
+	mono_error_cleanup (error);
 
 	return o;
 }
@@ -5618,12 +5618,12 @@ mono_object_new_from_token  (MonoDomain *domain, MonoImage *image, guint32 token
 	MonoObject *result;
 	MonoClass *klass;
 
-	klass = mono_class_get_checked (image, token, &error);
-	mono_error_assert_ok (&error);
+	klass = mono_class_get_checked (image, token, error);
+	mono_error_assert_ok (error);
 	
-	result = mono_object_new_checked (domain, klass, &error);
+	result = mono_object_new_checked (domain, klass, error);
 
-	mono_error_cleanup (&error);
+	mono_error_cleanup (error);
 	return result;
 	
 }
@@ -5638,8 +5638,8 @@ MonoObject *
 mono_object_clone (MonoObject *obj)
 {
 	ERROR_DECL (error);
-	MonoObject *o = mono_object_clone_checked (obj, &error);
-	mono_error_cleanup (&error);
+	MonoObject *o = mono_object_clone_checked (obj, error);
+	mono_error_cleanup (error);
 
 	return o;
 }
@@ -5778,8 +5778,8 @@ mono_array_clone (MonoArray *array)
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	ERROR_DECL (error);
-	MonoArray *result = mono_array_clone_checked (array, &error);
-	mono_error_cleanup (&error);
+	MonoArray *result = mono_array_clone_checked (array, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -5854,8 +5854,8 @@ MonoArray*
 mono_array_new_full (MonoDomain *domain, MonoClass *array_class, uintptr_t *lengths, intptr_t *lower_bounds)
 {
 	ERROR_DECL (error);
-	MonoArray *array = mono_array_new_full_checked (domain, array_class, lengths, lower_bounds, &error);
-	mono_error_cleanup (&error);
+	MonoArray *array = mono_array_new_full_checked (domain, array_class, lengths, lower_bounds, error);
+	mono_error_cleanup (error);
 
 	return array;
 }
@@ -5966,8 +5966,8 @@ mono_array_new (MonoDomain *domain, MonoClass *eclass, uintptr_t n)
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	ERROR_DECL (error);
-	MonoArray *result = mono_array_new_checked (domain, eclass, n, &error);
-	mono_error_cleanup (&error);
+	MonoArray *result = mono_array_new_checked (domain, eclass, n, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -6000,8 +6000,8 @@ MonoArray*
 ves_icall_array_new (MonoDomain *domain, MonoClass *eclass, uintptr_t n)
 {
 	ERROR_DECL (error);
-	MonoArray *arr = mono_array_new_checked (domain, eclass, n, &error);
-	mono_error_set_pending_exception (&error);
+	MonoArray *arr = mono_array_new_checked (domain, eclass, n, error);
+	mono_error_set_pending_exception (error);
 
 	return arr;
 }
@@ -6017,8 +6017,8 @@ MonoArray *
 mono_array_new_specific (MonoVTable *vtable, uintptr_t n)
 {
 	ERROR_DECL (error);
-	MonoArray *arr = mono_array_new_specific_checked (vtable, n, &error);
-	mono_error_cleanup (&error);
+	MonoArray *arr = mono_array_new_specific_checked (vtable, n, error);
+	mono_error_cleanup (error);
 
 	return arr;
 }
@@ -6056,8 +6056,8 @@ MonoArray*
 ves_icall_array_new_specific (MonoVTable *vtable, uintptr_t n)
 {
 	ERROR_DECL (error);
-	MonoArray *arr = mono_array_new_specific_checked (vtable, n, &error);
-	mono_error_set_pending_exception (&error);
+	MonoArray *arr = mono_array_new_specific_checked (vtable, n, error);
+	mono_error_set_pending_exception (error);
 
 	return arr;
 }
@@ -6100,8 +6100,8 @@ mono_string_new_utf16 (MonoDomain *domain, const guint16 *text, gint32 len)
 
 	ERROR_DECL (error);
 	MonoString *res = NULL;
-	res = mono_string_new_utf16_checked (domain, text, len, &error);
-	mono_error_cleanup (&error);
+	res = mono_string_new_utf16_checked (domain, text, len, error);
+	mono_error_cleanup (error);
 
 	return res;
 }
@@ -6186,8 +6186,8 @@ MonoString *
 mono_string_new_utf32 (MonoDomain *domain, const mono_unichar4 *text, gint32 len)
 {
 	ERROR_DECL (error);
-	MonoString *result = mono_string_new_utf32_checked (domain, text, len, &error);
-	mono_error_cleanup (&error);
+	MonoString *result = mono_string_new_utf32_checked (domain, text, len, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -6201,8 +6201,8 @@ MonoString *
 mono_string_new_size (MonoDomain *domain, gint32 len)
 {
 	ERROR_DECL (error);
-	MonoString *str = mono_string_new_size_checked (domain, len, &error);
-	mono_error_cleanup (&error);
+	MonoString *str = mono_string_new_size_checked (domain, len, error);
+	mono_error_cleanup (error);
 
 	return str;
 }
@@ -6252,8 +6252,8 @@ mono_string_new_len (MonoDomain *domain, const char *text, guint length)
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	ERROR_DECL (error);
-	MonoString *result = mono_string_new_len_checked (domain, text, length, &error);
-	mono_error_cleanup (&error);
+	MonoString *result = mono_string_new_len_checked (domain, text, length, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -6301,15 +6301,15 @@ mono_string_new (MonoDomain *domain, const char *text)
 {
 	ERROR_DECL (error);
 	MonoString *res = NULL;
-	res = mono_string_new_checked (domain, text, &error);
-	if (!is_ok (&error)) {
+	res = mono_string_new_checked (domain, text, error);
+	if (!is_ok (error)) {
 		/* Mono API compatability: assert on Out of Memory errors,
 		 * return NULL otherwise (most likely an invalid UTF-8 byte
 		 * sequence). */
-		if (mono_error_get_error_code (&error) == MONO_ERROR_OUT_OF_MEMORY)
-			mono_error_assert_ok (&error);
+		if (mono_error_get_error_code (error) == MONO_ERROR_OUT_OF_MEMORY)
+			mono_error_assert_ok (error);
 		else
-			mono_error_cleanup (&error);
+			mono_error_cleanup (error);
 	}
 	return res;
 }
@@ -6389,8 +6389,8 @@ mono_string_new_wrapper (const char *text)
 
 	if (text) {
 		ERROR_DECL (error);
-		MonoString *result = mono_string_new_checked (domain, text, &error);
-		mono_error_assert_ok (&error);
+		MonoString *result = mono_string_new_checked (domain, text, error);
+		mono_error_assert_ok (error);
 		return result;
 	}
 
@@ -6407,8 +6407,8 @@ MonoObject *
 mono_value_box (MonoDomain *domain, MonoClass *klass, gpointer value)
 {
 	ERROR_DECL (error);
-	MonoObject *result = mono_value_box_checked (domain, klass, value, &error);
-	mono_error_cleanup (&error);
+	MonoObject *result = mono_value_box_checked (domain, klass, value, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -6605,8 +6605,8 @@ mono_object_isinst (MonoObject *obj_raw, MonoClass *klass)
 	HANDLE_FUNCTION_ENTER ();
 	MONO_HANDLE_DCL (MonoObject, obj);
 	ERROR_DECL (error);
-	MonoObjectHandle result = mono_object_handle_isinst (obj, klass, &error);
-	mono_error_cleanup (&error);
+	MonoObjectHandle result = mono_object_handle_isinst (obj, klass, error);
+	mono_error_cleanup (error);
 	HANDLE_FUNCTION_RETURN_OBJ (result);
 }
 	
@@ -6669,8 +6669,8 @@ mono_object_isinst_mbyref (MonoObject *obj_raw, MonoClass *klass)
 	HANDLE_FUNCTION_ENTER ();
 	ERROR_DECL (error);
 	MONO_HANDLE_DCL (MonoObject, obj);
-	MonoObjectHandle result = mono_object_handle_isinst_mbyref (obj, klass, &error);
-	mono_error_cleanup (&error); /* FIXME better API that doesn't swallow the error */
+	MonoObjectHandle result = mono_object_handle_isinst_mbyref (obj, klass, error);
+	mono_error_cleanup (error); /* FIXME better API that doesn't swallow the error */
 	HANDLE_FUNCTION_RETURN_OBJ (result);
 }
 
@@ -6776,8 +6776,8 @@ mono_object_castclass_mbyref (MonoObject *obj_raw, MonoClass *klass)
 	MonoObjectHandle result = MONO_HANDLE_NEW (MonoObject, NULL);
 	if (MONO_HANDLE_IS_NULL (obj))
 		goto leave;
-	MONO_HANDLE_ASSIGN (result, mono_object_handle_isinst_mbyref (obj, klass, &error));
-	mono_error_cleanup (&error);
+	MONO_HANDLE_ASSIGN (result, mono_object_handle_isinst_mbyref (obj, klass, error));
+	mono_error_cleanup (error);
 leave:
 	HANDLE_FUNCTION_RETURN_OBJ (result);
 }
@@ -6854,9 +6854,9 @@ MonoString*
 mono_string_is_interned (MonoString *o)
 {
 	ERROR_DECL (error);
-	MonoString *result = mono_string_is_interned_lookup (o, FALSE, &error);
+	MonoString *result = mono_string_is_interned_lookup (o, FALSE, error);
 	/* This function does not fail. */
-	mono_error_assert_ok (&error);
+	mono_error_assert_ok (error);
 	return result;
 }
 
@@ -6870,8 +6870,8 @@ MonoString*
 mono_string_intern (MonoString *str)
 {
 	ERROR_DECL (error);
-	MonoString *result = mono_string_intern_checked (str, &error);
-	mono_error_assert_ok (&error);
+	MonoString *result = mono_string_intern_checked (str, error);
+	mono_error_assert_ok (error);
 	return result;
 }
 
@@ -6904,8 +6904,8 @@ MonoString*
 mono_ldstr (MonoDomain *domain, MonoImage *image, guint32 idx)
 {
 	ERROR_DECL (error);
-	MonoString *result = mono_ldstr_checked (domain, image, idx, &error);
-	mono_error_cleanup (&error);
+	MonoString *result = mono_ldstr_checked (domain, image, idx, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -7044,10 +7044,10 @@ mono_string_to_utf8 (MonoString *s)
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	ERROR_DECL (error);
-	char *result = mono_string_to_utf8_checked (s, &error);
+	char *result = mono_string_to_utf8_checked (s, error);
 	
-	if (!is_ok (&error)) {
-		mono_error_cleanup (&error);
+	if (!is_ok (error)) {
+		mono_error_cleanup (error);
 		return NULL;
 	}
 	return result;
@@ -7194,8 +7194,8 @@ MonoString *
 mono_string_from_utf16 (gunichar2 *data)
 {
 	ERROR_DECL (error);
-	MonoString *result = mono_string_from_utf16_checked (data, &error);
-	mono_error_cleanup (&error);
+	MonoString *result = mono_string_from_utf16_checked (data, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -7234,8 +7234,8 @@ MonoString *
 mono_string_from_utf32 (mono_unichar4 *data)
 {
 	ERROR_DECL (error);
-	MonoString *result = mono_string_from_utf32_checked (data, &error);
-	mono_error_cleanup (&error);
+	MonoString *result = mono_string_from_utf32_checked (data, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -7533,24 +7533,24 @@ ves_icall_System_Runtime_Remoting_Messaging_AsyncResult_Invoke (MonoAsyncResult 
 
 	ac = (MonoAsyncCall*) ares->object_data;
 	if (!ac) {
-		res = mono_runtime_delegate_invoke_checked (ares->async_delegate, (void**) &ares->async_state, &error);
-		if (mono_error_set_pending_exception (&error))
+		res = mono_runtime_delegate_invoke_checked (ares->async_delegate, (void**) &ares->async_state, error);
+		if (mono_error_set_pending_exception (error))
 			return NULL;
 	} else {
 		gpointer wait_event = NULL;
 
 		ac->msg->exc = NULL;
 
-		res = mono_message_invoke (ares->async_delegate, ac->msg, &ac->msg->exc, &ac->out_args, &error);
+		res = mono_message_invoke (ares->async_delegate, ac->msg, &ac->msg->exc, &ac->out_args, error);
 
 		/* The exit side of the invoke must not be aborted as it would leave the runtime in an undefined state */
 		mono_threads_begin_abort_protected_block ();
 
 		if (!ac->msg->exc) {
-			MonoException *ex = mono_error_convert_to_exception (&error);
+			MonoException *ex = mono_error_convert_to_exception (error);
 			ac->msg->exc = (MonoObject *)ex;
 		} else {
-			mono_error_cleanup (&error);
+			mono_error_cleanup (error);
 		}
 
 		MONO_OBJECT_SETREF (ac, res, res);
@@ -7564,13 +7564,13 @@ ves_icall_System_Runtime_Remoting_Messaging_AsyncResult_Invoke (MonoAsyncResult 
 		if (wait_event != NULL)
 			mono_w32event_set (wait_event);
 
-		error_init (&error); //the else branch would leave it in an undefined state
+		error_init (error); //the else branch would leave it in an undefined state
 		if (ac->cb_method)
-			mono_runtime_invoke_checked (ac->cb_method, ac->cb_target, (gpointer*) &ares, &error);
+			mono_runtime_invoke_checked (ac->cb_method, ac->cb_target, (gpointer*) &ares, error);
 
 		mono_threads_end_abort_protected_block ();
 
-		if (mono_error_set_pending_exception (&error))
+		if (mono_error_set_pending_exception (error))
 			return NULL;
 	}
 
@@ -7768,14 +7768,14 @@ mono_object_to_string (MonoObject *obj, MonoObject **exc)
 	void *target;
 	MonoMethod *method = prepare_to_string_method (obj, &target);
 	if (exc) {
-		s = (MonoString *) mono_runtime_try_invoke (method, target, NULL, exc, &error);
-		if (*exc == NULL && !mono_error_ok (&error))
-			*exc = (MonoObject*) mono_error_convert_to_exception (&error);
+		s = (MonoString *) mono_runtime_try_invoke (method, target, NULL, exc, error);
+		if (*exc == NULL && !mono_error_ok (error))
+			*exc = (MonoObject*) mono_error_convert_to_exception (error);
 		else
-			mono_error_cleanup (&error);
+			mono_error_cleanup (error);
 	} else {
-		s = (MonoString *) mono_runtime_invoke_checked (method, target, NULL, &error);
-		mono_error_raise_exception_deprecated (&error); /* OK to throw, external only without a good alternative */
+		s = (MonoString *) mono_runtime_invoke_checked (method, target, NULL, error);
+		mono_error_raise_exception_deprecated (error); /* OK to throw, external only without a good alternative */
 	}
 
 	return s;
@@ -7856,11 +7856,11 @@ mono_print_unhandled_exception (MonoObject *exc)
 			free_message = TRUE;
 		} else {
 			MonoObject *other_exc = NULL;
-			str = mono_object_try_to_string (exc, &other_exc, &error);
-			if (other_exc == NULL && !is_ok (&error))
-				other_exc = (MonoObject*)mono_error_convert_to_exception (&error);
+			str = mono_object_try_to_string (exc, &other_exc, error);
+			if (other_exc == NULL && !is_ok (error))
+				other_exc = (MonoObject*)mono_error_convert_to_exception (error);
 			else
-				mono_error_cleanup (&error);
+				mono_error_cleanup (error);
 			if (other_exc) {
 				char *original_backtrace = mono_exception_get_managed_backtrace ((MonoException*)exc);
 				char *nested_backtrace = mono_exception_get_managed_backtrace ((MonoException*)other_exc);
@@ -7872,9 +7872,9 @@ mono_print_unhandled_exception (MonoObject *exc)
 				g_free (nested_backtrace);
 				free_message = TRUE;
 			} else if (str) {
-				message = mono_string_to_utf8_checked (str, &error);
-				if (!mono_error_ok (&error)) {
-					mono_error_cleanup (&error);
+				message = mono_string_to_utf8_checked (str, error);
+				if (!mono_error_ok (error)) {
+					mono_error_cleanup (error);
 					message = (char *) "";
 				} else {
 					free_message = TRUE;
@@ -8129,8 +8129,8 @@ gpointer
 mono_load_remote_field (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, gpointer *res)
 {
 	ERROR_DECL (error);
-	gpointer result = mono_load_remote_field_checked (this_obj, klass, field, res, &error);
-	mono_error_cleanup (&error);
+	gpointer result = mono_load_remote_field_checked (this_obj, klass, field, res, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -8231,8 +8231,8 @@ mono_load_remote_field_new (MonoObject *this_obj, MonoClass *klass, MonoClassFie
 {
 	ERROR_DECL (error);
 
-	MonoObject *result = mono_load_remote_field_new_checked (this_obj, klass, field, &error);
-	mono_error_cleanup (&error);
+	MonoObject *result = mono_load_remote_field_new_checked (this_obj, klass, field, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -8289,8 +8289,8 @@ void
 mono_store_remote_field (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, gpointer val)
 {
 	ERROR_DECL (error);
-	(void) mono_store_remote_field_checked (this_obj, klass, field, val, &error);
-	mono_error_cleanup (&error);
+	(void) mono_store_remote_field_checked (this_obj, klass, field, val, error);
+	mono_error_cleanup (error);
 }
 
 /**
@@ -8343,8 +8343,8 @@ void
 mono_store_remote_field_new (MonoObject *this_obj, MonoClass *klass, MonoClassField *field, MonoObject *arg)
 {
 	ERROR_DECL (error);
-	(void) mono_store_remote_field_new_checked (this_obj, klass, field, arg, &error);
-	mono_error_cleanup (&error);
+	(void) mono_store_remote_field_new_checked (this_obj, klass, field, arg, error);
+	mono_error_cleanup (error);
 }
 
 /**

--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -315,8 +315,8 @@ mono_profiler_get_coverage_data (MonoProfilerHandle handle, MonoMethod *method, 
 	coverage_unlock ();
 
 	ERROR_DECL (error);
-	MonoMethodHeader *header = mono_method_get_header_checked (method, &error);
-	mono_error_assert_ok (&error);
+	MonoMethodHeader *header = mono_method_get_header_checked (method, error);
+	mono_error_assert_ok (error);
 
 	guint32 size;
 

--- a/mono/metadata/rand.c
+++ b/mono/metadata/rand.c
@@ -38,8 +38,8 @@ ves_icall_System_Security_Cryptography_RNGCryptoServiceProvider_RngGetBytes (gpo
 {
 	ERROR_DECL (error);
 	g_assert (arry);
-	mono_rand_try_get_bytes (&handle, mono_array_addr (arry, guchar, 0), mono_array_length (arry), &error);
-	mono_error_set_pending_exception (&error);
+	mono_rand_try_get_bytes (&handle, mono_array_addr (arry, guchar, 0), mono_array_length (arry), error);
+	mono_error_set_pending_exception (error);
 	return handle;
 }
 

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -219,8 +219,8 @@ mono_assembly_get_object (MonoDomain *domain, MonoAssembly *assembly)
 {
 	HANDLE_FUNCTION_ENTER ();
 	ERROR_DECL (error);
-	MonoReflectionAssemblyHandle result = mono_assembly_get_object_handle (domain, assembly, &error);
-	mono_error_cleanup (&error); /* FIXME new API that doesn't swallow the error */
+	MonoReflectionAssemblyHandle result = mono_assembly_get_object_handle (domain, assembly, error);
+	mono_error_cleanup (error); /* FIXME new API that doesn't swallow the error */
 	HANDLE_FUNCTION_RETURN_OBJ (result);
 }
 
@@ -256,8 +256,8 @@ mono_module_get_object   (MonoDomain *domain, MonoImage *image)
 {
 	HANDLE_FUNCTION_ENTER ();
 	ERROR_DECL (error);
-	MonoReflectionModuleHandle result = mono_module_get_object_handle (domain, image, &error);
-	mono_error_cleanup (&error);
+	MonoReflectionModuleHandle result = mono_module_get_object_handle (domain, image, error);
+	mono_error_cleanup (error);
 	HANDLE_FUNCTION_RETURN_OBJ (result);
 }
 
@@ -320,8 +320,8 @@ mono_module_file_get_object (MonoDomain *domain, MonoImage *image, int table_ind
 {
 	HANDLE_FUNCTION_ENTER ();
 	ERROR_DECL (error);
-	MonoReflectionModuleHandle result = mono_module_file_get_object_handle (domain, image, table_index, &error);
-	mono_error_cleanup (&error);
+	MonoReflectionModuleHandle result = mono_module_file_get_object_handle (domain, image, table_index, error);
+	mono_error_cleanup (error);
 	HANDLE_FUNCTION_RETURN_OBJ (result);
 }
 
@@ -426,8 +426,8 @@ MonoReflectionType*
 mono_type_get_object (MonoDomain *domain, MonoType *type)
 {
 	ERROR_DECL (error);
-	MonoReflectionType *ret = mono_type_get_object_checked (domain, type, &error);
-	mono_error_cleanup (&error);
+	MonoReflectionType *ret = mono_type_get_object_checked (domain, type, error);
+	mono_error_cleanup (error);
 
 	return ret;
 }
@@ -564,8 +564,8 @@ mono_method_get_object (MonoDomain *domain, MonoMethod *method, MonoClass *refcl
 {
 	HANDLE_FUNCTION_ENTER ();
 	ERROR_DECL (error);
-	MonoReflectionMethodHandle ret = mono_method_get_object_handle (domain, method, refclass, &error);
-	mono_error_cleanup (&error);
+	MonoReflectionMethodHandle ret = mono_method_get_object_handle (domain, method, refclass, error);
+	mono_error_cleanup (error);
 	HANDLE_FUNCTION_RETURN_OBJ (ret);
 }
 
@@ -678,8 +678,8 @@ mono_field_get_object (MonoDomain *domain, MonoClass *klass, MonoClassField *fie
 {
 	HANDLE_FUNCTION_ENTER ();
 	ERROR_DECL (error);
-	MonoReflectionFieldHandle result = mono_field_get_object_handle (domain, klass, field, &error);
-	mono_error_cleanup (&error);
+	MonoReflectionFieldHandle result = mono_field_get_object_handle (domain, klass, field, error);
+	mono_error_cleanup (error);
 	HANDLE_FUNCTION_RETURN_OBJ (result);
 }
 
@@ -758,8 +758,8 @@ mono_property_get_object (MonoDomain *domain, MonoClass *klass, MonoProperty *pr
 {
 	HANDLE_FUNCTION_ENTER ();
 	ERROR_DECL (error);
-	MonoReflectionPropertyHandle result = mono_property_get_object_handle (domain, klass, property, &error);
-	mono_error_cleanup (&error);
+	MonoReflectionPropertyHandle result = mono_property_get_object_handle (domain, klass, property, error);
+	mono_error_cleanup (error);
 	HANDLE_FUNCTION_RETURN_OBJ (result);
 }
 
@@ -823,8 +823,8 @@ mono_event_get_object (MonoDomain *domain, MonoClass *klass, MonoEvent *event)
 {
 	HANDLE_FUNCTION_ENTER ();
 	ERROR_DECL (error);
-	MonoReflectionEventHandle result = mono_event_get_object_handle (domain, klass, event, &error);
-	mono_error_cleanup (&error);
+	MonoReflectionEventHandle result = mono_event_get_object_handle (domain, klass, event, error);
+	mono_error_cleanup (error);
 	HANDLE_FUNCTION_RETURN_OBJ (result);
 }
 
@@ -882,8 +882,8 @@ mono_get_reflection_missing_object (MonoDomain *domain)
 		g_assert (missing_value_field);
 	}
 	/* FIXME change mono_field_get_value_object_checked to return a handle */
-	MonoObjectHandle obj = MONO_HANDLE_NEW (MonoObject, mono_field_get_value_object_checked (domain, missing_value_field, NULL, &error));
-	mono_error_assert_ok (&error);
+	MonoObjectHandle obj = MONO_HANDLE_NEW (MonoObject, mono_field_get_value_object_checked (domain, missing_value_field, NULL, error));
+	mono_error_assert_ok (error);
 	return obj;
 }
 
@@ -1100,8 +1100,8 @@ mono_param_get_objects (MonoDomain *domain, MonoMethod *method)
 {
 	HANDLE_FUNCTION_ENTER ();
 	ERROR_DECL (error);
-	MonoArrayHandle result = mono_param_get_objects_internal (domain, method, NULL, &error);
-	mono_error_assert_ok (&error);
+	MonoArrayHandle result = mono_param_get_objects_internal (domain, method, NULL, error);
+	mono_error_assert_ok (error);
 	HANDLE_FUNCTION_RETURN_OBJ (result);
 }
 
@@ -1166,8 +1166,8 @@ mono_method_body_get_object (MonoDomain *domain, MonoMethod *method)
 {
 	HANDLE_FUNCTION_ENTER ();
 	ERROR_DECL (error);
-	MonoReflectionMethodBodyHandle result = mono_method_body_get_object_handle (domain, method, &error);
-	mono_error_cleanup (&error);
+	MonoReflectionMethodBodyHandle result = mono_method_body_get_object_handle (domain, method, error);
+	mono_error_cleanup (error);
 	HANDLE_FUNCTION_RETURN_OBJ (result);
 }
 
@@ -1290,8 +1290,8 @@ mono_get_dbnull_object (MonoDomain *domain)
 {
 	HANDLE_FUNCTION_ENTER ();
 	ERROR_DECL (error);
-	MonoObjectHandle obj = get_dbnull_object (domain, &error);
-	mono_error_assert_ok (&error);
+	MonoObjectHandle obj = get_dbnull_object (domain, error);
+	mono_error_assert_ok (error);
 	HANDLE_FUNCTION_RETURN_OBJ (obj);
 }
 
@@ -1787,8 +1787,8 @@ int
 mono_reflection_parse_type (char *name, MonoTypeNameParse *info)
 {
 	ERROR_DECL (error);
-	gboolean result = mono_reflection_parse_type_checked (name, info, &error);
-	mono_error_cleanup (&error);
+	gboolean result = mono_reflection_parse_type_checked (name, info, error);
+	mono_error_cleanup (error);
 	return result ? 1 : 0;
 }
 
@@ -2011,8 +2011,8 @@ leave:
 MonoType*
 mono_reflection_get_type (MonoImage* image, MonoTypeNameParse *info, gboolean ignorecase, gboolean *type_resolve) {
 	ERROR_DECL (error);
-	MonoType *result = mono_reflection_get_type_with_rootimage (image, image, info, ignorecase, type_resolve, &error);
-	mono_error_cleanup (&error);
+	MonoType *result = mono_reflection_get_type_with_rootimage (image, image, info, ignorecase, type_resolve, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -2196,11 +2196,11 @@ MonoType*
 mono_reflection_type_from_name (char *name, MonoImage *image)
 {
 	ERROR_DECL (error);
-	error_init (&error);
+	error_init (error);
 
-	MonoType * const result = mono_reflection_type_from_name_checked (name, image, &error);
+	MonoType * const result = mono_reflection_type_from_name_checked (name, image, error);
 
-	mono_error_cleanup (&error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -2225,7 +2225,7 @@ mono_reflection_type_from_name_checked (char *name, MonoImage *image, MonoError 
 	tmp = g_strdup (name);
 	
 	/*g_print ("requested type %s\n", str);*/
-	ERROR_DECL (parse_error);
+	ERROR_DECL_VALUE (parse_error);
 	if (!mono_reflection_parse_type_checked (tmp, &info, &parse_error)) {
 		mono_error_cleanup (&parse_error);
 		goto leave;
@@ -2248,8 +2248,8 @@ mono_reflection_get_token (MonoObject *obj_raw)
 	HANDLE_FUNCTION_ENTER ();
 	MONO_HANDLE_DCL (MonoObject, obj);
 	ERROR_DECL (error);
-	guint32 result = mono_reflection_get_token_checked (obj, &error);
-	mono_error_assert_ok (&error);
+	guint32 result = mono_reflection_get_token_checked (obj, error);
+	mono_error_assert_ok (error);
 	HANDLE_FUNCTION_RETURN_VAL (result);
 }
 
@@ -2962,7 +2962,7 @@ mono_reflection_call_is_assignable_to (MonoClass *klass, MonoClass *oklass, Mono
 	params [0] = mono_type_get_object_checked (mono_domain_get (), &oklass->byval_arg, error);
 	return_val_if_nok (error, FALSE);
 
-	ERROR_DECL (inner_error);
+	ERROR_DECL_VALUE (inner_error);
 	res = mono_runtime_try_invoke (method, mono_class_get_ref_info_raw (klass), params, &exc, &inner_error); /* FIXME use handles */
 
 	if (exc || !is_ok (&inner_error)) {
@@ -2983,8 +2983,8 @@ mono_reflection_type_get_type (MonoReflectionType *reftype)
 	g_assert (reftype);
 
 	ERROR_DECL (error);
-	MonoType *result = mono_reflection_type_get_handle (reftype, &error);
-	mono_error_assert_ok (&error);
+	MonoType *result = mono_reflection_type_get_handle (reftype, error);
+	mono_error_assert_ok (error);
 	return result;
 }
 

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -240,8 +240,8 @@ type_from_handle (MonoType *handle)
 
 	mono_class_init (klass);
 
-	ret = mono_type_get_object_checked (domain, handle, &error);
-	mono_error_set_pending_exception (&error);
+	ret = mono_type_get_object_checked (domain, handle, error);
+	mono_error_set_pending_exception (error);
 
 	return ret;
 }
@@ -402,8 +402,8 @@ mono_remoting_wrapper (MonoMethod *method, gpointer *params)
 				} else {
 					/* runtime_invoke expects a boxed instance */
 					if (mono_class_is_nullable (mono_class_from_mono_type (sig->params [i]))) {
-						mparams[i] = mono_nullable_box ((guint8 *)params [i], klass, &error);
-						goto_if_nok (&error, fail);
+						mparams[i] = mono_nullable_box ((guint8 *)params [i], klass, error);
+						goto_if_nok (error, fail);
 					} else
 						mparams[i] = params [i];
 				}
@@ -412,31 +412,31 @@ mono_remoting_wrapper (MonoMethod *method, gpointer *params)
 			}
 		}
 
-		res = mono_runtime_invoke_checked (method, method->klass->valuetype? mono_object_unbox ((MonoObject*)this_obj): this_obj, mparams, &error);
-		goto_if_nok (&error, fail);
+		res = mono_runtime_invoke_checked (method, method->klass->valuetype? mono_object_unbox ((MonoObject*)this_obj): this_obj, mparams, error);
+		goto_if_nok (error, fail);
 
 		return res;
 	}
 
-	msg = mono_method_call_message_new (method, params, NULL, NULL, NULL, &error);
-	goto_if_nok (&error, fail);
+	msg = mono_method_call_message_new (method, params, NULL, NULL, NULL, error);
+	goto_if_nok (error, fail);
 
-	res = mono_remoting_invoke ((MonoObject *)this_obj->rp, msg, &exc, &out_args, &error);
-	goto_if_nok (&error, fail);
+	res = mono_remoting_invoke ((MonoObject *)this_obj->rp, msg, &exc, &out_args, error);
+	goto_if_nok (error, fail);
 
 	if (exc) {
-		error_init (&error);
+		error_init (error);
 		exc = (MonoObject*) mono_remoting_update_exception ((MonoException*)exc);
-		mono_error_set_exception_instance (&error, (MonoException *)exc);
+		mono_error_set_exception_instance (error, (MonoException *)exc);
 		goto fail;
 	}
 
-	mono_method_return_message_restore (method, params, out_args, &error);
-	goto_if_nok (&error, fail);
+	mono_method_return_message_restore (method, params, out_args, error);
+	goto_if_nok (error, fail);
 
 	return res;
 fail:
-	mono_error_set_pending_exception (&error);
+	mono_error_set_pending_exception (error);
 	return NULL;
 } 
 
@@ -569,8 +569,8 @@ mono_marshal_xdomain_copy_out_value (MonoObject *src, MonoObject *dst)
 			int i, len = mono_array_length ((MonoArray *)dst);
 			for (i = 0; i < len; i++) {
 				MonoObject *item = (MonoObject *)mono_array_get ((MonoArray *)src, gpointer, i);
-				MonoObject *item_copy = mono_marshal_xdomain_copy_value (item, &error);
-				if (mono_error_set_pending_exception (&error))
+				MonoObject *item_copy = mono_marshal_xdomain_copy_value (item, error);
+				if (mono_error_set_pending_exception (error))
 					return;
 				mono_array_setref ((MonoArray *)dst, i, item_copy);
 			}
@@ -641,8 +641,8 @@ gpointer
 mono_compile_method_icall (MonoMethod *method)
 {
 	ERROR_DECL (error);
-	gpointer result = mono_compile_method_checked (method, &error);
-	mono_error_set_pending_exception (&error);
+	gpointer result = mono_compile_method_checked (method, error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 
@@ -1317,12 +1317,12 @@ mono_marshal_load_remoting_wrapper (MonoRealProxy *rp, MonoMethod *method)
 	ERROR_DECL (error);
 	MonoMethod *marshal_method = NULL;
 	if (rp->target_domain_id != -1)
-		marshal_method = mono_marshal_get_xappdomain_invoke (method, &error);
+		marshal_method = mono_marshal_get_xappdomain_invoke (method, error);
 	else
-		marshal_method = mono_marshal_get_remoting_invoke (method, &error);
-	mono_error_assert_ok (&error);
-	gpointer compiled_ptr = mono_compile_method_checked (marshal_method, &error);
-	mono_error_assert_ok (&error);
+		marshal_method = mono_marshal_get_remoting_invoke (method, error);
+	mono_error_assert_ok (error);
+	gpointer compiled_ptr = mono_compile_method_checked (marshal_method, error);
+	mono_error_assert_ok (error);
 	return compiled_ptr;
 }
 
@@ -1937,7 +1937,7 @@ mono_upgrade_remote_class_wrapper (MonoReflectionType *rtype_raw, MonoTransparen
 	MONO_HANDLE_DCL (MonoTransparentProxy, tproxy);
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (tproxy);
 	MonoClass *klass = mono_class_from_mono_type (MONO_HANDLE_GETVAL (rtype, type));
-	mono_upgrade_remote_class (domain, MONO_HANDLE_CAST (MonoObject, tproxy), klass, &error);
+	mono_upgrade_remote_class (domain, MONO_HANDLE_CAST (MonoObject, tproxy), klass, error);
 	ICALL_RETURN ();
 }
 
@@ -2102,8 +2102,8 @@ MonoObject *
 ves_icall_mono_marshal_xdomain_copy_value (MonoObject *val)
 {
 	ERROR_DECL (error);
-	MonoObject *result = mono_marshal_xdomain_copy_value (val, &error);
-	mono_error_set_pending_exception (&error);
+	MonoObject *result = mono_marshal_xdomain_copy_value (val, error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 

--- a/mono/metadata/runtime.c
+++ b/mono/metadata/runtime.c
@@ -68,8 +68,8 @@ fire_process_exit_event (MonoDomain *domain, gpointer user_data)
 
 	pa [0] = domain;
 	pa [1] = NULL;
-	mono_runtime_delegate_try_invoke (delegate, pa, &exc, &error);
-	mono_error_cleanup (&error);
+	mono_runtime_delegate_try_invoke (delegate, pa, &exc, error);
+	mono_error_cleanup (error);
 }
 
 static void

--- a/mono/metadata/security-core-clr.c
+++ b/mono/metadata/security-core-clr.c
@@ -519,9 +519,9 @@ check_field_access (MonoMethod *caller, MonoClassField *field)
 		MonoClass *klass;
 
 		/* this check can occur before the field's type is resolved (and that can fail) */
-		mono_field_get_type_checked (field, &error);
-		if (!mono_error_ok (&error)) {
-			mono_error_cleanup (&error);
+		mono_field_get_type_checked (field, error);
+		if (!mono_error_ok (error)) {
+			mono_error_cleanup (error);
 			return FALSE;
 		}
 
@@ -937,8 +937,8 @@ mono_security_core_clr_class_level_no_platform_check (MonoClass *klass)
 {
 	ERROR_DECL (error);
 	MonoSecurityCoreCLRLevel level = MONO_SECURITY_CORE_CLR_TRANSPARENT;
-	MonoCustomAttrInfo *cinfo = mono_custom_attrs_from_class_checked (klass, &error);
-	mono_error_cleanup (&error);
+	MonoCustomAttrInfo *cinfo = mono_custom_attrs_from_class_checked (klass, error);
+	mono_error_cleanup (error);
 	if (cinfo) {
 		level = mono_security_core_clr_level_from_cinfo (cinfo, klass->image);
 		mono_custom_attrs_free (cinfo);
@@ -988,8 +988,8 @@ mono_security_core_clr_field_level (MonoClassField *field, gboolean with_class_l
 	if (!mono_security_core_clr_test && !mono_security_core_clr_is_platform_image (field->parent->image))
 		return level;
 
-	cinfo = mono_custom_attrs_from_field_checked (field->parent, field, &error);
-	mono_error_cleanup (&error);
+	cinfo = mono_custom_attrs_from_field_checked (field->parent, field, error);
+	mono_error_cleanup (error);
 	if (cinfo) {
 		level = mono_security_core_clr_level_from_cinfo (cinfo, field->parent->image);
 		mono_custom_attrs_free (cinfo);
@@ -1024,8 +1024,8 @@ mono_security_core_clr_method_level (MonoMethod *method, gboolean with_class_lev
 	if (!mono_security_core_clr_test && !mono_security_core_clr_is_platform_image (method->klass->image))
 		return level;
 
-	cinfo = mono_custom_attrs_from_method_checked (method, &error);
-	mono_error_cleanup (&error);
+	cinfo = mono_custom_attrs_from_method_checked (method, error);
+	mono_error_cleanup (error);
 	if (cinfo) {
 		level = mono_security_core_clr_level_from_cinfo (cinfo, method->klass->image);
 		mono_custom_attrs_free (cinfo);

--- a/mono/metadata/sre-encode.c
+++ b/mono/metadata/sre-encode.c
@@ -675,8 +675,8 @@ mono_dynimage_encode_fieldref_signature (MonoDynamicImage *assembly, MonoImage *
 		for (i = 0; i < type->num_mods; ++i) {
 			if (field_image) {
 				ERROR_DECL (error);
-				MonoClass *klass = mono_class_get_checked (field_image, type->modifiers [i].token, &error);
-				g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+				MonoClass *klass = mono_class_get_checked (field_image, type->modifiers [i].token, error);
+				g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 
 				token = mono_image_typedef_or_ref (assembly, &klass->byval_arg);
 			} else {

--- a/mono/metadata/sre-save.c
+++ b/mono/metadata/sre-save.c
@@ -358,7 +358,7 @@ method_encode_code (MonoDynamicImage *assembly, ReflectionMethodBuilder *mb, Mon
 	} else {
 		code = mb->code;
 		if (code == NULL){
-			ERROR_DECL (inner_error);
+			ERROR_DECL_VALUE (inner_error);
 			char *name = mono_string_to_utf8_checked (mb->name, &inner_error);
 			if (!is_ok (&inner_error)) {
 				name = g_strdup ("");
@@ -1294,8 +1294,8 @@ mono_image_fill_export_table_from_module (MonoDomain *domain, MonoReflectionModu
 
 	for (i = 0; i < t->rows; ++i) {
 		ERROR_DECL (error);
-		MonoClass *klass = mono_class_get_checked (image, mono_metadata_make_token (MONO_TABLE_TYPEDEF, i + 1), &error);
-		g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+		MonoClass *klass = mono_class_get_checked (image, mono_metadata_make_token (MONO_TABLE_TYPEDEF, i + 1), error);
+		g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 
 		if (mono_class_is_public (klass))
 			mono_image_fill_export_table_from_class (domain, klass, module_index, 0, assembly);
@@ -1357,8 +1357,8 @@ mono_image_fill_export_table_from_type_forwarders (MonoReflectionAssemblyBuilder
 		if (!t)
 			continue;
 
-		type = mono_reflection_type_get_handle (t, &error);
-		mono_error_assert_ok (&error);
+		type = mono_reflection_type_get_handle (t, error);
+		mono_error_assert_ok (error);
 		g_assert (type);
 
 		klass = mono_class_from_mono_type (type);
@@ -1428,10 +1428,10 @@ compare_genericparam (const void *a, const void *b)
 	const GenericParamTableEntry **b_entry = (const GenericParamTableEntry **) b;
 
 	if ((*b_entry)->owner == (*a_entry)->owner) {
-		MonoType *a_type = mono_reflection_type_get_handle ((MonoReflectionType*)(*a_entry)->gparam, &error);
-		mono_error_assert_ok (&error);
-		MonoType *b_type = mono_reflection_type_get_handle ((MonoReflectionType*)(*b_entry)->gparam, &error);
-		mono_error_assert_ok (&error);
+		MonoType *a_type = mono_reflection_type_get_handle ((MonoReflectionType*)(*a_entry)->gparam, error);
+		mono_error_assert_ok (error);
+		MonoType *b_type = mono_reflection_type_get_handle ((MonoReflectionType*)(*b_entry)->gparam, error);
+		mono_error_assert_ok (error);
 		return 
 			mono_type_get_generic_param_num (a_type) -
 			mono_type_get_generic_param_num (b_type);

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -1304,19 +1304,19 @@ mono_reflection_dynimage_basic_init (MonoReflectionAssemblyBuilder *assemblyb)
 	assembly->assembly.dynamic = TRUE;
 	assembly->assembly.corlib_internal = assemblyb->corlib_internal;
 	assemblyb->assembly.assembly = (MonoAssembly*)assembly;
-	assembly->assembly.basedir = mono_string_to_utf8_checked (assemblyb->dir, &error);
-	if (mono_error_set_pending_exception (&error))
+	assembly->assembly.basedir = mono_string_to_utf8_checked (assemblyb->dir, error);
+	if (mono_error_set_pending_exception (error))
 		return;
 	if (assemblyb->culture) {
-		assembly->assembly.aname.culture = mono_string_to_utf8_checked (assemblyb->culture, &error);
-		if (mono_error_set_pending_exception (&error))
+		assembly->assembly.aname.culture = mono_string_to_utf8_checked (assemblyb->culture, error);
+		if (mono_error_set_pending_exception (error))
 			return;
 	} else
 		assembly->assembly.aname.culture = g_strdup ("");
 
         if (assemblyb->version) {
-			char *vstr = mono_string_to_utf8_checked (assemblyb->version, &error);
-			if (mono_error_set_pending_exception (&error))
+			char *vstr = mono_string_to_utf8_checked (assemblyb->version, error);
+			if (mono_error_set_pending_exception (error))
 				return;
 			char **version = g_strsplit (vstr, ".", 4);
 			char **parts = version;
@@ -1339,8 +1339,8 @@ mono_reflection_dynimage_basic_init (MonoReflectionAssemblyBuilder *assemblyb)
 	assembly->save = assemblybuilderaccess_can_save (assemblyb->access);
 	assembly->domain = domain;
 
-	char *assembly_name = mono_string_to_utf8_checked (assemblyb->name, &error);
-	if (mono_error_set_pending_exception (&error))
+	char *assembly_name = mono_string_to_utf8_checked (assemblyb->name, error);
+	if (mono_error_set_pending_exception (error))
 		return;
 	image = mono_dynamic_image_create (assembly, assembly_name, g_strdup ("RefEmit_YouForgotToDefineAModule"));
 	image->initial_image = TRUE;
@@ -2307,8 +2307,8 @@ MonoArray*
 mono_reflection_get_custom_attrs_blob (MonoReflectionAssembly *assembly, MonoObject *ctor, MonoArray *ctorArgs, MonoArray *properties, MonoArray *propValues, MonoArray *fields, MonoArray* fieldValues) 
 {
 	ERROR_DECL (error);
-	MonoArray *result = mono_reflection_get_custom_attrs_blob_checked (assembly, ctor, ctorArgs, properties, propValues, fields, fieldValues, &error);
-	mono_error_cleanup (&error);
+	MonoArray *result = mono_reflection_get_custom_attrs_blob_checked (assembly, ctor, ctorArgs, properties, propValues, fields, fieldValues, error);
+	mono_error_cleanup (error);
 	return result;
 }
 
@@ -3627,7 +3627,7 @@ remove_instantiations_of_and_ensure_contents (gpointer key,
 	MonoType *type = (MonoType*)key;
 	MonoClass *klass = data->klass;
 	gboolean already_failed = !is_ok (data->error);
-	ERROR_DECL (lerror);
+	ERROR_DECL_VALUE (lerror);
 	MonoError *error = already_failed ? &lerror : data->error;
 
 	if ((type->type == MONO_TYPE_GENERICINST) && (type->data.generic_class->container_class == klass)) {
@@ -4352,16 +4352,16 @@ void
 ves_icall_ModuleBuilder_WriteToFile (MonoReflectionModuleBuilder *mb, HANDLE file)
 {
 	ERROR_DECL (error);
-	mono_image_create_pefile (mb, file, &error);
-	mono_error_set_pending_exception (&error);
+	mono_image_create_pefile (mb, file, error);
+	mono_error_set_pending_exception (error);
 }
 
 void
 ves_icall_ModuleBuilder_build_metadata (MonoReflectionModuleBuilder *mb)
 {
 	ERROR_DECL (error);
-	mono_image_build_metadata (mb, &error);
-	mono_error_set_pending_exception (&error);
+	mono_image_build_metadata (mb, error);
+	mono_error_set_pending_exception (error);
 }
 
 void
@@ -4386,8 +4386,8 @@ MonoArray*
 ves_icall_CustomAttributeBuilder_GetBlob (MonoReflectionAssembly *assembly, MonoObject *ctor, MonoArray *ctorArgs, MonoArray *properties, MonoArray *propValues, MonoArray *fields, MonoArray* fieldValues)
 {
 	ERROR_DECL (error);
-	MonoArray *result = mono_reflection_get_custom_attrs_blob_checked (assembly, ctor, ctorArgs, properties, propValues, fields, fieldValues, &error);
-	mono_error_set_pending_exception (&error);
+	MonoArray *result = mono_reflection_get_custom_attrs_blob_checked (assembly, ctor, ctorArgs, properties, propValues, fields, fieldValues, error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 #endif

--- a/mono/metadata/string-icalls.c
+++ b/mono/metadata/string-icalls.c
@@ -37,8 +37,8 @@ MonoString *
 ves_icall_System_String_InternalAllocateStr (gint32 length)
 {
 	ERROR_DECL (error);
-	MonoString *str = mono_string_new_size_checked (mono_domain_get (), length, &error);
-	mono_error_set_pending_exception (&error);
+	MonoString *str = mono_string_new_size_checked (mono_domain_get (), length, error);
+	mono_error_set_pending_exception (error);
 
 	return str;
 }
@@ -49,9 +49,9 @@ ves_icall_System_String_InternalIntern (MonoString *str)
 	ERROR_DECL (error);
 	MonoString *res;
 
-	res = mono_string_intern_checked (str, &error);
+	res = mono_string_intern_checked (str, error);
 	if (!res) {
-		mono_error_set_pending_exception (&error);
+		mono_error_set_pending_exception (error);
 		return NULL;
 	}
 	return res;

--- a/mono/metadata/threadpool-io.c
+++ b/mono/metadata/threadpool-io.c
@@ -274,16 +274,16 @@ wait_callback (gint fd, gint events, gpointer user_data)
 		if (list && (events & EVENT_IN) != 0) {
 			MonoIOSelectorJob *job = get_job_for_event (&list, EVENT_IN);
 			if (job) {
-				mono_threadpool_enqueue_work_item (((MonoObject*) job)->vtable->domain, (MonoObject*) job, &error);
-				mono_error_assert_ok (&error);
+				mono_threadpool_enqueue_work_item (((MonoObject*) job)->vtable->domain, (MonoObject*) job, error);
+				mono_error_assert_ok (error);
 			}
 
 		}
 		if (list && (events & EVENT_OUT) != 0) {
 			MonoIOSelectorJob *job = get_job_for_event (&list, EVENT_OUT);
 			if (job) {
-				mono_threadpool_enqueue_work_item (((MonoObject*) job)->vtable->domain, (MonoObject*) job, &error);
-				mono_error_assert_ok (&error);
+				mono_threadpool_enqueue_work_item (((MonoObject*) job)->vtable->domain, (MonoObject*) job, error);
+				mono_error_assert_ok (error);
 			}
 		}
 
@@ -319,10 +319,10 @@ selector_thread (gpointer data)
 	ERROR_DECL (error);
 	MonoGHashTable *states;
 
-	MonoString *thread_name = mono_string_new_checked (mono_get_root_domain (), "Thread Pool I/O Selector", &error);
-	mono_error_assert_ok (&error);
-	mono_thread_set_name_internal (mono_thread_internal_current (), thread_name, FALSE, TRUE, &error);
-	mono_error_assert_ok (&error);
+	MonoString *thread_name = mono_string_new_checked (mono_get_root_domain (), "Thread Pool I/O Selector", error);
+	mono_error_assert_ok (error);
+	mono_thread_set_name_internal (mono_thread_internal_current (), thread_name, FALSE, TRUE, error);
+	mono_error_assert_ok (error);
 
 	if (mono_runtime_is_shutting_down ()) {
 		io_selector_running = FALSE;
@@ -362,8 +362,8 @@ selector_thread (gpointer data)
 				g_assert (job);
 
 				exists = mono_g_hash_table_lookup_extended (states, GINT_TO_POINTER (fd), &k, (gpointer*) &list);
-				list = mono_mlist_append_checked (list, (MonoObject*) job, &error);
-				mono_error_assert_ok (&error);
+				list = mono_mlist_append_checked (list, (MonoObject*) job, error);
+				mono_error_assert_ok (error);
 				mono_g_hash_table_replace (states, GINT_TO_POINTER (fd), list);
 
 				operations = get_operations_for_jobs (list);
@@ -393,8 +393,8 @@ selector_thread (gpointer data)
 					}
 
 					for (; list; list = mono_mlist_remove_item (list, list)) {
-						mono_threadpool_enqueue_work_item (mono_object_domain (mono_mlist_get_data (list)), mono_mlist_get_data (list), &error);
-						mono_error_assert_ok (&error);
+						mono_threadpool_enqueue_work_item (mono_object_domain (mono_mlist_get_data (list)), mono_mlist_get_data (list), error);
+						mono_error_assert_ok (error);
 					}
 
 					mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_SELECTOR, "io threadpool: del fd %3d", fd);
@@ -569,8 +569,8 @@ initialize (void)
 	io_selector_running = TRUE;
 
 	ERROR_DECL (error);
-	if (!mono_thread_create_internal (mono_get_root_domain (), selector_thread, NULL, MONO_THREAD_CREATE_FLAGS_THREADPOOL | MONO_THREAD_CREATE_FLAGS_SMALL_STACK, &error))
-		g_error ("initialize: mono_thread_create_internal () failed due to %s", mono_error_get_message (&error));
+	if (!mono_thread_create_internal (mono_get_root_domain (), selector_thread, NULL, MONO_THREAD_CREATE_FLAGS_THREADPOOL | MONO_THREAD_CREATE_FLAGS_SMALL_STACK, error))
+		g_error ("initialize: mono_thread_create_internal () failed due to %s", mono_error_get_message (error));
 
 	mono_coop_mutex_unlock (&threadpool_io->updates_lock);
 }

--- a/mono/metadata/threadpool-worker-default.c
+++ b/mono/metadata/threadpool-worker-default.c
@@ -206,9 +206,9 @@ rand_next (gpointer *handle, guint32 min, guint32 max)
 {
 	ERROR_DECL (error);
 	guint32 val;
-	mono_rand_try_get_uint32 (handle, &val, min, max, &error);
+	mono_rand_try_get_uint32 (handle, &val, min, max, error);
 	// FIXME handle error
-	mono_error_assert_ok (&error);
+	mono_error_assert_ok (error);
 	return val;
 }
 
@@ -551,11 +551,11 @@ worker_try_create (void)
 		counter._.starting ++;
 	});
 
-	thread = mono_thread_create_internal (mono_get_root_domain (), worker_thread, NULL, MONO_THREAD_CREATE_FLAGS_THREADPOOL, &error);
+	thread = mono_thread_create_internal (mono_get_root_domain (), worker_thread, NULL, MONO_THREAD_CREATE_FLAGS_THREADPOOL, error);
 	if (!thread) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_THREADPOOL, "[%p] try create worker, failed: could not create thread due to %s",
-			GUINT_TO_POINTER (MONO_NATIVE_THREAD_ID_TO_UINT (mono_native_thread_id_get ())), mono_error_get_message (&error));
-		mono_error_cleanup (&error);
+			GUINT_TO_POINTER (MONO_NATIVE_THREAD_ID_TO_UINT (mono_native_thread_id_get ())), mono_error_get_message (error));
+		mono_error_cleanup (error);
 
 		COUNTER_ATOMIC (counter, {
 			counter._.starting --;
@@ -782,10 +782,10 @@ monitor_ensure_running (void)
 				return;
 			if (mono_atomic_cas_i32 (&worker.monitor_status, MONITOR_STATUS_REQUESTED, MONITOR_STATUS_NOT_RUNNING) == MONITOR_STATUS_NOT_RUNNING) {
 				// printf ("monitor_thread: creating\n");
-				if (!mono_thread_create_internal (mono_get_root_domain (), monitor_thread, NULL, MONO_THREAD_CREATE_FLAGS_THREADPOOL | MONO_THREAD_CREATE_FLAGS_SMALL_STACK, &error)) {
+				if (!mono_thread_create_internal (mono_get_root_domain (), monitor_thread, NULL, MONO_THREAD_CREATE_FLAGS_THREADPOOL | MONO_THREAD_CREATE_FLAGS_SMALL_STACK, error)) {
 					// printf ("monitor_thread: creating failed\n");
 					worker.monitor_status = MONITOR_STATUS_NOT_RUNNING;
-					mono_error_cleanup (&error);
+					mono_error_cleanup (error);
 					mono_refcount_dec (&worker);
 				}
 				return;

--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -350,10 +350,10 @@ worker_callback (void)
 
 		domains_unlock ();
 
-		MonoString *thread_name = mono_string_new_checked (mono_get_root_domain (), "Thread Pool Worker", &error);
-		mono_error_assert_ok (&error);
-		mono_thread_set_name_internal (thread, thread_name, FALSE, TRUE, &error);
-		mono_error_assert_ok (&error);
+		MonoString *thread_name = mono_string_new_checked (mono_get_root_domain (), "Thread Pool Worker", error);
+		mono_error_assert_ok (error);
+		mono_thread_set_name_internal (thread, thread_name, FALSE, TRUE, error);
+		mono_error_assert_ok (error);
 
 		mono_thread_clr_state (thread, (MonoThreadState)~ThreadState_Background);
 		if (!mono_thread_test_state (thread , ThreadState_Background))
@@ -363,12 +363,12 @@ worker_callback (void)
 		if (mono_domain_set (tpdomain->domain, FALSE)) {
 			MonoObject *exc = NULL, *res;
 
-			res = try_invoke_perform_wait_callback (&exc, &error);
-			if (exc || !mono_error_ok(&error)) {
+			res = try_invoke_perform_wait_callback (&exc, error);
+			if (exc || !mono_error_ok(error)) {
 				if (exc == NULL)
-					exc = (MonoObject *) mono_error_convert_to_exception (&error);
+					exc = (MonoObject *) mono_error_convert_to_exception (error);
 				else
-					mono_error_cleanup (&error);
+					mono_error_cleanup (error);
 				mono_thread_internal_unhandled_exception (exc);
 			} else if (res && *(MonoBoolean*) mono_object_unbox (res) == FALSE) {
 				retire = TRUE;
@@ -749,8 +749,8 @@ ves_icall_System_Threading_ThreadPool_ReportThreadStatus (MonoBoolean is_working
 {
 	// TODO
 	ERROR_DECL (error);
-	mono_error_set_not_implemented (&error, "");
-	mono_error_set_pending_exception (&error);
+	mono_error_set_not_implemented (error, "");
+	mono_error_set_pending_exception (error);
 }
 
 MonoBoolean
@@ -810,8 +810,8 @@ ves_icall_System_Threading_ThreadPool_PostQueuedCompletionStatus (MonoNativeOver
 {
 	/* This copy the behavior of the current Mono implementation */
 	ERROR_DECL (error);
-	mono_error_set_not_implemented (&error, "");
-	mono_error_set_pending_exception (&error);
+	mono_error_set_not_implemented (error, "");
+	mono_error_set_pending_exception (error);
 	return FALSE;
 }
 

--- a/mono/metadata/verify.c
+++ b/mono/metadata/verify.c
@@ -556,9 +556,9 @@ verifier_inflate_type (VerifyContext *ctx, MonoType *type, MonoGenericContext *c
 	ERROR_DECL (error);
 	MonoType *result;
 
-	result = mono_class_inflate_generic_type_checked (type, context, &error);
-	if (!mono_error_ok (&error)) {
-		mono_error_cleanup (&error);
+	result = mono_class_inflate_generic_type_checked (type, context, error);
+	if (!mono_error_ok (error)) {
+		mono_error_cleanup (error);
 		return NULL;
 	}
 	return result;
@@ -629,9 +629,9 @@ is_valid_generic_instantiation (MonoGenericContainer *gc, MonoGenericContext *co
 			MonoClass *ctr = *constraints;
 			MonoType *inflated;
 
-			inflated = mono_class_inflate_generic_type_checked (&ctr->byval_arg, context, &error);
-			if (!mono_error_ok (&error)) {
-				mono_error_cleanup (&error);
+			inflated = mono_class_inflate_generic_type_checked (&ctr->byval_arg, context, error);
+			if (!mono_error_ok (error)) {
+				mono_error_cleanup (error);
 				return FALSE;
 			}
 			ctr = mono_class_from_mono_type (inflated);
@@ -956,8 +956,8 @@ verifier_load_field (VerifyContext *ctx, int token, MonoClass **out_klass, const
 			return NULL;
 		}
 
-		field = mono_field_from_token_checked (ctx->image, token, &klass, ctx->generic_context, &error);
-		mono_error_cleanup (&error); /*FIXME don't swallow the error */
+		field = mono_field_from_token_checked (ctx->image, token, &klass, ctx->generic_context, error);
+		mono_error_cleanup (error); /*FIXME don't swallow the error */
 	}
 
 	if (!field || !field->parent || !klass) {
@@ -993,8 +993,8 @@ verifier_load_method (VerifyContext *ctx, int token, const char *opcode) {
 			return NULL;
 		}
 
-		method = mono_get_method_checked (ctx->image, token, NULL, ctx->generic_context, &error);
-		mono_error_cleanup (&error); /* FIXME don't swallow this error */
+		method = mono_get_method_checked (ctx->image, token, NULL, ctx->generic_context, error);
+		mono_error_cleanup (error); /* FIXME don't swallow this error */
 	}
 
 	if (!method) {
@@ -1021,8 +1021,8 @@ verifier_load_type (VerifyContext *ctx, int token, const char *opcode) {
 			ADD_VERIFY_ERROR2 (ctx, g_strdup_printf ("Invalid type token 0x%08x at 0x%04x", token, ctx->ip_offset), MONO_EXCEPTION_BAD_IMAGE);
 			return NULL;
 		}
-		type = mono_type_get_checked (ctx->image, token, ctx->generic_context, &error);
-		mono_error_cleanup (&error); /*FIXME don't swallow the error */
+		type = mono_type_get_checked (ctx->image, token, ctx->generic_context, error);
+		mono_error_cleanup (error); /*FIXME don't swallow the error */
 	}
 
 	if (!type) {
@@ -2092,13 +2092,13 @@ static void
 init_stack_with_value_at_exception_boundary (VerifyContext *ctx, ILCodeDesc *code, MonoClass *klass)
 {
 	ERROR_DECL (error);
-	MonoType *type = mono_class_inflate_generic_type_checked (&klass->byval_arg, ctx->generic_context, &error);
+	MonoType *type = mono_class_inflate_generic_type_checked (&klass->byval_arg, ctx->generic_context, error);
 
-	if (!mono_error_ok (&error)) {
+	if (!mono_error_ok (error)) {
 		char *name = mono_type_get_full_name (klass);
 		ADD_VERIFY_ERROR (ctx, g_strdup_printf ("Invalid class %s used for exception", name));
 		g_free (name);
-		mono_error_cleanup (&error);
+		mono_error_cleanup (error);
 		return;
 	}
 
@@ -2195,9 +2195,9 @@ verifier_class_is_assignable_from (MonoClass *target, MonoClass *candidate)
 				ERROR_DECL (error);
 				int i;
 				while (candidate && candidate != mono_defaults.object_class) {
-					mono_class_setup_interfaces (candidate, &error);
-					if (!mono_error_ok (&error)) {
-						mono_error_cleanup (&error);
+					mono_class_setup_interfaces (candidate, error);
+					if (!mono_error_ok (error)) {
+						mono_error_cleanup (error);
 						return FALSE;
 					}
 
@@ -3241,15 +3241,15 @@ do_invoke_method (VerifyContext *ctx, int method_token, gboolean virtual_)
 		}
 	}
 
-	if (!(sig = mono_method_get_signature_checked (method, ctx->image, method_token, ctx->generic_context, &error))) {
-		mono_error_cleanup (&error);
-		sig = mono_method_get_signature_checked (method, ctx->image, method_token, NULL, &error);
+	if (!(sig = mono_method_get_signature_checked (method, ctx->image, method_token, ctx->generic_context, error))) {
+		mono_error_cleanup (error);
+		sig = mono_method_get_signature_checked (method, ctx->image, method_token, NULL, error);
 	}
 
 	if (!sig) {
 		char *name = mono_type_get_full_name (method->klass);
-		ADD_VERIFY_ERROR (ctx, g_strdup_printf ("Could not resolve signature of %s:%s at 0x%04x due to: %s", name, method->name, ctx->ip_offset, mono_error_get_message (&error)));
-		mono_error_cleanup (&error);
+		ADD_VERIFY_ERROR (ctx, g_strdup_printf ("Could not resolve signature of %s:%s at 0x%04x due to: %s", name, method->name, ctx->ip_offset, mono_error_get_message (error)));
+		mono_error_cleanup (error);
 		g_free (name);
 		return;
 	}
@@ -3729,12 +3729,12 @@ do_load_token (VerifyContext *ctx, int token)
 			return;
 		}
 
-		handle = mono_ldtoken_checked (ctx->image, token, &handle_class, ctx->generic_context, &error);
+		handle = mono_ldtoken_checked (ctx->image, token, &handle_class, ctx->generic_context, error);
 	}
 
 	if (!handle) {
-		ADD_VERIFY_ERROR (ctx, g_strdup_printf ("Invalid token 0x%x for ldtoken at 0x%04x due to %s", token, ctx->ip_offset, mono_error_get_message (&error)));
-		mono_error_cleanup (&error);
+		ADD_VERIFY_ERROR (ctx, g_strdup_printf ("Invalid token 0x%x for ldtoken at 0x%04x due to %s", token, ctx->ip_offset, mono_error_get_message (error)));
+		mono_error_cleanup (error);
 		return;
 	}
 	if (handle_class == mono_defaults.typehandle_class) {
@@ -4725,16 +4725,16 @@ merge_stacks (VerifyContext *ctx, ILCodeDesc *from, ILCodeDesc *to, gboolean sta
 				}
 			}
 
-			mono_class_setup_interfaces (old_class, &error);
-			if (!mono_error_ok (&error)) {
-				CODE_NOT_VERIFIABLE (ctx, g_strdup_printf ("Cannot merge stacks due to a TypeLoadException %s at 0x%04x", mono_error_get_message (&error), ctx->ip_offset));
-				mono_error_cleanup (&error);
+			mono_class_setup_interfaces (old_class, error);
+			if (!mono_error_ok (error)) {
+				CODE_NOT_VERIFIABLE (ctx, g_strdup_printf ("Cannot merge stacks due to a TypeLoadException %s at 0x%04x", mono_error_get_message (error), ctx->ip_offset));
+				mono_error_cleanup (error);
 				goto end_verify;
 			}
-			mono_class_setup_interfaces (new_class, &error);
-			if (!mono_error_ok (&error)) {
-				CODE_NOT_VERIFIABLE (ctx, g_strdup_printf ("Cannot merge stacks due to a TypeLoadException %s at 0x%04x", mono_error_get_message (&error), ctx->ip_offset));
-				mono_error_cleanup (&error);
+			mono_class_setup_interfaces (new_class, error);
+			if (!mono_error_ok (error)) {
+				CODE_NOT_VERIFIABLE (ctx, g_strdup_printf ("Cannot merge stacks due to a TypeLoadException %s at 0x%04x", mono_error_get_message (error), ctx->ip_offset));
+				mono_error_cleanup (error);
 				goto end_verify;
 			}
 
@@ -4954,10 +4954,10 @@ mono_method_verify (MonoMethod *method, int level)
 		return ctx.list;
 	}
 
-	ctx.header = mono_method_get_header_checked (method, &error);
+	ctx.header = mono_method_get_header_checked (method, error);
 	if (!ctx.header) {
-		ADD_VERIFY_ERROR (&ctx, g_strdup_printf ("Could not decode method header due to %s", mono_error_get_message (&error)));
-		mono_error_cleanup (&error);
+		ADD_VERIFY_ERROR (&ctx, g_strdup_printf ("Could not decode method header due to %s", mono_error_get_message (error)));
+		mono_error_cleanup (error);
 		finish_collect_stats ();
 		return ctx.list;
 	}
@@ -5005,12 +5005,12 @@ mono_method_verify (MonoMethod *method, int level)
 
 	for (i = 0; i < ctx.num_locals; ++i) {
 		MonoType *uninflated = ctx.locals [i];
-		ctx.locals [i] = mono_class_inflate_generic_type_checked (ctx.locals [i], ctx.generic_context, &error);
-		if (!mono_error_ok (&error)) {
+		ctx.locals [i] = mono_class_inflate_generic_type_checked (ctx.locals [i], ctx.generic_context, error);
+		if (!mono_error_ok (error)) {
 			char *name = mono_type_full_name (ctx.locals [i] ? ctx.locals [i] : uninflated);
 			ADD_VERIFY_ERROR (&ctx, g_strdup_printf ("Invalid local %d of type %s", i, name));
 			g_free (name);
-			mono_error_cleanup (&error);
+			mono_error_cleanup (error);
 			/* we must not free (in cleanup) what was not yet allocated (but only copied) */
 			ctx.num_locals = i;
 			ctx.max_args = 0;
@@ -5019,12 +5019,12 @@ mono_method_verify (MonoMethod *method, int level)
 	}
 	for (i = 0; i < ctx.max_args; ++i) {
 		MonoType *uninflated = ctx.params [i];
-		ctx.params [i] = mono_class_inflate_generic_type_checked (ctx.params [i], ctx.generic_context, &error);
-		if (!mono_error_ok (&error)) {
+		ctx.params [i] = mono_class_inflate_generic_type_checked (ctx.params [i], ctx.generic_context, error);
+		if (!mono_error_ok (error)) {
 			char *name = mono_type_full_name (ctx.params [i] ? ctx.params [i] : uninflated);
 			ADD_VERIFY_ERROR (&ctx, g_strdup_printf ("Invalid parameter %d of type %s", i, name));
 			g_free (name);
-			mono_error_cleanup (&error);
+			mono_error_cleanup (error);
 			/* we must not free (in cleanup) what was not yet allocated (but only copied) */
 			ctx.max_args = i;
 			goto cleanup;
@@ -5117,10 +5117,10 @@ mono_method_verify (MonoMethod *method, int level)
 	if (!ctx.valid)
 		goto cleanup;
 
-	original_bb = bb = mono_basic_block_split (method, &error, ctx.header);
-	if (!mono_error_ok (&error)) {
-		ADD_VERIFY_ERROR (&ctx, g_strdup_printf ("Invalid branch target: %s", mono_error_get_message (&error)));
-		mono_error_cleanup (&error);
+	original_bb = bb = mono_basic_block_split (method, error, ctx.header);
+	if (!mono_error_ok (error)) {
+		ADD_VERIFY_ERROR (&ctx, g_strdup_printf ("Invalid branch target: %s", mono_error_get_message (error)));
+		mono_error_cleanup (error);
 		goto cleanup;
 	}
 	g_assert (bb);

--- a/mono/metadata/w32file-win32-uwp.c
+++ b/mono/metadata/w32file-win32-uwp.c
@@ -117,7 +117,7 @@ mono_w32file_unlock (HANDLE handle, gint64 position, gint64 length, gint32 *erro
 HANDLE
 mono_w32file_get_console_output (void)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("GetStdHandle (STD_OUTPUT_HANDLE)");
@@ -133,7 +133,7 @@ mono_w32file_get_console_output (void)
 HANDLE
 mono_w32file_get_console_input (void)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("GetStdHandle (STD_INPUT_HANDLE)");
@@ -149,7 +149,7 @@ mono_w32file_get_console_input (void)
 HANDLE
 mono_w32file_get_console_error (void)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("GetStdHandle (STD_ERROR_HANDLE)");

--- a/mono/metadata/w32file.c
+++ b/mono/metadata/w32file.c
@@ -850,8 +850,8 @@ mono_filesize_from_path (MonoString *string)
 	ERROR_DECL (error);
 	struct stat buf;
 	gint64 res;
-	char *path = mono_string_to_utf8_checked (string, &error);
-	mono_error_raise_exception_deprecated (&error); /* OK to throw, external only without a good alternative */
+	char *path = mono_string_to_utf8_checked (string, error);
+	mono_error_raise_exception_deprecated (error); /* OK to throw, external only without a good alternative */
 
 	gint stat_res;
 	MONO_ENTER_GC_SAFE;

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -2332,8 +2332,8 @@ ves_icall_System_Diagnostics_Process_GetProcesses_internal (void)
 		mono_set_pending_exception (mono_get_exception_not_supported ("This system does not support EnumProcesses"));
 		return NULL;
 	}
-	procs = mono_array_new_checked (mono_domain_get (), mono_get_int32_class (), count, &error);
-	if (mono_error_set_pending_exception (&error)) {
+	procs = mono_array_new_checked (mono_domain_get (), mono_get_int32_class (), count, error);
+	if (mono_error_set_pending_exception (error)) {
 		g_free (pidarray);
 		return NULL;
 	}

--- a/mono/metadata/w32process-win32-uwp.c
+++ b/mono/metadata/w32process-win32-uwp.c
@@ -29,7 +29,7 @@ mono_process_win_enum_processes (DWORD *pids, DWORD count, DWORD *needed)
 HANDLE
 ves_icall_System_Diagnostics_Process_GetProcess_internal (guint32 pid)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("OpenProcess");
@@ -69,7 +69,7 @@ process_add_module (HANDLE process, HMODULE mod, gunichar2 *filename, gunichar2 
 MonoArray *
 ves_icall_System_Diagnostics_Process_GetModules_internal (MonoObject *this_obj, HANDLE process)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("EnumProcessModules, GetModuleBaseName, GetModuleFileNameEx");
@@ -85,7 +85,7 @@ ves_icall_System_Diagnostics_Process_GetModules_internal (MonoObject *this_obj, 
 MonoBoolean
 ves_icall_System_Diagnostics_Process_ShellExecuteEx_internal (MonoW32ProcessStartInfo *proc_start_info, MonoW32ProcessInfo *process_info)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("ShellExecuteEx");
@@ -111,9 +111,9 @@ ves_icall_System_Diagnostics_Process_ProcessName_internal (HANDLE process)
 	if (len == 0)
 		return NULL;
 
-	string = mono_string_new_utf16_checked (mono_domain_get (), name, len, &error);
-	if (!mono_error_ok (&error))
-		mono_error_set_pending_exception (&error);
+	string = mono_string_new_utf16_checked (mono_domain_get (), name, len, error);
+	if (!mono_error_ok (error))
+		mono_error_set_pending_exception (error);
 
 	return string;
 }
@@ -133,7 +133,7 @@ gboolean
 mono_process_create_process (MonoW32ProcessInfo *mono_process_info, MonoString *cmd, guint32 creation_flags,
 	gunichar2 *env_vars, gunichar2 *dir, STARTUPINFO *start_info, PROCESS_INFORMATION *process_info)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	gchar		*api_name = "";
 
 	if (mono_process_info->username) {
@@ -157,7 +157,7 @@ mono_process_create_process (MonoW32ProcessInfo *mono_process_info, MonoString *
 MonoBoolean
 mono_icall_get_process_working_set_size (gpointer handle, gsize *min, gsize *max)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("GetProcessWorkingSetSize");
@@ -173,7 +173,7 @@ mono_icall_get_process_working_set_size (gpointer handle, gsize *min, gsize *max
 MonoBoolean
 mono_icall_set_process_working_set_size (gpointer handle, gsize min, gsize max)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("SetProcessWorkingSetSize");
@@ -189,7 +189,7 @@ mono_icall_set_process_working_set_size (gpointer handle, gsize min, gsize max)
 gint32
 mono_icall_get_priority_class (gpointer handle)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("GetPriorityClass");
@@ -205,7 +205,7 @@ mono_icall_get_priority_class (gpointer handle)
 MonoBoolean
 mono_icall_set_priority_class (gpointer handle, gint32 priorityClass)
 {
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 	error_init (&mono_error);
 
 	g_unsupported_api ("SetPriorityClass");

--- a/mono/metadata/w32process-win32.c
+++ b/mono/metadata/w32process-win32.c
@@ -238,7 +238,7 @@ process_get_shell_arguments (MonoW32ProcessStartInfo *proc_start_info, MonoStrin
 {
 	gchar		*spath = NULL;
 	gchar		*new_cmd, *cmd_utf8;
-	ERROR_DECL (mono_error);
+	ERROR_DECL_VALUE (mono_error);
 
 	*cmd = proc_start_info->arguments;
 
@@ -382,8 +382,8 @@ ves_icall_System_Diagnostics_Process_GetProcesses_internal (void)
 	} while (TRUE);
 
 	count = needed / sizeof (guint32);
-	procs = mono_array_new_checked (mono_domain_get (), mono_get_int32_class (), count, &error);
-	if (mono_error_set_pending_exception (&error)) {
+	procs = mono_array_new_checked (mono_domain_get (), mono_get_int32_class (), count, error);
+	if (mono_error_set_pending_exception (error)) {
 		g_free (pids);
 		return NULL;
 	}

--- a/mono/metadata/w32process.c
+++ b/mono/metadata/w32process.c
@@ -432,15 +432,15 @@ ves_icall_System_Diagnostics_FileVersionInfo_GetVersionInfo_internal (MonoObject
 
 	stash_system_image (mono_object_class (this_obj)->image);
 
-	mono_w32process_get_fileversion (this_obj, mono_string_chars (filename), &error);
-	if (!mono_error_ok (&error)) {
-		mono_error_set_pending_exception (&error);
+	mono_w32process_get_fileversion (this_obj, mono_string_chars (filename), error);
+	if (!mono_error_ok (error)) {
+		mono_error_set_pending_exception (error);
 		return;
 	}
 
-	process_set_field_string (this_obj, "filename", mono_string_chars (filename), mono_string_length (filename), &error);
-	if (!mono_error_ok (&error)) {
-		mono_error_set_pending_exception (&error);
+	process_set_field_string (this_obj, "filename", mono_string_chars (filename), mono_string_length (filename), error);
+	if (!mono_error_ok (error)) {
+		mono_error_set_pending_exception (error);
 	}
 }
 
@@ -584,17 +584,17 @@ ves_icall_System_Diagnostics_Process_GetModules_internal (MonoObject *this_obj, 
 		module_count += needed / sizeof(HMODULE);
 
 	count = module_count + assembly_count;
-	temp_arr = mono_array_new_checked (mono_domain_get (), get_process_module_class (), count, &error);
-	if (mono_error_set_pending_exception (&error))
+	temp_arr = mono_array_new_checked (mono_domain_get (), get_process_module_class (), count, error);
+	if (mono_error_set_pending_exception (error))
 		return NULL;
 
 	for (i = 0; i < module_count; i++) {
 		if (mono_w32process_module_get_name (process, mods[i], modname, MAX_PATH)
 			 && mono_w32process_module_get_filename (process, mods[i], filename, MAX_PATH))
 		{
-			MonoObject *module = process_add_module (process, mods[i], filename, modname, get_process_module_class (), &error);
-			if (!mono_error_ok (&error)) {
-				mono_error_set_pending_exception (&error);
+			MonoObject *module = process_add_module (process, mods[i], filename, modname, get_process_module_class (), error);
+			if (!mono_error_ok (error)) {
+				mono_error_set_pending_exception (error);
 				return NULL;
 			}
 			mono_array_setref (temp_arr, num_added++, module);
@@ -604,9 +604,9 @@ ves_icall_System_Diagnostics_Process_GetModules_internal (MonoObject *this_obj, 
 	if (assemblies) {
 		for (i = 0; i < assembly_count; i++) {
 			MonoAssembly *ass = (MonoAssembly *)g_ptr_array_index (assemblies, i);
-			MonoObject *module = process_get_module (ass, get_process_module_class (), &error);
-			if (!mono_error_ok (&error)) {
-				mono_error_set_pending_exception (&error);
+			MonoObject *module = process_get_module (ass, get_process_module_class (), error);
+			if (!mono_error_ok (error)) {
+				mono_error_set_pending_exception (error);
 				return NULL;
 			}
 			mono_array_setref (temp_arr, num_added++, module);
@@ -618,8 +618,8 @@ ves_icall_System_Diagnostics_Process_GetModules_internal (MonoObject *this_obj, 
 		arr = temp_arr;
 	} else {
 		/* shorter version of the array */
-		arr = mono_array_new_checked (mono_domain_get (), get_process_module_class (), num_added, &error);
-		if (mono_error_set_pending_exception (&error))
+		arr = mono_array_new_checked (mono_domain_get (), get_process_module_class (), num_added, error);
+		if (mono_error_set_pending_exception (error))
 			return NULL;
 
 		for (i = 0; i < num_added; i++)
@@ -652,9 +652,9 @@ ves_icall_System_Diagnostics_Process_ProcessName_internal (HANDLE process)
 	if (len == 0)
 		return NULL;
 
-	string = mono_string_new_utf16_checked (mono_domain_get (), name, len, &error);
-	if (!mono_error_ok (&error))
-		mono_error_set_pending_exception (&error);
+	string = mono_string_new_utf16_checked (mono_domain_get (), name, len, error);
+	if (!mono_error_ok (error))
+		mono_error_set_pending_exception (error);
 
 	return string;
 }

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -2904,9 +2904,9 @@ find_typespec_for_class (MonoAotCompile *acfg, MonoClass *klass)
 		for (i = 0; i < len; i++) {
 			ERROR_DECL (error);
 			int typespec = MONO_TOKEN_TYPE_SPEC | (i + 1);
-			MonoClass *klass_key = mono_class_get_and_inflate_typespec_checked (acfg->image, typespec, NULL, &error);
-			if (!is_ok (&error)) {
-				mono_error_cleanup (&error);
+			MonoClass *klass_key = mono_class_get_and_inflate_typespec_checked (acfg->image, typespec, NULL, error);
+			if (!is_ok (error)) {
+				mono_error_cleanup (error);
 				continue;
 			}
 			g_hash_table_insert (acfg->typespec_classes, klass_key, GINT_TO_POINTER (typespec));
@@ -3959,8 +3959,8 @@ add_wrappers (MonoAotCompile *acfg)
 		guint32 token = MONO_TOKEN_METHOD_DEF | (i + 1);
 		gboolean skip = FALSE;
 
-		method = mono_get_method_checked (acfg->image, token, NULL, NULL, &error);
-		report_loader_error (acfg, &error, TRUE, "Failed to load method token 0x%x due to %s\n", i, mono_error_get_message (&error));
+		method = mono_get_method_checked (acfg->image, token, NULL, NULL, error);
+		report_loader_error (acfg, error, TRUE, "Failed to load method token 0x%x due to %s\n", i, mono_error_get_message (error));
 
 		if ((method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL) ||
 			(method->iflags & METHOD_IMPL_ATTRIBUTE_RUNTIME) ||
@@ -4149,8 +4149,8 @@ add_wrappers (MonoAotCompile *acfg)
 		MonoMethodSignature *sig;
 		
 		token = MONO_TOKEN_METHOD_DEF | (i + 1);
-		method = mono_get_method_checked (acfg->image, token, NULL, NULL, &error);
-		g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+		method = mono_get_method_checked (acfg->image, token, NULL, NULL, error);
+		g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 
 		sig = mono_method_signature (method);
 
@@ -4169,10 +4169,10 @@ add_wrappers (MonoAotCompile *acfg)
 		MonoCustomAttrInfo *cattr;
 		
 		token = MONO_TOKEN_TYPE_DEF | (i + 1);
-		klass = mono_class_get_checked (acfg->image, token, &error);
+		klass = mono_class_get_checked (acfg->image, token, error);
 
 		if (!klass) {
-			mono_error_cleanup (&error);
+			mono_error_cleanup (error);
 			continue;
 		}
 
@@ -4194,9 +4194,9 @@ add_wrappers (MonoAotCompile *acfg)
 			if (method)
 				add_method (acfg, mono_marshal_get_delegate_end_invoke (method));
 
-			cattr = mono_custom_attrs_from_class_checked (klass, &error);
-			if (!is_ok (&error)) {
-				mono_error_cleanup (&error);
+			cattr = mono_custom_attrs_from_class_checked (klass, error);
+			if (!is_ok (error)) {
+				mono_error_cleanup (error);
 				continue;
 			}
 
@@ -4231,8 +4231,8 @@ add_wrappers (MonoAotCompile *acfg)
 			method = mono_get_delegate_invoke (klass);
 			create_gsharedvt_inst (acfg, method, &ctx);
 
-			inst = mono_class_inflate_generic_method_checked (method, &ctx, &error);
-			g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+			inst = mono_class_inflate_generic_method_checked (method, &ctx, error);
+			g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 
 			m = mono_marshal_get_delegate_invoke (inst, NULL);
 			g_assert (m->is_inflated);
@@ -4245,8 +4245,8 @@ add_wrappers (MonoAotCompile *acfg)
 			if (method) {
 				create_gsharedvt_inst (acfg, method, &ctx);
 
-				inst = mono_class_inflate_generic_method_checked (method, &ctx, &error);
-				g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+				inst = mono_class_inflate_generic_method_checked (method, &ctx, error);
+				g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 
 				m = mono_marshal_get_delegate_begin_invoke (inst);
 				g_assert (m->is_inflated);
@@ -4260,8 +4260,8 @@ add_wrappers (MonoAotCompile *acfg)
 			if (method) {
 				create_gsharedvt_inst (acfg, method, &ctx);
 
-				inst = mono_class_inflate_generic_method_checked (method, &ctx, &error);
-				g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+				inst = mono_class_inflate_generic_method_checked (method, &ctx, error);
+				g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 
 				m = mono_marshal_get_delegate_end_invoke (inst);
 				g_assert (m->is_inflated);
@@ -4278,10 +4278,10 @@ add_wrappers (MonoAotCompile *acfg)
 		MonoClass *klass;
 		
 		token = MONO_TOKEN_TYPE_SPEC | (i + 1);
-		klass = mono_class_get_checked (acfg->image, token, &error);
+		klass = mono_class_get_checked (acfg->image, token, error);
 
 		if (!klass) {
-			mono_error_cleanup (&error);
+			mono_error_cleanup (error);
 			continue;
 		}
 
@@ -4310,8 +4310,8 @@ add_wrappers (MonoAotCompile *acfg)
 	for (i = 0; i < acfg->image->tables [MONO_TABLE_METHOD].rows; ++i) {
 		ERROR_DECL (error);
 		token = MONO_TOKEN_METHOD_DEF | (i + 1);
-		method = mono_get_method_checked (acfg->image, token, NULL, NULL, &error);
-		report_loader_error (acfg, &error, TRUE, "Failed to load method token 0x%x due to %s\n", i, mono_error_get_message (&error));
+		method = mono_get_method_checked (acfg->image, token, NULL, NULL, error);
+		report_loader_error (acfg, error, TRUE, "Failed to load method token 0x%x due to %s\n", i, mono_error_get_message (error));
 
 		if (method->iflags & METHOD_IMPL_ATTRIBUTE_SYNCHRONIZED) {
 			if (method->is_generic) {
@@ -4325,8 +4325,8 @@ add_wrappers (MonoAotCompile *acfg)
 				 * Create a generic wrapper for a generic instance, and AOT that.
 				 */
 				create_gsharedvt_inst (acfg, method, &ctx);
-				inst = mono_class_inflate_generic_method_checked (method, &ctx, &error);
-				g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+				inst = mono_class_inflate_generic_method_checked (method, &ctx, error);
+				g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 				m = mono_marshal_get_synchronized_wrapper (inst);
 				g_assert (m->is_inflated);
 				gshared = mini_get_shared_method_full (m, FALSE, TRUE);
@@ -4343,8 +4343,8 @@ add_wrappers (MonoAotCompile *acfg)
 		MonoMethod *method;
 		guint32 token = MONO_TOKEN_METHOD_DEF | (i + 1);
 
-		method = mono_get_method_checked (acfg->image, token, NULL, NULL, &error);
-		report_loader_error (acfg, &error, TRUE, "Failed to load method token 0x%x due to %s\n", i, mono_error_get_message (&error));
+		method = mono_get_method_checked (acfg->image, token, NULL, NULL, error);
+		report_loader_error (acfg, error, TRUE, "Failed to load method token 0x%x due to %s\n", i, mono_error_get_message (error));
 
 		if ((method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL) ||
 			(method->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL)) {
@@ -4367,18 +4367,18 @@ add_wrappers (MonoAotCompile *acfg)
 		MonoCustomAttrInfo *cattr;
 		int j;
 
-		method = mono_get_method_checked (acfg->image, token, NULL, NULL, &error);
-		report_loader_error (acfg, &error, TRUE, "Failed to load method token 0x%x due to %s\n", i, mono_error_get_message (&error));
+		method = mono_get_method_checked (acfg->image, token, NULL, NULL, error);
+		report_loader_error (acfg, error, TRUE, "Failed to load method token 0x%x due to %s\n", i, mono_error_get_message (error));
 
 		/* 
 		 * Only generate native-to-managed wrappers for methods which have an
 		 * attribute named MonoPInvokeCallbackAttribute. We search for the attribute by
 		 * name to avoid defining a new assembly to contain it.
 		 */
-		cattr = mono_custom_attrs_from_method_checked (method, &error);
-		if (!is_ok (&error)) {
+		cattr = mono_custom_attrs_from_method_checked (method, error);
+		if (!is_ok (error)) {
 			char *name = mono_method_get_full_name (method);
-			report_loader_error (acfg, &error, TRUE, "Failed to load custom attributes from method %s due to %s\n", name, mono_error_get_message (&error));
+			report_loader_error (acfg, error, TRUE, "Failed to load custom attributes from method %s due to %s\n", name, mono_error_get_message (error));
 			g_free (name);
 		}
 
@@ -4420,9 +4420,9 @@ add_wrappers (MonoAotCompile *acfg)
 				slen = mono_metadata_decode_value (p, &p);
 				n = (char *)g_memdup (p, slen + 1);
 				n [slen] = 0;
-				t = mono_reflection_type_from_name_checked (n, acfg->image, &error);
+				t = mono_reflection_type_from_name_checked (n, acfg->image, error);
 				g_assert (t);
-				mono_error_assert_ok (&error);
+				mono_error_assert_ok (error);
 				g_free (n);
 
 				klass = mono_class_from_mono_type (t);
@@ -4463,8 +4463,8 @@ add_wrappers (MonoAotCompile *acfg)
 					named += slen;
 				}
 
-				wrapper = mono_marshal_get_managed_wrapper (method, klass, 0, &error);
-				mono_error_assert_ok (&error);
+				wrapper = mono_marshal_get_managed_wrapper (method, klass, 0, error);
+				mono_error_assert_ok (error);
 
 				add_method (acfg, wrapper);
 				if (export_name)
@@ -4485,10 +4485,10 @@ add_wrappers (MonoAotCompile *acfg)
 		MonoClass *klass;
 		
 		token = MONO_TOKEN_TYPE_DEF | (i + 1);
-		klass = mono_class_get_checked (acfg->image, token, &error);
+		klass = mono_class_get_checked (acfg->image, token, error);
 
 		if (!klass) {
-			mono_error_cleanup (&error);
+			mono_error_cleanup (error);
 			continue;
 		}
 
@@ -4741,8 +4741,8 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 					break;
 			}
 			g_assert (nclass);
-			nclass = mono_class_inflate_generic_class_checked (nclass, mono_generic_class_get_context (mono_class_get_generic_class (klass)), &error);
-			mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+			nclass = mono_class_inflate_generic_class_checked (nclass, mono_generic_class_get_context (mono_class_get_generic_class (klass)), error);
+			mono_error_assert_ok (error); /* FIXME don't swallow the error */
 			add_generic_class (acfg, nclass, FALSE, "ICollection<T>");
 		}
 
@@ -4773,14 +4773,14 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 		args [0] = &tclass->byval_arg;
 		ctx.class_inst = mono_metadata_get_generic_inst (1, args);
 
-		icomparable_inst = mono_class_inflate_generic_class_checked (icomparable, &ctx, &error);
-		mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+		icomparable_inst = mono_class_inflate_generic_class_checked (icomparable, &ctx, error);
+		mono_error_assert_ok (error); /* FIXME don't swallow the error */
 
 		if (mono_class_is_assignable_from (icomparable_inst, tclass)) {
 			MonoClass *gcomparer_inst;
 			gcomparer = mono_class_load_from_name (mono_defaults.corlib, "System.Collections.Generic", "GenericComparer`1");
-			gcomparer_inst = mono_class_inflate_generic_class_checked (gcomparer, &ctx, &error);
-			mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+			gcomparer_inst = mono_class_inflate_generic_class_checked (gcomparer, &ctx, error);
+			mono_error_assert_ok (error); /* FIXME don't swallow the error */
 
 			add_generic_class (acfg, gcomparer_inst, FALSE, "Comparer<T>");
 		}
@@ -4801,16 +4801,16 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 		args [0] = &tclass->byval_arg;
 		ctx.class_inst = mono_metadata_get_generic_inst (1, args);
 
-		iface_inst = mono_class_inflate_generic_class_checked (iface, &ctx, &error);
-		mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+		iface_inst = mono_class_inflate_generic_class_checked (iface, &ctx, error);
+		mono_error_assert_ok (error); /* FIXME don't swallow the error */
 
 		if (mono_class_is_assignable_from (iface_inst, tclass)) {
 			MonoClass *gcomparer_inst;
 			ERROR_DECL (error);
 
 			gcomparer = mono_class_load_from_name (mono_defaults.corlib, "System.Collections.Generic", "GenericEqualityComparer`1");
-			gcomparer_inst = mono_class_inflate_generic_class_checked (gcomparer, &ctx, &error);
-			mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+			gcomparer_inst = mono_class_inflate_generic_class_checked (gcomparer, &ctx, error);
+			mono_error_assert_ok (error); /* FIXME don't swallow the error */
 			add_generic_class (acfg, gcomparer_inst, FALSE, "EqualityComparer<T>");
 		}
 	}
@@ -4831,8 +4831,8 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 			ctx.class_inst = mono_metadata_get_generic_inst (1, args);
 
 			enum_comparer = mono_class_load_from_name (mono_defaults.corlib, "System.Collections.Generic", "EnumEqualityComparer`1");
-			enum_comparer_inst = mono_class_inflate_generic_class_checked (enum_comparer, &ctx, &error);
-			mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+			enum_comparer_inst = mono_class_inflate_generic_class_checked (enum_comparer, &ctx, error);
+			mono_error_assert_ok (error); /* FIXME don't swallow the error */
 			add_generic_class (acfg, enum_comparer_inst, FALSE, "EqualityComparer<T>");
 		}
 	}
@@ -4853,8 +4853,8 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 			ctx.class_inst = mono_metadata_get_generic_inst (1, args);
 
 			comparer = mono_class_load_from_name (mono_defaults.corlib, "System.Collections.Generic", "ObjectComparer`1");
-			comparer_inst = mono_class_inflate_generic_class_checked (comparer, &ctx, &error);
-			mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+			comparer_inst = mono_class_inflate_generic_class_checked (comparer, &ctx, error);
+			mono_error_assert_ok (error); /* FIXME don't swallow the error */
 			add_generic_class (acfg, comparer_inst, FALSE, "Comparer<T>");
 		}
 	}
@@ -4877,8 +4877,8 @@ add_instances_of (MonoAotCompile *acfg, MonoClass *klass, MonoType **insts, int 
 		MonoClass *generic_inst;
 		args [0] = insts [i];
 		ctx.class_inst = mono_metadata_get_generic_inst (1, args);
-		generic_inst = mono_class_inflate_generic_class_checked (klass, &ctx, &error);
-		mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+		generic_inst = mono_class_inflate_generic_class_checked (klass, &ctx, error);
+		mono_error_assert_ok (error); /* FIXME don't swallow the error */
 		add_generic_class (acfg, generic_inst, force, "");
 	}
 }
@@ -4901,7 +4901,7 @@ add_types_from_method_header (MonoAotCompile *acfg, MonoMethod *method)
 				add_generic_class_with_depth (acfg, mono_class_from_mono_type (sig->params [j]), depth + 1, "arg");
 	}
 
-	header = mono_method_get_header_checked (method, &error);
+	header = mono_method_get_header_checked (method, error);
 
 	if (header) {
 		for (j = 0; j < header->num_locals; ++j)
@@ -4909,7 +4909,7 @@ add_types_from_method_header (MonoAotCompile *acfg, MonoMethod *method)
 				add_generic_class_with_depth (acfg, mono_class_from_mono_type (header->locals [j]), depth + 1, "local");
 		mono_metadata_free_mh (header);
 	} else {
-		mono_error_cleanup (&error); /* FIXME report the error */
+		mono_error_cleanup (error); /* FIXME report the error */
 	}
 
 }
@@ -4933,12 +4933,12 @@ add_generic_instances (MonoAotCompile *acfg)
 	for (i = 0; i < acfg->image->tables [MONO_TABLE_METHODSPEC].rows; ++i) {
 		ERROR_DECL (error);
 		token = MONO_TOKEN_METHOD_SPEC | (i + 1);
-		method = mono_get_method_checked (acfg->image, token, NULL, NULL, &error);
+		method = mono_get_method_checked (acfg->image, token, NULL, NULL, error);
 
 		if (!method) {
-			aot_printerrf (acfg, "Failed to load methodspec 0x%x due to %s.\n", token, mono_error_get_message (&error));
+			aot_printerrf (acfg, "Failed to load methodspec 0x%x due to %s.\n", token, mono_error_get_message (error));
 			aot_printerrf (acfg, "Run with MONO_LOG_LEVEL=debug for more information.\n");
-			mono_error_cleanup (&error);
+			mono_error_cleanup (error);
 			continue;
 		}
 
@@ -5021,8 +5021,8 @@ add_generic_instances (MonoAotCompile *acfg)
 			else
 				declaring_method = mono_method_get_declaring_generic_method (method);
 
-			method = mono_class_inflate_generic_method_checked (declaring_method, &shared_context, &error);
-			g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+			method = mono_class_inflate_generic_method_checked (declaring_method, &shared_context, error);
+			g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 		}
 
 		/* 
@@ -5045,9 +5045,9 @@ add_generic_instances (MonoAotCompile *acfg)
 
 		token = MONO_TOKEN_TYPE_SPEC | (i + 1);
 
-		klass = mono_class_get_checked (acfg->image, token, &error);
+		klass = mono_class_get_checked (acfg->image, token, error);
 		if (!klass || klass->rank) {
-			mono_error_cleanup (&error);
+			mono_error_cleanup (error);
 			continue;
 		}
 
@@ -5148,8 +5148,8 @@ add_generic_instances (MonoAotCompile *acfg)
 				memset (&ctx, 0, sizeof (ctx));
 				args [0] = &mono_defaults.object_class->byval_arg;
 				ctx.method_inst = mono_metadata_get_generic_inst (1, args);
-				add_extra_method (acfg, mono_marshal_get_native_wrapper (mono_class_inflate_generic_method_checked (get_method, &ctx, &error), TRUE, TRUE));
-				g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+				add_extra_method (acfg, mono_marshal_get_native_wrapper (mono_class_inflate_generic_method_checked (get_method, &ctx, error), TRUE, TRUE));
+				g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 			}
 		}
 
@@ -5167,8 +5167,8 @@ add_generic_instances (MonoAotCompile *acfg)
 					memset (&ctx, 0, sizeof (ctx));
 					args [0] = &mono_defaults.object_class->byval_arg;
 					ctx.method_inst = mono_metadata_get_generic_inst (1, args);
-					add_extra_method (acfg, mono_marshal_get_native_wrapper (mono_class_inflate_generic_method_checked (m, &ctx, &error), TRUE, TRUE));
-					g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+					add_extra_method (acfg, mono_marshal_get_native_wrapper (mono_class_inflate_generic_method_checked (m, &ctx, error), TRUE, TRUE));
+					g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 				}
 			}
 		}
@@ -5188,8 +5188,8 @@ add_generic_instances (MonoAotCompile *acfg)
 						memset (&ctx, 0, sizeof (ctx));
 						args [0] = &mono_defaults.object_class->byval_arg;
 						ctx.method_inst = mono_metadata_get_generic_inst (1, args);
-						add_extra_method (acfg, mono_marshal_get_native_wrapper (mono_class_inflate_generic_method_checked (m, &ctx, &error), TRUE, TRUE));
-						g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+						add_extra_method (acfg, mono_marshal_get_native_wrapper (mono_class_inflate_generic_method_checked (m, &ctx, error), TRUE, TRUE));
+						g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 					}
 				}
 			}
@@ -6484,14 +6484,14 @@ static guint32
 emit_klass_info (MonoAotCompile *acfg, guint32 token)
 {
 	ERROR_DECL (error);
-	MonoClass *klass = mono_class_get_checked (acfg->image, token, &error);
+	MonoClass *klass = mono_class_get_checked (acfg->image, token, error);
 	guint8 *p, *buf;
 	int i, buf_size, res;
 	gboolean no_special_static, cant_encode;
 	gpointer iter = NULL;
 
 	if (!klass) {
-		mono_error_cleanup (&error);
+		mono_error_cleanup (error);
 
 		buf_size = 16;
 
@@ -8067,8 +8067,8 @@ compile_method (MonoAotCompile *acfg, MonoMethod *method)
 		}
 		cfg->args = args;
 
-		header = mono_method_get_header_checked (method, &error);
-		mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+		header = mono_method_get_header_checked (method, error);
+		mono_error_assert_ok (error); /* FIXME don't swallow the error */
 		locals = (MonoInst **)mono_mempool_alloc (acfg->mempool, sizeof (MonoInst*) * header->num_locals);
 		for (i = 0; i < header->num_locals; ++i) {
 			locals [i] = (MonoInst *)mono_mempool_alloc (acfg->mempool, sizeof (MonoInst));
@@ -8120,10 +8120,10 @@ compile_thread_main (gpointer user_data)
 
 	ERROR_DECL (error);
 	MonoInternalThread *internal = mono_thread_internal_current ();
-	MonoString *str = mono_string_new_checked (mono_domain_get (), "AOT compiler", &error);
-	mono_error_assert_ok (&error);
-	mono_thread_set_name_internal (internal, str, TRUE, FALSE, &error);
-	mono_error_assert_ok (&error);
+	MonoString *str = mono_string_new_checked (mono_domain_get (), "AOT compiler", error);
+	mono_error_assert_ok (error);
+	mono_thread_set_name_internal (internal, str, TRUE, FALSE, error);
+	mono_error_assert_ok (error);
 
 	for (i = 0; i < methods->len; ++i)
 		compile_method (acfg, (MonoMethod *)g_ptr_array_index (methods, i));
@@ -9475,8 +9475,8 @@ mono_aot_get_array_helper_from_wrapper (MonoMethod *method)
 		memset (&ctx, 0, sizeof (ctx));
 		args [0] = &method->klass->element_class->byval_arg;
 		ctx.method_inst = mono_metadata_get_generic_inst (1, args);
-		m = mono_class_inflate_generic_method_checked (m, &ctx, &error);
-		g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+		m = mono_class_inflate_generic_method_checked (m, &ctx, error);
+		g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 	}
 
 	return m;
@@ -9637,8 +9637,8 @@ generate_aotid (guint8* aotid)
 	mono_rand_open ();
 	rand_handle = mono_rand_init (NULL, 0);
 
-	mono_rand_try_get_bytes (&rand_handle, aotid, 16, &error);
-	mono_error_assert_ok (&error);
+	mono_rand_try_get_bytes (&rand_handle, aotid, 16, error);
+	mono_error_assert_ok (error);
 
 	mono_rand_close (rand_handle);
 }
@@ -9783,9 +9783,9 @@ emit_class_name_table (MonoAotCompile *acfg)
 	for (i = 0; i < acfg->image->tables [MONO_TABLE_TYPEDEF].rows; ++i) {
 		ERROR_DECL (error);
 		token = MONO_TOKEN_TYPE_DEF | (i + 1);
-		klass = mono_class_get_checked (acfg->image, token, &error);
+		klass = mono_class_get_checked (acfg->image, token, error);
 		if (!klass) {
-			mono_error_cleanup (&error);
+			mono_error_cleanup (error);
 			continue;
 		}
 		full_name = mono_type_get_name_full (mono_class_get_type (klass), MONO_TYPE_NAME_FORMAT_FULL_NAME);
@@ -10915,12 +10915,12 @@ collect_methods (MonoAotCompile *acfg)
 		MonoMethod *method;
 		guint32 token = MONO_TOKEN_METHOD_DEF | (i + 1);
 
-		method = mono_get_method_checked (acfg->image, token, NULL, NULL, &error);
+		method = mono_get_method_checked (acfg->image, token, NULL, NULL, error);
 
 		if (!method) {
-			aot_printerrf (acfg, "Failed to load method 0x%x from '%s' due to %s.\n", token, image->name, mono_error_get_message (&error));
+			aot_printerrf (acfg, "Failed to load method 0x%x from '%s' due to %s.\n", token, image->name, mono_error_get_message (error));
 			aot_printerrf (acfg, "Run with MONO_LOG_LEVEL=debug for more information.\n");
-			mono_error_cleanup (&error);
+			mono_error_cleanup (error);
 			return FALSE;
 		}
 			
@@ -10967,8 +10967,8 @@ collect_methods (MonoAotCompile *acfg)
 		if (!(acfg->opts & MONO_OPT_GSHAREDVT))
 			continue;
 
-		method = mono_get_method_checked (acfg->image, token, NULL, NULL, &error);
-		report_loader_error (acfg, &error, TRUE, "Failed to load method token 0x%x due to %s\n", i, mono_error_get_message (&error));
+		method = mono_get_method_checked (acfg->image, token, NULL, NULL, error);
+		report_loader_error (acfg, error, TRUE, "Failed to load method token 0x%x due to %s\n", i, mono_error_get_message (error));
 
 		if (method->is_generic || mono_class_is_gtd (method->klass)) {
 			MonoMethod *gshared;
@@ -11030,8 +11030,8 @@ compile_methods (MonoAotCompile *acfg)
 			user_data [0] = acfg;
 			user_data [1] = frag;
 			
-			thread = mono_thread_create_internal (mono_domain_get (), compile_thread_main, (gpointer) user_data, MONO_THREAD_CREATE_FLAGS_NONE, &error);
-			mono_error_assert_ok (&error);
+			thread = mono_thread_create_internal (mono_domain_get (), compile_thread_main, (gpointer) user_data, MONO_THREAD_CREATE_FLAGS_NONE, error);
+			mono_error_assert_ok (error);
 
 			thread_handle = mono_threads_open_thread_handle (thread->handle);
 			g_ptr_array_add (threads, thread_handle);
@@ -11509,7 +11509,7 @@ resolve_class (ClassProfileData *cdata)
 	if (!cdata->image->image)
 		return;
 
-	klass = mono_class_from_name_checked (cdata->image->image, cdata->ns, cdata->name, &error);
+	klass = mono_class_from_name_checked (cdata->image->image, cdata->ns, cdata->name, error);
 	if (!klass) {
 		//printf ("[%s] %s.%s\n", cdata->image->name, cdata->ns, cdata->name);
 		return;
@@ -11522,7 +11522,7 @@ resolve_class (ClassProfileData *cdata)
 
 		memset (&ctx, 0, sizeof (ctx));
 		ctx.class_inst = cdata->inst->inst;
-		cdata->klass = mono_class_inflate_generic_class_checked (klass, &ctx, &error);
+		cdata->klass = mono_class_inflate_generic_class_checked (klass, &ctx, error);
 	} else {
 		cdata->klass = klass;
 	}
@@ -11611,12 +11611,12 @@ resolve_profile_data (MonoAotCompile *acfg, ProfileData *data)
 				memset (&ctx, 0, sizeof (ctx));
 				ctx.method_inst = mdata->inst->inst;
 
-				m = mono_class_inflate_generic_method_checked (m, &ctx, &error);
+				m = mono_class_inflate_generic_method_checked (m, &ctx, error);
 				if (!m)
 					continue;
-				sig = mono_method_signature_checked (m, &error);
-				if (!is_ok (&error)) {
-					mono_error_cleanup (&error);
+				sig = mono_method_signature_checked (m, error);
+				if (!is_ok (error)) {
+					mono_error_cleanup (error);
 					continue;
 				}
 			}

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -608,12 +608,12 @@ static MonoClassField*
 decode_field_info (MonoAotModule *module, guint8 *buf, guint8 **endbuf)
 {
 	ERROR_DECL (error);
-	MonoClass *klass = decode_klass_ref (module, buf, &buf, &error);
+	MonoClass *klass = decode_klass_ref (module, buf, &buf, error);
 	guint32 token;
 	guint8 *p = buf;
 
 	if (!klass) {
-		mono_error_cleanup (&error); /* FIXME don't swallow the error */
+		mono_error_cleanup (error); /* FIXME don't swallow the error */
 		return NULL;
 	}
 
@@ -788,7 +788,7 @@ decode_signature_with_target (MonoAotModule *module, MonoMethodSignature *target
 	sig->explicit_this = explicit_this;
 	sig->call_convention = call_conv;
 	sig->generic_param_count = gen_param_count;
-	sig->ret = decode_type (module, p, &p, &error);
+	sig->ret = decode_type (module, p, &p, error);
 	if (!sig->ret)
 		goto fail;
 	for (i = 0; i < param_count; ++i) {
@@ -797,7 +797,7 @@ decode_signature_with_target (MonoAotModule *module, MonoMethodSignature *target
 			sig->sentinelpos = i;
 			p ++;
 		}
-		sig->params [i] = decode_type (module, p, &p, &error);
+		sig->params [i] = decode_type (module, p, &p, error);
 		if (!sig->params [i])
 			goto fail;
 	}
@@ -809,7 +809,7 @@ decode_signature_with_target (MonoAotModule *module, MonoMethodSignature *target
 
 	return sig;
 fail:
-	mono_error_cleanup (&error); /* FIXME don't swallow the error */
+	mono_error_cleanup (error); /* FIXME don't swallow the error */
 	g_free (sig);
 	return NULL;
 }
@@ -1921,8 +1921,8 @@ init_amodule_got (MonoAotModule *amodule)
 		} else if (ji->type == MONO_PATCH_INFO_AOT_MODULE) {
 			amodule->shared_got [i] = amodule;
 		} else {
-			amodule->shared_got [i] = mono_resolve_patch_target (NULL, mono_get_root_domain (), NULL, ji, FALSE, &error);
-			mono_error_assert_ok (&error);
+			amodule->shared_got [i] = mono_resolve_patch_target (NULL, mono_get_root_domain (), NULL, ji, FALSE, error);
+			mono_error_assert_ok (error);
 		}
 	}
 
@@ -2321,8 +2321,8 @@ if (container_assm_name && !container_amodule) {
 	if (do_load_image) {
 		for (i = 0; i < amodule->image_table_len; ++i) {
 			ERROR_DECL (error);
-			load_image (amodule, i, &error);
-			mono_error_cleanup (&error); /* FIXME don't swallow the error */
+			load_image (amodule, i, error);
+			mono_error_cleanup (error); /* FIXME don't swallow the error */
 		}
 	}
 
@@ -2429,15 +2429,15 @@ decode_cached_class_info (MonoAotModule *module, MonoCachedClassInfo *info, guin
 	info->has_weak_fields = (flags >> 9) & 0x1;
 
 	if (info->has_cctor) {
-		res = decode_method_ref (module, &ref, buf, &buf, &error);
-		mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+		res = decode_method_ref (module, &ref, buf, &buf, error);
+		mono_error_assert_ok (error); /* FIXME don't swallow the error */
 		if (!res)
 			return FALSE;
 		info->cctor_token = ref.token;
 	}
 	if (info->has_finalize) {
-		res = decode_method_ref (module, &ref, buf, &buf, &error);
-		mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+		res = decode_method_ref (module, &ref, buf, &buf, error);
+		mono_error_assert_ok (error); /* FIXME don't swallow the error */
 		if (!res)
 			return FALSE;
 		info->finalize_image = ref.image;
@@ -2466,7 +2466,7 @@ mono_aot_get_method_from_vt_slot (MonoDomain *domain, MonoVTable *vtable, int sl
 	MethodRef ref;
 	gboolean res;
 	gpointer addr;
-	ERROR_DECL (inner_error);
+	ERROR_DECL_VALUE (inner_error);
 
 	error_init (error);
 
@@ -2598,9 +2598,9 @@ mono_aot_get_class_from_name (MonoImage *image, const char *name_space, const ch
 			if (!strcmp (name, name2) && !strcmp (name_space, name_space2)) {
 				ERROR_DECL (error);
 				amodule_unlock (amodule);
-				*klass = mono_class_get_checked (image, token, &error);
-				if (!mono_error_ok (&error))
-					mono_error_cleanup (&error); /* FIXME don't swallow the error */
+				*klass = mono_class_get_checked (image, token, error);
+				if (!mono_error_ok (error))
+					mono_error_cleanup (error); /* FIXME don't swallow the error */
 
 				/* Add to cache */
 				if (*klass) {
@@ -3020,8 +3020,8 @@ decode_exception_debug_info (MonoAotModule *amodule, MonoDomain *domain,
 					if (async) {
 						p += len;
 					} else {
-						ei->data.catch_class = decode_klass_ref (amodule, p, &p, &error);
-						mono_error_cleanup (&error); /* FIXME don't swallow the error */
+						ei->data.catch_class = decode_klass_ref (amodule, p, &p, error);
+						mono_error_cleanup (error); /* FIXME don't swallow the error */
 					}
 				}
 			}
@@ -3089,8 +3089,8 @@ decode_exception_debug_info (MonoAotModule *amodule, MonoDomain *domain,
 					if (async) {
 						p += len;
 					} else {
-						ei->data.catch_class = decode_klass_ref (amodule, p, &p, &error);
-						mono_error_cleanup (&error); /* FIXME don't swallow the error */
+						ei->data.catch_class = decode_klass_ref (amodule, p, &p, error);
+						mono_error_cleanup (error); /* FIXME don't swallow the error */
 					}
 				}
 			}
@@ -3180,8 +3180,8 @@ decode_exception_debug_info (MonoAotModule *amodule, MonoDomain *domain,
 		if (async) {
 			p += len;
 		} else {
-			jinfo->d.method = decode_resolve_method_ref (amodule, p, &p, &error);
-			mono_error_cleanup (&error); /* FIXME don't swallow the error */
+			jinfo->d.method = decode_resolve_method_ref (amodule, p, &p, error);
+			mono_error_cleanup (error); /* FIXME don't swallow the error */
 		}
 
 		gi->generic_sharing_context = alloc0_jit_info_data (domain, sizeof (MonoGenericSharingContext), async);
@@ -3495,17 +3495,17 @@ mono_aot_find_jit_info (MonoDomain *domain, MonoImage *image, gpointer addr)
 				}
 
 				p = amodule->blob + table [(pos * 2) + 1];
-				method = decode_resolve_method_ref (amodule, p, &p, &error);
-				mono_error_cleanup (&error); /* FIXME don't swallow the error */
+				method = decode_resolve_method_ref (amodule, p, &p, error);
+				mono_error_cleanup (error); /* FIXME don't swallow the error */
 				if (!method)
 					/* Happens when a random address is passed in which matches a not-yey called wrapper encoded using its name */
 					return NULL;
 			} else {
 				ERROR_DECL (error);
 				token = mono_metadata_make_token (MONO_TABLE_METHOD, method_index + 1);
-				method = mono_get_method_checked (image, token, NULL, NULL, &error);
+				method = mono_get_method_checked (image, token, NULL, NULL, error);
 				if (!method)
-					g_error ("AOT runtime could not load method due to %s", mono_error_get_message (&error)); /* FIXME don't swallow the error */
+					g_error ("AOT runtime could not load method due to %s", mono_error_get_message (error)); /* FIXME don't swallow the error */
 			}
 		}
 		/* FIXME: */
@@ -3575,8 +3575,8 @@ decode_patch (MonoAotModule *aot_module, MonoMemPool *mp, MonoJumpInfo *ji, guin
 		MethodRef ref;
 		gboolean res;
 
-		res = decode_method_ref (aot_module, &ref, p, &p, &error);
-		mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+		res = decode_method_ref (aot_module, &ref, p, &p, error);
+		mono_error_assert_ok (error); /* FIXME don't swallow the error */
 		if (!res)
 			goto cleanup;
 
@@ -3589,9 +3589,9 @@ decode_patch (MonoAotModule *aot_module, MonoMemPool *mp, MonoJumpInfo *ji, guin
 				ji->data.method = ref.method;
 			}else {
 				ERROR_DECL (error);
-				ji->data.method = mono_get_method_checked (ref.image, ref.token, NULL, NULL, &error);
+				ji->data.method = mono_get_method_checked (ref.image, ref.token, NULL, NULL, error);
 				if (!ji->data.method)
-					g_error ("AOT Runtime could not load method due to %s", mono_error_get_message (&error)); /* FIXME don't swallow the error */
+					g_error ("AOT Runtime could not load method due to %s", mono_error_get_message (error)); /* FIXME don't swallow the error */
 			}
 			g_assert (ji->data.method);
 			mono_class_init (ji->data.method->klass);
@@ -3609,8 +3609,8 @@ decode_patch (MonoAotModule *aot_module, MonoMemPool *mp, MonoJumpInfo *ji, guin
 	}
 	case MONO_PATCH_INFO_METHODCONST:
 		/* Shared */
-		ji->data.method = decode_resolve_method_ref (aot_module, p, &p, &error);
-		mono_error_cleanup (&error); /* FIXME don't swallow the error */
+		ji->data.method = decode_resolve_method_ref (aot_module, p, &p, error);
+		mono_error_cleanup (error); /* FIXME don't swallow the error */
 		if (!ji->data.method)
 			goto cleanup;
 		break;
@@ -3619,28 +3619,28 @@ decode_patch (MonoAotModule *aot_module, MonoMemPool *mp, MonoJumpInfo *ji, guin
 	case MONO_PATCH_INFO_IID:
 	case MONO_PATCH_INFO_ADJUSTED_IID:
 		/* Shared */
-		ji->data.klass = decode_klass_ref (aot_module, p, &p, &error);
-		mono_error_cleanup (&error); /* FIXME don't swallow the error */
+		ji->data.klass = decode_klass_ref (aot_module, p, &p, error);
+		mono_error_cleanup (error); /* FIXME don't swallow the error */
 		if (!ji->data.klass)
 			goto cleanup;
 		break;
 	case MONO_PATCH_INFO_DELEGATE_TRAMPOLINE:
 		ji->data.del_tramp = (MonoDelegateClassMethodPair *)mono_mempool_alloc0 (mp, sizeof (MonoDelegateClassMethodPair));
-		ji->data.del_tramp->klass = decode_klass_ref (aot_module, p, &p, &error);
-		mono_error_cleanup (&error); /* FIXME don't swallow the error */
+		ji->data.del_tramp->klass = decode_klass_ref (aot_module, p, &p, error);
+		mono_error_cleanup (error); /* FIXME don't swallow the error */
 		if (!ji->data.del_tramp->klass)
 			goto cleanup;
 		if (decode_value (p, &p)) {
-			ji->data.del_tramp->method = decode_resolve_method_ref (aot_module, p, &p, &error);
-			mono_error_cleanup (&error); /* FIXME don't swallow the error */
+			ji->data.del_tramp->method = decode_resolve_method_ref (aot_module, p, &p, error);
+			mono_error_cleanup (error); /* FIXME don't swallow the error */
 			if (!ji->data.del_tramp->method)
 				goto cleanup;
 		}
 		ji->data.del_tramp->is_virtual = decode_value (p, &p) ? TRUE : FALSE;
 		break;
 	case MONO_PATCH_INFO_IMAGE:
-		ji->data.image = load_image (aot_module, decode_value (p, &p), &error);
-		mono_error_cleanup (&error); /* FIXME don't swallow the error */
+		ji->data.image = load_image (aot_module, decode_value (p, &p), error);
+		mono_error_cleanup (error); /* FIXME don't swallow the error */
 		if (!ji->data.image)
 			goto cleanup;
 		break;
@@ -3680,8 +3680,8 @@ decode_patch (MonoAotModule *aot_module, MonoMemPool *mp, MonoJumpInfo *ji, guin
 		break;
 	}
 	case MONO_PATCH_INFO_LDSTR:
-		image = load_image (aot_module, decode_value (p, &p), &error);
-		mono_error_cleanup (&error); /* FIXME don't swallow the error */
+		image = load_image (aot_module, decode_value (p, &p), error);
+		mono_error_cleanup (error); /* FIXME don't swallow the error */
 		if (!image)
 			goto cleanup;
 		ji->data.token = mono_jump_info_token_new (mp, image, MONO_TOKEN_STRING + decode_value (p, &p));
@@ -3691,23 +3691,23 @@ decode_patch (MonoAotModule *aot_module, MonoMemPool *mp, MonoJumpInfo *ji, guin
 	case MONO_PATCH_INFO_LDTOKEN:
 	case MONO_PATCH_INFO_TYPE_FROM_HANDLE:
 		/* Shared */
-		image = load_image (aot_module, decode_value (p, &p), &error);
-		mono_error_cleanup (&error); /* FIXME don't swallow the error */
+		image = load_image (aot_module, decode_value (p, &p), error);
+		mono_error_cleanup (error); /* FIXME don't swallow the error */
 		if (!image)
 			goto cleanup;
 		ji->data.token = mono_jump_info_token_new (mp, image, decode_value (p, &p));
 
 		ji->data.token->has_context = decode_value (p, &p);
 		if (ji->data.token->has_context) {
-			gboolean res = decode_generic_context (aot_module, &ji->data.token->context, p, &p, &error);
-			mono_error_cleanup (&error); /* FIXME don't swallow the error */
+			gboolean res = decode_generic_context (aot_module, &ji->data.token->context, p, &p, error);
+			mono_error_cleanup (error); /* FIXME don't swallow the error */
 			if (!res)
 				goto cleanup;
 		}
 		break;
 	case MONO_PATCH_INFO_EXC_NAME:
-		ji->data.klass = decode_klass_ref (aot_module, p, &p, &error);
-		mono_error_cleanup (&error); /* FIXME don't swallow the error */
+		ji->data.klass = decode_klass_ref (aot_module, p, &p, error);
+		mono_error_cleanup (error); /* FIXME don't swallow the error */
 		if (!ji->data.klass)
 			goto cleanup;
 		ji->data.name = ji->data.klass->name;
@@ -3736,12 +3736,12 @@ decode_patch (MonoAotModule *aot_module, MonoMemPool *mp, MonoJumpInfo *ji, guin
 
 		entry = (MonoJumpInfoRgctxEntry *)mono_mempool_alloc0 (mp, sizeof (MonoJumpInfoRgctxEntry));
 		p2 = aot_module->blob + offset;
-		entry->method = decode_resolve_method_ref (aot_module, p2, &p2, &error);
+		entry->method = decode_resolve_method_ref (aot_module, p2, &p2, error);
 		entry->in_mrgctx = ((val & 1) > 0) ? TRUE : FALSE;
 		entry->info_type = (MonoRgctxInfoType)((val >> 1) & 0xff);
 		entry->data = (MonoJumpInfo *)mono_mempool_alloc0 (mp, sizeof (MonoJumpInfo));
 		entry->data->type = (MonoJumpInfoType)((val >> 9) & 0xff);
-		mono_error_cleanup (&error); /* FIXME don't swallow the error */
+		mono_error_cleanup (error); /* FIXME don't swallow the error */
 		
 		res = decode_patch (aot_module, mp, entry->data, p, &p);
 		if (!res)
@@ -3761,8 +3761,8 @@ decode_patch (MonoAotModule *aot_module, MonoMemPool *mp, MonoJumpInfo *ji, guin
 		MonoJumpInfoGSharedVtCall *info = (MonoJumpInfoGSharedVtCall *)mono_mempool_alloc0 (mp, sizeof (MonoJumpInfoGSharedVtCall));
 		info->sig = decode_signature (aot_module, p, &p);
 		g_assert (info->sig);
-		info->method = decode_resolve_method_ref (aot_module, p, &p, &error);
-		mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+		info->method = decode_resolve_method_ref (aot_module, p, &p, error);
+		mono_error_assert_ok (error); /* FIXME don't swallow the error */
 
 		ji->data.target = info;
 		break;
@@ -3771,8 +3771,8 @@ decode_patch (MonoAotModule *aot_module, MonoMemPool *mp, MonoJumpInfo *ji, guin
 		MonoGSharedVtMethodInfo *info = (MonoGSharedVtMethodInfo *)mono_mempool_alloc0 (mp, sizeof (MonoGSharedVtMethodInfo));
 		int i;
 		
-		info->method = decode_resolve_method_ref (aot_module, p, &p, &error);
-		mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+		info->method = decode_resolve_method_ref (aot_module, p, &p, error);
+		mono_error_assert_ok (error); /* FIXME don't swallow the error */
 
 		info->num_entries = decode_value (p, &p);
 		info->count_entries = info->num_entries;
@@ -3783,8 +3783,8 @@ decode_patch (MonoAotModule *aot_module, MonoMemPool *mp, MonoJumpInfo *ji, guin
 			template_->info_type = (MonoRgctxInfoType)decode_value (p, &p);
 			switch (mini_rgctx_info_type_to_patch_info_type (template_->info_type)) {
 			case MONO_PATCH_INFO_CLASS: {
-				MonoClass *klass = decode_klass_ref (aot_module, p, &p, &error);
-				mono_error_cleanup (&error); /* FIXME don't swallow the error */
+				MonoClass *klass = decode_klass_ref (aot_module, p, &p, error);
+				mono_error_cleanup (error); /* FIXME don't swallow the error */
 				if (!klass)
 					goto cleanup;
 				template_->data = &klass->byval_arg;
@@ -3817,11 +3817,11 @@ decode_patch (MonoAotModule *aot_module, MonoMemPool *mp, MonoJumpInfo *ji, guin
 	case MONO_PATCH_INFO_VIRT_METHOD: {
 		MonoJumpInfoVirtMethod *info = (MonoJumpInfoVirtMethod *)mono_mempool_alloc0 (mp, sizeof (MonoJumpInfoVirtMethod));
 
-		info->klass = decode_klass_ref (aot_module, p, &p, &error);
-		mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+		info->klass = decode_klass_ref (aot_module, p, &p, error);
+		mono_error_assert_ok (error); /* FIXME don't swallow the error */
 
-		info->method = decode_resolve_method_ref (aot_module, p, &p, &error);
-		mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+		info->method = decode_resolve_method_ref (aot_module, p, &p, error);
+		mono_error_assert_ok (error); /* FIXME don't swallow the error */
 
 		ji->data.target = info;
 		break;
@@ -4147,8 +4147,8 @@ find_aot_method_in_amodule (MonoAotModule *code_amodule, MonoMethod *method, gui
 		m = (MonoMethod *)g_hash_table_lookup (metadata_amodule->method_ref_to_method, p);
 		amodule_unlock (metadata_amodule);
 		if (!m) {
-			m = decode_resolve_method_ref_with_target (code_amodule, method, p, &p, &error);
-			mono_error_cleanup (&error); /* FIXME don't swallow the error */
+			m = decode_resolve_method_ref_with_target (code_amodule, method, p, &p, error);
+			mono_error_cleanup (error); /* FIXME don't swallow the error */
 			/*
 			 * Can't catche runtime invoke wrappers since it would break
 			 * the check in decode_method_ref_with_target ().
@@ -4402,9 +4402,9 @@ init_llvmonly_method (MonoAotModule *amodule, guint32 method_index, MonoMethod *
 	gboolean res;
 	ERROR_DECL (error);
 
-	res = init_method (amodule, method_index, method, init_class, context, &error);
-	if (!is_ok (&error)) {
-		MonoException *ex = mono_error_convert_to_exception (&error);
+	res = init_method (amodule, method_index, method, init_class, context, error);
+	if (!is_ok (error)) {
+		MonoException *ex = mono_error_convert_to_exception (error);
 		/* Its okay to raise in llvmonly mode */
 		if (ex)
 			mono_llvm_throw_exception ((MonoObject*)ex);
@@ -4495,7 +4495,7 @@ mono_aot_get_method_checked (MonoDomain *domain, MonoMethod *method, MonoError *
 	MonoAotModule *amodule = (MonoAotModule *)klass->image->aot_module;
 	guint8 *code;
 	gboolean cache_result = FALSE;
-	ERROR_DECL (inner_error);
+	ERROR_DECL_VALUE (inner_error);
 
 	error_init (error);
 
@@ -5205,8 +5205,8 @@ load_function_full (MonoAotModule *amodule, const char *name, MonoTrampInfo **ou
 				/* Hopefully the code doesn't have patches which need method or 
 				 * domain to be set.
 				 */
-				target = mono_resolve_patch_target (NULL, NULL, (guint8 *)code, ji, FALSE, &error);
-				mono_error_assert_ok (&error);
+				target = mono_resolve_patch_target (NULL, NULL, (guint8 *)code, ji, FALSE, error);
+				mono_error_assert_ok (error);
 				g_assert (target);
 			}
 

--- a/mono/mini/debug-mini.c
+++ b/mono/mini/debug-mini.c
@@ -134,8 +134,8 @@ mono_debug_add_vg_method (MonoMethod *method, MonoDebugMethodJitInfo *jit)
 	if (!RUNNING_ON_VALGRIND)
 		return;
 
-	header = mono_method_get_header_checked (method, &error);
-	mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+	header = mono_method_get_header_checked (method, error);
+	mono_error_assert_ok (error); /* FIXME don't swallow the error */
 
 	full_name = mono_method_full_name (method, TRUE);
 
@@ -537,8 +537,8 @@ deserialize_debug_info (MonoMethod *method, guint8 *code_start, guint8 *buf, gui
 	guint8 *p;
 	int i;
 
-	header = mono_method_get_header_checked (method, &error);
-	mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+	header = mono_method_get_header_checked (method, error);
+	mono_error_assert_ok (error); /* FIXME don't swallow the error */
 
 	jit = g_new0 (MonoDebugMethodJitInfo, 1);
 	jit->code_start = code_start;

--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -1527,7 +1527,7 @@ mono_decompose_array_access_opts (MonoCompile *cfg)
 						dest->dreg = ins->dreg;
 					} else {
 						MonoClass *array_class = mono_array_class_get (ins->inst_newa_class, 1);
-						ERROR_DECL (vt_error);
+						ERROR_DECL_VALUE (vt_error);
 						MonoVTable *vtable = mono_class_vtable_checked (cfg->domain, array_class, &vt_error);
 						MonoMethod *managed_alloc = mono_gc_get_managed_array_allocator (array_class);
 

--- a/mono/mini/dwarfwriter.c
+++ b/mono/mini/dwarfwriter.c
@@ -1316,8 +1316,8 @@ token_handler (MonoDisHelper *dh, MonoMethod *method, guint32 token)
 		if (method->wrapper_type) {
 			klass = (MonoClass *)data;
 		} else {
-			klass = mono_class_get_checked (method->klass->image, token, &error);
-			g_assert (mono_error_ok (&error)); /* FIXME error handling */
+			klass = mono_class_get_checked (method->klass->image, token, error);
+			g_assert (mono_error_ok (error)); /* FIXME error handling */
 		}
 		res = g_strdup_printf ("<%s>", klass->name);
 		break;
@@ -1328,9 +1328,9 @@ token_handler (MonoDisHelper *dh, MonoMethod *method, guint32 token)
 			cmethod = (MonoMethod *)data;
 		} else {
 			ERROR_DECL (error);
-			cmethod = mono_get_method_checked (method->klass->image, token, NULL, NULL, &error);
+			cmethod = mono_get_method_checked (method->klass->image, token, NULL, NULL, error);
 			if (!cmethod)
-				g_error ("Could not load method due to %s", mono_error_get_message (&error)); /* FIXME don't swallow the error */
+				g_error ("Could not load method due to %s", mono_error_get_message (error)); /* FIXME don't swallow the error */
 		}
 		desc = mono_method_full_name (cmethod, TRUE);
 		res = g_strdup_printf ("<%s>", desc);
@@ -1352,8 +1352,8 @@ token_handler (MonoDisHelper *dh, MonoMethod *method, guint32 token)
 		if (method->wrapper_type) {
 			field = (MonoClassField *)data;
 		} else {
-			field = mono_field_from_token_checked (method->klass->image, token, &klass, NULL,  &error);
-			g_assert (mono_error_ok (&error)); /* FIXME error handling */
+			field = mono_field_from_token_checked (method->klass->image, token, &klass, NULL,  error);
+			g_assert (mono_error_ok (error)); /* FIXME error handling */
 		}
 		desc = mono_field_full_name (field);
 		res = g_strdup_printf ("<%s>", desc);
@@ -1380,8 +1380,8 @@ disasm_ins (MonoMethod *method, const guchar *ip, const guint8 **endip)
 	ERROR_DECL (error);
 	char *dis;
 	MonoDisHelper dh;
-	MonoMethodHeader *header = mono_method_get_header_checked (method, &error);
-	mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+	MonoMethodHeader *header = mono_method_get_header_checked (method, error);
+	mono_error_assert_ok (error); /* FIXME don't swallow the error */
 
 	memset (&dh, 0, sizeof (dh));
 	dh.newline = "";
@@ -1503,12 +1503,12 @@ emit_line_number_info (MonoDwarfWriter *w, MonoMethod *method,
 	gboolean first = TRUE;
 	MonoDebugSourceLocation *loc;
 	char *prev_file_name = NULL;
-	MonoMethodHeader *header = mono_method_get_header_checked (method, &error);
+	MonoMethodHeader *header = mono_method_get_header_checked (method, error);
 	MonoDebugMethodInfo *minfo;
 	MonoDebugLineNumberEntry *ln_array;
 	int *native_to_il_offset = NULL;
 	
-	mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+	mono_error_assert_ok (error); /* FIXME don't swallow the error */
 
 	if (!w->emit_line) {
 		mono_metadata_free_mh (header);
@@ -1770,8 +1770,8 @@ mono_dwarf_writer_emit_method (MonoDwarfWriter *w, MonoCompile *cfg, MonoMethod 
 	emit_section_change (w, ".debug_info", 0);
 
 	sig = mono_method_signature (method);
-	header = mono_method_get_header_checked (method, &error);
-	mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+	header = mono_method_get_header_checked (method, error);
+	mono_error_assert_ok (error); /* FIXME don't swallow the error */
 
 	/* Parameter types */
 	for (i = 0; i < sig->param_count + sig->hasthis; ++i) {

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -388,14 +388,14 @@ mono_amd64_throw_exception (guint64 dummy1, guint64 dummy2, guint64 dummy3, guin
 	/* mctx is on the caller's stack */
 	memcpy (&ctx, mctx, sizeof (MonoContext));
 
-	if (mono_object_isinst_checked (exc, mono_defaults.exception_class, &error)) {
+	if (mono_object_isinst_checked (exc, mono_defaults.exception_class, error)) {
 		MonoException *mono_ex = (MonoException*)exc;
 		if (!rethrow) {
 			mono_ex->stack_trace = NULL;
 			mono_ex->trace_ips = NULL;
 		}
 	}
-	mono_error_assert_ok (&error);
+	mono_error_assert_ok (error);
 
 	/* adjust eip so that it point into the call instruction */
 	ctx.gregs [AMD64_RIP] --;

--- a/mono/mini/exceptions-arm.c
+++ b/mono/mini/exceptions-arm.c
@@ -160,14 +160,14 @@ mono_arm_throw_exception (MonoObject *exc, mgreg_t pc, mgreg_t sp, mgreg_t *int_
 	memcpy (((guint8*)&ctx.regs) + (ARMREG_R4 * sizeof (mgreg_t)), int_regs, 8 * sizeof (mgreg_t));
 	memcpy (&ctx.fregs, fp_regs, sizeof (double) * 16);
 
-	if (mono_object_isinst_checked (exc, mono_defaults.exception_class, &error)) {
+	if (mono_object_isinst_checked (exc, mono_defaults.exception_class, error)) {
 		MonoException *mono_ex = (MonoException*)exc;
 		if (!rethrow) {
 			mono_ex->stack_trace = NULL;
 			mono_ex->trace_ips = NULL;
 		}
 	}
-	mono_error_assert_ok (&error);
+	mono_error_assert_ok (error);
 	mono_handle_exception (&ctx, exc);
 	mono_restore_context (&ctx);
 	g_assert_not_reached ();

--- a/mono/mini/exceptions-arm64.c
+++ b/mono/mini/exceptions-arm64.c
@@ -400,14 +400,14 @@ mono_arm_throw_exception (gpointer arg, mgreg_t pc, mgreg_t *int_regs, gdouble *
 	ctx.has_fregs = 1;
 	ctx.pc = pc;
 
-	if (mono_object_isinst_checked (exc, mono_defaults.exception_class, &error)) {
+	if (mono_object_isinst_checked (exc, mono_defaults.exception_class, error)) {
 		MonoException *mono_ex = (MonoException*)exc;
 		if (!rethrow) {
 			mono_ex->stack_trace = NULL;
 			mono_ex->trace_ips = NULL;
 		}
 	}
-	mono_error_assert_ok (&error);
+	mono_error_assert_ok (error);
 
 	mono_handle_exception (&ctx, exc);
 

--- a/mono/mini/exceptions-mips.c
+++ b/mono/mini/exceptions-mips.c
@@ -198,14 +198,14 @@ throw_exception (MonoObject *exc, unsigned long eip, unsigned long esp, gboolean
 	memset (&ctx.sc_fpregs, 0, sizeof (mips_freg) * MONO_SAVED_FREGS);
 	MONO_CONTEXT_SET_IP (&ctx, eip);
 
-	if (mono_object_isinst_checked (exc, mono_defaults.exception_class, &error)) {
+	if (mono_object_isinst_checked (exc, mono_defaults.exception_class, error)) {
 		MonoException *mono_ex = (MonoException*)exc;
 		if (!rethrow) {
 			mono_ex->stack_trace = NULL;
 			mono_ex->trace_ips = NULL;
 		}
 	}
-	mono_error_assert_ok (&error);
+	mono_error_assert_ok (error);
 	mono_handle_exception (&ctx, exc);
 #ifdef DEBUG_EXCEPTIONS
 	g_print ("throw_exception: restore to pc=%p sp=%p fp=%p ctx=%p\n",

--- a/mono/mini/exceptions-ppc.c
+++ b/mono/mini/exceptions-ppc.c
@@ -338,14 +338,14 @@ mono_ppc_throw_exception (MonoObject *exc, unsigned long eip, unsigned long esp,
 	memcpy (&ctx.regs, int_regs, sizeof (mgreg_t) * MONO_MAX_IREGS);
 	memcpy (&ctx.fregs, fp_regs, sizeof (double) * MONO_MAX_FREGS);
 
-	if (mono_object_isinst_checked (exc, mono_defaults.exception_class, &error)) {
+	if (mono_object_isinst_checked (exc, mono_defaults.exception_class, error)) {
 		MonoException *mono_ex = (MonoException*)exc;
 		if (!rethrow) {
 			mono_ex->stack_trace = NULL;
 			mono_ex->trace_ips = NULL;
 		}
 	}
-	mono_error_assert_ok (&error);
+	mono_error_assert_ok (error);
 	mono_handle_exception (&ctx, exc);
 	mono_restore_context (&ctx);
 

--- a/mono/mini/exceptions-s390x.c
+++ b/mono/mini/exceptions-s390x.c
@@ -264,14 +264,14 @@ throw_exception (MonoObject *exc, unsigned long ip, unsigned long sp,
 	MONO_CONTEXT_SET_BP (&ctx, sp);
 	MONO_CONTEXT_SET_IP (&ctx, ip);
 	
-	if (mono_object_isinst_checked (exc, mono_defaults.exception_class, &error)) {
+	if (mono_object_isinst_checked (exc, mono_defaults.exception_class, error)) {
 		MonoException *mono_ex = (MonoException*)exc;
 		if (!rethrow) {
 			mono_ex->stack_trace = NULL;
 			mono_ex->trace_ips = NULL;
 		}
 	}
-	mono_error_assert_ok (&error);
+	mono_error_assert_ok (error);
 //	mono_arch_handle_exception (&ctx, exc, FALSE);
 	mono_handle_exception (&ctx, exc);
 	mono_restore_context(&ctx);

--- a/mono/mini/exceptions-sparc.c
+++ b/mono/mini/exceptions-sparc.c
@@ -180,14 +180,14 @@ throw_exception (MonoObject *exc, gpointer sp, gpointer ip, gboolean rethrow)
 	ctx.ip = ip;
 	ctx.fp = (gpointer*)(MONO_SPARC_WINDOW_ADDR (sp) [sparc_i6 - 16]);
 
-	if (mono_object_isinst_checked (exc, mono_defaults.exception_class, &error)) {
+	if (mono_object_isinst_checked (exc, mono_defaults.exception_class, error)) {
 		MonoException *mono_ex = (MonoException*)exc;
 		if (!rethrow) {
 			mono_ex->stack_trace = NULL;
 			mono_ex->trace_ips = NULL;
 		}
 	}
-	mono_error_assert_ok (&error);
+	mono_error_assert_ok (error);
 	mono_handle_exception (&ctx, exc);
 	restore_context (&ctx);
 

--- a/mono/mini/exceptions-x86.c
+++ b/mono/mini/exceptions-x86.c
@@ -473,14 +473,14 @@ mono_x86_throw_exception (mgreg_t *regs, MonoObject *exc,
 	g_assert ((ctx.esp % MONO_ARCH_FRAME_ALIGNMENT) == 0);
 #endif
 
-	if (mono_object_isinst_checked (exc, mono_defaults.exception_class, &error)) {
+	if (mono_object_isinst_checked (exc, mono_defaults.exception_class, error)) {
 		MonoException *mono_ex = (MonoException*)exc;
 		if (!rethrow) {
 			mono_ex->stack_trace = NULL;
 			mono_ex->trace_ips = NULL;
 		}
 	}
-	mono_error_assert_ok (&error);
+	mono_error_assert_ok (error);
 
 	/* adjust eip so that it point into the call instruction */
 	ctx.eip -= 1;

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -241,8 +241,8 @@ ves_real_abort (int line, MonoMethod *mh,
 		const unsigned short *ip, stackval *stack, stackval *sp)
 {
 	ERROR_DECL (error);
-	MonoMethodHeader *header = mono_method_get_header_checked (mh, &error);
-	mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+	MonoMethodHeader *header = mono_method_get_header_checked (mh, error);
+	mono_error_cleanup (error); /* FIXME: don't swallow the error */
 	g_printerr ("Execution aborted in method: %s::%s\n", mh->klass->name, mh->name);
 	g_printerr ("Line=%d IP=0x%04lx, Aborted execution\n", line, ip-(const unsigned short *) header->code);
 	g_print ("0x%04x %02x\n", ip-(const unsigned short *) header->code, *ip);
@@ -368,18 +368,18 @@ get_virtual_method (InterpMethod *imethod, MonoObject *obj)
 
 #ifndef DISABLE_REMOTING
 	if (mono_object_is_transparent_proxy (obj)) {
-		MonoMethod *remoting_invoke_method = mono_marshal_get_remoting_invoke_with_check (m, &error);
-		mono_error_assert_ok (&error);
-		ret = mono_interp_get_imethod (domain, remoting_invoke_method, &error);
-		mono_error_assert_ok (&error);
+		MonoMethod *remoting_invoke_method = mono_marshal_get_remoting_invoke_with_check (m, error);
+		mono_error_assert_ok (error);
+		ret = mono_interp_get_imethod (domain, remoting_invoke_method, error);
+		mono_error_assert_ok (error);
 		return ret;
 	}
 #endif
 
 	if ((m->flags & METHOD_ATTRIBUTE_FINAL) || !(m->flags & METHOD_ATTRIBUTE_VIRTUAL)) {
 		if (m->iflags & METHOD_IMPL_ATTRIBUTE_SYNCHRONIZED) {
-			ret = mono_interp_get_imethod (domain, mono_marshal_get_synchronized_wrapper (m), &error);
-			mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+			ret = mono_interp_get_imethod (domain, mono_marshal_get_synchronized_wrapper (m), error);
+			mono_error_cleanup (error); /* FIXME: don't swallow the error */
 		} else {
 			ret = imethod;
 		}
@@ -406,16 +406,16 @@ get_virtual_method (InterpMethod *imethod, MonoObject *obj)
 			context.class_inst = mono_class_get_generic_container (virtual_method->klass)->context.class_inst;
 		context.method_inst = mono_method_get_context (m)->method_inst;
 
-		virtual_method = mono_class_inflate_generic_method_checked (virtual_method, &context, &error);
-		mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+		virtual_method = mono_class_inflate_generic_method_checked (virtual_method, &context, error);
+		mono_error_cleanup (error); /* FIXME: don't swallow the error */
 	}
 
 	if (virtual_method->iflags & METHOD_IMPL_ATTRIBUTE_SYNCHRONIZED) {
 		virtual_method = mono_marshal_get_synchronized_wrapper (virtual_method);
 	}
 
-	InterpMethod *virtual_imethod = mono_interp_get_imethod (domain, virtual_method, &error);
-	mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+	InterpMethod *virtual_imethod = mono_interp_get_imethod (domain, virtual_method, error);
+	mono_error_cleanup (error); /* FIXME: don't swallow the error */
 	return virtual_imethod;
 }
 
@@ -711,8 +711,8 @@ fill_in_trace (MonoException *exception, InterpFrame *frame)
 	ERROR_DECL (error);
 	char *stack_trace = dump_frame (frame);
 	MonoDomain *domain = frame->imethod->domain;
-	(exception)->stack_trace = mono_string_new_checked (domain, stack_trace, &error);
-	mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+	(exception)->stack_trace = mono_string_new_checked (domain, stack_trace, error);
+	mono_error_cleanup (error); /* FIXME: don't swallow the error */
 	(exception)->trace_ips = get_trace_ips (domain, frame);
 	g_free (stack_trace);
 }
@@ -771,12 +771,12 @@ ves_array_create (InterpFrame *frame, MonoDomain *domain, MonoClass *klass, Mono
 		lower_bounds = (intptr_t *) lengths;
 		lengths += klass->rank;
 	}
-	obj = (MonoObject*) mono_array_new_full_checked (domain, klass, lengths, lower_bounds, &error);
-	if (!mono_error_ok (&error)) {
-		frame->ex = mono_error_convert_to_exception (&error);
+	obj = (MonoObject*) mono_array_new_full_checked (domain, klass, lengths, lower_bounds, error);
+	if (!mono_error_ok (error)) {
+		frame->ex = mono_error_convert_to_exception (error);
 		FILL_IN_TRACE (frame->ex, frame);
 	}
-	mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+	mono_error_cleanup (error); /* FIXME: don't swallow the error */
 	return obj;
 }
 
@@ -827,8 +827,8 @@ ves_array_set (InterpFrame *frame)
 
 	if (sp [ac->rank].data.p && !mono_object_class (o)->element_class->valuetype) {
 		ERROR_DECL (error);
-		MonoObject *isinst = mono_object_isinst_checked (sp [ac->rank].data.p, mono_object_class (o)->element_class, &error);
-		mono_error_cleanup (&error);
+		MonoObject *isinst = mono_object_isinst_checked (sp [ac->rank].data.p, mono_object_class (o)->element_class, error);
+		mono_error_cleanup (error);
 		if (!isinst) {
 			frame->ex = mono_get_exception_array_type_mismatch ();
 			FILL_IN_TRACE (frame->ex, frame);
@@ -1251,8 +1251,8 @@ ves_imethod (InterpFrame *frame, ThreadContext *context)
 		}
 	}
 
-	isinst_obj = mono_object_isinst_checked (obj, mono_defaults.array_class, &error);
-	mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+	isinst_obj = mono_object_isinst_checked (obj, mono_defaults.array_class, error);
+	mono_error_cleanup (error); /* FIXME: don't swallow the error */
 	if (obj && isinst_obj) {
 		if (*name == 'S' && (strcmp (name, "Set") == 0)) {
 			ves_array_set (frame);
@@ -1390,8 +1390,8 @@ dump_frame (InterpFrame *inv)
 
 			if ((method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL) == 0 &&
 				(method->iflags & METHOD_IMPL_ATTRIBUTE_RUNTIME) == 0) {
-				MonoMethodHeader *hd = mono_method_get_header_checked (method, &error);
-				mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+				MonoMethodHeader *hd = mono_method_get_header_checked (method, error);
+				mono_error_cleanup (error); /* FIXME: don't swallow the error */
 
 				if (hd != NULL) {
 					if (inv->ip) {
@@ -1435,8 +1435,8 @@ get_trace_ips (MonoDomain *domain, InterpFrame *top)
 		if (inv->imethod != NULL)
 			++i;
 
-	res = mono_array_new_checked (domain, mono_defaults.int_class, 3 * i, &error);
-	mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+	res = mono_array_new_checked (domain, mono_defaults.int_class, 3 * i, error);
+	mono_error_cleanup (error); /* FIXME: don't swallow the error */
 
 	for (i = 0, inv = top; inv; inv = inv->parent)
 		if (inv->imethod != NULL) {
@@ -1826,12 +1826,12 @@ do_jit_call (stackval *sp, unsigned char *vt_sp, ThreadContext *context, InterpF
 		MonoMethod *wrapper = mini_get_gsharedvt_out_sig_wrapper (sig);
 		//printf ("J: %s %s\n", mono_method_full_name (method, 1), mono_method_full_name (wrapper, 1));
 
-		gpointer jit_wrapper = mono_jit_compile_method_jit_only (wrapper, &error);
-		mono_error_assert_ok (&error);
+		gpointer jit_wrapper = mono_jit_compile_method_jit_only (wrapper, error);
+		mono_error_assert_ok (error);
 
-		gpointer addr = mono_jit_compile_method_jit_only (method, &error);
+		gpointer addr = mono_jit_compile_method_jit_only (method, error);
 		g_assert (addr);
-		mono_error_assert_ok (&error);
+		mono_error_assert_ok (error);
 
 		rmethod->jit_addr = addr;
 		rmethod->jit_sig = sig;
@@ -2571,8 +2571,8 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 			child_frame.stack_args = sp;
 
 			if (child_frame.imethod->method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL) {
-				child_frame.imethod = mono_interp_get_imethod (rtm->domain, mono_marshal_get_native_wrapper (child_frame.imethod->method, FALSE, FALSE), &error);
-				mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+				child_frame.imethod = mono_interp_get_imethod (rtm->domain, mono_marshal_get_native_wrapper (child_frame.imethod->method, FALSE, FALSE), error);
+				mono_error_cleanup (error); /* FIXME: don't swallow the error */
 			}
 
 			if (csignature->hasthis) {
@@ -3598,19 +3598,19 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 				}
 			} else {
 				if (newobj_class != mono_defaults.string_class) {
-					MonoVTable *vtable = mono_class_vtable_checked (rtm->domain, newobj_class, &error);
-					if (!mono_error_ok (&error) || !mono_runtime_class_init_full (vtable, &error))
-						THROW_EX (mono_error_convert_to_exception (&error), ip);
-					o = mono_object_new_checked (rtm->domain, newobj_class, &error);
-					mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+					MonoVTable *vtable = mono_class_vtable_checked (rtm->domain, newobj_class, error);
+					if (!mono_error_ok (error) || !mono_runtime_class_init_full (vtable, error))
+						THROW_EX (mono_error_convert_to_exception (error), ip);
+					o = mono_object_new_checked (rtm->domain, newobj_class, error);
+					mono_error_cleanup (error); /* FIXME: don't swallow the error */
 					EXCEPTION_CHECKPOINT;
 					sp->data.p = o;
 #ifndef DISABLE_REMOTING
 					if (mono_object_is_transparent_proxy (o)) {
-						MonoMethod *remoting_invoke_method = mono_marshal_get_remoting_invoke_with_check (child_frame.imethod->method, &error);
-						mono_error_assert_ok (&error);
-						child_frame.imethod = mono_interp_get_imethod (rtm->domain, remoting_invoke_method, &error);
-						mono_error_assert_ok (&error);
+						MonoMethod *remoting_invoke_method = mono_marshal_get_remoting_invoke_with_check (child_frame.imethod->method, error);
+						mono_error_assert_ok (error);
+						child_frame.imethod = mono_interp_get_imethod (rtm->domain, remoting_invoke_method, error);
+						mono_error_assert_ok (error);
 					}
 #endif
 				} else {
@@ -3659,8 +3659,8 @@ array_constructed:
 		MINT_IN_CASE(MINT_CASTCLASS)
 			c = rtm->data_items [*(guint16 *)(ip + 1)];
 			if ((o = sp [-1].data.p)) {
-				MonoObject *isinst_obj = mono_object_isinst_checked (o, c, &error);
-				mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+				MonoObject *isinst_obj = mono_object_isinst_checked (o, c, error);
+				mono_error_cleanup (error); /* FIXME: don't swallow the error */
 				if (!isinst_obj)
 					THROW_EX (mono_get_exception_invalid_cast (), ip);
 			}
@@ -3669,8 +3669,8 @@ array_constructed:
 		MINT_IN_CASE(MINT_ISINST)
 			c = rtm->data_items [*(guint16 *)(ip + 1)];
 			if ((o = sp [-1].data.p)) {
-				MonoObject *isinst_obj = mono_object_isinst_checked (o, c, &error);
-				mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+				MonoObject *isinst_obj = mono_object_isinst_checked (o, c, error);
+				mono_error_cleanup (error); /* FIXME: don't swallow the error */
 				if (!isinst_obj)
 					sp [-1].data.p = NULL;
 			}
@@ -3691,8 +3691,8 @@ array_constructed:
 			if (!o)
 				THROW_EX (mono_get_exception_null_reference (), ip);
 
-			MonoObject *isinst_obj = mono_object_isinst_checked (o, c, &error);
-			mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+			MonoObject *isinst_obj = mono_object_isinst_checked (o, c, error);
+			mono_error_cleanup (error); /* FIXME: don't swallow the error */
 			if (!(isinst_obj || ((o->vtable->klass->rank == 0) && (o->vtable->klass->element_class == c->element_class))))
 				THROW_EX (mono_get_exception_invalid_cast (), ip);
 
@@ -3782,8 +3782,8 @@ array_constructed:
 			if (mono_object_is_transparent_proxy (o)) {
 				MonoClass *klass = ((MonoTransparentProxy*)o)->remote_class->proxy_class;
 
-				addr = mono_load_remote_field_checked (o, klass, field, &tmp, &error);
-				mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+				addr = mono_load_remote_field_checked (o, klass, field, &tmp, error);
+				mono_error_cleanup (error); /* FIXME: don't swallow the error */
 			} else
 #endif
 				addr = (char*)o + field->offset;
@@ -3809,8 +3809,8 @@ array_constructed:
 #ifndef DISABLE_REMOTING
 			if (mono_object_is_transparent_proxy (o)) {
 				MonoClass *klass = ((MonoTransparentProxy*)o)->remote_class->proxy_class;
-				addr = mono_load_remote_field_checked (o, klass, field, &tmp, &error);
-				mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+				addr = mono_load_remote_field_checked (o, klass, field, &tmp, error);
+				mono_error_cleanup (error); /* FIXME: don't swallow the error */
 			} else
 #endif
 				addr = (char*)o + field->offset;
@@ -3878,8 +3878,8 @@ array_constructed:
 #ifndef DISABLE_REMOTING
 			if (mono_object_is_transparent_proxy (o)) {
 				MonoClass *klass = ((MonoTransparentProxy*)o)->remote_class->proxy_class;
-				mono_store_remote_field_checked (o, klass, field, &sp [-1].data, &error);
-				mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+				mono_store_remote_field_checked (o, klass, field, &sp [-1].data, error);
+				mono_error_cleanup (error); /* FIXME: don't swallow the error */
 			} else
 #endif
 				stackval_to_data (field->type, &sp [-1], (char*)o + field->offset, FALSE);
@@ -3901,8 +3901,8 @@ array_constructed:
 #ifndef DISABLE_REMOTING
 			if (mono_object_is_transparent_proxy (o)) {
 				MonoClass *klass = ((MonoTransparentProxy*)o)->remote_class->proxy_class;
-				mono_store_remote_field_checked (o, klass, field, &sp [-1].data, &error);
-				mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+				mono_store_remote_field_checked (o, klass, field, &sp [-1].data, error);
+				mono_error_cleanup (error); /* FIXME: don't swallow the error */
 			} else
 #endif
 				mono_value_copy ((char *) o + field->offset, sp [-1].data.p, klass);
@@ -4034,25 +4034,25 @@ array_constructed:
 
 			if (mint_type (&c->byval_arg) == MINT_TYPE_VT && !c->enumtype && !(mono_class_is_magic_int (c) || mono_class_is_magic_float (c))) {
 				int size = mono_class_value_size (c, NULL);
-				sp [-1 - offset].data.p = mono_value_box_checked (rtm->domain, c, sp [-1 - offset].data.p, &error);
-				mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+				sp [-1 - offset].data.p = mono_value_box_checked (rtm->domain, c, sp [-1 - offset].data.p, error);
+				mono_error_cleanup (error); /* FIXME: don't swallow the error */
 				size = (size + 7) & ~7;
 				if (pop_vt_sp)
 					vt_sp -= size;
 			} else {
 				stackval_to_data (&c->byval_arg, &sp [-1 - offset], (char *) &sp [-1 - offset], FALSE);
-				sp [-1 - offset].data.p = mono_value_box_checked (rtm->domain, c, &sp [-1 - offset], &error);
-				mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+				sp [-1 - offset].data.p = mono_value_box_checked (rtm->domain, c, &sp [-1 - offset], error);
+				mono_error_cleanup (error); /* FIXME: don't swallow the error */
 			}
 			ip += 3;
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_NEWARR)
-			sp [-1].data.p = (MonoObject*) mono_array_new_checked (rtm->domain, rtm->data_items[*(guint16 *)(ip + 1)], sp [-1].data.i, &error);
-			if (!mono_error_ok (&error)) {
-				THROW_EX (mono_error_convert_to_exception (&error), ip);
+			sp [-1].data.p = (MonoObject*) mono_array_new_checked (rtm->domain, rtm->data_items[*(guint16 *)(ip + 1)], sp [-1].data.i, error);
+			if (!mono_error_ok (error)) {
+				THROW_EX (mono_error_convert_to_exception (error), ip);
 			}
-			mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+			mono_error_cleanup (error); /* FIXME: don't swallow the error */
 			ip += 2;
 			/*if (profiling_classes) {
 				guint count = GPOINTER_TO_UINT (g_hash_table_lookup (profiling_classes, o->vtable->klass));
@@ -4244,8 +4244,8 @@ array_constructed:
 				mono_array_set ((MonoArray *)o, double, aindex, sp [2].data.f);
 				break;
 			case MINT_STELEM_REF: {
-				MonoObject *isinst_obj = mono_object_isinst_checked (sp [2].data.p, mono_object_class (o)->element_class, &error);
-				mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+				MonoObject *isinst_obj = mono_object_isinst_checked (sp [2].data.p, mono_object_class (o)->element_class, error);
+				mono_error_cleanup (error); /* FIXME: don't swallow the error */
 				if (sp [2].data.p && !isinst_obj)
 					THROW_EX (mono_get_exception_array_type_mismatch (), ip);
 				mono_array_setref ((MonoArray *) o, aindex, sp [2].data.p);
@@ -4597,8 +4597,8 @@ array_constructed:
 			++sp;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_MONO_NEWOBJ)
-			sp->data.p = mono_object_new_checked (rtm->domain, rtm->data_items [*(guint16 *)(ip + 1)], &error);
-			mono_error_cleanup (&error); /* FIXME: don't swallow the error */
+			sp->data.p = mono_object_new_checked (rtm->domain, rtm->data_items [*(guint16 *)(ip + 1)], error);
+			mono_error_cleanup (error); /* FIXME: don't swallow the error */
 			ip += 2;
 			sp++;
 			MINT_IN_BREAK;

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -4414,22 +4414,22 @@ mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, Int
 	InterpMethod tmp_imethod;
 	InterpMethod *real_imethod;
 
-	error_init (&error);
+	error_init (error);
 
 	if (mono_class_is_open_constructed_type (&method->klass->byval_arg)) {
-		mono_error_set_invalid_operation (&error, "Could not execute the method because the containing type is not fully instantiated.");
-		return mono_error_convert_to_exception (&error);
+		mono_error_set_invalid_operation (error, "Could not execute the method because the containing type is not fully instantiated.");
+		return mono_error_convert_to_exception (error);
 	}
 
 	// g_printerr ("TRANSFORM(0x%016lx): begin %s::%s\n", mono_thread_current (), method->klass->name, method->name);
-	method_class_vt = mono_class_vtable_checked (domain, imethod->method->klass, &error);
-	if (!is_ok (&error))
-		return mono_error_convert_to_exception (&error);
+	method_class_vt = mono_class_vtable_checked (domain, imethod->method->klass, error);
+	if (!is_ok (error))
+		return mono_error_convert_to_exception (error);
 
 	if (!method_class_vt->initialized) {
-		mono_runtime_class_init_full (method_class_vt, &error);
-		if (!mono_error_ok (&error)) {
-			return mono_error_convert_to_exception (&error);
+		mono_runtime_class_init_full (method_class_vt, error);
+		if (!mono_error_ok (error)) {
+			return mono_error_convert_to_exception (error);
 		}
 	}
 
@@ -4509,9 +4509,9 @@ mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, Int
 	}
 
 	if (!header) {
-		header = mono_method_get_header_checked (method, &error);
-		if (!is_ok (&error))
-			return mono_error_convert_to_exception (&error);
+		header = mono_method_get_header_checked (method, error);
+		if (!is_ok (error))
+			return mono_error_convert_to_exception (error);
 	}
 
 	g_assert ((signature->param_count + signature->hasthis) < 1000);
@@ -4557,19 +4557,19 @@ mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, Int
 			break;
 		case MonoInlineMethod:
 			if (method->wrapper_type == MONO_WRAPPER_NONE && *ip != CEE_CALLI) {
-				m = mono_get_method_checked (image, read32 (ip + 1), NULL, generic_context, &error);
-				if (!is_ok (&error)) {
+				m = mono_get_method_checked (image, read32 (ip + 1), NULL, generic_context, error);
+				if (!is_ok (error)) {
 					g_free (is_bb_start);
 					mono_metadata_free_mh (header);
-					return mono_error_convert_to_exception (&error);
+					return mono_error_convert_to_exception (error);
 				}
 				mono_class_init (m->klass);
 				if (!mono_class_is_interface (m->klass)) {
-					mono_class_vtable_checked (domain, m->klass, &error);
-					if (!is_ok (&error)) {
+					mono_class_vtable_checked (domain, m->klass, error);
+					if (!is_ok (error)) {
 						g_free (is_bb_start);
 						mono_metadata_free_mh (header);
-						return mono_error_convert_to_exception (&error);
+						return mono_error_convert_to_exception (error);
 					}
 				}
 			}
@@ -4686,14 +4686,14 @@ mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, Int
 	imethod->args_size = offset;
 	g_assert (imethod->args_size < 10000);
 
-	error_init (&error);
-	generate (method, header, imethod, is_bb_start, generic_context, &error);
+	error_init (error);
+	generate (method, header, imethod, is_bb_start, generic_context, error);
 
 	mono_metadata_free_mh (header);
 	g_free (is_bb_start);
 
-	if (!mono_error_ok (&error))
-		return mono_error_convert_to_exception (&error);
+	if (!mono_error_ok (error))
+		return mono_error_convert_to_exception (error);
 
 	// FIXME: Add a different callback ?
 	MONO_PROFILER_RAISE (jit_done, (method, imethod->jinfo));

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -40,8 +40,8 @@ mono_ldftn (MonoMethod *method)
 	if (mono_llvm_only) {
 		// FIXME: No error handling
 
-		addr = mono_compile_method_checked (method, &error);
-		mono_error_assert_ok (&error);
+		addr = mono_compile_method_checked (method, error);
+		mono_error_assert_ok (error);
 		g_assert (addr);
 
 		if (mono_method_needs_static_rgctx_invoke (method, FALSE))
@@ -52,9 +52,9 @@ mono_ldftn (MonoMethod *method)
 		return addr;
 	}
 
-	addr = mono_create_jump_trampoline (mono_domain_get (), method, FALSE, &error);
-	if (!mono_error_ok (&error)) {
-		mono_error_set_pending_exception (&error);
+	addr = mono_create_jump_trampoline (mono_domain_get (), method, FALSE, error);
+	if (!mono_error_ok (error)) {
+		mono_error_set_pending_exception (error);
 		return NULL;
 	}
 	return mono_create_ftnptr (mono_domain_get (), addr);
@@ -82,9 +82,9 @@ ldvirtfn_internal (MonoObject *obj, MonoMethod *method, gboolean gshared)
 			context.class_inst = mono_class_get_generic_container (res->klass)->context.class_inst;
 		context.method_inst = mono_method_get_context (method)->method_inst;
 
-		res = mono_class_inflate_generic_method_checked (res, &context, &error);
-		if (!mono_error_ok (&error)) {
-			mono_error_set_pending_exception (&error);
+		res = mono_class_inflate_generic_method_checked (res, &context, error);
+		if (!mono_error_ok (error)) {
+			mono_error_set_pending_exception (error);
 			return NULL;
 		}
 	}
@@ -114,8 +114,8 @@ mono_helper_stelem_ref_check (MonoArray *array, MonoObject *val)
 		mono_set_pending_exception (mono_get_exception_null_reference ());
 		return;
 	}
-	if (val && !mono_object_isinst_checked (val, array->obj.vtable->klass->element_class, &error)) {
-		if (mono_error_set_pending_exception (&error))
+	if (val && !mono_object_isinst_checked (val, array->obj.vtable->klass->element_class, error)) {
+		if (mono_error_set_pending_exception (error))
 			return;
 		mono_set_pending_exception (mono_get_exception_array_type_mismatch ());
 		return;
@@ -709,10 +709,10 @@ mono_array_new_va (MonoMethod *cm, ...)
 	}
 	va_end(ap);
 
-	arr = mono_array_new_full_checked (domain, cm->klass, lengths, lower_bounds, &error);
+	arr = mono_array_new_full_checked (domain, cm->klass, lengths, lower_bounds, error);
 
-	if (!mono_error_ok (&error)) {
-		mono_error_set_pending_exception (&error);
+	if (!mono_error_ok (error)) {
+		mono_error_set_pending_exception (error);
 		return NULL;
 	}
 
@@ -745,10 +745,10 @@ mono_array_new_1 (MonoMethod *cm, guint32 length)
 		lower_bounds = NULL;
 	}
 
-	arr = mono_array_new_full_checked (domain, cm->klass, lengths, lower_bounds, &error);
+	arr = mono_array_new_full_checked (domain, cm->klass, lengths, lower_bounds, error);
 
-	if (!mono_error_ok (&error)) {
-		mono_error_set_pending_exception (&error);
+	if (!mono_error_ok (error)) {
+		mono_error_set_pending_exception (error);
 		return NULL;
 	}
 
@@ -781,10 +781,10 @@ mono_array_new_2 (MonoMethod *cm, guint32 length1, guint32 length2)
 		lower_bounds = NULL;
 	}
 
-	arr = mono_array_new_full_checked (domain, cm->klass, lengths, lower_bounds, &error);
+	arr = mono_array_new_full_checked (domain, cm->klass, lengths, lower_bounds, error);
 
-	if (!mono_error_ok (&error)) {
-		mono_error_set_pending_exception (&error);
+	if (!mono_error_ok (error)) {
+		mono_error_set_pending_exception (error);
 		return NULL;
 	}
 
@@ -818,10 +818,10 @@ mono_array_new_3 (MonoMethod *cm, guint32 length1, guint32 length2, guint32 leng
 		lower_bounds = NULL;
 	}
 
-	arr = mono_array_new_full_checked (domain, cm->klass, lengths, lower_bounds, &error);
+	arr = mono_array_new_full_checked (domain, cm->klass, lengths, lower_bounds, error);
 
-	if (!mono_error_ok (&error)) {
-		mono_error_set_pending_exception (&error);
+	if (!mono_error_ok (error)) {
+		mono_error_set_pending_exception (error);
 		return NULL;
 	}
 
@@ -856,10 +856,10 @@ mono_array_new_4 (MonoMethod *cm, guint32 length1, guint32 length2, guint32 leng
 		lower_bounds = NULL;
 	}
 
-	arr = mono_array_new_full_checked (domain, cm->klass, lengths, lower_bounds, &error);
+	arr = mono_array_new_full_checked (domain, cm->klass, lengths, lower_bounds, error);
 
-	if (!mono_error_ok (&error)) {
-		mono_error_set_pending_exception (&error);
+	if (!mono_error_ok (error)) {
+		mono_error_set_pending_exception (error);
 		return NULL;
 	}
 
@@ -877,14 +877,14 @@ mono_class_static_field_address (MonoDomain *domain, MonoClassField *field)
 
 	mono_class_init (field->parent);
 
-	vtable = mono_class_vtable_checked (domain, field->parent, &error);
-	if (!is_ok (&error)) {
-		mono_error_set_pending_exception (&error);
+	vtable = mono_class_vtable_checked (domain, field->parent, error);
+	if (!is_ok (error)) {
+		mono_error_set_pending_exception (error);
 		return NULL;
 	}
 	if (!vtable->initialized) {
-		if (!mono_runtime_class_init_full (vtable, &error)) {
-			mono_error_set_pending_exception (&error);
+		if (!mono_runtime_class_init_full (vtable, error)) {
+			mono_error_set_pending_exception (error);
 			return NULL;
 		}
 	}
@@ -911,9 +911,9 @@ mono_ldtoken_wrapper (MonoImage *image, int token, MonoGenericContext *context)
 	MonoClass *handle_class;
 	gpointer res;
 
-	res = mono_ldtoken_checked (image, token, &handle_class, context, &error);
-	if (!mono_error_ok (&error)) {
-		mono_error_set_pending_exception (&error);
+	res = mono_ldtoken_checked (image, token, &handle_class, context, error);
+	if (!mono_error_ok (error)) {
+		mono_error_set_pending_exception (error);
 		return NULL;
 	}
 	mono_class_init (handle_class);
@@ -1111,8 +1111,8 @@ mono_helper_compile_generic_method (MonoObject *obj, MonoMethod *method, gpointe
 	g_assert (!mono_class_is_ginst (vmethod->klass) || !mono_class_get_generic_class (vmethod->klass)->context.class_inst->is_open);
 	g_assert (!context->method_inst || !context->method_inst->is_open);
 
-	addr = mono_compile_method_checked (vmethod, &error);
-	if (mono_error_set_pending_exception (&error))
+	addr = mono_compile_method_checked (vmethod, error);
+	if (mono_error_set_pending_exception (error))
 		return NULL;
 
 	addr = mini_add_method_trampoline (vmethod, addr, mono_method_needs_static_rgctx_invoke (vmethod, FALSE), FALSE);
@@ -1130,8 +1130,8 @@ MonoString*
 ves_icall_mono_ldstr (MonoDomain *domain, MonoImage *image, guint32 idx)
 {
 	ERROR_DECL (error);
-	MonoString *result = mono_ldstr_checked (domain, image, idx, &error);
-	mono_error_set_pending_exception (&error);
+	MonoString *result = mono_ldstr_checked (domain, image, idx, error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 
@@ -1139,8 +1139,8 @@ MonoString*
 mono_helper_ldstr (MonoImage *image, guint32 idx)
 {
 	ERROR_DECL (error);
-	MonoString *result = mono_ldstr_checked (mono_domain_get (), image, idx, &error);
-	mono_error_set_pending_exception (&error);
+	MonoString *result = mono_ldstr_checked (mono_domain_get (), image, idx, error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 
@@ -1148,8 +1148,8 @@ MonoString*
 mono_helper_ldstr_mscorlib (guint32 idx)
 {
 	ERROR_DECL (error);
-	MonoString *result = mono_ldstr_checked (mono_domain_get (), mono_defaults.corlib, idx, &error);
-	mono_error_set_pending_exception (&error);
+	MonoString *result = mono_ldstr_checked (mono_domain_get (), mono_defaults.corlib, idx, error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 
@@ -1157,16 +1157,16 @@ MonoObject*
 mono_helper_newobj_mscorlib (guint32 idx)
 {
 	ERROR_DECL (error);
-	MonoClass *klass = mono_class_get_checked (mono_defaults.corlib, MONO_TOKEN_TYPE_DEF | idx, &error);
+	MonoClass *klass = mono_class_get_checked (mono_defaults.corlib, MONO_TOKEN_TYPE_DEF | idx, error);
 
-	if (!mono_error_ok (&error)) {
-		mono_error_set_pending_exception (&error);
+	if (!mono_error_ok (error)) {
+		mono_error_set_pending_exception (error);
 		return NULL;
 	}
 
-	MonoObject *obj = mono_object_new_checked (mono_domain_get (), klass, &error);
-	if (!mono_error_ok (&error))
-		mono_error_set_pending_exception (&error);
+	MonoObject *obj = mono_object_new_checked (mono_domain_get (), klass, error);
+	if (!mono_error_ok (error))
+		mono_error_set_pending_exception (error);
 	return obj;
 }
 
@@ -1191,8 +1191,8 @@ mono_create_corlib_exception_1 (guint32 token, MonoString *arg)
 {
 	ERROR_DECL (error);
 	MonoException *ret = mono_exception_from_token_two_strings_checked (
-		mono_defaults.corlib, token, arg, NULL, &error);
-	mono_error_set_pending_exception (&error);
+		mono_defaults.corlib, token, arg, NULL, error);
+	mono_error_set_pending_exception (error);
 	return ret;
 }
 
@@ -1201,8 +1201,8 @@ mono_create_corlib_exception_2 (guint32 token, MonoString *arg1, MonoString *arg
 {
 	ERROR_DECL (error);
 	MonoException *ret = mono_exception_from_token_two_strings_checked (
-		mono_defaults.corlib, token, arg1, arg2, &error);
-	mono_error_set_pending_exception (&error);
+		mono_defaults.corlib, token, arg1, arg2, error);
+	mono_error_set_pending_exception (error);
 	return ret;
 }
 
@@ -1224,9 +1224,9 @@ mono_object_castclass_unbox (MonoObject *obj, MonoClass *klass)
 	oklass = obj->vtable->klass;
 	if ((klass->enumtype && oklass == klass->element_class) || (oklass->enumtype && klass == oklass->element_class))
 		return obj;
-	if (mono_object_isinst_checked (obj, klass, &error))
+	if (mono_object_isinst_checked (obj, klass, error))
 		return obj;
-	if (mono_error_set_pending_exception (&error))
+	if (mono_error_set_pending_exception (error))
 		return NULL;
 
 	if (mini_get_debug_options ()->better_cast_details) {
@@ -1261,11 +1261,11 @@ mono_object_castclass_with_cache (MonoObject *obj, MonoClass *klass, gpointer *c
 	if (cached_vtable == obj_vtable)
 		return obj;
 
-	if (mono_object_isinst_checked (obj, klass, &error)) {
+	if (mono_object_isinst_checked (obj, klass, error)) {
 		*cache = obj_vtable;
 		return obj;
 	}
-	if (mono_error_set_pending_exception (&error))
+	if (mono_error_set_pending_exception (error))
 		return NULL;
 
 	if (mini_get_debug_options ()->better_cast_details) {
@@ -1295,11 +1295,11 @@ mono_object_isinst_with_cache (MonoObject *obj, MonoClass *klass, gpointer *cach
 		return (cached_vtable & 0x1) ? NULL : obj;
 	}
 
-	if (mono_object_isinst_checked (obj, klass, &error)) {
+	if (mono_object_isinst_checked (obj, klass, error)) {
 		*cache = (gpointer)obj_vtable;
 		return obj;
 	} else {
-		if (mono_error_set_pending_exception (&error))
+		if (mono_error_set_pending_exception (error))
 			return NULL;
 		/*negative cache*/
 		*cache = (gpointer)(obj_vtable | 0x1);
@@ -1320,8 +1320,8 @@ mono_get_native_calli_wrapper (MonoImage *image, MonoMethodSignature *sig, gpoin
 
 	m = mono_marshal_get_native_func_wrapper (image, sig, &piinfo, mspecs, func);
 
-	gpointer compiled_ptr = mono_compile_method_checked (m, &error);
-	mono_error_set_pending_exception (&error);
+	gpointer compiled_ptr = mono_compile_method_checked (m, error);
+	mono_error_set_pending_exception (error);
 	return compiled_ptr;
 }
 
@@ -1411,9 +1411,9 @@ mono_gsharedvt_constrained_call (gpointer mp, MonoMethod *cmethod, MonoClass *kl
 	gpointer this_arg;
 	gpointer new_args [16];
 
-	m = constrained_gsharedvt_call_setup (mp, cmethod, klass, &this_arg, &error);
-	if (!mono_error_ok (&error)) {
-		mono_error_set_pending_exception (&error);
+	m = constrained_gsharedvt_call_setup (mp, cmethod, klass, &this_arg, error);
+	if (!mono_error_ok (error)) {
+		mono_error_set_pending_exception (error);
 		return NULL;
 	}
 
@@ -1430,9 +1430,9 @@ mono_gsharedvt_constrained_call (gpointer mp, MonoMethod *cmethod, MonoClass *kl
 		this_arg = NULL;
 	}
 
-	o = mono_runtime_invoke_checked (m, this_arg, args, &error);
-	if (!mono_error_ok (&error)) {
-		mono_error_set_pending_exception (&error);
+	o = mono_runtime_invoke_checked (m, this_arg, args, error);
+	if (!mono_error_ok (error)) {
+		mono_error_set_pending_exception (error);
 		return NULL;
 	}
 
@@ -1454,8 +1454,8 @@ ves_icall_runtime_class_init (MonoVTable *vtable)
 	MONO_REQ_GC_UNSAFE_MODE;
 	ERROR_DECL (error);
 
-	mono_runtime_class_init_full (vtable, &error);
-	mono_error_set_pending_exception (&error);
+	mono_runtime_class_init_full (vtable, error);
+	mono_error_set_pending_exception (error);
 }
 
 
@@ -1463,8 +1463,8 @@ void
 mono_generic_class_init (MonoVTable *vtable)
 {
 	ERROR_DECL (error);
-	mono_runtime_class_init_full (vtable, &error);
-	mono_error_set_pending_exception (&error);
+	mono_runtime_class_init_full (vtable, error);
+	mono_error_set_pending_exception (error);
 }
 
 void
@@ -1474,8 +1474,8 @@ ves_icall_mono_delegate_ctor (MonoObject *this_obj_raw, MonoObject *target_raw, 
 	ERROR_DECL (error);
 	MONO_HANDLE_DCL (MonoObject, this_obj);
 	MONO_HANDLE_DCL (MonoObject, target);
-	mono_delegate_ctor (this_obj, target, addr, &error);
-	mono_error_set_pending_exception (&error);
+	mono_delegate_ctor (this_obj, target, addr, error);
+	mono_error_set_pending_exception (error);
 	HANDLE_FUNCTION_RETURN ();
 }
 
@@ -1485,9 +1485,9 @@ mono_fill_class_rgctx (MonoVTable *vtable, int index)
 	ERROR_DECL (error);
 	gpointer res;
 
-	res = mono_class_fill_runtime_generic_context (vtable, index, &error);
-	if (!mono_error_ok (&error)) {
-		mono_error_set_pending_exception (&error);
+	res = mono_class_fill_runtime_generic_context (vtable, index, error);
+	if (!mono_error_ok (error)) {
+		mono_error_set_pending_exception (error);
 		return NULL;
 	}
 	return res;
@@ -1499,9 +1499,9 @@ mono_fill_method_rgctx (MonoMethodRuntimeGenericContext *mrgctx, int index)
 	ERROR_DECL (error);
 	gpointer res;
 
-	res = mono_method_fill_runtime_generic_context (mrgctx, index, &error);
-	if (!mono_error_ok (&error)) {
-		mono_error_set_pending_exception (&error);
+	res = mono_method_fill_runtime_generic_context (mrgctx, index, error);
+	if (!mono_error_ok (error)) {
+		mono_error_set_pending_exception (error);
 		return NULL;
 	}
 	return res;
@@ -1568,9 +1568,9 @@ gpointer
 mono_resolve_iface_call_gsharedvt (MonoObject *this_obj, int imt_slot, MonoMethod *imt_method, gpointer *out_arg)
 {
 	ERROR_DECL (error);
-	gpointer res = resolve_iface_call (this_obj, imt_slot, imt_method, out_arg, TRUE, &error);
-	if (!is_ok (&error)) {
-		MonoException *ex = mono_error_convert_to_exception (&error);
+	gpointer res = resolve_iface_call (this_obj, imt_slot, imt_method, out_arg, TRUE, error);
+	if (!is_ok (error)) {
+		MonoException *ex = mono_error_convert_to_exception (error);
 		mono_llvm_throw_exception ((MonoObject*)ex);
 	}
 	return res;
@@ -1678,9 +1678,9 @@ mono_resolve_vcall_gsharedvt (MonoObject *this_obj, int slot, MonoMethod *imt_me
 	g_assert (this_obj);
 
 	ERROR_DECL (error);
-	gpointer result = resolve_vcall (this_obj->vtable, slot, imt_method, out_arg, TRUE, &error);
-	if (!is_ok (&error)) {
-		MonoException *ex = mono_error_convert_to_exception (&error);
+	gpointer result = resolve_vcall (this_obj->vtable, slot, imt_method, out_arg, TRUE, error);
+	if (!is_ok (error)) {
+		MonoException *ex = mono_error_convert_to_exception (error);
 		mono_llvm_throw_exception ((MonoObject*)ex);
 	}
 	return result;
@@ -1720,15 +1720,15 @@ mono_resolve_generic_virtual_call (MonoVTable *vt, int slot, MonoMethod *generic
 	g_assert (generic_virtual->is_inflated);
 	context.method_inst = ((MonoMethodInflated*)generic_virtual)->context.method_inst;
 
-	m = mono_class_inflate_generic_method_checked (declaring, &context, &error);
-	g_assert (mono_error_ok (&error));
+	m = mono_class_inflate_generic_method_checked (declaring, &context, error);
+	g_assert (mono_error_ok (error));
 
 	if (vt->klass->valuetype)
 		need_unbox_tramp = TRUE;
 
 	// FIXME: This can throw exceptions
-	addr = compiled_method = mono_compile_method_checked (m, &error);
-	mono_error_assert_ok (&error);
+	addr = compiled_method = mono_compile_method_checked (m, error);
+	mono_error_assert_ok (error);
 	g_assert (addr);
 
 	addr = mini_add_method_wrappers_llvmonly (m, addr, FALSE, need_unbox_tramp, &arg);
@@ -1765,9 +1765,9 @@ mono_resolve_generic_virtual_iface_call (MonoVTable *vt, int imt_slot, MonoMetho
 
 	imt = (gpointer*)vt - MONO_IMT_SIZE;
 
-	mini_resolve_imt_method (vt, imt + imt_slot, generic_virtual, &m, &aot_addr, &need_rgctx_tramp, &variant_iface, &error);
-	if (!is_ok (&error)) {
-		MonoException *ex = mono_error_convert_to_exception (&error);
+	mini_resolve_imt_method (vt, imt + imt_slot, generic_virtual, &m, &aot_addr, &need_rgctx_tramp, &variant_iface, error);
+	if (!is_ok (error)) {
+		MonoException *ex = mono_error_convert_to_exception (error);
 		mono_llvm_throw_exception ((MonoObject*)ex);
 	}
 
@@ -1777,9 +1777,9 @@ mono_resolve_generic_virtual_iface_call (MonoVTable *vt, int imt_slot, MonoMetho
 	if (m->iflags & METHOD_IMPL_ATTRIBUTE_SYNCHRONIZED)
 		m = mono_marshal_get_synchronized_wrapper (m);
 
-	addr = compiled_method = mono_compile_method_checked (m, &error);
-	if (!is_ok (&error))
-		mono_llvm_raise_exception (mono_error_convert_to_exception (&error));
+	addr = compiled_method = mono_compile_method_checked (m, error);
+	if (!is_ok (error))
+		mono_llvm_raise_exception (mono_error_convert_to_exception (error));
 	g_assert (addr);
 
 	addr = mini_add_method_wrappers_llvmonly (m, addr, FALSE, need_unbox_tramp, &arg);
@@ -1811,8 +1811,8 @@ mono_init_vtable_slot (MonoVTable *vtable, int slot)
 	gpointer addr;
 	gpointer *ftnptr;
 
-	addr = resolve_vcall (vtable, slot, NULL, &arg, FALSE, &error);
-	if (mono_error_set_pending_exception (&error))
+	addr = resolve_vcall (vtable, slot, NULL, &arg, FALSE, error);
+	if (mono_error_set_pending_exception (error))
 		return NULL;
 	ftnptr = mono_domain_alloc0 (vtable->domain, 2 * sizeof (gpointer));
 	ftnptr [0] = addr;
@@ -1846,8 +1846,8 @@ mono_llvmonly_init_delegate (MonoDelegate *del)
 		if (m->iflags & METHOD_IMPL_ATTRIBUTE_SYNCHRONIZED)
 			m = mono_marshal_get_synchronized_wrapper (m);
 
-		gpointer addr = mono_compile_method_checked (m, &error);
-		if (mono_error_set_pending_exception (&error))
+		gpointer addr = mono_compile_method_checked (m, error);
+		if (mono_error_set_pending_exception (error))
 			return;
 
 		if (m->klass->valuetype && mono_method_signature (m)->hasthis)
@@ -1876,8 +1876,8 @@ mono_llvmonly_init_delegate_virtual (MonoDelegate *del, MonoObject *target, Mono
 		method = mono_marshal_get_synchronized_wrapper (method);
 
 	del->method = method;
-	del->method_ptr = mono_compile_method_checked (method, &error);
-	if (mono_error_set_pending_exception (&error))
+	del->method_ptr = mono_compile_method_checked (method, error);
+	if (mono_error_set_pending_exception (error))
 		return;
 	if (method->klass->valuetype)
 		del->method_ptr = mono_aot_get_unbox_trampoline (method);
@@ -1888,7 +1888,7 @@ MonoObject*
 mono_get_assembly_object (MonoImage *image)
 {
 	ICALL_ENTRY();
-	MonoObjectHandle result = MONO_HANDLE_CAST (MonoObject, mono_assembly_get_object_handle (mono_domain_get (), image->assembly, &error));
+	MonoObjectHandle result = MONO_HANDLE_CAST (MonoObject, mono_assembly_get_object_handle (mono_domain_get (), image->assembly, error));
 	ICALL_RETURN_OBJ (result);
 }
 
@@ -1897,8 +1897,8 @@ mono_get_method_object (MonoMethod *method)
 {
 	ERROR_DECL (error);
 	MonoObject * result;
-	result = (MonoObject*)mono_method_get_object_checked (mono_domain_get (), method, method->klass, &error);
-	mono_error_set_pending_exception (&error);
+	result = (MonoObject*)mono_method_get_object_checked (mono_domain_get (), method, method->klass, error);
+	mono_error_set_pending_exception (error);
 	return result;
 }
 
@@ -1917,9 +1917,9 @@ mono_throw_method_access (MonoMethod *caller, MonoMethod *callee)
 	char *callee_name = mono_method_get_reflection_name (callee);
 	ERROR_DECL (error);
 
-	error_init (&error);
-	mono_error_set_generic_error (&error, "System", "MethodAccessException", "Method `%s' is inaccessible from method `%s'", callee_name, caller_name);
-	mono_error_set_pending_exception (&error);
+	error_init (error);
+	mono_error_set_generic_error (error, "System", "MethodAccessException", "Method `%s' is inaccessible from method `%s'", callee_name, caller_name);
+	mono_error_set_pending_exception (error);
 	g_free (callee_name);
 	g_free (caller_name);
 }

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2874,15 +2874,15 @@ mono_print_thread_dump_internal (void *sigctx, MonoContext *start_ctx)
 #endif
 	GString* text;
 	char *name;
-	GError *error = NULL;
+	GError *gerror = NULL;
 
 	if (!thread)
 		return;
 
 	text = g_string_new (0);
 	if (thread->name) {
-		name = g_utf16_to_utf8 (thread->name, thread->name_len, NULL, NULL, &error);
-		g_assert (!error);
+		name = g_utf16_to_utf8 (thread->name, thread->name_len, NULL, NULL, &gerror);
+		g_assert (!gerror);
 		g_string_append_printf (text, "\n\"%s\"", name);
 		g_free (name);
 	}

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -558,9 +558,9 @@ inflate_info (MonoRuntimeGenericContextInfoTemplate *oti, MonoGenericContext *co
 	case MONO_RGCTX_INFO_NULLABLE_CLASS_BOX:
 	case MONO_RGCTX_INFO_NULLABLE_CLASS_UNBOX: {
 		gpointer result = mono_class_inflate_generic_type_with_mempool (temporary ? NULL : klass->image,
-			(MonoType *)data, context, &error);
-		if (!mono_error_ok (&error)) /*FIXME proper error handling */
-			g_error ("Could not inflate generic type due to %s", mono_error_get_message (&error));
+			(MonoType *)data, context, error);
+		if (!mono_error_ok (error)) /*FIXME proper error handling */
+			g_error ("Could not inflate generic type due to %s", mono_error_get_message (error));
 		return result;
 	}
 
@@ -573,8 +573,8 @@ inflate_info (MonoRuntimeGenericContextInfoTemplate *oti, MonoGenericContext *co
 	case MONO_RGCTX_INFO_METHOD_DELEGATE_CODE: {
 		MonoMethod *method = (MonoMethod *)data;
 		MonoMethod *inflated_method;
-		MonoType *inflated_type = mono_class_inflate_generic_type_checked (&method->klass->byval_arg, context, &error);
-		mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+		MonoType *inflated_type = mono_class_inflate_generic_type_checked (&method->klass->byval_arg, context, error);
+		mono_error_assert_ok (error); /* FIXME don't swallow the error */
 
 		MonoClass *inflated_class = mono_class_from_mono_type (inflated_type);
 
@@ -590,8 +590,8 @@ inflate_info (MonoRuntimeGenericContextInfoTemplate *oti, MonoGenericContext *co
 				method->name, method->signature);
 		} else {
 			ERROR_DECL (error);
-			inflated_method = mono_class_inflate_generic_method_checked (method, context, &error);
-			g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+			inflated_method = mono_class_inflate_generic_method_checked (method, context, error);
+			g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 		}
 		mono_class_init (inflated_method->klass);
 		g_assert (inflated_method->klass == inflated_class);
@@ -626,8 +626,8 @@ inflate_info (MonoRuntimeGenericContextInfoTemplate *oti, MonoGenericContext *co
 		MonoJumpInfoGSharedVtCall *info = (MonoJumpInfoGSharedVtCall *)data;
 		MonoMethod *method = info->method;
 		MonoMethod *inflated_method;
-		MonoType *inflated_type = mono_class_inflate_generic_type_checked (&method->klass->byval_arg, context, &error);
-		mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+		MonoType *inflated_type = mono_class_inflate_generic_type_checked (&method->klass->byval_arg, context, error);
+		mono_error_assert_ok (error); /* FIXME don't swallow the error */
 		WrapperInfo *winfo = NULL;
 
 		MonoClass *inflated_class = mono_class_from_mono_type (inflated_type);
@@ -656,8 +656,8 @@ inflate_info (MonoRuntimeGenericContextInfoTemplate *oti, MonoGenericContext *co
 				method->name, method->signature);
 		} else {
 			ERROR_DECL (error);
-			inflated_method = mono_class_inflate_generic_method_checked (method, context, &error);
-			g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+			inflated_method = mono_class_inflate_generic_method_checked (method, context, error);
+			g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 		}
 		mono_class_init (inflated_method->klass);
 		g_assert (inflated_method->klass == inflated_class);
@@ -676,8 +676,8 @@ inflate_info (MonoRuntimeGenericContextInfoTemplate *oti, MonoGenericContext *co
 	case MONO_RGCTX_INFO_FIELD_OFFSET: {
 		ERROR_DECL (error);
 		MonoClassField *field = (MonoClassField *)data;
-		MonoType *inflated_type = mono_class_inflate_generic_type_checked (&field->parent->byval_arg, context, &error);
-		mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+		MonoType *inflated_type = mono_class_inflate_generic_type_checked (&field->parent->byval_arg, context, error);
+		mono_error_assert_ok (error); /* FIXME don't swallow the error */
 
 		MonoClass *inflated_class = mono_class_from_mono_type (inflated_type);
 		int i = field - field->parent->fields;
@@ -696,8 +696,8 @@ inflate_info (MonoRuntimeGenericContextInfoTemplate *oti, MonoGenericContext *co
 		MonoMethodSignature *isig;
 		ERROR_DECL (error);
 
-		isig = mono_inflate_generic_signature (sig, context, &error);
-		g_assert (mono_error_ok (&error));
+		isig = mono_inflate_generic_signature (sig, context, error);
+		g_assert (mono_error_ok (error));
 		return isig;
 	}
 	case MONO_RGCTX_INFO_VIRT_METHOD_CODE:
@@ -710,14 +710,14 @@ inflate_info (MonoRuntimeGenericContextInfoTemplate *oti, MonoGenericContext *co
 
 		// FIXME: Temporary
 		res = (MonoJumpInfoVirtMethod *)mono_domain_alloc0 (domain, sizeof (MonoJumpInfoVirtMethod));
-		t = mono_class_inflate_generic_type_checked (&info->klass->byval_arg, context, &error);
-		mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+		t = mono_class_inflate_generic_type_checked (&info->klass->byval_arg, context, error);
+		mono_error_assert_ok (error); /* FIXME don't swallow the error */
 
 		res->klass = mono_class_from_mono_type (t);
 		mono_metadata_free_type (t);
 
-		res->method = mono_class_inflate_generic_method_checked (info->method, context, &error);
-		g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+		res->method = mono_class_inflate_generic_method_checked (info->method, context, error);
+		g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 
 		return res;
 	}
@@ -1158,8 +1158,8 @@ get_wrapper_shared_type (MonoType *t)
 				args [i] = get_wrapper_shared_type (inst->type_argv [i]);
 			ctx.method_inst = mono_metadata_get_generic_inst (inst->type_argc, args);
 		}
-		klass = mono_class_inflate_generic_class_checked (mono_class_get_generic_class (klass)->container_class, &ctx, &error);
-		mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+		klass = mono_class_inflate_generic_class_checked (mono_class_get_generic_class (klass)->container_class, &ctx, error);
+		mono_error_assert_ok (error); /* FIXME don't swallow the error */
 		return &klass->byval_arg;
 	}
 #if SIZEOF_VOID_P == 8
@@ -1636,8 +1636,8 @@ mini_get_gsharedvt_wrapper (gboolean gsharedvt_in, gpointer addr, MonoMethodSign
 			wrapper = mini_get_gsharedvt_in_sig_wrapper (normal_sig);
 		else
 			wrapper = mini_get_gsharedvt_out_sig_wrapper (normal_sig);
-		res = mono_compile_method_checked (wrapper, &error);
-		mono_error_assert_ok (&error);
+		res = mono_compile_method_checked (wrapper, error);
+		mono_error_assert_ok (error);
 		return res;
 	}
 
@@ -1670,9 +1670,9 @@ mini_get_gsharedvt_wrapper (gboolean gsharedvt_in, gpointer addr, MonoMethodSign
 
 		if (!tramp_addr) {
 			wrapper = mono_marshal_get_gsharedvt_in_wrapper ();
-			addr = mono_compile_method_checked (wrapper, &error);
+			addr = mono_compile_method_checked (wrapper, error);
 			mono_memory_barrier ();
-			mono_error_assert_ok (&error);
+			mono_error_assert_ok (error);
 			tramp_addr = addr;
 		}
 		addr = tramp_addr;
@@ -1682,9 +1682,9 @@ mini_get_gsharedvt_wrapper (gboolean gsharedvt_in, gpointer addr, MonoMethodSign
 
 		if (!tramp_addr) {
 			wrapper = mono_marshal_get_gsharedvt_out_wrapper ();
-			addr = mono_compile_method_checked (wrapper, &error);
+			addr = mono_compile_method_checked (wrapper, error);
 			mono_memory_barrier ();
-			mono_error_assert_ok (&error);
+			mono_error_assert_ok (error);
 			tramp_addr = addr;
 		}
 		addr = tramp_addr;
@@ -2868,9 +2868,9 @@ is_async_method (MonoMethod *method)
 				(sig->ret->type == MONO_TYPE_CLASS && !strcmp (sig->ret->data.generic_class->container_class->name, "Task")) ||
 				(sig->ret->type == MONO_TYPE_GENERICINST && !strcmp (sig->ret->data.generic_class->container_class->name, "Task`1")))) {
 		//printf ("X: %s\n", mono_method_full_name (method, TRUE));
-		cattr = mono_custom_attrs_from_method_checked (method, &error);
-		if (!is_ok (&error)) {
-			mono_error_cleanup (&error); /* FIXME don't swallow the error? */
+		cattr = mono_custom_attrs_from_method_checked (method, error);
+		if (!is_ok (error)) {
+			mono_error_cleanup (error); /* FIXME don't swallow the error? */
 			return FALSE;
 		}
 		if (cattr) {
@@ -3358,8 +3358,8 @@ gpointer
 mini_method_get_rgctx (MonoMethod *m)
 {
 	ERROR_DECL (error);
-	MonoVTable *vt = mono_class_vtable_checked (mono_domain_get (), m->klass, &error);
-	mono_error_assert_ok (&error);
+	MonoVTable *vt = mono_class_vtable_checked (mono_domain_get (), m->klass, error);
+	mono_error_assert_ok (error);
 	if (mini_method_get_context (m)->method_inst) {
 		return mono_method_lookup_rgctx (vt, mini_method_get_context (m)->method_inst);
 	} else
@@ -3534,8 +3534,8 @@ get_shared_type (MonoType *t, MonoType *type)
 		if (gclass->context.method_inst)
 			context.method_inst = get_shared_inst (gclass->context.method_inst, mono_class_get_generic_container (gclass->container_class)->context.method_inst, NULL, FALSE, FALSE, TRUE);
 
-		k = mono_class_inflate_generic_class_checked (gclass->container_class, &context, &error);
-		mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+		k = mono_class_inflate_generic_class_checked (gclass->container_class, &context, error);
+		mono_error_assert_ok (error); /* FIXME don't swallow the error */
 
 		return mini_get_shared_gparam (t, &k->byval_arg);
 	} else if (MONO_TYPE_ISSTRUCT (type)) {
@@ -3673,8 +3673,8 @@ mini_get_shared_method_full (MonoMethod *method, gboolean all_vt, gboolean is_gs
 	if (inst)
 		shared_context.method_inst = get_shared_inst (inst, shared_context.method_inst, method_container, all_vt, gsharedvt, partial);
 
-	res = mono_class_inflate_generic_method_checked (declaring_method, &shared_context, &error);
-	g_assert (mono_error_ok (&error)); /* FIXME don't swallow the error */
+	res = mono_class_inflate_generic_method_checked (declaring_method, &shared_context, error);
+	g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 
 	//printf ("%s\n", mono_method_full_name (res, 1));
 

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -1091,8 +1091,8 @@ resolve_patch (MonoCompile *cfg, MonoJumpInfoType type, gconstpointer target)
 	ji.type = type;
 	ji.data.target = target;
 
-	res = mono_resolve_patch_target (cfg->method, cfg->domain, NULL, &ji, FALSE, &error);
-	mono_error_assert_ok (&error);
+	res = mono_resolve_patch_target (cfg->method, cfg->domain, NULL, &ji, FALSE, error);
+	mono_error_assert_ok (error);
 
 	return res;
 }
@@ -3246,10 +3246,10 @@ process_call (EmitContext *ctx, MonoBasicBlock *bb, LLVMBuilderRef *builder_ref,
 				if (!tramp_var) {
 					target =
 						mono_create_jit_trampoline (mono_domain_get (),
-													call->method, &error);
-					if (!is_ok (&error)) {
-						set_failure (ctx, mono_error_get_message (&error));
-						mono_error_cleanup (&error);
+													call->method, error);
+					if (!is_ok (error)) {
+						set_failure (ctx, mono_error_get_message (error));
+						mono_error_cleanup (error);
 						return;
 					}
 
@@ -3262,11 +3262,11 @@ process_call (EmitContext *ctx, MonoBasicBlock *bb, LLVMBuilderRef *builder_ref,
 #else
 				target =
 					mono_create_jit_trampoline (mono_domain_get (),
-								    call->method, &error);
-				if (!is_ok (&error)) {
+								    call->method, error);
+				if (!is_ok (error)) {
 					g_free (name);
-					set_failure (ctx, mono_error_get_message (&error));
-					mono_error_cleanup (&error);
+					set_failure (ctx, mono_error_get_message (error));
+					mono_error_cleanup (error);
 					return;
 				}
 
@@ -3331,8 +3331,8 @@ process_call (EmitContext *ctx, MonoBasicBlock *bb, LLVMBuilderRef *builder_ref,
 					if (abs_ji) {
 						ERROR_DECL (error);
 
-						target = mono_resolve_patch_target (cfg->method, cfg->domain, NULL, abs_ji, FALSE, &error);
-						mono_error_assert_ok (&error);
+						target = mono_resolve_patch_target (cfg->method, cfg->domain, NULL, abs_ji, FALSE, error);
+						mono_error_assert_ok (error);
 						callee = emit_jit_callee (ctx, "", llvm_sig, target);
 					} else {
 						g_assert_not_reached ();
@@ -3352,8 +3352,8 @@ process_call (EmitContext *ctx, MonoBasicBlock *bb, LLVMBuilderRef *builder_ref,
 						 * FIXME: Some trampolines might have
 						 * their own calling convention on some platforms.
 						 */
-						target = mono_resolve_patch_target (cfg->method, cfg->domain, NULL, abs_ji, FALSE, &error);
-						mono_error_assert_ok (&error);
+						target = mono_resolve_patch_target (cfg->method, cfg->domain, NULL, abs_ji, FALSE, error);
+						mono_error_assert_ok (error);
 						LLVMAddGlobalMapping (ctx->module->ee, callee, target);
 					}
 				}

--- a/mono/mini/mini-profiler.c
+++ b/mono/mini/mini-profiler.c
@@ -237,8 +237,8 @@ gpointer
 mini_profiler_context_get_local (MonoProfilerCallContext *ctx, guint32 pos)
 {
 	ERROR_DECL (error);
-	MonoMethodHeader *header = mono_method_get_header_checked (ctx->method, &error);
-	mono_error_assert_ok (&error); // Must be a valid method at this point.
+	MonoMethodHeader *header = mono_method_get_header_checked (ctx->method, error);
+	mono_error_assert_ok (error); // Must be a valid method at this point.
 
 	if (pos >= header->num_locals) {
 		mono_metadata_free_mh (header);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -622,12 +622,12 @@ mono_icall_get_wrapper_full (MonoJitICallInfo* callinfo, gboolean do_compile)
 	g_free (name);
 
 	if (do_compile) {
-		trampoline = mono_compile_method_checked (wrapper, &error);
-		mono_error_assert_ok (&error);
+		trampoline = mono_compile_method_checked (wrapper, error);
+		mono_error_assert_ok (error);
 	} else {
 
-		trampoline = mono_create_jit_trampoline (domain, wrapper, &error);
-		mono_error_assert_ok (&error);
+		trampoline = mono_create_jit_trampoline (domain, wrapper, error);
+		mono_error_assert_ok (error);
 		trampoline = mono_create_ftnptr (domain, (gpointer)trampoline);
 	}
 
@@ -1745,12 +1745,12 @@ mini_get_class (MonoMethod *method, guint32 token, MonoGenericContext *context)
 	if (method->wrapper_type != MONO_WRAPPER_NONE) {
 		klass = (MonoClass *)mono_method_get_wrapper_data (method, token);
 		if (context) {
-			klass = mono_class_inflate_generic_class_checked (klass, context, &error);
-			mono_error_cleanup (&error); /* FIXME don't swallow the error */
+			klass = mono_class_inflate_generic_class_checked (klass, context, error);
+			mono_error_cleanup (error); /* FIXME don't swallow the error */
 		}
 	} else {
-		klass = mono_class_get_and_inflate_typespec_checked (method->klass->image, token, context, &error);
-		mono_error_cleanup (&error); /* FIXME don't swallow the error */
+		klass = mono_class_get_and_inflate_typespec_checked (method->klass->image, token, context, error);
+		mono_error_cleanup (error); /* FIXME don't swallow the error */
 	}
 	if (klass)
 		mono_class_init (klass);
@@ -4063,8 +4063,8 @@ mini_init (const char *filename, const char *runtime_version)
 #define JIT_RUNTIME_WORKS
 #ifdef JIT_RUNTIME_WORKS
 	mono_install_runtime_cleanup ((MonoDomainFunc)mini_cleanup);
-	mono_runtime_init_checked (domain, mono_thread_start_cb, mono_thread_attach_cb, &error);
-	mono_error_assert_ok (&error);
+	mono_runtime_init_checked (domain, mono_thread_start_cb, mono_thread_attach_cb, error);
+	mono_error_assert_ok (error);
 	mono_thread_attach (domain);
 	MONO_PROFILER_RAISE (thread_name, (MONO_NATIVE_THREAD_ID_TO_UINT (mono_native_thread_id_get ()), "Main"));
 #endif
@@ -4558,9 +4558,9 @@ mono_precompile_assembly (MonoAssembly *ass, void *user_data)
 	for (i = 0; i < mono_image_get_table_rows (image, MONO_TABLE_METHOD); ++i) {
 		ERROR_DECL (error);
 
-		method = mono_get_method_checked (image, MONO_TOKEN_METHOD_DEF | (i + 1), NULL, NULL, &error);
+		method = mono_get_method_checked (image, MONO_TOKEN_METHOD_DEF | (i + 1), NULL, NULL, error);
 		if (!method) {
-			mono_error_cleanup (&error); /* FIXME don't swallow the error */
+			mono_error_cleanup (error); /* FIXME don't swallow the error */
 			continue;
 		}
 		if (method->flags & METHOD_ATTRIBUTE_ABSTRACT)
@@ -4574,22 +4574,22 @@ mono_precompile_assembly (MonoAssembly *ass, void *user_data)
 			g_print ("Compiling %d %s\n", count, desc);
 			g_free (desc);
 		}
-		mono_compile_method_checked (method, &error);
-		if (!is_ok (&error)) {
-			mono_error_cleanup (&error); /* FIXME don't swallow the error */
+		mono_compile_method_checked (method, error);
+		if (!is_ok (error)) {
+			mono_error_cleanup (error); /* FIXME don't swallow the error */
 			continue;
 		}
 		if (strcmp (method->name, "Finalize") == 0) {
 			invoke = mono_marshal_get_runtime_invoke (method, FALSE);
-			mono_compile_method_checked (invoke, &error);
-			mono_error_assert_ok (&error);
+			mono_compile_method_checked (invoke, error);
+			mono_error_assert_ok (error);
 		}
 #ifndef DISABLE_REMOTING
 		if (mono_class_is_marshalbyref (method->klass) && mono_method_signature (method)->hasthis) {
-			invoke = mono_marshal_get_remoting_invoke_with_check (method, &error);
-			mono_error_assert_ok (&error);
-			mono_compile_method_checked (invoke, &error);
-			mono_error_assert_ok (&error);
+			invoke = mono_marshal_get_remoting_invoke_with_check (method, error);
+			mono_error_assert_ok (error);
+			mono_compile_method_checked (invoke, error);
+			mono_error_assert_ok (error);
 		}
 #endif
 	}

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -826,12 +826,12 @@ static void
 decodeParmString (MonoString *s)
 {
 	ERROR_DECL (error);
-	char *str = mono_string_to_utf8_checked(s, &error);
-	if (is_ok (&error))  {
+	char *str = mono_string_to_utf8_checked(s, error);
+	if (is_ok (error))  {
 		fprintf (trFd, "[STRING:%p:%s], ", s, str);
 		g_free (str);
 	} else {
-		mono_error_cleanup (&error);
+		mono_error_cleanup (error);
 		fprintf (trFd, "[STRING:%p:], ", s);
 	}
 }
@@ -2613,8 +2613,8 @@ mono_arch_emit_outarg_vt (MonoCompile *cfg, MonoInst *ins, MonoInst *src)
 		MonoMethodHeader *header;
 		int srcReg;
 
-		header = mono_method_get_header_checked (cfg->method, &error);
-		mono_error_assert_ok (&error); /* FIXME don't swallow the error */
+		header = mono_method_get_header_checked (cfg->method, error);
+		mono_error_assert_ok (error); /* FIXME don't swallow the error */
 		if ((cfg->flags & MONO_CFG_HAS_ALLOCA) || header->num_clauses)
 			srcReg = s390_r11;
 		else

--- a/mono/mini/mini-sparc.c
+++ b/mono/mini/mini-sparc.c
@@ -1579,8 +1579,8 @@ emit_call (MonoCompile *cfg, guint32 *code, guint32 patch_type, gconstpointer da
 		patch_info.type = patch_type;
 		patch_info.data.target = data;
 
-		target = mono_resolve_patch_target (cfg->method, cfg->domain, NULL, &patch_info, FALSE, &error);
-		mono_error_raise_exception_deprecated (&error); /* FIXME: don't raise here */
+		target = mono_resolve_patch_target (cfg->method, cfg->domain, NULL, &patch_info, FALSE, error);
+		mono_error_raise_exception_deprecated (error); /* FIXME: don't raise here */
 
 		/* FIXME: Add optimizations if the target is close enough */
 		sparc_set (code, target, sparc_o7);

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3077,7 +3077,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 {
 	MonoMethodHeader *header;
 	MonoMethodSignature *sig;
-	ERROR_DECL (err);
+	ERROR_DECL_VALUE (err);
 	MonoCompile *cfg;
 	int i;
 	gboolean try_generic_shared, try_llvm = FALSE;

--- a/mono/mini/simd-intrinsics.c
+++ b/mono/mini/simd-intrinsics.c
@@ -2041,7 +2041,7 @@ assert_handled (MonoCompile *cfg, MonoMethod *method)
 	ERROR_DECL (error);
 
 	if (cfg->verbose_level > 1) {
-		cattr = mono_custom_attrs_from_method_checked (method, &error);
+		cattr = mono_custom_attrs_from_method_checked (method, error);
 
 		if (cattr) {
 			gboolean has_attr = FALSE;

--- a/mono/mini/trace.c
+++ b/mono/mini/trace.c
@@ -86,17 +86,17 @@ static char *
 string_to_utf8 (MonoString *s)
 {
 	char *as;
-	GError *error = NULL;
+	GError *gerror = NULL;
 
 	g_assert (s);
 
 	if (!s->length)
 		return g_strdup ("");
 
-	as = g_utf16_to_utf8 (mono_string_chars (s), s->length, NULL, NULL, &error);
-	if (error) {
+	as = g_utf16_to_utf8 (mono_string_chars (s), s->length, NULL, NULL, &gerror);
+	if (gerror) {
 		/* Happens with StringBuilders */
-		g_error_free (error);
+		g_error_free (gerror);
 		return g_strdup ("<INVALID UTF8>");
 	}
 	else

--- a/mono/sgen/sgen-debug.c
+++ b/mono/sgen/sgen-debug.c
@@ -1008,9 +1008,9 @@ check_reference_for_xdomain (GCObject **ptr, GCObject *obj, MonoDomain *domain)
 	}
 
 	if (ref->vtable->klass == mono_defaults.string_class) {
-		MonoError error;
-		str = mono_string_to_utf8_checked ((MonoString*)ref, &error);
-		mono_error_cleanup (&error);
+		ERROR_DECL (error);
+		str = mono_string_to_utf8_checked ((MonoString*)ref, error);
+		mono_error_cleanup (error);
 	} else
 		str = NULL;
 	g_print ("xdomain reference in %p (%s.%s) at offset %d (%s) to %p (%s.%s) (%s)  -  pointed to by:\n",

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -47,10 +47,7 @@ struct _MonoErrorBoxed {
 #define ERROR_DECL(name) \
 	MonoError name
 
-#define error_init(error) do {	\
-	((MonoErrorInternal*)(error))->error_code = MONO_ERROR_NONE;	\
-	((MonoErrorInternal*)(error))->flags = 0;	\
-} while (0);
+#define error_init(error) ((void)((error)->init = 0))
 
 #define is_ok(error) ((error)->error_code == MONO_ERROR_NONE)
 

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -43,11 +43,71 @@ struct _MonoErrorBoxed {
 	MonoImage *image;
 };
 
-// Initial version for easier to read history.
-#define ERROR_DECL(name) \
-	MonoError name
+/*
+Historically MonoError initialization was deferred, but always had to occur,
+	even in success paths, as cleanup could be done unconditionally.
+	This was confusing.
 
-#define error_init(error) ((void)((error)->init = 0))
+ERROR_DECL (error)
+	This is the overwhelmingly common case.
+	Declare and initialize a local variable, named "error",
+	pointing to an initialized MonoError (named "error_value",
+	using token pasting).
+
+ERROR_DECL_VALUE (foo)
+	Declare and initialize a local variable, named "foo";
+	no pointer is produced for it.
+
+MONO_API_ERROR_INIT
+	This is used for MonoError in/out parameter on a public interface,
+	which must be presumed uninitialized. These are often
+	marked with MONO_API, MONO_RT_EXTERNAL_ONLY, MONO_PROFILER_API, etc.
+	Tnis includes functions called from dis, profiler, pedump, and driver.
+	dis, profiler, and pedump make sense, these are actually external and
+	uninitialized. Driver less so.
+
+error_init
+	Initialize a MonoError. These are historical and usually
+	but not always redundant, and should be reduced/eliminated.
+	All the non-redundant ones should be renamed and all the redundant
+	ones removed.
+
+error_init_reuse
+	This indicates an error has been cleaned up and will be reused.
+	Consider also changing mono_error_cleanup to call error_init_internal,
+	and then remove these.
+
+error_init_internal
+	Rare cases without a better name.
+	For example, setting up an icall frame, or initializing member data.
+
+new0, calloc, static
+	A zeroed MonoError is valid and initialized.
+	Zeroing an entire MonoError is overkill, unless it is near other
+	bulk zeroing.
+
+All initialization is actually bottlenecked to error_init_internal.
+Different names indicate different scenarios, but the same code.
+*/
+#define ERROR_DECL_VALUE(x) 		MonoError x; error_init_internal (&x)
+#define ERROR_DECL(x) 			ERROR_DECL_VALUE (x##_value); MonoError * const x = &x##_value
+#define error_init_internal(error) 	((void)((error)->init = 0))
+#define MONO_API_ERROR_INIT(error) 	error_init_internal (error)
+#define error_init_reuse(error) 	error_init_internal (error)
+
+// Historical deferred initialization was called error_init.
+
+// possible bug detection that did not work
+//#define error_init(error) (is_ok (error))
+
+// FIXME Eventually all error_init should be removed, however it is prudent
+// to leave them in for now, at least most of them, while we sort out
+// the few that are needed and to experiment with adding them back in bulk,
+// i.e. in an entire source file. Some are obviously not needed.
+//#define error_init(error) // nothing
+#define error_init(error) error_init_internal (error)
+// Function for experimentation, should go away.
+//void error_init(MonoError*);
 
 #define is_ok(error) ((error)->error_code == MONO_ERROR_NONE)
 

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -593,7 +593,7 @@ mono_error_set_not_verifiable (MonoError *oerror, MonoMethod *method, const char
 static MonoString*
 string_new_cleanup (MonoDomain *domain, const char *text)
 {
-	ERROR_DECL (ignored_err);
+	ERROR_DECL_VALUE (ignored_err);
 	MonoString *result = mono_string_new_checked (domain, text, &ignored_err);
 	mono_error_cleanup (&ignored_err);
 	return result;
@@ -840,14 +840,14 @@ mono_error_convert_to_exception (MonoError *target_error)
 	if (mono_error_ok (target_error))
 		return NULL;
 
-	ex = mono_error_prepare_exception (target_error, &error);
-	if (!mono_error_ok (&error)) {
-		ERROR_DECL (second_chance);
+	ex = mono_error_prepare_exception (target_error, error);
+	if (!mono_error_ok (error)) {
+		ERROR_DECL_VALUE (second_chance);
 		/*Try to produce the exception for the second error. FIXME maybe we should log about the original one*/
-		ex = mono_error_prepare_exception (&error, &second_chance);
+		ex = mono_error_prepare_exception (error, &second_chance);
 
 		g_assert (mono_error_ok (&second_chance)); /*We can't reasonable handle double faults, maybe later.*/
-		mono_error_cleanup (&error);
+		mono_error_cleanup (error);
 	}
 	mono_error_cleanup (target_error);
 	return ex;

--- a/mono/utils/mono-error.h
+++ b/mono/utils/mono-error.h
@@ -49,11 +49,15 @@ enum {
 };
 
 /*Keep in sync with MonoErrorInternal*/
-typedef struct _MonoError {
-	unsigned short error_code;
-    unsigned short hidden_0; /*DON'T TOUCH */
-
-	void *hidden_1 [12]; /*DON'T TOUCH */
+typedef union _MonoError {
+	// Merge two uint16 into one uint32 so it can be initialized
+	// with one instruction instead of two.
+	uint32_t init;
+	struct {
+		uint16_t error_code;
+		uint16_t private_flags; /*DON'T TOUCH */
+		void *hidden_1 [12]; /*DON'T TOUCH */
+	};
 } MonoError;
 
 /* Mempool-allocated MonoError.*/


### PR DESCRIPTION
but not on the others, and tweak macros to support.
Initialization is now in the declaration, and the redundant
others remain for now.

Also includes: initialize with one int32 instead of two int16.
And changing error_init from statement to expression, so
 one missing semicolon added (mono/metadata/metadata.c).