### PR TITLE
[interp] Fix resuming from finally block

### DIFF
--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -145,6 +145,8 @@ typedef struct {
 	InterpFrame *handler_frame;
 	/* IP to resume execution at */
 	gpointer handler_ip;
+	/* Clause that we are resuming to */
+	MonoJitExceptionInfo *handler_ei;
 } ThreadContext;
 
 extern int mono_interp_traceopt;

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -209,6 +209,7 @@ set_resume_state (ThreadContext *context, InterpFrame *frame)
 	frame->ex = NULL;
 	context->has_resume_state = 0;
 	context->handler_frame = NULL;
+	context->handler_ei = NULL;
 }
 
 /* Set the current execution state to the resume state in context */
@@ -221,6 +222,11 @@ set_resume_state (ThreadContext *context, InterpFrame *frame)
 		sp->data.p = frame->ex;											\
 		++sp;															\
 		} \
+		/* We have thrown an exception from a finally block. Some of the leave targets were unwinded already */ \
+		while (finally_ips && \
+				finally_ips->data >= (context)->handler_ei->try_start && \
+				finally_ips->data < (context)->handler_ei->try_end) \
+			finally_ips = g_slist_remove (finally_ips, finally_ips->data); \
 		set_resume_state ((context), (frame));							\
 		goto main_loop;													\
 	} while (0)
@@ -2331,6 +2337,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 #include "mintops.def"
 	0 };
 #endif
+
 
 	frame->ex = NULL;
 	frame->ex_handler = NULL;
@@ -5234,6 +5241,7 @@ interp_set_resume_state (MonoJitTlsData *jit_tls, MonoException *ex, MonoJitExce
 
 	context->has_resume_state = TRUE;
 	context->handler_frame = interp_frame;
+	context->handler_ei = ei;
 	/* This is on the stack, so it doesn't need a wbarrier */
 	context->handler_frame->ex = ex;
 	/* Ditto */

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -301,6 +301,7 @@ TESTS_CS_SRC=		\
 	exception16.cs		\
 	exception17.cs		\
 	exception18.cs		\
+	exception19.cs		\
 	typeload-unaligned.cs	\
 	struct.cs		\
 	valuetype-gettype.cs	\

--- a/mono/tests/exception19.cs
+++ b/mono/tests/exception19.cs
@@ -1,0 +1,25 @@
+using System;
+
+public class TestFinallyException {
+
+	public static int Main (string[] args)
+	{
+		int ret = -1;
+
+		try {
+		} finally {
+			try {
+				try {
+				} finally {
+					throw new Exception ();
+				}
+				ret = 1;
+			} catch (Exception) {
+				ret = 0;
+			}
+		}
+
+		return ret;
+	}
+
+}


### PR DESCRIPTION
In interp we implement the leave statement by enqueuing finally ips (and the destination ip that we are leaving to) that we call as we exit finally blocks. When throwing an exception from a finally block we need to flush these ips, so we don't jump back into clauses that were already skipped by EH.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
