### PR TITLE
[2017-12] [corlib] Ignore TimeZoneTest.TestCtors on iOS under certain conditions due to an Apple bug.

### DIFF
--- a/mcs/class/corlib/Test/System/TimeZoneTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneTest.cs
@@ -186,6 +186,10 @@ public class TimeZoneTest {
 				TST (t1);
 				break;
 			case "GMT":
+#if __IOS__
+				if (string.IsNullOrEmpty (t1.DaylightName))
+					Assert.Ignore ("This test may fail due to: http://www.openradar.me/38174449");
+#endif
 				GMT (t1);
 				break;
 			case "NZST":

--- a/mcs/class/corlib/Test/System/TimeZoneTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneTest.cs
@@ -186,7 +186,7 @@ public class TimeZoneTest {
 				TST (t1);
 				break;
 			case "GMT":
-#if __IOS__
+#if MONOTOUCH
 				if (string.IsNullOrEmpty (t1.DaylightName))
 					Assert.Ignore ("This test may fail due to: http://www.openradar.me/38174449");
 #endif


### PR DESCRIPTION
Fixes https://github.com/xamarin/maccore/issues/629.