### PR TITLE
[System]: Fix a race condition that was exposed by #7358 (see #7668).

### DIFF
--- a/mcs/class/System/System.Net/HttpWebRequest.cs
+++ b/mcs/class/System/System.Net/HttpWebRequest.cs
@@ -983,7 +983,7 @@ namespace System.Net
 				WebConnection.Debug ($"HWR GET RESPONSE: Req={ID} {oldCompletion != null}");
 				if (oldCompletion != null) {
 					oldCompletion.ThrowOnError ();
-					if (haveResponse && oldCompletion.IsCompleted)
+					if (haveResponse && oldCompletion.Task.IsCompleted)
 						return webResponse;
 					throw new InvalidOperationException ("Cannot re-call start of asynchronous " +
 								"method while a previous call is still in progress.");
@@ -1052,7 +1052,7 @@ namespace System.Net
 				try {
 					if (mustReadAll)
 						await stream.ReadAllAsync (redirect || ntlm != null, cancellationToken).ConfigureAwait (false);
-					operation.CompleteResponseRead (true);
+					operation.Finish (true);
 					response.Close ();
 				} catch (Exception e) {
 					throwMe = GetWebException (e);

--- a/mcs/class/System/System.Net/ServicePointScheduler.cs
+++ b/mcs/class/System/System.Net/ServicePointScheduler.cs
@@ -160,7 +160,7 @@ namespace System.Net
 
 					taskList.Add (schedulerEvent.WaitAsync (maxIdleTime));
 					foreach (var item in operationArray)
-						taskList.Add (item.Item2.WaitForCompletion (true));
+						taskList.Add (item.Item2.Finished.Task);
 					foreach (var item in idleArray)
 						taskList.Add (item.Item3);
 				}
@@ -170,32 +170,42 @@ namespace System.Net
 				var ret = await Task.WhenAny (taskList).ConfigureAwait (false);
 
 				lock (ServicePoint) {
-					if (ret == taskList[0]) {
-						RunSchedulerIteration ();
-						continue;
-					}
+					bool runMaster = false;
+					if (ret == taskList[0])
+						runMaster = true;
 
-					int idx = -1;
+					/*
+					 * We discard the `taskList` at this point as it is only used to wake us up.
+					 *
+					 * The `WebCompletionSource<T>` assigns its `CurrentResult` property prior
+					 * to completing the `Task` instance, so whenever a task is finished we will
+					 * also get a non-null `CurrentResult`.
+					 * 
+					 */
 					for (int i = 0; i < operationArray.Length; i++) {
-						if (ret == taskList[i + 1]) {
-							idx = i;
-							break;
-						}
-					}
+						var item = operationArray[i];
+						var result = item.Item2.Finished.CurrentResult;
+						if (result == null)
+							continue;
 
-					if (idx >= 0) {
-						var item = operationArray[idx];
-						Debug ($"MAIN LOOP #2: {idx} group={item.Item1.ID} Op={item.Item2.ID}");
+						Debug ($"MAIN LOOP #2: {i} group={item.Item1.ID} Op={item.Item2.ID} Status={result.Status}");
 						operations.Remove (item);
 
-						var opTask = (Task<ValueTuple<bool, WebOperation>>)ret;
-						var runLoop = OperationCompleted (item.Item1, item.Item2, opTask);
-						Debug ($"MAIN LOOP #2 DONE: {idx} {runLoop}");
-						if (runLoop)
-							RunSchedulerIteration ();
-						continue;
+						var runLoop = OperationCompleted (item.Item1, item.Item2);
+						Debug ($"MAIN LOOP #2 DONE: {i} {runLoop}");
+						runMaster |= runLoop;
 					}
 
+					/*
+					 * This needs to be called after we deal with pending completions to
+					 * ensure that connections are properly recognized as being idle.
+					 * 
+					 */
+					Debug ($"MAIN LOOP #3: runMaster={runMaster}");
+					if (runMaster)
+						RunSchedulerIteration ();
+
+					int idx = -1;
 					for (int i = 0; i < idleArray.Length; i++) {
 						if (ret == taskList[i + 1 + operationArray.Length]) {
 							idx = i;
@@ -205,7 +215,7 @@ namespace System.Net
 
 					if (idx >= 0) {
 						var item = idleArray[idx];
-						Debug ($"MAIN LOOP #3: {idx} group={item.Item1.ID} Cnc={item.Item2.ID}");
+						Debug ($"MAIN LOOP #4: {idx} group={item.Item1.ID} Cnc={item.Item2.ID}");
 						idleConnections.Remove (item);
 						CloseIdleConnection (item.Item1, item.Item2);
 					}
@@ -255,7 +265,7 @@ namespace System.Net
 			} while (repeat);
 		}
 
-		bool OperationCompleted (ConnectionGroup group, WebOperation operation, Task<(bool, WebOperation)> task)
+		bool OperationCompleted (ConnectionGroup group, WebOperation operation)
 		{
 #if MONO_WEB_DEBUG
 			var me = $"{nameof (OperationCompleted)}(group={group.ID}, Op={operation.ID}, Cnc={operation.Connection.ID})";
@@ -263,8 +273,10 @@ namespace System.Net
 			string me = null;
 #endif
 
-			var (ok, next) = task.Status == TaskStatus.RanToCompletion ? task.Result : (false, null);
-			Debug ($"{me}: {task.Status} {ok} {next?.ID}");
+			var result = operation.Finished.CurrentResult;
+			var (ok, next) = result.Success ? result.Argument : (false, null);
+
+			Debug ($"{me}: {operation.Finished.CurrentStatus} {ok} {next?.ID}");
 
 			if (!ok || !operation.Connection.Continue (next)) {
 				group.RemoveConnection (operation.Connection);
@@ -556,7 +568,9 @@ namespace System.Net
 
 			public (WebConnection connection, bool created) CreateOrReuseConnection (WebOperation operation, bool force)
 			{
+				Scheduler.Debug ($"CREATE OR REUSE: group={ID} OP={operation.ID} force={force}");
 				var connection = FindIdleConnection (operation);
+				Scheduler.Debug ($"CREATE OR REUSE #1: group={ID} OP={operation.ID} force={force} - connection={connection?.ID}");
 				if (connection != null)
 					return (connection, false);
 

--- a/mcs/class/System/System.Net/WebCompletionSource.cs
+++ b/mcs/class/System/System.Net/WebCompletionSource.cs
@@ -33,37 +33,67 @@ namespace System.Net
 	class WebCompletionSource<T>
 	{
 		TaskCompletionSource<Result> completion;
+		Result currentResult;
 
-		public WebCompletionSource ()
+		public WebCompletionSource (bool runAsync = true)
 		{
 			completion = new TaskCompletionSource<Result> (
-				TaskCreationOptions.RunContinuationsAsynchronously);
+				runAsync ?
+				TaskCreationOptions.RunContinuationsAsynchronously :
+				TaskCreationOptions.None);
 		}
+
+		/*
+		 * Provide a non-blocking way of getting the current status.
+		 * 
+		 * We are using `TaskCreationOptions.RunContinuationsAsynchronously`
+		 * to prevent any user continuations from being run during the
+		 * `TrySet*()` methods - to make these safe to be called while holding
+		 * internal locks.
+		 * 
+		 */
+		internal Result CurrentResult => currentResult;
+
+		internal Status CurrentStatus => currentResult?.Status ?? Status.Running;
+
+		internal Task Task => completion.Task;
 
 		public bool TrySetCompleted (T argument)
 		{
-			return completion.TrySetResult (new Result (argument));
+			var result = new Result (argument);
+			if (Interlocked.CompareExchange (ref currentResult, result, null) != null)
+				return false;
+			return completion.TrySetResult (result);
 		}
 
 		public bool TrySetCompleted ()
 		{
-			return completion.TrySetResult (new Result (State.Completed, null));
+			var result = new Result (Status.Completed, null);
+			if (Interlocked.CompareExchange (ref currentResult, result, null) != null)
+				return false;
+			return completion.TrySetResult (result);
 		}
 
 		public bool TrySetCanceled ()
 		{
-			var error = new OperationCanceledException ();
-			var result = new Result (State.Canceled, ExceptionDispatchInfo.Capture (error));
+			return TrySetCanceled (new OperationCanceledException ());
+		}
+
+		public bool TrySetCanceled (OperationCanceledException error)
+		{
+			var result = new Result (Status.Canceled, ExceptionDispatchInfo.Capture (error));
+			if (Interlocked.CompareExchange (ref currentResult, result, null) != null)
+				return false;
 			return completion.TrySetResult (result);
 		}
 
 		public bool TrySetException (Exception error)
 		{
-			var result = new Result (State.Faulted, ExceptionDispatchInfo.Capture (error));
+			var result = new Result (Status.Faulted, ExceptionDispatchInfo.Capture (error));
+			if (Interlocked.CompareExchange (ref currentResult, result, null) != null)
+				return false;
 			return completion.TrySetResult (result);
 		}
-
-		public bool IsCompleted => completion.Task.IsCompleted;
 
 		public void ThrowOnError ()
 		{
@@ -75,25 +105,27 @@ namespace System.Net
 		public async Task<T> WaitForCompletion ()
 		{
 			var result = await completion.Task.ConfigureAwait (false);
-			if (result.State == State.Completed)
+			if (result.Status == Status.Completed)
 				return (T)result.Argument;
 			// This will always throw once we get here.
 			result.Error.Throw ();
 			throw new InvalidOperationException ("Should never happen.");
 		}
 
-		enum State : int {
+		internal enum Status : int {
 			Running,
 			Completed,
 			Canceled,
 			Faulted
 		}
 
-		class Result
+		internal class Result
 		{
-			public State State {
+			public Status Status {
 				get;
 			}
+
+			public bool Success => Status == Status.Completed;
 
 			public ExceptionDispatchInfo Error {
 				get;
@@ -105,13 +137,13 @@ namespace System.Net
 
 			public Result (T argument)
 			{
-				State = State.Completed;
+				Status = Status.Completed;
 				Argument = argument;
 			}
 
-			public Result (State state, ExceptionDispatchInfo error)
+			public Result (Status state, ExceptionDispatchInfo error)
 			{
-				State = state;
+				Status = state;
 				Error = error;
 			}
 		}

--- a/mcs/class/System/System.Net/WebResponseStream.cs
+++ b/mcs/class/System/System.Net/WebResponseStream.cs
@@ -164,7 +164,7 @@ namespace System.Net
 				}
 
 				closed = true;
-				Operation.CompleteResponseRead (false, throwMe);
+				Operation.Finish (false, throwMe);
 				throw throwMe;
 			}
 
@@ -178,7 +178,7 @@ namespace System.Net
 				WebConnection.Debug ($"{ME} READ ASYNC - READ COMPLETE: {oldBytes} {nbytes} - {totalRead} {contentLength} {nextReadCalled}");
 				if (!nextReadCalled) {
 					nextReadCalled = true;
-					Operation.CompleteResponseRead (true);
+					Operation.Finish (true);
 				}
 			}
 
@@ -388,7 +388,7 @@ namespace System.Net
 						contentLength = 0;
 					nextReadCalled = true;
 				}
-				Operation.CompleteResponseRead (true);
+				Operation.Finish (true);
 			}
 		}
 
@@ -399,7 +399,7 @@ namespace System.Net
 			if (read_eof || totalRead >= contentLength || nextReadCalled) {
 				if (!nextReadCalled) {
 					nextReadCalled = true;
-					Operation.CompleteResponseRead (true);
+					Operation.Finish (true);
 				}
 				return;
 			}
@@ -506,7 +506,7 @@ namespace System.Net
 				pendingRead = null;
 			}
 
-			Operation.CompleteResponseRead (true);
+			Operation.Finish (true);
 		}
 
 		public override Task WriteAsync (byte[] buffer, int offset, int count, CancellationToken cancellationToken)
@@ -521,12 +521,12 @@ namespace System.Net
 				nextReadCalled = true;
 				if (totalRead >= contentLength) {
 					disposed = true;
-					Operation.CompleteResponseRead (true);
+					Operation.Finish (true);
 				} else {
 					// If we have not read all the contents
 					closed = true;
 					disposed = true;
-					Operation.CompleteResponseRead (false);
+					Operation.Finish (false);
 				}
 			}
 		}


### PR DESCRIPTION
The latest `WebCompletionSource<T>` changes (PR #7358) exposed and
intensified the side-effects of a race condition between `WebOperation`
and `ServicePointScheduler`.

See #7668 for an in-depth explanation of this race condition.

* `WebCompletionSource<T>` now contains new `CurrentResult` and `CurrentStatus`
  properties, which allow completion status to be checked in a non-blocking way.

* `WebOperation.CompleteResponseRead()` has been renamed into `Finish()` and
  contains the continuation that was previouly known as `FinishReading()`.
  Calling this new `Finish()` method will now complete the `finishedTask`
  completion, which has a new accessor called `Finished`.

* The ServicePointScheduler's main-loop is still woken up by completion of
  `WebOperation.Finished.Task`, but we use the new `CurrentResult` property
  to check state in a non-blocking way.  This ensures the the clean-up and
  bookkeeping work that's necessary after `WebCompletion.Finish()` always
  happens prior to starting new connections.
