### PR TITLE
[mini] Don't verify types if you store to a pointer byref.

### DIFF
--- a/mono/mini/iltests.il
+++ b/mono/mini/iltests.il
@@ -3194,7 +3194,7 @@ L_3:
 
 	.method public hidebysig static int32 test_1_dont_verify_ptr_byrefs () cil managed
 	 {
-		.locals init (int32 v_0, int32 *& v_2, int32 *v_1)
+		.locals init (int32 v_0, int32 *& v_1, int32 *v_2)
 
 		//v_0 = 1
 		ldc.i4.1

--- a/mono/mini/iltests.il
+++ b/mono/mini/iltests.il
@@ -3191,4 +3191,27 @@ L_3:
 		conv.i4
 		ret
 	}
+
+	.method public hidebysig static int32 test_1_dont_verify_ptr_byrefs () cil managed
+	 {
+		.locals init (int32 v_0, int32 *& v_2, int32 *v_1)
+
+		//v_0 = 1
+		ldc.i4.1
+		stloc.0
+
+		//v_1 = &v_0 < bad store of `int32&` to ìnt32*&` but must work
+		ldloca v_0
+		stloc.1
+
+		//v_2 = (intptr)v_1
+		ldloc.1
+		conv.u
+		stloc.2
+
+		//return *v_2
+		ldloc.2
+		ldind.i4
+		ret
+	 }
 }

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -1857,8 +1857,8 @@ target_type_is_incompatible (MonoCompile *cfg, MonoType *target, MonoInst *arg)
 			MonoClass *target_class_lowered = mono_class_from_mono_type (mini_get_underlying_type (m_class_get_byval_arg (mono_class_from_mono_type (target))));
 			MonoClass *source_class_lowered = mono_class_from_mono_type (mini_get_underlying_type (m_class_get_byval_arg (arg->klass)));
 
-			/* if the target is native int& or same type */
-			if (target->type == MONO_TYPE_I || target_class_lowered == source_class_lowered)
+			/* if the target is native int& or X* or same type */
+			if (target->type == MONO_TYPE_I || target->type == MONO_TYPE_PTR || target_class_lowered == source_class_lowered)
 				return 0;
 
 			/* Both are primitive type byrefs and the source points to a larger type that the destination */


### PR DESCRIPTION
Workarounds #8403.