### PR TITLE
[metadata] Improve error message for loading unresolved types

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -204,7 +204,7 @@ done:
 	if (!res && mono_error_ok (error)) {
 		char *name = mono_class_name_from_token (image, type_token);
 		char *assembly = mono_assembly_name_from_token (image, type_token);
-		mono_error_set_type_load_name (error, name, assembly, "Could not resolve type with token %08x (from typeref, class/assembly %s, %s)", type_token, name, assembly);
+		mono_error_set_type_load_name (error, name, assembly, "Could not resolve type with token %08x from typeref (expected class '%s' in assembly '%s')", type_token, name, assembly);
 	}
 	return res;
 }
@@ -2623,7 +2623,7 @@ done:
 	if (!klass && mono_error_ok (error)) {
 		char *name = mono_class_name_from_token (image, type_token);
 		char *assembly = mono_assembly_name_from_token (image, type_token);
-		mono_error_set_type_load_name (error, name, assembly, "Could not resolve type with token %08x (class/assembly %s, %s)", type_token, name, assembly);
+		mono_error_set_type_load_name (error, name, assembly, "Could not resolve type with token %08x (expected class '%s' in assembly '%s')", type_token, name, assembly);
 	}
 
 	return klass;


### PR DESCRIPTION
I've been confused by the error a few times and seen others too, I think this should make the message clearer.

```
old: System.TypeLoadException: Could not resolve type with token 01000055 (from typeref, class/assembly System.Runtime.ProfileOptimization, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
new: System.TypeLoadException: Could not resolve type with token 01000055 from typeref (expected class 'System.Runtime.ProfileOptimization' in assembly 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089')
```
