### PR TITLE
Enable mono-state-based telemetry for crashing on CI

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -993,6 +993,7 @@ fi
 
 AC_ARG_WITH(crash-privacy,       [  --with-crash_privacy=yes,no         If you want your crashes to not include names of symbols present in the binary. ], [], [with_crash_privacy=no])
 AC_ARG_WITH(structured-crashes,  [  --with-structured_crashes=yes,no    If you want your unmanaged crashes to result in a small crash dump file. ],        [], [with_structured_crashes=yes])
+AC_ARG_ENABLE(crash-reporting,  [  --disable-crash-reporting            Enable or Disable crash reporting subsystem],        [crash_reporting=$enableval], [crash_reporting=yes])
 
 if test "x$with_crash_privacy" = "xno"; then
 AC_DEFINE(MONO_PRIVATE_CRASHES,1,[Do not include names of unmanaged functions in the crash dump])
@@ -1003,7 +1004,12 @@ AC_DEFINE(DISABLE_STRUCTURED_CRASH,1,[Do not create structured crash files durin
 fi
 
 if test "x$host_win32" = "xyes"; then
-AC_DEFINE(DISABLE_CRASH_REPORTING,1,[Do not use cooperative crash reporter])
+crash_reporting=no
+fi
+
+if test "x$crash_reporting" != "xyes"; then
+CFLAGS="$CFLAGS -DDISABLE_CRASH_REPORTING=1"
+CXXFLAGS="$CXXFLAGS -DDISABLE_CRASH_REPORTING=1"
 fi
 
 AC_ARG_ENABLE(monodroid, [ --enable-monodroid Enable runtime support for Monodroid (Xamarin.Android)], enable_monodroid=$enableval, enable_monodroid=no)
@@ -5735,6 +5741,7 @@ echo "
 	zlib:            $zlib_msg
 	BTLS:            $enable_btls$btls_platform_string
 	jemalloc:        $with_jemalloc (always use: $with_jemalloc_always)
+	crash reporting: $crash_reporting
 	$disabled
 "
 if test x$with_static_mono = xno -a "x$host_win32" != "xyes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -1002,6 +1002,10 @@ if test "x$with_structured_crashes" = "xno"; then
 AC_DEFINE(DISABLE_STRUCTURED_CRASH,1,[Do not create structured crash files during unmanaged crashes])
 fi
 
+if test "x$host_win32" = "xyes"; then
+AC_DEFINE(DISABLE_CRASH_REPORTING,1,[Do not use cooperative crash reporter])
+fi
+
 AC_ARG_ENABLE(monodroid, [ --enable-monodroid Enable runtime support for Monodroid (Xamarin.Android)], enable_monodroid=$enableval, enable_monodroid=no)
 AM_CONDITIONAL(ENABLE_MONODROID, test x$enable_monodroid = xyes)
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -675,9 +675,7 @@ typedef struct {
 	gpointer (*create_delegate_trampoline) (MonoDomain *domain, MonoClass *klass);
 	gpointer (*interp_get_remoting_invoke) (gpointer imethod, MonoError *error);
 	GHashTable *(*get_weak_field_indexes) (MonoImage *image);
-#ifdef TARGET_OSX
 	void     (*install_state_summarizer) (void);
-#endif
 } MonoRuntimeCallbacks;
 
 typedef gboolean (*MonoInternalStackWalk) (MonoStackFrameInfo *frame, MonoContext *ctx, gpointer data);
@@ -695,9 +693,7 @@ typedef struct {
 	gboolean (*mono_above_abort_threshold) (void);
 	void (*mono_clear_abort_threshold) (void);
 	void (*mono_reraise_exception) (MonoException *ex);
-#ifdef TARGET_OSX
 	void (*mono_summarize_stack) (MonoDomain *domain, MonoThreadSummary *out, MonoContext *crash_ctx);
-#endif
 } MonoRuntimeExceptionHandlingCallbacks;
 
 MONO_COLD void mono_set_pending_exception (MonoException *exc);

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -341,7 +341,6 @@ mono_set_thread_dump_dir(gchar* dir);
 MONO_COLD void
 mono_set_pending_exception_handle (MonoExceptionHandle exc);
 
-#ifdef TARGET_OSX
 #define MONO_MAX_SUMMARY_NAME_LEN 140
 #define MONO_MAX_SUMMARY_THREADS 32
 #define MONO_MAX_SUMMARY_FRAMES 40
@@ -386,6 +385,5 @@ typedef struct {
 
 gboolean
 mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes);
-#endif
 
 #endif /* _MONO_METADATA_THREADS_TYPES_H_ */

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -5898,7 +5898,14 @@ mono_set_thread_dump_dir (gchar* dir) {
 	thread_dump_dir = dir;
 }
 
-#ifdef TARGET_OSX
+#ifdef DISABLE_CRASH_REPORTING
+gboolean
+mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes)
+{
+	return FALSE;
+}
+
+#else
 
 static size_t num_threads_summarized = 0;
 

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -127,9 +127,7 @@ static gboolean mono_install_handler_block_guard (MonoThreadUnwindState *ctx);
 static void mono_uninstall_current_handler_block_guard (void);
 static gboolean mono_exception_walk_trace_internal (MonoException *ex, MonoExceptionFrameWalk func, gpointer user_data);
 
-#ifdef TARGET_OSX
 static void mono_summarize_stack (MonoDomain *domain, MonoThreadSummary *out, MonoContext *crash_ctx);
-#endif
 
 static gboolean
 first_managed (MonoStackFrameInfo *frame, MonoContext *ctx, gpointer addr)
@@ -234,10 +232,7 @@ mono_exceptions_init (void)
 
 	cbs.mono_walk_stack_with_ctx = mono_runtime_walk_stack_with_ctx;
 	cbs.mono_walk_stack_with_state = mono_walk_stack_with_state;
-
-#ifdef TARGET_OSX
 	cbs.mono_summarize_stack = mono_summarize_stack;
-#endif
 
 	if (mono_llvm_only) {
 		cbs.mono_raise_exception = mono_llvm_raise_exception;
@@ -1259,7 +1254,15 @@ next:
 	}
 }
 
