### PR TITLE
[bcl] Fix more assembly identity mismatches

### DIFF
--- a/mcs/class/Facades/System.IO.Compression.ZipFile/Makefile
+++ b/mcs/class/Facades/System.IO.Compression.ZipFile/Makefile
@@ -9,7 +9,7 @@ LIBRARY_INSTALL_DIR = $(mono_libdir)/mono/$(FRAMEWORK_VERSION)/Facades
 
 LIBRARY = System.IO.Compression.ZipFile.dll
 
-KEYFILE = ../../msfinal.pub
+KEYFILE = ../../ecma.pub
 SIGN_FLAGS = /delaysign /nowarn:1616,1699
 LIB_REFS = System System.IO.Compression.FileSystem
 LIB_MCS_FLAGS = $(SIGN_FLAGS)

--- a/mcs/class/Microsoft.VisualC/Assembly/AssemblyInfo.cs
+++ b/mcs/class/Microsoft.VisualC/Assembly/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Resources;
 
-[assembly: AssemblyVersion (Consts.VsVersion)]
+[assembly: AssemblyVersion ("10.0.0.0")]
 
 /* TODO COMPLETE INFORMATION
 

--- a/mcs/class/System.Dynamic/Makefile
+++ b/mcs/class/System.Dynamic/Makefile
@@ -5,7 +5,7 @@ include ../../build/rules.make
 LIBRARY = System.Dynamic.dll
 
 LIB_REFS = System.Core System
-KEYFILE = ../ecma.pub
+KEYFILE = ../msfinal.pub
 LIB_MCS_FLAGS = -unsafe -d:CODEPLEX_40 -nowarn:414,169
 
 # This is a .NET 4.0+ only assembly

--- a/mcs/class/System.Reflection.Context/Makefile
+++ b/mcs/class/System.Reflection.Context/Makefile
@@ -4,7 +4,7 @@ include ../../build/rules.make
 
 LIBRARY = System.Reflection.Context.dll
 LIB_REFS = System
-KEYFILE = ../msfinal.pub
+KEYFILE = ../ecma.pub
 LIB_MCS_FLAGS =
 
 NO_TEST = yes


### PR DESCRIPTION
As a follow up to https://github.com/mono/mono/issues/6848 I checked all the implementation assemblies too and found some more identity mismatches with .NET
