### PR TITLE
[coop] Convert some `mono_exception_*` functions

### DIFF
--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -347,6 +347,7 @@ libmonoruntimeinclude_HEADERS = \
 	mono-debug.h		\
 	mono-gc.h		\
 	object.h		\
+	object-forward.h	\
 	opcodes.h		\
 	profiler.h		\
 	profiler-events.h	\

--- a/mono/metadata/exception.h
+++ b/mono/metadata/exception.h
@@ -5,6 +5,7 @@
 #ifndef _MONO_METADATA_EXCEPTION_H_
 #define _MONO_METADATA_EXCEPTION_H_
 
+#include <mono/metadata/object-forward.h>
 #include <mono/metadata/object.h>
 #include <mono/metadata/image.h>
 

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -22,6 +22,7 @@
 #include <mono/utils/mono-error-internals.h>
 #include <mono/utils/mono-threads.h>
 #include <mono/utils/checked-build.h>
+#include <mono/metadata/class-internals.h>
 
 G_BEGIN_DECLS
 
@@ -208,11 +209,13 @@ Icall macros
 	CLEAR_ICALL_FRAME;			\
 	} while (0)
 
+// Return a non-pointer or non-managed pointer, e.g. gboolean.
 #define HANDLE_FUNCTION_RETURN_VAL(VAL)		\
 	CLEAR_ICALL_FRAME;			\
 	return (VAL);				\
 	} while (0)
 
+// Return a raw pointer from coop handle.
 #define HANDLE_FUNCTION_RETURN_OBJ(HANDLE)			\
 	do {							\
 		void* __result = (MONO_HANDLE_RAW (HANDLE));	\
@@ -220,6 +223,7 @@ Icall macros
 		return __result;				\
 	} while (0); } while (0);
 
