### PR TITLE
Fix for stepping in VSTU taking multiple steps to get to next line when there is a breakpoint

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -5097,9 +5097,9 @@ process_breakpoint (DebuggerTlsData *tls, gboolean from_signal)
 	
 	if (ss_reqs->len > 0)
 		ss_events = create_event_list (EVENT_KIND_STEP, ss_reqs, ji, NULL, &suspend_policy);
-	if (bp_reqs->len > 0)
+	else if (bp_reqs->len > 0)
 		bp_events = create_event_list (EVENT_KIND_BREAKPOINT, bp_reqs, ji, NULL, &suspend_policy);
-	if (kind != EVENT_KIND_BREAKPOINT)
+	else if (kind != EVENT_KIND_BREAKPOINT)
 		enter_leave_events = create_event_list (kind, NULL, ji, NULL, &suspend_policy);
 
 	mono_loader_unlock ();


### PR DESCRIPTION
process_breakpoint() will process breakpoint, stepping, and method
exit/entry events all at the same time when checking a sequence point.
So, if there is is a breakpoint and a stepping event at the same time,
the debugger agent will suspend the current thread twice, which means
you have to click the step button in the debugger client twice on that
line.  Considering only one of these events at a time seems to fix
the issue without breaking any current unit tests or showing any other
noticeable issues in testing.
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
