### PR TITLE
WSL does not nul terminate uname.release. memset(0) it first.

### DIFF
--- a/mono/metadata/environment.c
+++ b/mono/metadata/environment.c
@@ -70,6 +70,8 @@ ves_icall_System_Environment_GetOSVersionString (MonoError *error)
 #elif defined(HAVE_SYS_UTSNAME_H)
 	struct utsname name;
 
+    memset (&name, 0, sizeof (name)); // WSL does not always nul terminate.
+
 	if (uname (&name) >= 0) {
 		return mono_string_new_handle (mono_domain_get (), name.release, error);
 	}

--- a/mono/metadata/environment.c
+++ b/mono/metadata/environment.c
@@ -70,7 +70,7 @@ ves_icall_System_Environment_GetOSVersionString (MonoError *error)
 #elif defined(HAVE_SYS_UTSNAME_H)
 	struct utsname name;
 
-    memset (&name, 0, sizeof (name)); // WSL does not always nul terminate.
+	memset (&name, 0, sizeof (name)); // WSL does not always nul terminate.
 
 	if (uname (&name) >= 0) {
 		return mono_string_new_handle (mono_domain_get (), name.release, error);


### PR DESCRIPTION
WSL does not nul terminate uname.release. memset(0) it first.