### PR TITLE
[tests] Prevent starvation by thread doing GCs

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -965,7 +965,6 @@ CI_PR_DISABLED_TESTS = \
 	monitor-abort.exe \
 	monitor-wait-abort.exe \
 	process-stress-3.exe \
-	sleep.exe \
 	bug-80307.exe
 
 if ENABLE_COOP

--- a/mono/tests/sleep.cs
+++ b/mono/tests/sleep.cs
@@ -13,8 +13,10 @@ public class Tests
 	public static int test_0_time_drift () {
 		// Test the Thread.Sleep () is able to deal with time drifting due to interrupts
 		Thread t = new Thread (delegate () {
-				while (!finished)
+				while (!finished) {
 					GC.Collect ();
+					Thread.Yield ();
+				}
 			});
 		t.Start ();
 


### PR DESCRIPTION
On macos the stopwatch's elapsed time was regurarly getting skewed by 200-800ms. On average, yielding decreases the number of GCs by only 25%, while the elapsed time error is always less than 15ms.

Fixes https://github.com/mono/mono/issues/6999