### PR TITLE
[Mono.Posix] Fix the Android xattr check to not disable it on all other platforms.

### DIFF
--- a/support/sys-xattr.c
+++ b/support/sys-xattr.c
@@ -12,7 +12,7 @@
 #include <config.h>
 
 //If we're compiling to API level < 16 this won't be available
-#if __ANDROID_API__ < 16
+#if defined (HOST_ANDROID) && __ANDROID_API__ < 16
 #define ANDROID_NO_XATTR
 #endif
 


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/6794