### PR TITLE
[interp] workaround undefined behaviour in r8 to u1 cast

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3332,7 +3332,14 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 			++ip;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_I1_R8)
-			sp [-1].data.i = (gint8)sp [-1].data.f;
+			/* without gint32 cast, C compiler is allowed to use undefined
+			 * behaviour if data.f is bigger than >255. See conv.fpint section
+			 * in C standard:
+			 * > The conversion truncates; that is, the fractional  part
+			 * > is discarded.  The behavior is undefined if the truncated
+			 * > value cannot be represented in the destination type.
+			 * */
+			sp [-1].data.i = (gint8) (gint32) sp [-1].data.f;
 			++ip;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_U1_I4)
@@ -3344,7 +3351,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 			++ip;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_U1_R8)
-			sp [-1].data.i = (guint8)sp [-1].data.f;
+			sp [-1].data.i = (guint8) (guint32) sp [-1].data.f;
 			++ip;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_I2_I4)
@@ -3356,7 +3363,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 			++ip;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_I2_R8)
-			sp [-1].data.i = (gint16)sp [-1].data.f;
+			sp [-1].data.i = (gint16) (gint32) sp [-1].data.f;
 			++ip;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_U2_I4)
@@ -3368,7 +3375,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 			++ip;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_U2_R8)
-			sp [-1].data.i = (guint16)sp [-1].data.f;
+			sp [-1].data.i = (guint16) (guint32) sp [-1].data.f;
 			++ip;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_I4_R8)


### PR DESCRIPTION
This fixes `test_0_simple_double_casts` on iOS/arm64.
According to the C standard (section [conv.fpint]), the behaviour of
such a cast is undefined if the truncated value doesn't fit into the
destination type.

```c
unsigned char __attribute__ ((noinline)) convr8u1 (double i)
{
        return (unsigned char) i;
}
```

for arm64, `clang -O0` produces (works as you would expect):

```
_convr8u1:
100006848:  ff 43 00 d1     sub sp, sp, #16
10000684c:  e0 07 00 fd     str d0, [sp, #8]
100006850:  e0 07 40 fd     ldr d0, [sp, #8]
100006854:  08 00 78 1e     fcvtzs  w8, d0
100006858:  00 1d 00 53     uxtb    w0, w8
10000685c:  ff 43 00 91     add sp, sp, #16
100006860:  c0 03 5f d6     ret
```

while `clang -O2` produces:

```
_convr8u1:
100006ae8:  00 00 78 1e     fcvtzs  w0, d0
100006aec:  c0 03 5f d6     ret
```

which is fine according the standard: Any value < 256 gets casted just
fine, but for example `convr8u1 ((double) 0xffff)` would end up with
`0xffff` in `w0`.

We workaround this behaviour by casting to a 32bit int first, the
resulting code looks like this then:

```
_convr8u1:
100006ae4:  08 00 78 1e     fcvtzs  w8, d0
100006ae8:  00 1d 00 12     and w0, w8, #0xff
100006aec:  c0 03 5f d6     ret
```



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
