### PR TITLE
Check errors when mono_method_to_ir calls handle_delegate_ctor.

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -12275,6 +12275,8 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 								ip += 5;
 								sp ++;
 								break;
+							} else {
+								CHECK_CFG_ERROR;
 							}
 							ip -= 6;
 						}
@@ -12339,6 +12341,8 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 								ip += 5;
 								sp ++;
 								break;
+							} else {
+								CHECK_CFG_ERROR;
 							}
 							ip -= 6;
 						}


### PR DESCRIPTION
Otherwise this ends up reusing MonoError which everyone agrees isn't intended, and goes further in compilation than it is probably supposed to, before probably eventually erroring reasonably.

Problem occurs around here:

$ gdb --args ./mono/mini/mono ./mono/tests/array_load_exception.exe 

(gdb) p *(MonoErrorInternal*)error
$8 = {error_code = 3, flags = 1, type_name = 0x0, assembly_name = 0x0, member_name = 0x0, exception_name_space = 0x0, exception_name = 0x0, exn = {klass = 0x105011500, 
    instance_handle = 83956992}, full_message = 0x102f00000 "VTable setup of type Dele failed", full_message_with_fields = 0x0, first_argument = 0x0, member_signature = 0x0, 
  padding = {0x0, 0x0}}

bt

mono_class_vtable_checked
handle_alloc
handle_delegate_ctor
mono_method_to_ir 
inline_method 
mono_method_to_ir
mini_method_compile
mono_jit_compile_method_inner
mono_jit_compile_method_with_opt
mono_jit_compile_method 
mono_jit_runtime_invoke
do_runtime_invoke
mono_runtime_invoke_checked
mono_runtime_try_invoke_array
mono_runtime_invoke_array_checked
ves_icall_InternalInvoke 