-#ifdef TARGET_OSX
+#ifdef DISABLE_CRASH_REPORTING
+static void
+mono_summarize_stack (MonoDomain *domain, MonoThreadSummary *out, MonoContext *crash_ctx)
+{
+	return;
+}
+
+#else
+
 typedef struct {
 	MonoFrameSummary *frames;
 	int num_frames;

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -223,11 +223,11 @@ MONO_SIG_HANDLER_FUNC (static, sigabrt_signal_handler)
 	}
 }
 
-#ifdef TARGET_OSX
 MONO_SIG_HANDLER_FUNC (static, sigterm_signal_handler)
 {
 	MONO_SIG_HANDLER_GET_CONTEXT;
 
+#ifndef DISABLE_CRASH_REPORTING
 	// Note: this function only returns for a single thread
 	// When it's invoked on other threads once the dump begins,
 	// those threads perform their dumps and then sleep until we
@@ -239,20 +239,23 @@ MONO_SIG_HANDLER_FUNC (static, sigterm_signal_handler)
 	if (!mono_threads_summarize (&mctx, &output, &hashes))
 		g_assert_not_reached ();
 
+#ifdef TARGET_OSX
 	if (mono_merp_enabled ()) {
 		pid_t crashed_pid = getpid ();
 		char *full_version = mono_get_runtime_build_info ();
 		mono_merp_invoke (crashed_pid, "SIGTERM", output, &hashes, full_version);
-	} else {
+	} else
+#endif
+	{
 		// Only the dumping-supervisor thread exits mono_thread_summarize
 		MOSTLY_ASYNC_SAFE_PRINTF("Unhandled exception dump: \n######\n%s\n######\n", output);
 		sleep (3);
 	}
+#endif
 
 	mono_chain_signal (MONO_SIG_HANDLER_PARAMS);
 	exit (1);
 }
-#endif
 
 #if (defined (USE_POSIX_BACKEND) && defined (SIGRTMIN)) || defined (SIGPROF)
 #define HAVE_PROFILER_SIGNAL
@@ -405,14 +408,14 @@ remove_signal_handler (int signo)
 	}
 }
 
-#ifdef TARGET_OSX
 void
 mini_register_sigterm_handler (void)
 {
+#ifndef DISABLE_CRASH_REPORTING
 	/* always catch SIGTERM, conditionals inside of handler */
 	add_signal_handler (SIGTERM, sigterm_signal_handler, 0);
-}
 #endif
+}
 
 void
 mono_runtime_posix_install_handlers (void)
@@ -956,7 +959,7 @@ print_process_map (void)
 #endif
 }
 
-#ifdef TARGET_OSX
+#ifndef DISABLE_CRASH_REPORTING
 static void
 mono_crash_dump (const char *jsonFile)
 {
@@ -992,7 +995,7 @@ mono_crash_dump (const char *jsonFile)
 
 	return;
 }
-#endif /*TARGET_OSX*/
+#endif /* DISABLE_CRASH_REPORTING */
 
 static void
 dump_native_stacktrace (const char *signal, void *ctx)
@@ -1027,9 +1030,8 @@ dump_native_stacktrace (const char *signal, void *ctx)
 		int status;
 		pid_t crashed_pid = getpid ();
 
-#if defined(TARGET_OSX)
+#ifndef DISABLE_CRASH_REPORTING
 		MonoStackHash hashes;
