### PR TITLE
Simplify System.Windows.Forms XplatUI code by adding PaintEventArgs p…

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Control.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Control.cs
@@ -5250,7 +5250,7 @@ namespace System.Windows.Forms
 			}
 
 
-			XplatUI.PaintEventEnd (ref m, handle, true);
+			XplatUI.PaintEventEnd (ref m, handle, true, paint_event);
 		}
 
 		private void WmEraseBackground (ref Message m) {

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Form.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Form.cs
@@ -2787,7 +2787,7 @@ namespace System.Windows.Forms {
 				if (ActiveMaximizedMdiChild != null)
 					ActiveMaximizedMdiChild.DrawMaximizedButtons (ActiveMenu, pe);
 
-				XplatUI.PaintEventEnd (ref m, Handle, false);
+				XplatUI.PaintEventEnd (ref m, Handle, false, pe);
 			}
 
 			base.WndProc (ref m);

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Hwnd.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Hwnd.cs
@@ -67,7 +67,6 @@ namespace System.Windows.Forms {
 		internal bool		configure_pending;
 		internal bool		resizing_or_moving; // Used by the X11 backend to track form resize/move
 		internal bool		reparented;
-		internal Stack          drawing_stack;
 		internal object		user_data;
 		internal Rectangle	client_rectangle;
 		internal ArrayList	marshal_free_list;
@@ -119,7 +118,6 @@ namespace System.Windows.Forms {
 			marshal_free_list = new ArrayList(2);
 			opacity = 0xffffffff;
 			fixed_size = false;
-			drawing_stack = new Stack ();
 			children = new ArrayList ();
 			resizing_or_moving = false;
 			whacky_wm = false;

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/InternalWindowManager.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/InternalWindowManager.cs
@@ -265,7 +265,7 @@ namespace System.Windows.Forms {
 				clip = new Rectangle (0, 0, form.Width, form.Height);
 				ThemeEngine.Current.DrawManagedWindowDecorations (pe.Graphics, clip, this);
 			}
-			XplatUI.PaintEventEnd (ref m, form.Handle, false);
+			XplatUI.PaintEventEnd (ref m, form.Handle, false, pe);
 			return true;
 		}
 

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/MainMenu.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/MainMenu.cs
@@ -128,7 +128,7 @@ namespace System.Windows.Forms
 				PaintEventArgs pevent = XplatUI.PaintEventStart (ref m, Wnd.window.Handle, false);
 				pevent.Graphics.SetClip (new Rectangle (rect.X + pt.X, rect.Y + pt.Y, rect.Width, rect.Height));
 				Draw (pevent, Rect);
-				XplatUI.PaintEventEnd (ref m, Wnd.window.Handle, false);
+				XplatUI.PaintEventEnd (ref m, Wnd.window.Handle, false, pevent);
 			}
 		}
 

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/MdiClient.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/MdiClient.cs
@@ -173,7 +173,7 @@ namespace System.Windows.Forms {
 				clip = new Rectangle (0, 0, Width, Height);
 
 				ControlPaint.DrawBorder3D (pe.Graphics, clip, Border3DStyle.Sunken);
-				XplatUI.PaintEventEnd (ref m, Handle, false);
+				XplatUI.PaintEventEnd (ref m, Handle, false, pe);
 				m.Result = IntPtr.Zero;
 				return ;
 			}

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ThemeVisualStyles.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ThemeVisualStyles.cs
@@ -1544,7 +1544,7 @@ namespace System.Windows.Forms
 				new Rectangle (new Point ((textBoxBase.Width - textBoxBase.ClientSize.Width) / 2,
 					(textBoxBase.Height - textBoxBase.ClientSize.Height) / 2),
 					textBoxBase.ClientSize));
-			XplatUI.PaintEventEnd (ref m, textBoxBase.Handle, false);
+			XplatUI.PaintEventEnd (ref m, textBoxBase.Handle, false, e);
 			return true;
 		}
 		public override bool TextBoxBaseShouldPaintBackground (TextBoxBase textBoxBase)

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUI.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUI.cs
@@ -831,12 +831,12 @@ namespace System.Windows.Forms {
 			driver.OverrideCursor (cursor);
 		}
 
