### PR TITLE
[metadata] add missing MONO_ENTER/EXIT_GC_SAFE guards

### DIFF
--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -893,6 +893,7 @@ static gboolean lock_while_writing = FALSE;
 static gboolean
 is_file_writable (struct stat *st, const gchar *path)
 {
+	gboolean ret;
 #if __APPLE__
 	// OS X Finder "locked" or `ls -lO` "uchg".
 	// This only covers one of several cases where an OS X file could be unwritable through special flags.
@@ -915,7 +916,10 @@ is_file_writable (struct stat *st, const gchar *path)
 	/* Fallback to using access(2). It's not ideal as it might not take into consideration euid/egid
 	 * but it's the only sane option we have on unix.
 	 */
-	return access (path, W_OK) == 0;
+	MONO_ENTER_GC_SAFE;
+	ret = access (path, W_OK) == 0;
+	MONO_EXIT_GC_SAFE;
+	return ret;
 }
 
 


### PR DESCRIPTION
This commit adds missing `MONO_ENTER`/`EXIT_GC_SAFE` guards around `access(2)` in is_file_writable in `mono/metadata/w32file-unix.c`

This is necessary for correct behavior when either the cooperative GC is enabled, or `MONO_ENABLE_BLOCKING_TRANSITION` is used. Without this change, it's possible for the GC to get stuck waiting for the `access(2)` call to complete and hang all threads.

This is related to #7099, but not a fix for it. It just makes makes one of the workarounds suggested in that issue more viable. 