### PR TITLE
[System]: Set NetworkStream.ReadTimeout in WebConnection.InitConnection().

### DIFF
--- a/mcs/class/System/System.Net/WebConnection.cs
+++ b/mcs/class/System/System.Net/WebConnection.cs
@@ -265,6 +265,8 @@ namespace System.Net
 				goto retry;
 			}
 
+			networkStream.ReadTimeout = operation.Request.ReadWriteTimeout;
+
 			return new WebRequestStream (this, operation, networkStream, tunnel);
 		}
 

--- a/mcs/class/System/System.Net/WebResponseStream.cs
+++ b/mcs/class/System/System.Net/WebResponseStream.cs
@@ -81,7 +81,6 @@ namespace System.Net
 			: base (request.Connection, request.Operation, request.InnerStream)
 		{
 			RequestStream = request;
-			request.InnerStream.ReadTimeout = ReadTimeout;
 
 #if MONO_WEB_DEBUG
 			ME = $"WRP(Cnc={Connection.ID}, Op={Operation.ID})";


### PR DESCRIPTION
Setting `ReadTimeout` in `WebResponseStream.ctor` throws `System.Net.Sockets.SocketException : Invalid arguments` on iOS.

Set it in `WebConnection.InitConnection()` immediately after establishing a connection, before we read/write anything.