### PR TITLE
[runtime] Fix file handle leak with dedup+aot

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -12796,8 +12796,10 @@ mono_compile_assembly (MonoAssembly *ass, guint32 opts, const char *aot_options,
 
 	emit_extra_methods (acfg);
 
-	if (acfg->aot_opts.dedup_include && !is_dedup_dummy)
+	if (acfg->aot_opts.dedup_include && !is_dedup_dummy) {
+		fclose (acfg->fp);
 		return 0;
+	}
 
 	emit_trampolines (acfg);
 


### PR DESCRIPTION
When we use asm_only, we don't use a temp file. We always write directly to the output file instead. 

We currently leave this file in a dirty state when we exit with an error. Dedup exits early, but not in error. We don't pull down the runtime between our sweeps of assemblies. This means that our temp file (the provided output assembly file) is written to by each step without closing it. 

On Unix when you don't close a file and you open it again, you're given a pointer to the open file. Therefore each step uses the temp file, appending to the end, until the dedup inflation pass tries to use it. 

This fails when the dedup inflation pass yields an assembly file with multiple `method_addresses` tables, multiple conflicting sets of DWARF, and multiple method bodies. 

Closing it here ensures that the future fopen will result in the file being zeroed out when the dedup dummy pass comes to write to it. 
