### PR TITLE
Use Environment.Platform to access the platform, rather than probing the file system

### DIFF
--- a/mcs/class/Facades/System.Runtime.InteropServices.RuntimeInformation/System.Runtime.InteropServices/RuntimeInformation.cs
+++ b/mcs/class/Facades/System.Runtime.InteropServices.RuntimeInformation/System.Runtime.InteropServices/RuntimeInformation.cs
@@ -43,13 +43,12 @@ namespace System.Runtime.InteropServices
 
 		public static bool IsOSPlatform (OSPlatform osPlatform)
 		{
-			switch (Environment.OSVersion.Platform) {
+			switch (Environment.Platform) {
 			case PlatformID.Win32NT:
 				return osPlatform == OSPlatform.Windows;
+			case PlatformID.MacOSX:
+				return osPlatform == OSPlatform.OSX;
 			case PlatformID.Unix:
-				if (Environment.Platform == PlatformID.MacOSX)
-					return osPlatform == OSPlatform.OSX;
-
 				return osPlatform == OSPlatform.Linux;
 			default:
 				return false;

--- a/mcs/class/Facades/System.Runtime.InteropServices.RuntimeInformation/System.Runtime.InteropServices/RuntimeInformation.cs
+++ b/mcs/class/Facades/System.Runtime.InteropServices.RuntimeInformation/System.Runtime.InteropServices/RuntimeInformation.cs
@@ -47,7 +47,7 @@ namespace System.Runtime.InteropServices
 			case PlatformID.Win32NT:
 				return osPlatform == OSPlatform.Windows;
 			case PlatformID.Unix:
-				if (File.Exists ("/usr/lib/libc.dylib"))
+				if (Environment.Platform == PlatformID.MacOSX)
 					return osPlatform == OSPlatform.OSX;
 
 				return osPlatform == OSPlatform.Linux;

--- a/mcs/class/corlib/System/Environment.cs
+++ b/mcs/class/corlib/System/Environment.cs
@@ -214,7 +214,7 @@ namespace System {
 		//
 		static OperatingSystem os;
 
-		static extern PlatformID Platform {
+		static internal PlatformID Platform {
 			[MethodImplAttribute (MethodImplOptions.InternalCall)]
 			get;
 		}


### PR DESCRIPTION
Backport https://github.com/mono/mono/pull/6535