### PR TITLE
[Tailcall] Add 11 tests that are all runnable, never crash, are self checking.

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -553,6 +553,17 @@ endif
 endif
 
 TESTS_IL_SRC=			\
+	gptail1.il		\
+	itail1.il		\
+	itaili1.il		\
+	ivtail1.il		\
+	sirtail1.il		\
+	sitail1.il		\
+	srtail1.il		\
+	stail1.il		\
+	tail1.il		\
+	taili1.il		\
+	vtail1.il		\
 	field-access.il		\
 	method-access.il	\
 	ldftn-access.il		\
@@ -1009,7 +1020,16 @@ DISABLED_TESTS = \
 	$(if $(AOT),$(AOT_DISABLED_TESTS)) \
 	$(if $(CI),$(CI_DISABLED_TESTS)) \
 	$(if $(CI_PR),$(CI_PR_DISABLED_TESTS)) \
-	$(if $(LLVM),$(LLVM_DISABLED_TESTS))
+	$(if $(LLVM),$(LLVM_DISABLED_TESTS)) \
+	gptail1.exe		\
+	itaili1.exe		\
+	ivtail1.exe		\
+	sirtail1.exe		\
+	srtail1.exe		\
+	stail1.exe		\
+	tail1.exe		\
+	taili1.exe		\
+	vtail1.exe
 
 # bug-48015.exe: be careful when re-enabling, it happens that it returns with
 #                exit code 0, but doesn't actually execute the test.

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1076,7 +1076,18 @@ INTERP_DISABLED_TESTS = \
 	vararg.exe \
 	vararg2.exe \
 	vararg3.exe	\
-	dim-diamondshape.exe
+	dim-diamondshape.exe \
+	gptail1.exe		\
+	itaili1.exe		\
+	ivtail1.exe		\
+	sirtail1.exe		\
+	srtail1.exe		\
+	stail1.exe		\
+	tail1.exe		\
+	taili1.exe		\
+	vtail1.exe		\
+	itail1.exe 		\
+	sitail1.exe
 
 TESTS_CS=$(filter-out $(DISABLED_TESTS),$(TESTS_CS_SRC:.cs=.exe))
 TESTS_IL=$(filter-out $(DISABLED_TESTS),$(TESTS_IL_SRC:.il=.exe))

--- a/mono/tests/gptail1.il
+++ b/mono/tests/gptail1.il
@@ -1,0 +1,92 @@
+.assembly extern mscorlib { }
+.assembly tailcall1 { }
+.class A extends [mscorlib]System.Object {
+.method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+{
+.maxstack 8
+ldarg.0
+call instance void [mscorlib]System.Object::.ctor()
+ret
+}
+.method public hidebysig static int32 gptail1() cil managed noinlining {
+.entrypoint
+.maxstack 4
+.locals init (uint8 V_0)
+newobj instance void A::.ctor()
+ldloca.s V_0
+conv.u
+ldc.i4.0
+conv.i8
+ldc.i4.7
+call instance int32 A::gptail2<int32>(uint8*, int64, int32)
+ret
+}
+.method private hidebysig instance int32 gptail2<T>(uint8* root_stack, int64 diff_stack, int32 counter) cil managed noinlining {
+.maxstack 5
+.locals init (uint8 V_0)
+ldarg.3
+ldc.i4.0
+ble.s IL_0017
+ldarg.0
+ldarg.1
+ldloca.s V_0
+conv.u
+ldarg.1
+sub
+ldc.i4.1
+div
+conv.i8
+ldarg.3
+ldc.i4.1
+sub
+tail. call instance int32 A::gptail2<int32>(uint8*, int64, int32)
+ret
+IL_0017: ldarg.1
+ldloca.s V_0
+conv.u
+ldarg.2
+ldstr "gptail1"
+call int32 A::check(uint8*, uint8*, int64, string)
+ret
+}
+.method private hidebysig static int32 check(uint8* root_stack, uint8* local, int64 diff_stack, string name) cil managed noinlining {
+.maxstack 8
+ldarg.1
+ldarg.0
+sub
+ldc.i4.1
+div
+conv.i8
+ldarg.2
+beq.s IL_0026
+ldstr "{0} failure {1}"
+ldarg.3
+ldarg.0
+ldarg.1
+sub
+ldc.i4.1
+div
+conv.i8
+box [mscorlib]System.Int64
+call string [mscorlib]System.String::Format(string, object, object)
+call void [mscorlib]System.Console::WriteLine(string)
+ldc.i4.1
+ret
+IL_0026: ldstr "{0} success"
+ldarg.3
+call string [mscorlib]System.String::Format(string, object)
+call void [mscorlib]System.Console::WriteLine(string)
+ldc.i4.0
+ret
+}
+.method private hidebysig static int32 check(int64 root_stack, uint8* local, int64 diff_stack, string name) cil managed noinlining {
+.maxstack 8
+ldarg.0
+conv.u
+ldarg.1
+ldarg.2
+ldarg.3
+call int32 A::check(uint8*, uint8*, int64, string)
+ret
+}
+}

