### PR TITLE
Fix generic-stack-traces2.2.cs under FullAOT+LLVM.

### DIFF
--- a/mono/tests/generic-stack-traces2.2.cs
+++ b/mono/tests/generic-stack-traces2.2.cs
@@ -33,6 +33,7 @@ namespace GetStackTrace
         }
 
 		/* Test for gshared methods declared in a generic subclass of a nongeneric class */
+		[MethodImplAttribute (MethodImplOptions.NoInlining)]
 		public static int test_0_nongeneric_subclass () {
 			return new D ().foo ();
 		}


### PR DESCRIPTION
It relies on poorly defined behavior that mono cannot likely well define.

https://msdn.microsoft.com/en-us/library/system.diagnostics.stacktrace(v=vs.110).aspx

"StackTrace might not report as many method calls as expected, due to code transformations
that occur during optimization."



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
