### PR TITLE
[interp] Some MonoError fixes

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1534,6 +1534,9 @@ mono_class_get_weak_bitmap (MonoClass *klass, int *nbits);
 MonoMethod *
 mono_class_get_method_from_name_checked (MonoClass *klass, const char *name, int param_count, int flags, MonoError *error);
 
+gboolean
+mono_method_has_no_body (MonoMethod *method);
+
 // FIXME Replace all internal callers of mono_method_get_header_checked with
 // mono_method_get_header_internal; the difference is in error initialization.
 //

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -2620,6 +2620,15 @@ mono_method_get_token (MonoMethod *method)
 	return method->token;
 }
 
+gboolean
+mono_method_has_no_body (MonoMethod *method)
+{
+	return ((method->flags & METHOD_ATTRIBUTE_ABSTRACT) ||
+		(method->iflags & METHOD_IMPL_ATTRIBUTE_RUNTIME) ||
+		(method->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL) ||
+		(method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL));
+}
+
 // FIXME Replace all internal callers of mono_method_get_header_checked with
 // mono_method_get_header_internal; the difference is in error initialization.
 MonoMethodHeader*
@@ -2634,7 +2643,9 @@ mono_method_get_header_internal (MonoMethod *method, MonoError *error)
 	error_init (error);
 	img = method->klass->image;
 
-	if ((method->flags & METHOD_ATTRIBUTE_ABSTRACT) || (method->iflags & METHOD_IMPL_ATTRIBUTE_RUNTIME) || (method->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL) || (method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL)) {
+	// FIXME: for internal callers maybe it makes sense to do this check at the call site, not
+	// here?
+	if (mono_method_has_no_body (method)) {
 		mono_error_set_bad_image (error, img, "Method has no body");
 		return NULL;
 	}

--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -8,7 +8,6 @@
 #include <mono/metadata/domain-internals.h>
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/debug-internals.h>
-#include "config.h"
 #include "interp.h"
 
 #define MINT_TYPE_I1 0

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -7,6 +7,7 @@
  * Copyright (c) 2004.
  */
 
+#include "config.h"
 #include <string.h>
 #include <mono/metadata/appdomain.h>
 #include <mono/metadata/debug-helpers.h>


### PR DESCRIPTION
1. In `generate()` in `transform.c`, `return_if_nok` will leak `TransformData`.  Switch to `goto_if_nok` that jumps to the various `free` calls.
2. Because `config.h` wasn't the first `#include` in `transform.c`, functions marked `MONO_RT_EXTERNAL_ONLY` weren't rejected by the C compiler.  Now they are, and now we use various `_checked` functions and deal with the `MonoError` explicitly.
