### PR TITLE
Use the preallocated domain->out_of_memory_ex instead of allocating

### DIFF
--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -607,7 +607,10 @@ mono_error_prepare_exception (MonoError *oerror, MonoError *error_out)
 		break;
 
 	case MONO_ERROR_OUT_OF_MEMORY:
-		exception = mono_get_exception_out_of_memory ();
+		if (domain)
+			exception = domain->out_of_memory_ex;
+		if (!exception)
+			exception = mono_get_exception_out_of_memory ();
 		break;
 
 	case MONO_ERROR_ARGUMENT:


### PR DESCRIPTION
a new exception when out of memory. While surviving low memory
might not really be supported, work was put into it and other
code should leverage it as it is easy.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
