### PR TITLE
[bcl] Fix Cscompmgd/I18N.Rare not having any tests

### DIFF
--- a/mcs/class/Cscompmgd/Test/Microsoft.CSharp/CompilerTest.cs
+++ b/mcs/class/Cscompmgd/Test/Microsoft.CSharp/CompilerTest.cs
@@ -8,6 +8,7 @@
 //
 
 using System;
+using System.Collections.Generic;
 using Microsoft.CSharp;
 
 using NUnit.Framework;
@@ -20,6 +21,12 @@ namespace MonoTests.Cscompmgd
 		[SetUp]
 		public void GetReady ()
 		{
+		}
+
+		[TestCase]
+		public void EmptySourceTexts ()
+		{
+			Assert.Throws<IndexOutOfRangeException> (() => Compiler.Compile (Array.Empty<string> (), Array.Empty<string> (), "", null, null));
 		}
 	}
 }

--- a/mcs/class/I18N/Rare/I18N.Rare_test.dll.sources
+++ b/mcs/class/I18N/Rare/I18N.Rare_test.dll.sources
@@ -1,2 +1,3 @@
 ../../EncodingTestBase.cs
 I18N.Rare.EncodingTest.cs
+I18N.Rare.Test.cs

--- a/mcs/class/I18N/Rare/Makefile
+++ b/mcs/class/I18N/Rare/Makefile
@@ -8,6 +8,7 @@ KEYFILE = ../../mono.pub
 LOCAL_MCS_FLAGS = /unsafe
 TEST_LIB_REFS = I18N
 
-EXTRA_DISTFILES = $(wildcard *.ucm)
+EXTRA_DISTFILES = $(wildcard *.ucm) \
+	$(wildcard Test/texts/*.txt)
 
 include ../../../build/library.make

--- a/mcs/class/I18N/Rare/Test/I18N.Rare.Test.cs
+++ b/mcs/class/I18N/Rare/Test/I18N.Rare.Test.cs
@@ -1,0 +1,74 @@
+//
+// I18N.Rare.Test.cs
+//
+// Author:
+//	Alexander Köplinger (alexander.koeplinger@xamarin.com)
+//
+// Copyright (C) 2018 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.IO;
+using System.Text;
+using NUnit.Framework;
+
+namespace MonoTests.I18N.Rare
+{
+	[TestFixture]
+	public class TestRare
+	{
+		private global::I18N.Common.Manager Manager = global::I18N.Common.Manager.PrimaryManager;
+
+		// ASCII compatible Rare codepages
+		int[] cps = { 708, 852, 855, 857, 858, 862, 864, 866, 869 };
+
+		void AssertDecode (string utf8file, string decfile, int codepage)
+		{
+			string decoded = null;
+			byte [] encoded = null;
+			using (StreamReader sr = new StreamReader (utf8file,
+				Encoding.UTF8)) {
+				decoded = sr.ReadToEnd ();
+			}
+			using (FileStream fs = File.OpenRead (decfile)) {
+				encoded = new byte [fs.Length];
+				fs.Read (encoded, 0, (int) fs.Length);
+			}
+			Encoding enc = Manager.GetEncoding (codepage);
+			char [] actual;
+
+			Assert.AreEqual (decoded.Length,
+				enc.GetCharCount (encoded, 0, encoded.Length),
+				"GetCharCount(byte[], 0, len)");
+			actual = enc.GetChars (encoded, 0, encoded.Length);
+			Assert.AreEqual (decoded.ToCharArray (), actual,
+				"GetChars(byte[], 0, len)");
+		}
+
+		[Test]
+		[TestCaseSource (nameof (cps))]
+		public void Ascii_Test_All(int cp)
+		{
+			AssertDecode("Test/texts/ascii-test.txt", "Test/texts/ascii-test.txt", cp);
+		}
+	}
+}

--- a/mcs/class/I18N/Rare/Test/texts/ascii-test.txt
+++ b/mcs/class/I18N/Rare/Test/texts/ascii-test.txt
@@ -1,0 +1,1 @@
+begin123end


### PR DESCRIPTION
This caused a warning in some tools that process the NUnit result xml.
The fix is to make them execute at least one test.
