### PR TITLE
Turn off BTLS assembly optimizations on 32-bit ARM.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4642,6 +4642,7 @@ if test "x$enable_btls" = "xyes"; then
 		;;
 	arm)
 		btls_arch=arm
+		btls_cflags="-DOPENSSL_NO_ASM=1"
 		;;
 	armsoft)
 		btls_arch=arm


### PR DESCRIPTION
See https://github.com/mono/mono/issues/8100