### PR TITLE
[2018-02] [corlib] Handle multiple segments in IsolatedStored::GetFileNames. Fixes bxc #11771

### DIFF
--- a/mcs/class/corlib/Test/System.IO.IsolatedStorage/IsolatedStorageFileTest.cs
+++ b/mcs/class/corlib/Test/System.IO.IsolatedStorage/IsolatedStorageFileTest.cs
@@ -1118,5 +1118,17 @@ namespace MonoTests.System.IO.IsolatedStorageTest {
 				isf.DeleteDirectory ("/test");
 			}
 		}
+
+		[Test] //fixes bxc #11771
+	    public void GetFileNamesWithMultiSegmentDirectory ()
+	    {
+			string dir = Path.Combine("Dir", "Level");
+			using (var f = IsolatedStorageFile.GetUserStoreForAssembly ())
+			{
+				f.CreateDirectory (dir);
+				f.GetFileNames (Path.Combine (dir, "*"));
+				f.DeleteDirectory (dir);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Backport of #7618.

/cc @marek-safar