### PR TITLE
[2018-02] Bug 60088 - Assertion at ../../../../external/mono/mono/mini/debugger-agent.c:4765, condition `array-\u003elen == 1\u0027 not met Problem was that I didn\u0027t consider `async void` method when adding that assert

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -322,6 +322,12 @@ public class Tests : TestsBase, ITest2
 			new Tests ().attach ();
 			return 0;
 		}
+		if (args.Length > 0 && args [0] == "step-out-void-async") {
+			var wait = new ManualResetEvent (false);
+			step_out_void_async (wait);
+			wait.WaitOne ();//Don't exist until step_out_void_async is executed...
+			return 0;
+		}
 		assembly_load ();
 		breakpoints ();
 		single_stepping ();
@@ -1741,6 +1747,19 @@ public class Tests : TestsBase, ITest2
 	public static void Bug59649 ()
 	{
 		UninitializedClass.Call();//Breakpoint here and step in
+	}
+
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	static async void step_out_void_async (ManualResetEvent wait)
+	{
+		await Task.Yield ();
+		step_out_void_async_2 ();
+		wait.Set ();
+	}
+
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	static void step_out_void_async_2 ()
+	{
 	}
 }
 

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -10,6 +10,7 @@ using Diag = System.Diagnostics;
 using System.Linq;
 using System.IO;
 using System.Security.Cryptography;
+using System.Threading.Tasks;
 
 using NUnit.Framework;
 
@@ -4284,6 +4285,25 @@ public class DebuggerTests
 		var req = create_step (e);
 		e = step_out (); // leave threadpool_bp
 		e = step_out (); // leave threadpool_io
+	}
+
+	[Test]
+	public void StepOutAsync () {
+		vm.Detach ();
+		Start (new string [] { "dtest-app.exe", "step-out-void-async" });
+		var e = run_until ("step_out_void_async_2");
+		create_step (e);
+		var e2 = step_out ();
+		assert_location (e2, "MoveNext");//we are in step_out_void_async
+		step_req.Disable ();
+		step_req.Depth = StepDepth.Out;
+		step_req.Enable ();
+		vm.Resume ();
+		var e3 = GetNextEvent ();
+		//after step-out from async void, execution should continue
+		//and runtime should exit
+		Assert.IsTrue (e3 is VMDeathEvent, e3.GetType().FullName);
+		vm = null;
 	}
 
 	[Test]


### PR DESCRIPTION
Backport of #6902.

/cc @vargaz