-		internal static void PaintEventEnd (ref Message msg, IntPtr handle, bool client)
+		internal static void PaintEventEnd (ref Message msg, IntPtr handle, bool client, PaintEventArgs pevent)
 		{
 			#if DriverDebug || DriverDebugPaint
 				Console.WriteLine ("PaintEventEnd ({0}, {1}, {2}): Called from thread {3}", msg, Window (handle), client, Thread.CurrentThread.GetHashCode ());
 			#endif
-			driver.PaintEventEnd (ref msg, handle, client);
+			driver.PaintEventEnd (ref msg, handle, client, pevent);
 		}
 
 		internal static PaintEventArgs PaintEventStart (ref Message msg, IntPtr handle, bool client)

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUICarbon.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUICarbon.cs
@@ -1558,9 +1558,6 @@ namespace System.Windows.Forms {
 				paint_event = new PaintEventArgs(dc, hwnd.Invalid);
 				hwnd.expose_pending = false;
 				hwnd.ClearInvalidArea();
-
-				hwnd.drawing_stack.Push (paint_event);
-				hwnd.drawing_stack.Push (dc);
 			} else {
 				dc = Graphics.FromHwnd (paint_hwnd.whole_window);
 
@@ -1573,29 +1570,16 @@ namespace System.Windows.Forms {
 				}
 				hwnd.nc_expose_pending = false;
 				hwnd.ClearNcInvalidArea ();
-
-				hwnd.drawing_stack.Push (paint_event);
-				hwnd.drawing_stack.Push (dc);
 			}
 
 			return paint_event;
 		}
 		
-		internal override void PaintEventEnd(ref Message msg, IntPtr handle, bool client) {
-			Hwnd	hwnd;
-
-			hwnd = Hwnd.ObjectFromHandle(handle);
-
-			// FIXME: Pop is causing invalid stack ops sometimes; race condition?
-			try {
-				Graphics dc = (Graphics)hwnd.drawing_stack.Pop();
-				dc.Flush ();
-				dc.Dispose ();
-			
-				PaintEventArgs pe = (PaintEventArgs)hwnd.drawing_stack.Pop();
-				pe.SetGraphics (null);
-				pe.Dispose ();  
-			} catch {}
+		internal override void PaintEventEnd(ref Message msg, IntPtr handle, bool client, PaintEventArgs pevent) {
+			if (pevent.Graphics != null)
+				pevent.Graphics.Dispose();
+			pevent.SetGraphics(null);
+			pevent.Dispose();
 
 			if (Caret.Visible == 1) {
 				ShowCaret();

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIDriver.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIDriver.cs
@@ -321,7 +321,7 @@ namespace System.Windows.Forms {
 
 		internal abstract void UpdateWindow(IntPtr handle);
 		internal abstract PaintEventArgs PaintEventStart (ref Message msg, IntPtr handle, bool client);
-		internal abstract void PaintEventEnd (ref Message msg, IntPtr handle, bool client);
+		internal abstract void PaintEventEnd (ref Message msg, IntPtr handle, bool client, PaintEventArgs pevent);
 
 		internal abstract void SetWindowPos(IntPtr handle, int x, int y, int width, int height);
 		internal abstract void GetWindowPos(IntPtr handle, bool is_toplevel, out int x, out int y, out int width, out int height, out int client_width, out int client_height);

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
@@ -5111,9 +5111,6 @@ namespace System.Windows.Forms {
 
 				hwnd.ClearInvalidArea();
 
-				hwnd.drawing_stack.Push (paint_event);
-				hwnd.drawing_stack.Push (dc);
-
 				return paint_event;
 			} else {
 				dc = Graphics.FromHwnd (paint_hwnd.whole_window);
@@ -5128,26 +5125,16 @@ namespace System.Windows.Forms {
 
 				hwnd.ClearNcInvalidArea ();
 
-				hwnd.drawing_stack.Push (paint_event);
-				hwnd.drawing_stack.Push (dc);
-
 				return paint_event;
 			}
 		}
 
-		internal override void PaintEventEnd(ref Message msg, IntPtr handle, bool client)
+		internal override void PaintEventEnd(ref Message msg, IntPtr handle, bool client, PaintEventArgs pevent)
 		{
-			Hwnd	hwnd;
-
-			hwnd = Hwnd.ObjectFromHandle (msg.HWnd);
-
-			Graphics dc = (Graphics)hwnd.drawing_stack.Pop ();
-			dc.Flush();
-			dc.Dispose();
-			
-			PaintEventArgs pe = (PaintEventArgs)hwnd.drawing_stack.Pop();
-			pe.SetGraphics (null);
-			pe.Dispose ();
+			if (pevent.Graphics != null)
+				pevent.Graphics.Dispose();
+			pevent.SetGraphics(null);
+			pevent.Dispose();
 
 			if (Caret.Visible == true) {
 				ShowCaret();


### PR DESCRIPTION
Simplify System.Windows.Forms XplatUI code by adding PaintEventArgs parameter to PaintEventEnd. This brings the ABI in line with the System.Windows.Forms fork at https://github.com/filipnavara/mac-playground and should eventually allow reusing the Cocoa XplatUI driver.  