### PR TITLE
[mkbundle] Probe for a .exe on the target runtime directory

### DIFF
--- a/mcs/tools/mkbundle/mkbundle.cs
+++ b/mcs/tools/mkbundle/mkbundle.cs
@@ -534,8 +534,12 @@ class MakeBundle {
 		if (!Directory.Exists (path))
 			Error ($"The specified SDK path does not exist: {path}");
 		runtime = Path.Combine (sdk_path, "bin", "mono");
-		if (!File.Exists (runtime))
-			Error ($"The SDK location does not contain a {path}/bin/mono runtime");
+		if (!File.Exists (runtime)){
+			if (File.Exists (runtime + ".exe"))
+				runtime += ".exe";
+			else
+				Error ($"The SDK location does not contain a {path}/bin/mono runtime");
+		}
 		lib_path = Path.Combine (path, "lib", "mono", "4.5");
 		if (!Directory.Exists (lib_path))
 			Error ($"The SDK location does not contain a {path}/lib/mono/4.5 directory");


### PR DESCRIPTION
This needs to probe for the .exe not based on the current platform.   

As Linux can compile for Windows, and Windows can compile for Linux, this is why this should not do this conditionally on the host OS.

Fixes #7731