### PR TITLE
Provide a little wchar_t support in public API (customer suggestion).

### DIFF
--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -788,6 +788,12 @@ gunichar  *g_utf16_to_ucs4 (const gunichar2 *str, glong len, glong *items_read, 
 gchar     *g_ucs4_to_utf8  (const gunichar *str, glong len, glong *items_read, glong *items_written, GError **err);
 gunichar2 *g_ucs4_to_utf16 (const gunichar *str, glong len, glong *items_read, glong *items_written, GError **err);
 
+gchar*
+g_wcs_to_utf8 (const wchar_t *str, glong length);
+
+gchar**
+g_argvw_to_argv (int argc, wchar_t *argv [ ]);
+
 #define u8to16(str) g_utf8_to_utf16(str, (glong)strlen(str), NULL, NULL, NULL)
 
 #ifdef G_OS_WIN32

--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -194,6 +194,7 @@ common_sources = \
 	metadata.c		\
 	metadata-verify.c	\
 	metadata-internals.h	\
+	metadataw.c		\
 	method-builder.h 	\
 	method-builder.c 	\
 	mono-basic-block.c	\

--- a/mono/metadata/appdomain.h
+++ b/mono/metadata/appdomain.h
@@ -30,11 +30,20 @@ typedef void (*MonoDomainFunc) (MonoDomain *domain, void* user_data);
 MONO_API MonoDomain*
 mono_init                  (const char *filename);
 
+MONO_API MonoDomain*
+mono_init_w                (const wchar_t *filename);
+
 MONO_API MonoDomain *
 mono_init_from_assembly    (const char *domain_name, const char *filename);
 
 MONO_API MonoDomain *
+mono_init_from_assembly_w  (const wchar_t *domain_name, const wchar_t *filename);
+
+MONO_API MonoDomain *
 mono_init_version          (const char *domain_name, const char *version);
+
+MONO_API MonoDomain *
+mono_init_version_w        (const wchar_t *domain_name, const wchar_t *version);
 
 MONO_API MonoDomain*
 mono_get_root_domain       (void);
@@ -110,6 +119,9 @@ mono_domain_foreach        (MonoDomainFunc func, void* user_data);
 
 MONO_API MonoAssembly *
 mono_domain_assembly_open  (MonoDomain *domain, const char *name);
+
+MONO_API MonoAssembly *
+mono_domain_assembly_open_w (MonoDomain *domain, const wchar_t *name);
 
 MONO_API mono_bool
 mono_domain_finalize       (MonoDomain *domain, uint32_t timeout);
@@ -236,4 +248,3 @@ mono_security_set_core_clr_platform_callback (MonoCoreClrPlatformCB callback);
 MONO_END_DECLS
 
 #endif /* _MONO_METADATA_APPDOMAIN_H_ */
-

--- a/mono/metadata/metadataw.c
+++ b/mono/metadata/metadataw.c
@@ -1,0 +1,67 @@
+/**
+ * \file
+ * functions that accept wchar_t strings
+ * see https://github.com/mono/mono/issues/7117
+ *
+ * Author:
+ *	Jay Krell (jaykrell@microsoft.com)
+ *
+ * Copyright (C) 2018 Microsoft Corporation (http://www.microsoft.com)
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+#include <config.h>
+#include <glib.h>
+#include <mono/metadata/appdomain.h>
+
+MonoAssembly *
+mono_domain_assembly_open_w (MonoDomain *domain, const wchar_t *name_w)
+{
+	gchar *name = g_wcs_to_utf8 (name_w, -1);
+
+	MonoAssembly *result = mono_domain_assembly_open (domain, name);
+
+	g_free (name);
+
+	return result;
+}
+
+MonoDomain *
+mono_init_w (const wchar_t *filename_w)
+{
+	gchar *filename = g_wcs_to_utf8 (filename_w, -1);
+
+	MonoDomain *domain = mono_init (filename);
+
+	g_free (filename);
+
+	return domain;
+}
+
+MonoDomain *
+mono_init_from_assembly_w (const wchar_t *domain_name_w, const wchar_t *filename_w)
+{
+	gchar *domain_name = g_wcs_to_utf8 (domain_name_w, -1);
+	gchar *filename = g_wcs_to_utf8 (filename_w, -1);
+
+	MonoDomain *domain = mono_init_from_assembly (domain_name, filename);
+
+	g_free (domain_name);
+	g_free (filename);
+
+	return domain;
+}
+
+MonoDomain *
+mono_init_version_w (const wchar_t *domain_name_w, const wchar_t *version_w)
+{
+	gchar *domain_name = g_wcs_to_utf8 (domain_name_w, -1);
+	gchar *version = g_wcs_to_utf8 (version_w, -1);
+
+	MonoDomain *domain = mono_init_version (domain_name, version);
+
+	g_free (domain_name);
+	g_free (version);
+
+	return domain;
+}

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -395,6 +395,7 @@ endif
 
 common_sources = \
 	mini.c			\
+	miniw.c			\
 	mini-runtime.c	\
 	seq-points.c	\
 	seq-points.h	\

--- a/mono/mini/jit.h
+++ b/mono/mini/jit.h
@@ -16,12 +16,22 @@ MONO_BEGIN_DECLS
 MONO_API MonoDomain * 
 mono_jit_init              (const char *file);
 
+MONO_API MonoDomain *
+mono_jit_init_w            (const wchar_t *file);
+
 MONO_API MonoDomain * 
 mono_jit_init_version      (const char *root_domain_name, const char *runtime_version);
+
+MONO_API MonoDomain *
+mono_jit_init_version_w    (const wchar_t *root_domain_name, const wchar_t *runtime_version);
 
 MONO_API int
 mono_jit_exec              (MonoDomain *domain, MonoAssembly *assembly, 
 			    int argc, char *argv[]);
+
+MONO_API int
+mono_jit_exec_w (MonoDomain *domain, MonoAssembly *assembly, int argc, wchar_t *argv [ ]);
+
 MONO_API void        
 mono_jit_cleanup           (MonoDomain *domain);
 

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -342,6 +342,8 @@ jinfo_get_method (MonoJitInfo *ji)
 
 /* main function */
 MONO_API int         mono_main                      (int argc, char* argv[]);
+MONO_API int
+mono_main_w (int argc, wchar_t* argv [ ]);
 MONO_API void        mono_set_defaults              (int verbose_level, guint32 opts);
 MONO_API void        mono_parse_env_options         (int *ref_argc, char **ref_argv []);
 MONO_API char       *mono_parse_options_from        (const char *options, int *ref_argc, char **ref_argv []);

--- a/mono/mini/miniw.c
+++ b/mono/mini/miniw.c
@@ -1,0 +1,66 @@
+/**
+ * \file
+ * functions that accept wchar_t strings
+ * see https://github.com/mono/mono/issues/7117
+ *
+ * Author:
+ *	Jay Krell (jaykrell@microsoft.com)
+ *
+ * Copyright (C) 2018 Microsoft Corporation (http://www.microsoft.com)
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+#include <config.h>
+#include <glib.h>
+#include <mono/mini/jit.h>
+#include <mono/mini/mini-runtime.h>
+
+int
+mono_main_w (int argc, wchar_t* argv_w[])
+{
+	gchar **argv = g_argvw_to_argv (argc, argv_w);
+
+	int result = mono_main (argc, argv);
+
+	g_strfreev (argv);
+
+	return result;
+}
+
+MonoDomain *
+mono_jit_init_w (const wchar_t *file_w)
+{
+	gchar *file = g_wcs_to_utf8 (file_w, -1);
+
+	MonoDomain *domain = mono_jit_init (file);
+
+	g_free (file);
+
+	return domain;
+}
+
+MonoDomain *
+mono_jit_init_version_w (const wchar_t *root_domain_name_w, const wchar_t *runtime_version_w)
+{
+	gchar *root_domain_name = g_wcs_to_utf8 (root_domain_name_w, -1);
+	gchar *runtime_version = g_wcs_to_utf8 (runtime_version_w, -1);
+
+	MonoDomain *domain = mono_jit_init_version (root_domain_name, runtime_version);
+
+	g_free (root_domain_name);
+	g_free (runtime_version);
+
+	return domain;
+}
+
+int
+mono_jit_exec_w (MonoDomain *domain, MonoAssembly *assembly, int argc, wchar_t *argv_w[])
+{
+	gchar **argv = g_argvw_to_argv (argc, argv_w);
+
+	int result = mono_jit_exec (domain, assembly, argc, argv);
+
+	g_strfreev (argv);
+
+	return result;
+}


### PR DESCRIPTION
In particular, instead of char* presumed utf8 and easy to get wrong,
some work for users to get correct, provide for wchar_t input, which
is easy to get correct.

Implementation just turns around and translates to utf8, which isn't really ideal
but is a path of significantly less resistance.

See https://github.com/mono/mono/issues/7117
Chinese characters cause "String conversion error: Illegal byte sequence encounted in the input." #7117

which this does most of the work to "fix".
The remaining is for the customer to change "A" to "W", char to wchar_t or WCHAR, str to wcs.