### PR TITLE
Add BTLS/AppleTLS symbols to System.Data's Makefile

### DIFF
--- a/mcs/class/System.Data/Makefile
+++ b/mcs/class/System.Data/Makefile
@@ -21,6 +21,16 @@ else
 LIB_REFS += System.EnterpriseServices System.Configuration
 endif
 
+ifdef MONO_FEATURE_APPLETLS
+LIB_MCS_FLAGS += -d:MONO_FEATURE_APPLETLS
+endif
+
+ifndef PROFILE_DISABLE_BTLS
+ifdef HAVE_BTLS
+LIB_MCS_FLAGS += -d:MONO_FEATURE_BTLS
+endif
+endif
+
 TXT_RESOURCE_STRINGS = ../referencesource/System.Data/system.data.txt
 RESX_RESOURCE_STRING = \
 	../../../external/corefx/src/System.Data.Common/src/Resources/Strings.resx	\


### PR DESCRIPTION
Needed for https://github.com/mono/corefx/pull/14/files
in order to fix https://github.com/mono/mono/issues/6350