### PR TITLE
Add BindingFlags.DoNotWrapExceptions

### DIFF
--- a/mcs/class/corlib/ReferenceSources/RuntimeType.cs
+++ b/mcs/class/corlib/ReferenceSources/RuntimeType.cs
@@ -138,7 +138,7 @@ namespace System
 			return m_serializationCtor;
 		}
 
-		internal Object CreateInstanceSlow(bool publicOnly, bool skipCheckThis, bool fillCache, ref StackCrawlMark stackMark)
+		internal Object CreateInstanceSlow(bool publicOnly, bool wrapExceptions, bool skipCheckThis, bool fillCache, ref StackCrawlMark stackMark)
 		{
 			//bool bNeedSecurityCheck = true;
 			//bool bCanBeCached = false;
@@ -150,10 +150,10 @@ namespace System
 			//if (!fillCache)
 			//	bSecurityCheckOff = true;
 
-			return CreateInstanceMono (!publicOnly);
+			return CreateInstanceMono (!publicOnly, wrapExceptions);
 		}
 
-		object CreateInstanceMono (bool nonPublic)
+		object CreateInstanceMono (bool nonPublic, bool wrapExceptions)
 		{
 			var ctor = GetDefaultConstructor ();
 			if (!nonPublic && ctor != null && !ctor.IsPublic) {
@@ -176,7 +176,7 @@ namespace System
 				throw new MissingMethodException (Locale.GetText ("Cannot create an abstract class '{0}'.", FullName));
 			}
 
-			return ctor.InternalInvoke (null, null);
+			return ctor.InternalInvoke (null, null, wrapExceptions);
 		}
 
 		internal Object CheckValue (Object value, Binder binder, CultureInfo culture, BindingFlags invokeAttr)
@@ -465,7 +465,7 @@ namespace System
 		{
 			var gt = (RuntimeType) MakeGenericType (genericType, new Type [] { genericArgument });
 			var ctor = gt.GetDefaultConstructor ();
-			return ctor.InternalInvoke (null, null);
+			return ctor.InternalInvoke (null, null, wrapExceptions: true);
 		}
 
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]

--- a/mcs/class/corlib/System.Reflection.Emit/DynamicMethod.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/DynamicMethod.cs
@@ -296,7 +296,7 @@ namespace System.Reflection.Emit {
 				if (method == null)
 					method = new MonoMethod (mhandle);
 
-				return method.Invoke (obj, parameters);
+				return method.Invoke (obj, invokeAttr, binder, parameters, culture);
 			}
 			catch (MethodAccessException mae) {
 				throw new TargetInvocationException ("Method cannot be invoked.", mae);

--- a/mcs/class/corlib/corlib.dll.sources
+++ b/mcs/class/corlib/corlib.dll.sources
@@ -1170,7 +1170,7 @@ ReferenceSources/AppContextDefaultValues.cs
 ../referencesource/mscorlib/system/reflection/assemblynameflags.cs
 ../referencesource/mscorlib/system/reflection/assemblynameproxy.cs
 ../referencesource/mscorlib/system/reflection/binder.cs
-../referencesource/mscorlib/system/reflection/bindingflags.cs
+../../../external/corefx/src/Common/src/CoreLib/System/Reflection/BindingFlags.cs
 ../referencesource/mscorlib/system/reflection/callingconventions.cs
 ../referencesource/mscorlib/system/reflection/CustomAttributeExtensions.cs
 ../referencesource/mscorlib/system/reflection/defaultmemberattribute.cs

--- a/mcs/class/corlib/corlib_xtest.dll.sources
+++ b/mcs/class/corlib/corlib_xtest.dll.sources
@@ -157,6 +157,7 @@
 # System.Runtime
 # TODO: Many more to be included
 ../../../external/corefx/src/System.Runtime/tests/System/String.SplitTests.cs
+../../../external/corefx/src/System.Runtime/tests/System/Reflection/BindingFlagsDoNotWrap.netcoreapp.cs
 
 ../../../external/corefx/src/System.Runtime/tests/System/Runtime/CompilerServices/*.cs:RuntimeHelpersTests.netcoreapp.cs,ConditionalWeakTableTests.netcoreapp.cs,ConditionalWeakTableTests.cs
 

--- a/mcs/class/referencesource/mscorlib/system/activator.cs
+++ b/mcs/class/referencesource/mscorlib/system/activator.cs
@@ -184,9 +184,14 @@ namespace System {
                                   null,
                                   ref stackMark);
         }
-            
+
+        public static object CreateInstance(Type type, bool nonPublic)
+        {
+            return CreateInstance(type, nonPublic, wrapExceptions: true);
+        }
+
         [MethodImplAttribute(MethodImplOptions.NoInlining)] // Methods containing StackCrawlMark local var has to be marked non-inlineable
-        static public Object CreateInstance(Type type, bool nonPublic)
+        internal static object CreateInstance(Type type, bool nonPublic, bool wrapExceptions)
         {
             if ((object)type == null)
                 throw new ArgumentNullException("type");
@@ -198,7 +203,7 @@ namespace System {
                 throw new ArgumentException(Environment.GetResourceString("Arg_MustBeType"), "type");
 
             StackCrawlMark stackMark = StackCrawlMark.LookForMyCaller;
-            return rt.CreateInstanceDefaultCtor(!nonPublic, false, true, ref stackMark);
+            return rt.CreateInstanceDefaultCtor(!nonPublic, false, true, wrapExceptions, ref stackMark);
         }
 
         [MethodImplAttribute(MethodImplOptions.NoInlining)] // Methods containing StackCrawlMark local var has to be marked non-inlineable
@@ -228,7 +233,7 @@ namespace System {
                 return (T)rt.CreateInstanceSlow(true /*publicOnly*/, true /*skipCheckThis*/, false /*fillCache*/, ref stackMark);
             else
 #endif // FEATURE_CORECLR
