### PR TITLE
Implement Freeform Unmanaged Error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -976,6 +976,30 @@ AC_SUBST(JEMALLOC_LDFLAGS)
 AC_SUBST(JEMALLOC_AUTOCONF_FLAGS)
 fi
 
+
+# Terminology:
+# Crash privacy - Attempts to not send identifying information in the crash dump / to protect the obscurity of the program control flow
+# MERP - The MS telemetry profile. Not for general use.
+# Structured crashes - crashes at runtime that trigger a stack walk by mono that happens cooperatively
+
+# Structured crashes are not merp crashes. Structured crashes are json dumps made by mono during crashes. Merp upload is going to use the dumping code is a very specific way, and is enabled at runtime with an icall.
+
+#--with-crash_privacy=yes --with-structured_crashes=no means we don't wanna dump in non-merp-enabled builds, and we want to not send symbol strings. This is going to be the default pair of settings for VS4Mac.
+#--with-crash_privacy=yes --with-structured_crashes=yes means you want to see crashes on your console, and you want to not see unmanaged symbol names. This is an option for proprietary apps that have manual bugs filed.
+#--with-crash_privacy=no --with-structured_crashes=no means you want to see no crash dumps on failure and you don't care about privacy. This is how you'd set a "don't want it, don't care" configuration.
+#--with-crash_privacy=no --with-structured_crashes=yes means you want full crashes and you want to see them in the terminal, not on telemetry. This is going to be how we build for CI.
+
+AC_ARG_WITH(crash-privacy,       [  --with-crash_privacy=yes,no         If you want your crashes to not include names of symbols present in the binary. ], [], [with_crash_privacy=no])
+AC_ARG_WITH(structured-crashes,  [  --with-structured_crashes=yes,no    If you want your unmanaged crashes to result in a small crash dump file. ],        [], [with_structured_crashes=yes])
+
+if test "x$with_crash_privacy" = "xno"; then
+AC_DEFINE(MONO_PRIVATE_CRASHES,1,[Do not include names of unmanaged functions in the crash dump])
+fi
+
+if test "x$with_structured_crashes" = "xno"; then
+AC_DEFINE(DISABLE_STRUCTURED_CRASH,1,[Do not create structured crash files during unmanaged crashes])
+fi
+
 #
 # Set the build profiles and options before things which use them
 #

--- a/mono/eglib/eglib-remap.h
+++ b/mono/eglib/eglib-remap.h
@@ -264,6 +264,7 @@
 #define g_vasprintf monoeg_g_vasprintf
 #define g_win32_getlocale monoeg_g_win32_getlocale
 #define g_assertion_message monoeg_assertion_message