--- a/mono/tests/itail1.il
+++ b/mono/tests/itail1.il
@@ -1,0 +1,91 @@
+.assembly extern mscorlib { }
+.assembly tailcall1 { }
+.class A extends [mscorlib]System.Object {
+.method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+{
+.maxstack 8
+ldarg.0
+call instance void [mscorlib]System.Object::.ctor()
+ret
+}
+.method public hidebysig static int32 itail1() cil managed noinlining {
+.entrypoint
+.maxstack 4
+.locals init (uint8 V_0)
+newobj instance void A::.ctor()
+ldloca.s V_0
+conv.u
+conv.u8
+ldc.i4.0
+conv.i8
+ldc.i4.2
+call instance int32 A::itail2(int64, int64, int32)
+ret
+}
+.method private hidebysig instance int32 itail2(int64 root_stack, int64 diff_stack, int32 counter) cil managed noinlining {
+.maxstack 5
+.locals init (uint8 V_0)
+ldarg.3
+ldc.i4.0
+ble.s IL_0015
+ldarg.0
+ldarg.1
+ldloca.s V_0
+conv.u
+conv.u8
+ldarg.1
+sub
+ldarg.3
+ldc.i4.1
+sub
+tail. call instance int32 A::itail2(int64, int64, int32)
+ret
+IL_0015: ldarg.1
+ldloca.s V_0
+conv.u
+ldarg.2
+ldstr "itail1"
+call int32 A::check(int64, uint8*, int64, string)
+ret
+}
+.method private hidebysig static int32 check(uint8* root_stack, uint8* local, int64 diff_stack, string name) cil managed noinlining {
+.maxstack 8
+ldarg.1
+ldarg.0
+sub
+ldc.i4.1
+div
+conv.i8
+ldarg.2
+beq.s IL_0026
+ldstr "{0} failure {1}"
+ldarg.3
+ldarg.0
+ldarg.1
+sub
+ldc.i4.1
+div
+conv.i8
+box [mscorlib]System.Int64
+call string [mscorlib]System.String::Format(string, object, object)
+call void [mscorlib]System.Console::WriteLine(string)
+ldc.i4.1
+ret
+IL_0026: ldstr "{0} success"
+ldarg.3
+call string [mscorlib]System.String::Format(string, object)
+call void [mscorlib]System.Console::WriteLine(string)
+ldc.i4.0
+ret
+}
+.method private hidebysig static int32 check(int64 root_stack, uint8* local, int64 diff_stack, string name) cil managed noinlining {
+.maxstack 8
+ldarg.0
+conv.u
+ldarg.1
+ldarg.2
+ldarg.3
+call int32 A::check(uint8*, uint8*, int64, string)
+ret
+}
+}

