### PR TITLE
[Tests] Skip a subset of the System.IdentityModel for iOS and Mac.

### DIFF
--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Claims/ClaimSetTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Claims/ClaimSetTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.IdentityModel.Claims;
 using System.Net.Mail;
@@ -52,3 +53,4 @@ namespace MonoTests.System.IdentityModel.Claims
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Claims/ClaimTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Claims/ClaimTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.IdentityModel.Claims;
 using System.Net.Mail;
@@ -116,3 +117,4 @@ namespace MonoTests.System.IdentityModel.Claims
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Claims/ClaimTypesTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Claims/ClaimTypesTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.IdentityModel.Claims;
 using NUnit.Framework;
@@ -102,3 +103,4 @@ namespace MonoTests.System.IdentityModel.Claims
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Claims/X509CertificateClaimSetTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Claims/X509CertificateClaimSetTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.IdentityModel.Claims;
@@ -70,3 +71,4 @@ namespace MonoTests.System.IdentityModel.Claims
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Common/MySecurityTokenSerializer.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Common/MySecurityTokenSerializer.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Globalization;
 using System.IO;
@@ -97,3 +98,4 @@ namespace MonoTests.System.IdentityModel.Common
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Policy/AuthorizationContextTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Policy/AuthorizationContextTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.IdentityModel.Claims;
 using System.IdentityModel.Policy;
@@ -72,3 +73,4 @@ namespace MonoTests.System.IdentityModel.Claims
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Selectors/CustomUserNameSecurityTokenAuthenticatorTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Selectors/CustomUserNameSecurityTokenAuthenticatorTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE && !XAMMAC_4_5
 using System;
 using System.Collections.Generic;
 using System.IdentityModel.Claims;
@@ -80,3 +81,4 @@ namespace MonoTests.System.IdentityModel.Selectors
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Selectors/RsaSecurityTokenAuthenticatorTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Selectors/RsaSecurityTokenAuthenticatorTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE && !XAMMAC_4_5
 using System;
 using System.Collections.Generic;
 using System.IdentityModel.Claims;
@@ -66,3 +67,4 @@ namespace MonoTests.System.IdentityModel.Selectors
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Selectors/SamlSecurityTokenAuthenticatorTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Selectors/SamlSecurityTokenAuthenticatorTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE && !XAMMAC_4_5
 using System;
 using System.Collections.Generic;
 using System.IdentityModel.Claims;
@@ -118,3 +119,4 @@ Console.Error.WriteLine (doc.OuterXml);
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Selectors/SecurityTokenRequirementTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Selectors/SecurityTokenRequirementTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
@@ -95,3 +96,4 @@ namespace MonoTests.System.IdentityModel.Selectors
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Selectors/SecurityTokenResolverTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Selectors/SecurityTokenResolverTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.ObjectModel;
 using System.IdentityModel.Selectors;
@@ -79,3 +80,4 @@ namespace MonoTests.System.IdentityModel.Selectors
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Selectors/TestEvaluationContext.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Selectors/TestEvaluationContext.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE && !XAMMAC_4_5
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -82,3 +83,4 @@ namespace MonoTests.System.IdentityModel.Selectors
 
 	}
 }
+#endif 

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Selectors/X509SecurityTokenAuthenticatorTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Selectors/X509SecurityTokenAuthenticatorTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE && !XAMMAC_4_5
 using System;
 using System.Collections.Generic;
 using System.IdentityModel.Claims;
@@ -81,3 +82,4 @@ namespace MonoTests.System.IdentityModel.Selectors
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Selectors/X509SecurityTokenProviderTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Selectors/X509SecurityTokenProviderTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
@@ -52,3 +53,4 @@ namespace MonoTests.System.IdentityModel.Selectors
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/BootstrapContextTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/BootstrapContextTest.cs
@@ -1,7 +1,7 @@
 ﻿//
 // BootstrapContextTest.cs - NUnit Test Cases for System.IdentityModel.Tokens.BootstrapContext
 //
-
+#if !MOBILE
 using System;
 using System.IO;
 using System.IdentityModel.Tokens;
