### PR TITLE
[runtime] Compare custom modifiers in type equality

### DIFF
--- a/mono/dis/get.c
+++ b/mono/dis/get.c
@@ -1150,8 +1150,10 @@ dis_stringify_type (MonoImage *m, MonoType *type, gboolean is_def)
 	char *bare = NULL, *mods = NULL;
 	char *result;
 
-	if (type->num_mods)
-		mods = dis_stringify_modifiers (m, type->num_mods, type->modifiers);
+	if (type->has_cmods) {
+		MonoCustomModContainer *cmods = mono_type_get_cmods (type);
+		mods = dis_stringify_modifiers (cmods->image, cmods->count, cmods->modifiers);
+	}
 
 	switch (type->type){
 	case MONO_TYPE_BOOLEAN:

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7704,20 +7704,24 @@ type_array_from_modifiers (MonoImage *image, MonoType *type, int optional, MonoE
 	int i, count = 0;
 	MonoDomain *domain = mono_domain_get ();
 
+	MonoCustomModContainer *cmods = mono_type_get_cmods (type);
+	if (!cmods)
+		goto fail;
+
 	error_init (error);
-	for (i = 0; i < type->num_mods; ++i) {
-		if ((optional && !type->modifiers [i].required) || (!optional && type->modifiers [i].required))
+	for (i = 0; i < cmods->count; ++i) {
+		if ((optional && !cmods->modifiers [i].required) || (!optional && cmods->modifiers [i].required))
 			count++;
 	}
 	if (!count)
-		return MONO_HANDLE_NEW (MonoArray, NULL);
+		goto fail;
 
 	MonoArrayHandle res = mono_array_new_handle (domain, mono_defaults.systemtype_class, count, error);
 	goto_if_nok (error, fail);
 	count = 0;
-	for (i = 0; i < type->num_mods; ++i) {
-		if ((optional && !type->modifiers [i].required) || (!optional && type->modifiers [i].required)) {
-			if (!add_modifier_to_array (domain, image, &type->modifiers[i], res, count , error))
+	for (i = 0; i < cmods->count; ++i) {
+		if ((optional && !cmods->modifiers [i].required) || (!optional && cmods->modifiers [i].required)) {
+			if (!add_modifier_to_array (domain, image, &cmods->modifiers [i], res, count , error))
 				goto fail;
 			count++;
 		}

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -30,13 +30,33 @@ struct _MonoType {
 	} data;
 	unsigned int attrs    : 16; /* param attributes or field flags */
 	MonoTypeEnum type     : 8;
-	unsigned int num_mods : 6;  /* max 64 modifiers follow at the end */
+	unsigned int has_cmods : 1;  
 	unsigned int byref    : 1;
 	unsigned int pinned   : 1;  /* valid when included in a local var signature */
-	MonoCustomMod modifiers [MONO_ZERO_LEN_ARRAY]; /* this may grow */
 };
 
-#define MONO_SIZEOF_TYPE (offsetof (struct _MonoType, modifiers))
+typedef struct {
+	MonoType unmodified;
+	MonoCustomModContainer cmods;
+} MonoTypeWithModifiers;
+
+MonoCustomModContainer *
+mono_type_get_cmods (const MonoType *t);
+
+// Note: sizeof (MonoType) is dangerous. It can copy the num_mods
+// field without copying the variably sized array. This leads to
+// memory unsafety on the stack and/or heap, when we try to traverse
+// this array.
+//
+// Use mono_sizeof_monotype 
+// to get the size of the memory to copy.
+#define MONO_SIZEOF_TYPE sizeof (MonoType)
+
+size_t 
+mono_sizeof_type_with_mods (uint8_t num_mods);
+
+size_t 
+mono_sizeof_type (const MonoType *ty);
 
 #define MONO_SECMAN_FLAG_INIT(x)		(x & 0x2)
 #define MONO_SECMAN_FLAG_GET_VALUE(x)		(x & 0x1)

--- a/mono/metadata/metadata.h
+++ b/mono/metadata/metadata.h
@@ -309,6 +309,12 @@ typedef struct {
 	unsigned int token    : 31;
 } MonoCustomMod;
 
+typedef struct _MonoCustomModContainer {
+	uint8_t count; /* max 64 modifiers follow at the end */
+	MonoImage *image; /* Image containing types in modifiers array */
+	MonoCustomMod modifiers [1]; /* Actual length is count */
+} MonoCustomModContainer;
+
 struct _MonoArrayType {
 	MonoClass *eklass;
 	// Number of dimensions of the array

--- a/mono/metadata/sre-encode.c
+++ b/mono/metadata/sre-encode.c
@@ -671,19 +671,20 @@ mono_dynimage_encode_fieldref_signature (MonoDynamicImage *assembly, MonoImage *
 	
 	sigbuffer_add_value (&buf, 0x06);
 	/* encode custom attributes before the type */
-	if (type->num_mods) {
-		for (i = 0; i < type->num_mods; ++i) {
+	if (type->has_cmods) {
+		MonoCustomModContainer *cmods = mono_type_get_cmods (type);
+		for (i = 0; i < cmods->count; ++i) {
 			if (field_image) {
 				ERROR_DECL (error);
-				MonoClass *klass = mono_class_get_checked (field_image, type->modifiers [i].token, error);
+				MonoClass *klass = mono_class_get_checked (field_image, cmods->modifiers [i].token, error);
 				g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 
 				token = mono_image_typedef_or_ref (assembly, m_class_get_byval_arg (klass));
 			} else {
-				token = type->modifiers [i].token;
+				token = cmods->modifiers [i].token;
 			}
 
-			if (type->modifiers [i].required)
+			if (cmods->modifiers [i].required)
 				sigbuffer_add_byte (&buf, MONO_TYPE_CMOD_REQD);
 			else
 				sigbuffer_add_byte (&buf, MONO_TYPE_CMOD_OPT);

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -2898,7 +2898,7 @@ reflection_methodbuilder_to_mono_method (MonoClass *klass,
 			header->locals [i] = image_g_new0 (image, MonoType, 1);
 			MonoType *type = mono_reflection_type_get_handle ((MonoReflectionType*)lb->type, error);
 			mono_error_assert_ok (error);
-			memcpy (header->locals [i], type, MONO_SIZEOF_TYPE);
+			memcpy (header->locals [i], type, mono_sizeof_type (type));
 		}
 
 		header->num_clauses = num_clauses;

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -3115,7 +3115,9 @@ encode_type (MonoAotCompile *acfg, MonoType *t, guint8 *buf, guint8 **endbuf)
 {
 	guint8 *p = buf;
 
-	g_assert (t->num_mods == 0);
+	// Change memory allocation in decode_type if you change
+	g_assert (!t->has_cmods);
+
 	/* t->attrs can be ignored */
 	//g_assert (t->attrs == 0);
 

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -633,7 +633,9 @@ decode_type (MonoAotModule *module, guint8 *buf, guint8 **endbuf, MonoError *err
 	guint8 *p = buf;
 	MonoType *t;
 
-	t = (MonoType *)g_malloc0 (sizeof (MonoType));
+	// In encode_type, we have g_assert (!t->has_mods);
+	// This is the only reason we can do sizeof (MonoType)
+	t = (MonoType *) g_malloc0 (sizeof (MonoType));
 	error_init (error);
 
 	while (TRUE) {

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -531,6 +531,7 @@ TESTS_CS_SRC=		\
 	nullable_boxing.2.cs	\
 	valuetype-equals.cs	\
 	custom-modifiers.2.cs	\
+	custom-modifiers-inheritance.cs	\
 	bug-382986.cs	\
 	test-inline-call-stack.cs	\
 	bug-324535.cs	\
@@ -1100,6 +1101,7 @@ PROFILE_DISABLED_TESTS += \
 	bug-389886-2.exe	\
 	bug-349190.2.exe	\
 	bug-389886-sre-generic-interface-instances.exe	\
+	custom-modifiers-inheritance.exe	\
 	bug-462592.exe	\
 	bug-575941.exe	\
 	bug-389886-3.exe	\

--- a/mono/tests/custom-modifiers-inheritance.cs
+++ b/mono/tests/custom-modifiers-inheritance.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+
+public class Tests {
+	// This set of tests are for checking the impact of custom modifiers on vtable layout and
+	// method overrides. CustomModifiers are used for one thing and one thing alone, and that's making
+	// two method signatures that would otherwise be equal into unequal signatures. This is used by C++/CLI
+	// to tag primitive types with the C++-side type. For instance, this allows a single primitive type for 
+	// various integer types, but prevents a function taking an int from overriding a function taking a long.
+	//
+	// We have to use SRE or il to interact with it, as C# compilers don't do much with modifiers beyond
+	// reflection. There's no way to generate the below hierarchy and methods by compiling C#.
+
+	Object childNoModObj;
+	Object childOptModObj;
+	Object childSameModObj;
+	Object childForwardObj;
+	Object childBackwardObj;
+	MethodInfo invokeParentSig;
+	MethodInfo invokeParentForwardSig;
+
+	public static void DefineMethodM (TypeBuilder tb, string className, Type [] required_modifiers, Type [] optional_modifiers)
+	{
+		// Example il (no equivalent C# for modreqs)
+		// Note that the modifiers will change for each class
+		//
+		//    // method line 4
+		// .method public virtual hidebysig 
+		//        instance default string M (int32* modreq ([mscorlib]System.Runtime.CompilerServices.IsReadOnlyAttribute)  A_1)  cil managed 
+		// {
+		//     // Method begins at RVA 0x2104
+		// Code size 6 (0x6)
+		// 	.maxstack 8
+		// 	IL_0000:  ldstr "ChildSameMod"
+		// 	IL_0005:  ret 
+		//   } // end of method ChildSameMod::M
+		//
+
+		Type[][] req_mods = required_modifiers != null ? new Type [][] {required_modifiers} : null;
+		Type[][] opt_mods = optional_modifiers != null ? new Type [][] {optional_modifiers} : null;
+		MethodBuilder mbIM = tb.DefineMethod("M", MethodAttributes.Public | MethodAttributes.HideBySig |
+		        MethodAttributes.Virtual,
+		    CallingConventions.Standard,
+		    typeof (string), null, null,
+		    new Type[] {typeof (int *)}, req_mods, opt_mods);
+		ILGenerator il = mbIM.GetILGenerator();
+		il.Emit (OpCodes.Ldstr, className);
+		//il.Emit (OpCodes.Ldstr, className);
+		//il.Emit (OpCodes.Call, typeof(Console).GetMethod("WriteLine", new Type[] { typeof(string) }));
+		il.Emit (OpCodes.Ret);
+	}
+
+	public static void DefineMethodInvoke (TypeBuilder tb, string invokeName, MethodInfo target, Type argument)
+	{
+		// Example il (no equivalent C# for modreqs)
+		// Note that the modifiers will change as per the callee
+		//
+		//    .method public static
+		//           default string InvokeParentSig (class Parent A_0)  cil managed
+		//    {
+		//	// Code size 14 (0xe)
+		//	.maxstack 3
+		//	.locals init (
+		//		int32	V_0)
+		//	IL_0000:  ldarg.0
+		//	IL_0001:  ldc.i4.0
+		//	IL_0002:  stloc.0
+		//	IL_0003:  ldloca.s 0
+		//	IL_0005:  nop
+		//	IL_0006:  nop
+		//	IL_0007:  nop
+		//	IL_0008:  callvirt instance string class Parent::M(int32* modreq ([mscorlib]System.Runtime.CompilerServices.IsReadOnlyAttribute) )
+		//	IL_000d:  ret
+		//} // end of method Invoker::InvokeParentSig
+		// 
+		//
+
+		MethodBuilder mbIM = tb.DefineMethod(invokeName, MethodAttributes.Public | MethodAttributes.Static,
+		    CallingConventions.Standard,
+		    typeof (string), null, null,
+		    new Type [] {argument}, null, null);
+		ILGenerator il = mbIM.GetILGenerator();
+		var local = il.DeclareLocal (typeof (int));
+
+		il.Emit (OpCodes.Ldarg_0);
+		il.Emit (OpCodes.Ldc_I4_0);
+		il.Emit (OpCodes.Stloc, local);
+		il.Emit (OpCodes.Ldloca_S, 0);
+		il.Emit (OpCodes.Callvirt, target);
+
+		il.Emit (OpCodes.Ret);
+	}
+
+	public Tests ()
+	{
+		string name = "CustomModifiersOverride";
+		AssemblyName asmName = new AssemblyName(name);
+		AssemblyBuilder ab = AppDomain.CurrentDomain.DefineDynamicAssembly(asmName, AssemblyBuilderAccess.RunAndSave);
+		ModuleBuilder mb = ab.DefineDynamicModule(name, name + ".dll");
+
+		// Create class hierarchy:
+		// Parent > ChildSameMod
+		// Parent > ChildNoMod
+		// Parent > ChildOptMod
+		//
+		// The Same, No, and Opt labels describe whether it's the same modifiers,
+		// optional modifiers rather than required, or with no modifiers.
+		//
+		// ParentThreeForward > ChildThreeForward
+		// ParentThreeForward > ChildThreeBackward
+		//
+		// These have to do with ordering. There are 3 mods, and forward/backwards is
+		// relative and has to do with the order the modifiers appear in the IL.
+		//
+		// Each of these classes has a function called "M" with an int pointer argument which
+		// contains custom modifiers. Based on whether the child's method overrides the parent's
+		// method, we can tell whether the method signatures have been found equal by the underlying
+		// runtime, and whether the impact on VTable layout is correct.
+
+		var mods = new Type [] { typeof (System.Runtime.CompilerServices.IsReadOnlyAttribute) };
+	
+		var parent = mb.DefineType("Parent", TypeAttributes.Public);
+		DefineMethodM (parent, "Parent", mods, null);
+		var parentType = parent.CreateType ();
+	
+		var childSameMod = mb.DefineType("ChildSameMod", TypeAttributes.Public, parent);
+		DefineMethodM (childSameMod, "ChildSameMod", mods, null);
+		var childSameModType = childSameMod.CreateType ();
+
+		var childNoMod = mb.DefineType("ChildNoMod", TypeAttributes.Public, parent);
+		DefineMethodM (childNoMod, "ChildNoMod", null, null);
+		var childNoModType = childNoMod.CreateType ();
+
+		var childOptMod = mb.DefineType("ChildOptMod", TypeAttributes.Public, parent);
+		DefineMethodM (childOptMod, "ChildOptMod", null, mods);
+		var childOptModType = childOptMod.CreateType ();
+
+		var first_mod = typeof (System.Runtime.CompilerServices.IsReadOnlyAttribute);
+		var second_mod = typeof (System.Runtime.CompilerServices.SpecialNameAttribute);
+		var third_mod = typeof (System.Runtime.CompilerServices.IsConst);
+
+		var forwardMods = new Type [] {first_mod, second_mod, third_mod};
+		var backwardMods = new Type [] {third_mod, second_mod, first_mod};
+
+		var parentThreeForward = mb.DefineType("ParentThreeForward", TypeAttributes.Public);
+		DefineMethodM (parentThreeForward, "ParentThreeForward", forwardMods, null);
+		var parentThreeForwardType = parentThreeForward.CreateType ();
+
+		var childThreeForward = mb.DefineType("ChildThreeForward", TypeAttributes.Public, parentThreeForward);
+		DefineMethodM (childThreeForward, "ChildThreeForward", forwardMods, null);
+		var childThreeForwardType = childThreeForward.CreateType ();
+
+		var childThreeBackward = mb.DefineType("ChildThreeBackward", TypeAttributes.Public, parentThreeForward);
+		DefineMethodM (childThreeBackward, "ChildThreeBackward", backwardMods, null);
+		var childThreeBackwardType = childThreeBackward.CreateType ();
+
+		var invoker = mb.DefineType("Invoker", TypeAttributes.Public);
+		// Since we want to generate callvirt calls which contain references to the custom modifiers
+		// for the parent types, to actually probe overloading or not, we need to generate the classes the make those
+		// calls
+
+		var methodBaseReference = parentType.GetMethod ("M");
+		DefineMethodInvoke (invoker, "InvokeParentSig", methodBaseReference, parentType);
+
+		var methodBaseReferenceMultiple = parentThreeForwardType.GetMethod ("M");
+		DefineMethodInvoke (invoker, "InvokeParentThreeForwardSig", methodBaseReferenceMultiple, parentThreeForwardType);
+
+		var invokerType = invoker.CreateType ();
+
+		ab.Save(name + ".dll");
+
+		childNoModObj = Activator.CreateInstance (childNoModType);
+		childOptModObj = Activator.CreateInstance (childOptModType);
+		childSameModObj = Activator.CreateInstance (childSameModType);
+		childForwardObj = Activator.CreateInstance (childThreeForwardType);
+		childBackwardObj = Activator.CreateInstance (childThreeBackwardType);
+		invokeParentSig = invokerType.GetMethod ("InvokeParentSig");
+		invokeParentForwardSig = invokerType.GetMethod ("InvokeParentThreeForwardSig");
+	}
+
+	public static int Main () {
+		// The expected behavior can be near impossible to reproduce using this .exe on
+		// another CLR because many SRE implementations do not correctly use modifiers. To
+		// compare results with another runtime, get the dll saved by the above ab.Save()
+		// line, manually copy it over, and run it with the other CLR. 
+		var tester = new Tests ();
+		tester.TestModSufficient ();
+		tester.TestModNecessary ();
+		tester.TestModReqSameAsOpt ();
+		tester.TestModReqMulti ();
+		tester.TestModReqMultiNoOrder ();
+
+		return 0;
+	}
+
+	public void TestModSufficient()
+	{
+		var result = (string)invokeParentSig.Invoke(null, new Object[] { childSameModObj });
+		if (result != "ChildSameMod")
+			throw new Exception("TestModSufficient: Unexpected Class Override");
+		else
+			Console.WriteLine("Success: {0} {1}", childSameModObj.GetType().Name, result);
+	}
+	public void TestModNecessary()
+	{
+		var result = (string)invokeParentSig.Invoke(null, new Object[] { childNoModObj });
+		if (result != "Parent")
+			throw new Exception(String.Format("Unexpected Class Override: {0}", result));
+		else
+			Console.WriteLine("Success: {0} {1}", childNoModObj.GetType().Name, result);
+	}
+	public void TestModReqSameAsOpt()
+	{
+		var result = (string)invokeParentSig.Invoke(null, new Object[] { childOptModObj });
+		if (result != "Parent")
+			throw new Exception("Unexpected Class Override");
+		else
+			Console.WriteLine("Success: {0} {1}", childOptModObj.GetType().Name, result);
+	}
+	public void TestModReqMulti()
+	{
+		var result = (string)invokeParentForwardSig.Invoke(null, new Object[] { childForwardObj });
+		if (result != "ChildThreeForward")
+			throw new Exception(String.Format("Unexpected Class Override {0}, MULTIPLE MODS BROKEN", result));
+		else
+			Console.WriteLine("Success MULTI MODS: {0} {1}", childForwardObj.GetType().Name, result);
+	}
+	public void TestModReqMultiNoOrder()
+	{
+		var result = (string)invokeParentForwardSig.Invoke(null, new Object[] { childBackwardObj });
+		if (result != "ParentThreeForward")
+			throw new Exception(String.Format("Unexpected Class Override: {0}, ORDER MATTERS", result));
+		else
+			Console.WriteLine("Success ORDER MATTERS: {0} {1}", childBackwardObj.GetType().Name, result);
+	}
+}


### PR DESCRIPTION
Custom modifiers are an odd feature of .net which allow types to
be tagged. These tags are semantically relevant. A method with a
modifier should not override a method without a modifier, for
instance (github bug #6936).

We don't put enough information into the modifier to uniquely find the
Image associated with the token we have in the type. Modifiers from
different referring assemblies will have different tokens to refer to
the same modifier class, making it important to resolve the tokens to
MonoClass pointers at runtime. Pointer equality of these classes is the
way to determine two custom modifiers the same, or unique.

We cannot resolve the image just from the MonoType because it is
possible to put modifiers on primitive, builtin types. These builtin
types lack any filled-out pointers in the data block, meaning we have
zero metadata associated with our floating token.

Other places in the codebase fixed this by passing around MonoImages,
but adding a MonoImage argument to our type comparison function for
this single bug would be a very poor decision with much code churn all
throughout the runtime.

The bug above resolves to two I4 types, one of which has a modifier, one
of which does not.

In order to pass this MonoImage around, we need to put a reference to it
into something reachable from the MonoType. We can't put it in the
custom module type because that is exported. It is part of the public
API.

MonoTypes do not adhere to pointer equality, and custom modules are structs
baked directly into the MonoType. We need therefore to make MonoType
point to a MonoCustomModInternal, a new type. This type embeds the
public type as a struct and carries around the image as another element
in the struct.

All public interfaces still see the same metadata endpoints for parsing the
modules, including the icalls. It is only our type comparison code that
accesses our new field.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
