### PR TITLE
[2017-12] [Tests] Skip some of the System.ServiceModel tests when using MOBILE

### DIFF
--- a/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Contracts/AsyncCallTester.cs
+++ b/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Contracts/AsyncCallTester.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !MOBILE
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.ServiceModel;
@@ -22,3 +23,4 @@ namespace MonoTests.Features.Contracts
 	}
 
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Contracts/FaultsTester.cs
+++ b/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Contracts/FaultsTester.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !MOBILE
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.ServiceModel;
@@ -37,3 +38,4 @@ namespace MonoTests.Features.Contracts
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Serialization/AsyncCallTest.cs
+++ b/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Serialization/AsyncCallTest.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !MOBILE
+using System;
 using System.Collections.Generic;
 using System.Text;
 using NUnit.Framework;
@@ -49,3 +50,4 @@ namespace MonoTests.Features.Serialization
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Serialization/AsyncPatternTester.cs
+++ b/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Serialization/AsyncPatternTester.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !MOBILE
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Proxy.MonoTests.Features.Client;
@@ -19,3 +20,4 @@ namespace MonoTests.Features.Serialization
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Serialization/DataContractSerializerTest.cs
+++ b/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Serialization/DataContractSerializerTest.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !MOBILE
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.ServiceModel;
@@ -101,3 +102,4 @@ namespace NS1.NS3 {
 		public NS2.Type2 AType {get; set; }
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Serialization/DualContractTester.cs
+++ b/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Serialization/DualContractTester.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !MOBILE
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Proxy.MonoTests.Features.Client;
@@ -28,3 +29,4 @@ namespace MonoTests.Features.Serialization
 	}
 
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Serialization/ExitProcessHelper.cs
+++ b/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Serialization/ExitProcessHelper.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !MOBILE
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Proxy.MonoTests.Features.Client;
@@ -13,3 +14,4 @@ namespace MonoTests.Features.Serialization
 	{
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Serialization/FaultsTest.cs
+++ b/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Serialization/FaultsTest.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !MOBILE
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Proxy.MonoTests.Features.Client;
@@ -41,3 +42,4 @@ namespace MonoTests.Features.Serialization
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Serialization/KnownTypeTest.cs
+++ b/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Serialization/KnownTypeTest.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !MOBILE
+using System;
 using System.Collections.Generic;
 using System.Text;
 using NUnit.Framework;
@@ -33,3 +34,4 @@ namespace MonoTests.Features.Serialization
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Serialization/MessageContractTest.cs
+++ b/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Serialization/MessageContractTest.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !MOBILE
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Proxy.MonoTests.Features.Client;
@@ -23,3 +24,4 @@ namespace MonoTests.Features.Serialization
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Serialization/OperationContractTester.cs
+++ b/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Serialization/OperationContractTester.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !MOBILE
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Proxy.MonoTests.Features.Client;
@@ -43,3 +44,4 @@ namespace MonoTests.Features.Serialization
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Serialization/PrimitiveTesterTest.cs
+++ b/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Serialization/PrimitiveTesterTest.cs
@@ -1,5 +1,5 @@
 ﻿
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -118,3 +118,4 @@ namespace MonoTests.Features.Serialization
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Serialization/UntypedMessageTest.cs
+++ b/mcs/class/System.ServiceModel/Test/FeatureBased/Features.Serialization/UntypedMessageTest.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !MOBILE
+using System;
 using System.Collections.Generic;
 using System.Text;
 using NUnit.Framework;
@@ -30,3 +31,4 @@ namespace MonoTests.Features.Serialization
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/FeatureBased/TestFixtureBase.cs
+++ b/mcs/class/System.ServiceModel/Test/FeatureBased/TestFixtureBase.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !MOBILE
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.ServiceModel;
@@ -214,3 +215,4 @@ namespace MonoTests.Features
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/MetadataTests/BindingTestAssertions.cs
+++ b/mcs/class/System.ServiceModel/Test/MetadataTests/BindingTestAssertions.cs
@@ -23,7 +23,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
+#if !MOBILE
 using System;
 using System.Net;
 using System.Net.Security;
@@ -859,3 +859,5 @@ namespace MonoTests.System.ServiceModel.MetadataTests {
 		}
 	}
 }
+#endif
+

