### PR TITLE
[Tailcall] Allow returning valuetypes from tailcalls.

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -2279,7 +2279,10 @@ mono_emit_call_args (MonoCompile *cfg, MonoMethodSignature *sig,
 	MonoType *sig_ret;
 	MonoCallInst *call;
 
-	if (tailcall && cfg->llvm_only) { // FIXME?
+	if (tailcall && cfg->llvm_only) {
+		// FIXME tailcall should not be changed this late.
+		// FIXME It really should not be changed due to llvm_only.
+		// Accuracy is presently available MONO_IS_TAILCALL (call->inst).
 		tailcall = FALSE;
 		tailcall_print ("losing tailcall in %s due to llvm_only\n", cfg->method->name);
 		test_tailcall (cfg, FALSE);
@@ -2556,7 +2559,6 @@ mono_emit_method_call_full (MonoCompile *cfg, MonoMethod *method, MonoMethodSign
 		call->method = method;
 	call->inst.flags |= MONO_INST_HAS_METHOD;
 	call->inst.inst_left = this_ins;
-	call->tailcall = tailcall;
 
 	if (virtual_) {
 		int vtable_reg, slot_reg, this_reg;
@@ -8430,7 +8432,6 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				emit_tailcall_parameters (cfg, fsig);
 				MONO_INST_NEW_CALL (cfg, call, OP_TAILCALL);
 				call->method = cmethod;
-				call->tailcall = TRUE;
 				call->signature = fsig;
 				call->args = (MonoInst **)mono_mempool_alloc (cfg->mempool, sizeof (MonoInst*) * n);
 				call->inst.inst_p0 = cmethod;

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -2313,10 +2313,7 @@ mono_emit_call_args (MonoCompile *cfg, MonoMethodSignature *sig,
 	mini_type_to_eval_stack_type ((cfg), sig_ret, &call->inst);
 
 	if (tailcall) {
-		if (mini_type_is_vtype (sig_ret)) {
-			call->vret_var = cfg->vret_addr;
-			//g_assert_not_reached ();
-		}
+		call->vret_var = cfg->vret_addr;
 	} else if (mini_type_is_vtype (sig_ret)) {
 		MonoInst *temp = mono_compile_create_var (cfg, sig_ret, OP_LOCAL);
 		MonoInst *loada;

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -1960,7 +1960,7 @@ emit_sig_cookie (MonoCompile *cfg, MonoCallInst *call, CallInfo *cinfo)
 	MonoMethodSignature *tmp_sig;
 	int sig_reg;
 
-	if (call->tailcall)
+	if (MONO_IS_TAILCALL (&call->inst))
 		NOT_IMPLEMENTED;
 
 	g_assert (cinfo->sig_cookie.storage == ArgOnStack);
@@ -2152,7 +2152,7 @@ mono_arch_emit_call (MonoCompile *cfg, MonoCallInst *call)
 
 		t = mini_get_underlying_type (t);
 		//XXX what about ArgGSharedVtOnStack here?
-		if (ainfo->storage == ArgOnStack && !MONO_TYPE_ISSTRUCT (t) && !call->tailcall) {
+		if (ainfo->storage == ArgOnStack && !MONO_TYPE_ISSTRUCT (t) && !MONO_IS_TAILCALL (&call->inst)) {
 			if (!t->byref) {
 				if (t->type == MONO_TYPE_R4)
 					MONO_EMIT_NEW_STORE_MEMBASE (cfg, OP_STORER4_MEMBASE_REG, AMD64_RSP, ainfo->offset, in->dreg);
@@ -2211,11 +2211,11 @@ mono_arch_emit_call (MonoCompile *cfg, MonoCallInst *call)
 		case ArgValuetypeAddrOnStack:
 		case ArgGSharedVtInReg:
 		case ArgGSharedVtOnStack: {
-			if (ainfo->storage == ArgOnStack && !MONO_TYPE_ISSTRUCT (t) && !call->tailcall)
+			if (ainfo->storage == ArgOnStack && !MONO_TYPE_ISSTRUCT (t) && !MONO_IS_TAILCALL (&call->inst))
 				/* Already emitted above */
 				break;
 			//FIXME what about ArgGSharedVtOnStack ?
-			if (ainfo->storage == ArgOnStack && call->tailcall) {
+			if (ainfo->storage == ArgOnStack && MONO_IS_TAILCALL (&call->inst)) {
 				MonoInst *call_inst = (MonoInst*)call;
 				cfg->args [i]->flags |= MONO_INST_VOLATILE;
 				EMIT_NEW_ARGSTORE (cfg, call_inst, i, in);
@@ -2285,7 +2285,7 @@ mono_arch_emit_call (MonoCompile *cfg, MonoCallInst *call)
 			if (call->vret_var)
 				NULLIFY_INS (call->vret_var);
 		} else {
-			if (call->tailcall)
+			if (MONO_IS_TAILCALL (&call->inst))
 				NOT_IMPLEMENTED;
 			/*
 			 * The valuetype is in RAX:RDX after the call, need to be copied to

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -1266,8 +1266,6 @@ is_supported_tailcall_helper (gboolean value, const char *svalue)
 gboolean
 mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig, MonoMethodSignature *callee_sig)
 {
-	MonoType *callee_ret;
-
 	CallInfo *caller_info = get_call_info (NULL, caller_sig);
 	CallInfo *callee_info = get_call_info (NULL, callee_sig);
 	gboolean res = IS_SUPPORTED_TAILCALL (callee_info->stack_usage <= caller_info->stack_usage)
@@ -1275,11 +1273,6 @@ mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig,
 
 	if (!res && !debug_tailcall)
 		goto exit;
-
-	// FIXME: Pass caller's caller's return area to callee.
-	/* An address on the callee's stack is passed as the first argument */
-	callee_ret = mini_get_underlying_type (callee_sig->ret);
-	res &= IS_SUPPORTED_TAILCALL (!(callee_ret && MONO_TYPE_ISSTRUCT (callee_ret) && callee_info->ret.storage != ArgValuetypeInReg));
 
 	// Limit stack_usage to 1G. Assume 32bit limits when we move parameters.
 	res &= IS_SUPPORTED_TAILCALL (callee_info->stack_usage < (1 << 30));

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -2262,7 +2262,7 @@ emit_sig_cookie (MonoCompile *cfg, MonoCallInst *call, CallInfo *cinfo)
 	MonoMethodSignature *tmp_sig;
 	int sig_reg;
 
-	if (call->tailcall)
+	if (MONO_IS_TAILCALL (&call->inst))
 		NOT_IMPLEMENTED;
 
 	g_assert (cinfo->sig_cookie.storage == RegTypeBase);
@@ -2405,7 +2405,7 @@ mono_arch_emit_call (MonoCompile *cfg, MonoCallInst *call)
 			call->vret_in_reg = TRUE;
 			break;
 		}
-		if (call->inst.opcode == OP_TAILCALL)
+		if (MONO_IS_TAILCALL (&call->inst))
 			break;
 		/*
 		 * The vtype is returned in registers, save the return area address in a local, and save the vtype into

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -1794,7 +1794,6 @@ mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig,
 	g_assert (caller_sig);
 	g_assert (callee_sig);
 
-	MonoType *callee_ret;
 	CallInfo *caller_info = get_call_info (NULL, caller_sig);
 	CallInfo *callee_info = get_call_info (NULL, callee_sig);
 
@@ -1804,13 +1803,6 @@ mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig,
 	 */
 	gboolean res = IS_SUPPORTED_TAILCALL (callee_info->stack_usage <= caller_info->stack_usage)
 				&& IS_SUPPORTED_TAILCALL (caller_info->ret.storage == callee_info->ret.storage);
-	if (!res && !debug_tailcall)
-		goto exit;
-
-	// FIXME: Pass caller's caller's return area to callee.
-	/* An address on the callee's stack is passed as the first argument */
-	callee_ret = mini_get_underlying_type (callee_sig->ret);
-	res &= IS_SUPPORTED_TAILCALL (!(callee_ret && MONO_TYPE_ISSTRUCT (callee_ret) && callee_info->ret.storage != RegTypeStructByVal));
 	if (!res && !debug_tailcall)
 		goto exit;
 

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -2759,32 +2759,6 @@ is_supported_tailcall_helper (gboolean value, const char *svalue)
 
 #define IS_SUPPORTED_TAILCALL(x) (is_supported_tailcall_helper((x), #x))
 
-static gboolean
-tailcall_return_storage_supported (ArgStorage storage)
-{
-	switch (storage) {
-	case ArgInIReg:
-	case ArgInFReg:
-	case ArgInFRegR4:
-	case ArgNone:
-		return TRUE;
-
-	case ArgHFA:
-	case ArgOnStack:
-	case ArgOnStackR8:
-	case ArgOnStackR4:
-	case ArgVtypeByRef:
-	case ArgVtypeByRefOnStack:
-	case ArgVtypeInIRegs: // FIXME: Pass caller's caller's return area to callee.
-	case ArgVtypeOnStack:
-		return FALSE;
-
-	default:
-		g_assert_not_reached ();
-		return FALSE;
-	}
-}
-
 gboolean
 mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig, MonoMethodSignature *callee_sig)
 {
@@ -2799,8 +2773,7 @@ mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig,
 	CallInfo *callee_info = get_call_info (NULL, callee_sig);
 
 	gboolean res = IS_SUPPORTED_TAILCALL (callee_info->stack_usage <= caller_info->stack_usage)
-		  && IS_SUPPORTED_TAILCALL (caller_info->ret.storage == callee_info->ret.storage)
-		  && IS_SUPPORTED_TAILCALL (tailcall_return_storage_supported (caller_info->ret.storage));
+		  && IS_SUPPORTED_TAILCALL (caller_info->ret.storage == callee_info->ret.storage);
 
 	// FIXME Limit stack_usage to 1G. emit_ldrx / strx has 32bit limits.
 	res &= IS_SUPPORTED_TAILCALL (callee_info->stack_usage < (1 << 30));

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -2527,17 +2527,19 @@ mono_arch_emit_call (MonoCompile *cfg, MonoCallInst *call)
 	switch (cinfo->ret.storage) {
 	case ArgVtypeInIRegs:
 	case ArgHFA:
-		/*
-		 * The vtype is returned in registers, save the return area address in a local, and save the vtype into
-		 * the location pointed to by it after call in emit_move_return_value ().
-		 */
-		if (!cfg->arch.vret_addr_loc) {
-			cfg->arch.vret_addr_loc = mono_compile_create_var (cfg, mono_get_int_type (), OP_LOCAL);
-			/* Prevent it from being register allocated or optimized away */
-			((MonoInst*)cfg->arch.vret_addr_loc)->flags |= MONO_INST_VOLATILE;
-		}
+		if (!call->tailcall) {
+			/*
+			 * The vtype is returned in registers, save the return area address in a local, and save the vtype into
+			 * the location pointed to by it after call in emit_move_return_value ().
+			 */
+			if (!cfg->arch.vret_addr_loc) {
+				cfg->arch.vret_addr_loc = mono_compile_create_var (cfg, mono_get_int_type (), OP_LOCAL);
+				/* Prevent it from being register allocated or optimized away */
+				((MonoInst*)cfg->arch.vret_addr_loc)->flags |= MONO_INST_VOLATILE;
+			}
 
-		MONO_EMIT_NEW_UNALU (cfg, OP_MOVE, ((MonoInst*)cfg->arch.vret_addr_loc)->dreg, call->vret_var->dreg);
+			MONO_EMIT_NEW_UNALU (cfg, OP_MOVE, ((MonoInst*)cfg->arch.vret_addr_loc)->dreg, call->vret_var->dreg);
+		}
 		break;
 	case ArgVtypeByRef:
 		/* Pass the vtype return address in R8 */

--- a/mono/mini/mini-mips.c
+++ b/mono/mini/mini-mips.c
@@ -1639,7 +1639,7 @@ emit_sig_cookie (MonoCompile *cfg, MonoCallInst *call, CallInfo *cinfo)
 	MonoMethodSignature *tmp_sig;
 	MonoInst *sig_arg;
 
-	if (call->tailcall)
+	if (MONO_IS_TAILCALL (&call->inst))
 		NOT_IMPLEMENTED;
 
 	/* FIXME: Add support for signature tokens to AOT */

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -1346,24 +1346,10 @@ mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig,
 {
 	CallInfo *c1, *c2;
 	gboolean res;
-	int i;
 
 	c1 = get_call_info (caller_sig);
 	c2 = get_call_info (callee_sig);
 	res = c1->stack_usage >= c2->stack_usage;
-	if (callee_sig->ret && MONO_TYPE_ISSTRUCT (callee_sig->ret))
-		/* An address on the callee's stack is passed as the first argument */
-		res = FALSE;
-	for (i = 0; i < c2->nargs; ++i) {
-		if (c2->args [i].regtype == RegTypeStructByAddr)
-			/* An address on the callee's stack is passed as the argument */
-			res = FALSE;
-	}
-
-	/*
-	if (!mono_debug_count ())
-		res = FALSE;
-	*/
 
 	g_free (c1);
 	g_free (c2);

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -7551,15 +7551,10 @@ mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig,
 {
 	CallInfo *c1, *c2;
 	gboolean res;
-	MonoType *callee_ret;
 
 	c1 = get_call_info (NULL, caller_sig);
 	c2 = get_call_info (NULL, callee_sig);
 	res = c1->stack_usage >= c2->stack_usage;
-	callee_ret = mini_get_underlying_type (callee_sig->ret);
-	if (callee_ret && MONO_TYPE_ISSTRUCT (callee_ret) && c2->struct_ret && c2->ret.size > 8)
-		/* An address on the callee's stack is passed as the first argument */
-		res = FALSE;
 
 	g_free (c1);
 	g_free (c2);

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -669,7 +669,6 @@ mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig,
 		/* OP_TAILCALL doesn't work with AOT */
 		return FALSE;
 
-	MonoType *callee_ret;
 	CallInfo *caller_info = get_call_info (NULL, caller_sig);
 	CallInfo *callee_info = get_call_info (NULL, callee_sig);
 
@@ -681,10 +680,6 @@ mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig,
 				&& IS_SUPPORTED_TAILCALL (caller_info->ret.storage == callee_info->ret.storage);
 	if (!res && !debug_tailcall)
 		goto exit;
-
-	// FIXME: Pass caller's caller's return area to callee.
-	callee_ret = mini_get_underlying_type (callee_sig->ret);
-	res &= IS_SUPPORTED_TAILCALL (!(callee_ret && MONO_TYPE_ISSTRUCT (callee_ret) && callee_info->ret.storage != ArgValuetypeInReg));
 
 	// Limit stack_usage to 1G.
 	res &= IS_SUPPORTED_TAILCALL (callee_info->stack_usage < (1 << 30));

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -274,8 +274,10 @@ enum {
 
 // OP_DYN_CALL is not a MonoCallInst
 
+#define MONO_IS_TAILCALL(ins) ((ins)->opcode == OP_TAILCALL || (ins)->opcode == OP_TAILCALL_MEMBASE || (ins)->opcode == OP_TAILCALL_REG)
+
 #define MONO_IS_CALL(ins) (((ins)->opcode >= OP_VOIDCALL && (ins)->opcode <= OP_VCALL2_MEMBASE) || \
-	(ins)->opcode == OP_TAILCALL || (ins)->opcode == OP_TAILCALL_MEMBASE || (ins)->opcode == OP_TAILCALL_REG)
+	MONO_IS_TAILCALL (ins))
 
 #define MONO_IS_JUMP_TABLE(ins) (((ins)->opcode == OP_JUMP_TABLE) ? TRUE : ((((ins)->opcode == OP_AOTCONST) && (ins->inst_i1 == (gpointer)MONO_PATCH_INFO_SWITCH)) ? TRUE : ((ins)->opcode == OP_SWITCH) ? TRUE : ((((ins)->opcode == OP_GOT_ENTRY) && ((ins)->inst_right->inst_i1 == (gpointer)MONO_PATCH_INFO_SWITCH)) ? TRUE : FALSE)))
 
@@ -715,7 +717,6 @@ struct MonoCallInst {
 	guint stack_usage;
 	guint stack_align_amount;
 	guint is_virtual : 1;
-	guint tailcall : 1;
 	/* If this is TRUE, 'fptr' points to a MonoJumpInfo instead of an address. */
 	guint fptr_is_patch : 1;
 	/*

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -877,7 +877,6 @@ TESTS_GSHARED_SRC = \
 	generic-type-builder.2.cs
 
 PLATFORM_DISABLED_TESTS=\
-	tailcall-return-valuetype.exe \
 	tailcall-rgctxb.exe
 
 if HOST_WIN32

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -816,6 +816,7 @@ TESTS_IL_SRC=			\
 	dim-valuetypes.il \
 	tailcall-generic-cast-conservestack-il.il \
 	tailcall-generic-cast-nocrash-il.il \
+	tailcall-return-valuetype.il \
 	ldfldvt.il \
 	newobj-abstract.il
 
@@ -876,6 +877,7 @@ TESTS_GSHARED_SRC = \
 	generic-type-builder.2.cs
 
 PLATFORM_DISABLED_TESTS=\
+	tailcall-return-valuetype.exe \
 	tailcall-rgctxb.exe
 
 if HOST_WIN32

--- a/mono/tests/tailcall-return-valuetype.il
+++ b/mono/tests/tailcall-return-valuetype.il
@@ -5,18 +5,26 @@ using static System.Runtime.CompilerServices.MethodImplOptions;
 
 unsafe public struct ValueType
 {
-	public long a, b, c, d, e, f, g, h, i, j, k, l, m;
+	public long a0, a1, a2, a3, a4, a5, a6, a7, a8, a9;
 
-	public void Init ()
+	public ValueType Init ()
 	{
-		a = b = c = d = e = f = g = h = i = j = k = l = m = 1;
+		a0 = 0;
+		a1 = 1;
+		a2 = 2;
+		a3 = 3;
+		a4 = 4;
+		a5 = 5;
+		a6 = 6;
+		a7 = 7;
+		a8 = 8;
+		a9 = 9;
+		return this;
 	}
 
 	public static ValueType New ()
 	{
-		var a = new ValueType ();
-		a.Init ();
-		return a;
+		return new ValueType ().Init ();
 	}
 
 	[MethodImpl (NoInlining)]
@@ -80,9 +88,11 @@ extends [mscorlib]System.ValueType
 .field public int64 a8
 .field public int64 a9
 
-.method static void check (int64 stack1, int64 stack2) noinlining
+.method static valuetype ValueType check (int64 stack1, int64 stack2) noinlining
 {
-/*
+	.locals init ( int64 V_0, valuetype ValueType V_1)
+
+/* in the C# but deliberately removed here
 	ldarg 0
 	brfalse IL_0004
 	ret
@@ -91,8 +101,8 @@ IL_0004:
 */
 	ldarg 0
 	ldarg 1
-	bne.un IL_0009
-	ret
+	beq success
+	//br success // to see the resulting value
 
 IL_0009:
 	ldstr "tailcall failure {0} {1}"
@@ -101,15 +111,57 @@ IL_0009:
 	ldarg 1
 	box [mscorlib]System.Int64
 	call void class [mscorlib]System.Console::WriteLine (string, object, object)
-	ldc.i4 1
-tail.
-	call void class [mscorlib]System.Environment::Exit (int32)
+
+// exit early, or let Main check for the expected values
+	//ldc.i4 1
+	//tail.call void class [mscorlib]System.Environment::Exit (int32)
+
+// fail with all zeros (.locals init)
+	ldloca 1
+	ldobj ValueType
+	ret
+
+success: // with slightly nontrivial values a0 == 0, a1 == 1, etc.
+	ldloca 1
+	ldc.i8 0
+	stfld int64 ValueType::a0
+	ldloca 1
+	ldc.i8 1
+	stfld int64 ValueType::a1
+	ldloca 1
+	ldc.i8 2
+	stfld int64 ValueType::a2
+	ldloca 1
+	ldc.i8 3
+	stfld int64 ValueType::a3
+	ldloca 1
+	ldc.i8 4
+	stfld int64 ValueType::a4
+	ldloca 1
+	ldc.i8 5
+	stfld int64 ValueType::a5
+	ldloca 1
+	ldc.i8 6
+	stfld int64 ValueType::a6
+	ldloca 1
+	ldc.i8 7
+	stfld int64 ValueType::a7
+	ldloca 1
+	ldc.i8 8
+	stfld int64 ValueType::a8
+	ldloca 1
+	ldc.i8 9
+	stfld int64 ValueType::a9
+
+	ldloca 1
+	ldobj ValueType
+
 	ret
 }
 
 .method public static valuetype ValueType Method1 (int64 depth, int64 stack) noinlining
 {
-	.locals init ( int64 V_0, valuetype ValueType V_1)
+	.locals ( int64 V_0)
 
 	ldarg 0
 	ldc.i8 0
@@ -127,15 +179,15 @@ tail.
 IL_0013:
 	ldloca 0
 	conv.u8
-	ldarg.1
-	call void valuetype ValueType::check (int64, int64)
-	ldloc 1
+	ldarg 1
+tail.
+	call valuetype ValueType valuetype ValueType::check (int64, int64)
 	ret
 }
 
 .method static valuetype ValueType Method2 (int64 depth, int64 stack) noinlining
 {
-	.locals init ( int64 V_0, valuetype ValueType V_1)
+	.locals ( int64 V_0 )
 
 	ldarg 0
 	ldc.i8 0
@@ -154,8 +206,8 @@ IL_0013:
 	ldloca 0
 	conv.u8
 	ldarg 1
-	call void valuetype ValueType::check(int64, int64)
-	ldloc 1
+tail.
+	call valuetype ValueType valuetype ValueType::check (int64, int64)
 	ret
 }
 }
@@ -165,11 +217,152 @@ IL_0013:
 
 .method public static void Main (string[] args) noinlining
 {
+	.maxstack 99
 	.entrypoint
+	.locals init (valuetype ValueType V_1)
+
 	ldc.i8 1
 	ldc.i8 0
 	call valuetype ValueType valuetype ValueType::Method1 (int64, int64)
-	pop
+	stloc 0
+
+// compare elements to expected a0 == 0, a1 == a1, etc.
+
+	ldloc 0
+	ldfld int64 ValueType::a0
+	ldc.i8 0
+	bne.un failure
+
+	ldloc 0
+	ldfld int64 ValueType::a1
+	ldc.i8 1
+	bne.un failure
+
+	ldloc 0
+	ldfld int64 ValueType::a2
+	ldc.i8 2
+	bne.un failure
+
+	ldloc 0
+	ldfld int64 ValueType::a3
+	ldc.i8 3
+	bne.un failure
+
+	ldloc 0
+	ldfld int64 ValueType::a4
+	ldc.i8 4
+	bne.un failure
+
+	ldloc 0
+	ldfld int64 ValueType::a5
+	ldc.i8 5
+	bne.un failure
+
+	ldloc 0
+	ldfld int64 ValueType::a6
+	ldc.i8 6
+	bne.un failure
+
+	ldloc 0
+	ldfld int64 ValueType::a7
+	ldc.i8 7
+	bne.un failure
+
+	ldloc 0
+	ldfld int64 ValueType::a8
+	ldc.i8 8
+	bne.un failure
+
+	ldloc 0
+	ldfld int64 ValueType::a9
+	ldc.i8 9
+	bne.un failure
+
+	ldc.i4 0
+	tail. call void class [mscorlib]System.Environment::Exit (int32)
+	ret
+
+failure:
+
+	ldstr "failed: {0}{1}{2}{3}{4}{5}{6}{7}{8}{9}"
+
+	ldc.i4 10
+	newarr [mscorlib]System.Object
+
+	dup
+	ldc.i4 0
+	ldloc 0
+	ldfld int64 ValueType::a0
+	box [mscorlib]System.Int64
+	stelem.ref
+
+	dup
+	ldc.i4 1
+	ldloc 0
+	ldfld int64 ValueType::a1
+	box [mscorlib]System.Int64
+	stelem.ref
+
+	dup
+	ldc.i4 2
+	ldloc 0
+	ldfld int64 ValueType::a2
+	box [mscorlib]System.Int64
+	stelem.ref
+
+	dup
+	ldc.i4 3
+	ldloc 0
+	ldfld int64 ValueType::a3
+	box [mscorlib]System.Int64
+	stelem.ref
+
+	dup
+	ldc.i4 4
+	ldloc 0
+	ldfld int64 ValueType::a4
+	box [mscorlib]System.Int64
+	stelem.ref
+
+	dup
+	ldc.i4 5
+	ldloc 0
+	ldfld int64 ValueType::a5
+	box [mscorlib]System.Int64
+	stelem.ref
+
+	dup
+	ldc.i4 6
+	ldloc 0
+	ldfld int64 ValueType::a6
+	box [mscorlib]System.Int64
+	stelem.ref
+
+	dup
+	ldc.i4 7
+	ldloc 0
+	ldfld int64 ValueType::a7
+	box [mscorlib]System.Int64
+	stelem.ref
+
+	dup
+	ldc.i4 8
+	ldloc 0
+	ldfld int64 ValueType::a8
+	box [mscorlib]System.Int64
+	stelem.ref
+
+	dup
+	ldc.i4 9
+	ldloc 0
+	ldfld int64 ValueType::a9
+	box [mscorlib]System.Int64
+	stelem.ref
+
+	call void class [mscorlib]System.Console::WriteLine(string, object[])
+
+	ldc.i4 1
+	tail. call void class [mscorlib]System.Environment::Exit (int32)
 	ret
 }
 

--- a/mono/tests/tailcall-return-valuetype.il
+++ b/mono/tests/tailcall-return-valuetype.il
@@ -1,0 +1,176 @@
+/*
+using System;
+using System.Runtime.CompilerServices;
+using static System.Runtime.CompilerServices.MethodImplOptions;
+
+unsafe public struct ValueType
+{
+	public long a, b, c, d, e, f, g, h, i, j, k, l, m;
+
+	public void Init ()
+	{
+		a = b = c = d = e = f = g = h = i = j = k = l = m = 1;
+	}
+
+	public static ValueType New ()
+	{
+		var a = new ValueType ();
+		a.Init ();
+		return a;
+	}
+
+	[MethodImpl (NoInlining)]
+	static void check (long stack1, long stack2)
+	{
+// NOTE: This is wierd in order to be later hand edited (removed) in the IL.
+		if (stack1 != 0)
+			return;
+		if (stack1 == stack2)
+			return;
+		Console.WriteLine ("tailcall failure {0} {1}", stack1, stack2);
+		Environment.Exit (1);
+	}
+
+	[MethodImpl (NoInlining)]
+	public static ValueType Method1 (long depth = 999999, long stack = 0)
+	{
+		long local;
+		if (depth > 0)
+			return Method2 (depth - 1, (long)&local);
+		check ((long)&local, stack);
+		return New ();
+	}
+
+	[MethodImpl (NoInlining)]
+	static ValueType Method2 (long depth = 999999, long stack = 0)
+	{
+		long local;
+		if (depth > 0)
+			return Method1 (depth - 1, (long)&local);
+		check ((long)&local, stack);
+		return New ();
+	}
+}
+
+class B
+{
+	[MethodImpl (NoInlining)]
+	public static void Main (string[] args)
+	{
+		Console.WriteLine(ValueType.Method1 (2));
+	}
+}
+*/
+
+.assembly extern mscorlib { }
+
+.assembly 'tailcall-return-valuetype' { }
+
+.class public ValueType
+extends [mscorlib]System.ValueType
+{
+.field public int64 a0
+.field public int64 a1
+.field public int64 a2
+.field public int64 a3
+.field public int64 a4
+.field public int64 a5
+.field public int64 a6
+.field public int64 a7
+.field public int64 a8
+.field public int64 a9
+
+.method static void check (int64 stack1, int64 stack2) noinlining
+{
+/*
+	ldarg 0
+	brfalse IL_0004
+	ret
+
+IL_0004:
+*/
+	ldarg 0
+	ldarg 1
+	bne.un IL_0009
+	ret
+
+IL_0009:
+	ldstr "tailcall failure {0} {1}"
+	ldarg 0
+	box [mscorlib]System.Int64
+	ldarg 1
+	box [mscorlib]System.Int64
+	call void class [mscorlib]System.Console::WriteLine (string, object, object)
+	ldc.i4 1
+tail.
+	call void class [mscorlib]System.Environment::Exit (int32)
+	ret
+}
+
+.method public static valuetype ValueType Method1 (int64 depth, int64 stack) noinlining
+{
+	.locals init ( int64 V_0, valuetype ValueType V_1)
+
+	ldarg 0
+	ldc.i8 0
+	ble IL_0013
+
+	ldarg 0
+	ldc.i8 1
+	sub
+	ldloca 0
+	conv.u8
+tail.
+	call valuetype ValueType valuetype ValueType::Method2 (int64, int64)
+	ret
+
+IL_0013:
+	ldloca 0
+	conv.u8
+	ldarg.1
+	call void valuetype ValueType::check (int64, int64)
+	ldloc 1
+	ret
+}
+
+.method static valuetype ValueType Method2 (int64 depth, int64 stack) noinlining
+{
+	.locals init ( int64 V_0, valuetype ValueType V_1)
+
+	ldarg 0
+	ldc.i8 0
+	ble IL_0013
+
+	ldarg 0
+	ldc.i8 1
+	sub
+	ldloca 0
+	conv.u8
+tail.
+	call valuetype ValueType valuetype ValueType::Method1 (int64, int64)
+	ret
+
+IL_0013:
+	ldloca 0
+	conv.u8
+	ldarg 1
+	call void valuetype ValueType::check(int64, int64)
+	ldloc 1
+	ret
+}
+}
+
+.class B
+{
+
+.method public static void Main (string[] args) noinlining
+{
+	.entrypoint
+	ldc.i8 1
+	ldc.i8 0
+	call valuetype ValueType valuetype ValueType::Method1 (int64, int64)
+	pop
+	ret
+}
+
+}

--- a/mono/tests/tailcall/fsharp-deeptail.il
+++ b/mono/tests/tailcall/fsharp-deeptail.il
@@ -819,14 +819,12 @@ callvirt instance !0 class Fsharp/TailCallLoopGenericClass`1<int32>::get_Result(
 ldc.i4.3
 call void Fsharp::RunTest<int32>(string, !!0, !!0)
 
-/* FIXME This fails on x86 and ARM64. It passes on AMD64.
 ldstr "TailCallLoopGenericClass<DateTime>"
 ldsfld valuetype [mscorlib]System.DateTime [mscorlib]System.DateTime::MinValue
 newobj instance void class Fsharp/TailCallLoopGenericClass`1<valuetype [mscorlib]System.DateTime>::.ctor(!0)
 callvirt instance !0 class Fsharp/TailCallLoopGenericClass`1<valuetype [mscorlib]System.DateTime>::get_Result()
 ldsfld valuetype [mscorlib]System.DateTime [mscorlib]System.DateTime::MinValue
 call void Fsharp::RunTest<valuetype [mscorlib]System.DateTime>(string, !!0, !!0)
-*/
 
 ldstr "TailCallLoopGenericClass<string>"
 ldstr "abc"


### PR DESCRIPTION
This can be fixed easily -- when F1 calls F2 tailcalls F3.
F2 can pass F3 the temporary it got from F1 instead of having another temporary.