### PR TITLE
x86/amd64 require a control transfer to notice writes to code

### DIFF
--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -7704,10 +7704,11 @@ mono_arch_instrument_epilog (MonoCompile *cfg, void *func, void *p, gboolean ena
 	return code;
 }
 
+MONO_NEVER_INLINE
 void
 mono_arch_flush_icache (guint8 *code, gint size)
 {
-	/* Not needed */
+	/* call/ret required (or likely other control transfer) */
 }
 
 void

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -5500,10 +5500,11 @@ mono_arch_emit_exceptions (MonoCompile *cfg)
 	g_assert (cfg->code_len < cfg->code_size);
 }
 
+MONO_NEVER_INLINE
 void
 mono_arch_flush_icache (guint8 *code, gint size)
 {
-	/* not needed */
+	/* call/ret required (or likely other control transfer) */
 }
 
 void


### PR DESCRIPTION
(citation needed).

Therefore, while mono_arch_flush_icache does not need to do anything, it cannot be inlined.
