### PR TITLE
[System.Net.Http] Use '*' as the host instead of '+' in the tests. Fixes xamarin/maccore#673.

### DIFF
--- a/mcs/class/System.Net.Http/Test/System.Net.Http/HttpClientTest.cs
+++ b/mcs/class/System.Net.Http/Test/System.Net.Http/HttpClientTest.cs
@@ -1461,7 +1461,7 @@ namespace MonoTests.System.Net.Http
 		HttpListener CreateListener (Action<HttpListenerContext> contextAssert, int port)
 		{
 			var l = new HttpListener ();
-			l.Prefixes.Add (string.Format ("http://+:{0}/", port));
+			l.Prefixes.Add (string.Format ("http://*:{0}/", port));
 			l.Start ();
 			AddListenerContext(l, contextAssert);
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->

Use '*' as the host instead of '+' in the tests.

The behavior should be the same, just faster, because '+' will fail to resolve
("Could not resolve host '+'"), and we'll fall back to the same behavior as
'*': https://github.com/mono/mono/blob/5128cce2dcd097aa4e7b86dd3b56e833c15a9ff0/mcs/class/System/System.Net/EndPointManager.cs#L83-L96

The problem arises when failing to resolve '+' takes a long time: on some of
our bots it takes 5-10 seconds. This adds up quickly since the tests try many
times, effectively increasing a test run from 1-2 seconds to 30+ minutes.

Fixes https://github.com/xamarin/maccore/issues/673.