### PR TITLE
Report more information in debugger for assertion failures etc.

### DIFF
--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -828,6 +828,12 @@ native_stack_with_gdb (pid_t crashed_pid, const char **argv, FILE *commands, cha
 	fprintf (commands, "attach %ld\n", (long) crashed_pid);
 	fprintf (commands, "info threads\n");
 	fprintf (commands, "thread apply all bt\n");
+	for (int i = 0; i < 32; ++i) {
+		fprintf (commands, "info registers\n");
+		fprintf (commands, "info frame\n");
+		fprintf (commands, "info locals\n");
+		fprintf (commands, "up\n");
+	}
 
 	return TRUE;
 }
@@ -851,6 +857,12 @@ native_stack_with_lldb (pid_t crashed_pid, const char **argv, FILE *commands, ch
 	fprintf (commands, "process attach --pid %ld\n", (long) crashed_pid);
 	fprintf (commands, "thread list\n");
 	fprintf (commands, "thread backtrace all\n");
+	for (int i = 0; i < 32; ++i) {
+		fprintf (commands, "reg read\n");
+		fprintf (commands, "frame info\n");
+		fprintf (commands, "frame variable\n");
+		fprintf (commands, "up\n");
+	}
 	fprintf (commands, "detach\n");
 	fprintf (commands, "quit\n");
 


### PR DESCRIPTION
And cleanup a little.

32 times:

gdb:
```
 info registers
 info frame
 info locals
 up
```

lldb:
```
 reg red
 frame info
 frame variable
 up
```
