### PR TITLE
Throw MemberAccessException when abstract class is used with newobj instruction

### DIFF
--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -2897,6 +2897,13 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsig
 				goto_if_nok (error, exit);
 			}
 
+			if (mono_class_get_flags (klass) & TYPE_ATTRIBUTE_ABSTRACT) {
+				char* full_name = mono_type_get_full_name (klass);
+				mono_error_set_member_access (error, "Cannot create an abstract class: %s", full_name);
+				g_free (full_name);
+				goto_if_nok (error, exit);
+			}
+
 			td->sp -= csignature->param_count;
 			if (mono_class_is_magic_int (klass) || mono_class_is_magic_float (klass)) {
 				ADD_CODE (td, MINT_NEWOBJ_MAGIC);

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -3641,6 +3641,14 @@ handle_alloc (MonoCompile *cfg, MonoClass *klass, gboolean for_box, int context_
 	MonoInst *iargs [2];
 	void *alloc_ftn;
 
+	if (mono_class_get_flags (klass) & TYPE_ATTRIBUTE_ABSTRACT) {
+		char* full_name = mono_type_get_full_name (klass);
+		mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
+		mono_error_set_member_access (&cfg->error, "Cannot create an abstract class: %s", full_name);
+		g_free (full_name);
+		return NULL;
+	}
+
 	if (context_used) {
 		MonoInst *data;
 		MonoRgctxInfoType rgctx_info;

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -992,7 +992,7 @@ PROFILE_DISABLED_TESTS= \
 	tailcall-rgctxb.exe
 
 if FULL_AOT_TESTS
-# Tests which rely on TypeLoadExceptions
+# Tests which rely on TypeLoadExceptions or MemberAccessExceptions
 # In full-aot mode, these cause the relevant methods to be not AOTed.
 PROFILE_DISABLED_TESTS += \
 	typeload-unaligned.exe \
@@ -1013,7 +1013,8 @@ PROFILE_DISABLED_TESTS += \
 	resolve_field_bug.2.exe \
 	resolve_type_bug.2.exe \
 	bug-81691.exe \
-	bug-327438.2.exe
+	bug-327438.2.exe \
+	newobj-abstract.exe
 
 # Tests which rely on remoting
 PROFILE_DISABLED_TESTS += \

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -793,7 +793,8 @@ TESTS_IL_SRC=			\
 	dim-simple.il	\
 	dim-valuetypes.il \
 	tailcall-generic-cast-conservestack-il.il \
-	tailcall-generic-cast-nocrash-il.il
+	tailcall-generic-cast-nocrash-il.il \
+	newobj-abstract.il
 
 TESTS_GSHARED_SRC = \
 	generics-sharing.2.cs	\

--- a/mono/tests/newobj-abstract.il
+++ b/mono/tests/newobj-abstract.il
@@ -1,0 +1,61 @@
+﻿.assembly extern mscorlib {}
+
+.assembly 'newobj-abstract' {}
+
+.class private auto ansi beforefieldinit Program
+       extends [mscorlib]System.Object
+{
+  .method public hidebysig static int32  Main() cil managed
+  {
+    .entrypoint
+    .locals init (int32 V_0)
+
+    ldc.i4.1
+    stloc.0
+    .try
+    {
+      call       void Program::NewAbstract()
+      leave.s    leavetarget
+
+    }  // end .try
+    catch [mscorlib]System.MemberAccessException
+    {
+      pop
+      ldc.i4.0
+      stloc.0
+      leave.s    leavetarget
+    }
+leavetarget:
+    ldloc.0
+    ret
+  } // end of method Program::Main
+
+  .method public hidebysig static void  NewAbstract() cil managed
+  {
+    newobj     instance void Foo::.ctor()
+    call       void [mscorlib]System.GC::KeepAlive(object)
+    ret
+  }
+
+  .method public hidebysig specialname rtspecialname
+          instance void  .ctor() cil managed
+  {
+    ldarg.0
+    call instance void [mscorlib]System.Object::.ctor()
+    ret
+  }
+
+}
+
+.class private abstract auto ansi beforefieldinit Foo
+       extends [mscorlib]System.Object
+{
+  .method public hidebysig specialname rtspecialname
+          instance void  .ctor() cil managed
+  {
+    ldarg.0
+    call instance void [mscorlib]System.Object::.ctor()
+    ret
+  }
+
+}

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -194,6 +194,9 @@ void
 mono_error_set_invalid_program (MonoError *oerror, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(2,3);
 
 void
+mono_error_set_member_access (MonoError *error, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(2,3);
+
+void
 mono_error_set_invalid_cast (MonoError *oerror);
 
 MonoException*

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -428,6 +428,17 @@ mono_error_set_invalid_program (MonoError *oerror, const char *msg_format, ...)
 	set_error_message ();
 }
 
+void
+mono_error_set_member_access (MonoError *oerror, const char *msg_format, ...)
+{
+	MonoErrorInternal *error = (MonoErrorInternal*)oerror;
+
+	mono_error_prepare (error);
+	error->error_code = MONO_ERROR_MEMBER_ACCESS;
+
+	set_error_message ();
+}
+
 /**
  * mono_error_set_invalid_cast:
  *
@@ -587,6 +598,9 @@ mono_error_prepare_exception (MonoError *oerror, MonoError *error_out)
 		break;
 	case MONO_ERROR_MISSING_FIELD:
 		exception = mono_corlib_exception_new_with_args ("System", "MissingFieldException", error->full_message, error->first_argument, error_out);
+		break;
+	case MONO_ERROR_MEMBER_ACCESS:
+		exception = mono_exception_from_name_msg (mono_defaults.corlib, "System", "MemberAccessException", error->full_message);
 		break;
 
 	case MONO_ERROR_TYPE_LOAD:

--- a/mono/utils/mono-error.h
+++ b/mono/utils/mono-error.h
@@ -35,6 +35,7 @@ enum {
 	MONO_ERROR_ARGUMENT_NULL = 11,
 	MONO_ERROR_NOT_VERIFIABLE = 8,
 	MONO_ERROR_INVALID_PROGRAM = 12,
+	MONO_ERROR_MEMBER_ACCESS = 13,
 
 	/*
 	 * This is a generic error mechanism is you need to raise an arbitrary corlib exception.


### PR DESCRIPTION
Previously an abstract instance would be created and potentially crash when vtable members were accessed.