### PR TITLE
[RFC] [mini] Introduce MonoEEFeatures with a single feature use_aot_trampolines.

### DIFF
--- a/mono/mini/aot-runtime-wasm.c
+++ b/mono/mini/aot-runtime-wasm.c
@@ -91,7 +91,7 @@ get_long_arg (InterpMethodArguments *margs, int idx)
 #include "wasm_m2n_invoke.g.h"
 
 void
-wasm_interp_to_native_trampoline (void *target_func, InterpMethodArguments *margs)
+mono_wasm_interp_to_native_trampoline (void *target_func, InterpMethodArguments *margs)
 {
 	char cookie [32];
 	int c_count;

--- a/mono/mini/aot-runtime-wasm.c
+++ b/mono/mini/aot-runtime-wasm.c
@@ -12,36 +12,6 @@
 
 #ifdef TARGET_WASM
 
-static void
-wasm_restore_context (void)
-{
-	g_error ("wasm_restore_context");
-}
-
-static void
-wasm_call_filter (void)
-{
-	g_error ("wasm_call_filter");
-}
-
-static void
-wasm_throw_exception (void)
-{
-	g_error ("wasm_throw_exception");
-}
-
-static void
-wasm_rethrow_exception (void)
-{
-	g_error ("wasm_rethrow_exception");
-}
-
-static void
-wasm_throw_corlib_exception (void)
-{
-	g_error ("wasm_throw_corlib_exception");
-}
-
 static char
 type_to_c (MonoType *t)
 {
@@ -120,7 +90,7 @@ get_long_arg (InterpMethodArguments *margs, int idx)
 
 #include "wasm_m2n_invoke.g.h"
 
-static void
+void
 wasm_interp_to_native_trampoline (void *target_func, InterpMethodArguments *margs)
 {
 	char cookie [32];
@@ -142,45 +112,6 @@ wasm_interp_to_native_trampoline (void *target_func, InterpMethodArguments *marg
 	icall_trampoline_dispatch (cookie, target_func, margs);
 }
 
-gpointer
-mono_aot_get_trampoline_full (const char *name, MonoTrampInfo **out_tinfo)
-{
-	gpointer code = NULL;
-
-	if (!strcmp (name, "restore_context"))
-		code = wasm_restore_context;
-	else if (!strcmp (name, "call_filter"))
-		code = wasm_call_filter;
-	else if (!strcmp (name, "throw_exception"))
-		code = wasm_throw_exception;
-	else if (!strcmp (name, "rethrow_exception"))
-		code = wasm_rethrow_exception;
-	else if (!strcmp (name, "throw_corlib_exception"))
-		code = wasm_throw_corlib_exception;
-	else if (!strcmp (name, "interp_to_native_trampoline"))
-		code = wasm_interp_to_native_trampoline;
-	else if (!strcmp (name, "sdb_breakpoint_trampoline"))
-		code = mono_wasm_breakpoint_hit;
-
-	if (!code)
-		g_error ("could not find trampoline for %s\n", name);
-
-	if (out_tinfo) {
-		MonoTrampInfo *tinfo = g_new0 (MonoTrampInfo, 1);
-		tinfo->code = code;
-		tinfo->code_size = 1;
-		tinfo->name = g_strdup (name);
-		tinfo->ji = NULL;
-		tinfo->unwind_ops = NULL;
-		tinfo->uw_info = NULL;
-		tinfo->uw_info_len = 0;
-		tinfo->owns_uw_info = FALSE;
-
-		*out_tinfo = tinfo;
-	}
-
-	return code;
-}
 #else /* TARGET_WASM */
 
 MONO_EMPTY_SOURCE_FILE (aot_runtime_wasm);

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -5260,8 +5260,6 @@ no_trampolines (void)
 	g_assert_not_reached ();
 }
 
-
-#ifndef TARGET_WASM
 /*
  * Return the trampoline identified by NAME from the mscorlib AOT file.
  * On ppc64, this returns a function descriptor.
@@ -5278,8 +5276,6 @@ mono_aot_get_trampoline_full (const char *name, MonoTrampInfo **out_tinfo)
 
 	return mono_create_ftnptr_malloc ((guint8 *)load_function_full (amodule, name, out_tinfo));
 }
-#endif
-
 
 gpointer
 mono_aot_get_trampoline (const char *name)

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -74,6 +74,7 @@
 static FILE *mini_stats_fd;
 
 static void mini_usage (void);
+static void mono_runtime_set_execution_mode (MonoEEMode mode);
 
 #ifdef HOST_WIN32
 /* Need this to determine whether to detach console */
@@ -1752,7 +1753,7 @@ apply_root_domain_configuration_file_bindings (MonoDomain *domain, char *root_do
 static void
 mono_enable_interp (const char *opts)
 {
-	mono_use_interpreter = TRUE;
+	mono_runtime_set_execution_mode (MONO_EE_MODE_INTERP);
 	if (opts)
 		mono_interp_opts_string = opts;
 
@@ -2556,6 +2557,50 @@ mono_jit_set_aot_only (gboolean val)
 	mono_aot_only = val;
 }
 
+static void
+mono_runtime_set_execution_mode (MonoEEMode mode)
+{
+	memset (&mono_ee_features, 0, sizeof (mono_ee_features));
+
+	switch (mono_aot_mode) {
+	case MONO_AOT_MODE_LLVMONLY:
+		mono_aot_only = TRUE;
+		mono_llvm_only = TRUE;
+
+		mono_ee_features.use_aot_trampolines = TRUE;
+		break;
+
+	case MONO_AOT_MODE_FULL:
+		mono_aot_only = TRUE;
+		break;
+
+	case MONO_AOT_MODE_HYBRID:
+		mono_set_generic_sharing_vt_supported (TRUE);
+		mono_set_partial_sharing_supported (TRUE);
+		break;
+
+	case MONO_AOT_MODE_INTERP:
+		mono_aot_only = TRUE;
+		mono_use_interpreter = TRUE;
+
+		mono_ee_features.use_aot_trampolines = TRUE;
+		break;
+
+	case MONO_AOT_MODE_INTERP_LLVMONLY:
+		mono_aot_only = TRUE;
+		mono_use_interpreter = TRUE;
+		mono_llvm_only = TRUE;
+		break;
+
+	case MONO_EE_MODE_INTERP:
+		mono_use_interpreter = TRUE;
+		break;
+
+	default:
+		g_error ("Unknown execution-mode %d", mode);
+	}
+}
+
 /**
  * mono_jit_set_aot_mode:
  */
@@ -2565,32 +2610,9 @@ mono_jit_set_aot_mode (MonoAotMode mode)
 	/* we don't want to set mono_aot_mode twice */
 	g_assert (mono_aot_mode == MONO_AOT_MODE_NONE);
 	mono_aot_mode = mode;
-	memset (&mono_ee_features, 0, sizeof (mono_ee_features));
+	
+	mono_runtime_set_execution_mode ((MonoEEMode)mode);
 
-	if (mono_aot_mode == MONO_AOT_MODE_LLVMONLY) {
-		mono_aot_only = TRUE;
-		mono_llvm_only = TRUE;
-
-		mono_ee_features.use_aot_trampolines = TRUE;
-	}
-	if (mono_aot_mode == MONO_AOT_MODE_FULL) {
-		mono_aot_only = TRUE;
-	}
-	if (mono_aot_mode == MONO_AOT_MODE_HYBRID) {
-		mono_set_generic_sharing_vt_supported (TRUE);
-		mono_set_partial_sharing_supported (TRUE);
-	}
-	if (mono_aot_mode == MONO_AOT_MODE_INTERP) {
-		mono_aot_only = TRUE;
-		mono_use_interpreter = TRUE;
-
-		mono_ee_features.use_aot_trampolines = TRUE;
-	}
-	if (mono_aot_mode == MONO_AOT_MODE_INTERP_LLVMONLY) {
-		mono_aot_only = TRUE;
-		mono_use_interpreter = TRUE;
-		mono_llvm_only = TRUE;
-	}
 }
 
 mono_bool

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -2565,10 +2565,13 @@ mono_jit_set_aot_mode (MonoAotMode mode)
 	/* we don't want to set mono_aot_mode twice */
 	g_assert (mono_aot_mode == MONO_AOT_MODE_NONE);
 	mono_aot_mode = mode;
+	memset (&mono_ee_features, 0, sizeof (mono_ee_features));
 
 	if (mono_aot_mode == MONO_AOT_MODE_LLVMONLY) {
 		mono_aot_only = TRUE;
 		mono_llvm_only = TRUE;
+
+		mono_ee_features.use_aot_trampolines = TRUE;
 	}
 	if (mono_aot_mode == MONO_AOT_MODE_FULL) {
 		mono_aot_only = TRUE;
@@ -2580,11 +2583,15 @@ mono_jit_set_aot_mode (MonoAotMode mode)
 	if (mono_aot_mode == MONO_AOT_MODE_INTERP) {
 		mono_aot_only = TRUE;
 		mono_use_interpreter = TRUE;
+
+		mono_ee_features.use_aot_trampolines = TRUE;
 	}
 	if (mono_aot_mode == MONO_AOT_MODE_INTERP_LLVMONLY) {
 		mono_aot_only = TRUE;
 		mono_use_interpreter = TRUE;
 		mono_llvm_only = TRUE;
+
+		mono_ee_features.use_aot_trampolines = TRUE;
 	}
 }
 

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -2590,8 +2590,6 @@ mono_jit_set_aot_mode (MonoAotMode mode)
 		mono_aot_only = TRUE;
 		mono_use_interpreter = TRUE;
 		mono_llvm_only = TRUE;
-
-		mono_ee_features.use_aot_trampolines = TRUE;
 	}
 }
 

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -2562,7 +2562,7 @@ mono_runtime_set_execution_mode (MonoEEMode mode)
 {
 	memset (&mono_ee_features, 0, sizeof (mono_ee_features));
 
-	switch (mono_aot_mode) {
+	switch (mode) {
 	case MONO_AOT_MODE_LLVMONLY:
 		mono_aot_only = TRUE;
 		mono_llvm_only = TRUE;
@@ -2572,6 +2572,8 @@ mono_runtime_set_execution_mode (MonoEEMode mode)
 
 	case MONO_AOT_MODE_FULL:
 		mono_aot_only = TRUE;
+
+		mono_ee_features.use_aot_trampolines = TRUE;
 		break;
 
 	case MONO_AOT_MODE_HYBRID:

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -930,7 +930,7 @@ mono_arch_exceptions_init (void)
 	GSList *tramps, *l;
 	gpointer tramp;
 
-	if (mono_aot_only) {
+	if (mono_ee_features.use_aot_trampolines) {
 		tramp = mono_aot_get_trampoline ("llvm_throw_corlib_exception_trampoline");
 		mono_register_jit_icall (tramp, "llvm_throw_corlib_exception_trampoline", NULL, TRUE);
 		tramp = mono_aot_get_trampoline ("llvm_throw_corlib_exception_abs_trampoline");

--- a/mono/mini/exceptions-wasm.c
+++ b/mono/mini/exceptions-wasm.c
@@ -1,18 +1,52 @@
 #include "mini.h"
 
-
-gpointer
-mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
+static gpointer
+create_tramp_info (gpointer code, const char *name, MonoTrampInfo **info)
 {
-	g_error ("mono_arch_get_call_filter");
-	return NULL;
+	if (info) {
+		MonoTrampInfo *tinfo = g_new0 (MonoTrampInfo, 1);
+		tinfo->code = code;
+		tinfo->code_size = 1;
+		tinfo->name = g_strdup (name);
+		tinfo->ji = NULL;
+		tinfo->unwind_ops = NULL;
+		tinfo->uw_info = NULL;
+		tinfo->uw_info_len = 0;
+		tinfo->owns_uw_info = FALSE;
+
+		*info = tinfo;
+	}
+	return code;
 }
 
-gpointer
-mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
+static void
+wasm_restore_context (void)
 {
-	g_error ("mono_arch_get_restore_context");
-	return NULL;
+	g_error ("wasm_restore_context");
+}
+
+static void
+wasm_call_filter (void)
+{
+	g_error ("wasm_call_filter");
+}
+
+static void
+wasm_throw_exception (void)
+{
+	g_error ("wasm_throw_exception");
+}
+
+static void
+wasm_rethrow_exception (void)
+{
+	g_error ("wasm_rethrow_exception");
+}
+
+static void
+wasm_throw_corlib_exception (void)
+{
+	g_error ("wasm_throw_corlib_exception");
 }
 
 gboolean
@@ -34,25 +68,33 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 	return FALSE;
 }
 
+gpointer
+mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
+{
+	return create_tramp_info (wasm_call_filter, "call_filter", info);
+}
+
+gpointer
+mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
+{
+	return create_tramp_info (wasm_restore_context, "restore_context", info);
+}
 gpointer 
 mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 {
-	g_error ("mono_arch_get_throw_corlib_exception");
-	return NULL;
+	return create_tramp_info (wasm_throw_corlib_exception, "throw_corlib_exception", info);
 }
 
 gpointer
 mono_arch_get_rethrow_exception (MonoTrampInfo **info, gboolean aot)
 {
-	g_error ("mono_arch_get_rethrow_exception");
-	return NULL;
+	return create_tramp_info (wasm_rethrow_exception, "rethrow_exception", info);
 }
 
 gpointer
 mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 {
-	g_error ("mono_arch_get_rethrow_exception");
-	return NULL;
+	return create_tramp_info (wasm_throw_exception, "throw_exception", info);
 }
 
 void

--- a/mono/mini/exceptions-wasm.c
+++ b/mono/mini/exceptions-wasm.c
@@ -1,24 +1,5 @@
 #include "mini.h"
 
-static gpointer
-create_tramp_info (gpointer code, const char *name, MonoTrampInfo **info)
-{
-	if (info) {
-		MonoTrampInfo *tinfo = g_new0 (MonoTrampInfo, 1);
-		tinfo->code = code;
-		tinfo->code_size = 1;
-		tinfo->name = g_strdup (name);
-		tinfo->ji = NULL;
-		tinfo->unwind_ops = NULL;
-		tinfo->uw_info = NULL;
-		tinfo->uw_info_len = 0;
-		tinfo->owns_uw_info = FALSE;
-
-		*info = tinfo;
-	}
-	return code;
-}
-
 static void
 wasm_restore_context (void)
 {
@@ -71,30 +52,40 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 gpointer
 mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 {
-	return create_tramp_info (wasm_call_filter, "call_filter", info);
+	if (info)
+		*info = mono_tramp_info_create ("call_filter", wasm_call_filter, 1, NULL, NULL);
+	return wasm_call_filter;
 }
 
 gpointer
 mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 {
-	return create_tramp_info (wasm_restore_context, "restore_context", info);
+	if (info)
+		*info = mono_tramp_info_create ("restore_context", wasm_restore_context, 1, NULL, NULL);
+	return wasm_restore_context;
 }
 gpointer 
 mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 {
-	return create_tramp_info (wasm_throw_corlib_exception, "throw_corlib_exception", info);
+	if (info)
+		*info = mono_tramp_info_create ("throw_corlib_exception", wasm_throw_corlib_exception, 1, NULL, NULL);
+	return wasm_throw_corlib_exception;
 }
 
 gpointer
 mono_arch_get_rethrow_exception (MonoTrampInfo **info, gboolean aot)
 {
-	return create_tramp_info (wasm_rethrow_exception, "rethrow_exception", info);
+	if (info)
+		*info = mono_tramp_info_create ("rethrow_exception", wasm_rethrow_exception, 1, NULL, NULL);
+	return wasm_rethrow_exception;
 }
 
 gpointer
 mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 {
-	return create_tramp_info (wasm_throw_exception, "throw_exception", info);
+	if (info)
+		*info = mono_tramp_info_create ("throw_exception", wasm_throw_exception, 1, NULL, NULL);
+	return wasm_throw_exception;
 }
 
 void

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -1136,7 +1136,7 @@ ves_pinvoke_method (InterpFrame *frame, MonoMethodSignature *sig, MonoFuncV addr
 
 	g_assert (!frame->imethod);
 	if (!mono_interp_to_native_trampoline) {
-		if (mono_aot_only) {
+		if (mono_ee_features.use_aot_trampolines) {
 			mono_interp_to_native_trampoline = mono_aot_get_trampoline ("interp_to_native_trampoline");
 		} else {
 			MonoTrampInfo *info;

--- a/mono/mini/jit.h
+++ b/mono/mini/jit.h
@@ -60,8 +60,8 @@ typedef enum {
 	MONO_AOT_MODE_INTERP,
 	/* Same as INTERP, but use only llvm compiled code */
 	MONO_AOT_MODE_INTERP_LLVMONLY,
-	/* Sentinel value */
-	MONO_AOT_MODE_LAST,
+	/* Sentinel value used internally by the runtime. We use a large number to avoid clashing with some internal values. */
+	MONO_AOT_MODE_LAST = 1000,
 } MonoAotMode;
 
 MONO_API void

--- a/mono/mini/jit.h
+++ b/mono/mini/jit.h
@@ -60,6 +60,8 @@ typedef enum {
 	MONO_AOT_MODE_INTERP,
 	/* Same as INTERP, but use only llvm compiled code */
 	MONO_AOT_MODE_INTERP_LLVMONLY,
+	/* Sentinel value */
+	MONO_AOT_MODE_LAST,
 } MonoAotMode;
 
 MONO_API void

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -7923,7 +7923,7 @@ mono_arch_get_delegate_invoke_impl (MonoMethodSignature *sig, gboolean has_targe
 		if (cached)
 			return cached;
 
-		if (mono_aot_only) {
+		if (mono_ee_features.use_aot_trampolines) {
 			start = (guint8 *)mono_aot_get_trampoline ("delegate_invoke_impl_has_target");
 		} else {
 			MonoTrampInfo *info;
@@ -7946,7 +7946,7 @@ mono_arch_get_delegate_invoke_impl (MonoMethodSignature *sig, gboolean has_targe
 		if (code)
 			return code;
 
-		if (mono_aot_only) {
+		if (mono_ee_features.use_aot_trampolines) {
 			char *name = g_strdup_printf ("delegate_invoke_impl_target_%d", sig->param_count);
 			start = (guint8 *)mono_aot_get_trampoline (name);
 			g_free (name);

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -699,7 +699,7 @@ mono_arch_get_delegate_invoke_impl (MonoMethodSignature *sig, gboolean has_targe
 			return cached;
 		}
 
-		if (mono_aot_only) {
+		if (mono_ee_features.use_aot_trampolines) {
 			start = mono_aot_get_trampoline ("delegate_invoke_impl_has_target");
 		} else {
 			MonoTrampInfo *info;
@@ -726,7 +726,7 @@ mono_arch_get_delegate_invoke_impl (MonoMethodSignature *sig, gboolean has_targe
 			return code;
 		}
 
-		if (mono_aot_only) {
+		if (mono_ee_features.use_aot_trampolines) {
 			char *name = g_strdup_printf ("delegate_invoke_impl_target_%d", sig->param_count);
 			start = mono_aot_get_trampoline (name);
 			g_free (name);

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -178,7 +178,7 @@ mono_arch_get_delegate_invoke_impl (MonoMethodSignature *sig, gboolean has_targe
 		if (cached)
 			return cached;
 
-		if (mono_aot_only)
+		if (mono_ee_features.use_aot_trampolines)
 			start = mono_aot_get_trampoline ("delegate_invoke_impl_has_target");
 		else
 			start = get_delegate_invoke_impl (TRUE, 0, NULL);
@@ -199,7 +199,7 @@ mono_arch_get_delegate_invoke_impl (MonoMethodSignature *sig, gboolean has_targe
 		if (code)
 			return code;
 
-		if (mono_aot_only) {
+		if (mono_ee_features.use_aot_trampolines) {
 			char *name = g_strdup_printf ("delegate_invoke_impl_target_%d", sig->param_count);
 			start = mono_aot_get_trampoline (name);
 			g_free (name);

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -202,7 +202,7 @@ void
 mono_exceptions_init (void)
 {
 	MonoRuntimeExceptionHandlingCallbacks cbs;
-	if (mono_aot_only) {
+	if (mono_ee_features.use_aot_trampolines) {
 		restore_context_func = mono_aot_get_trampoline ("restore_context");
 		call_filter_func = mono_aot_get_trampoline ("call_filter");
 		throw_exception_func = mono_aot_get_trampoline ("throw_exception");
@@ -281,7 +281,7 @@ mono_get_throw_corlib_exception (void)
 	if (throw_corlib_exception_func)
 		return throw_corlib_exception_func;
 
-	if (mono_aot_only)
+	if (mono_ee_features.use_aot_trampolines)
 		code = mono_aot_get_trampoline ("throw_corlib_exception");
 	else {
 		code = mono_arch_get_throw_corlib_exception (&info, FALSE);

--- a/mono/mini/mini-mips.c
+++ b/mono/mini/mini-mips.c
@@ -601,7 +601,7 @@ mono_arch_get_delegate_invoke_impl (MonoMethodSignature *sig, gboolean has_targe
 			return cached;
 		}
 
-		if (mono_aot_only) {
+		if (mono_ee_features.use_aot_trampolines) {
 			start = mono_aot_get_trampoline ("delegate_invoke_impl_has_target");
 		} else {
 			MonoTrampInfo *info;
@@ -628,7 +628,7 @@ mono_arch_get_delegate_invoke_impl (MonoMethodSignature *sig, gboolean has_targe
 			return code;
 		}
 
-		if (mono_aot_only) {
+		if (mono_ee_features.use_aot_trampolines) {
 			char *name = g_strdup_printf ("delegate_invoke_impl_target_%d", sig->param_count);
 			start = mono_aot_get_trampoline (name);
 			g_free (name);

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -417,7 +417,7 @@ mono_arch_get_delegate_invoke_impl (MonoMethodSignature *sig, gboolean has_targe
 		if (cached)
 			return cached;
 
-		if (mono_aot_only) {
+		if (mono_ee_features.use_aot_trampolines) {
 			start = mono_aot_get_trampoline ("delegate_invoke_impl_has_target");
 		} else {
 			MonoTrampInfo *info;
@@ -442,7 +442,7 @@ mono_arch_get_delegate_invoke_impl (MonoMethodSignature *sig, gboolean has_targe
 		if (code)
 			return code;
 
-		if (mono_aot_only) {
+		if (mono_ee_features.use_aot_trampolines) {
 			char *name = g_strdup_printf ("delegate_invoke_impl_target_%d", sig->param_count);
 			start = mono_aot_get_trampoline (name);
 			g_free (name);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -104,6 +104,7 @@ gboolean mono_aot_only = FALSE;
 /* Same as mono_aot_only, but only LLVM compiled code is used, no trampolines */
 gboolean mono_llvm_only = FALSE;
 MonoAotMode mono_aot_mode = MONO_AOT_MODE_NONE;
+MonoEEFeatures mono_ee_features;
 
 const char *mono_build_date;
 gboolean mono_do_signal_chaining;
@@ -3494,7 +3495,7 @@ mono_get_delegate_virtual_invoke_impl (MonoMethodSignature *sig, MonoMethod *met
 		return cache [idx];
 
 	/* FIXME Support more cases */
-	if (mono_aot_only) {
+	if (mono_ee_features.use_aot_trampolines) {
 		cache [idx] = (guint8 *)mono_aot_get_trampoline (mono_get_delegate_virtual_invoke_impl_name (load_imt_reg, offset));
 		g_assert (cache [idx]);
 	} else {

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -353,6 +353,13 @@ typedef struct {
 
 extern MonoEEFeatures mono_ee_features;
 
+//XXX this enum *MUST extend MonoAotMode as they are consumed together.
+typedef enum {
+	/* Always execute with interp, will use JIT to produce trampolines */
+	MONO_EE_MODE_INTERP = MONO_AOT_MODE_LAST,
+} MonoEEMode;
+
+
 static inline MonoMethod*
 jinfo_get_method (MonoJitInfo *ji)
 {

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -337,6 +337,22 @@ extern GList* mono_aot_paths;
 extern MonoDebugOptions mini_debug_options;
 extern GSList *mono_interp_only_classes;
 
+/*
+This struct describes what execution engine feature to use.
+The subsume and will eventually sunset mono_aot_only / mono_llvm_only and friends.
+The goal is to transition us to a place were we can more easily compose/describe what features we need for a given execution mode.
+
+A good feature flag is checked alone, a bad one described many things and keeps breaking some of the modes
+*/
+typedef struct {
+	/*
+	 * If true, trampolines are to be fetched from the AOT runtime instead of JIT compiled
+	 */
+	gboolean use_aot_trampolines;
+} MonoEEFeatures;
+
+extern MonoEEFeatures mono_ee_features;
+
 static inline MonoMethod*
 jinfo_get_method (MonoJitInfo *ji)
 {

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -339,7 +339,7 @@ extern GSList *mono_interp_only_classes;
 
 /*
 This struct describes what execution engine feature to use.
-The subsume and will eventually sunset mono_aot_only / mono_llvm_only and friends.
+This subsume, and will eventually sunset, mono_aot_only / mono_llvm_only and friends.
 The goal is to transition us to a place were we can more easily compose/describe what features we need for a given execution mode.
 
 A good feature flag is checked alone, a bad one described many things and keeps breaking some of the modes

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -7002,7 +7002,7 @@ mono_arch_get_delegate_invoke_impl (MonoMethodSignature *sig, gboolean has_targe
 		if (cached)
 			return cached;
 
-		if (mono_aot_only) {
+		if (mono_ee_features.use_aot_trampolines) {
 			start = mono_aot_get_trampoline ("delegate_invoke_impl_has_target");
 		} else {
 			MonoTrampInfo *info;
@@ -7028,7 +7028,7 @@ mono_arch_get_delegate_invoke_impl (MonoMethodSignature *sig, gboolean has_targe
 		if (code)
 			return code;
 
-		if (mono_aot_only) {
+		if (mono_ee_features.use_aot_trampolines) {
 			char *name = g_strdup_printf ("delegate_invoke_impl_target_%d", sig->param_count);
 			start = mono_aot_get_trampoline (name);
 			g_free (name);

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -1743,7 +1743,7 @@ mini_get_single_step_trampoline (void)
 	if (!trampoline) {
 		gpointer tramp;
 
-		if (mono_aot_only) {
+		if (mono_ee_features.use_aot_trampolines) {
 			tramp = mono_aot_get_trampoline ("sdb_single_step_trampoline");
 		} else {
 #ifdef MONO_ARCH_HAVE_SDB_TRAMPOLINES
@@ -1775,7 +1775,7 @@ mini_get_breakpoint_trampoline (void)
 	if (!trampoline) {
 		gpointer tramp;
 
-		if (mono_aot_only) {
+		if (mono_ee_features.use_aot_trampolines) {
 			tramp = mono_aot_get_trampoline ("sdb_breakpoint_trampoline");
 		} else {
 #ifdef MONO_ARCH_HAVE_SDB_TRAMPOLINES

--- a/mono/mini/mini-wasm.c
+++ b/mono/mini/mini-wasm.c
@@ -722,6 +722,12 @@ mono_wasm_set_breakpoint (const char *assembly_name, int method_token, int il_of
 //trampoline
 
 void
+mono_sdb_single_step_trampoline (void)
+{
+	g_error ("mono_sdb_single_step_trampoline");
+}
+
+void
 mono_wasm_breakpoint_hit (void)
 {
 	mono_wasm_fire_bp ();

--- a/mono/mini/mini-wasm.h
+++ b/mono/mini/mini-wasm.h
@@ -50,6 +50,7 @@ typedef struct {
 #define MONO_ARCH_INTERPRETER_SUPPORTED 1
 #define MONO_ARCH_HAS_REGISTER_ICALL 1
 #define MONO_ARCH_HAVE_PATCH_CODE_NEW 1
+#define MONO_ARCH_HAVE_SDB_TRAMPOLINES 1
 
 void mono_wasm_debugger_init (void);
 

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -6011,7 +6011,7 @@ mono_arch_get_delegate_invoke_impl (MonoMethodSignature *sig, gboolean has_targe
 		if (cached)
 			return cached;
 
-		if (mono_aot_only) {
+		if (mono_ee_features.use_aot_trampolines) {
 			start = mono_aot_get_trampoline ("delegate_invoke_impl_has_target");
 		} else {
 			MonoTrampInfo *info;
@@ -6034,7 +6034,7 @@ mono_arch_get_delegate_invoke_impl (MonoMethodSignature *sig, gboolean has_targe
 		if (code)
 			return code;
 
-		if (mono_aot_only) {
+		if (mono_ee_features.use_aot_trampolines) {
 			char *name = g_strdup_printf ("delegate_invoke_impl_target_%d", sig->param_count);
 			start = mono_aot_get_trampoline (name);
 			g_free (name);

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -4147,7 +4147,7 @@ mono_jit_compile_method_inner (MonoMethod *method, MonoDomain *target_domain, in
 			 * works.
 			 * FIXME: The caller signature doesn't match the callee, which might cause problems on some platforms
 			 */
-			if (mono_aot_only)
+			if (mono_ee_features.use_aot_trampolines)
 				mono_aot_get_trampoline_full (is_in ? "gsharedvt_trampoline" : "gsharedvt_out_trampoline", &tinfo);
 			else
 				mono_arch_get_gsharedvt_trampoline (&tinfo, FALSE);

--- a/mono/mini/tramp-wasm.c
+++ b/mono/mini/tramp-wasm.c
@@ -1,4 +1,5 @@
 #include "mini.h"
+#include "interp/interp.h"
 
 void mono_wasm_interp_to_native_trampoline (void *target_func, InterpMethodArguments *margs);
 void mono_sdb_single_step_trampoline (void);

--- a/mono/mini/tramp-wasm.c
+++ b/mono/mini/tramp-wasm.c
@@ -4,25 +4,6 @@ void wasm_interp_to_native_trampoline (void *target_func, InterpMethodArguments 
 void mono_sdb_single_step_trampoline (void);
 void mono_sdb_single_step_trampoline (void);
 
-static gpointer
-create_tramp_info (gpointer code, const char *name, MonoTrampInfo **info)
-{
-	if (info) {
-		MonoTrampInfo *tinfo = g_new0 (MonoTrampInfo, 1);
-		tinfo->code = code;
-		tinfo->code_size = 1;
-		tinfo->name = g_strdup (name);
-		tinfo->ji = NULL;
-		tinfo->unwind_ops = NULL;
-		tinfo->uw_info = NULL;
-		tinfo->uw_info_len = 0;
-		tinfo->owns_uw_info = FALSE;
-
-		*info = tinfo;
-	}
-	return code;
-}
-
 gpointer
 mono_arch_create_specific_trampoline (gpointer arg1, MonoTrampolineType tramp_type, MonoDomain *domain, guint32 *code_len)
 {
@@ -70,15 +51,26 @@ mono_arch_get_static_rgctx_trampoline (gpointer arg, gpointer addr)
 gpointer
 mono_arch_get_interp_to_native_trampoline (MonoTrampInfo **info)
 {
-	return create_tramp_info (wasm_interp_to_native_trampoline, "interp_to_native_trampoline", info);
+	if (info)
+		*info = mono_tramp_info_create ("interp_to_native_trampoline", wasm_interp_to_native_trampoline, 1, NULL, NULL);
+	return wasm_interp_to_native_trampoline;
 }
 
 guint8*
 mono_arch_create_sdb_trampoline (gboolean single_step, MonoTrampInfo **info, gboolean aot)
 {
 	g_assert (!aot);
-	if (single_step)
-		return create_tramp_info (mono_sdb_single_step_trampoline, "sdb_single_step_trampoline", info);
-	else
-		return create_tramp_info (mono_wasm_breakpoint_hit, "sdb_breakpoint_trampoline", info);
+	const char *name;
+	gpointer code;
+	if (single_step) {
+		name = "sdb_single_step_trampoline";
+		code = mono_sdb_single_step_trampoline;
+	} else {
+		name = "sdb_breakpoint_trampoline";
+		code = mono_wasm_breakpoint_hit;
+	}
+
+	if (info)
+		*info = mono_tramp_info_create (name, code, 1, NULL, NULL);
+	return code;
 }

--- a/mono/mini/tramp-wasm.c
+++ b/mono/mini/tramp-wasm.c
@@ -1,7 +1,6 @@
 #include "mini.h"
 
-void wasm_interp_to_native_trampoline (void *target_func, InterpMethodArguments *margs);
-void mono_sdb_single_step_trampoline (void);
+void mono_wasm_interp_to_native_trampoline (void *target_func, InterpMethodArguments *margs);
 void mono_sdb_single_step_trampoline (void);
 
 gpointer
@@ -52,8 +51,8 @@ gpointer
 mono_arch_get_interp_to_native_trampoline (MonoTrampInfo **info)
 {
 	if (info)
-		*info = mono_tramp_info_create ("interp_to_native_trampoline", wasm_interp_to_native_trampoline, 1, NULL, NULL);
-	return wasm_interp_to_native_trampoline;
+		*info = mono_tramp_info_create ("interp_to_native_trampoline", mono_wasm_interp_to_native_trampoline, 1, NULL, NULL);
+	return mono_wasm_interp_to_native_trampoline;
 }
 
 guint8*


### PR DESCRIPTION
MonoEEFeatures is meant to replace the mode flag soup with have.
Each feature is supposed to be checked alone and descriptive enough of the underlying behavior.

use_aot_trampolines is a good example because the inter_aot_llvmonly mode could set it to false and
skip all the trampoline engine nonsense as trampolines are C functions.

Contributes to #7885