### PR TITLE
[WCF] fix ChannelDispatcher by accepting InstanceProvider

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel.Dispatcher/ChannelDispatcher.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Dispatcher/ChannelDispatcher.cs
@@ -357,7 +357,7 @@ namespace System.ServiceModel.Dispatcher
 
 				// It is tested at Open(), but strangely it is not instantiated at this point.
 				foreach (var ed in owner.Endpoints)
-					if (ed.DispatchRuntime.InstanceContextProvider == null && (ed.DispatchRuntime.Type == null || ed.DispatchRuntime.Type.GetConstructor (Type.EmptyTypes) == null))
+					if (ed.DispatchRuntime.InstanceProvider == null && (ed.DispatchRuntime.Type == null || ed.DispatchRuntime.Type.GetConstructor (Type.EmptyTypes) == null))
 						throw new InvalidOperationException ("There is no default constructor for the service Type in the DispatchRuntime");
 				SetupChannelAcceptor ();
 			}

--- a/mcs/class/System.ServiceModel/System.ServiceModel.Dispatcher/ChannelDispatcher.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Dispatcher/ChannelDispatcher.cs
@@ -356,9 +356,12 @@ namespace System.ServiceModel.Dispatcher
 				owner.Listener.Open (openTimeout);
 
 				// It is tested at Open(), but strangely it is not instantiated at this point.
-				foreach (var ed in owner.Endpoints)
-					if (ed.DispatchRuntime.InstanceProvider == null && (ed.DispatchRuntime.Type == null || ed.DispatchRuntime.Type.GetConstructor (Type.EmptyTypes) == null))
+				foreach (var ed in owner.Endpoints) {
+					if ((ed.DispatchRuntime.InstanceProvider == null && ed.DispatchRuntime.InstanceContextProvider == null)
+						&& (ed.DispatchRuntime.Type == null || ed.DispatchRuntime.Type.GetConstructor (Type.EmptyTypes) == null)) {
 						throw new InvalidOperationException ("There is no default constructor for the service Type in the DispatchRuntime");
+					}
+				}
 				SetupChannelAcceptor ();
 			}
 


### PR DESCRIPTION
ChannelDispatcher/ListenerLoopManager.Setup must validate InstanceProvider, not InstanceContextProvider
- the creation of endpoints requires an instance provider or a default constructor
- InstanceProvider vs InstanceContextProvider was obviously a typo

While working with DI and WCF, you design classes with custom constructures. Therefor an InstanceProvider is bound to the service- and endpoint classes.
This works well unter Windows but with mono you will get an exception `There is no default constructor for the service Type in the DispatchRuntime` when the service gets instantiated.

This was mentioned in stackoverflow [WCF Extensibility – IInstanceProvider in mono](https://stackoverflow.com/questions/14500730/wcf-extensibility-iinstanceprovider-in-mono/30550165#30550165) and the only answer proposed, to additionally provide an InstanceContextProvider to make mono happy.
But the idea of a no-op InstanceContextProvider did not work for me.
So the deeper analysis showed, that in the code of the ChannelDispatcher an InstanceContextProvider makes no sense and what really matters is an InstanceProvider.

With this fix WCF services with Autofac DI (and other DI frameworks) run with mono.
Here some usefull information about [IInstanceProvider](https://blogs.msdn.microsoft.com/carlosfigueira/2011/05/31/wcf-extensibility-iinstanceprovider/) and [IInstanceContextProvider](https://blogs.msdn.microsoft.com/carlosfigueira/2012/02/06/wcf-extensibility-iinstancecontextprovider/).