--- a/mono/tests/itaili1.il
+++ b/mono/tests/itaili1.il
@@ -1,0 +1,83 @@
+.assembly extern mscorlib { }
+.assembly tailcall1 { }
+.class A extends [mscorlib]System.Object {
+.method public hidebysig static int32 itaili1() cil managed noinlining {
+.entrypoint
+.maxstack 3
+.locals init (uint8 V_0)
+ldloca.s V_0
+conv.u
+conv.u8
+ldc.i4.0
+conv.i8
+ldc.i4.s 9
+call int32 A::itaili2(int64, int64, int32)
+ret
+}
+.method private hidebysig static int32 itaili2(int64 root_stack, int64 diff_stack, int32 counter) cil managed noinlining {
+.maxstack 4
+.locals init (uint8 V_0)
+ldarg.2
+ldc.i4.0
+ble.s IL_0014
+ldarg.0
+ldloca.s V_0
+conv.u
+conv.u8
+ldarg.0
+sub
+ldarg.2
+ldc.i4.1
+sub
+ldftn int32 A::itaili2(int64, int64, int32)
+tail. calli int32 (int64, int64, int32)
+ret
+IL_0014: ldarg.0
+ldloca.s V_0
+conv.u
+ldarg.1
+ldstr "itaili1"
+call int32 A::check(int64, uint8*, int64, string)
+ret
+}
+.method private hidebysig static int32 check(uint8* root_stack, uint8* local, int64 diff_stack, string name) cil managed noinlining {
+.maxstack 8
+ldarg.1
+ldarg.0
+sub
+ldc.i4.1
+div
+conv.i8
+ldarg.2
+beq.s IL_0026
+ldstr "{0} failure {1}"
+ldarg.3
+ldarg.0
+ldarg.1
+sub
+ldc.i4.1
+div
+conv.i8
+box [mscorlib]System.Int64
+call string [mscorlib]System.String::Format(string, object, object)
+call void [mscorlib]System.Console::WriteLine(string)
+ldc.i4.1
+ret
+IL_0026: ldstr "{0} success"
+ldarg.3
+call string [mscorlib]System.String::Format(string, object)
+call void [mscorlib]System.Console::WriteLine(string)
+ldc.i4.0
+ret
+}
+.method private hidebysig static int32 check(int64 root_stack, uint8* local, int64 diff_stack, string name) cil managed noinlining {
+.maxstack 8
+ldarg.0
+conv.u
+ldarg.1
+ldarg.2
+ldarg.3
+call int32 A::check(uint8*, uint8*, int64, string)
+ret
+}
+}

--- a/mono/tests/ivtail1.il
+++ b/mono/tests/ivtail1.il
@@ -1,0 +1,91 @@
+.assembly extern mscorlib { }
+.assembly tailcall1 { }
+.class A extends [mscorlib]System.Object {
+.method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+{
+.maxstack 8
+ldarg.0
+call instance void [mscorlib]System.Object::.ctor()
+ret
+}
+.method public hidebysig static int32 ivtail1() cil managed noinlining {
+.entrypoint
+.maxstack 4
+.locals init (uint8 V_0)
+newobj instance void A::.ctor()
+ldloca.s V_0
+conv.u
+conv.u8
+ldc.i4.0
+conv.i8
+ldc.i4.6
+callvirt instance int32 A::ivtail2(int64, int64, int32)
+ret
+}
+.method public hidebysig newslot virtual instance int32 ivtail2(int64 root_stack, int64 diff_stack, int32 counter) cil managed noinlining {
+.maxstack 5
+.locals init (uint8 V_0)
+ldarg.3
+ldc.i4.0
+ble.s IL_0015
+ldarg.0
+ldarg.1
+ldloca.s V_0
+conv.u
+conv.u8
+ldarg.1
+sub
+ldarg.3
+ldc.i4.1
+sub
+tail. callvirt instance int32 A::ivtail2(int64, int64, int32)
+ret
+IL_0015: ldarg.1
+ldloca.s V_0
+conv.u
+ldarg.2
+ldstr "ivtail1"
+call int32 A::check(int64, uint8*, int64, string)
+ret
+}
+.method private hidebysig static int32 check(uint8* root_stack, uint8* local, int64 diff_stack, string name) cil managed noinlining {
+.maxstack 8
+ldarg.1
+ldarg.0
+sub
+ldc.i4.1
+div
+conv.i8
+ldarg.2
+beq.s IL_0026
+ldstr "{0} failure {1}"
+ldarg.3
+ldarg.0
+ldarg.1
+sub
+ldc.i4.1
+div
+conv.i8
+box [mscorlib]System.Int64
+call string [mscorlib]System.String::Format(string, object, object)
+call void [mscorlib]System.Console::WriteLine(string)
+ldc.i4.1
+ret
+IL_0026: ldstr "{0} success"
+ldarg.3
+call string [mscorlib]System.String::Format(string, object)
+call void [mscorlib]System.Console::WriteLine(string)
+ldc.i4.0
+ret
+}
+.method private hidebysig static int32 check(int64 root_stack, uint8* local, int64 diff_stack, string name) cil managed noinlining {
+.maxstack 8
+ldarg.0
+conv.u
+ldarg.1
+ldarg.2
+ldarg.3
+call int32 A::check(uint8*, uint8*, int64, string)
+ret
+}
+}

