### PR TITLE
[jit] Decompose CEE_BOX later, to enable more optimization opportunities. Optimize Enum.HasFlags ().

### DIFF
--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -1450,7 +1450,7 @@ mono_decompose_vtype_opts (MonoCompile *cfg)
 						src->klass = ins->klass;
 						src->dreg = ins->sreg1;
 					}
-					MonoInst *tmp = mini_emit_box (cfg, src, ins->klass, 0);
+					MonoInst *tmp = mini_emit_box (cfg, src, ins->klass, mini_class_check_context_used (cfg, ins->klass));
 					g_assert (tmp);
 
 					MONO_EMIT_NEW_UNALU (cfg, OP_MOVE, ins->dreg, tmp->dreg);

--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -1207,6 +1207,7 @@ mono_decompose_vtype_opts (MonoCompile *cfg)
 		if (cfg->verbose_level > 2) mono_print_bb (bb, "BEFORE LOWER-VTYPE-OPTS ");
 
 		cfg->cbb->code = cfg->cbb->last_ins = NULL;
+		cfg->cbb->out_of_line = bb->out_of_line;
 		restart = TRUE;
 
 		while (restart) {
@@ -1432,6 +1433,30 @@ mono_decompose_vtype_opts (MonoCompile *cfg)
 						}
 						ins->dreg = -1;
 					}
+					break;
+				}
+				case OP_BOX:
+				case OP_BOX_ICONST: {
+					MonoInst *src;
+
+					/* Temporary value required by emit_box () */
+					if (ins->opcode == OP_BOX_ICONST) {
+						NEW_ICONST (cfg, src, ins->inst_c0);
+						src->klass = ins->klass;
+						MONO_ADD_INS (cfg->cbb, src);
+					} else {
+						MONO_INST_NEW (cfg, src, OP_LOCAL);
+						src->type = STACK_MP;
+						src->klass = ins->klass;
+						src->dreg = ins->sreg1;
+					}
+					MonoInst *tmp = mini_emit_box (cfg, src, ins->klass, 0);
+					g_assert (tmp);
+
+					MONO_EMIT_NEW_UNALU (cfg, OP_MOVE, ins->dreg, tmp->dreg);
+
+					/* This might be decomposed into other vtype opcodes */
+					restart = TRUE;
 					break;
 				}
 				default:

--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -1113,6 +1113,12 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 			if (mono_type_is_native_blittable (arg0))
 				return mini_emit_memory_load (cfg, arg0, args [0], 0, 0);
 		}
+	} else if (cmethod->klass == mono_defaults.enum_class && !strcmp (cmethod->name, "HasFlag") &&
+			   args [0]->opcode == OP_BOX && args [1]->opcode == OP_BOX_ICONST) {
+		args [1]->opcode = OP_ICONST;
+		ins = mini_handle_enum_has_flag (cfg, args [0]->klass, NULL, args [0]->sreg1, args [1]);
+		NULLIFY_INS (args [0]);
+		return ins;
 	}
 
 #ifdef MONO_ARCH_SIMD_INTRINSICS

--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -1114,7 +1114,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 				return mini_emit_memory_load (cfg, arg0, args [0], 0, 0);
 		}
 	} else if (cmethod->klass == mono_defaults.enum_class && !strcmp (cmethod->name, "HasFlag") &&
-			   args [0]->opcode == OP_BOX && args [1]->opcode == OP_BOX_ICONST) {
+			   args [0]->opcode == OP_BOX && args [1]->opcode == OP_BOX_ICONST && args [0]->klass == args [1]->klass) {
 		args [1]->opcode = OP_ICONST;
 		ins = mini_handle_enum_has_flag (cfg, args [0]->klass, NULL, args [0]->sreg1, args [1]);
 		NULLIFY_INS (args [0]);

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -9485,7 +9485,8 @@ calli_end:
 				break;
 			}
 
