### PR TITLE
[System]: Minor web stack cleanups to make some of the corefx tests pass.

### DIFF
--- a/mcs/class/System/System.Net/HttpWebRequest.cs
+++ b/mcs/class/System/System.Net/HttpWebRequest.cs
@@ -68,7 +68,7 @@ namespace System.Net
 		bool hostChanged;
 		bool allowAutoRedirect = true;
 		bool allowBuffering = true;
-		bool allowReadStreamBuffering = false;
+		bool allowReadStreamBuffering;
 		X509CertificateCollection certificates;
 		string connectionGroup;
 		bool haveContentLength;

--- a/mcs/class/System/System.Net/HttpWebResponse.cs
+++ b/mcs/class/System/System.Net/HttpWebResponse.cs
@@ -168,6 +168,8 @@ namespace System.Net
 
 				if (contentType == null)
 					contentType = webHeaders ["Content-Type"];
+				if (contentType == null)
+					contentType = string.Empty;
 
 				return contentType;
 			}

--- a/mcs/class/System/System.Net/WebConnectionStream.cs
+++ b/mcs/class/System/System.Net/WebConnectionStream.cs
@@ -227,6 +227,13 @@ namespace System.Net
 		{
 		}
 
+		public override Task FlushAsync (CancellationToken cancellationToken)
+		{
+			return cancellationToken.IsCancellationRequested ?
+			    Task.FromCancellation (cancellationToken) :
+			    Task.CompletedTask;
+		}
+
 		internal void InternalClose ()
 		{
 			disposed = true;

--- a/mcs/class/System/System.Net/WebConnectionStream.cs
+++ b/mcs/class/System/System.Net/WebConnectionStream.cs
@@ -115,7 +115,7 @@ namespace System.Net
 			return e;
 		}
 
-		public override int Read (byte[] buffer, int offset, int size)
+		public override int Read (byte[] buffer, int offset, int count)
 		{
 			if (!CanRead)
 				throw new NotSupportedException (SR.net_writeonlystream);
@@ -127,17 +127,17 @@ namespace System.Net
 			int length = buffer.Length;
 			if (offset < 0 || length < offset)
 				throw new ArgumentOutOfRangeException (nameof (offset));
-			if (size < 0 || (length - offset) < size)
-				throw new ArgumentOutOfRangeException (nameof (size));
+			if (count < 0 || (length - offset) < count)
+				throw new ArgumentOutOfRangeException (nameof (count));
 
 			try {
-				return ReadAsync (buffer, offset, size, CancellationToken.None).Result;
+				return ReadAsync (buffer, offset, count, CancellationToken.None).Result;
 			} catch (Exception e) {
 				throw GetException (e);
 			}
 		}
 
-		public override IAsyncResult BeginRead (byte[] buffer, int offset, int size,
+		public override IAsyncResult BeginRead (byte[] buffer, int offset, int count,
 							AsyncCallback cb, object state)
 		{
 			if (!CanRead)
@@ -150,10 +150,10 @@ namespace System.Net
 			int length = buffer.Length;
 			if (offset < 0 || length < offset)
 				throw new ArgumentOutOfRangeException (nameof (offset));
-			if (size < 0 || (length - offset) < size)
-				throw new ArgumentOutOfRangeException (nameof (size));
+			if (count < 0 || (length - offset) < count)
+				throw new ArgumentOutOfRangeException (nameof (count));
 
-			var task = ReadAsync (buffer, offset, size, CancellationToken.None);
+			var task = ReadAsync (buffer, offset, count, CancellationToken.None);
 			return TaskToApm.Begin (task, cb, state);
 		}
 
@@ -169,7 +169,7 @@ namespace System.Net
 			}
 		}
 
-		public override IAsyncResult BeginWrite (byte[] buffer, int offset, int size,
+		public override IAsyncResult BeginWrite (byte[] buffer, int offset, int count,
 							 AsyncCallback cb, object state)
 		{
 			if (!CanWrite)
@@ -182,10 +182,10 @@ namespace System.Net
 			int length = buffer.Length;
 			if (offset < 0 || length < offset)
 				throw new ArgumentOutOfRangeException (nameof (offset));
-			if (size < 0 || (length - offset) < size)
-				throw new ArgumentOutOfRangeException (nameof (size));
+			if (count < 0 || (length - offset) < count)
+				throw new ArgumentOutOfRangeException (nameof (count));
 
-			var task = WriteAsync (buffer, offset, size, CancellationToken.None);
+			var task = WriteAsync (buffer, offset, count, CancellationToken.None);
 			return TaskToApm.Begin (task, cb, state);
 		}
 
@@ -201,7 +201,7 @@ namespace System.Net
 			}
 		}
 
