### PR TITLE
[Tailcall] Do not create never-executed trampoline for tail.call self.

### DIFF
--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -1364,6 +1364,10 @@ mono_resolve_patch_target (MonoMethod *method, MonoDomain *domain, guint8 *code,
 		break;
 	}
 	case MONO_PATCH_INFO_METHOD_JUMP:
+		// When a function is calling itself (recursively), skip creating the trampoline.
+		// Trampoline would be shortly patched out and never executed.
+		if (method == patch_info->data.method)
+			return code;
 		target = mono_create_jump_trampoline (domain, patch_info->data.method, FALSE, error);
 		if (!mono_error_ok (error))
 			return NULL;


### PR DESCRIPTION
https://github.com/mono/mono/issues/7328

test case:

```
.assembly extern mscorlib { }
.assembly a { }
.class b
{
.method static void f3<f3>() noinlining
{
tail. call void b::f3<!!0>()
ret
}
.method static void main()
{
.entrypoint
call void b::f3<int32>()
ret
}
}
```
ends up on NT/amd64 as:
```
0:000> uf .
0000016c`3c951420 55              push    rbp
0000016c`3c951421 488bec          mov     rbp,rsp
0000016c`3c951424 4883ec20        sub     rsp,20h
0000016c`3c951428 488b0424        mov     rax,qword ptr [rsp]
0000016c`3c95142c 48894510        mov     qword ptr [rbp+10h],rax
0000016c`3c951430 488b442408      mov     rax,qword ptr [rsp+8]
0000016c`3c951435 48894518        mov     qword ptr [rbp+18h],rax
0000016c`3c951439 488b442410      mov     rax,qword ptr [rsp+10h]
0000016c`3c95143e 48894520        mov     qword ptr [rbp+20h],rax
0000016c`3c951442 488b442418      mov     rax,qword ptr [rsp+18h]
0000016c`3c951447 48894528        mov     qword ptr [rbp+28h],rax
0000016c`3c95144b 488d6500        lea     rsp,[rbp]
0000016c`3c95144f 5d              pop     rbp
0000016c`3c951450 49bb2014953c6c010000 mov r11,16C3C951420h
0000016c`3c95145a 41ffe3          jmp     r11
```
w/ or w/o change, but skipping some steps w/ change.
The move to r11 is initially to a trampoline w/o change, but gets
patched out before it is executed, as compiling the function finishes.

Notice that the next case is similar, method vs. jmp.
