### PR TITLE
Avoid crash under GNOME if no gtk+2 available

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/MimeIcon.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/MimeIcon.cs
@@ -119,10 +119,17 @@ namespace System.Windows.Forms
 				SmallIcons.ImageSize = new Size (24, 24);
 				LargeIcons.ImageSize = new Size (48, 48);
 				
-				platformMimeHandler = new GnomeHandler ();
-				if (platformMimeHandler.Start () == MimeExtensionHandlerStatus.OK) {
-					platform = EPlatformHandler.GNOME;
-				} else {
+				try {
+					platformMimeHandler = new GnomeHandler ();
+					if (platformMimeHandler.Start () == MimeExtensionHandlerStatus.OK) {
+						platform = EPlatformHandler.GNOME;
+					} else {
+						MimeIconEngine.LargeIcons.Images.Clear ();
+						MimeIconEngine.SmallIcons.Images.Clear ();
+						platformMimeHandler = new PlatformDefaultHandler ();
+						platformMimeHandler.Start ();
+					}
+				} catch {
 					MimeIconEngine.LargeIcons.Images.Clear ();
 					MimeIconEngine.SmallIcons.Images.Clear ();
 					platformMimeHandler = new PlatformDefaultHandler ();


### PR DESCRIPTION
gtk+2 is non-essential part of the GNOME 3 desktop nowadays.