### PR TITLE
[System]: WebResponseStream now correctly reads the chunk trailer when using gzip/deflate.

### DIFF
--- a/mcs/class/System/System.Net/WebResponseStream.cs
+++ b/mcs/class/System/System.Net/WebResponseStream.cs
@@ -227,7 +227,7 @@ namespace System.Net
 			 */
 
 			WebConnection.Debug ($"{ME} INNER READ - READ CHUNK TRAILER");
-			await innerChunkStream.ReadChunkTrailer (cancellationToken);
+			await innerChunkStream.ReadChunkTrailer (cancellationToken).ConfigureAwait (false);
 			WebConnection.Debug ($"{ME} INNER READ - READ CHUNK TRAILER #DONE");
 
 			return 0;


### PR DESCRIPTION
This should actually fix bug #59779.

When backporting, this needs to be applied on top of PR #6662.