### PR TITLE
[corlib] Ignore TimeZoneTest.TestCtors on iOS under certain conditions due to an Apple bug.

### DIFF
--- a/mcs/class/corlib/Test/System/TimeZoneTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneTest.cs
@@ -186,6 +186,10 @@ public class TimeZoneTest {
 				TST (t1);
 				break;
 			case "GMT":
+#if __IOS__
+				if (string.IsNullOrEmpty (t1.DaylightName))
+					Assert.Ignore ("This test may fail due to: http://www.openradar.me/38174449");
+#endif
 				GMT (t1);
 				break;
 			case "NZST":

--- a/mcs/class/corlib/Test/System/TimeZoneTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneTest.cs
@@ -186,7 +186,7 @@ public class TimeZoneTest {
 				TST (t1);
 				break;
 			case "GMT":
-#if __IOS__
+#if MONOTOUCH
 				if (string.IsNullOrEmpty (t1.DaylightName))
 					Assert.Ignore ("This test may fail due to: http://www.openradar.me/38174449");
 #endif


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->

Fixes https://github.com/xamarin/maccore/issues/629.