### PR TITLE
[tests] Disable delegate-15.exe in the full-aot profile. (#7529)

### DIFF
--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -2097,7 +2097,7 @@ lookup_start:
 			 * This is not a problem, since it will be initialized when the method is first
 			 * called by init_method ().
 			 */
-			if (!mono_llvm_only) {
+			if (!mono_llvm_only && !mono_class_is_open_constructed_type (&method->klass->byval_arg)) {
 				vtable = mono_class_vtable (domain, method->klass);
 				g_assert (vtable);
 				if (!mono_runtime_class_init_full (vtable, error))

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -907,6 +907,9 @@ PROFILE_DISABLED_TESTS += \
 	assemblyresolve_event3.exe \
 	appdomain-serialize-exception.exe
 
+PROFILE_DISABLED_TESTS += \
+	delegate15.exe
+
 # https://bugzilla.xamarin.com/show_bug.cgi?id=60973
 PROFILE_DISABLED_TESTS += \
 	weak-fields.exe


### PR DESCRIPTION
* [jit] Avoid calling mono_class_vtable () for open constructed types.

* [tests] Disable delegate-15.exe in the full-aot profile.

backport of #7529 