### PR TITLE
[coop] Remove AbortBlockingIgnoreAndPoll

### DIFF
--- a/mono/utils/mono-threads-coop.c
+++ b/mono/utils/mono-threads-coop.c
@@ -352,9 +352,6 @@ mono_threads_enter_gc_unsafe_region_unbalanced_with_info (MonoThreadInfo *info, 
 	case AbortBlockingIgnore:
 		info->thread_saved_state [SELF_SUSPEND_STATE_INDEX].valid = FALSE;
 		return NULL;
-	case AbortBlockingIgnoreAndPoll:
-		mono_threads_state_poll_with_info (info);
-		return NULL;
 	case AbortBlockingOk:
 		info->thread_saved_state [SELF_SUSPEND_STATE_INDEX].valid = FALSE;
 		break;

--- a/mono/utils/mono-threads-state-machine.c
+++ b/mono/utils/mono-threads-state-machine.c
@@ -500,10 +500,6 @@ retry_state_change:
 		trace_state_change ("ABORT_BLOCKING", info, raw_state, cur_state, 0);
 		return AbortBlockingIgnore;
 
-	case STATE_ASYNC_SUSPEND_REQUESTED: //thread is runnable and have a pending suspend
-		trace_state_change ("ABORT_BLOCKING", info, raw_state, cur_state, 0);
-		return AbortBlockingIgnoreAndPoll;
-
 	case STATE_BLOCKING:
 		if (suspend_count == 0) {
 			if (mono_atomic_cas_i32 (&info->thread_state, build_thread_state (STATE_RUNNING, suspend_count), raw_state) != raw_state)
@@ -522,6 +518,7 @@ retry_state_change:
 STATE_ASYNC_SUSPENDED:
 STATE_SELF_SUSPENDED: Code should not be running while suspended.
 STATE_BLOCKING_AND_SUSPENDED: This is an exit state of done blocking, can't happen here.
+STATE_ASYNC_SUSPEND_REQUESTED: Once we're in STATE_BLOCKING, request_async_suspend just increments the suspend count, so this should never happen.
 */
 	default:
 		mono_fatal_with_history ("Cannot transition thread %p from %s with DONE_BLOCKING", mono_thread_info_get_tid (info), state_name (cur_state));

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -627,7 +627,6 @@ typedef enum {
 
 typedef enum {
 	AbortBlockingIgnore, //Ignore
-	AbortBlockingIgnoreAndPoll, //Ignore and poll
 	AbortBlockingOk, //Abort worked
 	AbortBlockingWait, //Abort worked, but should wait for resume
 } MonoAbortBlockingResult;


### PR DESCRIPTION
This is used to indicate that `mono_threads_transition_abort_blocking` was called
by a thread in the `STATE_ASYNC_SUSPEND_REQUESTED` state.  But we have no
transitions from `STATE_BLOCKING` to `STATE_ASYNC_SUSPEND_REQUESTED` (as
`mono_threads_transition_request_async_suspension` just increments the suspend
count when in `STATE_BLOCKING`), therefore abort is always a programmer error.
