### PR TITLE
[runtime] Get rid of the GLIB_LIBS autoconf define, it prevents automake from detecting the dependency on libeglib.la.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -836,7 +836,6 @@ AC_SUBST([SHARED_CFLAGS])
 GLIB_CFLAGS='-I$(top_srcdir)/mono/eglib -I$(top_builddir)/mono/eglib'
   
 AC_SUBST(GLIB_CFLAGS)
-AC_SUBST(GLIB_LIBS)
 
 # Enable support for fast thread-local storage
 # Some systems have broken support, so we allow to disable it.

--- a/configure.ac
+++ b/configure.ac
@@ -834,7 +834,6 @@ AC_SUBST([WERROR_CFLAGS])
 AC_SUBST([SHARED_CFLAGS])
 
 GLIB_CFLAGS='-I$(top_srcdir)/mono/eglib -I$(top_builddir)/mono/eglib'
-GLIB_LIBS='$(top_builddir)/mono/eglib/libeglib.la -lm'
   
 AC_SUBST(GLIB_CFLAGS)
 AC_SUBST(GLIB_LIBS)

--- a/ikvm-native/Makefile.am
+++ b/ikvm-native/Makefile.am
@@ -1,9 +1,11 @@
 
 AM_CPPFLAGS = $(GLIB_CFLAGS)
 
+glib_libs = $(top_builddir)/mono/eglib/libeglib.la
+
 lib_LTLIBRARIES = libikvm-native.la
 
 libikvm_native_la_SOURCES = jni.c os.c jni.h
 
 libikvm_native_la_LDFLAGS = -avoid-version
-libikvm_native_la_LIBADD = $(GLIB_LIBS)
+libikvm_native_la_LIBADD = $(glib_libs)

--- a/mono/dis/Makefile.am
+++ b/mono/dis/Makefile.am
@@ -4,6 +4,8 @@ if HOST_WIN32
 export HOST_CC
 endif
 
+glib_libs = $(top_builddir)/mono/eglib/libeglib.la -lm
+
 if SUPPORT_SGEN
 metadata_lib=$(top_builddir)/mono/metadata/libmonoruntimesgen.la
 gc_lib=$(top_builddir)/mono/sgen/libmonosgen.la
@@ -16,7 +18,7 @@ runtime_lib=	\
 	$(metadata_lib) \
 	$(gc_lib)	\
 	$(top_builddir)/mono/utils/libmonoutils.la \
-	$(GLIB_LIBS)
+	$(glib_libs)
 
 if DISABLE_EXECUTABLES
 bin_PROGRAMS =
@@ -51,7 +53,7 @@ monodis_LDADD = 			\
 	$(runtime_lib)			\
 	$(LLVM_LIBS)			\
 	$(LLVM_LDFLAGS)			\
-	$(GLIB_LIBS)
+	$(glib_libs)
 
 if HOST_DARWIN
 monodis_LDFLAGS=-framework CoreFoundation -framework Foundation

--- a/mono/dis/Makefile.am
+++ b/mono/dis/Makefile.am
@@ -4,7 +4,7 @@ if HOST_WIN32
 export HOST_CC
 endif
 
-glib_libs = $(top_builddir)/mono/eglib/libeglib.la -lm
+glib_libs = $(top_builddir)/mono/eglib/libeglib.la
 
 if SUPPORT_SGEN
 metadata_lib=$(top_builddir)/mono/metadata/libmonoruntimesgen.la

--- a/mono/eglib/Makefile.am
+++ b/mono/eglib/Makefile.am
@@ -53,12 +53,12 @@ libeglib_la_CFLAGS = -g -Wall -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE
 AM_CPPFLAGS = -I$(srcdir)
 
 if HOST_ANDROID
-libeglib_la_LIBADD = -llog
+libeglib_la_LIBADD = -lm -llog
 else
 if HOST_WIN32
 libeglib_la_LIBADD = -lm -lpsapi $(LTLIBICONV)
 else
-libeglib_la_LIBADD = $(LTLIBICONV)
+libeglib_la_LIBADD = -lm $(LTLIBICONV)
 endif
 endif
 

