### PR TITLE
Assorted fixes for AIX and i

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -378,7 +378,7 @@ case "$host" in
 		dnl Set up a 64-bit build
 		CPPFLAGS="$CPPFLAGS -maix64 -DGC_AIX_THREADS -D_ALL_SOURCE -D_THREAD_SAFE -D_LARGE_FILES -D_REENTRANT"
 		LDFLAGS="-maix64"
-		libmono_cflags="-D_REENTRANT"
+		libmono_cflags="-D_THREAD_SAFE -D_REENTRANT"
 		dnl Would you believe GNU nm doesn't know how to process AIX libraries?
 		dnl Hardcode IBM binutils in case GNU ones end up on our path. Also
 		dnl specifiy 64-bit mode for tools.

--- a/configure.ac
+++ b/configure.ac
@@ -376,7 +376,7 @@ case "$host" in
 		;;
 	*-*-aix*|*-*-os400*)
 		dnl Set up a 64-bit build
-		CPPFLAGS="$CPPFLAGS -maix64 -DGC_AIX_THREADS -D_ALL_SOURCE -D_LARGE_FILES -D_REENTRANT"
+		CPPFLAGS="$CPPFLAGS -maix64 -DGC_AIX_THREADS -D_ALL_SOURCE -D_THREAD_SAFE -D_LARGE_FILES -D_REENTRANT"
 		LDFLAGS="-maix64"
 		libmono_cflags="-D_REENTRANT"
 		dnl Would you believe GNU nm doesn't know how to process AIX libraries?

--- a/mono/metadata/environment.c
+++ b/mono/metadata/environment.c
@@ -67,6 +67,19 @@ ves_icall_System_Environment_GetOSVersionString (MonoError *error)
 				 verinfo.wServicePackMajor << 16);
 		return mono_string_new_handle (mono_domain_get (), version, error);
 	}
+#elif defined(HAVE_SYS_UTSNAME_H) && defined(_AIX)
+	/*
+	 * AIX puts the major version number in .version and minor in .release; so make a
+	 * version string based on that; other Unices seem to cram everything in .release
+	 * and .version is for things like kernel variants.
+	 */
+	char version [128];
+	struct utsname name;
+
+	if (uname (&name) >= 0) {
+		sprintf (version, "%s.%s", name.version, name.release);
+		return mono_string_new_handle (mono_domain_get (), version, error);
+	}
 #elif defined(HAVE_SYS_UTSNAME_H)
 	struct utsname name;
 

--- a/mono/metadata/environment.c
+++ b/mono/metadata/environment.c
@@ -73,8 +73,8 @@ ves_icall_System_Environment_GetOSVersionString (MonoError *error)
 	 * version string based on that; other Unices seem to cram everything in .release
 	 * and .version is for things like kernel variants.
 	 */
-	char version [128];
 	struct utsname name;
+	char version [sizeof(name)];
 
 	if (uname (&name) >= 0) {
 		sprintf (version, "%s.%s", name.version, name.release);

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -127,7 +127,7 @@ struct _MonoArray {
 	mono_64bitaligned_t vector [MONO_ZERO_LEN_ARRAY];
 };
 
-#define MONO_SIZEOF_MONO_ARRAY (sizeof (MonoArray) - MONO_ZERO_LEN_ARRAY * sizeof (double))
+#define MONO_SIZEOF_MONO_ARRAY (sizeof (MonoArray) - MONO_ZERO_LEN_ARRAY * sizeof (mono_64bitaligned_t))
 
 struct _MonoString {
 	MonoObject object;

--- a/mono/utils/hazard-pointer.c
+++ b/mono/utils/hazard-pointer.c
@@ -110,9 +110,19 @@ mono_thread_small_id_alloc (void)
 		int num_pages = (hazard_table_size * sizeof (MonoThreadHazardPointers) + pagesize - 1) / pagesize;
 
 		if (hazard_table == NULL) {
+#if defined(_AIX)
+			/*
+			 * HACK: allocating this section with none prot will cause i 7.1
+			 * to segfault when accessing or protecting it
+			 */
+			hazard_table = (MonoThreadHazardPointers *volatile) mono_valloc (NULL,
+				sizeof (MonoThreadHazardPointers) * HAZARD_TABLE_MAX_SIZE,
+				MONO_MMAP_READ | MONO_MMAP_WRITE, MONO_MEM_ACCOUNT_HAZARD_POINTERS);
+#else
 			hazard_table = (MonoThreadHazardPointers *volatile) mono_valloc (NULL,
 				sizeof (MonoThreadHazardPointers) * HAZARD_TABLE_MAX_SIZE,
 				MONO_MMAP_NONE, MONO_MEM_ACCOUNT_HAZARD_POINTERS);
+#endif
 		}
 
 		g_assert (hazard_table != NULL);

--- a/mono/utils/hazard-pointer.c
+++ b/mono/utils/hazard-pointer.c
@@ -106,23 +106,22 @@ mono_thread_small_id_alloc (void)
 		hazard_table_size = HAZARD_TABLE_MAX_SIZE;
 #else
 		gpointer page_addr;
+#if defined(_AIX)
+		/*
+		 * HACK: allocating the table with none prot will cause i 7.1
+		 * to segfault when accessing or protecting it
+		 */
+		int table_prot = MONO_MMAP_READ | MONO_MMAP_WRITE;
+#else
+		int table_prot = MONO_MMAP_NONE;
+#endif
 		int pagesize = mono_pagesize ();
 		int num_pages = (hazard_table_size * sizeof (MonoThreadHazardPointers) + pagesize - 1) / pagesize;
 
 		if (hazard_table == NULL) {
-#if defined(_AIX)
-			/*
-			 * HACK: allocating this section with none prot will cause i 7.1
-			 * to segfault when accessing or protecting it
-			 */
 			hazard_table = (MonoThreadHazardPointers *volatile) mono_valloc (NULL,
 				sizeof (MonoThreadHazardPointers) * HAZARD_TABLE_MAX_SIZE,
-				MONO_MMAP_READ | MONO_MMAP_WRITE, MONO_MEM_ACCOUNT_HAZARD_POINTERS);
-#else
-			hazard_table = (MonoThreadHazardPointers *volatile) mono_valloc (NULL,
-				sizeof (MonoThreadHazardPointers) * HAZARD_TABLE_MAX_SIZE,
-				MONO_MMAP_NONE, MONO_MEM_ACCOUNT_HAZARD_POINTERS);
-#endif
+				table_prot, MONO_MEM_ACCOUNT_HAZARD_POINTERS);
 		}
 
 		g_assert (hazard_table != NULL);

--- a/mono/utils/mono-hwcap-ppc.c
+++ b/mono/utils/mono-hwcap-ppc.c
@@ -62,16 +62,27 @@ mono_hwcap_arch_init (void)
 			mono_hwcap_ppc_has_multiple_ls_units = TRUE;
 	}
 #elif defined(_AIX)
