### PR TITLE
Use size_t for gsize if it matches, else C99 uintptr_t. type-based instead of size-based autoconf printf(size_t)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4164,10 +4164,81 @@ AC_CHECK_LIB([iconv], [locale_charset],[],[AC_CHECK_LIB([charset], [locale_chars
 AC_CHECK_HEADER(alloca.h, [HAVE_ALLOCA_H=1], [HAVE_ALLOCA_H=0])
 AC_SUBST(HAVE_ALLOCA_H)
 
+# Get the exact type of size_t, not just its size.
+# This is so we can find an exact printf format among u, lu, llu, I64u.
+# To avoid warnings about slight mismatches.
+# C99 runtime "zu" dependency is being avoided here.
+#
+# We have to compile as C++ because C is too lenient
+# and lets the wrong thing compile, with warnings.
+#
+# Note: "zu" or ifdef <something> have the advantage
+# of producing installable "biarch" headers. i.e. one Mac header
+# for Mac/x86 and Mac/amd64.
+
+AC_LANG_PUSH([C++])
+
+# Check long before int because it is the overwhelming Unix answer,
+# across 32bit and 64bit systems -- fewer compiler invocations in autoconf.
+#
+# long ahead of int also tends to produce biarch-compatible headers except Windows.
+#
+AC_MSG_CHECKING(if size_t is unsigned long)
+AC_COMPILE_IFELSE([
+	#include <stddef.h>
+	unsigned long *a = (size_t*)0;
+], [
+	AC_MSG_RESULT(yes)
+	AC_SUBST(GSIZE_FORMAT, '"%lu"')
+], [
+	AC_MSG_RESULT(no)
+	AC_MSG_CHECKING(if size_t is unsigned int)
+	AC_COMPILE_IFELSE([
+		#include <stddef.h>
+		unsigned *a = (size_t*)0;
+	], [
+		AC_MSG_RESULT(yes)
+		AC_SUBST(GSIZE_FORMAT, '"%u"')
+	], [
+# At this point the vast majority of systems have their answer,
+# and we descend into non-standard or new-standard territory.
+#
+# Check __int64 first because I64 on some systems predates ll, enabling
+# new compiler/old runtime interop, and the types always have the same size.
+		AC_MSG_RESULT(no)
+		AC_MSG_CHECKING(if size_t is unsigned __int64)
+		AC_COMPILE_IFELSE([
+			#include <stddef.h>
+			unsigned __int64 *a = (size_t*)0;
+		], [
+			AC_MSG_RESULT(yes)
+			AC_SUBST(GSIZE_FORMAT, '"%I64u"')
+		], [
+			AC_MSG_RESULT(no)
+			AC_MSG_CHECKING(if size_t is unsigned long long)
+			AC_COMPILE_IFELSE([
+				#include <stddef.h>
+				unsigned long long *a = (size_t*)0;
+			], [
+				AC_MSG_RESULT(yes)
+				AC_SUBST(GSIZE_FORMAT, '"%llu"')
+			], [
+				AC_MSG_RESULT(no)
+				AC_MSG_ERROR(Unable to determine size_t among unsigned int, long, __int64, long long)
+			] )
+		] )
+	] )
+] )
+
+AC_LANG_POP([C++])
+
 # If size_t/ptrdiff_t is correct, use it. Otherwise C99 [u]intptr_t.
 # This provides for an exact match with functions that
-# take size_t like malloc and pthread_attr_getstacksize.
-# uintptr_t is not quite the same.
+# take size_t like malloc and pthread_attr_getstacksize, avoiding warnings.
+# uintptr_t is not necessarily the same, but it probably is.
+#
+# ptrdiff_t is preferred over ssize_t as it is C89 vs. new Posix.
+# ssize_t looks prettier but ptrdiff_t is dressed up as gssize anyway.
 
 if test $ac_cv_sizeof_void_p = $ac_cv_sizeof_size_t; then
    GSIZE="size_t"
@@ -4179,6 +4250,7 @@ fi
 
 AC_SUBST(GSIZE)
 AC_SUBST(GSSIZE)
+AC_SUBST(GSIZE_FORMAT)
 
 #
 # END OF EGLIB CHECKS

--- a/configure.ac
+++ b/configure.ac
@@ -4164,41 +4164,21 @@ AC_CHECK_LIB([iconv], [locale_charset],[],[AC_CHECK_LIB([charset], [locale_chars
 AC_CHECK_HEADER(alloca.h, [HAVE_ALLOCA_H=1], [HAVE_ALLOCA_H=0])
 AC_SUBST(HAVE_ALLOCA_H)
 
-if test $ac_cv_sizeof_void_p = $ac_cv_sizeof_int; then
-   GPOINTER_TO_INT="((gint) (ptr))"
-   GPOINTER_TO_UINT="((guint) (ptr))"
-   GINT_TO_POINTER="((gpointer) (v))"
-   GUINT_TO_POINTER="((gpointer) (v))"
-   GSIZE="int"
-   GSIZE_FORMAT='"u"'
-elif test $ac_cv_sizeof_void_p = $ac_cv_sizeof_long; then
-   GPOINTER_TO_INT="((gint)(long) (ptr))"
-   GPOINTER_TO_UINT="((guint)(long) (ptr))"
-   GINT_TO_POINTER="((gpointer)(glong) (v))"
-   GUINT_TO_POINTER="((gpointer)(gulong) (v))"
-   GSIZE="long"
-   GSIZE_FORMAT='"lu"'
-elif test $ac_cv_sizeof_void_p = $ac_cv_sizeof_long_long; then
-   GPOINTER_TO_INT="((gint)(long long) (ptr))"
-   GPOINTER_TO_UINT="((guint)(unsigned long long) (ptr))"
-   GINT_TO_POINTER="((gpointer)(long long) (v))"
-   GUINT_TO_POINTER="((gpointer)(unsigned long long) (v))"
-   GSIZE="long long"
-   GSIZE_FORMAT='"I64u"'
+# If size_t/ptrdiff_t is correct, use it. Otherwise C99 [u]intptr_t.
+# This provides for an exact match with functions that
+# take size_t like malloc and pthread_attr_getstacksize.
+# uintptr_t is not quite the same.
+
+if test $ac_cv_sizeof_void_p = $ac_cv_sizeof_size_t; then
+   GSIZE="size_t"
+   GSSIZE="ptrdiff_t"
 else
-   AC_MSG_ERROR([unsupported pointer size])
+   GSIZE="uintptr_t"
+   GSSIZE="intptr_t"
 fi
 
-AC_SUBST(GPOINTER_TO_INT)
-AC_SUBST(GPOINTER_TO_UINT)
-AC_SUBST(GINT_TO_POINTER)
-AC_SUBST(GUINT_TO_POINTER)
 AC_SUBST(GSIZE)
-AC_SUBST(GSIZE_FORMAT)
-AC_SUBST(G_GUINT64_FORMAT)
-AC_SUBST(G_GINT64_FORMAT)
-AC_SUBST(G_GUINT32_FORMAT)
-AC_SUBST(G_GINT32_FORMAT)
+AC_SUBST(GSSIZE)
 
 #
 # END OF EGLIB CHECKS

--- a/configure.ac
+++ b/configure.ac
@@ -4176,7 +4176,7 @@ AC_SUBST(HAVE_ALLOCA_H)
 # of producing installable "biarch" headers. i.e. one Mac header
 # for Mac/x86 and Mac/amd64.
 
-AC_LANG_PUSH([C++])
+AC_LANG_PUSH(C++)
 
 # Check long before int because it is the overwhelming Unix answer,
 # across 32bit and 64bit systems -- fewer compiler invocations in autoconf.
@@ -4184,61 +4184,61 @@ AC_LANG_PUSH([C++])
 # long ahead of int also tends to produce biarch-compatible headers except Windows.
 #
 AC_MSG_CHECKING(if size_t is unsigned long)
-AC_COMPILE_IFELSE([
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([
 	#include <stddef.h>
 	unsigned long *a = (size_t*)0;
-], [
+])], [
 	AC_MSG_RESULT(yes)
 	AC_SUBST(GSIZE_FORMAT, '"%lu"')
 ], [
 	AC_MSG_RESULT(no)
 	AC_MSG_CHECKING(if size_t is unsigned int)
-	AC_COMPILE_IFELSE([
+	AC_COMPILE_IFELSE([AC_LANG_SOURCE([
 		#include <stddef.h>
 		unsigned *a = (size_t*)0;
-	], [
+	])], [
 		AC_MSG_RESULT(yes)
 		AC_SUBST(GSIZE_FORMAT, '"%u"')
 	], [
-# At this point the vast majority of systems have their answer,
+# At this point the majority of systems have their answer,
 # and we descend into non-standard or new-standard territory.
 #
 # Check __int64 first because I64 on some systems predates ll, enabling
 # new compiler/old runtime interop, and the types always have the same size.
 		AC_MSG_RESULT(no)
 		AC_MSG_CHECKING(if size_t is unsigned __int64)
-		AC_COMPILE_IFELSE([
+		AC_COMPILE_IFELSE([AC_LANG_SOURCE([
 			#include <stddef.h>
 			unsigned __int64 *a = (size_t*)0;
-		], [
+		])], [
 			AC_MSG_RESULT(yes)
 			AC_SUBST(GSIZE_FORMAT, '"%I64u"')
 		], [
 			AC_MSG_RESULT(no)
 			AC_MSG_CHECKING(if size_t is unsigned long long)
-			AC_COMPILE_IFELSE([
+			AC_COMPILE_IFELSE([AC_LANG_SOURCE([
 				#include <stddef.h>
 				unsigned long long *a = (size_t*)0;
-			], [
+			])], [
 				AC_MSG_RESULT(yes)
 				AC_SUBST(GSIZE_FORMAT, '"%llu"')
 			], [
 				AC_MSG_RESULT(no)
-				AC_MSG_ERROR(Unable to determine size_t among unsigned int, long, __int64, long long)
+				AC_MSG_ERROR(Unable to determine size_t among unsigned long, int, __int64, long long)
 			] )
 		] )
 	] )
 ] )
 
-AC_LANG_POP([C++])
+AC_LANG_POP
 
 # If size_t/ptrdiff_t is correct, use it. Otherwise C99 [u]intptr_t.
 # This provides for an exact match with functions that
 # take size_t like malloc and pthread_attr_getstacksize, avoiding warnings.
-# uintptr_t is not necessarily the same, but it probably is.
+# uintptr_t is not necessarily the same.
 #
 # ptrdiff_t is preferred over ssize_t as it is C89 vs. new Posix.
-# ssize_t looks prettier but ptrdiff_t is dressed up as gssize anyway.
+# ssize_t looks nicer but ptrdiff_t is wrapped up as gssize anyway.
 
 if test $ac_cv_sizeof_void_p = $ac_cv_sizeof_size_t; then
    GSIZE="size_t"

--- a/mono/eglib/eglib-config.h.in
+++ b/mono/eglib/eglib-config.h.in
@@ -14,19 +14,15 @@
 #define G_DIR_SEPARATOR_S        "@PATHSEP@"
 #define G_BREAKPOINT()           @BREAKPOINT@
 #define G_OS_@OS@
-#define GPOINTER_TO_INT(ptr)   @GPOINTER_TO_INT@
-#define GPOINTER_TO_UINT(ptr)  @GPOINTER_TO_UINT@
-#define GINT_TO_POINTER(v)     @GINT_TO_POINTER@
-#define GUINT_TO_POINTER(v)    @GUINT_TO_POINTER@
 
 #if @HAVE_ALLOCA_H@ == 1
 #define G_HAVE_ALLOCA_H
 #endif
 
-typedef unsigned @GSIZE@ gsize;
-typedef signed   @GSIZE@ gssize;
+typedef @GSIZE@ gsize;
+typedef @GSSIZE@ gssize;
 
-#define G_GSIZE_FORMAT   @GSIZE_FORMAT@
+#define G_GSIZE_FORMAT   "zu"
 
 #if @G_HAVE_ISO_VARARGS@ == 1
 #define G_HAVE_ISO_VARARGS

--- a/mono/eglib/eglib-config.h.in
+++ b/mono/eglib/eglib-config.h.in
@@ -22,7 +22,7 @@
 typedef @GSIZE@ gsize;
 typedef @GSSIZE@ gssize;
 
-#define G_GSIZE_FORMAT   "zu"
+#define G_GSIZE_FORMAT   @GSIZE_FORMAT@
 
 #if @G_HAVE_ISO_VARARGS@ == 1
 #define G_HAVE_ISO_VARARGS

--- a/mono/eglib/eglib-config.hw
+++ b/mono/eglib/eglib-config.hw
@@ -9,6 +9,7 @@
 #ifdef _MSC_VER
 
 #include <io.h>
+#include <stddef.h>
 
 #define G_GNUC_PRETTY_FUNCTION   __FUNCTION__
 #define G_GNUC_UNUSED            
@@ -17,23 +18,16 @@
 #define G_BREAKPOINT()           __debugbreak()
 #define MAXPATHLEN 242
 
-typedef uintptr_t gsize;
-typedef intptr_t gssize;
+typedef size_t gsize;
+typedef ptrdiff_t gssize;
 typedef int pid_t;
 
 #define G_DIR_SEPARATOR          '\\'
 #define G_DIR_SEPARATOR_S        "\\"
 #define G_SEARCHPATH_SEPARATOR_S ";"
 #define G_SEARCHPATH_SEPARATOR   ';'
-#ifdef _WIN64
-#define G_GSIZE_FORMAT   "I64u" // assuming Microsoft C runtime back to circa year 2000, newer supports "ll"
-#else
-#define G_GSIZE_FORMAT   "u"
-#endif
-#define GPOINTER_TO_INT(ptr)   ((gint)(intptr_t) (ptr))
-#define GPOINTER_TO_UINT(ptr)  ((guint)(intptr_t) (ptr))
-#define GINT_TO_POINTER(v)     ((gpointer)(intptr_t) (v))
-#define GUINT_TO_POINTER(v)    ((gpointer)(intptr_t) (v))
+
+#define G_GSIZE_FORMAT   "Iu"
 
 // https://msdn.microsoft.com/en-us/library/40bbyw78.aspx
 #define STDOUT_FILENO (1)

--- a/mono/eglib/eglib-config.hw
+++ b/mono/eglib/eglib-config.hw
@@ -27,7 +27,13 @@ typedef int pid_t;
 #define G_SEARCHPATH_SEPARATOR_S ";"
 #define G_SEARCHPATH_SEPARATOR   ';'
 
+#ifdef _WIN64
+// Correct for Win32 and Win64 since circa 2000.
 #define G_GSIZE_FORMAT   "Iu"
+#else
+// Correct for Win32 since circa 1992.
+#define G_GSIZE_FORMAT   "u"
+#endif
 
 // https://msdn.microsoft.com/en-us/library/40bbyw78.aspx
 #define STDOUT_FILENO (1)

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -17,6 +17,16 @@
 #include <inttypes.h>
 
 #include <eglib-config.h>
+
+// - Pointers should only be converted to or from pointer-sized integers.
+// - Any size integer can be converted to any other size integer.
+// - Therefore a pointer-sized integer is the intermediary between
+//   a pointer and any integer type.
+#define GPOINTER_TO_INT(ptr)   ((gint)(gssize)(ptr))
+#define GPOINTER_TO_UINT(ptr)  ((guint)(gsize)(ptr))
+#define GINT_TO_POINTER(v)     ((gpointer)(gssize)(v))
+#define GUINT_TO_POINTER(v)    ((gpointer)(gsize)(v))
+
 #ifndef EGLIB_NO_REMAP
 #include <eglib-remap.h>
 #endif
@@ -1135,6 +1145,3 @@ glong     g_utf8_pointer_to_offset (const gchar *str, const gchar *pos);
 G_END_DECLS
 
 #endif
-
-
-


### PR DESCRIPTION
If C99 zu is not portable enough, then autoconf can find the exact type.
Iu always works on Win64.
Very old Win32 would want plain u.

GINT_TO_POINTER and such need no autoconf, beyond chosing gsize, gssize.

Using size_t provides for an exact match with functions like malloc and pthread_attr_getstack, no warnings.