### PR TITLE
Fix Automatic Proxy Configuration protocol for OSX 10.13

### DIFF
--- a/mcs/class/System/System.Net/MacProxy.cs
+++ b/mcs/class/System/System.Net/MacProxy.cs
@@ -335,6 +335,15 @@ namespace Mono.Net
 				return (int) CFStringGetLength (Handle);
 			}
 		}
+		
+		[DllImport (CoreFoundationLibrary)]
+		//CFComparisonResult CFStringCompare(CFStringRef theString1, CFStringRef theString2, CFStringCompareFlags compareOptions)
+		extern static int CFStringCompare(IntPtr theString1, IntPtr theString2, int compareOptions);
+		
+		public static int Compare(IntPtr string1, IntPtr string2, int compareOptions = 0)
+		{
+			return CFStringCompare(string1, string2, compareOptions);
+		}
 
 		[DllImport (CoreFoundationLibrary)]
 		extern static IntPtr CFStringGetCharactersPtr (IntPtr handle);
@@ -689,22 +698,23 @@ namespace Mono.Net
 				return CFProxyType.SOCKS;
 			
 			//in OSX 10.13 pointer comparison didn't work for kCFProxyTypeAutoConfigurationURL
-			var typeString = CFString.AsString(type);
-			switch (typeString)                 
-			{                                   
-				case "kCFProxyTypeAutoConfigurationURL":
-					return CFProxyType.AutoConfigurationUrl;
-				case "kCFProxyTypeAutoConfigurationJavaScript":
-					return CFProxyType.AutoConfigurationJavaScript;
-				case "kCFProxyTypeFTP":         
-					return CFProxyType.FTP;     
-				case "kCFProxyTypeHTTP":        
-					return CFProxyType.HTTP;    
-				case "kCFProxyTypeHTTPS":       
-					return CFProxyType.HTTPS;   
-				case "kCFProxyTypeSOCKS":       
-					return CFProxyType.SOCKS;   
-			}
+			if (CFString.Compare(type, kCFProxyTypeAutoConfigurationJavaScript) == 0)
+				return CFProxyType.AutoConfigurationJavaScript;
+
+			if (CFString.Compare(type, kCFProxyTypeAutoConfigurationURL) == 0)
+				return CFProxyType.AutoConfigurationUrl;
+
+			if (CFString.Compare(type, kCFProxyTypeFTP) == 0)
+				return CFProxyType.FTP;
+
+			if (CFString.Compare(type, kCFProxyTypeHTTP) == 0)
+				return CFProxyType.HTTP;
+
+			if (CFString.Compare(type, kCFProxyTypeHTTPS) == 0)
+				return CFProxyType.HTTPS;
+
+			if (CFString.Compare(type, kCFProxyTypeSOCKS) == 0)
+				return CFProxyType.SOCKS;
 			
 			return CFProxyType.None;
 		}

--- a/mcs/class/System/System.Net/MacProxy.cs
+++ b/mcs/class/System/System.Net/MacProxy.cs
@@ -337,12 +337,11 @@ namespace Mono.Net
 		}
 		
 		[DllImport (CoreFoundationLibrary)]
-		//CFComparisonResult CFStringCompare(CFStringRef theString1, CFStringRef theString2, CFStringCompareFlags compareOptions)
-		extern static int CFStringCompare(IntPtr theString1, IntPtr theString2, int compareOptions);
+		extern static int CFStringCompare (IntPtr theString1, IntPtr theString2, int compareOptions);
 		
-		public static int Compare(IntPtr string1, IntPtr string2, int compareOptions = 0)
+		public static int Compare (IntPtr string1, IntPtr string2, int compareOptions = 0)
 		{
-			return CFStringCompare(string1, string2, compareOptions);
+			return CFStringCompare (string1, string2, compareOptions);
 		}
 
 		[DllImport (CoreFoundationLibrary)]
@@ -698,22 +697,22 @@ namespace Mono.Net
 				return CFProxyType.SOCKS;
 			
 			//in OSX 10.13 pointer comparison didn't work for kCFProxyTypeAutoConfigurationURL
-			if (CFString.Compare(type, kCFProxyTypeAutoConfigurationJavaScript) == 0)
+			if (CFString.Compare (type, kCFProxyTypeAutoConfigurationJavaScript) == 0)
 				return CFProxyType.AutoConfigurationJavaScript;
 
-			if (CFString.Compare(type, kCFProxyTypeAutoConfigurationURL) == 0)
+			if (CFString.Compare (type, kCFProxyTypeAutoConfigurationURL) == 0)
 				return CFProxyType.AutoConfigurationUrl;
 
-			if (CFString.Compare(type, kCFProxyTypeFTP) == 0)
+			if (CFString.Compare (type, kCFProxyTypeFTP) == 0)
 				return CFProxyType.FTP;
 