-			if (mono_class_is_enum (klass)) {
+			if (mono_class_is_enum (klass) && !(val->type == STACK_I8 && SIZEOF_VOID_P == 4)) {
+				/* Can't do this with 64 bit enums on 32 bit since the vtype decomp pass is ran after the long decomp pass */
 				if (val->opcode == OP_ICONST) {
 					MONO_INST_NEW (cfg, ins, OP_BOX_ICONST);
 					ins->type = STACK_OBJ;

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -1306,8 +1306,13 @@ check_values_to_signature (MonoInst *args, MonoType *this_ins, MonoMethodSignatu
 inline static MonoInst *
 mono_get_domainvar (MonoCompile *cfg)
 {
-	if (!cfg->domainvar)
+	if (!cfg->domainvar) {
+		/* Make sure we don't generate references after checking whenever to init this */
+		g_assert (!cfg->domainvar_inited);
 		cfg->domainvar = mono_compile_create_var (cfg, mono_get_int_type (), OP_LOCAL);
+		/* Avoid optimizing it away */
+		cfg->domainvar->flags |= MONO_INST_VOLATILE;
+	}
 	return cfg->domainvar;
 }
 
@@ -3844,8 +3849,8 @@ handle_alloc (MonoCompile *cfg, MonoClass *klass, gboolean for_box, int context_
 /*
  * Returns NULL and set the cfg exception on error.
  */	
-static MonoInst*
-handle_box (MonoCompile *cfg, MonoInst *val, MonoClass *klass, int context_used)
+MonoInst*
+mini_emit_box (MonoCompile *cfg, MonoInst *val, MonoClass *klass, int context_used)
 {
 	MonoInst *alloc, *ins;
 
@@ -3956,14 +3961,14 @@ handle_box (MonoCompile *cfg, MonoInst *val, MonoClass *klass, int context_used)
 		MONO_START_BB (cfg, end_bb);
 
 		return res;
-	} else {
-		alloc = handle_alloc (cfg, klass, TRUE, context_used);
-		if (!alloc)
-			return NULL;
-
-		EMIT_NEW_STORE_MEMBASE_TYPE (cfg, ins, m_class_get_byval_arg (klass), alloc->dreg, sizeof (MonoObject), val->dreg);
-		return alloc;
 	}
+
+	alloc = handle_alloc (cfg, klass, TRUE, context_used);
+	if (!alloc)
+		return NULL;
+
+	EMIT_NEW_STORE_MEMBASE_TYPE (cfg, ins, m_class_get_byval_arg (klass), alloc->dreg, sizeof (MonoObject), val->dreg);
+	return alloc;
 }
 
 static gboolean
@@ -3976,8 +3981,8 @@ method_needs_stack_walk (MonoCompile *cfg, MonoMethod *cmethod)
 	return FALSE;
 }
 
-static G_GNUC_UNUSED MonoInst*
-handle_enum_has_flag (MonoCompile *cfg, MonoClass *klass, MonoInst *enum_this, MonoInst *enum_flag)
+G_GNUC_UNUSED MonoInst*
+mini_handle_enum_has_flag (MonoCompile *cfg, MonoClass *klass, MonoInst *enum_this, int enum_val_reg, MonoInst *enum_flag)
 {
 	MonoType *enum_type = mono_type_get_underlying_type (m_class_get_byval_arg (klass));
 	guint32 load_opc = mono_type_to_load_membase (cfg, enum_type);
@@ -4003,7 +4008,12 @@ handle_enum_has_flag (MonoCompile *cfg, MonoClass *klass, MonoInst *enum_this, M
 		int and_reg = is_i4 ? alloc_ireg (cfg) : alloc_lreg (cfg);
 		int dest_reg = alloc_ireg (cfg);
 
-		EMIT_NEW_LOAD_MEMBASE (cfg, load, load_opc, enum_reg, enum_this->dreg, 0);
+		if (enum_this) {
+			EMIT_NEW_LOAD_MEMBASE (cfg, load, load_opc, enum_reg, enum_this->dreg, 0);
+		} else {
+			g_assert (enum_val_reg != -1);
+			enum_reg = enum_val_reg;
+		}
 		EMIT_NEW_BIALU (cfg, and_, is_i4 ? OP_IAND : OP_LAND, and_reg, enum_reg, enum_flag->dreg);
 		EMIT_NEW_BIALU (cfg, cmp, is_i4 ? OP_ICOMPARE : OP_LCOMPARE, -1, and_reg, enum_flag->dreg);
 		EMIT_NEW_UNALU (cfg, ceq, is_i4 ? OP_ICEQ : OP_LCEQ, dest_reg, -1);
@@ -7684,7 +7694,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 						/* The called method is not virtual, i.e. Object:GetType (), the receiver is a vtype, has to box */
 						EMIT_NEW_LOAD_MEMBASE_TYPE (cfg, ins, m_class_get_byval_arg (constrained_class), sp [0]->dreg, 0);
 						ins->klass = constrained_class;
-						sp [0] = handle_box (cfg, ins, constrained_class, mono_class_check_context_used (constrained_class));
+						sp [0] = mini_emit_box (cfg, ins, constrained_class, mono_class_check_context_used (constrained_class));
 						CHECK_CFG_EXCEPTION;
 					} else if (need_box) {
 						MonoInst *box_type;
@@ -7719,7 +7729,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 						MONO_START_BB (cfg, is_ref_bb);
 						EMIT_NEW_LOAD_MEMBASE_TYPE (cfg, ins, m_class_get_byval_arg (constrained_class), sp [0]->dreg, 0);
 						ins->klass = constrained_class;
-						sp [0] = handle_box (cfg, ins, constrained_class, mono_class_check_context_used (constrained_class));
+						sp [0] = mini_emit_box (cfg, ins, constrained_class, mono_class_check_context_used (constrained_class));
 						if (cfg->llvm_only)
 							ins = emit_llvmonly_calli (cfg, fsig, sp, addr);
 						else
@@ -7753,7 +7763,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 					 */
 					EMIT_NEW_LOAD_MEMBASE_TYPE (cfg, ins, m_class_get_byval_arg (constrained_class), sp [0]->dreg, 0);
 					ins->klass = constrained_class;
-					sp [0] = handle_box (cfg, ins, constrained_class, mono_class_check_context_used (constrained_class));
+					sp [0] = mini_emit_box (cfg, ins, constrained_class, mono_class_check_context_used (constrained_class));
 					CHECK_CFG_EXCEPTION;
 				} else if (!m_class_is_valuetype (constrained_class)) {
 					int dreg = alloc_ireg_ref (cfg);
@@ -7787,7 +7797,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 							/* Enum implements some interfaces, so treat this as the first case */
 							EMIT_NEW_LOAD_MEMBASE_TYPE (cfg, ins, m_class_get_byval_arg (constrained_class), sp [0]->dreg, 0);
 							ins->klass = constrained_class;
-							sp [0] = handle_box (cfg, ins, constrained_class, mono_class_check_context_used (constrained_class));
+							sp [0] = mini_emit_box (cfg, ins, constrained_class, mono_class_check_context_used (constrained_class));
 							CHECK_CFG_EXCEPTION;
 						}
 					}
@@ -9381,6 +9391,8 @@ calli_end:
 			 * If we find this sequence and the operand types on box and constrained
 			 * are equal, we can emit a specialized instruction sequence instead of
 			 * the very slow HasFlag () call.
+			 * This code sequence is generated by older mcs/csc, the newer one is handled in
+			 * emit_inst_for_method ().
 			 */
 			guint32 constrained_token;
 			guint32 callvirt_token;
@@ -9411,7 +9423,7 @@ calli_end:
 					enum_this = sp [0];
 					enum_flag = sp [1];
 
-					*sp++ = handle_enum_has_flag (cfg, klass, enum_this, enum_flag);
+					*sp++ = mini_handle_enum_has_flag (cfg, klass, enum_this, -1, enum_flag);
 					break;
 				}
 			}
@@ -9473,8 +9485,28 @@ calli_end:
 				break;
 			}
 
