### PR TITLE
[profiler] Do GC state transitions in profiler helper threads.

### DIFF
--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -3420,7 +3420,9 @@ writer_thread (void *arg)
 	MonoProfilerThread *thread = profiler_thread_begin ("Profiler Writer", FALSE);
 
 	while (mono_atomic_load_i32 (&log_profiler.run_writer_thread)) {
+		MONO_ENTER_GC_SAFE;
 		mono_os_sem_wait (&log_profiler.writer_queue_sem, MONO_SEM_FLAGS_NONE);
+		MONO_EXIT_GC_SAFE;
 		handle_writer_queue_entry ();
 
 		profiler_thread_check_detach (thread);
@@ -3533,11 +3535,15 @@ dumper_thread (void *arg)
 	MonoProfilerThread *thread = profiler_thread_begin ("Profiler Dumper", TRUE);
 
 	while (mono_atomic_load_i32 (&log_profiler.run_dumper_thread)) {
+		gboolean timedout = FALSE;
+		MONO_ENTER_GC_SAFE;
 		/*
 		 * Flush samples every second so it doesn't seem like the profiler is
 		 * not working if the program is mostly idle.
 		 */
-		if (mono_os_sem_timedwait (&log_profiler.dumper_queue_sem, 1000, MONO_SEM_FLAGS_NONE) == MONO_SEM_TIMEDWAIT_RET_TIMEDOUT)
+		timedout = mono_os_sem_timedwait (&log_profiler.dumper_queue_sem, 1000, MONO_SEM_FLAGS_NONE) == MONO_SEM_TIMEDWAIT_RET_TIMEDOUT;
+		MONO_EXIT_GC_SAFE;
+		if (timedout)
 			send_log_unsafe (FALSE);
 
 		handle_dumper_queue_entry ();

--- a/mono/utils/mono-threads-mach.c
+++ b/mono/utils/mono-threads-mach.c
@@ -77,7 +77,6 @@ mono_threads_suspend_begin_async_suspend (MonoThreadInfo *info, gboolean interru
 
 	/* We're in the middle of a self-suspend, resume and register */
 	if (!mono_threads_transition_finish_async_suspend (info)) {
-		mono_threads_add_to_pending_operation_set (info);
 		do {
 			ret = thread_resume (info->native_handle);
 		} while (ret == KERN_ABORTED);

--- a/mono/utils/mono-threads-windows.c
+++ b/mono/utils/mono-threads-windows.c
@@ -52,7 +52,6 @@ mono_threads_suspend_begin_async_suspend (MonoThreadInfo *info, gboolean interru
 
 	/* We're in the middle of a self-suspend, resume and register */
 	if (!mono_threads_transition_finish_async_suspend (info)) {
-		mono_threads_add_to_pending_operation_set (info);
 		result = ResumeThread (handle);
 		g_assert (result == 1);
 		THREADS_SUSPEND_DEBUG ("FAILSAFE RESUME/1 %p -> %d\n", (void*)id, 0);


### PR DESCRIPTION
After the calls to `profiler_thread_check_detach`, the GC doesn't skip
the profiler helper threads anymore (because of the call to
`mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NONE)`.

Under hybrid or full cooperative GC, the helper threads in GC Unsafe
mode should not block without periodically polling.  Otherwise we get
into a deadlock on shutdown when finalizing the root domain:  The profiler
threads have been told to detach and we run a GC in preparation for
running the finalizers.  The GC STW ends up waiting for the dumper and
writer threads which never self-suspend.

---

In the mach and windows suspend code, don't add the suspending thread to the pending operations set. 

Under hybrid suspend if the suspend initiator raced with
done_blocking/abort_blocking, then the thread self-suspended and is already
waiting for the resume semaphor - there's nothing else for the suspend initiator
to do, so don't add victim to the pending operation set.

---

Fixes #8355 