### PR TITLE
Use g_print to dump threads when SIGQUIT is sent to Mono

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -3785,7 +3785,7 @@ dump_thread (MonoInternalThread *thread, ThreadDumpUserData *ud)
 		}
 	}
 
-	fprintf (stdout, "%s", text->str);
+	g_print ("%s", text->str);
 
 #if PLATFORM_WIN32 && TARGET_WIN32 && _DEBUG
 	OutputDebugStringA(text->str);
@@ -3805,7 +3805,7 @@ mono_threads_perform_thread_dump (void)
 	if (!thread_dump_requested)
 		return;
 
-	printf ("Full thread dump:\n");
+	g_print ("Full thread dump:\n");
 
 	/* Make a copy of the threads hash to avoid doing work inside threads_lock () */
 	nthreads = collect_threads (thread_array, 128);


### PR DESCRIPTION
`printf`, `fprintf` don't work on Android, using g_print will redirect the output to
`mono-stdout` so that it can appear in Android `logcat` output.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
