### PR TITLE
[System]: Use new `WebCompletionSource` instead of `TaskCompletionSource`.

### DIFF
--- a/mcs/class/System/System.Net/HttpWebRequest.cs
+++ b/mcs/class/System/System.Net/HttpWebRequest.cs
@@ -96,7 +96,7 @@ namespace System.Net
 
 		WebRequestStream writeStream;
 		HttpWebResponse webResponse;
-		TaskCompletionSource<HttpWebResponse> responseTask;
+		WebCompletionSource responseTask;
 		WebOperation currentOperation;
 		int aborted;
 		bool gotRequestStream;
@@ -968,15 +968,16 @@ namespace System.Net
 			if (!sendChunked && transferEncoding != null && transferEncoding.Trim () != "")
 				throw new ProtocolViolationException ("SendChunked should be true.");
 
-			var myTcs = new TaskCompletionSource<HttpWebResponse> ();
+			var completion = new WebCompletionSource ();
 			WebOperation operation;
 			lock (locker) {
 				getResponseCalled = true;
-				var oldTcs = Interlocked.CompareExchange (ref responseTask, myTcs, null);
-				WebConnection.Debug ($"HWR GET RESPONSE: Req={ID} {oldTcs != null}");
-				if (oldTcs != null) {
-					if (haveResponse && oldTcs.Task.IsCompleted)
-						return oldTcs.Task.Result;
+				var oldCompletion = Interlocked.CompareExchange (ref responseTask, completion, null);
+				WebConnection.Debug ($"HWR GET RESPONSE: Req={ID} {oldCompletion != null}");
+				if (oldCompletion != null) {
+					oldCompletion.Throw ();
+					if (haveResponse && oldCompletion.IsCompleted)
+						return webResponse;
 					throw new InvalidOperationException ("Cannot re-call start of asynchronous " +
 								"method while a previous call is still in progress.");
 				}
@@ -1023,14 +1024,14 @@ namespace System.Net
 					if (throwMe != null) {
 						WebConnection.Debug ($"HWR GET RESPONSE LOOP #1 EX: Req={ID} {throwMe.Status} {throwMe.InnerException?.GetType ()}");
 						haveResponse = true;
-						myTcs.TrySetException (throwMe);
+						completion.SetException (throwMe);
 						throw throwMe;
 					}
 
 					if (!redirect) {
 						haveResponse = true;
 						webResponse = response;
-						myTcs.TrySetResult (response);
+						completion.SetCompleted ();
 						return response;
 					}
 
@@ -1056,7 +1057,7 @@ namespace System.Net
 						WebConnection.Debug ($"HWR GET RESPONSE LOOP #3 EX: Req={ID} {throwMe.Status} {throwMe.InnerException?.GetType ()}");
 						haveResponse = true;
 						stream?.Close ();
-						myTcs.TrySetException (throwMe);
+						completion.SetException (throwMe);
 						throw throwMe;
 					}
 
@@ -1215,7 +1216,7 @@ namespace System.Net
 			if (operation != null)
 				operation.Abort ();
 
-			responseTask?.TrySetCanceled ();
+			responseTask?.SetCanceled ();
 
 			if (webResponse != null) {
 				try {

--- a/mcs/class/System/System.Net/HttpWebRequest.cs
+++ b/mcs/class/System/System.Net/HttpWebRequest.cs
@@ -975,7 +975,7 @@ namespace System.Net
 				var oldCompletion = Interlocked.CompareExchange (ref responseTask, completion, null);
 				WebConnection.Debug ($"HWR GET RESPONSE: Req={ID} {oldCompletion != null}");
 				if (oldCompletion != null) {
-					oldCompletion.Throw ();
+					oldCompletion.ThrowOnError ();
 					if (haveResponse && oldCompletion.IsCompleted)
 						return webResponse;
 					throw new InvalidOperationException ("Cannot re-call start of asynchronous " +
@@ -1024,14 +1024,14 @@ namespace System.Net
 					if (throwMe != null) {
 						WebConnection.Debug ($"HWR GET RESPONSE LOOP #1 EX: Req={ID} {throwMe.Status} {throwMe.InnerException?.GetType ()}");
 						haveResponse = true;
-						completion.SetException (throwMe);
+						completion.TrySetException (throwMe);
 						throw throwMe;
 					}
 
 					if (!redirect) {
 						haveResponse = true;
 						webResponse = response;
-						completion.SetCompleted ();
+						completion.TrySetCompleted ();
 						return response;
 					}
 
@@ -1057,7 +1057,7 @@ namespace System.Net
 						WebConnection.Debug ($"HWR GET RESPONSE LOOP #3 EX: Req={ID} {throwMe.Status} {throwMe.InnerException?.GetType ()}");
 						haveResponse = true;
 						stream?.Close ();
-						completion.SetException (throwMe);
+						completion.TrySetException (throwMe);
 						throw throwMe;
 					}
 
@@ -1216,7 +1216,7 @@ namespace System.Net
 			if (operation != null)
 				operation.Abort ();
 
-			responseTask?.SetCanceled ();
+			responseTask?.TrySetCanceled ();
 
 			if (webResponse != null) {
 				try {

--- a/mcs/class/System/System.Net/WebCompletionSource.cs
+++ b/mcs/class/System/System.Net/WebCompletionSource.cs
@@ -1,0 +1,97 @@
+//
+// WebCompletionSource.cs
+//
+// Author:
+//       Martin Baulig <mabaul@microsoft.com>
+//
+// Copyright (c) 2018 Xamarin Inc. (http://www.xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Runtime.ExceptionServices;
+
+namespace System.Net
+{
+	class WebCompletionSource
+	{
+		TaskCompletionSource<Result> completion;
+
+		public WebCompletionSource ()
+		{
+			completion = new TaskCompletionSource<Result> ();
+		}
+
+		public bool SetCompleted ()
+		{
+			var result = new Result (1, null);
+			return completion.TrySetResult (new Result (1, null));
+		}
+
+		public bool SetCanceled ()
+		{
+			var error = new OperationCanceledException ();
+			var result = new Result (2, ExceptionDispatchInfo.Capture (error));
+			return completion.TrySetResult (result);
+		}
+
+		public bool SetException (Exception error)
+		{
+			var result = new Result (3, ExceptionDispatchInfo.Capture (error));
+			return completion.TrySetResult (result);
+		}
+
+		public bool IsCompleted => completion.Task.IsCompleted;
+
+		public void Throw ()
+		{
+			if (!completion.Task.IsCompleted)
+				return;
+			completion.Task.Result.Error?.Throw ();
+		}
+
+		public async Task<bool> WaitForCompletion (bool throwOnError)
+		{
+			var result = await completion.Task.ConfigureAwait (false);
+			if (result.State == 1)
+				return true;
+			if (throwOnError)
+				result.Error.Throw ();
+			return false;
+		}
+
+		class Result
+		{
+			public int State {
+				get;
+			}
+
+			public ExceptionDispatchInfo Error {
+				get;
+			}
+
+			public Result (int state, ExceptionDispatchInfo error)
+			{
+				State = state;
+				Error = error;
+			}
+		}
+	}
+}

--- a/mcs/class/System/System.Net/WebRequestStream.cs
+++ b/mcs/class/System/System.Net/WebRequestStream.cs
@@ -162,7 +162,7 @@ namespace System.Net
 					await FinishWriting (cancellationToken);
 
 				pendingWrite = null;
-				completion.SetCompleted ();
+				completion.TrySetCompleted ();
 			} catch (Exception ex) {
 				KillBuffer ();
 				closed = true;
@@ -175,7 +175,7 @@ namespace System.Net
 				Operation.CompleteRequestWritten (this, ex);
 
 				pendingWrite = null;
-				completion.SetException (ex);
+				completion.TrySetException (ex);
 				throw;
 			}
 		}

--- a/mcs/class/System/System.Net/WebResponseStream.cs
+++ b/mcs/class/System/System.Net/WebResponseStream.cs
@@ -158,7 +158,7 @@ namespace System.Net
 
 			if (throwMe != null) {
 				lock (locker) {
-					completion.SetException (throwMe);
+					completion.TrySetException (throwMe);
 					pendingRead = null;
 					nestedRead = 0;
 				}
@@ -169,7 +169,7 @@ namespace System.Net
 			}
 
 			lock (locker) {
-				pendingRead.SetCompleted ();
+				pendingRead.TrySetCompleted ();
 				pendingRead = null;
 				nestedRead = 0;
 			}
@@ -496,10 +496,10 @@ namespace System.Net
 				readBuffer = new BufferOffsetSize (b, 0, new_size, false);
 				totalRead = 0;
 				nextReadCalled = true;
-				completion.SetCompleted ();
+				completion.TrySetCompleted ();
 			} catch (Exception ex) {
 				WebConnection.Debug ($"{ME} READ ALL ASYNC EX: {ex.Message}");
-				completion.SetException (ex);
+				completion.TrySetException (ex);
 				throw;
 			} finally {
 				WebConnection.Debug ($"{ME} READ ALL ASYNC #2");

--- a/mcs/class/System/System.Net/WebResponseStream.cs
+++ b/mcs/class/System/System.Net/WebResponseStream.cs
@@ -41,7 +41,7 @@ namespace System.Net
 		long totalRead;
 		bool nextReadCalled;
 		int stream_length; // -1 when CL not present
-		TaskCompletionSource<int> readTcs;
+		WebCompletionSource pendingRead;
 		object locker = new object ();
 		int nestedRead;
 		bool read_eof;
@@ -125,16 +125,16 @@ namespace System.Net
 			if (Interlocked.CompareExchange (ref nestedRead, 1, 0) != 0)
 				throw new InvalidOperationException ("Invalid nested call.");
 
-			var myReadTcs = new TaskCompletionSource<int> ();
+			var completion = new WebCompletionSource ();
 			while (!cancellationToken.IsCancellationRequested) {
 				/*
-				 * 'readTcs' is set by ReadAllAsync().
+				 * 'currentRead' is set by ReadAllAsync().
 				 */
-				var oldReadTcs = Interlocked.CompareExchange (ref readTcs, myReadTcs, null);
-				WebConnection.Debug ($"{ME} READ ASYNC #1: {oldReadTcs != null}");
-				if (oldReadTcs == null)
+				var oldCompletion = Interlocked.CompareExchange (ref pendingRead, completion, null);
+				WebConnection.Debug ($"{ME} READ ASYNC #1: {oldCompletion != null}");
+				if (oldCompletion == null)
 					break;
-				await oldReadTcs.Task.ConfigureAwait (false);
+				await oldCompletion.WaitForCompletion (true).ConfigureAwait (false);
 			}
 
 			WebConnection.Debug ($"{ME} READ ASYNC #2: {totalRead} {contentLength}");
@@ -158,8 +158,8 @@ namespace System.Net
 
 			if (throwMe != null) {
 				lock (locker) {
-					myReadTcs.TrySetException (throwMe);
-					readTcs = null;
+					completion.SetException (throwMe);
+					pendingRead = null;
 					nestedRead = 0;
 				}
 
@@ -169,8 +169,8 @@ namespace System.Net
 			}
 
 			lock (locker) {
-				readTcs.TrySetResult (oldBytes + nbytes);
-				readTcs = null;
+				pendingRead.SetCompleted ();
+				pendingRead = null;
 				nestedRead = 0;
 			}
 
@@ -405,18 +405,19 @@ namespace System.Net
 			}
 
 			var timeoutTask = Task.Delay (ReadTimeout);
-			var myReadTcs = new TaskCompletionSource<int> ();
+			var completion = new WebCompletionSource ();
 			while (true) {
 				/*
-				 * 'readTcs' is set by ReadAsync().
+				 * 'currentRead' is set by ReadAsync().
 				 */
 				cancellationToken.ThrowIfCancellationRequested ();
-				var oldReadTcs = Interlocked.CompareExchange (ref readTcs, myReadTcs, null);
-				if (oldReadTcs == null)
+				var oldCompletion = Interlocked.CompareExchange (ref pendingRead, completion, null);
+				if (oldCompletion == null)
 					break;
 
 				// ReadAsync() is in progress.
-				var anyTask = await Task.WhenAny (oldReadTcs.Task, timeoutTask).ConfigureAwait (false);
+				var oldReadTask = oldCompletion.WaitForCompletion (true);
+				var anyTask = await Task.WhenAny (oldReadTask, timeoutTask).ConfigureAwait (false);
 				if (anyTask == timeoutTask)
 					throw new WebException ("The operation has timed out.", WebExceptionStatus.Timeout);
 			}
@@ -495,14 +496,14 @@ namespace System.Net
 				readBuffer = new BufferOffsetSize (b, 0, new_size, false);
 				totalRead = 0;
 				nextReadCalled = true;
-				myReadTcs.TrySetResult (new_size);
+				completion.SetCompleted ();
 			} catch (Exception ex) {
 				WebConnection.Debug ($"{ME} READ ALL ASYNC EX: {ex.Message}");
-				myReadTcs.TrySetException (ex);
+				completion.SetException (ex);
 				throw;
 			} finally {
 				WebConnection.Debug ($"{ME} READ ALL ASYNC #2");
-				readTcs = null;
+				pendingRead = null;
 			}
 
 			Operation.CompleteResponseRead (true);

--- a/mcs/class/System/common_networking.sources
+++ b/mcs/class/System/common_networking.sources
@@ -43,6 +43,7 @@ System.Net/ServicePoint.cs
 System.Net/ServicePointManager.cs
 System.Net/ServicePointManager.extra.cs
 System.Net/ServicePointScheduler.cs
+System.Net/WebCompletionSource.cs
 System.Net/WebConnection.cs
 System.Net/WebConnectionStream.cs
 System.Net/WebConnectionTunnel.cs


### PR DESCRIPTION
This new helper class uses `TaskCompletionSource<>` internally, but instead
of using TrySetException(), it sets a result containing an `ExceptionDispatchInfo`.

The problem with using TrySetException() is that it wraps the exception
object in an `AggregateException`, that would be unobserved if the caller
throws the original exception.

Fixes #7194