### PR TITLE
Hybrid suspend and checked build fixes (async signal safety)

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,12 +241,12 @@ Disables the inclusion of a Boehm garbage collector.
 
   * This defaults to `included`.
 
-* `--with-cooperative-gc`
+* `--enable-cooperative-suspend`
 
   * If you pass this flag the Mono runtime is configured to only use
   the cooperative mode of the garbage collector.  If you do not pass
   this flag, then you can control at runtime the use of the
-  cooperative GC mode by setting the `MONO_ENABLE_COOP` flag.
+  cooperative GC mode by setting the `MONO_ENABLE_COOP_SUSPEND` flag.
   
 * `--with-tls=__thread,pthread`
 

--- a/configure.ac
+++ b/configure.ac
@@ -1063,7 +1063,7 @@ with_unreal_default=no
 with_wasm_default=no
 
 with_bitcode_default=no
-with_cooperative_gc_default=no
+enable_cooperative_suspend_default=no
 
 INVARIANT_AOT_OPTIONS=nimt-trampolines=2000,ntrampolines=10000,nrgctx-fetch-trampolines=256,ngsharedvt-trampolines=4000
 
@@ -1090,7 +1090,7 @@ elif test x$with_runtime_preset = xbitcode; then
    DISABLE_MCS_DOCS_default=yes
    with_testing_aot_full_default=yes
    with_bitcode_default=yes
-   with_cooperative_gc_default=yes
+   enable_cooperative_suspend_default=yes
    TEST_PROFILE=testing_aot_full
    enable_llvm_default=yes
 
@@ -4513,26 +4513,34 @@ AC_ARG_WITH(lazy_gc_thread_creation, [  --with-lazy-gc-thread-creation=yes|no   
 	fi
 ], [with_lazy_gc_thread_creation=no])
 
-AC_ARG_WITH(cooperative_gc, [  --with-cooperative-gc=yes|no      Enable cooperative stop-the-world garbage collection (sgen only) (defaults to no)], [], [with_cooperative_gc=default])
+AC_ARG_WITH(cooperative_gc,        [  --with-cooperative-gc=yes|no        Enable cooperative stop-the-world garbage collection (sgen only) (defaults to no)], [AC_MSG_WARN([--with-cooperative-gc is deprecated, use --enable-cooperative-suspend instead])], [with_cooperative_gc=default])
+AC_ARG_ENABLE(cooperative_suspend, [  --enable-cooperative-suspend      Enable cooperative stop-the-world garbage collection (sgen only) (defaults to no)], [], [enable_cooperative_suspend=default])
 
-if test x$with_cooperative_gc = xdefault; then
-	with_cooperative_gc=$with_cooperative_gc_default
+if test x$enable_cooperative_suspend = xdefault -a test x$with_cooperative_gc != xdefault; then
+	enable_cooperative_suspend=$with_cooperative_gc
 fi
 
-if test x$with_cooperative_gc != xno; then
-	AC_DEFINE(USE_COOP_GC,1,[Enable cooperative stop-the-world garbage collection.])
+if test x$enable_cooperative_suspend = xdefault; then
+	enable_cooperative_suspend=$enable_cooperative_suspend_default
 fi
 
-AM_CONDITIONAL([ENABLE_COOP], [test x$with_cooperative_gc != xno])
+if test x$enable_cooperative_suspend != xno; then
+	AC_DEFINE(ENABLE_COOP_SUSPEND,1,[Enable cooperative stop-the-world garbage collection.])
+fi
 
