### PR TITLE
Revert "[coop] Remove support for invoke thunk wrapper"

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -3142,8 +3142,6 @@ mono_method_get_unmanaged_thunk (MonoMethod *method)
 	ERROR_DECL (error);
 	gpointer res;
 
-	g_assert (!mono_threads_is_coop_enabled ());
-
 	MONO_ENTER_GC_UNSAFE;
 	method = mono_marshal_get_thunk_invoke_wrapper (method);
 	res = mono_compile_method_checked (method, error);

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -292,6 +292,7 @@ MONO_API MonoObject*
 mono_runtime_invoke_array   (MonoMethod *method, void *obj, MonoArray *params,
 			     MonoObject **exc);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API void*
 mono_method_get_unmanaged_thunk (MonoMethod *method);
 

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -771,12 +771,6 @@ PLATFORM_DISABLED_TESTS += \
 	sgen-bridge-xref.exe
 endif
 
-if ENABLE_COOP
-COOP_DISABLED_TESTS= thunks.exe
-else
-COOP_DISABLED_TESTS= 
-endif
-
 PROFILE_DISABLED_TESTS=
 
 if FULL_AOT_TESTS


### PR DESCRIPTION
We still want to be able to invoke thunk wrappers. The transition to MonoHandle will be a separate change.

This reverts commit 150d896d198dc053db482525f397ae1e2acb56e6.