### PR TITLE
[2018-02] [timezone] ignore LocalId test on XAMMAC_4_5 too

### DIFF
--- a/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
@@ -124,7 +124,7 @@ namespace MonoTests.System
 				} catch (DllNotFoundException e) {
 					return;
 				}
-#if !MONOTOUCH && !XAMMAC
+#if !MONOTOUCH && !XAMMAC && !XAMMAC_4_5
 				// this assumption is incorrect for iOS, tvO, watchOS and OSX
 				Assert.IsTrue (TimeZoneInfo.Local.Id != "Local", "Local timezone id should not be \"Local\"");
 #endif


### PR DESCRIPTION
Backport of #6830.

/cc @lewurm