### PR TITLE
[tests] Fix pinvoke test

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1353,7 +1353,6 @@ INTERP_DISABLED_TESTS += \
 	handleref.exe \
 	monitor-abort.exe \
 	nullable_boxing.2.exe \
-	pinvoke.exe \
 	pinvoke2.exe \
 	pinvoke3.exe \
 	remoting2.exe \
@@ -1390,7 +1389,6 @@ INTERP_DISABLED_TESTS += \
 	cominterop.exe \
 	delegate-with-null-target.exe \
 	dim-diamondshape.exe \
-	pinvoke.exe \
 	pinvoke3.exe
 endif
 

--- a/mono/tests/pinvoke.cs
+++ b/mono/tests/pinvoke.cs
@@ -7,11 +7,11 @@ public class Test {
 	public static extern int mono_test_many_int_arguments (int a, int b, int c, int d, int e,
 							       int f, int g, int h, int i, int j);
 	[DllImport ("libtest", EntryPoint="mono_test_many_short_arguments")]
-	public static extern int mono_test_many_short_arguments (short a, short b, short c, short d, short e,
+	public static extern short mono_test_many_short_arguments (short a, short b, short c, short d, short e,
 								 short f, short g, short h, short i, short j);
 	[DllImport ("libtest", EntryPoint="mono_test_many_byte_arguments")]
-	public static extern int mono_test_many_byte_arguments (byte a, byte b, byte c, byte d, byte e,
-								byte f, byte g, byte h, byte i, byte j);
+	public static extern sbyte mono_test_many_byte_arguments (sbyte a, sbyte b, sbyte c, sbyte d, sbyte e,
+								sbyte f, sbyte g, sbyte h, sbyte i, sbyte j);
 	[DllImport ("libtest", EntryPoint="mono_test_many_float_arguments")]
 	public static extern float mono_test_many_float_arguments (float a, float b, float c, float d, float e,
 								float f, float g, float h, float i, float j);


### PR DESCRIPTION
Pinvoke signatures need to match the native ones from libtest.c

Fixes https://github.com/mono/mono/issues/7058



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
