### PR TITLE
Free or destroy, of any type, should do nothing, silently, given a null pointer.

### DIFF
--- a/mono/eglib/ghashtable.c
+++ b/mono/eglib/ghashtable.c
@@ -545,8 +545,9 @@ void
 g_hash_table_destroy (GHashTable *hash)
 {
 	int i;
-	
-	g_return_if_fail (hash != NULL);
+
+	if (!hash)
+		return;
 
 	for (i = 0; i < hash->table_size; i++){
 		Slot *s, *next;

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -4236,7 +4236,7 @@ mono_metadata_free_mh (MonoMethodHeader *mh)
 	 * or a SRE-generated method, so the lifetime in that case is
 	 * dictated by the method's own lifetime
 	 */
-	if (mh->is_transient) {
+	if (mh && mh->is_transient) {
 		for (i = 0; i < mh->num_locals; ++i)
 			mono_metadata_free_type (mh->locals [i]);
 		g_free (mh);

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -11895,10 +11895,8 @@ acfg_free (MonoAotCompile *acfg)
 	g_hash_table_destroy (acfg->method_indexes);
 	g_hash_table_destroy (acfg->method_depth);
 	g_hash_table_destroy (acfg->plt_offset_to_entry);
-	for (i = 0; i < MONO_PATCH_INFO_NUM; ++i) {
-		if (acfg->patch_to_plt_entry [i])
-			g_hash_table_destroy (acfg->patch_to_plt_entry [i]);
-	}
+	for (i = 0; i < MONO_PATCH_INFO_NUM; ++i)
+		g_hash_table_destroy (acfg->patch_to_plt_entry [i]);
 	g_free (acfg->patch_to_plt_entry);
 	g_hash_table_destroy (acfg->method_to_cfg);
 	g_hash_table_destroy (acfg->token_info_hash);
@@ -11906,8 +11904,7 @@ acfg_free (MonoAotCompile *acfg)
 	g_hash_table_destroy (acfg->image_hash);
 	g_hash_table_destroy (acfg->unwind_info_offsets);
 	g_hash_table_destroy (acfg->method_label_hash);
-	if (acfg->typespec_classes)
-		g_hash_table_destroy (acfg->typespec_classes);
+	g_hash_table_destroy (acfg->typespec_classes);
 	g_hash_table_destroy (acfg->export_names);
 	g_hash_table_destroy (acfg->plt_entry_debug_sym_cache);
 	g_hash_table_destroy (acfg->klass_blob_hash);

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -2402,10 +2402,8 @@ mono_aot_init (void)
 void
 mono_aot_cleanup (void)
 {
-	if (aot_jit_icall_hash)
-		g_hash_table_destroy (aot_jit_icall_hash);
-	if (aot_modules)
-		g_hash_table_destroy (aot_modules);
+	g_hash_table_destroy (aot_jit_icall_hash);
+	g_hash_table_destroy (aot_modules);
 }
 
 static gboolean

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -2214,8 +2214,7 @@ debugger_agent_free_domain_info (MonoDomain *domain)
 
 	if (info) {
 		for (i = 0; i < ID_NUM; ++i)
-			if (info->val_to_id [i])
-				g_hash_table_destroy (info->val_to_id [i]);
+			g_hash_table_destroy (info->val_to_id [i]);
 		g_hash_table_destroy (info->loaded_classes);
 
 		g_hash_table_iter_init (&iter, info->source_files);
@@ -5709,8 +5708,7 @@ ss_start (SingleStepReq *ss_req, MonoMethod *method, SeqPoint* sp, MonoSeqPointI
 				if (sp->il_offset == asyncMethod->yield_offsets [i]) {
 					ss_req->async_id = get_this_async_id (frames [0]);
 					ss_bp_add_one (ss_req, &ss_req_bp_count, &ss_req_bp_cache, method, asyncMethod->resume_offsets [i]);
-					if (ss_req_bp_cache)
-						g_hash_table_destroy (ss_req_bp_cache);
+					g_hash_table_destroy (ss_req_bp_cache);
 					mono_debug_free_method_async_debug_info (asyncMethod);
 					return;
 				}
@@ -5726,8 +5724,7 @@ ss_start (SingleStepReq *ss_req, MonoMethod *method, SeqPoint* sp, MonoSeqPointI
 					ss_req->async_id = get_this_async_id (frames [0]);
 					ss_req->async_stepout_method = get_notify_debugger_of_wait_completion_method ();
 					ss_bp_add_one (ss_req, &ss_req_bp_count, &ss_req_bp_cache, ss_req->async_stepout_method, 0);
-					if (ss_req_bp_cache)
-						g_hash_table_destroy (ss_req_bp_cache);
+					g_hash_table_destroy (ss_req_bp_cache);
 					mono_debug_free_method_async_debug_info (asyncMethod);
 					return;
 				}
@@ -5848,8 +5845,7 @@ ss_start (SingleStepReq *ss_req, MonoMethod *method, SeqPoint* sp, MonoSeqPointI
 		ss_req->global = FALSE;
 	}
 
-	if (ss_req_bp_cache)
-		g_hash_table_destroy (ss_req_bp_cache);
+	g_hash_table_destroy (ss_req_bp_cache);
 }
 
 /*

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1207,8 +1207,7 @@ no_intrinsic:
 				has_vt_arg |= !mini_type_is_reference (csignature->params [i]);
 
 			gboolean empty_callee = mheader && *mheader->code == CEE_RET;
-			if (mheader)
-				mono_metadata_free_mh (mheader);
+			mono_metadata_free_mh (mheader);
 
 			if (empty_callee && called_inited && !has_vt_arg) {
 				if (td->verbose_level)

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -3433,8 +3433,7 @@ mono_generic_sharing_cleanup (void)
 {
 	mono_remove_image_unload_hook (mono_class_unregister_image_generic_subclasses, NULL);
 
-	if (generic_subclass_hash)
-		g_hash_table_destroy (generic_subclass_hash);
+	g_hash_table_destroy (generic_subclass_hash);
 }
 
 /*

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -8534,8 +8534,7 @@ mono_llvm_free_domain_info (MonoDomain *domain)
 	if (!module)
 		return;
 
-	if (module->llvm_types)
-		g_hash_table_destroy (module->llvm_types);
+	g_hash_table_destroy (module->llvm_types);
 
 	mono_llvm_dispose_ee (module->mono_ee);
 
@@ -8557,8 +8556,7 @@ mono_llvm_create_aot_module (MonoAssembly *assembly, const char *global_prefix, 
 	MonoLLVMModule *module = &aot_module;
 
 	/* Delete previous module */
-	if (module->plt_entries)
-		g_hash_table_destroy (module->plt_entries);
+	g_hash_table_destroy (module->plt_entries);
 	if (module->lmodule)
 		LLVMDisposeModule (module->lmodule);
 

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -164,10 +164,8 @@ save_old_signal_handler (int signo, struct sigaction *old_action)
 static void
 free_saved_signal_handlers (void)
 {
-	if (mono_saved_signal_handlers) {
-		g_hash_table_destroy (mono_saved_signal_handlers);
-		mono_saved_signal_handlers = NULL;
-	}
+	g_hash_table_destroy (mono_saved_signal_handlers);
+	mono_saved_signal_handlers = NULL;
 }
 
 /*

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3817,25 +3817,20 @@ mini_free_jit_domain_info (MonoDomain *domain)
 		g_hash_table_foreach (info->dynamic_code_hash, dynamic_method_info_free, NULL);
 		g_hash_table_destroy (info->dynamic_code_hash);
 	}
-	if (info->method_code_hash)
-		g_hash_table_destroy (info->method_code_hash);
+	g_hash_table_destroy (info->method_code_hash);
 	g_hash_table_destroy (info->jump_trampoline_hash);
 	g_hash_table_destroy (info->jit_trampoline_hash);
 	g_hash_table_destroy (info->delegate_trampoline_hash);
-	if (info->static_rgctx_trampoline_hash)
-		g_hash_table_destroy (info->static_rgctx_trampoline_hash);
-	if (info->mrgctx_hash)
-		g_hash_table_destroy (info->mrgctx_hash);
-	if (info->method_rgctx_hash)
-		g_hash_table_destroy (info->method_rgctx_hash);
+	g_hash_table_destroy (info->static_rgctx_trampoline_hash);
+	g_hash_table_destroy (info->mrgctx_hash);
+	g_hash_table_destroy (info->method_rgctx_hash);
 	g_hash_table_destroy (info->llvm_vcall_trampoline_hash);
 	mono_conc_hashtable_destroy (info->runtime_invoke_hash);
 	g_hash_table_destroy (info->seq_points);
 	g_hash_table_destroy (info->arch_seq_points);
 	if (info->agent_info)
 		mini_get_dbg_callbacks ()->free_domain_info (domain);
-	if (info->gsharedvt_arg_tramp_hash)
-		g_hash_table_destroy (info->gsharedvt_arg_tramp_hash);
+	g_hash_table_destroy (info->gsharedvt_arg_tramp_hash);
 	if (info->llvm_jit_callees) {
 		g_hash_table_foreach (info->llvm_jit_callees, free_jit_callee_list, NULL);
 		g_hash_table_destroy (info->llvm_jit_callees);

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -1405,11 +1405,8 @@ mono_trampolines_init (void)
 void
 mono_trampolines_cleanup (void)
 {
-	if (rgctx_lazy_fetch_trampoline_hash)
-		g_hash_table_destroy (rgctx_lazy_fetch_trampoline_hash);
-	if (rgctx_lazy_fetch_trampoline_hash_addr)
-		g_hash_table_destroy (rgctx_lazy_fetch_trampoline_hash_addr);
-
+	g_hash_table_destroy (rgctx_lazy_fetch_trampoline_hash);
+	g_hash_table_destroy (rgctx_lazy_fetch_trampoline_hash_addr);
 	mono_os_mutex_destroy (&trampolines_mutex);
 }
 

--- a/mono/mini/mini-wasm.c
+++ b/mono/mini/mini-wasm.c
@@ -923,8 +923,7 @@ describe_variable (MonoStackFrameInfo *info, MonoContext *ctx, gpointer ud)
 			g_free (type_name);
 		}
 	}
-	if (header)
-		mono_metadata_free_mh (header);
+	mono_metadata_free_mh (header);
 
 	return TRUE;
 }

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -1922,21 +1922,13 @@ mono_destroy_compile (MonoCompile *cfg)
 {
 	mono_empty_compile (cfg);
 
-	if (cfg->header)
-		mono_metadata_free_mh (cfg->header);
+	mono_metadata_free_mh (cfg->header);
 
-	if (cfg->spvars)
-		g_hash_table_destroy (cfg->spvars);
-	if (cfg->exvars)
-		g_hash_table_destroy (cfg->exvars);
-
+	g_hash_table_destroy (cfg->spvars);
+	g_hash_table_destroy (cfg->exvars);
 	g_list_free (cfg->ldstr_list);
-
-	if (cfg->token_info_hash)
-		g_hash_table_destroy (cfg->token_info_hash);
-
-	if (cfg->abs_patches)
-		g_hash_table_destroy (cfg->abs_patches);
+	g_hash_table_destroy (cfg->token_info_hash);
+	g_hash_table_destroy (cfg->abs_patches);
 
 	mono_debug_free_method (cfg);
 


### PR DESCRIPTION
Remove excess null checks.