--- a/mono/tests/sirtail1.il
+++ b/mono/tests/sirtail1.il
@@ -1,0 +1,86 @@
+.assembly extern mscorlib { }
+.assembly tailcall1 { }
+.class A extends [mscorlib]System.Object {
+.method public hidebysig static int32 sirtail1() cil managed noinlining {
+.entrypoint
+.maxstack 4
+.locals init (uint8 V_0, object V_1)
+newobj instance void [mscorlib]System.Object::.ctor()
+stloc.1
+ldloca.s V_0
+conv.u
+conv.u8
+ldc.i4.0
+conv.i8
+ldc.i4.s 11
+ldloca.s V_1
+call int32 A::sirtail2(int64, int64, int32, object&)
+ret
+}
+.method private hidebysig static int32 sirtail2(int64 root_stack, int64 diff_stack, int32 counter, object& o) cil managed noinlining {
+.maxstack 4
+.locals init (uint8 V_0)
+ldarg.2
+ldc.i4.0
+ble.s IL_0015
+ldarg.0
+ldloca.s V_0
+conv.u
+conv.u8
+ldarg.0
+sub
+ldarg.2
+ldc.i4.1
+sub
+ldarg.3
+tail. call int32 A::sirtail2(int64, int64, int32, object&)
+ret
+IL_0015: ldarg.0
+ldloca.s V_0
+conv.u
+ldarg.1
+ldstr "irtail1"
+call int32 A::check(int64, uint8*, int64, string)
+ret
+}
+.method private hidebysig static int32 check(uint8* root_stack, uint8* local, int64 diff_stack, string name) cil managed noinlining {
+.maxstack 8
+ldarg.1
+ldarg.0
+sub
+ldc.i4.1
+div
+conv.i8
+ldarg.2
+beq.s IL_0026
+ldstr "{0} failure {1}"
+ldarg.3
+ldarg.0
+ldarg.1
+sub
+ldc.i4.1
+div
+conv.i8
+box [mscorlib]System.Int64
+call string [mscorlib]System.String::Format(string, object, object)
+call void [mscorlib]System.Console::WriteLine(string)
+ldc.i4.1
+ret
+IL_0026: ldstr "{0} success"
+ldarg.3
+call string [mscorlib]System.String::Format(string, object)
+call void [mscorlib]System.Console::WriteLine(string)
+ldc.i4.0
+ret
+}
+.method private hidebysig static int32 check(int64 root_stack, uint8* local, int64 diff_stack, string name) cil managed noinlining {
+.maxstack 8
+ldarg.0
+conv.u
+ldarg.1
+ldarg.2
+ldarg.3
+call int32 A::check(uint8*, uint8*, int64, string)
+ret
+}
+}

