### PR TITLE
[runtime] Workaround GCC inlining bug when building FullAOT config

### DIFF
--- a/mono/utils/mono-publib.h
+++ b/mono/utils/mono-publib.h
@@ -122,10 +122,12 @@ mono_set_allocator_vtable (MonoAllocatorVTable* vtable);
 #if defined (__clang__)
 #define MONO_RT_EXTERNAL_ONLY \
 	__attribute__ ((__unavailable__ ("The mono runtime must not call this function"))) \
+	__attribute__ ((__noinline__))
 	MONO_RT_CENTRINEL_SUPPRESS
 #elif defined (__GNUC__)
 #define MONO_RT_EXTERNAL_ONLY \
 	__attribute__ ((__error__ ("The mono runtime must not call this function"))) \
+	__attribute__ ((__noinline__))
 	MONO_RT_CENTRINEL_SUPPRESS
 #else
 #define MONO_RT_EXTERNAL_ONLY MONO_RT_CENTRINEL_SUPPRESS

--- a/mono/utils/mono-publib.h
+++ b/mono/utils/mono-publib.h
@@ -122,7 +122,6 @@ mono_set_allocator_vtable (MonoAllocatorVTable* vtable);
 #if defined (__clang__)
 #define MONO_RT_EXTERNAL_ONLY \
 	__attribute__ ((__unavailable__ ("The mono runtime must not call this function"))) \
-	__attribute__ ((__noinline__))
 	MONO_RT_CENTRINEL_SUPPRESS
 #elif defined (__GNUC__)
 #define MONO_RT_EXTERNAL_ONLY \


### PR DESCRIPTION
When building the FullAOT configuration on Jenkins we're hitting
the following issue since we switched to Debian 9:

```
object.c: In function 'mono_object_new_alloc_specific':
cc1: error: call to 'mono_object_new_specific.localalias.36' declared with attribute error: The mono runtime must not call this function
```

The function doesn't call `mono_object_new_specific` though.

It looks like we're hitting an inliner bug on the newer GCC since marking the `mono_object_new_specific` function as noinline prevents the issue. (as does compiling with anything other than -O2, or with -finline-functions interestingly)

This is with `gcc (Debian 6.3.0-18) 6.3.0` and `gcc-7 (Debian 7.3.0-5) 7.3.0`, `clang 4.0.1-10` doesn't show the issue.

To fix the problem and workaround the GCC bug we decided to mark all `MONO_RT_EXTERNAL_ONLY` as noinline.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
