### PR TITLE
[System.Windows.Forms] Remove dependency on Hwnd objects outside of XplatUI code.

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms.X11Internal/XplatUIX11-new.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms.X11Internal/XplatUIX11-new.cs
@@ -506,7 +506,7 @@ namespace System.Windows.Forms.X11Internal {
 
 		// XXX this should be someplace shareable by all non-win32 backends..  like in Hwnd itself.
 		// maybe a Hwnd.ParentHandle property
-		internal override IntPtr GetParent (IntPtr handle)
+		internal override IntPtr GetParent (IntPtr handle, bool with_owner)
 		{
 			Hwnd	hwnd;
 
@@ -514,6 +514,7 @@ namespace System.Windows.Forms.X11Internal {
 			if (hwnd != null && hwnd.parent != null) {
 				return hwnd.parent.Handle;
 			}
+			// FIXME: Handle with_owner
 			return IntPtr.Zero;
 		}
 

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ComboBox.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ComboBox.cs
@@ -2534,9 +2534,8 @@ namespace System.Windows.Forms
 					}
 				}
 
-				var borderWidth = Hwnd.GetBorderWidth (CreateParams);
 				var borderAdjustment = dropdown_style == ComboBoxStyle.Simple ? new Size (0, 0) :
-					new Size (borderWidth.top + borderWidth.bottom, borderWidth.left + borderWidth.right);
+					SizeFromClientSize(Size.Empty);
 				Size = new Size (width, height + borderAdjustment.Height);
 				textarea_drawable = new Rectangle (ClientRectangle.Location,
 					new Size (width - borderAdjustment.Width, height));

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Control.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Control.cs
@@ -2780,10 +2780,6 @@ namespace System.Windows.Forms
 				if (window == null || window.Handle == IntPtr.Zero)
 					return false;
 
-				Hwnd hwnd = Hwnd.ObjectFromHandle (window.Handle);
-				if (hwnd != null && hwnd.zombie)
-					return false;
-
 				return true;
 			}
 		}
