### PR TITLE
PPC support for BoringTLS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3453,13 +3453,17 @@ case "$host" in
 		arch_target=ppc;
 		case $host_os in
 		  aix*|os400*)
+			BTLS_SUPPORTED=yes
+			BTLS_PLATFORM=powerpc
 			dnl on AIX/PASE, shared libraries can be inside archives
 			dnl if they are, we specify them by lib.a(lib.so)
 			dnl we may hardcode 64-bit names at times, but we don't do 32-bit AIX, so
 			LIBC="libc.a(shr_64.o)"
 			INTL="libintl.a(libintl.so.9)"
 			;;
-		  linux*|darwin*)
+		  linux*)
+			BTLS_SUPPORTED=yes
+			BTLS_PLATFORM=powerpc
 			;;
 		esac
 		;;
@@ -4538,6 +4542,14 @@ if test "x$enable_btls" = "xyes"; then
 		;;
 	aarch64)
 		btls_arch=aarch64
+		;;
+	powerpc)
+		btls_arch=powerpc
+		case $host_os in
+			aix*|os400*)
+				btls_cflags="$btls_cflags -maix64 -D_ALL_SOURCE -D_THREAD_SAFE -D_REENTRANT"
+				BTLS_CMAKE_ARGS="-DCMAKE_AR=/usr/bin/ar -DCMAKE_C_ARCHIVE_CREATE=\"<CMAKE_AR> -X64 cr <TARGET> <LINK_FLAGS> <OBJECTS>\""
+		esac
 		;;
 	android-armv5)
 		BTLS_CMAKE_ARGS="-DANDROID_ABI=\"armeabi\" -DANDROID_NATIVE_API_LEVEL=14"


### PR DESCRIPTION
Doesn't seem to be completely working: AIX triggers the [trampoline bug](https://github.com/mono/mono/issues/7396) in the ctor for contexts, and Linux inits fine but seems to be using SSLv3?

With certs installed, a simple program on ppc64be/Linux gets:

```
> /opt/mono/bin/mono curl.exe https://github.com

Unhandled Exception:
System.Net.WebException: Error: SecureChannelFailure (A call to SSPI failed, see inner exception.) ---> System.Security.Authentication.AuthenticationException: A call to SSPI failed, see inner exception. ---> Mono.Btls.MonoBtlsException: Ssl error:10000410:SSL routines:OPENSSL_internal:SSLV3_ALERT_HANDSHAKE_FAILURE
  at /home/calvin/mono/external/boringssl/ssl/tls_record.c:462
  at Mono.Btls.MonoBtlsContext.ProcessHandshake () [0x00054] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
  at Mono.Net.Security.MobileAuthenticatedStream.ProcessHandshake (Mono.Net.Security.AsyncOperationStatus status) [0x0004a] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
  at (wrapper remoting-invoke-with-check) Mono.Net.Security.MobileAuthenticatedStream.ProcessHandshake(Mono.Net.Security.AsyncOperationStatus)
  at Mono.Net.Security.AsyncHandshakeRequest.Run (Mono.Net.Security.AsyncOperationStatus status) [0x00006] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
  at Mono.Net.Security.AsyncProtocolRequest+<ProcessOperation>c__async1.MoveNext () [0x0012a] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0004e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x0002e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x0000b] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.ConfiguredTaskAwaitable+ConfiguredTaskAwaiter.GetResult () [0x00000] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at Mono.Net.Security.AsyncProtocolRequest+<StartOperation>c__async0.MoveNext () [0x000a4] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
   --- End of inner exception stack trace ---
  at Mono.Net.Security.MobileAuthenticatedStream+<ProcessAuthentication>c__async0.MoveNext () [0x00333] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0004e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x0002e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x0000b] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.ConfiguredTaskAwaitable+ConfiguredTaskAwaiter.GetResult () [0x00000] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at Mono.Net.Security.MonoTlsStream+<CreateStream>c__async0.MoveNext () [0x0018c] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0004e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x0002e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x0000b] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter[TResult].GetResult () [0x00000] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Net.WebConnection+<CreateStream>c__async1.MoveNext () [0x001f5] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
   --- End of inner exception stack trace ---
  at System.Net.WebConnection+<CreateStream>c__async1.MoveNext () [0x00275] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0004e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x0002e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x0000b] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter[TResult].GetResult () [0x00000] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Net.WebConnection+<InitConnection>c__async2.MoveNext () [0x0015b] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0004e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x0002e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x0000b] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter[TResult].GetResult () [0x00000] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Net.WebOperation+<Run>c__async2.MoveNext () [0x000c2] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
--- End of stack trace from previous location where exception was thrown ---
  at System.Net.HttpWebRequest+<RunWithTimeoutWorker>c__async0`1[T].MoveNext () [0x0010e] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
