### PR TITLE
[aot] Emit the weak field indexes table using the MONO_AOT_TABLE code, so it works with separate aot data fiels/bitcode.

### DIFF
--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -114,6 +114,7 @@ typedef struct MonoAotModule {
 	guint8 *plt;
 	guint8 *plt_end;
 	guint8 *blob;
+	gpointer weak_field_indexes;
 	/* Maps method indexes to their code */
 	gpointer *methods;
 	/* Sorted array of method addresses */
@@ -2191,6 +2192,7 @@ if (container_assm_name && !container_amodule) {
 		amodule->extra_method_info_offsets = amodule->tables [MONO_AOT_TABLE_EXTRA_METHOD_INFO_OFFSETS];
 		amodule->got_info_offsets = amodule->tables [MONO_AOT_TABLE_GOT_INFO_OFFSETS];
 		amodule->llvm_got_info_offsets = amodule->tables [MONO_AOT_TABLE_LLVM_GOT_INFO_OFFSETS];
+		amodule->weak_field_indexes = amodule->tables [MONO_AOT_TABLE_WEAK_FIELD_INDEXES];
 	} else {
 		amodule->blob = info->blob;
 		amodule->method_info_offsets = (guint32 *)info->method_info_offsets;
@@ -2201,6 +2203,7 @@ if (container_assm_name && !container_amodule) {
 		amodule->extra_method_info_offsets = (guint32 *)info->extra_method_info_offsets;
 		amodule->got_info_offsets = info->got_info_offsets;
 		amodule->llvm_got_info_offsets = info->llvm_got_info_offsets;
+		amodule->weak_field_indexes = info->weak_field_indexes;
 	}
 	amodule->unbox_trampolines = (guint32 *)info->unbox_trampolines;
 	amodule->unbox_trampolines_end = (guint32 *)info->unbox_trampolines_end;
@@ -2636,7 +2639,7 @@ mono_aot_get_weak_field_indexes (MonoImage *image)
 		return NULL;
 
 	/* Initialize weak field indexes from the cached copy */
-	guint32 *indexes = amodule->info.weak_field_indexes;
+	guint32 *indexes = amodule->weak_field_indexes;
 	int len  = indexes [0];
 	GHashTable *indexes_hash = g_hash_table_new (NULL, NULL);
 	for (int i = 0; i < len; ++i)

--- a/mono/mini/aot-runtime.h
+++ b/mono/mini/aot-runtime.h
@@ -82,6 +82,7 @@ typedef enum {
 	MONO_AOT_TABLE_LLVM_GOT_INFO_OFFSETS,
 	MONO_AOT_TABLE_EXTRA_METHOD_INFO_OFFSETS,
 	MONO_AOT_TABLE_EXTRA_METHOD_TABLE,
+	MONO_AOT_TABLE_WEAK_FIELD_INDEXES,
 	MONO_AOT_TABLE_NUM
 } MonoAotFileTable;
 
@@ -109,6 +110,11 @@ typedef struct MonoAotFileInfo
 	gpointer jit_code_start;
 	gpointer jit_code_end;
 	gpointer method_addresses;
+
+	/*
+	 * Data tables.
+	 * One pointer for each entry in MonoAotFileTable.
+	 */
 	/* Data blob */
 	gpointer blob;
 	gpointer class_name_table;
@@ -120,6 +126,9 @@ typedef struct MonoAotFileInfo
 	gpointer got_info_offsets;
 	gpointer llvm_got_info_offsets;
 	gpointer image_table;
+	/* Points to an array of weak field indexes */
+	gpointer weak_field_indexes;
+
 	gpointer mem_end;
 	/* The GUID of the assembly which the AOT image was generated from */
 	gpointer assembly_guid;
@@ -148,9 +157,7 @@ typedef struct MonoAotFileInfo
 	gpointer unbox_trampolines_end;
 	/* Points to a table of unbox trampoline addresses/offsets */
 	gpointer unbox_trampoline_addresses;
-	/* Points to an array of weak field indexes */
-	gpointer weak_field_indexes;
-#define MONO_AOT_FILE_INFO_LAST_SYMBOL weak_field_indexes
+#define MONO_AOT_FILE_INFO_LAST_SYMBOL unbox_trampoline_addresses
 
 	/* Scalars */
 	/* The index of the first GOT slot used by the PLT */

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -8712,6 +8712,7 @@ emit_aot_file_info (MonoLLVMModule *module)
 		fields [tindex ++] = LLVMGetNamedGlobal (lmodule, "got_info_offsets");
 		fields [tindex ++] = LLVMGetNamedGlobal (lmodule, "llvm_got_info_offsets");
 		fields [tindex ++] = LLVMGetNamedGlobal (lmodule, "image_table");
+		fields [tindex ++] = LLVMGetNamedGlobal (lmodule, "weak_field_indexes");
 	}
 	/* Not needed (mem_end) */
 	fields [tindex ++] = LLVMConstNull (eltype);
@@ -8748,7 +8749,6 @@ emit_aot_file_info (MonoLLVMModule *module)
 		fields [tindex ++] = LLVMConstNull (eltype);
 		fields [tindex ++] = LLVMConstNull (eltype);
 	}
-	fields [tindex ++] = AddJitGlobal (module, eltype, "weak_field_indexes");
 
 	for (i = 0; i < MONO_AOT_FILE_INFO_NUM_SYMBOLS; ++i) {
 		g_assert (fields [2 + i]);


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/6948