### PR TITLE
[2017-12] [sdks] Disable the interpreter on ios device builds.

### DIFF
--- a/sdks/builds/ios.mk
+++ b/sdks/builds/ios.mk
@@ -111,7 +111,7 @@ _ios-$(1)_CONFIGURE_FLAGS = \
 	--enable-dtrace=no \
 	--enable-icall-export \
 	--enable-maintainer-mode \
-	--enable-minimal=ssa,com,jit,reflection_emit_save,reflection_emit,portability,assembly_remapping,attach,verifier,full_messages,appdomains,security,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,remoting,shared_perfcounters \
+	--enable-minimal=ssa,com,interpreter,jit,reflection_emit_save,reflection_emit,portability,assembly_remapping,attach,verifier,full_messages,appdomains,security,sgen_remset,sgen_marksweep_par,sgen_marksweep_fixed,sgen_marksweep_fixed_par,sgen_copying,logging,remoting,shared_perfcounters \
 	--with-lazy-gc-thread-creation=yes \
 	--with-monotouch \
 	--with-tls=pthread \


### PR DESCRIPTION
Backport of #7793.

/cc @vargaz