### PR TITLE
[2017-12] Revert "[mini] Align stack when resuming to catch handler"

### DIFF
--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2234,11 +2234,6 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 #endif
 					} else {
 						MONO_CONTEXT_SET_IP (ctx, ei->handler_start);
-						/*
-						 * When the exception is thrown in async fashion, we can have the stack pointer
-						 * unaligned. Make sure we resume to the catch handler with an aligned stack.
-						 */
-						MONO_CONTEXT_SET_SP (ctx, (mgreg_t)MONO_CONTEXT_GET_SP (ctx) & ~(MONO_ARCH_FRAME_ALIGNMENT - 1));
 					}
 					mono_set_lmf (lmf);
 #ifndef DISABLE_PERFCOUNTERS


### PR DESCRIPTION
Backport of #6717.

/cc @marek-safar