### PR TITLE
Reduce #ifdef MONO_ARCH_SOFT_FLOAT_FALLBACK, and #if SIZEOF_VOID_P == 4.

### DIFF
--- a/mono/mini/alias-analysis.c
+++ b/mono/mini/alias-analysis.c
@@ -195,6 +195,10 @@ handle_instruction:
 				}
 				break;
 
+			case OP_LOADR4_MEMBASE:
+				if (MONO_ARCH_SOFT_FLOAT_FALLBACK)
+					break;
+				// fallthrough
 			case OP_LOADV_MEMBASE:
 			case OP_LOAD_MEMBASE:
 			case OP_LOADU1_MEMBASE:
@@ -204,9 +208,6 @@ handle_instruction:
 			case OP_LOADU4_MEMBASE:
 			case OP_LOADI1_MEMBASE:
 			case OP_LOADI8_MEMBASE:
-#ifndef MONO_ARCH_SOFT_FLOAT_FALLBACK
-			case OP_LOADR4_MEMBASE:
-#endif
 			case OP_LOADR8_MEMBASE:
 				if (ins->inst_offset != 0)
 					continue;
@@ -221,14 +222,15 @@ handle_instruction:
 				}
 				break;
 
+			case OP_STORER4_MEMBASE_REG:
+				if (MONO_ARCH_SOFT_FLOAT_FALLBACK)
+					break;
+				// fallthrough
 			case OP_STORE_MEMBASE_REG:
 			case OP_STOREI1_MEMBASE_REG:
 			case OP_STOREI2_MEMBASE_REG:
 			case OP_STOREI4_MEMBASE_REG:
 			case OP_STOREI8_MEMBASE_REG:
-#ifndef MONO_ARCH_SOFT_FLOAT_FALLBACK
-			case OP_STORER4_MEMBASE_REG:
-#endif
 			case OP_STORER8_MEMBASE_REG:
 			case OP_STOREV_MEMBASE:
 				if (ins->inst_offset != 0)

--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -1583,8 +1583,6 @@ typedef union {
 	double vald;
 } DVal;
 
-#ifdef MONO_ARCH_SOFT_FLOAT_FALLBACK
-
 /**
  * mono_decompose_soft_float:
  *
@@ -1596,6 +1594,8 @@ typedef union {
 void
 mono_decompose_soft_float (MonoCompile *cfg)
 {
+	mono_soft_float_reached ();
+
 	MonoBasicBlock *bb, *first_bb;
 
 	/*
@@ -1880,8 +1880,6 @@ mono_decompose_soft_float (MonoCompile *cfg)
 
 	mono_decompose_long_opts (cfg);
 }
-
-#endif
 
 void
 mono_local_emulate_ops (MonoCompile *cfg)

--- a/mono/mini/ir-emit.h
+++ b/mono/mini/ir-emit.h
@@ -504,14 +504,13 @@ handle_gsharedvt_ldaddr (MonoCompile *cfg)
 
 #define EMIT_NEW_VARLOADA(cfg,dest,var,vartype) do { NEW_VARLOADA ((cfg), (dest), (var), (vartype)); MONO_ADD_INS ((cfg)->cbb, (dest)); } while (0)
 
-#ifdef MONO_ARCH_SOFT_FLOAT_FALLBACK
-
 /*
  * Since the IL stack (and our vregs) contain double values, we have to do a conversion
  * when loading/storing args/locals of type R4.
  */
 
 #define EMIT_NEW_VARLOAD_SFLOAT(cfg,dest,var,vartype) do { \
+		mono_soft_float_reached (); \
 		if (!COMPILE_LLVM ((cfg)) && !(vartype)->byref && (vartype)->type == MONO_TYPE_R4) { \
 			MonoInst *iargs [1]; \
 			EMIT_NEW_VARLOADA (cfg, iargs [0], (var), (vartype)); \
@@ -522,6 +521,7 @@ handle_gsharedvt_ldaddr (MonoCompile *cfg)
 	} while (0)
 
 #define EMIT_NEW_VARSTORE_SFLOAT(cfg,dest,var,vartype,inst) do {	\
+		mono_soft_float_reached (); \
 		if (COMPILE_SOFT_FLOAT ((cfg)) && !(vartype)->byref && (vartype)->type == MONO_TYPE_R4) { \
 			MonoInst *iargs [2]; \
 			iargs [0] = (inst); \
@@ -567,18 +567,6 @@ handle_gsharedvt_ldaddr (MonoCompile *cfg)
 			MONO_ADD_INS ((cfg)->cbb, (dest));	\
 		}	\
 	} while (0)
