### PR TITLE
Rationalize MonoGCHandleType and GCHandleType.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5513,6 +5513,7 @@ scripts/mono-find-requires
 mk/Makefile
 mono/Makefile
 mono/btls/Makefile
+mono/inc/Makefile
 mono/utils/Makefile
 mono/utils/jemalloc/Makefile
 mono/metadata/Makefile

--- a/mono/Makefile.am
+++ b/mono/Makefile.am
@@ -9,10 +9,10 @@ btls_dirs = btls
 endif
 
 if CROSS_COMPILING
-SUBDIRS = $(btls_dirs) eglib arch utils cil $(sgen_dirs) metadata mini dis profiler
+SUBDIRS = $(btls_dirs) eglib arch utils cil $(sgen_dirs) metadata mini dis profiler inc
 else
 if INSTALL_MONOTOUCH
-SUBDIRS = $(btls_dirs) eglib arch utils $(sgen_dirs) metadata mini profiler
+SUBDIRS = $(btls_dirs) eglib arch utils $(sgen_dirs) metadata mini profiler inc
 
 monotouch-do-build:
 	@list='$(SUBDIRS)'; for subdir in $$list; do \

--- a/mono/inc/Makefile.am
+++ b/mono/inc/Makefile.am
@@ -1,0 +1,7 @@
+include $(top_srcdir)/mk/common.mk
+
+# Note this ends up with double "inc" -- /usr/include/mono-$(API_VER)/mono/inc
+monoincdir = $(includedir)/mono-$(API_VER)/mono/inc
+
+monoinc_HEADERS = \
+	mono-gc-handle.h

--- a/mono/inc/mono-gc-handle.h
+++ b/mono/inc/mono-gc-handle.h
@@ -1,0 +1,24 @@
+/**
+ * \file
+ * GC handle type used by profiler, metadata, sgen.
+ * They must all use the same values, even if, for example
+ * sgen is not coupled to metadata so they are
+ * in a common place, outside of metadata.
+ */
+#ifndef __MONO_INC_MONO_GC_HANDLE_H__
+#define __MONO_INC_MONO_GC_HANDLE_H__
+
+// These should match System.Runtime.InteropServices.GCHandleType.
+// And mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogEnums.cs.
+// And mono/sgen/gc-internal-agnostic.h aliases them.
+typedef enum {
+#define MONO_GC_HANDLE_TYPE_MIN MONO_GC_HANDLE_WEAK // Prefer no duplicates in enum type.
+       MONO_GC_HANDLE_WEAK			= 0,
+       MONO_GC_HANDLE_WEAK_TRACK_RESURRECTION	= 1,
+       MONO_GC_HANDLE_NORMAL			= 2,
+       MONO_GC_HANDLE_PINNED			= 3,
+       MONO_GC_HANDLE_WEAK_FIELDS		= 4,
+       MONO_GC_HANDLE_TYPE_MAX			= 5,
+} MonoGCHandleType;
+
+#endif // __MONO_INC_MONO_GC_HANDLE_H__

--- a/mono/metadata/mono-gc.h
+++ b/mono/metadata/mono-gc.h
@@ -98,13 +98,17 @@ typedef enum {
 	MONO_ROOT_SOURCE_EPHEMERON = 15,
 } MonoGCRootSource;
 
+// These should match System.Runtime.InteropServices.GCHandleType.
+// And mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogEnums.cs.
+// And mono/sgen/gc-internal-agnostic.h aliases them.
 typedef enum {
-	MONO_GC_HANDLE_TYPE_MIN = 0,
-	MONO_GC_HANDLE_WEAK = MONO_GC_HANDLE_TYPE_MIN,
-	MONO_GC_HANDLE_WEAK_TRACK_RESURRECTION,
-	MONO_GC_HANDLE_NORMAL,
-	MONO_GC_HANDLE_PINNED,
-	MONO_GC_HANDLE_TYPE_MAX,
+#define MONO_GC_HANDLE_TYPE_MIN MONO_GC_HANDLE_WEAK // Prefer no duplicates in enum type.
+       MONO_GC_HANDLE_WEAK			= 0,
+       MONO_GC_HANDLE_WEAK_TRACK_RESURRECTION	= 1,
+       MONO_GC_HANDLE_NORMAL			= 2,
+       MONO_GC_HANDLE_PINNED			= 3,
+       MONO_GC_HANDLE_WEAK_FIELDS		= 4,
+       MONO_GC_HANDLE_TYPE_MAX			= 5,
 } MonoGCHandleType;
 
 MONO_API void   mono_gc_collect         (int generation);

--- a/mono/metadata/mono-gc.h
+++ b/mono/metadata/mono-gc.h
@@ -7,6 +7,7 @@
 #define __METADATA_MONO_GC_H__
 
 #include <mono/metadata/object.h>
+#include <mono/inc/mono-gc-handle.h>
 
 MONO_BEGIN_DECLS
 
@@ -98,18 +99,7 @@ typedef enum {
 	MONO_ROOT_SOURCE_EPHEMERON = 15,
 } MonoGCRootSource;
 
-// These should match System.Runtime.InteropServices.GCHandleType.
-// And mcs/class/Mono.Profiler.Log/Mono.Profiler.Log/LogEnums.cs.
 // And mono/sgen/gc-internal-agnostic.h aliases them.
