### PR TITLE
[eglib] Fix typo in g_assertf

### DIFF
--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -729,12 +729,8 @@ GUnicodeBreakType   g_unichar_break_type (gunichar c);
 #define  eg_unreachable()
 #endif
 
-/* Old version. Preserved for testing and history. */
-
 /* g_assert is a boolean expression; the precise value is not preserved, just true or false. */
-#define g_assert(x) \
-	(G_LIKELY(x) ? 1 : (g_assertion_message ( \
-	"* Assertion at %s:%d, condition `%s' not met\n", __FILE__, __LINE__, #x), 0))
+#define g_assert(x) (G_LIKELY((x)) ? 1 : (g_assertion_message ("* Assertion at %s:%d, condition `%s' not met\n", __FILE__, __LINE__, #x), 0))
 
 #define  g_assert_not_reached() G_STMT_START { g_assertion_message ("* Assertion: should not be reached at %s:%d\n", __FILE__, __LINE__); eg_unreachable(); } G_STMT_END
 
@@ -755,10 +751,11 @@ GUnicodeBreakType   g_unichar_break_type (gunichar c);
  * format must be a string literal, in order to be concatenated.
  * If this is too restrictive, g_error remains.
  */
-#define  g_assertf(x, format, ...) \
-	(G_LIKELY(x) ? 1 : (g_assertion_message ( \
-	"* Assertion at %s:%d, condition `%s' not met, function:%s, " format "\n", \
-	__FILE__, __LINE__, #x, __func__, __VA_ARGS__), 0))
+#if defined(_MSC_VER) && (_MSC_VER < 1910)
+#define g_assertf(x, format, ...) (G_LIKELY((x)) ? 1 : (g_assertion_message ("* Assertion at %s:%d, condition `%s' not met, function:%s, " format "\n", __FILE__, __LINE__, #x, __func__, __VA_ARGS__), 0))
+#else
+#define g_assertf(x, format, ...) (G_LIKELY((x)) ? 1 : (g_assertion_message ("* Assertion at %s:%d, condition `%s' not met, function:%s, " format "\n", __FILE__, __LINE__, #x, __func__, ##__VA_ARGS__), 0))
+#endif
 
 /*
  * Unicode conversion

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -1151,11 +1151,8 @@ mono_string_builder_to_utf16 (MonoStringBuilder *sb)
 			// Check that we will not overrun our boundaries.
 			gunichar2 *source = (gunichar2 *)chunk->chunkChars->vector;
 
-			if (chunk->chunkLength <= len) {
-				memcpy (str + chunk->chunkOffset, source, chunk->chunkLength * sizeof(gunichar2));
-			} else {
-				g_error ("A chunk in the StringBuilder had a length longer than expected from the offset.");
-			}
+			g_assertf (chunk->chunkLength <= len, "A chunk in the StringBuilder had a length longer than expected from the offset.");
+			memcpy (str + chunk->chunkOffset, source, chunk->chunkLength * sizeof(gunichar2));
 
 			len -= chunk->chunkLength;
 		}


### PR DESCRIPTION
This would trigger the following error:
```
In file included from ../../mono/utils/mono-os-semaphore.h:15:0,
                 from ../../mono/utils/mono-threads.h:14,
                 from mono-threads-windows.c:11:
mono-threads-windows.c: In function 'mono_threads_suspend_register':
../../mono/eglib/glib.h:761:47: error: expected expression before ')' token
  __FILE__, __LINE__, #x, __func__, __VA_ARGS__), 0))
                                               ^
mono-threads-windows.c:144:2: note: in expansion of macro 'g_assertf'
  g_assertf (success, "Failed to duplicate current thread handle");
```