### PR TITLE
[interp] add System.Core tests to CI

### DIFF
--- a/mcs/class/System.Core/Test/System.Linq.Expressions/ExpressionTest_Coalesce.cs
+++ b/mcs/class/System.Core/Test/System.Linq.Expressions/ExpressionTest_Coalesce.cs
@@ -133,6 +133,7 @@ namespace MonoTests.System.Linq.Expressions
 
 		[Test]
 		[Category ("NotDotNet")] // https://connect.microsoft.com/VisualStudio/feedback/ViewFeedback.aspx?FeedbackID=349822
+		[Category ("NotWorkingRuntimeInterpreter")]
 		public void CoalesceUserDefinedConversion ()
 		{
 			var s = Expression.Parameter (typeof (string), "s");

--- a/mcs/class/System.Core/Test/System.Linq/EnumerableAsQueryableTest.cs
+++ b/mcs/class/System.Core/Test/System.Linq/EnumerableAsQueryableTest.cs
@@ -239,6 +239,7 @@ namespace MonoTests.System.Linq {
 		}
 
 		[Test]
+		[Category ("NotWorkingRuntimeInterpreter")]
 		public void SelectMany ()
 		{
 			int [] arr1 = _array.SelectMany<int, int> ((n) => new int [] { n, n, n }).ToArray ();

--- a/mcs/class/System.Core/Test/System.Linq/ParallelEnumerableTests.cs
+++ b/mcs/class/System.Core/Test/System.Linq/ParallelEnumerableTests.cs
@@ -364,6 +364,7 @@ namespace MonoTests.System.Linq
 		}
 
 		[Test]
+		[Category ("NotWorkingRuntimeInterpreter")]
 		public void SelectManyOrderedTest ()
 		{
 			IEnumerable<int> initial = Enumerable.Range (1, 50);

--- a/scripts/ci/run-test-interpreter.sh
+++ b/scripts/ci/run-test-interpreter.sh
@@ -8,5 +8,6 @@ ${TESTCMD} --label=mixedmode-regression --timeout=10m make -C mono/mini mixedche
 ${TESTCMD} --label=compile-runtime-tests --timeout=40m make -w -C mono/tests -j4 tests
 ${TESTCMD} --label=runtime-interp --timeout=160m make -w -C mono/tests -k testinterp V=1 CI=1 CI_PR=${ghprbPullId}
 ${TESTCMD} --label=corlib --timeout=160m make -w -C mcs/class/corlib run-test V=1
+${TESTCMD} --label=System.Core --timeout=160m make -w -C mcs/class/System.Core run-test V=1
 if [[ ${CI_TAGS} != *'linux-armhf'* ]]; then ${TESTCMD} --label=mcs-tests --timeout=160m make -w -C mcs/tests run-test V=1; fi
 ${TESTCMD} --label=Mono.Debugger.Soft --timeout=5m make -w -C mcs/class/Mono.Debugger.Soft run-test V=1


### PR DESCRIPTION
https://github.com/mono/mono/issues/7053

LSWCIS (let's see what CI says 😛 )

should be good, as @kumpera is already running those tests as part of the webassembly tests