### PR TITLE
[runtime] Clean up symbol names to not pollute the global namespace.

### DIFF
--- a/mono/eglib/eglib-remap.h
+++ b/mono/eglib/eglib-remap.h
@@ -243,6 +243,9 @@
 #define g_usleep monoeg_g_usleep
 #define g_utf16_to_ucs4 monoeg_g_utf16_to_ucs4
 #define g_utf16_to_utf8 monoeg_g_utf16_to_utf8
+#define g_utf16_ascii_equal monoeg_g_utf16_ascii_equal
+#define g_utf16_asciiz_equal monoeg_g_utf16_asciiz_equal
+#define g_utf8_jump_table monoeg_g_utf8_jump_table
 #define g_utf8_get_char monoeg_g_utf8_get_char
 #define g_utf8_offset_to_pointer monoeg_g_utf8_offset_to_pointer
 #define g_utf8_pointer_to_offset monoeg_g_utf8_pointer_to_offset

--- a/mono/eglib/gunicode-win32-uwp.c
+++ b/mono/eglib/gunicode-win32-uwp.c
@@ -11,24 +11,24 @@
 #define CODESET 1
 #include <windows.h>
 
-extern const char *my_charset;
+extern const char *eg_my_charset;
 static gboolean is_utf8;
 
 gboolean
 g_get_charset (G_CONST_RETURN char **charset)
 {
-	if (my_charset == NULL) {
+	if (eg_my_charset == NULL) {
 		static char buf [14];
 		CPINFOEXA cp_info;
 
 		GetCPInfoExA (CP_ACP, 0, &cp_info);
 		sprintf (buf, "CP%u", cp_info.CodePage);
-		my_charset = buf;
+		eg_my_charset = buf;
 		is_utf8 = FALSE;
 	}
 	
 	if (charset != NULL)
-		*charset = my_charset;
+		*charset = eg_my_charset;
 
 	return is_utf8;
 }

--- a/mono/eglib/gunicode-win32.c
+++ b/mono/eglib/gunicode-win32.c
@@ -11,21 +11,21 @@
 #define CODESET 1
 #include <windows.h>
 
-extern const char *my_charset;
+extern const char *eg_my_charset;
 static gboolean is_utf8;
 
 gboolean
 g_get_charset (G_CONST_RETURN char **charset)
 {
-	if (my_charset == NULL) {
+	if (eg_my_charset == NULL) {
 		static char buf [14];
 		sprintf (buf, "CP%u", GetACP ());
-		my_charset = buf;
+		eg_my_charset = buf;
 		is_utf8 = FALSE;
 	}
 	
 	if (charset != NULL)
-		*charset = my_charset;
+		*charset = eg_my_charset;
 
 	return is_utf8;
 }

--- a/mono/eglib/gunicode.c
+++ b/mono/eglib/gunicode.c
@@ -45,7 +45,7 @@
 #    endif
 #endif
 
-const char *my_charset;
+const char *eg_my_charset;
 
 /*
  * Character set conversion
@@ -206,18 +206,18 @@ static gboolean is_utf8;
 gboolean
 g_get_charset (G_CONST_RETURN char **charset)
 {
-	if (my_charset == NULL) {
+	if (eg_my_charset == NULL) {
 		/* These shouldn't be heap allocated */
 #if defined(HAVE_LOCALCHARSET_H)
-		my_charset = locale_charset ();
+		eg_my_charset = locale_charset ();
 #else
-		my_charset = "UTF-8";
+		eg_my_charset = "UTF-8";
 #endif
-		is_utf8 = strcmp (my_charset, "UTF-8") == 0;
+		is_utf8 = strcmp (eg_my_charset, "UTF-8") == 0;
 	}
 	
 	if (charset != NULL)
-		*charset = my_charset;
+		*charset = eg_my_charset;
 
 	return is_utf8;
 }
