### PR TITLE
Support cookie-less sessions which are not rooted

### DIFF
--- a/mcs/class/System.Web/System.Web.UI.HtmlControls/HtmlForm.cs
+++ b/mcs/class/System.Web/System.Web.UI.HtmlControls/HtmlForm.cs
@@ -253,7 +253,10 @@ namespace System.Web.UI.HtmlControls
 					
 					if (cookieless) {
 						Uri current_uri = new Uri ("http://host" + current_path);
-						Uri fp_uri = new Uri ("http://host" + file_path);
+						//Determine if the file_path is rooted (ie starts with a '/')
+						//and inject a '/' into the Uri string accordingly.
+						string separator = file_path[0] == '/' ? "" : "/";
+						Uri fp_uri = new Uri ("http://host" + separator + file_path);
 						action = fp_uri.MakeRelative (current_uri);
 					} else
 						action = current_path;


### PR DESCRIPTION
When running with cookieless sessions, the file_path does not necessarily contain a leading '/' character which can lead to a Uri being constructed from something that looks like, "http://hostmyPage.aspx" which immediately fails and throw an exception stating that the hostname could not be parsed.

Fixes #8526