### PR TITLE
[mkbundle] Fix generated file when passing --bundled-header

### DIFF
--- a/mcs/tools/mkbundle/mkbundle.cs
+++ b/mcs/tools/mkbundle/mkbundle.cs
@@ -821,6 +821,11 @@ typedef struct {
 void          mono_register_bundled_assemblies (const MonoBundledAssembly **assemblies);
 void          mono_register_config_for_assembly (const char* assembly_name, const char* config_xml);
 ");
+
+				// These values are part of the public API, so they are expected not to change
+				tc.WriteLine("#define MONO_AOT_MODE_NORMAL 1");
+				tc.WriteLine("#define MONO_AOT_MODE_FULL 3");
+				tc.WriteLine("#define MONO_AOT_MODE_LLVMONLY 4");
 			} else {
 				tc.WriteLine ("#include <mono/metadata/mono-config.h>");
 				tc.WriteLine ("#include <mono/metadata/assembly.h>\n");


### PR DESCRIPTION
There would be a compilation error in the XA build as follow:

```
obj/Release/bundles/armeabi-v7a/temp.c: In function 'install_aot_modules':
obj/Release/bundles/armeabi-v7a/temp.c:49:25: error: 'MONO_AOT_MODE_NORMAL' undeclared (first use in this function)
  mono_jit_set_aot_mode (MONO_AOT_MODE_NORMAL);
                         ^
obj/Release/bundles/armeabi-v7a/temp.c:49:25: note: each undeclared identifier is reported only once for each function it appears in
```