### PR TITLE
[2017-12] [sdks] Add ANDROID_BUILD_TOOLS_DIR to differentiate it from ANDROID_BUILD_TOOLS_VERSION

### DIFF
--- a/sdks/builds/android.mk
+++ b/sdks/builds/android.mk
@@ -50,13 +50,13 @@ endif
 AndroidSDKProvisioningTemplate=$(call AndroidProvisioningTemplate,$(1),$(2),sdk,$(ANDROID_URI)$(3))
 
 ifeq ($(UNAME),Darwin)
-$(eval $(call AndroidSDKProvisioningTemplate,build-tools_r$(ANDROID_BUILD_TOOLS_VERSION)-macosx,build-tools/$(ANDROID_BUILD_TOOLS_VERSION)))
+$(eval $(call AndroidSDKProvisioningTemplate,build-tools_r$(ANDROID_BUILD_TOOLS_VERSION)-macosx,build-tools/$(or $(ANDROID_BUILD_TOOLS_DIR),$(ANDROID_BUILD_TOOLS_VERSION))))
 $(eval $(call AndroidSDKProvisioningTemplate,platform-tools_r27.0.1-darwin,platforms-tools))
 $(eval $(call AndroidSDKProvisioningTemplate,sdk-tools-darwin-4333796,tools))
 $(eval $(call AndroidSDKProvisioningTemplate,emulator-darwin-4266726,emulator))
 else
 ifeq ($(UNAME),Linux)
-$(eval $(call AndroidSDKProvisioningTemplate,build-tools_r$(ANDROID_BUILD_TOOLS_VERSION)-linux,build-tools/$(ANDROID_BUILD_TOOLS_VERSION)))
+$(eval $(call AndroidSDKProvisioningTemplate,build-tools_r$(ANDROID_BUILD_TOOLS_VERSION)-linux,build-tools/$(or $(ANDROID_BUILD_TOOLS_DIR),$(ANDROID_BUILD_TOOLS_VERSION))))
 $(eval $(call AndroidSDKProvisioningTemplate,platform-tools_r27.0.1-linux,platform-tools))
 $(eval $(call AndroidSDKProvisioningTemplate,sdk-tools-linux-4333796,tools))
 $(eval $(call AndroidSDKProvisioningTemplate,emulator-linux-4266726,emulator))


### PR DESCRIPTION
Backport of #8191.

/cc @luhenry