### PR TITLE
[loader] Add loader contexts

### DIFF
--- a/mcs/class/corlib/System.Reflection/Assembly.cs
+++ b/mcs/class/corlib/System.Reflection/Assembly.cs
@@ -531,6 +531,9 @@ namespace System.Reflection {
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		private extern static Assembly LoadFrom (String assemblyFile, bool refonly);
 
+		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		private extern static Assembly LoadFile_internal (String assemblyFile);
+
 		public static Assembly LoadFrom (String assemblyFile)
 		{
 			return LoadFrom (assemblyFile, false);
@@ -575,8 +578,11 @@ namespace System.Reflection {
 				throw new ArgumentNullException ("path");
 			if (path == String.Empty)
 				throw new ArgumentException ("Path can't be empty", "path");
-			// FIXME: Make this do the right thing
-			return LoadFrom (path, securityEvidence);
+			Assembly a = LoadFile_internal (path);
+			if (a != null && securityEvidence != null) {
+				throw new NotImplementedException ();
+			}
+			return a;
 		}
 
 		public static Assembly LoadFile (String path)

--- a/mono/dis/main.c
+++ b/mono/dis/main.c
@@ -1854,7 +1854,7 @@ try_load_from (MonoAssembly **assembly,
 	*assembly = NULL;
 	fullpath = g_build_filename (path1, path2, path3, path4, NULL);
 	if (g_file_test (fullpath, G_FILE_TEST_IS_REGULAR))
-		*assembly = mono_assembly_open_predicate (fullpath, refonly, FALSE, predicate, user_data, NULL);
+		*assembly = mono_assembly_open_predicate (fullpath, refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT, predicate, user_data, NULL);
 
 	g_free (fullpath);
 	return (*assembly != NULL);

--- a/mono/metadata/appdomain-icalls.h
+++ b/mono/metadata/appdomain-icalls.h
@@ -56,6 +56,10 @@ ves_icall_System_AppDomain_GetAssemblies           (MonoAppDomainHandle ad,
 						    MonoError *error);
 
 MonoReflectionAssemblyHandle
+ves_icall_System_Reflection_Assembly_LoadFile_internal (MonoStringHandle fname,
+							MonoError *error);
+
+MonoReflectionAssemblyHandle
 ves_icall_System_Reflection_Assembly_LoadFrom      (MonoStringHandle fname,
 						    MonoBoolean refonly,
 						    MonoError *error);

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2156,6 +2156,37 @@ mono_domain_assembly_preload (MonoAssemblyName *aname,
 	return result;
 }
 
+/**
+ * mono_assembly_load_from_assemblies_path:
+ *
+ * \param assemblies_path directories to search for given assembly name, terminated by NULL
+ * \param aname assembly name to look for
+ * \param asmctx assembly load context for this load operation
+ *
+ * Given a NULL-terminated array of paths, look for \c name.ext, \c name, \c
+ * culture/name.ext, \c culture/name/name.ext where \c ext is \c dll and \c
+ * exe and try to load it in the given assembly load context.
+ *
+ * \returns A \c MonoAssembly if probing was successful, or NULL otherwise.
+ */
+MonoAssembly*
+mono_assembly_load_from_assemblies_path (gchar **assemblies_path, MonoAssemblyName *aname, MonoAssemblyContextKind asmctx)
+{
+	MonoAssemblyCandidatePredicate predicate = NULL;
+	void* predicate_ud = NULL;
+#if !defined(DISABLE_DESKTOP_LOADER)
+	if (G_LIKELY (mono_loader_get_strict_strong_names ())) {
+		predicate = &mono_assembly_candidate_predicate_sn_same_name;
+		predicate_ud = aname;
+	}
+#endif
+	MonoAssembly *result = NULL;
+	if (assemblies_path && assemblies_path[0] != NULL) {
+		result = real_load (assemblies_path, aname->culture, aname->name, asmctx, predicate, predicate_ud);
+	}
+	return result;
+}
+
 /*
  * Check whenever a given assembly was already loaded in the current appdomain.
  */

--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -9,26 +9,33 @@
 #include <glib.h>
 
 #include <mono/metadata/assembly.h>
+#include <mono/metadata/metadata-internals.h>
 
 MONO_API MonoImage*    mono_assembly_load_module_checked (MonoAssembly *assembly, uint32_t idx, MonoError *error);
 
-MonoAssembly * mono_assembly_open_a_lot (const char *filename, MonoImageOpenStatus *status, gboolean refonly, gboolean load_from_context);
+MonoAssembly * mono_assembly_open_a_lot (const char *filename, MonoImageOpenStatus *status, MonoAssemblyContextKind asmctx);
+
+MonoAssembly* mono_assembly_load_full_nosearch (MonoAssemblyName *aname, 
+						const char       *basedir,
+						MonoAssemblyContextKind asmctx,
+						MonoImageOpenStatus *status);
+
 
 /* If predicate returns true assembly should be loaded, if false ignore it. */
 typedef gboolean (*MonoAssemblyCandidatePredicate)(MonoAssembly *, gpointer);
 
 MonoAssembly*          mono_assembly_open_predicate (const char *filename,
-						     gboolean refonly,
-						     gboolean load_from_context,
+						     MonoAssemblyContextKind asmctx,
 						     MonoAssemblyCandidatePredicate pred,
 						     gpointer user_data,
 						     MonoImageOpenStatus *status);
 
 MonoAssembly*          mono_assembly_load_from_predicate (MonoImage *image, const char *fname,
-							  gboolean refonly,
+							  MonoAssemblyContextKind asmctx,
 							  MonoAssemblyCandidatePredicate pred,
 							  gpointer user_data,
 							  MonoImageOpenStatus *status);
+
 
 /* MonoAssemblyCandidatePredicate that compares the assembly name (name, version,
  * culture, public key token) of the candidate with the wanted name, if the

--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -48,4 +48,7 @@ mono_assembly_candidate_predicate_sn_same_name (MonoAssembly *candidate, gpointe
 MonoAssembly*
 mono_assembly_binding_applies_to_image (MonoImage* image, MonoImageOpenStatus *status);
 
+MonoAssembly*
+mono_assembly_load_from_assemblies_path (gchar **assemblies_path, MonoAssemblyName *aname, MonoAssemblyContextKind asmctx);
+
 #endif /* __MONO_METADATA_ASSEMBLY_INTERNALS_H__ */

--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -45,4 +45,7 @@ MonoAssembly*          mono_assembly_load_from_predicate (MonoImage *image, cons
 gboolean
 mono_assembly_candidate_predicate_sn_same_name (MonoAssembly *candidate, gpointer wanted_name);
 
+MonoAssembly*
+mono_assembly_binding_applies_to_image (MonoImage* image, MonoImageOpenStatus *status);
+
 #endif /* __MONO_METADATA_ASSEMBLY_INTERNALS_H__ */

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -353,7 +353,7 @@ static GENERATE_TRY_GET_CLASS_WITH_CACHE (internals_visible, "System.Runtime.Com
 static MonoAssembly*
 mono_assembly_invoke_search_hook_internal (MonoAssemblyName *aname, MonoAssembly *requesting, gboolean refonly, gboolean postload);
 static MonoAssembly*
-mono_assembly_load_full_internal (MonoAssemblyName *aname, MonoAssembly *requesting, const char *basedir, MonoImageOpenStatus *status, gboolean refonly);
+mono_assembly_load_full_internal (MonoAssemblyName *aname, MonoAssembly *requesting, const char *basedir, MonoAssemblyContextKind asmctx, MonoImageOpenStatus *status);
 static MonoBoolean
 mono_assembly_is_in_gac (const gchar *filanem);
 
@@ -700,7 +700,7 @@ assembly_names_compare_versions (MonoAssemblyName *l, MonoAssemblyName *r, int m
 }
 
 static MonoAssembly *
-load_in_path (const char *basename, const char** search_path, MonoImageOpenStatus *status, MonoBoolean refonly, MonoAssemblyCandidatePredicate predicate, gpointer user_data)
+load_in_path (const char *basename, const char** search_path, MonoImageOpenStatus *status, MonoAssemblyContextKind asmctx, MonoAssemblyCandidatePredicate predicate, gpointer user_data)
 {
 	int i;
 	char *fullpath;
@@ -708,7 +708,7 @@ load_in_path (const char *basename, const char** search_path, MonoImageOpenStatu
 
 	for (i = 0; search_path [i]; ++i) {
 		fullpath = g_build_filename (search_path [i], basename, NULL);
-		result = mono_assembly_open_predicate (fullpath, refonly, FALSE, predicate, user_data, status);
+		result = mono_assembly_open_predicate (fullpath, asmctx, predicate, user_data, status);
 		g_free (fullpath);
 		if (result)
 			return result;
@@ -1371,7 +1371,7 @@ load_reference_by_aname_refonly_asmctx (MonoAssemblyName *aname, MonoAssembly *a
 	{
 		/* We use the loaded corlib */
 		if (!strcmp (aname->name, "mscorlib"))
-			reference = mono_assembly_load_full_internal (aname, assm, assm->basedir, status, FALSE);
+			reference = mono_assembly_load_full_internal (aname, assm, assm->basedir, MONO_ASMCTX_DEFAULT, status);
 		else {
 			reference = mono_assembly_loaded_full (aname, TRUE);
 			if (!reference)
@@ -1401,10 +1401,35 @@ load_reference_by_aname_default_asmctx (MonoAssemblyName *aname, MonoAssembly *a
 		 * The second load attempt has the basedir set to keep compatibility with the old mono behavior, for
 		 * example bug-349190.2.cs and who knows how much more code in the wild.
 		 */
-		reference = mono_assembly_load_full_internal (aname, assm, NULL, status, FALSE);
+		reference = mono_assembly_load_full_internal (aname, assm, NULL, MONO_ASMCTX_DEFAULT, status);
 		if (!reference && assm)
-			reference = mono_assembly_load_full_internal (aname, assm, assm->basedir, status, FALSE);
+			reference = mono_assembly_load_full_internal (aname, assm, assm->basedir, MONO_ASMCTX_DEFAULT, status);
 	}
+	return reference;
+}
+
+static MonoAssembly*
+load_reference_by_aname_loadfrom_asmctx (MonoAssemblyName *aname, MonoAssembly *requesting, MonoImageOpenStatus *status)
+{
+	MonoAssembly *reference = NULL;
+	/* Just like default search, but look in the requesting assembly basedir right away */
+	reference = mono_assembly_load_full_internal (aname, requesting, requesting->basedir, MONO_ASMCTX_LOADFROM, status);
+	return reference;
+
+}
+
+static MonoAssembly*
+load_reference_by_aname_individual_asmctx (MonoAssemblyName *aname, MonoAssembly *requesting, MonoImageOpenStatus *status)
+{
+	MonoAssembly *reference = NULL;
+	*status = MONO_IMAGE_OK;
+	/* For an individual assembly, all references must already be loaded or
+	 * else we fire the assembly resolve event - similar to refonly */
+	reference = mono_assembly_loaded_full (aname, FALSE);
+	if (!reference)
+		reference = mono_assembly_invoke_search_hook_internal (aname, requesting, FALSE, TRUE);
+	if (!reference)
+		reference = (MonoAssembly*)REFERENCE_MISSING;
 	return reference;
 }
 
@@ -1445,8 +1470,10 @@ mono_assembly_load_reference (MonoImage *image, int index)
 			reference = load_reference_by_aname_refonly_asmctx (&aname, image->assembly, &status);
 			break;
 		case MONO_ASMCTX_LOADFROM:
+			reference = load_reference_by_aname_loadfrom_asmctx (&aname, image->assembly, &status);
+			break;
 		case MONO_ASMCTX_INDIVIDUAL:
-			g_assert_not_reached ();
+			reference = load_reference_by_aname_individual_asmctx (&aname, image->assembly, &status);
 			break;
 		default:
 			g_error ("Unexpected assembly load context kind %d for image %s.", mono_asmctx_get_kind (&image->assembly->context), image->name);
@@ -1920,18 +1947,17 @@ mono_assembly_open_from_bundle (const char *filename, MonoImageOpenStatus *statu
 MonoAssembly *
 mono_assembly_open_full (const char *filename, MonoImageOpenStatus *status, gboolean refonly)
 {
-	return mono_assembly_open_a_lot (filename, status, refonly, FALSE);
+	return mono_assembly_open_a_lot (filename, status, refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT);
 }
 
 MonoAssembly *
-mono_assembly_open_a_lot (const char *filename, MonoImageOpenStatus *status, gboolean refonly, gboolean load_from_context)
+mono_assembly_open_a_lot (const char *filename, MonoImageOpenStatus *status, MonoAssemblyContextKind asmctx)
 {
-	return mono_assembly_open_predicate (filename, refonly, load_from_context, NULL, NULL, status);
+	return mono_assembly_open_predicate (filename, asmctx, NULL, NULL, status);
 }
 
 MonoAssembly *
-mono_assembly_open_predicate (const char *filename, gboolean refonly,
-			      gboolean load_from_context,
+mono_assembly_open_predicate (const char *filename, MonoAssemblyContextKind asmctx,
 			      MonoAssemblyCandidatePredicate predicate,
 			      gpointer user_data,
 			      MonoImageOpenStatus *status)
@@ -2003,6 +2029,14 @@ mono_assembly_open_predicate (const char *filename, gboolean refonly,
 	
 	image = NULL;
 
+	const gboolean refonly = asmctx == MONO_ASMCTX_REFONLY;
+	/* for LoadFrom(string), LoadFile(string) and Load(byte[]), allow them
+	 * to load problematic images.  Not sure if ReflectionOnlyLoad(string)
+	 * and ReflectionOnlyLoadFrom(string) should also be allowed - let's
+	 * say, yes.
+	 */
+	const gboolean load_from_context = asmctx == MONO_ASMCTX_LOADFROM || asmctx == MONO_ASMCTX_INDIVIDUAL || asmctx == MONO_ASMCTX_REFONLY;
+
 	// If VM built with mkbundle
 	loaded_from_bundle = FALSE;
 	if (bundles != NULL) {
@@ -2041,7 +2075,7 @@ mono_assembly_open_predicate (const char *filename, gboolean refonly,
 		}
 	}
 
-	ass = mono_assembly_load_from_predicate (image, fname, refonly, predicate, user_data, status);
+	ass = mono_assembly_load_from_predicate (image, fname, asmctx, predicate, user_data, status);
 
 	if (ass) {
 		if (!loaded_from_bundle)
@@ -2228,7 +2262,7 @@ mono_assembly_has_reference_assembly_attribute (MonoAssembly *assembly, MonoErro
 MonoAssembly *
 mono_assembly_open (const char *filename, MonoImageOpenStatus *status)
 {
-	return mono_assembly_open_predicate (filename, FALSE, FALSE, NULL, NULL, status);
+	return mono_assembly_open_predicate (filename, MONO_ASMCTX_DEFAULT, NULL, NULL, status);
 }
 
 /**
@@ -2254,12 +2288,12 @@ MonoAssembly *
 mono_assembly_load_from_full (MonoImage *image, const char*fname, 
 			      MonoImageOpenStatus *status, gboolean refonly)
 {
-	return mono_assembly_load_from_predicate (image, fname, refonly, NULL, NULL, status);
+	return mono_assembly_load_from_predicate (image, fname, refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT, NULL, NULL, status);
 }
 
 MonoAssembly *
 mono_assembly_load_from_predicate (MonoImage *image, const char *fname,
-				   gboolean refonly,
+				   MonoAssemblyContextKind asmctx,
 				   MonoAssemblyCandidatePredicate predicate,
 				   gpointer user_data,
 				   MonoImageOpenStatus *status)
@@ -2296,7 +2330,7 @@ mono_assembly_load_from_predicate (MonoImage *image, const char *fname,
 	 */
 	ass = g_new0 (MonoAssembly, 1);
 	ass->basedir = base_dir;
-	ass->context.ref_only = refonly;
+	ass->context.kind = asmctx;
 	ass->image = image;
 
 	MONO_PROFILER_RAISE (assembly_loading, (ass));
@@ -2322,7 +2356,7 @@ mono_assembly_load_from_predicate (MonoImage *image, const char *fname,
 	 * assemblies lock.
 	 */
 	if (ass->aname.name) {
-		ass2 = mono_assembly_invoke_search_hook_internal (&ass->aname, NULL, refonly, FALSE);
+		ass2 = mono_assembly_invoke_search_hook_internal (&ass->aname, NULL, asmctx == MONO_ASMCTX_REFONLY, FALSE);
 		if (ass2) {
 			g_free (ass);
 			g_free (base_dir);
@@ -2339,7 +2373,7 @@ mono_assembly_load_from_predicate (MonoImage *image, const char *fname,
 	 * this image and we won't be able to look for a different
 	 * candidate. */
 
-	if (!refonly) {
+	if (asmctx != MONO_ASMCTX_REFONLY) {
 		ERROR_DECL_VALUE (refasm_error);
 		if (mono_assembly_has_reference_assembly_attribute (ass, &refasm_error)) {
 			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Image for assembly '%s' (%s) has ReferenceAssemblyAttribute, skipping", ass->aname.name, image->name);
@@ -2974,7 +3008,7 @@ probe_for_partial_name (const char *basepath, const char *fullname, MonoAssembly
 	if (fullpath == NULL)
 		return NULL;
 	else {
-		MonoAssembly *res = mono_assembly_open_predicate (fullpath, FALSE, FALSE, NULL, NULL, status);
+		MonoAssembly *res = mono_assembly_open_predicate (fullpath, MONO_ASMCTX_DEFAULT, NULL, NULL, status);
 		g_free (fullpath);
 		return res;
 	}
@@ -3505,11 +3539,13 @@ mono_assembly_load_from_gac (MonoAssemblyName *aname,  gchar *filename, MonoImag
 	g_free (version);
 	g_free (culture);
 
+	const MonoAssemblyContextKind asmctx = refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT;
+
 	if (extra_gac_paths) {
 		paths = extra_gac_paths;
 		while (!result && *paths) {
 			fullpath = g_build_path (G_DIR_SEPARATOR_S, *paths, "lib", "mono", "gac", subpath, NULL);
-			result = mono_assembly_open_predicate (fullpath, refonly, FALSE, NULL, NULL, status);
+			result = mono_assembly_open_predicate (fullpath, asmctx, NULL, NULL, status);
 			g_free (fullpath);
 			paths++;
 		}
@@ -3523,7 +3559,7 @@ mono_assembly_load_from_gac (MonoAssemblyName *aname,  gchar *filename, MonoImag
 
 	fullpath = g_build_path (G_DIR_SEPARATOR_S, mono_assembly_getrootdir (),
 			"mono", "gac", subpath, NULL);
-	result = mono_assembly_open_predicate (fullpath, refonly, FALSE, NULL, NULL, status);
+	result = mono_assembly_open_predicate (fullpath, asmctx, NULL, NULL, status);
 	g_free (fullpath);
 
 	if (result)
@@ -3555,7 +3591,7 @@ mono_assembly_load_corlib (const MonoRuntimeInfo *runtime, MonoImageOpenStatus *
 
 	// This unusual directory layout can occur if mono is being built and run out of its own source repo
 	if (assemblies_path) { // Custom assemblies path set via MONO_PATH or mono_set_assemblies_path
-		corlib = load_in_path ("mscorlib.dll", (const char**)assemblies_path, status, FALSE, NULL, NULL);
+		corlib = load_in_path ("mscorlib.dll", (const char**)assemblies_path, status, MONO_ASMCTX_DEFAULT, NULL, NULL);
 		if (corlib)
 			goto return_corlib_and_facades;
 	}
@@ -3563,13 +3599,13 @@ mono_assembly_load_corlib (const MonoRuntimeInfo *runtime, MonoImageOpenStatus *
 	/* Normal case: Load corlib from mono/<version> */
 	corlib_file = g_build_filename ("mono", runtime->framework_version, "mscorlib.dll", NULL);
 	if (assemblies_path) { // Custom assemblies path
-		corlib = load_in_path (corlib_file, (const char**)assemblies_path, status, FALSE, NULL, NULL);
+		corlib = load_in_path (corlib_file, (const char**)assemblies_path, status, MONO_ASMCTX_DEFAULT, NULL, NULL);
 		if (corlib) {
 			g_free (corlib_file);
 			goto return_corlib_and_facades;
 		}
 	}
-	corlib = load_in_path (corlib_file, default_path, status, FALSE, NULL, NULL);
+	corlib = load_in_path (corlib_file, default_path, status, MONO_ASMCTX_DEFAULT, NULL, NULL);
 	g_free (corlib_file);
 
 return_corlib_and_facades:
@@ -3674,9 +3710,10 @@ framework_assembly_sn_match (MonoAssemblyName *wanted_name, MonoAssemblyName *ca
 
 MonoAssembly*
 mono_assembly_load_full_nosearch (MonoAssemblyName *aname, 
-								  const char       *basedir, 
-								  MonoImageOpenStatus *status,
-								  gboolean refonly)
+				  const char *basedir, 
+				  MonoAssemblyContextKind asmctx,
+				  MonoImageOpenStatus *status)
+
 {
 	MonoAssembly *result;
 	char *fullpath, *filename;
@@ -3688,10 +3725,12 @@ mono_assembly_load_full_nosearch (MonoAssemblyName *aname,
 
 	aname = mono_assembly_remap_version (aname, &maped_aname);
 
+	const gboolean refonly = asmctx == MONO_ASMCTX_REFONLY;
+
 	/* Reflection only assemblies don't get assembly binding */
 	if (!refonly)
 		aname = mono_assembly_apply_binding (aname, &maped_name_pp);
-	
+
 	result = mono_assembly_loaded_full (aname, refonly);
 	if (result)
 		return result;
@@ -3737,7 +3776,7 @@ mono_assembly_load_full_nosearch (MonoAssemblyName *aname,
 
 		if (basedir) {
 			fullpath = g_build_filename (basedir, filename, NULL);
-			result = mono_assembly_open_predicate (fullpath, refonly, FALSE, predicate, predicate_ud, status);
+			result = mono_assembly_open_predicate (fullpath, asmctx, predicate, predicate_ud, status);
 			g_free (fullpath);
 			if (result) {
 				result->in_gac = FALSE;
@@ -3746,7 +3785,7 @@ mono_assembly_load_full_nosearch (MonoAssemblyName *aname,
 			}
 		}
 
-		result = load_in_path (filename, default_path, status, refonly, predicate, predicate_ud);
+		result = load_in_path (filename, default_path, status, asmctx, predicate, predicate_ud);
 		if (result)
 			result->in_gac = FALSE;
 		g_free (filename);
@@ -3758,9 +3797,10 @@ mono_assembly_load_full_nosearch (MonoAssemblyName *aname,
 }
 
 MonoAssembly*
-mono_assembly_load_full_internal (MonoAssemblyName *aname, MonoAssembly *requesting, const char *basedir, MonoImageOpenStatus *status, gboolean refonly)
+mono_assembly_load_full_internal (MonoAssemblyName *aname, MonoAssembly *requesting, const char *basedir, MonoAssemblyContextKind asmctx, MonoImageOpenStatus *status)
 {
-	MonoAssembly *result = mono_assembly_load_full_nosearch (aname, basedir, status, refonly);
+	MonoAssembly *result = mono_assembly_load_full_nosearch (aname, basedir, asmctx, status);
+	const gboolean refonly = asmctx == MONO_ASMCTX_REFONLY;
 
 	if (!result) {
 		/* Try a postload search hook */
@@ -3789,7 +3829,7 @@ mono_assembly_load_full_internal (MonoAssemblyName *aname, MonoAssembly *request
 MonoAssembly*
 mono_assembly_load_full (MonoAssemblyName *aname, const char *basedir, MonoImageOpenStatus *status, gboolean refonly)
 {
-	return mono_assembly_load_full_internal (aname, NULL, basedir, status, refonly);
+	return mono_assembly_load_full_internal (aname, NULL, basedir, refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT, status);
 }
 
 /**
@@ -3807,7 +3847,7 @@ mono_assembly_load_full (MonoAssemblyName *aname, const char *basedir, MonoImage
 MonoAssembly*
 mono_assembly_load (MonoAssemblyName *aname, const char *basedir, MonoImageOpenStatus *status)
 {
-	return mono_assembly_load_full_internal (aname, NULL, basedir, status, FALSE);
+	return mono_assembly_load_full_internal (aname, NULL, basedir, MONO_ASMCTX_DEFAULT, status);
 }
 
 /**
@@ -4234,8 +4274,5 @@ mono_assembly_has_skip_verification (MonoAssembly *assembly)
 MonoAssemblyContextKind
 mono_asmctx_get_kind (const MonoAssemblyContext *ctx)
 {
-	if (ctx->ref_only)
-		return MONO_ASMCTX_REFONLY;
-	else
-		return MONO_ASMCTX_DEFAULT;
+	return ctx->kind;
 }

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -2056,10 +2056,11 @@ mono_assembly_open_predicate (const char *filename, MonoAssemblyContextKind asmc
 		return NULL;
 	}
 
-	if (asmctx == MONO_ASMCTX_LOADFROM) {
+	if (asmctx == MONO_ASMCTX_LOADFROM || asmctx == MONO_ASMCTX_INDIVIDUAL) {
 		/* This is a "fun" one now.
-		 * For LoadFrom ("/basedir/some.dll"), apparently what we're meant to do is:
-		 *   1. probe the assembly name from some.dll
+		 * For LoadFrom ("/basedir/some.dll") or LoadFile("/basedir/some.dll") or Load(byte[])),
+		 * apparently what we're meant to do is:
+		 *   1. probe the assembly name from some.dll (or the byte array)
 		 *   2. apply binding redirects
 		 *   3. If we get some other different name, drop this image and use
 		 *      the binding redirected name to probe.

--- a/mono/metadata/attach.c
+++ b/mono/metadata/attach.c
@@ -276,7 +276,7 @@ mono_attach_load_agent (MonoDomain *domain, char *agent, char *args, MonoObject 
 	gpointer pa [1];
 	MonoImageOpenStatus open_status;
 
-	agent_assembly = mono_assembly_open_predicate (agent, FALSE, FALSE, NULL, NULL, &open_status);
+	agent_assembly = mono_assembly_open_predicate (agent, MONO_ASMCTX_DEFAULT, NULL, NULL, &open_status);
 	if (!agent_assembly) {
 		fprintf (stderr, "Cannot open agent assembly '%s': %s.\n", agent, mono_image_strerror (open_status));
 		g_free (agent);

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -201,7 +201,10 @@ mono_class_from_typeref_checked (MonoImage *image, guint32 type_token, MonoError
 		
 		mono_assembly_get_assemblyref (image, idx - 1, &aname);
 		human_name = mono_stringify_assembly_name (&aname);
-		mono_error_set_simple_file_not_found (error, human_name, image->assembly ? image->assembly->ref_only : FALSE);
+		gboolean refonly = FALSE;
+		if (image->assembly)
+			refonly = mono_asmctx_get_kind (&image->assembly->context) == MONO_ASMCTX_REFONLY;
+		mono_error_set_simple_file_not_found (error, human_name, refonly);
 		g_free (human_name);
 		return NULL;
 	}

--- a/mono/metadata/coree.c
+++ b/mono/metadata/coree.c
@@ -120,7 +120,7 @@ BOOL STDMETHODCALLTYPE _CorDllMain(HINSTANCE hInst, DWORD dwReason, LPVOID lpRes
 		 * probably be delayed until the first call to an exported function.
 		 */
 		if (image->tables [MONO_TABLE_ASSEMBLY].rows && ((MonoCLIImageInfo*) image->image_info)->cli_cli_header.ch_vtable_fixups.rva)
-			assembly = mono_assembly_open_predicate (file_name, FALSE, FALSE, NULL, NULL, NULL);
+			assembly = mono_assembly_open_predicate (file_name, MONO_ASMCTX_DEFAULT, NULL, NULL, NULL);
 
 		g_free (file_name);
 		break;
@@ -171,7 +171,7 @@ __int32 STDMETHODCALLTYPE _CorExeMain(void)
 		ExitProcess (1);
 	}
 
-	assembly = mono_assembly_open_predicate (file_name, FALSE, FALSE, NULL, NULL, NULL);
+	assembly = mono_assembly_open_predicate (file_name, MONO_ASMCTX_DEFAULT, NULL, NULL, NULL);
 	mono_close_exe_image ();
 	if (!assembly) {
 		g_free (file_name);

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -589,11 +589,6 @@ mono_try_assembly_resolve (MonoDomain *domain, const char *fname, MonoAssembly *
 MonoAssembly *
 mono_domain_assembly_postload_search (MonoAssemblyName *aname, MonoAssembly *requesting, gboolean refonly);
 
-MonoAssembly* mono_assembly_load_full_nosearch (MonoAssemblyName *aname, 
-						const char       *basedir, 
-						MonoImageOpenStatus *status,
-						gboolean refonly);
-
 void mono_domain_set_options_from_config (MonoDomain *domain);
 
 int mono_framework_version (void);

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -1967,7 +1967,8 @@ mono_domain_get_assemblies (MonoDomain *domain, gboolean refonly)
 	mono_domain_assemblies_lock (domain);
 	for (tmp = domain->domain_assemblies; tmp; tmp = tmp->next) {
 		ass = (MonoAssembly *)tmp->data;
-		if (refonly != ass->ref_only)
+		gboolean ass_ref_only = mono_asmctx_get_kind (&ass->context) == MONO_ASMCTX_REFONLY;
+		if (refonly != ass_ref_only)
 			continue;
 		if (ass->corlib_internal)
 			continue;

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -1010,10 +1010,10 @@ mono_domain_assembly_open (MonoDomain *domain, const char *name)
 		current = mono_domain_get ();
 
 		mono_domain_set (domain, FALSE);
-		ass = mono_assembly_open_predicate (name, FALSE, FALSE, NULL, NULL, NULL);
+		ass = mono_assembly_open_predicate (name, MONO_ASMCTX_DEFAULT, NULL, NULL, NULL);
 		mono_domain_set (current, FALSE);
 	} else {
-		ass = mono_assembly_open_predicate (name, FALSE, FALSE, NULL, NULL, NULL);
+		ass = mono_assembly_open_predicate (name, MONO_ASMCTX_DEFAULT, NULL, NULL, NULL);
 	}
 
 	return ass;

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -543,6 +543,7 @@ HANDLES(ICALL(ASSEM_14, "InternalGetAssemblyName", ves_icall_System_Reflection_A
 HANDLES(ICALL(ASSEM_12, "InternalGetReferencedAssemblies", ves_icall_System_Reflection_Assembly_InternalGetReferencedAssemblies))
 HANDLES(ICALL(ASSEM_15, "InternalGetType", ves_icall_System_Reflection_Assembly_InternalGetType))
 HANDLES(ICALL(ASSEM_16, "InternalImageRuntimeVersion", ves_icall_System_Reflection_Assembly_InternalImageRuntimeVersion))
+HANDLES(ICALL(ASSEM_16a, "LoadFile_internal", ves_icall_System_Reflection_Assembly_LoadFile_internal))
 HANDLES(ICALL(ASSEM_17, "LoadFrom", ves_icall_System_Reflection_Assembly_LoadFrom))
 HANDLES(ICALL(ASSEM_18, "LoadPermissions", ves_icall_System_Reflection_Assembly_LoadPermissions))
 

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -2000,7 +2000,7 @@ ves_icall_MonoField_GetValueInternal (MonoReflectionField *field, MonoObject *ob
 	MonoClassField *cf = field->field;
 	MonoDomain *domain = mono_object_domain (field);
 
-	if (m_class_get_image (fklass)->assembly->ref_only) {
+	if (mono_asmctx_get_kind (&m_class_get_image (fklass)->assembly->context) == MONO_ASMCTX_REFONLY) {
 		mono_set_pending_exception (mono_get_exception_invalid_operation (
 					"It is illegal to get the value on a field on a type loaded using the ReflectionOnly methods."));
 		return NULL;
@@ -2035,7 +2035,7 @@ ves_icall_MonoField_SetValueInternal (MonoReflectionFieldHandle field, MonoObjec
 	MonoClassField *cf = MONO_HANDLE_GETVAL (field, field);
 
 	MonoClass *field_klass = MONO_HANDLE_GETVAL (field, klass);
-	if (m_class_get_image (field_klass)->assembly->ref_only) {
+	if (mono_asmctx_get_kind (&m_class_get_image (field_klass)->assembly->context) == MONO_ASMCTX_REFONLY) {
 		mono_error_set_invalid_operation (error, "It is illegal to set the value on a field on a type loaded using the ReflectionOnly methods.");
 		return;
 	}
@@ -3369,7 +3369,7 @@ ves_icall_InternalInvoke (MonoReflectionMethod *method, MonoObject *this_arg, Mo
 	}
 
 	image = m_class_get_image (m->klass);
-	if (image->assembly->ref_only) {
+	if (mono_asmctx_get_kind (&image->assembly->context) == MONO_ASMCTX_REFONLY) {
 		mono_gc_wbarrier_generic_store (exc, (MonoObject*) mono_get_exception_invalid_operation ("It is illegal to invoke a method on a type loaded using the ReflectionOnly api."));
 		return NULL;
 	}
@@ -4765,7 +4765,7 @@ ves_icall_System_Reflection_Assembly_get_ReflectionOnly (MonoReflectionAssemblyH
 {
 	error_init (error);
 	MonoAssembly *assembly = MONO_HANDLE_GETVAL (assembly_h, assembly);
-	return assembly->ref_only;
+	return mono_asmctx_get_kind (&assembly->context) == MONO_ASMCTX_REFONLY;
 }
 
 ICALL_EXPORT MonoStringHandle

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -416,8 +416,10 @@ find_method_in_class (MonoClass *klass, const char *name, const char *qname, con
 	FIXME we should better report this error to the caller
 	 */
 	if (!m_class_get_methods (klass) || mono_class_has_failure (klass)) {
-		mono_error_set_type_load_class (error, klass, "Could not find method due to a type load error"); //FIXME get the error from the class 
-
+		ERROR_DECL (cause_error);
+		mono_error_set_for_class_failure (cause_error, klass);
+		mono_error_set_type_load_class (error, klass, "Could not find method '%s' due to a type load error: %s", name, mono_error_get_message (cause_error));
+		mono_error_cleanup (cause_error);
 		return NULL;
 	}
 	int mcount = mono_class_get_method_count (klass);

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -93,6 +93,29 @@ struct MonoTypeNameParse {
 	GList *nested;
 };
 
+
+typedef enum MonoAssemblyContextKind {
+	/* Default assembly context: Load(String) and assembly references */
+	MONO_ASMCTX_DEFAULT = 0,
+	/* Reflection-only only context: ReflectionOnlyLoad and ReeflectionOnlyLoadFrom */
+	MONO_ASMCTX_REFONLY = 1,
+	/* FIXME: LOADFROM and INDIVIDUAL are unimplemented */
+	/* LoadFrom context: LoadFrom() and references */
+	MONO_ASMCTX_LOADFROM = 2,
+	/* Individual assembly context (.NET Framework docs call this "not in
+	 * any context"): LoadFile(String) and Load(byte[]) are here.
+	 */
+	MONO_ASMCTX_INDIVIDUAL = 3,
+
+	MONO_ASMCTX_LAST = 3
+} MonoAssemblyContextKind;
+
+typedef struct _MonoAssemblyContext {
+	/* FIXME: Add more load contexts as described by .NET Framework
+	 * documentation on assembly loading. */
+	gboolean ref_only; /* If TRUE, loaded for reflection only, otherwise default context */
+} MonoAssemblyContext;
+
 struct _MonoAssembly {
 	/* 
 	 * The number of appdomains which have this assembly loaded plus the number of 
@@ -111,7 +134,7 @@ struct _MonoAssembly {
 	guint8 in_gac;
 	guint8 dynamic;
 	guint8 corlib_internal;
-	gboolean ref_only;
+	MonoAssemblyContext context;
 	guint8 wrap_non_exception_throws;
 	guint8 wrap_non_exception_throws_inited;
 	guint8 jit_optimizer_disabled;
@@ -987,6 +1010,9 @@ mono_signature_get_managed_fmt_string (MonoMethodSignature *sig);
 
 gboolean
 mono_type_in_image (MonoType *type, MonoImage *image);
+
+MonoAssemblyContextKind
+mono_asmctx_get_kind (const MonoAssemblyContext *ctx);
 
 #endif /* __MONO_METADATA_INTERNALS_H__ */
 

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -99,7 +99,6 @@ typedef enum MonoAssemblyContextKind {
 	MONO_ASMCTX_DEFAULT = 0,
 	/* Reflection-only only context: ReflectionOnlyLoad and ReeflectionOnlyLoadFrom */
 	MONO_ASMCTX_REFONLY = 1,
-	/* FIXME: LOADFROM and INDIVIDUAL are unimplemented */
 	/* LoadFrom context: LoadFrom() and references */
 	MONO_ASMCTX_LOADFROM = 2,
 	/* Individual assembly context (.NET Framework docs call this "not in
@@ -111,9 +110,7 @@ typedef enum MonoAssemblyContextKind {
 } MonoAssemblyContextKind;
 
 typedef struct _MonoAssemblyContext {
-	/* FIXME: Add more load contexts as described by .NET Framework
-	 * documentation on assembly loading. */
-	gboolean ref_only; /* If TRUE, loaded for reflection only, otherwise default context */
+	MonoAssemblyContextKind kind;
 } MonoAssemblyContext;
 
 struct _MonoAssembly {

--- a/mono/metadata/mono-security.c
+++ b/mono/metadata/mono-security.c
@@ -632,7 +632,7 @@ void mono_invoke_protected_memory_method (MonoArray *data, MonoObject *scope, gb
 	if (system_security_assembly == NULL) {
 		system_security_assembly = mono_image_loaded ("System.Security");
 		if (!system_security_assembly) {
-			MonoAssembly *sa = mono_assembly_open_predicate ("System.Security.dll", FALSE, FALSE, NULL, NULL, NULL);
+			MonoAssembly *sa = mono_assembly_open_predicate ("System.Security.dll", MONO_ASMCTX_DEFAULT, NULL, NULL, NULL);
 			if (!sa)
 				g_assert_not_reached ();
 			system_security_assembly = mono_assembly_get_image (sa);

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -1343,7 +1343,10 @@ mono_reflection_dynimage_basic_init (MonoReflectionAssemblyBuilder *assemblyb)
 			assembly->assembly.aname.revision = 0;
         }
 
-	assembly->assembly.context.ref_only = assemblybuilderaccess_can_refonlyload (assemblyb->access);
+	/* SRE assemblies are loaded into the individual loading context, ie,
+	 * they only fire AssemblyResolve events, they don't cause probing for
+	 * referenced assemblies to happen. */
+	assembly->assembly.context.kind = assemblybuilderaccess_can_refonlyload (assemblyb->access) ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_INDIVIDUAL;
 	assembly->run = assemblybuilderaccess_can_run (assemblyb->access);
 	assembly->save = assemblybuilderaccess_can_save (assemblyb->access);
 	assembly->domain = domain;

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -1343,7 +1343,7 @@ mono_reflection_dynimage_basic_init (MonoReflectionAssemblyBuilder *assemblyb)
 			assembly->assembly.aname.revision = 0;
         }
 
-	assembly->assembly.ref_only = assemblybuilderaccess_can_refonlyload (assemblyb->access);
+	assembly->assembly.context.ref_only = assemblybuilderaccess_can_refonlyload (assemblyb->access);
 	assembly->run = assemblybuilderaccess_can_run (assemblyb->access);
 	assembly->save = assemblybuilderaccess_can_save (assemblyb->access);
 	assembly->domain = domain;

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -717,7 +717,7 @@ get_socket_assembly (void)
 
 		socket_assembly = mono_image_loaded ("System");
 		if (!socket_assembly) {
-			MonoAssembly *sa = mono_assembly_open_predicate ("System.dll", FALSE, FALSE, NULL, NULL, NULL);
+			MonoAssembly *sa = mono_assembly_open_predicate ("System.dll", MONO_ASMCTX_DEFAULT, NULL, NULL, NULL);
 		
 			if (!sa) {
 				g_assert_not_reached ();
@@ -2000,7 +2000,7 @@ ves_icall_System_Net_Sockets_Socket_GetSocketOption_obj_internal (gsize sock, gi
 		if (mono_posix_image == NULL) {
 			mono_posix_image = mono_image_loaded ("Mono.Posix");
 			if (!mono_posix_image) {
-				MonoAssembly *sa = mono_assembly_open_predicate ("Mono.Posix.dll", FALSE, FALSE, NULL, NULL, NULL);
+				MonoAssembly *sa = mono_assembly_open_predicate ("Mono.Posix.dll", MONO_ASMCTX_DEFAULT, NULL, NULL, NULL);
 				if (!sa) {
 					*werror = WSAENOPROTOOPT;
 					return;

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -1966,7 +1966,7 @@ load_aot_module (MonoAssembly *assembly, gpointer user_data)
 		 */
 		return;
 
-	if (image_is_dynamic (assembly->image) || assembly->ref_only || mono_domain_get () != mono_get_root_domain ())
+	if (image_is_dynamic (assembly->image) || mono_asmctx_get_kind (&assembly->context) == MONO_ASMCTX_REFONLY || mono_domain_get () != mono_get_root_domain ())
 		return;
 
 	mono_aot_lock ();

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -1976,10 +1976,10 @@ if (container_assm_name && !container_amodule) {
 	container_assm_name = NULL;
 	MonoImageOpenStatus status = MONO_IMAGE_OK;
 	gchar *dll = g_strdup_printf (		"%s.dll", local_ref);
-	MonoAssembly *assm = mono_assembly_open_a_lot (dll, &status, FALSE, FALSE);
+	MonoAssembly *assm = mono_assembly_open_a_lot (dll, &status, MONO_ASMCTX_DEFAULT);
 	if (!assm) {
 		gchar *exe = g_strdup_printf ("%s.exe", local_ref);
-		assm = mono_assembly_open_a_lot (exe, &status, FALSE, FALSE);
+		assm = mono_assembly_open_a_lot (exe, &status, MONO_ASMCTX_DEFAULT);
 	}
 	g_assert (assm);
 	load_aot_module (assm, NULL);

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -272,6 +272,8 @@ load_image (MonoAotModule *amodule, int index, MonoError *error)
 
 	error_init (error);
 
+	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_AOT, "AOT: module %s wants to load image %d: %s", amodule->aot_name, index, amodule->image_names[index].name);
+
 	if (amodule->image_table [index])
 		return amodule->image_table [index];
 	if (amodule->out_of_date) {
@@ -279,7 +281,26 @@ load_image (MonoAotModule *amodule, int index, MonoError *error)
 		return NULL;
 	}
 
-	assembly = mono_assembly_load (&amodule->image_names [index], amodule->assembly->basedir, &status);
+	/*
+	 * LoadFile allows loading more than one assembly with the same name.
+	 * That means that just calling mono_assembly_load is unlikely to find
+	 * the correct assembly (it'll just return the first one loaded).  But
+	 * we shouldn't hardcode the full assembly filepath into the AOT image,
+	 * so it's not obvious that we can call mono_assembly_open_predicate.
+	 *
+	 * In the JIT, an assembly opened with LoadFile is supposed to only
+	 * refer to already-loaded assemblies (or to GAC & MONO_PATH)
+	 * assemblies - so nothing new should be loading.  And for the
+	 * LoadFile'd assembly itself, we can check if the name and guid of the
+	 * current AOT module matches the wanted name and guid and just return
+	 * the AOT module's assembly.
+	 */
+	if (mono_asmctx_get_kind (&amodule->assembly->context) == MONO_ASMCTX_INDIVIDUAL &&
+	    !strcmp (amodule->assembly->image->guid, amodule->image_guids [index]) &&
+	    mono_assembly_names_equal (&amodule->image_names [index], &amodule->assembly->aname))
+		assembly = amodule->assembly;
+	else
+		assembly = mono_assembly_load (&amodule->image_names [index], amodule->assembly->basedir, &status);
 	if (!assembly) {
 		mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_AOT, "AOT: module %s is unusable because dependency %s is not found.", amodule->aot_name, amodule->image_names [index].name);
 		mono_error_set_bad_image_by_name (error, amodule->aot_name, "module is unusable because dependency %s is not found (error %d).\n", amodule->image_names [index].name, status);

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -547,7 +547,7 @@ mini_regression_list (int verbose, int count, char *images [])
 	
 	total_run =  total = 0;
 	for (i = 0; i < count; ++i) {
-		ass = mono_assembly_open_predicate (images [i], FALSE, FALSE, NULL, NULL, NULL);
+		ass = mono_assembly_open_predicate (images [i], MONO_ASMCTX_DEFAULT, NULL, NULL, NULL);
 		if (!ass) {
 			g_warning ("failed to load assembly: %s", images [i]);
 			continue;
@@ -713,7 +713,7 @@ mono_interp_regression_list (int verbose, int count, char *images [])
 
 	total_run = total = 0;
 	for (i = 0; i < count; ++i) {
-		MonoAssembly *ass = mono_assembly_open_predicate (images [i], FALSE, FALSE, NULL, NULL, NULL);
+		MonoAssembly *ass = mono_assembly_open_predicate (images [i], MONO_ASMCTX_DEFAULT, NULL, NULL, NULL);
 		if (!ass) {
 			g_warning ("failed to load assembly: %s", images [i]);
 			continue;
@@ -1305,7 +1305,7 @@ load_agent (MonoDomain *domain, char *desc)
 		args = NULL;
 	}
 
-	agent_assembly = mono_assembly_open_predicate (agent, FALSE, FALSE, NULL, NULL, &open_status);
+	agent_assembly = mono_assembly_open_predicate (agent, MONO_ASMCTX_DEFAULT, NULL, NULL, &open_status);
 	if (!agent_assembly) {
 		fprintf (stderr, "Cannot open agent assembly '%s': %s.\n", agent, mono_image_strerror (open_status));
 		g_free (agent);
@@ -2341,7 +2341,7 @@ mono_main (int argc, char* argv[])
 		apply_root_domain_configuration_file_bindings (domain, extra_bindings_config_file);
 	}
 
-	assembly = mono_assembly_open_predicate (aname, FALSE, FALSE, NULL, NULL, &open_status);
+	assembly = mono_assembly_open_predicate (aname, MONO_ASMCTX_DEFAULT, NULL, NULL, &open_status);
 	if (!assembly) {
 		fprintf (stderr, "Cannot open assembly '%s': %s.\n", aname, mono_image_strerror (open_status));
 		mini_cleanup (domain);

--- a/mono/mini/type-checking.c
+++ b/mono/mini/type-checking.c
@@ -436,7 +436,7 @@ handle_castclass (MonoCompile *cfg, MonoClass *klass, MonoInst *src, int context
 
 		MONO_EMIT_NEW_LOAD_MEMBASE (cfg, tmp_reg, obj_reg, MONO_STRUCT_OFFSET (MonoObject, vtable));
 
-		if (klass->is_array_special_interface) {
+		if (m_class_is_array_special_interface (klass)) {
 			NEW_BBLOCK (cfg, interface_fail_bb);
 			mini_emit_iface_cast (cfg, tmp_reg, klass, interface_fail_bb, is_null_bb);
 			// iface bitmap check failed

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -271,6 +271,9 @@ TESTS_CS_SRC=		\
 	assembly-load-bytes.cs	\
 	assembly-loadfile.cs	\
 	assembly-loadfrom.cs	\
+	assembly-load-bytes-bindingredirect.cs	\
+	assembly-loadfile-bindingredirect.cs	\
+	assembly-loadfrom-bindingredirect.cs	\
 	assemblyresolve_event.cs	\
 	assemblyresolve_event3.cs	\
 	assemblyresolve_event4.cs	\
@@ -2287,7 +2290,14 @@ assembly-load-dir1/Lib.dll: assembly-load-dir1/Lib.cs
 assembly-load-dir2/Lib.dll: assembly-load-dir2/Lib.cs
 	$(MCS) -target:library -out:$@ $<
 
-EXTRA_DIST += assembly-load-dir1/Lib.cs assmebly-load-dir2/Lib.cs
+assembly-load-dir1/LibStrongName.dll: assembly-load-dir1/LibStrongName.cs testing_gac/testkey.snk
+	$(MCS) -target:library -out:$@ $<
+
+assembly-load-dir2/LibStrongName.dll: assembly-load-dir2/LibStrongName.cs testing_gac/testkey.snk
+	$(MCS) -target:library -out:$@ $<
+
+EXTRA_DIST += assembly-load-dir1/Lib.cs assmebly-load-dir2/Lib.cs \
+	assembly-load-dir1/LibStrongName.cs assembly-load-dir2/LibStrongName.cs
 
 assembly-load-bytes.exe$(PLATFORM_AOT_SUFFIX): assembly-load-dir1/Lib.dll$(PLATFORM_AOT_SUFFIX) assembly-load-dir2/Lib.dll$(PLATFORM_AOT_SUFFIX)
 assembly-load-bytes.exe: assembly-load-dir1/Lib.dll assembly-load-dir2/Lib.dll
@@ -2297,6 +2307,17 @@ assembly-loadfrom.exe: assembly-load-dir1/Lib.dll assembly-load-dir2/Lib.dll
 
 assembly-loadfile.exe$(PLATFORM_AOT_SUFFIX): assembly-load-dir1/Lib.dll$(PLATFORM_AOT_SUFFIX) assembly-load-dir2/Lib.dll$(PLATFORM_AOT_SUFFIX)
 assembly-loadfile.exe: assembly-load-dir1/Lib.dll assembly-load-dir2/Lib.dll
+
+assembly-loadfrom-bindingredirect.exe$(PLATFORM_AOT_SUFFIX): assembly-load-dir1/LibStrongName.dll$(PLATFORM_AOT_SUFFIX) assembly-load-dir2/LibStrongName.dll$(PLATFORM_AOT_SUFFIX) assembly-loadfrom-bindingredirect.exe.config
+assembly-loadfrom-bindingredirect.exe: assembly-load-dir1/LibStrongName.dll assembly-load-dir2/LibStrongName.dll assembly-loadfrom-bindingredirect.exe.config
+
+assembly-loadfile-bindingredirect.exe$(PLATFORM_AOT_SUFFIX): assembly-load-dir1/LibStrongName.dll$(PLATFORM_AOT_SUFFIX) assembly-load-dir2/LibStrongName.dll$(PLATFORM_AOT_SUFFIX) assembly-loadfile-bindingredirect.exe.config
+assembly-loadfile-bindingredirect.exe: assembly-load-dir1/LibStrongName.dll assembly-load-dir2/LibStrongName.dll assembly-loadfile-bindingredirect.exe.config
+
+assembly-load-bytes-bindingredirect.exe$(PLATFORM_AOT_SUFFIX): assembly-load-dir1/LibStrongName.dll$(PLATFORM_AOT_SUFFIX) assembly-load-dir2/LibStrongName.dll$(PLATFORM_AOT_SUFFIX) assembly-load-bytes-bindingredirect.exe.config
+assembly-load-bytes-bindingredirect.exe: assembly-load-dir1/LibStrongName.dll assembly-load-dir2/LibStrongName.dll assembly-load-bytes-bindingredirect.exe.config
+
+EXTRA_DIST += assembly-loadfrom-bindingredirect.exe.config assembly-loadfile-bindingredirect.exe.config assembly-load-bytes-bindingredirect.exe.config
 
 gshared:
 	$(MAKE) test-generic-sharing

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1165,6 +1165,11 @@ PROFILE_DISABLED_TESTS += \
 PROFILE_DISABLED_TESTS += \
 	reference-loader.exe
 
+# Tests which have no way of finding AOT images because they use Assembly.Load(byte[])
+PROFILE_DISABLED_TESTS += \
+	assembly-load-bytes.exe \
+	assembly-load-bytes-bindingredirect.exe
+
 # constraints-load.il: 
 # Failed to load method 0x6000007 from '..../mono/tests/constraints-load.exe' due to 
 # Could not resolve type with token 01000002 assembly:mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 type:System.BrokenIComparable`1 member:<none>.
@@ -2299,7 +2304,6 @@ assembly-load-dir2/LibStrongName.dll: assembly-load-dir2/LibStrongName.cs testin
 EXTRA_DIST += assembly-load-dir1/Lib.cs assmebly-load-dir2/Lib.cs \
 	assembly-load-dir1/LibStrongName.cs assembly-load-dir2/LibStrongName.cs
 
-assembly-load-bytes.exe$(PLATFORM_AOT_SUFFIX): assembly-load-dir1/Lib.dll$(PLATFORM_AOT_SUFFIX) assembly-load-dir2/Lib.dll$(PLATFORM_AOT_SUFFIX)
 assembly-load-bytes.exe: assembly-load-dir1/Lib.dll assembly-load-dir2/Lib.dll
 
 assembly-loadfrom.exe$(PLATFORM_AOT_SUFFIX): assembly-load-dir1/Lib.dll$(PLATFORM_AOT_SUFFIX) assembly-load-dir2/Lib.dll$(PLATFORM_AOT_SUFFIX)
@@ -2314,7 +2318,6 @@ assembly-loadfrom-bindingredirect.exe: assembly-load-dir1/LibStrongName.dll asse
 assembly-loadfile-bindingredirect.exe$(PLATFORM_AOT_SUFFIX): assembly-load-dir1/LibStrongName.dll$(PLATFORM_AOT_SUFFIX) assembly-load-dir2/LibStrongName.dll$(PLATFORM_AOT_SUFFIX) assembly-loadfile-bindingredirect.exe.config
 assembly-loadfile-bindingredirect.exe: assembly-load-dir1/LibStrongName.dll assembly-load-dir2/LibStrongName.dll assembly-loadfile-bindingredirect.exe.config
 
-assembly-load-bytes-bindingredirect.exe$(PLATFORM_AOT_SUFFIX): assembly-load-dir1/LibStrongName.dll$(PLATFORM_AOT_SUFFIX) assembly-load-dir2/LibStrongName.dll$(PLATFORM_AOT_SUFFIX) assembly-load-bytes-bindingredirect.exe.config
 assembly-load-bytes-bindingredirect.exe: assembly-load-dir1/LibStrongName.dll assembly-load-dir2/LibStrongName.dll assembly-load-bytes-bindingredirect.exe.config
 
 EXTRA_DIST += assembly-loadfrom-bindingredirect.exe.config assembly-loadfile-bindingredirect.exe.config assembly-load-bytes-bindingredirect.exe.config

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -268,6 +268,9 @@ TESTS_CS_SRC=		\
 	array-init.cs		\
 	arraylist.cs		\
 	assembly-load-remap.cs	\
+	assembly-load-bytes.cs	\
+	assembly-loadfile.cs	\
+	assembly-loadfrom.cs	\
 	assemblyresolve_event.cs	\
 	assemblyresolve_event3.cs	\
 	assemblyresolve_event4.cs	\
@@ -2278,6 +2281,22 @@ MidAssembly.dll: appdomain-marshalbyref-assemblyload-MidAssembly.cs LeafAssembly
 
 appdomain-marshalbyref-assemblyload.exe: appdomain-marshalbyref-assemblyload.cs MidAssembly.dll LeafAssembly.dll appdomain-marshalbyref-assemblyload2/LeafAssembly.dll
 	$(MCS) -out:$@ $< -r:MidAssembly.dll -r:LeafAssembly.dll
+
+assembly-load-dir1/Lib.dll: assembly-load-dir1/Lib.cs
+	$(MCS) -target:library -out:$@ $<
+assembly-load-dir2/Lib.dll: assembly-load-dir2/Lib.cs
+	$(MCS) -target:library -out:$@ $<
+
+EXTRA_DIST += assembly-load-dir1/Lib.cs assmebly-load-dir2/Lib.cs
+
+assembly-load-bytes.exe$(PLATFORM_AOT_SUFFIX): assembly-load-dir1/Lib.dll$(PLATFORM_AOT_SUFFIX) assembly-load-dir2/Lib.dll$(PLATFORM_AOT_SUFFIX)
+assembly-load-bytes.exe: assembly-load-dir1/Lib.dll assembly-load-dir2/Lib.dll
+
+assembly-loadfrom.exe$(PLATFORM_AOT_SUFFIX): assembly-load-dir1/Lib.dll$(PLATFORM_AOT_SUFFIX) assembly-load-dir2/Lib.dll$(PLATFORM_AOT_SUFFIX)
+assembly-loadfrom.exe: assembly-load-dir1/Lib.dll assembly-load-dir2/Lib.dll
+
+assembly-loadfile.exe$(PLATFORM_AOT_SUFFIX): assembly-load-dir1/Lib.dll$(PLATFORM_AOT_SUFFIX) assembly-load-dir2/Lib.dll$(PLATFORM_AOT_SUFFIX)
+assembly-loadfile.exe: assembly-load-dir1/Lib.dll assembly-load-dir2/Lib.dll
 
 gshared:
 	$(MAKE) test-generic-sharing

--- a/mono/tests/assembly-load-bytes-bindingredirect.cs
+++ b/mono/tests/assembly-load-bytes-bindingredirect.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+public class TestAssemblyLoad {
+
+	public static int Main ()
+	{
+		return TestDriver.RunTests (typeof (TestAssemblyLoad));
+	}
+
+	public static int test_0_LoadBytesBindingRedirect ()
+	{
+		
+		string path1 = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "assembly-load-dir1", "LibStrongName.dll");
+
+		// Try to load from dir1/LibStrongName.dll, but
+		// the assembly-load-bytes-bindingredirect.exe.config redirects all old versions to
+		// be mapped to version 2.0.0.0 which is in the assembly-load-dir2 directory
+		//
+		// In old versions of .net binding redirection did not apply to
+		// Load(byte[]), but since .NET 2 it does.
+		byte[] bytes1 = File.ReadAllBytes (path1);
+		Assembly asm1 = Assembly.Load (bytes1);
+		if (asm1 == null) {
+			Console.Error.WriteLine ("expected asm1 {0} to not be null", asm1);
+			return 1;
+		}
+
+		Type t1 = asm1.GetType ("LibClass");
+		if (t1 == null) {
+			Console.Error.WriteLine ("expected t1 {0} to not be null", t1);
+			return 2;
+		}
+			
+		FieldInfo f1 = t1.GetField ("OnlyInVersion1");
+		if (f1 != null) {
+			Console.Error.WriteLine ("expected not to find field OnlyInVersion1, but got {0}", f1);
+			return 3;
+		}
+
+		FieldInfo f2 = t1.GetField ("OnlyInVersion2");
+
+		if (f2 == null) {
+			Console.Error.WriteLine ("expected field OnlyInVersion2 not to be null");
+			return 4;
+		}
+
+		if (f2.FieldType != typeof(int)) {
+			Console.Error.WriteLine ("Field OnlyInVersion2 has type {0}, expected int", f2.FieldType);
+			return 5;
+		}
+		return 0;
+	}
+}

--- a/mono/tests/assembly-load-bytes-bindingredirect.exe.config
+++ b/mono/tests/assembly-load-bytes-bindingredirect.exe.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <probing privatePath="assembly-load-dir2"/>  
+      <dependentAssembly>
+        <assemblyIdentity name="LibStrongName" publicKeyToken="537eab56aa911cb7" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="2.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/mono/tests/assembly-load-bytes.cs
+++ b/mono/tests/assembly-load-bytes.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+public class TestAssemblyLoad {
+
+	public static int Main ()
+	{
+		return TestDriver.RunTests (typeof (TestAssemblyLoad));
+	}
+
+	public static int test_0_LoadBytesSameAssemblyName ()
+	{
+		
+		string path1 = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "assembly-load-dir1", "Lib.dll");
+		string path2 = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "assembly-load-dir2", "Lib.dll");
+		byte[] bytes1 = File.ReadAllBytes (path1);
+		byte[] bytes2 = File.ReadAllBytes (path2);
+
+		Assembly asm1 = Assembly.Load (bytes1);
+		Assembly asm2 = Assembly.Load (bytes2);
+		if (asm1 == asm2) {
+			Console.Error.WriteLine ("expected asm1 {0} and asm2 {1} to be different", asm1, asm2);
+			return 1;
+		}
+
+		Type t1 = asm1.GetType ("LibClass");
+		Type t2 = asm2.GetType ("LibClass");
+		if (t1 == t2) {
+			Console.Error.WriteLine ("expected t1 {0} and t2 {1} to be different", t1, t2);
+			return 2;
+		}
+			
+		object o1 = Activator.CreateInstance (t1);
+		object o2 = Activator.CreateInstance (t2);
+
+		string s1 = o1.ToString ();
+		string s2 = o2.ToString ();
+
+		if (s1 == s2) {
+			Console.Error.WriteLine ("expected string s1 {0} and s2 {1} to be different", s1, s2);
+			return 3;
+		}
+
+		return 0;
+	}
+}

--- a/mono/tests/assembly-load-dir1/Lib.cs
+++ b/mono/tests/assembly-load-dir1/Lib.cs
@@ -1,0 +1,11 @@
+using System;
+
+public class LibClass {
+	public LibClass () {
+		Console.WriteLine ("dir1");
+	}
+
+	public override string ToString () {
+		return "LibClass from dir1";
+	}
+}

--- a/mono/tests/assembly-load-dir1/LibStrongName.cs
+++ b/mono/tests/assembly-load-dir1/LibStrongName.cs
@@ -1,0 +1,11 @@
+
+using System.Reflection;
+
+[assembly:AssemblyVersion("1.0.0.0")]
+[assembly:AssemblyKeyFile("../testing_gac/testkey.snk")]
+
+public class LibClass {
+	public int OnlyInVersion1;
+	public int InAllVersions;
+	public LibClass () {}
+}

--- a/mono/tests/assembly-load-dir2/Lib.cs
+++ b/mono/tests/assembly-load-dir2/Lib.cs
@@ -1,0 +1,10 @@
+using System;
+
+public class LibClass {
+	public LibClass () {
+		Console.WriteLine ("dir2");
+	}
+	public override string ToString () {
+		return "LibClass from dir2";
+	}
+}

--- a/mono/tests/assembly-load-dir2/LibStrongName.cs
+++ b/mono/tests/assembly-load-dir2/LibStrongName.cs
@@ -1,0 +1,11 @@
+
+using System.Reflection;
+
+[assembly:AssemblyVersion("2.0.0.0")]
+[assembly:AssemblyKeyFile("../testing_gac/testkey.snk")]
+
+public class LibClass {
+	public int InAllVersions;
+	public int OnlyInVersion2;
+	public LibClass () {}
+}

--- a/mono/tests/assembly-loadbyte-bindingredirect.cs
+++ b/mono/tests/assembly-loadbyte-bindingredirect.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+public class TestAssemblyLoad {
+
+	public static int Main ()
+	{
+		return TestDriver.RunTests (typeof (TestAssemblyLoad));
+	}
+
+	public static int test_0_LoadFileBindingRedirect ()
+	{
+		
+		string path1 = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "assembly-load-dir1", "LibStrongName.dll");
+
+		// Try to load from dir1/LibStrongName.dll, but
+		// the assembly-loadfrom-bindingredirect.exe.config redirects all old versions to
+		// be mapped to version 2.0.0.0 which is in the assembly-load-dir2 directory
+		//
+		// In old versions of .net binding redirection did not apply to
+		// LoadFile, but since .NET 2 it does.
+		Assembly asm1 = Assembly.LoadFile (path1);
+		if (asm1 == null) {
+			Console.Error.WriteLine ("expected asm1 {0} to not be null", asm1);
+			return 1;
+		}
+
+		Type t1 = asm1.GetType ("LibClass");
+		if (t1 == null) {
+			Console.Error.WriteLine ("expected t1 {0} to not be null", t1);
+			return 2;
+		}
+			
+		FieldInfo f1 = t1.GetField ("OnlyInVersion1");
+		if (f1 != null) {
+			Console.Error.WriteLine ("expected not to find field OnlyInVersion1, but got {0}", f1);
+			return 3;
+		}
+
+		FieldInfo f2 = t1.GetField ("OnlyInVersion2");
+
+		if (f2 == null) {
+			Console.Error.WriteLine ("expected field OnlyInVersion2 not to be null");
+			return 4;
+		}
+
+		if (f2.FieldType != typeof(int)) {
+			Console.Error.WriteLine ("Field OnlyInVersion2 has type {0}, expected int", f2.FieldType);
+			return 5;
+		}
+		return 0;
+	}
+}

--- a/mono/tests/assembly-loadfile-bindingredirect.cs
+++ b/mono/tests/assembly-loadfile-bindingredirect.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+public class TestAssemblyLoad {
+
+	public static int Main ()
+	{
+		return TestDriver.RunTests (typeof (TestAssemblyLoad));
+	}
+
+	public static int test_0_LoadFileBindingRedirect ()
+	{
+		
+		string path1 = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "assembly-load-dir1", "LibStrongName.dll");
+
+		// Try to load from dir1/LibStrongName.dll, but
+		// the assembly-loadfile-bindingredirect.exe.config redirects all old versions to
+		// be mapped to version 2.0.0.0 which is in the assembly-load-dir2 directory
+		//
+		// In old versions of .net binding redirection did not apply to
+		// LoadFile, but since .NET 2 it does.
+		Assembly asm1 = Assembly.LoadFile (path1);
+		if (asm1 == null) {
+			Console.Error.WriteLine ("expected asm1 {0} to not be null", asm1);
+			return 1;
+		}
+
+		Type t1 = asm1.GetType ("LibClass");
+		if (t1 == null) {
+			Console.Error.WriteLine ("expected t1 {0} to not be null", t1);
+			return 2;
+		}
+			
+		FieldInfo f1 = t1.GetField ("OnlyInVersion1");
+		if (f1 != null) {
+			Console.Error.WriteLine ("expected not to find field OnlyInVersion1, but got {0}", f1);
+			return 3;
+		}
+
+		FieldInfo f2 = t1.GetField ("OnlyInVersion2");
+
+		if (f2 == null) {
+			Console.Error.WriteLine ("expected field OnlyInVersion2 not to be null");
+			return 4;
+		}
+
+		if (f2.FieldType != typeof(int)) {
+			Console.Error.WriteLine ("Field OnlyInVersion2 has type {0}, expected int", f2.FieldType);
+			return 5;
+		}
+		return 0;
+	}
+}

--- a/mono/tests/assembly-loadfile-bindingredirect.exe.config
+++ b/mono/tests/assembly-loadfile-bindingredirect.exe.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <probing privatePath="assembly-load-dir2"/>  
+      <dependentAssembly>
+        <assemblyIdentity name="LibStrongName" publicKeyToken="537eab56aa911cb7" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="2.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/mono/tests/assembly-loadfile.cs
+++ b/mono/tests/assembly-loadfile.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+public class TestAssemblyLoad {
+
+	public static int Main ()
+	{
+		return TestDriver.RunTests (typeof (TestAssemblyLoad));
+	}
+
+	public static int test_0_LoadFileSameAssemblyName ()
+	{
+		
+		string path1 = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "assembly-load-dir1", "Lib.dll");
+		string path2 = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "assembly-load-dir2", "Lib.dll");
+
+		Assembly asm1 = Assembly.LoadFile (path1);
+		Assembly asm2 = Assembly.LoadFile (path2);
+		if (asm1 == asm2) {
+			Console.Error.WriteLine ("expected asm1 {0} and asm2 {1} to be different", asm1, asm2);
+			return 1;
+		}
+
+		Type t1 = asm1.GetType ("LibClass");
+		Type t2 = asm2.GetType ("LibClass");
+		if (t1 == t2) {
+			Console.Error.WriteLine ("expected t1 {0} and t2 {1} to be different", t1, t2);
+			return 2;
+		}
+			
+		object o1 = Activator.CreateInstance (t1);
+		object o2 = Activator.CreateInstance (t2);
+
+		string s1 = o1.ToString ();
+		string s2 = o2.ToString ();
+
+		if (s1 == s2) {
+			Console.Error.WriteLine ("expected string s1 {0} and s2 {1} to be different", s1, s2);
+			return 3;
+		}
+
+		return 0;
+	}
+}

--- a/mono/tests/assembly-loadfrom-bindingredirect.cs
+++ b/mono/tests/assembly-loadfrom-bindingredirect.cs
@@ -1,0 +1,53 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+public class TestAssemblyLoad {
+
+	public static int Main ()
+	{
+		return TestDriver.RunTests (typeof (TestAssemblyLoad));
+	}
+
+	public static int test_0_LoadFromBindingRedirect ()
+	{
+		
+		string path1 = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "assembly-load-dir1", "LibStrongName.dll");
+
+		// Try to load from dir1/LibStrongName.dll, but
+		// the assembly-loadfrom-bindingredirect.exe.config redirects all old versions to
+		// be mapped to version 2.0.0.0 which is in the assembly-load-dir2 directory
+		//
+		// This is a regression test for https://github.com/mono/mono/issues/8152
+		Assembly asm1 = Assembly.LoadFrom (path1);
+		if (asm1 == null) {
+			Console.Error.WriteLine ("expected asm1 {0} to not be null", asm1);
+			return 1;
+		}
+
+		Type t1 = asm1.GetType ("LibClass");
+		if (t1 == null) {
+			Console.Error.WriteLine ("expected t1 {0} to not be null", t1);
+			return 2;
+		}
+			
+		FieldInfo f1 = t1.GetField ("OnlyInVersion1");
+		if (f1 != null) {
+			Console.Error.WriteLine ("expected not to find field OnlyInVersion1, but got {0}", f1);
+			return 3;
+		}
+
+		FieldInfo f2 = t1.GetField ("OnlyInVersion2");
+
+		if (f2 == null) {
+			Console.Error.WriteLine ("expected field OnlyInVersion2 not to be null");
+			return 4;
+		}
+
+		if (f2.FieldType != typeof(int)) {
+			Console.Error.WriteLine ("Field OnlyInVersion2 has type {0}, expected int", f2.FieldType);
+			return 5;
+		}
+		return 0;
+	}
+}

--- a/mono/tests/assembly-loadfrom-bindingredirect.exe.config
+++ b/mono/tests/assembly-loadfrom-bindingredirect.exe.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <probing privatePath="assembly-load-dir2"/>  
+      <dependentAssembly>
+        <assemblyIdentity name="LibStrongName" publicKeyToken="537eab56aa911cb7" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="2.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/mono/tests/assembly-loadfrom.cs
+++ b/mono/tests/assembly-loadfrom.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+public class TestAssemblyLoad {
+
+	public static int Main ()
+	{
+		return TestDriver.RunTests (typeof (TestAssemblyLoad));
+	}
+
+	public static int test_0_LoadFromSameAssemblyName ()
+	{
+		
+		string path1 = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "assembly-load-dir1", "Lib.dll");
+		string path2 = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "assembly-load-dir2", "Lib.dll");
+
+		Assembly asm1 = Assembly.LoadFrom (path1);
+		Assembly asm2 = Assembly.LoadFrom (path2);
+		if (asm1 != asm2) {
+			Console.Error.WriteLine ("expected asm1 {0} and asm2 {1} to be the same", asm1, asm2);
+			return 1;
+		}
+
+		Type t1 = asm1.GetType ("LibClass");
+		Type t2 = asm2.GetType ("LibClass");
+		if (t1 != t2) {
+			Console.Error.WriteLine ("expected t1 {0} and t2 {1} to be the same", t1, t2);
+			return 2;
+		}
+			
+		object o1 = Activator.CreateInstance (t1);
+		object o2 = Activator.CreateInstance (t2);
+
+		string s1 = o1.ToString ();
+		string s2 = o2.ToString ();
+
+		if (s1 != s2) {
+			Console.Error.WriteLine ("expected s1 {0} and s1 {1} to be the same", s1, s2);
+			return 3;
+		}
+
+		return 0;
+	}
+}

--- a/tools/pedump/pedump.c
+++ b/tools/pedump/pedump.c
@@ -568,7 +568,7 @@ try_load_from (MonoAssembly **assembly, const gchar *path1, const gchar *path2,
 	*assembly = NULL;
 	fullpath = g_build_filename (path1, path2, path3, path4, NULL);
 	if (g_file_test (fullpath, G_FILE_TEST_IS_REGULAR))
-		*assembly = mono_assembly_open_predicate (fullpath, refonly, FALSE, NULL, NULL, NULL);
+		*assembly = mono_assembly_open_predicate (fullpath, refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT, NULL, NULL, NULL);
 
 	g_free (fullpath);
 	return (*assembly != NULL);
@@ -794,7 +794,7 @@ main (int argc, char *argv [])
 
 		mono_verifier_set_mode (verifier_mode);
 
-		assembly = mono_assembly_open_predicate (file, FALSE, FALSE, NULL, NULL, NULL);
+		assembly = mono_assembly_open_predicate (file, MONO_ASMCTX_DEFAULT, NULL, NULL, NULL);
 		/*fake an assembly for netmodules so the verifier works*/
 		if (!assembly && (image = mono_image_open (file, &status)) && image->tables [MONO_TABLE_ASSEMBLY].rows == 0) {
 			assembly = g_new0 (MonoAssembly, 1);


### PR DESCRIPTION
There are 4 different ways that an assembly can be loaded in .NET:
1. default context - `Assembly.Load(string)` does this.
2. reflection only context - `Assembly.ReflectionOnlyLoad` and `Assembly.ReflectionOnlyLoadFrom` do this.
2. load from context - `Assembly.LoadFrom(string)` does this. The interesting bit is that the assembly at the specified path is probed for its assembly name, and then binding redirects are applied to figure out if we need to load a different version of the assembly (from elsewhere in the search path, presumably).
3. "no context" (.NET Core's [AssemblyLoadContext](https://github.com/dotnet/coreclr/blob/master/Documentation/design-docs/assemblyloadcontext.md) design doc calls it "custom context", and internally they implement it as `IndividualAssemblyLoadContext`) - in Mono I'm going to call it the "individual context".  This is what `Assembly.LoadFile(string)` and `Assembly.Load(byte[])` do: you get exactly the thing you asked for even if something with the same assembly name is already loaded and you get to have problems with type resolution.

So this PR adds:
1. `MonoAssemblyLoadContextKind` enum - default, refonly, loadfrom and individual.
2. Store the `MonoAssemblyLoadContext` in every `MonoAssembly` instead of a boolean `refonly` flag.
3. When loading references from assemblies, consider the load context of the requesting assembly.
4. Do the wacky `LoadFrom` probe and rebind dance.
5. Don't check for duplicated for the individual assembly context.

Not in this PR:

The managed assembly load context stuff in .NET Core.  If we eventually want to add it, it will likely build on this work, but it's not here now.

Fixes: #8149, #8152, [bugzilla #11199](https://bugzilla.xamarin.com/show_bug.cgi?id=11199), [bugzilla #33728](https://bugzilla.xamarin.com/show_bug.cgi?id=33728)

TODO:
- [x] Add tests.  (I tried the repros from all the bugs above, but didn't turn them into tests yet).
- [x] Check that `ReflectionOnlyLoadFrom` is correct and binding redirects do not apply to it.
- [x] ~Find out what happens in this situation: directory `d` contains `Asm1.dll` version 1 and `Asm2.dll` version 1. App has a binding redirect for `Asm1` all versions to version 2.  normal app probing path has `Asm1` version 2 and `Asm2` version 2. `LoadFrom(d/Asm1.dll)` and then cause the `Asm2` reference to be loaded - do we get `Asm2` version 1 or version 2.  (ie did we retain `d` as a probing path even though the redirect made us look for `Asm1` somewhere else)~ it's fine... there's nothing that remembers that we started with a `LoadFrom` in `d/`. 
- [x] FIXME: resolving references from individual context assemblies should only fire the `AssemblyResolve` event and not look in the default context.
- [x] FIXME: SRE assemblies should be in the individual context.
- [x] FIXME: "assemblies that are loaded from byte arrays are loaded without context unless their identity (after policy is applied) establishes that they are in the global assembly cache." - I'm not applying policy or looking in the GAC...
- [x] Figure out the FIXMEs by trying .NET Framework
  - [x] ~If `LoadFrom` is subject to a binding redirect, where should `LoadFrom` look for the replacement assembly. Is the given filename's basename relevant at all? Is the new assembly loaded in the default context?~ No
  - [x] Should any sort of deduplication happen for `LoadFile` and `Load(byte[])` - should you really get brand new `MonoAssembly*` pointers every time (even if for `LoadFile` the `MonoImage` is shared).
  - [x] Am I firing all the right managed events? As best I can tell, yes.
