### PR TITLE
[2018-02] Whitelist illinkanalyzer in macOS package

### DIFF
--- a/packaging/MacSDK/packaging/resources/whitelist.txt
+++ b/packaging/MacSDK/packaging/resources/whitelist.txt
@@ -42,6 +42,7 @@ gmcs
 httpcfg
 ikdasm
 ilasm
+illinkanalyzer
 installvst
 ipy
 ipy64


### PR DESCRIPTION
Backport of #7861.

/cc @akoeplinger