### PR TITLE
Symlink the 4.5 machine.config unconditionally.

### DIFF
--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -6,8 +6,11 @@ etctmp = etc
 symlinks = etc/mono/1.0/machine.config etc/mono/2.0/machine.config etc/mono/2.0/web.config etc/mono/browscap.ini etc/mono/2.0/Browsers/Compat.browser
 
 if INSTALL_4_x
-symlinks += etc/mono/4.0/machine.config etc/mono/4.0/web.config etc/mono/4.5/web.config etc/mono/4.5/machine.config etc/mono/4.0/Browsers/Compat.browser etc/mono/4.5/Browsers/Compat.browser
+symlinks += etc/mono/4.0/machine.config etc/mono/4.0/web.config etc/mono/4.5/web.config etc/mono/4.0/Browsers/Compat.browser etc/mono/4.5/Browsers/Compat.browser
 endif
+
+# This is needed at least to build configure -with-runtime_preset=fullaot.
+symlinks += etc/mono/4.5/machine.config
 
 etc/mono/2.0/machine.config: $(top_srcdir)/data/net_2_0/machine.config
 etc/mono/2.0/web.config: $(top_srcdir)/data/net_2_0/web.config


### PR DESCRIPTION
This fixes https://github.com/mono/mono/issues/8074.

I see this 100%. Why others do not? I usually skip aot so usually I don't see it. Linux Ubuntu 1604 and
1710 tested. mono-devel package is installed, which is probably not relevant.

git clean -xddf (or new git clone)
./configure --with-runtime_preset=fullaot   likely also with others (hybridaot)
make

Many errors like:

MONO_PATH="./../../class/lib/build:$MONO_PATH" /s/mono/runtime/mono-wrapper ./../../class/lib/build/sn.exe
-q -R ../../class/lib/testing_aot_full/mscorlib.dll ./../../class/mono.snk Couldn't sign the assembly
../../class/lib/testing_aot_full/mscorlib.dll with this key pair. Public key of assembly did not match
signing public key. ../../build/library.make:342: recipe for target
'../../class/lib/testing_aot_full/mscorlib.dll' failed

If you run make V=1 you see the sn command.
 You can see the installed sn works ok. Remove the -Q for quiet and you see a warning about missing
machine.config. Run with ptrace and you see it looking for 4.5/machine.config. Look in the tree and you
see 1.1 and 2.0. Copy the 2.0 to 4.5 and problem goes away. And can be edited down a bunch. Actual fix is
to move symlink of the file to outside a conditional.

Maybe people aren't using fullaot or git clean? Repro is 100% for me.
I was going to bisect, but it was occuring as far back as September 2017 so I did not.