### PR TITLE
[runtime] Implement support for conflict detection for Default Interface Methods.

### DIFF
--- a/mono/metadata/class-getters.h
+++ b/mono/metadata/class-getters.h
@@ -48,6 +48,7 @@ MONO_CLASS_GETTER(m_class_is_has_finalize_inited, gboolean, , MonoClass, has_fin
 MONO_CLASS_GETTER(m_class_is_fields_inited, gboolean, , MonoClass, fields_inited)
 MONO_CLASS_GETTER(m_class_has_failure, gboolean, , MonoClass, has_failure)
 MONO_CLASS_GETTER(m_class_has_weak_fields, gboolean, , MonoClass, has_weak_fields)
+MONO_CLASS_GETTER(m_class_has_dim_conflicts, gboolean, , MonoClass, has_dim_conflicts)
 MONO_CLASS_GETTER(m_class_get_parent, MonoClass *, , MonoClass, parent)
 MONO_CLASS_GETTER(m_class_get_nested_in, MonoClass *, ,  MonoClass, nested_in)
 MONO_CLASS_GETTER(m_class_get_image, MonoImage *, , MonoClass, image)

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1374,6 +1374,15 @@ mono_class_set_weak_bitmap (MonoClass *klass, int nbits, gsize *bits);
 gsize*
 mono_class_get_weak_bitmap (MonoClass *klass, int *nbits);
 
+gboolean
+mono_class_has_dim_conflicts (MonoClass *klass);
+
+void
+mono_class_set_dim_conflicts (MonoClass *klass, GSList *conflicts);
+
+GSList*
+mono_class_get_dim_conflicts (MonoClass *klass);
+
 MonoMethod *
 mono_class_get_method_from_name_checked (MonoClass *klass, const char *name, int param_count, int flags, MonoError *error);
 

--- a/mono/metadata/class-private-definition.h
+++ b/mono/metadata/class-private-definition.h
@@ -80,6 +80,7 @@ struct _MonoClass {
 	guint fields_inited : 1; /* setup_fields () has finished */
 	guint has_failure : 1; /* See mono_class_get_exception_data () for a MonoErrorBoxed with the details */
 	guint has_weak_fields : 1; /* class has weak reference fields */
+	guint has_dim_conflicts : 1; /* Class has conflicting default interface methods */
 
 	MonoClass  *parent;
 	MonoClass  *nested_in;

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -2914,16 +2914,6 @@ emit_get_rgctx (MonoCompile *cfg, MonoMethod *method, int context_used)
 		EMIT_NEW_TEMPLOAD (cfg, mrgctx_var, mrgctx_loc->inst_c0);
 
 		return mrgctx_var;
-	} else if (MONO_CLASS_IS_INTERFACE (cfg->method->klass)) {
-		MonoInst *mrgctx_loc, *mrgctx_var;
-
-		/* Default interface methods need an mrgctx since the vtabke at runtime points at an implementing class */
-		mrgctx_loc = mono_get_vtable_var (cfg);
-		EMIT_NEW_TEMPLOAD (cfg, mrgctx_var, mrgctx_loc->inst_c0);
-
-		g_assert (mono_method_needs_static_rgctx_invoke (cfg->method, TRUE));
-
-		return mrgctx_var;
 	} else if (method->flags & METHOD_ATTRIBUTE_STATIC || method->klass->valuetype) {
 		MonoInst *vtable_loc, *vtable_var;
 

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -2899,6 +2899,10 @@ mono_method_is_generic_sharable_full (MonoMethod *method, gboolean allow_type_va
 	if (!mono_method_is_generic_impl (method))
 		return FALSE;
 
+	if (MONO_CLASS_IS_INTERFACE (method->klass))
+		/* Default Interface Methods don't work yet with gshared */
+		return FALSE;
+
 	/*
 	if (!mono_debug_count ())
 		allow_partial = FALSE;

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -574,6 +574,31 @@ common_call_trampoline (mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVTable *
 			vtable_slot = mini_resolve_imt_method (vt, vtable_slot, imt_method, &impl_method, &addr, &need_rgctx_tramp, &variant_iface, error);
 			return_val_if_nok (error, NULL);
 
+			if (mono_class_has_dim_conflicts (vt->klass)) {
+				GSList *conflicts = mono_class_get_dim_conflicts (vt->klass);
+				GSList *l;
+				MonoMethod *decl = imt_method;
+
+				if (decl->is_inflated)
+					decl = mono_method_get_declaring_generic_method (decl);
+
+				gboolean in_conflict = FALSE;
+				for (l = conflicts; l; l = l->next) {
+					if (decl == l->data) {
+						in_conflict = TRUE;
+						break;
+					}
+				}
+				if (in_conflict) {
+					char *class_name = mono_class_full_name (vt->klass);
+					char *method_name = mono_method_full_name (decl, TRUE);
+					mono_error_set_not_supported (error, "Interface method '%s' in class '%s' has multiple candidate implementations.", method_name, class_name);
+					g_free (class_name);
+					g_free (method_name);
+					return NULL;
+				}
+			}
+
 			/* We must handle magic interfaces on rank 1 arrays of ref types as if they were variant */
 			if (!variant_iface && vt->klass->rank == 1 && !vt->klass->element_class->valuetype && imt_method->klass->is_array_special_interface)
 				variant_iface = imt_method;

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -990,8 +990,8 @@ LLVM = $(filter --llvm, $(MONO_ENV_OPTIONS))
 # appdomain-thread-abort.exe: https://bugzilla.xamarin.com/show_bug.cgi?id=47054
 # abort-try-holes.exe is flaky due to unwinding failure to the finally block when aborting
 # appdomain-marshalbyref-assemblyload.exe: https://bugzilla.xamarin.com/show_bug.cgi?id=49308
-# dim-*: https://github.com/mono/mono/pull/6252
 # threads-init.exe: runs out of system threads
+# dim-constrainedcall.exe: fails on dontnet as well (https://github.com/dotnet/coreclr/issues/15353)
 KNOWN_FAILING_TESTS = \
 	delegate-async-exception.exe	\
 	bug-348522.2.exe	\
@@ -1001,8 +1001,7 @@ KNOWN_FAILING_TESTS = \
 	appdomain-marshalbyref-assemblyload.exe	\
 	abort-try-holes.exe \
 	threads-init.exe \
-	dim-constrainedcall.exe	\
-	dim-diamondshape.exe
+	dim-constrainedcall.exe
 
 DISABLED_TESTS = \
 	$(KNOWN_FAILING_TESTS) \
@@ -1060,7 +1059,11 @@ INTERP_DISABLED_TESTS = \
 	threadpool-exceptions4.exe \
 	threadpool-exceptions5.exe \
 	typeload-unaligned.exe \
-	weak-fields.exe
+	weak-fields.exe \
+	vararg.exe \
+	vararg2.exe \
+	vararg3.exe	\
+	dim-diamondshape.exe
 
 TESTS_CS=$(filter-out $(DISABLED_TESTS),$(TESTS_CS_SRC:.cs=.exe))
 TESTS_IL=$(filter-out $(DISABLED_TESTS),$(TESTS_IL_SRC:.il=.exe))


### PR DESCRIPTION
Detect conflicts caused by diamond inheritance during vtable construction, and throw an exception when a conflicting
methods is called.
Disable generic sharing for default interface methods, it doesn't work yet, probably
because these methods are called on classes, but the gshared information is associated with the interface.
Enable dim-diamondshape.exe test.