-			if (CFString.Compare(type, kCFProxyTypeHTTP) == 0)
+			if (CFString.Compare (type, kCFProxyTypeHTTP) == 0)
 				return CFProxyType.HTTP;
 
-			if (CFString.Compare(type, kCFProxyTypeHTTPS) == 0)
+			if (CFString.Compare (type, kCFProxyTypeHTTPS) == 0)
 				return CFProxyType.HTTPS;
 
-			if (CFString.Compare(type, kCFProxyTypeSOCKS) == 0)
+			if (CFString.Compare (type, kCFProxyTypeSOCKS) == 0)
 				return CFProxyType.SOCKS;
 			
 			return CFProxyType.None;

--- a/mcs/class/System/System.Net/MacProxy.cs
+++ b/mcs/class/System/System.Net/MacProxy.cs
@@ -688,6 +688,24 @@ namespace Mono.Net
 			if (type == kCFProxyTypeSOCKS)
 				return CFProxyType.SOCKS;
 			
+			//in OSX 10.13 pointer comparison didn't work for kCFProxyTypeAutoConfigurationURL
+			var typeString = CFString.AsString(type);
+			switch (typeString)                 
+			{                                   
+				case "kCFProxyTypeAutoConfigurationURL":
+					return CFProxyType.AutoConfigurationUrl;
+				case "kCFProxyTypeAutoConfigurationJavaScript":
+					return CFProxyType.AutoConfigurationJavaScript;
+				case "kCFProxyTypeFTP":         
+					return CFProxyType.FTP;     
+				case "kCFProxyTypeHTTP":        
+					return CFProxyType.HTTP;    
+				case "kCFProxyTypeHTTPS":       
+					return CFProxyType.HTTPS;   
+				case "kCFProxyTypeSOCKS":       
+					return CFProxyType.SOCKS;   
+			}
+			
 			return CFProxyType.None;
 		}
 		


### PR DESCRIPTION
Reference comparison of kCFProxyTypeAutoConfigurationURL doesn't work in OSX 10.13. Added fallback to do value/string comparison to get proxy type.

In OSX 10.13, the IntPrt value for kCFProxyTypeKey in the dictionary returned by CFProxyAutoConfigurationResultCallback no longer match CFProxy.kCFProxyTypeAutoConfigurationURL.

I tested for my use case by compiling the mono 5.8.0.127 tarball with my changes.

Excerpt of my discovery code (altered code from CFNetwork.ExecuteProxyAutoConfigurationURL) :
```CSharp
        [DllImport(CFObject.CoreFoundationLibrary)]
        extern static void CFDictionaryGetKeysAndValues(IntPtr theDict, IntPtr[] keys, IntPtr[] values);

        [DllImport(CFObject.CoreFoundationLibrary)]
        extern static int CFDictionaryGetCount(IntPtr theDict);

...

           var proxyAutoConfigURL = CFUrl.Create("http://[url-to-doc-pac-file]");
            var targetURL = CFUrl.Create("http://[target-url]");

            CFProxy[] proxies = null;

            var runLoop = CFRunLoop.CurrentRunLoop;

            // Callback that will be called after executing the configuration script
            CFNetwork.CFProxyAutoConfigurationResultCallback cb = delegate (IntPtr client, IntPtr proxyList, IntPtr error)
            {
                Console.WriteLine("In Callback");
                if (proxyList != IntPtr.Zero)
                {
                    var array = new CFArray(proxyList, false);
                    proxies = new CFProxy[array.Count];
                    for (int i = 0; i < proxies.Length; i++)
                    {
                        CFDictionary dict = new CFDictionary(array[i], false);
                        var v = dict.GetValue(CFProxy.kCFProxyTypeKey);
                        Console.WriteLine($"kCFProxyTypeKey {CFString.AsString(v)}");
                        var count = CFDictionaryGetCount(dict.Handle);

                        var keys = new IntPtr[count];
                        var values = new IntPtr[count];
                        CFDictionaryGetKeysAndValues(dict.Handle, keys, values);

                        foreach(var k in keys) {
                            var keyStr = new CFString(k, false);
                            Console.WriteLine($"{keyStr}");
                        }

                        proxies[i] = new CFProxy(dict);
                    }
                    array.Dispose();
                }
                runLoop.Stop();
            };

            var clientContext = new CFStreamClientContext();
            var loopSource = CFNetwork.CFNetworkExecuteProxyAutoConfigurationURL(proxyAutoConfigURL.Handle, targetURL.Handle, cb, ref clientContext);

            // Create a private mode
            var mode = CFString.Create("Mono.MacProxy");

            runLoop.AddSource(loopSource, mode);
            runLoop.RunInMode(mode, double.MaxValue, false);
            runLoop.RemoveSource(loopSource, mode);

            foreach (var p in proxies)
            {
                Console.WriteLine($"{p.ProxyType} {p.HostName}");
            }
```