+#define g_get_assertion_message monoeg_get_assertion_message
 #define g_malloc monoeg_malloc
 #define g_malloc0 monoeg_malloc0
 #define g_ptr_array_grow monoeg_ptr_array_grow

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -585,6 +585,8 @@ GLogLevelFlags g_log_set_fatal_mask   (const gchar *log_domain, GLogLevelFlags f
 void           g_logv                 (const gchar *log_domain, GLogLevelFlags log_level, const gchar *format, va_list args);
 void           g_log                  (const gchar *log_domain, GLogLevelFlags log_level, const gchar *format, ...);
 void           g_assertion_message    (const gchar *format, ...) G_GNUC_NORETURN;
+void           g_assertion_message    (const gchar *format, ...) G_GNUC_NORETURN;
+const char *   g_get_assertion_message (void);
 
 #ifdef HAVE_C99_SUPPORT
 /* The for (;;) tells gc thats g_error () doesn't return, avoiding warnings */

--- a/mono/eglib/goutput.c
+++ b/mono/eglib/goutput.c
@@ -130,12 +130,23 @@ g_log (const gchar *log_domain, GLogLevelFlags log_level, const gchar *format, .
 	va_end (args);
 }
 
+static char *failure_assertion = NULL;
+
+const char *
+g_get_assertion_message (void)
+{
+	return failure_assertion;
+}
+
 void
 g_assertion_message (const gchar *format, ...)
 {
 	va_list args;
 
 	va_start (args, format);
+
+	g_vasprintf (&failure_assertion, format, args);
+
 	g_logv (G_LOG_DOMAIN, G_LOG_LEVEL_ERROR, format, args);
 	va_end (args);
 	exit (0);

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5759,7 +5759,7 @@ ves_icall_Mono_Runtime_EnableMicrosoftTelemetry (char *appBundleID, char *appSig
 #ifdef TARGET_OSX
 	mono_merp_enable (appBundleID, appSignature, appVersion, merpGUIPath);
 
-	mono_get_runtime_callbacks ()->runtime_telemetry_callback ();
+	mono_get_runtime_callbacks ()->install_state_summarizer ();
 #else
 	// Icall has platform check in managed too.
 	g_assert_not_reached ();

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -631,7 +631,9 @@ typedef struct {
 	gpointer (*create_delegate_trampoline) (MonoDomain *domain, MonoClass *klass);
 	gpointer (*interp_get_remoting_invoke) (gpointer imethod, MonoError *error);
 	GHashTable *(*get_weak_field_indexes) (MonoImage *image);
+#ifndef HOST_WIN32
 	void     (*install_state_summarizer) (void);
+#endif
 } MonoRuntimeCallbacks;
 
 typedef gboolean (*MonoInternalStackWalk) (MonoStackFrameInfo *frame, MonoContext *ctx, gpointer data);
@@ -649,7 +651,9 @@ typedef struct {
 	gboolean (*mono_above_abort_threshold) (void);
 	void (*mono_clear_abort_threshold) (void);
 	void (*mono_reraise_exception) (MonoException *ex);
+#ifndef HOST_WIN32
 	void (*mono_summarize_stack) (MonoDomain *domain, MonoThreadSummary *out, MonoContext *crash_ctx);
+#endif
 } MonoRuntimeExceptionHandlingCallbacks;
 
 MONO_COLD void mono_set_pending_exception (MonoException *exc);

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -649,6 +649,7 @@ typedef struct {
 	gboolean (*mono_above_abort_threshold) (void);
 	void (*mono_clear_abort_threshold) (void);
 	void (*mono_reraise_exception) (MonoException *ex);
+	void (*mono_summarize_stack) (MonoDomain *domain, MonoThreadSummary *out, MonoContext *crash_ctx);
 } MonoRuntimeExceptionHandlingCallbacks;
 
 MONO_COLD void mono_set_pending_exception (MonoException *exc);

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -631,7 +631,7 @@ typedef struct {
 	gpointer (*create_delegate_trampoline) (MonoDomain *domain, MonoClass *klass);
 	gpointer (*interp_get_remoting_invoke) (gpointer imethod, MonoError *error);
 	GHashTable *(*get_weak_field_indexes) (MonoImage *image);
-#ifndef HOST_WIN32
+#ifdef TARGET_OSX
 	void     (*install_state_summarizer) (void);
 #endif
 } MonoRuntimeCallbacks;
@@ -651,7 +651,7 @@ typedef struct {
 	gboolean (*mono_above_abort_threshold) (void);
 	void (*mono_clear_abort_threshold) (void);
 	void (*mono_reraise_exception) (MonoException *ex);
-#ifndef HOST_WIN32
+#ifdef TARGET_OSX
 	void (*mono_summarize_stack) (MonoDomain *domain, MonoThreadSummary *out, MonoContext *crash_ctx);
 #endif
 } MonoRuntimeExceptionHandlingCallbacks;

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -631,7 +631,7 @@ typedef struct {
 	gpointer (*create_delegate_trampoline) (MonoDomain *domain, MonoClass *klass);
 	gpointer (*interp_get_remoting_invoke) (gpointer imethod, MonoError *error);
 	GHashTable *(*get_weak_field_indexes) (MonoImage *image);
-	void     (*runtime_telemetry_callback) (void);
+	void     (*install_state_summarizer) (void);
 } MonoRuntimeCallbacks;
 
 typedef gboolean (*MonoInternalStackWalk) (MonoStackFrameInfo *frame, MonoContext *ctx, gpointer data);

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -338,4 +338,43 @@ mono_threads_exit_gc_safe_region_unbalanced_internal (gpointer cookie, MonoStack
 void
 mono_set_thread_dump_dir(gchar* dir);
 
+#ifdef TARGET_OSX
+#define MONO_MAX_SUMMARY_NAME_LEN 140
+#define MONO_MAX_SUMMARY_THREADS 32
+#define MONO_MAX_SUMMARY_FRAMES 40
+
+typedef struct {
+	gboolean is_managed;
+	char str_descr [MONO_MAX_SUMMARY_NAME_LEN];
+	struct {
+		int token;
+		int il_offset;
+		int native_offset;
+	} managed_data;
+	struct {
+		intptr_t ip;
+		gboolean is_trampoline;
+		gboolean has_name;
+	} unmanaged_data;
+} MonoFrameSummary;
+
+typedef struct {
+	gboolean is_managed;
+
+	const char *name;
+	intptr_t managed_thread_ptr;
+	intptr_t info_addr;
+	intptr_t native_thread_id;
+
+	int num_managed_frames;
+	MonoFrameSummary managed_frames [MONO_MAX_SUMMARY_FRAMES];
+
+	int num_unmanaged_frames;
+	MonoFrameSummary unmanaged_frames [MONO_MAX_SUMMARY_FRAMES];
+} MonoThreadSummary;
+
+gboolean
+mono_threads_summarize (MonoContext *ctx, gchar **out);
+#endif
+
 #endif /* _MONO_METADATA_THREADS_TYPES_H_ */

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -338,7 +338,7 @@ mono_threads_exit_gc_safe_region_unbalanced_internal (gpointer cookie, MonoStack
 void
 mono_set_thread_dump_dir(gchar* dir);
 
-#ifndef HOST_WIN32
+#ifdef TARGET_OSX
 #define MONO_MAX_SUMMARY_NAME_LEN 140
 #define MONO_MAX_SUMMARY_THREADS 32
 #define MONO_MAX_SUMMARY_FRAMES 40

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -338,7 +338,7 @@ mono_threads_exit_gc_safe_region_unbalanced_internal (gpointer cookie, MonoStack
 void
 mono_set_thread_dump_dir(gchar* dir);
 
-#ifdef TARGET_OSX
+#ifndef HOST_WIN32
 #define MONO_MAX_SUMMARY_NAME_LEN 140
 #define MONO_MAX_SUMMARY_THREADS 32
 #define MONO_MAX_SUMMARY_FRAMES 40

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -5887,7 +5887,7 @@ mono_set_thread_dump_dir (gchar* dir) {
 	thread_dump_dir = dir;
 }
 
-#ifndef HOST_WIN32
+#ifdef TARGET_OSX
 
 static size_t num_threads_summarized = 0;
 

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -126,7 +126,9 @@ static gboolean mono_current_thread_has_handle_block_guard (void);
 static gboolean mono_install_handler_block_guard (MonoThreadUnwindState *ctx);
 static void mono_uninstall_current_handler_block_guard (void);
 
+#ifndef HOST_WIN32
 static void mono_summarize_stack (MonoDomain *domain, MonoThreadSummary *out, MonoContext *crash_ctx);
+#endif
 
 static gboolean
 first_managed (MonoStackFrameInfo *frame, MonoContext *ctx, gpointer addr)
@@ -232,7 +234,9 @@ mono_exceptions_init (void)
 	cbs.mono_walk_stack_with_ctx = mono_runtime_walk_stack_with_ctx;
 	cbs.mono_walk_stack_with_state = mono_walk_stack_with_state;
 
+#ifndef HOST_WIN32
 	cbs.mono_summarize_stack = mono_summarize_stack;
+#endif
 
 	if (mono_llvm_only) {
 		cbs.mono_raise_exception = mono_llvm_raise_exception;
@@ -1296,7 +1300,6 @@ mono_get_portable_ip (intptr_t in_ip, intptr_t *out_ip, char *out_name)
 #endif
 	return TRUE;
 }
-#endif
 
 
 static gboolean
@@ -1381,6 +1384,7 @@ mono_summarize_stack (MonoDomain *domain, MonoThreadSummary *out, MonoContext *c
 
 	return;
 }
+#endif
 
 MonoBoolean
 ves_icall_get_frame_info (gint32 skip, MonoBoolean need_file_info, 

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2978,7 +2978,12 @@ mono_handle_native_crash (const char *signal, void *ctx, MONO_SIG_HANDLER_INFO_T
 		MonoContext mctx;
 		if (ctx) {
 			gboolean leave = FALSE;
-			if (!mono_merp_enabled ()) {
+			gboolean dump_for_merp = FALSE;
+#if defined(TARGET_OSX)
+			dump_for_merp = mono_merp_enabled ();
+#endif
+
+			if (!dump_for_merp) {
 #ifdef DISABLE_STRUCTURED_CRASH
 				leave = TRUE;
 #else
@@ -2995,7 +3000,7 @@ mono_handle_native_crash (const char *signal, void *ctx, MONO_SIG_HANDLER_INFO_T
 
 			// We want our crash, and don't have telemetry
 			// So we dump to disk
-			if (!leave && !mono_merp_enabled ())
+			if (!leave && !dump_for_merp)
 				mono_crash_dump (output);
 		}
 

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -126,7 +126,7 @@ static gboolean mono_current_thread_has_handle_block_guard (void);
 static gboolean mono_install_handler_block_guard (MonoThreadUnwindState *ctx);
 static void mono_uninstall_current_handler_block_guard (void);
 
-#ifndef HOST_WIN32
+#ifdef TARGET_OSX
 static void mono_summarize_stack (MonoDomain *domain, MonoThreadSummary *out, MonoContext *crash_ctx);
 #endif
 
@@ -234,7 +234,7 @@ mono_exceptions_init (void)
 	cbs.mono_walk_stack_with_ctx = mono_runtime_walk_stack_with_ctx;
 	cbs.mono_walk_stack_with_state = mono_walk_stack_with_state;
 
-#ifndef HOST_WIN32
+#ifdef TARGET_OSX
 	cbs.mono_summarize_stack = mono_summarize_stack;
 #endif
 
@@ -1246,7 +1246,7 @@ next:
 	}
 }
 
-#ifndef HOST_WIN32
+#ifdef TARGET_OSX
 typedef struct {
 	MonoFrameSummary *frames;
 	int num_frames;
@@ -2990,11 +2990,12 @@ mono_handle_native_crash (const char *signal, void *ctx, MONO_SIG_HANDLER_INFO_T
 			if (!dump_for_merp) {
 #ifdef DISABLE_STRUCTURED_CRASH
 				leave = TRUE;
-#else
+#elif defined(TARGET_OSX)
 				mini_register_sigterm_handler ();
 #endif
 			}
 
+#ifdef TARGET_OSX
 			if (!leave) {
 				mono_sigctx_to_monoctx (ctx, &mctx);
 				// Do before forking
@@ -3006,6 +3007,7 @@ mono_handle_native_crash (const char *signal, void *ctx, MONO_SIG_HANDLER_INFO_T
 			// So we dump to disk
 			if (!leave && !dump_for_merp)
 				mono_crash_dump (output);
+#endif
 		}
 
 		/*

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -76,6 +76,10 @@
 #include <mono/utils/mono-merp.h>
 #endif
 
+#ifndef HOST_WIN32
+#include <mono/utils/mono-threads-debug.h>
+#endif
+
 #if defined(HOST_WATCHOS)
 
 void
@@ -209,7 +213,7 @@ MONO_SIG_HANDLER_FUNC (static, sigabrt_signal_handler)
 	}
 }
 
-#ifdef TARGET_OSX
+#ifndef HOST_WIN32
 MONO_SIG_HANDLER_FUNC (static, sigterm_signal_handler)
 {
 	MONO_SIG_HANDLER_INFO_TYPE *info = MONO_SIG_HANDLER_GET_INFO ();
@@ -226,7 +230,7 @@ MONO_SIG_HANDLER_FUNC (static, sigterm_signal_handler)
 		g_assert_not_reached ();
 
 	// Only the dumping-supervisor thread exits mono_thread_summarize
-	fprintf (stderr, "Unhandled exception dump: \n######\n%s\n######\n", output);
+	MOSTLY_ASYNC_SAFE_PRINTF("Unhandled exception dump: \n######\n%s\n######\n", output);
 
 	mono_chain_signal (MONO_SIG_HANDLER_PARAMS);
 	exit (1);
@@ -384,7 +388,7 @@ remove_signal_handler (int signo)
 	}
 }
 
-#ifdef TARGET_OSX
+#ifndef HOST_WIN32
 void
 mini_register_sigterm_handler (void)
 {

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -213,7 +213,7 @@ MONO_SIG_HANDLER_FUNC (static, sigabrt_signal_handler)
 	}
 }
 
-#ifndef HOST_WIN32
+#ifdef TARGET_OSX
 MONO_SIG_HANDLER_FUNC (static, sigterm_signal_handler)
 {
 	MONO_SIG_HANDLER_INFO_TYPE *info = MONO_SIG_HANDLER_GET_INFO ();
@@ -388,7 +388,7 @@ remove_signal_handler (int signo)
 	}
 }
 
-#ifndef HOST_WIN32
+#ifdef TARGET_OSX
 void
 mini_register_sigterm_handler (void)
 {

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4039,7 +4039,7 @@ mini_init (const char *filename, const char *runtime_version)
 	callbacks.get_weak_field_indexes = mono_aot_get_weak_field_indexes;
 
 #ifdef TARGET_OSX
-	callbacks.runtime_telemetry_callback = mini_register_sigterm_handler;
+	callbacks.install_state_summarizer = mini_register_sigterm_handler;
 #endif
 
 	mono_install_callbacks (&callbacks);

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -528,7 +528,7 @@ gboolean MONO_SIG_HANDLER_SIGNATURE (mono_chain_signal);
 #define DISABLE_SDB 1
 #endif
 
-#ifndef HOST_WIN32
+#ifdef TARGET_OSX
 void mini_register_sigterm_handler (void);
 #endif
 

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -528,7 +528,7 @@ gboolean MONO_SIG_HANDLER_SIGNATURE (mono_chain_signal);
 #define DISABLE_SDB 1
 #endif
 
-#ifdef TARGET_OSX
+#ifndef HOST_WIN32
 void mini_register_sigterm_handler (void);
 #endif
 

--- a/mono/utils/Makefile.am
+++ b/mono/utils/Makefile.am
@@ -52,6 +52,8 @@ monoutils_sources = \
 	mono-log-darwin.c \
 	mono-merp.c	\
 	mono-merp.h	\
+	mono-state.h	\
+	mono-state.c	\
 	mono-internal-hash.c	\
 	mono-internal-hash.h	\
 	mono-io-portability.c 	\

--- a/mono/utils/mono-merp.c
+++ b/mono/utils/mono-merp.c
@@ -445,8 +445,11 @@ mono_init_merp (const char *serviceName, const char *signal, pid_t crashed_pid, 
 }
 
 void
-mono_merp_invoke (pid_t crashed_pid, intptr_t thread_pointer, const char *signal)
+mono_merp_invoke (pid_t crashed_pid, intptr_t thread_pointer, const char *signal, const char *dump_file)
 {
+	if (dump_file != NULL)
+		fprintf (stderr, "Crashing Dump File:\n####\n%s\n####\n", dump_file);
+
 	// This unique service name is used to communicate with merp over mach service ports
 	char *serviceName = g_strdup_printf ("com.mono.merp.%.8x", crashed_pid);
 

--- a/mono/utils/mono-merp.h
+++ b/mono/utils/mono-merp.h
@@ -45,7 +45,7 @@ gboolean mono_merp_enabled (void);
  * crash dump (leaving the caller to call exit), or terminates the runtime
  * when the registered telemetry application does not respond.
  */
-void mono_merp_invoke (pid_t crashed_pid, intptr_t thread_pointer, const char *signal);
+void mono_merp_invoke (pid_t crashed_pid, intptr_t thread_pointer, const char *signal, const char *dump_file);
 
 
 #endif // TARGET_OSX

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -1,0 +1,476 @@
+/**
+ * \file
+ * Support for verbose unmanaged crash dumps
+ *
+ * Author:
+ *   Alexander Kyte (alkyte@microsoft.com)
+ *
+ * (C) 2018 Microsoft, Inc.
+ *
+ */
+#include <config.h>
+#include <glib.h>
+#include <mono/utils/json.h>
+#include <mono/utils/mono-state.h>
+#include <mono/metadata/object-internals.h>
+
+extern GCStats mono_gc_stats;
+
+// For AOT mode
+#include <mono/mini/mini-runtime.h>
+
+#ifdef TARGET_OSX
+#include <mach/mach.h>
+#include <mach/task_info.h>
+#endif
+
+#define MONO_MAX_SUMMARY_LEN 900
+static JsonWriter writer;
+static GString static_gstr;
+static char output_dump_str [MONO_MAX_SUMMARY_LEN];
+
+static void mono_json_writer_init_static (void) {
+	static_gstr.len = 0;
+	static_gstr.allocated_len = MONO_MAX_SUMMARY_LEN;
+	static_gstr.str = output_dump_str;
+	memset (output_dump_str, 0, sizeof (output_dump_str));
+
+	writer.indent = 0;
+	writer.text = &static_gstr;
+}
+
+static void
+mono_native_state_add_ctx (JsonWriter *writer, MonoContext *ctx)
+{
+	// Context
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "ctx");
+	mono_json_writer_object_begin(writer);
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "IP");
+	mono_json_writer_printf (writer, "\"%p\",\n", (gpointer) MONO_CONTEXT_GET_IP (ctx));
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "SP");
+	mono_json_writer_printf (writer, "\"%p\",\n", (gpointer) MONO_CONTEXT_GET_SP (ctx));
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "BP");
+	mono_json_writer_printf (writer, "\"%p\"\n", (gpointer) MONO_CONTEXT_GET_BP (ctx));
+
+	mono_json_writer_indent_pop (writer);
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_end (writer);
+	mono_json_writer_printf (writer, ",\n");
+}
+
+static void
+mono_native_state_add_frame (JsonWriter *writer, MonoFrameSummary *frame)
+{
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_begin(writer);
+
+	if (frame->is_managed) {
+		mono_json_writer_indent (writer);
+		mono_json_writer_object_key(writer, "is_managed");
+		mono_json_writer_printf (writer, "\"%s\",\n", frame->is_managed ? "true" : "false");
+	}
+
+	if (frame->unmanaged_data.is_trampoline) {
+		mono_json_writer_indent (writer);
+		mono_json_writer_object_key(writer, "is_trampoline");
+		mono_json_writer_printf (writer, "\"true\",");
+	}
+
+	if (frame->is_managed) {
+		mono_json_writer_indent (writer);
+		mono_json_writer_object_key(writer, "assembly");
+		mono_json_writer_printf (writer, "\"%s\",\n", frame->str_descr);
+
+		mono_json_writer_indent (writer);
+		mono_json_writer_object_key(writer, "token");
+		mono_json_writer_printf (writer, "\"0x%05x\",\n", frame->managed_data.token);
+
+		mono_json_writer_indent (writer);
+		mono_json_writer_object_key(writer, "native_offset");
+		mono_json_writer_printf (writer, "\"0x%x\",\n", frame->managed_data.native_offset);
+
+		mono_json_writer_indent (writer);
+		mono_json_writer_object_key(writer, "il_offset");
+		mono_json_writer_printf (writer, "\"0x%05x\"\n", frame->managed_data.il_offset);
+
+	} else {
+		mono_json_writer_indent (writer);
+		mono_json_writer_object_key(writer, "native_address");
+		if (frame->unmanaged_data.ip)
+			mono_json_writer_printf (writer, "\"%p\"", (void *) frame->unmanaged_data.ip);
+		else
+			mono_json_writer_printf (writer, "\"outside mono-sgen\"");
+
+		if (frame->unmanaged_data.has_name) {
+			mono_json_writer_printf (writer, ",\n");
+
+			mono_json_writer_indent (writer);
+			mono_json_writer_object_key(writer, "unmanaged_name");
+			mono_json_writer_printf (writer, "\"%s\"\n", frame->str_descr);
+		} else {
+			mono_json_writer_printf (writer, "\n");
+		}
+	}
+
+	mono_json_writer_indent_pop (writer);
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_end (writer);
+}
+
+static void
+mono_native_state_add_frames (JsonWriter *writer, int num_frames, MonoFrameSummary *frames, const char *label)
+{
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, label);
+
+	mono_json_writer_array_begin (writer);
+
+	mono_native_state_add_frame (writer, &frames [0]);
+	for (int i = 1; i < num_frames; ++i) {
+		mono_json_writer_printf (writer, ",\n");
+		mono_native_state_add_frame (writer, &frames [i]);
+	}
+	mono_json_writer_printf (writer, "\n");
+
+	mono_json_writer_indent_pop (writer);
+	mono_json_writer_indent (writer);
+	mono_json_writer_array_end (writer);
+}
+
+
+static void
+mono_native_state_add_thread (JsonWriter *writer, MonoThreadSummary *thread, MonoContext *ctx)
+{
+	static gboolean not_first_thread;
+
+	if (not_first_thread) {
+		mono_json_writer_printf (writer, ",\n");
+	} else {
+		not_first_thread = TRUE;
+	}
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_begin(writer);
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "is_managed");
+	mono_json_writer_printf (writer, "%s,\n", thread->is_managed ? "true" : "false");
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "managed_thread_ptr");
+	mono_json_writer_printf (writer, "\"0x%x\",\n", (gpointer) thread->managed_thread_ptr);
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "thread_info_addr");
+	mono_json_writer_printf (writer, "\"0x%x\",\n", (gpointer) thread->info_addr);
+
+	if (thread->name) {
+		mono_json_writer_indent (writer);
+		mono_json_writer_object_key(writer, "thread_name");
+		mono_json_writer_printf (writer, "\"%s\",\n", thread->name);
+	}
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "native_thread_id");
+	mono_json_writer_printf (writer, "\"0x%x\",\n", (gpointer) thread->native_thread_id);
+
+	mono_native_state_add_ctx (writer, ctx);
+
+	if (thread->num_managed_frames > 0) {
+		mono_native_state_add_frames (writer, thread->num_managed_frames, thread->managed_frames, "managed_frames");
+	}
+	if (thread->num_unmanaged_frames > 0) {
+		if (thread->num_managed_frames > 0)
+			mono_json_writer_printf (writer, ",\n");
+		mono_native_state_add_frames (writer, thread->num_unmanaged_frames, thread->unmanaged_frames, "unmanaged_frames");
+	}
+	mono_json_writer_printf (writer, "\n");
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_end (writer);
+}
+
+static void
+mono_native_state_add_ee_info  (JsonWriter *writer)
+{
+	// FIXME: setup callbacks to enable
+	/*const char *aot_mode;*/
+	/*MonoAotMode mono_aot_mode = mono_jit_get_aot_mode ();*/
+	/*switch (mono_aot_mode) {*/
+		/*case MONO_AOT_MODE_NONE:*/
+			/*aot_mode = "none";*/
+			/*break;*/
+		/*case MONO_AOT_MODE_NORMAL:*/
+			/*aot_mode = "normal";*/
+			/*break;*/
+		/*case MONO_AOT_MODE_HYBRID:*/
+			/*aot_mode = "hybrid";*/
+			/*break;*/
+		/*case MONO_AOT_MODE_FULL:*/
+			/*aot_mode = "full";*/
+			/*break;*/
+		/*case MONO_AOT_MODE_LLVMONLY:*/
+			/*aot_mode = "llvmonly";*/
+			/*break;*/
+		/*case MONO_AOT_MODE_INTERP:*/
+			/*aot_mode = "interp";*/
+			/*break;*/
+		/*case MONO_AOT_MODE_INTERP_LLVMONLY:*/
+			/*aot_mode = "interp_llvmonly";*/
+			/*break;*/
+		/*default:*/
+			/*aot_mode = "error";*/
+	/*}*/
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "execution_context");
+	mono_json_writer_object_begin(writer);
+
+	/*mono_json_writer_indent (writer);*/
+	/*mono_json_writer_object_key(writer, "aot_mode");*/
+	/*mono_json_writer_printf (writer, "\"%s\",\n", aot_mode);*/
+
+	/*mono_json_writer_indent (writer);*/
+	/*mono_json_writer_object_key(writer, "mono_use_llvm");*/
+	/*mono_json_writer_printf (writer, "\"%s\",\n", mono_use_llvm ? "true" : "false");*/
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "coop-enabled");
+	mono_json_writer_printf (writer, "\"%s\"\n", mono_threads_is_cooperative_suspension_enabled () ? "true" : "false");
+
+	mono_json_writer_indent_pop (writer);
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_end (writer);
+	mono_json_writer_printf (writer, ",\n");
+}
+
+// Taken from driver.c
+#if defined(MONO_ARCH_ARCHITECTURE)
+/* Redefine MONO_ARCHITECTURE to include more information */
+#undef MONO_ARCHITECTURE
+#define MONO_ARCHITECTURE MONO_ARCH_ARCHITECTURE
+#endif
+
+static void
+mono_native_state_add_version (JsonWriter *writer)
+{
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "configuration");
+	mono_json_writer_object_begin(writer);
+
+	char *build = mono_get_runtime_callbacks ()->get_runtime_build_info ();
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "version");
+	mono_json_writer_printf (writer, "\"%s\",\n", build);
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "tlc");
+#ifdef HAVE_KW_THREAD
+	mono_json_writer_printf (writer, "\"__thread\",\n");
+#else
+	mono_json_writer_printf (writer, "\"normal\",\n");
+#endif /* HAVE_KW_THREAD */
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "sigsgev");
+#ifdef MONO_ARCH_SIGSEGV_ON_ALTSTACK
+	mono_json_writer_printf (writer, "\"altstack\",\n");
+#else
+	mono_json_writer_printf (writer, "\"normal\",\n");
+#endif
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "notifications");
+#ifdef HAVE_EPOLL
+	mono_json_writer_printf (writer, "\"epoll\",\n");
+#elif defined(HAVE_KQUEUE)
+	mono_json_writer_printf (writer, "\"kqueue\",\n");
+#else
+	mono_json_writer_printf (writer, "\"thread+polling\",\n");
+#endif
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "architecture");
+	mono_json_writer_printf (writer, "\"%s\",\n", MONO_ARCHITECTURE);
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "disabled_features");
+	mono_json_writer_printf (writer, "\"%s\",\n", DISABLED_FEATURES);
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "smallconfig");
+#ifdef MONO_SMALL_CONFIG
+	mono_json_writer_printf (writer, "\"enabled\",\n");
+#else
+	mono_json_writer_printf (writer, "\"disabled\",\n");
+#endif
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "bigarrays");
+#ifdef MONO_BIG_ARRAYS
+	mono_json_writer_printf (writer, "\"enabled\",\n");
+#else
+	mono_json_writer_printf (writer, "\"disabled\",\n");
+#endif
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "softdebug");
+#if !defined(DISABLE_SDB)
+	mono_json_writer_printf (writer, "\"enabled\",\n");
+#else
+	mono_json_writer_printf (writer, "\"disabled\",\n");
+#endif
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "interpreter");
+#ifndef DISABLE_INTERPRETER
+	mono_json_writer_printf (writer, "\"enabled\",\n");
+#else
+	mono_json_writer_printf (writer, "\"disabled\",\n");
+#endif
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "llvm_support");
+#ifdef MONO_ARCH_LLVM_SUPPORTED
+#ifdef ENABLE_LLVM
+	mono_json_writer_printf (writer, "\"%s\"\n", LLVM_VERSION);
+#else
+	mono_json_writer_printf (writer, "\"disabled\"\n");
+#endif
+#endif
+
+	mono_json_writer_indent_pop (writer);
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_end (writer);
+	mono_json_writer_printf (writer, ",\n");
+}
+
+static void
+mono_native_state_add_memory (JsonWriter *writer)
+{
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "memory");
+	mono_json_writer_object_begin(writer);
+
+#ifdef TARGET_OSX
+	struct task_basic_info t_info;
+	memset (&t_info, 0, sizeof (t_info));
+	mach_msg_type_number_t t_info_count = TASK_BASIC_INFO_COUNT;
+	task_name_t task = mach_task_self ();
+	task_info(task, TASK_BASIC_INFO, (task_info_t) &t_info, &t_info_count);
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "Resident Size");
+	mono_json_writer_printf (writer, "\"%lu\",\n", t_info.resident_size);
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "Virtual Size");
+	mono_json_writer_printf (writer, "\"%lu\",\n", t_info.virtual_size);
+#endif
+
+	GCStats stats;
+	memcpy (&stats, &mono_gc_stats, sizeof (GCStats));
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "minor_gc_time");
+	mono_json_writer_printf (writer, "\"%lu\",\n", stats.minor_gc_time);
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "major_gc_time");
+	mono_json_writer_printf (writer, "\"%lu\",\n", stats.major_gc_time);
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "minor_gc_count");
+	mono_json_writer_printf (writer, "\"%lu\",\n", stats.minor_gc_count);
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "major_gc_count");
+	mono_json_writer_printf (writer, "\"%lu\",\n", stats.major_gc_count);
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "major_gc_time_concurrent");
+	mono_json_writer_printf (writer, "\"%lu\"\n", stats.major_gc_time_concurrent);
+
+	mono_json_writer_indent_pop (writer);
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_end (writer);
+	mono_json_writer_printf (writer, ",\n");
+}
+
+static void
+mono_native_state_add_prologue (JsonWriter *writer)
+{
+	mono_json_writer_init (writer);
+	mono_json_writer_object_begin(writer);
+
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "protocol_version");
+	mono_json_writer_printf (writer, "\"%s\",\n", MONO_NATIVE_STATE_PROTOCOL_VERSION);
+
+	mono_native_state_add_version (writer);
+
+#ifndef MONO_PRIVATE_CRASHES
+	mono_native_state_add_ee_info (writer);
+#endif
+
+	mono_native_state_add_memory (writer);
+
+	const char *assertion_msg = g_get_assertion_message ();
+	if (assertion_msg != NULL) {
+		mono_json_writer_indent (writer);
+		mono_json_writer_object_key(writer, "assertion_message");
+
+		char *pos;
+		if ((pos = strchr (assertion_msg, '\n')) != NULL)
+			*pos = '\0';
+
+		mono_json_writer_printf (writer, "\"%s\",\n", assertion_msg);
+	}
+
+	// Start threads array
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key(writer, "threads");
+	mono_json_writer_array_begin (writer);
+}
+
+static void
+mono_native_state_add_epilogue (JsonWriter *writer)
+{
+	mono_json_writer_indent_pop (writer);
+	mono_json_writer_printf (writer, "\n");
+	mono_json_writer_indent (writer);
+	mono_json_writer_array_end (writer);
+
+	mono_json_writer_indent_pop (writer);
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_end (writer);
+	mono_json_writer_printf (writer, "\n");
+}
+
+void
+mono_summarize_native_state_begin (void)
+{
+	mono_json_writer_init_static ();
+	mono_native_state_add_prologue (&writer);
+}
+
+char *
+mono_summarize_native_state_end (void)
+{
+	mono_native_state_add_epilogue (&writer);
+	return writer.text->str;
+}
+
+void
+mono_summarize_native_state_add_thread (MonoThreadSummary *thread, MonoContext *ctx)
+{
+	mono_native_state_add_thread (&writer, thread, ctx);
+}
+

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -14,7 +14,7 @@
 #include <mono/utils/mono-state.h>
 #include <mono/metadata/object-internals.h>
 
