### PR TITLE
[mini] fix some warnings with newer GCC

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -2509,7 +2509,7 @@ get_top_method_ji (gpointer ip, MonoDomain **domain, gpointer *out_ip)
 		MonoLMF *lmf = mono_get_lmf ();
 		MonoInterpFrameHandle *frame;
 
-		g_assert (((guint64)lmf->previous_lmf) & 2);
+		g_assert (((gsize)lmf->previous_lmf) & 2);
 		MonoLMFExt *ext = (MonoLMFExt*)lmf;
 
 		g_assert (ext->interp_exit);
@@ -4981,7 +4981,7 @@ process_breakpoint (DebuggerTlsData *tls, gboolean from_signal)
 		MonoLMF *lmf = mono_get_lmf ();
 		MonoInterpFrameHandle *frame;
 
-		g_assert (((guint64)lmf->previous_lmf) & 2);
+		g_assert (((gsize)lmf->previous_lmf) & 2);
 		MonoLMFExt *ext = (MonoLMFExt*)lmf;
 
 		g_assert (ext->interp_exit);

--- a/mono/mini/exceptions-x86.c
+++ b/mono/mini/exceptions-x86.c
@@ -843,7 +843,7 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 
 		return TRUE;
 	} else if (*lmf) {
-		g_assert ((((guint64)(*lmf)->previous_lmf) & 2) == 0);
+		g_assert ((((gsize)(*lmf)->previous_lmf) & 2) == 0);
 
 		if ((ji = mini_jit_info_table_find (domain, (gpointer)(*lmf)->eip, NULL))) {
 			frame->ji = ji;
@@ -865,7 +865,7 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 		frame->type = FRAME_TYPE_MANAGED_TO_NATIVE;
 
 		/* Check if we are in a trampoline LMF frame */
-		if ((guint32)((*lmf)->previous_lmf) & 1) {
+		if ((gsize)((*lmf)->previous_lmf) & 1) {
 			/* lmf->esp is set by the trampoline code */
 			new_ctx->esp = (*lmf)->esp;
 		}

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -255,7 +255,7 @@ ves_real_abort (int line, MonoMethod *mh,
 	g_print ("0x%04x %02x\n", ip-(const unsigned short *) header->code, *ip);
 	mono_metadata_free_mh (header);
 	if (sp > stack)
-		printf ("\t[%ld] 0x%08x %0.5f\n", sp-stack, sp[-1].data.i, sp[-1].data.f);
+		printf ("\t[%lld] 0x%08x %0.5f\n", (gint64) (sp - stack), sp[-1].data.i, sp[-1].data.f);
 }
 
 #define ves_abort() \

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -252,10 +252,8 @@ ves_real_abort (int line, MonoMethod *mh,
 	mono_error_cleanup (error); /* FIXME: don't swallow the error */
 	g_printerr ("Execution aborted in method: %s::%s\n", m_class_get_name (mh->klass), mh->name);
 	g_printerr ("Line=%d IP=0x%04lx, Aborted execution\n", line, ip-(const unsigned short *) header->code);
-	g_print ("0x%04x %02x\n", ip-(const unsigned short *) header->code, *ip);
+	g_printerr ("0x%04x %02x\n", ip-(const unsigned short *) header->code, *ip);
 	mono_metadata_free_mh (header);
-	if (sp > stack)
-		printf ("\t[%lld] 0x%08x %0.5f\n", (gint64) (sp - stack), sp[-1].data.i, sp[-1].data.f);
 }
 
 #define ves_abort() \

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -699,7 +699,7 @@ unwinder_unwind_frame (Unwinder *unwinder,
 
 		/* Process debugger invokes */
 		/* The DEBUGGER_INVOKE should be returned before the first interpreter frame for the invoke */
-		if (unwinder->last_frame_addr > (gsize)(*lmf)) {
+		if (unwinder->last_frame_addr > (gpointer)(*lmf)) {
 			if (((gsize)(*lmf)->previous_lmf) & 2) {
 				MonoLMFExt *ext = (MonoLMFExt*)(*lmf);
 				if (ext->debugger_invoke) {

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -384,7 +384,7 @@ arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 				   StackFrameInfo *frame)
 {
 	if (!ji && *lmf) {
-		if (((guint64)(*lmf)->previous_lmf) & 2) {
+		if (((gsize)(*lmf)->previous_lmf) & 2) {
 			MonoLMFExt *ext = (MonoLMFExt*)(*lmf);
 
 			memset (frame, 0, sizeof (StackFrameInfo));
@@ -406,7 +406,7 @@ arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 				g_assert_not_reached ();
 			}
 
-			*lmf = (MonoLMF *)(((guint64)(*lmf)->previous_lmf) & ~3);
+			*lmf = (MonoLMF *)(((gsize)(*lmf)->previous_lmf) & ~3);
 
 			return TRUE;
 		}
@@ -699,11 +699,11 @@ unwinder_unwind_frame (Unwinder *unwinder,
 
 		/* Process debugger invokes */
 		/* The DEBUGGER_INVOKE should be returned before the first interpreter frame for the invoke */
-		if (unwinder->last_frame_addr > (gpointer)(*lmf)) {
-			if (((guint64)(*lmf)->previous_lmf) & 2) {
+		if (unwinder->last_frame_addr > (gsize)(*lmf)) {
+			if (((gsize)(*lmf)->previous_lmf) & 2) {
 				MonoLMFExt *ext = (MonoLMFExt*)(*lmf);
 				if (ext->debugger_invoke) {
-					*lmf = (MonoLMF *)(((guint64)(*lmf)->previous_lmf) & ~7);
+					*lmf = (MonoLMF *)(((gsize)(*lmf)->previous_lmf) & ~7);
 					frame->type = FRAME_TYPE_DEBUGGER_INVOKE;
 					return TRUE;
 				}

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -74,9 +74,6 @@ static mono_mutex_t mini_arch_mutex;
 
 #define OP_SEQ_POINT_BP_OFFSET 7
 
-static guint8*
-emit_load_aotconst (guint8 *start, guint8 *code, MonoCompile *cfg, MonoJumpInfo **ji, int dreg, int tramp_type, gconstpointer target);
-
 const char*
 mono_arch_regname (int reg)
 {
@@ -6341,17 +6338,6 @@ mono_arch_emit_load_got_addr (guint8 *start, guint8 *code, MonoCompile *cfg, Mon
 	x86_pop_reg (code, MONO_ARCH_GOT_REG);
 	x86_alu_reg_imm (code, X86_ADD, MONO_ARCH_GOT_REG, 0xf0f0f0f0);
 
-	return code;
-}
-
-static guint8*
-emit_load_aotconst (guint8 *start, guint8 *code, MonoCompile *cfg, MonoJumpInfo **ji, int dreg, int tramp_type, gconstpointer target)
-{
-	if (cfg)
-		mono_add_patch_info (cfg, code - cfg->native_code, tramp_type, target);
-	else
-		g_assert_not_reached ();
-	x86_mov_reg_membase (code, dreg, MONO_ARCH_GOT_REG, 0xf0f0f0f0, 4);
 	return code;
 }
 

--- a/mono/mini/mini-x86.h
+++ b/mono/mini/mini-x86.h
@@ -138,7 +138,7 @@ struct MonoLMF {
 	 * If the second lowest bit is set to 1, then this is a MonoLMFExt structure, and
 	 * the other fields are not valid.
 	 */
-	guint32    previous_lmf;
+	gpointer    previous_lmf;
 	gpointer    lmf_addr;
 	/* Only set in trampoline LMF frames */
 	MonoMethod *method;

--- a/mono/mini/trace.c
+++ b/mono/mini/trace.c
@@ -143,7 +143,9 @@ mono_trace_enter_method (MonoMethod *method, char *ebp)
 	g_free (fname);
 
 	if (!ebp) {
+#pragma GCC diagnostic ignored "-Wframe-address"
 		printf (") ip: %p\n", MONO_RETURN_ADDRESS_N (1));
+#pragma GCC diagnostic pop
 		goto unlock;
 	}
 

--- a/mono/mini/tramp-x86.c
+++ b/mono/mini/tramp-x86.c
@@ -165,17 +165,6 @@ get_vcall_slot (guint8 *code, mgreg_t *regs, int *displacement)
 	return (gpointer)regs [reg];
 }
 
-static gpointer*
-get_vcall_slot_addr (guint8* code, mgreg_t *regs)
-{
-	gpointer vt;
-	int displacement;
-	vt = get_vcall_slot (code, regs, &displacement);
-	if (!vt)
-		return NULL;
-	return (gpointer*)((char*)vt + displacement);
-}
-
 guchar*
 mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInfo **info, gboolean aot)
 {

--- a/mono/mini/tramp-x86.c
+++ b/mono/mini/tramp-x86.c
@@ -140,31 +140,6 @@ mono_arch_patch_plt_entry (guint8 *code, gpointer *got, mgreg_t *regs, guint8 *a
 	*(guint8**)((guint8*)got + offset) = addr;
 }
 
-static gpointer
-get_vcall_slot (guint8 *code, mgreg_t *regs, int *displacement)
-{
-	const int kBufSize = 8;
-	guint8 buf [64];
-	guint8 reg = 0;
-	gint32 disp = 0;
-
-	mono_breakpoint_clean_code (NULL, code, kBufSize, buf, kBufSize);
-	code = buf + 8;
-
-	*displacement = 0;
-
-	if ((code [0] == 0xff) && ((code [1] & 0x18) == 0x10) && ((code [1] >> 6) == 2)) {
-		reg = code [1] & 0x07;
-		disp = *((gint32*)(code + 2));
-	} else {
-		g_assert_not_reached ();
-		return NULL;
-	}
-
-	*displacement = disp;
-	return (gpointer)regs [reg];
-}
-
 guchar*
 mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInfo **info, gboolean aot)
 {


### PR DESCRIPTION
[interp] remove unnecessary code

[monolmf/x86] make int cast dependend one machine word size

```
In file included from debugger-agent.c:36:0:
debugger-agent.c: In function ‘get_top_method_ji’:
debugger-agent.c:2501:14: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
   g_assert (((guint64)lmf->previous_lmf) & 2);
              ^
../../mono/eglib/glib.h:710:46: note: in definition of macro ‘G_UNLIKELY’
 #define G_UNLIKELY(expr) (__builtin_expect ((expr) != 0, 0))
                                              ^~~~
debugger-agent.c:2501:3: note: in expansion of macro ‘g_assert’
   g_assert (((guint64)lmf->previous_lmf) & 2);
   ^~~~~~~~
```

[mini-x86] change previous_lmf to pointer type (same as amd64)

```
mini-runtime.c: In function ‘mono_push_lmf’:
mini-runtime.c:806:24: warning: assignment makes integer from pointer without a cast [-Wint-conversion]
  ext->lmf.previous_lmf = *lmf_addr;
                        ^
mini-runtime.c:808:24: warning: assignment makes integer from pointer without a cast [-Wint-conversion]
  ext->lmf.previous_lmf = (gpointer)(((gssize)ext->lmf.previous_lmf) | 2);
                        ^
mini-exceptions.c: In function ‘arch_unwind_frame’:
mini-exceptions.c:420:11: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
    *lmf = (MonoLMF *)(((guint64)(*lmf)->previous_lmf) & ~3);
           ^
mini-exceptions.c: In function ‘unwinder_unwind_frame’:
mini-exceptions.c:715:13: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
      *lmf = (MonoLMF *)(((guint64)(*lmf)->previous_lmf) & ~7);
             ^
```

[tramp-x86] remove unused function

```
tramp-x86.c:146:1: warning: ‘get_vcall_slot’ defined but not used [-Wunused-function]
 get_vcall_slot (guint8 *code, mgreg_t *regs, int *displacement)
  ^~~~~~~~~~~~~~
```


[mini-x86] remove unused function

```
mini-x86.c:6327:1: warning: ‘emit_load_aotconst’ defined but not used [-Wunused-function]
 emit_load_aotconst (guint8 *start, guint8 *code, MonoCompile *cfg, MonoJumpInfo **ji, int dreg, int tramp_type, gconstpointer target)
 ^~~~~~~~~~~~~~~~~~
```

[tramp-x86] remove unused function

```
tramp-x86.c:171:1: warning: ‘get_vcall_slot_addr’ defined but not used [-Wunused-function]
 get_vcall_slot_addr (guint8* code, mgreg_t *regs)
 ^~~~~~~~~~~~~~~~~~~
```

[mini] ignore GCC warning in trace.c

```
trace.c: In function ‘mono_trace_enter_method’:
trace.c:145:3: warning: calling ‘__builtin_return_address’ with a nonzero argument is unsafe [-Wframe-address]
   printf (") ip: %p\n", MONO_RETURN_ADDRESS_N (1));
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

[interp] fix warning

```
interp/interp.c: In function ‘ves_real_abort’:
interp/interp.c:251:17: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 2 has type ‘int’ [-Wformat=]
   printf ("\t[%ld] 0x%08x %0.5f\n", sp-stack, sp[-1].data.i, sp[-1].data.f);
               ~~^                   ~~~~~~~~
               %d
```