### PR TITLE
[System]: Epic: Client Certificate Support - Part Two.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # This can be reset to 0 when Mono's version number is bumped
 # since it's part of the corlib version (the prefix '1' in the full
 # version number is to ensure the number isn't treated as octal in C)
-MONO_CORLIB_COUNTER=6
+MONO_CORLIB_COUNTER=7
 MONO_CORLIB_VERSION=`printf "1%02d%02d%02d%03d" $MONO_VERSION_MAJOR $MONO_VERSION_MINOR 0 $MONO_CORLIB_COUNTER`
 
 AC_DEFINE_UNQUOTED(MONO_CORLIB_VERSION,$MONO_CORLIB_VERSION,[Version of the corlib-runtime interface])

--- a/mcs/class/Mono.Security/Mono.Security.Interface/IMonoSslStream.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Interface/IMonoSslStream.cs
@@ -208,6 +208,12 @@ namespace Mono.Security.Interface
 
 
 		MonoTlsConnectionInfo GetConnectionInfo ();
+
+		bool CanRenegotiate {
+			get;
+		}
+
+		Task RenegotiateAsync (CancellationToken cancellationToken);
 	}
 
 	interface IMonoSslStream2 : IMonoSslStream

--- a/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsProviderFactory.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsProviderFactory.cs
@@ -182,9 +182,10 @@ namespace Mono.Security.Interface
 		 *
 		 * - 1: everything up until May 2018
 		 * - 2: the new ServicePointScheduler changes have landed
+		 * - 3: full support for Client Certificates
 		 *
 		 */
-		internal const int InternalVersion = 2;
+		internal const int InternalVersion = 3;
 
 		#endregion
 	}

--- a/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsSettings.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsSettings.cs
@@ -100,6 +100,10 @@ namespace Mono.Security.Interface
 			get; set;
 		}
 
+		public bool DisallowUnauthenticatedCertificateRequest {
+			get; set;
+		}
+
 		/*
 		 * If you set this here, then it will override 'ServicePointManager.SecurityProtocol'.
 		 */
@@ -189,6 +193,7 @@ namespace Mono.Security.Interface
 			CertificateValidationTime = other.CertificateValidationTime;
 			SendCloseNotify = other.SendCloseNotify;
 			ClientCertificateIssuers = other.ClientCertificateIssuers;
+			DisallowUnauthenticatedCertificateRequest = other.DisallowUnauthenticatedCertificateRequest;
 			if (other.TrustAnchors != null)
 				TrustAnchors = new X509CertificateCollection (other.TrustAnchors);
 			if (other.CertificateSearchPaths != null) {

--- a/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
@@ -137,6 +137,9 @@ namespace Mono.Btls
 			} else {
 				ssl.SetServerName (ServerName);
 			}
+
+			if (Options.AllowRenegotiation)
+				ssl.SetRenegotiateMode (MonoBtlsSslRenegotiateMode.FREELY);
 		}
 
 		void SetPrivateCertificate (X509CertificateImplBtls privateCert)

--- a/mcs/class/System/Mono.Net.Security/AsyncProtocolRequest.cs
+++ b/mcs/class/System/Mono.Net.Security/AsyncProtocolRequest.cs
@@ -280,7 +280,7 @@ namespace Mono.Net.Security
 
 		protected override AsyncOperationStatus Run (AsyncOperationStatus status)
 		{
-			return Parent.ProcessHandshake (status);
+			return Parent.ProcessHandshake (status, false);
 		}
 	}
 
@@ -390,5 +390,17 @@ namespace Mono.Net.Security
 		}
 	}
 
+	class AsyncRenegotiateRequest : AsyncProtocolRequest
+	{
+		public AsyncRenegotiateRequest (MobileAuthenticatedStream parent)
+			: base (parent, false)
+		{
+		}
+
+		protected override AsyncOperationStatus Run (AsyncOperationStatus status)
+		{
+			return Parent.ProcessHandshake (status, true);
+		}
+	}
 }
 #endif

--- a/mcs/class/System/Mono.Net.Security/MobileTlsContext.cs
+++ b/mcs/class/System/Mono.Net.Security/MobileTlsContext.cs
@@ -109,6 +109,10 @@ namespace Mono.Net.Security
 			get;
 		}
 
+		internal bool AllowRenegotiation {
+			get { return false; }
+		}
+
 		protected void GetProtocolVersions (out TlsProtocolCode? min, out TlsProtocolCode? max)
 		{
 			if ((EnabledProtocols & SslProtocols.Tls) != 0)
@@ -184,6 +188,9 @@ namespace Mono.Net.Security
 
 		protected X509Certificate SelectClientCertificate (string[] acceptableIssuers)
 		{
+			if (Settings.DisallowUnauthenticatedCertificateRequest && !IsAuthenticated)
+				return null;
+
 			if (RemoteCertificate == null)
 				throw new TlsException (AlertDescription.InternalError, "Cannot request client certificate before receiving one from the server.");
 


### PR DESCRIPTION
[System]: Epic: Client Certificate Support - Part Two.

This is the second and final part to bring Client Certificate support.  It needs to be landed on top of #8753 and #8756.

* `Mono.Security.Interface.IMonoSslStream`: Add `CanRenegotiate` and `RenegotiateAsync()`.

* `Mono.Security.Interface.MonoTlsSettings`: Add `DisallowUnauthenticatedCertificateRequest`.

* `AppleTlsContext`: fully support renegotiation.
  - we may now receive `SslStatus.PeerAuthCompleted` and `SslStatus.PeerClientCertRequested`
    during `Read()`.  It should in theory not happen during `Write()`, but I added it there
    as well just to be on the safe side.
  - `SetSessionOption()` may only be called before the initial handshake.

* `MobileAuthenticatedStream`: this is the major part of the work and the most complex one.
  - added a new `Operation` enum to keep track of what is going on and detect invalid state.
  - a renegotion may only be triggered while we're idle - that is no handshake, read or write
    operation is currently active.
  - `InternalWrite()` may now be called from `SSLRead()`, the new `Operation` tells us what
    is currently happening.
  - `ProcessHandshake()` now takes a `bool renegotiate` argument.
  - added sanity checks to `ProcessRead()` and `ProcessWrite()`.

* `MobileTlsContext.SelectClientCertificate()`: check for
  `MonoTlsSettings.DisallowUnauthenticatedCertificateRequest`

Tests have already been added to https://github.com/xamarin/web-tests/commit/869370e00ff95b9bd66a9342236cd31939ae8736, they will auto-enable themselves when using a Mono runtime that contains this code.

Implements #7075 

Fixes #6498