### PR TITLE
[2018-02] [xbuild] add property that is available in msbuild

### DIFF
--- a/mcs/class/Microsoft.Build.Utilities/Microsoft.Build.Utilities/ToolTask.cs
+++ b/mcs/class/Microsoft.Build.Utilities/Microsoft.Build.Utilities/ToolTask.cs
@@ -59,6 +59,13 @@ namespace Microsoft.Build.Utilities
 		bool typeLoadException;
 		ManualResetEvent canceled;
 
+		/* dummy getter/setter for msbuild compability */
+		public bool YieldDuringToolExecution
+		{
+			get;
+			set;
+		}
+
 		protected ToolTask ()
 			: this (null, null)
 		{


### PR DESCRIPTION
They fsharp team decided to remove a `#if MONO` with the assumption that
`xbuild` is dead and everything has switched over to `msbuild`:
https://github.com/Microsoft/visualfsharp/pull/3969/files#diff-bcb4028a918d13bbab2d0c1c15c97e6aL181
https://github.com/Microsoft/visualfsharp/pull/3969/commits/5e17e3111f88b1a1f025ac54c8147052e12f347f#r151844561

which, alas, is not true yet.

With this PR we started to ship above modifications in the MDK:
https://github.com/mono/mono/pull/7018


