### PR TITLE
[tests] Bump timeouts in process-stress-?.exe runtime tests

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1988,7 +1988,7 @@ TESTSAOT_STRESS_PROCESS=$(TESTS_STRESS_PROCESS:.exe=.exe$(PLATFORM_AOT_SUFFIX))
 endif
 
 test-process-stress: $(TESTS_STRESS_PROCESS) $(TESTSAOT_STRESS_PROCESS) test-runner.exe
-	$(TOOLS_RUNTIME) $(TEST_RUNNER) --testsuite-name $@ --disabled "$(DISABLED_TESTS)" --timeout 600 $(TESTS_STRESS_PROCESS)
+	$(TOOLS_RUNTIME) $(TEST_RUNNER) --testsuite-name $@ --disabled "$(DISABLED_TESTS)" --timeout 900 $(TESTS_STRESS_PROCESS)
 
 coreclr-gcstress:
 	$(MAKE) -C $(mono_build_root)/acceptance-tests coreclr-gcstress

--- a/mono/tests/process-stress-1.cs
+++ b/mono/tests/process-stress-1.cs
@@ -20,16 +20,16 @@ class Driver
 
 			Task t = Task.Run (() => {
 				mre.Set ();
-				if (!p.WaitForExit (1000))
+				if (!p.WaitForExit (10000))
 					Environment.Exit (1);
 			});
 
-			if (!mre.WaitOne (1000))
+			if (!mre.WaitOne (10000))
 				Environment.Exit (2);
-			if (!p.WaitForExit (1000))
+			if (!p.WaitForExit (10000))
 				Environment.Exit (3);
 
-			if (!t.Wait (1000))
+			if (!t.Wait (10000))
 				Environment.Exit (4);
 		}
 	}

--- a/mono/tests/process-stress-2.cs
+++ b/mono/tests/process-stress-2.cs
@@ -49,9 +49,9 @@ class Driver
 
 		p.BeginOutputReadLine ();
 
-		if (!mre_exit.WaitOne (1000))
+		if (!mre_exit.WaitOne (10000))
 			Environment.Exit (1);
-		if (!mre_output.WaitOne (1000))
+		if (!mre_output.WaitOne (10000))
 			Environment.Exit (2);
 
 		if (sb.ToString () != "hello") {
@@ -78,9 +78,9 @@ class Driver
 
 		p.BeginOutputReadLine ();
 
-		if (!p.WaitForExit (1000))
+		if (!p.WaitForExit (10000))
 			Environment.Exit (4);
-		if (!mre_output.WaitOne (1000))
+		if (!mre_output.WaitOne (10000))
 			Environment.Exit (5);
 
 		if (sb.ToString () != "hello") {

--- a/mono/tests/process-stress-3.cs
+++ b/mono/tests/process-stress-3.cs
@@ -59,9 +59,9 @@ class Driver
 
 		if (!mre_exit.WaitOne (10000))
 			Environment.Exit (1);
-		if (!mre_output.WaitOne (1000))
+		if (!mre_output.WaitOne (10000))
 			Environment.Exit (2);
-		if (!mre_error.WaitOne (1000))
+		if (!mre_error.WaitOne (10000))
 			Environment.Exit (3);
 	}
 


### PR DESCRIPTION
We're seeing these fail sometimes on Linux Azure VMs, let's try if bumping the timeouts helps.

Also record test duration in nunit xml correctly.