### PR TITLE
[corlib]: Misc updates from CoreFX.

### DIFF
--- a/mcs/class/System.Numerics/Test/System.Numerics/BigIntegerTest.cs
+++ b/mcs/class/System.Numerics/Test/System.Numerics/BigIntegerTest.cs
@@ -974,7 +974,7 @@ namespace MonoTests.System.Numerics
 		[Test]
 		public void TryParse () {
 			BigInteger x = BigInteger.One;
-			Assert.IsFalse (BigInteger.TryParse (null, out x), "#1");
+			Assert.IsFalse (BigInteger.TryParse ((string)null, out x), "#1");
 			Assert.AreEqual (0, (int)x, "#1a");
 			Assert.IsFalse (BigInteger.TryParse ("", out x), "#2");
 			Assert.IsFalse (BigInteger.TryParse (" ", out x), "#3");

--- a/mcs/class/corlib/ReferenceSources/String.cs
+++ b/mcs/class/corlib/ReferenceSources/String.cs
@@ -60,6 +60,13 @@ namespace System
 				return new ReadOnlySpan<char> (start, value.Length);
 		}
 
+		public unsafe static implicit operator String (ReadOnlySpan<char> value)
+		{
+			if (value == null)
+				return default;
+			return new String (value);
+		}
+
 		internal unsafe int IndexOfUnchecked (string value, int startIndex, int count)
 		{
 			int valueLen = value.Length;

--- a/mcs/class/corlib/Test/System.IO/PathTest.cs
+++ b/mcs/class/corlib/Test/System.IO/PathTest.cs
@@ -434,7 +434,7 @@ namespace MonoTests.System.IO
 			string testFileName = Path.GetFileName (path1);
 
 			Assert.AreEqual ("test.txt", testFileName, "#1");
-			testFileName = Path.GetFileName (null);
+			testFileName = Path.GetFileName ((string)null);
 			Assert.AreEqual (null, testFileName, "#2");
 			testFileName = Path.GetFileName (String.Empty);
 			Assert.AreEqual (String.Empty, testFileName, "#3");

--- a/mcs/class/corlib/corlib.csproj
+++ b/mcs/class/corlib/corlib.csproj
@@ -331,6 +331,7 @@
     <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\src\System\Runtime\CompilerServices\TaskAwaiter.cs" />
     <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\src\System\String.Comparison.cs" />
     <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\src\System\String.cs" />
+    <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\src\System\Threading\CancellationTokenRegistration.cs" />
     <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\src\System\Threading\LockHolder.cs" />
     <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\src\System\Threading\Tasks\ConcurrentExclusiveSchedulerPair.cs" />
     <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\src\System\Threading\Tasks\DebuggerSupport.cs" />
@@ -908,7 +909,6 @@
     <Compile Include="..\referencesource\mscorlib\system\threading\asynclocal.cs" />
     <Compile Include="..\referencesource\mscorlib\system\threading\autoresetevent.cs" />
     <Compile Include="..\referencesource\mscorlib\system\threading\CancellationToken.cs" />
-    <Compile Include="..\referencesource\mscorlib\system\threading\CancellationTokenRegistration.cs" />
     <Compile Include="..\referencesource\mscorlib\system\threading\CancellationTokenSource.cs" />
     <Compile Include="..\referencesource\mscorlib\system\threading\CountdownEvent.cs" />
     <Compile Include="..\referencesource\mscorlib\system\threading\eventresetmode.cs" />

--- a/mcs/class/corlib/corlib.dll.sources
+++ b/mcs/class/corlib/corlib.dll.sources
@@ -1488,7 +1488,6 @@ ReferenceSources/AppContextDefaultValues.cs
 ../referencesource/mscorlib/system/threading/asynclocal.cs
 ../referencesource/mscorlib/system/threading/autoresetevent.cs
 ../referencesource/mscorlib/system/threading/CancellationToken.cs
-../referencesource/mscorlib/system/threading/CancellationTokenRegistration.cs
 ../referencesource/mscorlib/system/threading/CancellationTokenSource.cs
 ../referencesource/mscorlib/system/threading/CountdownEvent.cs
 ../referencesource/mscorlib/system/threading/eventresetmode.cs
@@ -1523,6 +1522,7 @@ ReferenceSources/AppContextDefaultValues.cs
 ../referencesource/mscorlib/system/threading/waithandleExtensions.cs
 
 ../referencesource/mscorlib/system/threading/Tasks/AsyncCausalityTracer.cs
+../../../external/corert/src/System.Private.CoreLib/src/System/Threading/CancellationTokenRegistration.cs
 ../../../external/corert/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskExceptionHolder.cs
 ../../../external/corert/src/System.Private.CoreLib/src/System/Threading/Tasks/ConcurrentExclusiveSchedulerPair.cs
 ../../../external/corert/src/System.Private.CoreLib/src/System/Threading/Tasks/ProducerConsumerQueues.cs

--- a/mcs/class/referencesource/mscorlib/system/bitconverter.cs
+++ b/mcs/class/referencesource/mscorlib/system/bitconverter.cs
@@ -483,6 +483,24 @@ namespace System {
             return Unsafe.ReadUnaligned<int>(ref value.DangerousGetPinnableReference());
         }
 
+        // Convert a Span into a uint
+        [CLSCompliant(false)]
+        public static uint ToUInt32(ReadOnlySpan<byte> value)
+        {
+            if (value.Length < sizeof(uint))
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.value);
+	        return Unsafe.ReadUnaligned<uint>(ref value.DangerousGetPinnableReference());
+        }
+
+        // Converts a Span into an unsigned long
+        [CLSCompliant(false)]
+        public static ulong ToUInt64(ReadOnlySpan<byte> value)
+        {
+            if (value.Length < sizeof(ulong))
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.value);
+            return Unsafe.ReadUnaligned<ulong>(ref value.DangerousGetPinnableReference());
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe int SingleToInt32Bits(float value)
         {

--- a/mcs/class/referencesource/mscorlib/system/timespan.cs
+++ b/mcs/class/referencesource/mscorlib/system/timespan.cs
@@ -379,6 +379,26 @@ namespace System {
             return t1._ticks >= t2._ticks;
         }
 
+        public static TimeSpan operator / (TimeSpan timeSpan, double divisor)
+        {
+            if (double.IsNaN (divisor)) {
+                throw new ArgumentException (SR.Arg_CannotBeNaN, nameof (divisor));
+            }
+
+            double ticks = Math.Round (timeSpan.Ticks / divisor);
+            if (ticks > long.MaxValue | ticks < long.MinValue || double.IsNaN (ticks)) {
+                throw new OverflowException (SR.Overflow_TimeSpanTooLong);
+            }
+
+            return FromTicks ((long)ticks);
+        }
+
+        // Using floating-point arithmetic directly means that infinities can be returned, which is reasonable
+        // if we consider TimeSpan.FromHours(1) / TimeSpan.Zero asks how many zero-second intervals there are in
+        // an hour for which infinity is the mathematic correct answer. Having TimeSpan.Zero / TimeSpan.Zero return NaN
+        // is perhaps less useful, but no less useful than an exception.
+        public static double operator /(TimeSpan t1, TimeSpan t2) => t1.Ticks / (double)t2.Ticks;
+
 
         //
         // In .NET Framework v1.0 - v3.5 System.TimeSpan did not implement IFormattable


### PR DESCRIPTION
* `CancellationTokenRegistration`: use the CoreFX version.

* `String`: add `implicit operator String (ReadOnlySpan<char> value)`.

* `TimeSpan`: add `TimeSpan operator / (TimeSpan timeSpan, double divisor)`
  and `double operator /(TimeSpan t1, TimeSpan t2)`.

* `BitConverter`: add `uint ToUInt32(ReadOnlySpan<byte> value)` and
  `ulong ToUInt64(ReadOnlySpan<byte> value)`.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
