### PR TITLE
FormsAuthenticationTicket should expire with persistent cookies

### DIFF
--- a/mcs/class/System.Web/System.Web.Security/FormsAuthenticationModule.cs
+++ b/mcs/class/System.Web/System.Web.Security/FormsAuthenticationModule.cs
@@ -155,7 +155,7 @@ namespace System.Web.Security
 				// incorrect cookie value, suppress the exception
 				return;
 			}
-			if (ticket == null || (!ticket.IsPersistent && ticket.Expired))
+			if (ticket == null || ticket.Expired)
 				return;
 
 			FormsAuthenticationTicket oldticket = ticket;


### PR DESCRIPTION
## Steps to Reproduce

1. I have an application web
2. The user enters your credentials. Then, the controller creates an authentication ticket:
`var ticket = new FormsAuthenticationTicket( 1, userName, DateTime.Now, DateTime.Now.Add(timeout), createPersistentCookie, userDataSerialized, FormsAuthentication.FormsCookiePath);`
 where **createPersistentCookie = true**
3. The browser will erase the cookies when they reach the expiration time, but really ticket authentication 
 contains in cookie will never expire. An attacker can steal cookies and they will always be valid.

<!--
You may drag & drop the attachment (repro code/solution, screenshot, etc.) onto the issue.
-->

### Current Behavior

When a user is authenticated, the **FormsAuthenticationModule** doesn't check expiration ticket when it is persistent

<!--
What is the current behavior?
-->

### Expected Behavior
When a user is authenticated, the **FormsAuthenticationModule** should check the expiration field independently of ticket is persistent or not.


<!--
Please describe the behavior you are expecting
-->

## On which platforms did you notice this

[X] macOS
[X] Linux
[X] Windows

**Version Used**: 4.8.1.0

<!--
You can use `mono --version` or About dialog to obtain this information.
-->

## Notes

I have executed my application on Windows environment and the result is correct.
Reviewing the Microsoft's documentation, from ASP.NET 2, cookies are expired for security reasons.

Next we can see how it is in referencesource:
* https://github.com/mono/mono/blob/master/mcs/class/referencesource/System.Web/Security/FormsAuthenticationModule.cs#L118
* https://blogs.msdn.microsoft.com/dansellers/2006/02/15/change-to-asp-net-2-0-forms-authentication-persistent-cookies/

