### PR TITLE
 Have automake copy instead of symlink, for more git checkout sharability

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -89,7 +89,7 @@ if test x$NOCONFIGURE = x && test -z "$*"; then
   echo
 fi
 
-am_opt="--add-missing --gnu -Wno-portability -Wno-obsolete"
+am_opt="--add-missing --copy --gnu -Wno-portability -Wno-obsolete"
 
 case $CC in
 xlc )

--- a/autogen.sh
+++ b/autogen.sh
@@ -89,9 +89,11 @@ if test x$NOCONFIGURE = x && test -z "$*"; then
   echo
 fi
 
+am_opt="--add-missing --gnu -Wno-portability -Wno-obsolete"
+
 case $CC in
 xlc )
-  am_opt=--include-deps;;
+  am_opt="$am_opt --include-deps";;
 esac
 
 
@@ -142,8 +144,8 @@ if grep "^AC_CONFIG_HEADERS" configure.ac >/dev/null; then
   autoheader || { echo "**Error**: autoheader failed."; exit 1; }
 fi
 
-echo "Running automake --gnu $am_opt ..."
-automake --add-missing --gnu -Wno-portability -Wno-obsolete $am_opt ||
+echo "Running automake $am_opt ..."
+automake $am_opt ||
   { echo "**Error**: automake failed."; exit 1; }
 echo "Running autoconf ..."
 autoconf || { echo "**Error**: autoconf failed."; exit 1; }

--- a/libgc/autogen.sh
+++ b/libgc/autogen.sh
@@ -74,11 +74,12 @@ if test x$NOCONFIGURE = x && test -z "$*"; then
   echo
 fi
 
+am_opt="--add-missing --gnu -Wno-obsolete"
+
 case $CC in
 xlc )
-  am_opt=--include-deps;;
+  am_opt="$am_opt --include-deps";;
 esac
-
 
 if grep "^AC_PROG_LIBTOOL" configure.ac >/dev/null; then
   if test -z "$NO_LIBTOOLIZE" ; then 
@@ -104,8 +105,8 @@ if grep "^AC_CONFIG_HEADERS" configure.ac >/dev/null; then
   autoheader || { echo "**Error**: autoheader failed."; exit 1; }
 fi
 
-echo "Running automake --gnu $am_opt ..."
-automake --add-missing --gnu -Wno-obsolete $am_opt ||
+echo "Running automake $am_opt ..."
+automake $am_opt ||
   { echo "**Error**: automake failed."; exit 1; }
 echo "Running autoconf ..."
 autoconf || { echo "**Error**: autoconf failed."; exit 1; }

--- a/libgc/autogen.sh
+++ b/libgc/autogen.sh
@@ -74,7 +74,7 @@ if test x$NOCONFIGURE = x && test -z "$*"; then
   echo
 fi
 
-am_opt="--add-missing --gnu -Wno-obsolete"
+am_opt="--add-missing --copy --gnu -Wno-obsolete"
 
 case $CC in
 xlc )


### PR DESCRIPTION
Have automake copy instead of symlink.
- This sounds analogous to libtool --copy that we do.
- It enables sharing a source tree more broadly.

For real example, Cygwin symlinks are not portable to Windows Subsystem For Linux, and probably vice versa.
For real example, Homebrew symlinks are not portable to Linux in Docker.

Downside I notice is that ls -l is less informative as to what is from git vs. a symlink to outside.
git clean -xxddff works just as well either way.

Hypothetical downside is that updating automake/autoconf doesn't upgrade the copies.
This has never mattered to me, but it might matter. It might be viewed as an advantage.