-            return (T)rt.CreateInstanceDefaultCtor(true /*publicOnly*/, true /*skipCheckThis*/, true /*fillCache*/, ref stackMark);
+            return (T)rt.CreateInstanceDefaultCtor(true /*publicOnly*/, true /*skipCheckThis*/, true /*fillCache*/, true /*wrapExceptions*/, ref stackMark);
         }
 
         [ResourceExposure(ResourceScope.Machine)]

--- a/mcs/class/referencesource/mscorlib/system/rttype.cs
+++ b/mcs/class/referencesource/mscorlib/system/rttype.cs
@@ -5266,10 +5266,12 @@ namespace System
 
                     // deal with the __COMObject case first. It is very special because from a reflection point of view it has no ctors
                     // so a call to GetMemberCons would fail
+                    bool publicOnly = (bindingAttr & BindingFlags.NonPublic) == 0;
+                    bool wrapExceptions = (bindingAttr & BindingFlags.DoNotWrapExceptions) == 0;
                     if (argCnt == 0 && (bindingAttr & BindingFlags.Public) != 0 && (bindingAttr & BindingFlags.Instance) != 0
                         && (IsGenericCOMObjectImpl() || IsValueType)) 
                     {
-                        server = CreateInstanceDefaultCtor((bindingAttr & BindingFlags.NonPublic) == 0 , false, true, ref stackMark);
+                        server = CreateInstanceDefaultCtor(publicOnly, false, true, wrapExceptions, ref stackMark);
                     }
                     else 
                     {
@@ -5381,7 +5383,7 @@ namespace System
                             } else {
 #endif
                             // fast path??
-                            server = Activator.CreateInstance(this, true);
+                            server = Activator.CreateInstance(this, nonPublic: true, wrapExceptions: wrapExceptions);
 
 #if MONO && FEATURE_REMOTING
                             }
@@ -5593,7 +5595,7 @@ namespace System
         [System.Security.SecuritySafeCritical]  // auto-generated
         [DebuggerStepThroughAttribute]
         [Diagnostics.DebuggerHidden]
-        internal Object CreateInstanceDefaultCtor(bool publicOnly, bool skipCheckThis, bool fillCache, ref StackCrawlMark stackMark)
+        internal Object CreateInstanceDefaultCtor(bool publicOnly, bool skipCheckThis, bool fillCache, bool wrapExceptions, ref StackCrawlMark stackMark)
         {
             if (GetType() == typeof(ReflectionOnlyType))
                 throw new InvalidOperationException(Environment.GetResourceString("InvalidOperation_NotAllowedInReflectionOnly"));
@@ -5639,7 +5641,7 @@ namespace System
                 }
             }
 #endif
-            return CreateInstanceSlow(publicOnly, skipCheckThis, fillCache, ref stackMark);
+            return CreateInstanceSlow(publicOnly, wrapExceptions, skipCheckThis, fillCache, ref stackMark);
         }
 #if !MONO
         internal void InvalidateCachedNestedType()


### PR DESCRIPTION
The original design review is here: dotnet/corefx#22866 . To summarize, this adds a new flag to `BindingFlags` called `DoNotWrapExceptions`. When this flag is used to invoke a method using reflection, any exceptions thrown are not wrapped with a `TargetInvocationException`.

It has already been implemented in some other version of .NET:
- dotnet/corert#4437
- dotnet/coreclr#13767

I would be delighted if this handy feature was also available in Mono.

I have in part based my changes on the CoreCLR implementation. There all already tests for this feature in corefx, so I have added those to the corlib_xtest.dll.sources file.

I have a couple of concerns about my implementation:
- I notice that `DynamicMethod.Invoke` was ignoring the BindingFlags and other arguments. I changed this method to pass along all the arguments. For what it's worth, it appears that [CoreCLR respects](https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/Reflection/Emit/DynamicMethod.cs#L488) these arguments.