### PR TITLE
Fix G_LIKELY / G_UNLIKELY compile error.

### DIFF
--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -726,8 +726,8 @@ GUnicodeBreakType   g_unichar_break_type (gunichar c);
 #endif
 
 #if defined(__GNUC__) && (__GNUC__ > 2)
-#define G_LIKELY(expr) (__builtin_expect ((expr) != 0, 1))
-#define G_UNLIKELY(expr) (__builtin_expect ((expr) != 0, 0))
+#define G_LIKELY(expr) (__builtin_expect (!!(expr), 1))
+#define G_UNLIKELY(expr) (__builtin_expect (!!(expr), 0))
 #else
 #define G_LIKELY(x) (x)
 #define G_UNLIKELY(x) (x)


### PR DESCRIPTION
https://jenkins.mono-project.com/job/test-mono-pull-request-amd64-fullaot+llvm/1023/parsed_console/log_content.html#ERROR1

```
In file included from mini-llvm-cpp.h:14:0,
                 from llvm-jit.cpp:18:
llvm-jit.cpp: In member function 'void* MonoLLVMJIT::compile(llvm::Function*, int, LLVMOpaqueValue**, void**, void**)':
../../mono/eglib/glib.h:710:50: error: no match for 'operator!=' (operand types are 'llvm::Expected<long unsigned int>' and 'int')
 #define G_LIKELY(expr) (__builtin_expect ((expr) != 0, 1))
                                           ~~~~~~~^~~~
../../mono/eglib/glib.h:729:3: note: in expansion of macro 'G_LIKELY'
  (G_LIKELY(x) ? 1 : (g_assertion_message ( \
   ^~~~~~~~
llvm-jit.cpp:247:4: note: in expansion of macro 'g_assert'
    g_assert (addr);
```