### PR TITLE
[System]: Use WebClient from CoreFX.

### DIFF
--- a/mcs/class/System/System_xtest.dll.sources
+++ b/mcs/class/System/System_xtest.dll.sources
@@ -34,7 +34,7 @@ System/RemoteExecutorTests.cs
 #../../../external/corefx/src/System.Net.NameResolution/tests/FunctionalTests/*.cs
 
 # System.Net.WebClient
-#../../../external/corefx/src/System.Net.WebClient/tests/*.cs
+../../../external/corefx/src/System.Net.WebClient/tests/*.cs
 
 # System.Net.Security
 ../../../external/corefx/src/Common/tests/System/Net/SslProtocolSupport.cs

--- a/mcs/class/System/Test/System.Net/WebClientTest.cs
+++ b/mcs/class/System/Test/System.Net/WebClientTest.cs
@@ -1035,7 +1035,7 @@ namespace MonoTests.System.Net
 				Assert.IsNull (ex.InnerException, "#3");
 				Assert.IsNotNull (ex.Message, "#4");
 				Assert.IsNotNull (ex.ParamName, "#5");
-				Assert.AreEqual ("path", ex.ParamName, "#6");
+				Assert.AreEqual ("address", ex.ParamName, "#6");
 			}
 		}
 

--- a/mcs/class/System/Test/System.Net/WebClientTest.cs
+++ b/mcs/class/System/Test/System.Net/WebClientTest.cs
@@ -23,25 +23,6 @@ namespace MonoTests.System.Net
 	[TestFixture]
 	public class WebClientTest
 	{
-		private string _tempFolder;
-
-		[SetUp]
-		public void SetUp ()
-		{
-			_tempFolder = Path.Combine (Path.GetTempPath (),
-				GetType ().FullName);
-			if (Directory.Exists (_tempFolder))
-				Directory.Delete (_tempFolder, true);
-			Directory.CreateDirectory (_tempFolder);
-		}
-
-		[TearDown]
-		public void TearDown ()
-		{
-			if (Directory.Exists (_tempFolder))
-				Directory.Delete (_tempFolder, true);
-		}
-
 		[Test]
 #if FEATURE_NO_BSD_SOCKETS
 		[ExpectedException (typeof (WebException))] // Something catches the PlatformNotSupportedException and re-throws an WebException
@@ -840,8 +821,7 @@ namespace MonoTests.System.Net
 		[Test] // UploadFile (string, string)
 		public void UploadFile1_Address_Null ()
 		{
-			string tempFile = Path.Combine (_tempFolder, "upload.tmp");
-			File.Create (tempFile).Close ();
+			string tempFile = Path.GetTempFileName ();
 
 			WebClient wc = new WebClient ();
 			try {
@@ -853,14 +833,16 @@ namespace MonoTests.System.Net
 				Assert.IsNotNull (ex.Message, "#4");
 				Assert.IsNotNull (ex.ParamName, "#5");
 				Assert.AreEqual ("address", ex.ParamName, "#6");
+			} finally {
+				if (File.Exists (tempFile))
+					File.Delete (tempFile);
 			}
 		}
 
 		[Test] // UploadFile (string, string)
 		public void UploadFile1_Address_SchemeNotSupported ()
 		{
-			string tempFile = Path.Combine (_tempFolder, "upload.tmp");
-			File.Create (tempFile).Close ();
+			string tempFile = Path.GetTempFileName ();
 
 			WebClient wc = new WebClient ();
 			try {
@@ -880,13 +862,16 @@ namespace MonoTests.System.Net
 				Assert.AreEqual (typeof (NotSupportedException), inner.GetType (), "#7");
 				Assert.IsNull (inner.InnerException, "#8");
 				Assert.IsNotNull (inner.Message, "#9");
+			} finally {
+				if (File.Exists (tempFile))
+					File.Delete (tempFile);
 			}
 		}
 
 		[Test] // UploadFile (string, string)
 		public void UploadFile1_FileName_NotFound ()
 		{
-			string tempFile = Path.Combine (_tempFolder, "upload.tmp");
+			string tempFile = Path.GetRandomFileName ();
 
 			WebClient wc = new WebClient ();
 			try {
@@ -932,7 +917,7 @@ namespace MonoTests.System.Net
 		[Test] // UploadFile (Uri, string)
 		public void UploadFile2_Address_Null ()
 		{
-			string tempFile = Path.Combine (_tempFolder, "upload.tmp");
+			string tempFile = Path.GetRandomFileName ();
 
 			WebClient wc = new WebClient ();
 			try {
@@ -950,8 +935,7 @@ namespace MonoTests.System.Net
 		[Test] // UploadFile (Uri, string)
 		public void UploadFile2_Address_SchemeNotSupported ()
 		{
-			string tempFile = Path.Combine (_tempFolder, "upload.tmp");
-			File.Create (tempFile).Close ();
+			string tempFile = Path.GetTempFileName ();
 
 			WebClient wc = new WebClient ();
 			try {
@@ -971,13 +955,16 @@ namespace MonoTests.System.Net
 				Assert.AreEqual (typeof (NotSupportedException), inner.GetType (), "#7");
 				Assert.IsNull (inner.InnerException, "#8");
 				Assert.IsNotNull (inner.Message, "#9");
+			} finally {
+				if (File.Exists (tempFile))
+					File.Delete (tempFile);
 			}
 		}
 
 		[Test] // UploadFile (Uri, string)
 		public void UploadFile2_FileName_NotFound ()
 		{
-			string tempFile = Path.Combine (_tempFolder, "upload.tmp");
+			string tempFile = Path.GetRandomFileName ();
 
 			WebClient wc = new WebClient ();
 			try {
@@ -1023,8 +1010,7 @@ namespace MonoTests.System.Net
 		[Test] // UploadFile (string, string, string)
 		public void UploadFile3_Address_Null ()
 		{
-			string tempFile = Path.Combine (_tempFolder, "upload.tmp");
-			File.Create (tempFile).Close ();
+			string tempFile = Path.GetRandomFileName ();
 
 			WebClient wc = new WebClient ();
 			try {
@@ -1042,8 +1028,7 @@ namespace MonoTests.System.Net
 		[Test] // UploadFile (string, string, string)
 		public void UploadFile3_Address_SchemeNotSupported ()
 		{
-			string tempFile = Path.Combine (_tempFolder, "upload.tmp");
-			File.Create (tempFile).Close ();
+			string tempFile = Path.GetTempFileName ();
 
 			WebClient wc = new WebClient ();
 			try {
@@ -1063,13 +1048,16 @@ namespace MonoTests.System.Net
 				Assert.AreEqual (typeof (NotSupportedException), inner.GetType (), "#7");
 				Assert.IsNull (inner.InnerException, "#8");
 				Assert.IsNotNull (inner.Message, "#9");
+			} finally {
+				if (File.Exists (tempFile))
+					File.Delete (tempFile);
 			}
 		}
 
 		[Test] // UploadFile (string, string, string)
 		public void UploadFile3_FileName_NotFound ()
 		{
-			string tempFile = Path.Combine (_tempFolder, "upload.tmp");
+			string tempFile = Path.GetRandomFileName ();
 
 			WebClient wc = new WebClient ();
 			try {
@@ -1115,7 +1103,7 @@ namespace MonoTests.System.Net
 		[Test] // UploadFile (Uri, string, string)
 		public void UploadFile4_Address_Null ()
 		{
-			string tempFile = Path.Combine (_tempFolder, "upload.tmp");
+			string tempFile = Path.GetRandomFileName ();
 
 			WebClient wc = new WebClient ();
 			try {
@@ -1133,8 +1121,7 @@ namespace MonoTests.System.Net
 		[Test] // UploadFile (Uri, string, string)
 		public void UploadFile4_Address_SchemeNotSupported ()
 		{
-			string tempFile = Path.Combine (_tempFolder, "upload.tmp");
-			File.Create (tempFile).Close ();
+			string tempFile = Path.GetTempFileName ();
 
 			WebClient wc = new WebClient ();
 			try {
@@ -1154,13 +1141,16 @@ namespace MonoTests.System.Net
 				Assert.AreEqual (typeof (NotSupportedException), inner.GetType (), "#7");
 				Assert.IsNull (inner.InnerException, "#8");
 				Assert.IsNotNull (inner.Message, "#9");
+			} finally {
+				if (File.Exists (tempFile))
+					File.Delete (tempFile);
 			}
 		}
 
 		[Test] // UploadFile (Uri, string, string)
 		public void UploadFile4_FileName_NotFound ()
 		{
-			string tempFile = Path.Combine (_tempFolder, "upload.tmp");
+			string tempFile = Path.GetRandomFileName ();
 
 			WebClient wc = new WebClient ();
 			try {
@@ -1871,8 +1861,7 @@ namespace MonoTests.System.Net
 		{
 			UploadAsyncCancelEventTest (9304,(webClient, uri, cancelEvent) =>
 			{
-				string tempFile = Path.Combine (_tempFolder, "upload.tmp");
-				File.Create (tempFile).Close ();
+				string tempFile = Path.GetTempFileName ();
 
 				webClient.UploadFileCompleted += (sender, args) =>
 				{

--- a/mcs/class/System/Test/System.Net/WebClientTest.cs
+++ b/mcs/class/System/Test/System.Net/WebClientTest.cs
@@ -871,7 +871,8 @@ namespace MonoTests.System.Net
 		[Test] // UploadFile (string, string)
 		public void UploadFile1_FileName_NotFound ()
 		{
-			string tempFile = Path.GetRandomFileName ();
+			var tempPath = Path.GetTempPath ();
+			string tempFile = Path.Combine (tempPath, Path.GetRandomFileName ());
 
 			WebClient wc = new WebClient ();
 			try {
@@ -964,7 +965,8 @@ namespace MonoTests.System.Net
 		[Test] // UploadFile (Uri, string)
 		public void UploadFile2_FileName_NotFound ()
 		{
-			string tempFile = Path.GetRandomFileName ();
+			var tempPath = Path.GetTempPath ();
+			string tempFile = Path.Combine (tempPath, Path.GetRandomFileName ());
 
 			WebClient wc = new WebClient ();
 			try {
@@ -1057,7 +1059,8 @@ namespace MonoTests.System.Net
 		[Test] // UploadFile (string, string, string)
 		public void UploadFile3_FileName_NotFound ()
 		{
-			string tempFile = Path.GetRandomFileName ();
+			var tempPath = Path.GetTempPath ();
+			string tempFile = Path.Combine (tempPath, Path.GetRandomFileName ());
 
 			WebClient wc = new WebClient ();
 			try {
@@ -1150,7 +1153,8 @@ namespace MonoTests.System.Net
 		[Test] // UploadFile (Uri, string, string)
 		public void UploadFile4_FileName_NotFound ()
 		{
-			string tempFile = Path.GetRandomFileName ();
+			var tempPath = Path.GetTempPath ();
+			string tempFile = Path.Combine (tempPath, Path.GetRandomFileName ());
 
 			WebClient wc = new WebClient ();
 			try {

--- a/mcs/class/System/common.sources
+++ b/mcs/class/System/common.sources
@@ -694,7 +694,6 @@ ReferenceSources/Win32Exception.cs
 ../referencesource/System/net/System/Net/ServicePointManager.cs
 ../referencesource/System/net/System/Net/SocketAddress.cs
 ../referencesource/System/net/System/Net/SocketException.cs
-../referencesource/System/net/System/Net/webclient.cs
 ../referencesource/System/net/System/Net/WebException.cs
 ../referencesource/System/net/System/Net/WebExceptionStatus.cs
 ../referencesource/System/net/System/Net/WebHeaderCollection.cs
@@ -704,7 +703,6 @@ ReferenceSources/Win32Exception.cs
 ../referencesource/System/net/System/Net/WebRequest.cs
 ../referencesource/System/net/System/Net/WebResponse.cs
 ../referencesource/System/net/System/Net/WebUtility.cs
-../referencesource/System/net/System/Net/WriteStreamClosedEventArgs.cs
 
 ../referencesource/System/net/System/Net/Cache/RequestCache.cs
 ../referencesource/System/net/System/Net/Cache/RequestCacheEntry.cs
@@ -864,6 +862,9 @@ corefx/SR.cs
 ../../../external/corefx/src/Common/src/System/Collections/Generic/EnumerableHelpers.cs
 ../../../external/corefx/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
 
+../../../external/corefx/src/Common/src/System/IO/DelegatingStream.cs
+../../../external/corefx/src/Common/src/System/IO/ChunkedMemoryStream.cs
+
 ../../../external/corefx/src/Common/src/System/Net/HttpStatusDescription.cs
 ../../../external/corefx/src/Common/src/System/Net/SecurityProtocol.cs
 ../../../external/corefx/src/Common/src/System/Net/UriScheme.cs
@@ -921,6 +922,8 @@ corefx/SR.cs
 ../../../external/corefx/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
 
 ../../../external/corefx/src/System.Net.WebSockets.WebSocketProtocol/src/System/Net/WebSockets/ManagedWebSocket.netstandard.cs
+
+../../../external/corefx/src/System.Net.WebClient/src/System/Net/WebClient.cs
 
 ../../../external/corefx/src/System.Private.Uri/src/System/UriBuilder.cs
 


### PR DESCRIPTION
The CoreFX version has a few error checks which are not in the
referencesource, switching to CoreFX allows us to enable their tests.