### PR TITLE
[runtime] Extract the debugger code into a separate library.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1432,9 +1432,11 @@ if test "x$mono_feature_disable_simd" = "xyes"; then
 fi
 
 if test "x$mono_feature_disable_soft_debug" = "xyes"; then
-	AC_DEFINE(DISABLE_SOFT_DEBUG, 1, [Disable Soft Debugger Agent.])
+	AC_DEFINE(DISABLE_DEBUGGER_AGENT, 1, [Disable Soft Debugger Agent.])
 	AC_MSG_NOTICE([Disabled Soft Debugger.])
 fi
+
+AM_CONDITIONAL(DISABLE_DEBUGGER_AGENT, test x$mono_feature_disable_debugger_agent = xyes)
 
 if test "x$mono_feature_disable_perfcounters" = "xyes"; then
 	AC_DEFINE(DISABLE_PERFCOUNTERS, 1, [Disable Performance Counters.])

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -83,12 +83,12 @@ endif
 if SUPPORT_SGEN
 sgen_binaries = mono-sgen
 sgen_libraries = libmonosgen-2.0.la
-sgen_static_libraries = libmini.la $(interp_libs_with_mini) $(sgen_libs)
+sgen_static_libraries = libmini.la $(interp_libs_with_mini) $(dbg_libs_with_mini) $(sgen_libs)
 endif
 
 if SUPPORT_BOEHM
 boehm_libraries = libmonoboehm-2.0.la
-boehm_static_libraries = libmini.la $(interp_libs_with_mini) $(boehm_libs)
+boehm_static_libraries = libmini.la $(interp_libs_with_mini) $(dbg_libs_with_mini) $(boehm_libs)
 boehm_binaries  = mono-boehm
 endif
 
@@ -448,7 +448,7 @@ common_sources = \
 	mini-gc.h		\
 	mini-gc.c		\
 	debugger-agent.h 	\
-	debugger-agent.c	\
+	debugger-agent-stubs.c	\
 	xdebug.c			\
 	mini-llvm.h			\
 	mini-llvm-cpp.h	\
@@ -629,6 +629,23 @@ if BITCODE
 libmono_ee_interp_la_LIBADD = libmonosgen-2.0.la
 endif
 
+libmono_dbg_la_SOURCES = debugger-agent.c
+libmono_dbg_la_CFLAGS = $(mono_CFLAGS)
+if BITCODE
+libmono_dbg_la_LIBADD = libmonosgen-2.0.la
+endif
+
+dbg_libs = libmono-dbg.la
+
+if DISABLE_DEBUGGER_AGENT
+lib_LTLIBRARIES += $(dbg_libs)
+endif
+
+if !DISABLE_DEBUGGER_AGENT
+dbg_libs_with_mini = $(dbg_libs)
+noinst_LTLIBRARIES += $(dbg_libs)
+endif
+
 #
 # This library is shared between mono and mono-sgen, since the code in mini/ doesn't contain
 # compile time dependencies on boehm/sgen.
@@ -638,12 +655,12 @@ libmini_la_CFLAGS = $(mono_CFLAGS)
 
 libmonoboehm_2_0_la_SOURCES =
 libmonoboehm_2_0_la_CFLAGS = $(mono_boehm_CFLAGS)
-libmonoboehm_2_0_la_LIBADD = libmini.la $(interp_libs_with_mini) $(boehm_libs) $(LIBMONO_DTRACE_OBJECT) $(LLVMMONOF)
+libmonoboehm_2_0_la_LIBADD = libmini.la $(interp_libs_with_mini) $(dbg_libs_with_mini) $(boehm_libs) $(LIBMONO_DTRACE_OBJECT) $(LLVMMONOF)
 libmonoboehm_2_0_la_LDFLAGS = $(libmonoldflags) $(monobin_platform_ldflags)
 
 libmonosgen_2_0_la_SOURCES =
 libmonosgen_2_0_la_CFLAGS = $(mono_sgen_CFLAGS)
