### PR TITLE
[interp] remove `method` field from `InterpFrame`

### DIFF
--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -121,7 +121,6 @@ typedef struct _InterpMethod
 struct _InterpFrame {
 	InterpFrame *parent; /* parent */
 	InterpMethod  *imethod; /* parent */
-	MonoMethod     *method; /* parent */
 	stackval       *retval; /* parent */
 	char           *args;
 	char           *varargs;

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -5332,7 +5332,7 @@ interp_frame_iter_next (MonoInterpStackIter *iter, StackFrameInfo *frame)
 	frame->domain = iframe->domain;
 	frame->interp_frame = iframe;
 	frame->method = iframe->imethod->method;
-	frame->actual_method = frame->method;
+	frame->actual_method = iframe->imethod->method;
 	/* This is the offset in the interpreter IR */
 	frame->native_offset = (guint8*)iframe->ip - (guint8*)iframe->imethod->code;
 	frame->ji = iframe->imethod->jinfo;


### PR DESCRIPTION
`MonoMethod *` can be accessed via `imethod->method` instead.


