### PR TITLE
[build] Add a -march forcing crypto extensions on ARM64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4652,6 +4652,7 @@ if test "x$enable_btls" = "xyes"; then
 		;;
 	aarch64)
 		btls_arch=aarch64
+		btls_cflags="-march=armv8-a+crypto"
 		;;
 	s390x)
 		btls_arch=s390x


### PR DESCRIPTION
We only care about CPUs with this extension, and it fixes https://github.com/mono/mono/issues/8488

GCC doesn't object to this flag, so don't bother gating it as Clang-only