--- a/mcs/class/System.ServiceModel/Test/MetadataTests/ExportTests.cs
+++ b/mcs/class/System.ServiceModel/Test/MetadataTests/ExportTests.cs
@@ -23,6 +23,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+#if !MOBILE
+
 using System;
 using System.Net;
 using System.Xml;
@@ -239,4 +241,5 @@ namespace MonoTests.System.ServiceModel.MetadataTests {
 		}
 	}
 }
+#endif
 

--- a/mcs/class/System.ServiceModel/Test/MetadataTests/ImportTests.cs
+++ b/mcs/class/System.ServiceModel/Test/MetadataTests/ImportTests.cs
@@ -23,7 +23,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
+#if !MOBILE
 using System;
 using System.Net;
 using System.Xml;
@@ -320,4 +320,5 @@ namespace MonoTests.System.ServiceModel.MetadataTests {
 	}
 
 }
+#endif
 

--- a/mcs/class/System.ServiceModel/Test/MetadataTests/ImportTests_CreateMetadata.cs
+++ b/mcs/class/System.ServiceModel/Test/MetadataTests/ImportTests_CreateMetadata.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if !MOBILE
 using System;
 using NUnit.Framework;
 
@@ -42,3 +43,4 @@ namespace MonoTests.System.ServiceModel.MetadataTests {
 
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/MetadataTests/ImportTests_LoadMetadata.cs
+++ b/mcs/class/System.ServiceModel/Test/MetadataTests/ImportTests_LoadMetadata.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if !MOBILE
 using System;
 using System.Net;
 using System.Xml;
@@ -59,3 +60,4 @@ namespace MonoTests.System.ServiceModel.MetadataTests {
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/MetadataTests/ImportTests_RoundTrip.cs
+++ b/mcs/class/System.ServiceModel/Test/MetadataTests/ImportTests_RoundTrip.cs
@@ -24,7 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-
+#if !MOBILE
 using System;
 using NUnit.Framework;
 
@@ -45,3 +45,4 @@ namespace MonoTests.System.ServiceModel.MetadataTests {
 
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/MetadataTests/MetadataSamples.cs
+++ b/mcs/class/System.ServiceModel/Test/MetadataTests/MetadataSamples.cs
@@ -23,6 +23,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+#if !MOBILE
 using System;
 using System.IO;
 using System.Reflection;
@@ -439,3 +440,4 @@ namespace MonoTests.System.ServiceModel.MetadataTests {
 		#endregion
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/MetadataTests/MiscImportTests.cs
+++ b/mcs/class/System.ServiceModel/Test/MetadataTests/MiscImportTests.cs
@@ -23,7 +23,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
+#if !MOBILE
 using System;
 using System.Net;
 using System.Xml;
@@ -277,4 +277,5 @@ namespace MonoTests.System.ServiceModel.MetadataTests {
 
 	}
 }
+#endif
 

--- a/mcs/class/System.ServiceModel/Test/MetadataTests/TestContext.cs
+++ b/mcs/class/System.ServiceModel/Test/MetadataTests/TestContext.cs
@@ -23,7 +23,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
+#if !MOBILE
 using System;
 using System.IO;
 using System.Text;
@@ -322,4 +322,6 @@ namespace MonoTests.System.ServiceModel.MetadataTests {
 		#endregion
 	}
 }
+#endif
+
 

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/AsymmetricSecurityBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/AsymmetricSecurityBindingElementTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -258,3 +259,4 @@ namespace MonoTests.System.ServiceModel.Channels
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/BinaryMessageEncodingBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/BinaryMessageEncodingBindingElementTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -461,3 +462,4 @@ namespace MonoTests.System.ServiceModel.Channels
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/BindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/BindingElementTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -204,3 +205,4 @@ namespace MonoTests.System.ServiceModel.Channels
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/CalcSampleProxy.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/CalcSampleProxy.cs
@@ -32,8 +32,10 @@ using System.IO;
 using System.Net;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
+#if !MOBILE
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
+#endif
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/ConnectionOrientedTransportBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/ConnectionOrientedTransportBindingElementTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
@@ -197,4 +197,4 @@ namespace MonoTests.System.ServiceModel.Channels
 		}
 	}
 }
-
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/CustomBindingTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/CustomBindingTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.Net.Security;
@@ -443,3 +444,5 @@ namespace MonoTests.System.ServiceModel.Channels
 	{
 	}
 }
