### PR TITLE
Fix mono_perfcounter_instance_exists to match prototype when #ifndef …

### DIFF
--- a/mono/metadata/mono-perfcounters.c
+++ b/mono/metadata/mono-perfcounters.c
@@ -1945,7 +1945,7 @@ mono_perfcounter_create (MonoString *category, MonoString *help, int type, MonoA
 	g_assert_not_reached ();
 }
 
-int
+MonoBoolean
 mono_perfcounter_instance_exists (MonoString *instance, MonoString *category)
 {
 	g_assert_not_reached ();


### PR DESCRIPTION
…DISABLE_PERFCOUNTERS.
