### PR TITLE
[packaging] Support setting the FULL_VERSION number via env vars

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -918,7 +918,11 @@ version.h: Makefile
 			echo "#define FULL_VERSION \"$$branch/$$version\""; \
 		); \
 	else \
-		echo "#define FULL_VERSION \"tarball\""; \
+		if test -z "$$MONO_BRANCH" -o -z "$$MONO_BUILD_REVISION"; then \
+			echo "#define FULL_VERSION \"tarball\""; \
+		else \
+			echo "#define FULL_VERSION \"$$MONO_BRANCH/$$MONO_BUILD_REVISION\""; \
+		fi \
 	fi > version.h
 
 # Utility target for patching libtool to speed up linking


### PR DESCRIPTION
The Linux build currently just displays `tarball` since we don't have the .git directory when building the Linux packages.

This allows us to pass environment variables that contain the branch+commit to the build for generating version.h so we can show the more detailed info like on OSX.
