### PR TITLE
[wasm] Add OS detection for WASM. Fixes #7344 [DEPEND ON #7874]

### DIFF
--- a/mcs/class/corlib/System.Runtime.InteropServices.RuntimeInformation/RuntimeInformation.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices.RuntimeInformation/RuntimeInformation.cs
@@ -43,6 +43,9 @@ namespace System.Runtime.InteropServices
 
 		public static bool IsOSPlatform (OSPlatform osPlatform)
 		{
+#if WASM
+			return osPlatform == OSPlatform.Create ("WEBASSEMBLY"); 
+#else
 			switch (Environment.Platform) {
 			case PlatformID.Win32NT:
 				return osPlatform == OSPlatform.Windows;
@@ -53,13 +56,18 @@ namespace System.Runtime.InteropServices
 			default:
 				return false;
 			}
+#endif
 		}
 
 		public static string OSDescription
 		{
 			get
 			{
+#if WASM
+				return "web"; //yes, hardcoded as right now we don't really support other environments
+#else
 				return Environment.OSVersion.VersionString;
+#endif
 			}
 		}
 

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2703,14 +2703,18 @@ sgen_client_degraded_allocation (void)
 	static gint32 num_degraded = 0;
 
 	gint32 major_gc_count = mono_atomic_load_i32 (&mono_gc_stats.major_gc_count);
+	//The WASM target aways triggers degrated allocation before collecting. So no point in printing the warning as it will just confuse users
+#if !defined (TARGET_WASM)
 	if (mono_atomic_load_i32 (&last_major_gc_warned) < major_gc_count) {
 		gint32 num = mono_atomic_inc_i32 (&num_degraded);
 		if (num == 1 || num == 3)
 			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "Warning: Degraded allocation.  Consider increasing nursery-size if the warning persists.");
 		else if (num == 10)
 			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "Warning: Repeated degraded allocation.  Consider increasing nursery-size.");
+
 		mono_atomic_store_i32 (&last_major_gc_warned, major_gc_count);
 	}
+#endif
 }
 
 /*

--- a/mono/mini/aot-runtime-wasm.c
+++ b/mono/mini/aot-runtime-wasm.c
@@ -77,7 +77,7 @@ handle_enum:
 	case MONO_TYPE_VOID:
 		return 'V';
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enum_type (t->data.klass)) {
+		if (m_class_is_enumtype (t->data.klass)) {
 			t = mono_class_enum_basetype (t->data.klass);
 			goto handle_enum;
 		}

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -2585,6 +2585,7 @@ mono_jit_set_aot_mode (MonoAotMode mode)
 		mono_aot_only = TRUE;
 		mono_use_interpreter = TRUE;
 		mono_llvm_only = TRUE;
+		mono_interpreter_only = TRUE;
 	}
 }
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -103,6 +103,8 @@ gboolean mono_compile_aot = FALSE;
 gboolean mono_aot_only = FALSE;
 /* Same as mono_aot_only, but only LLVM compiled code is used, no trampolines */
 gboolean mono_llvm_only = FALSE;
+/* If this is set, force the usage of the interpreter */
+gboolean mono_interpreter_only = FALSE;
 MonoAotMode mono_aot_mode = MONO_AOT_MODE_NONE;
 
 const char *mono_build_date;
@@ -2092,7 +2094,7 @@ mono_jit_compile_method_with_opt (MonoMethod *method, guint32 opt, gboolean jit_
 
 	error_init (error);
 
-	if (mono_use_interpreter && !mono_aot_only && !jit_only)
+	if (mono_interpreter_only || (mono_use_interpreter && !mono_aot_only && !jit_only))
 		use_interp = TRUE;
 	if (!use_interp && mono_interp_only_classes) {
 		for (GSList *l = mono_interp_only_classes; l; l = l->next) {
@@ -2738,7 +2740,7 @@ mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 	MonoJitInfo *ji = NULL;
 	gboolean callee_gsharedvt = FALSE;
 
-	if (mono_use_interpreter && !mono_aot_only)
+	if (mono_interpreter_only || (mono_use_interpreter && !mono_aot_only))
 		return mini_get_interp_callbacks ()->runtime_invoke (method, obj, params, exc, error);
 
 	error_init (error);

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -321,6 +321,7 @@ extern gboolean mono_break_on_exc;
 extern gboolean mono_compile_aot;
 extern gboolean mono_aot_only;
 extern gboolean mono_llvm_only;
+extern gboolean mono_interpreter_only;
 extern MonoAotMode mono_aot_mode;
 extern MONO_API const char *mono_build_date;
 extern gboolean mono_do_signal_chaining;

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -1609,7 +1609,7 @@ no_delegate_trampoline (void)
 gpointer
 mono_create_delegate_trampoline (MonoDomain *domain, MonoClass *klass)
 {
-	if (mono_llvm_only || (mono_use_interpreter && !mono_aot_only))
+	if (mono_llvm_only || mono_interpreter_only || (mono_use_interpreter && !mono_aot_only))
 		return no_delegate_trampoline;
 
 	return mono_create_delegate_trampoline_info (domain, klass, NULL)->invoke_impl;

--- a/mono/utils/mono-time.c
+++ b/mono/utils/mono-time.c
@@ -151,7 +151,7 @@ mono_msec_boottime (void)
 	gint64 retval = 0;
 
 	/* clock_gettime () is found by configure on Apple builds, but its only present from ios 10, macos 10.12, tvos 10 and watchos 3 */
-#if (defined(HAVE_CLOCK_MONOTONIC_COARSE) || defined(HAVE_CLOCK_MONOTONIC)) && !(defined(TARGET_IOS) || defined(TARGET_OSX) || defined(TARGET_WATCHOS) || defined(TARGET_TVOS))
+#if !defined (TARGET_WASM) && ((defined(HAVE_CLOCK_MONOTONIC_COARSE) || defined(HAVE_CLOCK_MONOTONIC)) && !(defined(TARGET_IOS) || defined(TARGET_OSX) || defined(TARGET_WATCHOS) || defined(TARGET_TVOS)))
 	clockid_t clockType =
 #if HAVE_CLOCK_MONOTONIC_COARSE
 	CLOCK_MONOTONIC_COARSE; /* good enough resolution, fastest speed */

--- a/sdks/wasm/main.cs
+++ b/sdks/wasm/main.cs
@@ -43,10 +43,13 @@ public class Driver {
 
 	static void TPStart () {
 		var l = new List<Task> ();
-		for (int i = 0; i < 10; ++i) {
+		for (int i = 0; i < 5; ++i) {
 			l.Add (Task.Run (() => {
 				++step_count;
 			}));
+			l.Add (Task.Factory.StartNew (() => {
+				++step_count;
+			}, TaskCreationOptions.LongRunning));
 		}
 		cur_task = Task.WhenAll (l).ContinueWith (t => {
 		});
@@ -55,9 +58,12 @@ public class Driver {
 	static bool TPPump () {
 		if (tp_pump_count > 10) {
 			Console.WriteLine ("Pumped the TP test 10 times and no progress <o> giving up");
+			latest_test_result = "FAIL";
 			return false;
 		}
+
 		tp_pump_count++;
+		latest_test_result = "PASS";
 		return !cur_task.IsCompleted;
 	}
 


### PR DESCRIPTION
The change was done by ifdef'ing WASM because I don't see a way to change
Environment.Platform / Environment.OSVersion without touching the public
API.

Right now OSDescription is being used to return the execution environment.
Once we properly support node and other non-web embeddings, it will be
adjusted to do so.

Fixes https://github.com/mono/mono/issues/7344
Depends on #7874