### PR TITLE
[runtime] Put multiple assemblies in one native library

### DIFF
--- a/mono/mini/aot-compiler.h
+++ b/mono/mini/aot-compiler.h
@@ -12,6 +12,10 @@ int mono_compile_deferred_assemblies (guint32 opts, const char *aot_options, gpo
 void* mono_aot_readonly_field_override (MonoClassField *field);
 gboolean mono_aot_is_shared_got_offset (int offset) MONO_LLVM_INTERNAL;
 
+gpointer mono_merge_assembly_start (const char *output_name);
+void mono_merge_assembly_iter (gpointer pstate, MonoAssembly *assm);
+void mono_merge_assembly_finish (gpointer pstate);
+
 guint32  mono_aot_get_got_offset            (MonoJumpInfo *ji) MONO_LLVM_INTERNAL;
 char*    mono_aot_get_method_name           (MonoCompile *cfg) MONO_LLVM_INTERNAL;
 char*    mono_aot_get_mangled_method_name   (MonoMethod *method) MONO_LLVM_INTERNAL;

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -2404,6 +2404,29 @@ if (container_assm_name && !container_amodule) {
 	}
 }
 
+void
+mono_aot_register_modules_in_file (char *filename)
+{
+	char *err;
+	MonoDl *merged_modules = mono_dl_open (filename, MONO_DL_LAZY, &err);
+	if (!merged_modules)
+		g_error (err);
+
+	MonoAotFileInfo ***aot_file_infos;
+	find_symbol (merged_modules, NULL, "mono_aot_modules", (gpointer *) &aot_file_infos);
+
+	g_assert (aot_file_infos);
+
+	while (*aot_file_infos != NULL) {
+		MonoAotFileInfo *info = **aot_file_infos;
+		aot_file_infos++;
+
+		// Make this aot module available when loading an assembly later
+		mono_aot_register_module ((gpointer) info);
+	}
+}
+
+
 /*
  * mono_aot_register_module:
  *

--- a/mono/mini/aot-runtime.h
+++ b/mono/mini/aot-runtime.h
@@ -254,6 +254,8 @@ GHashTable *mono_aot_get_weak_field_indexes (MonoImage *image);
 /* This is an exported function */
 MONO_API void     mono_aot_register_module           (gpointer *aot_info);
 
+void              mono_aot_register_modules_in_file   (char *filename);
+
 /* These are used to load the AOT data for aot images compiled with MONO_AOT_FILE_FLAG_SEPARATE_DATA */
 /*
  * Return the AOT data for ASSEMBLY. SIZE is the size of the data. OUT_HANDLE should be set to a handle which is later

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -99,7 +99,10 @@
 static guint32 default_opt = 0;
 static gboolean default_opt_set = FALSE;
 
+/* If this is set, we are compiling assemblies to AOT native libraries */
 gboolean mono_compile_aot = FALSE;
+/* If this is set, we are linking static AOT native libraries into a dynamic AOT library */
+char *mono_merge_aot = NULL;
 /* If this is set, no code is generated dynamically, everything is taken from AOT files */
 gboolean mono_aot_only = FALSE;
 /* Same as mono_aot_only, but only LLVM compiled code is used, no trampolines */

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -334,6 +334,7 @@ struct MonoJumpInfo {
 };
 
 extern gboolean mono_break_on_exc;
+extern char *mono_merge_aot;
 extern gboolean mono_compile_aot;
 extern gboolean mono_aot_only;
 extern gboolean mono_llvm_only;


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/6370

In certain situations it is desirable to only ship a single native
library containing all of an application's AOT code. This is done
here by creating a library which statically AOTs all of the assemblies
and embeds them in an array that the runtime can look up.

Now a design issue around finding this native library arises. We
currently discover dynamic libraries by looking for files with names
that look like the names of the relevant managed files. When you have many
managed files that are associated with a single native library,
most external solutions result in dependence on library loading order.

I thought it useful to load these static libraries using the API
endpoint that mono typically registers static native libraries with.

Usage:

Let's make two sample assemblies, one of which depends on the other
```
$> echo '''
using System;

public class FooTwo {
	public static void MainTwo (string[] args) {
		Console.WriteLine ("foobarTwo!");
	}
}
''' > FooTwo.cs
```
```
$> echo '''
public class Foo {
	public static void Main (string[] args) {
		FooTwo.MainTwo (args);
	}
}
''' > Foo.cs
```
```
$> mcs FooTwo.cs -t:library
$> mcs Foo.cs /reference:FooTwo.dll
```

Let's AOT them
```
$> mono --aot=static,full FooTwo.dll
$> mono --aot=static,full Foo.exe
```
Let's merge the two static AOT copies to make a dynamic library
```
$> mono --aot-merge=FooMerged FooTwo.dll Foo.exe
```
Let's remove the object files to make sure we're definitely getting the
code from our joined module
```
$> rm Foo.* FooTwo.*
```
Let's load the entry point in full aot mode, and watch the runtime find
AOT'ed code in the merged module
```
$> mono  --aot-preload=FooMerged.dylib --full-aot Foo.exe
```
You should see the textual output, rather than the error about
missing native code.