### PR TITLE
Always enable explicit null checks for AIX

### DIFF
--- a/mono/mini/mini-ppc.h
+++ b/mono/mini/mini-ppc.h
@@ -254,6 +254,15 @@ typedef struct MonoCompileArch {
 #endif
 #define MONO_ARCH_HAVE_OP_TAIL_CALL 1
 
+#if defined(_AIX)
+/*
+ * HACK: AIX always allows accessing page 0! We can't rely on SIGSEGV
+ * to save us when a null dereference in managed code occurs, so we
+ * always have to check for null.
+ */
+#define MONO_ARCH_NEED_NULL_CHECK 1
+#endif
+
 #define PPC_NUM_REG_ARGS (PPC_LAST_ARG_REG-PPC_FIRST_ARG_REG+1)
 #define PPC_NUM_REG_FPARGS (PPC_LAST_FPARG_REG-PPC_FIRST_FPARG_REG+1)
 

--- a/mono/mini/mini-ppc.h
+++ b/mono/mini/mini-ppc.h
@@ -260,7 +260,7 @@ typedef struct MonoCompileArch {
  * to save us when a null dereference in managed code occurs, so we
  * always have to check for null.
  */
-#define MONO_ARCH_NEED_NULL_CHECK 1
+#define MONO_ARCH_EXPLICIT_NULL_CHECKS 1
 #endif
 
 #define PPC_NUM_REG_ARGS (PPC_LAST_ARG_REG-PPC_FIRST_ARG_REG+1)

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3044,6 +3044,9 @@ init_backend (MonoBackend *backend)
 #ifdef MONO_ARCH_NO_DIV_WITH_MUL
 	backend->disable_div_with_mul = 1;
 #endif
+#ifdef MONO_ARCH_EXPLICIT_NULL_CHECKS
+	backend->explicit_null_checks = 1;
+#endif
 }
 
 /*
@@ -3171,12 +3174,12 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 	/* coop requires loop detection to happen */
 	if (mono_threads_are_safepoints_enabled ())
 		cfg->opt |= MONO_OPT_LOOP;
-#if defined(MONO_ARCH_NEED_NULL_CHECK)
-	/* some platforms have null pages, so we can't rely on SIGSEGV */
-	cfg->explicit_null_checks = TRUE;
-#else
-	cfg->explicit_null_checks = debug_options.explicit_null_checks || (flags & JIT_FLAG_EXPLICIT_NULL_CHECKS);
-#endif
+	if (cfg->backend->explicit_null_checks) {
+		/* some platforms have null pages, so we can't SIGSEGV */
+		cfg->explicit_null_checks = TRUE;
+	} else {
+		cfg->explicit_null_checks = debug_options.explicit_null_checks || (flags & JIT_FLAG_EXPLICIT_NULL_CHECKS);
+	}
 	cfg->soft_breakpoints = debug_options.soft_breakpoints;
 	cfg->check_pinvoke_callconv = debug_options.check_pinvoke_callconv;
 	cfg->disable_direct_icalls = disable_direct_icalls;

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3171,7 +3171,16 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 	/* coop requires loop detection to happen */
 	if (mono_threads_are_safepoints_enabled ())
 		cfg->opt |= MONO_OPT_LOOP;
+#if defined(_AIX)
+	/*
+	 * HACK: AIX always allows accessing page 0! We can't rely on SIGSEGV
+	 * to save us when a null dereference in managed code occurs, so we
+	 * always have to check for null.
+	 */
+	cfg->explicit_null_checks = TRUE;
+#else
 	cfg->explicit_null_checks = debug_options.explicit_null_checks || (flags & JIT_FLAG_EXPLICIT_NULL_CHECKS);
+#endif
 	cfg->soft_breakpoints = debug_options.soft_breakpoints;
 	cfg->check_pinvoke_callconv = debug_options.check_pinvoke_callconv;
 	cfg->disable_direct_icalls = disable_direct_icalls;

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3171,12 +3171,8 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 	/* coop requires loop detection to happen */
 	if (mono_threads_are_safepoints_enabled ())
 		cfg->opt |= MONO_OPT_LOOP;
-#if defined(_AIX)
-	/*
-	 * HACK: AIX always allows accessing page 0! We can't rely on SIGSEGV
-	 * to save us when a null dereference in managed code occurs, so we
-	 * always have to check for null.
-	 */
+#if defined(MONO_ARCH_NEED_NULL_CHECK)
+	/* some platforms have null pages, so we can't rely on SIGSEGV */
 	cfg->explicit_null_checks = TRUE;
 #else
 	cfg->explicit_null_checks = debug_options.explicit_null_checks || (flags & JIT_FLAG_EXPLICIT_NULL_CHECKS);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1095,6 +1095,7 @@ typedef struct {
 	guint            need_div_check : 1;
 	guint            no_unaligned_access : 1;
 	guint            disable_div_with_mul : 1;
+	guint            explicit_null_checks : 1;
 	int              monitor_enter_adjustment;
 	int              dyn_call_param_area;
 } MonoBackend;


### PR DESCRIPTION
AIX has a "null page" that allows reads (but not W|X) to occur on
*0; allegedly legacy crap for old stupid C programs that poorly
managed string handling. Because of this, we can't catch SIGSEGVs
to give out NREs with - we have to do null checks ourselves. As
such, turn this debug option on all the time; it's seemingly what
other managed runtimes have done, at least according to with what
one contact says.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
