### PR TITLE
[sre-save] Remove type_token assignment in mono_image_fill_export_table

### DIFF
--- a/mono/metadata/sre-save.c
+++ b/mono/metadata/sre-save.c
@@ -1275,7 +1275,6 @@ mono_image_fill_export_table (MonoDomain *domain, MonoReflectionTypeBuilder *tb,
 	if (m_class_get_type_token (klass) != tb_token) {
 		g_error ("TypeBuilder token %08x does not match klass token %08x", tb_token, m_class_get_type_token (klass));
 	}
-	klass->type_token = tb_token; /* FIXME: shouldn't this already be set? Why is this assignment here? */
 
 	idx = mono_image_fill_export_table_from_class (domain, klass, module_index, 
 												   parent_index, assembly);


### PR DESCRIPTION
In 9725d50c8726b9f34e897737176c64a94865ba0a we added the `g_error`, that should
fire if the `MonoClass:type_token` and the `TypeBuilder` token ever disagree. As a
result, this assignment is strictly redundant.