-
-#else
-
-#define EMIT_NEW_ARGLOAD(cfg,dest,num) do { NEW_ARGLOAD ((cfg), (dest), (num)); MONO_ADD_INS ((cfg)->cbb, (dest)); } while (0)
-
-#define EMIT_NEW_LOCLOAD(cfg,dest,num) do { NEW_LOCLOAD ((cfg), (dest), (num)); MONO_ADD_INS ((cfg)->cbb, (dest)); } while (0)
-
-#define EMIT_NEW_LOCSTORE(cfg,dest,num,inst) do { NEW_LOCSTORE ((cfg), (dest), (num), (inst)); MONO_ADD_INS ((cfg)->cbb, (dest)); } while (0)
-
-#define EMIT_NEW_ARGSTORE(cfg,dest,num,inst) do { NEW_ARGSTORE ((cfg), (dest), (num), (inst)); MONO_ADD_INS ((cfg)->cbb, (dest)); } while (0)
-
-#endif
 
 #define EMIT_NEW_TEMPLOAD(cfg,dest,num) do { NEW_TEMPLOAD ((cfg), (dest), (num)); MONO_ADD_INS ((cfg)->cbb, (dest)); } while (0)
 

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -476,35 +476,35 @@ mono_fdiv (double a, double b)
 #endif
 }
 
-double
+static double
 mono_fsub (double a, double b)
 {
 	mono_soft_float_reached ();
 	return a - b;
 }
 
-double
+static double
 mono_fadd (double a, double b)
 {
 	mono_soft_float_reached ();
 	return a + b;
 }
 
-double
+static double
 mono_fmul (double a, double b)
 {
 	mono_soft_float_reached ();
 	return a * b;
 }
 
-double
+static double
 mono_fneg (double a)
 {
 	mono_soft_float_reached ();
 	return -a;
 }
 
-double
+static double
 mono_fconv_r4 (double a)
 {
 	mono_soft_float_reached ();
@@ -525,140 +525,140 @@ mono_conv_to_r4 (int a)
 	return (double)(float)a;
 }
 
-gint8
+static gint8
 mono_fconv_i1 (double a)
 {
 	mono_soft_float_reached ();
 	return (gint8)a;
 }
 
-gint16
+static gint16
 mono_fconv_i2 (double a)
 {
 	mono_soft_float_reached ();
 	return (gint16)a;
 }
 
-gint32
+static gint32
 mono_fconv_i4 (double a)
 {
 	mono_soft_float_reached ();
 	return (gint32)a;
 }
 
-guint8
+static guint8
 mono_fconv_u1 (double a)
 {
 	mono_soft_float_reached ();
 	return (guint8)a;
 }
 
-guint16
+static guint16
 mono_fconv_u2 (double a)
 {
 	mono_soft_float_reached ();
 	return (guint16)a;
 }
 
-gboolean
+static gboolean
 mono_fcmp_eq (double a, double b)
 {
 	mono_soft_float_reached ();
 	return a == b;
 }
 
-gboolean
+static gboolean
 mono_fcmp_ge (double a, double b)
 {
 	mono_soft_float_reached ();
 	return a >= b;
 }
 
-gboolean
+static gboolean
 mono_fcmp_gt (double a, double b)
 {
 	mono_soft_float_reached ();
 	return a > b;
 }
 
-gboolean
+static gboolean
 mono_fcmp_le (double a, double b)
 {
 	mono_soft_float_reached ();
 	return a <= b;
 }
 
-gboolean
+static gboolean
 mono_fcmp_lt (double a, double b)
 {
 	mono_soft_float_reached ();
 	return a < b;
 }
 
-gboolean
+static gboolean
 mono_fcmp_ne_un (double a, double b)
 {
 	mono_soft_float_reached ();
 	return isunordered (a, b) || a != b;
 }
 
-gboolean
+static gboolean
 mono_fcmp_ge_un (double a, double b)
 {
 	mono_soft_float_reached ();
 	return isunordered (a, b) || a >= b;
 }
 
-gboolean
+static gboolean
 mono_fcmp_gt_un (double a, double b)
 {
 	mono_soft_float_reached ();
 	return isunordered (a, b) || a > b;
 }
 
-gboolean
+static gboolean
 mono_fcmp_le_un (double a, double b)
 {
 	mono_soft_float_reached ();
 	return isunordered (a, b) || a <= b;
 }
 
-gboolean
+static gboolean
 mono_fcmp_lt_un (double a, double b)
 {
 	mono_soft_float_reached ();
 	return isunordered (a, b) || a < b;
 }
 
-gboolean
+static gboolean
 mono_fceq (double a, double b)
 {
 	mono_soft_float_reached ();
 	return a == b;
 }
 
-gboolean
+static gboolean
 mono_fcgt (double a, double b)
 {
 	mono_soft_float_reached ();
 	return a > b;
 }
 
