### PR TITLE
Report the proper socket error

### DIFF
--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -1168,6 +1168,16 @@ namespace System.Net.Sockets
 			DnsEndPoint dep = e.RemoteEndPoint as DnsEndPoint;
 			if (dep != null) {
 				addresses = Dns.GetHostAddresses (dep.Host);
+				int last_valid = 0;
+				for (int i = 0; i < addresses.Length; ++i) {
+					if (addresses [i].AddressFamily != dep.AddressFamily)
+						continue;
+
+					addresses [last_valid++] = addresses [i];
+				}
+
+				if (last_valid != addresses.Length)
+					Array.Resize (ref addresses, last_valid);
 				return true;
 			} else {
 				e.ConnectByNameError = null;


### PR DESCRIPTION
When a connection fails, the socket error was being incorrectly reported
as an address family not supported error, instead of connection refused.

Why did this happen? The order of addresses returned from
`Dns.GetHostAddresses` changed. The newer code returns the IPv6 address
first, and the IPv4 address second. While `GetCheckedIPs` mentioned in a
comment that it skips addresses that don't match the address family, it
did not. The code using the addresses returned by `GetCheckedIPs` will
use the first address in the array. If this address happens to match the
address family of the socket, things will work "properly" (the correct
socket error will occur).

If, however the first entry has the wrong address family, then the
socket error will be an address family not supported error, since the
socket was created with different address family.

This change modifies `GetCheckedIPs` to filter the addresses, removing
those which do not match the address family.
