### PR TITLE
[System.Data] Throw PNSE in SqlClient on watchos (#6519)

### DIFF
--- a/mcs/class/System.Data/System.Data.SqlClient/SqlBulkCopy.platformnotsupported.cs
+++ b/mcs/class/System.Data/System.Data.SqlClient/SqlBulkCopy.platformnotsupported.cs
@@ -1,0 +1,161 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Data.SqlTypes;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace System.Data.SqlClient
+{
+	public sealed class SqlBulkCopy : IDisposable
+	{
+		const string EXCEPTION_MESSAGE = "System.Data.SqlClient.SqlBulkCopy is not supported on the current platform.";
+
+		public SqlBulkCopy(SqlConnection connection)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public SqlBulkCopy(SqlConnection connection, SqlBulkCopyOptions copyOptions, SqlTransaction externalTransaction)
+			: this(connection)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public SqlBulkCopy(string connectionString) : this(new SqlConnection(connectionString))
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public SqlBulkCopy(string connectionString, SqlBulkCopyOptions copyOptions)
+			: this(connectionString)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public int BatchSize {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public int BulkCopyTimeout {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public bool EnableStreaming {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public SqlBulkCopyColumnMappingCollection ColumnMappings
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public string DestinationTableName {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public int NotifyAfter {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public event SqlRowsCopiedEventHandler SqlRowsCopied;
+
+		internal SqlStatistics Statistics
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		void IDisposable.Dispose() {}
+
+		public void Close()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public void WriteToServer(DbDataReader reader)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public void WriteToServer(IDataReader reader)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public void WriteToServer(DataTable table)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public void WriteToServer(DataTable table, DataRowState rowState)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public void WriteToServer(DataRow[] rows)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public Task WriteToServerAsync(DataRow[] rows)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public Task WriteToServerAsync(DataRow[] rows, CancellationToken cancellationToken)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public Task WriteToServerAsync(DbDataReader reader)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public Task WriteToServerAsync(DbDataReader reader, CancellationToken cancellationToken)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public Task WriteToServerAsync(IDataReader reader)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public Task WriteToServerAsync(IDataReader reader, CancellationToken cancellationToken)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public Task WriteToServerAsync(DataTable table)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public Task WriteToServerAsync(DataTable table, CancellationToken cancellationToken)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public Task WriteToServerAsync(DataTable table, DataRowState rowState)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public Task WriteToServerAsync(DataTable table, DataRowState rowState, CancellationToken cancellationToken)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void OnConnectionClosed()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+#if DEBUG
+		internal static bool _setAlwaysTaskOnWrite = false;
+		internal static bool SetAlwaysTaskOnWrite {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+#endif
+	}
+
+	internal sealed class _ColumnMapping
+	{
+		internal int _sourceColumnOrdinal;
+		internal _SqlMetaData _metadata;
+		internal _ColumnMapping(int columnId, _SqlMetaData metadata) {}
+	}
+
+	internal sealed class Row
+	{
+		internal Row(int rowCount) {}
+		internal object[] DataFields => null;
+		internal object this[int index] => null;
+	}
+
+	internal sealed class Result
+	{
+		internal Result(_SqlMetaDataSet metadata) {}
+		internal int Count => 0;
+		internal _SqlMetaDataSet MetaData => null;
+		internal Row this[int index] => null;
+		internal void AddRow(Row row) {}
+	}
+
+	internal sealed class BulkCopySimpleResultSet
+	{
+		internal BulkCopySimpleResultSet() {}
+		internal Result this[int idx] => null;
+		internal void SetMetaData(_SqlMetaDataSet metadata) {}
+		internal int[] CreateIndexMap() => null;
+		internal object[] CreateRowBuffer() => null;
+	}
+}

--- a/mcs/class/System.Data/System.Data.SqlClient/SqlCommand.platformnotsupported.cs
+++ b/mcs/class/System.Data/System.Data.SqlClient/SqlCommand.platformnotsupported.cs
@@ -1,0 +1,284 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Data.Sql;
+using System.Data.SqlTypes;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+
+using Microsoft.SqlServer.Server;
+
+namespace System.Data.SqlClient
+{
+	public sealed partial class SqlCommand : DbCommand, ICloneable
+	{
+		const string EXCEPTION_MESSAGE = "System.Data.SqlClient.SqlCommand is not supported on the current platform.";
+
+		internal SqlDependency _sqlDep;
+		internal int _rowsAffected = -1;
+		internal bool InPrepare
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public SqlCommand() : base() => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		public SqlCommand(string cmdText) : this() {}
+		public SqlCommand(string cmdText, SqlConnection connection) : this() {}
+		public SqlCommand(string cmdText, SqlConnection connection, SqlTransaction transaction) : this() {}
+
+		new public SqlConnection Connection {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		override protected DbConnection DbConnection {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public SqlNotificationRequest Notification {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		internal SqlStatistics Statistics
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		new public SqlTransaction Transaction {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		override protected DbTransaction DbTransaction {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		override public string CommandText {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		override public int CommandTimeout {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public void ResetCommandTimeout()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		override public CommandType CommandType {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+#if DEBUG
+		internal static int DebugForceAsyncWriteDelay {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+#endif
+
+		public override bool DesignTimeVisible {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		new public SqlParameterCollection Parameters
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		override protected DbParameterCollection DbParameterCollection
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		override public UpdateRowSource UpdatedRowSource {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public event StatementCompletedEventHandler StatementCompleted;
+
+		internal void OnStatementCompleted(int recordCount)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		override public void Prepare()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void Unprepare()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		override public void Cancel()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		new public SqlParameter CreateParameter()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		override protected DbParameter CreateDbParameter()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		override protected void Dispose(bool disposing) {}
+
+		override public object ExecuteScalar()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		override public int ExecuteNonQuery()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public XmlReader ExecuteXmlReader()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		override protected DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		new public SqlDataReader ExecuteReader()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		new public SqlDataReader ExecuteReader(CommandBehavior behavior)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal SqlDataReader EndExecuteReader(IAsyncResult asyncResult)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal IAsyncResult BeginExecuteReader(CommandBehavior behavior, AsyncCallback callback, object stateObject)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		protected override Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		new public Task<SqlDataReader> ExecuteReaderAsync()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		new public Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		new public Task<SqlDataReader> ExecuteReaderAsync(CancellationToken cancellationToken)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		new public Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override Task<object> ExecuteScalarAsync(CancellationToken cancellationToken)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public Task<XmlReader> ExecuteXmlReaderAsync()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public Task<XmlReader> ExecuteXmlReaderAsync(CancellationToken cancellationToken)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal static readonly string[] PreKatmaiProcParamsNames = new string[] {};
+
+		internal static readonly string[] KatmaiProcParamsNames = new string[] {};
+
+		internal void DeriveParameters()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal _SqlMetaDataSet MetaData
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal SqlDataReader RunExecuteReader(CommandBehavior cmdBehavior, RunBehavior runBehavior, bool returnStream, [CallerMemberName] string method = "")
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal SqlDataReader RunExecuteReader(CommandBehavior cmdBehavior, RunBehavior runBehavior, bool returnStream, TaskCompletionSource<object> completion, int timeout, out Task task, bool asyncWrite = false, [CallerMemberName] string method = "")
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void OnDoneProc()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void OnReturnStatus(int status)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void OnReturnValue(SqlReturnValue rec, TdsParserStateObject stateObj)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal string BuildParamList(TdsParser parser, SqlParameterCollection parameters)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void CheckThrowSNIException()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void OnConnectionClosed()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal TdsParserStateObject StateObject
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal bool IsDirty {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		internal int InternalRecordsAffected {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		internal void ClearBatchCommand()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal bool BatchRPCMode {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		internal void AddBatchCommand(string commandText, SqlParameterCollection parameters, CommandType cmdType)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal int ExecuteBatchRPCCommand()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal int? GetRecordsAffected(int commandIndex)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal SqlException GetErrors(int commandIndex)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+#if DEBUG
+		internal void CompletePendingReadWithSuccess(bool resetForcePendingReadsToWait)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void CompletePendingReadWithFailure(int errorCode, bool resetForcePendingReadsToWait)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+#endif
+
+		internal void CancelIgnoreFailure()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		object ICloneable.Clone()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public SqlCommand Clone()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public bool NotificationAutoEnlist {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public IAsyncResult BeginExecuteNonQuery()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public IAsyncResult BeginExecuteXmlReader()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public IAsyncResult BeginExecuteReader()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public IAsyncResult BeginExecuteReader(AsyncCallback callback, object stateObject)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public IAsyncResult BeginExecuteReader(AsyncCallback callback, object stateObject, CommandBehavior behavior)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public IAsyncResult BeginExecuteReader(CommandBehavior behavior)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+	}
+}

--- a/mcs/class/System.Data/System.Data.SqlClient/SqlCommandBuilder.platformnotsupported.cs
+++ b/mcs/class/System.Data/System.Data.SqlClient/SqlCommandBuilder.platformnotsupported.cs
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Data.SqlClient;
+
+namespace System.Data.SqlClient
+{
+	public class SqlCommandBuilder : DbCommandBuilder 
+	{
+		const string EXCEPTION_MESSAGE = "System.Data.SqlClient.SqlCommandBuilder is not supported on the current platform.";
+
+		public SqlCommandBuilder ()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public SqlCommandBuilder (SqlDataAdapter adapter)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public static void DeriveParameters (SqlCommand command)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public SqlCommand GetDeleteCommand ()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public SqlCommand GetInsertCommand ()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public SqlCommand GetUpdateCommand ()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public SqlCommand GetUpdateCommand (bool useColumnsForParameterNames)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public SqlCommand GetDeleteCommand (bool useColumnsForParameterNames)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public SqlCommand GetInsertCommand (bool useColumnsForParameterNames)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override string QuoteIdentifier (string unquotedIdentifier)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override string UnquoteIdentifier (string quotedIdentifier)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		protected override void ApplyParameterInfo (DbParameter parameter, DataRow datarow, StatementType statementType, bool whereClause)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		protected override string GetParameterName (int parameterOrdinal)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		protected override string GetParameterName (string parameterName)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		protected override string GetParameterPlaceholder (int parameterOrdinal)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		protected override void SetRowUpdatingHandler (DbDataAdapter adapter)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		protected override DataTable GetSchemaTable (DbCommand srcCommand)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		protected override DbCommand InitializeCommand (DbCommand command)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public SqlDataAdapter DataAdapter {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public override string QuotePrefix {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public override string QuoteSuffix {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public override string CatalogSeparator {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public override string SchemaSeparator {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public override CatalogLocation CatalogLocation {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+	}
+}

--- a/mcs/class/System.Data/System.Data.SqlClient/SqlConnection.platformnotsupported.cs
+++ b/mcs/class/System.Data/System.Data.SqlClient/SqlConnection.platformnotsupported.cs
@@ -1,0 +1,269 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Data.Common;
+using System.Data.ProviderBase;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Diagnostics.CodeAnalysis;
+using System.Transactions;
+using Microsoft.SqlServer.Server;
+using System.Reflection;
+using System.IO;
+using System.Globalization;
+
+namespace System.Data.SqlClient
+{
+	public sealed partial class SqlConnection : DbConnection, ICloneable
+	{
+		const string EXCEPTION_MESSAGE = "System.Data.SqlClient.SqlConnection is not supported on the current platform.";
+
+		internal SqlStatistics _statistics;
+		internal Task _currentReconnectionTask;
+		internal SessionData _recoverySessionData;
+		internal bool _suppressStateChangeForReconnection;
+		internal bool _applyTransientFaultHandling = false;
+
+		public SqlConnection() : base() => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		public SqlConnection(string connectionString) : this() {}
+
+		public bool StatisticsEnabled {
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+			set { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+		}
+
+		internal bool AsyncCommandInProgress {
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+			set { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+		}
+
+		internal SqlConnectionString.TransactionBindingEnum TransactionBinding
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal SqlConnectionString.TypeSystem TypeSystem
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal Version TypeSystemAssemblyVersion
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal int ConnectRetryInterval
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override string ConnectionString {
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+			set { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+		}
+
+		public override int ConnectionTimeout
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override string Database
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override string DataSource
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public int PacketSize
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public Guid ClientConnectionId
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override string ServerVersion
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override ConnectionState State
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal SqlStatistics Statistics
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public string WorkstationId
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		protected override DbProviderFactory DbProviderFactory
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public event SqlInfoMessageEventHandler InfoMessage;
+
+		public bool FireInfoMessageEventOnUserErrors {
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+			set { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+		}
+
+		internal int ReconnectCount
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal bool ForceNewConnection {
+			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+			set { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
+		}
+
+		protected override void OnStateChange(StateChangeEventArgs stateChange)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		new public SqlTransaction BeginTransaction()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		new public SqlTransaction BeginTransaction(IsolationLevel iso)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public SqlTransaction BeginTransaction(string transactionName)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		override protected DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public SqlTransaction BeginTransaction(IsolationLevel iso, string transactionName)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override void ChangeDatabase(string database)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public static void ClearAllPools()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public static void ClearPool(SqlConnection connection)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override void Close()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		new public SqlCommand CreateCommand()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override void Open()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void RegisterWaitingForReconnect(Task waitingTask)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal Task ValidateAndReconnect(Action beforeDisconnect, int timeout)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override Task OpenAsync(CancellationToken cancellationToken)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override DataTable GetSchema()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override DataTable GetSchema(string collectionName)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override DataTable GetSchema(string collectionName, string[] restrictionValues)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal bool HasLocalTransaction
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal bool HasLocalTransactionFromAPI
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal bool IsKatmaiOrNewer
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal TdsParser Parser
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void ValidateConnectionForExecute(string method, SqlCommand command)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal static string FixupDatabaseTransactionName(string name)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void OnError(SqlException exception, bool breakConnection, Action<Action> wrapCloseInAction)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal SqlInternalConnectionTds GetOpenTdsConnection()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal SqlInternalConnectionTds GetOpenTdsConnection(string method)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void OnInfoMessage(SqlInfoMessageEventArgs imevent)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void OnInfoMessage(SqlInfoMessageEventArgs imevent, out bool notified)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void RegisterForConnectionCloseNotification<T>(ref Task<T> outerTask, object value, int tag)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public void ResetStatistics()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public IDictionary RetrieveStatistics()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		object ICloneable.Clone()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void CheckGetExtendedUDTInfo(SqlMetaDataPriv metaData, bool fThrow)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal object GetUdtValue(object value, SqlMetaDataPriv metaData, bool returnDBNull)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal byte[] GetBytes(object o)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal byte[] GetBytes(object o, out Format format, out int maxSize)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal int CloseCount
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal DbConnectionFactory ConnectionFactory
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal DbConnectionOptions ConnectionOptions
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+
+		internal DbConnectionInternal InnerConnection
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal System.Data.ProviderBase.DbConnectionPoolGroup PoolGroup {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		internal DbConnectionOptions UserConnectionOptions
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void Abort(Exception e)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void AddWeakReference(object value, int tag)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		override protected DbCommand CreateDbCommand()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		override protected void Dispose(bool disposing) {}
+
+		public override void EnlistTransaction(Transaction transaction)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void NotifyWeakReference(int message)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void PermissionDemand()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void RemoveWeakReference(object value)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void SetInnerConnectionEvent(DbConnectionInternal to)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal bool SetInnerConnectionFrom(DbConnectionInternal to, DbConnectionInternal from)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void SetInnerConnectionTo(DbConnectionInternal to)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+	}
+}

--- a/mcs/class/System.Data/System.Data.SqlClient/SqlDataAdapter.platformnotsupported.cs
+++ b/mcs/class/System.Data/System.Data.SqlClient/SqlDataAdapter.platformnotsupported.cs
@@ -1,0 +1,106 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.ComponentModel;
+using System.Data.Common;
+using System.Diagnostics;
+
+namespace System.Data.SqlClient
+{
+	public sealed class SqlDataAdapter : DbDataAdapter, IDbDataAdapter, ICloneable
+	{
+		const string EXCEPTION_MESSAGE = "System.Data.SqlClient.SqlDataAdapter is not supported on the current platform.";
+
+		public SqlDataAdapter() : base() {}
+		public SqlDataAdapter(SqlCommand selectCommand) : this() {}
+		public SqlDataAdapter(string selectCommandText, string selectConnectionString) : this() {}
+		public SqlDataAdapter(string selectCommandText, SqlConnection selectConnection) : this() {}
+
+		new public SqlCommand DeleteCommand {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		IDbCommand IDbDataAdapter.DeleteCommand {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		new public SqlCommand InsertCommand {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		IDbCommand IDbDataAdapter.InsertCommand {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		new public SqlCommand SelectCommand {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		IDbCommand IDbDataAdapter.SelectCommand {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		new public SqlCommand UpdateCommand {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		IDbCommand IDbDataAdapter.UpdateCommand {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public override int UpdateBatchSize {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		protected override int AddToBatch(IDbCommand command)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		protected override void ClearBatch()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		protected override int ExecuteBatch()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		protected override IDataParameter GetBatchedParameter(int commandIdentifier, int parameterIndex)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		protected override bool GetBatchedRecordsAffected(int commandIdentifier, out int recordsAffected, out Exception error)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		protected override void InitializeBatching()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		protected override void TerminateBatching()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		object ICloneable.Clone()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		protected override RowUpdatedEventArgs CreateRowUpdatedEvent(DataRow dataRow, IDbCommand command, StatementType statementType, DataTableMapping tableMapping)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		protected override RowUpdatingEventArgs CreateRowUpdatingEvent(DataRow dataRow, IDbCommand command, StatementType statementType, DataTableMapping tableMapping)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public event SqlRowUpdatedEventHandler RowUpdated;
+		public event SqlRowUpdatingEventHandler RowUpdating;
+
+		override protected void OnRowUpdated(RowUpdatedEventArgs value)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		override protected void OnRowUpdating(RowUpdatingEventArgs value)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+	}
+}

--- a/mcs/class/System.Data/System.Data.SqlClient/SqlException.platformnotsupported.cs
+++ b/mcs/class/System.Data/System.Data.SqlClient/SqlException.platformnotsupported.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Data.Common;
+using System.Data.SqlClient;
+using System.Runtime.Serialization;
+
+namespace System.Data.SqlClient
+{
+	public class SqlException : DbException 
+	{
+		const string EXCEPTION_MESSAGE = "System.Data.SqlClient.SqlException is not supported on the current platform.";
+
+		internal bool _doNotReconnect;
+
+		static internal SqlException CreateException(SqlErrorCollection errorCollection, string serverVersion)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		static internal SqlException CreateException(SqlErrorCollection errorCollection, string serverVersion, SqlInternalConnectionTds internalConnection, Exception innerException = null)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		static internal SqlException CreateException(SqlErrorCollection errorCollection, string serverVersion, Guid conId, Exception innerException = null)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		SqlException () {}
+
+		public override void GetObjectData (SerializationInfo si, StreamingContext context)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public byte Class
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public Guid ClientConnectionId
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public SqlErrorCollection Errors
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public int LineNumber
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override string Message
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public int Number
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public string Procedure
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public string Server
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override string Source
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public byte State
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		
+		internal SqlException InternalClone()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+	}
+}

--- a/mcs/class/System.Data/System.Data.SqlClient/SqlParameter.platformnotsupported.cs
+++ b/mcs/class/System.Data/System.Data.SqlClient/SqlParameter.platformnotsupported.cs
@@ -1,0 +1,328 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Data.SqlTypes;
+using System.Diagnostics;
+using System.IO;
+using System.Globalization;
+using System.Reflection;
+using System.Xml;
+using MSS = Microsoft.SqlServer.Server;
+using Microsoft.SqlServer.Server;
+using System.ComponentModel.Design.Serialization;
+
+namespace System.Data.SqlClient
+{
+	public sealed partial class SqlParameter : DbParameter, IDbDataParameter, ICloneable
+	{
+		const string EXCEPTION_MESSAGE = "System.Data.SqlClient.SqlParameter is not supported on the current platform.";
+
+		public SqlParameter() : base() {}
+		public SqlParameter(string parameterName, SqlDbType dbType) : this() {}
+		public SqlParameter(string parameterName, object value) : this() {}
+		public SqlParameter(string parameterName, SqlDbType dbType, int size) : this() {}
+		public SqlParameter(string parameterName, SqlDbType dbType, int size, string sourceColumn) : this() {}
+
+		public SqlParameter(
+			string parameterName,
+			SqlDbType dbType,
+			int size,
+			ParameterDirection direction,
+			bool isNullable,
+			byte precision,
+			byte scale,
+			string sourceColumn,
+			DataRowVersion sourceVersion,
+			object value
+		) : this(parameterName, dbType, size, sourceColumn)
+		{
+		}
+
+		public SqlParameter(
+			string parameterName,
+			SqlDbType dbType, 
+			int size,
+			ParameterDirection direction,
+			byte precision,
+			byte scale,
+			string sourceColumn,
+			DataRowVersion sourceVersion,
+			bool sourceColumnNullMapping,
+			object value,
+			string xmlSchemaCollectionDatabase,
+			string xmlSchemaCollectionOwningSchema,
+			string xmlSchemaCollectionName
+		) : this()
+		{
+		}
+
+		internal SqlCollation Collation
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public string XmlSchemaCollectionDatabase
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public string XmlSchemaCollectionOwningSchema
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public string XmlSchemaCollectionName
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public override DbType DbType
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public override void ResetDbType()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal MetaType InternalMetaType
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public int LocaleId
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		internal MSS.SmiParameterMetaData MetaDataForSmi(out ParameterPeekAheadValue peekAhead)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal bool ParameterIsSqlType
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public override string ParameterName
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		internal string ParameterNameFixed
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public new byte Precision
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		internal byte PrecisionInternal
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public new byte Scale
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		internal byte ScaleInternal
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public SqlDbType SqlDbType
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public void ResetSqlDbType()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public object SqlValue
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public string UdtTypeName
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public String TypeName
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public override object Value
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		internal INullable ValueAsINullable
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal bool IsNull
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal int GetActualSize()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		object ICloneable.Clone()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal static object CoerceValue(object value, MetaType destinationType, out bool coercedToDataFeed, out bool typeChanged, bool allowStreaming = true)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void FixStreamDataForNonPLP()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override DataRowVersion SourceVersion
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		internal byte GetActualPrecision()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal byte GetActualScale()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal int GetParameterSize()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal object GetCoercedValue()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal bool CoercedValueIsSqlType
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal bool CoercedValueIsDataFeed
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		[Conditional("DEBUG")]
+		internal void AssertCachedPropertiesAreValid()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		[Conditional("DEBUG")]
+		internal void AssertPropertiesAreValid(object value, bool? isSqlType = null, bool? isDataFeed = null, bool? isNull = null)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void Prepare(SqlCommand cmd)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void SetSqlBuffer(SqlBuffer buff)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void SetUdtLoadError(Exception e)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void Validate(int index, bool isCommandProc)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal MetaType ValidateTypeLengths()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal static string[] ParseTypeName(string typeName, bool isUdtTypeName)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal sealed class SqlParameterConverter : ExpandableObjectConverter
+		{
+			public SqlParameterConverter()
+				=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+			public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+				=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+			public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+				=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public override ParameterDirection Direction
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public override bool IsNullable
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public int Offset
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public override int Size
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public override string SourceColumn
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public override bool SourceColumnNullMapping
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		internal void CopyTo(SqlParameter destination)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public SqlCompareOptions CompareInfo
+		{
+			get	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set	=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+	}
+
+	internal abstract class DataFeed {}
+
+	internal class StreamDataFeed : DataFeed
+	{
+		internal Stream _source;
+		internal StreamDataFeed(Stream source) {}
+	}
+
+	internal class TextDataFeed : DataFeed
+	{
+		internal TextReader _source;
+		internal TextDataFeed(TextReader source) {}
+	}
+
+	internal class XmlDataFeed : DataFeed
+	{
+		internal XmlReader _source;
+		internal XmlDataFeed(XmlReader source) {}
+	}
+}

--- a/mcs/class/System.Data/System.Data.SqlClient/SqlParameterCollection.platformnotsupported.cs
+++ b/mcs/class/System.Data/System.Data.SqlClient/SqlParameterCollection.platformnotsupported.cs
@@ -1,0 +1,133 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Data;
+using System.Data.Common;
+using System.Data.SqlClient;
+
+namespace System.Data.SqlClient
+{
+	public partial class SqlParameterCollection : DbParameterCollection , IDataParameterCollection, IList, ICollection, IEnumerable
+	{
+		const string EXCEPTION_MESSAGE = "System.Data.SqlClient.SqlParameterCollection is not supported on the current platform.";
+
+		internal SqlParameterCollection () {}
+
+		protected override DbParameter GetParameter (int index)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		protected override DbParameter GetParameter (string parameterName)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		protected override void SetParameter (int index, DbParameter value)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		protected override void SetParameter (string parameterName, DbParameter value)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override int Add (object value)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public SqlParameter Add (SqlParameter value)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public SqlParameter AddWithValue (string parameterName, object value)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public SqlParameter Add (string parameterName, SqlDbType sqlDbType)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public SqlParameter Add (string parameterName, SqlDbType sqlDbType, int size)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public SqlParameter Add (string parameterName, SqlDbType sqlDbType, int size, string sourceColumn)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override void Clear ()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override bool Contains (object value)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override bool Contains (string value)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public bool Contains (SqlParameter value)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override void CopyTo (Array array, int index)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override IEnumerator GetEnumerator ()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override int IndexOf (object value)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override int IndexOf (string parameterName)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public int IndexOf (SqlParameter value)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override void Insert (int index, object value)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public void Insert (int index, SqlParameter value)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override void Remove (object value)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public void Remove (SqlParameter value)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override void RemoveAt (int index)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override void RemoveAt (string parameterName)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override void AddRange (Array values)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public void AddRange (SqlParameter [] values)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public void CopyTo (SqlParameter [] array, int index)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override int Count
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override bool IsFixedSize
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override bool IsReadOnly
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override bool IsSynchronized
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public override object SyncRoot
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public SqlParameter this [int index] {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+
+		public SqlParameter this [string parameterName] {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+		
+		internal bool IsDirty {
+			get => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+			set => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+		}
+	}
+}

--- a/mcs/class/System.Data/System.Data.SqlClient/SqlTransaction.platformnotsupported.cs
+++ b/mcs/class/System.Data/System.Data.SqlClient/SqlTransaction.platformnotsupported.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Data.Common;
+using System.Diagnostics;
+
+namespace System.Data.SqlClient
+{
+	public sealed class SqlTransaction : DbTransaction
+	{
+		const string EXCEPTION_MESSAGE = "System.Data.SqlClient.SqlTransaction is not supported on the current platform.";
+
+		internal readonly IsolationLevel _isolationLevel = IsolationLevel.ReadCommitted;
+
+		internal SqlTransaction(SqlInternalConnection internalConnection, SqlConnection con,
+								IsolationLevel iso, SqlInternalTransaction internalTransaction)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		new public SqlConnection Connection
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		override protected DbConnection DbConnection
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal SqlInternalTransaction InternalTransaction
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		override public IsolationLevel IsolationLevel
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal bool IsZombied
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal SqlStatistics Statistics
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		override public void Commit()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		protected override void Dispose(bool disposing)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		override public void Rollback()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public void Rollback(string transactionName)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		public void Save(string savePointName)
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
+		internal void Zombie()
+			=> throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+	}
+}
+

--- a/mcs/class/System.Data/Test/System.Data.SqlClient/SqlDataAdapterTest.cs
+++ b/mcs/class/System.Data/Test/System.Data.SqlClient/SqlDataAdapterTest.cs
@@ -41,6 +41,9 @@ namespace MonoTests.System.Data.SqlClient
 	public class SqlDataAdapterTest
 	{
 		[Test] // SqlDataAdapter ()
+#if FEATURE_NO_BSD_SOCKETS
+		[ExpectedException (typeof (PlatformNotSupportedException))]
+#endif
 		public void Constructor1 ()
 		{
 			SqlDataAdapter da = new SqlDataAdapter ();
@@ -90,6 +93,9 @@ namespace MonoTests.System.Data.SqlClient
 		}
 
 		[Test] // SqlDataAdapter (SqlCommand)
+#if FEATURE_NO_BSD_SOCKETS
+		[ExpectedException (typeof (PlatformNotSupportedException))]
+#endif
 		public void Constructor2_SelectCommand_Null ()
 		{
 			SqlDataAdapter da = new SqlDataAdapter ((SqlCommand) null);
@@ -374,6 +380,9 @@ namespace MonoTests.System.Data.SqlClient
 		}
 
 		[Test]
+#if FEATURE_NO_BSD_SOCKETS
+		[ExpectedException (typeof (PlatformNotSupportedException))]
+#endif
 		public void UpdateBatchSize ()
 		{
 			SqlDataAdapter da = new SqlDataAdapter ();
@@ -386,6 +395,9 @@ namespace MonoTests.System.Data.SqlClient
 		}
 		
 		[Test]
+#if FEATURE_NO_BSD_SOCKETS
+		[ExpectedException (typeof (PlatformNotSupportedException))]
+#endif
 		public void UpdateBatchSize_Negative ()
 		{
 			SqlDataAdapter da = new SqlDataAdapter ();

--- a/mcs/class/System.Data/monotouch_watch_System.Data.dll.exclude.sources
+++ b/mcs/class/System.Data/monotouch_watch_System.Data.dll.exclude.sources
@@ -1,0 +1,14 @@
+corefx/SqlCommand.cs
+corefx/SqlException.cs
+../../../external/corefx/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlBulkCopy.cs
+../../../external/corefx/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+../../../external/corefx/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommandBuilder.cs
+../../../external/corefx/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
+../../../external/corefx/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionHelper.cs
+../../../external/corefx/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataAdapter.cs
+../../../external/corefx/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlException.cs
+../../../external/corefx/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
+../../../external/corefx/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameterCollection.cs
+../../../external/corefx/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameterCollectionHelper.cs
+../../../external/corefx/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameterHelper.cs
+../../../external/corefx/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlTransaction.cs

--- a/mcs/class/System.Data/monotouch_watch_System.Data.dll.sources
+++ b/mcs/class/System.Data/monotouch_watch_System.Data.dll.sources
@@ -1,0 +1,12 @@
+#include corefx.common.sources
+#include corefx.unix.sources
+
+System.Data.SqlClient/SqlBulkCopy.platformnotsupported.cs
+System.Data.SqlClient/SqlCommand.platformnotsupported.cs
+System.Data.SqlClient/SqlCommandBuilder.platformnotsupported.cs
+System.Data.SqlClient/SqlConnection.platformnotsupported.cs
+System.Data.SqlClient/SqlDataAdapter.platformnotsupported.cs
+System.Data.SqlClient/SqlException.platformnotsupported.cs
+System.Data.SqlClient/SqlParameter.platformnotsupported.cs
+System.Data.SqlClient/SqlParameterCollection.platformnotsupported.cs
+System.Data.SqlClient/SqlTransaction.platformnotsupported.cs


### PR DESCRIPTION
Fixes #6519
Similar to how it was implemented before we moved System.Data to corefx:
https://github.com/mono/mono/blob/mono-4.8.0-branch/mcs/class/System.Data/monotouch_watch_System.Data.dll.exclude.sources
and
https://github.com/mono/mono/blob/mono-4.8.0-branch/mcs/class/System.Data/System.Data.SqlClient/SqlConnection.platformnotsupported.cs