### PR TITLE
[sgen] Use current nursery size when computing allowance

### DIFF
--- a/mono/sgen/sgen-memory-governor.c
+++ b/mono/sgen/sgen-memory-governor.c
@@ -23,7 +23,13 @@
 #include "mono/sgen/sgen-workers.h"
 #include "mono/sgen/sgen-client.h"
 
-#define MIN_MINOR_COLLECTION_ALLOWANCE	((mword)(sgen_nursery_size * default_allowance_nursery_size_ratio))
+/*
+ * The allowance we are targeting is a third of the current heap size. Still, we
+ * allow the heap to grow at least 4 times the nursery size before triggering a
+ * major, to reduce unnecessary collections. We make sure we don't set the minimum
+ * allowance too high when using a soft heap limit.
+ */
+#define MIN_MINOR_COLLECTION_ALLOWANCE	(MIN(((mword)(sgen_nursery_size * default_allowance_nursery_size_ratio)), (soft_heap_limit * SGEN_DEFAULT_ALLOWANCE_HEAP_SIZE_RATIO)))
 
 static SgenPointerQueue log_entries = SGEN_POINTER_QUEUE_INIT (INTERNAL_MEM_TEMPORARY);
 static mono_mutex_t log_entries_mutex;

--- a/mono/sgen/sgen-memory-governor.c
+++ b/mono/sgen/sgen-memory-governor.c
@@ -23,7 +23,7 @@
 #include "mono/sgen/sgen-workers.h"
 #include "mono/sgen/sgen-client.h"
 
-#define MIN_MINOR_COLLECTION_ALLOWANCE	((mword)(SGEN_DEFAULT_NURSERY_SIZE * default_allowance_nursery_size_ratio))
+#define MIN_MINOR_COLLECTION_ALLOWANCE	((mword)(sgen_nursery_size * default_allowance_nursery_size_ratio))
 
 static SgenPointerQueue log_entries = SGEN_POINTER_QUEUE_INIT (INTERNAL_MEM_TEMPORARY);
 static mono_mutex_t log_entries_mutex;


### PR DESCRIPTION
The allowance is the minimum heap growth that we allow between two majors (which is 4 * nursery_size). We need to use the current nursery size instead of the 4MB default, in order to facilitate low memory uses.

Fixes #7597

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
