### PR TITLE
Add @directhex to CODEOWNERS for packaging-related stuff

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -102,7 +102,7 @@
 /msvc/*profiler* @alexrp
 /msvc/scripts @akoeplinger @kg
 
-/packaging/ @alexischr @akoeplinger @luhenry
+/packaging/ @alexischr @akoeplinger @luhenry @directhex
 /packaging/MacSDK/msbuild.py @radical @akoeplinger
 
 /runtime @akoeplinger @marek-safar @luhenry


### PR DESCRIPTION
At the very least, this way I get pinged when we bump Gtk# or MSBuild or something, so I can work on the Linux equivalent