--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -21,6 +21,8 @@ win32_sources = \
 
 platform_sources = $(win32_sources)
 
+glib_libs = $(top_builddir)/mono/eglib/libeglib.la
+
 # Use -m here. This will use / as directory separator (C:/WINNT).
 # The files that use MONO_ASSEMBLIES and/or MONO_CFG_DIR replace the
 # / by \ if running under WIN32.
@@ -122,7 +124,7 @@ libmono_icall_table_la_SOURCES = \
 libmono_icall_table_la_CFLAGS = $(SGEN_DEFINES)
 libmono_icall_table_la_LDFLAGS = $(libmonoldflags)
 if BITCODE
-libmono_icall_table_la_LIBADD = ../eglib/libeglib.la ../utils/libmonoutils.la ../sgen/libmonosgen.la libmonoruntimesgen.la
+libmono_icall_table_la_LIBADD = $(glib_libs) ../utils/libmonoutils.la ../sgen/libmonosgen.la libmonoruntimesgen.la
 endif
 endif
 
@@ -141,7 +143,7 @@ libmono_ilgen_la_SOURCES = \
 libmono_ilgen_la_CFLAGS = $(SGEN_DEFINES)
 libmono_ilgen_la_LDFLAGS = $(libmonoldflags)
 if BITCODE
-libmono_ilgen_la_LIBADD = ../eglib/libeglib.la ../utils/libmonoutils.la ../sgen/libmonosgen.la libmonoruntimesgen.la
+libmono_ilgen_la_LIBADD = $(glib_libs) ../utils/libmonoutils.la ../sgen/libmonosgen.la libmonoruntimesgen.la
 endif
 endif
 

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -18,7 +18,7 @@ libgc_libs=$(monodir)/libgc/libmonogc.la
 libgc_static_libs=$(monodir)/libgc/libmonogc-static.la
 endif
 
-glib_libs = $(monodir)/mono/eglib/libeglib.la -lm
+glib_libs = $(monodir)/mono/eglib/libeglib.la
 
 boehm_libs=	\
 	$(monodir)/mono/metadata/libmonoruntime.la	\

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -18,17 +18,19 @@ libgc_libs=$(monodir)/libgc/libmonogc.la
 libgc_static_libs=$(monodir)/libgc/libmonogc-static.la
 endif
 
+glib_libs = $(monodir)/mono/eglib/libeglib.la -lm
+
 boehm_libs=	\
 	$(monodir)/mono/metadata/libmonoruntime.la	\
 	$(monodir)/mono/utils/libmonoutils.la \
-	$(GLIB_LIBS) \
+	$(glib_libs) \
 	$(libgc_libs)
 
 sgen_libs = \
 	$(monodir)/mono/metadata/libmonoruntimesgen.la	\
 	$(monodir)/mono/sgen/libmonosgen.la	\
 	$(monodir)/mono/utils/libmonoutils.la \
-	$(GLIB_LIBS)
+	$(glib_libs)
 
 if FULL_AOT_TESTS
 # if the tests are going to run with framework assemblies compiled with
@@ -153,7 +155,7 @@ noinst_LTLIBRARIES = $(mini_common_lib)
 if LOADED_LLVM
 lib_LTLIBRARIES += libmono-llvm.la
 libmono_llvm_la_SOURCES = mini-llvm.c mini-llvm-cpp.cpp llvm-jit.cpp
-libmono_llvm_la_LIBADD = $(GLIB_LIBS) $(LLVM_LIBS) $(LLVM_LDFLAGS)
+libmono_llvm_la_LIBADD = $(glib_libs) $(LLVM_LIBS) $(LLVM_LDFLAGS)
 if HOST_DARWIN
 libmono_llvm_la_LDFLAGS=-Wl,-undefined -Wl,suppress -Wl,-flat_namespace
 else
@@ -221,7 +223,7 @@ endif
 
 mono_boehm_LDADD = \
 	$(MONO_LIB)		\
-	$(GLIB_LIBS)		\
+	$(glib_libs)		\
 	$(LLVMMONOF)		\
 	-lm			\
 	$(MONO_DTRACE_OBJECT)
