### PR TITLE
[threadpool] ThreadPool.SetMinThreads fails if ThreadPool.GetMaxThreads was not called before

### DIFF
--- a/mcs/class/corlib/Test/System.Threading/ThreadPoolTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/ThreadPoolTest.cs
@@ -281,5 +281,17 @@ namespace MonoTests.System.Threading
 			Assert.IsTrue (threads0 > 0, "#2");
 		}
 #endif
+
+		[Test]
+		public void SetMinThreads ()
+		{
+			int workerThreads, cpThreads;
+			int expectedWt = 64, expectedCpt = 64;
+			bool set = ThreadPool.SetMinThreads (expectedWt, expectedCpt);
+			ThreadPool.GetMinThreads (out workerThreads, out cpThreads);
+			Assert.IsTrue (set, "#1");
+			Assert.AreEqual (expectedWt, workerThreads, "#2");
+			Assert.AreEqual (expectedCpt, cpThreads, "#3");
+		}
 	}
 }

--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -668,10 +668,10 @@ ves_icall_System_Threading_ThreadPool_GetMaxThreadsNative (gint32 *worker_thread
 MonoBoolean
 ves_icall_System_Threading_ThreadPool_SetMinThreadsNative (gint32 worker_threads, gint32 completion_port_threads, MonoError *error)
 {
-	if (completion_port_threads <= 0 || completion_port_threads > threadpool.limit_io_max)
+	if (!mono_lazy_initialize (&status, initialize) || !mono_refcount_tryinc (&threadpool))
 		return FALSE;
 
-	if (!mono_lazy_initialize (&status, initialize) || !mono_refcount_tryinc (&threadpool))
+	if (completion_port_threads <= 0 || completion_port_threads > threadpool.limit_io_max)
 		return FALSE;
 
 	if (!mono_threadpool_worker_set_min (worker_threads)) {

--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -688,15 +688,15 @@ ves_icall_System_Threading_ThreadPool_SetMinThreadsNative (gint32 worker_threads
 MonoBoolean
 ves_icall_System_Threading_ThreadPool_SetMaxThreadsNative (gint32 worker_threads, gint32 completion_port_threads, MonoError *error)
 {
+	if (!mono_lazy_initialize (&status, initialize) || !mono_refcount_tryinc (&threadpool))
+		return FALSE;
+
 	worker_threads = MIN (worker_threads, MAX_POSSIBLE_THREADS);
 	completion_port_threads = MIN (completion_port_threads, MAX_POSSIBLE_THREADS);
 
 	gint cpu_count = mono_cpu_count ();
 
 	if (completion_port_threads < threadpool.limit_io_min || completion_port_threads < cpu_count)
-		return FALSE;
-
-	if (!mono_lazy_initialize (&status, initialize) || !mono_refcount_tryinc (&threadpool))
 		return FALSE;
 
 	if (!mono_threadpool_worker_set_max (worker_threads)) {


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/7988 
