### PR TITLE
Update the random checking code in autoconf to this decade

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3004,9 +3004,6 @@ try_dev_random=$enableval, try_dev_random=yes)
 AC_MSG_RESULT($try_dev_random)
 
 case "{$build}" in
-    *-openbsd*)
-    NAME_DEV_RANDOM="/dev/srandom"
-    ;;
 
 dnl IBM i does not have /dev/random, use unblocking only
 
@@ -3057,7 +3054,7 @@ if test "x$ac_cv_have_dev_random" = "xno" \
 *** will throw a NotImplemented exception.
 ***
 *** If you are seeing this message, and you know your system DOES have an
-*** entropy collection in place, please contact <crichton@gimp.org> and
+*** entropy collection in place, please report an issue on GitHub and
 *** provide information about the system and how to access the random device.
 ***
 *** Otherwise you can install either egd or prngd and set the environment


### PR DESCRIPTION
	* OpenBSD hasn't have /dev/srandom anymore. See:
	  https://mastodon.social/@_xhr_/99389358375291806

	* Crichton hasn't touched Mono since 2004, per logs. I
	  doubt they're who to consult about this issue anymore, if
	  someone somehow does.

cc @rnagy 