@@ -231,7 +233,7 @@ mono_boehm_LDFLAGS = \
 
 mono_sgen_LDADD = \
 	$(MONO_SGEN_LIB)	\
-	$(GLIB_LIBS)		\
+	$(glib_libs)		\
 	$(LLVMMONOF)		\
 	-lm			\
 	$(MONO_DTRACE_OBJECT)

--- a/mono/profiler/Makefile.am
+++ b/mono/profiler/Makefile.am
@@ -3,6 +3,8 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	$(GLIB_CFLAGS)
 
+glib_libs = $(top_builddir)/mono/eglib/libeglib.la -lm
+
 if !HOST_WIN32
 if !DISABLE_LIBRARIES
 if !DISABLE_PROFILER
@@ -97,19 +99,19 @@ endif
 # builds.
 
 libmono_profiler_aot_la_SOURCES = aot.c
-libmono_profiler_aot_la_LIBADD =  $(libmono_dep) $(GLIB_LIBS)
+libmono_profiler_aot_la_LIBADD =  $(libmono_dep) $(glib_libs)
 libmono_profiler_aot_la_LDFLAGS = $(prof_ldflags)
 libmono_profiler_aot_static_la_SOURCES = aot.c
 libmono_profiler_aot_static_la_LDFLAGS = -static
 
 libmono_profiler_log_la_SOURCES = log.c log-args.c
-libmono_profiler_log_la_LIBADD = $(libmono_dep) $(GLIB_LIBS) $(zlib_dep)
+libmono_profiler_log_la_LIBADD = $(libmono_dep) $(glib_libs) $(zlib_dep)
 libmono_profiler_log_la_LDFLAGS = $(prof_ldflags)
 libmono_profiler_log_static_la_SOURCES = log.c log-args.c
 libmono_profiler_log_static_la_LDFLAGS = -static
 
 libmono_profiler_coverage_la_SOURCES = coverage.c
-libmono_profiler_coverage_la_LIBADD = $(libmono_dep) $(GLIB_LIBS)
+libmono_profiler_coverage_la_LIBADD = $(libmono_dep) $(glib_libs)
 libmono_profiler_coverage_la_LDFLAGS = $(prof_ldflags)
 libmono_profiler_coverage_static_la_SOURCES = coverage.c
 libmono_profiler_coverage_static_la_LDFLAGS = -static
@@ -117,7 +119,7 @@ libmono_profiler_coverage_static_la_LDFLAGS = -static
 if HAVE_VTUNE
 libmono_profiler_vtune_la_SOURCES = vtune.c
 libmono_profiler_vtune_la_CFLAGS = $(VTUNE_CFLAGS)
-libmono_profiler_vtune_la_LIBADD = $(VTUNE_LIBS) $(libmono_dep) $(GLIB_LIBS)
+libmono_profiler_vtune_la_LIBADD = $(VTUNE_LIBS) $(libmono_dep) $(glib_libs)
 libmono_profiler_vtune_la_LDFLAGS = $(prof_ldflags)
 libmono_profiler_vtune_static_la_SOURCES = vtune.c
 libmono_profiler_vtune_static_la_LDFLAGS = -static
@@ -126,7 +128,7 @@ libmono_profiler_vtune_static_la_LIBADD = $(VTUNE_LIBS)
 endif
 
 mprof_report_SOURCES = mprof-report.c
-mprof_report_LDADD = $(GLIB_LIBS) $(zlib_dep)
+mprof_report_LDADD = $(glib_libs) $(zlib_dep)
 
 PLOG_TESTS_SRC = \
 	test-alloc.cs \

--- a/mono/profiler/Makefile.am
+++ b/mono/profiler/Makefile.am
@@ -3,7 +3,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	$(GLIB_CFLAGS)
 
-glib_libs = $(top_builddir)/mono/eglib/libeglib.la -lm
+glib_libs = $(top_builddir)/mono/eglib/libeglib.la
 
 if !HOST_WIN32
 if !DISABLE_LIBRARIES

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -2417,7 +2417,7 @@ else
 libtest_la_LDFLAGS = -rpath `pwd`
 endif
 libtest_la_SOURCES = libtest.c
