### PR TITLE
[aot] Fix encoding/decoding of types with custom modifiers. (#8729)

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -48,7 +48,7 @@ TOOLS_RUNTIME = MONO_PATH=$(mcs_topdir)/class/lib/build $(top_builddir)/runtime/
 INTERP_RUNTIME = $(MINI_RUNTIME) --interpreter
 RUNTIME_AOTCHECK = MONO_PATH="$(CLASS)$(PLATFORM_PATH_SEPARATOR)." $(RUNTIME_EXECUTABLE)
 
-MCS = CSC_SDK_PATH_DISABLED= $(TOOLS_RUNTIME) $(CSC) -unsafe -nowarn:0162 -nologo -noconfig -r:$(CLASS)/mscorlib.dll -r:$(CLASS)/System.dll -r:$(CLASS)/System.Core.dll
+MCS = CSC_SDK_PATH_DISABLED= $(TOOLS_RUNTIME) $(CSC) -langversion:7.2 -unsafe -nowarn:0162 -nologo -noconfig -r:$(CLASS)/mscorlib.dll -r:$(CLASS)/System.dll -r:$(CLASS)/System.Core.dll
 ILASM = $(TOOLS_RUNTIME) $(mcs_topdir)/class/lib/build/ilasm.exe
 
 AM_CFLAGS = \

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -3115,7 +3115,17 @@ encode_type (MonoAotCompile *acfg, MonoType *t, guint8 *buf, guint8 **endbuf)
 {
 	guint8 *p = buf;
 
-	g_assert (t->num_mods == 0);
+	if (t->num_mods) {
+		*p = MONO_TYPE_CMOD_REQD;
+		++p;
+
+		encode_value (t->num_mods, p, &p);
+		for (int i = 0; i < t->num_mods; ++i) {
+			encode_value (t->modifiers [i].required, p, &p);
+			encode_value (t->modifiers [i].token, p, &p);
+		}
+	}
+
 	/* t->attrs can be ignored */
 	//g_assert (t->attrs == 0);
 

--- a/mono/mini/aot-runtime.h
+++ b/mono/mini/aot-runtime.h
@@ -11,7 +11,7 @@
 #include "mini.h"
 
 /* Version number of the AOT file format */
-#define MONO_AOT_FILE_VERSION 143
+#define MONO_AOT_FILE_VERSION 144
 
 #define MONO_AOT_TRAMP_PAGE_SIZE 16384
 

--- a/mono/mini/aot-tests.cs
+++ b/mono/mini/aot-tests.cs
@@ -506,7 +506,7 @@ class Tests
 		try {
 			Action d = delegate () { data.Cast<IEnumerable> ().GetEnumerator ().MoveNext (); };
 			d ();
-		} catch (Exception ex) {
+		} catch (Exception) {
 		}
 		return 0;
 	}
@@ -516,4 +516,39 @@ class Tests
 		var map2 = new Dictionary <IntPtr, WeakReference> (EqualityComparer<IntPtr>.Default);
 		return 0;
 	}
+
+	// Requires c# 7.2
+#if !__MonoCS__
+	public interface GameComponent {
+	}
+
+	public struct Components<T> {
+        public T[] Collection;
+        public int Count;
+    }
+
+	struct AStruct : GameComponent {
+	}
+
+	public class ReadonlyTest<T> where T: GameComponent {
+		private static Components<T> _components;
+
+        public static T[] GetArray()
+		{
+			ref readonly Components<T> components = ref GetComponents();
+			return components.Collection;
+		}
+
+		public static ref readonly Components<T> GetComponents()
+		{
+			return ref _components;
+		}
+	}
+
+	// gh #8701
+	public static int test_0_readonly_modopt () {
+		typeof (ReadonlyTest<>).MakeGenericType (new Type[] { typeof (AStruct) }).GetMethod ("GetArray").Invoke (null, null);
+		return 0;
+	}
+#endif
 }


### PR DESCRIPTION
* [aot] Fix encoding/decoding of types with custom modifiers.

Fixes https://github.com/mono/mono/issues/8701.

* [aot] Add a test, disabling for now because it depends on c# 7.2.

* [aot] Bump AOT file format version.

* [aot] Only disable the test with mcs.

* [aot] Fix compilation of test.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