-			*sp++ = handle_box (cfg, val, klass, context_used);
-
+			if (mono_class_is_enum (klass)) {
+				if (val->opcode == OP_ICONST) {
+					MONO_INST_NEW (cfg, ins, OP_BOX_ICONST);
+					ins->type = STACK_OBJ;
+					ins->klass = klass;
+					ins->inst_c0 = val->inst_c0;
+					ins->dreg = alloc_dreg (cfg, val->type);
+				} else {
+					MONO_INST_NEW (cfg, ins, OP_BOX);
+					ins->type = STACK_OBJ;
+					ins->klass = klass;
+					ins->sreg1 = val->dreg;
+					ins->dreg = alloc_dreg (cfg, val->type);
+				}
+				MONO_ADD_INS (cfg->cbb, ins);
+				*sp++ = ins;
+				/* Create domainvar early so it gets initialized earlier than this code */
+				if (cfg->opt & MONO_OPT_SHARED)
+					mono_get_domainvar (cfg);
+			} else {
+				*sp++ = mini_emit_box (cfg, val, klass, context_used);
+			}
 			CHECK_CFG_EXCEPTION;
 			inline_costs += 1;
 			break;
@@ -11674,6 +11706,7 @@ mono_ldptr:
 		get_domain = mono_create_tls_get (cfg, TLS_KEY_DOMAIN);
 		NEW_TEMPSTORE (cfg, store, cfg->domainvar->inst_c0, get_domain);
 		MONO_ADD_INS (cfg->cbb, store);
