### PR TITLE
[ci] Consistently use CI_TAGS instead of label

### DIFF
--- a/packaging/Windows/defs/mono
+++ b/packaging/Windows/defs/mono
@@ -29,7 +29,7 @@ build()
 	pushd ${REPODIR}
 	report "Building Mono"
 	mkdir -p ${INSTALLDIR}
-	EXTRA_CONF_FLAGS="--prefix=${INSTALLDIR}" CI_TAGS="no-tests" label="w32" scripts/ci/run-jenkins.sh || error "*** Could not run autogen ***"
+	EXTRA_CONF_FLAGS="--prefix=${INSTALLDIR}" CI_TAGS="win-i386,no-tests" scripts/ci/run-jenkins.sh || error "*** Could not run autogen ***"
 	popd
 }
 

--- a/packaging/Windows/defs/mono64
+++ b/packaging/Windows/defs/mono64
@@ -29,7 +29,7 @@ build()
 	pushd ${REPODIR}
 	report "Building Mono"
 	mkdir -p ${INSTALLDIR}
-	EXTRA_CONF_FLAGS="--prefix=${INSTALLDIR}" CI_TAGS="no-tests" label="w64" scripts/ci/run-jenkins.sh || error "*** Could not run autogen ***"
+	EXTRA_CONF_FLAGS="--prefix=${INSTALLDIR}" CI_TAGS="win-amd64,no-tests" scripts/ci/run-jenkins.sh || error "*** Could not run autogen ***"
 	popd
 }
 

--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -18,7 +18,7 @@ if [[ ${CI_TAGS} == *'clang-sanitizer'* ]]; then
 	make_timeout=30m
 fi
 
-if [[ ${label} == w* ]]; then
+if [[ ${CI_TAGS} == *'win-'* ]]; then
     # Passing -ggdb3 on Cygwin breaks linking against libmonosgen-x.y.dll
     export CFLAGS="$CFLAGS -g -O2"
 else
@@ -35,10 +35,10 @@ if [[ $CI_TAGS == *'retry-flaky-tests'* ]]; then
     export MONO_FLAKY_TEST_RETRIES=5
 fi
 
-if [[ ${label} == 'osx-i386' ]]; then CFLAGS="$CFLAGS -m32 -arch i386"; LDFLAGS="$LDFLAGS -m32 -arch i386"; EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-libgdiplus=/Library/Frameworks/Mono.framework/Versions/Current/lib/libgdiplus.dylib --host=i386-apple-darwin11.2.0 --build=i386-apple-darwin11.2.0"; fi
-if [[ ${label} == 'osx-amd64' ]]; then CFLAGS="$CFLAGS -m64 -arch x86_64"; LDFLAGS="$LDFLAGS -m64 -arch x86_64" EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-libgdiplus=/Library/Frameworks/Mono.framework/Versions/Current/lib/libgdiplus.dylib"; fi
-if [[ ${label} == 'w32' ]]; then PLATFORM=Win32; EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --host=i686-w64-mingw32"; export MONO_EXECUTABLE="${MONO_REPO_ROOT}/msvc/build/sgen/Win32/bin/Release/mono-sgen.exe"; fi
-if [[ ${label} == 'w64' ]]; then PLATFORM=x64; EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --host=x86_64-w64-mingw32 --disable-boehm"; export MONO_EXECUTABLE="${MONO_REPO_ROOT}/msvc/build/sgen/x64/bin/Release/mono-sgen.exe"; fi
+if [[ ${CI_TAGS} == *'osx-i386'* ]]; then CFLAGS="$CFLAGS -m32 -arch i386"; LDFLAGS="$LDFLAGS -m32 -arch i386"; EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-libgdiplus=/Library/Frameworks/Mono.framework/Versions/Current/lib/libgdiplus.dylib --host=i386-apple-darwin11.2.0 --build=i386-apple-darwin11.2.0"; fi
+if [[ ${CI_TAGS} == *'osx-amd64'* ]]; then CFLAGS="$CFLAGS -m64 -arch x86_64"; LDFLAGS="$LDFLAGS -m64 -arch x86_64" EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-libgdiplus=/Library/Frameworks/Mono.framework/Versions/Current/lib/libgdiplus.dylib"; fi
+if [[ ${CI_TAGS} == *'win-i386'* ]]; then PLATFORM=Win32; EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --host=i686-w64-mingw32"; export MONO_EXECUTABLE="${MONO_REPO_ROOT}/msvc/build/sgen/Win32/bin/Release/mono-sgen.exe"; fi
+if [[ ${CI_TAGS} == *'win-amd64'* ]]; then PLATFORM=x64; EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --host=x86_64-w64-mingw32 --disable-boehm"; export MONO_EXECUTABLE="${MONO_REPO_ROOT}/msvc/build/sgen/x64/bin/Release/mono-sgen.exe"; fi
 
 if [[ ${CI_TAGS} == *'coop-gc'* ]]; then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-cooperative-gc=yes"; fi
 
