### PR TITLE
[2018-02] [metadata] split IL generation code into seperate compilation units.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1421,6 +1421,12 @@ fi
 
 AM_CONDITIONAL(DISABLE_INTERPRETER, test x$mono_feature_disable_interpreter = xyes)
 
+if test "x$mono_feature_disable_interpreter" != "xyes" -o "x$mono_feature_disable_jit" != "xyes"; then
+	AC_DEFINE(ENABLE_ILGEN, 1, [Some VES is available at runtime])
+fi
+
+AM_CONDITIONAL(ENABLE_ILGEN, test x$mono_feature_disable_interpreter != xyes -o x$mono_feature_disable_jit != xyes)
+
 if test "x$mono_feature_disable_simd" = "xyes"; then
 	AC_DEFINE(DISABLE_SIMD, 1, [Disable SIMD intrinsics related optimizations.])
 	AC_MSG_NOTICE([Disabled SIMD support])

--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -85,9 +85,13 @@ if DISABLE_ICALL_TABLES
 icall_table_libraries = libmono-icall-table.la
 endif
 
+if !ENABLE_ILGEN
+ilgen_libraries = libmono-ilgen.la
+endif
+
 noinst_LTLIBRARIES = libmonoruntime-config.la $(boehm_libraries) $(sgen_libraries)
 
-lib_LTLIBRARIES = $(icall_table_libraries)
+lib_LTLIBRARIES = $(icall_table_libraries) $(ilgen_libraries)
 
 AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/mono $(LIBGC_CPPFLAGS) $(GLIB_CFLAGS) $(SHARED_CFLAGS)
 
@@ -122,6 +126,25 @@ libmono_icall_table_la_LIBADD = ../eglib/libeglib.la ../utils/libmonoutils.la ..
 endif
 endif
 
+#
+# This library contains code to generate IL at runtime
+#
+if !ENABLE_ILGEN
+libmono_ilgen_la_SOURCES = \
+	method-builder-ilgen.c \
+	method-builder-ilgen.h \
+	method-builder-ilgen-internals.h \
+	marshal-ilgen.c \
+	marshal-ilgen.h	\
+	sgen-mono-ilgen.c \
+	sgen-mono-ilgen.h
+libmono_ilgen_la_CFLAGS = $(SGEN_DEFINES)
+libmono_ilgen_la_LDFLAGS = $(libmonoldflags)
+if BITCODE
+libmono_ilgen_la_LIBADD = ../eglib/libeglib.la ../utils/libmonoutils.la ../sgen/libmonosgen.la libmonoruntimesgen.la
+endif
+endif
+
 CLEANFILES = mono-bundle.stamp
 
 null_sources = \
@@ -135,6 +158,17 @@ null_gc_sources = \
 if !DISABLE_ICALL_TABLES
 icall_tables_sources = \
 	icall-table.c
+endif
+
+if ENABLE_ILGEN
+ilgen_sources = \
+	method-builder-ilgen.c \
+	method-builder-ilgen.h \
+	method-builder-ilgen-internals.h \
+	marshal-ilgen.c \
+	marshal-ilgen.h	\
+	sgen-mono-ilgen.c \
+	sgen-mono-ilgen.h
 endif
 
 common_sources = \
@@ -200,6 +234,7 @@ common_sources = \
 	metadata-verify.c	\
 	metadata-internals.h	\
 	method-builder.h 	\
+	method-builder-internals.h 	\
 	method-builder.c 	\
 	mono-basic-block.c	\
 	mono-basic-block.h	\
@@ -322,13 +357,14 @@ sgen_sources = \
 	sgen-toggleref.h		\
 	sgen-stw.c				\
 	sgen-mono.c		\
+	sgen-mono.h		\
 	sgen-client-mono.h
 
-libmonoruntime_la_SOURCES = $(common_sources) $(icall_tables_sources) $(gc_dependent_sources) $(null_gc_sources) $(boehm_sources)
+libmonoruntime_la_SOURCES = $(common_sources) $(icall_tables_sources) $(ilgen_sources) $(gc_dependent_sources) $(null_gc_sources) $(boehm_sources)
 libmonoruntime_la_CFLAGS = $(BOEHM_DEFINES)
 libmonoruntime_la_LIBADD = libmonoruntime-config.la
 
-libmonoruntimesgen_la_SOURCES = $(common_sources) $(icall_tables_sources) $(gc_dependent_sources) $(sgen_sources)
+libmonoruntimesgen_la_SOURCES = $(common_sources) $(icall_tables_sources) $(ilgen_sources) $(gc_dependent_sources) $(sgen_sources)
 libmonoruntimesgen_la_CFLAGS = $(SGEN_DEFINES)
 libmonoruntimesgen_la_LIBADD = libmonoruntime-config.la
 

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -18,6 +18,8 @@
 #include <mono/metadata/profiler-private.h>
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/method-builder.h>
+#include <mono/metadata/method-builder-ilgen.h>
+#include <mono/metadata/method-builder-ilgen-internals.h>
 #include <mono/metadata/opcodes.h>
 #include <mono/metadata/domain-internals.h>
 #include <mono/metadata/metadata-internals.h>

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -28,6 +28,7 @@
 #include "mono/metadata/threads.h"
 #include "mono/metadata/monitor.h"
 #include "mono/metadata/metadata-internals.h"
+#include "mono/metadata/method-builder-ilgen-internals.h"
 #include "mono/metadata/domain-internals.h"
 #include "mono/metadata/gc-internals.h"
 #include "mono/metadata/threads-types.h"

--- a/mono/metadata/cominterop.h
+++ b/mono/metadata/cominterop.h
@@ -11,6 +11,7 @@
 #define __MONO_COMINTEROP_H__
 
 #include <mono/metadata/method-builder.h>
+#include <mono/metadata/method-builder-ilgen.h>
 #include <mono/metadata/marshal.h>
 
 void

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -1,0 +1,6495 @@
+/**
+ * \file
+ * Copyright 2018 Microsoft
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+#include "config.h"
+#ifdef HAVE_ALLOCA_H
+#include <alloca.h>
+#endif
+
+#include "metadata/method-builder-ilgen.h"
+#include "metadata/method-builder-ilgen-internals.h"
+#include "object.h"
+#include "loader.h"
+#include "cil-coff.h"
+#include "metadata/marshal.h"
+#include "metadata/marshal-internals.h"
+#include "metadata/marshal-ilgen.h"
+#include "metadata/tabledefs.h"
+#include "metadata/exception.h"
+#include "metadata/appdomain.h"
+#include "mono/metadata/abi-details.h"
+#include "mono/metadata/debug-helpers.h"
+#include "mono/metadata/threads.h"
+#include "mono/metadata/monitor.h"
+#include "mono/metadata/class-internals.h"
+#include "mono/metadata/metadata-internals.h"
+#include "mono/metadata/domain-internals.h"
+#include "mono/metadata/gc-internals.h"
+#include "mono/metadata/threads-types.h"
+#include "mono/metadata/string-icalls.h"
+#include "mono/metadata/attrdefs.h"
+#include "mono/metadata/cominterop.h"
+#include "mono/metadata/remoting.h"
+#include "mono/metadata/reflection-internals.h"
+#include "mono/metadata/threadpool.h"
+#include "mono/metadata/handle.h"
+#include "mono/utils/mono-counters.h"
+#include "mono/utils/mono-tls.h"
+#include "mono/utils/mono-memory-model.h"
+#include "mono/utils/atomic.h"
+#include <mono/utils/mono-threads.h>
+#include <mono/utils/mono-threads-coop.h>
+#include <mono/utils/mono-error-internals.h>
+
+#include <string.h>
+#include <errno.h>
+
+#define OPDEF(a,b,c,d,e,f,g,h,i,j) \
+	a = i,
+
+enum {
+#include "mono/cil/opcode.def"
+	LAST = 0xff
+};
+#undef OPDEF
+
+static GENERATE_GET_CLASS_WITH_CACHE (fixed_buffer_attribute, "System.Runtime.CompilerServices", "FixedBufferAttribute");
+static GENERATE_GET_CLASS_WITH_CACHE (date_time, "System", "DateTime");
+static GENERATE_TRY_GET_CLASS_WITH_CACHE (icustom_marshaler, "System.Runtime.InteropServices", "ICustomMarshaler");
+
+/* MonoMethod pointers to SafeHandle::DangerousAddRef and ::DangerousRelease */
+static MonoMethod *sh_dangerous_add_ref;
+static MonoMethod *sh_dangerous_release;
+
+static void
+init_safe_handle ()
+{
+	sh_dangerous_add_ref = mono_class_get_method_from_name (
+		mono_class_try_get_safehandle_class (), "DangerousAddRef", 1);
+	sh_dangerous_release = mono_class_get_method_from_name (
+		mono_class_try_get_safehandle_class (), "DangerousRelease", 0);
+}
+
+static void
+emit_struct_conv (MonoMethodBuilder *mb, MonoClass *klass, gboolean to_object);
+
+static void
+emit_struct_conv_full (MonoMethodBuilder *mb, MonoClass *klass, gboolean to_object, int offset_of_first_child_field, MonoMarshalNative string_encoding);
+
+/*
+ * mono_mb_emit_exception_marshal_directive:
+ *
+ *   This function assumes ownership of MSG, which should be malloc-ed.
+ */
+static void
+mono_mb_emit_exception_marshal_directive (MonoMethodBuilder *mb, char *msg)
+{
+	char *s;
+
+	if (!mb->dynamic) {
+		s = mono_image_strdup (mb->method->klass->image, msg);
+		g_free (msg);
+	} else {
+		s = g_strdup (msg);
+	}
+	mono_mb_emit_exception_full (mb, "System.Runtime.InteropServices", "MarshalDirectiveException", s);
+}
+
+static int
+offset_of_first_nonstatic_field (MonoClass *klass)
+{
+	int i;
+	int fcount = mono_class_get_field_count (klass);
+	mono_class_setup_fields (klass);
+	for (i = 0; i < fcount; i++) {
+		if (!(klass->fields[i].type->attrs & FIELD_ATTRIBUTE_STATIC) && !mono_field_is_deleted (&klass->fields[i]))
+			return klass->fields[i].offset - sizeof (MonoObject);
+	}
+
+	return 0;
+}
+
+static gboolean
+get_fixed_buffer_attr (MonoClassField *field, MonoType **out_etype, int *out_len)
+{
+	ERROR_DECL (error);
+	MonoCustomAttrInfo *cinfo;
+	MonoCustomAttrEntry *attr;
+	int aindex;
+
+	cinfo = mono_custom_attrs_from_field_checked (field->parent, field, error);
+	if (!is_ok (error))
+		return FALSE;
+	attr = NULL;
+	if (cinfo) {
+		for (aindex = 0; aindex < cinfo->num_attrs; ++aindex) {
+			MonoClass *ctor_class = cinfo->attrs [aindex].ctor->klass;
+			if (mono_class_has_parent (ctor_class, mono_class_get_fixed_buffer_attribute_class ())) {
+				attr = &cinfo->attrs [aindex];
+				break;
+			}
+		}
+	}
+	if (attr) {
+		MonoArray *typed_args, *named_args;
+		CattrNamedArg *arginfo;
+		MonoObject *o;
+
+		mono_reflection_create_custom_attr_data_args (mono_defaults.corlib, attr->ctor, attr->data, attr->data_size, &typed_args, &named_args, &arginfo, error);
+		if (!is_ok (error))
+			return FALSE;
+		g_assert (mono_array_length (typed_args) == 2);
+
+		/* typed args */
+		o = mono_array_get (typed_args, MonoObject*, 0);
+		*out_etype = monotype_cast (o)->type;
+		o = mono_array_get (typed_args, MonoObject*, 1);
+		g_assert (o->vtable->klass == mono_defaults.int32_class);
+		*out_len = *(gint32*)mono_object_unbox (o);
+		g_free (arginfo);
+	}
+	if (cinfo && !cinfo->cached)
+		mono_custom_attrs_free (cinfo);
+	return attr != NULL;
+}
+
+static void
+emit_fixed_buf_conv (MonoMethodBuilder *mb, MonoType *type, MonoType *etype, int len, gboolean to_object, int *out_usize)
+{
+	MonoClass *klass = mono_class_from_mono_type (type);
+	MonoClass *eklass = mono_class_from_mono_type (etype);
+	int esize;
+
+	esize = mono_class_native_size (eklass, NULL);
+
+	MonoMarshalNative string_encoding = klass->unicode ? MONO_NATIVE_LPWSTR : MONO_NATIVE_LPSTR;
+	int usize = mono_class_value_size (eklass, NULL);
+	int msize = mono_class_value_size (eklass, NULL);
+
+	//printf ("FIXED: %s %d %d\n", mono_type_full_name (type), eklass->blittable, string_encoding);
+
+	if (eklass->blittable) {
+		/* copy the elements */
+		mono_mb_emit_ldloc (mb, 1);
+		mono_mb_emit_ldloc (mb, 0);
+		mono_mb_emit_icon (mb, len * esize);
+		mono_mb_emit_byte (mb, CEE_PREFIX1);
+		mono_mb_emit_byte (mb, CEE_CPBLK);
+	} else {
+		int index_var;
+		guint32 label2, label3;
+
+		/* Emit marshalling loop */
+		index_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		mono_mb_emit_byte (mb, CEE_LDC_I4_0);
+		mono_mb_emit_stloc (mb, index_var);
+
+		/* Loop header */
+		label2 = mono_mb_get_label (mb);
+		mono_mb_emit_ldloc (mb, index_var);
+		mono_mb_emit_icon (mb, len);
+		label3 = mono_mb_emit_branch (mb, CEE_BGE);
+
+		/* src/dst is already set */
+
+		/* Do the conversion */
+		MonoTypeEnum t = etype->type;
+		switch (t) {
+		case MONO_TYPE_I4:
+		case MONO_TYPE_U4:
+		case MONO_TYPE_I1:
+		case MONO_TYPE_U1:
+		case MONO_TYPE_BOOLEAN:
+		case MONO_TYPE_I2:
+		case MONO_TYPE_U2:
+		case MONO_TYPE_CHAR:
+		case MONO_TYPE_I8:
+		case MONO_TYPE_U8:
+		case MONO_TYPE_PTR:
+		case MONO_TYPE_R4:
+		case MONO_TYPE_R8:
+			mono_mb_emit_ldloc (mb, 1);
+			mono_mb_emit_ldloc (mb, 0);
+			if (t == MONO_TYPE_CHAR && string_encoding != MONO_NATIVE_LPWSTR) {
+				if (to_object) {
+					mono_mb_emit_byte (mb, CEE_LDIND_U1);
+					mono_mb_emit_byte (mb, CEE_STIND_I2);
+				} else {
+					mono_mb_emit_byte (mb, CEE_LDIND_U2);
+					mono_mb_emit_byte (mb, CEE_STIND_I1);
+				}
+				usize = 1;
+			} else {
+				mono_mb_emit_byte (mb, mono_type_to_ldind (etype));
+				mono_mb_emit_byte (mb, mono_type_to_stind (etype));
+			}
+			break;
+		default:
+			g_assert_not_reached ();
+			break;
+		}
+
+		if (to_object) {
+			mono_mb_emit_add_to_local (mb, 0, usize);
+			mono_mb_emit_add_to_local (mb, 1, msize);
+		} else {
+			mono_mb_emit_add_to_local (mb, 0, msize);
+			mono_mb_emit_add_to_local (mb, 1, usize);
+		}
+
+		/* Loop footer */
+		mono_mb_emit_add_to_local (mb, index_var, 1);
+
+		mono_mb_emit_branch_label (mb, CEE_BR, label2);
+
+		mono_mb_patch_branch (mb, label3);
+	}
+
+	*out_usize = usize * len;
+}
+
+static void
+emit_ptr_to_object_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv conv, MonoMarshalSpec *mspec)
+{
+	switch (conv) {
+	case MONO_MARSHAL_CONV_BOOL_I4:
+		mono_mb_emit_ldloc (mb, 1);
+		mono_mb_emit_ldloc (mb, 0);
+		mono_mb_emit_byte (mb, CEE_LDIND_I4);
+		mono_mb_emit_byte (mb, CEE_BRFALSE_S);
+		mono_mb_emit_byte (mb, 3);
+		mono_mb_emit_byte (mb, CEE_LDC_I4_1);
+		mono_mb_emit_byte (mb, CEE_BR_S);
+		mono_mb_emit_byte (mb, 1);
+		mono_mb_emit_byte (mb, CEE_LDC_I4_0);
+		mono_mb_emit_byte (mb, CEE_STIND_I1);
+		break;
+	case MONO_MARSHAL_CONV_BOOL_VARIANTBOOL:
+		mono_mb_emit_ldloc (mb, 1);
+		mono_mb_emit_ldloc (mb, 0);
+		mono_mb_emit_byte (mb, CEE_LDIND_I2);
+		mono_mb_emit_byte (mb, CEE_BRFALSE_S);
+		mono_mb_emit_byte (mb, 3);
+		mono_mb_emit_byte (mb, CEE_LDC_I4_1);
+		mono_mb_emit_byte (mb, CEE_BR_S);
+		mono_mb_emit_byte (mb, 1);
+		mono_mb_emit_byte (mb, CEE_LDC_I4_0);
+		mono_mb_emit_byte (mb, CEE_STIND_I1);
+		break;
+	case MONO_MARSHAL_CONV_ARRAY_BYVALARRAY: {
+		MonoClass *eklass = NULL;
+		int esize;
+
+		if (type->type == MONO_TYPE_SZARRAY) {
+			eklass = type->data.klass;
+		} else {
+			g_assert_not_reached ();
+		}
+
+		esize = mono_class_native_size (eklass, NULL);
+
+		/* create a new array */
+		mono_mb_emit_ldloc (mb, 1);
+		mono_mb_emit_icon (mb, mspec->data.array_data.num_elem);
+		mono_mb_emit_op (mb, CEE_NEWARR, eklass);	
+		mono_mb_emit_byte (mb, CEE_STIND_REF);
+
+		if (eklass->blittable) {
+			/* copy the elements */
+			mono_mb_emit_ldloc (mb, 1);
+			mono_mb_emit_byte (mb, CEE_LDIND_I);
+			mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoArray, vector));
+			mono_mb_emit_byte (mb, CEE_ADD);
+			mono_mb_emit_ldloc (mb, 0);
+			mono_mb_emit_icon (mb, mspec->data.array_data.num_elem * esize);
+			mono_mb_emit_byte (mb, CEE_PREFIX1);
+			mono_mb_emit_byte (mb, CEE_CPBLK);			
+		}
+		else {
+			int array_var, src_var, dst_var, index_var;
+			guint32 label2, label3;
+
+			array_var = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
+			src_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+			dst_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+
+			/* set array_var */
+			mono_mb_emit_ldloc (mb, 1);
+			mono_mb_emit_byte (mb, CEE_LDIND_REF);
+			mono_mb_emit_stloc (mb, array_var);
+		
+			/* save the old src pointer */
+			mono_mb_emit_ldloc (mb, 0);
+			mono_mb_emit_stloc (mb, src_var);
+			/* save the old dst pointer */
+			mono_mb_emit_ldloc (mb, 1);
+			mono_mb_emit_stloc (mb, dst_var);
+
+			/* Emit marshalling loop */
+			index_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+			mono_mb_emit_byte (mb, CEE_LDC_I4_0);
+			mono_mb_emit_stloc (mb, index_var);
+
+			/* Loop header */
+			label2 = mono_mb_get_label (mb);
+			mono_mb_emit_ldloc (mb, index_var);
+			mono_mb_emit_ldloc (mb, array_var);
+			mono_mb_emit_byte (mb, CEE_LDLEN);
+			label3 = mono_mb_emit_branch (mb, CEE_BGE);
+
+			/* src is already set */
+
+			/* Set dst */
+			mono_mb_emit_ldloc (mb, array_var);
+			mono_mb_emit_ldloc (mb, index_var);
+			mono_mb_emit_op (mb, CEE_LDELEMA, eklass);
+			mono_mb_emit_stloc (mb, 1);
+
+			/* Do the conversion */
+			emit_struct_conv (mb, eklass, TRUE);
+
+			/* Loop footer */
+			mono_mb_emit_add_to_local (mb, index_var, 1);
+
+			mono_mb_emit_branch_label (mb, CEE_BR, label2);
+
+			mono_mb_patch_branch (mb, label3);
+		
+			/* restore the old src pointer */
+			mono_mb_emit_ldloc (mb, src_var);
+			mono_mb_emit_stloc (mb, 0);
+			/* restore the old dst pointer */
+			mono_mb_emit_ldloc (mb, dst_var);
+			mono_mb_emit_stloc (mb, 1);
+		}
+		break;
+	}
+	case MONO_MARSHAL_CONV_ARRAY_BYVALCHARARRAY: {
+		MonoClass *eclass = mono_defaults.char_class;
+
+		/* create a new array */
+		mono_mb_emit_ldloc (mb, 1);
+		mono_mb_emit_icon (mb, mspec->data.array_data.num_elem);
+		mono_mb_emit_op (mb, CEE_NEWARR, eclass);	
+		mono_mb_emit_byte (mb, CEE_STIND_REF);
+
+		mono_mb_emit_ldloc (mb, 1);
+		mono_mb_emit_byte (mb, CEE_LDIND_REF);
+		mono_mb_emit_ldloc (mb, 0);
+		mono_mb_emit_icon (mb, mspec->data.array_data.num_elem);
+		mono_mb_emit_icall (mb, mono_byvalarray_to_byte_array);
+		break;
+	}
+	case MONO_MARSHAL_CONV_STR_BYVALSTR: 
+		if (mspec && mspec->native == MONO_NATIVE_BYVALTSTR && mspec->data.array_data.num_elem) {
+			mono_mb_emit_ldloc (mb, 1);
+			mono_mb_emit_ldloc (mb, 0);
+			mono_mb_emit_icon (mb, mspec->data.array_data.num_elem);
+			mono_mb_emit_icall (mb, mono_string_from_byvalstr);
+		} else {
+			mono_mb_emit_ldloc (mb, 1);
+			mono_mb_emit_ldloc (mb, 0);
+			mono_mb_emit_icall (mb, ves_icall_string_new_wrapper);
+		}
+		mono_mb_emit_byte (mb, CEE_STIND_REF);		
+		break;
+	case MONO_MARSHAL_CONV_STR_BYVALWSTR:
+		if (mspec && mspec->native == MONO_NATIVE_BYVALTSTR && mspec->data.array_data.num_elem) {
+			mono_mb_emit_ldloc (mb, 1);
+			mono_mb_emit_ldloc (mb, 0);
+			mono_mb_emit_icon (mb, mspec->data.array_data.num_elem);
+			mono_mb_emit_icall (mb, mono_string_from_byvalwstr);
+		} else {
+			mono_mb_emit_ldloc (mb, 1);
+			mono_mb_emit_ldloc (mb, 0);
+			mono_mb_emit_icall (mb, ves_icall_mono_string_from_utf16);
+		}
+		mono_mb_emit_byte (mb, CEE_STIND_REF);		
+		break;		
+	case MONO_MARSHAL_CONV_STR_LPTSTR:
+		mono_mb_emit_ldloc (mb, 1);
+		mono_mb_emit_ldloc (mb, 0);
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+#ifdef TARGET_WIN32
+		mono_mb_emit_icall (mb, ves_icall_mono_string_from_utf16);
+#else
+		mono_mb_emit_icall (mb, ves_icall_string_new_wrapper);
+#endif
+		mono_mb_emit_byte (mb, CEE_STIND_REF);	
+		break;
+
+		// In Mono historically LPSTR was treated as a UTF8STR
+	case MONO_MARSHAL_CONV_STR_LPSTR:
+	case MONO_MARSHAL_CONV_STR_UTF8STR:
+		mono_mb_emit_ldloc (mb, 1);
+		mono_mb_emit_ldloc (mb, 0);
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+		mono_mb_emit_icall (mb, ves_icall_string_new_wrapper);
+		mono_mb_emit_byte (mb, CEE_STIND_REF);		
+		break;
+	case MONO_MARSHAL_CONV_STR_LPWSTR:
+		mono_mb_emit_ldloc (mb, 1);
+		mono_mb_emit_ldloc (mb, 0);
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+		mono_mb_emit_icall (mb, ves_icall_mono_string_from_utf16);
+		mono_mb_emit_byte (mb, CEE_STIND_REF);
+		break;
+	case MONO_MARSHAL_CONV_OBJECT_STRUCT: {
+		MonoClass *klass = mono_class_from_mono_type (type);
+		int src_var, dst_var;
+
+		src_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		dst_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		
+		/* *dst = new object */
+		mono_mb_emit_ldloc (mb, 1);
+		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+		mono_mb_emit_op (mb, CEE_MONO_NEWOBJ, klass);	
+		mono_mb_emit_byte (mb, CEE_STIND_REF);
+	
+		/* save the old src pointer */
+		mono_mb_emit_ldloc (mb, 0);
+		mono_mb_emit_stloc (mb, src_var);
+		/* save the old dst pointer */
+		mono_mb_emit_ldloc (mb, 1);
+		mono_mb_emit_stloc (mb, dst_var);
+
+		/* dst = pointer to newly created object data */
+		mono_mb_emit_ldloc (mb, 1);
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+		mono_mb_emit_icon (mb, sizeof (MonoObject));
+		mono_mb_emit_byte (mb, CEE_ADD);
+		mono_mb_emit_stloc (mb, 1); 
+
+		emit_struct_conv (mb, klass, TRUE);
+		
+		/* restore the old src pointer */
+		mono_mb_emit_ldloc (mb, src_var);
+		mono_mb_emit_stloc (mb, 0);
+		/* restore the old dst pointer */
+		mono_mb_emit_ldloc (mb, dst_var);
+		mono_mb_emit_stloc (mb, 1);
+		break;
+	}
+	case MONO_MARSHAL_CONV_DEL_FTN: {
+		MonoClass *klass = mono_class_from_mono_type (type);
+
+		mono_mb_emit_ldloc (mb, 1);
+		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+		mono_mb_emit_op (mb, CEE_MONO_CLASSCONST, klass);
+		mono_mb_emit_ldloc (mb, 0);
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+		mono_mb_emit_icall (mb, mono_ftnptr_to_delegate);
+		mono_mb_emit_byte (mb, CEE_STIND_REF);
+		break;
+	}
+	case MONO_MARSHAL_CONV_ARRAY_LPARRAY:
+		g_error ("Structure field of type %s can't be marshalled as LPArray", mono_class_from_mono_type (type)->name);
+		break;
+
+#ifndef DISABLE_COM
+	case MONO_MARSHAL_CONV_OBJECT_INTERFACE:
+	case MONO_MARSHAL_CONV_OBJECT_IUNKNOWN:
+	case MONO_MARSHAL_CONV_OBJECT_IDISPATCH:
+		mono_cominterop_emit_ptr_to_object_conv (mb, type, conv, mspec);
+		break;
+#endif /* DISABLE_COM */
+
+	case MONO_MARSHAL_CONV_SAFEHANDLE: {
+		/*
+		 * Passing SafeHandles as ref does not allow the unmanaged code
+		 * to change the SafeHandle value.   If the value is changed,
+		 * we should issue a diagnostic exception (NotSupportedException)
+		 * that informs the user that changes to handles in unmanaged code
+		 * is not supported. 
+		 *
+		 * Since we currently have no access to the original
+		 * SafeHandle that was used during the marshalling,
+		 * for now we just ignore this, and ignore/discard any
+		 * changes that might have happened to the handle.
+		 */
+		break;
+	}
+		
+	case MONO_MARSHAL_CONV_HANDLEREF: {
+		/*
+		 * Passing HandleRefs in a struct that is ref()ed does not 
+		 * copy the values back to the HandleRef
+		 */
+		break;
+	}
+		
+	case MONO_MARSHAL_CONV_STR_BSTR:
+	case MONO_MARSHAL_CONV_STR_ANSIBSTR:
+	case MONO_MARSHAL_CONV_STR_TBSTR:
+	case MONO_MARSHAL_CONV_ARRAY_SAVEARRAY:
+	default: {
+		char *msg = g_strdup_printf ("marshaling conversion %d not implemented", conv);
+
+		mono_mb_emit_exception_marshal_directive (mb, msg);
+		break;
+	}
+	}
+}
+
+static gpointer
+conv_to_icall (MonoMarshalConv conv, int *ind_store_type)
+{
+	int dummy;
+	if (!ind_store_type)
+		ind_store_type = &dummy;
+	*ind_store_type = CEE_STIND_I;
+	switch (conv) {
+	case MONO_MARSHAL_CONV_STR_LPWSTR:
+		return mono_marshal_string_to_utf16;		
+	case MONO_MARSHAL_CONV_LPWSTR_STR:
+		*ind_store_type = CEE_STIND_REF;
+		return ves_icall_mono_string_from_utf16;
+	case MONO_MARSHAL_CONV_LPTSTR_STR:
+		*ind_store_type = CEE_STIND_REF;
+		return ves_icall_string_new_wrapper;
+	case MONO_MARSHAL_CONV_UTF8STR_STR:
+	case MONO_MARSHAL_CONV_LPSTR_STR:
+		*ind_store_type = CEE_STIND_REF;
+		return ves_icall_string_new_wrapper;
+	case MONO_MARSHAL_CONV_STR_LPTSTR:
+#ifdef TARGET_WIN32
+		return mono_marshal_string_to_utf16;
+#else
+		return mono_string_to_utf8str;
+#endif
+		// In Mono historically LPSTR was treated as a UTF8STR
+	case MONO_MARSHAL_CONV_STR_UTF8STR:
+	case MONO_MARSHAL_CONV_STR_LPSTR:
+		return mono_string_to_utf8str;
+	case MONO_MARSHAL_CONV_STR_BSTR:
+		return mono_string_to_bstr;
+	case MONO_MARSHAL_CONV_BSTR_STR:
+		*ind_store_type = CEE_STIND_REF;
+		return mono_string_from_bstr_icall;
+	case MONO_MARSHAL_CONV_STR_TBSTR:
+	case MONO_MARSHAL_CONV_STR_ANSIBSTR:
+		return mono_string_to_ansibstr;
+	case MONO_MARSHAL_CONV_SB_UTF8STR:
+	case MONO_MARSHAL_CONV_SB_LPSTR:
+		return mono_string_builder_to_utf8;
+	case MONO_MARSHAL_CONV_SB_LPTSTR:
+#ifdef TARGET_WIN32
+		return mono_string_builder_to_utf16;
+#else
+		return mono_string_builder_to_utf8;
+#endif
+	case MONO_MARSHAL_CONV_SB_LPWSTR:
+		return mono_string_builder_to_utf16;
+	case MONO_MARSHAL_CONV_ARRAY_SAVEARRAY:
+		return mono_array_to_savearray;
+	case MONO_MARSHAL_CONV_ARRAY_LPARRAY:
+		return mono_array_to_lparray;
+	case MONO_MARSHAL_FREE_LPARRAY:
+		return mono_free_lparray;
+	case MONO_MARSHAL_CONV_DEL_FTN:
+		return mono_delegate_to_ftnptr;
+	case MONO_MARSHAL_CONV_FTN_DEL:
+		*ind_store_type = CEE_STIND_REF;
+		return mono_ftnptr_to_delegate;
+	case MONO_MARSHAL_CONV_UTF8STR_SB:
+	case MONO_MARSHAL_CONV_LPSTR_SB:
+		*ind_store_type = CEE_STIND_REF;
+		return mono_string_utf8_to_builder;
+	case MONO_MARSHAL_CONV_LPTSTR_SB:
+		*ind_store_type = CEE_STIND_REF;
+#ifdef TARGET_WIN32
+		return mono_string_utf16_to_builder;
+#else
+		return mono_string_utf8_to_builder;
+#endif
+	case MONO_MARSHAL_CONV_LPWSTR_SB:
+		*ind_store_type = CEE_STIND_REF;
+		return mono_string_utf16_to_builder;
+	case MONO_MARSHAL_FREE_ARRAY:
+		return mono_marshal_free_array;
+	case MONO_MARSHAL_CONV_STR_BYVALSTR:
+		return mono_string_to_byvalstr;
+	case MONO_MARSHAL_CONV_STR_BYVALWSTR:
+		return mono_string_to_byvalwstr;
+	default:
+		g_assert_not_reached ();
+	}
+
+	return NULL;
+}
+
+static void
+emit_object_to_ptr_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv conv, MonoMarshalSpec *mspec)
+{
+	int pos;
+	int stind_op;
+
+	switch (conv) {
+	case MONO_MARSHAL_CONV_BOOL_I4:
+		mono_mb_emit_ldloc (mb, 1);
+		mono_mb_emit_ldloc (mb, 0);
+		mono_mb_emit_byte (mb, CEE_LDIND_U1);
+		mono_mb_emit_byte (mb, CEE_STIND_I4);
+		break;
+	case MONO_MARSHAL_CONV_BOOL_VARIANTBOOL:
+		mono_mb_emit_ldloc (mb, 1);
+		mono_mb_emit_ldloc (mb, 0);
+		mono_mb_emit_byte (mb, CEE_LDIND_U1);
+		mono_mb_emit_byte (mb, CEE_NEG);
+		mono_mb_emit_byte (mb, CEE_STIND_I2);
+		break;
+	// In Mono historically LPSTR was treated as a UTF8STR
+	case MONO_MARSHAL_CONV_STR_UTF8STR:
+	case MONO_MARSHAL_CONV_STR_LPWSTR:
+	case MONO_MARSHAL_CONV_STR_LPSTR:
+	case MONO_MARSHAL_CONV_STR_LPTSTR:
+	case MONO_MARSHAL_CONV_STR_BSTR:
+	case MONO_MARSHAL_CONV_STR_ANSIBSTR:
+	case MONO_MARSHAL_CONV_STR_TBSTR: {
+		int pos;
+
+		/* free space if free == true */
+		mono_mb_emit_ldloc (mb, 2);
+		pos = mono_mb_emit_short_branch (mb, CEE_BRFALSE_S);
+		mono_mb_emit_ldloc (mb, 1);
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+		mono_mb_emit_icall (mb, g_free);
+		mono_mb_patch_short_branch (mb, pos);
+
+		mono_mb_emit_ldloc (mb, 1);
+		mono_mb_emit_ldloc (mb, 0);
+		mono_mb_emit_byte (mb, CEE_LDIND_REF);
+		mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
+		mono_mb_emit_byte (mb, stind_op);
+		break;
+	}
+	case MONO_MARSHAL_CONV_ARRAY_SAVEARRAY:
+	case MONO_MARSHAL_CONV_ARRAY_LPARRAY:
+	case MONO_MARSHAL_CONV_DEL_FTN:
+		mono_mb_emit_ldloc (mb, 1);
+		mono_mb_emit_ldloc (mb, 0);
+		mono_mb_emit_byte (mb, CEE_LDIND_REF);
+		mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
+		mono_mb_emit_byte (mb, stind_op);
+		break;
+	case MONO_MARSHAL_CONV_STR_BYVALSTR: 
+	case MONO_MARSHAL_CONV_STR_BYVALWSTR: {
+		g_assert (mspec);
+
+		mono_mb_emit_ldloc (mb, 1); /* dst */
+		mono_mb_emit_ldloc (mb, 0);	
+		mono_mb_emit_byte (mb, CEE_LDIND_REF); /* src String */
+		mono_mb_emit_icon (mb, mspec->data.array_data.num_elem);
+		mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+		break;
+	}
+	case MONO_MARSHAL_CONV_ARRAY_BYVALARRAY: {
+		MonoClass *eklass = NULL;
+		int esize;
+
+		if (type->type == MONO_TYPE_SZARRAY) {
+			eklass = type->data.klass;
+		} else {
+			g_assert_not_reached ();
+		}
+
+		if (eklass->valuetype)
+			esize = mono_class_native_size (eklass, NULL);
+		else
+			esize = sizeof (gpointer);
+
+		mono_mb_emit_ldloc (mb, 0);
+		mono_mb_emit_byte (mb, CEE_LDIND_REF);
+		pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+		if (eklass->blittable) {
+			mono_mb_emit_ldloc (mb, 1);
+			mono_mb_emit_ldloc (mb, 0);	
+			mono_mb_emit_byte (mb, CEE_LDIND_REF);	
+			mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoArray, vector));
+			mono_mb_emit_icon (mb, mspec->data.array_data.num_elem * esize);
+			mono_mb_emit_byte (mb, CEE_PREFIX1);
+			mono_mb_emit_byte (mb, CEE_CPBLK);			
+		} else {
+			int array_var, src_var, dst_var, index_var;
+			guint32 label2, label3;
+
+			array_var = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
+			src_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+			dst_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+
+			/* set array_var */
+			mono_mb_emit_ldloc (mb, 0);	
+			mono_mb_emit_byte (mb, CEE_LDIND_REF);
+			mono_mb_emit_stloc (mb, array_var);
+
+			/* save the old src pointer */
+			mono_mb_emit_ldloc (mb, 0);
+			mono_mb_emit_stloc (mb, src_var);
+			/* save the old dst pointer */
+			mono_mb_emit_ldloc (mb, 1);
+			mono_mb_emit_stloc (mb, dst_var);
+
+			/* Emit marshalling loop */
+			index_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+			mono_mb_emit_byte (mb, CEE_LDC_I4_0);
+			mono_mb_emit_stloc (mb, index_var);
+
+			/* Loop header */
+			label2 = mono_mb_get_label (mb);
+			mono_mb_emit_ldloc (mb, index_var);
+			mono_mb_emit_ldloc (mb, array_var);
+			mono_mb_emit_byte (mb, CEE_LDLEN);
+			label3 = mono_mb_emit_branch (mb, CEE_BGE);
+
+			/* Set src */
+			mono_mb_emit_ldloc (mb, array_var);
+			mono_mb_emit_ldloc (mb, index_var);
+			mono_mb_emit_op (mb, CEE_LDELEMA, eklass);
+			mono_mb_emit_stloc (mb, 0);
+
+			/* dst is already set */
+
+			/* Do the conversion */
+			emit_struct_conv (mb, eklass, FALSE);
+
+			/* Loop footer */
+			mono_mb_emit_add_to_local (mb, index_var, 1);
+
+			mono_mb_emit_branch_label (mb, CEE_BR, label2);
+
+			mono_mb_patch_branch (mb, label3);
+		
+			/* restore the old src pointer */
+			mono_mb_emit_ldloc (mb, src_var);
+			mono_mb_emit_stloc (mb, 0);
+			/* restore the old dst pointer */
+			mono_mb_emit_ldloc (mb, dst_var);
+			mono_mb_emit_stloc (mb, 1);
+		}
+
+		mono_mb_patch_branch (mb, pos);
+		break;
+	}
+	case MONO_MARSHAL_CONV_ARRAY_BYVALCHARARRAY: {
+		mono_mb_emit_ldloc (mb, 0);
+		mono_mb_emit_byte (mb, CEE_LDIND_REF);
+		pos = mono_mb_emit_short_branch (mb, CEE_BRFALSE_S);
+
+		mono_mb_emit_ldloc (mb, 1);
+		mono_mb_emit_ldloc (mb, 0);	
+		mono_mb_emit_byte (mb, CEE_LDIND_REF);
+		mono_mb_emit_icon (mb, mspec->data.array_data.num_elem);
+		mono_mb_emit_icall (mb, mono_array_to_byte_byvalarray);
+		mono_mb_patch_short_branch (mb, pos);
+		break;
+	}
+	case MONO_MARSHAL_CONV_OBJECT_STRUCT: {
+		int src_var, dst_var;
+
+		src_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		dst_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		
+		mono_mb_emit_ldloc (mb, 0);
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+		pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
+		
+		/* save the old src pointer */
+		mono_mb_emit_ldloc (mb, 0);
+		mono_mb_emit_stloc (mb, src_var);
+		/* save the old dst pointer */
+		mono_mb_emit_ldloc (mb, 1);
+		mono_mb_emit_stloc (mb, dst_var);
+
+		/* src = pointer to object data */
+		mono_mb_emit_ldloc (mb, 0);
+		mono_mb_emit_byte (mb, CEE_LDIND_I);		
+		mono_mb_emit_icon (mb, sizeof (MonoObject));
+		mono_mb_emit_byte (mb, CEE_ADD);
+		mono_mb_emit_stloc (mb, 0); 
+
+		emit_struct_conv (mb, mono_class_from_mono_type (type), FALSE);
+		
+		/* restore the old src pointer */
+		mono_mb_emit_ldloc (mb, src_var);
+		mono_mb_emit_stloc (mb, 0);
+		/* restore the old dst pointer */
+		mono_mb_emit_ldloc (mb, dst_var);
+		mono_mb_emit_stloc (mb, 1);
+
+		mono_mb_patch_branch (mb, pos);
+		break;
+	}
+
+#ifndef DISABLE_COM
+	case MONO_MARSHAL_CONV_OBJECT_INTERFACE:
+	case MONO_MARSHAL_CONV_OBJECT_IDISPATCH:
+	case MONO_MARSHAL_CONV_OBJECT_IUNKNOWN:
+		mono_cominterop_emit_object_to_ptr_conv (mb, type, conv, mspec);
+		break;
+#endif /* DISABLE_COM */
+
+	case MONO_MARSHAL_CONV_SAFEHANDLE: {
+		int pos;
+		
+		mono_mb_emit_ldloc (mb, 0);
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+		pos = mono_mb_emit_branch (mb, CEE_BRTRUE);
+		mono_mb_emit_exception (mb, "ArgumentNullException", NULL);
+		mono_mb_patch_branch (mb, pos);
+		
+		/* Pull the handle field from SafeHandle */
+		mono_mb_emit_ldloc (mb, 1);
+		mono_mb_emit_ldloc (mb, 0);
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoSafeHandle, handle));
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+		mono_mb_emit_byte (mb, CEE_STIND_I);
+		break;
+	}
+
+	case MONO_MARSHAL_CONV_HANDLEREF: {
+		mono_mb_emit_ldloc (mb, 1);
+		mono_mb_emit_ldloc (mb, 0);
+		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoHandleRef, handle));
+		mono_mb_emit_byte (mb, CEE_ADD);
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+		mono_mb_emit_byte (mb, CEE_STIND_I);
+		break;
+	}
+		
+	default: {
+		g_error ("marshalling conversion %d not implemented", conv);
+	}
+	}
+}
+
+
+static void
+emit_struct_conv_full (MonoMethodBuilder *mb, MonoClass *klass, gboolean to_object,
+						int offset_of_first_child_field, MonoMarshalNative string_encoding)
+{
+	MonoMarshalType *info;
+	int i;
+
+	if (klass->parent)
+		emit_struct_conv_full (mb, klass->parent, to_object, offset_of_first_nonstatic_field (klass), string_encoding);
+
+	info = mono_marshal_load_type_info (klass);
+
+	if (info->native_size == 0)
+		return;
+
+	if (klass->blittable) {
+		int usize = mono_class_value_size (klass, NULL);
+		g_assert (usize == info->native_size);
+		mono_mb_emit_ldloc (mb, 1);
+		mono_mb_emit_ldloc (mb, 0);
+		mono_mb_emit_icon (mb, usize);
+		mono_mb_emit_byte (mb, CEE_PREFIX1);
+		mono_mb_emit_byte (mb, CEE_CPBLK);
+
+		if (to_object) {
+			mono_mb_emit_add_to_local (mb, 0, usize);
+			mono_mb_emit_add_to_local (mb, 1, offset_of_first_child_field);
+		} else {
+			mono_mb_emit_add_to_local (mb, 0, offset_of_first_child_field);
+			mono_mb_emit_add_to_local (mb, 1, usize);
+		}
+		return;
+	}
+
+	if (klass != mono_class_try_get_safehandle_class ()) {
+		if (mono_class_is_auto_layout (klass)) {
+			char *msg = g_strdup_printf ("Type %s which is passed to unmanaged code must have a StructLayout attribute.",
+										 mono_type_full_name (&klass->byval_arg));
+			mono_mb_emit_exception_marshal_directive (mb, msg);
+			return;
+		}
+	}
+
+	for (i = 0; i < info->num_fields; i++) {
+		MonoMarshalNative ntype;
+		MonoMarshalConv conv;
+		MonoType *ftype = info->fields [i].field->type;
+		int msize = 0;
+		int usize = 0;
+		gboolean last_field = i < (info->num_fields -1) ? 0 : 1;
+
+		if (ftype->attrs & FIELD_ATTRIBUTE_STATIC)
+			continue;
+
+		ntype = (MonoMarshalNative)mono_type_to_unmanaged (ftype, info->fields [i].mspec, TRUE, klass->unicode, &conv);
+
+		if (last_field) {
+			msize = klass->instance_size - info->fields [i].field->offset;
+			usize = info->native_size - info->fields [i].offset;
+		} else {
+			msize = info->fields [i + 1].field->offset - info->fields [i].field->offset;
+			usize = info->fields [i + 1].offset - info->fields [i].offset;
+		}
+
+		if (klass != mono_class_try_get_safehandle_class ()){
+			/* 
+			 * FIXME: Should really check for usize==0 and msize>0, but we apply 
+			 * the layout to the managed structure as well.
+			 */
+			
+			if (mono_class_is_explicit_layout (klass) && (usize == 0)) {
+				if (MONO_TYPE_IS_REFERENCE (info->fields [i].field->type) ||
+				    ((!last_field && MONO_TYPE_IS_REFERENCE (info->fields [i + 1].field->type))))
+					g_error ("Type %s which has an [ExplicitLayout] attribute cannot have a "
+						 "reference field at the same offset as another field.",
+						 mono_type_full_name (&klass->byval_arg));
+			}
+		}
+		
+		switch (conv) {
+		case MONO_MARSHAL_CONV_NONE: {
+			int t;
+
+			//XXX a byref field!?!? that's not allowed! and worse, it might miss a WB
+			g_assert (!ftype->byref);
+			if (ftype->type == MONO_TYPE_I || ftype->type == MONO_TYPE_U) {
+				mono_mb_emit_ldloc (mb, 1);
+				mono_mb_emit_ldloc (mb, 0);
+				mono_mb_emit_byte (mb, CEE_LDIND_I);
+				mono_mb_emit_byte (mb, CEE_STIND_I);
+				break;
+			}
+
+		handle_enum:
+			t = ftype->type;
+			switch (t) {
+			case MONO_TYPE_I4:
+			case MONO_TYPE_U4:
+			case MONO_TYPE_I1:
+			case MONO_TYPE_U1:
+			case MONO_TYPE_BOOLEAN:
+			case MONO_TYPE_I2:
+			case MONO_TYPE_U2:
+			case MONO_TYPE_CHAR:
+			case MONO_TYPE_I8:
+			case MONO_TYPE_U8:
+			case MONO_TYPE_PTR:
+			case MONO_TYPE_R4:
+			case MONO_TYPE_R8:
+				mono_mb_emit_ldloc (mb, 1);
+				mono_mb_emit_ldloc (mb, 0);
+				if (t == MONO_TYPE_CHAR && ntype == MONO_NATIVE_U1 && string_encoding != MONO_NATIVE_LPWSTR) {
+					if (to_object) {
+						mono_mb_emit_byte (mb, CEE_LDIND_U1);
+						mono_mb_emit_byte (mb, CEE_STIND_I2);
+					} else {
+						mono_mb_emit_byte (mb, CEE_LDIND_U2);
+						mono_mb_emit_byte (mb, CEE_STIND_I1);
+					}
+				} else {
+					mono_mb_emit_byte (mb, mono_type_to_ldind (ftype));
+					mono_mb_emit_byte (mb, mono_type_to_stind (ftype));
+				}
+				break;
+			case MONO_TYPE_VALUETYPE: {
+				int src_var, dst_var;
+				MonoType *etype;
+				int len;
+
+				if (ftype->data.klass->enumtype) {
+					ftype = mono_class_enum_basetype (ftype->data.klass);
+					goto handle_enum;
+				}
+
+				src_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+				dst_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+	
+				/* save the old src pointer */
+				mono_mb_emit_ldloc (mb, 0);
+				mono_mb_emit_stloc (mb, src_var);
+				/* save the old dst pointer */
+				mono_mb_emit_ldloc (mb, 1);
+				mono_mb_emit_stloc (mb, dst_var);
+
+				if (get_fixed_buffer_attr (info->fields [i].field, &etype, &len)) {
+					emit_fixed_buf_conv (mb, ftype, etype, len, to_object, &usize);
+				} else {
+					emit_struct_conv (mb, ftype->data.klass, to_object);
+				}
+
+				/* restore the old src pointer */
+				mono_mb_emit_ldloc (mb, src_var);
+				mono_mb_emit_stloc (mb, 0);
+				/* restore the old dst pointer */
+				mono_mb_emit_ldloc (mb, dst_var);
+				mono_mb_emit_stloc (mb, 1);
+				break;
+			}
+			case MONO_TYPE_OBJECT: {
+#ifndef DISABLE_COM
+				if (to_object) {
+					static MonoMethod *variant_clear = NULL;
+					static MonoMethod *get_object_for_native_variant = NULL;
+
+					if (!variant_clear)
+						variant_clear = mono_class_get_method_from_name (mono_class_get_variant_class (), "Clear", 0);
+					if (!get_object_for_native_variant)
+						get_object_for_native_variant = mono_class_get_method_from_name (mono_defaults.marshal_class, "GetObjectForNativeVariant", 1);
+					mono_mb_emit_ldloc (mb, 1);
+					mono_mb_emit_ldloc (mb, 0);
+					mono_mb_emit_managed_call (mb, get_object_for_native_variant, NULL);
+					mono_mb_emit_byte (mb, CEE_STIND_REF);
+
+					mono_mb_emit_ldloc (mb, 0);
+					mono_mb_emit_managed_call (mb, variant_clear, NULL);
+				}
+				else {
+					static MonoMethod *get_native_variant_for_object = NULL;
+
+					if (!get_native_variant_for_object)
+						get_native_variant_for_object = mono_class_get_method_from_name (mono_defaults.marshal_class, "GetNativeVariantForObject", 2);
+
+					mono_mb_emit_ldloc (mb, 0);
+					mono_mb_emit_byte(mb, CEE_LDIND_REF);
+					mono_mb_emit_ldloc (mb, 1);
+					mono_mb_emit_managed_call (mb, get_native_variant_for_object, NULL);
+				}
+#else
+				char *msg = g_strdup_printf ("COM support was disabled at compilation time.");
+				mono_mb_emit_exception_marshal_directive (mb, msg);
+#endif
+				break;
+			}
+
+			default: 
+				g_warning ("marshaling type %02x not implemented", ftype->type);
+				g_assert_not_reached ();
+			}
+			break;
+		}
+		default: {
+			int src_var, dst_var;
+
+			src_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+			dst_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+
+			/* save the old src pointer */
+			mono_mb_emit_ldloc (mb, 0);
+			mono_mb_emit_stloc (mb, src_var);
+			/* save the old dst pointer */
+			mono_mb_emit_ldloc (mb, 1);
+			mono_mb_emit_stloc (mb, dst_var);
+
+			if (to_object) 
+				emit_ptr_to_object_conv (mb, ftype, conv, info->fields [i].mspec);
+			else
+				emit_object_to_ptr_conv (mb, ftype, conv, info->fields [i].mspec);
+
+			/* restore the old src pointer */
+			mono_mb_emit_ldloc (mb, src_var);
+			mono_mb_emit_stloc (mb, 0);
+			/* restore the old dst pointer */
+			mono_mb_emit_ldloc (mb, dst_var);
+			mono_mb_emit_stloc (mb, 1);
+		}
+		}
+
+		if (to_object) {
+			mono_mb_emit_add_to_local (mb, 0, usize);
+			mono_mb_emit_add_to_local (mb, 1, msize);
+		} else {
+			mono_mb_emit_add_to_local (mb, 0, msize);
+			mono_mb_emit_add_to_local (mb, 1, usize);
+		}				
+	}
+}
+
+static void
+emit_struct_conv (MonoMethodBuilder *mb, MonoClass *klass, gboolean to_object)
+{
+	emit_struct_conv_full (mb, klass, to_object, 0, (MonoMarshalNative)-1);
+}
+
+static void
+emit_struct_free (MonoMethodBuilder *mb, MonoClass *klass, int struct_var)
+{
+	/* Call DestroyStructure */
+	/* FIXME: Only do this if needed */
+	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+	mono_mb_emit_op (mb, CEE_MONO_CLASSCONST, klass);
+	mono_mb_emit_ldloc (mb, struct_var);
+	mono_mb_emit_icall (mb, mono_struct_delete_old);
+}
+
+static void
+emit_thread_interrupt_checkpoint_call (MonoMethodBuilder *mb, gpointer checkpoint_func)
+{
+	int pos_noabort, pos_noex;
+
+	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+	mono_mb_emit_byte (mb, CEE_MONO_LDPTR_INT_REQ_FLAG);
+	mono_mb_emit_byte (mb, CEE_LDIND_U4);
+	pos_noabort = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+	mono_mb_emit_byte (mb, CEE_MONO_NOT_TAKEN);
+
+	mono_mb_emit_icall (mb, checkpoint_func);
+	/* Throw the exception returned by the checkpoint function, if any */
+	mono_mb_emit_byte (mb, CEE_DUP);
+	pos_noex = mono_mb_emit_branch (mb, CEE_BRFALSE);
+	mono_mb_emit_byte (mb, CEE_THROW);
+	mono_mb_patch_branch (mb, pos_noex);
+	mono_mb_emit_byte (mb, CEE_POP);
+	
+	mono_mb_patch_branch (mb, pos_noabort);
+}
+
+static void
+emit_thread_interrupt_checkpoint (MonoMethodBuilder *mb)
+{
+	if (strstr (mb->name, "mono_thread_interruption_checkpoint"))
+		return;
+	
+	emit_thread_interrupt_checkpoint_call (mb, mono_thread_interruption_checkpoint);
+}
+
+static void
+emit_thread_force_interrupt_checkpoint (MonoMethodBuilder *mb)
+{
+	emit_thread_interrupt_checkpoint_call (mb, mono_thread_force_interruption_checkpoint_noraise);
+}
+
+void
+mono_marshal_emit_thread_interrupt_checkpoint (MonoMethodBuilder *mb)
+{
+	emit_thread_interrupt_checkpoint (mb);
+}
+
+void
+mono_marshal_emit_thread_force_interrupt_checkpoint (MonoMethodBuilder *mb)
+{
+	emit_thread_force_interrupt_checkpoint (mb);
+}
+
+int
+mono_mb_emit_save_args (MonoMethodBuilder *mb, MonoMethodSignature *sig, gboolean save_this)
+{
+	int i, params_var, tmp_var;
+
+	/* allocate local (pointer) *params[] */
+	params_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+	/* allocate local (pointer) tmp */
+	tmp_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+
+	/* alloate space on stack to store an array of pointers to the arguments */
+	mono_mb_emit_icon (mb, sizeof (gpointer) * (sig->param_count + 1));
+	mono_mb_emit_byte (mb, CEE_PREFIX1);
+	mono_mb_emit_byte (mb, CEE_LOCALLOC);
+	mono_mb_emit_stloc (mb, params_var);
+
+	/* tmp = params */
+	mono_mb_emit_ldloc (mb, params_var);
+	mono_mb_emit_stloc (mb, tmp_var);
+
+	if (save_this && sig->hasthis) {
+		mono_mb_emit_ldloc (mb, tmp_var);
+		mono_mb_emit_ldarg_addr (mb, 0);
+		mono_mb_emit_byte (mb, CEE_STIND_I);
+		/* tmp = tmp + sizeof (gpointer) */
+		if (sig->param_count)
+			mono_mb_emit_add_to_local (mb, tmp_var, sizeof (gpointer));
+
+	}
+
+	for (i = 0; i < sig->param_count; i++) {
+		mono_mb_emit_ldloc (mb, tmp_var);
+		mono_mb_emit_ldarg_addr (mb, i + sig->hasthis);
+		mono_mb_emit_byte (mb, CEE_STIND_I);
+		/* tmp = tmp + sizeof (gpointer) */
+		if (i < (sig->param_count - 1))
+			mono_mb_emit_add_to_local (mb, tmp_var, sizeof (gpointer));
+	}
+
+	return params_var;
+}
+
+
+void
+mono_mb_emit_restore_result (MonoMethodBuilder *mb, MonoType *return_type)
+{
+	MonoType *t = mono_type_get_underlying_type (return_type);
+
+	if (return_type->byref)
+		return_type = &mono_defaults.int_class->byval_arg;
+
+	switch (t->type) {
+	case MONO_TYPE_VOID:
+		g_assert_not_reached ();
+		break;
+	case MONO_TYPE_PTR:
+	case MONO_TYPE_STRING:
+	case MONO_TYPE_CLASS: 
+	case MONO_TYPE_OBJECT: 
+	case MONO_TYPE_ARRAY: 
+	case MONO_TYPE_SZARRAY: 
+		/* nothing to do */
+		break;
+	case MONO_TYPE_U1:
+	case MONO_TYPE_BOOLEAN:
+	case MONO_TYPE_I1:
+	case MONO_TYPE_U2:
+	case MONO_TYPE_CHAR:
+	case MONO_TYPE_I2:
+	case MONO_TYPE_I:
+	case MONO_TYPE_U:
+	case MONO_TYPE_I4:
+	case MONO_TYPE_U4:
+	case MONO_TYPE_U8:
+	case MONO_TYPE_I8:
+	case MONO_TYPE_R4:
+	case MONO_TYPE_R8:
+		mono_mb_emit_op (mb, CEE_UNBOX, mono_class_from_mono_type (return_type));
+		mono_mb_emit_byte (mb, mono_type_to_ldind (return_type));
+		break;
+	case MONO_TYPE_GENERICINST:
+		if (!mono_type_generic_inst_is_valuetype (t))
+			break;
+		/* fall through */
+	case MONO_TYPE_VALUETYPE: {
+		MonoClass *klass = mono_class_from_mono_type (return_type);
+		mono_mb_emit_op (mb, CEE_UNBOX, klass);
+		mono_mb_emit_op (mb, CEE_LDOBJ, klass);
+		break;
+	}
+	case MONO_TYPE_VAR:
+	case MONO_TYPE_MVAR: {
+		MonoClass *klass = mono_class_from_mono_type (return_type);
+		mono_mb_emit_op (mb, CEE_UNBOX_ANY, klass);
+		break;
+	}
+	default:
+		g_warning ("type 0x%x not handled", return_type->type);
+		g_assert_not_reached ();
+	}
+
+	mono_mb_emit_byte (mb, CEE_RET);
+}
+
+/*
+ * emit_invoke_call:
+ *
+ *   Emit the call to the wrapper method from a runtime invoke wrapper.
+ */
+static void
+emit_invoke_call (MonoMethodBuilder *mb, MonoMethod *method,
+				  MonoMethodSignature *sig, MonoMethodSignature *callsig,
+				  int loc_res,
+				  gboolean virtual_, gboolean need_direct_wrapper)
+{
+	static MonoString *string_dummy = NULL;
+	int i;
+	int *tmp_nullable_locals;
+	gboolean void_ret = FALSE;
+	gboolean string_ctor = method && method->string_ctor;
+
+	/* to make it work with our special string constructors */
+	if (!string_dummy) {
+		ERROR_DECL (error);
+		MONO_GC_REGISTER_ROOT_SINGLE (string_dummy, MONO_ROOT_SOURCE_MARSHAL, NULL, "Marshal Dummy String");
+		string_dummy = mono_string_new_checked (mono_get_root_domain (), "dummy", error);
+		mono_error_assert_ok (error);
+	}
+
+	if (virtual_) {
+		g_assert (sig->hasthis);
+		g_assert (method->flags & METHOD_ATTRIBUTE_VIRTUAL);
+	}
+
+	if (sig->hasthis) {
+		if (string_ctor) {
+			if (mono_gc_is_moving ()) {
+				mono_mb_emit_ptr (mb, &string_dummy);
+				mono_mb_emit_byte (mb, CEE_LDIND_REF);
+			} else {
+				mono_mb_emit_ptr (mb, string_dummy);
+			}
+		} else {
+			mono_mb_emit_ldarg (mb, 0);
+		}
+	}
+
+	tmp_nullable_locals = g_new0 (int, sig->param_count);
+
+	for (i = 0; i < sig->param_count; i++) {
+		MonoType *t = sig->params [i];
+		int type;
+
+		mono_mb_emit_ldarg (mb, 1);
+		if (i) {
+			mono_mb_emit_icon (mb, sizeof (gpointer) * i);
+			mono_mb_emit_byte (mb, CEE_ADD);
+		}
+
+		if (t->byref) {
+			mono_mb_emit_byte (mb, CEE_LDIND_I);
+			/* A Nullable<T> type don't have a boxed form, it's either null or a boxed T.
+			 * So to make this work we unbox it to a local variablee and push a reference to that.
+			 */
+			if (t->type == MONO_TYPE_GENERICINST && mono_class_is_nullable (mono_class_from_mono_type (t))) {
+				tmp_nullable_locals [i] = mono_mb_add_local (mb, &mono_class_from_mono_type (t)->byval_arg);
+
+				mono_mb_emit_op (mb, CEE_UNBOX_ANY, mono_class_from_mono_type (t));
+				mono_mb_emit_stloc (mb, tmp_nullable_locals [i]);
+				mono_mb_emit_ldloc_addr (mb, tmp_nullable_locals [i]);
+			}
+			continue;
+		}
+
+		/*FIXME 'this doesn't handle generic enums. Shouldn't we?*/
+		type = sig->params [i]->type;
+handle_enum:
+		switch (type) {
+		case MONO_TYPE_I1:
+		case MONO_TYPE_BOOLEAN:
+		case MONO_TYPE_U1:
+		case MONO_TYPE_I2:
+		case MONO_TYPE_U2:
+		case MONO_TYPE_CHAR:
+		case MONO_TYPE_I:
+		case MONO_TYPE_U:
+		case MONO_TYPE_I4:
+		case MONO_TYPE_U4:
+		case MONO_TYPE_R4:
+		case MONO_TYPE_R8:
+		case MONO_TYPE_I8:
+		case MONO_TYPE_U8:
+			mono_mb_emit_byte (mb, CEE_LDIND_I);
+			mono_mb_emit_byte (mb, mono_type_to_ldind (sig->params [i]));
+			break;
+		case MONO_TYPE_STRING:
+		case MONO_TYPE_CLASS:  
+		case MONO_TYPE_ARRAY:
+		case MONO_TYPE_PTR:
+		case MONO_TYPE_SZARRAY:
+		case MONO_TYPE_OBJECT:
+			mono_mb_emit_byte (mb, mono_type_to_ldind (sig->params [i]));
+			break;
+		case MONO_TYPE_GENERICINST:
+			if (!mono_type_generic_inst_is_valuetype (sig->params [i])) {
+				mono_mb_emit_byte (mb, mono_type_to_ldind (sig->params [i]));
+				break;
+			}
+
+			/* fall through */
+		case MONO_TYPE_VALUETYPE:
+			if (type == MONO_TYPE_VALUETYPE && t->data.klass->enumtype) {
+				type = mono_class_enum_basetype (t->data.klass)->type;
+				goto handle_enum;
+			}
+			mono_mb_emit_byte (mb, CEE_LDIND_I);
+			if (mono_class_is_nullable (mono_class_from_mono_type (sig->params [i]))) {
+				/* Need to convert a boxed vtype to an mp to a Nullable struct */
+				mono_mb_emit_op (mb, CEE_UNBOX, mono_class_from_mono_type (sig->params [i]));
+				mono_mb_emit_op (mb, CEE_LDOBJ, mono_class_from_mono_type (sig->params [i]));
+			} else {
+				mono_mb_emit_op (mb, CEE_LDOBJ, mono_class_from_mono_type (sig->params [i]));
+			}
+			break;
+		default:
+			g_assert_not_reached ();
+		}
+	}
+	
+	if (virtual_) {
+		mono_mb_emit_op (mb, CEE_CALLVIRT, method);
+	} else if (need_direct_wrapper) {
+		mono_mb_emit_op (mb, CEE_CALL, method);
+	} else {
+		mono_mb_emit_ldarg (mb, 3);
+		mono_mb_emit_calli (mb, callsig);
+	}
+
+	if (sig->ret->byref) {
+		/* fixme: */
+		g_assert_not_reached ();
+	}
+
+	switch (sig->ret->type) {
+	case MONO_TYPE_VOID:
+		if (!string_ctor)
+			void_ret = TRUE;
+		break;
+	case MONO_TYPE_BOOLEAN:
+	case MONO_TYPE_CHAR:
+	case MONO_TYPE_I1:
+	case MONO_TYPE_U1:
+	case MONO_TYPE_I2:
+	case MONO_TYPE_U2:
+	case MONO_TYPE_I4:
+	case MONO_TYPE_U4:
+	case MONO_TYPE_I:
+	case MONO_TYPE_U:
+	case MONO_TYPE_R4:
+	case MONO_TYPE_R8:
+	case MONO_TYPE_I8:
+	case MONO_TYPE_U8:
+	case MONO_TYPE_VALUETYPE:
+	case MONO_TYPE_TYPEDBYREF:
+	case MONO_TYPE_GENERICINST:
+		/* box value types */
+		mono_mb_emit_op (mb, CEE_BOX, mono_class_from_mono_type (sig->ret));
+		break;
+	case MONO_TYPE_STRING:
+	case MONO_TYPE_CLASS:  
+	case MONO_TYPE_ARRAY:
+	case MONO_TYPE_SZARRAY:
+	case MONO_TYPE_OBJECT:
+		/* nothing to do */
+		break;
+	case MONO_TYPE_PTR:
+		/* The result is an IntPtr */
+		mono_mb_emit_op (mb, CEE_BOX, mono_defaults.int_class);
+		break;
+	default:
+		g_assert_not_reached ();
+	}
+
+	if (!void_ret)
+		mono_mb_emit_stloc (mb, loc_res);
+
+	/* Convert back nullable-byref arguments */
+	for (i = 0; i < sig->param_count; i++) {
+		MonoType *t = sig->params [i];
+
+		/* 
+		 * Box the result and put it back into the array, the caller will have
+		 * to obtain it from there.
+		 */
+		if (t->byref && t->type == MONO_TYPE_GENERICINST && mono_class_is_nullable (mono_class_from_mono_type (t))) {
+			mono_mb_emit_ldarg (mb, 1);			
+			mono_mb_emit_icon (mb, sizeof (gpointer) * i);
+			mono_mb_emit_byte (mb, CEE_ADD);
+
+			mono_mb_emit_ldloc (mb, tmp_nullable_locals [i]);
+			mono_mb_emit_op (mb, CEE_BOX, mono_class_from_mono_type (t));
+
+			mono_mb_emit_byte (mb, CEE_STIND_REF);
+		}
+	}
+
+	g_free (tmp_nullable_locals);
+}
+
+static void
+emit_runtime_invoke_body_ilgen (MonoMethodBuilder *mb, const char **param_names, MonoImage *image, MonoMethod *method,
+						  MonoMethodSignature *sig, MonoMethodSignature *callsig,
+						  gboolean virtual_, gboolean need_direct_wrapper)
+{
+	gint32 labels [16];
+	MonoExceptionClause *clause;
+	int loc_res, loc_exc;
+
+	mono_mb_set_param_names (mb, param_names);
+
+	/* The wrapper looks like this:
+	 *
+	 * <interrupt check>
+	 * if (exc) {
+	 *	 try {
+	 *	   return <call>
+	 *	 } catch (Exception e) {
+	 *     *exc = e;
+	 *   }
+	 * } else {
+	 *     return <call>
+	 * }
+	 */
+
+	/* allocate local 0 (object) tmp */
+	loc_res = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
+	/* allocate local 1 (object) exc */
+	loc_exc = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
+
+	/* *exc is assumed to be initialized to NULL by the caller */
+
+	mono_mb_emit_byte (mb, CEE_LDARG_2);
+	labels [0] = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+	/*
+	 * if (exc) case
+	 */
+	labels [1] = mono_mb_get_label (mb);
+	emit_thread_force_interrupt_checkpoint (mb);
+	emit_invoke_call (mb, method, sig, callsig, loc_res, virtual_, need_direct_wrapper);
+
+	labels [2] = mono_mb_emit_branch (mb, CEE_LEAVE);
+
+	/* Add a try clause around the call */
+	clause = (MonoExceptionClause *)mono_image_alloc0 (image, sizeof (MonoExceptionClause));
+	clause->flags = MONO_EXCEPTION_CLAUSE_NONE;
+	clause->data.catch_class = mono_defaults.exception_class;
+	clause->try_offset = labels [1];
+	clause->try_len = mono_mb_get_label (mb) - labels [1];
+
+	clause->handler_offset = mono_mb_get_label (mb);
+
+	/* handler code */
+	mono_mb_emit_stloc (mb, loc_exc);	
+	mono_mb_emit_byte (mb, CEE_LDARG_2);
+	mono_mb_emit_ldloc (mb, loc_exc);
+	mono_mb_emit_byte (mb, CEE_STIND_REF);
+
+	mono_mb_emit_branch (mb, CEE_LEAVE);
+
+	clause->handler_len = mono_mb_get_pos (mb) - clause->handler_offset;
+
+	mono_mb_set_clauses (mb, 1, clause);
+
+	mono_mb_patch_branch (mb, labels [2]);
+	mono_mb_emit_ldloc (mb, loc_res);
+	mono_mb_emit_byte (mb, CEE_RET);
+
+	/*
+	 * if (!exc) case
+	 */
+	mono_mb_patch_branch (mb, labels [0]);
+	emit_thread_force_interrupt_checkpoint (mb);
+	emit_invoke_call (mb, method, sig, callsig, loc_res, virtual_, need_direct_wrapper);
+
+	mono_mb_emit_ldloc (mb, 0);
+	mono_mb_emit_byte (mb, CEE_RET);
+}
+
+static void
+emit_runtime_invoke_dynamic_ilgen (MonoMethodBuilder *mb)
+{
+	int pos;
+	MonoExceptionClause *clause;
+	/* allocate local 0 (object) tmp */
+	mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
+	/* allocate local 1 (object) exc */
+	mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
+
+	/* cond set *exc to null */
+	mono_mb_emit_byte (mb, CEE_LDARG_1);
+	mono_mb_emit_byte (mb, CEE_BRFALSE_S);
+	mono_mb_emit_byte (mb, 3);	
+	mono_mb_emit_byte (mb, CEE_LDARG_1);
+	mono_mb_emit_byte (mb, CEE_LDNULL);
+	mono_mb_emit_byte (mb, CEE_STIND_REF);
+
+	emit_thread_force_interrupt_checkpoint (mb);
+
+	mono_mb_emit_byte (mb, CEE_LDARG_0);
+	mono_mb_emit_byte (mb, CEE_LDARG_2);
+	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+	mono_mb_emit_byte (mb, CEE_MONO_DYN_CALL);
+
+	pos = mono_mb_emit_branch (mb, CEE_LEAVE);
+
+	clause = (MonoExceptionClause *)mono_image_alloc0 (mono_defaults.corlib, sizeof (MonoExceptionClause));
+	clause->flags = MONO_EXCEPTION_CLAUSE_FILTER;
+	clause->try_len = mono_mb_get_label (mb);
+
+	/* filter code */
+	clause->data.filter_offset = mono_mb_get_label (mb);
+	
+	mono_mb_emit_byte (mb, CEE_POP);
+	mono_mb_emit_byte (mb, CEE_LDARG_1);
+	mono_mb_emit_byte (mb, CEE_LDC_I4_0);
+	mono_mb_emit_byte (mb, CEE_PREFIX1);
+	mono_mb_emit_byte (mb, CEE_CGT_UN);
+	mono_mb_emit_byte (mb, CEE_PREFIX1);
+	mono_mb_emit_byte (mb, CEE_ENDFILTER);
+
+	clause->handler_offset = mono_mb_get_label (mb);
+
+	/* handler code */
+	/* store exception */
+	mono_mb_emit_stloc (mb, 1);
+	
+	mono_mb_emit_byte (mb, CEE_LDARG_1);
+	mono_mb_emit_ldloc (mb, 1);
+	mono_mb_emit_byte (mb, CEE_STIND_REF);
+
+	mono_mb_emit_byte (mb, CEE_LDNULL);
+	mono_mb_emit_stloc (mb, 0);
+
+	mono_mb_emit_branch (mb, CEE_LEAVE);
+
+	clause->handler_len = mono_mb_get_pos (mb) - clause->handler_offset;
+
+	mono_mb_set_clauses (mb, 1, clause);
+
+	/* return result */
+	mono_mb_patch_branch (mb, pos);
+	//mono_mb_emit_ldloc (mb, 0);
+	mono_mb_emit_byte (mb, CEE_RET);
+}
+
+static void
+mono_mb_emit_auto_layout_exception (MonoMethodBuilder *mb, MonoClass *klass)
+{
+	char *msg = g_strdup_printf ("The type `%s.%s' layout needs to be Sequential or Explicit",
+				     klass->name_space, klass->name);
+
+	mono_mb_emit_exception_marshal_directive (mb, msg);
+}
+
+/**
+ * emit_native_wrapper_ilgen:
+ * \param image the image to use for looking up custom marshallers
+ * \param sig The signature of the native function
+ * \param piinfo Marshalling information
+ * \param mspecs Marshalling information
+ * \param aot whenever the created method will be compiled by the AOT compiler
+ * \param method if non-NULL, the pinvoke method to call
+ * \param check_exceptions Whenever to check for pending exceptions after the native call
+ * \param func_param the function to call is passed as a boxed IntPtr as the first parameter
+ *
+ * generates IL code for the pinvoke wrapper, the generated code calls \p func .
+ */
+static void
+emit_native_wrapper_ilgen (MonoImage *image, MonoMethodBuilder *mb, MonoMethodSignature *sig, MonoMethodPInvoke *piinfo, MonoMarshalSpec **mspecs, gpointer func, gboolean aot, gboolean check_exceptions, gboolean func_param)
+{
+	EmitMarshalContext m;
+	MonoMethodSignature *csig;
+	MonoClass *klass;
+	int i, argnum, *tmp_locals;
+	int type, param_shift = 0;
+	int coop_gc_stack_dummy, coop_gc_var;
+#ifndef DISABLE_COM
+	int coop_cominterop_fnptr;
+#endif
+
+	memset (&m, 0, sizeof (m));
+	m.mb = mb;
+	m.sig = sig;
+	m.piinfo = piinfo;
+
+	/* we copy the signature, so that we can set pinvoke to 0 */
+	if (func_param) {
+		/* The function address is passed as the first argument */
+		g_assert (!sig->hasthis);
+		param_shift += 1;
+	}
+	csig = mono_metadata_signature_dup_full (mb->method->klass->image, sig);
+	csig->pinvoke = 1;
+	m.csig = csig;
+	m.image = image;
+
+	if (sig->hasthis)
+		param_shift += 1;
+
+	/* we allocate local for use with emit_struct_conv() */
+	/* allocate local 0 (pointer) src_ptr */
+	mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+	/* allocate local 1 (pointer) dst_ptr */
+	mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+	/* allocate local 2 (boolean) delete_old */
+	mono_mb_add_local (mb, &mono_defaults.boolean_class->byval_arg);
+
+	/* delete_old = FALSE */
+	mono_mb_emit_icon (mb, 0);
+	mono_mb_emit_stloc (mb, 2);
+
+	if (!MONO_TYPE_IS_VOID (sig->ret)) {
+		/* allocate local 3 to store the return value */
+		mono_mb_add_local (mb, sig->ret);
+	}
+
+	if (mono_threads_is_blocking_transition_enabled ()) {
+		/* local 4, dummy local used to get a stack address for suspend funcs */
+		coop_gc_stack_dummy = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		/* local 5, the local to be used when calling the suspend funcs */
+		coop_gc_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+#ifndef DISABLE_COM
+		if (!func_param && MONO_CLASS_IS_IMPORT (mb->method->klass)) {
+			coop_cominterop_fnptr = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		}
+#endif
+	}
+
+	/*
+	 * cookie = mono_threads_enter_gc_safe_region_unbalanced (ref dummy);
+	 *
+	 * ret = method (...);
+	 *
+	 * mono_threads_exit_gc_safe_region_unbalanced (cookie, ref dummy);
+	 *
+	 * <interrupt check>
+	 *
+	 * return ret;
+	 */
+
+	if (MONO_TYPE_ISSTRUCT (sig->ret))
+		m.vtaddr_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+
+	if (mspecs [0] && mspecs [0]->native == MONO_NATIVE_CUSTOM) {
+		/* Return type custom marshaling */
+		/*
+		 * Since we can't determine the return type of the unmanaged function,
+		 * we assume it returns a pointer, and pass that pointer to
+		 * MarshalNativeToManaged.
+		 */
+		csig->ret = &mono_defaults.int_class->byval_arg;
+	}
+
+	/* we first do all conversions */
+	tmp_locals = (int *)alloca (sizeof (int) * sig->param_count);
+	m.orig_conv_args = (int *)alloca (sizeof (int) * (sig->param_count + 1));
+
+	for (i = 0; i < sig->param_count; i ++) {
+		tmp_locals [i] = mono_emit_marshal (&m, i + param_shift, sig->params [i], mspecs [i + 1], 0, &csig->params [i], MARSHAL_ACTION_CONV_IN);
+	}
+
+	// In coop mode need to register blocking state during native call
+	if (mono_threads_is_blocking_transition_enabled ()) {
+		// Perform an extra, early lookup of the function address, so any exceptions
+		// potentially resulting from the lookup occur before entering blocking mode.
+		if (!func_param && !MONO_CLASS_IS_IMPORT (mb->method->klass) && aot) {
+			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+			mono_mb_emit_op (mb, CEE_MONO_ICALL_ADDR, &piinfo->method);
+			mono_mb_emit_byte (mb, CEE_POP); // Result not needed yet
+		}
+
+#ifndef DISABLE_COM
+		if (!func_param && MONO_CLASS_IS_IMPORT (mb->method->klass)) {
+			mono_mb_emit_cominterop_get_function_pointer (mb, &piinfo->method);
+			mono_mb_emit_stloc (mb, coop_cominterop_fnptr);
+		}
+#endif
+
+		mono_mb_emit_ldloc_addr (mb, coop_gc_stack_dummy);
+		mono_mb_emit_icall (mb, mono_threads_enter_gc_safe_region_unbalanced);
+		mono_mb_emit_stloc (mb, coop_gc_var);
+	}
+
+	/* push all arguments */
+
+	if (sig->hasthis)
+		mono_mb_emit_byte (mb, CEE_LDARG_0);
+
+	for (i = 0; i < sig->param_count; i++) {
+		mono_emit_marshal (&m, i + param_shift, sig->params [i], mspecs [i + 1], tmp_locals [i], NULL, MARSHAL_ACTION_PUSH);
+	}			
+
+	/* call the native method */
+	if (func_param) {
+		mono_mb_emit_byte (mb, CEE_LDARG_0);
+		mono_mb_emit_op (mb, CEE_UNBOX, mono_defaults.int_class);
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+		mono_mb_emit_calli (mb, csig);
+	} else if (MONO_CLASS_IS_IMPORT (mb->method->klass)) {
+#ifndef DISABLE_COM
+		if (!mono_threads_is_blocking_transition_enabled ()) {
+			mono_mb_emit_cominterop_call (mb, csig, &piinfo->method);
+		} else {
+			mono_mb_emit_ldloc (mb, coop_cominterop_fnptr);
+			mono_mb_emit_cominterop_call_function_pointer (mb, csig);
+		}
+#else
+		g_assert_not_reached ();
+#endif
+	} else {
+		if (aot) {
+			/* Reuse the ICALL_ADDR opcode for pinvokes too */
+			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+			mono_mb_emit_op (mb, CEE_MONO_ICALL_ADDR, &piinfo->method);
+			mono_mb_emit_calli (mb, csig);
+		} else {			
+			mono_mb_emit_native_call (mb, csig, func);
+		}
+	}
+
+	/* Set LastError if needed */
+	if (piinfo->piflags & PINVOKE_ATTRIBUTE_SUPPORTS_LAST_ERROR) {
+#ifdef TARGET_WIN32
+		if (!aot) {
+			static MonoMethodSignature *get_last_error_sig = NULL;
+			if (!get_last_error_sig) {
+				get_last_error_sig = mono_metadata_signature_alloc (mono_defaults.corlib, 0);
+				get_last_error_sig->ret = &mono_defaults.int_class->byval_arg;
+				get_last_error_sig->pinvoke = 1;
+			}
+
+			/*
+			 * Have to call GetLastError () early and without a wrapper, since various runtime components could
+			 * clobber its value.
+			 */
+			mono_mb_emit_native_call (mb, get_last_error_sig, GetLastError);
+			mono_mb_emit_icall (mb, mono_marshal_set_last_error_windows);
+		} else {
+			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+			mono_mb_emit_byte (mb, CEE_MONO_GET_LAST_ERROR);
+			mono_mb_emit_icall (mb, mono_marshal_set_last_error_windows);
+		}
+#else
+		mono_mb_emit_icall (mb, mono_marshal_set_last_error);
+#endif
+	}
+
+	if (MONO_TYPE_ISSTRUCT (sig->ret)) {
+		MonoClass *klass = mono_class_from_mono_type (sig->ret);
+		mono_class_init (klass);
+		if (!(mono_class_is_explicit_layout (klass) || klass->blittable)) {
+			/* This is used by emit_marshal_vtype (), but it needs to go right before the call */
+			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+			mono_mb_emit_byte (mb, CEE_MONO_VTADDR);
+			mono_mb_emit_stloc (mb, m.vtaddr_var);
+		}
+	}
+
+	/* Unblock before converting the result, since that can involve calls into the runtime */
+	if (mono_threads_is_blocking_transition_enabled ()) {
+		mono_mb_emit_ldloc (mb, coop_gc_var);
+		mono_mb_emit_ldloc_addr (mb, coop_gc_stack_dummy);
+		mono_mb_emit_icall (mb, mono_threads_exit_gc_safe_region_unbalanced);
+	}
+
+	/* convert the result */
+	if (!sig->ret->byref) {
+		MonoMarshalSpec *spec = mspecs [0];
+		type = sig->ret->type;
+
+		if (spec && spec->native == MONO_NATIVE_CUSTOM) {
+			mono_emit_marshal (&m, 0, sig->ret, spec, 0, NULL, MARSHAL_ACTION_CONV_RESULT);
+		} else {
+		handle_enum:
+			switch (type) {
+			case MONO_TYPE_VOID:
+				break;
+			case MONO_TYPE_VALUETYPE:
+				klass = sig->ret->data.klass;
+				if (klass->enumtype) {
+					type = mono_class_enum_basetype (sig->ret->data.klass)->type;
+					goto handle_enum;
+				}
+				mono_emit_marshal (&m, 0, sig->ret, spec, 0, NULL, MARSHAL_ACTION_CONV_RESULT);
+				break;
+			case MONO_TYPE_I1:
+			case MONO_TYPE_U1:
+			case MONO_TYPE_I2:
+			case MONO_TYPE_U2:
+			case MONO_TYPE_I4:
+			case MONO_TYPE_U4:
+			case MONO_TYPE_I:
+			case MONO_TYPE_U:
+			case MONO_TYPE_R4:
+			case MONO_TYPE_R8:
+			case MONO_TYPE_I8:
+			case MONO_TYPE_U8:
+			case MONO_TYPE_FNPTR:
+			case MONO_TYPE_STRING:
+			case MONO_TYPE_CLASS:
+			case MONO_TYPE_OBJECT:
+			case MONO_TYPE_BOOLEAN:
+			case MONO_TYPE_ARRAY:
+			case MONO_TYPE_SZARRAY:
+			case MONO_TYPE_CHAR:
+			case MONO_TYPE_PTR:
+			case MONO_TYPE_GENERICINST:
+				mono_emit_marshal (&m, 0, sig->ret, spec, 0, NULL, MARSHAL_ACTION_CONV_RESULT);
+				break;
+			case MONO_TYPE_TYPEDBYREF:
+			default:
+				g_warning ("return type 0x%02x unknown", sig->ret->type);	
+				g_assert_not_reached ();
+			}
+		}
+	} else {
+		mono_mb_emit_stloc (mb, 3);
+	}
+
+	/* 
+	 * Need to call this after converting the result since MONO_VTADDR needs 
+	 * to be adjacent to the call instruction.
+	 */
+	if (check_exceptions)
+		emit_thread_interrupt_checkpoint (mb);
+
+	/* we need to convert byref arguments back and free string arrays */
+	for (i = 0; i < sig->param_count; i++) {
+		MonoType *t = sig->params [i];
+		MonoMarshalSpec *spec = mspecs [i + 1];
+
+		argnum = i + param_shift;
+
+		if (spec && ((spec->native == MONO_NATIVE_CUSTOM) || (spec->native == MONO_NATIVE_ASANY))) {
+			mono_emit_marshal (&m, argnum, t, spec, tmp_locals [i], NULL, MARSHAL_ACTION_CONV_OUT);
+			continue;
+		}
+
+		switch (t->type) {
+		case MONO_TYPE_STRING:
+		case MONO_TYPE_VALUETYPE:
+		case MONO_TYPE_CLASS:
+		case MONO_TYPE_OBJECT:
+		case MONO_TYPE_SZARRAY:
+		case MONO_TYPE_BOOLEAN:
+			mono_emit_marshal (&m, argnum, t, spec, tmp_locals [i], NULL, MARSHAL_ACTION_CONV_OUT);
+			break;
+		default:
+			break;
+		}
+	}
+
+	if (!MONO_TYPE_IS_VOID(sig->ret))
+		mono_mb_emit_ldloc (mb, 3);
+
+	mono_mb_emit_byte (mb, CEE_RET);
+}
+
+/*
+ * The code directly following this is the cache hit, value positive branch
+ *
+ * This function takes a new method builder with 0 locals and adds two locals
+ * to create multiple out-branches and the fall through state of having the object
+ * on the stack after a cache miss
+ */
+static void
+generate_check_cache (int obj_arg_position, int class_arg_position, int cache_arg_position, // In-parameters
+											int *null_obj, int *cache_hit_neg, int *cache_hit_pos, // Out-parameters
+											MonoMethodBuilder *mb)
+{
+	int cache_miss_pos;
+
+	/* allocate local 0 (pointer) obj_vtable */
+	mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+	/* allocate local 1 (pointer) cached_vtable */
+	mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+
+	/*if (!obj)*/
+	mono_mb_emit_ldarg (mb, obj_arg_position);
+	*null_obj = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+	/*obj_vtable = obj->vtable;*/
+	mono_mb_emit_ldarg (mb, obj_arg_position);
+	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoObject, vtable));
+	mono_mb_emit_byte (mb, CEE_LDIND_I);
+	mono_mb_emit_stloc (mb, 0);
+
+	/* cached_vtable = *cache*/
+	mono_mb_emit_ldarg (mb, cache_arg_position);
+	mono_mb_emit_byte (mb, CEE_LDIND_I);
+	mono_mb_emit_stloc (mb, 1);
+
+	mono_mb_emit_ldloc (mb, 1);
+	mono_mb_emit_byte (mb, CEE_LDC_I4);
+	mono_mb_emit_i4 (mb, ~0x1);
+	mono_mb_emit_byte (mb, CEE_CONV_I);
+	mono_mb_emit_byte (mb, CEE_AND);
+	mono_mb_emit_ldloc (mb, 0);
+	/*if ((cached_vtable & ~0x1)== obj_vtable)*/
+	cache_miss_pos = mono_mb_emit_branch (mb, CEE_BNE_UN);
+
+	/*return (cached_vtable & 0x1) ? NULL : obj;*/
+	mono_mb_emit_ldloc (mb, 1);
+	mono_mb_emit_byte(mb, CEE_LDC_I4_1);
+	mono_mb_emit_byte (mb, CEE_CONV_U);
+	mono_mb_emit_byte (mb, CEE_AND);
+	*cache_hit_neg = mono_mb_emit_branch (mb, CEE_BRTRUE);
+	*cache_hit_pos = mono_mb_emit_branch (mb, CEE_BR);
+
+	// slow path
+	mono_mb_patch_branch (mb, cache_miss_pos);
+
+	// if isinst
+	mono_mb_emit_ldarg (mb, obj_arg_position);
+	mono_mb_emit_ldarg (mb, class_arg_position);
+	mono_mb_emit_ldarg (mb, cache_arg_position);
+	mono_mb_emit_icall (mb, mono_marshal_isinst_with_cache);
+}
+
+static void
+emit_castclass_ilgen (MonoMethodBuilder *mb)
+{
+	int return_null_pos, positive_cache_hit_pos, negative_cache_hit_pos, invalid_cast_pos;
+	const int obj_arg_position = TYPECHECK_OBJECT_ARG_POS;
+	const int class_arg_position = TYPECHECK_CLASS_ARG_POS;
+	const int cache_arg_position = TYPECHECK_CACHE_ARG_POS;
+
+	generate_check_cache (obj_arg_position, class_arg_position, cache_arg_position, 
+												&return_null_pos, &negative_cache_hit_pos, &positive_cache_hit_pos, mb);
+	invalid_cast_pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+	/*return obj;*/
+	mono_mb_patch_branch (mb, positive_cache_hit_pos);
+	mono_mb_emit_ldarg (mb, obj_arg_position);
+	mono_mb_emit_byte (mb, CEE_RET);
+
+	/*fails*/
+	mono_mb_patch_branch (mb, negative_cache_hit_pos);
+	mono_mb_patch_branch (mb, invalid_cast_pos);
+	mono_mb_emit_exception (mb, "InvalidCastException", NULL);
+
+	/*return null*/
+	mono_mb_patch_branch (mb, return_null_pos);
+	mono_mb_emit_byte (mb, CEE_LDNULL);
+	mono_mb_emit_byte (mb, CEE_RET);
+}
+
+static void
+emit_isinst_ilgen (MonoMethodBuilder *mb)
+{
+	int return_null_pos, positive_cache_hit_pos, negative_cache_hit_pos;
+	const int obj_arg_position = TYPECHECK_OBJECT_ARG_POS;
+	const int class_arg_position = TYPECHECK_CLASS_ARG_POS;
+	const int cache_arg_position = TYPECHECK_CACHE_ARG_POS;
+
+	generate_check_cache (obj_arg_position, class_arg_position, cache_arg_position, 
+		&return_null_pos, &negative_cache_hit_pos, &positive_cache_hit_pos, mb);
+	// Return the object gotten via the slow path.
+	mono_mb_emit_byte (mb, CEE_RET);
+
+	// return NULL;
+	mono_mb_patch_branch (mb, negative_cache_hit_pos);
+	mono_mb_patch_branch (mb, return_null_pos);
+	mono_mb_emit_byte (mb, CEE_LDNULL);
+	mono_mb_emit_byte (mb, CEE_RET);
+
+	// return obj
+	mono_mb_patch_branch (mb, positive_cache_hit_pos);
+	mono_mb_emit_ldarg (mb, obj_arg_position);
+	mono_mb_emit_byte (mb, CEE_RET);
+}
+
+static void
+load_array_element_address (MonoMethodBuilder *mb)
+{
+	mono_mb_emit_ldarg (mb, 0);
+	mono_mb_emit_ldarg (mb, 1);
+	mono_mb_emit_op (mb, CEE_LDELEMA, mono_defaults.object_class);
+}
+
+static void
+load_array_class (MonoMethodBuilder *mb, int aklass)
+{
+	mono_mb_emit_ldarg (mb, 0);
+	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoObject, vtable));
+	mono_mb_emit_byte (mb, CEE_LDIND_I);
+	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoVTable, klass));
+	mono_mb_emit_byte (mb, CEE_LDIND_I);
+	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, element_class));
+	mono_mb_emit_byte (mb, CEE_LDIND_I);
+	mono_mb_emit_stloc (mb, aklass);
+}
+
+static void
+load_value_class (MonoMethodBuilder *mb, int vklass)
+{
+	mono_mb_emit_ldarg (mb, 2);
+	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoObject, vtable));
+	mono_mb_emit_byte (mb, CEE_LDIND_I);
+	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoVTable, klass));
+	mono_mb_emit_byte (mb, CEE_LDIND_I);
+	mono_mb_emit_stloc (mb, vklass);
+}
+
+static int
+emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
+					MonoMarshalSpec *spec, 
+					int conv_arg, MonoType **conv_arg_type, 
+					MarshalAction action)
+{
+	MonoMethodBuilder *mb = m->mb;
+	MonoClass *klass = mono_class_from_mono_type (t);
+	gboolean need_convert, need_free;
+	MonoMarshalNative encoding;
+
+	encoding = mono_marshal_get_string_encoding (m->piinfo, spec);
+
+	switch (action) {
+	case MARSHAL_ACTION_CONV_IN:
+		*conv_arg_type = &mono_defaults.object_class->byval_arg;
+		conv_arg = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
+
+		if (klass->element_class->blittable) {
+			mono_mb_emit_ldarg (mb, argnum);
+			if (t->byref)
+				mono_mb_emit_byte (mb, CEE_LDIND_I);
+			mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_ARRAY_LPARRAY, NULL));
+			mono_mb_emit_stloc (mb, conv_arg);
+		} else {
+			MonoClass *eklass;
+			guint32 label1, label2, label3;
+			int index_var, src_var, dest_ptr, esize;
+			MonoMarshalConv conv;
+			gboolean is_string = FALSE;
+
+			dest_ptr = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+
+			eklass = klass->element_class;
+
+			if (eklass == mono_defaults.string_class) {
+				is_string = TRUE;
+				conv = mono_marshal_get_string_to_ptr_conv (m->piinfo, spec);
+			}
+			else if (eklass == mono_defaults.stringbuilder_class) {
+				is_string = TRUE;
+				conv = mono_marshal_get_stringbuilder_to_ptr_conv (m->piinfo, spec);
+			}
+			else
+				conv = MONO_MARSHAL_CONV_INVALID;
+
+			if (is_string && conv == MONO_MARSHAL_CONV_INVALID) {
+				char *msg = g_strdup_printf ("string/stringbuilder marshalling conversion %d not implemented", encoding);
+				mono_mb_emit_exception_marshal_directive (mb, msg);
+				break;
+			}
+
+			src_var = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
+			mono_mb_emit_ldarg (mb, argnum);
+			if (t->byref)
+				mono_mb_emit_byte (mb, CEE_LDIND_I);
+			mono_mb_emit_stloc (mb, src_var);
+
+			/* Check null */
+			mono_mb_emit_ldloc (mb, src_var);
+			mono_mb_emit_stloc (mb, conv_arg);
+			mono_mb_emit_ldloc (mb, src_var);
+			label1 = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+			if (is_string)
+				esize = sizeof (gpointer);
+			else if (eklass == mono_defaults.char_class) /*can't call mono_marshal_type_size since it causes all sorts of asserts*/
+				esize = mono_pinvoke_is_unicode (m->piinfo) ? 2 : 1;
+			else
+				esize = mono_class_native_size (eklass, NULL);
+
+			/* allocate space for the native struct and store the address */
+			mono_mb_emit_icon (mb, esize);
+			mono_mb_emit_ldloc (mb, src_var);
+			mono_mb_emit_byte (mb, CEE_LDLEN);
+
+			if (eklass == mono_defaults.string_class) {
+				/* Make the array bigger for the terminating null */
+				mono_mb_emit_byte (mb, CEE_LDC_I4_1);
+				mono_mb_emit_byte (mb, CEE_ADD);
+			}
+			mono_mb_emit_byte (mb, CEE_MUL);
+			mono_mb_emit_byte (mb, CEE_PREFIX1);
+			mono_mb_emit_byte (mb, CEE_LOCALLOC);
+			mono_mb_emit_stloc (mb, conv_arg);
+
+			mono_mb_emit_ldloc (mb, conv_arg);
+			mono_mb_emit_stloc (mb, dest_ptr);
+
+			/* Emit marshalling loop */
+			index_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);				
+			mono_mb_emit_byte (mb, CEE_LDC_I4_0);
+			mono_mb_emit_stloc (mb, index_var);
+			label2 = mono_mb_get_label (mb);
+			mono_mb_emit_ldloc (mb, index_var);
+			mono_mb_emit_ldloc (mb, src_var);
+			mono_mb_emit_byte (mb, CEE_LDLEN);
+			label3 = mono_mb_emit_branch (mb, CEE_BGE);
+
+			/* Emit marshalling code */
+
+			if (is_string) {
+				int stind_op;
+				mono_mb_emit_ldloc (mb, dest_ptr);
+				mono_mb_emit_ldloc (mb, src_var);
+				mono_mb_emit_ldloc (mb, index_var);
+				mono_mb_emit_byte (mb, CEE_LDELEM_REF);
+				mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
+				mono_mb_emit_byte (mb, stind_op);
+			} else {
+				/* set the src_ptr */
+				mono_mb_emit_ldloc (mb, src_var);
+				mono_mb_emit_ldloc (mb, index_var);
+				mono_mb_emit_op (mb, CEE_LDELEMA, eklass);
+				mono_mb_emit_stloc (mb, 0);
+
+				/* set dst_ptr */
+				mono_mb_emit_ldloc (mb, dest_ptr);
+				mono_mb_emit_stloc (mb, 1);
+
+				/* emit valuetype conversion code */
+				emit_struct_conv_full (mb, eklass, FALSE, 0, eklass == mono_defaults.char_class ? encoding : (MonoMarshalNative)-1);
+			}
+
+			mono_mb_emit_add_to_local (mb, index_var, 1);
+			mono_mb_emit_add_to_local (mb, dest_ptr, esize);
+			
+			mono_mb_emit_branch_label (mb, CEE_BR, label2);
+
+			mono_mb_patch_branch (mb, label3);
+
+			if (eklass == mono_defaults.string_class) {
+				/* Null terminate */
+				mono_mb_emit_ldloc (mb, dest_ptr);
+				mono_mb_emit_byte (mb, CEE_LDC_I4_0);
+				mono_mb_emit_byte (mb, CEE_STIND_I);
+			}
+
+			mono_mb_patch_branch (mb, label1);
+		}
+
+		break;
+
+	case MARSHAL_ACTION_CONV_OUT:
+		/* Unicode character arrays are implicitly marshalled as [Out] under MS.NET */
+		need_convert = ((klass->element_class == mono_defaults.char_class) && (encoding == MONO_NATIVE_LPWSTR)) || (klass->element_class == mono_defaults.stringbuilder_class) || (t->attrs & PARAM_ATTRIBUTE_OUT);
+		need_free = mono_marshal_need_free (&klass->element_class->byval_arg, 
+											m->piinfo, spec);
+
+		if ((t->attrs & PARAM_ATTRIBUTE_OUT) && spec && spec->native == MONO_NATIVE_LPARRAY && spec->data.array_data.param_num != -1) {
+			int param_num = spec->data.array_data.param_num;
+			MonoType *param_type;
+
+			param_type = m->sig->params [param_num];
+
+			if (param_type->byref && param_type->type != MONO_TYPE_I4) {
+				char *msg = g_strdup ("Not implemented.");
+				mono_mb_emit_exception_marshal_directive (mb, msg);
+				break;
+			}
+
+			if (t->byref ) {
+				mono_mb_emit_ldarg (mb, argnum);
+
+				/* Create the managed array */
+				mono_mb_emit_ldarg (mb, param_num);
+				if (m->sig->params [param_num]->byref)
+					// FIXME: Support other types
+					mono_mb_emit_byte (mb, CEE_LDIND_I4);
+				mono_mb_emit_byte (mb, CEE_CONV_OVF_I);
+				mono_mb_emit_op (mb, CEE_NEWARR, klass->element_class);
+				/* Store into argument */
+				mono_mb_emit_byte (mb, CEE_STIND_REF);
+			}
+		}
+
+		if (need_convert || need_free) {
+			/* FIXME: Optimize blittable case */
+			MonoClass *eklass;
+			guint32 label1, label2, label3;
+			int index_var, src_ptr, loc, esize;
+
+			eklass = klass->element_class;
+			if ((eklass == mono_defaults.stringbuilder_class) || (eklass == mono_defaults.string_class))
+				esize = sizeof (gpointer);
+			else if (eklass == mono_defaults.char_class)
+				esize = mono_pinvoke_is_unicode (m->piinfo) ? 2 : 1;
+			else
+				esize = mono_class_native_size (eklass, NULL);
+			src_ptr = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+			loc = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+
+			/* Check null */
+			mono_mb_emit_ldarg (mb, argnum);
+			if (t->byref)
+				mono_mb_emit_byte (mb, CEE_LDIND_I);
+			label1 = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+			mono_mb_emit_ldloc (mb, conv_arg);
+			mono_mb_emit_stloc (mb, src_ptr);
+
+			/* Emit marshalling loop */
+			index_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);				
+			mono_mb_emit_byte (mb, CEE_LDC_I4_0);
+			mono_mb_emit_stloc (mb, index_var);
+			label2 = mono_mb_get_label (mb);
+			mono_mb_emit_ldloc (mb, index_var);
+			mono_mb_emit_ldarg (mb, argnum);
+			if (t->byref)
+				mono_mb_emit_byte (mb, CEE_LDIND_REF);
+			mono_mb_emit_byte (mb, CEE_LDLEN);
+			label3 = mono_mb_emit_branch (mb, CEE_BGE);
+
+			/* Emit marshalling code */
+
+			if (eklass == mono_defaults.stringbuilder_class) {
+				gboolean need_free2;
+				MonoMarshalConv conv = mono_marshal_get_ptr_to_stringbuilder_conv (m->piinfo, spec, &need_free2);
+
+				g_assert (conv != MONO_MARSHAL_CONV_INVALID);
+
+				/* dest */
+				mono_mb_emit_ldarg (mb, argnum);
+				if (t->byref)
+					mono_mb_emit_byte (mb, CEE_LDIND_I);
+				mono_mb_emit_ldloc (mb, index_var);
+				mono_mb_emit_byte (mb, CEE_LDELEM_REF);
+
+				/* src */
+				mono_mb_emit_ldloc (mb, src_ptr);
+				mono_mb_emit_byte (mb, CEE_LDIND_I);
+
+				mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+
+				if (need_free) {
+					/* src */
+					mono_mb_emit_ldloc (mb, src_ptr);
+					mono_mb_emit_byte (mb, CEE_LDIND_I);
+
+					mono_mb_emit_icall (mb, mono_marshal_free);
+				}
+			}
+			else if (eklass == mono_defaults.string_class) {
+				if (need_free) {
+					/* src */
+					mono_mb_emit_ldloc (mb, src_ptr);
+					mono_mb_emit_byte (mb, CEE_LDIND_I);
+
+					mono_mb_emit_icall (mb, mono_marshal_free);
+				}
+			}
+			else {
+				if (need_convert) {
+					/* set the src_ptr */
+					mono_mb_emit_ldloc (mb, src_ptr);
+					mono_mb_emit_stloc (mb, 0);
+
+					/* set dst_ptr */
+					mono_mb_emit_ldarg (mb, argnum);
+					if (t->byref)
+						mono_mb_emit_byte (mb, CEE_LDIND_REF);
+					mono_mb_emit_ldloc (mb, index_var);
+					mono_mb_emit_op (mb, CEE_LDELEMA, eklass);
+					mono_mb_emit_stloc (mb, 1);
+
+					/* emit valuetype conversion code */
+					emit_struct_conv_full (mb, eklass, TRUE, 0, eklass == mono_defaults.char_class ? encoding : (MonoMarshalNative)-1);
+				}
+
+				if (need_free) {
+					mono_mb_emit_ldloc (mb, src_ptr);
+					mono_mb_emit_stloc (mb, loc);
+
+					emit_struct_free (mb, eklass, loc);
+				}
+			}
+
+			mono_mb_emit_add_to_local (mb, index_var, 1);
+			mono_mb_emit_add_to_local (mb, src_ptr, esize);
+
+			mono_mb_emit_branch_label (mb, CEE_BR, label2);
+
+			mono_mb_patch_branch (mb, label1);
+			mono_mb_patch_branch (mb, label3);
+		}
+		
+		if (klass->element_class->blittable) {
+			/* free memory allocated (if any) by MONO_MARSHAL_CONV_ARRAY_LPARRAY */
+
+			mono_mb_emit_ldarg (mb, argnum);
+			if (t->byref)
+				mono_mb_emit_byte (mb, CEE_LDIND_REF);
+			mono_mb_emit_ldloc (mb, conv_arg);
+			mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_FREE_LPARRAY, NULL));
+		}
+
+		break;
+
+	case MARSHAL_ACTION_PUSH:
+		if (t->byref)
+			mono_mb_emit_ldloc_addr (mb, conv_arg);
+		else
+			mono_mb_emit_ldloc (mb, conv_arg);
+		break;
+
+	case MARSHAL_ACTION_CONV_RESULT:
+		/* fixme: we need conversions here */
+		mono_mb_emit_stloc (mb, 3);
+		break;
+
+	case MARSHAL_ACTION_MANAGED_CONV_IN: {
+		MonoClass *eklass;
+		guint32 label1, label2, label3;
+		int index_var, src_ptr, esize, param_num, num_elem;
+		MonoMarshalConv conv;
+		gboolean is_string = FALSE;
+		
+		conv_arg = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
+		*conv_arg_type = &mono_defaults.int_class->byval_arg;
+
+		if (t->byref) {
+			char *msg = g_strdup ("Byref array marshalling to managed code is not implemented.");
+			mono_mb_emit_exception_marshal_directive (mb, msg);
+			return conv_arg;
+		}
+		if (!spec) {
+			char *msg = g_strdup ("[MarshalAs] attribute required to marshal arrays to managed code.");
+			mono_mb_emit_exception_marshal_directive (mb, msg);
+			return conv_arg;
+		}			
+		if (spec->native != MONO_NATIVE_LPARRAY) {
+			char *msg = g_strdup ("Non LPArray marshalling of arrays to managed code is not implemented.");
+			mono_mb_emit_exception_marshal_directive (mb, msg);
+			return conv_arg;			
+		}
+
+		/* FIXME: t is from the method which is wrapped, not the delegate type */
+		/* g_assert (t->attrs & PARAM_ATTRIBUTE_IN); */
+
+		param_num = spec->data.array_data.param_num;
+		num_elem = spec->data.array_data.num_elem;
+		if (spec->data.array_data.elem_mult == 0)
+			/* param_num is not specified */
+			param_num = -1;
+
+		if (param_num == -1) {
+			if (num_elem <= 0) {
+				char *msg = g_strdup ("Either SizeConst or SizeParamIndex should be specified when marshalling arrays to managed code.");
+				mono_mb_emit_exception_marshal_directive (mb, msg);
+				return conv_arg;
+			}
+		}
+
+		/* FIXME: Optimize blittable case */
+
+		eklass = klass->element_class;
+		if (eklass == mono_defaults.string_class) {
+			is_string = TRUE;
+			conv = mono_marshal_get_ptr_to_string_conv (m->piinfo, spec, &need_free);
+		}
+		else if (eklass == mono_defaults.stringbuilder_class) {
+			is_string = TRUE;
+			conv = mono_marshal_get_ptr_to_stringbuilder_conv (m->piinfo, spec, &need_free);
+		}
+		else
+			conv = MONO_MARSHAL_CONV_INVALID;
+
+		mono_marshal_load_type_info (eklass);
+
+		if (is_string)
+			esize = sizeof (gpointer);
+		else
+			esize = mono_class_native_size (eklass, NULL);
+		src_ptr = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+
+		mono_mb_emit_byte (mb, CEE_LDNULL);
+		mono_mb_emit_stloc (mb, conv_arg);
+
+		/* Check param index */
+		if (param_num != -1) {
+			if (param_num >= m->sig->param_count) {
+				char *msg = g_strdup ("Array size control parameter index is out of range.");
+				mono_mb_emit_exception_marshal_directive (mb, msg);
+				return conv_arg;
+			}
+			switch (m->sig->params [param_num]->type) {
+			case MONO_TYPE_I1:
+			case MONO_TYPE_U1:
+			case MONO_TYPE_I2:
+			case MONO_TYPE_U2:
+			case MONO_TYPE_I4:
+			case MONO_TYPE_U4:
+			case MONO_TYPE_I:
+			case MONO_TYPE_U:
+			case MONO_TYPE_I8:
+			case MONO_TYPE_U8:
+				break;
+			default: {
+				char *msg = g_strdup ("Array size control parameter must be an integral type.");
+				mono_mb_emit_exception_marshal_directive (mb, msg);
+				return conv_arg;
+			}
+			}
+		}
+
+		/* Check null */
+		mono_mb_emit_ldarg (mb, argnum);
+		label1 = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+		mono_mb_emit_ldarg (mb, argnum);
+		mono_mb_emit_stloc (mb, src_ptr);
+
+		/* Create managed array */
+		/* 
+		 * The LPArray marshalling spec says that sometimes param_num starts 
+		 * from 1, sometimes it starts from 0. But MS seems to allways start
+		 * from 0.
+		 */
+
+		if (param_num == -1) {
+			mono_mb_emit_icon (mb, num_elem);
+		} else {
+			mono_mb_emit_ldarg (mb, param_num);
+			if (num_elem > 0) {
+				mono_mb_emit_icon (mb, num_elem);
+				mono_mb_emit_byte (mb, CEE_ADD);
+			}
+			mono_mb_emit_byte (mb, CEE_CONV_OVF_I);
+		}
+
+		mono_mb_emit_op (mb, CEE_NEWARR, eklass);
+		mono_mb_emit_stloc (mb, conv_arg);
+
+		if (eklass->blittable) {
+			mono_mb_emit_ldloc (mb, conv_arg);
+			mono_mb_emit_byte (mb, CEE_CONV_I);
+			mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoArray, vector));
+			mono_mb_emit_byte (mb, CEE_ADD);
+			mono_mb_emit_ldarg (mb, argnum);
+			mono_mb_emit_ldloc (mb, conv_arg);
+			mono_mb_emit_byte (mb, CEE_LDLEN);
+			mono_mb_emit_icon (mb, esize);
+			mono_mb_emit_byte (mb, CEE_MUL);
+			mono_mb_emit_byte (mb, CEE_PREFIX1);
+			mono_mb_emit_byte (mb, CEE_CPBLK);
+			mono_mb_patch_branch (mb, label1);
+			break;
+		}
+
+		/* Emit marshalling loop */
+		index_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		mono_mb_emit_byte (mb, CEE_LDC_I4_0);
+		mono_mb_emit_stloc (mb, index_var);
+		label2 = mono_mb_get_label (mb);
+		mono_mb_emit_ldloc (mb, index_var);
+		mono_mb_emit_ldloc (mb, conv_arg);
+		mono_mb_emit_byte (mb, CEE_LDLEN);
+		label3 = mono_mb_emit_branch (mb, CEE_BGE);
+
+		/* Emit marshalling code */
+		if (is_string) {
+			g_assert (conv != MONO_MARSHAL_CONV_INVALID);
+
+			mono_mb_emit_ldloc (mb, conv_arg);
+			mono_mb_emit_ldloc (mb, index_var);
+
+			mono_mb_emit_ldloc (mb, src_ptr);
+			mono_mb_emit_byte (mb, CEE_LDIND_I);
+
+			mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+			mono_mb_emit_byte (mb, CEE_STELEM_REF);
+		}
+		else {
+			char *msg = g_strdup ("Marshalling of non-string and non-blittable arrays to managed code is not implemented.");
+			mono_mb_emit_exception_marshal_directive (mb, msg);
+			return conv_arg;
+		}
+
+		mono_mb_emit_add_to_local (mb, index_var, 1);
+		mono_mb_emit_add_to_local (mb, src_ptr, esize);
+
+		mono_mb_emit_branch_label (mb, CEE_BR, label2);
+
+		mono_mb_patch_branch (mb, label1);
+		mono_mb_patch_branch (mb, label3);
+		
+		break;
+	}
+	case MARSHAL_ACTION_MANAGED_CONV_OUT: {
+		MonoClass *eklass;
+		guint32 label1, label2, label3;
+		int index_var, dest_ptr, esize, param_num, num_elem;
+		MonoMarshalConv conv;
+		gboolean is_string = FALSE;
+
+		if (!spec)
+			/* Already handled in CONV_IN */
+			break;
+		
+		/* These are already checked in CONV_IN */
+		g_assert (!t->byref);
+		g_assert (spec->native == MONO_NATIVE_LPARRAY);
+		g_assert (t->attrs & PARAM_ATTRIBUTE_OUT);
+
+		param_num = spec->data.array_data.param_num;
+		num_elem = spec->data.array_data.num_elem;
+
+		if (spec->data.array_data.elem_mult == 0)
+			/* param_num is not specified */
+			param_num = -1;
+
+		if (param_num == -1) {
+			if (num_elem <= 0) {
+				g_assert_not_reached ();
+			}
+		}
+
+		/* FIXME: Optimize blittable case */
+
+		eklass = klass->element_class;
+		if (eklass == mono_defaults.string_class) {
+			is_string = TRUE;
+			conv = mono_marshal_get_string_to_ptr_conv (m->piinfo, spec);
+		}
+		else if (eklass == mono_defaults.stringbuilder_class) {
+			is_string = TRUE;
+			conv = mono_marshal_get_stringbuilder_to_ptr_conv (m->piinfo, spec);
+		}
+		else
+			conv = MONO_MARSHAL_CONV_INVALID;
+
+		mono_marshal_load_type_info (eklass);
+
+		if (is_string)
+			esize = sizeof (gpointer);
+		else
+			esize = mono_class_native_size (eklass, NULL);
+
+		dest_ptr = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+
+		/* Check null */
+		mono_mb_emit_ldloc (mb, conv_arg);
+		label1 = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+		mono_mb_emit_ldarg (mb, argnum);
+		mono_mb_emit_stloc (mb, dest_ptr);
+
+		if (eklass->blittable) {
+			/* dest */
+			mono_mb_emit_ldarg (mb, argnum);
+			/* src */
+			mono_mb_emit_ldloc (mb, conv_arg);
+			mono_mb_emit_byte (mb, CEE_CONV_I);
+			mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoArray, vector));
+			mono_mb_emit_byte (mb, CEE_ADD);
+			/* length */
+			mono_mb_emit_ldloc (mb, conv_arg);
+			mono_mb_emit_byte (mb, CEE_LDLEN);
+			mono_mb_emit_icon (mb, esize);
+			mono_mb_emit_byte (mb, CEE_MUL);
+			mono_mb_emit_byte (mb, CEE_PREFIX1);
+			mono_mb_emit_byte (mb, CEE_CPBLK);			
+			break;
+		}
+
+		/* Emit marshalling loop */
+		index_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		mono_mb_emit_byte (mb, CEE_LDC_I4_0);
+		mono_mb_emit_stloc (mb, index_var);
+		label2 = mono_mb_get_label (mb);
+		mono_mb_emit_ldloc (mb, index_var);
+		mono_mb_emit_ldloc (mb, conv_arg);
+		mono_mb_emit_byte (mb, CEE_LDLEN);
+		label3 = mono_mb_emit_branch (mb, CEE_BGE);
+
+		/* Emit marshalling code */
+		if (is_string) {
+			int stind_op;
+			g_assert (conv != MONO_MARSHAL_CONV_INVALID);
+
+			/* dest */
+			mono_mb_emit_ldloc (mb, dest_ptr);
+
+			/* src */
+			mono_mb_emit_ldloc (mb, conv_arg);
+			mono_mb_emit_ldloc (mb, index_var);
+
+			mono_mb_emit_byte (mb, CEE_LDELEM_REF);
+
+			mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
+			mono_mb_emit_byte (mb, stind_op);
+		}
+		else {
+			char *msg = g_strdup ("Marshalling of non-string and non-blittable arrays to managed code is not implemented.");
+			mono_mb_emit_exception_marshal_directive (mb, msg);
+			return conv_arg;
+		}
+
+		mono_mb_emit_add_to_local (mb, index_var, 1);
+		mono_mb_emit_add_to_local (mb, dest_ptr, esize);
+
+		mono_mb_emit_branch_label (mb, CEE_BR, label2);
+
+		mono_mb_patch_branch (mb, label1);
+		mono_mb_patch_branch (mb, label3);
+
+		break;
+	}
+	case MARSHAL_ACTION_MANAGED_CONV_RESULT: {
+		MonoClass *eklass;
+		guint32 label1, label2, label3;
+		int index_var, src, dest, esize;
+		MonoMarshalConv conv = MONO_MARSHAL_CONV_INVALID;
+		gboolean is_string = FALSE;
+		
+		g_assert (!t->byref);
+
+		eklass = klass->element_class;
+
+		mono_marshal_load_type_info (eklass);
+
+		if (eklass == mono_defaults.string_class) {
+			is_string = TRUE;
+			conv = mono_marshal_get_string_to_ptr_conv (m->piinfo, spec);
+		}
+		else {
+			g_assert_not_reached ();
+		}
+
+		if (is_string)
+			esize = sizeof (gpointer);
+		else if (eklass == mono_defaults.char_class)
+			esize = mono_pinvoke_is_unicode (m->piinfo) ? 2 : 1;
+		else
+			esize = mono_class_native_size (eklass, NULL);
+
+		src = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
+		dest = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+			
+		mono_mb_emit_stloc (mb, src);
+		mono_mb_emit_ldloc (mb, src);
+		mono_mb_emit_stloc (mb, 3);
+
+		/* Check for null */
+		mono_mb_emit_ldloc (mb, src);
+		label1 = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+		/* Allocate native array */
+		mono_mb_emit_icon (mb, esize);
+		mono_mb_emit_ldloc (mb, src);
+		mono_mb_emit_byte (mb, CEE_LDLEN);
+
+		if (eklass == mono_defaults.string_class) {
+			/* Make the array bigger for the terminating null */
+			mono_mb_emit_byte (mb, CEE_LDC_I4_1);
+			mono_mb_emit_byte (mb, CEE_ADD);
+		}
+		mono_mb_emit_byte (mb, CEE_MUL);
+		mono_mb_emit_icall (mb, ves_icall_marshal_alloc);
+		mono_mb_emit_stloc (mb, dest);
+		mono_mb_emit_ldloc (mb, dest);
+		mono_mb_emit_stloc (mb, 3);
+
+		/* Emit marshalling loop */
+		index_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		mono_mb_emit_byte (mb, CEE_LDC_I4_0);
+		mono_mb_emit_stloc (mb, index_var);
+		label2 = mono_mb_get_label (mb);
+		mono_mb_emit_ldloc (mb, index_var);
+		mono_mb_emit_ldloc (mb, src);
+		mono_mb_emit_byte (mb, CEE_LDLEN);
+		label3 = mono_mb_emit_branch (mb, CEE_BGE);
+
+		/* Emit marshalling code */
+		if (is_string) {
+			int stind_op;
+			g_assert (conv != MONO_MARSHAL_CONV_INVALID);
+
+			/* dest */
+			mono_mb_emit_ldloc (mb, dest);
+
+			/* src */
+			mono_mb_emit_ldloc (mb, src);
+			mono_mb_emit_ldloc (mb, index_var);
+
+			mono_mb_emit_byte (mb, CEE_LDELEM_REF);
+
+			mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
+			mono_mb_emit_byte (mb, stind_op);
+		}
+		else {
+			char *msg = g_strdup ("Marshalling of non-string arrays to managed code is not implemented.");
+			mono_mb_emit_exception_marshal_directive (mb, msg);
+			return conv_arg;
+		}
+
+		mono_mb_emit_add_to_local (mb, index_var, 1);
+		mono_mb_emit_add_to_local (mb, dest, esize);
+
+		mono_mb_emit_branch_label (mb, CEE_BR, label2);
+
+		mono_mb_patch_branch (mb, label3);
+		mono_mb_patch_branch (mb, label1);
+		break;
+	}
+	default:
+		g_assert_not_reached ();
+	}
+	return conv_arg;
+}
+
+static int
+emit_marshal_boolean_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
+		      MonoMarshalSpec *spec, 
+		      int conv_arg, MonoType **conv_arg_type, 
+		      MarshalAction action)
+{
+	MonoMethodBuilder *mb = m->mb;
+
+	switch (action) {
+	case MARSHAL_ACTION_CONV_IN: {
+		MonoType *local_type;
+		int label_false;
+		guint8 ldc_op = CEE_LDC_I4_1;
+
+		local_type = marshal_boolean_conv_in_get_local_type (spec, &ldc_op);
+		if (t->byref)
+			*conv_arg_type = &mono_defaults.int_class->byval_arg;
+		else
+			*conv_arg_type = local_type;
+		conv_arg = mono_mb_add_local (mb, local_type);
+		
+		mono_mb_emit_ldarg (mb, argnum);
+		if (t->byref)
+			mono_mb_emit_byte (mb, CEE_LDIND_I1);
+		label_false = mono_mb_emit_branch (mb, CEE_BRFALSE);
+		mono_mb_emit_byte (mb, ldc_op);
+		mono_mb_emit_stloc (mb, conv_arg);
+		mono_mb_patch_branch (mb, label_false);
+
+		break;
+	}
+
+	case MARSHAL_ACTION_CONV_OUT:
+	{
+		int label_false, label_end;
+		if (!t->byref)
+			break;
+
+		mono_mb_emit_ldarg (mb, argnum);
+		mono_mb_emit_ldloc (mb, conv_arg);
+		
+		label_false = mono_mb_emit_branch (mb, CEE_BRFALSE);
+		mono_mb_emit_byte (mb, CEE_LDC_I4_1);
+
+		label_end = mono_mb_emit_branch (mb, CEE_BR);
+		mono_mb_patch_branch (mb, label_false);
+		mono_mb_emit_byte (mb, CEE_LDC_I4_0);
+		mono_mb_patch_branch (mb, label_end);
+
+		mono_mb_emit_byte (mb, CEE_STIND_I1);
+		break;
+	}
+
+	case MARSHAL_ACTION_PUSH:
+		if (t->byref)
+			mono_mb_emit_ldloc_addr (mb, conv_arg);
+		else if (conv_arg)
+			mono_mb_emit_ldloc (mb, conv_arg);
+		else
+			mono_mb_emit_ldarg (mb, argnum);
+		break;
+
+	case MARSHAL_ACTION_CONV_RESULT:
+		/* maybe we need to make sure that it fits within 8 bits */
+		mono_mb_emit_stloc (mb, 3);
+		break;
+
+	case MARSHAL_ACTION_MANAGED_CONV_IN: {
+		MonoClass* conv_arg_class = mono_defaults.int32_class;
+		guint8 ldop = CEE_LDIND_I4;
+		int label_null, label_false;
+
+		conv_arg_class = marshal_boolean_managed_conv_in_get_conv_arg_class (spec, &ldop);
+		conv_arg = mono_mb_add_local (mb, &mono_defaults.boolean_class->byval_arg);
+
+		if (t->byref)
+			*conv_arg_type = &conv_arg_class->this_arg;
+		else
+			*conv_arg_type = &conv_arg_class->byval_arg;
+
+
+		mono_mb_emit_ldarg (mb, argnum);
+		
+		/* Check null */
+		if (t->byref) {
+			label_null = mono_mb_emit_branch (mb, CEE_BRFALSE);
+			mono_mb_emit_ldarg (mb, argnum);
+			mono_mb_emit_byte (mb, ldop);
+		} else
+			label_null = 0;
+
+		label_false = mono_mb_emit_branch (mb, CEE_BRFALSE);
+		mono_mb_emit_byte (mb, CEE_LDC_I4_1);
+		mono_mb_emit_stloc (mb, conv_arg);
+		mono_mb_patch_branch (mb, label_false);
+
+		if (t->byref) 
+			mono_mb_patch_branch (mb, label_null);
+		break;
+	}
+
+	case MARSHAL_ACTION_MANAGED_CONV_OUT: {
+		guint8 stop = CEE_STIND_I4;
+		guint8 ldc_op = CEE_LDC_I4_1;
+		int label_null,label_false, label_end;;
+
+		if (!t->byref)
+			break;
+		if (spec) {
+			switch (spec->native) {
+			case MONO_NATIVE_I1:
+			case MONO_NATIVE_U1:
+				stop = CEE_STIND_I1;
+				break;
+			case MONO_NATIVE_VARIANTBOOL:
+				stop = CEE_STIND_I2;
+				ldc_op = CEE_LDC_I4_M1;
+				break;
+			default:
+				break;
+			}
+		}
+		
+		/* Check null */
+		mono_mb_emit_ldarg (mb, argnum);
+		label_null = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+		mono_mb_emit_ldarg (mb, argnum);
+		mono_mb_emit_ldloc (mb, conv_arg);
+
+		label_false = mono_mb_emit_branch (mb, CEE_BRFALSE);
+		mono_mb_emit_byte (mb, ldc_op);
+		label_end = mono_mb_emit_branch (mb, CEE_BR);
+
+		mono_mb_patch_branch (mb, label_false);
+		mono_mb_emit_byte (mb, CEE_LDC_I4_0);
+		mono_mb_patch_branch (mb, label_end);
+
+		mono_mb_emit_byte (mb, stop);
+		mono_mb_patch_branch (mb, label_null);
+		break;
+	}
+
+	default:
+		g_assert_not_reached ();
+	}
+	return conv_arg;
+}
+
+static int
+emit_marshal_ptr_ilgen (EmitMarshalContext *m, int argnum, MonoType *t, 
+		  MonoMarshalSpec *spec, int conv_arg, 
+		  MonoType **conv_arg_type, MarshalAction action)
+{
+	MonoMethodBuilder *mb = m->mb;
+
+	switch (action) {
+	case MARSHAL_ACTION_CONV_IN:
+		/* MS seems to allow this in some cases, ie. bxc #158 */
+		/*
+		if (MONO_TYPE_ISSTRUCT (t->data.type) && !mono_class_from_mono_type (t->data.type)->blittable) {
+			char *msg = g_strdup_printf ("Can not marshal 'parameter #%d': Pointers can not reference marshaled structures. Use byref instead.", argnum + 1);
+			mono_mb_emit_exception_marshal_directive (m->mb, msg);
+		}
+		*/
+		break;
+
+	case MARSHAL_ACTION_PUSH:
+		mono_mb_emit_ldarg (mb, argnum);
+		break;
+
+	case MARSHAL_ACTION_CONV_RESULT:
+		/* no conversions necessary */
+		mono_mb_emit_stloc (mb, 3);
+		break;
+
+	default:
+		break;
+	}
+	return conv_arg;
+}
+
+static int
+emit_marshal_char_ilgen (EmitMarshalContext *m, int argnum, MonoType *t, 
+		   MonoMarshalSpec *spec, int conv_arg, 
+		   MonoType **conv_arg_type, MarshalAction action)
+{
+	MonoMethodBuilder *mb = m->mb;
+
+	switch (action) {
+	case MARSHAL_ACTION_PUSH:
+		/* fixme: dont know how to marshal that. We cant simply
+		 * convert it to a one byte UTF8 character, because an
+		 * unicode character may need more that one byte in UTF8 */
+		mono_mb_emit_ldarg (mb, argnum);
+		break;
+
+	case MARSHAL_ACTION_CONV_RESULT:
+		/* fixme: we need conversions here */
+		mono_mb_emit_stloc (mb, 3);
+		break;
+
+	default:
+		break;
+	}
+	return conv_arg;
+}
+
+static int
+emit_marshal_scalar_ilgen (EmitMarshalContext *m, int argnum, MonoType *t, 
+		     MonoMarshalSpec *spec, int conv_arg, 
+		     MonoType **conv_arg_type, MarshalAction action)
+{
+	MonoMethodBuilder *mb = m->mb;
+
+	switch (action) {
+	case MARSHAL_ACTION_PUSH:
+		mono_mb_emit_ldarg (mb, argnum);
+		break;
+
+	case MARSHAL_ACTION_CONV_RESULT:
+		/* no conversions necessary */
+		mono_mb_emit_stloc (mb, 3);
+		break;
+
+	default:
+		break;
+	}
+	return conv_arg;
+}
+
+static void
+emit_virtual_stelemref_ilgen (MonoMethodBuilder *mb, const char **param_names, int kind)
+{
+	guint32 b1, b2, b3, b4;
+	int aklass, vklass, vtable, uiid;
+	int array_slot_addr;
+
+	mono_mb_set_param_names (mb, param_names);
+
+	/*For now simply call plain old stelemref*/
+	switch (kind) {
+	case STELEMREF_OBJECT:
+		/* ldelema (implicit bound check) */
+		load_array_element_address (mb);
+		/* do_store */
+		mono_mb_emit_ldarg (mb, 2);
+		mono_mb_emit_byte (mb, CEE_STIND_REF);
+		mono_mb_emit_byte (mb, CEE_RET);
+		break;
+
+	case STELEMREF_COMPLEX: {
+		int b_fast;
+		/*
+		<ldelema (bound check)>
+		if (!value)
+			goto store;
+		if (!mono_object_isinst (value, aklass))
+			goto do_exception;
+
+		 do_store:
+			 *array_slot_addr = value;
+
+		do_exception:
+			throw new ArrayTypeMismatchException ();
+		*/
+
+		aklass = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		vklass = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		array_slot_addr = mono_mb_add_local (mb, &mono_defaults.object_class->this_arg);
+
+#if 0
+		{
+			/*Use this to debug/record stores that are going thru the slow path*/
+			MonoMethodSignature *csig;
+			csig = mono_metadata_signature_alloc (mono_defaults.corlib, 3);
+			csig->ret = &mono_defaults.void_class->byval_arg;
+			csig->params [0] = &mono_defaults.object_class->byval_arg;
+			csig->params [1] = &mono_defaults.int_class->byval_arg; /* this is a natural sized int */
+			csig->params [2] = &mono_defaults.object_class->byval_arg;
+			mono_mb_emit_ldarg (mb, 0);
+			mono_mb_emit_ldarg (mb, 1);
+			mono_mb_emit_ldarg (mb, 2);
+			mono_mb_emit_native_call (mb, csig, record_slot_vstore);
+		}
+#endif
+
+		/* ldelema (implicit bound check) */
+		load_array_element_address (mb);
+		mono_mb_emit_stloc (mb, array_slot_addr);
+
+		/* if (!value) goto do_store */
+		mono_mb_emit_ldarg (mb, 2);
+		b1 = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+		/* aklass = array->vtable->klass->element_class */
+		load_array_class (mb, aklass);
+		/* vklass = value->vtable->klass */
+		load_value_class (mb, vklass);
+
+		/* fastpath */
+		mono_mb_emit_ldloc (mb, vklass);
+		mono_mb_emit_ldloc (mb, aklass);
+		b_fast = mono_mb_emit_branch (mb, CEE_BEQ);
+
+		/*if (mono_object_isinst (value, aklass)) */
+		mono_mb_emit_ldarg (mb, 2);
+		mono_mb_emit_ldloc (mb, aklass);
+		mono_mb_emit_icall (mb, mono_object_isinst_icall);
+		b2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+		/* do_store: */
+		mono_mb_patch_branch (mb, b1);
+		mono_mb_patch_branch (mb, b_fast);
+		mono_mb_emit_ldloc (mb, array_slot_addr);
+		mono_mb_emit_ldarg (mb, 2);
+		mono_mb_emit_byte (mb, CEE_STIND_REF);
+		mono_mb_emit_byte (mb, CEE_RET);
+
+		/* do_exception: */
+		mono_mb_patch_branch (mb, b2);
+
+		mono_mb_emit_exception (mb, "ArrayTypeMismatchException", NULL);
+		break;
+	}
+	case STELEMREF_SEALED_CLASS:
+		/*
+		<ldelema (bound check)>
+		if (!value)
+			goto store;
+
+		aklass = array->vtable->klass->element_class;
+		vklass = value->vtable->klass;
+
+		if (vklass != aklass)
+			goto do_exception;
+
+		do_store:
+			 *array_slot_addr = value;
+
+		do_exception:
+			throw new ArrayTypeMismatchException ();
+		*/
+		aklass = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		vklass = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		array_slot_addr = mono_mb_add_local (mb, &mono_defaults.object_class->this_arg);
+
+		/* ldelema (implicit bound check) */
+		load_array_element_address (mb);
+		mono_mb_emit_stloc (mb, array_slot_addr);
+
+		/* if (!value) goto do_store */
+		mono_mb_emit_ldarg (mb, 2);
+		b1 = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+		/* aklass = array->vtable->klass->element_class */
+		load_array_class (mb, aklass);
+
+		/* vklass = value->vtable->klass */
+		load_value_class (mb, vklass);
+
+		/*if (vklass != aklass) goto do_exception; */
+		mono_mb_emit_ldloc (mb, aklass);
+		mono_mb_emit_ldloc (mb, vklass);
+		b2 = mono_mb_emit_branch (mb, CEE_BNE_UN);
+
+		/* do_store: */
+		mono_mb_patch_branch (mb, b1);
+		mono_mb_emit_ldloc (mb, array_slot_addr);
+		mono_mb_emit_ldarg (mb, 2);
+		mono_mb_emit_byte (mb, CEE_STIND_REF);
+		mono_mb_emit_byte (mb, CEE_RET);
+
+		/* do_exception: */
+		mono_mb_patch_branch (mb, b2);
+		mono_mb_emit_exception (mb, "ArrayTypeMismatchException", NULL);
+		break;
+
+	case STELEMREF_CLASS: {
+		/*
+		the method:
+		<ldelema (bound check)>
+		if (!value)
+			goto do_store;
+
+		aklass = array->vtable->klass->element_class;
+		vklass = value->vtable->klass;
+
+		if (vklass->idepth < aklass->idepth)
+			goto do_exception;
+
+		if (vklass->supertypes [aklass->idepth - 1] != aklass)
+			goto do_exception;
+
+		do_store:
+			*array_slot_addr = value;
+			return;
+
+		long:
+			throw new ArrayTypeMismatchException ();
+		*/
+		aklass = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		vklass = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		array_slot_addr = mono_mb_add_local (mb, &mono_defaults.object_class->this_arg);
+
+		/* ldelema (implicit bound check) */
+		load_array_element_address (mb);
+		mono_mb_emit_stloc (mb, array_slot_addr);
+
+		/* if (!value) goto do_store */
+		mono_mb_emit_ldarg (mb, 2);
+		b1 = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+		/* aklass = array->vtable->klass->element_class */
+		load_array_class (mb, aklass);
+
+		/* vklass = value->vtable->klass */
+		load_value_class (mb, vklass);
+
+		/* if (vklass->idepth < aklass->idepth) goto failue */
+		mono_mb_emit_ldloc (mb, vklass);
+		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, idepth));
+		mono_mb_emit_byte (mb, CEE_LDIND_U2);
+
+		mono_mb_emit_ldloc (mb, aklass);
+		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, idepth));
+		mono_mb_emit_byte (mb, CEE_LDIND_U2);
+
+		b3 = mono_mb_emit_branch (mb, CEE_BLT_UN);
+
+		/* if (vklass->supertypes [aklass->idepth - 1] != aklass) goto failure */
+		mono_mb_emit_ldloc (mb, vklass);
+		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, supertypes));
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+
+		mono_mb_emit_ldloc (mb, aklass);
+		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, idepth));
+		mono_mb_emit_byte (mb, CEE_LDIND_U2);
+		mono_mb_emit_icon (mb, 1);
+		mono_mb_emit_byte (mb, CEE_SUB);
+		mono_mb_emit_icon (mb, sizeof (void*));
+		mono_mb_emit_byte (mb, CEE_MUL);
+		mono_mb_emit_byte (mb, CEE_ADD);
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+
+		mono_mb_emit_ldloc (mb, aklass);
+		b4 = mono_mb_emit_branch (mb, CEE_BNE_UN);
+
+		/* do_store: */
+		mono_mb_patch_branch (mb, b1);
+		mono_mb_emit_ldloc (mb, array_slot_addr);
+		mono_mb_emit_ldarg (mb, 2);
+		mono_mb_emit_byte (mb, CEE_STIND_REF);
+		mono_mb_emit_byte (mb, CEE_RET);
+
+		/* do_exception: */
+		mono_mb_patch_branch (mb, b3);
+		mono_mb_patch_branch (mb, b4);
+
+		mono_mb_emit_exception (mb, "ArrayTypeMismatchException", NULL);
+		break;
+	}
+
+	case STELEMREF_CLASS_SMALL_IDEPTH:
+		/*
+		the method:
+		<ldelema (bound check)>
+		if (!value)
+			goto do_store;
+
+		aklass = array->vtable->klass->element_class;
+		vklass = value->vtable->klass;
+
+		if (vklass->supertypes [aklass->idepth - 1] != aklass)
+			goto do_exception;
+
+		do_store:
+			*array_slot_addr = value;
+			return;
+
+		long:
+			throw new ArrayTypeMismatchException ();
+		*/
+		aklass = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		vklass = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		array_slot_addr = mono_mb_add_local (mb, &mono_defaults.object_class->this_arg);
+
+		/* ldelema (implicit bound check) */
+		load_array_element_address (mb);
+		mono_mb_emit_stloc (mb, array_slot_addr);
+
+		/* if (!value) goto do_store */
+		mono_mb_emit_ldarg (mb, 2);
+		b1 = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+		/* aklass = array->vtable->klass->element_class */
+		load_array_class (mb, aklass);
+
+		/* vklass = value->vtable->klass */
+		load_value_class (mb, vklass);
+
+		/* if (vklass->supertypes [aklass->idepth - 1] != aklass) goto failure */
+		mono_mb_emit_ldloc (mb, vklass);
+		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, supertypes));
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+
+		mono_mb_emit_ldloc (mb, aklass);
+		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, idepth));
+		mono_mb_emit_byte (mb, CEE_LDIND_U2);
+		mono_mb_emit_icon (mb, 1);
+		mono_mb_emit_byte (mb, CEE_SUB);
+		mono_mb_emit_icon (mb, sizeof (void*));
+		mono_mb_emit_byte (mb, CEE_MUL);
+		mono_mb_emit_byte (mb, CEE_ADD);
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+
+		mono_mb_emit_ldloc (mb, aklass);
+		b4 = mono_mb_emit_branch (mb, CEE_BNE_UN);
+
+		/* do_store: */
+		mono_mb_patch_branch (mb, b1);
+		mono_mb_emit_ldloc (mb, array_slot_addr);
+		mono_mb_emit_ldarg (mb, 2);
+		mono_mb_emit_byte (mb, CEE_STIND_REF);
+		mono_mb_emit_byte (mb, CEE_RET);
+
+		/* do_exception: */
+		mono_mb_patch_branch (mb, b4);
+
+		mono_mb_emit_exception (mb, "ArrayTypeMismatchException", NULL);
+		break;
+
+	case STELEMREF_INTERFACE:
+		/*Mono *klass;
+		MonoVTable *vt;
+		unsigned uiid;
+		if (value == NULL)
+			goto store;
+
+		klass = array->obj.vtable->klass->element_class;
+		vt = value->vtable;
+		uiid = klass->interface_id;
+		if (uiid > vt->max_interface_id)
+			goto exception;
+		if (!(vt->interface_bitmap [(uiid) >> 3] & (1 << ((uiid)&7))))
+			goto exception;
+		store:
+			mono_array_setref (array, index, value);
+			return;
+		exception:
+			mono_raise_exception (mono_get_exception_array_type_mismatch ());*/
+
+		array_slot_addr = mono_mb_add_local (mb, &mono_defaults.object_class->this_arg);
+		aklass = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		vtable = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		uiid = mono_mb_add_local (mb, &mono_defaults.int32_class->byval_arg);
+
+		/* ldelema (implicit bound check) */
+		load_array_element_address (mb);
+		mono_mb_emit_stloc (mb, array_slot_addr);
+
+		/* if (!value) goto do_store */
+		mono_mb_emit_ldarg (mb, 2);
+		b1 = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+		/* klass = array->vtable->klass->element_class */
+		load_array_class (mb, aklass);
+
+		/* vt = value->vtable */
+		mono_mb_emit_ldarg (mb, 2);
+		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoObject, vtable));
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+		mono_mb_emit_stloc (mb, vtable);
+
+		/* uiid = klass->interface_id; */
+		mono_mb_emit_ldloc (mb, aklass);
+		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, interface_id));
+		mono_mb_emit_byte (mb, CEE_LDIND_U4);
+		mono_mb_emit_stloc (mb, uiid);
+
+		/*if (uiid > vt->max_interface_id)*/
+		mono_mb_emit_ldloc (mb, uiid);
+		mono_mb_emit_ldloc (mb, vtable);
+		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoVTable, max_interface_id));
+		mono_mb_emit_byte (mb, CEE_LDIND_U4);
+		b2 = mono_mb_emit_branch (mb, CEE_BGT_UN);
+
+		/* if (!(vt->interface_bitmap [(uiid) >> 3] & (1 << ((uiid)&7)))) */
+
+		/*vt->interface_bitmap*/
+		mono_mb_emit_ldloc (mb, vtable);
+		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoVTable, interface_bitmap));
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+
+		/*uiid >> 3*/
+		mono_mb_emit_ldloc (mb, uiid);
+		mono_mb_emit_icon (mb, 3);
+		mono_mb_emit_byte (mb, CEE_SHR_UN);
+
+		/*vt->interface_bitmap [(uiid) >> 3]*/
+		mono_mb_emit_byte (mb, CEE_ADD); /*interface_bitmap is a guint8 array*/
+		mono_mb_emit_byte (mb, CEE_LDIND_U1);
+
+		/*(1 << ((uiid)&7)))*/
+		mono_mb_emit_icon (mb, 1);
+		mono_mb_emit_ldloc (mb, uiid);
+		mono_mb_emit_icon (mb, 7);
+		mono_mb_emit_byte (mb, CEE_AND);
+		mono_mb_emit_byte (mb, CEE_SHL);
+
+		/*bitwise and the whole thing*/
+		mono_mb_emit_byte (mb, CEE_AND);
+		b3 = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+		/* do_store: */
+		mono_mb_patch_branch (mb, b1);
+		mono_mb_emit_ldloc (mb, array_slot_addr);
+		mono_mb_emit_ldarg (mb, 2);
+		mono_mb_emit_byte (mb, CEE_STIND_REF);
+		mono_mb_emit_byte (mb, CEE_RET);
+
+		/* do_exception: */
+		mono_mb_patch_branch (mb, b2);
+		mono_mb_patch_branch (mb, b3);
+		mono_mb_emit_exception (mb, "ArrayTypeMismatchException", NULL);
+		break;
+
+	default:
+		mono_mb_emit_ldarg (mb, 0);
+		mono_mb_emit_ldarg (mb, 1);
+		mono_mb_emit_ldarg (mb, 2);
+		mono_mb_emit_managed_call (mb, mono_marshal_get_stelemref (), NULL);
+		mono_mb_emit_byte (mb, CEE_RET);
+		g_assert (0);
+	}
+}
+
+static void
+emit_stelemref_ilgen (MonoMethodBuilder *mb)
+{
+	guint32 b1, b2, b3, b4;
+	guint32 copy_pos;
+	int aklass, vklass;
+	int array_slot_addr;
+	
+	aklass = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+	vklass = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+	array_slot_addr = mono_mb_add_local (mb, &mono_defaults.object_class->this_arg);
+	
+	/*
+	the method:
+	<ldelema (bound check)>
+	if (!value)
+		goto store;
+	
+	aklass = array->vtable->klass->element_class;
+	vklass = value->vtable->klass;
+	
+	if (vklass->idepth < aklass->idepth)
+		goto long;
+	
+	if (vklass->supertypes [aklass->idepth - 1] != aklass)
+		goto long;
+	
+	store:
+		*array_slot_addr = value;
+		return;
+	
+	long:
+		if (mono_object_isinst (value, aklass))
+			goto store;
+		
+		throw new ArrayTypeMismatchException ();
+	*/
+	
+	/* ldelema (implicit bound check) */
+	mono_mb_emit_ldarg (mb, 0);
+	mono_mb_emit_ldarg (mb, 1);
+	mono_mb_emit_op (mb, CEE_LDELEMA, mono_defaults.object_class);
+	mono_mb_emit_stloc (mb, array_slot_addr);
+		
+	/* if (!value) goto do_store */
+	mono_mb_emit_ldarg (mb, 2);
+	b1 = mono_mb_emit_branch (mb, CEE_BRFALSE);
+	
+	/* aklass = array->vtable->klass->element_class */
+	mono_mb_emit_ldarg (mb, 0);
+	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoObject, vtable));
+	mono_mb_emit_byte (mb, CEE_LDIND_I);
+	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoVTable, klass));
+	mono_mb_emit_byte (mb, CEE_LDIND_I);
+	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, element_class));
+	mono_mb_emit_byte (mb, CEE_LDIND_I);
+	mono_mb_emit_stloc (mb, aklass);
+	
+	/* vklass = value->vtable->klass */
+	mono_mb_emit_ldarg (mb, 2);
+	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoObject, vtable));
+	mono_mb_emit_byte (mb, CEE_LDIND_I);
+	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoVTable, klass));
+	mono_mb_emit_byte (mb, CEE_LDIND_I);
+	mono_mb_emit_stloc (mb, vklass);
+	
+	/* if (vklass->idepth < aklass->idepth) goto failue */
+	mono_mb_emit_ldloc (mb, vklass);
+	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, idepth));
+	mono_mb_emit_byte (mb, CEE_LDIND_U2);
+	
+	mono_mb_emit_ldloc (mb, aklass);
+	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, idepth));
+	mono_mb_emit_byte (mb, CEE_LDIND_U2);
+	
+	b2 = mono_mb_emit_branch (mb, CEE_BLT_UN);
+	
+	/* if (vklass->supertypes [aklass->idepth - 1] != aklass) goto failure */
+	mono_mb_emit_ldloc (mb, vklass);
+	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, supertypes));
+	mono_mb_emit_byte (mb, CEE_LDIND_I);
+	
+	mono_mb_emit_ldloc (mb, aklass);
+	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, idepth));
+	mono_mb_emit_byte (mb, CEE_LDIND_U2);
+	mono_mb_emit_icon (mb, 1);
+	mono_mb_emit_byte (mb, CEE_SUB);
+	mono_mb_emit_icon (mb, sizeof (void*));
+	mono_mb_emit_byte (mb, CEE_MUL);
+	mono_mb_emit_byte (mb, CEE_ADD);
+	mono_mb_emit_byte (mb, CEE_LDIND_I);
+	
+	mono_mb_emit_ldloc (mb, aklass);
+	
+	b3 = mono_mb_emit_branch (mb, CEE_BNE_UN);
+	
+	copy_pos = mono_mb_get_label (mb);
+	/* do_store */
+	mono_mb_patch_branch (mb, b1);
+	mono_mb_emit_ldloc (mb, array_slot_addr);
+	mono_mb_emit_ldarg (mb, 2);
+	mono_mb_emit_byte (mb, CEE_STIND_REF);
+	
+	mono_mb_emit_byte (mb, CEE_RET);
+	
+	/* the hard way */
+	mono_mb_patch_branch (mb, b2);
+	mono_mb_patch_branch (mb, b3);
+	
+	mono_mb_emit_ldarg (mb, 2);
+	mono_mb_emit_ldloc (mb, aklass);
+	mono_mb_emit_icall (mb, mono_object_isinst_icall);
+	
+	b4 = mono_mb_emit_branch (mb, CEE_BRTRUE);
+	mono_mb_patch_addr (mb, b4, copy_pos - (b4 + 4));
+	mono_mb_emit_exception (mb, "ArrayTypeMismatchException", NULL);
+	
+	mono_mb_emit_byte (mb, CEE_RET);
+}
+
+static void
+mb_emit_byte_ilgen (MonoMethodBuilder *mb, guint8 op)
+{
+	mono_mb_emit_byte (mb, op);
+}
+
+static void
+emit_array_address_ilgen (MonoMethodBuilder *mb, int rank, int elem_size)
+{
+	int i, bounds, ind, realidx;
+	int branch_pos, *branch_positions;
+
+	branch_positions = g_new0 (int, rank);
+
+	bounds = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+	ind = mono_mb_add_local (mb, &mono_defaults.int32_class->byval_arg);
+	realidx = mono_mb_add_local (mb, &mono_defaults.int32_class->byval_arg);
+
+	/* bounds = array->bounds; */
+	mono_mb_emit_ldarg (mb, 0);
+	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoArray, bounds));
+	mono_mb_emit_byte (mb, CEE_LDIND_I);
+	mono_mb_emit_stloc (mb, bounds);
+
+	/* ind is the overall element index, realidx is the partial index in a single dimension */
+	/* ind = idx0 - bounds [0].lower_bound */
+	mono_mb_emit_ldarg (mb, 1);
+	mono_mb_emit_ldloc (mb, bounds);
+	mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoArrayBounds, lower_bound));
+	mono_mb_emit_byte (mb, CEE_ADD);
+	mono_mb_emit_byte (mb, CEE_LDIND_I4);
+	mono_mb_emit_byte (mb, CEE_SUB);
+	mono_mb_emit_stloc (mb, ind);
+	/* if (ind >= bounds [0].length) goto exeception; */
+	mono_mb_emit_ldloc (mb, ind);
+	mono_mb_emit_ldloc (mb, bounds);
+	mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoArrayBounds, length));
+	mono_mb_emit_byte (mb, CEE_ADD);
+	mono_mb_emit_byte (mb, CEE_LDIND_I4);
+	/* note that we use unsigned comparison */
+	branch_pos = mono_mb_emit_branch (mb, CEE_BGE_UN);
+
+ 	/* For large ranks (> 4?) use a loop n IL later to reduce code size.
+	 * We could also decide to ignore the passed elem_size and get it
+	 * from the array object, to reduce the number of methods we generate:
+	 * the additional cost is 3 memory loads and a non-immediate mul.
+	 */
+	for (i = 1; i < rank; ++i) {
+		/* realidx = idxi - bounds [i].lower_bound */
+		mono_mb_emit_ldarg (mb, 1 + i);
+		mono_mb_emit_ldloc (mb, bounds);
+		mono_mb_emit_icon (mb, (i * sizeof (MonoArrayBounds)) + MONO_STRUCT_OFFSET (MonoArrayBounds, lower_bound));
+		mono_mb_emit_byte (mb, CEE_ADD);
+		mono_mb_emit_byte (mb, CEE_LDIND_I4);
+		mono_mb_emit_byte (mb, CEE_SUB);
+		mono_mb_emit_stloc (mb, realidx);
+		/* if (realidx >= bounds [i].length) goto exeception; */
+		mono_mb_emit_ldloc (mb, realidx);
+		mono_mb_emit_ldloc (mb, bounds);
+		mono_mb_emit_icon (mb, (i * sizeof (MonoArrayBounds)) + MONO_STRUCT_OFFSET (MonoArrayBounds, length));
+		mono_mb_emit_byte (mb, CEE_ADD);
+		mono_mb_emit_byte (mb, CEE_LDIND_I4);
+		branch_positions [i] = mono_mb_emit_branch (mb, CEE_BGE_UN);
+		/* ind = ind * bounds [i].length + realidx */
+		mono_mb_emit_ldloc (mb, ind);
+		mono_mb_emit_ldloc (mb, bounds);
+		mono_mb_emit_icon (mb, (i * sizeof (MonoArrayBounds)) + MONO_STRUCT_OFFSET (MonoArrayBounds, length));
+		mono_mb_emit_byte (mb, CEE_ADD);
+		mono_mb_emit_byte (mb, CEE_LDIND_I4);
+		mono_mb_emit_byte (mb, CEE_MUL);
+		mono_mb_emit_ldloc (mb, realidx);
+		mono_mb_emit_byte (mb, CEE_ADD);
+		mono_mb_emit_stloc (mb, ind);
+	}
+
+	/* return array->vector + ind * element_size */
+	mono_mb_emit_ldarg (mb, 0);
+	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoArray, vector));
+	mono_mb_emit_ldloc (mb, ind);
+	if (elem_size) {
+		mono_mb_emit_icon (mb, elem_size);
+	} else {
+		/* Load arr->vtable->klass->sizes.element_class */
+		mono_mb_emit_ldarg (mb, 0);
+		mono_mb_emit_byte (mb, CEE_CONV_I);
+		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoObject, vtable));
+		mono_mb_emit_byte (mb, CEE_ADD);
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoVTable, klass));
+		mono_mb_emit_byte (mb, CEE_ADD);
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+		/* sizes is an union, so this reads sizes.element_size */
+		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoClass, sizes));
+		mono_mb_emit_byte (mb, CEE_ADD);
+		mono_mb_emit_byte (mb, CEE_LDIND_I4);
+	}
+		mono_mb_emit_byte (mb, CEE_MUL);
+	mono_mb_emit_byte (mb, CEE_ADD);
+	mono_mb_emit_byte (mb, CEE_RET);
+
+	/* patch the branches to get here and throw */
+	for (i = 1; i < rank; ++i) {
+		mono_mb_patch_branch (mb, branch_positions [i]);
+	}
+	mono_mb_patch_branch (mb, branch_pos);
+	/* throw exception */
+	mono_mb_emit_exception (mb, "IndexOutOfRangeException", NULL);
+
+	g_free (branch_positions);
+}
+
+static void
+emit_delegate_begin_invoke_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *sig)
+{
+	int params_var;
+	params_var = mono_mb_emit_save_args (mb, sig, FALSE);
+
+	mono_mb_emit_ldarg (mb, 0);
+	mono_mb_emit_ldloc (mb, params_var);
+	mono_mb_emit_icall (mb, mono_delegate_begin_invoke);
+	mono_mb_emit_byte (mb, CEE_RET);
+}
+
+static void
+emit_delegate_end_invoke_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *sig)
+{
+	int params_var;
+	params_var = mono_mb_emit_save_args (mb, sig, FALSE);
+
+	mono_mb_emit_ldarg (mb, 0);
+	mono_mb_emit_ldloc (mb, params_var);
+	mono_mb_emit_icall (mb, mono_delegate_end_invoke);
+
+	if (sig->ret->type == MONO_TYPE_VOID) {
+		mono_mb_emit_byte (mb, CEE_POP);
+		mono_mb_emit_byte (mb, CEE_RET);
+	} else
+		mono_mb_emit_restore_result (mb, sig->ret);
+}
+
+static void
+emit_delegate_invoke_internal_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *sig, MonoMethodSignature *invoke_sig, gboolean static_method_with_first_arg_bound, gboolean callvirt, gboolean closed_over_null, MonoMethod *method, MonoMethod *target_method, MonoClass *target_class, MonoGenericContext *ctx, MonoGenericContainer *container)
+{
+	int local_i, local_len, local_delegates, local_d, local_target, local_res;
+	int pos0, pos1, pos2;
+	int i;
+	gboolean void_ret;
+
+	void_ret = sig->ret->type == MONO_TYPE_VOID && !method->string_ctor;
+
+	/* allocate local 0 (object) */
+	local_i = mono_mb_add_local (mb, &mono_defaults.int32_class->byval_arg);
+	local_len = mono_mb_add_local (mb, &mono_defaults.int32_class->byval_arg);
+	local_delegates = mono_mb_add_local (mb, &mono_defaults.array_class->byval_arg);
+	local_d = mono_mb_add_local (mb, &mono_defaults.multicastdelegate_class->byval_arg);
+	local_target = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
+
+	if (!void_ret)
+		local_res = mono_mb_add_local (mb, &mono_class_from_mono_type (sig->ret)->byval_arg);
+
+	g_assert (sig->hasthis);
+
+	/*
+	 * {type: sig->ret} res;
+	 * if (delegates == null) {
+	 *     return this.<target> ( args .. );
+	 * } else {
+	 *     int i = 0, len = this.delegates.Length;
+	 *     do {
+	 *         res = this.delegates [i].Invoke ( args .. );
+	 *     } while (++i < len);
+	 *     return res;
+	 * }
+	 */
+
+	/* this wrapper can be used in unmanaged-managed transitions */
+	emit_thread_interrupt_checkpoint (mb);
+
+	/* delegates = this.delegates */
+	mono_mb_emit_ldarg (mb, 0);
+	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoMulticastDelegate, delegates));
+	mono_mb_emit_byte (mb, CEE_LDIND_REF);
+	mono_mb_emit_stloc (mb, local_delegates);
+
+	/* if (delegates == null) */
+	mono_mb_emit_ldloc (mb, local_delegates);
+	pos2 = mono_mb_emit_branch (mb, CEE_BRTRUE);
+
+	/* return target.<target_method|method_ptr> ( args .. ); */
+
+	/* target = d.target; */
+	mono_mb_emit_ldarg (mb, 0);
+	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoDelegate, target));
+	mono_mb_emit_byte (mb, CEE_LDIND_REF);
+	mono_mb_emit_stloc (mb, local_target);
+
+	/*static methods with bound first arg can have null target and still be bound*/
+	if (!static_method_with_first_arg_bound) {
+		/* if target != null */
+		mono_mb_emit_ldloc (mb, local_target);
+		pos0 = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+		/* then call this->method_ptr nonstatic */
+		if (callvirt) {
+			// FIXME:
+			mono_mb_emit_exception_full (mb, "System", "NotImplementedException", "");
+		} else {
+			mono_mb_emit_ldloc (mb, local_target);
+			for (i = 0; i < sig->param_count; ++i)
+				mono_mb_emit_ldarg (mb, i + 1);
+			mono_mb_emit_ldarg (mb, 0);
+			mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoDelegate, extra_arg));
+			mono_mb_emit_byte (mb, CEE_LDIND_I);
+			mono_mb_emit_ldarg (mb, 0);
+			mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoDelegate, method_ptr));
+			mono_mb_emit_byte (mb, CEE_LDIND_I);
+			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+			mono_mb_emit_op (mb, CEE_MONO_CALLI_EXTRA_ARG, sig);
+			mono_mb_emit_byte (mb, CEE_RET);
+		}
+	
+		/* else [target == null] call this->method_ptr static */
+		mono_mb_patch_branch (mb, pos0);
+	}
+
+	if (callvirt) {
+		if (!closed_over_null) {
+			if (target_class->valuetype) {
+				mono_mb_emit_ldarg (mb, 1);
+				for (i = 1; i < sig->param_count; ++i)
+					mono_mb_emit_ldarg (mb, i + 1);
+				mono_mb_emit_op (mb, CEE_CALL, target_method);
+			} else {
+				mono_mb_emit_ldarg (mb, 1);
+				mono_mb_emit_op (mb, CEE_CASTCLASS, target_class);
+				for (i = 1; i < sig->param_count; ++i)
+					mono_mb_emit_ldarg (mb, i + 1);
+				mono_mb_emit_op (mb, CEE_CALLVIRT, target_method);
+			}
+		} else {
+			mono_mb_emit_byte (mb, CEE_LDNULL);
+			for (i = 0; i < sig->param_count; ++i)
+				mono_mb_emit_ldarg (mb, i + 1);
+			mono_mb_emit_op (mb, CEE_CALL, target_method);
+		}
+	} else {
+		if (static_method_with_first_arg_bound) {
+			mono_mb_emit_ldloc (mb, local_target);
+			if (!MONO_TYPE_IS_REFERENCE (invoke_sig->params[0]))
+				mono_mb_emit_op (mb, CEE_UNBOX_ANY, mono_class_from_mono_type (invoke_sig->params[0]));
+		}
+		for (i = 0; i < sig->param_count; ++i)
+			mono_mb_emit_ldarg (mb, i + 1);
+		mono_mb_emit_ldarg (mb, 0);
+		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoDelegate, extra_arg));
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+		mono_mb_emit_ldarg (mb, 0);
+		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoDelegate, method_ptr));
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+		mono_mb_emit_op (mb, CEE_MONO_CALLI_EXTRA_ARG, invoke_sig);
+	}
+
+	mono_mb_emit_byte (mb, CEE_RET);
+
+	/* else [delegates != null] */
+	mono_mb_patch_branch (mb, pos2);
+
+	/* len = delegates.Length; */
+	mono_mb_emit_ldloc (mb, local_delegates);
+	mono_mb_emit_byte (mb, CEE_LDLEN);
+	mono_mb_emit_byte (mb, CEE_CONV_I4);
+	mono_mb_emit_stloc (mb, local_len);
+
+	/* i = 0; */
+	mono_mb_emit_icon (mb, 0);
+	mono_mb_emit_stloc (mb, local_i);
+
+	pos1 = mono_mb_get_label (mb);
+
+	/* d = delegates [i]; */
+	mono_mb_emit_ldloc (mb, local_delegates);
+	mono_mb_emit_ldloc (mb, local_i);
+	mono_mb_emit_byte (mb, CEE_LDELEM_REF);
+	mono_mb_emit_stloc (mb, local_d);
+
+	/* res = d.Invoke ( args .. ); */
+	mono_mb_emit_ldloc (mb, local_d);
+	for (i = 0; i < sig->param_count; i++)
+		mono_mb_emit_ldarg (mb, i + 1);
+	if (!ctx) {
+		mono_mb_emit_op (mb, CEE_CALLVIRT, method);
+	} else {
+		ERROR_DECL (error);
+		mono_mb_emit_op (mb, CEE_CALLVIRT, mono_class_inflate_generic_method_checked (method, &container->context, error));
+		g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
+	}
+	if (!void_ret)
+		mono_mb_emit_stloc (mb, local_res);
+
+	/* i += 1 */
+	mono_mb_emit_add_to_local (mb, local_i, 1);
+
+	/* i < l */
+	mono_mb_emit_ldloc (mb, local_i);
+	mono_mb_emit_ldloc (mb, local_len);
+	mono_mb_emit_branch_label (mb, CEE_BLT, pos1);
+
+	/* return res */
+	if (!void_ret)
+		mono_mb_emit_ldloc (mb, local_res);
+	mono_mb_emit_byte (mb, CEE_RET);
+}
+
+static void
+mb_skip_visibility_ilgen (MonoMethodBuilder *mb)
+{
+	mb->skip_visibility = 1;
+}
+
+static void
+mb_set_dynamic_ilgen (MonoMethodBuilder *mb)
+{
+	mb->dynamic = 1;
+}
+
+static void
+emit_synchronized_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, MonoGenericContext *ctx, MonoGenericContainer *container, MonoMethod *enter_method, MonoMethod *exit_method, MonoMethod *gettypefromhandle_method)
+{
+	int i, pos, pos2, this_local, taken_local, ret_local = 0;
+	MonoMethodSignature *sig = mono_method_signature (method);
+	MonoExceptionClause *clause;
+
+	/* result */
+	if (!MONO_TYPE_IS_VOID (sig->ret))
+		ret_local = mono_mb_add_local (mb, sig->ret);
+
+	if (method->klass->valuetype && !(method->flags & MONO_METHOD_ATTR_STATIC)) {
+		/* FIXME Is this really the best way to signal an error here?  Isn't this called much later after class setup? -AK */
+		mono_class_set_type_load_failure (method->klass, "");
+		/* This will throw the type load exception when the wrapper is compiled */
+		mono_mb_emit_byte (mb, CEE_LDNULL);
+		mono_mb_emit_op (mb, CEE_ISINST, method->klass);
+		mono_mb_emit_byte (mb, CEE_POP);
+
+		if (!MONO_TYPE_IS_VOID (sig->ret))
+			mono_mb_emit_ldloc (mb, ret_local);
+		mono_mb_emit_byte (mb, CEE_RET);
+
+		return;
+	}
+
+	/* this */
+	this_local = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
+	taken_local = mono_mb_add_local (mb, &mono_defaults.boolean_class->byval_arg);
+
+	clause = (MonoExceptionClause *)mono_image_alloc0 (method->klass->image, sizeof (MonoExceptionClause));
+	clause->flags = MONO_EXCEPTION_CLAUSE_FINALLY;
+
+	/* Push this or the type object */
+	if (method->flags & METHOD_ATTRIBUTE_STATIC) {
+		/* We have special handling for this in the JIT */
+		int index = mono_mb_add_data (mb, method->klass);
+		mono_mb_add_data (mb, mono_defaults.typehandle_class);
+		mono_mb_emit_byte (mb, CEE_LDTOKEN);
+		mono_mb_emit_i4 (mb, index);
+
+		mono_mb_emit_managed_call (mb, gettypefromhandle_method, NULL);
+	}
+	else
+		mono_mb_emit_ldarg (mb, 0);
+	mono_mb_emit_stloc (mb, this_local);
+
+	/* Call Monitor::Enter() */
+	mono_mb_emit_ldloc (mb, this_local);
+	mono_mb_emit_ldloc_addr (mb, taken_local);
+	mono_mb_emit_managed_call (mb, enter_method, NULL);
+
+	clause->try_offset = mono_mb_get_label (mb);
+
+	/* Call the method */
+	if (sig->hasthis)
+		mono_mb_emit_ldarg (mb, 0);
+	for (i = 0; i < sig->param_count; i++)
+		mono_mb_emit_ldarg (mb, i + (sig->hasthis == TRUE));
+
+	if (ctx) {
+		ERROR_DECL (error);
+		mono_mb_emit_managed_call (mb, mono_class_inflate_generic_method_checked (method, &container->context, error), NULL);
+		g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
+	} else {
+		mono_mb_emit_managed_call (mb, method, NULL);
+	}
+
+	if (!MONO_TYPE_IS_VOID (sig->ret))
+		mono_mb_emit_stloc (mb, ret_local);
+
+	pos = mono_mb_emit_branch (mb, CEE_LEAVE);
+
+	clause->try_len = mono_mb_get_pos (mb) - clause->try_offset;
+	clause->handler_offset = mono_mb_get_label (mb);
+
+	/* Call Monitor::Exit() if needed */
+	mono_mb_emit_ldloc (mb, taken_local);
+	pos2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
+	mono_mb_emit_ldloc (mb, this_local);
+	mono_mb_emit_managed_call (mb, exit_method, NULL);
+	mono_mb_patch_branch (mb, pos2);
+	mono_mb_emit_byte (mb, CEE_ENDFINALLY);
+
+	clause->handler_len = mono_mb_get_pos (mb) - clause->handler_offset;
+
+	mono_mb_patch_branch (mb, pos);
+	if (!MONO_TYPE_IS_VOID (sig->ret))
+		mono_mb_emit_ldloc (mb, ret_local);
+	mono_mb_emit_byte (mb, CEE_RET);
+
+	mono_mb_set_clauses (mb, 1, clause);
+}
+
+static void
+emit_unbox_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method)
+{
+	MonoMethodSignature *sig = mono_method_signature (method);
+
+	mono_mb_emit_ldarg (mb, 0); 
+	mono_mb_emit_icon (mb, sizeof (MonoObject));
+	mono_mb_emit_byte (mb, CEE_ADD);
+	for (int i = 0; i < sig->param_count; ++i)
+		mono_mb_emit_ldarg (mb, i + 1);
+	mono_mb_emit_managed_call (mb, method, NULL);
+	mono_mb_emit_byte (mb, CEE_RET);
+}
+
+static void
+emit_array_accessor_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, MonoMethodSignature *sig, MonoGenericContext *ctx)
+{
+	MonoGenericContainer *container = NULL;
+	/* Call the method */
+	if (sig->hasthis)
+		mono_mb_emit_ldarg (mb, 0);
+	for (int i = 0; i < sig->param_count; i++)
+		mono_mb_emit_ldarg (mb, i + (sig->hasthis == TRUE));
+
+	if (ctx) {
+		ERROR_DECL (error);
+		mono_mb_emit_managed_call (mb, mono_class_inflate_generic_method_checked (method, &container->context, error), NULL);
+		g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
+	} else {
+		mono_mb_emit_managed_call (mb, method, NULL);
+	}
+	mono_mb_emit_byte (mb, CEE_RET);
+}
+
+static void
+emit_generic_array_helper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, MonoMethodSignature *csig)
+{
+	mono_mb_emit_ldarg (mb, 0);
+	for (int i = 0; i < csig->param_count; i++)
+		mono_mb_emit_ldarg (mb, i + 1);
+	mono_mb_emit_managed_call (mb, method, NULL);
+	mono_mb_emit_byte (mb, CEE_RET);
+}
+
+static void
+emit_thunk_invoke_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, MonoMethodSignature *csig)
+{
+	MonoImage *image = method->klass->image;
+	MonoMethodSignature *sig = mono_method_signature (method);
+	int param_count = sig->param_count + sig->hasthis + 1;
+	int pos_leave;
+	MonoExceptionClause *clause;
+
+	/* local 0 (temp for exception object) */
+	mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
+
+	/* local 1 (temp for result) */
+	if (!MONO_TYPE_IS_VOID (sig->ret))
+		mono_mb_add_local (mb, sig->ret);
+
+	/* clear exception arg */
+	mono_mb_emit_ldarg (mb, param_count - 1);
+	mono_mb_emit_byte (mb, CEE_LDNULL);
+	mono_mb_emit_byte (mb, CEE_STIND_REF);
+
+	/* try */
+	clause = (MonoExceptionClause *)mono_image_alloc0 (image, sizeof (MonoExceptionClause));
+	clause->try_offset = mono_mb_get_label (mb);
+
+	/* push method's args */
+	for (int i = 0; i < param_count - 1; i++) {
+		MonoType *type;
+		MonoClass *klass;
+
+		mono_mb_emit_ldarg (mb, i);
+
+		/* get the byval type of the param */
+		klass = mono_class_from_mono_type (csig->params [i]);
+		type = &klass->byval_arg;
+
+		/* unbox struct args */
+		if (MONO_TYPE_ISSTRUCT (type)) {
+			mono_mb_emit_op (mb, CEE_UNBOX, klass);
+
+			/* byref args & and the "this" arg must remain a ptr.
+			   Otherwise make a copy of the value type */
+			if (!(csig->params [i]->byref || (i == 0 && sig->hasthis)))
+				mono_mb_emit_op (mb, CEE_LDOBJ, klass);
+
+			csig->params [i] = &mono_defaults.object_class->byval_arg;
+		}
+	}
+
+	/* call */
+	if (method->flags & METHOD_ATTRIBUTE_VIRTUAL)
+		mono_mb_emit_op (mb, CEE_CALLVIRT, method);
+	else
+		mono_mb_emit_op (mb, CEE_CALL, method);
+
+	/* save result at local 1 */
+	if (!MONO_TYPE_IS_VOID (sig->ret))
+		mono_mb_emit_stloc (mb, 1);
+
+	pos_leave = mono_mb_emit_branch (mb, CEE_LEAVE);
+
+	/* catch */
+	clause->flags = MONO_EXCEPTION_CLAUSE_NONE;
+	clause->try_len = mono_mb_get_pos (mb) - clause->try_offset;
+	clause->data.catch_class = mono_defaults.object_class;
+
+	clause->handler_offset = mono_mb_get_label (mb);
+
+	/* store exception at local 0 */
+	mono_mb_emit_stloc (mb, 0);
+	mono_mb_emit_ldarg (mb, param_count - 1);
+	mono_mb_emit_ldloc (mb, 0);
+	mono_mb_emit_byte (mb, CEE_STIND_REF);
+	mono_mb_emit_branch (mb, CEE_LEAVE);
+
+	clause->handler_len = mono_mb_get_pos (mb) - clause->handler_offset;
+
+	mono_mb_set_clauses (mb, 1, clause);
+
+	mono_mb_patch_branch (mb, pos_leave);
+	/* end-try */
+
+	if (!MONO_TYPE_IS_VOID (sig->ret)) {
+		mono_mb_emit_ldloc (mb, 1);
+
+		/* box the return value */
+		if (MONO_TYPE_ISSTRUCT (sig->ret))
+			mono_mb_emit_op (mb, CEE_BOX, mono_class_from_mono_type (sig->ret));
+	}
+
+	mono_mb_emit_byte (mb, CEE_RET);
+}
+
+static int
+emit_marshal_custom_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
+					 MonoMarshalSpec *spec, 
+					 int conv_arg, MonoType **conv_arg_type, 
+					 MarshalAction action)
+{
+	ERROR_DECL (error);
+	MonoType *mtype;
+	MonoClass *mklass;
+	static MonoClass *ICustomMarshaler = NULL;
+	static MonoMethod *cleanup_native, *cleanup_managed;
+	static MonoMethod *marshal_managed_to_native, *marshal_native_to_managed;
+	MonoMethod *get_instance = NULL;
+	MonoMethodBuilder *mb = m->mb;
+	char *exception_msg = NULL;
+	guint32 loc1;
+	int pos2;
+
+	if (!ICustomMarshaler) {
+		MonoClass *klass = mono_class_try_get_icustom_marshaler_class ();
+		if (!klass) {
+			exception_msg = g_strdup ("Current profile doesn't support ICustomMarshaler");
+			goto handle_exception;
+		}
+
+		cleanup_native = mono_class_get_method_from_name (klass, "CleanUpNativeData", 1);
+		g_assert (cleanup_native);
+		cleanup_managed = mono_class_get_method_from_name (klass, "CleanUpManagedData", 1);
+		g_assert (cleanup_managed);
+		marshal_managed_to_native = mono_class_get_method_from_name (klass, "MarshalManagedToNative", 1);
+		g_assert (marshal_managed_to_native);
+		marshal_native_to_managed = mono_class_get_method_from_name (klass, "MarshalNativeToManaged", 1);
+		g_assert (marshal_native_to_managed);
+
+		mono_memory_barrier ();
+		ICustomMarshaler = klass;
+	}
+
+	if (spec->data.custom_data.image)
+		mtype = mono_reflection_type_from_name_checked (spec->data.custom_data.custom_name, spec->data.custom_data.image, error);
+	else
+		mtype = mono_reflection_type_from_name_checked (spec->data.custom_data.custom_name, m->image, error);
+	g_assert (mtype != NULL);
+	mono_error_assert_ok (error);
+	mklass = mono_class_from_mono_type (mtype);
+	g_assert (mklass != NULL);
+
+	if (!mono_class_is_assignable_from (ICustomMarshaler, mklass))
+		exception_msg = g_strdup_printf ("Custom marshaler '%s' does not implement the ICustomMarshaler interface.", mklass->name);
+
+	get_instance = mono_class_get_method_from_name_flags (mklass, "GetInstance", 1, METHOD_ATTRIBUTE_STATIC);
+	if (get_instance) {
+		MonoMethodSignature *get_sig = mono_method_signature (get_instance);
+		if ((get_sig->ret->type != MONO_TYPE_CLASS) ||
+			(mono_class_from_mono_type (get_sig->ret) != ICustomMarshaler) ||
+			(get_sig->params [0]->type != MONO_TYPE_STRING))
+			get_instance = NULL;
+	}
+
+	if (!get_instance)
+		exception_msg = g_strdup_printf ("Custom marshaler '%s' does not implement a static GetInstance method that takes a single string parameter and returns an ICustomMarshaler.", mklass->name);
+
+handle_exception:
+	/* Throw exception and emit compensation code if neccesary */
+	if (exception_msg) {
+		switch (action) {
+		case MARSHAL_ACTION_CONV_IN:
+		case MARSHAL_ACTION_CONV_RESULT:
+		case MARSHAL_ACTION_MANAGED_CONV_RESULT:
+			if ((action == MARSHAL_ACTION_CONV_RESULT) || (action == MARSHAL_ACTION_MANAGED_CONV_RESULT))
+				mono_mb_emit_byte (mb, CEE_POP);
+
+			mono_mb_emit_exception_full (mb, "System", "ApplicationException", exception_msg);
+
+			break;
+		case MARSHAL_ACTION_PUSH:
+			mono_mb_emit_byte (mb, CEE_LDNULL);
+			break;
+		default:
+			break;
+		}
+		return 0;
+	}
+
+	/* FIXME: MS.NET seems to create one instance for each klass + cookie pair */
+	/* FIXME: MS.NET throws an exception if GetInstance returns null */
+
+	switch (action) {
+	case MARSHAL_ACTION_CONV_IN:
+		switch (t->type) {
+		case MONO_TYPE_CLASS:
+		case MONO_TYPE_OBJECT:
+		case MONO_TYPE_STRING:
+		case MONO_TYPE_ARRAY:
+		case MONO_TYPE_SZARRAY:
+		case MONO_TYPE_VALUETYPE:
+			break;
+
+		default:
+			g_warning ("custom marshalling of type %x is currently not supported", t->type);
+			g_assert_not_reached ();
+			break;
+		}
+
+		conv_arg = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+
+		mono_mb_emit_byte (mb, CEE_LDNULL);
+		mono_mb_emit_stloc (mb, conv_arg);
+
+		if (t->byref && (t->attrs & PARAM_ATTRIBUTE_OUT))
+			break;
+
+		/* Minic MS.NET behavior */
+		if (!t->byref && (t->attrs & PARAM_ATTRIBUTE_OUT) && !(t->attrs & PARAM_ATTRIBUTE_IN))
+			break;
+
+		/* Check for null */
+		mono_mb_emit_ldarg (mb, argnum);
+		if (t->byref)
+			mono_mb_emit_byte (mb, CEE_LDIND_I);
+		pos2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+		mono_mb_emit_ldstr (mb, g_strdup (spec->data.custom_data.cookie));
+
+		mono_mb_emit_op (mb, CEE_CALL, get_instance);
+				
+		mono_mb_emit_ldarg (mb, argnum);
+		if (t->byref)
+			mono_mb_emit_byte (mb, CEE_LDIND_REF);
+
+		if (t->type == MONO_TYPE_VALUETYPE) {
+			/*
+			 * Since we can't determine the type of the argument, we
+			 * will assume the unmanaged function takes a pointer.
+			 */
+			*conv_arg_type = &mono_defaults.int_class->byval_arg;
+
+			mono_mb_emit_op (mb, CEE_BOX, mono_class_from_mono_type (t));
+		}
+
+		mono_mb_emit_op (mb, CEE_CALLVIRT, marshal_managed_to_native);
+		mono_mb_emit_stloc (mb, conv_arg);
+
+		mono_mb_patch_branch (mb, pos2);
+		break;
+
+	case MARSHAL_ACTION_CONV_OUT:
+		/* Check for null */
+		mono_mb_emit_ldloc (mb, conv_arg);
+		pos2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+		if (t->byref) {
+			mono_mb_emit_ldarg (mb, argnum);
+
+			mono_mb_emit_ldstr (mb, g_strdup (spec->data.custom_data.cookie));
+
+			mono_mb_emit_op (mb, CEE_CALL, get_instance);
+
+			mono_mb_emit_ldloc (mb, conv_arg);
+			mono_mb_emit_op (mb, CEE_CALLVIRT, marshal_native_to_managed);
+			mono_mb_emit_byte (mb, CEE_STIND_REF);
+		} else if (t->attrs & PARAM_ATTRIBUTE_OUT) {
+			mono_mb_emit_ldstr (mb, g_strdup (spec->data.custom_data.cookie));
+
+			mono_mb_emit_op (mb, CEE_CALL, get_instance);
+
+			mono_mb_emit_ldloc (mb, conv_arg);
+			mono_mb_emit_op (mb, CEE_CALLVIRT, marshal_native_to_managed);
+
+			/* We have nowhere to store the result */
+			mono_mb_emit_byte (mb, CEE_POP);
+		}
+
+		mono_mb_emit_ldstr (mb, g_strdup (spec->data.custom_data.cookie));
+
+		mono_mb_emit_op (mb, CEE_CALL, get_instance);
+
+		mono_mb_emit_ldloc (mb, conv_arg);
+
+		mono_mb_emit_op (mb, CEE_CALLVIRT, cleanup_native);
+
+		mono_mb_patch_branch (mb, pos2);
+		break;
+
+	case MARSHAL_ACTION_PUSH:
+		if (t->byref)
+			mono_mb_emit_ldloc_addr (mb, conv_arg);
+		else
+			mono_mb_emit_ldloc (mb, conv_arg);
+		break;
+
+	case MARSHAL_ACTION_CONV_RESULT:
+		loc1 = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+			
+		mono_mb_emit_stloc (mb, 3);
+
+		mono_mb_emit_ldloc (mb, 3);
+		mono_mb_emit_stloc (mb, loc1);
+
+		/* Check for null */
+		mono_mb_emit_ldloc (mb, 3);
+		pos2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+		mono_mb_emit_ldstr (mb, g_strdup (spec->data.custom_data.cookie));
+
+		mono_mb_emit_op (mb, CEE_CALL, get_instance);
+		mono_mb_emit_byte (mb, CEE_DUP);
+
+		mono_mb_emit_ldloc (mb, 3);
+		mono_mb_emit_op (mb, CEE_CALLVIRT, marshal_native_to_managed);
+		mono_mb_emit_stloc (mb, 3);
+
+		mono_mb_emit_ldloc (mb, loc1);
+		mono_mb_emit_op (mb, CEE_CALLVIRT, cleanup_native);
+
+		mono_mb_patch_branch (mb, pos2);
+		break;
+
+	case MARSHAL_ACTION_MANAGED_CONV_IN:
+		conv_arg = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
+
+		mono_mb_emit_byte (mb, CEE_LDNULL);
+		mono_mb_emit_stloc (mb, conv_arg);
+
+		if (t->byref && t->attrs & PARAM_ATTRIBUTE_OUT)
+			break;
+
+		/* Check for null */
+		mono_mb_emit_ldarg (mb, argnum);
+		if (t->byref)
+			mono_mb_emit_byte (mb, CEE_LDIND_I);
+		pos2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+		mono_mb_emit_ldstr (mb, g_strdup (spec->data.custom_data.cookie));
+		mono_mb_emit_op (mb, CEE_CALL, get_instance);
+				
+		mono_mb_emit_ldarg (mb, argnum);
+		if (t->byref)
+			mono_mb_emit_byte (mb, CEE_LDIND_I);
+				
+		mono_mb_emit_op (mb, CEE_CALLVIRT, marshal_native_to_managed);
+		mono_mb_emit_stloc (mb, conv_arg);
+
+		mono_mb_patch_branch (mb, pos2);
+		break;
+
+	case MARSHAL_ACTION_MANAGED_CONV_RESULT:
+		g_assert (!t->byref);
+
+		loc1 = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
+			
+		mono_mb_emit_stloc (mb, 3);
+			
+		mono_mb_emit_ldloc (mb, 3);
+		mono_mb_emit_stloc (mb, loc1);
+
+		/* Check for null */
+		mono_mb_emit_ldloc (mb, 3);
+		pos2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+		mono_mb_emit_ldstr (mb, g_strdup (spec->data.custom_data.cookie));
+		mono_mb_emit_op (mb, CEE_CALL, get_instance);
+		mono_mb_emit_byte (mb, CEE_DUP);
+
+		mono_mb_emit_ldloc (mb, 3);
+		mono_mb_emit_op (mb, CEE_CALLVIRT, marshal_managed_to_native);
+		mono_mb_emit_stloc (mb, 3);
+
+		mono_mb_emit_ldloc (mb, loc1);
+		mono_mb_emit_op (mb, CEE_CALLVIRT, cleanup_managed);
+
+		mono_mb_patch_branch (mb, pos2);
+		break;
+
+	case MARSHAL_ACTION_MANAGED_CONV_OUT:
+
+		/* Check for null */
+		mono_mb_emit_ldloc (mb, conv_arg);
+		pos2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+		if (t->byref) {
+			mono_mb_emit_ldarg (mb, argnum);
+
+			mono_mb_emit_ldstr (mb, g_strdup (spec->data.custom_data.cookie));
+
+			mono_mb_emit_op (mb, CEE_CALL, get_instance);
+
+			mono_mb_emit_ldloc (mb, conv_arg);
+			mono_mb_emit_op (mb, CEE_CALLVIRT, marshal_managed_to_native);
+			mono_mb_emit_byte (mb, CEE_STIND_I);
+		}
+
+		/* Call CleanUpManagedData */
+		mono_mb_emit_ldstr (mb, g_strdup (spec->data.custom_data.cookie));
+
+		mono_mb_emit_op (mb, CEE_CALL, get_instance);
+				
+		mono_mb_emit_ldloc (mb, conv_arg);
+		mono_mb_emit_op (mb, CEE_CALLVIRT, cleanup_managed);
+
+		mono_mb_patch_branch (mb, pos2);
+		break;
+
+	default:
+		g_assert_not_reached ();
+	}
+	return conv_arg;
+}
+
+static int
+emit_marshal_asany_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
+					MonoMarshalSpec *spec, 
+					int conv_arg, MonoType **conv_arg_type, 
+					MarshalAction action)
+{
+	MonoMethodBuilder *mb = m->mb;
+
+	switch (action) {
+	case MARSHAL_ACTION_CONV_IN: {
+		MonoMarshalNative encoding = mono_marshal_get_string_encoding (m->piinfo, NULL);
+
+		g_assert (t->type == MONO_TYPE_OBJECT);
+		g_assert (!t->byref);
+
+		conv_arg = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		mono_mb_emit_ldarg (mb, argnum);
+		mono_mb_emit_icon (mb, encoding);
+		mono_mb_emit_icon (mb, t->attrs);
+		mono_mb_emit_icall (mb, mono_marshal_asany);
+		mono_mb_emit_stloc (mb, conv_arg);
+		break;
+	}
+
+	case MARSHAL_ACTION_PUSH:
+		mono_mb_emit_ldloc (mb, conv_arg);
+		break;
+
+	case MARSHAL_ACTION_CONV_OUT: {
+		MonoMarshalNative encoding = mono_marshal_get_string_encoding (m->piinfo, NULL);
+
+		mono_mb_emit_ldarg (mb, argnum);
+		mono_mb_emit_ldloc (mb, conv_arg);
+		mono_mb_emit_icon (mb, encoding);
+		mono_mb_emit_icon (mb, t->attrs);
+		mono_mb_emit_icall (mb, mono_marshal_free_asany);
+		break;
+	}
+
+	default:
+		g_assert_not_reached ();
+	}
+	return conv_arg;
+}
+
+static int
+emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
+					MonoMarshalSpec *spec, 
+					int conv_arg, MonoType **conv_arg_type, 
+					MarshalAction action)
+{
+	MonoMethodBuilder *mb = m->mb;
+	MonoClass *klass, *date_time_class;
+	int pos = 0, pos2;
+
+	klass = mono_class_from_mono_type (t);
+
+	date_time_class = mono_class_get_date_time_class ();
+
+	switch (action) {
+	case MARSHAL_ACTION_CONV_IN:
+		if (klass == date_time_class) {
+			/* Convert it to an OLE DATE type */
+			static MonoMethod *to_oadate;
+
+			if (!to_oadate)
+				to_oadate = mono_class_get_method_from_name (date_time_class, "ToOADate", 0);
+			g_assert (to_oadate);
+
+			conv_arg = mono_mb_add_local (mb, &mono_defaults.double_class->byval_arg);
+
+			if (t->byref) {
+				mono_mb_emit_ldarg (mb, argnum);
+				pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
+			}
+
+			if (!(t->byref && !(t->attrs & PARAM_ATTRIBUTE_IN) && (t->attrs & PARAM_ATTRIBUTE_OUT))) {
+				if (!t->byref)
+					m->csig->params [argnum - m->csig->hasthis] = &mono_defaults.double_class->byval_arg;
+
+				mono_mb_emit_ldarg_addr (mb, argnum);
+				mono_mb_emit_managed_call (mb, to_oadate, NULL);
+				mono_mb_emit_stloc (mb, conv_arg);
+			}
+
+			if (t->byref)
+				mono_mb_patch_branch (mb, pos);
+			break;
+		}
+
+		if (mono_class_is_explicit_layout (klass) || klass->blittable || klass->enumtype)
+			break;
+
+		conv_arg = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+			
+		/* store the address of the source into local variable 0 */
+		if (t->byref)
+			mono_mb_emit_ldarg (mb, argnum);
+		else
+			mono_mb_emit_ldarg_addr (mb, argnum);
+		
+		mono_mb_emit_stloc (mb, 0);
+			
+		/* allocate space for the native struct and
+		 * store the address into local variable 1 (dest) */
+		mono_mb_emit_icon (mb, mono_class_native_size (klass, NULL));
+		mono_mb_emit_byte (mb, CEE_PREFIX1);
+		mono_mb_emit_byte (mb, CEE_LOCALLOC);
+		mono_mb_emit_stloc (mb, conv_arg);
+
+		if (t->byref) {
+			mono_mb_emit_ldloc (mb, 0);
+			pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
+		}
+
+		if (!(t->byref && !(t->attrs & PARAM_ATTRIBUTE_IN) && (t->attrs & PARAM_ATTRIBUTE_OUT))) {
+			/* set dst_ptr */
+			mono_mb_emit_ldloc (mb, conv_arg);
+			mono_mb_emit_stloc (mb, 1);
+
+			/* emit valuetype conversion code */
+			emit_struct_conv (mb, klass, FALSE);
+		}
+
+		if (t->byref)
+			mono_mb_patch_branch (mb, pos);
+		break;
+
+	case MARSHAL_ACTION_PUSH:
+		if (spec && spec->native == MONO_NATIVE_LPSTRUCT) {
+			/* FIXME: */
+			g_assert (!t->byref);
+
+			/* Have to change the signature since the vtype is passed byref */
+			m->csig->params [argnum - m->csig->hasthis] = &mono_defaults.int_class->byval_arg;
+
+			if (mono_class_is_explicit_layout (klass) || klass->blittable || klass->enumtype)
+				mono_mb_emit_ldarg_addr (mb, argnum);
+			else
+				mono_mb_emit_ldloc (mb, conv_arg);
+			break;
+		}
+
+		if (klass == date_time_class) {
+			if (t->byref)
+				mono_mb_emit_ldloc_addr (mb, conv_arg);
+			else
+				mono_mb_emit_ldloc (mb, conv_arg);
+			break;
+		}
+
+		if (mono_class_is_explicit_layout (klass) || klass->blittable || klass->enumtype) {
+			mono_mb_emit_ldarg (mb, argnum);
+			break;
+		}			
+		mono_mb_emit_ldloc (mb, conv_arg);
+		if (!t->byref) {
+			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+			mono_mb_emit_op (mb, CEE_MONO_LDNATIVEOBJ, klass);
+		}
+		break;
+
+	case MARSHAL_ACTION_CONV_OUT:
+		if (klass == date_time_class) {
+			/* Convert from an OLE DATE type */
+			static MonoMethod *from_oadate;
+
+			if (!t->byref)
+				break;
+
+			if (!((t->attrs & PARAM_ATTRIBUTE_IN) && !(t->attrs & PARAM_ATTRIBUTE_OUT))) {
+				if (!from_oadate)
+					from_oadate = mono_class_get_method_from_name (date_time_class, "FromOADate", 1);
+				g_assert (from_oadate);
+
+				mono_mb_emit_ldarg (mb, argnum);
+				mono_mb_emit_ldloc (mb, conv_arg);
+				mono_mb_emit_managed_call (mb, from_oadate, NULL);
+				mono_mb_emit_op (mb, CEE_STOBJ, date_time_class);
+			}
+			break;
+		}
+
+		if (mono_class_is_explicit_layout (klass) || klass->blittable || klass->enumtype)
+			break;
+
+		if (t->byref) {
+			/* dst = argument */
+			mono_mb_emit_ldarg (mb, argnum);
+			mono_mb_emit_stloc (mb, 1);
+
+			mono_mb_emit_ldloc (mb, 1);
+			pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+			if (!((t->attrs & PARAM_ATTRIBUTE_IN) && !(t->attrs & PARAM_ATTRIBUTE_OUT))) {
+				/* src = tmp_locals [i] */
+				mono_mb_emit_ldloc (mb, conv_arg);
+				mono_mb_emit_stloc (mb, 0);
+
+				/* emit valuetype conversion code */
+				emit_struct_conv (mb, klass, TRUE);
+			}
+		}
+
+		emit_struct_free (mb, klass, conv_arg);
+		
+		if (t->byref)
+			mono_mb_patch_branch (mb, pos);
+		break;
+
+	case MARSHAL_ACTION_CONV_RESULT:
+		if (mono_class_is_explicit_layout (klass) || klass->blittable) {
+			mono_mb_emit_stloc (mb, 3);
+			break;
+		}
+
+		/* load pointer to returned value type */
+		g_assert (m->vtaddr_var);
+		mono_mb_emit_ldloc (mb, m->vtaddr_var);
+		/* store the address of the source into local variable 0 */
+		mono_mb_emit_stloc (mb, 0);
+		/* set dst_ptr */
+		mono_mb_emit_ldloc_addr (mb, 3);
+		mono_mb_emit_stloc (mb, 1);
+				
+		/* emit valuetype conversion code */
+		emit_struct_conv (mb, klass, TRUE);
+		break;
+
+	case MARSHAL_ACTION_MANAGED_CONV_IN:
+		if (mono_class_is_explicit_layout (klass) || klass->blittable || klass->enumtype) {
+			conv_arg = 0;
+			break;
+		}
+
+		conv_arg = mono_mb_add_local (mb, &klass->byval_arg);
+
+		if (t->attrs & PARAM_ATTRIBUTE_OUT)
+			break;
+
+		if (t->byref) 
+			mono_mb_emit_ldarg (mb, argnum);
+		else
+			mono_mb_emit_ldarg_addr (mb, argnum);
+		mono_mb_emit_stloc (mb, 0);
+
+		if (t->byref) {
+			mono_mb_emit_ldloc (mb, 0);
+			pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
+		}			
+
+		mono_mb_emit_ldloc_addr (mb, conv_arg);
+		mono_mb_emit_stloc (mb, 1);
+
+		/* emit valuetype conversion code */
+		emit_struct_conv (mb, klass, TRUE);
+
+		if (t->byref)
+			mono_mb_patch_branch (mb, pos);
+		break;
+
+	case MARSHAL_ACTION_MANAGED_CONV_OUT:
+		if (mono_class_is_explicit_layout (klass) || klass->blittable || klass->enumtype)
+			break;
+		if (t->byref && (t->attrs & PARAM_ATTRIBUTE_IN) && !(t->attrs & PARAM_ATTRIBUTE_OUT))
+			break;
+
+		/* Check for null */
+		mono_mb_emit_ldarg (mb, argnum);
+		pos2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+		/* Set src */
+		mono_mb_emit_ldloc_addr (mb, conv_arg);
+		mono_mb_emit_stloc (mb, 0);
+
+		/* Set dest */
+		mono_mb_emit_ldarg (mb, argnum);
+		mono_mb_emit_stloc (mb, 1);
+
+		/* emit valuetype conversion code */
+		emit_struct_conv (mb, klass, FALSE);
+
+		mono_mb_patch_branch (mb, pos2);
+		break;
+
+	case MARSHAL_ACTION_MANAGED_CONV_RESULT:
+		if (mono_class_is_explicit_layout (klass) || klass->blittable || klass->enumtype) {
+			mono_mb_emit_stloc (mb, 3);
+			m->retobj_var = 0;
+			break;
+		}
+			
+		/* load pointer to returned value type */
+		g_assert (m->vtaddr_var);
+		mono_mb_emit_ldloc (mb, m->vtaddr_var);
+			
+		/* store the address of the source into local variable 0 */
+		mono_mb_emit_stloc (mb, 0);
+		/* allocate space for the native struct and
+		 * store the address into dst_ptr */
+		m->retobj_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		m->retobj_class = klass;
+		g_assert (m->retobj_var);
+		mono_mb_emit_icon (mb, mono_class_native_size (klass, NULL));
+		mono_mb_emit_byte (mb, CEE_CONV_I);
+		mono_mb_emit_icall (mb, ves_icall_marshal_alloc);
+		mono_mb_emit_stloc (mb, 1);
+		mono_mb_emit_ldloc (mb, 1);
+		mono_mb_emit_stloc (mb, m->retobj_var);
+
+		/* emit valuetype conversion code */
+		emit_struct_conv (mb, klass, FALSE);
+		break;
+
+	default:
+		g_assert_not_reached ();
+	}
+	return conv_arg;
+}
+
+static int
+emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
+					 MonoMarshalSpec *spec, 
+					 int conv_arg, MonoType **conv_arg_type, 
+					 MarshalAction action)
+{
+	MonoMethodBuilder *mb = m->mb;
+	MonoMarshalNative encoding = mono_marshal_get_string_encoding (m->piinfo, spec);
+	MonoMarshalConv conv = mono_marshal_get_string_to_ptr_conv (m->piinfo, spec);
+	gboolean need_free;
+
+	switch (action) {
+	case MARSHAL_ACTION_CONV_IN:
+		*conv_arg_type = &mono_defaults.int_class->byval_arg;
+		conv_arg = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+
+		if (t->byref) {
+			if (t->attrs & PARAM_ATTRIBUTE_OUT)
+				break;
+
+			mono_mb_emit_ldarg (mb, argnum);
+			mono_mb_emit_byte (mb, CEE_LDIND_I);				
+		} else {
+			mono_mb_emit_ldarg (mb, argnum);
+		}
+
+		if (conv == MONO_MARSHAL_CONV_INVALID) {
+			char *msg = g_strdup_printf ("string marshalling conversion %d not implemented", encoding);
+			mono_mb_emit_exception_marshal_directive (mb, msg);
+		} else {
+			mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+
+			mono_mb_emit_stloc (mb, conv_arg);
+		}
+		break;
+
+	case MARSHAL_ACTION_CONV_OUT:
+		conv = mono_marshal_get_ptr_to_string_conv (m->piinfo, spec, &need_free);
+		if (conv == MONO_MARSHAL_CONV_INVALID) {
+			char *msg = g_strdup_printf ("string marshalling conversion %d not implemented", encoding);
+			mono_mb_emit_exception_marshal_directive (mb, msg);
+			break;
+		}
+
+		if (encoding == MONO_NATIVE_VBBYREFSTR) {
+			static MonoMethod *m;
+
+			if (!m) {
+				m = mono_class_get_method_from_name_flags (mono_defaults.string_class, "get_Length", -1, 0);
+				g_assert (m);
+			}
+
+			if (!t->byref) {
+				char *msg = g_strdup_printf ("VBByRefStr marshalling requires a ref parameter.", encoding);
+				mono_mb_emit_exception_marshal_directive (mb, msg);
+				break;
+			}
+
+			/* 
+			 * Have to allocate a new string with the same length as the original, and
+			 * copy the contents of the buffer pointed to by CONV_ARG into it.
+			 */
+			g_assert (t->byref);
+			mono_mb_emit_ldarg (mb, argnum);
+			mono_mb_emit_ldloc (mb, conv_arg);
+			mono_mb_emit_ldarg (mb, argnum);
+			mono_mb_emit_byte (mb, CEE_LDIND_I);				
+			mono_mb_emit_managed_call (mb, m, NULL);
+			mono_mb_emit_icall (mb, mono_string_new_len_wrapper);
+			mono_mb_emit_byte (mb, CEE_STIND_REF);
+		} else if (t->byref && (t->attrs & PARAM_ATTRIBUTE_OUT || !(t->attrs & PARAM_ATTRIBUTE_IN))) {
+			int stind_op;
+			mono_mb_emit_ldarg (mb, argnum);
+			mono_mb_emit_ldloc (mb, conv_arg);
+			mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
+			mono_mb_emit_byte (mb, stind_op);
+			need_free = TRUE;
+		}
+
+		if (need_free) {
+			mono_mb_emit_ldloc (mb, conv_arg);
+			if (conv == MONO_MARSHAL_CONV_BSTR_STR)
+				mono_mb_emit_icall (mb, mono_free_bstr);
+			else
+				mono_mb_emit_icall (mb, mono_marshal_free);
+		}
+		break;
+
+	case MARSHAL_ACTION_PUSH:
+		if (t->byref && encoding != MONO_NATIVE_VBBYREFSTR)
+			mono_mb_emit_ldloc_addr (mb, conv_arg);
+		else
+			mono_mb_emit_ldloc (mb, conv_arg);
+		break;
+
+	case MARSHAL_ACTION_CONV_RESULT:
+		mono_mb_emit_stloc (mb, 0);
+				
+		conv = mono_marshal_get_ptr_to_string_conv (m->piinfo, spec, &need_free);
+		if (conv == MONO_MARSHAL_CONV_INVALID) {
+			char *msg = g_strdup_printf ("string marshalling conversion %d not implemented", encoding);
+			mono_mb_emit_exception_marshal_directive (mb, msg);
+			break;
+		}
+
+		mono_mb_emit_ldloc (mb, 0);
+		mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+		mono_mb_emit_stloc (mb, 3);
+
+		/* free the string */
+		mono_mb_emit_ldloc (mb, 0);
+		if (conv == MONO_MARSHAL_CONV_BSTR_STR)
+			mono_mb_emit_icall (mb, mono_free_bstr);
+		else
+			mono_mb_emit_icall (mb, mono_marshal_free);
+		break;
+
+	case MARSHAL_ACTION_MANAGED_CONV_IN:
+		conv_arg = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
+
+		*conv_arg_type = &mono_defaults.int_class->byval_arg;
+
+		if (t->byref) {
+			if (t->attrs & PARAM_ATTRIBUTE_OUT)
+				break;
+		}
+
+		conv = mono_marshal_get_ptr_to_string_conv (m->piinfo, spec, &need_free);
+		if (conv == MONO_MARSHAL_CONV_INVALID) {
+			char *msg = g_strdup_printf ("string marshalling conversion %d not implemented", encoding);
+			mono_mb_emit_exception_marshal_directive (mb, msg);
+			break;
+		}
+
+		mono_mb_emit_ldarg (mb, argnum);
+		if (t->byref)
+			mono_mb_emit_byte (mb, CEE_LDIND_I);
+		mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+		mono_mb_emit_stloc (mb, conv_arg);
+		break;
+
+	case MARSHAL_ACTION_MANAGED_CONV_OUT:
+		if (t->byref) {
+			if (conv_arg) {
+				int stind_op;
+				mono_mb_emit_ldarg (mb, argnum);
+				mono_mb_emit_ldloc (mb, conv_arg);
+				mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
+				mono_mb_emit_byte (mb, stind_op);
+			}
+		}
+		break;
+
+	case MARSHAL_ACTION_MANAGED_CONV_RESULT:
+		if (conv_to_icall (conv, NULL) == mono_marshal_string_to_utf16)
+			/* We need to make a copy so the caller is able to free it */
+			mono_mb_emit_icall (mb, mono_marshal_string_to_utf16_copy);
+		else
+			mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+		mono_mb_emit_stloc (mb, 3);
+		break;
+
+	default:
+		g_assert_not_reached ();
+	}
+	return conv_arg;
+}
+
+
+static int
+emit_marshal_safehandle_ilgen (EmitMarshalContext *m, int argnum, MonoType *t, 
+			 MonoMarshalSpec *spec, int conv_arg, 
+			 MonoType **conv_arg_type, MarshalAction action)
+{
+	MonoMethodBuilder *mb = m->mb;
+
+	switch (action){
+	case MARSHAL_ACTION_CONV_IN: {
+		MonoType *intptr_type;
+		int dar_release_slot, pos;
+
+		intptr_type = &mono_defaults.int_class->byval_arg;
+		conv_arg = mono_mb_add_local (mb, intptr_type);
+		*conv_arg_type = intptr_type;
+
+		if (!sh_dangerous_add_ref)
+			init_safe_handle ();
+
+		mono_mb_emit_ldarg (mb, argnum);
+		pos = mono_mb_emit_branch (mb, CEE_BRTRUE);
+		mono_mb_emit_exception (mb, "ArgumentNullException", NULL);
+		
+		mono_mb_patch_branch (mb, pos);
+		if (t->byref){
+			/*
+			 * My tests in show that ref SafeHandles are not really
+			 * passed as ref objects.  Instead a NULL is passed as the
+			 * value of the ref
+			 */
+			mono_mb_emit_icon (mb, 0);
+			mono_mb_emit_stloc (mb, conv_arg);
+			break;
+		} 
+
+		/* Create local to hold the ref parameter to DangerousAddRef */
+		dar_release_slot = mono_mb_add_local (mb, &mono_defaults.boolean_class->byval_arg);
+
+		/* set release = false; */
+		mono_mb_emit_icon (mb, 0);
+		mono_mb_emit_stloc (mb, dar_release_slot);
+
+		/* safehandle.DangerousAddRef (ref release) */
+		mono_mb_emit_ldarg (mb, argnum);
+		mono_mb_emit_ldloc_addr (mb, dar_release_slot);
+		mono_mb_emit_managed_call (mb, sh_dangerous_add_ref, NULL);
+
+		/* Pull the handle field from SafeHandle */
+		mono_mb_emit_ldarg (mb, argnum);
+		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoSafeHandle, handle));
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+		mono_mb_emit_stloc (mb, conv_arg);
+
+		break;
+	}
+
+	case MARSHAL_ACTION_PUSH:
+		if (t->byref)
+			mono_mb_emit_ldloc_addr (mb, conv_arg);
+		else 
+			mono_mb_emit_ldloc (mb, conv_arg);
+		break;
+
+	case MARSHAL_ACTION_CONV_OUT: {
+		/* The slot for the boolean is the next temporary created after conv_arg, see the CONV_IN code */
+		int dar_release_slot = conv_arg + 1;
+		int label_next;
+
+		if (!sh_dangerous_release)
+			init_safe_handle ();
+
+		if (t->byref){
+			MonoMethod *ctor;
+			
+			/*
+			 * My tests indicate that ref SafeHandles parameters are not actually
+			 * passed by ref, but instead a new Handle is created regardless of
+			 * whether a change happens in the unmanaged side.
+			 *
+			 * Also, the Handle is created before calling into unmanaged code,
+			 * but we do not support that mechanism (getting to the original
+			 * handle) and it makes no difference where we create this
+			 */
+			ctor = mono_class_get_method_from_name (t->data.klass, ".ctor", 0);
+			if (ctor == NULL){
+				mono_mb_emit_exception (mb, "MissingMethodException", "paramterless constructor required");
+				break;
+			}
+			/* refval = new SafeHandleDerived ()*/
+			mono_mb_emit_ldarg (mb, argnum);
+			mono_mb_emit_op (mb, CEE_NEWOBJ, ctor);
+			mono_mb_emit_byte (mb, CEE_STIND_REF);
+
+			/* refval.handle = returned_handle */
+			mono_mb_emit_ldarg (mb, argnum);
+			mono_mb_emit_byte (mb, CEE_LDIND_REF);
+			mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoSafeHandle, handle));
+			mono_mb_emit_ldloc (mb, conv_arg);
+			mono_mb_emit_byte (mb, CEE_STIND_I);
+		} else {
+			mono_mb_emit_ldloc (mb, dar_release_slot);
+			label_next = mono_mb_emit_branch (mb, CEE_BRFALSE);
+			mono_mb_emit_ldarg (mb, argnum);
+			mono_mb_emit_managed_call (mb, sh_dangerous_release, NULL);
+			mono_mb_patch_branch (mb, label_next);
+		}
+		break;
+	}
+		
+	case MARSHAL_ACTION_CONV_RESULT: {
+		MonoMethod *ctor = NULL;
+		int intptr_handle_slot;
+		
+		if (mono_class_is_abstract (t->data.klass)) {
+			mono_mb_emit_byte (mb, CEE_POP);
+			mono_mb_emit_exception_marshal_directive (mb, g_strdup ("Returned SafeHandles should not be abstract"));
+			break;
+		}
+
+		ctor = mono_class_get_method_from_name (t->data.klass, ".ctor", 0);
+		if (ctor == NULL){
+			mono_mb_emit_byte (mb, CEE_POP);
+			mono_mb_emit_exception (mb, "MissingMethodException", "paramterless constructor required");
+			break;
+		}
+		/* Store the IntPtr results into a local */
+		intptr_handle_slot = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		mono_mb_emit_stloc (mb, intptr_handle_slot);
+
+		/* Create return value */
+		mono_mb_emit_op (mb, CEE_NEWOBJ, ctor);
+		mono_mb_emit_stloc (mb, 3);
+
+		/* Set the return.handle to the value, am using ldflda, not sure if thats a good idea */
+		mono_mb_emit_ldloc (mb, 3);
+		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoSafeHandle, handle));
+		mono_mb_emit_ldloc (mb, intptr_handle_slot);
+		mono_mb_emit_byte (mb, CEE_STIND_I);
+		break;
+	}
+		
+	case MARSHAL_ACTION_MANAGED_CONV_IN:
+		fprintf (stderr, "mono/marshal: SafeHandles missing MANAGED_CONV_IN\n");
+		break;
+		
+	case MARSHAL_ACTION_MANAGED_CONV_OUT:
+		fprintf (stderr, "mono/marshal: SafeHandles missing MANAGED_CONV_OUT\n");
+		break;
+
+	case MARSHAL_ACTION_MANAGED_CONV_RESULT:
+		fprintf (stderr, "mono/marshal: SafeHandles missing MANAGED_CONV_RESULT\n");
+		break;
+	default:
+		printf ("Unhandled case for MarshalAction: %d\n", action);
+	}
+	return conv_arg;
+}
+
+
+static int
+emit_marshal_handleref_ilgen (EmitMarshalContext *m, int argnum, MonoType *t, 
+			MonoMarshalSpec *spec, int conv_arg, 
+			MonoType **conv_arg_type, MarshalAction action)
+{
+	MonoMethodBuilder *mb = m->mb;
+
+	switch (action){
+	case MARSHAL_ACTION_CONV_IN: {
+		MonoType *intptr_type;
+
+		intptr_type = &mono_defaults.int_class->byval_arg;
+		conv_arg = mono_mb_add_local (mb, intptr_type);
+		*conv_arg_type = intptr_type;
+
+		if (t->byref){
+			char *msg = g_strdup ("HandleRefs can not be returned from unmanaged code (or passed by ref)");
+			mono_mb_emit_exception_marshal_directive (mb, msg);
+			break;
+		} 
+		mono_mb_emit_ldarg_addr (mb, argnum);
+		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoHandleRef, handle));
+		mono_mb_emit_byte (mb, CEE_ADD);
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+		mono_mb_emit_stloc (mb, conv_arg);
+		break;
+	}
+
+	case MARSHAL_ACTION_PUSH:
+		mono_mb_emit_ldloc (mb, conv_arg);
+		break;
+
+	case MARSHAL_ACTION_CONV_OUT: {
+		/* no resource release required */
+		break;
+	}
+		
+	case MARSHAL_ACTION_CONV_RESULT: {
+		char *msg = g_strdup ("HandleRefs can not be returned from unmanaged code (or passed by ref)");
+		mono_mb_emit_exception_marshal_directive (mb, msg);
+		break;
+	}
+		
+	case MARSHAL_ACTION_MANAGED_CONV_IN:
+		fprintf (stderr, "mono/marshal: SafeHandles missing MANAGED_CONV_IN\n");
+		break;
+		
+	case MARSHAL_ACTION_MANAGED_CONV_OUT:
+		fprintf (stderr, "mono/marshal: SafeHandles missing MANAGED_CONV_OUT\n");
+		break;
+
+	case MARSHAL_ACTION_MANAGED_CONV_RESULT:
+		fprintf (stderr, "mono/marshal: SafeHandles missing MANAGED_CONV_RESULT\n");
+		break;
+	default:
+		fprintf (stderr, "Unhandled case for MarshalAction: %d\n", action);
+	}
+	return conv_arg;
+}
+
+
+static int
+emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
+		     MonoMarshalSpec *spec, 
+		     int conv_arg, MonoType **conv_arg_type, 
+		     MarshalAction action)
+{
+	MonoMethodBuilder *mb = m->mb;
+	MonoClass *klass = mono_class_from_mono_type (t);
+	int pos, pos2, loc;
+
+	switch (action) {
+	case MARSHAL_ACTION_CONV_IN:
+		*conv_arg_type = &mono_defaults.int_class->byval_arg;
+		conv_arg = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+
+		m->orig_conv_args [argnum] = 0;
+
+		if (mono_class_from_mono_type (t) == mono_defaults.object_class) {
+			char *msg = g_strdup_printf ("Marshalling of type object is not implemented");
+			mono_mb_emit_exception_marshal_directive (mb, msg);
+			break;
+		}
+
+		if (klass->delegate) {
+			if (t->byref) {
+				if (!(t->attrs & PARAM_ATTRIBUTE_OUT)) {
+					char *msg = g_strdup_printf ("Byref marshalling of delegates is not implemented.");
+					mono_mb_emit_exception_marshal_directive (mb, msg);
+				}
+				mono_mb_emit_byte (mb, CEE_LDNULL);
+				mono_mb_emit_stloc (mb, conv_arg);
+			} else {
+				mono_mb_emit_ldarg (mb, argnum);
+				mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_DEL_FTN, NULL));
+				mono_mb_emit_stloc (mb, conv_arg);
+			}
+		} else if (klass == mono_defaults.stringbuilder_class) {
+			MonoMarshalNative encoding = mono_marshal_get_string_encoding (m->piinfo, spec);
+			MonoMarshalConv conv = mono_marshal_get_stringbuilder_to_ptr_conv (m->piinfo, spec);
+
+#if 0			
+			if (t->byref) {
+				if (!(t->attrs & PARAM_ATTRIBUTE_OUT)) {
+					char *msg = g_strdup_printf ("Byref marshalling of stringbuilders is not implemented.");
+					mono_mb_emit_exception_marshal_directive (mb, msg);
+				}
+				break;
+			}
+#endif
+
+			if (t->byref && !(t->attrs & PARAM_ATTRIBUTE_IN) && (t->attrs & PARAM_ATTRIBUTE_OUT))
+				break;
+
+			if (conv == MONO_MARSHAL_CONV_INVALID) {
+				char *msg = g_strdup_printf ("stringbuilder marshalling conversion %d not implemented", encoding);
+				mono_mb_emit_exception_marshal_directive (mb, msg);
+				break;
+			}
+
+			mono_mb_emit_ldarg (mb, argnum);
+			if (t->byref)
+				mono_mb_emit_byte (mb, CEE_LDIND_I);
+
+			mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+			mono_mb_emit_stloc (mb, conv_arg);
+		} else if (klass->blittable) {
+			mono_mb_emit_byte (mb, CEE_LDNULL);
+			mono_mb_emit_stloc (mb, conv_arg);
+
+			mono_mb_emit_ldarg (mb, argnum);
+			pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+			mono_mb_emit_ldarg (mb, argnum);
+			mono_mb_emit_ldflda (mb, sizeof (MonoObject));
+			mono_mb_emit_stloc (mb, conv_arg);
+
+			mono_mb_patch_branch (mb, pos);
+			break;
+		} else {
+			mono_mb_emit_byte (mb, CEE_LDNULL);
+			mono_mb_emit_stloc (mb, conv_arg);
+
+			if (t->byref) {
+				/* we dont need any conversions for out parameters */
+				if (t->attrs & PARAM_ATTRIBUTE_OUT)
+					break;
+
+				mono_mb_emit_ldarg (mb, argnum);				
+				mono_mb_emit_byte (mb, CEE_LDIND_I);
+
+			} else {
+				mono_mb_emit_ldarg (mb, argnum);
+				mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+				mono_mb_emit_byte (mb, CEE_MONO_OBJADDR);
+			}
+				
+			/* store the address of the source into local variable 0 */
+			mono_mb_emit_stloc (mb, 0);
+			mono_mb_emit_ldloc (mb, 0);
+			pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+			/* allocate space for the native struct and store the address */
+			mono_mb_emit_icon (mb, mono_class_native_size (klass, NULL));
+			mono_mb_emit_byte (mb, CEE_PREFIX1);
+			mono_mb_emit_byte (mb, CEE_LOCALLOC);
+			mono_mb_emit_stloc (mb, conv_arg);
+
+			if (t->byref) {
+				/* Need to store the original buffer so we can free it later */
+				m->orig_conv_args [argnum] = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+				mono_mb_emit_ldloc (mb, conv_arg);
+				mono_mb_emit_stloc (mb, m->orig_conv_args [argnum]);
+			}
+
+			/* set the src_ptr */
+			mono_mb_emit_ldloc (mb, 0);
+			mono_mb_emit_ldflda (mb, sizeof (MonoObject));
+			mono_mb_emit_stloc (mb, 0);
+
+			/* set dst_ptr */
+			mono_mb_emit_ldloc (mb, conv_arg);
+			mono_mb_emit_stloc (mb, 1);
+
+			/* emit valuetype conversion code */
+			emit_struct_conv (mb, klass, FALSE);
+
+			mono_mb_patch_branch (mb, pos);
+		}
+		break;
+
+	case MARSHAL_ACTION_CONV_OUT:
+		if (klass == mono_defaults.stringbuilder_class) {
+			gboolean need_free;
+			MonoMarshalNative encoding;
+			MonoMarshalConv conv;
+
+			encoding = mono_marshal_get_string_encoding (m->piinfo, spec);
+			conv = mono_marshal_get_ptr_to_stringbuilder_conv (m->piinfo, spec, &need_free);
+
+			g_assert (encoding != -1);
+
+			if (t->byref) {
+				//g_assert (!(t->attrs & PARAM_ATTRIBUTE_OUT));
+
+				need_free = TRUE;
+
+				mono_mb_emit_ldarg (mb, argnum);
+				mono_mb_emit_ldloc (mb, conv_arg);
+
+				switch (encoding) {
+				case MONO_NATIVE_LPWSTR:
+					mono_mb_emit_icall (mb, mono_string_utf16_to_builder2);
+					break;
+				case MONO_NATIVE_LPSTR:
+					mono_mb_emit_icall (mb, mono_string_utf8_to_builder2);
+					break;
+				case MONO_NATIVE_UTF8STR:
+					mono_mb_emit_icall (mb, mono_string_utf8_to_builder2);
+					break;
+				default:
+					g_assert_not_reached ();
+				}
+
+				mono_mb_emit_byte (mb, CEE_STIND_REF);
+			} else {
+				mono_mb_emit_ldarg (mb, argnum);
+				mono_mb_emit_ldloc (mb, conv_arg);
+
+				mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+			}
+
+			if (need_free) {
+				mono_mb_emit_ldloc (mb, conv_arg);
+				mono_mb_emit_icall (mb, mono_marshal_free);
+			}
+			break;
+		}
+
+		if (klass->delegate) {
+			if (t->byref) {
+				mono_mb_emit_ldarg (mb, argnum);
+				mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+				mono_mb_emit_op (mb, CEE_MONO_CLASSCONST, klass);
+				mono_mb_emit_ldloc (mb, conv_arg);
+				mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_FTN_DEL, NULL));
+				mono_mb_emit_byte (mb, CEE_STIND_REF);
+			}
+			break;
+		}
+
+		if (t->byref && (t->attrs & PARAM_ATTRIBUTE_OUT)) {
+			/* allocate a new object */
+			mono_mb_emit_ldarg (mb, argnum);
+			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+			mono_mb_emit_op (mb, CEE_MONO_NEWOBJ, klass);
+			mono_mb_emit_byte (mb, CEE_STIND_REF);
+		}
+
+		/* dst = *argument */
+		mono_mb_emit_ldarg (mb, argnum);
+
+		if (t->byref)
+			mono_mb_emit_byte (mb, CEE_LDIND_I);
+
+		mono_mb_emit_stloc (mb, 1);
+
+		mono_mb_emit_ldloc (mb, 1);
+		pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+		if (t->byref || (t->attrs & PARAM_ATTRIBUTE_OUT)) {
+			mono_mb_emit_ldloc (mb, 1);
+			mono_mb_emit_icon (mb, sizeof (MonoObject));
+			mono_mb_emit_byte (mb, CEE_ADD);
+			mono_mb_emit_stloc (mb, 1);
+			
+			/* src = tmp_locals [i] */
+			mono_mb_emit_ldloc (mb, conv_arg);
+			mono_mb_emit_stloc (mb, 0);
+
+			/* emit valuetype conversion code */
+			emit_struct_conv (mb, klass, TRUE);
+
+			/* Free the structure returned by the native code */
+			emit_struct_free (mb, klass, conv_arg);
+
+			if (m->orig_conv_args [argnum]) {
+				/* 
+				 * If the native function changed the pointer, then free
+				 * the original structure plus the new pointer.
+				 */
+				mono_mb_emit_ldloc (mb, m->orig_conv_args [argnum]);
+				mono_mb_emit_ldloc (mb, conv_arg);
+				pos2 = mono_mb_emit_branch (mb, CEE_BEQ);
+
+				if (!(t->attrs & PARAM_ATTRIBUTE_OUT)) {
+					g_assert (m->orig_conv_args [argnum]);
+
+					emit_struct_free (mb, klass, m->orig_conv_args [argnum]);
+				}
+
+				mono_mb_emit_ldloc (mb, conv_arg);
+				mono_mb_emit_icall (mb, mono_marshal_free);
+
+				mono_mb_patch_branch (mb, pos2);
+			}
+		}
+		else
+			/* Free the original structure passed to native code */
+			emit_struct_free (mb, klass, conv_arg);
+
+		mono_mb_patch_branch (mb, pos);
+		break;
+
+	case MARSHAL_ACTION_PUSH:
+		if (t->byref)
+			mono_mb_emit_ldloc_addr (mb, conv_arg);
+		else
+			mono_mb_emit_ldloc (mb, conv_arg);
+		break;
+
+	case MARSHAL_ACTION_CONV_RESULT:
+		if (klass->delegate) {
+			g_assert (!t->byref);
+			mono_mb_emit_stloc (mb, 0);
+			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+			mono_mb_emit_op (mb, CEE_MONO_CLASSCONST, klass);
+			mono_mb_emit_ldloc (mb, 0);
+			mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_FTN_DEL, NULL));
+			mono_mb_emit_stloc (mb, 3);
+		} else if (klass == mono_defaults.stringbuilder_class) {
+			// FIXME:
+			char *msg = g_strdup_printf ("Return marshalling of stringbuilders is not implemented.");
+			mono_mb_emit_exception_marshal_directive (mb, msg);
+		} else {
+			/* set src */
+			mono_mb_emit_stloc (mb, 0);
+	
+			/* Make a copy since emit_conv modifies local 0 */
+			loc = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+			mono_mb_emit_ldloc (mb, 0);
+			mono_mb_emit_stloc (mb, loc);
+	
+			mono_mb_emit_byte (mb, CEE_LDNULL);
+			mono_mb_emit_stloc (mb, 3);
+	
+			mono_mb_emit_ldloc (mb, 0);
+			pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
+	
+			/* allocate result object */
+	
+			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+			mono_mb_emit_op (mb, CEE_MONO_NEWOBJ, klass);	
+			mono_mb_emit_stloc (mb, 3);
+					
+			/* set dst  */
+	
+			mono_mb_emit_ldloc (mb, 3);
+			mono_mb_emit_ldflda (mb, sizeof (MonoObject));
+			mono_mb_emit_stloc (mb, 1);
+								
+			/* emit conversion code */
+			emit_struct_conv (mb, klass, TRUE);
+	
+			emit_struct_free (mb, klass, loc);
+	
+			/* Free the pointer allocated by unmanaged code */
+			mono_mb_emit_ldloc (mb, loc);
+			mono_mb_emit_icall (mb, mono_marshal_free);
+			mono_mb_patch_branch (mb, pos);
+		}
+		break;
+
+	case MARSHAL_ACTION_MANAGED_CONV_IN:
+		conv_arg = mono_mb_add_local (mb, &klass->byval_arg);
+
+		if (klass->delegate) {
+			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+			mono_mb_emit_op (mb, CEE_MONO_CLASSCONST, klass);
+			mono_mb_emit_ldarg (mb, argnum);
+			if (t->byref)
+				mono_mb_emit_byte (mb, CEE_LDIND_I);
+			mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_FTN_DEL, NULL));
+			mono_mb_emit_stloc (mb, conv_arg);
+			break;
+		}
+
+		if (klass == mono_defaults.stringbuilder_class) {
+			MonoMarshalNative encoding;
+
+			encoding = mono_marshal_get_string_encoding (m->piinfo, spec);
+
+			// FIXME:
+			g_assert (encoding == MONO_NATIVE_LPSTR || encoding == MONO_NATIVE_UTF8STR);
+
+			g_assert (!t->byref);
+			g_assert (encoding != -1);
+
+			mono_mb_emit_ldarg (mb, argnum);
+			mono_mb_emit_icall (mb, mono_string_utf8_to_builder2);
+			mono_mb_emit_stloc (mb, conv_arg);
+			break;
+		}
+
+		/* The class can not have an automatic layout */
+		if (mono_class_is_auto_layout (klass)) {
+			mono_mb_emit_auto_layout_exception (mb, klass);
+			break;
+		}
+
+		if (t->attrs & PARAM_ATTRIBUTE_OUT) {
+			mono_mb_emit_byte (mb, CEE_LDNULL);
+			mono_mb_emit_stloc (mb, conv_arg);
+			break;
+		}
+
+		/* Set src */
+		mono_mb_emit_ldarg (mb, argnum);
+		if (t->byref) {
+			int pos2;
+
+			/* Check for NULL and raise an exception */
+			pos2 = mono_mb_emit_branch (mb, CEE_BRTRUE);
+
+			mono_mb_emit_exception (mb, "ArgumentNullException", NULL);
+
+			mono_mb_patch_branch (mb, pos2);
+			mono_mb_emit_ldarg (mb, argnum);
+			mono_mb_emit_byte (mb, CEE_LDIND_I);
+		}				
+
+		mono_mb_emit_stloc (mb, 0);
+
+		mono_mb_emit_byte (mb, CEE_LDC_I4_0);
+		mono_mb_emit_stloc (mb, conv_arg);
+
+		mono_mb_emit_ldloc (mb, 0);
+		pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
+
+		/* Create and set dst */
+		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+		mono_mb_emit_op (mb, CEE_MONO_NEWOBJ, klass);	
+		mono_mb_emit_stloc (mb, conv_arg);
+		mono_mb_emit_ldloc (mb, conv_arg);
+		mono_mb_emit_ldflda (mb, sizeof (MonoObject));
+		mono_mb_emit_stloc (mb, 1); 
+
+		/* emit valuetype conversion code */
+		emit_struct_conv (mb, klass, TRUE);
+
+		mono_mb_patch_branch (mb, pos);
+		break;
+
+	case MARSHAL_ACTION_MANAGED_CONV_OUT:
+		if (klass->delegate) {
+			if (t->byref) {
+				int stind_op;
+				mono_mb_emit_ldarg (mb, argnum);
+				mono_mb_emit_ldloc (mb, conv_arg);
+				mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_DEL_FTN, &stind_op));
+				mono_mb_emit_byte (mb, stind_op);
+				break;
+			}
+		}
+
+		if (t->byref) {
+			/* Check for null */
+			mono_mb_emit_ldloc (mb, conv_arg);
+			pos = mono_mb_emit_branch (mb, CEE_BRTRUE);
+			mono_mb_emit_ldarg (mb, argnum);
+			mono_mb_emit_byte (mb, CEE_LDC_I4_0);
+			mono_mb_emit_byte (mb, CEE_STIND_I);
+			pos2 = mono_mb_emit_branch (mb, CEE_BR);
+
+			mono_mb_patch_branch (mb, pos);			
+			
+			/* Set src */
+			mono_mb_emit_ldloc (mb, conv_arg);
+			mono_mb_emit_ldflda (mb, sizeof (MonoObject));
+			mono_mb_emit_stloc (mb, 0);
+
+			/* Allocate and set dest */
+			mono_mb_emit_icon (mb, mono_class_native_size (klass, NULL));
+			mono_mb_emit_byte (mb, CEE_CONV_I);
+			mono_mb_emit_icall (mb, ves_icall_marshal_alloc);
+			mono_mb_emit_stloc (mb, 1);
+			
+			/* Update argument pointer */
+			mono_mb_emit_ldarg (mb, argnum);
+			mono_mb_emit_ldloc (mb, 1);
+			mono_mb_emit_byte (mb, CEE_STIND_I);
+		
+			/* emit valuetype conversion code */
+			emit_struct_conv (mb, klass, FALSE);
+
+			mono_mb_patch_branch (mb, pos2);
+		} else if (klass == mono_defaults.stringbuilder_class) {
+			// FIXME: What to do here ?
+		} else {
+			/* byval [Out] marshalling */
+
+			/* FIXME: Handle null */
+
+			/* Set src */
+			mono_mb_emit_ldloc (mb, conv_arg);
+			mono_mb_emit_ldflda (mb, sizeof (MonoObject));
+			mono_mb_emit_stloc (mb, 0);
+
+			/* Set dest */
+			mono_mb_emit_ldarg (mb, argnum);
+			mono_mb_emit_stloc (mb, 1);
+			
+			/* emit valuetype conversion code */
+			emit_struct_conv (mb, klass, FALSE);
+		}			
+		break;
+
+	case MARSHAL_ACTION_MANAGED_CONV_RESULT:
+		if (klass->delegate) {
+			mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_DEL_FTN, NULL));
+			mono_mb_emit_stloc (mb, 3);
+			break;
+		}
+
+		/* The class can not have an automatic layout */
+		if (mono_class_is_auto_layout (klass)) {
+			mono_mb_emit_auto_layout_exception (mb, klass);
+			break;
+		}
+
+		mono_mb_emit_stloc (mb, 0);
+		/* Check for null */
+		mono_mb_emit_ldloc (mb, 0);
+		pos = mono_mb_emit_branch (mb, CEE_BRTRUE);
+		mono_mb_emit_byte (mb, CEE_LDNULL);
+		mono_mb_emit_stloc (mb, 3);
+		pos2 = mono_mb_emit_branch (mb, CEE_BR);
+
+		mono_mb_patch_branch (mb, pos);
+
+		/* Set src */
+		mono_mb_emit_ldloc (mb, 0);
+		mono_mb_emit_ldflda (mb, sizeof (MonoObject));
+		mono_mb_emit_stloc (mb, 0);
+
+		/* Allocate and set dest */
+		mono_mb_emit_icon (mb, mono_class_native_size (klass, NULL));
+		mono_mb_emit_byte (mb, CEE_CONV_I);
+		mono_mb_emit_icall (mb, ves_icall_marshal_alloc);
+		mono_mb_emit_byte (mb, CEE_DUP);
+		mono_mb_emit_stloc (mb, 1);
+		mono_mb_emit_stloc (mb, 3);
+
+		emit_struct_conv (mb, klass, FALSE);
+
+		mono_mb_patch_branch (mb, pos2);
+		break;
+
+	default:
+		g_assert_not_reached ();
+	}
+	return conv_arg;
+}
+
+
+static int
+emit_marshal_variant_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
+		     MonoMarshalSpec *spec, 
+		     int conv_arg, MonoType **conv_arg_type, 
+		     MarshalAction action)
+{
+#ifndef DISABLE_COM
+	MonoMethodBuilder *mb = m->mb;
+	static MonoMethod *get_object_for_native_variant = NULL;
+	static MonoMethod *get_native_variant_for_object = NULL;
+
+	if (!get_object_for_native_variant)
+		get_object_for_native_variant = mono_class_get_method_from_name (mono_defaults.marshal_class, "GetObjectForNativeVariant", 1);
+	g_assert (get_object_for_native_variant);
+
+	if (!get_native_variant_for_object)
+		get_native_variant_for_object = mono_class_get_method_from_name (mono_defaults.marshal_class, "GetNativeVariantForObject", 2);
+	g_assert (get_native_variant_for_object);
+
+	switch (action) {
+	case MARSHAL_ACTION_CONV_IN: {
+		conv_arg = mono_mb_add_local (mb, &mono_class_get_variant_class ()->byval_arg);
+		
+		if (t->byref)
+			*conv_arg_type = &mono_class_get_variant_class ()->this_arg;
+		else
+			*conv_arg_type = &mono_class_get_variant_class ()->byval_arg;
+
+		if (t->byref && !(t->attrs & PARAM_ATTRIBUTE_IN) && t->attrs & PARAM_ATTRIBUTE_OUT)
+			break;
+
+		mono_mb_emit_ldarg (mb, argnum);
+		if (t->byref)
+			mono_mb_emit_byte(mb, CEE_LDIND_REF);
+		mono_mb_emit_ldloc_addr (mb, conv_arg);
+		mono_mb_emit_managed_call (mb, get_native_variant_for_object, NULL);
+		break;
+	}
+
+	case MARSHAL_ACTION_CONV_OUT: {
+		static MonoMethod *variant_clear = NULL;
+
+		if (!variant_clear)
+			variant_clear = mono_class_get_method_from_name (mono_class_get_variant_class (), "Clear", 0);
+		g_assert (variant_clear);
+
+
+		if (t->byref && (t->attrs & PARAM_ATTRIBUTE_OUT || !(t->attrs & PARAM_ATTRIBUTE_IN))) {
+			mono_mb_emit_ldarg (mb, argnum);
+			mono_mb_emit_ldloc_addr (mb, conv_arg);
+			mono_mb_emit_managed_call (mb, get_object_for_native_variant, NULL);
+			mono_mb_emit_byte (mb, CEE_STIND_REF);
+		}
+
+		mono_mb_emit_ldloc_addr (mb, conv_arg);
+		mono_mb_emit_managed_call (mb, variant_clear, NULL);
+		break;
+	}
+
+	case MARSHAL_ACTION_PUSH:
+		if (t->byref)
+			mono_mb_emit_ldloc_addr (mb, conv_arg);
+		else
+			mono_mb_emit_ldloc (mb, conv_arg);
+		break;
+
+	case MARSHAL_ACTION_CONV_RESULT: {
+		char *msg = g_strdup ("Marshalling of VARIANT not supported as a return type.");
+		mono_mb_emit_exception_marshal_directive (mb, msg);
+		break;
+	}
+
+	case MARSHAL_ACTION_MANAGED_CONV_IN: {
+		conv_arg = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
+
+		if (t->byref)
+			*conv_arg_type = &mono_class_get_variant_class ()->this_arg;
+		else
+			*conv_arg_type = &mono_class_get_variant_class ()->byval_arg;
+
+		if (t->byref && !(t->attrs & PARAM_ATTRIBUTE_IN) && t->attrs & PARAM_ATTRIBUTE_OUT)
+			break;
+
+		if (t->byref)
+			mono_mb_emit_ldarg (mb, argnum);
+		else
+			mono_mb_emit_ldarg_addr (mb, argnum);
+		mono_mb_emit_managed_call (mb, get_object_for_native_variant, NULL);
+		mono_mb_emit_stloc (mb, conv_arg);
+		break;
+	}
+
+	case MARSHAL_ACTION_MANAGED_CONV_OUT: {
+		if (t->byref && (t->attrs & PARAM_ATTRIBUTE_OUT || !(t->attrs & PARAM_ATTRIBUTE_IN))) {
+			mono_mb_emit_ldloc (mb, conv_arg);
+			mono_mb_emit_ldarg (mb, argnum);
+			mono_mb_emit_managed_call (mb, get_native_variant_for_object, NULL);
+		}
+		break;
+	}
+
+	case MARSHAL_ACTION_MANAGED_CONV_RESULT: {
+		char *msg = g_strdup ("Marshalling of VARIANT not supported as a return type.");
+		mono_mb_emit_exception_marshal_directive (mb, msg);
+		break;
+	}
+
+	default:
+		g_assert_not_reached ();
+	}
+#endif /* DISABLE_COM */
+
+	return conv_arg;
+}
+
+static void
+emit_managed_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *invoke_sig, MonoMarshalSpec **mspecs, EmitMarshalContext* m, MonoMethod *method, uint32_t target_handle)
+{
+	MonoMethodSignature *sig, *csig;
+	MonoExceptionClause *clauses, *clause_finally, *clause_catch;
+	int i, *tmp_locals, ex_local, e_local, attach_cookie_local, attach_dummy_local;
+	int leave_try_pos, leave_catch_pos, ex_m1_pos;
+	gboolean closed = FALSE;
+
+	sig = m->sig;
+	csig = m->csig;
+
+	/* allocate local 0 (pointer) src_ptr */
+	mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+	/* allocate local 1 (pointer) dst_ptr */
+	mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+	/* allocate local 2 (boolean) delete_old */
+	mono_mb_add_local (mb, &mono_defaults.boolean_class->byval_arg);
+
+	if (!sig->hasthis && sig->param_count != invoke_sig->param_count) {
+		/* Closed delegate */
+		g_assert (sig->param_count == invoke_sig->param_count + 1);
+		closed = TRUE;
+		/* Use a new signature without the first argument */
+		sig = mono_metadata_signature_dup (sig);
+		memmove (&sig->params [0], &sig->params [1], (sig->param_count - 1) * sizeof (MonoType*));
+		sig->param_count --;
+	}
+
+	if (!MONO_TYPE_IS_VOID(sig->ret)) {
+		/* allocate local 3 to store the return value */
+		mono_mb_add_local (mb, sig->ret);
+	}
+
+	if (MONO_TYPE_ISSTRUCT (sig->ret))
+		m->vtaddr_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+
+	ex_local = mono_mb_add_local (mb, &mono_defaults.uint32_class->byval_arg);
+	e_local = mono_mb_add_local (mb, &mono_defaults.exception_class->byval_arg);
+
+	attach_cookie_local = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+	attach_dummy_local = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+
+	/*
+	 * guint32 ex = -1;
+	 * try {
+	 *   // does (STARTING|RUNNING|BLOCKING) -> RUNNING + set/switch domain
+	 *   mono_threads_attach_coop ();
+	 *
+	 *   <interrupt check>
+	 *
+	 *   ret = method (...);
+	 * } catch (Exception e) {
+	 *   ex = mono_gchandle_new (e, false);
+	 * } finally {
+	 *   // does RUNNING -> (RUNNING|BLOCKING) + unset/switch domain
+	 *   mono_threads_detach_coop ();
+	 *
+	 *   if (ex != -1)
+	 *     mono_marshal_ftnptr_eh_callback (ex);
+	 * }
+	 *
+	 * return ret;
+	 */
+
+	clauses = g_new0 (MonoExceptionClause, 2);
+
+	clause_catch = &clauses [0];
+	clause_catch->flags = MONO_EXCEPTION_CLAUSE_NONE;
+	clause_catch->data.catch_class = mono_defaults.exception_class;
+
+	clause_finally = &clauses [1];
+	clause_finally->flags = MONO_EXCEPTION_CLAUSE_FINALLY;
+
+	mono_mb_emit_icon (mb, 0);
+	mono_mb_emit_stloc (mb, 2);
+
+	mono_mb_emit_icon (mb, -1);
+	mono_mb_emit_byte (mb, CEE_CONV_U4);
+	mono_mb_emit_stloc (mb, ex_local);
+
+	/* try { */
+	clause_catch->try_offset = clause_finally->try_offset = mono_mb_get_label (mb);
+
+	if (!mono_threads_is_blocking_transition_enabled ()) {
+		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+		mono_mb_emit_byte (mb, CEE_MONO_JIT_ATTACH);
+	} else {
+		/* mono_threads_attach_coop (); */
+		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+		mono_mb_emit_byte (mb, CEE_MONO_LDDOMAIN);
+		mono_mb_emit_ldloc_addr (mb, attach_dummy_local);
+		/*
+		 * This icall is special cased in the JIT so it works in native-to-managed wrappers in unattached threads.
+		 * Keep this in sync with the CEE_JIT_ICALL code in the JIT.
+		 */
+		mono_mb_emit_icall (mb, mono_threads_attach_coop);
+		mono_mb_emit_stloc (mb, attach_cookie_local);
+	}
+
+	/* <interrupt check> */
+	emit_thread_interrupt_checkpoint (mb);
+
+	/* we first do all conversions */
+	tmp_locals = (int *)alloca (sizeof (int) * sig->param_count);
+	for (i = 0; i < sig->param_count; i ++) {
+		MonoType *t = sig->params [i];
+
+		switch (t->type) {
+		case MONO_TYPE_OBJECT:
+		case MONO_TYPE_CLASS:
+		case MONO_TYPE_VALUETYPE:
+		case MONO_TYPE_ARRAY:
+		case MONO_TYPE_SZARRAY:
+		case MONO_TYPE_STRING:
+		case MONO_TYPE_BOOLEAN:
+			tmp_locals [i] = mono_emit_marshal (m, i, sig->params [i], mspecs [i + 1], 0, &csig->params [i], MARSHAL_ACTION_MANAGED_CONV_IN);
+
+			break;
+		default:
+			tmp_locals [i] = 0;
+			break;
+		}
+	}
+
+	if (sig->hasthis) {
+		if (target_handle) {
+			mono_mb_emit_icon (mb, (gint32)target_handle);
+			mono_mb_emit_icall (mb, mono_gchandle_get_target);
+		} else {
+			/* fixme: */
+			g_assert_not_reached ();
+		}
+	} else if (closed) {
+		mono_mb_emit_icon (mb, (gint32)target_handle);
+		mono_mb_emit_icall (mb, mono_gchandle_get_target);
+	}
+
+	for (i = 0; i < sig->param_count; i++) {
+		MonoType *t = sig->params [i];
+
+		if (tmp_locals [i]) {
+			if (t->byref)
+				mono_mb_emit_ldloc_addr (mb, tmp_locals [i]);
+			else
+				mono_mb_emit_ldloc (mb, tmp_locals [i]);
+		}
+		else
+			mono_mb_emit_ldarg (mb, i);
+	}
+
+	/* ret = method (...) */
+	mono_mb_emit_managed_call (mb, method, NULL);
+
+	if (MONO_TYPE_ISSTRUCT (sig->ret)) {
+		MonoClass *klass = mono_class_from_mono_type (sig->ret);
+		mono_class_init (klass);
+		if (!(mono_class_is_explicit_layout (klass) || klass->blittable)) {
+			/* This is used by get_marshal_cb ()->emit_marshal_vtype (), but it needs to go right before the call */
+			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+			mono_mb_emit_byte (mb, CEE_MONO_VTADDR);
+			mono_mb_emit_stloc (mb, m->vtaddr_var);
+		}
+	}
+
+	if (mspecs [0] && mspecs [0]->native == MONO_NATIVE_CUSTOM) {
+		mono_emit_marshal (m, 0, sig->ret, mspecs [0], 0, NULL, MARSHAL_ACTION_MANAGED_CONV_RESULT);
+	} else if (!sig->ret->byref) { 
+		switch (sig->ret->type) {
+		case MONO_TYPE_VOID:
+			break;
+		case MONO_TYPE_BOOLEAN:
+		case MONO_TYPE_I1:
+		case MONO_TYPE_U1:
+		case MONO_TYPE_CHAR:
+		case MONO_TYPE_I2:
+		case MONO_TYPE_U2:
+		case MONO_TYPE_I4:
+		case MONO_TYPE_U4:
+		case MONO_TYPE_I:
+		case MONO_TYPE_U:
+		case MONO_TYPE_PTR:
+		case MONO_TYPE_R4:
+		case MONO_TYPE_R8:
+		case MONO_TYPE_I8:
+		case MONO_TYPE_U8:
+		case MONO_TYPE_OBJECT:
+			mono_mb_emit_stloc (mb, 3);
+			break;
+		case MONO_TYPE_STRING:
+			csig->ret = &mono_defaults.int_class->byval_arg;
+			mono_emit_marshal (m, 0, sig->ret, mspecs [0], 0, NULL, MARSHAL_ACTION_MANAGED_CONV_RESULT);
+			break;
+		case MONO_TYPE_VALUETYPE:
+		case MONO_TYPE_CLASS:
+		case MONO_TYPE_SZARRAY:
+			mono_emit_marshal (m, 0, sig->ret, mspecs [0], 0, NULL, MARSHAL_ACTION_MANAGED_CONV_RESULT);
+			break;
+		default:
+			g_warning ("return type 0x%02x unknown", sig->ret->type);	
+			g_assert_not_reached ();
+		}
+	} else {
+		mono_mb_emit_stloc (mb, 3);
+	}
+
+	/* Convert byref arguments back */
+	for (i = 0; i < sig->param_count; i ++) {
+		MonoType *t = sig->params [i];
+		MonoMarshalSpec *spec = mspecs [i + 1];
+
+		if (spec && spec->native == MONO_NATIVE_CUSTOM) {
+			mono_emit_marshal (m, i, t, mspecs [i + 1], tmp_locals [i], NULL, MARSHAL_ACTION_MANAGED_CONV_OUT);
+		}
+		else if (t->byref) {
+			switch (t->type) {
+			case MONO_TYPE_CLASS:
+			case MONO_TYPE_VALUETYPE:
+			case MONO_TYPE_OBJECT:
+			case MONO_TYPE_STRING:
+			case MONO_TYPE_BOOLEAN:
+				mono_emit_marshal (m, i, t, mspecs [i + 1], tmp_locals [i], NULL, MARSHAL_ACTION_MANAGED_CONV_OUT);
+				break;
+			default:
+				break;
+			}
+		}
+		else if (invoke_sig->params [i]->attrs & PARAM_ATTRIBUTE_OUT) {
+			/* The [Out] information is encoded in the delegate signature */
+			switch (t->type) {
+			case MONO_TYPE_SZARRAY:
+			case MONO_TYPE_CLASS:
+			case MONO_TYPE_VALUETYPE:
+				mono_emit_marshal (m, i, invoke_sig->params [i], mspecs [i + 1], tmp_locals [i], NULL, MARSHAL_ACTION_MANAGED_CONV_OUT);
+				break;
+			default:
+				g_assert_not_reached ();
+			}
+		}
+	}
+
+	leave_try_pos = mono_mb_emit_branch (mb, CEE_LEAVE);
+
+	/* } [endtry] */
+
+	/* catch (Exception e) { */
+	clause_catch->try_len = mono_mb_get_label (mb) - clause_catch->try_offset;
+	clause_catch->handler_offset = mono_mb_get_label (mb);
+
+	mono_mb_emit_stloc (mb, e_local);
+
+	/* ex = mono_gchandle_new (e, false); */
+	mono_mb_emit_ldloc (mb, e_local);
+	mono_mb_emit_icon (mb, 0);
+	mono_mb_emit_icall (mb, mono_gchandle_new);
+	mono_mb_emit_stloc (mb, ex_local);
+
+	leave_catch_pos = mono_mb_emit_branch (mb, CEE_LEAVE);
+
+	/* } [endcatch] */
+	clause_catch->handler_len = mono_mb_get_pos (mb) - clause_catch->handler_offset;
+
+	/* finally { */
+	clause_finally->try_len = mono_mb_get_label (mb) - clause_finally->try_offset;
+	clause_finally->handler_offset = mono_mb_get_label (mb);
+
+	if (!mono_threads_is_blocking_transition_enabled ()) {
+		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+		mono_mb_emit_byte (mb, CEE_MONO_JIT_DETACH);
+	} else {
+		/* mono_threads_detach_coop (); */
+		mono_mb_emit_ldloc (mb, attach_cookie_local);
+		mono_mb_emit_ldloc_addr (mb, attach_dummy_local);
+		mono_mb_emit_icall (mb, mono_threads_detach_coop);
+	}
+
+	/* if (ex != -1) */
+	mono_mb_emit_ldloc (mb, ex_local);
+	mono_mb_emit_icon (mb, -1);
+	mono_mb_emit_byte (mb, CEE_CONV_U4);
+	ex_m1_pos = mono_mb_emit_branch (mb, CEE_BEQ);
+
+	/* mono_marshal_ftnptr_eh_callback (ex) */
+	mono_mb_emit_ldloc (mb, ex_local);
+	mono_mb_emit_icall (mb, mono_marshal_ftnptr_eh_callback);
+
+	/* [ex == -1] */
+	mono_mb_patch_branch (mb, ex_m1_pos);
+
+	mono_mb_emit_byte (mb, CEE_ENDFINALLY);
+
+	/* } [endfinally] */
+	clause_finally->handler_len = mono_mb_get_pos (mb) - clause_finally->handler_offset;
+
+	mono_mb_patch_branch (mb, leave_try_pos);
+	mono_mb_patch_branch (mb, leave_catch_pos);
+
+	/* return ret; */
+	if (m->retobj_var) {
+		mono_mb_emit_ldloc (mb, m->retobj_var);
+		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+		mono_mb_emit_op (mb, CEE_MONO_RETOBJ, m->retobj_class);
+	}
+	else {
+		if (!MONO_TYPE_IS_VOID(sig->ret))
+			mono_mb_emit_ldloc (mb, 3);
+		mono_mb_emit_byte (mb, CEE_RET);
+	}
+
+	mono_mb_set_clauses (mb, 2, clauses);
+
+	if (closed)
+		g_free (sig);
+}
+
+static void
+emit_struct_to_ptr_ilgen (MonoMethodBuilder *mb, MonoClass *klass)
+{
+	if (klass->blittable) {
+		mono_mb_emit_byte (mb, CEE_LDARG_1);
+		mono_mb_emit_byte (mb, CEE_LDARG_0);
+		mono_mb_emit_ldflda (mb, sizeof (MonoObject));
+		mono_mb_emit_icon (mb, mono_class_value_size (klass, NULL));
+		mono_mb_emit_byte (mb, CEE_PREFIX1);
+		mono_mb_emit_byte (mb, CEE_CPBLK);
+	} else {
+
+		/* allocate local 0 (pointer) src_ptr */
+		mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		/* allocate local 1 (pointer) dst_ptr */
+		mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		/* allocate local 2 (boolean) delete_old */
+		mono_mb_add_local (mb, &mono_defaults.boolean_class->byval_arg);
+		mono_mb_emit_byte (mb, CEE_LDARG_2);
+		mono_mb_emit_stloc (mb, 2);
+
+		/* initialize src_ptr to point to the start of object data */
+		mono_mb_emit_byte (mb, CEE_LDARG_0);
+		mono_mb_emit_ldflda (mb, sizeof (MonoObject));
+		mono_mb_emit_stloc (mb, 0);
+
+		/* initialize dst_ptr */
+		mono_mb_emit_byte (mb, CEE_LDARG_1);
+		mono_mb_emit_stloc (mb, 1);
+
+		emit_struct_conv (mb, klass, FALSE);
+	}
+
+	mono_mb_emit_byte (mb, CEE_RET);
+}
+
+static void
+emit_ptr_to_struct_ilgen (MonoMethodBuilder *mb, MonoClass *klass)
+{
+	if (klass->blittable) {
+		mono_mb_emit_byte (mb, CEE_LDARG_1);
+		mono_mb_emit_ldflda (mb, sizeof (MonoObject));
+		mono_mb_emit_byte (mb, CEE_LDARG_0);
+		mono_mb_emit_icon (mb, mono_class_value_size (klass, NULL));
+		mono_mb_emit_byte (mb, CEE_PREFIX1);
+		mono_mb_emit_byte (mb, CEE_CPBLK);
+	} else {
+
+		/* allocate local 0 (pointer) src_ptr */
+		mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		/* allocate local 1 (pointer) dst_ptr */
+		mono_mb_add_local (mb, &klass->this_arg);
+		
+		/* initialize src_ptr to point to the start of object data */
+		mono_mb_emit_byte (mb, CEE_LDARG_0);
+		mono_mb_emit_stloc (mb, 0);
+
+		/* initialize dst_ptr */
+		mono_mb_emit_byte (mb, CEE_LDARG_1);
+		mono_mb_emit_ldflda (mb, sizeof (MonoObject));
+		mono_mb_emit_stloc (mb, 1);
+
+		emit_struct_conv (mb, klass, TRUE);
+	}
+
+	mono_mb_emit_byte (mb, CEE_RET);
+}
+
+static void
+emit_create_string_hack_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *csig, MonoMethod *res)
+{
+	int i;
+	mono_mb_emit_byte (mb, CEE_LDARG_0);
+	for (i = 1; i <= csig->param_count; i++)
+		mono_mb_emit_ldarg (mb, i);
+	mono_mb_emit_managed_call (mb, res, NULL);
+	mono_mb_emit_byte (mb, CEE_RET);
+}
+
+/* How the arguments of an icall should be wrapped */
+typedef enum {
+	/* Don't wrap at all, pass the argument as is */
+	ICALL_HANDLES_WRAP_NONE,
+	/* Wrap the argument in an object handle, pass the handle to the icall */
+	ICALL_HANDLES_WRAP_OBJ,
+	/* Wrap the argument in an object handle, pass the handle to the icall,
+	   write the value out from the handle when the icall returns */
+	ICALL_HANDLES_WRAP_OBJ_INOUT,
+	/* Initialized an object handle to null, pass to the icalls,
+	   write the value out from the handle when the icall returns */
+	ICALL_HANDLES_WRAP_OBJ_OUT,
+	/* Wrap the argument (a valuetype reference) in a handle to pin its enclosing object,
+	   but pass the raw reference to the icall */
+	ICALL_HANDLES_WRAP_VALUETYPE_REF,
+} IcallHandlesWrap;
+
+typedef struct {
+	IcallHandlesWrap wrap;
+	/* if wrap is NONE or OBJ or VALUETYPE_REF, this is not meaningful.
+	   if wrap is OBJ_INOUT it's the local var that holds the MonoObjectHandle.
+	*/
+	int handle;
+}  IcallHandlesLocal;
+
+/*
+ * Describes how to wrap the given parameter.
+ *
+ */
+static IcallHandlesWrap
+signature_param_uses_handles (MonoMethodSignature *sig, int param)
+{
+	if (MONO_TYPE_IS_REFERENCE (sig->params [param])) {
+		if (mono_signature_param_is_out (sig, param))
+			return ICALL_HANDLES_WRAP_OBJ_OUT;
+		else if (mono_type_is_byref (sig->params [param]))
+			return ICALL_HANDLES_WRAP_OBJ_INOUT;
+		else
+			return ICALL_HANDLES_WRAP_OBJ;
+	} else if (mono_type_is_byref (sig->params [param]))
+		return ICALL_HANDLES_WRAP_VALUETYPE_REF;
+	else
+		return ICALL_HANDLES_WRAP_NONE;
+}
+
+static void
+emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, MonoMethodSignature *csig, gboolean check_exceptions, gboolean aot, MonoMethodPInvoke *piinfo)
+{
+	// FIXME:
+	MonoClass *handle_stack_mark_class;
+	MonoClass *error_class;
+	int thread_info_var = -1, stack_mark_var = -1, error_var = -1;
+	MonoMethodSignature *call_sig = csig;
+	gboolean uses_handles = FALSE;
+	gboolean save_handles_to_locals = FALSE;
+	IcallHandlesLocal *handles_locals = NULL;
+	MonoMethodSignature *sig = mono_method_signature (method);
+
+	(void) mono_lookup_internal_call_full (method, &uses_handles);
+
+	/* If it uses handles and MonoError, it had better check exceptions */
+	g_assert (!uses_handles || check_exceptions);
+
+	if (uses_handles) {
+		MonoMethodSignature *ret;
+
+		/* Add a MonoError argument and figure out which args need to be wrapped in handles */
+		// FIXME: The stuff from mono_metadata_signature_dup_internal_with_padding ()
+		ret = mono_metadata_signature_alloc (method->klass->image, csig->param_count + 1);
+
+		ret->param_count = csig->param_count + 1;
+		ret->ret = csig->ret;
+
+		handles_locals = g_new0 (IcallHandlesLocal, csig->param_count);
+		for (int i = 0; i < csig->param_count; ++i) {
+			IcallHandlesWrap w = signature_param_uses_handles (csig, i);
+			handles_locals [i].wrap = w;
+			switch (w) {
+				case ICALL_HANDLES_WRAP_OBJ:
+				case ICALL_HANDLES_WRAP_OBJ_INOUT:
+				case ICALL_HANDLES_WRAP_OBJ_OUT:
+					ret->params [i] = mono_class_get_byref_type (mono_class_from_mono_type(csig->params[i]));
+					if (w == ICALL_HANDLES_WRAP_OBJ_OUT || w == ICALL_HANDLES_WRAP_OBJ_INOUT)
+						save_handles_to_locals = TRUE;
+					break;
+				case ICALL_HANDLES_WRAP_NONE:
+				case ICALL_HANDLES_WRAP_VALUETYPE_REF:
+					ret->params [i] = csig->params [i];
+					break;
+				default:
+					g_assert_not_reached ();
+			}
+		}
+		/* Add MonoError* param */
+		ret->params [csig->param_count] = &mono_get_intptr_class ()->byval_arg;
+		ret->pinvoke = csig->pinvoke;
+
+		call_sig = ret;
+	}
+
+	if (uses_handles) {
+		handle_stack_mark_class = mono_class_load_from_name (mono_get_corlib (), "Mono", "RuntimeStructs/HandleStackMark");
+		error_class = mono_class_load_from_name (mono_get_corlib (), "Mono", "RuntimeStructs/MonoError");
+
+		thread_info_var = mono_mb_add_local (mb, &mono_get_intptr_class ()->byval_arg);
+		stack_mark_var = mono_mb_add_local (mb, &handle_stack_mark_class->byval_arg);
+		error_var = mono_mb_add_local (mb, &error_class->byval_arg);
+
+		if (save_handles_to_locals) {
+			/* add a local var to hold the handles for each out arg */
+			for (int i = 0; i < sig->param_count; ++i) {
+				int j = i + sig->hasthis;
+				switch (handles_locals[j].wrap) {
+					case ICALL_HANDLES_WRAP_NONE:
+					case ICALL_HANDLES_WRAP_OBJ:
+					case ICALL_HANDLES_WRAP_VALUETYPE_REF:
+						handles_locals [j].handle = -1;
+						break;
+					case ICALL_HANDLES_WRAP_OBJ_INOUT:
+					case ICALL_HANDLES_WRAP_OBJ_OUT:
+						handles_locals [j].handle = mono_mb_add_local (mb, sig->params [i]);
+						break;
+					default:
+						g_assert_not_reached ();
+				}
+			}
+		}
+	}
+
+	if (sig->hasthis) {
+		int pos;
+
+		/*
+		 * Add a null check since public icalls can be called with 'call' which
+		 * does no such check.
+		 */
+		mono_mb_emit_byte (mb, CEE_LDARG_0);			
+		pos = mono_mb_emit_branch (mb, CEE_BRTRUE);
+		mono_mb_emit_exception (mb, "NullReferenceException", NULL);
+		mono_mb_patch_branch (mb, pos);
+	}
+
+	if (uses_handles) {
+		mono_mb_emit_ldloc_addr (mb, stack_mark_var);
+		mono_mb_emit_ldloc_addr (mb, error_var);
+		mono_mb_emit_icall (mb, mono_icall_start);
+		mono_mb_emit_stloc (mb, thread_info_var);
+
+		if (sig->hasthis) {
+			mono_mb_emit_byte (mb, CEE_LDARG_0);
+			/* TODO support adding wrappers to non-static struct methods */
+			g_assert (!mono_class_is_valuetype(mono_method_get_class (method)));
+			mono_mb_emit_icall (mb, mono_icall_handle_new);
+		}
+		for (int i = 0; i < sig->param_count; i++) {
+			/* load each argument. references into the managed heap get wrapped in handles */
+			int j = i + sig->hasthis;
+			switch (handles_locals[j].wrap) {
+				case ICALL_HANDLES_WRAP_NONE:
+					mono_mb_emit_ldarg (mb, j);
+					break;
+				case ICALL_HANDLES_WRAP_OBJ:
+					/* argI = mono_handle_new (argI_raw) */
+					mono_mb_emit_ldarg (mb, j);
+					mono_mb_emit_icall (mb, mono_icall_handle_new);
+					break;
+				case ICALL_HANDLES_WRAP_OBJ_INOUT:
+				case ICALL_HANDLES_WRAP_OBJ_OUT:
+					/* if inout:
+					 *   handleI = argI = mono_handle_new (*argI_raw)
+					 * otherwise:
+					 *   handleI = argI = mono_handle_new (NULL)
+					 */
+					if (handles_locals[j].wrap == ICALL_HANDLES_WRAP_OBJ_INOUT) {
+						mono_mb_emit_ldarg (mb, j);
+						mono_mb_emit_byte (mb, CEE_LDIND_REF);
+					} else
+						mono_mb_emit_byte (mb, CEE_LDNULL);
+					mono_mb_emit_icall (mb, mono_icall_handle_new);
+					/* tmp = argI */
+					mono_mb_emit_byte (mb, CEE_DUP);
+					/* handleI = tmp */
+					mono_mb_emit_stloc (mb, handles_locals[j].handle);
+					break;
+				case ICALL_HANDLES_WRAP_VALUETYPE_REF:
+					/* (void) mono_handle_new (argI); argI */
+					mono_mb_emit_ldarg (mb, j);
+					mono_mb_emit_byte (mb, CEE_DUP);
+					mono_mb_emit_icall (mb, mono_icall_handle_new_interior);
+					mono_mb_emit_byte (mb, CEE_POP);
+#if 0
+					fprintf (stderr, " Method %s.%s.%s has byref valuetype argument %d\n", method->klass->name_space, method->klass->name, method->name, i);
+#endif
+					break;
+				default:
+					g_assert_not_reached ();
+			}
+		}
+		mono_mb_emit_ldloc_addr (mb, error_var);
+	} else {
+		if (sig->hasthis)
+			mono_mb_emit_byte (mb, CEE_LDARG_0);
+		for (int i = 0; i < sig->param_count; i++)
+			mono_mb_emit_ldarg (mb, i + sig->hasthis);
+	}
+
+	if (aot) {
+		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+		mono_mb_emit_op (mb, CEE_MONO_ICALL_ADDR, &piinfo->method);
+		mono_mb_emit_calli (mb, call_sig);
+	} else {
+		g_assert (piinfo->addr);
+		mono_mb_emit_native_call (mb, call_sig, piinfo->addr);
+	}
+
+	if (uses_handles) {
+		if (MONO_TYPE_IS_REFERENCE (sig->ret)) {
+			// if (ret != NULL_HANDLE) {
+			//   ret = MONO_HANDLE_RAW(ret)
+			// }
+			mono_mb_emit_byte (mb, CEE_DUP);
+			int pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
+			mono_mb_emit_ldflda (mb, MONO_HANDLE_PAYLOAD_OFFSET (MonoObject));
+			mono_mb_emit_byte (mb, CEE_LDIND_REF);
+			mono_mb_patch_branch (mb, pos);
+		}
+		if (save_handles_to_locals) {
+			for (int i = 0; i < sig->param_count; i++) {
+				int j = i + sig->hasthis;
+				switch (handles_locals [j].wrap) {
+					case ICALL_HANDLES_WRAP_NONE:
+					case ICALL_HANDLES_WRAP_OBJ:
+					case ICALL_HANDLES_WRAP_VALUETYPE_REF:
+						break;
+					case ICALL_HANDLES_WRAP_OBJ_INOUT:
+					case ICALL_HANDLES_WRAP_OBJ_OUT:
+						/* *argI_raw = MONO_HANDLE_RAW (handleI) */
+
+						/* argI_raw */
+						mono_mb_emit_ldarg (mb, j);
+						/* handleI */
+						mono_mb_emit_ldloc (mb, handles_locals [j].handle);
+						/* MONO_HANDLE_RAW(handleI) */
+						mono_mb_emit_ldflda (mb, MONO_HANDLE_PAYLOAD_OFFSET (MonoObject));
+						mono_mb_emit_byte (mb, CEE_LDIND_REF);
+						/* *argI_raw = MONO_HANDLE_RAW(handleI) */
+						mono_mb_emit_byte (mb, CEE_STIND_REF);
+						break;
+					default:
+						g_assert_not_reached ();
+				}
+			}
+		}
+		g_free (handles_locals);
+
+		mono_mb_emit_ldloc (mb, thread_info_var);
+		mono_mb_emit_ldloc_addr (mb, stack_mark_var);
+		mono_mb_emit_ldloc_addr (mb, error_var);
+		mono_mb_emit_icall (mb, mono_icall_end);
+	}
+
+	if (check_exceptions)
+		emit_thread_interrupt_checkpoint (mb);
+	mono_mb_emit_byte (mb, CEE_RET);
+}
+
+static void
+mb_emit_exception_ilgen (MonoMethodBuilder *mb, const char *exc_nspace, const char *exc_name, const char *msg)
+{
+	mono_mb_emit_exception_full (mb, exc_nspace, exc_name, msg);
+}
+
+static void
+emit_vtfixup_ftnptr_ilgen (MonoMethodBuilder *mb, MonoMethod *method, int param_count, guint16 type)
+{
+	for (int i = 0; i < param_count; i++)
+		mono_mb_emit_ldarg (mb, i);
+
+	if (type & VTFIXUP_TYPE_CALL_MOST_DERIVED)
+		mono_mb_emit_op (mb, CEE_CALLVIRT, method);
+	else
+		mono_mb_emit_op (mb, CEE_CALL, method);
+	mono_mb_emit_byte (mb, CEE_RET);
+}
+
+static void
+emit_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *sig, gconstpointer func, MonoMethodSignature *csig2, gboolean check_exceptions)
+{
+	if (sig->hasthis)
+		mono_mb_emit_byte (mb, CEE_LDARG_0);
+
+	for (int i = 0; i < sig->param_count; i++)
+		mono_mb_emit_ldarg (mb, i + sig->hasthis);
+
+	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+	mono_mb_emit_op (mb, CEE_MONO_JIT_ICALL_ADDR, (gpointer)func);
+	mono_mb_emit_calli (mb, csig2);
+	if (check_exceptions)
+		emit_thread_interrupt_checkpoint (mb);
+	mono_mb_emit_byte (mb, CEE_RET);
+}
+
+void
+mono_marshal_ilgen_init (void)
+{
+	MonoMarshalCallbacks cb;
+	cb.version = MONO_MARSHAL_CALLBACKS_VERSION;;
+	cb.emit_marshal_array = emit_marshal_array_ilgen;
+	cb.emit_marshal_boolean = emit_marshal_boolean_ilgen;
+	cb.emit_marshal_ptr = emit_marshal_ptr_ilgen;
+	cb.emit_marshal_char = emit_marshal_char_ilgen;
+	cb.emit_marshal_scalar = emit_marshal_scalar_ilgen;
+	cb.emit_marshal_custom = emit_marshal_custom_ilgen;
+	cb.emit_marshal_asany = emit_marshal_asany_ilgen;
+	cb.emit_marshal_vtype = emit_marshal_vtype_ilgen;
+	cb.emit_marshal_string = emit_marshal_string_ilgen;
+	cb.emit_marshal_safehandle = emit_marshal_safehandle_ilgen;
+	cb.emit_marshal_handleref = emit_marshal_handleref_ilgen;
+	cb.emit_marshal_object = emit_marshal_object_ilgen;
+	cb.emit_marshal_variant = emit_marshal_variant_ilgen;
+	cb.emit_castclass = emit_castclass_ilgen;
+	cb.emit_struct_to_ptr = emit_struct_to_ptr_ilgen;
+	cb.emit_ptr_to_struct = emit_ptr_to_struct_ilgen;
+	cb.emit_isinst = emit_isinst_ilgen;
+	cb.emit_virtual_stelemref = emit_virtual_stelemref_ilgen;
+	cb.emit_stelemref = emit_stelemref_ilgen;
+	cb.emit_array_address = emit_array_address_ilgen;
+	cb.emit_native_wrapper = emit_native_wrapper_ilgen;
+	cb.emit_managed_wrapper = emit_managed_wrapper_ilgen;
+	cb.emit_runtime_invoke_body = emit_runtime_invoke_body_ilgen;
+	cb.emit_runtime_invoke_dynamic = emit_runtime_invoke_dynamic_ilgen;
+	cb.emit_delegate_begin_invoke = emit_delegate_begin_invoke_ilgen;
+	cb.emit_delegate_end_invoke = emit_delegate_end_invoke_ilgen;
+	cb.emit_delegate_invoke_internal = emit_delegate_invoke_internal_ilgen;
+	cb.emit_synchronized_wrapper = emit_synchronized_wrapper_ilgen;
+	cb.emit_unbox_wrapper = emit_unbox_wrapper_ilgen;
+	cb.emit_array_accessor_wrapper = emit_array_accessor_wrapper_ilgen;
+	cb.emit_generic_array_helper = emit_generic_array_helper_ilgen;
+	cb.emit_thunk_invoke_wrapper = emit_thunk_invoke_wrapper_ilgen;
+	cb.emit_create_string_hack = emit_create_string_hack_ilgen;
+	cb.emit_native_icall_wrapper = emit_native_icall_wrapper_ilgen;
+	cb.emit_icall_wrapper = emit_icall_wrapper_ilgen;
+	cb.emit_vtfixup_ftnptr = emit_vtfixup_ftnptr_ilgen;
+	cb.mb_skip_visibility = mb_skip_visibility_ilgen;
+	cb.mb_set_dynamic = mb_set_dynamic_ilgen;
+	cb.mb_emit_exception = mb_emit_exception_ilgen;
+	cb.mb_emit_byte = mb_emit_byte_ilgen;
+	mono_install_marshal_callbacks (&cb);
+}

--- a/mono/metadata/marshal-ilgen.h
+++ b/mono/metadata/marshal-ilgen.h
@@ -1,0 +1,12 @@
+/**
+ * \file
+ * Copyright 2018 Microsoft
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+#ifndef __MONO_MARSHAL_ILGEN_H__
+#define __MONO_MARSHAL_ILGEN_H__
+
+MONO_API void
+mono_marshal_ilgen_init (void);
+
+#endif

--- a/mono/metadata/marshal-internals.h
+++ b/mono/metadata/marshal-internals.h
@@ -39,4 +39,10 @@ gpointer
 mono_string_to_utf8str (MonoString *s);
 #endif  /* HOST_WIN32 */
 
+typedef enum {
+	TYPECHECK_OBJECT_ARG_POS = 0,
+	TYPECHECK_CLASS_ARG_POS = 1,
+	TYPECHECK_CACHE_ARG_POS = 2
+} MarshalTypeCheckPositions;
+
 #endif /* __MONO_METADATA_MARSHAL_INTERNALS_H__ */

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -22,7 +22,9 @@
 #include "cil-coff.h"
 #include "metadata/marshal.h"
 #include "metadata/marshal-internals.h"
+#include "metadata/marshal-ilgen.h"
 #include "metadata/method-builder.h"
+#include "metadata/method-builder-internals.h"
 #include "metadata/tabledefs.h"
 #include "metadata/exception.h"
 #include "metadata/appdomain.h"
@@ -88,6 +90,9 @@ static void ftnptr_eh_callback_default (guint32 gchandle);
 
 static MonoFtnPtrEHCallback ftnptr_eh_callback = ftnptr_eh_callback_default;
 
+static MonoMarshalCallbacks *
+get_marshal_cb (void);
+
 static void
 delegate_hash_table_add (MonoDelegateHandle d);
 
@@ -95,157 +100,23 @@ static void
 delegate_hash_table_remove (MonoDelegate *d);
 
 static void
-emit_struct_conv (MonoMethodBuilder *mb, MonoClass *klass, gboolean to_object);
-
-static void
-emit_struct_conv_full (MonoMethodBuilder *mb, MonoClass *klass, gboolean to_object, int offset_of_first_child_field, MonoMarshalNative string_encoding);
-
-static void 
-mono_struct_delete_old (MonoClass *klass, char *ptr);
-
-MONO_API void *
-mono_marshal_string_to_utf16 (MonoString *s);
-
-static void *
-mono_marshal_string_to_utf16_copy (MonoString *s);
-
-#ifndef HOST_WIN32
-static gpointer
-mono_string_to_utf8str (MonoString *string_obj);
-#endif
-
-static MonoStringBuilder *
-mono_string_utf8_to_builder2 (char *text);
-
-static MonoStringBuilder *
-mono_string_utf16_to_builder2 (gunichar2 *text);
-
-static MonoString*
-mono_string_new_len_wrapper (const char *text, guint length);
-
-static MonoString *
-mono_string_from_byvalstr (const char *data, int len);
-
-static MonoString *
-mono_string_from_byvalwstr (gunichar2 *data, int len);
-
-static void
 mono_byvalarray_to_array (MonoArray *arr, gpointer native_arr, MonoClass *eltype, guint32 elnum);
-
-static void
-mono_byvalarray_to_byte_array (MonoArray *arr, gpointer native_arr, guint32 elnum);
 
 static void
 mono_array_to_byvalarray (gpointer native_arr, MonoArray *arr, MonoClass *eltype, guint32 elnum);
 
 static void
-mono_array_to_byte_byvalarray (gpointer native_arr, MonoArray *arr, guint32 elnum);
-
-static MonoAsyncResult *
-mono_delegate_begin_invoke (MonoDelegate *delegate, gpointer *params);
-
-static MonoObject *
-mono_delegate_end_invoke (MonoDelegate *delegate, gpointer *params);
-
-static void
 mono_marshal_set_last_error_windows (int error);
-
-static MonoObject *
-mono_marshal_isinst_with_cache (MonoObject *obj, MonoClass *klass, uintptr_t *cache);
-
-static void init_safe_handle (void);
-
-static void*
-ves_icall_marshal_alloc (gsize size);
-
-void
-mono_string_utf8_to_builder (MonoStringBuilder *sb, char *text);
-
-void
-mono_string_utf16_to_builder (MonoStringBuilder *sb, gunichar2 *text);
-
-gchar*
-mono_string_builder_to_utf8 (MonoStringBuilder *sb);
-
-gunichar2*
-mono_string_builder_to_utf16 (MonoStringBuilder *sb);
-
-void
-mono_string_to_byvalstr (gpointer dst, MonoString *src, int size);
-
-void
-mono_string_to_byvalwstr (gpointer dst, MonoString *src, int size);
-
-gpointer
-mono_delegate_to_ftnptr (MonoDelegate *delegate);
 
 gpointer
 mono_delegate_handle_to_ftnptr (MonoDelegateHandle delegate, MonoError *error);
 
-MonoDelegate*
-mono_ftnptr_to_delegate (MonoClass *klass, gpointer ftn);
-
 MonoDelegateHandle
 mono_ftnptr_to_delegate_handle (MonoClass *klass, gpointer ftn, MonoError *error);
 
-gpointer
-mono_array_to_savearray (MonoArray *array);
-
-gpointer
-mono_array_to_lparray (MonoArray *array);
-
-void
-mono_free_lparray (MonoArray *array, gpointer* nativeArray);
-
-gpointer
-mono_marshal_asany (MonoObject *obj, MonoMarshalNative string_encoding, int param_attrs);
-
-void
-mono_marshal_free_asany (MonoObject *o, gpointer ptr, MonoMarshalNative string_encoding, int param_attrs);
-
-gpointer
-mono_array_to_savearray (MonoArray *array);
-
-gpointer
-mono_array_to_lparray (MonoArray *array);
-
-void
-mono_free_lparray (MonoArray *array, gpointer* nativeArray);
-
-static void
-mono_marshal_ftnptr_eh_callback (guint32 gchandle);
-
-static MonoThreadInfo*
-mono_icall_start (HandleStackMark *stackmark, MonoError *error);
-
-static void
-mono_icall_end (MonoThreadInfo *info, HandleStackMark *stackmark, MonoError *error);
-
-static MonoObjectHandle
-mono_icall_handle_new (gpointer rawobj);
-
-static MonoObjectHandle
-mono_icall_handle_new_interior (gpointer rawobj);
-
 /* Lazy class loading functions */
 static GENERATE_GET_CLASS_WITH_CACHE (string_builder, "System.Text", "StringBuilder");
-static GENERATE_GET_CLASS_WITH_CACHE (date_time, "System", "DateTime");
-static GENERATE_GET_CLASS_WITH_CACHE (fixed_buffer_attribute, "System.Runtime.CompilerServices", "FixedBufferAttribute");
 static GENERATE_TRY_GET_CLASS_WITH_CACHE (unmanaged_function_pointer_attribute, "System.Runtime.InteropServices", "UnmanagedFunctionPointerAttribute");
-static GENERATE_TRY_GET_CLASS_WITH_CACHE (icustom_marshaler, "System.Runtime.InteropServices", "ICustomMarshaler");
-
-/* MonoMethod pointers to SafeHandle::DangerousAddRef and ::DangerousRelease */
-static MonoMethod *sh_dangerous_add_ref;
-static MonoMethod *sh_dangerous_release;
-
-static void
-init_safe_handle ()
-{
-	sh_dangerous_add_ref = mono_class_get_method_from_name (
-		mono_class_try_get_safehandle_class (), "DangerousAddRef", 1);
-	sh_dangerous_release = mono_class_get_method_from_name (
-		mono_class_try_get_safehandle_class (), "DangerousRelease", 0);
-}
 
 static void
 register_icall (gpointer func, const char *name, const char *sigstr, gboolean no_wrapper)
@@ -282,7 +153,7 @@ mono_marshal_init_tls (void)
 	mono_native_tls_alloc (&load_type_info_tls_id, NULL);
 }
 
-static MonoObject*
+MonoObject*
 mono_object_isinst_icall (MonoObject *obj, MonoClass *klass)
 {
 	if (!klass)
@@ -306,7 +177,7 @@ mono_object_isinst_icall (MonoObject *obj, MonoClass *klass)
 	return result;
 }
 
-static MonoString*
+MonoString*
 ves_icall_mono_string_from_utf16 (gunichar2 *data)
 {
 	ERROR_DECL (error);
@@ -315,7 +186,7 @@ ves_icall_mono_string_from_utf16 (gunichar2 *data)
 	return result;
 }
 
-static char*
+char*
 ves_icall_mono_string_to_utf8 (MonoString *str)
 {
 	ERROR_DECL (error);
@@ -324,7 +195,7 @@ ves_icall_mono_string_to_utf8 (MonoString *str)
 	return result;
 }
 
-static MonoString*
+MonoString*
 ves_icall_string_new_wrapper (const char *text)
 {
 	if (text) {
@@ -733,7 +604,7 @@ mono_delegate_free_ftnptr (MonoDelegate *delegate)
 }
 
 /* This is a JIT icall, it sets the pending exception and returns NULL on error */
-static MonoString *
+MonoString *
 mono_string_from_byvalstr (const char *data, int max_len)
 {
 	ERROR_DECL (error);
@@ -752,7 +623,7 @@ mono_string_from_byvalstr (const char *data, int max_len)
 }
 
 /* This is a JIT icall, it sets the pending exception and return NULL on error */
-static MonoString *
+MonoString *
 mono_string_from_byvalwstr (gunichar2 *data, int max_len)
 {
 	ERROR_DECL (error);
@@ -863,7 +734,7 @@ mono_free_lparray (MonoArray *array, gpointer* nativeArray)
 #endif
 }
 
-static void
+void
 mono_byvalarray_to_array (MonoArray *arr, gpointer native_arr, MonoClass *elclass, guint32 elnum)
 {
 	g_assert (arr->obj.vtable->klass->element_class == mono_defaults.char_class);
@@ -886,7 +757,7 @@ mono_byvalarray_to_array (MonoArray *arr, gpointer native_arr, MonoClass *elclas
 		g_assert_not_reached ();
 }
 
-static void
+void
 mono_byvalarray_to_byte_array (MonoArray *arr, gpointer native_arr, guint32 elnum)
 {
 	mono_byvalarray_to_array (arr, native_arr, mono_defaults.byte_class, elnum);
@@ -916,7 +787,7 @@ mono_array_to_byvalarray (gpointer native_arr, MonoArray *arr, MonoClass *elclas
 	}
 }
 
-static void
+void
 mono_array_to_byte_byvalarray (gpointer native_arr, MonoArray *arr, guint32 elnum)
 {
 	mono_array_to_byvalarray (native_arr, arr, mono_defaults.byte_class, elnum);
@@ -1155,7 +1026,7 @@ mono_string_builder_to_utf16 (MonoStringBuilder *sb)
 
 #ifndef HOST_WIN32
 /* This is a JIT icall, it sets the pending exception and returns NULL on error. */
-static gpointer
+gpointer
 mono_string_to_utf8str (MonoString *s)
 {
 	ERROR_DECL (error);
@@ -1236,7 +1107,7 @@ mono_string_to_byvalwstr (gpointer dst, MonoString *src, int size)
 }
 
 /* this is an icall, it sets the pending exception and returns NULL on error */
-static MonoString*
+MonoString*
 mono_string_new_len_wrapper (const char *text, guint length)
 {
 	ERROR_DECL (error);
@@ -1244,28 +1115,6 @@ mono_string_new_len_wrapper (const char *text, guint length)
 	mono_error_set_pending_exception (error);
 	return result;
 }
-
-#ifdef ENABLE_ILGEN
-
-/*
- * mono_mb_emit_exception_marshal_directive:
- *
- *   This function assumes ownership of MSG, which should be malloc-ed.
- */
-static void
-mono_mb_emit_exception_marshal_directive (MonoMethodBuilder *mb, char *msg)
-{
-	char *s;
-
-	if (!mb->dynamic) {
-		s = mono_image_strdup (mb->method->klass->image, msg);
-		g_free (msg);
-	} else {
-		s = g_strdup (msg);
-	}
-	mono_mb_emit_exception_full (mb, "System.Runtime.InteropServices", "MarshalDirectiveException", s);
-}
-#endif /* ENABLE_ILGEN */
 
 guint
 mono_type_to_ldind (MonoType *type)
@@ -1379,1087 +1228,8 @@ handle_enum:
 	return -1;
 }
 
-#ifdef ENABLE_ILGEN
-
-static void
-emit_ptr_to_object_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv conv, MonoMarshalSpec *mspec)
-{
-	switch (conv) {
-	case MONO_MARSHAL_CONV_BOOL_I4:
-		mono_mb_emit_ldloc (mb, 1);
-		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_byte (mb, CEE_LDIND_I4);
-		mono_mb_emit_byte (mb, CEE_BRFALSE_S);
-		mono_mb_emit_byte (mb, 3);
-		mono_mb_emit_byte (mb, CEE_LDC_I4_1);
-		mono_mb_emit_byte (mb, CEE_BR_S);
-		mono_mb_emit_byte (mb, 1);
-		mono_mb_emit_byte (mb, CEE_LDC_I4_0);
-		mono_mb_emit_byte (mb, CEE_STIND_I1);
-		break;
-	case MONO_MARSHAL_CONV_BOOL_VARIANTBOOL:
-		mono_mb_emit_ldloc (mb, 1);
-		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_byte (mb, CEE_LDIND_I2);
-		mono_mb_emit_byte (mb, CEE_BRFALSE_S);
-		mono_mb_emit_byte (mb, 3);
-		mono_mb_emit_byte (mb, CEE_LDC_I4_1);
-		mono_mb_emit_byte (mb, CEE_BR_S);
-		mono_mb_emit_byte (mb, 1);
-		mono_mb_emit_byte (mb, CEE_LDC_I4_0);
-		mono_mb_emit_byte (mb, CEE_STIND_I1);
-		break;
-	case MONO_MARSHAL_CONV_ARRAY_BYVALARRAY: {
-		MonoClass *eklass = NULL;
-		int esize;
-
-		if (type->type == MONO_TYPE_SZARRAY) {
-			eklass = type->data.klass;
-		} else {
-			g_assert_not_reached ();
-		}
-
-		esize = mono_class_native_size (eklass, NULL);
-
-		/* create a new array */
-		mono_mb_emit_ldloc (mb, 1);
-		mono_mb_emit_icon (mb, mspec->data.array_data.num_elem);
-		mono_mb_emit_op (mb, CEE_NEWARR, eklass);	
-		mono_mb_emit_byte (mb, CEE_STIND_REF);
-
-		if (eklass->blittable) {
-			/* copy the elements */
-			mono_mb_emit_ldloc (mb, 1);
-			mono_mb_emit_byte (mb, CEE_LDIND_I);
-			mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoArray, vector));
-			mono_mb_emit_byte (mb, CEE_ADD);
-			mono_mb_emit_ldloc (mb, 0);
-			mono_mb_emit_icon (mb, mspec->data.array_data.num_elem * esize);
-			mono_mb_emit_byte (mb, CEE_PREFIX1);
-			mono_mb_emit_byte (mb, CEE_CPBLK);			
-		}
-		else {
-			int array_var, src_var, dst_var, index_var;
-			guint32 label2, label3;
-
-			array_var = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
-			src_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-			dst_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-
-			/* set array_var */
-			mono_mb_emit_ldloc (mb, 1);
-			mono_mb_emit_byte (mb, CEE_LDIND_REF);
-			mono_mb_emit_stloc (mb, array_var);
-		
-			/* save the old src pointer */
-			mono_mb_emit_ldloc (mb, 0);
-			mono_mb_emit_stloc (mb, src_var);
-			/* save the old dst pointer */
-			mono_mb_emit_ldloc (mb, 1);
-			mono_mb_emit_stloc (mb, dst_var);
-
-			/* Emit marshalling loop */
-			index_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-			mono_mb_emit_byte (mb, CEE_LDC_I4_0);
-			mono_mb_emit_stloc (mb, index_var);
-
-			/* Loop header */
-			label2 = mono_mb_get_label (mb);
-			mono_mb_emit_ldloc (mb, index_var);
-			mono_mb_emit_ldloc (mb, array_var);
-			mono_mb_emit_byte (mb, CEE_LDLEN);
-			label3 = mono_mb_emit_branch (mb, CEE_BGE);
-
-			/* src is already set */
-
-			/* Set dst */
-			mono_mb_emit_ldloc (mb, array_var);
-			mono_mb_emit_ldloc (mb, index_var);
-			mono_mb_emit_op (mb, CEE_LDELEMA, eklass);
-			mono_mb_emit_stloc (mb, 1);
-
-			/* Do the conversion */
-			emit_struct_conv (mb, eklass, TRUE);
-
-			/* Loop footer */
-			mono_mb_emit_add_to_local (mb, index_var, 1);
-
-			mono_mb_emit_branch_label (mb, CEE_BR, label2);
-
-			mono_mb_patch_branch (mb, label3);
-		
-			/* restore the old src pointer */
-			mono_mb_emit_ldloc (mb, src_var);
-			mono_mb_emit_stloc (mb, 0);
-			/* restore the old dst pointer */
-			mono_mb_emit_ldloc (mb, dst_var);
-			mono_mb_emit_stloc (mb, 1);
-		}
-		break;
-	}
-	case MONO_MARSHAL_CONV_ARRAY_BYVALCHARARRAY: {
-		MonoClass *eclass = mono_defaults.char_class;
-
-		/* create a new array */
-		mono_mb_emit_ldloc (mb, 1);
-		mono_mb_emit_icon (mb, mspec->data.array_data.num_elem);
-		mono_mb_emit_op (mb, CEE_NEWARR, eclass);	
-		mono_mb_emit_byte (mb, CEE_STIND_REF);
-
-		mono_mb_emit_ldloc (mb, 1);
-		mono_mb_emit_byte (mb, CEE_LDIND_REF);
-		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_icon (mb, mspec->data.array_data.num_elem);
-		mono_mb_emit_icall (mb, mono_byvalarray_to_byte_array);
-		break;
-	}
-	case MONO_MARSHAL_CONV_STR_BYVALSTR: 
-		if (mspec && mspec->native == MONO_NATIVE_BYVALTSTR && mspec->data.array_data.num_elem) {
-			mono_mb_emit_ldloc (mb, 1);
-			mono_mb_emit_ldloc (mb, 0);
-			mono_mb_emit_icon (mb, mspec->data.array_data.num_elem);
-			mono_mb_emit_icall (mb, mono_string_from_byvalstr);
-		} else {
-			mono_mb_emit_ldloc (mb, 1);
-			mono_mb_emit_ldloc (mb, 0);
-			mono_mb_emit_icall (mb, ves_icall_string_new_wrapper);
-		}
-		mono_mb_emit_byte (mb, CEE_STIND_REF);		
-		break;
-	case MONO_MARSHAL_CONV_STR_BYVALWSTR:
-		if (mspec && mspec->native == MONO_NATIVE_BYVALTSTR && mspec->data.array_data.num_elem) {
-			mono_mb_emit_ldloc (mb, 1);
-			mono_mb_emit_ldloc (mb, 0);
-			mono_mb_emit_icon (mb, mspec->data.array_data.num_elem);
-			mono_mb_emit_icall (mb, mono_string_from_byvalwstr);
-		} else {
-			mono_mb_emit_ldloc (mb, 1);
-			mono_mb_emit_ldloc (mb, 0);
-			mono_mb_emit_icall (mb, ves_icall_mono_string_from_utf16);
-		}
-		mono_mb_emit_byte (mb, CEE_STIND_REF);		
-		break;		
-	case MONO_MARSHAL_CONV_STR_LPTSTR:
-		mono_mb_emit_ldloc (mb, 1);
-		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-#ifdef TARGET_WIN32
-		mono_mb_emit_icall (mb, ves_icall_mono_string_from_utf16);
-#else
-		mono_mb_emit_icall (mb, ves_icall_string_new_wrapper);
-#endif
-		mono_mb_emit_byte (mb, CEE_STIND_REF);	
-		break;
-
-		// In Mono historically LPSTR was treated as a UTF8STR
-	case MONO_MARSHAL_CONV_STR_LPSTR:
-	case MONO_MARSHAL_CONV_STR_UTF8STR:
-		mono_mb_emit_ldloc (mb, 1);
-		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_icall (mb, ves_icall_string_new_wrapper);
-		mono_mb_emit_byte (mb, CEE_STIND_REF);		
-		break;
-	case MONO_MARSHAL_CONV_STR_LPWSTR:
-		mono_mb_emit_ldloc (mb, 1);
-		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_icall (mb, ves_icall_mono_string_from_utf16);
-		mono_mb_emit_byte (mb, CEE_STIND_REF);
-		break;
-	case MONO_MARSHAL_CONV_OBJECT_STRUCT: {
-		MonoClass *klass = mono_class_from_mono_type (type);
-		int src_var, dst_var;
-
-		src_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		dst_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		
-		/* *dst = new object */
-		mono_mb_emit_ldloc (mb, 1);
-		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-		mono_mb_emit_op (mb, CEE_MONO_NEWOBJ, klass);	
-		mono_mb_emit_byte (mb, CEE_STIND_REF);
-	
-		/* save the old src pointer */
-		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_stloc (mb, src_var);
-		/* save the old dst pointer */
-		mono_mb_emit_ldloc (mb, 1);
-		mono_mb_emit_stloc (mb, dst_var);
-
-		/* dst = pointer to newly created object data */
-		mono_mb_emit_ldloc (mb, 1);
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_icon (mb, sizeof (MonoObject));
-		mono_mb_emit_byte (mb, CEE_ADD);
-		mono_mb_emit_stloc (mb, 1); 
-
-		emit_struct_conv (mb, klass, TRUE);
-		
-		/* restore the old src pointer */
-		mono_mb_emit_ldloc (mb, src_var);
-		mono_mb_emit_stloc (mb, 0);
-		/* restore the old dst pointer */
-		mono_mb_emit_ldloc (mb, dst_var);
-		mono_mb_emit_stloc (mb, 1);
-		break;
-	}
-	case MONO_MARSHAL_CONV_DEL_FTN: {
-		MonoClass *klass = mono_class_from_mono_type (type);
-
-		mono_mb_emit_ldloc (mb, 1);
-		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-		mono_mb_emit_op (mb, CEE_MONO_CLASSCONST, klass);
-		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_icall (mb, mono_ftnptr_to_delegate);
-		mono_mb_emit_byte (mb, CEE_STIND_REF);
-		break;
-	}
-	case MONO_MARSHAL_CONV_ARRAY_LPARRAY:
-		g_error ("Structure field of type %s can't be marshalled as LPArray", mono_class_from_mono_type (type)->name);
-		break;
-
-#ifndef DISABLE_COM
-	case MONO_MARSHAL_CONV_OBJECT_INTERFACE:
-	case MONO_MARSHAL_CONV_OBJECT_IUNKNOWN:
-	case MONO_MARSHAL_CONV_OBJECT_IDISPATCH:
-		mono_cominterop_emit_ptr_to_object_conv (mb, type, conv, mspec);
-		break;
-#endif /* DISABLE_COM */
-
-	case MONO_MARSHAL_CONV_SAFEHANDLE: {
-		/*
-		 * Passing SafeHandles as ref does not allow the unmanaged code
-		 * to change the SafeHandle value.   If the value is changed,
-		 * we should issue a diagnostic exception (NotSupportedException)
-		 * that informs the user that changes to handles in unmanaged code
-		 * is not supported. 
-		 *
-		 * Since we currently have no access to the original
-		 * SafeHandle that was used during the marshalling,
-		 * for now we just ignore this, and ignore/discard any
-		 * changes that might have happened to the handle.
-		 */
-		break;
-	}
-		
-	case MONO_MARSHAL_CONV_HANDLEREF: {
-		/*
-		 * Passing HandleRefs in a struct that is ref()ed does not 
-		 * copy the values back to the HandleRef
-		 */
-		break;
-	}
-		
-	case MONO_MARSHAL_CONV_STR_BSTR:
-	case MONO_MARSHAL_CONV_STR_ANSIBSTR:
-	case MONO_MARSHAL_CONV_STR_TBSTR:
-	case MONO_MARSHAL_CONV_ARRAY_SAVEARRAY:
-	default: {
-		char *msg = g_strdup_printf ("marshaling conversion %d not implemented", conv);
-
-		mono_mb_emit_exception_marshal_directive (mb, msg);
-		break;
-	}
-	}
-}
-
-static gpointer
-conv_to_icall (MonoMarshalConv conv, int *ind_store_type)
-{
-	int dummy;
-	if (!ind_store_type)
-		ind_store_type = &dummy;
-	*ind_store_type = CEE_STIND_I;
-	switch (conv) {
-	case MONO_MARSHAL_CONV_STR_LPWSTR:
-		return mono_marshal_string_to_utf16;		
-	case MONO_MARSHAL_CONV_LPWSTR_STR:
-		*ind_store_type = CEE_STIND_REF;
-		return ves_icall_mono_string_from_utf16;
-	case MONO_MARSHAL_CONV_LPTSTR_STR:
-		*ind_store_type = CEE_STIND_REF;
-		return ves_icall_string_new_wrapper;
-	case MONO_MARSHAL_CONV_UTF8STR_STR:
-	case MONO_MARSHAL_CONV_LPSTR_STR:
-		*ind_store_type = CEE_STIND_REF;
-		return ves_icall_string_new_wrapper;
-	case MONO_MARSHAL_CONV_STR_LPTSTR:
-#ifdef TARGET_WIN32
-		return mono_marshal_string_to_utf16;
-#else
-		return mono_string_to_utf8str;
-#endif
-		// In Mono historically LPSTR was treated as a UTF8STR
-	case MONO_MARSHAL_CONV_STR_UTF8STR:
-	case MONO_MARSHAL_CONV_STR_LPSTR:
-		return mono_string_to_utf8str;
-	case MONO_MARSHAL_CONV_STR_BSTR:
-		return mono_string_to_bstr;
-	case MONO_MARSHAL_CONV_BSTR_STR:
-		*ind_store_type = CEE_STIND_REF;
-		return mono_string_from_bstr_icall;
-	case MONO_MARSHAL_CONV_STR_TBSTR:
-	case MONO_MARSHAL_CONV_STR_ANSIBSTR:
-		return mono_string_to_ansibstr;
-	case MONO_MARSHAL_CONV_SB_UTF8STR:
-	case MONO_MARSHAL_CONV_SB_LPSTR:
-		return mono_string_builder_to_utf8;
-	case MONO_MARSHAL_CONV_SB_LPTSTR:
-#ifdef TARGET_WIN32
-		return mono_string_builder_to_utf16;
-#else
-		return mono_string_builder_to_utf8;
-#endif
-	case MONO_MARSHAL_CONV_SB_LPWSTR:
-		return mono_string_builder_to_utf16;
-	case MONO_MARSHAL_CONV_ARRAY_SAVEARRAY:
-		return mono_array_to_savearray;
-	case MONO_MARSHAL_CONV_ARRAY_LPARRAY:
-		return mono_array_to_lparray;
-	case MONO_MARSHAL_FREE_LPARRAY:
-		return mono_free_lparray;
-	case MONO_MARSHAL_CONV_DEL_FTN:
-		return mono_delegate_to_ftnptr;
-	case MONO_MARSHAL_CONV_FTN_DEL:
-		*ind_store_type = CEE_STIND_REF;
-		return mono_ftnptr_to_delegate;
-	case MONO_MARSHAL_CONV_UTF8STR_SB:
-	case MONO_MARSHAL_CONV_LPSTR_SB:
-		*ind_store_type = CEE_STIND_REF;
-		return mono_string_utf8_to_builder;
-	case MONO_MARSHAL_CONV_LPTSTR_SB:
-		*ind_store_type = CEE_STIND_REF;
-#ifdef TARGET_WIN32
-		return mono_string_utf16_to_builder;
-#else
-		return mono_string_utf8_to_builder;
-#endif
-	case MONO_MARSHAL_CONV_LPWSTR_SB:
-		*ind_store_type = CEE_STIND_REF;
-		return mono_string_utf16_to_builder;
-	case MONO_MARSHAL_FREE_ARRAY:
-		return mono_marshal_free_array;
-	case MONO_MARSHAL_CONV_STR_BYVALSTR:
-		return mono_string_to_byvalstr;
-	case MONO_MARSHAL_CONV_STR_BYVALWSTR:
-		return mono_string_to_byvalwstr;
-	default:
-		g_assert_not_reached ();
-	}
-
-	return NULL;
-}
-
-static void
-emit_object_to_ptr_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv conv, MonoMarshalSpec *mspec)
-{
-	int pos;
-	int stind_op;
-
-	switch (conv) {
-	case MONO_MARSHAL_CONV_BOOL_I4:
-		mono_mb_emit_ldloc (mb, 1);
-		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_byte (mb, CEE_LDIND_U1);
-		mono_mb_emit_byte (mb, CEE_STIND_I4);
-		break;
-	case MONO_MARSHAL_CONV_BOOL_VARIANTBOOL:
-		mono_mb_emit_ldloc (mb, 1);
-		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_byte (mb, CEE_LDIND_U1);
-		mono_mb_emit_byte (mb, CEE_NEG);
-		mono_mb_emit_byte (mb, CEE_STIND_I2);
-		break;
-	// In Mono historically LPSTR was treated as a UTF8STR
-	case MONO_MARSHAL_CONV_STR_UTF8STR:
-	case MONO_MARSHAL_CONV_STR_LPWSTR:
-	case MONO_MARSHAL_CONV_STR_LPSTR:
-	case MONO_MARSHAL_CONV_STR_LPTSTR:
-	case MONO_MARSHAL_CONV_STR_BSTR:
-	case MONO_MARSHAL_CONV_STR_ANSIBSTR:
-	case MONO_MARSHAL_CONV_STR_TBSTR: {
-		int pos;
-
-		/* free space if free == true */
-		mono_mb_emit_ldloc (mb, 2);
-		pos = mono_mb_emit_short_branch (mb, CEE_BRFALSE_S);
-		mono_mb_emit_ldloc (mb, 1);
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_icall (mb, g_free);
-		mono_mb_patch_short_branch (mb, pos);
-
-		mono_mb_emit_ldloc (mb, 1);
-		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_byte (mb, CEE_LDIND_REF);
-		mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
-		mono_mb_emit_byte (mb, stind_op);
-		break;
-	}
-	case MONO_MARSHAL_CONV_ARRAY_SAVEARRAY:
-	case MONO_MARSHAL_CONV_ARRAY_LPARRAY:
-	case MONO_MARSHAL_CONV_DEL_FTN:
-		mono_mb_emit_ldloc (mb, 1);
-		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_byte (mb, CEE_LDIND_REF);
-		mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
-		mono_mb_emit_byte (mb, stind_op);
-		break;
-	case MONO_MARSHAL_CONV_STR_BYVALSTR: 
-	case MONO_MARSHAL_CONV_STR_BYVALWSTR: {
-		g_assert (mspec);
-
-		mono_mb_emit_ldloc (mb, 1); /* dst */
-		mono_mb_emit_ldloc (mb, 0);	
-		mono_mb_emit_byte (mb, CEE_LDIND_REF); /* src String */
-		mono_mb_emit_icon (mb, mspec->data.array_data.num_elem);
-		mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
-		break;
-	}
-	case MONO_MARSHAL_CONV_ARRAY_BYVALARRAY: {
-		MonoClass *eklass = NULL;
-		int esize;
-
-		if (type->type == MONO_TYPE_SZARRAY) {
-			eklass = type->data.klass;
-		} else {
-			g_assert_not_reached ();
-		}
-
-		if (eklass->valuetype)
-			esize = mono_class_native_size (eklass, NULL);
-		else
-			esize = sizeof (gpointer);
-
-		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_byte (mb, CEE_LDIND_REF);
-		pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-		if (eklass->blittable) {
-			mono_mb_emit_ldloc (mb, 1);
-			mono_mb_emit_ldloc (mb, 0);	
-			mono_mb_emit_byte (mb, CEE_LDIND_REF);	
-			mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoArray, vector));
-			mono_mb_emit_icon (mb, mspec->data.array_data.num_elem * esize);
-			mono_mb_emit_byte (mb, CEE_PREFIX1);
-			mono_mb_emit_byte (mb, CEE_CPBLK);			
-		} else {
-			int array_var, src_var, dst_var, index_var;
-			guint32 label2, label3;
-
-			array_var = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
-			src_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-			dst_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-
-			/* set array_var */
-			mono_mb_emit_ldloc (mb, 0);	
-			mono_mb_emit_byte (mb, CEE_LDIND_REF);
-			mono_mb_emit_stloc (mb, array_var);
-
-			/* save the old src pointer */
-			mono_mb_emit_ldloc (mb, 0);
-			mono_mb_emit_stloc (mb, src_var);
-			/* save the old dst pointer */
-			mono_mb_emit_ldloc (mb, 1);
-			mono_mb_emit_stloc (mb, dst_var);
-
-			/* Emit marshalling loop */
-			index_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-			mono_mb_emit_byte (mb, CEE_LDC_I4_0);
-			mono_mb_emit_stloc (mb, index_var);
-
-			/* Loop header */
-			label2 = mono_mb_get_label (mb);
-			mono_mb_emit_ldloc (mb, index_var);
-			mono_mb_emit_ldloc (mb, array_var);
-			mono_mb_emit_byte (mb, CEE_LDLEN);
-			label3 = mono_mb_emit_branch (mb, CEE_BGE);
-
-			/* Set src */
-			mono_mb_emit_ldloc (mb, array_var);
-			mono_mb_emit_ldloc (mb, index_var);
-			mono_mb_emit_op (mb, CEE_LDELEMA, eklass);
-			mono_mb_emit_stloc (mb, 0);
-
-			/* dst is already set */
-
-			/* Do the conversion */
-			emit_struct_conv (mb, eklass, FALSE);
-
-			/* Loop footer */
-			mono_mb_emit_add_to_local (mb, index_var, 1);
-
-			mono_mb_emit_branch_label (mb, CEE_BR, label2);
-
-			mono_mb_patch_branch (mb, label3);
-		
-			/* restore the old src pointer */
-			mono_mb_emit_ldloc (mb, src_var);
-			mono_mb_emit_stloc (mb, 0);
-			/* restore the old dst pointer */
-			mono_mb_emit_ldloc (mb, dst_var);
-			mono_mb_emit_stloc (mb, 1);
-		}
-
-		mono_mb_patch_branch (mb, pos);
-		break;
-	}
-	case MONO_MARSHAL_CONV_ARRAY_BYVALCHARARRAY: {
-		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_byte (mb, CEE_LDIND_REF);
-		pos = mono_mb_emit_short_branch (mb, CEE_BRFALSE_S);
-
-		mono_mb_emit_ldloc (mb, 1);
-		mono_mb_emit_ldloc (mb, 0);	
-		mono_mb_emit_byte (mb, CEE_LDIND_REF);
-		mono_mb_emit_icon (mb, mspec->data.array_data.num_elem);
-		mono_mb_emit_icall (mb, mono_array_to_byte_byvalarray);
-		mono_mb_patch_short_branch (mb, pos);
-		break;
-	}
-	case MONO_MARSHAL_CONV_OBJECT_STRUCT: {
-		int src_var, dst_var;
-
-		src_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		dst_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		
-		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
-		
-		/* save the old src pointer */
-		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_stloc (mb, src_var);
-		/* save the old dst pointer */
-		mono_mb_emit_ldloc (mb, 1);
-		mono_mb_emit_stloc (mb, dst_var);
-
-		/* src = pointer to object data */
-		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_byte (mb, CEE_LDIND_I);		
-		mono_mb_emit_icon (mb, sizeof (MonoObject));
-		mono_mb_emit_byte (mb, CEE_ADD);
-		mono_mb_emit_stloc (mb, 0); 
-
-		emit_struct_conv (mb, mono_class_from_mono_type (type), FALSE);
-		
-		/* restore the old src pointer */
-		mono_mb_emit_ldloc (mb, src_var);
-		mono_mb_emit_stloc (mb, 0);
-		/* restore the old dst pointer */
-		mono_mb_emit_ldloc (mb, dst_var);
-		mono_mb_emit_stloc (mb, 1);
-
-		mono_mb_patch_branch (mb, pos);
-		break;
-	}
-
-#ifndef DISABLE_COM
-	case MONO_MARSHAL_CONV_OBJECT_INTERFACE:
-	case MONO_MARSHAL_CONV_OBJECT_IDISPATCH:
-	case MONO_MARSHAL_CONV_OBJECT_IUNKNOWN:
-		mono_cominterop_emit_object_to_ptr_conv (mb, type, conv, mspec);
-		break;
-#endif /* DISABLE_COM */
-
-	case MONO_MARSHAL_CONV_SAFEHANDLE: {
-		int pos;
-		
-		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		pos = mono_mb_emit_branch (mb, CEE_BRTRUE);
-		mono_mb_emit_exception (mb, "ArgumentNullException", NULL);
-		mono_mb_patch_branch (mb, pos);
-		
-		/* Pull the handle field from SafeHandle */
-		mono_mb_emit_ldloc (mb, 1);
-		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoSafeHandle, handle));
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_byte (mb, CEE_STIND_I);
-		break;
-	}
-
-	case MONO_MARSHAL_CONV_HANDLEREF: {
-		mono_mb_emit_ldloc (mb, 1);
-		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoHandleRef, handle));
-		mono_mb_emit_byte (mb, CEE_ADD);
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_byte (mb, CEE_STIND_I);
-		break;
-	}
-		
-	default: {
-		g_error ("marshalling conversion %d not implemented", conv);
-	}
-	}
-}
-
-static int
-offset_of_first_nonstatic_field (MonoClass *klass)
-{
-	int i;
-	int fcount = mono_class_get_field_count (klass);
-	mono_class_setup_fields (klass);
-	for (i = 0; i < fcount; i++) {
-		if (!(klass->fields[i].type->attrs & FIELD_ATTRIBUTE_STATIC) && !mono_field_is_deleted (&klass->fields[i]))
-			return klass->fields[i].offset - sizeof (MonoObject);
-	}
-
-	return 0;
-}
-
-static gboolean
-get_fixed_buffer_attr (MonoClassField *field, MonoType **out_etype, int *out_len)
-{
-	ERROR_DECL (error);
-	MonoCustomAttrInfo *cinfo;
-	MonoCustomAttrEntry *attr;
-	int aindex;
-
-	cinfo = mono_custom_attrs_from_field_checked (field->parent, field, error);
-	if (!is_ok (error))
-		return FALSE;
-	attr = NULL;
-	if (cinfo) {
-		for (aindex = 0; aindex < cinfo->num_attrs; ++aindex) {
-			MonoClass *ctor_class = cinfo->attrs [aindex].ctor->klass;
-			if (mono_class_has_parent (ctor_class, mono_class_get_fixed_buffer_attribute_class ())) {
-				attr = &cinfo->attrs [aindex];
-				break;
-			}
-		}
-	}
-	if (attr) {
-		MonoArray *typed_args, *named_args;
-		CattrNamedArg *arginfo;
-		MonoObject *o;
-
-		mono_reflection_create_custom_attr_data_args (mono_defaults.corlib, attr->ctor, attr->data, attr->data_size, &typed_args, &named_args, &arginfo, error);
-		if (!is_ok (error))
-			return FALSE;
-		g_assert (mono_array_length (typed_args) == 2);
-
-		/* typed args */
-		o = mono_array_get (typed_args, MonoObject*, 0);
-		*out_etype = monotype_cast (o)->type;
-		o = mono_array_get (typed_args, MonoObject*, 1);
-		g_assert (o->vtable->klass == mono_defaults.int32_class);
-		*out_len = *(gint32*)mono_object_unbox (o);
-		g_free (arginfo);
-	}
-	if (cinfo && !cinfo->cached)
-		mono_custom_attrs_free (cinfo);
-	return attr != NULL;
-}
-
-static void
-emit_fixed_buf_conv (MonoMethodBuilder *mb, MonoType *type, MonoType *etype, int len, gboolean to_object, int *out_usize)
-{
-	MonoClass *klass = mono_class_from_mono_type (type);
-	MonoClass *eklass = mono_class_from_mono_type (etype);
-	int esize;
-
-	esize = mono_class_native_size (eklass, NULL);
-
-	MonoMarshalNative string_encoding = klass->unicode ? MONO_NATIVE_LPWSTR : MONO_NATIVE_LPSTR;
-	int usize = mono_class_value_size (eklass, NULL);
-	int msize = mono_class_value_size (eklass, NULL);
-
-	//printf ("FIXED: %s %d %d\n", mono_type_full_name (type), eklass->blittable, string_encoding);
-
-	if (eklass->blittable) {
-		/* copy the elements */
-		mono_mb_emit_ldloc (mb, 1);
-		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_icon (mb, len * esize);
-		mono_mb_emit_byte (mb, CEE_PREFIX1);
-		mono_mb_emit_byte (mb, CEE_CPBLK);
-	} else {
-		int index_var;
-		guint32 label2, label3;
-
-		/* Emit marshalling loop */
-		index_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		mono_mb_emit_byte (mb, CEE_LDC_I4_0);
-		mono_mb_emit_stloc (mb, index_var);
-
-		/* Loop header */
-		label2 = mono_mb_get_label (mb);
-		mono_mb_emit_ldloc (mb, index_var);
-		mono_mb_emit_icon (mb, len);
-		label3 = mono_mb_emit_branch (mb, CEE_BGE);
-
-		/* src/dst is already set */
-
-		/* Do the conversion */
-		MonoTypeEnum t = etype->type;
-		switch (t) {
-		case MONO_TYPE_I4:
-		case MONO_TYPE_U4:
-		case MONO_TYPE_I1:
-		case MONO_TYPE_U1:
-		case MONO_TYPE_BOOLEAN:
-		case MONO_TYPE_I2:
-		case MONO_TYPE_U2:
-		case MONO_TYPE_CHAR:
-		case MONO_TYPE_I8:
-		case MONO_TYPE_U8:
-		case MONO_TYPE_PTR:
-		case MONO_TYPE_R4:
-		case MONO_TYPE_R8:
-			mono_mb_emit_ldloc (mb, 1);
-			mono_mb_emit_ldloc (mb, 0);
-			if (t == MONO_TYPE_CHAR && string_encoding != MONO_NATIVE_LPWSTR) {
-				if (to_object) {
-					mono_mb_emit_byte (mb, CEE_LDIND_U1);
-					mono_mb_emit_byte (mb, CEE_STIND_I2);
-				} else {
-					mono_mb_emit_byte (mb, CEE_LDIND_U2);
-					mono_mb_emit_byte (mb, CEE_STIND_I1);
-				}
-				usize = 1;
-			} else {
-				mono_mb_emit_byte (mb, mono_type_to_ldind (etype));
-				mono_mb_emit_byte (mb, mono_type_to_stind (etype));
-			}
-			break;
-		default:
-			g_assert_not_reached ();
-			break;
-		}
-
-		if (to_object) {
-			mono_mb_emit_add_to_local (mb, 0, usize);
-			mono_mb_emit_add_to_local (mb, 1, msize);
-		} else {
-			mono_mb_emit_add_to_local (mb, 0, msize);
-			mono_mb_emit_add_to_local (mb, 1, usize);
-		}
-
-		/* Loop footer */
-		mono_mb_emit_add_to_local (mb, index_var, 1);
-
-		mono_mb_emit_branch_label (mb, CEE_BR, label2);
-
-		mono_mb_patch_branch (mb, label3);
-	}
-
-	*out_usize = usize * len;
-}
-
-static void
-emit_struct_conv_full (MonoMethodBuilder *mb, MonoClass *klass, gboolean to_object,
-						int offset_of_first_child_field, MonoMarshalNative string_encoding)
-{
-	MonoMarshalType *info;
-	int i;
-
-	if (klass->parent)
-		emit_struct_conv_full (mb, klass->parent, to_object, offset_of_first_nonstatic_field (klass), string_encoding);
-
-	info = mono_marshal_load_type_info (klass);
-
-	if (info->native_size == 0)
-		return;
-
-	if (klass->blittable) {
-		int usize = mono_class_value_size (klass, NULL);
-		g_assert (usize == info->native_size);
-		mono_mb_emit_ldloc (mb, 1);
-		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_icon (mb, usize);
-		mono_mb_emit_byte (mb, CEE_PREFIX1);
-		mono_mb_emit_byte (mb, CEE_CPBLK);
-
-		if (to_object) {
-			mono_mb_emit_add_to_local (mb, 0, usize);
-			mono_mb_emit_add_to_local (mb, 1, offset_of_first_child_field);
-		} else {
-			mono_mb_emit_add_to_local (mb, 0, offset_of_first_child_field);
-			mono_mb_emit_add_to_local (mb, 1, usize);
-		}
-		return;
-	}
-
-	if (klass != mono_class_try_get_safehandle_class ()) {
-		if (mono_class_is_auto_layout (klass)) {
-			char *msg = g_strdup_printf ("Type %s which is passed to unmanaged code must have a StructLayout attribute.",
-										 mono_type_full_name (&klass->byval_arg));
-			mono_mb_emit_exception_marshal_directive (mb, msg);
-			return;
-		}
-	}
-
-	for (i = 0; i < info->num_fields; i++) {
-		MonoMarshalNative ntype;
-		MonoMarshalConv conv;
-		MonoType *ftype = info->fields [i].field->type;
-		int msize = 0;
-		int usize = 0;
-		gboolean last_field = i < (info->num_fields -1) ? 0 : 1;
-
-		if (ftype->attrs & FIELD_ATTRIBUTE_STATIC)
-			continue;
-
-		ntype = (MonoMarshalNative)mono_type_to_unmanaged (ftype, info->fields [i].mspec, TRUE, klass->unicode, &conv);
-
-		if (last_field) {
-			msize = klass->instance_size - info->fields [i].field->offset;
-			usize = info->native_size - info->fields [i].offset;
-		} else {
-			msize = info->fields [i + 1].field->offset - info->fields [i].field->offset;
-			usize = info->fields [i + 1].offset - info->fields [i].offset;
-		}
-
-		if (klass != mono_class_try_get_safehandle_class ()){
-			/* 
-			 * FIXME: Should really check for usize==0 and msize>0, but we apply 
-			 * the layout to the managed structure as well.
-			 */
-			
-			if (mono_class_is_explicit_layout (klass) && (usize == 0)) {
-				if (MONO_TYPE_IS_REFERENCE (info->fields [i].field->type) ||
-				    ((!last_field && MONO_TYPE_IS_REFERENCE (info->fields [i + 1].field->type))))
-					g_error ("Type %s which has an [ExplicitLayout] attribute cannot have a "
-						 "reference field at the same offset as another field.",
-						 mono_type_full_name (&klass->byval_arg));
-			}
-		}
-		
-		switch (conv) {
-		case MONO_MARSHAL_CONV_NONE: {
-			int t;
-
-			//XXX a byref field!?!? that's not allowed! and worse, it might miss a WB
-			g_assert (!ftype->byref);
-			if (ftype->type == MONO_TYPE_I || ftype->type == MONO_TYPE_U) {
-				mono_mb_emit_ldloc (mb, 1);
-				mono_mb_emit_ldloc (mb, 0);
-				mono_mb_emit_byte (mb, CEE_LDIND_I);
-				mono_mb_emit_byte (mb, CEE_STIND_I);
-				break;
-			}
-
-		handle_enum:
-			t = ftype->type;
-			switch (t) {
-			case MONO_TYPE_I4:
-			case MONO_TYPE_U4:
-			case MONO_TYPE_I1:
-			case MONO_TYPE_U1:
-			case MONO_TYPE_BOOLEAN:
-			case MONO_TYPE_I2:
-			case MONO_TYPE_U2:
-			case MONO_TYPE_CHAR:
-			case MONO_TYPE_I8:
-			case MONO_TYPE_U8:
-			case MONO_TYPE_PTR:
-			case MONO_TYPE_R4:
-			case MONO_TYPE_R8:
-				mono_mb_emit_ldloc (mb, 1);
-				mono_mb_emit_ldloc (mb, 0);
-				if (t == MONO_TYPE_CHAR && ntype == MONO_NATIVE_U1 && string_encoding != MONO_NATIVE_LPWSTR) {
-					if (to_object) {
-						mono_mb_emit_byte (mb, CEE_LDIND_U1);
-						mono_mb_emit_byte (mb, CEE_STIND_I2);
-					} else {
-						mono_mb_emit_byte (mb, CEE_LDIND_U2);
-						mono_mb_emit_byte (mb, CEE_STIND_I1);
-					}
-				} else {
-					mono_mb_emit_byte (mb, mono_type_to_ldind (ftype));
-					mono_mb_emit_byte (mb, mono_type_to_stind (ftype));
-				}
-				break;
-			case MONO_TYPE_VALUETYPE: {
-				int src_var, dst_var;
-				MonoType *etype;
-				int len;
-
-				if (ftype->data.klass->enumtype) {
-					ftype = mono_class_enum_basetype (ftype->data.klass);
-					goto handle_enum;
-				}
-
-				src_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-				dst_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-	
-				/* save the old src pointer */
-				mono_mb_emit_ldloc (mb, 0);
-				mono_mb_emit_stloc (mb, src_var);
-				/* save the old dst pointer */
-				mono_mb_emit_ldloc (mb, 1);
-				mono_mb_emit_stloc (mb, dst_var);
-
-				if (get_fixed_buffer_attr (info->fields [i].field, &etype, &len)) {
-					emit_fixed_buf_conv (mb, ftype, etype, len, to_object, &usize);
-				} else {
-					emit_struct_conv (mb, ftype->data.klass, to_object);
-				}
-
-				/* restore the old src pointer */
-				mono_mb_emit_ldloc (mb, src_var);
-				mono_mb_emit_stloc (mb, 0);
-				/* restore the old dst pointer */
-				mono_mb_emit_ldloc (mb, dst_var);
-				mono_mb_emit_stloc (mb, 1);
-				break;
-			}
-			case MONO_TYPE_OBJECT: {
-#ifndef DISABLE_COM
-				if (to_object) {
-					static MonoMethod *variant_clear = NULL;
-					static MonoMethod *get_object_for_native_variant = NULL;
-
-					if (!variant_clear)
-						variant_clear = mono_class_get_method_from_name (mono_class_get_variant_class (), "Clear", 0);
-					if (!get_object_for_native_variant)
-						get_object_for_native_variant = mono_class_get_method_from_name (mono_defaults.marshal_class, "GetObjectForNativeVariant", 1);
-					mono_mb_emit_ldloc (mb, 1);
-					mono_mb_emit_ldloc (mb, 0);
-					mono_mb_emit_managed_call (mb, get_object_for_native_variant, NULL);
-					mono_mb_emit_byte (mb, CEE_STIND_REF);
-
-					mono_mb_emit_ldloc (mb, 0);
-					mono_mb_emit_managed_call (mb, variant_clear, NULL);
-				}
-				else {
-					static MonoMethod *get_native_variant_for_object = NULL;
-
-					if (!get_native_variant_for_object)
-						get_native_variant_for_object = mono_class_get_method_from_name (mono_defaults.marshal_class, "GetNativeVariantForObject", 2);
-
-					mono_mb_emit_ldloc (mb, 0);
-					mono_mb_emit_byte(mb, CEE_LDIND_REF);
-					mono_mb_emit_ldloc (mb, 1);
-					mono_mb_emit_managed_call (mb, get_native_variant_for_object, NULL);
-				}
-#else
-				char *msg = g_strdup_printf ("COM support was disabled at compilation time.");
-				mono_mb_emit_exception_marshal_directive (mb, msg);
-#endif
-				break;
-			}
-
-			default: 
-				g_warning ("marshaling type %02x not implemented", ftype->type);
-				g_assert_not_reached ();
-			}
-			break;
-		}
-		default: {
-			int src_var, dst_var;
-
-			src_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-			dst_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-
-			/* save the old src pointer */
-			mono_mb_emit_ldloc (mb, 0);
-			mono_mb_emit_stloc (mb, src_var);
-			/* save the old dst pointer */
-			mono_mb_emit_ldloc (mb, 1);
-			mono_mb_emit_stloc (mb, dst_var);
-
-			if (to_object) 
-				emit_ptr_to_object_conv (mb, ftype, conv, info->fields [i].mspec);
-			else
-				emit_object_to_ptr_conv (mb, ftype, conv, info->fields [i].mspec);
-
-			/* restore the old src pointer */
-			mono_mb_emit_ldloc (mb, src_var);
-			mono_mb_emit_stloc (mb, 0);
-			/* restore the old dst pointer */
-			mono_mb_emit_ldloc (mb, dst_var);
-			mono_mb_emit_stloc (mb, 1);
-		}
-		}
-
-		if (to_object) {
-			mono_mb_emit_add_to_local (mb, 0, usize);
-			mono_mb_emit_add_to_local (mb, 1, msize);
-		} else {
-			mono_mb_emit_add_to_local (mb, 0, msize);
-			mono_mb_emit_add_to_local (mb, 1, usize);
-		}				
-	}
-}
-
-static void
-emit_struct_conv (MonoMethodBuilder *mb, MonoClass *klass, gboolean to_object)
-{
-	emit_struct_conv_full (mb, klass, to_object, 0, (MonoMarshalNative)-1);
-}
-
-static void
-emit_struct_free (MonoMethodBuilder *mb, MonoClass *klass, int struct_var)
-{
-	/* Call DestroyStructure */
-	/* FIXME: Only do this if needed */
-	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-	mono_mb_emit_op (mb, CEE_MONO_CLASSCONST, klass);
-	mono_mb_emit_ldloc (mb, struct_var);
-	mono_mb_emit_icall (mb, mono_struct_delete_old);
-}
-
-static void
-emit_thread_interrupt_checkpoint_call (MonoMethodBuilder *mb, gpointer checkpoint_func)
-{
-	int pos_noabort, pos_noex;
-
-	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-	mono_mb_emit_byte (mb, CEE_MONO_LDPTR_INT_REQ_FLAG);
-	mono_mb_emit_byte (mb, CEE_LDIND_U4);
-	pos_noabort = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-	mono_mb_emit_byte (mb, CEE_MONO_NOT_TAKEN);
-
-	mono_mb_emit_icall (mb, checkpoint_func);
-	/* Throw the exception returned by the checkpoint function, if any */
-	mono_mb_emit_byte (mb, CEE_DUP);
-	pos_noex = mono_mb_emit_branch (mb, CEE_BRFALSE);
-	mono_mb_emit_byte (mb, CEE_THROW);
-	mono_mb_patch_branch (mb, pos_noex);
-	mono_mb_emit_byte (mb, CEE_POP);
-	
-	mono_mb_patch_branch (mb, pos_noabort);
-}
-
-static void
-emit_thread_interrupt_checkpoint (MonoMethodBuilder *mb)
-{
-	if (strstr (mb->name, "mono_thread_interruption_checkpoint"))
-		return;
-	
-	emit_thread_interrupt_checkpoint_call (mb, mono_thread_interruption_checkpoint);
-}
-
-static void
-emit_thread_force_interrupt_checkpoint (MonoMethodBuilder *mb)
-{
-	emit_thread_interrupt_checkpoint_call (mb, mono_thread_force_interruption_checkpoint_noraise);
-}
-
-void
-mono_marshal_emit_thread_interrupt_checkpoint (MonoMethodBuilder *mb)
-{
-	emit_thread_interrupt_checkpoint (mb);
-}
-
-void
-mono_marshal_emit_thread_force_interrupt_checkpoint (MonoMethodBuilder *mb)
-{
-	emit_thread_force_interrupt_checkpoint (mb);
-}
-
-#endif /* ENABLE_ILGEN */
-
 /* This is a JIT icall, it sets the pending exception and returns NULL on error. */
-static MonoAsyncResult *
+MonoAsyncResult *
 mono_delegate_begin_invoke (MonoDelegate *delegate, gpointer *params)
 {
 	ERROR_DECL (error);
@@ -2525,52 +1295,6 @@ mono_delegate_begin_invoke (MonoDelegate *delegate, gpointer *params)
 	return result;
 }
 
-#ifdef ENABLE_ILGEN
-
-int
-mono_mb_emit_save_args (MonoMethodBuilder *mb, MonoMethodSignature *sig, gboolean save_this)
-{
-	int i, params_var, tmp_var;
-
-	/* allocate local (pointer) *params[] */
-	params_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-	/* allocate local (pointer) tmp */
-	tmp_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-
-	/* alloate space on stack to store an array of pointers to the arguments */
-	mono_mb_emit_icon (mb, sizeof (gpointer) * (sig->param_count + 1));
-	mono_mb_emit_byte (mb, CEE_PREFIX1);
-	mono_mb_emit_byte (mb, CEE_LOCALLOC);
-	mono_mb_emit_stloc (mb, params_var);
-
-	/* tmp = params */
-	mono_mb_emit_ldloc (mb, params_var);
-	mono_mb_emit_stloc (mb, tmp_var);
-
-	if (save_this && sig->hasthis) {
-		mono_mb_emit_ldloc (mb, tmp_var);
-		mono_mb_emit_ldarg_addr (mb, 0);
-		mono_mb_emit_byte (mb, CEE_STIND_I);
-		/* tmp = tmp + sizeof (gpointer) */
-		if (sig->param_count)
-			mono_mb_emit_add_to_local (mb, tmp_var, sizeof (gpointer));
-
-	}
-
-	for (i = 0; i < sig->param_count; i++) {
-		mono_mb_emit_ldloc (mb, tmp_var);
-		mono_mb_emit_ldarg_addr (mb, i + sig->hasthis);
-		mono_mb_emit_byte (mb, CEE_STIND_I);
-		/* tmp = tmp + sizeof (gpointer) */
-		if (i < (sig->param_count - 1))
-			mono_mb_emit_add_to_local (mb, tmp_var, sizeof (gpointer));
-	}
-
-	return params_var;
-}
-
-#endif /* ENABLE_ILGEN */
-
 static char*
 mono_signature_to_name (MonoMethodSignature *sig, const char *prefix)
 {
@@ -2602,7 +1326,7 @@ mono_signature_to_name (MonoMethodSignature *sig, const char *prefix)
  *
  *  Return the string encoding which should be used for a given parameter.
  */
-static MonoMarshalNative
+MonoMarshalNative
 mono_marshal_get_string_encoding (MonoMethodPInvoke *piinfo, MonoMarshalSpec *spec)
 {
 	/* First try the parameter marshal info */
@@ -2635,7 +1359,7 @@ mono_marshal_get_string_encoding (MonoMethodPInvoke *piinfo, MonoMarshalSpec *sp
 	}
 }
 
-static MonoMarshalConv
+MonoMarshalConv
 mono_marshal_get_string_to_ptr_conv (MonoMethodPInvoke *piinfo, MonoMarshalSpec *spec)
 {
 	MonoMarshalNative encoding = mono_marshal_get_string_encoding (piinfo, spec);
@@ -2657,7 +1381,7 @@ mono_marshal_get_string_to_ptr_conv (MonoMethodPInvoke *piinfo, MonoMarshalSpec 
 	}
 }
 
-static MonoMarshalConv
+MonoMarshalConv
 mono_marshal_get_stringbuilder_to_ptr_conv (MonoMethodPInvoke *piinfo, MonoMarshalSpec *spec)
 {
 	MonoMarshalNative encoding = mono_marshal_get_string_encoding (piinfo, spec);
@@ -2676,7 +1400,7 @@ mono_marshal_get_stringbuilder_to_ptr_conv (MonoMethodPInvoke *piinfo, MonoMarsh
 	}
 }
 
-static MonoMarshalConv
+MonoMarshalConv
 mono_marshal_get_ptr_to_string_conv (MonoMethodPInvoke *piinfo, MonoMarshalSpec *spec, gboolean *need_free)
 {
 	MonoMarshalNative encoding = mono_marshal_get_string_encoding (piinfo, spec);
@@ -2704,7 +1428,7 @@ mono_marshal_get_ptr_to_string_conv (MonoMethodPInvoke *piinfo, MonoMarshalSpec 
 	}
 }
 
-static MonoMarshalConv
+MonoMarshalConv
 mono_marshal_get_ptr_to_stringbuilder_conv (MonoMethodPInvoke *piinfo, MonoMarshalSpec *spec, gboolean *need_free)
 {
 	MonoMarshalNative encoding = mono_marshal_get_string_encoding (piinfo, spec);
@@ -2736,7 +1460,7 @@ mono_marshal_get_ptr_to_stringbuilder_conv (MonoMethodPInvoke *piinfo, MonoMarsh
  * Return whenever a field of a native structure or an array member needs to 
  * be freed.
  */
-static gboolean
+gboolean
 mono_marshal_need_free (MonoType *t, MonoMethodPInvoke *piinfo, MonoMarshalSpec *spec)
 {
 	MonoMarshalNative encoding;
@@ -3140,6 +1864,11 @@ cache_generic_delegate_wrapper (GHashTable *cache, MonoMethod *orig_method, Mono
 	return res;
 }
 
+static void
+emit_delegate_begin_invoke_noilgen (MonoMethodBuilder *mb, MonoMethodSignature *sig)
+{
+}
+
 /**
  * mono_marshal_get_delegate_begin_invoke:
  */
@@ -3150,7 +1879,6 @@ mono_marshal_get_delegate_begin_invoke (MonoMethod *method)
 	MonoMethodBuilder *mb;
 	MonoMethod *res;
 	GHashTable *cache;
-	int params_var;
 	char *name;
 	MonoGenericContext *ctx = NULL;
 	MonoMethod *orig_method = NULL;
@@ -3194,14 +1922,7 @@ mono_marshal_get_delegate_begin_invoke (MonoMethod *method)
 		mb = mono_mb_new (get_wrapper_target_class (method->klass->image), name, MONO_WRAPPER_DELEGATE_BEGIN_INVOKE);
 	g_free (name);
 
-#ifdef ENABLE_ILGEN
-	params_var = mono_mb_emit_save_args (mb, sig, FALSE);
-
-	mono_mb_emit_ldarg (mb, 0);
-	mono_mb_emit_ldloc (mb, params_var);
-	mono_mb_emit_icall (mb, mono_delegate_begin_invoke);
-	mono_mb_emit_byte (mb, CEE_RET);
-#endif
+	get_marshal_cb ()->emit_delegate_begin_invoke (mb, sig);
 
 	if (ctx) {
 		MonoMethod *def;
@@ -3216,7 +1937,7 @@ mono_marshal_get_delegate_begin_invoke (MonoMethod *method)
 }
 
 /* This is a JIT icall, it sets the pending exception and returns NULL on error. */
-static MonoObject *
+MonoObject *
 mono_delegate_end_invoke (MonoDelegate *delegate, gpointer *params)
 {
 	ERROR_DECL (error);
@@ -3317,70 +2038,10 @@ mono_delegate_end_invoke (MonoDelegate *delegate, gpointer *params)
 	return res;
 }
 
-#ifdef ENABLE_ILGEN
-
-void
-mono_mb_emit_restore_result (MonoMethodBuilder *mb, MonoType *return_type)
+static void
+emit_delegate_end_invoke_noilgen (MonoMethodBuilder *mb, MonoMethodSignature *sig)
 {
-	MonoType *t = mono_type_get_underlying_type (return_type);
-
-	if (return_type->byref)
-		return_type = &mono_defaults.int_class->byval_arg;
-
-	switch (t->type) {
-	case MONO_TYPE_VOID:
-		g_assert_not_reached ();
-		break;
-	case MONO_TYPE_PTR:
-	case MONO_TYPE_STRING:
-	case MONO_TYPE_CLASS: 
-	case MONO_TYPE_OBJECT: 
-	case MONO_TYPE_ARRAY: 
-	case MONO_TYPE_SZARRAY: 
-		/* nothing to do */
-		break;
-	case MONO_TYPE_U1:
-	case MONO_TYPE_BOOLEAN:
-	case MONO_TYPE_I1:
-	case MONO_TYPE_U2:
-	case MONO_TYPE_CHAR:
-	case MONO_TYPE_I2:
-	case MONO_TYPE_I:
-	case MONO_TYPE_U:
-	case MONO_TYPE_I4:
-	case MONO_TYPE_U4:
-	case MONO_TYPE_U8:
-	case MONO_TYPE_I8:
-	case MONO_TYPE_R4:
-	case MONO_TYPE_R8:
-		mono_mb_emit_op (mb, CEE_UNBOX, mono_class_from_mono_type (return_type));
-		mono_mb_emit_byte (mb, mono_type_to_ldind (return_type));
-		break;
-	case MONO_TYPE_GENERICINST:
-		if (!mono_type_generic_inst_is_valuetype (t))
-			break;
-		/* fall through */
-	case MONO_TYPE_VALUETYPE: {
-		MonoClass *klass = mono_class_from_mono_type (return_type);
-		mono_mb_emit_op (mb, CEE_UNBOX, klass);
-		mono_mb_emit_op (mb, CEE_LDOBJ, klass);
-		break;
-	}
-	case MONO_TYPE_VAR:
-	case MONO_TYPE_MVAR: {
-		MonoClass *klass = mono_class_from_mono_type (return_type);
-		mono_mb_emit_op (mb, CEE_UNBOX_ANY, klass);
-		break;
-	}
-	default:
-		g_warning ("type 0x%x not handled", return_type->type);
-		g_assert_not_reached ();
-	}
-
-	mono_mb_emit_byte (mb, CEE_RET);
 }
-
-#endif /* ENABLE_ILGEN */
 
 /**
  * mono_marshal_get_delegate_end_invoke:
@@ -3392,7 +2053,6 @@ mono_marshal_get_delegate_end_invoke (MonoMethod *method)
 	MonoMethodBuilder *mb;
 	MonoMethod *res;
 	GHashTable *cache;
-	int params_var;
 	char *name;
 	MonoGenericContext *ctx = NULL;
 	MonoMethod *orig_method = NULL;
@@ -3436,19 +2096,7 @@ mono_marshal_get_delegate_end_invoke (MonoMethod *method)
 		mb = mono_mb_new (get_wrapper_target_class (method->klass->image), name, MONO_WRAPPER_DELEGATE_END_INVOKE);
 	g_free (name);
 
-#ifdef ENABLE_ILGEN
-	params_var = mono_mb_emit_save_args (mb, sig, FALSE);
-
-	mono_mb_emit_ldarg (mb, 0);
-	mono_mb_emit_ldloc (mb, params_var);
-	mono_mb_emit_icall (mb, mono_delegate_end_invoke);
-
-	if (sig->ret->type == MONO_TYPE_VOID) {
-		mono_mb_emit_byte (mb, CEE_POP);
-		mono_mb_emit_byte (mb, CEE_RET);
-	} else
-		mono_mb_emit_restore_result (mb, sig->ret);
-#endif
+	get_marshal_cb ()->emit_delegate_end_invoke (mb, sig);
 
 	if (ctx) {
 		MonoMethod *def;
@@ -3498,19 +2146,36 @@ free_signature_pointer_pair (SignaturePointerPair *pair)
 	g_free (pair);
 }
 
+static void
+mb_skip_visibility_noilgen (MonoMethodBuilder *mb)
+{
+}
+
+static void
+mb_set_dynamic_noilgen (MonoMethodBuilder *mb)
+{
+}
+
+static void
+mb_emit_exception_noilgen (MonoMethodBuilder *mb, const char *exc_nspace, const char *exc_name, const char *msg)
+{
+}
+
+static void
+emit_delegate_invoke_internal_noilgen (MonoMethodBuilder *mb, MonoMethodSignature *sig, MonoMethodSignature *invoke_sig, gboolean static_method_with_first_arg_bound, gboolean callvirt, gboolean closed_over_null, MonoMethod *method, MonoMethod *target_method, MonoClass *target_class, MonoGenericContext *ctx, MonoGenericContainer *container)
+{
+}
+
 MonoMethod *
 mono_marshal_get_delegate_invoke_internal (MonoMethod *method, gboolean callvirt, gboolean static_method_with_first_arg_bound, MonoMethod *target_method)
 {
 	MonoMethodSignature *sig, *static_sig, *invoke_sig;
-	int i;
 	MonoMethodBuilder *mb;
 	MonoMethod *res;
 	GHashTable *cache;
 	gpointer cache_key = NULL;
 	SignaturePointerPair key = { NULL, NULL };
 	SignaturePointerPair *new_key;
-	int local_i, local_len, local_delegates, local_d, local_target, local_res;
-	int pos0, pos1, pos2;
 	char *name;
 	MonoClass *target_class = NULL;
 	gboolean closed_over_null = FALSE;
@@ -3520,7 +2185,6 @@ mono_marshal_get_delegate_invoke_internal (MonoMethod *method, gboolean callvirt
 	WrapperInfo *info;
 	WrapperSubtype subtype = WRAPPER_SUBTYPE_NONE;
 	gboolean found;
-	gboolean void_ret;
 
 	g_assert (method && method->klass->parent == mono_defaults.multicastdelegate_class &&
 		  !strcmp (method->name, "Invoke"));
@@ -3638,174 +2302,9 @@ mono_marshal_get_delegate_invoke_internal (MonoMethod *method, gboolean callvirt
 		mb = mono_mb_new (get_wrapper_target_class (method->klass->image), name, MONO_WRAPPER_DELEGATE_INVOKE);
 	g_free (name);
 
-#ifdef ENABLE_ILGEN
-	void_ret = sig->ret->type == MONO_TYPE_VOID && !method->string_ctor;
+	get_marshal_cb ()->emit_delegate_invoke_internal (mb, sig, invoke_sig, static_method_with_first_arg_bound, callvirt, closed_over_null, method, target_method, target_class, ctx, container);
 
-	/* allocate local 0 (object) */
-	local_i = mono_mb_add_local (mb, &mono_defaults.int32_class->byval_arg);
-	local_len = mono_mb_add_local (mb, &mono_defaults.int32_class->byval_arg);
-	local_delegates = mono_mb_add_local (mb, &mono_defaults.array_class->byval_arg);
-	local_d = mono_mb_add_local (mb, &mono_defaults.multicastdelegate_class->byval_arg);
-	local_target = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
-
-	if (!void_ret)
-		local_res = mono_mb_add_local (mb, &mono_class_from_mono_type (sig->ret)->byval_arg);
-
-	g_assert (sig->hasthis);
-
-	/*
-	 * {type: sig->ret} res;
-	 * if (delegates == null) {
-	 *     return this.<target> ( args .. );
-	 * } else {
-	 *     int i = 0, len = this.delegates.Length;
-	 *     do {
-	 *         res = this.delegates [i].Invoke ( args .. );
-	 *     } while (++i < len);
-	 *     return res;
-	 * }
-	 */
-
-	/* this wrapper can be used in unmanaged-managed transitions */
-	emit_thread_interrupt_checkpoint (mb);
-
-	/* delegates = this.delegates */
-	mono_mb_emit_ldarg (mb, 0);
-	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoMulticastDelegate, delegates));
-	mono_mb_emit_byte (mb, CEE_LDIND_REF);
-	mono_mb_emit_stloc (mb, local_delegates);
-
-	/* if (delegates == null) */
-	mono_mb_emit_ldloc (mb, local_delegates);
-	pos2 = mono_mb_emit_branch (mb, CEE_BRTRUE);
-
-	/* return target.<target_method|method_ptr> ( args .. ); */
-
-	/* target = d.target; */
-	mono_mb_emit_ldarg (mb, 0);
-	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoDelegate, target));
-	mono_mb_emit_byte (mb, CEE_LDIND_REF);
-	mono_mb_emit_stloc (mb, local_target);
-
-	/*static methods with bound first arg can have null target and still be bound*/
-	if (!static_method_with_first_arg_bound) {
-		/* if target != null */
-		mono_mb_emit_ldloc (mb, local_target);
-		pos0 = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-		/* then call this->method_ptr nonstatic */
-		if (callvirt) {
-			// FIXME:
-			mono_mb_emit_exception_full (mb, "System", "NotImplementedException", "");
-		} else {
-			mono_mb_emit_ldloc (mb, local_target);
-			for (i = 0; i < sig->param_count; ++i)
-				mono_mb_emit_ldarg (mb, i + 1);
-			mono_mb_emit_ldarg (mb, 0);
-			mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoDelegate, extra_arg));
-			mono_mb_emit_byte (mb, CEE_LDIND_I);
-			mono_mb_emit_ldarg (mb, 0);
-			mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoDelegate, method_ptr));
-			mono_mb_emit_byte (mb, CEE_LDIND_I);
-			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-			mono_mb_emit_op (mb, CEE_MONO_CALLI_EXTRA_ARG, sig);
-			mono_mb_emit_byte (mb, CEE_RET);
-		}
-	
-		/* else [target == null] call this->method_ptr static */
-		mono_mb_patch_branch (mb, pos0);
-	}
-
-	if (callvirt) {
-		if (!closed_over_null) {
-			if (target_class->valuetype) {
-				mono_mb_emit_ldarg (mb, 1);
-				for (i = 1; i < sig->param_count; ++i)
-					mono_mb_emit_ldarg (mb, i + 1);
-				mono_mb_emit_op (mb, CEE_CALL, target_method);
-			} else {
-				mono_mb_emit_ldarg (mb, 1);
-				mono_mb_emit_op (mb, CEE_CASTCLASS, target_class);
-				for (i = 1; i < sig->param_count; ++i)
-					mono_mb_emit_ldarg (mb, i + 1);
-				mono_mb_emit_op (mb, CEE_CALLVIRT, target_method);
-			}
-		} else {
-			mono_mb_emit_byte (mb, CEE_LDNULL);
-			for (i = 0; i < sig->param_count; ++i)
-				mono_mb_emit_ldarg (mb, i + 1);
-			mono_mb_emit_op (mb, CEE_CALL, target_method);
-		}
-	} else {
-		if (static_method_with_first_arg_bound) {
-			mono_mb_emit_ldloc (mb, local_target);
-			if (!MONO_TYPE_IS_REFERENCE (invoke_sig->params[0]))
-				mono_mb_emit_op (mb, CEE_UNBOX_ANY, mono_class_from_mono_type (invoke_sig->params[0]));
-		}
-		for (i = 0; i < sig->param_count; ++i)
-			mono_mb_emit_ldarg (mb, i + 1);
-		mono_mb_emit_ldarg (mb, 0);
-		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoDelegate, extra_arg));
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_ldarg (mb, 0);
-		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoDelegate, method_ptr));
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-		mono_mb_emit_op (mb, CEE_MONO_CALLI_EXTRA_ARG, invoke_sig);
-	}
-
-	mono_mb_emit_byte (mb, CEE_RET);
-
-	/* else [delegates != null] */
-	mono_mb_patch_branch (mb, pos2);
-
-	/* len = delegates.Length; */
-	mono_mb_emit_ldloc (mb, local_delegates);
-	mono_mb_emit_byte (mb, CEE_LDLEN);
-	mono_mb_emit_byte (mb, CEE_CONV_I4);
-	mono_mb_emit_stloc (mb, local_len);
-
-	/* i = 0; */
-	mono_mb_emit_icon (mb, 0);
-	mono_mb_emit_stloc (mb, local_i);
-
-	pos1 = mono_mb_get_label (mb);
-
-	/* d = delegates [i]; */
-	mono_mb_emit_ldloc (mb, local_delegates);
-	mono_mb_emit_ldloc (mb, local_i);
-	mono_mb_emit_byte (mb, CEE_LDELEM_REF);
-	mono_mb_emit_stloc (mb, local_d);
-
-	/* res = d.Invoke ( args .. ); */
-	mono_mb_emit_ldloc (mb, local_d);
-	for (i = 0; i < sig->param_count; i++)
-		mono_mb_emit_ldarg (mb, i + 1);
-	if (!ctx) {
-		mono_mb_emit_op (mb, CEE_CALLVIRT, method);
-	} else {
-		ERROR_DECL (error);
-		mono_mb_emit_op (mb, CEE_CALLVIRT, mono_class_inflate_generic_method_checked (method, &container->context, error));
-		g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
-	}
-	if (!void_ret)
-		mono_mb_emit_stloc (mb, local_res);
-
-	/* i += 1 */
-	mono_mb_emit_add_to_local (mb, local_i, 1);
-
-	/* i < l */
-	mono_mb_emit_ldloc (mb, local_i);
-	mono_mb_emit_ldloc (mb, local_len);
-	mono_mb_emit_branch_label (mb, CEE_BLT, pos1);
-
-	/* return res */
-	if (!void_ret)
-		mono_mb_emit_ldloc (mb, local_res);
-	mono_mb_emit_byte (mb, CEE_RET);
-
-	mb->skip_visibility = 1;
-#endif /* ENABLE_ILGEN */
+	get_marshal_cb ()->mb_skip_visibility (mb);
 
 	info = mono_wrapper_info_create (mb, subtype);
 	info->d.delegate_invoke.method = method;
@@ -4000,291 +2499,6 @@ runtime_invoke_signature_equal (MonoMethodSignature *sig1, MonoMethodSignature *
 		return mono_metadata_signature_equal (sig1, sig2);
 }
 
-#ifdef ENABLE_ILGEN
-
-/*
- * emit_invoke_call:
- *
- *   Emit the call to the wrapper method from a runtime invoke wrapper.
- */
-static void
-emit_invoke_call (MonoMethodBuilder *mb, MonoMethod *method,
-				  MonoMethodSignature *sig, MonoMethodSignature *callsig,
-				  int loc_res,
-				  gboolean virtual_, gboolean need_direct_wrapper)
-{
-	static MonoString *string_dummy = NULL;
-	int i;
-	int *tmp_nullable_locals;
-	gboolean void_ret = FALSE;
-	gboolean string_ctor = method && method->string_ctor;
-
-	/* to make it work with our special string constructors */
-	if (!string_dummy) {
-		ERROR_DECL (error);
-		MONO_GC_REGISTER_ROOT_SINGLE (string_dummy, MONO_ROOT_SOURCE_MARSHAL, NULL, "Marshal Dummy String");
-		string_dummy = mono_string_new_checked (mono_get_root_domain (), "dummy", error);
-		mono_error_assert_ok (error);
-	}
-
-	if (virtual_) {
-		g_assert (sig->hasthis);
-		g_assert (method->flags & METHOD_ATTRIBUTE_VIRTUAL);
-	}
-
-	if (sig->hasthis) {
-		if (string_ctor) {
-			if (mono_gc_is_moving ()) {
-				mono_mb_emit_ptr (mb, &string_dummy);
-				mono_mb_emit_byte (mb, CEE_LDIND_REF);
-			} else {
-				mono_mb_emit_ptr (mb, string_dummy);
-			}
-		} else {
-			mono_mb_emit_ldarg (mb, 0);
-		}
-	}
-
-	tmp_nullable_locals = g_new0 (int, sig->param_count);
-
-	for (i = 0; i < sig->param_count; i++) {
-		MonoType *t = sig->params [i];
-		int type;
-
-		mono_mb_emit_ldarg (mb, 1);
-		if (i) {
-			mono_mb_emit_icon (mb, sizeof (gpointer) * i);
-			mono_mb_emit_byte (mb, CEE_ADD);
-		}
-
-		if (t->byref) {
-			mono_mb_emit_byte (mb, CEE_LDIND_I);
-			/* A Nullable<T> type don't have a boxed form, it's either null or a boxed T.
-			 * So to make this work we unbox it to a local variablee and push a reference to that.
-			 */
-			if (t->type == MONO_TYPE_GENERICINST && mono_class_is_nullable (mono_class_from_mono_type (t))) {
-				tmp_nullable_locals [i] = mono_mb_add_local (mb, &mono_class_from_mono_type (t)->byval_arg);
-
-				mono_mb_emit_op (mb, CEE_UNBOX_ANY, mono_class_from_mono_type (t));
-				mono_mb_emit_stloc (mb, tmp_nullable_locals [i]);
-				mono_mb_emit_ldloc_addr (mb, tmp_nullable_locals [i]);
-			}
-			continue;
-		}
-
-		/*FIXME 'this doesn't handle generic enums. Shouldn't we?*/
-		type = sig->params [i]->type;
-handle_enum:
-		switch (type) {
-		case MONO_TYPE_I1:
-		case MONO_TYPE_BOOLEAN:
-		case MONO_TYPE_U1:
-		case MONO_TYPE_I2:
-		case MONO_TYPE_U2:
-		case MONO_TYPE_CHAR:
-		case MONO_TYPE_I:
-		case MONO_TYPE_U:
-		case MONO_TYPE_I4:
-		case MONO_TYPE_U4:
-		case MONO_TYPE_R4:
-		case MONO_TYPE_R8:
-		case MONO_TYPE_I8:
-		case MONO_TYPE_U8:
-			mono_mb_emit_byte (mb, CEE_LDIND_I);
-			mono_mb_emit_byte (mb, mono_type_to_ldind (sig->params [i]));
-			break;
-		case MONO_TYPE_STRING:
-		case MONO_TYPE_CLASS:  
-		case MONO_TYPE_ARRAY:
-		case MONO_TYPE_PTR:
-		case MONO_TYPE_SZARRAY:
-		case MONO_TYPE_OBJECT:
-			mono_mb_emit_byte (mb, mono_type_to_ldind (sig->params [i]));
-			break;
-		case MONO_TYPE_GENERICINST:
-			if (!mono_type_generic_inst_is_valuetype (sig->params [i])) {
-				mono_mb_emit_byte (mb, mono_type_to_ldind (sig->params [i]));
-				break;
-			}
-
-			/* fall through */
-		case MONO_TYPE_VALUETYPE:
-			if (type == MONO_TYPE_VALUETYPE && t->data.klass->enumtype) {
-				type = mono_class_enum_basetype (t->data.klass)->type;
-				goto handle_enum;
-			}
-			mono_mb_emit_byte (mb, CEE_LDIND_I);
-			if (mono_class_is_nullable (mono_class_from_mono_type (sig->params [i]))) {
-				/* Need to convert a boxed vtype to an mp to a Nullable struct */
-				mono_mb_emit_op (mb, CEE_UNBOX, mono_class_from_mono_type (sig->params [i]));
-				mono_mb_emit_op (mb, CEE_LDOBJ, mono_class_from_mono_type (sig->params [i]));
-			} else {
-				mono_mb_emit_op (mb, CEE_LDOBJ, mono_class_from_mono_type (sig->params [i]));
-			}
-			break;
-		default:
-			g_assert_not_reached ();
-		}
-	}
-	
-	if (virtual_) {
-		mono_mb_emit_op (mb, CEE_CALLVIRT, method);
-	} else if (need_direct_wrapper) {
-		mono_mb_emit_op (mb, CEE_CALL, method);
-	} else {
-		mono_mb_emit_ldarg (mb, 3);
-		mono_mb_emit_calli (mb, callsig);
-	}
-
-	if (sig->ret->byref) {
-		/* fixme: */
-		g_assert_not_reached ();
-	}
-
-	switch (sig->ret->type) {
-	case MONO_TYPE_VOID:
-		if (!string_ctor)
-			void_ret = TRUE;
-		break;
-	case MONO_TYPE_BOOLEAN:
-	case MONO_TYPE_CHAR:
-	case MONO_TYPE_I1:
-	case MONO_TYPE_U1:
-	case MONO_TYPE_I2:
-	case MONO_TYPE_U2:
-	case MONO_TYPE_I4:
-	case MONO_TYPE_U4:
-	case MONO_TYPE_I:
-	case MONO_TYPE_U:
-	case MONO_TYPE_R4:
-	case MONO_TYPE_R8:
-	case MONO_TYPE_I8:
-	case MONO_TYPE_U8:
-	case MONO_TYPE_VALUETYPE:
-	case MONO_TYPE_TYPEDBYREF:
-	case MONO_TYPE_GENERICINST:
-		/* box value types */
-		mono_mb_emit_op (mb, CEE_BOX, mono_class_from_mono_type (sig->ret));
-		break;
-	case MONO_TYPE_STRING:
-	case MONO_TYPE_CLASS:  
-	case MONO_TYPE_ARRAY:
-	case MONO_TYPE_SZARRAY:
-	case MONO_TYPE_OBJECT:
-		/* nothing to do */
-		break;
-	case MONO_TYPE_PTR:
-		/* The result is an IntPtr */
-		mono_mb_emit_op (mb, CEE_BOX, mono_defaults.int_class);
-		break;
-	default:
-		g_assert_not_reached ();
-	}
-
-	if (!void_ret)
-		mono_mb_emit_stloc (mb, loc_res);
-
-	/* Convert back nullable-byref arguments */
-	for (i = 0; i < sig->param_count; i++) {
-		MonoType *t = sig->params [i];
-
-		/* 
-		 * Box the result and put it back into the array, the caller will have
-		 * to obtain it from there.
-		 */
-		if (t->byref && t->type == MONO_TYPE_GENERICINST && mono_class_is_nullable (mono_class_from_mono_type (t))) {
-			mono_mb_emit_ldarg (mb, 1);			
-			mono_mb_emit_icon (mb, sizeof (gpointer) * i);
-			mono_mb_emit_byte (mb, CEE_ADD);
-
-			mono_mb_emit_ldloc (mb, tmp_nullable_locals [i]);
-			mono_mb_emit_op (mb, CEE_BOX, mono_class_from_mono_type (t));
-
-			mono_mb_emit_byte (mb, CEE_STIND_REF);
-		}
-	}
-
-	g_free (tmp_nullable_locals);
-}
-
-static void
-emit_runtime_invoke_body (MonoMethodBuilder *mb, MonoImage *image, MonoMethod *method,
-						  MonoMethodSignature *sig, MonoMethodSignature *callsig,
-						  gboolean virtual_, gboolean need_direct_wrapper)
-{
-	gint32 labels [16];
-	MonoExceptionClause *clause;
-	int loc_res, loc_exc;
-
-	/* The wrapper looks like this:
-	 *
-	 * <interrupt check>
-	 * if (exc) {
-	 *	 try {
-	 *	   return <call>
-	 *	 } catch (Exception e) {
-	 *     *exc = e;
-	 *   }
-	 * } else {
-	 *     return <call>
-	 * }
-	 */
-
-	/* allocate local 0 (object) tmp */
-	loc_res = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
-	/* allocate local 1 (object) exc */
-	loc_exc = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
-
-	/* *exc is assumed to be initialized to NULL by the caller */
-
-	mono_mb_emit_byte (mb, CEE_LDARG_2);
-	labels [0] = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-	/*
-	 * if (exc) case
-	 */
-	labels [1] = mono_mb_get_label (mb);
-	emit_thread_force_interrupt_checkpoint (mb);
-	emit_invoke_call (mb, method, sig, callsig, loc_res, virtual_, need_direct_wrapper);
-
-	labels [2] = mono_mb_emit_branch (mb, CEE_LEAVE);
-
-	/* Add a try clause around the call */
-	clause = (MonoExceptionClause *)mono_image_alloc0 (image, sizeof (MonoExceptionClause));
-	clause->flags = MONO_EXCEPTION_CLAUSE_NONE;
-	clause->data.catch_class = mono_defaults.exception_class;
-	clause->try_offset = labels [1];
-	clause->try_len = mono_mb_get_label (mb) - labels [1];
-
-	clause->handler_offset = mono_mb_get_label (mb);
-
-	/* handler code */
-	mono_mb_emit_stloc (mb, loc_exc);	
-	mono_mb_emit_byte (mb, CEE_LDARG_2);
-	mono_mb_emit_ldloc (mb, loc_exc);
-	mono_mb_emit_byte (mb, CEE_STIND_REF);
-
-	mono_mb_emit_branch (mb, CEE_LEAVE);
-
-	clause->handler_len = mono_mb_get_pos (mb) - clause->handler_offset;
-
-	mono_mb_set_clauses (mb, 1, clause);
-
-	mono_mb_patch_branch (mb, labels [2]);
-	mono_mb_emit_ldloc (mb, loc_res);
-	mono_mb_emit_byte (mb, CEE_RET);
-
-	/*
-	 * if (!exc) case
-	 */
-	mono_mb_patch_branch (mb, labels [0]);
-	emit_thread_force_interrupt_checkpoint (mb);
-	emit_invoke_call (mb, method, sig, callsig, loc_res, virtual_, need_direct_wrapper);
-
-	mono_mb_emit_ldloc (mb, 0);
-	mono_mb_emit_byte (mb, CEE_RET);
-}
-#endif
 
 /**
  * mono_marshal_get_runtime_invoke:
@@ -4413,20 +2627,15 @@ mono_marshal_get_runtime_invoke_full (MonoMethod *method, gboolean virtual_, gbo
 	mb = mono_mb_new (target_klass, name,  MONO_WRAPPER_RUNTIME_INVOKE);
 	g_free (name);
 
-#ifdef ENABLE_ILGEN
 	param_names [0] = "this";
 	param_names [1] = "params";
 	param_names [2] = "exc";
 	param_names [3] = "method";
-	mono_mb_set_param_names (mb, param_names);
 
-	emit_runtime_invoke_body (mb, target_klass->image, method, sig, callsig, virtual_, need_direct_wrapper);
-#endif
+	get_marshal_cb ()->emit_runtime_invoke_body (mb, param_names, target_klass->image, method, sig, callsig, virtual_, need_direct_wrapper);
 
 	if (need_direct_wrapper) {
-#ifdef ENABLE_ILGEN
-		mb->skip_visibility = 1;
-#endif
+		get_marshal_cb ()->mb_skip_visibility (mb);
 		info = mono_wrapper_info_create (mb, virtual_ ? WRAPPER_SUBTYPE_RUNTIME_INVOKE_VIRTUAL : WRAPPER_SUBTYPE_RUNTIME_INVOKE_DIRECT);
 		info->d.runtime_invoke.method = method;
 		res = mono_mb_create_and_cache_full (cache, method, mb, csig, sig->param_count + 16, info, NULL);
@@ -4496,6 +2705,18 @@ mono_marshal_get_runtime_invoke (MonoMethod *method, gboolean virtual_)
 	return mono_marshal_get_runtime_invoke_full (method, virtual_, need_direct_wrapper);
 }
 
+static void
+emit_runtime_invoke_body_noilgen (MonoMethodBuilder *mb, const char **param_names, MonoImage *image, MonoMethod *method,
+						  MonoMethodSignature *sig, MonoMethodSignature *callsig,
+						  gboolean virtual_, gboolean need_direct_wrapper)
+{
+}
+
+static void
+emit_runtime_invoke_dynamic_noilgen (MonoMethodBuilder *mb)
+{
+}
+
 /*
  * mono_marshal_get_runtime_invoke_dynamic:
  *
@@ -4515,9 +2736,7 @@ mono_marshal_get_runtime_invoke_dynamic (void)
 {
 	static MonoMethod *method;
 	MonoMethodSignature *csig;
-	MonoExceptionClause *clause;
 	MonoMethodBuilder *mb;
-	int pos;
 	char *name;
 	WrapperInfo *info;
 
@@ -4536,68 +2755,7 @@ mono_marshal_get_runtime_invoke_dynamic (void)
 	mb = mono_mb_new (mono_defaults.object_class, name, MONO_WRAPPER_RUNTIME_INVOKE);
 	g_free (name);
 
-#ifdef ENABLE_ILGEN
-	/* allocate local 0 (object) tmp */
-	mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
-	/* allocate local 1 (object) exc */
-	mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
-
-	/* cond set *exc to null */
-	mono_mb_emit_byte (mb, CEE_LDARG_1);
-	mono_mb_emit_byte (mb, CEE_BRFALSE_S);
-	mono_mb_emit_byte (mb, 3);	
-	mono_mb_emit_byte (mb, CEE_LDARG_1);
-	mono_mb_emit_byte (mb, CEE_LDNULL);
-	mono_mb_emit_byte (mb, CEE_STIND_REF);
-
-	emit_thread_force_interrupt_checkpoint (mb);
-
-	mono_mb_emit_byte (mb, CEE_LDARG_0);
-	mono_mb_emit_byte (mb, CEE_LDARG_2);
-	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-	mono_mb_emit_byte (mb, CEE_MONO_DYN_CALL);
-
-	pos = mono_mb_emit_branch (mb, CEE_LEAVE);
-
-	clause = (MonoExceptionClause *)mono_image_alloc0 (mono_defaults.corlib, sizeof (MonoExceptionClause));
-	clause->flags = MONO_EXCEPTION_CLAUSE_FILTER;
-	clause->try_len = mono_mb_get_label (mb);
-
-	/* filter code */
-	clause->data.filter_offset = mono_mb_get_label (mb);
-	
-	mono_mb_emit_byte (mb, CEE_POP);
-	mono_mb_emit_byte (mb, CEE_LDARG_1);
-	mono_mb_emit_byte (mb, CEE_LDC_I4_0);
-	mono_mb_emit_byte (mb, CEE_PREFIX1);
-	mono_mb_emit_byte (mb, CEE_CGT_UN);
-	mono_mb_emit_byte (mb, CEE_PREFIX1);
-	mono_mb_emit_byte (mb, CEE_ENDFILTER);
-
-	clause->handler_offset = mono_mb_get_label (mb);
-
-	/* handler code */
-	/* store exception */
-	mono_mb_emit_stloc (mb, 1);
-	
-	mono_mb_emit_byte (mb, CEE_LDARG_1);
-	mono_mb_emit_ldloc (mb, 1);
-	mono_mb_emit_byte (mb, CEE_STIND_REF);
-
-	mono_mb_emit_byte (mb, CEE_LDNULL);
-	mono_mb_emit_stloc (mb, 0);
-
-	mono_mb_emit_branch (mb, CEE_LEAVE);
-
-	clause->handler_len = mono_mb_get_pos (mb) - clause->handler_offset;
-
-	mono_mb_set_clauses (mb, 1, clause);
-
-	/* return result */
-	mono_mb_patch_branch (mb, pos);
-	//mono_mb_emit_ldloc (mb, 0);
-	mono_mb_emit_byte (mb, CEE_RET);
-#endif /* ENABLE_ILGEN */
+	get_marshal_cb ()->emit_runtime_invoke_dynamic (mb);
 
 	info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_RUNTIME_INVOKE_DYNAMIC);
 
@@ -4671,15 +2829,12 @@ mono_marshal_get_runtime_invoke_for_sig (MonoMethodSignature *sig)
 	mb = mono_mb_new (mono_defaults.object_class, name,  MONO_WRAPPER_RUNTIME_INVOKE);
 	g_free (name);
 
-#ifdef ENABLE_ILGEN
 	param_names [0] = "this";
 	param_names [1] = "params";
 	param_names [2] = "exc";
 	param_names [3] = "method";
-	mono_mb_set_param_names (mb, param_names);
 
-	emit_runtime_invoke_body (mb, image, NULL, sig, callsig, FALSE, FALSE);
-#endif
+	get_marshal_cb ()->emit_runtime_invoke_body (mb, param_names, image, NULL, sig, callsig, FALSE, FALSE);
 
 	/* taken from mono_mb_create_and_cache */
 	mono_marshal_lock ();
@@ -4712,16 +2867,10 @@ mono_marshal_get_runtime_invoke_for_sig (MonoMethodSignature *sig)
 	return res;
 }
 
-#ifdef ENABLE_ILGEN
 static void
-mono_mb_emit_auto_layout_exception (MonoMethodBuilder *mb, MonoClass *klass)
+emit_icall_wrapper_noilgen (MonoMethodBuilder *mb, MonoMethodSignature *sig, gconstpointer func, MonoMethodSignature *csig2, gboolean check_exceptions)
 {
-	char *msg = g_strdup_printf ("The type `%s.%s' layout needs to be Sequential or Explicit",
-				     klass->name_space, klass->name);
-
-	mono_mb_emit_exception_marshal_directive (mb, msg);
 }
-#endif
 
 /**
  * mono_marshal_get_icall_wrapper:
@@ -4734,7 +2883,6 @@ mono_marshal_get_icall_wrapper (MonoMethodSignature *sig, const char *name, gcon
 	MonoMethodSignature *csig, *csig2;
 	MonoMethodBuilder *mb;
 	MonoMethod *res;
-	int i;
 	WrapperInfo *info;
 	
 	GHashTable *cache = get_cache (&mono_defaults.object_class->image->icall_wrapper_cache, mono_aligned_addr_hash, NULL);
@@ -4753,20 +2901,7 @@ mono_marshal_get_icall_wrapper (MonoMethodSignature *sig, const char *name, gcon
 	else
 		csig2 = mono_metadata_signature_dup_full (mono_defaults.corlib, sig);
 
-#ifdef ENABLE_ILGEN
-	if (sig->hasthis)
-		mono_mb_emit_byte (mb, CEE_LDARG_0);
-
-	for (i = 0; i < sig->param_count; i++)
-		mono_mb_emit_ldarg (mb, i + sig->hasthis);
-
-	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-	mono_mb_emit_op (mb, CEE_MONO_JIT_ICALL_ADDR, (gpointer)func);
-	mono_mb_emit_calli (mb, csig2);
-	if (check_exceptions)
-		emit_thread_interrupt_checkpoint (mb);
-	mono_mb_emit_byte (mb, CEE_RET);
-#endif
+	get_marshal_cb ()->emit_icall_wrapper (mb, sig, func, csig2, check_exceptions);
 
 	csig = mono_metadata_signature_dup_full (mono_defaults.corlib, sig);
 	csig->pinvoke = 0;
@@ -4782,652 +2917,40 @@ mono_marshal_get_icall_wrapper (MonoMethodSignature *sig, const char *name, gcon
 }
 
 static int
-emit_marshal_custom (EmitMarshalContext *m, int argnum, MonoType *t,
+emit_marshal_custom_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 					 MonoMarshalSpec *spec, 
 					 int conv_arg, MonoType **conv_arg_type, 
 					 MarshalAction action)
 {
-#ifndef ENABLE_ILGEN
 	if (action == MARSHAL_ACTION_CONV_IN && t->type == MONO_TYPE_VALUETYPE)
 		*conv_arg_type = &mono_defaults.int_class->byval_arg;
 	return conv_arg;
-#else
-	ERROR_DECL (error);
-	MonoType *mtype;
-	MonoClass *mklass;
-	static MonoClass *ICustomMarshaler = NULL;
-	static MonoMethod *cleanup_native, *cleanup_managed;
-	static MonoMethod *marshal_managed_to_native, *marshal_native_to_managed;
-	MonoMethod *get_instance = NULL;
-	MonoMethodBuilder *mb = m->mb;
-	char *exception_msg = NULL;
-	guint32 loc1;
-	int pos2;
-
-	if (!ICustomMarshaler) {
-		MonoClass *klass = mono_class_try_get_icustom_marshaler_class ();
-		if (!klass) {
-			exception_msg = g_strdup ("Current profile doesn't support ICustomMarshaler");
-			goto handle_exception;
-		}
-
-		cleanup_native = mono_class_get_method_from_name (klass, "CleanUpNativeData", 1);
-		g_assert (cleanup_native);
-		cleanup_managed = mono_class_get_method_from_name (klass, "CleanUpManagedData", 1);
-		g_assert (cleanup_managed);
-		marshal_managed_to_native = mono_class_get_method_from_name (klass, "MarshalManagedToNative", 1);
-		g_assert (marshal_managed_to_native);
-		marshal_native_to_managed = mono_class_get_method_from_name (klass, "MarshalNativeToManaged", 1);
-		g_assert (marshal_native_to_managed);
-
-		mono_memory_barrier ();
-		ICustomMarshaler = klass;
-	}
-
-	if (spec->data.custom_data.image)
-		mtype = mono_reflection_type_from_name_checked (spec->data.custom_data.custom_name, spec->data.custom_data.image, error);
-	else
-		mtype = mono_reflection_type_from_name_checked (spec->data.custom_data.custom_name, m->image, error);
-	g_assert (mtype != NULL);
-	mono_error_assert_ok (error);
-	mklass = mono_class_from_mono_type (mtype);
-	g_assert (mklass != NULL);
-
-	if (!mono_class_is_assignable_from (ICustomMarshaler, mklass))
-		exception_msg = g_strdup_printf ("Custom marshaler '%s' does not implement the ICustomMarshaler interface.", mklass->name);
-
-	get_instance = mono_class_get_method_from_name_flags (mklass, "GetInstance", 1, METHOD_ATTRIBUTE_STATIC);
-	if (get_instance) {
-		MonoMethodSignature *get_sig = mono_method_signature (get_instance);
-		if ((get_sig->ret->type != MONO_TYPE_CLASS) ||
-			(mono_class_from_mono_type (get_sig->ret) != ICustomMarshaler) ||
-			(get_sig->params [0]->type != MONO_TYPE_STRING))
-			get_instance = NULL;
-	}
-
-	if (!get_instance)
-		exception_msg = g_strdup_printf ("Custom marshaler '%s' does not implement a static GetInstance method that takes a single string parameter and returns an ICustomMarshaler.", mklass->name);
-
-handle_exception:
-	/* Throw exception and emit compensation code if neccesary */
-	if (exception_msg) {
-		switch (action) {
-		case MARSHAL_ACTION_CONV_IN:
-		case MARSHAL_ACTION_CONV_RESULT:
-		case MARSHAL_ACTION_MANAGED_CONV_RESULT:
-			if ((action == MARSHAL_ACTION_CONV_RESULT) || (action == MARSHAL_ACTION_MANAGED_CONV_RESULT))
-				mono_mb_emit_byte (mb, CEE_POP);
-
-			mono_mb_emit_exception_full (mb, "System", "ApplicationException", exception_msg);
-
-			break;
-		case MARSHAL_ACTION_PUSH:
-			mono_mb_emit_byte (mb, CEE_LDNULL);
-			break;
-		default:
-			break;
-		}
-		return 0;
-	}
-
-	/* FIXME: MS.NET seems to create one instance for each klass + cookie pair */
-	/* FIXME: MS.NET throws an exception if GetInstance returns null */
-
-	switch (action) {
-	case MARSHAL_ACTION_CONV_IN:
-		switch (t->type) {
-		case MONO_TYPE_CLASS:
-		case MONO_TYPE_OBJECT:
-		case MONO_TYPE_STRING:
-		case MONO_TYPE_ARRAY:
-		case MONO_TYPE_SZARRAY:
-		case MONO_TYPE_VALUETYPE:
-			break;
-
-		default:
-			g_warning ("custom marshalling of type %x is currently not supported", t->type);
-			g_assert_not_reached ();
-			break;
-		}
-
-		conv_arg = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-
-		mono_mb_emit_byte (mb, CEE_LDNULL);
-		mono_mb_emit_stloc (mb, conv_arg);
-
-		if (t->byref && (t->attrs & PARAM_ATTRIBUTE_OUT))
-			break;
-
-		/* Minic MS.NET behavior */
-		if (!t->byref && (t->attrs & PARAM_ATTRIBUTE_OUT) && !(t->attrs & PARAM_ATTRIBUTE_IN))
-			break;
-
-		/* Check for null */
-		mono_mb_emit_ldarg (mb, argnum);
-		if (t->byref)
-			mono_mb_emit_byte (mb, CEE_LDIND_I);
-		pos2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-		mono_mb_emit_ldstr (mb, g_strdup (spec->data.custom_data.cookie));
-
-		mono_mb_emit_op (mb, CEE_CALL, get_instance);
-				
-		mono_mb_emit_ldarg (mb, argnum);
-		if (t->byref)
-			mono_mb_emit_byte (mb, CEE_LDIND_REF);
-
-		if (t->type == MONO_TYPE_VALUETYPE) {
-			/*
-			 * Since we can't determine the type of the argument, we
-			 * will assume the unmanaged function takes a pointer.
-			 */
-			*conv_arg_type = &mono_defaults.int_class->byval_arg;
-
-			mono_mb_emit_op (mb, CEE_BOX, mono_class_from_mono_type (t));
-		}
-
-		mono_mb_emit_op (mb, CEE_CALLVIRT, marshal_managed_to_native);
-		mono_mb_emit_stloc (mb, conv_arg);
-
-		mono_mb_patch_branch (mb, pos2);
-		break;
-
-	case MARSHAL_ACTION_CONV_OUT:
-		/* Check for null */
-		mono_mb_emit_ldloc (mb, conv_arg);
-		pos2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-		if (t->byref) {
-			mono_mb_emit_ldarg (mb, argnum);
-
-			mono_mb_emit_ldstr (mb, g_strdup (spec->data.custom_data.cookie));
-
-			mono_mb_emit_op (mb, CEE_CALL, get_instance);
-
-			mono_mb_emit_ldloc (mb, conv_arg);
-			mono_mb_emit_op (mb, CEE_CALLVIRT, marshal_native_to_managed);
-			mono_mb_emit_byte (mb, CEE_STIND_REF);
-		} else if (t->attrs & PARAM_ATTRIBUTE_OUT) {
-			mono_mb_emit_ldstr (mb, g_strdup (spec->data.custom_data.cookie));
-
-			mono_mb_emit_op (mb, CEE_CALL, get_instance);
-
-			mono_mb_emit_ldloc (mb, conv_arg);
-			mono_mb_emit_op (mb, CEE_CALLVIRT, marshal_native_to_managed);
-
-			/* We have nowhere to store the result */
-			mono_mb_emit_byte (mb, CEE_POP);
-		}
-
-		mono_mb_emit_ldstr (mb, g_strdup (spec->data.custom_data.cookie));
-
-		mono_mb_emit_op (mb, CEE_CALL, get_instance);
-
-		mono_mb_emit_ldloc (mb, conv_arg);
-
-		mono_mb_emit_op (mb, CEE_CALLVIRT, cleanup_native);
-
-		mono_mb_patch_branch (mb, pos2);
-		break;
-
-	case MARSHAL_ACTION_PUSH:
-		if (t->byref)
-			mono_mb_emit_ldloc_addr (mb, conv_arg);
-		else
-			mono_mb_emit_ldloc (mb, conv_arg);
-		break;
-
-	case MARSHAL_ACTION_CONV_RESULT:
-		loc1 = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-			
-		mono_mb_emit_stloc (mb, 3);
-
-		mono_mb_emit_ldloc (mb, 3);
-		mono_mb_emit_stloc (mb, loc1);
-
-		/* Check for null */
-		mono_mb_emit_ldloc (mb, 3);
-		pos2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-		mono_mb_emit_ldstr (mb, g_strdup (spec->data.custom_data.cookie));
-
-		mono_mb_emit_op (mb, CEE_CALL, get_instance);
-		mono_mb_emit_byte (mb, CEE_DUP);
-
-		mono_mb_emit_ldloc (mb, 3);
-		mono_mb_emit_op (mb, CEE_CALLVIRT, marshal_native_to_managed);
-		mono_mb_emit_stloc (mb, 3);
-
-		mono_mb_emit_ldloc (mb, loc1);
-		mono_mb_emit_op (mb, CEE_CALLVIRT, cleanup_native);
-
-		mono_mb_patch_branch (mb, pos2);
-		break;
-
-	case MARSHAL_ACTION_MANAGED_CONV_IN:
-		conv_arg = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
-
-		mono_mb_emit_byte (mb, CEE_LDNULL);
-		mono_mb_emit_stloc (mb, conv_arg);
-
-		if (t->byref && t->attrs & PARAM_ATTRIBUTE_OUT)
-			break;
-
-		/* Check for null */
-		mono_mb_emit_ldarg (mb, argnum);
-		if (t->byref)
-			mono_mb_emit_byte (mb, CEE_LDIND_I);
-		pos2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-		mono_mb_emit_ldstr (mb, g_strdup (spec->data.custom_data.cookie));
-		mono_mb_emit_op (mb, CEE_CALL, get_instance);
-				
-		mono_mb_emit_ldarg (mb, argnum);
-		if (t->byref)
-			mono_mb_emit_byte (mb, CEE_LDIND_I);
-				
-		mono_mb_emit_op (mb, CEE_CALLVIRT, marshal_native_to_managed);
-		mono_mb_emit_stloc (mb, conv_arg);
-
-		mono_mb_patch_branch (mb, pos2);
-		break;
-
-	case MARSHAL_ACTION_MANAGED_CONV_RESULT:
-		g_assert (!t->byref);
-
-		loc1 = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
-			
-		mono_mb_emit_stloc (mb, 3);
-			
-		mono_mb_emit_ldloc (mb, 3);
-		mono_mb_emit_stloc (mb, loc1);
-
-		/* Check for null */
-		mono_mb_emit_ldloc (mb, 3);
-		pos2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-		mono_mb_emit_ldstr (mb, g_strdup (spec->data.custom_data.cookie));
-		mono_mb_emit_op (mb, CEE_CALL, get_instance);
-		mono_mb_emit_byte (mb, CEE_DUP);
-
-		mono_mb_emit_ldloc (mb, 3);
-		mono_mb_emit_op (mb, CEE_CALLVIRT, marshal_managed_to_native);
-		mono_mb_emit_stloc (mb, 3);
-
-		mono_mb_emit_ldloc (mb, loc1);
-		mono_mb_emit_op (mb, CEE_CALLVIRT, cleanup_managed);
-
-		mono_mb_patch_branch (mb, pos2);
-		break;
-
-	case MARSHAL_ACTION_MANAGED_CONV_OUT:
-
-		/* Check for null */
-		mono_mb_emit_ldloc (mb, conv_arg);
-		pos2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-		if (t->byref) {
-			mono_mb_emit_ldarg (mb, argnum);
-
-			mono_mb_emit_ldstr (mb, g_strdup (spec->data.custom_data.cookie));
-
-			mono_mb_emit_op (mb, CEE_CALL, get_instance);
-
-			mono_mb_emit_ldloc (mb, conv_arg);
-			mono_mb_emit_op (mb, CEE_CALLVIRT, marshal_managed_to_native);
-			mono_mb_emit_byte (mb, CEE_STIND_I);
-		}
-
-		/* Call CleanUpManagedData */
-		mono_mb_emit_ldstr (mb, g_strdup (spec->data.custom_data.cookie));
-
-		mono_mb_emit_op (mb, CEE_CALL, get_instance);
-				
-		mono_mb_emit_ldloc (mb, conv_arg);
-		mono_mb_emit_op (mb, CEE_CALLVIRT, cleanup_managed);
-
-		mono_mb_patch_branch (mb, pos2);
-		break;
-
-	default:
-		g_assert_not_reached ();
-	}
-	return conv_arg;
-#endif
-
 }
 
 static int
-emit_marshal_asany (EmitMarshalContext *m, int argnum, MonoType *t,
+emit_marshal_asany_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 					MonoMarshalSpec *spec, 
 					int conv_arg, MonoType **conv_arg_type, 
 					MarshalAction action)
 {
-#ifdef ENABLE_ILGEN
-	MonoMethodBuilder *mb = m->mb;
-
-	switch (action) {
-	case MARSHAL_ACTION_CONV_IN: {
-		MonoMarshalNative encoding = mono_marshal_get_string_encoding (m->piinfo, NULL);
-
-		g_assert (t->type == MONO_TYPE_OBJECT);
-		g_assert (!t->byref);
-
-		conv_arg = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		mono_mb_emit_ldarg (mb, argnum);
-		mono_mb_emit_icon (mb, encoding);
-		mono_mb_emit_icon (mb, t->attrs);
-		mono_mb_emit_icall (mb, mono_marshal_asany);
-		mono_mb_emit_stloc (mb, conv_arg);
-		break;
-	}
-
-	case MARSHAL_ACTION_PUSH:
-		mono_mb_emit_ldloc (mb, conv_arg);
-		break;
-
-	case MARSHAL_ACTION_CONV_OUT: {
-		MonoMarshalNative encoding = mono_marshal_get_string_encoding (m->piinfo, NULL);
-
-		mono_mb_emit_ldarg (mb, argnum);
-		mono_mb_emit_ldloc (mb, conv_arg);
-		mono_mb_emit_icon (mb, encoding);
-		mono_mb_emit_icon (mb, t->attrs);
-		mono_mb_emit_icall (mb, mono_marshal_free_asany);
-		break;
-	}
-
-	default:
-		g_assert_not_reached ();
-	}
-#endif
 	return conv_arg;
 }
 
 static int
-emit_marshal_vtype (EmitMarshalContext *m, int argnum, MonoType *t,
+emit_marshal_vtype_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 					MonoMarshalSpec *spec, 
 					int conv_arg, MonoType **conv_arg_type, 
 					MarshalAction action)
 {
-#ifdef ENABLE_ILGEN
-	MonoMethodBuilder *mb = m->mb;
-	MonoClass *klass, *date_time_class;
-	int pos = 0, pos2;
-
-	klass = mono_class_from_mono_type (t);
-
-	date_time_class = mono_class_get_date_time_class ();
-
-	switch (action) {
-	case MARSHAL_ACTION_CONV_IN:
-		if (klass == date_time_class) {
-			/* Convert it to an OLE DATE type */
-			static MonoMethod *to_oadate;
-
-			if (!to_oadate)
-				to_oadate = mono_class_get_method_from_name (date_time_class, "ToOADate", 0);
-			g_assert (to_oadate);
-
-			conv_arg = mono_mb_add_local (mb, &mono_defaults.double_class->byval_arg);
-
-			if (t->byref) {
-				mono_mb_emit_ldarg (mb, argnum);
-				pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
-			}
-
-			if (!(t->byref && !(t->attrs & PARAM_ATTRIBUTE_IN) && (t->attrs & PARAM_ATTRIBUTE_OUT))) {
-				if (!t->byref)
-					m->csig->params [argnum - m->csig->hasthis] = &mono_defaults.double_class->byval_arg;
-
-				mono_mb_emit_ldarg_addr (mb, argnum);
-				mono_mb_emit_managed_call (mb, to_oadate, NULL);
-				mono_mb_emit_stloc (mb, conv_arg);
-			}
-
-			if (t->byref)
-				mono_mb_patch_branch (mb, pos);
-			break;
-		}
-
-		if (mono_class_is_explicit_layout (klass) || klass->blittable || klass->enumtype)
-			break;
-
-		conv_arg = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-			
-		/* store the address of the source into local variable 0 */
-		if (t->byref)
-			mono_mb_emit_ldarg (mb, argnum);
-		else
-			mono_mb_emit_ldarg_addr (mb, argnum);
-		
-		mono_mb_emit_stloc (mb, 0);
-			
-		/* allocate space for the native struct and
-		 * store the address into local variable 1 (dest) */
-		mono_mb_emit_icon (mb, mono_class_native_size (klass, NULL));
-		mono_mb_emit_byte (mb, CEE_PREFIX1);
-		mono_mb_emit_byte (mb, CEE_LOCALLOC);
-		mono_mb_emit_stloc (mb, conv_arg);
-
-		if (t->byref) {
-			mono_mb_emit_ldloc (mb, 0);
-			pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
-		}
-
-		if (!(t->byref && !(t->attrs & PARAM_ATTRIBUTE_IN) && (t->attrs & PARAM_ATTRIBUTE_OUT))) {
-			/* set dst_ptr */
-			mono_mb_emit_ldloc (mb, conv_arg);
-			mono_mb_emit_stloc (mb, 1);
-
-			/* emit valuetype conversion code */
-			emit_struct_conv (mb, klass, FALSE);
-		}
-
-		if (t->byref)
-			mono_mb_patch_branch (mb, pos);
-		break;
-
-	case MARSHAL_ACTION_PUSH:
-		if (spec && spec->native == MONO_NATIVE_LPSTRUCT) {
-			/* FIXME: */
-			g_assert (!t->byref);
-
-			/* Have to change the signature since the vtype is passed byref */
-			m->csig->params [argnum - m->csig->hasthis] = &mono_defaults.int_class->byval_arg;
-
-			if (mono_class_is_explicit_layout (klass) || klass->blittable || klass->enumtype)
-				mono_mb_emit_ldarg_addr (mb, argnum);
-			else
-				mono_mb_emit_ldloc (mb, conv_arg);
-			break;
-		}
-
-		if (klass == date_time_class) {
-			if (t->byref)
-				mono_mb_emit_ldloc_addr (mb, conv_arg);
-			else
-				mono_mb_emit_ldloc (mb, conv_arg);
-			break;
-		}
-
-		if (mono_class_is_explicit_layout (klass) || klass->blittable || klass->enumtype) {
-			mono_mb_emit_ldarg (mb, argnum);
-			break;
-		}			
-		mono_mb_emit_ldloc (mb, conv_arg);
-		if (!t->byref) {
-			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-			mono_mb_emit_op (mb, CEE_MONO_LDNATIVEOBJ, klass);
-		}
-		break;
-
-	case MARSHAL_ACTION_CONV_OUT:
-		if (klass == date_time_class) {
-			/* Convert from an OLE DATE type */
-			static MonoMethod *from_oadate;
-
-			if (!t->byref)
-				break;
-
-			if (!((t->attrs & PARAM_ATTRIBUTE_IN) && !(t->attrs & PARAM_ATTRIBUTE_OUT))) {
-				if (!from_oadate)
-					from_oadate = mono_class_get_method_from_name (date_time_class, "FromOADate", 1);
-				g_assert (from_oadate);
-
-				mono_mb_emit_ldarg (mb, argnum);
-				mono_mb_emit_ldloc (mb, conv_arg);
-				mono_mb_emit_managed_call (mb, from_oadate, NULL);
-				mono_mb_emit_op (mb, CEE_STOBJ, date_time_class);
-			}
-			break;
-		}
-
-		if (mono_class_is_explicit_layout (klass) || klass->blittable || klass->enumtype)
-			break;
-
-		if (t->byref) {
-			/* dst = argument */
-			mono_mb_emit_ldarg (mb, argnum);
-			mono_mb_emit_stloc (mb, 1);
-
-			mono_mb_emit_ldloc (mb, 1);
-			pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-			if (!((t->attrs & PARAM_ATTRIBUTE_IN) && !(t->attrs & PARAM_ATTRIBUTE_OUT))) {
-				/* src = tmp_locals [i] */
-				mono_mb_emit_ldloc (mb, conv_arg);
-				mono_mb_emit_stloc (mb, 0);
-
-				/* emit valuetype conversion code */
-				emit_struct_conv (mb, klass, TRUE);
-			}
-		}
-
-		emit_struct_free (mb, klass, conv_arg);
-		
-		if (t->byref)
-			mono_mb_patch_branch (mb, pos);
-		break;
-
-	case MARSHAL_ACTION_CONV_RESULT:
-		if (mono_class_is_explicit_layout (klass) || klass->blittable) {
-			mono_mb_emit_stloc (mb, 3);
-			break;
-		}
-
-		/* load pointer to returned value type */
-		g_assert (m->vtaddr_var);
-		mono_mb_emit_ldloc (mb, m->vtaddr_var);
-		/* store the address of the source into local variable 0 */
-		mono_mb_emit_stloc (mb, 0);
-		/* set dst_ptr */
-		mono_mb_emit_ldloc_addr (mb, 3);
-		mono_mb_emit_stloc (mb, 1);
-				
-		/* emit valuetype conversion code */
-		emit_struct_conv (mb, klass, TRUE);
-		break;
-
-	case MARSHAL_ACTION_MANAGED_CONV_IN:
-		if (mono_class_is_explicit_layout (klass) || klass->blittable || klass->enumtype) {
-			conv_arg = 0;
-			break;
-		}
-
-		conv_arg = mono_mb_add_local (mb, &klass->byval_arg);
-
-		if (t->attrs & PARAM_ATTRIBUTE_OUT)
-			break;
-
-		if (t->byref) 
-			mono_mb_emit_ldarg (mb, argnum);
-		else
-			mono_mb_emit_ldarg_addr (mb, argnum);
-		mono_mb_emit_stloc (mb, 0);
-
-		if (t->byref) {
-			mono_mb_emit_ldloc (mb, 0);
-			pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
-		}			
-
-		mono_mb_emit_ldloc_addr (mb, conv_arg);
-		mono_mb_emit_stloc (mb, 1);
-
-		/* emit valuetype conversion code */
-		emit_struct_conv (mb, klass, TRUE);
-
-		if (t->byref)
-			mono_mb_patch_branch (mb, pos);
-		break;
-
-	case MARSHAL_ACTION_MANAGED_CONV_OUT:
-		if (mono_class_is_explicit_layout (klass) || klass->blittable || klass->enumtype)
-			break;
-		if (t->byref && (t->attrs & PARAM_ATTRIBUTE_IN) && !(t->attrs & PARAM_ATTRIBUTE_OUT))
-			break;
-
-		/* Check for null */
-		mono_mb_emit_ldarg (mb, argnum);
-		pos2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-		/* Set src */
-		mono_mb_emit_ldloc_addr (mb, conv_arg);
-		mono_mb_emit_stloc (mb, 0);
-
-		/* Set dest */
-		mono_mb_emit_ldarg (mb, argnum);
-		mono_mb_emit_stloc (mb, 1);
-
-		/* emit valuetype conversion code */
-		emit_struct_conv (mb, klass, FALSE);
-
-		mono_mb_patch_branch (mb, pos2);
-		break;
-
-	case MARSHAL_ACTION_MANAGED_CONV_RESULT:
-		if (mono_class_is_explicit_layout (klass) || klass->blittable || klass->enumtype) {
-			mono_mb_emit_stloc (mb, 3);
-			m->retobj_var = 0;
-			break;
-		}
-			
-		/* load pointer to returned value type */
-		g_assert (m->vtaddr_var);
-		mono_mb_emit_ldloc (mb, m->vtaddr_var);
-			
-		/* store the address of the source into local variable 0 */
-		mono_mb_emit_stloc (mb, 0);
-		/* allocate space for the native struct and
-		 * store the address into dst_ptr */
-		m->retobj_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		m->retobj_class = klass;
-		g_assert (m->retobj_var);
-		mono_mb_emit_icon (mb, mono_class_native_size (klass, NULL));
-		mono_mb_emit_byte (mb, CEE_CONV_I);
-		mono_mb_emit_icall (mb, ves_icall_marshal_alloc);
-		mono_mb_emit_stloc (mb, 1);
-		mono_mb_emit_ldloc (mb, 1);
-		mono_mb_emit_stloc (mb, m->retobj_var);
-
-		/* emit valuetype conversion code */
-		emit_struct_conv (mb, klass, FALSE);
-		break;
-
-	default:
-		g_assert_not_reached ();
-	}
-#endif
 	return conv_arg;
 }
 
 static int
-emit_marshal_string (EmitMarshalContext *m, int argnum, MonoType *t,
+emit_marshal_string_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 					 MonoMarshalSpec *spec, 
 					 int conv_arg, MonoType **conv_arg_type, 
 					 MarshalAction action)
 {
-#ifndef ENABLE_ILGEN
 	switch (action) {
 	case MARSHAL_ACTION_CONV_IN:
 		*conv_arg_type = &mono_defaults.int_class->byval_arg;
@@ -5436,1029 +2959,53 @@ emit_marshal_string (EmitMarshalContext *m, int argnum, MonoType *t,
 		*conv_arg_type = &mono_defaults.int_class->byval_arg;
 		break;
 	}
-#else
-	MonoMethodBuilder *mb = m->mb;
-	MonoMarshalNative encoding = mono_marshal_get_string_encoding (m->piinfo, spec);
-	MonoMarshalConv conv = mono_marshal_get_string_to_ptr_conv (m->piinfo, spec);
-	gboolean need_free;
-
-	switch (action) {
-	case MARSHAL_ACTION_CONV_IN:
-		*conv_arg_type = &mono_defaults.int_class->byval_arg;
-		conv_arg = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-
-		if (t->byref) {
-			if (t->attrs & PARAM_ATTRIBUTE_OUT)
-				break;
-
-			mono_mb_emit_ldarg (mb, argnum);
-			mono_mb_emit_byte (mb, CEE_LDIND_I);				
-		} else {
-			mono_mb_emit_ldarg (mb, argnum);
-		}
-
-		if (conv == MONO_MARSHAL_CONV_INVALID) {
-			char *msg = g_strdup_printf ("string marshalling conversion %d not implemented", encoding);
-			mono_mb_emit_exception_marshal_directive (mb, msg);
-		} else {
-			mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
-
-			mono_mb_emit_stloc (mb, conv_arg);
-		}
-		break;
-
-	case MARSHAL_ACTION_CONV_OUT:
-		conv = mono_marshal_get_ptr_to_string_conv (m->piinfo, spec, &need_free);
-		if (conv == MONO_MARSHAL_CONV_INVALID) {
-			char *msg = g_strdup_printf ("string marshalling conversion %d not implemented", encoding);
-			mono_mb_emit_exception_marshal_directive (mb, msg);
-			break;
-		}
-
-		if (encoding == MONO_NATIVE_VBBYREFSTR) {
-			static MonoMethod *m;
-
-			if (!m) {
-				m = mono_class_get_method_from_name_flags (mono_defaults.string_class, "get_Length", -1, 0);
-				g_assert (m);
-			}
-
-			if (!t->byref) {
-				char *msg = g_strdup_printf ("VBByRefStr marshalling requires a ref parameter.", encoding);
-				mono_mb_emit_exception_marshal_directive (mb, msg);
-				break;
-			}
-
-			/* 
-			 * Have to allocate a new string with the same length as the original, and
-			 * copy the contents of the buffer pointed to by CONV_ARG into it.
-			 */
-			g_assert (t->byref);
-			mono_mb_emit_ldarg (mb, argnum);
-			mono_mb_emit_ldloc (mb, conv_arg);
-			mono_mb_emit_ldarg (mb, argnum);
-			mono_mb_emit_byte (mb, CEE_LDIND_I);				
-			mono_mb_emit_managed_call (mb, m, NULL);
-			mono_mb_emit_icall (mb, mono_string_new_len_wrapper);
-			mono_mb_emit_byte (mb, CEE_STIND_REF);
-		} else if (t->byref && (t->attrs & PARAM_ATTRIBUTE_OUT || !(t->attrs & PARAM_ATTRIBUTE_IN))) {
-			int stind_op;
-			mono_mb_emit_ldarg (mb, argnum);
-			mono_mb_emit_ldloc (mb, conv_arg);
-			mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
-			mono_mb_emit_byte (mb, stind_op);
-			need_free = TRUE;
-		}
-
-		if (need_free) {
-			mono_mb_emit_ldloc (mb, conv_arg);
-			if (conv == MONO_MARSHAL_CONV_BSTR_STR)
-				mono_mb_emit_icall (mb, mono_free_bstr);
-			else
-				mono_mb_emit_icall (mb, mono_marshal_free);
-		}
-		break;
-
-	case MARSHAL_ACTION_PUSH:
-		if (t->byref && encoding != MONO_NATIVE_VBBYREFSTR)
-			mono_mb_emit_ldloc_addr (mb, conv_arg);
-		else
-			mono_mb_emit_ldloc (mb, conv_arg);
-		break;
-
-	case MARSHAL_ACTION_CONV_RESULT:
-		mono_mb_emit_stloc (mb, 0);
-				
-		conv = mono_marshal_get_ptr_to_string_conv (m->piinfo, spec, &need_free);
-		if (conv == MONO_MARSHAL_CONV_INVALID) {
-			char *msg = g_strdup_printf ("string marshalling conversion %d not implemented", encoding);
-			mono_mb_emit_exception_marshal_directive (mb, msg);
-			break;
-		}
-
-		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
-		mono_mb_emit_stloc (mb, 3);
-
-		/* free the string */
-		mono_mb_emit_ldloc (mb, 0);
-		if (conv == MONO_MARSHAL_CONV_BSTR_STR)
-			mono_mb_emit_icall (mb, mono_free_bstr);
-		else
-			mono_mb_emit_icall (mb, mono_marshal_free);
-		break;
-
-	case MARSHAL_ACTION_MANAGED_CONV_IN:
-		conv_arg = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
-
-		*conv_arg_type = &mono_defaults.int_class->byval_arg;
-
-		if (t->byref) {
-			if (t->attrs & PARAM_ATTRIBUTE_OUT)
-				break;
-		}
-
-		conv = mono_marshal_get_ptr_to_string_conv (m->piinfo, spec, &need_free);
-		if (conv == MONO_MARSHAL_CONV_INVALID) {
-			char *msg = g_strdup_printf ("string marshalling conversion %d not implemented", encoding);
-			mono_mb_emit_exception_marshal_directive (mb, msg);
-			break;
-		}
-
-		mono_mb_emit_ldarg (mb, argnum);
-		if (t->byref)
-			mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
-		mono_mb_emit_stloc (mb, conv_arg);
-		break;
-
-	case MARSHAL_ACTION_MANAGED_CONV_OUT:
-		if (t->byref) {
-			if (conv_arg) {
-				int stind_op;
-				mono_mb_emit_ldarg (mb, argnum);
-				mono_mb_emit_ldloc (mb, conv_arg);
-				mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
-				mono_mb_emit_byte (mb, stind_op);
-			}
-		}
-		break;
-
-	case MARSHAL_ACTION_MANAGED_CONV_RESULT:
-		if (conv_to_icall (conv, NULL) == mono_marshal_string_to_utf16)
-			/* We need to make a copy so the caller is able to free it */
-			mono_mb_emit_icall (mb, mono_marshal_string_to_utf16_copy);
-		else
-			mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
-		mono_mb_emit_stloc (mb, 3);
-		break;
-
-	default:
-		g_assert_not_reached ();
-	}
-#endif
 	return conv_arg;
 }
 
 
 static int
-emit_marshal_safehandle (EmitMarshalContext *m, int argnum, MonoType *t, 
+emit_marshal_safehandle_noilgen (EmitMarshalContext *m, int argnum, MonoType *t, 
 			 MonoMarshalSpec *spec, int conv_arg, 
 			 MonoType **conv_arg_type, MarshalAction action)
 {
-#ifndef ENABLE_ILGEN
 	if (action == MARSHAL_ACTION_CONV_IN)
 		*conv_arg_type = &mono_defaults.int_class->byval_arg;
-#else
-	MonoMethodBuilder *mb = m->mb;
-
-	switch (action){
-	case MARSHAL_ACTION_CONV_IN: {
-		MonoType *intptr_type;
-		int dar_release_slot, pos;
-
-		intptr_type = &mono_defaults.int_class->byval_arg;
-		conv_arg = mono_mb_add_local (mb, intptr_type);
-		*conv_arg_type = intptr_type;
-
-		if (!sh_dangerous_add_ref)
-			init_safe_handle ();
-
-		mono_mb_emit_ldarg (mb, argnum);
-		pos = mono_mb_emit_branch (mb, CEE_BRTRUE);
-		mono_mb_emit_exception (mb, "ArgumentNullException", NULL);
-		
-		mono_mb_patch_branch (mb, pos);
-		if (t->byref){
-			/*
-			 * My tests in show that ref SafeHandles are not really
-			 * passed as ref objects.  Instead a NULL is passed as the
-			 * value of the ref
-			 */
-			mono_mb_emit_icon (mb, 0);
-			mono_mb_emit_stloc (mb, conv_arg);
-			break;
-		} 
-
-		/* Create local to hold the ref parameter to DangerousAddRef */
-		dar_release_slot = mono_mb_add_local (mb, &mono_defaults.boolean_class->byval_arg);
-
-		/* set release = false; */
-		mono_mb_emit_icon (mb, 0);
-		mono_mb_emit_stloc (mb, dar_release_slot);
-
-		/* safehandle.DangerousAddRef (ref release) */
-		mono_mb_emit_ldarg (mb, argnum);
-		mono_mb_emit_ldloc_addr (mb, dar_release_slot);
-		mono_mb_emit_managed_call (mb, sh_dangerous_add_ref, NULL);
-
-		/* Pull the handle field from SafeHandle */
-		mono_mb_emit_ldarg (mb, argnum);
-		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoSafeHandle, handle));
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_stloc (mb, conv_arg);
-
-		break;
-	}
-
-	case MARSHAL_ACTION_PUSH:
-		if (t->byref)
-			mono_mb_emit_ldloc_addr (mb, conv_arg);
-		else 
-			mono_mb_emit_ldloc (mb, conv_arg);
-		break;
-
-	case MARSHAL_ACTION_CONV_OUT: {
-		/* The slot for the boolean is the next temporary created after conv_arg, see the CONV_IN code */
-		int dar_release_slot = conv_arg + 1;
-		int label_next;
-
-		if (!sh_dangerous_release)
-			init_safe_handle ();
-
-		if (t->byref){
-			MonoMethod *ctor;
-			
-			/*
-			 * My tests indicate that ref SafeHandles parameters are not actually
-			 * passed by ref, but instead a new Handle is created regardless of
-			 * whether a change happens in the unmanaged side.
-			 *
-			 * Also, the Handle is created before calling into unmanaged code,
-			 * but we do not support that mechanism (getting to the original
-			 * handle) and it makes no difference where we create this
-			 */
-			ctor = mono_class_get_method_from_name (t->data.klass, ".ctor", 0);
-			if (ctor == NULL){
-				mono_mb_emit_exception (mb, "MissingMethodException", "paramterless constructor required");
-				break;
-			}
-			/* refval = new SafeHandleDerived ()*/
-			mono_mb_emit_ldarg (mb, argnum);
-			mono_mb_emit_op (mb, CEE_NEWOBJ, ctor);
-			mono_mb_emit_byte (mb, CEE_STIND_REF);
-
-			/* refval.handle = returned_handle */
-			mono_mb_emit_ldarg (mb, argnum);
-			mono_mb_emit_byte (mb, CEE_LDIND_REF);
-			mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoSafeHandle, handle));
-			mono_mb_emit_ldloc (mb, conv_arg);
-			mono_mb_emit_byte (mb, CEE_STIND_I);
-		} else {
-			mono_mb_emit_ldloc (mb, dar_release_slot);
-			label_next = mono_mb_emit_branch (mb, CEE_BRFALSE);
-			mono_mb_emit_ldarg (mb, argnum);
-			mono_mb_emit_managed_call (mb, sh_dangerous_release, NULL);
-			mono_mb_patch_branch (mb, label_next);
-		}
-		break;
-	}
-		
-	case MARSHAL_ACTION_CONV_RESULT: {
-		MonoMethod *ctor = NULL;
-		int intptr_handle_slot;
-		
-		if (mono_class_is_abstract (t->data.klass)) {
-			mono_mb_emit_byte (mb, CEE_POP);
-			mono_mb_emit_exception_marshal_directive (mb, g_strdup ("Returned SafeHandles should not be abstract"));
-			break;
-		}
-
-		ctor = mono_class_get_method_from_name (t->data.klass, ".ctor", 0);
-		if (ctor == NULL){
-			mono_mb_emit_byte (mb, CEE_POP);
-			mono_mb_emit_exception (mb, "MissingMethodException", "paramterless constructor required");
-			break;
-		}
-		/* Store the IntPtr results into a local */
-		intptr_handle_slot = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		mono_mb_emit_stloc (mb, intptr_handle_slot);
-
-		/* Create return value */
-		mono_mb_emit_op (mb, CEE_NEWOBJ, ctor);
-		mono_mb_emit_stloc (mb, 3);
-
-		/* Set the return.handle to the value, am using ldflda, not sure if thats a good idea */
-		mono_mb_emit_ldloc (mb, 3);
-		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoSafeHandle, handle));
-		mono_mb_emit_ldloc (mb, intptr_handle_slot);
-		mono_mb_emit_byte (mb, CEE_STIND_I);
-		break;
-	}
-		
-	case MARSHAL_ACTION_MANAGED_CONV_IN:
-		fprintf (stderr, "mono/marshal: SafeHandles missing MANAGED_CONV_IN\n");
-		break;
-		
-	case MARSHAL_ACTION_MANAGED_CONV_OUT:
-		fprintf (stderr, "mono/marshal: SafeHandles missing MANAGED_CONV_OUT\n");
-		break;
-
-	case MARSHAL_ACTION_MANAGED_CONV_RESULT:
-		fprintf (stderr, "mono/marshal: SafeHandles missing MANAGED_CONV_RESULT\n");
-		break;
-	default:
-		printf ("Unhandled case for MarshalAction: %d\n", action);
-	}
-#endif
 	return conv_arg;
 }
 
 
 static int
-emit_marshal_handleref (EmitMarshalContext *m, int argnum, MonoType *t, 
+emit_marshal_handleref_noilgen (EmitMarshalContext *m, int argnum, MonoType *t, 
 			MonoMarshalSpec *spec, int conv_arg, 
 			MonoType **conv_arg_type, MarshalAction action)
 {
-#ifndef ENABLE_ILGEN
 	if (action == MARSHAL_ACTION_CONV_IN)
 		*conv_arg_type = &mono_defaults.int_class->byval_arg;
-#else
-	MonoMethodBuilder *mb = m->mb;
-
-	switch (action){
-	case MARSHAL_ACTION_CONV_IN: {
-		MonoType *intptr_type;
-
-		intptr_type = &mono_defaults.int_class->byval_arg;
-		conv_arg = mono_mb_add_local (mb, intptr_type);
-		*conv_arg_type = intptr_type;
-
-		if (t->byref){
-			char *msg = g_strdup ("HandleRefs can not be returned from unmanaged code (or passed by ref)");
-			mono_mb_emit_exception_marshal_directive (mb, msg);
-			break;
-		} 
-		mono_mb_emit_ldarg_addr (mb, argnum);
-		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoHandleRef, handle));
-		mono_mb_emit_byte (mb, CEE_ADD);
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_stloc (mb, conv_arg);
-		break;
-	}
-
-	case MARSHAL_ACTION_PUSH:
-		mono_mb_emit_ldloc (mb, conv_arg);
-		break;
-
-	case MARSHAL_ACTION_CONV_OUT: {
-		/* no resource release required */
-		break;
-	}
-		
-	case MARSHAL_ACTION_CONV_RESULT: {
-		char *msg = g_strdup ("HandleRefs can not be returned from unmanaged code (or passed by ref)");
-		mono_mb_emit_exception_marshal_directive (mb, msg);
-		break;
-	}
-		
-	case MARSHAL_ACTION_MANAGED_CONV_IN:
-		fprintf (stderr, "mono/marshal: SafeHandles missing MANAGED_CONV_IN\n");
-		break;
-		
-	case MARSHAL_ACTION_MANAGED_CONV_OUT:
-		fprintf (stderr, "mono/marshal: SafeHandles missing MANAGED_CONV_OUT\n");
-		break;
-
-	case MARSHAL_ACTION_MANAGED_CONV_RESULT:
-		fprintf (stderr, "mono/marshal: SafeHandles missing MANAGED_CONV_RESULT\n");
-		break;
-	default:
-		fprintf (stderr, "Unhandled case for MarshalAction: %d\n", action);
-	}
-#endif
 	return conv_arg;
 }
 
 
 static int
-emit_marshal_object (EmitMarshalContext *m, int argnum, MonoType *t,
+emit_marshal_object_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		     MonoMarshalSpec *spec, 
 		     int conv_arg, MonoType **conv_arg_type, 
 		     MarshalAction action)
 {
-#ifndef ENABLE_ILGEN
 	if (action == MARSHAL_ACTION_CONV_IN)
 		*conv_arg_type = &mono_defaults.int_class->byval_arg;
-#else
-	MonoMethodBuilder *mb = m->mb;
-	MonoClass *klass = mono_class_from_mono_type (t);
-	int pos, pos2, loc;
-
-	switch (action) {
-	case MARSHAL_ACTION_CONV_IN:
-		*conv_arg_type = &mono_defaults.int_class->byval_arg;
-		conv_arg = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-
-		m->orig_conv_args [argnum] = 0;
-
-		if (mono_class_from_mono_type (t) == mono_defaults.object_class) {
-			char *msg = g_strdup_printf ("Marshalling of type object is not implemented");
-			mono_mb_emit_exception_marshal_directive (mb, msg);
-			break;
-		}
-
-		if (klass->delegate) {
-			if (t->byref) {
-				if (!(t->attrs & PARAM_ATTRIBUTE_OUT)) {
-					char *msg = g_strdup_printf ("Byref marshalling of delegates is not implemented.");
-					mono_mb_emit_exception_marshal_directive (mb, msg);
-				}
-				mono_mb_emit_byte (mb, CEE_LDNULL);
-				mono_mb_emit_stloc (mb, conv_arg);
-			} else {
-				mono_mb_emit_ldarg (mb, argnum);
-				mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_DEL_FTN, NULL));
-				mono_mb_emit_stloc (mb, conv_arg);
-			}
-		} else if (klass == mono_defaults.stringbuilder_class) {
-			MonoMarshalNative encoding = mono_marshal_get_string_encoding (m->piinfo, spec);
-			MonoMarshalConv conv = mono_marshal_get_stringbuilder_to_ptr_conv (m->piinfo, spec);
-
-#if 0			
-			if (t->byref) {
-				if (!(t->attrs & PARAM_ATTRIBUTE_OUT)) {
-					char *msg = g_strdup_printf ("Byref marshalling of stringbuilders is not implemented.");
-					mono_mb_emit_exception_marshal_directive (mb, msg);
-				}
-				break;
-			}
-#endif
-
-			if (t->byref && !(t->attrs & PARAM_ATTRIBUTE_IN) && (t->attrs & PARAM_ATTRIBUTE_OUT))
-				break;
-
-			if (conv == MONO_MARSHAL_CONV_INVALID) {
-				char *msg = g_strdup_printf ("stringbuilder marshalling conversion %d not implemented", encoding);
-				mono_mb_emit_exception_marshal_directive (mb, msg);
-				break;
-			}
-
-			mono_mb_emit_ldarg (mb, argnum);
-			if (t->byref)
-				mono_mb_emit_byte (mb, CEE_LDIND_I);
-
-			mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
-			mono_mb_emit_stloc (mb, conv_arg);
-		} else if (klass->blittable) {
-			mono_mb_emit_byte (mb, CEE_LDNULL);
-			mono_mb_emit_stloc (mb, conv_arg);
-
-			mono_mb_emit_ldarg (mb, argnum);
-			pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-			mono_mb_emit_ldarg (mb, argnum);
-			mono_mb_emit_ldflda (mb, sizeof (MonoObject));
-			mono_mb_emit_stloc (mb, conv_arg);
-
-			mono_mb_patch_branch (mb, pos);
-			break;
-		} else {
-			mono_mb_emit_byte (mb, CEE_LDNULL);
-			mono_mb_emit_stloc (mb, conv_arg);
-
-			if (t->byref) {
-				/* we dont need any conversions for out parameters */
-				if (t->attrs & PARAM_ATTRIBUTE_OUT)
-					break;
-
-				mono_mb_emit_ldarg (mb, argnum);				
-				mono_mb_emit_byte (mb, CEE_LDIND_I);
-
-			} else {
-				mono_mb_emit_ldarg (mb, argnum);
-				mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-				mono_mb_emit_byte (mb, CEE_MONO_OBJADDR);
-			}
-				
-			/* store the address of the source into local variable 0 */
-			mono_mb_emit_stloc (mb, 0);
-			mono_mb_emit_ldloc (mb, 0);
-			pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-			/* allocate space for the native struct and store the address */
-			mono_mb_emit_icon (mb, mono_class_native_size (klass, NULL));
-			mono_mb_emit_byte (mb, CEE_PREFIX1);
-			mono_mb_emit_byte (mb, CEE_LOCALLOC);
-			mono_mb_emit_stloc (mb, conv_arg);
-
-			if (t->byref) {
-				/* Need to store the original buffer so we can free it later */
-				m->orig_conv_args [argnum] = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-				mono_mb_emit_ldloc (mb, conv_arg);
-				mono_mb_emit_stloc (mb, m->orig_conv_args [argnum]);
-			}
-
-			/* set the src_ptr */
-			mono_mb_emit_ldloc (mb, 0);
-			mono_mb_emit_ldflda (mb, sizeof (MonoObject));
-			mono_mb_emit_stloc (mb, 0);
-
-			/* set dst_ptr */
-			mono_mb_emit_ldloc (mb, conv_arg);
-			mono_mb_emit_stloc (mb, 1);
-
-			/* emit valuetype conversion code */
-			emit_struct_conv (mb, klass, FALSE);
-
-			mono_mb_patch_branch (mb, pos);
-		}
-		break;
-
-	case MARSHAL_ACTION_CONV_OUT:
-		if (klass == mono_defaults.stringbuilder_class) {
-			gboolean need_free;
-			MonoMarshalNative encoding;
-			MonoMarshalConv conv;
-
-			encoding = mono_marshal_get_string_encoding (m->piinfo, spec);
-			conv = mono_marshal_get_ptr_to_stringbuilder_conv (m->piinfo, spec, &need_free);
-
-			g_assert (encoding != -1);
-
-			if (t->byref) {
-				//g_assert (!(t->attrs & PARAM_ATTRIBUTE_OUT));
-
-				need_free = TRUE;
-
-				mono_mb_emit_ldarg (mb, argnum);
-				mono_mb_emit_ldloc (mb, conv_arg);
-
-				switch (encoding) {
-				case MONO_NATIVE_LPWSTR:
-					mono_mb_emit_icall (mb, mono_string_utf16_to_builder2);
-					break;
-				case MONO_NATIVE_LPSTR:
-					mono_mb_emit_icall (mb, mono_string_utf8_to_builder2);
-					break;
-				case MONO_NATIVE_UTF8STR:
-					mono_mb_emit_icall (mb, mono_string_utf8_to_builder2);
-					break;
-				default:
-					g_assert_not_reached ();
-				}
-
-				mono_mb_emit_byte (mb, CEE_STIND_REF);
-			} else {
-				mono_mb_emit_ldarg (mb, argnum);
-				mono_mb_emit_ldloc (mb, conv_arg);
-
-				mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
-			}
-
-			if (need_free) {
-				mono_mb_emit_ldloc (mb, conv_arg);
-				mono_mb_emit_icall (mb, mono_marshal_free);
-			}
-			break;
-		}
-
-		if (klass->delegate) {
-			if (t->byref) {
-				mono_mb_emit_ldarg (mb, argnum);
-				mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-				mono_mb_emit_op (mb, CEE_MONO_CLASSCONST, klass);
-				mono_mb_emit_ldloc (mb, conv_arg);
-				mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_FTN_DEL, NULL));
-				mono_mb_emit_byte (mb, CEE_STIND_REF);
-			}
-			break;
-		}
-
-		if (t->byref && (t->attrs & PARAM_ATTRIBUTE_OUT)) {
-			/* allocate a new object */
-			mono_mb_emit_ldarg (mb, argnum);
-			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-			mono_mb_emit_op (mb, CEE_MONO_NEWOBJ, klass);
-			mono_mb_emit_byte (mb, CEE_STIND_REF);
-		}
-
-		/* dst = *argument */
-		mono_mb_emit_ldarg (mb, argnum);
-
-		if (t->byref)
-			mono_mb_emit_byte (mb, CEE_LDIND_I);
-
-		mono_mb_emit_stloc (mb, 1);
-
-		mono_mb_emit_ldloc (mb, 1);
-		pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-		if (t->byref || (t->attrs & PARAM_ATTRIBUTE_OUT)) {
-			mono_mb_emit_ldloc (mb, 1);
-			mono_mb_emit_icon (mb, sizeof (MonoObject));
-			mono_mb_emit_byte (mb, CEE_ADD);
-			mono_mb_emit_stloc (mb, 1);
-			
-			/* src = tmp_locals [i] */
-			mono_mb_emit_ldloc (mb, conv_arg);
-			mono_mb_emit_stloc (mb, 0);
-
-			/* emit valuetype conversion code */
-			emit_struct_conv (mb, klass, TRUE);
-
-			/* Free the structure returned by the native code */
-			emit_struct_free (mb, klass, conv_arg);
-
-			if (m->orig_conv_args [argnum]) {
-				/* 
-				 * If the native function changed the pointer, then free
-				 * the original structure plus the new pointer.
-				 */
-				mono_mb_emit_ldloc (mb, m->orig_conv_args [argnum]);
-				mono_mb_emit_ldloc (mb, conv_arg);
-				pos2 = mono_mb_emit_branch (mb, CEE_BEQ);
-
-				if (!(t->attrs & PARAM_ATTRIBUTE_OUT)) {
-					g_assert (m->orig_conv_args [argnum]);
-
-					emit_struct_free (mb, klass, m->orig_conv_args [argnum]);
-				}
-
-				mono_mb_emit_ldloc (mb, conv_arg);
-				mono_mb_emit_icall (mb, mono_marshal_free);
-
-				mono_mb_patch_branch (mb, pos2);
-			}
-		}
-		else
-			/* Free the original structure passed to native code */
-			emit_struct_free (mb, klass, conv_arg);
-
-		mono_mb_patch_branch (mb, pos);
-		break;
-
-	case MARSHAL_ACTION_PUSH:
-		if (t->byref)
-			mono_mb_emit_ldloc_addr (mb, conv_arg);
-		else
-			mono_mb_emit_ldloc (mb, conv_arg);
-		break;
-
-	case MARSHAL_ACTION_CONV_RESULT:
-		if (klass->delegate) {
-			g_assert (!t->byref);
-			mono_mb_emit_stloc (mb, 0);
-			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-			mono_mb_emit_op (mb, CEE_MONO_CLASSCONST, klass);
-			mono_mb_emit_ldloc (mb, 0);
-			mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_FTN_DEL, NULL));
-			mono_mb_emit_stloc (mb, 3);
-		} else if (klass == mono_defaults.stringbuilder_class) {
-			// FIXME:
-			char *msg = g_strdup_printf ("Return marshalling of stringbuilders is not implemented.");
-			mono_mb_emit_exception_marshal_directive (mb, msg);
-		} else {
-			/* set src */
-			mono_mb_emit_stloc (mb, 0);
-	
-			/* Make a copy since emit_conv modifies local 0 */
-			loc = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-			mono_mb_emit_ldloc (mb, 0);
-			mono_mb_emit_stloc (mb, loc);
-	
-			mono_mb_emit_byte (mb, CEE_LDNULL);
-			mono_mb_emit_stloc (mb, 3);
-	
-			mono_mb_emit_ldloc (mb, 0);
-			pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
-	
-			/* allocate result object */
-	
-			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-			mono_mb_emit_op (mb, CEE_MONO_NEWOBJ, klass);	
-			mono_mb_emit_stloc (mb, 3);
-					
-			/* set dst  */
-	
-			mono_mb_emit_ldloc (mb, 3);
-			mono_mb_emit_ldflda (mb, sizeof (MonoObject));
-			mono_mb_emit_stloc (mb, 1);
-								
-			/* emit conversion code */
-			emit_struct_conv (mb, klass, TRUE);
-	
-			emit_struct_free (mb, klass, loc);
-	
-			/* Free the pointer allocated by unmanaged code */
-			mono_mb_emit_ldloc (mb, loc);
-			mono_mb_emit_icall (mb, mono_marshal_free);
-			mono_mb_patch_branch (mb, pos);
-		}
-		break;
-
-	case MARSHAL_ACTION_MANAGED_CONV_IN:
-		conv_arg = mono_mb_add_local (mb, &klass->byval_arg);
-
-		if (klass->delegate) {
-			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-			mono_mb_emit_op (mb, CEE_MONO_CLASSCONST, klass);
-			mono_mb_emit_ldarg (mb, argnum);
-			if (t->byref)
-				mono_mb_emit_byte (mb, CEE_LDIND_I);
-			mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_FTN_DEL, NULL));
-			mono_mb_emit_stloc (mb, conv_arg);
-			break;
-		}
-
-		if (klass == mono_defaults.stringbuilder_class) {
-			MonoMarshalNative encoding;
-
-			encoding = mono_marshal_get_string_encoding (m->piinfo, spec);
-
-			// FIXME:
-			g_assert (encoding == MONO_NATIVE_LPSTR || encoding == MONO_NATIVE_UTF8STR);
-
-			g_assert (!t->byref);
-			g_assert (encoding != -1);
-
-			mono_mb_emit_ldarg (mb, argnum);
-			mono_mb_emit_icall (mb, mono_string_utf8_to_builder2);
-			mono_mb_emit_stloc (mb, conv_arg);
-			break;
-		}
-
-		/* The class can not have an automatic layout */
-		if (mono_class_is_auto_layout (klass)) {
-			mono_mb_emit_auto_layout_exception (mb, klass);
-			break;
-		}
-
-		if (t->attrs & PARAM_ATTRIBUTE_OUT) {
-			mono_mb_emit_byte (mb, CEE_LDNULL);
-			mono_mb_emit_stloc (mb, conv_arg);
-			break;
-		}
-
-		/* Set src */
-		mono_mb_emit_ldarg (mb, argnum);
-		if (t->byref) {
-			int pos2;
-
-			/* Check for NULL and raise an exception */
-			pos2 = mono_mb_emit_branch (mb, CEE_BRTRUE);
-
-			mono_mb_emit_exception (mb, "ArgumentNullException", NULL);
-
-			mono_mb_patch_branch (mb, pos2);
-			mono_mb_emit_ldarg (mb, argnum);
-			mono_mb_emit_byte (mb, CEE_LDIND_I);
-		}				
-
-		mono_mb_emit_stloc (mb, 0);
-
-		mono_mb_emit_byte (mb, CEE_LDC_I4_0);
-		mono_mb_emit_stloc (mb, conv_arg);
-
-		mono_mb_emit_ldloc (mb, 0);
-		pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-		/* Create and set dst */
-		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-		mono_mb_emit_op (mb, CEE_MONO_NEWOBJ, klass);	
-		mono_mb_emit_stloc (mb, conv_arg);
-		mono_mb_emit_ldloc (mb, conv_arg);
-		mono_mb_emit_ldflda (mb, sizeof (MonoObject));
-		mono_mb_emit_stloc (mb, 1); 
-
-		/* emit valuetype conversion code */
-		emit_struct_conv (mb, klass, TRUE);
-
-		mono_mb_patch_branch (mb, pos);
-		break;
-
-	case MARSHAL_ACTION_MANAGED_CONV_OUT:
-		if (klass->delegate) {
-			if (t->byref) {
-				int stind_op;
-				mono_mb_emit_ldarg (mb, argnum);
-				mono_mb_emit_ldloc (mb, conv_arg);
-				mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_DEL_FTN, &stind_op));
-				mono_mb_emit_byte (mb, stind_op);
-				break;
-			}
-		}
-
-		if (t->byref) {
-			/* Check for null */
-			mono_mb_emit_ldloc (mb, conv_arg);
-			pos = mono_mb_emit_branch (mb, CEE_BRTRUE);
-			mono_mb_emit_ldarg (mb, argnum);
-			mono_mb_emit_byte (mb, CEE_LDC_I4_0);
-			mono_mb_emit_byte (mb, CEE_STIND_I);
-			pos2 = mono_mb_emit_branch (mb, CEE_BR);
-
-			mono_mb_patch_branch (mb, pos);			
-			
-			/* Set src */
-			mono_mb_emit_ldloc (mb, conv_arg);
-			mono_mb_emit_ldflda (mb, sizeof (MonoObject));
-			mono_mb_emit_stloc (mb, 0);
-
-			/* Allocate and set dest */
-			mono_mb_emit_icon (mb, mono_class_native_size (klass, NULL));
-			mono_mb_emit_byte (mb, CEE_CONV_I);
-			mono_mb_emit_icall (mb, ves_icall_marshal_alloc);
-			mono_mb_emit_stloc (mb, 1);
-			
-			/* Update argument pointer */
-			mono_mb_emit_ldarg (mb, argnum);
-			mono_mb_emit_ldloc (mb, 1);
-			mono_mb_emit_byte (mb, CEE_STIND_I);
-		
-			/* emit valuetype conversion code */
-			emit_struct_conv (mb, klass, FALSE);
-
-			mono_mb_patch_branch (mb, pos2);
-		} else if (klass == mono_defaults.stringbuilder_class) {
-			// FIXME: What to do here ?
-		} else {
-			/* byval [Out] marshalling */
-
-			/* FIXME: Handle null */
-
-			/* Set src */
-			mono_mb_emit_ldloc (mb, conv_arg);
-			mono_mb_emit_ldflda (mb, sizeof (MonoObject));
-			mono_mb_emit_stloc (mb, 0);
-
-			/* Set dest */
-			mono_mb_emit_ldarg (mb, argnum);
-			mono_mb_emit_stloc (mb, 1);
-			
-			/* emit valuetype conversion code */
-			emit_struct_conv (mb, klass, FALSE);
-		}			
-		break;
-
-	case MARSHAL_ACTION_MANAGED_CONV_RESULT:
-		if (klass->delegate) {
-			mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_DEL_FTN, NULL));
-			mono_mb_emit_stloc (mb, 3);
-			break;
-		}
-
-		/* The class can not have an automatic layout */
-		if (mono_class_is_auto_layout (klass)) {
-			mono_mb_emit_auto_layout_exception (mb, klass);
-			break;
-		}
-
-		mono_mb_emit_stloc (mb, 0);
-		/* Check for null */
-		mono_mb_emit_ldloc (mb, 0);
-		pos = mono_mb_emit_branch (mb, CEE_BRTRUE);
-		mono_mb_emit_byte (mb, CEE_LDNULL);
-		mono_mb_emit_stloc (mb, 3);
-		pos2 = mono_mb_emit_branch (mb, CEE_BR);
-
-		mono_mb_patch_branch (mb, pos);
-
-		/* Set src */
-		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_ldflda (mb, sizeof (MonoObject));
-		mono_mb_emit_stloc (mb, 0);
-
-		/* Allocate and set dest */
-		mono_mb_emit_icon (mb, mono_class_native_size (klass, NULL));
-		mono_mb_emit_byte (mb, CEE_CONV_I);
-		mono_mb_emit_icall (mb, ves_icall_marshal_alloc);
-		mono_mb_emit_byte (mb, CEE_DUP);
-		mono_mb_emit_stloc (mb, 1);
-		mono_mb_emit_stloc (mb, 3);
-
-		emit_struct_conv (mb, klass, FALSE);
-
-		mono_mb_patch_branch (mb, pos2);
-		break;
-
-	default:
-		g_assert_not_reached ();
-	}
-#endif
 	return conv_arg;
 }
 
-#ifdef ENABLE_ILGEN
-#ifndef DISABLE_COM
-
 static int
-emit_marshal_variant (EmitMarshalContext *m, int argnum, MonoType *t,
+emit_marshal_variant_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		     MonoMarshalSpec *spec, 
 		     int conv_arg, MonoType **conv_arg_type, 
 		     MarshalAction action)
 {
-	MonoMethodBuilder *mb = m->mb;
-	static MonoMethod *get_object_for_native_variant = NULL;
-	static MonoMethod *get_native_variant_for_object = NULL;
-
-	if (!get_object_for_native_variant)
-		get_object_for_native_variant = mono_class_get_method_from_name (mono_defaults.marshal_class, "GetObjectForNativeVariant", 1);
-	g_assert (get_object_for_native_variant);
-
-	if (!get_native_variant_for_object)
-		get_native_variant_for_object = mono_class_get_method_from_name (mono_defaults.marshal_class, "GetNativeVariantForObject", 2);
-	g_assert (get_native_variant_for_object);
-
-	switch (action) {
-	case MARSHAL_ACTION_CONV_IN: {
-		conv_arg = mono_mb_add_local (mb, &mono_class_get_variant_class ()->byval_arg);
-		
-		if (t->byref)
-			*conv_arg_type = &mono_class_get_variant_class ()->this_arg;
-		else
-			*conv_arg_type = &mono_class_get_variant_class ()->byval_arg;
-
-		if (t->byref && !(t->attrs & PARAM_ATTRIBUTE_IN) && t->attrs & PARAM_ATTRIBUTE_OUT)
-			break;
-
-		mono_mb_emit_ldarg (mb, argnum);
-		if (t->byref)
-			mono_mb_emit_byte(mb, CEE_LDIND_REF);
-		mono_mb_emit_ldloc_addr (mb, conv_arg);
-		mono_mb_emit_managed_call (mb, get_native_variant_for_object, NULL);
-		break;
-	}
-
-	case MARSHAL_ACTION_CONV_OUT: {
-		static MonoMethod *variant_clear = NULL;
-
-		if (!variant_clear)
-			variant_clear = mono_class_get_method_from_name (mono_class_get_variant_class (), "Clear", 0);
-		g_assert (variant_clear);
-
-
-		if (t->byref && (t->attrs & PARAM_ATTRIBUTE_OUT || !(t->attrs & PARAM_ATTRIBUTE_IN))) {
-			mono_mb_emit_ldarg (mb, argnum);
-			mono_mb_emit_ldloc_addr (mb, conv_arg);
-			mono_mb_emit_managed_call (mb, get_object_for_native_variant, NULL);
-			mono_mb_emit_byte (mb, CEE_STIND_REF);
-		}
-
-		mono_mb_emit_ldloc_addr (mb, conv_arg);
-		mono_mb_emit_managed_call (mb, variant_clear, NULL);
-		break;
-	}
-
-	case MARSHAL_ACTION_PUSH:
-		if (t->byref)
-			mono_mb_emit_ldloc_addr (mb, conv_arg);
-		else
-			mono_mb_emit_ldloc (mb, conv_arg);
-		break;
-
-	case MARSHAL_ACTION_CONV_RESULT: {
-		char *msg = g_strdup ("Marshalling of VARIANT not supported as a return type.");
-		mono_mb_emit_exception_marshal_directive (mb, msg);
-		break;
-	}
-
-	case MARSHAL_ACTION_MANAGED_CONV_IN: {
-		conv_arg = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
-
-		if (t->byref)
-			*conv_arg_type = &mono_class_get_variant_class ()->this_arg;
-		else
-			*conv_arg_type = &mono_class_get_variant_class ()->byval_arg;
-
-		if (t->byref && !(t->attrs & PARAM_ATTRIBUTE_IN) && t->attrs & PARAM_ATTRIBUTE_OUT)
-			break;
-
-		if (t->byref)
-			mono_mb_emit_ldarg (mb, argnum);
-		else
-			mono_mb_emit_ldarg_addr (mb, argnum);
-		mono_mb_emit_managed_call (mb, get_object_for_native_variant, NULL);
-		mono_mb_emit_stloc (mb, conv_arg);
-		break;
-	}
-
-	case MARSHAL_ACTION_MANAGED_CONV_OUT: {
-		if (t->byref && (t->attrs & PARAM_ATTRIBUTE_OUT || !(t->attrs & PARAM_ATTRIBUTE_IN))) {
-			mono_mb_emit_ldloc (mb, conv_arg);
-			mono_mb_emit_ldarg (mb, argnum);
-			mono_mb_emit_managed_call (mb, get_native_variant_for_object, NULL);
-		}
-		break;
-	}
-
-	case MARSHAL_ACTION_MANAGED_CONV_RESULT: {
-		char *msg = g_strdup ("Marshalling of VARIANT not supported as a return type.");
-		mono_mb_emit_exception_marshal_directive (mb, msg);
-		break;
-	}
-
-	default:
-		g_assert_not_reached ();
-	}
-
-	return conv_arg;
+	g_assert_not_reached ();
 }
 
-#endif /* DISABLE_COM */
-#endif /* ENABLE_ILGEN */
-
-static gboolean
+gboolean
 mono_pinvoke_is_unicode (MonoMethodPInvoke *piinfo)
 {
 	switch (piinfo->piflags & PINVOKE_ATTRIBUTE_CHAR_SET_MASK) {
@@ -6476,14 +3023,12 @@ mono_pinvoke_is_unicode (MonoMethodPInvoke *piinfo)
 	}
 }
 
-
 static int
-emit_marshal_array (EmitMarshalContext *m, int argnum, MonoType *t,
+emit_marshal_array_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 					MonoMarshalSpec *spec, 
 					int conv_arg, MonoType **conv_arg_type, 
 					MarshalAction action)
 {
-#ifndef ENABLE_ILGEN
 	switch (action) {
 	case MARSHAL_ACTION_CONV_IN:
 		*conv_arg_type = &mono_defaults.object_class->byval_arg;
@@ -6492,714 +3037,10 @@ emit_marshal_array (EmitMarshalContext *m, int argnum, MonoType *t,
 		*conv_arg_type = &mono_defaults.int_class->byval_arg;
 		break;
 	}
-#else
-	MonoMethodBuilder *mb = m->mb;
-	MonoClass *klass = mono_class_from_mono_type (t);
-	gboolean need_convert, need_free;
-	MonoMarshalNative encoding;
-
-	encoding = mono_marshal_get_string_encoding (m->piinfo, spec);
-
-	switch (action) {
-	case MARSHAL_ACTION_CONV_IN:
-		*conv_arg_type = &mono_defaults.object_class->byval_arg;
-		conv_arg = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
-
-		if (klass->element_class->blittable) {
-			mono_mb_emit_ldarg (mb, argnum);
-			if (t->byref)
-				mono_mb_emit_byte (mb, CEE_LDIND_I);
-			mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_ARRAY_LPARRAY, NULL));
-			mono_mb_emit_stloc (mb, conv_arg);
-		} else {
-			MonoClass *eklass;
-			guint32 label1, label2, label3;
-			int index_var, src_var, dest_ptr, esize;
-			MonoMarshalConv conv;
-			gboolean is_string = FALSE;
-
-			dest_ptr = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-
-			eklass = klass->element_class;
-
-			if (eklass == mono_defaults.string_class) {
-				is_string = TRUE;
-				conv = mono_marshal_get_string_to_ptr_conv (m->piinfo, spec);
-			}
-			else if (eklass == mono_defaults.stringbuilder_class) {
-				is_string = TRUE;
-				conv = mono_marshal_get_stringbuilder_to_ptr_conv (m->piinfo, spec);
-			}
-			else
-				conv = MONO_MARSHAL_CONV_INVALID;
-
-			if (is_string && conv == MONO_MARSHAL_CONV_INVALID) {
-				char *msg = g_strdup_printf ("string/stringbuilder marshalling conversion %d not implemented", encoding);
-				mono_mb_emit_exception_marshal_directive (mb, msg);
-				break;
-			}
-
-			src_var = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
-			mono_mb_emit_ldarg (mb, argnum);
-			if (t->byref)
-				mono_mb_emit_byte (mb, CEE_LDIND_I);
-			mono_mb_emit_stloc (mb, src_var);
-
-			/* Check null */
-			mono_mb_emit_ldloc (mb, src_var);
-			mono_mb_emit_stloc (mb, conv_arg);
-			mono_mb_emit_ldloc (mb, src_var);
-			label1 = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-			if (is_string)
-				esize = sizeof (gpointer);
-			else if (eklass == mono_defaults.char_class) /*can't call mono_marshal_type_size since it causes all sorts of asserts*/
-				esize = mono_pinvoke_is_unicode (m->piinfo) ? 2 : 1;
-			else
-				esize = mono_class_native_size (eklass, NULL);
-
-			/* allocate space for the native struct and store the address */
-			mono_mb_emit_icon (mb, esize);
-			mono_mb_emit_ldloc (mb, src_var);
-			mono_mb_emit_byte (mb, CEE_LDLEN);
-
-			if (eklass == mono_defaults.string_class) {
-				/* Make the array bigger for the terminating null */
-				mono_mb_emit_byte (mb, CEE_LDC_I4_1);
-				mono_mb_emit_byte (mb, CEE_ADD);
-			}
-			mono_mb_emit_byte (mb, CEE_MUL);
-			mono_mb_emit_byte (mb, CEE_PREFIX1);
-			mono_mb_emit_byte (mb, CEE_LOCALLOC);
-			mono_mb_emit_stloc (mb, conv_arg);
-
-			mono_mb_emit_ldloc (mb, conv_arg);
-			mono_mb_emit_stloc (mb, dest_ptr);
-
-			/* Emit marshalling loop */
-			index_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);				
-			mono_mb_emit_byte (mb, CEE_LDC_I4_0);
-			mono_mb_emit_stloc (mb, index_var);
-			label2 = mono_mb_get_label (mb);
-			mono_mb_emit_ldloc (mb, index_var);
-			mono_mb_emit_ldloc (mb, src_var);
-			mono_mb_emit_byte (mb, CEE_LDLEN);
-			label3 = mono_mb_emit_branch (mb, CEE_BGE);
-
-			/* Emit marshalling code */
-
-			if (is_string) {
-				int stind_op;
-				mono_mb_emit_ldloc (mb, dest_ptr);
-				mono_mb_emit_ldloc (mb, src_var);
-				mono_mb_emit_ldloc (mb, index_var);
-				mono_mb_emit_byte (mb, CEE_LDELEM_REF);
-				mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
-				mono_mb_emit_byte (mb, stind_op);
-			} else {
-				/* set the src_ptr */
-				mono_mb_emit_ldloc (mb, src_var);
-				mono_mb_emit_ldloc (mb, index_var);
-				mono_mb_emit_op (mb, CEE_LDELEMA, eklass);
-				mono_mb_emit_stloc (mb, 0);
-
-				/* set dst_ptr */
-				mono_mb_emit_ldloc (mb, dest_ptr);
-				mono_mb_emit_stloc (mb, 1);
-
-				/* emit valuetype conversion code */
-				emit_struct_conv_full (mb, eklass, FALSE, 0, eklass == mono_defaults.char_class ? encoding : (MonoMarshalNative)-1);
-			}
-
-			mono_mb_emit_add_to_local (mb, index_var, 1);
-			mono_mb_emit_add_to_local (mb, dest_ptr, esize);
-			
-			mono_mb_emit_branch_label (mb, CEE_BR, label2);
-
-			mono_mb_patch_branch (mb, label3);
-
-			if (eklass == mono_defaults.string_class) {
-				/* Null terminate */
-				mono_mb_emit_ldloc (mb, dest_ptr);
-				mono_mb_emit_byte (mb, CEE_LDC_I4_0);
-				mono_mb_emit_byte (mb, CEE_STIND_I);
-			}
-
-			mono_mb_patch_branch (mb, label1);
-		}
-
-		break;
-
-	case MARSHAL_ACTION_CONV_OUT:
-		/* Unicode character arrays are implicitly marshalled as [Out] under MS.NET */
-		need_convert = ((klass->element_class == mono_defaults.char_class) && (encoding == MONO_NATIVE_LPWSTR)) || (klass->element_class == mono_defaults.stringbuilder_class) || (t->attrs & PARAM_ATTRIBUTE_OUT);
-		need_free = mono_marshal_need_free (&klass->element_class->byval_arg, 
-											m->piinfo, spec);
-
-		if ((t->attrs & PARAM_ATTRIBUTE_OUT) && spec && spec->native == MONO_NATIVE_LPARRAY && spec->data.array_data.param_num != -1) {
-			int param_num = spec->data.array_data.param_num;
-			MonoType *param_type;
-
-			param_type = m->sig->params [param_num];
-
-			if (param_type->byref && param_type->type != MONO_TYPE_I4) {
-				char *msg = g_strdup ("Not implemented.");
-				mono_mb_emit_exception_marshal_directive (mb, msg);
-				break;
-			}
-
-			if (t->byref ) {
-				mono_mb_emit_ldarg (mb, argnum);
-
-				/* Create the managed array */
-				mono_mb_emit_ldarg (mb, param_num);
-				if (m->sig->params [param_num]->byref)
-					// FIXME: Support other types
-					mono_mb_emit_byte (mb, CEE_LDIND_I4);
-				mono_mb_emit_byte (mb, CEE_CONV_OVF_I);
-				mono_mb_emit_op (mb, CEE_NEWARR, klass->element_class);
-				/* Store into argument */
-				mono_mb_emit_byte (mb, CEE_STIND_REF);
-			}
-		}
-
-		if (need_convert || need_free) {
-			/* FIXME: Optimize blittable case */
-			MonoClass *eklass;
-			guint32 label1, label2, label3;
-			int index_var, src_ptr, loc, esize;
-
-			eklass = klass->element_class;
-			if ((eklass == mono_defaults.stringbuilder_class) || (eklass == mono_defaults.string_class))
-				esize = sizeof (gpointer);
-			else if (eklass == mono_defaults.char_class)
-				esize = mono_pinvoke_is_unicode (m->piinfo) ? 2 : 1;
-			else
-				esize = mono_class_native_size (eklass, NULL);
-			src_ptr = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-			loc = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-
-			/* Check null */
-			mono_mb_emit_ldarg (mb, argnum);
-			if (t->byref)
-				mono_mb_emit_byte (mb, CEE_LDIND_I);
-			label1 = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-			mono_mb_emit_ldloc (mb, conv_arg);
-			mono_mb_emit_stloc (mb, src_ptr);
-
-			/* Emit marshalling loop */
-			index_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);				
-			mono_mb_emit_byte (mb, CEE_LDC_I4_0);
-			mono_mb_emit_stloc (mb, index_var);
-			label2 = mono_mb_get_label (mb);
-			mono_mb_emit_ldloc (mb, index_var);
-			mono_mb_emit_ldarg (mb, argnum);
-			if (t->byref)
-				mono_mb_emit_byte (mb, CEE_LDIND_REF);
-			mono_mb_emit_byte (mb, CEE_LDLEN);
-			label3 = mono_mb_emit_branch (mb, CEE_BGE);
-
-			/* Emit marshalling code */
-
-			if (eklass == mono_defaults.stringbuilder_class) {
-				gboolean need_free2;
-				MonoMarshalConv conv = mono_marshal_get_ptr_to_stringbuilder_conv (m->piinfo, spec, &need_free2);
-
-				g_assert (conv != MONO_MARSHAL_CONV_INVALID);
-
-				/* dest */
-				mono_mb_emit_ldarg (mb, argnum);
-				if (t->byref)
-					mono_mb_emit_byte (mb, CEE_LDIND_I);
-				mono_mb_emit_ldloc (mb, index_var);
-				mono_mb_emit_byte (mb, CEE_LDELEM_REF);
-
-				/* src */
-				mono_mb_emit_ldloc (mb, src_ptr);
-				mono_mb_emit_byte (mb, CEE_LDIND_I);
-
-				mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
-
-				if (need_free) {
-					/* src */
-					mono_mb_emit_ldloc (mb, src_ptr);
-					mono_mb_emit_byte (mb, CEE_LDIND_I);
-
-					mono_mb_emit_icall (mb, mono_marshal_free);
-				}
-			}
-			else if (eklass == mono_defaults.string_class) {
-				if (need_free) {
-					/* src */
-					mono_mb_emit_ldloc (mb, src_ptr);
-					mono_mb_emit_byte (mb, CEE_LDIND_I);
-
-					mono_mb_emit_icall (mb, mono_marshal_free);
-				}
-			}
-			else {
-				if (need_convert) {
-					/* set the src_ptr */
-					mono_mb_emit_ldloc (mb, src_ptr);
-					mono_mb_emit_stloc (mb, 0);
-
-					/* set dst_ptr */
-					mono_mb_emit_ldarg (mb, argnum);
-					if (t->byref)
-						mono_mb_emit_byte (mb, CEE_LDIND_REF);
-					mono_mb_emit_ldloc (mb, index_var);
-					mono_mb_emit_op (mb, CEE_LDELEMA, eklass);
-					mono_mb_emit_stloc (mb, 1);
-
-					/* emit valuetype conversion code */
-					emit_struct_conv_full (mb, eklass, TRUE, 0, eklass == mono_defaults.char_class ? encoding : (MonoMarshalNative)-1);
-				}
-
-				if (need_free) {
-					mono_mb_emit_ldloc (mb, src_ptr);
-					mono_mb_emit_stloc (mb, loc);
-
-					emit_struct_free (mb, eklass, loc);
-				}
-			}
-
-			mono_mb_emit_add_to_local (mb, index_var, 1);
-			mono_mb_emit_add_to_local (mb, src_ptr, esize);
-
-			mono_mb_emit_branch_label (mb, CEE_BR, label2);
-
-			mono_mb_patch_branch (mb, label1);
-			mono_mb_patch_branch (mb, label3);
-		}
-		
-		if (klass->element_class->blittable) {
-			/* free memory allocated (if any) by MONO_MARSHAL_CONV_ARRAY_LPARRAY */
-
-			mono_mb_emit_ldarg (mb, argnum);
-			if (t->byref)
-				mono_mb_emit_byte (mb, CEE_LDIND_REF);
-			mono_mb_emit_ldloc (mb, conv_arg);
-			mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_FREE_LPARRAY, NULL));
-		}
-
-		break;
-
-	case MARSHAL_ACTION_PUSH:
-		if (t->byref)
-			mono_mb_emit_ldloc_addr (mb, conv_arg);
-		else
-			mono_mb_emit_ldloc (mb, conv_arg);
-		break;
-
-	case MARSHAL_ACTION_CONV_RESULT:
-		/* fixme: we need conversions here */
-		mono_mb_emit_stloc (mb, 3);
-		break;
-
-	case MARSHAL_ACTION_MANAGED_CONV_IN: {
-		MonoClass *eklass;
-		guint32 label1, label2, label3;
-		int index_var, src_ptr, esize, param_num, num_elem;
-		MonoMarshalConv conv;
-		gboolean is_string = FALSE;
-		
-		conv_arg = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
-		*conv_arg_type = &mono_defaults.int_class->byval_arg;
-
-		if (t->byref) {
-			char *msg = g_strdup ("Byref array marshalling to managed code is not implemented.");
-			mono_mb_emit_exception_marshal_directive (mb, msg);
-			return conv_arg;
-		}
-		if (!spec) {
-			char *msg = g_strdup ("[MarshalAs] attribute required to marshal arrays to managed code.");
-			mono_mb_emit_exception_marshal_directive (mb, msg);
-			return conv_arg;
-		}			
-		if (spec->native != MONO_NATIVE_LPARRAY) {
-			char *msg = g_strdup ("Non LPArray marshalling of arrays to managed code is not implemented.");
-			mono_mb_emit_exception_marshal_directive (mb, msg);
-			return conv_arg;			
-		}
-
-		/* FIXME: t is from the method which is wrapped, not the delegate type */
-		/* g_assert (t->attrs & PARAM_ATTRIBUTE_IN); */
-
-		param_num = spec->data.array_data.param_num;
-		num_elem = spec->data.array_data.num_elem;
-		if (spec->data.array_data.elem_mult == 0)
-			/* param_num is not specified */
-			param_num = -1;
-
-		if (param_num == -1) {
-			if (num_elem <= 0) {
-				char *msg = g_strdup ("Either SizeConst or SizeParamIndex should be specified when marshalling arrays to managed code.");
-				mono_mb_emit_exception_marshal_directive (mb, msg);
-				return conv_arg;
-			}
-		}
-
-		/* FIXME: Optimize blittable case */
-
-		eklass = klass->element_class;
-		if (eklass == mono_defaults.string_class) {
-			is_string = TRUE;
-			conv = mono_marshal_get_ptr_to_string_conv (m->piinfo, spec, &need_free);
-		}
-		else if (eklass == mono_defaults.stringbuilder_class) {
-			is_string = TRUE;
-			conv = mono_marshal_get_ptr_to_stringbuilder_conv (m->piinfo, spec, &need_free);
-		}
-		else
-			conv = MONO_MARSHAL_CONV_INVALID;
-
-		mono_marshal_load_type_info (eklass);
-
-		if (is_string)
-			esize = sizeof (gpointer);
-		else
-			esize = mono_class_native_size (eklass, NULL);
-		src_ptr = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-
-		mono_mb_emit_byte (mb, CEE_LDNULL);
-		mono_mb_emit_stloc (mb, conv_arg);
-
-		/* Check param index */
-		if (param_num != -1) {
-			if (param_num >= m->sig->param_count) {
-				char *msg = g_strdup ("Array size control parameter index is out of range.");
-				mono_mb_emit_exception_marshal_directive (mb, msg);
-				return conv_arg;
-			}
-			switch (m->sig->params [param_num]->type) {
-			case MONO_TYPE_I1:
-			case MONO_TYPE_U1:
-			case MONO_TYPE_I2:
-			case MONO_TYPE_U2:
-			case MONO_TYPE_I4:
-			case MONO_TYPE_U4:
-			case MONO_TYPE_I:
-			case MONO_TYPE_U:
-			case MONO_TYPE_I8:
-			case MONO_TYPE_U8:
-				break;
-			default: {
-				char *msg = g_strdup ("Array size control parameter must be an integral type.");
-				mono_mb_emit_exception_marshal_directive (mb, msg);
-				return conv_arg;
-			}
-			}
-		}
-
-		/* Check null */
-		mono_mb_emit_ldarg (mb, argnum);
-		label1 = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-		mono_mb_emit_ldarg (mb, argnum);
-		mono_mb_emit_stloc (mb, src_ptr);
-
-		/* Create managed array */
-		/* 
-		 * The LPArray marshalling spec says that sometimes param_num starts 
-		 * from 1, sometimes it starts from 0. But MS seems to allways start
-		 * from 0.
-		 */
-
-		if (param_num == -1) {
-			mono_mb_emit_icon (mb, num_elem);
-		} else {
-			mono_mb_emit_ldarg (mb, param_num);
-			if (num_elem > 0) {
-				mono_mb_emit_icon (mb, num_elem);
-				mono_mb_emit_byte (mb, CEE_ADD);
-			}
-			mono_mb_emit_byte (mb, CEE_CONV_OVF_I);
-		}
-
-		mono_mb_emit_op (mb, CEE_NEWARR, eklass);
-		mono_mb_emit_stloc (mb, conv_arg);
-
-		if (eklass->blittable) {
-			mono_mb_emit_ldloc (mb, conv_arg);
-			mono_mb_emit_byte (mb, CEE_CONV_I);
-			mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoArray, vector));
-			mono_mb_emit_byte (mb, CEE_ADD);
-			mono_mb_emit_ldarg (mb, argnum);
-			mono_mb_emit_ldloc (mb, conv_arg);
-			mono_mb_emit_byte (mb, CEE_LDLEN);
-			mono_mb_emit_icon (mb, esize);
-			mono_mb_emit_byte (mb, CEE_MUL);
-			mono_mb_emit_byte (mb, CEE_PREFIX1);
-			mono_mb_emit_byte (mb, CEE_CPBLK);
-			mono_mb_patch_branch (mb, label1);
-			break;
-		}
-
-		/* Emit marshalling loop */
-		index_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		mono_mb_emit_byte (mb, CEE_LDC_I4_0);
-		mono_mb_emit_stloc (mb, index_var);
-		label2 = mono_mb_get_label (mb);
-		mono_mb_emit_ldloc (mb, index_var);
-		mono_mb_emit_ldloc (mb, conv_arg);
-		mono_mb_emit_byte (mb, CEE_LDLEN);
-		label3 = mono_mb_emit_branch (mb, CEE_BGE);
-
-		/* Emit marshalling code */
-		if (is_string) {
-			g_assert (conv != MONO_MARSHAL_CONV_INVALID);
-
-			mono_mb_emit_ldloc (mb, conv_arg);
-			mono_mb_emit_ldloc (mb, index_var);
-
-			mono_mb_emit_ldloc (mb, src_ptr);
-			mono_mb_emit_byte (mb, CEE_LDIND_I);
-
-			mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
-			mono_mb_emit_byte (mb, CEE_STELEM_REF);
-		}
-		else {
-			char *msg = g_strdup ("Marshalling of non-string and non-blittable arrays to managed code is not implemented.");
-			mono_mb_emit_exception_marshal_directive (mb, msg);
-			return conv_arg;
-		}
-
-		mono_mb_emit_add_to_local (mb, index_var, 1);
-		mono_mb_emit_add_to_local (mb, src_ptr, esize);
-
-		mono_mb_emit_branch_label (mb, CEE_BR, label2);
-
-		mono_mb_patch_branch (mb, label1);
-		mono_mb_patch_branch (mb, label3);
-		
-		break;
-	}
-	case MARSHAL_ACTION_MANAGED_CONV_OUT: {
-		MonoClass *eklass;
-		guint32 label1, label2, label3;
-		int index_var, dest_ptr, esize, param_num, num_elem;
-		MonoMarshalConv conv;
-		gboolean is_string = FALSE;
-
-		if (!spec)
-			/* Already handled in CONV_IN */
-			break;
-		
-		/* These are already checked in CONV_IN */
-		g_assert (!t->byref);
-		g_assert (spec->native == MONO_NATIVE_LPARRAY);
-		g_assert (t->attrs & PARAM_ATTRIBUTE_OUT);
-
-		param_num = spec->data.array_data.param_num;
-		num_elem = spec->data.array_data.num_elem;
-
-		if (spec->data.array_data.elem_mult == 0)
-			/* param_num is not specified */
-			param_num = -1;
-
-		if (param_num == -1) {
-			if (num_elem <= 0) {
-				g_assert_not_reached ();
-			}
-		}
-
-		/* FIXME: Optimize blittable case */
-
-		eklass = klass->element_class;
-		if (eklass == mono_defaults.string_class) {
-			is_string = TRUE;
-			conv = mono_marshal_get_string_to_ptr_conv (m->piinfo, spec);
-		}
-		else if (eklass == mono_defaults.stringbuilder_class) {
-			is_string = TRUE;
-			conv = mono_marshal_get_stringbuilder_to_ptr_conv (m->piinfo, spec);
-		}
-		else
-			conv = MONO_MARSHAL_CONV_INVALID;
-
-		mono_marshal_load_type_info (eklass);
-
-		if (is_string)
-			esize = sizeof (gpointer);
-		else
-			esize = mono_class_native_size (eklass, NULL);
-
-		dest_ptr = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-
-		/* Check null */
-		mono_mb_emit_ldloc (mb, conv_arg);
-		label1 = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-		mono_mb_emit_ldarg (mb, argnum);
-		mono_mb_emit_stloc (mb, dest_ptr);
-
-		if (eklass->blittable) {
-			/* dest */
-			mono_mb_emit_ldarg (mb, argnum);
-			/* src */
-			mono_mb_emit_ldloc (mb, conv_arg);
-			mono_mb_emit_byte (mb, CEE_CONV_I);
-			mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoArray, vector));
-			mono_mb_emit_byte (mb, CEE_ADD);
-			/* length */
-			mono_mb_emit_ldloc (mb, conv_arg);
-			mono_mb_emit_byte (mb, CEE_LDLEN);
-			mono_mb_emit_icon (mb, esize);
-			mono_mb_emit_byte (mb, CEE_MUL);
-			mono_mb_emit_byte (mb, CEE_PREFIX1);
-			mono_mb_emit_byte (mb, CEE_CPBLK);			
-			break;
-		}
-
-		/* Emit marshalling loop */
-		index_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		mono_mb_emit_byte (mb, CEE_LDC_I4_0);
-		mono_mb_emit_stloc (mb, index_var);
-		label2 = mono_mb_get_label (mb);
-		mono_mb_emit_ldloc (mb, index_var);
-		mono_mb_emit_ldloc (mb, conv_arg);
-		mono_mb_emit_byte (mb, CEE_LDLEN);
-		label3 = mono_mb_emit_branch (mb, CEE_BGE);
-
-		/* Emit marshalling code */
-		if (is_string) {
-			int stind_op;
-			g_assert (conv != MONO_MARSHAL_CONV_INVALID);
-
-			/* dest */
-			mono_mb_emit_ldloc (mb, dest_ptr);
-
-			/* src */
-			mono_mb_emit_ldloc (mb, conv_arg);
-			mono_mb_emit_ldloc (mb, index_var);
-
-			mono_mb_emit_byte (mb, CEE_LDELEM_REF);
-
-			mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
-			mono_mb_emit_byte (mb, stind_op);
-		}
-		else {
-			char *msg = g_strdup ("Marshalling of non-string and non-blittable arrays to managed code is not implemented.");
-			mono_mb_emit_exception_marshal_directive (mb, msg);
-			return conv_arg;
-		}
-
-		mono_mb_emit_add_to_local (mb, index_var, 1);
-		mono_mb_emit_add_to_local (mb, dest_ptr, esize);
-
-		mono_mb_emit_branch_label (mb, CEE_BR, label2);
-
-		mono_mb_patch_branch (mb, label1);
-		mono_mb_patch_branch (mb, label3);
-
-		break;
-	}
-	case MARSHAL_ACTION_MANAGED_CONV_RESULT: {
-		MonoClass *eklass;
-		guint32 label1, label2, label3;
-		int index_var, src, dest, esize;
-		MonoMarshalConv conv = MONO_MARSHAL_CONV_INVALID;
-		gboolean is_string = FALSE;
-		
-		g_assert (!t->byref);
-
-		eklass = klass->element_class;
-
-		mono_marshal_load_type_info (eklass);
-
-		if (eklass == mono_defaults.string_class) {
-			is_string = TRUE;
-			conv = mono_marshal_get_string_to_ptr_conv (m->piinfo, spec);
-		}
-		else {
-			g_assert_not_reached ();
-		}
-
-		if (is_string)
-			esize = sizeof (gpointer);
-		else if (eklass == mono_defaults.char_class)
-			esize = mono_pinvoke_is_unicode (m->piinfo) ? 2 : 1;
-		else
-			esize = mono_class_native_size (eklass, NULL);
-
-		src = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
-		dest = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-			
-		mono_mb_emit_stloc (mb, src);
-		mono_mb_emit_ldloc (mb, src);
-		mono_mb_emit_stloc (mb, 3);
-
-		/* Check for null */
-		mono_mb_emit_ldloc (mb, src);
-		label1 = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-		/* Allocate native array */
-		mono_mb_emit_icon (mb, esize);
-		mono_mb_emit_ldloc (mb, src);
-		mono_mb_emit_byte (mb, CEE_LDLEN);
-
-		if (eklass == mono_defaults.string_class) {
-			/* Make the array bigger for the terminating null */
-			mono_mb_emit_byte (mb, CEE_LDC_I4_1);
-			mono_mb_emit_byte (mb, CEE_ADD);
-		}
-		mono_mb_emit_byte (mb, CEE_MUL);
-		mono_mb_emit_icall (mb, ves_icall_marshal_alloc);
-		mono_mb_emit_stloc (mb, dest);
-		mono_mb_emit_ldloc (mb, dest);
-		mono_mb_emit_stloc (mb, 3);
-
-		/* Emit marshalling loop */
-		index_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		mono_mb_emit_byte (mb, CEE_LDC_I4_0);
-		mono_mb_emit_stloc (mb, index_var);
-		label2 = mono_mb_get_label (mb);
-		mono_mb_emit_ldloc (mb, index_var);
-		mono_mb_emit_ldloc (mb, src);
-		mono_mb_emit_byte (mb, CEE_LDLEN);
-		label3 = mono_mb_emit_branch (mb, CEE_BGE);
-
-		/* Emit marshalling code */
-		if (is_string) {
-			int stind_op;
-			g_assert (conv != MONO_MARSHAL_CONV_INVALID);
-
-			/* dest */
-			mono_mb_emit_ldloc (mb, dest);
-
-			/* src */
-			mono_mb_emit_ldloc (mb, src);
-			mono_mb_emit_ldloc (mb, index_var);
-
-			mono_mb_emit_byte (mb, CEE_LDELEM_REF);
-
-			mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
-			mono_mb_emit_byte (mb, stind_op);
-		}
-		else {
-			char *msg = g_strdup ("Marshalling of non-string arrays to managed code is not implemented.");
-			mono_mb_emit_exception_marshal_directive (mb, msg);
-			return conv_arg;
-		}
-
-		mono_mb_emit_add_to_local (mb, index_var, 1);
-		mono_mb_emit_add_to_local (mb, dest, esize);
-
-		mono_mb_emit_branch_label (mb, CEE_BR, label2);
-
-		mono_mb_patch_branch (mb, label3);
-		mono_mb_patch_branch (mb, label1);
-		break;
-	}
-	default:
-		g_assert_not_reached ();
-	}
-#endif
 	return conv_arg;
 }
 
-static MonoType*
+MonoType*
 marshal_boolean_conv_in_get_local_type (MonoMarshalSpec *spec, guint8 *ldc_op /*out*/)
 {
 	if (spec == NULL) {
@@ -7221,7 +3062,7 @@ marshal_boolean_conv_in_get_local_type (MonoMarshalSpec *spec, guint8 *ldc_op /*
 	}
 }
 
-static MonoClass*
+MonoClass*
 marshal_boolean_managed_conv_in_get_conv_arg_class (MonoMarshalSpec *spec, guint8 *ldop/*out*/)
 {
 	MonoClass* conv_arg_class = mono_defaults.int32_class;
@@ -7246,12 +3087,11 @@ marshal_boolean_managed_conv_in_get_conv_arg_class (MonoMarshalSpec *spec, guint
 }
 
 static int
-emit_marshal_boolean (EmitMarshalContext *m, int argnum, MonoType *t,
+emit_marshal_boolean_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		      MonoMarshalSpec *spec, 
 		      int conv_arg, MonoType **conv_arg_type, 
 		      MarshalAction action)
 {
-#ifndef ENABLE_ILGEN
 	switch (action) {
 	case MARSHAL_ACTION_CONV_IN:
 		if (t->byref)
@@ -7270,241 +3110,35 @@ emit_marshal_boolean (EmitMarshalContext *m, int argnum, MonoType *t,
 	}
 
 	}
-#else
-	MonoMethodBuilder *mb = m->mb;
-
-	switch (action) {
-	case MARSHAL_ACTION_CONV_IN: {
-		MonoType *local_type;
-		int label_false;
-		guint8 ldc_op = CEE_LDC_I4_1;
-
-		local_type = marshal_boolean_conv_in_get_local_type (spec, &ldc_op);
-		if (t->byref)
-			*conv_arg_type = &mono_defaults.int_class->byval_arg;
-		else
-			*conv_arg_type = local_type;
-		conv_arg = mono_mb_add_local (mb, local_type);
-		
-		mono_mb_emit_ldarg (mb, argnum);
-		if (t->byref)
-			mono_mb_emit_byte (mb, CEE_LDIND_I1);
-		label_false = mono_mb_emit_branch (mb, CEE_BRFALSE);
-		mono_mb_emit_byte (mb, ldc_op);
-		mono_mb_emit_stloc (mb, conv_arg);
-		mono_mb_patch_branch (mb, label_false);
-
-		break;
-	}
-
-	case MARSHAL_ACTION_CONV_OUT:
-	{
-		int label_false, label_end;
-		if (!t->byref)
-			break;
-
-		mono_mb_emit_ldarg (mb, argnum);
-		mono_mb_emit_ldloc (mb, conv_arg);
-		
-		label_false = mono_mb_emit_branch (mb, CEE_BRFALSE);
-		mono_mb_emit_byte (mb, CEE_LDC_I4_1);
-
-		label_end = mono_mb_emit_branch (mb, CEE_BR);
-		mono_mb_patch_branch (mb, label_false);
-		mono_mb_emit_byte (mb, CEE_LDC_I4_0);
-		mono_mb_patch_branch (mb, label_end);
-
-		mono_mb_emit_byte (mb, CEE_STIND_I1);
-		break;
-	}
-
-	case MARSHAL_ACTION_PUSH:
-		if (t->byref)
-			mono_mb_emit_ldloc_addr (mb, conv_arg);
-		else if (conv_arg)
-			mono_mb_emit_ldloc (mb, conv_arg);
-		else
-			mono_mb_emit_ldarg (mb, argnum);
-		break;
-
-	case MARSHAL_ACTION_CONV_RESULT:
-		/* maybe we need to make sure that it fits within 8 bits */
-		mono_mb_emit_stloc (mb, 3);
-		break;
-
-	case MARSHAL_ACTION_MANAGED_CONV_IN: {
-		MonoClass* conv_arg_class = mono_defaults.int32_class;
-		guint8 ldop = CEE_LDIND_I4;
-		int label_null, label_false;
-
-		conv_arg_class = marshal_boolean_managed_conv_in_get_conv_arg_class (spec, &ldop);
-		conv_arg = mono_mb_add_local (mb, &mono_defaults.boolean_class->byval_arg);
-
-		if (t->byref)
-			*conv_arg_type = &conv_arg_class->this_arg;
-		else
-			*conv_arg_type = &conv_arg_class->byval_arg;
-
-
-		mono_mb_emit_ldarg (mb, argnum);
-		
-		/* Check null */
-		if (t->byref) {
-			label_null = mono_mb_emit_branch (mb, CEE_BRFALSE);
-			mono_mb_emit_ldarg (mb, argnum);
-			mono_mb_emit_byte (mb, ldop);
-		} else
-			label_null = 0;
-
-		label_false = mono_mb_emit_branch (mb, CEE_BRFALSE);
-		mono_mb_emit_byte (mb, CEE_LDC_I4_1);
-		mono_mb_emit_stloc (mb, conv_arg);
-		mono_mb_patch_branch (mb, label_false);
-
-		if (t->byref) 
-			mono_mb_patch_branch (mb, label_null);
-		break;
-	}
-
-	case MARSHAL_ACTION_MANAGED_CONV_OUT: {
-		guint8 stop = CEE_STIND_I4;
-		guint8 ldc_op = CEE_LDC_I4_1;
-		int label_null,label_false, label_end;;
-
-		if (!t->byref)
-			break;
-		if (spec) {
-			switch (spec->native) {
-			case MONO_NATIVE_I1:
-			case MONO_NATIVE_U1:
-				stop = CEE_STIND_I1;
-				break;
-			case MONO_NATIVE_VARIANTBOOL:
-				stop = CEE_STIND_I2;
-				ldc_op = CEE_LDC_I4_M1;
-				break;
-			default:
-				break;
-			}
-		}
-		
-		/* Check null */
-		mono_mb_emit_ldarg (mb, argnum);
-		label_null = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-		mono_mb_emit_ldarg (mb, argnum);
-		mono_mb_emit_ldloc (mb, conv_arg);
-
-		label_false = mono_mb_emit_branch (mb, CEE_BRFALSE);
-		mono_mb_emit_byte (mb, ldc_op);
-		label_end = mono_mb_emit_branch (mb, CEE_BR);
-
-		mono_mb_patch_branch (mb, label_false);
-		mono_mb_emit_byte (mb, CEE_LDC_I4_0);
-		mono_mb_patch_branch (mb, label_end);
-
-		mono_mb_emit_byte (mb, stop);
-		mono_mb_patch_branch (mb, label_null);
-		break;
-	}
-
-	default:
-		g_assert_not_reached ();
-	}
-#endif
 	return conv_arg;
 }
 
 static int
-emit_marshal_ptr (EmitMarshalContext *m, int argnum, MonoType *t, 
+emit_marshal_ptr_noilgen (EmitMarshalContext *m, int argnum, MonoType *t, 
 		  MonoMarshalSpec *spec, int conv_arg, 
 		  MonoType **conv_arg_type, MarshalAction action)
 {
-#ifdef ENABLE_ILGEN
-	MonoMethodBuilder *mb = m->mb;
-
-	switch (action) {
-	case MARSHAL_ACTION_CONV_IN:
-		/* MS seems to allow this in some cases, ie. bxc #158 */
-		/*
-		if (MONO_TYPE_ISSTRUCT (t->data.type) && !mono_class_from_mono_type (t->data.type)->blittable) {
-			char *msg = g_strdup_printf ("Can not marshal 'parameter #%d': Pointers can not reference marshaled structures. Use byref instead.", argnum + 1);
-			mono_mb_emit_exception_marshal_directive (m->mb, msg);
-		}
-		*/
-		break;
-
-	case MARSHAL_ACTION_PUSH:
-		mono_mb_emit_ldarg (mb, argnum);
-		break;
-
-	case MARSHAL_ACTION_CONV_RESULT:
-		/* no conversions necessary */
-		mono_mb_emit_stloc (mb, 3);
-		break;
-
-	default:
-		break;
-	}
-#endif
 	return conv_arg;
 }
 
 static int
-emit_marshal_char (EmitMarshalContext *m, int argnum, MonoType *t, 
+emit_marshal_char_noilgen (EmitMarshalContext *m, int argnum, MonoType *t, 
 		   MonoMarshalSpec *spec, int conv_arg, 
 		   MonoType **conv_arg_type, MarshalAction action)
 {
-#ifdef ENABLE_ILGEN
-	MonoMethodBuilder *mb = m->mb;
-
-	switch (action) {
-	case MARSHAL_ACTION_PUSH:
-		/* fixme: dont know how to marshal that. We cant simply
-		 * convert it to a one byte UTF8 character, because an
-		 * unicode character may need more that one byte in UTF8 */
-		mono_mb_emit_ldarg (mb, argnum);
-		break;
-
-	case MARSHAL_ACTION_CONV_RESULT:
-		/* fixme: we need conversions here */
-		mono_mb_emit_stloc (mb, 3);
-		break;
-
-	default:
-		break;
-	}
-#endif
 	return conv_arg;
 }
 
 static int
-emit_marshal_scalar (EmitMarshalContext *m, int argnum, MonoType *t, 
+emit_marshal_scalar_noilgen (EmitMarshalContext *m, int argnum, MonoType *t, 
 		     MonoMarshalSpec *spec, int conv_arg, 
 		     MonoType **conv_arg_type, MarshalAction action)
 {
-#ifdef ENABLE_ILGEN
-	MonoMethodBuilder *mb = m->mb;
-
-	switch (action) {
-	case MARSHAL_ACTION_PUSH:
-		mono_mb_emit_ldarg (mb, argnum);
-		break;
-
-	case MARSHAL_ACTION_CONV_RESULT:
-		/* no conversions necessary */
-		mono_mb_emit_stloc (mb, 3);
-		break;
-
-	default:
-		break;
-	}
-#endif
 	return conv_arg;
 }
 
-static int
-emit_marshal (EmitMarshalContext *m, int argnum, MonoType *t, 
+int
+mono_emit_marshal (EmitMarshalContext *m, int argnum, MonoType *t, 
 	      MonoMarshalSpec *spec, int conv_arg, 
 	      MonoType **conv_arg_type, MarshalAction action)
 {
@@ -7512,24 +3146,24 @@ emit_marshal (EmitMarshalContext *m, int argnum, MonoType *t,
 	mono_marshal_load_type_info (mono_class_from_mono_type (t));
 
 	if (spec && spec->native == MONO_NATIVE_CUSTOM)
-		return emit_marshal_custom (m, argnum, t, spec, conv_arg, conv_arg_type, action);
+		return get_marshal_cb ()->emit_marshal_custom (m, argnum, t, spec, conv_arg, conv_arg_type, action);
 
 	if (spec && spec->native == MONO_NATIVE_ASANY)
-		return emit_marshal_asany (m, argnum, t, spec, conv_arg, conv_arg_type, action);
+		return get_marshal_cb ()->emit_marshal_asany (m, argnum, t, spec, conv_arg, conv_arg_type, action);
 			
 	switch (t->type) {
 	case MONO_TYPE_VALUETYPE:
 		if (t->data.klass == mono_defaults.handleref_class)
-			return emit_marshal_handleref (m, argnum, t, spec, conv_arg, conv_arg_type, action);
+			return get_marshal_cb ()->emit_marshal_handleref (m, argnum, t, spec, conv_arg, conv_arg_type, action);
 		
-		return emit_marshal_vtype (m, argnum, t, spec, conv_arg, conv_arg_type, action);
+		return get_marshal_cb ()->emit_marshal_vtype (m, argnum, t, spec, conv_arg, conv_arg_type, action);
 	case MONO_TYPE_STRING:
-		return emit_marshal_string (m, argnum, t, spec, conv_arg, conv_arg_type, action);
+		return get_marshal_cb ()->emit_marshal_string (m, argnum, t, spec, conv_arg, conv_arg_type, action);
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_OBJECT:
-#if !defined(DISABLE_COM) && defined(ENABLE_ILGEN)
+#if !defined(DISABLE_COM)
 		if (spec && spec->native == MONO_NATIVE_STRUCT)
-			return emit_marshal_variant (m, argnum, t, spec, conv_arg, conv_arg_type, action);
+			return get_marshal_cb ()->emit_marshal_variant (m, argnum, t, spec, conv_arg, conv_arg_type, action);
 #endif
 
 #if !defined(DISABLE_COM)
@@ -7545,18 +3179,18 @@ emit_marshal (EmitMarshalContext *m, int argnum, MonoType *t,
 
 		if (mono_class_try_get_safehandle_class () != NULL && t->data.klass &&
 		    mono_class_is_subclass_of (t->data.klass,  mono_class_try_get_safehandle_class (), FALSE))
-			return emit_marshal_safehandle (m, argnum, t, spec, conv_arg, conv_arg_type, action);
+			return get_marshal_cb ()->emit_marshal_safehandle (m, argnum, t, spec, conv_arg, conv_arg_type, action);
 		
-		return emit_marshal_object (m, argnum, t, spec, conv_arg, conv_arg_type, action);
+		return get_marshal_cb ()->emit_marshal_object (m, argnum, t, spec, conv_arg, conv_arg_type, action);
 	case MONO_TYPE_ARRAY:
 	case MONO_TYPE_SZARRAY:
-		return emit_marshal_array (m, argnum, t, spec, conv_arg, conv_arg_type, action);
+		return get_marshal_cb ()->emit_marshal_array (m, argnum, t, spec, conv_arg, conv_arg_type, action);
 	case MONO_TYPE_BOOLEAN:
-		return emit_marshal_boolean (m, argnum, t, spec, conv_arg, conv_arg_type, action);
+		return get_marshal_cb ()->emit_marshal_boolean (m, argnum, t, spec, conv_arg, conv_arg_type, action);
 	case MONO_TYPE_PTR:
-		return emit_marshal_ptr (m, argnum, t, spec, conv_arg, conv_arg_type, action);
+		return get_marshal_cb ()->emit_marshal_ptr (m, argnum, t, spec, conv_arg, conv_arg_type, action);
 	case MONO_TYPE_CHAR:
-		return emit_marshal_char (m, argnum, t, spec, conv_arg, conv_arg_type, action);
+		return get_marshal_cb ()->emit_marshal_char (m, argnum, t, spec, conv_arg, conv_arg_type, action);
 	case MONO_TYPE_I1:
 	case MONO_TYPE_U1:
 	case MONO_TYPE_I2:
@@ -7570,368 +3204,26 @@ emit_marshal (EmitMarshalContext *m, int argnum, MonoType *t,
 	case MONO_TYPE_I8:
 	case MONO_TYPE_U8:
 	case MONO_TYPE_FNPTR:
-		return emit_marshal_scalar (m, argnum, t, spec, conv_arg, conv_arg_type, action);
+		return get_marshal_cb ()->emit_marshal_scalar (m, argnum, t, spec, conv_arg, conv_arg_type, action);
 	case MONO_TYPE_GENERICINST:
 		if (mono_type_generic_inst_is_valuetype (t))
-			return emit_marshal_vtype (m, argnum, t, spec, conv_arg, conv_arg_type, action);
+			return get_marshal_cb ()->emit_marshal_vtype (m, argnum, t, spec, conv_arg, conv_arg_type, action);
 		else
-			return emit_marshal_object (m, argnum, t, spec, conv_arg, conv_arg_type, action);
+			return get_marshal_cb ()->emit_marshal_object (m, argnum, t, spec, conv_arg, conv_arg_type, action);
 	default:
 		return conv_arg;
 	}
 }
 
-/* How the arguments of an icall should be wrapped */
-typedef enum {
-	/* Don't wrap at all, pass the argument as is */
-	ICALL_HANDLES_WRAP_NONE,
-	/* Wrap the argument in an object handle, pass the handle to the icall */
-	ICALL_HANDLES_WRAP_OBJ,
-	/* Wrap the argument in an object handle, pass the handle to the icall,
-	   write the value out from the handle when the icall returns */
-	ICALL_HANDLES_WRAP_OBJ_INOUT,
-	/* Initialized an object handle to null, pass to the icalls,
-	   write the value out from the handle when the icall returns */
-	ICALL_HANDLES_WRAP_OBJ_OUT,
-	/* Wrap the argument (a valuetype reference) in a handle to pin its enclosing object,
-	   but pass the raw reference to the icall */
-	ICALL_HANDLES_WRAP_VALUETYPE_REF,
-} IcallHandlesWrap;
-
-typedef struct {
-	IcallHandlesWrap wrap;
-	/* if wrap is NONE or OBJ or VALUETYPE_REF, this is not meaningful.
-	   if wrap is OBJ_INOUT it's the local var that holds the MonoObjectHandle.
-	*/
-	int handle;
-}  IcallHandlesLocal;
-
-/*
- * Describes how to wrap the given parameter.
- *
- */
-static IcallHandlesWrap
-signature_param_uses_handles (MonoMethodSignature *sig, int param)
+static void
+emit_create_string_hack_noilgen (MonoMethodBuilder *mb, MonoMethodSignature *csig, MonoMethod *res)
 {
-	if (MONO_TYPE_IS_REFERENCE (sig->params [param])) {
-		if (mono_signature_param_is_out (sig, param))
-			return ICALL_HANDLES_WRAP_OBJ_OUT;
-		else if (mono_type_is_byref (sig->params [param]))
-			return ICALL_HANDLES_WRAP_OBJ_INOUT;
-		else
-			return ICALL_HANDLES_WRAP_OBJ;
-	} else if (mono_type_is_byref (sig->params [param]))
-		return ICALL_HANDLES_WRAP_VALUETYPE_REF;
-	else
-		return ICALL_HANDLES_WRAP_NONE;
 }
 
-
-#ifdef ENABLE_ILGEN
-/**
- * mono_marshal_emit_native_wrapper:
- * \param image the image to use for looking up custom marshallers
- * \param sig The signature of the native function
- * \param piinfo Marshalling information
- * \param mspecs Marshalling information
- * \param aot whenever the created method will be compiled by the AOT compiler
- * \param method if non-NULL, the pinvoke method to call
- * \param check_exceptions Whenever to check for pending exceptions after the native call
- * \param func_param the function to call is passed as a boxed IntPtr as the first parameter
- *
- * generates IL code for the pinvoke wrapper, the generated code calls \p func .
- */
-void
-mono_marshal_emit_native_wrapper (MonoImage *image, MonoMethodBuilder *mb, MonoMethodSignature *sig, MonoMethodPInvoke *piinfo, MonoMarshalSpec **mspecs, gpointer func, gboolean aot, gboolean check_exceptions, gboolean func_param)
+static void
+emit_native_icall_wrapper_noilgen (MonoMethodBuilder *mb, MonoMethod *method, MonoMethodSignature *csig, gboolean check_exceptions, gboolean aot, MonoMethodPInvoke *pinfo)
 {
-	EmitMarshalContext m;
-	MonoMethodSignature *csig;
-	MonoClass *klass;
-	int i, argnum, *tmp_locals;
-	int type, param_shift = 0;
-	int coop_gc_stack_dummy, coop_gc_var;
-#ifndef DISABLE_COM
-	int coop_cominterop_fnptr;
-#endif
-
-	memset (&m, 0, sizeof (m));
-	m.mb = mb;
-	m.sig = sig;
-	m.piinfo = piinfo;
-
-	/* we copy the signature, so that we can set pinvoke to 0 */
-	if (func_param) {
-		/* The function address is passed as the first argument */
-		g_assert (!sig->hasthis);
-		param_shift += 1;
-	}
-	csig = mono_metadata_signature_dup_full (mb->method->klass->image, sig);
-	csig->pinvoke = 1;
-	m.csig = csig;
-	m.image = image;
-
-	if (sig->hasthis)
-		param_shift += 1;
-
-	/* we allocate local for use with emit_struct_conv() */
-	/* allocate local 0 (pointer) src_ptr */
-	mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-	/* allocate local 1 (pointer) dst_ptr */
-	mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-	/* allocate local 2 (boolean) delete_old */
-	mono_mb_add_local (mb, &mono_defaults.boolean_class->byval_arg);
-
-	/* delete_old = FALSE */
-	mono_mb_emit_icon (mb, 0);
-	mono_mb_emit_stloc (mb, 2);
-
-	if (!MONO_TYPE_IS_VOID (sig->ret)) {
-		/* allocate local 3 to store the return value */
-		mono_mb_add_local (mb, sig->ret);
-	}
-
-	if (mono_threads_is_blocking_transition_enabled ()) {
-		/* local 4, dummy local used to get a stack address for suspend funcs */
-		coop_gc_stack_dummy = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		/* local 5, the local to be used when calling the suspend funcs */
-		coop_gc_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-#ifndef DISABLE_COM
-		if (!func_param && MONO_CLASS_IS_IMPORT (mb->method->klass)) {
-			coop_cominterop_fnptr = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		}
-#endif
-	}
-
-	/*
-	 * cookie = mono_threads_enter_gc_safe_region_unbalanced (ref dummy);
-	 *
-	 * ret = method (...);
-	 *
-	 * mono_threads_exit_gc_safe_region_unbalanced (cookie, ref dummy);
-	 *
-	 * <interrupt check>
-	 *
-	 * return ret;
-	 */
-
-	if (MONO_TYPE_ISSTRUCT (sig->ret))
-		m.vtaddr_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-
-	if (mspecs [0] && mspecs [0]->native == MONO_NATIVE_CUSTOM) {
-		/* Return type custom marshaling */
-		/*
-		 * Since we can't determine the return type of the unmanaged function,
-		 * we assume it returns a pointer, and pass that pointer to
-		 * MarshalNativeToManaged.
-		 */
-		csig->ret = &mono_defaults.int_class->byval_arg;
-	}
-
-	/* we first do all conversions */
-	tmp_locals = (int *)alloca (sizeof (int) * sig->param_count);
-	m.orig_conv_args = (int *)alloca (sizeof (int) * (sig->param_count + 1));
-
-	for (i = 0; i < sig->param_count; i ++) {
-		tmp_locals [i] = emit_marshal (&m, i + param_shift, sig->params [i], mspecs [i + 1], 0, &csig->params [i], MARSHAL_ACTION_CONV_IN);
-	}
-
-	// In coop mode need to register blocking state during native call
-	if (mono_threads_is_blocking_transition_enabled ()) {
-		// Perform an extra, early lookup of the function address, so any exceptions
-		// potentially resulting from the lookup occur before entering blocking mode.
-		if (!func_param && !MONO_CLASS_IS_IMPORT (mb->method->klass) && aot) {
-			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-			mono_mb_emit_op (mb, CEE_MONO_ICALL_ADDR, &piinfo->method);
-			mono_mb_emit_byte (mb, CEE_POP); // Result not needed yet
-		}
-
-#ifndef DISABLE_COM
-		if (!func_param && MONO_CLASS_IS_IMPORT (mb->method->klass)) {
-			mono_mb_emit_cominterop_get_function_pointer (mb, &piinfo->method);
-			mono_mb_emit_stloc (mb, coop_cominterop_fnptr);
-		}
-#endif
-
-		mono_mb_emit_ldloc_addr (mb, coop_gc_stack_dummy);
-		mono_mb_emit_icall (mb, mono_threads_enter_gc_safe_region_unbalanced);
-		mono_mb_emit_stloc (mb, coop_gc_var);
-	}
-
-	/* push all arguments */
-
-	if (sig->hasthis)
-		mono_mb_emit_byte (mb, CEE_LDARG_0);
-
-	for (i = 0; i < sig->param_count; i++) {
-		emit_marshal (&m, i + param_shift, sig->params [i], mspecs [i + 1], tmp_locals [i], NULL, MARSHAL_ACTION_PUSH);
-	}			
-
-	/* call the native method */
-	if (func_param) {
-		mono_mb_emit_byte (mb, CEE_LDARG_0);
-		mono_mb_emit_op (mb, CEE_UNBOX, mono_defaults.int_class);
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_calli (mb, csig);
-	} else if (MONO_CLASS_IS_IMPORT (mb->method->klass)) {
-#ifndef DISABLE_COM
-		if (!mono_threads_is_blocking_transition_enabled ()) {
-			mono_mb_emit_cominterop_call (mb, csig, &piinfo->method);
-		} else {
-			mono_mb_emit_ldloc (mb, coop_cominterop_fnptr);
-			mono_mb_emit_cominterop_call_function_pointer (mb, csig);
-		}
-#else
-		g_assert_not_reached ();
-#endif
-	} else {
-		if (aot) {
-			/* Reuse the ICALL_ADDR opcode for pinvokes too */
-			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-			mono_mb_emit_op (mb, CEE_MONO_ICALL_ADDR, &piinfo->method);
-			mono_mb_emit_calli (mb, csig);
-		} else {			
-			mono_mb_emit_native_call (mb, csig, func);
-		}
-	}
-
-	/* Set LastError if needed */
-	if (piinfo->piflags & PINVOKE_ATTRIBUTE_SUPPORTS_LAST_ERROR) {
-#ifdef TARGET_WIN32
-		if (!aot) {
-			static MonoMethodSignature *get_last_error_sig = NULL;
-			if (!get_last_error_sig) {
-				get_last_error_sig = mono_metadata_signature_alloc (mono_defaults.corlib, 0);
-				get_last_error_sig->ret = &mono_defaults.int_class->byval_arg;
-				get_last_error_sig->pinvoke = 1;
-			}
-
-			/*
-			 * Have to call GetLastError () early and without a wrapper, since various runtime components could
-			 * clobber its value.
-			 */
-			mono_mb_emit_native_call (mb, get_last_error_sig, GetLastError);
-			mono_mb_emit_icall (mb, mono_marshal_set_last_error_windows);
-		} else {
-			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-			mono_mb_emit_byte (mb, CEE_MONO_GET_LAST_ERROR);
-			mono_mb_emit_icall (mb, mono_marshal_set_last_error_windows);
-		}
-#else
-		mono_mb_emit_icall (mb, mono_marshal_set_last_error);
-#endif
-	}
-
-	if (MONO_TYPE_ISSTRUCT (sig->ret)) {
-		MonoClass *klass = mono_class_from_mono_type (sig->ret);
-		mono_class_init (klass);
-		if (!(mono_class_is_explicit_layout (klass) || klass->blittable)) {
-			/* This is used by emit_marshal_vtype (), but it needs to go right before the call */
-			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-			mono_mb_emit_byte (mb, CEE_MONO_VTADDR);
-			mono_mb_emit_stloc (mb, m.vtaddr_var);
-		}
-	}
-
-	/* Unblock before converting the result, since that can involve calls into the runtime */
-	if (mono_threads_is_blocking_transition_enabled ()) {
-		mono_mb_emit_ldloc (mb, coop_gc_var);
-		mono_mb_emit_ldloc_addr (mb, coop_gc_stack_dummy);
-		mono_mb_emit_icall (mb, mono_threads_exit_gc_safe_region_unbalanced);
-	}
-
-	/* convert the result */
-	if (!sig->ret->byref) {
-		MonoMarshalSpec *spec = mspecs [0];
-		type = sig->ret->type;
-
-		if (spec && spec->native == MONO_NATIVE_CUSTOM) {
-			emit_marshal (&m, 0, sig->ret, spec, 0, NULL, MARSHAL_ACTION_CONV_RESULT);
-		} else {
-		handle_enum:
-			switch (type) {
-			case MONO_TYPE_VOID:
-				break;
-			case MONO_TYPE_VALUETYPE:
-				klass = sig->ret->data.klass;
-				if (klass->enumtype) {
-					type = mono_class_enum_basetype (sig->ret->data.klass)->type;
-					goto handle_enum;
-				}
-				emit_marshal (&m, 0, sig->ret, spec, 0, NULL, MARSHAL_ACTION_CONV_RESULT);
-				break;
-			case MONO_TYPE_I1:
-			case MONO_TYPE_U1:
-			case MONO_TYPE_I2:
-			case MONO_TYPE_U2:
-			case MONO_TYPE_I4:
-			case MONO_TYPE_U4:
-			case MONO_TYPE_I:
-			case MONO_TYPE_U:
-			case MONO_TYPE_R4:
-			case MONO_TYPE_R8:
-			case MONO_TYPE_I8:
-			case MONO_TYPE_U8:
-			case MONO_TYPE_FNPTR:
-			case MONO_TYPE_STRING:
-			case MONO_TYPE_CLASS:
-			case MONO_TYPE_OBJECT:
-			case MONO_TYPE_BOOLEAN:
-			case MONO_TYPE_ARRAY:
-			case MONO_TYPE_SZARRAY:
-			case MONO_TYPE_CHAR:
-			case MONO_TYPE_PTR:
-			case MONO_TYPE_GENERICINST:
-				emit_marshal (&m, 0, sig->ret, spec, 0, NULL, MARSHAL_ACTION_CONV_RESULT);
-				break;
-			case MONO_TYPE_TYPEDBYREF:
-			default:
-				g_warning ("return type 0x%02x unknown", sig->ret->type);	
-				g_assert_not_reached ();
-			}
-		}
-	} else {
-		mono_mb_emit_stloc (mb, 3);
-	}
-
-	/* 
-	 * Need to call this after converting the result since MONO_VTADDR needs 
-	 * to be adjacent to the call instruction.
-	 */
-	if (check_exceptions)
-		emit_thread_interrupt_checkpoint (mb);
-
-	/* we need to convert byref arguments back and free string arrays */
-	for (i = 0; i < sig->param_count; i++) {
-		MonoType *t = sig->params [i];
-		MonoMarshalSpec *spec = mspecs [i + 1];
-
-		argnum = i + param_shift;
-
-		if (spec && ((spec->native == MONO_NATIVE_CUSTOM) || (spec->native == MONO_NATIVE_ASANY))) {
-			emit_marshal (&m, argnum, t, spec, tmp_locals [i], NULL, MARSHAL_ACTION_CONV_OUT);
-			continue;
-		}
-
-		switch (t->type) {
-		case MONO_TYPE_STRING:
-		case MONO_TYPE_VALUETYPE:
-		case MONO_TYPE_CLASS:
-		case MONO_TYPE_OBJECT:
-		case MONO_TYPE_SZARRAY:
-		case MONO_TYPE_BOOLEAN:
-			emit_marshal (&m, argnum, t, spec, tmp_locals [i], NULL, MARSHAL_ACTION_CONV_OUT);
-			break;
-		default:
-			break;
-		}
-	}
-
-	if (!MONO_TYPE_IS_VOID(sig->ret))
-		mono_mb_emit_ldloc (mb, 3);
-
-	mono_mb_emit_byte (mb, CEE_RET);
 }
-#endif /* ENABLE_ILGEN */
 
 /**
  * mono_marshal_get_native_wrapper:
@@ -8030,13 +3322,7 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 				/* create a wrapper to preserve .ctor in stack trace */
 				mb = mono_mb_new (method->klass, method->name, MONO_WRAPPER_MANAGED_TO_MANAGED);
 
-#ifdef ENABLE_ILGEN
-				mono_mb_emit_byte (mb, CEE_LDARG_0);
-				for (i = 1; i <= csig->param_count; i++)
-					mono_mb_emit_ldarg (mb, i);
-				mono_mb_emit_managed_call (mb, res, NULL);
-				mono_mb_emit_byte (mb, CEE_RET);
-#endif
+				get_marshal_cb ()->emit_create_string_hack (mb, csig, res);
 
 				info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_STRING_CTOR);
 				info->d.string_ctor.method = method;
@@ -8064,9 +3350,7 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 	 * registered in the runtime doing the AOT compilation.
 	 */
 	if (!piinfo->addr && !aot) {
-#ifdef ENABLE_ILGEN
-		mono_mb_emit_exception (mb, exc_class, exc_arg);
-#endif
+		get_marshal_cb ()->mb_emit_exception (mb, "System", exc_class, exc_arg);
 		info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_NONE);
 		info->d.managed_to_native.method = method;
 
@@ -8092,223 +3376,8 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 		if (method->string_ctor)
 			csig->ret = &mono_defaults.string_class->byval_arg;
 
-#ifdef ENABLE_ILGEN
-		// FIXME:
-		MonoClass *handle_stack_mark_class;
-		MonoClass *error_class;
-		int thread_info_var = -1, stack_mark_var = -1, error_var = -1;
-		MonoMethodSignature *call_sig = csig;
-		gboolean uses_handles = FALSE;
-		gboolean save_handles_to_locals = FALSE;
-		IcallHandlesLocal *handles_locals = NULL;
+		get_marshal_cb ()->emit_native_icall_wrapper (mb, method, csig, check_exceptions, aot, piinfo);
 
-		(void) mono_lookup_internal_call_full (method, &uses_handles);
-
-		/* If it uses handles and MonoError, it had better check exceptions */
-		g_assert (!uses_handles || check_exceptions);
-
-		if (uses_handles) {
-			MonoMethodSignature *ret;
-
-			/* Add a MonoError argument and figure out which args need to be wrapped in handles */
-			// FIXME: The stuff from mono_metadata_signature_dup_internal_with_padding ()
-			ret = mono_metadata_signature_alloc (method->klass->image, csig->param_count + 1);
-
-			ret->param_count = csig->param_count + 1;
-			ret->ret = csig->ret;
-
-			handles_locals = g_new0 (IcallHandlesLocal, csig->param_count);
-			for (int i = 0; i < csig->param_count; ++i) {
-				IcallHandlesWrap w = signature_param_uses_handles (csig, i);
-				handles_locals [i].wrap = w;
-				switch (w) {
-				case ICALL_HANDLES_WRAP_OBJ:
-				case ICALL_HANDLES_WRAP_OBJ_INOUT:
-				case ICALL_HANDLES_WRAP_OBJ_OUT:
-					ret->params [i] = mono_class_get_byref_type (mono_class_from_mono_type(csig->params[i]));
-					if (w == ICALL_HANDLES_WRAP_OBJ_OUT || w == ICALL_HANDLES_WRAP_OBJ_INOUT)
-						save_handles_to_locals = TRUE;
-					break;
-				case ICALL_HANDLES_WRAP_NONE:
-				case ICALL_HANDLES_WRAP_VALUETYPE_REF:
-					ret->params [i] = csig->params [i];
-					break;
-				default:
-					g_assert_not_reached ();
-				}
-			}
-			/* Add MonoError* param */
-			ret->params [csig->param_count] = &mono_get_intptr_class ()->byval_arg;
-			ret->pinvoke = csig->pinvoke;
-
-			call_sig = ret;
-		}
-
-		if (uses_handles) {
-			handle_stack_mark_class = mono_class_load_from_name (mono_get_corlib (), "Mono", "RuntimeStructs/HandleStackMark");
-			error_class = mono_class_load_from_name (mono_get_corlib (), "Mono", "RuntimeStructs/MonoError");
-
-			thread_info_var = mono_mb_add_local (mb, &mono_get_intptr_class ()->byval_arg);
-			stack_mark_var = mono_mb_add_local (mb, &handle_stack_mark_class->byval_arg);
-			error_var = mono_mb_add_local (mb, &error_class->byval_arg);
-
-			if (save_handles_to_locals) {
-				/* add a local var to hold the handles for each out arg */
-				for (int i = 0; i < sig->param_count; ++i) {
-					int j = i + sig->hasthis;
-					switch (handles_locals[j].wrap) {
-					case ICALL_HANDLES_WRAP_NONE:
-					case ICALL_HANDLES_WRAP_OBJ:
-					case ICALL_HANDLES_WRAP_VALUETYPE_REF:
-						handles_locals [j].handle = -1;
-						break;
-					case ICALL_HANDLES_WRAP_OBJ_INOUT:
-					case ICALL_HANDLES_WRAP_OBJ_OUT:
-						handles_locals [j].handle = mono_mb_add_local (mb, sig->params [i]);
-						break;
-					default:
-						g_assert_not_reached ();
-					}
-				}
-			}
-		}
-
-		if (sig->hasthis) {
-			int pos;
-
-			/*
-			 * Add a null check since public icalls can be called with 'call' which
-			 * does no such check.
-			 */
-			mono_mb_emit_byte (mb, CEE_LDARG_0);			
-			pos = mono_mb_emit_branch (mb, CEE_BRTRUE);
-			mono_mb_emit_exception (mb, "NullReferenceException", NULL);
-			mono_mb_patch_branch (mb, pos);
-		}
-
-		if (uses_handles) {
-			mono_mb_emit_ldloc_addr (mb, stack_mark_var);
-			mono_mb_emit_ldloc_addr (mb, error_var);
-			mono_mb_emit_icall (mb, mono_icall_start);
-			mono_mb_emit_stloc (mb, thread_info_var);
-
-			if (sig->hasthis) {
-				mono_mb_emit_byte (mb, CEE_LDARG_0);
-				/* TODO support adding wrappers to non-static struct methods */
-				g_assert (!mono_class_is_valuetype(mono_method_get_class (method)));
-				mono_mb_emit_icall (mb, mono_icall_handle_new);
-			}
-			for (i = 0; i < sig->param_count; i++) {
-				/* load each argument. references into the managed heap get wrapped in handles */
-				int j = i + sig->hasthis;
-				switch (handles_locals[j].wrap) {
-				case ICALL_HANDLES_WRAP_NONE:
-					mono_mb_emit_ldarg (mb, j);
-					break;
-				case ICALL_HANDLES_WRAP_OBJ:
-					/* argI = mono_handle_new (argI_raw) */
-					mono_mb_emit_ldarg (mb, j);
-					mono_mb_emit_icall (mb, mono_icall_handle_new);
-					break;
-				case ICALL_HANDLES_WRAP_OBJ_INOUT:
-				case ICALL_HANDLES_WRAP_OBJ_OUT:
-					/* if inout:
-					 *   handleI = argI = mono_handle_new (*argI_raw)
-					 * otherwise:
-					 *   handleI = argI = mono_handle_new (NULL)
-					 */
-					if (handles_locals[j].wrap == ICALL_HANDLES_WRAP_OBJ_INOUT) {
-						mono_mb_emit_ldarg (mb, j);
-						mono_mb_emit_byte (mb, CEE_LDIND_REF);
-					} else
-						mono_mb_emit_byte (mb, CEE_LDNULL);
-					mono_mb_emit_icall (mb, mono_icall_handle_new);
-					/* tmp = argI */
-					mono_mb_emit_byte (mb, CEE_DUP);
-					/* handleI = tmp */
-					mono_mb_emit_stloc (mb, handles_locals[j].handle);
-					break;
-				case ICALL_HANDLES_WRAP_VALUETYPE_REF:
-					/* (void) mono_handle_new (argI); argI */
-					mono_mb_emit_ldarg (mb, j);
-					mono_mb_emit_byte (mb, CEE_DUP);
-					mono_mb_emit_icall (mb, mono_icall_handle_new_interior);
-					mono_mb_emit_byte (mb, CEE_POP);
-#if 0
-					fprintf (stderr, " Method %s.%s.%s has byref valuetype argument %d\n", method->klass->name_space, method->klass->name, method->name, i);
-#endif
-					break;
-				default:
-					g_assert_not_reached ();
-				}
-			}
-			mono_mb_emit_ldloc_addr (mb, error_var);
-		} else {
-			if (sig->hasthis)
-				mono_mb_emit_byte (mb, CEE_LDARG_0);
-			for (i = 0; i < sig->param_count; i++)
-				mono_mb_emit_ldarg (mb, i + sig->hasthis);
-		}
-
-		if (aot) {
-			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-			mono_mb_emit_op (mb, CEE_MONO_ICALL_ADDR, &piinfo->method);
-			mono_mb_emit_calli (mb, call_sig);
-		} else {
-			g_assert (piinfo->addr);
-			mono_mb_emit_native_call (mb, call_sig, piinfo->addr);
-		}
-
-		if (uses_handles) {
-			if (MONO_TYPE_IS_REFERENCE (sig->ret)) {
-				// if (ret != NULL_HANDLE) {
-				//   ret = MONO_HANDLE_RAW(ret)
-				// }
-				mono_mb_emit_byte (mb, CEE_DUP);
-				int pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
-				mono_mb_emit_ldflda (mb, MONO_HANDLE_PAYLOAD_OFFSET (MonoObject));
-				mono_mb_emit_byte (mb, CEE_LDIND_REF);
-				mono_mb_patch_branch (mb, pos);
-			}
-			if (save_handles_to_locals) {
-				for (i = 0; i < sig->param_count; i++) {
-					int j = i + sig->hasthis;
-					switch (handles_locals [j].wrap) {
-					case ICALL_HANDLES_WRAP_NONE:
-					case ICALL_HANDLES_WRAP_OBJ:
-					case ICALL_HANDLES_WRAP_VALUETYPE_REF:
-						break;
-					case ICALL_HANDLES_WRAP_OBJ_INOUT:
-					case ICALL_HANDLES_WRAP_OBJ_OUT:
-						/* *argI_raw = MONO_HANDLE_RAW (handleI) */
-
-						/* argI_raw */
-						mono_mb_emit_ldarg (mb, j);
-						/* handleI */
-						mono_mb_emit_ldloc (mb, handles_locals [j].handle);
-						/* MONO_HANDLE_RAW(handleI) */
-						mono_mb_emit_ldflda (mb, MONO_HANDLE_PAYLOAD_OFFSET (MonoObject));
-						mono_mb_emit_byte (mb, CEE_LDIND_REF);
-						/* *argI_raw = MONO_HANDLE_RAW(handleI) */
-						mono_mb_emit_byte (mb, CEE_STIND_REF);
-						break;
-					default:
-						g_assert_not_reached ();
-					}
-				}
-			}
-			g_free (handles_locals);
-
-			mono_mb_emit_ldloc (mb, thread_info_var);
-			mono_mb_emit_ldloc_addr (mb, stack_mark_var);
-			mono_mb_emit_ldloc_addr (mb, error_var);
-			mono_mb_emit_icall (mb, mono_icall_end);
-		}
-
-		if (check_exceptions)
-			emit_thread_interrupt_checkpoint (mb);
-		mono_mb_emit_byte (mb, CEE_RET);
-#endif
 		info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_NONE);
 		info->d.managed_to_native.method = method;
 
@@ -8325,12 +3394,10 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 	if (!aot)
 		g_assert (piinfo->addr);
 
-#ifdef ENABLE_ILGEN
 	mspecs = g_new (MonoMarshalSpec*, sig->param_count + 1);
 	mono_method_get_marshal_info (method, mspecs);
 
 	mono_marshal_emit_native_wrapper (mb->method->klass->image, mb, sig, piinfo, mspecs, piinfo->addr, aot, check_exceptions, FALSE);
-#endif
 	info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_PINVOKE);
 	info->d.managed_to_native.method = method;
 
@@ -8340,12 +3407,10 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 										 info, NULL);
 	mono_mb_free (mb);
 
-#ifdef ENABLE_ILGEN
 	for (i = sig->param_count; i >= 0; i--)
 		if (mspecs [i])
 			mono_metadata_free_marshal_spec (mspecs [i]);
 	g_free (mspecs);
-#endif
 
 	/* mono_method_print_code (res); */
 
@@ -8388,9 +3453,7 @@ mono_marshal_get_native_func_wrapper (MonoImage *image, MonoMethodSignature *sig
 	mb = mono_mb_new (mono_defaults.object_class, name, MONO_WRAPPER_MANAGED_TO_NATIVE);
 	mb->method->save_lmf = 1;
 
-#ifdef ENABLE_ILGEN
 	mono_marshal_emit_native_wrapper (image, mb, sig, piinfo, mspecs, func, FALSE, TRUE, FALSE);
-#endif
 
 	csig = mono_metadata_signature_dup_full (image, sig);
 	csig->pinvoke = 0;
@@ -8453,9 +3516,7 @@ mono_marshal_get_native_func_wrapper_aot (MonoClass *klass)
 	mb = mono_mb_new (invoke->klass, name, MONO_WRAPPER_MANAGED_TO_NATIVE);
 	mb->method->save_lmf = 1;
 
-#ifdef ENABLE_ILGEN
 	mono_marshal_emit_native_wrapper (image, mb, sig, piinfo, mspecs, NULL, FALSE, TRUE, TRUE);
-#endif
 
 	info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_NATIVE_FUNC_AOT);
 	info->d.managed_to_native.method = invoke;
@@ -8488,7 +3549,12 @@ mono_marshal_get_native_func_wrapper_aot (MonoClass *klass)
 void
 mono_marshal_emit_managed_wrapper (MonoMethodBuilder *mb, MonoMethodSignature *invoke_sig, MonoMarshalSpec **mspecs, EmitMarshalContext* m, MonoMethod *method, uint32_t target_handle)
 {
-#ifndef ENABLE_ILGEN
+	get_marshal_cb ()->emit_managed_wrapper (mb, invoke_sig, mspecs, m, method, target_handle);
+}
+
+static void
+emit_managed_wrapper_noilgen (MonoMethodBuilder *mb, MonoMethodSignature *invoke_sig, MonoMarshalSpec **mspecs, EmitMarshalContext* m, MonoMethod *method, uint32_t target_handle)
+{
 	MonoMethodSignature *sig, *csig;
 	int i;
 
@@ -8507,7 +3573,7 @@ mono_marshal_emit_managed_wrapper (MonoMethodBuilder *mb, MonoMethodSignature *i
 		case MONO_TYPE_SZARRAY:
 		case MONO_TYPE_STRING:
 		case MONO_TYPE_BOOLEAN:
-			emit_marshal (m, i, sig->params [i], mspecs [i + 1], 0, &csig->params [i], MARSHAL_ACTION_MANAGED_CONV_IN);
+			mono_emit_marshal (m, i, sig->params [i], mspecs [i + 1], 0, &csig->params [i], MARSHAL_ACTION_MANAGED_CONV_IN);
 		}
 	}
 
@@ -8520,318 +3586,6 @@ mono_marshal_emit_managed_wrapper (MonoMethodBuilder *mb, MonoMethodSignature *i
 			break;
 		}
 	}
-#else
-	MonoMethodSignature *sig, *csig;
-	MonoExceptionClause *clauses, *clause_finally, *clause_catch;
-	int i, *tmp_locals, ex_local, e_local, attach_cookie_local, attach_dummy_local;
-	int leave_try_pos, leave_catch_pos, ex_m1_pos;
-	gboolean closed = FALSE;
-
-	sig = m->sig;
-	csig = m->csig;
-
-	/* allocate local 0 (pointer) src_ptr */
-	mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-	/* allocate local 1 (pointer) dst_ptr */
-	mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-	/* allocate local 2 (boolean) delete_old */
-	mono_mb_add_local (mb, &mono_defaults.boolean_class->byval_arg);
-
-	if (!sig->hasthis && sig->param_count != invoke_sig->param_count) {
-		/* Closed delegate */
-		g_assert (sig->param_count == invoke_sig->param_count + 1);
-		closed = TRUE;
-		/* Use a new signature without the first argument */
-		sig = mono_metadata_signature_dup (sig);
-		memmove (&sig->params [0], &sig->params [1], (sig->param_count - 1) * sizeof (MonoType*));
-		sig->param_count --;
-	}
-
-	if (!MONO_TYPE_IS_VOID(sig->ret)) {
-		/* allocate local 3 to store the return value */
-		mono_mb_add_local (mb, sig->ret);
-	}
-
-	if (MONO_TYPE_ISSTRUCT (sig->ret))
-		m->vtaddr_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-
-	ex_local = mono_mb_add_local (mb, &mono_defaults.uint32_class->byval_arg);
-	e_local = mono_mb_add_local (mb, &mono_defaults.exception_class->byval_arg);
-
-	attach_cookie_local = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-	attach_dummy_local = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-
-	/*
-	 * guint32 ex = -1;
-	 * try {
-	 *   // does (STARTING|RUNNING|BLOCKING) -> RUNNING + set/switch domain
-	 *   mono_threads_attach_coop ();
-	 *
-	 *   <interrupt check>
-	 *
-	 *   ret = method (...);
-	 * } catch (Exception e) {
-	 *   ex = mono_gchandle_new (e, false);
-	 * } finally {
-	 *   // does RUNNING -> (RUNNING|BLOCKING) + unset/switch domain
-	 *   mono_threads_detach_coop ();
-	 *
-	 *   if (ex != -1)
-	 *     mono_marshal_ftnptr_eh_callback (ex);
-	 * }
-	 *
-	 * return ret;
-	 */
-
-	clauses = g_new0 (MonoExceptionClause, 2);
-
-	clause_catch = &clauses [0];
-	clause_catch->flags = MONO_EXCEPTION_CLAUSE_NONE;
-	clause_catch->data.catch_class = mono_defaults.exception_class;
-
-	clause_finally = &clauses [1];
-	clause_finally->flags = MONO_EXCEPTION_CLAUSE_FINALLY;
-
-	mono_mb_emit_icon (mb, 0);
-	mono_mb_emit_stloc (mb, 2);
-
-	mono_mb_emit_icon (mb, -1);
-	mono_mb_emit_byte (mb, CEE_CONV_U4);
-	mono_mb_emit_stloc (mb, ex_local);
-
-	/* try { */
-	clause_catch->try_offset = clause_finally->try_offset = mono_mb_get_label (mb);
-
-	if (!mono_threads_is_blocking_transition_enabled ()) {
-		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-		mono_mb_emit_byte (mb, CEE_MONO_JIT_ATTACH);
-	} else {
-		/* mono_threads_attach_coop (); */
-		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-		mono_mb_emit_byte (mb, CEE_MONO_LDDOMAIN);
-		mono_mb_emit_ldloc_addr (mb, attach_dummy_local);
-		/*
-		 * This icall is special cased in the JIT so it works in native-to-managed wrappers in unattached threads.
-		 * Keep this in sync with the CEE_JIT_ICALL code in the JIT.
-		 */
-		mono_mb_emit_icall (mb, mono_threads_attach_coop);
-		mono_mb_emit_stloc (mb, attach_cookie_local);
-	}
-
-	/* <interrupt check> */
-	emit_thread_interrupt_checkpoint (mb);
-
-	/* we first do all conversions */
-	tmp_locals = (int *)alloca (sizeof (int) * sig->param_count);
-	for (i = 0; i < sig->param_count; i ++) {
-		MonoType *t = sig->params [i];
-
-		switch (t->type) {
-		case MONO_TYPE_OBJECT:
-		case MONO_TYPE_CLASS:
-		case MONO_TYPE_VALUETYPE:
-		case MONO_TYPE_ARRAY:
-		case MONO_TYPE_SZARRAY:
-		case MONO_TYPE_STRING:
-		case MONO_TYPE_BOOLEAN:
-			tmp_locals [i] = emit_marshal (m, i, sig->params [i], mspecs [i + 1], 0, &csig->params [i], MARSHAL_ACTION_MANAGED_CONV_IN);
-
-			break;
-		default:
-			tmp_locals [i] = 0;
-			break;
-		}
-	}
-
-	if (sig->hasthis) {
-		if (target_handle) {
-			mono_mb_emit_icon (mb, (gint32)target_handle);
-			mono_mb_emit_icall (mb, mono_gchandle_get_target);
-		} else {
-			/* fixme: */
-			g_assert_not_reached ();
-		}
-	} else if (closed) {
-		mono_mb_emit_icon (mb, (gint32)target_handle);
-		mono_mb_emit_icall (mb, mono_gchandle_get_target);
-	}
-
-	for (i = 0; i < sig->param_count; i++) {
-		MonoType *t = sig->params [i];
-
-		if (tmp_locals [i]) {
-			if (t->byref)
-				mono_mb_emit_ldloc_addr (mb, tmp_locals [i]);
-			else
-				mono_mb_emit_ldloc (mb, tmp_locals [i]);
-		}
-		else
-			mono_mb_emit_ldarg (mb, i);
-	}
-
-	/* ret = method (...) */
-	mono_mb_emit_managed_call (mb, method, NULL);
-
-	if (MONO_TYPE_ISSTRUCT (sig->ret)) {
-		MonoClass *klass = mono_class_from_mono_type (sig->ret);
-		mono_class_init (klass);
-		if (!(mono_class_is_explicit_layout (klass) || klass->blittable)) {
-			/* This is used by emit_marshal_vtype (), but it needs to go right before the call */
-			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-			mono_mb_emit_byte (mb, CEE_MONO_VTADDR);
-			mono_mb_emit_stloc (mb, m->vtaddr_var);
-		}
-	}
-
-	if (mspecs [0] && mspecs [0]->native == MONO_NATIVE_CUSTOM) {
-		emit_marshal (m, 0, sig->ret, mspecs [0], 0, NULL, MARSHAL_ACTION_MANAGED_CONV_RESULT);
-	} else if (!sig->ret->byref) { 
-		switch (sig->ret->type) {
-		case MONO_TYPE_VOID:
-			break;
-		case MONO_TYPE_BOOLEAN:
-		case MONO_TYPE_I1:
-		case MONO_TYPE_U1:
-		case MONO_TYPE_CHAR:
-		case MONO_TYPE_I2:
-		case MONO_TYPE_U2:
-		case MONO_TYPE_I4:
-		case MONO_TYPE_U4:
-		case MONO_TYPE_I:
-		case MONO_TYPE_U:
-		case MONO_TYPE_PTR:
-		case MONO_TYPE_R4:
-		case MONO_TYPE_R8:
-		case MONO_TYPE_I8:
-		case MONO_TYPE_U8:
-		case MONO_TYPE_OBJECT:
-			mono_mb_emit_stloc (mb, 3);
-			break;
-		case MONO_TYPE_STRING:
-			csig->ret = &mono_defaults.int_class->byval_arg;
-			emit_marshal (m, 0, sig->ret, mspecs [0], 0, NULL, MARSHAL_ACTION_MANAGED_CONV_RESULT);
-			break;
-		case MONO_TYPE_VALUETYPE:
-		case MONO_TYPE_CLASS:
-		case MONO_TYPE_SZARRAY:
-			emit_marshal (m, 0, sig->ret, mspecs [0], 0, NULL, MARSHAL_ACTION_MANAGED_CONV_RESULT);
-			break;
-		default:
-			g_warning ("return type 0x%02x unknown", sig->ret->type);	
-			g_assert_not_reached ();
-		}
-	} else {
-		mono_mb_emit_stloc (mb, 3);
-	}
-
-	/* Convert byref arguments back */
-	for (i = 0; i < sig->param_count; i ++) {
-		MonoType *t = sig->params [i];
-		MonoMarshalSpec *spec = mspecs [i + 1];
-
-		if (spec && spec->native == MONO_NATIVE_CUSTOM) {
-			emit_marshal (m, i, t, mspecs [i + 1], tmp_locals [i], NULL, MARSHAL_ACTION_MANAGED_CONV_OUT);
-		}
-		else if (t->byref) {
-			switch (t->type) {
-			case MONO_TYPE_CLASS:
-			case MONO_TYPE_VALUETYPE:
-			case MONO_TYPE_OBJECT:
-			case MONO_TYPE_STRING:
-			case MONO_TYPE_BOOLEAN:
-				emit_marshal (m, i, t, mspecs [i + 1], tmp_locals [i], NULL, MARSHAL_ACTION_MANAGED_CONV_OUT);
-				break;
-			default:
-				break;
-			}
-		}
-		else if (invoke_sig->params [i]->attrs & PARAM_ATTRIBUTE_OUT) {
-			/* The [Out] information is encoded in the delegate signature */
-			switch (t->type) {
-			case MONO_TYPE_SZARRAY:
-			case MONO_TYPE_CLASS:
-			case MONO_TYPE_VALUETYPE:
-				emit_marshal (m, i, invoke_sig->params [i], mspecs [i + 1], tmp_locals [i], NULL, MARSHAL_ACTION_MANAGED_CONV_OUT);
-				break;
-			default:
-				g_assert_not_reached ();
-			}
-		}
-	}
-
-	leave_try_pos = mono_mb_emit_branch (mb, CEE_LEAVE);
-
-	/* } [endtry] */
-
-	/* catch (Exception e) { */
-	clause_catch->try_len = mono_mb_get_label (mb) - clause_catch->try_offset;
-	clause_catch->handler_offset = mono_mb_get_label (mb);
-
-	mono_mb_emit_stloc (mb, e_local);
-
-	/* ex = mono_gchandle_new (e, false); */
-	mono_mb_emit_ldloc (mb, e_local);
-	mono_mb_emit_icon (mb, 0);
-	mono_mb_emit_icall (mb, mono_gchandle_new);
-	mono_mb_emit_stloc (mb, ex_local);
-
-	leave_catch_pos = mono_mb_emit_branch (mb, CEE_LEAVE);
-
-	/* } [endcatch] */
-	clause_catch->handler_len = mono_mb_get_pos (mb) - clause_catch->handler_offset;
-
-	/* finally { */
-	clause_finally->try_len = mono_mb_get_label (mb) - clause_finally->try_offset;
-	clause_finally->handler_offset = mono_mb_get_label (mb);
-
-	if (!mono_threads_is_blocking_transition_enabled ()) {
-		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-		mono_mb_emit_byte (mb, CEE_MONO_JIT_DETACH);
-	} else {
-		/* mono_threads_detach_coop (); */
-		mono_mb_emit_ldloc (mb, attach_cookie_local);
-		mono_mb_emit_ldloc_addr (mb, attach_dummy_local);
-		mono_mb_emit_icall (mb, mono_threads_detach_coop);
-	}
-
-	/* if (ex != -1) */
-	mono_mb_emit_ldloc (mb, ex_local);
-	mono_mb_emit_icon (mb, -1);
-	mono_mb_emit_byte (mb, CEE_CONV_U4);
-	ex_m1_pos = mono_mb_emit_branch (mb, CEE_BEQ);
-
-	/* mono_marshal_ftnptr_eh_callback (ex) */
-	mono_mb_emit_ldloc (mb, ex_local);
-	mono_mb_emit_icall (mb, mono_marshal_ftnptr_eh_callback);
-
-	/* [ex == -1] */
-	mono_mb_patch_branch (mb, ex_m1_pos);
-
-	mono_mb_emit_byte (mb, CEE_ENDFINALLY);
-
-	/* } [endfinally] */
-	clause_finally->handler_len = mono_mb_get_pos (mb) - clause_finally->handler_offset;
-
-	mono_mb_patch_branch (mb, leave_try_pos);
-	mono_mb_patch_branch (mb, leave_catch_pos);
-
-	/* return ret; */
-	if (m->retobj_var) {
-		mono_mb_emit_ldloc (mb, m->retobj_var);
-		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-		mono_mb_emit_op (mb, CEE_MONO_RETOBJ, m->retobj_class);
-	}
-	else {
-		if (!MONO_TYPE_IS_VOID(sig->ret))
-			mono_mb_emit_ldloc (mb, 3);
-		mono_mb_emit_byte (mb, CEE_RET);
-	}
-
-	mono_mb_set_clauses (mb, 2, clauses);
-
-	if (closed)
-		g_free (sig);
-#endif
 }
 
 static void 
@@ -9024,9 +3778,7 @@ mono_marshal_get_managed_wrapper (MonoMethod *method, MonoClass *delegate_klass,
 											 mb, csig, sig->param_count + 16,
 											 info, NULL);
 	} else {
-#ifdef ENABLE_ILGEN
-		mb->dynamic = TRUE;
-#endif
+		get_marshal_cb ()->mb_set_dynamic (mb);
 		res = mono_mb_create (mb, csig, sig->param_count + 16, NULL);
 	}
 	mono_mb_free (mb);
@@ -9039,6 +3791,11 @@ mono_marshal_get_managed_wrapper (MonoMethod *method, MonoClass *delegate_klass,
 	/* mono_method_print_code (res); */
 
 	return res;
+}
+
+static void
+emit_vtfixup_ftnptr_noilgen (MonoMethodBuilder *mb, MonoMethod *method, int param_count, guint16 type)
+{
 }
 
 gpointer
@@ -9087,9 +3844,7 @@ mono_marshal_get_vtfixup_ftnptr (MonoImage *image, guint32 token, guint16 type)
 
 		mono_marshal_emit_managed_wrapper (mb, sig, mspecs, &m, method, 0);
 
-#ifdef ENABLE_ILGEN
-		mb->dynamic = TRUE;
-#endif
+		get_marshal_cb ()->mb_set_dynamic (mb);
 		method = mono_mb_create (mb, csig, sig->param_count + 16, NULL);
 		mono_mb_free (mb);
 
@@ -9107,18 +3862,8 @@ mono_marshal_get_vtfixup_ftnptr (MonoImage *image, guint32 token, guint16 type)
 	mb = mono_mb_new (method->klass, method->name, MONO_WRAPPER_MANAGED_TO_MANAGED);
 
 	param_count = sig->param_count + sig->hasthis;
-#ifdef ENABLE_ILGEN
-	for (i = 0; i < param_count; i++)
-		mono_mb_emit_ldarg (mb, i);
-
-	if (type & VTFIXUP_TYPE_CALL_MOST_DERIVED)
-		mono_mb_emit_op (mb, CEE_CALLVIRT, method);
-	else
-		mono_mb_emit_op (mb, CEE_CALL, method);
-	mono_mb_emit_byte (mb, CEE_RET);
-
-	mb->dynamic = TRUE;
-#endif
+	get_marshal_cb ()->emit_vtfixup_ftnptr (mb, method, param_count, type);
+	get_marshal_cb ()->mb_set_dynamic (mb);
 
 	method = mono_mb_create (mb, sig, param_count, NULL);
 	mono_mb_free (mb);
@@ -9128,70 +3873,10 @@ mono_marshal_get_vtfixup_ftnptr (MonoImage *image, guint32 token, guint16 type)
 	return compiled_ptr;
 }
 
-#ifdef ENABLE_ILGEN
-
-/*
- * The code directly following this is the cache hit, value positive branch
- *
- * This function takes a new method builder with 0 locals and adds two locals
- * to create multiple out-branches and the fall through state of having the object
- * on the stack after a cache miss
- */
 static void
-generate_check_cache (int obj_arg_position, int class_arg_position, int cache_arg_position, // In-parameters
-											int *null_obj, int *cache_hit_neg, int *cache_hit_pos, // Out-parameters
-											MonoMethodBuilder *mb)
+emit_castclass_noilgen (MonoMethodBuilder *mb)
 {
-	int cache_miss_pos;
-
-	/* allocate local 0 (pointer) obj_vtable */
-	mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-	/* allocate local 1 (pointer) cached_vtable */
-	mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-
-	/*if (!obj)*/
-	mono_mb_emit_ldarg (mb, obj_arg_position);
-	*null_obj = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-	/*obj_vtable = obj->vtable;*/
-	mono_mb_emit_ldarg (mb, obj_arg_position);
-	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoObject, vtable));
-	mono_mb_emit_byte (mb, CEE_LDIND_I);
-	mono_mb_emit_stloc (mb, 0);
-
-	/* cached_vtable = *cache*/
-	mono_mb_emit_ldarg (mb, cache_arg_position);
-	mono_mb_emit_byte (mb, CEE_LDIND_I);
-	mono_mb_emit_stloc (mb, 1);
-
-	mono_mb_emit_ldloc (mb, 1);
-	mono_mb_emit_byte (mb, CEE_LDC_I4);
-	mono_mb_emit_i4 (mb, ~0x1);
-	mono_mb_emit_byte (mb, CEE_CONV_I);
-	mono_mb_emit_byte (mb, CEE_AND);
-	mono_mb_emit_ldloc (mb, 0);
-	/*if ((cached_vtable & ~0x1)== obj_vtable)*/
-	cache_miss_pos = mono_mb_emit_branch (mb, CEE_BNE_UN);
-
-	/*return (cached_vtable & 0x1) ? NULL : obj;*/
-	mono_mb_emit_ldloc (mb, 1);
-	mono_mb_emit_byte(mb, CEE_LDC_I4_1);
-	mono_mb_emit_byte (mb, CEE_CONV_U);
-	mono_mb_emit_byte (mb, CEE_AND);
-	*cache_hit_neg = mono_mb_emit_branch (mb, CEE_BRTRUE);
-	*cache_hit_pos = mono_mb_emit_branch (mb, CEE_BR);
-
-	// slow path
-	mono_mb_patch_branch (mb, cache_miss_pos);
-
-	// if isinst
-	mono_mb_emit_ldarg (mb, obj_arg_position);
-	mono_mb_emit_ldarg (mb, class_arg_position);
-	mono_mb_emit_ldarg (mb, cache_arg_position);
-	mono_mb_emit_icall (mb, mono_marshal_isinst_with_cache);
 }
-
-#endif /* ENABLE_ILGEN */
 
 /**
  * mono_marshal_get_castclass_with_cache:
@@ -9204,44 +3889,20 @@ mono_marshal_get_castclass_with_cache (void)
 	MonoMethod *res;
 	MonoMethodBuilder *mb;
 	MonoMethodSignature *sig;
-	int return_null_pos, positive_cache_hit_pos, negative_cache_hit_pos, invalid_cast_pos;
 	WrapperInfo *info;
-
-	const int obj_arg_position = 0;
-	const int class_arg_position = 1;
-	const int cache_arg_position = 2;
 
 	if (cached)
 		return cached;
 
 	mb = mono_mb_new (mono_defaults.object_class, "__castclass_with_cache", MONO_WRAPPER_CASTCLASS);
 	sig = mono_metadata_signature_alloc (mono_defaults.corlib, 3);
-	sig->params [obj_arg_position] = &mono_defaults.object_class->byval_arg;
-	sig->params [class_arg_position] = &mono_defaults.int_class->byval_arg;
-	sig->params [cache_arg_position] = &mono_defaults.int_class->byval_arg;
+	sig->params [TYPECHECK_OBJECT_ARG_POS] = &mono_defaults.object_class->byval_arg;
+	sig->params [TYPECHECK_CLASS_ARG_POS] = &mono_defaults.int_class->byval_arg;
+	sig->params [TYPECHECK_CACHE_ARG_POS] = &mono_defaults.int_class->byval_arg;
 	sig->ret = &mono_defaults.object_class->byval_arg;
 	sig->pinvoke = 0;
 
-#ifdef ENABLE_ILGEN
-	generate_check_cache (obj_arg_position, class_arg_position, cache_arg_position, 
-												&return_null_pos, &negative_cache_hit_pos, &positive_cache_hit_pos, mb);
-	invalid_cast_pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-	/*return obj;*/
-	mono_mb_patch_branch (mb, positive_cache_hit_pos);
-	mono_mb_emit_ldarg (mb, obj_arg_position);
-	mono_mb_emit_byte (mb, CEE_RET);
-
-	/*fails*/
-	mono_mb_patch_branch (mb, negative_cache_hit_pos);
-	mono_mb_patch_branch (mb, invalid_cast_pos);
-	mono_mb_emit_exception (mb, "InvalidCastException", NULL);
-
-	/*return null*/
-	mono_mb_patch_branch (mb, return_null_pos);
-	mono_mb_emit_byte (mb, CEE_LDNULL);
-	mono_mb_emit_byte (mb, CEE_RET);
-#endif /* ENABLE_ILGEN */
+	get_marshal_cb ()->emit_castclass (mb);
 
 	info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_CASTCLASS_WITH_CACHE);
 	res = mono_mb_create (mb, sig, 8, info);
@@ -9257,7 +3918,7 @@ mono_marshal_get_castclass_with_cache (void)
 }
 
 /* this is an icall */
-static MonoObject *
+MonoObject *
 mono_marshal_isinst_with_cache (MonoObject *obj, MonoClass *klass, uintptr_t *cache)
 {
 	ERROR_DECL (error);
@@ -9277,6 +3938,11 @@ mono_marshal_isinst_with_cache (MonoObject *obj, MonoClass *klass, uintptr_t *ca
 	return isinst;
 }
 
+static void
+emit_isinst_noilgen (MonoMethodBuilder *mb)
+{
+}
+
 /**
  * mono_marshal_get_isinst_with_cache:
  * This does the equivalent of \c mono_marshal_isinst_with_cache.
@@ -9288,12 +3954,7 @@ mono_marshal_get_isinst_with_cache (void)
 	MonoMethod *res;
 	MonoMethodBuilder *mb;
 	MonoMethodSignature *sig;
-	int return_null_pos, positive_cache_hit_pos, negative_cache_hit_pos;
 	WrapperInfo *info;
-
-	const int obj_arg_position = 0;
-	const int class_arg_position = 1;
-	const int cache_arg_position = 2;
 
 	if (cached)
 		return cached;
@@ -9301,31 +3962,15 @@ mono_marshal_get_isinst_with_cache (void)
 	mb = mono_mb_new (mono_defaults.object_class, "__isinst_with_cache", MONO_WRAPPER_CASTCLASS);
 	sig = mono_metadata_signature_alloc (mono_defaults.corlib, 3);
 	// The object
-	sig->params [obj_arg_position] = &mono_defaults.object_class->byval_arg;
+	sig->params [TYPECHECK_OBJECT_ARG_POS] = &mono_defaults.object_class->byval_arg;
 	// The class
-	sig->params [class_arg_position] = &mono_defaults.int_class->byval_arg;
+	sig->params [TYPECHECK_CLASS_ARG_POS] = &mono_defaults.int_class->byval_arg;
 	// The cache
-	sig->params [cache_arg_position] = &mono_defaults.int_class->byval_arg;
+	sig->params [TYPECHECK_CACHE_ARG_POS] = &mono_defaults.int_class->byval_arg;
 	sig->ret = &mono_defaults.object_class->byval_arg;
 	sig->pinvoke = 0;
 
-#ifdef ENABLE_ILGEN
-	generate_check_cache (obj_arg_position, class_arg_position, cache_arg_position, 
-		&return_null_pos, &negative_cache_hit_pos, &positive_cache_hit_pos, mb);
-	// Return the object gotten via the slow path.
-	mono_mb_emit_byte (mb, CEE_RET);
-
-	// return NULL;
-	mono_mb_patch_branch (mb, negative_cache_hit_pos);
-	mono_mb_patch_branch (mb, return_null_pos);
-	mono_mb_emit_byte (mb, CEE_LDNULL);
-	mono_mb_emit_byte (mb, CEE_RET);
-
-	// return obj
-	mono_mb_patch_branch (mb, positive_cache_hit_pos);
-	mono_mb_emit_ldarg (mb, obj_arg_position);
-	mono_mb_emit_byte (mb, CEE_RET);
-#endif
+	get_marshal_cb ()->emit_isinst (mb);
 
 	info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_ISINST_WITH_CACHE);
 	res = mono_mb_create (mb, sig, 8, info);
@@ -9338,6 +3983,11 @@ mono_marshal_get_isinst_with_cache (void)
 	mono_mb_free (mb);
 
 	return cached;
+}
+
+static void
+emit_struct_to_ptr_noilgen (MonoMethodBuilder *mb, MonoClass *klass)
+{
 }
 
 /**
@@ -9368,39 +4018,8 @@ mono_marshal_get_struct_to_ptr (MonoClass *klass)
 
 	mb = mono_mb_new (klass, stoptr->name, MONO_WRAPPER_UNKNOWN);
 
-#ifdef ENABLE_ILGEN
-	if (klass->blittable) {
-		mono_mb_emit_byte (mb, CEE_LDARG_1);
-		mono_mb_emit_byte (mb, CEE_LDARG_0);
-		mono_mb_emit_ldflda (mb, sizeof (MonoObject));
-		mono_mb_emit_icon (mb, mono_class_value_size (klass, NULL));
-		mono_mb_emit_byte (mb, CEE_PREFIX1);
-		mono_mb_emit_byte (mb, CEE_CPBLK);
-	} else {
+	get_marshal_cb ()->emit_struct_to_ptr (mb, klass);
 
-		/* allocate local 0 (pointer) src_ptr */
-		mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		/* allocate local 1 (pointer) dst_ptr */
-		mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		/* allocate local 2 (boolean) delete_old */
-		mono_mb_add_local (mb, &mono_defaults.boolean_class->byval_arg);
-		mono_mb_emit_byte (mb, CEE_LDARG_2);
-		mono_mb_emit_stloc (mb, 2);
-
-		/* initialize src_ptr to point to the start of object data */
-		mono_mb_emit_byte (mb, CEE_LDARG_0);
-		mono_mb_emit_ldflda (mb, sizeof (MonoObject));
-		mono_mb_emit_stloc (mb, 0);
-
-		/* initialize dst_ptr */
-		mono_mb_emit_byte (mb, CEE_LDARG_1);
-		mono_mb_emit_stloc (mb, 1);
-
-		emit_struct_conv (mb, klass, FALSE);
-	}
-
-	mono_mb_emit_byte (mb, CEE_RET);
-#endif
 	info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_STRUCTURE_TO_PTR);
 	res = mono_mb_create (mb, mono_signature_no_pinvoke (stoptr), 0, info);
 	mono_mb_free (mb);
@@ -9412,6 +4031,11 @@ mono_marshal_get_struct_to_ptr (MonoClass *klass)
 		res = marshal_info->str_to_ptr;
 	mono_marshal_unlock ();
 	return res;
+}
+
+static void
+emit_ptr_to_struct_noilgen (MonoMethodBuilder *mb, MonoClass *klass)
+{
 }
 
 /**
@@ -9450,35 +4074,8 @@ mono_marshal_get_ptr_to_struct (MonoClass *klass)
 
 	mb = mono_mb_new (klass, "PtrToStructure", MONO_WRAPPER_UNKNOWN);
 
-#ifdef ENABLE_ILGEN
-	if (klass->blittable) {
-		mono_mb_emit_byte (mb, CEE_LDARG_1);
-		mono_mb_emit_ldflda (mb, sizeof (MonoObject));
-		mono_mb_emit_byte (mb, CEE_LDARG_0);
-		mono_mb_emit_icon (mb, mono_class_value_size (klass, NULL));
-		mono_mb_emit_byte (mb, CEE_PREFIX1);
-		mono_mb_emit_byte (mb, CEE_CPBLK);
-	} else {
+	get_marshal_cb ()->emit_ptr_to_struct (mb, klass);
 
-		/* allocate local 0 (pointer) src_ptr */
-		mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		/* allocate local 1 (pointer) dst_ptr */
-		mono_mb_add_local (mb, &klass->this_arg);
-		
-		/* initialize src_ptr to point to the start of object data */
-		mono_mb_emit_byte (mb, CEE_LDARG_0);
-		mono_mb_emit_stloc (mb, 0);
-
-		/* initialize dst_ptr */
-		mono_mb_emit_byte (mb, CEE_LDARG_1);
-		mono_mb_emit_ldflda (mb, sizeof (MonoObject));
-		mono_mb_emit_stloc (mb, 1);
-
-		emit_struct_conv (mb, klass, TRUE);
-	}
-
-	mono_mb_emit_byte (mb, CEE_RET);
-#endif
 	info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_PTR_TO_STRUCTURE);
 	res = mono_mb_create (mb, ptostr, 0, info);
 	mono_mb_free (mb);
@@ -9518,10 +4115,9 @@ mono_marshal_get_synchronized_inner_wrapper (MonoMethod *method)
 	}
 
 	mb = mono_mb_new (method->klass, method->name, MONO_WRAPPER_UNKNOWN);
-#ifdef ENABLE_ILGEN
-	mono_mb_emit_exception_full (mb, "System", "ExecutionEngineException", "Shouldn't be called.");
-	mono_mb_emit_byte (mb, CEE_RET);
-#endif
+	get_marshal_cb ()->mb_emit_exception (mb, "System", "ExecutionEngineException", "Shouldn't be called.");
+	get_marshal_cb ()->mb_emit_byte (mb, CEE_RET);
+
 	sig = mono_metadata_signature_dup_full (method->klass->image, mono_method_signature (method));
 
 	info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_SYNCHRONIZED_INNER);
@@ -9536,6 +4132,17 @@ mono_marshal_get_synchronized_inner_wrapper (MonoMethod *method)
 	return res;
 }
 
+static void
+emit_synchronized_wrapper_noilgen (MonoMethodBuilder *mb, MonoMethod *method, MonoGenericContext *ctx, MonoGenericContainer *container, MonoMethod *enter_method, MonoMethod *exit_method, MonoMethod *gettypefromhandle_method)
+{
+	if (method->klass->valuetype && !(method->flags & MONO_METHOD_ATTR_STATIC)) {
+		/* FIXME Is this really the best way to signal an error here?  Isn't this called much later after class setup? -AK */
+		mono_class_set_type_load_failure (method->klass, "");
+		return;
+	}
+
+}
+
 /**
  * mono_marshal_get_synchronized_wrapper:
  * Generates IL code for the synchronized wrapper: the generated method
@@ -9546,12 +4153,10 @@ mono_marshal_get_synchronized_wrapper (MonoMethod *method)
 {
 	static MonoMethod *enter_method, *exit_method, *gettypefromhandle_method;
 	MonoMethodSignature *sig;
-	MonoExceptionClause *clause;
 	MonoMethodBuilder *mb;
 	MonoMethod *res;
 	GHashTable *cache;
 	WrapperInfo *info;
-	int i, pos, pos2, this_local, taken_local, ret_local = 0;
 	MonoGenericContext *ctx = NULL;
 	MonoMethod *orig_method = NULL;
 	MonoGenericContainer *container = NULL;
@@ -9594,43 +4199,6 @@ mono_marshal_get_synchronized_wrapper (MonoMethod *method)
 	info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_NONE);
 	info->d.synchronized.method = method;
 
-#ifdef ENABLE_ILGEN
-	mb->skip_visibility = 1;
-	/* result */
-	if (!MONO_TYPE_IS_VOID (sig->ret))
-		ret_local = mono_mb_add_local (mb, sig->ret);
-#endif
-
-	if (method->klass->valuetype && !(method->flags & MONO_METHOD_ATTR_STATIC)) {
-		/* FIXME Is this really the best way to signal an error here?  Isn't this called much later after class setup? -AK */
-		mono_class_set_type_load_failure (method->klass, "");
-#ifdef ENABLE_ILGEN
-		/* This will throw the type load exception when the wrapper is compiled */
-		mono_mb_emit_byte (mb, CEE_LDNULL);
-		mono_mb_emit_op (mb, CEE_ISINST, method->klass);
-		mono_mb_emit_byte (mb, CEE_POP);
-
-		if (!MONO_TYPE_IS_VOID (sig->ret))
-			mono_mb_emit_ldloc (mb, ret_local);
-		mono_mb_emit_byte (mb, CEE_RET);
-#endif
-
-		res = mono_mb_create_and_cache_full (cache, method,
-											 mb, sig, sig->param_count + 16, info, NULL);
-		mono_mb_free (mb);
-
-		return res;
-	}
-
-#ifdef ENABLE_ILGEN
-	/* this */
-	this_local = mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
-	taken_local = mono_mb_add_local (mb, &mono_defaults.boolean_class->byval_arg);
-
-	clause = (MonoExceptionClause *)mono_image_alloc0 (method->klass->image, sizeof (MonoExceptionClause));
-	clause->flags = MONO_EXCEPTION_CLAUSE_FINALLY;
-#endif
-
 	mono_marshal_lock ();
 
 	if (!enter_method) {
@@ -9654,67 +4222,8 @@ mono_marshal_get_synchronized_wrapper (MonoMethod *method)
 
 	mono_marshal_unlock ();
 
-#ifdef ENABLE_ILGEN
-	/* Push this or the type object */
-	if (method->flags & METHOD_ATTRIBUTE_STATIC) {
-		/* We have special handling for this in the JIT */
-		int index = mono_mb_add_data (mb, method->klass);
-		mono_mb_add_data (mb, mono_defaults.typehandle_class);
-		mono_mb_emit_byte (mb, CEE_LDTOKEN);
-		mono_mb_emit_i4 (mb, index);
-
-		mono_mb_emit_managed_call (mb, gettypefromhandle_method, NULL);
-	}
-	else
-		mono_mb_emit_ldarg (mb, 0);
-	mono_mb_emit_stloc (mb, this_local);
-
-	/* Call Monitor::Enter() */
-	mono_mb_emit_ldloc (mb, this_local);
-	mono_mb_emit_ldloc_addr (mb, taken_local);
-	mono_mb_emit_managed_call (mb, enter_method, NULL);
-
-	clause->try_offset = mono_mb_get_label (mb);
-
-	/* Call the method */
-	if (sig->hasthis)
-		mono_mb_emit_ldarg (mb, 0);
-	for (i = 0; i < sig->param_count; i++)
-		mono_mb_emit_ldarg (mb, i + (sig->hasthis == TRUE));
-
-	if (ctx) {
-		ERROR_DECL (error);
-		mono_mb_emit_managed_call (mb, mono_class_inflate_generic_method_checked (method, &container->context, error), NULL);
-		g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
-	} else {
-		mono_mb_emit_managed_call (mb, method, NULL);
-	}
-
-	if (!MONO_TYPE_IS_VOID (sig->ret))
-		mono_mb_emit_stloc (mb, ret_local);
-
-	pos = mono_mb_emit_branch (mb, CEE_LEAVE);
-
-	clause->try_len = mono_mb_get_pos (mb) - clause->try_offset;
-	clause->handler_offset = mono_mb_get_label (mb);
-
-	/* Call Monitor::Exit() if needed */
-	mono_mb_emit_ldloc (mb, taken_local);
-	pos2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
-	mono_mb_emit_ldloc (mb, this_local);
-	mono_mb_emit_managed_call (mb, exit_method, NULL);
-	mono_mb_patch_branch (mb, pos2);
-	mono_mb_emit_byte (mb, CEE_ENDFINALLY);
-
-	clause->handler_len = mono_mb_get_pos (mb) - clause->handler_offset;
-
-	mono_mb_patch_branch (mb, pos);
-	if (!MONO_TYPE_IS_VOID (sig->ret))
-		mono_mb_emit_ldloc (mb, ret_local);
-	mono_mb_emit_byte (mb, CEE_RET);
-
-	mono_mb_set_clauses (mb, 1, clause);
-#endif
+	get_marshal_cb ()->mb_skip_visibility (mb);
+	get_marshal_cb ()->emit_synchronized_wrapper (mb, method, ctx, container, enter_method, exit_method, gettypefromhandle_method);
 
 	if (ctx) {
 		MonoMethod *def;
@@ -9729,6 +4238,10 @@ mono_marshal_get_synchronized_wrapper (MonoMethod *method)
 	return res;	
 }
 
+static void
+emit_unbox_wrapper_noilgen (MonoMethodBuilder *mb, MonoMethod *method)
+{
+}
 
 /**
  * mono_marshal_get_unbox_wrapper:
@@ -9738,7 +4251,6 @@ MonoMethod *
 mono_marshal_get_unbox_wrapper (MonoMethod *method)
 {
 	MonoMethodSignature *sig = mono_method_signature (method);
-	int i;
 	MonoMethodBuilder *mb;
 	MonoMethod *res;
 	GHashTable *cache;
@@ -9753,15 +4265,7 @@ mono_marshal_get_unbox_wrapper (MonoMethod *method)
 
 	g_assert (sig->hasthis);
 	
-#ifdef ENABLE_ILGEN
-	mono_mb_emit_ldarg (mb, 0); 
-	mono_mb_emit_icon (mb, sizeof (MonoObject));
-	mono_mb_emit_byte (mb, CEE_ADD);
-	for (i = 0; i < sig->param_count; ++i)
-		mono_mb_emit_ldarg (mb, i + 1);
-	mono_mb_emit_managed_call (mb, method, NULL);
-	mono_mb_emit_byte (mb, CEE_RET);
-#endif
+	get_marshal_cb ()->emit_unbox_wrapper (mb, method);
 
 	info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_NONE);
 	info->d.unbox.method = method;
@@ -9774,20 +4278,6 @@ mono_marshal_get_unbox_wrapper (MonoMethod *method)
 
 	return res;	
 }
-
-enum {
-	STELEMREF_OBJECT, /*no check at all*/
-	STELEMREF_SEALED_CLASS, /*check vtable->klass->element_type */
-	STELEMREF_CLASS, /*only the klass->parents check*/
-	STELEMREF_CLASS_SMALL_IDEPTH, /* like STELEMREF_CLASS bit without the idepth check */
-	STELEMREF_INTERFACE, /*interfaces without variant generic arguments. */
-	STELEMREF_COMPLEX, /*arrays, MBR or types with variant generic args - go straight to icalls*/
-	STELEMREF_KIND_COUNT
-};
-
-static const char *strelemref_wrapper_name[] = {
-	"object", "sealed_class", "class", "class_small_idepth", "interface", "complex"
-};
 
 static gboolean
 is_monomorphic_array (MonoClass *klass)
@@ -9830,41 +4320,6 @@ get_virtual_stelemref_kind (MonoClass *element_class)
 	return STELEMREF_CLASS;
 }
 
-#ifdef ENABLE_ILGEN
-
-static void
-load_array_element_address (MonoMethodBuilder *mb)
-{
-	mono_mb_emit_ldarg (mb, 0);
-	mono_mb_emit_ldarg (mb, 1);
-	mono_mb_emit_op (mb, CEE_LDELEMA, mono_defaults.object_class);
-}
-
-static void
-load_array_class (MonoMethodBuilder *mb, int aklass)
-{
-	mono_mb_emit_ldarg (mb, 0);
-	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoObject, vtable));
-	mono_mb_emit_byte (mb, CEE_LDIND_I);
-	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoVTable, klass));
-	mono_mb_emit_byte (mb, CEE_LDIND_I);
-	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, element_class));
-	mono_mb_emit_byte (mb, CEE_LDIND_I);
-	mono_mb_emit_stloc (mb, aklass);
-}
-
-static void
-load_value_class (MonoMethodBuilder *mb, int vklass)
-{
-	mono_mb_emit_ldarg (mb, 2);
-	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoObject, vtable));
-	mono_mb_emit_byte (mb, CEE_LDIND_I);
-	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoVTable, klass));
-	mono_mb_emit_byte (mb, CEE_LDIND_I);
-	mono_mb_emit_stloc (mb, vklass);
-}
-#endif
-
 #if 0
 static void
 record_slot_vstore (MonoObject *array, size_t index, MonoObject *value)
@@ -9874,6 +4329,12 @@ record_slot_vstore (MonoObject *array, size_t index, MonoObject *value)
 	g_free (name);
 }
 #endif
+
+static void
+emit_virtual_stelemref_noilgen (MonoMethodBuilder *mb, const char **param_names, int kind)
+{
+}
+
 
 /*
  * TODO:
@@ -9891,9 +4352,6 @@ get_virtual_stelemref_wrapper (int kind)
 	MonoMethod *res;
 	char *name;
 	const char *param_names [16];
-	guint32 b1, b2, b3, b4;
-	int aklass, vklass, vtable, uiid;
-	int array_slot_addr;
 	WrapperInfo *info;
 
 	if (cached_methods [kind])
@@ -9914,407 +4372,9 @@ get_virtual_stelemref_wrapper (int kind)
 		signature = sig;
 	}
 
-#ifdef ENABLE_ILGEN
 	param_names [0] = "index";
 	param_names [1] = "value";
-	mono_mb_set_param_names (mb, param_names);
-
-	/*For now simply call plain old stelemref*/
-	switch (kind) {
-	case STELEMREF_OBJECT:
-		/* ldelema (implicit bound check) */
-		load_array_element_address (mb);
-		/* do_store */
-		mono_mb_emit_ldarg (mb, 2);
-		mono_mb_emit_byte (mb, CEE_STIND_REF);
-		mono_mb_emit_byte (mb, CEE_RET);
-		break;
-
-	case STELEMREF_COMPLEX: {
-		int b_fast;
-		/*
-		<ldelema (bound check)>
-		if (!value)
-			goto store;
-		if (!mono_object_isinst (value, aklass))
-			goto do_exception;
-
-		 do_store:
-			 *array_slot_addr = value;
-
-		do_exception:
-			throw new ArrayTypeMismatchException ();
-		*/
-
-		aklass = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		vklass = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		array_slot_addr = mono_mb_add_local (mb, &mono_defaults.object_class->this_arg);
-
-#if 0
-		{
-			/*Use this to debug/record stores that are going thru the slow path*/
-			MonoMethodSignature *csig;
-			csig = mono_metadata_signature_alloc (mono_defaults.corlib, 3);
-			csig->ret = &mono_defaults.void_class->byval_arg;
-			csig->params [0] = &mono_defaults.object_class->byval_arg;
-			csig->params [1] = &mono_defaults.int_class->byval_arg; /* this is a natural sized int */
-			csig->params [2] = &mono_defaults.object_class->byval_arg;
-			mono_mb_emit_ldarg (mb, 0);
-			mono_mb_emit_ldarg (mb, 1);
-			mono_mb_emit_ldarg (mb, 2);
-			mono_mb_emit_native_call (mb, csig, record_slot_vstore);
-		}
-#endif
-
-		/* ldelema (implicit bound check) */
-		load_array_element_address (mb);
-		mono_mb_emit_stloc (mb, array_slot_addr);
-
-		/* if (!value) goto do_store */
-		mono_mb_emit_ldarg (mb, 2);
-		b1 = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-		/* aklass = array->vtable->klass->element_class */
-		load_array_class (mb, aklass);
-		/* vklass = value->vtable->klass */
-		load_value_class (mb, vklass);
-
-		/* fastpath */
-		mono_mb_emit_ldloc (mb, vklass);
-		mono_mb_emit_ldloc (mb, aklass);
-		b_fast = mono_mb_emit_branch (mb, CEE_BEQ);
-
-		/*if (mono_object_isinst (value, aklass)) */
-		mono_mb_emit_ldarg (mb, 2);
-		mono_mb_emit_ldloc (mb, aklass);
-		mono_mb_emit_icall (mb, mono_object_isinst_icall);
-		b2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-		/* do_store: */
-		mono_mb_patch_branch (mb, b1);
-		mono_mb_patch_branch (mb, b_fast);
-		mono_mb_emit_ldloc (mb, array_slot_addr);
-		mono_mb_emit_ldarg (mb, 2);
-		mono_mb_emit_byte (mb, CEE_STIND_REF);
-		mono_mb_emit_byte (mb, CEE_RET);
-
-		/* do_exception: */
-		mono_mb_patch_branch (mb, b2);
-
-		mono_mb_emit_exception (mb, "ArrayTypeMismatchException", NULL);
-		break;
-	}
-	case STELEMREF_SEALED_CLASS:
-		/*
-		<ldelema (bound check)>
-		if (!value)
-			goto store;
-
-		aklass = array->vtable->klass->element_class;
-		vklass = value->vtable->klass;
-
-		if (vklass != aklass)
-			goto do_exception;
-
-		do_store:
-			 *array_slot_addr = value;
-
-		do_exception:
-			throw new ArrayTypeMismatchException ();
-		*/
-		aklass = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		vklass = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		array_slot_addr = mono_mb_add_local (mb, &mono_defaults.object_class->this_arg);
-
-		/* ldelema (implicit bound check) */
-		load_array_element_address (mb);
-		mono_mb_emit_stloc (mb, array_slot_addr);
-
-		/* if (!value) goto do_store */
-		mono_mb_emit_ldarg (mb, 2);
-		b1 = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-		/* aklass = array->vtable->klass->element_class */
-		load_array_class (mb, aklass);
-
-		/* vklass = value->vtable->klass */
-		load_value_class (mb, vklass);
-
-		/*if (vklass != aklass) goto do_exception; */
-		mono_mb_emit_ldloc (mb, aklass);
-		mono_mb_emit_ldloc (mb, vklass);
-		b2 = mono_mb_emit_branch (mb, CEE_BNE_UN);
-
-		/* do_store: */
-		mono_mb_patch_branch (mb, b1);
-		mono_mb_emit_ldloc (mb, array_slot_addr);
-		mono_mb_emit_ldarg (mb, 2);
-		mono_mb_emit_byte (mb, CEE_STIND_REF);
-		mono_mb_emit_byte (mb, CEE_RET);
-
-		/* do_exception: */
-		mono_mb_patch_branch (mb, b2);
-		mono_mb_emit_exception (mb, "ArrayTypeMismatchException", NULL);
-		break;
-
-	case STELEMREF_CLASS: {
-		/*
-		the method:
-		<ldelema (bound check)>
-		if (!value)
-			goto do_store;
-
-		aklass = array->vtable->klass->element_class;
-		vklass = value->vtable->klass;
-
-		if (vklass->idepth < aklass->idepth)
-			goto do_exception;
-
-		if (vklass->supertypes [aklass->idepth - 1] != aklass)
-			goto do_exception;
-
-		do_store:
-			*array_slot_addr = value;
-			return;
-
-		long:
-			throw new ArrayTypeMismatchException ();
-		*/
-		aklass = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		vklass = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		array_slot_addr = mono_mb_add_local (mb, &mono_defaults.object_class->this_arg);
-
-		/* ldelema (implicit bound check) */
-		load_array_element_address (mb);
-		mono_mb_emit_stloc (mb, array_slot_addr);
-
-		/* if (!value) goto do_store */
-		mono_mb_emit_ldarg (mb, 2);
-		b1 = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-		/* aklass = array->vtable->klass->element_class */
-		load_array_class (mb, aklass);
-
-		/* vklass = value->vtable->klass */
-		load_value_class (mb, vklass);
-
-		/* if (vklass->idepth < aklass->idepth) goto failue */
-		mono_mb_emit_ldloc (mb, vklass);
-		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, idepth));
-		mono_mb_emit_byte (mb, CEE_LDIND_U2);
-
-		mono_mb_emit_ldloc (mb, aklass);
-		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, idepth));
-		mono_mb_emit_byte (mb, CEE_LDIND_U2);
-
-		b3 = mono_mb_emit_branch (mb, CEE_BLT_UN);
-
-		/* if (vklass->supertypes [aklass->idepth - 1] != aklass) goto failure */
-		mono_mb_emit_ldloc (mb, vklass);
-		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, supertypes));
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-
-		mono_mb_emit_ldloc (mb, aklass);
-		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, idepth));
-		mono_mb_emit_byte (mb, CEE_LDIND_U2);
-		mono_mb_emit_icon (mb, 1);
-		mono_mb_emit_byte (mb, CEE_SUB);
-		mono_mb_emit_icon (mb, sizeof (void*));
-		mono_mb_emit_byte (mb, CEE_MUL);
-		mono_mb_emit_byte (mb, CEE_ADD);
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-
-		mono_mb_emit_ldloc (mb, aklass);
-		b4 = mono_mb_emit_branch (mb, CEE_BNE_UN);
-
-		/* do_store: */
-		mono_mb_patch_branch (mb, b1);
-		mono_mb_emit_ldloc (mb, array_slot_addr);
-		mono_mb_emit_ldarg (mb, 2);
-		mono_mb_emit_byte (mb, CEE_STIND_REF);
-		mono_mb_emit_byte (mb, CEE_RET);
-
-		/* do_exception: */
-		mono_mb_patch_branch (mb, b3);
-		mono_mb_patch_branch (mb, b4);
-
-		mono_mb_emit_exception (mb, "ArrayTypeMismatchException", NULL);
-		break;
-	}
-
-	case STELEMREF_CLASS_SMALL_IDEPTH:
-		/*
-		the method:
-		<ldelema (bound check)>
-		if (!value)
-			goto do_store;
-
-		aklass = array->vtable->klass->element_class;
-		vklass = value->vtable->klass;
-
-		if (vklass->supertypes [aklass->idepth - 1] != aklass)
-			goto do_exception;
-
-		do_store:
-			*array_slot_addr = value;
-			return;
-
-		long:
-			throw new ArrayTypeMismatchException ();
-		*/
-		aklass = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		vklass = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		array_slot_addr = mono_mb_add_local (mb, &mono_defaults.object_class->this_arg);
-
-		/* ldelema (implicit bound check) */
-		load_array_element_address (mb);
-		mono_mb_emit_stloc (mb, array_slot_addr);
-
-		/* if (!value) goto do_store */
-		mono_mb_emit_ldarg (mb, 2);
-		b1 = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-		/* aklass = array->vtable->klass->element_class */
-		load_array_class (mb, aklass);
-
-		/* vklass = value->vtable->klass */
-		load_value_class (mb, vklass);
-
-		/* if (vklass->supertypes [aklass->idepth - 1] != aklass) goto failure */
-		mono_mb_emit_ldloc (mb, vklass);
-		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, supertypes));
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-
-		mono_mb_emit_ldloc (mb, aklass);
-		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, idepth));
-		mono_mb_emit_byte (mb, CEE_LDIND_U2);
-		mono_mb_emit_icon (mb, 1);
-		mono_mb_emit_byte (mb, CEE_SUB);
-		mono_mb_emit_icon (mb, sizeof (void*));
-		mono_mb_emit_byte (mb, CEE_MUL);
-		mono_mb_emit_byte (mb, CEE_ADD);
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-
-		mono_mb_emit_ldloc (mb, aklass);
-		b4 = mono_mb_emit_branch (mb, CEE_BNE_UN);
-
-		/* do_store: */
-		mono_mb_patch_branch (mb, b1);
-		mono_mb_emit_ldloc (mb, array_slot_addr);
-		mono_mb_emit_ldarg (mb, 2);
-		mono_mb_emit_byte (mb, CEE_STIND_REF);
-		mono_mb_emit_byte (mb, CEE_RET);
-
-		/* do_exception: */
-		mono_mb_patch_branch (mb, b4);
-
-		mono_mb_emit_exception (mb, "ArrayTypeMismatchException", NULL);
-		break;
-
-	case STELEMREF_INTERFACE:
-		/*Mono *klass;
-		MonoVTable *vt;
-		unsigned uiid;
-		if (value == NULL)
-			goto store;
-
-		klass = array->obj.vtable->klass->element_class;
-		vt = value->vtable;
-		uiid = klass->interface_id;
-		if (uiid > vt->max_interface_id)
-			goto exception;
-		if (!(vt->interface_bitmap [(uiid) >> 3] & (1 << ((uiid)&7))))
-			goto exception;
-		store:
-			mono_array_setref (array, index, value);
-			return;
-		exception:
-			mono_raise_exception (mono_get_exception_array_type_mismatch ());*/
-
-		array_slot_addr = mono_mb_add_local (mb, &mono_defaults.object_class->this_arg);
-		aklass = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		vtable = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		uiid = mono_mb_add_local (mb, &mono_defaults.int32_class->byval_arg);
-
-		/* ldelema (implicit bound check) */
-		load_array_element_address (mb);
-		mono_mb_emit_stloc (mb, array_slot_addr);
-
-		/* if (!value) goto do_store */
-		mono_mb_emit_ldarg (mb, 2);
-		b1 = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-		/* klass = array->vtable->klass->element_class */
-		load_array_class (mb, aklass);
-
-		/* vt = value->vtable */
-		mono_mb_emit_ldarg (mb, 2);
-		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoObject, vtable));
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_stloc (mb, vtable);
-
-		/* uiid = klass->interface_id; */
-		mono_mb_emit_ldloc (mb, aklass);
-		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, interface_id));
-		mono_mb_emit_byte (mb, CEE_LDIND_U4);
-		mono_mb_emit_stloc (mb, uiid);
-
-		/*if (uiid > vt->max_interface_id)*/
-		mono_mb_emit_ldloc (mb, uiid);
-		mono_mb_emit_ldloc (mb, vtable);
-		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoVTable, max_interface_id));
-		mono_mb_emit_byte (mb, CEE_LDIND_U4);
-		b2 = mono_mb_emit_branch (mb, CEE_BGT_UN);
-
-		/* if (!(vt->interface_bitmap [(uiid) >> 3] & (1 << ((uiid)&7)))) */
-
-		/*vt->interface_bitmap*/
-		mono_mb_emit_ldloc (mb, vtable);
-		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoVTable, interface_bitmap));
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-
-		/*uiid >> 3*/
-		mono_mb_emit_ldloc (mb, uiid);
-		mono_mb_emit_icon (mb, 3);
-		mono_mb_emit_byte (mb, CEE_SHR_UN);
-
-		/*vt->interface_bitmap [(uiid) >> 3]*/
-		mono_mb_emit_byte (mb, CEE_ADD); /*interface_bitmap is a guint8 array*/
-		mono_mb_emit_byte (mb, CEE_LDIND_U1);
-
-		/*(1 << ((uiid)&7)))*/
-		mono_mb_emit_icon (mb, 1);
-		mono_mb_emit_ldloc (mb, uiid);
-		mono_mb_emit_icon (mb, 7);
-		mono_mb_emit_byte (mb, CEE_AND);
-		mono_mb_emit_byte (mb, CEE_SHL);
-
-		/*bitwise and the whole thing*/
-		mono_mb_emit_byte (mb, CEE_AND);
-		b3 = mono_mb_emit_branch (mb, CEE_BRFALSE);
-
-		/* do_store: */
-		mono_mb_patch_branch (mb, b1);
-		mono_mb_emit_ldloc (mb, array_slot_addr);
-		mono_mb_emit_ldarg (mb, 2);
-		mono_mb_emit_byte (mb, CEE_STIND_REF);
-		mono_mb_emit_byte (mb, CEE_RET);
-
-		/* do_exception: */
-		mono_mb_patch_branch (mb, b2);
-		mono_mb_patch_branch (mb, b3);
-		mono_mb_emit_exception (mb, "ArrayTypeMismatchException", NULL);
-		break;
-
-	default:
-		mono_mb_emit_ldarg (mb, 0);
-		mono_mb_emit_ldarg (mb, 1);
-		mono_mb_emit_ldarg (mb, 2);
-		mono_mb_emit_managed_call (mb, mono_marshal_get_stelemref (), NULL);
-		mono_mb_emit_byte (mb, CEE_RET);
-		g_assert (0);
-	}
-#endif /* ENABLE_ILGEN */
+	get_marshal_cb ()->emit_virtual_stelemref (mb, param_names, kind);
 	info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_VIRTUAL_STELEMREF);
 	info->d.virtual_stelemref.kind = kind;
 	res = mono_mb_create (mb, signature, 4, info);
@@ -10357,6 +4417,11 @@ mono_marshal_get_virtual_stelemref_wrappers (int *nwrappers)
 	return res;
 }
 
+static void
+emit_stelemref_noilgen (MonoMethodBuilder *mb)
+{
+}
+
 /**
  * mono_marshal_get_stelemref:
  */
@@ -10367,11 +4432,6 @@ mono_marshal_get_stelemref (void)
 	MonoMethodSignature *sig;
 	MonoMethodBuilder *mb;
 	WrapperInfo *info;
-	
-	guint32 b1, b2, b3, b4;
-	guint32 copy_pos;
-	int aklass, vklass;
-	int array_slot_addr;
 	
 	if (ret)
 		return ret;
@@ -10387,123 +4447,18 @@ mono_marshal_get_stelemref (void)
 	sig->params [1] = &mono_defaults.int_class->byval_arg; /* this is a natural sized int */
 	sig->params [2] = &mono_defaults.object_class->byval_arg;
 
-#ifdef ENABLE_ILGEN
-	aklass = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-	vklass = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-	array_slot_addr = mono_mb_add_local (mb, &mono_defaults.object_class->this_arg);
-	
-	/*
-	the method:
-	<ldelema (bound check)>
-	if (!value)
-		goto store;
-	
-	aklass = array->vtable->klass->element_class;
-	vklass = value->vtable->klass;
-	
-	if (vklass->idepth < aklass->idepth)
-		goto long;
-	
-	if (vklass->supertypes [aklass->idepth - 1] != aklass)
-		goto long;
-	
-	store:
-		*array_slot_addr = value;
-		return;
-	
-	long:
-		if (mono_object_isinst (value, aklass))
-			goto store;
-		
-		throw new ArrayTypeMismatchException ();
-	*/
-	
-	/* ldelema (implicit bound check) */
-	mono_mb_emit_ldarg (mb, 0);
-	mono_mb_emit_ldarg (mb, 1);
-	mono_mb_emit_op (mb, CEE_LDELEMA, mono_defaults.object_class);
-	mono_mb_emit_stloc (mb, array_slot_addr);
-		
-	/* if (!value) goto do_store */
-	mono_mb_emit_ldarg (mb, 2);
-	b1 = mono_mb_emit_branch (mb, CEE_BRFALSE);
-	
-	/* aklass = array->vtable->klass->element_class */
-	mono_mb_emit_ldarg (mb, 0);
-	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoObject, vtable));
-	mono_mb_emit_byte (mb, CEE_LDIND_I);
-	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoVTable, klass));
-	mono_mb_emit_byte (mb, CEE_LDIND_I);
-	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, element_class));
-	mono_mb_emit_byte (mb, CEE_LDIND_I);
-	mono_mb_emit_stloc (mb, aklass);
-	
-	/* vklass = value->vtable->klass */
-	mono_mb_emit_ldarg (mb, 2);
-	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoObject, vtable));
-	mono_mb_emit_byte (mb, CEE_LDIND_I);
-	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoVTable, klass));
-	mono_mb_emit_byte (mb, CEE_LDIND_I);
-	mono_mb_emit_stloc (mb, vklass);
-	
-	/* if (vklass->idepth < aklass->idepth) goto failue */
-	mono_mb_emit_ldloc (mb, vklass);
-	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, idepth));
-	mono_mb_emit_byte (mb, CEE_LDIND_U2);
-	
-	mono_mb_emit_ldloc (mb, aklass);
-	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, idepth));
-	mono_mb_emit_byte (mb, CEE_LDIND_U2);
-	
-	b2 = mono_mb_emit_branch (mb, CEE_BLT_UN);
-	
-	/* if (vklass->supertypes [aklass->idepth - 1] != aklass) goto failure */
-	mono_mb_emit_ldloc (mb, vklass);
-	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, supertypes));
-	mono_mb_emit_byte (mb, CEE_LDIND_I);
-	
-	mono_mb_emit_ldloc (mb, aklass);
-	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoClass, idepth));
-	mono_mb_emit_byte (mb, CEE_LDIND_U2);
-	mono_mb_emit_icon (mb, 1);
-	mono_mb_emit_byte (mb, CEE_SUB);
-	mono_mb_emit_icon (mb, sizeof (void*));
-	mono_mb_emit_byte (mb, CEE_MUL);
-	mono_mb_emit_byte (mb, CEE_ADD);
-	mono_mb_emit_byte (mb, CEE_LDIND_I);
-	
-	mono_mb_emit_ldloc (mb, aklass);
-	
-	b3 = mono_mb_emit_branch (mb, CEE_BNE_UN);
-	
-	copy_pos = mono_mb_get_label (mb);
-	/* do_store */
-	mono_mb_patch_branch (mb, b1);
-	mono_mb_emit_ldloc (mb, array_slot_addr);
-	mono_mb_emit_ldarg (mb, 2);
-	mono_mb_emit_byte (mb, CEE_STIND_REF);
-	
-	mono_mb_emit_byte (mb, CEE_RET);
-	
-	/* the hard way */
-	mono_mb_patch_branch (mb, b2);
-	mono_mb_patch_branch (mb, b3);
-	
-	mono_mb_emit_ldarg (mb, 2);
-	mono_mb_emit_ldloc (mb, aklass);
-	mono_mb_emit_icall (mb, mono_object_isinst_icall);
-	
-	b4 = mono_mb_emit_branch (mb, CEE_BRTRUE);
-	mono_mb_patch_addr (mb, b4, copy_pos - (b4 + 4));
-	mono_mb_emit_exception (mb, "ArrayTypeMismatchException", NULL);
-	
-	mono_mb_emit_byte (mb, CEE_RET);
-#endif
+	get_marshal_cb ()->emit_stelemref (mb);
+
 	info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_NONE);
 	ret = mono_mb_create (mb, sig, 4, info);
 	mono_mb_free (mb);
 
 	return ret;
+}
+
+static void
+mb_emit_byte_noilgen (MonoMethodBuilder *mb, guint8 op)
+{
 }
 
 /*
@@ -10527,12 +4482,11 @@ mono_marshal_get_gsharedvt_in_wrapper (void)
 	sig = mono_metadata_signature_alloc (mono_defaults.corlib, 0);
 	sig->ret = &mono_defaults.void_class->byval_arg;
 
-#ifdef ENABLE_ILGEN
 	/*
 	 * The body is generated by the JIT, we use a wrapper instead of a trampoline so EH works.
 	 */
-	mono_mb_emit_byte (mb, CEE_RET);
-#endif
+	get_marshal_cb ()->mb_emit_byte (mb, CEE_RET);
+
 	info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_GSHAREDVT_IN);
 	ret = mono_mb_create (mb, sig, 4, info);
 	mono_mb_free (mb);
@@ -10561,17 +4515,21 @@ mono_marshal_get_gsharedvt_out_wrapper (void)
 	sig = mono_metadata_signature_alloc (mono_defaults.corlib, 0);
 	sig->ret = &mono_defaults.void_class->byval_arg;
 
-#ifdef ENABLE_ILGEN
 	/*
 	 * The body is generated by the JIT, we use a wrapper instead of a trampoline so EH works.
 	 */
-	mono_mb_emit_byte (mb, CEE_RET);
-#endif
+	get_marshal_cb ()->mb_emit_byte (mb, CEE_RET);
+
 	info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_GSHAREDVT_OUT);
 	ret = mono_mb_create (mb, sig, 4, info);
 	mono_mb_free (mb);
 
 	return ret;
+}
+
+static void
+emit_array_address_noilgen (MonoMethodBuilder *mb, int rank, int elem_size)
+{
 }
 
 typedef struct {
@@ -10604,13 +4562,11 @@ mono_marshal_get_array_address (int rank, int elem_size)
 	MonoMethodSignature *sig;
 	WrapperInfo *info;
 	char *name;
-	int i, bounds, ind, realidx;
-	int branch_pos, *branch_positions;
 	int cached;
 
 	ret = NULL;
 	mono_marshal_lock ();
-	for (i = 0; i < elem_addr_cache_next; ++i) {
+	for (int i = 0; i < elem_addr_cache_next; ++i) {
 		if (elem_addr_cache [i].rank == rank && elem_addr_cache [i].elem_size == elem_size) {
 			ret = elem_addr_cache [i].method;
 			break;
@@ -10620,14 +4576,12 @@ mono_marshal_get_array_address (int rank, int elem_size)
 	if (ret)
 		return ret;
 
-	branch_positions = g_new0 (int, rank);
-
 	sig = mono_metadata_signature_alloc (mono_defaults.corlib, 1 + rank);
 
 	/* void* address (void* array, int idx0, int idx1, int idx2, ...) */
 	sig->ret = &mono_defaults.int_class->byval_arg;
 	sig->params [0] = &mono_defaults.object_class->byval_arg;
-	for (i = 0; i < rank; ++i) {
+	for (int i = 0; i < rank; ++i) {
 		sig->params [i + 1] = &mono_defaults.int32_class->byval_arg;
 	}
 
@@ -10635,103 +4589,7 @@ mono_marshal_get_array_address (int rank, int elem_size)
 	mb = mono_mb_new (mono_defaults.object_class, name, MONO_WRAPPER_MANAGED_TO_MANAGED);
 	g_free (name);
 	
-#ifdef ENABLE_ILGEN
-	bounds = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-	ind = mono_mb_add_local (mb, &mono_defaults.int32_class->byval_arg);
-	realidx = mono_mb_add_local (mb, &mono_defaults.int32_class->byval_arg);
-
-	/* bounds = array->bounds; */
-	mono_mb_emit_ldarg (mb, 0);
-	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoArray, bounds));
-	mono_mb_emit_byte (mb, CEE_LDIND_I);
-	mono_mb_emit_stloc (mb, bounds);
-
-	/* ind is the overall element index, realidx is the partial index in a single dimension */
-	/* ind = idx0 - bounds [0].lower_bound */
-	mono_mb_emit_ldarg (mb, 1);
-	mono_mb_emit_ldloc (mb, bounds);
-	mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoArrayBounds, lower_bound));
-	mono_mb_emit_byte (mb, CEE_ADD);
-	mono_mb_emit_byte (mb, CEE_LDIND_I4);
-	mono_mb_emit_byte (mb, CEE_SUB);
-	mono_mb_emit_stloc (mb, ind);
-	/* if (ind >= bounds [0].length) goto exeception; */
-	mono_mb_emit_ldloc (mb, ind);
-	mono_mb_emit_ldloc (mb, bounds);
-	mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoArrayBounds, length));
-	mono_mb_emit_byte (mb, CEE_ADD);
-	mono_mb_emit_byte (mb, CEE_LDIND_I4);
-	/* note that we use unsigned comparison */
-	branch_pos = mono_mb_emit_branch (mb, CEE_BGE_UN);
-
- 	/* For large ranks (> 4?) use a loop n IL later to reduce code size.
-	 * We could also decide to ignore the passed elem_size and get it
-	 * from the array object, to reduce the number of methods we generate:
-	 * the additional cost is 3 memory loads and a non-immediate mul.
-	 */
-	for (i = 1; i < rank; ++i) {
-		/* realidx = idxi - bounds [i].lower_bound */
-		mono_mb_emit_ldarg (mb, 1 + i);
-		mono_mb_emit_ldloc (mb, bounds);
-		mono_mb_emit_icon (mb, (i * sizeof (MonoArrayBounds)) + MONO_STRUCT_OFFSET (MonoArrayBounds, lower_bound));
-		mono_mb_emit_byte (mb, CEE_ADD);
-		mono_mb_emit_byte (mb, CEE_LDIND_I4);
-		mono_mb_emit_byte (mb, CEE_SUB);
-		mono_mb_emit_stloc (mb, realidx);
-		/* if (realidx >= bounds [i].length) goto exeception; */
-		mono_mb_emit_ldloc (mb, realidx);
-		mono_mb_emit_ldloc (mb, bounds);
-		mono_mb_emit_icon (mb, (i * sizeof (MonoArrayBounds)) + MONO_STRUCT_OFFSET (MonoArrayBounds, length));
-		mono_mb_emit_byte (mb, CEE_ADD);
-		mono_mb_emit_byte (mb, CEE_LDIND_I4);
-		branch_positions [i] = mono_mb_emit_branch (mb, CEE_BGE_UN);
-		/* ind = ind * bounds [i].length + realidx */
-		mono_mb_emit_ldloc (mb, ind);
-		mono_mb_emit_ldloc (mb, bounds);
-		mono_mb_emit_icon (mb, (i * sizeof (MonoArrayBounds)) + MONO_STRUCT_OFFSET (MonoArrayBounds, length));
-		mono_mb_emit_byte (mb, CEE_ADD);
-		mono_mb_emit_byte (mb, CEE_LDIND_I4);
-		mono_mb_emit_byte (mb, CEE_MUL);
-		mono_mb_emit_ldloc (mb, realidx);
-		mono_mb_emit_byte (mb, CEE_ADD);
-		mono_mb_emit_stloc (mb, ind);
-	}
-
-	/* return array->vector + ind * element_size */
-	mono_mb_emit_ldarg (mb, 0);
-	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoArray, vector));
-	mono_mb_emit_ldloc (mb, ind);
-	if (elem_size) {
-		mono_mb_emit_icon (mb, elem_size);
-	} else {
-		/* Load arr->vtable->klass->sizes.element_class */
-		mono_mb_emit_ldarg (mb, 0);
-		mono_mb_emit_byte (mb, CEE_CONV_I);
-		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoObject, vtable));
-		mono_mb_emit_byte (mb, CEE_ADD);
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoVTable, klass));
-		mono_mb_emit_byte (mb, CEE_ADD);
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		/* sizes is an union, so this reads sizes.element_size */
-		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoClass, sizes));
-		mono_mb_emit_byte (mb, CEE_ADD);
-		mono_mb_emit_byte (mb, CEE_LDIND_I4);
-	}
-		mono_mb_emit_byte (mb, CEE_MUL);
-	mono_mb_emit_byte (mb, CEE_ADD);
-	mono_mb_emit_byte (mb, CEE_RET);
-
-	/* patch the branches to get here and throw */
-	for (i = 1; i < rank; ++i) {
-		mono_mb_patch_branch (mb, branch_positions [i]);
-	}
-	mono_mb_patch_branch (mb, branch_pos);
-	/* throw exception */
-	mono_mb_emit_exception (mb, "IndexOutOfRangeException", NULL);
-
-	g_free (branch_positions);
-#endif /* ENABLE_ILGEN */
+	get_marshal_cb ()->emit_array_address (mb, rank, elem_size);
 
 	info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_ELEMENT_ADDR);
 	info->d.element_addr.rank = rank;
@@ -10742,7 +4600,7 @@ mono_marshal_get_array_address (int rank, int elem_size)
 	/* cache the result */
 	cached = 0;
 	mono_marshal_lock ();
-	for (i = 0; i < elem_addr_cache_next; ++i) {
+	for (int i = 0; i < elem_addr_cache_next; ++i) {
 		if (elem_addr_cache [i].rank == rank && elem_addr_cache [i].elem_size == elem_size) {
 			/* FIXME: free ret */
 			ret = elem_addr_cache [i].method;
@@ -10768,6 +4626,11 @@ mono_marshal_get_array_address (int rank, int elem_size)
 	return ret;
 }
 
+static void
+emit_array_accessor_wrapper_noilgen (MonoMethodBuilder *mb, MonoMethod *method, MonoMethodSignature *sig, MonoGenericContext *ctx)
+{
+}
+
 /*
  * mono_marshal_get_array_accessor_wrapper:
  *
@@ -10780,10 +4643,8 @@ mono_marshal_get_array_accessor_wrapper (MonoMethod *method)
 	MonoMethodBuilder *mb;
 	MonoMethod *res;
 	GHashTable *cache;
-	int i;
 	MonoGenericContext *ctx = NULL;
 	MonoMethod *orig_method = NULL;
-	MonoGenericContainer *container = NULL;
 	WrapperInfo *info;
 
 	/*
@@ -10808,22 +4669,7 @@ mono_marshal_get_array_accessor_wrapper (MonoMethod *method)
 
 	mb = mono_mb_new (method->klass, method->name, MONO_WRAPPER_UNKNOWN);
 
-#ifdef ENABLE_ILGEN
-	/* Call the method */
-	if (sig->hasthis)
-		mono_mb_emit_ldarg (mb, 0);
-	for (i = 0; i < sig->param_count; i++)
-		mono_mb_emit_ldarg (mb, i + (sig->hasthis == TRUE));
-
-	if (ctx) {
-		ERROR_DECL (error);
-		mono_mb_emit_managed_call (mb, mono_class_inflate_generic_method_checked (method, &container->context, error), NULL);
-		g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
-	} else {
-		mono_mb_emit_managed_call (mb, method, NULL);
-	}
-	mono_mb_emit_byte (mb, CEE_RET);
-#endif
+	get_marshal_cb ()->emit_array_accessor_wrapper (mb, method, sig, ctx);
 
 	info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_ARRAY_ACCESSOR);
 	info->d.array_accessor.method = method;
@@ -10872,7 +4718,7 @@ mono_marshal_alloc (gsize size, MonoError *error)
 }
 
 /* This is a JIT icall, it sets the pending exception and returns NULL on error. */
-static void*
+void*
 ves_icall_marshal_alloc (gsize size)
 {
 	ERROR_DECL (error);
@@ -10926,7 +4772,7 @@ mono_marshal_string_to_utf16 (MonoString *s)
 }
 
 /* This is a JIT icall, it sets the pending exception and returns NULL on error. */
-static void *
+void *
 mono_marshal_string_to_utf16_copy (MonoString *s)
 {
 	if (s == NULL) {
@@ -11329,7 +5175,7 @@ ves_icall_System_Runtime_InteropServices_Marshal_StringToHGlobalUni (MonoString 
 }
 #endif /* !HOST_WIN32 */
 
-static void
+void
 mono_struct_delete_old (MonoClass *klass, char *ptr)
 {
 	MonoMarshalType *info;
@@ -12086,6 +5932,11 @@ mono_marshal_free_asany (MonoObject *o, gpointer ptr, MonoMarshalNative string_e
 	}
 }
 
+static void
+emit_generic_array_helper_noilgen (MonoMethodBuilder *mb, MonoMethod *method, MonoMethodSignature *csig)
+{
+}
+
 /*
  * mono_marshal_get_generic_array_helper:
  *
@@ -12099,7 +5950,6 @@ mono_marshal_get_generic_array_helper (MonoClass *klass, gchar *name, MonoMethod
 	MonoMethodBuilder *mb;
 	MonoMethod *res;
 	WrapperInfo *info;
-	int i;
 
 	mb = mono_mb_new_no_dup_name (klass, name, MONO_WRAPPER_MANAGED_TO_MANAGED);
 	mb->method->slot = -1;
@@ -12111,16 +5961,11 @@ mono_marshal_get_generic_array_helper (MonoClass *klass, gchar *name, MonoMethod
 	csig = mono_metadata_signature_dup_full (method->klass->image, sig);
 	csig->generic_param_count = 0;
 
-#ifdef ENABLE_ILGEN
-	mono_mb_emit_ldarg (mb, 0);
-	for (i = 0; i < csig->param_count; i++)
-		mono_mb_emit_ldarg (mb, i + 1);
-	mono_mb_emit_managed_call (mb, method, NULL);
-	mono_mb_emit_byte (mb, CEE_RET);
+	get_marshal_cb ()->emit_generic_array_helper (mb, method, csig);
 
 	/* We can corlib internal methods */
-	mb->skip_visibility = TRUE;
-#endif
+	get_marshal_cb ()->mb_skip_visibility (mb);
+
 	info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_GENERIC_ARRAY_HELPER);
 	info->d.generic_array_helper.method = method;
 	res = mono_mb_create (mb, csig, csig->param_count + 16, info);
@@ -12190,17 +6035,21 @@ mono_marshal_find_nonzero_bit_offset (guint8 *buf, int len, int *byte_offset, gu
 	*bitmask = buf [i];
 }
 
+static void
+emit_thunk_invoke_wrapper_noilgen (MonoMethodBuilder *mb, MonoMethod *method, MonoMethodSignature *csig)
+{
+}
+
 MonoMethod *
 mono_marshal_get_thunk_invoke_wrapper (MonoMethod *method)
 {
 	MonoMethodBuilder *mb;
 	MonoMethodSignature *sig, *csig;
-	MonoExceptionClause *clause;
 	MonoImage *image;
 	MonoClass *klass;
 	GHashTable *cache;
 	MonoMethod *res;
-	int i, param_count, sig_size, pos_leave;
+	int i, param_count, sig_size;
 
 	g_assert (method);
 
@@ -12248,90 +6097,7 @@ mono_marshal_get_thunk_invoke_wrapper (MonoMethod *method)
 	if (MONO_TYPE_ISSTRUCT (sig->ret))
 		csig->ret = &mono_defaults.object_class->byval_arg;
 
-#ifdef ENABLE_ILGEN
-	/* local 0 (temp for exception object) */
-	mono_mb_add_local (mb, &mono_defaults.object_class->byval_arg);
-
-	/* local 1 (temp for result) */
-	if (!MONO_TYPE_IS_VOID (sig->ret))
-		mono_mb_add_local (mb, sig->ret);
-
-	/* clear exception arg */
-	mono_mb_emit_ldarg (mb, param_count - 1);
-	mono_mb_emit_byte (mb, CEE_LDNULL);
-	mono_mb_emit_byte (mb, CEE_STIND_REF);
-
-	/* try */
-	clause = (MonoExceptionClause *)mono_image_alloc0 (image, sizeof (MonoExceptionClause));
-	clause->try_offset = mono_mb_get_label (mb);
-
-	/* push method's args */
-	for (i = 0; i < param_count - 1; i++) {
-		MonoType *type;
-		MonoClass *klass;
-
-		mono_mb_emit_ldarg (mb, i);
-
-		/* get the byval type of the param */
-		klass = mono_class_from_mono_type (csig->params [i]);
-		type = &klass->byval_arg;
-
-		/* unbox struct args */
-		if (MONO_TYPE_ISSTRUCT (type)) {
-			mono_mb_emit_op (mb, CEE_UNBOX, klass);
-
-			/* byref args & and the "this" arg must remain a ptr.
-			   Otherwise make a copy of the value type */
-			if (!(csig->params [i]->byref || (i == 0 && sig->hasthis)))
-				mono_mb_emit_op (mb, CEE_LDOBJ, klass);
-
-			csig->params [i] = &mono_defaults.object_class->byval_arg;
-		}
-	}
-
-	/* call */
-	if (method->flags & METHOD_ATTRIBUTE_VIRTUAL)
-		mono_mb_emit_op (mb, CEE_CALLVIRT, method);
-	else
-		mono_mb_emit_op (mb, CEE_CALL, method);
-
-	/* save result at local 1 */
-	if (!MONO_TYPE_IS_VOID (sig->ret))
-		mono_mb_emit_stloc (mb, 1);
-
-	pos_leave = mono_mb_emit_branch (mb, CEE_LEAVE);
-
-	/* catch */
-	clause->flags = MONO_EXCEPTION_CLAUSE_NONE;
-	clause->try_len = mono_mb_get_pos (mb) - clause->try_offset;
-	clause->data.catch_class = mono_defaults.object_class;
-
-	clause->handler_offset = mono_mb_get_label (mb);
-
-	/* store exception at local 0 */
-	mono_mb_emit_stloc (mb, 0);
-	mono_mb_emit_ldarg (mb, param_count - 1);
-	mono_mb_emit_ldloc (mb, 0);
-	mono_mb_emit_byte (mb, CEE_STIND_REF);
-	mono_mb_emit_branch (mb, CEE_LEAVE);
-
-	clause->handler_len = mono_mb_get_pos (mb) - clause->handler_offset;
-
-	mono_mb_set_clauses (mb, 1, clause);
-
-	mono_mb_patch_branch (mb, pos_leave);
-	/* end-try */
-
-	if (!MONO_TYPE_IS_VOID (sig->ret)) {
-		mono_mb_emit_ldloc (mb, 1);
-
-		/* box the return value */
-		if (MONO_TYPE_ISSTRUCT (sig->ret))
-			mono_mb_emit_op (mb, CEE_BOX, mono_class_from_mono_type (sig->ret));
-	}
-
-	mono_mb_emit_byte (mb, CEE_RET);
-#endif
+	get_marshal_cb ()->emit_thunk_invoke_wrapper (mb, method, csig);
 
 	res = mono_mb_create_and_cache (cache, method, mb, csig, param_count + 16);
 	mono_mb_free (mb);
@@ -12370,7 +6136,7 @@ mono_marshal_free_dynamic_wrappers (MonoMethod *method)
 		mono_marshal_unlock ();
 }
 
-static void
+void
 mono_marshal_ftnptr_eh_callback (guint32 gchandle)
 {
 	g_assert (ftnptr_eh_callback);
@@ -12407,7 +6173,7 @@ mono_install_ftnptr_eh_callback (MonoFtnPtrEHCallback callback)
 	ftnptr_eh_callback = callback;
 }
 
-static MonoThreadInfo*
+MonoThreadInfo*
 mono_icall_start (HandleStackMark *stackmark, MonoError *error)
 {
 	MonoThreadInfo *info = mono_thread_info_current ();
@@ -12417,7 +6183,7 @@ mono_icall_start (HandleStackMark *stackmark, MonoError *error)
 	return info;
 }
 
-static void
+void
 mono_icall_end (MonoThreadInfo *info, HandleStackMark *stackmark, MonoError *error)
 {
 	mono_stack_mark_pop (info, stackmark);
@@ -12425,7 +6191,7 @@ mono_icall_end (MonoThreadInfo *info, HandleStackMark *stackmark, MonoError *err
 		mono_error_set_pending_exception (error);
 }
 
-static MonoObjectHandle
+MonoObjectHandle
 mono_icall_handle_new (gpointer rawobj)
 {
 #ifdef MONO_HANDLE_TRACK_OWNER
@@ -12435,7 +6201,7 @@ mono_icall_handle_new (gpointer rawobj)
 #endif
 }
 
-static MonoObjectHandle
+MonoObjectHandle
 mono_icall_handle_new_interior (gpointer rawobj)
 {
 #ifdef MONO_HANDLE_TRACK_OWNER
@@ -12444,3 +6210,88 @@ mono_icall_handle_new_interior (gpointer rawobj)
 	return mono_handle_new_interior (rawobj);
 #endif
 }
+
+void
+mono_marshal_emit_native_wrapper (MonoImage *image, MonoMethodBuilder *mb, MonoMethodSignature *sig, MonoMethodPInvoke *piinfo, MonoMarshalSpec **mspecs, gpointer func, gboolean aot, gboolean check_exceptions, gboolean func_param)
+{
+	get_marshal_cb ()->emit_native_wrapper (image, mb, sig, piinfo, mspecs, func, aot, check_exceptions, func_param);
+}
+
+static void
+emit_native_wrapper_noilgen (MonoImage *image, MonoMethodBuilder *mb, MonoMethodSignature *sig, MonoMethodPInvoke *piinfo, MonoMarshalSpec **mspecs, gpointer func, gboolean aot, gboolean check_exceptions, gboolean func_param)
+{
+}
+
+static MonoMarshalCallbacks marshal_cb;
+static gboolean cb_inited = FALSE;
+
+void
+mono_install_marshal_callbacks (MonoMarshalCallbacks *cb)
+{
+	g_assert (!cb_inited);
+	g_assert (cb->version == MONO_MARSHAL_CALLBACKS_VERSION);
+	memcpy (&marshal_cb, cb, sizeof (MonoMarshalCallbacks));
+	cb_inited = TRUE;
+}
+
+static void
+install_noilgen (void)
+{
+	MonoMarshalCallbacks cb;
+	cb.version = MONO_MARSHAL_CALLBACKS_VERSION;
+	cb.emit_marshal_array = emit_marshal_array_noilgen;
+	cb.emit_marshal_boolean = emit_marshal_boolean_noilgen;
+	cb.emit_marshal_ptr = emit_marshal_ptr_noilgen;
+	cb.emit_marshal_char = emit_marshal_char_noilgen;
+	cb.emit_marshal_scalar = emit_marshal_scalar_noilgen;
+	cb.emit_marshal_custom = emit_marshal_custom_noilgen;
+	cb.emit_marshal_asany = emit_marshal_asany_noilgen;
+	cb.emit_marshal_vtype = emit_marshal_vtype_noilgen;
+	cb.emit_marshal_string = emit_marshal_string_noilgen;
+	cb.emit_marshal_safehandle = emit_marshal_safehandle_noilgen;
+	cb.emit_marshal_handleref = emit_marshal_handleref_noilgen;
+	cb.emit_marshal_object = emit_marshal_object_noilgen;
+	cb.emit_marshal_variant = emit_marshal_variant_noilgen;
+	cb.emit_castclass = emit_castclass_noilgen;
+	cb.emit_struct_to_ptr = emit_struct_to_ptr_noilgen;
+	cb.emit_ptr_to_struct = emit_ptr_to_struct_noilgen;
+	cb.emit_isinst = emit_isinst_noilgen;
+	cb.emit_virtual_stelemref = emit_virtual_stelemref_noilgen;
+	cb.emit_stelemref = emit_stelemref_noilgen;
+	cb.emit_array_address = emit_array_address_noilgen;
+	cb.emit_native_wrapper = emit_native_wrapper_noilgen;
+	cb.emit_managed_wrapper = emit_managed_wrapper_noilgen;
+	cb.emit_runtime_invoke_body = emit_runtime_invoke_body_noilgen;
+	cb.emit_runtime_invoke_dynamic = emit_runtime_invoke_dynamic_noilgen;
+	cb.emit_delegate_begin_invoke = emit_delegate_begin_invoke_noilgen;
+	cb.emit_delegate_end_invoke = emit_delegate_end_invoke_noilgen;
+	cb.emit_delegate_invoke_internal = emit_delegate_invoke_internal_noilgen;
+	cb.emit_synchronized_wrapper = emit_synchronized_wrapper_noilgen;
+	cb.emit_unbox_wrapper = emit_unbox_wrapper_noilgen;
+	cb.emit_array_accessor_wrapper = emit_array_accessor_wrapper_noilgen;
+	cb.emit_generic_array_helper = emit_generic_array_helper_noilgen;
+	cb.emit_thunk_invoke_wrapper = emit_thunk_invoke_wrapper_noilgen;
+	cb.emit_create_string_hack = emit_create_string_hack_noilgen;
+	cb.emit_native_icall_wrapper = emit_native_icall_wrapper_noilgen;
+	cb.emit_icall_wrapper = emit_icall_wrapper_noilgen;
+	cb.emit_vtfixup_ftnptr = emit_vtfixup_ftnptr_noilgen;
+	cb.mb_skip_visibility = mb_skip_visibility_noilgen;
+	cb.mb_set_dynamic = mb_set_dynamic_noilgen;
+	cb.mb_emit_exception = mb_emit_exception_noilgen;
+	cb.mb_emit_byte = mb_emit_byte_noilgen;
+	mono_install_marshal_callbacks (&cb);
+}
+
+static MonoMarshalCallbacks *
+get_marshal_cb (void)
+{
+	if (G_UNLIKELY (!cb_inited)) {
+#ifdef ENABLE_ILGEN
+		mono_marshal_ilgen_init ();
+#else
+		install_noilgen ();
+#endif
+	}
+	return &marshal_cb;
+}
+

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -105,9 +105,6 @@ mono_byvalarray_to_array (MonoArray *arr, gpointer native_arr, MonoClass *eltype
 static void
 mono_array_to_byvalarray (gpointer native_arr, MonoArray *arr, MonoClass *eltype, guint32 elnum);
 
-static void
-mono_marshal_set_last_error_windows (int error);
-
 gpointer
 mono_delegate_handle_to_ftnptr (MonoDelegateHandle delegate, MonoError *error);
 
@@ -4809,7 +4806,7 @@ mono_marshal_set_last_error (void)
 #endif
 }
 
-static void
+void
 mono_marshal_set_last_error_windows (int error)
 {
 #ifdef WIN32

--- a/mono/metadata/marshal.h
+++ b/mono/metadata/marshal.h
@@ -247,12 +247,77 @@ typedef struct {
 	} d;
 } WrapperInfo;
 
+enum {
+	STELEMREF_OBJECT, /*no check at all*/
+	STELEMREF_SEALED_CLASS, /*check vtable->klass->element_type */
+	STELEMREF_CLASS, /*only the klass->parents check*/
+	STELEMREF_CLASS_SMALL_IDEPTH, /* like STELEMREF_CLASS bit without the idepth check */
+	STELEMREF_INTERFACE, /*interfaces without variant generic arguments. */
+	STELEMREF_COMPLEX, /*arrays, MBR or types with variant generic args - go straight to icalls*/
+	STELEMREF_KIND_COUNT
+};
+
+static const char *strelemref_wrapper_name[] = {
+	"object", "sealed_class", "class", "class_small_idepth", "interface", "complex"
+};
+
+
+#define MONO_MARSHAL_CALLBACKS_VERSION 1
+
+typedef struct {
+	int version;
+	int (*emit_marshal_array) (EmitMarshalContext *m, int argnum, MonoType *t, MonoMarshalSpec *spec, int conv_arg, MonoType **conv_arg_type, MarshalAction action);
+	int (*emit_marshal_boolean) (EmitMarshalContext *m, int argnum, MonoType *t, MonoMarshalSpec *spec, int conv_arg, MonoType **conv_arg_type, MarshalAction action);
+	int (*emit_marshal_ptr) (EmitMarshalContext *m, int argnum, MonoType *t, MonoMarshalSpec *spec, int conv_arg, MonoType **conv_arg_type, MarshalAction action);
+	int (*emit_marshal_char) (EmitMarshalContext *m, int argnum, MonoType *t, MonoMarshalSpec *spec, int conv_arg, MonoType **conv_arg_type, MarshalAction action);
+	int (*emit_marshal_scalar) (EmitMarshalContext *m, int argnum, MonoType *t, MonoMarshalSpec *spec, int conv_arg, MonoType **conv_arg_type, MarshalAction action);
+
+	int (*emit_marshal_custom) (EmitMarshalContext *m, int argnum, MonoType *t, MonoMarshalSpec *spec, int conv_arg, MonoType **conv_arg_type, MarshalAction action);
+	int (*emit_marshal_asany) (EmitMarshalContext *m, int argnum, MonoType *t, MonoMarshalSpec *spec, int conv_arg, MonoType **conv_arg_type, MarshalAction action);
+	int (*emit_marshal_vtype) (EmitMarshalContext *m, int argnum, MonoType *t, MonoMarshalSpec *spec, int conv_arg, MonoType **conv_arg_type, MarshalAction action);
+	int (*emit_marshal_string) (EmitMarshalContext *m, int argnum, MonoType *t, MonoMarshalSpec *spec, int conv_arg, MonoType **conv_arg_type, MarshalAction action);
+	int (*emit_marshal_safehandle) (EmitMarshalContext *m, int argnum, MonoType *t, MonoMarshalSpec *spec, int conv_arg, MonoType **conv_arg_type, MarshalAction action);
+	int (*emit_marshal_handleref) (EmitMarshalContext *m, int argnum, MonoType *t, MonoMarshalSpec *spec, int conv_arg, MonoType **conv_arg_type, MarshalAction action);
+	int (*emit_marshal_object) (EmitMarshalContext *m, int argnum, MonoType *t, MonoMarshalSpec *spec, int conv_arg, MonoType **conv_arg_type, MarshalAction action);
+	int (*emit_marshal_variant) (EmitMarshalContext *m, int argnum, MonoType *t, MonoMarshalSpec *spec, int conv_arg, MonoType **conv_arg_type, MarshalAction action);
+	void (*emit_castclass) (MonoMethodBuilder *mb);
+	void (*emit_struct_to_ptr) (MonoMethodBuilder *mb, MonoClass *klass);
+	void (*emit_ptr_to_struct) (MonoMethodBuilder *mb, MonoClass *klass);
+	void (*emit_isinst) (MonoMethodBuilder *mb);
+	void (*emit_virtual_stelemref) (MonoMethodBuilder *mb, const char **param_names, int kind);
+	void (*emit_stelemref) (MonoMethodBuilder *mb);
+	void (*emit_array_address) (MonoMethodBuilder *mb, int rank, int elem_size);
+	void (*emit_native_wrapper) (MonoImage *image, MonoMethodBuilder *mb, MonoMethodSignature *sig, MonoMethodPInvoke *piinfo, MonoMarshalSpec **mspecs, gpointer func, gboolean aot, gboolean check_exceptions, gboolean func_param);
+	void (*emit_managed_wrapper) (MonoMethodBuilder *mb, MonoMethodSignature *invoke_sig, MonoMarshalSpec **mspecs, EmitMarshalContext* m, MonoMethod *method, uint32_t target_handle);
+	void (*emit_runtime_invoke_body) (MonoMethodBuilder *mb, const char **param_names, MonoImage *image, MonoMethod *method, MonoMethodSignature *sig, MonoMethodSignature *callsig, gboolean virtual_, gboolean need_direct_wrapper);
+	void (*emit_runtime_invoke_dynamic) (MonoMethodBuilder *mb);
+	void (*emit_delegate_begin_invoke) (MonoMethodBuilder *mb, MonoMethodSignature *sig);
+	void (*emit_delegate_end_invoke) (MonoMethodBuilder *mb, MonoMethodSignature *sig);
+	void (*emit_delegate_invoke_internal) (MonoMethodBuilder *mb, MonoMethodSignature *sig, MonoMethodSignature *invoke_sig, gboolean static_method_with_first_arg_bound, gboolean callvirt, gboolean closed_over_null, MonoMethod *method, MonoMethod *target_method, MonoClass *target_class, MonoGenericContext *ctx, MonoGenericContainer *container);
+	void (*emit_synchronized_wrapper) (MonoMethodBuilder *mb, MonoMethod *method, MonoGenericContext *ctx, MonoGenericContainer *container, MonoMethod *enter_method, MonoMethod *exit_method, MonoMethod *gettypefromhandle_method);
+	void (*emit_unbox_wrapper) (MonoMethodBuilder *mb, MonoMethod *method);
+	void (*emit_array_accessor_wrapper) (MonoMethodBuilder *mb, MonoMethod *method, MonoMethodSignature *sig, MonoGenericContext *ctx);
+	void (*emit_generic_array_helper) (MonoMethodBuilder *mb, MonoMethod *method, MonoMethodSignature *csig);
+	void (*emit_thunk_invoke_wrapper) (MonoMethodBuilder *mb, MonoMethod *method, MonoMethodSignature *csig);
+	void (*emit_create_string_hack) (MonoMethodBuilder *mb, MonoMethodSignature *csig, MonoMethod *res);
+	void (*emit_native_icall_wrapper) (MonoMethodBuilder *mb, MonoMethod *method, MonoMethodSignature *csig, gboolean check_exceptions, gboolean aot, MonoMethodPInvoke *pinfo);
+	void (*emit_icall_wrapper) (MonoMethodBuilder *mb, MonoMethodSignature *sig, gconstpointer func, MonoMethodSignature *csig2, gboolean check_exceptions);
+	void (*emit_vtfixup_ftnptr) (MonoMethodBuilder *mb, MonoMethod *method, int param_count, guint16 type);
+	void (*mb_skip_visibility) (MonoMethodBuilder *mb);
+	void (*mb_set_dynamic) (MonoMethodBuilder *mb);
+	void (*mb_emit_exception) (MonoMethodBuilder *mb, const char *exc_nspace, const char *exc_name, const char *msg);
+	void (*mb_emit_byte) (MonoMethodBuilder *mb, guint8 op);
+} MonoMarshalCallbacks;
+
 G_BEGIN_DECLS
 
 /*type of the function pointer of methods returned by mono_marshal_get_runtime_invoke*/
 typedef MonoObject *(*RuntimeInvokeFunction) (MonoObject *this_obj, void **params, MonoObject **exc, void* compiled_method);
 
 typedef void (*RuntimeInvokeDynamicFunction) (void *args, MonoObject **exc, void* compiled_method);
+
+void
+mono_install_marshal_callbacks (MonoMarshalCallbacks *cb);
 
 /* marshaling helper functions */
 
@@ -289,6 +354,18 @@ mono_string_to_bstr(MonoString* str);
 
 void mono_delegate_free_ftnptr (MonoDelegate *delegate);
 
+gpointer
+mono_marshal_asany (MonoObject *obj, MonoMarshalNative string_encoding, int param_attrs);
+
+void
+mono_marshal_free_asany (MonoObject *o, gpointer ptr, MonoMarshalNative string_encoding, int param_attrs);
+
+void
+mono_free_lparray (MonoArray *array, gpointer* nativeArray);
+
+void
+mono_marshal_ftnptr_eh_callback (guint32 gchandle);
+
 void
 mono_marshal_set_last_error (void);
 
@@ -297,6 +374,15 @@ mono_type_to_ldind (MonoType *type);
 
 guint
 mono_type_to_stind (MonoType *type);
+
+void
+mono_byvalarray_to_byte_array (MonoArray *arr, gpointer native_arr, guint32 elnum);
+
+MonoString *
+mono_string_from_byvalstr (const char *data, int len);
+
+MonoString *
+mono_string_from_byvalwstr (gunichar2 *data, int len);
 
 /* functions to create various architecture independent helper functions */
 
@@ -430,6 +516,133 @@ mono_marshal_free_ccw (MonoObject* obj);
 
 void
 cominterop_release_all_rcws (void); 
+
+MonoString*
+ves_icall_mono_string_from_utf16 (gunichar2 *data);
+
+char*
+ves_icall_mono_string_to_utf8 (MonoString *str);
+
+void *
+mono_marshal_string_to_utf16_copy (MonoString *s);
+
+MonoString*
+mono_string_new_len_wrapper (const char *text, guint length);
+
+MonoDelegate*
+mono_ftnptr_to_delegate (MonoClass *klass, gpointer ftn);
+
+MONO_API void *
+mono_marshal_string_to_utf16 (MonoString *s);
+
+#ifndef HOST_WIN32
+gpointer
+mono_string_to_utf8str (MonoString *string_obj);
+#endif
+
+MonoStringBuilder *
+mono_string_utf8_to_builder2 (char *text);
+
+MonoStringBuilder *
+mono_string_utf16_to_builder2 (gunichar2 *text);
+
+gchar*
+mono_string_builder_to_utf8 (MonoStringBuilder *sb);
+
+gunichar2*
+mono_string_builder_to_utf16 (MonoStringBuilder *sb);
+
+void
+mono_string_utf8_to_builder (MonoStringBuilder *sb, char *text);
+
+void
+mono_string_utf16_to_builder (MonoStringBuilder *sb, gunichar2 *text);
+
+void
+mono_string_to_byvalstr (gpointer dst, MonoString *src, int size);
+
+void
+mono_string_to_byvalwstr (gpointer dst, MonoString *src, int size);
+
+gpointer
+mono_delegate_to_ftnptr (MonoDelegate *delegate);
+
+gpointer
+mono_array_to_savearray (MonoArray *array);
+
+void
+mono_free_lparray (MonoArray *array, gpointer* nativeArray);
+
+void
+mono_array_to_byte_byvalarray (gpointer native_arr, MonoArray *arr, guint32 elnum);
+
+gpointer
+mono_array_to_lparray (MonoArray *array);
+
+void 
+mono_struct_delete_old (MonoClass *klass, char *ptr);
+
+MonoObject*
+mono_object_isinst_icall (MonoObject *obj, MonoClass *klass);
+
+MonoString*
+ves_icall_string_new_wrapper (const char *text);
+
+int
+mono_emit_marshal (EmitMarshalContext *m, int argnum, MonoType *t, 
+	      MonoMarshalSpec *spec, int conv_arg, 
+	      MonoType **conv_arg_type, MarshalAction action);
+
+MonoObject *
+mono_marshal_isinst_with_cache (MonoObject *obj, MonoClass *klass, uintptr_t *cache);
+
+MonoAsyncResult *
+mono_delegate_begin_invoke (MonoDelegate *delegate, gpointer *params);
+
+MonoObject *
+mono_delegate_end_invoke (MonoDelegate *delegate, gpointer *params);
+
+MonoMarshalNative
+mono_marshal_get_string_encoding (MonoMethodPInvoke *piinfo, MonoMarshalSpec *spec);
+
+MonoMarshalConv
+mono_marshal_get_string_to_ptr_conv (MonoMethodPInvoke *piinfo, MonoMarshalSpec *spec);
+
+MonoMarshalConv
+mono_marshal_get_stringbuilder_to_ptr_conv (MonoMethodPInvoke *piinfo, MonoMarshalSpec *spec);
+
+MonoMarshalConv
+mono_marshal_get_ptr_to_stringbuilder_conv (MonoMethodPInvoke *piinfo, MonoMarshalSpec *spec, gboolean *need_free);
+
+MonoMarshalConv
+mono_marshal_get_ptr_to_string_conv (MonoMethodPInvoke *piinfo, MonoMarshalSpec *spec, gboolean *need_free);
+
+MonoType*
+marshal_boolean_conv_in_get_local_type (MonoMarshalSpec *spec, guint8 *ldc_op /*out*/);
+
+MonoClass*
+marshal_boolean_managed_conv_in_get_conv_arg_class (MonoMarshalSpec *spec, guint8 *ldop/*out*/);
+
+gboolean
+mono_pinvoke_is_unicode (MonoMethodPInvoke *piinfo);
+
+gboolean
+mono_marshal_need_free (MonoType *t, MonoMethodPInvoke *piinfo, MonoMarshalSpec *spec);
+
+MonoThreadInfo*
+mono_icall_start (HandleStackMark *stackmark, MonoError *error);
+
+void
+mono_icall_end (MonoThreadInfo *info, HandleStackMark *stackmark, MonoError *error);
+
+MonoObjectHandle
+mono_icall_handle_new (gpointer rawobj);
+
+MonoObjectHandle
+mono_icall_handle_new_interior (gpointer rawobj);
+
+void*
+ves_icall_marshal_alloc (gsize size);
 
 void
 ves_icall_System_Runtime_InteropServices_Marshal_copy_to_unmanaged (MonoArray *src, gint32 start_index,

--- a/mono/metadata/marshal.h
+++ b/mono/metadata/marshal.h
@@ -579,6 +579,9 @@ mono_array_to_byte_byvalarray (gpointer native_arr, MonoArray *arr, guint32 elnu
 gpointer
 mono_array_to_lparray (MonoArray *array);
 
+void
+mono_marshal_set_last_error_windows (int error);
+
 void 
 mono_struct_delete_old (MonoClass *klass, char *ptr);
 

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -51,11 +51,6 @@ struct _MonoType {
 #define MONO_PROCESSOR_ARCHITECTURE_AMD64 4
 #define MONO_PROCESSOR_ARCHITECTURE_ARM 5
 
-#if !defined(DISABLE_JIT) || !defined(DISABLE_INTERPRETER)
-/* Some VES is available at runtime */
-#define ENABLE_ILGEN
-#endif
-
 struct _MonoAssemblyName {
 	const char *name;
 	const char *culture;

--- a/mono/metadata/method-builder-ilgen-internals.h
+++ b/mono/metadata/method-builder-ilgen-internals.h
@@ -1,0 +1,33 @@
+/**
+ * \file
+ * Copyright 2018 Microsoft
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+#ifndef __MONO_METHOD_BUILDER_ILGEN_INTERNALS_H__
+#define __MONO_METHOD_BUILDER_ILGEN_INTERNALS_H__
+
+#include "config.h"
+#include <mono/metadata/class.h>
+#include <mono/metadata/object-internals.h>
+#include <mono/metadata/class-internals.h>
+#include <mono/metadata/opcodes.h>
+#include <mono/metadata/reflection.h>
+#include <mono/metadata/method-builder.h>
+
+/* ilgen version */
+struct _MonoMethodBuilder {
+	MonoMethod *method;
+	char *name;
+	gboolean no_dup_name;
+	GList *locals_list;
+	int locals;
+	gboolean dynamic;
+	gboolean skip_visibility, init_locals;
+	guint32 code_size, pos;
+	unsigned char *code;
+	int num_clauses;
+	MonoExceptionClause *clauses;
+	const char **param_names;
+};
+
+#endif

--- a/mono/metadata/method-builder-ilgen.c
+++ b/mono/metadata/method-builder-ilgen.c
@@ -1,0 +1,619 @@
+/**
+ * \file
+ * Copyright 2018 Microsoft
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+#include "config.h"
+#include "loader.h"
+#include "mono/metadata/abi-details.h"
+#include "mono/metadata/method-builder.h"
+#include "mono/metadata/method-builder-ilgen.h"
+#include "mono/metadata/method-builder-ilgen-internals.h"
+#include "mono/metadata/tabledefs.h"
+#include "mono/metadata/exception.h"
+#include "mono/metadata/appdomain.h"
+#include "mono/metadata/debug-helpers.h"
+#include "mono/metadata/metadata-internals.h"
+#include "mono/metadata/domain-internals.h"
+#include <string.h>
+#include <errno.h>
+
+#define OPDEF(a,b,c,d,e,f,g,h,i,j) \
+	a = i,
+
+enum {
+#include "mono/cil/opcode.def"
+	LAST = 0xff
+};
+#undef OPDEF
+
+static MonoMethodBuilder *
+new_base_ilgen (MonoClass *klass, MonoWrapperType type)
+{
+	MonoMethodBuilder *mb;
+	MonoMethod *m;
+
+	g_assert (klass != NULL);
+
+	mb = g_new0 (MonoMethodBuilder, 1);
+
+	mb->method = m = (MonoMethod *)g_new0 (MonoMethodWrapper, 1);
+
+	m->klass = klass;
+	m->inline_info = 1;
+	m->wrapper_type = type;
+
+	mb->code_size = 40;
+	mb->code = (unsigned char *)g_malloc (mb->code_size);
+	mb->init_locals = TRUE;
+
+	/* placeholder for the wrapper always at index 1 */
+	mono_mb_add_data (mb, NULL);
+
+	return mb;
+}
+
+static void
+free_ilgen (MonoMethodBuilder *mb)
+{
+	GList *l;
+
+	for (l = mb->locals_list; l; l = l->next) {
+		/* Allocated in mono_mb_add_local () */
+		g_free (l->data);
+	}
+	g_list_free (mb->locals_list);
+	if (!mb->dynamic) {
+		g_free (mb->method);
+		if (!mb->no_dup_name)
+			g_free (mb->name);
+		g_free (mb->code);
+	}
+	g_free (mb);
+}
+
+static MonoMethod *
+create_method_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *signature, int max_stack)
+{
+	MonoMethodHeader *header;
+	MonoMethodWrapper *mw;
+	MonoImage *image;
+	MonoMethod *method;
+	GList *l;
+	int i;
+
+	g_assert (mb != NULL);
+
+	image = mb->method->klass->image;
+
+	if (mb->dynamic) {
+		method = mb->method;
+		mw = (MonoMethodWrapper*)method;
+
+		method->name = mb->name;
+		method->dynamic = TRUE;
+
+		mw->header = header = (MonoMethodHeader *) 
+			g_malloc0 (MONO_SIZEOF_METHOD_HEADER + mb->locals * sizeof (MonoType *));
+
+		header->code = mb->code;
+
+		for (i = 0, l = mb->locals_list; l; l = l->next, i++) {
+			header->locals [i] = (MonoType*)l->data;
+		}
+	} else
+	{
+		/* Realloc the method info into a mempool */
+
+		method = (MonoMethod *)mono_image_alloc0 (image, sizeof (MonoMethodWrapper));
+		memcpy (method, mb->method, sizeof (MonoMethodWrapper));
+		mw = (MonoMethodWrapper*) method;
+
+		if (mb->no_dup_name)
+			method->name = mb->name;
+		else
+			method->name = mono_image_strdup (image, mb->name);
+
+		mw->header = header = (MonoMethodHeader *) 
+			mono_image_alloc0 (image, MONO_SIZEOF_METHOD_HEADER + mb->locals * sizeof (MonoType *));
+
+		header->code = (const unsigned char *)mono_image_alloc (image, mb->pos);
+		memcpy ((char*)header->code, mb->code, mb->pos);
+
+		for (i = 0, l = mb->locals_list; l; l = l->next, i++) {
+			header->locals [i] = (MonoType*)l->data;
+		}
+	}
+
+	/* Free the locals list so mono_mb_free () doesn't free the types twice */
+	g_list_free (mb->locals_list);
+	mb->locals_list = NULL;
+
+	method->signature = signature;
+	if (!signature->hasthis)
+		method->flags |= METHOD_ATTRIBUTE_STATIC;
+
+	if (max_stack < 8)
+		max_stack = 8;
+
+	header->max_stack = max_stack;
+
+	header->code_size = mb->pos;
+	header->num_locals = mb->locals;
+	header->init_locals = mb->init_locals;
+
+	header->num_clauses = mb->num_clauses;
+	header->clauses = mb->clauses;
+
+	method->skip_visibility = mb->skip_visibility;
+
+	i = g_list_length ((GList *)mw->method_data);
+	if (i) {
+		GList *tmp;
+		void **data;
+		l = g_list_reverse ((GList *)mw->method_data);
+		if (method_is_dynamic (method))
+			data = (void **)g_malloc (sizeof (gpointer) * (i + 1));
+		else
+			data = (void **)mono_image_alloc (image, sizeof (gpointer) * (i + 1));
+		/* store the size in the first element */
+		data [0] = GUINT_TO_POINTER (i);
+		i = 1;
+		for (tmp = l; tmp; tmp = tmp->next) {
+			data [i++] = tmp->data;
+		}
+		g_list_free (l);
+
+		mw->method_data = data;
+	}
+
+	/*{
+		static int total_code = 0;
+		static int total_alloc = 0;
+		total_code += mb->pos;
+		total_alloc += mb->code_size;
+		g_print ("code size: %d of %d (allocated: %d)\n", mb->pos, total_code, total_alloc);
+	}*/
+
+#ifdef DEBUG_RUNTIME_CODE
+	printf ("RUNTIME CODE FOR %s\n", mono_method_full_name (method, TRUE));
+	printf ("%s\n", mono_disasm_code (&marshal_dh, method, mb->code, mb->code + mb->pos));
+#endif
+
+	if (mb->param_names) {
+		char **param_names = (char **)mono_image_alloc0 (image, signature->param_count * sizeof (gpointer));
+		for (i = 0; i < signature->param_count; ++i)
+			param_names [i] = mono_image_strdup (image, mb->param_names [i]);
+
+		mono_image_lock (image);
+		if (!image->wrapper_param_names)
+			image->wrapper_param_names = g_hash_table_new (NULL, NULL);
+		g_hash_table_insert (image->wrapper_param_names, method, param_names);
+		mono_image_unlock (image);
+	}
+
+	return method;
+}
+
+void
+mono_method_builder_ilgen_init (void)
+{
+	MonoMethodBuilderCallbacks cb;
+	cb.version = MONO_METHOD_BUILDER_CALLBACKS_VERSION;
+	cb.new_base = new_base_ilgen;
+	cb.free = free_ilgen;
+	cb.create_method = create_method_ilgen;
+	mono_install_method_builder_callbacks (&cb);
+}
+
+/**
+ * mono_mb_add_local:
+ */
+int
+mono_mb_add_local (MonoMethodBuilder *mb, MonoType *type)
+{
+	int res;
+	MonoType *t;
+
+	/*
+	 * Have to make a copy early since type might be sig->ret,
+	 * which is transient, see mono_metadata_signature_dup_internal_with_padding ().
+	 */
+	t = mono_metadata_type_dup (NULL, type);
+
+	g_assert (mb != NULL);
+	g_assert (type != NULL);
+
+	res = mb->locals;
+	mb->locals_list = g_list_append (mb->locals_list, t);
+	mb->locals++;
+
+	return res;
+}
+
+/**
+ * mono_mb_patch_addr:
+ */
+void
+mono_mb_patch_addr (MonoMethodBuilder *mb, int pos, int value)
+{
+	mb->code [pos] = value & 0xff;
+	mb->code [pos + 1] = (value >> 8) & 0xff;
+	mb->code [pos + 2] = (value >> 16) & 0xff;
+	mb->code [pos + 3] = (value >> 24) & 0xff;
+}
+
+/**
+ * mono_mb_patch_addr_s:
+ */
+void
+mono_mb_patch_addr_s (MonoMethodBuilder *mb, int pos, gint8 value)
+{
+	*((gint8 *)(&mb->code [pos])) = value;
+}
+
+/**
+ * mono_mb_emit_byte:
+ */
+void
+mono_mb_emit_byte (MonoMethodBuilder *mb, guint8 op)
+{
+	if (mb->pos >= mb->code_size) {
+		mb->code_size += mb->code_size >> 1;
+		mb->code = (unsigned char *)g_realloc (mb->code, mb->code_size);
+	}
+
+	mb->code [mb->pos++] = op;
+}
+
+/**
+ * mono_mb_emit_ldflda:
+ */
+void
+mono_mb_emit_ldflda (MonoMethodBuilder *mb, gint32 offset)
+{
+        mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+        mono_mb_emit_byte (mb, CEE_MONO_OBJADDR);
+
+	if (offset) {
+		mono_mb_emit_icon (mb, offset);
+		mono_mb_emit_byte (mb, CEE_ADD);
+	}
+}
+
+/**
+ * mono_mb_emit_i4:
+ */
+void
+mono_mb_emit_i4 (MonoMethodBuilder *mb, gint32 data)
+{
+	if ((mb->pos + 4) >= mb->code_size) {
+		mb->code_size += mb->code_size >> 1;
+		mb->code = (unsigned char *)g_realloc (mb->code, mb->code_size);
+	}
+
+	mono_mb_patch_addr (mb, mb->pos, data);
+	mb->pos += 4;
+}
+
+void
+mono_mb_emit_i8 (MonoMethodBuilder *mb, gint64 data)
+{
+	if ((mb->pos + 8) >= mb->code_size) {
+		mb->code_size += mb->code_size >> 1;
+		mb->code = (unsigned char *)g_realloc (mb->code, mb->code_size);
+	}
+
+	mono_mb_patch_addr (mb, mb->pos, data);
+	mono_mb_patch_addr (mb, mb->pos + 4, data >> 32);
+	mb->pos += 8;
+}
+
+/**
+ * mono_mb_emit_i2:
+ */
+void
+mono_mb_emit_i2 (MonoMethodBuilder *mb, gint16 data)
+{
+	if ((mb->pos + 2) >= mb->code_size) {
+		mb->code_size += mb->code_size >> 1;
+		mb->code = (unsigned char *)g_realloc (mb->code, mb->code_size);
+	}
+
+	mb->code [mb->pos] = data & 0xff;
+	mb->code [mb->pos + 1] = (data >> 8) & 0xff;
+	mb->pos += 2;
+}
+
+void
+mono_mb_emit_op (MonoMethodBuilder *mb, guint8 op, gpointer data)
+{
+	mono_mb_emit_byte (mb, op);
+	mono_mb_emit_i4 (mb, mono_mb_add_data (mb, data));
+}
+
+/**
+ * mono_mb_emit_ldstr:
+ */
+void
+mono_mb_emit_ldstr (MonoMethodBuilder *mb, char *str)
+{
+	mono_mb_emit_op (mb, CEE_LDSTR, str);
+}
+
+/**
+ * mono_mb_emit_ldarg:
+ */
+void
+mono_mb_emit_ldarg (MonoMethodBuilder *mb, guint argnum)
+{
+	if (argnum < 4) {
+ 		mono_mb_emit_byte (mb, CEE_LDARG_0 + argnum);
+	} else if (argnum < 256) {
+		mono_mb_emit_byte (mb, CEE_LDARG_S);
+		mono_mb_emit_byte (mb, argnum);
+	} else {
+		mono_mb_emit_byte (mb, CEE_PREFIX1);
+		mono_mb_emit_byte (mb, CEE_LDARG);
+		mono_mb_emit_i2 (mb, argnum);
+	}
+}
+
+/**
+ * mono_mb_emit_ldarg_addr:
+ */
+void
+mono_mb_emit_ldarg_addr (MonoMethodBuilder *mb, guint argnum)
+{
+	if (argnum < 256) {
+		mono_mb_emit_byte (mb, CEE_LDARGA_S);
+		mono_mb_emit_byte (mb, argnum);
+	} else {
+		mono_mb_emit_byte (mb, CEE_PREFIX1);
+		mono_mb_emit_byte (mb, CEE_LDARGA);
+		mono_mb_emit_i2 (mb, argnum);
+	}
+}
+
+/**
+ * mono_mb_emit_ldloc_addr:
+ */
+void
+mono_mb_emit_ldloc_addr (MonoMethodBuilder *mb, guint locnum)
+{
+	if (locnum < 256) {
+		mono_mb_emit_byte (mb, CEE_LDLOCA_S);
+		mono_mb_emit_byte (mb, locnum);
+	} else {
+		mono_mb_emit_byte (mb, CEE_PREFIX1);
+		mono_mb_emit_byte (mb, CEE_LDLOCA);
+		mono_mb_emit_i2 (mb, locnum);
+	}
+}
+
+/**
+ * mono_mb_emit_ldloc:
+ */
+void
+mono_mb_emit_ldloc (MonoMethodBuilder *mb, guint num)
+{
+	if (num < 4) {
+ 		mono_mb_emit_byte (mb, CEE_LDLOC_0 + num);
+	} else if (num < 256) {
+		mono_mb_emit_byte (mb, CEE_LDLOC_S);
+		mono_mb_emit_byte (mb, num);
+	} else {
+		mono_mb_emit_byte (mb, CEE_PREFIX1);
+		mono_mb_emit_byte (mb, CEE_LDLOC);
+		mono_mb_emit_i2 (mb, num);
+	}
+}
+
+/**
+ * mono_mb_emit_stloc:
+ */
+void
+mono_mb_emit_stloc (MonoMethodBuilder *mb, guint num)
+{
+	if (num < 4) {
+ 		mono_mb_emit_byte (mb, CEE_STLOC_0 + num);
+	} else if (num < 256) {
+		mono_mb_emit_byte (mb, CEE_STLOC_S);
+		mono_mb_emit_byte (mb, num);
+	} else {
+		mono_mb_emit_byte (mb, CEE_PREFIX1);
+		mono_mb_emit_byte (mb, CEE_STLOC);
+		mono_mb_emit_i2 (mb, num);
+	}
+}
+
+/**
+ * mono_mb_emit_icon:
+ */
+void
+mono_mb_emit_icon (MonoMethodBuilder *mb, gint32 value)
+{
+	if (value >= -1 && value < 8) {
+		mono_mb_emit_byte (mb, CEE_LDC_I4_0 + value);
+	} else if (value >= -128 && value <= 127) {
+		mono_mb_emit_byte (mb, CEE_LDC_I4_S);
+		mono_mb_emit_byte (mb, value);
+	} else {
+		mono_mb_emit_byte (mb, CEE_LDC_I4);
+		mono_mb_emit_i4 (mb, value);
+	}
+}
+
+void
+mono_mb_emit_icon8 (MonoMethodBuilder *mb, gint64 value)
+{
+	mono_mb_emit_byte (mb, CEE_LDC_I8);
+	mono_mb_emit_i8 (mb, value);
+}
+
+int
+mono_mb_get_label (MonoMethodBuilder *mb)
+{
+	return mb->pos;
+}
+
+int
+mono_mb_get_pos (MonoMethodBuilder *mb)
+{
+	return mb->pos;
+}
+
+/**
+ * mono_mb_emit_branch:
+ */
+guint32
+mono_mb_emit_branch (MonoMethodBuilder *mb, guint8 op)
+{
+	guint32 res;
+	mono_mb_emit_byte (mb, op);
+	res = mb->pos;
+	mono_mb_emit_i4 (mb, 0);
+	return res;
+}
+
+guint32
+mono_mb_emit_short_branch (MonoMethodBuilder *mb, guint8 op)
+{
+	guint32 res;
+	mono_mb_emit_byte (mb, op);
+	res = mb->pos;
+	mono_mb_emit_byte (mb, 0);
+
+	return res;
+}
+
+void
+mono_mb_emit_branch_label (MonoMethodBuilder *mb, guint8 op, guint32 label)
+{
+	mono_mb_emit_byte (mb, op);
+	mono_mb_emit_i4 (mb, label - (mb->pos + 4));
+}
+
+void
+mono_mb_patch_branch (MonoMethodBuilder *mb, guint32 pos)
+{
+	mono_mb_patch_addr (mb, pos, mb->pos - (pos + 4));
+}
+
+void
+mono_mb_patch_short_branch (MonoMethodBuilder *mb, guint32 pos)
+{
+	mono_mb_patch_addr_s (mb, pos, mb->pos - (pos + 1));
+}
+
+void
+mono_mb_emit_ptr (MonoMethodBuilder *mb, gpointer ptr)
+{
+	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+	mono_mb_emit_op (mb, CEE_MONO_LDPTR, ptr);
+}
+
+void
+mono_mb_emit_calli (MonoMethodBuilder *mb, MonoMethodSignature *sig)
+{
+	mono_mb_emit_op (mb, CEE_CALLI, sig);
+}
+
+/**
+ * mono_mb_emit_managed_call:
+ */
+void
+mono_mb_emit_managed_call (MonoMethodBuilder *mb, MonoMethod *method, MonoMethodSignature *opt_sig)
+{
+	mono_mb_emit_op (mb, CEE_CALL, method);
+}
+
+/**
+ * mono_mb_emit_native_call:
+ */
+void
+mono_mb_emit_native_call (MonoMethodBuilder *mb, MonoMethodSignature *sig, gpointer func)
+{
+	mono_mb_emit_ptr (mb, func);
+	mono_mb_emit_calli (mb, sig);
+}
+
+void
+mono_mb_emit_icall (MonoMethodBuilder *mb, gpointer func)
+{
+	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+	mono_mb_emit_op (mb, CEE_MONO_ICALL, func);
+}
+
+void
+mono_mb_emit_exception_full (MonoMethodBuilder *mb, const char *exc_nspace, const char *exc_name, const char *msg)
+{
+	MonoMethod *ctor = NULL;
+
+	MonoClass *mme = mono_class_load_from_name (mono_defaults.corlib, exc_nspace, exc_name);
+	mono_class_init (mme);
+	ctor = mono_class_get_method_from_name (mme, ".ctor", 0);
+	g_assert (ctor);
+	mono_mb_emit_op (mb, CEE_NEWOBJ, ctor);
+	if (msg != NULL) {
+		mono_mb_emit_byte (mb, CEE_DUP);
+		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoException, message));
+		mono_mb_emit_ldstr (mb, (char*)msg);
+		mono_mb_emit_byte (mb, CEE_STIND_REF);
+	}
+	mono_mb_emit_byte (mb, CEE_THROW);
+}
+
+/**
+ * mono_mb_emit_exception:
+ */
+void
+mono_mb_emit_exception (MonoMethodBuilder *mb, const char *exc_name, const char *msg)
+{
+	mono_mb_emit_exception_full (mb, "System", exc_name, msg);
+}
+
+/**
+ * mono_mb_emit_exception_for_error:
+ */
+void
+mono_mb_emit_exception_for_error (MonoMethodBuilder *mb, MonoError *error)
+{
+	/*
+	 * If at some point there is need to support other types of errors,
+	 * the behaviour should conform with mono_error_prepare_exception().
+	 */
+	g_assert (mono_error_get_error_code (error) == MONO_ERROR_GENERIC && "Unsupported error code.");
+	mono_mb_emit_exception_full (mb, "System", mono_error_get_exception_name (error), mono_error_get_message (error));
+}
+
+/**
+ * mono_mb_emit_add_to_local:
+ */
+void
+mono_mb_emit_add_to_local (MonoMethodBuilder *mb, guint16 local, gint32 incr)
+{
+	mono_mb_emit_ldloc (mb, local); 
+	mono_mb_emit_icon (mb, incr);
+	mono_mb_emit_byte (mb, CEE_ADD);
+	mono_mb_emit_stloc (mb, local); 
+}
+
+void
+mono_mb_set_clauses (MonoMethodBuilder *mb, int num_clauses, MonoExceptionClause *clauses)
+{
+	mb->num_clauses = num_clauses;
+	mb->clauses = clauses;
+}
+
+/*
+ * mono_mb_set_param_names:
+ *
+ *   PARAM_NAMES should have length equal to the sig->param_count, the caller retains
+ * ownership of the array, and its entries.
+ */
+void
+mono_mb_set_param_names (MonoMethodBuilder *mb, const char **param_names)
+{
+	mb->param_names = param_names;
+}

--- a/mono/metadata/method-builder-ilgen.h
+++ b/mono/metadata/method-builder-ilgen.h
@@ -1,0 +1,125 @@
+/**
+ * \file
+ * Copyright 2018 Microsoft
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+#ifndef __MONO_METHOD_BUILDER_ILGEN_H__
+#define __MONO_METHOD_BUILDER_ILGEN_H__
+
+#include "config.h"
+#include <mono/metadata/class.h>
+#include <mono/metadata/object-internals.h>
+#include <mono/metadata/class-internals.h>
+#include <mono/metadata/opcodes.h>
+#include <mono/metadata/reflection.h>
+#include <mono/metadata/method-builder.h>
+
+MONO_API void
+mono_method_builder_ilgen_init (void);
+
+void
+mono_mb_patch_addr (MonoMethodBuilder *mb, int pos, int value);
+
+void
+mono_mb_patch_addr_s (MonoMethodBuilder *mb, int pos, gint8 value);
+
+void
+mono_mb_patch_branch (MonoMethodBuilder *mb, guint32 pos);
+
+void
+mono_mb_patch_short_branch (MonoMethodBuilder *mb, guint32 pos);
+
+int
+mono_mb_get_label (MonoMethodBuilder *mb);
+
+int
+mono_mb_get_pos (MonoMethodBuilder *mb);
+
+void
+mono_mb_emit_ptr (MonoMethodBuilder *mb, gpointer ptr);
+
+void
+mono_mb_emit_calli (MonoMethodBuilder *mb, MonoMethodSignature *sig);
+
+void
+mono_mb_emit_native_call (MonoMethodBuilder *mb, MonoMethodSignature *sig, gpointer func);
+
+void
+mono_mb_emit_managed_call (MonoMethodBuilder *mb, MonoMethod *method, MonoMethodSignature *opt_sig);
+
+void
+mono_mb_emit_icall (MonoMethodBuilder *mb, gpointer func);
+
+int
+mono_mb_add_local (MonoMethodBuilder *mb, MonoType *type);
+
+void
+mono_mb_emit_ldarg (MonoMethodBuilder *mb, guint argnum);
+
+void
+mono_mb_emit_ldarg_addr (MonoMethodBuilder *mb, guint argnum);
+
+void
+mono_mb_emit_ldloc (MonoMethodBuilder *mb, guint num);
+
+void
+mono_mb_emit_ldloc_addr (MonoMethodBuilder *mb, guint locnum);
+
+void
+mono_mb_emit_stloc (MonoMethodBuilder *mb, guint num);
+
+void
+mono_mb_emit_exception (MonoMethodBuilder *mb, const char *exc_name, const char *msg);
+
+void
+mono_mb_emit_exception_full (MonoMethodBuilder *mb, const char *exc_nspace, const char *exc_name, const char *msg);
+
+void
+mono_mb_emit_exception_for_error (MonoMethodBuilder *mb, MonoError *error);
+
+void
+mono_mb_emit_icon (MonoMethodBuilder *mb, gint32 value);
+
+void
+mono_mb_emit_icon8 (MonoMethodBuilder *mb, gint64 value);
+
+guint32
+mono_mb_emit_branch (MonoMethodBuilder *mb, guint8 op);
+
+guint32
+mono_mb_emit_short_branch (MonoMethodBuilder *mb, guint8 op);
+
+void
+mono_mb_emit_branch_label (MonoMethodBuilder *mb, guint8 op, guint32 label);
+
+void
+mono_mb_emit_add_to_local (MonoMethodBuilder *mb, guint16 local, gint32 incr);
+
+void
+mono_mb_emit_ldflda (MonoMethodBuilder *mb, gint32 offset);
+
+void
+mono_mb_emit_byte (MonoMethodBuilder *mb, guint8 op);
+
+void
+mono_mb_emit_i2 (MonoMethodBuilder *mb, gint16 data);
+
+void
+mono_mb_emit_i4 (MonoMethodBuilder *mb, gint32 data);
+
+void
+mono_mb_emit_i8 (MonoMethodBuilder *mb, gint64 data);
+
+void
+mono_mb_emit_op (MonoMethodBuilder *mb, guint8 op, gpointer data);
+
+void
+mono_mb_emit_ldstr (MonoMethodBuilder *mb, char *str);
+
+void
+mono_mb_set_clauses (MonoMethodBuilder *mb, int num_clauses, MonoExceptionClause *clauses);
+
+void
+mono_mb_set_param_names (MonoMethodBuilder *mb, const char **param_names);
+
+#endif

--- a/mono/metadata/method-builder-internals.h
+++ b/mono/metadata/method-builder-internals.h
@@ -1,0 +1,24 @@
+/**
+ * \file
+ * Copyright 2018 Microsoft
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+#ifndef __MONO_METHOD_BUILDER_INTERNALS_H__
+#define __MONO_METHOD_BUILDER_INTERNALS_H__
+
+#include "config.h"
+#include <mono/metadata/class.h>
+#include <mono/metadata/object-internals.h>
+#include <mono/metadata/class-internals.h>
+#include <mono/metadata/opcodes.h>
+#include <mono/metadata/reflection.h>
+#include <mono/metadata/method-builder.h>
+
+/* noilgen version */
+struct _MonoMethodBuilder {
+	MonoMethod *method;
+	char *name;
+	gboolean no_dup_name;
+};
+
+#endif

--- a/mono/metadata/method-builder.c
+++ b/mono/metadata/method-builder.c
@@ -14,6 +14,8 @@
 #include "loader.h"
 #include "mono/metadata/abi-details.h"
 #include "mono/metadata/method-builder.h"
+#include "mono/metadata/method-builder-internals.h"
+#include "mono/metadata/method-builder-ilgen.h"
 #include "mono/metadata/tabledefs.h"
 #include "mono/metadata/exception.h"
 #include "mono/metadata/appdomain.h"
@@ -51,8 +53,11 @@ static MonoDisHelper marshal_dh = {
 };
 #endif 
 
+static MonoMethodBuilderCallbacks mb_cb;
+static gboolean cb_inited = FALSE;
+
 static MonoMethodBuilder *
-mono_mb_new_base (MonoClass *klass, MonoWrapperType type)
+new_base_noilgen (MonoClass *klass, MonoWrapperType type)
 {
 	MonoMethodBuilder *mb;
 	MonoMethod *m;
@@ -67,76 +72,24 @@ mono_mb_new_base (MonoClass *klass, MonoWrapperType type)
 	m->inline_info = 1;
 	m->wrapper_type = type;
 
-#ifdef ENABLE_ILGEN
-	mb->code_size = 40;
-	mb->code = (unsigned char *)g_malloc (mb->code_size);
-	mb->init_locals = TRUE;
-#endif
 	/* placeholder for the wrapper always at index 1 */
 	mono_mb_add_data (mb, NULL);
 
 	return mb;
 }
 
-MonoMethodBuilder *
-mono_mb_new_no_dup_name (MonoClass *klass, const char *name, MonoWrapperType type)
+static void
+free_noilgen (MonoMethodBuilder *mb)
 {
-	MonoMethodBuilder *mb = mono_mb_new_base (klass, type);
-	mb->name = (char*)name;
-	mb->no_dup_name = TRUE;
-	return mb;
-}
-
-/**
- * mono_mb_new:
- */
-MonoMethodBuilder *
-mono_mb_new (MonoClass *klass, const char *name, MonoWrapperType type)
-{
-	MonoMethodBuilder *mb = mono_mb_new_base (klass, type);
-	mb->name = g_strdup (name);
-	return mb;
-}
-
-/**
- * mono_mb_free:
- */
-void
-mono_mb_free (MonoMethodBuilder *mb)
-{
-#ifdef ENABLE_ILGEN
-	GList *l;
-
-	for (l = mb->locals_list; l; l = l->next) {
-		/* Allocated in mono_mb_add_local () */
-		g_free (l->data);
-	}
-	g_list_free (mb->locals_list);
-	if (!mb->dynamic) {
-		g_free (mb->method);
-		if (!mb->no_dup_name)
-			g_free (mb->name);
-		g_free (mb->code);
-	}
-#else
 	g_free (mb->method);
 	if (!mb->no_dup_name)
 		g_free (mb->name);
-#endif
 	g_free (mb);
 }
 
-/**
- * mono_mb_create_method:
- * Create a \c MonoMethod from this method builder.
- * \returns the newly created method.
- */
-MonoMethod *
-mono_mb_create_method (MonoMethodBuilder *mb, MonoMethodSignature *signature, int max_stack)
+static MonoMethod *
+create_method_noilgen (MonoMethodBuilder *mb, MonoMethodSignature *signature, int max_stack)
 {
-#ifdef ENABLE_ILGEN
-	MonoMethodHeader *header;
-#endif
 	MonoMethodWrapper *mw;
 	MonoImage *image;
 	MonoMethod *method;
@@ -147,24 +100,6 @@ mono_mb_create_method (MonoMethodBuilder *mb, MonoMethodSignature *signature, in
 
 	image = mb->method->klass->image;
 
-#ifdef ENABLE_ILGEN
-	if (mb->dynamic) {
-		method = mb->method;
-		mw = (MonoMethodWrapper*)method;
-
-		method->name = mb->name;
-		method->dynamic = TRUE;
-
-		mw->header = header = (MonoMethodHeader *) 
-			g_malloc0 (MONO_SIZEOF_METHOD_HEADER + mb->locals * sizeof (MonoType *));
-
-		header->code = mb->code;
-
-		for (i = 0, l = mb->locals_list; l; l = l->next, i++) {
-			header->locals [i] = (MonoType*)l->data;
-		}
-	} else
-#endif
 	{
 		/* Realloc the method info into a mempool */
 
@@ -176,45 +111,11 @@ mono_mb_create_method (MonoMethodBuilder *mb, MonoMethodSignature *signature, in
 			method->name = mb->name;
 		else
 			method->name = mono_image_strdup (image, mb->name);
-
-#ifdef ENABLE_ILGEN
-		mw->header = header = (MonoMethodHeader *) 
-			mono_image_alloc0 (image, MONO_SIZEOF_METHOD_HEADER + mb->locals * sizeof (MonoType *));
-
-		header->code = (const unsigned char *)mono_image_alloc (image, mb->pos);
-		memcpy ((char*)header->code, mb->code, mb->pos);
-
-		for (i = 0, l = mb->locals_list; l; l = l->next, i++) {
-			header->locals [i] = (MonoType*)l->data;
-		}
-#endif
 	}
-
-#ifdef ENABLE_ILGEN
-	/* Free the locals list so mono_mb_free () doesn't free the types twice */
-	g_list_free (mb->locals_list);
-	mb->locals_list = NULL;
-#endif
 
 	method->signature = signature;
 	if (!signature->hasthis)
 		method->flags |= METHOD_ATTRIBUTE_STATIC;
-
-#ifdef ENABLE_ILGEN
-	if (max_stack < 8)
-		max_stack = 8;
-
-	header->max_stack = max_stack;
-
-	header->code_size = mb->pos;
-	header->num_locals = mb->locals;
-	header->init_locals = mb->init_locals;
-
-	header->num_clauses = mb->num_clauses;
-	header->clauses = mb->clauses;
-
-	method->skip_visibility = mb->skip_visibility;
-#endif
 
 	i = g_list_length ((GList *)mw->method_data);
 	if (i) {
@@ -236,34 +137,81 @@ mono_mb_create_method (MonoMethodBuilder *mb, MonoMethodSignature *signature, in
 		mw->method_data = data;
 	}
 
-#ifdef ENABLE_ILGEN
-	/*{
-		static int total_code = 0;
-		static int total_alloc = 0;
-		total_code += mb->pos;
-		total_alloc += mb->code_size;
-		g_print ("code size: %d of %d (allocated: %d)\n", mb->pos, total_code, total_alloc);
-	}*/
-
-#ifdef DEBUG_RUNTIME_CODE
-	printf ("RUNTIME CODE FOR %s\n", mono_method_full_name (method, TRUE));
-	printf ("%s\n", mono_disasm_code (&marshal_dh, method, mb->code, mb->code + mb->pos));
-#endif
-
-	if (mb->param_names) {
-		char **param_names = (char **)mono_image_alloc0 (image, signature->param_count * sizeof (gpointer));
-		for (i = 0; i < signature->param_count; ++i)
-			param_names [i] = mono_image_strdup (image, mb->param_names [i]);
-
-		mono_image_lock (image);
-		if (!image->wrapper_param_names)
-			image->wrapper_param_names = g_hash_table_new (NULL, NULL);
-		g_hash_table_insert (image->wrapper_param_names, method, param_names);
-		mono_image_unlock (image);
-	}
-#endif
-
 	return method;
+}
+
+
+void
+mono_install_method_builder_callbacks (MonoMethodBuilderCallbacks *cb)
+{
+	g_assert (!cb_inited);
+	g_assert (cb->version == MONO_METHOD_BUILDER_CALLBACKS_VERSION);
+	memcpy (&mb_cb, cb, sizeof (MonoMethodBuilderCallbacks));
+	cb_inited = TRUE;
+}
+
+static void
+install_noilgen (void)
+{
+	MonoMethodBuilderCallbacks cb;
+	cb.version = MONO_METHOD_BUILDER_CALLBACKS_VERSION;
+	cb.new_base = new_base_noilgen;
+	cb.free = free_noilgen;
+	cb.create_method = create_method_noilgen;
+	mono_install_method_builder_callbacks (&cb);
+}
+
+static MonoMethodBuilderCallbacks *
+get_mb_cb (void)
+{
+	if (G_UNLIKELY (!cb_inited)) {
+#ifdef ENABLE_ILGEN
+		mono_method_builder_ilgen_init ();
+#else
+		install_noilgen ();
+#endif
+	}
+	return &mb_cb;
+}
+
+MonoMethodBuilder *
+mono_mb_new_no_dup_name (MonoClass *klass, const char *name, MonoWrapperType type)
+{
+	MonoMethodBuilder *mb = get_mb_cb ()->new_base (klass, type);
+	mb->name = (char*)name;
+	mb->no_dup_name = TRUE;
+	return mb;
+}
+
+/**
+ * mono_mb_new:
+ */
+MonoMethodBuilder *
+mono_mb_new (MonoClass *klass, const char *name, MonoWrapperType type)
+{
+	MonoMethodBuilder *mb = get_mb_cb ()->new_base (klass, type);
+	mb->name = g_strdup (name);
+	return mb;
+}
+
+/**
+ * mono_mb_free:
+ */
+void
+mono_mb_free (MonoMethodBuilder *mb)
+{
+	get_mb_cb ()->free (mb);
+}
+
+/**
+ * mono_mb_create_method:
+ * Create a \c MonoMethod from this method builder.
+ * \returns the newly created method.
+ */
+MonoMethod *
+mono_mb_create_method (MonoMethodBuilder *mb, MonoMethodSignature *signature, int max_stack)
+{
+	return get_mb_cb ()->create_method (mb, signature, max_stack);
 }
 
 /**
@@ -284,418 +232,3 @@ mono_mb_add_data (MonoMethodBuilder *mb, gpointer data)
 	return g_list_length ((GList *)mw->method_data);
 }
 
-#ifdef ENABLE_ILGEN
-
-/**
- * mono_mb_add_local:
- */
-int
-mono_mb_add_local (MonoMethodBuilder *mb, MonoType *type)
-{
-	int res;
-	MonoType *t;
-
-	/*
-	 * Have to make a copy early since type might be sig->ret,
-	 * which is transient, see mono_metadata_signature_dup_internal_with_padding ().
-	 */
-	t = mono_metadata_type_dup (NULL, type);
-
-	g_assert (mb != NULL);
-	g_assert (type != NULL);
-
-	res = mb->locals;
-	mb->locals_list = g_list_append (mb->locals_list, t);
-	mb->locals++;
-
-	return res;
-}
-
-/**
- * mono_mb_patch_addr:
- */
-void
-mono_mb_patch_addr (MonoMethodBuilder *mb, int pos, int value)
-{
-	mb->code [pos] = value & 0xff;
-	mb->code [pos + 1] = (value >> 8) & 0xff;
-	mb->code [pos + 2] = (value >> 16) & 0xff;
-	mb->code [pos + 3] = (value >> 24) & 0xff;
-}
-
-/**
- * mono_mb_patch_addr_s:
- */
-void
-mono_mb_patch_addr_s (MonoMethodBuilder *mb, int pos, gint8 value)
-{
-	*((gint8 *)(&mb->code [pos])) = value;
-}
-
-/**
- * mono_mb_emit_byte:
- */
-void
-mono_mb_emit_byte (MonoMethodBuilder *mb, guint8 op)
-{
-	if (mb->pos >= mb->code_size) {
-		mb->code_size += mb->code_size >> 1;
-		mb->code = (unsigned char *)g_realloc (mb->code, mb->code_size);
-	}
-
-	mb->code [mb->pos++] = op;
-}
-
-/**
- * mono_mb_emit_ldflda:
- */
-void
-mono_mb_emit_ldflda (MonoMethodBuilder *mb, gint32 offset)
-{
-        mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-        mono_mb_emit_byte (mb, CEE_MONO_OBJADDR);
-
-	if (offset) {
-		mono_mb_emit_icon (mb, offset);
-		mono_mb_emit_byte (mb, CEE_ADD);
-	}
-}
-
-/**
- * mono_mb_emit_i4:
- */
-void
-mono_mb_emit_i4 (MonoMethodBuilder *mb, gint32 data)
-{
-	if ((mb->pos + 4) >= mb->code_size) {
-		mb->code_size += mb->code_size >> 1;
-		mb->code = (unsigned char *)g_realloc (mb->code, mb->code_size);
-	}
-
-	mono_mb_patch_addr (mb, mb->pos, data);
-	mb->pos += 4;
-}
-
-void
-mono_mb_emit_i8 (MonoMethodBuilder *mb, gint64 data)
-{
-	if ((mb->pos + 8) >= mb->code_size) {
-		mb->code_size += mb->code_size >> 1;
-		mb->code = (unsigned char *)g_realloc (mb->code, mb->code_size);
-	}
-
-	mono_mb_patch_addr (mb, mb->pos, data);
-	mono_mb_patch_addr (mb, mb->pos + 4, data >> 32);
-	mb->pos += 8;
-}
-
-/**
- * mono_mb_emit_i2:
- */
-void
-mono_mb_emit_i2 (MonoMethodBuilder *mb, gint16 data)
-{
-	if ((mb->pos + 2) >= mb->code_size) {
-		mb->code_size += mb->code_size >> 1;
-		mb->code = (unsigned char *)g_realloc (mb->code, mb->code_size);
-	}
-
-	mb->code [mb->pos] = data & 0xff;
-	mb->code [mb->pos + 1] = (data >> 8) & 0xff;
-	mb->pos += 2;
-}
-
-void
-mono_mb_emit_op (MonoMethodBuilder *mb, guint8 op, gpointer data)
-{
-	mono_mb_emit_byte (mb, op);
-	mono_mb_emit_i4 (mb, mono_mb_add_data (mb, data));
-}
-
-/**
- * mono_mb_emit_ldstr:
- */
-void
-mono_mb_emit_ldstr (MonoMethodBuilder *mb, char *str)
-{
-	mono_mb_emit_op (mb, CEE_LDSTR, str);
-}
-
-/**
- * mono_mb_emit_ldarg:
- */
-void
-mono_mb_emit_ldarg (MonoMethodBuilder *mb, guint argnum)
-{
-	if (argnum < 4) {
- 		mono_mb_emit_byte (mb, CEE_LDARG_0 + argnum);
-	} else if (argnum < 256) {
-		mono_mb_emit_byte (mb, CEE_LDARG_S);
-		mono_mb_emit_byte (mb, argnum);
-	} else {
-		mono_mb_emit_byte (mb, CEE_PREFIX1);
-		mono_mb_emit_byte (mb, CEE_LDARG);
-		mono_mb_emit_i2 (mb, argnum);
-	}
-}
-
-/**
- * mono_mb_emit_ldarg_addr:
- */
-void
-mono_mb_emit_ldarg_addr (MonoMethodBuilder *mb, guint argnum)
-{
-	if (argnum < 256) {
-		mono_mb_emit_byte (mb, CEE_LDARGA_S);
-		mono_mb_emit_byte (mb, argnum);
-	} else {
-		mono_mb_emit_byte (mb, CEE_PREFIX1);
-		mono_mb_emit_byte (mb, CEE_LDARGA);
-		mono_mb_emit_i2 (mb, argnum);
-	}
-}
-
-/**
- * mono_mb_emit_ldloc_addr:
- */
-void
-mono_mb_emit_ldloc_addr (MonoMethodBuilder *mb, guint locnum)
-{
-	if (locnum < 256) {
-		mono_mb_emit_byte (mb, CEE_LDLOCA_S);
-		mono_mb_emit_byte (mb, locnum);
-	} else {
-		mono_mb_emit_byte (mb, CEE_PREFIX1);
-		mono_mb_emit_byte (mb, CEE_LDLOCA);
-		mono_mb_emit_i2 (mb, locnum);
-	}
-}
-
-/**
- * mono_mb_emit_ldloc:
- */
-void
-mono_mb_emit_ldloc (MonoMethodBuilder *mb, guint num)
-{
-	if (num < 4) {
- 		mono_mb_emit_byte (mb, CEE_LDLOC_0 + num);
-	} else if (num < 256) {
-		mono_mb_emit_byte (mb, CEE_LDLOC_S);
-		mono_mb_emit_byte (mb, num);
-	} else {
-		mono_mb_emit_byte (mb, CEE_PREFIX1);
-		mono_mb_emit_byte (mb, CEE_LDLOC);
-		mono_mb_emit_i2 (mb, num);
-	}
-}
-
-/**
- * mono_mb_emit_stloc:
- */
-void
-mono_mb_emit_stloc (MonoMethodBuilder *mb, guint num)
-{
-	if (num < 4) {
- 		mono_mb_emit_byte (mb, CEE_STLOC_0 + num);
-	} else if (num < 256) {
-		mono_mb_emit_byte (mb, CEE_STLOC_S);
-		mono_mb_emit_byte (mb, num);
-	} else {
-		mono_mb_emit_byte (mb, CEE_PREFIX1);
-		mono_mb_emit_byte (mb, CEE_STLOC);
-		mono_mb_emit_i2 (mb, num);
-	}
-}
-
-/**
- * mono_mb_emit_icon:
- */
-void
-mono_mb_emit_icon (MonoMethodBuilder *mb, gint32 value)
-{
-	if (value >= -1 && value < 8) {
-		mono_mb_emit_byte (mb, CEE_LDC_I4_0 + value);
-	} else if (value >= -128 && value <= 127) {
-		mono_mb_emit_byte (mb, CEE_LDC_I4_S);
-		mono_mb_emit_byte (mb, value);
-	} else {
-		mono_mb_emit_byte (mb, CEE_LDC_I4);
-		mono_mb_emit_i4 (mb, value);
-	}
-}
-
-void
-mono_mb_emit_icon8 (MonoMethodBuilder *mb, gint64 value)
-{
-	mono_mb_emit_byte (mb, CEE_LDC_I8);
-	mono_mb_emit_i8 (mb, value);
-}
-
-int
-mono_mb_get_label (MonoMethodBuilder *mb)
-{
-	return mb->pos;
-}
-
-int
-mono_mb_get_pos (MonoMethodBuilder *mb)
-{
-	return mb->pos;
-}
-
-/**
- * mono_mb_emit_branch:
- */
-guint32
-mono_mb_emit_branch (MonoMethodBuilder *mb, guint8 op)
-{
-	guint32 res;
-	mono_mb_emit_byte (mb, op);
-	res = mb->pos;
-	mono_mb_emit_i4 (mb, 0);
-	return res;
-}
-
-guint32
-mono_mb_emit_short_branch (MonoMethodBuilder *mb, guint8 op)
-{
-	guint32 res;
-	mono_mb_emit_byte (mb, op);
-	res = mb->pos;
-	mono_mb_emit_byte (mb, 0);
-
-	return res;
-}
-
-void
-mono_mb_emit_branch_label (MonoMethodBuilder *mb, guint8 op, guint32 label)
-{
-	mono_mb_emit_byte (mb, op);
-	mono_mb_emit_i4 (mb, label - (mb->pos + 4));
-}
-
-void
-mono_mb_patch_branch (MonoMethodBuilder *mb, guint32 pos)
-{
-	mono_mb_patch_addr (mb, pos, mb->pos - (pos + 4));
-}
-
-void
-mono_mb_patch_short_branch (MonoMethodBuilder *mb, guint32 pos)
-{
-	mono_mb_patch_addr_s (mb, pos, mb->pos - (pos + 1));
-}
-
-void
-mono_mb_emit_ptr (MonoMethodBuilder *mb, gpointer ptr)
-{
-	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-	mono_mb_emit_op (mb, CEE_MONO_LDPTR, ptr);
-}
-
-void
-mono_mb_emit_calli (MonoMethodBuilder *mb, MonoMethodSignature *sig)
-{
-	mono_mb_emit_op (mb, CEE_CALLI, sig);
-}
-
-/**
- * mono_mb_emit_managed_call:
- */
-void
-mono_mb_emit_managed_call (MonoMethodBuilder *mb, MonoMethod *method, MonoMethodSignature *opt_sig)
-{
-	mono_mb_emit_op (mb, CEE_CALL, method);
-}
-
-/**
- * mono_mb_emit_native_call:
- */
-void
-mono_mb_emit_native_call (MonoMethodBuilder *mb, MonoMethodSignature *sig, gpointer func)
-{
-	mono_mb_emit_ptr (mb, func);
-	mono_mb_emit_calli (mb, sig);
-}
-
-void
-mono_mb_emit_icall (MonoMethodBuilder *mb, gpointer func)
-{
-	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-	mono_mb_emit_op (mb, CEE_MONO_ICALL, func);
-}
-
-void
-mono_mb_emit_exception_full (MonoMethodBuilder *mb, const char *exc_nspace, const char *exc_name, const char *msg)
-{
-	MonoMethod *ctor = NULL;
-
-	MonoClass *mme = mono_class_load_from_name (mono_defaults.corlib, exc_nspace, exc_name);
-	mono_class_init (mme);
-	ctor = mono_class_get_method_from_name (mme, ".ctor", 0);
-	g_assert (ctor);
-	mono_mb_emit_op (mb, CEE_NEWOBJ, ctor);
-	if (msg != NULL) {
-		mono_mb_emit_byte (mb, CEE_DUP);
-		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoException, message));
-		mono_mb_emit_ldstr (mb, (char*)msg);
-		mono_mb_emit_byte (mb, CEE_STIND_REF);
-	}
-	mono_mb_emit_byte (mb, CEE_THROW);
-}
-
-/**
- * mono_mb_emit_exception:
- */
-void
-mono_mb_emit_exception (MonoMethodBuilder *mb, const char *exc_name, const char *msg)
-{
-	mono_mb_emit_exception_full (mb, "System", exc_name, msg);
-}
-
-/**
- * mono_mb_emit_exception_for_error:
- */
-void
-mono_mb_emit_exception_for_error (MonoMethodBuilder *mb, MonoError *error)
-{
-	/*
-	 * If at some point there is need to support other types of errors,
-	 * the behaviour should conform with mono_error_prepare_exception().
-	 */
-	g_assert (mono_error_get_error_code (error) == MONO_ERROR_GENERIC && "Unsupported error code.");
-	mono_mb_emit_exception_full (mb, "System", mono_error_get_exception_name (error), mono_error_get_message (error));
-}
-
-/**
- * mono_mb_emit_add_to_local:
- */
-void
-mono_mb_emit_add_to_local (MonoMethodBuilder *mb, guint16 local, gint32 incr)
-{
-	mono_mb_emit_ldloc (mb, local); 
-	mono_mb_emit_icon (mb, incr);
-	mono_mb_emit_byte (mb, CEE_ADD);
-	mono_mb_emit_stloc (mb, local); 
-}
-
-void
-mono_mb_set_clauses (MonoMethodBuilder *mb, int num_clauses, MonoExceptionClause *clauses)
-{
-	mb->num_clauses = num_clauses;
-	mb->clauses = clauses;
-}
-
-/*
- * mono_mb_set_param_names:
- *
- *   PARAM_NAMES should have length equal to the sig->param_count, the caller retains
- * ownership of the array, and its entries.
- */
-void
-mono_mb_set_param_names (MonoMethodBuilder *mb, const char **param_names)
-{
-	mb->param_names = param_names;
-}
-
-#endif /* DISABLE_JIT */

--- a/mono/metadata/method-builder.h
+++ b/mono/metadata/method-builder.h
@@ -21,22 +21,16 @@
 
 G_BEGIN_DECLS
 
-typedef struct _MonoMethodBuilder {
-	MonoMethod *method;
-	char *name;
-	gboolean no_dup_name;
-#ifdef ENABLE_ILGEN
-	GList *locals_list;
-	int locals;
-	gboolean dynamic;
-	gboolean skip_visibility, init_locals;
-	guint32 code_size, pos;
-	unsigned char *code;
-	int num_clauses;
-	MonoExceptionClause *clauses;
-	const char **param_names;
-#endif
-} MonoMethodBuilder;
+typedef struct _MonoMethodBuilder MonoMethodBuilder;
+
+#define MONO_METHOD_BUILDER_CALLBACKS_VERSION 1
+
+typedef struct {
+	int version;
+	MonoMethodBuilder* (*new_base) (MonoClass *klass, MonoWrapperType type);
+	void (*free) (MonoMethodBuilder *mb);
+	MonoMethod* (*create_method) (MonoMethodBuilder *mb, MonoMethodSignature *signature, int max_stack);
+} MonoMethodBuilderCallbacks;
 
 MonoMethodBuilder *
 mono_mb_new (MonoClass *klass, const char *name, MonoWrapperType type);
@@ -53,113 +47,8 @@ mono_mb_create_method (MonoMethodBuilder *mb, MonoMethodSignature *signature, in
 guint32
 mono_mb_add_data (MonoMethodBuilder *mb, gpointer data);
 
-#ifdef ENABLE_ILGEN
 void
-mono_mb_patch_addr (MonoMethodBuilder *mb, int pos, int value);
-
-void
-mono_mb_patch_addr_s (MonoMethodBuilder *mb, int pos, gint8 value);
-
-void
-mono_mb_patch_branch (MonoMethodBuilder *mb, guint32 pos);
-
-void
-mono_mb_patch_short_branch (MonoMethodBuilder *mb, guint32 pos);
-
-int
-mono_mb_get_label (MonoMethodBuilder *mb);
-
-int
-mono_mb_get_pos (MonoMethodBuilder *mb);
-
-void
-mono_mb_emit_ptr (MonoMethodBuilder *mb, gpointer ptr);
-
-void
-mono_mb_emit_calli (MonoMethodBuilder *mb, MonoMethodSignature *sig);
-
-void
-mono_mb_emit_native_call (MonoMethodBuilder *mb, MonoMethodSignature *sig, gpointer func);
-
-void
-mono_mb_emit_managed_call (MonoMethodBuilder *mb, MonoMethod *method, MonoMethodSignature *opt_sig);
-
-void
-mono_mb_emit_icall (MonoMethodBuilder *mb, gpointer func);
-
-int
-mono_mb_add_local (MonoMethodBuilder *mb, MonoType *type);
-
-void
-mono_mb_emit_ldarg (MonoMethodBuilder *mb, guint argnum);
-
-void
-mono_mb_emit_ldarg_addr (MonoMethodBuilder *mb, guint argnum);
-
-void
-mono_mb_emit_ldloc (MonoMethodBuilder *mb, guint num);
-
-void
-mono_mb_emit_ldloc_addr (MonoMethodBuilder *mb, guint locnum);
-
-void
-mono_mb_emit_stloc (MonoMethodBuilder *mb, guint num);
-
-void
-mono_mb_emit_exception (MonoMethodBuilder *mb, const char *exc_name, const char *msg);
-
-void
-mono_mb_emit_exception_full (MonoMethodBuilder *mb, const char *exc_nspace, const char *exc_name, const char *msg);
-
-void
-mono_mb_emit_exception_for_error (MonoMethodBuilder *mb, MonoError *error);
-
-void
-mono_mb_emit_icon (MonoMethodBuilder *mb, gint32 value);
-
-void
-mono_mb_emit_icon8 (MonoMethodBuilder *mb, gint64 value);
-
-guint32
-mono_mb_emit_branch (MonoMethodBuilder *mb, guint8 op);
-
-guint32
-mono_mb_emit_short_branch (MonoMethodBuilder *mb, guint8 op);
-
-void
-mono_mb_emit_branch_label (MonoMethodBuilder *mb, guint8 op, guint32 label);
-
-void
-mono_mb_emit_add_to_local (MonoMethodBuilder *mb, guint16 local, gint32 incr);
-
-void
-mono_mb_emit_ldflda (MonoMethodBuilder *mb, gint32 offset);
-
-void
-mono_mb_emit_byte (MonoMethodBuilder *mb, guint8 op);
-
-void
-mono_mb_emit_i2 (MonoMethodBuilder *mb, gint16 data);
-
-void
-mono_mb_emit_i4 (MonoMethodBuilder *mb, gint32 data);
-
-void
-mono_mb_emit_i8 (MonoMethodBuilder *mb, gint64 data);
-
-void
-mono_mb_emit_op (MonoMethodBuilder *mb, guint8 op, gpointer data);
-
-void
-mono_mb_emit_ldstr (MonoMethodBuilder *mb, char *str);
-
-void
-mono_mb_set_clauses (MonoMethodBuilder *mb, int num_clauses, MonoExceptionClause *clauses);
-
-void
-mono_mb_set_param_names (MonoMethodBuilder *mb, const char **param_names);
-
-#endif
+mono_install_method_builder_callbacks (MonoMethodBuilderCallbacks *cb);
 
 G_END_DECLS
 

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -12,6 +12,7 @@
 #include "config.h"
 
 #include "mono/metadata/handle.h"
+#include "mono/metadata/method-builder-ilgen-internals.h"
 #include "mono/metadata/remoting.h"
 #include "mono/metadata/marshal.h"
 #include "mono/metadata/marshal-internals.h"

--- a/mono/metadata/sgen-mono-ilgen.c
+++ b/mono/metadata/sgen-mono-ilgen.c
@@ -1,0 +1,545 @@
+/**
+ * \file
+ * Copyright 2018 Microsoft
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+#include "config.h"
+#ifdef HAVE_SGEN_GC
+
+#include "metadata/method-builder.h"
+#include "metadata/method-builder-ilgen.h"
+#include "metadata/method-builder-ilgen-internals.h"
+#include "sgen/sgen-gc.h"
+#include "sgen/sgen-protocol.h"
+#include "metadata/monitor.h"
+#include "sgen/sgen-layout-stats.h"
+#include "sgen/sgen-client.h"
+#include "sgen/sgen-cardtable.h"
+#include "sgen/sgen-pinning.h"
+#include "sgen/sgen-workers.h"
+#include "metadata/marshal.h"
+#include "metadata/abi-details.h"
+#include "metadata/mono-gc.h"
+#include "metadata/runtime.h"
+#include "metadata/sgen-bridge-internals.h"
+#include "metadata/sgen-mono.h"
+#include "metadata/sgen-mono-ilgen.h"
+#include "metadata/gc-internals.h"
+#include "metadata/handle.h"
+#include "utils/mono-memory-model.h"
+#include "utils/mono-logger-internals.h"
+#include "utils/mono-threads-coop.h"
+#include "utils/mono-threads.h"
+#include "metadata/w32handle.h"
+
+#define OPDEF(a,b,c,d,e,f,g,h,i,j) \
+	a = i,
+
+enum {
+#include "mono/cil/opcode.def"
+	CEE_LAST
+};
+
+#undef OPDEF
+
+#ifdef MANAGED_ALLOCATION
+// Cache the SgenThreadInfo pointer in a local 'var'.
+#define EMIT_TLS_ACCESS_VAR(mb, var) \
+	do { \
+		var = mono_mb_add_local ((mb), &mono_defaults.int_class->byval_arg); \
+		mono_mb_emit_byte ((mb), MONO_CUSTOM_PREFIX); \
+		mono_mb_emit_byte ((mb), CEE_MONO_TLS); \
+		mono_mb_emit_i4 ((mb), TLS_KEY_SGEN_THREAD_INFO); \
+		mono_mb_emit_stloc ((mb), (var)); \
+	} while (0)
+
+#define EMIT_TLS_ACCESS_IN_CRITICAL_REGION_ADDR(mb, var) \
+	do { \
+		mono_mb_emit_ldloc ((mb), (var)); \
+		mono_mb_emit_icon ((mb), MONO_STRUCT_OFFSET (SgenClientThreadInfo, in_critical_region)); \
+		mono_mb_emit_byte ((mb), CEE_ADD); \
+	} while (0)
+
+#define EMIT_TLS_ACCESS_NEXT_ADDR(mb, var)	do {	\
+	mono_mb_emit_ldloc ((mb), (var));		\
+	mono_mb_emit_icon ((mb), MONO_STRUCT_OFFSET (SgenThreadInfo, tlab_next));	\
+	mono_mb_emit_byte ((mb), CEE_ADD);		\
+	} while (0)
+
+#define EMIT_TLS_ACCESS_TEMP_END(mb, var)	do {	\
+	mono_mb_emit_ldloc ((mb), (var));		\
+	mono_mb_emit_icon ((mb), MONO_STRUCT_OFFSET (SgenThreadInfo, tlab_temp_end));	\
+	mono_mb_emit_byte ((mb), CEE_ADD);		\
+	mono_mb_emit_byte ((mb), CEE_LDIND_I);		\
+	} while (0)
+#endif
+
+static void
+emit_nursery_check (MonoMethodBuilder *mb, int *nursery_check_return_labels, gboolean is_concurrent)
+{
+	int shifted_nursery_start = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+
+	memset (nursery_check_return_labels, 0, sizeof (int) * 2);
+	// if (ptr_in_nursery (ptr)) return;
+	/*
+	 * Masking out the bits might be faster, but we would have to use 64 bit
+	 * immediates, which might be slower.
+	 */
+	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+	mono_mb_emit_byte (mb, CEE_MONO_LDPTR_NURSERY_START);
+	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+	mono_mb_emit_byte (mb, CEE_MONO_LDPTR_NURSERY_BITS);
+	mono_mb_emit_byte (mb, CEE_SHR_UN);
+	mono_mb_emit_stloc (mb, shifted_nursery_start);
+
+	mono_mb_emit_ldarg (mb, 0);
+	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+	mono_mb_emit_byte (mb, CEE_MONO_LDPTR_NURSERY_BITS);
+	mono_mb_emit_byte (mb, CEE_SHR_UN);
+	mono_mb_emit_ldloc (mb, shifted_nursery_start);
+	nursery_check_return_labels [0] = mono_mb_emit_branch (mb, CEE_BEQ);
+
+	if (!is_concurrent) {
+		// if (!ptr_in_nursery (*ptr)) return;
+		mono_mb_emit_ldarg (mb, 0);
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+		mono_mb_emit_byte (mb, CEE_MONO_LDPTR_NURSERY_BITS);
+		mono_mb_emit_byte (mb, CEE_SHR_UN);
+		mono_mb_emit_ldloc (mb, shifted_nursery_start);
+		nursery_check_return_labels [1] = mono_mb_emit_branch (mb, CEE_BNE_UN);
+	}
+}
+
+static void
+emit_nursery_check_ilgen (MonoMethodBuilder *mb, gboolean is_concurrent)
+{
+#ifdef MANAGED_WBARRIER
+	int i, nursery_check_labels [2];
+	emit_nursery_check (mb, nursery_check_labels, is_concurrent);
+	/*
+	addr = sgen_cardtable + ((address >> CARD_BITS) & CARD_MASK)
+	*addr = 1;
+
+	sgen_cardtable:
+		LDC_PTR sgen_cardtable
+
+	address >> CARD_BITS
+		LDARG_0
+		LDC_I4 CARD_BITS
+		SHR_UN
+	if (SGEN_HAVE_OVERLAPPING_CARDS) {
+		LDC_PTR card_table_mask
+		AND
+	}
+	AND
+	ldc_i4_1
+	stind_i1
+	*/
+	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+	mono_mb_emit_byte (mb, CEE_MONO_LDPTR_CARD_TABLE);
+	mono_mb_emit_ldarg (mb, 0);
+	mono_mb_emit_icon (mb, CARD_BITS);
+	mono_mb_emit_byte (mb, CEE_SHR_UN);
+	mono_mb_emit_byte (mb, CEE_CONV_I);
+#ifdef SGEN_HAVE_OVERLAPPING_CARDS
+#if SIZEOF_VOID_P == 8
+	mono_mb_emit_icon8 (mb, CARD_MASK);
+#else
+	mono_mb_emit_icon (mb, CARD_MASK);
+#endif
+	mono_mb_emit_byte (mb, CEE_CONV_I);
+	mono_mb_emit_byte (mb, CEE_AND);
+#endif
+	mono_mb_emit_byte (mb, CEE_ADD);
+	mono_mb_emit_icon (mb, 1);
+	mono_mb_emit_byte (mb, CEE_STIND_I1);
+
+	// return;
+	for (i = 0; i < 2; ++i) {
+		if (nursery_check_labels [i])
+			mono_mb_patch_branch (mb, nursery_check_labels [i]);
+	}
+	mono_mb_emit_byte (mb, CEE_RET);
+#else
+	mono_mb_emit_ldarg (mb, 0);
+	mono_mb_emit_icall (mb, mono_gc_wbarrier_generic_nostore);
+	mono_mb_emit_byte (mb, CEE_RET);
+#endif
+}
+
+static void
+emit_managed_allocater_ilgen (MonoMethodBuilder *mb, gboolean slowpath, gboolean profiler, int atype)
+{
+	int p_var, size_var, real_size_var, thread_var G_GNUC_UNUSED;
+	int tlab_next_addr_var, new_next_var;
+	guint32 fastpath_branch, max_size_branch, no_oom_branch;
+
+	if (slowpath) {
+		switch (atype) {
+		case ATYPE_NORMAL:
+		case ATYPE_SMALL:
+			mono_mb_emit_ldarg (mb, 0);
+			mono_mb_emit_icall (mb, ves_icall_object_new_specific);
+			break;
+		case ATYPE_VECTOR:
+			mono_mb_emit_ldarg (mb, 0);
+			mono_mb_emit_ldarg (mb, 1);
+			mono_mb_emit_icall (mb, ves_icall_array_new_specific);
+			break;
+		case ATYPE_STRING:
+			mono_mb_emit_ldarg (mb, 1);
+			mono_mb_emit_icall (mb, ves_icall_string_alloc);
+			break;
+		default:
+			g_assert_not_reached ();
+		}
+
+		goto done;
+	}
+
+	/*
+	 * Tls access might call foreign code or code without jinfo. This can
+	 * only happen if we are outside of the critical region.
+	 */
+	EMIT_TLS_ACCESS_VAR (mb, thread_var);
+
+	size_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+	if (atype == ATYPE_SMALL) {
+		/* size_var = size_arg */
+		mono_mb_emit_ldarg (mb, 1);
+		mono_mb_emit_stloc (mb, size_var);
+	} else if (atype == ATYPE_NORMAL) {
+		/* size = vtable->klass->instance_size; */
+		mono_mb_emit_ldarg (mb, 0);
+		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoVTable, klass));
+		mono_mb_emit_byte (mb, CEE_ADD);
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoClass, instance_size));
+		mono_mb_emit_byte (mb, CEE_ADD);
+		/* FIXME: assert instance_size stays a 4 byte integer */
+		mono_mb_emit_byte (mb, CEE_LDIND_U4);
+		mono_mb_emit_byte (mb, CEE_CONV_I);
+		mono_mb_emit_stloc (mb, size_var);
+	} else if (atype == ATYPE_VECTOR) {
+		MonoExceptionClause *clause;
+		int pos, pos_leave, pos_error;
+		MonoClass *oom_exc_class;
+		MonoMethod *ctor;
+
+		/*
+		 * n > MONO_ARRAY_MAX_INDEX => OutOfMemoryException
+		 * n < 0                    => OverflowException
+		 *
+		 * We can do an unsigned comparison to catch both cases, then in the error
+		 * case compare signed to distinguish between them.
+		 */
+		mono_mb_emit_ldarg (mb, 1);
+		mono_mb_emit_icon (mb, MONO_ARRAY_MAX_INDEX);
+		mono_mb_emit_byte (mb, CEE_CONV_U);
+		pos = mono_mb_emit_short_branch (mb, CEE_BLE_UN_S);
+
+		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+		mono_mb_emit_byte (mb, CEE_MONO_NOT_TAKEN);
+		mono_mb_emit_ldarg (mb, 1);
+		mono_mb_emit_icon (mb, 0);
+		pos_error = mono_mb_emit_short_branch (mb, CEE_BLT_S);
+		mono_mb_emit_exception (mb, "OutOfMemoryException", NULL);
+		mono_mb_patch_short_branch (mb, pos_error);
+		mono_mb_emit_exception (mb, "OverflowException", NULL);
+
+		mono_mb_patch_short_branch (mb, pos);
+
+		clause = (MonoExceptionClause *)mono_image_alloc0 (mono_defaults.corlib, sizeof (MonoExceptionClause));
+		clause->try_offset = mono_mb_get_label (mb);
+
+		/* vtable->klass->sizes.element_size */
+		mono_mb_emit_ldarg (mb, 0);
+		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoVTable, klass));
+		mono_mb_emit_byte (mb, CEE_ADD);
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoClass, sizes));
+		mono_mb_emit_byte (mb, CEE_ADD);
+		mono_mb_emit_byte (mb, CEE_LDIND_U4);
+		mono_mb_emit_byte (mb, CEE_CONV_I);
+
+		/* * n */
+		mono_mb_emit_ldarg (mb, 1);
+		mono_mb_emit_byte (mb, CEE_MUL_OVF_UN);
+		/* + sizeof (MonoArray) */
+		mono_mb_emit_icon (mb, MONO_SIZEOF_MONO_ARRAY);
+		mono_mb_emit_byte (mb, CEE_ADD_OVF_UN);
+		mono_mb_emit_stloc (mb, size_var);
+
+		pos_leave = mono_mb_emit_branch (mb, CEE_LEAVE);
+
+		/* catch */
+		clause->flags = MONO_EXCEPTION_CLAUSE_NONE;
+		clause->try_len = mono_mb_get_pos (mb) - clause->try_offset;
+		clause->data.catch_class = mono_class_load_from_name (mono_defaults.corlib,
+				"System", "OverflowException");
+		clause->handler_offset = mono_mb_get_label (mb);
+
+		oom_exc_class = mono_class_load_from_name (mono_defaults.corlib,
+				"System", "OutOfMemoryException");
+		ctor = mono_class_get_method_from_name (oom_exc_class, ".ctor", 0);
+		g_assert (ctor);
+
+		mono_mb_emit_byte (mb, CEE_POP);
+		mono_mb_emit_op (mb, CEE_NEWOBJ, ctor);
+		mono_mb_emit_byte (mb, CEE_THROW);
+
+		clause->handler_len = mono_mb_get_pos (mb) - clause->handler_offset;
+		mono_mb_set_clauses (mb, 1, clause);
+		mono_mb_patch_branch (mb, pos_leave);
+		/* end catch */
+	} else if (atype == ATYPE_STRING) {
+		int pos;
+
+		/*
+		 * a string allocator method takes the args: (vtable, len)
+		 *
+		 * bytes = offsetof (MonoString, chars) + ((len + 1) * 2)
+		 *
+		 * condition:
+		 *
+		 * bytes <= INT32_MAX - (SGEN_ALLOC_ALIGN - 1)
+		 *
+		 * therefore:
+		 *
+		 * offsetof (MonoString, chars) + ((len + 1) * 2) <= INT32_MAX - (SGEN_ALLOC_ALIGN - 1)
+		 * len <= (INT32_MAX - (SGEN_ALLOC_ALIGN - 1) - offsetof (MonoString, chars)) / 2 - 1
+		 */
+		mono_mb_emit_ldarg (mb, 1);
+		mono_mb_emit_icon (mb, (INT32_MAX - (SGEN_ALLOC_ALIGN - 1) - MONO_STRUCT_OFFSET (MonoString, chars)) / 2 - 1);
+		pos = mono_mb_emit_short_branch (mb, MONO_CEE_BLE_UN_S);
+
+		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+		mono_mb_emit_byte (mb, CEE_MONO_NOT_TAKEN);
+		mono_mb_emit_exception (mb, "OutOfMemoryException", NULL);
+		mono_mb_patch_short_branch (mb, pos);
+
+		mono_mb_emit_ldarg (mb, 1);
+		mono_mb_emit_icon (mb, 1);
+		mono_mb_emit_byte (mb, MONO_CEE_SHL);
+		//WE manually fold the above + 2 here
+		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoString, chars) + 2);
+		mono_mb_emit_byte (mb, CEE_ADD);
+		mono_mb_emit_stloc (mb, size_var);
+	} else {
+		g_assert_not_reached ();
+	}
+
+#ifdef MANAGED_ALLOCATOR_CAN_USE_CRITICAL_REGION
+	EMIT_TLS_ACCESS_IN_CRITICAL_REGION_ADDR (mb, thread_var);
+	mono_mb_emit_byte (mb, CEE_LDC_I4_1);
+	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+	mono_mb_emit_byte (mb, CEE_MONO_ATOMIC_STORE_I4);
+	mono_mb_emit_i4 (mb, MONO_MEMORY_BARRIER_NONE);
+#endif
+
+	if (nursery_canaries_enabled ()) {
+		real_size_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+		mono_mb_emit_ldloc (mb, size_var);
+		mono_mb_emit_stloc(mb, real_size_var);
+	}
+	else
+		real_size_var = size_var;
+
+	/* size += ALLOC_ALIGN - 1; */
+	mono_mb_emit_ldloc (mb, size_var);
+	mono_mb_emit_icon (mb, SGEN_ALLOC_ALIGN - 1);
+	mono_mb_emit_byte (mb, CEE_ADD);
+	/* size &= ~(ALLOC_ALIGN - 1); */
+	mono_mb_emit_icon (mb, ~(SGEN_ALLOC_ALIGN - 1));
+	mono_mb_emit_byte (mb, CEE_AND);
+	mono_mb_emit_stloc (mb, size_var);
+
+	/* if (size > MAX_SMALL_OBJ_SIZE) goto slowpath */
+	if (atype != ATYPE_SMALL) {
+		mono_mb_emit_ldloc (mb, size_var);
+		mono_mb_emit_icon (mb, SGEN_MAX_SMALL_OBJ_SIZE);
+		max_size_branch = mono_mb_emit_short_branch (mb, MONO_CEE_BGT_UN_S);
+	}
+
+	/*
+	 * We need to modify tlab_next, but the JIT only supports reading, so we read
+	 * another tls var holding its address instead.
+	 */
+
+	/* tlab_next_addr (local) = tlab_next_addr (TLS var) */
+	tlab_next_addr_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+	EMIT_TLS_ACCESS_NEXT_ADDR (mb, thread_var);
+	mono_mb_emit_stloc (mb, tlab_next_addr_var);
+
+	/* p = (void**)tlab_next; */
+	p_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+	mono_mb_emit_ldloc (mb, tlab_next_addr_var);
+	mono_mb_emit_byte (mb, CEE_LDIND_I);
+	mono_mb_emit_stloc (mb, p_var);
+	
+	/* new_next = (char*)p + size; */
+	new_next_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
+	mono_mb_emit_ldloc (mb, p_var);
+	mono_mb_emit_ldloc (mb, size_var);
+	mono_mb_emit_byte (mb, CEE_CONV_I);
+	mono_mb_emit_byte (mb, CEE_ADD);
+
+	if (nursery_canaries_enabled ()) {
+			mono_mb_emit_icon (mb, CANARY_SIZE);
+			mono_mb_emit_byte (mb, CEE_ADD);
+	}
+	mono_mb_emit_stloc (mb, new_next_var);
+
+	/* if (G_LIKELY (new_next < tlab_temp_end)) */
+	mono_mb_emit_ldloc (mb, new_next_var);
+	EMIT_TLS_ACCESS_TEMP_END (mb, thread_var);
+	fastpath_branch = mono_mb_emit_short_branch (mb, MONO_CEE_BLT_UN_S);
+
+	/* Slowpath */
+	if (atype != ATYPE_SMALL)
+		mono_mb_patch_short_branch (mb, max_size_branch);
+
+	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+	mono_mb_emit_byte (mb, CEE_MONO_NOT_TAKEN);
+	/*
+	 * We are no longer in a critical section. We need to do this before calling
+	 * to unmanaged land in order to avoid stw deadlocks since unmanaged code
+	 * might take locks.
+	 */
+#ifdef MANAGED_ALLOCATOR_CAN_USE_CRITICAL_REGION
+	EMIT_TLS_ACCESS_IN_CRITICAL_REGION_ADDR (mb, thread_var);
+	mono_mb_emit_byte (mb, CEE_LDC_I4_0);
+	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+	mono_mb_emit_byte (mb, CEE_MONO_ATOMIC_STORE_I4);
+	mono_mb_emit_i4 (mb, MONO_MEMORY_BARRIER_NONE);
+#endif
+
+	/* FIXME: mono_gc_alloc_obj takes a 'size_t' as an argument, not an int32 */
+	mono_mb_emit_ldarg (mb, 0);
+	mono_mb_emit_ldloc (mb, real_size_var);
+	if (atype == ATYPE_NORMAL || atype == ATYPE_SMALL) {
+		mono_mb_emit_icall (mb, mono_gc_alloc_obj);
+	} else if (atype == ATYPE_VECTOR) {
+		mono_mb_emit_ldarg (mb, 1);
+		mono_mb_emit_icall (mb, mono_gc_alloc_vector);
+	} else if (atype == ATYPE_STRING) {
+		mono_mb_emit_ldarg (mb, 1);
+		mono_mb_emit_icall (mb, mono_gc_alloc_string);
+	} else {
+		g_assert_not_reached ();
+	}
+
+	/* if (ret == NULL) throw OOM; */
+	mono_mb_emit_byte (mb, CEE_DUP);
+	no_oom_branch = mono_mb_emit_branch (mb, CEE_BRTRUE);
+	mono_mb_emit_exception (mb, "OutOfMemoryException", NULL);
+
+	mono_mb_patch_branch (mb, no_oom_branch);
+	mono_mb_emit_byte (mb, CEE_RET);
+
+	/* Fastpath */
+	mono_mb_patch_short_branch (mb, fastpath_branch);
+
+	/* FIXME: Memory barrier */
+
+	/* tlab_next = new_next */
+	mono_mb_emit_ldloc (mb, tlab_next_addr_var);
+	mono_mb_emit_ldloc (mb, new_next_var);
+	mono_mb_emit_byte (mb, CEE_STIND_I);
+
+	/* *p = vtable; */
+	mono_mb_emit_ldloc (mb, p_var);
+	mono_mb_emit_ldarg (mb, 0);
+	mono_mb_emit_byte (mb, CEE_STIND_I);
+
+	/* mark object end with nursery word */
+	if (nursery_canaries_enabled ()) {
+			mono_mb_emit_ldloc (mb, p_var);
+			mono_mb_emit_ldloc (mb, real_size_var);
+			mono_mb_emit_byte (mb, MONO_CEE_ADD);
+			mono_mb_emit_icon8 (mb, (mword) CANARY_STRING);
+			mono_mb_emit_icon (mb, CANARY_SIZE);
+			mono_mb_emit_byte (mb, MONO_CEE_PREFIX1);
+			mono_mb_emit_byte (mb, CEE_CPBLK);
+	}
+
+	if (atype == ATYPE_VECTOR) {
+		/* arr->max_length = max_length; */
+		mono_mb_emit_ldloc (mb, p_var);
+		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoArray, max_length));
+		mono_mb_emit_ldarg (mb, 1);
+#ifdef MONO_BIG_ARRAYS
+		mono_mb_emit_byte (mb, CEE_STIND_I);
+#else
+		mono_mb_emit_byte (mb, CEE_STIND_I4);
+#endif
+	} else 	if (atype == ATYPE_STRING) {
+		/* need to set length and clear the last char */
+		/* s->length = len; */
+		mono_mb_emit_ldloc (mb, p_var);
+		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoString, length));
+		mono_mb_emit_byte (mb, MONO_CEE_ADD);
+		mono_mb_emit_ldarg (mb, 1);
+		mono_mb_emit_byte (mb, MONO_CEE_STIND_I4);
+	}
+
+#ifdef MANAGED_ALLOCATOR_CAN_USE_CRITICAL_REGION
+	EMIT_TLS_ACCESS_IN_CRITICAL_REGION_ADDR (mb, thread_var);
+	mono_mb_emit_byte (mb, CEE_LDC_I4_0);
+	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+	mono_mb_emit_byte (mb, CEE_MONO_ATOMIC_STORE_I4);
+#else
+	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+	mono_mb_emit_byte (mb, CEE_MONO_MEMORY_BARRIER);
+#endif
+	/*
+	We must make sure both vtable and max_length are globaly visible before returning to managed land.
+	*/
+	mono_mb_emit_i4 (mb, MONO_MEMORY_BARRIER_REL);
+
+	/* return p */
+	mono_mb_emit_ldloc (mb, p_var);
+
+ done:
+
+	/*
+	 * It's important that we do this outside of the critical region as we
+	 * will be invoking arbitrary code.
+	 */
+	if (profiler) {
+		/*
+		 * if (G_UNLIKELY (*&mono_profiler_state.gc_allocation_count)) {
+		 * 	mono_profiler_raise_gc_allocation (p);
+		 * }
+		 */
+
+		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+		mono_mb_emit_byte (mb, CEE_MONO_LDPTR_PROFILER_ALLOCATION_COUNT);
+		mono_mb_emit_byte (mb, CEE_LDIND_U4);
+
+		int prof_br = mono_mb_emit_short_branch (mb, CEE_BRFALSE_S);
+
+		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+		mono_mb_emit_byte (mb, CEE_MONO_NOT_TAKEN);
+		mono_mb_emit_byte (mb, CEE_DUP);
+		mono_mb_emit_icall (mb, mono_profiler_raise_gc_allocation);
+
+		mono_mb_patch_short_branch (mb, prof_br);
+	}
+
+	mono_mb_emit_byte (mb, CEE_RET);
+	mb->init_locals = FALSE;
+}
+
+void
+mono_sgen_mono_ilgen_init (void)
+{
+	MonoSgenMonoCallbacks cb;
+	cb.version = MONO_SGEN_MONO_CALLBACKS_VERSION;
+	cb.emit_nursery_check = emit_nursery_check_ilgen;
+	cb.emit_managed_allocater = emit_managed_allocater_ilgen;
+	mono_install_sgen_mono_callbacks (&cb);
+}
+#endif
+

--- a/mono/metadata/sgen-mono-ilgen.h
+++ b/mono/metadata/sgen-mono-ilgen.h
@@ -1,0 +1,13 @@
+/**
+ * \file
+ * Copyright 2018 Microsoft
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+#ifndef __MONO_SGEN_MONO_ILGEN_H__
+#define __MONO_SGEN_MONO_ILGEN_H__
+
+#include "config.h"
+
+MONO_API void
+mono_sgen_mono_ilgen_init (void);
+#endif

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -24,6 +24,8 @@
 #include "metadata/mono-gc.h"
 #include "metadata/runtime.h"
 #include "metadata/sgen-bridge-internals.h"
+#include "metadata/sgen-mono.h"
+#include "metadata/sgen-mono-ilgen.h"
 #include "metadata/gc-internals.h"
 #include "metadata/handle.h"
 #include "utils/mono-memory-model.h"
@@ -51,16 +53,6 @@ gboolean sgen_mono_xdomain_checks = FALSE;
 static MonoGCCallbacks gc_callbacks;
 
 #define ALIGN_TO(val,align) ((((guint64)val) + ((align) - 1)) & ~((align) - 1))
-
-#define OPDEF(a,b,c,d,e,f,g,h,i,j) \
-	a = i,
-
-enum {
-#include "mono/cil/opcode.def"
-	CEE_LAST
-};
-
-#undef OPDEF
 
 /*
  * Write barriers
@@ -225,45 +217,50 @@ mono_gc_is_critical_method (MonoMethod *method)
 	return sgen_is_critical_method (method);
 }
 
-#ifdef ENABLE_ILGEN
+static void
+emit_nursery_check_noilgen (MonoMethodBuilder *mb, gboolean is_concurrent)
+{
+}
+
+static MonoSgenMonoCallbacks sgenmono_cb;
+static gboolean cb_inited = FALSE;
+
+void
+mono_install_sgen_mono_callbacks (MonoSgenMonoCallbacks *cb)
+{
+	g_assert (!cb_inited);
+	g_assert (cb->version == MONO_SGEN_MONO_CALLBACKS_VERSION);
+	memcpy (&sgenmono_cb, cb, sizeof (MonoSgenMonoCallbacks));
+	cb_inited = TRUE;
+}
 
 static void
-emit_nursery_check (MonoMethodBuilder *mb, int *nursery_check_return_labels, gboolean is_concurrent)
+emit_managed_allocater_noilgen (MonoMethodBuilder *mb, gboolean slowpath, gboolean profiler, int atype)
 {
-	int shifted_nursery_start = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-
-	memset (nursery_check_return_labels, 0, sizeof (int) * 2);
-	// if (ptr_in_nursery (ptr)) return;
-	/*
-	 * Masking out the bits might be faster, but we would have to use 64 bit
-	 * immediates, which might be slower.
-	 */
-	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-	mono_mb_emit_byte (mb, CEE_MONO_LDPTR_NURSERY_START);
-	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-	mono_mb_emit_byte (mb, CEE_MONO_LDPTR_NURSERY_BITS);
-	mono_mb_emit_byte (mb, CEE_SHR_UN);
-	mono_mb_emit_stloc (mb, shifted_nursery_start);
-
-	mono_mb_emit_ldarg (mb, 0);
-	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-	mono_mb_emit_byte (mb, CEE_MONO_LDPTR_NURSERY_BITS);
-	mono_mb_emit_byte (mb, CEE_SHR_UN);
-	mono_mb_emit_ldloc (mb, shifted_nursery_start);
-	nursery_check_return_labels [0] = mono_mb_emit_branch (mb, CEE_BEQ);
-
-	if (!is_concurrent) {
-		// if (!ptr_in_nursery (*ptr)) return;
-		mono_mb_emit_ldarg (mb, 0);
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-		mono_mb_emit_byte (mb, CEE_MONO_LDPTR_NURSERY_BITS);
-		mono_mb_emit_byte (mb, CEE_SHR_UN);
-		mono_mb_emit_ldloc (mb, shifted_nursery_start);
-		nursery_check_return_labels [1] = mono_mb_emit_branch (mb, CEE_BNE_UN);
-	}
 }
+
+static void
+install_noilgen (void)
+{
+	MonoSgenMonoCallbacks cb;
+	cb.version = MONO_SGEN_MONO_CALLBACKS_VERSION;
+	cb.emit_nursery_check = emit_nursery_check_noilgen;
+	cb.emit_managed_allocater = emit_managed_allocater_noilgen;
+	mono_install_sgen_mono_callbacks (&cb);
+}
+
+static MonoSgenMonoCallbacks *
+get_sgen_mono_cb (void)
+{
+	if (G_UNLIKELY (!cb_inited)) {
+#ifdef ENABLE_ILGEN
+		mono_sgen_mono_ilgen_init ();
+#else
+		install_noilgen ();
 #endif
+	}
+	return &sgenmono_cb;
+}
 
 MonoMethod*
 mono_gc_get_specific_write_barrier (gboolean is_concurrent)
@@ -273,10 +270,6 @@ mono_gc_get_specific_write_barrier (gboolean is_concurrent)
 	MonoMethodSignature *sig;
 	MonoMethod **write_barrier_method_addr;
 	WrapperInfo *info;
-#ifdef MANAGED_WBARRIER
-	int i, nursery_check_labels [2];
-#endif
-
 	// FIXME: Maybe create a separate version for ctors (the branch would be
 	// correctly predicted more times)
 	if (is_concurrent)
@@ -297,59 +290,8 @@ mono_gc_get_specific_write_barrier (gboolean is_concurrent)
 	else
 		mb = mono_mb_new (mono_defaults.object_class, "wbarrier_noconc", MONO_WRAPPER_WRITE_BARRIER);
 
-#ifdef ENABLE_ILGEN
-#ifdef MANAGED_WBARRIER
-	emit_nursery_check (mb, nursery_check_labels, is_concurrent);
-	/*
-	addr = sgen_cardtable + ((address >> CARD_BITS) & CARD_MASK)
-	*addr = 1;
+	get_sgen_mono_cb ()->emit_nursery_check (mb, is_concurrent);
 
-	sgen_cardtable:
-		LDC_PTR sgen_cardtable
-
-	address >> CARD_BITS
-		LDARG_0
-		LDC_I4 CARD_BITS
-		SHR_UN
-	if (SGEN_HAVE_OVERLAPPING_CARDS) {
-		LDC_PTR card_table_mask
-		AND
-	}
-	AND
-	ldc_i4_1
-	stind_i1
-	*/
-	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-	mono_mb_emit_byte (mb, CEE_MONO_LDPTR_CARD_TABLE);
-	mono_mb_emit_ldarg (mb, 0);
-	mono_mb_emit_icon (mb, CARD_BITS);
-	mono_mb_emit_byte (mb, CEE_SHR_UN);
-	mono_mb_emit_byte (mb, CEE_CONV_I);
-#ifdef SGEN_HAVE_OVERLAPPING_CARDS
-#if SIZEOF_VOID_P == 8
-	mono_mb_emit_icon8 (mb, CARD_MASK);
-#else
-	mono_mb_emit_icon (mb, CARD_MASK);
-#endif
-	mono_mb_emit_byte (mb, CEE_CONV_I);
-	mono_mb_emit_byte (mb, CEE_AND);
-#endif
-	mono_mb_emit_byte (mb, CEE_ADD);
-	mono_mb_emit_icon (mb, 1);
-	mono_mb_emit_byte (mb, CEE_STIND_I1);
-
-	// return;
-	for (i = 0; i < 2; ++i) {
-		if (nursery_check_labels [i])
-			mono_mb_patch_branch (mb, nursery_check_labels [i]);
-	}
-	mono_mb_emit_byte (mb, CEE_RET);
-#else
-	mono_mb_emit_ldarg (mb, 0);
-	mono_mb_emit_icall (mb, mono_gc_wbarrier_generic_nostore);
-	mono_mb_emit_byte (mb, CEE_RET);
-#endif
-#endif
 	res = mono_mb_create_method (mb, sig, 16);
 	info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_NONE);
 	mono_marshal_set_wrapper_info (res, info);
@@ -1013,41 +955,11 @@ mono_gc_free_fixed (void* addr)
  * Managed allocator
  */
 
+#ifdef MANAGED_ALLOCATION
 static MonoMethod* alloc_method_cache [ATYPE_NUM];
 static MonoMethod* slowpath_alloc_method_cache [ATYPE_NUM];
 static MonoMethod* profiler_alloc_method_cache [ATYPE_NUM];
 static gboolean use_managed_allocator = TRUE;
-
-#ifdef MANAGED_ALLOCATION
-// Cache the SgenThreadInfo pointer in a local 'var'.
-#define EMIT_TLS_ACCESS_VAR(mb, var) \
-	do { \
-		var = mono_mb_add_local ((mb), &mono_defaults.int_class->byval_arg); \
-		mono_mb_emit_byte ((mb), MONO_CUSTOM_PREFIX); \
-		mono_mb_emit_byte ((mb), CEE_MONO_TLS); \
-		mono_mb_emit_i4 ((mb), TLS_KEY_SGEN_THREAD_INFO); \
-		mono_mb_emit_stloc ((mb), (var)); \
-	} while (0)
-
-#define EMIT_TLS_ACCESS_IN_CRITICAL_REGION_ADDR(mb, var) \
-	do { \
-		mono_mb_emit_ldloc ((mb), (var)); \
-		mono_mb_emit_icon ((mb), MONO_STRUCT_OFFSET (SgenClientThreadInfo, in_critical_region)); \
-		mono_mb_emit_byte ((mb), CEE_ADD); \
-	} while (0)
-
-#define EMIT_TLS_ACCESS_NEXT_ADDR(mb, var)	do {	\
-	mono_mb_emit_ldloc ((mb), (var));		\
-	mono_mb_emit_icon ((mb), MONO_STRUCT_OFFSET (SgenThreadInfo, tlab_next));	\
-	mono_mb_emit_byte ((mb), CEE_ADD);		\
-	} while (0)
-
-#define EMIT_TLS_ACCESS_TEMP_END(mb, var)	do {	\
-	mono_mb_emit_ldloc ((mb), (var));		\
-	mono_mb_emit_icon ((mb), MONO_STRUCT_OFFSET (SgenThreadInfo, tlab_temp_end));	\
-	mono_mb_emit_byte ((mb), CEE_ADD);		\
-	mono_mb_emit_byte ((mb), CEE_LDIND_I);		\
-	} while (0)
 
 /* FIXME: Do this in the JIT, where specialized allocation sequences can be created
  * for each class. This is currently not easy to do, as it is hard to generate basic 
@@ -1060,15 +972,12 @@ static gboolean use_managed_allocator = TRUE;
 static MonoMethod*
 create_allocator (int atype, ManagedAllocatorVariant variant)
 {
-	int p_var, size_var, real_size_var, thread_var G_GNUC_UNUSED;
 	gboolean slowpath = variant == MANAGED_ALLOCATOR_SLOW_PATH;
 	gboolean profiler = variant == MANAGED_ALLOCATOR_PROFILER;
-	guint32 fastpath_branch, max_size_branch, no_oom_branch;
 	MonoMethodBuilder *mb;
 	MonoMethod *res;
 	MonoMethodSignature *csig;
 	static gboolean registered = FALSE;
-	int tlab_next_addr_var, new_next_var;
 	const char *name = NULL;
 	WrapperInfo *info;
 	int num_params, i;
@@ -1111,374 +1020,14 @@ create_allocator (int atype, ManagedAllocatorVariant variant)
 
 	mb = mono_mb_new (mono_defaults.object_class, name, MONO_WRAPPER_ALLOC);
 
-#ifdef ENABLE_ILGEN
-	if (slowpath) {
-		switch (atype) {
-		case ATYPE_NORMAL:
-		case ATYPE_SMALL:
-			mono_mb_emit_ldarg (mb, 0);
-			mono_mb_emit_icall (mb, ves_icall_object_new_specific);
-			break;
-		case ATYPE_VECTOR:
-			mono_mb_emit_ldarg (mb, 0);
-			mono_mb_emit_ldarg (mb, 1);
-			mono_mb_emit_icall (mb, ves_icall_array_new_specific);
-			break;
-		case ATYPE_STRING:
-			mono_mb_emit_ldarg (mb, 1);
-			mono_mb_emit_icall (mb, ves_icall_string_alloc);
-			break;
-		default:
-			g_assert_not_reached ();
-		}
-
-		goto done;
-	}
-
-	/*
-	 * Tls access might call foreign code or code without jinfo. This can
-	 * only happen if we are outside of the critical region.
-	 */
-	EMIT_TLS_ACCESS_VAR (mb, thread_var);
-
-	size_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-	if (atype == ATYPE_SMALL) {
-		/* size_var = size_arg */
-		mono_mb_emit_ldarg (mb, 1);
-		mono_mb_emit_stloc (mb, size_var);
-	} else if (atype == ATYPE_NORMAL) {
-		/* size = vtable->klass->instance_size; */
-		mono_mb_emit_ldarg (mb, 0);
-		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoVTable, klass));
-		mono_mb_emit_byte (mb, CEE_ADD);
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoClass, instance_size));
-		mono_mb_emit_byte (mb, CEE_ADD);
-		/* FIXME: assert instance_size stays a 4 byte integer */
-		mono_mb_emit_byte (mb, CEE_LDIND_U4);
-		mono_mb_emit_byte (mb, CEE_CONV_I);
-		mono_mb_emit_stloc (mb, size_var);
-	} else if (atype == ATYPE_VECTOR) {
-		MonoExceptionClause *clause;
-		int pos, pos_leave, pos_error;
-		MonoClass *oom_exc_class;
-		MonoMethod *ctor;
-
-		/*
-		 * n > MONO_ARRAY_MAX_INDEX => OutOfMemoryException
-		 * n < 0                    => OverflowException
-		 *
-		 * We can do an unsigned comparison to catch both cases, then in the error
-		 * case compare signed to distinguish between them.
-		 */
-		mono_mb_emit_ldarg (mb, 1);
-		mono_mb_emit_icon (mb, MONO_ARRAY_MAX_INDEX);
-		mono_mb_emit_byte (mb, CEE_CONV_U);
-		pos = mono_mb_emit_short_branch (mb, CEE_BLE_UN_S);
-
-		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-		mono_mb_emit_byte (mb, CEE_MONO_NOT_TAKEN);
-		mono_mb_emit_ldarg (mb, 1);
-		mono_mb_emit_icon (mb, 0);
-		pos_error = mono_mb_emit_short_branch (mb, CEE_BLT_S);
-		mono_mb_emit_exception (mb, "OutOfMemoryException", NULL);
-		mono_mb_patch_short_branch (mb, pos_error);
-		mono_mb_emit_exception (mb, "OverflowException", NULL);
-
-		mono_mb_patch_short_branch (mb, pos);
-
-		clause = (MonoExceptionClause *)mono_image_alloc0 (mono_defaults.corlib, sizeof (MonoExceptionClause));
-		clause->try_offset = mono_mb_get_label (mb);
-
-		/* vtable->klass->sizes.element_size */
-		mono_mb_emit_ldarg (mb, 0);
-		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoVTable, klass));
-		mono_mb_emit_byte (mb, CEE_ADD);
-		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoClass, sizes));
-		mono_mb_emit_byte (mb, CEE_ADD);
-		mono_mb_emit_byte (mb, CEE_LDIND_U4);
-		mono_mb_emit_byte (mb, CEE_CONV_I);
-
-		/* * n */
-		mono_mb_emit_ldarg (mb, 1);
-		mono_mb_emit_byte (mb, CEE_MUL_OVF_UN);
-		/* + sizeof (MonoArray) */
-		mono_mb_emit_icon (mb, MONO_SIZEOF_MONO_ARRAY);
-		mono_mb_emit_byte (mb, CEE_ADD_OVF_UN);
-		mono_mb_emit_stloc (mb, size_var);
-
-		pos_leave = mono_mb_emit_branch (mb, CEE_LEAVE);
-
-		/* catch */
-		clause->flags = MONO_EXCEPTION_CLAUSE_NONE;
-		clause->try_len = mono_mb_get_pos (mb) - clause->try_offset;
-		clause->data.catch_class = mono_class_load_from_name (mono_defaults.corlib,
-				"System", "OverflowException");
-		clause->handler_offset = mono_mb_get_label (mb);
-
-		oom_exc_class = mono_class_load_from_name (mono_defaults.corlib,
-				"System", "OutOfMemoryException");
-		ctor = mono_class_get_method_from_name (oom_exc_class, ".ctor", 0);
-		g_assert (ctor);
-
-		mono_mb_emit_byte (mb, CEE_POP);
-		mono_mb_emit_op (mb, CEE_NEWOBJ, ctor);
-		mono_mb_emit_byte (mb, CEE_THROW);
-
-		clause->handler_len = mono_mb_get_pos (mb) - clause->handler_offset;
-		mono_mb_set_clauses (mb, 1, clause);
-		mono_mb_patch_branch (mb, pos_leave);
-		/* end catch */
-	} else if (atype == ATYPE_STRING) {
-		int pos;
-
-		/*
-		 * a string allocator method takes the args: (vtable, len)
-		 *
-		 * bytes = offsetof (MonoString, chars) + ((len + 1) * 2)
-		 *
-		 * condition:
-		 *
-		 * bytes <= INT32_MAX - (SGEN_ALLOC_ALIGN - 1)
-		 *
-		 * therefore:
-		 *
-		 * offsetof (MonoString, chars) + ((len + 1) * 2) <= INT32_MAX - (SGEN_ALLOC_ALIGN - 1)
-		 * len <= (INT32_MAX - (SGEN_ALLOC_ALIGN - 1) - offsetof (MonoString, chars)) / 2 - 1
-		 */
-		mono_mb_emit_ldarg (mb, 1);
-		mono_mb_emit_icon (mb, (INT32_MAX - (SGEN_ALLOC_ALIGN - 1) - MONO_STRUCT_OFFSET (MonoString, chars)) / 2 - 1);
-		pos = mono_mb_emit_short_branch (mb, MONO_CEE_BLE_UN_S);
-
-		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-		mono_mb_emit_byte (mb, CEE_MONO_NOT_TAKEN);
-		mono_mb_emit_exception (mb, "OutOfMemoryException", NULL);
-		mono_mb_patch_short_branch (mb, pos);
-
-		mono_mb_emit_ldarg (mb, 1);
-		mono_mb_emit_icon (mb, 1);
-		mono_mb_emit_byte (mb, MONO_CEE_SHL);
-		//WE manually fold the above + 2 here
-		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoString, chars) + 2);
-		mono_mb_emit_byte (mb, CEE_ADD);
-		mono_mb_emit_stloc (mb, size_var);
-	} else {
-		g_assert_not_reached ();
-	}
-
-#ifdef MANAGED_ALLOCATOR_CAN_USE_CRITICAL_REGION
-	EMIT_TLS_ACCESS_IN_CRITICAL_REGION_ADDR (mb, thread_var);
-	mono_mb_emit_byte (mb, CEE_LDC_I4_1);
-	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-	mono_mb_emit_byte (mb, CEE_MONO_ATOMIC_STORE_I4);
-	mono_mb_emit_i4 (mb, MONO_MEMORY_BARRIER_NONE);
-#endif
-
-	if (nursery_canaries_enabled ()) {
-		real_size_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-		mono_mb_emit_ldloc (mb, size_var);
-		mono_mb_emit_stloc(mb, real_size_var);
-	}
-	else
-		real_size_var = size_var;
-
-	/* size += ALLOC_ALIGN - 1; */
-	mono_mb_emit_ldloc (mb, size_var);
-	mono_mb_emit_icon (mb, SGEN_ALLOC_ALIGN - 1);
-	mono_mb_emit_byte (mb, CEE_ADD);
-	/* size &= ~(ALLOC_ALIGN - 1); */
-	mono_mb_emit_icon (mb, ~(SGEN_ALLOC_ALIGN - 1));
-	mono_mb_emit_byte (mb, CEE_AND);
-	mono_mb_emit_stloc (mb, size_var);
-
-	/* if (size > MAX_SMALL_OBJ_SIZE) goto slowpath */
-	if (atype != ATYPE_SMALL) {
-		mono_mb_emit_ldloc (mb, size_var);
-		mono_mb_emit_icon (mb, SGEN_MAX_SMALL_OBJ_SIZE);
-		max_size_branch = mono_mb_emit_short_branch (mb, MONO_CEE_BGT_UN_S);
-	}
-
-	/*
-	 * We need to modify tlab_next, but the JIT only supports reading, so we read
-	 * another tls var holding its address instead.
-	 */
-
-	/* tlab_next_addr (local) = tlab_next_addr (TLS var) */
-	tlab_next_addr_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-	EMIT_TLS_ACCESS_NEXT_ADDR (mb, thread_var);
-	mono_mb_emit_stloc (mb, tlab_next_addr_var);
-
-	/* p = (void**)tlab_next; */
-	p_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-	mono_mb_emit_ldloc (mb, tlab_next_addr_var);
-	mono_mb_emit_byte (mb, CEE_LDIND_I);
-	mono_mb_emit_stloc (mb, p_var);
-	
-	/* new_next = (char*)p + size; */
-	new_next_var = mono_mb_add_local (mb, &mono_defaults.int_class->byval_arg);
-	mono_mb_emit_ldloc (mb, p_var);
-	mono_mb_emit_ldloc (mb, size_var);
-	mono_mb_emit_byte (mb, CEE_CONV_I);
-	mono_mb_emit_byte (mb, CEE_ADD);
-
-	if (nursery_canaries_enabled ()) {
-			mono_mb_emit_icon (mb, CANARY_SIZE);
-			mono_mb_emit_byte (mb, CEE_ADD);
-	}
-	mono_mb_emit_stloc (mb, new_next_var);
-
-	/* if (G_LIKELY (new_next < tlab_temp_end)) */
-	mono_mb_emit_ldloc (mb, new_next_var);
-	EMIT_TLS_ACCESS_TEMP_END (mb, thread_var);
-	fastpath_branch = mono_mb_emit_short_branch (mb, MONO_CEE_BLT_UN_S);
-
-	/* Slowpath */
-	if (atype != ATYPE_SMALL)
-		mono_mb_patch_short_branch (mb, max_size_branch);
-
-	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-	mono_mb_emit_byte (mb, CEE_MONO_NOT_TAKEN);
-	/*
-	 * We are no longer in a critical section. We need to do this before calling
-	 * to unmanaged land in order to avoid stw deadlocks since unmanaged code
-	 * might take locks.
-	 */
-#ifdef MANAGED_ALLOCATOR_CAN_USE_CRITICAL_REGION
-	EMIT_TLS_ACCESS_IN_CRITICAL_REGION_ADDR (mb, thread_var);
-	mono_mb_emit_byte (mb, CEE_LDC_I4_0);
-	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-	mono_mb_emit_byte (mb, CEE_MONO_ATOMIC_STORE_I4);
-	mono_mb_emit_i4 (mb, MONO_MEMORY_BARRIER_NONE);
-#endif
-
-	/* FIXME: mono_gc_alloc_obj takes a 'size_t' as an argument, not an int32 */
-	mono_mb_emit_ldarg (mb, 0);
-	mono_mb_emit_ldloc (mb, real_size_var);
-	if (atype == ATYPE_NORMAL || atype == ATYPE_SMALL) {
-		mono_mb_emit_icall (mb, mono_gc_alloc_obj);
-	} else if (atype == ATYPE_VECTOR) {
-		mono_mb_emit_ldarg (mb, 1);
-		mono_mb_emit_icall (mb, mono_gc_alloc_vector);
-	} else if (atype == ATYPE_STRING) {
-		mono_mb_emit_ldarg (mb, 1);
-		mono_mb_emit_icall (mb, mono_gc_alloc_string);
-	} else {
-		g_assert_not_reached ();
-	}
-
-	/* if (ret == NULL) throw OOM; */
-	mono_mb_emit_byte (mb, CEE_DUP);
-	no_oom_branch = mono_mb_emit_branch (mb, CEE_BRTRUE);
-	mono_mb_emit_exception (mb, "OutOfMemoryException", NULL);
-
-	mono_mb_patch_branch (mb, no_oom_branch);
-	mono_mb_emit_byte (mb, CEE_RET);
-
-	/* Fastpath */
-	mono_mb_patch_short_branch (mb, fastpath_branch);
-
-	/* FIXME: Memory barrier */
-
-	/* tlab_next = new_next */
-	mono_mb_emit_ldloc (mb, tlab_next_addr_var);
-	mono_mb_emit_ldloc (mb, new_next_var);
-	mono_mb_emit_byte (mb, CEE_STIND_I);
-
-	/* *p = vtable; */
-	mono_mb_emit_ldloc (mb, p_var);
-	mono_mb_emit_ldarg (mb, 0);
-	mono_mb_emit_byte (mb, CEE_STIND_I);
-
-	/* mark object end with nursery word */
-	if (nursery_canaries_enabled ()) {
-			mono_mb_emit_ldloc (mb, p_var);
-			mono_mb_emit_ldloc (mb, real_size_var);
-			mono_mb_emit_byte (mb, MONO_CEE_ADD);
-			mono_mb_emit_icon8 (mb, (mword) CANARY_STRING);
-			mono_mb_emit_icon (mb, CANARY_SIZE);
-			mono_mb_emit_byte (mb, MONO_CEE_PREFIX1);
-			mono_mb_emit_byte (mb, CEE_CPBLK);
-	}
-
-	if (atype == ATYPE_VECTOR) {
-		/* arr->max_length = max_length; */
-		mono_mb_emit_ldloc (mb, p_var);
-		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoArray, max_length));
-		mono_mb_emit_ldarg (mb, 1);
-#ifdef MONO_BIG_ARRAYS
-		mono_mb_emit_byte (mb, CEE_STIND_I);
-#else
-		mono_mb_emit_byte (mb, CEE_STIND_I4);
-#endif
-	} else 	if (atype == ATYPE_STRING) {
-		/* need to set length and clear the last char */
-		/* s->length = len; */
-		mono_mb_emit_ldloc (mb, p_var);
-		mono_mb_emit_icon (mb, MONO_STRUCT_OFFSET (MonoString, length));
-		mono_mb_emit_byte (mb, MONO_CEE_ADD);
-		mono_mb_emit_ldarg (mb, 1);
-		mono_mb_emit_byte (mb, MONO_CEE_STIND_I4);
-	}
-
-#ifdef MANAGED_ALLOCATOR_CAN_USE_CRITICAL_REGION
-	EMIT_TLS_ACCESS_IN_CRITICAL_REGION_ADDR (mb, thread_var);
-	mono_mb_emit_byte (mb, CEE_LDC_I4_0);
-	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-	mono_mb_emit_byte (mb, CEE_MONO_ATOMIC_STORE_I4);
-#else
-	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-	mono_mb_emit_byte (mb, CEE_MONO_MEMORY_BARRIER);
-#endif
-	/*
-	We must make sure both vtable and max_length are globaly visible before returning to managed land.
-	*/
-	mono_mb_emit_i4 (mb, MONO_MEMORY_BARRIER_REL);
-
-	/* return p */
-	mono_mb_emit_ldloc (mb, p_var);
-
- done:
-
-	/*
-	 * It's important that we do this outside of the critical region as we
-	 * will be invoking arbitrary code.
-	 */
-	if (profiler) {
-		/*
-		 * if (G_UNLIKELY (*&mono_profiler_state.gc_allocation_count)) {
-		 * 	mono_profiler_raise_gc_allocation (p);
-		 * }
-		 */
-
-		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-		mono_mb_emit_byte (mb, CEE_MONO_LDPTR_PROFILER_ALLOCATION_COUNT);
-		mono_mb_emit_byte (mb, CEE_LDIND_U4);
-
-		int prof_br = mono_mb_emit_short_branch (mb, CEE_BRFALSE_S);
-
-		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-		mono_mb_emit_byte (mb, CEE_MONO_NOT_TAKEN);
-		mono_mb_emit_byte (mb, CEE_DUP);
-		mono_mb_emit_icall (mb, mono_profiler_raise_gc_allocation);
-
-		mono_mb_patch_short_branch (mb, prof_br);
-	}
-
-	mono_mb_emit_byte (mb, CEE_RET);
-#endif
+	get_sgen_mono_cb ()->emit_managed_allocater (mb, slowpath, profiler, atype);
 
 	info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_NONE);
 	info->d.alloc.gc_name = "sgen";
 	info->d.alloc.alloc_type = atype;
 
-#ifdef ENABLE_ILGEN
-	mb->init_locals = FALSE;
-#endif
-
 	res = mono_mb_create (mb, csig, 8, info);
 	mono_mb_free (mb);
-
 
 	return res;
 }

--- a/mono/metadata/sgen-mono.h
+++ b/mono/metadata/sgen-mono.h
@@ -1,0 +1,20 @@
+/**
+ * \file
+ * Copyright 2018 Microsoft
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+#ifndef __MONO_SGEN_MONO_H__
+#define __MONO_SGEN_MONO_H__
+
+#define MONO_SGEN_MONO_CALLBACKS_VERSION 1
+
+typedef struct {
+	int version;
+	void (*emit_nursery_check) (MonoMethodBuilder *mb, gboolean is_concurrent);
+	void (*emit_managed_allocater) (MonoMethodBuilder *mb, gboolean slowpath, gboolean profiler, int atype);
+} MonoSgenMonoCallbacks;
+
+void
+mono_install_sgen_mono_callbacks (MonoSgenMonoCallbacks *cb);
+
+#endif

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -14,6 +14,8 @@
 
 #include <mono/metadata/class.h>
 #include <mono/metadata/method-builder.h>
+#include <mono/metadata/method-builder-ilgen.h>
+#include <mono/metadata/method-builder-ilgen-internals.h>
 #include <mono/metadata/reflection-internals.h>
 #include <mono/utils/mono-counters.h>
 #include <mono/utils/atomic.h>

--- a/msvc/libmonoruntime-common.targets
+++ b/msvc/libmonoruntime-common.targets
@@ -55,6 +55,8 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\lock-tracer.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\marshal.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\marshal.h" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\marshal-ilgen.c" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\marshal-ilgen.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\marshal-internals.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\mempool.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mempool.h" />
@@ -63,7 +65,11 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\metadata-verify.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\metadata-internals.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\method-builder.h" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\method-builder-internals.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\method-builder.c" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\method-builder-ilgen.h" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\method-builder-ilgen-internals.h" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\method-builder-ilgen.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\mono-basic-block.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\mono-basic-block.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\mono-config.c" />
@@ -203,6 +209,9 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\sgen-toggleref.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\sgen-stw.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\sgen-mono.c" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\sgen-mono.h" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\sgen-mono-ilgen.c" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\sgen-mono-ilgen.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\sgen-client-mono.h" />
   </ItemGroup>
   <ItemGroup Label="libmonoruntimeinclude_headers">

--- a/msvc/libmonoruntime-common.targets.filters
+++ b/msvc/libmonoruntime-common.targets.filters
@@ -154,6 +154,12 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\marshal.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common</Filter>
     </ClInclude>
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\marshal-ilgen.c">
+      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common</Filter>
+    </ClCompile>
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\marshal-ilgen.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common</Filter>
+    </ClInclude>
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\marshal-internals.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common</Filter>
     </ClInclude>
@@ -178,7 +184,19 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\method-builder.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common</Filter>
     </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\method-builder-internals.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common</Filter>
+    </ClInclude>
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\method-builder.c">
+      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common</Filter>
+    </ClCompile>
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\method-builder-ilgen.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\method-builder-ilgen-internals.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common</Filter>
+    </ClInclude>
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\method-builder-ilgen.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common</Filter>
     </ClCompile>
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\mono-basic-block.c">
@@ -550,6 +568,15 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\sgen-mono.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common\sgen</Filter>
     </ClCompile>
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\sgen-mono.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common\sgen</Filter>
+    </ClInclude>
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\sgen-mono-ilgen.c">
+      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common\sgen</Filter>
+    </ClCompile>
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\sgen-mono-ilgen.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common\sgen</Filter>
+    </ClInclude>
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\sgen-client-mono.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common\sgen</Filter>
     </ClInclude>

--- a/winconfig.h
+++ b/winconfig.h
@@ -96,6 +96,9 @@
 /* Disable interpreter */
 /* #undef DISABLE_INTERPRETER */
 
+/* Some VES is available at runtime */
+#define ENABLE_ILGEN 1
+
 /* Enable DTrace probes */
 /* #undef ENABLE_DTRACE */
 


### PR DESCRIPTION

By adding callbacks for IL generating runtime code, we can link in code
later into the runtime that does such for configurations which do not
need IL generation initially. This is the case if you configure the
runtime with `--enable-minimal=jit,interpreter`.

In such configuration, the build will produce an additional library,
called `libmono-ilgen`.

An embedder can choose to link this library to the final binary and
initialize IL generation with the following three, newly added, API
calls:

* `void mono_marshal_ilgen_init (void)`
* `void mono_method_builder_ilgen_init (void)`
* `void mono_sgen_mono_ilgen_init (void)`

This change is mostly moving code around, but there are minor changes
like introducing the enum `MarshalTypeCheckPositions`, so we avoid
copy/paste constants across compilation units.

This PR is against `2018-02`, because it was developed and tested against it. Relevant XI changes look like this: https://github.com/xamarin/xamarin-macios/pull/3058/commits/d4ac3078568ec06452fe44fa49a4095afaaea45a


https://github.com/mono/mono/issues/6918