### PR TITLE
[runtime] Make GetFrames consider nested exceptions

### DIFF
--- a/mcs/class/corlib/System.Diagnostics/StackTrace.cs
+++ b/mcs/class/corlib/System.Diagnostics/StackTrace.cs
@@ -180,7 +180,15 @@ namespace System.Diagnostics {
 		[ComVisibleAttribute (false)]
 		public virtual StackFrame[] GetFrames ()
 		{
-			return frames;
+			if (captured_traces == null)
+				return frames;
+
+			var accum = new List<StackFrame> ();
+			foreach (var t in captured_traces)
+				accum.AddRange(t.GetFrames ());
+
+			accum.AddRange (frames);
+			return accum.ToArray ();
 		}
 
 		static bool isAotidSet;

--- a/mcs/class/corlib/Test/System.Diagnostics/StackFrameTest.cs
+++ b/mcs/class/corlib/Test/System.Diagnostics/StackFrameTest.cs
@@ -11,6 +11,7 @@ using System;
 using System.Diagnostics;
 using System.Reflection;
 using NUnit.Framework;
+using System.Runtime.ExceptionServices;
 
 namespace MonoTests.System.Diagnostics
 {
@@ -339,6 +340,41 @@ namespace MonoTests.System.Diagnostics
 			Assert.AreEqual (4,
 							 frame2.GetFileColumnNumber (),
 							 "Column number (2)");
+		}
+
+		/// <summary>
+		/// Test whether GetFrames contains the frames for nested exceptions
+		/// </summary>
+		[Test]
+		public void GetFramesAndNestedExc ()
+		{
+			try
+			{
+				throw new Exception("This is a test");
+			}
+			catch (Exception e)
+			{
+				try
+				{
+					ExceptionDispatchInfo.Capture(e.InnerException ?? e).Throw();
+				}
+				catch (Exception ee)
+				{
+					StackTrace st = new StackTrace(ee, true);
+					StackFrame[] frames = st.GetFrames();
+
+					//Console.WriteLine("StackFrame.ToString() foreach StackFrame in Stacktrace.GetFrames():");
+					//foreach (StackFrame frame in frames)
+						//Console.WriteLine(frame);
+					//Console.WriteLine("Expecting: Main, Throw, Main");
+
+					Assert.AreEqual (3, frames.Length);
+					var wrongFrames = false;
+					Assert.AreEqual ("GetFramesAndNestedExc", frames [0].GetMethod ().Name);
+					Assert.AreEqual ("Throw", frames [1].GetMethod ().Name);
+					Assert.AreEqual ("GetFramesAndNestedExc", frames [2].GetMethod ().Name);
+				}
+			}
 		}
 
 		/// <summary>

--- a/mcs/class/corlib/Test/System.Diagnostics/StackFrameTest.cs
+++ b/mcs/class/corlib/Test/System.Diagnostics/StackFrameTest.cs
@@ -181,7 +181,7 @@ namespace MonoTests.System.Diagnostics
 							 frame1.GetFileLineNumber (),
 							 "Line number (1)");
 
-			Assert.AreEqual (134,
+			Assert.AreEqual (135,
 							 frame2.GetFileLineNumber (),
 							 "Line number (2)");
 
@@ -321,7 +321,7 @@ namespace MonoTests.System.Diagnostics
 							 frame1.GetFileLineNumber (),
 							 "Line number (1)");
 
-			Assert.AreEqual (270,
+			Assert.AreEqual (271,
 							 frame2.GetFileLineNumber (),
 							 "Line number (2)");
 		}


### PR DESCRIPTION
Fixes #7260 

