### PR TITLE
Fix warning: function declaration isn’t a prototype () vs. (void).

### DIFF
--- a/mono/metadata/class-inlines.h
+++ b/mono/metadata/class-inlines.h
@@ -10,25 +10,25 @@
 #include <mono/metadata/tabledefs.h>
 
 static inline MonoType*
-mono_get_void_type ()
+mono_get_void_type (void)
 {
 	return m_class_get_byval_arg (mono_defaults.void_class);
 }
 
 static inline MonoType*
-mono_get_int32_type ()
+mono_get_int32_type (void)
 {
 	return m_class_get_byval_arg (mono_defaults.int32_class);
 }
 
 static inline MonoType*
-mono_get_int_type ()
+mono_get_int_type (void)
 {
 	return m_class_get_byval_arg (mono_defaults.int_class);
 }
 
 static inline MonoType*
-mono_get_object_type ()
+mono_get_object_type (void)
 {
 	return m_class_get_byval_arg (mono_defaults.object_class);
 }


### PR DESCRIPTION
 class-inlines.h:13:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  mono_get_void_type ()

In C: () means accept any parameters -- K&R unprototyped
      (void) is new-standardized-in-1989 form meaning accept no parameters
In C++ this is fixed and they mean the same thing -- accept no parameters.
To accept any parameters in C++, use (...), which is not valid in C, C requires
  at least one fixed parameter.

() is very rarely what you want in C, or in C++ headers consumable from C.

If you do need () for highly unusual code, for a function that accepts anything,
and has no fixed parameters, then use ifdef __cplusplus and ... for C++.

printf for example does not fit in this bucket because it always has the const char *format.

In fact, it is so rare because a variable-argument ("varargs") function would need *some* way to decide what is in "...".



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