@@ -57,19 +57,13 @@ elif [[ ${CI_TAGS} == *'winaot'* ]];             then EXTRA_CONF_FLAGS="${EXTRA_
 elif [[ ${CI_TAGS} == *'aot'* ]];                then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-runtime_preset=aot";
 elif [[ ${CI_TAGS} == *'bitcode'* ]];            then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-runtime_preset=bitcode";
 elif [[ ${CI_TAGS} == *'acceptance-tests'* ]];   then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --prefix=${MONO_REPO_ROOT}/tmp/mono-acceptance-tests --with-sgen-default-concurrent=yes";
-elif [[ ${label} != w* ]] && [[ ${label} != 'debian-8-ppc64el' ]] && [[ ${label} != 'centos-s390x' ]] && [[ ${CI_TAGS} != *'monolite'* ]];
-    then
-    # only enable the concurrent collector by default on main unix archs
-    EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-sgen-default-concurrent=yes"
-
-    if [[ ${label} == 'ubuntu-1404-amd64' ]]; then
-        # only enable build of the additional profiles on one architecture to save time
-        EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-runtime_preset=all"
-        # when building profiles like monotouch/monodroid which don't build System.Drawing.dll in the Mono repo we need
-        # to build the facades against _something_ to satisfy the typeforwards. In CI we can cheat a little and pass
-        # them System.Drawing.dll from the 'build' profile since we don't test those profiles here (we just ensure they compile).
-        export EXTERNAL_FACADE_DRAWING_REFERENCE=${MONO_REPO_ROOT}/mcs/class/lib/build/System.Drawing.dll
-    fi
+elif [[ ${CI_TAGS} == *'all-profiles'* ]]; then
+    # only enable build of the additional profiles on one config to save time
+    EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-runtime_preset=all"
+    # when building profiles like monotouch/monodroid which don't build System.Drawing.dll in the Mono repo we need
+    # to build the facades against _something_ to satisfy the typeforwards. In CI we can cheat a little and pass
+    # them System.Drawing.dll from the 'build' profile since we don't test those profiles here (we just ensure they compile).
+    export EXTERNAL_FACADE_DRAWING_REFERENCE=${MONO_REPO_ROOT}/mcs/class/lib/build/System.Drawing.dll
 fi
 
 if [ -x "/usr/bin/dpkg-architecture" ];
@@ -80,7 +74,7 @@ if [ -x "/usr/bin/dpkg-architecture" ];
 	wget -qO- https://download.mono-project.com/test/new-certs.tgz| tar zx -C ~/.config/.mono/
 fi
 
-if [[ ${CI_TAGS} == 'product-sdks' ]];
+if [[ ${CI_TAGS} == *'product-sdks'* ]];
    then
 	   echo "DISABLE_ANDROID=1" > sdks/Make.config
 	   ${TESTCMD} --label=runtimes --timeout=60m --fatal make -j4 -C sdks/builds package-ios-sim64 package-ios-target64
@@ -115,12 +109,12 @@ if [[ ${CI_TAGS} != *'mac-sdk'* ]]; # Mac SDK builds Mono itself
 	then
 	${TESTCMD} --label=configure --timeout=60m --fatal ./autogen.sh $EXTRA_CONF_FLAGS
 fi
