### PR TITLE
[System.Windows.Forms] fix PropertyGrid

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/PropertyGrid.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/PropertyGrid.cs
@@ -937,6 +937,7 @@ namespace System.Windows.Forms
 			if (tabs != null && tabs.Count > 0) {
 				foreach (PropertyTab tab in tabs) {
 					PropertyToolBarButton button = new PropertyToolBarButton (tab);
+					button.Click += new EventHandler (toolbarbutton_clicked);
 					toolbar.Items.Add (button);
 					if (tab.Bitmap != null) {
 						tab.Bitmap.MakeTransparent ();
@@ -986,7 +987,7 @@ namespace System.Windows.Forms
 				scopes.Clear ();
 				IList currentIntersection = (i == 0 ? (IList)tabAttribute.TabClasses : (IList)intersection);
 				for (int j=0; j < currentIntersection.Count; j++) {
-					if ((Type)intersection[j] == tabAttribute.TabClasses[j]) {
+					if ((Type)currentIntersection[j] == tabAttribute.TabClasses[j]) {
 						new_intersection.Add (tabAttribute.TabClasses[j]);
 						scopes.Add (tabAttribute.TabScopes[j]);
 					}
@@ -1410,8 +1411,10 @@ namespace System.Windows.Forms
 						toRemove.Add (i);
 				}
 				foreach (int indexToRemove in toRemove) {
-					property_tabs.RemoveAt (indexToRemove);
-					property_tabs_scopes.RemoveAt (indexToRemove);
+					if (property_tabs.Count > indexToRemove)
+						property_tabs.RemoveAt (indexToRemove);
+					if (property_tabs_scopes.Count > indexToRemove)	
+						property_tabs_scopes.RemoveAt (indexToRemove);
 				}
 				property_grid.RefreshToolbar (this);
 			}


### PR DESCRIPTION
When ProppertyGrid contains more than one propertyTab it crashes whith NullReferenceException. And when clicking on propertyTab toolstripbutton it didn`t switch to this tab.
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
