### PR TITLE
[2017-12] [sgen] Fix the clearing of bits in the gc descriptor bitmap when using weak fields.

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -1081,7 +1081,7 @@ mono_class_compute_gc_descriptor (MonoClass *klass)
 			for (int pos = 0; pos < weak_bitmap_nbits; ++pos) {
 				if (weak_bitmap [pos / BITMAP_EL_SIZE] & ((gsize)1) << (pos % BITMAP_EL_SIZE)) {
 					/* Clear the normal bitmap so these refs don't keep an object alive */
-					bitmap [pos / BITMAP_EL_SIZE] &= ~((gsize)1) << (pos % BITMAP_EL_SIZE);
+					bitmap [pos / BITMAP_EL_SIZE] &= ~(((gsize)1) << (pos % BITMAP_EL_SIZE));
 				}
 			}
 


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/7378

Backport of #7534.

/cc @marek-safar