### PR TITLE
[llvm] Set the visibility of the llvm globals referring to the jit mo…

### DIFF
--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -8734,6 +8734,7 @@ AddJitGlobal (MonoLLVMModule *module, LLVMTypeRef type, const char *name)
 
 	s = g_strdup_printf ("%s%s", module->global_prefix, name);
 	v = LLVMAddGlobal (module->lmodule, LLVMInt8Type (), s);
+	LLVMSetVisibility (v, LLVMHiddenVisibility);
 	g_free (s);
 	return v;
 }


### PR DESCRIPTION
…dule to hidden, otherwise they can resolve to symbols outside the aot image.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