-if [[ ${label} == 'w32' ]];
+if [[ ${CI_TAGS} == *'win-i386'* ]];
     then
 	# only build boehm on w32 (only windows platform supporting boehm).
     ${TESTCMD} --label=make-msvc --timeout=60m --fatal /cygdrive/c/Program\ Files\ \(x86\)/MSBuild/14.0/Bin/MSBuild.exe /p:PlatformToolset=v140 /p:Platform=${PLATFORM} /p:Configuration=Release /p:MONO_TARGET_GC=boehm msvc/mono.sln
 fi
-if [[ ${label} == w* ]];
+if [[ ${CI_TAGS} == *'win-'* ]];
     then
     ${TESTCMD} --label=make-msvc-sgen --timeout=60m --fatal /cygdrive/c/Program\ Files\ \(x86\)/MSBuild/14.0/Bin/MSBuild.exe /p:PlatformToolset=v140 /p:Platform=${PLATFORM} /p:Configuration=Release /p:MONO_TARGET_GC=sgen msvc/mono.sln
 fi
@@ -136,7 +130,7 @@ fi
 if [[ ${CI_TAGS} == *'monolite'* ]]; then make get-monolite-latest; fi
 
 make_parallelism=-j4
-if [[ ${label} == 'debian-8-ppc64el' ]]; then make_parallelism=-j1; fi
+if [[ ${CI_TAGS} == *'linux-ppc64el'* ]]; then make_parallelism=-j1; fi
 
 if [[ ${CI_TAGS} != *'mac-sdk'* ]]; # Mac SDK builds Mono itself
 	then

--- a/scripts/ci/run-test-default.sh
+++ b/scripts/ci/run-test-default.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 ${TESTCMD} --label=mini --timeout=5m make -w -C mono/mini -k check check-seq-points EMIT_NUNIT=1
-if [[ ${label} == w* ]]
+if [[ ${CI_TAGS} == *'win-'* ]]
 then ${TESTCMD} --label=aot-test --skip;
 else ${TESTCMD} --label=aot-test --timeout=30m make -w -C mono/tests -j4 -k test-aot
 fi
@@ -17,15 +17,15 @@ ${TESTCMD} --label=compiler --timeout=30m make -w -C mcs/tests run-test
 ${TESTCMD} --label=compiler-errors --timeout=30m make -w -C mcs/errors run-test
 ${TESTCMD} --label=System-xunit --timeout=5m make -w -C mcs/class/System run-xunit-test
 ${TESTCMD} --label=System --timeout=10m bash -c "export MONO_TLS_PROVIDER=legacy && make -w -C mcs/class/System run-test"
-if [[ ${label} == osx-* ]]; then ${TESTCMD} --label=System-btls --timeout=10m bash -c "export MONO_TLS_PROVIDER=btls && make -w -C mcs/class/System run-test"; fi
+if [[ ${CI_TAGS} == *'osx-'* ]]; then ${TESTCMD} --label=System-btls --timeout=10m bash -c "export MONO_TLS_PROVIDER=btls && make -w -C mcs/class/System run-test"; fi
 ${TESTCMD} --label=System.XML --timeout=5m make -w -C mcs/class/System.XML run-test
 ${TESTCMD} --label=Mono.Security --timeout=5m make -w -C mcs/class/Mono.Security run-test
 ${TESTCMD} --label=System.Security --timeout=5m make -w -C mcs/class/System.Security run-test
-if [[ ${label} == w* ]]
+if [[ ${CI_TAGS} == *'win-'* ]]
 then ${TESTCMD} --label=System.Drawing --skip;
 else ${TESTCMD} --label=System.Drawing --timeout=5m make -w -C mcs/class/System.Drawing run-test
 fi
-if [[ ${label} == osx-* ]] || [[ ${label} == w* ]]
+if [[ ${CI_TAGS} == *'osx-'* ]] || [[ ${CI_TAGS} == *'win-'* ]]
 then ${TESTCMD} --label=Windows.Forms --skip;
 else
     if xvfb-run -a -- make -C mcs/class/System.Windows.Forms test-simple;