--- a/mono/tests/sitail1.il
+++ b/mono/tests/sitail1.il
@@ -1,0 +1,82 @@
+.assembly extern mscorlib { }
+.assembly tailcall1 { }
+.class A extends [mscorlib]System.Object {
+.method public hidebysig static int32 sitail1() cil managed noinlining {
+.entrypoint
+.maxstack 3
+.locals init (uint8 V_0)
+ldloca.s V_0
+conv.u
+conv.u8
+ldc.i4.0
+conv.i8
+ldc.i4.4
+call int32 A::sitail2(int64, int64, int32)
+ret
+}
+.method private hidebysig static int32 sitail2(int64 root_stack, int64 diff_stack, int32 counter) cil managed noinlining {
+.maxstack 4
+.locals init (uint8 V_0)
+ldarg.2
+ldc.i4.0
+ble.s IL_0014
+ldarg.0
+ldloca.s V_0
+conv.u
+conv.u8
+ldarg.0
+sub
+ldarg.2
+ldc.i4.1
+sub
+tail. call int32 A::sitail2(int64, int64, int32)
+ret
+IL_0014: ldarg.0
+ldloca.s V_0
+conv.u
+ldarg.1
+ldstr "sitail1"
+call int32 A::check(int64, uint8*, int64, string)
+ret
+}
+.method private hidebysig static int32 check(uint8* root_stack, uint8* local, int64 diff_stack, string name) cil managed noinlining {
+.maxstack 8
+ldarg.1
+ldarg.0
+sub
+ldc.i4.1
+div
+conv.i8
+ldarg.2
+beq.s IL_0026
+ldstr "{0} failure {1}"
+ldarg.3
+ldarg.0
+ldarg.1
+sub
+ldc.i4.1
+div
+conv.i8
+box [mscorlib]System.Int64
+call string [mscorlib]System.String::Format(string, object, object)
+call void [mscorlib]System.Console::WriteLine(string)
+ldc.i4.1
+ret
+IL_0026: ldstr "{0} success"
+ldarg.3
+call string [mscorlib]System.String::Format(string, object)
+call void [mscorlib]System.Console::WriteLine(string)
+ldc.i4.0
+ret
+}
+.method private hidebysig static int32 check(int64 root_stack, uint8* local, int64 diff_stack, string name) cil managed noinlining {
+.maxstack 8
+ldarg.0
+conv.u
+ldarg.1
+ldarg.2
+ldarg.3
+call int32 A::check(uint8*, uint8*, int64, string)
+ret
+}
+}

--- a/mono/tests/srtail1.il
+++ b/mono/tests/srtail1.il
@@ -1,0 +1,87 @@
+.assembly extern mscorlib { }
+.assembly tailcall1 { }
+.class A extends [mscorlib]System.Object {
+.method public hidebysig static int32 srtail1() cil managed noinlining {
+.entrypoint
+.maxstack 4
+.locals init (uint8 V_0, object V_1)
+newobj instance void [mscorlib]System.Object::.ctor()
+stloc.1
+ldloca.s V_0
+conv.u
+ldc.i4.0
+conv.i8
+ldc.i4.s 10
+ldloca.s V_1
+call int32 A::srtail2(uint8*, int64, int32, object&)
+ret
+}
+.method private hidebysig static int32 srtail2(uint8* root_stack, int64 diff_stack, int32 counter, object& o) cil managed noinlining {
+.maxstack 4
+.locals init (uint8 V_0)
+ldarg.2
+ldc.i4.0
+ble.s IL_0017
+ldarg.0
+ldloca.s V_0
+conv.u
+ldarg.0
+sub
+ldc.i4.1
+div
+conv.i8
+ldarg.2
+ldc.i4.1
+sub
+ldarg.3
+tail. call int32 A::srtail2(uint8*, int64, int32, object&)
+ret
+IL_0017: ldarg.0
+ldloca.s V_0
+conv.u
+ldarg.1
+ldstr "rtail1"
+call int32 A::check(uint8*, uint8*, int64, string)
+ret
+}
+.method private hidebysig static int32 check(uint8* root_stack, uint8* local, int64 diff_stack, string name) cil managed noinlining {
+.maxstack 8
+ldarg.1
+ldarg.0
+sub
+ldc.i4.1
+div
+conv.i8
+ldarg.2
+beq.s IL_0026
+ldstr "{0} failure {1}"
+ldarg.3
+ldarg.0
+ldarg.1
+sub
+ldc.i4.1
+div
+conv.i8
+box [mscorlib]System.Int64
+call string [mscorlib]System.String::Format(string, object, object)
+call void [mscorlib]System.Console::WriteLine(string)
+ldc.i4.1
+ret
+IL_0026: ldstr "{0} success"
+ldarg.3
+call string [mscorlib]System.String::Format(string, object)
+call void [mscorlib]System.Console::WriteLine(string)
+ldc.i4.0
+ret
+}
+.method private hidebysig static int32 check(int64 root_stack, uint8* local, int64 diff_stack, string name) cil managed noinlining {
+.maxstack 8
+ldarg.0
+conv.u
+ldarg.1
+ldarg.2
+ldarg.3
+call int32 A::check(uint8*, uint8*, int64, string)
+ret
+}
+}

