### PR TITLE
[metadata] Use getters for MonoClass fields in class.c

### DIFF
--- a/mono/metadata/class-accessors.c
+++ b/mono/metadata/class-accessors.c
@@ -469,6 +469,33 @@ mono_class_get_dim_conflicts (MonoClass *klass)
 	return info->data;
 }
 
+/**
+ * mono_class_set_failure:
+ * \param klass class in which the failure was detected
+ * \param ex_type the kind of exception/error to be thrown (later)
+ * \param ex_data exception data (specific to each type of exception/error)
+ *
+ * Keep a detected failure informations in the class for later processing.
+ * Note that only the first failure is kept.
+ *
+ * LOCKING: Acquires the loader lock.
+ */
+gboolean
+mono_class_set_failure (MonoClass *klass, MonoErrorBoxed *boxed_error)
+{
+	g_assert (boxed_error != NULL);
+
+	if (mono_class_has_failure (klass))
+		return FALSE;
+
+	mono_loader_lock ();
+	klass->has_failure = 1;
+	mono_class_set_exception_data (klass, boxed_error);
+	mono_loader_unlock ();
+
+	return TRUE;
+}
+
 #ifdef MONO_CLASS_DEF_PRIVATE
 #define MONO_CLASS_GETTER(funcname, rettype, optref, argtype, fieldname) rettype funcname (argtype *klass) { return optref klass-> fieldname ; }
 #include "class-getters.h"

--- a/mono/metadata/class-init.h
+++ b/mono/metadata/class-init.h
@@ -74,6 +74,11 @@ mono_class_setup_parent    (MonoClass *klass, MonoClass *parent);
 void
 mono_class_setup_mono_type (MonoClass *klass);
 
+void
+mono_class_setup_has_finalizer (MonoClass *klass);
+
+void
+mono_class_setup_nested_types (MonoClass *klass);
 
 MONO_END_DECLS
 

--- a/mono/metadata/metadata.h
+++ b/mono/metadata/metadata.h
@@ -19,7 +19,7 @@ MONO_BEGIN_DECLS
 #define MONO_TYPE_IS_POINTER(t) mono_type_is_pointer (t)
 #define MONO_TYPE_IS_REFERENCE(t) mono_type_is_reference (t)
 
-#define MONO_CLASS_IS_INTERFACE(c) ((mono_class_get_flags (c) & TYPE_ATTRIBUTE_INTERFACE) || (c->byval_arg.type == MONO_TYPE_VAR) || (c->byval_arg.type == MONO_TYPE_MVAR))
+#define MONO_CLASS_IS_INTERFACE(c) ((mono_class_get_flags (c) & TYPE_ATTRIBUTE_INTERFACE) || mono_type_is_generic_parameter (mono_class_get_type (c)))
 
 #define MONO_CLASS_IS_IMPORT(c) ((mono_class_get_flags (c) & TYPE_ATTRIBUTE_IMPORT))
 


### PR DESCRIPTION
1. Use getters when accessing the `MonoClass` fields in `class.c`
  Also
   - Move `mono_class_set_failure` definition to `class-accessors.c`
   - Move a few functions that set up specific `MonoClass` fields to `class-init.c`:
     - `mono_class_setup_has_finalizer`
     - `mono_class_setup_nested_types`
     - `mono_class_setup_supertypes`

2. Change `MONO_CLASS_IS_INTERFACE(c)` to use the public API instead of accessing
   `MonoClass` and `MonoType` fields directly.  Note that the definition of `MonoClass` hasn't been part of the public API for a couple of years, so in the status quo the macro was unusable outside of Mono's source tree.
   
   There is a subtle semantic change here: `mono_type_is_generic_parameter` will
  return FALSE if it's given a byref type parameter, where the previous version of the macro
  would return TRUE.  (E.g. if you had `class F<T>` then `IS_INTERFACE("T&")`
  used to return TRUE but will now return FALSE. )