### PR TITLE
[sdks] fix $(mktemp) usage on older versions of macOS

### DIFF
--- a/sdks/builds/unzip-android-archive.sh
+++ b/sdks/builds/unzip-android-archive.sh
@@ -27,7 +27,7 @@ ZIP_ROOT_DIR=$(unzip -qql "$1" | head -n1 | tr -s ' ' | cut -d' ' -f5- | tr '/' 
 # We need a temporary directory because some archives (emulator) have their root directory named the
 # same as a file/directory inside it (emulator has emulator/emulator executable for instance) and
 # moving such a file/directory to .. wouldn't work
-ARCHIVE_TEMP_DIR=$(mktemp -d unzip_android_archive_XXXXXXXX)
+ARCHIVE_TEMP_DIR=$(mktemp -d -t unzip_android_archive_XXXXXXXX)
 
 unzip "$1" -d "$ARCHIVE_TEMP_DIR"
 mkdir -p "$2"


### PR DESCRIPTION
Context: https://unix.stackexchange.com/questions/30091/fix-or-alternative-for-mktemp-in-os-x

When making the bumps to use the `mono-sdks` upstream in Xamarin.Android,
we were getting build errors such as:

    usage: mktemp [-d] [-q] [-t prefix] [-u] template ... (TaskId:404)

The build bot is running Mavericks (10.9), so it must be an issue with older
versions of macOS.

When reading the Unix StackExchange post, it appears that the `-t` option
without a template should work more reliably on older macOS versions.

Then I tested it locally via `make -C sdks/builds provision-android`.

The command:

    mktemp -d unzip_android_archive_XXXXXXXX

Resulted in paths such as:

    creating: unzip_android_archive_Nt1XzgS5/android-P/

And sure enough, looking into `sdks/builds` it had created a directory in
the working directory, so it isn't using a path inside of `$TMPDIR`.

Changing the command to:

    mktemp -d -t unzip_android_archive

Resulted in paths such as:

    creating: /var/folders/nx/rzr6lcqj6j3_vp7vtp28v2cw0000gn/T/unzip_android_archive.W247QkyW/android-P/

The StackExchange post mentions `-t` is a "prefix" that gets expanded to
`$TMPDIR/{prefix}.XXXXXXXX`, so I think it is better to use this option as
long as it works on all platforms.

CC @jonpryor 
