### PR TITLE
[System.IO] Use CoreFX FileSystemWatcher on Windows

### DIFF
--- a/mcs/class/System/System.IO/FileSystemWatcher.cs
+++ b/mcs/class/System/System.IO/FileSystemWatcher.cs
@@ -125,8 +125,8 @@ namespace System.IO {
 				bool ok = false;
 				switch (mode) {
 				case 1: // windows
-					ok = DefaultWatcher.GetInstance (out watcher);
-					watcher_handle = this;
+					ok = CoreFXFileSystemWatcherProxy.GetInstance (out watcher);
+					watcher_handle = (watcher as CoreFXFileSystemWatcherProxy).NewWatcher (this);
 					break;
 				case 2: // libfam
 					ok = FAMWatcher.GetInstance (out watcher, false);


### PR DESCRIPTION
Outstanding Issues:

- [x] https://jenkins.mono-project.com/job/x/8254/testReport/junit/MonoTests/runtime/bug_80307_exe/
- [ ] Fix System.Web failures

#6966 