### PR TITLE
Update server.py to run on both python 2 and 3

### DIFF
--- a/sdks/wasm/server.py
+++ b/sdks/wasm/server.py
@@ -1,14 +1,32 @@
-import SimpleHTTPServer
-import SocketServer
+import sys
 
-PORT = 8000
+if sys.version_info[0] == 2:
 
-class Handler(SimpleHTTPServer.SimpleHTTPRequestHandler):
-    pass
+    import SimpleHTTPServer
+    import SocketServer
 
-Handler.extensions_map['.wasm'] = 'application/wasm'
+    PORT = 8000
 
-httpd = SocketServer.TCPServer(("", PORT), Handler)
+    class Handler(SimpleHTTPServer.SimpleHTTPRequestHandler):
+        pass
 
-print "serving at port", PORT
-httpd.serve_forever()
+    Handler.extensions_map['.wasm'] = 'application/wasm'
+
+    httpd = SocketServer.TCPServer(("", PORT), Handler)
+
+    print ("python 2 serving at port", PORT)
+    httpd.serve_forever()
+
+
+if sys.version_info[0] == 3:
+    
+    import http.server
+    import socketserver
+
+    PORT = 8000
+
+    Handler = http.server.SimpleHTTPRequestHandler
+    with socketserver.TCPServer(("", PORT), Handler) as httpd:
+        print("python 3 serving at port", PORT)
+        httpd.serve_forever()
+


### PR DESCRIPTION
This is just a small python code change so users with both python 2 and 3 should be able to use the server.py



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
