### PR TITLE
[2017-12] [jit] Move the check for open constructed types later in mono_jit_compile_method_with_opt (), this function can receive gshared methods in llvmonly mode.

### DIFF
--- a/mono/mini/aot-tests.cs
+++ b/mono/mini/aot-tests.cs
@@ -510,4 +510,10 @@ class Tests
 		}
 		return 0;
 	}
+
+	public static int test_0_regress_gh_7364 () {
+		var map1 = new Dictionary <Type, IntPtr> (EqualityComparer<Type>.Default);
+		var map2 = new Dictionary <IntPtr, WeakReference> (EqualityComparer<IntPtr>.Default);
+		return 0;
+	}
 }

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -1992,11 +1992,6 @@ mono_jit_compile_method_with_opt (MonoMethod *method, guint32 opt, gboolean jit_
 
 	error_init (error);
 
-	if (mono_class_is_open_constructed_type (&method->klass->byval_arg)) {
-		mono_error_set_invalid_operation (error, "Could not execute the method because the containing type is not fully instantiated.");
-		return NULL;
-	}
-
 	if (mono_use_interpreter && !jit_only) {
 		code = mini_get_interp_callbacks ()->create_method_pointer (method, error);
 		if (code)
@@ -2125,6 +2120,10 @@ lookup_start:
 	}
 
 	if (!code) {
+		if (mono_class_is_open_constructed_type (&method->klass->byval_arg)) {
+			mono_error_set_invalid_operation (error, "Could not execute the method because the containing type is not fully instantiated.");
+			return NULL;
+		}
 		if (wait_or_register_method_to_compile (method, target_domain))
 			goto lookup_start;
 		code = mono_jit_compile_method_inner (method, target_domain, opt, error);


### PR DESCRIPTION
Backport of #7494.

/cc @marek-safar