### PR TITLE
[2018-04] [corlib] Disables test which depends on LogicalCallContext for mobile

### DIFF
--- a/mcs/class/corlib/Test/System.Threading/ThreadPrincipalTests.cs
+++ b/mcs/class/corlib/Test/System.Threading/ThreadPrincipalTests.cs
@@ -10,7 +10,9 @@ namespace MonoTests.System.Threading.Tasks
 {
     [TestFixture]
     public class ThreadPrincipalTests
-    {   
+    {
+
+#if !MONOTOUCH // Uses LogicalCallContext
         [Test]
         public void PrincipalFlowsToAsyncTask ()
         {
@@ -18,6 +20,7 @@ namespace MonoTests.System.Threading.Tasks
             * where SynchronizationContext is set (e.g. Xamarin.iOS) */
             Assert.IsTrue (Task.Run (async () => await _PrincipalFlowsToAsyncTask ()).Wait (5000));
         }
+#endif
 
         public async Task _PrincipalFlowsToAsyncTask ()
         {    


### PR DESCRIPTION
Backport of #8830.

/cc @marek-safar