### PR TITLE
[threadpool] Clear data field of MonoListItem after we are done with it

### DIFF
--- a/mono/metadata/threadpool-io.c
+++ b/mono/metadata/threadpool-io.c
@@ -121,6 +121,7 @@ get_job_for_event (MonoMList **list, gint32 event)
 		MonoIOSelectorJob *job = (MonoIOSelectorJob*) mono_mlist_get_data (current);
 		if (job->operation == event) {
 			*list = mono_mlist_remove_item (*list, current);
+			mono_mlist_set_data (current, NULL);
 			return job;
 		}
 	}
@@ -402,6 +403,7 @@ selector_thread (gpointer data)
 
 					for (; list; list = mono_mlist_remove_item (list, list)) {
 						mono_threadpool_enqueue_work_item (mono_object_domain (mono_mlist_get_data (list)), mono_mlist_get_data (list), error);
+						mono_mlist_set_data (list, NULL);
 						mono_error_assert_ok (error);
 					}
 


### PR DESCRIPTION
Currently the list elements are allocated in the root domain, while the data can be allocated in other domains. We need to clear the reference when removing the list element so we are not left with hidden cross domain refs.

Ideally we should have per domain lists, so we also would just let the list and elements die, without having to iterate through them at domain unload time.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
