### PR TITLE
[2018-02] [runtime] Add a 'frame_addr' field to MonoStackFrameInfo, which is equal to either interp_frame or ctx->sp.

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -141,6 +141,7 @@ typedef struct
 	MonoDebugMethodJitInfo *jit;
 	MonoJitInfo *ji;
 	MonoInterpFrameHandle interp_frame;
+	gpointer frame_addr;
 	int flags;
 	mgreg_t *reg_locations [MONO_MAX_IREGS];
 	/*
@@ -3150,6 +3151,7 @@ process_frame (StackFrameInfo *info, MonoContext *ctx, gpointer user_data)
 	frame->flags = flags;
 	frame->ji = info->ji;
 	frame->interp_frame = info->interp_frame;
+	frame->frame_addr = info->frame_addr;
 	if (info->reg_locations)
 		memcpy (frame->reg_locations, info->reg_locations, MONO_MAX_IREGS * sizeof (mgreg_t*));
 	if (ctx) {
@@ -3175,8 +3177,7 @@ process_filter_frame (StackFrameInfo *info, MonoContext *ctx, gpointer user_data
 	 * directly from the filter to the call site; we abort stack unwinding here
 	 * once this happens and resume from the throw site.
 	 */
-
-	if (MONO_CONTEXT_GET_SP (ctx) >= MONO_CONTEXT_GET_SP (&ud->tls->filter_state.ctx))
+	if (info->frame_addr >= MONO_CONTEXT_GET_SP (&ud->tls->filter_state.ctx))
 		return TRUE;
 
 	return process_frame (info, ctx, user_data);
@@ -3268,7 +3269,7 @@ compute_frame_info (MonoInternalThread *thread, DebuggerTlsData *tls)
 		 * the still valid stack frames.
 		 */
 		for (i = 0; i < tls->frame_count; ++i) {
-			if (MONO_CONTEXT_GET_SP (&tls->frames [i]->ctx) == MONO_CONTEXT_GET_SP (&f->ctx)) {
+			if (tls->frames [i]->frame_addr == f->frame_addr) {
 				f->id = tls->frames [i]->id;
 				break;
 			}

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -5386,6 +5386,7 @@ interp_frame_iter_next (MonoInterpStackIter *iter, StackFrameInfo *frame)
 	frame->native_offset = (guint8*)iframe->ip - (guint8*)iframe->imethod->code;
 	frame->ji = iframe->imethod->jinfo;
 	frame->managed = TRUE;
+	frame->frame_addr = iframe;
 
 	stack_iter->current = iframe->parent;
 

--- a/mono/utils/mono-stack-unwinding.h
+++ b/mono/utils/mono-stack-unwinding.h
@@ -84,6 +84,15 @@ typedef struct {
 	/* For FRAME_TYPE_INTERP */
 	gpointer interp_frame;
 
+	/*
+	 * A stack address associated with the frame which can be used
+	 * to compare frames.
+	 * This is needed because ctx is not changed when unwinding through
+	 * interpreter frames, it still refers to the last native interpreter
+	 * frame.
+	 */
+	gpointer frame_addr;
+
 	/* The next fields are only useful for the jit */
 	gpointer lmf;
 	guint32 unwind_info_len;

--- a/scripts/ci/run-test-interpreter.sh
+++ b/scripts/ci/run-test-interpreter.sh
@@ -4,7 +4,7 @@ export TESTCMD=`dirname "${BASH_SOURCE[0]}"`/run-step.sh
 export TEST_WITH_INTERPRETER=1
 
 ${TESTCMD} --label=interpreter-regression --timeout=10m make -C mono/mini richeck
-#${TESTCMD} --label=mixedmode-regression --timeout=10m make -C mono/mini mixedcheck
+${TESTCMD} --label=mixedmode-regression --timeout=10m make -C mono/mini mixedcheck
 ${TESTCMD} --label=compile-runtime-tests --timeout=40m make -w -C mono/tests -j4 tests
 ${TESTCMD} --label=runtime-interp --timeout=160m make -w -C mono/tests -k testinterp V=1 CI=1 CI_PR=${ghprbPullId}
 ${TESTCMD} --label=corlib --timeout=160m make -w -C mcs/class/corlib run-test V=1


### PR DESCRIPTION
Backport of #6644.

/cc @lewurm