### PR TITLE
[sdks] Wrap configure to provide better output.

### DIFF
--- a/sdks/builds/runtime.mk
+++ b/sdks/builds/runtime.mk
@@ -50,7 +50,7 @@ __$(1)_CONFIGURE_ENVIRONMENT = \
 
 .stamp-$(1)-$$(CONFIGURATION)-configure: $$(TOP)/configure .stamp-$(1)-toolchain
 	mkdir -p $$(TOP)/sdks/builds/$(1)-$$(CONFIGURATION)
-	cd $$(TOP)/sdks/builds/$(1)-$$(CONFIGURATION) && $(if $$(_$(1)_PATH),PATH="$$$$PATH:$$(_$(1)_PATH)") $$(TOP)/configure $$(_$(1)_AC_VARS) $$(__$(1)_CONFIGURE_ENVIRONMENT) $$(_$(1)_CONFIGURE_FLAGS)
+	$(if $$(_$(1)_PATH),PATH="$$$$PATH:$$(_$(1)_PATH)") ./wrap-configure.sh $$(TOP)/sdks/builds/$(1)-$$(CONFIGURATION) $(abspath $(TOP)/configure) $$(_$(1)_AC_VARS) $$(__$(1)_CONFIGURE_ENVIRONMENT) $$(_$(1)_CONFIGURE_FLAGS)
 	touch $$@
 
 .PHONY: .stamp-$(1)-configure

--- a/sdks/builds/wrap-configure.sh
+++ b/sdks/builds/wrap-configure.sh
@@ -1,0 +1,57 @@
+#!/bin/bash -e
+
+START=$(date -u +"%s")
+
+# First argument is the directory where we'll execute configure
+# We assume the directory name is descriptive and use it in messages
+# and temporary file names.
+DIR="$1"
+D=$(basename "$DIR")
+shift
+
+# Check if a cache is being used
+if test -f "$D.config.cache"; then
+	HAS_CACHE=1
+fi
+
+mkdir -p "$D"
+echo "Configuring $D"
+cd "$DIR"
+
+# The rest of the arguments is the command to execute.
+#
+# We capture the output to a log (to make the output more quiet), and only
+# print it if something goes wrong (in which case we print config.log as well,
+# which can be quite useful when looking at configure problems on bots where
+# there's much information in that file).
+#
+# If a cache was used and configure failed, we remove the cache and then try
+# again.
+#
+if ! "$@" > ".stamp-configure-$D.log" 2>&1; then
+	FAILED=1
+	if [[ x"$HAS_CACHE" == "x1" ]]; then
+		echo "Configuring $D failed, but a cache was used. Will try to configure without the cache."
+		rm "../$D.config.cache"
+		if ! "$@" > ".stamp-configure-$D.log" 2>&1; then
+			echo "Configuring $D failed without cache as well."
+		else
+			FAILED=
+		fi
+	fi
+
+	if [[ x"$FAILED" == "x1" ]]; then
+		echo "Configuring $D failed:"
+		sed "s/^/    /" < ".stamp-configure-$D.log"
+		echo
+		echo "    *** config.log *** "
+		echo
+		sed "s/^/    /" < config.log
+		exit 1
+	fi
+fi
+
+END=$(date -u +"%s")
+DIFF=$((END-START))
+
+echo "Configured $D in $((DIFF/60))m $((DIFF%60))s"


### PR DESCRIPTION
Wrap configure in a script that:

* Captures stdout/stderr and only shows it in case of errors.
* If configure fails, and a cache file was used, deletes the cache file and
  tries again.
* If configure really fails, then print config.log in addition to
  stdout/stderr, since a lot of valuable diagnostic output is in that file
  (and it's annoying to track down configure failures on bots when the file
  with the important output has already been deleted).