### PR TITLE
[loader] If binding redirection redirects to the same version, ignore it

### DIFF
--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -2385,7 +2385,7 @@ mono_assembly_binding_applies_to_image (MonoImage* image, MonoImageOpenStatus *s
 	MonoAssembly *result_ass = NULL;
 	MonoAssemblyName *result_name = &probed_aname;
 	result_name = mono_assembly_apply_binding (result_name, &dest_name);
-	if (result_name != &probed_aname) {
+	if (result_name != &probed_aname && !mono_assembly_names_equal (result_name, &probed_aname)) {
 		if (mono_trace_is_traced (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY)) {
 			char *probed_fullname = mono_stringify_assembly_name (&probed_aname);
 			char *result_fullname = mono_stringify_assembly_name (result_name);


### PR DESCRIPTION
If you load Foo.dll and it happens to be version 2.0.0.0 and an app.config says
to redirect all versions of Foo.dll to version 2.0.0.0, we're there already -
don't close the image and probe again, that's silly.

Followup for #8326. This should address #8540, but I want to keep that issue open in case I note more breakage with more testing.