### PR TITLE
[interp] Add missing exception checkpoints

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -2794,13 +2794,9 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 				g_warning ("ret.vt: more values on stack: %d", sp-frame->stack);
 			goto exit_frame;
 		MINT_IN_CASE(MINT_BR_S)
-			/* Checkpoint to be able to handle aborts */
-			EXCEPTION_CHECKPOINT;
 			ip += (short) *(ip + 1);
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_BR)
-			/* Checkpoint to be able to handle aborts */
-			EXCEPTION_CHECKPOINT;
 			ip += (gint32) READ32(ip + 1);
 			MINT_IN_BREAK;
 #define ZEROP_S(datamem, op) \
@@ -3649,6 +3645,11 @@ array_constructed:
 				sp->data.p = mono_get_exception_null_reference ();
 
 			THROW_EX ((MonoException *)sp->data.p, ip);
+			MINT_IN_BREAK;
+		MINT_IN_CASE(MINT_CHECKPOINT)
+			/* Do synchronous checking of abort requests */
+			EXCEPTION_CHECKPOINT;
+			++ip;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_LDFLDA_UNSAFE)
 			o = sp [-1].data.p;

--- a/mono/mini/interp/mintops.def
+++ b/mono/mini/interp/mintops.def
@@ -179,6 +179,8 @@ OPDEF(MINT_THROW, "throw", 1, MintOpNoArgs)
 OPDEF(MINT_RETHROW, "rethrow", 2, MintOpUShortInt)
 OPDEF(MINT_ENDFINALLY, "endfinally", 2, MintOpNoArgs)
 
+OPDEF(MINT_CHECKPOINT, "checkpoint", 1, MintOpNoArgs)
+
 OPDEF(MINT_BRFALSE_I4, "brfalse.i4", 3, MintOpBranch)
 OPDEF(MINT_BRFALSE_I8, "brfalse.i8", 3, MintOpBranch)
 OPDEF(MINT_BRFALSE_R8, "brfalse.r8", 3, MintOpBranch)

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -313,6 +313,9 @@ handle_branch (TransformData *td, int short_op, int long_op, int offset)
 	int target = td->ip + offset - td->il_code;
 	if (target < 0 || target >= td->code_size)
 		g_assert_not_reached ();
+	/* Add exception checkpoint for backward branches */
+	if (offset < 0)
+		ADD_CODE(td, MINT_CHECKPOINT);
 	if (offset > 0 && td->stack_height [target] < 0) {
 		td->stack_height [target] = td->sp - td->stack;
 		if (td->stack_height [target] > 0)

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1027,7 +1027,6 @@ INTERP_DISABLED_TESTS = \
 	$(if $(CI),$(CI_DISABLED_TESTS)) \
 	$(if $(CI_PR),$(CI_PR_DISABLED_TESTS)) \
 	appdomain-unload.exe \
-	async-exc-compilation.exe \
 	async-with-cb-throws.exe \
 	block_guard_restore_aligment_on_exit.exe \
 	bug-335131.2.exe \


### PR DESCRIPTION
On interp we can't async abort since we cannot unwind from an ip in the interp, so the interpreter does explicit checks as part of branch instructions.

Note this can lead to increased stack usage when compiling with -O0.


<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
