### PR TITLE
Fix Win32 G_GSIZE_FORMAT to be %u consistent with other 32bit platforms instead of %d.

### DIFF
--- a/mono/eglib/eglib-config.hw
+++ b/mono/eglib/eglib-config.hw
@@ -25,7 +25,11 @@ typedef int pid_t;
 #define G_DIR_SEPARATOR_S        "\\"
 #define G_SEARCHPATH_SEPARATOR_S ";"
 #define G_SEARCHPATH_SEPARATOR   ';'
-#define G_GSIZE_FORMAT   "d"
+#ifdef _WIN64
+#define G_GSIZE_FORMAT   "I64u" // assuming Microsoft C runtime back to circa year 2000, newer supports "ll"
+#else
+#define G_GSIZE_FORMAT   "u"
+#endif
 #define GPOINTER_TO_INT(ptr)   ((gint)(intptr_t) (ptr))
 #define GPOINTER_TO_UINT(ptr)  ((guint)(intptr_t) (ptr))
 #define GINT_TO_POINTER(v)     ((gpointer)(intptr_t) (v))


### PR DESCRIPTION
Fix Win64 G_GSIZE_FORMAT, assuming Microsoft C runtime, old or new, or
 others compatible with it, i.e. last century I64 instead of newfangled ll.
