### PR TITLE
[2018-02] [corlib] Fix TimeZoneInfo.Local when /usr/share/zoneinfo is a symlink

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -266,11 +266,12 @@ namespace System
 			}
 		}
 #if LIBC
+		const string DefaultTimeZoneDirectory = "/usr/share/zoneinfo";
 		static string timeZoneDirectory;
 		static string TimeZoneDirectory {
 			get {
 				if (timeZoneDirectory == null)
-					timeZoneDirectory = "/usr/share/zoneinfo";
+					timeZoneDirectory = readlink (DefaultTimeZoneDirectory) ?? DefaultTimeZoneDirectory;
 				return timeZoneDirectory;
 			}
 			set {

--- a/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
@@ -124,8 +124,8 @@ namespace MonoTests.System
 				} catch (DllNotFoundException e) {
 					return;
 				}
-#if !MONOTOUCH && !XAMMAC && !XAMMAC_4_5
-				// this assumption is incorrect for iOS, tvO, watchOS and OSX
+#if !MONOTOUCH && !XAMMAC
+				// this assumption is incorrect for the TimeZoneInfo.MonoTouch.cs implementation (iOS, tvOS, watchOS and XamMac Modern)
 				Assert.IsTrue (TimeZoneInfo.Local.Id != "Local", "Local timezone id should not be \"Local\"");
 #endif
 			}


### PR DESCRIPTION
Backport of #8283.

/cc @akoeplinger