### PR TITLE
[wasm] JS engine testing improvements.

### DIFF
--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -123,11 +123,11 @@ if [[ ${CI_TAGS} == *'webassembly'* ]];
 	   ${TESTCMD} --label=runtimes --timeout=60m --fatal make -j4 -C sdks/builds package-wasm-interp
 	   ${TESTCMD} --label=bcl --timeout=60m --fatal make -j4 -C sdks/builds package-bcl
 	   ${TESTCMD} --label=wasm-build --timeout=60m --fatal make -j4 -C sdks/wasm build
-	   ${TESTCMD} --label=mini-test --timeout=60m make -C sdks/wasm run-mini
+	   ${TESTCMD} --label=mini-test --timeout=60m make -C sdks/wasm run-all-mini
 	   #The following tests are not passing yet, so enabling them would make us perma-red
-	   #${TESTCMD} --label=mini-corlib --timeout=60m make -C sdks/wasm run-corlib
-	   #${TESTCMD} --label=mini-system --timeout=60m make -C sdks/wasm run-system
-	   ${TESTCMD} --label=mini-system-core --timeout=60m make -C sdks/wasm run-system-core
+	   #${TESTCMD} --label=mini-corlib --timeout=60m make -C sdks/wasm run-all-corlib
+	   #${TESTCMD} --label=mini-system --timeout=60m make -C sdks/wasm run-all-system
+	   ${TESTCMD} --label=mini-system-core --timeout=60m make -C sdks/wasm run-system-all-core
 	   ${TESTCMD} --label=package --timeout=60m make -C sdks/wasm package
 	   exit 0
 fi

--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -17,7 +17,8 @@ MINI_PATH=$(TOP)/mono/mini
 BCL_ASSEMBLIES= \
         mscorlib.dll    \
         System.dll      \
-        System.Core.dll
+        System.Core.dll	\
+        Mono.Security.dll
 
 DEPS_ASSEMBLIES= \
         nunitlite.dll

--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -129,13 +129,13 @@ build-managed: managed/nunitlite.dll managed/mini_tests.dll managed/main.exe man
 
 build: build-native build-managed
 
-CHACKA=~/.jsvu/ch
+CHAKRA=~/.jsvu/ch
 D8=~/.jsvu/v8
 JSC=~/.jsvu/jsc
 SM=~/.jsvu/sm
 
 run-ch-%: toolchain build
-	$(CHACKA) test.js -args $*
+	$(CHAKRA) test.js -args $*
 
 run-v8-%: toolchain build
 	$(D8) --expose_wasm test.js -- $*

--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -10,7 +10,6 @@ DRIVER_CONF=debug
 
 
 EMCC=source $(TOP)/sdks/builds/toolchains/emsdk/emsdk_env.sh && emcc
-D8=$(TOP)/sdks/wasm/v8/out.gn/x64.release/d8
 WASM_BCL_DIR=$(TOP)/sdks/out/bcl/wasm
 MANAGED_DEPLOY_DIR=$(TOP)/sdks/wasm/managed
 MINI_PATH=$(TOP)/mono/mini
@@ -50,22 +49,13 @@ MINI_TEST_SOURCES = $(patsubst %,$(MINI_PATH)/%,$(MINI_TEST_FILES))
 TEST_DEPS = $(patsubst %,managed/%,$(BCL_ASSEMBLIES)) managed/nunitlite.dll
 TEST_MCS_DEPS = $(patsubst %,-r:%, $(TEST_DEPS))
 
-
-.stamp-depot-tools:
-	rm -rf $(TOP)/sdks/wasm/depot_tools
-	git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git $(TOP)/sdks/wasm/depot_tools
-	touch $@
-
-.stamp-v8: .stamp-depot-tools
-	rm -rf $(TOP)/sdks/wasm/v8
-	rm -rf $(TOP)/sdks/wasm/.gclient*
-	cd $(TOP)/sdks/wasm/ && PATH=$(TOP)/sdks/wasm/depot_tools:$$PATH fetch v8
-	cd $(TOP)/sdks/wasm/v8 && tools/dev/v8gen.py -vv x64.release
-	cd $(TOP)/sdks/wasm/v8 && $(TOP)/sdks/wasm/depot_tools/ninja -C out.gn/x64.release
+.stamp-jsvu:
+	npm install jsvu -g
+	jsvu --engines=all
 	touch $@
 
 .PHONY: toolchain
-toolchain: .stamp-v8
+toolchain: .stamp-jsvu
 
 driver.o: driver.c
 	$(EMCC) -g -Os -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s BINARYEN=1 -s "BINARYEN_TRAP_MODE='clamp'" -s TOTAL_MEMORY=134217728 -s ALIASING_FUNCTION_POINTERS=0 driver.c -c -o driver.o
@@ -138,8 +128,28 @@ build-managed: managed/nunitlite.dll managed/mini_tests.dll managed/main.exe man
 
 build: build-native build-managed
 
-run-%: toolchain build
+CHACKA=~/.jsvu/ch
+D8=~/.jsvu/v8
+JSC=~/.jsvu/jsc
+SM=~/.jsvu/sm
+
+run-ch-%: toolchain build
+	$(CHACKA) test.js -args $*
+
+run-v8-%: toolchain build
 	$(D8) --expose_wasm test.js -- $*
+
+run-jsc-%: toolchain build
+	$(JSC) test.js -- $*
+
+run-sm-%: toolchain build
+	$(SM) test.js $*
+
+# Leaving JSC for now cuz it aborts when it encounters wasm
+run-all-%:
+	make -C . run-ch-$*
+	make -C . run-v8-$*
+	make -C . run-sm-$*
 
 clean:
 	

--- a/sdks/wasm/test.js
+++ b/sdks/wasm/test.js
@@ -56,7 +56,7 @@ var Module = {
 	},
 };
 
-var assemblies = [ "mscorlib.dll", "System.dll", "System.Core.dll", "main.exe", "nunitlite.dll", "mini_tests.dll", "wasm_corlib_test.dll", "wasm_System_test.dll", "wasm_System.Core_test.dll" ];
+var assemblies = [ "mscorlib.dll", "System.dll", "System.Core.dll", "Mono.Security.dll", "main.exe", "nunitlite.dll", "mini_tests.dll", "wasm_corlib_test.dll", "wasm_System_test.dll", "wasm_System.Core_test.dll" ];
 
 load ("mono.js");
 Module.finish_loading ();

--- a/sdks/wasm/test.js
+++ b/sdks/wasm/test.js
@@ -1,3 +1,24 @@
+//glue code to deal with the differences between ch, d8, jsc and sm.
+if (print == undefined)
+	print = console.log;
+
+if (console.warn === undefined)
+	console.warn = console.log;
+
+try {
+	arguments = WScript.Arguments;
+	exit = WScript.Quit;
+	load = WScript.LoadScriptFile;
+	read = WScript.LoadBinaryFile;
+} catch(e) {}
+
+try {
+	if (scriptArgs !== undefined)
+		arguments = scriptArgs;
+} catch(e) {}
+//end of all the nice shell glue code.
+
+
 function inspect_object (o){
     var r="";
     for(var p in o) {


### PR DESCRIPTION
This PR switch from manual compiling of V8 to using jsvu for engine provisioning.
Plus it adds jsc, ch and sm testing as it's all super easy now.

Finally, add ch and sm testing to CI as they work fine on OSX.

This PR might break CI as I'm not 100% we have node.js installed on the bots.