### PR TITLE
[mcs] Mimic csc behaviour when attribute value is a typedef and add

### DIFF
--- a/mcs/mcs/assembly.cs
+++ b/mcs/mcs/assembly.cs
@@ -554,7 +554,8 @@ namespace Mono.CSharp
 						if (prop != null) {
 							AttributeEncoder encoder = new AttributeEncoder ();
 							encoder.EncodeNamedPropertyArgument (prop, new BoolLiteral (Compiler.BuiltinTypes, true, Location.Null));
-							SetCustomAttribute (pa.Constructor, encoder.ToArray ());
+							SetCustomAttribute (pa.Constructor, encoder.ToArray (out var references));
+							module.AddAssemblyReferences (references);
 						}
 					}
 				}

--- a/mcs/mcs/class.cs
+++ b/mcs/mcs/class.cs
@@ -2117,7 +2117,8 @@ namespace Mono.CSharp
 			encoder.Encode (GetAttributeDefaultMember ());
 			encoder.EncodeEmptyNamedArguments ();
 
-			TypeBuilder.SetCustomAttribute ((ConstructorInfo) ctor.GetMetaInfo (), encoder.ToArray ());
+			TypeBuilder.SetCustomAttribute ((ConstructorInfo) ctor.GetMetaInfo (), encoder.ToArray (out var references));
+			Module.AddAssemblyReferences (references);
 		}
 
 		public override void VerifyMembers ()

--- a/mcs/mcs/field.cs
+++ b/mcs/mcs/field.cs
@@ -542,7 +542,7 @@ namespace Mono.CSharp
 				}
 			);
 
-			fixed_buffer_type.SetCustomAttribute ((ConstructorInfo) ctor.GetMetaInfo (), encoder.ToArray ());
+			fixed_buffer_type.SetCustomAttribute ((ConstructorInfo) ctor.GetMetaInfo (), encoder.ToArray (out _));
 #endif
 			//
 			// Don't emit FixedBufferAttribute attribute for private types
@@ -559,7 +559,8 @@ namespace Mono.CSharp
 			encoder.Encode (buffer_size);
 			encoder.EncodeEmptyNamedArguments ();
 
-			FieldBuilder.SetCustomAttribute ((ConstructorInfo) ctor.GetMetaInfo (), encoder.ToArray ());
+			FieldBuilder.SetCustomAttribute ((ConstructorInfo) ctor.GetMetaInfo (), encoder.ToArray (out var references));
+			Module.AddAssemblyReferences (references);
 		}
 	}
 

--- a/mcs/mcs/module.cs
+++ b/mcs/mcs/module.cs
@@ -480,6 +480,18 @@ namespace Mono.CSharp
 			attributes.AddAttribute (attr);
 		}
 
+		public void AddAssemblyReferences (List<Assembly> names)
+		{
+			if (names == null)
+				return;
+
+#if STATIC
+			foreach (var name in names) {
+				Builder.__GetAssemblyToken (name);
+			}
+#endif
+		}
+
 		public override void AddTypeContainer (TypeContainer tc)
 		{
 			AddTypeContainerMember (tc);


### PR DESCRIPTION
also assembly reference for it

/cc @mrvoorhe 



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
