### PR TITLE
Fix ThreadPoolTests.PerformanceCounter_WorkItems fails occasionally.

### DIFF
--- a/mcs/class/corlib/Test/System.Threading/ThreadPoolTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/ThreadPoolTest.cs
@@ -277,7 +277,7 @@ namespace MonoTests.System.Threading
 			//Console.WriteLine ("workItems0:{0} workItems1:{1}", workItems0, workItems1);
 			//Console.WriteLine ("threads:{0}",  threads0);
 
-			Assert.AreEqual (N, workItems1 - workItems0, "#1");
+			Assert.IsTrue (workItems1 - workItems0) >= N, "#1");
 			Assert.IsTrue (threads0 > 0, "#2");
 		}
 #endif

--- a/mcs/class/corlib/Test/System.Threading/ThreadPoolTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/ThreadPoolTest.cs
@@ -277,7 +277,7 @@ namespace MonoTests.System.Threading
 			//Console.WriteLine ("workItems0:{0} workItems1:{1}", workItems0, workItems1);
 			//Console.WriteLine ("threads:{0}",  threads0);
 
-			Assert.IsTrue (workItems1 - workItems0) >= N, "#1");
+			AssertHelper.GreaterOrEqual ((int)(workItems1 - workItems0), N, "#1");
 			Assert.IsTrue (threads0 > 0, "#2");
 		}
 #endif


### PR DESCRIPTION
https://github.com/mono/mono/issues/8473
At least N work items, not exactly.
