### PR TITLE
[2017-12][metadata] An array is not an IEnumerator`1

### DIFF
--- a/mcs/class/corlib/Test/System/TypeTest.cs
+++ b/mcs/class/corlib/Test/System/TypeTest.cs
@@ -3765,6 +3765,25 @@ namespace MonoTests.System
 			Assert.IsFalse (il.IsAssignableFrom (typeof (Array)), "System.Array -!-> IList<>");
 		}
 
+		[Test]
+		public void IsAssignableFromArrayEnumerator ()
+		{
+			// Regression test for https://github.com/mono/mono/issues/7093
+			// An array does not implement IEnumerator`1
+
+			var arrStr = typeof (string[]);
+			var ieStr = typeof (IEnumerator<string>);
+			var ieEqStr = typeof (IEnumerator<IEquatable<string>>);
+			Assert.IsFalse (ieStr.IsAssignableFrom (arrStr), "string[] -!-> IEnumerator<string>");
+			Assert.IsFalse (ieEqStr.IsAssignableFrom (arrStr), "string[] -!-> IEnumerator<IEquatable<string>>");
+
+			var arrInt = typeof (int[]);
+			var ieInt = typeof (IEnumerator<int>);
+			var ieEqInt = typeof (IEnumerator<IEquatable<int>>);
+			Assert.IsFalse (ieInt.IsAssignableFrom (arrInt), "int[] -!-> IEnumerator<int>");
+			Assert.IsFalse (ieEqInt.IsAssignableFrom (arrInt), "int[] -!-> IEnumerator<IEquatable<int>>");
+		}
+
 		[Test] // Bug #612780
 		public void CannotMakeDerivedTypesFromTypedByRef ()
 		{

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1116,6 +1116,7 @@ typedef struct {
 	MonoClass *customattribute_data_class;
 	MonoClass *critical_finalizer_object; /* MAYBE NULL */
 	MonoClass *generic_ireadonlylist_class;
+	MonoClass *generic_ienumerator_class;
 	MonoClass *threadpool_wait_callback_class;
 	MonoMethod *threadpool_perform_wait_callback_method;
 } MonoDefaults;

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -8413,6 +8413,14 @@ mono_class_is_assignable_from (MonoClass *klass, MonoClass *oklass)
 				 */
 				return FALSE;
 			}
+			// FIXME: IEnumerator`1 should not be an array special interface.
+			// The correct fix is to make
+			// ((IEnumerable<U>) (new T[] {...})).GetEnumerator()
+			// return an IEnumerator<U> (like .NET does) instead of IEnumerator<T>
+			// and to stop marking IEnumerable`1 as an array_special_interface.
+			if (mono_class_get_generic_type_definition (klass) == mono_defaults.generic_ienumerator_class)
+				return FALSE;
+
 			//XXX we could offset this by having the cast target computed at JIT time
 			//XXX we could go even further and emit a wrapper that would do the extra type check
 			MonoClass *iface_klass = mono_class_from_mono_type (mono_class_get_generic_class (klass)->context.class_inst->type_argv [0]);

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -753,6 +753,8 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	        mono_defaults.corlib, "System.Collections.Generic", "IList`1");
 	mono_defaults.generic_ireadonlylist_class = mono_class_load_from_name (
 	        mono_defaults.corlib, "System.Collections.Generic", "IReadOnlyList`1");
+	mono_defaults.generic_ienumerator_class = mono_class_load_from_name (
+	        mono_defaults.corlib, "System.Collections.Generic", "IEnumerator`1");
 
 	mono_defaults.threadpool_wait_callback_class = mono_class_load_from_name (
 		mono_defaults.corlib, "System.Threading", "_ThreadPoolWaitCallback");


### PR DESCRIPTION
Backport https://github.com/mono/mono/pull/7482 to `2017-12`

----

Address #7093 in kind of an adhoc way.

The correct fix is to make

    ((IEnumerable<U>) (new T[] {...})).GetEnumerator()
return an IEnumerator<U> (like .NET does) instead of IEnumerator<T>
and to stop marking IEnumerator as an array special interface.