### PR TITLE
Add zlib.lib/zlibstatic.lib in Windows VS mkbundle build when using -z argument.

### DIFF
--- a/mcs/tools/mkbundle/mkbundle.cs
+++ b/mcs/tools/mkbundle/mkbundle.cs
@@ -2584,6 +2584,13 @@ void          mono_register_config_for_assembly (const char* assembly_name, cons
 			linkerArgs.Add ("oldnames.lib");
 		}
 
+		if (MakeBundle.compress) {
+			if (staticLinkMono)
+				linkerArgs.Add("zlibstatic.lib");
+			else
+				linkerArgs.Add("zlib.lib");
+		}
+
 		return;
 	}
 


### PR DESCRIPTION
The mkbundle VS toolchain build has never supported zlib compression and the -z argument. This commit adds zlib.lib or zlibstatic.lib (depending on use of --static argument) to the linker command line when using -z argument.

NOTE, user still needs to make sure zlib.h, zconf.h, zlib.lib or zlibstatic.lib is visible to cl.exe and link.exe when running mkbundle using VS toolchain and -z argument.

One alternative (that I tried locally) is to build zlib windows versions (x86_windows, x86_windows_static, x64_windows, x64_windows_static) using vcpkg utility:

https://github.com/Microsoft/vcpkg

In order to make sure mkbundle picks up the correct versions (x86/x64) I created symbolic links using mklink.exe under respective mono installation folder's (x86/x64) include/mono-2.0 to zlib.h and zconf.h and lib zlib.lib and zlibstatic.lib pointing to the build corresponding vcpkg zlib build artifacts, x86_windows, x86_windows_static, x64_windows, x64_windows_static.

The same pattern could be use to map other zlib distribution (like Anaconda SDK) into corresponding mono installation folders and then used by mkbundle.
