### PR TITLE
[runtime] Fix debug_log prototype in runtime callbacks

### DIFF
--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -618,7 +618,7 @@ typedef struct {
 	gpointer (*get_imt_trampoline) (MonoVTable *vtable, int imt_slot_index);
 	gboolean (*imt_entry_inited) (MonoVTable *vtable, int imt_slot_index);
 	void     (*set_cast_details) (MonoClass *from, MonoClass *to);
-	void     (*debug_log) (int level, MonoString *category, MonoString *message);
+	void     (*debug_log) (int level, MonoStringHandle category, MonoStringHandle message);
 	gboolean (*debug_log_is_enabled) (void);
 	void     (*init_delegate) (MonoDelegate *del);
 	MonoObject* (*runtime_invoke) (MonoMethod *method, void *obj, void **params, MonoObject **exc, MonoError *error);


### PR DESCRIPTION
The debug log fnptr is used with MonoStringHandle arguments since
cc7406b2269560bf960e7924fd0d3006ddbdf0e9

The corresponding functions and prototypes in mini/ have already been updated.
