### PR TITLE
[perfcounters] fix alignment issue on 32bit

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -729,9 +729,9 @@ typedef struct {
 	gint32 security_depth;
 	gint32 unused;
 	/* Threadpool */
+	gint32 threadpool_threads;
 	gint64 threadpool_workitems;
 	gint64 threadpool_ioworkitems;
-	gint32 threadpool_threads;
 	gint32 threadpool_iothreads;
 } MonoPerfCounters;
 


### PR DESCRIPTION
clang fails to properly align 64bit members of the `MonoPerfCounters` struct on
32bit builds:

```
* thread #1, name = 'tid_403', queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=EXC_ARM_DA_ALIGN, address=0x16933124)
    frame #0: 0x0066f4b2 mini`mono_atomic_cas_i64(dest=0x16933124, exch=<unavailable>, comp=<unavailable>) at atomic.c:519 [opt]
   516 	gint64
   517 	mono_atomic_cas_i64(volatile gint64 *dest, gint64 exch, gint64 comp)
   518 	{
-> 519 		return  __sync_val_compare_and_swap (dest, comp, exch);
   520 	}
   521
   522 	#elif defined (TARGET_ANDROID)
(lldb) up
frame #1: 0x006292ea mini`ves_icall_System_Threading_ThreadPool_NotifyWorkItemQueued [inlined] mono_atomic_inc_i64 at atomic.h:397 [opt]
   394 		do {
   395 			get = *val;
   396 			set = get + 1;
-> 397 		} while (mono_atomic_cas_i64 (val, set, get) != get);
   398 		return set;
   399 	}
   400
(lldb) up
frame #2: 0x006292d6 mini`ves_icall_System_Threading_ThreadPool_NotifyWorkItemQueued at threadpool.c:743 [opt]
   740 	ves_icall_System_Threading_ThreadPool_NotifyWorkItemQueued (void)
   741 	{
   742 	#ifndef DISABLE_PERFCOUNTERS
-> 743 		mono_atomic_inc_i64 (&mono_perfcounters->threadpool_workitems);
   744 	#endif
   745 	}
   746
```

Note that the member `threadpool_workitems` is on an unnatural alignment
(`0x16933124`) regarding to its type `gint64`.

related https://github.com/xamarin/xamarin-macios/issues/3826

