### PR TITLE
[Tailcall] Reapply tailcall for generics (F#)

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -9060,11 +9060,13 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 
 			/* Tail prefix / tail call optimization */
 
-			/* FIXME: Enabling TAILC breaks some inlining/stack trace/etc tests */
+			/* FIXME: Enabling TAILC breaks some inlining/stack trace/etc tests.
+				  Inlining and stack traces are not guaranteed however. */
 			/* FIXME: runtime generic context pointer for jumps? */
 			/* FIXME: handle this for generic sharing eventually */
-			if ((ins_flag & MONO_INST_TAILCALL) &&
-				!vtable_arg && !cfg->gshared && is_supported_tail_call (cfg, method, cmethod, fsig, call_opcode))
+			if ((ins_flag & MONO_INST_TAILCALL)
+					&& (MONO_ARCH_HAVE_OP_TAIL_CALL || (!vtable_arg && !cfg->gshared))
+					&& is_supported_tail_call (cfg, method, cmethod, fsig, call_opcode))
 				supported_tail_call = TRUE;
 
 			if (supported_tail_call) {


### PR DESCRIPTION
 [Tailcall] Fix the F# code; let rec functiona ()= printfn "%d" 1; fun…

…ctionb ()

	and functionb ()= functiona ()
	let ()= functiona ()

The test case and the fix are from https://bugzilla.xamarin.com/show_bug.cgi?id=25224.

Just bringing in change ca0dd5c:
	commit ca0dd5c
	Author: Zoltan Varga <vargaz@gmail.com>
	Date:   Thu Dec 11 15:37:29 2014 -0500
	[jit] Enable tail calls from gshared code. Fixes #25224.

Previously it was reverted due to performance regression, which has been fixed.
The problem was that use vs. patch of jmps was using inflated vs. non-inflated code.
Fixed here: fe95e4b

The IL is:
  .method public static !!a  functiona<a>() cil managed
  {
.
.
.
    IL_001d:  tail.
    IL_001f:  call       !!0 '1'::functionb<!!0>()
    IL_0024:  ret
  }

  .method public static !!a  functionb<a>() cil managed
  {
    IL_0000:  tail.
    IL_0002:  call       !!0 '1'::functiona<!!0>()
    IL_0007:  ret
  }