### PR TITLE
[WindowsBase] Use case-insensitive extension match in System.IO.Packaging.ZipPackage

### DIFF
--- a/mcs/class/WindowsBase/System.IO.Packaging/ZipPackage.cs
+++ b/mcs/class/WindowsBase/System.IO.Packaging/ZipPackage.cs
@@ -191,7 +191,7 @@ namespace System.IO.Packaging {
 							string ext = Path.GetExtension (file);
 							if (ext.StartsWith("."))
 								ext = ext.Substring (1);
-							xPath = string.Format("/content:Types/content:Default[@Extension='{0}']", ext);
+							xPath = string.Format("/content:Types/content:Default[translate(@Extension,'abcdefghijklmnopqrstuvwxyz','ABCDEFGHIJKLMNOPQRSTUVWXYZ')='{0}']", ext.ToUpperInvariant());
 							node = doc.SelectSingleNode (xPath, manager);
 						}
 


### PR DESCRIPTION
Using DocumentFormat.OpenXml I've found that these files cause crashes or NullReferenceExceptions depending on the usage scenario. And the actual bug fix was in changing the matching policy from case-sensitive to (limited) case-insensitive. I did not consult any documentation on Open Package convention, so I leave the decision, whether this commit is 'good' or not to the reviewer's responsibility.

The file with required case insensitive match (as an example):
[06fzbx7qh8.docx](https://github.com/mono/mono/files/1648791/06fzbx7qh8.docx)