### PR TITLE
Remove MONO_API from mono_metadata_parse_method_signature_full.

### DIFF
--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -757,7 +757,7 @@ mono_metadata_interfaces_from_typedef_full  (MonoImage             *image,
 											 MonoGenericContext    *context,
 											 MonoError *error);
 
-MONO_API MonoMethodSignature *
+MonoMethodSignature *
 mono_metadata_parse_method_signature_full   (MonoImage             *image,
 					     MonoGenericContainer  *generic_container,
 					     int                     def,


### PR DESCRIPTION
Not in a public header and not used by current Xamarin, so it shouldn't be exported, right?