### PR TITLE
[corlib] Match .NET behavior in ParameterInfo.ToString()

### DIFF
--- a/mcs/class/corlib/System.Reflection/ParameterInfo.cs
+++ b/mcs/class/corlib/System.Reflection/ParameterInfo.cs
@@ -63,23 +63,7 @@ namespace System.Reflection
 		protected ParameterInfo () {
 		}
 
-		public override string ToString() {
-			Type elementType = ClassImpl;
-			while (elementType.HasElementType) {
-					elementType = elementType.GetElementType();
-			}
-			bool useShort = elementType.IsPrimitive || ClassImpl == typeof(void)
-				|| ClassImpl.Namespace == MemberImpl.DeclaringType.Namespace;
-			string result = useShort
-				? ClassImpl.Name
-				: ClassImpl.FullName;
-			// MS.NET seems to skip this check and produce an extra space for return types
-			if (!IsRetval) {
-				result += ' ';
-				result += NameImpl;
-			}
-			return result;
-		}
+		public override string ToString() => ClassImpl.FormatTypeName() + " " + Name;
 
 		internal static void FormatParameters (StringBuilder sb, ParameterInfo[] p, CallingConventions callingConvention, bool serialization)
 		{

--- a/mcs/class/corlib/Test/System.Reflection/ParameterInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/ParameterInfoTest.cs
@@ -15,6 +15,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 using NUnit.Framework;
 
@@ -430,13 +431,78 @@ namespace MonoTests.System.Reflection
 		}
 
 		[Test]
-		public void SubClassWithOverrides()
+		public void SubClassWithOverrides ()
 		{
 			var p2 = new MyParameterInfo2 ();
 			Assert.IsFalse (p2.IsIn, "#1");
 			p2.MyAttrsImpl = ParameterAttributes.In;
 			Assert.IsTrue (p2.IsIn, "#2");
 			Assert.AreEqual (p2.myList, p2.CustomAttributes, "#3");
+		}
+
+		[Test] 
+		public void ParameterInfoToString ()
+		{
+			var method = typeof (TestNestedClass).GetTypeInfo ().GetMethod ("TestMethod");
+			var sb = new StringBuilder ();
+			
+			foreach (var parameter in method.GetParameters ())
+			{
+				sb.Append (parameter + "\n");
+			}
+
+			string actual = sb.ToString ();
+			string expected = "Int32 a0\n" +
+"System.String a1\n" +
+"TestNestedClass a2\n" +
+"System.Collections.Generic.List`1[System.Int32] a3\n" +
+"System.Collections.Generic.List`1[System.Text.StringBuilder] a4\n" +
+"System.Collections.Generic.List`1[MonoTests.System.Reflection.ParameterInfoTest+TestNestedClass] a5\n" +
+"System.Text.StringBuilder a6\n" +
+"System.Collections.Generic.Dictionary`2[System.Int32,System.String] a7\n" +
+"Int32& a8\n" +
+"Int32& a9\n" +
+"TestNestedClass& a10\n" +
+"System.Collections.Generic.List`1[System.Int32]& a11\n";
+
+			Assert.AreEqual (expected, actual, "#1");
+		}
+
+		public class TestNestedClass
+		{
+			public static void TestMethod (int a0, string a1, 
+				TestNestedClass a2, List<int> a3, 
+				List<StringBuilder> a4, List<TestNestedClass> a5, 
+				StringBuilder a6, Dictionary<int, string> a7,
+				out int a8, ref int a9, out TestNestedClass a10, out List<int> a11) 
+				{
+					a8 = 0;
+					a9 = 0;
+					a10 = null;
+					a11 = null;
+				}
+		}
+
+		[Test] // https://github.com/mono/mono/issues/8312
+		public void ParameterInfoToStringForQueryableSkipWhile ()
+		{
+			var sb = new StringBuilder ();
+			var methods = typeof (Queryable).GetTypeInfo ().GetMethods ().Where (m => m.Name == "SkipWhile");
+			foreach (var methodInfo in methods)
+			{
+				foreach (var parameter in methodInfo.GetParameters ())
+				{
+					sb.Append (parameter + "\n");
+				}
+			}
+
+			string actual = sb.ToString ();
+			string expected = "System.Linq.IQueryable`1[TSource] source\n" +
+"System.Linq.Expressions.Expression`1[System.Func`2[TSource,System.Boolean]] predicate\n" +
+"System.Linq.IQueryable`1[TSource] source\n" +
+"System.Linq.Expressions.Expression`1[System.Func`3[TSource,System.Int32,System.Boolean]] predicate\n";
+			
+			Assert.AreEqual (expected, actual, "#1");
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/8312
.NET Core behavior: https://github.com/dotnet/coreclr/blob/85374ceaed177f71472cc4c23c69daf7402e5048/src/System.Private.CoreLib/shared/System/Reflection/ParameterInfo.cs#L99