### PR TITLE
[System.Windows.Forms] Improve logic for closing complex ToolStripDropDown layouts.

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms.X11Internal/X11Hwnd.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms.X11Internal/X11Hwnd.cs
@@ -1422,6 +1422,7 @@ namespace System.Windows.Forms.X11Internal {
 
 		public bool SetOwner (X11Hwnd owner)
 		{
+			this.owner = owner;
 			if (owner != null) {
 				WINDOW_TYPE = display.Atoms._NET_WM_WINDOW_TYPE_NORMAL;
 				if (owner != null)

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms.X11Internal/XplatUIX11-new.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms.X11Internal/XplatUIX11-new.cs
@@ -511,10 +511,14 @@ namespace System.Windows.Forms.X11Internal {
 			Hwnd	hwnd;
 
 			hwnd = Hwnd.ObjectFromHandle(handle);
-			if (hwnd != null && hwnd.parent != null) {
-				return hwnd.parent.Handle;
+			if (hwnd != null) {
+				if (hwnd.parent != null) {
+					return hwnd.parent.Handle;
+				}
+				if (hwnd.owner != null && with_owner) {
+					return hwnd.owner.Handle;
+				}
 			}
-			// FIXME: Handle with_owner
 			return IntPtr.Zero;
 		}
 

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ComboBox.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ComboBox.cs
@@ -2776,6 +2776,7 @@ namespace System.Windows.Forms
 				if (this.Location.Y + this.Height >= scrn_rect.Bottom)
 					this.Location = new Point (this.Location.X, this.Location.Y - (this.Height + owner.TextArea.Height));
 				Show ();
+				XplatUI.SetOwner (Handle, owner.Handle);
 
 				Refresh ();
 				owner.OnDropDown (EventArgs.Empty);

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Hwnd.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Hwnd.cs
@@ -55,6 +55,7 @@ namespace System.Windows.Forms {
 		internal int		height;
 		internal bool		allow_drop;
 		internal Hwnd		parent;
+		internal Hwnd		owner;
 		internal bool		visible;
 		internal bool		mapped;
 		internal uint		opacity;

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUICarbon.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUICarbon.cs
@@ -1291,10 +1291,14 @@ namespace System.Windows.Forms {
 			Hwnd	hwnd;
 
 			hwnd = Hwnd.ObjectFromHandle(handle);
-			if (hwnd != null && hwnd.Parent != null) {
-				return hwnd.Parent.Handle;
+			if (hwnd != null) {
+				if (hwnd.parent != null) {
+					return hwnd.parent.Handle;
+				}
+				if (hwnd.owner != null && with_owner) {
+					return hwnd.owner.Handle;
+				}
 			}
-			// FIXME: Handle with_owner
 			return IntPtr.Zero;
 		}
 
@@ -1830,6 +1834,12 @@ namespace System.Windows.Forms {
 		
 		internal override bool SetOwner(IntPtr hWnd, IntPtr hWndOwner) {
 			// TODO: Set window owner. 
+			Hwnd hwnd = Hwnd.ObjectFromHandle(hWnd);			
+			if (hWndOwner != IntPtr.Zero) {
+				hwnd.owner = Hwnd.ObjectFromHandle(hWndOwner);
+			} else {
+				hwnd.owner = null;
+			}
 			return true;
 		}
 		


### PR DESCRIPTION
Fixes the logic for closing ToolStripDropDowns for the following cases:
* ComboBox embedded in ToolStripDropDown as seen in KeePass when the window is resized to be small enough for the toolbar to overflow.
* ToolStripDropDown containing controls that open other ToolStripDropDowns and the user clicks on the top-level ToolStripDropDown. The child ToolStripDropDown, and only that child, should be closed in that case.