--- a/mono/tests/stail1.il
+++ b/mono/tests/stail1.il
@@ -1,0 +1,83 @@
+.assembly extern mscorlib { }
+.assembly tailcall1 { }
+.class A extends [mscorlib]System.Object {
+.method public hidebysig static int32 stail1() cil managed noinlining {
+.entrypoint
+.maxstack 3
+.locals init (uint8 V_0)
+ldloca.s V_0
+conv.u
+ldc.i4.0
+conv.i8
+ldc.i4.3
+call int32 A::stail2(uint8*, int64, int32)
+ret
+}
+.method private hidebysig static int32 stail2(uint8* root_stack, int64 diff_stack, int32 counter) cil managed noinlining {
+.maxstack 4
+.locals init (uint8 V_0)
+ldarg.2
+ldc.i4.0
+ble.s IL_0016
+ldarg.0
+ldloca.s V_0
+conv.u
+ldarg.0
+sub
+ldc.i4.1
+div
+conv.i8
+ldarg.2
+ldc.i4.1
+sub
+tail. call int32 A::stail2(uint8*, int64, int32)
+ret
+IL_0016: ldarg.0
+ldloca.s V_0
+conv.u
+ldarg.1
+ldstr "stail1"
+call int32 A::check(uint8*, uint8*, int64, string)
+ret
+}
+.method private hidebysig static int32 check(uint8* root_stack, uint8* local, int64 diff_stack, string name) cil managed noinlining {
+.maxstack 8
+ldarg.1
+ldarg.0
+sub
+ldc.i4.1
+div
+conv.i8
+ldarg.2
+beq.s IL_0026
+ldstr "{0} failure {1}"
+ldarg.3
+ldarg.0
+ldarg.1
+sub
+ldc.i4.1
+div
+conv.i8
+box [mscorlib]System.Int64
+call string [mscorlib]System.String::Format(string, object, object)
+call void [mscorlib]System.Console::WriteLine(string)
+ldc.i4.1
+ret
+IL_0026: ldstr "{0} success"
+ldarg.3
+call string [mscorlib]System.String::Format(string, object)
+call void [mscorlib]System.Console::WriteLine(string)
+ldc.i4.0
+ret
+}
+.method private hidebysig static int32 check(int64 root_stack, uint8* local, int64 diff_stack, string name) cil managed noinlining {
+.maxstack 8
+ldarg.0
+conv.u
+ldarg.1
+ldarg.2
+ldarg.3
+call int32 A::check(uint8*, uint8*, int64, string)
+ret
+}
+}

