### PR TITLE
Doesn't compile with Clang on ppc64el

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3528,7 +3528,9 @@ case "$host" in
 		if test "x$ac_cv_sizeof_void_p" = "x8"; then
 			TARGET=POWERPC64;
 			CPPFLAGS="$CPPFLAGS -D__mono_ppc__ -D__mono_ppc64__"
-			CFLAGS="$CFLAGS -mminimal-toc"
+			if ! (echo $CC | grep -q -- 'clang'); then
+				CFLAGS="$CFLAGS -mminimal-toc"
+			fi
 		else
 			TARGET=POWERPC;
 			CPPFLAGS="$CPPFLAGS -D__mono_ppc__"


### PR DESCRIPTION
Hey, at least THIS one has a patch.

```
09:13:32 (cd build-shared && CC="/usr/bin/clang" CXX="/usr/bin/clang++" /usr/bin/cmake -D CMAKE_MAKE_PROGRAM=/usr/bin/make -D CMAKE_INSTALL_PREFIX:PATH=/usr -D BTLS_ROOT:PATH=/build/mono-5.15.0.292/external/boringssl -D SRC_DIR:PATH=/build/mono-5.15.0.292/mono/btls -D BTLS_CFLAGS:STRING="-Wdate-time -D_FORTIFY_SOURCE=2 "  -DBTLS_ARCH="powerpc" -DBUILD_SHARED_LIBS=1 /build/mono-5.15.0.292/mono/btls)
09:13:32 -- The C compiler identification is unknown
09:13:32 -- The CXX compiler identification is Clang 3.8.1
09:13:32 -- Check for working C compiler: /usr/bin/clang
09:13:32 -- Check for working C compiler: /usr/bin/clang -- broken
09:13:32 CMake Error at /usr/share/cmake-3.7/Modules/CMakeTestCCompiler.cmake:51 (message):
09:13:32   The C compiler "/usr/bin/clang" is not able to compile a simple test
09:13:32   program.
09:13:32 
09:13:32   It fails with the following output:
09:13:32 
09:13:32    Change Dir: /build/mono-5.15.0.292/mono/btls/build-shared/CMakeFiles/CMakeTmp
09:13:32 
09:13:32   
09:13:32 
09:13:32   Run Build Command:"/usr/bin/make" "cmTC_ab86b/fast"
09:13:32 
09:13:32   make[3]: Entering directory
09:13:32   '/build/mono-5.15.0.292/mono/btls/build-shared/CMakeFiles/CMakeTmp'
09:13:32 
09:13:32   /usr/bin/make -f CMakeFiles/cmTC_ab86b.dir/build.make
09:13:32   CMakeFiles/cmTC_ab86b.dir/build
09:13:32 
09:13:32   make[4]: Entering directory
09:13:32   '/build/mono-5.15.0.292/mono/btls/build-shared/CMakeFiles/CMakeTmp'
09:13:32 
09:13:32   Building C object CMakeFiles/cmTC_ab86b.dir/testCCompiler.c.o
09:13:32 
09:13:32   /usr/bin/clang -g -O2 -fdebug-prefix-map=/build/mono-5.15.0.292=.
09:13:32   -fstack-protector-strong -Wformat -Werror=format-security -std=gnu99
09:13:32   -fno-strict-aliasing -fwrapv -DMONO_DLL_EXPORT -g -Wall -Wunused
09:13:32   -Wmissing-prototypes -Wmissing-declarations -Wstrict-prototypes
09:13:32   -Wmissing-prototypes -Wnested-externs -Wpointer-arith -Wno-cast-qual
09:13:32   -Wwrite-strings -Wno-switch -Wno-switch-enum -Wno-unused-value
09:13:32   -Wno-attributes -Wno-format-zero-length -Qunused-arguments
09:13:32   -Wno-unused-function -Wno-tautological-compare -Wno-parentheses-equality
09:13:32   -Wno-self-assign -Wno-return-stack-address -Wno-constant-logical-operand
09:13:32   -Wno-zero-length-array -mminimal-toc -Werror-implicit-function-declaration
09:13:32   -o CMakeFiles/cmTC_ab86b.dir/testCCompiler.c.o -c
09:13:32   /build/mono-5.15.0.292/mono/btls/build-shared/CMakeFiles/CMakeTmp/testCCompiler.c
09:13:32 
09:13:32 
09:13:32   clang: error: unknown argument: '-mminimal-toc'
09:13:32 
09:13:32   CMakeFiles/cmTC_ab86b.dir/build.make:65: recipe for target
09:13:32   'CMakeFiles/cmTC_ab86b.dir/testCCompiler.c.o' failed
09:13:32 
09:13:32   make[4]: *** [CMakeFiles/cmTC_ab86b.dir/testCCompiler.c.o] Error 1
09:13:32 
09:13:32   make[4]: Leaving directory
09:13:32   '/build/mono-5.15.0.292/mono/btls/build-shared/CMakeFiles/CMakeTmp'
09:13:32 
09:13:32   Makefile:126: recipe for target 'cmTC_ab86b/fast' failed
09:13:32 
09:13:32   make[3]: *** [cmTC_ab86b/fast] Error 2
09:13:32 
09:13:32   make[3]: Leaving directory
09:13:32   '/build/mono-5.15.0.292/mono/btls/build-shared/CMakeFiles/CMakeTmp'
09:13:32 
09:13:32   
09:13:32 
09:13:32   
09:13:32 
09:13:32   CMake will not be able to correctly generate this project.
09:13:32 Call Stack (most recent call first):
09:13:32   CMakeLists.txt:3 (project)
```

Clang on PPC doesn't support `-mminimal-toc` and fails with an unknown flag due to our default CFLAGS. Try to detect Clang, and avoid that flag.