### PR TITLE
[runtime] Fix the marshalling of class types using MarshalAs(UnmanagedType.Struct).

### DIFF
--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -6411,6 +6411,7 @@ handle_enum:
 		if (mspec) {
 			switch (mspec->native) {
 			case MONO_NATIVE_STRUCT:
+				*conv = MONO_MARSHAL_CONV_OBJECT_STRUCT;
 				return MONO_NATIVE_STRUCT;
 			case MONO_NATIVE_CUSTOM:
 				return MONO_NATIVE_CUSTOM;


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/8250.