### PR TITLE
Don't set LDFLAGS on the libmono-ee library. Fixes this warning:

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -626,8 +626,8 @@ endif
 
 libmono_ee_interp_la_SOURCES = $(interp_sources)
 libmono_ee_interp_la_CFLAGS = $(mono_CFLAGS)
-libmono_ee_interp_la_LDFLAGS = $(libmonoldflags)
 if BITCODE
+libmono_ee_interp_la_LDFLAGS = $(libmonoldflags)
 if DISABLE_INTERPRETER
 libmono_ee_interp_la_LIBADD = libmonosgen-2.0.la
 endif


### PR DESCRIPTION
libtool: warning: '-version-info/-version-number' is ignored for convenience libraries