### PR TITLE
[System.IO.Compression.FileSystem] Improve ZipCreateFromEntryChangeTimestamp test

### DIFF
--- a/mcs/class/System.IO.Compression.FileSystem/Test/System.IO.Compression.FileSystem/ZipTest.cs
+++ b/mcs/class/System.IO.Compression.FileSystem/Test/System.IO.Compression.FileSystem/ZipTest.cs
@@ -134,9 +134,10 @@ namespace MonoTests.System.IO.Compression.FileSystem
 			{
 				var entry = archive.GetEntry (file);
 				Assert.IsNotNull (entry);
-				Assert.AreEqual(entry.LastWriteTime.Year, date.Year);
-				Assert.AreEqual(entry.LastWriteTime.Month, date.Month);
-				Assert.AreEqual(entry.LastWriteTime.Day, date.Day);
+				var lastWriteTimeUtc = entry.LastWriteTime.ToUniversalTime ();
+				Assert.AreEqual (date.Year, lastWriteTimeUtc.Year);
+				Assert.AreEqual (date.Month, lastWriteTimeUtc.Month);
+				Assert.AreEqual (date.Day, lastWriteTimeUtc.Day);
 			}
 		}
 	}


### PR DESCRIPTION
`entry.LastWriteTime` is an unspecified/local DateTime but we're comparing it against `date` which is in UTC. This could lead to issues where the Day isn't matching when running the test around
midnight.

Examples:

- https://github.com/xamarin/maccore/issues/597
- https://jenkins.mono-project.com/job/xamarin-android-pr-builder/2387/testReport/Xamarin.Android.Bcl_Tests,%20MonoTests.System.IO.Compression.FileSystem/ZipArchiveTests/ZipCreateFromEntryChangeTimestamp___Debug/