### PR TITLE
[runtime] Handle failed classes in mono_type_get_checked ().

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -2603,8 +2603,12 @@ mono_type_get_checked (MonoImage *image, guint32 type_token, MonoGenericContext 
 	if ((type_token & 0xff000000) != MONO_TOKEN_TYPE_SPEC) {
 		MonoClass *klass = mono_class_get_checked (image, type_token, error);
 
-		if (!klass || m_class_has_failure (klass))
+		if (!klass)
 			return NULL;
+		if (m_class_has_failure (klass)) {
+			mono_error_set_for_class_failure (error, klass);
+			return NULL;
+		}
 		return mono_class_get_type (klass);
 	}
 

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -2603,7 +2603,7 @@ mono_type_get_checked (MonoImage *image, guint32 type_token, MonoGenericContext 
 	if ((type_token & 0xff000000) != MONO_TOKEN_TYPE_SPEC) {
 		MonoClass *klass = mono_class_get_checked (image, type_token, error);
 
-		if (!klass || klass->has_failure)
+		if (!klass || m_class_has_failure (klass))
 			return NULL;
 		return mono_class_get_type (klass);
 	}

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -2603,11 +2603,8 @@ mono_type_get_checked (MonoImage *image, guint32 type_token, MonoGenericContext 
 	if ((type_token & 0xff000000) != MONO_TOKEN_TYPE_SPEC) {
 		MonoClass *klass = mono_class_get_checked (image, type_token, error);
 
-		if (!klass) {
+		if (!klass || klass->has_failure)
 			return NULL;
-		}
-
-		g_assert (klass);
 		return mono_class_get_type (klass);
 	}
 


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/8311.