### PR TITLE
[sdb] Fix VirtualMachine.CreateEnumMirror () so it works with types from non-root domains.

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/EnumMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/EnumMirror.cs
@@ -19,7 +19,8 @@ namespace Mono.Debugger.Soft
 			if (!type.IsEnum)
 				throw new ArgumentException ("type must be an enum type", "type");
 			TypeMirror t = type.EnumUnderlyingType;
-			if (value.Value == null || !value.Value.GetType ().IsPrimitive || t != vm.RootDomain.GetCorrespondingType (value.Value.GetType ()))
+			// Can't access t's domain, so compare type names
+			if (value.Value == null || !value.Value.GetType ().IsPrimitive || t.Name != vm.RootDomain.GetCorrespondingType (value.Value.GetType ()).Name)
 				throw new ArgumentException ("Value '" + value.Value + "' does not match the type of the enum.");
 		}
 

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -3509,6 +3509,10 @@ public class DebuggerTests
 		Assert.AreEqual ("domains", frames [2].Method.Name);
 		Assert.AreEqual (vm.RootDomain, frames [2].Domain);
 
+		// Check enum creation in other domains
+		var anenum = vm.CreateEnumMirror (d_method.DeclaringType.Assembly.GetType ("AnEnum"), vm.CreateValue (1));
+		Assert.AreEqual (1, anenum.Value);
+
 		// Test breakpoints on already JITted methods in other domains
 		m = entry_point.DeclaringType.GetMethod ("invoke_in_domain_2");
 		Assert.IsNotNull (m);


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/7289.