### PR TITLE
[2017-12] [sdks] Pass LLVM_SRC from XA to use `xamarin-android/external/llvm` + Pass IGNORE_PACKAGE_MXE from XA + Only checkout specific MXE and LLVM commit when cloning

### DIFF
--- a/sdks/builds/android.mk
+++ b/sdks/builds/android.mk
@@ -195,7 +195,7 @@ _android-$(1)_CONFIGURE_FLAGS= \
 .stamp-android-$(1)-toolchain:
 	touch $$@
 
-.stamp-android-$(1)-$$(CONFIGURATION)-configure: | package-mxe
+.stamp-android-$(1)-$$(CONFIGURATION)-configure: | $(if $(IGNORE_PACKAGE_MXE),,package-mxe)
 
 $$(eval $$(call RuntimeTemplate,android-$(1)))
 

--- a/sdks/builds/llvm.mk
+++ b/sdks/builds/llvm.mk
@@ -1,8 +1,10 @@
 
+LLVM_SRC?=$(TOP)/sdks/builds/toolchains/llvm
+
 $(TOP)/sdks/builds/toolchains/llvm:
 	git clone -b master https://github.com/mono/llvm.git $@
 
-$(TOP)/sdks/builds/toolchains/llvm/configure: | $(TOP)/sdks/builds/toolchains/llvm
+$(LLVM_SRC)/configure: | $(LLVM_SRC)
 
 ##
 # Parameters
@@ -30,10 +32,10 @@ _llvm_$(1)_CONFIGURE_FLAGS= \
 	--enable-targets="arm,aarch64,x86" \
 	--enable-libcpp
 
-.stamp-llvm-$(1)-toolchain: | $$(TOP)/sdks/builds/toolchains/llvm
+.stamp-llvm-$(1)-toolchain: | $$(LLVM_SRC)
 	touch $$@
 
-.stamp-llvm-$(1)-configure: $$(TOP)/sdks/builds/toolchains/llvm/configure
+.stamp-llvm-$(1)-configure: $$(LLVM_SRC)/configure
 	mkdir -p $$(TOP)/sdks/builds/llvm-$(1)
 	cd $$(TOP)/sdks/builds/llvm-$(1) && $$< $$(_llvm_$(1)_CONFIGURE_ENVIRONMENT) $$(_llvm_$(1)_CONFIGURE_FLAGS)
 	touch $$@
@@ -101,11 +103,11 @@ _llvm_$(1)_CONFIGURE_FLAGS = \
 	--disable-pthreads \
 	--disable-zlib
 
-.stamp-llvm-$(1)-toolchain: | $$(TOP)/sdks/builds/toolchains/llvm
-	cd $$(TOP)/sdks/builds/toolchains/llvm && git checkout $(LLVM_HASH)
+.stamp-llvm-$(1)-toolchain: | $$(LLVM_SRC)
+	cd $$(LLVM_SRC) && git checkout $(LLVM_HASH)
 	touch $$@
 
-.stamp-llvm-$(1)-configure: $$(TOP)/sdks/builds/toolchains/llvm/configure | package-mxe
+.stamp-llvm-$(1)-configure: $$(LLVM_SRC)/configure | package-mxe
 	mkdir -p $$(TOP)/sdks/builds/llvm-$(1)
 	cd $$(TOP)/sdks/builds/llvm-$(1) && PATH="$$$$PATH:$$(_llvm_$(1)_PATH)" $$< $$(_llvm_$(1)_CONFIGURE_ENVIRONMENT) $$(_llvm_$(1)_CONFIGURE_FLAGS)
 	touch $$@

--- a/sdks/builds/llvm.mk
+++ b/sdks/builds/llvm.mk
@@ -107,7 +107,7 @@ _llvm_$(1)_CONFIGURE_FLAGS = \
 	cd $$(LLVM_SRC) && git checkout $(LLVM_HASH)
 	touch $$@
 
-.stamp-llvm-$(1)-configure: $$(LLVM_SRC)/configure | package-mxe
+.stamp-llvm-$(1)-configure: $$(LLVM_SRC)/configure | $(if $(IGNORE_PACKAGE_MXE),,package-mxe)
 	mkdir -p $$(TOP)/sdks/builds/llvm-$(1)
 	cd $$(TOP)/sdks/builds/llvm-$(1) && PATH="$$$$PATH:$$(_llvm_$(1)_PATH)" $$< $$(_llvm_$(1)_CONFIGURE_ENVIRONMENT) $$(_llvm_$(1)_CONFIGURE_FLAGS)
 	touch $$@

--- a/sdks/builds/llvm.mk
+++ b/sdks/builds/llvm.mk
@@ -3,6 +3,7 @@ LLVM_SRC?=$(TOP)/sdks/builds/toolchains/llvm
 
 $(TOP)/sdks/builds/toolchains/llvm:
 	git clone -b master https://github.com/mono/llvm.git $@
+	cd $@ && git checkout $(LLVM_HASH)
 
 $(LLVM_SRC)/configure: | $(LLVM_SRC)
 
@@ -104,7 +105,6 @@ _llvm_$(1)_CONFIGURE_FLAGS = \
 	--disable-zlib
 
 .stamp-llvm-$(1)-toolchain: | $$(LLVM_SRC)
-	cd $$(LLVM_SRC) && git checkout $(LLVM_HASH)
 	touch $$@
 
 .stamp-llvm-$(1)-configure: $$(LLVM_SRC)/configure | $(if $(IGNORE_PACKAGE_MXE),,package-mxe)

--- a/sdks/builds/mxe.mk
+++ b/sdks/builds/mxe.mk
@@ -4,9 +4,9 @@ MXE_PREFIX?=$(TOP)/sdks/out/mxe
 
 $(TOP)/sdks/builds/toolchains/mxe:
 	git clone -b xamarin https://github.com/xamarin/mxe.git $@
+	cd $@ && git checkout $(MXE_HASH)
 
 .stamp-mxe-toolchain: | $(MXE_SRC)
-	cd $(MXE_SRC) && git checkout $(MXE_HASH)
 	touch $@
 
 .stamp-mxe-configure:


### PR DESCRIPTION
Backport of #7893.

/cc @luhenry