### PR TITLE
[Mono.Debugger.Soft] Properly close connections

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
@@ -136,8 +136,8 @@ namespace Mono.Debugger.Soft
 		}
 
 		public void Detach () {
-			conn.VM_Dispose ();
 			conn.Close ();
+			conn.VM_Dispose ();
 			notify_vm_event (EventType.VMDisconnect, SuspendPolicy.None, 0, 0, null, 0);
 		}
 


### PR DESCRIPTION
This PR fixes https://github.com/mono/mono/issues/7377

After ```Detach``` and with the current behavior, ```receiver_thread_main``` is still running and waiting on ```Receive```.

By swapping ```VM_Dispose```/```Close``` calls, we're setting the closed flag to true, sending and reading the reply to ```VM_Dispose```, and exiting the ```receiver_thread_main```.

cc @jbevain, @DavidKarlas, @vargaz 