### PR TITLE
[System] Don't use http://www.mono-project.com for test

### DIFF
--- a/mcs/class/System/Test/System.Net/WebClientTest.cs
+++ b/mcs/class/System/Test/System.Net/WebClientTest.cs
@@ -1685,10 +1685,11 @@ namespace MonoTests.System.Net
 		// We throw a PlatformNotSupportedException deeper, which is caught and re-thrown as WebException
 		[ExpectedException (typeof (WebException))]
 #endif
+		[Category ("InetAccess")]
 		public void GetWebRequestOverriding ()
 		{
 			GetWebRequestOverridingTestClass testObject = new GetWebRequestOverridingTestClass ();
-			testObject.DownloadData ("http://www.mono-project.com");
+			testObject.DownloadData ("http://www.example.com");
 
 			Assert.IsTrue (testObject.overridedCodeRan, "Overrided code wasn't called");
 		}

--- a/mcs/class/System/Test/System.Net/WebClientTestAsync.cs
+++ b/mcs/class/System/Test/System.Net/WebClientTestAsync.cs
@@ -88,7 +88,7 @@ namespace MonoTests.System.Net
 			WebClient wc = new WebClient ();
 			string filename = Path.GetTempFileName ();
 
-			var task = wc.DownloadFileTaskAsync ("http://www.mono-project.com/", filename);
+			var task = wc.DownloadFileTaskAsync ("http://www.example.com/", filename);
 			Assert.IsTrue (task.Wait (15000));
 			Assert.IsTrue (task.IsCompleted);
 			


### PR DESCRIPTION
When we tried switching mono-project.com to enforce HTTPS these tests started failing on systems without working SSL configuration.

Use a different domain which is guaranteed to be available over HTTP instead.
