### PR TITLE
"On" field breaks compatibility with System.Net.Http because of "Internals Visible To" & member type mis-match

### DIFF
--- a/mcs/class/System/ReferenceSources/Logging.cs
+++ b/mcs/class/System/ReferenceSources/Logging.cs
@@ -4,14 +4,13 @@ namespace System.Net {
 	static class Logging
 	{
 
-        internal static bool On {
-            get {
-                return false;
-            }
-        }
+		internal static bool On {
+			get {
+				return false;
+			    }
+		}
 
-
-        internal static TraceSource Web {
+		internal static TraceSource Web {
 			get {
 				return null;
 			}

--- a/mcs/class/System/ReferenceSources/Logging.cs
+++ b/mcs/class/System/ReferenceSources/Logging.cs
@@ -3,9 +3,15 @@ using System.Diagnostics;
 namespace System.Net {
 	static class Logging
 	{
-		internal static readonly bool On = false;
 
-		internal static TraceSource Web {
+        internal static bool On {
+            get {
+                return false;
+            }
+        }
+
+
+        internal static TraceSource Web {
 			get {
 				return null;
 			}


### PR DESCRIPTION
Hi Mono Team,
This commit fixes an interesting bug that relates to the  System.Net.Http nuget packages.

So the short story is that System.Net.Http can view the internals of this assembly because of InternalsVisibleTo.  Part of HttpClient references System.Net.Logging's "On" _property_.  The problem is that mono has implemented "On" as a _field_ . When the latest version of System.Net.Http.HttpClient tries to invoke a HttpClient.SyncAsync using Mono, you get a MissingMethodException because:
bool System.Net.Logging.get_On()
does not exist.

This commit is simple and only changes the signature of On to match that of the reference source (property instead of field).  This will cause the Missing Method Exception not to be thrown.




