### PR TITLE
[Tailcall] Better sizing of tailcalls, allow arm64 r4, copy arm64 stacked parameters

### DIFF
--- a/mono/mini/cpu-arm.md
+++ b/mono/mini/cpu-arm.md
@@ -99,7 +99,25 @@ lcall_membase: dest:l src1:b len:24 clob:c
 vcall: len:64 clob:c
 vcall_reg: src1:i len:64 clob:c
 vcall_membase: src1:b len:70 clob:c
-tailcall: len:160 clob:c
+
+tailcall: len:255 clob:c # FIXME len
+tailcall_membase: src1:b len:255 clob:c # FIXME len
+tailcall_reg: src1:b len:255 clob:c # FIXME len
+
+# tailcall_parameter models the size of moving one parameter,
+# so that the required size of a branch around a tailcall can
+# be accurately estimated; something like:
+# void f1(volatile long *a)
+# {
+# a[large] = a[another large]
+# }
+#
+# In current implementation with 4K limit this is typically
+# two full instructions, howevever raising the limit some
+# can lead two instructions and two thumb instructions.
+# FIXME A fixed size sequence to move parameters would moot this.
+tailcall_parameter: len:12
+
 iconst: dest:i len:16
 r4const: dest:f len:24
 r8const: dest:f len:20

--- a/mono/mini/cpu-arm64.md
+++ b/mono/mini/cpu-arm64.md
@@ -99,9 +99,23 @@ lcall_membase: dest:l src1:b len:32 clob:c
 vcall: len:32 clob:c
 vcall_reg: src1:i len:32 clob:c
 vcall_membase: src1:b len:32 clob:c
-tailcall: len:64 clob:c
-tailcall_membase: src1:b len:128 clob:c # FIXME len? Eventually depends on stack_usage.
+
+tailcall: len:255 clob:c # FIXME len
+tailcall_membase: src1:b len:255 clob:c # FIXME len
 tailcall_reg: src1:b len:255 clob:c # FIXME len
+
+# tailcall_parameter models the size of moving one parameter,
+# so that the required size of a branch around a tailcall can
+# be accurately estimated; something like:
+# void f1(volatile long *a)
+# {
+# a[large] = a[another large]
+# }
+#
+# This is two instructions typically, but can be 6 for frames larger than 32K.
+# FIXME A fixed size sequence to move parameters would moot this.
+tailcall_parameter: len:24
+
 iconst: dest:i len:16
 r4const: dest:f len:24
 r8const: dest:f len:20

--- a/mono/mini/cpu-x86.md
+++ b/mono/mini/cpu-x86.md
@@ -65,7 +65,27 @@
 break: len:1
 call: dest:a clob:c len:17
 tailcall: len:255 clob:c
-tailcall_membase: src1:b len:255 clob:c # FIXME len?
+tailcall_membase: src1:b len:255 clob:c # FIXME len
+tailcall_reg: src1:b len:255 clob:c # FIXME len
+
+# tailcall_parameter models the size of moving one parameter,
+# so that the required size of a branch around a tailcall can
+# be accurately estimated; something like:
+# void f1(volatile long *a)
+# {
+# a[large] = a[another large]
+# }
+#
+# This is like amd64 but without the rex bytes.
+#
+# Frame size is artificially limited to 1GB in mono_arch_tailcall_supported.
+# This is presently redundant with tailcall len:255, as the limit of
+# near branches is [-128, +127], after which the limit is
+# [-2GB, +2GB-1]
+
+# FIXME A fixed size sequence to move parameters would moot this.
+tailcall_parameter: len:12
+
 br: len:5
 seq_point: len:26 clob:c
 il_seq_point: len:0

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -2252,6 +2252,25 @@ test_tailcall (MonoCompile *cfg, MonoBoolean tailcall)
 	tailcall_print ("tailcalllog %s from %s\n", tailcall ? "success" : "fail", cfg->method->name);
 }
 
