### PR TITLE
[merp] only target macOS, HOST_DARWIN includes iOS etc. as well

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5711,7 +5711,7 @@ ves_icall_Mono_RuntimeMarshal_FreeAssemblyName (MonoAssemblyName *aname, gboolea
 ICALL_EXPORT void
 ves_icall_Mono_Runtime_DisableMicrosoftTelemetry (void)
 {
-#ifdef HOST_DARWIN
+#ifdef TARGET_OSX
 	mono_merp_disable ();
 #else
 	// Icall has platform check in managed too.
@@ -5722,7 +5722,7 @@ ves_icall_Mono_Runtime_DisableMicrosoftTelemetry (void)
 ICALL_EXPORT void
 ves_icall_Mono_Runtime_EnableMicrosoftTelemetry (char *appBundleID, char *appSignature, char *appVersion, char *merpGUIPath)
 {
-#ifdef HOST_DARWIN
+#ifdef TARGET_OSX
 	mono_merp_enable (appBundleID, appSignature, appVersion, merpGUIPath);
 #else
 	// Icall has platform check in managed too.

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2716,7 +2716,7 @@ mono_handle_native_crash (const char *signal, void *ctx, MONO_SIG_HANDLER_INFO_T
 		}
 #endif
 
-#if defined(HOST_DARWIN)
+#if defined(TARGET_OSX)
 		if (mono_merp_enabled ()) {
 			if (pid == 0) {
 				MonoContext mctx;

--- a/mono/utils/mono-merp.c
+++ b/mono/utils/mono-merp.c
@@ -12,7 +12,7 @@
 #include <config.h>
 #include <glib.h>
 
-#ifdef HOST_DARWIN
+#ifdef TARGET_OSX
 #include "mono-merp.h"
 
 #include <unistd.h>
@@ -496,5 +496,5 @@ mono_merp_enabled (void)
 	return config.enable_merp;
 }
 
-#endif // HOST_DARWIN
+#endif // TARGET_OSX
 

--- a/mono/utils/mono-merp.h
+++ b/mono/utils/mono-merp.h
@@ -14,7 +14,7 @@
 #include <config.h>
 #include <glib.h>
 
-#ifdef HOST_DARWIN
+#ifdef TARGET_OSX
 
 /**
  * Unregister the MERP-based handler
@@ -48,6 +48,6 @@ gboolean mono_merp_enabled (void);
 void mono_merp_invoke (pid_t crashed_pid, intptr_t thread_pointer, const char *signal);
 
 
-#endif // HOST_DARWIN
+#endif // TARGET_OSX
 
 #endif // MONO_UTILS_MERP


### PR DESCRIPTION
fixes `xamarin-macios` build. needs to be backported to `2017-12` and `2018-02.

Fixes this error:
```
  CC       mono-merp.lo
/Users/lewurm/work/xamarin-macios-MASTER/xamarin-macios/external/mono/mono/utils/mono-merp.c:26:10: fatal error: 'servers/bootstrap.h' file not found
#include <servers/bootstrap.h>
         ^~~~~~~~~~~~~~~~~~~~~
1 error generated.
make[3]: *** [mono-merp.lo] Error 1
```