### PR TITLE
Remove MONO_API from mono_metadata_parse_mh_full.

### DIFF
--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -765,7 +765,7 @@ mono_metadata_parse_method_signature_full   (MonoImage             *image,
 					     const char            **rptr,
 					     MonoError *error);
 
-MONO_API MonoMethodHeader *
+MonoMethodHeader *
 mono_metadata_parse_mh_full                 (MonoImage             *image,
 					     MonoGenericContainer  *container,
 					     const char            *ptr,


### PR DESCRIPTION
It is not in a public header nor apparently used by Xamarin so should
not be MONO_API. Reduction of MONO_API incrementally eases maintenance.