### PR TITLE
Remove MONO_API from mono_assembly_load_module_checked.

### DIFF
--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -10,7 +10,8 @@
 
 #include <mono/metadata/assembly.h>
 
-MONO_API MonoImage*    mono_assembly_load_module_checked (MonoAssembly *assembly, uint32_t idx, MonoError *error);
+MonoImage*
+mono_assembly_load_module_checked (MonoAssembly *assembly, uint32_t idx, MonoError *error);
 
 MonoAssembly * mono_assembly_open_a_lot (const char *filename, MonoImageOpenStatus *status, gboolean refonly, gboolean load_from_context);
 

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -3869,7 +3869,7 @@ mono_assembly_load_module (MonoAssembly *assembly, guint32 idx)
 	return result;
 }
 
-MONO_API MonoImage*
+MonoImage*
 mono_assembly_load_module_checked (MonoAssembly *assembly, uint32_t idx, MonoError *error)
 {
 	return mono_image_load_file_for_image_checked (assembly->image, idx, error);


### PR DESCRIPTION
It not in a public header and appears unused by Xamarin.