### PR TITLE
[2017-12] [jit] Fix OP_ICONV_TO_OVF_I8_UN, it should use OP_ZEXT_I4 instead of …

### DIFF
--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -145,7 +145,7 @@ decompose_long_opcode (MonoCompile *cfg, MonoInst *ins, MonoInst **repl_ins)
 	case OP_ICONV_TO_OVF_U_UN:
 		/* an unsigned 32 bit num always fits in an (un)signed 64 bit one */
 		/* Clean out the upper word */
-		MONO_EMIT_NEW_BIALU_IMM (cfg, OP_ISHR_UN_IMM, ins->dreg, ins->sreg1, 0);
+		MONO_EMIT_NEW_UNALU (cfg, OP_ZEXT_I4, ins->dreg, ins->sreg1);
 		NULLIFY_INS (ins);
 		break;
 	case OP_LCONV_TO_OVF_I1:

--- a/mono/mini/iltests.il
+++ b/mono/mini/iltests.il
@@ -3119,4 +3119,21 @@ L_3:
 	ldc.i4.0
 	ret
   }
+
+  .method public hidebysig static int32 test_0_github_issue_6721 () cil managed
+  {
+       .maxstack 8
+       ldc.i4.0
+       conv.i8
+       ldc.i4.m1
+       conv.ovf.i8.un
+       sub.ovf
+       ldc.i8 0xffffffff00000001
+       beq.s IL_success
+       ldc.i4.1
+       ret
+       IL_success:
+       ldc.i4.0
+       ret
+  }
 }


### PR DESCRIPTION
Backport of #6753.

/cc @marek-safar