### PR TITLE
[2017-12][runtime] Fix class visibility check for protected nested classes.

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -10329,13 +10329,11 @@ can_access_type (MonoClass *access_klass, MonoClass *member_klass)
 	if (is_nesting_type (access_klass, member_klass) || (access_klass->nested_in && is_nesting_type (access_klass->nested_in, member_klass)))
 		return TRUE;
 
-	if (member_klass->nested_in && !can_access_type (access_klass, member_klass->nested_in))
-		return FALSE;
-
 	/*Non nested type with nested visibility. We just fail it.*/
 	if (access_level >= TYPE_ATTRIBUTE_NESTED_PRIVATE && access_level <= TYPE_ATTRIBUTE_NESTED_FAM_OR_ASSEM && member_klass->nested_in == NULL)
 		return FALSE;
 
+	MonoClass *member_klass_nested_in = member_klass->nested_in;
 	switch (access_level) {
 	case TYPE_ATTRIBUTE_NOT_PUBLIC:
 		return can_access_internals (access_klass->image->assembly, member_klass->image->assembly);
@@ -10344,16 +10342,16 @@ can_access_type (MonoClass *access_klass, MonoClass *member_klass)
 		return TRUE;
 
 	case TYPE_ATTRIBUTE_NESTED_PUBLIC:
-		return TRUE;
+		return member_klass_nested_in && can_access_type (access_klass, member_klass_nested_in);
 
 	case TYPE_ATTRIBUTE_NESTED_PRIVATE:
-		return is_nesting_type (member_klass, access_klass);
+		return is_nesting_type (member_klass, access_klass) && member_klass_nested_in && can_access_type (access_klass, member_klass_nested_in);
 
 	case TYPE_ATTRIBUTE_NESTED_FAMILY:
 		return mono_class_has_parent_and_ignore_generics (access_klass, member_klass->nested_in); 
 
 	case TYPE_ATTRIBUTE_NESTED_ASSEMBLY:
-		return can_access_internals (access_klass->image->assembly, member_klass->image->assembly);
+		return can_access_internals (access_klass->image->assembly, member_klass->image->assembly) && member_klass_nested_in && can_access_type (access_klass, member_klass_nested_in);
 
 	case TYPE_ATTRIBUTE_NESTED_FAM_AND_ASSEM:
 		return can_access_internals (access_klass->image->assembly, member_klass->nested_in->image->assembly) &&

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -531,7 +531,8 @@ TESTS_CS_SRC=		\
 	bug-59281.cs	\
 	init_array_with_lazy_type.cs \
 	weak-fields.cs \
-	threads-leak.cs
+	threads-leak.cs	\
+	nested_type_visibility.cs
 
 if AMD64
 TESTS_CS_SRC += async-exc-compilation.cs finally_guard.cs finally_block_ending_in_dead_bb.cs

--- a/mono/tests/nested_type_visibility.cs
+++ b/mono/tests/nested_type_visibility.cs
@@ -1,0 +1,36 @@
+namespace ConsoleApplication1
+{
+    public abstract class SuperClass
+    {
+        protected abstract class SuperInnerAbstractClass
+        {
+            protected class SuperInnerInnerClass
+            {
+            }
+        }
+    }
+
+    public class ChildClass : SuperClass
+    {
+        private class ChildInnerClass : SuperInnerAbstractClass
+        {
+            private readonly SuperInnerInnerClass s_class = new SuperInnerInnerClass();
+        }
+
+        public ChildClass()
+        {
+            var childInnerClass = new ChildInnerClass();
+        }
+    }
+    
+    internal class Program
+    {
+        public static int Main(string[] args)
+        {
+            new ChildClass();
+
+			return 0;
+        }
+    }
+}
+


### PR DESCRIPTION
Backport #7907 to `2017-12`
 Fixes #7657