### PR TITLE
Fixed markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,7 +541,7 @@ file for information about Microsoft's patent grant.
 Mono Trademark Use Policy
 =========================
 
-The use of trademarks and logos for Mono can be found [here] (http://www.dotnetfoundation.org/legal/mono-tm). 
+The use of trademarks and logos for Mono can be found [here](http://www.dotnetfoundation.org/legal/mono-tm). 
 
 Maintaining the Class Library Solution Files
 ============================================


### PR DESCRIPTION
Looks like there has been added an unintentional space between link title, and the href.
I've fixed it in this small PR. 👍 