### PR TITLE
[Mono.Security] Fix session ID handling in legacy TLS provider.

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.Protocol.Tls.Handshake.Server/TlsClientHello.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Protocol.Tls.Handshake.Server/TlsClientHello.cs
@@ -56,7 +56,6 @@ namespace Mono.Security.Protocol.Tls.Handshake.Server
 			this.selectCipherSuite();
 			this.selectCompressionMethod();
 
-			this.Context.SessionId			= this.sessionId;
 			this.Context.ClientRandom		= this.random;
 			this.Context.ProtocolNegotiated	= true;
 		}

--- a/mcs/class/Mono.Security/Mono.Security.Protocol.Tls.Handshake.Server/TlsServerHello.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Protocol.Tls.Handshake.Server/TlsServerHello.cs
@@ -97,18 +97,8 @@ namespace Mono.Security.Protocol.Tls.Handshake.Server
 			random = this.Context.GetSecureRandomBytes(28);
 			this.Write(this.random);
 						
-			if (this.Context.SessionId == null)
-			{
-				this.WriteByte(0);
-			}
-			else
-			{
-				// Write Session ID length
-				this.WriteByte((byte)this.Context.SessionId.Length);
-
-				// Write Session ID
-				this.Write(this.Context.SessionId);
-			}
+			// Write empty session ID. Resumption is unsupported.
+			this.WriteByte(0);
 
 			// Write selected cipher suite
 			this.Write(this.Context.Negotiating.Cipher.Code);


### PR DESCRIPTION
The legacy TLS provider echos back the session ID from the ClientHello
to the ServerHello. This is incorrect. Echoing back the session ID means
the server is resuming the session that the client offered. The legacy
provider does not implement session resumption as a server at all, thus
it should unconditionally send an empty value in the ServerHello field,
signaling that it neither resumed the offered session nor issued a new
session ID for future connections.

This bug causes problems for clients which support TLS 1.3 which, in
order to work around different bugs in the ecosystem, involves the
client filling the session ID with a random string. It would
additionally cause problems if a deployment were migrating from a
different, more featureful, stack to Mono. Clients may then attempt to
offer a cached session from the other stack.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
