### PR TITLE
[RFC] [interp] turn crash in main loop into managed exception

### DIFF
--- a/mono/mini/ee.h
+++ b/mono/mini/ee.h
@@ -15,7 +15,7 @@
 #ifndef __MONO_EE_H__
 #define __MONO_EE_H__
 
-#define MONO_EE_API_VERSION 0x2
+#define MONO_EE_API_VERSION 0x3
 
 typedef struct _MonoInterpStackIter MonoInterpStackIter;
 
@@ -51,6 +51,7 @@ struct _MonoEECallbacks {
 	MonoInterpFrameHandle (*frame_get_parent) (MonoInterpFrameHandle frame);
 	void (*start_single_stepping) (void);
 	void (*stop_single_stepping) (void);
+	gboolean (*ip_in_interpreter_loop) (gpointer ip);
 };
 
 typedef struct _MonoEECallbacks MonoEECallbacks;

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -850,8 +850,12 @@ altstack_handle_and_restore (MonoContext *ctx, MonoObject *obj, gboolean stack_o
 {
 	MonoContext mctx;
 	MonoJitInfo *ji = mini_jit_info_table_find (mono_domain_get (), MONO_CONTEXT_GET_IP (ctx), NULL);
+	gboolean in_interp = FALSE;
 
 	if (!ji)
+		in_interp = mini_get_interp_callbacks ()->ip_in_interpreter_loop (MONO_CONTEXT_GET_IP (ctx));
+
+	if (!ji && !in_interp)
 		mono_handle_native_crash ("SIGSEGV", NULL, NULL);
 
 	mctx = *ctx;

--- a/mono/mini/interp-stubs.c
+++ b/mono/mini/interp-stubs.c
@@ -146,6 +146,12 @@ stub_walk_stack_with_ctx (MonoInternalStackWalk func, MonoContext *ctx, MonoUnwi
 	g_assert_not_reached ();
 }
 
+static gboolean
+stub_ip_in_interpreter_loop (gpointer ip)
+{
+	return FALSE;
+}
+
 void
 mono_interp_stub_init (void)
 {
@@ -175,5 +181,6 @@ mono_interp_stub_init (void)
 	c.frame_get_parent = stub_frame_get_parent;
 	c.start_single_stepping = stub_start_single_stepping;
 	c.stop_single_stepping = stub_stop_single_stepping;
+	c.ip_in_interpreter_loop = stub_ip_in_interpreter_loop;
 	mini_install_interp_callbacks (&c);
 }

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -5435,6 +5435,15 @@ interp_stop_single_stepping (void)
 	ss_enabled = FALSE;
 }
 
+static gboolean
+interp_ip_in_interpreter_loop (gpointer ip)
+{
+	gpointer start = (gpointer) interp_exec_method_full;
+	gpointer end = start + 0x10000;
+
+	return ip >= start && ip <= end;
+}
+
 void
 mono_ee_interp_init (const char *opts)
 {
@@ -5473,5 +5482,6 @@ mono_ee_interp_init (const char *opts)
 	c.frame_arg_to_storage = interp_frame_arg_to_storage;
 	c.start_single_stepping = interp_start_single_stepping;
 	c.stop_single_stepping = interp_stop_single_stepping;
+	c.ip_in_interpreter_loop = interp_ip_in_interpreter_loop;
 	mini_install_interp_callbacks (&c);
 }

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1874,6 +1874,12 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 	gboolean in_interp;
 
 	g_assert (ctx != NULL);
+
+	if (mini_get_interp_callbacks ()->ip_in_interpreter_loop (MONO_CONTEXT_GET_IP (ctx))) {
+		MonoException *ex = mono_get_exception_execution_engine ("Invalid interpreter state");
+		obj = (MonoObject *) ex;
+	}
+
 	if (!obj) {
 		MonoException *ex = mono_get_exception_null_reference ();
 		MonoString *msg = mono_string_new_checked (domain, "Object reference not set to an instance of an object", error);


### PR DESCRIPTION
running the following program in the interpreter:
```csharp
using System;

public class Lol {
    public static unsafe int Meh ()
    {
                int *p = (int *) 0;
                return *p;
        }

        public static void Main (string[] args) {
                System.Console.WriteLine ("Going to crash");
                System.Console.WriteLine ("done: " + Meh ());
        }
}
```

before:
```
Going to crash
Stacktrace:


Native stacktrace:

        0   mono-sgen                           0x0000000105677d33 mono_handle_native_crash + 291
        1   mono-sgen                           0x000000010576a28b altstack_handle_and_restore + 91
        2   mono-sgen                           0x0000000105789e48 interp_exec_method_full + 19992
        3   mono-sgen                           0x0000000105784c22 interp_exec_method + 50
        4   mono-sgen                           0x0000000105786c8c interp_exec_method_full + 7260
        5   mono-sgen                           0x0000000105784c22 interp_exec_method + 50
        6   mono-sgen                           0x0000000105786c8c interp_exec_method_full + 7260
        7   mono-sgen                           0x0000000105784c22 interp_exec_method + 50
        8   mono-sgen                           0x0000000105783476 interp_runtime_invoke + 598
        9   mono-sgen                           0x000000010555d408 mono_jit_runtime_invoke + 152
        10  mono-sgen                           0x00000001058b4bd3 do_runtime_invoke + 195
        11  mono-sgen                           0x00000001058ae237 mono_runtime_invoke_checked + 103
        12  mono-sgen                           0x00000001058b94fa do_exec_main_checked + 250
        13  mono-sgen                           0x00000001058b7bc3 mono_runtime_exec_main_checked + 67
        14  mono-sgen                           0x00000001058b7c16 mono_runtime_run_main_checked + 70
        15  mono-sgen                           0x000000010562863b mono_jit_exec + 427
        16  mono-sgen                           0x000000010562cb20 main_thread_handler + 640
        17  mono-sgen                           0x000000010562b000 mono_main + 9040
        18  mono-sgen                           0x0000000105547dee mono_main_with_options + 46
        19  mono-sgen                           0x000000010554748d main + 77
        20  libdyld.dylib                       0x00007fff58fba115 start + 1
        21  ???                                 0x0000000000000003 0x0 + 3

Debug info from gdb:
[...]
```
after:
```
Going to crash

Unhandled Exception:
System.ExecutionEngineException: Invalid interpreter state
[ERROR] FATAL UNHANDLED EXCEPTION: System.ExecutionEngineException: Invalid interpreter state
```

JIT output:
```
Going to crash

Unhandled Exception:
System.NullReferenceException: Object reference not set to an instance of an object
  at Lol.Main (System.String[] args) [0x0000a] in <8ee6d9bd31f94fa1952b052df683d906>:0
[ERROR] FATAL UNHANDLED EXCEPTION: System.NullReferenceException: Object reference not set to an instance of an object
  at Lol.Main (System.String[] args) [0x0000a] in <8ee6d9bd31f94fa1952b052df683d906>:0
```

Thoughts
=======

Pro:
* it gives the application a chance to recover from a fatal issue (not yet, LMF marker is missing, see below).
* runtime shuts down gracefully.

Contra:
* we can't distinguish between a segmentation fault caused by the program (unsafe code) or caused by an actual bug in the interpreter. This might hides some actual issues when the user application is wrapped around `try { ... } catch (Exception e) { retry (); }`. I think this will make bug reports worse once real users reporting issues.
* LMF marker is missing and thus we don't have a proper stack trace. We can fix it somehow I guess, but it looks like it's going to be messy.

The JIT catches this situations because of the way we implement implicit null checks. However, in the JIT case we are sure it's coming from managed code (though, it can be a code gen issue... imho we should disable that functionality when explicit null checks are enabled, but that's a different topic).


@vargaz @BrzVlad @kumpera @luhenry I would like to hear your opinions. 