### PR TITLE
Genproj updates for BCL build in Windows Visual Studio

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -144,9 +144,10 @@ update-llvm-version:
 
 
 update-solution-files:
+	(pushd msvc/scripts; $(MAKE) genproj.exe; popd)
 	$(MAKE) update-csproj
 	$(MAKE) package-inputs
-	(cd msvc/scripts; $(MAKE) genproj.exe; mono --debug genproj.exe $(GENPROJ_ARGS))
+	(cd msvc/scripts; mono --debug genproj.exe $(GENPROJ_ARGS))
 
 update-solution-files-with-tests:
 	$(MAKE) "GENPROJ_ARGS=2012 true true" update-solution-files

--- a/Makefile.am
+++ b/Makefile.am
@@ -144,7 +144,7 @@ update-llvm-version:
 
 
 update-solution-files:
-	(pushd msvc/scripts; $(MAKE) genproj.exe; popd)
+	(pushd msvc/scripts; rm genproj.exe; $(MAKE) genproj.exe; popd)
 	$(MAKE) update-csproj
 	$(MAKE) package-inputs
 	(cd msvc/scripts; mono --debug genproj.exe $(GENPROJ_ARGS))

--- a/Makefile.am
+++ b/Makefile.am
@@ -146,7 +146,7 @@ update-llvm-version:
 update-solution-files:
 	$(MAKE) update-csproj
 	$(MAKE) package-inputs
-	(cd msvc/scripts; $(MAKE) genproj.exe; mono genproj.exe $(GENPROJ_ARGS))
+	(cd msvc/scripts; $(MAKE) genproj.exe; mono --debug genproj.exe $(GENPROJ_ARGS))
 
 update-solution-files-with-tests:
 	$(MAKE) "GENPROJ_ARGS=2012 true true" update-solution-files

--- a/mcs/tools/Makefile
+++ b/mcs/tools/Makefile
@@ -10,7 +10,6 @@ net_4_5_dirs := \
 	mono-service	\
 	mono-xsd	\
 	resgen		\
-	gacutil		\
 	wsdl		\
 	xbuild		\
 	csharp		\

--- a/msvc/scripts/csproj.tmpl
+++ b/msvc/scripts/csproj.tmpl
@@ -25,7 +25,7 @@
     <RootNamespace>
     </RootNamespace>
     <AssemblyName>@ASSEMBLYNAME@</AssemblyName>
-    <TargetFrameworkVersion>v@FX_VERSION</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v@FX_VERSION@</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
 @SIGNATURE@
   </PropertyGroup>
@@ -53,22 +53,14 @@
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
   </PropertyGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <ItemGroup>
-@SOURCES@  </ItemGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  <!-- @ALL_SOURCES@ -->
+  <!-- @ALL_REFERENCES@ -->
   <PropertyGroup>
 @PREBUILD@
 @POSTBUILD@
   </PropertyGroup>
   <ItemGroup>
-@REFERENCES@  </ItemGroup>
-  <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
-@RESOURCES@</Project>
+  <!-- @ALL_RESOURCES@ -->
+</Project>

--- a/msvc/scripts/csproj.tmpl
+++ b/msvc/scripts/csproj.tmpl
@@ -3,7 +3,6 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>@PROJECTGUID@</ProjectGuid>
@@ -13,8 +12,6 @@
     <HostPlatform Condition=" '$(HostPlatform)' == '' and '$(OS)' == 'Windows_NT'">win32</HostPlatform>
     <HostPlatform Condition=" '$(HostPlatform)' == '' and '$(OS)' == 'Unix' and $([System.IO.File]::Exists('/usr/lib/libc.dylib'))">darwin</HostPlatform>
     <HostPlatform Condition=" '$(HostPlatform)' == '' and '$(OS)' == 'Unix'">linux</HostPlatform>
-    <OutputPath>@OUTPUTDIR@</OutputPath>
-    <IntermediateOutputPath>obj-@OUTPUTSUFFIX@</IntermediateOutputPath>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     @NOSTDLIB@
     @METADATAVERSION@
