### PR TITLE
[Tailcall] Remove confusing outdated references to OP_JMP.

### DIFF
--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -6675,9 +6675,6 @@ mono_arch_emit_epilog (MonoCompile *cfg)
 		cfg->stat_code_reallocs++;
 	}
 
-	/*
-	 * Keep in sync with OP_JMP
-	 */
 	code = cfg->native_code + cfg->code_len;
 
 	/* Save the uwind state which is needed by the out-of-line code */

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -5329,9 +5329,6 @@ mono_arch_emit_epilog (MonoCompile *cfg)
 		cfg->stat_code_reallocs++;
 	}
 
-	/*
-	 * Keep in sync with OP_JMP
-	 */
 	code = cfg->native_code + cfg->code_len;
 
 	if (mono_jit_trace_calls != NULL && mono_trace_eval (method)) {


### PR DESCRIPTION
These architectures do not implement OP_JMP.
I go looking for the code to keep in sync and it isn't there. Replaced by OP_TAILCALL, etc.