### PR TITLE
[2018-02] [mono-time] Replace mono_msec_boottime() with CoreCLR implementation.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1663,6 +1663,33 @@ if test x$platform_android = xyes; then
 fi
 
 if test x$host_win32 = xno; then
+	dnl *************************************
+	dnl *** Checks for time capabilities ***
+	dnl *************************************
+
+	AC_MSG_CHECKING(for CLOCK_MONOTONIC)
+	AC_TRY_COMPILE([#include <time.h>], [
+		const int foo = CLOCK_MONOTONIC;
+	],[
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_CLOCK_MONOTONIC, 1, [CLOCK_MONOTONIC])
+	], [
+		AC_MSG_RESULT(no)
+	])
+
+	AC_MSG_CHECKING(for CLOCK_MONOTONIC_COARSE)
+	AC_TRY_COMPILE([#include <time.h>], [
+		const int foo = CLOCK_MONOTONIC_COARSE;
+	],[
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_CLOCK_MONOTONIC_COARSE, 1, [CLOCK_MONOTONIC_COARSE])
+	], [
+		AC_MSG_RESULT(no)
+	])
+
+	AC_CHECK_FUNC(mach_absolute_time, [AC_DEFINE(HAVE_MACH_ABSOLUTE_TIME, 1, [mach_absolute_time])])
+	AC_CHECK_FUNC(gethrtime, [AC_DEFINE(HAVE_GETHRTIME, 1, [gethrtime])])
+	AC_CHECK_FUNC(read_real_time, [AC_DEFINE(HAVE_READ_REAL_TIME, 1, [read_real_time])])
 
 	dnl hires monotonic clock support
 	AC_SEARCH_LIBS(clock_gettime, rt)

--- a/mono/utils/mono-time.c
+++ b/mono/utils/mono-time.c
@@ -9,6 +9,7 @@
 #include <config.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <errno.h>
 
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
@@ -18,6 +19,18 @@
 
 
 #define MTICKS_PER_SEC (10 * 1000 * 1000)
+
+typedef enum _TimeConversionConstants
+{
+	tccSecondsToMillieSeconds       = 1000,         // 10^3
+	tccSecondsToMicroSeconds        = 1000000,      // 10^6
+	tccSecondsToNanoSeconds         = 1000000000,   // 10^9
+	tccMillieSecondsToMicroSeconds  = 1000,         // 10^3
+	tccMillieSecondsToNanoSeconds   = 1000000,      // 10^6
+	tccMicroSecondsToNanoSeconds    = 1000,         // 10^3
+	tccSecondsTo100NanoSeconds      = 10000000,     // 10^7
+	tccMicroSecondsTo100NanoSeconds = 10            // 10^1
+} TimeConversionConstants;
 
 gint64
 mono_msec_ticks (void)
@@ -126,16 +139,57 @@ get_boot_time (void)
 }
 
 /* Returns the number of milliseconds from boot time: this should be monotonic */
+/* Adapted from CoreCLR: https://github.com/dotnet/coreclr/blob/66d2738ea96fcce753dec1370e79a0c78f7b6adb/src/pal/src/misc/time.cpp */
 gint64
 mono_msec_boottime (void)
 {
-	static gint64 boot_time = 0;
-	gint64 now;
-	if (!boot_time)
-		boot_time = get_boot_time ();
-	now = mono_100ns_datetime ();
-	/*printf ("now: %llu (boot: %llu) ticks: %llu\n", (gint64)now, (gint64)boot_time, (gint64)(now - boot_time));*/
-	return (now - boot_time)/10000;
+	gint64 retval = 0;
+
+#if HAVE_CLOCK_MONOTONIC_COARSE || HAVE_CLOCK_MONOTONIC
+	clockid_t clockType =
+#if HAVE_CLOCK_MONOTONIC_COARSE
+	CLOCK_MONOTONIC_COARSE; /* good enough resolution, fastest speed */
+#else
+	CLOCK_MONOTONIC;
+#endif
+	struct timespec ts;
+	if (clock_gettime (clockType, &ts) != 0) {
+		g_error ("clock_gettime(CLOCK_MONOTONIC*) failed; errno is %d", errno, strerror (errno));
+		goto exit;
+	}
+	retval = (ts.tv_sec * tccSecondsToMillieSeconds) + (ts.tv_nsec / tccMillieSecondsToNanoSeconds);
+
+#elif HAVE_MACH_ABSOLUTE_TIME
+	/* use denom == 0 to indicate that s_TimebaseInfo is uninitialised. */
+	if (s_TimebaseInfo.denom == 0) {
+		g_error ("s_TimebaseInfo is uninitialized.");
+		goto exit;
+	}
+	retval = (mach_absolute_time () * s_TimebaseInfo.numer / s_TimebaseInfo.denom) / tccMillieSecondsToNanoSeconds;
+
+#elif HAVE_GETHRTIME
+	retval = (gint64)(gethrtime () / tccMillieSecondsToNanoSeconds);
+
+#elif HAVE_READ_REAL_TIME
+	timebasestruct_t tb;
+	read_real_time (&tb, TIMEBASE_SZ);
+	if (time_base_to_time (&tb, TIMEBASE_SZ) != 0) {
+		g_error ("time_base_to_time() failed; errno is %d (%s)", errno, strerror (errno));
+		goto exit;
+	}
+	retval = (tb.tb_high * tccSecondsToMillieSeconds) + (tb.tb_low / tccMillieSecondsToNanoSeconds);
+
+#else
+	struct timeval tv;
+	if (gettimeofday (&tv, NULL) == -1) {
+		g_error ("gettimeofday() failed; errno is %d (%s)", errno, strerror (errno));
+		goto exit;
+	}
+    retval = (tv.tv_sec * tccSecondsToMillieSeconds) + (tv.tv_usec / tccMillieSecondsToMicroSeconds);
+
+#endif /* HAVE_CLOCK_MONOTONIC */
+exit:
+	return retval;
 }
 
 /* Returns the number of 100ns ticks from unspecified time: this should be monotonic */


### PR DESCRIPTION
Backport of #7520.

/cc @alexischr