### PR TITLE
[Tailcall] Fix patching of generic GOT under FullAOT.

### DIFF
--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -3955,9 +3955,8 @@ register_jump_target_got_slot (MonoDomain *domain, MonoMethod *method, gpointer 
 	 */
 	MonoJitDomainInfo *info = domain_jit_info (domain);
 	GSList *list;
-	MonoMethod *shared_method = mini_method_to_shared (method);
-	method = shared_method ? shared_method : method;
-		
+	method = mono_method_to_shared (method);
+
 	mono_domain_lock (domain);
 	if (!info->jump_target_got_slot_hash)
 		info->jump_target_got_slot_hash = g_hash_table_new (NULL, NULL);

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -3955,6 +3955,8 @@ register_jump_target_got_slot (MonoDomain *domain, MonoMethod *method, gpointer 
 	 */
 	MonoJitDomainInfo *info = domain_jit_info (domain);
 	GSList *list;
+	MonoMethod *shared_method = mini_method_to_shared (method);
+	method = shared_method ? shared_method : method;
 		
 	mono_domain_lock (domain);
 	if (!info->jump_target_got_slot_hash)

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -3955,8 +3955,9 @@ register_jump_target_got_slot (MonoDomain *domain, MonoMethod *method, gpointer 
 	 */
 	MonoJitDomainInfo *info = domain_jit_info (domain);
 	GSList *list;
-	method = mono_method_to_shared (method);
-
+	MonoMethod *shared_method = mini_method_to_shared (method);
+	method = shared_method ? shared_method : method;
+		
 	mono_domain_lock (domain);
 	if (!info->jump_target_got_slot_hash)
 		info->jump_target_got_slot_hash = g_hash_table_new (NULL, NULL);

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -4114,25 +4114,28 @@ mini_is_gsharedvt_variable_signature (MonoMethodSignature *sig)
 }
 
 MonoMethod*
-mini_method_to_shared (MonoMethod *method)
+mono_method_to_shared (MonoMethod *method)
 {
 	if (!mono_method_is_generic_impl (method))
-		return NULL;
+		return method;
 
 	ERROR_DECL (error);
+
+	MonoMethod *shared_method;
 
 	// This pattern is based on add_extra_method_with_depth.
 
 	if (mono_method_is_generic_sharable_full (method, TRUE, TRUE, FALSE))
 		// gshared over reference type
-		method = mini_get_shared_method_full (method, SHARE_MODE_NONE, error);
+		shared_method = mini_get_shared_method_full (method, SHARE_MODE_NONE, error);
 	else if (mono_method_is_generic_sharable_full (method, FALSE, FALSE, TRUE))
 		// gshared over valuetype (or primitive?)
-		method = mini_get_shared_method_full (method, SHARE_MODE_GSHAREDVT, error);
+		shared_method = mini_get_shared_method_full (method, SHARE_MODE_GSHAREDVT, error);
 	else
-		return NULL;
+		return method;
+	g_assert (shared_method != method);
 	mono_error_assert_ok (error);
-	return method;
+	return shared_method;
 }
 
 #else
@@ -4174,9 +4177,9 @@ mini_is_gsharedvt_variable_signature (MonoMethodSignature *sig)
 }
 
 MonoMethod*
-mini_method_to_shared (MonoMethod *method)
+mono_method_to_shared (MonoMethod *method)
 {
-	return NULL;
+	return method;
 }
 
 #endif /* !MONO_ARCH_GSHAREDVT_SUPPORTED */

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -4114,28 +4114,25 @@ mini_is_gsharedvt_variable_signature (MonoMethodSignature *sig)
 }
 
 MonoMethod*
-mono_method_to_shared (MonoMethod *method)
+mini_method_to_shared (MonoMethod *method)
 {
 	if (!mono_method_is_generic_impl (method))
-		return method;
+		return NULL;
 
 	ERROR_DECL (error);
-
-	MonoMethod *shared_method;
 
 	// This pattern is based on add_extra_method_with_depth.
 
 	if (mono_method_is_generic_sharable_full (method, TRUE, TRUE, FALSE))
 		// gshared over reference type
-		shared_method = mini_get_shared_method_full (method, SHARE_MODE_NONE, error);
+		method = mini_get_shared_method_full (method, SHARE_MODE_NONE, error);
 	else if (mono_method_is_generic_sharable_full (method, FALSE, FALSE, TRUE))
 		// gshared over valuetype (or primitive?)
-		shared_method = mini_get_shared_method_full (method, SHARE_MODE_GSHAREDVT, error);
+		method = mini_get_shared_method_full (method, SHARE_MODE_GSHAREDVT, error);
 	else
-		return method;
-	g_assert (shared_method != method);
+		return NULL;
 	mono_error_assert_ok (error);
-	return shared_method;
+	return method;
 }
 
 #else
