### PR TITLE
[runtime] Don't use clock_gettime in MacOS.

### DIFF
--- a/mono/utils/mono-time.c
+++ b/mono/utils/mono-time.c
@@ -150,8 +150,8 @@ mono_msec_boottime (void)
 {
 	gint64 retval = 0;
 
-	/* clock_gettime () is found by configure but its only present from ios 10 */
-#if (defined(HAVE_CLOCK_MONOTONIC_COARSE) || defined(HAVE_CLOCK_MONOTONIC)) && !defined(TARGET_IOS)
+	/* clock_gettime () is found by configure but its only present from ios 10 and macos 10.12 */
+#if (defined(HAVE_CLOCK_MONOTONIC_COARSE) || defined(HAVE_CLOCK_MONOTONIC)) && !(defined(TARGET_IOS) || defined(TARGET_OSX))
 	clockid_t clockType =
 #if HAVE_CLOCK_MONOTONIC_COARSE
 	CLOCK_MONOTONIC_COARSE; /* good enough resolution, fastest speed */


### PR DESCRIPTION
Even though it's found during configure when targetting 10.7, it's not "really" available before versions 10.12 and it would crash with "lazy symbol binding failed".

```
$ ./mono-sgen timebug.exe
dyld: lazy symbol binding failed: Symbol not found: _clock_gettime
  Referenced from: /Users/builder/./mono-sgen
  Expected in: /usr/lib/libSystem.B.dylib

dyld: Symbol not found: _clock_gettime
  Referenced from: /Users/builder/./mono-sgen
  Expected in: /usr/lib/libSystem.B.dylib

Trace/BPT trap: 5
```