### PR TITLE
Make stack traces readable

### DIFF
--- a/mcs/tests/test-async-17.cs
+++ b/mcs/tests/test-async-17.cs
@@ -64,7 +64,7 @@ class Tester
 		try {
 			await Task.Factory.StartNew (() => { throw new ArgumentException (); }).ConfigureAwait (false);
 		} catch (ArgumentException e) {
-			if (e.StackTrace.Contains (".MoveNext"))
+			if (e.StackTrace.Contains (".MoveNext") || e.StackTrace.Contains ("TestException_7 ()"))
 				throw new ApplicationException ();	
 		}
 		

--- a/mcs/tests/ver-il-net_4_x.xml
+++ b/mcs/tests/ver-il-net_4_x.xml
@@ -63639,7 +63639,7 @@
     </type>
     <type name="Tester+&lt;TestException_7&gt;c__async6">
       <method name="Void MoveNext()" attrs="486">
-        <size>272</size>
+        <size>293</size>
       </method>
     </type>
     <type name="Tester+&lt;TestException_3&gt;c__async2+&lt;TestException_3&gt;c__async7">

--- a/mcs/tools/mono-symbolicate/Makefile
+++ b/mcs/tools/mono-symbolicate/Makefile
@@ -45,7 +45,7 @@ PREPARE_OUTDIR = @\
 	mkdir -p $(MSYM_DIR);
 
 COMPILE = \
-	$(CSCOMPILE) $(TEST_CS) -r:$(LIB_PATH)/mscorlib.dll -out:$(TEST_EXE); \
+	$(CSCOMPILE) $(TEST_CS) -r:$(LIB_PATH)/mscorlib.dll -r:$(LIB_PATH)/System.Core.dll -warn:0 -out:$(TEST_EXE); \
 	$(MONO) $(LIB_PATH)/$(PROGRAM) store-symbols $(MSYM_DIR) $(OUT_DIR); \
 	$(MONO) $(LIB_PATH)/$(PROGRAM) store-symbols $(MSYM_DIR) $(LIB_PATH);
 

--- a/mcs/tools/mono-symbolicate/StackFrameData.cs
+++ b/mcs/tools/mono-symbolicate/StackFrameData.cs
@@ -17,13 +17,8 @@ namespace Mono
 		public readonly string Mvid;
 		public readonly string Aotid;
 
-		public string File { get; private set; }
-		public int LineNumber { get; private set; }
-
 		private StackFrameData (string line, string typeFullName, string methodSig, int offset, bool isILOffset, uint methodIndex, string mvid, string aotid)
 		{
-			LineNumber = -1;
-
 			Line = line;
 			TypeFullName = typeFullName;
 			MethodSignature = methodSig;
@@ -32,6 +27,11 @@ namespace Mono
 			MethodIndex = methodIndex;
 			Mvid = mvid;
 			Aotid = aotid;
+		}
+
+		public StackFrameData Relocate (string typeName, string methodName)
+		{
+			return new StackFrameData (Line, typeName, methodName, Offset, IsILOffset, MethodIndex, Mvid, Aotid);
 		}
 
 		public static bool TryParse (string line, out StackFrameData stackFrame)
@@ -90,17 +90,6 @@ namespace Mono
 			methodSignature = str.Substring (typeNameEnd + 1);
 
 			return true;
-		}
-
-		internal void SetLocation (string file, int lineNumber)
-		{
-			File = file;
-			LineNumber = lineNumber;
-		}
-
-		public override string ToString ()
-		{
-			return string.Format ("{0} in {1}:{2} ", Line.Substring (0, Line.IndexOf(" in <", StringComparison.Ordinal)), File, LineNumber);
 		}
 	}
 }

