### PR TITLE
[runtime] Increase the BCL trampoline count

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1069,7 +1069,7 @@ with_wasm_default=no
 with_bitcode_default=no
 with_cooperative_gc_default=no
 
-INVARIANT_AOT_OPTIONS=nimt-trampolines=2000,ntrampolines=9000,nrgctx-fetch-trampolines=256,ngsharedvt-trampolines=4000
+INVARIANT_AOT_OPTIONS=nimt-trampolines=2000,ntrampolines=10000,nrgctx-fetch-trampolines=256,ngsharedvt-trampolines=4000
 
 AOT_BUILD_ATTRS=$INVARIANT_AOT_OPTIONS
 


### PR DESCRIPTION
Same as in https://github.com/mono/mono/pull/6033 to fix the following error on the FullAOT armel/armhf builds:

```
Ran out of trampolines of type 0 in '/home/builder/jenkins/workspace/test-mono-mainline-fullaot/label/debian-9-armhf/mcs/class/lib/testing_aot_full/mscorlib.dll' (limit 9000)
```



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
