### PR TITLE
[interp] clear exception fields only if it is a real exception object

### DIFF
--- a/mono/mini/iltests.il
+++ b/mono/mini/iltests.il
@@ -2606,7 +2606,6 @@ END:
 
 	.method public static default int32 test_0_wrap_non_exception_throws () cil managed
 	{
-	  .custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
 	  .try {
 	  	    newobj instance void class [mscorlib]System.Object::'.ctor'()
 			throw

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -685,16 +685,21 @@ stackval_to_data_addr (MonoType *type_, stackval *val)
 static MONO_NEVER_INLINE void
 interp_throw (ThreadContext *context, MonoException *ex, InterpFrame *frame, gconstpointer ip, gboolean rethrow)
 {
+	ERROR_DECL (error);
 	MonoLMFExt ext;
 
 	interp_push_lmf (&ext, frame);
 	frame->ip = ip;
 	frame->ex = ex;
 
-	if (!rethrow) {
-		ex->stack_trace = NULL;
-		ex->trace_ips = NULL;
+	if (mono_object_isinst_checked ((MonoObject *) ex, mono_defaults.exception_class, error)) {
+		MonoException *mono_ex = (MonoException *) ex;
+		if (!rethrow) {
+			mono_ex->stack_trace = NULL;
+			mono_ex->trace_ips = NULL;
+		}
 	}
+	mono_error_assert_ok (error);
 
 	MonoContext ctx;
 	memset (&ctx, 0, sizeof (MonoContext));


### PR DESCRIPTION
Storytime: With https://github.com/mono/mono/pull/8367 we tried to enable more tests to be run on CI regarding our corlib tests. However, this test crashed:

https://github.com/mono/mono/blob/9b702e8052f6d888febe4e74dfea4d8388c1706e/mcs/class/corlib/Test/System/StringTest.cs#L4473-L4477

which was _weird_ because the test was enabled before and worked.

So what is the test doing? It compares `String.Empty` and `""` to be the same object. Empty string is special in two ways:
* It's an interned string. Per domain we have a hash table that manages interned strings: https://github.com/mono/mono/blob/8d1c93e563b98f83f8b7e3596eef7afd01422ead/mono/metadata/domain.c#L429
* We create an empty string instance per domain on domain creation: https://github.com/mono/mono/blob/8d1c93e563b98f83f8b7e3596eef7afd01422ead/mono/metadata/appdomain.c#L197-L202

Therefore, I claim this must be true at every point in time after domain creation:
```c
  domain->empty_string == mono_g_hash_table_lookup (domain->ldstr_table, domain->empty_string)
```

I put this condition at a few points in the interpreter main loop, and indeed, at a certain point this condition isn't true anymore. With further debugging I noticed that this violation happens after a rehash of `ldstr_table`. So it means we have suddenly two empty string objects in the table, how can this be? An insertion of a second empty string object wouldn't work.

My initial guess was that some corlib test is doing some dirty unsafe business on interned strings, but it wasn't that obvious unfortunately.  What happened was the following: In this test a string gets loaded and is then thrown as an exception:
https://github.com/mono/mono/blob/8d1c93e563b98f83f8b7e3596eef7afd01422ead/mcs/class/corlib/Test/System.Reflection.Emit/DynamicMethodTest.cs#L626-L629

When this IL is executed we hit this code:
https://github.com/mono/mono/blob/8d1c93e563b98f83f8b7e3596eef7afd01422ead/mono/mini/interp/interp.c#L694-L697

but wait! `ex` is a `MonoString` not a `MonoException`, really. Urgh. In this specific situation the offset of `->trace_ips` points beyond `ex`, that is, into the next object in the heap. Which, "by accident", is a interned string too and exactly nulls out the first few characters of the string. So there we have our second empty string in our hash table.

That is obviously wrong. And we have a test case for this:
https://github.com/mono/mono/blob/f024bb5f595c85388b1495c7a5247486327ecede/mono/mini/iltests.il#L2607-L2620

Alas it's disabled :grin: (as a matter of fact, it's one of the two disabled tests for the interpreter in the mini regression test suite). The reason why this test wasn't enabled is because with the old exception handling we didn't wrap such objects into an exception object. The exception handling implementation has changed and now shares it with the JIT which does the wrapping. We still missed a check which is added by this commit.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
