### PR TITLE
[2018-02] [runtime] Magic interfaces requires the complex stelemref to handle arrays. Fixes gh #6266

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -9807,6 +9807,11 @@ get_virtual_stelemref_kind (MonoClass *element_class)
 		return STELEMREF_OBJECT;
 	if (is_monomorphic_array (element_class))
 		return STELEMREF_SEALED_CLASS;
+
+	/* magic ifaces requires aditional checks for when the element type is an array */
+	if (MONO_CLASS_IS_INTERFACE (element_class) && element_class->is_array_special_interface)
+		return STELEMREF_COMPLEX;
+
 	/* Compressed interface bitmaps require code that is quite complex, so don't optimize for it. */
 	if (MONO_CLASS_IS_INTERFACE (element_class) && !mono_class_has_variant_generic_params (element_class))
 #ifdef COMPRESSED_INTERFACE_BITMAP

--- a/mono/mini/objects.cs
+++ b/mono/mini/objects.cs
@@ -1848,6 +1848,30 @@ ncells ) {
 
 	  return t == -122 ? 0 : 1;
 	}
+
+	public interface IFoo
+	{
+	  int MyInt { get; }
+	}
+
+	public class IFooImpl : IFoo
+	{
+	  public int MyInt => 0;
+	}
+
+	//gh 6266
+    public static int test_store_to_magic_iface_array ()
+    {
+      ICollection<IFoo> arr1 = new IFooImpl[1] { new IFooImpl() };
+      ICollection<IFoo> arr2 = new IFooImpl[1] { new IFooImpl() };
+
+      ICollection<IFoo>[] a2d = new ICollection<IFoo>[2] {
+        arr1,
+        arr2,
+      };
+
+	  return 0;
+    }
 }
 
 #if __MOBILE__

--- a/mono/mini/objects.cs
+++ b/mono/mini/objects.cs
@@ -1860,7 +1860,7 @@ ncells ) {
 	}
 
 	//gh 6266
-    public static int test_store_to_magic_iface_array ()
+    public static int test_0_store_to_magic_iface_array ()
     {
       ICollection<IFoo> arr1 = new IFooImpl[1] { new IFooImpl() };
       ICollection<IFoo> arr2 = new IFooImpl[1] { new IFooImpl() };


### PR DESCRIPTION
Backport of #7038.

/cc @marek-safar