### PR TITLE
[System]: Cleanup `SslStream` callbacks and internal validation code.

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.Interface/CertificateValidationHelper.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Interface/CertificateValidationHelper.cs
@@ -139,20 +139,6 @@ namespace Mono.Security.Interface
 		}
 
 		/*
-		 * Internal API, intended to be used by MonoTlsProvider implementations.
-		 */
-		internal static ICertificateValidator2 GetInternalValidator (MonoTlsSettings settings, MonoTlsProvider provider)
-		{
-			return (ICertificateValidator2)NoReflectionHelper.GetInternalValidator (provider, settings);
-		}
-
-		[Obsolete ("Use GetInternalValidator")]
-		internal static ICertificateValidator2 GetDefaultValidator (MonoTlsSettings settings, MonoTlsProvider provider)
-		{
-			return GetInternalValidator (settings, provider);
-		}
-
-		/*
 		 * Use this overloaded version in user code.
 		 */
 		public static ICertificateValidator GetValidator (MonoTlsSettings settings)

--- a/mcs/class/System/Mono.Net.Security/CallbackHelpers.cs
+++ b/mcs/class/System/Mono.Net.Security/CallbackHelpers.cs
@@ -57,14 +57,6 @@ namespace Mono.Net.Security.Private
 			return (h, c, ch, e) => callback (h, c, ch, (SslPolicyErrors)e);
 		}
 
-		internal static MSI.MonoLocalCertificateSelectionCallback PublicToMono (LocalCertificateSelectionCallback callback)
-		{
-			if (callback == null)
-				return null;
-
-			return (t, lc, rc, ai) => callback (null, t, lc, rc, ai);
-		}
-
 		internal static MSI.MonoRemoteCertificateValidationCallback InternalToMono (RemoteCertValidationCallback callback)
 		{
 			if (callback == null)
@@ -87,14 +79,6 @@ namespace Mono.Net.Security.Private
 				return null;
 
 			return (t, lc, rc, ai) => callback (t, lc, rc, ai);
-		}
-
-		internal static RemoteCertificateValidationCallback MonoToPublic (MSI.MonoRemoteCertificateValidationCallback callback)
-		{
-			if (callback == null)
-				return null;
-
-			return (t, c, ch, e) => callback (null, c, ch, (MSI.MonoSslPolicyErrors)e);
 		}
 
 		internal static LocalCertificateSelectionCallback MonoToPublic (MSI.MonoLocalCertificateSelectionCallback callback)

--- a/mcs/class/System/Mono.Net.Security/LegacySslStream.cs
+++ b/mcs/class/System/Mono.Net.Security/LegacySslStream.cs
@@ -62,13 +62,12 @@ using System;
 using System.IO;
 using System.Net;
 using System.Net.Security;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Principal;
 using System.Security.Cryptography;
-
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Mono.Net.Security.Private
 {
@@ -92,7 +91,7 @@ namespace Mono.Net.Security.Private
 		{
 			SslStream = owner;
 			Provider = provider;
-			certificateValidator = ChainValidationHelper.GetInternalValidator (provider, settings);
+			certificateValidator = ChainValidationHelper.GetInternalValidator (owner, provider, settings);
 		}
 		#endregion // Constructors
 

--- a/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
+++ b/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
@@ -85,6 +85,11 @@ namespace Mono.Net.Security
 			get { return xobileTlsContext != null; }
 		}
 
+		internal string TargetHost {
+			get;
+			private set;
+		}
+
 		internal void CheckThrow (bool authSuccessCheck, bool shutdownCheck = false)
 		{
 			if (lastException != null)
@@ -313,6 +318,7 @@ namespace Mono.Net.Security
 					throw new ArgumentException (nameof (options.TargetHost));
 				if (options.TargetHost.Length == 0)
 					options.TargetHost = "?" + Interlocked.Increment (ref uniqueNameInteger).ToString (NumberFormatInfo.InvariantInfo);
+				TargetHost = options.TargetHost;
 			}
 
 			if (lastException != null)
