### PR TITLE
[SDKS] fix Linux (and possibly other OSes) build for Android

### DIFF
--- a/mono/btls/Makefile.am
+++ b/mono/btls/Makefile.am
@@ -44,12 +44,14 @@ NINJA_VERBOSE=$(if ($V),-v,)
 if NINJA
 NINJA_ARGS = -G Ninja
 BUILDFILE = build.ninja
+CMAKE_MAKE_PROGRAM = $(shell which ninja-build || which ninja)
 else
 NINJA_ARGS =
 BUILDFILE = Makefile
+CMAKE_MAKE_PROGRAM = $(shell which gmake || which gnumake || which make)
 endif
 
-CMAKE_ARGS = -D CMAKE_INSTALL_PREFIX:PATH=$(prefix) -D BTLS_ROOT:PATH=$(BTLS_ROOT) \
+CMAKE_ARGS = -D CMAKE_MAKE_PROGRAM=$(CMAKE_MAKE_PROGRAM) -D CMAKE_INSTALL_PREFIX:PATH=$(prefix) -D BTLS_ROOT:PATH=$(BTLS_ROOT) \
 	-D SRC_DIR:PATH=$(abs_top_srcdir)/mono/btls -D BTLS_CFLAGS:STRING="$(BTLS_CFLAGS)" $(NINJA_ARGS)
 
 all-local: build-shared/libmono-btls-shared$(libsuffix)


### PR DESCRIPTION
OS: Ubuntu 18.03
CMake: 3.10

For some reason cmake fails to detect any make program (be it ninja or make)
when cross-compiling for Android in XA. It happens despite the programs being in
$PATH and working correctly. The effect is that CMAKE_MAKE_PROGRAM is set to
"not found" in CMakeCache.txt and configuration fails as follows:
```
 Call Stack (most recent call first):
   external/mono/external/boringssl/util/android-cmake/android.toolchain.cmake:1140 (CMAKE_FORCE_CXX_COMPILER)
   external/mono/sdks/builds/android-armeabi-v7a-debug/mono/btls/build-shared/CMakeFiles/3.10.2/CMakeSystem.cmake:6 (include)
      CMakeLists.txt:3 (project)
   CMake Error: CMake was unable to find a build program corresponding to "Ninja".  CMAKE_MAKE_PROGRAM is not set.  You probably need to select a different build tool.
      -- Configuring incomplete, errors occurred!
```
This commit does not fix the issue, per se, but it works around it by finding
the first ninja/make (as configured) executable in $PATH and setting the
CMAKE_MAKE_PROGRAM to full path of the executable. I haven't spent too much time
investigating *why* cmake fails to find the executable (I merely ran it with
--trace-expand --debug-output which revealed nothing of consequence) but this
workaround should be safe for any version of CMake and any OS we use makefiles
on.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
