### PR TITLE
[2017-12] [sdks] IOS fixes. (#7617)

### DIFF
--- a/sdks/builds/bcl.mk
+++ b/sdks/builds/bcl.mk
@@ -2,20 +2,20 @@
 .stamp-bcl-toolchain:
 	touch $@
 
-bcl_ios_CONFIGURE_FLAGS = \
-	--with-monotouch=yes \
-	--with-monotouch_tv=yes \
-	--with-xammac=yes \
-	--with-monotouch_watch=yes
+bcl-ios_CONFIGURE_FLAGS = \
+       --with-monotouch=yes \
+       --with-monotouch_tv=yes \
+       --with-xammac=yes \
+       --with-monotouch_watch=yes
 
 bcl_CONFIGURE_FLAGS = \
-	--with-profile4_x=no \
-	$(if $(DISABLE_ANDROID),,--with-monodroid=yes) \
-	$(if $(DISABLE_IOS),,$(bcl_ios_CONFIGURE_FLAGS)) \
-	$(if $(DISABLE_WASM),,--with-wasm=yes) \
-	--with-mcs-docs=no \
-	--disable-nls \
-	--disable-boehm
+       --with-profile4_x=no \
+       $(if $(DISABLE_ANDROID),,--with-monodroid=yes) \
+       $(if $(DISABLE_IOS),,$(bcl-ios_CONFIGURE_FLAGS)) \
+       $(if $(DISABLE_WASM),,--with-wasm=yes) \
+       --with-mcs-docs=no \
+       --disable-nls \
+       --disable-boehm
 
 .stamp-bcl-configure: $(TOP)/configure
 	mkdir -p $(TOP)/sdks/builds/bcl

--- a/sdks/builds/ios.mk
+++ b/sdks/builds/ios.mk
@@ -373,15 +373,15 @@ _ios-$(1)_CONFIGURE_FLAGS= \
 .stamp-ios-$(1)-toolchain:
 	touch $$@
 
-.stamp-ios-$(1)-configure-$$(CONFIGURATION): | build-ios-llvm
+.stamp-ios-$(1)-$$(CONFIGURATION)-configure: | build-ios-llvm
 
-$$(TOP)/sdks/builds/ios-$(1)-$$(CONFIGURATION)/$(4).h: .stamp-ios-$(1)-configure-$$(CONFIGURATION) $$(TOP)/tools/offsets-tool/MonoAotOffsetsDumper.exe
+$$(TOP)/sdks/builds/ios-$(1)-$$(CONFIGURATION)/$(4).h: .stamp-ios-$(1)-$$(CONFIGURATION)-configure $$(TOP)/tools/offsets-tool/MonoAotOffsetsDumper.exe
 	cd $$(TOP)/sdks/builds/ios-$(1)-$$(CONFIGURATION) && \
 		MONO_PATH=$(TOP)/tools/offsets-tool/CppSharp/osx_32 \
 			mono --arch=32 --debug $$(TOP)/tools/offsets-tool/MonoAotOffsetsDumper.exe \
 				--gen-ios --abi $$(_ios-$(1)_OFFSET_TOOL_ABI) --outfile $$@ --mono $$(TOP) --targetdir $$(TOP)/sdks/builds/ios-$(1)-$$(CONFIGURATION)
 
-build-ios-$(1)-$$(CONFIGURATION): $$(TOP)/sdks/builds/ios-$(1)-$$(CONFIGURATION)/$(4).h
+build-custom-ios-$(1):: $$(TOP)/sdks/builds/ios-$(1)-$$(CONFIGURATION)/$(4).h
 
 $$(eval $$(call RuntimeTemplate,ios-$(1)))
 

--- a/sdks/builds/runtime.mk
+++ b/sdks/builds/runtime.mk
@@ -55,7 +55,7 @@ __$(1)_CONFIGURE_ENVIRONMENT = \
 .stamp-$(1)-configure: .stamp-$(1)-$$(CONFIGURATION)-configure
 
 .PHONY: build-custom-$(1)
-build-custom-$(1):
+build-custom-$(1)::
 	$$(MAKE) -C $(1)-$$(CONFIGURATION)
 
 .PHONY: setup-custom-$(1)
@@ -65,6 +65,10 @@ setup-custom-$(1):
 .PHONY: package-android-$(1)-$$(CONFIGURATION)
 package-android-$(1)-$$(CONFIGURATION)::
 	$$(MAKE) -C $$(TOP)/sdks/builds/android-$(1)-$$(CONFIGURATION)/mono install
+
+.PHONY: package-$(1)-$$(CONFIGURATION)
+package-$(1)-$$(CONFIGURATION)::
+	$$(MAKE) -C $$(TOP)/sdks/builds/$(1)-$$(CONFIGURATION)/mono install
 
 .PHONY: package-$(1)
 package-$(1):


### PR DESCRIPTION
* [sdks] Fix ios build.

* [sdks] Pass -DMONOTOUCH to the ios cross compiler builds. Compile monotouch/tvos/watchos profiles for the bcl build.