-libtest_la_LIBADD = $(top_builddir)/mono/eglib/libeglib.la -lm
+libtest_la_LIBADD = $(top_builddir)/mono/eglib/libeglib.la
 
 INTERNALSVISIBLETO_TEST_SRC = \
 	internalsvisibleto-runtimetest.cs \

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -2417,7 +2417,7 @@ else
 libtest_la_LDFLAGS = -rpath `pwd`
 endif
 libtest_la_SOURCES = libtest.c
-libtest_la_LIBADD = $(GLIB_LIBS)
+libtest_la_LIBADD = $(top_builddir)/mono/eglib/libeglib.la -lm
 
 INTERNALSVISIBLETO_TEST_SRC = \
 	internalsvisibleto-runtimetest.cs \

--- a/mono/unit-tests/Makefile.am
+++ b/mono/unit-tests/Makefile.am
@@ -19,10 +19,11 @@ else
 LLVMMONOF=$(LLVM_LIBS) $(LLVM_LDFLAGS)
 endif
 
+glib_libs = $(top_builddir)/mono/eglib/libeglib.la -lm
 
 test_cflags = $(AM_CFLAGS) $(SGEN_DEFINES)
 test_ldadd = libtestlib.la \
-	$(LIBGC_LIBS) $(GLIB_LIBS) -lm $(LLVMMONOF)
+	$(LIBGC_LIBS) $(glib_libs) -lm $(LLVMMONOF)
 if HOST_DARWIN
 test_ldflags = -framework CoreFoundation -framework Foundation
 endif
@@ -32,7 +33,7 @@ sgen_libs = \
 	$(monodir)/mono/metadata/libmonoruntimesgen.la	\
 	$(monodir)/mono/sgen/libmonosgen.la	\
 	$(monodir)/mono/utils/libmonoutils.la \
-	$(GLIB_LIBS)
+	$(glib_libs)
 
 mini_libs = \
 	$(monodir)/mono/mini/libmini.la

--- a/mono/unit-tests/Makefile.am
+++ b/mono/unit-tests/Makefile.am
@@ -19,11 +19,11 @@ else
 LLVMMONOF=$(LLVM_LIBS) $(LLVM_LDFLAGS)
 endif
 
-glib_libs = $(top_builddir)/mono/eglib/libeglib.la -lm
+glib_libs = $(top_builddir)/mono/eglib/libeglib.la
 
 test_cflags = $(AM_CFLAGS) $(SGEN_DEFINES)
 test_ldadd = libtestlib.la \
-	$(LIBGC_LIBS) $(glib_libs) -lm $(LLVMMONOF)
+	$(LIBGC_LIBS) $(glib_libs) $(LLVMMONOF)
 if HOST_DARWIN
 test_ldflags = -framework CoreFoundation -framework Foundation
 endif

--- a/support/Makefile.am
+++ b/support/Makefile.am
@@ -14,6 +14,8 @@ AM_CPPFLAGS =					\
 	$(GLIB_CFLAGS)				\
 	-I$(top_srcdir)
 
+glib_libs = $(top_builddir)/mono/eglib/libeglib.la -lm
+
 # Source code which helps implement the ANSI C standards, and thus *should* be
 # portable to any platform having a C compiler.
 MPH_C_SOURCE =					\
@@ -59,10 +61,10 @@ MPH_UNIX_SOURCE =				\
 
 if HOST_WIN32
 MPH_SOURCE = $(MPH_C_SOURCE)
-MPH_LIBS   = $(GLIB_LIBS)
+MPH_LIBS   = $(glib_libs)
 else
 MPH_SOURCE = $(MPH_C_SOURCE) $(MPH_UNIX_SOURCE)
-MPH_LIBS   = $(GLIB_LIBS)
+MPH_LIBS   = $(glib_libs)
 endif
 
 MINIZIP_SOURCE = \
@@ -125,7 +127,7 @@ libMonoSupportW_la_SOURCES =			\
 		supportw.h
 
 libMonoSupportW_la_LIBADD =			\
-		$(GLIB_LIBS)
+		$(glib_libs)
 
 # 
 # Use this target to refresh the values in map.[ch]

