### PR TITLE
[WCF] fix index of message body parts

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel.Description/ContractDescriptionGenerator.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Description/ContractDescriptionGenerator.cs
@@ -497,7 +497,6 @@ namespace System.ServiceModel.Description
 				mb.WrapperNamespace = mca.WrapperNamespace ?? defaultNamespace;
 			}
 
-			int index = 0;
 			foreach (MemberInfo bmi in messageType.GetMembers (BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)) {
 				Type mtype = null;
 				string mname = null;
@@ -531,13 +530,14 @@ namespace System.ServiceModel.Description
 				var mba = GetMessageBodyMemberAttribute (bmi);
 				if (mba != null) {
 					var pd = CreatePartCore (mba, mname, defaultNamespace);
-					if (pd.Index <= 0)
-						pd.Index = index++;
 					pd.Type = MessageFilterOutByRef (mtype);
 					pd.MemberInfo = bmi;
 					mb.Parts.Add (pd);
 				}
 			}
+			int index = 0;
+			foreach (var part in mb.Parts)
+				part.Index = index++;			
 
 			return md;
 		}


### PR DESCRIPTION
Do not use MessageBodyMemberAttribute.Order as index.

When working with Order attribute of MessageBodyMember in MessageContracts, the deserialization of messages often fails with array index out of bounds exception.
WCF services with such message contracts run with dotnet for windows but fail with mono.

Debugging the System.ServiceModel.Dispatcher.DataContractMessagesFormatter method MessageToParts showed the source of the exception: part.Index is used as index to an array of all parts. Therefor the index is expected to be 0 to (number of parts -1).
Since the collection in the message body is already ordered by the name and order of the parts, the solution is to adjust the indexes after all parts are added to the collection.