### PR TITLE
[Mono.Posix] .NET Core compatibility - Use [In,Out] for arrays of structures

### DIFF
--- a/mcs/class/Mono.Posix/Mono.Unix.Native/Syscall.cs
+++ b/mcs/class/Mono.Posix/Mono.Unix.Native/Syscall.cs
@@ -3783,7 +3783,7 @@ namespace Mono.Unix.Native {
 		public static extern int epoll_ctl (int epfd, EpollOp op, int fd, ref EpollEvent ee);
 
 		[DllImport (LIBC, SetLastError=true, EntryPoint="epoll_wait")]
-		private static extern int sys_epoll_wait (int epfd, EpollEvent [] ee, int maxevents, int timeout);
+		private static extern int sys_epoll_wait (int epfd, [In,Out] EpollEvent [] ee, int maxevents, int timeout);
 		#endregion
 		
 		#region <sys/mman.h> Declarations
@@ -3866,7 +3866,7 @@ namespace Mono.Unix.Native {
 #pragma warning restore 649
 
 		[DllImport (LIBC, SetLastError=true, EntryPoint="poll")]
-		private static extern int sys_poll (_pollfd[] ufds, uint nfds, int timeout);
+		private static extern int sys_poll ([In,Out] _pollfd[] ufds, uint nfds, int timeout);
 
 		public static int poll (Pollfd [] fds, uint nfds, int timeout)
 		{


### PR DESCRIPTION
While Mono does copy the values of arrays back when they are marshaled
to unmanaged code, .NET does not seem to be doing this, and manifests
as the Syscall.poll invocation in Mono.Posix with .NET Core does not update
the values in the provided array.

The following example should print "Got 1 and 1" with the following command:

```
echo foo | dotnet run
```

But instead prints 0 and 1 on .NET Core, but the correct result with Mono.

This patch is going here for the sake of the Mono.Posix.NetCore package that
we publish.

Sample:

```csharp
using System;
using System.Runtime.InteropServices;

class X {
        private struct _pollfd {
                public int fd;
                public short events;
                public short revents;
        }

        [DllImport("libc")]
        static extern int poll ([In,Out]_pollfd[] ufds, uint nfds, int timeout);

        static void Main ()
        {
                var p2 = new _pollfd [1] { new _pollfd () { fd = 0, events = 1 } };
                var m = poll (p2, 1, -1);

                Console.WriteLine ("Got: {0} and {1}", n, pollmap [0].revents);
                Console.ReadLine ();
        }
}
```