@@ -22,45 +19,53 @@
     @NOCONFIG@
     @ALLOWUNSAFE@
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>
-    </RootNamespace>
+    <RootNamespace></RootNamespace>
     <AssemblyName>@ASSEMBLYNAME@</AssemblyName>
     <TargetFrameworkVersion>v@FX_VERSION@</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-@SIGNATURE@
+    @SIGNATURE@
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <NoWarn>@DISABLEDWARNINGS@</NoWarn>
-    <Optimize>false</Optimize>
-    <DefineConstants>TRACE;@DEFINECONSTANTS@</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <NoWarn>@DISABLEDWARNINGS@</NoWarn>
-    <Optimize>true</Optimize>
-    <DefineConstants>@DEFINECONSTANTS@</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
+
   <!-- Set AddAdditionalExplicitAssemblyReferences to false, otherwise if targetting .NET4.0, 
   Microsoft.NETFramework.props will force a dependency on the assembly System.Core. This
   is a problem to compile the Mono mscorlib.dll -->
   <PropertyGroup>
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
   </PropertyGroup>
+
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- @ALL_SOURCES@ -->
-  <!-- @ALL_REFERENCES@ -->
+
+<!-- @ALL_PROFILE_PROPERTIES@ -->
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <NoWarn>@DISABLEDWARNINGS@</NoWarn>
+    <Optimize>false</Optimize>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <!-- TRACE is set only for Debug configuration, so inherit from platform-specific value -->
+    <DefineConstants>TRACE;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugType>pdbonly</DebugType>
+    <NoWarn>@DISABLEDWARNINGS@</NoWarn>
+    <Optimize>true</Optimize>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+
+<!-- @ALL_SOURCES@ -->
+<!-- @ALL_REFERENCES@ -->
+
   <PropertyGroup>
 @PREBUILD@
 @POSTBUILD@
   </PropertyGroup>
+
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
-  <!-- @ALL_RESOURCES@ -->
+
+<!-- @ALL_RESOURCES@ -->
 </Project>

--- a/msvc/scripts/csproj.tmpl
+++ b/msvc/scripts/csproj.tmpl
@@ -33,8 +33,6 @@
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-
 <!-- @ALL_PROFILE_PROPERTIES@ -->
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
@@ -54,6 +52,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 
 <!-- @ALL_SOURCES@ -->
 <!-- @ALL_REFERENCES@ -->

--- a/msvc/scripts/csproj.tmpl
+++ b/msvc/scripts/csproj.tmpl
@@ -13,6 +13,8 @@
     <HostPlatform Condition=" '$(HostPlatform)' == '' and '$(OS)' == 'Unix' and $([System.IO.File]::Exists('/usr/lib/libc.dylib'))">darwin</HostPlatform>
     <HostPlatform Condition=" '$(HostPlatform)' == '' and '$(OS)' == 'Unix'">linux</HostPlatform>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
     @NOSTDLIB@
     @METADATAVERSION@
     @STARTUPOBJECT@
@@ -23,7 +25,7 @@
     <AssemblyName>@ASSEMBLYNAME@</AssemblyName>
     <TargetFrameworkVersion>v@FX_VERSION@</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    @SIGNATURE@
+@SIGNATURE@
   </PropertyGroup>
 
   <!-- Set AddAdditionalExplicitAssemblyReferences to false, otherwise if targetting .NET4.0, 
@@ -38,19 +40,13 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <NoWarn>@DISABLEDWARNINGS@</NoWarn>
     <Optimize>false</Optimize>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <!-- TRACE is set only for Debug configuration, so inherit from platform-specific value -->
     <DefineConstants>TRACE;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DebugType>pdbonly</DebugType>
