### PR TITLE
add some OpenBSD patches

### DIFF
--- a/libgc/dyn_load.c
+++ b/libgc/dyn_load.c
@@ -396,7 +396,8 @@ GC_bool GC_register_main_static_data()
 
 # if (defined(LINUX) || defined (__GLIBC__) || defined(NACL)) /* Are others OK here, too? */ \
      && (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ > 2) \
-         || (__GLIBC__ == 2 && __GLIBC_MINOR__ == 2 && defined(DT_CONFIG))) 
+         || (__GLIBC__ == 2 && __GLIBC_MINOR__ == 2 && defined(DT_CONFIG))) \
+	 || defined(OPENBSD)
 
 /* We have the header files for a glibc that includes dl_iterate_phdr.	*/
 /* It may still not be available in the library on the target system.   */

--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -41,7 +41,7 @@ typedef __m128d MonoContextSimdReg;
 #elif defined(HOST_ANDROID)
 #define MONO_HAVE_SIMD_REG
 typedef struct _libc_xmmreg MonoContextSimdReg;
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__OpenBSD__)
 #define MONO_HAVE_SIMD_REG
 #include <emmintrin.h>
 typedef __m128d MonoContextSimdReg;

--- a/mono/utils/mono-threads-posix-signals.c
+++ b/mono/utils/mono-threads-posix-signals.c
@@ -68,6 +68,8 @@ abort_signal_get (void)
 {
 #if defined(HOST_ANDROID)
 	return SIGTTIN;
+#elif defined (__OpenBSD__)
+	return SIGUSR1;
 #elif defined (SIGRTMIN)
 	static int abort_signum = -1;
 	if (abort_signum == -1)

--- a/mono/utils/networking-posix.c
+++ b/mono/utils/networking-posix.c
@@ -21,6 +21,9 @@
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_NET_IF_H
+#ifdef (__OpenBSD__)
+#include <sys/socket.h>
+#endif
 #include <net/if.h>
 #endif
 #ifdef HAVE_UNISTD_H

--- a/mono/utils/networking-posix.c
+++ b/mono/utils/networking-posix.c
@@ -17,7 +17,7 @@
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #endif
-#if defined(HAVE_SYS_SOCKET_H) || defined(__OpenBSD__)
+#if defined(HAVE_SYS_SOCKET_H)
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_NET_IF_H

--- a/mono/utils/networking-posix.c
+++ b/mono/utils/networking-posix.c
@@ -17,7 +17,7 @@
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #endif
-#if defined(HAVE_SYS_SOCKET_H)
+#ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_NET_IF_H

--- a/mono/utils/networking-posix.c
+++ b/mono/utils/networking-posix.c
@@ -17,13 +17,10 @@
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #endif
-#ifdef HAVE_SYS_SOCKET_H
+#if defined(HAVE_SYS_SOCKET_H) || defined(__OpenBSD__)
 #include <sys/socket.h>
 #endif
 #ifdef HAVE_NET_IF_H
-#ifdef (__OpenBSD__)
-#include <sys/socket.h>
-#endif
 #include <net/if.h>
 #endif
 #ifdef HAVE_UNISTD_H

--- a/support/sys-mman.c
+++ b/support/sys-mman.c
@@ -17,7 +17,7 @@
 /* For mincore () */
 #define _DARWIN_C_SOURCE
 #endif
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 /* For mincore () */
 #define __BSD_VISIBLE 1
 #endif


### PR DESCRIPTION
Hi,

A few trivial additions of OpenBSD to ifdefs, plus the change of the abort signal to SIGUSR1 which fixes the SIGABRT problem (other compilation problems remain). SIGTTIN is broadcast to the process group which leads to the SIGABRT (at least on OpenBSD).