### PR TITLE
[2018-04] [corlib] SynchronizationContext.Current does not work on non-root AppDomain on Android

### DIFF
--- a/mcs/class/corlib/System.Threading/WaitHandle.cs
+++ b/mcs/class/corlib/System.Threading/WaitHandle.cs
@@ -55,7 +55,9 @@ namespace System.Threading
 		static int WaitOneNative (SafeHandle waitableSafeHandle, uint millisecondsTimeout, bool hasThreadAffinity, bool exitContext)
 		{
 			bool release = false;
+#if !MONODROID
 			var context = SynchronizationContext.Current;
+#endif
 			try {
 				waitableSafeHandle.DangerousAddRef (ref release);
 
@@ -64,6 +66,7 @@ namespace System.Threading
 					SynchronizationAttribute.ExitContext ();
 #endif
 
+#if !MONODROID
 				// HACK: Documentation (and public posts by experts like Joe Duffy) suggests that
 				//  users must first call SetWaitNotificationRequired to flag that a given synchronization
 				//  context overrides .Wait. Because invoking the Wait method is somewhat expensive, we use
@@ -79,7 +82,9 @@ namespace System.Threading
 						false, 
 						(int)millisecondsTimeout
 					);
-				} else {
+				} else
+#endif
+				{
 					unsafe {
 						IntPtr handle = waitableSafeHandle.DangerousGetHandle ();
 						return Wait_internal (&handle, 1, false, (int)millisecondsTimeout);


### PR DESCRIPTION
Backport of #8291.

/cc @luhenry