--- a/mcs/tools/mono-symbolicate/SymbolManager.cs
+++ b/mcs/tools/mono-symbolicate/SymbolManager.cs
@@ -9,6 +9,19 @@ using Mono.Collections.Generic;
 
 namespace Mono
 {
+	// Should be (string File, int Line) but need to bump monodroid_tools to 4.7
+	readonly struct Location
+	{
+		public readonly string File;
+		public readonly int Line;
+
+		public Location (string file, int line)
+		{
+			File = file;
+			Line = line;
+		}
+	}
+
 	public class SymbolManager
 	{
 		string msymDir;
@@ -19,20 +32,25 @@ namespace Mono
 			this.logger = logger;
 		}
 
-		internal bool TryResolveLocation (StackFrameData sfData)
+		internal bool TryResolveLocation (StackFrameData sfData, out Location location)
 		{
-			if (sfData.Mvid == null)
+			if (sfData.Mvid == null) {
+				location = default;
 				return false;
+			}
 
 			var assemblyLocProvider = GetOrCreateAssemblyLocationProvider (sfData.Mvid);
-			if (assemblyLocProvider == null)
+			if (assemblyLocProvider == null) {
+				location = default;
 				return false;
+			}
 
 			SeqPointInfo seqPointInfo = null;
 			if (!sfData.IsILOffset && sfData.Aotid != null)
 				seqPointInfo = GetOrCreateSeqPointInfo (sfData.Aotid);
 
-			return assemblyLocProvider.TryResolveLocation (sfData, seqPointInfo);
+
+			return assemblyLocProvider.TryResolveLocation (sfData, seqPointInfo, out location);
 		}
 
 		Dictionary<string, AssemblyLocationProvider> assemblies = new Dictionary<string, AssemblyLocationProvider> ();

--- a/mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs
+++ b/mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Linq;
 
 class StackTraceDumper {
 
@@ -53,6 +55,10 @@ class StackTraceDumper {
 			var d = new Dictionary<string, string> ();
 			d.ContainsKey (null); // ArgumentNullException
 		});
+
+		Catch (() => TestAsync ().Wait ());
+
+		Catch (() => TestIterator ().ToArray ());
 
 		/*
 		The following test include ambiguous methods we can't resolve. Testing this is hard, so I'm leaving a test behind but disabling it for the time being
@@ -124,6 +130,19 @@ class StackTraceDumper {
 	public static void ThrowExceptionGeneric<T1,T2> (string message)
 	{
 		throw new Exception (message);
+	}
+
+	public static async Task TestAsync ()
+	{
+		await Task.Yield ();
+		throw new ApplicationException ();
+	}
+
+	public static IEnumerable<int> TestIterator ()
+	{
+		yield return 1;
+		yield return 3;
+		throw new ApplicationException ();
 	}
 
 	class InnerClass {

--- a/mcs/tools/mono-symbolicate/Test/symbolicate.expected
+++ b/mcs/tools/mono-symbolicate/Test/symbolicate.expected
@@ -1,152 +1,185 @@
 System.Exception: Stacktrace with 1 frame
-  at StackTraceDumper.Main () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:9 
+  at StackTraceDumper.Main () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:11
 Stacktrace:
-  at StackTraceDumper.Main () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:9 
+  at StackTraceDumper.Main () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:11
 
 System.Exception: Stacktrace with 2 frames
-  at StackTraceDumper+<>c.<Main>b__0_0 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:16 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper+<>c.<Main>b__0_0 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:18
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 Stacktrace:
-  at StackTraceDumper+<>c.<Main>b__0_0 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:16 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper+<>c.<Main>b__0_0 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:18
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 
 System.Exception: Stacktrace with 3 frames
-  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:96 
-  at StackTraceDumper+<>c.<Main>b__0_1 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:18 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:102
+  at StackTraceDumper+<>c.<Main>b__0_1 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:20
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 Stacktrace:
-  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:96 
-  at StackTraceDumper+<>c.<Main>b__0_1 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:18 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:102
+  at StackTraceDumper+<>c.<Main>b__0_1 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:20
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 
 System.Exception: Stacktrace with 4 frames
-  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:96 
-  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:94 
-  at StackTraceDumper+<>c.<Main>b__0_2 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:20 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:102
+  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:100
+  at StackTraceDumper+<>c.<Main>b__0_2 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:22
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 Stacktrace:
-  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:96 
-  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:94 
-  at StackTraceDumper+<>c.<Main>b__0_2 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:20 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:102
+  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:100
+  at StackTraceDumper+<>c.<Main>b__0_2 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:22
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 
 System.Exception: Stack frame with method overload using ref parameter
-  at StackTraceDumper.ThrowException (System.String& message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:88 
-  at StackTraceDumper+<>c.<Main>b__0_3 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:24 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper.ThrowException (System.String& message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:94
+  at StackTraceDumper+<>c.<Main>b__0_3 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:26
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 Stacktrace:
-  at StackTraceDumper.ThrowException (System.String& message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:88 
-  at StackTraceDumper+<>c.<Main>b__0_3 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:24 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper.ThrowException (System.String& message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:94
+  at StackTraceDumper+<>c.<Main>b__0_3 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:26
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 
 System.Exception: Stack frame with method overload using out parameter
-  at StackTraceDumper.ThrowException (System.String message, System.Int32& o) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:101 
-  at StackTraceDumper+<>c.<Main>b__0_4 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:29 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper.ThrowException (System.String message, System.Int32& o) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:107
+  at StackTraceDumper+<>c.<Main>b__0_4 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:31
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 Stacktrace:
-  at StackTraceDumper.ThrowException (System.String message, System.Int32& o) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:101 
-  at StackTraceDumper+<>c.<Main>b__0_4 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:29 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper.ThrowException (System.String message, System.Int32& o) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:107
+  at StackTraceDumper+<>c.<Main>b__0_4 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:31
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 
 System.Exception: Stack frame with 1 generic parameter
-  at StackTraceDumper.ThrowExceptionGeneric[T] (System.String message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:106 
-  at StackTraceDumper+<>c.<Main>b__0_5 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:32 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper.ThrowExceptionGeneric[T] (System.String message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:112
+  at StackTraceDumper+<>c.<Main>b__0_5 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:34
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 Stacktrace:
-  at StackTraceDumper.ThrowExceptionGeneric[T] (System.String message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:106 
-  at StackTraceDumper+<>c.<Main>b__0_5 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:32 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper.ThrowExceptionGeneric[T] (System.String message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:112
+  at StackTraceDumper+<>c.<Main>b__0_5 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:34
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 
 System.Exception: Stack frame with 2 generic parameters
-  at StackTraceDumper.ThrowExceptionGeneric[T1,T2] (System.String message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:126 
-  at StackTraceDumper+<>c.<Main>b__0_6 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:34 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper.ThrowExceptionGeneric[T1,T2] (System.String message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:132
+  at StackTraceDumper+<>c.<Main>b__0_6 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:36
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 Stacktrace:
-  at StackTraceDumper.ThrowExceptionGeneric[T1,T2] (System.String message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:126 
-  at StackTraceDumper+<>c.<Main>b__0_6 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:34 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper.ThrowExceptionGeneric[T1,T2] (System.String message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:132
+  at StackTraceDumper+<>c.<Main>b__0_6 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:36
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 
 System.Exception: Stack frame with generic method overload
-  at StackTraceDumper.ThrowExceptionGeneric[T] (T a1) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:111 
-  at StackTraceDumper+<>c.<Main>b__0_7 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:36 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper.ThrowExceptionGeneric[T] (T a1) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:117
+  at StackTraceDumper+<>c.<Main>b__0_7 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:38
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 Stacktrace:
-  at StackTraceDumper.ThrowExceptionGeneric[T] (T a1) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:111 
-  at StackTraceDumper+<>c.<Main>b__0_7 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:36 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper.ThrowExceptionGeneric[T] (T a1) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:117
+  at StackTraceDumper+<>c.<Main>b__0_7 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:38
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 
 System.Exception: Stack trace with inner class
-  at StackTraceDumper+InnerClass.ThrowException (System.String message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:132 
-  at StackTraceDumper+<>c.<Main>b__0_8 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:38 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper+InnerClass.ThrowException (System.String message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:151
+  at StackTraceDumper+<>c.<Main>b__0_8 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:40
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 Stacktrace:
-  at StackTraceDumper+InnerClass.ThrowException (System.String message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:132 
-  at StackTraceDumper+<>c.<Main>b__0_8 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:38 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper+InnerClass.ThrowException (System.String message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:151
+  at StackTraceDumper+<>c.<Main>b__0_8 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:40
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 
 System.Exception: Stack trace with inner generic class
-  at StackTraceDumper+InnerGenericClass`1[T].ThrowException (System.String message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:139 
-  at StackTraceDumper+<>c.<Main>b__0_9 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:40 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper+InnerGenericClass`1[T].ThrowException (System.String message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:158
+  at StackTraceDumper+<>c.<Main>b__0_9 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:42
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 Stacktrace:
-  at StackTraceDumper+InnerGenericClass`1[T].ThrowException (System.String message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:139 
-  at StackTraceDumper+<>c.<Main>b__0_9 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:40 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper+InnerGenericClass`1[T].ThrowException (System.String message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:158
+  at StackTraceDumper+<>c.<Main>b__0_9 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:42
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 Generic to string:string
 
 System.Exception: Stack trace with inner generic class and method generic parameter
-  at StackTraceDumper+InnerGenericClass`1[T].ThrowException (System.String message, T arg) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:145 
-  at StackTraceDumper+<>c.<Main>b__0_10 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:42 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper+InnerGenericClass`1[T].ThrowException (System.String message, T arg) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:164
+  at StackTraceDumper+<>c.<Main>b__0_10 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:44
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 Stacktrace:
-  at StackTraceDumper+InnerGenericClass`1[T].ThrowException (System.String message, T arg) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:145 
-  at StackTraceDumper+<>c.<Main>b__0_10 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:42 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper+InnerGenericClass`1[T].ThrowException (System.String message, T arg) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:164
+  at StackTraceDumper+<>c.<Main>b__0_10 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:44
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 
 System.Exception: Stack trace with inner generic class and generic overload
-  at StackTraceDumper+InnerGenericClass`1[T].ThrowException[T1] (System.String message, T1 arg) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:150 
-  at StackTraceDumper+<>c.<Main>b__0_11 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:44 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper+InnerGenericClass`1[T].ThrowException[T1] (System.String message, T1 arg) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:169
+  at StackTraceDumper+<>c.<Main>b__0_11 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:46
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 Stacktrace:
-  at StackTraceDumper+InnerGenericClass`1[T].ThrowException[T1] (System.String message, T1 arg) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:150 
-  at StackTraceDumper+<>c.<Main>b__0_11 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:44 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper+InnerGenericClass`1[T].ThrowException[T1] (System.String message, T1 arg) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:169
+  at StackTraceDumper+<>c.<Main>b__0_11 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:46
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 
 System.Exception: Stack trace with 2 inner generic class and generic overload
-  at StackTraceDumper+InnerGenericClass`1+InnerInnerGenericClass`1[T,T2].ThrowException (T message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:161 
-  at StackTraceDumper+<>c.<Main>b__0_12 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:46 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper+InnerGenericClass`1+InnerInnerGenericClass`1[T,T2].ThrowException (T message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:180
+  at StackTraceDumper+<>c.<Main>b__0_12 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:48
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 Stacktrace:
-  at StackTraceDumper+InnerGenericClass`1+InnerInnerGenericClass`1[T,T2].ThrowException (T message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:161 
-  at StackTraceDumper+<>c.<Main>b__0_12 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:46 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper+InnerGenericClass`1+InnerInnerGenericClass`1[T,T2].ThrowException (T message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:180
+  at StackTraceDumper+<>c.<Main>b__0_12 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:48
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 
 System.Exception: Stack trace with 2 inner generic class and generic overload
-  at StackTraceDumper+InnerGenericClass`1+InnerInnerGenericClass`1[T,T2].ThrowException (T2 message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:166 
-  at StackTraceDumper+<>c.<Main>b__0_13 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:48 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper+InnerGenericClass`1+InnerInnerGenericClass`1[T,T2].ThrowException (T2 message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:185
+  at StackTraceDumper+<>c.<Main>b__0_13 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:50
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 Stacktrace:
-  at StackTraceDumper+InnerGenericClass`1+InnerInnerGenericClass`1[T,T2].ThrowException (T2 message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:166 
-  at StackTraceDumper+<>c.<Main>b__0_13 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:48 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper+InnerGenericClass`1+InnerInnerGenericClass`1[T,T2].ThrowException (T2 message) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:185
+  at StackTraceDumper+<>c.<Main>b__0_13 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:50
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 
 System.Exception: Stack trace with nested type argument
-  at StackTraceDumper+InnerGenericClass`1[T].ThrowException[T1] (System.String message, T1 arg, StackTraceDumper+InnerGenericClass`1[T] _ignore) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:155 
-  at StackTraceDumper+<>c.<Main>b__0_14 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:50 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper+InnerGenericClass`1[T].ThrowException[T1] (System.String message, T1 arg, StackTraceDumper+InnerGenericClass`1[T] _ignore) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:174
+  at StackTraceDumper+<>c.<Main>b__0_14 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:52
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 Stacktrace:
-  at StackTraceDumper+InnerGenericClass`1[T].ThrowException[T1] (System.String message, T1 arg, StackTraceDumper+InnerGenericClass`1[T] _ignore) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:155 
-  at StackTraceDumper+<>c.<Main>b__0_14 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:50 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at StackTraceDumper+InnerGenericClass`1[T].ThrowException[T1] (System.String message, T1 arg, StackTraceDumper+InnerGenericClass`1[T] _ignore) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:174
+  at StackTraceDumper+<>c.<Main>b__0_14 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:52
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 
 System.ArgumentNullException: Value cannot be null.
 Parameter name: key
-  at System.Collections.Generic.Dictionary`2[TKey,TValue].FindEntry (TKey key) in external/corefx/src/Common/src/CoreLib/System/Collections/Generic/Dictionary.cs:380 
-  at System.Collections.Generic.Dictionary`2[TKey,TValue].ContainsKey (TKey key) in external/corefx/src/Common/src/CoreLib/System/Collections/Generic/Dictionary.cs:286 
-  at StackTraceDumper+<>c.<Main>b__0_15 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:54 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at System.Collections.Generic.Dictionary`2[TKey,TValue].FindEntry (TKey key) in external/corefx/src/Common/src/CoreLib/System/Collections/Generic/Dictionary.cs:380
+  at System.Collections.Generic.Dictionary`2[TKey,TValue].ContainsKey (TKey key) in external/corefx/src/Common/src/CoreLib/System/Collections/Generic/Dictionary.cs:286
+  at StackTraceDumper+<>c.<Main>b__0_15 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:56
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
 Stacktrace:
-  at System.Collections.Generic.Dictionary`2[TKey,TValue].FindEntry (TKey key) in external/corefx/src/Common/src/CoreLib/System/Collections/Generic/Dictionary.cs:380 
-  at System.Collections.Generic.Dictionary`2[TKey,TValue].ContainsKey (TKey key) in external/corefx/src/Common/src/CoreLib/System/Collections/Generic/Dictionary.cs:286 
-  at StackTraceDumper+<>c.<Main>b__0_15 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:54 
-  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:72 
+  at System.Collections.Generic.Dictionary`2[TKey,TValue].FindEntry (TKey key) in external/corefx/src/Common/src/CoreLib/System/Collections/Generic/Dictionary.cs:380
+  at System.Collections.Generic.Dictionary`2[TKey,TValue].ContainsKey (TKey key) in external/corefx/src/Common/src/CoreLib/System/Collections/Generic/Dictionary.cs:286
+  at StackTraceDumper+<>c.<Main>b__0_15 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:56
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
+
+System.AggregateException: One or more errors occurred. ---> System.ApplicationException: Error in the application.
+  at StackTraceDumper.TestAsync () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:138
+   --- End of inner exception stack trace ---
+  at System.Threading.Tasks.Task.ThrowIfExceptional (System.Boolean includeTaskCanceledExceptions) in external/corert/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs:2052
+  at System.Threading.Tasks.Task.Wait (System.Int32 millisecondsTimeout, System.Threading.CancellationToken cancellationToken) in external/corert/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs:2784
+  at System.Threading.Tasks.Task.Wait () in external/corert/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs:2650
+  at StackTraceDumper+<>c.<Main>b__0_16 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:59
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
+---> (Inner Exception #0) System.ApplicationException: Error in the application.
+  at StackTraceDumper.TestAsync () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:138
+
+Stacktrace:
+  at System.Threading.Tasks.Task.ThrowIfExceptional (System.Boolean includeTaskCanceledExceptions) in external/corert/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs:2052
+  at System.Threading.Tasks.Task.Wait (System.Int32 millisecondsTimeout, System.Threading.CancellationToken cancellationToken) in external/corert/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs:2784
+  at System.Threading.Tasks.Task.Wait () in external/corert/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs:2650
+  at StackTraceDumper+<>c.<Main>b__0_16 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:59
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
+
+System.ApplicationException: Error in the application.
+  at StackTraceDumper+<TestIterator>d__12.MoveNext () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:145
+  at System.Collections.Generic.LargeArrayBuilder`1[T].AddRange (System.Collections.Generic.IEnumerable`1[T] items) in external/corefx/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs:172
+  at System.Collections.Generic.EnumerableHelpers.ToArray[T] (System.Collections.Generic.IEnumerable`1[T] source) in external/corefx/src/Common/src/System/Collections/Generic/EnumerableHelpers.cs:84
+  at System.Linq.Enumerable.ToArray[TSource] (System.Collections.Generic.IEnumerable`1[T] source) in external/corefx/src/System.Linq/src/System/Linq/ToCollection.cs:18
+  at StackTraceDumper+<>c.<Main>b__0_17 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:61
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78
+Stacktrace:
+  at StackTraceDumper+<TestIterator>d__12.MoveNext () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:145
+  at System.Collections.Generic.LargeArrayBuilder`1[T].AddRange (System.Collections.Generic.IEnumerable`1[T] items) in external/corefx/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs:172
+  at System.Collections.Generic.EnumerableHelpers.ToArray[T] (System.Collections.Generic.IEnumerable`1[T] source) in external/corefx/src/Common/src/System/Collections/Generic/EnumerableHelpers.cs:84
+  at System.Linq.Enumerable.ToArray[TSource] (System.Collections.Generic.IEnumerable`1[T] source) in external/corefx/src/System.Linq/src/System/Linq/ToCollection.cs:18
+  at StackTraceDumper+<>c.<Main>b__0_17 () in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:61
+  at StackTraceDumper.Catch (System.Action action) in mcs/tools/mono-symbolicate/Test/StackTraceDumper.cs:78

--- a/mcs/tools/mono-symbolicate/symbolicate.cs
+++ b/mcs/tools/mono-symbolicate/symbolicate.cs
@@ -81,11 +81,9 @@ namespace Mono
 
 			using (StreamReader r = new StreamReader (inputFile)) {
 				for (var line = r.ReadLine (); line != null; line = r.ReadLine ()) {
-					StackFrameData sfData;
-					if (StackFrameData.TryParse (line, out sfData) &&
-						symbolManager.TryResolveLocation (sfData)) {
-						Console.WriteLine (sfData.ToString ());
-						continue;
+					if (StackFrameData.TryParse (line, out var sfData) && symbolManager.TryResolveLocation (sfData, out var location)) {
+						var sign = sfData.Line.Substring (0, sfData.Line.IndexOf (" in <", StringComparison.Ordinal));
+						line = $"{sign} in {location.File}:{location.Line}";
 					}
 
 					Console.WriteLine (line);


### PR DESCRIPTION
Brings Mono in line with recent coreclr changes https://github.com/dotnet/coreclr/pull/14655

Still working out how to test this locally (my first Mono PR)