### PR TITLE
[WIP - DONT MERGE][wasm/sdb] Introduce debugger-engine.c file that will host the common code between sdb and the wasm debugger.

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -451,6 +451,8 @@ common_sources = \
 	mini-gc.c		\
 	debugger-agent.h 	\
 	debugger-agent.c	\
+	debugger-engine.h	\
+	debugger-engine.c	\
 	xdebug.c			\
 	mini-llvm.h			\
 	mini-llvm-cpp.h	\

--- a/mono/mini/debugger-engine.c
+++ b/mono/mini/debugger-engine.c
@@ -1,0 +1,77 @@
+#include <config.h>
+
+#include "mini.h"
+#include "debugger-engine.h"
+
+#if (!defined (MONO_ARCH_SOFT_DEBUG_SUPPORTED) || defined (DISABLE_SOFT_DEBUG)) && !defined(MONO_ARCH_WASM_DEBUG_SUPPORTED)
+#define DISABLE_DEBUGGER_ENGINE 1
+#endif
+
+#ifndef DISABLE_DEBUGGER_ENGINE
+
+static int log_level;
+static FILE* log_file;
+
+
+void
+mono_de_init (MonoDebuggerEngineOptions *options)
+{
+	log_level = options->log_level;
+
+	if (options->log_file) {
+		log_file = fopen (options->log_file, "w+");
+		if (!log_file) {
+			fprintf (stderr, "Unable to create log file '%s': %s.\n", options->log_file, strerror (errno));
+			exit (1);
+		}
+	} else {
+		log_file = stdout;
+	}
+}
+
+void
+mono_de_log (int level, const char *format, ...)
+{
+	va_list args;
+	va_start (args, format);
+
+#ifdef HOST_ANDROID
+	char *msg = NULL;
+	if (g_vasprintf (&msg, format, args) >= 0)
+		g_print ("%s", msg);
+	g_free (msg);
+#else
+	vfprintf (log_file, format, args);
+	fflush (log_file);
+#endif
+
+	va_end (args);
+}
+
+int
+mono_de_get_log_level (void)
+{
+	return log_level;
+}
+
+#else
+
+void
+mono_de_init (MonoDebuggerEngineOptions *options)
+{
+	g_error ("Debugger engine disabled");
+}
+
+void
+mono_de_log (int level, const char *format, ...)
+{
+	g_error ("Debugger engine disabled");
+}
+int
+mono_de_get_log_level (void)
+{
+	return 0;
+}
+
+#endif
+

--- a/mono/mini/debugger-engine.h
+++ b/mono/mini/debugger-engine.h
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+#ifndef __MONO_DEBUGGER_ENGINE_H__
+#define __MONO_DEBUGGER_ENGINE_H__
+
+typedef struct {
+	int log_level;
+	char *log_file;
+} MonoDebuggerEngineOptions;
+
+void mono_de_init (MonoDebuggerEngineOptions *options);
+
+//Logging functions
+
+void mono_de_log (int level, const char *format, ...);
+int mono_de_get_log_level (void);
+
+#endif

--- a/mono/mini/mini-wasm.h
+++ b/mono/mini/mini-wasm.h
@@ -50,6 +50,7 @@ typedef struct {
 #define MONO_ARCH_INTERPRETER_SUPPORTED 1
 #define MONO_ARCH_HAS_REGISTER_ICALL 1
 #define MONO_ARCH_HAVE_PATCH_CODE_NEW 1
+#define MONO_ARCH_WASM_DEBUG_SUPPORTED 1
 
 void mono_wasm_debugger_init (void);
 


### PR DESCRIPTION
This PR includes the refactoring to unify the breakpoint engine between sdb and the wasm debugger.

It moves/adjusts code from sdb into debugger-engine.c and will then replace tons of code in mini-wasm.c with it.

Making an early PR to draw feedback on the design before I land too much code into it.