-gboolean
+static gboolean
 mono_fcgt_un (double a, double b)
 {
 	mono_soft_float_reached ();
 	return isunordered (a, b) || a > b;
 }
 
-gboolean
+static gboolean
 mono_fclt (double a, double b)
 {
 	mono_soft_float_reached ();
 	return a < b;
 }
 
-gboolean
+static gboolean
 mono_fclt_un (double a, double b)
 {
 	mono_soft_float_reached ();
@@ -746,6 +746,80 @@ mono_array_new_va (MonoMethod *cm, ...)
 	}
 
 	return arr;
+}
+
+static void
+register_opcode_emulation (int opcode, const char *name, const char *sigstr, gpointer func, const char *symbol, gboolean no_wrapper)
+// FIXME two copies of this: jit-icalls.c and mini-runtime.c
+{
+#ifndef DISABLE_JIT
+	mini_register_opcode_emulation (opcode, name, sigstr, func, symbol, no_wrapper);
+#else
+	MonoMethodSignature *sig = mono_create_icall_signature (sigstr);
+
+	g_assert (!sig->hasthis);
+	g_assert (sig->param_count < 3);
+
+	mono_register_jit_icall_full (func, name, sig, no_wrapper, symbol);
+#endif
+}
+
+/*
+ * For JIT icalls implemented in C.
+ * NAME should be the same as the name of the C function whose address is FUNC.
+ */
+static void
+register_icall_helper (gpointer func, const char *name, const char *sigstr)
+{
+	g_assert (sigstr);
+	mono_register_jit_icall_full (func, name, mono_create_icall_signature (sigstr), FALSE, NULL);
+}
+
+#define register_icall(func, sigstr) (register_icall_helper (func, #func, sigstr))
+
+void
+mono_register_icalls_soft_float (void)
+{
+	if (!mono_arch_is_soft_float ())
+		return;
+
+	register_opcode_emulation (OP_FSUB, "__emul_fsub", "double double double", mono_fsub, "mono_fsub", FALSE);
+	register_opcode_emulation (OP_FADD, "__emul_fadd", "double double double", mono_fadd, "mono_fadd", FALSE);
+	register_opcode_emulation (OP_FMUL, "__emul_fmul", "double double double", mono_fmul, "mono_fmul", FALSE);
+	register_opcode_emulation (OP_FNEG, "__emul_fneg", "double double", mono_fneg, "mono_fneg", FALSE);
+	register_opcode_emulation (OP_ICONV_TO_R8, "__emul_iconv_to_r8", "double int32", mono_conv_to_r8, "mono_conv_to_r8", FALSE);
+	register_opcode_emulation (OP_ICONV_TO_R4, "__emul_iconv_to_r4", "double int32", mono_conv_to_r4, "mono_conv_to_r4", FALSE);
+	register_opcode_emulation (OP_FCONV_TO_R4, "__emul_fconv_to_r4", "double double", mono_fconv_r4, "mono_fconv_r4", FALSE);
+	register_opcode_emulation (OP_FCONV_TO_I1, "__emul_fconv_to_i1", "int8 double", mono_fconv_i1, "mono_fconv_i1", FALSE);
+	register_opcode_emulation (OP_FCONV_TO_I2, "__emul_fconv_to_i2", "int16 double", mono_fconv_i2, "mono_fconv_i2", FALSE);
+	register_opcode_emulation (OP_FCONV_TO_I4, "__emul_fconv_to_i4", "int32 double", mono_fconv_i4, "mono_fconv_i4", FALSE);
+	register_opcode_emulation (OP_FCONV_TO_U1, "__emul_fconv_to_u1", "uint8 double", mono_fconv_u1, "mono_fconv_u1", FALSE);
+	register_opcode_emulation (OP_FCONV_TO_U2, "__emul_fconv_to_u2", "uint16 double", mono_fconv_u2, "mono_fconv_u2", FALSE);
+
+	if (SIZEOF_VOID_P == 4)
+		register_opcode_emulation (OP_FCONV_TO_I, "__emul_fconv_to_i", "int32 double", mono_fconv_i4, "mono_fconv_i4", FALSE);
+
+	register_opcode_emulation (OP_FBEQ, "__emul_fcmp_eq", "uint32 double double", mono_fcmp_eq, "mono_fcmp_eq", FALSE);
+	register_opcode_emulation (OP_FBLT, "__emul_fcmp_lt", "uint32 double double", mono_fcmp_lt, "mono_fcmp_lt", FALSE);
+	register_opcode_emulation (OP_FBGT, "__emul_fcmp_gt", "uint32 double double", mono_fcmp_gt, "mono_fcmp_gt", FALSE);
+	register_opcode_emulation (OP_FBLE, "__emul_fcmp_le", "uint32 double double", mono_fcmp_le, "mono_fcmp_le", FALSE);
+	register_opcode_emulation (OP_FBGE, "__emul_fcmp_ge", "uint32 double double", mono_fcmp_ge, "mono_fcmp_ge", FALSE);
+	register_opcode_emulation (OP_FBNE_UN, "__emul_fcmp_ne_un", "uint32 double double", mono_fcmp_ne_un, "mono_fcmp_ne_un", FALSE);
+	register_opcode_emulation (OP_FBLT_UN, "__emul_fcmp_lt_un", "uint32 double double", mono_fcmp_lt_un, "mono_fcmp_lt_un", FALSE);
+	register_opcode_emulation (OP_FBGT_UN, "__emul_fcmp_gt_un", "uint32 double double", mono_fcmp_gt_un, "mono_fcmp_gt_un", FALSE);
+	register_opcode_emulation (OP_FBLE_UN, "__emul_fcmp_le_un", "uint32 double double", mono_fcmp_le_un, "mono_fcmp_le_un", FALSE);
+	register_opcode_emulation (OP_FBGE_UN, "__emul_fcmp_ge_un", "uint32 double double", mono_fcmp_ge_un, "mono_fcmp_ge_un", FALSE);
+
+	register_opcode_emulation (OP_FCEQ, "__emul_fcmp_ceq", "uint32 double double", mono_fceq, "mono_fceq", FALSE);
+	register_opcode_emulation (OP_FCGT, "__emul_fcmp_cgt", "uint32 double double", mono_fcgt, "mono_fcgt", FALSE);
+	register_opcode_emulation (OP_FCGT_UN, "__emul_fcmp_cgt_un", "uint32 double double", mono_fcgt_un, "mono_fcgt_un", FALSE);
+	register_opcode_emulation (OP_FCLT, "__emul_fcmp_clt", "uint32 double double", mono_fclt, "mono_fclt", FALSE);
+	register_opcode_emulation (OP_FCLT_UN, "__emul_fcmp_clt_un", "uint32 double double", mono_fclt_un, "mono_fclt_un", FALSE);
+
+	register_icall (mono_fload_r4, "double ptr");
+	register_icall (mono_fstore_r4, "void double ptr");
+	register_icall (mono_fload_r4_arg, "uint32 double");
+	register_icall (mono_isfinite, "uint32 double");
 }
 
 /* Specialized version of mono_array_new_va () which avoids varargs */

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -466,181 +466,209 @@ mono_imul_ovf_un (guint32 a, guint32 b)
 }
 #endif
 