-#ifndef HOST_WIN32
+#ifdef TARGET_OSX
 
 extern GCStats mono_gc_stats;
 

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -14,6 +14,8 @@
 #include <mono/utils/mono-state.h>
 #include <mono/metadata/object-internals.h>
 
+#ifndef HOST_WIN32
+
 extern GCStats mono_gc_stats;
 
 // For AOT mode
@@ -474,3 +476,4 @@ mono_summarize_native_state_add_thread (MonoThreadSummary *thread, MonoContext *
 	mono_native_state_add_thread (&writer, thread, ctx);
 }
 
+#endif // HOST_WIN32

--- a/mono/utils/mono-state.h
+++ b/mono/utils/mono-state.h
@@ -1,0 +1,33 @@
+/**
+ * \file
+ * Support for cooperative creation of unmanaged state dumps
+ *
+ * Author:
+ *   Alexander Kyte (alkyte@microsoft.com)
+ *
+ * (C) 2018 Microsoft, Inc.
+ *
+ */
+#ifndef __MONO_UTILS_NATIVE_STATE__
+#define __MONO_UTILS_NATIVE_STATE__
+
+#include <mono/utils/mono-publib.h>
+#include <mono/utils/mono-context.h>
+#include <mono/metadata/threads-types.h>
+
+#define MONO_NATIVE_STATE_PROTOCOL_VERSION "0.0.1"
+
+MONO_BEGIN_DECLS
+
+void
+mono_summarize_native_state_begin (void);
+
+char *
+mono_summarize_native_state_end (void);
+
+void
+mono_summarize_native_state_add_thread (MonoThreadSummary *thread, MonoContext *ctx);
+
+MONO_END_DECLS
+
+#endif // MONO_UTILS_NATIVE_STATE

