### PR TITLE
[2018-02] [aot] Bump aot file format version because of 7cac757e60cd61aa070f7e0fffca225364f58c0c.

### DIFF
--- a/mono/mini/aot-runtime.h
+++ b/mono/mini/aot-runtime.h
@@ -11,7 +11,7 @@
 #include "mini.h"
 
 /* Version number of the AOT file format */
-#define MONO_AOT_FILE_VERSION 142
+#define MONO_AOT_FILE_VERSION 143
 
 #define MONO_AOT_TRAMP_PAGE_SIZE 16384
 


### PR DESCRIPTION
Backport of #7079.

/cc @vargaz