### PR TITLE
Implement Field SetValueDirect on non-struct targets. Add test case from roslyn issue 19038.

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -2169,6 +2169,8 @@ mono_TypedReference_ToObject (MonoTypedRef* tref);
 ICALL_EXPORT void
 ves_icall_System_RuntimeFieldHandle_SetValueDirect (MonoReflectionField *field, MonoReflectionType *field_type, MonoTypedRef *obj, MonoObject *value, MonoReflectionType *context_type)
 {
+	HANDLE_FUNCTION_ENTER ();
+
 	ERROR_DECL (error);
 
 	MonoClassField *f;
@@ -2186,13 +2188,14 @@ ves_icall_System_RuntimeFieldHandle_SetValueDirect (MonoReflectionField *field, 
 		valueHandle = MONO_HANDLE_NEW (MonoObject, value);
 		ves_icall_MonoField_SetValueInternal (fieldHandle, objHandle, valueHandle, error);
 		mono_error_set_pending_exception (error);
-		return;
+	} else {
+		if (MONO_TYPE_IS_REFERENCE (f->type))
+			mono_copy_value (f->type, (guint8*)obj->value + f->offset - sizeof (MonoObject), value, FALSE);
+		else
+			mono_copy_value (f->type, (guint8*)obj->value + f->offset - sizeof (MonoObject), mono_object_unbox (value), FALSE);
 	}
 
-	if (MONO_TYPE_IS_REFERENCE (f->type))
-		mono_copy_value (f->type, (guint8*)obj->value + f->offset - sizeof (MonoObject), value, FALSE);
-	else
-		mono_copy_value (f->type, (guint8*)obj->value + f->offset - sizeof (MonoObject), mono_object_unbox (value), FALSE);
+	HANDLE_FUNCTION_RETURN ();
 }
 
 ICALL_EXPORT MonoObject *

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -2174,7 +2174,7 @@ typed_reference_to_object (MonoTypedRef *tref, MonoError *error)
 	} else {
 		result = mono_value_box_handle (mono_domain_get (), tref->klass, tref->value, error);
 	}
-	HANDLE_FUNCTION_RETURN_OBJ (result);
+	HANDLE_FUNCTION_RETURN_REF (MonoObject, result);
 }
 
 ICALL_EXPORT void
@@ -2195,12 +2195,10 @@ ves_icall_System_RuntimeFieldHandle_SetValueDirect (MonoReflectionField *field, 
 			valueHandle = MONO_HANDLE_NEW (MonoObject, value);
 		goto_if_nok (error, leave);
 		ves_icall_MonoField_SetValueInternal (fieldHandle, objHandle, valueHandle, error);
-	} else {
-		if (MONO_TYPE_IS_REFERENCE (f->type))
-			mono_copy_value (f->type, (guint8*)obj->value + f->offset - sizeof (MonoObject), value, FALSE);
-		else
-			mono_copy_value (f->type, (guint8*)obj->value + f->offset - sizeof (MonoObject), mono_object_unbox (value), FALSE);
-	}
+	} else if (MONO_TYPE_IS_REFERENCE (f->type))
+		mono_copy_value (f->type, (guint8*)obj->value + f->offset - sizeof (MonoObject), value, FALSE);
+	else
+		mono_copy_value (f->type, (guint8*)obj->value + f->offset - sizeof (MonoObject), mono_object_unbox (value), FALSE);
 
 leave:
 	ICALL_RETURN ();

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -539,7 +539,8 @@ TESTS_CS_SRC=		\
 	tailcall-generic-cast-cs.cs \
 	tailcall-interface.cs \
 	sizeof-empty-structs.cs \
-	bug-60843.cs
+	bug-60843.cs \
+	roslyn-bug-19038.cs
 
 if AMD64
 TESTS_CS_SRC += async-exc-compilation.cs finally_guard.cs finally_block_ending_in_dead_bb.cs

--- a/mono/tests/roslyn-bug-19038.cs
+++ b/mono/tests/roslyn-bug-19038.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Reflection;
+
+unsafe public class C {
+    public int Value;
+
+    static void Main()
+    {
+        C a = new C { Value = 12 };
+        FieldInfo info = typeof(C).GetField("Value");
+        TypedReference reference = __makeref(a);
+
+        if (!(reference is TypedReference reference0)) 
+            throw new Exception("TypedReference");
+
+        info.SetValueDirect(reference0, 34);
+
+        Console.WriteLine($"a.Value = {a.Value}");
+        if (a.Value != 34)
+            throw new Exception("SetValueDirect");
+
+        int z = 56;
+        if (CopyRefInt(ref z) != 56) 
+            throw new Exception("ref z");
+
+        Console.WriteLine("ok");
+    }
+
+    static int CopyRefInt(ref int z)
+    {
+        if (!(z is int z0)) 
+            throw new Exception("CopyRefInt");
+        return z0;
+    }
+}


### PR DESCRIPTION
A test case from Roslyn issue 19308 uses SetValueDirect to modify a field on a class. Mono currently only implements SetValueDirect for fields of structs. Adding class support makes the test pass as expected.