-#endif
 		gchar *output = NULL;
 		MonoContext mctx;
 		if (ctx) {
@@ -1042,12 +1044,11 @@ dump_native_stacktrace (const char *signal, void *ctx)
 			if (!dump_for_merp) {
 #ifdef DISABLE_STRUCTURED_CRASH
 				leave = TRUE;
-#elif defined(TARGET_OSX)
+#else
 				mini_register_sigterm_handler ();
 #endif
 			}
 
-#ifdef TARGET_OSX
 			if (!leave) {
 				mono_sigctx_to_monoctx (ctx, &mctx);
 				// Do before forking
@@ -1059,8 +1060,8 @@ dump_native_stacktrace (const char *signal, void *ctx)
 			// So we dump to disk
 			if (!leave && !dump_for_merp)
 				mono_crash_dump (output);
-#endif
 		}
+#endif
 
 		/*
 		* glibc fork acquires some locks, so if the crash happened inside malloc/free,
@@ -1087,7 +1088,7 @@ dump_native_stacktrace (const char *signal, void *ctx)
 		}
 #endif
 
-#if defined(TARGET_OSX)
+#if defined(TARGET_OSX) && !defined(DISABLE_CRASH_REPORTING)
 		if (mono_merp_enabled ()) {
 			if (pid == 0) {
 				if (!ctx) {

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -563,9 +563,7 @@ gboolean MONO_SIG_HANDLER_SIGNATURE (mono_chain_signal);
 #define DISABLE_SDB 1
 #endif
 
-#ifdef TARGET_OSX
 void mini_register_sigterm_handler (void);
-#endif
 
 #endif /* __MONO_MINI_RUNTIME_H__ */
 

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -15,7 +15,7 @@
 #include <mono/utils/mono-threads-coop.h>
 #include <mono/metadata/object-internals.h>
 
-#ifdef TARGET_OSX
+#ifndef DISABLE_CRASH_REPORTING
 
 extern GCStats mono_gc_stats;
 
@@ -482,4 +482,4 @@ mono_summarize_native_state_add_thread (MonoThreadSummary *thread, MonoContext *
 	mono_native_state_add_thread (&writer, thread, ctx);
 }
 
-#endif // HOST_WIN32
+#endif // DISABLE_CRASH_REPORTING

--- a/mono/utils/mono-state.h
+++ b/mono/utils/mono-state.h
@@ -11,7 +11,7 @@
 #ifndef __MONO_UTILS_NATIVE_STATE__
 #define __MONO_UTILS_NATIVE_STATE__
 
-#ifdef TARGET_OSX
+#ifndef DISABLE_CRASH_REPORTING
 
 #include <mono/utils/mono-publib.h>
 #include <mono/utils/mono-context.h>
@@ -31,6 +31,6 @@ void
 mono_summarize_native_state_add_thread (MonoThreadSummary *thread, MonoContext *ctx);
 
 MONO_END_DECLS
-#endif // TARGET_OSX
+#endif // DISABLE_CRASH_REPORTING
 
 #endif // MONO_UTILS_NATIVE_STATE

--- a/sdks/builds/runtime.mk
+++ b/sdks/builds/runtime.mk
@@ -48,9 +48,11 @@ __$(1)_CONFIGURE_ENVIRONMENT = \
 	$(if $$(_$(1)_LDFLAGS),LDFLAGS="$$(_$(1)_LDFLAGS)") \
 	$$(_$(1)_CONFIGURE_ENVIRONMENT)
 
+__$(1)_CONFIGURE_FLAGS= --disable-crash-reporting $$(_$(1)_CONFIGURE_FLAGS)
+
 .stamp-$(1)-$$(CONFIGURATION)-configure: $$(TOP)/configure .stamp-$(1)-toolchain
 	mkdir -p $$(TOP)/sdks/builds/$(1)-$$(CONFIGURATION)
-	$(if $$(_$(1)_PATH),PATH="$$$$PATH:$$(_$(1)_PATH)") ./wrap-configure.sh $$(TOP)/sdks/builds/$(1)-$$(CONFIGURATION) $(abspath $(TOP)/configure) $$(_$(1)_AC_VARS) $$(__$(1)_CONFIGURE_ENVIRONMENT) $$(_$(1)_CONFIGURE_FLAGS)
+	$(if $$(_$(1)_PATH),PATH="$$$$PATH:$$(_$(1)_PATH)") ./wrap-configure.sh $$(TOP)/sdks/builds/$(1)-$$(CONFIGURATION) $(abspath $(TOP)/configure) $$(_$(1)_AC_VARS) $$(__$(1)_CONFIGURE_ENVIRONMENT) $$(__$(1)_CONFIGURE_FLAGS)
 	touch $$@
 
 .PHONY: .stamp-$(1)-configure

--- a/winconfig.h
+++ b/winconfig.h
@@ -83,6 +83,9 @@
 /* Disable support debug logging */
 /* #undef DISABLE_LOGGING */
 
+/* Disable runtime state dumping */
+#define DISABLE_CRASH_REPORTING 1
+
 /* Disable P/Invoke support */
 /* #undef DISABLE_PINVOKE */
 


### PR DESCRIPTION
Everything seemed to be working before on CI before. Let's add the jenkins hooks for the crash files with this PR too.