### PR TITLE
[2018-02] [Test] Reenable HttpRequestIgnoreBadCookies in monotouch.

### DIFF
--- a/mcs/class/System/Test/System.Net/HttpListenerRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpListenerRequestTest.cs
@@ -294,9 +294,6 @@ namespace MonoTests.System.Net
 #if FEATURE_NO_BSD_SOCKETS
 		[ExpectedException (typeof (PlatformNotSupportedException))]
 #endif
-#if MONOTOUCH
-		[Ignore ("On device sometimes hangs in the call to listener.GetContext (). See bug #60542.")]
-#endif
 		public void HttpRequestIgnoreBadCookies ()
 		{
 			var port = NetworkHelpers.FindFreePort ();


### PR DESCRIPTION
Backport of #7330.

/cc @akoeplinger