### PR TITLE
Use mono_error_assert{f,_msg}_ok instead of if (is_ok (error)) g_error(...)

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -998,8 +998,7 @@ mono_class_inflate_generic_method (MonoMethod *method, MonoGenericContext *conte
 	ERROR_DECL (error);
 	error_init (error);
 	MonoMethod *res = mono_class_inflate_generic_method_full_checked (method, NULL, context, error);
-	if (!is_ok (error))
-		g_error ("Could not inflate generic method due to %s", mono_error_get_message (error));
+	mono_error_assert_msg_ok (error, "Could not inflate generic method");
 	return res;
 }
 
@@ -8050,8 +8049,7 @@ mono_class_load_from_name (MonoImage *image, const char* name_space, const char 
 	klass = mono_class_from_name_checked (image, name_space, name, error);
 	if (!klass)
 		g_error ("Runtime critical type %s.%s not found", name_space, name);
-	if (!mono_error_ok (error))
-		g_error ("Could not load runtime critical type %s.%s due to %s", name_space, name, mono_error_get_message (error));
+	mono_error_assertf_ok (error, "Could not load runtime critical type %s.%s", name_space, name);
 	return klass;
 }
 
@@ -8075,8 +8073,7 @@ mono_class_try_load_from_name (MonoImage *image, const char* name_space, const c
 	MonoClass *klass;
 
 	klass = mono_class_from_name_checked (image, name_space, name, error);
-	if (!mono_error_ok (error))
-		g_error ("Could not load runtime critical type %s.%s due to %s", name_space, name, mono_error_get_message (error));
+	mono_error_assertf_ok (error, "Could not load runtime critical type %s.%s", name_space, name);
 	return klass;
 }
 
@@ -8668,16 +8665,14 @@ mono_class_get_cctor (MonoClass *klass)
 		ERROR_DECL (error);
 		error_init (error);
 		MonoMethod *result = mono_class_get_inflated_method (klass, mono_class_get_cctor (mono_class_get_generic_class (klass)->container_class), error);
-		if (!is_ok (error))
-			g_error ("Could not lookup inflated class cctor due to %s", mono_error_get_message (error)); /* FIXME do proper error handling */
+		mono_error_assert_msg_ok (error, "Could not lookup inflated class cctor"); /* FIXME do proper error handling */
 		return result;
 	}
 
 	if (mono_class_get_cached_class_info (klass, &cached_info)) {
 		ERROR_DECL (error);
 		MonoMethod *result = mono_get_method_checked (klass->image, cached_info.cctor_token, klass, NULL, error);
-		if (!mono_error_ok (error))
-			g_error ("Could not lookup class cctor from cached metadata due to %s", mono_error_get_message (error));
+		mono_error_assert_msg_ok (error, "Could not lookup class cctor from cached metadata");
 		return result;
 	}
 
@@ -8703,8 +8698,7 @@ mono_class_get_finalizer (MonoClass *klass)
 	if (mono_class_get_cached_class_info (klass, &cached_info)) {
 		ERROR_DECL (error);
 		MonoMethod *result = mono_get_method_checked (cached_info.finalize_image, cached_info.finalize_token, NULL, NULL, error);
-		if (!mono_error_ok (error))
-			g_error ("Could not lookup finalizer from cached metadata due to %s", mono_error_get_message (error));
+		mono_error_assert_msg_ok (error, "Could not lookup finalizer from cached metadata");
 		return result;
 	}else {
 		mono_class_setup_vtable (klass);

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -2213,8 +2213,7 @@ interp_create_method_pointer (MonoMethod *method, MonoError *error)
 	wrapper = mini_get_interp_in_wrapper (sig);
 
 	gpointer jit_wrapper = mono_jit_compile_method_jit_only (wrapper, error);
-	if (!mono_error_ok (error))
-		g_error ("couldn't compile wrapper \"%s\" for \"%s\" (error: %s)\n", mono_method_get_full_name (wrapper), mono_method_get_full_name (method), mono_error_get_message (error));
+	mono_error_assertf_ok (error, "couldn't compile wrapper \"%s\" for \"%s\"", mono_method_get_full_name (wrapper), mono_method_get_full_name (method));
 
 	gpointer entry_func;
 	if (sig->param_count > MAX_INTERP_ENTRY_ARGS) {

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -559,8 +559,7 @@ inflate_info (MonoRuntimeGenericContextInfoTemplate *oti, MonoGenericContext *co
 	case MONO_RGCTX_INFO_NULLABLE_CLASS_UNBOX: {
 		gpointer result = mono_class_inflate_generic_type_with_mempool (temporary ? NULL : klass->image,
 			(MonoType *)data, context, error);
-		if (!mono_error_ok (error)) /*FIXME proper error handling */
-			g_error ("Could not inflate generic type due to %s", mono_error_get_message (error));
+		mono_error_assert_msg_ok (error, "Could not inflate generic type"); /* FIXME proper error handling */
 		return result;
 	}
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -1516,8 +1516,7 @@ mono_resolve_patch_target (MonoMethod *method, MonoDomain *domain, guint8 *code,
 
 		handle = mono_ldtoken_checked (patch_info->data.token->image,
 							   patch_info->data.token->token, &handle_class, patch_info->data.token->has_context ? &patch_info->data.token->context : NULL, error);
- 		if (!mono_error_ok (error))
-			g_error ("Could not patch ldtoken due to %s", mono_error_get_message (error));
+		mono_error_assert_msg_ok (error, "Could not patch ldtoken");
 		mono_class_init (handle_class);
 
 		target = handle;

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -162,15 +162,6 @@ mono_error_ok (MonoError *error)
 	return error->error_code == MONO_ERROR_NONE;
 }
 
-void
-mono_error_assert_ok_pos (MonoError *error, const char* filename, int lineno)
-{
-	if (mono_error_ok (error))
-		return;
-
-	g_error ("%s:%d: %s\n", filename, lineno, mono_error_get_message (error));
-}
-
 unsigned short
 mono_error_get_error_code (MonoError *error)
 {


### PR DESCRIPTION
* Rewrite `mono_error_assert_ok` in terms of `g_assertf`
* Add `mono_error_assert_msg_ok(err, msg)` and `mono_error_assertf_ok (err, fmt, msg)`
* Use the two new macros in a few places to replace:
  ```c
     if (is_ok (error))
         g_error ("fmt, due to %s", args..., mono_error_get_message (error));
  ```