--- a/support/Makefile.am
+++ b/support/Makefile.am
@@ -14,7 +14,7 @@ AM_CPPFLAGS =					\
 	$(GLIB_CFLAGS)				\
 	-I$(top_srcdir)
 
-glib_libs = $(top_builddir)/mono/eglib/libeglib.la -lm
+glib_libs = $(top_builddir)/mono/eglib/libeglib.la
 
 # Source code which helps implement the ANSI C standards, and thus *should* be
 # portable to any platform having a C compiler.

--- a/tools/monograph/Makefile.am
+++ b/tools/monograph/Makefile.am
@@ -34,8 +34,7 @@ AM_CPPFLAGS = 				\
 monograph_LDADD = \
 	$(runtime_lib)			\
 	$(GLIB_LIBS)			\
-	$(LLVM_LIBS)			\
-	-lm
+	$(LLVM_LIBS)
 
 if HOST_DARWIN
 monograph_LDFLAGS=-framework CoreFoundation -framework Foundation

--- a/tools/monograph/Makefile.am
+++ b/tools/monograph/Makefile.am
@@ -3,6 +3,8 @@ if HOST_WIN32
 export HOST_CC
 endif
 
+glib_libs = $(top_builddir)/mono/eglib/libeglib.la
+
 if DISABLE_EXECUTABLES
 runtime_lib=$(top_builddir)/mono/mini/$(LIBMONO_LA) $(static_libs)
 else
@@ -10,7 +12,7 @@ static_libs=	\
 	$(top_builddir)/mono/metadata/libmonoruntimesgen.la	\
 	$(top_builddir)/mono/sgen/libmonosgen.la	\
 	$(top_builddir)/mono/utils/libmonoutils.la \
-	$(GLIB_LIBS)
+	$(glib_libs)
 
 runtime_lib=$(static_libs)
 endif
@@ -33,7 +35,7 @@ AM_CPPFLAGS = 				\
 
 monograph_LDADD = \
 	$(runtime_lib)			\
-	$(GLIB_LIBS)			\
+	$(glib_libs)			\
 	$(LLVM_LIBS)
 
 if HOST_DARWIN

--- a/tools/pedump/Makefile.am
+++ b/tools/pedump/Makefile.am
@@ -1,6 +1,8 @@
 
 AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/mono $(LIBGC_CPPFLAGS) $(GLIB_CFLAGS) $(SHARED_CFLAGS)
 
+glib_libs = $(top_builddir)/mono/eglib/libeglib.la
+
 if DISABLE_EXECUTABLES
 bin_PROGRAMS =
 else
@@ -22,7 +24,7 @@ pedump_LDADD = 			\
 	$(top_builddir)/mono/utils/libmonoutils.la \
 	$(LLVM_LIBS)			\
 	$(LLVM_LDFLAGS)			\
-	$(GLIB_LIBS)
+	$(glib_libs)
 
 if HOST_DARWIN
 pedump_LDFLAGS=-framework CoreFoundation -framework Foundation

--- a/tools/sgen/Makefile.am
+++ b/tools/sgen/Makefile.am
@@ -2,6 +2,8 @@ bin_PROGRAMS = sgen-grep-binprot
 
 AM_CPPFLAGS =  $(GLIB_CFLAGS) -I$(top_srcdir)
 
+glib_libs = $(top_builddir)/mono/eglib/libeglib.la
+
 noinst_LIBRARIES = libsgen-grep-binprot.a libsgen-grep-binprot32p.a libsgen-grep-binprot64p.a
 libsgen_grep_binprot_a_SOURCES = sgen-grep-binprot.c sgen-grep-binprot.h
 libsgen_grep_binprot_a_CPPFLAGS = $(GLIB_CFLAGS) -I$(top_srcdir)
@@ -16,4 +18,4 @@ sgen_grep_binprot_SOURCES = \
 	sgen-entry-stream.h
 
 sgen_grep_binprot_LDADD = \
-	$(GLIB_LIBS) libsgen-grep-binprot.a libsgen-grep-binprot32p.a libsgen-grep-binprot64p.a
+	$(glib_libs) libsgen-grep-binprot.a libsgen-grep-binprot32p.a libsgen-grep-binprot64p.a


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/8175