### PR TITLE
Don't throw NotImplementedException in Dispose()

### DIFF
--- a/mcs/class/System.Design/System.Web.UI.Design/HtmlControlDesigner.cs
+++ b/mcs/class/System.Design/System.Web.UI.Design/HtmlControlDesigner.cs
@@ -35,7 +35,7 @@ namespace System.Web.UI.Design
 		public HtmlControlDesigner () { throw new NotImplementedException (); }
 
 		[MonoTODO]
-		protected override void Dispose (bool disposing) { throw new NotImplementedException (); }
+		protected override void Dispose (bool disposing) { }
 
 		[MonoTODO]
 		[Obsolete ("Use ControlDesigner.Tag instead")]

--- a/mcs/class/System.Net.Http.WinHttpHandler/System.Net.Http/WinHttpHandler.cs
+++ b/mcs/class/System.Net.Http.WinHttpHandler/System.Net.Http/WinHttpHandler.cs
@@ -85,7 +85,7 @@ namespace System.Net.Http
 
 		public WindowsProxyUsePolicy WindowsProxyUsePolicy { get { throw new PlatformNotSupportedException (); } set { throw new PlatformNotSupportedException (); } }
 
-		protected override void Dispose (bool disposing) { throw new PlatformNotSupportedException (); }
+		protected override void Dispose (bool disposing) { }
 
 		protected override Task<HttpResponseMessage> SendAsync (HttpRequestMessage request, Threading.CancellationToken cancellationToken) { throw new PlatformNotSupportedException (); }
 	}

--- a/mcs/class/System/System.IO/FileSystemWatcher_mobile.cs
+++ b/mcs/class/System/System.IO/FileSystemWatcher_mobile.cs
@@ -59,6 +59,6 @@ namespace System.IO
         protected void OnRenamed (RenamedEventArgs e) { throw new NotImplementedException (); }
         public WaitForChangedResult WaitForChanged (WatcherChangeTypes changeType) { throw new NotImplementedException (); }
         public WaitForChangedResult WaitForChanged (WatcherChangeTypes changeType, int timeout) { throw new NotImplementedException (); }
-        protected override void Dispose (bool disposing) { throw new NotImplementedException (); }
+        protected override void Dispose (bool disposing) { }
     }
 }


### PR DESCRIPTION
We had a few stubs that threw not implemented exceptions in Dispose() which causes the finalizer thread to abort.

Since those classes throw in the constructor already there's no way to create a valid object and we can remove the throw in Dispose().

Fixes https://github.com/mono/mono/issues/7338
