### PR TITLE
[runtime] Don't prepend '0x' to %p-formatted numbers.

### DIFF
--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2811,7 +2811,7 @@ mono_print_thread_dump_internal (void *sigctx, MonoContext *start_ctx)
 	else
 		g_string_append (text, "\n\"<unnamed thread>\"");
 
-	g_string_append_printf (text, " tid=0x%p this=0x%p ", (gpointer)(gsize)thread->tid, thread);
+	g_string_append_printf (text, " tid=%p this=%p ", (gpointer)(gsize)thread->tid, thread);
 	mono_thread_internal_describe (thread, text);
 	g_string_append (text, "\n");
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->

%p-formatted numbers already include '0x'

Fixes this output when dumping threads:

    "Threadpool worker" tid=0x0x7000105cc000 this=0x0x10bc18508 , thread handle : 0x7fbb9e6c6c90, state : not waiting

to become:

    "Threadpool worker" tid=0x7000105cc000 this=0x10bc18508 , thread handle : 0x7fbb9e6c6c90, state : not waiting