### PR TITLE
[2018-02] Fix mono_perfcounter_instance_exists to match prototype when #ifndef …

### DIFF
--- a/mono/metadata/mono-perfcounters.c
+++ b/mono/metadata/mono-perfcounters.c
@@ -1957,7 +1957,7 @@ mono_perfcounter_create (MonoString *category, MonoString *help, int type, MonoA
 	g_assert_not_reached ();
 }
 
-int
+MonoBoolean
 mono_perfcounter_instance_exists (MonoString *instance, MonoString *category)
 {
 	g_assert_not_reached ();


### PR DESCRIPTION
Backport of #8302.

/cc @lewurm