+static void
+emit_tailcall_parameters (MonoCompile *cfg, MonoMethodSignature *sig)
+{
+	// OP_TAILCALL_PARAMETER helps compute the size of code, in order
+	// to size branches around OP_TAILCALL_[REG,MEMBASE].
+	//
+	// The actual bytes are output from OP_TAILCALL_[REG,MEMBASE].
+	// OP_TAILCALL_PARAMETER is an overestimate because typically
+	// many parameters are in registers.
+
+	int n = sig->param_count + sig->hasthis + 1; // always at least one
+	for (int i = 0; i < n; ++i) {
+		MonoInst *ins;
+		MONO_INST_NEW (cfg, ins, OP_TAILCALL_PARAMETER);
+		MONO_ADD_INS (cfg->cbb, ins);
+	}
+
+}
+
 static MonoCallInst *
 mono_emit_call_args (MonoCompile *cfg, MonoMethodSignature *sig, 
 		     MonoInst **args, gboolean calli, gboolean virtual_, gboolean tailcall,
@@ -2281,6 +2300,7 @@ mono_emit_call_args (MonoCompile *cfg, MonoMethodSignature *sig,
 
 	if (tailcall) {
 		mini_profiler_emit_tail_call (cfg, target);
+		emit_tailcall_parameters (cfg, sig);
 		MONO_INST_NEW_CALL (cfg, call, calli ? OP_TAILCALL_REG : virtual_ ? OP_TAILCALL_MEMBASE : OP_TAILCALL);
 	} else
 		MONO_INST_NEW_CALL (cfg, call, ret_type_to_call_opcode (cfg, sig->ret, calli, virtual_));
@@ -8410,10 +8430,13 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				/* Handle tailcalls similarly to calls */
 				DISABLE_AOT (cfg);
 
+				MonoMethodSignature *sig = mono_method_signature (cmethod);
+
+				emit_tailcall_parameters (cfg, sig);
 				MONO_INST_NEW_CALL (cfg, call, OP_TAILCALL);
 				call->method = cmethod;
 				call->tailcall = TRUE;
-				call->signature = mono_method_signature (cmethod);
+				call->signature = sig;
 				call->args = (MonoInst **)mono_mempool_alloc (cfg->mempool, sizeof (MonoInst*) * n);
 				call->inst.inst_p0 = cmethod;
 				for (i = 0; i < n; ++i)

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -8430,13 +8430,11 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				/* Handle tailcalls similarly to calls */
 				DISABLE_AOT (cfg);
 
-				MonoMethodSignature *sig = mono_method_signature (cmethod);
-
-				emit_tailcall_parameters (cfg, sig);
+				emit_tailcall_parameters (cfg, fsig);
 				MONO_INST_NEW_CALL (cfg, call, OP_TAILCALL);
 				call->method = cmethod;
 				call->tailcall = TRUE;
-				call->signature = sig;
+				call->signature = fsig;
 				call->args = (MonoInst **)mono_mempool_alloc (cfg->mempool, sizeof (MonoInst*) * n);
 				call->inst.inst_p0 = cmethod;
 				for (i = 0; i < n; ++i)

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -2262,7 +2262,7 @@ emit_tailcall_parameters (MonoCompile *cfg, MonoMethodSignature *sig)
 	// OP_TAILCALL_PARAMETER is an overestimate because typically
 	// many parameters are in registers.
 
-	int n = sig->param_count + sig->hasthis + 1; // always at least one
+	const int n = sig->param_count + (sig->hasthis ? 1 : 0);
 	for (int i = 0; i < n; ++i) {
 		MonoInst *ins;
 		MONO_INST_NEW (cfg, ins, OP_TAILCALL_PARAMETER);

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -3804,11 +3804,11 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 	MONO_BB_FOR_EACH_INS (bb, ins) {
 		offset = code - cfg->native_code;
 
-		max_len = ((guint8 *)ins_get_spec (ins->opcode))[MONO_INST_LEN];
+		max_len = ins_get_size (ins->opcode);
 
 #define EXTRA_CODE_SPACE (16)
 
-		if (G_UNLIKELY ((offset + max_len + EXTRA_CODE_SPACE) > cfg->code_size)) {
+		while (G_UNLIKELY ((offset + max_len + EXTRA_CODE_SPACE) > cfg->code_size)) {
 			cfg->code_size *= 2;
 			cfg->native_code = (unsigned char *)mono_realloc_native_code(cfg);
 			code = cfg->native_code + offset;

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -1281,6 +1281,10 @@ mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig,
 	callee_ret = mini_get_underlying_type (callee_sig->ret);
 	res &= IS_SUPPORTED_TAILCALL (!(callee_ret && MONO_TYPE_ISSTRUCT (callee_ret) && callee_info->ret.storage != ArgValuetypeInReg));
 
+	// Limit stack_usage to 1G. Assume 32bit limits when we move parameters.
+	res &= IS_SUPPORTED_TAILCALL (callee_info->stack_usage < (1 << 30));
+	res &= IS_SUPPORTED_TAILCALL (caller_info->stack_usage < (1 << 30));
+
 exit:
 	g_free (caller_info);
 	g_free (callee_info);
@@ -4640,6 +4644,13 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				amd64_sse_movsd_reg_reg (code, ins->dreg, ins->sreg1);
 			break;
 		}
+
+		case OP_TAILCALL_PARAMETER:
+			// This opcode helps compute sizes, i.e.
+			// of the subsequent OP_TAILCALL, but contributes no code.
+			g_assert (ins->next);
+			break;
+
 		case OP_TAILCALL:
 		case OP_TAILCALL_REG:
 		case OP_TAILCALL_MEMBASE: {
@@ -4650,12 +4661,9 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 
 			g_assert (!cfg->method->save_lmf);
 
-			/* the size of the tailcall op depends on signature, let's check for enough
-			 * space in the code buffer here again */
-			max_len += AMD64_NREG * 4 + call->stack_usage * 15 + EXTRA_CODE_SPACE;
-			max_len += 64; // FIXME make this two pass for an accurate size
-
-			if (G_UNLIKELY (offset + max_len > cfg->code_size)) {
+			max_len += AMD64_NREG * 4;
+			max_len += call->stack_usage / sizeof (mgreg_t) * ins_get_size (OP_TAILCALL_PARAMETER);
+			while (G_UNLIKELY (offset + max_len > cfg->code_size)) {
 				cfg->code_size *= 2;
 				cfg->native_code = (unsigned char *) mono_realloc_native_code(cfg);
 				code = cfg->native_code + offset;

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -4387,9 +4387,11 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 	MONO_BB_FOR_EACH_INS (bb, ins) {
 		offset = code - cfg->native_code;
 
-		max_len = ((guint8 *)ins_get_spec (ins->opcode))[MONO_INST_LEN];
+		max_len = ins_get_size (ins->opcode);
 
-		if (offset > (cfg->code_size - max_len - 16)) {
+#define EXTRA_CODE_SPACE (16)
+
+		while (offset > (cfg->code_size - max_len - EXTRA_CODE_SPACE)) {
 			cfg->code_size *= 2;
 			cfg->native_code = g_realloc (cfg->native_code, cfg->code_size);
 			code = cfg->native_code + offset;

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -1816,7 +1816,10 @@ mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig,
 	if (!res && !debug_tailcall)
 		goto exit;
 
-	res &= IS_SUPPORTED_TAILCALL (callee_info->stack_usage <= 16 * 4); // FIXME why?
+	// FIXME The limit here is that moving the parameters requires addressing the parameters
+	// with 12bit (4K) immediate offsets.
+	res &= IS_SUPPORTED_TAILCALL (callee_info->stack_usage < 4096);
+	res &= IS_SUPPORTED_TAILCALL (caller_info->stack_usage < 4096);
 
 exit:
 	g_free (caller_info);
@@ -5132,8 +5135,23 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				}
 			}
 			break;
+
+		case OP_TAILCALL_PARAMETER:
+			// This opcode helps compute sizes, i.e.
+			// of the subsequent OP_TAILCALL, but contributes no code.
+			g_assert (ins->next);
+			break;
+
 		case OP_TAILCALL: {
 			MonoCallInst *call = (MonoCallInst*)ins;
+
+			max_len += call->stack_usage / sizeof (mgreg_t) * ins_get_size (OP_TAILCALL_PARAMETER);
+			while (G_UNLIKELY (offset + max_len > cfg->code_size)) {
+				cfg->code_size *= 2;
+				cfg->native_code = (unsigned char *)mono_realloc_native_code (cfg);
+				code = cfg->native_code + offset;
+				cfg->stat_code_reallocs++;
+			}
 
 			/*
 			 * The stack looks like the following:
@@ -5160,6 +5178,8 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				code = emit_big_add (code, ARMREG_IP, cfg->frame_reg, cfg->stack_usage + prev_sp_offset);
 
 				/* Copy arguments on the stack to our argument area */
+				// FIXME a fixed size memcpy is desirable here,
+				// at least for larger values of stack_usage.
 				for (i = 0; i < call->stack_usage; i += sizeof (mgreg_t)) {
 					ARM_LDR_IMM (code, ARMREG_LR, ARMREG_SP, i);
 					ARM_STR_IMM (code, ARMREG_LR, ARMREG_IP, i);

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -2695,11 +2695,11 @@ tailcall_return_storage_supported (ArgStorage storage)
 	switch (storage) {
 	case ArgInIReg:
 	case ArgInFReg:
+	case ArgInFRegR4:
 	case ArgNone:
 		return TRUE;
 
 	case ArgHFA:
-	case ArgInFRegR4: // conversion in emit_move_return_value missed
 	case ArgOnStack:
 	case ArgOnStackR8:
 	case ArgOnStackR4:

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -3161,9 +3161,11 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 	MONO_BB_FOR_EACH_INS (bb, ins) {
 		offset = code - cfg->native_code;
 
-		max_len = ((guint8 *)ins_get_spec (ins->opcode))[MONO_INST_LEN];
+		max_len = ins_get_size (ins->opcode);
 
-		if (offset > (cfg->code_size - max_len - 16)) {
+#define EXTRA_CODE_SPACE (16)
+
+		while (offset > (cfg->code_size - max_len - EXTRA_CODE_SPACE)) {
 			cfg->code_size *= 2;
 			cfg->native_code = g_realloc (cfg->native_code, cfg->code_size);
 			code = cfg->native_code + offset;

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -4340,7 +4340,13 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				g_assert_not_reached ();
 			}
 
-			// FIXME: Copy stack arguments
+			// Copy stack arguments.
+			// FIXME a fixed size memcpy is desirable here,
+			// at least for larger values of stack_usage.
+			for (i = 0; i < call->stack_usage; i += sizeof (mgreg_t)) {
+				code = emit_ldrx (code, ARMREG_LR, ARMREG_SP, i);
+				code = emit_strx (code, ARMREG_LR, ARMREG_R28, i);
+			}
 
 			/* Restore registers */
 			code = emit_load_regset (code, MONO_ARCH_CALLEE_SAVED_REGS & cfg->used_int_regs, ARMREG_FP, cfg->arch.saved_gregs_offset);

--- a/mono/mini/mini-mips.c
+++ b/mono/mini/mini-mips.c
@@ -3222,9 +3222,11 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 	MONO_BB_FOR_EACH_INS (bb, ins) {
 		offset = code - cfg->native_code;
 
-		max_len = ((guint8 *)ins_get_spec (ins->opcode))[MONO_INST_LEN];
+		max_len = ins_get_size (ins->opcode);
 
-		if (offset > (cfg->code_size - max_len - 16)) {
+#define EXTRA_CODE_SPACE (16)
+
+		while (offset > (cfg->code_size - max_len - EXTRA_CODE_SPACE)) {
 			cfg->code_size *= 2;
 			cfg->native_code = g_realloc (cfg->native_code, cfg->code_size);
 			code = cfg->native_code + offset;

--- a/mono/mini/mini-ops.h
+++ b/mono/mini/mini-ops.h
@@ -209,6 +209,7 @@ MINI_OP(OP_SHR_UN_IMM, "shr_un_imm", IREG, IREG, NONE)
 MINI_OP(OP_BR,         "br", NONE, NONE, NONE)
 /* Similar to old OP_JMP, but the passing of arguments is done similarly to calls */
 MINI_OP(OP_TAILCALL,   "tailcall", NONE, NONE, NONE)
+MINI_OP(OP_TAILCALL_PARAMETER, "tailcall_parameter", NONE, NONE, NONE) // no code, just size
 MINI_OP(OP_TAILCALL_REG, "tailcall_reg", NONE, IREG, NONE)
 MINI_OP(OP_TAILCALL_MEMBASE, "tailcall_membase", NONE, IREG, NONE)
 MINI_OP(OP_BREAK,      "break", NONE, NONE, NONE)

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -3212,7 +3212,9 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 
 		max_len = ((guint8 *)ins_get_spec (ins->opcode))[MONO_INST_LEN];
 
-		if (offset > (cfg->code_size - max_len - 16)) {
+#define EXTRA_CODE_SPACE (16)
+
+		while (offset > (cfg->code_size - max_len - EXTRA_CODE_SPACE)) {
 			cfg->code_size *= 2;
 			cfg->native_code = g_realloc (cfg->native_code, cfg->code_size);
 			code = cfg->native_code + offset;

--- a/mono/mini/mini-sparc.c
+++ b/mono/mini/mini-sparc.c
@@ -2414,9 +2414,11 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 
 		spec = ins_get_spec (ins->opcode);
 
-		max_len = ((guint8 *)spec)[MONO_INST_LEN];
+		max_len = ins_get_size (ins->opcode);
 
-		if (offset > (cfg->code_size - max_len - 16)) {
+#define EXTRA_CODE_SPACE (16)
+
+		while (offset > (cfg->code_size - max_len - EXTRA_CODE_SPACE)) {
 			cfg->code_size *= 2;
 			cfg->native_code = g_realloc (cfg->native_code, cfg->code_size);
 			code = (guint32*)(cfg->native_code + offset);

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -686,6 +686,10 @@ mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig,
 	callee_ret = mini_get_underlying_type (callee_sig->ret);
 	res &= IS_SUPPORTED_TAILCALL (!(callee_ret && MONO_TYPE_ISSTRUCT (callee_ret) && callee_info->ret.storage != ArgValuetypeInReg));
 
+	// Limit stack_usage to 1G.
+	res &= IS_SUPPORTED_TAILCALL (callee_info->stack_usage < (1 << 30));
+	res &= IS_SUPPORTED_TAILCALL (caller_info->stack_usage < (1 << 30));
+
 exit:
 	g_free (caller_info);
 	g_free (callee_info);
@@ -3081,6 +3085,13 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			if (ins->dreg != ins->sreg1)
 				x86_mov_reg_reg (code, ins->dreg, ins->sreg1, 4);
 			break;
+
+		case OP_TAILCALL_PARAMETER:
+			// This opcode helps compute sizes, i.e.
+			// of the subsequent OP_TAILCALL, but contributes no code.
+			g_assert (ins->next);
+			break;
+
 		case OP_TAILCALL:
 		case OP_TAILCALL_MEMBASE: {
 			call = (MonoCallInst*)ins;
@@ -3090,6 +3101,16 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			gboolean const sreg1_ecx = sreg1 == X86_ECX;
 			gboolean const tailcall_membase_ecx = tailcall_membase && sreg1_ecx;
 			gboolean const tailcall_membase_not_ecx = tailcall_membase && !sreg1_ecx;
+
+			max_len += (call->stack_usage - call->stack_align_amount) / sizeof (mgreg_t) * ins_get_size (OP_TAILCALL_PARAMETER);
+			max_len += EXTRA_CODE_SPACE * 4; // FIXME accurate code sizing
+
+			while (G_UNLIKELY (offset + max_len > cfg->code_size)) {
+				cfg->code_size *= 2;
+				cfg->native_code = (unsigned char *)mono_realloc_native_code (cfg);
+				code = cfg->native_code + offset;
+				cfg->stat_code_reallocs++;
+			}
 
 			ins->flags |= MONO_INST_GC_CALLSITE;
 			ins->backend.pc_offset = code - cfg->native_code;

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -2452,11 +2452,11 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 	MONO_BB_FOR_EACH_INS (bb, ins) {
 		offset = code - cfg->native_code;
 
-		max_len = ((guint8 *)ins_get_spec (ins->opcode))[MONO_INST_LEN];
+		max_len = ins_get_size (ins->opcode);
 
 #define EXTRA_CODE_SPACE (16)
 
-		if (G_UNLIKELY (offset > (cfg->code_size - max_len - EXTRA_CODE_SPACE))) {
+		while (G_UNLIKELY (offset > (cfg->code_size - max_len - EXTRA_CODE_SPACE))) {
 			cfg->code_size *= 2;
 			cfg->native_code = mono_realloc_native_code(cfg);
 			code = cfg->native_code + offset;

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1698,6 +1698,12 @@ extern const char MONO_ARCH_CPU_SPEC [];
 extern const guint16 MONO_ARCH_CPU_SPEC_IDX(MONO_ARCH_CPU_SPEC) [];
 #define ins_get_spec(op) ((const char*)&MONO_ARCH_CPU_SPEC + MONO_ARCH_CPU_SPEC_IDX(MONO_ARCH_CPU_SPEC)[(op) - OP_LOAD])
 
+static inline unsigned
+ins_get_size (int opcode)
+{
+	return ((guint8 *)ins_get_spec (opcode))[MONO_INST_LEN];
+}
+
 enum {
 	MONO_COMP_DOM = 1,
 	MONO_COMP_IDOM = 2,

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1698,7 +1698,7 @@ extern const char MONO_ARCH_CPU_SPEC [];
 extern const guint16 MONO_ARCH_CPU_SPEC_IDX(MONO_ARCH_CPU_SPEC) [];
 #define ins_get_spec(op) ((const char*)&MONO_ARCH_CPU_SPEC + MONO_ARCH_CPU_SPEC_IDX(MONO_ARCH_CPU_SPEC)[(op) - OP_LOAD])
 
-static inline unsigned
+static inline int
 ins_get_size (int opcode)
 {
 	return ((guint8 *)ins_get_spec (opcode))[MONO_INST_LEN];

--- a/mono/tests/tailcall/2.il
+++ b/mono/tests/tailcall/2.il
@@ -74,24 +74,24 @@ class B
 
 .method static void check (int64 stack1, int64 stack2) noinlining
 {
-//ldarg.0
+//ldarg 0
 //brfalse.s IL_0004
 //ret
 //IL_0004:
 
-ldarg.0
-ldarg.1
+ldarg 0
+ldarg 1
 bne.un.s IL_0009
 ret
 
 IL_0009:
 ldstr "tailcall failure {0:X}"
-ldarg.0
-ldarg.1
+ldarg 0
+ldarg 1
 sub
 box int64
 call void class [mscorlib]System.Console::WriteLine(string, object)
-ldc.i4.1
+ldc.i4 1
 tail.
 call void class [mscorlib]System.Environment::Exit(int32)
 ret
@@ -99,61 +99,155 @@ ret
 
 .method instance void '.ctor' (!T1 a) noinlining
 {
-ldarg.0
+ldarg 0
 call instance void object::'.ctor'()
-ldarg.0
-ldarg.1
+ldarg 0
+ldarg 1
 stfld !0 class A`1<!0>::resultA
 ret
 }
 
-.method instance class [mscorlib]System.Tuple`2<!T1, !!T2> Method1<T2> (!!T2 resultB, int64 depth, int64 stack) noinlining
+.method instance class [mscorlib]System.Tuple`2<!T1, !!T2> Method1<T2> (
+//     0      1      2      3.     4      5      6      7 ..15
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+
+   !!T2 resultB, int64 depth, int64 stack) noinlining
 {
+.maxstack 999
 .locals init ( int64 a, int64 b, int64 c, int64 d, int64 e)
 
 
-ldarg.2
-ldc.i4.0
-conv.i8
-ble.s IL_0015
+ldarg 0x102
+ldc.i8 0
+ble IL_0015
 
-ldarg.0
-ldarg.1
-ldarg.2
-ldc.i4.1
+ldarg 0
+
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+
+ldarg 0x101
+ldarg 0x102
+ldc.i4 1
 conv.i8
 sub
 ldloca.s 0
 conv.u
 conv.u8
 tail.
-call instance class [mscorlib]System.Tuple`2<!0,!!0> class A`1<!T1>::Method2<!!0> (!!0, int64, int64)
+call instance class [mscorlib]System.Tuple`2<!0,!!0> class A`1<!T1>::Method2<!!0> (
+//     0      1      2      3.     4      5      6      7
+//     0      1      2      3.     4      5      6      7 ..15
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   !!0, int64, int64)
+
 ret
 
 IL_0015:
 ldloca.s 0
 conv.u
 conv.u8
-ldarg.3
+ldarg 0x103
 call void class A`1<!T1>::check(int64, int64)
-ldarg.0
+ldarg 0
 ldfld !0 class A`1<!0>::resultA
-ldarg.1
+ldarg 0x101
 newobj instance void class [mscorlib]System.Tuple`2<!T1, !!T2>::'.ctor'(!0, !1)
 ret
 }
 
-.method instance class [mscorlib]System.Tuple`2<!T1, !!T2> Method2<T2> (!!T2 resultB, int64 depth, int64 stack) noinlining
+.method instance class [mscorlib]System.Tuple`2<!T1, !!T2> Method2<T2> (
+//     0      1      2      3.     4      5      6      7 ..15
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   !!T2 resultB, int64 depth, int64 stack) noinlining
 {
+.maxstack 999
 .locals ( int64 a )
 
-ldarg.2
+ldarg 0x102
 ldc.i8 0
-ble.s IL_0015
+ble IL_0015
 
-ldarg.0
-ldarg.1
-ldarg.2
+ldarg 0
+
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+
+ldarg 0x101
+ldarg 0x102
 ldc.i8 1
 sub
 ldloca.s 0
@@ -161,19 +255,38 @@ conv.u
 conv.u8
 
 tail.
-call instance class [mscorlib]System.Tuple`2<!0,!!0> class A`1<!T1>::Method1<!!0> (!!0, int64, int64)
+call instance class [mscorlib]System.Tuple`2<!0,!!0> class A`1<!T1>::Method1<!!0> (
+//     0      1      2      3.     4      5      6      7
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   !!0, int64, int64)
 ret
 
 IL_0015:
 ldloca.s 0
 conv.u
 conv.u8
-ldarg.3
+ldarg 0x103
 call void class A`1<!T1>::check (int64, int64)
 
-ldarg.0
+ldarg 0
 ldfld !0 class A`1<!0>::resultA
-ldarg.1
+ldarg 0x101
+
 newobj instance void class [mscorlib]System.Tuple`2<!T1, !!T2>::'.ctor'(!0, !1)
 ret
 }
@@ -184,15 +297,55 @@ ret
 
 .method static void Main (string[] args) noinlining
 {
+.maxstack 999
 .entrypoint
 
-ldc.i4.1
+ldc.i4 1
 newobj instance void class A`1<int32>::'.ctor'(!0)
-ldc.i4.2
+
+
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7 ldc.i4 0 ldc.i4 1 ldc.i4 2 ldc.i4 3 ldc.i4 4 ldc.i4 5 ldc.i4 6 ldc.i4 7
+
+
+ldc.i4 2
 ldc.i8 9
 ldc.i8 0
 
-call instance class [mscorlib]System.Tuple`2<!0,!!0> class A`1<int32>::Method1<int32> (!!0, int64, int64)
+call instance class [mscorlib]System.Tuple`2<!0,!!0> class A`1<int32>::Method1<int32> (
+//     0      1      2      3.     4      5      6      7 .. 15
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+   int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32, int32,
+
+   !!0, int64, int64)
 //call void class [mscorlib]System.Console::WriteLine (object)
 pop
 ret
@@ -200,7 +353,7 @@ ret
 
 .method void '.ctor' ()
 {
-ldarg.0
+ldarg 0
 tail.
 call instance void object::'.ctor'()
 ret


### PR DESCRIPTION
Better sizing of tailcalls via new OP_TAILCALL_PARAMETER.
Allow arm64 r4.
Copy arm64 stacked parameters.
Better interface to instruction sizes.
Adding possibly missing reallocs.