### PR TITLE
[runtime] Don't assert in mono_class_is_assignable_from on iface gtd

### DIFF
--- a/mcs/class/corlib/Test/System/TypeTest.cs
+++ b/mcs/class/corlib/Test/System/TypeTest.cs
@@ -3742,6 +3742,29 @@ namespace MonoTests.System
 		{
 		}
 
+		[Test]
+		public void IsAssignableFromArraySpecialInterfaceGtd ()
+		{
+			// Regression test for https://github.com/mono/mono/issues/7095
+			// An "array special interface" is a Mono name for some
+			// interfaces that are implemented by arrays.
+			// Check that an array special interface GTD (ie, IList<> not IList<Foo>) work
+			// correctly with IsAssignableFrom.
+			var il = typeof (IList<>);
+			var ie = typeof (IEnumerable<>);
+			var ilparam = il.GetTypeInfo ().GenericTypeParameters [0];
+			var ilparr = ilparam.MakeArrayType ();
+
+			Assert.IsTrue (ie.IsAssignableFrom (ie), "IList<> ---> IEnumerable<>");
+			Assert.IsTrue (il.IsAssignableFrom (ilparr), "!0[] ---> IList<>");
+
+			var ilparrarr = ilparr.MakeArrayType ();
+
+			Assert.IsFalse (il.IsAssignableFrom (ilparrarr), "!0[][] -!-> IList<>");
+
+			Assert.IsFalse (il.IsAssignableFrom (typeof (Array)), "System.Array -!-> IList<>");
+		}
+
 		[Test] // Bug #612780
 		public void CannotMakeDerivedTypesFromTypedByRef ()
 		{

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -3496,6 +3496,16 @@ mono_class_is_assignable_from (MonoClass *klass, MonoClass *oklass)
 			return TRUE;
 
 		if (m_class_is_array_special_interface (klass) && m_class_get_rank (oklass) == 1) {
+			if (mono_class_is_gtd (klass)) {
+				/* klass is an array special gtd like
+				 * IList`1<>, and oklass is X[] for some X.
+				 * Moreover we know that X isn't !0 (the gparam
+				 * of IList`1) because in that case we would
+				 * have returned TRUE for
+				 * MONO_CLASS_IMPLEMENTS_INTERFACE, above.
+				 */
+				return FALSE;
+			}
 			//XXX we could offset this by having the cast target computed at JIT time
 			//XXX we could go even further and emit a wrapper that would do the extra type check
 			MonoClass *iface_klass = mono_class_from_mono_type (mono_class_get_generic_class (klass)->context.class_inst->type_argv [0]);


### PR DESCRIPTION
Don't assert when comparing if an "array special interface" is assignable from
an array.

The code assumed that the special interface is some sort of generic instance
like ``IList`1<string>``, but it could be a generic type definition
``IList`1``.

There is a case where we would be obligated to return TRUE:
If someone used reflection to get the generic param of ``IList`1`` and then made an
array:
```csharp
   var i = typeof (IList<>);
   var iparam = i.GetTypeInfo().GenericTypeParameters [0]; // returns gparam T
   var a = iparam.MakeArrayType (); // T[]

   Console.WriteLine (i.IsAssignableFrom (a));
```

But that case is handled by the `MONO_CLASS_IMPLEMENTED_INTERFACE` check,
earlier in mono_class_is_assignable_from.

So we can return FALSE here.

Fixes #7095 