### PR TITLE
[2017-12] [class] Add Obsolete message to ICSharpCode.SharpZipLib.dll

### DIFF
--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/BZip2/BZip2Constants.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/BZip2/BZip2Constants.cs
@@ -39,6 +39,7 @@ namespace ICSharpCode.SharpZipLib.BZip2
 	/// Base class for both the compress and decompress classes.
 	/// Holds common arrays, and static data.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public sealed class BZip2Constants
 	{
 		public readonly static int[] rNums = {

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/BZip2/BZip2InputStream.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/BZip2/BZip2InputStream.cs
@@ -44,6 +44,7 @@ namespace ICSharpCode.SharpZipLib.BZip2
 	/// An input stream that decompresses from the BZip2 format (without the file
 	/// header chars) to be read as any other stream.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class BZip2InputStream : Stream
 	{
 		/// <summary>

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/BZip2/BZip2OutputStream.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/BZip2/BZip2OutputStream.cs
@@ -45,6 +45,7 @@ namespace ICSharpCode.SharpZipLib.BZip2
 	/// header chars) into another stream.
 	/// TODO: Update to BZip2 1.0.1, 1.0.2
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class BZip2OutputStream : Stream
 	{
 		/// <summary>

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Checksums/Adler32.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Checksums/Adler32.cs
@@ -86,6 +86,7 @@ namespace ICSharpCode.SharpZipLib.Checksums
 	/// </summary>
 	/// <see cref="ICSharpCode.SharpZipLib.Zip.Compression.Streams.InflaterInputStream"/>
 	/// <see cref="ICSharpCode.SharpZipLib.Zip.Compression.Streams.DeflaterOutputStream"/>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public sealed class Adler32 : IChecksum
 	{
 		/// <summary>

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Checksums/Crc32.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Checksums/Crc32.cs
@@ -64,6 +64,7 @@ namespace ICSharpCode.SharpZipLib.Checksums
 	/// the information needed to generate CRC's on data a byte at a time for all
 	/// combinations of CRC register values and incoming bytes.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public sealed class Crc32 : IChecksum
 	{
 		readonly static uint CrcSeed = 0xFFFFFFFF;

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Checksums/IChecksum.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Checksums/IChecksum.cs
@@ -45,6 +45,7 @@ namespace ICSharpCode.SharpZipLib.Checksums
 	/// <code>getValue</code>. The complete checksum object can also be reset
 	/// so it can be used again with new data.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public interface IChecksum
 	{
 		/// <summary>

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Checksums/StrangeCrc.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Checksums/StrangeCrc.cs
@@ -41,6 +41,7 @@ using System;
 namespace ICSharpCode.SharpZipLib.Checksums 
 {
 	
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class StrangeCRC : IChecksum
 	{
 		readonly static uint[] crc32Table = {

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/GZip/GZipConstants.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/GZip/GZipConstants.cs
@@ -41,6 +41,7 @@ namespace ICSharpCode.SharpZipLib.GZip
 	/// <summary>
 	/// This class contains constants used for gzip.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class GZipConstants 
 	{
 		/// <summary>

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/GZip/GZipInputStream.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/GZip/GZipInputStream.cs
@@ -79,6 +79,7 @@ namespace ICSharpCode.SharpZipLib.GZip
 	/// }	
 	/// </code>
 	/// </example>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class GZipInputStream : InflaterInputStream 
 	{
 		/// <summary>

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/GZip/GZipOutputStream.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/GZip/GZipOutputStream.cs
@@ -72,6 +72,7 @@ namespace ICSharpCode.SharpZipLib.GZip
 	/// }	
 	/// </code>
 	/// </example>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class GZipOutputStream : DeflaterOutputStream
 	{
 		//Variables

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/InvalidHeaderException.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/InvalidHeaderException.cs
@@ -43,6 +43,7 @@ namespace ICSharpCode.SharpZipLib.Tar {
 	/// This exception is used to indicate that there is a problem
 	/// with a TAR archive header.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class InvalidHeaderException : System.IO.IOException
 	{
 		public InvalidHeaderException()

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarArchive.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarArchive.cs
@@ -38,6 +38,7 @@ using System.Text;
 
 namespace ICSharpCode.SharpZipLib.Tar {
 	
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public delegate void ProgressMessageHandler(TarArchive archive, TarEntry entry, string message);
 	
 	/// <summary>
@@ -61,6 +62,7 @@ namespace ICSharpCode.SharpZipLib.Tar {
 	/// TarBuffer.getCurrentRecordNum() and TarBuffer.getCurrentBlockNum()
 	/// methods, this would be rather trvial.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class TarArchive
 	{
 		bool verbose;

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarBuffer.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarBuffer.cs
@@ -51,6 +51,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 	/// TarBuffers are created by Tar IO Streams.
 	/// </p>
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class TarBuffer
 	{
 

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarEntry.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarEntry.cs
@@ -67,6 +67,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 	/// 
 	/// <see cref="TarHeader"/>
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class TarEntry
 	{
 		/// <summary>

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarHeader.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarHeader.cs
@@ -74,6 +74,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 	/// This class encapsulates the Tar Entry Header used in Tar Archives.
 	/// The class also holds a number of tar constants, used mostly in headers.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class TarHeader : ICloneable
 	{
 		/// <summary>

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarInputStream.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarInputStream.cs
@@ -45,6 +45,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 	/// the archive, and the read each entry as a normal input stream
 	/// using read().
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class TarInputStream : Stream
 	{
 		protected bool debug;
@@ -598,6 +599,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// the programmer to have their own TarEntry subclass instantiated for the
 		/// entries return from getNextEntry().
 		/// </summary>
+		[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 		public interface IEntryFactory
 		{
 			TarEntry CreateEntry(string name);
@@ -607,6 +609,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 			TarEntry CreateEntry(byte[] headerBuf);
 		}
 		
+		[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 		public class EntryFactoryAdapter : IEntryFactory
 		{
 			public TarEntry CreateEntry(string name)

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarOutputStream.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarOutputStream.cs
@@ -45,6 +45,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 	/// by writing to this stream using write().
 	/// </summary>
 	/// public
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class TarOutputStream : Stream
 	{
 		protected bool   debug;

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/Deflater.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/Deflater.cs
@@ -50,6 +50,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression
 	/// 
 	/// author of the original java version : Jochen Hoenicke
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class Deflater
 	{
 		/// <summary>

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/DeflaterConstants.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/DeflaterConstants.cs
@@ -43,6 +43,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression
 	/// <summary>
 	/// This class contains constants used for the deflater.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class DeflaterConstants 
 	{
 		public const bool DEBUGGING = false;

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/DeflaterEngine.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/DeflaterEngine.cs
@@ -42,6 +42,7 @@ using ICSharpCode.SharpZipLib.Checksums;
 namespace ICSharpCode.SharpZipLib.Zip.Compression 
 {
 	
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public enum DeflateStrategy 
 	{
 		// The default strategy.
@@ -57,6 +58,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression
 		HuffmanOnly = 2
 	}
 	
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class DeflaterEngine : DeflaterConstants 
 	{
 		static int TOO_FAR = 4096;

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/DeflaterHuffman.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/DeflaterHuffman.cs
@@ -48,6 +48,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression
 	/// 
 	/// author of the original java version : Jochen Hoenicke
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class DeflaterHuffman
 	{
 		private static  int BUFSIZE = 1 << (DeflaterConstants.DEFAULT_MEM_LEVEL + 6);
@@ -79,6 +80,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression
 			15
 		};
 		
+		[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 		public class Tree 
 		{
 			public short[] freqs;

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/DeflaterPending.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/DeflaterPending.cs
@@ -43,6 +43,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression
 	/// 
 	/// author of the original java version : Jochen Hoenicke
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class DeflaterPending : PendingBuffer
 	{
 		public DeflaterPending() : base(DeflaterConstants.PENDING_BUF_SIZE)

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/Inflater.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/Inflater.cs
@@ -64,6 +64,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression
 	///
 	/// author of the original java version : John Leuner, Jochen Hoenicke
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class Inflater
 	{
 		/// <summary>

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/InflaterHuffmanTree.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/InflaterHuffmanTree.cs
@@ -42,6 +42,7 @@ using ICSharpCode.SharpZipLib.Zip.Compression.Streams;
 namespace ICSharpCode.SharpZipLib.Zip.Compression 
 {
 	
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class InflaterHuffmanTree 
 	{
 		private static int MAX_BITLEN = 15;

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/PendingBuffer.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/PendingBuffer.cs
@@ -48,6 +48,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression
 	/// 
 	/// author of the original java version : Jochen Hoenicke
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class PendingBuffer
 	{
 		protected byte[] buf;

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
@@ -49,6 +49,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 	/// 
 	/// authors of the original java version : Tom Tromey, Jochen Hoenicke 
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class DeflaterOutputStream : Stream
 	{
 		/// <summary>

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/Streams/InflaterInputStream.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/Streams/InflaterInputStream.cs
@@ -53,6 +53,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 	///
 	/// author of the original java version : John Leuner
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class InflaterInputStream : Stream
 	{
 		//Variables

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/Streams/OutputWindow.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/Streams/OutputWindow.cs
@@ -47,6 +47,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 	///
 	/// author of the original java version : John Leuner
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class OutputWindow
 	{
 		private static int WINDOW_SIZE = 1 << 15;

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/Streams/StreamManipulator.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/Streams/StreamManipulator.cs
@@ -55,6 +55,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 	///
 	/// authors of the original java version : John Leuner, Jochen Hoenicke
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class StreamManipulator
 	{
 		private byte[] window;

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
@@ -43,6 +43,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 	/// <summary>
 	/// This class contains constants used for zip.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public sealed class ZipConstants
 	{
 		/* The local file header */

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
@@ -40,6 +40,7 @@ using System;
 namespace ICSharpCode.SharpZipLib.Zip 
 {
 	
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public enum CompressionMethod
 	{
 		Stored   = 0,
@@ -54,6 +55,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 	///
 	/// author of the original java version : Jochen Hoenicke
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class ZipEntry : ICloneable
 	{
 		static int KNOWN_SIZE   = 1;

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -82,6 +82,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 	/// 	}
 	/// }
 	/// </example>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class ZipFile : IEnumerable
 	{
 		string     name;

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
@@ -90,6 +90,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 	/// }	
 	/// </code>
 	/// </example>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class ZipInputStream : InflaterInputStream
 	{
 		Crc32 crc = new Crc32();

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -94,6 +94,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 	/// }	
 	/// </code>
 	/// </example>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class ZipOutputStream : DeflaterOutputStream
 	{
 		private ArrayList entries  = new ArrayList();

--- a/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/ZipException.cs
+++ b/mcs/class/Compat.ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/ZipException.cs
@@ -43,6 +43,7 @@ namespace ICSharpCode.SharpZipLib
 	/// <summary>
 	/// Is thrown during the creation or input of a zip file.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class ZipException : Exception
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/BZip2/BZip2.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/BZip2/BZip2.cs
@@ -44,6 +44,7 @@ namespace ICSharpCode.SharpZipLib.BZip2
 	/// Sets up the streams and file header characters.
 	/// Uses multiply overloaded methods to call for the compress/decompress.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public sealed class BZip2
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/BZip2/BZip2Constants.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/BZip2/BZip2Constants.cs
@@ -38,6 +38,7 @@ namespace ICSharpCode.SharpZipLib.BZip2
 	/// <summary>
 	/// Defines internal values for both compression and decompression
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public sealed class BZip2Constants
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/BZip2/BZip2Exception.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/BZip2/BZip2Exception.cs
@@ -41,6 +41,7 @@ namespace ICSharpCode.SharpZipLib.BZip2
 	/// <summary>
 	/// BZip2Exception represents exceptions specific to Bzip2 algorithm
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class BZip2Exception : SharpZipBaseException
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/BZip2/BZip2InputStream.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/BZip2/BZip2InputStream.cs
@@ -44,6 +44,7 @@ namespace ICSharpCode.SharpZipLib.BZip2
 	/// <summary>
 	/// An input stream that decompresses files in the BZip2 format 
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class BZip2InputStream : Stream
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/BZip2/BZip2OutputStream.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/BZip2/BZip2OutputStream.cs
@@ -46,6 +46,7 @@ namespace ICSharpCode.SharpZipLib.BZip2
 	/// An output stream that compresses into the BZip2 format 
 	/// including file header chars into another stream.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class BZip2OutputStream : Stream
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Checksums/Adler32.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Checksums/Adler32.cs
@@ -86,6 +86,7 @@ namespace ICSharpCode.SharpZipLib.Checksums
 	/// </summary>
 	/// <see cref="ICSharpCode.SharpZipLib.Zip.Compression.Streams.InflaterInputStream"/>
 	/// <see cref="ICSharpCode.SharpZipLib.Zip.Compression.Streams.DeflaterOutputStream"/>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public sealed class Adler32 : IChecksum
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Checksums/CRC32.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Checksums/CRC32.cs
@@ -64,6 +64,7 @@ namespace ICSharpCode.SharpZipLib.Checksums
 	/// the information needed to generate CRC's on data a byte at a time for all
 	/// combinations of CRC register values and incoming bytes.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public sealed class Crc32 : IChecksum
 	{
 		readonly static uint CrcSeed = 0xFFFFFFFF;

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Checksums/IChecksum.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Checksums/IChecksum.cs
@@ -45,6 +45,7 @@ namespace ICSharpCode.SharpZipLib.Checksums
 	/// <code>getValue</code>. The complete checksum object can also be reset
 	/// so it can be used again with new data.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public interface IChecksum
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Checksums/StrangeCRC.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Checksums/StrangeCRC.cs
@@ -43,6 +43,7 @@ namespace ICSharpCode.SharpZipLib.Checksums
 	/// <summary>
 	/// Bzip2 checksum algorithm
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class StrangeCRC : IChecksum
 	{
 		readonly static uint[] crc32Table = {

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Core/FileSystemScanner.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Core/FileSystemScanner.cs
@@ -42,6 +42,7 @@ namespace ICSharpCode.SharpZipLib.Core
 	/// <summary>
 	/// Event arguments for scanning.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class ScanEventArgs : EventArgs
 	{
 		/// <summary>
@@ -79,6 +80,7 @@ namespace ICSharpCode.SharpZipLib.Core
 	/// <summary>
 	/// Event arguments for directories.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class DirectoryEventArgs : ScanEventArgs
 	{
 		/// <summary>
@@ -106,6 +108,7 @@ namespace ICSharpCode.SharpZipLib.Core
 	/// <summary>
 	/// Arguments passed when scan failures are detected.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class ScanFailureEventArgs
 	{
 		/// <summary>
@@ -155,26 +158,31 @@ namespace ICSharpCode.SharpZipLib.Core
 	/// <summary>
 	/// Delegate invokked when a directory is processed.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public delegate void ProcessDirectoryDelegate(object Sender, DirectoryEventArgs e);
 	
 	/// <summary>
 	/// Delegate invoked when a file is processed.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public delegate void ProcessFileDelegate(object sender, ScanEventArgs e);
 	
 	/// <summary>
 	/// Delegate invoked when a directory failure is detected.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public delegate void DirectoryFailureDelegate(object sender, ScanFailureEventArgs e);
 	
 	/// <summary>
 	/// Delegate invoked when a file failure is detected.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public delegate void FileFailureDelegate(object sender, ScanFailureEventArgs e);
 
 	/// <summary>
 	/// FileSystemScanner provides facilities scanning of files and directories.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class FileSystemScanner
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Core/INameTransform.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Core/INameTransform.cs
@@ -38,6 +38,7 @@ namespace ICSharpCode.SharpZipLib.Core
 	/// <summary>
 	/// INameTransform defines how file system names are transformed for use with archives.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public interface INameTransform
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Core/NameFilter.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Core/NameFilter.cs
@@ -50,6 +50,7 @@ namespace ICSharpCode.SharpZipLib.Core
 	/// and not matching an exclude spec are deemed to match the filter.
 	/// An empty filter matches any name.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class NameFilter
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Core/PathFilter.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Core/PathFilter.cs
@@ -42,6 +42,7 @@ namespace ICSharpCode.SharpZipLib.Core
 	/// <summary>
 	/// Scanning filters support these operations.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public interface IScanFilter
 	{
 		/// <summary>
@@ -55,6 +56,7 @@ namespace ICSharpCode.SharpZipLib.Core
 	/// <summary>
 	/// PathFilter filters directories and files by full path name.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class PathFilter : IScanFilter
 	{
 		/// <summary>
@@ -84,6 +86,7 @@ namespace ICSharpCode.SharpZipLib.Core
 	/// <summary>
 	/// NameAnsSizeFilter filters based on name and file size.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class NameAndSizeFilter : PathFilter
 	{
 	

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Encryption/PkzipClassic.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Encryption/PkzipClassic.cs
@@ -47,6 +47,7 @@ namespace ICSharpCode.SharpZipLib.Encryption
 	/// While it has been superceded by more recent and more powerful algorithms, its still in use and 
 	/// is viable for preventing casual snooping
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public abstract class PkzipClassic  : SymmetricAlgorithm
 	{
 		/// <summary>
@@ -368,6 +369,7 @@ namespace ICSharpCode.SharpZipLib.Encryption
 	/// Defines a wrapper object to access the Pkzip algorithm. 
 	/// This class cannot be inherited.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public sealed class PkzipClassicManaged : PkzipClassic
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/GZip/GZIPConstants.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/GZip/GZIPConstants.cs
@@ -41,6 +41,7 @@ namespace ICSharpCode.SharpZipLib.GZip
 	/// <summary>
 	/// This class contains constants used for gzip.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class GZipConstants
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/GZip/GZipException.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/GZip/GZipException.cs
@@ -41,6 +41,7 @@ namespace ICSharpCode.SharpZipLib.GZip
 	/// <summary>
 	/// GZipException represents a Gzip specific exception	
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class GZipException : SharpZipBaseException
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/GZip/GzipInputStream.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/GZip/GzipInputStream.cs
@@ -80,6 +80,7 @@ namespace ICSharpCode.SharpZipLib.GZip
 	/// }	
 	/// </code>
 	/// </example>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class GZipInputStream : InflaterInputStream 
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/GZip/GzipOutputStream.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/GZip/GzipOutputStream.cs
@@ -73,6 +73,7 @@ namespace ICSharpCode.SharpZipLib.GZip
 	/// }	
 	/// </code>
 	/// </example>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class GZipOutputStream : DeflaterOutputStream
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/SharpZipBaseException.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/SharpZipBaseException.cs
@@ -44,6 +44,7 @@ namespace ICSharpCode.SharpZipLib
 	/// SharpZipBaseException is the base exception class for the SharpZipLibrary.
 	/// All library exceptions are derived from this.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class SharpZipBaseException : ApplicationException
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/InvalidHeaderException.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/InvalidHeaderException.cs
@@ -38,6 +38,7 @@ namespace ICSharpCode.SharpZipLib.Tar {
 	/// This exception is used to indicate that there is a problem
 	/// with a TAR archive header.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class InvalidHeaderException : TarException
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarArchive.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarArchive.cs
@@ -41,6 +41,7 @@ namespace ICSharpCode.SharpZipLib.Tar {
 	/// <summary>
 	/// Used to advise clients of 'events' while processing archives
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public delegate void ProgressMessageHandler(TarArchive archive, TarEntry entry, string message);
 
 	/// <summary>
@@ -64,6 +65,7 @@ namespace ICSharpCode.SharpZipLib.Tar {
 	/// TarBuffer.getCurrentRecordNum() and TarBuffer.getCurrentBlockNum()
 	/// methods, this would be rather trvial.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class TarArchive
 	{
 		bool keepOldFiles;

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarBuffer.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarBuffer.cs
@@ -51,6 +51,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 	/// TarBuffers are created by Tar IO Streams.
 	/// </p>
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class TarBuffer
 	{
 

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarEntry.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarEntry.cs
@@ -68,6 +68,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 	/// 
 	/// <see cref="TarHeader"/>
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class TarEntry : ICloneable
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarException.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarException.cs
@@ -40,6 +40,7 @@ namespace ICSharpCode.SharpZipLib.Tar {
 	/// <summary>
 	/// TarExceptions are used for exceptions specific to tar classes and code.	
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class TarException : SharpZipBaseException
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarHeader.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarHeader.cs
@@ -77,6 +77,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 	/// This class encapsulates the Tar Entry Header used in Tar Archives.
 	/// The class also holds a number of tar constants, used mostly in headers.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class TarHeader : ICloneable
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarInputStream.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarInputStream.cs
@@ -46,6 +46,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 	/// the archive, and the read each entry as a normal input stream
 	/// using read().
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class TarInputStream : Stream
 	{
 		/// <summary>
@@ -551,6 +552,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// the programmer to have their own TarEntry subclass instantiated for the
 		/// entries return from getNextEntry().
 		/// </summary>
+		[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 		public interface IEntryFactory
 		{
 			/// <summary>
@@ -588,6 +590,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 		/// <summary>
 		/// Standard entry factory class creating instances of the class TarEntry
 		/// </summary>
+		[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 		public class EntryFactoryAdapter : IEntryFactory
 		{
 			/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarOutputStream.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Tar/TarOutputStream.cs
@@ -46,6 +46,7 @@ namespace ICSharpCode.SharpZipLib.Tar
 	/// by writing to this stream using write().
 	/// </summary>
 	/// public
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class TarOutputStream : Stream
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/Deflater.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/Deflater.cs
@@ -52,6 +52,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression
 	/// 
 	/// author of the original java version : Jochen Hoenicke
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class Deflater
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/DeflaterConstants.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/DeflaterConstants.cs
@@ -45,6 +45,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression
 	/// <summary>
 	/// This class contains constants used for deflation.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class DeflaterConstants 
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/DeflaterEngine.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/DeflaterEngine.cs
@@ -47,6 +47,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression
 	/// <summary>
 	/// Strategies for deflater
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public enum DeflateStrategy 
 	{
 		/// <summary>
@@ -87,6 +88,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression
 	/// Low level compression engine for deflate algorithm which uses a 32K sliding window
 	/// with secondary compression from Huffman/Shannon-Fano codes.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class DeflaterEngine : DeflaterConstants 
 	{
 		static int TOO_FAR = 4096;

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/DeflaterHuffman.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/DeflaterHuffman.cs
@@ -50,6 +50,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression
 	/// 
 	/// author of the original java version : Jochen Hoenicke
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class DeflaterHuffman
 	{
 		static  int BUFSIZE = 1 << (DeflaterConstants.DEFAULT_MEM_LEVEL + 6);
@@ -84,6 +85,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression
 		/// <summary>
 		/// Not documented
 		/// </summary>
+		[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 		public class Tree 
 		{
 			/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/DeflaterPending.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/DeflaterPending.cs
@@ -45,6 +45,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression
 	/// 
 	/// author of the original java version : Jochen Hoenicke
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class DeflaterPending : PendingBuffer
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/Inflater.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/Inflater.cs
@@ -70,6 +70,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression
 	///
 	/// author of the original java version : John Leuner, Jochen Hoenicke
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class Inflater
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/InflaterHuffmanTree.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/InflaterHuffmanTree.cs
@@ -45,6 +45,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression
 	/// <summary>
 	/// Huffman tree used for inflation
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class InflaterHuffmanTree 
 	{
 		static int MAX_BITLEN = 15;

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/PendingBuffer.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/PendingBuffer.cs
@@ -50,6 +50,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression
 	/// 
 	/// author of the original java version : Jochen Hoenicke
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class PendingBuffer
 	{
 		/// <summary>Internal work buffer

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/Streams/DeflaterOutputStream.cs
@@ -49,6 +49,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 	/// written to it.  It uses a Deflater to perform actual deflating.<br/>
 	/// Authors of the original java version : Tom Tromey, Jochen Hoenicke 
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class DeflaterOutputStream : Stream
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/Streams/InflaterInputStream.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/Streams/InflaterInputStream.cs
@@ -53,6 +53,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
    /// <remarks>
    /// The buffer supports decryption of incoming data.
    /// </remarks>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class InflaterInputBuffer
 	{
 		/// <summary>
@@ -325,6 +326,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 	///
 	/// Author of the original java version : John Leuner.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class InflaterInputStream : Stream
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/Streams/OutputWindow.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/Streams/OutputWindow.cs
@@ -47,6 +47,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 	/// to repeat stuff.<br/>
 	/// Author of the original java version : John Leuner
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class OutputWindow
 	{
 		private static int WINDOW_SIZE = 1 << 15;

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/Streams/StreamManipulator.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/Compression/Streams/StreamManipulator.cs
@@ -56,6 +56,7 @@ namespace ICSharpCode.SharpZipLib.Zip.Compression.Streams
 	///
 	/// authors of the original java version : John Leuner, Jochen Hoenicke
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class StreamManipulator
 	{
 		private byte[] window;

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/FastZip.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/FastZip.cs
@@ -43,6 +43,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 	/// <summary>
 	/// FastZipEvents supports all events applicable to <see cref="FastZip">FastZip</see> operations.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class FastZipEvents
 	{
 		/// <summary>
@@ -122,6 +123,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 	/// FastZip provides facilities for creating and extracting zip files.
 	/// Only relative paths are supported.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class FastZip
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/ZipConstants.cs
@@ -46,6 +46,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 	/// <summary>
 	/// The kind of compression used for an entry in an archive
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public enum CompressionMethod
 	{
 		/// <summary>
@@ -120,6 +121,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 	/// <summary>
 	/// This class contains constants used for Zip format files
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public sealed class ZipConstants
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/ZipEntry.cs
@@ -52,6 +52,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 	/// <br/>
 	/// <br/>Author of the original java version : Jochen Hoenicke
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class ZipEntry : ICloneable
 	{
 		static int KNOWN_SIZE               = 1;

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/ZipException.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/ZipException.cs
@@ -44,6 +44,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 	/// <summary>
 	/// Represents errors specific to Zip file handling
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class ZipException : SharpZipBaseException
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/ZipFile.cs
@@ -54,6 +54,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 	/// <summary>
 	/// Arguments used with KeysRequiredEvent
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class KeysRequiredEventArgs : EventArgs
 	{
 		string fileName;
@@ -136,6 +137,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 	/// }
 	/// </code>
 	/// </example>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class ZipFile : IEnumerable
 	{
 		string     name;

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/ZipInputStream.cs
@@ -94,6 +94,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 	/// }	
 	/// </code>
 	/// </example>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class ZipInputStream : InflaterInputStream
 	{
 		// Delegate for reading bytes from a stream.

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/ZipNameTransform.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/ZipNameTransform.cs
@@ -44,6 +44,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 	/// <summary>
 	/// ZipNameTransform transforms name as per the Zip file convention.
 	/// </summary>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class ZipNameTransform : INameTransform
 	{
 		/// <summary>

--- a/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
+++ b/mcs/class/ICSharpCode.SharpZipLib/ICSharpCode.SharpZipLib/Zip/ZipOutputStream.cs
@@ -96,6 +96,7 @@ namespace ICSharpCode.SharpZipLib.Zip
 	/// }	
 	/// </code>
 	/// </example>
+	[System.ObsoleteAttribute("This assembly has been deprecated. Please use https://www.nuget.org/packages/SharpZipLib/ instead.")]
 	public class ZipOutputStream : DeflaterOutputStream
 	{
 		private ArrayList entries  = new ArrayList();

--- a/mcs/class/reference-assemblies/Makefile
+++ b/mcs/class/reference-assemblies/Makefile
@@ -60,6 +60,7 @@ install-local:
 	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/mono/*.dll $(PROFILE_DIR)/4.6.2-api
 	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/mono/*.dll $(PROFILE_DIR)/4.7-api
 	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/mono/*.dll $(PROFILE_DIR)/4.7.1-api
+	rm -f $(PROFILE_DIR)/4.7.1-api/ICSharpCode.SharpZipLib.dll
 
 	# Unfortunately, a few programs (most notably NUnit and FSharp) have hardcoded checks for <prefix>/lib/mono/4.0/mscorlib.dll or Mono.Posix.dll,
 	# so we need to place something there or those tools break. We decided to symlink to the reference assembly for now.


### PR DESCRIPTION
Users should use the nuget package instead, we'll remove the assembly in Mono 6.0

Don't install it into the 4.7.1 reference assembly directory anymore.

Backport of https://github.com/mono/mono/pull/6511 to 2017-12