+#endif
+

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/CustomPolicyConversionContext.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/CustomPolicyConversionContext.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
@@ -73,4 +73,4 @@ namespace MonoTests.System.ServiceModel.Channels
 
 	}
 }
-
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/HandlerTransportBindingElement.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/HandlerTransportBindingElement.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.IO;
 using System.Net;
@@ -647,3 +648,4 @@ namespace MonoTests.System.ServiceModel.Channels
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/HttpTransportBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/HttpTransportBindingElementTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -580,3 +581,4 @@ namespace MonoTests.System.ServiceModel.Channels
 		#endregion
     }
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/HttpsTransportBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/HttpsTransportBindingElementTest.cs
@@ -43,6 +43,7 @@ namespace MonoTests.System.ServiceModel.Channels
 	[TestFixture]
 	public class HttpsTransportBindingElementTest
 	{
+#if !MOBILE
 		[Test]
 		[ExpectedException (typeof (ArgumentException))]
 		public void BuildChannelFactoryForHttpEndpoint ()
@@ -62,7 +63,7 @@ namespace MonoTests.System.ServiceModel.Channels
 			b.Security.Mode = BasicHttpSecurityMode.Transport;
 			b.BuildChannelListener<IReplyChannel> (new Uri ("http://localhost:8080"));
 		}
-
+#endif
 		[Test]
 		public void GetProperty ()
 		{

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/InterceptorBindingElement.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/InterceptorBindingElement.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.Net;
@@ -513,3 +514,4 @@ namespace MonoTests.System.ServiceModel.Channels
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/LocalClientSecuritySettingsTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/LocalClientSecuritySettingsTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -62,3 +63,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/MessageBufferTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/MessageBufferTest.cs
@@ -13,6 +13,7 @@ namespace MonoTests.System.ServiceModel.Channels
 	[TestFixture]
 	public class MessageBufferTest
 	{
+#if !MOBILE
 		[Test]
 		public void TestCreateNavigator ()
 		{
@@ -23,7 +24,7 @@ namespace MonoTests.System.ServiceModel.Channels
 
 			Assert.IsTrue (nav is SeekableXPathNavigator);
 		}
-
+#endif
 		[Test]
 		[ExpectedException (typeof (InvalidOperationException))]
 		public void TestCreateBufferedCopyTwice ()

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/MessageEncoderTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/MessageEncoderTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -135,3 +136,5 @@ namespace MonoTests.System.ServiceModel.Channels
 
 	}
 }
+#endif
+

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/MsmqBindingElementBaseTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/MsmqBindingElementBaseTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Net.Security;
 using System.ServiceModel;
@@ -159,4 +159,5 @@ namespace MonoTests.System.ServiceModel.Channels
 		}
 	}
 }
