### PR TITLE
Small cleanups for mini-ppc.h

### DIFF
--- a/mono/mini/mini-ppc.h
+++ b/mono/mini/mini-ppc.h
@@ -349,13 +349,13 @@ extern guint8* mono_ppc_create_pre_code_ftnptr (guint8 *code);
 
 #if defined(__linux__)
 #define MONO_ARCH_USE_SIGACTION 1
-#elif defined (__APPLE__) && defined (_STRUCT_MCONTEXT)
-#define MONO_ARCH_USE_SIGACTION 1
-#elif defined (__APPLE__) && !defined (_STRUCT_MCONTEXT)
+#elif defined (__APPLE__)
 #define MONO_ARCH_USE_SIGACTION 1
 #elif defined(__NetBSD__)
 #define MONO_ARCH_USE_SIGACTION 1
 #elif defined(__FreeBSD__)
+#define MONO_ARCH_USE_SIGACTION 1
+#elif defined (_AIX)
 #define MONO_ARCH_USE_SIGACTION 1
 #elif defined(MONO_CROSS_COMPILE)
 	typedef MonoContext ucontext_t;
@@ -366,11 +366,8 @@ extern guint8* mono_ppc_create_pre_code_ftnptr (guint8 *code);
 	#define UCONTEXT_REG_FPRn(ctx, n)
 	#define UCONTEXT_REG_NIP(ctx)
 	#define UCONTEXT_REG_LNK(ctx)
-#elif defined (_AIX)
-#define MONO_ARCH_USE_SIGACTION 1
 #else
-/* For other operating systems, we pull the definition from an external file */
-#include "mini-ppc-os.h"
+#error No OS definition for MONO_ARCH_USE_SIGACTION.
 #endif
 
 gboolean


### PR DESCRIPTION
	* mini-ppc-os.h doesn't exist. If the OS lacks a define,
	  give an error instead of a broken include.

	* Remove redundant Mac OS case.

	* Move AIX define for sigaction above cross-compile case,
	  so it won't get lost in the noise there.