### PR TITLE
Bump version to 5.8.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 # Process this file with autoconf to produce a configure script.
 #AC_PREREQ([2.62])
 
-AC_INIT(mono, [5.8.0],
+AC_INIT(mono, [5.8.1],
         [http://bugzilla.xamarin.com/enter_bug.cgi?classification=Mono])
 
 AC_CONFIG_SRCDIR([README.md])


### PR DESCRIPTION
The idea for this pull request is to update the revision number now that the original Mono framework version 5.8.0 has been published to the Visual Studio for Mac Stable updater channel. The pull request increments the revision number to indicate that the new package is a minor update that contains specific targeted fixes.

But I'm creating the pull request only to raise the question about whether this sounds good or not. No worries if it turns out it's better to leave the version number unchanged. Feel free to just close this pull request in that case. Thanks!