-typedef enum {
-#define MONO_GC_HANDLE_TYPE_MIN MONO_GC_HANDLE_WEAK // Prefer no duplicates in enum type.
-       MONO_GC_HANDLE_WEAK			= 0,
-       MONO_GC_HANDLE_WEAK_TRACK_RESURRECTION	= 1,
-       MONO_GC_HANDLE_NORMAL			= 2,
-       MONO_GC_HANDLE_PINNED			= 3,
-       MONO_GC_HANDLE_WEAK_FIELDS		= 4,
-       MONO_GC_HANDLE_TYPE_MAX			= 5,
-} MonoGCHandleType;
 
 MONO_API void   mono_gc_collect         (int generation);
 MONO_API int    mono_gc_max_generation  (void);

--- a/mono/sgen/gc-internal-agnostic.h
+++ b/mono/sgen/gc-internal-agnostic.h
@@ -18,7 +18,7 @@
 #include "mono/utils/mono-compiler.h"
 #include "mono/utils/parse.h"
 #include "mono/utils/memfuncs.h"
-#include "mono/metadata/mono-gc.h"
+#include "mono/inc/mono-gc-handle.h"
 #ifdef HAVE_SGEN_GC
 #include "mono/sgen/sgen-conf.h"
 #endif
@@ -47,7 +47,7 @@
 #define MONO_GC_HANDLE_IS_METADATA_POINTER(slot) (MONO_GC_HANDLE_TAG (slot) == MONO_GC_HANDLE_OCCUPIED_MASK)
 
 // Shorter local names for GC handle type and its values.
-// See mono-gc.h.
+// See mono-gc-handle.h. FIXME? Remove these? (Convert users.)
 #define HANDLE_TYPE_MIN    MONO_GC_HANDLE_TYPE_MIN                // 0
 #define HANDLE_WEAK        MONO_GC_HANDLE_WEAK                    // 0
 #define HANDLE_WEAK_TRACK  MONO_GC_HANDLE_WEAK_TRACK_RESURRECTION // 1

--- a/mono/sgen/gc-internal-agnostic.h
+++ b/mono/sgen/gc-internal-agnostic.h
@@ -18,6 +18,7 @@
 #include "mono/utils/mono-compiler.h"
 #include "mono/utils/parse.h"
 #include "mono/utils/memfuncs.h"
+#include "mono/metadata/mono-gc.h"
 #ifdef HAVE_SGEN_GC
 #include "mono/sgen/sgen-conf.h"
 #endif
@@ -45,16 +46,16 @@
 #define MONO_GC_HANDLE_IS_OBJECT_POINTER(slot) (MONO_GC_HANDLE_TAG (slot) == (MONO_GC_HANDLE_OCCUPIED_MASK | MONO_GC_HANDLE_VALID_MASK))
 #define MONO_GC_HANDLE_IS_METADATA_POINTER(slot) (MONO_GC_HANDLE_TAG (slot) == MONO_GC_HANDLE_OCCUPIED_MASK)
 
-/* These should match System.Runtime.InteropServices.GCHandleType */
-typedef enum {
-	HANDLE_TYPE_MIN = 0,
-	HANDLE_WEAK = HANDLE_TYPE_MIN,
-	HANDLE_WEAK_TRACK,
-	HANDLE_NORMAL,
-	HANDLE_PINNED,
-	HANDLE_WEAK_FIELDS,
-	HANDLE_TYPE_MAX
-} GCHandleType;
+// Shorter local names for GC handle type and its values.
+// See mono-gc.h.
+#define HANDLE_TYPE_MIN    MONO_GC_HANDLE_TYPE_MIN                // 0
+#define HANDLE_WEAK        MONO_GC_HANDLE_WEAK                    // 0
+#define HANDLE_WEAK_TRACK  MONO_GC_HANDLE_WEAK_TRACK_RESURRECTION // 1
+#define HANDLE_NORMAL      MONO_GC_HANDLE_NORMAL                  // 2
+#define HANDLE_PINNED      MONO_GC_HANDLE_PINNED                  // 3
+#define HANDLE_WEAK_FIELDS MONO_GC_HANDLE_WEAK_FIELDS             // 4
+#define HANDLE_TYPE_MAX    MONO_GC_HANDLE_TYPE_MAX                // 5
+typedef /*enum*/ MonoGCHandleType GCHandleType;
 
 #define GC_HANDLE_TYPE_IS_WEAK(x) ((x) <= HANDLE_WEAK_TRACK)
 


### PR DESCRIPTION
MonoGCHandleType is public, rarely used, slightly out of date.
GCHandleType is authoritative, correct, heavily used.

However, we don't want to ship additional files,
 and we don't want to expose a name without "Mono" prefix,
 and profiler should not maybe include any more,
 so now MonoGCHandleType is authoritative and correct,
 and GCHandleType aliases it.

Just keeping them in sync is fragile and would
 require casting in C++. Much better to actually
 have one type, with perhaps multiple names.

Spell out enum values for easier to read headers.
Maintenance is slighty more difficult but a good trade off for reading.
Avoid duplicate values in enum type so debugger has only once choice to show.