### PR TITLE
[corlib] Support terminals without color support

### DIFF
--- a/mcs/class/corlib/System/TermInfoDriver.cs
+++ b/mcs/class/corlib/System/TermInfoDriver.cs
@@ -391,6 +391,10 @@ namespace System {
 
 		void ChangeColor (string format, ConsoleColor color)
 		{
+			if (String.IsNullOrEmpty (format))
+				// the terminal doesn't support colors
+				return;
+
 			int ccValue = (int)color;
 			if ((ccValue & ~0xF) != 0)
 				throw new ArgumentException("Invalid Console Color");


### PR DESCRIPTION
Some terminals like vt220 don't have a format string for setting foreground
or background colors. In that case, the set*color members of the
TermInfoDriver are set to null and trying to set the background color throws.

I tried to run an ASP.NET Core app with its console logger on Mono while using a serial connection to my embedded ARM device. That console was configured with TERM=vt220. The console logger tries to switch to a green color when it receives a request and that throws:

```
System.ArgumentNullException: Value cannot be null.
Parameter name: format
  at System.ParameterizedStrings.Evaluate (System.String format, System.ParameterizedStrings+FormatParam[] args) [0x00003] in <83db5af180cb41aa9cb5c28dd875b8c8>:0
  at System.TermInfoDriver.ChangeColor (System.String format, System.ConsoleColor color) [0x00032] in <83db5af180cb41aa9cb5c28dd875b8c8>:0
  at System.TermInfoDriver.set_BackgroundColor (System.ConsoleColor value) [0x0000e] in <83db5af180cb41aa9cb5c28dd875b8c8>:0
  at System.ConsoleDriver.set_BackgroundColor (System.ConsoleColor value) [0x00019] in <83db5af180cb41aa9cb5c28dd875b8c8>:0
  at System.Console.set_BackgroundColor (System.ConsoleColor value) [0x00000] in <83db5af180cb41aa9cb5c28dd875b8c8>:0
  at Microsoft.Extensions.Logging.Console.Internal.WindowsLogConsole.SetColor (System.Nullable`1[T] background, System.Nullable`1[T] foreground) [0x00010] in <2603c9c8dd694a3e883db34fc012f771>:0
  at Microsoft.Extensions.Logging.Console.Internal.WindowsLogConsole.Write (System.String message, System.Nullable`1[T] background, System.Nullable`1[T] foreground) [0x00000] in <2603c9c8dd694a3e883db34fc012f771>:0
  at Microsoft.Extensions.Logging.Console.Internal.ConsoleLoggerProcessor.WriteMessage (Microsoft.Extensions.Logging.Console.Internal.LogMessageEntry message) [0x00008] in <2603c9c8dd694a3e883db34fc012f771>:0
  at Microsoft.Extensions.Logging.Console.Internal.ConsoleLoggerProcessor.ProcessLogQueue () [0x0001a] in <2603c9c8dd694a3e883db34fc012f771>:0
  at Microsoft.Extensions.Logging.Console.Internal.ConsoleLoggerProcessor.ProcessLogQueue (System.Object state) [0x00000] in <2603c9c8dd694a3e883db34fc012f771>:0
  at System.Threading.Tasks.Task.InnerInvoke () [0x00025] in <83db5af180cb41aa9cb5c28dd875b8c8>:0
  at System.Threading.Tasks.Task.Execute () [0x00010] in <83db5af180cb41aa9cb5c28dd875b8c8>:0 <---
```

This PR changes the behavior to be in line with CoreFX, which doesn't try to set a foreground or background color when the terminal doesn't support it:
https://github.com/dotnet/corefx/blob/fc225bd023e4e692d18442b02454cada7c252368/src/System.Console/src/System/ConsolePal.Unix.cs#L536

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
