### PR TITLE
Give failing test 2.5 seconds to run instead of just 2.

### DIFF
--- a/mcs/class/Microsoft.Build/Test/Microsoft.Build.Execution/BuildSubmissionTest.cs
+++ b/mcs/class/Microsoft.Build/Test/Microsoft.Build.Execution/BuildSubmissionTest.cs
@@ -102,8 +102,8 @@ namespace MonoTests.Microsoft.Build.Execution
 			AssertHelper.GreaterOrEqual (endBuildDone, TimeSpan.FromSeconds (1), "#2");
 			AssertHelper.GreaterOrEqual (waitDone, TimeSpan.FromSeconds (1), "#3");
 			AssertHelper.GreaterOrEqual (endBuildDone, waitDone, "#4");
-			AssertHelper.LessOrEqual (endBuildDone, TimeSpan.FromSeconds (2), "#5");
-			AssertHelper.LessOrEqual (waitDone, TimeSpan.FromSeconds (2), "#6");
+			AssertHelper.LessOrEqual (endBuildDone, TimeSpan.FromSeconds (2.5), "#5");
+			AssertHelper.LessOrEqual (waitDone, TimeSpan.FromSeconds (2.5), "#6");
 		}
 		
 		[Test]


### PR DESCRIPTION
This test is supposed to take between 1 and 2 seconds, but takes slightly longer in practise and fails.
Give it 2.5 seconds.

https://jenkins.mono-project.com/job/test-mono-pull-request-amd64/10727/parsed_console/log.html

Tests run: 120, Passed: 119, Errors: 0, Failures: 1, Inconclusive: 0
  Not run: 0, Invalid: 0, Ignored: 0, Skipped: 0
Elapsed time: 00:00:32.8320000

Errors and Failures:

1) EndBuildWaitsForSubmissionCompletion (MonoTests.Microsoft.Build.Execution.BuildSubmissionTest.EndBuildWaitsForSubmissionCompletion)
     #5
  Expected: less than or equal to 00:00:02
  But was:  00:00:02.0757916

  at MonoTests.Microsoft.Build.Execution.BuildSubmissionTest.EndBuildWaitsForSubmissionCompletion () [0x00126] in /mnt/jenkins/workspace/test-mono-pull-request-amd64/mcs/class/Microsoft.Build/Test/Microsoft.Build.Execution/BuildSubmissionTest.cs:105
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00032] in /mnt/jenkins/workspace/test-mono-pull-request-amd64/mcs/class/corlib/System.Reflection/MonoMethod.cs:305