### PR TITLE
[runtime] Fixup freeform, incorporate feedback from backports

### DIFF
--- a/mono/eglib/goutput.c
+++ b/mono/eglib/goutput.c
@@ -144,7 +144,6 @@ g_assertion_message (const gchar *format, ...)
 	va_list args;
 
 	va_start (args, format);
-
 	g_vasprintf (&failure_assertion, format, args);
 
 	g_logv (G_LOG_DOMAIN, G_LOG_LEVEL_ERROR, format, args);


### PR DESCRIPTION
In the backports, @jaykrell noticed a mistake that was merged with the initial freeform PR. This commit incorporates the fixes made during backport that apply to master