### PR TITLE
[RFC] If an icall only has input pointers, just 'fix' them and pass in raw?

### DIFF
--- a/mcs/class/System.Core/System.IO.MemoryMappedFiles/MemoryMappedFile.cs
+++ b/mcs/class/System.Core/System.IO.MemoryMappedFiles/MemoryMappedFile.cs
@@ -93,22 +93,26 @@ namespace System.IO.MemoryMappedFiles
 			}
 		}
 
-		internal static IntPtr OpenFile (string path, FileMode mode, string mapName, out long capacity, MemoryMappedFileAccess access, MemoryMappedFileOptions options)
+		internal static unsafe IntPtr OpenFile (string path, FileMode mode, string mapName, out long capacity, MemoryMappedFileAccess access, MemoryMappedFileOptions options)
 		{
-			int error = 0;
-			IntPtr res = OpenFileInternal (path, mode, mapName, out capacity, access, options, out error);
-			if (error != 0)
-				throw CreateException (error, path);
-			return res;
+			fixed (char* fpath = path, fmapName = mapName) {
+				int error = 0;
+				IntPtr res = OpenFileInternal (path, mode, mapName, out capacity, access, options, out error);
+				if (error != 0)
+					throw CreateException (error, path);
+				return res;
+			}
 		}
 
-		internal static IntPtr OpenHandle (IntPtr handle, string mapName, out long capacity, MemoryMappedFileAccess access, MemoryMappedFileOptions options)
+		internal static unsafe IntPtr OpenHandle (IntPtr handle, string mapName, out long capacity, MemoryMappedFileAccess access, MemoryMappedFileOptions options)
 		{
-			int error = 0;
-			IntPtr res = OpenHandleInternal (handle, mapName, out capacity, access, options, out error);
-			if (error != 0)
-				throw CreateException (error, "<none>");
-			return res;
+			fixed (char* fmapName = mapName) {
+				int error = 0;
+				IntPtr res = OpenHandleInternal (handle, mapName, out capacity, access, options, out error);
+				if (error != 0)
+					throw CreateException (error, "<none>");
+				return res;
+			}
 		}
 	}
 


### PR DESCRIPTION
 Upside: Low churn. Might handle many cases.
 Downsides:
   - Centrinel doesn't understand. But could annotate.
   - Does not address return values, intermediates in implementation (including exceptions).
     Centrinel and obvious code inspection still handle those.
   - Return values could be out parameters? Do they offer any GC-related convenience?



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