+// Return a coop handle from coop handle.
 #define HANDLE_FUNCTION_RETURN_REF(TYPE, HANDLE)			\
 	do {								\
 		MonoRawHandle __result;					\

--- a/mono/metadata/image.h
+++ b/mono/metadata/image.h
@@ -8,10 +8,10 @@
 #include <stdio.h>
 #include <mono/utils/mono-publib.h>
 #include <mono/utils/mono-error.h>
+#include <mono/metadata/object-forward.h>
 
 MONO_BEGIN_DECLS
 
-typedef struct _MonoImage MonoImage;
 typedef struct _MonoAssembly MonoAssembly;
 typedef struct _MonoAssemblyName MonoAssemblyName;
 typedef struct _MonoTableInfo MonoTableInfo;

--- a/mono/metadata/metadata.h
+++ b/mono/metadata/metadata.h
@@ -10,6 +10,7 @@
 #include <mono/metadata/blob.h>
 #include <mono/metadata/row-indexes.h>
 #include <mono/metadata/image.h>
+#include <mono/metadata/object-forward.h>
 
 MONO_BEGIN_DECLS
 
@@ -22,9 +23,7 @@ MONO_BEGIN_DECLS
 
 #define MONO_CLASS_IS_IMPORT(c) ((mono_class_get_flags (c) & TYPE_ATTRIBUTE_IMPORT))
 
-typedef struct _MonoClass MonoClass;
 typedef struct _MonoDomain MonoDomain;
-typedef struct _MonoMethod MonoMethod;
 
 typedef enum {
 	MONO_EXCEPTION_CLAUSE_NONE,

--- a/mono/metadata/object-forward.h
+++ b/mono/metadata/object-forward.h
@@ -8,6 +8,13 @@
 #ifndef __MONO_OBJECT_FORWARD_H__
 #define __MONO_OBJECT_FORWARD_H__
 
+#include <mono/utils/mono-publib.h>
+
 typedef struct _MonoReflectionTypeBuilder MonoReflectionTypeBuilder;
+typedef struct _MonoException MONO_RT_MANAGED_ATTR MonoException;
+typedef struct _MonoClass MonoClass;
+typedef struct _MonoImage MonoImage;
+typedef struct _MonoMethod MonoMethod;
+
 
 #endif /* __MONO_OBJECT_FORWARD_H__ */

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1959,4 +1959,7 @@ ves_icall_ModuleBuilder_set_wrappers_type (MonoReflectionModuleBuilderHandle mod
 MonoAssembly*
 mono_try_assembly_resolve_handle (MonoDomain *domain, MonoStringHandle fname, MonoAssembly *requesting, gboolean refonly, MonoError *error);
 
+gboolean
+mono_runtime_object_init_handle (MonoObjectHandle this_obj, MonoError *error);
+
 #endif /* __MONO_OBJECT_INTERNALS_H__ */

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -5,6 +5,7 @@
 #ifndef _MONO_CLI_OBJECT_H_
 #define _MONO_CLI_OBJECT_H_
 
+#include <mono/metadata/object-forward.h>
 #include <mono/metadata/class.h>
 #include <mono/utils/mono-error.h>
 
@@ -22,7 +23,6 @@ typedef struct _MonoReflectionProperty MONO_RT_MANAGED_ATTR MonoReflectionProper
 typedef struct _MonoReflectionEvent MONO_RT_MANAGED_ATTR MonoReflectionEvent;
 typedef struct _MonoReflectionType MONO_RT_MANAGED_ATTR MonoReflectionType;
 typedef struct _MonoDelegate MONO_RT_MANAGED_ATTR MonoDelegate;
-typedef struct _MonoException MONO_RT_MANAGED_ATTR MonoException;
 typedef struct _MonoThreadsSync MonoThreadsSync;
 typedef struct _MonoThread MONO_RT_MANAGED_ATTR MonoThread;
 typedef struct _MonoDynamicAssembly MonoDynamicAssembly;

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -20,6 +20,7 @@
 #include "mono/utils/mono-compiler.h"
 #include "mono/utils/mono-membar.h"
 #include "mono/utils/mono-threads.h"
+#include "mono/metadata/class-internals.h"
 
 /* This is a copy of System.Threading.ThreadState */
 typedef enum {

--- a/mono/profiler/coverage.c
+++ b/mono/profiler/coverage.c
@@ -64,6 +64,7 @@
 #include <mono/metadata/profiler.h>
 #include <mono/metadata/tabledefs.h>
 #include <mono/metadata/tokentype.h>
+#include <mono/metadata/class-internals.h>
 
 #include <mono/mini/jit.h>
 

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -5,8 +5,8 @@
 #ifndef __MONO_ERROR_INTERNALS_H__
 #define __MONO_ERROR_INTERNALS_H__
 
+#include <mono/metadata/object-forward.h>
 #include "mono/utils/mono-compiler.h"
-#include "mono/metadata/class-internals.h"
 
 /*Keep in sync with MonoError*/
 typedef struct {
@@ -113,7 +113,9 @@ Different names indicate different scenarios, but the same code.
 #define return_if_nok(error) do { if (!is_ok ((error))) return; } while (0)
 #define return_val_if_nok(error,val) do { if (!is_ok ((error))) return (val); } while (0)
 
-#define goto_if_nok(error,label) do { if (!is_ok ((error))) goto label; } while (0)
+#define goto_if(expr, label) 	  do { if (expr) goto label; } while (0)
+#define goto_if_ok(error, label)  goto_if (is_ok (error), label)
+#define goto_if_nok(error, label) goto_if (!is_ok (error), label)
 
 /* Only use this in icalls */
 #define return_val_and_set_pending_if_nok(error, value) \

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -553,6 +553,13 @@ set_message_on_exception (MonoException *exception, MonoErrorInternal *error, Mo
 		mono_error_set_out_of_memory (error_out, "Could not allocate exception object");
 }
 
+MonoExceptionHandle
+mono_error_prepare_exception_handle (MonoError *oerror, MonoError *error_out)
+// Can fail with out-of-memory
+{
+	return MONO_HANDLE_NEW (MonoException, mono_error_prepare_exception (oerror, error_out));
+}
+
 /*Can fail with out-of-memory*/
 MonoException*
 mono_error_prepare_exception (MonoError *oerror, MonoError *error_out)
@@ -675,6 +682,36 @@ mono_error_prepare_exception (MonoError *oerror, MonoError *error_out)
 Convert this MonoError to an exception if it's faulty or return NULL.
 The error object is cleant after.
 */
+
+MonoExceptionHandle
+mono_error_convert_to_exception_handle (MonoError *target_error)
+{
+	ERROR_DECL (error);
+
+	HANDLE_FUNCTION_ENTER ()
+
+	MonoExceptionHandle ex = MONO_HANDLE_NEW (MonoException, NULL);
+
+	/* Mempool stored error shouldn't be cleaned up */
+	g_assert (!is_boxed ((MonoErrorInternal*)target_error));
+
+	if (mono_error_ok (target_error))
+		goto exit;
+
+	ex = mono_error_prepare_exception_handle (target_error, error);
+	if (!mono_error_ok (error)) {
+		ERROR_DECL_VALUE (second_chance);
+		/*Try to produce the exception for the second error. FIXME maybe we should log about the original one*/
+		ex = mono_error_prepare_exception_handle (error, &second_chance);
+
+		g_assert (mono_error_ok (&second_chance)); /*We can't reasonable handle double faults, maybe later.*/
+		mono_error_cleanup (error);
+	}
+	mono_error_cleanup (target_error);
+
+exit:
+	HANDLE_FUNCTION_RETURN_REF (MonoException, ex)
+}
 
 MonoException*
 mono_error_convert_to_exception (MonoError *target_error)


### PR DESCRIPTION
 arbitrarily split out from a too-large change to make
 forward progress. The large change is hard to review
 and has bugs somewhere. Breaking it up will provide
 digestable diffs and proceed through more debuggable
 and working states, and in the event of breakage,
 bisectable later.

Declare many and implement some exception handle creating functions.
They will probably eventually all be needed (depending
  on other restructuring).

Move MonoExceptionHandle from handle.h to object-forward.h,
   which appears needed for larger conversion, but perhaps
   can be avoided.

Provide MONO_HANDLE_ASSIGN_RAW to remove some MONO_HANDLE_NEW
  and/or avoid adding more.

Port mono_raise_exception_with_context to handle, but don't use it yet.

Provide mono_runtime_object_init_handle.

Provide goto_if_ok analogous to goto_if_nok.

Build goto_if_ok and goto_if_nok on top of goto_if,
  which, in all three cases, are just collapsing two
  lines to one.

Provide mono_error_convert_to_exception_handle.

Provide mono_error_prepare_exception_handle.