### PR TITLE
[threads] Fix race between abort socket syscall and thread shutdown

### DIFF
--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -1133,18 +1133,8 @@ mono_thread_info_abort_socket_syscall_for_close (MonoNativeThreadId tid)
 	if (tid == mono_native_thread_id_get ())
 		return;
 
-	hp = mono_hazard_pointer_get ();
-	info = mono_thread_info_lookup (tid);
-	if (!info)
-		return;
-
-	if (mono_thread_info_run_state (info) == STATE_DETACHED) {
-		mono_hazard_pointer_clear (hp, 1);
-		return;
-	}
-
 	mono_thread_info_suspend_lock ();
-	/* lookup info again in case we raced with shutdown of the other thread and it's already gone.*/
+	hp = mono_hazard_pointer_get ();
 	info = mono_thread_info_lookup (tid);
 	if (!info) {
 		mono_thread_info_suspend_unlock ();

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -1144,6 +1144,12 @@ mono_thread_info_abort_socket_syscall_for_close (MonoNativeThreadId tid)
 	}
 
 	mono_thread_info_suspend_lock ();
+	/* lookup info again in case we raced with shutdown of the other thread and it's already gone.*/
+	info = mono_thread_info_lookup (tid);
+	if (!info) {
+		mono_thread_info_suspend_unlock ();
+		return;
+	}
 	mono_threads_begin_global_suspend ();
 
 	mono_threads_suspend_abort_syscall (info);


### PR DESCRIPTION
The race happens when we call `mono_thread_info_abort_socket_sycall_for_close` on
a thread that's about to shut down.

We lookup the `MonoThreadInfo` for that thread outside the
`mono_thread_info_suspend_lock`, and then use it to send the signal once we've
taken the lock.

In between those two actions, the other thread already finished
`unregister_thread` and pthreads may already have destroyed its TLS keys and
otherwise started to dismantle the thread.

The fix is to do a second `mono_thread_info_lookup` once we have the lock and
only signal the other thread if it still around.

Fixes https://github.com/mono/mono/issues/6998

