### PR TITLE
[runtime] Add GC Unsafe transitions to some MONO_API functions

### DIFF
--- a/mono/dis/main.c
+++ b/mono/dis/main.c
@@ -1631,7 +1631,8 @@ disassemble_file (const char *file)
 		return 1;
 	} else {
 		/* FIXME: is this call necessary? */
-		mono_assembly_load_from_full (img, file, &status, FALSE);
+		/* FIXME: if it's necessary, can it be refonly instead? */
+		mono_assembly_load_from_predicate (img, file, MONO_ASMCTX_DEFAULT, NULL, NULL, &status);
 	}
 
 	setup_filter (img);

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -90,6 +90,9 @@ static gboolean process_guid_set = FALSE;
 
 static gboolean no_exec = FALSE;
 
+static const char *
+mono_check_corlib_version_internal (void);
+
 static MonoAssembly *
 mono_domain_assembly_preload (MonoAssemblyName *aname,
 			      gchar **assemblies_path,
@@ -363,6 +366,16 @@ mono_get_corlib_version (void)
  */
 const char*
 mono_check_corlib_version (void)
+{
+	const char* res;
+	MONO_ENTER_GC_UNSAFE;
+	res = mono_check_corlib_version_internal ();
+	MONO_EXIT_GC_UNSAFE;
+	return res;
+}
+
+static const char *
+mono_check_corlib_version_internal (void)
 {
 	int version = mono_get_corlib_version ();
 	if (version != MONO_CORLIB_VERSION)

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2326,7 +2326,7 @@ ves_icall_System_AppDomain_LoadAssemblyRaw (MonoAppDomainHandle ad,
 	mono_gchandle_free (gchandle); /* unpin */
 	MONO_HANDLE_ASSIGN (raw_assembly, NULL_HANDLE); /* don't reference the data anymore */
 	
-	MonoImage *image = mono_image_open_from_data_full (assembly_data, raw_assembly_len, FALSE, NULL, refonly);
+	MonoImage *image = mono_image_open_from_data_internal (assembly_data, raw_assembly_len, FALSE, NULL, refonly, FALSE, NULL);
 
 	if (!image) {
 		mono_error_set_bad_image_by_name (error, "In memory assembly", "0x%p", raw_data);
@@ -2362,7 +2362,7 @@ ves_icall_System_AppDomain_LoadAssemblyRaw (MonoAppDomainHandle ad,
 		return refass; 
 	}
 
-	/* Clear the reference added by mono_image_open_from_data_full above */
+	/* Clear the reference added by mono_image_open_from_data_internal above */
 	mono_image_close (image);
 
 	refass = mono_assembly_get_object_handle (domain, ass, error);

--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -40,6 +40,8 @@ MonoAssembly* mono_assembly_load_full_nosearch (MonoAssemblyName *aname,
 						MonoAssemblyContextKind asmctx,
 						MonoImageOpenStatus *status);
 
+MonoAssembly* mono_assembly_load_with_partial_name_internal (const char *name, MonoImageOpenStatus *status);
+
 
 /* If predicate returns true assembly should be loaded, if false ignore it. */
 typedef gboolean (*MonoAssemblyCandidatePredicate)(MonoAssembly *, gpointer);

--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -71,4 +71,10 @@ mono_assembly_binding_applies_to_image (MonoImage* image, MonoImageOpenStatus *s
 MonoAssembly*
 mono_assembly_load_from_assemblies_path (gchar **assemblies_path, MonoAssemblyName *aname, MonoAssemblyContextKind asmctx);
 
+MONO_PROFILER_API MonoAssemblyName*
+mono_assembly_get_name_internal (MonoAssembly *assembly);
+
+MONO_PROFILER_API MonoImage*
+mono_assembly_get_image_internal (MonoAssembly *assembly);
+
 #endif /* __MONO_METADATA_ASSEMBLY_INTERNALS_H__ */

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -2052,7 +2052,11 @@ mono_assembly_open_from_bundle (const char *filename, MonoImageOpenStatus *statu
 MonoAssembly *
 mono_assembly_open_full (const char *filename, MonoImageOpenStatus *status, gboolean refonly)
 {
-	return mono_assembly_open_a_lot (filename, status, refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT);
+	MonoAssembly *res;
+	MONO_ENTER_GC_UNSAFE;
+	res = mono_assembly_open_a_lot (filename, status, refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT);
+	MONO_EXIT_GC_UNSAFE;
+	return res;
 }
 
 MonoAssembly *
@@ -2525,7 +2529,11 @@ mono_problematic_image_reprobe (MonoImage *image, MonoImageOpenStatus *status)
 MonoAssembly *
 mono_assembly_open (const char *filename, MonoImageOpenStatus *status)
 {
-	return mono_assembly_open_predicate (filename, MONO_ASMCTX_DEFAULT, NULL, NULL, status);
+	MonoAssembly *res;
+	MONO_ENTER_GC_UNSAFE;
+	res = mono_assembly_open_predicate (filename, MONO_ASMCTX_DEFAULT, NULL, NULL, status);
+	MONO_EXIT_GC_UNSAFE;
+	return res;
 }
 
 /**

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -3334,7 +3334,7 @@ mono_assembly_load_with_partial_name (const char *name, MonoImageOpenStatus *sta
 	if ((aname->major | aname->minor | aname->build | aname->revision) == 0)
 		aname = mono_assembly_remap_version (aname, &mapped_aname);
 	
-	res = mono_assembly_loaded (aname);
+	res = mono_assembly_loaded_full (aname, FALSE);
 	if (res) {
 		mono_assembly_name_free (aname);
 		return res;
@@ -4202,7 +4202,11 @@ mono_assembly_loaded_full (MonoAssemblyName *aname, gboolean refonly)
 MonoAssembly*
 mono_assembly_loaded (MonoAssemblyName *aname)
 {
-	return mono_assembly_loaded_full (aname, FALSE);
+	MonoAssembly *res;
+	MONO_ENTER_GC_UNSAFE;
+	res = mono_assembly_loaded_full (aname, FALSE);
+	MONO_EXIT_GC_UNSAFE;
+	return res;
 }
 
 void

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -2551,7 +2551,11 @@ MonoAssembly *
 mono_assembly_load_from_full (MonoImage *image, const char*fname, 
 			      MonoImageOpenStatus *status, gboolean refonly)
 {
-	return mono_assembly_load_from_predicate (image, fname, refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT, NULL, NULL, status);
+	MonoAssembly *res;
+	MONO_ENTER_GC_UNSAFE;
+	res = mono_assembly_load_from_predicate (image, fname, refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT, NULL, NULL, status);
+	MONO_EXIT_GC_UNSAFE;
+	return res;
 }
 
 MonoAssembly *
@@ -2727,7 +2731,11 @@ MonoAssembly *
 mono_assembly_load_from (MonoImage *image, const char *fname,
 			 MonoImageOpenStatus *status)
 {
-	return mono_assembly_load_from_full (image, fname, status, FALSE);
+	MonoAssembly *res;
+	MONO_ENTER_GC_UNSAFE;
+	res = mono_assembly_load_from_predicate (image, fname, MONO_ASMCTX_DEFAULT, NULL, NULL, status);
+	MONO_EXIT_GC_UNSAFE;
+	return res;
 }
 
 /**
@@ -4417,6 +4425,17 @@ mono_assembly_get_main (void)
 MonoImage*
 mono_assembly_get_image (MonoAssembly *assembly)
 {
+	MonoImage *res;
+	MONO_ENTER_GC_UNSAFE;
+	res = mono_assembly_get_image_internal (assembly);
+	MONO_EXIT_GC_UNSAFE;
+	return res;
+}
+
+MonoImage*
+mono_assembly_get_image_internal (MonoAssembly *assembly)
+{
+	MONO_REQ_GC_UNSAFE_MODE;
 	return assembly->image;
 }
 
@@ -4431,6 +4450,17 @@ mono_assembly_get_image (MonoAssembly *assembly)
 MonoAssemblyName *
 mono_assembly_get_name (MonoAssembly *assembly)
 {
+	MonoAssemblyName *res;
+	MONO_ENTER_GC_UNSAFE;
+	res = mono_assembly_get_name_internal (assembly);
+	MONO_EXIT_GC_UNSAFE;
+	return res;
+}
+
+MonoAssemblyName *
+mono_assembly_get_name_internal (MonoAssembly *assembly)
+{
+	MONO_REQ_GC_UNSAFE_MODE;
 	return &assembly->aname;
 }
 

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -3322,12 +3322,24 @@ probe_for_partial_name (const char *basepath, const char *fullname, MonoAssembly
 MonoAssembly*
 mono_assembly_load_with_partial_name (const char *name, MonoImageOpenStatus *status)
 {
+	MonoAssembly *result;
+	MONO_ENTER_GC_UNSAFE;
+	result = mono_assembly_load_with_partial_name_internal (name, status);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
+}
+
+MonoAssembly*
+mono_assembly_load_with_partial_name_internal (const char *name, MonoImageOpenStatus *status)
+{
 	ERROR_DECL (error);
 	MonoAssembly *res;
 	MonoAssemblyName *aname, base_name;
 	MonoAssemblyName mapped_aname;
 	gchar *fullname, *gacpath;
 	gchar **paths;
+
+	MONO_REQ_GC_UNSAFE_MODE;
 
 	memset (&base_name, 0, sizeof (MonoAssemblyName));
 	aname = &base_name;

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -4143,7 +4143,11 @@ mono_assembly_load_full_internal (MonoAssemblyName *aname, MonoAssembly *request
 MonoAssembly*
 mono_assembly_load_full (MonoAssemblyName *aname, const char *basedir, MonoImageOpenStatus *status, gboolean refonly)
 {
-	return mono_assembly_load_full_internal (aname, NULL, basedir, refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT, status);
+	MonoAssembly *res;
+	MONO_ENTER_GC_UNSAFE;
+	res = mono_assembly_load_full_internal (aname, NULL, basedir, refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT, status);
+	MONO_EXIT_GC_UNSAFE;
+	return res;
 }
 
 /**

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -2009,7 +2009,7 @@ mono_assembly_open_from_bundle (const char *filename, MonoImageOpenStatus *statu
 	mono_assemblies_lock ();
 	for (i = 0; !image && bundles [i]; ++i) {
 		if (strcmp (bundles [i]->name, is_satellite ? filename : name) == 0) {
-			image = mono_image_open_from_data_with_name ((char*)bundles [i]->data, bundles [i]->size, FALSE, status, refonly, name);
+			image = mono_image_open_from_data_internal ((char*)bundles [i]->data, bundles [i]->size, FALSE, status, refonly, FALSE, name);
 			break;
 		}
 	}

--- a/mono/metadata/assembly.h
+++ b/mono/metadata/assembly.h
@@ -37,6 +37,7 @@ MONO_API MonoAssembly* mono_assembly_load_from_full  (MonoImage *image, const ch
 
 MONO_API MonoAssembly* mono_assembly_load_with_partial_name (const char *name, MonoImageOpenStatus *status);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoAssembly* mono_assembly_loaded     (MonoAssemblyName *aname);
 MONO_API MonoAssembly* mono_assembly_loaded_full (MonoAssemblyName *aname, mono_bool refonly);
 MONO_API void          mono_assembly_get_assemblyref (MonoImage *image, int index, MonoAssemblyName *aname);

--- a/mono/metadata/assembly.h
+++ b/mono/metadata/assembly.h
@@ -26,8 +26,10 @@ MONO_API MonoAssembly* mono_assembly_load_full (MonoAssemblyName *aname,
                                        	const char       *basedir, 
 				     	MonoImageOpenStatus *status,
 					mono_bool refonly);
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoAssembly* mono_assembly_load_from  (MonoImage *image, const char *fname,
 					MonoImageOpenStatus *status);
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoAssembly* mono_assembly_load_from_full  (MonoImage *image, const char *fname,
 					MonoImageOpenStatus *status,
 					mono_bool refonly);
@@ -47,7 +49,9 @@ MONO_API char         *mono_native_getrootdir (void);
 MONO_API void	       mono_assembly_foreach    (MonoFunc func, void* user_data);
 MONO_API void          mono_assembly_set_main   (MonoAssembly *assembly);
 MONO_API MonoAssembly *mono_assembly_get_main   (void);
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoImage    *mono_assembly_get_image  (MonoAssembly *assembly);
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoAssemblyName *mono_assembly_get_name (MonoAssembly *assembly);
 MONO_API mono_bool      mono_assembly_fill_assembly_name (MonoImage *image, MonoAssemblyName *aname);
 MONO_API mono_bool      mono_assembly_names_equal (MonoAssemblyName *l, MonoAssemblyName *r);

--- a/mono/metadata/assembly.h
+++ b/mono/metadata/assembly.h
@@ -22,6 +22,7 @@ MONO_API MonoAssembly *mono_assembly_open_full (const char *filename,
 MONO_API MonoAssembly* mono_assembly_load       (MonoAssemblyName *aname, 
                                        	const char       *basedir, 
 				     	MonoImageOpenStatus *status);
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoAssembly* mono_assembly_load_full (MonoAssemblyName *aname, 
                                        	const char       *basedir, 
 				     	MonoImageOpenStatus *status,

--- a/mono/metadata/assembly.h
+++ b/mono/metadata/assembly.h
@@ -35,6 +35,7 @@ MONO_API MonoAssembly* mono_assembly_load_from_full  (MonoImage *image, const ch
 					MonoImageOpenStatus *status,
 					mono_bool refonly);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoAssembly* mono_assembly_load_with_partial_name (const char *name, MonoImageOpenStatus *status);
 
 MONO_RT_EXTERNAL_ONLY

--- a/mono/metadata/attach.c
+++ b/mono/metadata/attach.c
@@ -287,7 +287,7 @@ mono_attach_load_agent (MonoDomain *domain, char *agent, char *args, MonoObject 
 	 * Can't use mono_jit_exec (), as it sets things which might confuse the
 	 * real Main method.
 	 */
-	image = mono_assembly_get_image (agent_assembly);
+	image = mono_assembly_get_image_internal (agent_assembly);
 	entry = mono_image_get_entry_point (image);
 	if (!entry) {
 		g_print ("Assembly '%s' doesn't have an entry point.\n", mono_image_get_filename (image));

--- a/mono/metadata/callspec.c
+++ b/mono/metadata/callspec.c
@@ -15,6 +15,7 @@
 #include "metadata.h"
 #include "callspec.h"
 #include "assembly.h"
+#include "assembly-internals.h"
 #include "class-internals.h"
 #include "debug-helpers.h"
 
@@ -74,7 +75,7 @@ gboolean mono_callspec_eval (MonoMethod *method, const MonoCallSpec *spec)
 		case MONO_TRACEOP_PROGRAM:
 			if (prog_assembly &&
 			    (m_class_get_image (method->klass) ==
-			     mono_assembly_get_image (prog_assembly)))
+			     mono_assembly_get_image_internal (prog_assembly)))
 				inc = 1;
 			break;
 		case MONO_TRACEOP_WRAPPER:

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -4132,11 +4132,15 @@ mono_class_is_enum (MonoClass *klass)
 MonoType*
 mono_class_enum_basetype (MonoClass *klass)
 {
+	MonoType *res;
+	MONO_ENTER_GC_UNSAFE;
 	if (m_class_get_element_class (klass) == klass)
 		/* SRE or broken types */
-		return NULL;
+		res = NULL;
 	else
-		return m_class_get_byval_arg (m_class_get_element_class (klass));
+		res = m_class_get_byval_arg (m_class_get_element_class (klass));
+	MONO_EXIT_GC_UNSAFE;
+	return res;
 }
 
 /**

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -4603,11 +4603,14 @@ MonoType*
 mono_field_get_type (MonoClassField *field)
 {
 	ERROR_DECL (error);
-	MonoType *type = mono_field_get_type_checked (field, error);
+	MonoType *type;
+	MONO_ENTER_GC_UNSAFE;
+	type = mono_field_get_type_checked (field, error);
 	if (!mono_error_ok (error)) {
 		mono_trace_warning (MONO_TRACE_TYPE, "Could not load field's type due to %s", mono_error_get_message (error));
 		mono_error_cleanup (error);
 	}
+	MONO_EXIT_GC_UNSAFE;
 	return type;
 }
 

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -966,7 +966,11 @@ mono_method_get_name_full (MonoMethod *method, gboolean signature, gboolean ret,
 char *
 mono_method_full_name (MonoMethod *method, gboolean signature)
 {
-	return mono_method_get_name_full (method, signature, FALSE, MONO_TYPE_NAME_FORMAT_IL);
+	char *res;
+	MONO_ENTER_GC_UNSAFE;
+	res = mono_method_get_name_full (method, signature, FALSE, MONO_TYPE_NAME_FORMAT_IL);
+	MONO_EXIT_GC_UNSAFE;
+	return res;
 }
 
 char *

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -124,6 +124,9 @@ get_runtimes_from_exe (const char *exe_file, MonoImage **exe_image, const MonoRu
 static const MonoRuntimeInfo*
 get_runtime_by_version (const char *version);
 
+MonoAssembly *
+mono_domain_assembly_open_internal (MonoDomain *domain, const char *name);
+
 static LockFreeMempool*
 lock_free_mempool_new (void)
 {
@@ -992,9 +995,21 @@ mono_domain_foreach (MonoDomainFunc func, gpointer user_data)
 MonoAssembly *
 mono_domain_assembly_open (MonoDomain *domain, const char *name)
 {
+	MonoAssembly *result;
+	MONO_ENTER_GC_UNSAFE;
+	result = mono_domain_assembly_open_internal (domain, name);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
+}
+
+MonoAssembly *
+mono_domain_assembly_open_internal (MonoDomain *domain, const char *name)
+{
 	MonoDomain *current;
 	MonoAssembly *ass;
 	GSList *tmp;
+
+	MONO_REQ_GC_UNSAFE_MODE;
 
 	mono_domain_assemblies_lock (domain);
 	for (tmp = domain->domain_assemblies; tmp; tmp = tmp->next) {

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -594,7 +594,7 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 		
 		exit (1);
 	}
-	mono_defaults.corlib = mono_assembly_get_image (ass);
+	mono_defaults.corlib = mono_assembly_get_image_internal (ass);
 
 	mono_defaults.object_class = mono_class_load_from_name (
                 mono_defaults.corlib, "System", "Object");

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -4749,7 +4749,7 @@ ves_icall_System_Reflection_Assembly_load_with_partial_name (MonoStringHandle mn
 	
 	name = mono_string_handle_to_utf8 (mname, error);
 	goto_if_nok (error, leave);
-	MonoAssembly *res = mono_assembly_load_with_partial_name (name, &status);
+	MonoAssembly *res = mono_assembly_load_with_partial_name_internal (name, &status);
 
 	g_free (name);
 

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1544,7 +1544,7 @@ ves_icall_System_Type_internal_from_name (MonoStringHandle name,
 			if (info.assembly.name)
 				aname = mono_stringify_assembly_name (&info.assembly);
 			else if (caller_assembly)
-				aname = mono_stringify_assembly_name (mono_assembly_get_name (caller_assembly));
+				aname = mono_stringify_assembly_name (mono_assembly_get_name_internal (caller_assembly));
 			else
 				aname = g_strdup ("");
 			mono_error_set_type_load_name (error, tname, aname, "");

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1614,7 +1614,11 @@ mono_image_open_from_data_with_name (char *data, guint32 data_len, gboolean need
 MonoImage *
 mono_image_open_from_data_full (char *data, guint32 data_len, gboolean need_copy, MonoImageOpenStatus *status, gboolean refonly)
 {
-  return mono_image_open_from_data_with_name (data, data_len, need_copy, status, refonly, NULL);
+	MonoImage *result;
+	MONO_ENTER_GC_UNSAFE;
+	result = mono_image_open_from_data_internal (data, data_len, need_copy, status, refonly, FALSE, NULL);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
 }
 
 /**
@@ -1623,7 +1627,11 @@ mono_image_open_from_data_full (char *data, guint32 data_len, gboolean need_copy
 MonoImage *
 mono_image_open_from_data (char *data, guint32 data_len, gboolean need_copy, MonoImageOpenStatus *status)
 {
-	return mono_image_open_from_data_full (data, data_len, need_copy, status, FALSE);
+	MonoImage *result;
+	MONO_ENTER_GC_UNSAFE;
+	result = mono_image_open_from_data_internal (data, data_len, need_copy, status, FALSE, FALSE, NULL);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
 }
 
 #ifdef HOST_WIN32

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1605,7 +1605,11 @@ mono_image_open_from_data_internal (char *data, guint32 data_len, gboolean need_
 MonoImage *
 mono_image_open_from_data_with_name (char *data, guint32 data_len, gboolean need_copy, MonoImageOpenStatus *status, gboolean refonly, const char *name)
 {
-	return mono_image_open_from_data_internal (data, data_len, need_copy, status, refonly, FALSE, name);
+	MonoImage *result;
+	MONO_ENTER_GC_UNSAFE;
+	result = mono_image_open_from_data_internal (data, data_len, need_copy, status, refonly, FALSE, name);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
 }
 
 /**

--- a/mono/metadata/image.h
+++ b/mono/metadata/image.h
@@ -32,10 +32,13 @@ MONO_API MonoImage    *mono_image_open_full (const char *fname,
 				   MonoImageOpenStatus *status, mono_bool refonly);
 MONO_API MonoImage    *mono_pe_file_open     (const char *fname,
 				     MonoImageOpenStatus *status);
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoImage    *mono_image_open_from_data (char *data, uint32_t data_len, mono_bool need_copy,
                                          MonoImageOpenStatus *status);
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoImage    *mono_image_open_from_data_full (char *data, uint32_t data_len, mono_bool need_copy,
                                          MonoImageOpenStatus *status, mono_bool refonly);
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoImage    *mono_image_open_from_data_with_name (char *data, uint32_t data_len, mono_bool need_copy,
                                                    MonoImageOpenStatus *status, mono_bool refonly, const char *name);
 MONO_API void          mono_image_fixup_vtable (MonoImage *image);

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -2577,7 +2577,7 @@ mono_method_signature (MonoMethod *m)
 {
 	ERROR_DECL (error);
 	MonoMethodSignature *sig;
-
+	MONO_ENTER_GC_UNSAFE;
 	sig = mono_method_signature_checked (m, error);
 	if (!sig) {
 		char *type_name = mono_type_get_full_name (m->klass);
@@ -2585,7 +2585,7 @@ mono_method_signature (MonoMethod *m)
 		g_free (type_name);
 		mono_error_cleanup (error);
 	}
-
+	MONO_EXIT_GC_UNSAFE;
 	return sig;
 }
 

--- a/mono/metadata/mono-debug.c
+++ b/mono/metadata/mono-debug.c
@@ -12,6 +12,7 @@
 
 #include <config.h>
 #include <mono/metadata/assembly.h>
+#include <mono/metadata/assembly-internals.h>
 #include <mono/metadata/tabledefs.h>
 #include <mono/metadata/tokentype.h>
 #include <mono/metadata/appdomain.h>
@@ -295,7 +296,7 @@ mono_debug_add_assembly (MonoAssembly *assembly, gpointer user_data)
 	MonoImage *image;
 
 	mono_debugger_lock ();
-	image = mono_assembly_get_image (assembly);
+	image = mono_assembly_get_image_internal (assembly);
 	handle = open_symfile_from_bundle (image);
 	if (!handle)
 		mono_debug_open_image (image, NULL, 0);

--- a/mono/metadata/mono-security.c
+++ b/mono/metadata/mono-security.c
@@ -627,7 +627,7 @@ void mono_invoke_protected_memory_method (MonoArray *data, MonoObject *scope, gb
 			MonoAssembly *sa = mono_assembly_open_predicate ("System.Security.dll", MONO_ASMCTX_DEFAULT, NULL, NULL, NULL);
 			if (!sa)
 				g_assert_not_reached ();
-			system_security_assembly = mono_assembly_get_image (sa);
+			system_security_assembly = mono_assembly_get_image_internal (sa);
 		}
 	}
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1768,6 +1768,9 @@ MonoObject *
 mono_object_new_alloc_specific_checked (MonoVTable *vtable, MonoError *error);
 
 void
+mono_field_get_value_internal (MonoObject *obj, MonoClassField *field, void *value);
+
+void
 mono_field_static_get_value_checked (MonoVTable *vt, MonoClassField *field, void *value, MonoError *error);
 
 void

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -6596,9 +6596,12 @@ mono_string_new_wrapper (const char *text)
 MonoObject *
 mono_value_box (MonoDomain *domain, MonoClass *klass, gpointer value)
 {
+	MonoObject *result;
+	MONO_ENTER_GC_UNSAFE;
 	ERROR_DECL (error);
-	MonoObject *result = mono_value_box_checked (domain, klass, value, error);
+	result = mono_value_box_checked (domain, klass, value, error);
 	mono_error_cleanup (error);
+	MONO_EXIT_GC_UNSAFE;
 	return result;
 }
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -7308,15 +7308,16 @@ mono_ldstr_utf8 (MonoImage *image, guint32 idx, MonoError *error)
 char *
 mono_string_to_utf8 (MonoString *s)
 {
-	MONO_REQ_GC_UNSAFE_MODE;
-
+	char *result;
+	MONO_ENTER_GC_UNSAFE;
 	ERROR_DECL (error);
-	char *result = mono_string_to_utf8_checked (s, error);
+	result = mono_string_to_utf8_checked (s, error);
 	
 	if (!is_ok (error)) {
 		mono_error_cleanup (error);
-		return NULL;
+		result = NULL;
 	}
+	MONO_EXIT_GC_UNSAFE;
 	return result;
 }
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -3775,7 +3775,7 @@ mono_field_static_get_value_checked (MonoVTable *vt, MonoClassField *field, void
 void
 mono_property_set_value (MonoProperty *prop, void *obj, void **params, MonoObject **exc)
 {
-	MONO_REQ_GC_UNSAFE_MODE;
+	MONO_ENTER_GC_UNSAFE;
 
 	ERROR_DECL (error);
 	do_runtime_invoke (prop->set, obj, params, exc, error);
@@ -3784,6 +3784,7 @@ mono_property_set_value (MonoProperty *prop, void *obj, void **params, MonoObjec
 	} else {
 		mono_error_cleanup (error);
 	}
+	MONO_EXIT_GC_UNSAFE;
 }
 
 /**

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -7635,7 +7635,9 @@ mono_get_eh_callbacks (void)
 void
 mono_raise_exception (MonoException *ex) 
 {
+	MONO_ENTER_GC_UNSAFE;
 	mono_raise_exception_deprecated (ex);
+	MONO_EXIT_GC_UNSAFE;
 }
 
 /*

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -5385,13 +5385,12 @@ object_new_handle_common_tail (MonoObjectHandle o, MonoClass *klass, MonoError *
 MonoObject *
 mono_object_new (MonoDomain *domain, MonoClass *klass)
 {
-	MONO_REQ_GC_UNSAFE_MODE;
-
+	MonoObject * result;
+	MONO_ENTER_GC_UNSAFE;
 	ERROR_DECL (error);
-
-	MonoObject * result = mono_object_new_checked (domain, klass, error);
-
+	result = mono_object_new_checked (domain, klass, error);
 	mono_error_cleanup (error);
+	MONO_EXIT_GC_UNSAFE;
 	return result;
 }
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -3413,6 +3413,14 @@ mono_field_get_addr (MonoObject *obj, MonoVTable *vt, MonoClassField *field)
 void
 mono_field_get_value (MonoObject *obj, MonoClassField *field, void *value)
 {
+	MONO_ENTER_GC_UNSAFE;
+	mono_field_get_value_internal (obj, field, value);
+	MONO_EXIT_GC_UNSAFE;
+}
+
+void
+mono_field_get_value_internal (MonoObject *obj, MonoClassField *field, void *value)
+{
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	void *src;

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -8737,9 +8737,11 @@ mono_string_handle_length (MonoStringHandle s)
 uintptr_t
 mono_array_length (MonoArray *array)
 {
-	MONO_REQ_GC_UNSAFE_MODE;
-
-	return array->max_length;
+	uintptr_t res;
+	MONO_ENTER_GC_UNSAFE;
+	res = array->max_length;
+	MONO_EXIT_GC_UNSAFE;
+	return res;
 }
 
 /**

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -3328,13 +3328,15 @@ leave:
 void
 mono_field_static_set_value (MonoVTable *vt, MonoClassField *field, void *value)
 {
-	MONO_REQ_GC_UNSAFE_MODE;
+	MONO_ENTER_GC_UNSAFE;
 
 	void *dest;
 
-	g_return_if_fail (field->type->attrs & FIELD_ATTRIBUTE_STATIC);
+	if ((field->type->attrs & FIELD_ATTRIBUTE_STATIC) == 0)
+		goto leave;
 	/* you cant set a constant! */
-	g_return_if_fail (!(field->type->attrs & FIELD_ATTRIBUTE_LITERAL));
+	if ((field->type->attrs & FIELD_ATTRIBUTE_LITERAL))
+		goto leave;
 
 	if (field->offset == -1) {
 		/* Special static */
@@ -3348,6 +3350,8 @@ mono_field_static_set_value (MonoVTable *vt, MonoClassField *field, void *value)
 		dest = (char*)mono_vtable_get_static_field_data (vt) + field->offset;
 	}
 	mono_copy_value (field->type, dest, value, FALSE);
+leave:
+	MONO_EXIT_GC_UNSAFE;
 }
 
 /**

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -3304,14 +3304,17 @@ handle_enum:
 void
 mono_field_set_value (MonoObject *obj, MonoClassField *field, void *value)
 {
-	MONO_REQ_GC_UNSAFE_MODE;
+	MONO_ENTER_GC_UNSAFE;
 
 	void *dest;
 
-	g_return_if_fail (!(field->type->attrs & FIELD_ATTRIBUTE_STATIC));
+	if ((field->type->attrs & FIELD_ATTRIBUTE_STATIC))
+		goto leave;
 
 	dest = (char*)obj + field->offset;
 	mono_copy_value (field->type, dest, value, FALSE);
+leave:
+	MONO_EXIT_GC_UNSAFE;
 }
 
 /**

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -2993,11 +2993,14 @@ mono_reflection_call_is_assignable_to (MonoClass *klass, MonoClass *oklass, Mono
 MonoType*
 mono_reflection_type_get_type (MonoReflectionType *reftype)
 {
+	MonoType *result;
+	MONO_ENTER_GC_UNSAFE;
 	g_assert (reftype);
 
 	ERROR_DECL (error);
-	MonoType *result = mono_reflection_type_get_handle (reftype, error);
+	result = mono_reflection_type_get_handle (reftype, error);
 	mono_error_assert_ok (error);
+	MONO_EXIT_GC_UNSAFE;
 	return result;
 }
 

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -219,9 +219,12 @@ MonoReflectionAssembly*
 mono_assembly_get_object (MonoDomain *domain, MonoAssembly *assembly)
 {
 	HANDLE_FUNCTION_ENTER ();
+	MonoReflectionAssemblyHandle result;
+	MONO_ENTER_GC_UNSAFE;
 	ERROR_DECL (error);
-	MonoReflectionAssemblyHandle result = mono_assembly_get_object_handle (domain, assembly, error);
+	result = mono_assembly_get_object_handle (domain, assembly, error);
 	mono_error_cleanup (error); /* FIXME new API that doesn't swallow the error */
+	MONO_EXIT_GC_UNSAFE;
 	HANDLE_FUNCTION_RETURN_OBJ (result);
 }
 

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -575,9 +575,12 @@ MonoReflectionMethod*
 mono_method_get_object (MonoDomain *domain, MonoMethod *method, MonoClass *refclass)
 {
 	HANDLE_FUNCTION_ENTER ();
+	MonoReflectionMethodHandle ret;
+	MONO_ENTER_GC_UNSAFE;
 	ERROR_DECL (error);
-	MonoReflectionMethodHandle ret = mono_method_get_object_handle (domain, method, refclass, error);
+	ret = mono_method_get_object_handle (domain, method, refclass, error);
 	mono_error_cleanup (error);
+	MONO_EXIT_GC_UNSAFE;
 	HANDLE_FUNCTION_RETURN_OBJ (ret);
 }
 

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -1840,7 +1840,7 @@ _mono_reflection_get_type_from_info (MonoTypeNameParse *info, MonoImage *image, 
 	error_init (error);
 
 	if (info->assembly.name) {
-		MonoAssembly *assembly = mono_assembly_loaded (&info->assembly);
+		MonoAssembly *assembly = mono_assembly_loaded_full (&info->assembly, FALSE);
 		if (!assembly && image && image->assembly && mono_assembly_names_equal (&info->assembly, &image->assembly->aname))
 			/* 
 			 * This could happen in the AOT compiler case when the search hook is not

--- a/mono/metadata/reflection.h
+++ b/mono/metadata/reflection.h
@@ -62,6 +62,7 @@ MONO_RT_EXTERNAL_ONLY
 MONO_API MonoReflectionModule*   mono_module_get_object   (MonoDomain *domain, MonoImage *image);
 MONO_RT_EXTERNAL_ONLY
 MONO_API MonoReflectionModule*   mono_module_file_get_object (MonoDomain *domain, MonoImage *image, int table_index);
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoReflectionType*     mono_type_get_object     (MonoDomain *domain, MonoType *type);
 MONO_RT_EXTERNAL_ONLY
 MONO_API MonoReflectionMethod*   mono_method_get_object   (MonoDomain *domain, MonoMethod *method, MonoClass *refclass);

--- a/mono/metadata/reflection.h
+++ b/mono/metadata/reflection.h
@@ -164,6 +164,7 @@ MONO_API MonoBoolean mono_declsec_get_method_action (MonoMethod *method, uint32_
 MONO_API MonoBoolean mono_declsec_get_class_action (MonoClass *klass, uint32_t action, MonoDeclSecurityEntry *entry);
 MONO_API MonoBoolean mono_declsec_get_assembly_action (MonoAssembly *assembly, uint32_t action, MonoDeclSecurityEntry *entry);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoType* mono_reflection_type_get_type (MonoReflectionType *reftype);
 
 MONO_API MonoAssembly* mono_reflection_assembly_get_assembly (MonoReflectionAssembly *refassembly);

--- a/mono/metadata/sgen-toggleref.c
+++ b/mono/metadata/sgen-toggleref.c
@@ -207,7 +207,8 @@ test_toggleref_callback (MonoObject *obj)
 		g_assert (mono_toggleref_test_field);
 	}
 
-	mono_field_get_value (obj, mono_toggleref_test_field, &status);
+	/* In coop mode, important to not call a helper that will pin obj! */
+	mono_field_get_value_internal (obj, mono_toggleref_test_field, &status);
 	printf ("toggleref-cb obj %d\n", status);
 	return status;
 }

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1362,9 +1362,11 @@ mono_thread_create_internal (MonoDomain *domain, gpointer func, gpointer arg, Mo
 void
 mono_thread_create (MonoDomain *domain, gpointer func, gpointer arg)
 {
+	MONO_ENTER_GC_UNSAFE;
 	ERROR_DECL (error);
 	if (!mono_thread_create_checked (domain, func, arg, error))
 		mono_error_cleanup (error);
+	MONO_EXIT_GC_UNSAFE;
 }
 
 gboolean

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -722,7 +722,7 @@ get_socket_assembly (void)
 			if (!sa) {
 				g_assert_not_reached ();
 			} else {
-				socket_assembly = mono_assembly_get_image (sa);
+				socket_assembly = mono_assembly_get_image_internal (sa);
 			}
 		}
 		mono_atomic_store_release (&domain->socket_assembly, socket_assembly);
@@ -2005,7 +2005,7 @@ ves_icall_System_Net_Sockets_Socket_GetSocketOption_obj_internal (gsize sock, gi
 					*werror = WSAENOPROTOOPT;
 					return;
 				} else {
-					mono_posix_image = mono_assembly_get_image (sa);
+					mono_posix_image = mono_assembly_get_image_internal (sa);
 				}
 			}
 		}

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -60,6 +60,7 @@
 #include <mono/metadata/threads-types.h>
 #include <mono/metadata/threadpool.h>
 #include <mono/metadata/assembly.h>
+#include <mono/metadata/assembly-internals.h>
 #include <mono/metadata/runtime.h>
 #include <mono/metadata/verify-internals.h>
 #include <mono/metadata/reflection-internals.h>
@@ -6581,7 +6582,7 @@ clear_event_requests_for_assembly (MonoAssembly *assembly)
 static gboolean
 type_comes_from_assembly (gpointer klass, gpointer also_klass, gpointer assembly)
 {
-	return mono_type_in_image (mono_class_get_type ((MonoClass*)klass), mono_assembly_get_image ((MonoAssembly*)assembly));
+	return mono_type_in_image (mono_class_get_type ((MonoClass*)klass), mono_assembly_get_image_internal ((MonoAssembly*)assembly));
 }
 
 /*

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -554,7 +554,7 @@ mini_regression_list (int verbose, int count, char *images [])
 			g_warning ("failed to load assembly: %s", images [i]);
 			continue;
 		}
-		total += mini_regression (mono_assembly_get_image (ass), verbose, &run);
+		total += mini_regression (mono_assembly_get_image_internal (ass), verbose, &run);
 		total_run += run;
 	}
 	if (total > 0){
@@ -720,7 +720,7 @@ mono_interp_regression_list (int verbose, int count, char *images [])
 			g_warning ("failed to load assembly: %s", images [i]);
 			continue;
 		}
-		total += interp_regression (mono_assembly_get_image (ass), verbose, &run);
+		total += interp_regression (mono_assembly_get_image_internal (ass), verbose, &run);
 		total_run += run;
 	}
 	if (total > 0) {
@@ -1076,7 +1076,7 @@ compile_all_methods_thread_main_inner (CompileAllThreadArgs *args)
 {
 	MonoAssembly *ass = args->ass;
 	int verbose = args->verbose;
-	MonoImage *image = mono_assembly_get_image (ass);
+	MonoImage *image = mono_assembly_get_image_internal (ass);
 	MonoMethod *method;
 	MonoCompile *cfg;
 	int i, count = 0, fail_count = 0;
@@ -1175,7 +1175,7 @@ int
 mono_jit_exec (MonoDomain *domain, MonoAssembly *assembly, int argc, char *argv[])
 {
 	ERROR_DECL (error);
-	MonoImage *image = mono_assembly_get_image (assembly);
+	MonoImage *image = mono_assembly_get_image_internal (assembly);
 	MonoMethod *method;
 	guint32 entry = mono_image_get_entry_point (image);
 
@@ -1321,7 +1321,7 @@ load_agent (MonoDomain *domain, char *desc)
 	 * Can't use mono_jit_exec (), as it sets things which might confuse the
 	 * real Main method.
 	 */
-	image = mono_assembly_get_image (agent_assembly);
+	image = mono_assembly_get_image_internal (agent_assembly);
 	entry = mono_image_get_entry_point (image);
 	if (!entry) {
 		g_print ("Assembly '%s' doesn't have an entry point.\n", mono_image_get_filename (image));
@@ -2383,7 +2383,7 @@ mono_main (int argc, char* argv[])
 
 #if defined(HOST_WIN32) && G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT)
 		/* Detach console when executing IMAGE_SUBSYSTEM_WINDOWS_GUI on win32 */
-		if (!enable_debugging && !mono_compile_aot && ((MonoCLIImageInfo*)(mono_assembly_get_image (assembly)->image_info))->cli_header.nt.pe_subsys_required == IMAGE_SUBSYSTEM_WINDOWS_GUI)
+		if (!enable_debugging && !mono_compile_aot && ((MonoCLIImageInfo*)(mono_assembly_get_image_internal (assembly)->image_info))->cli_header.nt.pe_subsys_required == IMAGE_SUBSYSTEM_WINDOWS_GUI)
 			FreeConsole ();
 #endif
 
@@ -2418,7 +2418,7 @@ mono_main (int argc, char* argv[])
 		mini_cleanup (domain);
 		return 3;
 	}
-	method = mono_method_desc_search_in_image (desc, mono_assembly_get_image (assembly));
+	method = mono_method_desc_search_in_image (desc, mono_assembly_get_image_internal (assembly));
 	if (!method) {
 		g_print ("Cannot find method %s\n", mname);
 		mini_cleanup (domain);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -30,6 +30,7 @@
 #include <mono/utils/memcheck.h>
 
 #include <mono/metadata/assembly.h>
+#include <mono/metadata/assembly-internals.h>
 #include <mono/metadata/loader.h>
 #include <mono/metadata/tabledefs.h>
 #include <mono/metadata/class.h>
@@ -4892,7 +4893,7 @@ static void
 mono_precompile_assembly (MonoAssembly *ass, void *user_data)
 {
 	GHashTable *assemblies = (GHashTable*)user_data;
-	MonoImage *image = mono_assembly_get_image (ass);
+	MonoImage *image = mono_assembly_get_image_internal (ass);
 	MonoMethod *method, *invoke;
 	int i, count = 0;
 

--- a/mono/profiler/coverage.c
+++ b/mono/profiler/coverage.c
@@ -59,6 +59,7 @@
 #include <stdio.h>
 
 #include <mono/metadata/assembly.h>
+#include <mono/metadata/assembly-internals.h>
 #include <mono/metadata/debug-helpers.h>
 #include <mono/metadata/metadata-internals.h>
 #include <mono/metadata/profiler.h>
@@ -412,7 +413,7 @@ static void
 dump_assembly (gpointer key, gpointer value, gpointer userdata)
 {
 	MonoAssembly *assembly = (MonoAssembly *)value;
-	MonoImage *image = mono_assembly_get_image (assembly);
+	MonoImage *image = mono_assembly_get_image_internal (assembly);
 	const char *image_name, *image_guid, *image_filename;
 	char *escaped_image_name, *escaped_image_filename;
 	int number_of_methods = 0, partially_covered = 0;
@@ -646,7 +647,7 @@ assembly_loaded (MonoProfiler *prof, MonoAssembly *assembly)
 		return;
 	}
 
-	MonoImage *image = mono_assembly_get_image (assembly);
+	MonoImage *image = mono_assembly_get_image_internal (assembly);
 
 	if (!consider_image (image))
 		return;

--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -12,6 +12,7 @@
 
 #include <config.h>
 #include <mono/metadata/assembly.h>
+#include <mono/metadata/assembly-internals.h>
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/debug-helpers.h>
 #include <mono/metadata/loader.h>
@@ -1759,9 +1760,9 @@ image_unloaded (MonoProfiler *prof, MonoImage *image)
 static void
 assembly_loaded (MonoProfiler *prof, MonoAssembly *assembly)
 {
-	char *name = mono_stringify_assembly_name (mono_assembly_get_name (assembly));
+	char *name = mono_stringify_assembly_name (mono_assembly_get_name_internal (assembly));
 	int nlen = strlen (name) + 1;
-	MonoImage *image = mono_assembly_get_image (assembly);
+	MonoImage *image = mono_assembly_get_image_internal (assembly);
 
 	ENTER_LOG (&assembly_loads_ctr, logbuffer,
 		EVENT_SIZE /* event */ +
@@ -1786,9 +1787,9 @@ assembly_loaded (MonoProfiler *prof, MonoAssembly *assembly)
 static void
 assembly_unloaded (MonoProfiler *prof, MonoAssembly *assembly)
 {
-	char *name = mono_stringify_assembly_name (mono_assembly_get_name (assembly));
+	char *name = mono_stringify_assembly_name (mono_assembly_get_name_internal (assembly));
 	int nlen = strlen (name) + 1;
-	MonoImage *image = mono_assembly_get_image (assembly);
+	MonoImage *image = mono_assembly_get_image_internal (assembly);
 
 	ENTER_LOG (&assembly_unloads_ctr, logbuffer,
 		EVENT_SIZE /* event */ +

--- a/mono/tests/metadata-verifier/gen-md-tests.c
+++ b/mono/tests/metadata-verifier/gen-md-tests.c
@@ -272,7 +272,7 @@ init_test_set (test_set_t *test_set)
 	if (test_set->init)
 		return;
 	test_set->assembly_data = read_whole_file_and_close (test_set->assembly, &test_set->assembly_size);
-	test_set->image = mono_image_open_from_data (test_set->assembly_data, test_set->assembly_size, FALSE, &status);
+	test_set->image = mono_image_open_from_data_internal (test_set->assembly_data, test_set->assembly_size, FALSE, &status, FALSE, FALSE, NULL);
 	if (!test_set->image || status != MONO_IMAGE_OK) {
 		printf ("Could not parse image %s\n", test_set->assembly);
 		exit (INVALID_BAD_FILE);

--- a/mono/tests/sgen-toggleref.cs
+++ b/mono/tests/sgen-toggleref.cs
@@ -37,7 +37,7 @@ class Driver {
 	static WeakReference<Toggleref> root, child;
 
 	[DllImport ("__Internal", EntryPoint="mono_gc_toggleref_add")]
-	static extern int mono_gc_toggleref_add (IntPtr ptr, bool strong_ref);
+	static extern void mono_gc_toggleref_add (IntPtr ptr, bool strong_ref);
 
 	static void Register (object obj)
 	{

--- a/mono/unit-tests/test-mono-callspec.c
+++ b/mono/unit-tests/test-mono-callspec.c
@@ -183,7 +183,7 @@ main (void)
 
 	mono_callspec_set_assembly(assembly);
 
-	prog_image = mono_assembly_get_image (assembly);
+	prog_image = mono_assembly_get_image_internal (assembly);
 
 	prog_klass = test_mono_class_from_name (prog_image, "Baz", "Foo");
 	if (!prog_klass) {

--- a/mono/utils/mono-logger-internals.h
+++ b/mono/utils/mono-logger-internals.h
@@ -29,6 +29,7 @@ typedef enum {
 	MONO_TRACE_IO_LAYER_MUTEX     = 1 << 14,
 	MONO_TRACE_IO_LAYER_HANDLE    = 1 << 15,
 	MONO_TRACE_TAILCALL           = 1 << 16,
+	MONO_TRACE_PROFILER           = 1 << 17,
 } MonoTraceMask;
 
 MONO_API extern GLogLevelFlags mono_internal_current_level;

--- a/mono/utils/mono-logger.c
+++ b/mono/utils/mono-logger.c
@@ -305,6 +305,7 @@ mono_trace_set_mask_string (const char *value)
 		               | MONO_TRACE_IO_LAYER_HANDLE },
 		{ "w32handle", MONO_TRACE_IO_LAYER_HANDLE },
 		{ "tailcall", MONO_TRACE_TAILCALL },
+		{ "profiler", MONO_TRACE_PROFILER },
 		{ "all", ~((MonoTraceMask)0) },
 		{ NULL, 0 },
 	};


### PR DESCRIPTION
For Hybrid suspend #6921 to be seamless for embedders, we want each Mono function that can be called from GC Safe code to perform its own transition to GC Unsafe.

This PR adds the transitions to about a third of the functions in the list in this comment: https://github.com/mono/mono/issues/6921#issuecomment-390757584