### PR TITLE
[configure] fix altstack detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2269,11 +2269,7 @@ if test x$host_win32 = xno; then
 			child ()
 			{
 				struct sigaction sa;
-			#ifdef __APPLE__
 				stack_t sas;
-			#else
-				struct sigaltstack sas;
-			#endif
 				pthread_t id;
 				pthread_attr_t attr;
 


### PR DESCRIPTION
newer linux headers hide the `struct sigaltstack` definition (e.g. on
Ubuntu 17.10), probably because it is encouraged to use `stack_t`
anyway.

We use `stack_t` in our code anyway:
https://github.com/mono/mono/blob/146346977cea8aaed2de8ab6a84c2a58b30aea24/mono/mini/mini-exceptions.c#L2379-L2385

The change introducing the `ifdef` was already wrong imho:
https://github.com/mono/mono/commit/f6d15e14c234c505e4b5e4d5e46a2666370d2b4a

/cc @grendello 