### PR TITLE
Use __PASE__ for things i needs that AIX doesn't

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -652,11 +652,8 @@ mono_thread_internal_set_priority (MonoInternalThread *internal, MonoThreadPrior
 
 	/* Necessary to get valid priority range */
 
-#if defined(_AIX)
-	/*
-	 * this AIX hack is because PASE is finicky; AIX is just less
-	 * fatalistic about it
-	 */
+#if defined(__PASE__)
+	/* only priorities allowed by IBM i */
 	min = PRIORITY_MIN;
 	max = PRIORITY_MAX;
 #else
@@ -691,7 +688,8 @@ mono_thread_internal_set_priority (MonoInternalThread *internal, MonoThreadPrior
 		}
 	}
 
-#if defined(_AIX)
+#if defined(__PASE__)
+	/* only scheduling param allowed by IBM i */
 	res = pthread_setschedparam (tid, SCHED_OTHER, &param);
 #else
 	res = pthread_setschedparam (tid, policy, &param);

--- a/mono/utils/hazard-pointer.c
+++ b/mono/utils/hazard-pointer.c
@@ -106,7 +106,7 @@ mono_thread_small_id_alloc (void)
 		hazard_table_size = HAZARD_TABLE_MAX_SIZE;
 #else
 		gpointer page_addr;
-#if defined(_AIX)
+#if defined(__PASE__)
 		/*
 		 * HACK: allocating the table with none prot will cause i 7.1
 		 * to segfault when accessing or protecting it

--- a/mono/utils/mono-time.c
+++ b/mono/utils/mono-time.c
@@ -219,8 +219,8 @@ mono_100ns_ticks (void)
 		timebase.denom *= 100; /* we return 100ns ticks */
 	}
 	return now * timebase.numer / timebase.denom;
-#elif defined(CLOCK_MONOTONIC) && !defined(_AIX)
-	/* !_AIX is defined because i 7.1 doesn't have clock_getres */
+#elif defined(CLOCK_MONOTONIC) && !defined(__PASE__)
+	/* !__PASE__ is defined because i 7.1 doesn't have clock_getres */
 	struct timespec tspec;
 	static struct timespec tspec_freq = {0};
 	static int can_use_clock = 0;


### PR DESCRIPTION
IBM's new toolchain for i defines `__PASE__` for GCC packages intended for it, and if cross-compiling from AIX, we can pass `CPPFLAGS="-D__PASE__"` to `./configure` as needed. (Theoretically, we could also add a check for `os400` for `$host_os` and append that to `CPPFLAGS`, but apparently everyone should be on that new toolchain if they intended to compile directly on i anyways, so I didn't add it.)