### PR TITLE
[interp] fix warning introduced with 8e0a12189a84

### DIFF
--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -2867,7 +2867,7 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsig
 			} else {
 				/* defer allocation to execution-time */
 				ADD_CODE (td, MINT_LDSTR_TOKEN);
-				ADD_CODE (td, get_data_item_index (td, (gpointer) token));
+				ADD_CODE (td, get_data_item_index (td, GUINT_TO_POINTER (token)));
 			}
 			PUSH_TYPE(td, STACK_TYPE_O, mono_defaults.string_class);
 			break;


### PR DESCRIPTION
```
interp/transform.c:2870:44: warning: cast to 'gpointer' (aka 'void *') from smaller integer type 'guint32' (aka 'unsigned int') [-Wint-to-void-pointer-cast]
                                ADD_CODE (td, get_data_item_index (td, (gpointer) token));
                                                                       ^
```