@@ -247,3 +247,4 @@ namespace MonoTests.System.IdentityModel.Tokens.net_4_5 {
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/EncryptedKeyIdentifierClauseTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/EncryptedKeyIdentifierClauseTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
@@ -51,3 +52,4 @@ namespace MonoTests.System.IdentityModel.Selectors
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/InMemorySymmetricSecurityKeyTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/InMemorySymmetricSecurityKeyTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.IO;
 using System.Text;
@@ -277,3 +278,4 @@ namespace MonoTests.System.IdentityModel.Tokens
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/LocalIdKeyIdentifierClauseTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/LocalIdKeyIdentifierClauseTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
@@ -53,3 +54,4 @@ namespace MonoTests.System.IdentityModel.Selectors
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SamlActionTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SamlActionTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Globalization;
 using System.IO;
@@ -130,3 +131,4 @@ namespace MonoTests.System.IdentityModel.Tokens
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SamlAssertionTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SamlAssertionTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Globalization;
 using System.IO;
@@ -199,3 +200,4 @@ namespace MonoTests.System.IdentityModel.Tokens
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SamlAttributeStatementTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SamlAttributeStatementTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Globalization;
 using System.IO;
@@ -86,3 +87,4 @@ namespace MonoTests.System.IdentityModel.Tokens
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SamlAudienceRestrictionConditionTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SamlAudienceRestrictionConditionTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Globalization;
 using System.IO;
@@ -76,3 +77,4 @@ namespace MonoTests.System.IdentityModel.Tokens
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SamlAuthenticationStatementTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SamlAuthenticationStatementTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Globalization;
 using System.IO;
@@ -115,3 +116,4 @@ namespace MonoTests.System.IdentityModel.Tokens
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SamlAuthorityBindingTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SamlAuthorityBindingTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Globalization;
 using System.IO;
@@ -156,3 +157,4 @@ namespace MonoTests.System.IdentityModel.Tokens
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SamlAuthorizationDecisionStatementTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SamlAuthorizationDecisionStatementTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Globalization;
 using System.IO;
@@ -183,3 +184,4 @@ namespace MonoTests.System.IdentityModel.Tokens
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SamlConditionsTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SamlConditionsTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Globalization;
 using System.IO;
@@ -100,3 +101,4 @@ namespace MonoTests.System.IdentityModel.Tokens
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SamlConstantsTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SamlConstantsTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Globalization;
 using System.IO;
@@ -54,3 +55,4 @@ namespace MonoTests.System.IdentityModel.Tokens
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SamlEvidenceTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SamlEvidenceTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -144,3 +145,4 @@ namespace MonoTests.System.IdentityModel.Tokens
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SamlSubjectTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SamlSubjectTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.Globalization;
 using System.IO;
@@ -139,3 +140,4 @@ namespace MonoTests.System.IdentityModel.Tokens
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SecurityAlgorithmsTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SecurityAlgorithmsTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System.IdentityModel.Tokens;
 using NUnit.Framework;
 
@@ -86,3 +87,4 @@ namespace MonoTests.System.IdentityModel.Tokens
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SecurityKeyIdentifierTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SecurityKeyIdentifierTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
@@ -60,3 +61,4 @@ namespace MonoTests.System.IdentityModel.Tokens
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SecurityTokenTypesTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/SecurityTokenTypesTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
@@ -57,3 +58,4 @@ namespace MonoTests.System.IdentityModel.Tokens
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/UserNameSecurityTokenTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/UserNameSecurityTokenTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
@@ -50,3 +51,4 @@ namespace MonoTests.System.IdentityModel.Selectors
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/X509AsymmetricSecurityKeyTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/X509AsymmetricSecurityKeyTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
@@ -144,3 +145,4 @@ namespace MonoTests.System.IdentityModel.Selectors
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/X509IssuerSerialKeyIdentifierClauseTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/X509IssuerSerialKeyIdentifierClauseTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.IdentityModel.Claims;
 using System.IdentityModel.Selectors;
@@ -62,3 +63,4 @@ namespace MonoTests.System.IdentityModel.Selectors
         }
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/X509SecurityTokenTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/X509SecurityTokenTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.IdentityModel.Selectors;
 using System.IdentityModel.Tokens;
@@ -87,3 +88,4 @@ namespace MonoTests.System.IdentityModel.Selectors
 		}
 	}
 }
+#endif

--- a/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/X509ThumbprintKeyIdentifierClauseTest.cs
+++ b/mcs/class/System.IdentityModel/Test/System.IdentityModel.Tokens/X509ThumbprintKeyIdentifierClauseTest.cs
@@ -25,6 +25,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+#if !MOBILE
 using System;
 using System.IdentityModel.Claims;
 using System.IdentityModel.Selectors;
@@ -55,3 +56,4 @@ namespace MonoTests.System.IdentityModel.Selectors
 		}
 	}
 }
+#endif


### PR DESCRIPTION
The iOS and Mac runtimes do not support all of the classes in System.IdentityModel, this change skips the tests of those classes on MOBILE and XAMMAC_4_5.