### PR TITLE
[runtime] Make icall tables loadable.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4181,6 +4181,8 @@ if test "x$icall_tables" = "xno"; then
    AC_DEFINE(DISABLE_ICALL_TABLES, 1, [Icall tables disabled])
 fi
 
+AM_CONDITIONAL(DISABLE_ICALL_TABLES, test x$icall_tables = xno)
+
 if test "x$with_tls" = "x__thread"; then
 	AC_DEFINE(HAVE_KW_THREAD, 1, [Have __thread keyword])
 	# Pass the information to libgc

--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -77,7 +77,13 @@ if SUPPORT_BOEHM
 boehm_libraries = libmonoruntime.la
 endif
 
+if DISABLE_ICALL_TABLES
+icall_table_libraries = libmono-icall-table.la
+endif
+
 noinst_LTLIBRARIES = libmonoruntime-config.la $(boehm_libraries) $(sgen_libraries)
+
+lib_LTLIBRARIES = $(icall_table_libraries)
 
 AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/mono $(LIBGC_CPPFLAGS) $(GLIB_CFLAGS) $(SHARED_CFLAGS)
 
@@ -99,6 +105,14 @@ libmonoruntime_config_la_SOURCES = \
 	mono-config-dirs.c
 libmonoruntime_config_la_CPPFLAGS = $(AM_CPPFLAGS) -DMONO_BINDIR=\"$(bindir)/\" -DMONO_ASSEMBLIES=\"$(assembliesdir)\" -DMONO_CFG_DIR=\"$(confdir)\" -DMONO_RELOC_LIBDIR=\"../$(reloc_libdir)\"
 
+#
+# This library contains the icall tables if the runtime was configured with --disable-icall-tables
+#
+if DISABLE_ICALL_TABLES
+libmono_icall_table_la_SOURCES = \
+	icall-table.c
+endif
+
 CLEANFILES = mono-bundle.stamp
 
 null_sources = \
@@ -108,6 +122,11 @@ null_gc_sources = \
 	null-gc.c \
 	null-gc-handles.h \
 	null-gc-handles.c
+
+if !DISABLE_ICALL_TABLES
+icall_tables_sources = \
+	icall-table.c
+endif
 
 common_sources = \
 	$(platform_sources)	\
@@ -157,6 +176,7 @@ common_sources = \
 	icall.c			\
 	icall-internals.h \
 	icall-def.h		\
+	icall-table.h	\
 	image.c			\
 	image-internals.h	\
 	jit-info.c		\
@@ -299,11 +319,11 @@ sgen_sources = \
 	sgen-mono.c		\
 	sgen-client-mono.h
 
-libmonoruntime_la_SOURCES = $(common_sources) $(gc_dependent_sources) $(null_gc_sources) $(boehm_sources)
+libmonoruntime_la_SOURCES = $(common_sources) $(icall_tables_sources) $(gc_dependent_sources) $(null_gc_sources) $(boehm_sources)
 libmonoruntime_la_CFLAGS = $(BOEHM_DEFINES)
 libmonoruntime_la_LIBADD = libmonoruntime-config.la
 
-libmonoruntimesgen_la_SOURCES = $(common_sources) $(gc_dependent_sources) $(sgen_sources)
+libmonoruntimesgen_la_SOURCES = $(common_sources) $(icall_tables_sources) $(gc_dependent_sources) $(sgen_sources)
 libmonoruntimesgen_la_CFLAGS = $(SGEN_DEFINES)
 libmonoruntimesgen_la_LIBADD = libmonoruntime-config.la
 

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -42,7 +42,8 @@ typedef struct _MonoDynamicMethod MonoDynamicMethod;
 #define ICALL_EXPORT MONO_API
 #else
 #define ICALL_DECL_EXPORT
