### PR TITLE
Fix CLA link in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,7 +32,7 @@ file in this directory.
 CLA
 =======
 
-Contributions are now taken under the [.NET Foundation CLA](https://cla2.dotnetfoundation.org/).
+Contributions are now taken under the [.NET Foundation CLA](https://cla.dotnetfoundation.org/).
 
 Code Review
 =======


### PR DESCRIPTION
It was changed when .NET Foundation switched to new CLA infrastructure.