### PR TITLE
Fix timestamp for file copy

### DIFF
--- a/mcs/class/corlib/Test/System.IO/FileTest.cs
+++ b/mcs/class/corlib/Test/System.IO/FileTest.cs
@@ -1286,6 +1286,35 @@ namespace MonoTests.System.IO
 			}
 		}
 
+		/* regression test from https://github.com/xamarin/xamarin-macios/issues/3929 */
+		[Test]
+		public void LastWriteTimeSubMsCopy ()
+		{
+			string path = tmpFolder + Path.DirectorySeparatorChar + "lastWriteTimeSubMs";
+			if (File.Exists (path))
+				File.Delete (path);
+
+			string path_copy = tmpFolder + Path.DirectorySeparatorChar + "LastWriteTimeSubMs_copy";
+			if (File.Exists (path_copy))
+				File.Delete (path_copy);
+
+			try {
+				var fmt = "HH:mm:ss:fffffff";
+				for (var i = 0; i < 200; i++) {
+					File.WriteAllText (path, "");
+					var untouched = File.GetLastWriteTimeUtc (path);
+					File.Copy (path, path_copy);
+					var copy_touched = File.GetLastWriteTimeUtc (path_copy);
+
+					Assert.IsTrue (copy_touched >= untouched, $"Iteration #{i} failed, untouched: {untouched.ToString (fmt)} copy_touched: {copy_touched.ToString (fmt)}");
+					File.Delete (path_copy);
+				}
+			} finally {
+				DeleteFile (path);
+				DeleteFile (path_copy);
+			}
+		}
+
 		[Test]
 		public void GetCreationTime_Path_Null ()
 		{

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -48,6 +48,7 @@
 #include "utils/strenc.h"
 #include "utils/refcount.h"
 
+#define NANOSECONDS_PER_MICROSECOND 1000LL
 #define TICKS_PER_MICROSECOND 10L
 #define TICKS_PER_MILLISECOND 10000L
 #define TICKS_PER_SECOND 10000000LL
@@ -1471,11 +1472,11 @@ static void convert_stattime_access_to_timeval (struct timeval *dest, struct sta
 {
 #if HAVE_STRUCT_STAT_ST_ATIMESPEC
 	dest->tv_sec = statbuf->st_atimespec.tv_sec;
-	dest->tv_usec = statbuf->st_atimespec.tv_nsec / 1000;
+	dest->tv_usec = statbuf->st_atimespec.tv_nsec / NANOSECONDS_PER_MICROSECOND;
 #else
 	dest->tv_sec = statbuf->st_atime;
 #if HAVE_STRUCT_STAT_ST_ATIM
-	dest->tv_usec = statbuf->st_atim.tv_nsec / 1000;
+	dest->tv_usec = statbuf->st_atim.tv_nsec / NANOSECONDS_PER_MICROSECOND;
 #endif
 #endif
 }
@@ -1484,11 +1485,11 @@ static void convert_stattime_mod_to_timeval (struct timeval *dest, struct stat *
 {
 #if HAVE_STRUCT_STAT_ST_ATIMESPEC
 	dest->tv_sec = statbuf->st_mtimespec.tv_sec;
-	dest->tv_usec = statbuf->st_mtimespec.tv_nsec / 1000;
+	dest->tv_usec = statbuf->st_mtimespec.tv_nsec / NANOSECONDS_PER_MICROSECOND;
 #else
 	dest->tv_sec = statbuf->st_mtime;
 #if HAVE_STRUCT_STAT_ST_ATIM
-	dest->tv_usec = statbuf->st_mtim.tv_nsec / 1000;
+	dest->tv_usec = statbuf->st_mtim.tv_nsec / NANOSECONDS_PER_MICROSECOND;
 #endif
 #endif
 }
@@ -3493,20 +3494,20 @@ mono_w32file_get_attributes_ex (const gunichar2 *name, MonoIOStat *stat)
 
 #if HAVE_STRUCT_STAT_ST_ATIMESPEC
 	if (buf.st_mtimespec.tv_sec < buf.st_ctimespec.tv_sec || (buf.st_mtimespec.tv_sec == buf.st_ctimespec.tv_sec && buf.st_mtimespec.tv_nsec < buf.st_ctimespec.tv_nsec))
-		stat->creation_time = buf.st_mtimespec.tv_sec * TICKS_PER_SECOND + (buf.st_mtimespec.tv_nsec / 1000) * TICKS_PER_MILLISECOND + CONVERT_BASE;
+		stat->creation_time = buf.st_mtimespec.tv_sec * TICKS_PER_SECOND + (buf.st_mtimespec.tv_nsec / NANOSECONDS_PER_MICROSECOND) * TICKS_PER_MILLISECOND + CONVERT_BASE;
 	else
-		stat->creation_time = buf.st_ctimespec.tv_sec * TICKS_PER_SECOND + (buf.st_ctimespec.tv_nsec / 1000) * TICKS_PER_MILLISECOND + CONVERT_BASE;
+		stat->creation_time = buf.st_ctimespec.tv_sec * TICKS_PER_SECOND + (buf.st_ctimespec.tv_nsec / NANOSECONDS_PER_MICROSECOND) * TICKS_PER_MILLISECOND + CONVERT_BASE;
 
-	stat->last_access_time = buf.st_atimespec.tv_sec * TICKS_PER_SECOND + (buf.st_atimespec.tv_nsec / 1000) * TICKS_PER_MILLISECOND + CONVERT_BASE;
-	stat->last_write_time = buf.st_mtimespec.tv_sec * TICKS_PER_SECOND + (buf.st_mtimespec.tv_nsec / 1000) * TICKS_PER_MILLISECOND + CONVERT_BASE;
+	stat->last_access_time = buf.st_atimespec.tv_sec * TICKS_PER_SECOND + (buf.st_atimespec.tv_nsec / NANOSECONDS_PER_MICROSECOND) * TICKS_PER_MILLISECOND + CONVERT_BASE;
+	stat->last_write_time = buf.st_mtimespec.tv_sec * TICKS_PER_SECOND + (buf.st_mtimespec.tv_nsec / NANOSECONDS_PER_MICROSECOND) * TICKS_PER_MILLISECOND + CONVERT_BASE;
 #elif HAVE_STRUCT_STAT_ST_ATIM
 	if (buf.st_mtime < buf.st_ctime || (buf.st_mtime == buf.st_ctime && buf.st_mtim.tv_nsec < buf.st_ctim.tv_nsec))
-		stat->creation_time = buf.st_mtime * TICKS_PER_SECOND + (buf.st_mtim.tv_nsec / 1000) * TICKS_PER_MILLISECOND + CONVERT_BASE;
+		stat->creation_time = buf.st_mtime * TICKS_PER_SECOND + (buf.st_mtim.tv_nsec / NANOSECONDS_PER_MICROSECOND) * TICKS_PER_MILLISECOND + CONVERT_BASE;
 	else
-		stat->creation_time = buf.st_ctime * TICKS_PER_SECOND + (buf.st_ctim.tv_nsec / 1000) * TICKS_PER_MILLISECOND + CONVERT_BASE;
+		stat->creation_time = buf.st_ctime * TICKS_PER_SECOND + (buf.st_ctim.tv_nsec / NANOSECONDS_PER_MICROSECOND) * TICKS_PER_MILLISECOND + CONVERT_BASE;
 
-	stat->last_access_time = buf.st_atime * TICKS_PER_SECOND + (buf.st_atim.tv_nsec / 1000) * TICKS_PER_MILLISECOND + CONVERT_BASE;
-	stat->last_write_time = buf.st_mtime * TICKS_PER_SECOND + (buf.st_mtim.tv_nsec / 1000) * TICKS_PER_MILLISECOND + CONVERT_BASE;
+	stat->last_access_time = buf.st_atime * TICKS_PER_SECOND + (buf.st_atim.tv_nsec / NANOSECONDS_PER_MICROSECOND) * TICKS_PER_MILLISECOND + CONVERT_BASE;
+	stat->last_write_time = buf.st_mtime * TICKS_PER_SECOND + (buf.st_mtim.tv_nsec / NANOSECONDS_PER_MICROSECOND) * TICKS_PER_MILLISECOND + CONVERT_BASE;
 #else
 	stat->creation_time = (((guint64) (buf.st_mtime < buf.st_ctime ? buf.st_mtime : buf.st_ctime)) * TICKS_PER_SECOND) + CONVERT_BASE;
 	stat->last_access_time = (((guint64) (buf.st_atime)) * TICKS_PER_SECOND) + CONVERT_BASE;

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -1467,6 +1467,32 @@ convert_unix_filetime (const FILETIME *file_time, size_t field_size, const char 
 }
 #endif
 
+static void convert_stattime_access_to_timeval (struct timeval *dest, struct stat *statbuf)
+{
+#if HAVE_STRUCT_STAT_ST_ATIMESPEC
+	dest->tv_sec = statbuf->st_atimespec.tv_sec;
+	dest->tv_usec = statbuf->st_atimespec.tv_nsec / 1000;
+#else
+	dest->tv_sec = statbuf->st_atime;
+#if HAVE_STRUCT_STAT_ST_ATIM
+	dest->tv_usec = statbuf->st_atim.tv_nsec / 1000;
+#endif
+#endif
+}
+
+static void convert_stattime_mod_to_timeval (struct timeval *dest, struct stat *statbuf)
+{
+#if HAVE_STRUCT_STAT_ST_ATIMESPEC
+	dest->tv_sec = statbuf->st_mtimespec.tv_sec;
+	dest->tv_usec = statbuf->st_mtimespec.tv_nsec / 1000;
+#else
+	dest->tv_sec = statbuf->st_mtime;
+#if HAVE_STRUCT_STAT_ST_ATIM
+	dest->tv_usec = statbuf->st_mtim.tv_nsec / 1000;
+#endif
+#endif
+}
+
 static gboolean file_setfiletime(FileHandle *filehandle,
 				 const FILETIME *create_time G_GNUC_UNUSED,
 				 const FILETIME *access_time,
@@ -1511,15 +1537,7 @@ static gboolean file_setfiletime(FileHandle *filehandle,
 		times [0].tv_sec = actime / TICKS_PER_SECOND;
 		times [0].tv_usec = (actime % TICKS_PER_SECOND) / TICKS_PER_MICROSECOND;
 	} else {
-#if HAVE_STRUCT_STAT_ST_ATIMESPEC
-		times [0].tv_sec = statbuf.st_atimespec.tv_sec;
-		times [0].tv_usec = statbuf.st_atimespec.tv_nsec / 1000;
-#else
-		times [0].tv_sec = statbuf.st_atime;
-#if HAVE_STRUCT_STAT_ST_ATIM
-		times [0].tv_usec = statbuf.st_atim.tv_nsec / 1000;
-#endif
-#endif
+		convert_stattime_access_to_timeval (&times [0], &statbuf);
 	}
 
 	if (write_time) {
@@ -1527,15 +1545,7 @@ static gboolean file_setfiletime(FileHandle *filehandle,
 		times [1].tv_sec = wtime / TICKS_PER_SECOND;
 		times [1].tv_usec = (wtime % TICKS_PER_SECOND) / TICKS_PER_MICROSECOND;
 	} else {
-#if HAVE_STRUCT_STAT_ST_ATIMESPEC
-		times [1].tv_sec = statbuf.st_mtimespec.tv_sec;
-		times [1].tv_usec = statbuf.st_mtimespec.tv_nsec / 1000;
-#else
-		times [1].tv_sec = statbuf.st_mtime;
-#if HAVE_STRUCT_STAT_ST_ATIM
-		times [1].tv_usec = statbuf.st_mtim.tv_nsec / 1000;
-#endif
-#endif
+		convert_stattime_mod_to_timeval (&times [1], &statbuf);
 	}
 
 	ret = _wapi_utimes (filehandle->filename, times);
@@ -2309,7 +2319,6 @@ CopyFile (const gunichar2 *name, const gunichar2 *dest_name, gboolean fail_if_ex
 	gchar *utf8_src, *utf8_dest;
 	gint src_fd, dest_fd;
 	struct stat st, dest_st;
-	struct utimbuf dest_time;
 	gboolean ret = TRUE;
 	gint ret_utime;
 	gint syscall_res;
@@ -2426,11 +2435,21 @@ CopyFile (const gunichar2 *name, const gunichar2 *dest_name, gboolean fail_if_ex
 	close (src_fd);
 	close (dest_fd);
 	
+#ifdef HAVE_STRUCT_TIMEVAL
+	struct timeval times [2];
+	memset (times, 0, sizeof (times));
+
+	convert_stattime_access_to_timeval (&times [0], &st);
+	convert_stattime_mod_to_timeval (&times [1], &st);
+
+	ret_utime = _wapi_utimes (utf8_dest, times);
+#else
+	struct utimbuf dest_time;
 	dest_time.modtime = st.st_mtime;
 	dest_time.actime = st.st_atime;
-	MONO_ENTER_GC_SAFE;
-	ret_utime = utime (utf8_dest, &dest_time);
-	MONO_EXIT_GC_SAFE;
+
+	ret_utime = _wapi_utime (utf8_dest, &dest_time);
+#endif
 	if (ret_utime == -1)
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: file [%s] utime failed: %s", __func__, utf8_dest, g_strerror(errno));
 	

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -3493,20 +3493,20 @@ mono_w32file_get_attributes_ex (const gunichar2 *name, MonoIOStat *stat)
 
 #if HAVE_STRUCT_STAT_ST_ATIMESPEC
 	if (buf.st_mtimespec.tv_sec < buf.st_ctimespec.tv_sec || (buf.st_mtimespec.tv_sec == buf.st_ctimespec.tv_sec && buf.st_mtimespec.tv_nsec < buf.st_ctimespec.tv_nsec))
-		stat->creation_time = buf.st_mtimespec.tv_sec * TICKS_PER_SECOND + (buf.st_mtimespec.tv_nsec / 100) + CONVERT_BASE;
+		stat->creation_time = buf.st_mtimespec.tv_sec * TICKS_PER_SECOND + (buf.st_mtimespec.tv_nsec / 1000) * TICKS_PER_MILLISECOND + CONVERT_BASE;
 	else
-		stat->creation_time = buf.st_ctimespec.tv_sec * TICKS_PER_SECOND + (buf.st_ctimespec.tv_nsec / 100) + CONVERT_BASE;
+		stat->creation_time = buf.st_ctimespec.tv_sec * TICKS_PER_SECOND + (buf.st_ctimespec.tv_nsec / 1000) * TICKS_PER_MILLISECOND + CONVERT_BASE;
 
-	stat->last_access_time = buf.st_atimespec.tv_sec * TICKS_PER_SECOND + (buf.st_atimespec.tv_nsec / 100) + CONVERT_BASE;
-	stat->last_write_time = buf.st_mtimespec.tv_sec * TICKS_PER_SECOND + (buf.st_mtimespec.tv_nsec / 100) + CONVERT_BASE;
+	stat->last_access_time = buf.st_atimespec.tv_sec * TICKS_PER_SECOND + (buf.st_atimespec.tv_nsec / 1000) * TICKS_PER_MILLISECOND + CONVERT_BASE;
+	stat->last_write_time = buf.st_mtimespec.tv_sec * TICKS_PER_SECOND + (buf.st_mtimespec.tv_nsec / 1000) * TICKS_PER_MILLISECOND + CONVERT_BASE;
 #elif HAVE_STRUCT_STAT_ST_ATIM
 	if (buf.st_mtime < buf.st_ctime || (buf.st_mtime == buf.st_ctime && buf.st_mtim.tv_nsec < buf.st_ctim.tv_nsec))
-		stat->creation_time = buf.st_mtime * TICKS_PER_SECOND + (buf.st_mtim.tv_nsec / 100) + CONVERT_BASE;
+		stat->creation_time = buf.st_mtime * TICKS_PER_SECOND + (buf.st_mtim.tv_nsec / 1000) * TICKS_PER_MILLISECOND + CONVERT_BASE;
 	else
-		stat->creation_time = buf.st_ctime * TICKS_PER_SECOND + (buf.st_ctim.tv_nsec / 100) + CONVERT_BASE;
+		stat->creation_time = buf.st_ctime * TICKS_PER_SECOND + (buf.st_ctim.tv_nsec / 1000) * TICKS_PER_MILLISECOND + CONVERT_BASE;
 
-	stat->last_access_time = buf.st_atime * TICKS_PER_SECOND + (buf.st_atim.tv_nsec / 100) + CONVERT_BASE;
-	stat->last_write_time = buf.st_mtime * TICKS_PER_SECOND + (buf.st_mtim.tv_nsec / 100) + CONVERT_BASE;
+	stat->last_access_time = buf.st_atime * TICKS_PER_SECOND + (buf.st_atim.tv_nsec / 1000) * TICKS_PER_MILLISECOND + CONVERT_BASE;
+	stat->last_write_time = buf.st_mtime * TICKS_PER_SECOND + (buf.st_mtim.tv_nsec / 1000) * TICKS_PER_MILLISECOND + CONVERT_BASE;
 #else
 	stat->creation_time = (((guint64) (buf.st_mtime < buf.st_ctime ? buf.st_mtime : buf.st_ctime)) * TICKS_PER_SECOND) + CONVERT_BASE;
 	stat->last_access_time = (((guint64) (buf.st_atime)) * TICKS_PER_SECOND) + CONVERT_BASE;


### PR DESCRIPTION
4a8d840 introduced that the destination
file of a copy operation has the same modification and access timestamps
as the source file.

With e0e185d this behaviour regresses,
since getting timestamps provides more precise information. Fixing this
by being more accurate when applying timestamps to destination file.

also: convert nano seconds to microseconds properly, by using `TICKS_PER_MILLISECOND` (which has L suffix in its definition)

fixes https://github.com/xamarin/xamarin-macios/issues/3929

needs backporting to `2018-02` and `2018-04`