### PR TITLE
[interp] remove useless assert in mint_newobj

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3575,8 +3575,6 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 				}
 			}
 
-			g_assert (csig->call_convention == MONO_CALL_DEFAULT);
-
 			interp_exec_method (&child_frame, context);
 
 			context->current_frame = frame;


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/8329. That is, make the interpreter work on Windows.


No idea what the original indent of this assert was, it came with the import of the old interpreter code base.