--- a/mono/tests/tail1.il
+++ b/mono/tests/tail1.il
@@ -1,0 +1,92 @@
+.assembly extern mscorlib { }
+.assembly tailcall1 { }
+.class A extends [mscorlib]System.Object {
+.method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+{
+.maxstack 8
+ldarg.0
+call instance void [mscorlib]System.Object::.ctor()
+ret
+}
+.method public hidebysig static int32 tail1() cil managed noinlining {
+.entrypoint
+.maxstack 4
+.locals init (uint8 V_0)
+newobj instance void A::.ctor()
+ldloca.s V_0
+conv.u
+ldc.i4.0
+conv.i8
+ldc.i4.1
+call instance int32 A::tail2(uint8*, int64, int32)
+ret
+}
+.method private hidebysig instance int32 tail2(uint8* root_stack, int64 diff_stack, int32 counter) cil managed noinlining {
+.maxstack 5
+.locals init (uint8 V_0)
+ldarg.3
+ldc.i4.0
+ble.s IL_0017
+ldarg.0
+ldarg.1
+ldloca.s V_0
+conv.u
+ldarg.1
+sub
+ldc.i4.1
+div
+conv.i8
+ldarg.3
+ldc.i4.1
+sub
+tail. call instance int32 A::tail2(uint8*, int64, int32)
+ret
+IL_0017: ldarg.1
+ldloca.s V_0
+conv.u
+ldarg.2
+ldstr "tail1"
+call int32 A::check(uint8*, uint8*, int64, string)
+ret
+}
+.method private hidebysig static int32 check(uint8* root_stack, uint8* local, int64 diff_stack, string name) cil managed noinlining {
+.maxstack 8
+ldarg.1
+ldarg.0
+sub
+ldc.i4.1
+div
+conv.i8
+ldarg.2
+beq.s IL_0026
+ldstr "{0} failure {1}"
+ldarg.3
+ldarg.0
+ldarg.1
+sub
+ldc.i4.1
+div
+conv.i8
+box [mscorlib]System.Int64
+call string [mscorlib]System.String::Format(string, object, object)
+call void [mscorlib]System.Console::WriteLine(string)
+ldc.i4.1
+ret
+IL_0026: ldstr "{0} success"
+ldarg.3
+call string [mscorlib]System.String::Format(string, object)
+call void [mscorlib]System.Console::WriteLine(string)
+ldc.i4.0
+ret
+}
+.method private hidebysig static int32 check(int64 root_stack, uint8* local, int64 diff_stack, string name) cil managed noinlining {
+.maxstack 8
+ldarg.0
+conv.u
+ldarg.1
+ldarg.2
+ldarg.3
+call int32 A::check(uint8*, uint8*, int64, string)
+ret
+}
+}

--- a/mono/tests/taili1.il
+++ b/mono/tests/taili1.il
@@ -1,0 +1,84 @@
+.assembly extern mscorlib { }
+.assembly tailcall1 { }
+.class A extends [mscorlib]System.Object {
+.method public hidebysig static int32 taili1() cil managed noinlining {
+.entrypoint
+.maxstack 3
+.locals init (uint8 V_0)
+ldloca.s V_0
+conv.u
+ldc.i4.0
+conv.i8
+ldc.i4.8
+call int32 A::taili2(uint8*, int64, int32)
+ret
+}
+.method private hidebysig static int32 taili2(uint8* root_stack, int64 diff_stack, int32 counter) cil managed noinlining {
+.maxstack 4
+.locals init (uint8 V_0)
+ldarg.2
+ldc.i4.0
+ble.s IL_0016
+ldarg.0
+ldloca.s V_0
+conv.u
+ldarg.0
+sub
+ldc.i4.1
+div
+conv.i8
+ldarg.2
+ldc.i4.1
+sub
+ldftn int32 A::taili2(uint8*, int64, int32)
+tail. calli int32 (uint8*, int64, int32)
+ret
+IL_0016: ldarg.0
+ldloca.s V_0
+conv.u
+ldarg.1
+ldstr "taili1"
+call int32 A::check(uint8*, uint8*, int64, string)
+ret
+}
+.method private hidebysig static int32 check(uint8* root_stack, uint8* local, int64 diff_stack, string name) cil managed noinlining {
+.maxstack 8
+ldarg.1
+ldarg.0
+sub
+ldc.i4.1
+div
+conv.i8
+ldarg.2
+beq.s IL_0026
+ldstr "{0} failure {1}"
+ldarg.3
+ldarg.0
+ldarg.1
+sub
+ldc.i4.1
+div
+conv.i8
+box [mscorlib]System.Int64
+call string [mscorlib]System.String::Format(string, object, object)
+call void [mscorlib]System.Console::WriteLine(string)
+ldc.i4.1
+ret
+IL_0026: ldstr "{0} success"
+ldarg.3
+call string [mscorlib]System.String::Format(string, object)
+call void [mscorlib]System.Console::WriteLine(string)
+ldc.i4.0
+ret
+}
+.method private hidebysig static int32 check(int64 root_stack, uint8* local, int64 diff_stack, string name) cil managed noinlining {
+.maxstack 8
+ldarg.0
+conv.u
+ldarg.1
+ldarg.2
+ldarg.3
+call int32 A::check(uint8*, uint8*, int64, string)
+ret
+}
+}

