### PR TITLE
[mcs] Fixes parsing ref-struct with partial keyword

### DIFF
--- a/mcs/errors/cs1525-27.cs
+++ b/mcs/errors/cs1525-27.cs
@@ -1,4 +1,4 @@
-// CS1525: Unexpected symbol `fe', expecting `class', `delegate', `enum', `interface', `partial', or `struct'
+// CS1525: Unexpected symbol `fe', expecting `class', `delegate', `enum', `interface', `partial', `ref', or `struct'
 // Line: 6
 
 namespace X

--- a/mcs/mcs/cs-parser.jay
+++ b/mcs/mcs/cs-parser.jay
@@ -40,7 +40,9 @@ namespace Mono.CSharp
 		}
 		
 		static readonly object ModifierNone = 0;
-	
+		static readonly object RefStructToken = new object ();
+		static readonly object RefPartialStructToken = new object ();
+
 		NamespaceContainer current_namespace;
 		TypeContainer current_container;
 		TypeDefinition current_type;
@@ -338,6 +340,7 @@ namespace Mono.CSharp
 %token OPEN_BRACKET_EXPR
 %token OPEN_PARENS_DECONSTRUCT
 %token REF_STRUCT
+%token REF_PARTIAL
 
 // Make the parser go into eval mode parsing (statements and compilation units).
 %token EVAL_STATEMENT_PARSER
@@ -1028,7 +1031,15 @@ struct_keyword
 			FeatureIsNotAvailable (GetLocation ($1), "ref structs");
 		}
 
-		$$ = this;
+		$$ = RefStructToken;
+	  }
+	| REF_PARTIAL STRUCT
+	  {
+		if (lang_version < LanguageVersion.V_7_2) {
+			FeatureIsNotAvailable (GetLocation ($1), "ref structs");
+		}
+
+		$$ = RefPartialStructToken;
 	  }
 	;
 
@@ -1043,8 +1054,13 @@ struct_declaration
 		if ((mods & Modifiers.READONLY) != 0 && lang_version < LanguageVersion.V_7_2) {
 			FeatureIsNotAvailable (GetLocation ($4), "readonly structs");
 		}
-		if ($4 != null)
+		if ($4 != null) {
 			mods |= Modifiers.REF;
+			if ($4 == RefPartialStructToken) {
+				mods |= Modifiers.PARTIAL;
+				$3 = $4;
+			}
+		}
 
 		lexer.ConstraintsParsing = true;
 		valid_param_mod = ParameterModifierType.PrimaryConstructor;
@@ -8430,6 +8446,8 @@ static string GetTokenName (int token)
 	case Token.READONLY:
 		return "readonly";
 	case Token.REF:
+	case Token.REF_STRUCT:
+	case Token.REF_PARTIAL:
 		return "ref";
 	case Token.RETURN:
 		return "return";
@@ -8444,7 +8462,6 @@ static string GetTokenName (int token)
 	case Token.STATIC:
 		return "static";
 	case Token.STRUCT:
-	case Token.REF_STRUCT:
 		return "struct";
 	case Token.SWITCH:
 		return "switch";

--- a/mcs/mcs/cs-tokenizer.cs
+++ b/mcs/mcs/cs-tokenizer.cs
@@ -825,8 +825,7 @@ namespace Mono.CSharp
 					next_token == Token.CLASS ||
 					next_token == Token.STRUCT ||
 					next_token == Token.INTERFACE ||
-					next_token == Token.VOID ||
-					next_token == Token.REF_STRUCT;
+					next_token == Token.VOID;
 
 				PopPosition ();
 
@@ -916,13 +915,19 @@ namespace Mono.CSharp
 
 				break;
 			case Token.REF:
-				if (peek_token () == Token.STRUCT) {
+				var pp = peek_token ();
+				switch (pp) {
+				case Token.STRUCT:
 					token ();
 					res = Token.REF_STRUCT;
+					break;
+				case Token.PARTIAL:
+					token ();
+					res = Token.REF_PARTIAL;
+					break;
 				}
 				break;
 			}
-
 
 			return res;
 		}

--- a/mcs/tests/test-ref-07.cs
+++ b/mcs/tests/test-ref-07.cs
@@ -1,6 +1,6 @@
 // Compiler options: -langversion:latest
 
-public readonly partial ref struct Test
+public readonly ref partial struct Test
 {
 	public static void Main ()
 	{
@@ -12,6 +12,11 @@ public readonly partial ref struct Test
 	{
 		return new Test ();
 	}
+}
+
+ref partial struct Test
+{
+
 }
 
 ref struct Second


### PR DESCRIPTION

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
