### PR TITLE
[2017-12] [System.Net.Http] Use \u0027*\u0027 as the host instead of \u0027+\u0027 in the tests. Fixes xamarin/maccore#673.

### DIFF
--- a/mcs/class/System.Net.Http/Test/System.Net.Http/HttpClientTest.cs
+++ b/mcs/class/System.Net.Http/Test/System.Net.Http/HttpClientTest.cs
@@ -1443,7 +1443,7 @@ namespace MonoTests.System.Net.Http
 		HttpListener CreateListener (Action<HttpListenerContext> contextAssert, int port)
 		{
 			var l = new HttpListener ();
-			l.Prefixes.Add (string.Format ("http://+:{0}/", port));
+			l.Prefixes.Add (string.Format ("http://*:{0}/", port));
 			l.Start ();
 			AddListenerContext(l, contextAssert);
 


### PR DESCRIPTION
Backport of #8173.

/cc @marek-safar