### PR TITLE
Remove System.Array.SetGenericValueImpl and InternalArray__set_Item<T>.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # This can be reset to 0 when Mono's version number is bumped
 # since it's part of the corlib version (the prefix '1' in the full
 # version number is to ensure the number isn't treated as octal in C)
-MONO_CORLIB_COUNTER=3
+MONO_CORLIB_COUNTER=4
 MONO_CORLIB_VERSION=`printf "1%02d%02d%02d%03d" $MONO_VERSION_MAJOR $MONO_VERSION_MINOR 0 $MONO_CORLIB_COUNTER`
 
 AC_DEFINE_UNQUOTED(MONO_CORLIB_VERSION,$MONO_CORLIB_VERSION,[Version of the corlib-runtime interface])

--- a/mcs/class/corlib/System/Array.cs
+++ b/mcs/class/corlib/System/Array.cs
@@ -180,26 +180,9 @@ namespace System
 			return value;
 		}
 
-		internal void InternalArray__set_Item<T> (int index, T item)
-		{
-			if (unchecked ((uint) index) >= unchecked ((uint) Length))
-				throw new ArgumentOutOfRangeException ("index");
-
-			object[] oarray = this as object [];
-			if (oarray != null) {
-				oarray [index] = (object)item;
-				return;
-			}
-			SetGenericValueImpl (index, ref item);
-		}
-
 		// CAUTION! No bounds checking!
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		internal extern void GetGenericValueImpl<T> (int pos, out T value);
-
-		// CAUTION! No bounds checking!
-		[MethodImplAttribute (MethodImplOptions.InternalCall)]
-		internal extern void SetGenericValueImpl<T> (int pos, ref T value);
 
 		internal struct InternalEnumerator<T> : IEnumerator<T>
 		{

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -162,7 +162,6 @@ ICALL(ARRAY_7, "GetLowerBound",    ves_icall_System_Array_GetLowerBound)
 ICALL(ARRAY_8, "GetRank",          ves_icall_System_Array_GetRank)
 ICALL(ARRAY_9, "GetValue",         ves_icall_System_Array_GetValue)
 ICALL(ARRAY_10, "GetValueImpl",     ves_icall_System_Array_GetValueImpl)
-ICALL(ARRAY_11, "SetGenericValueImpl", ves_icall_System_Array_SetGenericValueImpl)
 HANDLES(ICALL(ARRAY_12, "SetValue",         ves_icall_System_Array_SetValue))
 HANDLES(ICALL(ARRAY_13, "SetValueImpl",     ves_icall_System_Array_SetValueImpl))
 

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -859,32 +859,6 @@ ves_icall_System_Array_GetGenericValueImpl (MonoArray *arr, guint32 pos, gpointe
 }
 
 ICALL_EXPORT void
-ves_icall_System_Array_SetGenericValueImpl (MonoArray *arr, guint32 pos, gpointer value)
-{
-	MonoClass *ac, *ec;
-	gint32 esize;
-	gpointer *ea;
-
-	ac = (MonoClass *)arr->obj.vtable->klass;
-	ec = m_class_get_element_class (ac);
-
-	esize = mono_array_element_size (ac);
-	ea = (gpointer*)((char*)arr->vector + (pos * esize));
-
-	if (MONO_TYPE_IS_REFERENCE (m_class_get_byval_arg (ec))) {
-		g_assert (esize == sizeof (gpointer));
-		mono_gc_wbarrier_generic_store (ea, *(MonoObject **)value);
-	} else {
-		g_assert (m_class_is_inited (ec));
-		g_assert (esize == mono_class_value_size (ec, NULL));
-		if (m_class_has_references (ec))
-			mono_gc_wbarrier_value_copy (ea, value, 1, ec);
-		else
-			mono_gc_memmove_atomic (ea, value, esize);
-	}
-}
-
-ICALL_EXPORT void
 ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_InitializeArray (MonoArrayHandle array, MonoClassField *field_handle, MonoError *error)
 {
 	error_init (error);


### PR DESCRIPTION
They are not used. They are only reachable via reflection to non-public functions.