### PR TITLE
[metadata] Use MonoClass getters in the rest of metadata/

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -718,7 +718,7 @@ mono_gc_alloc_obj (MonoVTable *vtable, size_t size)
 {
 	MonoObject *obj;
 
-	if (!vtable->klass->has_references) {
+	if (!m_class_has_references (vtable->klass)) {
 		obj = (MonoObject *)GC_MALLOC_ATOMIC (size);
 		if (G_UNLIKELY (!obj))
 			return NULL;
@@ -750,7 +750,7 @@ mono_gc_alloc_vector (MonoVTable *vtable, size_t size, uintptr_t max_length)
 {
 	MonoArray *obj;
 
-	if (!vtable->klass->has_references) {
+	if (!m_class_has_references (vtable->klass)) {
 		obj = (MonoArray *)GC_MALLOC_ATOMIC (size);
 		if (G_UNLIKELY (!obj))
 			return NULL;
@@ -784,7 +784,7 @@ mono_gc_alloc_array (MonoVTable *vtable, size_t size, uintptr_t max_length, uint
 {
 	MonoArray *obj;
 
-	if (!vtable->klass->has_references) {
+	if (!m_class_has_references (vtable->klass)) {
 		obj = (MonoArray *)GC_MALLOC_ATOMIC (size);
 		if (G_UNLIKELY (!obj))
 			return NULL;
@@ -911,7 +911,7 @@ mono_gc_wbarrier_object_copy (MonoObject* obj, MonoObject *src)
 {
 	/* do not copy the sync state */
 	mono_gc_memmove_aligned ((char*)obj + sizeof (MonoObject), (char*)src + sizeof (MonoObject),
-			mono_object_class (obj)->instance_size - sizeof (MonoObject));
+				m_class_get_instance_size (mono_object_class (obj)) - sizeof (MonoObject));
 }
 
 void

--- a/mono/metadata/callspec.c
+++ b/mono/metadata/callspec.c
@@ -39,8 +39,8 @@ mono_callspec_eval_exception (MonoClass *klass, MonoCallSpec *spec)
 			    strcmp ("all", op->data2) == 0)
 				inc = 1;
 			else if (strcmp ("", op->data) == 0 ||
-				 strcmp (klass->name_space, op->data) == 0)
-				if (strcmp (klass->name, op->data2) == 0)
+				 strcmp (m_class_get_name_space (klass), op->data) == 0)
+				if (strcmp (m_class_get_name (klass), op->data2) == 0)
 					inc = 1;
 			break;
 		default:
@@ -73,7 +73,7 @@ gboolean mono_callspec_eval (MonoMethod *method, const MonoCallSpec *spec)
 			break;
 		case MONO_TRACEOP_PROGRAM:
 			if (prog_assembly &&
-			    (method->klass->image ==
+			    (m_class_get_image (method->klass) ==
 			     mono_assembly_get_image (prog_assembly)))
 				inc = 1;
 			break;
@@ -94,18 +94,18 @@ gboolean mono_callspec_eval (MonoMethod *method, const MonoCallSpec *spec)
 				inc = 1;
 			break;
 		case MONO_TRACEOP_CLASS:
-			if (strcmp (method->klass->name_space, op->data) == 0)
-				if (strcmp (method->klass->name, op->data2) ==
+			if (strcmp (m_class_get_name_space (method->klass), op->data) == 0)
+				if (strcmp (m_class_get_name (method->klass), op->data2) ==
 				    0)
 					inc = 1;
 			break;
 		case MONO_TRACEOP_ASSEMBLY:
-			if (strcmp (mono_image_get_name (method->klass->image),
+			if (strcmp (mono_image_get_name (m_class_get_image (method->klass)),
 				    op->data) == 0)
 				inc = 1;
 			break;
 		case MONO_TRACEOP_NAMESPACE:
-			if (strcmp (method->klass->name_space, op->data) == 0)
+			if (strcmp (m_class_get_name_space (method->klass), op->data) == 0)
 				inc = 1;
 			break;
 		case MONO_TRACEOP_EXCEPTION:

--- a/mono/metadata/class-accessors.c
+++ b/mono/metadata/class-accessors.c
@@ -5,6 +5,7 @@
  */
 #include <config.h>
 #include <mono/metadata/class-internals.h>
+#include <mono/metadata/marshal.h>
 #include <mono/metadata/tabledefs.h>
 #include <mono/metadata/class-abi-details.h>
 #ifdef MONO_CLASS_DEF_PRIVATE
@@ -512,6 +513,13 @@ mono_class_set_nonblittable (MonoClass *klass) {
 	klass->blittable = FALSE;
 	mono_loader_unlock ();
 }
+
+#ifndef DISABLE_REMOTING
+void
+mono_class_contextbound_bit_offset (int* byte_offset_out, guint8* mask_out) {
+	mono_marshal_find_bitfield_offset (MonoClass, contextbound, byte_offset_out, mask_out);
+}
+#endif
 
 #ifdef MONO_CLASS_DEF_PRIVATE
 #define MONO_CLASS_GETTER(funcname, rettype, optref, argtype, fieldname) rettype funcname (argtype *klass) { return optref klass-> fieldname ; }

--- a/mono/metadata/class-accessors.c
+++ b/mono/metadata/class-accessors.c
@@ -6,6 +6,7 @@
 #include <config.h>
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/tabledefs.h>
+#include <mono/metadata/class-abi-details.h>
 #ifdef MONO_CLASS_DEF_PRIVATE
 #include <mono/metadata/abi-details.h>
 #define REALLY_INCLUDE_CLASS_DEF 1

--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -5478,6 +5478,30 @@ mono_class_setup_runtime_info (MonoClass *klass, MonoDomain *domain, MonoVTable 
 }
 
 /**
+ * mono_class_create_array_fill_type:
+ *
+ * Returns a \c MonoClass that is used by SGen to fill out nursery fragments before a collection.
+ */
+MonoClass *
+mono_class_create_array_fill_type (void)
+{
+	static MonoClass klass;
+	static gboolean inited = FALSE;
+
+	if (!inited) {
+		klass.element_class = mono_defaults.byte_class;
+		klass.rank = 1;
+		klass.instance_size = MONO_SIZEOF_MONO_ARRAY;
+		klass.sizes.element_size = 1;
+		klass.size_inited = 1;
+		klass.name = "array_filler_type";
+
+		inited = TRUE;
+	}
+	return &klass;
+}
+
+/**
  * mono_classes_init:
  *
  * Initialize the resources used by this module.

--- a/mono/metadata/class-init.h
+++ b/mono/metadata/class-init.h
@@ -84,6 +84,9 @@ mono_class_setup_nested_types (MonoClass *klass);
 void
 mono_class_setup_runtime_info (MonoClass *klass, MonoDomain *domain, MonoVTable *vtable);
 
+MonoClass *
+mono_class_create_array_fill_type (void);
+
 MONO_END_DECLS
 
 #endif

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1416,6 +1416,11 @@ mono_class_set_nonblittable (MonoClass *klass);
 void
 mono_class_compute_gc_descriptor (MonoClass *klass);
 
+#ifndef DISABLE_REMOTING
+void
+mono_class_contextbound_bit_offset (int* byte_offset_out, guint8* mask_out);
+#endif
+
 /*Now that everything has been defined, let's include the inline functions */
 #include <mono/metadata/class-inlines.h>
 

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -79,7 +79,7 @@ custom_attr_visible (MonoImage *image, MonoReflectionCustomAttr *cattr)
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	/* FIXME: Need to do more checks */
-	if (cattr->ctor->method && (cattr->ctor->method->klass->image != image)) {
+	if (cattr->ctor->method && (m_class_get_image (cattr->ctor->method->klass) != image)) {
 		int visibility = mono_class_get_flags (cattr->ctor->method->klass) & TYPE_ATTRIBUTE_VISIBILITY_MASK;
 
 		if ((visibility != TYPE_ATTRIBUTE_PUBLIC) && (visibility != TYPE_ATTRIBUTE_NESTED_PUBLIC))
@@ -131,8 +131,9 @@ find_field_index (MonoClass *klass, MonoClassField *field) {
 	int i;
 
 	int fcount = mono_class_get_field_count (klass);
+	MonoClassField *klass_fields = m_class_get_fields (klass);
 	for (i = 0; i < fcount; ++i) {
-		if (field == &klass->fields [i])
+		if (field == &klass_fields [i])
 			return mono_class_get_first_field_idx (klass) + 1 + i;
 	}
 	return 0;
@@ -282,13 +283,13 @@ handle_enum:
 		return val;
 	}
 	case MONO_TYPE_VALUETYPE:
-		if (t->data.klass->enumtype) {
+		if (m_class_is_enumtype (t->data.klass)) {
 			type = mono_class_enum_basetype (t->data.klass)->type;
 			goto handle_enum;
 		} else {
 			MonoClass *k =  t->data.klass;
 			
-			if (mono_is_corlib_image (k->image) && strcmp (k->name_space, "System") == 0 && strcmp (k->name, "DateTime") == 0){
+			if (mono_is_corlib_image (m_class_get_image (k)) && strcmp (m_class_get_name_space (k), "System") == 0 && strcmp (m_class_get_name (k), "DateTime") == 0){
 				guint64 *val = (guint64 *)g_malloc (sizeof (guint64));
 				if (!bcheck_blob (p, 7, boundp, error))
 					return NULL;
@@ -297,7 +298,7 @@ handle_enum:
 				return val;
 			}
 		}
-		g_error ("generic valutype %s not handled in custom attr value decoding", t->data.klass->name);
+		g_error ("generic valutype %s not handled in custom attr value decoding", m_class_get_name (t->data.klass));
 		break;
 		
 	case MONO_TYPE_STRING:
@@ -403,11 +404,11 @@ handle_type:
 		} else {
 			g_error ("Unknown type 0x%02x for object type encoding in custom attr", subt);
 		}
-		val = load_cattr_value (image, &subc->byval_arg, p, boundp, end, error);
+		val = load_cattr_value (image, m_class_get_byval_arg (subc), p, boundp, end, error);
 		obj = NULL;
 		if (is_ok (error)) {
 			obj = mono_object_new_checked (mono_domain_get (), subc, error);
-			g_assert (!subc->has_references);
+			g_assert (!m_class_has_references (subc));
 			if (is_ok (error))
 				mono_gc_memmove_atomic ((char*)obj + sizeof (MonoObject), val, mono_class_value_size (subc, NULL));
 		}
@@ -428,8 +429,8 @@ handle_type:
 		}
 		arr = mono_array_new_checked (mono_domain_get(), tklass, alen, error);
 		return_val_if_nok (error, NULL);
-		basetype = tklass->byval_arg.type;
-		if (basetype == MONO_TYPE_VALUETYPE && tklass->enumtype)
+		basetype = m_class_get_byval_arg (tklass)->type;
+		if (basetype == MONO_TYPE_VALUETYPE && m_class_is_enumtype (tklass))
 			basetype = mono_class_enum_basetype (tklass)->type;
 		switch (basetype)
 		{
@@ -490,7 +491,7 @@ handle_type:
 			case MONO_TYPE_STRING:
 			case MONO_TYPE_SZARRAY:
 				for (i = 0; i < alen; i++) {
-					MonoObject *item = (MonoObject *)load_cattr_value (image, &tklass->byval_arg, p, boundp, &p, error);
+					MonoObject *item = (MonoObject *)load_cattr_value (image, m_class_get_byval_arg (tklass), p, boundp, &p, error);
 					if (!is_ok (error))
 						return NULL;
 					mono_array_setref (arr, i, item);
@@ -1397,8 +1398,8 @@ mono_custom_attrs_from_method_checked (MonoMethod *method, MonoError *error)
 	if (method->is_inflated)
 		method = ((MonoMethodInflated *) method)->declaring;
 	
-	if (method_is_dynamic (method) || image_is_dynamic (method->klass->image))
-		return lookup_custom_attr (method->klass->image, method);
+	if (method_is_dynamic (method) || image_is_dynamic (m_class_get_image (method->klass)))
+		return lookup_custom_attr (m_class_get_image (method->klass), method);
 
 	if (!method->token)
 		/* Synthetic methods */
@@ -1407,7 +1408,7 @@ mono_custom_attrs_from_method_checked (MonoMethod *method, MonoError *error)
 	idx = mono_method_get_index (method);
 	idx <<= MONO_CUSTOM_ATTR_BITS;
 	idx |= MONO_CUSTOM_ATTR_METHODDEF;
-	return mono_custom_attrs_from_index_checked (method->klass->image, idx, FALSE, error);
+	return mono_custom_attrs_from_index_checked (m_class_get_image (method->klass), idx, FALSE, error);
 }
 
 /**
@@ -1432,19 +1433,19 @@ mono_custom_attrs_from_class_checked (MonoClass *klass, MonoError *error)
 	if (mono_class_is_ginst (klass))
 		klass = mono_class_get_generic_class (klass)->container_class;
 
-	if (image_is_dynamic (klass->image))
-		return lookup_custom_attr (klass->image, klass);
+	if (image_is_dynamic (m_class_get_image (klass)))
+		return lookup_custom_attr (m_class_get_image (klass), klass);
 
-	if (klass->byval_arg.type == MONO_TYPE_VAR || klass->byval_arg.type == MONO_TYPE_MVAR) {
-		idx = mono_metadata_token_index (klass->sizes.generic_param_token);
+	if (m_class_get_byval_arg (klass)->type == MONO_TYPE_VAR || m_class_get_byval_arg (klass)->type == MONO_TYPE_MVAR) {
+		idx = mono_metadata_token_index (m_class_get_sizes (klass).generic_param_token);
 		idx <<= MONO_CUSTOM_ATTR_BITS;
 		idx |= MONO_CUSTOM_ATTR_GENERICPAR;
 	} else {
-		idx = mono_metadata_token_index (klass->type_token);
+		idx = mono_metadata_token_index (m_class_get_type_token (klass));
 		idx <<= MONO_CUSTOM_ATTR_BITS;
 		idx |= MONO_CUSTOM_ATTR_TYPEDEF;
 	}
-	return mono_custom_attrs_from_index_checked (klass->image, idx, FALSE, error);
+	return mono_custom_attrs_from_index_checked (m_class_get_image (klass), idx, FALSE, error);
 }
 
 /**
@@ -1508,14 +1509,14 @@ mono_custom_attrs_from_property_checked (MonoClass *klass, MonoProperty *propert
 
 	error_init (error);
 	
-	if (image_is_dynamic (klass->image)) {
+	if (image_is_dynamic (m_class_get_image (klass))) {
 		property = mono_metadata_get_corresponding_property_from_generic_type_definition (property);
-		return lookup_custom_attr (klass->image, property);
+		return lookup_custom_attr (m_class_get_image (klass), property);
 	}
 	idx = find_property_index (klass, property);
 	idx <<= MONO_CUSTOM_ATTR_BITS;
 	idx |= MONO_CUSTOM_ATTR_PROPERTY;
-	return mono_custom_attrs_from_index_checked (klass->image, idx, FALSE, error);
+	return mono_custom_attrs_from_index_checked (m_class_get_image (klass), idx, FALSE, error);
 }
 
 /**
@@ -1537,14 +1538,14 @@ mono_custom_attrs_from_event_checked (MonoClass *klass, MonoEvent *event, MonoEr
 
 	error_init (error);
 	
-	if (image_is_dynamic (klass->image)) {
+	if (image_is_dynamic (m_class_get_image (klass))) {
 		event = mono_metadata_get_corresponding_event_from_generic_type_definition (event);
-		return lookup_custom_attr (klass->image, event);
+		return lookup_custom_attr (m_class_get_image (klass), event);
 	}
 	idx = find_event_index (klass, event);
 	idx <<= MONO_CUSTOM_ATTR_BITS;
 	idx |= MONO_CUSTOM_ATTR_EVENT;
-	return mono_custom_attrs_from_index_checked (klass->image, idx, FALSE, error);
+	return mono_custom_attrs_from_index_checked (m_class_get_image (klass), idx, FALSE, error);
 }
 
 /**
@@ -1565,14 +1566,14 @@ mono_custom_attrs_from_field_checked (MonoClass *klass, MonoClassField *field, M
 	guint32 idx;
 	error_init (error);
 
-	if (image_is_dynamic (klass->image)) {
+	if (image_is_dynamic (m_class_get_image (klass))) {
 		field = mono_metadata_get_corresponding_field_from_generic_type_definition (field);
-		return lookup_custom_attr (klass->image, field);
+		return lookup_custom_attr (m_class_get_image (klass), field);
 	}
 	idx = find_field_index (klass, field);
 	idx <<= MONO_CUSTOM_ATTR_BITS;
 	idx |= MONO_CUSTOM_ATTR_FIELDDEF;
-	return mono_custom_attrs_from_index_checked (klass->image, idx, FALSE, error);
+	return mono_custom_attrs_from_index_checked (m_class_get_image (klass), idx, FALSE, error);
 }
 
 /**
@@ -1623,11 +1624,11 @@ mono_custom_attrs_from_param_checked (MonoMethod *method, guint32 param, MonoErr
 	if (method->is_inflated)
 		method = ((MonoMethodInflated *) method)->declaring;
 
-	if (image_is_dynamic (method->klass->image)) {
+	if (image_is_dynamic (m_class_get_image (method->klass))) {
 		MonoCustomAttrInfo *res, *ainfo;
 		int size;
 
-		aux = (MonoReflectionMethodAux *)g_hash_table_lookup (((MonoDynamicImage*)method->klass->image)->method_aux_hash, method);
+		aux = (MonoReflectionMethodAux *)g_hash_table_lookup (((MonoDynamicImage*)m_class_get_image (method->klass))->method_aux_hash, method);
 		if (!aux || !aux->param_cattr)
 			return NULL;
 
@@ -1641,7 +1642,7 @@ mono_custom_attrs_from_param_checked (MonoMethod *method, guint32 param, MonoErr
 		return res;
 	}
 
-	image = method->klass->image;
+	image = m_class_get_image (method->klass);
 	method_index = mono_method_get_index (method);
 	if (!method_index)
 		return NULL;
@@ -1765,6 +1766,7 @@ mono_reflection_get_custom_attrs_info_checked (MonoObjectHandle obj, MonoError *
 	error_init (error);
 
 	klass = mono_handle_class (obj);
+	const char *klass_name = m_class_get_name (klass);
 	if (klass == mono_defaults.runtimetype_class) {
 		MonoType *type = mono_reflection_type_handle_mono_type (MONO_HANDLE_CAST(MonoReflectionType, obj), error);
 		goto_if_nok (error, leave);
@@ -1772,34 +1774,34 @@ mono_reflection_get_custom_attrs_info_checked (MonoObjectHandle obj, MonoError *
 		/*We cannot mono_class_init the class from which we'll load the custom attributes since this must work with broken types.*/
 		cinfo = mono_custom_attrs_from_class_checked (klass, error);
 		goto_if_nok (error, leave);
-	} else if (strcmp ("Assembly", klass->name) == 0 || strcmp ("MonoAssembly", klass->name) == 0) {
+	} else if (strcmp ("Assembly", klass_name) == 0 || strcmp ("MonoAssembly", klass_name) == 0) {
 		MonoReflectionAssemblyHandle rassembly = MONO_HANDLE_CAST (MonoReflectionAssembly, obj);
 		cinfo = mono_custom_attrs_from_assembly_checked (MONO_HANDLE_GETVAL (rassembly, assembly), FALSE, error);
 		goto_if_nok (error, leave);
-	} else if (strcmp ("Module", klass->name) == 0 || strcmp ("MonoModule", klass->name) == 0) {
+	} else if (strcmp ("Module", klass_name) == 0 || strcmp ("MonoModule", klass_name) == 0) {
 		MonoReflectionModuleHandle module = MONO_HANDLE_CAST (MonoReflectionModule, obj);
 		cinfo = mono_custom_attrs_from_module (MONO_HANDLE_GETVAL (module, image), error);
 		goto_if_nok (error, leave);
-	} else if (strcmp ("MonoProperty", klass->name) == 0) {
+	} else if (strcmp ("MonoProperty", klass_name) == 0) {
 		MonoReflectionPropertyHandle rprop = MONO_HANDLE_CAST (MonoReflectionProperty, obj);
 		MonoProperty *property = MONO_HANDLE_GETVAL (rprop, property);
 		cinfo = mono_custom_attrs_from_property_checked (property->parent, property, error);
 		goto_if_nok (error, leave);
-	} else if (strcmp ("MonoEvent", klass->name) == 0) {
+	} else if (strcmp ("MonoEvent", klass_name) == 0) {
 		MonoReflectionMonoEventHandle revent = MONO_HANDLE_CAST (MonoReflectionMonoEvent, obj);
 		MonoEvent *event = MONO_HANDLE_GETVAL (revent, event);
 		cinfo = mono_custom_attrs_from_event_checked (event->parent, event, error);
 		goto_if_nok (error, leave);
-	} else if (strcmp ("MonoField", klass->name) == 0) {
+	} else if (strcmp ("MonoField", klass_name) == 0) {
 		MonoReflectionFieldHandle rfield = MONO_HANDLE_CAST (MonoReflectionField, obj);
 		MonoClassField *field = MONO_HANDLE_GETVAL (rfield, field);
 		cinfo = mono_custom_attrs_from_field_checked (field->parent, field, error);
 		goto_if_nok (error, leave);
-	} else if ((strcmp ("MonoMethod", klass->name) == 0) || (strcmp ("MonoCMethod", klass->name) == 0)) {
+	} else if ((strcmp ("MonoMethod", klass_name) == 0) || (strcmp ("MonoCMethod", klass_name) == 0)) {
 		MonoReflectionMethodHandle rmethod = MONO_HANDLE_CAST (MonoReflectionMethod, obj);
 		cinfo = mono_custom_attrs_from_method_checked (MONO_HANDLE_GETVAL (rmethod, method), error);
 		goto_if_nok (error, leave);
-	} else if (strcmp ("ParameterInfo", klass->name) == 0 || strcmp ("MonoParameterInfo", klass->name) == 0) {
+	} else if (strcmp ("ParameterInfo", klass_name) == 0 || strcmp ("MonoParameterInfo", klass_name) == 0) {
 		MonoReflectionParameterHandle param = MONO_HANDLE_CAST (MonoReflectionParameter, obj);
 		MonoObjectHandle member_impl = MONO_HANDLE_NEW_GET (MonoObject, param, MemberImpl);
 		MonoClass *member_class = mono_handle_class (member_impl);
@@ -1835,48 +1837,48 @@ mono_reflection_get_custom_attrs_info_checked (MonoObjectHandle obj, MonoError *
 			g_free (type_name);
 			goto leave;
 		}
-	} else if (strcmp ("AssemblyBuilder", klass->name) == 0) {
+	} else if (strcmp ("AssemblyBuilder", klass_name) == 0) {
 		MonoReflectionAssemblyBuilderHandle assemblyb = MONO_HANDLE_CAST (MonoReflectionAssemblyBuilder, obj);
 		MonoReflectionAssemblyHandle assembly = MONO_HANDLE_CAST (MonoReflectionAssembly, assemblyb);
 		MonoArrayHandle cattrs = MONO_HANDLE_NEW_GET (MonoArray, assemblyb, cattrs);
 		MonoImage * image = MONO_HANDLE_GETVAL (assembly, assembly)->image;
 		g_assert (image);
 		cinfo = mono_custom_attrs_from_builders_handle (NULL, image, cattrs);
-	} else if (strcmp ("TypeBuilder", klass->name) == 0) {
+	} else if (strcmp ("TypeBuilder", klass_name) == 0) {
 		MonoReflectionTypeBuilderHandle tb = MONO_HANDLE_CAST (MonoReflectionTypeBuilder, obj);
 		MonoReflectionModuleBuilderHandle module = MONO_HANDLE_NEW_GET (MonoReflectionModuleBuilder, tb, module);
 		MonoDynamicImage *dynamic_image = MONO_HANDLE_GETVAL (module, dynamic_image);
 		MonoArrayHandle cattrs = MONO_HANDLE_NEW_GET (MonoArray, tb, cattrs);
 		cinfo = mono_custom_attrs_from_builders_handle (NULL, &dynamic_image->image, cattrs);
-	} else if (strcmp ("ModuleBuilder", klass->name) == 0) {
+	} else if (strcmp ("ModuleBuilder", klass_name) == 0) {
 		MonoReflectionModuleBuilderHandle mb = MONO_HANDLE_CAST (MonoReflectionModuleBuilder, obj);
 		MonoDynamicImage *dynamic_image = MONO_HANDLE_GETVAL (mb, dynamic_image);
 		MonoArrayHandle cattrs = MONO_HANDLE_NEW_GET (MonoArray, mb, cattrs);
 		cinfo = mono_custom_attrs_from_builders_handle (NULL, &dynamic_image->image, cattrs);
-	} else if (strcmp ("ConstructorBuilder", klass->name) == 0) {
+	} else if (strcmp ("ConstructorBuilder", klass_name) == 0) {
 		MonoReflectionCtorBuilderHandle cb = MONO_HANDLE_CAST (MonoReflectionCtorBuilder, obj);
 		MonoMethod *mhandle = MONO_HANDLE_GETVAL (cb, mhandle);
 		MonoArrayHandle cattrs = MONO_HANDLE_NEW_GET (MonoArray, cb, cattrs);
-		cinfo = mono_custom_attrs_from_builders_handle (NULL, mhandle->klass->image, cattrs);
-	} else if (strcmp ("MethodBuilder", klass->name) == 0) {
+		cinfo = mono_custom_attrs_from_builders_handle (NULL, m_class_get_image (mhandle->klass), cattrs);
+	} else if (strcmp ("MethodBuilder", klass_name) == 0) {
 		MonoReflectionMethodBuilderHandle mb = MONO_HANDLE_CAST (MonoReflectionMethodBuilder, obj);
 		MonoMethod *mhandle = MONO_HANDLE_GETVAL (mb, mhandle);
 		MonoArrayHandle cattrs = MONO_HANDLE_NEW_GET (MonoArray, mb, cattrs);
-		cinfo = mono_custom_attrs_from_builders_handle (NULL, mhandle->klass->image, cattrs);
-	} else if (strcmp ("FieldBuilder", klass->name) == 0) {
+		cinfo = mono_custom_attrs_from_builders_handle (NULL, m_class_get_image (mhandle->klass), cattrs);
+	} else if (strcmp ("FieldBuilder", klass_name) == 0) {
 		MonoReflectionFieldBuilderHandle fb = MONO_HANDLE_CAST (MonoReflectionFieldBuilder, obj);
 		MonoReflectionTypeBuilderHandle tb = MONO_HANDLE_NEW_GET (MonoReflectionTypeBuilder, fb, typeb);
 		MonoReflectionModuleBuilderHandle mb = MONO_HANDLE_NEW_GET (MonoReflectionModuleBuilder, tb, module);
 		MonoDynamicImage *dynamic_image = MONO_HANDLE_GETVAL (mb, dynamic_image);
 		MonoArrayHandle cattrs = MONO_HANDLE_NEW_GET (MonoArray, fb, cattrs);
 		cinfo = mono_custom_attrs_from_builders_handle (NULL, &dynamic_image->image, cattrs);
-	} else if (strcmp ("MonoGenericClass", klass->name) == 0) {
+	} else if (strcmp ("MonoGenericClass", klass_name) == 0) {
 		MonoReflectionGenericClassHandle gclass = MONO_HANDLE_CAST (MonoReflectionGenericClass, obj);
 		MonoReflectionTypeHandle generic_type = MONO_HANDLE_NEW_GET (MonoReflectionType, gclass, generic_type);
 		cinfo = mono_reflection_get_custom_attrs_info_checked (MONO_HANDLE_CAST (MonoObject, generic_type), error);
 		goto_if_nok (error, leave);
 	} else { /* handle other types here... */
-		g_error ("get custom attrs not yet supported for %s", klass->name);
+		g_error ("get custom attrs not yet supported for %s", m_class_get_name (klass));
 	}
 
 leave:
@@ -2250,9 +2252,9 @@ init_weak_fields_inner (MonoImage *image, GHashTable *indexes)
 						mono_error_cleanup (error);
 						return;
 					}
-					g_assert (!strcmp (klass->name, "WeakAttribute"));
+					g_assert (!strcmp (m_class_get_name (klass), "WeakAttribute"));
 					/* Allow a testing dll as well since some profiles don't have WeakAttribute */
-					if (klass && (klass->image == mono_get_corlib () || strstr (klass->image->name, "Mono.Runtime.Testing"))) {
+					if (klass && (m_class_get_image (klass) == mono_get_corlib () || strstr (m_class_get_image (klass)->name, "Mono.Runtime.Testing"))) {
 						/* Sanity check that it only has 1 ctor */
 						gpointer iter = NULL;
 						int count = 0;

--- a/mono/metadata/dynamic-image.c
+++ b/mono/metadata/dynamic-image.c
@@ -198,7 +198,7 @@ mono_dynamic_image_register_token (MonoDynamicImage *assembly, guint32 token, Mo
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	g_assert (!MONO_HANDLE_IS_NULL (obj));
-	g_assert (strcmp (mono_handle_class (obj)->name, "EnumBuilder"));
+	g_assert (strcmp (m_class_get_name (mono_handle_class (obj)), "EnumBuilder"));
 	dynamic_image_lock (assembly);
 	MonoObject *prev = (MonoObject *)mono_g_hash_table_lookup (assembly->tokens, GUINT_TO_POINTER (token));
 	if (prev) {

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -183,25 +183,28 @@ mono_gc_run_finalize (void *obj, void *data)
 
 	o = (MonoObject*)((char*)obj + GPOINTER_TO_UINT (data));
 
+	const char *o_ns = m_class_get_name_space (mono_object_class (o));
+	const char *o_name = m_class_get_name (mono_object_class (o));
+
 	if (mono_do_not_finalize) {
 		if (!mono_do_not_finalize_class_names)
 			return;
 
-		size_t namespace_len = strlen (o->vtable->klass->name_space);
+		size_t namespace_len = strlen (o_ns);
 		for (int i = 0; mono_do_not_finalize_class_names [i]; ++i) {
 			const char *name = mono_do_not_finalize_class_names [i];
-			if (strncmp (name, o->vtable->klass->name_space, namespace_len))
+			if (strncmp (name, o_ns, namespace_len))
 				break;
 			if (name [namespace_len] != '.')
 				break;
-			if (strcmp (name + namespace_len + 1, o->vtable->klass->name))
+			if (strcmp (name + namespace_len + 1, o_name))
 				break;
 			return;
 		}
 	}
 
 	if (log_finalizers)
-		g_log ("mono-gc-finalizers", G_LOG_LEVEL_DEBUG, "<%s at %p> Starting finalizer checks.", o->vtable->klass->name, o);
+		g_log ("mono-gc-finalizers", G_LOG_LEVEL_DEBUG, "<%s at %p> Starting finalizer checks.", o_name, o);
 
 	if (suspend_finalizers)
 		return;
@@ -224,7 +227,7 @@ mono_gc_run_finalize (void *obj, void *data)
 	object_register_finalizer ((MonoObject *)obj, NULL);
 
 	if (log_finalizers)
-		g_log ("mono-gc-finalizers", G_LOG_LEVEL_MESSAGE, "<%s at %p> Registered finalizer as processed.", o->vtable->klass->name, o);
+		g_log ("mono-gc-finalizers", G_LOG_LEVEL_MESSAGE, "<%s at %p> Registered finalizer as processed.", o_name, o);
 
 	if (o->vtable->klass == mono_defaults.internal_thread_class) {
 		MonoInternalThread *t = (MonoInternalThread*)o;
@@ -234,7 +237,7 @@ mono_gc_run_finalize (void *obj, void *data)
 			return;
 	}
 
-	if (o->vtable->klass->image == mono_defaults.corlib && !strcmp (o->vtable->klass->name, "DynamicMethod") && finalizing_root_domain) {
+	if (m_class_get_image (mono_object_class (o)) == mono_defaults.corlib && !strcmp (o_name, "DynamicMethod") && finalizing_root_domain) {
 		/*
 		 * These can't be finalized during unloading/shutdown, since that would
 		 * free the native code which can still be referenced by other
@@ -258,7 +261,7 @@ mono_gc_run_finalize (void *obj, void *data)
 	 * registered for finalization, but they don't have a Finalize
 	 * method, because in most cases it's not needed and it's just a waste.
 	 */
-	if (o->vtable->klass->delegate) {
+	if (m_class_is_delegate (mono_object_class (o))) {
 		MonoDelegate* del = (MonoDelegate*)o;
 		if (del->delegate_trampoline)
 			mono_delegate_free_ftnptr ((MonoDelegate*)o);
@@ -285,7 +288,7 @@ mono_gc_run_finalize (void *obj, void *data)
 	 * a CALLVIRT.
 	 */
 	if (log_finalizers)
-		g_log ("mono-gc-finalizers", G_LOG_LEVEL_MESSAGE, "<%s at %p> Compiling finalizer.", o->vtable->klass->name, o);
+		g_log ("mono-gc-finalizers", G_LOG_LEVEL_MESSAGE, "<%s at %p> Compiling finalizer.", o_name, o);
 
 #ifndef HOST_WASM
 	if (!domain->finalize_runtime_invoke) {
@@ -303,11 +306,11 @@ mono_gc_run_finalize (void *obj, void *data)
 
 	if (G_UNLIKELY (MONO_GC_FINALIZE_INVOKE_ENABLED ())) {
 		MONO_GC_FINALIZE_INVOKE ((unsigned long)o, mono_object_get_size (o),
-				o->vtable->klass->name_space, o->vtable->klass->name);
+				o_ns, o_name);
 	}
 
 	if (log_finalizers)
-		g_log ("mono-gc-finalizers", G_LOG_LEVEL_MESSAGE, "<%s at %p> Calling finalizer.", o->vtable->klass->name, o);
+		g_log ("mono-gc-finalizers", G_LOG_LEVEL_MESSAGE, "<%s at %p> Calling finalizer.", o_name, o);
 
 	MONO_PROFILER_RAISE (gc_finalizing_object, (o));
 
@@ -321,7 +324,7 @@ mono_gc_run_finalize (void *obj, void *data)
 	MONO_PROFILER_RAISE (gc_finalized_object, (o));
 
 	if (log_finalizers)
-		g_log ("mono-gc-finalizers", G_LOG_LEVEL_MESSAGE, "<%s at %p> Returned from finalizer.", o->vtable->klass->name, o);
+		g_log ("mono-gc-finalizers", G_LOG_LEVEL_MESSAGE, "<%s at %p> Returned from finalizer.", o_name, o);
 
 unhandled_error:
 	if (!is_ok (error))
@@ -564,7 +567,7 @@ ves_icall_System_GC_SuppressFinalize (MonoObject *obj)
 	 * unmanaged->managed trampoline. We don't let the user suppress it
 	 * otherwise we'd leak it.
 	 */
-	if (obj->vtable->klass->delegate)
+	if (m_class_is_delegate (mono_object_class (obj)))
 		return;
 
 	/* FIXME: Need to handle case where obj has COM Callable Wrapper
@@ -683,7 +686,7 @@ ves_icall_System_GCHandle_GetAddrOfPinnedObject (guint32 handle)
 		MonoClass *klass = mono_object_class (obj);
 		if (klass == mono_defaults.string_class) {
 			return mono_string_chars ((MonoString*)obj);
-		} else if (klass->rank) {
+		} else if (m_class_get_rank (klass)) {
 			return mono_array_addr ((MonoArray*)obj, char, 0);
 		} else {
 			/* the C# code will check and throw the exception */

--- a/mono/metadata/handle.c
+++ b/mono/metadata/handle.c
@@ -538,7 +538,7 @@ mono_object_handle_pin_unbox (MonoObjectHandle obj, uint32_t *gchandle)
 {
 	g_assert (!MONO_HANDLE_IS_NULL (obj));
 	MonoClass *klass = mono_handle_class (obj);
-	g_assert (klass->valuetype);
+	g_assert (m_class_is_valuetype (klass));
 	*gchandle = mono_gchandle_from_handle (obj, TRUE);
 	return mono_object_unbox (MONO_HANDLE_RAW (obj));
 }

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -547,7 +547,7 @@ mono_object_handle_pin_unbox (MonoObjectHandle boxed_valuetype_obj, uint32_t *gc
 static inline gpointer
 mono_handle_unbox_unsafe (MonoObjectHandle handle)
 {
-	g_assert (MONO_HANDLE_GETVAL (handle, vtable)->klass->valuetype);
+	g_assert (m_class_is_valuetype (MONO_HANDLE_GETVAL (handle, vtable)->klass));
 	return MONO_HANDLE_SUPPRESS (MONO_HANDLE_RAW (handle) + 1);
 }
 

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -174,8 +174,9 @@ ves_icall_System_Array_GetValueImpl (MonoArray *arr, guint32 pos)
 	esize = mono_array_element_size (ac);
 	ea = (gpointer*)((char*)arr->vector + (pos * esize));
 
-	if (ac->element_class->valuetype) {
-		result = mono_value_box_checked (arr->obj.vtable->domain, ac->element_class, ea, error);
+	MonoClass *ac_element_class = m_class_get_element_class (ac);
+	if (m_class_is_valuetype (ac_element_class)) {
+		result = mono_value_box_checked (arr->obj.vtable->domain, ac_element_class, ea, error);
 		mono_error_set_pending_exception (error);
 	} else
 		result = (MonoObject *)*ea;
@@ -196,8 +197,8 @@ ves_icall_System_Array_GetValue (MonoArray *arr, MonoArray *idxs)
 	
 	ac = (MonoClass *)arr->obj.vtable->klass;
 
-	g_assert (ic->rank == 1);
-	if (io->bounds != NULL || io->max_length !=  ac->rank) {
+	g_assert (m_class_get_rank (ic) == 1);
+	if (io->bounds != NULL || io->max_length !=  m_class_get_rank (ac)) {
 		mono_set_pending_exception (mono_get_exception_argument (NULL, NULL));
 		return NULL;
 	}
@@ -213,7 +214,7 @@ ves_icall_System_Array_GetValue (MonoArray *arr, MonoArray *idxs)
 		return ves_icall_System_Array_GetValueImpl (arr, *ind);
 	}
 	
-	for (i = 0; i < ac->rank; i++) {
+	for (i = 0; i < m_class_get_rank (ac); i++) {
 		if ((ind [i] < arr->bounds [i].lower_bound) ||
 		    (ind [i] >=  (mono_array_lower_bound_t)arr->bounds [i].length + arr->bounds [i].lower_bound)) {
 			mono_set_pending_exception (mono_get_exception_index_out_of_range ());
@@ -222,7 +223,7 @@ ves_icall_System_Array_GetValue (MonoArray *arr, MonoArray *idxs)
 	}
 
 	pos = ind [0] - arr->bounds [0].lower_bound;
-	for (i = 1; i < ac->rank; i++)
+	for (i = 1; i < m_class_get_rank (ac); i++)
 		pos = pos * arr->bounds [i].length + ind [i] - 
 			arr->bounds [i].lower_bound;
 
@@ -242,7 +243,6 @@ array_set_value_impl (MonoArrayHandle arr, MonoObjectHandle value, guint32 pos, 
 	MonoClass *ac, *vc, *ec;
 	gint32 esize, vsize;
 	gpointer *ea, *va;
-	int et, vt;
 
 	guint64 u64 = 0;
 	gint64 i64 = 0;
@@ -259,7 +259,7 @@ array_set_value_impl (MonoArrayHandle arr, MonoObjectHandle value, guint32 pos, 
 		vc = NULL;
 
 	ac = mono_handle_class (arr);
-	ec = ac->element_class;
+	ec = m_class_get_element_class (ac);
 
 	esize = mono_array_element_size (ac);
 	ea = mono_array_handle_pin_with_size (arr, esize, pos, &arr_gchandle);
@@ -292,10 +292,12 @@ array_set_value_impl (MonoArrayHandle arr, MonoObjectHandle value, guint32 pos, 
 		goto leave;							\
 	}G_STMT_END
 
+	MonoTypeEnum et = m_class_get_byval_arg (ec)->type;
+	MonoTypeEnum vt = m_class_get_byval_arg (vc)->type;
 	/* Check element (destination) type. */
-	switch (ec->byval_arg.type) {
+	switch (et) {
 	case MONO_TYPE_STRING:
-		switch (vc->byval_arg.type) {
+		switch (vt) {
 		case MONO_TYPE_STRING:
 			break;
 		default:
@@ -303,7 +305,7 @@ array_set_value_impl (MonoArrayHandle arr, MonoObjectHandle value, guint32 pos, 
 		}
 		break;
 	case MONO_TYPE_BOOLEAN:
-		switch (vc->byval_arg.type) {
+		switch (vt) {
 		case MONO_TYPE_BOOLEAN:
 			break;
 		case MONO_TYPE_CHAR:
@@ -330,7 +332,7 @@ array_set_value_impl (MonoArrayHandle arr, MonoObjectHandle value, guint32 pos, 
 	goto_if_nok (error, leave);
 	gboolean castOk = !MONO_HANDLE_IS_NULL (inst);
 
-	if (!ec->valuetype) {
+	if (!m_class_is_valuetype (ec)) {
 		if (!castOk)
 			INVALID_CAST;
 		MONO_HANDLE_ARRAY_SETREF (arr, pos, value);
@@ -339,7 +341,7 @@ array_set_value_impl (MonoArrayHandle arr, MonoObjectHandle value, guint32 pos, 
 
 	if (castOk) {
 		va = mono_object_handle_pin_unbox (value, &value_gchandle);
-		if (ec->has_references)
+		if (m_class_has_references (ec))
 			mono_value_copy (ea, va, ec);
 		else
 			mono_gc_memmove_atomic (ea, va, esize);
@@ -348,20 +350,18 @@ array_set_value_impl (MonoArrayHandle arr, MonoObjectHandle value, guint32 pos, 
 		goto leave;
 	}
 
-	if (!vc->valuetype)
+	if (!m_class_is_valuetype (vc))
 		INVALID_CAST;
 
 	va = mono_object_handle_pin_unbox (value, &value_gchandle);
 
 	vsize = mono_class_instance_size (vc) - sizeof (MonoObject);
 
-	et = ec->byval_arg.type;
-	if (et == MONO_TYPE_VALUETYPE && ec->byval_arg.data.klass->enumtype)
-		et = mono_class_enum_basetype (ec->byval_arg.data.klass)->type;
+	if (et == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_class_get_byval_arg (ec)->data.klass))
+		et = mono_class_enum_basetype (m_class_get_byval_arg (ec)->data.klass)->type;
 
-	vt = vc->byval_arg.type;
-	if (vt == MONO_TYPE_VALUETYPE && vc->byval_arg.data.klass->enumtype)
-		vt = mono_class_enum_basetype (vc->byval_arg.data.klass)->type;
+	if (vt == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_class_get_byval_arg (vc)->data.klass))
+		vt = mono_class_enum_basetype (m_class_get_byval_arg (vc)->data.klass)->type;
 
 #define ASSIGN_UNSIGNED(etype) G_STMT_START{\
 	switch (vt) { \
@@ -554,8 +554,8 @@ ves_icall_System_Array_SetValue (MonoArrayHandle arr, MonoObjectHandle value,
 	ic = mono_handle_class (idxs);
 	ac = mono_handle_class (arr);
 
-	g_assert (ic->rank == 1);
-	if (mono_handle_array_has_bounds (idxs) || MONO_HANDLE_GETVAL (idxs, max_length) != ac->rank) {
+	g_assert (m_class_get_rank (ic) == 1);
+	if (mono_handle_array_has_bounds (idxs) || MONO_HANDLE_GETVAL (idxs, max_length) != m_class_get_rank (ac)) {
 		mono_error_set_argument (error, "idxs", "");
 		return;
 	}
@@ -571,7 +571,8 @@ ves_icall_System_Array_SetValue (MonoArrayHandle arr, MonoObjectHandle value,
 		return;
 	}
 	
-	for (i = 0; i < ac->rank; i++) {
+	gint32 ac_rank = m_class_get_rank (ac);
+	for (i = 0; i < ac_rank; i++) {
 		mono_handle_array_get_bounds_dim (arr, i, &dim);
 		MONO_HANDLE_ARRAY_GETVAL (idx, idxs, gint32, i);
 		if ((idx < dim.lower_bound) ||
@@ -585,7 +586,7 @@ ves_icall_System_Array_SetValue (MonoArrayHandle arr, MonoObjectHandle value,
 	MONO_HANDLE_ARRAY_GETVAL  (idx, idxs, gint32, 0);
 	mono_handle_array_get_bounds_dim (arr, 0, &dim);
 	pos = idx - dim.lower_bound;
-	for (i = 1; i < ac->rank; i++) {
+	for (i = 1; i < ac_rank; i++) {
 		mono_handle_array_get_bounds_dim (arr, i, &dim);
 		MONO_HANDLE_ARRAY_GETVAL (idx, idxs, gint32, i);
 		pos = pos * dim.length + idx - dim.lower_bound;
@@ -622,7 +623,7 @@ ves_icall_System_Array_CreateInstanceImpl (MonoReflectionType *type, MonoArray *
 	if (mono_error_set_pending_exception (error))
 		return NULL;
 
-	if (klass->element_class->byval_arg.type == MONO_TYPE_VOID) {
+	if (m_class_get_byval_arg (m_class_get_element_class (klass))->type == MONO_TYPE_VOID) {
 		mono_set_pending_exception (mono_get_exception_not_supported ("Arrays of System.Void are not supported."));
 		return NULL;
 	}
@@ -635,16 +636,17 @@ ves_icall_System_Array_CreateInstanceImpl (MonoReflectionType *type, MonoArray *
 
 	aklass = mono_class_create_bounded_array (klass, mono_array_length (lengths), bounded);
 
-	sizes = (uintptr_t *)alloca (aklass->rank * sizeof(intptr_t) * 2);
-	for (i = 0; i < aklass->rank; ++i) {
+	uintptr_t aklass_rank = m_class_get_rank (aklass);
+	sizes = (uintptr_t *)alloca (aklass_rank * sizeof(intptr_t) * 2);
+	for (i = 0; i < aklass_rank; ++i) {
 		sizes [i] = mono_array_get (lengths, guint32, i);
 		if (bounds)
-			sizes [i + aklass->rank] = mono_array_get (bounds, gint32, i);
+			sizes [i + aklass_rank] = mono_array_get (bounds, gint32, i);
 		else
-			sizes [i + aklass->rank] = 0;
+			sizes [i + aklass_rank] = 0;
 	}
 
-	array = mono_array_new_full_checked (mono_object_domain (type), aklass, sizes, (intptr_t*)sizes + aklass->rank, error);
+	array = mono_array_new_full_checked (mono_object_domain (type), aklass, sizes, (intptr_t*)sizes + aklass_rank, error);
 	mono_error_set_pending_exception (error);
 
 	return array;
@@ -687,16 +689,18 @@ ves_icall_System_Array_CreateInstanceImpl64 (MonoReflectionType *type, MonoArray
 
 	aklass = mono_class_create_bounded_array (klass, mono_array_length (lengths), bounded);
 
-	sizes = (uintptr_t *)alloca (aklass->rank * sizeof(intptr_t) * 2);
-	for (i = 0; i < aklass->rank; ++i) {
+	uintptr_t aklass_rank = m_class_get_rank (aklass);
+
+	sizes = (uintptr_t *)alloca (aklass_rank * sizeof(intptr_t) * 2);
+	for (i = 0; i < aklass_rank; ++i) {
 		sizes [i] = mono_array_get (lengths, guint64, i);
 		if (bounds)
-			sizes [i + aklass->rank] = (mono_array_size_t) mono_array_get (bounds, guint64, i);
+			sizes [i + aklass_rank] = (mono_array_size_t) mono_array_get (bounds, guint64, i);
 		else
-			sizes [i + aklass->rank] = 0;
+			sizes [i + aklass_rank] = 0;
 	}
 
-	array = mono_array_new_full_checked (mono_object_domain (type), aklass, sizes, (intptr_t*)sizes + aklass->rank, error);
+	array = mono_array_new_full_checked (mono_object_domain (type), aklass, sizes, (intptr_t*)sizes + aklass_rank, error);
 	mono_error_set_pending_exception (error);
 
 	return array;
@@ -705,13 +709,13 @@ ves_icall_System_Array_CreateInstanceImpl64 (MonoReflectionType *type, MonoArray
 ICALL_EXPORT gint32 
 ves_icall_System_Array_GetRank (MonoObject *arr)
 {
-	return arr->vtable->klass->rank;
+	return m_class_get_rank (mono_object_class (arr));
 }
 
 ICALL_EXPORT gint32
 ves_icall_System_Array_GetLength (MonoArray *arr, gint32 dimension)
 {
-	gint32 rank = arr->obj.vtable->klass->rank;
+	gint32 rank = m_class_get_rank (mono_object_class (&arr->obj));
 	uintptr_t length;
 
 	if ((dimension < 0) || (dimension >= rank)) {
@@ -736,7 +740,7 @@ ves_icall_System_Array_GetLength (MonoArray *arr, gint32 dimension)
 ICALL_EXPORT gint64
 ves_icall_System_Array_GetLongLength (MonoArray *arr, gint32 dimension)
 {
-	gint32 rank = arr->obj.vtable->klass->rank;
+	gint32 rank = m_class_get_rank (mono_object_class (&arr->obj));
 
 	if ((dimension < 0) || (dimension >= rank)) {
 		mono_set_pending_exception (mono_get_exception_index_out_of_range ());
@@ -752,7 +756,7 @@ ves_icall_System_Array_GetLongLength (MonoArray *arr, gint32 dimension)
 ICALL_EXPORT gint32
 ves_icall_System_Array_GetLowerBound (MonoArray *arr, gint32 dimension)
 {
-	gint32 rank = arr->obj.vtable->klass->rank;
+	gint32 rank = m_class_get_rank (mono_object_class (&arr->obj));
 
 	if ((dimension < 0) || (dimension >= rank)) {
 		mono_set_pending_exception (mono_get_exception_index_out_of_range ());
@@ -798,8 +802,8 @@ ves_icall_System_Array_FastCopy (MonoArray *source, int source_idx, MonoArray* d
 		(source_idx + length > mono_array_length_fast (source)))
 		return FALSE;
 
-	src_class = src_vtable->klass->element_class;
-	dest_class = dest_vtable->klass->element_class;
+	src_class = m_class_get_element_class (src_vtable->klass);
+	dest_class = m_class_get_element_class (dest_vtable->klass);
 
 	/*
 	 * Handle common cases.
@@ -808,12 +812,13 @@ ves_icall_System_Array_FastCopy (MonoArray *source, int source_idx, MonoArray* d
 	/* Case1: object[] -> valuetype[] (ArrayList::ToArray) 
 	We fallback to managed here since we need to typecheck each boxed valuetype before storing them in the dest array.
 	*/
-	if (src_class == mono_defaults.object_class && dest_class->valuetype)
+	if (src_class == mono_defaults.object_class && m_class_is_valuetype (dest_class))
 		return FALSE;
 
 	/* Check if we're copying a char[] <==> (u)short[] */
 	if (src_class != dest_class) {
-		if (dest_class->valuetype || dest_class->enumtype || src_class->valuetype || src_class->enumtype)
+		if (m_class_is_valuetype (dest_class) || m_class_is_enumtype (dest_class) ||
+		 	m_class_is_valuetype (src_class) || m_class_is_valuetype (src_class))
 			return FALSE;
 
 		/* It's only safe to copy between arrays if we can ensure the source will always have a subtype of the destination. We bail otherwise. */
@@ -821,10 +826,10 @@ ves_icall_System_Array_FastCopy (MonoArray *source, int source_idx, MonoArray* d
 			return FALSE;
 	}
 
-	if (dest_class->valuetype) {
+	if (m_class_is_valuetype (dest_class)) {
 		element_size = mono_array_element_size (source->obj.vtable->klass);
 		source_addr = mono_array_addr_with_size_fast (source, element_size, source_idx);
-		if (dest_class->has_references) {
+		if (m_class_has_references (dest_class)) {
 			mono_value_copy_array (dest, dest_idx, source_addr, length);
 		} else {
 			dest_addr = mono_array_addr_with_size_fast (dest, element_size, dest_idx);
@@ -860,18 +865,18 @@ ves_icall_System_Array_SetGenericValueImpl (MonoArray *arr, guint32 pos, gpointe
 	gpointer *ea;
 
 	ac = (MonoClass *)arr->obj.vtable->klass;
-	ec = ac->element_class;
+	ec = m_class_get_element_class (ac);
 
 	esize = mono_array_element_size (ac);
 	ea = (gpointer*)((char*)arr->vector + (pos * esize));
 
-	if (MONO_TYPE_IS_REFERENCE (&ec->byval_arg)) {
+	if (MONO_TYPE_IS_REFERENCE (m_class_get_byval_arg (ec))) {
 		g_assert (esize == sizeof (gpointer));
 		mono_gc_wbarrier_generic_store (ea, *(MonoObject **)value);
 	} else {
-		g_assert (ec->inited);
+		g_assert (m_class_is_inited (ec));
 		g_assert (esize == mono_class_value_size (ec, NULL));
-		if (ec->has_references)
+		if (m_class_has_references (ec))
 			mono_gc_wbarrier_value_copy (ea, value, 1, ec);
 		else
 			mono_gc_memmove_atomic (ea, value, esize);
@@ -885,7 +890,7 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_InitializeArray (MonoAr
 
 	MonoClass *klass = mono_handle_class (array);
 	guint32 size = mono_array_element_size (klass);
-	MonoType *type = mono_type_get_underlying_type (&klass->element_class->byval_arg);
+	MonoType *type = mono_type_get_underlying_type (m_class_get_byval_arg (m_class_get_element_class (klass)));
 	int align;
 	const char *field_data;
 
@@ -960,7 +965,7 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_GetOffsetToStringData (
 ICALL_EXPORT MonoObject *
 ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_GetObjectValue (MonoObject *obj)
 {
-	if ((obj == NULL) || (! (obj->vtable->klass->valuetype)))
+	if ((obj == NULL) || !m_class_is_valuetype (mono_object_class (obj)))
 		return obj;
 	else {
 		ERROR_DECL (error);
@@ -1153,7 +1158,7 @@ ves_icall_System_ValueType_Equals (MonoObject *this_obj, MonoObject *that, MonoA
 
 	klass = mono_object_class (this_obj);
 
-	if (klass->enumtype && mono_class_enum_basetype (klass) && mono_class_enum_basetype (klass)->type == MONO_TYPE_I4)
+	if (m_class_is_enumtype (klass) && mono_class_enum_basetype (klass) && mono_class_enum_basetype (klass)->type == MONO_TYPE_I4)
 		return (*(gint32*)((guint8*)this_obj + sizeof (MonoObject)) == *(gint32*)((guint8*)that + sizeof (MonoObject)));
 
 	/*
@@ -1275,7 +1280,7 @@ ves_icall_System_ValueType_Equals (MonoObject *this_obj, MonoObject *that, MonoA
 
 #undef UNALIGNED_COMPARE
 
-		if (klass->enumtype)
+		if (m_class_is_enumtype (klass))
 			/* enums only have one non-static field */
 			break;
 	}
@@ -1309,12 +1314,12 @@ ves_icall_System_Object_GetType (MonoObjectHandle obj, MonoError *error)
 		 * is just MarshalByRefObject). */
 		MonoType *proxy_type =
 			mono_remote_class_is_interface_proxy (remote_class) ?
-			&remote_class->interfaces[0]->byval_arg :
-			&remote_class->proxy_class->byval_arg;
+			m_class_get_byval_arg (remote_class->interfaces[0]) :
+			m_class_get_byval_arg (remote_class->proxy_class);
 		return mono_type_get_object_handle (domain, proxy_type, error);
 	} else
 #endif
-		return mono_type_get_object_handle (domain, &klass->byval_arg, error);
+		return mono_type_get_object_handle (domain, m_class_get_byval_arg (klass), error);
 }
 
 static gboolean
@@ -1327,12 +1332,19 @@ get_executing (MonoMethod *m, gint32 no, gint32 ilo, gboolean managed, gpointer 
 		return FALSE;
 
 	if (!(*dest)) {
-		if (!strcmp (m->klass->name_space, "System.Reflection"))
+		if (!strcmp (m_class_get_name_space (m->klass), "System.Reflection"))
 			return FALSE;
 		*dest = m;
 		return TRUE;
 	}
 	return FALSE;
+}
+
+static gboolean
+in_corlib_name_space (MonoClass *klass, const char *name_space)
+{
+	return m_class_get_image (klass) == mono_defaults.corlib &&
+		!strcmp (m_class_get_name_space (klass), name_space);
 }
 
 static gboolean
@@ -1352,7 +1364,7 @@ get_caller_no_reflection (MonoMethod *m, gint32 no, gint32 ilo, gboolean managed
 		return FALSE;
 	}
 
-	if (m->klass->image == mono_defaults.corlib && !strcmp (m->klass->name_space, "System.Reflection"))
+	if (in_corlib_name_space (m->klass, "System.Reflection"))
 		return FALSE;
 
 	if (!(*dest)) {
@@ -1379,8 +1391,7 @@ get_caller_no_system_or_reflection (MonoMethod *m, gint32 no, gint32 ilo, gboole
 		return FALSE;
 	}
 
-	if (m->klass->image == mono_defaults.corlib && ((!strcmp (m->klass->name_space, "System.Reflection"))
-													|| (!strcmp (m->klass->name_space, "System"))))
+	if (in_corlib_name_space (m->klass, "System.Reflection") || in_corlib_name_space (m->klass, "System"))
 		return FALSE;
 
 	if (!(*dest)) {
@@ -1409,7 +1420,7 @@ type_from_parsed_name (MonoTypeNameParse *info, MonoBoolean ignoreCase, MonoAsse
 	 */
 	m = mono_method_get_last_managed ();
 	dest = m;
-	if (m && m->klass->image != mono_defaults.corlib) {
+	if (m && m_class_get_image (m->klass) != mono_defaults.corlib) {
 		/* Happens with inlining */
 	} else {
 		/* Ugly hack: type_from_parsed_name is called from
@@ -1436,7 +1447,7 @@ type_from_parsed_name (MonoTypeNameParse *info, MonoBoolean ignoreCase, MonoAsse
 	 */
 
 	if (dest) {
-		assembly = dest->klass->image->assembly;
+		assembly = m_class_get_image (dest->klass)->assembly;
 		type_resolve = TRUE;
 		rootimage = assembly->image;
 	} else {
@@ -1638,14 +1649,14 @@ handle_enum:
 	case MONO_TYPE_VALUETYPE: {
 		MonoClass *klass = type->data.klass;
 		
-		if (klass->enumtype) {
+		if (m_class_is_enumtype (klass)) {
 			t = mono_class_enum_basetype (klass)->type;
 			goto handle_enum;
-		} else if (mono_is_corlib_image (klass->image)) {
-			if (strcmp (klass->name_space, "System") == 0) {
-				if (strcmp (klass->name, "Decimal") == 0)
+		} else if (mono_is_corlib_image (m_class_get_image (klass))) {
+			if (strcmp (m_class_get_name_space (klass), "System") == 0) {
+				if (strcmp (m_class_get_name (klass), "Decimal") == 0)
 					return TYPECODE_DECIMAL;
-				else if (strcmp (klass->name, "DateTime") == 0)
+				else if (strcmp (m_class_get_name (klass), "DateTime") == 0)
 					return TYPECODE_DATETIME;
 			}
 		}
@@ -1663,8 +1674,8 @@ handle_enum:
 	case MONO_TYPE_CLASS:
 		{
 			MonoClass *klass =  type->data.klass;
-			if (klass->image == mono_defaults.corlib && strcmp (klass->name_space, "System") == 0) {
-				if (strcmp (klass->name, "DBNull") == 0)
+			if (m_class_get_image (klass) == mono_defaults.corlib && strcmp (m_class_get_name_space (klass), "System") == 0) {
+				if (strcmp (m_class_get_name (klass), "DBNull") == 0)
 					return TYPECODE_DBNULL;
 			}
 		}
@@ -1680,9 +1691,9 @@ handle_enum:
 static MonoType*
 mono_type_get_underlying_type_ignore_byref (MonoType *type)
 {
-	if (type->type == MONO_TYPE_VALUETYPE && type->data.klass->enumtype)
+	if (type->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (type->data.klass))
 		return mono_class_enum_basetype (type->data.klass);
-	if (type->type == MONO_TYPE_GENERICINST && type->data.generic_class->container_class->enumtype)
+	if (type->type == MONO_TYPE_GENERICINST && m_class_is_enumtype (type->data.generic_class->container_class))
 		return mono_class_enum_basetype (type->data.generic_class->container_class);
 	return type;
 }
@@ -1710,7 +1721,7 @@ ves_icall_RuntimeTypeHandle_type_is_assignable_from (MonoReflectionTypeHandle re
 		klassc = mono_class_from_mono_type (ot);
 
 		if (mono_type_is_primitive (t)) {
-			return mono_type_is_primitive (ot) && klass->instance_size == klassc->instance_size;
+			return mono_type_is_primitive (ot) && m_class_get_instance_size (klass) == m_class_get_instance_size (klassc);
 		} else if (t->type == MONO_TYPE_VAR || t->type == MONO_TYPE_MVAR) {
 			return t->type == ot->type && t->data.generic_param->num == ot->data.generic_param->num;
 		} else if (t->type == MONO_TYPE_PTR || t->type == MONO_TYPE_FNPTR) {
@@ -1719,9 +1730,9 @@ ves_icall_RuntimeTypeHandle_type_is_assignable_from (MonoReflectionTypeHandle re
 			 if (ot->type == MONO_TYPE_VAR || ot->type == MONO_TYPE_MVAR)
 				 return FALSE;
 
-			 if (klass->valuetype)
+			 if (m_class_is_valuetype (klass))
 				return klass == klassc;
-			return klass->valuetype == klassc->valuetype;
+			 return m_class_is_valuetype (klass) == m_class_is_valuetype (klassc);
 		}
 	}
 	return mono_class_is_assignable_from (klass, klassc);
@@ -1861,7 +1872,7 @@ ves_icall_System_Reflection_FieldInfo_GetTypeModifiers (MonoReflectionFieldHandl
 	if (!is_ok (error))
 		return MONO_HANDLE_CAST (MonoArray, NULL_HANDLE);
 
-	return type_array_from_modifiers (field->parent->image, type, optional, error);
+	return type_array_from_modifiers (m_class_get_image (field->parent), type, optional, error);
 }
 
 ICALL_EXPORT int
@@ -1878,7 +1889,7 @@ ves_icall_get_method_info (MonoMethod *method, MonoMethodInfo *info, MonoError *
 	MonoMethodSignature* sig = mono_method_signature_checked (method, error);
 	return_if_nok (error);
 
-	MonoReflectionTypeHandle rt = mono_type_get_object_handle (domain, &method->klass->byval_arg, error);
+	MonoReflectionTypeHandle rt = mono_type_get_object_handle (domain, m_class_get_byval_arg (method->klass), error);
 	return_if_nok (error);
 
 	MONO_STRUCT_SETREF (info, parent, MONO_HANDLE_RAW (rt));
@@ -1964,7 +1975,7 @@ ves_icall_MonoField_GetParentType (MonoReflectionFieldHandle field, MonoBoolean 
 		parent = MONO_HANDLE_GETVAL (field, klass);
 	}
 
-	return mono_type_get_object_handle (domain, &parent->byval_arg, error);
+	return mono_type_get_object_handle (domain, m_class_get_byval_arg (parent), error);
 }
 
 ICALL_EXPORT MonoObject *
@@ -1975,7 +1986,7 @@ ves_icall_MonoField_GetValueInternal (MonoReflectionField *field, MonoObject *ob
 	MonoClassField *cf = field->field;
 	MonoDomain *domain = mono_object_domain (field);
 
-	if (fklass->image->assembly->ref_only) {
+	if (m_class_get_image (fklass)->assembly->ref_only) {
 		mono_set_pending_exception (mono_get_exception_invalid_operation (
 					"It is illegal to get the value on a field on a type loaded using the ReflectionOnly methods."));
 		return NULL;
@@ -2010,7 +2021,7 @@ ves_icall_MonoField_SetValueInternal (MonoReflectionFieldHandle field, MonoObjec
 	MonoClassField *cf = MONO_HANDLE_GETVAL (field, field);
 
 	MonoClass *field_klass = MONO_HANDLE_GETVAL (field, klass);
-	if (field_klass->image->assembly->ref_only) {
+	if (m_class_get_image (field_klass)->assembly->ref_only) {
 		mono_error_set_invalid_operation (error, "It is illegal to set the value on a field on a type loaded using the ReflectionOnly methods.");
 		return;
 	}
@@ -2094,7 +2105,7 @@ ves_icall_MonoField_SetValueInternal (MonoReflectionFieldHandle field, MonoObjec
 				v = (gchar*)nval;
 			}
 			else {
-				isref = !gclass->container_class->valuetype;
+				isref = !m_class_is_valuetype (gclass->container_class);
 				if (!isref && !MONO_HANDLE_IS_NULL (value)) {
 					v = mono_object_handle_pin_unbox (value, &value_gchandle);
 				};
@@ -2148,7 +2159,7 @@ ves_icall_System_RuntimeFieldHandle_SetValueDirect (MonoReflectionField *field, 
 	g_assert (value);
 
 	f = field->field;
-	if (!MONO_TYPE_ISSTRUCT (&f->parent->byval_arg)) {
+	if (!MONO_TYPE_ISSTRUCT (m_class_get_byval_arg (f->parent))) {
 		mono_set_pending_exception (mono_get_exception_not_implemented (NULL));
 		return;
 	}
@@ -2185,9 +2196,9 @@ ves_icall_MonoField_GetRawConstantValue (MonoReflectionField *rfield)
 		return NULL;
 	}
 
-	if (image_is_dynamic (field->parent->image)) {
+	if (image_is_dynamic (m_class_get_image (field->parent))) {
 		MonoClass *klass = field->parent;
-		int fidx = field - klass->fields;
+		int fidx = field - m_class_get_fields (klass);
 		MonoFieldDefaultValue *def_values = mono_class_get_field_def_values (klass);
 
 		g_assert (def_values);
@@ -2286,13 +2297,13 @@ ves_icall_MonoPropertyInfo_get_property_info (MonoReflectionPropertyHandle prope
 
 	if ((req_info & PInfo_ReflectedType) != 0) {
 		MonoClass *klass = MONO_HANDLE_GETVAL (property, klass);
-		MonoReflectionTypeHandle rt = mono_type_get_object_handle (domain, &klass->byval_arg, error);
+		MonoReflectionTypeHandle rt = mono_type_get_object_handle (domain, m_class_get_byval_arg (klass), error);
 		return_if_nok (error);
 
 		MONO_STRUCT_SETREF (info, parent, MONO_HANDLE_RAW (rt));
 	}
 	if ((req_info & PInfo_DeclaringType) != 0) {
-		MonoReflectionTypeHandle rt = mono_type_get_object_handle (domain, &pproperty->parent->byval_arg, error);
+		MonoReflectionTypeHandle rt = mono_type_get_object_handle (domain, m_class_get_byval_arg (pproperty->parent), error);
 		return_if_nok (error);
 
 		MONO_STRUCT_SETREF (info, declaring_type, MONO_HANDLE_RAW (rt));
@@ -2363,11 +2374,11 @@ ves_icall_MonoEventInfo_get_event_info (MonoReflectionMonoEventHandle ref_event,
 	MonoClass *klass = MONO_HANDLE_GETVAL (ref_event, klass);
 	MonoEvent *event = MONO_HANDLE_GETVAL (ref_event, event);
 
-	MonoReflectionTypeHandle rt = mono_type_get_object_handle (domain, &klass->byval_arg, error);
+	MonoReflectionTypeHandle rt = mono_type_get_object_handle (domain, m_class_get_byval_arg (klass), error);
 	return_if_nok (error);
 	MONO_STRUCT_SETREF (info, reflected_type, MONO_HANDLE_RAW (rt));
 
-	rt = mono_type_get_object_handle (domain, &event->parent->byval_arg, error);
+	rt = mono_type_get_object_handle (domain, m_class_get_byval_arg (event->parent), error);
 	return_if_nok (error);
 	MONO_STRUCT_SETREF (info, declaring_type, MONO_HANDLE_RAW (rt));
 
@@ -2432,8 +2443,10 @@ collect_interfaces (MonoClass *klass, GHashTable *ifaces, MonoError *error)
 	if (!mono_error_ok (error))
 		return;
 
-	for (i = 0; i < klass->interface_count; i++) {
-		ic = klass->interfaces [i];
+	int klass_interface_count = m_class_get_interface_count (klass);
+	MonoClass **klass_interfaces = m_class_get_interfaces (klass);
+	for (i = 0; i < klass_interface_count; i++) {
+		ic = klass_interfaces [i];
 		g_hash_table_insert (ifaces, ic, ic);
 
 		collect_interfaces (ic, ifaces, error);
@@ -2456,7 +2469,7 @@ fill_iface_array (gpointer key, gpointer value, gpointer user_data)
 	HANDLE_FUNCTION_ENTER ();
 	FillIfaceArrayData *data = (FillIfaceArrayData *)user_data;
 	MonoClass *ic = (MonoClass *)key;
-	MonoType *ret = &ic->byval_arg, *inflated = NULL;
+	MonoType *ret = m_class_get_byval_arg (ic), *inflated = NULL;
 	MonoError *error = data->error;
 
 	goto_if_nok (error, leave);
@@ -2483,7 +2496,7 @@ get_interfaces_hash (gconstpointer v1)
 {
 	MonoClass *k = (MonoClass*)v1;
 
-	return k->type_token;
+	return m_class_get_type_token (k);
 }
 
 ICALL_EXPORT MonoArrayHandle
@@ -2501,7 +2514,7 @@ ves_icall_RuntimeType_GetInterfaces (MonoReflectionTypeHandle ref_type, MonoErro
 		klass = mono_class_get_generic_class (klass)->container_class;
 	}
 
-	for (MonoClass *parent = klass; parent; parent = parent->parent) {
+	for (MonoClass *parent = klass; parent; parent = m_class_get_parent (parent)) {
 		mono_class_setup_interfaces (parent, error);
 		goto_if_nok (error, fail);
 		collect_interfaces (parent, iface_hash, error);
@@ -2550,7 +2563,7 @@ set_interface_map_data_method_object (MonoDomain *domain, MonoMethod *method, Mo
 
 	MONO_HANDLE_ARRAY_SETREF (methods, i, member);
 
-	MONO_HANDLE_ASSIGN (member, mono_method_get_object_handle (domain, klass->vtable [i + ioffset], klass, error));
+	MONO_HANDLE_ASSIGN (member, mono_method_get_object_handle (domain, m_class_get_vtable (klass) [i + ioffset], klass, error));
 	goto_if_nok (error, leave);
 
 	MONO_HANDLE_ARRAY_SETREF (targets, i, member);
@@ -2611,12 +2624,12 @@ ves_icall_RuntimeType_GetPacking (MonoReflectionTypeHandle ref_type, guint32 *pa
 	if (!is_ok (error))
 		return;
 
-	if (image_is_dynamic (klass->image)) {
+	if (image_is_dynamic (m_class_get_image (klass))) {
 		MonoReflectionTypeBuilderHandle tb = MONO_HANDLE_CAST (MonoReflectionTypeBuilder, ref_type);
 		*packing = MONO_HANDLE_GETVAL (tb, packing_size);
 		*size = MONO_HANDLE_GETVAL (tb, class_size);
 	} else {
-		mono_metadata_packing_from_typedef (klass->image, klass->type_token, packing, size);
+		mono_metadata_packing_from_typedef (m_class_get_image (klass), m_class_get_type_token (klass), packing, size);
 	}
 }
 
@@ -2629,7 +2642,7 @@ ves_icall_RuntimeTypeHandle_GetElementType (MonoReflectionTypeHandle ref_type, M
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
 	if (!type->byref && type->type == MONO_TYPE_SZARRAY) {
-		return mono_type_get_object_handle (domain, &type->data.klass->byval_arg, error);
+		return mono_type_get_object_handle (domain, m_class_get_byval_arg (type->data.klass), error);
 	}
 
 	MonoClass *klass = mono_class_from_mono_type (type);
@@ -2640,11 +2653,11 @@ ves_icall_RuntimeTypeHandle_GetElementType (MonoReflectionTypeHandle ref_type, M
 	// GetElementType should only return a type for:
 	// Array Pointer PassedByRef
 	if (type->byref)
-		return mono_type_get_object_handle (domain, &klass->byval_arg, error);
-	else if (klass->element_class && MONO_CLASS_IS_ARRAY (klass))
-		return mono_type_get_object_handle (domain, &klass->element_class->byval_arg, error);
-	else if (klass->element_class && type->type == MONO_TYPE_PTR)
-		return mono_type_get_object_handle (domain, &klass->element_class->byval_arg, error);
+		return mono_type_get_object_handle (domain, m_class_get_byval_arg (klass), error);
+	else if (m_class_get_element_class (klass) && MONO_CLASS_IS_ARRAY (klass))
+		return mono_type_get_object_handle (domain, m_class_get_byval_arg (m_class_get_element_class (klass)), error);
+	else if (m_class_get_element_class (klass) && type->type == MONO_TYPE_PTR)
+		return mono_type_get_object_handle (domain, m_class_get_byval_arg (m_class_get_element_class (klass)), error);
 	else
 		return MONO_HANDLE_CAST (MonoReflectionType, NULL_HANDLE);
 }
@@ -2661,10 +2674,10 @@ ves_icall_RuntimeTypeHandle_GetBaseType (MonoReflectionTypeHandle ref_type, Mono
 		return MONO_HANDLE_CAST (MonoReflectionType, NULL_HANDLE);
 
 	MonoClass *klass = mono_class_from_mono_type (type);
-	if (!klass->parent)
+	if (!m_class_get_parent (klass))
 		return MONO_HANDLE_CAST (MonoReflectionType, NULL_HANDLE);
 
-	return mono_type_get_object_handle (domain, &klass->parent->byval_arg, error);
+	return mono_type_get_object_handle (domain, m_class_get_byval_arg (m_class_get_parent (klass)), error);
 }
 
 ICALL_EXPORT MonoBoolean
@@ -2692,7 +2705,7 @@ ves_icall_RuntimeTypeHandle_HasReferences (MonoReflectionTypeHandle ref_type, Mo
 
 	klass = mono_class_from_mono_type (type);
 	mono_class_init (klass);
-	return klass->has_references;
+	return m_class_has_references (klass);
 }
 
 ICALL_EXPORT MonoBoolean
@@ -2730,7 +2743,7 @@ ves_icall_RuntimeTypeHandle_GetModule (MonoReflectionTypeHandle type, MonoError 
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (type);
 	MonoType *t = MONO_HANDLE_GETVAL (type, type);
 	MonoClass *klass = mono_class_from_mono_type (t);
-	return mono_module_get_object_handle (domain, klass->image, error);
+	return mono_module_get_object_handle (domain, m_class_get_image (klass), error);
 }
 
 ICALL_EXPORT MonoReflectionAssemblyHandle
@@ -2740,7 +2753,7 @@ ves_icall_RuntimeTypeHandle_GetAssembly (MonoReflectionTypeHandle type, MonoErro
 	MonoDomain *domain = mono_domain_get (); 
 	MonoType *t = MONO_HANDLE_GETVAL (type, type);
 	MonoClass *klass = mono_class_from_mono_type (t);
-	return mono_assembly_get_object_handle (domain, klass->image->assembly, error);
+	return mono_assembly_get_object_handle (domain, m_class_get_image (klass)->assembly, error);
 }
 
 ICALL_EXPORT MonoReflectionTypeHandle
@@ -2760,13 +2773,13 @@ ves_icall_RuntimeType_get_DeclaringType (MonoReflectionTypeHandle ref_type, Mono
 		MonoGenericContainer *param = mono_type_get_generic_param_owner (type);
 		klass = param ? param->owner.method->klass : NULL;
 	} else {
-		klass = mono_class_from_mono_type (type)->nested_in;
+		klass = m_class_get_nested_in (mono_class_from_mono_type (type));
 	}
 
 	if (!klass)
 		return MONO_HANDLE_CAST (MonoReflectionType, NULL_HANDLE);
 
-	return mono_type_get_object_handle (domain, &klass->byval_arg, error);
+	return mono_type_get_object_handle (domain, m_class_get_byval_arg (klass), error);
 }
 
 ICALL_EXPORT MonoStringHandle
@@ -2777,14 +2790,14 @@ ves_icall_RuntimeType_get_Name (MonoReflectionTypeHandle reftype, MonoError *err
 	MonoClass *klass = mono_class_from_mono_type (type);
 
 	if (type->byref) {
-		char *n = g_strdup_printf ("%s&", klass->name);
+		char *n = g_strdup_printf ("%s&", m_class_get_name (klass));
 		MonoStringHandle res = mono_string_new_handle (domain, n, error);
 
 		g_free (n);
 
 		return res;
 	} else {
-		return mono_string_new_handle (domain, klass->name, error);
+		return mono_string_new_handle (domain, m_class_get_name (klass), error);
 	}
 }
 
@@ -2794,13 +2807,14 @@ ves_icall_RuntimeType_get_Namespace (MonoReflectionTypeHandle type, MonoError *e
 	MonoDomain *domain = mono_domain_get (); 
 	MonoClass *klass = mono_class_from_mono_type_handle (type);
 
-	while (klass->nested_in)
-		klass = klass->nested_in;
+	MonoClass *klass_nested_in;
+	while ((klass_nested_in = m_class_get_nested_in (klass)))
+		klass = klass_nested_in;
 
-	if (klass->name_space [0] == '\0')
+	if (m_class_get_name_space (klass) [0] == '\0')
 		return NULL_HANDLE_STRING;
 	else
-		return mono_string_new_handle (domain, klass->name_space, error);
+		return mono_string_new_handle (domain, m_class_get_name_space (klass), error);
 }
 
 ICALL_EXPORT gint32
@@ -2816,7 +2830,7 @@ ves_icall_RuntimeTypeHandle_GetArrayRank (MonoReflectionTypeHandle ref_type, Mon
 
 	MonoClass *klass = mono_class_from_mono_type (type);
 
-	return klass->rank;
+	return m_class_get_rank (klass);
 }
 
 static MonoArrayHandle
@@ -2856,7 +2870,7 @@ ves_icall_RuntimeType_GetGenericArguments (MonoReflectionTypeHandle ref_type, Mo
 		for (int i = 0; i < container->type_argc; ++i) {
 			MonoClass *pklass = mono_class_create_generic_parameter (mono_generic_container_get_param (container, i));
 
-			if (!set_type_object_in_array (domain, &pklass->byval_arg, res, i, error))
+			if (!set_type_object_in_array (domain, m_class_get_byval_arg (pklass), res, i, error))
 				goto leave;
 		}
 		
@@ -2913,13 +2927,13 @@ ves_icall_RuntimeTypeHandle_GetGenericTypeDefinition_impl (MonoReflectionTypeHan
 
 		guint32 ref_info_handle = mono_class_get_ref_info_handle (generic_class);
 		
-		if (generic_class->wastypebuilder && ref_info_handle) {
+		if (m_class_was_typebuilder (generic_class) && ref_info_handle) {
 			MonoObjectHandle tb = mono_gchandle_get_target_handle (ref_info_handle);
 			g_assert (!MONO_HANDLE_IS_NULL (tb));
 			MONO_HANDLE_ASSIGN (ret, tb);
 		} else {
 			MonoDomain *domain = MONO_HANDLE_DOMAIN (ref_type);
-			MONO_HANDLE_ASSIGN (ret, mono_type_get_object_handle (domain, &generic_class->byval_arg, error));
+			MONO_HANDLE_ASSIGN (ret, mono_type_get_object_handle (domain, m_class_get_byval_arg (generic_class), error));
 		}
 	}
 leave:
@@ -3084,7 +3098,7 @@ ves_icall_MonoMethod_GetPInvoke (MonoReflectionMethodHandle ref_method, int* fla
 {
 	MonoDomain *domain = mono_domain_get ();
 	MonoMethod *method = MONO_HANDLE_GETVAL (ref_method, method);
-	MonoImage *image = method->klass->image;
+	MonoImage *image = m_class_get_image (method->klass);
 	MonoMethodPInvoke *piinfo = (MonoMethodPInvoke *)method;
 	MonoTableInfo *tables = image->tables;
 	MonoTableInfo *im = &tables [MONO_TABLE_IMPLMAP];
@@ -3145,8 +3159,8 @@ ves_icall_MonoMethod_GetGenericMethodDefinition (MonoReflectionMethodHandle ref_
 	if (!result->is_generic)
 		return MONO_HANDLE_CAST (MonoReflectionMethod, NULL_HANDLE);
 
-	if (image_is_dynamic (method->klass->image)) {
-		MonoDynamicImage *image = (MonoDynamicImage*)method->klass->image;
+	if (image_is_dynamic (m_class_get_image (method->klass))) {
+		MonoDynamicImage *image = (MonoDynamicImage*)m_class_get_image (method->klass);
 
 		/*
 		 * FIXME: Why is this stuff needed at all ? Why can't the code below work for
@@ -3205,7 +3219,7 @@ set_array_generic_argument_handle_gparam (MonoDomain *domain, MonoGenericContain
 	error_init (error);
 	MonoGenericParam *param = mono_generic_container_get_param (container, i);
 	MonoClass *pklass = mono_class_create_generic_parameter (param);
-	MonoReflectionTypeHandle rt = mono_type_get_object_handle (domain, &pklass->byval_arg, error);
+	MonoReflectionTypeHandle rt = mono_type_get_object_handle (domain, m_class_get_byval_arg (pklass), error);
 	goto_if_nok (error, leave);
 	MONO_HANDLE_ARRAY_SETREF (arr, i, rt);
 leave:
@@ -3296,7 +3310,7 @@ ves_icall_InternalInvoke (MonoReflectionMethod *method, MonoObject *this_arg, Mo
 			}
 			m = mono_object_get_virtual_method (this_arg, m);
 			/* must pass the pointer to the value for valuetype methods */
-			if (m->klass->valuetype)
+			if (m_class_is_valuetype (m->klass))
 				obj = mono_object_unbox (this_arg);
 		} else if (strcmp (m->name, ".ctor") && !m->wrapper_type) {
 			mono_gc_wbarrier_generic_store (exc, (MonoObject*) mono_exception_from_name_msg (mono_defaults.corlib, "System.Reflection", "TargetException", "Non-static method requires a target."));
@@ -3320,7 +3334,7 @@ ves_icall_InternalInvoke (MonoReflectionMethod *method, MonoObject *this_arg, Mo
 		return NULL;
 	}
 
-	image = m->klass->image;
+	image = m_class_get_image (m->klass);
 	if (image->assembly->ref_only) {
 		mono_gc_wbarrier_generic_store (exc, (MonoObject*) mono_get_exception_invalid_operation ("It is illegal to invoke a method on a type loaded using the ReflectionOnly api."));
 		return NULL;
@@ -3331,7 +3345,7 @@ ves_icall_InternalInvoke (MonoReflectionMethod *method, MonoObject *this_arg, Mo
 		return NULL;
 	}
 	
-	if (m->klass->rank && !strcmp (m->name, ".ctor")) {
+	if (m_class_get_rank (m->klass) && !strcmp (m->name, ".ctor")) {
 		MonoArray *arr;
 		int i;
 		uintptr_t *lengths;
@@ -3342,7 +3356,7 @@ ves_icall_InternalInvoke (MonoReflectionMethod *method, MonoObject *this_arg, Mo
 		for (i = 0; i < pcount; ++i)
 			lengths [i] = *(int32_t*) ((char*)mono_array_get (params, gpointer, i) + sizeof (MonoObject));
 
-		if (m->klass->rank == 1 && sig->param_count == 2 && m->klass->element_class->rank) {
+		if (m_class_get_rank (m->klass) == 1 && sig->param_count == 2 && m_class_get_rank (m_class_get_element_class (m->klass))) {
 			/* This is a ctor for jagged arrays. MS creates an array of arrays. */
 			arr = mono_array_new_full_checked (mono_object_domain (params), m->klass, lengths, NULL, error);
 			if (!mono_error_ok (error)) {
@@ -3351,7 +3365,7 @@ ves_icall_InternalInvoke (MonoReflectionMethod *method, MonoObject *this_arg, Mo
 			}
 
 			for (i = 0; i < mono_array_length (arr); ++i) {
-				MonoArray *subarray = mono_array_new_full_checked (mono_object_domain (params), m->klass->element_class, &lengths [1], NULL, error);
+				MonoArray *subarray = mono_array_new_full_checked (mono_object_domain (params), m_class_get_element_class (m->klass), &lengths [1], NULL, error);
 				if (!mono_error_ok (error)) {
 					mono_error_set_pending_exception (error);
 					return NULL;
@@ -3361,7 +3375,7 @@ ves_icall_InternalInvoke (MonoReflectionMethod *method, MonoObject *this_arg, Mo
 			return (MonoObject*)arr;
 		}
 
-		if (m->klass->rank == pcount) {
+		if (m_class_get_rank (m->klass) == pcount) {
 			/* Only lengths provided. */
 			arr = mono_array_new_full_checked (mono_object_domain (params), m->klass, lengths, NULL, error);
 			if (!mono_error_ok (error)) {
@@ -3371,7 +3385,7 @@ ves_icall_InternalInvoke (MonoReflectionMethod *method, MonoObject *this_arg, Mo
 
 			return (MonoObject*)arr;
 		} else {
-			g_assert (pcount == (m->klass->rank * 2));
+			g_assert (pcount == (m_class_get_rank (m->klass) * 2));
 			/* The arguments are lower-bound-length pairs */
 			lower_bounds = (intptr_t *)g_alloca (sizeof (intptr_t) * pcount);
 
@@ -3422,7 +3436,7 @@ internal_execute_field_getter (MonoDomain *domain, MonoObject *this_arg, MonoArr
 			g_free (str);
 			MonoClass *field_klass =  mono_class_from_mono_type (field->type);
 			MonoObject *result;
-			if (field_klass->valuetype) {
+			if (m_class_is_valuetype (field_klass)) {
 				result = mono_value_box_checked (domain, field_klass, (char *)this_arg + field->offset, error);
 				return_if_nok (error);
 			} else 
@@ -3434,7 +3448,7 @@ internal_execute_field_getter (MonoDomain *domain, MonoObject *this_arg, MonoArr
 			mono_array_setref (out_args, 0, result);
 			return;
 		}
-		k = k->parent;
+		k = m_class_get_parent (k);
 	} while (k);
 
 	g_free (str);
@@ -3471,7 +3485,7 @@ internal_execute_field_setter (MonoDomain *domain, MonoObject *this_arg, MonoArr
 			MonoClass *field_klass =  mono_class_from_mono_type (field->type);
 			MonoObject *val = (MonoObject *)mono_array_get (params, gpointer, 2);
 
-			if (field_klass->valuetype) {
+			if (m_class_is_valuetype (field_klass)) {
 				size = mono_type_size (field->type, &align);
 				g_assert (size == mono_class_value_size (field_klass, NULL));
 				mono_gc_wbarrier_value_copy ((char *)this_arg + field->offset, (char*)val + sizeof (MonoObject), 1, field_klass);
@@ -3485,7 +3499,7 @@ internal_execute_field_setter (MonoDomain *domain, MonoObject *this_arg, MonoArr
 			return;
 		}
 				
-		k = k->parent;
+		k = m_class_get_parent (k);
 	} while (k);
 
 	g_free (str);
@@ -3529,7 +3543,7 @@ ves_icall_InternalExecute (MonoReflectionMethod *method, MonoObject *this_arg, M
 		g_assert (this_arg);
 
 	/* This can be called only on MBR objects, so no need to unbox for valuetypes. */
-	g_assert (!method->method->klass->valuetype);
+	g_assert (!m_class_is_valuetype (method->method->klass));
 	result = mono_runtime_invoke_array_checked (method->method, this_arg, params, error);
 	if (mono_error_set_pending_exception (error))
 		return NULL;
@@ -3641,7 +3655,7 @@ return_null:
 ICALL_EXPORT MonoBoolean
 ves_icall_System_Enum_InternalHasFlag (MonoObjectHandle a, MonoObjectHandle b, MonoError *error)
 {
-	int size = mono_class_value_size (MONO_HANDLE_GETVAL (a, vtable)->klass, NULL);
+	int size = mono_class_value_size (mono_handle_class (a), NULL);
 	guint64 a_val = 0, b_val = 0;
 
 	memcpy (&a_val, mono_handle_unbox_unsafe (a), size);
@@ -3658,11 +3672,10 @@ ves_icall_System_Enum_get_value (MonoObjectHandle ehandle, MonoError *error)
 	int size;
 
 	goto_if (MONO_HANDLE_IS_NULL (ehandle), return_null);
-	goto_if (!MONO_HANDLE_RAW (ehandle), return_null);
 
-	g_assert (MONO_HANDLE_GETVAL (ehandle, vtable)->klass->enumtype);
+	g_assert (m_class_is_enumtype (mono_handle_class (ehandle)));
 
-	enumc = mono_class_from_mono_type (mono_class_enum_basetype (MONO_HANDLE_GETVAL (ehandle, vtable)->klass));
+	enumc = mono_class_from_mono_type (mono_class_enum_basetype (mono_handle_class (ehandle)));
 
 	resultHandle = mono_object_new_handle (MONO_HANDLE_DOMAIN (ehandle), enumc, error);
 	goto_if_nok (error, return_null);
@@ -3687,7 +3700,7 @@ ves_icall_System_Enum_get_underlying_type (MonoReflectionTypeHandle type, MonoEr
 
 	etype = mono_class_enum_basetype (klass);
 	if (!etype) {
-		mono_set_pending_exception_handle (mono_exception_new_argument ("enumType", "Type provided must be an Enum.", error));
+		mono_error_set_argument (error, "enumType", "Type provided must be an Enum.");
 		goto return_null;
 	}
 
@@ -3830,7 +3843,7 @@ ves_icall_System_Enum_GetEnumValuesAndNames (MonoReflectionTypeHandle type, Mono
 	mono_class_init_checked (enumc, error);
 	return_val_if_nok (error, FALSE);
 
-	if (!enumc->enumtype) {
+	if (!m_class_is_enumtype (enumc)) {
 		mono_error_set_argument (error, "enumType", "Type provided must be an Enum.");
 		return TRUE;
 	}
@@ -3932,7 +3945,7 @@ handle_parent:
 
 		g_ptr_array_add (ptr_array, field);
 	}
-	if (!(bflags & BFLAGS_DeclaredOnly) && (klass = klass->parent))
+	if (!(bflags & BFLAGS_DeclaredOnly) && (klass = m_class_get_parent (klass)))
 		goto handle_parent;
 
 	return ptr_array;
@@ -3978,7 +3991,7 @@ mono_class_get_methods_by_name (MonoClass *klass, const char *name, guint32 bfla
 		compare_func = (ignore_case) ? mono_utf8_strcasecmp : strcmp;
 
 	/* An optimization for calls made from Delegate:CreateDelegate () */
-	if (klass->delegate && name && !strcmp (name, "Invoke") && (bflags == (BFLAGS_Public | BFLAGS_Static | BFLAGS_Instance))) {
+	if (m_class_is_delegate (klass) && name && !strcmp (name, "Invoke") && (bflags == (BFLAGS_Public | BFLAGS_Static | BFLAGS_Instance))) {
 		method = mono_get_delegate_invoke (klass);
 		g_assert (method);
 
@@ -3991,8 +4004,8 @@ mono_class_get_methods_by_name (MonoClass *klass, const char *name, guint32 bfla
 	if (mono_class_has_failure (klass))
 		goto loader_error;
 
-	if (is_generic_parameter (&klass->byval_arg))
-		nslots = mono_class_get_vtable_size (klass->parent);
+	if (is_generic_parameter (m_class_get_byval_arg (klass)))
+		nslots = mono_class_get_vtable_size (m_class_get_parent (klass));
 	else
 		nslots = MONO_CLASS_IS_INTERFACE (klass) ? mono_class_num_methods (klass) : mono_class_get_vtable_size (klass);
 	if (nslots >= sizeof (method_slots_default) * 8) {
@@ -4049,7 +4062,7 @@ handle_parent:
 		match = 0;
 		g_ptr_array_add (array, method);
 	}
-	if (!(bflags & BFLAGS_DeclaredOnly) && (klass = klass->parent))
+	if (!(bflags & BFLAGS_DeclaredOnly) && (klass = m_class_get_parent (klass)))
 		goto handle_parent;
 	if (method_slots != method_slots_default)
 		g_free (method_slots);
@@ -4272,7 +4285,7 @@ handle_parent:
 		
 		g_hash_table_insert (properties, prop, prop);
 	}
-	if (!(bflags & BFLAGS_DeclaredOnly) && (klass = klass->parent))
+	if (!(bflags & BFLAGS_DeclaredOnly) && (klass = m_class_get_parent (klass)))
 		goto handle_parent;
 
 	g_hash_table_destroy (properties);
@@ -4379,7 +4392,7 @@ handle_parent:
 
 		g_hash_table_insert (events, event, event);
 	}
-	if (!(bflags & BFLAGS_DeclaredOnly) && (klass = klass->parent))
+	if (!(bflags & BFLAGS_DeclaredOnly) && (klass = m_class_get_parent (klass)))
 		goto handle_parent;
 
 	g_hash_table_destroy (events);
@@ -4435,10 +4448,10 @@ ves_icall_RuntimeType_GetNestedTypes_native (MonoReflectionTypeHandle ref_type, 
 		if (!match)
 			continue;
 
-		if (str != NULL && strcmp (nested->name, str))
+		if (str != NULL && strcmp (m_class_get_name (nested), str))
 				continue;
 
-		g_ptr_array_add (res_array, &nested->byval_arg);
+		g_ptr_array_add (res_array, m_class_get_byval_arg (nested));
 	}
 
 	return res_array;
@@ -5209,8 +5222,9 @@ mono_method_get_equivalent_method (MonoMethod *method, MonoClass *klass)
 	if (mono_class_has_failure (method->klass))
 		return NULL;
 	int mcount = mono_class_get_method_count (method->klass);
+	MonoMethod **method_klass_methods = m_class_get_methods (method->klass);
 	for (i = 0; i < mcount; ++i) {
-		if (method->klass->methods [i] == method) {
+		if (method_klass_methods [i] == method) {
 			offset = i;
 			break;
 		}	
@@ -5219,7 +5233,7 @@ mono_method_get_equivalent_method (MonoMethod *method, MonoClass *klass)
 	if (mono_class_has_failure (klass))
 		return NULL;
 	g_assert (offset >= 0 && offset < mono_class_get_method_count (klass));
-	return klass->methods [offset];
+	return m_class_get_methods (klass) [offset];
 }
 
 ICALL_EXPORT MonoReflectionMethodHandle
@@ -5259,7 +5273,7 @@ ves_icall_System_Reflection_Assembly_GetExecutingAssembly (MonoError *error)
 	MonoMethod *dest = NULL;
 	mono_stack_walk_no_il (get_executing, &dest);
 	g_assert (dest);
-	return mono_assembly_get_object_handle (mono_domain_get (), dest->klass->image->assembly, error);
+	return mono_assembly_get_object_handle (mono_domain_get (), m_class_get_image (dest->klass)->assembly, error);
 }
 
 
@@ -5293,7 +5307,7 @@ ves_icall_System_Reflection_Assembly_GetCallingAssembly (MonoError *error)
 		mono_error_set_not_supported (error, "Stack walks are not supported on this platform.");
 		return MONO_HANDLE_CAST (MonoReflectionAssembly, NULL_HANDLE);
 	}
-	return mono_assembly_get_object_handle (mono_domain_get (), dest->klass->image->assembly, error);
+	return mono_assembly_get_object_handle (mono_domain_get (), m_class_get_image (dest->klass)->assembly, error);
 }
 
 ICALL_EXPORT MonoStringHandle
@@ -5489,7 +5503,7 @@ image_get_type (MonoDomain *domain, MonoImage *image, MonoTableInfo *tdef, int t
 	MonoClass *klass = mono_class_get_checked (image, table_idx | MONO_TOKEN_TYPE_DEF, &klass_error);
 
 	if (klass) {
-		MonoReflectionTypeHandle rt = mono_type_get_object_handle (domain, &klass->byval_arg, error);
+		MonoReflectionTypeHandle rt = mono_type_get_object_handle (domain, m_class_get_byval_arg (klass), error);
 		return_if_nok (error);
 
 		MONO_HANDLE_ARRAY_SETREF (res, count, rt);
@@ -5713,7 +5727,7 @@ ves_icall_System_Reflection_Module_GetGlobalType (MonoReflectionModuleHandle mod
 	klass = mono_class_get_checked (image, 1 | MONO_TOKEN_TYPE_DEF, error);
 	goto_if_nok (error, leave);
 
-	ret = mono_type_get_object_handle (domain, &klass->byval_arg, error);
+	ret = mono_type_get_object_handle (domain, m_class_get_byval_arg (klass), error);
 leave:
 	return ret;
 }
@@ -5885,7 +5899,7 @@ module_resolve_type_token (MonoImage *image, guint32 token, MonoArrayHandle type
 			ERROR_DECL_VALUE (inner_error);
 			klass = (MonoClass *)mono_lookup_dynamic_token_class (image, token, FALSE, NULL, NULL, &inner_error);
 			mono_error_cleanup (&inner_error);
-			result = klass ? &klass->byval_arg : NULL;
+			result = klass ? m_class_get_byval_arg (klass) : NULL;
 			goto leave;
 		}
 
@@ -5893,7 +5907,7 @@ module_resolve_type_token (MonoImage *image, guint32 token, MonoArrayHandle type
 		ERROR_DECL_VALUE (inner_error);
 		klass = (MonoClass *)mono_lookup_dynamic_token_class (image, token, FALSE, NULL, &context, &inner_error);
 		mono_error_cleanup (&inner_error);
-		result = klass ? &klass->byval_arg : NULL;
+		result = klass ? m_class_get_byval_arg (klass) : NULL;
 		goto leave;
 	}
 
@@ -5909,7 +5923,7 @@ module_resolve_type_token (MonoImage *image, guint32 token, MonoArrayHandle type
 	goto_if_nok (error, leave);
 
 	if (klass)
-		result = &klass->byval_arg;
+		result = m_class_get_byval_arg (klass);
 leave:
 	HANDLE_FUNCTION_RETURN_VAL (result);
 
@@ -6189,7 +6203,7 @@ check_for_invalid_type (MonoClass *klass, MonoError *error)
 
 	error_init (error);
 
-	if (klass->byval_arg.type != MONO_TYPE_TYPEDBYREF)
+	if (m_class_get_byval_arg (klass)->type != MONO_TYPE_TYPEDBYREF)
 		return;
 
 	name = mono_type_get_full_name (klass);
@@ -6219,7 +6233,7 @@ ves_icall_RuntimeType_make_array_type (MonoReflectionTypeHandle ref_type, int ra
 	}
 
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (ref_type);
-	return mono_type_get_object_handle (domain, &aklass->byval_arg, error);
+	return mono_type_get_object_handle (domain, m_class_get_byval_arg (aklass), error);
 }
 
 ICALL_EXPORT MonoReflectionTypeHandle
@@ -6238,7 +6252,7 @@ ves_icall_RuntimeType_make_byref_type (MonoReflectionTypeHandle ref_type, MonoEr
 		return MONO_HANDLE_CAST (MonoReflectionType, NULL_HANDLE);
 
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (ref_type);
-	return mono_type_get_object_handle (domain, &klass->this_arg, error);
+	return mono_type_get_object_handle (domain, m_class_get_this_arg (klass), error);
 }
 
 ICALL_EXPORT MonoReflectionTypeHandle
@@ -6258,7 +6272,7 @@ ves_icall_RuntimeType_MakePointerType (MonoReflectionTypeHandle ref_type, MonoEr
 
 	MonoClass *pklass = mono_class_create_ptr (type);
 
-	return mono_type_get_object_handle (domain, &pklass->byval_arg, error);
+	return mono_type_get_object_handle (domain, m_class_get_byval_arg (pklass), error);
 }
 
 ICALL_EXPORT MonoObjectHandle
@@ -6274,7 +6288,7 @@ ves_icall_System_Delegate_CreateDelegate_internal (MonoReflectionTypeHandle ref_
 	mono_class_init_checked (delegate_class, error);
 	return_val_if_nok (error, NULL_HANDLE);
 
-	if (!(delegate_class->parent == mono_defaults.multicastdelegate_class)) {
+	if (!(m_class_get_parent (delegate_class) == mono_defaults.multicastdelegate_class)) {
 		/* FIXME improve this exception message */
 		mono_error_set_execution_engine (error, "file %s: line %d (%s): assertion failed: (%s)", __FILE__, __LINE__,
 						 __func__,
@@ -6364,11 +6378,12 @@ mono_array_get_byte_length (MonoArray *array)
 		length = array->max_length;
 	else {
 		length = 1;
-		for (i = 0; i < klass->rank; ++ i)
+		int klass_rank = m_class_get_rank (klass);
+		for (i = 0; i < klass_rank; ++ i)
 			length *= array->bounds [i].length;
 	}
 
-	switch (klass->element_class->byval_arg.type) {
+	switch (m_class_get_byval_arg (m_class_get_element_class (klass))->type) {
 	case MONO_TYPE_I1:
 	case MONO_TYPE_U1:
 	case MONO_TYPE_BOOLEAN:
@@ -6492,7 +6507,7 @@ ves_icall_Remoting_RealProxy_InternalGetProxyType (MonoTransparentProxy *tp)
 	ERROR_DECL (error);
 	g_assert (tp != NULL && mono_object_class (tp) == mono_defaults.transparent_proxy_class);
 	g_assert (tp->remote_class != NULL && tp->remote_class->proxy_class != NULL);
-	MonoReflectionType *ret = mono_type_get_object_checked (mono_object_domain (tp), &tp->remote_class->proxy_class->byval_arg, error);
+	MonoReflectionType *ret = mono_type_get_object_checked (mono_object_domain (tp), m_class_get_byval_arg (tp->remote_class->proxy_class), error);
 	mono_error_set_pending_exception (error);
 
 	return ret;
@@ -7042,7 +7057,7 @@ ves_icall_Remoting_RemotingServices_GetVirtualMethod (
 	}
 
 	mono_class_setup_vtable (klass);
-	MonoMethod **vtable = klass->vtable;
+	MonoMethod **vtable = m_class_get_vtable (klass);
 
 	MonoMethod *res = NULL;
 	if (mono_class_is_interface (method->klass)) {
@@ -7104,9 +7119,9 @@ ves_icall_System_Runtime_Activation_ActivationServices_AllocateUninitializedClas
 		return NULL_HANDLE;
 	}
 
-	if (klass->rank >= 1) {
-		g_assert (klass->rank == 1);
-		return MONO_HANDLE_CAST (MonoObject, mono_array_new_handle (domain, klass->element_class, 0, error));
+	if (m_class_get_rank (klass) >= 1) {
+		g_assert (m_class_get_rank (klass) == 1);
+		return MONO_HANDLE_CAST (MonoObject, mono_array_new_handle (domain, m_class_get_element_class (klass), 0, error));
 	} else {
 		MonoVTable *vtable = mono_class_vtable_checked (domain, klass, error);
 		return_val_if_nok (error, NULL_HANDLE);
@@ -7621,7 +7636,7 @@ add_modifier_to_array (MonoDomain *domain, MonoImage *image, MonoCustomMod *modi
 	MonoClass *klass = mono_class_get_checked (image, modifier->token, error);
 	goto_if_nok (error, leave);
 
-	MonoReflectionTypeHandle rt = mono_type_get_object_handle (domain, &klass->byval_arg, error);
+	MonoReflectionTypeHandle rt = mono_type_get_object_handle (domain, m_class_get_byval_arg (klass), error);
 	goto_if_nok (error, leave);
 
 	MONO_HANDLE_ARRAY_SETREF (dest, dest_idx, rt);
@@ -7679,7 +7694,7 @@ ves_icall_ParameterInfo_GetTypeModifiers (MonoReflectionParameterHandle param, M
 
 	if (mono_class_is_reflection_method_or_constructor (member_class)) {
 		method = MONO_HANDLE_GETVAL (MONO_HANDLE_CAST (MonoReflectionMethod, member), method);
-	} else if (member_class->image == mono_defaults.corlib && !strcmp ("MonoProperty", member_class->name)) {
+	} else if (m_class_get_image (member_class) == mono_defaults.corlib && !strcmp ("MonoProperty", m_class_get_name (member_class))) {
 		MonoProperty *prop = MONO_HANDLE_GETVAL (MONO_HANDLE_CAST (MonoReflectionProperty, member), property);
 		if (!(method = prop->get))
 			method = prop->set;
@@ -7691,7 +7706,7 @@ ves_icall_ParameterInfo_GetTypeModifiers (MonoReflectionParameterHandle param, M
 		return MONO_HANDLE_CAST (MonoArray, NULL_HANDLE);
 	}
 
-	image = method->klass->image;
+	image = m_class_get_image (method->klass);
 	pos = MONO_HANDLE_GETVAL (param, PositionImpl);
 	sig = mono_method_signature (method);
 	if (pos == -1)
@@ -7723,7 +7738,7 @@ ves_icall_MonoPropertyInfo_GetTypeModifiers (MonoReflectionPropertyHandle proper
 	MonoProperty *prop = MONO_HANDLE_GETVAL (property, property);
 	MonoClass *klass = MONO_HANDLE_GETVAL (property, klass);
 	MonoType *type = get_property_type (prop);
-	MonoImage *image = klass->image;
+	MonoImage *image = m_class_get_image (klass);
 
 	if (!type)
 		return MONO_HANDLE_CAST (MonoArray, NULL_HANDLE);
@@ -7744,7 +7759,7 @@ mono_type_from_blob_type (MonoType *type, MonoTypeEnum blob_type, MonoType *real
 	type->data.klass = NULL;
 	if (blob_type == MONO_TYPE_CLASS)
 		type->data.klass = mono_defaults.object_class;
-	else if (real_type->type == MONO_TYPE_VALUETYPE && real_type->data.klass->enumtype) {
+	else if (real_type->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (real_type->data.klass)) {
 		/* For enums, we need to use the base type */
 		type->type = MONO_TYPE_VALUETYPE;
 		type->data.klass = mono_class_from_mono_type (real_type);
@@ -8040,15 +8055,15 @@ static int
 concat_class_name (char *buf, int bufsize, MonoClass *klass)
 {
 	int nspacelen, cnamelen;
-	nspacelen = strlen (klass->name_space);
-	cnamelen = strlen (klass->name);
+	nspacelen = strlen (m_class_get_name_space (klass));
+	cnamelen = strlen (m_class_get_name (klass));
 	if (nspacelen + cnamelen + 2 > bufsize)
 		return 0;
 	if (nspacelen) {
-		memcpy (buf, klass->name_space, nspacelen);
+		memcpy (buf, m_class_get_name_space (klass), nspacelen);
 		buf [nspacelen ++] = '.';
 	}
-	memcpy (buf + nspacelen, klass->name, cnamelen);
+	memcpy (buf + nspacelen, m_class_get_name (klass), cnamelen);
 	buf [nspacelen + cnamelen] = 0;
 	return nspacelen + cnamelen;
 }
@@ -8087,8 +8102,8 @@ mono_lookup_internal_call_full (MonoMethod *method, mono_bool *uses_handles)
 	if (method->is_inflated)
 		method = ((MonoMethodInflated *) method)->declaring;
 
-	if (method->klass->nested_in) {
-		int pos = concat_class_name (mname, sizeof (mname)-2, method->klass->nested_in);
+	if (m_class_get_nested_in (method->klass)) {
+		int pos = concat_class_name (mname, sizeof (mname)-2, m_class_get_nested_in (method->klass));
 		if (!pos)
 			return NULL;
 
@@ -8165,7 +8180,7 @@ mono_lookup_internal_call_full (MonoMethod *method, mono_bool *uses_handles)
 
 		g_warning ("cant resolve internal call to \"%s\" (tested without signature also)", mname);
 		g_print ("\nYour mono runtime and class libraries are out of sync.\n");
-		g_print ("The out of sync library is: %s\n", method->klass->image->name);
+		g_print ("The out of sync library is: %s\n", m_class_get_image (method->klass)->name);
 		g_print ("\nWhen you update one from git you need to update, compile and install\nthe other too.\n");
 		g_print ("Do not report this as a bug unless you're sure you have updated correctly:\nyou probably have a broken mono install.\n");
 		g_print ("If you see other errors or faults after this message they are probably related\n");
@@ -8249,7 +8264,7 @@ type_from_typename (char *type_name)
 		g_error ("%s", type_name);
 		g_assert_not_reached ();
 	}
-	return &klass->byval_arg;
+	return m_class_get_byval_arg (klass);
 }
 
 /**

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -376,8 +376,9 @@ find_method_in_class (MonoClass *klass, const char *name, const char *qname, con
 	/* Search directly in the metadata to avoid calling setup_methods () */
 	error_init (error);
 
+	MonoImage *klass_image = m_class_get_image (klass);
 	/* FIXME: !mono_class_is_ginst (from_class) condition causes test failures. */
-	if (klass->type_token && !image_is_dynamic (klass->image) && !klass->methods && !klass->rank && klass == from_class && !mono_class_is_ginst (from_class)) {
+	if (m_class_get_type_token (klass) && !image_is_dynamic (klass_image) && !m_class_get_methods (klass) && !m_class_get_rank (klass) && klass == from_class && !mono_class_is_ginst (from_class)) {
 		int first_idx = mono_class_get_first_method_idx (klass);
 		int mcount = mono_class_get_method_count (klass);
 		for (i = 0; i < mcount; ++i) {
@@ -386,16 +387,16 @@ find_method_in_class (MonoClass *klass, const char *name, const char *qname, con
 			const char *m_name;
 			MonoMethodSignature *other_sig;
 
-			mono_metadata_decode_table_row (klass->image, MONO_TABLE_METHOD, first_idx + i, cols, MONO_METHOD_SIZE);
+			mono_metadata_decode_table_row (klass_image, MONO_TABLE_METHOD, first_idx + i, cols, MONO_METHOD_SIZE);
 
-			m_name = mono_metadata_string_heap (klass->image, cols [MONO_METHOD_NAME]);
+			m_name = mono_metadata_string_heap (klass_image, cols [MONO_METHOD_NAME]);
 
 			if (!((fqname && !strcmp (m_name, fqname)) ||
 				  (qname && !strcmp (m_name, qname)) ||
 				  (name && !strcmp (m_name, name))))
 				continue;
 
-			method = mono_get_method_checked (klass->image, MONO_TOKEN_METHOD_DEF | (first_idx + i + 1), klass, NULL, error);
+			method = mono_get_method_checked (klass_image, MONO_TOKEN_METHOD_DEF | (first_idx + i + 1), klass, NULL, error);
 			if (!mono_error_ok (error)) //bail out if we hit a loader error
 				return NULL;
 			if (method) {
@@ -414,14 +415,15 @@ find_method_in_class (MonoClass *klass, const char *name, const char *qname, con
 	See mono/tests/generic-type-load-exception.2.il
 	FIXME we should better report this error to the caller
 	 */
-	if (!klass->methods || mono_class_has_failure (klass)) {
+	if (!m_class_get_methods (klass) || mono_class_has_failure (klass)) {
 		mono_error_set_type_load_class (error, klass, "Could not find method due to a type load error"); //FIXME get the error from the class 
 
 		return NULL;
 	}
 	int mcount = mono_class_get_method_count (klass);
+	MonoMethod **klass_methods = m_class_get_methods (klass);
 	for (i = 0; i < mcount; ++i) {
-		MonoMethod *m = klass->methods [i];
+		MonoMethod *m = klass_methods [i];
 		MonoMethodSignature *msig;
 
 		/* We must cope with failing to load some of the types. */
@@ -433,7 +435,7 @@ find_method_in_class (MonoClass *klass, const char *name, const char *qname, con
 		      (name && !strcmp (m->name, name))))
 			continue;
 		msig = mono_method_signature_checked (m, error);
-		if (!mono_error_ok (error)) //bail out if we hit a loader error
+		if (!mono_error_ok (error)) //bail out if we hit a loader error 
 			return NULL;
 
 		if (!msig)
@@ -466,11 +468,12 @@ find_method (MonoClass *in_class, MonoClass *ic, const char* name, MonoMethodSig
 	is_interface = MONO_CLASS_IS_INTERFACE (in_class);
 
 	if (ic) {
-		class_name = mono_type_get_name_full (&ic->byval_arg, MONO_TYPE_NAME_FORMAT_IL);
+		class_name = mono_type_get_name_full (m_class_get_byval_arg (ic), MONO_TYPE_NAME_FORMAT_IL);
 
-		qname = g_strconcat (class_name, ".", name, NULL); 
-		if (ic->name_space && ic->name_space [0])
-			fqname = g_strconcat (ic->name_space, ".", class_name, ".", name, NULL);
+		qname = g_strconcat (class_name, ".", name, NULL);
+		const char *ic_name_space = m_class_get_name_space (ic);
+		if (ic_name_space && ic_name_space [0])
+			fqname = g_strconcat (ic_name_space, ".", class_name, ".", name, NULL);
 		else
 			fqname = NULL;
 	} else
@@ -489,21 +492,25 @@ find_method (MonoClass *in_class, MonoClass *ic, const char* name, MonoMethodSig
 		 * This happens when we fail to lazily load the interfaces of one of the types.
 		 * On such case we can't just bail out since user code depends on us trying harder.
 		 */
-		if (from_class->interface_offsets_count != in_class->interface_offsets_count) {
-			in_class = in_class->parent;
-			from_class = from_class->parent;
+		if (m_class_get_interface_offsets_count (from_class) != m_class_get_interface_offsets_count (in_class)) {
+			in_class = m_class_get_parent (in_class);
+			from_class = m_class_get_parent (from_class);
 			continue;
 		}
 
-		for (i = 0; i < in_class->interface_offsets_count; i++) {
-			MonoClass *in_ic = in_class->interfaces_packed [i];
-			MonoClass *from_ic = from_class->interfaces_packed [i];
+		int in_class_interface_offsets_count = m_class_get_interface_offsets_count (in_class);
+		MonoClass **in_class_interfaces_packed = m_class_get_interfaces_packed (in_class);
+		MonoClass **from_class_interfaces_packed = m_class_get_interfaces_packed (from_class);
+		for (i = 0; i < in_class_interface_offsets_count; i++) {
+			MonoClass *in_ic = in_class_interfaces_packed [i];
+			MonoClass *from_ic = from_class_interfaces_packed [i];
 			char *ic_qname, *ic_fqname, *ic_class_name;
 			
-			ic_class_name = mono_type_get_name_full (&in_ic->byval_arg, MONO_TYPE_NAME_FORMAT_IL);
+			ic_class_name = mono_type_get_name_full (m_class_get_byval_arg (in_ic), MONO_TYPE_NAME_FORMAT_IL);
 			ic_qname = g_strconcat (ic_class_name, ".", name, NULL); 
-			if (in_ic->name_space && in_ic->name_space [0])
-				ic_fqname = g_strconcat (in_ic->name_space, ".", ic_class_name, ".", name, NULL);
+			const char *in_ic_name_space = m_class_get_name_space (in_ic);
+			if (in_ic_name_space && in_ic_name_space [0])
+				ic_fqname = g_strconcat (in_ic_name_space, ".", ic_class_name, ".", name, NULL);
 			else
 				ic_fqname = NULL;
 
@@ -515,8 +522,8 @@ find_method (MonoClass *in_class, MonoClass *ic, const char* name, MonoMethodSig
 				goto out;
 		}
 
-		in_class = in_class->parent;
-		from_class = from_class->parent;
+		in_class = m_class_get_parent (in_class);
+		from_class = m_class_get_parent (from_class);
 	}
 	g_assert (!in_class == !from_class);
 
@@ -766,8 +773,9 @@ mono_method_search_in_array_class (MonoClass *klass, const char *name, MonoMetho
 	mono_class_setup_methods (klass);
 	g_assert (!mono_class_has_failure (klass)); /*FIXME this should not fail, right?*/
 	int mcount = mono_class_get_method_count (klass);
+	MonoMethod **klass_methods = m_class_get_methods (klass);
 	for (i = 0; i < mcount; ++i) {
-		MonoMethod *method = klass->methods [i];
+		MonoMethod *method = klass_methods [i];
 		if (strcmp (method->name, name) == 0 && sig->param_count == method->signature->param_count)
 			return method;
 	}
@@ -866,7 +874,7 @@ method_from_memberref (MonoImage *image, guint32 idx, MonoGenericContext *typesp
 	case MONO_MEMBERREF_PARENT_TYPESPEC: {
 		MonoType *type;
 
-		type = &klass->byval_arg;
+		type = m_class_get_byval_arg (klass);
 
 		if (type->type != MONO_TYPE_ARRAY && type->type != MONO_TYPE_SZARRAY) {
 			MonoClass *in_class = mono_class_is_ginst (klass) ? mono_class_get_generic_class (klass)->container_class : klass;
@@ -1172,7 +1180,7 @@ is_absolute_path (const char *path)
 gpointer
 mono_lookup_pinvoke_call (MonoMethod *method, const char **exc_class, const char **exc_arg)
 {
-	MonoImage *image = method->klass->image;
+	MonoImage *image = m_class_get_image (method->klass);
 	MonoMethodPInvoke *piinfo = (MonoMethodPInvoke *)method;
 	MonoTableInfo *tables = image->tables;
 	MonoTableInfo *im = &tables [MONO_TABLE_IMPLMAP];
@@ -1199,10 +1207,10 @@ mono_lookup_pinvoke_call (MonoMethod *method, const char **exc_class, const char
 	if (piinfo->addr)
 		return piinfo->addr;
 
-	if (image_is_dynamic (method->klass->image)) {
+	if (image_is_dynamic (m_class_get_image (method->klass))) {
 		MonoReflectionMethodAux *method_aux = 
 			(MonoReflectionMethodAux *)g_hash_table_lookup (
-				((MonoDynamicImage*)method->klass->image)->method_aux_hash, method);
+				((MonoDynamicImage*)m_class_get_image (method->klass))->method_aux_hash, method);
 		if (!method_aux)
 			return NULL;
 
@@ -1967,7 +1975,7 @@ mono_free_method  (MonoMethod *method)
 
 		mono_marshal_free_dynamic_wrappers (method);
 
-		mono_image_property_remove (method->klass->image, method);
+		mono_image_property_remove (m_class_get_image (method->klass), method);
 
 		g_free ((char*)method->name);
 		if (mw->header) {
@@ -2012,15 +2020,16 @@ mono_method_get_param_names (MonoMethod *method, const char **names)
 		names [i] = "";
 
 	klass = method->klass;
-	if (klass->rank)
+	if (m_class_get_rank (klass))
 		return;
 
 	mono_class_init (klass);
 
-	if (image_is_dynamic (klass->image)) {
+	MonoImage *klass_image = m_class_get_image (klass);
+	if (image_is_dynamic (klass_image)) {
 		MonoReflectionMethodAux *method_aux = 
 			(MonoReflectionMethodAux *)g_hash_table_lookup (
-				((MonoDynamicImage*)method->klass->image)->method_aux_hash, method);
+				((MonoDynamicImage*)m_class_get_image (method->klass))->method_aux_hash, method);
 		if (method_aux && method_aux->param_names) {
 			for (i = 0; i < mono_method_signature (method)->param_count; ++i)
 				if (method_aux->param_names [i + 1])
@@ -2032,10 +2041,10 @@ mono_method_get_param_names (MonoMethod *method, const char **names)
 	if (method->wrapper_type) {
 		char **pnames = NULL;
 
-		mono_image_lock (klass->image);
-		if (klass->image->wrapper_param_names)
-			pnames = (char **)g_hash_table_lookup (klass->image->wrapper_param_names, method);
-		mono_image_unlock (klass->image);
+		mono_image_lock (klass_image);
+		if (klass_image->wrapper_param_names)
+			pnames = (char **)g_hash_table_lookup (klass_image->wrapper_param_names, method);
+		mono_image_unlock (klass_image);
 
 		if (pnames) {
 			for (i = 0; i < signature->param_count; ++i)
@@ -2044,8 +2053,8 @@ mono_method_get_param_names (MonoMethod *method, const char **names)
 		return;
 	}
 
-	methodt = &klass->image->tables [MONO_TABLE_METHOD];
-	paramt = &klass->image->tables [MONO_TABLE_PARAM];
+	methodt = &klass_image->tables [MONO_TABLE_METHOD];
+	paramt = &klass_image->tables [MONO_TABLE_PARAM];
 	idx = mono_method_get_index (method);
 	if (idx > 0) {
 		guint32 cols [MONO_PARAM_SIZE];
@@ -2060,7 +2069,7 @@ mono_method_get_param_names (MonoMethod *method, const char **names)
 		for (i = param_index; i < lastp; ++i) {
 			mono_metadata_decode_row (paramt, i -1, cols, MONO_PARAM_SIZE);
 			if (cols [MONO_PARAM_SEQUENCE] && cols [MONO_PARAM_SEQUENCE] <= signature->param_count) /* skip return param spec and bounds check*/
-				names [cols [MONO_PARAM_SEQUENCE] - 1] = mono_metadata_string_heap (klass->image, cols [MONO_PARAM_NAME]);
+				names [cols [MONO_PARAM_SEQUENCE] - 1] = mono_metadata_string_heap (klass_image, cols [MONO_PARAM_NAME]);
 		}
 	}
 }
@@ -2077,10 +2086,10 @@ mono_method_get_param_token (MonoMethod *method, int index)
 
 	mono_class_init (klass);
 
-	if (image_is_dynamic (klass->image))
-		g_assert_not_reached ();
+	MonoImage *klass_image = m_class_get_image (klass);
+	g_assert (!image_is_dynamic (klass_image));
 
-	methodt = &klass->image->tables [MONO_TABLE_METHOD];
+	methodt = &klass_image->tables [MONO_TABLE_METHOD];
 	idx = mono_method_get_index (method);
 	if (idx > 0) {
 		guint param_index = mono_metadata_decode_row_col (methodt, idx - 1, MONO_METHOD_PARAMLIST);
@@ -2114,10 +2123,10 @@ mono_method_get_marshal_info (MonoMethod *method, MonoMarshalSpec **mspecs)
 	for (i = 0; i < signature->param_count + 1; ++i)
 		mspecs [i] = NULL;
 
-	if (image_is_dynamic (method->klass->image)) {
+	if (image_is_dynamic (m_class_get_image (method->klass))) {
 		MonoReflectionMethodAux *method_aux = 
 			(MonoReflectionMethodAux *)g_hash_table_lookup (
-				((MonoDynamicImage*)method->klass->image)->method_aux_hash, method);
+				((MonoDynamicImage*)m_class_get_image (method->klass))->method_aux_hash, method);
 		if (method_aux && method_aux->param_marshall) {
 			MonoMarshalSpec **dyn_specs = method_aux->param_marshall;
 			for (i = 0; i < signature->param_count + 1; ++i)
@@ -2133,8 +2142,9 @@ mono_method_get_marshal_info (MonoMethod *method, MonoMarshalSpec **mspecs)
 
 	mono_class_init (klass);
 
-	methodt = &klass->image->tables [MONO_TABLE_METHOD];
-	paramt = &klass->image->tables [MONO_TABLE_PARAM];
+	MonoImage *klass_image = m_class_get_image (klass);
+	methodt = &klass_image->tables [MONO_TABLE_METHOD];
+	paramt = &klass_image->tables [MONO_TABLE_PARAM];
 	idx = mono_method_get_index (method);
 	if (idx > 0) {
 		guint32 cols [MONO_PARAM_SIZE];
@@ -2150,9 +2160,9 @@ mono_method_get_marshal_info (MonoMethod *method, MonoMarshalSpec **mspecs)
 
 			if (cols [MONO_PARAM_FLAGS] & PARAM_ATTRIBUTE_HAS_FIELD_MARSHAL && cols [MONO_PARAM_SEQUENCE] <= signature->param_count) {
 				const char *tp;
-				tp = mono_metadata_get_marshal_info (klass->image, i - 1, FALSE);
+				tp = mono_metadata_get_marshal_info (klass_image, i - 1, FALSE);
 				g_assert (tp);
-				mspecs [cols [MONO_PARAM_SEQUENCE]]= mono_metadata_parse_marshal_spec (klass->image, tp);
+				mspecs [cols [MONO_PARAM_SEQUENCE]]= mono_metadata_parse_marshal_spec (klass_image, tp);
 			}
 		}
 
@@ -2172,10 +2182,10 @@ mono_method_has_marshal_info (MonoMethod *method)
 	MonoTableInfo *paramt;
 	guint32 idx;
 
-	if (image_is_dynamic (method->klass->image)) {
+	if (image_is_dynamic (m_class_get_image (method->klass))) {
 		MonoReflectionMethodAux *method_aux = 
 			(MonoReflectionMethodAux *)g_hash_table_lookup (
-				((MonoDynamicImage*)method->klass->image)->method_aux_hash, method);
+				((MonoDynamicImage*)m_class_get_image (method->klass))->method_aux_hash, method);
 		MonoMarshalSpec **dyn_specs = method_aux->param_marshall;
 		if (dyn_specs) {
 			for (i = 0; i < mono_method_signature (method)->param_count + 1; ++i)
@@ -2187,8 +2197,8 @@ mono_method_has_marshal_info (MonoMethod *method)
 
 	mono_class_init (klass);
 
-	methodt = &klass->image->tables [MONO_TABLE_METHOD];
-	paramt = &klass->image->tables [MONO_TABLE_PARAM];
+	methodt = &m_class_get_image (klass)->tables [MONO_TABLE_METHOD];
+	paramt = &m_class_get_image (klass)->tables [MONO_TABLE_PARAM];
 	idx = mono_method_get_index (method);
 	if (idx > 0) {
 		guint32 cols [MONO_PARAM_SIZE];
@@ -2432,13 +2442,13 @@ mono_method_signature_checked (MonoMethod *m, MonoError *error)
 	if (m->signature)
 		return m->signature;
 
-	img = m->klass->image;
+	img = m_class_get_image (m->klass);
 
 	if (m->is_inflated) {
 		MonoMethodInflated *imethod = (MonoMethodInflated *) m;
 		/* the lock is recursive */
 		signature = mono_method_signature (imethod->declaring);
-		signature = inflate_generic_signature_checked (imethod->declaring->klass->image, signature, mono_method_get_context (m), error);
+		signature = inflate_generic_signature_checked (m_class_get_image (imethod->declaring->klass), signature, mono_method_get_context (m), error);
 		if (!mono_error_ok (error))
 			return NULL;
 
@@ -2637,7 +2647,7 @@ mono_method_get_header_internal (MonoMethod *method, MonoError *error)
 	MonoGenericContainer *container;
 
 	error_init (error);
-	img = method->klass->image;
+	img = m_class_get_image (method->klass);
 
 	// FIXME: for internal callers maybe it makes sense to do this check at the call site, not
 	// here?
@@ -2739,7 +2749,7 @@ mono_method_get_index (MonoMethod *method)
 	MonoClass *klass = method->klass;
 	int i;
 
-	if (klass->rank)
+	if (m_class_get_rank (klass))
 		/* constructed array methods are not in the MethodDef table */
 		return 0;
 
@@ -2751,10 +2761,11 @@ mono_method_get_index (MonoMethod *method)
 		return 0;
 	int first_idx = mono_class_get_first_method_idx (klass);
 	int mcount = mono_class_get_method_count (klass);
+	MonoMethod **klass_methods = m_class_get_methods (klass);
 	for (i = 0; i < mcount; ++i) {
-		if (method == klass->methods [i]) {
-			if (klass->image->uncompressed_metadata)
-				return mono_metadata_translate_token_index (klass->image, MONO_TABLE_METHOD, first_idx + i + 1);
+		if (method == klass_methods [i]) {
+			if (m_class_get_image (klass)->uncompressed_metadata)
+				return mono_metadata_translate_token_index (m_class_get_image (klass), MONO_TABLE_METHOD, first_idx + i + 1);
 			else
 				return first_idx + i + 1;
 		}

--- a/mono/metadata/metadata-cross-helpers.c
+++ b/mono/metadata/metadata-cross-helpers.c
@@ -15,6 +15,13 @@
 #ifdef HAVE_SGEN_GC
 #include <mono/sgen/sgen-gc.h>
 #endif
+#ifdef MONO_CLASS_DEF_PRIVATE
+/* Rationale: MonoClass field offsets are computed here.  Need to see the definition.
+ */
+#define REALLY_INCLUDE_CLASS_DEF 1
+#include <mono/metadata/class-private-definition.h>
+#undef REALLY_INCLUDE_CLASS_DEF
+#endif
 
 static int
 dump_arch (void)

--- a/mono/metadata/method-builder.c
+++ b/mono/metadata/method-builder.c
@@ -145,7 +145,7 @@ mono_mb_create_method (MonoMethodBuilder *mb, MonoMethodSignature *signature, in
 
 	g_assert (mb != NULL);
 
-	image = mb->method->klass->image;
+	image = m_class_get_image (mb->method->klass);
 
 #ifdef ENABLE_ILGEN
 	if (mb->dynamic) {

--- a/mono/metadata/mono-debug.c
+++ b/mono/metadata/mono-debug.c
@@ -994,7 +994,7 @@ mono_debug_print_stack_frame (MonoMethod *method, guint32 native_offset, MonoDom
 		if (offset < 0)
 			res = g_strdup_printf ("at %s <0x%05x>", fname, native_offset);
 		else {
-			char *mvid = mono_guid_to_string_minimal ((uint8_t*)method->klass->image->heap_guid.data);
+			char *mvid = mono_guid_to_string_minimal ((uint8_t*)m_class_get_image (method->klass)->heap_guid.data);
 			char *aotid = mono_runtime_get_aotid ();
 			if (aotid)
 				res = g_strdup_printf ("at %s [0x%05x] in <%s#%s>:0" , fname, offset, mvid, aotid);

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -284,7 +284,7 @@ mono_mb_emit_contextbound_check (MonoMethodBuilder *mb, int branch_code)
 	static guint8 mask;
 
 	if (offset < 0)
-		mono_marshal_find_bitfield_offset (MonoClass, contextbound, &offset, &mask);
+		mono_class_contextbound_bit_offset (&offset, &mask);
 
 	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoTransparentProxy, remote_class));
 	mono_mb_emit_byte (mb, CEE_LDIND_REF);
@@ -397,7 +397,7 @@ mono_remoting_wrapper (MonoMethod *method, gpointer *params)
 
 		for (i=0; i<count; i++) {
 			MonoClass *klass = mono_class_from_mono_type (sig->params [i]);
-			if (klass->valuetype) {
+			if (m_class_is_valuetype (klass)) {
 				if (sig->params [i]->byref) {
 					mparams[i] = *((gpointer *)params [i]);
 				} else {
@@ -413,7 +413,7 @@ mono_remoting_wrapper (MonoMethod *method, gpointer *params)
 			}
 		}
 
-		res = mono_runtime_invoke_checked (method, method->klass->valuetype? mono_object_unbox ((MonoObject*)this_obj): this_obj, mparams, error);
+		res = mono_runtime_invoke_checked (method, m_class_is_valuetype (method->klass)? mono_object_unbox ((MonoObject*)this_obj): this_obj, mparams, error);
 		goto_if_nok (error, fail);
 
 		return res;
@@ -455,8 +455,8 @@ mono_remoting_update_exception (MonoException *exc)
 	/* Serialization error can only happen when still in the target appdomain */
 	if (!(mono_class_get_flags (klass) & TYPE_ATTRIBUTE_SERIALIZABLE)) {
 		MonoException *ret;
-		char *aname = mono_stringify_assembly_name (&klass->image->assembly->aname);
-		char *message = g_strdup_printf ("Type '%s' in Assembly '%s' is not marked as serializable", klass->name, aname);
+		char *aname = mono_stringify_assembly_name (&m_class_get_image (klass)->assembly->aname);
+		char *message = g_strdup_printf ("Type '%s' in Assembly '%s' is not marked as serializable", m_class_get_name (klass), aname);
 		ret =  mono_get_exception_serialization (message);
 		g_free (aname);
 		g_free (message);
@@ -561,10 +561,10 @@ mono_marshal_xdomain_copy_out_value (MonoObject *src, MonoObject *dst)
 	
 	g_assert (mono_object_class (src) == mono_object_class (dst));
 
-	switch (mono_object_class (src)->byval_arg.type) {
+	switch (m_class_get_byval_arg (mono_object_class (src))->type) {
 	case MONO_TYPE_ARRAY:
 	case MONO_TYPE_SZARRAY: {
-		int mt = mono_get_xdomain_marshal_type (&(mono_object_class (src)->element_class->byval_arg));
+		int mt = mono_get_xdomain_marshal_type (m_class_get_byval_arg (m_class_get_element_class (mono_object_class (src))));
 		if (mt == MONO_MARSHAL_SERIALIZE) return;
 		if (mt == MONO_MARSHAL_COPY) {
 			int i, len = mono_array_length ((MonoArray *)dst);
@@ -713,9 +713,9 @@ mono_marshal_get_xappdomain_dispatch (MonoMethod *method, int *marshal_types, in
 
 	j = 0;
 	csig = mono_metadata_signature_alloc (mono_defaults.corlib, 3 + sig->param_count - complex_count);
-	csig->params [j++] = &mono_defaults.object_class->byval_arg;
-	csig->params [j++] = &byte_array_class->this_arg;
-	csig->params [j++] = &byte_array_class->this_arg;
+	csig->params [j++] = m_class_get_byval_arg (mono_defaults.object_class);
+	csig->params [j++] = m_class_get_this_arg (byte_array_class);
+	csig->params [j++] = m_class_get_this_arg (byte_array_class);
 	for (i = 0; i < sig->param_count; i++) {
 		if (marshal_types [i] != MONO_MARSHAL_SERIALIZE)
 			csig->params [j++] = sig->params [i];
@@ -723,7 +723,7 @@ mono_marshal_get_xappdomain_dispatch (MonoMethod *method, int *marshal_types, in
 	if (copy_return)
 		csig->ret = sig->ret;
 	else
-		csig->ret = &mono_defaults.void_class->byval_arg;
+		csig->ret = m_class_get_byval_arg (mono_defaults.void_class);
 	csig->pinvoke = 1;
 	csig->hasthis = FALSE;
 
@@ -733,9 +733,9 @@ mono_marshal_get_xappdomain_dispatch (MonoMethod *method, int *marshal_types, in
 #ifndef DISABLE_JIT
 	/* Locals */
 
-	loc_serialized_exc = mono_mb_add_local (mb, &byte_array_class->byval_arg);
+	loc_serialized_exc = mono_mb_add_local (mb, m_class_get_byval_arg (byte_array_class));
 	if (complex_count > 0)
-		loc_array = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
+		loc_array = mono_mb_add_local (mb, m_class_get_byval_arg (mono_defaults.object_class));
 	if (sig->ret->type != MONO_TYPE_VOID) {
 		loc_return = mono_mb_add_local (mb, sig->ret);
 		ret_class = mono_class_from_mono_type (sig->ret);
@@ -743,7 +743,7 @@ mono_marshal_get_xappdomain_dispatch (MonoMethod *method, int *marshal_types, in
 
 	/* try */
 
-	main_clause = (MonoExceptionClause *)mono_image_alloc0 (method->klass->image, sizeof (MonoExceptionClause));
+	main_clause = (MonoExceptionClause *)mono_image_alloc0 (m_class_get_image (method->klass), sizeof (MonoExceptionClause));
 	main_clause->try_offset = mono_mb_get_label (mb);
 
 	/* Clean the call context */
@@ -788,14 +788,14 @@ mono_marshal_get_xappdomain_dispatch (MonoMethod *method, int *marshal_types, in
 			mono_mb_emit_ldloc (mb, loc_array);
 			mono_mb_emit_icon (mb, j++);
 			if (pt->byref) {
-				if (pclass->valuetype) {
+				if (m_class_is_valuetype (pclass)) {
 					mono_mb_emit_byte (mb, CEE_LDELEM_REF);
 					mono_mb_emit_op (mb, CEE_UNBOX, pclass);
 				} else {
 					mono_mb_emit_op (mb, CEE_LDELEMA, pclass);
 				}
 			} else {
-				if (pclass->valuetype) {
+				if (m_class_is_valuetype (pclass)) {
 					mono_mb_emit_byte (mb, CEE_LDELEM_REF);
 					mono_mb_emit_op (mb, CEE_UNBOX, pclass);
 					mono_mb_emit_op (mb, CEE_LDOBJ, pclass);
@@ -810,7 +810,7 @@ mono_marshal_get_xappdomain_dispatch (MonoMethod *method, int *marshal_types, in
 		}
 		case MONO_MARSHAL_COPY_OUT: {
 			/* Keep a local copy of the value since we need to copy it back after the call */
-			int copy_local = mono_mb_add_local (mb, &(pclass->byval_arg));
+			int copy_local = mono_mb_add_local (mb, m_class_get_byval_arg (pclass));
 			mono_mb_emit_ldarg (mb, param_index++);
 			mono_marshal_emit_xdomain_copy_value (mb, pclass);
 			mono_mb_emit_byte (mb, CEE_DUP);
@@ -884,7 +884,7 @@ mono_marshal_get_xappdomain_dispatch (MonoMethod *method, int *marshal_types, in
 			mono_mb_emit_ldloc (mb, loc_return);
 
 			g_assert (ret_class); /*FIXME properly fail here*/
-			if (ret_class->valuetype) {
+			if (m_class_is_valuetype (ret_class)) {
 				mono_mb_emit_op (mb, CEE_BOX, ret_class);
 			}
 			mono_mb_emit_byte (mb, CEE_STELEM_REF);
@@ -899,7 +899,7 @@ mono_marshal_get_xappdomain_dispatch (MonoMethod *method, int *marshal_types, in
 	} else if (ret_marshal_type == MONO_MARSHAL_SERIALIZE) {
 		mono_mb_emit_ldarg (mb, 1);
 		mono_mb_emit_ldloc (mb, loc_return);
-		if (ret_class->valuetype) {
+		if (m_class_is_valuetype (ret_class)) {
 			mono_mb_emit_op (mb, CEE_BOX, ret_class);
 		}
 		mono_mb_emit_managed_call (mb, method_rs_serialize, NULL);
@@ -1026,16 +1026,19 @@ mono_marshal_get_xappdomain_invoke (MonoMethod *method, MonoError *error)
 	/* Locals */
 
 #ifndef DISABLE_JIT
+	MonoType *object_type = m_class_get_byval_arg (mono_defaults.object_class);
+	MonoType *byte_array_type = m_class_get_byval_arg (byte_array_class);
+	MonoType *int32_type = m_class_get_byval_arg (mono_defaults.int32_class);
 	if (complex_count > 0)
-		loc_array = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
-	loc_serialized_data = mono_mb_add_local (mb, &byte_array_class->byval_arg);
-	loc_real_proxy = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
+		loc_array = mono_mb_add_local (mb, object_type);
+	loc_serialized_data = mono_mb_add_local (mb, byte_array_type);
+	loc_real_proxy = mono_mb_add_local (mb, object_type);
 	if (copy_return)
 		loc_return = mono_mb_add_local (mb, sig->ret);
-	loc_old_domainid = mono_mb_add_local (mb, &mono_defaults.int32_class->byval_arg);
-	loc_domainid = mono_mb_add_local (mb, &mono_defaults.int32_class->byval_arg);
-	loc_serialized_exc = mono_mb_add_local (mb, &byte_array_class->byval_arg);
-	loc_context = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
+	loc_old_domainid = mono_mb_add_local (mb, int32_type);
+	loc_domainid = mono_mb_add_local (mb, int32_type);
+	loc_serialized_exc = mono_mb_add_local (mb, byte_array_type);
+	loc_context = mono_mb_add_local (mb, object_type);
 
 	/* Save thread domain data */
 
@@ -1068,7 +1071,7 @@ mono_marshal_get_xappdomain_invoke (MonoMethod *method, MonoError *error)
 	/* Check if the target domain has the same image for the required assembly */
 
 	mono_mb_emit_ldloc (mb, loc_domainid);
-	mono_mb_emit_ptr (mb, method->klass->image);
+	mono_mb_emit_ptr (mb, m_class_get_image (method->klass));
 	mono_mb_emit_icall (mb, mono_marshal_check_domain_image);
 	pos_dispatch = mono_mb_emit_short_branch (mb, CEE_BRTRUE_S);
 
@@ -1104,12 +1107,12 @@ mono_marshal_get_xappdomain_invoke (MonoMethod *method, MonoError *error)
 			mono_mb_emit_icon (mb, j);
 			mono_mb_emit_ldarg (mb, i + 1);		/* 0=this */
 			if (sig->params[i]->byref) {
-				if (pclass->valuetype)
+				if (m_class_is_valuetype (pclass))
 					mono_mb_emit_op (mb, CEE_LDOBJ, pclass);
 				else
 					mono_mb_emit_byte (mb, CEE_LDIND_REF);
 			}
-			if (pclass->valuetype)
+			if (m_class_is_valuetype (pclass))
 				mono_mb_emit_op (mb, CEE_BOX, pclass);
 			mono_mb_emit_byte (mb, CEE_STELEM_REF);
 			j++;
@@ -1152,7 +1155,7 @@ mono_marshal_get_xappdomain_invoke (MonoMethod *method, MonoError *error)
 				 * will be updated after the xdomain call
 				 */
 				MonoClass *pclass = mono_class_from_mono_type (sig->params [i]);
-				int copy_local = mono_mb_add_local (mb, &(pclass->byval_arg));
+				int copy_local = mono_mb_add_local (mb, m_class_get_byval_arg (pclass));
 				mono_mb_emit_byte (mb, CEE_LDIND_REF);
 				mono_mb_emit_stloc (mb, copy_local);
 				mono_mb_emit_ldloc_addr (mb, copy_local);
@@ -1230,7 +1233,7 @@ mono_marshal_get_xappdomain_invoke (MonoMethod *method, MonoError *error)
 				mono_mb_emit_ldloc (mb, loc_array);
 				mono_mb_emit_icon (mb, j);
 				mono_mb_emit_byte (mb, CEE_LDELEM_REF);
-				if (pclass->valuetype) {
+				if (m_class_is_valuetype (pclass)) {
 					mono_mb_emit_op (mb, CEE_UNBOX, pclass);
 					mono_mb_emit_op (mb, CEE_LDOBJ, pclass);
 					mono_mb_emit_op (mb, CEE_STOBJ, pclass);
@@ -1247,7 +1250,7 @@ mono_marshal_get_xappdomain_invoke (MonoMethod *method, MonoError *error)
 			mono_mb_emit_ldloc (mb, loc_array);
 			mono_mb_emit_icon (mb, complex_count);
 			mono_mb_emit_byte (mb, CEE_LDELEM_REF);
-			if (ret_class->valuetype) {
+			if (m_class_is_valuetype (ret_class)) {
 				mono_mb_emit_op (mb, CEE_UNBOX, ret_class);
 				mono_mb_emit_op (mb, CEE_LDOBJ, ret_class);
 			}
@@ -1256,7 +1259,7 @@ mono_marshal_get_xappdomain_invoke (MonoMethod *method, MonoError *error)
 		mono_mb_emit_ldloc (mb, loc_serialized_data);
 		mono_marshal_emit_xdomain_copy_value (mb, byte_array_class);
 		mono_mb_emit_managed_call (mb, method_rs_deserialize, NULL);
-		if (ret_class->valuetype) {
+		if (m_class_is_valuetype (ret_class)) {
 			mono_mb_emit_op (mb, CEE_UNBOX, ret_class);
 			mono_mb_emit_op (mb, CEE_LDOBJ, ret_class);
 		} else if (ret_class != mono_defaults.object_class) {
@@ -1447,7 +1450,7 @@ mono_marshal_get_ldfld_wrapper (MonoType *type)
 		klass = mono_defaults.int_class;
 	}
 
-	cache = get_cache (&klass->image->ldfld_wrapper_cache, mono_aligned_addr_hash, NULL);
+	cache = get_cache (&m_class_get_image (klass)->ldfld_wrapper_cache, mono_aligned_addr_hash, NULL);
 	if ((res = mono_marshal_find_in_cache (cache, klass)))
 		return res;
 
@@ -1459,16 +1462,18 @@ mono_marshal_get_ldfld_wrapper (MonoType *type)
 #endif
 
 	/* we add the %p pointer value of klass because class names are not unique */
-	name = g_strdup_printf ("__ldfld_wrapper_%p_%s.%s", klass, klass->name_space, klass->name); 
+	name = g_strdup_printf ("__ldfld_wrapper_%p_%s.%s", klass, m_class_get_name_space (klass), m_class_get_name (klass)); 
 	mb = mono_mb_new (mono_defaults.object_class, name, MONO_WRAPPER_LDFLD);
 	g_free (name);
 
+	MonoType *object_type = m_class_get_byval_arg (mono_defaults.object_class);
+	MonoType *int_type = m_class_get_byval_arg (mono_defaults.int_class);
 	sig = mono_metadata_signature_alloc (mono_defaults.corlib, 4);
-	sig->params [0] = &mono_defaults.object_class->byval_arg;
-	sig->params [1] = &mono_defaults.int_class->byval_arg;
-	sig->params [2] = &mono_defaults.int_class->byval_arg;
-	sig->params [3] = &mono_defaults.int_class->byval_arg;
-	sig->ret = &klass->byval_arg;
+	sig->params [0] = object_type;
+	sig->params [1] = int_type;
+	sig->params [2] = int_type;
+	sig->params [3] = int_type;
+	sig->ret = m_class_get_byval_arg (klass);
 
 #ifndef DISABLE_JIT
 	mono_mb_emit_ldarg (mb, 0);
@@ -1493,7 +1498,7 @@ mono_marshal_get_ldfld_wrapper (MonoType *type)
 	mono_marshal_emit_thread_interrupt_checkpoint (mb);
 	*/
 
-	if (klass->valuetype) {
+	if (m_class_is_valuetype (klass)) {
 		mono_mb_emit_op (mb, CEE_UNBOX, klass);
 		pos1 = mono_mb_emit_branch (mb, CEE_BR);
 	} else {
@@ -1509,7 +1514,7 @@ mono_marshal_get_ldfld_wrapper (MonoType *type)
 	mono_mb_emit_ldarg (mb, 3);
 	mono_mb_emit_byte (mb, CEE_ADD);
 
-	if (klass->valuetype)
+	if (m_class_is_valuetype (klass))
 		mono_mb_patch_branch (mb, pos1);
 
 	switch (t) {
@@ -1537,7 +1542,7 @@ mono_marshal_get_ldfld_wrapper (MonoType *type)
 		mono_mb_emit_byte (mb, mono_type_to_ldind (type));
 		break;
 	case MONO_TYPE_VALUETYPE:
-		g_assert (!klass->enumtype);
+		g_assert (!m_class_is_enumtype (klass));
 		mono_mb_emit_op (mb, CEE_LDOBJ, klass);
 		break;
 	case MONO_TYPE_GENERICINST:
@@ -1612,23 +1617,25 @@ mono_marshal_get_ldflda_wrapper (MonoType *type)
 		klass = mono_defaults.int_class;
 	}
 
-	cache = get_cache (&klass->image->ldflda_wrapper_cache, mono_aligned_addr_hash, NULL);
+	cache = get_cache (&m_class_get_image (klass)->ldflda_wrapper_cache, mono_aligned_addr_hash, NULL);
 	if ((res = mono_marshal_find_in_cache (cache, klass)))
 		return res;
 
 	mono_remoting_marshal_init ();
 
 	/* we add the %p pointer value of klass because class names are not unique */
-	name = g_strdup_printf ("__ldflda_wrapper_%p_%s.%s", klass, klass->name_space, klass->name); 
+	name = g_strdup_printf ("__ldflda_wrapper_%p_%s.%s", klass, m_class_get_name_space (klass), m_class_get_name (klass)); 
 	mb = mono_mb_new (mono_defaults.object_class, name, MONO_WRAPPER_LDFLDA);
 	g_free (name);
 
+	MonoType *object_type = m_class_get_byval_arg (mono_defaults.object_class);
+	MonoType *int_type = m_class_get_byval_arg (mono_defaults.int_class);
 	sig = mono_metadata_signature_alloc (mono_defaults.corlib, 4);
-	sig->params [0] = &mono_defaults.object_class->byval_arg;
-	sig->params [1] = &mono_defaults.int_class->byval_arg;
-	sig->params [2] = &mono_defaults.int_class->byval_arg;
-	sig->params [3] = &mono_defaults.int_class->byval_arg;
-	sig->ret = &mono_defaults.int_class->byval_arg;
+	sig->params [0] = object_type;
+	sig->params [1] = int_type;
+	sig->params [2] = int_type;
+	sig->params [3] = int_type;
+	sig->ret = int_type;
 
 #ifndef DISABLE_JIT
 	/* if typeof (this) != transparent_proxy goto pos0 */
@@ -1743,7 +1750,7 @@ mono_marshal_get_stfld_wrapper (MonoType *type)
 		klass = mono_defaults.int_class;
 	}
 
-	cache = get_cache (&klass->image->stfld_wrapper_cache, mono_aligned_addr_hash, NULL);
+	cache = get_cache (&m_class_get_image (klass)->stfld_wrapper_cache, mono_aligned_addr_hash, NULL);
 	if ((res = mono_marshal_find_in_cache (cache, klass)))
 		return res;
 
@@ -1755,17 +1762,21 @@ mono_marshal_get_stfld_wrapper (MonoType *type)
 #endif
 
 	/* we add the %p pointer value of klass because class names are not unique */
-	name = g_strdup_printf ("__stfld_wrapper_%p_%s.%s", klass, klass->name_space, klass->name); 
+	name = g_strdup_printf ("__stfld_wrapper_%p_%s.%s", klass, m_class_get_name_space (klass), m_class_get_name (klass)); 
 	mb = mono_mb_new (mono_defaults.object_class, name, MONO_WRAPPER_STFLD);
 	g_free (name);
 
+	
+	MonoType *object_type = m_class_get_byval_arg (mono_defaults.object_class);
+	MonoType *int_type = m_class_get_byval_arg (mono_defaults.int_class);
+	MonoType *void_type = m_class_get_byval_arg (mono_defaults.void_class);
 	sig = mono_metadata_signature_alloc (mono_defaults.corlib, 5);
-	sig->params [0] = &mono_defaults.object_class->byval_arg;
-	sig->params [1] = &mono_defaults.int_class->byval_arg;
-	sig->params [2] = &mono_defaults.int_class->byval_arg;
-	sig->params [3] = &mono_defaults.int_class->byval_arg;
-	sig->params [4] = &klass->byval_arg;
-	sig->ret = &mono_defaults.void_class->byval_arg;
+	sig->params [0] = object_type;
+	sig->params [1] = int_type;
+	sig->params [2] = int_type;
+	sig->params [3] = int_type;
+	sig->params [4] = m_class_get_byval_arg (klass);
+	sig->ret = void_type;
 
 #ifndef DISABLE_JIT
 	mono_mb_emit_ldarg (mb, 0);
@@ -1776,7 +1787,7 @@ mono_marshal_get_stfld_wrapper (MonoType *type)
 	mono_mb_emit_ldarg (mb, 1);
 	mono_mb_emit_ldarg (mb, 2);
 	mono_mb_emit_ldarg (mb, 4);
-	if (klass->valuetype)
+	if (m_class_is_valuetype (klass))
 		mono_mb_emit_op (mb, CEE_BOX, klass);
 
 	mono_mb_emit_managed_call (mb, tp_store, NULL);
@@ -1818,7 +1829,7 @@ mono_marshal_get_stfld_wrapper (MonoType *type)
 		mono_mb_emit_byte (mb, mono_type_to_stind (type));
 		break;
 	case MONO_TYPE_VALUETYPE:
-		g_assert (!klass->enumtype);
+		g_assert (!m_class_is_enumtype (klass));
 		mono_mb_emit_op (mb, CEE_STOBJ, klass);
 		break;
 	case MONO_TYPE_GENERICINST:
@@ -1860,18 +1871,18 @@ mono_marshal_get_proxy_cancast (MonoClass *klass)
 	MonoMethodDesc *desc;
 	MonoMethodBuilder *mb;
 
-	cache = get_cache (&klass->image->proxy_isinst_cache, mono_aligned_addr_hash, NULL);
+	cache = get_cache (&m_class_get_image (klass)->proxy_isinst_cache, mono_aligned_addr_hash, NULL);
 	if ((res = mono_marshal_find_in_cache (cache, klass)))
 		return res;
 
 	if (!isint_sig) {
 		isint_sig = mono_metadata_signature_alloc (mono_defaults.corlib, 1);
-		isint_sig->params [0] = &mono_defaults.object_class->byval_arg;
-		isint_sig->ret = &mono_defaults.object_class->byval_arg;
+		isint_sig->params [0] = m_class_get_byval_arg (mono_defaults.object_class);
+		isint_sig->ret = m_class_get_byval_arg (mono_defaults.object_class);
 		isint_sig->pinvoke = 0;
 	}
 
-	klass_name = mono_type_full_name (&klass->byval_arg);
+	klass_name = mono_type_full_name (m_class_get_byval_arg (klass));
 	name = g_strdup_printf ("__proxy_isinst_wrapper_%s", klass_name); 
 	mb = mono_mb_new (mono_defaults.object_class, name, MONO_WRAPPER_PROXY_ISINST);
 	g_free (klass_name);
@@ -1886,7 +1897,7 @@ mono_marshal_get_proxy_cancast (MonoClass *klass)
 	mono_mb_emit_byte (mb, CEE_LDIND_REF);
 	
 	/* get the reflection type from the type handle */
-	mono_mb_emit_ptr (mb, &klass->byval_arg);
+	mono_mb_emit_ptr (mb, m_class_get_byval_arg (klass));
 	mono_mb_emit_icall (mb, type_from_handle);
 	
 	mono_mb_emit_ldarg (mb, 0);
@@ -1901,7 +1912,7 @@ mono_marshal_get_proxy_cancast (MonoClass *klass)
 	pos_failed = mono_mb_emit_branch (mb, CEE_BRFALSE);
 
 	/* Upgrade the proxy vtable by calling: mono_upgrade_remote_class_wrapper (type, ob)*/
-	mono_mb_emit_ptr (mb, &klass->byval_arg);
+	mono_mb_emit_ptr (mb, m_class_get_byval_arg (klass));
 	mono_mb_emit_icall (mb, type_from_handle);
 	mono_mb_emit_ldarg (mb, 0);
 	
@@ -1978,8 +1989,8 @@ mono_get_xdomain_marshal_type (MonoType *t)
 		return MONO_MARSHAL_COPY;
 	case MONO_TYPE_ARRAY:
 	case MONO_TYPE_SZARRAY: {
-		MonoClass *elem_class = mono_class_from_mono_type (t)->element_class;
-		if (mono_get_xdomain_marshal_type (&(elem_class->byval_arg)) != MONO_MARSHAL_SERIALIZE)
+		MonoClass *elem_class = m_class_get_element_class (mono_class_from_mono_type (t));
+		if (mono_get_xdomain_marshal_type (m_class_get_byval_arg (elem_class)) != MONO_MARSHAL_SERIALIZE)
 			return MONO_MARSHAL_COPY;
 		break;
 	}
@@ -2024,7 +2035,7 @@ mono_marshal_xdomain_copy_value_handle (MonoObjectHandle val, MonoError *error)
 
 	MonoClass *klass = mono_handle_class (val);
 
-	switch (klass->byval_arg.type) {
+	switch (m_class_get_byval_arg (klass)->type) {
 	case MONO_TYPE_VOID:
 		g_assert_not_reached ();
 		break;
@@ -2059,7 +2070,7 @@ mono_marshal_xdomain_copy_value_handle (MonoObjectHandle val, MonoError *error)
 	case MONO_TYPE_ARRAY:
 	case MONO_TYPE_SZARRAY: {
 		MonoArrayHandle arr = MONO_HANDLE_CAST (MonoArray, val);
-		MonoXDomainMarshalType mt = mono_get_xdomain_marshal_type (&klass->element_class->byval_arg);
+		MonoXDomainMarshalType mt = mono_get_xdomain_marshal_type (m_class_get_byval_arg (m_class_get_element_class (klass)));
 		if (mt == MONO_MARSHAL_SERIALIZE)
 			goto leave;
 		MonoArrayHandle acopy = mono_array_clone_in_domain (domain, arr, error);

--- a/mono/metadata/security-manager.c
+++ b/mono/metadata/security-manager.c
@@ -43,7 +43,7 @@ mono_security_manager_get_methods (void)
 
 	/* Initialize */
 	secman.securitymanager = mono_class_get_security_manager_class ();
-	if (!secman.securitymanager->inited)
+	if (!m_class_is_inited (secman.securitymanager))
 		mono_class_init (secman.securitymanager);
 
 	return &secman;

--- a/mono/metadata/sgen-bridge.c
+++ b/mono/metadata/sgen-bridge.c
@@ -516,7 +516,7 @@ static const char *bridge_class;
 static MonoGCBridgeObjectKind
 bridge_test_bridge_class_kind (MonoClass *klass)
 {
-	if (!strcmp (bridge_class, klass->name))
+	if (!strcmp (bridge_class, m_class_get_name (klass)))
 		return GC_BRIDGE_TRANSPARENT_BRIDGE_CLASS;
 	return GC_BRIDGE_TRANSPARENT_CLASS;
 }

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -18,6 +18,7 @@
 #include "sgen/sgen-cardtable.h"
 #include "sgen/sgen-pinning.h"
 #include "sgen/sgen-workers.h"
+#include "metadata/class-init.h"
 #include "metadata/marshal.h"
 #include "metadata/method-builder.h"
 #include "metadata/abi-details.h"
@@ -384,22 +385,15 @@ static GCVTable
 get_array_fill_vtable (void)
 {
 	if (!array_fill_vtable) {
-		static MonoClass klass;
 		static char _vtable[sizeof(MonoVTable)+8];
 		MonoVTable* vtable = (MonoVTable*) ALIGN_TO((mword)_vtable, 8);
 		gsize bmap;
 
+		MonoClass *klass = mono_class_create_array_fill_type ();
 		MonoDomain *domain = mono_get_root_domain ();
 		g_assert (domain);
 
-		klass.element_class = mono_defaults.byte_class;
-		klass.rank = 1;
-		klass.instance_size = MONO_SIZEOF_MONO_ARRAY;
-		klass.sizes.element_size = 1;
-		klass.size_inited = 1;
-		klass.name = "array_filler_type";
-
-		vtable->klass = &klass;
+		vtable->klass = klass;
 		bmap = 0;
 		vtable->gc_descr = mono_gc_make_descr_for_array (TRUE, &bmap, 0, 1);
 		vtable->rank = 1;

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -22,6 +22,7 @@
 #include "metadata/marshal.h"
 #include "metadata/method-builder.h"
 #include "metadata/abi-details.h"
+#include "metadata/class-abi-details.h"
 #include "metadata/mono-gc.h"
 #include "metadata/runtime.h"
 #include "metadata/sgen-bridge-internals.h"
@@ -98,11 +99,11 @@ void
 mono_gc_wbarrier_value_copy (gpointer dest, gpointer src, int count, MonoClass *klass)
 {
 	HEAVY_STAT (++stat_wbarrier_value_copy);
-	g_assert (klass->valuetype);
+	g_assert (m_class_is_valuetype (klass));
 
-	SGEN_LOG (8, "Adding value remset at %p, count %d, descr %p for class %s (%p)", dest, count, (gpointer)klass->gc_descr, klass->name, klass);
+	SGEN_LOG (8, "Adding value remset at %p, count %d, descr %p for class %s (%p)", dest, count, (gpointer)m_class_get_gc_descr (klass), m_class_get_name (klass), klass);
 
-	if (sgen_ptr_in_nursery (dest) || ptr_on_stack (dest) || !sgen_gc_descr_has_references ((mword)klass->gc_descr)) {
+	if (sgen_ptr_in_nursery (dest) || ptr_on_stack (dest) || !sgen_gc_descr_has_references ((mword)m_class_get_gc_descr (klass))) {
 		size_t element_size = mono_class_value_size (klass, NULL);
 		size_t size = count * element_size;
 		mono_gc_memmove_atomic (dest, src, size);		
@@ -138,7 +139,7 @@ mono_gc_wbarrier_object_copy (MonoObject* obj, MonoObject *src)
 
 	SGEN_ASSERT (6, !ptr_on_stack (obj), "Why is this called for a non-reference type?");
 	if (sgen_ptr_in_nursery (obj) || !SGEN_OBJECT_HAS_REFERENCES (src)) {
-		size = mono_object_class (obj)->instance_size;
+		size = m_class_get_instance_size (mono_object_class (obj));
 		mono_gc_memmove_aligned ((char*)obj + sizeof (MonoObject), (char*)src + sizeof (MonoObject),
 				size - sizeof (MonoObject));
 		return;	
@@ -229,7 +230,7 @@ mono_gc_is_critical_method (MonoMethod *method)
 static void
 emit_nursery_check (MonoMethodBuilder *mb, int *nursery_check_return_labels, gboolean is_concurrent)
 {
-	int shifted_nursery_start = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+	int shifted_nursery_start = mono_mb_add_local (mb, m_class_get_byval_arg (mono_defaults.int_class));
 
 	memset (nursery_check_return_labels, 0, sizeof (int) * 2);
 	// if (ptr_in_nursery (ptr)) return;
@@ -288,8 +289,8 @@ mono_gc_get_specific_write_barrier (gboolean is_concurrent)
 
 	/* Create the IL version of mono_gc_barrier_generic_store () */
 	sig = mono_metadata_signature_alloc (mono_defaults.corlib, 1);
-	sig->ret = &mono_defaults.void_class->byval_arg;
-	sig->params [0] = &mono_defaults.int_class->byval_arg;
+	sig->ret = m_class_get_byval_arg (mono_defaults.void_class);
+	sig->params [0] = m_class_get_byval_arg (mono_defaults.int_class);
 
 	if (is_concurrent)
 		mb = mono_mb_new (mono_defaults.object_class, "wbarrier_conc", MONO_WRAPPER_WRITE_BARRIER);
@@ -783,7 +784,7 @@ process_object_for_domain_clearing (GCObject *start, MonoDomain *domain)
 	/* The object could be a proxy for an object in the domain
 	   we're deleting. */
 #ifndef DISABLE_REMOTING
-	if (mono_defaults.real_proxy_class->supertypes && mono_class_has_parent_fast (vt->klass, mono_defaults.real_proxy_class)) {
+	if (m_class_get_supertypes (mono_defaults.real_proxy_class) && mono_class_has_parent_fast (vt->klass, mono_defaults.real_proxy_class)) {
 		MonoObject *server = ((MonoRealProxy*)start)->unwrapped_server;
 
 		/* The server could already have been zeroed out, so
@@ -1014,7 +1015,7 @@ static gboolean use_managed_allocator = TRUE;
 // Cache the SgenThreadInfo pointer in a local 'var'.
 #define EMIT_TLS_ACCESS_VAR(mb, var) \
 	do { \
-		var = mono_mb_add_local ((mb), &mono_defaults.int_class->byval_arg); \
+		var = mono_mb_add_local ((mb), m_class_get_byval_arg (mono_defaults.int_class)); \
 		mono_mb_emit_byte ((mb), MONO_CUSTOM_PREFIX); \
 		mono_mb_emit_byte ((mb), CEE_MONO_TLS); \
 		mono_mb_emit_i4 ((mb), TLS_KEY_SGEN_THREAD_INFO); \
@@ -1090,15 +1091,16 @@ create_allocator (int atype, ManagedAllocatorVariant variant)
 	else
 		num_params = 2;
 
+	MonoType *int_type = m_class_get_byval_arg (mono_defaults.int_class);
 	csig = mono_metadata_signature_alloc (mono_defaults.corlib, num_params);
 	if (atype == ATYPE_STRING) {
-		csig->ret = &mono_defaults.string_class->byval_arg;
-		csig->params [0] = &mono_defaults.int_class->byval_arg;
-		csig->params [1] = &mono_defaults.int32_class->byval_arg;
+		csig->ret = m_class_get_byval_arg (mono_defaults.string_class);
+		csig->params [0] = int_type;
+		csig->params [1] = m_class_get_byval_arg (mono_defaults.int32_class);
 	} else {
-		csig->ret = &mono_defaults.object_class->byval_arg;
+		csig->ret = m_class_get_byval_arg (mono_defaults.object_class);
 		for (i = 0; i < num_params; i++)
-			csig->params [i] = &mono_defaults.int_class->byval_arg;
+			csig->params [i] = int_type;
 	}
 
 	mb = mono_mb_new (mono_defaults.object_class, name, MONO_WRAPPER_ALLOC);
@@ -1133,7 +1135,7 @@ create_allocator (int atype, ManagedAllocatorVariant variant)
 	 */
 	EMIT_TLS_ACCESS_VAR (mb, thread_var);
 
-	size_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+	size_var = mono_mb_add_local (mb, int_type);
 	if (atype == ATYPE_SMALL) {
 		/* size_var = size_arg */
 		mono_mb_emit_ldarg (mb, 1);
@@ -1144,7 +1146,7 @@ create_allocator (int atype, ManagedAllocatorVariant variant)
 		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoVTable, klass));
 		mono_mb_emit_byte (mb, CEE_ADD);
 		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoClass, instance_size));
+		mono_mb_emit_icon (mb, m_class_offsetof_instance_size ());
 		mono_mb_emit_byte (mb, CEE_ADD);
 		/* FIXME: assert instance_size stays a 4 byte integer */
 		mono_mb_emit_byte (mb, CEE_LDIND_U4);
@@ -1187,7 +1189,7 @@ create_allocator (int atype, ManagedAllocatorVariant variant)
 		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoVTable, klass));
 		mono_mb_emit_byte (mb, CEE_ADD);
 		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoClass, sizes));
+		mono_mb_emit_icon (mb, m_class_offsetof_sizes ());
 		mono_mb_emit_byte (mb, CEE_ADD);
 		mono_mb_emit_byte (mb, CEE_LDIND_U4);
 		mono_mb_emit_byte (mb, CEE_CONV_I);
@@ -1268,7 +1270,7 @@ create_allocator (int atype, ManagedAllocatorVariant variant)
 #endif
 
 	if (nursery_canaries_enabled ()) {
-		real_size_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		real_size_var = mono_mb_add_local (mb, int_type);
 		mono_mb_emit_ldloc (mb, size_var);
 		mono_mb_emit_stloc(mb, real_size_var);
 	}
@@ -1297,18 +1299,18 @@ create_allocator (int atype, ManagedAllocatorVariant variant)
 	 */
 
 	/* tlab_next_addr (local) = tlab_next_addr (TLS var) */
-	tlab_next_addr_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+	tlab_next_addr_var = mono_mb_add_local (mb, int_type);
 	EMIT_TLS_ACCESS_NEXT_ADDR (mb, thread_var);
 	mono_mb_emit_stloc (mb, tlab_next_addr_var);
 
 	/* p = (void**)tlab_next; */
-	p_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+	p_var = mono_mb_add_local (mb, int_type);
 	mono_mb_emit_ldloc (mb, tlab_next_addr_var);
 	mono_mb_emit_byte (mb, CEE_LDIND_I);
 	mono_mb_emit_stloc (mb, p_var);
 	
 	/* new_next = (char*)p + size; */
-	new_next_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+	new_next_var = mono_mb_add_local (mb, int_type);
 	mono_mb_emit_ldloc (mb, p_var);
 	mono_mb_emit_ldloc (mb, size_var);
 	mono_mb_emit_byte (mb, CEE_CONV_I);
@@ -1496,15 +1498,15 @@ mono_gc_get_managed_allocator (MonoClass *klass, gboolean for_box, gboolean know
 
 	if (collect_before_allocs)
 		return NULL;
-	if (klass->instance_size > tlab_size)
+	if (m_class_get_instance_size (klass) > tlab_size)
 		return NULL;
-	if (known_instance_size && ALIGN_TO (klass->instance_size, SGEN_ALLOC_ALIGN) >= SGEN_MAX_SMALL_OBJ_SIZE)
+	if (known_instance_size && ALIGN_TO (m_class_get_instance_size (klass), SGEN_ALLOC_ALIGN) >= SGEN_MAX_SMALL_OBJ_SIZE)
 		return NULL;
-	if (mono_class_has_finalizer (klass) || mono_class_is_marshalbyref (klass) || klass->has_weak_fields)
+	if (mono_class_has_finalizer (klass) || mono_class_is_marshalbyref (klass) || m_class_has_weak_fields (klass))
 		return NULL;
-	if (klass->rank)
+	if (m_class_get_rank (klass))
 		return NULL;
-	if (klass->byval_arg.type == MONO_TYPE_STRING)
+	if (m_class_get_byval_arg (klass)->type == MONO_TYPE_STRING)
 		return mono_gc_get_managed_allocator_by_type (ATYPE_STRING, variant);
 	/* Generic classes have dynamic field and can go above MAX_SMALL_OBJ_SIZE. */
 	if (known_instance_size)
@@ -1520,7 +1522,7 @@ MonoMethod*
 mono_gc_get_managed_array_allocator (MonoClass *klass)
 {
 #ifdef MANAGED_ALLOCATION
-	if (klass->rank != 1)
+	if (m_class_get_rank (klass) != 1)
 		return NULL;
 	if (has_per_allocation_action)
 		return NULL;
@@ -1627,7 +1629,7 @@ sgen_client_cardtable_scan_object (GCObject *obj, guint8 *cards, ScanCopyContext
 		size_t card_count;
 		size_t extra_idx = 0;
 
-		mword desc = (mword)klass->element_class->gc_descr;
+		mword desc = (mword)m_class_get_gc_descr (m_class_get_element_class (klass));
 		int elem_size = mono_array_element_size (klass);
 
 #ifdef SGEN_HAVE_OVERLAPPING_CARDS
@@ -1635,7 +1637,7 @@ sgen_client_cardtable_scan_object (GCObject *obj, guint8 *cards, ScanCopyContext
 #endif
 
 #ifdef SGEN_OBJECT_LAYOUT_STATISTICS
-		if (klass->element_class->valuetype)
+		if (m_class_is_valuetype (m_class_get_element_class (klass)))
 			sgen_object_layout_scanned_vtype_array ();
 		else
 			sgen_object_layout_scanned_ref_array ();
@@ -1682,7 +1684,7 @@ LOOP_HEAD:
 				index = ARRAY_OBJ_INDEX (start, obj, elem_size);
 
 			elem = first_elem = (char*)mono_array_addr_with_size_fast ((MonoArray*)obj, elem_size, index);
-			if (klass->element_class->valuetype) {
+			if (m_class_is_valuetype (m_class_get_element_class (klass))) {
 				ScanVTypeFunc scan_vtype_func = ctx.ops->scan_vtype;
 
 				for (; elem < card_end; elem += elem_size)
@@ -3173,19 +3175,19 @@ sgen_client_pre_collection_checks (void)
 gboolean
 sgen_client_vtable_is_inited (MonoVTable *vt)
 {
-	return vt->klass->inited;
+	return m_class_is_inited (vt->klass);
 }
 
 const char*
 sgen_client_vtable_get_namespace (MonoVTable *vt)
 {
-	return vt->klass->name_space;
+	return m_class_get_name_space (vt->klass);
 }
 
 const char*
 sgen_client_vtable_get_name (MonoVTable *vt)
 {
-	return vt->klass->name;
+	return m_class_get_name (vt->klass);
 }
 
 /*

--- a/mono/metadata/sgen-old-bridge.c
+++ b/mono/metadata/sgen-old-bridge.c
@@ -749,7 +749,7 @@ processing_build_callback_data (int generation)
 			HashEntryWithAccounting *entry = (HashEntryWithAccounting*)all_entries [i];
 			if (entry->entry.is_bridge) {
 				MonoClass *klass = SGEN_LOAD_VTABLE (entry->entry.obj)->klass;
-				mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "OBJECT %s::%s (%p) weight %f", klass->name_space, klass->name, entry->entry.obj, entry->weight);
+				mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "OBJECT %s::%s (%p) weight %f", m_class_get_name_space (klass), m_class_get_name (klass), entry->entry.obj, entry->weight);
 			}
 		}
 	}

--- a/mono/metadata/sgen-tarjan-bridge.c
+++ b/mono/metadata/sgen-tarjan-bridge.c
@@ -52,19 +52,19 @@ class_kind (MonoClass *klass)
 		return res;
 
 	/* Non bridge classes with no pointers will never point to a bridge, so we can savely ignore them. */
-	if (!klass->has_references) {
-		SGEN_LOG (6, "class %s is opaque\n", klass->name);
+	if (!m_class_has_references (klass)) {
+		SGEN_LOG (6, "class %s is opaque\n", m_class_get_name (klass));
 		return GC_BRIDGE_OPAQUE_CLASS;
 	}
 
 	/* Some arrays can be ignored */
-	if (klass->rank == 1) {
-		MonoClass *elem_class = klass->element_class;
+	if (m_class_get_rank (klass) == 1) {
+		MonoClass *elem_class = m_class_get_element_class (klass);
 
 		/* FIXME the bridge check can be quite expensive, cache it at the class level. */
 		/* An array of a sealed type that is not a bridge will never get to a bridge */
-		if ((mono_class_get_flags (elem_class) & TYPE_ATTRIBUTE_SEALED) && !elem_class->has_references && !bridge_callbacks.bridge_class_kind (elem_class)) {
-			SGEN_LOG (6, "class %s is opaque\n", klass->name);
+		if ((mono_class_get_flags (elem_class) & TYPE_ATTRIBUTE_SEALED) && !m_class_has_references (elem_class) && !bridge_callbacks.bridge_class_kind (elem_class)) {
+			SGEN_LOG (6, "class %s is opaque\n", m_class_get_name (klass));
 			return GC_BRIDGE_OPAQUE_CLASS;
 		}
 	}
@@ -596,7 +596,7 @@ is_opaque_object (GCObject *obj)
 {
 	MonoVTable *vt = SGEN_LOAD_VTABLE (obj);
 	if ((vt->gc_bits & SGEN_GC_BIT_BRIDGE_OPAQUE_OBJECT) == SGEN_GC_BIT_BRIDGE_OPAQUE_OBJECT) {
-		SGEN_LOG (6, "ignoring %s\n", vt->klass->name);
+		SGEN_LOG (6, "ignoring %s\n", m_class_get_name (vt->klass));
 		++ignored_objects;
 		return TRUE;
 	}

--- a/mono/metadata/sre-encode.c
+++ b/mono/metadata/sre-encode.c
@@ -140,8 +140,8 @@ encode_generic_class (MonoDynamicImage *assembly, MonoGenericClass *gclass, SigB
 
 	sigbuffer_add_value (buf, MONO_TYPE_GENERICINST);
 	klass = gclass->container_class;
-	sigbuffer_add_value (buf, klass->byval_arg.type);
-	sigbuffer_add_value (buf, mono_dynimage_encode_typedef_or_ref_full (assembly, &klass->byval_arg, FALSE));
+	sigbuffer_add_value (buf, m_class_get_byval_arg (klass)->type);
+	sigbuffer_add_value (buf, mono_dynimage_encode_typedef_or_ref_full (assembly, m_class_get_byval_arg (klass), FALSE));
 
 	sigbuffer_add_value (buf, class_inst->type_argc);
 	for (i = 0; i < class_inst->type_argc; ++i)
@@ -189,7 +189,7 @@ encode_type (MonoDynamicImage *assembly, MonoType *type, SigBuffer *buf)
 		break;
 	case MONO_TYPE_SZARRAY:
 		sigbuffer_add_value (buf, type->type);
-		encode_type (assembly, &type->data.klass->byval_arg, buf);
+		encode_type (assembly, m_class_get_byval_arg (type->data.klass), buf);
 		break;
 	case MONO_TYPE_VALUETYPE:
 	case MONO_TYPE_CLASS: {
@@ -202,19 +202,19 @@ encode_type (MonoDynamicImage *assembly, MonoType *type, SigBuffer *buf)
 			/*
 			 * Make sure we use the correct type.
 			 */
-			sigbuffer_add_value (buf, k->byval_arg.type);
+			sigbuffer_add_value (buf, m_class_get_byval_arg (k)->type);
 			/*
 			 * ensure only non-byref gets passed to mono_image_typedef_or_ref(),
 			 * otherwise two typerefs could point to the same type, leading to
 			 * verification errors.
 			 */
-			sigbuffer_add_value (buf, mono_image_typedef_or_ref (assembly, &k->byval_arg));
+			sigbuffer_add_value (buf, mono_image_typedef_or_ref (assembly, m_class_get_byval_arg (k)));
 		}
 		break;
 	}
 	case MONO_TYPE_ARRAY:
 		sigbuffer_add_value (buf, type->type);
-		encode_type (assembly, &type->data.array->eklass->byval_arg, buf);
+		encode_type (assembly, m_class_get_byval_arg (type->data.array->eklass), buf);
 		sigbuffer_add_value (buf, type->data.array->rank);
 		sigbuffer_add_value (buf, 0); /* FIXME: set to 0 for now */
 		sigbuffer_add_value (buf, 0);
@@ -530,7 +530,7 @@ mono_dynimage_encode_constant (MonoDynamicImage *assembly, MonoObject *val, Mono
 		box_val = (char*)&dummy;
 	} else {
 		box_val = ((char*)val) + sizeof (MonoObject);
-		*ret_type = val->vtable->klass->byval_arg.type;
+		*ret_type = m_class_get_byval_arg (val->vtable->klass)->type;
 	}
 handle_enum:
 	switch (*ret_type) {
@@ -559,10 +559,10 @@ handle_enum:
 	case MONO_TYPE_VALUETYPE: {
 		MonoClass *klass = val->vtable->klass;
 		
-		if (klass->enumtype) {
+		if (m_class_is_enumtype (klass)) {
 			*ret_type = mono_class_enum_basetype (klass)->type;
 			goto handle_enum;
-		} else if (mono_is_corlib_image (klass->image) && strcmp (klass->name_space, "System") == 0 && strcmp (klass->name, "DateTime") == 0) {
+		} else if (mono_is_corlib_image (m_class_get_image (klass)) && strcmp (m_class_get_name_space (klass), "System") == 0 && strcmp (m_class_get_name (klass), "DateTime") == 0) {
 			len = 8;
 		} else 
 			g_error ("we can't encode valuetypes, we should have never reached this line");
@@ -592,7 +592,7 @@ handle_enum:
 		return idx;
 	}
 	case MONO_TYPE_GENERICINST:
-		*ret_type = mono_class_get_generic_class (val->vtable->klass)->container_class->byval_arg.type;
+		*ret_type = m_class_get_byval_arg (mono_class_get_generic_class (val->vtable->klass)->container_class)->type;
 		goto handle_enum;
 	default:
 		g_error ("we don't encode constant type 0x%02x yet", *ret_type);
@@ -678,7 +678,7 @@ mono_dynimage_encode_fieldref_signature (MonoDynamicImage *assembly, MonoImage *
 				MonoClass *klass = mono_class_get_checked (field_image, type->modifiers [i].token, error);
 				g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 
-				token = mono_image_typedef_or_ref (assembly, &klass->byval_arg);
+				token = mono_image_typedef_or_ref (assembly, m_class_get_byval_arg (klass));
 			} else {
 				token = type->modifiers [i].token;
 			}
@@ -782,7 +782,7 @@ mono_dynimage_encode_typedef_or_ref_full (MonoDynamicImage *assembly, MonoType *
 	/*
 	 * If it's in the same module and not a generic type parameter:
 	 */
-	if ((klass->image == &assembly->image) && (type->type != MONO_TYPE_VAR) && 
+	if ((m_class_get_image (klass) == &assembly->image) && (type->type != MONO_TYPE_VAR) && 
 			(type->type != MONO_TYPE_MVAR)) {
 		token = MONO_TYPEDEFORREF_TYPEDEF | (MONO_HANDLE_GETVAL (tb, table_idx) << MONO_TYPEDEFORREF_BITS);
 		/* This function is called multiple times from sre and sre-save, so same object is okay */
@@ -790,21 +790,21 @@ mono_dynimage_encode_typedef_or_ref_full (MonoDynamicImage *assembly, MonoType *
 		goto leave;
 	}
 
-	if (klass->nested_in) {
-		enclosing = mono_dynimage_encode_typedef_or_ref_full (assembly, &klass->nested_in->byval_arg, FALSE);
+	if (m_class_get_nested_in (klass)) {
+		enclosing = mono_dynimage_encode_typedef_or_ref_full (assembly, m_class_get_byval_arg (m_class_get_nested_in (klass)), FALSE);
 		/* get the typeref idx of the enclosing type */
 		enclosing >>= MONO_TYPEDEFORREF_BITS;
 		scope = (enclosing << MONO_RESOLUTION_SCOPE_BITS) | MONO_RESOLUTION_SCOPE_TYPEREF;
 	} else {
-		scope = mono_reflection_resolution_scope_from_image (assembly, klass->image);
+		scope = mono_reflection_resolution_scope_from_image (assembly, m_class_get_image (klass));
 	}
 	table = &assembly->tables [MONO_TABLE_TYPEREF];
 	if (assembly->save) {
 		alloc_table (table, table->rows + 1);
 		values = table->values + table->next_idx * MONO_TYPEREF_SIZE;
 		values [MONO_TYPEREF_SCOPE] = scope;
-		values [MONO_TYPEREF_NAME] = mono_dynstream_insert_string (&assembly->sheap, klass->name);
-		values [MONO_TYPEREF_NAMESPACE] = mono_dynstream_insert_string (&assembly->sheap, klass->name_space);
+		values [MONO_TYPEREF_NAME] = mono_dynstream_insert_string (&assembly->sheap, m_class_get_name (klass));
+		values [MONO_TYPEREF_NAMESPACE] = mono_dynstream_insert_string (&assembly->sheap, m_class_get_name_space (klass));
 	}
 	token = MONO_TYPEDEFORREF_TYPEREF | (table->next_idx << MONO_TYPEDEFORREF_BITS); /* typeref */
 	g_hash_table_insert (assembly->typeref, type, GUINT_TO_POINTER(token));

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -37,6 +37,14 @@
 #include "mono/utils/checked-build.h"
 #include "mono/utils/mono-digest.h"
 #include "mono/utils/w32api.h"
+#ifdef MONO_CLASS_DEF_PRIVATE
+/* Rationale: Some of the code here does MonoClass construction.
+ * FIXME: Move SRE class construction to class-init.c and unify with ordinary class construction.
+ */
+#define REALLY_INCLUDE_CLASS_DEF 1
+#include <mono/metadata/class-private-definition.h>
+#undef REALLY_INCLUDE_CLASS_DEF
+#endif
 
 static GENERATE_GET_CLASS_WITH_CACHE (marshal_as_attribute, "System.Runtime.InteropServices", "MarshalAsAttribute");
 static GENERATE_GET_CLASS_WITH_CACHE (module_builder, "System.Reflection.Emit", "ModuleBuilder");

--- a/mono/metadata/w32process.c
+++ b/mono/metadata/w32process.c
@@ -430,7 +430,7 @@ ves_icall_System_Diagnostics_FileVersionInfo_GetVersionInfo_internal (MonoObject
 {
 	ERROR_DECL (error);
 
-	stash_system_image (mono_object_class (this_obj)->image);
+	stash_system_image (m_class_get_image (mono_object_class (this_obj)));
 
 	mono_w32process_get_fileversion (this_obj, mono_string_chars (filename), error);
 	if (!mono_error_ok (error)) {
@@ -573,7 +573,7 @@ ves_icall_System_Diagnostics_Process_GetModules_internal (MonoObject *this_obj, 
 	guint32 i, num_added = 0;
 	GPtrArray *assemblies = NULL;
 
-	stash_system_image (mono_object_class (this_obj)->image);
+	stash_system_image (m_class_get_image (mono_object_class (this_obj)));
 
 	if (mono_w32process_get_pid (process) == mono_process_current_pid ()) {
 		assemblies = get_domain_assemblies (mono_domain_get ());


### PR DESCRIPTION
Use `MonoClass` getters in the rest of the code in `mono/metadata/`
1. Add `mono_class_contextbound_bit_offset()` which returns the bit offset of `MonoClass:contextbound` which is needed by `remoting.c`
2. Add `mono_class_create_array_fill_type` which is used by sgen to write over unused nursery fragments.
3. Alllow `metadata-cross-helpers.c` to access `MonoClass` fields directly. Rationale: it needs to compute field offsets.
4. Everything else shouldn't have any functional changes.

https://github.com/mono/mono/issues/6925