### PR TITLE
Upstream unity fixes for marshaling code.

### DIFF
--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -497,9 +497,11 @@ emit_ptr_to_object_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv 
 		mono_mb_emit_byte (mb, CEE_STIND_REF);
 		break;
 	}
-	case MONO_MARSHAL_CONV_ARRAY_LPARRAY:
-		g_error ("Structure field of type %s can't be marshalled as LPArray", m_class_get_name (mono_class_from_mono_type (type)));
+	case MONO_MARSHAL_CONV_ARRAY_LPARRAY: {
+		char *msg = g_strdup_printf ("Structure field of type %s can't be marshalled as LPArray", mono_class_from_mono_type (type)->name);
+		mono_mb_emit_exception_marshal_directive (mb, msg);
 		break;
+	}
 
 #ifndef DISABLE_COM
 	case MONO_MARSHAL_CONV_OBJECT_INTERFACE:
@@ -704,6 +706,9 @@ emit_object_to_ptr_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv 
 
 		if (type->type == MONO_TYPE_SZARRAY) {
 			eklass = type->data.klass;
+		} else if (type->type == MONO_TYPE_ARRAY) {
+			eklass = type->data.array->eklass;
+			g_assert(eklass->blittable);
 		} else {
 			g_assert_not_reached ();
 		}

--- a/mono/tests/marshal2.cs
+++ b/mono/tests/marshal2.cs
@@ -60,6 +60,26 @@ public class Tests {
 		byte b;
 		PackStruct1 s;
 	}
+
+	[StructLayout (LayoutKind.Sequential)]
+	struct InvalidArrayForMarshalingStruct
+	{
+		// Missing the following needed directive
+		// [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
+		public readonly char[] CharArray;
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	struct TwoDimensionalArrayStruct
+	{
+		public TwoDimensionalArrayStruct(int[,] vals)
+		{
+			TwoDimensionalArray = vals;
+		}
+
+		[MarshalAs(UnmanagedType.ByValArray, SizeConst = 6)]
+		public readonly int[,] TwoDimensionalArray;
+	}
 	
 	public unsafe static int Main (String[] args) {
 		if (TestDriver.RunTests (typeof (Tests), args) != 0)
@@ -292,5 +312,27 @@ public class Tests {
 		if (s.b != 2)
 			return 2;
 		return 0;
+	}
+
+	public static int test_0_invalid_array_throws () {
+		var ptr = Marshal.AllocHGlobal(Marshal.SizeOf (typeof (InvalidArrayForMarshalingStruct)));
+		try {
+			Marshal.PtrToStructure (ptr, typeof (InvalidArrayForMarshalingStruct));
+		}
+		catch (MarshalDirectiveException e) {
+			return 0;
+		}
+		return 1;
+	}
+
+	public static int test_0_multidimentional_arrays () {
+		var structToMarshal = new TwoDimensionalArrayStruct (new[, ] { {1, 2, 3}, {4, 5, 6} });
+		var ptr = Marshal.AllocHGlobal (Marshal.SizeOf (structToMarshal));
+		Marshal.StructureToPtr (structToMarshal, ptr, false);
+		unsafe {
+			if(((int*)ptr)[4] == 5)
+				return 0;
+		}
+		return 1;
 	}
 }


### PR DESCRIPTION
- Structure field that cannot be marshaled throws exception instead of aborts
- Allow structure pointer conversion for blittable multi-dimentional arrays