### PR TITLE
[coop] Hybrid suspend

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4491,6 +4491,15 @@ fi
 
 AM_CONDITIONAL([ENABLE_COOP], [test x$with_cooperative_gc != xno])
 
+AC_ARG_WITH(hybrid_suspend, [ --with-hybrid-suspend=yes|no     Enable hybrid cooperative stop-the-world garbage collection (sgen only) - cooperative suspend for threads running managed and native code, and preemptive suspend for threads running native and P/Invoke code (defaults to no)], [
+	if test x$with_hybrid_suspend != xno ; then
+		AC_DEFINE(USE_HYBRID_SUSPEND,1,[Enable hybrid cooperative suspend for GC stop-the-world])
+	fi
+	if test x$with_cooperative_gc != xyes ; then
+		AC_MSG_ERROR([Hybrid suspend requires --with-cooperative-gc=yes])
+	fi
+], [with_hybrid_suspend=no])
+
 AC_ARG_ENABLE(checked_build, [  --enable-checked-build=LIST      To enable checked build (expensive asserts), configure with a comma-separated LIST of checked build modules and then include that same list in the environment variable MONO_CHECK_MODE at runtime. Recognized checked build modules: all, gc, metadata, thread, private_types],[
 
 	if test x$enable_checked_build != x ; then

--- a/mono/metadata/mono-hash.c
+++ b/mono/metadata/mono-hash.c
@@ -227,7 +227,7 @@ rehash (MonoGHashTable *hash)
 	if (hash->gc_type & MONO_HASH_VALUE_GC)
 		mono_gc_register_root_wbarrier ((char*)data.values, sizeof (MonoObject*) * data.new_size, mono_gc_make_vector_descr (), hash->source, hash->key, hash->msg);
 
-	if (!mono_threads_are_safepoints_enabled ()) {
+	if (!mono_threads_are_safepoints_enabled () || mono_threads_is_hybrid_suspension_enabled ()) {
 		mono_gc_invoke_with_gc_lock (do_rehash, &data);
 	} else {
 		/* We cannot be preempted */

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -2599,7 +2599,9 @@ mono_thread_suspend (MonoInternalThread *thread)
 	}
 	
 	thread->state |= ThreadState_SuspendRequested;
+	MONO_ENTER_GC_SAFE;
 	mono_os_event_reset (thread->suspended);
+	MONO_EXIT_GC_SAFE;
 
 	if (thread == mono_thread_internal_current ()) {
 		/* calls UNLOCK_THREAD (thread) */
@@ -2627,7 +2629,9 @@ mono_thread_resume (MonoInternalThread *thread)
 	if ((thread->state & ThreadState_SuspendRequested) != 0) {
 		// MOSTLY_ASYNC_SAFE_PRINTF ("RESUME (1) thread %p\n", thread_get_tid (thread));
 		thread->state &= ~ThreadState_SuspendRequested;
+		MONO_ENTER_GC_SAFE;
 		mono_os_event_set (thread->suspended);
+		MONO_EXIT_GC_SAFE;
 		return TRUE;
 	}
 
@@ -2642,7 +2646,9 @@ mono_thread_resume (MonoInternalThread *thread)
 
 	// MOSTLY_ASYNC_SAFE_PRINTF ("RESUME (3) thread %p\n", thread_get_tid (thread));
 
+	MONO_ENTER_GC_SAFE;
 	mono_os_event_set (thread->suspended);
+	MONO_EXIT_GC_SAFE;
 
 	if (!thread->self_suspended) {
 		UNLOCK_THREAD (thread);
@@ -3429,8 +3435,10 @@ mono_threads_set_shutting_down (void)
 		 * interrupt the main thread if it is waiting for all
 		 * the other threads.
 		 */
+		MONO_ENTER_GC_SAFE;
 		mono_os_event_set (&background_change_event);
-		
+		MONO_EXIT_GC_SAFE;
+
 		mono_threads_unlock ();
 	}
 }
@@ -3467,7 +3475,9 @@ mono_thread_manage (void)
 		THREAD_DEBUG (g_message ("%s: There are %d threads to join", __func__, mono_g_hash_table_size (threads));
 			mono_g_hash_table_foreach (threads, print_tids, NULL));
 	
+		MONO_ENTER_GC_SAFE;
 		mono_os_event_reset (&background_change_event);
+		MONO_EXIT_GC_SAFE;
 		wait->num=0;
 		/* We must zero all InternalThread pointers to avoid making the GC unhappy. */
 		memset (wait->threads, 0, MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS * SIZEOF_VOID_P);
@@ -3615,7 +3625,9 @@ void mono_thread_suspend_all_other_threads (void)
 				thread->state &= ~ThreadState_AbortRequested;
 			
 			thread->state |= ThreadState_SuspendRequested;
+			MONO_ENTER_GC_SAFE;
 			mono_os_event_reset (thread->suspended);
+			MONO_EXIT_GC_SAFE;
 
 			/* Signal the thread to suspend + calls UNLOCK_THREAD (thread) */
 			async_suspend_internal (thread, TRUE);
@@ -4628,6 +4640,8 @@ static void CALLBACK dummy_apc (ULONG_PTR param)
 static MonoException*
 mono_thread_execute_interruption (void)
 {
+	MONO_REQ_GC_UNSAFE_MODE;
+
 	MonoException *exc = NULL;
 	MonoInternalThread *thread = mono_thread_internal_current ();
 	MonoThread *sys_thread = mono_thread_current ();
@@ -4912,7 +4926,9 @@ mono_thread_notify_change_state (MonoThreadState old_state, MonoThreadState new_
 		 * be notified, since it has to rebuild the list of threads to
 		 * wait for.
 		 */
+		MONO_ENTER_GC_SAFE;
 		mono_os_event_set (&background_change_event);
+		MONO_EXIT_GC_SAFE;
 	}
 }
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -4993,6 +4993,9 @@ self_interrupt_thread (void *_unused)
 		if (mono_threads_are_safepoints_enabled ()) {
 			/* We can return from an async call in coop, as
 			 * it's simply called when exiting the safepoint */
+			/* If we're using hybrid suspend, we only self
+			 * interrupt if we were running, hence using
+			 * safepoints */
 			return;
 		}
 

--- a/mono/utils/mono-threads-coop.c
+++ b/mono/utils/mono-threads-coop.c
@@ -312,9 +312,14 @@ mono_threads_exit_gc_safe_region_unbalanced_internal (gpointer cookie, MonoStack
 	case DoneBlockingOk:
 		info->thread_saved_state [SELF_SUSPEND_STATE_INDEX].valid = FALSE;
 		break;
-	case DoneBlockingWait:
 	case DoneBlockingNotifyAndWait:
 		// in full coop NotifyAndWait doesn't notify
+		if (mono_threads_is_hybrid_suspension_enabled ()) {
+			mono_threads_notify_initiator_of_suspend (info);
+		}
+		mono_thread_info_wait_for_resume (info);
+		break;
+	case DoneBlockingWait:
 		THREADS_SUSPEND_DEBUG ("state polling done, notifying of resume\n");
 		mono_thread_info_wait_for_resume (info);
 		break;
@@ -413,9 +418,14 @@ mono_threads_enter_gc_unsafe_region_unbalanced_with_info (MonoThreadInfo *info, 
 	case AbortBlockingOk:
 		info->thread_saved_state [SELF_SUSPEND_STATE_INDEX].valid = FALSE;
 		break;
-	case AbortBlockingWait:
 	case AbortBlockingNotifyAndWait:
 		// in full coop, notify and wait doesn't need to notify
+		if (mono_threads_is_hybrid_suspension_enabled ()) {
+			mono_threads_notify_initiator_of_suspend (info);
+		}
+		mono_thread_info_wait_for_resume (info);
+		break;
+	case AbortBlockingWait:
 		mono_thread_info_wait_for_resume (info);
 		break;
 	default:

--- a/mono/utils/mono-threads-coop.c
+++ b/mono/utils/mono-threads-coop.c
@@ -313,6 +313,8 @@ mono_threads_exit_gc_safe_region_unbalanced_internal (gpointer cookie, MonoStack
 		info->thread_saved_state [SELF_SUSPEND_STATE_INDEX].valid = FALSE;
 		break;
 	case DoneBlockingWait:
+	case DoneBlockingNotifyAndWait:
+		// in full coop NotifyAndWait doesn't notify
 		THREADS_SUSPEND_DEBUG ("state polling done, notifying of resume\n");
 		mono_thread_info_wait_for_resume (info);
 		break;
@@ -412,6 +414,8 @@ mono_threads_enter_gc_unsafe_region_unbalanced_with_info (MonoThreadInfo *info, 
 		info->thread_saved_state [SELF_SUSPEND_STATE_INDEX].valid = FALSE;
 		break;
 	case AbortBlockingWait:
+	case AbortBlockingNotifyAndWait:
+		// in full coop, notify and wait doesn't need to notify
 		mono_thread_info_wait_for_resume (info);
 		break;
 	default:

--- a/mono/utils/mono-threads-coop.c
+++ b/mono/utils/mono-threads-coop.c
@@ -524,6 +524,15 @@ mono_threads_is_blocking_transition_enabled (void)
 #endif
 }
 
+gboolean
+mono_threads_is_hybrid_suspension_enabled (void)
+{
+	static int is_hybrid_suspension_enabled = -1;
+	if (G_UNLIKELY (is_hybrid_suspension_enabled == -1))
+		is_hybrid_suspension_enabled = g_hasenv ("MONO_ENABLE_COOP") && g_hasenv ("MONO_ENABLE_HYBRID_SUSPEND");
+	return is_hybrid_suspension_enabled == 1;
+}
+
 
 void
 mono_threads_coop_init (void)

--- a/mono/utils/mono-threads-coop.c
+++ b/mono/utils/mono-threads-coop.c
@@ -537,10 +537,14 @@ mono_threads_is_blocking_transition_enabled (void)
 gboolean
 mono_threads_is_hybrid_suspension_enabled (void)
 {
+#if defined(USE_HYBRID_SUSPEND)
+	return TRUE;
+#else
 	static int is_hybrid_suspension_enabled = -1;
 	if (G_UNLIKELY (is_hybrid_suspension_enabled == -1))
 		is_hybrid_suspension_enabled = g_hasenv ("MONO_ENABLE_COOP") && g_hasenv ("MONO_ENABLE_HYBRID_SUSPEND");
 	return is_hybrid_suspension_enabled == 1;
+#endif
 }
 
 

--- a/mono/utils/mono-threads-coop.h
+++ b/mono/utils/mono-threads-coop.h
@@ -36,6 +36,9 @@ mono_threads_is_blocking_transition_enabled (void);
 void
 mono_threads_state_poll (void);
 
+gboolean
+mono_threads_is_hybrid_suspension_enabled (void);
+
 static inline void
 mono_threads_safepoint (void)
 {

--- a/mono/utils/mono-threads-state-machine.c
+++ b/mono/utils/mono-threads-state-machine.c
@@ -598,29 +598,6 @@ STATE_BLOCKING_ASYNC_SUSPENDED: This is an exit state of abort blocking, can't h
 	}
 }
 
-MonoThreadUnwindState*
-mono_thread_info_get_suspend_state (MonoThreadInfo *info)
-{
-	int raw_state, cur_state, suspend_count;
-	UNWRAP_THREAD_STATE (raw_state, cur_state, suspend_count, info);
-	switch (cur_state) {
-	case STATE_ASYNC_SUSPENDED:
-	case STATE_BLOCKING_ASYNC_SUSPENDED:
-		return &info->thread_saved_state [ASYNC_SUSPEND_STATE_INDEX];
-	case STATE_SELF_SUSPENDED:
-	case STATE_BLOCKING_SELF_SUSPENDED:
-		return &info->thread_saved_state [SELF_SUSPEND_STATE_INDEX];
-	default:
-/*
-STATE_RUNNING
-STATE_BLOCKING_SUSPEND_REQUESTED
-STATE_ASYNC_SUSPEND_REQUESTED
-STATE_BLOCKING: All those are invalid suspend states.
-*/
-		g_error ("Cannot read suspend state when target %p is in the %s state", mono_thread_info_get_tid (info), state_name (cur_state));
-	}
-}
-
 // State checking code
 /**
  * Return TRUE is the thread is in a runnable state.

--- a/mono/utils/mono-threads-state-machine.c
+++ b/mono/utils/mono-threads-state-machine.c
@@ -41,13 +41,17 @@ state_name (int state)
 {
 	static const char *state_names [] = {
 		"STARTING",
-		"RUNNING",
 		"DETACHED",
+
+		"RUNNING",
 		"ASYNC_SUSPENDED",
 		"SELF_SUSPENDED",
 		"ASYNC_SUSPEND_REQUESTED",
+
 		"STATE_BLOCKING",
+		"STATE_BLOCKING_ASYNC_SUSPENDED",
 		"STATE_BLOCKING_SELF_SUSPENDED",
+		"STATE_BLOCKING_SUSPEND_REQUESTED",
 	};
 	return state_names [get_thread_state (state)];
 }
@@ -73,9 +77,12 @@ check_thread_state (MonoThreadInfo* info)
 	case STATE_SELF_SUSPENDED:
 	case STATE_ASYNC_SUSPEND_REQUESTED:
 	case STATE_BLOCKING_SELF_SUSPENDED:
+	case STATE_BLOCKING_SUSPEND_REQUESTED:
+	case STATE_BLOCKING_ASYNC_SUSPENDED:
 		g_assert (suspend_count > 0);
 		break;
-	case STATE_BLOCKING: //this is a special state that can have zero or positive suspend count.
+	case STATE_BLOCKING:
+		g_assert (suspend_count == 0);
 		break;
 	default:
 		g_error ("Invalid state %d", cur_state);
@@ -153,12 +160,14 @@ retry_state_change:
 		trace_state_change ("DETACH", info, raw_state, STATE_DETACHED, 0);
 		return TRUE;
 	case STATE_ASYNC_SUSPEND_REQUESTED: //Can't detach until whoever asked us to suspend to be happy with us
+	case STATE_BLOCKING_SUSPEND_REQUESTED:
 		return FALSE;
 
 /*
 STATE_ASYNC_SUSPENDED: Code should not be running while suspended.
 STATE_SELF_SUSPENDED: Code should not be running while suspended.
 STATE_BLOCKING_SELF_SUSPENDED: This is a bug in coop x suspend that resulted the thread in an undetachable state.
+STATE_BLOCKING_ASYNC_SUSPENDED: Same as BLOCKING_SELF_SUSPENDED
 */
 	default:
 		mono_fatal_with_history ("Cannot transition current thread %p from %s with DETACH", info, state_name (cur_state));
@@ -170,12 +179,15 @@ This transition initiates the suspension of another thread.
 
 Returns one of the following values:
 
-- AsyncSuspendInitSuspend: Thread suspend requested, async suspend needs to be done.
-- AsyncSuspendAlreadySuspended: Thread already suspended, nothing to do.
-- AsyncSuspendBlocking: Thread in blocking state
+- ReqSuspendInitSuspendRunning: Thread suspend requested, caller must initiate suspend.
+- ReqSuspendInitSuspendBlocking: Thread in blocking state, caller may initiate suspend.
+- ReqSuspendAlreadySuspended: Thread was already suspended and not executing, nothing to do.
+- ReqSuspendAlreadySuspendedBlocking: Thread was already in blocking and a suspend was requested
+                                      and the thread is still executing (perhaps in a syscall),
+                                      nothing to do.
 */
-MonoRequestAsyncSuspendResult
-mono_threads_transition_request_async_suspension (MonoThreadInfo *info)
+MonoRequestSuspendResult
+mono_threads_transition_request_suspension (MonoThreadInfo *info)
 {
 	int raw_state, cur_state, suspend_count;
 	g_assert (info != mono_thread_info_current ());
@@ -189,27 +201,40 @@ retry_state_change:
 			mono_fatal_with_history ("suspend_count = %d, but should be == 0", suspend_count);
 		if (mono_atomic_cas_i32 (&info->thread_state, build_thread_state (STATE_ASYNC_SUSPEND_REQUESTED, 1), raw_state) != raw_state)
 			goto retry_state_change;
-		trace_state_change ("ASYNC_SUSPEND_REQUESTED", info, raw_state, STATE_ASYNC_SUSPEND_REQUESTED, 1);
-		return AsyncSuspendInitSuspend; //This is the first async suspend request against the target
+		trace_state_change ("SUSPEND_INIT_REQUESTED", info, raw_state, STATE_ASYNC_SUSPEND_REQUESTED, 1);
+		return ReqSuspendInitSuspendRunning; //This is the first async suspend request against the target
 
 	case STATE_ASYNC_SUSPENDED:
-	case STATE_SELF_SUSPENDED: //Async suspend can suspend the same thread multiple times as it starts from the outside
+	case STATE_SELF_SUSPENDED:
 	case STATE_BLOCKING_SELF_SUSPENDED:
+	case STATE_BLOCKING_ASYNC_SUSPENDED:
 		if (!(suspend_count > 0 && suspend_count < THREAD_SUSPEND_COUNT_MAX))
 			mono_fatal_with_history ("suspend_count = %d, but should be > 0 and < THREAD_SUSPEND_COUNT_MAX", suspend_count);
 		if (mono_atomic_cas_i32 (&info->thread_state, build_thread_state (cur_state, suspend_count + 1), raw_state) != raw_state)
 			goto retry_state_change;
-		trace_state_change ("ASYNC_SUSPEND_REQUESTED", info, raw_state, cur_state, 1);
-		return AsyncSuspendAlreadySuspended; //Thread is already suspended so we don't need to wait it to suspend
+		trace_state_change ("SUSPEND_INIT_REQUESTED", info, raw_state, cur_state, 1);
+		return ReqSuspendAlreadySuspended; //Thread is already suspended so we don't need to wait it to suspend
 
 	case STATE_BLOCKING:
-		if (!(suspend_count < THREAD_SUSPEND_COUNT_MAX))
-			mono_fatal_with_history ("suspend_count = %d, but should be < THREAD_SUSPEND_COUNT_MAX", suspend_count);
+		if (!(suspend_count == 0))
+			mono_fatal_with_history ("suspend_count = %d, but should be == 0", suspend_count);
+		if (mono_atomic_cas_i32 (&info->thread_state, build_thread_state (STATE_BLOCKING_SUSPEND_REQUESTED, 1), raw_state) != raw_state)
+			goto retry_state_change;
+		trace_state_change ("SUSPEND_INIT_REQUESTED", info, raw_state, STATE_BLOCKING_SUSPEND_REQUESTED, 1);
+		return ReqSuspendInitSuspendBlocking; //A thread in the blocking state has its state saved so we can treat it as suspended.
+	case STATE_BLOCKING_SUSPEND_REQUESTED:
+		/* This should only be happening if we're doing a cooperative suspend of a blocking thread.
+		 * In which case we could be in BLOCKING_SUSPEND_REQUESTED until we execute a done or abort blocking.
+		 * In preemptive suspend of a blocking thread since there's a single suspend initiator active at a time,
+		 * we would expect a finish_async_suspension or a done/abort blocking before the next suspension request
+		 */
+		if (!(suspend_count > 0 && suspend_count < THREAD_SUSPEND_COUNT_MAX))
+			mono_fatal_with_history ("suspend_count = %d, but should be > 0 and < THREAD_SUSPEND_COUNT_MAX", suspend_count);
 		if (mono_atomic_cas_i32 (&info->thread_state, build_thread_state (cur_state, suspend_count + 1), raw_state) != raw_state)
 			goto retry_state_change;
-		trace_state_change ("ASYNC_SUSPEND_REQUESTED", info, raw_state, cur_state, 1);
-		return AsyncSuspendBlocking; //A thread in the blocking state has its state saved so we can treat it as suspended.
-
+		trace_state_change ("SUSPEND_INIT_REQUESTED", info, raw_state, cur_state, 1);
+		return ReqSuspendAlreadySuspendedBlocking;
+		
 /*
 
 [1] It's questionable on what to do if we hit the beginning of a self suspend.
@@ -218,10 +243,11 @@ The expected behavior is that the target should poll its state very soon so the 
 STATE_ASYNC_SUSPEND_REQUESTED: Since there can only be one async suspend in progress and it must finish, it should not be possible to witness this.
 */
 	default:
-		mono_fatal_with_history ("Cannot transition thread %p from %s with ASYNC_SUSPEND_REQUESTED", mono_thread_info_get_tid (info), state_name (cur_state));
+		mono_fatal_with_history ("Cannot transition thread %p from %s with SUSPEND_INIT_REQUESTED", mono_thread_info_get_tid (info), state_name (cur_state));
 	}
-	return (MonoRequestAsyncSuspendResult) FALSE;
+	return (MonoRequestSuspendResult) FALSE;
 }
+
 
 /*
 Check the current state of the thread and try to init a self suspend.
@@ -262,7 +288,11 @@ retry_state_change:
 STATE_ASYNC_SUSPENDED: Code should not be running while suspended.
 STATE_SELF_SUSPENDED: Code should not be running while suspended.
 STATE_BLOCKING:
-STATE_BLOCKING_SELF_SUSPENDED: Pool is a local state transition. No VM activities are allowed while in blocking mode.
+STATE_BLOCKING_SUSPEND_REQUESTED:
+STATE_BLOCKING_ASYNC_SUSPENDED:
+STATE_BLOCKING_SELF_SUSPENDED: Poll is a local state transition. No VM activities are allowed while in blocking mode.
+      (In all the blocking states - the local thread has no checkpoints, hence
+      no polling, it can only do abort blocking or done blocking on itself).
 */
 	default:
 		mono_fatal_with_history ("Cannot transition thread %p from %s with STATE_POLL", mono_thread_info_get_tid (info), state_name (cur_state));
@@ -276,8 +306,9 @@ Returns one of the following values:
 - Sucess: The thread was resumed.
 - Error: The thread was not suspended in the first place. [2]
 - InitSelfResume: The thread is blocked on self suspend and should be resumed 
-- InitAsycResume: The thread is blocked on async suspend and should be resumed
+- InitAsyncResume: The thread is blocked on async suspend and should be resumed
 - ResumeInitBlockingResume: The thread was suspended on the exit path of blocking state and should be resumed
+      FIXME: ResumeInitBlockingResume is just InitSelfResume by a different name.
 
 [2] This threading system uses an unsigned suspend count. Which means a resume cannot be
 used as a suspend permit and cancel each other.
@@ -307,16 +338,38 @@ retry_state_change:
 		return ResumeError; //Resume failed because thread was not blocked
 
 	case STATE_BLOCKING: //Blocking, might have a suspend count, we decrease if it's > 0
-		if (suspend_count == 0) {
-			trace_state_change ("RESUME", info, raw_state, cur_state, 0);
-			return ResumeError;
-		} else {
+		if (!(suspend_count == 0))
+			mono_fatal_with_history ("suspend_count = %d, but should be == 0", suspend_count);
+		trace_state_change ("RESUME", info, raw_state, cur_state, 0);
+		return ResumeError;
+	case STATE_BLOCKING_SUSPEND_REQUESTED:
+		if (!(suspend_count > 0))
+			mono_fatal_with_history ("suspend_count = %d, but should be > 0", suspend_count);
+		if (suspend_count > 1) {
 			if (mono_atomic_cas_i32 (&info->thread_state, build_thread_state (cur_state, suspend_count - 1), raw_state) != raw_state)
-					goto retry_state_change;
+				goto retry_state_change;
 			trace_state_change ("RESUME", info, raw_state, cur_state, -1);
 			return ResumeOk; //Resume worked and there's nothing for the caller to do.
+		} else {
+			if (mono_atomic_cas_i32 (&info->thread_state, STATE_BLOCKING, raw_state) != raw_state)
+				goto retry_state_change;
+			trace_state_change ("RESUME", info, raw_state, STATE_BLOCKING, -1);
+			return ResumeOk; // Resume worked, back in blocking, nothing for the caller to do.
 		}
-		break;
+	case STATE_BLOCKING_ASYNC_SUSPENDED:
+		if (!(suspend_count > 0))
+			mono_fatal_with_history ("suspend_count = %d, but should be > 0", suspend_count);
+		if (suspend_count > 1) {
+			if (mono_atomic_cas_i32 (&info->thread_state, build_thread_state (cur_state, suspend_count - 1), raw_state) != raw_state)
+				goto retry_state_change;
+			trace_state_change ("RESUME", info, raw_state, cur_state, -1);
+			return ResumeOk; // Resume worked, there's nothing else for the caller to do.
+		} else {
+			if (mono_atomic_cas_i32 (&info->thread_state, STATE_BLOCKING, raw_state) != raw_state)
+				goto retry_state_change;
+			trace_state_change ("RESUME", info, raw_state, STATE_BLOCKING, -1);
+			return ResumeInitAsyncResume; // Resume worked and caller must do async resume, thread resumes in BLOCKING
+		}
 	case STATE_ASYNC_SUSPENDED:
 	case STATE_SELF_SUSPENDED:
 	case STATE_BLOCKING_SELF_SUSPENDED: //Decrease the suspend_count and maybe resume
@@ -360,7 +413,7 @@ If this turns to be a problem we should either implement [2] or make this an inv
 }
 
 /*
-This performs the last step of async suspend.
+This performs the last step of preemptive suspend.
 
 Returns TRUE if the caller should wait for resume.
 */
@@ -383,11 +436,18 @@ retry_state_change:
 			goto retry_state_change;
 		trace_state_change ("FINISH_ASYNC_SUSPEND", info, raw_state, STATE_ASYNC_SUSPENDED, 0);
 		return TRUE; //Async suspend worked, now wait for resume
+	case STATE_BLOCKING_SUSPEND_REQUESTED:
+		if (mono_atomic_cas_i32 (&info->thread_state, build_thread_state (STATE_BLOCKING_ASYNC_SUSPENDED, suspend_count), raw_state) != raw_state)
+			goto retry_state_change;
+		trace_state_change ("FINISH_ASYNC_SUSPEND", info, raw_state, STATE_BLOCKING_ASYNC_SUSPENDED, 0);
+		return TRUE; //Async suspend of blocking thread worked, now wait for resume
 
 /*
 STATE_RUNNING: A thread cannot escape suspension once requested.
 STATE_ASYNC_SUSPENDED: There can be only one suspend initiator at a given time, meaning this state should have been visible on the first stage of suspend.
-STATE_BLOCKING: Async suspend only begins if a transition to async suspend requested happened. Blocking would have put us into blocking with positive suspend count if it raced with async finish.
+STATE_BLOCKING: If a thread is subject to preemptive suspend, there is no race as the resume initiator should have suspended the thread to STATE_BLOCKING_ASYNC_SUSPENDED or STATE_BLOCKING_SELF_SUSPENDED before resuming.
+                With cooperative suspend, there are no finish_async_suspend transitions since there's no path back from asyns_suspend requested to running.
+STATE_BLOCKING_ASYNC_SUSPENDED: There can only be one suspend initiator at a given time, meaning this state should have ben visible on the first stage of suspend.
 */
 	default:
 		mono_fatal_with_history ("Cannot transition thread %p from %s with FINISH_ASYNC_SUSPEND", mono_thread_info_get_tid (info), state_name (cur_state));
@@ -432,7 +492,9 @@ retry_state_change:
 STATE_ASYNC_SUSPENDED
 STATE_SELF_SUSPENDED: Code should not be running while suspended.
 STATE_BLOCKING:
+STATE_BLOCKING_SUSPEND_REQUESTED:
 STATE_BLOCKING_SELF_SUSPENDED: Blocking is not nestabled
+STATE_BLOCKING_ASYNC_SUSPENDED: Blocking is not nestable _and_ code should not be running while suspended
 */
 	default:
 		mono_fatal_with_history ("%s Cannot transition thread %p from %s with DO_BLOCKING", func, mono_thread_info_get_tid (info), state_name (cur_state));
@@ -444,10 +506,9 @@ This is the exit transition from the blocking state. If this thread is logically
 until its resumed before continuing.
 
 It returns one of:
--Aborted: The blocking operation was aborted and not properly restored. Aborts can happen due to lazy loading and some n2m transitions;
 -Ok: Done with blocking, just move on;
 -Wait: This thread was async suspended, wait for resume
-
+-NotifyAndWait: This thread was suspended while in blocking, it must notify the initiator if it was suspended preemptively and wait for resume.
 */
 MonoDoneBlockingResult
 mono_threads_transition_done_blocking (MonoThreadInfo* info, const char *func)
@@ -458,26 +519,26 @@ retry_state_change:
 	UNWRAP_THREAD_STATE (raw_state, cur_state, suspend_count, info);
 	switch (cur_state) {
 	case STATE_BLOCKING:
-		if (suspend_count == 0) {
-			if (mono_atomic_cas_i32 (&info->thread_state, build_thread_state (STATE_RUNNING, suspend_count), raw_state) != raw_state)
-				goto retry_state_change;
-			trace_state_change_with_func ("DONE_BLOCKING", info, raw_state, STATE_RUNNING, 0, func);
-			return DoneBlockingOk;
-		} else {
-			if (!(suspend_count >= 0))
-				mono_fatal_with_history ("%s suspend_count = %d, but should be >= 0", func, suspend_count);
-			if (mono_atomic_cas_i32 (&info->thread_state, build_thread_state (STATE_BLOCKING_SELF_SUSPENDED, suspend_count), raw_state) != raw_state)
-				goto retry_state_change;
-			trace_state_change_with_func ("DONE_BLOCKING", info, raw_state, STATE_BLOCKING_SELF_SUSPENDED, 0, func);
-			return DoneBlockingWait;
-		}
-
+		if (!(suspend_count == 0))
+			mono_fatal_with_history ("%s suspend_count = %d, but should be == 0", func, suspend_count);
+		if (mono_atomic_cas_i32 (&info->thread_state, build_thread_state (STATE_RUNNING, suspend_count), raw_state) != raw_state)
+			goto retry_state_change;
+		trace_state_change_with_func ("DONE_BLOCKING", info, raw_state, STATE_RUNNING, 0, func);
+		return DoneBlockingOk;
+	case STATE_BLOCKING_SUSPEND_REQUESTED:
+		if (!(suspend_count > 0))
+			mono_fatal_with_history ("suspend_count = %d, but should be > 0", suspend_count);
+		if (mono_atomic_cas_i32 (&info->thread_state, build_thread_state (STATE_BLOCKING_SELF_SUSPENDED, suspend_count), raw_state) != raw_state)
+			goto retry_state_change;
+		trace_state_change ("DONE_BLOCKING", info, raw_state, STATE_BLOCKING_SELF_SUSPENDED, 0);
+		return DoneBlockingNotifyAndWait;
 /*
 STATE_RUNNING: //Blocking was aborted and not properly restored
 STATE_ASYNC_SUSPEND_REQUESTED: //Blocking was aborted, not properly restored and now there's a pending suspend
 STATE_ASYNC_SUSPENDED
 STATE_SELF_SUSPENDED: Code should not be running while suspended.
 STATE_BLOCKING_SELF_SUSPENDED: This an exit state of done blocking
+STATE_BLOCKING_ASYNC_SUSPENDED: This is an exit state of done blocking
 */
 	default:
 		mono_fatal_with_history ("Cannot transition thread %p from %s with DONE_BLOCKING", mono_thread_info_get_tid (info), state_name (cur_state));
@@ -494,6 +555,7 @@ It returns one of:
 -IgnoreAndPool: Thread was not blocking and there's a pending suspend that needs to be processed;
 -Ok: Blocking state successfully aborted;
 -Wait: Blocking state successfully aborted, there's a pending suspend to be processed though
+-NotifyAndWait: Blocking state was successfully aborted but the thread was preemptively suspended while in blocking, it must notify the initiator and wait for resume.
 */
 MonoAbortBlockingResult
 mono_threads_transition_abort_blocking (THREAD_INFO_TYPE* info)
@@ -512,23 +574,24 @@ retry_state_change:
 		return AbortBlockingIgnoreAndPoll;
 
 	case STATE_BLOCKING:
-		if (suspend_count == 0) {
-			if (mono_atomic_cas_i32 (&info->thread_state, build_thread_state (STATE_RUNNING, suspend_count), raw_state) != raw_state)
-				goto retry_state_change;
-			trace_state_change ("ABORT_BLOCKING", info, raw_state, STATE_RUNNING, 0);
-			return AbortBlockingOk;
-		} else {
-			if (!(suspend_count > 0))
-				mono_fatal_with_history ("suspend_count = %d, but should be > 0", suspend_count);
-			if (mono_atomic_cas_i32 (&info->thread_state, build_thread_state (STATE_BLOCKING_SELF_SUSPENDED, suspend_count), raw_state) != raw_state)
-				goto retry_state_change;
-			trace_state_change ("ABORT_BLOCKING", info, raw_state, STATE_BLOCKING_SELF_SUSPENDED, 0);
-			return AbortBlockingWait;
-		}
+		if (!(suspend_count == 0))
+			mono_fatal_with_history ("suspend_count = %d,  but should be == 0", suspend_count);
+		if (mono_atomic_cas_i32 (&info->thread_state, build_thread_state (STATE_RUNNING, suspend_count), raw_state) != raw_state)
+			goto retry_state_change;
+		trace_state_change ("ABORT_BLOCKING", info, raw_state, STATE_RUNNING, 0);
+		return AbortBlockingOk;
+	case STATE_BLOCKING_SUSPEND_REQUESTED:
+		if (!(suspend_count > 0))
+			mono_fatal_with_history ("suspend_count = %d, but should be > 0", suspend_count);
+		if (mono_atomic_cas_i32 (&info->thread_state, build_thread_state (STATE_BLOCKING_SELF_SUSPENDED, suspend_count), raw_state) != raw_state)
+			goto retry_state_change;
+		trace_state_change ("ABORT_BLOCKING", info, raw_state, STATE_BLOCKING_SELF_SUSPENDED, 0);
+		return AbortBlockingNotifyAndWait;
 /*
 STATE_ASYNC_SUSPENDED:
 STATE_SELF_SUSPENDED: Code should not be running while suspended.
 STATE_BLOCKING_SELF_SUSPENDED: This is an exit state of done blocking, can't happen here.
+STATE_BLOCKING_ASYNC_SUSPENDED: This is an exit state of abort blocking, can't happen here.
 */
 	default:
 		mono_fatal_with_history ("Cannot transition thread %p from %s with DONE_BLOCKING", mono_thread_info_get_tid (info), state_name (cur_state));
@@ -542,17 +605,15 @@ mono_thread_info_get_suspend_state (MonoThreadInfo *info)
 	UNWRAP_THREAD_STATE (raw_state, cur_state, suspend_count, info);
 	switch (cur_state) {
 	case STATE_ASYNC_SUSPENDED:
+	case STATE_BLOCKING_ASYNC_SUSPENDED:
 		return &info->thread_saved_state [ASYNC_SUSPEND_STATE_INDEX];
 	case STATE_SELF_SUSPENDED:
 	case STATE_BLOCKING_SELF_SUSPENDED:
 		return &info->thread_saved_state [SELF_SUSPEND_STATE_INDEX];
-	case STATE_BLOCKING:
-		if (suspend_count > 0)
-			return &info->thread_saved_state [SELF_SUSPEND_STATE_INDEX];
 	default:
 /*
 STATE_RUNNING
-STATE_SELF_SUSPENDED
+STATE_BLOCKING_SUSPEND_REQUESTED
 STATE_ASYNC_SUSPEND_REQUESTED
 STATE_BLOCKING: All those are invalid suspend states.
 */
@@ -570,6 +631,7 @@ mono_thread_info_is_running (MonoThreadInfo *info)
 	switch (get_thread_state (info->thread_state)) {
 	case STATE_RUNNING:
 	case STATE_ASYNC_SUSPEND_REQUESTED:
+	case STATE_BLOCKING_SUSPEND_REQUESTED:
 	case STATE_BLOCKING:
 		return TRUE;
 	}


### PR DESCRIPTION
## Summary

This is a new suspend mode where threads that are running managed or native runtime code (what we call "GC Unsafe") are suspended cooperatively using safepoints, but threads running either embedder code or P/Invoke code or blocking syscalls (what we call "GC Safe") are suspended preemptively using signals.

The motivation is to make an embedder-friendly coop suspend mechanism where the runtime will do GC Safe -> GC Unsafe transitions on calls to `MONO_API` functions, but the embedders themselves don't have to have any special knowledge of coop safepoints or state transitions.

To try this out, set **both** `MONO_ENABLE_COOP` and `MONO_ENABLE_HYBRID_COOP` environment variables.

## Implementation

Here's a picture of the new state machine.  There's two new states `Blocking_Suspend_Requested` and `Blocking_Async_Suspended` and one updated transition `req_s` (request suspension).

![coop-state-machine](https://user-images.githubusercontent.com/480437/38572948-9fe879e2-3cc2-11e8-8f27-9493f05f03bf.png)

### State machine states and transitions

The hybrid cooperative suspend mechanism works like this:
 - when a thread is executing in GC Unsafe mode, we use cooperative suspend and expect
   the thread to periodically checkpoint its execution (as in the ordinary full
   coop mode).
 - when a thread is executing in GC Safe mode, we use a preemptive signal-based
   suspend.  This is new - previously in full coop we would allow `BLOCKING`
   threads to continue executing and only suspend them when they wanted to go
   from GC Safe to GC Unsafe (via the `BLOCKING_SELF_SUSPENDED` state).

There are two new states and one updated transition - the transition will
service both running and blocking threads: The idea is that suspend mechanism
is determined by the suspend initiator, and is not embodied in the the state
machine.  The state machine just has to return distinctive enough values from
the transitions for the initiator to select a policy.

Resume mechanism is determined by the state that a thread finds itself in when
it is resumed, and the original suspend policy.

The primary differences between suspend mechanisms are: the preemptive
suspend is two phase - the `finish_async_suspension` does not
apply for cooperative suspend; the cooperative policy uses the `poll` transition when the thread is running.

We renamed `mono_threads_transition_request_async_suspension` to `mono_threads_transition_request_suspension`.

 - It must be called by a suspend initiator on a victim thread that is not
   itself.

 - There can only be one suspend initiator for a victim at a time - if the
   suspend initiator initiates a suspension it must follow through with the
   whole protocol.

 - If a victim is `RUNNING` we transition it to `ASYNC_SUSPEND_REQUSTED` and return
   `ReqSuspendInitSuspendRunning` which signals that the caller must initiate
   suspension for a running thread.  (Same as the old `AsyncSuspendInitSuspend`).

 - If a victim is `BLOCKING` we transition it to `BLOCKING_SUSPEND_REQUESTED`.
   Note that this is different from the old `request_async_suspension` which just
   incremented the suspend count and returned `AsyncSuspendBlocking`.  Now we
   return `ReqSuspendInitSuspendBlocking`.  The return of
   `ReqSuspendInitSuspendBlocking` means the initiator may signal the victim and
   must wait to be notified of the suspension (in preemptive suspend it will be
   notified by the signal handler, in cooperative when the blocking thread
   attempts to exit from blocking mode).

 - In `BLOCKING_SUSPEND_REQUESTED` we
   may increment the suspend count.  This is slightly too lax if we're going to
   be using preemptive suspend on blocking threads: in that case we're in the
   middle of a two-phase suspend and since there is only one suspend initiator,
   we wouldn't expect another suspend to be initiated until we have a chance to
   finish suspending.  We leave it to the suspend initiator to rule out by returning
  `ReqSuspendAlreadySuspendedBlocking` from this state.

 - In all the not executing states (`SELF_SUSPENDED`, `ASYNC_SUSPENDED`,
  `BLOCKING_SELF_SUSPENDED`, `BLOCKING_ASYNC_SUSPENDED`) we just
   increment the suspend count.

 - All other transitions are illegal.

- Note that `BLOCKING` must always have a suspend count of 0 and
   `BLOCKING_SUSPEND_REQUESTED` must have suspend_count > 0.

We add two new states:

 - `STATE_BLOCKING_SUSPEND_REQUESTED` - this is a new state that indicates that a
   suspend initiator wants to suspend this victim thread.
   - The thread is still executing in this state.
   - We only transition into this state with
     `mono_threads_transition_request_suspension`.
   - The only legal transitions out from this state are:
     - `resume` - decrements the `suspend_count`. If the `suspend_count` becomes 0 we
       go back to `BLOCKING`, otherwise we stay in `BLOCKING_SUSPEND_REQUESTED`.
     - `finish_async_suspension` (executed by the suspend signal handler to
       finish the two phase preemptive suspend request and notify the suspend initiator),
     - `done_blocking` and `abort_blocking`.  It means that the a
       suspend initiator requested a suspend but we got to done (or abort)
       blocking before the signal was delivered. We return `NotifyAndWait` and the
       caller is supposed to send a notification to the suspend initiator and
       wait for a resume(with suspend count == 0) which will return to
       `RUNNING` (the victim thread goes to `STATE_BLOCKING_SELF_SUSPENDED`).
 - `STATE_BLOCKING_ASYNC_SUSPENDED`
   - The thread is not executing in this state (it is waiting for a `resume`).
   - a thread transitions into this state from `STATE_BLOCKING_SUSPEND_REQUESTED`
     on a `finish_async_suspension` transition (see above).
   - on a `resume` transition we decrement the suspend count. if it's still
     positive we stay in this state. if it's 0 the thread transitions out of
     this state.  Unlike other resume transitions, in this case the thread goes
     back to `BLOCKING` and resumes executing in GC Safe mode.  The resume caller
     must notify the resume initiator (ie this is a `ResumeInitAsyncResume`).
   - on a `request_suspension` we stay in this state and just increment the
     suspend count.
   - all other transitions from this state are illegal.

We add two new return values for `abort_blocking` and `done_blocking`:
  - `DoneBlockingNotifyAndWait` and `AbortBlockingNotifyAndWait`. Similar to
    `SelfSuspendNotifyAndWait` - there was a race between the second phase of a
    preemptive suspend and another operation (in that case a poll, in this case a
    done or abort blocking) and the other operation won, so its caller should
    notify the suspend initiator. Since the thread is now suspended, the caller
    should wait for the resume signal.

We add new results for `request_initiate_suspension` `MonoRequestSuspendResult`
(formerly `MonoRequestAsyncSuspendResult`):
  - `ReqSuspendAlreadySuspended` means the thread is not executing and we just
    incremented its suspend count and there's nothing else for the suspend
    initiator to do. (The old `AsyncSuspendAlreadySuspended`)
  - `ReqSuspendAlreadySuspendedBlocking` means the thread is in
    `BLOCKING_SUSPEND_REQUESTED` and we initiated another suspend request.  This
    should only happen with full cooperative suspend - with hybrid suspend we
    will use a two phase preemptive suspend on a blocking thread and since only
    a single suspend initiator is active, this state should not be visible to
    another suspend initiator.
  - `ReqSuspendInitSuspendRunning` - Thread is executing in GC Unsafe mode and the
    caller should suspend it.  This is the old `AsyncSuspendInitSuspend`.  In
    full preemptive suspend this is the only suspend initiation action and the caller
    should begin the preemptive suspend procedure.  In full coop we expect the
    victim thread to reach a safepoint and poll to finish suspending.
  - `ReqSuspendInitSuspendBlocking` - Thread is executing in GC Safe mode and
    the caller should initiate a suspend.  In full coop the caller has nothing
    to do - a thread executing in blocking mode is assumed to be suspended.  In
    hybrid suspend, the caller has to initiate a preemptive suspend.

### Suspend initiator, signal handler, self suspender

Basically we call `mono_threads_transition_request_suspension` instead of `mono_threads_transition_request_async_suspension`.
Then if it says to suspend a running thread we call `begin_suspend_for_running_thread`, if it says initiate a suspension of a blocking thread, we call `begin_suspend_for_blocking_thread`, and if it says do nothing we do nothing.

**Questions**
1. We have an assumption in `safe_interrupt_thread` that we can return from a self interrupt if we're using coop suspend.  I'm not sure if that makes sense for hybrid suspend, and not clear what to do about it.
2. In `mono_thread_info_safe_suspend_and_run` we expect that the callback won't return `KeepSuspended` if coop is enabled.  I'm not sure what this means for hybrid.
3. A bunch of tests like `monitor-abort` and `appdomain-threadpool-unload` are failing if I enable hybrid suspend.  Don't know why yet.