### PR TITLE
[wcf] use ConcurrentDictionary for wait handles

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/SvcHttpHandler.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/SvcHttpHandler.cs
@@ -28,6 +28,7 @@
 //
 using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Web;
@@ -51,7 +52,7 @@ namespace System.ServiceModel.Channels
 		Type factory_type;
 		string path;
 		ServiceHostBase host;
-		Dictionary<HttpContext,ManualResetEvent> wcf_wait_handles = new Dictionary<HttpContext,ManualResetEvent> ();
+		ConcurrentDictionary<HttpContext,ManualResetEvent> wcf_wait_handles = new ConcurrentDictionary<HttpContext,ManualResetEvent> ();
 		int close_state;
 
 		public SvcHttpHandler (Type type, Type factoryType, string path)
@@ -90,10 +91,9 @@ namespace System.ServiceModel.Channels
 		public void EndHttpRequest (HttpContext context)
 		{
 			ManualResetEvent wait;
-			if (!wcf_wait_handles.TryGetValue (context, out wait))
+			if (!wcf_wait_handles.TryRemove (context, out wait))
 				return;
 
-			wcf_wait_handles.Remove (context);
 			if (wait != null)
 				wait.Set ();
 		}


### PR DESCRIPTION
SvcHttpHandler is supposed to be thread-safe so it shouldn't use plain
Dictionary without additional locking.

The problem is apparent when running test app from issue #7134 with
hyperfastcgi as the following exception sometimes surfaces:

```
[System.NullReferenceException]: Object reference not set to an instance of an object
  at System.Collections.Generic.Dictionary`2[TKey,TValue].TryInsert (TKey key, TValue value, System.Collections.Generic.InsertionBehavior behavior) [0x00111] in .../mono/external/corefx/src/Common/src/CoreLib/System/Collections/Generic/Dictionary.cs:441
  at System.Collections.Generic.Dictionary`2[TKey,TValue].set_Item (TKey key, TValue value) [0x00000] in .../mono/external/corefx/src/Common/src/CoreLib/System/Collections/Generic/Dictionary.cs:223
  at System.ServiceModel.Channels.SvcHttpHandler.ProcessRequest (System.Web.HttpContext context) [0x00048] in .../mono/mcs/class/System.ServiceModel/System.ServiceModel.Channels/SvcHttpHandler.cs:82
  at System.Web.HttpApplication+<Pipeline>d__225.MoveNext () [0x008fd] in .../mono/mcs/class/System.Web/System.Web/HttpApplication.cs:1338
  at System.Web.HttpApplication.Tick () [0x00000] in .../mono/mcs/class/System.Web/System.Web/HttpApplication.cs:927
```


<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