-		public override void Write (byte[] buffer, int offset, int size)
+		public override void Write (byte[] buffer, int offset, int count)
 		{
 			if (!CanWrite)
 				throw new NotSupportedException (SR.net_readonlystream);
@@ -213,11 +213,11 @@ namespace System.Net
 			int length = buffer.Length;
 			if (offset < 0 || length < offset)
 				throw new ArgumentOutOfRangeException (nameof (offset));
-			if (size < 0 || (length - offset) < size)
-				throw new ArgumentOutOfRangeException (nameof (size));
+			if (count < 0 || (length - offset) < count)
+				throw new ArgumentOutOfRangeException (nameof (count));
 
 			try {
-				WriteAsync (buffer, offset, size).Wait ();
+				WriteAsync (buffer, offset, count).Wait ();
 			} catch (Exception e) {
 				throw GetException (e);
 			}

--- a/mcs/class/System/System.Net/WebOperation.cs
+++ b/mcs/class/System/System.Net/WebOperation.cs
@@ -215,7 +215,12 @@ namespace System.Net
 			}
 		}
 
-		public Task<WebRequestStream> GetRequestStream ()
+		public async Task<Stream> GetRequestStream ()
+		{
+			return await requestTask.Task.ConfigureAwait (false);
+		}
+
+		internal Task<WebRequestStream> GetRequestStreamInternal ()
 		{
 			return requestTask.Task;
 		}

--- a/mcs/class/System/System.Net/WebRequestStream.cs
+++ b/mcs/class/System/System.Net/WebRequestStream.cs
@@ -131,28 +131,38 @@ namespace System.Net
 			Operation.CompleteRequestWritten (this);
 		}
 
-		public override async Task WriteAsync (byte[] buffer, int offset, int size, CancellationToken cancellationToken)
+		public override Task WriteAsync (byte[] buffer, int offset, int count, CancellationToken cancellationToken)
 		{
-			WebConnection.Debug ($"{ME} WRITE ASYNC: {buffer.Length}/{offset}/{size}");
-
-			Operation.ThrowIfClosedOrDisposed (cancellationToken);
-
-			if (Operation.WriteBuffer != null)
-				throw new InvalidOperationException ();
-
 			if (buffer == null)
 				throw new ArgumentNullException (nameof (buffer));
 
 			int length = buffer.Length;
 			if (offset < 0 || length < offset)
 				throw new ArgumentOutOfRangeException (nameof (offset));
-			if (size < 0 || (length - offset) < size)
-				throw new ArgumentOutOfRangeException (nameof (size));
+			if (count < 0 || (length - offset) < count)
+				throw new ArgumentOutOfRangeException (nameof (count));
+
+			WebConnection.Debug ($"{ME} WRITE ASYNC: {buffer.Length}/{offset}/{count}");
+
+			if (cancellationToken.IsCancellationRequested)
+				return Task.FromCanceled (cancellationToken);
+
+			Operation.ThrowIfClosedOrDisposed (cancellationToken);
+
+			if (Operation.WriteBuffer != null)
+				throw new InvalidOperationException ();
 
 			var myWriteTcs = new TaskCompletionSource<int> ();
 			if (Interlocked.CompareExchange (ref pendingWrite, myWriteTcs, null) != null)
 				throw new InvalidOperationException (SR.GetString (SR.net_repcall));
 
+			return WriteAsyncInner (buffer, offset, count, myWriteTcs, cancellationToken);
+		}
+
+		async Task WriteAsyncInner (byte[] buffer, int offset, int size,
+		                            TaskCompletionSource<int> myWriteTcs,
+		                            CancellationToken cancellationToken)
+		{
 			try {
 				await ProcessWrite (buffer, offset, size, cancellationToken).ConfigureAwait (false);
 

--- a/mcs/class/System/System.Net/WebResponseStream.cs
+++ b/mcs/class/System/System.Net/WebResponseStream.cs
@@ -108,7 +108,7 @@ namespace System.Net
 			private set;
 		}
 
-		public override async Task<int> ReadAsync (byte[] buffer, int offset, int size, CancellationToken cancellationToken)
+		public override async Task<int> ReadAsync (byte[] buffer, int offset, int count, CancellationToken cancellationToken)
 		{
 			WebConnection.Debug ($"{ME} READ ASYNC");
 
@@ -120,8 +120,8 @@ namespace System.Net
 			int length = buffer.Length;
 			if (offset < 0 || length < offset)
 				throw new ArgumentOutOfRangeException (nameof (offset));
-			if (size < 0 || (length - offset) < size)
-				throw new ArgumentOutOfRangeException (nameof (size));
+			if (count < 0 || (length - offset) < count)
+				throw new ArgumentOutOfRangeException (nameof (count));
 
 			if (Interlocked.CompareExchange (ref nestedRead, 1, 0) != 0)
 				throw new InvalidOperationException ("Invalid nested call.");
@@ -146,7 +146,7 @@ namespace System.Net
 			try {
 				// FIXME: NetworkStream.ReadAsync() does not support cancellation.
 				(oldBytes, nbytes) = await HttpWebRequest.RunWithTimeout (
-					ct => ProcessRead (buffer, offset, size, ct),
+					ct => ProcessRead (buffer, offset, count, ct),
 					ReadTimeout, () => {
 						Operation.Abort ();
 						InnerStream.Dispose ();
@@ -509,7 +509,7 @@ namespace System.Net
 			Operation.CompleteResponseRead (true);
 		}
 
-		public override Task WriteAsync (byte[] buffer, int offset, int size, CancellationToken cancellationToken)
+		public override Task WriteAsync (byte[] buffer, int offset, int count, CancellationToken cancellationToken)
 		{
 			return Task.FromException (new NotSupportedException (SR.net_readonlystream));
 		}

--- a/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
@@ -2642,21 +2642,6 @@ namespace MonoTests.System.Net
 			}
 		}
 
-		[Test]
-#if FEATURE_NO_BSD_SOCKETS
-		[ExpectedException (typeof (PlatformNotSupportedException))]
-#endif
-		public void AllowReadStreamBuffering ()
-		{
-			var hr = WebRequest.CreateHttp ("http://www.google.com");
-			Assert.IsFalse (hr.AllowReadStreamBuffering, "#1");
-			try {
-				hr.AllowReadStreamBuffering = true;
-				Assert.Fail ("#2");
-			} catch (InvalidOperationException) {
-			}
-		}
-
 		class ListenerScope : IDisposable {
 			EventWaitHandle completed;
 			public HttpListener listener;
@@ -3253,7 +3238,7 @@ namespace MonoTests.System.Net
 						Assert.AreEqual (typeof (ArgumentOutOfRangeException), ex.GetType (), "#A2");
 						Assert.IsNull (ex.InnerException, "#A3");
 						Assert.IsNotNull (ex.Message, "#A4");
-						Assert.AreEqual ("size", ex.ParamName, "#A5");
+						Assert.AreEqual ("count", ex.ParamName, "#A5");
 					}
 				}
 
@@ -3284,7 +3269,7 @@ namespace MonoTests.System.Net
 						Assert.AreEqual (typeof (ArgumentOutOfRangeException), ex.GetType (), "#2");
 						Assert.IsNull (ex.InnerException, "#3");
 						Assert.IsNotNull (ex.Message, "#4");
-						Assert.AreEqual ("size", ex.ParamName, "#5");
+						Assert.AreEqual ("count", ex.ParamName, "#5");
 					}
 				}
 

