### PR TITLE
Update gitignore, keep paths in windows format for csproj

### DIFF
--- a/msvc/scripts/genproj.cs
+++ b/msvc/scripts/genproj.cs
@@ -929,9 +929,9 @@ class MsbuildGenerator {
 		// ../class/lib/build/tmp/System.Xml.dll  [No longer possible, we should be removing this from order.xml]
 		//   /class/lib/basic/System.Core.dll
 		// <library_output>mcs.exe</library_output>
-		string build_output_dir;
+		string build_output_dir = Path.GetDirectoryName (LibraryOutput);
 		if (LibraryOutput.Contains ("/"))
-			build_output_dir = Path.GetDirectoryName (LibraryOutput);
+			build_output_dir = Path.IsPathRooted (build_output_dir) ? build_output_dir : build_output_dir.Replace("/", "\\");
 		else
 			build_output_dir = "bin\\Debug\\" + library;
 

--- a/tools/pedump/.gitignore
+++ b/tools/pedump/.gitignore
@@ -2,4 +2,5 @@
 /Makefile
 /pedump
 /pedump.exe
-
+.libs/pedump_ltshwrapper
+.libs/lt-pedump.c

--- a/tools/sgen/.gitignore
+++ b/tools/sgen/.gitignore
@@ -4,3 +4,5 @@ Makefile.in
 /sgen-grep-binprot
 /*.o
 /*.a
+.libs/sgen-grep-binprot_ltshwrapper
+.libs/lt-sgen-grep-binprot.c


### PR DESCRIPTION
1) Add temp stuff generated by tools/ to .gitignore
2) Jenkins bot updates all csproj on macOS so when I want to re-generate them locally the script overwrites, let' say:
`<OutputPath>./../../../class/lib/net_4_x-$(HostPlatform)/Facades</OutputPath>`
to
`<OutputPath>.\..\..\..\class\lib\net_4_x-$(HostPlatform)\Facades</OutputPath>`
since the second one is "more default" for msbuild and still works on macOS we can use it