### PR TITLE
[monitor] Fix abort of synchronisation wrapper

### DIFF
--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -3965,12 +3965,11 @@ emit_synchronized_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 		mono_mb_emit_ldarg (mb, 0);
 	mono_mb_emit_stloc (mb, this_local);
 
+	clause->try_offset = mono_mb_get_label (mb);
 	/* Call Monitor::Enter() */
 	mono_mb_emit_ldloc (mb, this_local);
 	mono_mb_emit_ldloc_addr (mb, taken_local);
 	mono_mb_emit_managed_call (mb, enter_method, NULL);
-
-	clause->try_offset = mono_mb_get_label (mb);
 
 	/* Call the method */
 	if (sig->hasthis)


### PR DESCRIPTION
When we switched to the new version of Monitor.Enter, we didn't expand the try block to include the call. This led to unreleased locks when we acquired the lock but were aborted shortly afterwards.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