--- a/mcs/class/System/Test/System.Net/HttpWebResponseTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpWebResponseTest.cs
@@ -875,7 +875,7 @@ namespace MonoTests.System.Net
 							Assert.AreEqual (typeof (ArgumentOutOfRangeException), ex.GetType (), "#A2");
 							Assert.IsNull (ex.InnerException, "#A3");
 							Assert.IsNotNull (ex.Message, "#A4");
-							Assert.AreEqual ("size", ex.ParamName, "#A5");
+							Assert.AreEqual ("count", ex.ParamName, "#A5");
 						}
 
 						// read full response
@@ -890,7 +890,7 @@ namespace MonoTests.System.Net
 							Assert.AreEqual (typeof (ArgumentOutOfRangeException), ex.GetType (), "#B2");
 							Assert.IsNull (ex.InnerException, "#B3");
 							Assert.IsNotNull (ex.Message, "#B4");
-							Assert.AreEqual ("size", ex.ParamName, "#B5");
+							Assert.AreEqual ("count", ex.ParamName, "#B5");
 						}
 					} finally {
 						rs.Close ();
@@ -928,7 +928,7 @@ namespace MonoTests.System.Net
 							Assert.AreEqual (typeof (ArgumentOutOfRangeException), ex.GetType (), "#A2");
 							Assert.IsNull (ex.InnerException, "#A3");
 							Assert.IsNotNull (ex.Message, "#A4");
-							Assert.AreEqual ("size", ex.ParamName, "#A5");
+							Assert.AreEqual ("count", ex.ParamName, "#A5");
 						}
 
 						// read full response
@@ -943,7 +943,7 @@ namespace MonoTests.System.Net
 							Assert.AreEqual (typeof (ArgumentOutOfRangeException), ex.GetType (), "#B2");
 							Assert.IsNull (ex.InnerException, "#B3");
 							Assert.IsNotNull (ex.Message, "#B4");
-							Assert.AreEqual ("size", ex.ParamName, "#B5");
+							Assert.AreEqual ("count", ex.ParamName, "#B5");
 						}
 					} finally {
 						rs.Close ();


### PR DESCRIPTION
This is not complete yet - the goal is the make the `System.Net.Requests/tests/HttpWebRequestTest.cs` tests pass.

- A few unused properties no longer throw exceptions
- Added a few error checks
- Use `nameof (value)` and name-based `ArgumentException` constructor
- Renamed `size` into `count` where required to match the base class's parameter name
- When called with invalid parameters, throw instead of returning a faulted task

TODO:

1. The logic which protects `BeginGetRequestStream()` / `BeginGetResponse()` and their async variants against being called multiple times is broken.
2. When aborting `BeingGetRequestStream()` / `BeginGetResponse()`, their callback should be called before `Abort()` returns.
3. `GetResponseAsync_UseDefaultCredentials_ExpectSuccess()` hangs
4. Need to check tested behavior in our `HttpWebRequestTest.TestIPv6Host` - when using the implementation from corefx, it now returns ` changed `[2001::1:1:1:157:0]`.
