### PR TITLE
[runtime] Transition to GC Unsafe in MONO_API functions

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -3110,12 +3110,13 @@ mono_class_from_name_checked (MonoImage *image, const char* name_space, const ch
 MonoClass *
 mono_class_from_name (MonoImage *image, const char* name_space, const char *name)
 {
-	ERROR_DECL (error);
 	MonoClass *klass;
+	MONO_ENTER_GC_UNSAFE;
+	ERROR_DECL (error);
 
 	klass = mono_class_from_name_checked (image, name_space, name, error);
 	mono_error_cleanup (error); /* FIXME Don't swallow the error */
-
+	MONO_EXIT_GC_UNSAFE;
 	return klass;
 }
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -2831,7 +2831,6 @@ mono_object_get_virtual_method (MonoObject *obj_raw, MonoMethod *method)
 	HANDLE_FUNCTION_ENTER ();
 	MonoMethod *result;
 	MONO_ENTER_GC_UNSAFE;
-	MONO_REQ_GC_UNSAFE_MODE;
 	ERROR_DECL (error);
 	MONO_HANDLE_DCL (MonoObject, obj);
 	result = mono_object_handle_get_virtual_method (obj, method, error);
@@ -6146,7 +6145,6 @@ mono_array_new (MonoDomain *domain, MonoClass *eclass, uintptr_t n)
 {
 	MonoArray *result;
 	MONO_ENTER_GC_UNSAFE;
-	MONO_REQ_GC_UNSAFE_MODE;
 
 	ERROR_DECL (error);
 	result = mono_array_new_checked (domain, eclass, n, error);
@@ -6611,7 +6609,6 @@ mono_string_new_wrapper (const char *text)
 {
 	MonoString *res;
 	MONO_ENTER_GC_UNSAFE;
-	MONO_REQ_GC_UNSAFE_MODE;
 
 	res = mono_string_new_internal (mono_domain_get (), text);
 	MONO_EXIT_GC_UNSAFE;
@@ -6831,7 +6828,6 @@ mono_object_get_class (MonoObject *obj)
 {
 	MonoClass *res;
 	MONO_ENTER_GC_UNSAFE;
-	MONO_REQ_GC_UNSAFE_MODE;
 
 	res = mono_object_class (obj);
 	MONO_EXIT_GC_UNSAFE;
@@ -6877,7 +6873,6 @@ mono_object_unbox (MonoObject *obj)
 {
 	gpointer res;
 	MONO_ENTER_GC_UNSAFE;
-	MONO_REQ_GC_UNSAFE_MODE;
 
 	/* add assert for valuetypes? */
 	g_assert (m_class_is_valuetype (mono_object_class (obj)));
@@ -6898,7 +6893,6 @@ mono_object_isinst (MonoObject *obj_raw, MonoClass *klass)
 	HANDLE_FUNCTION_ENTER ();
 	MonoObjectHandle result;
 	MONO_ENTER_GC_UNSAFE;
-	MONO_REQ_GC_UNSAFE_MODE;
 
 	MONO_HANDLE_DCL (MonoObject, obj);
 	ERROR_DECL (error);
@@ -8792,7 +8786,6 @@ mono_array_addr_with_size (MonoArray *array, int size, uintptr_t idx)
 {
 	char *res;
 	MONO_ENTER_GC_UNSAFE;
-	MONO_REQ_GC_UNSAFE_MODE;
 
 	res = ((char*)(array)->vector) + size * idx;
 	MONO_EXIT_GC_UNSAFE;

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -2828,12 +2828,15 @@ leave:
 MonoMethod*
 mono_object_get_virtual_method (MonoObject *obj_raw, MonoMethod *method)
 {
-	MONO_REQ_GC_UNSAFE_MODE;
 	HANDLE_FUNCTION_ENTER ();
+	MonoMethod *result;
+	MONO_ENTER_GC_UNSAFE;
+	MONO_REQ_GC_UNSAFE_MODE;
 	ERROR_DECL (error);
 	MONO_HANDLE_DCL (MonoObject, obj);
-	MonoMethod *result = mono_object_handle_get_virtual_method (obj, method, error);
+	result = mono_object_handle_get_virtual_method (obj, method, error);
 	mono_error_assert_ok (error);
+	MONO_EXIT_GC_UNSAFE;
 	HANDLE_FUNCTION_RETURN_VAL (result);
 }
 
@@ -2862,6 +2865,7 @@ mono_object_handle_get_virtual_method (MonoObjectHandle obj, MonoMethod *method,
 static MonoMethod*
 class_get_virtual_method (MonoClass *klass, MonoMethod *method, gboolean is_proxy, MonoError *error)
 {
+	MONO_REQ_GC_NEUTRAL_MODE;
 	error_init (error);
 
 
@@ -2984,8 +2988,9 @@ do_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **ex
 MonoObject*
 mono_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **exc)
 {
-	ERROR_DECL (error);
 	MonoObject *res;
+	MONO_ENTER_GC_UNSAFE;
+	ERROR_DECL (error);
 	if (exc) {
 		res = mono_runtime_try_invoke (method, obj, params, exc, error);
 		if (*exc == NULL && !mono_error_ok(error)) {
@@ -2996,6 +3001,7 @@ mono_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **
 		res = mono_runtime_invoke_checked (method, obj, params, error);
 		mono_error_raise_exception_deprecated (error); /* OK to throw, external only without a good alternative */
 	}
+	MONO_EXIT_GC_UNSAFE;
 	return res;
 }
 
@@ -3412,9 +3418,12 @@ mono_field_get_value (MonoObject *obj, MonoClassField *field, void *value)
 MonoObject *
 mono_field_get_value_object (MonoDomain *domain, MonoClassField *field, MonoObject *obj)
 {	
+	MonoObject* result;
+	MONO_ENTER_GC_UNSAFE;
 	ERROR_DECL (error);
-	MonoObject* result = mono_field_get_value_object_checked (domain, field, obj, error);
+	result = mono_field_get_value_object_checked (domain, field, obj, error);
 	mono_error_assert_ok (error);
+	MONO_EXIT_GC_UNSAFE;
 	return result;
 }
 
@@ -4782,6 +4791,7 @@ mono_runtime_exec_managed_code (MonoDomain *domain,
 static void
 prepare_thread_to_exec_main (MonoDomain *domain, MonoMethod *method)
 {
+	MONO_REQ_GC_UNSAFE_MODE;
 	MonoInternalThread* thread = mono_thread_internal_current ();
 	MonoCustomAttrInfo* cinfo;
 	gboolean has_stathread_attribute;
@@ -4923,16 +4933,18 @@ do_try_exec_main (MonoMethod *method, MonoArray *args, MonoObject **exc)
 int
 mono_runtime_exec_main (MonoMethod *method, MonoArray *args, MonoObject **exc)
 {
+	int rval;
+	MONO_ENTER_GC_UNSAFE;
 	ERROR_DECL (error);
 	prepare_thread_to_exec_main (mono_object_domain (args), method);
 	if (exc) {
-		int rval = do_try_exec_main (method, args, exc);
-		return rval;
+		rval = do_try_exec_main (method, args, exc);
 	} else {
-		int rval = do_exec_main_checked (method, args, error);
+		rval = do_exec_main_checked (method, args, error);
 		mono_error_raise_exception_deprecated (error); /* OK to throw, external only with no better option */
-		return rval;
 	}
+	MONO_EXIT_GC_UNSAFE;
+	return rval;
 }
 
 /*
@@ -6132,11 +6144,14 @@ mono_array_new_full_checked (MonoDomain *domain, MonoClass *array_class, uintptr
 MonoArray *
 mono_array_new (MonoDomain *domain, MonoClass *eclass, uintptr_t n)
 {
+	MonoArray *result;
+	MONO_ENTER_GC_UNSAFE;
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	ERROR_DECL (error);
-	MonoArray *result = mono_array_new_checked (domain, eclass, n, error);
+	result = mono_array_new_checked (domain, eclass, n, error);
 	mono_error_cleanup (error);
+	MONO_EXIT_GC_UNSAFE;
 	return result;
 }
 
@@ -6486,7 +6501,11 @@ mono_string_new_internal (MonoDomain *domain, const char *text)
 MonoString*
 mono_string_new (MonoDomain *domain, const char *text)
 {
-	return mono_string_new_internal (domain, text);
+	MonoString *res;
+	MONO_ENTER_GC_UNSAFE;
+	res = mono_string_new_internal (domain, text);
+	MONO_EXIT_GC_UNSAFE;
+	return res;
 }
 
 /**
@@ -6590,9 +6609,13 @@ mono_string_new_wtf8_len_checked (MonoDomain *domain, const char *text, guint le
 MonoString*
 mono_string_new_wrapper (const char *text)
 {
+	MonoString *res;
+	MONO_ENTER_GC_UNSAFE;
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	return mono_string_new_internal (mono_domain_get (), text);
+	res = mono_string_new_internal (mono_domain_get (), text);
+	MONO_EXIT_GC_UNSAFE;
+	return res;
 }
 
 /**
@@ -6806,9 +6829,13 @@ mono_object_get_domain (MonoObject *obj)
 MonoClass*
 mono_object_get_class (MonoObject *obj)
 {
+	MonoClass *res;
+	MONO_ENTER_GC_UNSAFE;
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	return mono_object_class (obj);
+	res = mono_object_class (obj);
+	MONO_EXIT_GC_UNSAFE;
+	return res;
 }
 /**
  * mono_object_get_size:
@@ -6848,11 +6875,15 @@ mono_object_get_size (MonoObject* o)
 gpointer
 mono_object_unbox (MonoObject *obj)
 {
+	gpointer res;
+	MONO_ENTER_GC_UNSAFE;
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	/* add assert for valuetypes? */
 	g_assert (m_class_is_valuetype (mono_object_class (obj)));
-	return ((char*)obj) + sizeof (MonoObject);
+	res = ((char*)obj) + sizeof (MonoObject);
+	MONO_EXIT_GC_UNSAFE;
+	return res;
 }
 
 /**
@@ -6864,13 +6895,16 @@ mono_object_unbox (MonoObject *obj)
 MonoObject *
 mono_object_isinst (MonoObject *obj_raw, MonoClass *klass)
 {
+	HANDLE_FUNCTION_ENTER ();
+	MonoObjectHandle result;
+	MONO_ENTER_GC_UNSAFE;
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	HANDLE_FUNCTION_ENTER ();
 	MONO_HANDLE_DCL (MonoObject, obj);
 	ERROR_DECL (error);
-	MonoObjectHandle result = mono_object_handle_isinst (obj, klass, error);
+	result = mono_object_handle_isinst (obj, klass, error);
 	mono_error_cleanup (error);
+	MONO_EXIT_GC_UNSAFE;
 	HANDLE_FUNCTION_RETURN_OBJ (result);
 }
 	
@@ -8756,9 +8790,13 @@ mono_array_length (MonoArray *array)
 char*
 mono_array_addr_with_size (MonoArray *array, int size, uintptr_t idx)
 {
+	char *res;
+	MONO_ENTER_GC_UNSAFE;
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	return ((char*)(array)->vector) + size * idx;
+	res = ((char*)(array)->vector) + size * idx;
+	MONO_EXIT_GC_UNSAFE;
+	return res;
 }
 
 

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -426,10 +426,12 @@ mono_type_normalize (MonoType *type)
 MonoReflectionType*
 mono_type_get_object (MonoDomain *domain, MonoType *type)
 {
+	MonoReflectionType *ret;
+	MONO_ENTER_GC_UNSAFE;
 	ERROR_DECL (error);
-	MonoReflectionType *ret = mono_type_get_object_checked (domain, type, error);
+	ret = mono_type_get_object_checked (domain, type, error);
 	mono_error_cleanup (error);
-
+	MONO_EXIT_GC_UNSAFE;
 	return ret;
 }
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -848,15 +848,6 @@ mono_jit_thread_attach (MonoDomain *domain)
 	attached = mono_tls_get_jit_tls () != NULL;
 
 	if (!attached) {
-		if (mono_threads_is_blocking_transition_enabled ()) {
-			/* This should only happen when we come in from Xamarin.Mac because they have
-			 * code that calls it before they start messing with managed objects.
-			 * We're committed to switching the runtime to UNSAFE when they do so.
-			 */
-			g_warning ("JIT Attaching thread %" G_GSIZE_FORMAT " to mono", mono_native_thread_id_get ());
-		}
-
-
 		mono_thread_attach (domain);
 
 		// #678164

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -907,7 +907,6 @@ mono_vcall_trampoline (mgreg_t *regs, guint8 *code, int slot, guint8 *tramp)
 {
 	gpointer res;
 	MONO_ENTER_GC_UNSAFE;
-	MONO_REQ_GC_UNSAFE_MODE;
 
 	MonoObject *this_arg;
 	MonoVTable *vt;

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -881,7 +881,7 @@ mono_magic_trampoline (mgreg_t *regs, guint8 *code, gpointer arg, guint8* tramp)
 	gpointer res;
 	ERROR_DECL (error);
 
-	MONO_REQ_GC_UNSAFE_MODE;
+	MONO_ENTER_GC_UNSAFE;
 
 	g_assert (mono_thread_is_gc_unsafe_mode ());
 
@@ -890,9 +890,10 @@ mono_magic_trampoline (mgreg_t *regs, guint8 *code, gpointer arg, guint8* tramp)
 	res = common_call_trampoline (regs, code, (MonoMethod *)arg, NULL, NULL, error);
 	if (!is_ok (error)) {
 		mono_error_set_pending_exception (error);
-		return NULL;
+		res = NULL;
 	}
 
+	MONO_EXIT_GC_UNSAFE;
 	return res;
 }
 
@@ -904,6 +905,8 @@ mono_magic_trampoline (mgreg_t *regs, guint8 *code, gpointer arg, guint8* tramp)
 static gpointer
 mono_vcall_trampoline (mgreg_t *regs, guint8 *code, int slot, guint8 *tramp)
 {
+	gpointer res;
+	MONO_ENTER_GC_UNSAFE;
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	MonoObject *this_arg;
@@ -911,7 +914,8 @@ mono_vcall_trampoline (mgreg_t *regs, guint8 *code, int slot, guint8 *tramp)
 	gpointer *vtable_slot;
 	MonoMethod *m;
 	ERROR_DECL (error);
-	gpointer addr, res = NULL;
+	gpointer addr;
+	res = NULL;
 
 	UnlockedIncrement (&trampoline_calls);
 
@@ -942,7 +946,8 @@ mono_vcall_trampoline (mgreg_t *regs, guint8 *code, int slot, guint8 *tramp)
 			if (mono_domain_owns_vtable_slot (mono_domain_get (), vtable_slot))
 				*vtable_slot = addr;
 
-			return mono_create_ftnptr (mono_domain_get (), addr);
+			res = mono_create_ftnptr (mono_domain_get (), addr);
+			goto leave;
 		}
 
 		/*
@@ -970,8 +975,9 @@ mono_vcall_trampoline (mgreg_t *regs, guint8 *code, int slot, guint8 *tramp)
 leave:
 	if (!mono_error_ok (error)) {
 		mono_error_set_pending_exception (error);
-		return NULL;
+		res = NULL;
 	}
+	MONO_EXIT_GC_UNSAFE;
 	return res;
 }
 


### PR DESCRIPTION
The idea is that on any external->runtime transition we want to ensure that we
switch to GC Unsafe mode (and back on return).  This allows Mono embedders to
be oblivous about hybrid suspend - the runtime will run native embedder code in
GC Safe mode (and use preemptive suspend when necessary) and when they switch
back to the runtime we will switch to GC Unsafe mode (and use cooperative suspend).

This is just the initial set of transitions that was enough to get the Xwt sample apps and VSfM up and running without assertions.  The rest of the Mono API functions need to be updated too.