### PR TITLE
[2017-12] Disable building btls/ and support/ on the bcl build, they are not needed.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4354,9 +4354,10 @@ dnl ***  Btls  ***
 dnl **************
 
 AC_ARG_ENABLE(btls, [  --disable-btls             Disable the BoringTls provider], enable_btls=$enableval, enable_btls=$BTLS_SUPPORTED)
+AC_ARG_ENABLE(btls-lib, [  --disable-btls-lib             Disable building the BTLS native library], enable_btls_lib=$enableval, enable_btls_lib=$BTLS_SUPPORTED)
 AC_ARG_WITH(btls_android_ndk, [  --with-btls-android-ndk        Android NDK for BoringTls])
 
-AM_CONDITIONAL(BTLS, test x$enable_btls = xyes)
+AM_CONDITIONAL(BTLS, test x$enable_btls_lib = xyes)
 
 btls_android=no
 if test "x$enable_btls" = "xyes"; then

--- a/sdks/builds/bcl.mk
+++ b/sdks/builds/bcl.mk
@@ -15,6 +15,8 @@ bcl_CONFIGURE_FLAGS = \
        $(if $(DISABLE_WASM),,--with-wasm=yes) \
        --with-mcs-docs=no \
        --disable-nls \
+       --disable-btls-lib \
+       --disable-support-build \
        --disable-boehm
 
 .stamp-bcl-configure: $(TOP)/configure


### PR DESCRIPTION
Backport of #7921.

/cc @vargaz