### PR TITLE
[runtime] Add public API to set the pending exception.

### DIFF
--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -248,6 +248,10 @@ MONO_API void
 mono_raise_exception	    (MonoException *ex);
 
 MONO_RT_EXTERNAL_ONLY
+MONO_API mono_bool
+mono_runtime_set_pending_exception (MonoException *exc, mono_bool overwrite);
+
+MONO_RT_EXTERNAL_ONLY
 MONO_API void
 mono_reraise_exception	    (MonoException *ex);
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -4814,7 +4814,9 @@ mono_set_pending_exception (MonoException *exc)
  *
  *   Set the pending exception of the current thread to \p exc.
  *   The exception will be thrown when execution returns to managed code.
- *   Can optionally \p overwrite any existing pending exceptions.
+ *   Can optionally \p overwrite any existing pending exceptions (it's not supported
+ *   to overwrite any pending exceptions if the runtime is processing a thread abort request,
+ *   in which case the behavior will be undefined).
  *   Return whether the pending exception was set or not.
  *   It will not be set if:
  *   * The thread or runtime is stopping or shutting down

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -4810,6 +4810,38 @@ mono_set_pending_exception (MonoException *exc)
 }
 
 /*
+ * mono_runtime_set_pending_exception:
+ *
+ *   Set the pending exception of the current thread to \p exc.
+ *   The exception will be thrown when execution returns to managed code.
+ *   Can optionally \p overwrite any existing pending exceptions.
+ *   Return whether the pending exception was set or not.
+ *   It will not be set if:
+ *   * The thread or runtime is stopping or shutting down
+ *   * There already is a pending exception (and \p overwrite is false)
+ */
+mono_bool
+mono_runtime_set_pending_exception (MonoException *exc, mono_bool overwrite)
+{
+	MonoThread *thread = mono_thread_current ();
+
+	/* The thread may already be stopping */
+	if (thread == NULL)
+		return FALSE;
+
+	/* Don't overwrite any existing pending exceptions unless asked to */
+	if (!overwrite && thread->pending_exception)
+		return FALSE;
+
+	MONO_OBJECT_SETREF (thread, pending_exception, exc);
+
+	mono_thread_request_interruption (FALSE);
+
+	return TRUE;
+}
+
+
+/*
  * mono_set_pending_exception_handle:
  *
  *   Set the pending exception of the current thread to EXC.


### PR DESCRIPTION
Xamarin.iOS and Xamarin.Mac need a public API to set the pending exception
when converting Objective-C exceptions to managed exceptions.

This adds a public API to support this scenario.

Partially fixes https://bugzilla.xamarin.com/show_bug.cgi?id=60065.