### PR TITLE
[runtime] Avoid padding classes with an explicit size.

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -918,7 +918,7 @@ void
 mono_classes_cleanup (void);
 
 void
-mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_size, gboolean sre);
+mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_size, int real_size, gboolean sre);
 
 void
 mono_class_setup_interface_offsets (MonoClass *klass);

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -1646,7 +1646,7 @@ mono_class_setup_fields (MonoClass *klass)
 
 	if (!mono_class_has_failure (klass)) {
 		mono_loader_lock ();
-		mono_class_layout_fields (klass, instance_size, packing_size, FALSE);
+		mono_class_layout_fields (klass, instance_size, packing_size, real_size, FALSE);
 		mono_loader_unlock ();
 	}
 
@@ -1764,7 +1764,7 @@ type_has_references (MonoClass *klass, MonoType *ftype)
  * LOCKING: Acquires the loader lock
  */
 void
-mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_size, gboolean sre)
+mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_size, int explicit_size, gboolean sre)
 {
 	int i;
 	const int top = mono_class_get_field_count (klass);
@@ -2079,9 +2079,11 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 		}
 
 		instance_size = MAX (real_size, instance_size);
-		if (instance_size & (min_align - 1)) {
-			instance_size += min_align - 1;
-			instance_size &= ~(min_align - 1);
+		if (!((layout == TYPE_ATTRIBUTE_EXPLICIT_LAYOUT) && explicit_size)) {
+			if (instance_size & (min_align - 1)) {
+				instance_size += min_align - 1;
+				instance_size &= ~(min_align - 1);
+			}
 		}
 		break;
 	}

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -3504,9 +3504,8 @@ typebuilder_setup_fields (MonoClass *klass, MonoError *error)
 		}
 	}
 
-	if (!mono_class_has_failure (klass)) {
-		mono_class_layout_fields (klass, instance_size, packing_size, TRUE);
-	}
+	if (!mono_class_has_failure (klass))
+		mono_class_layout_fields (klass, instance_size, packing_size, tb->class_size, TRUE);
 }
 
 static void

--- a/mono/tests/bug-6148.cs
+++ b/mono/tests/bug-6148.cs
@@ -33,8 +33,15 @@ struct ExplicitPack
 		public int A4;
 }
 
+[StructLayout(LayoutKind.Explicit, Size = 12)]
+struct ExplicitSize
+{
+	[FieldOffset(0)]
+    private long Data1;
 
-
+	[FieldOffset(8)]
+    private int Data3;
+}
 
 public class Program {
 	public static unsafe int Main(string[] args)
@@ -44,6 +51,9 @@ public class Program {
 
 		if (sizeof(ExplicitPack) != 18)
 			return 2;
+
+		if (sizeof (ExplicitSize) != 12)
+			return 3;
 		return 0;
 	}
 }


### PR DESCRIPTION
Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=60298

Backport of https://github.com/mono/mono/pull/6223