+#endif
 

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/MsmqTransportBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/MsmqTransportBindingElementTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -181,3 +182,4 @@ namespace MonoTests.System.ServiceModel.Channels
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/NamedPipeTransportBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/NamedPipeTransportBindingElementTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -118,3 +119,4 @@ namespace MonoTests.System.ServiceModel.Channels
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/OneWayBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/OneWayBindingElementTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.ServiceModel;
@@ -88,3 +89,4 @@ namespace MonoTests.System.ServiceModel.Channels
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/PeerTransportBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/PeerTransportBindingElementTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.Net;
@@ -153,3 +154,4 @@ namespace MonoTests.System.ServiceModel.Channels
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/ReplyChannelBase.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/ReplyChannelBase.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -125,3 +126,4 @@ namespace MonoTests.System.ServiceModel.Channels
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/SecurityAssert.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/SecurityAssert.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -264,3 +265,4 @@ namespace MonoTests.System.ServiceModel.Channels
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/SecurityBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/SecurityBindingElementTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -634,3 +635,4 @@ namespace MonoTests.System.ServiceModel.Channels
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/SslStreamSecurityBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/SslStreamSecurityBindingElementTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -120,3 +121,4 @@ namespace MonoTests.System.ServiceModel.Channels
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/SymmetricSecurityBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/SymmetricSecurityBindingElementTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -663,3 +664,4 @@ settings.Indent = true;
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/TcpTransportBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/TcpTransportBindingElementTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -268,3 +269,4 @@ namespace MonoTests.System.ServiceModel.Channels
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/TextMessageEncodingBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/TextMessageEncodingBindingElementTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -153,3 +154,4 @@ namespace MonoTests.System.ServiceModel.Channels
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/TransactionFlowBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Channels/TransactionFlowBindingElementTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.Net;
@@ -75,3 +76,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/AddressHeaderCollectionElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/AddressHeaderCollectionElementTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -56,3 +56,4 @@ namespace MonoTests.System.ServiceModel.Configuration
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/BasicHttpBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/BasicHttpBindingElementTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -63,3 +63,4 @@ namespace MonoTests.System.ServiceModel.Configuration
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/BehaviorsSectionTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/BehaviorsSectionTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -62,3 +62,4 @@ namespace MonoTests.System.ServiceModel.Configuration
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/BindingsSectionTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/BindingsSectionTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -60,3 +60,4 @@ namespace MonoTests.System.ServiceModel.Configuration
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/ChannelEndpointElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/ChannelEndpointElementTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -54,3 +54,4 @@ namespace MonoTests.System.ServiceModel.Configuration
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/CustomBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/CustomBindingElementTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -403,3 +403,4 @@ namespace MonoTests.System.ServiceModel.Configuration
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/EndpointBehaviorElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/EndpointBehaviorElementTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -260,3 +260,4 @@ namespace MonoTests.System.ServiceModel.Configuration
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/ExtensionsSectionTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/ExtensionsSectionTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -91,3 +91,4 @@ namespace MonoTests.System.ServiceModel.Configuration
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/MetadataElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/MetadataElementTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -132,3 +132,4 @@ namespace MonoTests.System.ServiceModel.Configuration
 
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/MexBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/MexBindingElementTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -56,3 +56,4 @@ namespace MonoTests.System.ServiceModel.Configuration
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/NetNamedPipeBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/NetNamedPipeBindingElementTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -52,3 +52,4 @@ namespace MonoTests.System.ServiceModel.Configuration
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/NetPeerTcpBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/NetPeerTcpBindingElementTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -52,3 +52,4 @@ namespace MonoTests.System.ServiceModel.Configuration
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/NetTcpBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/NetTcpBindingElementTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -52,3 +52,4 @@ namespace MonoTests.System.ServiceModel.Configuration
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/ServiceBehaviorElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/ServiceBehaviorElementTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -387,3 +387,4 @@ namespace MonoTests.System.ServiceModel.Configuration
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/ServiceElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/ServiceElementTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -84,3 +84,4 @@ namespace MonoTests.System.ServiceModel.Configuration
 
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/ServiceModelConfigurationElementCollectionTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/ServiceModelConfigurationElementCollectionTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -129,4 +129,5 @@ namespace MonoTests.System.ServiceModel.Configuration
 		}
 	}
 }
+#endif
 

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/ServiceModelSectionGroupTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/ServiceModelSectionGroupTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Configuration;
@@ -88,3 +88,4 @@ namespace MonoTests.System.ServiceModel.Configuration
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/StandardBindingCollectionElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/StandardBindingCollectionElementTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -87,3 +87,5 @@ namespace MonoTests.System.ServiceModel.Configuration
 		}
 	}
 }
+#endif
+

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/StandardBindingElementCollectionTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/StandardBindingElementCollectionTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using NUnit.Framework;
 using System;
 using System.Configuration;
@@ -92,3 +92,4 @@ namespace MonoTests.System.ServiceModel.Configuration
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/StandardBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/StandardBindingElementTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -71,3 +71,4 @@ namespace MonoTests.System.ServiceModel.Configuration
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/StandardEndpointsSectionTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/StandardEndpointsSectionTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Configuration;
@@ -51,3 +51,4 @@ namespace MonoTests.System.ServiceModel.Configuration
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/UserBinding.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Configuration/UserBinding.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -68,3 +68,4 @@ namespace MonoTests.System.ServiceModel.Configuration
 	}
 
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ClientCredentialsTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ClientCredentialsTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.IdentityModel.Claims;
@@ -113,3 +113,4 @@ namespace MonoTests.System.ServiceModel.Description
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ContractDescriptionTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ContractDescriptionTest.cs
@@ -26,6 +26,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -1088,3 +1089,5 @@ namespace MonoTests.System.ServiceModel.Description
 
 	}
 }
