### PR TITLE
[runtime] Fix class visibility check for protected nested classes.

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -539,7 +539,8 @@ TESTS_CS_SRC=		\
 	tailcall-generic-cast-cs.cs \
 	tailcall-interface.cs \
 	sizeof-empty-structs.cs \
-	bug-60843.cs
+	bug-60843.cs	\
+	nested_type_visibility.cs
 
 if AMD64
 TESTS_CS_SRC += async-exc-compilation.cs finally_guard.cs finally_block_ending_in_dead_bb.cs

--- a/mono/tests/nested_type_visibility.cs
+++ b/mono/tests/nested_type_visibility.cs
@@ -1,0 +1,36 @@
+namespace ConsoleApplication1
+{
+    public abstract class SuperClass
+    {
+        protected abstract class SuperInnerAbstractClass
+        {
+            protected class SuperInnerInnerClass
+            {
+            }
+        }
+    }
+
+    public class ChildClass : SuperClass
+    {
+        private class ChildInnerClass : SuperInnerAbstractClass
+        {
+            private readonly SuperInnerInnerClass s_class = new SuperInnerInnerClass();
+        }
+
+        public ChildClass()
+        {
+            var childInnerClass = new ChildInnerClass();
+        }
+    }
+    
+    internal class Program
+    {
+        public static int Main(string[] args)
+        {
+            new ChildClass();
+
+			return 0;
+        }
+    }
+}
+


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/7657