### PR TITLE
Revert "[sdks] Disable btls and support/ on the bcl build, they are not needed."

### DIFF
--- a/sdks/builds/bcl.mk
+++ b/sdks/builds/bcl.mk
@@ -15,8 +15,6 @@ bcl_CONFIGURE_FLAGS = \
        $(if $(DISABLE_WASM),,--with-wasm=yes) \
        --with-mcs-docs=no \
        --disable-nls \
-       --disable-btls \
-       --disable-support-build \
        --disable-boehm
 
 .stamp-bcl-configure: $(TOP)/configure


### PR DESCRIPTION
Reverts mono/mono#7892

The change was affecting the bcl build, not just the runtime build.