+#endif
+

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/MetadataExchangeBindingsTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/MetadataExchangeBindingsTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -120,3 +120,4 @@ namespace MonoTests.System.ServiceModel.Description
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/MetadataResolverTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/MetadataResolverTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -375,3 +375,4 @@ namespace MonoTests.System.ServiceModel.Description
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/MetadataSetTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/MetadataSetTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -60,3 +60,4 @@ namespace MonoTests.System.ServiceModel.Description
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceAuthorizationBehaviorTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceAuthorizationBehaviorTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.ServiceModel;
@@ -116,3 +116,4 @@ namespace MonoTests.System.ServiceModel.Description
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceContractGeneratorTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceContractGeneratorTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.CodeDom;
 using System.Collections;
@@ -119,3 +119,4 @@ namespace MonoTests.System.ServiceModel.Description
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceCredentialsTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceCredentialsTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.IdentityModel.Claims;
@@ -134,3 +134,5 @@ namespace MonoTests.System.ServiceModel.Description
 		}
 	}
 }
+#endif
+

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceDebugBehaviorTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceDebugBehaviorTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Net.Sockets;
@@ -228,3 +228,4 @@ namespace MonoTests.System.ServiceModel.Description
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceMetadataBehaviorTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceMetadataBehaviorTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -278,3 +278,4 @@ namespace MonoTests.System.ServiceModel.Description
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceMetadataEndpointTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceMetadataEndpointTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -53,3 +53,4 @@ namespace MonoTests.System.ServiceModel.Description
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceThrottlingBehaviorTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/ServiceThrottlingBehaviorTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -57,3 +57,4 @@ namespace MonoTests.System.ServiceModel.Description
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/TypedMessageConverterTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/TypedMessageConverterTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -220,3 +220,4 @@ namespace MonoTests.System.ServiceModel.Description
 	}
 
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/WsdlExporterTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/WsdlExporterTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -766,5 +766,7 @@ namespace FooNS
 		public string foo;
 	}
 }
+
+#endif
 
 

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/WsdlImporterTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Description/WsdlImporterTest.cs
@@ -26,7 +26,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -594,3 +594,4 @@ namespace MonoTests.System.ServiceModel.Description
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/ActionFilterTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/ActionFilterTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.ServiceModel;
@@ -85,3 +86,4 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 */
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/Bug32886Test.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/Bug32886Test.cs
@@ -21,6 +21,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -713,3 +714,4 @@ public partial class TempConvertSoapClient : System.ServiceModel.ClientBase<Temp
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/Bug652331Test.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/Bug652331Test.cs
@@ -24,6 +24,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -388,3 +389,4 @@ namespace WebServiceMoonlightTest.ServiceReference1 {
 */
     }
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/Bug652331_2Test.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/Bug652331_2Test.cs
@@ -24,6 +24,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -882,4 +883,5 @@ namespace WebServiceMoonlightTest.ServiceReference2 {
 */
     }
 }
+#endif
 

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/ChannelDispatcherTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/ChannelDispatcherTest.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !MOBILE
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -464,3 +465,4 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/DispatchOperationTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/DispatchOperationTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
@@ -212,3 +212,4 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/DispatchRuntimeTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/DispatchRuntimeTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
@@ -406,3 +406,4 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 #endregion
 
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/EndpointAddressMessageFilterTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/EndpointAddressMessageFilterTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -86,3 +87,4 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/EndpointDispatcherTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/EndpointDispatcherTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -109,3 +110,4 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/ExceptionHandlerTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/ExceptionHandlerTest.cs
@@ -24,7 +24,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Reflection;
 using System.Runtime.ConstrainedExecution;
