### PR TITLE
[2018-02][runtime] Fix class visibility check for protected nested classes.

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -534,7 +534,8 @@ TESTS_CS_SRC=		\
 	threads-leak.cs	\
 	threads-init.cs \
 	bug-60848.cs \
-	bug-59400.cs
+	bug-59400.cs	\
+	nested_type_visibility.cs
 
 if AMD64
 TESTS_CS_SRC += async-exc-compilation.cs finally_guard.cs finally_block_ending_in_dead_bb.cs

--- a/mono/tests/nested_type_visibility.cs
+++ b/mono/tests/nested_type_visibility.cs
@@ -1,0 +1,36 @@
+namespace ConsoleApplication1
+{
+    public abstract class SuperClass
+    {
+        protected abstract class SuperInnerAbstractClass
+        {
+            protected class SuperInnerInnerClass
+            {
+            }
+        }
+    }
+
+    public class ChildClass : SuperClass
+    {
+        private class ChildInnerClass : SuperInnerAbstractClass
+        {
+            private readonly SuperInnerInnerClass s_class = new SuperInnerInnerClass();
+        }
+
+        public ChildClass()
+        {
+            var childInnerClass = new ChildInnerClass();
+        }
+    }
+    
+    internal class Program
+    {
+        public static int Main(string[] args)
+        {
+            new ChildClass();
+
+			return 0;
+        }
+    }
+}
+


### PR DESCRIPTION
Backport #7907 to `2018-02`

Fixes #7657 