### PR TITLE
[pkg] Set MONO_BUILD_REVISION for OSX package build

### DIFF
--- a/scripts/ci/pipeline/osx-package.groovy
+++ b/scripts/ci/pipeline/osx-package.groovy
@@ -37,7 +37,7 @@ node ("osx-amd64") {
 
                 // build the .pkg
                 timeout (time: 420, unit: 'MINUTES') {
-                    withEnv (["MONO_BRANCH=${isPr ? '' : monoBranch}"]) {
+                    withEnv (["MONO_BRANCH=${isPr ? '' : monoBranch}", "MONO_BUILD_REVISION=${commitHash}"]) {
                         sshagent (credentials: ['mono-extensions-ssh']) {
                             sh "external/bockbuild/bb MacSDKRelease --arch darwin-universal --verbose --package ${isReleaseJob ? '--release' : ''}"
                         }


### PR DESCRIPTION
Otherwise the default bockbuild behavior is to use the tip of MONO_BRANCH which is not what we want when building on Jenkins.