### PR TITLE
[System]: Fix memory leak in the web stack (partial fix of #7356).

### DIFF
--- a/mcs/class/System/System.Net/WebResponseStream.cs
+++ b/mcs/class/System/System.Net/WebResponseStream.cs
@@ -404,22 +404,28 @@ namespace System.Net
 				return;
 			}
 
-			var timeoutTask = Task.Delay (ReadTimeout);
 			var completion = new WebCompletionSource ();
-			while (true) {
-				/*
-				 * 'currentRead' is set by ReadAsync().
-				 */
-				cancellationToken.ThrowIfCancellationRequested ();
-				var oldCompletion = Interlocked.CompareExchange (ref pendingRead, completion, null);
-				if (oldCompletion == null)
-					break;
+			var timeoutCts = new CancellationTokenSource ();
+			try {
+				var timeoutTask = Task.Delay (ReadTimeout, timeoutCts.Token);
+				while (true) {
+					/*
+					 * 'currentRead' is set by ReadAsync().
+					 */
+					cancellationToken.ThrowIfCancellationRequested ();
+					var oldCompletion = Interlocked.CompareExchange (ref pendingRead, completion, null);
+					if (oldCompletion == null)
+						break;
 
-				// ReadAsync() is in progress.
-				var oldReadTask = oldCompletion.WaitForCompletion ();
-				var anyTask = await Task.WhenAny (oldReadTask, timeoutTask).ConfigureAwait (false);
-				if (anyTask == timeoutTask)
-					throw new WebException ("The operation has timed out.", WebExceptionStatus.Timeout);
+					// ReadAsync() is in progress.
+					var oldReadTask = oldCompletion.WaitForCompletion ();
+					var anyTask = await Task.WhenAny (oldReadTask, timeoutTask).ConfigureAwait (false);
+					if (anyTask == timeoutTask)
+						throw new WebException ("The operation has timed out.", WebExceptionStatus.Timeout);
+				}
+			} finally {
+				timeoutCts.Cancel ();
+				timeoutCts.Dispose ();
 			}
 
 			WebConnection.Debug ($"{ME} READ ALL ASYNC #1");


### PR DESCRIPTION
Using `Task.Delay (timeout)` has the potential of possibly allocating and holding large
chunks of memory throughout the timeout period.  While this is not strictly speaking a
memory leak because those objects will eventually be disposed and garbage collected, it
can cause memory usage of apps to grow quite significantly in the short run.

The default timeout values are as follows:

* `HttpWebRequest.ReadWriteTimeout`: 5 minutes.

* `HttpWebRequest.Timeout`: 100 seconds.

* `ServicePointManager.MaxServicePointIdleTime`: 100 seconds.

And these values can be increased by the user.  This means that we're potentially holding
hundreds, maybe even thousands of timeout objects in memory for 5+ minutes.

This has now been fixed by using the `Task.Delay(int,CancellationToken)` constructor.

Note that disposing a `CancellationTokenSource` will not cancel it, so the following code
will still leak:

	using (var cts = new CancellationTokenSource ()) {
		Task.Delay (TimeSpan.FromDays (3), cts.Token);
		// Work
	}

To actually make the `Task.Delay` instance go away when we're done with it, we need to
use this pattern:

	var cts = new CancellationTokenSource ();
	try {
		Task.Delay (TimeSpan.FromDays (3), cts.Token);
		// Work
	} finally {
		cts.Cancel ();
		cts.Dispose ();
	}

We also cannot use `CancellationToken.CancelAfter()` for timeouts because unfortunately
some of the underlying framework code that we're using does not honor cancellation
requests - like for instance `NetworkStream`.

This is a partial fix for #7356.  While this commit significantly improves the problem,
there may be other unrelated issues left that needs to be investigated.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