@@ -338,6 +344,8 @@ namespace Mono.Net.Security
 
 					xobileTlsContext = CreateContext (options);
 				}
+
+				Debug ($"ProcessAuthentication({(IsServer ? "server" : "client")})");
 
 				try {
 					result = await asyncRequest.StartOperation (cancellationToken).ConfigureAwait (false);
@@ -462,9 +470,15 @@ namespace Mono.Net.Security
 		internal readonly int ID = ++nextId;
 
 		[SD.Conditional ("MONO_TLS_DEBUG")]
-		protected internal void Debug (string message, params object[] args)
+		protected internal void Debug (string format, params object[] args)
 		{
-			MonoTlsProviderFactory.Debug ("MobileAuthenticatedStream({0}): {1}", ID, string.Format (message, args));
+			Debug (string.Format (format, args));
+		}
+
+		[SD.Conditional ("MONO_TLS_DEBUG")]
+		protected internal void Debug (string message)
+		{
+			MonoTlsProviderFactory.Debug ($"MobileAuthenticatedStream({ID}): {message}");
 		}
 
 #region Called back from native code via SslConnection

--- a/mcs/class/System/Mono.Net.Security/MobileTlsContext.cs
+++ b/mcs/class/System/Mono.Net.Security/MobileTlsContext.cs
@@ -37,6 +37,7 @@ namespace Mono.Net.Security
 		protected MobileTlsContext (MobileAuthenticatedStream parent, MonoSslAuthenticationOptions options)
 		{
 			Parent = parent;
+			Options = options;
 			IsServer = options.ServerMode;
 			EnabledProtocols = options.EnabledSslProtocols;
 
@@ -54,8 +55,12 @@ namespace Mono.Net.Security
 				}
 			}
 
-			certificateValidator = CertificateValidationHelper.GetInternalValidator (
-				parent.Settings, parent.Provider);
+			certificateValidator = (ICertificateValidator2)ChainValidationHelper.GetInternalValidator (
+				parent.SslStream, parent.Provider, parent.Settings);
+		}
+
+		internal MonoSslAuthenticationOptions Options {
+			get;
 		}
 
 		internal MobileAuthenticatedStream Parent {
@@ -84,7 +89,7 @@ namespace Mono.Net.Security
 			get;
 		}
 
-		protected string TargetHost {
+		internal string TargetHost {
 			get;
 		}
 

--- a/mcs/class/System/Mono.Net.Security/NoReflectionHelper.cs
+++ b/mcs/class/System/Mono.Net.Security/NoReflectionHelper.cs
@@ -47,15 +47,6 @@ namespace Mono.Net.Security
 	//
 	internal static class NoReflectionHelper
 	{
-		internal static object GetInternalValidator (object provider, object settings)
-		{
-			#if SECURITY_DEP
-			return ChainValidationHelper.GetInternalValidator ((MSI.MonoTlsProvider)provider, (MSI.MonoTlsSettings)settings);
-			#else
-			throw new NotSupportedException ();
-			#endif
-		}
-
 		internal static object GetDefaultValidator (object settings)
 		{
 			#if SECURITY_DEP


### PR DESCRIPTION
* `SslStream`: Reject attempts of setting conflicting callbacks using both the
  Mono-specific `MonoTlsSettings` and the new `SslClientAuthenticationOptions` /
  `SslServerAuthenticationOptions`.

  This makes it consistent with CoreFx behavior where those callbacks may only be
  specified in one of the possible places.

* `ChainValidationHelper` - this internal class has received a major overhaul and
  lots of old and unused code removed.

  All callbacks are not invoked with the correct `sender` parameter to make it
  match the .NET / CoreFx behavior.

* `Mono.Security.Interface.CertificateValidationHelper`: remove unused internal code.
