### PR TITLE
[System.Net] Replace use of obsolete `SupportsIPv6` property.

### DIFF
--- a/mcs/class/System/System.Net/Dns.cs
+++ b/mcs/class/System/System.Net/Dns.cs
@@ -320,11 +320,9 @@ namespace System.Net {
 				try {
 					IPAddress newAddress = IPAddress.Parse(h_addrlist[i]);
 
-#pragma warning disable 618
-					if( (Socket.SupportsIPv6 && newAddress.AddressFamily == AddressFamily.InterNetworkV6) ||
-					    (Socket.SupportsIPv4 && newAddress.AddressFamily == AddressFamily.InterNetwork) )
+					if( (Socket.OSSupportsIPv6 && newAddress.AddressFamily == AddressFamily.InterNetworkV6) ||
+					    (Socket.OSSupportsIPv4 && newAddress.AddressFamily == AddressFamily.InterNetwork) )
 						addrlist.Add(newAddress);
-#pragma warning restore 618
 				} catch (ArgumentNullException) {
 					/* Ignore this, as the
 					 * internal call might have

--- a/mcs/class/System/Test/System.Net/DnsTest.cs
+++ b/mcs/class/System/Test/System.Net/DnsTest.cs
@@ -210,6 +210,13 @@ namespace MonoTests.System.Net
 		}
 
 		[Test]
+		[Category("NotOnWindows")]
+		public void GetHostAddresses_IPv6 ()
+		{
+			var address = Dns.GetHostAddresses("ipv6.google.com");
+		}
+
+		[Test]
 		public void GetHostName ()
 		{
 			string hostName = Dns.GetHostName ();

--- a/mcs/class/System/Test/System.Net/IPAddressTest.cs
+++ b/mcs/class/System/Test/System.Net/IPAddressTest.cs
@@ -241,9 +241,6 @@ public class IPAddressTest
 	[Test]
 	public void IsLoopbackV6 ()
 	{
-//		if (!Socket.SupportsIPv6)
-//			Assert.Ignore ("IPv6 must be enabled in machine.config");
-
 		IPAddress ip = IPAddress.IPv6Loopback;
 		Assert.IsTrue (IPAddress.IsLoopback (ip), "#1");
 
@@ -612,9 +609,6 @@ public class IPAddressTest
 	[Test]
 	public void ParseWrongV6 ()
 	{
-		//if (!Socket.SupportsIPv6)
-		//	Assert.Ignore ("IPv6 must be enabled in machine.config");
-
 		for (int i = 0; i < ipv6ParseWrong.Length; i++) {
 			string ipAddress = ipv6ParseWrong [i];
 


### PR DESCRIPTION
The obsolete property was always set to false. Fixes https://github.com/mono/mono/issues/6940