### PR TITLE
[runtime] Use MonoClass getters in a few small files

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2507,10 +2507,10 @@ clear_cached_vtable (MonoVTable *vtable)
 	MonoClassRuntimeInfo *runtime_info;
 	void *data;
 
-	runtime_info = klass->runtime_info;
+	runtime_info = m_class_get_runtime_info (klass);
 	if (runtime_info && runtime_info->max_domain >= domain->domain_id)
 		runtime_info->domain_vtables [domain->domain_id] = NULL;
-	if (klass->has_static_refs && (data = mono_vtable_get_static_field_data (vtable)))
+	if (m_class_has_static_refs (klass) && (data = mono_vtable_get_static_field_data (vtable)))
 		mono_gc_free_fixed (data);
 }
 
@@ -2520,7 +2520,7 @@ zero_static_data (MonoVTable *vtable)
 	MonoClass *klass = vtable->klass;
 	void *data;
 
-	if (klass->has_static_refs && (data = mono_vtable_get_static_field_data (vtable)))
+	if (m_class_has_static_refs (klass) && (data = mono_vtable_get_static_field_data (vtable)))
 		mono_gc_bzero_aligned (data, mono_class_data_size (klass));
 }
 

--- a/mono/metadata/class-getters.h
+++ b/mono/metadata/class-getters.h
@@ -81,7 +81,7 @@ MONO_CLASS_GETTER(m_classdef_get_first_method_idx, guint32, ,  MonoClassDef, fir
 MONO_CLASS_GETTER(m_classdef_get_first_field_idx, guint32, , MonoClassDef, first_field_idx)
 MONO_CLASS_GETTER(m_classdef_get_method_count, guint32, ,  MonoClassDef, method_count)
 MONO_CLASS_GETTER(m_classdef_get_field_count, guint32, ,  MonoClassDef, field_count)
-MONO_CLASS_GETTER(m_classdef_get_next_class_cache, MonoClass *, , MonoClassDef, next_class_cache)
+MONO_CLASS_GETTER(m_classdef_get_next_class_cache, MonoClass **, &, MonoClassDef, next_class_cache)
 
 /* Accessors for _MonoClassGtd fields. */
 MONO_CLASS_GETTER(m_classgtd_get_klass, MonoClassDef*, &, MonoClassGtd, klass)

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -19,6 +19,17 @@
 #include "mono/metadata/debug-helpers.h"
 #include "mono/metadata/tabledefs.h"
 #include "mono/metadata/appdomain.h"
+#ifdef MONO_CLASS_DEF_PRIVATE
+/* Rationale: we want the functions in this file to work even when everything
+ * is broken.  They may be called from a debugger session, for example.  If
+ * MonoClass getters include assertions or trigger class loading, we don't want
+ * that kicked off by a call to one of the functions in here.
+ */
+#define REALLY_INCLUDE_CLASS_DEF 1
+#include <mono/metadata/class-private-definition.h>
+#undef REALLY_INCLUDE_CLASS_DEF
+#endif
+
 
 struct MonoMethodDesc {
 	char *name_space;

--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -1273,11 +1273,11 @@ mono_error_set_field_missing (MonoError *error, MonoClass *klass, const char *fi
 	}
 
 	if (klass) {
-		if (klass->name_space) {
-			g_string_append (res, klass->name_space);
+		if (m_class_get_name_space (klass)) {
+			g_string_append (res, m_class_get_name_space (klass));
 			g_string_append_c (res, '.');
 		}
-		g_string_append (res, klass->name);
+		g_string_append (res, m_class_get_name (klass));
 	}
 	else {
 		g_string_append (res, "<unknown type>");
@@ -1323,11 +1323,11 @@ mono_error_set_method_missing (MonoError *error, MonoClass *klass, const char *m
 	}
 
 	if (klass) {
-		if (klass->name_space) {
-			g_string_append (res, klass->name_space);
+		if (m_class_get_name_space (klass)) {
+			g_string_append (res, m_class_get_name_space (klass));
 			g_string_append_c (res, '.');
 		}
-		g_string_append (res, klass->name);
+		g_string_append (res, m_class_get_name (klass));
 	}
 	else {
 		g_string_append (res, "<unknown type>");

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -777,7 +777,7 @@ class_key_extract (gpointer value)
 {
 	MonoClass *klass = (MonoClass *)value;
 
-	return GUINT_TO_POINTER (klass->type_token);
+	return GUINT_TO_POINTER (m_class_get_type_token (klass));
 }
 
 static gpointer*
@@ -785,7 +785,7 @@ class_next_value (gpointer value)
 {
 	MonoClassDef *klass = (MonoClassDef *)value;
 
-	return (gpointer*)&klass->next_class_cache;
+	return (gpointer*)m_classdef_get_next_class_cache (klass);
 }
 
 /**
@@ -2901,7 +2901,7 @@ mono_image_property_remove (MonoImage *image, gpointer subject)
 void
 mono_image_append_class_to_reflection_info_set (MonoClass *klass)
 {
-	MonoImage *image = klass->image;
+	MonoImage *image = m_class_get_image (klass);
 	g_assert (image_is_dynamic (image));
 	mono_image_lock (image);
 	image->reflection_info_unregister_classes = g_slist_prepend_mempool (image->mempool, image->reflection_info_unregister_classes, klass);

--- a/mono/metadata/sgen-client-mono.h
+++ b/mono/metadata/sgen-client-mono.h
@@ -96,14 +96,14 @@ sgen_mono_array_size (GCVTable vtable, MonoArray *array, mword *bounds_size, mwo
 	if ((descr & DESC_TYPE_MASK) == DESC_TYPE_VECTOR)
 		element_size = ((descr) >> VECTOR_ELSIZE_SHIFT) & MAX_ELEMENT_SIZE;
 	else
-		element_size = vtable->klass->sizes.element_size;
+		element_size = m_class_get_sizes (vtable->klass).element_size;
 
 	size_without_bounds = size = MONO_SIZEOF_MONO_ARRAY + (mword)element_size * mono_array_length_fast (array);
 
 	if (G_UNLIKELY (array->bounds)) {
 		size += sizeof (mono_array_size_t) - 1;
 		size &= ~(sizeof (mono_array_size_t) - 1);
-		size += sizeof (MonoArrayBounds) * vtable->klass->rank;
+		size += sizeof (MonoArrayBounds) * m_class_get_rank (vtable->klass);
 	}
 
 	if (bounds_size)
@@ -125,11 +125,11 @@ sgen_client_slow_object_get_size (GCVTable vtable, GCObject* o)
 	 */
 	if (klass == mono_defaults.string_class) {
 		return G_STRUCT_OFFSET (MonoString, chars) + 2 * mono_string_length_fast ((MonoString*) o) + 2;
-	} else if (klass->rank) {
+	} else if (m_class_get_rank (klass)) {
 		return sgen_mono_array_size (vtable, (MonoArray*)o, NULL, 0);
 	} else {
 		/* from a created object: the class must be inited already */
-		return klass->instance_size;
+		return m_class_get_instance_size (klass);
 	}
 }
 
@@ -186,7 +186,7 @@ static MONO_ALWAYS_INLINE void G_GNUC_UNUSED
 sgen_client_pre_copy_checks (char *destination, GCVTable gc_vtable, void *obj, mword objsize)
 {
 	MonoVTable *vt = (MonoVTable*)gc_vtable;
-	SGEN_ASSERT (9, vt->klass->inited, "vtable %p for class %s:%s was not initialized", vt, vt->klass->name_space, vt->klass->name);
+	SGEN_ASSERT (9, m_class_is_inited (vt->klass), "vtable %p for class %s:%s was not initialized", vt, m_class_get_name_space (vt->klass), m_class_get_name (vt->klass));
 }
 
 static MONO_ALWAYS_INLINE void G_GNUC_UNUSED

--- a/mono/sgen/sgen-debug.c
+++ b/mono/sgen/sgen-debug.c
@@ -955,7 +955,7 @@ is_xdomain_ref_allowed (GCObject **ptr, GCObject *obj, MonoDomain *domain)
 		return TRUE;
 
 #ifndef DISABLE_REMOTING
-	if (mono_defaults.real_proxy_class->supertypes && mono_class_has_parent_fast (o->vtable->klass, mono_defaults.real_proxy_class) &&
+	if (m_class_get_supertypes (mono_defaults.real_proxy_class) && mono_class_has_parent_fast (o->vtable->klass, mono_defaults.real_proxy_class) &&
 			offset == G_STRUCT_OFFSET (MonoRealProxy, unwrapped_server))
 		return TRUE;
 #endif
@@ -970,10 +970,10 @@ is_xdomain_ref_allowed (GCObject **ptr, GCObject *obj, MonoDomain *domain)
 	 * at System.Runtime.Remoting.Channels.CrossAppDomainSink.ProcessMessageInDomain (byte[],System.Runtime.Remoting.Messaging.CADMethodCallMessage) [0x00008] in /home/schani/Work/novell/trunk/mcs/class/corlib/System.Runtime.Remoting.Channels/CrossAppDomainChannel.cs:198
 	 * at (wrapper runtime-invoke) object.runtime_invoke_CrossAppDomainSink/ProcessMessageRes_object_object (object,intptr,intptr,intptr) <IL 0x0004c, 0xffffffff>
 	 */
-	if (!strcmp (ref->vtable->klass->name_space, "System") &&
-			!strcmp (ref->vtable->klass->name, "Byte[]") &&
-			!strcmp (o->vtable->klass->name_space, "System.IO") &&
-			!strcmp (o->vtable->klass->name, "MemoryStream"))
+	if (!strcmp (m_class_get_name_space (ref->vtable->klass), "System") &&
+		!strcmp (m_class_get_name (ref->vtable->klass), "Byte[]") &&
+		!strcmp (m_class_get_name_space (o->vtable->klass), "System.IO") &&
+		!strcmp (m_class_get_name (o->vtable->klass), "MemoryStream"))
 		return TRUE;
 	return FALSE;
 }
@@ -993,13 +993,14 @@ check_reference_for_xdomain (GCObject **ptr, GCObject *obj, MonoDomain *domain)
 		return;
 
 	field = NULL;
-	for (klass = obj->vtable->klass; klass; klass = klass->parent) {
+	for (klass = obj->vtable->klass; klass; klass = m_class_get_parent (klass)) {
 		int i;
 
 		int fcount = mono_class_get_field_count (klass);
+		MonoClassField *klass_fields = m_class_get_fields (klass);
 		for (i = 0; i < fcount; ++i) {
-			if (klass->fields[i].offset == offset) {
-				field = &klass->fields[i];
+			if (klass_fields[i].offset == offset) {
+				field = &klass_fields[i];
 				break;
 			}
 		}
@@ -1014,9 +1015,9 @@ check_reference_for_xdomain (GCObject **ptr, GCObject *obj, MonoDomain *domain)
 	} else
 		str = NULL;
 	g_print ("xdomain reference in %p (%s.%s) at offset %d (%s) to %p (%s.%s) (%s)  -  pointed to by:\n",
-			obj, obj->vtable->klass->name_space, obj->vtable->klass->name,
+			obj, m_class_get_name_space (obj->vtable->klass), m_class_get_name (obj->vtable->klass),
 			offset, field ? field->name : "",
-			ref, ref->vtable->klass->name_space, ref->vtable->klass->name, str ? str : "");
+			ref, m_class_get_name_space (ref->vtable->klass), m_class_get_name (ref->vtable->klass), str ? str : "");
 	mono_gc_scan_for_specific_ref (obj, TRUE);
 	if (str)
 		g_free (str);
@@ -1121,16 +1122,16 @@ dump_object (GCObject *obj, gboolean dump_location)
 	 * in strings, so we just ignore them;
 	 */
 	i = j = 0;
-	while (klass->name [i] && j < sizeof (class_name) - 1) {
-		if (!strchr ("<>\"", klass->name [i]))
-			class_name [j++] = klass->name [i];
+	while (m_class_get_name (klass) [i] && j < sizeof (class_name) - 1) {
+		if (!strchr ("<>\"", m_class_get_name (klass) [i]))
+			class_name [j++] = m_class_get_name (klass) [i];
 		++i;
 	}
 	g_assert (j < sizeof (class_name));
 	class_name [j] = 0;
 
 	fprintf (heap_dump_file, "<object class=\"%s.%s\" size=\"%zd\"",
-			klass->name_space, class_name,
+			m_class_get_name_space (klass), class_name,
 			safe_object_get_size (obj));
 	if (dump_location) {
 		const char *location;

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -75,7 +75,7 @@ get_type_name (MonoErrorInternal *error)
 		return error->type_name;
 	MonoClass *klass = get_class (error);
 	if (klass)
-		return klass->name;
+		return m_class_get_name (klass);
 	return "<unknown type>";
 }
 
@@ -85,8 +85,8 @@ get_assembly_name (MonoErrorInternal *error)
 	if (error->assembly_name)
 		return error->assembly_name;
 	MonoClass *klass = get_class (error);
-	if (klass && klass->image)
-		return klass->image->name;
+	if (klass && m_class_get_image (klass))
+		return m_class_get_image (klass)->name;
 	return "<unknown assembly>";
 }
 
@@ -531,7 +531,7 @@ get_type_name_as_mono_string (MonoErrorInternal *error, MonoDomain *domain, Mono
 	} else {
 		MonoClass *klass = get_class (error);
 		if (klass) {
-			char *name = mono_type_full_name (&klass->byval_arg);
+			char *name = mono_type_full_name (m_class_get_byval_arg (klass));
 			if (name) {
 				res = string_new_cleanup (domain, name);
 				g_free (name);


### PR DESCRIPTION
1. Change `m_classdef_get_next_class_cache` to be a byref getter since it's used to internally chain MonoClasses in a hash table.
2. Allow `debug-helpers.c` to access `MonoClass` fields directly (rationale: all this stuff should be callable from a debugger session even in a checked mode with getter assertions enabled, once we have assertions in getters).
3. Update a couple of files to use MonoClass getters:
   * `sgen/sgen-debug.c`
   * `sgen/sgen-client-mono.h`
   * `metadata/image.c`
   * `metadata/appdomain.c`
   * `metadata/exceptions.c`
   * `utils/mono-error.c`

#6925
