### PR TITLE
[2018-04][loader] LoadFrom of problematic images should reprobe

### DIFF
--- a/mono/metadata/image-internals.h
+++ b/mono/metadata/image-internals.h
@@ -20,4 +20,7 @@ mono_image_load_module_checked (MonoImage *image, int idx, MonoError *error);
 MonoImage *
 mono_image_open_a_lot (const char *fname, MonoImageOpenStatus *status, gboolean refonly, gboolean load_from_context);
 
+gboolean
+mono_is_problematic_image (MonoImage *image);
+
 #endif /* __MONO_METADATA_IMAGE_INTERNALS_H__ */

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1286,8 +1286,8 @@ hash_guid (const char *str)
 	return h;
 }
 
-static gboolean
-is_problematic_image (MonoImage *image)
+gboolean
+mono_is_problematic_image (MonoImage *image)
 {
 	int h = hash_guid (image->guid);
 
@@ -1360,7 +1360,7 @@ do_mono_image_load (MonoImage *image, MonoImageOpenStatus *status,
 	if (!mono_image_load_cli_data (image))
 		goto invalid_image;
 
-	if (!image->ref_only && is_problematic_image (image)) {
+	if (!image->ref_only && mono_is_problematic_image (image)) {
 		if (image->load_from_context) {
 			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Loading problematic image %s", image->name);
 		} else {
@@ -1682,6 +1682,18 @@ mono_image_open_a_lot (const char *fname, MonoImageOpenStatus *status, gboolean 
 		mono_images_lock ();
 		image = g_hash_table_lookup (loaded_images, absfname);
 		if (image) { // Image already loaded
+			if (!load_from_context && mono_is_problematic_image (image)) {
+				// If we previously loaded a problematic image, don't
+				// return it if we're not in LoadFrom context.
+				//
+				// Note: this has an interaction with
+				//  mono_problematic_image_reprobe - at that point we
+				//  have a problematic image opened, but we don't want
+				//  to see it again when we go searching for an image
+				//  to load.
+				mono_images_unlock ();
+				return NULL;
+			}
 			g_assert (image->is_module_handle);
 			if (image->has_entry_point && image->ref_count == 0) {
 				/* Increment reference count on images loaded outside of the runtime. */
@@ -1752,6 +1764,18 @@ mono_image_open_a_lot (const char *fname, MonoImageOpenStatus *status, gboolean 
 	g_free (absfname);
 
 	if (image) { // Image already loaded
+		if (!load_from_context && mono_is_problematic_image (image)) {
+			// If we previously loaded a problematic image, don't
+			// return it if we're not in LoadFrom context.
+			//
+			// Note: this has an interaction with
+			//  mono_problematic_image_reprobe - at that point we
+			//  have a problematic image opened, but we don't want
+			//  to see it again when we go searching for an image
+			//  to load.
+			mono_images_unlock ();
+			return NULL;
+		}
 		mono_image_addref (image);
 		mono_images_unlock ();
 		return image;


### PR DESCRIPTION
This is a backport of #8737 to `2018-04`.

It's not entirely mechanical but it's pretty close to what's in master.
(The difference is the lack of the load context work in 2018-04, so there's more boolean flags instead of an enum)

----

The "problematic images" are Windows-specific assemblies that are often
included with applications that do not work on Mono, but for which Mono has its
own implementation.

Previously (9ec8ec5) we changed mono to deny
loading problematic images using Assembly.Load or when one assembly references
another and we find a problematic image using the usual assembly search.

For Assembly.LoadFrom, we used to emit a warning and then load the assembly anyway.

In this commit, we change the behavior: If Assembly.LoadFrom tries to open a
problematic image, we will instead probe for an assembly of that name in the
default context.  That should eventually end up opening Mono's version of that
assembly.

Example:
  Suppose a problematic System.Runtime.InteropServices.RuntimeInformation.dll
  is in the application bin path: /home/user/myapp/bin

  1. User code does (for whatever reason)
  Assembly.LoadFrom ("/home/user/myapp/bin/System.Runtime.InteropServices.RuntimeInformation.dll")

  2. We find the image and try to open it; add it to the images absfpath to
  image hash; note that there are no binding redirects; but that it is a
  problematic image.  We extract the assembly
  name ("System.Runtime.InteropServices.RuntimeInformation", version x.y.z.w
  and public key token 123456789a) from the problematic image.

  3. We probe for "System.Runtime.InteropServices.RuntimeInformation version
  x.y.z.w public key token 123456789a" in the default context.

  4. We find
  /home/user/myapp/bin/System.Runtime.InteropServices.RuntimeInformation.dll in
  the application bin path; we try to open it, we see it's already in the
  images hash, but it's a problematic image,  and we're not in a loadfrom
  context (we re-probed with default!) so we keep probing

  5. We find
  <prefix>/lib/mono/4.5/Facaded/System.Runtime.InteropServices.RuntimeInformation.dll,
  it's not a problematic image, so we open that and return it to (3)

  6. We return to (2) and close the problematic image and return the good one
  instead.

  7. Assembly.LoadFrom returns with the good image.

Fixes #8726



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
