### PR TITLE
Refactor 3 copies of mono_trace_is_traced into 1.

### DIFF
--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -577,6 +577,7 @@ typedef enum {
 	G_LOG_LEVEL_MASK              = ~(G_LOG_FLAG_RECURSION | G_LOG_FLAG_FATAL)
 } GLogLevelFlags;
 
+void           g_printv               (const gchar *format, va_list args);
 void           g_print                (const gchar *format, ...);
 void           g_printerr             (const gchar *format, ...);
 GLogLevelFlags g_log_set_always_fatal (GLogLevelFlags fatal_mask);

--- a/mono/eglib/goutput.c
+++ b/mono/eglib/goutput.c
@@ -41,23 +41,27 @@ static void default_stdout_handler (const gchar *string);
 static void default_stderr_handler (const gchar *string);
 
 void
-g_print (const gchar *format, ...)
+g_printv (const gchar *format, va_list args)
 {
 	char *msg;
-	va_list args;
 
-	va_start (args, format);
-	if (g_vasprintf (&msg, format, args) < 0) {
-		va_end (args);
+	if (g_vasprintf (&msg, format, args) < 0)
 		return;
-	}
-	va_end (args);
 
 	if (!stdout_handler)
 		stdout_handler = default_stdout_handler;
 
 	stdout_handler (msg);
 	g_free (msg);
+}
+
+void
+g_print (const gchar *format, ...)
+{
+	va_list args;
+	va_start (args, format);
+	g_printv (format, args);
+	va_end (args);
 }
 
 void

--- a/mono/utils/mono-logger-internals.h
+++ b/mono/utils/mono-logger-internals.h
@@ -58,10 +58,13 @@ mono_trace_pop (void);
 gboolean
 mono_trace_is_traced (GLogLevelFlags level, MonoTraceMask mask);
 
+#define MONO_TRACE_IS_TRACED(level, mask) \
+	G_UNLIKELY ((level) <= mono_internal_current_level && ((mask) & mono_internal_current_mask))
+
 G_GNUC_UNUSED static void
 mono_tracev (GLogLevelFlags level, MonoTraceMask mask, const char *format, va_list args)
 {
-	if(G_UNLIKELY (level <= mono_internal_current_level && (mask & mono_internal_current_mask)))
+	if (MONO_TRACE_IS_TRACED (level, mask))
 		mono_tracev_inner (level, mask, format, args);
 }
 
@@ -77,7 +80,7 @@ mono_tracev (GLogLevelFlags level, MonoTraceMask mask, const char *format, va_li
 G_GNUC_UNUSED MONO_ATTR_FORMAT_PRINTF(3,4) static void
 mono_trace (GLogLevelFlags level, MonoTraceMask mask, const char *format, ...)
 {
-	if(G_UNLIKELY (level <= mono_internal_current_level && (mask & mono_internal_current_mask))) {
+	if (MONO_TRACE_IS_TRACED (level, mask)) {
 		va_list args;
 		va_start (args, format);
 		mono_tracev_inner (level, mask, format, args);

--- a/mono/utils/mono-logger.c
+++ b/mono/utils/mono-logger.c
@@ -344,7 +344,7 @@ mono_trace_set_mask_string (const char *value)
 gboolean
 mono_trace_is_traced (GLogLevelFlags level, MonoTraceMask mask)
 {
-	return (level <= mono_internal_current_level && (mask & mono_internal_current_mask));
+	return MONO_TRACE_IS_TRACED (level, mask);
 }
 
 /**


### PR DESCRIPTION
Refactor g_print on top of new g_printv. g_log / g_logv provided precedent.

The intent is like:
void foo_print (const char *format, ...)
{
 if (debug_foo || MONO_IS_TRACED (foo, log)) {
   va_list args;
   va_args (format, args);
   g_printv (format args)
 }
}

so I can either set the environment variable, or edit the global,
besides removing the two parameters from every mono_trace call.
