### PR TITLE
[Mono.Debugger.Soft.Test] Use interp on debugee

### DIFF
--- a/mcs/build/tests.make
+++ b/mcs/build/tests.make
@@ -212,7 +212,7 @@ endif
 ## FIXME: i18n problem in the 'sed' command below
 run-test-lib: test-local test-local-aot-compile patch-nunitlite-appconfig
 	ok=:; \
-	PATH="$(TEST_RUNTIME_WRAPPERS_PATH):$(PATH)" MONO_REGISTRY_PATH="$(HOME)/.mono/registry" MONO_TESTS_IN_PROGRESS="yes" $(TEST_HARNESS_EXEC) $(test_assemblies) $(NOSHADOW_FLAG) $(TEST_HARNESS_FLAGS) $(LOCAL_TEST_HARNESS_FLAGS) $(TEST_HARNESS_EXCLUDES) $(LABELS_ARG) -format:nunit2 -result:TestResult-$(PROFILE).xml $(FIXTURE_ARG) $(TESTNAME_ARG)|| ok=false; \
+	PATH="$(TEST_RUNTIME_WRAPPERS_PATH):$(PATH)" MONO_REGISTRY_PATH="$(HOME)/.mono/registry" MONO_TESTS_IN_PROGRESS="yes" DBG_RUNTIME_ARGS="$(TEST_RUNTIME_FLAGS)" $(TEST_HARNESS_EXEC) $(test_assemblies) $(NOSHADOW_FLAG) $(TEST_HARNESS_FLAGS) $(LOCAL_TEST_HARNESS_FLAGS) $(TEST_HARNESS_EXCLUDES) $(LABELS_ARG) -format:nunit2 -result:TestResult-$(PROFILE).xml $(FIXTURE_ARG) $(TESTNAME_ARG)|| ok=false; \
 	if [ ! -f "TestResult-$(PROFILE).xml" ]; then echo "<?xml version='1.0' encoding='utf-8'?><test-results failures='1' total='1' not-run='0' name='bcl-tests' date='$$(date +%F)' time='$$(date +%T)'><test-suite name='$(strip $(test_assemblies))' success='False' time='0'><results><test-case name='$(notdir $(strip $(test_assemblies))).crash' executed='True' success='False' time='0'><failure><message>The test runner didn't produce a test result XML, probably due to a crash of the runtime. Check the log for more details.</message><stack-trace></stack-trace></failure></test-case></results></test-suite></test-results>" > TestResult-$(PROFILE).xml; fi; \
 	$$ok
 

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -45,6 +45,7 @@ public class DebuggerTests
 	public static bool listening = Environment.GetEnvironmentVariable ("DBG_SUSPEND") != null;
 #endif
 	public static string runtime = Environment.GetEnvironmentVariable ("DBG_RUNTIME");
+	public static string runtime_args = Environment.GetEnvironmentVariable ("DBG_RUNTIME_ARGS");
 	public static string agent_args = Environment.GetEnvironmentVariable ("DBG_AGENT_ARGS");
 
 	// Not currently used, but can be useful when debugging individual tests.
@@ -84,6 +85,8 @@ public class DebuggerTests
 		if (string.IsNullOrEmpty (pi.FileName))
 			pi.FileName = "mono";
 		pi.Arguments = String.Join (" ", args);
+		if (runtime_args != null)
+			pi.Arguments = runtime_args + " " + pi.Arguments;
 		return pi;
 	}
 

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -3114,7 +3114,7 @@ process_frame (StackFrameInfo *info, MonoContext *ctx, gpointer user_data)
 	int flags = 0;
 
 	mono_loader_lock ();
-	if (info->type != FRAME_TYPE_MANAGED && info->type != FRAME_TYPE_INTERP) {
+	if (info->type != FRAME_TYPE_MANAGED && info->type != FRAME_TYPE_INTERP && info->type != FRAME_TYPE_MANAGED_TO_NATIVE) {
 		if (info->type == FRAME_TYPE_DEBUGGER_INVOKE) {
 			/* Mark the last frame as an invoke frame */
 			if (ud->frames)

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -702,6 +702,7 @@ interp_throw (ThreadContext *context, MonoException *ex, InterpFrame *frame, gco
 
 	MonoContext ctx;
 	memset (&ctx, 0, sizeof (MonoContext));
+	MONO_CONTEXT_SET_SP (&ctx, frame);
 
 	/*
 	 * Call the JIT EH code. The EH code will call back to us using:

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -712,7 +712,7 @@ unwinder_unwind_frame (Unwinder *unwinder,
 
 		/* Process debugger invokes */
 		/* The DEBUGGER_INVOKE should be returned before the first interpreter frame for the invoke */
-		if (unwinder->last_frame_addr > (gpointer)(*lmf)) {
+		if (unwinder->last_frame_addr < (gpointer)(*lmf)) {
 			if (((gsize)(*lmf)->previous_lmf) & 2) {
 				MonoLMFExt *ext = (MonoLMFExt*)(*lmf);
 				if (ext->debugger_invoke) {


### PR DESCRIPTION
We only used the interpreter on the client side (by mistake). Luckily most tests are working when using the interpreter on the debugee side. 




--------------------------------------------

* [debugger tests] use runtime flags for debugee

------------------------------------------
* [debugger] fix debugger_invoke frame in interp case

fixes DebuggerTests.BreakpointDuringInvoke on the interpreter

------------------------------------------

* [debugger] handle managed-to-native frames

fixes DebuggerTests.InspectThreadSuspenedOnWaitOne on the interpreter


------------------------------------------


* [interp] set SP in monoctx that is passed to exception handling

fixes DebuggerTests.ExceptionFilter on the interpreter


------------------------------------------



Fixes https://github.com/mono/mono/issues/8767