@@ -4904,14 +4900,14 @@ namespace System.Windows.Forms
 		}
 
 		private void UpdateZOrderOfChild(Control child) {
-			if (IsHandleCreated && child.IsHandleCreated && (child.parent == this) && Hwnd.ObjectFromHandle(child.Handle).Mapped) {
+			if (IsHandleCreated && child.IsHandleCreated && (child.parent == this)) {
 				// Need to take into account all controls
 				Control [] all_controls = child_controls.GetAllControls ();
 
 				int index = Array.IndexOf (all_controls, child);
 				
 				for (; index > 0; index--) {
-					if (!all_controls [index - 1].IsHandleCreated || !all_controls [index - 1].VisibleInternal || !Hwnd.ObjectFromHandle(all_controls [index - 1].Handle).Mapped)
+					if (!all_controls [index - 1].IsHandleCreated || !all_controls [index - 1].VisibleInternal)
 						continue;
 					break;
 				}
@@ -4967,10 +4963,6 @@ namespace System.Windows.Forms
 
 			for (int i = 0; i < controls.Length; i ++) {
 				if (!controls[i].IsHandleCreated || !controls[i].VisibleInternal)
-					continue;
-
-				Hwnd hwnd = Hwnd.ObjectFromHandle (controls[i].Handle);
-				if (hwnd == null || hwnd.zero_sized)
 					continue;
 
 				children_to_order.Add (controls[i]);

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Control.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Control.cs
@@ -193,13 +193,12 @@ namespace System.Windows.Forms
 			static internal Control ControlFromChildHandle (IntPtr handle) {
 				ControlNativeWindow	window;
 
-				Hwnd hwnd = Hwnd.ObjectFromHandle (handle);
-				while (hwnd != null) {
+				while (handle != IntPtr.Zero) {
 					window = (ControlNativeWindow)NativeWindow.FromHandle (handle);
 					if (window != null) {
 						return window.owner;
 					}
-					hwnd = hwnd.Parent;
+					handle = XplatUI.GetParent(handle, false);
 				}
 
 				return null;
@@ -1670,6 +1669,17 @@ namespace System.Windows.Forms
 			foreach (Binding binding in data_bindings) {
 				binding.Check ();
 			}
+		}
+
+		internal static bool IsChild (IntPtr hWndParent, IntPtr hWnd)
+		{
+			for (var parent = XplatUI.GetParent(hWnd, true); parent != IntPtr.Zero; parent = XplatUI.GetParent(parent, true)) {
+				if (parent == hWndParent) {
+					return true;
+				}
+			}
+
+			return false;
 		}
 
 		private void ChangeParent(Control new_parent) {
@@ -5505,7 +5515,7 @@ namespace System.Windows.Forms
 //					bool parented = false;
 					for (int i=0; i<controls.Length; i++) {
 						if (controls [i].is_visible && controls[i].IsHandleCreated)
-							if (XplatUI.GetParent (controls[i].Handle) != window.Handle) {
+							if (XplatUI.GetParent (controls[i].Handle, false) != window.Handle) {
 								XplatUI.SetParent(controls[i].Handle, window.Handle);
 //								parented = true;
 							}

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Control.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Control.cs
@@ -5167,6 +5167,9 @@ namespace System.Windows.Forms
 		
 		private void WmDestroy (ref Message m) {
 			OnHandleDestroyed(EventArgs.Empty);
+
+			XplatUI.SetAllowDrop(window.Handle, false);
+			
 #if DebugRecreate
 			IntPtr handle = window.Handle;
 #endif

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Form.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Form.cs
@@ -2675,7 +2675,7 @@ namespace System.Windows.Forms {
 
 				IsActive = true;
 			} else {
-				if (XplatUI.IsEnabled (Handle) && XplatUI.GetParent (m.LParam) != Handle)
+				if (XplatUI.IsEnabled (Handle) && !IsChild (Handle, m.LParam))
 					ToolStripManager.FireAppFocusChanged (this);
 				IsActive = false;
 			}

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Hwnd.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Hwnd.cs
@@ -69,7 +69,6 @@ namespace System.Windows.Forms {
 		internal bool		reparented;
 		internal object		user_data;
 		internal Rectangle	client_rectangle;
-		internal ArrayList	marshal_free_list;
 		internal int		caption_height;
 		internal int		tool_caption_height;
 		internal bool		whacky_wm;
@@ -115,7 +114,6 @@ namespace System.Windows.Forms {
 			enabled = true;
 			reparented = false;
 			client_rectangle = Rectangle.Empty;
-			marshal_free_list = new ArrayList(2);
 			opacity = 0xffffffff;
 			fixed_size = false;
 			children = new ArrayList ();
@@ -135,10 +133,6 @@ namespace System.Windows.Forms {
 			client_window = IntPtr.Zero;
 			whole_window = IntPtr.Zero;
 			zombie = true;
-			for (int i = 0; i < marshal_free_list.Count; i++) {
-				Marshal.FreeHGlobal((IntPtr)marshal_free_list[i]);
-			}
-			marshal_free_list.Clear();
 		}
 		#endregion
 

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Hwnd.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Hwnd.cs
@@ -805,28 +805,22 @@ namespace System.Windows.Forms {
 			return String.Format("Hwnd, Mapped:{3} ClientWindow:0x{0:X}, WholeWindow:0x{1:X}, Zombie={4}, Parent:[{2:X}]", client_window.ToInt32(), whole_window.ToInt32(), parent != null ? parent.ToString() : "<null>", Mapped, zombie);
 		}
 
-		public static Point GetNextStackedFormLocation  (CreateParams cp, Hwnd parent_hwnd)
+		public static Point GetNextStackedFormLocation (CreateParams cp)
 		{
 			if (cp.control == null)
 				return Point.Empty;
 		
+			MdiClient parent = cp.control.Parent as MdiClient;
+			if (parent != null)
+				return parent.GetNextStackedFormLocation (cp);
+
 			int X = cp.X;
 			int Y = cp.Y;
 			Point previous, next;
 			Rectangle within;
 
-			if (parent_hwnd != null) {
-				Control parent = cp.control.Parent;
-				previous = parent_hwnd.previous_child_startup_location;
-				if (parent_hwnd.client_rectangle == Rectangle.Empty && parent != null) {
-					within = parent.ClientRectangle;
-				} else {
-					within = parent_hwnd.client_rectangle;
-				}
-			} else {
-				previous = Hwnd.previous_main_startup_location;
-				within = System.Windows.Forms.Screen.PrimaryScreen.WorkingArea;
-			}
+			previous = Hwnd.previous_main_startup_location;
+			within = System.Windows.Forms.Screen.PrimaryScreen.WorkingArea;
 
 			if (previous.X == int.MinValue || previous.Y == int.MinValue) {
 				next = Point.Empty;
@@ -842,18 +836,9 @@ namespace System.Windows.Forms {
 				next = new Point (22, 22);
 			}
 
-			if (parent_hwnd != null) {
-				parent_hwnd.previous_child_startup_location = next;
-			} else {
-				Hwnd.previous_main_startup_location = next;
-			}
+			Hwnd.previous_main_startup_location = next;
 
-			if (X == int.MinValue && Y == int.MinValue) {
-				X = next.X;
-				Y = next.Y;
-			}
-			
-			return new Point (X, Y);
+			return next;
 		}
 
 		#endregion	// Methods

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/MdiClient.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/MdiClient.cs
@@ -52,6 +52,7 @@ namespace System.Windows.Forms {
 		private string form_text;
 		private bool setting_form_text;
 		private Form active_child;
+		private Point next_child_stack_location;
 
 		#endregion	// Local Variables
 
@@ -996,6 +997,16 @@ namespace System.Windows.Forms {
 					return;
 				}
 			}
+		}
+
+		internal Point GetNextStackedFormLocation (CreateParams cp)
+		{
+			Point previous = next_child_stack_location;
+			next_child_stack_location = new Point (previous.X + 22, previous.Y + 22);
+			if (!ClientRectangle.Contains (next_child_stack_location.X * 3, next_child_stack_location.Y * 3)) {
+				next_child_stack_location = Point.Empty;
+			}
+			return previous;
 		}
 	}
 }

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUI.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUI.cs
@@ -724,10 +724,10 @@ namespace System.Windows.Forms {
 			return driver.GetMessage (queue_id, ref msg, hWnd, wFilterMin, wFilterMax);
 		}
 
-		internal static IntPtr GetParent (IntPtr handle)
+		internal static IntPtr GetParent (IntPtr handle, bool with_owner)
 		{
-			DriverDebug ("GetParent ({0}): Called", Window (handle));
-			return driver.GetParent (handle);
+			DriverDebug ("GetParent ({0}, {1}): Called", Window (handle), with_owner);
+			return driver.GetParent (handle, with_owner);
 		}
 
 		internal static IntPtr GetPreviousWindow (IntPtr handle)

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUICarbon.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUICarbon.cs
@@ -1288,13 +1288,14 @@ namespace System.Windows.Forms {
 			size = new Size ((int)bounds.size.width, (int)bounds.size.height);
 		}
 
-		internal override IntPtr GetParent(IntPtr handle) {
+		internal override IntPtr GetParent(IntPtr handle, bool with_owner) {
 			Hwnd	hwnd;
 
 			hwnd = Hwnd.ObjectFromHandle(handle);
 			if (hwnd != null && hwnd.Parent != null) {
 				return hwnd.Parent.Handle;
 			}
+			// FIXME: Handle with_owner
 			return IntPtr.Zero;
 		}
 

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUICarbon.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUICarbon.cs
@@ -906,9 +906,8 @@ namespace System.Windows.Forms {
 				}
 			}
 
-			Point next;
-			if (cp.control is Form) {
-				next = Hwnd.GetNextStackedFormLocation (cp, parent_hwnd);
+			if (cp.control is Form && cp.X == int.MinValue && cp.Y == int.MinValue) {
+				Point next = Hwnd.GetNextStackedFormLocation (cp);
 				X = next.X;
 				Y = next.Y;
 			}

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIDriver.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIDriver.cs
@@ -317,7 +317,7 @@ namespace System.Windows.Forms {
 		internal abstract bool IsEnabled(IntPtr handle);
 		internal virtual bool IsKeyLocked (VirtualKeys key) { return false; }
 		internal abstract IntPtr SetParent(IntPtr handle, IntPtr parent);
-		internal abstract IntPtr GetParent(IntPtr handle);
+		internal abstract IntPtr GetParent(IntPtr handle, bool with_owner);
 
 		internal abstract void UpdateWindow(IntPtr handle);
 		internal abstract PaintEventArgs PaintEventStart (ref Message msg, IntPtr handle, bool client);

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIWin32.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIWin32.cs
@@ -2293,8 +2293,12 @@ namespace System.Windows.Forms {
 		}
 
 		// If we ever start using this, we should probably replace FosterParent with IntPtr.Zero
-		internal override IntPtr GetParent(IntPtr handle) {
-			return Win32GetParent(handle);
+		internal override IntPtr GetParent(IntPtr handle, bool with_owner) {
+			if (with_owner) {
+				return Win32GetParent(handle);
+			} else {
+				return Win32GetAncestor(handle, AncestorType.GA_PARENT);
+			}
 		}
 
 		// This is a nop on win32 and x11

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIWin32.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIWin32.cs
@@ -64,7 +64,6 @@ namespace System.Windows.Forms {
 		private static Hashtable	wm_nc_registered;
 		private static RECT		clipped_cursor_rect;
 		private Hashtable		registered_classes;
-		private Hwnd HwndCreating; // the Hwnd we are currently creating (see CreateWindow)
 
 		#endregion	// Local Variables
 
@@ -1617,9 +1616,6 @@ namespace System.Windows.Forms {
 		internal override IntPtr CreateWindow(CreateParams cp) {
 			IntPtr	WindowHandle;
 			IntPtr	ParentHandle;
-			Hwnd	hwnd;
-
-			hwnd = new Hwnd();
 
 			ParentHandle=cp.Parent;
 
@@ -1642,7 +1638,6 @@ namespace System.Windows.Forms {
 			}
 
 			string class_name = RegisterWindowClass (cp.ClassStyle);
-			HwndCreating = hwnd;
 
 			// We cannot actually send the WS_EX_MDICHILD flag to Windows because we
 			// are faking MDI, not uses Windows' version.
@@ -1651,16 +1646,12 @@ namespace System.Windows.Forms {
 				
 			WindowHandle = Win32CreateWindow (cp.WindowExStyle, class_name, cp.Caption, cp.WindowStyle, location.X, location.Y, cp.Width, cp.Height, ParentHandle, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
 
-			HwndCreating = null;
-
 			if (WindowHandle==IntPtr.Zero) {
 				int error = Marshal.GetLastWin32Error ();
 
 				Win32MessageBox(IntPtr.Zero, "Error : " + error.ToString(), "Failed to create window, class '"+cp.ClassName+"'", 0);
 			}
 
-			hwnd.ClientWindow = WindowHandle;
-			hwnd.Mapped = true;
 			Win32SetWindowLong(WindowHandle, WindowLong.GWL_USERDATA, (uint)ThemeEngine.Current.DefaultControlBackColor.ToArgb());
 
 			return WindowHandle;
@@ -1685,12 +1676,7 @@ namespace System.Windows.Forms {
 		}
 
 		internal override void DestroyWindow(IntPtr handle) {
-			Hwnd	hwnd;
-
-			hwnd = Hwnd.ObjectFromHandle(handle);
 			Win32DestroyWindow(handle);
-			hwnd.Dispose();
-			return;
 		}
 
 		internal override void SetWindowMinMax(IntPtr handle, Rectangle maximized, Size min, Size max) {
@@ -1958,8 +1944,6 @@ namespace System.Windows.Forms {
 
 		private IntPtr InternalWndProc (IntPtr hWnd, Msg msg, IntPtr wParam, IntPtr lParam)
 		{
-			if (HwndCreating != null && HwndCreating.ClientWindow == IntPtr.Zero)
-				HwndCreating.ClientWindow = hWnd;
 			return NativeWindow.WndProc (hWnd, msg, wParam, lParam);
 		}
 

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIWin32.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIWin32.cs
@@ -1631,8 +1631,8 @@ namespace System.Windows.Forms {
 			}
 
 			Point location;
-			if (cp.HasWindowManager) {
-				location = Hwnd.GetNextStackedFormLocation (cp, Hwnd.ObjectFromHandle (cp.Parent));
+			if (cp.control is Form && cp.X == int.MinValue && cp.Y == int.MinValue) {
+				location = Hwnd.GetNextStackedFormLocation (cp);
 			} else {
 				location = new Point (cp.X, cp.Y);
 			}

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
@@ -3894,7 +3894,7 @@ namespace System.Windows.Forms {
 			return new SizeF(width, font.Height);
 		}
 
-		internal override IntPtr GetParent(IntPtr handle)
+		internal override IntPtr GetParent(IntPtr handle, bool with_owner)
 		{
 			Hwnd	hwnd;
 
@@ -3902,6 +3902,7 @@ namespace System.Windows.Forms {
 			if (hwnd != null && hwnd.parent != null) {
 				return hwnd.parent.Handle;
 			}
+			// FIXME: Handle with_owner
 			return IntPtr.Zero;
 		}
 		

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs
@@ -2922,9 +2922,8 @@ namespace System.Windows.Forms {
 			}
 
 			// Set the default location location for forms.
-			Point next;
-			if (cp.control is Form) {
-				next = Hwnd.GetNextStackedFormLocation (cp, parent_hwnd);
+			if (cp.control is Form && cp.X == int.MinValue && cp.Y == int.MinValue) {
+				Point next = Hwnd.GetNextStackedFormLocation (cp);
 				X = next.X;
 				Y = next.Y;
 			}


### PR DESCRIPTION
Depends on https://github.com/mono/mono/pull/7234.

The Hwnd object was introduced as a way to store information about window handles for non-Windows XplatUI backends. However, over the time, it started to be used throughout the code for different purposes. This PR aims to remove the usage of Hwnd objects outside the scope of XplatUI code and it removes its usage completely for Win32 backend.