--- End of stack trace from previous location where exception was thrown ---
  at System.Net.HttpWebRequest.GetResponse () [0x00018] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
  at System.Net.WebClient.GetWebResponse (System.Net.WebRequest request) [0x00000] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
  at System.Net.WebClient.DownloadBits (System.Net.WebRequest request, System.IO.Stream writeStream) [0x00000] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0004e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x0002e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x0000b] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter[TResult].GetResult () [0x00000] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Net.WebOperation+<FinishReading>c__async3.MoveNext () [0x00094] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0004e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x0002e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x0000b] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter[TResult].GetResult () [0x00000] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Net.WebClient.DownloadBits (System.Net.WebRequest request, System.IO.Stream writeStream) [0x0011c] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
  at System.Net.WebClient.DownloadDataInternal (System.Uri address, System.Net.WebRequest& request) [0x00069] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
  at System.Net.WebClient.DownloadString (System.Uri address) [0x00011] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
  at System.Net.WebClient.DownloadString (System.String address) [0x00008] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
  at (wrapper remoting-invoke-with-check) System.Net.WebClient.DownloadString(string)
  at Curl.Main (System.String[] args) [0x00006] in <f4a8182b4077483fb5a80aed742d078c>:0
[ERROR] FATAL UNHANDLED EXCEPTION: System.Net.WebException: Error: SecureChannelFailure (A call to SSPI failed, see inner exception.) ---> System.Security.Authentication.AuthenticationException: A call to SSPI failed, see inner exception. ---> Mono.Btls.MonoBtlsException: Ssl error:10000410:SSL routines:OPENSSL_internal:SSLV3_ALERT_HANDSHAKE_FAILURE
  at /home/calvin/mono/external/boringssl/ssl/tls_record.c:462
  at Mono.Btls.MonoBtlsContext.ProcessHandshake () [0x00054] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
  at Mono.Net.Security.MobileAuthenticatedStream.ProcessHandshake (Mono.Net.Security.AsyncOperationStatus status) [0x0004a] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
  at (wrapper remoting-invoke-with-check) Mono.Net.Security.MobileAuthenticatedStream.ProcessHandshake(Mono.Net.Security.AsyncOperationStatus)
  at Mono.Net.Security.AsyncHandshakeRequest.Run (Mono.Net.Security.AsyncOperationStatus status) [0x00006] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
  at Mono.Net.Security.AsyncProtocolRequest+<ProcessOperation>c__async1.MoveNext () [0x0012a] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0004e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x0002e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x0000b] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.ConfiguredTaskAwaitable+ConfiguredTaskAwaiter.GetResult () [0x00000] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at Mono.Net.Security.AsyncProtocolRequest+<StartOperation>c__async0.MoveNext () [0x000a4] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
   --- End of inner exception stack trace ---
  at Mono.Net.Security.MobileAuthenticatedStream+<ProcessAuthentication>c__async0.MoveNext () [0x00333] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0004e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x0002e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x0000b] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.ConfiguredTaskAwaitable+ConfiguredTaskAwaiter.GetResult () [0x00000] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at Mono.Net.Security.MonoTlsStream+<CreateStream>c__async0.MoveNext () [0x0018c] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0004e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x0002e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x0000b] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter[TResult].GetResult () [0x00000] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Net.WebConnection+<CreateStream>c__async1.MoveNext () [0x001f5] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
   --- End of inner exception stack trace ---
  at System.Net.WebConnection+<CreateStream>c__async1.MoveNext () [0x00275] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0004e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x0002e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x0000b] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter[TResult].GetResult () [0x00000] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Net.WebConnection+<InitConnection>c__async2.MoveNext () [0x0015b] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0004e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x0002e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x0000b] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter[TResult].GetResult () [0x00000] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Net.WebOperation+<Run>c__async2.MoveNext () [0x000c2] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
--- End of stack trace from previous location where exception was thrown ---
  at System.Net.HttpWebRequest+<RunWithTimeoutWorker>c__async0`1[T].MoveNext () [0x0010e] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
--- End of stack trace from previous location where exception was thrown ---
  at System.Net.HttpWebRequest.GetResponse () [0x00018] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
  at System.Net.WebClient.GetWebResponse (System.Net.WebRequest request) [0x00000] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
  at System.Net.WebClient.DownloadBits (System.Net.WebRequest request, System.IO.Stream writeStream) [0x00000] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0004e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x0002e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x0000b] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter[TResult].GetResult () [0x00000] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Net.WebOperation+<FinishReading>c__async3.MoveNext () [0x00094] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0004e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x0002e] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x0000b] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter[TResult].GetResult () [0x00000] in <2851cc0911e843b2ad35b479c8e2a704>:0
  at System.Net.WebClient.DownloadBits (System.Net.WebRequest request, System.IO.Stream writeStream) [0x0011c] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
  at System.Net.WebClient.DownloadDataInternal (System.Uri address, System.Net.WebRequest& request) [0x00069] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
  at System.Net.WebClient.DownloadString (System.Uri address) [0x00011] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
  at System.Net.WebClient.DownloadString (System.String address) [0x00008] in <697f158bf0a84348a1ef6ca3914dfe6b>:0
  at (wrapper remoting-invoke-with-check) System.Net.WebClient.DownloadString(string)
  at Curl.Main (System.String[] args) [0x00006] in <f4a8182b4077483fb5a80aed742d078c>:0
```