@@ -4177,9 +4174,9 @@ mini_is_gsharedvt_variable_signature (MonoMethodSignature *sig)
 }
 
 MonoMethod*
-mono_method_to_shared (MonoMethod *method)
+mini_method_to_shared (MonoMethod *method)
 {
-	return method;
+	return NULL;
 }
 
 #endif /* !MONO_ARCH_GSHAREDVT_SUPPORTED */

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -1670,13 +1670,10 @@ mono_resolve_patch_target (MonoMethod *method, MonoDomain *domain, guint8 *code,
 void
 mini_register_jump_site (MonoDomain *domain, MonoMethod *method, gpointer ip)
 {
-	ERROR_DECL (error);
 	MonoJumpList *jlist;
 
-	if (mono_method_is_generic_sharable (method, TRUE)) {
-		method = mini_get_shared_method_full (method, SHARE_MODE_NONE, error);
-		mono_error_assert_ok (error);
-	}
+	MonoMethod *shared_method = mini_method_to_shared (method);
+	method = shared_method ? shared_method : method;
 
 	mono_domain_lock (domain);
 	jlist = (MonoJumpList *)g_hash_table_lookup (domain_jit_info (domain)->jump_target_hash, method);
@@ -1696,7 +1693,6 @@ mini_register_jump_site (MonoDomain *domain, MonoMethod *method, gpointer ip)
 void
 mini_patch_jump_sites (MonoDomain *domain, MonoMethod *method, gpointer addr)
 {
-	ERROR_DECL (error);
 	GHashTable *hash = domain_jit_info (domain)->jump_target_hash;
 
 	if (!hash)
@@ -1707,10 +1703,8 @@ mini_patch_jump_sites (MonoDomain *domain, MonoMethod *method, gpointer addr)
 	GSList *tmp;
 
 	/* The caller/callee might use different instantiations */
-	if (mono_method_is_generic_sharable (method, TRUE)) {
-		method = mini_get_shared_method_full (method, SHARE_MODE_NONE, error);
-		mono_error_assert_ok (error);
-	}
+	MonoMethod *shared_method = mini_method_to_shared (method);
+	method = shared_method ? shared_method : method;
 
 	mono_domain_lock (domain);
 	jlist = (MonoJumpList *)g_hash_table_lookup (hash, method);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -1672,8 +1672,7 @@ mini_register_jump_site (MonoDomain *domain, MonoMethod *method, gpointer ip)
 {
 	MonoJumpList *jlist;
 
-	MonoMethod *shared_method = mini_method_to_shared (method);
-	method = shared_method ? shared_method : method;
+	method = mono_method_to_shared (method);
 
 	mono_domain_lock (domain);
 	jlist = (MonoJumpList *)g_hash_table_lookup (domain_jit_info (domain)->jump_target_hash, method);
@@ -1703,8 +1702,7 @@ mini_patch_jump_sites (MonoDomain *domain, MonoMethod *method, gpointer addr)
 	GSList *tmp;
 
 	/* The caller/callee might use different instantiations */
-	MonoMethod *shared_method = mini_method_to_shared (method);
-	method = shared_method ? shared_method : method;
+	method = mono_method_to_shared (method);
 
 	mono_domain_lock (domain);
 	jlist = (MonoJumpList *)g_hash_table_lookup (hash, method);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -1672,7 +1672,8 @@ mini_register_jump_site (MonoDomain *domain, MonoMethod *method, gpointer ip)
 {
 	MonoJumpList *jlist;
 
-	method = mono_method_to_shared (method);
+	MonoMethod *shared_method = mini_method_to_shared (method);
+	method = shared_method ? shared_method : method;
 
 	mono_domain_lock (domain);
 	jlist = (MonoJumpList *)g_hash_table_lookup (domain_jit_info (domain)->jump_target_hash, method);
@@ -1702,7 +1703,8 @@ mini_patch_jump_sites (MonoDomain *domain, MonoMethod *method, gpointer addr)
 	GSList *tmp;
 
 	/* The caller/callee might use different instantiations */
-	method = mono_method_to_shared (method);
+	MonoMethod *shared_method = mini_method_to_shared (method);
+	method = shared_method ? shared_method : method;
 
 	mono_domain_lock (domain);
 	jlist = (MonoJumpList *)g_hash_table_lookup (hash, method);

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -792,6 +792,8 @@ common_call_trampoline (mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVTable *
 		 */
 		if (domain_jit_info (domain)->jump_target_got_slot_hash) {
 			GSList *list, *tmp;
+			MonoMethod *shared_method = mini_method_to_shared (m);
+			m = shared_method ? shared_method : m;
 
 			mono_domain_lock (domain);
 			list = (GSList *)g_hash_table_lookup (domain_jit_info (domain)->jump_target_got_slot_hash, m);

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -792,7 +792,8 @@ common_call_trampoline (mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVTable *
 		 */
 		if (domain_jit_info (domain)->jump_target_got_slot_hash) {
 			GSList *list, *tmp;
-			m = mono_method_to_shared (m);
+			MonoMethod *shared_method = mini_method_to_shared (m);
+			m = shared_method ? shared_method : m;
 
 			mono_domain_lock (domain);
 			list = (GSList *)g_hash_table_lookup (domain_jit_info (domain)->jump_target_got_slot_hash, m);

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -792,8 +792,7 @@ common_call_trampoline (mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVTable *
 		 */
 		if (domain_jit_info (domain)->jump_target_got_slot_hash) {
 			GSList *list, *tmp;
-			MonoMethod *shared_method = mini_method_to_shared (m);
-			m = shared_method ? shared_method : m;
+			m = mono_method_to_shared (m);
 
 			mono_domain_lock (domain);
 			list = (GSList *)g_hash_table_lookup (domain_jit_info (domain)->jump_target_got_slot_hash, m);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2612,6 +2612,6 @@ MonoInst*   mono_emit_native_types_intrinsics (MonoCompile *cfg, MonoMethod *cme
 MonoType*   mini_native_type_replace_type (MonoType *type) MONO_LLVM_INTERNAL;
 
 MonoMethod*
-mono_method_to_shared (MonoMethod *method);
+mini_method_to_shared (MonoMethod *method); // null if not shared
 
 #endif /* __MONO_MINI_H__ */

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2612,6 +2612,6 @@ MonoInst*   mono_emit_native_types_intrinsics (MonoCompile *cfg, MonoMethod *cme
 MonoType*   mini_native_type_replace_type (MonoType *type) MONO_LLVM_INTERNAL;
 
 MonoMethod*
-mini_method_to_shared (MonoMethod *method); // null if not shared
+mono_method_to_shared (MonoMethod *method);
 
 #endif /* __MONO_MINI_H__ */

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2611,4 +2611,7 @@ gboolean    mono_class_is_magic_float (MonoClass *klass);
 MonoInst*   mono_emit_native_types_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args);
 MonoType*   mini_native_type_replace_type (MonoType *type) MONO_LLVM_INTERNAL;
 
+MonoMethod*
+mini_method_to_shared (MonoMethod *method); // null if not shared
+
 #endif /* __MONO_MINI_H__ */

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -927,6 +927,7 @@ PLATFORM_DISABLED_TESTS += tailcall-interface-conservestack.exe
 PLATFORM_DISABLED_TESTS += tailcall/2.exe
 PLATFORM_DISABLED_TESTS += tailcall/3.exe
 PLATFORM_DISABLED_TESTS += tailcall/4.exe
+PLATFORM_DISABLED_TESTS += tailcall/8273.exe
 
 endif
 
@@ -940,6 +941,7 @@ PLATFORM_DISABLED_TESTS += tailcall-virt.exe
 PLATFORM_DISABLED_TESTS += tailcall/2.exe
 PLATFORM_DISABLED_TESTS += tailcall/3.exe
 PLATFORM_DISABLED_TESTS += tailcall/4.exe
+PLATFORM_DISABLED_TESTS += tailcall/8273.exe
 PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail.exe
 PLATFORM_DISABLED_TESTS += tailcall-interface-conservestack.exe
 PLATFORM_DISABLED_TESTS += ivtail1.exe
@@ -959,6 +961,7 @@ PLATFORM_DISABLED_TESTS += tailcall-virt.exe
 PLATFORM_DISABLED_TESTS += tailcall/2.exe
 PLATFORM_DISABLED_TESTS += tailcall/3.exe
 PLATFORM_DISABLED_TESTS += tailcall/4.exe
+PLATFORM_DISABLED_TESTS += tailcall/8273.exe
 PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail.exe
 PLATFORM_DISABLED_TESTS += tailcall-interface-conservestack.exe
 PLATFORM_DISABLED_TESTS += ivtail1.exe
@@ -980,6 +983,7 @@ PLATFORM_DISABLED_TESTS += tailcall-virt.exe
 PLATFORM_DISABLED_TESTS += tailcall/2.exe
 PLATFORM_DISABLED_TESTS += tailcall/3.exe
 PLATFORM_DISABLED_TESTS += tailcall/4.exe
+PLATFORM_DISABLED_TESTS += tailcall/8273.exe
 PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail.exe
 PLATFORM_DISABLED_TESTS += tailcall-interface-conservestack.exe
 PLATFORM_DISABLED_TESTS += ivtail1.exe
@@ -1020,6 +1024,7 @@ PLATFORM_DISABLED_TESTS += tailcall-virt.exe
 PLATFORM_DISABLED_TESTS += tailcall/2.exe
 PLATFORM_DISABLED_TESTS += tailcall/3.exe
 PLATFORM_DISABLED_TESTS += tailcall/4.exe
+PLATFORM_DISABLED_TESTS += tailcall/8273.exe
 PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail.exe
 PLATFORM_DISABLED_TESTS += tailcall-interface-conservestack.exe
 PLATFORM_DISABLED_TESTS += ivtail1.exe
@@ -1041,6 +1046,7 @@ PLATFORM_DISABLED_TESTS += tailcall-virt.exe
 PLATFORM_DISABLED_TESTS += tailcall/2.exe
 PLATFORM_DISABLED_TESTS += tailcall/3.exe
 PLATFORM_DISABLED_TESTS += tailcall/4.exe
+PLATFORM_DISABLED_TESTS += tailcall/8273.exe
 PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail.exe
 PLATFORM_DISABLED_TESTS += tailcall-interface-conservestack.exe
 PLATFORM_DISABLED_TESTS += ivtail1.exe
@@ -1234,7 +1240,6 @@ endif
 AOT_DISABLED_TESTS= \
 	constraints-load.exe
 
-# tailcall/fsharp AOT hangs
 # tailcall/fsharp FullAOT stack overflow in CI but not locally.
 AOT_DISABLED_TESTS += tailcall/fsharp-deeptail.exe
 
@@ -1330,6 +1335,7 @@ INTERP_DISABLED_TESTS = $(DISABLED_TESTS) \
 	tailcall/2.exe \
 	tailcall/3.exe \
 	tailcall/4.exe \
+	tailcall/8273.exe \
 	bug-60843.exe
 
 # bug-48015.exe: be careful when re-enabling, it happens that it returns with exit code 0, but doesn't actually execute the test.

--- a/mono/tests/tailcall/8273.il
+++ b/mono/tests/tailcall/8273.il
@@ -1,0 +1,221 @@
+/*
+
+https://github.com/mono/mono/issues/8273
+
+This test is really slow, so its iteration count is lowered.
+It takes under a second for JIT and AOT, but 9 minutes for FullAOT, if you grow the iteration count.
+Also string is slow but int32 is fast.
+Search for "999".
+
+Based on this F# and C#.
+
+type TailCallLoopGenericClassAndMethod<'T1>(resultA: 'T1) =
+    member this.Method1<'T2>(x:int, resultB: 'T2) =
+        if x = 0 then (resultA, resultB) else this.Method2 (x - 1, resultB)
+    member this.Method2<'T2>(x:int, resultB: 'T2) =
+        if x = 0 then (resultA, resultB) else this.Method1 (x  - 1, resultB)
+
+using System;
+using System.Runtime.CompilerServices;
+using static System.Runtime.CompilerServices.MethodImplOptions;
+
+unsafe class A<T1>
+{
+	T1 resultA;
+
+	[MethodImpl (NoInlining)]
+	static void check (long stack1, long stack2)
+	{
+// NOTE: This is wierd in order to feed into the edited IL.
+		if (stack1 != 0)
+			return;
+		if (stack1 == stack2)
+			return;
+		Console.WriteLine ("tailcall failure {0} {1}", stack1, stack2);
+		Environment.Exit (1);
+	}
+
+	[MethodImpl (NoInlining)]
+	public A(T1 a)
+	{
+		resultA = a;
+	}
+
+	[MethodImpl (NoInlining)]
+	public System.Tuple<T1, T2> Method1<T2> (T2 resultB, long depth = 100, long stack = 0)
+	{
+		int local;
+		if (depth > 0)
+			return Method2 (resultB, depth - 1, (long)&local);
+		check ((long)&local, stack);
+		return new System.Tuple<T1, T2> (resultA, resultB);
+	}
+
+	[MethodImpl (NoInlining)]
+	System.Tuple<T1, T2> Method2<T2> (T2 resultB, long depth = 100, long stack = 0)
+	{
+		int local;
+		if (depth > 0)
+			return Method1 (resultB, depth - 1, (long)&local);
+		check ((long)&local, stack);
+		return new System.Tuple<T1, T2> (resultA, resultB);
+	}
+}
+
+class B
+{
+	[MethodImpl (NoInlining)]
+	public static void Main (string[] args)
+	{
+		new A<int> (1).Method1 (2);
+	}
+}
+*/
+
+.assembly extern mscorlib { }
+
+.assembly '1' { }
+
+.class A`1<T1>
+{
+.field assembly !T1 resultA
+
+.method static void check (int64 stack1, int64 stack2) noinlining
+{
+//ldarg.0
+//brfalse.s IL_0004
+//ret
+//IL_0004:
+
+ldarg.0
+ldarg.1
+bne.un.s IL_0009
+ret
+
+IL_0009:
+ldstr "tailcall failure {0:X}"
+ldarg.0
+ldarg.1
+sub
+box int64
+call void class [mscorlib]System.Console::WriteLine(string, object)
+ldc.i4.1
+tail.
+call void class [mscorlib]System.Environment::Exit(int32)
+ret
+}
+
+.method instance void '.ctor' (!T1 a) noinlining
+{
+ldarg.0
+call instance void object::'.ctor'()
+ldarg.0
+ldarg.1
+stfld !0 class A`1<!0>::resultA
+ret
+}
+
+.method public hidebysig instance class [mscorlib]System.Tuple`2<!T1, !!T2> Method1<T2> (!!T2 resultB, int64 depth, int64 stack) noinlining
+{
+.locals init ( int64 a, int64 b, int64 c, int64 d, int64 e)
+
+ldarg.2
+ldc.i4.0
+conv.i8
+ble.s IL_0015
+
+ldarg.0
+ldarg.1
+ldarg.2
+ldc.i4.1
+conv.i8
+sub
+ldloca.s 0
+conv.u
+conv.u8
+tail.
+call instance class [mscorlib]System.Tuple`2<!0,!!0> class A`1<!T1>::Method2<!!0> (!!0, int64, int64)
+ret
+
+IL_0015:
+ldloca.s 0
+conv.u
+conv.u8
+ldarg.3
+call void class A`1<!T1>::check(int64, int64)
+ldarg.0
+ldfld !0 class A`1<!0>::resultA
+ldarg.1
+newobj instance void class [mscorlib]System.Tuple`2<!T1, !!T2>::'.ctor'(!0, !1)
+ret
+}
+
+.method public hidebysig instance class [mscorlib]System.Tuple`2<!T1, !!T2> Method2<T2> (!!T2 resultB, int64 depth, int64 stack) noinlining
+{
+.locals ( int64 a )
+
+ldarg.2
+ldc.i8 0
+ble.s IL_0015
+
+ldarg.0
+ldarg.1
+ldarg.2
+ldc.i8 1
+sub
+ldloca.s 0
+conv.u
+conv.u8
+
+tail.
+call instance class [mscorlib]System.Tuple`2<!0,!!0> class A`1<!T1>::Method1<!!0> (!!0, int64, int64)
+ret
+
+IL_0015:
+ldloca.s 0
+conv.u
+conv.u8
+ldarg.3
+call void class A`1<!T1>::check (int64, int64)
+
+ldarg.0
+ldfld !0 class A`1<!0>::resultA
+ldarg.1
+newobj instance void class [mscorlib]System.Tuple`2<!T1, !!T2>::'.ctor'(!0, !1)
+ret
+}
+}
+
+.class B
+{
+
+.method static void Main (string[] args) noinlining
+{
+.entrypoint
+
+// Using string instead of int32 here makes this test really slow,'
+// so use a low iteration count -- anything small is ok to test tailcall.
+
+ldstr "a"
+//ldc.i4 1
+newobj instance void class A`1<string>::'.ctor'(!0)
+ldstr "b"
+//ldc.i4 2
+ldc.i8 99999999
+//ldc.i8 9
+ldc.i8 0
+
+call instance class [mscorlib]System.Tuple`2<!0,!!0> class A`1<string>::Method1<string> (!!0, int64, int64)
+//call void class [mscorlib]System.Console::WriteLine (object)
+pop
+ret
+}
+
+.method void '.ctor' ()
+{
+ldarg.0
+tail.
+call instance void object::'.ctor'()
+ret
+}
+}


### PR DESCRIPTION
This fixes bug https://github.com/mono/mono/issues/8273 where FullAOT generic-shared (valuetype?) runs hundreds of times slower than regular AOT due to hitting the trampoline for every call.

[Coop] Fork test 8273.il from 3.il and increase iteration count
so it takes a long time previously.

Also possibly fix a JIT path where gshared but not gsharedvt handled.
