### PR TITLE
[bcl] Fix test build with mcs

### DIFF
--- a/mcs/class/System.Data.OracleClient/Makefile
+++ b/mcs/class/System.Data.OracleClient/Makefile
@@ -8,7 +8,7 @@ KEYFILE = ../ecma.pub
 LIB_MCS_FLAGS =
 
 TEST_MCS_FLAGS = /nowarn:618
-TEST_LIB_REFS = System System.Data
+TEST_LIB_REFS = System System.Xml System.Data
 
 EXTRA_DISTFILES = Test/*.cs
 

--- a/mcs/class/System.Json.Microsoft/Makefile
+++ b/mcs/class/System.Json.Microsoft/Makefile
@@ -18,6 +18,6 @@ ifdef MOBILE_DYNAMIC
 LIB_MCS_FLAGS += -d:FEATURE_DYNAMIC
 endif
 
-TEST_MCS_FLAGS =
+TEST_LIB_REFS = System.Core
 
 include ../../build/library.make

--- a/mcs/class/System.Windows.Forms/Makefile
+++ b/mcs/class/System.Windows.Forms/Makefile
@@ -110,7 +110,7 @@ TEST_MCS_FLAGS = \
 
 DummyAssembly.dll:
 	$(CSCOMPILE) /target:library /out:$@ Test/DummyAssembly/AnotherSerializable.cs Test/DummyAssembly/Convertable.cs Test/DummyAssembly/Properties/AssemblyInfo.cs \
-	-r:$(topdir)/class/lib/$(PROFILE)/System.dll
+	-r:$(topdir)/class/lib/$(PROFILE)/mscorlib.dll -r:$(topdir)/class/lib/$(PROFILE)/System.dll
 
 test-local: DummyAssembly.dll
 

--- a/scripts/ci/run-test-mcs.sh
+++ b/scripts/ci/run-test-mcs.sh
@@ -2,3 +2,4 @@
 
 ${TESTCMD} --label=mcs-tests --timeout=30m make -w -C mcs/tests run-test
 ${TESTCMD} --label=mcs-errors --timeout=10m make -w -C mcs/errors run-test
+${TESTCMD} --label=compile-bcl-tests --timeout=40m make -w -C runtime test


### PR DESCRIPTION
It'd fail with the following errors since e6de24c2d196b064e64aeea6e45350e985a1bb23:

```
MCS     [net_4_x-darwin] net_4_x_System.Data.OracleClient_test.dll
Test/System.Data.OracleClient.jvm/MonoTests.System.Data.Utils/ADONetTesterClass.cs(337,71): error CS0012: The type `System.Xml.Serialization.IXmlSerializable' is defined in an assembly that is not referenced. Consider adding a reference to assembly `System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'

...

MCS     [net_4_x-darwin] net_4_x_System.Json.Microsoft_test.dll
Test/System.Json/JsonValueTest.cs(23,12): error CS0012: The type `System.Dynamic.IDynamicMetaObjectProvider' is defined in an assembly that is not referenced. Consider adding a reference to assembly `System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'

...

MCS     [net_4_x-darwin] DummyAssembly.dll
error CS0518: The predefined type `System.Object' is not defined or imported
error CS0518: The predefined type `System.ValueType' is not defined or imported
```

@marek-safar this sounds like mcs bugs to me as it compiles fine with csc.