-#if defined(MONO_ARCH_EMULATE_MUL_DIV) || defined(MONO_ARCH_SOFT_FLOAT_FALLBACK)
 double
 mono_fdiv (double a, double b)
 {
+#if defined(MONO_ARCH_EMULATE_MUL_DIV) || MONO_ARCH_SOFT_FLOAT_FALLBACK
 	return a / b;
-}
+#else
+	g_assert_not_reached ();
 #endif
-
-#ifdef MONO_ARCH_SOFT_FLOAT_FALLBACK
+}
 
 double
 mono_fsub (double a, double b)
 {
+	mono_soft_float_reached ();
 	return a - b;
 }
 
 double
 mono_fadd (double a, double b)
 {
+	mono_soft_float_reached ();
 	return a + b;
 }
 
 double
 mono_fmul (double a, double b)
 {
+	mono_soft_float_reached ();
 	return a * b;
 }
 
 double
 mono_fneg (double a)
 {
+	mono_soft_float_reached ();
 	return -a;
 }
 
 double
 mono_fconv_r4 (double a)
 {
+	mono_soft_float_reached ();
 	return (float)a;
 }
 
 double
 mono_conv_to_r8 (int a)
 {
+	mono_soft_float_reached ();
 	return (double)a;
 }
 
 double
 mono_conv_to_r4 (int a)
 {
+	mono_soft_float_reached ();
 	return (double)(float)a;
 }
 
 gint8
 mono_fconv_i1 (double a)
 {
+	mono_soft_float_reached ();
 	return (gint8)a;
 }
 
 gint16
 mono_fconv_i2 (double a)
 {
+	mono_soft_float_reached ();
 	return (gint16)a;
 }
 
 gint32
 mono_fconv_i4 (double a)
 {
+	mono_soft_float_reached ();
 	return (gint32)a;
 }
 
 guint8
 mono_fconv_u1 (double a)
 {
+	mono_soft_float_reached ();
 	return (guint8)a;
 }
 
 guint16
 mono_fconv_u2 (double a)
 {
+	mono_soft_float_reached ();
 	return (guint16)a;
 }
 
 gboolean
 mono_fcmp_eq (double a, double b)
 {
+	mono_soft_float_reached ();
 	return a == b;
 }
 
 gboolean
 mono_fcmp_ge (double a, double b)
 {
+	mono_soft_float_reached ();
 	return a >= b;
 }
 
 gboolean
 mono_fcmp_gt (double a, double b)
 {
+	mono_soft_float_reached ();
 	return a > b;
 }
 
 gboolean
 mono_fcmp_le (double a, double b)
 {
+	mono_soft_float_reached ();
 	return a <= b;
 }
 
 gboolean
 mono_fcmp_lt (double a, double b)
 {
+	mono_soft_float_reached ();
 	return a < b;
 }
 
 gboolean
 mono_fcmp_ne_un (double a, double b)
 {
+	mono_soft_float_reached ();
 	return isunordered (a, b) || a != b;
 }
 
 gboolean
 mono_fcmp_ge_un (double a, double b)
 {
+	mono_soft_float_reached ();
 	return isunordered (a, b) || a >= b;
 }
 
 gboolean
 mono_fcmp_gt_un (double a, double b)
 {
+	mono_soft_float_reached ();
 	return isunordered (a, b) || a > b;
 }
 
 gboolean
 mono_fcmp_le_un (double a, double b)
 {
+	mono_soft_float_reached ();
 	return isunordered (a, b) || a <= b;
 }
 
 gboolean
 mono_fcmp_lt_un (double a, double b)
 {
+	mono_soft_float_reached ();
 	return isunordered (a, b) || a < b;
 }
 
 gboolean
 mono_fceq (double a, double b)
 {
+	mono_soft_float_reached ();
 	return a == b;
 }
 
 gboolean
 mono_fcgt (double a, double b)
 {
+	mono_soft_float_reached ();
 	return a > b;
 }
 
 gboolean
 mono_fcgt_un (double a, double b)
 {
+	mono_soft_float_reached ();
 	return isunordered (a, b) || a > b;
 }
 
 gboolean
 mono_fclt (double a, double b)
 {
+	mono_soft_float_reached ();
 	return a < b;
 }
 
 gboolean
 mono_fclt_un (double a, double b)
 {
+	mono_soft_float_reached ();
 	return isunordered (a, b) || a < b;
 }
 
 gboolean
 mono_isfinite (double a)
 {
+	mono_soft_float_reached ();
 #ifdef HAVE_ISFINITE
 	return isfinite (a);
 #else
@@ -652,12 +680,14 @@ mono_isfinite (double a)
 double
 mono_fload_r4 (float *ptr)
 {
+	mono_soft_float_reached ();
 	return *ptr;
 }
 
 void
 mono_fstore_r4 (double val, float *ptr)
 {
+	mono_soft_float_reached ();
 	*ptr = (float)val;
 }
 
@@ -665,11 +695,10 @@ mono_fstore_r4 (double val, float *ptr)
 guint32
 mono_fload_r4_arg (double val)
 {
+	mono_soft_float_reached ();
 	float v = (float)val;
 	return *(guint32*)&v;
 }
-
-#endif
 
 MonoArray *
 mono_array_new_va (MonoMethod *cm, ...)
@@ -998,10 +1027,8 @@ mono_fconv_ovf_i8 (double v)
 guint64
 mono_fconv_ovf_u8 (double v)
 {
-	guint64 res;
-
 /*
- * The soft-float implementation of some ARM devices have a buggy guin64 to double
+ * The soft-float implementation of some ARM devices have a buggy guint64 to double
  * conversion that it looses precision even when the integer if fully representable
  * as a double.
  * 
@@ -1009,19 +1036,21 @@ mono_fconv_ovf_u8 (double v)
  * 
  * To work around this issue we test for value boundaries instead. 
  */
-#if defined(__arm__) && defined(MONO_ARCH_SOFT_FLOAT_FALLBACK)
-	if (isnan (v) || !(v >= -0.5 && v <= ULLONG_MAX+0.5)) {
-		mono_set_pending_exception (mono_get_exception_overflow ());
-		return 0;
+#if defined(__arm__)
+	if (MONO_ARCH_SOFT_FLOAT_FALLBACK) {
+		if (isnan (v) || !(v >= -0.5 && v <= ULLONG_MAX+0.5)) {
+			mono_set_pending_exception (mono_get_exception_overflow ());
+			return 0;
+		}
+		return (guint64)v;
 	}
-	res = (guint64)v;
-#else
+#endif
+	guint64 res;
 	res = (guint64)v;
 	if (isnan(v) || trunc (v) != res) {
 		mono_set_pending_exception (mono_get_exception_overflow ());
 		return 0;
 	}
-#endif
 	return res;
 }
 

--- a/mono/mini/jit-icalls.h
+++ b/mono/mini/jit-icalls.h
@@ -110,56 +110,6 @@ MonoString *mono_helper_ldstr_mscorlib (guint32 idx);
 
 MonoObject *mono_helper_newobj_mscorlib (guint32 idx);
 
-double mono_fsub (double a, double b);
-
-double mono_fadd (double a, double b);
-
-double mono_fmul (double a, double b);
-
-double mono_fneg (double a);
-
-double mono_fconv_r4 (double a);
-
-gint8 mono_fconv_i1 (double a);
-
-gint16 mono_fconv_i2 (double a);
-
-gint32 mono_fconv_i4 (double a);
-
-guint8 mono_fconv_u1 (double a);
-
-guint16 mono_fconv_u2 (double a);
-
-gboolean mono_fcmp_eq (double a, double b);
-
-gboolean mono_fcmp_ge (double a, double b);
-
-gboolean mono_fcmp_gt (double a, double b);
-
-gboolean mono_fcmp_le (double a, double b);
-
-gboolean mono_fcmp_lt (double a, double b);
-
-gboolean mono_fcmp_ne_un (double a, double b);
-
-gboolean mono_fcmp_ge_un (double a, double b);
-
-gboolean mono_fcmp_gt_un (double a, double b);
-
-gboolean mono_fcmp_le_un (double a, double b);
-
-gboolean mono_fcmp_lt_un (double a, double b);
-
-gboolean mono_fceq (double a, double b);
-
-gboolean mono_fcgt (double a, double b);
-
-gboolean mono_fcgt_un (double a, double b);
-
-gboolean mono_fclt (double a, double b);
-
-gboolean mono_fclt_un (double a, double b);
-
 gboolean mono_isfinite (double a);
 
 double   mono_fload_r4 (float *ptr);

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -49,6 +49,7 @@
 #include "mini-gc.h"
 #include "mini-runtime.h"
 #include "aot-runtime.h"
+#include "jit-icalls.h"
 
 #ifdef MONO_XEN_OPT
 static gboolean optimize_for_xen = TRUE;

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -940,7 +940,7 @@ mono_arch_opcode_needs_emulation (MonoCompile *cfg, int opcode)
 	return TRUE;
 }
 
-#ifdef MONO_ARCH_SOFT_FLOAT_FALLBACK
+#if MONO_ARCH_SOFT_FLOAT_FALLBACK
 gboolean
 mono_arch_is_soft_float (void)
 {

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4332,7 +4332,7 @@ register_icalls (void)
 	register_opcode_emulation (OP_IMUL_OVF_UN, "__emul_op_imul_ovf_un", "int32 int32 int32", mono_imul_ovf_un, "mono_imul_ovf_un", FALSE);
 #endif
 
-#if defined(MONO_ARCH_EMULATE_MUL_DIV) || defined(MONO_ARCH_SOFT_FLOAT_FALLBACK)
+#if defined(MONO_ARCH_EMULATE_MUL_DIV) || MONO_ARCH_SOFT_FLOAT_FALLBACK
 	register_opcode_emulation (OP_FDIV, "__emul_fdiv", "double double double", mono_fdiv, "mono_fdiv", FALSE);
 #endif
 
@@ -4367,7 +4367,6 @@ register_icalls (void)
 	register_opcode_emulation (OP_RREM, "__emul_rrem", "float float float", fmodf, "fmodf", FALSE);
 #endif
 
-#ifdef MONO_ARCH_SOFT_FLOAT_FALLBACK
 	if (mono_arch_is_soft_float ()) {
 		register_opcode_emulation (OP_FSUB, "__emul_fsub", "double double double", mono_fsub, "mono_fsub", FALSE);
 		register_opcode_emulation (OP_FADD, "__emul_fadd", "double double double", mono_fadd, "mono_fadd", FALSE);
@@ -4382,9 +4381,8 @@ register_icalls (void)
 		register_opcode_emulation (OP_FCONV_TO_U1, "__emul_fconv_to_u1", "uint8 double", mono_fconv_u1, "mono_fconv_u1", FALSE);
 		register_opcode_emulation (OP_FCONV_TO_U2, "__emul_fconv_to_u2", "uint16 double", mono_fconv_u2, "mono_fconv_u2", FALSE);
 
-#if SIZEOF_VOID_P == 4
-		register_opcode_emulation (OP_FCONV_TO_I, "__emul_fconv_to_i", "int32 double", mono_fconv_i4, "mono_fconv_i4", FALSE);
-#endif
+		if (SIZEOF_VOID_P == 4)
+			register_opcode_emulation (OP_FCONV_TO_I, "__emul_fconv_to_i", "int32 double", mono_fconv_i4, "mono_fconv_i4", FALSE);
 
 		register_opcode_emulation (OP_FBEQ, "__emul_fcmp_eq", "uint32 double double", mono_fcmp_eq, "mono_fcmp_eq", FALSE);
 		register_opcode_emulation (OP_FBLT, "__emul_fcmp_lt", "uint32 double double", mono_fcmp_lt, "mono_fcmp_lt", FALSE);
@@ -4408,7 +4406,7 @@ register_icalls (void)
 		register_icall (mono_fload_r4_arg, "mono_fload_r4_arg", "uint32 double", FALSE);
 		register_icall (mono_isfinite, "mono_isfinite", "uint32 double", FALSE);
 	}
-#endif
+
 	register_icall (mono_ckfinite, "mono_ckfinite", "double double", FALSE);
 
 #ifdef COMPRESSED_INTERFACE_BITMAP

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -664,6 +664,7 @@ mono_dynamic_code_hash_lookup (MonoDomain *domain, MonoMethod *method)
 
 static void
 register_opcode_emulation (int opcode, const char *name, const char *sigstr, gpointer func, const char *symbol, gboolean no_wrapper)
+// FIXME two copies of this: jit-icalls.c and mini-runtime.c
 {
 #ifndef DISABLE_JIT
 	mini_register_opcode_emulation (opcode, name, sigstr, func, symbol, no_wrapper);
@@ -4367,45 +4368,7 @@ register_icalls (void)
 	register_opcode_emulation (OP_RREM, "__emul_rrem", "float float float", fmodf, "fmodf", FALSE);
 #endif
 
-	if (mono_arch_is_soft_float ()) {
-		register_opcode_emulation (OP_FSUB, "__emul_fsub", "double double double", mono_fsub, "mono_fsub", FALSE);
-		register_opcode_emulation (OP_FADD, "__emul_fadd", "double double double", mono_fadd, "mono_fadd", FALSE);
-		register_opcode_emulation (OP_FMUL, "__emul_fmul", "double double double", mono_fmul, "mono_fmul", FALSE);
-		register_opcode_emulation (OP_FNEG, "__emul_fneg", "double double", mono_fneg, "mono_fneg", FALSE);
-		register_opcode_emulation (OP_ICONV_TO_R8, "__emul_iconv_to_r8", "double int32", mono_conv_to_r8, "mono_conv_to_r8", FALSE);
-		register_opcode_emulation (OP_ICONV_TO_R4, "__emul_iconv_to_r4", "double int32", mono_conv_to_r4, "mono_conv_to_r4", FALSE);
-		register_opcode_emulation (OP_FCONV_TO_R4, "__emul_fconv_to_r4", "double double", mono_fconv_r4, "mono_fconv_r4", FALSE);
-		register_opcode_emulation (OP_FCONV_TO_I1, "__emul_fconv_to_i1", "int8 double", mono_fconv_i1, "mono_fconv_i1", FALSE);
-		register_opcode_emulation (OP_FCONV_TO_I2, "__emul_fconv_to_i2", "int16 double", mono_fconv_i2, "mono_fconv_i2", FALSE);
-		register_opcode_emulation (OP_FCONV_TO_I4, "__emul_fconv_to_i4", "int32 double", mono_fconv_i4, "mono_fconv_i4", FALSE);
-		register_opcode_emulation (OP_FCONV_TO_U1, "__emul_fconv_to_u1", "uint8 double", mono_fconv_u1, "mono_fconv_u1", FALSE);
-		register_opcode_emulation (OP_FCONV_TO_U2, "__emul_fconv_to_u2", "uint16 double", mono_fconv_u2, "mono_fconv_u2", FALSE);
-
-		if (SIZEOF_VOID_P == 4)
-			register_opcode_emulation (OP_FCONV_TO_I, "__emul_fconv_to_i", "int32 double", mono_fconv_i4, "mono_fconv_i4", FALSE);
-
-		register_opcode_emulation (OP_FBEQ, "__emul_fcmp_eq", "uint32 double double", mono_fcmp_eq, "mono_fcmp_eq", FALSE);
-		register_opcode_emulation (OP_FBLT, "__emul_fcmp_lt", "uint32 double double", mono_fcmp_lt, "mono_fcmp_lt", FALSE);
-		register_opcode_emulation (OP_FBGT, "__emul_fcmp_gt", "uint32 double double", mono_fcmp_gt, "mono_fcmp_gt", FALSE);
-		register_opcode_emulation (OP_FBLE, "__emul_fcmp_le", "uint32 double double", mono_fcmp_le, "mono_fcmp_le", FALSE);
-		register_opcode_emulation (OP_FBGE, "__emul_fcmp_ge", "uint32 double double", mono_fcmp_ge, "mono_fcmp_ge", FALSE);
-		register_opcode_emulation (OP_FBNE_UN, "__emul_fcmp_ne_un", "uint32 double double", mono_fcmp_ne_un, "mono_fcmp_ne_un", FALSE);
-		register_opcode_emulation (OP_FBLT_UN, "__emul_fcmp_lt_un", "uint32 double double", mono_fcmp_lt_un, "mono_fcmp_lt_un", FALSE);
-		register_opcode_emulation (OP_FBGT_UN, "__emul_fcmp_gt_un", "uint32 double double", mono_fcmp_gt_un, "mono_fcmp_gt_un", FALSE);
-		register_opcode_emulation (OP_FBLE_UN, "__emul_fcmp_le_un", "uint32 double double", mono_fcmp_le_un, "mono_fcmp_le_un", FALSE);
-		register_opcode_emulation (OP_FBGE_UN, "__emul_fcmp_ge_un", "uint32 double double", mono_fcmp_ge_un, "mono_fcmp_ge_un", FALSE);
-
-		register_opcode_emulation (OP_FCEQ, "__emul_fcmp_ceq", "uint32 double double", mono_fceq, "mono_fceq", FALSE);
-		register_opcode_emulation (OP_FCGT, "__emul_fcmp_cgt", "uint32 double double", mono_fcgt, "mono_fcgt", FALSE);
-		register_opcode_emulation (OP_FCGT_UN, "__emul_fcmp_cgt_un", "uint32 double double", mono_fcgt_un, "mono_fcgt_un", FALSE);
-		register_opcode_emulation (OP_FCLT, "__emul_fcmp_clt", "uint32 double double", mono_fclt, "mono_fclt", FALSE);
-		register_opcode_emulation (OP_FCLT_UN, "__emul_fcmp_clt_un", "uint32 double double", mono_fclt_un, "mono_fclt_un", FALSE);
-
-		register_icall (mono_fload_r4, "mono_fload_r4", "double ptr", FALSE);
-		register_icall (mono_fstore_r4, "mono_fstore_r4", "void double ptr", FALSE);
-		register_icall (mono_fload_r4_arg, "mono_fload_r4_arg", "uint32 double", FALSE);
-		register_icall (mono_isfinite, "mono_isfinite", "uint32 double", FALSE);
-	}
+	mono_register_icalls_soft_float ();
 
 	register_icall (mono_ckfinite, "mono_ckfinite", "double double", FALSE);
 

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3701,10 +3701,9 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 	if (cfg->llvm_only && cfg->gsharedvt)
 		mono_ssa_remove_gsharedvt (cfg);
 
-#ifdef MONO_ARCH_SOFT_FLOAT_FALLBACK
 	if (COMPILE_SOFT_FLOAT (cfg))
 		mono_decompose_soft_float (cfg);
-#endif
+
 	MONO_TIME_TRACK (mono_jit_stats.jit_decompose_vtype_opts, mono_decompose_vtype_opts (cfg));
 	if (cfg->flags & MONO_CFG_HAS_ARRAY_ACCESS) {
 		MONO_TIME_TRACK (mono_jit_stats.jit_decompose_array_access_opts, mono_decompose_array_access_opts (cfg));

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2607,4 +2607,7 @@ gboolean    mono_class_is_magic_float (MonoClass *klass);
 MonoInst*   mono_emit_native_types_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args);
 MonoType*   mini_native_type_replace_type (MonoType *type) MONO_LLVM_INTERNAL;
 
+void
+mono_register_icalls_soft_float (void);
+
 #endif /* __MONO_MINI_H__ */

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -95,8 +95,11 @@
 
 #ifdef MONO_ARCH_SOFT_FLOAT_FALLBACK
 #define COMPILE_SOFT_FLOAT(cfg) (!COMPILE_LLVM ((cfg)) && mono_arch_is_soft_float ())
+#define mono_soft_float_reached() /* nothing */
 #else
+#define MONO_ARCH_SOFT_FLOAT_FALLBACK (0)
 #define COMPILE_SOFT_FLOAT(cfg) (0)
+#define mono_soft_float_reached() g_assert_not_reached ()
 #endif
 
 #define NOT_IMPLEMENTED do { g_assert_not_reached (); } while (0)
@@ -2192,7 +2195,7 @@ gboolean  mono_arch_have_fast_tls               (void);
 void      mono_arch_register_icall              (void);
 #endif
 
-#ifdef MONO_ARCH_SOFT_FLOAT_FALLBACK
+#if MONO_ARCH_SOFT_FLOAT_FALLBACK
 gboolean  mono_arch_is_soft_float               (void);
 #else
 static inline MONO_ALWAYS_INLINE gboolean


### PR DESCRIPTION
The optimizer should be able to do the same.

This reduces ARM32-specific breaks, as more code compiles
for all architectures (but is optimized away).