### PR TITLE
[corlib] Disables test which depends on LogicalCallContext for mobile

### DIFF
--- a/mcs/class/corlib/Test/System.Threading/ThreadPrincipalTests.cs
+++ b/mcs/class/corlib/Test/System.Threading/ThreadPrincipalTests.cs
@@ -10,7 +10,9 @@ namespace MonoTests.System.Threading.Tasks
 {
     [TestFixture]
     public class ThreadPrincipalTests
-    {   
+    {
+
+#if !MONOTOUCH // Uses LogicalCallContext
         [Test]
         public void PrincipalFlowsToAsyncTask ()
         {
@@ -18,6 +20,7 @@ namespace MonoTests.System.Threading.Tasks
             * where SynchronizationContext is set (e.g. Xamarin.iOS) */
             Assert.IsTrue (Task.Run (async () => await _PrincipalFlowsToAsyncTask ()).Wait (5000));
         }
+#endif
 
         public async Task _PrincipalFlowsToAsyncTask ()
         {    


### PR DESCRIPTION
Fixes #8787



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