@@ -34,7 +34,7 @@ else
 fi
 ${TESTCMD} --label=System.Data --timeout=5m make -w -C mcs/class/System.Data run-test
 ${TESTCMD} --label=System.Data-xunit --timeout=5m make -w -C mcs/class/System.Data run-xunit-test
-if [[ ${label} == w* ]]; then ${TESTCMD} --label=Mono.Data.Sqlite --skip; else ${TESTCMD} --label=Mono.Data.Sqlite --timeout=5m make -w -C mcs/class/Mono.Data.Sqlite run-test; fi
+if [[ ${CI_TAGS} == *'win-'* ]]; then ${TESTCMD} --label=Mono.Data.Sqlite --skip; else ${TESTCMD} --label=Mono.Data.Sqlite --timeout=5m make -w -C mcs/class/Mono.Data.Sqlite run-test; fi
 ${TESTCMD} --label=System.Data.OracleClient --timeout=5m make -w -C mcs/class/System.Data.OracleClient run-test;
 ${TESTCMD} --label=System.Design --timeout=5m make -w -C mcs/class/System.Design run-test;
 ${TESTCMD} --label=Mono.Posix --timeout=5m make -w -C mcs/class/Mono.Posix run-test
@@ -103,7 +103,7 @@ ${TESTCMD} --label=Microsoft.Build.Framework-14 --timeout=60m make -w -C mcs/cla
 ${TESTCMD} --label=Microsoft.Build.Tasks-14 --timeout=60m make -w -C mcs/class/Microsoft.Build.Tasks run-test PROFILE=xbuild_14
 ${TESTCMD} --label=Microsoft.Build.Utilities-14 --timeout=60m make -w -C mcs/class/Microsoft.Build.Utilities run-test PROFILE=xbuild_14
 ${TESTCMD} --label=System.IO.Compression --timeout=5m make -w -C mcs/class/System.IO.Compression run-test
-if [[ ${label} == w* ]]; then ${TESTCMD} --label=symbolicate --skip; else ${TESTCMD} --label=symbolicate --timeout=60m make -w -C mcs/tools/mono-symbolicate check; fi
+if [[ ${CI_TAGS} == *'win-'* ]]; then ${TESTCMD} --label=symbolicate --skip; else ${TESTCMD} --label=symbolicate --timeout=60m make -w -C mcs/tools/mono-symbolicate check; fi
 ${TESTCMD} --label=monolinker --timeout=10m make -w -C mcs/tools/linker check
 ${TESTCMD} --label=csi --timeout=10m make -w -C mcs/packages run-test
 

--- a/scripts/ci/run-test-interpreter.sh
+++ b/scripts/ci/run-test-interpreter.sh
@@ -8,5 +8,5 @@ ${TESTCMD} --label=interpreter-regression --timeout=10m make -C mono/mini richec
 ${TESTCMD} --label=compile-runtime-tests --timeout=40m make -w -C mono/tests -j4 tests
 ${TESTCMD} --label=runtime-interp --timeout=160m make -w -C mono/tests -k testinterp V=1 CI=1 CI_PR=${ghprbPullId}
 ${TESTCMD} --label=corlib --timeout=160m make -w -C mcs/class/corlib run-test V=1
-if [[ ${label} != 'debian-9-armhf' ]]; then ${TESTCMD} --label=mcs-tests --timeout=160m make -w -C mcs/tests run-test V=1; fi
+if [[ ${CI_TAGS} != *'linux-armhf'* ]]; then ${TESTCMD} --label=mcs-tests --timeout=160m make -w -C mcs/tests run-test V=1; fi
 ${TESTCMD} --label=Mono.Debugger.Soft --timeout=5m make -w -C mcs/class/Mono.Debugger.Soft run-test V=1


### PR DESCRIPTION
The `label` environment variable is set by Jenkins based on the chroot/node configuration a given job is using.

This crept into the CI scripts while it should have been a separate concern and caused all sorts of issues when we bumped from e.g. debian-8-* to debian-9-* in some jobs.

Instead we should consistently use the CI_TAGS env var which we control exclusively.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