@@ -62,3 +62,4 @@ namespace MonoTests.System.ServiceModel.Dispatcher {
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/FilterTableTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/FilterTableTest.cs
@@ -1,3 +1,4 @@
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.ServiceModel;
@@ -28,3 +29,4 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/InvalidBodyAccessExceptionTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/InvalidBodyAccessExceptionTest.cs
@@ -1,3 +1,4 @@
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
@@ -21,3 +22,4 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/PrefixEndpointAddressMessageFilterTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/PrefixEndpointAddressMessageFilterTest.cs
@@ -26,6 +26,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -80,3 +81,4 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/XPathMessageContextTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Dispatcher/XPathMessageContextTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
@@ -56,3 +56,4 @@ namespace MonoTests.System.ServiceModel.Dispatcher
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.PeerResolvers/CustomPeerResolverServiceTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.PeerResolvers/CustomPeerResolverServiceTest.cs
@@ -6,7 +6,7 @@
 // 
 // Copyright 2007 Marcos Cobena (http://www.youcannoteatbits.org/)
 // 
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.ServiceModel;
@@ -210,3 +210,4 @@ namespace MonoTests.System.ServiceModel.PeerResolvers
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.PeerResolvers/PeerResolverSerializationTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.PeerResolvers/PeerResolverSerializationTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -100,3 +100,5 @@ public class PeerNodeAddress
 */
 
 }
+#endif
+

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/IssuedSecurityTokenParametersTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/IssuedSecurityTokenParametersTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -116,3 +117,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/IssuedSecurityTokenProviderTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/IssuedSecurityTokenProviderTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -621,3 +622,5 @@ Console.Error.WriteLine ("============= Decrypted Body End ===========");
 		}
 	}
 }
+#endif
+

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/RsaSecurityTokenParametersTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/RsaSecurityTokenParametersTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -120,3 +121,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/SecureConversationSecurityTokenParametersTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/SecureConversationSecurityTokenParametersTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -140,3 +141,5 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif
+

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/SecurityContextSecurityTokenTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/SecurityContextSecurityTokenTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -54,3 +55,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/SecurityTokenParametersTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/SecurityTokenParametersTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -87,3 +88,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/ServiceModelSecurityTokenTypesTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/ServiceModelSecurityTokenTypesTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -53,3 +54,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/SslSecurityTokenParametersTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/SslSecurityTokenParametersTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -275,3 +276,5 @@ namespace MonoTests.System.ServiceModel.Security.Tokens
 		}
 	}
 }
+#endif
+

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/SspiSecurityTokenParametersTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/SspiSecurityTokenParametersTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -255,3 +256,4 @@ namespace MonoTests.System.ServiceModel.Security.Tokens
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/UserNameSecurityTokenParametersTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/UserNameSecurityTokenParametersTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -117,3 +118,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/WrappedKeySecurityTokenTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/WrappedKeySecurityTokenTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -204,3 +205,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/X509ListedCertificateValidator.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/X509ListedCertificateValidator.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -64,3 +65,4 @@ namespace MonoTests.System.ServiceModel.Security.Tokens
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/X509SecurityTokenParametersTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security.Tokens/X509SecurityTokenParametersTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -124,3 +125,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security/ChannelProtectionRequirementsTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security/ChannelProtectionRequirementsTest.cs
@@ -33,7 +33,9 @@ using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Security;
 using System.ServiceModel.Security.Tokens;
+#if !MOBILE
 using System.Security.Cryptography.Xml;
+#endif
 using NUnit.Framework;
 
 namespace MonoTests.System.ServiceModel.Security

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security/SecurityAlgorithmSuiteTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security/SecurityAlgorithmSuiteTest.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // SecurityAlgorithmSuiteTest.cs
 //
 // Author:
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.IdentityModel.Tokens;
@@ -244,3 +245,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security/SecurityMessagePropertyTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security/SecurityMessagePropertyTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.Net;
@@ -295,3 +296,4 @@ namespace MonoTests.System.ServiceModel.Security
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security/SecurityTokenSpeficicationTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security/SecurityTokenSpeficicationTest.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // SecurityTokenSpeficicationTest.cs
 //
 // Author:
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.IdentityModel.Policy;
@@ -50,3 +51,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security/ServiceCredentialsSecurityTokenManagerTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security/ServiceCredentialsSecurityTokenManagerTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
@@ -578,3 +579,4 @@ namespace MonoTests.System.ServiceModel.Security
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security/ServiceSecurityContextTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security/ServiceSecurityContextTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.Net;
@@ -87,3 +88,5 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif
+

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security/SupportingTokenParametersTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security/SupportingTokenParametersTest.cs
@@ -33,7 +33,9 @@ using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Security;
 using System.ServiceModel.Security.Tokens;
+#if !MOBILE
 using System.Security.Cryptography.Xml;
