### PR TITLE
[threads] Delay abort via handler block guard when in abort protected block.

### DIFF
--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -641,6 +641,7 @@ typedef struct {
 	void (*mono_raise_exception_with_ctx) (MonoException *ex, MonoContext *ctx);
 	gboolean (*mono_exception_walk_trace) (MonoException *ex, MonoInternalExceptionFrameWalk func, gpointer user_data);
 	gboolean (*mono_install_handler_block_guard) (MonoThreadUnwindState *unwind_state);
+	void (*mono_uninstall_current_handler_block_guard) (void);
 	gboolean (*mono_current_thread_has_handle_block_guard) (void);
 	gboolean (*mono_above_abort_threshold) (void);
 	void (*mono_clear_abort_threshold) (void);

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -238,7 +238,7 @@ void mono_threads_set_shutting_down (void);
 gunichar2* mono_thread_get_name (MonoInternalThread *this_obj, guint32 *name_len);
 
 MONO_API MonoException* mono_thread_get_undeniable_exception (void);
-void mono_thread_self_abort (void);
+void ves_icall_thread_finish_async_abort (void);
 
 MONO_PROFILER_API void mono_thread_set_name_internal (MonoInternalThread *this_obj, MonoString *name, gboolean permanent, gboolean reset, MonoError *error);
 

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -11522,7 +11522,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 					NEW_BBLOCK (cfg, dont_throw);
 					MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, abort_exc->dreg, 0);
 					MONO_EMIT_NEW_BRANCH_BLOCK (cfg, OP_PBEQ, dont_throw);
-					mono_emit_jit_icall (cfg, mono_thread_self_abort, NULL);
+					mono_emit_jit_icall (cfg, ves_icall_thread_finish_async_abort, NULL);
 					cfg->cbb->clause_holes = tmp;
 
 					MONO_START_BB (cfg, dont_throw);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4206,7 +4206,7 @@ register_icalls (void)
 	register_dyn_icall (mono_get_rethrow_exception (), "mono_arch_rethrow_exception", "void object", TRUE);
 	register_dyn_icall (mono_get_throw_corlib_exception (), "mono_arch_throw_corlib_exception", "void ptr", TRUE);
 	register_icall (mono_thread_get_undeniable_exception, "mono_thread_get_undeniable_exception", "object", FALSE);
-	register_icall (mono_thread_self_abort, "mono_thread_self_abort", "void", FALSE);
+	register_icall (ves_icall_thread_finish_async_abort, "ves_icall_thread_finish_async_abort", "void", FALSE);
 	register_icall (mono_thread_interruption_checkpoint, "mono_thread_interruption_checkpoint", "object", FALSE);
 	register_icall (mono_thread_force_interruption_checkpoint_noraise, "mono_thread_force_interruption_checkpoint_noraise", "object", FALSE);
 

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -970,7 +970,6 @@ CI_PR_DISABLED_TESTS = \
 
 if ENABLE_COOP
 CI_PR_DISABLED_TESTS += \
-	abort-cctor.exe \
 	bug-58782-plain-throw.exe \
 	bug-58782-capture-and-throw.exe
 endif


### PR DESCRIPTION
`mono_install_handler_block_guard` is called when we want to signal an async
abort to another thread.  In case the other thread is executing native code
while in a `finally` block, the handler block guard sets a byte in the finally
block that used to trigger a self abort (`mono_thread_self_abort`).

This PR renames `mono_thread_self_abort` to
`ves_icall_thread_finish_async_abort`.  It also changes the code from
immediately executing a synchronous abort, to checking whether we are in an
abort protected block (most commonly - whether we were called from a cctor) and
in that case merely toggling the "async interrupt"
MonoInternalThread:thread_state bit.  If we're not in an abort-protected block,
trigger a self interrupt (which will turn into an abort exception in the
icall wrapper of `ves_icall_thread_finish_async_abort`).

Fixes #7588 