### PR TITLE
[wasm] Add .wasm mime mapping for python3 in server.py too

### DIFF
--- a/sdks/wasm/server.py
+++ b/sdks/wasm/server.py
@@ -26,6 +26,8 @@ if sys.version_info[0] == 3:
     PORT = 8000
 
     Handler = http.server.SimpleHTTPRequestHandler
+    Handler.extensions_map['.wasm'] = 'application/wasm'
+
     with socketserver.TCPServer(("", PORT), Handler) as httpd:
         print("python 3 serving at port", PORT)
         httpd.serve_forever()


### PR DESCRIPTION
It was only done in the python2 case. Noticed this while answering a contributor question on gitter.