### PR TITLE
[System.IO] Don't throw exception when FileSystemWatcher is disposed while the backend is still trying to use it

### DIFF
--- a/mcs/class/System.Web/Test/System.Web.Compilation/AppResourcesCompilerTest.cs
+++ b/mcs/class/System.Web/Test/System.Web.Compilation/AppResourcesCompilerTest.cs
@@ -47,7 +47,6 @@ namespace MonoTests.System.Web.Compilation
 		}
 
 		[Test (Description="Bug #548768")]
-		[Category("NotWorking")] // https://github.com/mono/mono/issues/7568
 		public void GlobalResourcesLocalization ()
 		{
 			string pageHtml = new WebTest ("GlobalResourcesLocalization.aspx").Run ();

--- a/mcs/class/System.Web/Test/System.Web.Compilation/AppSettingsExpressionBuilderTest.cs
+++ b/mcs/class/System.Web/Test/System.Web.Compilation/AppSettingsExpressionBuilderTest.cs
@@ -78,7 +78,6 @@ namespace MonoTests.System.Web.Compilation
 	{
 		[Test] // GetAppSetting (String)
 		[Category ("NunitWeb")]
-		[Category ("NotWorking")] // https://github.com/mono/mono/issues/7568
 		public void GetAppSetting1 ()
 		{
 			PageDelegates pd = new PageDelegates ();
@@ -121,7 +120,6 @@ namespace MonoTests.System.Web.Compilation
 
 		[Test] // GetAppSetting (String, Type, String)
 		[Category ("NunitWeb")]
-		[Category ("NotWorking")] // https://github.com/mono/mono/issues/7568
 		public void GetAppSetting2 ()
 		{
 			PageDelegates pd = new PageDelegates ();

--- a/mcs/class/System/System.IO/CoreFXFileSystemWatcherProxy.cs
+++ b/mcs/class/System/System.IO/CoreFXFileSystemWatcherProxy.cs
@@ -127,6 +127,9 @@ namespace System.IO {
 
 		public void StartDispatching (object handle)
 		{
+			if (handle == null)
+				return;
+
 			Operation (object_op: (internal_fsw, fsw) => {
 					internal_fsw.Path = fsw.Path;
 					internal_fsw.Filter = fsw.Filter;
@@ -140,6 +143,9 @@ namespace System.IO {
 
 		public void StopDispatching (object handle)
 		{
+			if (handle == null)
+				return;
+
 			Operation (handle: handle,
 				cancel_op: (internal_fsw, fsw) =>
 				{

--- a/mcs/class/System/System.IO/FileSystemWatcher.cs
+++ b/mcs/class/System/System.IO/FileSystemWatcher.cs
@@ -196,7 +196,7 @@ namespace System.IO {
 		internal SearchPattern2 Pattern {
 			get {
 				if (pattern == null) {
-					if (watcher.GetType () == typeof (KeventWatcher))
+					if (watcher?.GetType () == typeof (KeventWatcher))
 						pattern = new SearchPattern2 (MangledFilter, true); //assume we want to ignore case (OS X)
 					else
 						pattern = new SearchPattern2 (MangledFilter);
@@ -386,8 +386,8 @@ namespace System.IO {
 				return;
 
 			try {
-				watcher.StopDispatching (watcher_handle);
-				watcher.Dispose (watcher_handle);
+				watcher?.StopDispatching (watcher_handle);
+				watcher?.Dispose (watcher_handle);
 			} catch (Exception) { }
 
 			watcher_handle = null;
@@ -550,7 +550,7 @@ namespace System.IO {
 				return;
 			if (watcher_handle == null)
 				return;
-			watcher.StartDispatching (watcher_handle);
+			watcher?.StartDispatching (watcher_handle);
 		}
 
 		void Stop ()
@@ -559,7 +559,7 @@ namespace System.IO {
 				return;
 			if (watcher_handle == null)
 				return;
-			watcher.StopDispatching (watcher_handle);
+			watcher?.StopDispatching (watcher_handle);
 		}
 		#endregion // Methods
 

--- a/mcs/class/System/System.IO/InotifyWatcher.cs
+++ b/mcs/class/System/System.IO/InotifyWatcher.cs
@@ -135,6 +135,8 @@ namespace System.IO {
 		
 		public void StartDispatching (object handle)
 		{
+			if (handle == null)
+				return;
 			var fsw = handle as FileSystemWatcher;
 			ParentInotifyData parent;
 			lock (this) {
@@ -331,6 +333,8 @@ namespace System.IO {
 
 		public void StopDispatching (object handle)
 		{
+			if (handle == null)
+				return;
 			var fsw = handle as FileSystemWatcher;
 			ParentInotifyData parent;
 			lock (this) {

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1184,8 +1184,7 @@ CI_PR_DISABLED_TESTS = \
 	appdomain-threadpool-unload.exe \
 	monitor-abort.exe \
 	monitor-wait-abort.exe \
-	process-stress-3.exe \
-	bug-80307.exe
+	process-stress-3.exe
 
 # appdomain-threadpool-unload.exe creates 100 appdomains, takes too long with llvm
 LLVM_DISABLED_TESTS = \


### PR DESCRIPTION
Fixes #7568 

Going to run the tests a few times, do not merge