### PR TITLE
[console-unix] retry `tcsetattr` if it was interrupted by signal

### DIFF
--- a/mono/metadata/console-unix.c
+++ b/mono/metadata/console-unix.c
@@ -465,7 +465,9 @@ ves_icall_System_ConsoleDriver_TtySetup (MonoStringHandle keypad, MonoStringHand
 #endif
 	gint ret;
 	do {
+		MONO_ENTER_GC_SAFE;
 		ret = tcsetattr (STDIN_FILENO, TCSANOW, &mono_attr);
+		MONO_EXIT_GC_SAFE;
 	} while (ret == -1 && errno == EINTR);
 
 	if (ret == -1)

--- a/mono/metadata/console-unix.c
+++ b/mono/metadata/console-unix.c
@@ -463,7 +463,12 @@ ves_icall_System_ConsoleDriver_TtySetup (MonoStringHandle keypad, MonoStringHand
 	/* Disable C-y being used as a suspend character on OSX */
 	mono_attr.c_cc [VDSUSP] = 255;
 #endif
-	if (tcsetattr (STDIN_FILENO, TCSANOW, &mono_attr) == -1)
+	gint ret;
+	do {
+		ret = tcsetattr (STDIN_FILENO, TCSANOW, &mono_attr);
+	} while (ret == -1 && errno == EINTR);
+
+	if (ret == -1)
 		return FALSE;
 
 	uint32_t h;


### PR DESCRIPTION
if configuring the terminal failed, we still try to continue (see
a3ce2f008bdb2fa5108034f1687fc7f87c92a0b8 ) and therefore succedings
`read`s can fail.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=26983
