### PR TITLE
[sgen] Don't report gc_resize profiler events from worker threads.

### DIFF
--- a/mono/metadata/sgen-client-mono.h
+++ b/mono/metadata/sgen-client-mono.h
@@ -77,6 +77,7 @@ struct _SgenClientThreadInfo {
 
 extern void mono_sgen_register_moved_object (void *obj, void *destination);
 extern void mono_sgen_gc_event_moves (void);
+extern void mono_sgen_gc_event_resize (void);
 
 extern void mono_sgen_init_stw (void);
 

--- a/mono/metadata/sgen-stw.c
+++ b/mono/metadata/sgen-stw.c
@@ -151,6 +151,9 @@ sgen_client_restart_world (int generation, gboolean serial_collection, gint64 *s
 	if (MONO_PROFILER_ENABLED (gc_moves))
 		mono_sgen_gc_event_moves ();
 
+	if (MONO_PROFILER_ENABLED (gc_resize))
+		mono_sgen_gc_event_resize ();
+
 	MONO_PROFILER_RAISE (gc_event, (MONO_GC_EVENT_PRE_START_WORLD, generation));
 	MONO_PROFILER_RAISE (gc_event2, (MONO_GC_EVENT_PRE_START_WORLD, generation, serial_collection));
 


### PR DESCRIPTION
See 4acc3df for why this is problematic. The bug was introduced in d7ac79c.

This fixes an occasional deadlock in the profiler stress tests.

Also some improvements to the profiler stress test runner to make it easier to work with.