### PR TITLE
[interp] enable more corlib tests

### DIFF
--- a/mcs/class/corlib/Test/Microsoft.Win32/RegistryKeyTest.cs
+++ b/mcs/class/corlib/Test/Microsoft.Win32/RegistryKeyTest.cs
@@ -3189,7 +3189,6 @@ namespace MonoTests.Microsoft.Win32
 
 		// Bug Xamarin 3632
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TypeCastTests ()
 		{
 			string subKeyName = Guid.NewGuid ().ToString ();

--- a/mcs/class/corlib/Test/System.Collections.Concurrent/PartitionerTests.cs
+++ b/mcs/class/corlib/Test/System.Collections.Concurrent/PartitionerTests.cs
@@ -37,7 +37,6 @@ namespace MonoTests.System.Collections.Concurrent
 	public class PartitionerTests
 	{
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void PartitionerCreateIntegerWithExplicitRange ()
 		{
 			OrderablePartitioner<Tuple<int, int>> partitioner = Partitioner.Create (1, 20, 5);
@@ -59,7 +58,6 @@ namespace MonoTests.System.Collections.Concurrent
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void PartitionerCreateLongWithExplicitRange ()
 		{
 			OrderablePartitioner<Tuple<long, long>> partitioner = Partitioner.Create ((long)1, (long)20, (long)5);

--- a/mcs/class/corlib/Test/System.IO/DriveInfoTest.cs
+++ b/mcs/class/corlib/Test/System.IO/DriveInfoTest.cs
@@ -65,7 +65,6 @@ namespace MonoTests.System.IO
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void GetDrivesValidInfo ()
 		{
 			var drives = DriveInfo.GetDrives ();

--- a/mcs/class/corlib/Test/System.Reflection.Emit/DynamicMethodTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection.Emit/DynamicMethodTest.cs
@@ -470,7 +470,6 @@ namespace MonoTests.System.Reflection.Emit
 
 	public delegate object RetObj();
 		[Test] //#640702
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void GetCurrentMethodWorksWithDynamicMethods ()
 		{
 	        DynamicMethod dm = new DynamicMethod("Foo", typeof(object), null);
@@ -527,7 +526,6 @@ namespace MonoTests.System.Reflection.Emit
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void ExceptionHandling ()
 		{
 			var method = new DynamicMethod ("", typeof(void), new[] { typeof(int) }, typeof (DynamicMethodTest));
@@ -594,7 +592,6 @@ namespace MonoTests.System.Reflection.Emit
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void ExceptionHandlingWithExceptionDispatchInfo ()
 		{
 			var method = new DynamicMethod ("", typeof(void), new[] { typeof(int) }, typeof (DynamicMethodTest));
@@ -652,7 +649,6 @@ namespace MonoTests.System.Reflection.Emit
 		}
 
 		[Test] //see bxc #59334
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void ExceptionWrapping ()
 		{
 			AssemblyBuilder ab = AppDomain.CurrentDomain.DefineDynamicAssembly (new AssemblyName ("ehatevfheiw"), AssemblyBuilderAccess.Run);

--- a/mcs/class/corlib/Test/System.Reflection.Emit/MethodBuilderTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection.Emit/MethodBuilderTest.cs
@@ -1024,7 +1024,6 @@ namespace MonoTests.System.Reflection.Emit
 	    }
 
 		[Test]//bug #626441
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void CanCallVarargMethods ()
 		{
 			var tb = module.DefineType ("foo");

--- a/mcs/class/corlib/Test/System.Reflection.Emit/TypeBuilderTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection.Emit/TypeBuilderTest.cs
@@ -1212,7 +1212,6 @@ namespace MonoTests.System.Reflection.Emit
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void DefineDefaultConstructor_Parent_DefaultCtorInaccessible ()
 		{
 			TypeBuilder tb;

--- a/mcs/class/corlib/Test/System.Runtime.ExceptionServices/ExceptionDispatchInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.ExceptionServices/ExceptionDispatchInfoTest.cs
@@ -66,7 +66,6 @@ namespace MonoTests.System.Runtime.ExceptionServices
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void Throw ()
 		{
 			Exception orig = null;
@@ -93,7 +92,6 @@ namespace MonoTests.System.Runtime.ExceptionServices
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void ThrowWithEmptyFrames ()
 		{
 			var edi = ExceptionDispatchInfo.Capture (new OperationCanceledException ());
@@ -108,7 +106,6 @@ namespace MonoTests.System.Runtime.ExceptionServices
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void LastThrowWins ()
 		{
 			Exception e;
@@ -140,7 +137,6 @@ namespace MonoTests.System.Runtime.ExceptionServices
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void ThrowMultipleCaptures ()
 		{
 			Exception e;
@@ -169,7 +165,6 @@ namespace MonoTests.System.Runtime.ExceptionServices
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void StackTraceUserCopy ()
 		{
 			try {

--- a/mcs/class/corlib/Test/System.Runtime.InteropServices/MarshalTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.InteropServices/MarshalTest.cs
@@ -963,7 +963,6 @@ namespace MonoTests.System.Runtime.InteropServices
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void CheckPtrToStructureWithFixedArrayAndBaseClassFields()
 		{
 			const int arraySize = 6;

--- a/mcs/class/corlib/Test/System.Runtime.Remoting.Proxies/RealProxyTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.Remoting.Proxies/RealProxyTest.cs
@@ -28,7 +28,6 @@ namespace MonoTests.System.Runtime.Remoting.Proxies {
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void InterfaceProxyGetTypeOkay ()
 		{
 			// Regression test for #17325

--- a/mcs/class/corlib/Test/System.Runtime.Remoting/ContextTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.Remoting/ContextTest.cs
@@ -40,7 +40,6 @@ namespace MonoTests.System.Runtime.Remoting
 		LocalDataStoreSlot slot;
 		
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TestDoCallback ()
 		{
 			otherCtx = cbo.GetContext ();
@@ -55,7 +54,6 @@ namespace MonoTests.System.Runtime.Remoting
 		}
 		
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TestDatastore ()
 		{
 			otherCtx = cbo.GetContext ();

--- a/mcs/class/corlib/Test/System.Runtime.Remoting/SynchronizationAttributeTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.Remoting/SynchronizationAttributeTest.cs
@@ -146,7 +146,6 @@ namespace MonoTests.System.Runtime.Remoting
 		bool otResult;
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TestSynchronization ()
 		{
 			Thread tr = new Thread (new ThreadStart (FirstSyncThread));
@@ -170,7 +169,6 @@ namespace MonoTests.System.Runtime.Remoting
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TestSupported ()
 		{
 			SincroRequiresNew ob = new SincroRequiresNew ();
@@ -183,7 +181,6 @@ namespace MonoTests.System.Runtime.Remoting
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TestRequired ()
 		{
 			SincroRequiresNew ob = new SincroRequiresNew ();
@@ -196,7 +193,6 @@ namespace MonoTests.System.Runtime.Remoting
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TestRequiresNew ()
 		{
 			SincroRequiresNew ob = new SincroRequiresNew ();
@@ -209,7 +205,6 @@ namespace MonoTests.System.Runtime.Remoting
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TestNotSupported ()
 		{
 			SincroRequiresNew ob = new SincroRequiresNew ();
@@ -222,7 +217,6 @@ namespace MonoTests.System.Runtime.Remoting
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TestLocked1 ()
 		{
 			sincob.Lock (false);
@@ -237,7 +231,6 @@ namespace MonoTests.System.Runtime.Remoting
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TestLocked2 ()
 		{
 			Thread tr = new Thread (new ThreadStart (FirstNotSyncThread));
@@ -261,7 +254,6 @@ namespace MonoTests.System.Runtime.Remoting
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TestLocked3 ()
 		{
 			Thread tr = new Thread (new ThreadStart (Lock1Thread));
@@ -281,7 +273,6 @@ namespace MonoTests.System.Runtime.Remoting
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TestReentry ()
 		{
 			Thread tr = new Thread (new ThreadStart (FirstReentryThread));
@@ -305,7 +296,6 @@ namespace MonoTests.System.Runtime.Remoting
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TestNoReentry ()
 		{
 			Thread tr = new Thread (new ThreadStart (FirstNoReentryThread));
@@ -329,7 +319,6 @@ namespace MonoTests.System.Runtime.Remoting
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TestCallback ()
 		{
 			Thread tr = new Thread (new ThreadStart (CallbackThread));
@@ -344,7 +333,6 @@ namespace MonoTests.System.Runtime.Remoting
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TestSynchronizationReleasedOnMultipleAcquire ()
 		{
 
@@ -367,7 +355,6 @@ namespace MonoTests.System.Runtime.Remoting
 		[Test]
 		[Category("NotDotNet")]
 		[Category ("MobileNotWorking")]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TestMonitorWait ()
 		{
 			Thread tr = new Thread (new ThreadStart (DoMonitorPulse));

--- a/mcs/class/corlib/Test/System.Threading/ThreadTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/ThreadTest.cs
@@ -453,7 +453,6 @@ namespace MonoTests.System.Threading
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TestUndivisibleByPageSizeMaxStackSize ()
 		{
 			const int undivisible_stacksize = 1048573;

--- a/mcs/class/corlib/Test/System/ConvertTest.cs
+++ b/mcs/class/corlib/Test/System/ConvertTest.cs
@@ -1295,7 +1295,6 @@ namespace MonoTests.System {
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TestToInt32() {
 			long tryMax = long.MaxValue;
 			long tryMin = long.MinValue;
@@ -1474,7 +1473,6 @@ namespace MonoTests.System {
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TestToInt64() {
 			decimal longMax = long.MaxValue;
 			longMax += 1000000;
@@ -1869,7 +1867,6 @@ namespace MonoTests.System {
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TestToSingle() {
 			int iTest = 1;
 			try {

--- a/mcs/class/corlib/Test/System/DecimalTest-Microsoft.cs
+++ b/mcs/class/corlib/Test/System/DecimalTest-Microsoft.cs
@@ -708,7 +708,6 @@ namespace MonoTests.System
 		}
 		
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TestToSingle()
 		{
 		    // Single Decimal.ToSingle(Decimal)
@@ -726,7 +725,6 @@ namespace MonoTests.System
 		}
 		
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TestToDouble()
 		{
 		    Double d = Decimal.ToDouble(new Decimal(0, 0, 1, false, 0));

--- a/mcs/class/corlib/Test/System/DecimalTest.cs
+++ b/mcs/class/corlib/Test/System/DecimalTest.cs
@@ -507,7 +507,6 @@ namespace MonoTests.System
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TestConstructSingle ()
 		{
 			Decimal d;
@@ -630,7 +629,6 @@ namespace MonoTests.System
 
 		[Test]
 		[SetCulture("en-US")]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TestConstructDouble ()
 		{
 			Decimal d;
@@ -729,7 +727,6 @@ namespace MonoTests.System
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TestConstructDoubleRound ()
 		{
 			decimal d;
@@ -982,7 +979,6 @@ namespace MonoTests.System
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void ToInt32 ()
 		{
 			Decimal d = 254.9m;
@@ -1045,7 +1041,6 @@ namespace MonoTests.System
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void ToSingle ()
 		{
 			Decimal d = 254.9m;
@@ -1059,7 +1054,6 @@ namespace MonoTests.System
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void ToDouble ()
 		{
 			Decimal d = 254.9m;

--- a/mcs/class/corlib/Test/System/DelegateTest.cs
+++ b/mcs/class/corlib/Test/System/DelegateTest.cs
@@ -851,7 +851,6 @@ namespace MonoTests.System
 		delegate object Boxer ();
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void BoxingCovariance ()
 		{
 			var boxer = (Boxer) Delegate.CreateDelegate (
@@ -913,7 +912,6 @@ namespace MonoTests.System
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void NullFirstArgumentOnStaticMethod ()
 		{
 			CallTarget call = (CallTarget) Delegate.CreateDelegate (
@@ -1027,7 +1025,6 @@ namespace MonoTests.System
 #if MONOTOUCH || FULL_AOT_RUNTIME
 		[Category ("NotWorking")] // #10539
 #endif
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void ClosedOverNullReferenceStaticMethod ()
 		{
 			var del = (Func<long?,long?>) Delegate.CreateDelegate (
@@ -1149,7 +1146,6 @@ namespace MonoTests.System
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void DynamicInvokeOpenInstanceDelegate ()
 		{
 			var d1 = Delegate.CreateDelegate (typeof (Func<DelegateTest, int>), typeof(DelegateTest).GetMethod ("DynamicInvokeOpenInstanceDelegate_CB"));

--- a/mcs/class/corlib/Test/System/ExceptionTest.cs
+++ b/mcs/class/corlib/Test/System/ExceptionTest.cs
@@ -262,7 +262,6 @@ namespace MonoTests.System
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void GetObjectData ()
 		{
 			string msg = "MESSAGE";
@@ -380,7 +379,6 @@ namespace MonoTests.System
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void Source ()
 		{
 			Exception ex1 = new Exception ("MSG");

--- a/mcs/class/corlib/Test/System/TimeZoneTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneTest.cs
@@ -317,7 +317,6 @@ public class TimeZoneTest {
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void GetUtcOffsetAtDSTBoundary ()
 		{
 			/*

--- a/mcs/class/corlib/Test/System/TypedReferenceCas.cs
+++ b/mcs/class/corlib/Test/System/TypedReferenceCas.cs
@@ -51,7 +51,6 @@ namespace MonoCasTests.System {
 		// when reflection is used (i.e. it gets testable).
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		[ReflectionPermission (SecurityAction.Deny, MemberAccess = true)]
 		[ExpectedException (typeof (SecurityException))]
 		public void MakeTypedReference ()

--- a/mcs/class/corlib/Test/System/TypedReferenceTest.cs
+++ b/mcs/class/corlib/Test/System/TypedReferenceTest.cs
@@ -59,7 +59,6 @@ namespace MonoTests.System
 		}
 
 		[Test]
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void MakeTypedReference ()
 		{
 			var o = new CClass () { a = new AStruct () { b = "5" }};


### PR DESCRIPTION
* DecimalTest
* DecimalTestMicrosoft
* ExceptionTest
* PartitionerTests
* TypeBuilderTest
* DynamicMethodTest
* MethodBuilderTest
* ContextTest
* SynchronizationAttributeTest
* RealProxyTest
* DriveInfoTest
* TimeZoneTest
* ConvertTest (except 1)
* DelegateTest (except 3)
* TypedReferenceTest
* TypedReferenceCas
* RegistryKeyTest
* ExceptionDispatchInfoTest
* MarshalTest

https://github.com/mono/mono/issues/7053

