### PR TITLE
Cleanup varargs -- 3 variations to 1 and no malfunctioning autoconf.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4144,21 +4144,6 @@ if test $found_export_dynamic = no; then
 	LDFLAGS="${old_ldflags}"
 fi
 
-AC_MSG_CHECKING(for varargs macros)
-AC_TRY_COMPILE([],[
-int foo (int i, int j);
-#define bar(...) foo (1, __VA_ARGS__)
-void main () {
-	 bar (2);
-}
-],have_iso_varargs=yes,have_iso_varargs=no)
-AC_MSG_RESULT($have_iso_varargs)
-G_HAVE_ISO_VARARGS=0
-if test "x$have_iso_varargs" = "xyes"; then
-   G_HAVE_ISO_VARARGS=1
-fi
-AC_SUBST(G_HAVE_ISO_VARARGS)
-
 AC_CHECK_HEADERS(getopt.h sys/select.h sys/time.h sys/wait.h pwd.h iconv.h localcharset.h sys/types.h sys/resource.h)
 AC_CHECK_LIB([iconv], [locale_charset],[],[AC_CHECK_LIB([charset], [locale_charset],[LIBS+=" -liconv -lcharset"])])
 AC_CHECK_HEADER(alloca.h, [HAVE_ALLOCA_H=1], [HAVE_ALLOCA_H=0])

--- a/mono/eglib/eglib-config.h.in
+++ b/mono/eglib/eglib-config.h.in
@@ -28,10 +28,6 @@ typedef signed   @GSIZE@ gssize;
 
 #define G_GSIZE_FORMAT   @GSIZE_FORMAT@
 
-#if @G_HAVE_ISO_VARARGS@ == 1
-#define G_HAVE_ISO_VARARGS
-#endif
-
 #if defined (HOST_WATCHOS)
 #undef G_BREAKPOINT
 #define G_BREAKPOINT()

--- a/mono/utils/mono-logger-internals.h
+++ b/mono/utils/mono-logger-internals.h
@@ -88,49 +88,10 @@ mono_trace (GLogLevelFlags level, MonoTraceMask mask, const char *format, ...)
 	}
 }
 
-#ifdef G_HAVE_ISO_VARARGS
-#define mono_trace_error(...)	mono_trace(G_LOG_LEVEL_ERROR, \
-											__VA_ARGS__)
-#define mono_trace_warning(...) mono_trace(G_LOG_LEVEL_WARNING, \
-											__VA_ARGS__)
-#define mono_trace_message(...) mono_trace(G_LOG_LEVEL_MESSAGE, \
-											__VA_ARGS__)
-#elif defined(G_HAVE_GNUC_VARARGS)
-#define mono_trace_error(format...)	mono_trace(G_LOG_LEVEL_ERROR, \
-											format)
-#define mono_trace_warning(format...) mono_trace(G_LOG_LEVEL_WARNING, \
-											format)
-#define mono_trace_message(format...) mono_trace(G_LOG_LEVEL_MESSAGE, \
-											format)
-#else /* no varargs macros */
-G_GNUC_UNUSED static void
-mono_trace_error(MonoTraceMask mask, const char *format, ...)
-{
-	va_list args;
-	va_start (args, format);
-	mono_tracev(G_LOG_LEVEL_ERROR, mask, format, args);
-	va_end (args);
-}
-
-G_GNUC_UNUSED static void
-mono_trace_warning(MonoTraceMask mask, const char *format, ...)
-{
-	va_list args;
-	va_start (args, format);
-	mono_tracev(G_LOG_LEVEL_WARNING, mask, format, args);
-	va_end (args);
-}
-
-G_GNUC_UNUSED static void
-mono_trace_message(MonoTraceMask mask, const char *format, ...)
-{
-	va_list args;
-	va_start (args, format);
-	mono_tracev(G_LOG_LEVEL_MESSAGE, mask, format, args);
-	va_end (args);
-}
-
-#endif /* !__GNUC__ */
+// __VA_ARGS__ is never empty, so a comma before it is always correct.
+#define mono_trace_error(...)	(mono_trace (G_LOG_LEVEL_ERROR, __VA_ARGS__))
+#define mono_trace_warning(...) (mono_trace (G_LOG_LEVEL_WARNING, __VA_ARGS__))
+#define mono_trace_message(...) (mono_trace (G_LOG_LEVEL_MESSAGE, __VA_ARGS__))
 
 #if defined (HOST_ANDROID) || (defined (TARGET_IOS) && defined (TARGET_IOS))
 


### PR DESCRIPTION
Change 3 ifdef versions to one portable one.
Remove supporting autoconf that did not work as intended.
See https://github.com/mono/mono/issues/8587.