### PR TITLE
Remove MONO_API from mono_metadata_load_generic_param_constraints_che…

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1224,7 +1224,7 @@ MONO_API MonoGenericContainer *
 mono_metadata_load_generic_params (MonoImage *image, guint32 token,
 				   MonoGenericContainer *parent_container);
 
-MONO_API gboolean
+gboolean
 mono_metadata_load_generic_param_constraints_checked (MonoImage *image, guint32 token,
 					      MonoGenericContainer *container, MonoError *error);
 


### PR DESCRIPTION
…cked.

It is not in public headers or used by Xamarin.
It used by monodis but that links statically and is in same repo.
Or is there any concern, for example, with compat with old Xamarin? Which I didn't look at.

Appears to come from here:

commit 6d60ff581c059f3269df4ea6dc93057406811f7b
Author: Rodrigo Kumpera <kumpera@gmail.com>
Date:   Fri Aug 29 14:11:51 2014 -0400

    [runtime] Introduce MonoError to mono_class_get_full.
    
    Introduce MonoError into callers of mono_class_get_full.
    
    Make mono_class_get not abort on failure until all callers are fixed.