### PR TITLE
[sgen] Fix the clearing of bits in the gc descriptor bitmap when using weak fields.

### DIFF
--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -5408,7 +5408,7 @@ mono_class_compute_gc_descriptor (MonoClass *klass)
 			for (int pos = 0; pos < weak_bitmap_nbits; ++pos) {
 				if (weak_bitmap [pos / BITMAP_EL_SIZE] & ((gsize)1) << (pos % BITMAP_EL_SIZE)) {
 					/* Clear the normal bitmap so these refs don't keep an object alive */
-					bitmap [pos / BITMAP_EL_SIZE] &= ~((gsize)1) << (pos % BITMAP_EL_SIZE);
+					bitmap [pos / BITMAP_EL_SIZE] &= ~(((gsize)1) << (pos % BITMAP_EL_SIZE));
 				}
 			}
 


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/7378.