### PR TITLE
[2017-12] [sgen] Use sgen_is_object_alive_for_current_gen () instead of sgen_is_object_alive (), the latter doesn't work for oldspace objects, causing the gc handle to be freed even through the object is still alive.

### DIFF
--- a/mono/sgen/sgen-gchandles.c
+++ b/mono/sgen/sgen-gchandles.c
@@ -407,7 +407,7 @@ scan_for_weak (gpointer hidden, GCHandleType handle_type, int max_generation, gp
 	GCObject *obj = (GCObject *)MONO_GC_REVEAL_POINTER (hidden, is_weak);
 
 	/* If the object is dead we free the gc handle */
-	if (!sgen_is_object_alive (obj))
+	if (!sgen_is_object_alive_for_current_gen (obj))
 		return NULL;
 
 	/* Relocate it */
@@ -421,7 +421,7 @@ scan_for_weak (gpointer hidden, GCHandleType handle_type, int max_generation, gp
 			GCObject *field = *addr;
 
 			/* if the object in the weak field is alive, we relocate it */
-			if (field && sgen_is_object_alive (field))
+			if (field && sgen_is_object_alive_for_current_gen (field))
 				ctx->ops->copy_or_mark_object (addr, ctx->queue);
 			else
 				*addr = NULL;


### PR DESCRIPTION
Backport of PR #6501 to 2017-12.

/cc @marek-safar