### PR TITLE
Remove obsolete code for getting TLS values from other threads.

### DIFF
--- a/mono/utils/mach-support-amd64.c
+++ b/mono/utils/mach-support-amd64.c
@@ -22,21 +22,6 @@
 //For reg numbers
 #include <mono/arch/amd64/amd64-codegen.h>
 
-/* Known offsets used for TLS storage*/
-
-/* All OSX versions up to 10.8 */
-#define TLS_VECTOR_OFFSET_CATS 0x60
-#define TLS_VECTOR_OFFSET_10_9 0xe0
-#define TLS_VECTOR_OFFSET_10_11 0x100
-
-/* This is 2 slots less than the known low */
-#define TLS_PROBE_LOW_WATERMARK 0x50
-/* This is 28 slots above the know high, which is more than the known high-low*/
-#define TLS_PROBE_HIGH_WATERMARK 0x200
-
-
-static int tls_vector_offset;
-
 void *
 mono_mach_arch_get_ip (thread_state_t state)
 {
@@ -160,64 +145,9 @@ mono_mach_arch_set_thread_states (thread_port_t thread, thread_state_t state, ma
 	return ret;
 }
 
-void *
-mono_mach_get_tls_address_from_thread (pthread_t thread, pthread_key_t key)
-{
-	/* OSX stores TLS values in a hidden array inside the pthread_t structure
-	 * They are keyed off a giant array from a known offset into the pointer.  This value
-	 * is baked into their pthread_getspecific implementation
-	 */
-	intptr_t *p = (intptr_t *)thread;
-	intptr_t **tsd = (intptr_t **) ((char*)p + tls_vector_offset);
-	g_assert (tls_vector_offset != -1);
-
-	return (void *) &tsd [key];
-}
-
-void *
-mono_mach_arch_get_tls_value_from_thread (pthread_t thread, guint32 key)
-{
-	return *(void**)mono_mach_get_tls_address_from_thread (thread, key);
-}
-
 void
 mono_mach_init (pthread_key_t key)
 {
-	int i;
-	void *old_value = pthread_getspecific (key);
-	void *canary = (void*)0xDEADBEEFu;
-
-	pthread_key_create (&key, NULL);
-	g_assert (old_value != canary);
-
-	pthread_setspecific (key, canary);
-
-	/*First we probe for cats*/
-	tls_vector_offset = TLS_VECTOR_OFFSET_CATS;
-	if (mono_mach_arch_get_tls_value_from_thread (pthread_self (), key) == canary)
-		goto ok;
-
-	tls_vector_offset = TLS_VECTOR_OFFSET_10_9;
-	if (mono_mach_arch_get_tls_value_from_thread (pthread_self (), key) == canary)
-		goto ok;
-
-	tls_vector_offset = TLS_VECTOR_OFFSET_10_11;
-	if (mono_mach_arch_get_tls_value_from_thread (pthread_self (), key) == canary)
-		goto ok;
-
-	/*Fallback to scanning a large range of offsets*/
-	for (i = TLS_PROBE_LOW_WATERMARK; i <= TLS_PROBE_HIGH_WATERMARK; i += 4) {
-		tls_vector_offset = i;
-		if (mono_mach_arch_get_tls_value_from_thread (pthread_self (), key) == canary) {
-			g_warning ("Found new TLS offset at %d", i);
-			goto ok;
-		}
-	}
-
-	tls_vector_offset = -1;
-	g_warning ("could not discover the mach TLS offset");
-ok:
-	pthread_setspecific (key, old_value);
 }
 
 #endif

--- a/mono/utils/mach-support-amd64.c
+++ b/mono/utils/mach-support-amd64.c
@@ -22,22 +22,6 @@
 //For reg numbers
 #include <mono/arch/amd64/amd64-codegen.h>
 
-void *
-mono_mach_arch_get_ip (thread_state_t state)
-{
-	x86_thread_state64_t *arch_state = (x86_thread_state64_t *) state;
-
-	return (void *) arch_state->__rip;
-}
-
-void *
-mono_mach_arch_get_sp (thread_state_t state)
-{
-	x86_thread_state64_t *arch_state = (x86_thread_state64_t *) state;
-
-	return (void *) arch_state->__rsp;
-}
-
 int
 mono_mach_arch_get_mcontext_size ()
 {
@@ -143,11 +127,6 @@ mono_mach_arch_set_thread_states (thread_port_t thread, thread_state_t state, ma
 		return ret;
 	ret = thread_set_state (thread, x86_FLOAT_STATE64, fpstate, fpcount);
 	return ret;
-}
-
-void
-mono_mach_init (pthread_key_t key)
-{
 }
 
 #endif

--- a/mono/utils/mach-support-arm.c
+++ b/mono/utils/mach-support-arm.c
@@ -25,23 +25,6 @@
        #define __darwin_mcontext       __darwin_mcontext32
 #endif
 
-void *
-mono_mach_arch_get_ip (thread_state_t state)
-{
-	/* Can't use unified_thread_state on !ARM64 since this has to compile on armv6 too */
-	arm_thread_state_t *arch_state = (arm_thread_state_t *) state;
-
-	return (void *) arch_state->__pc;
-}
-
-void *
-mono_mach_arch_get_sp (thread_state_t state)
-{
-	arm_thread_state_t *arch_state = (arm_thread_state_t *) state;
-
-	return (void *) arch_state->__sp;
-}
-
 int
 mono_mach_arch_get_mcontext_size ()
 {
@@ -116,11 +99,6 @@ mono_mach_arch_set_thread_states (thread_port_t thread, thread_state_t state, ma
 #else
 	return thread_set_state (thread, ARM_THREAD_STATE, state, count);
 #endif
-}
-
-void
-mono_mach_init (pthread_key_t key)
-{
 }
 
 #endif

--- a/mono/utils/mach-support-arm.c
+++ b/mono/utils/mach-support-arm.c
@@ -25,24 +25,6 @@
        #define __darwin_mcontext       __darwin_mcontext32
 #endif
 
-/* Known offsets used for TLS storage*/
-
-
-static const int known_tls_offsets[] = {
-	0x48, /*Found on iOS 6 */
-	0xA4,
-	0xA8,
-};
-
-#define TLS_PROBE_COUNT (sizeof (known_tls_offsets) / sizeof (int))
-
-/* This is 2 slots less than the known low */
-#define TLS_PROBE_LOW_WATERMARK 0x40
-/* This is 24 slots above the know high, which is the same diff as the knowns high-low*/
-#define TLS_PROBE_HIGH_WATERMARK 0x108
-
-static int tls_vector_offset;
-
 void *
 mono_mach_arch_get_ip (thread_state_t state)
 {
@@ -136,58 +118,9 @@ mono_mach_arch_set_thread_states (thread_port_t thread, thread_state_t state, ma
 #endif
 }
 
-void *
-mono_mach_get_tls_address_from_thread (pthread_t thread, pthread_key_t key)
-{
-	/* Mach stores TLS values in a hidden array inside the pthread_t structure
-	 * They are keyed off a giant array from a known offset into the pointer. This value
-	 * is baked into their pthread_getspecific implementation
-	 */
-	intptr_t *p = (intptr_t *) thread;
-	intptr_t **tsd = (intptr_t **) ((char*)p + tls_vector_offset);
-	g_assert (tls_vector_offset != -1);
-
-	return (void *) &tsd [key];
-}
-
-void *
-mono_mach_arch_get_tls_value_from_thread (pthread_t thread, guint32 key)
-{
-	return *(void**)mono_mach_get_tls_address_from_thread (thread, key);
-}
-
 void
 mono_mach_init (pthread_key_t key)
 {
-	int i;
-	void *old_value = pthread_getspecific (key);
-	void *canary = (void*)0xDEADBEEFu;
-
-	pthread_key_create (&key, NULL);
-	g_assert (old_value != canary);
-
-	pthread_setspecific (key, canary);
-
-	/*First we probe for cats*/
-	for (i = 0; i < TLS_PROBE_COUNT; ++i) {
-		tls_vector_offset = known_tls_offsets [i];
-		if (mono_mach_arch_get_tls_value_from_thread (pthread_self (), key) == canary)
-			goto ok;
-	}
-
-	/*Fallback to scanning a large range of offsets*/
-	for (i = TLS_PROBE_LOW_WATERMARK; i <= TLS_PROBE_HIGH_WATERMARK; i += 4) {
-		tls_vector_offset = i;
-		if (mono_mach_arch_get_tls_value_from_thread (pthread_self (), key) == canary) {
-			g_warning ("Found new TLS offset at %d", i);
-			goto ok;
-		}
-	}
-
-	tls_vector_offset = -1;
-	g_warning ("could not discover the mach TLS offset");
-ok:
-	pthread_setspecific (key, old_value);
 }
 
 #endif

--- a/mono/utils/mach-support-arm64.c
+++ b/mono/utils/mach-support-arm64.c
@@ -25,25 +25,6 @@
        #define __darwin_mcontext       __darwin_mcontext32
 #endif
 
-/* Known offsets used for TLS storage*/
-
-
-static const int known_tls_offsets[] = {
-	0x48, /*Found on iOS 6 */
-	0xA4,
-	0xA8,
-	0xE0, /* Found on at least iOS 10 and iOS 11 */
-};
-
-#define TLS_PROBE_COUNT (sizeof (known_tls_offsets) / sizeof (int))
-
-/* This is 2 slots less than the known low */
-#define TLS_PROBE_LOW_WATERMARK 0x40
-/* This is 24 slots above the know high, which is the same diff as the knowns high-low*/
-#define TLS_PROBE_HIGH_WATERMARK 0x108
-
-static int tls_vector_offset;
-
 void *
 mono_mach_arch_get_ip (thread_state_t state)
 {
@@ -148,58 +129,9 @@ mono_mach_arch_set_thread_states (thread_port_t thread, thread_state_t state, ma
 	return ret;
 }
 
-void *
-mono_mach_get_tls_address_from_thread (pthread_t thread, pthread_key_t key)
-{
-	/* Mach stores TLS values in a hidden array inside the pthread_t structure
-	 * They are keyed off a giant array from a known offset into the pointer. This value
-	 * is baked into their pthread_getspecific implementation
-	 */
-	intptr_t *p = (intptr_t *) thread;
-	intptr_t **tsd = (intptr_t **) ((char*)p + tls_vector_offset);
-	g_assert (tls_vector_offset != -1);
-
-	return (void *) &tsd [key];
-}
-
-void *
-mono_mach_arch_get_tls_value_from_thread (pthread_t thread, guint32 key)
-{
-	return *(void**)mono_mach_get_tls_address_from_thread (thread, key);
-}
-
 void
 mono_mach_init (pthread_key_t key)
 {
-	int i;
-	void *old_value = pthread_getspecific (key);
-	void *canary = (void*)0xDEADBEEFu;
-
-	pthread_key_create (&key, NULL);
-	g_assert (old_value != canary);
-
-	pthread_setspecific (key, canary);
-
-	/*First we probe for cats*/
-	for (i = 0; i < TLS_PROBE_COUNT; ++i) {
-		tls_vector_offset = known_tls_offsets [i];
-		if (mono_mach_arch_get_tls_value_from_thread (pthread_self (), key) == canary)
-			goto ok;
-	}
-
-	/*Fallback to scanning a large range of offsets*/
-	for (i = TLS_PROBE_LOW_WATERMARK; i <= TLS_PROBE_HIGH_WATERMARK; i += 4) {
-		tls_vector_offset = i;
-		if (mono_mach_arch_get_tls_value_from_thread (pthread_self (), key) == canary) {
-			g_warning ("Found new TLS offset at %d", i);
-			goto ok;
-		}
-	}
-
-	tls_vector_offset = -1;
-	g_warning ("could not discover the mach TLS offset");
-ok:
-	pthread_setspecific (key, old_value);
 }
 
 #endif

--- a/mono/utils/mach-support-arm64.c
+++ b/mono/utils/mach-support-arm64.c
@@ -25,23 +25,6 @@
        #define __darwin_mcontext       __darwin_mcontext32
 #endif
 
-void *
-mono_mach_arch_get_ip (thread_state_t state)
-{
-	/* Can't use unified_thread_state on !ARM64 since this has to compile on armv6 too */
-	arm_unified_thread_state_t *arch_state = (arm_unified_thread_state_t *) state;
-
-	return (void *) arch_state->ts_64.__pc;
-}
-
-void *
-mono_mach_arch_get_sp (thread_state_t state)
-{
-	arm_unified_thread_state_t *arch_state = (arm_unified_thread_state_t *) state;
-
-	return (void *) arch_state->ts_64.__sp;
-}
-
 int
 mono_mach_arch_get_mcontext_size ()
 {
@@ -127,11 +110,6 @@ mono_mach_arch_set_thread_states (thread_port_t thread, thread_state_t state, ma
 		return ret;
 	ret = thread_set_state (thread, ARM_NEON_STATE64, fpstate, fpcount);
 	return ret;
-}
-
-void
-mono_mach_init (pthread_key_t key)
-{
 }
 
 #endif

--- a/mono/utils/mach-support-unknown.c
+++ b/mono/utils/mach-support-unknown.c
@@ -17,18 +17,6 @@
 #include "utils/mono-sigcontext.h"
 #include "mach-support.h"
 
-void *
-mono_mach_arch_get_ip (thread_state_t state)
-{
-	g_assert_not_reached ();
-}
-
-void *
-mono_mach_arch_get_sp (thread_state_t state)
-{
-	g_assert_not_reached ();
-}
-
 int
 mono_mach_arch_get_mcontext_size ()
 {
@@ -69,23 +57,6 @@ kern_return_t
 mono_mach_arch_get_thread_states (thread_port_t thread, thread_state_t state, mach_msg_type_number_t *count, thread_state_t fpstate, mach_msg_type_number_t *fpcount)
 {
 	g_assert_not_reached ();
-}
-
-kern_return_t
-mono_mach_arch_set_thread_states (thread_port_t thread, thread_state_t state, mach_msg_type_number_t count, thread_state_t fpstate, mach_msg_type_number_t fpcount)
-{
-	g_assert_not_reached ();	
-}
-
-void *
-mono_mach_arch_get_tls_value_from_thread (pthread_t thread, guint32 key)
-{
-	g_assert_not_reached ();
-}
-
-void
-mono_mach_init (pthread_key_t key)
-{
 }
 
 #endif

--- a/mono/utils/mach-support-x86.c
+++ b/mono/utils/mach-support-x86.c
@@ -20,22 +20,6 @@
 // For reg numbers
 #include <mono/arch/amd64/amd64-codegen.h>
 
-/* Known offsets used for TLS storage*/
-
-/* All OSX versions up to 10.8 */
-#define TLS_VECTOR_OFFSET_CATS 0x48
-#define TLS_VECTOR_OFFSET_10_9 0xb0
-#define TLS_VECTOR_OFFSET_10_11 0x100
-
-
-/* This is 2 slots less than the known low */
-#define TLS_PROBE_LOW_WATERMARK 0x40
-/* This is 28 slots above the know high, which is more than the known high-low*/
-#define TLS_PROBE_HIGH_WATERMARK 0x120
-
-
-static int tls_vector_offset;
-
 void *
 mono_mach_arch_get_ip (thread_state_t state)
 {
@@ -151,64 +135,9 @@ mono_mach_arch_set_thread_states (thread_port_t thread, thread_state_t state, ma
 #endif	
 }
 
-void *
-mono_mach_get_tls_address_from_thread (pthread_t thread, pthread_key_t key)
-{
-	/* OSX stores TLS values in a hidden array inside the pthread_t structure
-	 * They are keyed off a giant array from a known offset into the pointer.  This value
-	 * is baked into their pthread_getspecific implementation
-	 */
-	intptr_t *p = (intptr_t *) thread;
-	intptr_t **tsd = (intptr_t **) ((char*)p + tls_vector_offset);
-	g_assert (tls_vector_offset != -1);
-
-	return (void *) &tsd [key];	
-}
-
-void *
-mono_mach_arch_get_tls_value_from_thread (pthread_t thread, guint32 key)
-{
-	return *(void**)mono_mach_get_tls_address_from_thread (thread, key);
-}
-
 void
 mono_mach_init (pthread_key_t key)
 {
-	int i;
-	void *old_value = pthread_getspecific (key);
-	void *canary = (void*)0xDEADBEEFu;
-
-	pthread_key_create (&key, NULL);
-	g_assert (old_value != canary);
-
-	pthread_setspecific (key, canary);
-
-	/*First we probe for cats*/
-	tls_vector_offset = TLS_VECTOR_OFFSET_CATS;
-	if (mono_mach_arch_get_tls_value_from_thread (pthread_self (), key) == canary)
-		goto ok;
-
-	tls_vector_offset = TLS_VECTOR_OFFSET_10_9;
-	if (mono_mach_arch_get_tls_value_from_thread (pthread_self (), key) == canary)
-		goto ok;
-
-	tls_vector_offset = TLS_VECTOR_OFFSET_10_11;
-	if (mono_mach_arch_get_tls_value_from_thread (pthread_self (), key) == canary)
-		goto ok;
-
-	/*Fallback to scanning a large range of offsets*/
-	for (i = TLS_PROBE_LOW_WATERMARK; i <= TLS_PROBE_HIGH_WATERMARK; i += 4) {
-		tls_vector_offset = i;
-		if (mono_mach_arch_get_tls_value_from_thread (pthread_self (), key) == canary) {
-			g_warning ("Found new TLS offset at %d", i);
-			goto ok;
-		}
-	}
-
-	tls_vector_offset = -1;
-	g_warning ("could not discover the mach TLS offset");
-ok:
-	pthread_setspecific (key, old_value);
 }
 
 #endif

--- a/mono/utils/mach-support-x86.c
+++ b/mono/utils/mach-support-x86.c
@@ -20,22 +20,6 @@
 // For reg numbers
 #include <mono/arch/amd64/amd64-codegen.h>
 
-void *
-mono_mach_arch_get_ip (thread_state_t state)
-{
-	x86_thread_state32_t *arch_state = (x86_thread_state32_t *) state;
-
-	return (void *) arch_state->__eip;
-}
-
-void *
-mono_mach_arch_get_sp (thread_state_t state)
-{
-	x86_thread_state32_t *arch_state = (x86_thread_state32_t *) state;
-
-	return (void *) arch_state->__esp;
-}
-
 int
 mono_mach_arch_get_mcontext_size ()
 {
@@ -133,11 +117,6 @@ mono_mach_arch_set_thread_states (thread_port_t thread, thread_state_t state, ma
 	ret = thread_set_state (thread, x86_FLOAT_STATE32, fpstate, fpcount);
 	return ret;
 #endif	
-}
-
-void
-mono_mach_init (pthread_key_t key)
-{
 }
 
 #endif

--- a/mono/utils/mach-support.h
+++ b/mono/utils/mach-support.h
@@ -28,10 +28,6 @@ typedef _STRUCT_MCONTEXT64 *mcontext_t;
 // and the pthread header guards against this
 extern pthread_t pthread_from_mach_thread_np(mach_port_t);
 
-void *mono_mach_arch_get_ip (thread_state_t state);
-void *mono_mach_arch_get_sp (thread_state_t state);
-void mono_mach_init (pthread_key_t key);
-
 int mono_mach_arch_get_mcontext_size (void);
 void mono_mach_arch_thread_states_to_mcontext (thread_state_t state, thread_state_t fpstate, void *context);
 void mono_mach_arch_mcontext_to_thread_states (void *context, thread_state_t state, thread_state_t fpstate);

--- a/mono/utils/mach-support.h
+++ b/mono/utils/mach-support.h
@@ -44,8 +44,6 @@ kern_return_t mono_mach_get_threads (thread_act_array_t *threads, guint32 *count
 kern_return_t mono_mach_free_threads (thread_act_array_t threads, guint32 count);
 kern_return_t mono_mach_arch_get_thread_states (thread_port_t thread, thread_state_t state, mach_msg_type_number_t *count, thread_state_t fpstate, mach_msg_type_number_t *fpcount);
 kern_return_t mono_mach_arch_set_thread_states (thread_port_t thread, thread_state_t state, mach_msg_type_number_t count, thread_state_t fpstate, mach_msg_type_number_t fpcount);
-void *mono_mach_arch_get_tls_value_from_thread (pthread_t thread, guint32 key);
-void *mono_mach_get_tls_address_from_thread (pthread_t thread, pthread_key_t key);
 
 #endif
 #endif /* __MONO_MACH_SUPPORT_H__ */

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -771,10 +771,6 @@ mono_thread_info_init (size_t info_size)
 	mono_threads_coop_init ();
 	mono_threads_platform_init ();
 
-#if defined(__MACH__)
-	mono_mach_init (thread_info_key);
-#endif
-
 	mono_threads_inited = TRUE;
 
 	g_assert (sizeof (MonoNativeThreadId) <= sizeof (uintptr_t));


### PR DESCRIPTION
Fixes #7692, in response to pull request #7530.