### PR TITLE
[SDKS] Fix Android SDK build on Linux

### DIFF
--- a/sdks/builds/android.mk
+++ b/sdks/builds/android.mk
@@ -24,8 +24,7 @@ $$(ANDROID_TOOLCHAIN_CACHE_DIR)/$(1).zip: | $$(ANDROID_TOOLCHAIN_CACHE_DIR)
 
 $$(ANDROID_TOOLCHAIN_DIR)/$(3)$$(if $(2),/$(2))/.stamp-$(1): $$(ANDROID_TOOLCHAIN_CACHE_DIR)/$(1).zip
 	rm -rf $$(ANDROID_TOOLCHAIN_DIR)/$(3)$$(if $(2),/$(2))
-	mkdir -p $$(ANDROID_TOOLCHAIN_DIR)/$(3)$$(if $(2),/$(2))
-	tar -xf $$< -C $$(ANDROID_TOOLCHAIN_DIR)/$(3)$$(if $(2),/$(2)) --strip-components 1
+	./unzip-android-archive.sh "$$<" "$$(ANDROID_TOOLCHAIN_DIR)/$(3)$$(if $(2),/$(2))"
 	touch $$@
 
 .PHONY: provision-android-$(3)-$(1)
@@ -58,7 +57,7 @@ $(eval $(call AndroidSDKProvisioningTemplate,emulator-darwin-4266726,emulator))
 else
 ifeq ($(UNAME),Linux)
 $(eval $(call AndroidSDKProvisioningTemplate,build-tools_r$(ANDROID_BUILD_TOOLS_VERSION)-linux,build-tools/$(ANDROID_BUILD_TOOLS_VERSION)))
-$(eval $(call AndroidSDKProvisioningTemplate,platform-tools_r27.0.1-linux,platforms-tools))
+$(eval $(call AndroidSDKProvisioningTemplate,platform-tools_r27.0.1-linux,platform-tools))
 $(eval $(call AndroidSDKProvisioningTemplate,sdk-tools-linux-4333796,tools))
 $(eval $(call AndroidSDKProvisioningTemplate,emulator-linux-4266726,emulator))
 else

--- a/sdks/builds/unzip-android-archive.sh
+++ b/sdks/builds/unzip-android-archive.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+
+function cleanup()
+{
+	if [ -n "$ARCHIVE_TEMP_DIR" ]; then
+		rm -rf "$ARCHIVE_TEMP_DIR"
+	fi
+}
+
+trap cleanup 0
+
+## Parameters:
+#    $1: path to source archive
+#    $2: destination directory
+
+# This weird syntax is necessary because some zip archives do not contain a separate
+# entry for the root directory but merely a collection of its subdirectories (for instance
+# platform-tools). The very first entry in the archive is retrieved, then its path is read and
+# finally the part up to the first '/' of the path is retrieved as the root directory of
+# the archive. With platform-tools the last part is necessary because otherwise the root directory
+# would end up being reported as `platform-tools/adb` as this is the first entry in the archive and
+# there's no `platform-tools/` entry
+ZIP_ROOT_DIR=$(unzip -qql "$1" | head -n1 | tr -s ' ' | cut -d' ' -f5- | tr '/' ' ' | cut -d' ' -f1)
+
+# We need a temporary directory because some archives (emulator) have their root directory named the
+# same as a file/directory inside it (emulator has emulator/emulator executable for instance) and
+# moving such a file/directory to .. wouldn't work
+ARCHIVE_TEMP_DIR=$(mktemp -d)
+
+unzip "$1" -d "$ARCHIVE_TEMP_DIR"
+mkdir -p "$2"
+find "$ARCHIVE_TEMP_DIR/$ZIP_ROOT_DIR/" -maxdepth 1 -not \( -name "$ZIP_ROOT_DIR" -and -type d \) -and -not -name . -and -not -name .. -exec mv -f '{}' "$2" ';'


### PR DESCRIPTION
Current build uses `tar` to extract ZIP archives. This works with BSD
tar but not with GNU tar, alas. Tar was used in order to strip the root
directory of Android archive while moving files into place. This commit
replaces `tar` with a call to a shell script (because doing what it does
using Make defines is an exercise in pain) which works both on macOS/BSD
and on Linux.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