--- a/mono/utils/mono-state.h
+++ b/mono/utils/mono-state.h
@@ -11,6 +11,8 @@
 #ifndef __MONO_UTILS_NATIVE_STATE__
 #define __MONO_UTILS_NATIVE_STATE__
 
+#ifndef HOST_WIN32
+
 #include <mono/utils/mono-publib.h>
 #include <mono/utils/mono-context.h>
 #include <mono/metadata/threads-types.h>
@@ -29,5 +31,6 @@ void
 mono_summarize_native_state_add_thread (MonoThreadSummary *thread, MonoContext *ctx);
 
 MONO_END_DECLS
+#endif // HOST_WIN32
 
 #endif // MONO_UTILS_NATIVE_STATE

--- a/mono/utils/mono-state.h
+++ b/mono/utils/mono-state.h
@@ -11,7 +11,7 @@
 #ifndef __MONO_UTILS_NATIVE_STATE__
 #define __MONO_UTILS_NATIVE_STATE__
 
-#ifndef HOST_WIN32
+#ifdef TARGET_OSX
 
 #include <mono/utils/mono-publib.h>
 #include <mono/utils/mono-context.h>
@@ -31,6 +31,6 @@ void
 mono_summarize_native_state_add_thread (MonoThreadSummary *thread, MonoContext *ctx);
 
 MONO_END_DECLS