-	mono_hwcap_ppc_is_isa_64 = __cpu64();
-	mono_hwcap_ppc_is_isa_2x = __power_4_andup();
-	mono_hwcap_ppc_has_icache_snoop = __power_5_andup();
+	if (__cpu64())
+		mono_hwcap_ppc_is_isa_64 = TRUE;
+	if (__power_4_andup())
+		mono_hwcap_ppc_is_isa_2x = TRUE;
+	if (__power_5_andup())
+		mono_hwcap_ppc_has_icache_snoop = TRUE;
 	/* not on POWER8 */
-	mono_hwcap_ppc_has_multiple_ls_units = __power_4() || __power_5() || __power_6() || __power_7();
+	if (__power_4() || __power_5() || __power_6() || __power_7())
+		mono_hwcap_ppc_has_multiple_ls_units = TRUE;
 	/*
 	 * I dont see a way to get extended POWER6 and the PV_6_1
 	 * def seems to be trigged on the POWER6 here despite not
 	 * having these extended instructions, so POWER7 it is
 	 */
-	mono_hwcap_ppc_has_move_fpr_gpr = __power_7_andup();
+	/*
+	 * WARNING: reports that this doesn't actually work, try
+	 * to re-enable after more investigation
+	 */
+	/*
+	if (__power_7_andup())
+		mono_hwcap_ppc_has_move_fpr_gpr = TRUE;
+	 */
 #endif
 }

--- a/mono/utils/mono-hwcap-ppc.c
+++ b/mono/utils/mono-hwcap-ppc.c
@@ -62,16 +62,16 @@ mono_hwcap_arch_init (void)
 			mono_hwcap_ppc_has_multiple_ls_units = TRUE;
 	}
 #elif defined(_AIX)
-	/*
-	 * FIXME: ensure these are valid, and we match Linux ones
-	 */
-	mono_hwcap_ppc_is_isa_2x = __power_4_andup() ? TRUE : FALSE;
-	mono_hwcap_ppc_is_isa_64 = __cpu64() ? TRUE: FALSE;
+	mono_hwcap_ppc_is_isa_64 = __cpu64();
+	mono_hwcap_ppc_is_isa_2x = __power_4_andup();
+	mono_hwcap_ppc_has_icache_snoop = __power_5_andup();
+	/* not on POWER8 */
+	mono_hwcap_ppc_has_multiple_ls_units = __power_4() || __power_5() || __power_6() || __power_7();
 	/*
 	 * I dont see a way to get extended POWER6 and the PV_6_1
 	 * def seems to be trigged on the POWER6 here despite not
 	 * having these extended instructions, so POWER7 it is
 	 */
-	mono_hwcap_ppc_has_move_fpr_gpr = __power_7_andup() ? TRUE : FALSE;
+	mono_hwcap_ppc_has_move_fpr_gpr = __power_7_andup();
 #endif
 }

--- a/mono/utils/mono-time.c
+++ b/mono/utils/mono-time.c
@@ -152,7 +152,8 @@ mono_100ns_ticks (void)
 		timebase.denom *= 100; /* we return 100ns ticks */
 	}
 	return now * timebase.numer / timebase.denom;
-#elif defined(CLOCK_MONOTONIC)
+#elif defined(CLOCK_MONOTONIC) && !defined(_AIX)
+	/* !_AIX is defined because i 7.1 doesn't have clock_getres */
 	struct timespec tspec;
 	static struct timespec tspec_freq = {0};
 	static int can_use_clock = 0;


### PR DESCRIPTION
* Fix a bug I introduced when changing the MonoArray vector
  type; array lengths wouldn't match up to what they
  actually were on AIX/i.

* Use a custom mkdtemp implementation on Unices without
  mkdtemp - and ones that do but don't necessarily have it,
  like i 7.1, which lacks mkdtemp in its libc. We can't
  determine this at runtime, so AIX will have to suffer
  with i.

* Enhance PowerPC hwcap on AIX to detect features like
  Linux does.

* Don't use clock_getres on AIX, because i 7.1 doesn't have
  that syscall - it's in libc, but it'll bomb out with a
  SIGILL; the way unimplemented opcodes are handled on i.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
