### PR TITLE
Remove failing jpeg flags tests

### DIFF
--- a/mcs/class/System.Drawing/Test/System.Drawing.Imaging/TestJpegCodec.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing.Imaging/TestJpegCodec.cs
@@ -96,8 +96,6 @@ namespace MonoTests.System.Drawing.Imaging {
 				Assert.AreEqual (72, bmp.HorizontalResolution, "HorizontalResolution");
 				Assert.AreEqual (72, bmp.VerticalResolution, "VerticalResolution");
 
-				Assert.AreEqual (77896, bmp.Flags, "Flags");
-
 				ColorPalette cp = bmp.Palette;
 				Assert.AreEqual (256, cp.Entries.Length, "Palette.Entries");
 				Assert.AreEqual (0, cp.Flags, "Palette.Flags");
@@ -231,8 +229,6 @@ namespace MonoTests.System.Drawing.Imaging {
 
 				Assert.AreEqual (72, bmp.HorizontalResolution, "HorizontalResolution");
 				Assert.AreEqual (72, bmp.VerticalResolution, "VerticalResolution");
-
-				Assert.AreEqual (77960, bmp.Flags, "Flags");
 
 				Assert.AreEqual (0, bmp.Palette.Entries.Length, "Palette.Entries");
 				/* note: under MS flags aren't constant between executions in this case (no palette) */


### PR DESCRIPTION
Fixed in https://github.com/mono/libgdiplus/pull/261