### PR TITLE
Added P/Invoke support to wasm backend

### DIFF
--- a/mono/utils/mono-dl-wasm.c
+++ b/mono/utils/mono-dl-wasm.c
@@ -12,6 +12,63 @@
 #include <string.h>
 #include <glib.h>
 
+typedef struct MonoDlWasmFunctionEntry
+{
+	char *name;
+	void *ptr;
+	struct MonoDlWasmFunctionEntry *next;
+
+} MonoDlWasmFunctionEntry;
+
+typedef struct MonoDlWasmLibraryEntry
+{
+	char *name;
+	MonoDlWasmFunctionEntry *functions;
+	struct MonoDlWasmLibraryEntry *next;
+
+} MonoDlWasmLibraryEntry;
+
+
+static MonoDlWasmLibraryEntry* mono_dl_wasm_entries = NULL;
+
+
+static MonoDlWasmLibraryEntry *
+mono_dl_wasm_get_library_entry (const char* name, int create)
+{
+	if (name == NULL)
+		name = "__Internal";
+
+	MonoDlWasmLibraryEntry *entry = mono_dl_wasm_entries;
+	while (entry)
+	{
+		if (0 == strcmp (name, entry->name))
+			return entry;
+		entry = entry->next;
+	}
+
+	if (!create)
+		return NULL;
+
+	entry = (MonoDlWasmLibraryEntry *)g_malloc0 (sizeof (MonoDlWasmFunctionEntry));
+	entry->next = mono_dl_wasm_entries;
+	entry->name = g_strdup (name);
+	entry->functions = NULL;
+	mono_dl_wasm_entries = entry;
+	return entry;
+}
+
+void mono_dl_wasm_add_internal_pinvoke (const char *library_name, const char *name, void *ptr)
+{
+	struct MonoDlWasmLibraryEntry *library = mono_dl_wasm_get_library_entry (library_name, TRUE);
+
+	MonoDlWasmFunctionEntry *entry = (MonoDlWasmFunctionEntry *)g_malloc0 (sizeof (MonoDlWasmFunctionEntry));
+	entry->next = library->functions;
+	entry->name = g_strdup (name);
+	entry->ptr = ptr;
+	library->functions = entry;
+}
+
+
 const char *
 mono_dl_get_so_prefix (void)
 {
@@ -45,6 +102,18 @@ mono_dl_get_system_dir (void)
 void*
 mono_dl_lookup_symbol (MonoDl *module, const char *name)
 {
+	if (name == NULL)
+		return NULL;
+	MonoDlWasmLibraryEntry *library = (MonoDlWasmLibraryEntry *) module->handle;
+
+	MonoDlWasmFunctionEntry *entry = library->functions;
+	while (entry)
+	{
+		if (0 == strcmp (name, entry->name))
+			return entry->ptr;
+		entry = entry->next;
+	}
+	
 	return NULL;
 }
 
@@ -64,7 +133,7 @@ mono_dl_convert_flags (int flags)
 void *
 mono_dl_open_file (const char *file, int flags)
 {
-	return NULL;
+	return mono_dl_wasm_get_library_entry (file, FALSE);
 }
 
 void

--- a/sdks/wasm/driver.c
+++ b/sdks/wasm/driver.c
@@ -66,6 +66,7 @@ const char* mono_image_get_name (MonoImage *image);
 const char* mono_class_get_name (MonoClass *klass);
 MonoString* mono_string_new (MonoDomain *domain, const char *text);
 void mono_add_internal_call (const char *name, const void* method);
+void mono_dl_wasm_add_internal_pinvoke (const char *library_name, const char *name, void *ptr);
 MonoString * mono_string_from_utf16 (char *data);
 MonoString* mono_string_new (MonoDomain *domain, const char *text);
 void mono_wasm_enable_debugging (void);


### PR DESCRIPTION
Since it's not quite viable to use dynamic linking provided by WebAssembly itself, one has to statically link the native library to resulting `mono.wasm`. However emsdk has no idea which functions are used and linker removes them. It's also not possible to get a function pointer by its name.

This PR enables accessing such libraries via P/Invoke by manually registering needed imports from a custom driver.c file

#8007
https://github.com/AvaloniaUI/Avalonia/issues/1387

@kumpera 