### PR TITLE
Use proper sized integer for ioctlsocket on Win32.

### DIFF
--- a/mono/metadata/w32socket-win32.c
+++ b/mono/metadata/w32socket-win32.c
@@ -331,8 +331,10 @@ gint
 mono_w32socket_get_available (SOCKET sock, guint64 *amount)
 {
 	gint ret;
+	u_long amount_long = 0;
 	MONO_ENTER_GC_SAFE;
-	ret = ioctlsocket (sock, FIONREAD, (int*) amount);
+	ret = ioctlsocket (sock, FIONREAD, &amount_long);
+	*amount = amount_long;
 	MONO_EXIT_GC_SAFE;
 	return ret;
 }


### PR DESCRIPTION
Windows expects a 32-bit unsigned long in this API.
Previously we passed a 64-bit value and the actual amount
was stored in the wrong bits.
