### PR TITLE
[interp] use mini infrastructure for stack walking

### DIFF
--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -2237,8 +2237,10 @@ stack_walk_adapter (MonoStackFrameInfo *frame, MonoContext *ctx, gpointer data)
 	case FRAME_TYPE_DEBUGGER_INVOKE:
 	case FRAME_TYPE_MANAGED_TO_NATIVE:
 	case FRAME_TYPE_TRAMPOLINE:
+	case FRAME_TYPE_INTERP_TO_MANAGED:
 		return FALSE;
 	case FRAME_TYPE_MANAGED:
+	case FRAME_TYPE_INTERP:
 		g_assert (frame->ji);
 		return d->func (frame->actual_method, frame->native_offset, frame->il_offset, frame->managed, d->user_data);
 		break;

--- a/mono/mini/ee.h
+++ b/mono/mini/ee.h
@@ -15,7 +15,7 @@
 #ifndef __MONO_EE_H__
 #define __MONO_EE_H__
 
-#define MONO_EE_API_VERSION 0x1
+#define MONO_EE_API_VERSION 0x2
 
 typedef struct _MonoInterpStackIter MonoInterpStackIter;
 
@@ -32,7 +32,6 @@ struct _MonoEECallbacks {
 	void (*init_delegate) (MonoDelegate *del);
 	gpointer (*get_remoting_invoke) (gpointer imethod, MonoError *error);
 	gpointer (*create_trampoline) (MonoDomain *domain, MonoMethod *method, MonoError *error);
-	void (*walk_stack_with_ctx) (MonoInternalStackWalk func, MonoContext *ctx, MonoUnwindOptions options, void *user_data);
 	void (*set_resume_state) (MonoJitTlsData *jit_tls, MonoException *ex, MonoJitExceptionInfo *ei, MonoInterpFrameHandle interp_frame, gpointer handler_ip);
 	gboolean (*run_finally) (StackFrameInfo *frame, int clause_index, gpointer handler_ip);
 	gboolean (*run_filter) (StackFrameInfo *frame, MonoException *ex, int clause_index, gpointer handler_ip);

--- a/mono/mini/interp-stubs.c
+++ b/mono/mini/interp-stubs.c
@@ -159,7 +159,6 @@ mono_interp_stub_init (void)
 	c.init_delegate = stub_init_delegate;
 	c.get_remoting_invoke = stub_get_remoting_invoke;
 	c.create_trampoline = stub_create_trampoline;
-	c.walk_stack_with_ctx = stub_walk_stack_with_ctx;
 	c.set_resume_state = stub_set_resume_state;
 	c.run_finally = stub_run_finally;
 	c.run_filter = stub_run_filter;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -218,11 +218,7 @@ mono_exceptions_init (void)
 
 	mono_arch_exceptions_init ();
 
-	if (mono_use_interpreter)
-		cbs.mono_walk_stack_with_ctx = mini_get_interp_callbacks ()->walk_stack_with_ctx;
-	else
-		cbs.mono_walk_stack_with_ctx = mono_runtime_walk_stack_with_ctx;
-
+	cbs.mono_walk_stack_with_ctx = mono_runtime_walk_stack_with_ctx;
 	cbs.mono_walk_stack_with_state = mono_walk_stack_with_state;
 
 	if (mono_llvm_only) {

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1293,12 +1293,16 @@ ves_icall_get_frame_info (gint32 skip, MonoBoolean need_file_info,
 			case FRAME_TYPE_MANAGED_TO_NATIVE:
 			case FRAME_TYPE_DEBUGGER_INVOKE:
 			case FRAME_TYPE_TRAMPOLINE:
+				continue;
 			case FRAME_TYPE_INTERP_TO_MANAGED:
+				if (!ji) {
+					/* gsharedvt_out_sig_wrapper from interp2jit transition */
+					skip--;
+					break;
+				}
 				continue;
 			case FRAME_TYPE_INTERP:
-				skip--;
-				break;
-			default:
+			case FRAME_TYPE_MANAGED:
 				ji = frame.ji;
 				*native_offset = frame.native_offset;
 
@@ -1308,13 +1312,14 @@ ves_icall_get_frame_info (gint32 skip, MonoBoolean need_file_info,
 					continue;
 				skip--;
 				break;
+			default:
+				g_assert_not_reached ();
 			}
 		} while (skip >= 0);
 
 		if (frame.type == FRAME_TYPE_INTERP) {
 			jmethod = frame.method;
 			actual_method = frame.actual_method;
-			*native_offset = frame.native_offset;
 		} else {
 			actual_method = get_method_from_stack_frame (ji, get_generic_info_from_stack_frame (ji, &ctx));
 		}

--- a/mono/mini/mixed.cs
+++ b/mono/mini/mixed.cs
@@ -81,6 +81,11 @@ class InterpClass
 	}
 
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	public static StackTrace get_stacktrace_interp2 () {
+		return JitClass.get_stacktrace_jit ();
+	}
+
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
 	public static void throw_ex () {
 		JitClass.throw_ex ();
 	}
@@ -160,6 +165,11 @@ class JitClass
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]
 	public static StackTrace get_stacktrace_jit () {
 		return InterpClass.get_stacktrace_interp ();
+	}
+
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	public static StackTrace get_stacktrace_jit2 () {
+		return InterpClass.get_stacktrace_interp2 ();
 	}
 }
 
@@ -249,16 +259,28 @@ class Tests
 		//
 		// Get a stacktrace for an interp->jit->interp call stack
 		//
-		StackTrace st = JitClass.get_stacktrace_jit ();
-		var frame = st.GetFrame (0);
-		if (frame.GetMethod ().Name != "get_stacktrace_interp")
+		StackTrace st = JitClass.get_stacktrace_jit2 ();
+
+		var frame0 = st.GetFrame (0);
+		var frame1 = st.GetFrame (1);
+		var frame2 = st.GetFrame (2);
+		var frame3 = st.GetFrame (3);
+		var frame4 = st.GetFrame (4);
+
+		if (frame0.GetMethod ().Name != "get_stacktrace_interp")
 			return 1;
-		frame = st.GetFrame (1);
-		if (frame.GetMethod ().Name != "get_stacktrace_jit")
+
+		if (frame1.GetMethod ().Name != "get_stacktrace_jit")
 			return 2;
-		frame = st.GetFrame (2);
-		if (frame.GetMethod ().Name != "test_0_stack_traces")
+
+		if (frame2.GetMethod ().Name != "get_stacktrace_interp2")
 			return 3;
+
+		if (frame3.GetMethod ().Name != "get_stacktrace_jit2")
+			return 4;
+
+		if (frame4.GetMethod ().Name != "test_0_stack_traces")
+			return 5;
 		return 0;
 	}
 }


### PR DESCRIPTION
this was left over code from times where mini didn't understand
interpreter frames.


