### PR TITLE
[version.h] Support .git being a submodule

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -907,11 +907,11 @@ EXTRA_DIST = TestDriver.cs \
 	Makefile.am.in
 
 version.h: Makefile
-	if test -d $(top_srcdir)/.git; then \
+	if test -e $(top_srcdir)/.git; then \
 		(cd $(top_srcdir); \
 			LANG=C; export LANG; \
 			if test -z "$$ghprbPullId"; then \
-				branch=`git branch | grep '^\*' | sed 's/(detached from .*/explicit/' | cut -d ' ' -f 2`; \
+				branch=`git branch | grep '^\*' | sed 's/.*detached .*/explicit/' | cut -d ' ' -f 2`; \
 			else \
 				branch="pull-request-$$ghprbPullId"; \
 			fi; \


### PR DESCRIPTION
When mono is used as a submodule then .git will be a file instead of a directory. Adjusted the version.h generation code to support that.

Also newer git version started to use `(HEAD detached at <git sha>)` in `git branch` output instead of `(detached from <git sha>)`, fixed the regex to support that pattern too.

Just two cosmetic changes to make the `mono --version` output more correct in those cases.