### PR TITLE
[genproj] Deduplication of sources

### DIFF
--- a/msvc/scripts/csproj.tmpl
+++ b/msvc/scripts/csproj.tmpl
@@ -51,6 +51,7 @@
 
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 
+<!-- @COMMON_SOURCES@ -->
 <!-- @ALL_SOURCES@ -->
 <!-- @ALL_REFERENCES@ -->
 


### PR DESCRIPTION
This implements a simple deduplication of source files in the .csproj's.

A postprocessing step opens the files and grabs all ItemGroups with sources
and then does an intersection. It then moves files that are common
across all platforms into a separate ItemGroup.
