### PR TITLE
[metadata] Cache GenericParamInfo for anonymous gparams in MonoImage

### DIFF
--- a/mono/dis/dump.c
+++ b/mono/dis/dump.c
@@ -578,14 +578,14 @@ dump_table_method (MonoImage *m)
 				mono_metadata_string_heap (m, mono_metadata_decode_row_col (td, current_type - 2, MONO_TYPEDEF_NAMESPACE)),
 				mono_metadata_string_heap (m, mono_metadata_decode_row_col (td, current_type - 2, MONO_TYPEDEF_NAME)));
 			first_m = last_m;
-			type_container = mono_metadata_load_generic_params (m, MONO_TOKEN_TYPE_DEF | (current_type - 1), NULL);
+			type_container = mono_metadata_load_generic_params (m, MONO_TOKEN_TYPE_DEF | (current_type - 1), NULL, NULL);
 			if (type_container) {
 				mono_metadata_load_generic_param_constraints_checked (m, MONO_TOKEN_TYPE_DEF | (current_type - 1), type_container, error);
 				g_assert (mono_error_ok (error)); /*FIXME don't swallow the error message*/
 			}
 		}
 
-		method_container = mono_metadata_load_generic_params (m, MONO_TOKEN_METHOD_DEF | i, type_container);
+		method_container = mono_metadata_load_generic_params (m, MONO_TOKEN_METHOD_DEF | i, type_container, NULL);
 		if (method_container) {
 			mono_metadata_load_generic_param_constraints_checked (m, MONO_TOKEN_METHOD_DEF | i, method_container, error);
 			g_assert (mono_error_ok (error)); /*FIXME don't swallow the error message*/

--- a/mono/dis/get.c
+++ b/mono/dis/get.c
@@ -899,7 +899,7 @@ dis_stringify_method_signature_full (MonoImage *m, MonoMethodSignature *method, 
 			ERROR_DECL (error);
 			const char *sig = mono_metadata_blob_heap (m, cols [MONO_METHOD_SIGNATURE]);
 
-			container = mono_metadata_load_generic_params (m, MONO_TOKEN_METHOD_DEF | methoddef_row, container);
+			container = mono_metadata_load_generic_params (m, MONO_TOKEN_METHOD_DEF | methoddef_row, container, NULL);
 			if (container) {
 				mono_metadata_load_generic_param_constraints_checked (m, MONO_TOKEN_METHOD_DEF | methoddef_row, container, error);
 				g_assert (mono_error_ok (error)); /*FIXME don't swallow the error message*/
@@ -1880,7 +1880,7 @@ get_memberref_container (MonoImage *m, guint32 mrp_token, MonoGenericContainer *
 
 	switch (table){
 	case 0: /* TypeDef */
-		return mono_metadata_load_generic_params (m, MONO_TOKEN_TYPE_DEF | idx, NULL);
+		return mono_metadata_load_generic_params (m, MONO_TOKEN_TYPE_DEF | idx, NULL, NULL);
 		
 	case 1: /* TypeRef */
 		return NULL;

--- a/mono/dis/main.c
+++ b/mono/dis/main.c
@@ -858,7 +858,7 @@ dis_method_list (const char *klass_name, MonoImage *m, guint32 start, guint32 en
 		sig = mono_metadata_blob_heap (m, cols [MONO_METHOD_SIGNATURE]);
 		mono_metadata_decode_blob_size (sig, &sig);
 
-		container = mono_metadata_load_generic_params (m, MONO_TOKEN_METHOD_DEF | (i + 1), type_container);
+		container = mono_metadata_load_generic_params (m, MONO_TOKEN_METHOD_DEF | (i + 1), type_container, NULL);
 		if (container) {
 			ERROR_DECL (error);
 			mono_metadata_load_generic_param_constraints_checked (m, MONO_TOKEN_METHOD_DEF | (i + 1), container, error);
@@ -1201,7 +1201,7 @@ dis_type (MonoImage *m, int n, int is_nested, int forward)
 		g_free (esnspace);
 	}
 
-	container = mono_metadata_load_generic_params (m, MONO_TOKEN_TYPE_DEF | (n + 1), NULL);
+	container = mono_metadata_load_generic_params (m, MONO_TOKEN_TYPE_DEF | (n + 1), NULL, NULL);
 	if (container) {
 		ERROR_DECL (error);
 		mono_metadata_load_generic_param_constraints_checked (m, MONO_TOKEN_TYPE_DEF | (n + 1), container, error);

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -378,10 +378,10 @@ mono_type_get_name_recurse (MonoType *type, GString *str, gboolean is_recursed,
 	}
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:
-		if (!mono_generic_param_info (type->data.generic_param))
+		if (!mono_generic_param_name (type->data.generic_param))
 			g_string_append_printf (str, "%s%d", type->type == MONO_TYPE_VAR ? "!" : "!!", type->data.generic_param->num);
 		else
-			g_string_append (str, mono_generic_param_info (type->data.generic_param)->name);
+			g_string_append (str, mono_generic_param_name (type->data.generic_param));
 
 		mono_type_name_check_byref (type, str);
 
@@ -605,16 +605,16 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 		if (!inst)
 			return NULL;
 		if (num >= inst->type_argc) {
-			MonoGenericParamInfo *info = mono_generic_param_info (type->data.generic_param);
+			const char *pname = mono_generic_param_name (type->data.generic_param);
 			mono_error_set_bad_image (error, image, "MVAR %d (%s) cannot be expanded in this context with %d instantiations",
-				num, info ? info->name : "", inst->type_argc);
+				num, pname ? pname : "", inst->type_argc);
 			return NULL;
 		}
 
 		if (!is_valid_generic_argument (inst->type_argv [num])) {
-			MonoGenericParamInfo *info = mono_generic_param_info (type->data.generic_param);
+			const char *pname = mono_generic_param_name (type->data.generic_param);
 			mono_error_set_bad_image (error, image, "MVAR %d (%s) cannot be expanded with type 0x%x",
-				num, info ? info->name : "", inst->type_argv [num]->type);
+				num, pname ? pname : "", inst->type_argv [num]->type);
 			return NULL;			
 		}
 		/*
@@ -634,15 +634,15 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 		if (!inst)
 			return NULL;
 		if (num >= inst->type_argc) {
-			MonoGenericParamInfo *info = mono_generic_param_info (type->data.generic_param);
+			const char *pname = mono_generic_param_name (type->data.generic_param);
 			mono_error_set_bad_image (error, image, "VAR %d (%s) cannot be expanded in this context with %d instantiations",
-				num, info ? info->name : "", inst->type_argc);
+				num, pname ? pname : "", inst->type_argc);
 			return NULL;
 		}
 		if (!is_valid_generic_argument (inst->type_argv [num])) {
-			MonoGenericParamInfo *info = mono_generic_param_info (type->data.generic_param);
+			const char *pname = mono_generic_param_name (type->data.generic_param);
 			mono_error_set_bad_image (error, image, "VAR %d (%s) cannot be expanded with type 0x%x",
-				num, info ? info->name : "", inst->type_argv [num]->type);
+				num, pname ? pname : "", inst->type_argv [num]->type);
 			return NULL;			
 		}
 		nt = mono_metadata_type_dup (image, inst->type_argv [num]);

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -2112,8 +2112,6 @@ mono_image_close_except_pools (MonoImage *image)
 		mono_conc_hashtable_destroy (image->var_gparam_cache);
 	if (image->mvar_gparam_cache)
 		mono_conc_hashtable_destroy (image->mvar_gparam_cache);
-	free_hash (image->var_cache_constrained);
-	free_hash (image->mvar_cache_constrained);
 	free_hash (image->wrapper_param_names);
 	free_hash (image->pinvoke_scopes);
 	free_hash (image->pinvoke_scope_filenames);

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -2108,8 +2108,6 @@ mono_image_close_except_pools (MonoImage *image)
 	free_hash (image->castclass_cache);
 	free_hash (image->icall_wrapper_cache);
 	free_hash (image->proxy_isinst_cache);
-	free_hash (image->var_cache_slow);
-	free_hash (image->mvar_cache_slow);
 	if (image->var_gparam_cache)
 		mono_conc_hashtable_destroy (image->var_gparam_cache);
 	if (image->mvar_gparam_cache)

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -2110,6 +2110,10 @@ mono_image_close_except_pools (MonoImage *image)
 	free_hash (image->proxy_isinst_cache);
 	free_hash (image->var_cache_slow);
 	free_hash (image->mvar_cache_slow);
+	if (image->var_gparam_cache)
+		mono_conc_hashtable_destroy (image->var_gparam_cache);
+	if (image->mvar_gparam_cache)
+		mono_conc_hashtable_destroy (image->mvar_gparam_cache);
 	free_hash (image->var_cache_constrained);
 	free_hash (image->mvar_cache_constrained);
 	free_hash (image->wrapper_param_names);

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -1693,12 +1693,10 @@ mono_get_method_from_token (MonoImage *image, guint32 token, MonoClass *klass,
 	 * is generic.
 	 */
 	if (*sig & 0x10) {
-		generic_container = mono_metadata_load_generic_params (image, token, container);
+		generic_container = mono_metadata_load_generic_params (image, token, container, result);
 	}
 	if (generic_container) {
 		result->is_generic = TRUE;
-		generic_container->owner.method = result;
-		generic_container->is_anonymous = FALSE; // Method is now known, container is no longer anonymous
 		/*FIXME put this before the image alloc*/
 		if (!mono_metadata_load_generic_param_constraints_checked (image, token, generic_container, error))
 			return NULL;

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -389,11 +389,6 @@ struct _MonoImage {
 	/* arguments */
 	MonoWrapperCaches wrapper_caches;
 
-	/* Caches for MonoClass-es representing anon generic params */
-	MonoClass **var_cache_fast;
-	MonoClass **mvar_cache_fast;
-	GHashTable *var_cache_slow;
-	GHashTable *mvar_cache_slow;
 	/* Pre-allocated anon generic params for the first N generic
 	 * parameters, for a small N */
 	MonoGenericParam *var_gparam_cache_fast;
@@ -401,6 +396,8 @@ struct _MonoImage {
 	/* Anon generic parameters past N, if needed */
 	MonoConcurrentHashTable *var_gparam_cache;
 	MonoConcurrentHashTable *mvar_gparam_cache;
+	/* Caches for MonoClasses for gparams with a gshared_constraint */
+	/* FIXME: get rid of these - cache in MonoGenericParamFull:pklass */
 	GHashTable *var_cache_constrained;
 	GHashTable *mvar_cache_constrained;
 

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -394,6 +394,13 @@ struct _MonoImage {
 	MonoClass **mvar_cache_fast;
 	GHashTable *var_cache_slow;
 	GHashTable *mvar_cache_slow;
+	/* Pre-allocated anon generic params for the first N generic
+	 * parameters, for a small N */
+	MonoGenericParam *var_gparam_cache_fast;
+	MonoGenericParam *mvar_gparam_cache_fast;
+	/* Anon generic parameters past N, if needed */
+	MonoConcurrentHashTable *var_gparam_cache;
+	MonoConcurrentHashTable *mvar_gparam_cache;
 	GHashTable *var_cache_constrained;
 	GHashTable *mvar_cache_constrained;
 
@@ -844,6 +851,9 @@ mono_assembly_fill_assembly_name_full (MonoImage *image, MonoAssemblyName *aname
 
 
 MONO_API guint32 mono_metadata_get_generic_param_row (MonoImage *image, guint32 token, guint32 *owner);
+
+MonoGenericParam*
+mono_metadata_create_anon_gparam (MonoImage *image, gint32 param_num, gboolean is_mvar);
 
 void mono_unload_interface_ids (MonoBitSet *bitset);
 

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -396,10 +396,6 @@ struct _MonoImage {
 	/* Anon generic parameters past N, if needed */
 	MonoConcurrentHashTable *var_gparam_cache;
 	MonoConcurrentHashTable *mvar_gparam_cache;
-	/* Caches for MonoClasses for gparams with a gshared_constraint */
-	/* FIXME: get rid of these - cache in MonoGenericParamFull:pklass */
-	GHashTable *var_cache_constrained;
-	GHashTable *mvar_cache_constrained;
 
 	/* Maps malloc-ed char* pinvoke scope -> MonoDl* */
 	GHashTable *pinvoke_scopes;

--- a/mono/metadata/sre-save.c
+++ b/mono/metadata/sre-save.c
@@ -996,7 +996,7 @@ write_generic_param_entry (MonoDynamicImage *assembly, GenericParamTableEntry *e
 	values [MONO_GENERICPARAM_OWNER] = entry->owner;
 	values [MONO_GENERICPARAM_FLAGS] = entry->gparam->attrs;
 	values [MONO_GENERICPARAM_NUMBER] = mono_generic_param_num (param);
-	values [MONO_GENERICPARAM_NAME] = string_heap_insert (&assembly->sheap, mono_generic_param_info (param)->name);
+	values [MONO_GENERICPARAM_NAME] = string_heap_insert (&assembly->sheap, mono_generic_param_name (param));
 
 	if (!mono_image_add_cattrs (assembly, table_idx, MONO_CUSTOM_ATTR_GENERICPAR, entry->gparam->cattrs, error))
 		return FALSE;

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -1628,7 +1628,7 @@ reflection_param_handle_mono_type (MonoReflectionGenericParamHandle ref_gparam, 
 	MonoStringHandle ref_name = MONO_HANDLE_NEW_GET (MonoString, ref_gparam, name);
 	param->info.name = mono_string_to_utf8_image (image, ref_name, error);
 	mono_error_assert_ok (error);
-	param->param.num = MONO_HANDLE_GETVAL (ref_gparam, index);
+	param->num = MONO_HANDLE_GETVAL (ref_gparam, index);
 
 	MonoReflectionMethodBuilderHandle ref_mbuilder = MONO_HANDLE_NEW_GET (MonoReflectionMethodBuilder, ref_gparam, mbuilder);
 	if (!MONO_HANDLE_IS_NULL (ref_mbuilder)) {
@@ -1644,13 +1644,13 @@ reflection_param_handle_mono_type (MonoReflectionGenericParamHandle ref_gparam, 
 			generic_container->owner.image = image;
 			MONO_HANDLE_SETVAL (ref_mbuilder, generic_container, MonoGenericContainer*, generic_container);
 		}
-		param->param.owner = generic_container;
+		param->owner = generic_container;
 	} else {
 		MonoType *type = mono_reflection_type_handle_mono_type (MONO_HANDLE_CAST (MonoReflectionType, ref_tbuilder), error);
 		goto_if_nok (error, leave);
 		MonoClass *owner = mono_class_from_mono_type (type);
 		g_assert (mono_class_is_gtd (owner));
-		param->param.owner = mono_class_get_generic_container (owner);
+		param->owner = mono_class_get_generic_container (owner);
 	}
 
 	MonoClass *pklass = mono_class_create_generic_parameter ((MonoGenericParam *) param);
@@ -2642,11 +2642,11 @@ reflection_init_generic_class (MonoReflectionTypeBuilderHandle ref_tb, MonoError
 		MonoGenericParamFull *param = (MonoGenericParamFull *) param_type->data.generic_param;
 		generic_container->type_params [i] = *param;
 		/*Make sure we are a diferent type instance */
-		generic_container->type_params [i].param.owner = generic_container;
+		generic_container->type_params [i].owner = generic_container;
 		generic_container->type_params [i].info.pklass = NULL;
 		generic_container->type_params [i].info.flags = MONO_HANDLE_GETVAL (ref_gparam, attrs);
 
-		g_assert (generic_container->type_params [i].param.owner);
+		g_assert (generic_container->type_params [i].owner);
 	}
 
 	generic_container->context.class_inst = mono_get_shared_generic_inst (generic_container);
@@ -2926,7 +2926,7 @@ reflection_methodbuilder_to_mono_method (MonoClass *klass,
 			mono_error_assert_ok (error);
 			MonoGenericParamFull *param = (MonoGenericParamFull *) gp_type->data.generic_param;
 			container->type_params [i] = *param;
-			container->type_params [i].param.owner = container;
+			container->type_params [i].owner = container;
 
 			gp->type.type->data.generic_param = (MonoGenericParam*)&container->type_params [i];
 

--- a/mono/metadata/verify.c
+++ b/mono/metadata/verify.c
@@ -1885,10 +1885,10 @@ dump_stack_value (ILStackDesc *value)
 				printf ("complex] (inst of %s )", value->type->data.generic_class->container_class->name);
 				return;
 			case MONO_TYPE_VAR:
-				printf ("complex] (type generic param !%d - %s) ", value->type->data.generic_param->num, mono_generic_param_info (value->type->data.generic_param)->name);
+				printf ("complex] (type generic param !%d - %s) ", value->type->data.generic_param->num, mono_generic_param_name (value->type->data.generic_param));
 				return;
 			case MONO_TYPE_MVAR:
-				printf ("complex] (method generic param !!%d - %s) ", value->type->data.generic_param->num, mono_generic_param_info (value->type->data.generic_param)->name);
+				printf ("complex] (method generic param !!%d - %s) ", value->type->data.generic_param->num, mono_generic_param_name (value->type->data.generic_param));
 				return;
 			default: {
 				//should be a boxed value 

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -3909,12 +3909,13 @@ create_gsharedvt_inst (MonoAotCompile *acfg, MonoMethod *method, MonoGenericCont
 	}
 	if (method->is_generic) {
 		container = mono_method_get_generic_container (method);
+		g_assert (!container->is_anonymous && container->is_method);
 		shared_context = container->context;
 		inst = shared_context.method_inst;
 
 		args = g_new0 (MonoType*, inst->type_argc);
 		for (i = 0; i < container->type_argc; ++i) {
-			MonoGenericParamInfo *info = &container->type_params [i].info;
+			MonoGenericParamInfo *info = mono_generic_param_info (&container->type_params [i]);
 			gboolean ref_only = FALSE;
 
 			if (info && info->constraints) {

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -555,10 +555,9 @@ decode_klass_ref (MonoAotModule *module, guint8 *buf, guint8 **endbuf, MonoError
 				t->data.generic_param = mono_generic_container_get_param (container, num);
 			} else {
 				/* Anonymous */
-				MonoGenericParam *par = (MonoGenericParam*)mono_image_alloc0 (module->assembly->image, sizeof (MonoGenericParamFull));
-				par->owner = container;
-				par->num = num;
+				MonoGenericParam *par = mono_metadata_create_anon_gparam (module->assembly->image, num, type == MONO_TYPE_MVAR);
 				t->data.generic_param = par;
+				// FIXME: maybe do this for all anon gparams?
 				((MonoGenericParamFull*)par)->info.name = make_generic_name_string (module->assembly->image, num);
 			}
 			// FIXME: Maybe use types directly to avoid

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -3460,7 +3460,7 @@ shared_gparam_hash (gconstpointer data)
 	guint hash;
 
 	hash = mono_metadata_generic_param_hash (p->parent);
-	hash = ((hash << 5) - hash) ^ mono_metadata_type_hash (p->param.param.gshared_constraint);
+	hash = ((hash << 5) - hash) ^ mono_metadata_type_hash (p->param.gshared_constraint);
 
 	return hash;
 }
@@ -3475,7 +3475,7 @@ shared_gparam_equal (gconstpointer ka, gconstpointer kb)
 		return TRUE;
 	if (p1->parent != p2->parent)
 		return FALSE;
-	if (!mono_metadata_type_equal (p1->param.param.gshared_constraint, p2->param.param.gshared_constraint))
+	if (!mono_metadata_type_equal (p1->param.gshared_constraint, p2->param.gshared_constraint))
 		return FALSE;
 	return TRUE;
 }
@@ -3496,7 +3496,7 @@ mini_get_shared_gparam (MonoType *t, MonoType *constraint)
 
 	memset (&key, 0, sizeof (key));
 	key.parent = par;
-	key.param.param.gshared_constraint = constraint;
+	key.param.gshared_constraint = constraint;
 
 	g_assert (mono_generic_param_info (par));
 	image = get_image_for_generic_param(par);
@@ -3524,9 +3524,10 @@ mini_get_shared_gparam (MonoType *t, MonoType *constraint)
 	copy->param.info.name = mono_image_strdup (image, name);
 	g_free (name);
 
-	copy->param.param.owner = par->owner;
+	copy->param.owner = par->owner;
+	g_assert (!par->owner->is_anonymous);
 
-	copy->param.param.gshared_constraint = constraint;
+	copy->param.gshared_constraint = constraint;
 	copy->parent = par;
 	res = mono_metadata_type_dup (NULL, t);
 	res->data.generic_param = (MonoGenericParam*)copy;


### PR DESCRIPTION

### Fix Leaks of `MonoGenericInst` and `MonoGenericParam`

Fix a couple of memory leaks that show up in pathological examples like https://bugzilla.xamarin.com/show_bug.cgi?id=48707 where we repeatedly allocate provisional metadata that cause `MonoImage` mempools to grow forever.

1. The argument to `mono_metadata_get_generic_inst` should be malloc'd instead of being mempool-alloc'd since `mono_metadata_get_generic_inst` will create a copy when it makes the canonical `MonoGenericInst`.
2. When parsing an anonymous generic param, mempool-alloc at most one copy of an anonymous `MonoGenericParam` per image instead of allocating a fresh one every time.  (This matters if we repeatedly call `method_from_methodspec` when JITing one generic method that calls another.)

### Simplify `MonoGenericParam` representations and `MonoClass` caching

Previously we had `MonoGenericParam` and `MonoGenericParamFull`.  The "full" param included an extra `MonoGenericParamInfo` field.  Params without the info were "small".   Anonymous gparams were previously small.  Because small params don't have a `MonoGenericParamInfo:pklass` field, we couldn't cache the `MonoClass` created for an anonymous generic param inside the param itself.  It's not clear if this brought any space savings.

After this PR, we have `typedef MonoGenericParam MonoGenericParamFull` - all gparams are "full".
This means we can get rid of the 6 `MonoClass` caches in `MonoImage`.