### PR TITLE
[bcl] Cache the result of System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform on osx.

### DIFF
--- a/mcs/class/corlib/System.Runtime.InteropServices.RuntimeInformation/RuntimeInformation.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices.RuntimeInformation/RuntimeInformation.cs
@@ -47,10 +47,10 @@ namespace System.Runtime.InteropServices
 			case PlatformID.Win32NT:
 				return osPlatform == OSPlatform.Windows;
 			case PlatformID.Unix:
-				if (File.Exists ("/usr/lib/libc.dylib"))
+				if (Environment.Platform == PlatformID.MacOSX)
 					return osPlatform == OSPlatform.OSX;
-
-				return osPlatform == OSPlatform.Linux;
+				else
+					return osPlatform == OSPlatform.Linux;
 			default:
 				return false;
 			}

--- a/mcs/class/corlib/System/Environment.cs
+++ b/mcs/class/corlib/System/Environment.cs
@@ -214,7 +214,7 @@ namespace System {
 		//
 		static OperatingSystem os;
 
-		static extern PlatformID Platform {
+		static internal extern PlatformID Platform {
 			[MethodImplAttribute (MethodImplOptions.InternalCall)]
 			get;
 		}


### PR DESCRIPTION
Fixes part of https://github.com/mono/mono/issues/6530.