### PR TITLE
Fix F# build.

### DIFF
--- a/packaging/MacSDK/fsharp.py
+++ b/packaging/MacSDK/fsharp.py
@@ -8,7 +8,7 @@ class FsharpPackage(GitHubTarballPackage):
             override_properties={ 'make': 'make' })
 
         self.extra_stage_files = ['lib/mono/xbuild/Microsoft/VisualStudio/v/FSharp/Microsoft.FSharp.Targets']
-        self.sources.extend(['patches/fsharp-portable-pdb.patch'])
+        self.sources.extend(['patches/fsharp-portable-pdb.patch', 'patches/fsharp-string-switchName.patch'])
 
     def prep(self):
         Package.prep(self)

--- a/packaging/MacSDK/patches/fsharp-string-switchName.patch
+++ b/packaging/MacSDK/patches/fsharp-string-switchName.patch
@@ -1,0 +1,13 @@
+diff --git a/src/scripts/scriptlib.fsx b/src/scripts/scriptlib.fsx
+index cc797e305..5a7be7d2b 100644
+--- a/src/scripts/scriptlib.fsx
++++ b/src/scripts/scriptlib.fsx
+@@ -36,7 +36,7 @@ module Scripting =
+ #if INTERACTIVE
+     let argv = Microsoft.FSharp.Compiler.Interactive.Settings.fsi.CommandLineArgs |> Seq.skip 1 |> Seq.toArray
+ 
+-    let getCmdLineArgOptional switchName = 
++    let getCmdLineArgOptional (switchName: string) =
+         argv |> Array.filter(fun t -> t.StartsWith(switchName)) |> Array.map(fun t -> t.Remove(0, switchName.Length).Trim()) |> Array.tryHead 
+ 
+     let getCmdLineArg switchName defaultValue = 


### PR DESCRIPTION
We need to be specific about the type of `switchName` as
String.StartsWith got a new char overload.

Fixes #7805 
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
