### PR TITLE
[2018-04] [sdks] Add support for building llvm unless the USE_PREBUILT_LLVM Make.config var is set.

### DIFF
--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -84,6 +84,7 @@ if [[ ${CI_TAGS} == *'product-sdks-ios'* ]];
    then
 	   echo "DISABLE_ANDROID=1" > sdks/Make.config
 	   echo "DISABLE_WASM=1" >> sdks/Make.config
+	   echo "USE_PREBUILT_LLVM=1" >> sdks/Make.config
 	   ${TESTCMD} --label=runtimes --timeout=60m --fatal make -j4 -C sdks/builds package-ios-sim64 package-ios-target64
 	   ${TESTCMD} --label=cross --timeout=60m --fatal make -j4 -C sdks/builds package-ios-cross64 package-ios-cross32
 	   ${TESTCMD} --label=bcl --timeout=60m --fatal make -j4 -C sdks/builds package-bcl

--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -84,7 +84,6 @@ if [[ ${CI_TAGS} == *'product-sdks-ios'* ]];
    then
 	   echo "DISABLE_ANDROID=1" > sdks/Make.config
 	   echo "DISABLE_WASM=1" >> sdks/Make.config
-	   echo "USE_PREBUILT_LLVM=1" >> sdks/Make.config
 	   ${TESTCMD} --label=runtimes --timeout=60m --fatal make -j4 -C sdks/builds package-ios-sim64 package-ios-target64
 	   ${TESTCMD} --label=cross --timeout=60m --fatal make -j4 -C sdks/builds package-ios-cross64 package-ios-cross32
 	   ${TESTCMD} --label=bcl --timeout=60m --fatal make -j4 -C sdks/builds package-bcl

--- a/sdks/builds/ios.mk
+++ b/sdks/builds/ios.mk
@@ -297,17 +297,28 @@ $(eval $(call iOSSimulatorTemplate,sim64,x86_64))
 $(eval $(call iOSSimulatorTemplate,simtv,x86_64))
 $(eval $(call iOSSimulatorTemplate,simwatch,i386))
 
-LLVM_REV=3b82b3c9041eb997f627f881a67d20be37264e9c
+ifdef USE_PREBUILT_LLVM
 
 # Download a prebuilt llvm
-.stamp-ios-llvm-$(LLVM_REV):
-	./download-llvm.sh $(LLVM_REV)
+.stamp-ios-llvm-$(LLVM_HASH):
+	./download-llvm.sh $(LLVM_HASH)
 	touch $@
 
-build-ios-llvm: .stamp-ios-llvm-$(LLVM_REV)
+build-ios-llvm: .stamp-ios-llvm-$(LLVM_HASH)
 
 clean-ios-llvm:
-	$(RM) -rf ../out/ios-llvm64 ../out/ios-llvm32 .stamp-ios-llvm-$(LLVM_REV)
+	$(RM) -rf ../out/ios-llvm64 ../out/ios-llvm32 .stamp-ios-llvm-$(LLVM_HASH)
+
+else
+
+build-ios-llvm: package-llvm-llvm64 package-llvm-llvm32
+	ln -sf ../out/llvm-llvm32 ../out/ios-llvm32
+	ln -sf ../out/llvm-llvm64 ../out/ios-llvm64
+
+clean-ios-llvm: clean-llvm-llvm64 clean-llvm-llvm32
+	$(RM) -rf ../out/{ios-llvm32,ios-llvm64}
+
+endif
 
 ##
 # Parameters:

--- a/sdks/builds/ios.mk
+++ b/sdks/builds/ios.mk
@@ -297,7 +297,7 @@ $(eval $(call iOSSimulatorTemplate,sim64,x86_64))
 $(eval $(call iOSSimulatorTemplate,simtv,x86_64))
 $(eval $(call iOSSimulatorTemplate,simwatch,i386))
 
-ifdef USE_PREBUILT_LLVM
+ifndef IGNORE_PACKAGE_LLVM
 
 # Download a prebuilt llvm
 .stamp-ios-llvm-$(LLVM_HASH):


### PR DESCRIPTION
Backport of #8017.

/cc @vargaz