@@ -228,7 +228,7 @@ g_locale_to_utf8 (const gchar *opsysstring, gssize len, gsize *bytes_read, gsize
 {
 	g_get_charset (NULL);
 
-	return g_convert (opsysstring, len, "UTF-8", my_charset, bytes_read, bytes_written, gerror);
+	return g_convert (opsysstring, len, "UTF-8", eg_my_charset, bytes_read, bytes_written, gerror);
 }
 
 gchar *
@@ -236,5 +236,5 @@ g_locale_from_utf8 (const gchar *utf8string, gssize len, gsize *bytes_read, gsiz
 {
 	g_get_charset (NULL);
 
-	return g_convert (utf8string, len, my_charset, "UTF-8", bytes_read, bytes_written, gerror);
+	return g_convert (utf8string, len, eg_my_charset, "UTF-8", bytes_read, bytes_written, gerror);
 }

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -341,7 +341,7 @@ static char* unquote (const char *str);
 static mono_mutex_t assemblies_mutex;
 
 /* If defined, points to the bundled assembly information */
-const MonoBundledAssembly **bundles;
+static const MonoBundledAssembly **bundles;
 
 static mono_mutex_t assembly_binding_mutex;
 
@@ -1462,7 +1462,7 @@ struct AssemblyLoadHook {
 	gpointer user_data;
 };
 
-AssemblyLoadHook *assembly_load_hook = NULL;
+static AssemblyLoadHook *assembly_load_hook = NULL;
 
 /**
  * mono_assembly_invoke_load_hook:
@@ -1514,7 +1514,7 @@ struct AssemblySearchHook {
 	gpointer user_data;
 };
 
-AssemblySearchHook *assembly_search_hook = NULL;
+static AssemblySearchHook *assembly_search_hook = NULL;
 
 static MonoAssembly*
 mono_assembly_invoke_search_hook_internal (MonoAssemblyName *aname, MonoAssembly *requesting, gboolean refonly, gboolean postload)

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -194,7 +194,7 @@ mono_gc_base_init (void)
 				if (!strcmp (opt, "do-not-finalize")) {
 					mono_do_not_finalize = 1;
 				} else if (!strcmp (opt, "log-finalizers")) {
-					log_finalizers = 1;
+					mono_log_finalizers = 1;
 				}
 			}
 			g_free (env);
@@ -462,7 +462,7 @@ on_gc_notification (GC_EventType event)
 		if (mono_perfcounters)
 			mono_atomic_inc_i32 (&mono_perfcounters->gc_collections0);
 #endif
-		mono_atomic_inc_i32 (&gc_stats.major_gc_count);
+		mono_atomic_inc_i32 (&mono_gc_stats.major_gc_count);
 		gc_start_time = mono_100ns_ticks ();
 		break;
 
@@ -487,7 +487,7 @@ on_gc_notification (GC_EventType event)
 			UnlockedWrite64 (&mono_perfcounters->gc_gen0size, heap_size);
 		}
 #endif
-		UnlockedAdd64 (&gc_stats.major_gc_time, mono_100ns_ticks () - gc_start_time);
+		UnlockedAdd64 (&mono_gc_stats.major_gc_time, mono_100ns_ticks () - gc_start_time);
 		mono_trace_message (MONO_TRACE_GC, "gc took %" G_GINT64_FORMAT " usecs", (mono_100ns_ticks () - gc_start_time) / 10);
 		break;
 	default:

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1245,10 +1245,10 @@ gpointer
 mono_ldtoken_checked (MonoImage *image, guint32 token, MonoClass **handle_class, MonoGenericContext *context, MonoError *error);
 
 MonoImage *
-get_image_for_generic_param (MonoGenericParam *param);
+mono_get_image_for_generic_param (MonoGenericParam *param);
 
 char *
-make_generic_name_string (MonoImage *image, int num);
+mono_make_generic_name_string (MonoImage *image, int num);
 
 MonoClass *
 mono_class_load_from_name (MonoImage *image, const char* name_space, const char *name) MONO_LLVM_INTERNAL;

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -55,7 +55,7 @@
 MonoStats mono_stats;
 
 /* Statistics */
-extern gint32 inflated_methods_size;
+extern gint32 mono_inflated_methods_size;
 
 /* Function supplied by the runtime to find classes by name using information from the AOT file */
 static MonoGetClassFromName get_class_from_name = NULL;
@@ -994,7 +994,7 @@ mono_class_inflate_generic_method_full_checked (MonoMethod *method, MonoClass *k
 
 	UnlockedIncrement (&mono_stats.inflated_method_count);
 
-	UnlockedAdd (&inflated_methods_size,  sizeof (MonoMethodInflated));
+	UnlockedAdd (&mono_inflated_methods_size,  sizeof (MonoMethodInflated));
 
 	sig = mono_method_signature (method);
 	if (!sig) {
@@ -1764,7 +1764,7 @@ get_image_for_container (MonoGenericContainer *container)
 }
 
 MonoImage *
-get_image_for_generic_param (MonoGenericParam *param)
+mono_get_image_for_generic_param (MonoGenericParam *param)
 {
 	MonoGenericContainer *container = mono_generic_param_owner (param);
 	g_assert_checked (container);
@@ -1774,7 +1774,7 @@ get_image_for_generic_param (MonoGenericParam *param)
 // Make a string in the designated image consisting of a single integer.
 #define INT_STRING_SIZE 16
 char *
-make_generic_name_string (MonoImage *image, int num)
+mono_make_generic_name_string (MonoImage *image, int num)
 {
 	char *name = (char *)mono_image_alloc0 (image, INT_STRING_SIZE);
 	g_snprintf (name, INT_STRING_SIZE, "%d", num);

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -1835,7 +1835,7 @@ cominterop_rcw_finalizer (gpointer key, gpointer value, gpointer user_data)
 }
 
 void
-cominterop_release_all_rcws (void)
+mono_cominterop_release_all_rcws (void)
 {
 	if (!rcw_hash)
 		return;
@@ -3587,7 +3587,7 @@ mono_cominterop_cleanup (void)
 }
 
 void
-cominterop_release_all_rcws (void)
+mono_cominterop_release_all_rcws (void)
 {
 }
 

--- a/mono/metadata/decimal-ms.c
+++ b/mono/metadata/decimal-ms.c
@@ -96,7 +96,7 @@ typedef union {
 
 static const SPLIT64    ten_to_eighteen = { 1000000000000000000ULL };
 
-const MonoDouble_double ds2to64 = { .s = { .sign = 0, .exp = MONO_DOUBLE_BIAS + 65, .mantHi = 0, .mantLo = 0 } };
+static const MonoDouble_double ds2to64 = { .s = { .sign = 0, .exp = MONO_DOUBLE_BIAS + 65, .mantHi = 0, .mantLo = 0 } };
 
 //
 // Data tables
@@ -118,7 +118,7 @@ static const double double_power10[] = {
 	1e70, 1e71, 1e72, 1e73, 1e74, 1e75, 1e76, 1e77, 1e78, 1e79,
 	1e80 };
 
-const SPLIT64 sdl_power10[] = { {10000000000ULL},          // 1E10
+static const SPLIT64 sdl_power10[] = { {10000000000ULL},          // 1E10
 				{100000000000ULL},         // 1E11
 				{1000000000000ULL},        // 1E12
 				{10000000000000ULL},       // 1E13
@@ -150,7 +150,7 @@ typedef struct  {
 	uint32_t Hi, Mid, Lo;
 } DECOVFL;
 
-const DECOVFL power_overflow[] = {
+static const DECOVFL power_overflow[] = {
 // This is a table of the largest values that can be in the upper two
 // ULONGs of a 96-bit number that will not overflow when multiplied
 // by a given power.  For the upper word, this is a table of 

--- a/mono/metadata/dynamic-image.c
+++ b/mono/metadata/dynamic-image.c
@@ -28,7 +28,7 @@
 #include "mono/utils/mono-error-internals.h"
 #include "mono/utils/mono-os-mutex.h"
 
-const unsigned char table_sizes [MONO_TABLE_NUM] = {
+static const unsigned char table_sizes [MONO_TABLE_NUM] = {
 	MONO_MODULE_SIZE,
 	MONO_TYPEREF_SIZE,
 	MONO_TYPEDEF_SIZE,

--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -395,7 +395,7 @@ void mono_gc_thread_detach_with_lock (THREAD_INFO_TYPE *info);
 gboolean mono_gc_thread_in_critical_region (THREAD_INFO_TYPE *info);
 
 /* If set, print debugging messages around finalizers. */
-extern gboolean log_finalizers;
+extern gboolean mono_log_finalizers;
 
 /* If set, do not run finalizers. */
 extern gboolean mono_do_not_finalize;

--- a/mono/metadata/gc-stats.c
+++ b/mono/metadata/gc-stats.c
@@ -14,7 +14,7 @@
  * "undefined symbol" errors.
  */
 #if defined(__APPLE__)
-GCStats gc_stats = {};
+GCStats mono_gc_stats = {};
 #else
-GCStats gc_stats;
+GCStats mono_gc_stats;
 #endif

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -486,7 +486,7 @@ HANDLES(ICALL(SOCK_18, "SetSocketOption_internal(intptr,System.Net.Sockets.Socke
 HANDLES(ICALL(SOCK_19, "Shutdown_internal(intptr,System.Net.Sockets.SocketShutdown,int&)", ves_icall_System_Net_Sockets_Socket_Shutdown_internal))
 HANDLES(ICALL(SOCK_20, "Socket_internal(System.Net.Sockets.AddressFamily,System.Net.Sockets.SocketType,System.Net.Sockets.ProtocolType,int&)", ves_icall_System_Net_Sockets_Socket_Socket_internal))
 HANDLES(ICALL(SOCK_20a, "SupportsPortReuse", ves_icall_System_Net_Sockets_Socket_SupportPortReuse))
-HANDLES(ICALL(SOCK_21a, "cancel_blocking_socket_operation", icall_cancel_blocking_socket_operation))
+HANDLES(ICALL(SOCK_21a, "cancel_blocking_socket_operation", ves_icall_cancel_blocking_socket_operation))
 
 ICALL_TYPE(SOCKEX, "System.Net.Sockets.SocketException", SOCKEX_1)
 ICALL(SOCKEX_1, "WSAGetLastError_internal", ves_icall_System_Net_Sockets_SocketException_WSAGetLastError_internal)
@@ -636,14 +636,14 @@ HANDLES(ICALL(MMETH_10, "get_core_clr_security_level", ves_icall_MonoMethod_get_
 HANDLES(ICALL(MMETH_9, "get_name", ves_icall_MonoMethod_get_name))
 
 ICALL_TYPE(MMETHI, "System.Reflection.MonoMethodInfo", MMETHI_4)
-ICALL(MMETHI_4, "get_method_attributes", vell_icall_get_method_attributes)
+ICALL(MMETHI_4, "get_method_attributes", ves_icall_get_method_attributes)
 HANDLES(ICALL(MMETHI_1, "get_method_info", ves_icall_get_method_info))
 HANDLES(ICALL(MMETHI_2, "get_parameter_info", ves_icall_System_Reflection_MonoMethodInfo_get_parameter_info))
 HANDLES(ICALL(MMETHI_3, "get_retval_marshal", ves_icall_System_MonoMethodInfo_get_retval_marshal))
 
 ICALL_TYPE(MPROPI, "System.Reflection.MonoPropertyInfo", MPROPI_1)
 HANDLES(ICALL(MPROPI_1, "GetTypeModifiers", ves_icall_MonoPropertyInfo_GetTypeModifiers))
-ICALL(MPROPI_3, "get_default_value", property_info_get_default_value)
+ICALL(MPROPI_3, "get_default_value", ves_icall_property_info_get_default_value)
 HANDLES(ICALL(MPROPI_2, "get_property_info", ves_icall_MonoPropertyInfo_get_property_info))
 
 ICALL_TYPE(PARAMI, "System.Reflection.ParameterInfo", PARAMI_1)
@@ -801,7 +801,7 @@ HANDLES(ICALL(RT_21, "get_DeclaringMethod", ves_icall_RuntimeType_get_DeclaringM
 HANDLES(ICALL(RT_22, "get_DeclaringType", ves_icall_RuntimeType_get_DeclaringType))
 HANDLES(ICALL(RT_23, "get_Name", ves_icall_RuntimeType_get_Name))
 HANDLES(ICALL(RT_24, "get_Namespace", ves_icall_RuntimeType_get_Namespace))
-HANDLES(ICALL(RT_25, "get_core_clr_security_level", vell_icall_RuntimeType_get_core_clr_security_level))
+HANDLES(ICALL(RT_25, "get_core_clr_security_level", ves_icall_RuntimeType_get_core_clr_security_level))
 HANDLES(ICALL(RT_26, "make_array_type", ves_icall_RuntimeType_make_array_type))
 HANDLES(ICALL(RT_27, "make_byref_type", ves_icall_RuntimeType_make_byref_type))
 

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1890,7 +1890,7 @@ ves_icall_System_Reflection_FieldInfo_GetTypeModifiers (MonoReflectionFieldHandl
 }
 
 ICALL_EXPORT int
-vell_icall_get_method_attributes (MonoMethod *method)
+ves_icall_get_method_attributes (MonoMethod *method)
 {
 	return method->flags;
 }
@@ -5357,7 +5357,7 @@ ves_icall_System_RuntimeType_getFullName (MonoReflectionTypeHandle object, gbool
 }
 
 ICALL_EXPORT int
-vell_icall_RuntimeType_get_core_clr_security_level (MonoReflectionTypeHandle rfield, MonoError *error)
+ves_icall_RuntimeType_get_core_clr_security_level (MonoReflectionTypeHandle rfield, MonoError *error)
 {
 	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (rfield, type);
@@ -7804,7 +7804,7 @@ mono_type_from_blob_type (MonoType *type, MonoTypeEnum blob_type, MonoType *real
 }
 
 ICALL_EXPORT MonoObject*
-property_info_get_default_value (MonoReflectionProperty *property)
+ves_icall_property_info_get_default_value (MonoReflectionProperty *property)
 {
 	ERROR_DECL (error);
 	MonoType blob_type;

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1141,7 +1141,7 @@ typedef struct {
 	guint16 major, minor, build, revision;
 } IgnoredAssemblyVersion;
 
-const char *ignored_assemblies_file_names[] = {
+static const char *ignored_assemblies_file_names[] = {
 	"System.Runtime.InteropServices.RuntimeInformation.dll",
 	"System.Globalization.Extensions.dll",
 	"System.IO.Compression.dll",
@@ -1212,7 +1212,7 @@ static const IgnoredAssembly ignored_assemblies [] = {
 };
 
 
-const char *ignored_assemblies_names[] = {
+static const char *ignored_assemblies_names[] = {
 	"System.Runtime.InteropServices.RuntimeInformation",
 	"System.Globalization.Extensions",
 	"System.IO.Compression",
@@ -2819,7 +2819,7 @@ mono_image_strdup_printf (MonoImage *image, const char *format, ...)
 }
 
 GList*
-g_list_prepend_image (MonoImage *image, GList *list, gpointer data)
+mono_g_list_prepend_image (MonoImage *image, GList *list, gpointer data)
 {
 	GList *new_list;
 	
@@ -2837,7 +2837,7 @@ g_list_prepend_image (MonoImage *image, GList *list, gpointer data)
 }
 
 GSList*
-g_slist_append_image (MonoImage *image, GSList *list, gpointer data)
+mono_g_slist_append_image (MonoImage *image, GSList *list, gpointer data)
 {
 	GSList *new_list;
 

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -73,7 +73,7 @@ static gint32 signatures_size;
  * This TLS variable holds how many times the current thread has acquired the loader 
  * lock.
  */
-MonoNativeTlsKey loader_lock_nest_id;
+static MonoNativeTlsKey loader_lock_nest_id;
 
 static void dllmap_cleanup (void);
 static void cached_module_cleanup(void);

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -2829,7 +2829,7 @@ emit_marshal_boolean_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		int label_false;
 		guint8 ldc_op = CEE_LDC_I4_1;
 
-		local_type = marshal_boolean_conv_in_get_local_type (spec, &ldc_op);
+		local_type = mono_marshal_boolean_conv_in_get_local_type (spec, &ldc_op);
 		if (t->byref)
 			*conv_arg_type = int_type;
 		else
@@ -2887,7 +2887,7 @@ emit_marshal_boolean_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		guint8 ldop = CEE_LDIND_I4;
 		int label_null, label_false;
 
-		conv_arg_class = marshal_boolean_managed_conv_in_get_conv_arg_class (spec, &ldop);
+		conv_arg_class = mono_marshal_boolean_managed_conv_in_get_conv_arg_class (spec, &ldop);
 		conv_arg = mono_mb_add_local (mb, boolean_type);
 
 		if (t->byref)

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -3061,7 +3061,7 @@ emit_marshal_array_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 }
 
 MonoType*
-marshal_boolean_conv_in_get_local_type (MonoMarshalSpec *spec, guint8 *ldc_op /*out*/)
+mono_marshal_boolean_conv_in_get_local_type (MonoMarshalSpec *spec, guint8 *ldc_op /*out*/)
 {
 	if (spec == NULL) {
 		return m_class_get_byval_arg (mono_defaults.int32_class);
@@ -3083,7 +3083,7 @@ marshal_boolean_conv_in_get_local_type (MonoMarshalSpec *spec, guint8 *ldc_op /*
 }
 
 MonoClass*
-marshal_boolean_managed_conv_in_get_conv_arg_class (MonoMarshalSpec *spec, guint8 *ldop/*out*/)
+mono_marshal_boolean_managed_conv_in_get_conv_arg_class (MonoMarshalSpec *spec, guint8 *ldop/*out*/)
 {
 	MonoClass* conv_arg_class = mono_defaults.int32_class;
 	if (spec) {
@@ -3118,11 +3118,11 @@ emit_marshal_boolean_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		if (t->byref)
 			*conv_arg_type = int_type;
 		else
-			*conv_arg_type = marshal_boolean_conv_in_get_local_type (spec, NULL);
+			*conv_arg_type = mono_marshal_boolean_conv_in_get_local_type (spec, NULL);
 		break;
 
 	case MARSHAL_ACTION_MANAGED_CONV_IN: {
-		MonoClass* conv_arg_class = marshal_boolean_managed_conv_in_get_conv_arg_class (spec, NULL);
+		MonoClass* conv_arg_class = mono_marshal_boolean_managed_conv_in_get_conv_arg_class (spec, NULL);
 		if (t->byref)
 			*conv_arg_type = m_class_get_this_arg (conv_arg_class);
 		else

--- a/mono/metadata/marshal.h
+++ b/mono/metadata/marshal.h
@@ -511,7 +511,7 @@ gboolean
 mono_marshal_free_ccw (MonoObject* obj);
 
 void
-cominterop_release_all_rcws (void); 
+mono_cominterop_release_all_rcws (void); 
 
 MonoString*
 ves_icall_mono_string_from_utf16 (gunichar2 *data);
@@ -617,10 +617,10 @@ MonoMarshalConv
 mono_marshal_get_ptr_to_string_conv (MonoMethodPInvoke *piinfo, MonoMarshalSpec *spec, gboolean *need_free);
 
 MonoType*
-marshal_boolean_conv_in_get_local_type (MonoMarshalSpec *spec, guint8 *ldc_op /*out*/);
+mono_marshal_boolean_conv_in_get_local_type (MonoMarshalSpec *spec, guint8 *ldc_op /*out*/);
 
 MonoClass*
-marshal_boolean_managed_conv_in_get_conv_arg_class (MonoMarshalSpec *spec, guint8 *ldop/*out*/);
+mono_marshal_boolean_managed_conv_in_get_conv_arg_class (MonoMarshalSpec *spec, guint8 *ldop/*out*/);
 
 gboolean
 mono_pinvoke_is_unicode (MonoMethodPInvoke *piinfo);

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -665,10 +665,10 @@ char*
 mono_image_strdup_printf (MonoImage *image, const char *format, ...) MONO_ATTR_FORMAT_PRINTF(2,3);;
 
 GList*
-g_list_prepend_image (MonoImage *image, GList *list, gpointer data);
+mono_g_list_prepend_image (MonoImage *image, GList *list, gpointer data);
 
 GSList*
-g_slist_append_image (MonoImage *image, GSList *list, gpointer data);
+mono_g_slist_append_image (MonoImage *image, GSList *list, gpointer data);
 
 void
 mono_image_lock (MonoImage *image);
@@ -906,7 +906,7 @@ MonoException *mono_get_exception_field_access_msg (const char *msg);
 
 MonoException *mono_get_exception_method_access_msg (const char *msg);
 
-MonoMethod* method_from_method_def_or_ref (MonoImage *m, guint32 tok, MonoGenericContext *context, MonoError *error);
+MonoMethod* mono_method_from_method_def_or_ref (MonoImage *m, guint32 tok, MonoGenericContext *context, MonoError *error);
 
 MonoMethod *mono_get_method_constrained_with_method (MonoImage *image, MonoMethod *method, MonoClass *constrained_class, MonoGenericContext *context, MonoError *error);
 MonoMethod *mono_get_method_constrained_checked (MonoImage *image, guint32 token, MonoClass *constrained_class, MonoGenericContext *context, MonoMethod **cil_method, MonoError *error);
@@ -939,7 +939,7 @@ MonoType*
 mono_metadata_parse_type_checked (MonoImage *m, MonoGenericContainer *container, short opt_attrs, gboolean transient, const char *ptr, const char **rptr, MonoError *error);
 
 MonoGenericContainer *
-get_anonymous_container_for_image (MonoImage *image, gboolean is_mvar);
+mono_get_anonymous_container_for_image (MonoImage *image, gboolean is_mvar);
 
 char *
 mono_image_set_description (MonoImageSet *);

--- a/mono/metadata/metadata-verify.c
+++ b/mono/metadata/metadata-verify.c
@@ -4372,11 +4372,11 @@ mono_verifier_verify_methodimpl_row (MonoImage *image, guint32 row, MonoError *e
 
 	mono_metadata_decode_row (table, row, data, MONO_METHODIMPL_SIZE);
 
-	body = method_from_method_def_or_ref (image, data [MONO_METHODIMPL_BODY], NULL, error);
+	body = mono_method_from_method_def_or_ref (image, data [MONO_METHODIMPL_BODY], NULL, error);
 	if (!body)
 		return FALSE;
 
-	declaration = method_from_method_def_or_ref (image, data [MONO_METHODIMPL_DECLARATION], NULL, error);
+	declaration = mono_method_from_method_def_or_ref (image, data [MONO_METHODIMPL_DECLARATION], NULL, error);
 	if (!declaration)
 		return FALSE;
 

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -2402,7 +2402,7 @@ retry:
 		return signature_in_image (type->data.method, image);
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:
-		return image == get_image_for_generic_param (type->data.generic_param);
+		return image == mono_get_image_for_generic_param (type->data.generic_param);
 	default:
 		/* At this point, we should've avoided all potential allocations in mono_class_from_mono_type () */
 		return image == m_class_get_image (mono_class_from_mono_type (type));
@@ -2861,7 +2861,7 @@ retry:
 	case MONO_TYPE_VAR:
 	case MONO_TYPE_MVAR:
 	{
-		MonoImage *image = get_image_for_generic_param (type->data.generic_param);
+		MonoImage *image = mono_get_image_for_generic_param (type->data.generic_param);
 		add_image (image, data);
 		break;
 	}
@@ -3448,7 +3448,7 @@ select_container (MonoGenericContainer *gc, MonoTypeEnum type)
 }
 
 MonoGenericContainer *
-get_anonymous_container_for_image (MonoImage *image, gboolean is_mvar)
+mono_get_anonymous_container_for_image (MonoImage *image, gboolean is_mvar)
 {
 	MonoGenericContainer **container_pointer;
 	if (is_mvar)
@@ -3552,7 +3552,7 @@ publish_anon_gparam_slow (MonoImage *image, MonoGenericParam *gparam)
 MonoGenericParam*
 mono_metadata_create_anon_gparam (MonoImage *image, gint32 param_num, gboolean is_mvar)
 {
-	MonoGenericContainer *container = get_anonymous_container_for_image (image, is_mvar);
+	MonoGenericContainer *container = mono_get_anonymous_container_for_image (image, is_mvar);
 	MonoGenericParam *gparam = lookup_anon_gparam (image, container, param_num, is_mvar);
 	if (gparam)
 		return gparam;
@@ -6361,7 +6361,7 @@ mono_metadata_get_marshal_info (MonoImage *meta, guint32 idx, gboolean is_field)
 }
 
 MonoMethod*
-method_from_method_def_or_ref (MonoImage *m, guint32 tok, MonoGenericContext *context, MonoError *error)
+mono_method_from_method_def_or_ref (MonoImage *m, guint32 tok, MonoGenericContext *context, MonoError *error)
 {
 	MonoMethod *result = NULL;
 	guint32 idx = tok >> MONO_METHODDEFORREF_BITS;
@@ -6440,12 +6440,12 @@ mono_class_get_overrides_full (MonoImage *image, guint32 type_token, MonoMethod 
 			break;
 
 		mono_metadata_decode_row (tdef, start + i, cols, MONO_METHODIMPL_SIZE);
-		method = method_from_method_def_or_ref (image, cols [MONO_METHODIMPL_DECLARATION], generic_context, error);
+		method = mono_method_from_method_def_or_ref (image, cols [MONO_METHODIMPL_DECLARATION], generic_context, error);
 		if (!method)
 			break;
 
 		result [i * 2] = method;
-		method = method_from_method_def_or_ref (image, cols [MONO_METHODIMPL_BODY], generic_context, error);
+		method = mono_method_from_method_def_or_ref (image, cols [MONO_METHODIMPL_BODY], generic_context, error);
 		if (!method)
 			break;
 

--- a/mono/metadata/mono-security.c
+++ b/mono/metadata/mono-security.c
@@ -610,18 +610,18 @@ void
 ves_icall_System_Security_SecureString_DecryptInternal (MonoArray *data, MonoObject *scope)
 {
 	ERROR_DECL (error);
-	invoke_protected_memory_method (data, scope, FALSE, error);
+	mono_invoke_protected_memory_method (data, scope, FALSE, error);
 	mono_error_set_pending_exception (error);
 }
 void
 ves_icall_System_Security_SecureString_EncryptInternal (MonoArray* data, MonoObject *scope)
 {
 	ERROR_DECL (error);
-	invoke_protected_memory_method (data, scope, TRUE, error);
+	mono_invoke_protected_memory_method (data, scope, TRUE, error);
 	mono_error_set_pending_exception (error);
 }
 
-void invoke_protected_memory_method (MonoArray *data, MonoObject *scope, gboolean encrypt, MonoError *error)
+void mono_invoke_protected_memory_method (MonoArray *data, MonoObject *scope, gboolean encrypt, MonoError *error)
 {
 	MonoClass *klass;
 	MonoMethod *method;

--- a/mono/metadata/reflection-cache.h
+++ b/mono/metadata/reflection-cache.h
@@ -25,10 +25,10 @@ typedef struct {
 } ReflectedEntry;
 
 gboolean
-reflected_equal (gconstpointer a, gconstpointer b);
+mono_reflected_equal (gconstpointer a, gconstpointer b);
 
 guint
-reflected_hash (gconstpointer a);
+mono_reflected_hash (gconstpointer a);
 
 static inline ReflectedEntry*
 alloc_reflected_entry (MonoDomain *domain)
@@ -56,7 +56,7 @@ cache_object (MonoDomain *domain, MonoClass *klass, gpointer item, MonoObject* o
 
 	mono_domain_lock (domain);
 	if (!domain->refobject_hash)
-		domain->refobject_hash = mono_conc_g_hash_table_new_type (reflected_hash, reflected_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Reflection Object Table");
+		domain->refobject_hash = mono_conc_g_hash_table_new_type (mono_reflected_hash, mono_reflected_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Reflection Object Table");
 
 	obj = (MonoObject*) mono_conc_g_hash_table_lookup (domain->refobject_hash, &pe);
 	if (obj == NULL) {
@@ -80,7 +80,7 @@ cache_object_handle (MonoDomain *domain, MonoClass *klass, gpointer item, MonoOb
 
 	mono_domain_lock (domain);
 	if (!domain->refobject_hash)
-		domain->refobject_hash = mono_conc_g_hash_table_new_type (reflected_hash, reflected_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Reflection Object Table");
+		domain->refobject_hash = mono_conc_g_hash_table_new_type (mono_reflected_hash, mono_reflected_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Reflection Object Table");
 
 	MonoObjectHandle obj = MONO_HANDLE_NEW (MonoObject, mono_conc_g_hash_table_lookup (domain->refobject_hash, &pe));
 	if (MONO_HANDLE_IS_NULL (obj)) {

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -157,7 +157,7 @@ mono_custom_attrs_free (MonoCustomAttrInfo *ainfo)
 }
 
 gboolean
-reflected_equal (gconstpointer a, gconstpointer b)
+mono_reflected_equal (gconstpointer a, gconstpointer b)
 {
 	const ReflectedEntry *ea = (const ReflectedEntry *)a;
 	const ReflectedEntry *eb = (const ReflectedEntry *)b;
@@ -166,7 +166,7 @@ reflected_equal (gconstpointer a, gconstpointer b)
 }
 
 guint
-reflected_hash (gconstpointer a) {
+mono_reflected_hash (gconstpointer a) {
 	const ReflectedEntry *ea = (const ReflectedEntry *)a;
 	/* Combine hashes for item and refclass. Identical to boost's hash_combine */
 	guint seed = mono_aligned_addr_hash (ea->item) + 0x9e3779b9;

--- a/mono/metadata/security.h
+++ b/mono/metadata/security.h
@@ -59,7 +59,7 @@ MonoBoolean ves_icall_System_Security_Policy_Evidence_IsAuthenticodePresent (Mon
 /* System.Security.SecureString */
 extern void ves_icall_System_Security_SecureString_DecryptInternal (MonoArray *data, MonoObject *scope);
 extern void ves_icall_System_Security_SecureString_EncryptInternal (MonoArray *data, MonoObject *scope);
-void invoke_protected_memory_method (MonoArray *data, MonoObject *scope, gboolean encrypt, MonoError *error);
+void mono_invoke_protected_memory_method (MonoArray *data, MonoObject *scope, gboolean encrypt, MonoError *error);
 
 G_END_DECLS
 

--- a/mono/metadata/sgen-bridge-internals.h
+++ b/mono/metadata/sgen-bridge-internals.h
@@ -19,8 +19,8 @@
 #include "mono/sgen/sgen-gc.h"
 #include "mono/metadata/sgen-bridge.h"
 
-extern volatile gboolean bridge_processing_in_progress;
-extern MonoGCBridgeCallbacks bridge_callbacks;
+extern volatile gboolean mono_bridge_processing_in_progress;
+extern MonoGCBridgeCallbacks mono_bridge_callbacks;
 
 gboolean sgen_need_bridge_processing (void);
 void sgen_bridge_reset_data (void);

--- a/mono/metadata/sgen-bridge.c
+++ b/mono/metadata/sgen-bridge.c
@@ -39,14 +39,14 @@ static MonoGCBridgeCallbacks pending_bridge_callbacks;
 // Configuration to be passed to bridge processor after init
 static SgenBridgeProcessorConfig bridge_processor_config;
 // Currently-in-use callbacks
-MonoGCBridgeCallbacks bridge_callbacks;
+MonoGCBridgeCallbacks mono_bridge_callbacks;
 
 // Bridge processor state
 static SgenBridgeProcessor bridge_processor;
 // This is used for a special debug feature
 static SgenBridgeProcessor compare_to_bridge_processor;
 
-volatile gboolean bridge_processing_in_progress = FALSE;
+volatile gboolean mono_bridge_processing_in_progress = FALSE;
 
 // FIXME: The current usage pattern for this function is unsafe. Bridge processing could start immediately after unlock
 /**
@@ -55,7 +55,7 @@ volatile gboolean bridge_processing_in_progress = FALSE;
 void
 mono_gc_wait_for_bridge_processing (void)
 {
-	if (!bridge_processing_in_progress)
+	if (!mono_bridge_processing_in_progress)
 		return;
 
 	mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_BRIDGE waiting for bridge processing to finish");
@@ -147,10 +147,10 @@ sgen_init_bridge (void)
 		// This lock is not initialized until the GC is
 		sgen_gc_lock ();
 
-		bridge_callbacks = pending_bridge_callbacks;
+		mono_bridge_callbacks = pending_bridge_callbacks;
 
 		// If a bridge was registered but there is no bridge processor yet
-		if (bridge_callbacks.cross_references && !bridge_processor_started ()) {
+		if (mono_bridge_callbacks.cross_references && !bridge_processor_started ()) {
 			init_bridge_processor (&bridge_processor, bridge_processor_selection);
 
 			if (bridge_processor.set_config)
@@ -183,13 +183,13 @@ sgen_is_bridge_object (GCObject *obj)
 {
 	if ((obj->vtable->gc_bits & SGEN_GC_BIT_BRIDGE_OBJECT) != SGEN_GC_BIT_BRIDGE_OBJECT)
 		return FALSE;
-	return bridge_callbacks.is_bridge_object (obj);
+	return mono_bridge_callbacks.is_bridge_object (obj);
 }
 
 gboolean
 sgen_need_bridge_processing (void)
 {
-	return bridge_callbacks.cross_references != NULL;
+	return mono_bridge_callbacks.cross_references != NULL;
 }
 
 static gboolean
@@ -211,10 +211,10 @@ void
 sgen_bridge_processing_stw_step (void)
 {
 	/*
-	 * bridge_processing_in_progress must be set with the world
+	 * mono_bridge_processing_in_progress must be set with the world
 	 * stopped.  If not there would be race conditions.
 	 */
-	bridge_processing_in_progress = TRUE;
+	mono_bridge_processing_in_progress = TRUE;
 
 	bridge_processor.processing_stw_step ();
 	if (compare_bridge_processors ())
@@ -459,7 +459,7 @@ sgen_bridge_processing_finish (int generation)
 		goto after_callback;
 	}
 
-	bridge_callbacks.cross_references (bridge_processor.num_sccs, bridge_processor.api_sccs,
+	mono_bridge_callbacks.cross_references (bridge_processor.num_sccs, bridge_processor.api_sccs,
 			bridge_processor.num_xrefs, bridge_processor.api_xrefs);
 
 	if (compare_bridge_processors ())
@@ -478,7 +478,7 @@ sgen_bridge_processing_finish (int generation)
 
 	mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_BRIDGE: Complete, was running for %.2fms", mono_time_since_last_stw () / 10000.0f);
 
-	bridge_processing_in_progress = FALSE;
+	mono_bridge_processing_in_progress = FALSE;
 }
 
 MonoGCBridgeObjectKind
@@ -729,7 +729,7 @@ sgen_bridge_print_gc_debug_usage (void)
 #else
 
 //UG
-volatile gboolean bridge_processing_in_progress = FALSE;
+volatile gboolean mono_bridge_processing_in_progress = FALSE;
 
 void
 mono_gc_wait_for_bridge_processing (void)

--- a/mono/metadata/sgen-mono-ilgen.c
+++ b/mono/metadata/sgen-mono-ilgen.c
@@ -341,7 +341,7 @@ emit_managed_allocater_ilgen (MonoMethodBuilder *mb, gboolean slowpath, gboolean
 	mono_mb_emit_i4 (mb, MONO_MEMORY_BARRIER_NONE);
 #endif
 
-	if (nursery_canaries_enabled ()) {
+	if (sgen_nursery_canaries_enabled ()) {
 		real_size_var = mono_mb_add_local (mb, int_type);
 		mono_mb_emit_ldloc (mb, size_var);
 		mono_mb_emit_stloc(mb, real_size_var);
@@ -388,7 +388,7 @@ emit_managed_allocater_ilgen (MonoMethodBuilder *mb, gboolean slowpath, gboolean
 	mono_mb_emit_byte (mb, CEE_CONV_I);
 	mono_mb_emit_byte (mb, CEE_ADD);
 
-	if (nursery_canaries_enabled ()) {
+	if (sgen_nursery_canaries_enabled ()) {
 			mono_mb_emit_icon (mb, CANARY_SIZE);
 			mono_mb_emit_byte (mb, CEE_ADD);
 	}
@@ -457,7 +457,7 @@ emit_managed_allocater_ilgen (MonoMethodBuilder *mb, gboolean slowpath, gboolean
 	mono_mb_emit_byte (mb, CEE_STIND_I);
 
 	/* mark object end with nursery word */
-	if (nursery_canaries_enabled ()) {
+	if (sgen_nursery_canaries_enabled ()) {
 			mono_mb_emit_ldloc (mb, p_var);
 			mono_mb_emit_ldloc (mb, real_size_var);
 			mono_mb_emit_byte (mb, MONO_CEE_ADD);

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -85,7 +85,7 @@ ptr_on_stack (void *ptr)
 		gpointer o = *(gpointer*)(ptr);				\
 		if ((o)) {						\
 			gpointer d = ((char*)dest) + ((char*)(ptr) - (char*)(obj)); \
-			binary_protocol_wbarrier (d, o, (gpointer) SGEN_LOAD_VTABLE (o)); \
+			sgen_binary_protocol_wbarrier (d, o, (gpointer) SGEN_LOAD_VTABLE (o)); \
 		}							\
 	} while (0)
 
@@ -113,7 +113,7 @@ mono_gc_wbarrier_value_copy (gpointer dest, gpointer src, int count, MonoClass *
 	}
 
 #ifdef SGEN_HEAVY_BINARY_PROTOCOL
-	if (binary_protocol_is_heavy_enabled ()) {
+	if (sgen_binary_protocol_is_heavy_enabled ()) {
 		size_t element_size = mono_class_value_size (klass, NULL);
 		int i;
 		for (i = 0; i < count; ++i) {
@@ -148,7 +148,7 @@ mono_gc_wbarrier_object_copy (MonoObject* obj, MonoObject *src)
 	}
 
 #ifdef SGEN_HEAVY_BINARY_PROTOCOL
-	if (binary_protocol_is_heavy_enabled ())
+	if (sgen_binary_protocol_is_heavy_enabled ())
 		scan_object_for_binary_protocol_copy_wbarrier (obj, (char*)src, (mword) src->vtable->gc_descr);
 #endif
 
@@ -168,7 +168,7 @@ mono_gc_wbarrier_set_arrayref (MonoArray *arr, gpointer slot_ptr, MonoObject* va
 	}
 	SGEN_LOG (8, "Adding remset at %p", slot_ptr);
 	if (value)
-		binary_protocol_wbarrier (slot_ptr, value, value->vtable);
+		sgen_binary_protocol_wbarrier (slot_ptr, value, value->vtable);
 
 	sgen_get_remset ()->wbarrier_set_field ((GCObject*)arr, slot_ptr, value);
 }
@@ -324,7 +324,7 @@ mono_gc_get_specific_write_barrier (gboolean is_concurrent)
 MonoMethod*
 mono_gc_get_write_barrier (void)
 {
-	return mono_gc_get_specific_write_barrier (major_collector.is_concurrent);
+	return mono_gc_get_specific_write_barrier (sgen_major_collector.is_concurrent);
 }
 
 /*
@@ -721,7 +721,7 @@ need_remove_object_for_domain (GCObject *start, MonoDomain *domain)
 {
 	if (mono_object_domain (start) == domain) {
 		SGEN_LOG (4, "Need to cleanup object %p", start);
-		binary_protocol_cleanup (start, (gpointer)SGEN_LOAD_VTABLE (start), sgen_safe_object_get_size ((GCObject*)start));
+		sgen_binary_protocol_cleanup (start, (gpointer)SGEN_LOAD_VTABLE (start), sgen_safe_object_get_size ((GCObject*)start));
 		return TRUE;
 	}
 	return FALSE;
@@ -785,14 +785,14 @@ static void
 clear_domain_free_major_non_pinned_object_callback (GCObject *obj, size_t size, MonoDomain *domain)
 {
 	if (need_remove_object_for_domain (obj, domain))
-		major_collector.free_non_pinned_object (obj, size);
+		sgen_major_collector.free_non_pinned_object (obj, size);
 }
 
 static void
 clear_domain_free_major_pinned_object_callback (GCObject *obj, size_t size, MonoDomain *domain)
 {
 	if (need_remove_object_for_domain (obj, domain))
-		major_collector.free_pinned_object (obj, size);
+		sgen_major_collector.free_pinned_object (obj, size);
 }
 
 /*
@@ -812,15 +812,15 @@ mono_gc_clear_domain (MonoDomain * domain)
 
 	LOCK_GC;
 
-	binary_protocol_domain_unload_begin (domain);
+	sgen_binary_protocol_domain_unload_begin (domain);
 
 	sgen_stop_world (0, FALSE);
 
-	if (sgen_concurrent_collection_in_progress ())
+	if (sgen_get_concurrent_collection_in_progress ())
 		sgen_perform_collection (0, GENERATION_OLD, "clear domain", TRUE, FALSE);
-	SGEN_ASSERT (0, !sgen_concurrent_collection_in_progress (), "We just ordered a synchronous collection.  Why are we collecting concurrently?");
+	SGEN_ASSERT (0, !sgen_get_concurrent_collection_in_progress (), "We just ordered a synchronous collection.  Why are we collecting concurrently?");
 
-	major_collector.finish_sweeping ();
+	sgen_major_collector.finish_sweeping ();
 
 	sgen_process_fin_stage_entries ();
 
@@ -844,7 +844,7 @@ mono_gc_clear_domain (MonoDomain * domain)
 	for (i = GENERATION_NURSERY; i < GENERATION_MAX; ++i)
 		sgen_remove_finalizers_if (object_in_domain_predicate, domain, i);
 
-	sgen_scan_area_with_callback (nursery_section->data, nursery_section->end_data,
+	sgen_scan_area_with_callback (sgen_nursery_section->data, sgen_nursery_section->end_data,
 			(IterateObjectCallbackFunc)clear_domain_process_minor_object_callback, domain, FALSE, TRUE);
 
 	/* We need two passes over major and large objects because
@@ -854,18 +854,18 @@ mono_gc_clear_domain (MonoDomain * domain)
 	   objects with major-mark&sweep), but we might need to
 	   dereference a pointer from an object to another object if
 	   the first object is a proxy. */
-	major_collector.iterate_objects (ITERATE_OBJECTS_SWEEP_ALL, (IterateObjectCallbackFunc)clear_domain_process_major_object_callback, domain);
-	for (bigobj = los_object_list; bigobj; bigobj = bigobj->next)
+	sgen_major_collector.iterate_objects (ITERATE_OBJECTS_SWEEP_ALL, (IterateObjectCallbackFunc)clear_domain_process_major_object_callback, domain);
+	for (bigobj = sgen_los_object_list; bigobj; bigobj = bigobj->next)
 		clear_domain_process_object ((GCObject*)bigobj->data, domain);
 
 	prev = NULL;
-	for (bigobj = los_object_list; bigobj;) {
+	for (bigobj = sgen_los_object_list; bigobj;) {
 		if (need_remove_object_for_domain ((GCObject*)bigobj->data, domain)) {
 			LOSObject *to_free = bigobj;
 			if (prev)
 				prev->next = bigobj->next;
 			else
-				los_object_list = bigobj->next;
+				sgen_los_object_list = bigobj->next;
 			bigobj = bigobj->next;
 			SGEN_LOG (4, "Freeing large object %p", bigobj->data);
 			sgen_los_free_object (to_free);
@@ -874,8 +874,8 @@ mono_gc_clear_domain (MonoDomain * domain)
 		prev = bigobj;
 		bigobj = bigobj->next;
 	}
-	major_collector.iterate_objects (ITERATE_OBJECTS_SWEEP_NON_PINNED, (IterateObjectCallbackFunc)clear_domain_free_major_non_pinned_object_callback, domain);
-	major_collector.iterate_objects (ITERATE_OBJECTS_SWEEP_PINNED, (IterateObjectCallbackFunc)clear_domain_free_major_pinned_object_callback, domain);
+	sgen_major_collector.iterate_objects (ITERATE_OBJECTS_SWEEP_NON_PINNED, (IterateObjectCallbackFunc)clear_domain_free_major_non_pinned_object_callback, domain);
+	sgen_major_collector.iterate_objects (ITERATE_OBJECTS_SWEEP_PINNED, (IterateObjectCallbackFunc)clear_domain_free_major_pinned_object_callback, domain);
 
 	if (domain == mono_get_root_domain ()) {
 		sgen_pin_stats_report ();
@@ -884,8 +884,8 @@ mono_gc_clear_domain (MonoDomain * domain)
 
 	sgen_restart_world (0, FALSE);
 
-	binary_protocol_domain_unload_end (domain);
-	binary_protocol_flush_buffers (FALSE);
+	sgen_binary_protocol_domain_unload_end (domain);
+	sgen_binary_protocol_flush_buffers (FALSE);
 
 	UNLOCK_GC;
 }
@@ -1055,9 +1055,9 @@ mono_gc_get_managed_allocator (MonoClass *klass, gboolean for_box, gboolean know
 	ManagedAllocatorVariant variant = mono_profiler_allocations_enabled () ?
 		MANAGED_ALLOCATOR_PROFILER : MANAGED_ALLOCATOR_REGULAR;
 
-	if (collect_before_allocs)
+	if (sgen_collect_before_allocs)
 		return NULL;
-	if (m_class_get_instance_size (klass) > tlab_size)
+	if (m_class_get_instance_size (klass) > sgen_tlab_size)
 		return NULL;
 	if (known_instance_size && ALIGN_TO (m_class_get_instance_size (klass), SGEN_ALLOC_ALIGN) >= SGEN_MAX_SMALL_OBJ_SIZE)
 		return NULL;
@@ -1083,7 +1083,7 @@ mono_gc_get_managed_array_allocator (MonoClass *klass)
 #ifdef MANAGED_ALLOCATION
 	if (m_class_get_rank (klass) != 1)
 		return NULL;
-	if (has_per_allocation_action)
+	if (sgen_has_per_allocation_action)
 		return NULL;
 	g_assert (!mono_class_has_finalizer (klass) && !mono_class_is_marshalbyref (klass));
 
@@ -1256,7 +1256,7 @@ LOOP_HEAD:
 					scan_ptr_field_func (obj, (GCObject**)elem, ctx.queue);
 			}
 
-			binary_protocol_card_scan (first_elem, elem - first_elem);
+			sgen_binary_protocol_card_scan (first_elem, elem - first_elem);
 		}
 
 #ifdef SGEN_HAVE_OVERLAPPING_CARDS
@@ -1419,7 +1419,7 @@ mono_gc_set_string_length (MonoString *str, gint32 new_length)
 	/* zero the discarded string. This null-delimits the string and allows
 	 * the space to be reclaimed by SGen. */
 
-	if (nursery_canaries_enabled () && sgen_ptr_in_nursery (str)) {
+	if (sgen_nursery_canaries_enabled () && sgen_ptr_in_nursery (str)) {
 		CHECK_CANARY_FOR_OBJECT ((GCObject*)str, TRUE);
 		memset (new_end, 0, (str->length - new_length + 1) * sizeof (mono_unichar2) + CANARY_SIZE);
 		memcpy (new_end + 1 , CANARY_STRING, CANARY_SIZE);
@@ -1717,7 +1717,7 @@ report_registered_roots_by_type (int root_type)
 	void **start_root;
 	RootRecord *root;
 	report.count = 0;
-	SGEN_HASH_TABLE_FOREACH (&roots_hash [root_type], void **, start_root, RootRecord *, root) {
+	SGEN_HASH_TABLE_FOREACH (&sgen_roots_hash [root_type], void **, start_root, RootRecord *, root) {
 		SGEN_LOG (6, "Profiler root scan %p-%p (desc: %p)", start_root, root->end_root, (void*)root->root_desc);
 		if (root_type == ROOT_TYPE_PINNED)
 			report_pinning_roots (&report, start_root, (void**)root->end_root);
@@ -1968,9 +1968,9 @@ mono_gc_walk_heap (int flags, MonoGCReferences callback, void *data)
 	hwi.data = data;
 
 	sgen_clear_nursery_fragments ();
-	sgen_scan_area_with_callback (nursery_section->data, nursery_section->end_data, walk_references, &hwi, FALSE, TRUE);
+	sgen_scan_area_with_callback (sgen_nursery_section->data, sgen_nursery_section->end_data, walk_references, &hwi, FALSE, TRUE);
 
-	major_collector.iterate_objects (ITERATE_OBJECTS_SWEEP_ALL, walk_references, &hwi);
+	sgen_major_collector.iterate_objects (ITERATE_OBJECTS_SWEEP_ALL, walk_references, &hwi);
 	sgen_los_iterate_objects (walk_references, &hwi);
 
 	return 0;
@@ -2017,7 +2017,7 @@ sgen_client_thread_attach (SgenThreadInfo* info)
 	if (mono_gc_get_gc_callbacks ()->thread_attach_func)
 		info->client_info.runtime_data = mono_gc_get_gc_callbacks ()->thread_attach_func ();
 
-	binary_protocol_thread_register ((gpointer)mono_thread_info_get_tid (info));
+	sgen_binary_protocol_thread_register ((gpointer)mono_thread_info_get_tid (info));
 
 	SGEN_LOG (3, "registered thread %p (%p) stack end %p", info, (gpointer)mono_thread_info_get_tid (info), info->client_info.info.stack_end);
 
@@ -2046,7 +2046,7 @@ sgen_client_thread_detach_with_lock (SgenThreadInfo *p)
 		p->client_info.runtime_data = NULL;
 	}
 
-	binary_protocol_thread_unregister ((gpointer)tid);
+	sgen_binary_protocol_thread_unregister ((gpointer)tid);
 	SGEN_LOG (3, "unregister thread %p (%p)", p, (gpointer)tid);
 
 	HandleStack *handles = (HandleStack*) p->client_info.info.handle_stack;
@@ -2168,7 +2168,7 @@ sgen_client_scan_thread_data (void *start_nursery, void *end_nursery, gboolean p
 			skip_reason = 4;
 		}
 
-		binary_protocol_scan_stack ((gpointer)mono_thread_info_get_tid (info), info->client_info.stack_start, info->client_info.info.stack_end, skip_reason);
+		sgen_binary_protocol_scan_stack ((gpointer)mono_thread_info_get_tid (info), info->client_info.stack_start, info->client_info.info.stack_end, skip_reason);
 
 		if (skip_reason) {
 			if (precise) {
@@ -2647,7 +2647,7 @@ sgen_client_ensure_weak_gchandles_accessible (void)
 	/* FIXME: A GC can occur after this check fails, in which case we
 	 * should wait for bridge processing but would fail to do so.
 	 */
-	if (G_UNLIKELY (bridge_processing_in_progress))
+	if (G_UNLIKELY (mono_bridge_processing_in_progress))
 		mono_gc_wait_for_bridge_processing ();
 }
 
@@ -2696,7 +2696,7 @@ sgen_client_degraded_allocation (void)
 	static gint32 last_major_gc_warned = -1;
 	static gint32 num_degraded = 0;
 
-	gint32 major_gc_count = mono_atomic_load_i32 (&gc_stats.major_gc_count);
+	gint32 major_gc_count = mono_atomic_load_i32 (&mono_gc_stats.major_gc_count);
 	if (mono_atomic_load_i32 (&last_major_gc_warned) < major_gc_count) {
 		gint32 num = mono_atomic_inc_i32 (&num_degraded);
 		if (num == 1 || num == 3)
@@ -2815,7 +2815,7 @@ sgen_client_handle_gc_debug (const char *opt)
 		mono_do_not_finalize = TRUE;
 		mono_do_not_finalize_class_names = g_strsplit (opt, ",", 0);
 	} else if (!strcmp (opt, "log-finalizers")) {
-		log_finalizers = TRUE;
+		mono_log_finalizers = TRUE;
 	} else if (!strcmp (opt, "no-managed-allocator")) {
 		sgen_set_use_managed_allocator (FALSE);
 	} else if (!sgen_bridge_handle_gc_debug (opt)) {
@@ -2921,7 +2921,7 @@ sgen_client_binary_protocol_collection_begin (int minor_gc_count, int generation
 	MONO_GC_BEGIN (generation);
 
 	MONO_PROFILER_RAISE (gc_event, (MONO_GC_EVENT_START, generation));
-	MONO_PROFILER_RAISE (gc_event2, (MONO_GC_EVENT_START, generation, generation == GENERATION_OLD && concurrent_collection_in_progress));
+	MONO_PROFILER_RAISE (gc_event2, (MONO_GC_EVENT_START, generation, generation == GENERATION_OLD && sgen_concurrent_collection_in_progress));
 
 	if (!pseudo_roots_registered) {
 		pseudo_roots_registered = TRUE;
@@ -2944,7 +2944,7 @@ sgen_client_binary_protocol_collection_end (int minor_gc_count, int generation, 
 	MONO_GC_END (generation);
 
 	MONO_PROFILER_RAISE (gc_event, (MONO_GC_EVENT_END, generation));
-	MONO_PROFILER_RAISE (gc_event2, (MONO_GC_EVENT_END, generation, generation == GENERATION_OLD && concurrent_collection_in_progress));
+	MONO_PROFILER_RAISE (gc_event2, (MONO_GC_EVENT_END, generation, generation == GENERATION_OLD && sgen_concurrent_collection_in_progress));
 }
 
 #ifdef HOST_WASM

--- a/mono/metadata/sgen-new-bridge.c
+++ b/mono/metadata/sgen-new-bridge.c
@@ -179,7 +179,7 @@ set_config (const SgenBridgeProcessorConfig *config)
 static MonoGCBridgeObjectKind
 class_kind (MonoClass *klass)
 {
-	MonoGCBridgeObjectKind res = bridge_callbacks.bridge_class_kind (klass);
+	MonoGCBridgeObjectKind res = mono_bridge_callbacks.bridge_class_kind (klass);
 
 	/* If it's a bridge, nothing we can do about it. */
 	if (res == GC_BRIDGE_TRANSPARENT_BRIDGE_CLASS || res == GC_BRIDGE_OPAQUE_BRIDGE_CLASS)
@@ -197,7 +197,7 @@ class_kind (MonoClass *klass)
 
 		/* FIXME the bridge check can be quite expensive, cache it at the class level. */
 		/* An array of a sealed type that is not a bridge will never get to a bridge */
-		if ((mono_class_get_flags (elem_class) & TYPE_ATTRIBUTE_SEALED) && !m_class_has_references (elem_class) && !bridge_callbacks.bridge_class_kind (elem_class)) {
+		if ((mono_class_get_flags (elem_class) & TYPE_ATTRIBUTE_SEALED) && !m_class_has_references (elem_class) && !mono_bridge_callbacks.bridge_class_kind (elem_class)) {
 			SGEN_LOG (6, "class %s is opaque\n", m_class_get_name (klass));
 			return GC_BRIDGE_OPAQUE_CLASS;
 		}
@@ -764,7 +764,7 @@ processing_build_callback_data (int generation)
 	if (!dyn_array_ptr_size (&registered_bridges))
 		return;
 
-	g_assert (bridge_processing_in_progress);
+	g_assert (mono_bridge_processing_in_progress);
 
 	SGEN_TV_GETTIME (atv);
 

--- a/mono/metadata/sgen-old-bridge.c
+++ b/mono/metadata/sgen-old-bridge.c
@@ -385,7 +385,7 @@ set_config (const SgenBridgeProcessorConfig *config)
 static MonoGCBridgeObjectKind
 class_kind (MonoClass *klass)
 {
-	return bridge_callbacks.bridge_class_kind (klass);
+	return mono_bridge_callbacks.bridge_class_kind (klass);
 }
 
 static HashEntry*
@@ -677,7 +677,7 @@ processing_build_callback_data (int generation)
 	if (!dyn_array_ptr_size (&registered_bridges))
 		return;
 
-	g_assert (bridge_processing_in_progress);
+	g_assert (mono_bridge_processing_in_progress);
 
 	SGEN_TV_GETTIME (atv);
 

--- a/mono/metadata/sgen-stw.c
+++ b/mono/metadata/sgen-stw.c
@@ -379,7 +379,7 @@ sgen_unified_suspend_stop_world (void)
 
 		stopped_ip = (gpointer) (MONO_CONTEXT_GET_IP (&info->client_info.ctx));
 
-		binary_protocol_thread_suspend ((gpointer) mono_thread_info_get_tid (info), stopped_ip);
+		sgen_binary_protocol_thread_suspend ((gpointer) mono_thread_info_get_tid (info), stopped_ip);
 
 		THREADS_STW_DEBUG ("[GC-STW-SUSPEND-END] thread %p is suspended, stopped_ip = %p, stack = %p -> %p\n",
 			mono_thread_info_get_tid (info), stopped_ip, info->client_info.stack_start, info->client_info.stack_start ? info->client_info.info.stack_end : NULL);
@@ -396,7 +396,7 @@ sgen_unified_suspend_restart_world (void)
 			g_assert (mono_thread_info_begin_resume (info));
 			THREADS_STW_DEBUG ("[GC-STW-RESUME-WORLD] RESUME thread %p\n", mono_thread_info_get_tid (info));
 
-			binary_protocol_thread_restart ((gpointer) mono_thread_info_get_tid (info));
+			sgen_binary_protocol_thread_restart ((gpointer) mono_thread_info_get_tid (info));
 		} else {
 			THREADS_STW_DEBUG ("[GC-STW-RESUME-WORLD] IGNORE thread %p, reason %d\n", mono_thread_info_get_tid (info), reason);
 		}

--- a/mono/metadata/sgen-tarjan-bridge.c
+++ b/mono/metadata/sgen-tarjan-bridge.c
@@ -45,7 +45,7 @@
 static MonoGCBridgeObjectKind
 class_kind (MonoClass *klass)
 {
-	MonoGCBridgeObjectKind res = bridge_callbacks.bridge_class_kind (klass);
+	MonoGCBridgeObjectKind res = mono_bridge_callbacks.bridge_class_kind (klass);
 
 	/* If it's a bridge, nothing we can do about it. */
 	if (res == GC_BRIDGE_TRANSPARENT_BRIDGE_CLASS || res == GC_BRIDGE_OPAQUE_BRIDGE_CLASS)
@@ -63,7 +63,7 @@ class_kind (MonoClass *klass)
 
 		/* FIXME the bridge check can be quite expensive, cache it at the class level. */
 		/* An array of a sealed type that is not a bridge will never get to a bridge */
-		if ((mono_class_get_flags (elem_class) & TYPE_ATTRIBUTE_SEALED) && !m_class_has_references (elem_class) && !bridge_callbacks.bridge_class_kind (elem_class)) {
+		if ((mono_class_get_flags (elem_class) & TYPE_ATTRIBUTE_SEALED) && !m_class_has_references (elem_class) && !mono_bridge_callbacks.bridge_class_kind (elem_class)) {
 			SGEN_LOG (6, "class %s is opaque\n", m_class_get_name (klass));
 			return GC_BRIDGE_OPAQUE_CLASS;
 		}

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -3786,7 +3786,7 @@ ves_icall_TypeBuilder_create_runtime_class (MonoReflectionTypeBuilderHandle ref_
 
 			MonoType *subtype = mono_reflection_type_handle_mono_type (nested_tb, error);
 			goto_if_nok (error, failure);
-			nested = g_list_prepend_image (klass->image, nested, mono_class_from_mono_type (subtype));
+			nested = mono_g_list_prepend_image (klass->image, nested, mono_class_from_mono_type (subtype));
 		}
 		mono_class_set_nested_classes_property (klass, nested);
 	}

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -2813,7 +2813,7 @@ mono_network_cleanup (void)
 }
 
 void
-icall_cancel_blocking_socket_operation (MonoThreadObjectHandle thread, MonoError *error)
+ves_icall_cancel_blocking_socket_operation (MonoThreadObjectHandle thread, MonoError *error)
 {
 	error_init (error);
 	MonoInternalThreadHandle internal = MONO_HANDLE_NEW_GET (MonoInternalThread, thread, internal_thread);

--- a/mono/metadata/w32socket.h
+++ b/mono/metadata/w32socket.h
@@ -288,7 +288,7 @@ ves_icall_System_Net_Sockets_Socket_SendFile_internal (gsize sock, MonoStringHan
 						       gint flags, gint32 *werror, gboolean blocking, MonoError *error);
 
 void
-icall_cancel_blocking_socket_operation (MonoThreadObjectHandle thread, MonoError *error);
+ves_icall_cancel_blocking_socket_operation (MonoThreadObjectHandle thread, MonoError *error);
 
 gboolean
 ves_icall_System_Net_Sockets_Socket_SupportPortReuse (MonoProtocolType proto, MonoError *error);

--- a/mono/mini/alias-analysis.c
+++ b/mono/mini/alias-analysis.c
@@ -63,7 +63,7 @@ lower_load (MonoCompile *cfg, MonoInst *load, MonoInst *ldaddr)
 	}
 
 	load->opcode = mono_type_to_regmove (cfg, type);
-	type_to_eval_stack_type (cfg, type, load);
+	mini_type_to_eval_stack_type (cfg, type, load);
 	load->sreg1 = var->dreg;
 	mono_atomic_inc_i32 (&mono_jit_stats.loads_eliminated);
 	return TRUE;
@@ -98,7 +98,7 @@ lower_store (MonoCompile *cfg, MonoInst *store, MonoInst *ldaddr)
 		store->opcode = coerce_op;
 	else
 		store->opcode = mono_type_to_regmove (cfg, type);
-	type_to_eval_stack_type (cfg, type, store);
+	mini_type_to_eval_stack_type (cfg, type, store);
 	store->dreg = var->dreg;
 	mono_atomic_inc_i32 (&mono_jit_stats.stores_eliminated);
 	return TRUE;

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -7383,7 +7383,7 @@ mono_aot_parse_options (const char *aot_options, MonoAotOptions *opts)
 		} else if (str_begins_with (arg, "gen-seq-points-file")) {
 			fprintf (stderr, "Mono Warning: aot option gen-seq-points-file is deprecated.\n");
 		} else if (str_begins_with (arg, "msym-dir=")) {
-			debug_options.no_seq_points_compact_data = FALSE;
+			mini_debug_options.no_seq_points_compact_data = FALSE;
 			opts->gen_msym_dir = TRUE;
 			opts->gen_msym_dir_path = g_strdup (arg + strlen ("msym_dir="));;
 		} else if (str_begins_with (arg, "direct-pinvoke")) {

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -546,7 +546,7 @@ decode_klass_ref (MonoAotModule *module, guint8 *buf, guint8 **endbuf, MonoError
 				}
 			} else {
 				// We didn't decode is_method, so we have to infer it from type enum.
-				container = get_anonymous_container_for_image (module->assembly->image, type == MONO_TYPE_MVAR);
+				container = mono_get_anonymous_container_for_image (module->assembly->image, type == MONO_TYPE_MVAR);
 			}
 
 			t = g_new0 (MonoType, 1);
@@ -558,7 +558,7 @@ decode_klass_ref (MonoAotModule *module, guint8 *buf, guint8 **endbuf, MonoError
 				MonoGenericParam *par = mono_metadata_create_anon_gparam (module->assembly->image, num, type == MONO_TYPE_MVAR);
 				t->data.generic_param = par;
 				// FIXME: maybe do this for all anon gparams?
-				((MonoGenericParamFull*)par)->info.name = make_generic_name_string (module->assembly->image, num);
+				((MonoGenericParamFull*)par)->info.name = mono_make_generic_name_string (module->assembly->image, num);
 			}
 			// FIXME: Maybe use types directly to avoid
 			// the overhead of creating MonoClass-es
@@ -5187,9 +5187,9 @@ load_function_full (MonoAotModule *amodule, const char *name, MonoTrampInfo **ou
 					target = mono_create_specific_trampoline (GUINT_TO_POINTER (slot), MONO_TRAMPOLINE_RGCTX_LAZY_FETCH, mono_get_root_domain (), NULL);
 					target = mono_create_ftnptr_malloc ((guint8 *)target);
 				} else if (!strcmp (ji->data.name, "debugger_agent_single_step_from_context")) {
-					target = debugger_agent_single_step_from_context;
+					target = mono_debugger_agent_single_step_from_context;
 				} else if (!strcmp (ji->data.name, "debugger_agent_breakpoint_from_context")) {
-					target = debugger_agent_breakpoint_from_context;
+					target = mono_debugger_agent_breakpoint_from_context;
 				} else if (!strcmp (ji->data.name, "throw_exception_addr")) {
 					target = mono_get_throw_exception_addr ();
 				} else if (strstr (ji->data.name, "generic_trampoline_")) {

--- a/mono/mini/debug-mini.c
+++ b/mono/mini/debug-mini.c
@@ -242,7 +242,7 @@ mono_debug_close_method (MonoCompile *cfg)
 	jit->code_start = cfg->native_code;
 	jit->epilogue_begin = cfg->epilog_begin;
 	jit->code_size = cfg->code_len;
-	jit->has_var_info = debug_options.mdb_optimizations || MONO_CFG_PROFILE_CALL_CONTEXT (cfg);
+	jit->has_var_info = mini_debug_options.mdb_optimizations || MONO_CFG_PROFILE_CALL_CONTEXT (cfg);
 
 	if (jit->epilogue_begin)
 		   record_line_number (info, jit->epilogue_begin, header->code_size);

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -727,7 +727,7 @@ static gboolean buffer_replies;
 
 /* Buffered reply packets */
 static ReplyPacket reply_packets [128];
-int nreply_packets;
+static int nreply_packets;
 
 #define dbg_lock() mono_coop_mutex_lock (&debug_mutex)
 #define dbg_unlock() mono_coop_mutex_unlock (&debug_mutex)
@@ -5233,7 +5233,7 @@ mono_debugger_agent_user_break (void)
 		mono_loader_unlock ();
 
 		process_event (EVENT_KIND_USER_BREAK, NULL, 0, &ctx, events, suspend_policy);
-	} else if (debug_options.native_debugger_break) {
+	} else if (mini_debug_options.native_debugger_break) {
 		G_BREAKPOINT ();
 	}
 }
@@ -5403,7 +5403,7 @@ mono_debugger_agent_single_step_event (void *sigctx)
 }
 
 void
-debugger_agent_single_step_from_context (MonoContext *ctx)
+mono_debugger_agent_single_step_from_context (MonoContext *ctx)
 {
 	DebuggerTlsData *tls;
 	MonoThreadUnwindState orig_restore_state;
@@ -5430,7 +5430,7 @@ debugger_agent_single_step_from_context (MonoContext *ctx)
 }
 
 void
-debugger_agent_breakpoint_from_context (MonoContext *ctx)
+mono_debugger_agent_breakpoint_from_context (MonoContext *ctx)
 {
 	DebuggerTlsData *tls;
 	MonoThreadUnwindState orig_restore_state;

--- a/mono/mini/debugger-agent.h
+++ b/mono/mini/debugger-agent.h
@@ -21,10 +21,10 @@ void
 mono_debugger_agent_single_step_event (void *sigctx);
 
 void
-debugger_agent_single_step_from_context (MonoContext *ctx);
+mono_debugger_agent_single_step_from_context (MonoContext *ctx);
 
 void
-debugger_agent_breakpoint_from_context (MonoContext *ctx);
+mono_debugger_agent_breakpoint_from_context (MonoContext *ctx);
 
 void
 mono_debugger_agent_free_domain_info (MonoDomain *domain);

--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -148,7 +148,7 @@ typedef struct {
 } ThreadContext;
 
 extern int mono_interp_traceopt;
-extern GSList *jit_classes;
+extern GSList *mono_interp_jit_classes;
 
 MonoException *
 mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, InterpFrame *frame);

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -107,7 +107,7 @@ init_frame (InterpFrame *frame, InterpFrame *parent_frame, InterpMethod *rmethod
  * List of classes whose methods will be executed by transitioning to JITted code.
  * Used for testing.
  */
-GSList *jit_classes;
+GSList *mono_interp_jit_classes;
 /* If TRUE, interpreted code will be interrupted at function entry/backward branches */
 static gboolean ss_enabled;
 
@@ -2175,10 +2175,10 @@ static void interp_entry_instance_ret_8 (gpointer this_arg, gpointer res, ARGLIS
 
 #define INTERP_ENTRY_FUNCLIST(type) interp_entry_ ## type ## _0, interp_entry_ ## type ## _1, interp_entry_ ## type ## _2, interp_entry_ ## type ## _3, interp_entry_ ## type ## _4, interp_entry_ ## type ## _5, interp_entry_ ## type ## _6, interp_entry_ ## type ## _7, interp_entry_ ## type ## _8
 
-gpointer entry_funcs_static [MAX_INTERP_ENTRY_ARGS + 1] = { INTERP_ENTRY_FUNCLIST (static) };
-gpointer entry_funcs_static_ret [MAX_INTERP_ENTRY_ARGS + 1] = { INTERP_ENTRY_FUNCLIST (static_ret) };
-gpointer entry_funcs_instance [MAX_INTERP_ENTRY_ARGS + 1] = { INTERP_ENTRY_FUNCLIST (instance) };
-gpointer entry_funcs_instance_ret [MAX_INTERP_ENTRY_ARGS + 1] = { INTERP_ENTRY_FUNCLIST (instance_ret) };
+static gpointer entry_funcs_static [MAX_INTERP_ENTRY_ARGS + 1] = { INTERP_ENTRY_FUNCLIST (static) };
+static gpointer entry_funcs_static_ret [MAX_INTERP_ENTRY_ARGS + 1] = { INTERP_ENTRY_FUNCLIST (static_ret) };
+static gpointer entry_funcs_instance [MAX_INTERP_ENTRY_ARGS + 1] = { INTERP_ENTRY_FUNCLIST (instance) };
+static gpointer entry_funcs_instance_ret [MAX_INTERP_ENTRY_ARGS + 1] = { INTERP_ENTRY_FUNCLIST (instance_ret) };
 
 /* General version for methods with more than MAX_INTERP_ENTRY_ARGS arguments */
 static void
@@ -5198,7 +5198,7 @@ interp_parse_options (const char *options)
 		char *arg = *ptr;
 
 		if (strncmp (arg, "jit=", 4) == 0)
-			jit_classes = g_slist_prepend (jit_classes, arg + 4);
+			mono_interp_jit_classes = g_slist_prepend (mono_interp_jit_classes, arg + 4);
 	}
 }
 

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -774,7 +774,7 @@ jit_call_supported (MonoMethod *method, MonoMethodSignature *sig)
 	if (method->string_ctor)
 		return FALSE;
 
-	for (l = jit_classes; l; l = l->next) {
+	for (l = mono_interp_jit_classes; l; l = l->next) {
 		char *class_name = l->data;
 		// FIXME: Namespaces
 		if (!strcmp (method->klass->name, class_name))
@@ -1758,7 +1758,7 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsig
 	td->data_items = NULL;
 	td->data_hash = g_hash_table_new (NULL, NULL);
 	td->clause_indexes = g_malloc (header->code_size * sizeof (int));
-	td->gen_sdb_seq_points = debug_options.gen_sdb_seq_points;
+	td->gen_sdb_seq_points = mini_debug_options.gen_sdb_seq_points;
 	td->seq_points = g_ptr_array_new ();
 	td->relocs = g_ptr_array_new ();
 	td->verbose_level = mono_interp_traceopt;

--- a/mono/mini/ir-emit.h
+++ b/mono/mini/ir-emit.h
@@ -344,7 +344,7 @@ alloc_dreg (MonoCompile *cfg, MonoStackType stack_type)
 #define NEW_VARLOAD(cfg,dest,var,vartype) do { \
         MONO_INST_NEW ((cfg), (dest), OP_MOVE); \
 		(dest)->opcode = mono_type_to_regmove ((cfg), (vartype));  \
-		type_to_eval_stack_type ((cfg), (vartype), (dest));	\
+		mini_type_to_eval_stack_type ((cfg), (vartype), (dest));	\
 		(dest)->klass = var->klass;	\
 		(dest)->sreg1 = var->dreg;   \
         (dest)->dreg = alloc_dreg ((cfg), (MonoStackType)(dest)->type); \
@@ -430,7 +430,7 @@ handle_gsharedvt_ldaddr (MonoCompile *cfg)
 /* Variants which take a type argument and handle vtypes as well */
 #define NEW_LOAD_MEMBASE_TYPE(cfg,dest,ltype,base,offset) do { \
 	    NEW_LOAD_MEMBASE ((cfg), (dest), mono_type_to_load_membase ((cfg), (ltype)), 0, (base), (offset)); \
-	    type_to_eval_stack_type ((cfg), (ltype), (dest)); \
+	    mini_type_to_eval_stack_type ((cfg), (ltype), (dest)); \
 	    (dest)->dreg = alloc_dreg ((cfg), (MonoStackType)(dest)->type); \
     } while (0)
 
@@ -439,7 +439,7 @@ handle_gsharedvt_ldaddr (MonoCompile *cfg)
         (dest)->sreg1 = sr; \
         (dest)->inst_destbasereg = base; \
         (dest)->inst_offset = offset; \
-	    type_to_eval_stack_type ((cfg), (ltype), (dest)); \
+	    mini_type_to_eval_stack_type ((cfg), (ltype), (dest)); \
         (dest)->klass = mono_class_from_mono_type (ltype); \
 	} while (0)
 

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -184,7 +184,7 @@ static GENERATE_TRY_GET_CLASS_WITH_CACHE (debuggable_attribute, "System.Diagnost
 #endif
 /* keep in sync with the enum in mini.h */
 const char
-ins_info[] = {
+mini_ins_info[] = {
 #include "mini-ops.h"
 };
 #undef MINI_OP
@@ -196,7 +196,7 @@ ins_info[] = {
  * This should contain the index of the last sreg + 1. This is not the same
  * as the number of sregs for opcodes like IA64_CMP_EQ_IMM.
  */
-const gint8 ins_sreg_counts[] = {
+const gint8 mini_ins_sreg_counts[] = {
 #include "mini-ops.h"
 };
 #undef MINI_OP
@@ -754,7 +754,7 @@ mono_create_exvar_for_offset (MonoCompile *cfg, int offset)
  * FIXME: return a MonoType/MonoClass for the byref and VALUETYPE cases.
  */
 void
-type_to_eval_stack_type (MonoCompile *cfg, MonoType *type, MonoInst *inst)
+mini_type_to_eval_stack_type (MonoCompile *cfg, MonoType *type, MonoInst *inst)
 {
 	MonoClass *klass;
 
@@ -824,7 +824,7 @@ handle_enum:
 			g_assert (cfg->gsharedvt);
 			inst->type = STACK_VTYPE;
 		} else {
-			type_to_eval_stack_type (cfg, mini_get_underlying_type (type), inst);
+			mini_type_to_eval_stack_type (cfg, mini_get_underlying_type (type), inst);
 		}
 		return;
 	default:
@@ -2184,7 +2184,7 @@ mono_emit_call_args (MonoCompile *cfg, MonoMethodSignature *sig,
 	call->rgctx_reg = rgctx;
 	sig_ret = mini_get_underlying_type (sig->ret);
 
-	type_to_eval_stack_type ((cfg), sig_ret, &call->inst);
+	mini_type_to_eval_stack_type ((cfg), sig_ret, &call->inst);
 
 	if (tail) {
 		if (mini_type_is_vtype (sig_ret)) {
@@ -8617,7 +8617,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 
 			if ((cfg->opt & MONO_OPT_INTRINS) && (ins = mini_emit_inst_for_sharable_method (cfg, cmethod, fsig, sp))) {
 				if (!MONO_TYPE_IS_VOID (fsig->ret)) {
-					type_to_eval_stack_type ((cfg), fsig->ret, ins);
+					mini_type_to_eval_stack_type ((cfg), fsig->ret, ins);
 					emit_widen = FALSE;
 				}
 
@@ -8789,7 +8789,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			/* Conversion to a JIT intrinsic */
 			if ((cfg->opt & MONO_OPT_INTRINS) && (ins = mini_emit_inst_for_method (cfg, cmethod, fsig, sp))) {
 				if (!MONO_TYPE_IS_VOID (fsig->ret)) {
-					type_to_eval_stack_type ((cfg), fsig->ret, ins);
+					mini_type_to_eval_stack_type ((cfg), fsig->ret, ins);
 					emit_widen = FALSE;
 				}
 				goto call_end;
@@ -10069,7 +10069,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			if (alloc == NULL) {
 				/* Valuetype */
 				EMIT_NEW_TEMPLOAD (cfg, ins, iargs [0]->inst_c0);
-				type_to_eval_stack_type (cfg, &ins->klass->byval_arg, ins);
+				mini_type_to_eval_stack_type (cfg, &ins->klass->byval_arg, ins);
 				*sp++= ins;
 			} else {
 				*sp++ = alloc;
@@ -10853,7 +10853,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 					case MONO_TYPE_PTR:
 					case MONO_TYPE_FNPTR:
 						EMIT_NEW_PCONST (cfg, *sp, *((gpointer *)addr));
-						type_to_eval_stack_type ((cfg), field->type, *sp);
+						mini_type_to_eval_stack_type ((cfg), field->type, *sp);
 						sp++;
 						break;
 					case MONO_TYPE_STRING:
@@ -10863,7 +10863,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 					case MONO_TYPE_ARRAY:
 						if (!mono_gc_is_moving ()) {
 							EMIT_NEW_PCONST (cfg, *sp, *((gpointer *)addr));
-							type_to_eval_stack_type ((cfg), field->type, *sp);
+							mini_type_to_eval_stack_type ((cfg), field->type, *sp);
 							sp++;
 						} else {
 							is_const = FALSE;

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -189,7 +189,7 @@ set_info_templates (MonoImage *image, MonoRuntimeGenericContextTemplate *templat
 
 		/* FIXME: quadratic! */
 		while (length < type_argc) {
-			template_->method_templates = g_slist_append_image (image, template_->method_templates, NULL);
+			template_->method_templates = mono_g_slist_append_image (image, template_->method_templates, NULL);
 			length++;
 		}
 
@@ -3527,7 +3527,7 @@ mini_get_shared_gparam (MonoType *t, MonoType *constraint)
 	key.param.gshared_constraint = constraint;
 
 	g_assert (mono_generic_param_info (par));
-	image = get_image_for_generic_param(par);
+	image = mono_get_image_for_generic_param(par);
 
 	/*
 	 * Need a cache to ensure the newly created gparam

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -204,7 +204,7 @@ typedef struct {
 #define LREG 'l'
 /* keep in sync with the enum in mini.h */
 const char
-llvm_ins_info[] = {
+mini_llvm_ins_info[] = {
 #include "mini-ops.h"
 };
 #undef MINI_OP
@@ -216,7 +216,7 @@ llvm_ins_info[] = {
 #define GET_LONG_IMM(ins) ((ins)->inst_imm)
 #endif
 
-#define LLVM_INS_INFO(opcode) (&llvm_ins_info [((opcode) - OP_START - 1) * 4])
+#define LLVM_INS_INFO(opcode) (&mini_llvm_ins_info [((opcode) - OP_START - 1) * 4])
 
 #if 0
 #define TRACE_FAILURE(msg) do { printf ("%s\n", msg); } while (0)

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -494,7 +494,7 @@ clock_sleep_ns_abs (guint64 ns_abs)
 
 #else
 
-clockid_t sampling_posix_clock;
+static clockid_t sampling_posix_clock;
 
 static void
 clock_init (MonoProfilerSampleMode mode)

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -125,7 +125,7 @@ static mono_mutex_t jit_mutex;
 
 static MonoCodeManager *global_codeman;
 
-MonoDebugOptions debug_options;
+MonoDebugOptions mini_debug_options;
 
 #ifdef VALGRIND_JIT_REGISTER_MAP
 int valgrind_register;
@@ -2331,7 +2331,7 @@ mono_jit_free_method (MonoDomain *domain, MonoMethod *method)
 	mono_domain_unlock (domain);
 
 #ifdef MONO_ARCH_HAVE_INVALIDATE_METHOD
-	if (debug_options.keep_delegates && method->wrapper_type == MONO_WRAPPER_NATIVE_TO_MANAGED) {
+	if (mini_debug_options.keep_delegates && method->wrapper_type == MONO_WRAPPER_NATIVE_TO_MANAGED) {
 		/*
 		 * Instead of freeing the code, change it to call an error routine
 		 * so people can fix their code.
@@ -2490,7 +2490,7 @@ create_runtime_invoke_info (MonoDomain *domain, MonoMethod *method, gpointer com
 	 * possible, built on top of the OP_DYN_CALL opcode provided by the JIT.
 	 */
 #ifdef MONO_ARCH_DYN_CALL_SUPPORTED
-	if (!mono_llvm_only && (mono_aot_only || debug_options.dyn_runtime_invoke)) {
+	if (!mono_llvm_only && (mono_aot_only || mini_debug_options.dyn_runtime_invoke)) {
 		gboolean supported = TRUE;
 		int i;
 
@@ -2509,7 +2509,7 @@ create_runtime_invoke_info (MonoDomain *domain, MonoMethod *method, gpointer com
 
 		if (supported) {
 			info->dyn_call_info = mono_arch_dyn_call_prepare (sig);
-			if (debug_options.dyn_runtime_invoke)
+			if (mini_debug_options.dyn_runtime_invoke)
 				g_assert (info->dyn_call_info);
 		}
 	}
@@ -3474,51 +3474,51 @@ gboolean
 mini_parse_debug_option (const char *option)
 {
 	if (!strcmp (option, "handle-sigint"))
-		debug_options.handle_sigint = TRUE;
+		mini_debug_options.handle_sigint = TRUE;
 	else if (!strcmp (option, "keep-delegates"))
-		debug_options.keep_delegates = TRUE;
+		mini_debug_options.keep_delegates = TRUE;
 	else if (!strcmp (option, "reverse-pinvoke-exceptions"))
-		debug_options.reverse_pinvoke_exceptions = TRUE;
+		mini_debug_options.reverse_pinvoke_exceptions = TRUE;
 	else if (!strcmp (option, "collect-pagefault-stats"))
-		debug_options.collect_pagefault_stats = TRUE;
+		mini_debug_options.collect_pagefault_stats = TRUE;
 	else if (!strcmp (option, "break-on-unverified"))
-		debug_options.break_on_unverified = TRUE;
+		mini_debug_options.break_on_unverified = TRUE;
 	else if (!strcmp (option, "no-gdb-backtrace"))
-		debug_options.no_gdb_backtrace = TRUE;
+		mini_debug_options.no_gdb_backtrace = TRUE;
 	else if (!strcmp (option, "suspend-on-native-crash") || !strcmp (option, "suspend-on-sigsegv"))
-		debug_options.suspend_on_native_crash = TRUE;
+		mini_debug_options.suspend_on_native_crash = TRUE;
 	else if (!strcmp (option, "suspend-on-exception"))
-		debug_options.suspend_on_exception = TRUE;
+		mini_debug_options.suspend_on_exception = TRUE;
 	else if (!strcmp (option, "suspend-on-unhandled"))
-		debug_options.suspend_on_unhandled = TRUE;
+		mini_debug_options.suspend_on_unhandled = TRUE;
 	else if (!strcmp (option, "dont-free-domains"))
 		mono_dont_free_domains = TRUE;
 	else if (!strcmp (option, "dyn-runtime-invoke"))
-		debug_options.dyn_runtime_invoke = TRUE;
+		mini_debug_options.dyn_runtime_invoke = TRUE;
 	else if (!strcmp (option, "gdb"))
-		debug_options.gdb = TRUE;
+		mini_debug_options.gdb = TRUE;
 	else if (!strcmp (option, "lldb"))
-		debug_options.lldb = TRUE;
+		mini_debug_options.lldb = TRUE;
 	else if (!strcmp (option, "explicit-null-checks"))
-		debug_options.explicit_null_checks = TRUE;
+		mini_debug_options.explicit_null_checks = TRUE;
 	else if (!strcmp (option, "gen-seq-points"))
-		debug_options.gen_sdb_seq_points = TRUE;
+		mini_debug_options.gen_sdb_seq_points = TRUE;
 	else if (!strcmp (option, "gen-compact-seq-points"))
 		fprintf (stderr, "Mono Warning: option gen-compact-seq-points is deprecated.\n");
 	else if (!strcmp (option, "no-compact-seq-points"))
-		debug_options.no_seq_points_compact_data = TRUE;
+		mini_debug_options.no_seq_points_compact_data = TRUE;
 	else if (!strcmp (option, "single-imm-size"))
-		debug_options.single_imm_size = TRUE;
+		mini_debug_options.single_imm_size = TRUE;
 	else if (!strcmp (option, "init-stacks"))
-		debug_options.init_stacks = TRUE;
+		mini_debug_options.init_stacks = TRUE;
 	else if (!strcmp (option, "casts"))
-		debug_options.better_cast_details = TRUE;
+		mini_debug_options.better_cast_details = TRUE;
 	else if (!strcmp (option, "soft-breakpoints"))
-		debug_options.soft_breakpoints = TRUE;
+		mini_debug_options.soft_breakpoints = TRUE;
 	else if (!strcmp (option, "check-pinvoke-callconv"))
-		debug_options.check_pinvoke_callconv = TRUE;
+		mini_debug_options.check_pinvoke_callconv = TRUE;
 	else if (!strcmp (option, "use-fallback-tls"))
-		debug_options.use_fallback_tls = TRUE;
+		mini_debug_options.use_fallback_tls = TRUE;
 	else if (!strcmp (option, "debug-domain-unload"))
 		mono_enable_debug_domain_unload (TRUE);
 	else if (!strcmp (option, "partial-sharing"))
@@ -3526,9 +3526,9 @@ mini_parse_debug_option (const char *option)
 	else if (!strcmp (option, "align-small-structs"))
 		mono_align_small_structs = TRUE;
 	else if (!strcmp (option, "native-debugger-break"))
-		debug_options.native_debugger_break = TRUE;
+		mini_debug_options.native_debugger_break = TRUE;
 	else if (!strcmp (option, "disable_omit_fp"))
-		debug_options.disable_omit_fp = TRUE;
+		mini_debug_options.disable_omit_fp = TRUE;
 	else
 		return FALSE;
 
@@ -3563,7 +3563,7 @@ mini_parse_debug_options (void)
 MonoDebugOptions *
 mini_get_debug_options (void)
 {
-	return &debug_options;
+	return &mini_debug_options;
 }
 
 static gpointer
@@ -3851,7 +3851,7 @@ mini_add_profiler_argument (const char *desc)
 }
 
 
-MonoEECallbacks interp_cbs = {0};
+static MonoEECallbacks interp_cbs = {0};
 
 void
 mini_install_interp_callbacks (MonoEECallbacks *cbs)
@@ -4065,7 +4065,7 @@ mini_init (const char *filename, const char *runtime_version)
 
 	mono_profiler_started ();
 
-	if (debug_options.collect_pagefault_stats)
+	if (mini_debug_options.collect_pagefault_stats)
 		mono_aot_set_make_unreadable (TRUE);
 
 	if (runtime_version)
@@ -4492,7 +4492,7 @@ mini_cleanup (MonoDomain *domain)
 	MONO_PROFILER_RAISE (runtime_shutdown_begin, ());
 
 #ifndef DISABLE_COM
-	cominterop_release_all_rcws ();
+	mono_cominterop_release_all_rcws ();
 #endif
 
 #ifndef MONO_CROSS_COMPILE

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -332,7 +332,7 @@ extern MonoMethod *mono_current_single_method;
 extern GSList *mono_single_method_list;
 extern GHashTable *mono_single_method_hash;
 extern GList* mono_aot_paths;
-extern MonoDebugOptions debug_options;
+extern MonoDebugOptions mini_debug_options;
 
 static inline MonoMethod*
 jinfo_get_method (MonoJitInfo *ji)

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -1769,7 +1769,7 @@ mini_get_single_step_trampoline (void)
 /*
  * mini_get_breakpoint_trampoline:
  *
- *   Return a trampoline which calls debugger_agent_breakpoint_from_context ().
+ *   Return a trampoline which calls mono_debugger_agent_breakpoint_from_context ().
  */
 gpointer
 mini_get_breakpoint_trampoline (void)

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -325,13 +325,13 @@ extern gboolean	mono_using_xdebug;
 extern int mini_verbose;
 extern int valgrind_register;
 
-#define INS_INFO(opcode) (&ins_info [((opcode) - OP_START - 1) * 4])
+#define INS_INFO(opcode) (&mini_ins_info [((opcode) - OP_START - 1) * 4])
 
-extern const char ins_info[];
-extern const gint8 ins_sreg_counts [];
+extern const char mini_ins_info[];
+extern const gint8 mini_ins_sreg_counts [];
 
 #ifndef DISABLE_JIT
-#define mono_inst_get_num_src_registers(ins) (ins_sreg_counts [(ins)->opcode - OP_START - 1])
+#define mono_inst_get_num_src_registers(ins) (mini_ins_sreg_counts [(ins)->opcode - OP_START - 1])
 #else
 #define mono_inst_get_num_src_registers(ins) 0
 #endif
@@ -2499,7 +2499,7 @@ int mini_get_rgctx_entry_slot (MonoJumpInfoRgctxEntry *entry);
 
 int mini_type_stack_size (MonoType *t, int *align);
 int mini_type_stack_size_full (MonoType *t, guint32 *align, gboolean pinvoke);
-void type_to_eval_stack_type (MonoCompile *cfg, MonoType *type, MonoInst *inst);
+void mini_type_to_eval_stack_type (MonoCompile *cfg, MonoType *type, MonoInst *inst);
 guint mono_type_to_regmove (MonoCompile *cfg, MonoType *type) MONO_LLVM_INTERNAL;
 
 void mono_cfg_add_try_hole (MonoCompile *cfg, MonoExceptionClause *clause, guint8 *start, MonoBasicBlock *bb);

--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -820,7 +820,7 @@ mono_arch_get_plt_info_offset (guint8 *plt_entry, mgreg_t *regs, guint8 *code)
  * mono_arch_create_sdb_trampoline:
  *
  *   Return a trampoline which captures the current context, passes it to
- * debugger_agent_single_step_from_context ()/debugger_agent_breakpoint_from_context (),
+ * mono_debugger_agent_single_step_from_context ()/mono_debugger_agent_breakpoint_from_context (),
  * then restores the (potentially changed) context.
  */
 guint8*
@@ -885,9 +885,9 @@ mono_arch_create_sdb_trampoline (gboolean single_step, MonoTrampInfo **info, gbo
 			code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, "debugger_agent_breakpoint_from_context");
 	} else {
 		if (single_step)
-			amd64_mov_reg_imm (code, AMD64_R11, debugger_agent_single_step_from_context);
+			amd64_mov_reg_imm (code, AMD64_R11, mono_debugger_agent_single_step_from_context);
 		else
-			amd64_mov_reg_imm (code, AMD64_R11, debugger_agent_breakpoint_from_context);
+			amd64_mov_reg_imm (code, AMD64_R11, mono_debugger_agent_breakpoint_from_context);
 	}	
 	amd64_call_reg (code, AMD64_R11);
 

--- a/mono/mini/tramp-arm.c
+++ b/mono/mini/tramp-arm.c
@@ -786,9 +786,9 @@ mono_arch_create_sdb_trampoline (gboolean single_step, MonoTrampInfo **info, gbo
 		ARM_LDR_IMM (code, ARMREG_IP, ARMREG_PC, 0);
 		ARM_B (code, 0);
 		if (single_step)
-			*(gpointer*)code = debugger_agent_single_step_from_context;
+			*(gpointer*)code = mono_debugger_agent_single_step_from_context;
 		else
-			*(gpointer*)code = debugger_agent_breakpoint_from_context;
+			*(gpointer*)code = mono_debugger_agent_breakpoint_from_context;
 		code += 4;
 		ARM_BLX_REG (code, ARMREG_IP);
 	}

--- a/mono/mini/tramp-arm64.c
+++ b/mono/mini/tramp-arm64.c
@@ -515,7 +515,7 @@ mono_arch_create_general_rgctx_lazy_fetch_trampoline (MonoTrampInfo **info, gboo
  * mono_arch_create_sdb_trampoline:
  *
  *   Return a trampoline which captures the current context, passes it to
- * debugger_agent_single_step_from_context ()/debugger_agent_breakpoint_from_context (),
+ * mono_debugger_agent_single_step_from_context ()/mono_debugger_agent_breakpoint_from_context (),
  * then restores the (potentially changed) context.
  */
 guint8*
@@ -581,7 +581,7 @@ mono_arch_create_sdb_trampoline (gboolean single_step, MonoTrampInfo **info, gbo
 		else
 			code = mono_arm_emit_aotconst (&ji, code, buf, ARMREG_IP0, MONO_PATCH_INFO_JIT_ICALL_ADDR, "debugger_agent_breakpoint_from_context");
 	} else {
-		gpointer addr = single_step ? debugger_agent_single_step_from_context : debugger_agent_breakpoint_from_context;
+		gpointer addr = single_step ? mono_debugger_agent_single_step_from_context : mono_debugger_agent_breakpoint_from_context;
 
 		code = mono_arm_emit_imm64 (code, ARMREG_IP0, (guint64)addr);
 	}

--- a/mono/mini/tramp-x86.c
+++ b/mono/mini/tramp-x86.c
@@ -652,7 +652,7 @@ mono_arch_get_gsharedvt_arg_trampoline (MonoDomain *domain, gpointer arg, gpoint
  * mono_arch_create_sdb_trampoline:
  *
  *   Return a trampoline which captures the current context, passes it to
- * debugger_agent_single_step_from_context ()/debugger_agent_breakpoint_from_context (),
+ * mono_debugger_agent_single_step_from_context ()/mono_debugger_agent_breakpoint_from_context (),
  * then restores the (potentially changed) context.
  */
 guint8*
@@ -716,9 +716,9 @@ mono_arch_create_sdb_trampoline (gboolean single_step, MonoTrampInfo **info, gbo
 		x86_breakpoint (code);
 	} else {
 		if (single_step)
-			x86_call_code (code, debugger_agent_single_step_from_context);
+			x86_call_code (code, mono_debugger_agent_single_step_from_context);
 		else
-			x86_call_code (code, debugger_agent_breakpoint_from_context);
+			x86_call_code (code, mono_debugger_agent_breakpoint_from_context);
 	}
 
 	/* Restore registers from ctx */

--- a/mono/sgen/gc-internal-agnostic.h
+++ b/mono/sgen/gc-internal-agnostic.h
@@ -73,7 +73,7 @@ typedef struct {
 	gint64 major_gc_time_concurrent;
 } GCStats;
 
-extern GCStats gc_stats;
+extern GCStats mono_gc_stats;
 
 #ifdef HAVE_SGEN_GC
 typedef SgenDescriptor MonoGCDescriptor;

--- a/mono/sgen/sgen-alloc.c
+++ b/mono/sgen/sgen-alloc.c
@@ -70,7 +70,7 @@ alloc_degraded (GCVTable vtable, size_t size, gboolean for_mature)
 
 	if (!for_mature) {
 		sgen_client_degraded_allocation ();
-		SGEN_ATOMIC_ADD_P (degraded_mode, size);
+		SGEN_ATOMIC_ADD_P (sgen_degraded_mode, size);
 		sgen_ensure_free_space (size, GENERATION_OLD);
 	} else {
 		if (sgen_need_major_collection (size))
@@ -78,10 +78,10 @@ alloc_degraded (GCVTable vtable, size_t size, gboolean for_mature)
 	}
 
 
-	p = major_collector.alloc_degraded (vtable, size);
+	p = sgen_major_collector.alloc_degraded (vtable, size);
 
 	if (!for_mature)
-		binary_protocol_alloc_degraded (p, vtable, size, sgen_client_get_provenance ());
+		sgen_binary_protocol_alloc_degraded (p, vtable, size, sgen_client_get_provenance ());
 
 	return p;
 }
@@ -89,7 +89,7 @@ alloc_degraded (GCVTable vtable, size_t size, gboolean for_mature)
 static void
 zero_tlab_if_necessary (void *p, size_t size)
 {
-	if (nursery_clear_policy == CLEAR_AT_TLAB_CREATION || nursery_clear_policy == CLEAR_AT_TLAB_CREATION_DEBUG) {
+	if (sgen_nursery_clear_policy == CLEAR_AT_TLAB_CREATION || sgen_nursery_clear_policy == CLEAR_AT_TLAB_CREATION_DEBUG) {
 		memset (p, 0, size);
 	} else {
 		/*
@@ -136,20 +136,20 @@ sgen_alloc_obj_nolock (GCVTable vtable, size_t size)
 
 	SGEN_ASSERT (6, sgen_vtable_get_descriptor (vtable), "VTable without descriptor");
 
-	if (G_UNLIKELY (has_per_allocation_action)) {
+	if (G_UNLIKELY (sgen_has_per_allocation_action)) {
 		static int alloc_count;
 		int current_alloc = mono_atomic_inc_i32 (&alloc_count);
 
-		if (collect_before_allocs) {
-			if (((current_alloc % collect_before_allocs) == 0) && nursery_section) {
+		if (sgen_collect_before_allocs) {
+			if (((current_alloc % sgen_collect_before_allocs) == 0) && sgen_nursery_section) {
 				sgen_perform_collection (0, GENERATION_NURSERY, "collect-before-alloc-triggered", TRUE, TRUE);
-				if (!degraded_mode && sgen_can_alloc_size (size) && real_size <= SGEN_MAX_SMALL_OBJ_SIZE) {
+				if (!sgen_degraded_mode && sgen_can_alloc_size (size) && real_size <= SGEN_MAX_SMALL_OBJ_SIZE) {
 					// FIXME:
 					g_assert_not_reached ();
 				}
 			}
-		} else if (verify_before_allocs) {
-			if ((current_alloc % verify_before_allocs) == 0)
+		} else if (sgen_verify_before_allocs) {
+			if ((current_alloc % sgen_verify_before_allocs) == 0)
 				sgen_check_whole_heap_stw ();
 		}
 	}
@@ -180,7 +180,7 @@ sgen_alloc_obj_nolock (GCVTable vtable, size_t size)
 
 			CANARIFY_ALLOC(p,real_size);
 			SGEN_LOG (6, "Allocated object %p, vtable: %p (%s), size: %zd", p, vtable, sgen_client_vtable_get_name (vtable), size);
-			binary_protocol_alloc (p , vtable, size, sgen_client_get_provenance ());
+			sgen_binary_protocol_alloc (p , vtable, size, sgen_client_get_provenance ());
 			g_assert (*p == NULL);
 			mono_atomic_store_seq (p, vtable);
 
@@ -211,11 +211,11 @@ sgen_alloc_obj_nolock (GCVTable vtable, size_t size)
 			/* when running in degraded mode, we continue allocing that way
 			 * for a while, to decrease the number of useless nursery collections.
 			 */
-			if (degraded_mode && degraded_mode < sgen_nursery_size)
+			if (sgen_degraded_mode && sgen_degraded_mode < sgen_nursery_size)
 				return alloc_degraded (vtable, size, FALSE);
 
 			available_in_tlab = (int)(TLAB_REAL_END - TLAB_NEXT);//We'll never have tlabs > 2Gb
-			if (size > tlab_size || available_in_tlab > SGEN_MAX_NURSERY_WASTE) {
+			if (size > sgen_tlab_size || available_in_tlab > SGEN_MAX_NURSERY_WASTE) {
 				/* Allocate directly from the nursery */
 				p = (void **)sgen_nursery_alloc (size);
 				if (!p) {
@@ -237,7 +237,7 @@ sgen_alloc_obj_nolock (GCVTable vtable, size_t size)
 					 * OOM).
 					 */
 					sgen_ensure_free_space (real_size, GENERATION_NURSERY);
-					if (!degraded_mode)
+					if (!sgen_degraded_mode)
 						p = (void **)sgen_nursery_alloc (size);
 				}
 				if (!p)
@@ -250,12 +250,12 @@ sgen_alloc_obj_nolock (GCVTable vtable, size_t size)
 					SGEN_LOG (3, "Retire TLAB: %p-%p [%ld]", TLAB_START, TLAB_REAL_END, (long)(TLAB_REAL_END - TLAB_NEXT - size));
 				sgen_nursery_retire_region (p, available_in_tlab);
 
-				p = (void **)sgen_nursery_alloc_range (tlab_size, size, &alloc_size);
+				p = (void **)sgen_nursery_alloc_range (sgen_tlab_size, size, &alloc_size);
 				if (!p) {
 					/* See comment above in similar case. */
-					sgen_ensure_free_space (tlab_size, GENERATION_NURSERY);
-					if (!degraded_mode)
-						p = (void **)sgen_nursery_alloc_range (tlab_size, size, &alloc_size);
+					sgen_ensure_free_space (sgen_tlab_size, GENERATION_NURSERY);
+					if (!sgen_degraded_mode)
+						p = (void **)sgen_nursery_alloc_range (sgen_tlab_size, size, &alloc_size);
 				}
 				if (!p)
 					return alloc_degraded (vtable, size, TRUE);
@@ -287,7 +287,7 @@ sgen_alloc_obj_nolock (GCVTable vtable, size_t size)
 
 	if (G_LIKELY (p)) {
 		SGEN_LOG (6, "Allocated object %p, vtable: %p (%s), size: %zd", p, vtable, sgen_client_vtable_get_name (vtable), size);
-		binary_protocol_alloc (p, vtable, size, sgen_client_get_provenance ());
+		sgen_binary_protocol_alloc (p, vtable, size, sgen_client_get_provenance ());
 		mono_atomic_store_seq (p, vtable);
 	}
 
@@ -312,7 +312,7 @@ sgen_try_alloc_obj_nolock (GCVTable vtable, size_t size)
 	if (real_size > SGEN_MAX_SMALL_OBJ_SIZE)
 		return NULL;
 
-	if (G_UNLIKELY (size > tlab_size)) {
+	if (G_UNLIKELY (size > sgen_tlab_size)) {
 		/* Allocate directly from the nursery */
 		p = (void **)sgen_nursery_alloc (size);
 		if (!p)
@@ -354,7 +354,7 @@ sgen_try_alloc_obj_nolock (GCVTable vtable, size_t size)
 			size_t alloc_size = 0;
 
 			sgen_nursery_retire_region (p, available_in_tlab);
-			new_next = (char *)sgen_nursery_alloc_range (tlab_size, size, &alloc_size);
+			new_next = (char *)sgen_nursery_alloc_range (sgen_tlab_size, size, &alloc_size);
 			p = (void**)new_next;
 			if (!p)
 				return NULL;
@@ -374,7 +374,7 @@ sgen_try_alloc_obj_nolock (GCVTable vtable, size_t size)
 
 	CANARIFY_ALLOC(p,real_size);
 	SGEN_LOG (6, "Allocated object %p, vtable: %p (%s), size: %zd", p, vtable, sgen_client_vtable_get_name (vtable), size);
-	binary_protocol_alloc (p, vtable, size, sgen_client_get_provenance ());
+	sgen_binary_protocol_alloc (p, vtable, size, sgen_client_get_provenance ());
 	g_assert (*p == NULL); /* FIXME disable this in non debug builds */
 
 	mono_atomic_store_seq (p, vtable);
@@ -391,19 +391,19 @@ sgen_alloc_obj (GCVTable vtable, size_t size)
 	if (!SGEN_CAN_ALIGN_UP (size))
 		return NULL;
 
-	if (G_UNLIKELY (has_per_allocation_action)) {
+	if (G_UNLIKELY (sgen_has_per_allocation_action)) {
 		static int alloc_count;
 		int current_alloc = mono_atomic_inc_i32 (&alloc_count);
 
-		if (verify_before_allocs) {
-			if ((current_alloc % verify_before_allocs) == 0) {
+		if (sgen_verify_before_allocs) {
+			if ((current_alloc % sgen_verify_before_allocs) == 0) {
 				LOCK_GC;
 				sgen_check_whole_heap_stw ();
 				UNLOCK_GC;
 			}
 		}
-		if (collect_before_allocs) {
-			if (((current_alloc % collect_before_allocs) == 0) && nursery_section) {
+		if (sgen_collect_before_allocs) {
+			if (((current_alloc % sgen_collect_before_allocs) == 0) && sgen_nursery_section) {
 				LOCK_GC;
 				sgen_perform_collection (0, GENERATION_NURSERY, "collect-before-alloc-triggered", TRUE, TRUE);
 				UNLOCK_GC;
@@ -445,11 +445,11 @@ sgen_alloc_obj_pinned (GCVTable vtable, size_t size)
 		p = (GCObject *)sgen_los_alloc_large_inner (vtable, size);
 	} else {
 		SGEN_ASSERT (9, sgen_client_vtable_is_inited (vtable), "class %s:%s is not initialized", sgen_client_vtable_get_namespace (vtable), sgen_client_vtable_get_name (vtable));
-		p = major_collector.alloc_small_pinned_obj (vtable, size, SGEN_VTABLE_HAS_REFERENCES (vtable));
+		p = sgen_major_collector.alloc_small_pinned_obj (vtable, size, SGEN_VTABLE_HAS_REFERENCES (vtable));
 	}
 	if (G_LIKELY (p)) {
 		SGEN_LOG (6, "Allocated pinned object %p, vtable: %p (%s), size: %zd", p, vtable, sgen_client_vtable_get_name (vtable), size);
-		binary_protocol_alloc_pinned (p, vtable, size, sgen_client_get_provenance ());
+		sgen_binary_protocol_alloc_pinned (p, vtable, size, sgen_client_get_provenance ());
 	}
 	UNLOCK_GC;
 	return p;

--- a/mono/sgen/sgen-cardtable.c
+++ b/mono/sgen/sgen-cardtable.c
@@ -152,7 +152,7 @@ sgen_card_table_wbarrier_range_copy (gpointer _dest, gpointer _src, int size)
 	while (size) {
 		GCObject *value = *src;
 		*dest = value;
-		if (SGEN_PTR_IN_NURSERY (value, nursery_bits, start, end) || concurrent_collection_in_progress) {
+		if (SGEN_PTR_IN_NURSERY (value, nursery_bits, start, end) || sgen_concurrent_collection_in_progress) {
 			*card_address = 1;
 			sgen_dummy_use (value);
 		}
@@ -571,7 +571,7 @@ sgen_cardtable_scan_object (GCObject *obj, mword block_obj_size, guint8 *cards, 
 		ctx.ops->scan_object (obj, sgen_obj_get_descriptor (obj), ctx.queue);
 	}
 
-	binary_protocol_card_scan (obj, sgen_safe_object_get_size (obj));
+	sgen_binary_protocol_card_scan (obj, sgen_safe_object_get_size (obj));
 }
 
 void

--- a/mono/sgen/sgen-copy-object.h
+++ b/mono/sgen/sgen-copy-object.h
@@ -47,7 +47,7 @@ static MONO_ALWAYS_INLINE void
 par_copy_object_no_checks (char *destination, GCVTable vt, void *obj, mword objsize)
 {
 	sgen_client_pre_copy_checks (destination, vt, obj, objsize);
-	binary_protocol_copy (obj, destination, vt, objsize);
+	sgen_binary_protocol_copy (obj, destination, vt, objsize);
 
 	/* FIXME: assumes object layout */
 	memcpy ((char*)destination + sizeof (mword), (char*)obj + sizeof (mword), objsize - sizeof (mword));

--- a/mono/sgen/sgen-fin-weak-hash.c
+++ b/mono/sgen/sgen-fin-weak-hash.c
@@ -122,7 +122,7 @@ sgen_collect_bridge_objects (int generation, ScanCopyContext ctx)
 			continue;
 
 		/* Object is a bridge object and major heap says it's dead  */
-		if (major_collector.is_object_live (object))
+		if (sgen_major_collector.is_object_live (object))
 			continue;
 
 		/* Nursery says the object is dead. */
@@ -186,7 +186,7 @@ sgen_finalize_in_range (int generation, ScanCopyContext ctx)
 	SGEN_HASH_TABLE_FOREACH (hash_table, GCObject *, object, gpointer, dummy) {
 		int tag = tagged_object_get_tag (object);
 		object = tagged_object_get_object (object);
-		if (!major_collector.is_object_live (object)) {
+		if (!sgen_major_collector.is_object_live (object)) {
 			gboolean is_fin_ready = sgen_gc_is_object_ready_for_finalization (object);
 			GCObject *copy = object;
 			copy_func (&copy, queue);

--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -210,11 +210,11 @@
 /* 0 means not initialized, 1 is initialized, -1 means in progress */
 static int gc_initialized = 0;
 /* If set, check if we need to do something every X allocations */
-gboolean has_per_allocation_action;
+gboolean sgen_has_per_allocation_action;
 /* If set, do a heap check every X allocation */
-guint32 verify_before_allocs = 0;
+guint32 sgen_verify_before_allocs = 0;
 /* If set, do a minor collection before every X allocation */
-guint32 collect_before_allocs = 0;
+guint32 sgen_collect_before_allocs = 0;
 /* If set, do a whole heap check before each collection */
 static gboolean whole_heap_check_before_collection = FALSE;
 /* If set, do a remset consistency check at various opportunities */
@@ -300,8 +300,8 @@ static float sgen_max_pause_margin = SGEN_DEFAULT_MAX_PAUSE_MARGIN;
 static SGEN_TV_DECLARE (time_major_conc_collection_start);
 static SGEN_TV_DECLARE (time_major_conc_collection_end);
 
-int gc_debug_level = 0;
-FILE* gc_debug_file;
+int sgen_gc_debug_level = 0;
+FILE* sgen_gc_debug_file;
 static char* gc_params_options;
 static char* gc_debug_options;
 
@@ -309,7 +309,7 @@ static char* gc_debug_options;
 void
 mono_gc_flush_info (void)
 {
-	fflush (gc_debug_file);
+	fflush (sgen_gc_debug_file);
 }
 */
 
@@ -319,7 +319,7 @@ mono_gc_flush_info (void)
 
 static SGEN_TV_DECLARE (sgen_init_timestamp);
 
-NurseryClearPolicy nursery_clear_policy = CLEAR_AT_TLAB_CREATION;
+NurseryClearPolicy sgen_nursery_clear_policy = CLEAR_AT_TLAB_CREATION;
 
 #define object_is_forwarded	SGEN_OBJECT_IS_FORWARDED
 #define object_is_pinned	SGEN_OBJECT_IS_PINNED
@@ -330,7 +330,7 @@ NurseryClearPolicy nursery_clear_policy = CLEAR_AT_TLAB_CREATION;
 #define LOAD_VTABLE	SGEN_LOAD_VTABLE
 
 gboolean
-nursery_canaries_enabled (void)
+sgen_nursery_canaries_enabled (void)
 {
 	return enable_nursery_canaries;
 }
@@ -363,22 +363,22 @@ typedef enum {
  * ########  Global data.
  * ######################################################################
  */
-MonoCoopMutex gc_mutex;
+MonoCoopMutex sgen_gc_mutex;
 
 #define SCAN_START_SIZE	SGEN_SCAN_START_SIZE
 
-size_t degraded_mode = 0;
+size_t sgen_degraded_mode = 0;
 
 static mword bytes_pinned_from_failed_allocation = 0;
 
-GCMemSection *nursery_section = NULL;
+GCMemSection *sgen_nursery_section = NULL;
 static volatile mword lowest_heap_address = ~(mword)0;
 static volatile mword highest_heap_address = 0;
 
 MonoCoopMutex sgen_interruption_mutex;
 
-int current_collection_generation = -1;
-volatile gboolean concurrent_collection_in_progress = FALSE;
+int sgen_current_collection_generation = -1;
+volatile gboolean sgen_concurrent_collection_in_progress = FALSE;
 
 /* objects that are ready to be finalized */
 static SgenPointerQueue fin_ready_queue = SGEN_POINTER_QUEUE_INIT (INTERNAL_MEM_FINALIZE_READY);
@@ -388,7 +388,7 @@ static SgenPointerQueue critical_fin_queue = SGEN_POINTER_QUEUE_INIT (INTERNAL_M
 /* 
  * Different kinds of roots are kept separate to speed up pin_from_roots () for example.
  */
-SgenHashTable roots_hash [ROOT_TYPE_NUM] = {
+SgenHashTable sgen_roots_hash [ROOT_TYPE_NUM] = {
 	SGEN_HASH_TABLE_INIT (INTERNAL_MEM_ROOTS_TABLE, INTERNAL_MEM_ROOT_RECORD, sizeof (RootRecord), sgen_aligned_addr_hash, NULL),
 	SGEN_HASH_TABLE_INIT (INTERNAL_MEM_ROOTS_TABLE, INTERNAL_MEM_ROOT_RECORD, sizeof (RootRecord), sgen_aligned_addr_hash, NULL),
 	SGEN_HASH_TABLE_INIT (INTERNAL_MEM_ROOTS_TABLE, INTERNAL_MEM_ROOT_RECORD, sizeof (RootRecord), sgen_aligned_addr_hash, NULL)
@@ -401,7 +401,7 @@ static mword roots_size = 0; /* amount of memory in the root set */
  * FIXME: Tune this.
  * FIXME: Make this self-tuning for each thread.
  */
-guint32 tlab_size = (1024 * 4);
+guint32 sgen_tlab_size = (1024 * 4);
 
 #define MAX_SMALL_OBJ_SIZE	SGEN_MAX_SMALL_OBJ_SIZE
 
@@ -429,7 +429,7 @@ static void pin_from_roots (void *start_nursery, void *end_nursery, ScanCopyCont
 static void finish_gray_stack (int generation, ScanCopyContext ctx);
 
 
-SgenMajorCollector major_collector;
+SgenMajorCollector sgen_major_collector;
 SgenMinorCollector sgen_minor_collector;
 
 static SgenRememberedSet remset;
@@ -450,7 +450,7 @@ sgen_workers_get_job_gray_queue (WorkerData *worker_data, SgenGrayQueue *default
 static void
 gray_queue_redirect (SgenGrayQueue *queue)
 {
-	sgen_workers_take_from_queue (current_collection_generation, queue);
+	sgen_workers_take_from_queue (sgen_current_collection_generation, queue);
 }
 
 void
@@ -501,15 +501,15 @@ sgen_add_to_global_remset (gpointer ptr, GCObject *obj)
 
 	HEAVY_STAT (++stat_wbarrier_add_to_global_remset);
 
-	if (!major_collector.is_concurrent) {
-		SGEN_ASSERT (5, current_collection_generation != -1, "Global remsets can only be added during collections");
+	if (!sgen_major_collector.is_concurrent) {
+		SGEN_ASSERT (5, sgen_current_collection_generation != -1, "Global remsets can only be added during collections");
 	} else {
-		if (current_collection_generation == -1)
-			SGEN_ASSERT (5, sgen_concurrent_collection_in_progress (), "Global remsets outside of collection pauses can only be added by the concurrent collector");
+		if (sgen_current_collection_generation == -1)
+			SGEN_ASSERT (5, sgen_get_concurrent_collection_in_progress (), "Global remsets outside of collection pauses can only be added by the concurrent collector");
 	}
 
 	if (!object_is_pinned (obj))
-		SGEN_ASSERT (5, sgen_minor_collector.is_split || sgen_concurrent_collection_in_progress (), "Non-pinned objects can only remain in nursery if it is a split nursery");
+		SGEN_ASSERT (5, sgen_minor_collector.is_split || sgen_get_concurrent_collection_in_progress (), "Non-pinned objects can only remain in nursery if it is a split nursery");
 	else if (sgen_cement_lookup_or_register (obj))
 		return;
 
@@ -518,7 +518,7 @@ sgen_add_to_global_remset (gpointer ptr, GCObject *obj)
 	sgen_pin_stats_register_global_remset (obj);
 
 	SGEN_LOG (8, "Adding global remset for %p", ptr);
-	binary_protocol_global_remset (ptr, obj, (gpointer)SGEN_LOAD_VTABLE (obj));
+	sgen_binary_protocol_global_remset (ptr, obj, (gpointer)SGEN_LOAD_VTABLE (obj));
 }
 
 /*
@@ -547,7 +547,7 @@ sgen_drain_gray_stack (ScanCopyContext ctx)
 static int
 pin_objects_from_nursery_pin_queue (gboolean do_scan_objects, ScanCopyContext ctx)
 {
-	GCMemSection *section = nursery_section;
+	GCMemSection *section = sgen_nursery_section;
 	void **start =  sgen_pinning_get_entry (section->pin_queue_first_entry);
 	void **end = sgen_pinning_get_entry (section->pin_queue_last_entry);
 	void *start_nursery = section->data;
@@ -679,7 +679,7 @@ pin_objects_from_nursery_pin_queue (gboolean do_scan_objects, ScanCopyContext ct
 		} else {
 			SGEN_LOG (4, "Pinned object %p, vtable %p (%s), count %d\n",
 					obj_to_pin, *(void**)obj_to_pin, sgen_client_vtable_get_name (SGEN_LOAD_VTABLE (obj_to_pin)), count);
-			binary_protocol_pin (obj_to_pin,
+			sgen_binary_protocol_pin (obj_to_pin,
 					(gpointer)LOAD_VTABLE (obj_to_pin),
 					safe_object_get_size (obj_to_pin));
 
@@ -689,7 +689,7 @@ pin_objects_from_nursery_pin_queue (gboolean do_scan_objects, ScanCopyContext ct
 			definitely_pinned [count] = obj_to_pin;
 			count++;
 		}
-		if (concurrent_collection_in_progress)
+		if (sgen_concurrent_collection_in_progress)
 			sgen_pinning_register_pinned_in_nursery (obj_to_pin);
 
 	next_pin_queue_entry:
@@ -706,11 +706,11 @@ pin_objects_in_nursery (gboolean do_scan_objects, ScanCopyContext ctx)
 {
 	size_t reduced_to;
 
-	if (nursery_section->pin_queue_first_entry == nursery_section->pin_queue_last_entry)
+	if (sgen_nursery_section->pin_queue_first_entry == sgen_nursery_section->pin_queue_last_entry)
 		return;
 
 	reduced_to = pin_objects_from_nursery_pin_queue (do_scan_objects, ctx);
-	nursery_section->pin_queue_last_entry = nursery_section->pin_queue_first_entry + reduced_to;
+	sgen_nursery_section->pin_queue_last_entry = sgen_nursery_section->pin_queue_first_entry + reduced_to;
 }
 
 /*
@@ -729,7 +729,7 @@ sgen_pin_object (GCObject *object, SgenGrayQueue *queue)
 	sgen_pin_stage_ptr (object);
 
 	SGEN_PIN_OBJECT (object);
-	binary_protocol_pin (object, (gpointer)LOAD_VTABLE (object), safe_object_get_size (object));
+	sgen_binary_protocol_pin (object, (gpointer)LOAD_VTABLE (object), safe_object_get_size (object));
 
 	++objects_pinned;
 	sgen_pin_stats_register_object (object, GENERATION_NURSERY);
@@ -828,7 +828,7 @@ sgen_conservatively_pin_objects_from (void **start, void **end, void *start_nurs
 		if (addr >= (mword)start_nursery && addr < (mword)end_nursery) {
 			SGEN_LOG (6, "Pinning address %p from %p", (void*)addr, start);
 			sgen_pin_stage_ptr ((void*)addr);
-			binary_protocol_pin_stage (start, (void*)addr);
+			sgen_binary_protocol_pin_stage (start, (void*)addr);
 			sgen_pin_stats_register_address ((char*)addr, pin_type);
 			count++;
 		}
@@ -848,9 +848,9 @@ pin_from_roots (void *start_nursery, void *end_nursery, ScanCopyContext ctx)
 {
 	void **start_root;
 	RootRecord *root;
-	SGEN_LOG (2, "Scanning pinned roots (%d bytes, %d/%d entries)", (int)roots_size, roots_hash [ROOT_TYPE_NORMAL].num_entries, roots_hash [ROOT_TYPE_PINNED].num_entries);
+	SGEN_LOG (2, "Scanning pinned roots (%d bytes, %d/%d entries)", (int)roots_size, sgen_roots_hash [ROOT_TYPE_NORMAL].num_entries, sgen_roots_hash [ROOT_TYPE_PINNED].num_entries);
 	/* objects pinned from the API are inside these roots */
-	SGEN_HASH_TABLE_FOREACH (&roots_hash [ROOT_TYPE_PINNED], void **, start_root, RootRecord *, root) {
+	SGEN_HASH_TABLE_FOREACH (&sgen_roots_hash [ROOT_TYPE_PINNED], void **, start_root, RootRecord *, root) {
 		SGEN_LOG (6, "Pinned roots %p-%p", start_root, root->end_root);
 		sgen_conservatively_pin_objects_from (start_root, (void**)root->end_root, start_nursery, end_nursery, PIN_TYPE_OTHER);
 	} SGEN_HASH_TABLE_FOREACH_END;
@@ -966,7 +966,7 @@ sgen_update_heap_boundaries (mword low, mword high)
 
 /*
  * Allocate and setup the data structures needed to be able to allocate objects
- * in the nursery. The nursery is stored in nursery_section.
+ * in the nursery. The nursery is stored in sgen_nursery_section.
  */
 static void
 alloc_nursery (gboolean dynamic, size_t min_size, size_t max_size)
@@ -985,11 +985,11 @@ alloc_nursery (gboolean dynamic, size_t min_size, size_t max_size)
 			min_size = max_size = SGEN_DEFAULT_NURSERY_SIZE;
 	}
 
-	SGEN_ASSERT (0, !nursery_section, "Why are we allocating the nursery twice?");
+	SGEN_ASSERT (0, !sgen_nursery_section, "Why are we allocating the nursery twice?");
 	SGEN_LOG (2, "Allocating nursery size: %zu, initial %zu", max_size, min_size);
 
 	/* FIXME: handle OOM */
-	nursery_section = (GCMemSection *)sgen_alloc_internal (INTERNAL_MEM_SECTION);
+	sgen_nursery_section = (GCMemSection *)sgen_alloc_internal (INTERNAL_MEM_SECTION);
 
 	/* If there isn't enough space even for the nursery we should simply abort. */
 	g_assert (sgen_memgov_try_alloc_space (max_size, SPACE_NURSERY));
@@ -1003,15 +1003,15 @@ alloc_nursery (gboolean dynamic, size_t min_size, size_t max_size)
 	 * nursery section is not always identical to the current nursery size
 	 * because it can contain pinned objects from when the nursery was larger.
 	 *
-	 * sgen_nursery_size <= nursery_section size <= sgen_nursery_max_size
+	 * sgen_nursery_size <= sgen_nursery_section size <= sgen_nursery_max_size
 	 */
-	data = (char *)major_collector.alloc_heap (max_size, max_size);
+	data = (char *)sgen_major_collector.alloc_heap (max_size, max_size);
 	sgen_update_heap_boundaries ((mword)data, (mword)(data + max_size));
-	nursery_section->data = data;
-	nursery_section->end_data = data + min_size;
+	sgen_nursery_section->data = data;
+	sgen_nursery_section->end_data = data + min_size;
 	scan_starts = (max_size + SCAN_START_SIZE - 1) / SCAN_START_SIZE;
-	nursery_section->scan_starts = (char **)sgen_alloc_internal_dynamic (sizeof (char*) * scan_starts, INTERNAL_MEM_SCAN_STARTS, TRUE);
-	nursery_section->num_scan_start = scan_starts;
+	sgen_nursery_section->scan_starts = (char **)sgen_alloc_internal_dynamic (sizeof (char*) * scan_starts, INTERNAL_MEM_SCAN_STARTS, TRUE);
+	sgen_nursery_section->num_scan_start = scan_starts;
 
 	sgen_nursery_allocator_set_nursery_bounds (data, min_size, max_size);
 }
@@ -1019,7 +1019,7 @@ alloc_nursery (gboolean dynamic, size_t min_size, size_t max_size)
 FILE *
 mono_gc_get_logfile (void)
 {
-	return gc_debug_file;
+	return sgen_gc_debug_file;
 }
 
 void
@@ -1082,7 +1082,7 @@ finish_gray_stack (int generation, ScanCopyContext ctx)
 	char *end_addr = generation == GENERATION_NURSERY ? sgen_get_nursery_end () : (char*)-1;
 	SgenGrayQueue *queue = ctx.queue;
 
-	binary_protocol_finish_gray_stack_start (sgen_timestamp (), generation);
+	sgen_binary_protocol_finish_gray_stack_start (sgen_timestamp (), generation);
 	/*
 	 * We copied all the reachable objects. Now it's the time to copy
 	 * the objects that were not referenced by the roots, but by the copied objects.
@@ -1219,7 +1219,7 @@ finish_gray_stack (int generation, ScanCopyContext ctx)
 
 	g_assert (sgen_gray_object_queue_is_empty (queue));
 
-	binary_protocol_finish_gray_stack_end (sgen_timestamp (), generation);
+	sgen_binary_protocol_finish_gray_stack_end (sgen_timestamp (), generation);
 }
 
 void
@@ -1239,8 +1239,8 @@ check_scan_starts (void)
 {
 	if (!do_scan_starts_check)
 		return;
-	sgen_check_section_scan_starts (nursery_section);
-	major_collector.check_scan_starts ();
+	sgen_check_section_scan_starts (sgen_nursery_section);
+	sgen_major_collector.check_scan_starts ();
 }
 
 static void
@@ -1248,7 +1248,7 @@ scan_from_registered_roots (char *addr_start, char *addr_end, int root_type, Sca
 {
 	void **start_root;
 	RootRecord *root;
-	SGEN_HASH_TABLE_FOREACH (&roots_hash [root_type], void **, start_root, RootRecord *, root) {
+	SGEN_HASH_TABLE_FOREACH (&sgen_roots_hash [root_type], void **, start_root, RootRecord *, root) {
 		SGEN_LOG (6, "Precise root scan %p-%p (desc: %p)", start_root, root->end_root, (void*)root->root_desc);
 		precisely_scan_objects_from (start_root, (void**)root->end_root, addr_start, addr_end, root->root_desc, ctx);
 	} SGEN_HASH_TABLE_FOREACH_END;
@@ -1334,21 +1334,21 @@ sgen_set_pinned_from_failed_allocation (mword objsize)
 gboolean
 sgen_collection_is_concurrent (void)
 {
-	switch (current_collection_generation) {
+	switch (sgen_current_collection_generation) {
 	case GENERATION_NURSERY:
 		return FALSE;
 	case GENERATION_OLD:
-		return concurrent_collection_in_progress;
+		return sgen_concurrent_collection_in_progress;
 	default:
-		g_error ("Invalid current generation %d", current_collection_generation);
+		g_error ("Invalid current generation %d", sgen_current_collection_generation);
 	}
 	return FALSE;
 }
 
 gboolean
-sgen_concurrent_collection_in_progress (void)
+sgen_get_concurrent_collection_in_progress (void)
 {
-	return concurrent_collection_in_progress;
+	return sgen_concurrent_collection_in_progress;
 }
 
 typedef struct {
@@ -1444,7 +1444,7 @@ job_scan_major_card_table (void *worker_data_untyped, SgenThreadPoolJob *job)
 	ScanCopyContext ctx = scan_copy_context_for_scan_job (worker_data_untyped, (ScanJob*)job_data);
 
 	SGEN_TV_GETTIME (atv);
-	major_collector.scan_card_table (CARDTABLE_SCAN_GLOBAL, ctx, job_data->job_index, job_data->job_split_count, job_data->data);
+	sgen_major_collector.scan_card_table (CARDTABLE_SCAN_GLOBAL, ctx, job_data->job_index, job_data->job_split_count, job_data->data);
 	SGEN_TV_GETTIME (btv);
 	time_minor_scan_major_blocks += SGEN_TV_ELAPSED (atv, btv);
 
@@ -1477,9 +1477,9 @@ job_scan_major_mod_union_card_table (void *worker_data_untyped, SgenThreadPoolJo
 	ParallelScanJob *job_data = (ParallelScanJob*)job;
 	ScanCopyContext ctx = scan_copy_context_for_scan_job (worker_data_untyped, (ScanJob*)job_data);
 
-	g_assert (concurrent_collection_in_progress);
+	g_assert (sgen_concurrent_collection_in_progress);
 	SGEN_TV_GETTIME (atv);
-	major_collector.scan_card_table (CARDTABLE_SCAN_MOD_UNION, ctx, job_data->job_index, job_data->job_split_count, job_data->data);
+	sgen_major_collector.scan_card_table (CARDTABLE_SCAN_MOD_UNION, ctx, job_data->job_index, job_data->job_split_count, job_data->data);
 	SGEN_TV_GETTIME (btv);
 	time_major_scan_mod_union_blocks += SGEN_TV_ELAPSED (atv, btv);
 
@@ -1495,7 +1495,7 @@ job_scan_los_mod_union_card_table (void *worker_data_untyped, SgenThreadPoolJob 
 	ParallelScanJob *job_data = (ParallelScanJob*)job;
 	ScanCopyContext ctx = scan_copy_context_for_scan_job (worker_data_untyped, (ScanJob*)job_data);
 
-	g_assert (concurrent_collection_in_progress);
+	g_assert (sgen_concurrent_collection_in_progress);
 	SGEN_TV_GETTIME (atv);
 	sgen_los_scan_card_table (CARDTABLE_SCAN_MOD_UNION, ctx, job_data->job_index, job_data->job_split_count);
 	SGEN_TV_GETTIME (btv);
@@ -1513,9 +1513,9 @@ job_major_mod_union_preclean (void *worker_data_untyped, SgenThreadPoolJob *job)
 	ParallelScanJob *job_data = (ParallelScanJob*)job;
 	ScanCopyContext ctx = scan_copy_context_for_scan_job (worker_data_untyped, (ScanJob*)job_data);
 
-	g_assert (concurrent_collection_in_progress);
+	g_assert (sgen_concurrent_collection_in_progress);
 	SGEN_TV_GETTIME (atv);
-	major_collector.scan_card_table (CARDTABLE_SCAN_MOD_UNION_PRECLEAN, ctx, job_data->job_index, job_data->job_split_count, job_data->data);
+	sgen_major_collector.scan_card_table (CARDTABLE_SCAN_MOD_UNION_PRECLEAN, ctx, job_data->job_index, job_data->job_split_count, job_data->data);
 	SGEN_TV_GETTIME (btv);
 
 	g_assert (worker_data_untyped);
@@ -1530,7 +1530,7 @@ job_los_mod_union_preclean (void *worker_data_untyped, SgenThreadPoolJob *job)
 	ParallelScanJob *job_data = (ParallelScanJob*)job;
 	ScanCopyContext ctx = scan_copy_context_for_scan_job (worker_data_untyped, (ScanJob*)job_data);
 
-	g_assert (concurrent_collection_in_progress);
+	g_assert (sgen_concurrent_collection_in_progress);
 	SGEN_TV_GETTIME (atv);
 	sgen_los_scan_card_table (CARDTABLE_SCAN_MOD_UNION_PRECLEAN, ctx, job_data->job_index, job_data->job_split_count);
 	SGEN_TV_GETTIME (btv);
@@ -1545,7 +1545,7 @@ job_scan_last_pinned (void *worker_data_untyped, SgenThreadPoolJob *job)
 	ScanJob *job_data = (ScanJob*)job;
 	ScanCopyContext ctx = scan_copy_context_for_scan_job (worker_data_untyped, job_data);
 
-	g_assert (concurrent_collection_in_progress);
+	g_assert (sgen_concurrent_collection_in_progress);
 
 	sgen_scan_pin_queue_objects (ctx);
 }
@@ -1555,7 +1555,7 @@ workers_finish_callback (void)
 {
 	ParallelScanJob *psj;
 	ScanJob *sj;
-	size_t num_major_sections = major_collector.get_num_major_sections ();
+	size_t num_major_sections = sgen_major_collector.get_num_major_sections ();
 	int split_count = sgen_workers_get_job_split_count (GENERATION_OLD);
 	int i;
 	/* Mod union preclean jobs */
@@ -1591,7 +1591,7 @@ static void
 enqueue_scan_remembered_set_jobs (SgenGrayQueue *gc_thread_gray_queue, SgenObjectOperations *ops, gboolean enqueue)
 {
 	int i, split_count = sgen_workers_get_job_split_count (GENERATION_NURSERY);
-	size_t num_major_sections = major_collector.get_num_major_sections ();
+	size_t num_major_sections = sgen_major_collector.get_num_major_sections ();
 	ScanJob *sj;
 
 	sj = (ScanJob*)sgen_thread_pool_job_alloc ("scan wbroots", job_scan_wbroots, sizeof (ScanJob));
@@ -1634,9 +1634,9 @@ enqueue_scan_from_roots_jobs (SgenGrayQueue *gc_thread_gray_queue, char *heap_st
 	scrrj->heap_start = heap_start;
 	scrrj->heap_end = heap_end;
 	scrrj->root_type = ROOT_TYPE_NORMAL;
-	sgen_workers_enqueue_job (current_collection_generation, &scrrj->scan_job.job, enqueue);
+	sgen_workers_enqueue_job (sgen_current_collection_generation, &scrrj->scan_job.job, enqueue);
 
-	if (current_collection_generation == GENERATION_OLD) {
+	if (sgen_current_collection_generation == GENERATION_OLD) {
 		/* During minors we scan the cardtable for these roots instead */
 		scrrj = (ScanFromRegisteredRootsJob*)sgen_thread_pool_job_alloc ("scan from registered roots wbarrier", job_scan_from_registered_roots, sizeof (ScanFromRegisteredRootsJob));
 		scrrj->scan_job.ops = ops;
@@ -1644,7 +1644,7 @@ enqueue_scan_from_roots_jobs (SgenGrayQueue *gc_thread_gray_queue, char *heap_st
 		scrrj->heap_start = heap_start;
 		scrrj->heap_end = heap_end;
 		scrrj->root_type = ROOT_TYPE_WBARRIER;
-		sgen_workers_enqueue_job (current_collection_generation, &scrrj->scan_job.job, enqueue);
+		sgen_workers_enqueue_job (sgen_current_collection_generation, &scrrj->scan_job.job, enqueue);
 	}
 
 	/* Threads */
@@ -1654,7 +1654,7 @@ enqueue_scan_from_roots_jobs (SgenGrayQueue *gc_thread_gray_queue, char *heap_st
 	stdj->scan_job.gc_thread_gray_queue = gc_thread_gray_queue;
 	stdj->heap_start = heap_start;
 	stdj->heap_end = heap_end;
-	sgen_workers_enqueue_job (current_collection_generation, &stdj->scan_job.job, enqueue);
+	sgen_workers_enqueue_job (sgen_current_collection_generation, &stdj->scan_job.job, enqueue);
 
 	/* Scan the list of objects ready for finalization. */
 
@@ -1662,13 +1662,13 @@ enqueue_scan_from_roots_jobs (SgenGrayQueue *gc_thread_gray_queue, char *heap_st
 	sfej->scan_job.ops = ops;
 	sfej->scan_job.gc_thread_gray_queue = gc_thread_gray_queue;
 	sfej->queue = &fin_ready_queue;
-	sgen_workers_enqueue_job (current_collection_generation, &sfej->scan_job.job, enqueue);
+	sgen_workers_enqueue_job (sgen_current_collection_generation, &sfej->scan_job.job, enqueue);
 
 	sfej = (ScanFinalizerEntriesJob*)sgen_thread_pool_job_alloc ("scan critical finalizer entries", job_scan_finalizer_entries, sizeof (ScanFinalizerEntriesJob));
 	sfej->scan_job.ops = ops;
 	sfej->scan_job.gc_thread_gray_queue = gc_thread_gray_queue;
 	sfej->queue = &critical_fin_queue;
-	sgen_workers_enqueue_job (current_collection_generation, &sfej->scan_job.job, enqueue);
+	sgen_workers_enqueue_job (sgen_current_collection_generation, &sfej->scan_job.job, enqueue);
 }
 
 /*
@@ -1698,13 +1698,13 @@ collect_nursery (const char *reason, gboolean is_overflow, SgenGrayQueue *unpin_
 	TV_GETTIME (last_minor_collection_start_tv);
 	atv = last_minor_collection_start_tv;
 
-	binary_protocol_collection_begin (mono_atomic_load_i32 (&gc_stats.minor_gc_count), GENERATION_NURSERY);
+	sgen_binary_protocol_collection_begin (mono_atomic_load_i32 (&mono_gc_stats.minor_gc_count), GENERATION_NURSERY);
 
-	object_ops_nopar = sgen_concurrent_collection_in_progress ()
+	object_ops_nopar = sgen_get_concurrent_collection_in_progress ()
 				? &sgen_minor_collector.serial_ops_with_concurrent_major
 				: &sgen_minor_collector.serial_ops;
 	if (sgen_minor_collector.is_parallel && sgen_nursery_size >= SGEN_PARALLEL_MINOR_MIN_NURSERY_SIZE) {
-		object_ops_par = sgen_concurrent_collection_in_progress ()
+		object_ops_par = sgen_get_concurrent_collection_in_progress ()
 					? &sgen_minor_collector.parallel_ops_with_concurrent_major
 					: &sgen_minor_collector.parallel_ops;
 		is_parallel = TRUE;
@@ -1713,7 +1713,7 @@ collect_nursery (const char *reason, gboolean is_overflow, SgenGrayQueue *unpin_
 	if (do_verify_nursery || do_dump_nursery_content)
 		sgen_debug_verify_nursery (do_dump_nursery_content);
 
-	current_collection_generation = GENERATION_NURSERY;
+	sgen_current_collection_generation = GENERATION_NURSERY;
 
 	SGEN_ASSERT (0, !sgen_collection_is_concurrent (), "Why is the nursery collection concurrent?");
 
@@ -1723,10 +1723,10 @@ collect_nursery (const char *reason, gboolean is_overflow, SgenGrayQueue *unpin_
 
 	sgen_nursery_alloc_prepare_for_minor ();
 
-	degraded_mode = 0;
+	sgen_degraded_mode = 0;
 	objects_pinned = 0;
 
-	SGEN_LOG (1, "Start nursery collection %" G_GINT32_FORMAT " %p-%p, size: %d", mono_atomic_load_i32 (&gc_stats.minor_gc_count), nursery_section->data, nursery_section->end_data, (int)(nursery_section->end_data - nursery_section->data));
+	SGEN_LOG (1, "Start nursery collection %" G_GINT32_FORMAT " %p-%p, size: %d", mono_atomic_load_i32 (&mono_gc_stats.minor_gc_count), sgen_nursery_section->data, sgen_nursery_section->end_data, (int)(sgen_nursery_section->end_data - sgen_nursery_section->data));
 
 	/* world must be stopped already */
 	TV_GETTIME (btv);
@@ -1734,32 +1734,32 @@ collect_nursery (const char *reason, gboolean is_overflow, SgenGrayQueue *unpin_
 
 	sgen_client_pre_collection_checks ();
 
-	major_collector.start_nursery_collection ();
+	sgen_major_collector.start_nursery_collection ();
 
 	sgen_memgov_minor_collection_start ();
 
 	init_gray_queue (&gc_thread_gray_queue);
 	ctx = CONTEXT_FROM_OBJECT_OPERATIONS (object_ops_nopar, &gc_thread_gray_queue);
 
-	mono_atomic_inc_i32 (&gc_stats.minor_gc_count);
+	mono_atomic_inc_i32 (&mono_gc_stats.minor_gc_count);
 
 	sgen_process_fin_stage_entries ();
 
 	/* pin from pinned handles */
 	sgen_init_pinning ();
-	if (concurrent_collection_in_progress)
+	if (sgen_concurrent_collection_in_progress)
 		sgen_init_pinning_for_conc ();
 	sgen_client_binary_protocol_mark_start (GENERATION_NURSERY);
-	pin_from_roots (nursery_section->data, nursery_section->end_data, ctx);
+	pin_from_roots (sgen_nursery_section->data, sgen_nursery_section->end_data, ctx);
 	/* pin cemented objects */
 	sgen_pin_cemented_objects ();
 	/* identify pinned objects */
 	sgen_optimize_pin_queue ();
-	sgen_pinning_setup_section (nursery_section);
+	sgen_pinning_setup_section (sgen_nursery_section);
 
 	pin_objects_in_nursery (FALSE, ctx);
-	sgen_pinning_trim_queue_to_section (nursery_section);
-	if (concurrent_collection_in_progress)
+	sgen_pinning_trim_queue_to_section (sgen_nursery_section);
+	if (sgen_concurrent_collection_in_progress)
 		sgen_finish_pinning_for_conc ();
 
 	if (remset_consistency_checks)
@@ -1790,7 +1790,7 @@ collect_nursery (const char *reason, gboolean is_overflow, SgenGrayQueue *unpin_
 	TV_GETTIME (atv);
 	time_minor_scan_pinned += TV_ELAPSED (btv, atv);
 
-	enqueue_scan_from_roots_jobs (&gc_thread_gray_queue, nursery_section->data, nursery_section->end_data, is_parallel ? NULL : object_ops_nopar, is_parallel);
+	enqueue_scan_from_roots_jobs (&gc_thread_gray_queue, sgen_nursery_section->data, sgen_nursery_section->end_data, is_parallel ? NULL : object_ops_nopar, is_parallel);
 
 	if (is_parallel) {
 		gray_queue_redirect (&gc_thread_gray_queue);
@@ -1809,7 +1809,7 @@ collect_nursery (const char *reason, gboolean is_overflow, SgenGrayQueue *unpin_
 
 	if (objects_pinned) {
 		sgen_optimize_pin_queue ();
-		sgen_pinning_setup_section (nursery_section);
+		sgen_pinning_setup_section (sgen_nursery_section);
 	}
 
 	/*
@@ -1844,9 +1844,9 @@ collect_nursery (const char *reason, gboolean is_overflow, SgenGrayQueue *unpin_
 	 * next allocations.
 	 */
 	sgen_client_binary_protocol_reclaim_start (GENERATION_NURSERY);
-	fragment_total = sgen_build_nursery_fragments (nursery_section, unpin_queue);
+	fragment_total = sgen_build_nursery_fragments (sgen_nursery_section, unpin_queue);
 	if (!fragment_total)
-		degraded_mode = 1;
+		sgen_degraded_mode = 1;
 
 	/* Clear TLABs for all threads */
 	sgen_clear_tlabs ();
@@ -1859,12 +1859,12 @@ collect_nursery (const char *reason, gboolean is_overflow, SgenGrayQueue *unpin_
 	if (remset_consistency_checks)
 		sgen_check_major_refs ();
 
-	major_collector.finish_nursery_collection ();
+	sgen_major_collector.finish_nursery_collection ();
 
 	TV_GETTIME (last_minor_collection_end_tv);
-	UnlockedAdd64 (&gc_stats.minor_gc_time, TV_ELAPSED (last_minor_collection_start_tv, last_minor_collection_end_tv));
+	UnlockedAdd64 (&mono_gc_stats.minor_gc_time, TV_ELAPSED (last_minor_collection_start_tv, last_minor_collection_end_tv));
 
-	sgen_debug_dump_heap ("minor", mono_atomic_load_i32 (&gc_stats.minor_gc_count) - 1, NULL);
+	sgen_debug_dump_heap ("minor", mono_atomic_load_i32 (&mono_gc_stats.minor_gc_count) - 1, NULL);
 
 	/* prepare the pin queue for the next collection */
 	sgen_finish_pinning ();
@@ -1880,24 +1880,24 @@ collect_nursery (const char *reason, gboolean is_overflow, SgenGrayQueue *unpin_
 
 	check_scan_starts ();
 
-	binary_protocol_flush_buffers (FALSE);
+	sgen_binary_protocol_flush_buffers (FALSE);
 
 	sgen_memgov_minor_collection_end (reason, is_overflow);
 
 	/*objects are late pinned because of lack of memory, so a major is a good call*/
 	needs_major = objects_pinned > 0;
-	current_collection_generation = -1;
+	sgen_current_collection_generation = -1;
 	objects_pinned = 0;
 
 	if (is_parallel)
-		binary_protocol_collection_end_stats (0, 0, time_minor_finish_gray_stack - finish_gray_start);
+		sgen_binary_protocol_collection_end_stats (0, 0, time_minor_finish_gray_stack - finish_gray_start);
 	else
-		binary_protocol_collection_end_stats (
+		sgen_binary_protocol_collection_end_stats (
 			time_minor_scan_major_blocks - major_scan_start,
 			time_minor_scan_los - los_scan_start,
 			time_minor_finish_gray_stack - finish_gray_start);
 
-	binary_protocol_collection_end (mono_atomic_load_i32 (&gc_stats.minor_gc_count) - 1, GENERATION_NURSERY, 0, 0);
+	sgen_binary_protocol_collection_end (mono_atomic_load_i32 (&mono_gc_stats.minor_gc_count) - 1, GENERATION_NURSERY, 0, 0);
 
 	if (check_nursery_objects_pinned && !sgen_minor_collector.is_split)
 		sgen_check_nursery_objects_pinned (unpin_queue != NULL);
@@ -1925,7 +1925,7 @@ major_copy_or_mark_from_roots (SgenGrayQueue *gc_thread_gray_queue, size_t *old_
 	ScanCopyContext ctx = CONTEXT_FROM_OBJECT_OPERATIONS (object_ops_nopar, gc_thread_gray_queue);
 	gboolean concurrent = mode != COPY_OR_MARK_FROM_ROOTS_SERIAL;
 
-	SGEN_ASSERT (0, !!concurrent == !!concurrent_collection_in_progress, "We've been called with the wrong mode.");
+	SGEN_ASSERT (0, !!concurrent == !!sgen_concurrent_collection_in_progress, "We've been called with the wrong mode.");
 
 	if (mode == COPY_OR_MARK_FROM_ROOTS_START_CONCURRENT) {
 		/*This cleans up unused fragments */
@@ -1995,13 +1995,13 @@ major_copy_or_mark_from_roots (SgenGrayQueue *gc_thread_gray_queue, size_t *old_
 	 */
 	SGEN_LOG (6, "Pinning from sections");
 	/* first pass for the sections */
-	sgen_find_section_pin_queue_start_end (nursery_section);
+	sgen_find_section_pin_queue_start_end (sgen_nursery_section);
 	/* identify possible pointers to the insize of large objects */
 	SGEN_LOG (6, "Pinning from large objects");
-	for (bigobj = los_object_list; bigobj; bigobj = bigobj->next) {
+	for (bigobj = sgen_los_object_list; bigobj; bigobj = bigobj->next) {
 		size_t dummy;
 		if (sgen_find_optimized_pin_queue_area ((char*)bigobj->data, (char*)bigobj->data + sgen_los_object_size (bigobj), &dummy, &dummy)) {
-			binary_protocol_pin (bigobj->data, (gpointer)LOAD_VTABLE (bigobj->data), safe_object_get_size (bigobj->data));
+			sgen_binary_protocol_pin (bigobj->data, (gpointer)LOAD_VTABLE (bigobj->data), safe_object_get_size (bigobj->data));
 
 			if (sgen_los_object_is_pinned (bigobj->data)) {
 				SGEN_ASSERT (0, mode == COPY_OR_MARK_FROM_ROOTS_FINISH_CONCURRENT, "LOS objects can only be pinned here after concurrent marking.");
@@ -2023,7 +2023,7 @@ major_copy_or_mark_from_roots (SgenGrayQueue *gc_thread_gray_queue, size_t *old_
 	if (check_nursery_objects_pinned && !sgen_minor_collector.is_split)
 		sgen_check_nursery_objects_pinned (mode != COPY_OR_MARK_FROM_ROOTS_START_CONCURRENT);
 
-	major_collector.pin_objects (gc_thread_gray_queue);
+	sgen_major_collector.pin_objects (gc_thread_gray_queue);
 	if (old_next_pin_slot)
 		*old_next_pin_slot = sgen_get_pinned_count ();
 
@@ -2036,7 +2036,7 @@ major_copy_or_mark_from_roots (SgenGrayQueue *gc_thread_gray_queue, size_t *old_
 	if (mode == COPY_OR_MARK_FROM_ROOTS_START_CONCURRENT)
 		sgen_finish_pinning_for_conc ();
 
-	major_collector.init_to_space ();
+	sgen_major_collector.init_to_space ();
 
 	SGEN_ASSERT (0, sgen_workers_all_done (), "Why are the workers not done when we start or finish a major collection?");
 	if (mode == COPY_OR_MARK_FROM_ROOTS_FINISH_CONCURRENT) {
@@ -2085,7 +2085,7 @@ major_copy_or_mark_from_roots (SgenGrayQueue *gc_thread_gray_queue, size_t *old_
 
 	if (mode == COPY_OR_MARK_FROM_ROOTS_FINISH_CONCURRENT) {
 		int i, split_count = sgen_workers_get_job_split_count (GENERATION_OLD);
-		size_t num_major_sections = major_collector.get_num_major_sections ();
+		size_t num_major_sections = sgen_major_collector.get_num_major_sections ();
 		gboolean parallel = object_ops_par != NULL;
 
 		/* If we're not parallel we finish the collection on the gc thread */
@@ -2144,13 +2144,13 @@ major_start_collection (SgenGrayQueue *gc_thread_gray_queue, const char *reason,
 	SgenObjectOperations *object_ops_nopar, *object_ops_par = NULL;
 
 	if (concurrent) {
-		g_assert (major_collector.is_concurrent);
-		concurrent_collection_in_progress = TRUE;
+		g_assert (sgen_major_collector.is_concurrent);
+		sgen_concurrent_collection_in_progress = TRUE;
 	}
 
-	binary_protocol_collection_begin (mono_atomic_load_i32 (&gc_stats.major_gc_count), GENERATION_OLD);
+	sgen_binary_protocol_collection_begin (mono_atomic_load_i32 (&mono_gc_stats.major_gc_count), GENERATION_OLD);
 
-	current_collection_generation = GENERATION_OLD;
+	sgen_current_collection_generation = GENERATION_OLD;
 
 	sgen_workers_assert_gray_queue_is_empty (GENERATION_OLD);
 
@@ -2158,12 +2158,12 @@ major_start_collection (SgenGrayQueue *gc_thread_gray_queue, const char *reason,
 		sgen_cement_reset ();
 
 	if (concurrent) {
-		object_ops_nopar = &major_collector.major_ops_concurrent_start;
-		if (major_collector.is_parallel)
-			object_ops_par = &major_collector.major_ops_conc_par_start;
+		object_ops_nopar = &sgen_major_collector.major_ops_concurrent_start;
+		if (sgen_major_collector.is_parallel)
+			object_ops_par = &sgen_major_collector.major_ops_conc_par_start;
 
 	} else {
-		object_ops_nopar = &major_collector.major_ops_serial;
+		object_ops_nopar = &sgen_major_collector.major_ops_serial;
 	}
 
 	reset_pinned_from_failed_allocation ();
@@ -2175,12 +2175,12 @@ major_start_collection (SgenGrayQueue *gc_thread_gray_queue, const char *reason,
 
 	check_scan_starts ();
 
-	degraded_mode = 0;
-	SGEN_LOG (1, "Start major collection %" G_GINT32_FORMAT, mono_atomic_load_i32 (&gc_stats.major_gc_count));
-	mono_atomic_inc_i32 (&gc_stats.major_gc_count);
+	sgen_degraded_mode = 0;
+	SGEN_LOG (1, "Start major collection %" G_GINT32_FORMAT, mono_atomic_load_i32 (&mono_gc_stats.major_gc_count));
+	mono_atomic_inc_i32 (&mono_gc_stats.major_gc_count);
 
-	if (major_collector.start_major_collection)
-		major_collector.start_major_collection ();
+	if (sgen_major_collector.start_major_collection)
+		sgen_major_collector.start_major_collection ();
 
 	major_copy_or_mark_from_roots (gc_thread_gray_queue, old_next_pin_slot, concurrent ? COPY_OR_MARK_FROM_ROOTS_START_CONCURRENT : COPY_OR_MARK_FROM_ROOTS_SERIAL, object_ops_nopar, object_ops_par);
 }
@@ -2197,12 +2197,12 @@ major_finish_collection (SgenGrayQueue *gc_thread_gray_queue, const char *reason
 	guint64 los_scan_start = time_major_scan_mod_union_los;
 	guint64 finish_gray_start = time_major_finish_gray_stack;
 
-	if (concurrent_collection_in_progress) {
+	if (sgen_concurrent_collection_in_progress) {
 		SgenObjectOperations *object_ops_par = NULL;
 
-		object_ops_nopar = &major_collector.major_ops_concurrent_finish;
-		if (major_collector.is_parallel)
-			object_ops_par = &major_collector.major_ops_conc_par_finish;
+		object_ops_nopar = &sgen_major_collector.major_ops_concurrent_finish;
+		if (sgen_major_collector.is_parallel)
+			object_ops_par = &sgen_major_collector.major_ops_conc_par_finish;
 
 		major_copy_or_mark_from_roots (gc_thread_gray_queue, NULL, COPY_OR_MARK_FROM_ROOTS_FINISH_CONCURRENT, object_ops_nopar, object_ops_par);
 
@@ -2210,7 +2210,7 @@ major_finish_collection (SgenGrayQueue *gc_thread_gray_queue, const char *reason
 		main_gc_thread = NULL;
 #endif
 	} else {
-		object_ops_nopar = &major_collector.major_ops_serial;
+		object_ops_nopar = &sgen_major_collector.major_ops_serial;
 	}
 
 	sgen_workers_assert_gray_queue_is_empty (GENERATION_OLD);
@@ -2223,7 +2223,7 @@ major_finish_collection (SgenGrayQueue *gc_thread_gray_queue, const char *reason
 	SGEN_ASSERT (0, sgen_workers_all_done (), "Can't have workers working after joining");
 
 	if (objects_pinned) {
-		g_assert (!concurrent_collection_in_progress);
+		g_assert (!sgen_concurrent_collection_in_progress);
 
 		/*
 		 * This is slow, but we just OOM'd.
@@ -2231,7 +2231,7 @@ major_finish_collection (SgenGrayQueue *gc_thread_gray_queue, const char *reason
 		 * See comment at `sgen_pin_queue_clear_discarded_entries` for how the pin
 		 * queue is laid out at this point.
 		 */
-		sgen_pin_queue_clear_discarded_entries (nursery_section, old_next_pin_slot);
+		sgen_pin_queue_clear_discarded_entries (sgen_nursery_section, old_next_pin_slot);
 		/*
 		 * We need to reestablish all pinned nursery objects in the pin queue
 		 * because they're needed for fragment creation.  Unpinning happens by
@@ -2240,7 +2240,7 @@ major_finish_collection (SgenGrayQueue *gc_thread_gray_queue, const char *reason
 		 * somewhere.
 		 */
 		sgen_optimize_pin_queue ();
-		sgen_find_section_pin_queue_start_end (nursery_section);
+		sgen_find_section_pin_queue_start_end (sgen_nursery_section);
 		objects_pinned = 0;
 	}
 
@@ -2257,12 +2257,12 @@ major_finish_collection (SgenGrayQueue *gc_thread_gray_queue, const char *reason
 	 * pinned objects as we go, memzero() the empty fragments so they are ready for the
 	 * next allocations.
 	 */
-	fragment_total = sgen_build_nursery_fragments (nursery_section, NULL);
+	fragment_total = sgen_build_nursery_fragments (sgen_nursery_section, NULL);
 	if (!fragment_total)
-		degraded_mode = 1;
+		sgen_degraded_mode = 1;
 	SGEN_LOG (4, "Free space in nursery after major %ld", (long)fragment_total);
 
-	if (do_concurrent_checks && concurrent_collection_in_progress)
+	if (do_concurrent_checks && sgen_concurrent_collection_in_progress)
 		sgen_debug_check_nursery_is_clean ();
 
 	/* prepare the pin queue for the next collection */
@@ -2276,12 +2276,12 @@ major_finish_collection (SgenGrayQueue *gc_thread_gray_queue, const char *reason
 	sgen_cement_clear_below_threshold ();
 
 	if (check_mark_bits_after_major_collection)
-		sgen_check_heap_marked (concurrent_collection_in_progress);
+		sgen_check_heap_marked (sgen_concurrent_collection_in_progress);
 
 	TV_GETTIME (btv);
 	time_major_fragment_creation += TV_ELAPSED (atv, btv);
 
-	binary_protocol_sweep_begin (GENERATION_OLD, !major_collector.sweeps_lazily);
+	sgen_binary_protocol_sweep_begin (GENERATION_OLD, !sgen_major_collector.sweeps_lazily);
 	sgen_memgov_major_pre_sweep ();
 
 	TV_GETTIME (atv);
@@ -2292,25 +2292,25 @@ major_finish_collection (SgenGrayQueue *gc_thread_gray_queue, const char *reason
 	TV_GETTIME (btv);
 	time_major_los_sweep += TV_ELAPSED (atv, btv);
 
-	major_collector.sweep ();
+	sgen_major_collector.sweep ();
 
-	binary_protocol_sweep_end (GENERATION_OLD, !major_collector.sweeps_lazily);
+	sgen_binary_protocol_sweep_end (GENERATION_OLD, !sgen_major_collector.sweeps_lazily);
 
 	TV_GETTIME (atv);
 	time_major_sweep += TV_ELAPSED (btv, atv);
 
-	sgen_debug_dump_heap ("major", mono_atomic_load_i32 (&gc_stats.major_gc_count) - 1, reason);
+	sgen_debug_dump_heap ("major", mono_atomic_load_i32 (&mono_gc_stats.major_gc_count) - 1, reason);
 
 	if (sgen_have_pending_finalizers ()) {
 		SGEN_LOG (4, "Finalizer-thread wakeup");
 		sgen_client_finalize_notify ();
 	}
 
-	sgen_memgov_major_collection_end (forced, concurrent_collection_in_progress, reason, is_overflow);
-	current_collection_generation = -1;
+	sgen_memgov_major_collection_end (forced, sgen_concurrent_collection_in_progress, reason, is_overflow);
+	sgen_current_collection_generation = -1;
 
 	memset (&counts, 0, sizeof (ScannedObjectCounts));
-	major_collector.finish_major_collection (&counts);
+	sgen_major_collector.finish_major_collection (&counts);
 
 	sgen_workers_assert_gray_queue_is_empty (GENERATION_OLD);
 
@@ -2318,21 +2318,21 @@ major_finish_collection (SgenGrayQueue *gc_thread_gray_queue, const char *reason
 
 	check_scan_starts ();
 
-	binary_protocol_flush_buffers (FALSE);
+	sgen_binary_protocol_flush_buffers (FALSE);
 
 	//consistency_check ();
-	if (major_collector.is_parallel)
-                binary_protocol_collection_end_stats (0, 0, time_major_finish_gray_stack - finish_gray_start);
+	if (sgen_major_collector.is_parallel)
+                sgen_binary_protocol_collection_end_stats (0, 0, time_major_finish_gray_stack - finish_gray_start);
         else
-                binary_protocol_collection_end_stats (
+                sgen_binary_protocol_collection_end_stats (
                         time_major_scan_mod_union_blocks - major_scan_start,
                         time_major_scan_mod_union_los - los_scan_start,
                         time_major_finish_gray_stack - finish_gray_start);
 
-	binary_protocol_collection_end (mono_atomic_load_i32 (&gc_stats.major_gc_count) - 1, GENERATION_OLD, counts.num_scanned_objects, counts.num_unique_scanned_objects);
+	sgen_binary_protocol_collection_end (mono_atomic_load_i32 (&mono_gc_stats.major_gc_count) - 1, GENERATION_OLD, counts.num_scanned_objects, counts.num_unique_scanned_objects);
 
-	if (concurrent_collection_in_progress)
-		concurrent_collection_in_progress = FALSE;
+	if (sgen_concurrent_collection_in_progress)
+		sgen_concurrent_collection_in_progress = FALSE;
 }
 
 static gboolean
@@ -2346,8 +2346,8 @@ major_do_collection (const char *reason, gboolean is_overflow, gboolean forced)
 	if (disable_major_collections)
 		return FALSE;
 
-	if (major_collector.get_and_reset_num_major_objects_marked) {
-		long long num_marked = major_collector.get_and_reset_num_major_objects_marked ();
+	if (sgen_major_collector.get_and_reset_num_major_objects_marked) {
+		long long num_marked = sgen_major_collector.get_and_reset_num_major_objects_marked ();
 		g_assert (!num_marked);
 	}
 
@@ -2360,11 +2360,11 @@ major_do_collection (const char *reason, gboolean is_overflow, gboolean forced)
 	sgen_gray_object_queue_dispose (&gc_thread_gray_queue);
 
 	TV_GETTIME (time_end);
-	UnlockedAdd64 (&gc_stats.major_gc_time, TV_ELAPSED (time_start, time_end));
+	UnlockedAdd64 (&mono_gc_stats.major_gc_time, TV_ELAPSED (time_start, time_end));
 
 	/* FIXME: also report this to the user, preferably in gc-end. */
-	if (major_collector.get_and_reset_num_major_objects_marked)
-		major_collector.get_and_reset_num_major_objects_marked ();
+	if (sgen_major_collector.get_and_reset_num_major_objects_marked)
+		sgen_major_collector.get_and_reset_num_major_objects_marked ();
 
 	return bytes_pinned_from_failed_allocation > 0;
 }
@@ -2383,22 +2383,22 @@ major_start_concurrent_collection (const char *reason)
 	TV_GETTIME (time_start);
 	SGEN_TV_GETTIME (time_major_conc_collection_start);
 
-	num_objects_marked = major_collector.get_and_reset_num_major_objects_marked ();
+	num_objects_marked = sgen_major_collector.get_and_reset_num_major_objects_marked ();
 	g_assert (num_objects_marked == 0);
 
-	binary_protocol_concurrent_start ();
+	sgen_binary_protocol_concurrent_start ();
 
 	init_gray_queue (&gc_thread_gray_queue);
 	// FIXME: store reason and pass it when finishing
 	major_start_collection (&gc_thread_gray_queue, reason, TRUE, NULL);
 	sgen_gray_object_queue_dispose (&gc_thread_gray_queue);
 
-	num_objects_marked = major_collector.get_and_reset_num_major_objects_marked ();
+	num_objects_marked = sgen_major_collector.get_and_reset_num_major_objects_marked ();
 
 	TV_GETTIME (time_end);
-	UnlockedAdd64 (&gc_stats.major_gc_time, TV_ELAPSED (time_start, time_end));
+	UnlockedAdd64 (&mono_gc_stats.major_gc_time, TV_ELAPSED (time_start, time_end));
 
-	current_collection_generation = -1;
+	sgen_current_collection_generation = -1;
 }
 
 /*
@@ -2418,13 +2418,13 @@ major_update_concurrent_collection (void)
 
 	TV_GETTIME (total_start);
 
-	binary_protocol_concurrent_update ();
+	sgen_binary_protocol_concurrent_update ();
 
-	major_collector.update_cardtable_mod_union ();
+	sgen_major_collector.update_cardtable_mod_union ();
 	sgen_los_update_cardtable_mod_union ();
 
 	TV_GETTIME (total_end);
-	UnlockedAdd64 (&gc_stats.major_gc_time, TV_ELAPSED (total_start, total_end));
+	UnlockedAdd64 (&mono_gc_stats.major_gc_time, TV_ELAPSED (total_start, total_end));
 }
 
 static void
@@ -2436,7 +2436,7 @@ major_finish_concurrent_collection (gboolean forced)
 
 	TV_GETTIME (total_start);
 
-	binary_protocol_concurrent_finish ();
+	sgen_binary_protocol_concurrent_finish ();
 
 	/*
 	 * We need to stop all workers since we're updating the cardtable below.
@@ -2446,24 +2446,24 @@ major_finish_concurrent_collection (gboolean forced)
 	sgen_workers_stop_all_workers (GENERATION_OLD);
 
 	SGEN_TV_GETTIME (time_major_conc_collection_end);
-	UnlockedAdd64 (&gc_stats.major_gc_time_concurrent, SGEN_TV_ELAPSED (time_major_conc_collection_start, time_major_conc_collection_end));
+	UnlockedAdd64 (&mono_gc_stats.major_gc_time_concurrent, SGEN_TV_ELAPSED (time_major_conc_collection_start, time_major_conc_collection_end));
 
-	major_collector.update_cardtable_mod_union ();
+	sgen_major_collector.update_cardtable_mod_union ();
 	sgen_los_update_cardtable_mod_union ();
 
 	if (mod_union_consistency_check)
 		sgen_check_mod_union_consistency ();
 
-	current_collection_generation = GENERATION_OLD;
+	sgen_current_collection_generation = GENERATION_OLD;
 	sgen_cement_reset ();
 	init_gray_queue (&gc_thread_gray_queue);
 	major_finish_collection (&gc_thread_gray_queue, "finishing", FALSE, -1, forced);
 	sgen_gray_object_queue_dispose (&gc_thread_gray_queue);
 
 	TV_GETTIME (total_end);
-	UnlockedAdd64 (&gc_stats.major_gc_time, TV_ELAPSED (total_start, total_end));
+	UnlockedAdd64 (&mono_gc_stats.major_gc_time, TV_ELAPSED (total_start, total_end));
 
-	current_collection_generation = -1;
+	sgen_current_collection_generation = -1;
 }
 
 /*
@@ -2483,13 +2483,13 @@ sgen_ensure_free_space (size_t size, int generation)
 			generation_to_collect = GENERATION_OLD;
 		}
 	} else {
-		if (degraded_mode) {
+		if (sgen_degraded_mode) {
 			if (sgen_need_major_collection (size)) {
 				reason = "Degraded mode overflow";
 				generation_to_collect = GENERATION_OLD;
 			}
 		} else if (sgen_need_major_collection (size)) {
-			reason = concurrent_collection_in_progress ? "Forced finish concurrent collection" : "Minor allowance";
+			reason = sgen_concurrent_collection_in_progress ? "Forced finish concurrent collection" : "Minor allowance";
 			generation_to_collect = GENERATION_OLD;
 		} else {
 			generation_to_collect = GENERATION_NURSERY;
@@ -2498,7 +2498,7 @@ sgen_ensure_free_space (size_t size, int generation)
 	}
 
 	if (generation_to_collect == -1) {
-		if (concurrent_collection_in_progress && sgen_workers_all_done ()) {
+		if (sgen_concurrent_collection_in_progress && sgen_workers_all_done ()) {
 			generation_to_collect = GENERATION_OLD;
 			reason = "Finish concurrent collection";
 		}
@@ -2520,14 +2520,14 @@ sgen_perform_collection_inner (size_t requested_size, int generation_to_collect,
 	int overflow_generation_to_collect = -1;
 	int oldest_generation_collected = generation_to_collect;
 	const char *overflow_reason = NULL;
-	gboolean finish_concurrent = concurrent_collection_in_progress && (major_should_finish_concurrent_collection () || generation_to_collect == GENERATION_OLD);
+	gboolean finish_concurrent = sgen_concurrent_collection_in_progress && (major_should_finish_concurrent_collection () || generation_to_collect == GENERATION_OLD);
 
-	binary_protocol_collection_requested (generation_to_collect, requested_size, forced_serial ? 1 : 0);
+	sgen_binary_protocol_collection_requested (generation_to_collect, requested_size, forced_serial ? 1 : 0);
 
 	SGEN_ASSERT (0, generation_to_collect == GENERATION_NURSERY || generation_to_collect == GENERATION_OLD, "What generation is this?");
 
 	if (stw)
-		sgen_stop_world (generation_to_collect, forced_serial || !major_collector.is_concurrent);
+		sgen_stop_world (generation_to_collect, forced_serial || !sgen_major_collector.is_concurrent);
 	else
 		SGEN_ASSERT (0, sgen_is_world_stopped (), "We can only collect if the world is stopped");
 		
@@ -2537,10 +2537,10 @@ sgen_perform_collection_inner (size_t requested_size, int generation_to_collect,
 	// FIXME: extract overflow reason
 	// FIXME: minor overflow for concurrent case
 	if (generation_to_collect == GENERATION_NURSERY && !finish_concurrent) {
-		if (concurrent_collection_in_progress)
+		if (sgen_concurrent_collection_in_progress)
 			major_update_concurrent_collection ();
 
-		if (collect_nursery (reason, FALSE, NULL) && !concurrent_collection_in_progress) {
+		if (collect_nursery (reason, FALSE, NULL) && !sgen_concurrent_collection_in_progress) {
 			overflow_generation_to_collect = GENERATION_OLD;
 			overflow_reason = "Minor overflow";
 		}
@@ -2551,7 +2551,7 @@ sgen_perform_collection_inner (size_t requested_size, int generation_to_collect,
 			major_do_collection (reason, FALSE, TRUE);
 	} else {
 		SGEN_ASSERT (0, generation_to_collect == GENERATION_OLD, "We should have handled nursery collections above");
-		if (major_collector.is_concurrent && !forced_serial) {
+		if (sgen_major_collector.is_concurrent && !forced_serial) {
 			collect_nursery ("Concurrent start", FALSE, NULL);
 			major_start_concurrent_collection (reason);
 			oldest_generation_collected = GENERATION_NURSERY;
@@ -2562,7 +2562,7 @@ sgen_perform_collection_inner (size_t requested_size, int generation_to_collect,
 	}
 
 	if (overflow_generation_to_collect != -1) {
-		SGEN_ASSERT (0, !concurrent_collection_in_progress, "We don't yet support overflow collections with the concurrent collector");
+		SGEN_ASSERT (0, !sgen_concurrent_collection_in_progress, "We don't yet support overflow collections with the concurrent collector");
 
 		/*
 		 * We need to do an overflow collection, either because we ran out of memory
@@ -2577,21 +2577,21 @@ sgen_perform_collection_inner (size_t requested_size, int generation_to_collect,
 		oldest_generation_collected = MAX (oldest_generation_collected, overflow_generation_to_collect);
 	}
 
-	SGEN_LOG (2, "Heap size: %lu, LOS size: %lu", (unsigned long)sgen_gc_get_total_heap_allocation (), (unsigned long)los_memory_usage);
+	SGEN_LOG (2, "Heap size: %lu, LOS size: %lu", (unsigned long)sgen_gc_get_total_heap_allocation (), (unsigned long)sgen_los_memory_usage);
 
 	/* this also sets the proper pointers for the next allocation */
 	if (generation_to_collect == GENERATION_NURSERY && !sgen_can_alloc_size (requested_size)) {
 		/* TypeBuilder and MonoMethod are killing mcs with fragmentation */
 		SGEN_LOG (1, "nursery collection didn't find enough room for %zd alloc (%zd pinned)", requested_size, sgen_get_pinned_count ());
 		sgen_dump_pin_queue ();
-		degraded_mode = 1;
+		sgen_degraded_mode = 1;
 	}
 
 	TV_GETTIME (gc_total_end);
 	time_max = MAX (time_max, TV_ELAPSED (gc_total_start, gc_total_end));
 
 	if (stw)
-		sgen_restart_world (oldest_generation_collected, forced_serial || !major_collector.is_concurrent);
+		sgen_restart_world (oldest_generation_collected, forced_serial || !sgen_major_collector.is_concurrent);
 }
 
 #ifdef HOST_WASM
@@ -2630,7 +2630,7 @@ sgen_perform_collection (size_t requested_size, int generation_to_collect, const
 		sgen_client_schedule_background_job (gc_pump_callback);
 	}
 
-	degraded_mode = 1; //enable degraded mode so allocation can continue
+	sgen_degraded_mode = 1; //enable degraded mode so allocation can continue
 #else
 	sgen_perform_collection_inner (requested_size, generation_to_collect, reason, forced_serial, stw);
 #endif
@@ -2653,7 +2653,7 @@ report_internal_mem_usage (void)
 	printf ("Internal memory usage:\n");
 	sgen_report_internal_mem_usage ();
 	printf ("Pinned memory usage:\n");
-	major_collector.report_pinned_memory_usage ();
+	sgen_major_collector.report_pinned_memory_usage ();
 }
 
 /*
@@ -2673,7 +2673,7 @@ sgen_is_object_alive_and_on_current_collection (GCObject *object)
 	if (ptr_in_nursery (object))
 		return sgen_nursery_is_object_alive (object);
 
-	if (current_collection_generation == GENERATION_NURSERY)
+	if (sgen_current_collection_generation == GENERATION_NURSERY)
 		return FALSE;
 
 	return sgen_major_is_object_alive (object);
@@ -2800,7 +2800,7 @@ sgen_register_root (char *start, size_t size, SgenDescriptor descr, int root_typ
 
 	LOCK_GC;
 	for (i = 0; i < ROOT_TYPE_NUM; ++i) {
-		RootRecord *root = (RootRecord *)sgen_hash_table_lookup (&roots_hash [i], start);
+		RootRecord *root = (RootRecord *)sgen_hash_table_lookup (&sgen_roots_hash [i], start);
 		/* we allow changing the size and the descriptor (for thread statics etc) */
 		if (root) {
 			size_t old_size = root->end_root - start;
@@ -2821,7 +2821,7 @@ sgen_register_root (char *start, size_t size, SgenDescriptor descr, int root_typ
 	new_root.source = source;
 	new_root.msg = msg;
 
-	sgen_hash_table_replace (&roots_hash [root_type], start, &new_root, NULL);
+	sgen_hash_table_replace (&sgen_roots_hash [root_type], start, &new_root, NULL);
 	roots_size += size;
 
 	SGEN_LOG (3, "Added root for range: %p-%p, descr: %llx  (%d/%d bytes)", start, new_root.end_root, (long long)descr, (int)size, (int)roots_size);
@@ -2840,7 +2840,7 @@ sgen_deregister_root (char* addr)
 
 	LOCK_GC;
 	for (root_type = 0; root_type < ROOT_TYPE_NUM; ++root_type) {
-		if (sgen_hash_table_remove (&roots_hash [root_type], addr, &root))
+		if (sgen_hash_table_remove (&sgen_roots_hash [root_type], addr, &root))
 			roots_size -= (root.end_root - addr);
 	}
 	UNLOCK_GC;
@@ -2851,7 +2851,7 @@ sgen_wbroots_iterate_live_block_ranges (sgen_cardtable_block_callback cb)
 {
 	void **start_root;
 	RootRecord *root;
-	SGEN_HASH_TABLE_FOREACH (&roots_hash [ROOT_TYPE_WBARRIER], void **, start_root, RootRecord *, root) {
+	SGEN_HASH_TABLE_FOREACH (&sgen_roots_hash [ROOT_TYPE_WBARRIER], void **, start_root, RootRecord *, root) {
 		cb ((mword)start_root, (mword)root->end_root - (mword)start_root);
 	} SGEN_HASH_TABLE_FOREACH_END;
 }
@@ -2907,7 +2907,7 @@ LOOP_HEAD:
 				scan_field_func (NULL, (GCObject**)elem, ctx.queue);
 		}
 
-		binary_protocol_card_scan (first_elem, elem - first_elem);
+		sgen_binary_protocol_card_scan (first_elem, elem - first_elem);
 	}
 
 #ifdef SGEN_HAVE_OVERLAPPING_CARDS
@@ -2927,7 +2927,7 @@ sgen_wbroots_scan_card_table (ScanCopyContext ctx)
 	void **start_root;
 	RootRecord *root;
 
-	SGEN_HASH_TABLE_FOREACH (&roots_hash [ROOT_TYPE_WBARRIER], void **, start_root, RootRecord *, root) {
+	SGEN_HASH_TABLE_FOREACH (&sgen_roots_hash [ROOT_TYPE_WBARRIER], void **, start_root, RootRecord *, root) {
 		SGEN_ASSERT (0, (root->root_desc & ROOT_DESC_TYPE_MASK) == ROOT_DESC_VECTOR, "Unsupported root type");
 
 		sgen_wbroot_scan_card_table (start_root, (mword)root->end_root - (mword)start_root, ctx);
@@ -2943,7 +2943,7 @@ sgen_wbroots_scan_card_table (ScanCopyContext ctx)
 int
 sgen_get_current_collection_generation (void)
 {
-	return current_collection_generation;
+	return sgen_current_collection_generation;
 }
 
 void*
@@ -2989,13 +2989,13 @@ mono_gc_wbarrier_arrayref_copy (gpointer dest_ptr, gpointer src_ptr, int count)
 	}
 
 #ifdef SGEN_HEAVY_BINARY_PROTOCOL
-	if (binary_protocol_is_heavy_enabled ()) {
+	if (sgen_binary_protocol_is_heavy_enabled ()) {
 		int i;
 		for (i = 0; i < count; ++i) {
 			gpointer dest = (gpointer*)dest_ptr + i;
 			gpointer obj = *((gpointer*)src_ptr + i);
 			if (obj)
-				binary_protocol_wbarrier (dest, obj, (gpointer)LOAD_VTABLE (obj));
+				sgen_binary_protocol_wbarrier (dest, obj, (gpointer)LOAD_VTABLE (obj));
 		}
 	}
 #endif
@@ -3017,13 +3017,13 @@ mono_gc_wbarrier_generic_nostore (gpointer ptr)
 
 	obj = *(gpointer*)ptr;
 	if (obj)
-		binary_protocol_wbarrier (ptr, obj, (gpointer)LOAD_VTABLE (obj));
+		sgen_binary_protocol_wbarrier (ptr, obj, (gpointer)LOAD_VTABLE (obj));
 
 	/*
 	 * We need to record old->old pointer locations for the
 	 * concurrent collector.
 	 */
-	if (!ptr_in_nursery (obj) && !concurrent_collection_in_progress) {
+	if (!ptr_in_nursery (obj) && !sgen_concurrent_collection_in_progress) {
 		SGEN_LOG (8, "Skipping remset at %p", ptr);
 		return;
 	}
@@ -3041,7 +3041,7 @@ mono_gc_wbarrier_generic_store (gpointer ptr, GCObject* value)
 {
 	SGEN_LOG (8, "Wbarrier store at %p to %p (%s)", ptr, value, value ? sgen_client_vtable_get_name (SGEN_LOAD_VTABLE (value)) : "null");
 	SGEN_UPDATE_REFERENCE_ALLOW_NULL (ptr, value);
-	if (ptr_in_nursery (value) || concurrent_collection_in_progress)
+	if (ptr_in_nursery (value) || sgen_concurrent_collection_in_progress)
 		mono_gc_wbarrier_generic_nostore (ptr);
 	sgen_dummy_use (value);
 }
@@ -3060,7 +3060,7 @@ mono_gc_wbarrier_generic_store_atomic (gpointer ptr, GCObject *value)
 
 	mono_atomic_store_ptr ((volatile gpointer *)ptr, value);
 
-	if (ptr_in_nursery (value) || concurrent_collection_in_progress)
+	if (ptr_in_nursery (value) || sgen_concurrent_collection_in_progress)
 		mono_gc_wbarrier_generic_nostore (ptr);
 
 	sgen_dummy_use (value);
@@ -3094,7 +3094,7 @@ sgen_gc_collect (int generation)
 int
 sgen_gc_collection_count (int generation)
 {
-	return mono_atomic_load_i32 (generation == GENERATION_NURSERY ? &gc_stats.minor_gc_count : &gc_stats.major_gc_count);
+	return mono_atomic_load_i32 (generation == GENERATION_NURSERY ? &mono_gc_stats.minor_gc_count : &mono_gc_stats.major_gc_count);
 }
 
 size_t
@@ -3102,9 +3102,9 @@ sgen_gc_get_used_size (void)
 {
 	gint64 tot = 0;
 	LOCK_GC;
-	tot = los_memory_usage;
-	tot += nursery_section->end_data - nursery_section->data;
-	tot += major_collector.get_used_size ();
+	tot = sgen_los_memory_usage;
+	tot += sgen_nursery_section->end_data - sgen_nursery_section->data;
+	tot += sgen_major_collector.get_used_size ();
 	/* FIXME: account for pinned objects */
 	UNLOCK_GC;
 	return tot;
@@ -3233,7 +3233,7 @@ init_sgen_major (SgenMajor major)
 
 	switch (major) {
 	case SGEN_MAJOR_SERIAL:
-		sgen_marksweep_init (&major_collector);
+		sgen_marksweep_init (&sgen_major_collector);
 		break;
 #ifdef DISABLE_SGEN_MAJOR_MARKSWEEP_CONC
 	case SGEN_MAJOR_CONCURRENT:
@@ -3241,10 +3241,10 @@ init_sgen_major (SgenMajor major)
 		g_error ("Sgen was build with the concurent collector disabled");
 #else
 	case SGEN_MAJOR_CONCURRENT:
-		sgen_marksweep_conc_init (&major_collector);
+		sgen_marksweep_conc_init (&sgen_major_collector);
 		break;
 	case SGEN_MAJOR_CONCURRENT_PARALLEL:
-		sgen_marksweep_conc_par_init (&major_collector);
+		sgen_marksweep_conc_par_init (&sgen_major_collector);
 		break;
 #endif
 	default:
@@ -3345,9 +3345,9 @@ sgen_gc_init (void)
 	mono_thread_smr_init ();
 #endif
 
-	mono_coop_mutex_init (&gc_mutex);
+	mono_coop_mutex_init (&sgen_gc_mutex);
 
-	gc_debug_file = stderr;
+	sgen_gc_debug_file = stderr;
 
 	mono_coop_mutex_init (&sgen_interruption_mutex);
 
@@ -3519,7 +3519,7 @@ sgen_gc_init (void)
 				continue;
 			}
 
-			if (major_collector.handle_gc_param && major_collector.handle_gc_param (opt))
+			if (sgen_major_collector.handle_gc_param && sgen_major_collector.handle_gc_param (opt))
 				continue;
 
 			if (sgen_minor_collector.handle_gc_param && sgen_minor_collector.handle_gc_param (opt))
@@ -3543,8 +3543,8 @@ sgen_gc_init (void)
 			fprintf (stderr, "  wbarrier=WBARRIER (where WBARRIER is `remset' or `cardtable')\n");
 			fprintf (stderr, "  [no-]cementing\n");
 			fprintf (stderr, "  [no-]dynamic-nursery\n");
-			if (major_collector.print_gc_param_usage)
-				major_collector.print_gc_param_usage ();
+			if (sgen_major_collector.print_gc_param_usage)
+				sgen_major_collector.print_gc_param_usage ();
 			if (sgen_minor_collector.print_gc_param_usage)
 				sgen_minor_collector.print_gc_param_usage ();
 			sgen_client_print_gc_params_usage ();
@@ -3580,15 +3580,15 @@ sgen_gc_init (void)
 			if (!strcmp (opt, ""))
 				continue;
 			if (opt [0] >= '0' && opt [0] <= '9') {
-				gc_debug_level = atoi (opt);
+				sgen_gc_debug_level = atoi (opt);
 				opt++;
 				if (opt [0] == ':')
 					opt++;
 				if (opt [0]) {
 					char *rf = g_strdup_printf ("%s.%d", opt, mono_process_current_pid ());
-					gc_debug_file = fopen (rf, "wb");
-					if (!gc_debug_file)
-						gc_debug_file = stderr;
+					sgen_gc_debug_file = fopen (rf, "wb");
+					if (!sgen_gc_debug_file)
+						sgen_gc_debug_file = stderr;
 					g_free (rf);
 				}
 			} else if (!strcmp (opt, "print-allowance")) {
@@ -3596,8 +3596,8 @@ sgen_gc_init (void)
 			} else if (!strcmp (opt, "print-pinning")) {
 				sgen_pin_stats_enable ();
 			} else if (!strcmp (opt, "verify-before-allocs")) {
-				verify_before_allocs = 1;
-				has_per_allocation_action = TRUE;
+				sgen_verify_before_allocs = 1;
+				sgen_has_per_allocation_action = TRUE;
 			} else if (g_str_has_prefix (opt, "max-valloc-size=")) {
 				size_t max_valloc_size;
 				char *arg = strchr (opt, '=') + 1;
@@ -3609,22 +3609,22 @@ sgen_gc_init (void)
 				continue;
 			} else if (g_str_has_prefix (opt, "verify-before-allocs=")) {
 				char *arg = strchr (opt, '=') + 1;
-				verify_before_allocs = atoi (arg);
-				has_per_allocation_action = TRUE;
+				sgen_verify_before_allocs = atoi (arg);
+				sgen_has_per_allocation_action = TRUE;
 			} else if (!strcmp (opt, "collect-before-allocs")) {
-				collect_before_allocs = 1;
-				has_per_allocation_action = TRUE;
+				sgen_collect_before_allocs = 1;
+				sgen_has_per_allocation_action = TRUE;
 			} else if (g_str_has_prefix (opt, "collect-before-allocs=")) {
 				char *arg = strchr (opt, '=') + 1;
-				has_per_allocation_action = TRUE;
-				collect_before_allocs = atoi (arg);
+				sgen_has_per_allocation_action = TRUE;
+				sgen_collect_before_allocs = atoi (arg);
 			} else if (!strcmp (opt, "verify-before-collections")) {
 				whole_heap_check_before_collection = TRUE;
 			} else if (!strcmp (opt, "check-remset-consistency")) {
 				remset_consistency_checks = TRUE;
-				nursery_clear_policy = CLEAR_AT_GC;
+				sgen_nursery_clear_policy = CLEAR_AT_GC;
 			} else if (!strcmp (opt, "mod-union-consistency-check")) {
-				if (!major_collector.is_concurrent) {
+				if (!sgen_major_collector.is_concurrent) {
 					sgen_env_var_error (MONO_GC_DEBUG_NAME, "Ignoring.", "`mod-union-consistency-check` only works with concurrent major collector.");
 					continue;
 				}
@@ -3634,23 +3634,23 @@ sgen_gc_init (void)
 			} else if (!strcmp (opt, "check-nursery-pinned")) {
 				check_nursery_objects_pinned = TRUE;
 			} else if (!strcmp (opt, "clear-at-gc")) {
-				nursery_clear_policy = CLEAR_AT_GC;
+				sgen_nursery_clear_policy = CLEAR_AT_GC;
 			} else if (!strcmp (opt, "clear-nursery-at-gc")) {
-				nursery_clear_policy = CLEAR_AT_GC;
+				sgen_nursery_clear_policy = CLEAR_AT_GC;
 			} else if (!strcmp (opt, "clear-at-tlab-creation")) {
-				nursery_clear_policy = CLEAR_AT_TLAB_CREATION;
+				sgen_nursery_clear_policy = CLEAR_AT_TLAB_CREATION;
 			} else if (!strcmp (opt, "debug-clear-at-tlab-creation")) {
-				nursery_clear_policy = CLEAR_AT_TLAB_CREATION_DEBUG;
+				sgen_nursery_clear_policy = CLEAR_AT_TLAB_CREATION_DEBUG;
 			} else if (!strcmp (opt, "check-scan-starts")) {
 				do_scan_starts_check = TRUE;
 			} else if (!strcmp (opt, "verify-nursery-at-minor-gc")) {
 				do_verify_nursery = TRUE;
 			} else if (!strcmp (opt, "check-concurrent")) {
-				if (!major_collector.is_concurrent) {
+				if (!sgen_major_collector.is_concurrent) {
 					sgen_env_var_error (MONO_GC_DEBUG_NAME, "Ignoring.", "`check-concurrent` only works with concurrent major collectors.");
 					continue;
 				}
-				nursery_clear_policy = CLEAR_AT_GC;
+				sgen_nursery_clear_policy = CLEAR_AT_GC;
 				do_concurrent_checks = TRUE;
 			} else if (!strcmp (opt, "dump-nursery-at-minor-gc")) {
 				do_dump_nursery_content = TRUE;
@@ -3660,7 +3660,7 @@ sgen_gc_init (void)
 				disable_major_collections = TRUE;
 			} else if (g_str_has_prefix (opt, "heap-dump=")) {
 				char *filename = strchr (opt, '=') + 1;
-				nursery_clear_policy = CLEAR_AT_GC;
+				sgen_nursery_clear_policy = CLEAR_AT_GC;
 				sgen_debug_enable_heap_dump (filename);
 			} else if (g_str_has_prefix (opt, "binary-protocol=")) {
 				char *filename = strchr (opt, '=') + 1;
@@ -3673,7 +3673,7 @@ sgen_gc_init (void)
 					}
 					*colon = '\0';
 				}
-				binary_protocol_init (filename, (long long)limit);
+				sgen_binary_protocol_init (filename, (long long)limit);
 			} else if (!strcmp (opt, "nursery-canaries")) {
 				do_verify_nursery = TRUE;
 				enable_nursery_canaries = TRUE;
@@ -3719,10 +3719,10 @@ sgen_gc_init (void)
 		g_free (debug_opts);
 
 	if (check_mark_bits_after_major_collection)
-		nursery_clear_policy = CLEAR_AT_GC;
+		sgen_nursery_clear_policy = CLEAR_AT_GC;
 
-	if (major_collector.post_param_init)
-		major_collector.post_param_init (&major_collector);
+	if (sgen_major_collector.post_param_init)
+		sgen_major_collector.post_param_init (&sgen_major_collector);
 
 	sgen_thread_pool_start ();
 
@@ -3748,37 +3748,37 @@ sgen_gc_initialized ()
 NurseryClearPolicy
 sgen_get_nursery_clear_policy (void)
 {
-	return nursery_clear_policy;
+	return sgen_nursery_clear_policy;
 }
 
 void
 sgen_gc_lock (void)
 {
-	mono_coop_mutex_lock (&gc_mutex);
+	mono_coop_mutex_lock (&sgen_gc_mutex);
 }
 
 void
 sgen_gc_unlock (void)
 {
-	mono_coop_mutex_unlock (&gc_mutex);
+	mono_coop_mutex_unlock (&sgen_gc_mutex);
 }
 
 void
 sgen_major_collector_iterate_live_block_ranges (sgen_cardtable_block_callback callback)
 {
-	major_collector.iterate_live_block_ranges (callback);
+	sgen_major_collector.iterate_live_block_ranges (callback);
 }
 
 void
 sgen_major_collector_iterate_block_ranges (sgen_cardtable_block_callback callback)
 {
-	major_collector.iterate_block_ranges (callback);
+	sgen_major_collector.iterate_block_ranges (callback);
 }
 
 SgenMajorCollector*
 sgen_get_major_collector (void)
 {
-	return &major_collector;
+	return &sgen_major_collector;
 }
 
 SgenMinorCollector*
@@ -3810,15 +3810,15 @@ sgen_stop_world (int generation, gboolean serial_collection)
 
 	SGEN_ASSERT (0, !world_is_stopped, "Why are we stopping a stopped world?");
 
-	binary_protocol_world_stopping (generation, sgen_timestamp (), (gpointer) (gsize) mono_native_thread_id_get ());
+	sgen_binary_protocol_world_stopping (generation, sgen_timestamp (), (gpointer) (gsize) mono_native_thread_id_get ());
 
 	sgen_client_stop_world (generation, serial_collection);
 
 	world_is_stopped = TRUE;
 
-	if (binary_protocol_is_heavy_enabled ())
+	if (sgen_binary_protocol_is_heavy_enabled ())
 		count_cards (&major_total, &major_marked, &los_total, &los_marked);
-	binary_protocol_world_stopped (generation, sgen_timestamp (), major_total, major_marked, los_total, los_marked);
+	sgen_binary_protocol_world_stopped (generation, sgen_timestamp (), major_total, major_marked, los_total, los_marked);
 }
 
 /* LOCKING: assumes the GC lock is held */
@@ -3830,15 +3830,15 @@ sgen_restart_world (int generation, gboolean serial_collection)
 
 	SGEN_ASSERT (0, world_is_stopped, "Why are we restarting a running world?");
 
-	if (binary_protocol_is_heavy_enabled ())
+	if (sgen_binary_protocol_is_heavy_enabled ())
 		count_cards (&major_total, &major_marked, &los_total, &los_marked);
-	binary_protocol_world_restarting (generation, sgen_timestamp (), major_total, major_marked, los_total, los_marked);
+	sgen_binary_protocol_world_restarting (generation, sgen_timestamp (), major_total, major_marked, los_total, los_marked);
 
 	world_is_stopped = FALSE;
 
 	sgen_client_restart_world (generation, serial_collection, &stw_time);
 
-	binary_protocol_world_restarted (generation, sgen_timestamp ());
+	sgen_binary_protocol_world_restarted (generation, sgen_timestamp ());
 
 	if (sgen_client_bridge_need_processing ())
 		sgen_client_bridge_processing_finish (generation);

--- a/mono/sgen/sgen-gchandles.c
+++ b/mono/sgen/sgen-gchandles.c
@@ -48,11 +48,11 @@ protocol_gchandle_update (int handle_type, gpointer link, gpointer old_value, gp
 		return;
 
 	if (!old && new_)
-		binary_protocol_dislink_add (link, MONO_GC_REVEAL_POINTER (new_value, TRUE), track);
+		sgen_binary_protocol_dislink_add (link, MONO_GC_REVEAL_POINTER (new_value, TRUE), track);
 	else if (old && !new_)
-		binary_protocol_dislink_remove (link, track);
+		sgen_binary_protocol_dislink_remove (link, track);
 	else if (old && new_ && old_value != new_value)
-		binary_protocol_dislink_update (link, MONO_GC_REVEAL_POINTER (new_value, TRUE), track);
+		sgen_binary_protocol_dislink_update (link, MONO_GC_REVEAL_POINTER (new_value, TRUE), track);
 }
 
 /* Returns the new value in the slot, or NULL if the CAS failed. */
@@ -406,7 +406,7 @@ null_link_if_necessary (gpointer hidden, GCHandleType handle_type, int max_gener
 	if (object_older_than (obj, max_generation))
 		return hidden;
 
-	if (major_collector.is_object_live (obj))
+	if (sgen_major_collector.is_object_live (obj))
 		return hidden;
 
 	/* Clear link if object is ready for finalization. This check may be redundant wrt is_object_live(). */

--- a/mono/sgen/sgen-gray.c
+++ b/mono/sgen/sgen-gray.c
@@ -140,7 +140,7 @@ sgen_gray_object_enqueue (SgenGrayQueue *queue, GCObject *obj, SgenDescriptor de
 	*++queue->cursor = entry;
 
 #ifdef SGEN_HEAVY_BINARY_PROTOCOL
-	binary_protocol_gray_enqueue (queue, queue->cursor, obj);
+	sgen_binary_protocol_gray_enqueue (queue, queue->cursor, obj);
 #endif
 }
 
@@ -224,7 +224,7 @@ sgen_gray_object_dequeue (SgenGrayQueue *queue, gboolean is_parallel)
 	entry = *queue->cursor--;
 
 #ifdef SGEN_HEAVY_BINARY_PROTOCOL
-	binary_protocol_gray_dequeue (queue, queue->cursor + 1, entry.obj);
+	sgen_binary_protocol_gray_dequeue (queue, queue->cursor + 1, entry.obj);
 #endif
 
 	if (G_UNLIKELY (queue->cursor < GRAY_FIRST_CURSOR_POSITION (queue->first))) {

--- a/mono/sgen/sgen-gray.h
+++ b/mono/sgen/sgen-gray.h
@@ -173,7 +173,7 @@ GRAY_OBJECT_ENQUEUE (SgenGrayQueue *queue, GCObject *obj, SgenDescriptor desc, g
 
 		*++queue->cursor = entry;
 #ifdef SGEN_HEAVY_BINARY_PROTOCOL
-		binary_protocol_gray_enqueue (queue, queue->cursor, obj);
+		sgen_binary_protocol_gray_enqueue (queue, queue->cursor, obj);
 #endif
 	}
 #endif
@@ -203,7 +203,7 @@ GRAY_OBJECT_DEQUEUE (SgenGrayQueue *queue, GCObject** obj, SgenDescriptor *desc,
 		*obj = entry.obj;
 		*desc = entry.desc;
 #ifdef SGEN_HEAVY_BINARY_PROTOCOL
-		binary_protocol_gray_dequeue (queue, queue->cursor + 1, *obj);
+		sgen_binary_protocol_gray_dequeue (queue, queue->cursor + 1, *obj);
 #endif
 	}
 #endif

--- a/mono/sgen/sgen-minor-copy-object.h
+++ b/mono/sgen/sgen-minor-copy-object.h
@@ -80,7 +80,7 @@ SERIAL_COPY_OBJECT (GCObject **obj_slot, SgenGrayQueue *queue)
 	GCObject *copy;
 	GCObject *obj = *obj_slot;
 
-	SGEN_ASSERT (9, current_collection_generation == GENERATION_NURSERY, "calling minor-serial-copy from a %d generation collection", current_collection_generation);
+	SGEN_ASSERT (9, sgen_current_collection_generation == GENERATION_NURSERY, "calling minor-serial-copy from a %d generation collection", sgen_current_collection_generation);
 
 	HEAVY_STAT (++stat_copy_object_called_nursery);
 
@@ -142,7 +142,7 @@ SERIAL_COPY_OBJECT_FROM_OBJ (GCObject **obj_slot, SgenGrayQueue *queue)
 	GCObject *obj = *obj_slot;
 	GCObject *copy;
 
-	SGEN_ASSERT (9, current_collection_generation == GENERATION_NURSERY, "calling minor-serial-copy-from-obj from a %d generation collection", current_collection_generation);
+	SGEN_ASSERT (9, sgen_current_collection_generation == GENERATION_NURSERY, "calling minor-serial-copy-from-obj from a %d generation collection", sgen_current_collection_generation);
 
 	HEAVY_STAT (++stat_copy_object_called_nursery);
 

--- a/mono/sgen/sgen-minor-scan-object.h
+++ b/mono/sgen/sgen-minor-scan-object.h
@@ -67,7 +67,7 @@ extern guint64 stat_scan_object_called_nursery;
 #define HANDLE_PTR(ptr,obj)	do {	\
 		void *__old = *(ptr);	\
 		SGEN_OBJECT_LAYOUT_STATISTICS_MARK_BITMAP ((obj), (ptr)); \
-		binary_protocol_scan_process_reference ((full_object), (ptr), __old); \
+		sgen_binary_protocol_scan_process_reference ((full_object), (ptr), __old); \
 		if (__old) {	\
 			SERIAL_COPY_OBJECT_FROM_OBJ ((ptr), queue);	\
 			SGEN_COND_LOG (9, __old != *(ptr), "Overwrote field at %p with %p (was: %p)", (ptr), *(ptr), __old); \

--- a/mono/sgen/sgen-nursery-allocator.c
+++ b/mono/sgen/sgen-nursery-allocator.c
@@ -652,7 +652,7 @@ static void
 add_nursery_frag (SgenFragmentAllocator *allocator, size_t frag_size, char* frag_start, char* frag_end)
 {
 	SGEN_LOG (4, "Found empty fragment: %p-%p, size: %zd", frag_start, frag_end, frag_size);
-	binary_protocol_empty (frag_start, frag_size);
+	sgen_binary_protocol_empty (frag_start, frag_size);
 	/* Not worth dealing with smaller fragments: need to tune */
 	if (frag_size >= SGEN_MAX_NURSERY_WASTE) {
 		/* memsetting just the first chunk start is bound to provide better cache locality */
@@ -927,7 +927,7 @@ sgen_resize_nursery (gboolean need_shrink)
 	if (sgen_nursery_min_size == sgen_nursery_max_size)
 		return;
 
-	major_size = major_collector.get_num_major_sections () * major_collector.section_size + los_memory_usage;
+	major_size = sgen_major_collector.get_num_major_sections () * sgen_major_collector.section_size + sgen_los_memory_usage;
 	/*
 	 * We attempt to use a larger nursery size, as long as it doesn't
 	 * exceed a certain percentage of the major heap.
@@ -939,8 +939,8 @@ sgen_resize_nursery (gboolean need_shrink)
 	 */
 	if ((sgen_nursery_size * 2) < (major_size / SGEN_DEFAULT_ALLOWANCE_NURSERY_SIZE_RATIO) &&
 			(sgen_nursery_size * 2) <= sgen_nursery_max_size && !need_shrink) {
-		if ((nursery_section->end_data - nursery_section->data) == sgen_nursery_size)
-			nursery_section->end_data += sgen_nursery_size;
+		if ((sgen_nursery_section->end_data - sgen_nursery_section->data) == sgen_nursery_size)
+			sgen_nursery_section->end_data += sgen_nursery_size;
 		sgen_nursery_size *= 2;
 	} else if ((sgen_nursery_size > (major_size / SGEN_DEFAULT_ALLOWANCE_NURSERY_SIZE_RATIO) || need_shrink) &&
 			(sgen_nursery_size / 2) >= sgen_nursery_min_size) {

--- a/mono/sgen/sgen-pinning-stats.c
+++ b/mono/sgen/sgen-pinning-stats.c
@@ -168,7 +168,7 @@ sgen_pin_stats_register_object (GCObject *obj, int generation)
 	int pin_types = 0;
 	size_t size = 0;
 
-	if (binary_protocol_is_enabled ()) {
+	if (sgen_binary_protocol_is_enabled ()) {
 		size = sgen_safe_object_get_size (obj);
 		pinned_bytes_in_generation [generation] += size;
 		++pinned_objects_in_generation [generation];
@@ -209,27 +209,27 @@ sgen_pin_stats_report (void)
 	PinnedClassEntry *pinned_entry;
 	GlobalRemsetClassEntry *remset_entry;
 
-	binary_protocol_pin_stats (pinned_objects_in_generation [GENERATION_NURSERY], pinned_bytes_in_generation [GENERATION_NURSERY],
+	sgen_binary_protocol_pin_stats (pinned_objects_in_generation [GENERATION_NURSERY], pinned_bytes_in_generation [GENERATION_NURSERY],
 			pinned_objects_in_generation [GENERATION_OLD], pinned_bytes_in_generation [GENERATION_OLD]);
 
 	if (!do_pin_stats)
 		return;
 
-	mono_gc_printf (gc_debug_file, "\n%-50s  %10s  %10s  %10s\n", "Class", "Stack", "Static", "Other");
+	mono_gc_printf (sgen_gc_debug_file, "\n%-50s  %10s  %10s  %10s\n", "Class", "Stack", "Static", "Other");
 	SGEN_HASH_TABLE_FOREACH (&pinned_class_hash_table, char *, name, PinnedClassEntry *, pinned_entry) {
 		int i;
-		mono_gc_printf (gc_debug_file, "%-50s", name);
+		mono_gc_printf (sgen_gc_debug_file, "%-50s", name);
 		for (i = 0; i < PIN_TYPE_MAX; ++i)
-			mono_gc_printf (gc_debug_file, "  %10ld", pinned_entry->num_pins [i]);
-		mono_gc_printf (gc_debug_file, "\n");
+			mono_gc_printf (sgen_gc_debug_file, "  %10ld", pinned_entry->num_pins [i]);
+		mono_gc_printf (sgen_gc_debug_file, "\n");
 	} SGEN_HASH_TABLE_FOREACH_END;
 
-	mono_gc_printf (gc_debug_file, "\n%-50s  %10s\n", "Class", "#Remsets");
+	mono_gc_printf (sgen_gc_debug_file, "\n%-50s  %10s\n", "Class", "#Remsets");
 	SGEN_HASH_TABLE_FOREACH (&global_remset_class_hash_table, char *, name, GlobalRemsetClassEntry *, remset_entry) {
-		mono_gc_printf (gc_debug_file, "%-50s  %10ld\n", name, remset_entry->num_remsets);
+		mono_gc_printf (sgen_gc_debug_file, "%-50s  %10ld\n", name, remset_entry->num_remsets);
 	} SGEN_HASH_TABLE_FOREACH_END;
 
-	mono_gc_printf (gc_debug_file, "\nTotal bytes pinned from stack: %ld  static: %ld  other: %ld\n",
+	mono_gc_printf (sgen_gc_debug_file, "\nTotal bytes pinned from stack: %ld  static: %ld  other: %ld\n",
 			pinned_byte_counts [PIN_TYPE_STACK],
 			pinned_byte_counts [PIN_TYPE_STATIC_DATA],
 			pinned_byte_counts [PIN_TYPE_OTHER]);

--- a/mono/sgen/sgen-pinning.c
+++ b/mono/sgen/sgen-pinning.c
@@ -243,7 +243,7 @@ sgen_cement_reset (void)
 			cement_hash [i].count = 0;
 		}
 	}
-	binary_protocol_cement_reset ();
+	sgen_binary_protocol_cement_reset ();
 }
 
 
@@ -350,7 +350,7 @@ sgen_cement_lookup_or_register (GCObject *obj)
 		SGEN_ASSERT (9, SGEN_OBJECT_IS_PINNED (obj), "Can only cement pinned objects");
 		SGEN_CEMENT_OBJECT (obj);
 
-		binary_protocol_cement (obj, (gpointer)SGEN_LOAD_VTABLE (obj),
+		sgen_binary_protocol_cement (obj, (gpointer)SGEN_LOAD_VTABLE (obj),
 				(int)sgen_safe_object_get_size (obj));
 	}
 
@@ -370,7 +370,7 @@ pin_from_hash (CementHashEntry *hash, gboolean has_been_reset)
 
 		sgen_client_pinned_cemented_object (hash [i].obj);
 		sgen_pin_stage_ptr (hash [i].obj);
-		binary_protocol_cement_stage (hash [i].obj);
+		sgen_binary_protocol_cement_stage (hash [i].obj);
 		/* FIXME: do pin stats if enabled */
 
 		SGEN_CEMENT_OBJECT (hash [i].obj);

--- a/mono/sgen/sgen-protocol.c
+++ b/mono/sgen/sgen-protocol.c
@@ -128,7 +128,7 @@ binary_protocol_open_file (gboolean assert_on_failure)
 }
 
 void
-binary_protocol_init (const char *filename, long long limit)
+sgen_binary_protocol_init (const char *filename, long long limit)
 {
 	file_size_limit = limit;
 
@@ -148,11 +148,11 @@ binary_protocol_init (const char *filename, long long limit)
 	if (file_size_limit == 0)
 		g_free (filename_or_prefix);
 
-	binary_protocol_header (PROTOCOL_HEADER_CHECK, PROTOCOL_HEADER_VERSION, SIZEOF_VOID_P, G_BYTE_ORDER == G_LITTLE_ENDIAN);
+	sgen_binary_protocol_header (PROTOCOL_HEADER_CHECK, PROTOCOL_HEADER_VERSION, SIZEOF_VOID_P, G_BYTE_ORDER == G_LITTLE_ENDIAN);
 }
 
 gboolean
-binary_protocol_is_enabled (void)
+sgen_binary_protocol_is_enabled (void)
 {
 	return binary_protocol_file != invalid_file_value;
 }
@@ -275,7 +275,7 @@ binary_protocol_check_file_overflow (void)
  * The protocol entries that do flush have `FLUSH()` in their definition.
  */
 gboolean
-binary_protocol_flush_buffers (gboolean force)
+sgen_binary_protocol_flush_buffers (gboolean force)
 {
 	int num_buffers = 0, i;
 	BinaryProtocolBuffer *header;
@@ -390,48 +390,48 @@ protocol_entry (unsigned char type, gpointer data, int size)
 #define TYPE_BOOL gboolean
 
 #define BEGIN_PROTOCOL_ENTRY0(method) \
-	void method (void) { \
+	void sgen_ ## method (void) { \
 		int __type = PROTOCOL_ID(method); \
 		gpointer __data = NULL; \
 		int __size = 0; \
 		CLIENT_PROTOCOL_NAME (method) ();
 #define BEGIN_PROTOCOL_ENTRY1(method,t1,f1) \
-	void method (t1 f1) { \
+	void sgen_ ## method (t1 f1) { \
 		PROTOCOL_STRUCT(method) __entry = { f1 }; \
 		int __type = PROTOCOL_ID(method); \
 		gpointer __data = &__entry; \
 		int __size = sizeof (PROTOCOL_STRUCT(method)); \
 		CLIENT_PROTOCOL_NAME (method) (f1);
 #define BEGIN_PROTOCOL_ENTRY2(method,t1,f1,t2,f2) \
-	void method (t1 f1, t2 f2) { \
+	void sgen_ ## method (t1 f1, t2 f2) { \
 		PROTOCOL_STRUCT(method) __entry = { f1, f2 }; \
 		int __type = PROTOCOL_ID(method); \
 		gpointer __data = &__entry; \
 		int __size = sizeof (PROTOCOL_STRUCT(method)); \
 		CLIENT_PROTOCOL_NAME (method) (f1, f2);
 #define BEGIN_PROTOCOL_ENTRY3(method,t1,f1,t2,f2,t3,f3) \
-	void method (t1 f1, t2 f2, t3 f3) { \
+	void sgen_ ## method (t1 f1, t2 f2, t3 f3) { \
 		PROTOCOL_STRUCT(method) __entry = { f1, f2, f3 }; \
 		int __type = PROTOCOL_ID(method); \
 		gpointer __data = &__entry; \
 		int __size = sizeof (PROTOCOL_STRUCT(method)); \
 		CLIENT_PROTOCOL_NAME (method) (f1, f2, f3);
 #define BEGIN_PROTOCOL_ENTRY4(method,t1,f1,t2,f2,t3,f3,t4,f4) \
-	void method (t1 f1, t2 f2, t3 f3, t4 f4) { \
+	void sgen_ ## method (t1 f1, t2 f2, t3 f3, t4 f4) { \
 		PROTOCOL_STRUCT(method) __entry = { f1, f2, f3, f4 }; \
 		int __type = PROTOCOL_ID(method); \
 		gpointer __data = &__entry; \
 		int __size = sizeof (PROTOCOL_STRUCT(method)); \
 		CLIENT_PROTOCOL_NAME (method) (f1, f2, f3, f4);
 #define BEGIN_PROTOCOL_ENTRY5(method,t1,f1,t2,f2,t3,f3,t4,f4,t5,f5) \
-	void method (t1 f1, t2 f2, t3 f3, t4 f4, t5 f5) { \
+	void sgen_ ## method (t1 f1, t2 f2, t3 f3, t4 f4, t5 f5) { \
 		PROTOCOL_STRUCT(method) __entry = { f1, f2, f3, f4, f5 }; \
 		int __type = PROTOCOL_ID(method); \
 		gpointer __data = &__entry; \
 		int __size = sizeof (PROTOCOL_STRUCT(method)); \
 		CLIENT_PROTOCOL_NAME (method) (f1, f2, f3, f4, f5);
 #define BEGIN_PROTOCOL_ENTRY6(method,t1,f1,t2,f2,t3,f3,t4,f4,t5,f5,t6,f6) \
-	void method (t1 f1, t2 f2, t3 f3, t4 f4, t5 f5, t6 f6) { \
+	void sgen_ ## method (t1 f1, t2 f2, t3 f3, t4 f4, t5 f5, t6 f6) { \
 		PROTOCOL_STRUCT(method) __entry = { f1, f2, f3, f4, f5, f6 }; \
 		int __type = PROTOCOL_ID(method); \
 		gpointer __data = &__entry; \
@@ -451,7 +451,7 @@ protocol_entry (unsigned char type, gpointer data, int size)
 
 #define END_PROTOCOL_ENTRY_FLUSH \
 		protocol_entry (__type, __data, __size); \
-		binary_protocol_flush_buffers (FALSE); \
+		sgen_binary_protocol_flush_buffers (FALSE); \
 	}
 
 #ifdef SGEN_HEAVY_BINARY_PROTOCOL

--- a/mono/sgen/sgen-protocol.h
+++ b/mono/sgen/sgen-protocol.h
@@ -169,28 +169,28 @@ enum {
 
 /* missing: finalizers, roots, non-store wbarriers */
 
-void binary_protocol_init (const char *filename, long long limit);
-gboolean binary_protocol_is_enabled (void);
+void sgen_binary_protocol_init (const char *filename, long long limit);
+gboolean sgen_binary_protocol_is_enabled (void);
 
-gboolean binary_protocol_flush_buffers (gboolean force);
+gboolean sgen_binary_protocol_flush_buffers (gboolean force);
 
 #define BEGIN_PROTOCOL_ENTRY0(method) \
-	void method (void);
+	void sgen_ ## method (void);
 #define BEGIN_PROTOCOL_ENTRY1(method,t1,f1) \
-	void method (t1 f1);
+	void sgen_ ## method (t1 f1);
 #define BEGIN_PROTOCOL_ENTRY2(method,t1,f1,t2,f2) \
-	void method (t1 f1, t2 f2);
+	void sgen_ ## method (t1 f1, t2 f2);
 #define BEGIN_PROTOCOL_ENTRY3(method,t1,f1,t2,f2,t3,f3) \
-	void method (t1 f1, t2 f2, t3 f3);
+	void sgen_ ## method (t1 f1, t2 f2, t3 f3);
 #define BEGIN_PROTOCOL_ENTRY4(method,t1,f1,t2,f2,t3,f3,t4,f4) \
-	void method (t1 f1, t2 f2, t3 f3, t4 f4);
+	void sgen_ ## method (t1 f1, t2 f2, t3 f3, t4 f4);
 #define BEGIN_PROTOCOL_ENTRY5(method,t1,f1,t2,f2,t3,f3,t4,f4,t5,f5) \
-	void method (t1 f1, t2 f2, t3 f3, t4 f4, t5 f5);
+	void sgen_ ## method (t1 f1, t2 f2, t3 f3, t4 f4, t5 f5);
 #define BEGIN_PROTOCOL_ENTRY6(method,t1,f1,t2,f2,t3,f3,t4,f4,t5,f5,t6,f6) \
-	void method (t1 f1, t2 f2, t3 f3, t4 f4, t5 f5, t6 f6);
+	void sgen_ ##  method (t1 f1, t2 f2, t3 f3, t4 f4, t5 f5, t6 f6);
 
 #ifdef SGEN_HEAVY_BINARY_PROTOCOL
-#define binary_protocol_is_heavy_enabled()	binary_protocol_is_enabled ()
+#define sgen_binary_protocol_is_heavy_enabled()	sgen_binary_protocol_is_enabled ()
 
 #define BEGIN_PROTOCOL_ENTRY_HEAVY0(method) \
 	BEGIN_PROTOCOL_ENTRY0 (method)
@@ -207,22 +207,22 @@ gboolean binary_protocol_flush_buffers (gboolean force);
 #define BEGIN_PROTOCOL_ENTRY_HEAVY6(method,t1,f1,t2,f2,t3,f3,t4,f4,t5,f5,t6,f6) \
 	BEGIN_PROTOCOL_ENTRY6 (method,t1,f1,t2,f2,t3,f3,t4,f4,t5,f5,t6,f6)
 #else
-#define binary_protocol_is_heavy_enabled()	FALSE
+#define sgen_binary_protocol_is_heavy_enabled()	FALSE
 
 #define BEGIN_PROTOCOL_ENTRY_HEAVY0(method) \
-	static inline void method (void) {}
+	static inline void sgen_ ## method (void) {}
 #define BEGIN_PROTOCOL_ENTRY_HEAVY1(method,t1,f1) \
-	static inline void method (t1 f1) {}
+	static inline void sgen_ ## method (t1 f1) {}
 #define BEGIN_PROTOCOL_ENTRY_HEAVY2(method,t1,f1,t2,f2) \
-	static inline void method (t1 f1, t2 f2) {}
+	static inline void sgen_ ## method (t1 f1, t2 f2) {}
 #define BEGIN_PROTOCOL_ENTRY_HEAVY3(method,t1,f1,t2,f2,t3,f3) \
-	static inline void method (t1 f1, t2 f2, t3 f3) {}
+	static inline void sgen_ ## method (t1 f1, t2 f2, t3 f3) {}
 #define BEGIN_PROTOCOL_ENTRY_HEAVY4(method,t1,f1,t2,f2,t3,f3,t4,f4) \
-	static inline void method (t1 f1, t2 f2, t3 f3, t4 f4) {}
+	static inline void sgen_ ## method (t1 f1, t2 f2, t3 f3, t4 f4) {}
 #define BEGIN_PROTOCOL_ENTRY_HEAVY5(method,t1,f1,t2,f2,t3,f3,t4,f4,t5,f5) \
-	static inline void method (t1 f1, t2 f2, t3 f3, t4 f4, t5 f5) {}
+	static inline void sgen_ ## method (t1 f1, t2 f2, t3 f3, t4 f4, t5 f5) {}
 #define BEGIN_PROTOCOL_ENTRY_HEAVY6(method,t1,f1,t2,f2,t3,f3,t4,f4,t5,f5,t6,f6) \
-	static inline void method (t1 f1, t2 f2, t3 f3, t4 f4, t5 f5, t6 f6) {}
+	static inline void sgen_ ## method (t1 f1, t2 f2, t3 f3, t4 f4, t5 f5, t6 f6) {}
 #endif
 
 #define DEFAULT_PRINT()

--- a/mono/sgen/sgen-scan-object.h
+++ b/mono/sgen/sgen-scan-object.h
@@ -36,11 +36,11 @@
 {
 #ifndef SCAN_OBJECT_NOVTABLE
 #if defined(SGEN_HEAVY_BINARY_PROTOCOL) && defined(SCAN_OBJECT_PROTOCOL)
-	binary_protocol_scan_begin ((GCObject*)start, SGEN_LOAD_VTABLE ((GCObject*)start), sgen_safe_object_get_size ((GCObject*)start));
+	sgen_binary_protocol_scan_begin ((GCObject*)start, SGEN_LOAD_VTABLE ((GCObject*)start), sgen_safe_object_get_size ((GCObject*)start));
 #endif
 #else
 #if defined(SGEN_HEAVY_BINARY_PROTOCOL) && defined(SCAN_OBJECT_PROTOCOL)
-	binary_protocol_scan_vtype_begin (start + SGEN_CLIENT_OBJECT_HEADER_SIZE, size);
+	sgen_binary_protocol_scan_vtype_begin (start + SGEN_CLIENT_OBJECT_HEADER_SIZE, size);
 #endif
 #endif
 	switch (desc & DESC_TYPE_MASK) {

--- a/mono/sgen/sgen-simple-nursery.c
+++ b/mono/sgen/sgen-simple-nursery.c
@@ -26,8 +26,8 @@
 static inline GCObject*
 alloc_for_promotion (GCVTable vtable, GCObject *obj, size_t objsize, gboolean has_references)
 {
-	total_promoted_size += objsize;
-	return major_collector.alloc_object (vtable, objsize, has_references);
+	sgen_total_promoted_size += objsize;
+	return sgen_major_collector.alloc_object (vtable, objsize, has_references);
 }
 
 static inline GCObject*
@@ -35,12 +35,12 @@ alloc_for_promotion_par (GCVTable vtable, GCObject *obj, size_t objsize, gboolea
 {
 	/*
 	 * FIXME
-	 * Note that the stat is not precise. total_promoted_size incrementing is not atomic and
+	 * Note that the stat is not precise. sgen_total_promoted_size incrementing is not atomic and
 	 * even in that case, the same object might be promoted simultaneously by different workers
 	 * leading to one of the allocated major object to be discarded.
 	 */
-	total_promoted_size += objsize;
-	return major_collector.alloc_object_par (vtable, objsize, has_references);
+	sgen_total_promoted_size += objsize;
+	return sgen_major_collector.alloc_object_par (vtable, objsize, has_references);
 }
 
 static SgenFragment*

--- a/mono/sgen/sgen-split-nursery.c
+++ b/mono/sgen/sgen-split-nursery.c
@@ -258,8 +258,8 @@ alloc_for_promotion (GCVTable vtable, GCObject *obj, size_t objsize, gboolean ha
 
 	age = get_object_age (obj);
 	if (age >= promote_age) {
-		total_promoted_size += objsize;
-		return major_collector.alloc_object (vtable, objsize, has_references);
+		sgen_total_promoted_size += objsize;
+		return sgen_major_collector.alloc_object (vtable, objsize, has_references);
 	}
 
 	/* Promote! */
@@ -271,8 +271,8 @@ alloc_for_promotion (GCVTable vtable, GCObject *obj, size_t objsize, gboolean ha
 	} else {
 		p = alloc_for_promotion_slow_path (age, objsize);
 		if (!p) {
-			total_promoted_size += objsize;
-			return major_collector.alloc_object (vtable, objsize, has_references);
+			sgen_total_promoted_size += objsize;
+			return sgen_major_collector.alloc_object (vtable, objsize, has_references);
 		}
 	}
 
@@ -289,7 +289,7 @@ minor_alloc_for_promotion (GCVTable vtable, GCObject *obj, size_t objsize, gbool
 	We only need to check for a non-nursery object if we're doing a major collection.
 	*/
 	if (!sgen_ptr_in_nursery (obj))
-		return major_collector.alloc_object (vtable, objsize, has_references);
+		return sgen_major_collector.alloc_object (vtable, objsize, has_references);
 
 	return alloc_for_promotion (vtable, obj, objsize, has_references);
 }

--- a/mono/sgen/sgen-workers.c
+++ b/mono/sgen/sgen-workers.c
@@ -142,7 +142,7 @@ worker_try_finish (WorkerData *data)
 			 * Log to be able to get the duration of normal concurrent M&S phase.
 			 * Worker indexes are 1 based, since 0 is logically considered gc thread.
 			 */
-			binary_protocol_worker_finish_stats (data - &context->workers_data [0] + 1, context->generation, context->forced_stop, data->major_scan_time, data->los_scan_time, data->total_time + sgen_timestamp () - last_start);
+			sgen_binary_protocol_worker_finish_stats (data - &context->workers_data [0] + 1, context->generation, context->forced_stop, data->major_scan_time, data->los_scan_time, data->total_time + sgen_timestamp () - last_start);
 			goto work_available;
 		}
 	}
@@ -168,7 +168,7 @@ worker_try_finish (WorkerData *data)
 	mono_os_mutex_unlock (&context->finished_lock);
 
 	data->total_time += (sgen_timestamp () - last_start);
-	binary_protocol_worker_finish_stats (data - &context->workers_data [0] + 1, context->generation, context->forced_stop, data->major_scan_time, data->los_scan_time, data->total_time);
+	sgen_binary_protocol_worker_finish_stats (data - &context->workers_data [0] + 1, context->generation, context->forced_stop, data->major_scan_time, data->los_scan_time, data->total_time);
 
 	sgen_gray_object_queue_trim_free_list (&data->private_gray_queue);
 	return;
@@ -248,7 +248,7 @@ workers_steal_work (WorkerData *data)
 static void
 concurrent_enqueue_check (GCObject *obj)
 {
-	g_assert (sgen_concurrent_collection_in_progress ());
+	g_assert (sgen_get_concurrent_collection_in_progress ());
 	g_assert (!sgen_ptr_in_nursery (obj));
 	g_assert (SGEN_LOAD_VTABLE (obj));
 }

--- a/mono/utils/mono-mmap-internals.h
+++ b/mono/utils/mono-mmap-internals.h
@@ -13,13 +13,13 @@
 #include "mono-compiler.h"
 
 void *
-malloc_shared_area (int pid);
+mono_malloc_shared_area (int pid);
 
 char*
-aligned_address (char *mem, size_t size, size_t alignment);
+mono_aligned_address (char *mem, size_t size, size_t alignment);
 
 void
-account_mem (MonoMemAccountType type, ssize_t size);
+mono_account_mem (MonoMemAccountType type, ssize_t size);
 
 gboolean
 mono_valloc_can_alloc (size_t size);

--- a/mono/utils/mono-mmap-windows.c
+++ b/mono/utils/mono-mmap-windows.c
@@ -76,7 +76,7 @@ mono_valloc (void *addr, size_t length, int flags, MonoMemAccountType type)
 
 	ptr = VirtualAlloc (addr, length, mflags, prot);
 
-	account_mem (type, (ssize_t)length);
+	mono_account_mem (type, (ssize_t)length);
 
 	return ptr;
 }
@@ -94,12 +94,12 @@ mono_valloc_aligned (size_t length, size_t alignment, int flags, MonoMemAccountT
 	if (!mono_valloc_can_alloc (length))
 		return NULL;
 
-	aligned = aligned_address (mem, length, alignment);
+	aligned = mono_aligned_address (mem, length, alignment);
 
 	aligned = VirtualAlloc (aligned, length, MEM_COMMIT, prot);
 	g_assert (aligned);
 
-	account_mem (type, (ssize_t)length);
+	mono_account_mem (type, (ssize_t)length);
 
 	return aligned;
 }
@@ -117,7 +117,7 @@ mono_vfree (void *addr, size_t length, MonoMemAccountType type)
 
 	g_assert (res);
 
-	account_mem (type, -(ssize_t)length);
+	mono_account_mem (type, -(ssize_t)length);
 
 	return 0;
 }
@@ -190,7 +190,7 @@ void*
 mono_shared_area (void)
 {
 	if (!malloced_shared_area)
-		malloced_shared_area = malloc_shared_area (0);
+		malloced_shared_area = mono_malloc_shared_area (0);
 	/* get the pid here */
 	return malloced_shared_area;
 }


### PR DESCRIPTION
Offending symbols found with:

    nm -D --defined-only libmonosgen-2.0.so | cut -d ' ' -f 3 | grep -v '^eg_\|mono_\|monoeg_\|wapi_\|ves_icall_\|sgen_\|mini_\|__jit_debug.*$' | sort

Fixes #7565.

---

Continuation of #1742.