### PR TITLE
Give flaky test more time.

### DIFF
--- a/mcs/class/Microsoft.Build/Test/Microsoft.Build.Execution/BuildSubmissionTest.cs
+++ b/mcs/class/Microsoft.Build/Test/Microsoft.Build.Execution/BuildSubmissionTest.cs
@@ -102,8 +102,8 @@ namespace MonoTests.Microsoft.Build.Execution
 			AssertHelper.GreaterOrEqual (endBuildDone, TimeSpan.FromSeconds (1), "#2");
 			AssertHelper.GreaterOrEqual (waitDone, TimeSpan.FromSeconds (1), "#3");
 			AssertHelper.GreaterOrEqual (endBuildDone, waitDone, "#4");
-			AssertHelper.LessOrEqual (endBuildDone, TimeSpan.FromSeconds (2.5), "#5");
-			AssertHelper.LessOrEqual (waitDone, TimeSpan.FromSeconds (2.5), "#6");
+			AssertHelper.LessOrEqual (endBuildDone, TimeSpan.FromSeconds (10.0), "#5");
+			AssertHelper.LessOrEqual (waitDone, TimeSpan.FromSeconds (10.0), "#6");
 		}
 		
 		[Test]


### PR DESCRIPTION
https://jenkins.mono-project.com/job/test-mono-pull-request-coop/3429/testReport/junit/(root)/BuildSubmissionTest/EndBuildWaitsForSubmissionCompletion/

```
BuildSubmissionTest.EndBuildWaitsForSubmissionCompletion

Failing for the past 1 build (Since Unstable#3429 )
Took 36 sec.
add description
Stacktrace
                                                MESSAGE:
                                                  #5
  Expected: less than or equal to 00:00:02.5000000
  But was:  00:00:09.1408213

                                                +++++++++++++++++++
                                                STACK TRACE:
                                                  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0003b] in /mnt/jenkins/workspace/test-mono-pull-request-coop/mcs/class/corlib/System.Reflection/MonoMethod.cs:305
```
