### PR TITLE
[2017-12] Fix a regression introduced by e05343ddf556a554ff9584759ac24610001d711f: Disable the ldobj+stobj optimization for reference types.

### DIFF
--- a/mono/mini/generics.cs
+++ b/mono/mini/generics.cs
@@ -1391,6 +1391,24 @@ class Tests
 
 		return 0;
 	}
+
+	class LdobjStobj {
+		public int counter;
+		public LdobjStobj buffer1;
+		public LdobjStobj buffer2;
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private static void swap<T>(ref T first, ref T second) {
+		second = first;
+	}
+
+	public static int test_42_ldobj_stobj_ref () {
+		var obj = new LdobjStobj ();
+		obj.counter = 42;
+		swap (ref obj.buffer1, ref obj.buffer2);
+		return obj.counter;
+	}
 }
 
 #if !__MOBILE__

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -9744,7 +9744,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			}
 
 			/* Optimize the ldobj+stobj combination */
-			if (((ip [5] == CEE_STOBJ) && ip_in_bb (cfg, cfg->cbb, ip + 5) && read32 (ip + 6) == token)) {
+			if (((ip [5] == CEE_STOBJ) && ip_in_bb (cfg, cfg->cbb, ip + 5) && read32 (ip + 6) == token) && !generic_class_is_reference_type (cfg, klass)) {
 				CHECK_STACK (1);
 
 				sp --;


### PR DESCRIPTION
Backport of #6779.

/cc @marek-safar