### PR TITLE
[RFC][win32] Deprecation error if using MONO_RT_EXTERNAL_ONLY function

### DIFF
--- a/mono/utils/mono-publib.h
+++ b/mono/utils/mono-publib.h
@@ -144,6 +144,12 @@ mono_set_allocator_vtable (MonoAllocatorVTable* vtable);
 #pragma GCC diagnostic error "-Wdeprecated-declarations"
 #endif
 
+#elif defined (_MSC_VER)
+#define MONO_RT_EXTERNAL_ONLY __declspec (deprecated ("The mono runtime must not call this function.")) \
+	MONO_RT_CENTRINEL_SUPPRESS
+// Turn deprecation warnings into errors
+#pragma warning (error : 4996)
+
 #else
 #define MONO_RT_EXTERNAL_ONLY MONO_RT_CENTRINEL_SUPPRESS
 #endif // clang or gcc


### PR DESCRIPTION
We do this under clang and gcc on Linux and Mac; so might as well try Windows with MSC, also.

One caveat is that it turns _all_ deprecations warnings into errors.  That may not be what we want.  (Or else we may need `#pragma warning (suppress : 4996)` if we use old API anywhere else.)

I'm not a Windows person - looking for feedback.
