### PR TITLE
[interp] do not bake object reference into code stream

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3477,6 +3477,23 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 			++sp;
 			ip += 2;
 			MINT_IN_BREAK;
+		MINT_IN_CASE(MINT_LDSTR_TOKEN) {
+			MonoString *s = NULL;
+			guint32 strtoken = (guint32) rtm->data_items [* (guint16 *)(ip + 1)];
+
+			MonoMethod *method = frame->imethod->method;
+			if (method->wrapper_type == MONO_WRAPPER_DYNAMIC_METHOD) {
+				s = mono_method_get_wrapper_data (method, strtoken);
+			} else if (method->wrapper_type != MONO_WRAPPER_NONE) {
+				s = mono_string_new_wrapper (mono_method_get_wrapper_data (method, strtoken));
+			} else {
+				g_assert_not_reached ();
+			}
+			sp->data.p = s;
+			++sp;
+			ip += 2;
+			MINT_IN_BREAK;
+		}
 		MINT_IN_CASE(MINT_NEWOBJ) {
 			MonoClass *newobj_class;
 			MonoMethodSignature *csig;

--- a/mono/mini/interp/mintops.def
+++ b/mono/mini/interp/mintops.def
@@ -262,6 +262,7 @@ OPDEF(MINT_BLT_UN_R8_S, "blt.un.r8.s", 2, MintOpShortBranch)
 OPDEF(MINT_SWITCH, "switch", 0, MintOpSwitch)
 
 OPDEF(MINT_LDSTR, "ldstr", 2, MintOpMethodToken) /* not really */
+OPDEF(MINT_LDSTR_TOKEN, "ldstr.token", 2, MintOpMethodToken) /* not really */
 
 OPDEF(MINT_CALL, "call", 2, MintOpMethodToken) 
 OPDEF(MINT_VCALL, "vcall", 2, MintOpMethodToken) 


### PR DESCRIPTION
it won't be scanned by the GC, defer string allocation to execution-time instead.


this fixes a GC crash when running mini regression suite on iOS/arm64.