### PR TITLE
[System]: Allow `SecurityProtocolType.SystemDefault` (#7340).

### DIFF
--- a/mcs/class/System/Mono.AppleTls/AppleTlsContext.cs
+++ b/mcs/class/System/Mono.AppleTls/AppleTlsContext.cs
@@ -279,18 +279,25 @@ namespace Mono.AppleTls
 			result = SSLSetConnection (Handle, GCHandle.ToIntPtr (handle));
 			CheckStatusAndThrow (result);
 
+			/*
+			 * If 'EnabledProtocols' is zero, then we use the system default values.
+			 *
+			 * In CoreFX, 'ServicePointManager.SecurityProtocol' defaults to
+			 * 'SecurityProtocolType.SystemDefault', which is zero.
+			 */
+
 			if ((EnabledProtocols & SSA.SslProtocols.Tls) != 0)
 				MinProtocol = SslProtocol.Tls_1_0;
 			else if ((EnabledProtocols & SSA.SslProtocols.Tls11) != 0)
 				MinProtocol = SslProtocol.Tls_1_1;
-			else
+			else if ((EnabledProtocols & SSA.SslProtocols.Tls12) != 0)
 				MinProtocol = SslProtocol.Tls_1_2;
 
 			if ((EnabledProtocols & SSA.SslProtocols.Tls12) != 0)
 				MaxProtocol = SslProtocol.Tls_1_2;
 			else if ((EnabledProtocols & SSA.SslProtocols.Tls11) != 0)
 				MaxProtocol = SslProtocol.Tls_1_1;
-			else
+			else if ((EnabledProtocols & SSA.SslProtocols.Tls) != 0)
 				MaxProtocol = SslProtocol.Tls_1_0;
 
 			if (Settings != null && Settings.EnabledCiphers != null) {

--- a/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
@@ -236,11 +236,13 @@ namespace Mono.Btls
 
 			ctx.SetVerifyParam (MonoBtlsProvider.GetVerifyParam (Settings, ServerName, IsServer));
 
-			TlsProtocolCode minProtocol, maxProtocol;
+			TlsProtocolCode? minProtocol, maxProtocol;
 			GetProtocolVersions (out minProtocol, out maxProtocol);
 
-			ctx.SetMinVersion ((int)minProtocol);
-			ctx.SetMaxVersion ((int)maxProtocol);
+			if (minProtocol != null)
+				ctx.SetMinVersion ((int)minProtocol.Value);
+			if (maxProtocol != null)
+				ctx.SetMaxVersion ((int)maxProtocol.Value);
 
 			if (Settings != null && Settings.EnabledCiphers != null) {
 				var ciphers = new short [Settings.EnabledCiphers.Length];

--- a/mcs/class/System/Mono.Net.Security/MobileTlsContext.cs
+++ b/mcs/class/System/Mono.Net.Security/MobileTlsContext.cs
@@ -116,21 +116,25 @@ namespace Mono.Net.Security
 			get { return clientCertificates; }
 		}
 
-		protected void GetProtocolVersions (out TlsProtocolCode min, out TlsProtocolCode max)
+		protected void GetProtocolVersions (out TlsProtocolCode? min, out TlsProtocolCode? max)
 		{
 			if ((enabledProtocols & SslProtocols.Tls) != 0)
 				min = TlsProtocolCode.Tls10;
 			else if ((enabledProtocols & SslProtocols.Tls11) != 0)
 				min = TlsProtocolCode.Tls11;
-			else
+			else if ((enabledProtocols & SslProtocols.Tls12) != 0)
 				min = TlsProtocolCode.Tls12;
+			else
+				min = null;
 
 			if ((enabledProtocols & SslProtocols.Tls12) != 0)
 				max = TlsProtocolCode.Tls12;
 			else if ((enabledProtocols & SslProtocols.Tls11) != 0)
 				max = TlsProtocolCode.Tls11;
-			else
+			else if ((enabledProtocols & SslProtocols.Tls) != 0)
 				max = TlsProtocolCode.Tls10;
+			else
+				max = null;
 		}
 
 		public abstract void StartHandshake ();

--- a/mcs/class/System/System.Net/ServicePointManager.cs
+++ b/mcs/class/System/System.Net/ServicePointManager.cs
@@ -120,7 +120,7 @@ namespace System.Net
 		private static int maxServicePoints = 0;
 		private static int dnsRefreshTimeout = 2 * 60 * 1000;
 		private static bool _checkCRL = false;
-		private static SecurityProtocolType _securityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+		private static SecurityProtocolType _securityProtocol = SecurityProtocolType.SystemDefault;
 
 		static bool expectContinue = true;
 		static bool useNagle;


### PR DESCRIPTION
In CoreFX, `ServicePointManager.SecurityProtocol` defaults to
`SecurityProtocolType.SystemDefault` (which is zero).

We now allow this value to mean "whatever the system default is"
in both AppleTls and BTLS.

The default value of `ServicePointManager.SecurityProtocol` has also
been changed to be consistent with CoreFX.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
