### PR TITLE
Move machine handling of performance counters from native to managed.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # This can be reset to 0 when Mono's version number is bumped
 # since it's part of the corlib version (the prefix '1' in the full
 # version number is to ensure the number isn't treated as octal in C)
-MONO_CORLIB_COUNTER=2
+MONO_CORLIB_COUNTER=3
 MONO_CORLIB_VERSION=`printf "1%02d%02d%02d%03d" $MONO_VERSION_MAJOR $MONO_VERSION_MINOR 0 $MONO_CORLIB_COUNTER`
 
 AC_DEFINE_UNQUOTED(MONO_CORLIB_VERSION,$MONO_CORLIB_VERSION,[Version of the corlib-runtime interface])

--- a/mcs/class/System/System.Diagnostics/PerformanceCounter.cs
+++ b/mcs/class/System/System.Diagnostics/PerformanceCounter.cs
@@ -127,7 +127,7 @@ namespace System.Diagnostics {
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		static extern IntPtr GetImpl (string category, string counter,
-				string instance, string machine, out PerformanceCounterType ctype, out bool custom);
+				string instance, out PerformanceCounterType ctype, out bool custom);
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		static extern bool GetSample (IntPtr impl, bool only_value, out CounterSample sample);
@@ -138,6 +138,11 @@ namespace System.Diagnostics {
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		static extern void FreeData (IntPtr impl);
 
+		static bool ValidMachine (string machine)
+		{ // no support for counters on other machines
+			return machine.Length == 1 && machine[0] == '.';
+		}
+
 		/* the perf counter has changed, ensure it's valid and setup it to
 		 * be able to collect/update data
 		 */
@@ -146,7 +151,9 @@ namespace System.Diagnostics {
 			// need to free the previous info
 			if (impl != IntPtr.Zero)
 				Close ();
-			impl = GetImpl (categoryName, counterName, instanceName, machineName, out type, out is_custom);
+			impl = IntPtr.Zero;
+			if (ValidMachine (machineName))
+				impl = GetImpl (categoryName, counterName, instanceName, out type, out is_custom);
 			// system counters are always readonly
 			if (!is_custom)
 				readOnly = true;

--- a/mcs/class/System/System.Diagnostics/PerformanceCounter.cs
+++ b/mcs/class/System/System.Diagnostics/PerformanceCounter.cs
@@ -138,9 +138,9 @@ namespace System.Diagnostics {
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		static extern void FreeData (IntPtr impl);
 
-		static bool ValidMachine (string machine)
+		static bool IsValidMachine (string machine)
 		{ // no support for counters on other machines
-			return machine.Length == 1 && machine[0] == '.';
+			return machine == ".";
 		}
 
 		/* the perf counter has changed, ensure it's valid and setup it to
@@ -151,8 +151,8 @@ namespace System.Diagnostics {
 			// need to free the previous info
 			if (impl != IntPtr.Zero)
 				Close ();
-			impl = IntPtr.Zero;
-			if (ValidMachine (machineName))
+
+			if (IsValidMachine (machineName))
 				impl = GetImpl (categoryName, counterName, instanceName, out type, out is_custom);
 			// system counters are always readonly
 			if (!is_custom)

--- a/mcs/class/System/System.Diagnostics/PerformanceCounterCategory.cs
+++ b/mcs/class/System/System.Diagnostics/PerformanceCounterCategory.cs
@@ -55,7 +55,7 @@ namespace System.Diagnostics
 			PerformanceCounterCategoryType categoryType, CounterCreationData[] items);
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
-		static extern int InstanceExistsInternal (string instance, string category);
+		static extern bool InstanceExistsInternal (string instance, string category);
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		static extern string[] GetCategoryNames ();
@@ -95,16 +95,16 @@ namespace System.Diagnostics
 			this.machineName = machineName;
 		}
 
-		static bool ValidMachine (string machine)
+		static bool IsValidMachine (string machine)
 		{ // no support for counters on other machines
-			return machine.Length == 1 && machine[0] == '.';
+			return machine == ".";
 		}
 
 		// may throw InvalidOperationException, Win32Exception
 		public string CategoryHelp {
 			get {
 				string res = null;
-				if (ValidMachine (machineName))
+				if (IsValidMachine (machineName))
 					res = CategoryHelpInternal (categoryName);
 				if (res != null)
 					return res;
@@ -161,7 +161,7 @@ namespace System.Diagnostics
 			CheckCategory (categoryName);
 			if (machineName == null)
 				throw new ArgumentNullException ("machineName");
-			return ValidMachine (machineName)
+			return IsValidMachine (machineName)
 				&& CounterCategoryExists (counterName, categoryName);
 		}
 
@@ -235,7 +235,7 @@ namespace System.Diagnostics
 		public static bool Exists (string categoryName, string machineName)
 		{
 			CheckCategory (categoryName);
-			return ValidMachine (machineName) &&
+			return IsValidMachine (machineName) &&
 				CounterCategoryExists (null, categoryName);
 		}
 
@@ -249,8 +249,8 @@ namespace System.Diagnostics
 			if (machineName == null)
 				throw new ArgumentNullException ("machineName");
 
-			if (!ValidMachine (machineName))
-				return new PerformanceCounterCategory[0];
+			if (!IsValidMachine (machineName))
+				return Array.Empty<PerformanceCounterCategory>();
 
 			string[] catnames = GetCategoryNames ();
 			PerformanceCounterCategory[] cats = new PerformanceCounterCategory [catnames.Length];
@@ -266,8 +266,8 @@ namespace System.Diagnostics
 
 		public PerformanceCounter[] GetCounters (string instanceName)
 		{
-			if (!ValidMachine (machineName))
-				return new PerformanceCounter[0];
+			if (!IsValidMachine (machineName))
+				return Array.Empty<PerformanceCounter>();
 			string[] countnames = GetCounterNames (categoryName);
 			PerformanceCounter[] counters = new PerformanceCounter [countnames.Length];
 			for (int i = 0; i < countnames.Length; ++i) {
@@ -278,8 +278,8 @@ namespace System.Diagnostics
 
 		public string[] GetInstanceNames ()
 		{
-			if (!ValidMachine (machineName))
-				return new string[0];
+			if (!IsValidMachine (machineName))
+				return Array.Empty<string>();
 			return GetInstanceNames (categoryName);
 		}
 
@@ -302,15 +302,10 @@ namespace System.Diagnostics
 				throw new ArgumentNullException ("machineName");
 
 			//?FIXME: machine appears to be wrong
-			//if (!ValidMachine (machineName))
+			//if (!IsValidMachine (machineName))
 			//return false;
 
-			int val = InstanceExistsInternal (instanceName, categoryName);
-			if (val == 0)
-				return false;
-			if (val == 1)
-				return true;
-			throw new InvalidOperationException ();
+			return InstanceExistsInternal (instanceName, categoryName);
 		}
 
 		[MonoTODO]

--- a/mono/metadata/mono-perfcounters.c
+++ b/mono/metadata/mono-perfcounters.c
@@ -1561,7 +1561,7 @@ failure:
 	return result;
 }
 
-int
+MonoBoolean
 mono_perfcounter_instance_exists (MonoString *instance, MonoString *category)
 {
 	ERROR_DECL (error);

--- a/mono/metadata/mono-perfcounters.c
+++ b/mono/metadata/mono-perfcounters.c
@@ -1316,14 +1316,11 @@ find_category (MonoString *category)
 
 void*
 mono_perfcounter_get_impl (MonoString* category, MonoString* counter, MonoString* instance,
-		MonoString* machine, int *type, MonoBoolean *custom)
+		int *type, MonoBoolean *custom)
 {
 	ERROR_DECL (error);
 	const CategoryDesc *cdesc;
 	void *result = NULL;
-	/* no support for counters on other machines */
-	if (mono_string_compare_ascii (machine, "."))
-		return NULL;
 	cdesc = find_category (category);
 	if (!cdesc) {
 		SharedCategory *scat = find_custom_category (category);
@@ -1419,15 +1416,12 @@ mono_perfcounter_category_del (MonoString *name)
 
 /* this is an icall */
 MonoString*
-mono_perfcounter_category_help (MonoString *category, MonoString *machine)
+mono_perfcounter_category_help (MonoString *category)
 {
 	ERROR_DECL (error);
 	MonoString *result = NULL;
 	const CategoryDesc *cdesc;
 	error_init (error);
-	/* no support for counters on other machines */
-	if (mono_string_compare_ascii (machine, "."))
-		return NULL;
 	cdesc = find_category (category);
 	if (!cdesc) {
 		SharedCategory *scat = find_custom_category (category);
@@ -1445,16 +1439,13 @@ mono_perfcounter_category_help (MonoString *category, MonoString *machine)
 }
 
 /*
- * Check if the category named @category exists on @machine. If @counter is not NULL, return
+ * Check if the category named @category exists. If @counter is not NULL, return
  * TRUE only if a counter with that name exists in the category.
  */
 MonoBoolean
-mono_perfcounter_category_exists (MonoString *counter, MonoString *category, MonoString *machine)
+mono_perfcounter_category_exists (MonoString *counter, MonoString *category)
 {
 	const CategoryDesc *cdesc;
-	/* no support for counters on other machines */
-	if (mono_string_compare_ascii (machine, "."))
-		return FALSE;
 	cdesc = find_category (category);
 	if (!cdesc) {
 		SharedCategory *scat = find_custom_category (category);
@@ -1571,16 +1562,12 @@ failure:
 }
 
 int
-mono_perfcounter_instance_exists (MonoString *instance, MonoString *category, MonoString *machine)
+mono_perfcounter_instance_exists (MonoString *instance, MonoString *category)
 {
 	ERROR_DECL (error);
 	const CategoryDesc *cdesc;
 	SharedInstance *sinst;
 	char *name;
-	/* no support for counters on other machines */
-	/*FIXME: machine appears to be wrong
-	if (mono_string_compare_ascii (machine, "."))
-		return FALSE;*/
 	cdesc = find_category (category);
 	if (!cdesc) {
 		SharedCategory *scat;
@@ -1602,19 +1589,13 @@ mono_perfcounter_instance_exists (MonoString *instance, MonoString *category, Mo
 
 /* this is an icall */
 MonoArray*
-mono_perfcounter_category_names (MonoString *machine)
+mono_perfcounter_category_names (void)
 {
 	ERROR_DECL (error);
 	int i;
 	MonoArray *res;
 	MonoDomain *domain = mono_domain_get ();
 	GSList *custom_categories, *tmp;
-	/* no support for counters on other machines */
-	if (mono_string_compare_ascii (machine, ".")) {
-		res = mono_array_new_checked (domain, mono_get_string_class (), 0, error);
-		mono_error_set_pending_exception (error);
-		return res;
-	}
 	perfctr_lock ();
 	custom_categories = get_custom_categories ();
 	res = mono_array_new_checked (domain, mono_get_string_class (), NUM_CATEGORIES + g_slist_length (custom_categories), error);
@@ -1644,7 +1625,7 @@ leave:
 }
 
 MonoArray*
-mono_perfcounter_counter_names (MonoString *category, MonoString *machine)
+mono_perfcounter_counter_names (MonoString *category)
 {
 	ERROR_DECL (error);
 	int i;
@@ -1652,12 +1633,6 @@ mono_perfcounter_counter_names (MonoString *category, MonoString *machine)
 	const CategoryDesc *cdesc;
 	MonoArray *res;
 	MonoDomain *domain = mono_domain_get ();
-	/* no support for counters on other machines */
-	if (mono_string_compare_ascii (machine, ".")) {
-		res =  mono_array_new_checked (domain, mono_get_string_class (), 0, error);
-		mono_error_set_pending_exception (error);
-		return res;
-	}
 	cdesc = find_category (category);
 	if (cdesc) {
 		res = mono_array_new_checked (domain, mono_get_string_class (), cdesc [1].first_counter - cdesc->first_counter, error);
@@ -1842,16 +1817,11 @@ get_custom_instances (MonoString *category, MonoError *error)
 }
 
 MonoArray*
-mono_perfcounter_instance_names (MonoString *category, MonoString *machine)
+mono_perfcounter_instance_names (MonoString *category)
 {
 	ERROR_DECL (error);
 	const CategoryDesc* cat;
 	MonoArray *result = NULL;
-	if (mono_string_compare_ascii (machine, ".")) {
-		result = mono_array_new_checked (mono_domain_get (), mono_get_string_class (), 0, error);
-		mono_error_set_pending_exception (error);
-		return result;
-	}
 	
 	cat = find_category (category);
 	if (!cat) {
@@ -1939,7 +1909,7 @@ mono_perfcounter_foreach (PerfCounterEnumCallback cb, gpointer data)
 
 #else
 void*
-mono_perfcounter_get_impl (MonoString* category, MonoString* counter, MonoString* instance, MonoString* machine, int *type, MonoBoolean *custom)
+mono_perfcounter_get_impl (MonoString* category, MonoString* counter, MonoString* instance, int *type, MonoBoolean *custom)
 {
 	g_assert_not_reached ();
 }
@@ -1970,13 +1940,13 @@ mono_perfcounter_category_del (MonoString *name)
 }
 
 MonoString*
-mono_perfcounter_category_help (MonoString *category, MonoString *machine)
+mono_perfcounter_category_help (MonoString *category)
 {
 	g_assert_not_reached ();
 }
 
 MonoBoolean
-mono_perfcounter_category_exists (MonoString *counter, MonoString *category, MonoString *machine)
+mono_perfcounter_category_exists (MonoString *counter, MonoString *category)
 {
 	g_assert_not_reached ();
 }
@@ -1988,25 +1958,25 @@ mono_perfcounter_create (MonoString *category, MonoString *help, int type, MonoA
 }
 
 int
-mono_perfcounter_instance_exists (MonoString *instance, MonoString *category, MonoString *machine)
+mono_perfcounter_instance_exists (MonoString *instance, MonoString *category)
 {
 	g_assert_not_reached ();
 }
 
 MonoArray*
-mono_perfcounter_category_names (MonoString *machine)
+mono_perfcounter_category_names (void)
 {
 	g_assert_not_reached ();
 }
 
 MonoArray*
-mono_perfcounter_counter_names (MonoString *category, MonoString *machine)
+mono_perfcounter_counter_names (MonoString *category)
 {
 	g_assert_not_reached ();
 }
 
 MonoArray*
-mono_perfcounter_instance_names (MonoString *category, MonoString *machine)
+mono_perfcounter_instance_names (MonoString *category)
 {
 	g_assert_not_reached ();
 }

--- a/mono/metadata/mono-perfcounters.h
+++ b/mono/metadata/mono-perfcounters.h
@@ -12,7 +12,7 @@
 typedef struct _MonoCounterSample MonoCounterSample;
 
 void* mono_perfcounter_get_impl (MonoString* category, MonoString* counter, MonoString* instance,
-		MonoString* machine, int *type, MonoBoolean *custom);
+		int *type, MonoBoolean *custom);
 
 MonoBoolean mono_perfcounter_get_sample (void *impl, MonoBoolean only_value, MonoCounterSample *sample);
 
@@ -21,13 +21,13 @@ void   mono_perfcounter_free_data       (void *impl);
 
 /* Category icalls */
 MonoBoolean mono_perfcounter_category_del    (MonoString *name);
-MonoString* mono_perfcounter_category_help   (MonoString *category, MonoString *machine);
-MonoBoolean mono_perfcounter_category_exists (MonoString *counter, MonoString *category, MonoString *machine);
+MonoString* mono_perfcounter_category_help   (MonoString *category);
+MonoBoolean mono_perfcounter_category_exists (MonoString *counter, MonoString *category);
 MonoBoolean mono_perfcounter_create          (MonoString *category, MonoString *help, int type, MonoArray *items);
-int         mono_perfcounter_instance_exists (MonoString *instance, MonoString *category, MonoString *machine);
-MonoArray*  mono_perfcounter_category_names  (MonoString *machine);
-MonoArray*  mono_perfcounter_counter_names   (MonoString *category, MonoString *machine);
-MonoArray*  mono_perfcounter_instance_names  (MonoString *category, MonoString *machine);
+int         mono_perfcounter_instance_exists (MonoString *instance, MonoString *category);
+MonoArray*  mono_perfcounter_category_names  (void);
+MonoArray*  mono_perfcounter_counter_names   (MonoString *category);
+MonoArray*  mono_perfcounter_instance_names  (MonoString *category);
 
 typedef gboolean (*PerfCounterEnumCallback) (char *category_name, char *name, unsigned char type, gint64 value, gpointer user_data);
 MONO_API void mono_perfcounter_foreach (PerfCounterEnumCallback cb, gpointer user_data);

--- a/mono/metadata/mono-perfcounters.h
+++ b/mono/metadata/mono-perfcounters.h
@@ -24,7 +24,7 @@ MonoBoolean mono_perfcounter_category_del    (MonoString *name);
 MonoString* mono_perfcounter_category_help   (MonoString *category);
 MonoBoolean mono_perfcounter_category_exists (MonoString *counter, MonoString *category);
 MonoBoolean mono_perfcounter_create          (MonoString *category, MonoString *help, int type, MonoArray *items);
-int         mono_perfcounter_instance_exists (MonoString *instance, MonoString *category);
+MonoBoolean mono_perfcounter_instance_exists (MonoString *instance, MonoString *category);
 MonoArray*  mono_perfcounter_category_names  (void);
 MonoArray*  mono_perfcounter_counter_names   (MonoString *category);
 MonoArray*  mono_perfcounter_instance_names  (MonoString *category);


### PR DESCRIPTION
Just slightly less native code therefore.

The handling is trivial: returning false or 0 or null or an empty array, or in one surprising case ignoring it entirely.