### PR TITLE
[interp] enable mcs tests on armv7

### DIFF
--- a/scripts/ci/run-test-interpreter.sh
+++ b/scripts/ci/run-test-interpreter.sh
@@ -10,5 +10,5 @@ ${TESTCMD} --label=runtime-interp --timeout=160m make -w -C mono/tests -k testin
 ${TESTCMD} --label=corlib --timeout=160m make -w -C mcs/class/corlib run-test V=1
 ${TESTCMD} --label=System --timeout=160m bash -c "export MONO_TLS_PROVIDER=legacy && make -w -C mcs/class/System run-test V=1"
 ${TESTCMD} --label=System.Core --timeout=160m make -w -C mcs/class/System.Core run-test V=1
-if [[ ${CI_TAGS} != *'linux-armhf'* ]]; then ${TESTCMD} --label=mcs-tests --timeout=160m make -w -C mcs/tests run-test V=1; fi
+${TESTCMD} --label=mcs-tests --timeout=160m make -w -C mcs/tests run-test V=1;
 ${TESTCMD} --label=Mono.Debugger.Soft --timeout=5m make -w -C mcs/class/Mono.Debugger.Soft run-test V=1


### PR DESCRIPTION
there was a technical limitiation to run it reliably (aka. "the r8 problem"), which was resolved by https://github.com/mono/mono/pull/8056
