### PR TITLE
[coop] fix regression in System.IO.MonoIO.ReplaceFile

### DIFF
--- a/mcs/class/corlib/System.IO/MonoIO.cs
+++ b/mcs/class/corlib/System.IO/MonoIO.cs
@@ -270,7 +270,10 @@ namespace System.IO
 				fixed (char* sourceFileNameChars = sourceFileName,
 				       destinationFileNameChars = destinationFileName,
 				       destinationBackupFileNameChars = destinationBackupFileName) {
-					return ReplaceFile (sourceFileNameChars, destinationFileNameChars, destinationBackupFileNameChars, ignoreMetadataErrors, out error);
+					return ReplaceFile (sourceFileName == null ? null : sourceFileNameChars,
+							destinationFileName == null ? null : destinationFileNameChars,
+							destinationBackupFileName == null ? null : destinationBackupFileNameChars,
+							ignoreMetadataErrors, out error);
 				}
 			}
 		}


### PR DESCRIPTION
introduced by 85f4b5b16704262bda7eb745aa74d125afa5c4ea

fixes crash that looks like this:
```
    frame #3: 0x000000010b91351a mono`mono_handle_native_crash(signal="SIGSEGV", ctx=0x0000000000000000, info=0x0000000000000000) at mini-exceptions.c:2652
    frame #4: 0x000000010ba059eb mono`altstack_handle_and_restore(ctx=0x00007ffee43ed3a0, obj=0x0000000000000000, stack_ovf=0) at exceptions-amd64.c:855
    frame #5: 0x000000010bcdcda7 mono`monoeg_g_utf16_to_utf8(str=0x0000000000000014, len=0, items_read=0x0000000000000000, items_written=0x0000000000000000, err=0x0000000000000000) at giconv.c:1036
    frame #6: 0x000000010bcc1a5b mono`mono_unicode_to_external(uni=0x0000000000000014) at strenc.c:183
    frame #7: 0x000000010ba77c3e mono`convert_arg_to_utf8(arg=0x0000000000000014, arg_name="backupFileName") at w32file-unix.c:2459
    frame #8: 0x000000010ba75d65 mono`ReplaceFile(replacedFileName=0x000000010c7b4ba4, replacementFileName=0x000000010c7b473c, backupFileName=0x0000000000000014, replaceFlags=1, exclude=0x0000000000000000, reserved=0x0000000000000000) at w32file-unix.c:2483
    frame #9: 0x000000010ba75c87 mono`mono_w32file_replace(destination_file_name=0x000000010c7b4ba4, source_file_name=0x000000010c7b473c, destination_backup_file_name=0x0000000000000014, flags=1, error=0x00007ffee43efbe8) at w32file-unix.c:4795
    frame #10: 0x000000010bad02e9 mono`ves_icall_System_IO_MonoIO_ReplaceFile(source_file_name=0x000000010c7b473c, destination_file_name=0x000000010c7b4ba4, destination_backup_file_name=0x0000000000000014, ignore_metadata_errors='\0', error=0x00007ffee43efbe8) at w32file.c:348
```

happens when running `FileInfoTest::Replace1_Backup_Null ()` of corlib
tests
(https://github.com/mono/mono/blob/7dea71ce64bb77cb96ff3dfb06bb9141fb73c3f0/mcs/class/corlib/Test/System.IO/FileInfoTest.cs#L937
) if it's compiled with `mcs`. Not sure why it doesn't trigger with
`roslyn`...


PS: I don't C# 😅 please do not hesitate to comment on the style!

/cc #7722