+		cfg->domainvar_inited = TRUE;
 	}
 
 #if defined(TARGET_POWERPC) || defined(TARGET_X86)

--- a/mono/mini/mini-ops.h
+++ b/mono/mini/mini-ops.h
@@ -42,6 +42,9 @@ MINI_OP(OP_CHECK_THIS,	"checkthis", NONE, IREG, NONE)
 MINI_OP(OP_SEQ_POINT, "seq_point", NONE, NONE, NONE)
 MINI_OP(OP_IL_SEQ_POINT, "il_seq_point", NONE, NONE, NONE)
 MINI_OP(OP_IMPLICIT_EXCEPTION, "implicit_exception", NONE, NONE, NONE)
+MINI_OP(OP_BOX, "box", IREG, IREG, NONE)
+/* A box of the int value in inst_c0 */
+MINI_OP(OP_BOX_ICONST, "box_iconst", IREG, NONE, NONE)
 
 /* CALL opcodes need to stay together, see MONO_IS_CALL macro */
 MINI_OP(OP_VOIDCALL,	"voidcall", NONE, NONE, NONE)

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1362,6 +1362,7 @@ typedef struct {
 	guint            gsharedvt : 1;
 	guint            r4fp : 1;
 	guint            llvm_only : 1;
+	guint            domainvar_inited : 1;
 	int              r4_stack_type;
 	gpointer         debug_info;
 	guint32          lmf_offset;
@@ -2112,6 +2113,7 @@ int               mini_class_check_context_used (MonoCompile *cfg, MonoClass *kl
 int               mini_method_check_context_used (MonoCompile *cfg, MonoMethod *method);
 void              mini_type_from_op (MonoCompile *cfg, MonoInst *ins, MonoInst *src1, MonoInst *src2);
 void              mini_set_inline_failure (MonoCompile *cfg, const char *msg);
+MonoInst*         mini_emit_box (MonoCompile *cfg, MonoInst *val, MonoClass *klass, int context_used);
 void              mini_emit_memcpy (MonoCompile *cfg, int destreg, int doffset, int srcreg, int soffset, int size, int align);
 void              mini_emit_memset (MonoCompile *cfg, int destreg, int offset, int size, int val, int align);
 void              mini_emit_stobj (MonoCompile *cfg, MonoInst *dest, MonoInst *src, MonoClass *klass, gboolean native);
@@ -2130,6 +2132,7 @@ MonoInst*         mini_emit_array_store (MonoCompile *cfg, MonoClass *klass, Mon
 MonoInst*         mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args);
 MonoInst*         mini_emit_inst_for_ctor (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args);
 MonoInst*         mini_emit_inst_for_sharable_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args);
+MonoInst*         mini_handle_enum_has_flag (MonoCompile *cfg, MonoClass *klass, MonoInst *enum_this, int enum_val_reg, MonoInst *enum_flag);
 
 MonoMethod*       mini_get_memcpy_method (void);
 MonoMethod*       mini_get_memset_method (void);

--- a/mono/mini/objects.cs
+++ b/mono/mini/objects.cs
@@ -1272,6 +1272,27 @@ ncells ) {
 		return sb.ToString () == "ADC" ? 0 : 1;
 	}
 
+	enum FlagsEnum {
+		None = 0,
+		A = 1,
+		B = 2,
+		C = 4
+	}
+
+	public static int test_0_intrins_enum_hasflag () {
+		var e = FlagsEnum.A | FlagsEnum.B;
+
+		if (!e.HasFlag (FlagsEnum.A))
+			return 1;
+		if (!e.HasFlag (FlagsEnum.A | FlagsEnum.B))
+			return 2;
+		if (!e.HasFlag (FlagsEnum.None))
+			return 3;
+		if (e.HasFlag (FlagsEnum.C))
+			return 4;
+		return 0;
+	}
+
 	public class Bar {
 		bool allowLocation = true;
         Foo f = new Foo ();	


### PR DESCRIPTION
Also mark the temporary bblocks used by decompose_vtypes () as out-of-line if
the bblock under processing is out-of-line. Make the domainvar as volatile to avoid
optimizing it away since references to it can now be generated later from the
decomposition of OP_BOX.