### PR TITLE
Fix gshared support for default interface methods by always passing an mrgctx to them.

### DIFF
--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -391,8 +391,6 @@ struct _MonoDomain {
 	/* Used when accessing 'domain_assemblies' */
 	mono_mutex_t    assemblies_lock;
 
-	GHashTable	   *method_rgctx_hash;
-
 	GHashTable	   *generic_virtual_cases;
 
 	/* Information maintained by the JIT engine */

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -439,8 +439,6 @@ mono_domain_create (void)
 	mono_os_mutex_init_recursive (&domain->jit_code_hash_lock);
 	mono_os_mutex_init_recursive (&domain->finalizable_objects_hash_lock);
 
-	domain->method_rgctx_hash = NULL;
-
 	mono_appdomains_lock ();
 	domain_id_alloc (domain);
 	mono_appdomains_unlock ();
@@ -1203,10 +1201,6 @@ mono_domain_free (MonoDomain *domain, gboolean force)
 
 	g_hash_table_destroy (domain->finalizable_objects_hash);
 	domain->finalizable_objects_hash = NULL;
-	if (domain->method_rgctx_hash) {
-		g_hash_table_destroy (domain->method_rgctx_hash);
-		domain->method_rgctx_hash = NULL;
-	}
 	if (domain->generic_virtual_cases) {
 		g_hash_table_destroy (domain->generic_virtual_cases);
 		domain->generic_virtual_cases = NULL;

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -2163,8 +2163,7 @@ check_method_sharing (MonoCompile *cfg, MonoMethod *cmethod, gboolean *out_pass_
 			pass_vtable = TRUE;
 	}
 
-	if (mini_method_get_context (cmethod) &&
-		mini_method_get_context (cmethod)->method_inst) {
+	if (mini_method_needs_mrgctx (cmethod)) {
 		g_assert (!pass_vtable);
 
 		if (mono_method_is_generic_sharable_full (cmethod, TRUE, TRUE, TRUE)) {
@@ -2886,6 +2885,15 @@ mini_emit_initobj (MonoCompile *cfg, MonoInst *dest, const guchar *ip, MonoClass
 	}
 }
 
+static gboolean
+context_used_is_mrgctx (MonoCompile *cfg, int context_used)
+{
+	/* gshared dim methods use an mrgctx */
+	if (MONO_CLASS_IS_INTERFACE (cfg->method->klass))
+		return context_used != 0;
+	return context_used & MONO_GENERIC_CONTEXT_USED_METHOD;
+}
+
 /*
  * emit_get_rgctx:
  *
@@ -2905,11 +2913,13 @@ emit_get_rgctx (MonoCompile *cfg, int context_used)
 		!method->klass->valuetype)
 		EMIT_NEW_VARLOAD (cfg, this_ins, cfg->this_arg, &mono_defaults.object_class->byval_arg);
 
-	if (context_used & MONO_GENERIC_CONTEXT_USED_METHOD) {
+	if (context_used_is_mrgctx (cfg, context_used)) {
 		MonoInst *mrgctx_loc, *mrgctx_var;
 
-		g_assert (!this_ins);
-		g_assert (method->is_inflated && mono_method_get_context (method)->method_inst);
+		if (!MONO_CLASS_IS_INTERFACE (method->klass)) {
+			g_assert (!this_ins);
+			g_assert (method->is_inflated && mono_method_get_context (method)->method_inst);
+		}
 
 		mrgctx_loc = mono_get_vtable_var (cfg);
 		EMIT_NEW_TEMPLOAD (cfg, mrgctx_var, mrgctx_loc->inst_c0);
@@ -3084,7 +3094,7 @@ MonoInst*
 mini_emit_get_rgctx_klass (MonoCompile *cfg, int context_used,
 					  MonoClass *klass, MonoRgctxInfoType rgctx_type)
 {
-	MonoJumpInfoRgctxEntry *entry = mono_patch_info_rgctx_entry_new (cfg->mempool, cfg->method, context_used & MONO_GENERIC_CONTEXT_USED_METHOD, MONO_PATCH_INFO_CLASS, klass, rgctx_type);
+	MonoJumpInfoRgctxEntry *entry = mono_patch_info_rgctx_entry_new (cfg->mempool, cfg->method, context_used_is_mrgctx (cfg, context_used), MONO_PATCH_INFO_CLASS, klass, rgctx_type);
 	MonoInst *rgctx = emit_get_rgctx (cfg, context_used);
 
 	return emit_rgctx_fetch (cfg, rgctx, entry);
@@ -3094,7 +3104,7 @@ static MonoInst*
 emit_get_rgctx_sig (MonoCompile *cfg, int context_used,
 					MonoMethodSignature *sig, MonoRgctxInfoType rgctx_type)
 {
-	MonoJumpInfoRgctxEntry *entry = mono_patch_info_rgctx_entry_new (cfg->mempool, cfg->method, context_used & MONO_GENERIC_CONTEXT_USED_METHOD, MONO_PATCH_INFO_SIGNATURE, sig, rgctx_type);
+	MonoJumpInfoRgctxEntry *entry = mono_patch_info_rgctx_entry_new (cfg->mempool, cfg->method, context_used_is_mrgctx (cfg, context_used), MONO_PATCH_INFO_SIGNATURE, sig, rgctx_type);
 	MonoInst *rgctx = emit_get_rgctx (cfg, context_used);
 
 	return emit_rgctx_fetch (cfg, rgctx, entry);
@@ -3112,7 +3122,7 @@ emit_get_rgctx_gsharedvt_call (MonoCompile *cfg, int context_used,
 	call_info->sig = sig;
 	call_info->method = cmethod;
 
-	entry = mono_patch_info_rgctx_entry_new (cfg->mempool, cfg->method, context_used & MONO_GENERIC_CONTEXT_USED_METHOD, MONO_PATCH_INFO_GSHAREDVT_CALL, call_info, rgctx_type);
+	entry = mono_patch_info_rgctx_entry_new (cfg->mempool, cfg->method, context_used_is_mrgctx (cfg, context_used), MONO_PATCH_INFO_GSHAREDVT_CALL, call_info, rgctx_type);
 	rgctx = emit_get_rgctx (cfg, context_used);
 
 	return emit_rgctx_fetch (cfg, rgctx, entry);
@@ -3135,7 +3145,7 @@ emit_get_rgctx_virt_method (MonoCompile *cfg, int context_used,
 	info->klass = klass;
 	info->method = virt_method;
 
-	entry = mono_patch_info_rgctx_entry_new (cfg->mempool, cfg->method, context_used & MONO_GENERIC_CONTEXT_USED_METHOD, MONO_PATCH_INFO_VIRT_METHOD, info, rgctx_type);
+	entry = mono_patch_info_rgctx_entry_new (cfg->mempool, cfg->method, context_used_is_mrgctx (cfg, context_used), MONO_PATCH_INFO_VIRT_METHOD, info, rgctx_type);
 	rgctx = emit_get_rgctx (cfg, context_used);
 
 	return emit_rgctx_fetch (cfg, rgctx, entry);
@@ -3148,7 +3158,7 @@ emit_get_rgctx_gsharedvt_method (MonoCompile *cfg, int context_used,
 	MonoJumpInfoRgctxEntry *entry;
 	MonoInst *rgctx;
 
-	entry = mono_patch_info_rgctx_entry_new (cfg->mempool, cfg->method, context_used & MONO_GENERIC_CONTEXT_USED_METHOD, MONO_PATCH_INFO_GSHAREDVT_METHOD, info, MONO_RGCTX_INFO_METHOD_GSHAREDVT_INFO);
+	entry = mono_patch_info_rgctx_entry_new (cfg->mempool, cfg->method, context_used_is_mrgctx (cfg, context_used), MONO_PATCH_INFO_GSHAREDVT_METHOD, info, MONO_RGCTX_INFO_METHOD_GSHAREDVT_INFO);
 	rgctx = emit_get_rgctx (cfg, context_used);
 
 	return emit_rgctx_fetch (cfg, rgctx, entry);
@@ -3178,7 +3188,7 @@ emit_get_rgctx_method (MonoCompile *cfg, int context_used,
 			g_assert_not_reached ();
 		}
 	} else {
-		MonoJumpInfoRgctxEntry *entry = mono_patch_info_rgctx_entry_new (cfg->mempool, cfg->method, context_used & MONO_GENERIC_CONTEXT_USED_METHOD, MONO_PATCH_INFO_METHODCONST, cmethod, rgctx_type);
+		MonoJumpInfoRgctxEntry *entry = mono_patch_info_rgctx_entry_new (cfg->mempool, cfg->method, context_used_is_mrgctx (cfg, context_used), MONO_PATCH_INFO_METHODCONST, cmethod, rgctx_type);
 		MonoInst *rgctx = emit_get_rgctx (cfg, context_used);
 
 		return emit_rgctx_fetch (cfg, rgctx, entry);
@@ -3189,7 +3199,7 @@ static MonoInst*
 emit_get_rgctx_field (MonoCompile *cfg, int context_used,
 					  MonoClassField *field, MonoRgctxInfoType rgctx_type)
 {
-	MonoJumpInfoRgctxEntry *entry = mono_patch_info_rgctx_entry_new (cfg->mempool, cfg->method, context_used & MONO_GENERIC_CONTEXT_USED_METHOD, MONO_PATCH_INFO_FIELD, field, rgctx_type);
+	MonoJumpInfoRgctxEntry *entry = mono_patch_info_rgctx_entry_new (cfg->mempool, cfg->method, context_used_is_mrgctx (cfg, context_used), MONO_PATCH_INFO_FIELD, field, rgctx_type);
 	MonoInst *rgctx = emit_get_rgctx (cfg, context_used);
 
 	return emit_rgctx_fetch (cfg, rgctx, entry);

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -2889,7 +2889,7 @@ static gboolean
 context_used_is_mrgctx (MonoCompile *cfg, int context_used)
 {
 	/* gshared dim methods use an mrgctx */
-	if (MONO_CLASS_IS_INTERFACE (cfg->method->klass))
+	if (mini_method_is_default_method (cfg->method))
 		return context_used != 0;
 	return context_used & MONO_GENERIC_CONTEXT_USED_METHOD;
 }
@@ -2916,7 +2916,7 @@ emit_get_rgctx (MonoCompile *cfg, int context_used)
 	if (context_used_is_mrgctx (cfg, context_used)) {
 		MonoInst *mrgctx_loc, *mrgctx_var;
 
-		if (!MONO_CLASS_IS_INTERFACE (method->klass)) {
+		if (!mini_method_is_default_method (method)) {
 			g_assert (!this_ins);
 			g_assert (method->is_inflated && mono_method_get_context (method)->method_inst);
 		}

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -2645,8 +2645,7 @@ mini_method_get_mrgctx (MonoVTable *class_vtable, MonoMethod *method)
 	mono_domain_lock (domain);
 
 	if (!method_inst) {
-		/* Default interface methods */
-		g_assert (MONO_CLASS_IS_INTERFACE (method->klass));
+		g_assert (mini_method_is_default_method (method));
 
 		if (!domain_info->mrgctx_hash)
 			domain_info->mrgctx_hash = g_hash_table_new (NULL, NULL);
@@ -3009,7 +3008,7 @@ mono_method_needs_static_rgctx_invoke (MonoMethod *method, gboolean allow_type_v
 
 	return ((method->flags & METHOD_ATTRIBUTE_STATIC) ||
 			method->klass->valuetype ||
-			MONO_CLASS_IS_INTERFACE (method->klass)) &&
+			mini_method_is_default_method (method)) &&
 		(mono_class_is_ginst (method->klass) || mono_class_is_gtd (method->klass));
 }
 
@@ -3359,9 +3358,15 @@ mini_type_is_reference (MonoType *type)
 }
 
 gboolean
+mini_method_is_default_method (MonoMethod *m)
+{
+	return MONO_CLASS_IS_INTERFACE (m->klass) && !(m->flags & METHOD_ATTRIBUTE_ABSTRACT);
+}
+
+gboolean
 mini_method_needs_mrgctx (MonoMethod *m)
 {
-	if (mono_class_is_ginst (m->klass) && MONO_CLASS_IS_INTERFACE (m->klass) && !(m->flags & METHOD_ATTRIBUTE_ABSTRACT))
+	if (mono_class_is_ginst (m->klass) && mini_method_is_default_method (m))
 		return TRUE;
 	return (mini_method_get_context (m) && mini_method_get_context (m)->method_inst);
 }

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -2405,16 +2405,16 @@ mono_method_lookup_or_register_info (MonoMethod *method, gboolean in_mrgctx, gpo
 	MonoRgctxInfoType info_type, MonoGenericContext *generic_context)
 {
 	MonoClass *klass = method->klass;
-	int type_argc, index;
+	int type_argc = 0, index;
 
 	if (in_mrgctx) {
 		MonoGenericInst *method_inst = mono_method_get_context (method)->method_inst;
 
-		g_assert (method->is_inflated && method_inst);
-		type_argc = method_inst->type_argc;
-		g_assert (type_argc > 0);
-	} else {
-		type_argc = 0;
+		if (method_inst) {
+			g_assert (method->is_inflated && method_inst);
+			type_argc = method_inst->type_argc;
+			g_assert (type_argc > 0);
+		}
 	}
 
 	index = lookup_or_register_info (klass, type_argc, data, info_type, generic_context);
@@ -2470,7 +2470,7 @@ alloc_rgctx_array (MonoDomain *domain, int n, gboolean is_mrgctx)
 
 static gpointer
 fill_runtime_generic_context (MonoVTable *class_vtable, MonoRuntimeGenericContext *rgctx, guint32 slot,
-							  MonoGenericInst *method_inst, MonoError *error)
+							  MonoGenericInst *method_inst, gboolean is_mrgctx, MonoError *error)
 {
 	gpointer info;
 	int i, first_slot, size;
@@ -2492,13 +2492,13 @@ fill_runtime_generic_context (MonoVTable *class_vtable, MonoRuntimeGenericContex
 	   This might happen because lookup doesn't lock.  Allocate
 	   arrays on the way. */
 	first_slot = 0;
-	size = mono_class_rgctx_get_array_size (0, method_inst != NULL);
-	if (method_inst)
+	size = mono_class_rgctx_get_array_size (0, is_mrgctx);
+	if (is_mrgctx)
 		size -= MONO_SIZEOF_METHOD_RUNTIME_GENERIC_CONTEXT / sizeof (gpointer);
 	for (i = 0; ; ++i) {
 		int offset;
 
-		if (method_inst && i == 0)
+		if (is_mrgctx && i == 0)
 			offset = MONO_SIZEOF_METHOD_RUNTIME_GENERIC_CONTEXT / sizeof (gpointer);
 		else
 			offset = 0;
@@ -2513,10 +2513,10 @@ fill_runtime_generic_context (MonoVTable *class_vtable, MonoRuntimeGenericContex
 			break;
 		}
 		if (!rgctx [offset + 0])
-			rgctx [offset + 0] = alloc_rgctx_array (domain, i + 1, method_inst != NULL);
+			rgctx [offset + 0] = alloc_rgctx_array (domain, i + 1, is_mrgctx);
 		rgctx = (void **)rgctx [offset + 0];
 		first_slot += size - 1;
-		size = mono_class_rgctx_get_array_size (i + 1, method_inst != NULL);
+		size = mono_class_rgctx_get_array_size (i + 1, is_mrgctx);
 	}
 
 	g_assert (!rgctx [rgctx_index]);
@@ -2580,7 +2580,7 @@ mono_class_fill_runtime_generic_context (MonoVTable *class_vtable, guint32 slot,
 
 	mono_domain_unlock (domain);
 
-	info = fill_runtime_generic_context (class_vtable, rgctx, slot, 0, error);
+	info = fill_runtime_generic_context (class_vtable, rgctx, slot, NULL, FALSE, error);
 
 	DEBUG (printf ("get rgctx slot: %s %d -> %p\n", mono_type_full_name (&class_vtable->klass->byval_arg), slot, info));
 
@@ -2599,7 +2599,7 @@ mono_method_fill_runtime_generic_context (MonoMethodRuntimeGenericContext *mrgct
 {
 	gpointer info;
 
-	info = fill_runtime_generic_context (mrgctx->class_vtable, (MonoRuntimeGenericContext*)mrgctx, slot, mrgctx->method_inst, error);
+	info = fill_runtime_generic_context (mrgctx->class_vtable, (MonoRuntimeGenericContext*)mrgctx, slot, mrgctx->method_inst, TRUE, error);
 
 	return info;
 }
@@ -2638,18 +2638,30 @@ mini_method_get_mrgctx (MonoVTable *class_vtable, MonoMethod *method)
 	MonoMethodRuntimeGenericContext *mrgctx;
 	MonoMethodRuntimeGenericContext key;
 	MonoGenericInst *method_inst = mini_method_get_context (method)->method_inst;
+	MonoJitDomainInfo *domain_info = domain_jit_info (domain);
 
 	g_assert (!mono_class_is_gtd (class_vtable->klass));
-	g_assert (!method_inst->is_open);
 
 	mono_domain_lock (domain);
-	if (!domain->method_rgctx_hash)
-		domain->method_rgctx_hash = g_hash_table_new (mrgctx_hash_func, mrgctx_equal_func);
 
-	key.class_vtable = class_vtable;
-	key.method_inst = method_inst;
+	if (!method_inst) {
+		/* Default interface methods */
+		g_assert (MONO_CLASS_IS_INTERFACE (method->klass));
 
-	mrgctx = (MonoMethodRuntimeGenericContext *)g_hash_table_lookup (domain->method_rgctx_hash, &key);
+		if (!domain_info->mrgctx_hash)
+			domain_info->mrgctx_hash = g_hash_table_new (NULL, NULL);
+		mrgctx = g_hash_table_lookup (domain_info->mrgctx_hash, method);
+	} else {
+		g_assert (!method_inst->is_open);
+
+		if (!domain_info->method_rgctx_hash)
+			domain_info->method_rgctx_hash = g_hash_table_new (mrgctx_hash_func, mrgctx_equal_func);
+
+		key.class_vtable = class_vtable;
+		key.method_inst = method_inst;
+
+		mrgctx = (MonoMethodRuntimeGenericContext *)g_hash_table_lookup (domain_info->method_rgctx_hash, &key);
+	}
 
 	if (!mrgctx) {
 		//int i;
@@ -2658,7 +2670,10 @@ mini_method_get_mrgctx (MonoVTable *class_vtable, MonoMethod *method)
 		mrgctx->class_vtable = class_vtable;
 		mrgctx->method_inst = method_inst;
 
-		g_hash_table_insert (domain->method_rgctx_hash, mrgctx, mrgctx);
+		if (!method_inst)
+			g_hash_table_insert (domain_info->mrgctx_hash, method, mrgctx);
+		else
+			g_hash_table_insert (domain_info->method_rgctx_hash, mrgctx, mrgctx);
 
 		/*
 		g_print ("mrgctx alloced for %s <", mono_type_get_full_name (class_vtable->klass));
@@ -2892,10 +2907,6 @@ mono_method_is_generic_sharable_full (MonoMethod *method, gboolean allow_type_va
 										   gboolean allow_partial, gboolean allow_gsharedvt)
 {
 	if (!mono_method_is_generic_impl (method))
-		return FALSE;
-
-	if (MONO_CLASS_IS_INTERFACE (method->klass))
-		/* Default Interface Methods don't work yet with gshared */
 		return FALSE;
 
 	/*
@@ -3347,6 +3358,14 @@ mini_type_is_reference (MonoType *type)
 	return mono_type_is_reference (type);
 }
 
+gboolean
+mini_method_needs_mrgctx (MonoMethod *m)
+{
+	if (mono_class_is_ginst (m->klass) && MONO_CLASS_IS_INTERFACE (m->klass) && !(m->flags & METHOD_ATTRIBUTE_ABSTRACT))
+		return TRUE;
+	return (mini_method_get_context (m) && mini_method_get_context (m)->method_inst);
+}
+
 /*
  * mini_method_get_rgctx:
  *
@@ -3358,9 +3377,9 @@ mini_method_get_rgctx (MonoMethod *m)
 	ERROR_DECL (error);
 	MonoVTable *vt = mono_class_vtable_checked (mono_domain_get (), m->klass, error);
 	mono_error_assert_ok (error);
-	if (mini_method_get_context (m)->method_inst) {
+	if (mini_method_needs_mrgctx (m))
 		return mini_method_get_mrgctx (vt, m);
-	} else
+	else
 		return vt;
 }
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3693,6 +3693,10 @@ mini_free_jit_domain_info (MonoDomain *domain)
 	g_hash_table_destroy (info->delegate_trampoline_hash);
 	if (info->static_rgctx_trampoline_hash)
 		g_hash_table_destroy (info->static_rgctx_trampoline_hash);
+	if (info->mrgctx_hash)
+		g_hash_table_destroy (info->mrgctx_hash);
+	if (info->method_rgctx_hash)
+		g_hash_table_destroy (info->method_rgctx_hash);
 	g_hash_table_destroy (info->llvm_vcall_trampoline_hash);
 	mono_conc_hashtable_destroy (info->runtime_invoke_hash);
 	g_hash_table_destroy (info->seq_points);

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -51,6 +51,9 @@ typedef struct
 	GHashTable *llvm_jit_callees;
 	/* Maps MonoMethod -> RuntimeMethod */
 	MonoInternalHashTable interp_code_hash;
+	/* Maps MonoMethod -> 	MonoMethodRuntimeGenericContext */
+	GHashTable *mrgctx_hash;
+	GHashTable *method_rgctx_hash;
 } MonoJitDomainInfo;
 
 #define domain_jit_info(domain) ((MonoJitDomainInfo*)((domain)->runtime_info))

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2525,6 +2525,7 @@ gboolean mini_is_gsharedvt_variable_klass (MonoClass *klass) MONO_LLVM_INTERNAL;
 gboolean mini_is_gsharedvt_sharable_method (MonoMethod *method);
 gboolean mini_is_gsharedvt_variable_signature (MonoMethodSignature *sig);
 gboolean mini_is_gsharedvt_sharable_inst (MonoGenericInst *inst);
+gboolean mini_method_is_default_method (MonoMethod *m);
 gboolean mini_method_needs_mrgctx (MonoMethod *m);
 gpointer mini_method_get_rgctx (MonoMethod *m);
 void mini_init_gsctx (MonoDomain *domain, MonoMemPool *mp, MonoGenericContext *context, MonoGenericSharingContext *gsctx);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2525,6 +2525,7 @@ gboolean mini_is_gsharedvt_variable_klass (MonoClass *klass) MONO_LLVM_INTERNAL;
 gboolean mini_is_gsharedvt_sharable_method (MonoMethod *method);
 gboolean mini_is_gsharedvt_variable_signature (MonoMethodSignature *sig);
 gboolean mini_is_gsharedvt_sharable_inst (MonoGenericInst *inst);
+gboolean mini_method_needs_mrgctx (MonoMethod *m);
 gpointer mini_method_get_rgctx (MonoMethod *m);
 void mini_init_gsctx (MonoDomain *domain, MonoMemPool *mp, MonoGenericContext *context, MonoGenericSharingContext *gsctx);
 


### PR DESCRIPTION
This is needed because these methods can be part of more than one inheritance hierarchy or
be present more than once in the same inheritance hierarchy so its not possible to
assign rgxtx slots to their gshared entries that would work in all cases.