--- a/mono/tests/vtail1.il
+++ b/mono/tests/vtail1.il
@@ -1,0 +1,92 @@
+.assembly extern mscorlib { }
+.assembly tailcall1 { }
+.class A extends [mscorlib]System.Object {
+.method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+{
+.maxstack 8
+ldarg.0
+call instance void [mscorlib]System.Object::.ctor()
+ret
+}
+.method public hidebysig static int32 vtail1() cil managed noinlining {
+.entrypoint
+.maxstack 4
+.locals init (uint8 V_0)
+newobj instance void A::.ctor()
+ldloca.s V_0
+conv.u
+ldc.i4.0
+conv.i8
+ldc.i4.5
+callvirt instance int32 A::vtail2(uint8*, int64, int32)
+ret
+}
+.method public hidebysig newslot virtual instance int32 vtail2(uint8* root_stack, int64 diff_stack, int32 counter) cil managed noinlining {
+.maxstack 5
+.locals init (uint8 V_0)
+ldarg.3
+ldc.i4.0
+ble.s IL_0017
+ldarg.0
+ldarg.1
+ldloca.s V_0
+conv.u
+ldarg.1
+sub
+ldc.i4.1
+div
+conv.i8
+ldarg.3
+ldc.i4.1
+sub
+tail. callvirt instance int32 A::vtail2(uint8*, int64, int32)
+ret
+IL_0017: ldarg.1
+ldloca.s V_0
+conv.u
+ldarg.2
+ldstr "vtail1"
+call int32 A::check(uint8*, uint8*, int64, string)
+ret
+}
+.method private hidebysig static int32 check(uint8* root_stack, uint8* local, int64 diff_stack, string name) cil managed noinlining {
+.maxstack 8
+ldarg.1
+ldarg.0
+sub
+ldc.i4.1
+div
+conv.i8
+ldarg.2
+beq.s IL_0026
+ldstr "{0} failure {1}"
+ldarg.3
+ldarg.0
+ldarg.1
+sub
+ldc.i4.1
+div
+conv.i8
+box [mscorlib]System.Int64
+call string [mscorlib]System.String::Format(string, object, object)
+call void [mscorlib]System.Console::WriteLine(string)
+ldc.i4.1
+ret
+IL_0026: ldstr "{0} success"
+ldarg.3
+call string [mscorlib]System.String::Format(string, object)
+call void [mscorlib]System.Console::WriteLine(string)
+ldc.i4.0
+ret
+}
+.method private hidebysig static int32 check(int64 root_stack, uint8* local, int64 diff_stack, string name) cil managed noinlining {
+.maxstack 8
+ldarg.0
+conv.u
+ldarg.1
+ldarg.2
+ldarg.3
+call int32 A::check(uint8*, uint8*, int64, string)
+ret
+}
+}


### PR DESCRIPTION
Tailcall] Add 11 tests. They all run w/o exception or stack overflow, on all platforms.

They are self-checking and report if they were tail called.
All 11 pass on Windows .NET.
2 pass with Mono on Windows or Mac.
CoreCLR not tested as it is a difficult/unknown command line environment.

Mono has problems with at least:
	virtual
	non-managed pointers
	generics
	calli
	managed references even if not to current frame

Tests originally written in C# and then run through ildasm and perl.
See https://github.com/jaykrell/mono/commits/tailcalltest2.gen.