### PR TITLE
[offsetdumper] remove InterpMethodArguments

### DIFF
--- a/mono/metadata/object-offsets.h
+++ b/mono/metadata/object-offsets.h
@@ -279,12 +279,6 @@ DECL_OFFSET(SeqPointInfo, ss_tramp_addr)
 DECL_OFFSET(SeqPointInfo, bp_addrs)
 #endif
 
-DECL_OFFSET(InterpMethodArguments, ilen)
-DECL_OFFSET(InterpMethodArguments, iargs)
-DECL_OFFSET(InterpMethodArguments, flen)
-DECL_OFFSET(InterpMethodArguments, fargs)
-DECL_OFFSET(InterpMethodArguments, retval)
-DECL_OFFSET(InterpMethodArguments, is_float_ret)
 #if defined(TARGET_AMD64) || defined(TARGET_ARM) || defined(TARGET_ARM64)
 DECL_OFFSET(CallContext, gregs)
 DECL_OFFSET(CallContext, fregs)

--- a/tools/offsets-tool/MonoAotOffsetsDumper.cs
+++ b/tools/offsets-tool/MonoAotOffsetsDumper.cs
@@ -818,7 +818,6 @@ namespace CppSharp
                 "SeqPointInfo",
                 "DynCallArgs", 
                 "MonoLMFTramp",
-                "InterpMethodArguments",
                 "CallContext"
             };
 


### PR DESCRIPTION
Every user of this tool is using architectures that are implementing
`CallContext`.