### PR TITLE
[2018-02] [arm64] Handle arguments of type ArgVtypeOnStack in the dyn call code. Part of the fix for #59184.

### DIFF
--- a/mono/mini/aot-tests.cs
+++ b/mono/mini/aot-tests.cs
@@ -193,6 +193,10 @@ class Tests
 		public static T Get_T (object o) {
 			return (T)o;
 		}
+
+		public static long vtype_by_val<T1, T2, T3, T4, T5> (T1 t1, T2 t2, T3 t3, T4 t4, long? t5) {
+			return (long)t5;
+		}
 	}
 
 	[Category ("DYNCALL")]
@@ -210,6 +214,12 @@ class Tests
 			return 2;
 		}
 		return 0;
+	}
+
+	static int test_42_arm64_dyncall_vtypebyval () {
+		var method = typeof (Foo5<string>).GetMethod ("vtype_by_val").MakeGenericMethod (new Type [] { typeof (int), typeof (long?), typeof (long?), typeof (long?), typeof (long?) });
+		long res = (long)method.Invoke (null, new object [] { 1, 2L, 3L, 4L, 42L });
+		return (int)res;
 	}
 
 	class Foo6 {

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -1537,6 +1537,7 @@ dyn_call_supported (CallInfo *cinfo, MonoMethodSignature *sig)
 		case ArgHFA:
 		case ArgVtypeByRef:
 		case ArgOnStack:
+		case ArgVtypeOnStack:
 			break;
 		default:
 			return FALSE;
@@ -1651,7 +1652,7 @@ mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, g
 		ArgInfo *ainfo = &cinfo->args [aindex + sig->hasthis];
 		int slot = -1;
 
-		if (ainfo->storage == ArgOnStack) {
+		if (ainfo->storage == ArgOnStack || ainfo->storage == ArgVtypeOnStack) {
 			slot = PARAM_REGS + 1 + (ainfo->offset / sizeof (mgreg_t));
 		} else {
 			slot = ainfo->reg;
@@ -1775,6 +1776,10 @@ mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, g
 				break;
 			case ArgVtypeByRef:
 				p->regs [slot] = (mgreg_t)arg;
+				break;
+			case ArgVtypeOnStack:
+				for (i = 0; i < ainfo->size / 8; ++i)
+					p->regs [slot ++] = ((mgreg_t*)arg) [i];
 				break;
 			default:
 				g_assert_not_reached ();


### PR DESCRIPTION
Backport of #6826.

/cc @vargaz