### PR TITLE
[System.ServiceModel] Prevent crash in Dispatcher.ListenerLoopManager…

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel.Dispatcher/ChannelDispatcher.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Dispatcher/ChannelDispatcher.cs
@@ -615,7 +615,8 @@ namespace System.ServiceModel.Dispatcher
 
 					if ((!(ex is SocketException)) && 
 					    (!(ex is XmlException)) &&
-					    (!(ex is IOException)))
+					    (!(ex is IOException)) &&
+					    rc != null)
 						rc.Reply (res);
 					
 					reply.Close (owner.DefaultCloseTimeout); // close the channel


### PR DESCRIPTION
….ProcessRequest

In certain cases of having concurrent WCF requests
HttpReplyChannel.TryReceiveRequest can return true with the context
being null ("at closing phase").

This patch prevents crashing the whole application with a
NullReferenceException as reported in issue #7134.

Whether this is just covering the issue over or a real fix is yet to be
determined.

Fixes https://github.com/mono/mono/issues/7134



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
