### PR TITLE
Fix Gdi+ WrongState exception type and remove incorrect test for GdiPlus status code

### DIFF
--- a/mcs/class/System.Drawing/System.Drawing/gdipFunctions.cs
+++ b/mcs/class/System.Drawing/System.Drawing/gdipFunctions.cs
@@ -253,7 +253,7 @@ namespace System.Drawing
 				throw new NotImplementedException (msg);
 			case Status.WrongState:
 				msg = Locale.GetText ("Object is not in a state that can allow this operation [GDI+ status: {0}]", status);
-				throw new ArgumentException (msg);
+				throw new InvalidOperationException (msg);
 			case Status.FontFamilyNotFound:
 				msg = Locale.GetText ("The requested FontFamily could not be found [GDI+ status: {0}]", status);
 				throw new ArgumentException (msg);

--- a/mcs/class/System.Drawing/Test/System.Drawing/GDIPlusTest.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/GDIPlusTest.cs
@@ -236,7 +236,6 @@ namespace MonoTests.System.Drawing {
 
 			Rectangle rect = new Rectangle (2, 2, 5, 5);
 			Assert.AreEqual (Status.Ok, GDIPlus.GdipBitmapLockBits (bmp, ref rect, ImageLockMode.ReadOnly, PixelFormat.Format24bppRgb, bd), "locked");
-			Assert.AreEqual (Status.Win32Error, GDIPlus.GdipBitmapLockBits (bmp, ref rect, ImageLockMode.ReadOnly, PixelFormat.Format24bppRgb, bd), "second lock");
 
 			Assert.AreEqual (rect.Width, bd.Width, "Width");
 			Assert.AreEqual (rect.Height, bd.Height, "Height");


### PR DESCRIPTION
This now matches the Windows behaviour: https://github.com/dotnet/corefx/blob/0eb5e7451028e9374b8bb03972aa945c128193e1/src/System.Drawing.Common/src/System/Drawing/Gdiplus.cs#L289-290

The exception code for locking an already locked bitmap is incorrect, as demonstrated here: https://github.com/dotnet/corefx/blob/ec22edc155aa13289770c9f49630cc7ab588fca4/src/System.Drawing.Common/src/System/Drawing/Bitmap.cs#L244-L248

This has been fixed in https://github.com/mono/libgdiplus/pull/367

@akoeplinger FYI