### PR TITLE
Remove unused signal.h include in interp.c

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -21,7 +21,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <glib.h>
-#include <signal.h>
 #include <math.h>
 #include <locale.h>
 


### PR DESCRIPTION
This include breaks compiling the interpreter on platforms which don't have a signal.h. The code in interp.c doesn't seem to need it to be included anyway.
