### PR TITLE
[runtime] Fixup freeform, incorporate feedback from backports

### DIFF
--- a/mono/eglib/goutput.c
+++ b/mono/eglib/goutput.c
@@ -143,10 +143,9 @@ g_assertion_message (const gchar *format, ...)
 {
 	va_list args;
 
-	va_start (args, format);
-
 	g_vasprintf (&failure_assertion, format, args);
 
+	va_start (args, format);
 	g_logv (G_LOG_DOMAIN, G_LOG_LEVEL_ERROR, format, args);
 	va_end (args);
 	exit (0);

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -16,7 +16,7 @@
 
 #ifdef TARGET_OSX
 
-extern GCStats mono_gc_stats;
+GCStats mono_gc_stats;
 
 // For AOT mode
 #include <mono/mini/mini-runtime.h>
@@ -245,7 +245,7 @@ mono_native_state_add_ee_info  (JsonWriter *writer)
 
 	mono_json_writer_indent (writer);
 	mono_json_writer_object_key(writer, "coop-enabled");
-	mono_json_writer_printf (writer, "\"%s\"\n", mono_threads_is_cooperative_suspension_enabled () ? "true" : "false");
+	mono_json_writer_printf (writer, "\"%s\"\n", mono_threads_is_coop_enabled () ? "true" : "false");
 
 	mono_json_writer_indent_pop (writer);
 	mono_json_writer_indent (writer);
@@ -476,4 +476,4 @@ mono_summarize_native_state_add_thread (MonoThreadSummary *thread, MonoContext *
 	mono_native_state_add_thread (&writer, thread, ctx);
 }
 
-#endif // HOST_WIN32
+#endif // TARGET_OSX


### PR DESCRIPTION
In the backports, @jaykrell noticed a mistake that was merged with the initial freeform PR. This commit incorporates the fixes made during backport that apply to master. 