### PR TITLE
[corlib] Add System.Runtime.ProfileOptimization APIs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # This can be reset to 0 when Mono's version number is bumped
 # since it's part of the corlib version (the prefix '1' in the full
 # version number is to ensure the number isn't treated as octal in C)
-MONO_CORLIB_COUNTER=1
+MONO_CORLIB_COUNTER=2
 MONO_CORLIB_VERSION=`printf "1%02d%02d%02d%03d" $MONO_VERSION_MAJOR $MONO_VERSION_MINOR 0 $MONO_CORLIB_COUNTER`
 
 AC_DEFINE_UNQUOTED(MONO_CORLIB_VERSION,$MONO_CORLIB_VERSION,[Version of the corlib-runtime interface])

--- a/mcs/class/corlib/corlib.dll.sources
+++ b/mcs/class/corlib/corlib.dll.sources
@@ -1252,6 +1252,7 @@ ReferenceSources/AppContextDefaultValues.cs
 ../referencesource/mscorlib/system/resources/ultimateresourcefallbacklocation.cs
 
 ../referencesource/mscorlib/system/runtime/NgenServicingAttributes.cs
+../referencesource/mscorlib/system/runtime/ProfileOptimization.cs
 
 ../referencesource/mscorlib/system/runtime/exceptionservices/corruptingexceptioncommon.cs
 ../referencesource/mscorlib/system/runtime/exceptionservices/exceptionnotification.cs

--- a/mcs/class/referencesource/mscorlib/system/runtime/ProfileOptimization.cs
+++ b/mcs/class/referencesource/mscorlib/system/runtime/ProfileOptimization.cs
@@ -25,10 +25,21 @@ namespace System.Runtime {
     using System.Runtime.Versioning;
     using System.Runtime.CompilerServices;
 
-#if FEATURE_MULTICOREJIT
+#if FEATURE_MULTICOREJIT || MONO
 
     public static class ProfileOptimization
     {
+#if MONO
+        internal static void InternalSetProfileRoot(string directoryPath)
+        {
+            // ignore
+        }
+
+        internal static void InternalStartProfile(string profile, IntPtr ptrNativeAssemblyLoadContext)
+        {
+            // ignore
+        }
+#else
         [DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
         [SecurityCritical]
         [ResourceExposure(ResourceScope.None)]
@@ -40,6 +51,7 @@ namespace System.Runtime {
         [ResourceExposure(ResourceScope.None)]
         [SuppressUnmanagedCodeSecurity]
         internal static extern void InternalStartProfile(string profile, IntPtr ptrNativeAssemblyLoadContext);
+#endif
 
         [SecurityCritical]
         public static void SetProfileRoot(string directoryPath)


### PR DESCRIPTION
They are starting to be used by Roslyn (https://github.com/dotnet/roslyn/commit/eed147d330e92a55cb2daa26acb28fcde1776f04)
and without them we crash because we can't load the type.

Making the APIs no-ops is explicitly allowed by the docs (e.g. on single-core machine):
https://docs.microsoft.com/en-us/dotnet/api/system.runtime.profileoptimization.startprofile?view=netframework-4.7.1#Remarks