-libmonosgen_2_0_la_LIBADD = libmini.la $(interp_libs_with_mini) $(sgen_libs) $(LIBMONO_DTRACE_OBJECT) $(LLVMMONOF)
+libmonosgen_2_0_la_LIBADD = libmini.la $(interp_libs_with_mini) $(dbg_libs_with_mini) $(sgen_libs) $(LIBMONO_DTRACE_OBJECT) $(LLVMMONOF)
 libmonosgen_2_0_la_LDFLAGS = $(libmonoldflags) $(monobin_platform_ldflags)
 
 libmonoincludedir = $(includedir)/mono-$(API_VER)/mono/jit

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -5199,9 +5199,9 @@ load_function_full (MonoAotModule *amodule, const char *name, MonoTrampInfo **ou
 					target = mono_create_specific_trampoline (GUINT_TO_POINTER (slot), MONO_TRAMPOLINE_RGCTX_LAZY_FETCH, mono_get_root_domain (), NULL);
 					target = mono_create_ftnptr_malloc ((guint8 *)target);
 				} else if (!strcmp (ji->data.name, "debugger_agent_single_step_from_context")) {
-					target = mono_debugger_agent_single_step_from_context;
+					target = mini_get_dbg_callbacks ()->single_step_from_context;
 				} else if (!strcmp (ji->data.name, "debugger_agent_breakpoint_from_context")) {
-					target = mono_debugger_agent_breakpoint_from_context;
+					target = mini_get_dbg_callbacks ()->breakpoint_from_context;
 				} else if (!strcmp (ji->data.name, "throw_exception_addr")) {
 					target = mono_get_throw_exception_addr ();
 				} else if (strstr (ji->data.name, "generic_trampoline_")) {

--- a/mono/mini/debugger-agent-stubs.c
+++ b/mono/mini/debugger-agent-stubs.c
@@ -1,0 +1,117 @@
+/* \file
+ * Soft Debugger stubs
+ *
+ * Author:
+ *   Zoltan Varga (vargaz@gmail.com)
+ *
+ * Copyright 2009-2010 Novell, Inc.
+ * Copyright 2011 Xamarin Inc.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+#include <config.h>
+
+#include "mini-runtime.h"
+#include "debugger-agent.h"
+
+static void
+stub_debugger_agent_parse_options (char *options)
+{
+	g_error ("This runtime is configured with the debugger agent disabled.");
+}
+
+static void
+stub_debugger_agent_init (void)
+{
+}
+
+static void
+stub_debugger_agent_breakpoint_hit (void *sigctx)
+{
+}
+
+static void
+stub_debugger_agent_single_step_event (void *sigctx)
+{
+}
+
+static void
+stub_debugger_agent_free_domain_info (MonoDomain *domain)
+{
+}
+
+static void
+stub_debugger_agent_handle_exception (MonoException *exc, MonoContext *throw_ctx,
+									  MonoContext *catch_ctx, StackFrameInfo *catch_frame)
+{
+}
+
+static void
+stub_debugger_agent_begin_exception_filter (MonoException *exc, MonoContext *ctx, MonoContext *orig_ctx)
+{
+}
+
+static void
+stub_debugger_agent_end_exception_filter (MonoException *exc, MonoContext *ctx, MonoContext *orig_ctx)
+{
+}
+
+static void
+stub_debugger_agent_user_break (void)
+{
+	G_BREAKPOINT ();
+}
+
+static void
+stub_debugger_agent_debug_log (int level, MonoString *category, MonoString *message)
+{
+}
+
+static gboolean
+stub_debugger_agent_debug_log_is_enabled (void)
+{
+	return FALSE;
+}
+
+static void
+stub_debugger_agent_unhandled_exception (MonoException *exc)
+{
+	g_assert_not_reached ();
+}
+
+static void
+stub_debugger_agent_single_step_from_context (MonoContext *ctx)
+{
+	g_assert_not_reached ();
+}
+
+static void
+stub_debugger_agent_breakpoint_from_context (MonoContext *ctx)
+{
+	g_assert_not_reached ();
+}
+
+void
+mono_debugger_agent_stub_init (void)
+{
+	MonoDebuggerCallbacks cbs;
+
+	memset (&cbs, 0, sizeof (MonoDebuggerCallbacks));
+	cbs.version = MONO_DBG_CALLBACKS_VERSION;
+	cbs.parse_options = stub_debugger_agent_parse_options;
+	cbs.init = stub_debugger_agent_init;
+	cbs.breakpoint_hit = stub_debugger_agent_breakpoint_hit;
+	cbs.single_step_event = stub_debugger_agent_single_step_event;
+	cbs.single_step_from_context = stub_debugger_agent_single_step_from_context;
+	cbs.breakpoint_from_context = stub_debugger_agent_breakpoint_from_context;
+	cbs.free_domain_info = stub_debugger_agent_free_domain_info;
+	cbs.unhandled_exception = stub_debugger_agent_unhandled_exception;
+	cbs.handle_exception = stub_debugger_agent_handle_exception;
+	cbs.begin_exception_filter = stub_debugger_agent_begin_exception_filter;
+	cbs.end_exception_filter = stub_debugger_agent_end_exception_filter;
+	cbs.user_break = stub_debugger_agent_user_break;
+	cbs.debug_log = stub_debugger_agent_debug_log;
+	cbs.debug_log_is_enabled = stub_debugger_agent_debug_log_is_enabled;
+
+	mini_install_dbg_callbacks (&cbs);
+}

--- a/mono/mini/debugger-agent.h
+++ b/mono/mini/debugger-agent.h
@@ -8,50 +8,32 @@
 #include "mini.h"
 #include <mono/utils/mono-stack-unwinding.h>
 
-MONO_API void
-mono_debugger_agent_parse_options (char *options);
+#define MONO_DBG_CALLBACKS_VERSION 0x1
 
-void
+struct _MonoDebuggerCallbacks {
+	int version;
+	void (*parse_options) (char *options);
+	void (*init) (void);
+	void (*breakpoint_hit) (void *sigctx);
+	void (*single_step_event) (void *sigctx);
+	void (*single_step_from_context) (MonoContext *ctx);
+	void (*breakpoint_from_context) (MonoContext *ctx);
+	void (*free_domain_info) (MonoDomain *domain);
+	void (*unhandled_exception) (MonoException *exc);
+	void (*handle_exception) (MonoException *exc, MonoContext *throw_ctx,
+							  MonoContext *catch_ctx, StackFrameInfo *catch_frame);
+	void (*begin_exception_filter) (MonoException *exc, MonoContext *ctx, MonoContext *orig_ctx);
+	void (*end_exception_filter) (MonoException *exc, MonoContext *ctx, MonoContext *orig_ctx);
+	void (*user_break) (void);
+	void (*debug_log) (int level, MonoString *category, MonoString *message);
+	gboolean (*debug_log_is_enabled) (void);
+};
+
+MONO_API void
 mono_debugger_agent_init (void);
 
 void
-mono_debugger_agent_breakpoint_hit (void *sigctx);
-
-void
-mono_debugger_agent_single_step_event (void *sigctx);
-
-void
-mono_debugger_agent_single_step_from_context (MonoContext *ctx);
-
-void
-mono_debugger_agent_breakpoint_from_context (MonoContext *ctx);
-
-void
-mono_debugger_agent_free_domain_info (MonoDomain *domain);
-
-#if defined(HOST_ANDROID) || defined(TARGET_ANDROID)
-void
-mono_debugger_agent_unhandled_exception (MonoException *exc);
-#endif
-
-void
-mono_debugger_agent_handle_exception (MonoException *exc, MonoContext *throw_ctx,
-									  MonoContext *catch_ctx, StackFrameInfo *catch_frame);
-
-void
-mono_debugger_agent_begin_exception_filter (MonoException *exc, MonoContext *ctx, MonoContext *orig_ctx);
-
-void
-mono_debugger_agent_end_exception_filter (MonoException *exc, MonoContext *ctx, MonoContext *orig_ctx);
-
-void
-mono_debugger_agent_user_break (void);
-
-void
-mono_debugger_agent_debug_log (int level, MonoString *category, MonoString *message);
-
-gboolean
-mono_debugger_agent_debug_log_is_enabled (void);
+mono_debugger_agent_stub_init (void);
 
 MONO_API gboolean
 mono_debugger_agent_transport_handshake (void);

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1578,7 +1578,7 @@ mono_jit_parse_options (int argc, char * argv[])
  		if (strncmp (argv [i], "--debugger-agent=", 17) == 0) {
 			MonoDebugOptions *opt = mini_get_debug_options ();
 
- 			mono_debugger_agent_parse_options (argv [i] + 17);
+			sdb_options = g_strdup (argv [i] + 17);
 			opt->mdb_optimizations = TRUE;
 			enable_debugging = TRUE;
 		} else if (!strcmp (argv [i], "--soft-breakpoints")) {
@@ -2062,7 +2062,7 @@ mono_main (int argc, char* argv[])
  		} else if (strncmp (argv [i], "--debugger-agent=", 17) == 0) {
 			MonoDebugOptions *opt = mini_get_debug_options ();
 
- 			mono_debugger_agent_parse_options (argv [i] + 17);
+			sdb_options = g_strdup (argv [i] + 17);
 			opt->mdb_optimizations = TRUE;
 			enable_debugging = TRUE;
 		} else if (strcmp (argv [i], "--security") == 0) {

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -2407,7 +2407,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_BREAK)
 			++ip;
-			do_debugger_tramp (mono_debugger_agent_user_break, frame);
+			do_debugger_tramp (mini_get_dbg_callbacks ()->user_break, frame);
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_LDNULL) 
 			sp->data.p = NULL;

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -5702,7 +5702,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 			(strcmp (cmethod_klass_name, "Debugger") == 0)) {
 		if (!strcmp (cmethod->name, "Break") && fsig->param_count == 0) {
 			if (mini_should_insert_breakpoint (cfg->method)) {
-				ins = mono_emit_jit_icall (cfg, mono_debugger_agent_user_break, NULL);
+				ins = mono_emit_jit_icall (cfg, mini_get_dbg_callbacks ()->user_break, NULL);
 			} else {
 				MONO_INST_NEW (cfg, ins, OP_NOP);
 				MONO_ADD_INS (cfg->cbb, ins);
@@ -7906,7 +7906,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			break;
 		case CEE_BREAK:
 			if (mini_should_insert_breakpoint (cfg->method)) {
-				ins = mono_emit_jit_icall (cfg, mono_debugger_agent_user_break, NULL);
+				ins = mono_emit_jit_icall (cfg, mini_get_dbg_callbacks ()->user_break, NULL);
 			} else {
 				MONO_INST_NEW (cfg, ins, OP_NOP);
 			}

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1816,7 +1816,7 @@ handle_exception_first_pass (MonoContext *ctx, MonoObject *obj, gint32 *out_filt
 #endif
 					}
 
-					mono_debugger_agent_begin_exception_filter (mono_ex, ctx, &initial_ctx);
+					mini_get_dbg_callbacks ()->begin_exception_filter (mono_ex, ctx, &initial_ctx);
 
 					if (G_UNLIKELY (mono_profiler_clauses_enabled ())) {
 						jit_tls->orig_ex_ctx_set = TRUE;
@@ -1829,7 +1829,7 @@ handle_exception_first_pass (MonoContext *ctx, MonoObject *obj, gint32 *out_filt
 					} else {
 						filtered = call_filter (ctx, ei->data.filter);
 					}
-					mono_debugger_agent_end_exception_filter (mono_ex, ctx, &initial_ctx);
+					mini_get_dbg_callbacks ()->end_exception_filter (mono_ex, ctx, &initial_ctx);
 					if (filtered && out_filter_idx)
 						*out_filter_idx = filter_idx;
 					if (out_ji)
@@ -2035,7 +2035,7 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 		if (res == MONO_FIRST_PASS_UNHANDLED) {
 			if (mini_get_debug_options ()->break_on_exc)
 				G_BREAKPOINT ();
-			mono_debugger_agent_handle_exception ((MonoException *)obj, ctx, NULL, NULL);
+			mini_get_dbg_callbacks ()->handle_exception ((MonoException *)obj, ctx, NULL, NULL);
 
 			if (mini_get_debug_options ()->suspend_on_unhandled) {
 				mono_runtime_printf_err ("Unhandled exception, suspending...");
@@ -2063,9 +2063,9 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 			}
 
 			if (unhandled)
-				mono_debugger_agent_handle_exception ((MonoException *)obj, ctx, NULL, NULL);
+				mini_get_dbg_callbacks ()->handle_exception ((MonoException *)obj, ctx, NULL, NULL);
 			else if (res != MONO_FIRST_PASS_CALLBACK_TO_NATIVE)
-				mono_debugger_agent_handle_exception ((MonoException *)obj, ctx, &ctx_cp, &catch_frame);
+				mini_get_dbg_callbacks ()->handle_exception ((MonoException *)obj, ctx, &ctx_cp, &catch_frame);
 		}
 	}
 

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -339,6 +339,7 @@ extern GHashTable *mono_single_method_hash;
 extern GList* mono_aot_paths;
 extern MonoDebugOptions mini_debug_options;
 extern GSList *mono_interp_only_classes;
+extern char *sdb_options;
 
 /*
 This struct describes what execution engine feature to use.
@@ -383,6 +384,11 @@ MONO_API char       *mono_parse_options_from        (const char *options, int *r
 void                   mono_interp_stub_init         (void);
 void                   mini_install_interp_callbacks (MonoEECallbacks *cbs);
 MonoEECallbacks*       mini_get_interp_callbacks     (void);
+
+typedef struct _MonoDebuggerCallbacks MonoDebuggerCallbacks;
+
+void                   mini_install_dbg_callbacks (MonoDebuggerCallbacks *cbs);
+MonoDebuggerCallbacks  *mini_get_dbg_callbacks (void);
 
 MonoDomain* mini_init                      (const char *filename, const char *runtime_version);
 void        mini_cleanup                   (MonoDomain *domain);

--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -885,9 +885,9 @@ mono_arch_create_sdb_trampoline (gboolean single_step, MonoTrampInfo **info, gbo
 			code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, "debugger_agent_breakpoint_from_context");
 	} else {
 		if (single_step)
-			amd64_mov_reg_imm (code, AMD64_R11, mono_debugger_agent_single_step_from_context);
+			amd64_mov_reg_imm (code, AMD64_R11, mini_get_dbg_callbacks ()->single_step_from_context);
 		else
-			amd64_mov_reg_imm (code, AMD64_R11, mono_debugger_agent_breakpoint_from_context);
+			amd64_mov_reg_imm (code, AMD64_R11, mini_get_dbg_callbacks ()->breakpoint_from_context);
 	}	
 	amd64_call_reg (code, AMD64_R11);
 

--- a/mono/mini/tramp-arm.c
+++ b/mono/mini/tramp-arm.c
@@ -786,9 +786,9 @@ mono_arch_create_sdb_trampoline (gboolean single_step, MonoTrampInfo **info, gbo
 		ARM_LDR_IMM (code, ARMREG_IP, ARMREG_PC, 0);
 		ARM_B (code, 0);
 		if (single_step)
-			*(gpointer*)code = mono_debugger_agent_single_step_from_context;
+			*(gpointer*)code = mini_get_dbg_callbacks ()->single_step_from_context;
 		else
-			*(gpointer*)code = mono_debugger_agent_breakpoint_from_context;
+			*(gpointer*)code = mini_get_dbg_callbacks ()->breakpoint_from_context;
 		code += 4;
 		ARM_BLX_REG (code, ARMREG_IP);
 	}

--- a/mono/mini/tramp-arm64.c
+++ b/mono/mini/tramp-arm64.c
@@ -515,7 +515,7 @@ mono_arch_create_general_rgctx_lazy_fetch_trampoline (MonoTrampInfo **info, gboo
  * mono_arch_create_sdb_trampoline:
  *
  *   Return a trampoline which captures the current context, passes it to
- * mono_debugger_agent_single_step_from_context ()/mono_debugger_agent_breakpoint_from_context (),
+ * mini_get_dbg_callbacks ()->single_step_from_context ()/mini_get_dbg_callbacks ()->breakpoint_from_context (),
  * then restores the (potentially changed) context.
  */
 guint8*
@@ -581,7 +581,7 @@ mono_arch_create_sdb_trampoline (gboolean single_step, MonoTrampInfo **info, gbo
 		else
 			code = mono_arm_emit_aotconst (&ji, code, buf, ARMREG_IP0, MONO_PATCH_INFO_JIT_ICALL_ADDR, "debugger_agent_breakpoint_from_context");
 	} else {
-		gpointer addr = single_step ? mono_debugger_agent_single_step_from_context : mono_debugger_agent_breakpoint_from_context;
+		gpointer addr = single_step ? mini_get_dbg_callbacks ()->single_step_from_context : mini_get_dbg_callbacks ()->breakpoint_from_context;
 
 		code = mono_arm_emit_imm64 (code, ARMREG_IP0, (guint64)addr);
 	}

--- a/mono/mini/tramp-x86.c
+++ b/mono/mini/tramp-x86.c
@@ -652,7 +652,7 @@ mono_arch_get_gsharedvt_arg_trampoline (MonoDomain *domain, gpointer arg, gpoint
  * mono_arch_create_sdb_trampoline:
  *
  *   Return a trampoline which captures the current context, passes it to
- * mono_debugger_agent_single_step_from_context ()/mono_debugger_agent_breakpoint_from_context (),
+ * mini_get_dbg_callbacks ()->single_step_from_context ()/mini_get_dbg_callbacks ()->breakpoint_from_context (),
  * then restores the (potentially changed) context.
  */
 guint8*
@@ -716,9 +716,9 @@ mono_arch_create_sdb_trampoline (gboolean single_step, MonoTrampInfo **info, gbo
 		x86_breakpoint (code);
 	} else {
 		if (single_step)
-			x86_call_code (code, mono_debugger_agent_single_step_from_context);
+			x86_call_code (code, mini_get_dbg_callbacks ()->single_step_from_context);
 		else
-			x86_call_code (code, mono_debugger_agent_breakpoint_from_context);
+			x86_call_code (code, mini_get_dbg_callbacks ()->breakpoint_from_context);
 	}
 
 	/* Restore registers from ctx */

--- a/mono/unit-tests/Makefile.am
+++ b/mono/unit-tests/Makefile.am
@@ -41,6 +41,10 @@ if !DISABLE_INTERPRETER
 mini_libs += $(monodir)/mono/mini/libmono-ee-interp.la
 endif
 
+if !DISABLE_DEBUGGER_AGENT
+mini_libs += $(monodir)/mono/mini/libmono-dbg.la
+endif
+
 if !CROSS_COMPILE
 if !HOST_WIN32
 

--- a/msvc/libmini-common.targets
+++ b/msvc/libmini-common.targets
@@ -57,6 +57,7 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\mini\mini-gc.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\mini\debugger-agent.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\mini\debugger-agent.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\mini\debugger-agent-stubs.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\mini\xdebug.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\mini\mini-llvm.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\mini\mini-llvm-cpp.h" />

--- a/msvc/libmini-common.targets.filters
+++ b/msvc/libmini-common.targets.filters
@@ -169,6 +169,9 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\mini\debugger-agent.c">
       <Filter>Source Files$(MonoMiniFilterSubFolder)\common</Filter>
     </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\mono\mini\debugger-agent-stubs.c">
+      <Filter>Source Files$(MonoMiniFilterSubFolder)\common</Filter>
+    </ClCompile>
     <ClCompile Include="$(MonoSourceLocation)\mono\mini\xdebug.c">
       <Filter>Source Files$(MonoMiniFilterSubFolder)\common</Filter>
     </ClCompile>


### PR DESCRIPTION
If the runtime is configured using --enable-minimal=soft_debug, the debugger code will be compiled into a separate
libmono-dbg.a library which needs to be linked into the app. The debugger needs to be registered with the runtime by
calling mono_debugger_agent_init () before runtime initialization.