-AC_ARG_WITH(hybrid_suspend, [ --with-hybrid-suspend=yes|no     Enable hybrid cooperative stop-the-world garbage collection (sgen only) - cooperative suspend for threads running managed and native code, and preemptive suspend for threads running native and P/Invoke code (defaults to no)], [
-	if test x$with_hybrid_suspend != xno ; then
-		AC_DEFINE(USE_HYBRID_SUSPEND,1,[Enable hybrid cooperative suspend for GC stop-the-world])
-	fi
-	if test x$with_cooperative_gc != xyes ; then
-		AC_MSG_ERROR([Hybrid suspend requires --with-cooperative-gc=yes])
-	fi
-], [with_hybrid_suspend=no])
+AM_CONDITIONAL([ENABLE_COOP_SUSPEND], [test x$enable_cooperative_suspend != xno])
+
+AC_ARG_ENABLE(hybrid_suspend, [ --enable-hybrid-suspend     Enable hybrid stop-the-world garbage collection (sgen only) - cooperative suspend for threads running managed and runtime code, and preemptive suspend for threads running native and P/Invoke code (defaults to no)], [], [enable_hybrid_suspend=no])
+
+if test x$enable_hybrid_suspend != xno -a x$enable_cooperative_suspend != xno ; then
+	AC_MSG_ERROR([Hybrid suspend and Cooperative suspend cannot be both enabled.])
+fi
+
+if test x$enable_hybrid_suspend != xno ; then
+	AC_DEFINE(ENABLE_HYBRID_SUSPEND,1,[Enable hybrid suspend for GC stop-the-world])
+fi
+
+AM_CONDITIONAL([ENABLE_HYBRID_SUSPEND], [test x$enable_hybrid_suspend != xno])
 
 AC_ARG_ENABLE(checked_build, [  --enable-checked-build=LIST      To enable checked build (expensive asserts), configure with a comma-separated LIST of checked build modules and then include that same list in the environment variable MONO_CHECK_MODE at runtime. Recognized checked build modules: all, gc, metadata, thread, private_types],[
 

--- a/man/mono.1
+++ b/man/mono.1
@@ -1170,7 +1170,7 @@ If set, tells mono to attempt using native asynchronous I/O services. If not
 set, a default select/poll implementation is used. Currently epoll and kqueue
 are supported.
 .TP
-\fBMONO_ENABLE_COOP\fR
+\fBMONO_ENABLE_COOP_SUSPEND\fR
 This makes the Mono runtime and the SGen garbage collector run in cooperative
 mode as opposed to run on preemptive mode.   Preemptive mode is the mode
 that Mono has used historically, going back to the Boehm days, where the
@@ -1181,7 +1181,7 @@ safe point.   This makes for an easier to debug garbage collector.   As
 of Mono 4.3.0 it is a work in progress, and while it works, it has not
 been used extensively.   This option enabled the feature and allows us to
 find spots that need to be tuned for this mode of operation.   Alternatively,
-this mode can be enabled at compile time by using the --with-cooperative-gc
+this mode can be enabled at compile time by using the --enable-cooperative-suspend
 flag when calling configure.
 .TP
 \fBMONO_ENV_OPTIONS\fR

--- a/mono/metadata/mono-hash.c
+++ b/mono/metadata/mono-hash.c
@@ -227,7 +227,7 @@ rehash (MonoGHashTable *hash)
 	if (hash->gc_type & MONO_HASH_VALUE_GC)
 		mono_gc_register_root_wbarrier ((char*)data.values, sizeof (MonoObject*) * data.new_size, mono_gc_make_vector_descr (), hash->source, hash->key, hash->msg);
 
-	if (!mono_threads_are_safepoints_enabled () || mono_threads_is_hybrid_suspension_enabled ()) {
+	if (!mono_threads_are_safepoints_enabled ()) {
 		mono_gc_invoke_with_gc_lock (do_rehash, &data);
 	} else {
 		/* We cannot be preempted */

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -4567,8 +4567,9 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			break;
 		}
 		case OP_GC_SAFE_POINT: {
-#if defined (USE_COOP_GC)
 			guint8 *buf [1];
+
+			g_assert (mono_threads_are_safepoints_enabled ());
 
 			arm_ldrx (code, ARMREG_IP1, ins->sreg1, 0);
 			/* Call it if it is non-null */
@@ -4576,7 +4577,6 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			arm_cbzx (code, ARMREG_IP1, 0);
 			code = emit_call (cfg, code, MONO_PATCH_INFO_INTERNAL_METHOD, "mono_threads_state_poll");
 			mono_arm_patch (buf [0], code, MONO_R_ARM64_CBZ);
-#endif
 			break;
 		}
 		case OP_FILL_PROF_CALL_CTX:

--- a/mono/profiler/Makefile.am
+++ b/mono/profiler/Makefile.am
@@ -33,8 +33,10 @@ suppression_DATA = mono-profiler-coverage.suppression
 # sampling infrastructure depends on signals being available.
 #
 # See: https://bugzilla.xamarin.com/show_bug.cgi?id=57011
-if !ENABLE_COOP
+if !ENABLE_COOP_SUSPEND
+if !ENABLE_HYBRID_SUSPEND
 check_targets = testlog
+endif
 endif
 
 endif

--- a/mono/utils/checked-build.c
+++ b/mono/utils/checked-build.c
@@ -185,6 +185,8 @@ collect_backtrace (gpointer out_data[])
 static char*
 translate_backtrace (gpointer native_trace[], int size)
 {
+	if (size == 0)
+		return g_strdup ("");
 	char **names = backtrace_symbols (native_trace, size);
 	GString* bt = g_string_sized_new (100);
 
@@ -227,15 +229,16 @@ translate_backtrace (gpointer native_trace[], int size)
 #endif
 
 void
-checked_build_thread_transition (const char *transition, void *info, int from_state, int suspend_count, int next_state, int suspend_count_delta)
+checked_build_thread_transition (const char *transition, void *info, int from_state, int suspend_count, int next_state, int suspend_count_delta, gboolean capture_backtrace)
 {
 	if (!mono_check_mode_enabled (MONO_CHECK_MODE_THREAD))
 		return;
 
-	CheckState *state = get_state ();
 	/* We currently don't record external changes as those are hard to reason about. */
 	if (!mono_thread_info_is_current (info))
 		return;
+
+	CheckState *state = get_state ();
 
 	guint16 cur = ringbuf_push (&state->ringbuf, MAX_TRANSITIONS);
 
@@ -245,7 +248,10 @@ checked_build_thread_transition (const char *transition, void *info, int from_st
 	t->next_state = next_state;
 	t->suspend_count = suspend_count;
 	t->suspend_count_delta = suspend_count_delta;
-	t->size = collect_backtrace (t->backtrace);
+	if (capture_backtrace)
+		t->size = collect_backtrace (t->backtrace);
+	else
+		t->size = 0;
 }
 
 void

--- a/mono/utils/checked-build.c
+++ b/mono/utils/checked-build.c
@@ -84,9 +84,23 @@ mono_check_transition_limit (void)
 	return transition_limit;
 }
 
+#define MAX_NATIVE_BT 6
+#define MAX_NATIVE_BT_PROBE (MAX_NATIVE_BT + 5)
+#define MAX_TRANSITIONS (mono_check_transition_limit ())
+
 typedef struct {
-	GPtrArray *transitions;
+	const char *name;
+	int from_state, next_state, suspend_count, suspend_count_delta, size;
+	gpointer backtrace [MAX_NATIVE_BT_PROBE];
+} ThreadTransition;
+
+typedef struct {
 	guint32 in_gc_critical_region;
+	// ring buffer of transitions, indexed by two guint16 indices:
+	// push at buf_end, iterate from buf_start. valid range is
+	// buf_start ... buf_end - 1 mod MAX_TRANSITIONS
+	gint32 ringbuf;
+	ThreadTransition transitions [MONO_ZERO_LEN_ARRAY];
 } CheckState;
 
 static MonoNativeTlsKey thread_status;
@@ -104,19 +118,60 @@ get_state (void)
 {
 	CheckState *state = mono_native_tls_get_value (thread_status);
 	if (!state) {
-		state = g_new0 (CheckState, 1);
-		state->transitions = g_ptr_array_new ();
+		state = (CheckState*) g_malloc0 (sizeof (CheckState) + sizeof(ThreadTransition) * MAX_TRANSITIONS);
 		mono_native_tls_set_value (thread_status, state);
 	}
 
 	return state;
 }
 
-#ifdef ENABLE_CHECKED_BUILD_THREAD
+static inline void
+ringbuf_unpack (gint32 ringbuf, guint16 *buf_start, guint16 *buf_end)
+{
+	*buf_start = (guint16) (ringbuf >> 16);
+	*buf_end = (guint16) (ringbuf & 0x00FF);
+}
 
-#define MAX_NATIVE_BT 6
-#define MAX_NATIVE_BT_PROBE (MAX_NATIVE_BT + 5)
-#define MAX_TRANSITIONS (mono_check_transition_limit ())
+static inline gint32
+ringbuf_pack (guint16 buf_start, guint16 buf_end)
+{
+	return ((((gint32)buf_start) << 16) | ((gint32)buf_end));
+}
+
+static int
+ringbuf_size (guint32 ringbuf, int n)
+{
+	guint16 buf_start, buf_end;
+	ringbuf_unpack (ringbuf, &buf_start, &buf_end);
+	if (buf_end > buf_start)
+		return buf_end - buf_start;
+	else
+		return n - (buf_start - buf_end);
+}
+
+static guint16
+ringbuf_push (gint32 *ringbuf, int n)
+{
+	gint32 ringbuf_old, ringbuf_new;
+	guint16 buf_start, buf_end;
+	guint16 cur;
+retry:
+	ringbuf_old = *ringbuf;
+	ringbuf_unpack (ringbuf_old, &buf_start, &buf_end);
+	cur = buf_end++;
+	if (buf_end == n)
+		buf_end = 0;
+	if (buf_end == buf_start) {
+		if (++buf_start == n)
+			buf_start = 0;
+	}
+	ringbuf_new = ringbuf_pack (buf_start, buf_end);
+	if (mono_atomic_cas_i32 (ringbuf, ringbuf_new, ringbuf_old) != ringbuf_old)
+		goto retry;
+	return cur;
+}
+
+#ifdef ENABLE_CHECKED_BUILD_THREAD
 
 #ifdef HAVE_BACKTRACE_SYMBOLS
 
@@ -171,18 +226,6 @@ translate_backtrace (gpointer native_trace[], int size)
 
 #endif
 
-typedef struct {
-	const char *name;
-	int from_state, next_state, suspend_count, suspend_count_delta, size;
-	gpointer backtrace [MAX_NATIVE_BT_PROBE];
-} ThreadTransition;
-
-static void
-free_transition (ThreadTransition *t)
-{
-	g_free (t);
-}
-
 void
 checked_build_thread_transition (const char *transition, void *info, int from_state, int suspend_count, int next_state, int suspend_count_delta)
 {
@@ -194,23 +237,20 @@ checked_build_thread_transition (const char *transition, void *info, int from_st
 	if (!mono_thread_info_is_current (info))
 		return;
 
-	if (state->transitions->len >= MAX_TRANSITIONS)
-		free_transition (g_ptr_array_remove_index (state->transitions, 0));
+	guint16 cur = ringbuf_push (&state->ringbuf, MAX_TRANSITIONS);
 
-	ThreadTransition *t = g_new0 (ThreadTransition, 1);
+	ThreadTransition *t = &state->transitions[cur];
 	t->name = transition;
 	t->from_state = from_state;
 	t->next_state = next_state;
 	t->suspend_count = suspend_count;
 	t->suspend_count_delta = suspend_count_delta;
 	t->size = collect_backtrace (t->backtrace);
-	g_ptr_array_add (state->transitions, t);
 }
 
 void
 mono_fatal_with_history (const char *msg, ...)
 {
-	int i;
 	GString* err = g_string_sized_new (100);
 
 	g_string_append_printf (err, "Assertion failure in thread %p due to: ", mono_native_thread_id_get ());
@@ -223,11 +263,14 @@ mono_fatal_with_history (const char *msg, ...)
 	if (mono_check_mode_enabled (MONO_CHECK_MODE_THREAD))
 	{
 		CheckState *state = get_state ();
+		guint16 cur, end;
+		int len = ringbuf_size (state->ringbuf, MAX_TRANSITIONS);
 
-		g_string_append_printf (err, "\nLast %d state transitions: (most recent first)\n", state->transitions->len);
+		g_string_append_printf (err, "\nLast %d state transitions: (most recent first)\n", len);
 
-		for (i = state->transitions->len - 1; i >= 0; --i) {
-			ThreadTransition *t = state->transitions->pdata [i];
+		ringbuf_unpack (state->ringbuf, &cur, &end);
+		while (cur != end) {
+			ThreadTransition *t = &state->transitions[cur];
 			char *bt = translate_backtrace (t->backtrace, t->size);
 			g_string_append_printf (err, "[%s] %s -> %s (%d) %s%d at:\n%s",
 				t->name,
@@ -238,6 +281,8 @@ mono_fatal_with_history (const char *msg, ...)
 				t->suspend_count_delta,
 				bt);
 			g_free (bt);
+			if (++cur == MAX_TRANSITIONS)
+				cur = 0;
 		}
 	}
 

--- a/mono/utils/checked-build.h
+++ b/mono/utils/checked-build.h
@@ -204,16 +204,22 @@ void check_metadata_store_local(void *from, void *to);
 #ifdef ENABLE_CHECKED_BUILD_THREAD
 
 #define CHECKED_BUILD_THREAD_TRANSITION(transition, info, from_state, suspend_count, next_state, suspend_count_delta) do {	\
-	checked_build_thread_transition (transition, info, from_state, suspend_count, next_state, suspend_count_delta);	\
+		checked_build_thread_transition (transition, info, from_state, suspend_count, next_state, suspend_count_delta, TRUE); \
 } while (0)
 
-void checked_build_thread_transition(const char *transition, void *info, int from_state, int suspend_count, int next_state, int suspend_count_delta);
+#define CHECKED_BUILD_THREAD_TRANSITION_NOBT(transition, info, from_state, suspend_count, next_state, suspend_count_delta) do {	\
+		checked_build_thread_transition (transition, info, from_state, suspend_count, next_state, suspend_count_delta, FALSE); \
+} while (0)
+
+void checked_build_thread_transition(const char *transition, void *info, int from_state, int suspend_count, int next_state, int suspend_count_delta, gboolean capture_backtrace);
 
 G_GNUC_NORETURN MONO_ATTR_FORMAT_PRINTF(1,2) void mono_fatal_with_history(const char *msg, ...);
 
 #else
 
 #define CHECKED_BUILD_THREAD_TRANSITION(transition, info, from_state, suspend_count, next_state, suspend_count_delta)
+
+#define CHECKED_BUILD_THREAD_TRANSITION_NOBT(transition, info, from_state, suspend_count, next_state, suspend_count_delta)
 
 #define mono_fatal_with_history g_error
 

--- a/mono/utils/mono-threads-coop.c
+++ b/mono/utils/mono-threads-coop.c
@@ -509,14 +509,14 @@ mono_threads_assert_gc_unsafe_region (void)
 }
 
 gboolean
-mono_threads_are_safepoints_enabled (void)
+mono_threads_is_cooperative_suspension_enabled (void)
 {
-#if defined(USE_COOP_GC)
+#if defined(ENABLE_COOP_SUSPEND)
 	return TRUE;
 #else
 	static int is_coop_enabled = -1;
 	if (G_UNLIKELY (is_coop_enabled == -1))
-		is_coop_enabled = g_hasenv ("MONO_ENABLE_COOP") ? 1 : 0;
+		is_coop_enabled = (g_hasenv ("MONO_ENABLE_COOP") || g_hasenv ("MONO_ENABLE_COOP_SUSPEND")) ? 1 : 0;
 	return is_coop_enabled == 1;
 #endif
 }
@@ -524,12 +524,12 @@ mono_threads_are_safepoints_enabled (void)
 gboolean
 mono_threads_is_blocking_transition_enabled (void)
 {
-#if defined(USE_COOP_GC)
+#if defined(ENABLE_COOP_SUSPEND) || defined(ENABLE_HYBRID_SUSPEND)
 	return TRUE;
 #else
 	static int is_blocking_transition_enabled = -1;
 	if (G_UNLIKELY (is_blocking_transition_enabled == -1))
-		is_blocking_transition_enabled = (g_hasenv ("MONO_ENABLE_COOP") || g_hasenv ("MONO_ENABLE_BLOCKING_TRANSITION")) ? 1 : 0;
+		is_blocking_transition_enabled = (g_hasenv ("MONO_ENABLE_COOP") || g_hasenv ("MONO_ENABLE_COOP_SUSPEND") || g_hasenv ("MONO_ENABLE_HYBRID_SUSPEND") || g_hasenv ("MONO_ENABLE_BLOCKING_TRANSITION")) ? 1 : 0;
 	return is_blocking_transition_enabled == 1;
 #endif
 }
@@ -537,12 +537,12 @@ mono_threads_is_blocking_transition_enabled (void)
 gboolean
 mono_threads_is_hybrid_suspension_enabled (void)
 {
-#if defined(USE_HYBRID_SUSPEND)
+#if defined(ENABLE_HYBRID_SUSPEND)
 	return TRUE;
 #else
 	static int is_hybrid_suspension_enabled = -1;
 	if (G_UNLIKELY (is_hybrid_suspension_enabled == -1))
-		is_hybrid_suspension_enabled = g_hasenv ("MONO_ENABLE_COOP") && g_hasenv ("MONO_ENABLE_HYBRID_SUSPEND");
+		is_hybrid_suspension_enabled = (g_hasenv ("MONO_ENABLE_HYBRID_SUSPEND")) ? 1 : 0;
 	return is_hybrid_suspension_enabled == 1;
 #endif
 }

--- a/mono/utils/mono-threads-coop.h
+++ b/mono/utils/mono-threads-coop.h
@@ -23,21 +23,25 @@ G_BEGIN_DECLS
 /* JIT specific interface */
 extern volatile size_t mono_polling_required;
 
-/* Runtime consumable API */
-
-gboolean
-mono_threads_are_safepoints_enabled (void);
-
-gboolean
-mono_threads_is_blocking_transition_enabled (void);
-
 /* Internal API */
 
 void
 mono_threads_state_poll (void);
 
 gboolean
+mono_threads_is_blocking_transition_enabled (void);
+
+gboolean
+mono_threads_is_cooperative_suspension_enabled (void);
+
+gboolean
 mono_threads_is_hybrid_suspension_enabled (void);
+
+static inline gboolean
+mono_threads_are_safepoints_enabled (void)
+{
+	return mono_threads_is_cooperative_suspension_enabled () || mono_threads_is_hybrid_suspension_enabled ();
+}
 
 static inline void
 mono_threads_safepoint (void)

--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -40,7 +40,9 @@ if [[ ${CI_TAGS} == *'osx-amd64'* ]]; then CFLAGS="$CFLAGS -m64 -arch x86_64"; L
 if [[ ${CI_TAGS} == *'win-i386'* ]]; then PLATFORM=Win32; EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --host=i686-w64-mingw32"; export MONO_EXECUTABLE="${MONO_REPO_ROOT}/msvc/build/sgen/Win32/bin/Release/mono-sgen.exe"; fi
 if [[ ${CI_TAGS} == *'win-amd64'* ]]; then PLATFORM=x64; EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --host=x86_64-w64-mingw32 --disable-boehm"; export MONO_EXECUTABLE="${MONO_REPO_ROOT}/msvc/build/sgen/x64/bin/Release/mono-sgen.exe"; fi
 
-if [[ ${CI_TAGS} == *'coop-gc'* ]]; then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-cooperative-gc=yes"; fi
+if   [[ ${CI_TAGS} == *'coop-suspend'* ]];   then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --enable-cooperative-suspend";
+elif [[ ${CI_TAGS} == *'hybrid-suspend'* ]]; then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --enable-hybrid-suspend";
+fi
 
 if [[ ${CI_TAGS} == *'checked-coop'* ]]; then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --enable-checked-build=gc,thread"; fi
 if [[ ${CI_TAGS} == *'checked-all'* ]]; then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --enable-checked-build=all"; fi

--- a/sdks/builds/ios.mk
+++ b/sdks/builds/ios.mk
@@ -132,7 +132,7 @@ watchos_sysroot = -isysroot $(XCODE_DIR)/Platforms/WatchOS.platform/Developer/SD
 
 # explicitly disable dtrace, since it requires inline assembly, which is disabled on AppleTV (and mono's configure.ac doesn't know that (yet at least))
 ios-targettv_CONFIGURE_FLAGS = 	--enable-dtrace=no $(BITCODE_CONFIGURE_FLAGS)
-ios-targetwatch_CONFIGURE_FLAGS = --with-cooperative-gc=yes $(BITCODE_CONFIGURE_FLAGS)
+ios-targetwatch_CONFIGURE_FLAGS = --enable-cooperative-suspend $(BITCODE_CONFIGURE_FLAGS)
 
 ios-target32_SYSROOT = $(ios_sysroot)
 ios-target32s_SYSROOT = $(ios_sysroot)
@@ -265,7 +265,7 @@ ios-sim64_SYSROOT = $(ios_sim_sysroot)
 ios-simtv_SYSROOT = $(tvos_sim_sysroot)
 ios-simwatch_SYSROOT = $(watchos_sim_sysroot)
 
-ios-simwatch_CONFIGURE_FLAGS = --with-cooperative-gc=yes
+ios-simwatch_CONFIGURE_FLAGS = --enable-cooperative-suspend
 
 ios-sim32_CPPFLAGS = -DHOST_IOS
 ios-sim64_CPPFLAGS = -DHOST_IOS
@@ -399,7 +399,7 @@ $$(eval $$(call RuntimeTemplate,ios-$(1)))
 endef
 
 ios-cross32_CONFIGURE_FLAGS=--build=i386-apple-darwin10
-ios-crosswatch_CONFIGURE_FLAGS=--build=i386-apple-darwin10 	--with-cooperative-gc=yes
+ios-crosswatch_CONFIGURE_FLAGS=--build=i386-apple-darwin10 	--enable-cooperative-suspend
 $(eval $(call iOSCrossTemplate,cross32,arm,llvm32,arm-darwin,arm-apple-darwin10))
 $(eval $(call iOSCrossTemplate,cross64,aarch64,llvm64,aarch64-darwin,aarch64-apple-darwin10))
 $(eval $(call iOSCrossTemplate,crosswatch,armv7k,llvm32,armv7k-unknown-darwin,armv7k-apple-darwin))


### PR DESCRIPTION
1. Add missing `mono_threads_wait_pending_operations` when suspending a BLOCKING thread using hybrid suspend.  There are now 4 possible `BeginSuspendResult` values - in the case of full coop suspend of a blocking thread we return `BeginSuspendOkNoWait` since there is nothing to do.

2. Fix deadlocks when using `MONO_CHECK_MODE=thread` if we call `CHECKED_BUILD_THREAD_TRANSITION` from a signal handler (as it happens, we do that for `finish_async_suspension`):
    * Use a ring buffer for state transition records instead of a `GPtrArray`
    * Add the option not to call `backtrace` (not async signal safe on Linux) - use it in `finish_async_suspension`.

Depends on #8261 