+#endif
 using NUnit.Framework;
 
 namespace MonoTests.System.ServiceModel

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security/TransportSecurityBindingElementTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security/TransportSecurityBindingElementTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.Net;
@@ -49,3 +50,4 @@ namespace MonoTests.System.ServiceModel.Security
 
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security/WSSecurityTokenSerializerTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel.Security/WSSecurityTokenSerializerTest.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // WSSecurityTokenSerializerTest.cs
 //
 // Author:
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -970,3 +971,5 @@ throw new Exception ("3");
 		}
 	}
 }
+#endif
+

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/BasicHttpBindingTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/BasicHttpBindingTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.Net;
@@ -326,3 +327,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/CallbackBehaviorAttributeTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/CallbackBehaviorAttributeTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -365,3 +366,4 @@ namespace MonoTests.System.ServiceModel
 		#endregion
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/ChannelFactoryTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/ChannelFactoryTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.ServiceModel;
@@ -195,3 +196,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/ChannelFactory_1Test.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/ChannelFactory_1Test.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.Runtime.Serialization;
@@ -662,3 +662,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/ClientBaseTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/ClientBaseTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -586,3 +587,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/ClientCredentialsSecurityTokenManagerTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/ClientCredentialsSecurityTokenManagerTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
@@ -825,3 +826,4 @@ Assert.IsFalse (new MyManager (new MyClientCredentials ()).IsIssued (r), "premis
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/EndpointAddress10Test.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/EndpointAddress10Test.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.IO;
 using System.ServiceModel;
@@ -119,3 +120,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/EndpointAddressBuilderTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/EndpointAddressBuilderTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -63,3 +64,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/EndpointAddressTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/EndpointAddressTest.cs
@@ -26,6 +26,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -434,4 +435,6 @@ namespace MonoTests.System.ServiceModel
 */
 	}
 }
+#endif
+
 

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/EndpointIdentityTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/EndpointIdentityTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.IO;
 using System.IdentityModel.Claims;
@@ -71,3 +72,5 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif
+

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/IntegratedConnectionTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/IntegratedConnectionTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -330,3 +331,4 @@ namespace MonoTests.System.ServiceModel
 
 	#endregion
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/MessageSecurityVersionTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/MessageSecurityVersionTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.ServiceModel;
@@ -95,3 +95,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/MsmqTransportSecurityTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/MsmqTransportSecurityTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Net.Security;
 using System.ServiceModel;
@@ -50,4 +50,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
-
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/NetMsmqBindingTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/NetMsmqBindingTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.Net.Security;
@@ -108,3 +109,4 @@ namespace MonoTests.System.ServiceModel
 */
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/NetPeerTcpBindingTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/NetPeerTcpBindingTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.Net.Security;
@@ -117,3 +118,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/NetTcpBindingTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/NetTcpBindingTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.Net.Sockets;
@@ -253,3 +254,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/OperationContextTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/OperationContextTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.IO;
 using System.IdentityModel.Claims;
@@ -104,3 +105,5 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif
+

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/PeerNodeAddressTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/PeerNodeAddressTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.IO;
 using System.Runtime.Serialization;
@@ -52,3 +53,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/ServiceHostBaseTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/ServiceHostBaseTest.cs
@@ -25,7 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -745,3 +745,4 @@ namespace MonoTests.System.ServiceModel
 		#endregion
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/ServiceHostTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/ServiceHostTest.cs
@@ -26,6 +26,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.ServiceModel;
@@ -485,3 +486,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/TransactionProtocolTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/TransactionProtocolTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.Net;
@@ -53,3 +54,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/WSFederationHttpBindingTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/WSFederationHttpBindingTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.IdentityModel.Tokens;
@@ -321,3 +322,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif

--- a/mcs/class/System.ServiceModel/Test/System.ServiceModel/WSHttpBindingTest.cs
+++ b/mcs/class/System.ServiceModel/Test/System.ServiceModel/WSHttpBindingTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.Net;
@@ -478,3 +479,4 @@ namespace MonoTests.System.ServiceModel
 		}
 	}
 }
+#endif


### PR DESCRIPTION
Mobile does not support all clases found in System.ServiceModel, we skip
those tests of the not supported classes yet run all the others.

Backport of https://github.com/mono/mono/pull/6545 to 2017-12