-#endif // HOST_WIN32
+#endif // TARGET_OSX
 
 #endif // MONO_UTILS_NATIVE_STATE


### PR DESCRIPTION
The below format is the format of the dump. I've confirmed it's valid json. 

```json
{
	"protocol_version": "0.0.1",
	"configuration": {
		"version": "5.15.0 (freeform_merp_cleanup/5abc4175f73 Mon Apr 30 02:18:06 EDT 2018)",
		"tlc": "normal",
		"sigsgev": "altstack",
		"notifications": "kqueue",
		"architecture": "amd64",
		"disabled_features": "none",
		"smallconfig": "disabled",
		"bigarrays": "disabled",
		"softdebug": "enabled",
		"interpreter": "enabled",
		"llvm_support": "disabled"
	},
	"execution_context": {
		"coop-enabled": "false"
	},
	"memory": {
		"Resident Size": "12509184",
		"Virtual Size": "4455686144",
		"minor_gc_time": "0",
		"major_gc_time": "0",
		"minor_gc_count": "0",
		"major_gc_count": "0",
		"major_gc_time_concurrent": "0"
	},
	"assertion_message": "* Assertion: should not be reached at sgen-mono.c:2363",
	"threads": [{
			"is_managed": false,
			"managed_thread_ptr": "0x381fe78",
			"thread_info_addr": "0x3818800",
			"thread_name": "Finalizer",
			"native_thread_id": "0x987000",
			"ctx": {
				"IP": "0x7fff674837fe",
				"SP": "0x700000986c78",
				"BP": "0x700000986ca0"
			},
			"unmanaged_frames": [{
					"native_address": "0x10012efaf",
					"unmanaged_name": "mono_summarize_stack"
				},
				{
					"native_address": "0x1003afaba",
					"unmanaged_name": "mono_threads_summarize_one"
				},
				{
					"native_address": "0x1003af91d",
					"unmanaged_name": "mono_threads_summarize"
				},
				{
					"native_address": "0x100220e17",
					"unmanaged_name": "sigterm_signal_handler"
				},
				{
					"native_address": "outside mono-sgen",
					"unmanaged_name": "_sigtramp"
				},
				{
					"native_address": "0x1005f7340",
					"unmanaged_name": "eg_my_charset"
				},
				{
					"native_address": "0x10042600d",
					"unmanaged_name": "mono_coop_sem_wait"
				},
				{
					"native_address": "0x100427dd7",
					"unmanaged_name": "finalizer_thread"
				},
				{
					"native_address": "0x1003b012f",
					"unmanaged_name": "start_wrapper_internal"
				},
				{
					"native_address": "0x1003afd2c",
					"unmanaged_name": "start_wrapper"
				},
				{
					"native_address": "outside mono-sgen",
					"unmanaged_name": "_pthread_body"
				},
				{
					"native_address": "outside mono-sgen",
					"unmanaged_name": "_pthread_body"
				},
				{
					"native_address": "outside mono-sgen",
					"unmanaged_name": "thread_start"
				}
			]
		},
		{
			"is_managed": false,
			"managed_thread_ptr": "0x3811078",
			"thread_info_addr": "0x1004400",
			"native_thread_id": "0xa0393340",
			"ctx": {
				"IP": "0x7fff6748ce3e",
				"SP": "0x7ffeefbfea18",
				"BP": "0x7ffeefbfea50"
			},
			"managed_frames": [{
					"native_address": "outside mono-sgen"
				},
				{
					"native_address": "outside mono-sgen",
					"unmanaged_name": "(wrapper managed-to-native) System.GC:GetGeneration (object)"
				},
				{
					"is_managed": "true",
					"assembly": "Foo",
					"token": "0x6000002",
					"native_offset": "0x142",
					"il_offset": "0x00000"
				},
				{
					"native_address": "outside mono-sgen",
					"unmanaged_name": "(wrapper runtime-invoke) <Module>:runtime_invoke_void_object (object,intptr,intptr,intptr)"
				}
			],
			"unmanaged_frames": [{
					"native_address": "0x10012efaf",
					"unmanaged_name": "mono_summarize_stack"
				},
				{
					"native_address": "0x1003afaba",
					"unmanaged_name": "mono_threads_summarize_one"
				},
				{
					"native_address": "0x1003af91d",
					"unmanaged_name": "mono_threads_summarize"
				},
				{
					"native_address": "0x100134fca",
					"unmanaged_name": "mono_handle_native_crash"
				},
				{
					"native_address": "0x1002211b0",
					"unmanaged_name": "sigabrt_signal_handler"
				},
				{
					"native_address": "outside mono-sgen",
					"unmanaged_name": "_sigtramp"
				},
				{
					"native_address": "outside mono-sgen"
				},
				{
					"native_address": "outside mono-sgen",
					"unmanaged_name": "abort"
				},
				{
					"native_address": "0x1004e8f74",
					"unmanaged_name": "mono_log_write_logfile"
				},
				{
					"native_address": "0x1004deedc",
					"unmanaged_name": "structured_log_adapter"
				},
				{
					"native_address": "0x10050f70d",
					"unmanaged_name": "monoeg_g_logv"
				},
				{
					"native_address": "0x10050fb2e",
					"unmanaged_name": "monoeg_assertion_message"
				},
				{
					"native_address": "0x10043ffd6",
					"unmanaged_name": "mono_gc_get_generation"
				},
				{
					"native_address": "outside mono-sgen"
				},
				{
					"native_address": "0x100017af1",
					"unmanaged_name": "mono_jit_runtime_invoke"
				},
				{
					"native_address": "0x10037dc43",
					"unmanaged_name": "do_runtime_invoke"
				},
				{
					"native_address": "0x100376bc7",
					"unmanaged_name": "mono_runtime_invoke_checked"
				},
				{
					"native_address": "0x10038254a",
					"unmanaged_name": "do_exec_main_checked"
				},
				{
					"native_address": "0x100380c13",
					"unmanaged_name": "mono_runtime_exec_main_checked"
				},
				{
					"native_address": "0x100380c66",
					"unmanaged_name": "mono_runtime_run_main_checked"
				},
				{
					"native_address": "0x1000e419b",
					"unmanaged_name": "mono_jit_exec"
				},
				{
					"native_address": "0x1000e85b0",
					"unmanaged_name": "main_thread_handler"
				},
				{
					"native_address": "0x1000e6bc4",
					"unmanaged_name": "mono_main"
				},
				{
					"native_address": "0x1000015ae",
					"unmanaged_name": "mono_main_with_options"
				},
				{
					"native_address": "0x100000c4d",
					"unmanaged_name": "main"
				},
				{
					"native_address": "outside mono-sgen",
					"unmanaged_name": "start"
				},
				{
					"native_address": "outside mono-sgen"
				}
			]
		}
	]
}
```

Fixes https://github.com/mono/mono/issues/8217
