### PR TITLE
[ppc] use ucontext_t

### DIFF
--- a/mono/utils/mono-sigcontext.h
+++ b/mono/utils/mono-sigcontext.h
@@ -326,7 +326,7 @@ typedef struct ucontext {
 #endif
 
 #if defined(__linux__)
-	typedef struct ucontext os_ucontext;
+	typedef ucontext_t os_ucontext;
 
 #ifdef __mono_ppc64__
 	#define UCONTEXT_REG_Rn(ctx, n)   (((os_ucontext*)(ctx))->uc_mcontext.gp_regs [(n)])


### PR DESCRIPTION
`struct ucontext` has been removed from glibc and `ucontext_t` has been
around for a while now.

Fixes a build failure on Ubuntu 18.04

Related glibc change
https://sourceware.org/git/gitweb.cgi?p=glibc.git;a=commitdiff;h=251287734e89a52da3db682a8241eb6bccc050c9;hp=c86ed71d633c22d6f638576f7660c52a5f783d66



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
