### PR TITLE
[tests] Disable finalizer-exit.exe, finalizer-abort.exe and finalizer-thread.exe tests on Windows

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -712,7 +712,7 @@ PLATFORM_DISABLED_TESTS += tailcall-virt.exe
 endif
 
 if HOST_WIN32
-PLATFORM_DISABLED_TESTS += bug-58782-plain-throw.exe bug-58782-capture-and-throw.exe
+PLATFORM_DISABLED_TESTS += bug-58782-plain-throw.exe bug-58782-capture-and-throw.exe finalizer-exit.exe finalizer-thread.exe finalizer-abort.exe
 endif
 
 if AMD64


### PR DESCRIPTION
They are flaky: https://github.com/mono/mono/issues/7733

