### PR TITLE
[Tailcall] Let watchos make more tailcalls.

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -7239,7 +7239,7 @@ is_supported_tailcall (MonoCompile *cfg, const guint8 *ip, MonoMethod *method, M
 		//
 		// Interface method dispatch has the same problem (imt_arg).
 
-		|| IS_NOT_SUPPORTED_TAILCALL ((vtable_arg || imt_arg) && !cfg->backend->have_volatile_non_param_register)
+		|| IS_NOT_SUPPORTED_TAILCALL ((vtable_arg || imt_arg) && !cfg->backend->have_volatile_non_param_register && !cfg->llvm_only)
 		) {
 		tailcall_calli = FALSE;
 		tailcall = FALSE;


### PR DESCRIPTION
This is a subset of https://github.com/mono/mono/pull/7963, perhaps most of what might be interesting to customers.

arm32 will have a bunch of holes in the matrix, but seemingly watchos is the main or half the interesting targets and this shores it up, while leaving more consistency elsewhere.