-#define ICALL_EXPORT static
+/* Can't be static as icall.c defines icalls referenced by icall-tables.c */
+#define ICALL_EXPORT
 #endif
 
 typedef enum {

--- a/mono/metadata/icall-table.c
+++ b/mono/metadata/icall-table.c
@@ -1,0 +1,426 @@
+/**
+ * \file
+ *
+ * Authors:
+ *   Dietmar Maurer (dietmar@ximian.com)
+ *   Paolo Molaro (lupus@ximian.com)
+ *	 Patrik Torstensson (patrik.torstensson@labs2.com)
+ *   Marek Safar (marek.safar@gmail.com)
+ *   Aleksey Kliger (aleksey@xamarin.com)
+ *
+ * Copyright 2001-2003 Ximian, Inc (http://www.ximian.com)
+ * Copyright 2004-2009 Novell, Inc (http://www.novell.com)
+ * Copyright 2011-2015 Xamarin Inc (http://www.xamarin.com).
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+#include <config.h>
+#include <glib.h>
+#include <stdarg.h>
+#include <string.h>
+#include <ctype.h>
+#ifdef HAVE_ALLOCA_H
+#include <alloca.h>
+#endif
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#if defined (HAVE_WCHAR_H)
+#include <wchar.h>
+#endif
+
+#include <mono/metadata/icall-table.h>
+#include <mono/utils/mono-publib.h>
+#include <mono/utils/bsearch.h>
+
+/*
+ * icall.c defines a lot of icalls as static, to avoid having to add prototypes for
+ * them, just don't include any mono headers and emit dummy prototypes.
+ */
+// Generate prototypes
+#define ICALL_TYPE(id,name,first)
+#define ICALL(id,name,func) extern void func (void);
+#define HANDLES(inner) inner
+#include "metadata/icall-def.h"
+
+// Generate Icall_ constants
+#undef ICALL_TYPE
+#undef ICALL
+#undef HANDLES
+#define ICALL_TYPE(id,name,first)
+#define ICALL(id,name,func) Icall_ ## id,
+#define HANDLES(inner) inner
+
+enum {
+#include "metadata/icall-def.h"
+	Icall_last
+};
+
+#undef ICALL_TYPE
+#undef ICALL
+#define ICALL_TYPE(id,name,first) Icall_type_ ## id,
+#define ICALL(id,name,func)
+#undef HANDLES
+#define HANDLES(inner) inner
+enum {
+#include "metadata/icall-def.h"
+	Icall_type_num
+};
+
+#undef ICALL_TYPE
+#undef ICALL
+#define ICALL_TYPE(id,name,firstic) {(Icall_ ## firstic)},
+#define ICALL(id,name,func)
+#undef HANDLES
+#define HANDLES(inner) inner
+typedef struct {
+	guint16 first_icall;
+} IcallTypeDesc;
+
+static const IcallTypeDesc
+icall_type_descs [] = {
+#include "metadata/icall-def.h"
+	{Icall_last}
+};
+
+#define icall_desc_num_icalls(desc) ((desc) [1].first_icall - (desc) [0].first_icall)
+
+#undef HANDLES
+#define HANDLES(inner) inner
+#undef ICALL_TYPE
+#define ICALL_TYPE(id,name,first)
+#undef ICALL
+
+#ifdef HAVE_ARRAY_ELEM_INIT
+#define MSGSTRFIELD(line) MSGSTRFIELD1(line)
+#define MSGSTRFIELD1(line) str##line
+
+static const struct msgstrtn_t {
+#define ICALL(id,name,func)
+#undef ICALL_TYPE
+#define ICALL_TYPE(id,name,first) char MSGSTRFIELD(__LINE__) [sizeof (name)];
+#include "metadata/icall-def.h"
+#undef ICALL_TYPE
+} icall_type_names_str = {
+#define ICALL_TYPE(id,name,first) (name),
+#include "metadata/icall-def.h"
+#undef ICALL_TYPE
+};
+static const guint16 icall_type_names_idx [] = {
+#define ICALL_TYPE(id,name,first) [Icall_type_ ## id] = offsetof (struct msgstrtn_t, MSGSTRFIELD(__LINE__)),
+#include "metadata/icall-def.h"
+#undef ICALL_TYPE
+};
+#define icall_type_name_get(id) ((const char*)&icall_type_names_str + icall_type_names_idx [(id)])
+
+static const struct msgstr_t {
+#undef ICALL
+#define ICALL_TYPE(id,name,first)
+#define ICALL(id,name,func) char MSGSTRFIELD(__LINE__) [sizeof (name)];
+#include "metadata/icall-def.h"
+#undef ICALL
+} icall_names_str = {
+#define ICALL(id,name,func) (name),
+#include "metadata/icall-def.h"
+#undef ICALL
+};
+static const guint16 icall_names_idx [] = {
+#define ICALL(id,name,func) [Icall_ ## id] = offsetof (struct msgstr_t, MSGSTRFIELD(__LINE__)),
+#include "metadata/icall-def.h"
+#undef ICALL
+};
+#define icall_name_get(id) ((const char*)&icall_names_str + icall_names_idx [(id)])
+
+#else
+
+#undef ICALL_TYPE
+#undef ICALL
+#define ICALL_TYPE(id,name,first) name,
+#define ICALL(id,name,func)
+static const char* const
+icall_type_names [] = {
+#include "metadata/icall-def.h"
+	NULL
+};
+
+#define icall_type_name_get(id) (icall_type_names [(id)])
+
+#undef ICALL_TYPE
+#undef ICALL
+#define ICALL_TYPE(id,name,first)
+#define ICALL(id,name,func) name,
+static const char* const
+icall_names [] = {
+#include "metadata/icall-def.h"
+	NULL
+};
+#define icall_name_get(id) icall_names [(id)]
+
+#endif /* !HAVE_ARRAY_ELEM_INIT */
+
+#undef HANDLES
+#define HANDLES(inner) inner
+#undef ICALL_TYPE
+#undef ICALL
+#define ICALL_TYPE(id,name,first)
+#define ICALL(id,name,func) func,
+static const gconstpointer
+icall_functions [] = {
+#include "metadata/icall-def.h"
+	NULL
+};
+
+#ifdef ENABLE_ICALL_SYMBOL_MAP
+#undef HANDLES
+#define HANDLES(inner) inner
+#undef ICALL_TYPE
+#undef ICALL
+#define ICALL_TYPE(id,name,first)
+#define ICALL(id,name,func) #func,
+static const gconstpointer
+icall_symbols [] = {
+#include "metadata/icall-def.h"
+	NULL
+};
+#endif
+
+#undef ICALL_TYPE
+#undef ICALL
+#define ICALL_TYPE(id,name,first)
+#define ICALL(id,name,func) 0,
+#undef HANDLES
+#define HANDLES(inner) 1,
+static const guchar
+icall_uses_handles [] = {
+#include "metadata/icall-def.h"
+#undef ICALL
+#undef HANDLES
+};
+
+#ifdef HAVE_ARRAY_ELEM_INIT
+static int
+compare_method_imap (const void *key, const void *elem)
+{
+	const char* method_name = (const char*)&icall_names_str + (*(guint16*)elem);
+	return strcmp (key, method_name);
+}
+
+static gsize
+find_slot_icall (const IcallTypeDesc *imap, const char *name)
+{
+	const guint16 *nameslot = (const guint16 *)mono_binary_search (name, icall_names_idx + imap->first_icall, icall_desc_num_icalls (imap), sizeof (icall_names_idx [0]), compare_method_imap);
+	if (!nameslot)
+		return -1;
+	return (nameslot - &icall_names_idx [0]);
+}
+
+static gboolean
+find_uses_handles_icall (const IcallTypeDesc *imap, const char *name)
+{
+	gsize slotnum = find_slot_icall (imap, name);
+	if (slotnum == -1)
+		return FALSE;
+	return (gboolean)icall_uses_handles [slotnum];
+}
+
+static gpointer
+find_method_icall (const IcallTypeDesc *imap, const char *name)
+{
+	gsize slotnum = find_slot_icall (imap, name);
+	if (slotnum == -1)
+		return NULL;
+	return (gpointer)icall_functions [slotnum];
+}
+
+static int
+compare_class_imap (const void *key, const void *elem)
+{
+	const char* class_name = (const char*)&icall_type_names_str + (*(guint16*)elem);
+	return strcmp (key, class_name);
+}
+
+static const IcallTypeDesc*
+find_class_icalls (const char *name)
+{
+	const guint16 *nameslot = (const guint16 *)mono_binary_search (name, icall_type_names_idx, Icall_type_num, sizeof (icall_type_names_idx [0]), compare_class_imap);
+	if (!nameslot)
+		return NULL;
+	return &icall_type_descs [nameslot - &icall_type_names_idx [0]];
+}
+
+#else /* HAVE_ARRAY_ELEM_INIT */
+
+static int
+compare_method_imap (const void *key, const void *elem)
+{
+	const char** method_name = (const char**)elem;
+	return strcmp (key, *method_name);
+}
+
+static gsize
+find_slot_icall (const IcallTypeDesc *imap, const char *name)
+{
+	const char **nameslot = mono_binary_search (name, icall_names + imap->first_icall, icall_desc_num_icalls (imap), sizeof (icall_names [0]), compare_method_imap);
+	if (!nameslot)
+		return -1;
+	return nameslot - icall_names;
+}
+
+static gpointer
+find_method_icall (const IcallTypeDesc *imap, const char *name)
+{
+	gsize slotnum = find_slot_icall (imap, name);
+	if (slotnum == -1)
+		return NULL;
+	return (gpointer)icall_functions [slotnum];
+}
+
+static gboolean
+find_uses_handles_icall (const IcallTypeDesc *imap, const char *name)
+{
+	gsize slotnum = find_slot_icall (imap, name);
+	if (slotnum == -1)
+		return FALSE;
+	return (gboolean)icall_uses_handles [slotnum];
+}
+
+static int
+compare_class_imap (const void *key, const void *elem)
+{
+	const char** class_name = (const char**)elem;
+	return strcmp (key, *class_name);
+}
+
+static const IcallTypeDesc*
+find_class_icalls (const char *name)
+{
+	const char **nameslot = mono_binary_search (name, icall_type_names, Icall_type_num, sizeof (icall_type_names [0]), compare_class_imap);
+	if (!nameslot)
+		return NULL;
+	return &icall_type_descs [nameslot - icall_type_names];
+}
+
+#endif /* HAVE_ARRAY_ELEM_INIT */
+
+static gpointer
+icall_table_lookup (char *classname, char *methodname, char *sigstart, gboolean *uses_handles)
+{
+	const IcallTypeDesc *imap = NULL;
+	gpointer res;
+
+	imap = find_class_icalls (classname);
+
+	/* it wasn't found in the static call tables */
+	if (!imap) {
+		if (uses_handles)
+			*uses_handles = FALSE;
+		return NULL;
+	}
+	res = find_method_icall (imap, methodname);
+	if (res) {
+		if (uses_handles)
+			*uses_handles = find_uses_handles_icall (imap, methodname);
+		return res;
+	}
+	/* try _with_ signature */
+	*sigstart = '(';
+	res = find_method_icall (imap, methodname);
+	if (res) {
+		if (uses_handles)
+			*uses_handles = find_uses_handles_icall (imap, methodname);
+		return res;
+	}
+	return NULL;
+}
+
+static const char*
+lookup_icall_symbol (gpointer func)
+{
+#ifdef ENABLE_ICALL_SYMBOL_MAP
+	gpointer func;
+	int i;
+	gpointer slot;
+	static gconstpointer *functions_sorted;
+	static const char**symbols_sorted;
+	static gboolean inited;
+
+	if (!inited) {
+		gboolean changed;
+
+		functions_sorted = g_malloc (G_N_ELEMENTS (icall_functions) * sizeof (gpointer));
+		memcpy (functions_sorted, icall_functions, G_N_ELEMENTS (icall_functions) * sizeof (gpointer));
+		symbols_sorted = g_malloc (G_N_ELEMENTS (icall_functions) * sizeof (gpointer));
+		memcpy (symbols_sorted, icall_symbols, G_N_ELEMENTS (icall_functions) * sizeof (gpointer));
+		/* Bubble sort the two arrays */
+		changed = TRUE;
+		while (changed) {
+			changed = FALSE;
+			for (i = 0; i < G_N_ELEMENTS (icall_functions) - 1; ++i) {
+				if (functions_sorted [i] > functions_sorted [i + 1]) {
+					gconstpointer tmp;
+
+					tmp = functions_sorted [i];
+					functions_sorted [i] = functions_sorted [i + 1];
+					functions_sorted [i + 1] = tmp;
+					tmp = symbols_sorted [i];
+					symbols_sorted [i] = symbols_sorted [i + 1];
+					symbols_sorted [i + 1] = tmp;
+					changed = TRUE;
+				}
+			}
+		}
+	}
+
+	slot = mono_binary_search (func, functions_sorted, G_N_ELEMENTS (icall_functions), sizeof (gpointer), func_cmp);
+	if (!slot)
+		return NULL;
+	g_assert (slot);
+	return symbols_sorted [(gpointer*)slot - (gpointer*)functions_sorted];
+#else
+	fprintf (stderr, "icall symbol maps not enabled, pass --enable-icall-symbol-map to configure.\n");
+	g_assert_not_reached ();
+	return NULL;
+#endif
+}
+
+void
+mono_icall_table_init (void)
+{
+	int i = 0;
+
+	/* check that tables are sorted: disable in release */
+	if (TRUE) {
+		int j;
+		const char *prev_class = NULL;
+		const char *prev_method;
+		
+		for (i = 0; i < Icall_type_num; ++i) {
+			const IcallTypeDesc *desc;
+			int num_icalls;
+			prev_method = NULL;
+			if (prev_class && strcmp (prev_class, icall_type_name_get (i)) >= 0)
+				g_print ("class %s should come before class %s\n", icall_type_name_get (i), prev_class);
+			prev_class = icall_type_name_get (i);
+			desc = &icall_type_descs [i];
+			num_icalls = icall_desc_num_icalls (desc);
+			/*g_print ("class %s has %d icalls starting at %d\n", prev_class, num_icalls, desc->first_icall);*/
+			for (j = 0; j < num_icalls; ++j) {
+				const char *methodn = icall_name_get (desc->first_icall + j);
+				if (prev_method && strcmp (prev_method, methodn) >= 0)
+					g_print ("method %s should come before method %s\n", methodn, prev_method);
+				prev_method = methodn;
+			}
+		}
+	}
+
+	MonoIcallTableCallbacks cb;
+	memset (&cb, 0, sizeof (MonoIcallTableCallbacks));
+	cb.version = MONO_ICALL_TABLE_CALLBACKS_VERSION;
+	cb.lookup = icall_table_lookup;
+	cb.lookup_icall_symbol = lookup_icall_symbol;
+
+	mono_install_icall_table_callbacks (&cb);
+}

--- a/mono/metadata/icall-table.h
+++ b/mono/metadata/icall-table.h
@@ -1,0 +1,27 @@
+/**
+ * \file
+ * Copyright 2016 Microsoft
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+#ifndef __MONO_METADATA_ICALL_TABLE_H__
+#define __MONO_METADATA_ICALL_TABLE_H__
+
+#include <config.h>
+#include <glib.h>
+#include <mono/utils/mono-publib.h>
+
+#define MONO_ICALL_TABLE_CALLBACKS_VERSION 1
+
+typedef struct {
+	int version;
+	gpointer (*lookup) (char *classname, char *methodname, char *sigstart, gboolean *uses_handles);
+	const char* (*lookup_icall_symbol) (gpointer func);
+} MonoIcallTableCallbacks;
+
+void
+mono_install_icall_table_callbacks (MonoIcallTableCallbacks *cb);
+
+MONO_API void
+mono_icall_table_init (void);
+
+#endif

--- a/msvc/libmonoruntime-common.targets
+++ b/msvc/libmonoruntime-common.targets
@@ -46,7 +46,7 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\gc-internals.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\icall.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\icall-table.c" />
-    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\icall-table.h" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\icall-table.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\icall-internals.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\icall-def.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\image.c" />

--- a/msvc/libmonoruntime-common.targets
+++ b/msvc/libmonoruntime-common.targets
@@ -45,6 +45,8 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\filewatcher.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\gc-internals.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\icall.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\icall-table.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\icall-table.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\icall-internals.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\icall-def.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\image.c" />

--- a/msvc/libmonoruntime-common.targets.filters
+++ b/msvc/libmonoruntime-common.targets.filters
@@ -124,6 +124,12 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\icall.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common</Filter>
     </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\icall-table.c">
+      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\icall-table.h">
+      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common</Filter>
+    </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\icall-internals.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common</Filter>
     </ClInclude>


### PR DESCRIPTION
Move the icall table code into a separate icall-table.c file, which is either linked into libmono or compiled into a
separate libmono-icall-table.a archive which can be linked into an app, and installed by calling mono_icall_table_init ().