### PR TITLE
[corlib] Fix RuntimeFeatureTest.NoNewFeaturesAdded on mobile

### DIFF
--- a/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
+++ b/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
@@ -676,6 +676,9 @@
 			<method signature="System.Void .ctor(System.Object)" />
 		</type>
 
+		<!-- fields are accessed via reflection by external code -->
+		<type fullname="System.Runtime.CompilerServices.RuntimeFeature" preserve="fields" />
+
 		<!-- icall.c | object-internal.h: MonoReflectionDllImportAttribute structure -->
 		<type fullname="System.Runtime.InteropServices.DllImportAttribute" preserve="fields"/> 
 		<!-- marshal.c: emit_marshal_custom (DISABLE_JIT is not defined for the AOT compiler, only the ARM runtimes) -->

--- a/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
+++ b/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
@@ -676,9 +676,6 @@
 			<method signature="System.Void .ctor(System.Object)" />
 		</type>
 
-		<!-- fields are accessed via reflection by external code -->
-		<type fullname="System.Runtime.CompilerServices.RuntimeFeature" preserve="fields" />
-
 		<!-- icall.c | object-internal.h: MonoReflectionDllImportAttribute structure -->
 		<type fullname="System.Runtime.InteropServices.DllImportAttribute" preserve="fields"/> 
 		<!-- marshal.c: emit_marshal_custom (DISABLE_JIT is not defined for the AOT compiler, only the ARM runtimes) -->

--- a/mcs/class/corlib/Test/System.Runtime.CompilerServices/RuntimeFeatureTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.CompilerServices/RuntimeFeatureTest.cs
@@ -28,6 +28,7 @@
 
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Linq;
 
@@ -36,9 +37,21 @@ namespace MonoTests.System.Runtime.CompilerServices
     [TestFixture]
     public class RuntimeFeatureTest
     {
-        readonly (string, bool)[] ExpectedFeatures = new [] {
-            ("PortablePdb", true)
+        readonly Dictionary<string, bool> ExpectedFeatures = new Dictionary<string, bool> {
+            {"PortablePdb", true}
         };
+
+        [Test]
+        public void PortablePdbSupported ()
+        {
+            Assert.IsTrue (RuntimeFeature.IsSupported (RuntimeFeature.PortablePdb));
+        }
+
+        [Test]
+        public void NonExistingFeatureNotSupported ()
+        {
+            Assert.IsFalse (RuntimeFeature.IsSupported ("foo"));
+        }
 
         [Test]
         public void NoNewFeaturesAdded ()
@@ -47,11 +60,11 @@ namespace MonoTests.System.Runtime.CompilerServices
             var features = from field in t.GetFields()
                 where field.FieldType == typeof (string)
                 let value = field.GetValue (null)
-                select (
+                select new KeyValuePair<string, bool> (
                     field.Name,
                     RuntimeFeature.IsSupported ((string)value)
                 );
-            Assert.AreEqual (ExpectedFeatures, features.ToArray ());
+            CollectionAssert.AreEquivalent (ExpectedFeatures, features.ToDictionary (k => k.Key, v => v.Value));
         }
     }
 }

--- a/mcs/class/corlib/Test/System.Runtime.CompilerServices/RuntimeFeatureTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.CompilerServices/RuntimeFeatureTest.cs
@@ -64,6 +64,10 @@ namespace MonoTests.System.Runtime.CompilerServices
                     field.Name,
                     RuntimeFeature.IsSupported ((string)value)
                 );
+
+            if (features.Count() == 0)
+                Assert.Inconclusive ("No features found, this can happen when running the linker.");
+
             CollectionAssert.AreEquivalent (ExpectedFeatures, features.ToDictionary (k => k.Key, v => v.Value));
         }
     }


### PR DESCRIPTION
The code uses reflection to access all the fields in the RuntimeFeatures class. When running the linker we strip out these fields since they're `const` and the test fails because it can't find the expected values.

Since the linker always removes all constant fields we can't simply "use" the field in the test and instead we just bail out when encountering this case.

Also used Dictionary instead of tuples for the test since it renders better in the nunit output.

Fixes https://github.com/mono/mono/issues/7145
