### PR TITLE
[System]: Disable the System.Net.ServicePoint tests from corefx.

### DIFF
--- a/mcs/class/System/System_xtest.dll.sources
+++ b/mcs/class/System/System_xtest.dll.sources
@@ -61,7 +61,7 @@ System/RemoteExecutorTests.cs
 #../../../external/corefx/src/System.Net.WebProxy/tests/*.cs
 
 # System.Net.ServicePoint
-../../../external/corefx/src/System.Net.ServicePoint/tests/*.cs
+#../../../external/corefx/src/System.Net.ServicePoint/tests/*.cs
 
 # System.Net.Sockets
 ../../../external/corefx/src/Common/tests/System/Diagnostics/Tracing/TestEventListener.cs


### PR DESCRIPTION
These tests never passed and are only spewing error message output,
making it much harder to see actual failures.