### PR TITLE
[monitor] Fix monitor aborts

### DIFF
--- a/mono/metadata/monitor.c
+++ b/mono/metadata/monitor.c
@@ -834,13 +834,6 @@ retry_contended:
 		}
 	}
 
-	/* If the object is currently locked by this thread... */
-	if (mon_status_get_owner (old_status) == id) {
-		mon->nest++;
-		MONO_PROFILER_RAISE (monitor_acquired, (obj));
-		return 1;
-	}
-
 	/* We need to make sure there's a semaphore handle (creating it if
 	 * necessary), and block on it
 	 */

--- a/mono/metadata/monitor.c
+++ b/mono/metadata/monitor.c
@@ -331,7 +331,7 @@ mono_locks_dump (gboolean include_untaken)
 					to_recycle++;
 			} else {
 				if (!monitor_is_on_freelist ((MonoThreadsSync *)mon->data)) {
-					MonoObject *holder = (MonoObject *)mono_gchandle_get_target ((guint32)mon->data);
+					MonoObject *holder = (MonoObject *)mono_gchandle_get_target ((guint32)(gsize)mon->data);
 					if (mon_status_get_owner (mon->status)) {
 						g_print ("Lock %p in object %p held by thread %d, nest level: %d\n",
 							mon, holder, mon_status_get_owner (mon->status), mon->nest);
@@ -393,7 +393,7 @@ mon_new (gsize id)
 		new_ = NULL;
 		for (marray = monitor_allocated; marray; marray = marray->next) {
 			for (i = 0; i < marray->num_monitors; ++i) {
-				if (mono_gchandle_get_target ((guint32)marray->monitors [i].data) == NULL) {
+				if (mono_gchandle_get_target ((guint32)(gsize)marray->monitors [i].data) == NULL) {
 					new_ = &marray->monitors [i];
 					if (new_->wait_list) {
 						/* Orphaned events left by aborted threads */
@@ -403,7 +403,7 @@ mon_new (gsize id)
 							new_->wait_list = g_slist_remove (new_->wait_list, new_->wait_list->data);
 						}
 					}
-					mono_gchandle_free ((guint32)new_->data);
+					mono_gchandle_free ((guint32)(gsize)new_->data);
 					new_->data = monitor_freelist;
 					monitor_freelist = new_;
 				}
@@ -471,7 +471,7 @@ static void
 discard_mon (MonoThreadsSync *mon)
 {
 	mono_monitor_allocator_lock ();
-	mono_gchandle_free ((guint32)mon->data);
+	mono_gchandle_free ((guint32)(gsize)mon->data);
 	mon_finalize (mon);
 	mono_monitor_allocator_unlock ();
 }
@@ -1123,7 +1123,7 @@ mono_monitor_get_object_monitor_gchandle (MonoObject *object)
 
 	if (lock_word_is_inflated (lw)) {
 		MonoThreadsSync *mon = lock_word_get_inflated_lock (lw);
-		return (guint32)mon->data;
+		return (guint32)(gsize)mon->data;
 	}
 	return 0;
 }

--- a/mono/metadata/monitor.h
+++ b/mono/metadata/monitor.h
@@ -14,7 +14,7 @@
 #include <glib.h>
 #include <mono/metadata/object.h>
 #include <mono/utils/mono-compiler.h>
-#include <mono/utils/mono-coop-semaphore.h>
+#include <mono/utils/mono-coop-mutex.h>
 
 G_BEGIN_DECLS
 
@@ -42,7 +42,8 @@ struct _MonoThreadsSync
 #endif
 	GSList *wait_list;
 	void *data;
-	MonoCoopSem *entry_sem;
+	MonoCoopMutex *entry_mutex;
+	MonoCoopCond *entry_cond;
 };
 
 /*

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1198,8 +1198,6 @@ CI_DISABLED_TESTS = \
 # so they don't interfere with other people's work
 CI_PR_DISABLED_TESTS = \
 	appdomain-threadpool-unload.exe \
-	monitor-abort.exe \
-	monitor-wait-abort.exe \
 	process-stress-3.exe
 
 # appdomain-threadpool-unload.exe creates 100 appdomains, takes too long with llvm


### PR DESCRIPTION
Replaces semaphore usage with condition variable.

Fixes https://github.com/mono/mono/issues/6834


<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
