### PR TITLE
[interp] Introduce MonoEEFeatures::force_use_interpreter as a way to make the wasm interp work.

### DIFF
--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -2592,10 +2592,14 @@ mono_runtime_set_execution_mode (MonoEEMode mode)
 		mono_aot_only = TRUE;
 		mono_use_interpreter = TRUE;
 		mono_llvm_only = TRUE;
+
+		mono_ee_features.force_use_interpreter = TRUE;
 		break;
 
 	case MONO_EE_MODE_INTERP:
 		mono_use_interpreter = TRUE;
+
+		mono_ee_features.force_use_interpreter = TRUE;
 		break;
 
 	default:

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -2093,7 +2093,7 @@ mono_jit_compile_method_with_opt (MonoMethod *method, guint32 opt, gboolean jit_
 
 	error_init (error);
 
-	if (mono_use_interpreter && !mono_aot_only && !jit_only)
+	if (mono_ee_features.force_use_interpreter && !jit_only)
 		use_interp = TRUE;
 	if (!use_interp && mono_interp_only_classes) {
 		for (GSList *l = mono_interp_only_classes; l; l = l->next) {
@@ -2739,7 +2739,7 @@ mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 	MonoJitInfo *ji = NULL;
 	gboolean callee_gsharedvt = FALSE;
 
-	if (mono_use_interpreter && !mono_aot_only)
+	if (mono_ee_features.force_use_interpreter)
 		return mini_get_interp_callbacks ()->runtime_invoke (method, obj, params, exc, error);
 
 	error_init (error);

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -352,6 +352,11 @@ typedef struct {
 	 * If true, trampolines are to be fetched from the AOT runtime instead of JIT compiled
 	 */
 	gboolean use_aot_trampolines;
+
+	/*
+	 * If true, the runtime will try to use the interpreter before looking for compiled code.
+	 */
+	gboolean force_use_interpreter;
 } MonoEEFeatures;
 
 extern MonoEEFeatures mono_ee_features;


### PR DESCRIPTION
This flag tells the EE to skip searching compiled code and use the interp exclusively.

This PR unbricks the wasm interp runtime.