### PR TITLE
LLVM 6.0 JIT (not AOT) problem?

### DIFF
--- a/mono/mini/llvm-jit.cpp
+++ b/mono/mini/llvm-jit.cpp
@@ -194,9 +194,9 @@ public:
 					  } );
 
 #if LLVM_API_VERSION >= 500
-		ModuleHandleT m = CompileLayer.addModule(M,
-												 std::move(Resolver)).get ();
-		return m;
+		auto m = CompileLayer.addModule(M, std::move(Resolver));
+		g_assert (!!m);
+		return m.get ();
 #else
 		return CompileLayer.addModuleSet(singletonSet(M),
 										  make_unique<MonoJitMemoryManager>(),


### PR DESCRIPTION
```
$  cat 1.cs
class B
{

    public static void  Main(string[] args)
    {
    }
}

MONO_PATH=/s/mono/mcs/class/lib/monolite-darwin/1051500005/  /s/mono/mono/mini/mono --llvm 1.exe
Expected<T> must be checked before access or destruction.
Expected<T> value was in success state. (Note: Expected<T> values in success mode must still be checked prior to being destroyed).
Stacktrace:

Native stacktrace:

    0   mono                                0x00000001028a00e8 mono_handle_native_crash + 264
    1   libsystem_platform.dylib            0x00007fffb3ca2b3a _sigtramp + 26
    2   mono                                0x0000000105217860 _ZZN4llvm4dbgsEvE7thestrm + 0
    3   libsystem_c.dylib                   0x00007fffb3b27420 abort + 129
    4   mono                                0x00000001028f1892 _ZNK4llvm8ExpectedINSt3__115__list_iteratorINS1_10unique_ptrINS_3orc28RTDyldObjectLinkingLayerBase12LinkedObjectENS1_14default_deleteIS6_EEEEPvEEE22fatalUncheckedExpectedEv + 226
    5   mono                                0x00000001028edd86 _ZN11MonoLLVMJIT9addModuleEPN4llvm8FunctionENSt3__110shared_ptrINS0_6ModuleEEE + 246
    6   mono                                0x00000001028ecd70 _ZN11MonoLLVMJIT7compileEPN4llvm8FunctionEiPP15LLVMOpaqueValuePPvS7_ + 304
    7   mono                                0x00000001028d79a5 emit_method_inner + 12165
    8   mono                                0x00000001028d47d1 mono_llvm_emit_method + 849
    9   mono                                0x00000001027f10ae mini_method_compile + 878
```