### PR TITLE
[Tests] Do not assume order of returned interfaces

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection.Emit/SaveTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection.Emit/SaveTest.cs
@@ -317,9 +317,10 @@ public class SaveTest
 		// Type attributes
 		Assert.AreEqual (TypeAttributes.Public|TypeAttributes.SequentialLayout, type1.Attributes);
 		// Interfaces
-		Assert.AreEqual (2, type1.GetInterfaces ().Length); 
-		Assert.AreEqual (iface1, type1.GetInterfaces () [0]);
-		Assert.AreEqual (typeof (IComparable), type1.GetInterfaces () [1]);
+		var ifaces = type1.GetInterfaces ();
+		Assert.AreEqual (2, ifaces.Length);
+		Assert.IsTrue (iface1 == ifaces [0] || iface1 == ifaces [1]);
+		Assert.IsTrue (typeof (IComparable) == ifaces [0] || typeof (IComparable) == ifaces [1]);
 		CheckCattr (type1);
 		// FIXME: Class size/packing size
 


### PR DESCRIPTION
Cherry-picked from master.

Updated the System.Reflection.Emit/SaveTest to not depend on order of
interfaces returned from the System.Type::GetInterfaces method, as the
order is not guaranted. As described in the [documentation][0].

Also see github [issue][1] for more information and reasoning.

[0]: https://msdn.microsoft.com/en-us/library/system.type.getinterfaces(v=vs.110).aspx#Anchor_2
[1]: https://github.com/xamarin/xamarin-android/issues/1186