### PR TITLE
[mini] Don't inline methods if they're going to be instrumented for coverage.

### DIFF
--- a/mono/metadata/profiler-private.h
+++ b/mono/metadata/profiler-private.h
@@ -111,6 +111,7 @@ mono_profiler_installed (void)
 	return !!mono_profiler_state.profilers;
 }
 
+gboolean mono_profiler_coverage_instrumentation_enabled (MonoMethod *method);
 MonoProfilerCoverageInfo *mono_profiler_coverage_alloc (MonoMethod *method, guint32 entries);
 
 struct _MonoProfilerCallContext {

--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -562,7 +562,7 @@ mono_profiler_enable_allocations (void)
  * filter functions from all installed profilers. If any of them return flags
  * other than \c MONO_PROFILER_CALL_INSTRUMENTATION_NONE, then the given method
  * will be instrumented as requested. All filters are guaranteed to be called
- * exactly once per method, even if earlier filters have already specified all
+ * at least once per method, even if earlier filters have already specified all
  * flags.
  *
  * Note that filter functions must be installed before a method is compiled in

--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -399,15 +399,9 @@ mono_profiler_get_coverage_data (MonoProfilerHandle handle, MonoMethod *method, 
 	return TRUE;
 }
 
-MonoProfilerCoverageInfo *
-mono_profiler_coverage_alloc (MonoMethod *method, guint32 entries)
+gboolean
+mono_profiler_coverage_instrumentation_enabled (MonoMethod *method)
 {
-	if (!mono_profiler_state.code_coverage)
-		return FALSE;
-
-	if (method->wrapper_type)
-		return FALSE;
-
 	gboolean cover = FALSE;
 
 	for (MonoProfilerHandle handle = mono_profiler_state.profilers; handle; handle = handle->next) {
@@ -417,7 +411,19 @@ mono_profiler_coverage_alloc (MonoMethod *method, guint32 entries)
 			cover |= cb (handle->prof, method);
 	}
 
-	if (!cover)
+	return cover;
+}
+
+MonoProfilerCoverageInfo *
+mono_profiler_coverage_alloc (MonoMethod *method, guint32 entries)
+{
+	if (!mono_profiler_state.code_coverage)
+		return FALSE;
+
+	if (method->wrapper_type)
+		return FALSE;
+
+	if (!mono_profiler_coverage_instrumentation_enabled (method))
 		return NULL;
 
 	coverage_lock ();

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -4290,6 +4290,9 @@ mono_method_check_inlining (MonoCompile *cfg, MonoMethod *method)
 	if (mono_profiler_get_call_instrumentation_flags (method))
 		return FALSE;
 
+	if (mono_profiler_coverage_instrumentation_enabled (method))
+		return FALSE;
+
 	return TRUE;
 }
 
@@ -7273,12 +7276,14 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 		seq_points = FALSE;
 	}
 
-	if (cfg->method == method)
-		cfg->coverage_info = mono_profiler_coverage_alloc (cfg->method, header->code_size);
-	if (cfg->compile_aot && cfg->coverage_info)
-		g_error ("Coverage profiling is not supported with AOT.");
+	if (cfg->prof_coverage) {
+		if (cfg->compile_aot)
+			g_error ("Coverage profiling is not supported with AOT.");
 
-	if ((cfg->gen_sdb_seq_points && cfg->method == method) || cfg->coverage_info) {
+		cfg->coverage_info = mono_profiler_coverage_alloc (cfg->method, header->code_size);
+	}
+
+	if ((cfg->gen_sdb_seq_points && cfg->method == method) || cfg->prof_coverage) {
 		minfo = mono_debug_lookup_method (method);
 		if (minfo) {
 			MonoSymSeqPoint *sps;
@@ -7764,7 +7769,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			if (sym_seq_points)
 				mono_bitset_set_fast (seq_point_set_locs, ip - header->code);
 
-			if ((cfg->method == method) && cfg->coverage_info) {
+			if (cfg->prof_coverage) {
 				guint32 cil_offset = ip - header->code;
 				gpointer counter = &cfg->coverage_info->data [cil_offset].count;
 				cfg->coverage_info->data [cil_offset].cil_code = ip;

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3290,6 +3290,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 #endif
 
 	cfg->prof_flags = mono_profiler_get_call_instrumentation_flags (cfg->method);
+	cfg->prof_coverage = mono_profiler_coverage_instrumentation_enabled (cfg->method);
 
 	/* The debugger has no liveness information, so avoid sharing registers/stack slots */
 	if (debug_options.mdb_optimizations || MONO_CFG_PROFILE_CALL_CONTEXT (cfg)) {

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1490,6 +1490,7 @@ typedef struct {
 	int stat_code_reallocs;
 
 	MonoProfilerCallInstrumentationFlags prof_flags;
+	gboolean prof_coverage;
 
 	/* For deduplication */
 	gboolean skip;


### PR DESCRIPTION
This handles coverage instrumentation in a similar fashion to call instrumentation.

Fixes #6186.