### PR TITLE
[mprof-report] Fix reading of TYPE_JITHELPER events in v13 files.

### DIFF
--- a/mono/profiler/mprof-report.c
+++ b/mono/profiler/mprof-report.c
@@ -2866,6 +2866,8 @@ decode_buffer (ProfContext *ctx)
 					type = *p++;
 				else
 					type = decode_uleb128 (p, &p);
+				if (ctx->data_version < 14)
+					--type;
 				intptr_t codediff = decode_sleb128 (p, &p);
 				int codelen = decode_uleb128 (p, &p);
 				const char *name;


### PR DESCRIPTION
This is the same fix as in 76d7ab281db976c40e9f15176e0b5a3488bad869.

Fixes #7613.