### PR TITLE
WIP LLVM on Windows

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -12765,7 +12765,7 @@ mono_compile_assembly (MonoAssembly *ass, guint32 opts, const char *aot_options,
 			if (strcmp (acfg->aot_opts.temp_path, "") != 0) {
 				temp_path = g_strdup (acfg->aot_opts.temp_path);
 			} else {
-				temp_path = mkdtemp(g_strdup ("mono_aot_XXXXXX"));
+				temp_path = g_mkdtemp(g_strdup ("mono_aot_XXXXXX"));
 				g_assertf (temp_path, "mkdtemp failed, error = (%d) %s", errno, g_strerror (errno));
 			}
 				

--- a/mono/mini/llvm-jit.cpp
+++ b/mono/mini/llvm-jit.cpp
@@ -68,10 +68,10 @@ static std::vector<T> singletonSet(T t) {
 
 #include <stddef.h>
 extern void *memset(void *, int, size_t);
-void bzero (void *to, size_t count) { memset (to, 0, count); }
+
 
 #endif
-
+void bzero(void *to, size_t count) { memset(to, 0, count); }
 static AllocCodeMemoryCb *alloc_code_mem_cb;
 
 class MonoJitMemoryManager : public RTDyldMemoryManager

--- a/mono/mini/llvm-jit.h
+++ b/mono/mini/llvm-jit.h
@@ -16,7 +16,7 @@
 #include "llvm-c/Core.h"
 #include "llvm-c/ExecutionEngine.h"
 
-#include <unwind.h>
+//#include <unwind.h>
 
 G_BEGIN_DECLS
 

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -3524,7 +3524,7 @@ mono_llvm_match_exception (MonoJitInfo *jinfo, guint32 region_start, guint32 reg
 	return index;
 }
 
-#ifdef ENABLE_LLVM
+#if 0//def ENABLE_LLVM
 _Unwind_Reason_Code 
 mono_debug_personality (int a, _Unwind_Action b,
 uint64_t c, struct _Unwind_Exception *d, struct _Unwind_Context *e)

--- a/mono/mini/mini-llvm-cpp.h
+++ b/mono/mini/mini-llvm-cpp.h
@@ -16,7 +16,7 @@
 #include "llvm-c/Core.h"
 #include "llvm-c/ExecutionEngine.h"
 
-#include <unwind.h>
+//#include <unwind.h>
 
 G_BEGIN_DECLS
 
@@ -113,9 +113,12 @@ mono_llvm_add_param_attr (LLVMValueRef param, AttrKind kind);
 void
 mono_llvm_add_instr_attr (LLVMValueRef val, int index, AttrKind kind);
 
-_Unwind_Reason_Code 
+/*_Unwind_Reason_Code 
 mono_debug_personality (int a, _Unwind_Action b,
-	uint64_t c, struct _Unwind_Exception *d, struct _Unwind_Context *e);
+	uint64_t c, struct _Unwind_Exception *d, struct _Unwind_Context *e);*/
+
+void
+mono_debug_personality(void);
 
 void
 default_mono_llvm_unhandled_exception (void);

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -42,10 +42,10 @@
 
 #include <stddef.h>
 extern void *memset(void *, int, size_t);
-void bzero (void *to, size_t count) { memset (to, 0, count); }
+
 
 #endif
-
+void bzero(void *to, size_t count) { memset(to, 0, count); }
 #if LLVM_API_VERSION < 4
 #error "The version of the mono llvm repository is too old."
 #endif
@@ -3786,7 +3786,7 @@ mono_llvm_emit_match_exception_call (EmitContext *ctx, LLVMBuilderRef builder, g
 	ctx->builder = builder;
 
 	const int num_args = 5;
-	LLVMValueRef args [num_args];
+	LLVMValueRef args [5];
 	args [0] = convert (ctx, get_aotconst (ctx, MONO_PATCH_INFO_AOT_JIT_INFO, GINT_TO_POINTER (ctx->cfg->method_index)), IntPtrType ());
 	args [1] = LLVMConstInt (LLVMInt32Type (), region_start, 0);
 	args [2] = LLVMConstInt (LLVMInt32Type (), region_end, 0);

--- a/msvc/libmini-llvm.targets
+++ b/msvc/libmini-llvm.targets
@@ -4,20 +4,10 @@
     <ExcludeFromWindowsBuild>true</ExcludeFromWindowsBuild>
   </PropertyGroup>
   <ItemGroup Label="llvm_sources">
-    <ClCompile Include="$(MonoSourceLocation)\mono\mini\mini-llvm-loaded.c">
-      <ExcludedFromBuild>$(ExcludeFromWindowsBuild)</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\mono\mini\mini-llvm.c">
-      <ExcludedFromBuild>$(ExcludeFromWindowsBuild)</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\mono\mini\llvm-runtime.cpp">
-      <ExcludedFromBuild>$(ExcludeFromWindowsBuild)</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\mono\mini\mini-llvm-cpp.cpp">
-      <ExcludedFromBuild>$(ExcludeFromWindowsBuild)</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="$(MonoSourceLocation)\mono\mini\llvm-jit.cpp">
-      <ExcludedFromBuild>$(ExcludeFromWindowsBuild)</ExcludedFromBuild>
-    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\mono\mini\mini-llvm-loaded.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\mini\mini-llvm.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\mini\llvm-runtime.cpp" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\mini\mini-llvm-cpp.cpp" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\mini\llvm-jit.cpp" />
   </ItemGroup>
 </Project>

--- a/msvc/libmini.vcxproj
+++ b/msvc/libmini.vcxproj
@@ -92,6 +92,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <IncludePath>C:\Users\Jo Shields\CMakeBuilds\42978d88-dc27-0e31-a1eb-0cb9a09df6c6\build\x64-Release\include;C:\source\repos\llvm\include;$(IncludePath)</IncludePath>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>
@@ -174,10 +177,10 @@
       </Command>
     </PreBuildEvent>
     <ClCompile>
-      <AdditionalOptions>/D /NODEFAULTLIB:LIBCD" " %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;WIN64;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;WIN64;NDEBUG;LLVM_API_VERSION=391;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
@@ -191,7 +194,8 @@
     </Link>
     <PostBuildEvent />
     <Lib>
-      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Users\Jo Shields\CMakeBuilds\42978d88-dc27-0e31-a1eb-0cb9a09df6c6\build\x64-Release\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>LLVMX86CodeGen.lib;LLVMX86Desc.lib;LLVMX86Info.lib;LLVMMCDisassembler.lib;LLVMX86AsmPrinter.lib;LLVMX86Utils.lib;LLVMSelectionDAG.lib;LLVMAsmPrinter.lib;LLVMDebugInfoCodeView.lib;LLVMCodeGen.lib;LLVMScalarOpts.lib;LLVMInstCombine.lib;LLVMInstrumentation.lib;LLVMBitWriter.lib;LLVMOrcJIT.lib;LLVMTransformUtils.lib;LLVMExecutionEngine.lib;LLVMTarget.lib;LLVMAnalysis.lib;LLVMProfileData.lib;LLVMRuntimeDyld.lib;LLVMObject.lib;LLVMMCParser.lib;LLVMBitReader.lib;LLVMMC.lib;LLVMCore.lib;LLVMSupport.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Lib>
   </ItemDefinitionGroup>
   <Import Project="libmini.targets" />

--- a/msvc/libmono-dynamic.vcxproj
+++ b/msvc/libmono-dynamic.vcxproj
@@ -89,6 +89,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <IncludePath>C:\Users\Jo Shields\CMakeBuilds\42978d88-dc27-0e31-a1eb-0cb9a09df6c6\build\x64-Release\include;C:\source\repos\llvm\include;$(IncludePath)</IncludePath>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>
       <Command>
@@ -210,7 +213,7 @@
       <AdditionalOptions>/D /NODEFAULTLIB:LIBCD" " %(AdditionalOptions)</AdditionalOptions>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(LIBGC_CPPFLAGS_INCLUDE);$(GLIB_CFLAGS_INCLUDE);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;$(GC_DEFINES);MONO_DLL_EXPORT;WIN64;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;$(GC_DEFINES);MONO_DLL_EXPORT;WIN64;NDEBUG;LLVM_API_VERSION=391;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <PrecompiledHeader>
       </PrecompiledHeader>
@@ -223,10 +226,11 @@
     <ProjectReference />
     <Link>
       <AdditionalDependencies Condition="'$(MONO_TARGET_GC)'=='boehm'">$(GC_LIB);%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Users\Jo Shields\CMakeBuilds\42978d88-dc27-0e31-a1eb-0cb9a09df6c6\build\x64-Release\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>
       </ModuleDefinitionFile>
       <ImportLibrary>$(MONO_BUILD_DIR_PREFIX)$(Platform)\lib\$(Configuration)\$(TargetName).lib</ImportLibrary>
+      <AdditionalDependencies>Mswsock.lib;ws2_32.lib;ole32.lib;oleaut32.lib;psapi.lib;version.lib;advapi32.lib;winmm.lib;kernel32.lib;LLVMX86CodeGen.lib;LLVMX86Desc.lib;LLVMX86Info.lib;LLVMMCDisassembler.lib;LLVMX86AsmPrinter.lib;LLVMX86Utils.lib;LLVMSelectionDAG.lib;LLVMAsmPrinter.lib;LLVMDebugInfoCodeView.lib;LLVMCodeGen.lib;LLVMScalarOpts.lib;LLVMInstCombine.lib;LLVMInstrumentation.lib;LLVMBitWriter.lib;LLVMOrcJIT.lib;LLVMTransformUtils.lib;LLVMExecutionEngine.lib;LLVMTarget.lib;LLVMAnalysis.lib;LLVMProfileData.lib;LLVMRuntimeDyld.lib;LLVMObject.lib;LLVMMCParser.lib;LLVMBitReader.lib;LLVMMC.lib;LLVMCore.lib;LLVMSupport.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>.\libmono.bat "$(MONO_INCLUDE_DIR)" "$(SolutionDir)include\mono" -q</Command>

--- a/winconfig.h
+++ b/winconfig.h
@@ -689,3 +689,7 @@
 #define MONO_CORLIB_VERSION #MONO_CORLIB_VERSION#
 
 #endif
+
+#define ENABLE_LLVM 1
+#define ENABLE_LLVM_RUNTIME 1
+#define LLVM_VERSION "3.9.1-mono"


### PR DESCRIPTION
Assumes you already built LLVM from release_39 branch. And that your user is `Jo Shields` and you got the exact same GUID for your CMake build output directory, because I haven't worked out how to be smarter about that yet. ¯\\\_(ツ)_/¯

With appropriate fixups for the path problems, this should be enough to _build_ mono, but it doesn't really work right yet.

```
c:\source>repos\mono\msvc\build\sgen\x64\bin\Release\mono-sgen.exe --version
Mono JIT compiler version 5.15.0 (Visual Studio built mono)
Copyright (C) 2002-2014 Novell, Inc, Xamarin Inc and Contributors. www.mono-project.com
        TLS:           normal
        SIGSEGV:       normal
        Notification:  Thread + polling
        Architecture:  amd64
        Disabled:      none
        Misc:          softdebug
        Interpreter:   yes
        LLVM:          yes(3.9.1-mono)
        GC:            sgen (concurrent by default)
```

Regular Mono AOT functions:

```
c:\source>repos\mono\msvc\build\sgen\x64\bin\Release\mono-sgen.exe --aot bottle.exe
Mono Ahead of Time compiler - compiling assembly c:\source\bottle.exe
AOTID AB17405F-EF78-B6D6-0243-19775FD82C6F
Code: 2186(51%) Info: 59(1%) Ex Info: 567(13%) Unwind Info: 226(5%) Class Info: 59(1%) PLT: 290(6%) GOT Info: 713(16%) Offsets: 178(4%) GOT: 640
Compiled: 12/12 (100%), No GOT slots: 8 (66%), Direct calls: 0 (0%)
Executing the native assembler: "clang.exe" -c -x assembler  -o C:\Users\JOSHIE~1\AppData\Local\Temp\mono_aot_a03328.obj C:\Users\JOSHIE~1\AppData\Local\Temp\mono_aot_a03328
Executing the native linker: "link.exe" /DLL /MACHINE:X64 /NOLOGO /INCREMENTAL:NO /DEBUG  /OUT:"c:\source\bottle.exe.dll.tmp" "C:\Users\JOSHIE~1\AppData\Local\Temp\mono_aot_a03328.obj"
   Creating library c:\source\bottle.exe.dll.lib and object c:\source\bottle.exe.dll.exp
JIT time: 4 ms, Generation time: 2 ms, Assembly+Link time: 343 ms.
```

LLVM AOT does not, complaining about the assembler clang is expected to compile:

```
c:\source>repos\mono\msvc\build\sgen\x64\bin\Release\mono-sgen.exe --aot=llvm bottle.exe
Mono Ahead of Time compiler - compiling assembly c:\source\bottle.exe
AOTID 165D55A1-624C-99AD-D808-2D0F2EA07984
Executing opt: "opt" -f -O2 -disable-tail-calls -o "mono_aot_a01056\temp.opt.bc" "mono_aot_a01056\temp.bc"
Executing llc: "llc"  -march=x86-64 -mattr=sse4.1 -asm-verbose=false -disable-gnu-eh-frame -enable-mono-eh-frame -mono-eh-frame-symbol=mono_aot_bottle_eh_frame -disable-tail-calls -relocation-model=pic -filetype=obj -o "mono_aot_a01056\temp-llvm.o" "mono_aot_a01056\temp.opt.bc"
Code: 1122(33%) Info: 59(1%) Ex Info: 415(12%) Unwind Info: 102(3%) Class Info: 59(1%) PLT: 300(8%) GOT Info: 1100(32%) Offsets: 240(7%) GOT: 560
Compiled: 12/12 (100%), LLVM: 9 (75%), No GOT slots: 8 (66%), Direct calls: 0 (100%)
Executing the native assembler: "clang.exe" -c -x assembler  -o C:\Users\JOSHIE~1\AppData\Local\Temp\mono_aot_a01056.obj C:\Users\JOSHIE~1\AppData\Local\Temp\mono_aot_a01056
C:\Users\JOSHIE~1\AppData\Local\Temp\mono_aot_a01056:591:8: error: assembler label '.Lme_0' can not be undefined
        .long .LDIFF_SYM2
              ^
C:\Users\JOSHIE~1\AppData\Local\Temp\mono_aot_a01056:614:8: error: assembler label '.Lme_1' can not be undefined
        .long .LDIFF_SYM4
              ^
C:\Users\JOSHIE~1\AppData\Local\Temp\mono_aot_a01056:637:8: error: assembler label '.Lme_2' can not be undefined
        .long .LDIFF_SYM6
              ^
C:\Users\JOSHIE~1\AppData\Local\Temp\mono_aot_a01056:660:8: error: assembler label '.Lme_3' can not be undefined
        .long .LDIFF_SYM8
              ^
C:\Users\JOSHIE~1\AppData\Local\Temp\mono_aot_a01056:729:8: error: assembler label '.Lme_6' can not be undefined
        .long .LDIFF_SYM14
              ^
C:\Users\JOSHIE~1\AppData\Local\Temp\mono_aot_a01056:775:8: error: assembler label '.Lme_8' can not be undefined
        .long .LDIFF_SYM18
              ^
C:\Users\JOSHIE~1\AppData\Local\Temp\mono_aot_a01056:798:8: error: assembler label '.Lme_9' can not be undefined
        .long .LDIFF_SYM20
              ^
C:\Users\JOSHIE~1\AppData\Local\Temp\mono_aot_a01056:821:8: error: assembler label '.Lme_a' can not be undefined
        .long .LDIFF_SYM22
              ^
C:\Users\JOSHIE~1\AppData\Local\Temp\mono_aot_a01056:844:8: error: assembler label '.Lme_b' can not be undefined
        .long .LDIFF_SYM24
              ^
AOT of image bottle.exe failed.
```

LLVM JIT is, well, just totally broken.

```
c:\source>repos\mono\msvc\build\sgen\x64\bin\Release\mono-sgen.exe --llvm bottle.exe
* Assertion at c:\source\repos\mono\mono\mini\llvm-jit.cpp:251, condition `addr' not met
```