### PR TITLE
[tools]: resx2sr now takes an '-i file' argument.

### DIFF
--- a/mcs/build/library.make
+++ b/mcs/build/library.make
@@ -390,9 +390,9 @@ gen-deps:
 
 update-corefx-sr-generic:
 ifneq ($(RESX_STRINGS),)
-	MONO_PATH="$(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(RUNTIME) $(RUNTIME_FLAGS) $(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)/resx2sr.exe $(RESX_STRINGS) >$(SR_OUTPUT)
+	MONO_PATH="$(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(RUNTIME) $(RUNTIME_FLAGS) $(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)/resx2sr.exe $(RESX_EXTRA_ARGUMENTS) $(RESX_STRINGS) >$(SR_OUTPUT)
 endif
 
 update-corefx-sr: $(RESX_RESOURCE_STRING) $(XTEST_RESX_RESOURCE_STRING)
-	make SR_OUTPUT=corefx/SR.cs RESX_STRINGS="$(RESX_RESOURCE_STRING)" update-corefx-sr-generic \
+	make SR_OUTPUT=corefx/SR.cs RESX_STRINGS="$(RESX_RESOURCE_STRING)" RESX_EXTRA_ARGUMENTS="$(RESX_EXTRA_ARGUMENTS)" update-corefx-sr-generic \
 	&& make SR_OUTPUT=corefx/SR.tests.cs RESX_STRINGS=$(XTEST_RESX_RESOURCE_STRING) update-corefx-sr-generic

--- a/mcs/class/System/Makefile
+++ b/mcs/class/System/Makefile
@@ -14,6 +14,10 @@ RESOURCE_FILES = \
 	resources/Question.wav
 endif
 
+RESX_EXTRA_ARGUMENTS = \
+	--in=ReferenceSources/SR.cs \
+	--in=ReferenceSources/SR2.cs
+
 RESX_RESOURCE_STRING = \
 	../../../external/corefx/src/System.Collections.Concurrent/src/Resources/Strings.resx \
 	../../../external/corefx/src/System.Collections/src/Resources/Strings.resx \
@@ -22,6 +26,9 @@ RESX_RESOURCE_STRING = \
 	../../../external/corefx/src/System.IO.Ports/src/Resources/Strings.resx \
 	../../../external/corefx/src/System.Net.HttpListener/src/Resources/Strings.resx \
 	../../../external/corefx/src/System.Net.Requests/src/Resources/Strings.resx	\
+	../../../external/corefx/src/System.Net.Http/src/Resources/Strings.resx \
+	../../../external/corefx/src/System.Text.RegularExpressions/src/Resources/Strings.resx \
+	../../../external/corefx/src/System.IO.FileSystem.Watcher/src/Resources/Strings.resx \
 	../../../external/corefx/src/System.ComponentModel.TypeConverter/src/Resources/Strings.resx
 
 TEST_RESOURCES = \


### PR DESCRIPTION
Pass all manually created 'SR.cs' files using the new `-i` argument and it will automatically eliminate all duplicates.

We can now pass extra arguments to the `resx2sr` tool via `RESX_EXTRA_ARGUMENTS`.

Use this in `mcs/class/System/Makefile` to add `ReferenceSources/SR.cs` and `ReferenceSources/SR2.cs` to the input list.