### PR TITLE
[marshal] always set ENABLE_ILGEN

### DIFF
--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -51,10 +51,9 @@ struct _MonoType {
 #define MONO_PROCESSOR_ARCHITECTURE_AMD64 4
 #define MONO_PROCESSOR_ARCHITECTURE_ARM 5
 
-#if !defined(DISABLE_JIT) || !defined(DISABLE_INTERPRETER)
-/* Some VES is available at runtime */
+/* Some VES is available at runtime. Since we can always statically link the
+ * interpreter into the runtime, always keep that code around */
 #define ENABLE_ILGEN
-#endif
 
 struct _MonoAssemblyName {
 	const char *name;


### PR DESCRIPTION
it ought to be a mechanism to remove some code from the runtime around
emitting wrappers, that aren't needed in a FullAOT environment.

However, since recently it's possible to statically link the interpreter
later into the runtime, which requires mentioned wrappers. The proper
solution would be to move that into a separate library as well, but this
requires some work.

Some numbers: object file size of marshal.o with `-O0 -g` on amd64

 * before: 265K
 * after: 429K