-    <NoWarn>@DISABLEDWARNINGS@</NoWarn>
     <Optimize>true</Optimize>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
 
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/msvc/scripts/genproj.cs
+++ b/msvc/scripts/genproj.cs
@@ -104,6 +104,8 @@ class SlnGenerator {
 
 	private void WriteProjectConfigurationPlatforms (StreamWriter sln, string guid, string defaultPlatform)
 	{
+		var fallbackProfileNames = new List<string> ();
+
 		foreach (var profile in profiles) {
 			var platformToBuild = profile;
 
@@ -112,7 +114,7 @@ class SlnGenerator {
 				!profilesByGuid.TryGetValue (guid, out projectProfiles) ||
 				!projectProfiles.Contains (platformToBuild)
 			) {
-				Console.Error.WriteLine($"// Project {guid} has no profile {platformToBuild} so using {defaultPlatform}");
+				fallbackProfileNames.Add (platformToBuild);
 				platformToBuild = defaultPlatform;
 			}
 
@@ -121,6 +123,9 @@ class SlnGenerator {
 			sln.WriteLine ("\t\t{0}.Release|{1}.ActiveCfg = Release|{2}", guid, profile, platformToBuild);
 			sln.WriteLine ("\t\t{0}.Release|{1}.Build.0 = Release|{2}", guid, profile, platformToBuild);
 		}
+
+		if (fallbackProfileNames.Count > 0)
+			Console.Error.WriteLine ($"// Project {guid} does not have profile(s) {string.Join(", ", fallbackProfileNames)} so using {defaultPlatform}");
 	}
 
 	public void Write (string filename)

--- a/msvc/scripts/genproj.cs
+++ b/msvc/scripts/genproj.cs
@@ -86,9 +86,7 @@ class SlnGenerator {
 		library = library.Replace("-net_4_x", "");
 		sln.WriteLine (project_start, prefixGuid, library, relativePath, projectGuid);
 
-		if (
-			(dependencyGuids != null) && (dependencyGuids.Length > 0)
-		) {
+		if (dependencyGuids != null && dependencyGuids.Length > 0) {
 			sln.WriteLine ("\tProjectSection(ProjectDependencies) = postProject");
 			foreach (var guid in dependencyGuids)
 	    		sln.WriteLine ("\t\t{0} = {0}", guid);
@@ -158,7 +156,7 @@ class SlnGenerator {
 			sln.WriteLine (header);
 
 			// Manually insert jay's vcxproj. We depend on jay.exe to perform build steps later.
-			WriteProjectReference (sln, jay_sln_guid, "jay", "mcs\\jay\\jay.vcxproj", jay_vcxproj_guid, null);
+			WriteProjectReference (sln, jay_sln_guid, "jay", "mcs/jay/jay.vcxproj", jay_vcxproj_guid, null);
 
 			foreach (var proj in libraries) {
 				WriteProjectReference (sln, fullPath, proj);

--- a/msvc/scripts/genproj.cs
+++ b/msvc/scripts/genproj.cs
@@ -78,6 +78,8 @@ class SlnGenerator {
 
 	private void WriteProjectReference (StreamWriter sln, string prefixGuid, string library, string relativePath, string projectGuid, params string[] dependencyGuids)
 	{
+		// HACK
+		library = library.Replace("-net_4_x", "");
 		sln.WriteLine (project_start, prefixGuid, library, relativePath, projectGuid);
 
 		foreach (var guid in dependencyGuids) {
@@ -1196,22 +1198,7 @@ public class Driver {
 			string dir = project.Attribute ("dir").Value;
 			string library = project.Attribute ("library").Value;
 			var profile = project.Element ("profile").Value;
-
-#if false
-			// Skip facades for now, the tool doesn't know how to deal with them yet.
-			if (dir.Contains ("Facades"))
-				continue;
-
-			// These are currently broken, skip until they're fixed.
-			if (dir.StartsWith ("mcs") || dir.Contains ("apigen"))
-				continue;
-
-			//
-			// Do only class libraries for now
-			//
-			if (!(dir.StartsWith ("class") || dir.StartsWith ("mcs") || dir.StartsWith ("basic")))
-				continue;
-#endif
+			
 			//
 			// Do not do 2.1, it is not working yet
 			// Do not do basic, as there is no point (requires a system mcs to be installed).
@@ -1230,11 +1217,6 @@ public class Driver {
 			
 			if (library.Contains ("tests") && !withTests)
 				continue;
-
-			/*
-			if (profile != "net_4_x")
-				continue;
-			*/
 
 			yield return project;
 		}

--- a/msvc/scripts/genproj.cs
+++ b/msvc/scripts/genproj.cs
@@ -49,6 +49,10 @@ class SlnGenerator {
 		"xammac",
 	};
 
+	public static readonly HashSet<string> observedProfiles = new HashSet<string> {
+		"net_4_x"
+	};
+
 	const string jay_vcxproj_guid = "{5D485D32-3B9F-4287-AB24-C8DA5B89F537}";
 	const string jay_sln_guid = "{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}";
 
@@ -121,6 +125,9 @@ class SlnGenerator {
 		var fallbackProfileNames = new List<string> ();
 
 		foreach (var profile in profiles) {
+			if (!observedProfiles.Contains (profile))
+				continue;
+
 			var platformToBuild = profile;
 
 			HashSet<string> projectProfiles;
@@ -161,6 +168,9 @@ class SlnGenerator {
 
 			sln.WriteLine ("\tGlobalSection(SolutionConfigurationPlatforms) = preSolution");
 			foreach (var profile in profiles) {
+				if (!observedProfiles.Contains (profile))
+					continue;
+
 				sln.WriteLine ("\t\tDebug|{0} = Debug|{0}", profile, profile);
 				sln.WriteLine ("\t\tRelease|{0} = Release|{0}", profile, profile);
 			}
@@ -1321,7 +1331,8 @@ public class Driver {
 					if (!SlnGenerator.profilesByGuid.TryGetValue (csproj.projectGuid, out profileNames))
 						SlnGenerator.profilesByGuid[csproj.projectGuid] = profileNames = new HashSet<string>();
 
-					profileNames.Add(profileName);
+					profileNames.Add (profileName);
+					SlnGenerator.observedProfiles.Add (profileName);
 				}
 			} catch (Exception e) {
 				Console.Error.WriteLine ("// Error in {0}\n{1}", project, e);

--- a/msvc/scripts/genproj.cs
+++ b/msvc/scripts/genproj.cs
@@ -82,10 +82,13 @@ class SlnGenerator {
 		library = library.Replace("-net_4_x", "");
 		sln.WriteLine (project_start, prefixGuid, library, relativePath, projectGuid);
 
-		foreach (var guid in dependencyGuids) {
-    		sln.WriteLine ("    ProjectSection(ProjectDependencies) = postProject");
-    		sln.WriteLine ("        {0} = {0}", guid);
-    		sln.WriteLine ("    EndProjectSection");
+		if (
+			(dependencyGuids != null) && (dependencyGuids.Length > 0)
+		) {
+			sln.WriteLine ("    ProjectSection(ProjectDependencies) = postProject");
+			foreach (var guid in dependencyGuids)
+	    		sln.WriteLine ("        {0} = {0}", guid);
+			sln.WriteLine ("    EndProjectSection");
 		}
 
 		sln.WriteLine (project_end);
@@ -94,8 +97,9 @@ class SlnGenerator {
 	private void WriteProjectReference (StreamWriter sln, string slnFullPath, MsbuildGenerator.VsCsproj proj)
 	{
 		var unixProjFile = proj.csProjFilename.Replace ("\\", "/");
-		var fullProjPath = Path.GetFullPath (unixProjFile);
+		var fullProjPath = Path.GetFullPath (unixProjFile).Replace ("\\", "/");
 		var relativePath = MsbuildGenerator.GetRelativePath (slnFullPath, fullProjPath);
+
 		var dependencyGuids = new string[0];
 		if (proj.preBuildEvent.Contains ("jay"))
 			dependencyGuids = new [] { jay_vcxproj_guid };
@@ -107,7 +111,7 @@ class SlnGenerator {
 		}
 
 		if (dependencyGuids.Length > 0)
-			Console.WriteLine ($"Project {unixProjFile} has {dependencyGuids.Length} dependencies: {string.Join(", ", dependencyGuids)}");
+			Console.WriteLine ($"Project {fullProjPath} has {dependencyGuids.Length} dependencies: {string.Join(", ", dependencyGuids)}");
 
 		WriteProjectReference(sln, "{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}", proj.library, relativePath, proj.projectGuid, dependencyGuids);
 	}

--- a/msvc/scripts/genproj.cs
+++ b/msvc/scripts/genproj.cs
@@ -76,7 +76,7 @@ class SlnGenerator {
 		}
 	}
 
-	private void WriteProjectReference (StreamWriter sln, string prefixGuid, string library, string relativePath, string projectGuid, params string[] dependencyGuids)
+	private void WriteProjectReference (StreamWriter sln, string prefixGuid, string library, string relativePath, string projectGuid, string[] dependencyGuids)
 	{
 		// HACK
 		library = library.Replace("-net_4_x", "");
@@ -85,10 +85,10 @@ class SlnGenerator {
 		if (
 			(dependencyGuids != null) && (dependencyGuids.Length > 0)
 		) {
-			sln.WriteLine ("    ProjectSection(ProjectDependencies) = postProject");
+			sln.WriteLine ("\tProjectSection(ProjectDependencies) = postProject");
 			foreach (var guid in dependencyGuids)
-	    		sln.WriteLine ("        {0} = {0}", guid);
-			sln.WriteLine ("    EndProjectSection");
+	    		sln.WriteLine ("\t\t{0} = {0}", guid);
+			sln.WriteLine ("\tEndProjectSection");
 		}
 
 		sln.WriteLine (project_end);
@@ -151,7 +151,7 @@ class SlnGenerator {
 			sln.WriteLine (header);
 
 			// Manually insert jay's vcxproj. We depend on jay.exe to perform build steps later.
-			WriteProjectReference (sln, jay_sln_guid, "jay", "mcs\\jay\\jay.vcxproj", jay_vcxproj_guid);
+			WriteProjectReference (sln, jay_sln_guid, "jay", "mcs\\jay\\jay.vcxproj", jay_vcxproj_guid, null);
 
 			foreach (var proj in libraries) {
 				WriteProjectReference (sln, fullPath, proj);

--- a/msvc/scripts/genproj.cs
+++ b/msvc/scripts/genproj.cs
@@ -110,7 +110,7 @@ class SlnGenerator {
 				!profilesByGuid.TryGetValue (guid, out projectProfiles) ||
 				!projectProfiles.Contains (platformToBuild)
 			) {
-				Console.Error.WriteLine($"Project {guid} has no profile {platformToBuild} so using {defaultPlatform}");
+				Console.Error.WriteLine($"// Project {guid} has no profile {platformToBuild} so using {defaultPlatform}");
 				platformToBuild = defaultPlatform;
 			}
 
@@ -1296,12 +1296,9 @@ public class Driver {
 				}
 				
 				HashSet<string> profileNames;
-				if (!SlnGenerator.profilesByGuid.TryGetValue (csproj.projectGuid, out profileNames)) {
-					Console.Error.WriteLine($"Created profile name list for {library_output} {csproj.projectGuid}");
+				if (!SlnGenerator.profilesByGuid.TryGetValue (csproj.projectGuid, out profileNames))
 					SlnGenerator.profilesByGuid[csproj.projectGuid] = profileNames = new HashSet<string>();
-				}
 
-				Console.Error.WriteLine($"{library_output} {csproj.projectGuid} {profileName}");
 				profileNames.Add(profileName);
 			} catch (Exception e) {
 				Console.Error.WriteLine ("// Error in {0}\n{1}", project, e);
@@ -1400,7 +1397,7 @@ public class Driver {
 
 	static void WriteSolution (SlnGenerator sln_gen, string slnfilename)
 	{
-		Console.WriteLine (String.Format ("Writing solution {1}, with {0} projects", sln_gen.Count, slnfilename));
+		Console.WriteLine (String.Format ("// Writing solution {1}, with {0} projects", sln_gen.Count, slnfilename));
 		sln_gen.Write (slnfilename);
 	}
 


### PR DESCRIPTION
This batch of commits makes further updates to our support for building the BCL using msbuild (Visual Studio, to be specific).

* Generates a single sln and set of csproj files with support for all of our build profiles (orbis, monodroid, net_4_x, etc)
* Project configuration selector (in VS or as parameter to msbuild) can be used to select which profile to build
* Includes partial dependency information so that culevel and jay are compiled before the rest of the sln (this keeps pre/post events from from failing on first build)

As of this rev things are working pretty good, but a lot of the measures I took here are temporary so I'd appreciate thoughts on how to go about them. The hard-coded System.Web -> Culevel dependency feels gross, for example - I kind of want to go through and build an automatic solution for it but I'm not sure it's necessary.

Implements #6858