### PR TITLE
[2017-12] [aot] Increase the buffer size in emit_exception_debug_info ().

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -6244,6 +6244,10 @@ emit_exception_debug_info (MonoAotCompile *acfg, MonoCompile *cfg, gboolean stor
 	seq_points_size = (store_seq_points)? mono_seq_point_info_get_write_size (seq_points) : 0;
 
 	buf_size = header->num_clauses * 256 + debug_info_size + 2048 + seq_points_size + cfg->gc_map_size;
+	if (jinfo->has_try_block_holes) {
+		MonoTryBlockHoleTableJitInfo *table = mono_jit_info_get_try_block_hole_table_info (jinfo);
+		buf_size += table->num_holes * 16;
+	}
 
 	p = buf = (guint8 *)g_malloc (buf_size);
 


### PR DESCRIPTION
Backport of #7638.

/cc @vargaz