### PR TITLE
Fix warnings

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -600,7 +600,7 @@ push_handle_stack (HandleStack* stack)
 
 	while (cur) {
 		if (cur->size > 0)
-			GC_push_all (cur->elems, (char*)(cur->elems + cur->size) + 1);
+			GC_push_all ((gpointer)&cur->elems[0], (char*)(cur->elems + cur->size) + 1);
 		if (cur == last)
 			break;
 		cur = cur->next;

--- a/mono/utils/checked-build.c
+++ b/mono/utils/checked-build.c
@@ -38,7 +38,7 @@ mono_check_mode_enabled (MonoCheckMode query)
 	if (G_UNLIKELY (check_mode == MONO_CHECK_MODE_UNKNOWN))
 	{
 		MonoCheckMode env_check_mode = MONO_CHECK_MODE_NONE;
-		const gchar *env_string = g_getenv ("MONO_CHECK_MODE");
+		gchar *env_string = g_getenv ("MONO_CHECK_MODE");
 
 		if (env_string)
 		{
@@ -73,7 +73,7 @@ mono_check_transition_limit (void)
 {
 	static int transition_limit = -1;
 	if (transition_limit < 0) {
-		const gchar *env_string = g_getenv ("MONO_CHECK_THREAD_TRANSITION_HISTORY");
+		gchar *env_string = g_getenv ("MONO_CHECK_THREAD_TRANSITION_HISTORY");
 		if (env_string) {
 			transition_limit = atoi (env_string);
 			g_free (env_string);


### PR DESCRIPTION
1. In checked builds, we declared the result of `g_getenv` as `const gchar*` which isn't correct anymore since our `g_getenv` now returns `gchar*` that you're responsible for freeing.
2. In the boehm coop handles support, we passed `cur->elems` of array type to a function expecting a `char*`.
