### PR TITLE
[2018-02] [corlib] Restores ConcurrentDictionary serialization support.

### DIFF
--- a/mcs/class/corlib/Test/System.Collections.Concurrent/ConcurrentDictionaryTests.cs
+++ b/mcs/class/corlib/Test/System.Collections.Concurrent/ConcurrentDictionaryTests.cs
@@ -29,6 +29,8 @@ using MonoTests.System.Threading.Tasks;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
 
 using NUnit;
 using NUnit.Framework;
@@ -363,6 +365,21 @@ namespace MonoTests.System.Collections.Concurrent
 
 			Assert.IsTrue (dict.Contains (validKeyPair));
 			Assert.IsFalse (dict.Contains (wrongKeyPair));
+		}
+
+		[Test]
+		public void SerializationRoundTrip ()
+		{
+			var bf = new BinaryFormatter();
+
+			var cd = new ConcurrentDictionary<int, int>();
+			cd[0] = 42;
+			var ms = new MemoryStream();
+			bf.Serialize(ms, cd);
+
+			ms.Seek(0, SeekOrigin.Begin);
+			var result = (ConcurrentDictionary<int, int>) bf.Deserialize(ms);
+			Assert.AreEqual (42, result [0]);
 		}
 	}
 }


### PR DESCRIPTION
Backport of #7849.

/cc @marek-safar