### PR TITLE
[mono-api-html] Fix markdown diff which was reversed

### DIFF
--- a/mcs/tools/mono-api-html/MarkdownFormatter.cs
+++ b/mcs/tools/mono-api-html/MarkdownFormatter.cs
@@ -188,8 +188,8 @@ namespace Xamarin.ApiDiff {
 		{
 			foreach (var line in apichange.Member.ToString ().Split ('\n')) {
 				if (line.Contains ("+++")) {
-					output.WriteLine ("-{0}", Clean (line, "---", "+++"));
-					output.WriteLine ("+{0}", Clean (line, "+++", "---"));
+					output.WriteLine ("-{0}", Clean (line, "+++", "---"));
+					output.WriteLine ("+{0}", Clean (line, "---", "+++"));
 				} else {
 					output.WriteLine (" {0}", line);
 				}


### PR DESCRIPTION
The previous code would produce

```diff
-public const string Version = "11.11.0";
+public const string Version = "11.9.1";
```

instead of

```diff
-public const string Version = "11.9.1";
+public const string Version = "11.11.0";
```

when diff are inlined. The addition and removal sections are fine.