### PR TITLE
debugging-in-ci failing FullAOT LLVM Linux x64 tests.

### DIFF
--- a/mcs/class/corlib/System.IO/File.cs
+++ b/mcs/class/corlib/System.IO/File.cs
@@ -71,7 +71,7 @@ namespace System.IO
 
 		public static void Copy (string sourceFileName, string destFileName, bool overwrite)
 		{
-			MonoIOError error;
+			MonoIOError error = 0;
 
 			if (sourceFileName == null)
 				throw new ArgumentNullException ("sourceFileName");
@@ -115,7 +115,7 @@ namespace System.IO
 			String fullSourceFileName = Path.GetFullPathInternal(sourceFileName);
 			String fullDestFileName = Path.GetFullPathInternal(destFileName);
 
-			MonoIOError error;
+			MonoIOError error = 0;
 
 			if (!MonoIO.CopyFile (fullSourceFileName, fullDestFileName, overwrite, out error)) {
 				string p = Locale.GetText ("{0}\" or \"{1}", sourceFileName, destFileName);
@@ -182,7 +182,7 @@ namespace System.IO
 
 			SecurityManager.EnsureElevatedPermissions (); // this is a no-op outside moonlight
 
-			MonoIOError error;
+			MonoIOError error = 0;
 			
 			if (!MonoIO.DeleteFile (path, out error)){
 				if (error != MonoIOError.ERROR_FILE_NOT_FOUND)
@@ -204,7 +204,7 @@ namespace System.IO
 			if (!SecurityManager.CheckElevatedPermissions ())
 				return false;
 
-			MonoIOError error;
+			MonoIOError error = 0;
 			return MonoIO.ExistsFile (path, out error);
 		}
 
@@ -239,7 +239,7 @@ namespace System.IO
 			if (verbose)
 				Console.WriteLine ($"GetAttributes 3 {path}");
 
-			MonoIOError error;
+			MonoIOError error = 0;
 			FileAttributes attrs;
 			
 			attrs = MonoIO.GetFileAttributes (path, out error);
@@ -262,7 +262,7 @@ namespace System.IO
 		public static DateTime GetCreationTime (string path)
 		{
 			MonoIOStat stat;
-			MonoIOError error;
+			MonoIOError error = 0;
 			Path.Validate (path);
 			SecurityManager.EnsureElevatedPermissions (); // this is a no-op outside moonlight
 
@@ -283,7 +283,7 @@ namespace System.IO
 		public static DateTime GetLastAccessTime (string path)
 		{
 			MonoIOStat stat;
-			MonoIOError error;
+			MonoIOError error = 0;
 			Path.Validate (path);
 			SecurityManager.EnsureElevatedPermissions (); // this is a no-op outside moonlight
 
@@ -304,7 +304,7 @@ namespace System.IO
 		public static DateTime GetLastWriteTime (string path)
 		{
 			MonoIOStat stat;
-			MonoIOError error;
+			MonoIOError error = 0;
 			Path.Validate (path);
 			SecurityManager.EnsureElevatedPermissions (); // this is a no-op outside moonlight
 
@@ -339,7 +339,7 @@ namespace System.IO
 
 			SecurityManager.EnsureElevatedPermissions (); // this is a no-op outside moonlight
 
-			MonoIOError error;
+			MonoIOError error = 0;
 			if (!MonoIO.Exists (sourceFileName, out error))
 				throw new FileNotFoundException (Locale.GetText ("{0} does not exist", sourceFileName), sourceFileName);
 
@@ -407,7 +407,7 @@ namespace System.IO
 					    string destinationBackupFileName,
 					    bool ignoreMetadataErrors)
 		{
-			MonoIOError error;
+			MonoIOError error = 0;
 
 			if (sourceFileName == null)
 				throw new ArgumentNullException ("sourceFileName");
@@ -479,7 +479,7 @@ namespace System.IO
 			if (verbose)
 				Console.WriteLine ($"SetAttributes 1 {path} {fileAttributes}");
 
-			MonoIOError error;
+			MonoIOError error = 0;
 			Path.Validate (path);
 
 			if (verbose)
@@ -497,7 +497,7 @@ namespace System.IO
 
 		public static void SetCreationTime (string path, DateTime creationTime)
 		{
-			MonoIOError error;
+			MonoIOError error = 0;
 			Path.Validate (path);
 			if (!MonoIO.Exists (path, out error))
 				throw MonoIO.GetException (path, error);
@@ -512,7 +512,7 @@ namespace System.IO
 
 		public static void SetLastAccessTime (string path, DateTime lastAccessTime)
 		{
-			MonoIOError error;
+			MonoIOError error = 0;
 			Path.Validate (path);
 			if (!MonoIO.Exists (path, out error))
 				throw MonoIO.GetException (path, error);
@@ -528,7 +528,7 @@ namespace System.IO
 		public static void SetLastWriteTime (string path,
 						     DateTime lastWriteTime)
 		{
-			MonoIOError error;
+			MonoIOError error = 0;
 			Path.Validate (path);
 			if (!MonoIO.Exists (path, out error))
 				throw MonoIO.GetException (path, error);
@@ -756,7 +756,7 @@ namespace System.IO
 			if (tryagain)
 				throw new NotImplementedException ();
 
-			MonoIOError error;
+			MonoIOError error = 0;
 			MonoIO.GetFileStat (path, out data, out error);
 
 			if (!returnErrorOnNotFound && (error == MonoIOError.ERROR_FILE_NOT_FOUND || error == MonoIOError.ERROR_PATH_NOT_FOUND || error == MonoIOError.ERROR_NOT_READY)) {

--- a/mcs/class/corlib/System.IO/File.cs
+++ b/mcs/class/corlib/System.IO/File.cs
@@ -212,15 +212,38 @@ namespace System.IO
 
 		public static FileAttributes GetAttributes (string path)
 		{
+			bool verbose = path.IndexOf ("/verbose") != -1;
+
+			if (verbose)
+				Console.WriteLine ($"GetAttributes 1 {path}");
+
 			Path.Validate (path);
+
+			if (verbose)
+				Console.WriteLine ($"GetAttributes 2 {path}");
+
 			SecurityManager.EnsureElevatedPermissions (); // this is a no-op outside moonlight
+
+			if (verbose)
+				Console.WriteLine ($"GetAttributes 3 {path}");
 
 			MonoIOError error;
 			FileAttributes attrs;
 			
 			attrs = MonoIO.GetFileAttributes (path, out error);
-			if (error != MonoIOError.ERROR_SUCCESS)
+
+			if (verbose)
+				Console.WriteLine ($"GetAttributes 4 {path} {attrs} {error}");
+
+			if (error != MonoIOError.ERROR_SUCCESS) {
+				if (verbose)
+					Console.WriteLine ($"GetAttributes 5 throw {path} {attrs} {error}");
 				throw MonoIO.GetException (path, error);
+			}
+
+			if (verbose)
+				Console.WriteLine ($"GetAttributes 6 {path} {attrs} {error}");
+
 			return attrs;
 		}
 
@@ -439,11 +462,25 @@ namespace System.IO
 		public static void SetAttributes (string path,
 						  FileAttributes fileAttributes)
 		{
+			bool verbose = path.IndexOf ("/verbose") != -1;
+
+			if (verbose)
+				Console.WriteLine ($"SetAttributes 1 {path} {fileAttributes}");
+
 			MonoIOError error;
 			Path.Validate (path);
 
-			if (!MonoIO.SetFileAttributes (path, fileAttributes, out error))
+			if (verbose)
+				Console.WriteLine ($"SetAttributes 2 {path} {fileAttributes}");
+
+			if (!MonoIO.SetFileAttributes (path, fileAttributes, out error)) {
+				if (verbose)
+					Console.WriteLine ($"SetAttributes 3 throw {path} {fileAttributes}");
 				throw MonoIO.GetException (path, error);
+			}
+
+			if (verbose)
+				Console.WriteLine ($"SetAttributes 4 {path} {fileAttributes}");
 		}
 
 		public static void SetCreationTime (string path, DateTime creationTime)

--- a/mcs/class/corlib/System.IO/File.cs
+++ b/mcs/class/corlib/System.IO/File.cs
@@ -127,11 +127,17 @@ namespace System.IO
 
 		public static FileStream Create (string path)
 		{
+			bool verbose = path.IndexOf ("/verbose") != -1;
+			if (verbose)
+				Console.WriteLine ($"Create 1 {path}");
 			return Create (path, 8192);
 		}
 
 		public static FileStream Create (string path, int bufferSize)
 		{
+			bool verbose = path.IndexOf ("/verbose") != -1;
+			if (verbose)
+				Console.WriteLine ($"Create 2 {path}");
 			return new FileStream (path, FileMode.Create, FileAccess.ReadWrite,
 				FileShare.None, bufferSize);
 		}
@@ -140,6 +146,9 @@ namespace System.IO
 		public static FileStream Create (string path, int bufferSize,
 						 FileOptions options)
 		{
+			bool verbose = path.IndexOf ("/verbose") != -1;
+			if (verbose)
+				Console.WriteLine ($"Create 3 {path}");
 			return new FileStream (path, FileMode.Create, FileAccess.ReadWrite,
 				FileShare.None, bufferSize, options);
 		}
@@ -149,6 +158,9 @@ namespace System.IO
 						 FileOptions options,
 						 FileSecurity fileSecurity)
 		{
+			bool verbose = path.IndexOf ("/verbose") != -1;
+			if (verbose)
+				Console.WriteLine ($"Create 4 {path}");
 			return new FileStream (path, FileMode.Create, FileAccess.ReadWrite,
 				FileShare.None, bufferSize, options);
 		}

--- a/mcs/class/corlib/System.IO/File.cs
+++ b/mcs/class/corlib/System.IO/File.cs
@@ -127,7 +127,7 @@ namespace System.IO
 
 		public static FileStream Create (string path)
 		{
-			bool verbose = path.IndexOf ("/verbose") != -1;
+			bool verbose = path != null &&  path.IndexOf ("/verbose") != -1;
 			if (verbose)
 				Console.WriteLine ($"Create 1 {path}");
 			return Create (path, 8192);
@@ -135,7 +135,7 @@ namespace System.IO
 
 		public static FileStream Create (string path, int bufferSize)
 		{
-			bool verbose = path.IndexOf ("/verbose") != -1;
+			bool verbose = path != null &&  path.IndexOf ("/verbose") != -1;
 			if (verbose)
 				Console.WriteLine ($"Create 2 {path}");
 			return new FileStream (path, FileMode.Create, FileAccess.ReadWrite,
@@ -146,7 +146,7 @@ namespace System.IO
 		public static FileStream Create (string path, int bufferSize,
 						 FileOptions options)
 		{
-			bool verbose = path.IndexOf ("/verbose") != -1;
+			bool verbose = path != null &&  path.IndexOf ("/verbose") != -1;
 			if (verbose)
 				Console.WriteLine ($"Create 3 {path}");
 			return new FileStream (path, FileMode.Create, FileAccess.ReadWrite,
@@ -158,7 +158,7 @@ namespace System.IO
 						 FileOptions options,
 						 FileSecurity fileSecurity)
 		{
-			bool verbose = path.IndexOf ("/verbose") != -1;
+			bool verbose = path != null &&  path.IndexOf ("/verbose") != -1;
 			if (verbose)
 				Console.WriteLine ($"Create 4 {path}");
 			return new FileStream (path, FileMode.Create, FileAccess.ReadWrite,
@@ -224,7 +224,7 @@ namespace System.IO
 
 		public static FileAttributes GetAttributes (string path)
 		{
-			bool verbose = path.IndexOf ("/verbose") != -1;
+			bool verbose = path != null &&  path.IndexOf ("/verbose") != -1;
 
 			if (verbose)
 				Console.WriteLine ($"GetAttributes 1 {path}");
@@ -474,7 +474,7 @@ namespace System.IO
 		public static void SetAttributes (string path,
 						  FileAttributes fileAttributes)
 		{
-			bool verbose = path.IndexOf ("/verbose") != -1;
+			bool verbose = path != null &&  path.IndexOf ("/verbose") != -1;
 
 			if (verbose)
 				Console.WriteLine ($"SetAttributes 1 {path} {fileAttributes}");

--- a/mcs/class/corlib/System.IO/File.cs
+++ b/mcs/class/corlib/System.IO/File.cs
@@ -127,7 +127,7 @@ namespace System.IO
 
 		public static FileStream Create (string path)
 		{
-			bool verbose = path != null &&  path.IndexOf ("/verbose") != -1;
+			bool verbose = path != null && path.IndexOf ("/verbose") != -1;
 			if (verbose)
 				Console.WriteLine ($"Create 1 {path}");
 			return Create (path, 8192);
@@ -135,7 +135,7 @@ namespace System.IO
 
 		public static FileStream Create (string path, int bufferSize)
 		{
-			bool verbose = path != null &&  path.IndexOf ("/verbose") != -1;
+			bool verbose = path != null && path.IndexOf ("/verbose") != -1;
 			if (verbose)
 				Console.WriteLine ($"Create 2 {path}");
 			return new FileStream (path, FileMode.Create, FileAccess.ReadWrite,
@@ -146,7 +146,7 @@ namespace System.IO
 		public static FileStream Create (string path, int bufferSize,
 						 FileOptions options)
 		{
-			bool verbose = path != null &&  path.IndexOf ("/verbose") != -1;
+			bool verbose = path != null && path.IndexOf ("/verbose") != -1;
 			if (verbose)
 				Console.WriteLine ($"Create 3 {path}");
 			return new FileStream (path, FileMode.Create, FileAccess.ReadWrite,
@@ -158,7 +158,7 @@ namespace System.IO
 						 FileOptions options,
 						 FileSecurity fileSecurity)
 		{
-			bool verbose = path != null &&  path.IndexOf ("/verbose") != -1;
+			bool verbose = path != null && path.IndexOf ("/verbose") != -1;
 			if (verbose)
 				Console.WriteLine ($"Create 4 {path}");
 			return new FileStream (path, FileMode.Create, FileAccess.ReadWrite,
@@ -224,7 +224,7 @@ namespace System.IO
 
 		public static FileAttributes GetAttributes (string path)
 		{
-			bool verbose = path != null &&  path.IndexOf ("/verbose") != -1;
+			bool verbose = path != null && path.IndexOf ("/verbose") != -1;
 
 			if (verbose)
 				Console.WriteLine ($"GetAttributes 1 {path}");
@@ -474,7 +474,7 @@ namespace System.IO
 		public static void SetAttributes (string path,
 						  FileAttributes fileAttributes)
 		{
-			bool verbose = path != null &&  path.IndexOf ("/verbose") != -1;
+			bool verbose = path != null && path.IndexOf ("/verbose") != -1;
 
 			if (verbose)
 				Console.WriteLine ($"SetAttributes 1 {path} {fileAttributes}");

--- a/mcs/class/corlib/System.IO/FileStream.cs
+++ b/mcs/class/corlib/System.IO/FileStream.cs
@@ -152,7 +152,7 @@ namespace System.IO
 
 		internal FileStream (string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, bool anonymous, FileOptions options)
 		{
-			bool verbose = path.IndexOf ("/verbose") != -1;
+			bool verbose = path != null &&  path.IndexOf ("/verbose") != -1;
 			if (verbose)
 				Console.WriteLine ($"FileStream 1 {path}");
 

--- a/mcs/class/corlib/System.IO/FileStream.cs
+++ b/mcs/class/corlib/System.IO/FileStream.cs
@@ -152,13 +152,23 @@ namespace System.IO
 
 		internal FileStream (string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, bool anonymous, FileOptions options)
 		{
+			bool verbose = path.IndexOf ("/verbose") != -1;
+			if (verbose)
+				Console.WriteLine ($"FileStream 1 {path}");
+
 			if (path == null) {
 				throw new ArgumentNullException ("path");
 			}
 
+			if (verbose)
+				Console.WriteLine ($"FileStream 2 {path}");
+
 			if (path.Length == 0) {
 				throw new ArgumentException ("Path is empty");
 			}
+
+			if (verbose)
+				Console.WriteLine ($"FileStream 3 {path}");
 
 			this.anonymous = anonymous;
 			// ignore the Inheritable flag
@@ -188,7 +198,13 @@ namespace System.IO
 				throw new ArgumentException ("Name has invalid chars");
 			}
 
+			if (verbose)
+				Console.WriteLine ($"FileStream 4 {path}");
+
 			path = Path.InsecureGetFullPath (path);
+
+			if (verbose)
+				Console.WriteLine ($"FileStream 5 {path}");
 
 			if (Directory.Exists (path)) {
 				// don't leak the path information for isolated storage
@@ -213,6 +229,9 @@ namespace System.IO
 
 			SecurityManager.EnsureElevatedPermissions (); // this is a no-op outside moonlight
 
+			if (verbose)
+				Console.WriteLine ($"FileStream 6 {path}");
+
 			string dname = Path.GetDirectoryName (path);
 			if (dname.Length > 0) {
 				string fp = Path.GetFullPath (dname);
@@ -232,12 +251,21 @@ namespace System.IO
 
 			MonoIOError error;
 
+			if (verbose)
+				Console.WriteLine ($"FileStream 7 {path}");
+
 			var nativeHandle = MonoIO.Open (path, mode, access, share, options, out error);
+
+			if (verbose)
+				Console.WriteLine ($"FileStream 8 {path}");
 
 			if (nativeHandle == MonoIO.InvalidHandle) {
 				// don't leak the path information for isolated storage
 				throw MonoIO.GetException (GetSecureFileName (path), error);
 			}
+
+			if (verbose)
+				Console.WriteLine ($"FileStream 9 {path}");
 
 			this.safeHandle = new SafeFileHandle (nativeHandle, false);
 
@@ -263,6 +291,9 @@ namespace System.IO
 				}
 			}
 
+			if (verbose)
+				Console.WriteLine ($"FileStream 10 {path}");
+
 			InitBuffer (bufferSize, false);
 
 			if (mode==FileMode.Append) {
@@ -271,6 +302,9 @@ namespace System.IO
 			} else {
 				this.append_startpos=0;
 			}
+
+			if (verbose)
+				Console.WriteLine ($"FileStream 11 {path}");
 		}
 
 		private void Init (SafeFileHandle safeHandle, FileAccess access, bool ownsHandle, int bufferSize, bool isAsync, bool isConsoleWrapper)

--- a/mcs/class/corlib/System.IO/FileStream.cs
+++ b/mcs/class/corlib/System.IO/FileStream.cs
@@ -249,7 +249,7 @@ namespace System.IO
 
 			// TODO: demand permissions
 
-			MonoIOError error;
+			MonoIOError error = 0;
 
 			if (verbose)
 				Console.WriteLine ($"FileStream 7 {path}");
@@ -316,7 +316,7 @@ namespace System.IO
 			if (!isConsoleWrapper && bufferSize <= 0)
 				throw new ArgumentOutOfRangeException("bufferSize", Environment.GetResourceString("ArgumentOutOfRange_NeedPosNum"));
 
-			MonoIOError error;
+			MonoIOError error = 0;
 			MonoFileType ftype = MonoIO.GetFileType (safeHandle, out error);
 
 			if (error != MonoIOError.ERROR_SUCCESS) {
@@ -394,7 +394,7 @@ namespace System.IO
 				// Buffered data might change the length of the stream
 				FlushBufferIfDirty ();
 
-				MonoIOError error;
+				MonoIOError error = 0;
 
 				long length = MonoIO.GetLength (safeHandle, out error);
 
@@ -419,7 +419,7 @@ namespace System.IO
 					return(buf_start + buf_offset);
 
 				// If the handle was leaked outside we always ask the real handle
-				MonoIOError error;
+				MonoIOError error = 0;
 
 				long ret = MonoIO.Seek (safeHandle, 0, SeekOrigin.Current, out error);
 
@@ -652,7 +652,7 @@ namespace System.IO
 		{
 			if (count > buf_size) {
 				// shortcut for long writes
-				MonoIOError error;
+				MonoIOError error = 0;
 
 				FlushBuffer ();
 
@@ -804,7 +804,7 @@ namespace System.IO
 
 			FlushBuffer ();
 
-			MonoIOError error;
+			MonoIOError error = 0;
 
 			buf_start = MonoIO.Seek (safeHandle, pos, SeekOrigin.Begin, out error);
 
@@ -832,7 +832,7 @@ namespace System.IO
 			
 			FlushBuffer ();
 
-			MonoIOError error;
+			MonoIOError error = 0;
 
 			MonoIO.SetLength (safeHandle, value, out error);
 			if (error != MonoIOError.ERROR_SUCCESS) {
@@ -861,7 +861,7 @@ namespace System.IO
 
 			// This does the fsync
 			if (flushToDisk){
-				MonoIOError error;
+				MonoIOError error = 0;
 				MonoIO.Flush (safeHandle, out error);
 			}
 		}
@@ -877,7 +877,7 @@ namespace System.IO
 				throw new ArgumentOutOfRangeException ("length must not be negative");
 			}
 
-			MonoIOError error;
+			MonoIOError error = 0;
 
 			MonoIO.Lock (safeHandle, position, length, out error);
 			if (error != MonoIOError.ERROR_SUCCESS) {
@@ -897,7 +897,7 @@ namespace System.IO
 				throw new ArgumentOutOfRangeException ("length must not be negative");
 			}
 
-			MonoIOError error;
+			MonoIOError error = 0;
 
 			MonoIO.Unlock (safeHandle, position, length, out error);
 			if (error != MonoIOError.ERROR_SUCCESS) {
@@ -927,7 +927,7 @@ namespace System.IO
 				}
 
 				if (owner) {
-					MonoIOError error;
+					MonoIOError error = 0;
 
 					MonoIO.Close (safeHandle.DangerousGetHandle (), out error);
 					if (error != MonoIOError.ERROR_SUCCESS) {
@@ -1044,7 +1044,7 @@ namespace System.IO
 		{
 			if (buf_dirty) {
 //				if (st == null) {
-					MonoIOError error;
+					MonoIOError error = 0;
 
 					if (CanSeek == true && !isExposed) {
 						MonoIO.Seek (safeHandle, buf_start, SeekOrigin.Begin, out error);
@@ -1092,7 +1092,7 @@ namespace System.IO
 		private int ReadData (SafeHandle safeHandle, byte[] buf, int offset,
 				      int count)
 		{
-			MonoIOError error;
+			MonoIOError error = 0;
 			int amount = 0;
 
 			/* when async == true, if we get here we don't suport AIO or it's disabled

--- a/mcs/class/corlib/System.IO/FileStream.cs
+++ b/mcs/class/corlib/System.IO/FileStream.cs
@@ -209,6 +209,7 @@ namespace System.IO
 			if (Directory.Exists (path)) {
 				// don't leak the path information for isolated storage
 				string msg = Locale.GetText ("Access to the path '{0}' is denied.");
+				Console.WriteLine ($"FileStream UnauthorizedAccessException denied");
 				throw new UnauthorizedAccessException (String.Format (msg, GetSecureFileName (path, false)));
 			}
 
@@ -217,6 +218,7 @@ namespace System.IO
 			 */
 			if (mode==FileMode.Append &&
 				(access&FileAccess.Read)==FileAccess.Read) {
+				Console.WriteLine ($"FileStream ArgumentException append");
 				throw new ArgumentException("Append access can be requested only in write-only mode.");
 			}
 
@@ -224,6 +226,7 @@ namespace System.IO
 				(mode != FileMode.Open && mode != FileMode.OpenOrCreate)) {
 				string msg = Locale.GetText ("Combining FileMode: {0} with " +
 					"FileAccess: {1} is invalid.");
+				Console.WriteLine ($"FileStream ArgumentException {msg} {access} {mode}");
 				throw new ArgumentException (string.Format (msg, access, mode));
 			}
 

--- a/mcs/class/corlib/System.IO/FileStream.cs
+++ b/mcs/class/corlib/System.IO/FileStream.cs
@@ -261,7 +261,8 @@ namespace System.IO
 
 			if (nativeHandle == MonoIO.InvalidHandle) {
 				// don't leak the path information for isolated storage
-				Console.WriteLine ($"FileStream 8throw {path} {nativeHandle}");
+				if (verbose)
+					Console.WriteLine ($"FileStream 8throw {path} {nativeHandle}");
 				throw MonoIO.GetException (GetSecureFileName (path), error);
 			}
 

--- a/mcs/class/corlib/System.IO/FileStream.cs
+++ b/mcs/class/corlib/System.IO/FileStream.cs
@@ -257,10 +257,11 @@ namespace System.IO
 			var nativeHandle = MonoIO.Open (path, mode, access, share, options, out error);
 
 			if (verbose)
-				Console.WriteLine ($"FileStream 8 {path}");
+				Console.WriteLine ($"FileStream 8 {path} {mode} {access} {share} {options} {nativeHandle}");
 
 			if (nativeHandle == MonoIO.InvalidHandle) {
 				// don't leak the path information for isolated storage
+				Console.WriteLine ($"FileStream 8throw {path} {nativeHandle}");
 				throw MonoIO.GetException (GetSecureFileName (path), error);
 			}
 

--- a/mcs/class/corlib/System.IO/FileStream.cs
+++ b/mcs/class/corlib/System.IO/FileStream.cs
@@ -262,12 +262,12 @@ namespace System.IO
 			if (nativeHandle == MonoIO.InvalidHandle) {
 				// don't leak the path information for isolated storage
 				if (verbose)
-					Console.WriteLine ($"FileStream 8throw {path} {nativeHandle}");
+					Console.WriteLine ($"FileStream 8throw {path} {nativeHandle} {MonoIO.InvalidHandle}");
 				throw MonoIO.GetException (GetSecureFileName (path), error);
 			}
 
 			if (verbose)
-				Console.WriteLine ($"FileStream 9 {path}");
+				Console.WriteLine ($"FileStream 9 {path} {nativeHandle} {MonoIO.InvalidHandle}");
 
 			this.safeHandle = new SafeFileHandle (nativeHandle, false);
 

--- a/mcs/class/corlib/System.IO/MonoIO.cs
+++ b/mcs/class/corlib/System.IO/MonoIO.cs
@@ -280,7 +280,7 @@ namespace System.IO
 
 		public static FileAttributes GetFileAttributes (string path, out MonoIOError error)
 		{
-			bool verbose = path.IndexOf ("/verbose") != -1;
+			bool verbose = path != null && path.IndexOf ("/verbose") != -1;
 
 			if (verbose)
 				Console.WriteLine ($"MonoIO.GetFileAttributes 1 {path}");
@@ -297,7 +297,7 @@ namespace System.IO
 
 		public static bool SetFileAttributes (string path, FileAttributes attrs, out MonoIOError error)
 		{
-			bool verbose = path.IndexOf ("/verbose") != -1;
+			bool verbose = path != null && path.IndexOf ("/verbose") != -1;
 
 			if (verbose)
 				Console.WriteLine ($"MonoIO.SetFileAttributes 1 {path} {attrs}");
@@ -348,7 +348,7 @@ namespace System.IO
 
 		public static bool Exists (string path, out MonoIOError error)
 		{
-			bool verbose = path.IndexOf ("/verbose") != -1;
+			bool verbose = path != null && path.IndexOf ("/verbose") != -1;
 
 			if (verbose)
 				Console.WriteLine ($"MonoIO.Exists 1 {path}");

--- a/mcs/class/corlib/System.IO/MonoIO.cs
+++ b/mcs/class/corlib/System.IO/MonoIO.cs
@@ -280,6 +280,11 @@ namespace System.IO
 
 		public static FileAttributes GetFileAttributes (string path, out MonoIOError error)
 		{
+			bool verbose = path.IndexOf ("/verbose") != -1;
+
+			if (verbose)
+				Console.WriteLine ($"MonoIO.GetFileAttributes 1 {path}");
+
 			unsafe {
 				fixed (char* pathChars = path) {
 					return GetFileAttributes (pathChars, out error);
@@ -292,6 +297,11 @@ namespace System.IO
 
 		public static bool SetFileAttributes (string path, FileAttributes attrs, out MonoIOError error)
 		{
+			bool verbose = path.IndexOf ("/verbose") != -1;
+
+			if (verbose)
+				Console.WriteLine ($"MonoIO.SetFileAttributes 1 {path} {attrs}");
+
 			unsafe {
 				fixed (char* pathChars = path) {
 					return SetFileAttributes (pathChars, attrs, out error);
@@ -338,10 +348,25 @@ namespace System.IO
 
 		public static bool Exists (string path, out MonoIOError error)
 		{
+			bool verbose = path.IndexOf ("/verbose") != -1;
+
+			if (verbose)
+				Console.WriteLine ($"MonoIO.Exists 1 {path}");
+
 			FileAttributes attrs = GetFileAttributes (path,
 								  out error);
-			if (attrs == InvalidFileAttributes)
+
+			if (verbose)
+				Console.WriteLine ($"MonoIO.Exists 2 {path} {attrs} {error}");
+
+			if (attrs == InvalidFileAttributes) {
+				if (verbose)
+					Console.WriteLine ($"MonoIO.Exists 3 {path} {attrs} {error}");
 				return false;
+			}
+
+			if (verbose)
+				Console.WriteLine ($"MonoIO.Exists 4 {path} {attrs} {error}");
 
 			return true;
 		}

--- a/mcs/class/corlib/Test/System.IO/FileTest.cs
+++ b/mcs/class/corlib/Test/System.IO/FileTest.cs
@@ -115,7 +115,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void Create_Path_Directory ()
 		{
-			string path = Path.Combine (tmpFolder, "foo");
+			string path = Path.Combine (tmpFolder, "foo_Create_Path_Directory");
 			Directory.CreateDirectory (path);
 			try {
 				File.Create (path);
@@ -149,7 +149,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void Create_Path_ReadOnly ()
 		{
-			string path = Path.Combine (tmpFolder, "foo");
+			string path = Path.Combine (tmpFolder, "foo_Create_Path_ReadOnly");
 			File.Create (path).Close ();
 			File.SetAttributes (path, FileAttributes.ReadOnly);
 			try {
@@ -185,7 +185,7 @@ namespace MonoTests.System.IO
 		public void Create_Directory_DoesNotExist ()
 		{
 			FileStream stream = null;
-			string path = tmpFolder + Path.DirectorySeparatorChar + "directory_does_not_exist" + Path.DirectorySeparatorChar + "foo";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "directory_does_not_exist" + Path.DirectorySeparatorChar + "foo_Create_Directory_DoesNotExist";
 			
 			try {
 				stream = File.Create (path);
@@ -210,7 +210,7 @@ namespace MonoTests.System.IO
 			string path = null;
 
 			/* positive test: create resources/foo */
-			path = tmpFolder + Path.DirectorySeparatorChar + "foo";
+			path = tmpFolder + Path.DirectorySeparatorChar + "foo_Create";
 			try {
 
 				stream = File.Create (path);
@@ -225,7 +225,7 @@ namespace MonoTests.System.IO
 			stream = null;
 
 			/* positive test: repeat test above again to test for overwriting file */
-			path = tmpFolder + Path.DirectorySeparatorChar + "foo";
+			path = tmpFolder + Path.DirectorySeparatorChar + "foo_Create";
 			try {
 				stream = File.Create (path);
 				Assert.IsTrue (File.Exists (path), "#2");
@@ -458,7 +458,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void Delete_Directory_DoesNotExist ()
 		{
-			string path = tmpFolder + Path.DirectorySeparatorChar + "directory_does_not_exist" + Path.DirectorySeparatorChar + "foo";
+			string path = tmpFolder + Path.DirectorySeparatorChar + "directory_does_not_exist" + Path.DirectorySeparatorChar + "foo_Delete_Directory_DoesNotExist";
 			if (Directory.Exists (path))
 				Directory.Delete (path, true);
 
@@ -477,7 +477,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void Delete ()
 		{
-			string foopath = tmpFolder + Path.DirectorySeparatorChar + "foo";
+			string foopath = tmpFolder + Path.DirectorySeparatorChar + "foo_Delete";
 			DeleteFile (foopath);
 			try {
 				File.Create (foopath).Close ();
@@ -549,7 +549,7 @@ namespace MonoTests.System.IO
 
 			FileAttributes attrs;
 
-			string path = Path.Combine (tmpFolder, "GetAttributes.tmp");
+			string path = Path.Combine (tmpFolder, "GetAttributes.tmp_GetAttributes_Archive");
 			File.Create (path).Close ();
 
 			attrs = File.GetAttributes (path);
@@ -568,7 +568,7 @@ namespace MonoTests.System.IO
 			if (RunningOnUnix)
 				Assert.Ignore ("bug #325181: FileAttributes.Archive has no effect on Unix.");
 
-			string path = Path.Combine (tmpFolder, "GetAttributes.tmp");
+			string path = Path.Combine (tmpFolder, "GetAttributes.tmp_GetAttributes_Default_File");
 			File.Create (path).Close ();
 
 			FileAttributes attrs = File.GetAttributes (path);
@@ -606,7 +606,7 @@ namespace MonoTests.System.IO
 
 			Assert.IsFalse ((attrs & FileAttributes.Directory) != 0, "#2");
 
-			string path = Path.Combine (tmpFolder, "GetAttributes.tmp");
+			string path = Path.Combine (tmpFolder, "GetAttributes.tmp_GetAttributes_Directory");
 			File.Create (path).Close ();
 
 			attrs = File.GetAttributes (path);
@@ -621,7 +621,7 @@ namespace MonoTests.System.IO
 		{
 			FileAttributes attrs;
 
-			string path = Path.Combine (tmpFolder, "GetAttributes.tmp");
+			string path = Path.Combine (tmpFolder, "GetAttributes.tmp_GetAttributes_ReadOnly");
 			File.Create (path).Close ();
 
 			attrs = File.GetAttributes (path);
@@ -646,7 +646,7 @@ namespace MonoTests.System.IO
 
 			FileAttributes attrs;
 
-			string path = Path.Combine (tmpFolder, "GetAttributes.tmp");
+			string path = Path.Combine (tmpFolder, "GetAttributes.tmp_GetAttributes_System");
 			File.Create (path).Close ();
 
 			attrs = File.GetAttributes (path);
@@ -662,7 +662,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void GetAttributes_Path_DoesNotExist ()
 		{
-			string path = Path.Combine (tmpFolder, "GetAttributes.tmp");
+			string path = Path.Combine (tmpFolder, "GetAttributes.tmp_GetAttributes_Path_DoesNotExist");
 			try {
 				File.GetAttributes (path);
 				Assert.Fail ("#1");
@@ -810,7 +810,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void Move_DestFileName_DirectoryDoesNotExist ()
 		{
-			string sourceFile = tmpFolder + Path.DirectorySeparatorChar + "foo";
+			string sourceFile = tmpFolder + Path.DirectorySeparatorChar + "foo_Move_DestFileName_DirectoryDoesNotExist";
 			string destFile = Path.Combine (Path.Combine (tmpFolder, "doesnotexist"), "b");
 			DeleteFile (sourceFile);
 			try {
@@ -833,7 +833,7 @@ namespace MonoTests.System.IO
 		[Test]
 		public void Move_DestFileName_AlreadyExists ()
 		{
-			string sourceFile = tmpFolder + Path.DirectorySeparatorChar + "foo";
+			string sourceFile = tmpFolder + Path.DirectorySeparatorChar + "foo_Move_DestFileName_AlreadyExists";
 			string destFile;
 
 			// move to same directory

--- a/mcs/class/corlib/Test/System.IO/FileTest.cs
+++ b/mcs/class/corlib/Test/System.IO/FileTest.cs
@@ -149,7 +149,8 @@ namespace MonoTests.System.IO
 		[Test]
 		public void Create_Path_ReadOnly ()
 		{
-			string path = Path.Combine (tmpFolder, "foo_Create_Path_ReadOnly");
+			var name = "verbose" + Guid.NewGuid ().ToString ("N");
+			string path = Path.Combine (tmpFolder, name + "foo_Create_Path_ReadOnly");
 			File.Create (path).Close ();
 			File.SetAttributes (path, FileAttributes.ReadOnly);
 			try {
@@ -624,7 +625,9 @@ namespace MonoTests.System.IO
 		{
 			FileAttributes attrs;
 
-			string path = Path.Combine (tmpFolder, "GetAttributes.tmp_GetAttributes_ReadOnly");
+			var name = "verbose" + Guid.NewGuid ().ToString ("N");
+
+			string path = Path.Combine (tmpFolder, name + "GetAttributes.tmp_GetAttributes_ReadOnly");
 			File.Create (path).Close ();
 
 			attrs = File.GetAttributes (path);

--- a/mcs/class/corlib/Test/System.IO/FileTest.cs
+++ b/mcs/class/corlib/Test/System.IO/FileTest.cs
@@ -103,7 +103,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.Create (null);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentNullException ex) {
 				Assert.AreEqual (typeof (ArgumentNullException), ex.GetType (), "#2");
 				Assert.IsNull (ex.InnerException, "#3");
@@ -119,7 +119,7 @@ namespace MonoTests.System.IO
 			Directory.CreateDirectory (path);
 			try {
 				File.Create (path);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (UnauthorizedAccessException ex) {
 				// Access to the path '...' is denied
 				Assert.AreEqual (typeof (UnauthorizedAccessException), ex.GetType (), "#2");
@@ -136,7 +136,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.Create (string.Empty);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Empty file name is not legal
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -154,11 +154,14 @@ namespace MonoTests.System.IO
 			File.SetAttributes (path, FileAttributes.ReadOnly);
 			try {
 				File.Create (path);
-				Assert.Fail ("#1");
+				Console.WriteLine ($"#1 {path}"); Assert.Fail ("#1");
 			} catch (UnauthorizedAccessException ex) {
 				// Access to the path '...' is denied
+				Console.WriteLine ($"1 {ex}");
+				Console.WriteLine ($"2 {ex.Message}");
 				Assert.AreEqual (typeof (UnauthorizedAccessException), ex.GetType (), "#2");
 				Assert.IsNull (ex.InnerException, "#3");
+				Console.WriteLine (ex.InnerException);
 				Assert.IsNotNull (ex.Message, "#4");
 				Assert.IsTrue (ex.Message.IndexOf (path) != -1, "#5");
 			} finally {
@@ -171,7 +174,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.Create (" ");
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// The path is not of a legal form
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -189,7 +192,7 @@ namespace MonoTests.System.IO
 			
 			try {
 				stream = File.Create (path);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (DirectoryNotFoundException ex) {
 				// Could not find a part of the path "..."
 				Assert.AreEqual (typeof (DirectoryNotFoundException), ex.GetType (), "#2");
@@ -242,7 +245,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.Copy (null, "b");
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentNullException ex) {
 				Assert.AreEqual (typeof (ArgumentNullException), ex.GetType (), "#2");
 				Assert.IsNull (ex.InnerException, "#3");
@@ -256,7 +259,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.Copy ("a", null);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentNullException ex) {
 				Assert.AreEqual (typeof (ArgumentNullException), ex.GetType (), "#2");
 				Assert.IsNull (ex.InnerException, "#3");
@@ -270,7 +273,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.Copy (string.Empty, "b");
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Empty file name is not legal
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -285,7 +288,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.Copy ("a", string.Empty);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Empty file name is not legal
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -300,7 +303,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.Copy (" ", "b");
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// The path is not of a legal form
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -315,7 +318,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.Copy ("a", " ");
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// The path is not of a legal form
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -330,7 +333,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.Copy ("doesnotexist", "b");
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (FileNotFoundException ex) {
 				Assert.AreEqual (typeof (FileNotFoundException), ex.GetType (), "#2");
 				Assert.AreEqual ("doesnotexist", ex.FileName, "#3");
@@ -351,7 +354,7 @@ namespace MonoTests.System.IO
 				File.Copy (source, dest);
 				try {
 					File.Copy (source, dest);
-					Assert.Fail ("#1");
+						Console.WriteLine ("#1"); Assert.Fail ("#1");
 				} catch (IOException ex) {
 					// The file '...' already exists.
 					Assert.AreEqual (typeof (IOException), ex.GetType (), "#2");
@@ -375,7 +378,7 @@ namespace MonoTests.System.IO
 				File.Create (source).Close ();
 				try {
 					File.Copy (source, source, true);
-					Assert.Fail ("#1");
+					Console.WriteLine ("#1"); Assert.Fail ("#1");
 				} catch (IOException ex) {
 					// process cannot access file ... because it is being used by another process
 					Assert.IsNull (ex.InnerException, "#2");
@@ -416,7 +419,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.Delete (null);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentNullException ex) {
 				Assert.AreEqual (typeof (ArgumentNullException), ex.GetType (), "#2");
 				Assert.IsNull (ex.InnerException, "#3");
@@ -430,7 +433,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.Delete (string.Empty);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Empty file name is not legal
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -445,7 +448,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.Delete (" ");
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// The path is not of a legal form
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -464,7 +467,7 @@ namespace MonoTests.System.IO
 
 			try {
 				File.Delete (path);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (DirectoryNotFoundException ex) {
 				// Could not find a part of the path "..."
 				Assert.AreEqual (typeof (DirectoryNotFoundException), ex.GetType (), "#2");
@@ -500,7 +503,7 @@ namespace MonoTests.System.IO
 				stream = new FileStream (path, FileMode.OpenOrCreate, FileAccess.ReadWrite);
 				try {
 					File.Delete (path);
-					Assert.Fail ("#1");
+					Console.WriteLine ("#1"); Assert.Fail ("#1");
 				} catch (IOException ex) {
 					// The process cannot access the file '...'
 					// because it is being used by another process
@@ -625,13 +628,16 @@ namespace MonoTests.System.IO
 			File.Create (path).Close ();
 
 			attrs = File.GetAttributes (path);
+			Console.WriteLine($"GetAttributes_ReadOnly 1 {path} {attrs}");
 			Assert.IsFalse ((attrs & FileAttributes.ReadOnly) != 0, "#1");
 
 			try {
 				attrs |= FileAttributes.ReadOnly;
+				Console.WriteLine($"GetAttributes_ReadOnly 2 {path} {attrs}");
 				File.SetAttributes (path, attrs);
 
 				attrs = File.GetAttributes (path);
+				Console.WriteLine($"GetAttributes_ReadOnly 3 {path} {attrs}");
 				Assert.IsTrue ((attrs & FileAttributes.ReadOnly) != 0, "#2");
 			} finally {
 				File.SetAttributes (path, FileAttributes.Normal);
@@ -665,7 +671,7 @@ namespace MonoTests.System.IO
 			string path = Path.Combine (tmpFolder, "GetAttributes.tmp_GetAttributes_Path_DoesNotExist");
 			try {
 				File.GetAttributes (path);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (FileNotFoundException ex) {
 				Assert.AreEqual (typeof (FileNotFoundException), ex.GetType (), "#2");
 				Assert.AreEqual (path, ex.FileName, "#3");
@@ -679,7 +685,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetAttributes (string.Empty);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Empty file name is not legal
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -694,7 +700,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetAttributes (null);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentNullException ex) {
 				Assert.AreEqual (typeof (ArgumentNullException), ex.GetType (), "#2");
 				Assert.IsNull (ex.InnerException, "#3");
@@ -708,7 +714,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.Move (null, "b");
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentNullException ex) {
 				Assert.AreEqual (typeof (ArgumentNullException), ex.GetType (), "#2");
 				Assert.IsNull (ex.InnerException, "#3");
@@ -722,7 +728,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.Move ("a", null);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentNullException ex) {
 				Assert.AreEqual (typeof (ArgumentNullException), ex.GetType (), "#2");
 				Assert.IsNull (ex.InnerException, "#3");
@@ -736,7 +742,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.Move (string.Empty, "b");
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Empty file name is not legal
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -751,7 +757,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.Move ("a", string.Empty);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Empty file name is not legal
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -766,7 +772,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.Move (" ", "b");
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// The path is not of a legal form
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -781,7 +787,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.Move ("a", " ");
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// The path is not of a legal form
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -798,7 +804,7 @@ namespace MonoTests.System.IO
 			DeleteFile (file);
 			try {
 				File.Move (file, "b");
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (FileNotFoundException ex) {
 				Assert.AreEqual (typeof (FileNotFoundException), ex.GetType (), "#2");
 				Assert.AreEqual (file, ex.FileName, "#3");
@@ -817,7 +823,7 @@ namespace MonoTests.System.IO
 				File.Create (sourceFile).Close ();
 				try {
 					File.Move (sourceFile, destFile);
-					Assert.Fail ("#1");
+					Console.WriteLine ("#1"); Assert.Fail ("#1");
 				} catch (DirectoryNotFoundException ex) {
 					// Could not find a part of the path
 					Assert.AreEqual (typeof (DirectoryNotFoundException), ex.GetType (), "#2");
@@ -1035,7 +1041,7 @@ namespace MonoTests.System.IO
 			FileStream stream = null;
 			try {
 				stream = File.Open (tmpFolder + Path.DirectorySeparatorChar + "AFile.txt", FileMode.CreateNew, FileAccess.Read);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Combining FileMode: CreateNew with FileAccess: Read is invalid
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1058,7 +1064,7 @@ namespace MonoTests.System.IO
 				File.Create (path).Close ();
 			try {
 				s = File.Open (path, FileMode.Append, FileAccess.Read);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Combining FileMode: Append with FileAccess: Read is invalid
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1324,7 +1330,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetCreationTime (null as string);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentNullException ex) {
 				Assert.AreEqual (typeof (ArgumentNullException), ex.GetType (), "#2");
 				Assert.IsNull (ex.InnerException, "#3");
@@ -1338,7 +1344,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetCreationTime (string.Empty);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Empty file name is not legal
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1369,7 +1375,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetCreationTime ("    ");
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// The path is not of a legal form
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1384,7 +1390,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetCreationTime (Path.InvalidPathChars [0].ToString ());
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Illegal characters in path
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1399,7 +1405,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetCreationTimeUtc (null as string);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentNullException ex) {
 				Assert.AreEqual (typeof (ArgumentNullException), ex.GetType (), "#2");
 				Assert.IsNull (ex.InnerException, "#3");
@@ -1413,7 +1419,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetCreationTimeUtc (string.Empty);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Empty file name is not legal
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1443,7 +1449,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetCreationTimeUtc ("    ");
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// The path is not of a legal form
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1458,7 +1464,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetCreationTimeUtc (Path.InvalidPathChars [0].ToString ());
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Illegal characters in path
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1473,7 +1479,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetLastAccessTime (null as string);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentNullException ex) {
 				Assert.AreEqual (typeof (ArgumentNullException), ex.GetType (), "#2");
 				Assert.IsNull (ex.InnerException, "#3");
@@ -1487,7 +1493,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetLastAccessTime (string.Empty);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Empty file name is not legal
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1518,7 +1524,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetLastAccessTime ("    ");
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// The path is not of a legal form
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1533,7 +1539,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetLastAccessTime (Path.InvalidPathChars [0].ToString ());
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Illegal characters in path
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1548,7 +1554,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetLastAccessTimeUtc (null as string);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentNullException ex) {
 				Assert.AreEqual (typeof (ArgumentNullException), ex.GetType (), "#2");
 				Assert.IsNull (ex.InnerException, "#3");
@@ -1562,7 +1568,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetLastAccessTimeUtc (string.Empty);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Empty file name is not legal
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1592,7 +1598,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetLastAccessTimeUtc ("    ");
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// The path is not of a legal form
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1607,7 +1613,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetLastAccessTimeUtc (Path.InvalidPathChars [0].ToString ());
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Illegal characters in path
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1622,7 +1628,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetLastWriteTime (null as string);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentNullException ex) {
 				Assert.AreEqual (typeof (ArgumentNullException), ex.GetType (), "#2");
 				Assert.IsNull (ex.InnerException, "#3");
@@ -1636,7 +1642,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetLastWriteTime (string.Empty);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Empty file name is not legal
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1667,7 +1673,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetLastWriteTime ("    ");
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// The path is not of a legal form
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1682,7 +1688,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetLastWriteTime (Path.InvalidPathChars [0].ToString ());
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Illegal characters in path
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1697,7 +1703,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetLastWriteTimeUtc (null as string);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentNullException ex) {
 				Assert.AreEqual (typeof (ArgumentNullException), ex.GetType (), "#2");
 				Assert.IsNull (ex.InnerException, "#3");
@@ -1711,7 +1717,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetLastWriteTimeUtc (string.Empty);
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Empty file name is not legal
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1741,7 +1747,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetLastWriteTimeUtc ("    ");
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// The path is not of a legal form
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1756,7 +1762,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.GetLastWriteTimeUtc (Path.InvalidPathChars [0].ToString ());
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Illegal characters in path
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1789,7 +1795,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.SetCreationTime (null as string, new DateTime (2000, 12, 12, 11, 59, 59));
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentNullException ex) {
 				Assert.AreEqual (typeof (ArgumentNullException), ex.GetType (), "#2");
 				Assert.IsNull (ex.InnerException, "#3");
@@ -1803,7 +1809,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.SetCreationTime (string.Empty, new DateTime (2000, 12, 12, 11, 59, 59));
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Empty file name is not legal
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1818,7 +1824,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.SetCreationTime ("     ", new DateTime (2000, 12, 12, 11, 59, 59));
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// The path is not of a legal form
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1836,7 +1842,7 @@ namespace MonoTests.System.IO
 				try {
 					File.SetCreationTime (Path.InvalidPathChars [1].ToString (),
 						new DateTime (2000, 12, 12, 11, 59, 59));
-					Assert.Fail ("#1");
+						Console.WriteLine ("#1"); Assert.Fail ("#1");
 				} catch (ArgumentException ex) {
 					// Illegal characters in path
 					Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1855,7 +1861,7 @@ namespace MonoTests.System.IO
 			
 			try {
 				File.SetCreationTime (path, new DateTime (2000, 12, 12, 11, 59, 59));
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (FileNotFoundException ex) {
 				Assert.AreEqual (typeof (FileNotFoundException), ex.GetType (), "#2");
 				Assert.AreEqual (path, ex.FileName, "#3");
@@ -1892,7 +1898,7 @@ namespace MonoTests.System.IO
 				stream = File.Create (path);
 				try {
 					File.SetCreationTime (path, new DateTime (1000, 12, 12, 11, 59, 59));
-					Assert.Fail ("#1");
+					Console.WriteLine ("#1"); Assert.Fail ("#1");
 				} catch (IOException ex) {
 					// The process cannot access the file '...'
 					// because it is being used by another process
@@ -1913,7 +1919,7 @@ namespace MonoTests.System.IO
 		{ 
 			try {
 				File.SetCreationTimeUtc (null as string, new DateTime (2000, 12, 12, 11, 59, 59));
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentNullException ex) {
 				Assert.AreEqual (typeof (ArgumentNullException), ex.GetType (), "#2");
 				Assert.IsNull (ex.InnerException, "#3");
@@ -1927,7 +1933,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.SetCreationTimeUtc (string.Empty, new DateTime (2000, 12, 12, 11, 59, 59));
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Empty file name is not legal
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1942,7 +1948,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.SetCreationTimeUtc ("     ", new DateTime (2000, 12, 12, 11, 59, 59));
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// The path is not of a legal form
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1960,7 +1966,7 @@ namespace MonoTests.System.IO
 				try {
 					File.SetCreationTimeUtc (Path.InvalidPathChars [1].ToString (),
 						new DateTime (2000, 12, 12, 11, 59, 59));
-					Assert.Fail ("#1");
+					Console.WriteLine ("#1"); Assert.Fail ("#1");
 				} catch (ArgumentException ex) {
 					// Illegal characters in path
 					Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -1979,7 +1985,7 @@ namespace MonoTests.System.IO
 
 			try {
 				File.SetCreationTimeUtc (path, new DateTime (2000, 12, 12, 11, 59, 59));
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (FileNotFoundException ex) {
 				Assert.AreEqual (typeof (FileNotFoundException), ex.GetType (), "#2");
 				Assert.AreEqual (path, ex.FileName, "#3");
@@ -2016,7 +2022,7 @@ namespace MonoTests.System.IO
 				stream = File.Create (path);
 				try {
 					File.SetCreationTimeUtc (path, new DateTime (1000, 12, 12, 11, 59, 59));
-					Assert.Fail ("#1");
+					Console.WriteLine ("#1"); Assert.Fail ("#1");
 				} catch (IOException ex) {
 					// The process cannot access the file "..."
 					// because it is being used by another process
@@ -2039,7 +2045,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.SetLastAccessTime (null as string, new DateTime (2000, 12, 12, 11, 59, 59));
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentNullException ex) {
 				Assert.AreEqual (typeof (ArgumentNullException), ex.GetType (), "#2");
 				Assert.IsNull (ex.InnerException, "#3");
@@ -2053,7 +2059,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.SetLastAccessTime (string.Empty, new DateTime (2000, 12, 12, 11, 59, 59));
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Empty file name is not legal
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -2068,7 +2074,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.SetLastAccessTime ("     ", new DateTime (2000, 12, 12, 11, 59, 59));
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// The path is not of a legal form
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -2086,7 +2092,8 @@ namespace MonoTests.System.IO
 				try {
 					File.SetLastAccessTime (Path.InvalidPathChars [1].ToString (),
 						new DateTime (2000, 12, 12, 11, 59, 59));
-					Assert.Fail ("#1");
+				Console.WriteLine ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 				} catch (ArgumentException ex) {
 					// Illegal characters in path
 					Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -2105,7 +2112,7 @@ namespace MonoTests.System.IO
 
 			try {
 				File.SetLastAccessTime (path, new DateTime (2000, 12, 12, 11, 59, 59));
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (FileNotFoundException ex) {
 				Assert.AreEqual (typeof (FileNotFoundException), ex.GetType (), "#2");
 				Assert.AreEqual (path, ex.FileName, "#3");
@@ -2142,7 +2149,7 @@ namespace MonoTests.System.IO
 				stream = File.Create (path);
 				try {
 					File.SetLastAccessTime (path, new DateTime (1000, 12, 12, 11, 59, 59));
-					Assert.Fail ("#1");
+					Console.WriteLine ("#1"); Assert.Fail ("#1");
 				} catch (IOException ex) {
 					// The process cannot access the file "..."
 					// because it is being used by another process
@@ -2163,7 +2170,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.SetLastAccessTimeUtc (null as string, new DateTime (2000, 12, 12, 11, 59, 59));
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentNullException ex) {
 				Assert.AreEqual (typeof (ArgumentNullException), ex.GetType (), "#2");
 				Assert.IsNull (ex.InnerException, "#3");
@@ -2177,7 +2184,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.SetLastAccessTimeUtc (string.Empty, new DateTime (2000, 12, 12, 11, 59, 59));
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Empty file name is not legal
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -2192,7 +2199,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.SetLastAccessTimeUtc ("     ", new DateTime (2000, 12, 12, 11, 59, 59));
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// The path is not of a legal form
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -2210,7 +2217,7 @@ namespace MonoTests.System.IO
 				try {
 					File.SetLastAccessTimeUtc (Path.InvalidPathChars [1].ToString (),
 						new DateTime (2000, 12, 12, 11, 59, 59));
-					Assert.Fail ("#1");
+					Console.WriteLine ("#1"); Assert.Fail ("#1");
 				} catch (ArgumentException ex) {
 					// Illegal characters in path
 					Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -2229,7 +2236,7 @@ namespace MonoTests.System.IO
 
 			try {
 				File.SetLastAccessTimeUtc (path, new DateTime (2000, 12, 12, 11, 59, 59));
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (FileNotFoundException ex) {
 				Assert.AreEqual (typeof (FileNotFoundException), ex.GetType (), "#2");
 				Assert.AreEqual (path, ex.FileName, "#3");
@@ -2266,7 +2273,7 @@ namespace MonoTests.System.IO
 				stream = File.Create (path);
 				try {
 					File.SetLastAccessTimeUtc (path, new DateTime (1000, 12, 12, 11, 59, 59));
-					Assert.Fail ("#1");
+					Console.WriteLine ("#1"); Assert.Fail ("#1");
 				} catch (IOException ex) {
 					// The process cannot access the file "..."
 					// because it is being used by another process
@@ -2289,7 +2296,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.SetLastWriteTime (null as string, new DateTime (2000, 12, 12, 11, 59, 59));
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentNullException ex) {
 				Assert.AreEqual (typeof (ArgumentNullException), ex.GetType (), "#2");
 				Assert.IsNull (ex.InnerException, "#3");
@@ -2303,7 +2310,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.SetLastWriteTime (string.Empty, new DateTime (2000, 12, 12, 11, 59, 59));
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Empty file name is not legal
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -2318,7 +2325,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.SetLastWriteTime ("     ", new DateTime (2000, 12, 12, 11, 59, 59));
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// The path is not of a legal form
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -2336,7 +2343,7 @@ namespace MonoTests.System.IO
 				try {
 					File.SetLastWriteTime (Path.InvalidPathChars [1].ToString (),
 						new DateTime (2000, 12, 12, 11, 59, 59));
-					Assert.Fail ("#1");
+					Console.WriteLine ("#1"); Assert.Fail ("#1");
 				} catch (ArgumentException ex) {
 					// Illegal characters in path
 					Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -2355,7 +2362,7 @@ namespace MonoTests.System.IO
 
 			try {
 				File.SetLastWriteTime (path, new DateTime (2000, 12, 12, 11, 59, 59));
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (FileNotFoundException ex) {
 				Assert.AreEqual (typeof (FileNotFoundException), ex.GetType (), "#2");
 				Assert.AreEqual (path, ex.FileName, "#3");
@@ -2392,7 +2399,7 @@ namespace MonoTests.System.IO
 				stream = File.Create (path);
 				try {
 					File.SetLastWriteTime (path, new DateTime (1000, 12, 12, 11, 59, 59));
-					Assert.Fail ("#1");
+					Console.WriteLine ("#1"); Assert.Fail ("#1");
 				} catch (IOException ex) {
 					// The process cannot access the file '...'
 					// because it is being used by another process
@@ -2413,7 +2420,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.SetLastWriteTimeUtc (null as string, new DateTime (2000, 12, 12, 11, 59, 59));
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentNullException ex) {
 				Assert.AreEqual (typeof (ArgumentNullException), ex.GetType (), "#2");
 				Assert.IsNull (ex.InnerException, "#3");
@@ -2427,7 +2434,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.SetLastWriteTimeUtc (string.Empty, new DateTime (2000, 12, 12, 11, 59, 59));
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// Empty file name is not legal
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -2442,7 +2449,7 @@ namespace MonoTests.System.IO
 		{
 			try {
 				File.SetLastWriteTimeUtc ("     ", new DateTime (2000, 12, 12, 11, 59, 59));
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (ArgumentException ex) {
 				// The path is not of a legal form
 				Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -2460,7 +2467,7 @@ namespace MonoTests.System.IO
 				try {
 					File.SetLastWriteTimeUtc (Path.InvalidPathChars [1].ToString (),
 						new DateTime (2000, 12, 12, 11, 59, 59));
-					Assert.Fail ("#1");
+					Console.WriteLine ("#1"); Assert.Fail ("#1");
 				} catch (ArgumentException ex) {
 					// Illegal characters in path
 					Assert.AreEqual (typeof (ArgumentException), ex.GetType (), "#2");
@@ -2479,7 +2486,7 @@ namespace MonoTests.System.IO
 
 			try {
 				File.SetLastWriteTimeUtc (path, new DateTime (2000, 12, 12, 11, 59, 59));
-				Assert.Fail ("#1");
+				Console.WriteLine ("#1"); Assert.Fail ("#1");
 			} catch (FileNotFoundException ex) {
 				Assert.AreEqual (typeof (FileNotFoundException), ex.GetType (), "#2");
 				Assert.AreEqual (path, ex.FileName, "#3");
@@ -2516,7 +2523,7 @@ namespace MonoTests.System.IO
 				stream = File.Create (path);
 				try {
 					File.SetLastWriteTimeUtc (path, new DateTime (1000, 12, 12, 11, 59, 59));
-					Assert.Fail ("#1");
+					Console.WriteLine ("#1"); Assert.Fail ("#1");
 				} catch (IOException ex) {
 					// The process cannot access the file '...'
 					// because it is being used by another process

--- a/mono/eglib/giconv.c
+++ b/mono/eglib/giconv.c
@@ -1020,6 +1020,28 @@ g_utf8_to_ucs4 (const gchar *str, glong len, glong *items_read, glong *items_wri
 	return outbuf;
 }
 
+gsize
+g_u16len (const gunichar2 *s)
+{
+#ifdef G_OS_WIN32
+	return wcslen (s);
+#else
+	const gunichar2 *t = s;
+	while (*s++) ;
+	return (gsize)(s - t - 1);
+#endif
+}
+
+#ifndef G_OS_WIN32
+
+gchar*
+u16to8 (const gunichar2 *str)
+{
+	return g_utf16_to_utf8 (str, (glong)g_u16len (str), NULL, NULL, NULL);
+}
+
+#endif
+
 gchar *
 g_utf16_to_utf8 (const gunichar2 *str, glong len, glong *items_read, glong *items_written, GError **err)
 {
@@ -1031,11 +1053,8 @@ g_utf16_to_utf8 (const gunichar2 *str, glong len, glong *items_read, glong *item
 	
 	g_return_val_if_fail (str != NULL, NULL);
 	
-	if (len < 0) {
-		len = 0;
-		while (str[len])
-			len++;
-	}
+	if (len < 0)
+		len = (glong)g_u16len (str);
 	
 	inptr = (char *) str;
 	inleft = len * 2;
@@ -1112,11 +1131,8 @@ g_utf16_to_ucs4 (const gunichar2 *str, glong len, glong *items_read, glong *item
 	
 	g_return_val_if_fail (str != NULL, NULL);
 	
-	if (len < 0) {
-		len = 0;
-		while (str[len])
-			len++;
-	}
+	if (len < 0)
+		len = (glong)g_u16len (str);
 	
 	inptr = (char *) str;
 	inleft = len * 2;

--- a/mono/eglib/giconv.c
+++ b/mono/eglib/giconv.c
@@ -1020,6 +1020,12 @@ g_utf8_to_ucs4 (const gchar *str, glong len, glong *items_read, glong *items_wri
 	return outbuf;
 }
 
+gunichar2*
+u8to16 (const gchar *str)
+{
+	return g_utf8_to_utf16 (str, (glong)strlen (str), NULL, NULL, NULL);
+}
+
 gsize
 g_u16len (const gunichar2 *s)
 {
@@ -1032,15 +1038,11 @@ g_u16len (const gunichar2 *s)
 #endif
 }
 
-#ifndef G_OS_WIN32
-
 gchar*
 u16to8 (const gunichar2 *str)
 {
 	return g_utf16_to_utf8 (str, (glong)g_u16len (str), NULL, NULL, NULL);
 }
-
-#endif
 
 gchar *
 g_utf16_to_utf8 (const gunichar2 *str, glong len, glong *items_read, glong *items_written, GError **err)

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -799,14 +799,20 @@ gunichar2 *g_ucs4_to_utf16 (const gunichar *str, glong len, glong *items_read, g
 gsize
 g_u16len (const gunichar2 *str);
 
-#define u8to16(str) g_utf8_to_utf16(str, (glong)strlen(str), NULL, NULL, NULL)
+#define g_u16len monoeg_g_u16len
+gsize
+g_u16len (const gunichar2 *str);
 
-#ifdef G_OS_WIN32
-#define u16to8(str) g_utf16_to_utf8((gunichar2 *) (str), (glong)wcslen((wchar_t *) (str)), NULL, NULL, NULL)
-#else
 gchar*
 u16to8 (const gunichar2 *str);
-#endif
+
+#define u8to16 monoeg_g_u8to16
+gunichar2*
+u8to16 (const gchar *str);
+
+#define u16to8 monoeg_g_u16to8
+gchar*
+u16to8 (const gunichar2 *str);
 
 /*
  * Path

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -796,13 +796,16 @@ gchar     *g_utf16_to_utf8 (const gunichar2 *str, glong len, glong *items_read, 
 gunichar  *g_utf16_to_ucs4 (const gunichar2 *str, glong len, glong *items_read, glong *items_written, GError **err);
 gchar     *g_ucs4_to_utf8  (const gunichar *str, glong len, glong *items_read, glong *items_written, GError **err);
 gunichar2 *g_ucs4_to_utf16 (const gunichar *str, glong len, glong *items_read, glong *items_written, GError **err);
+gsize
+g_u16len (const gunichar2 *str);
 
 #define u8to16(str) g_utf8_to_utf16(str, (glong)strlen(str), NULL, NULL, NULL)
 
 #ifdef G_OS_WIN32
 #define u16to8(str) g_utf16_to_utf8((gunichar2 *) (str), (glong)wcslen((wchar_t *) (str)), NULL, NULL, NULL)
 #else
-#define u16to8(str) g_utf16_to_utf8(str, (glong)strlen(str), NULL, NULL, NULL)
+gchar*
+u16to8 (const gunichar2 *str);
 #endif
 
 /*

--- a/mono/eglib/goutput.c
+++ b/mono/eglib/goutput.c
@@ -37,7 +37,6 @@ static GLogFunc default_log_func;
 static gpointer default_log_func_user_data;
 static GPrintFunc stdout_handler, stderr_handler;
 
-static void default_stdout_handler (const gchar *string);
 static void default_stderr_handler (const gchar *string);
 
 void
@@ -49,7 +48,7 @@ g_printv (const gchar *format, va_list args)
 		return;
 
 	if (!stdout_handler)
-		stdout_handler = default_stdout_handler;
+		stdout_handler = default_stderr_handler;
 
 	stdout_handler (msg);
 	g_free (msg);
@@ -240,13 +239,6 @@ g_log_default_handler (const gchar *log_domain, GLogLevelFlags log_level, const 
 }
 
 static void
-default_stdout_handler (const gchar *message)
-{
-	/* TODO: provide a proper app name */
-	android_log (ANDROID_LOG_ERROR, "mono", message);
-}
-
-static void
 default_stderr_handler (const gchar *message)
 {
 	/* TODO: provide a proper app name */
@@ -281,12 +273,6 @@ g_log_default_handler (const gchar *log_domain, GLogLevelFlags log_level, const 
 }
 
 static void
-default_stdout_handler (const gchar *message)
-{
-	asl_log (NULL, NULL, ASL_LEVEL_WARNING, "%s", message);
-}
-
-static void
 default_stderr_handler (const gchar *message)
 {
 	asl_log (NULL, NULL, ASL_LEVEL_WARNING, "%s", message);
@@ -309,12 +295,6 @@ g_log_default_handler (const gchar *log_domain, GLogLevelFlags log_level, const 
 		fflush (stderr);
 		abort ();
 	}
-}
-
-static void
-default_stdout_handler (const gchar *string)
-{
-	fprintf (stdout, "%s", string);
 }
 
 static void

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -1268,6 +1268,8 @@ static gboolean file_setendoffile(FileHandle *filehandle)
 	gint ret;
 	MonoThreadInfo *info = mono_thread_info_current ();
 	
+	memset (&statbuf, 0, sizeof (statbuf));
+
 	if(!(filehandle->fileaccess & (GENERIC_WRITE | GENERIC_ALL))) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: fd %d doesn't have GENERIC_WRITE access: %u", __func__, ((MonoFDHandle*) filehandle)->fd, filehandle->fileaccess);
 
@@ -1366,6 +1368,8 @@ static guint32 file_getfilesize(FileHandle *filehandle, guint32 *highsize)
 	struct stat statbuf;
 	guint32 size;
 	gint ret;
+
+	memset (&statbuf, 0, sizeof (statbuf));
 	
 	if(!(filehandle->fileaccess & (GENERIC_READ | GENERIC_WRITE | GENERIC_ALL))) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: fd %d doesn't have GENERIC_READ or GENERIC_WRITE access: %u", __func__, ((MonoFDHandle*) filehandle)->fd, filehandle->fileaccess);
@@ -1501,7 +1505,9 @@ static gboolean file_setfiletime(FileHandle *filehandle,
 {
 	struct stat statbuf;
 	gint ret;
-	
+
+	memset (&statbuf, 0, sizeof (statbuf));
+
 	if(!(filehandle->fileaccess & (GENERIC_WRITE | GENERIC_ALL))) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: fd %d doesn't have GENERIC_WRITE access: %u", __func__, ((MonoFDHandle*) filehandle)->fd, filehandle->fileaccess);
 
@@ -1940,6 +1946,8 @@ mono_w32file_create(const gunichar2 *name, guint32 fileaccess, guint32 sharemode
 	gchar *filename;
 	gint fd, ret;
 	struct stat statbuf;
+
+	memset (&statbuf, 0, sizeof (statbuf));
 
 	if (attrs & FILE_ATTRIBUTE_TEMPORARY)
 		perms = 0600;
@@ -3446,15 +3454,15 @@ mono_w32file_remove_directory (const gunichar2 *name)
 guint32
 mono_w32file_get_attributes (const gunichar2 *name)
 {
-	gchar *utf8_name;
-	struct stat buf, linkbuf;
-	gint result;
-	guint32 ret;
+	gchar *utf8_name = {0};
+	struct stat buf = {0}, linkbuf = {0};
+	gint result = {0};
+	guint32 ret = {0};
 
 	memset (&buf, 0, sizeof (buf));
 	memset (&linkbuf, 0, sizeof (linkbuf));
 
-	gboolean const verbose = path && has_verbose (path);
+	gboolean const verbose = name && has_verbose (name);
 	mono_verbose_eh |= verbose;
 
 	if (name == NULL) {
@@ -3505,7 +3513,10 @@ mono_w32file_get_attributes_ex (const gunichar2 *name, MonoIOStat *stat)
 
 	struct stat buf, linkbuf;
 	gint result;
-	
+
+	memset (&buf, 0, sizeof (buf));
+	memset (&linkbuf, 0, sizeof (linkbuf));
+
 	if (name == NULL) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: name is NULL", __func__);
 
@@ -3575,9 +3586,11 @@ gboolean
 mono_w32file_set_attributes (const gunichar2 *name, guint32 attrs)
 {
 	/* FIXME: think of something clever to do on unix */
-	gchar *utf8_name;
-	struct stat buf;
-	gint result;
+	gchar *utf8_name = {0};
+	struct stat buf = {0};
+	gint result = {0};
+
+	memset (&buf, 0, sizeof (buf));
 
 	/*
 	 * Currently we only handle one *internal* case, with a value that is

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -3450,7 +3450,13 @@ mono_w32file_get_attributes (const gunichar2 *name)
 	struct stat buf, linkbuf;
 	gint result;
 	guint32 ret;
-	
+
+	memset (&buf, 0, sizeof (buf));
+	memset (&linkbuf, 0, sizeof (linkbuf));
+
+	gboolean const verbose = path && has_verbose (path);
+	mono_verbose_eh |= verbose;
+
 	if (name == NULL) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: name is NULL", __func__);
 

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -321,14 +321,134 @@ _wapi_access (const gchar *pathname, gint mode)
 	return ret;
 }
 
+static ptrdiff_t
+strstr8 (const char *haystack, size_t haystack_length, const char *needle, size_t needle_length)
+{
+	if (!haystack_length || !needle_length || needle_length > haystack_length)
+		return -1;
+	char const needle0 = needle [0];
+	for (ptrdiff_t i = 0; i <= (ptrdiff_t)(haystack_length - needle_length); ++i) {
+		if (haystack [i] == needle0 && memcmp (haystack + i, needle, needle_length) == 0)
+			return i;
+	}
+	return -1;
+}
+
+static ptrdiff_t
+strstr16 (const gunichar2 *haystack, size_t haystack_length, const gunichar2 *needle, size_t needle_length)
+{
+	if (!haystack_length || !needle_length || needle_length > haystack_length)
+		return -1;
+	gunichar2 const needle0 = needle [0];
+	for (ptrdiff_t i = 0; i <= (ptrdiff_t)(haystack_length - needle_length); ++i) {
+		if (haystack [i] == needle0 && memcmp (haystack + i, needle, needle_length * 2) == 0)
+			return i;
+	}
+	return -1;
+}
+
+#define CONSTANT_STRING_AND_LENGTH(x) (x), (sizeof (x) / sizeof (x [0]) - 1)
+gboolean mono_verbose_eh;
+const static char slash_verbose8 [ ] = {'/','v','e','r','b','o','s','e',0};
+const static gunichar2 slash_verbose16 [ ] = {'/','v','e','r','b','o','s','e',0};
+static gboolean first_verbose;
+
+static void
+run (const char *a)
+{
+	fflush (stdout);
+	fflush (stderr);
+	g_print("%s\n", a);
+	system(a);
+	fflush (stdout);
+	fflush (stderr);
+}
+
+static void
+runv (const gchar *format, va_list args)
+{
+	char *msg;
+
+	if (g_vasprintf (&msg, format, args) < 0)
+		return;
+
+	run (msg);
+
+	g_free (msg);
+}
+
+static void
+runf (const char *format, ...)
+{
+	va_list args;
+	va_start (args, format);
+	runv (format, args);
+	va_end (args);
+}
+
+static gboolean
+handle_first_verbose (gboolean a)
+{
+	if (!a || first_verbose)
+		return a;
+
+	run("ls -l /tmp");
+	run("ls -l /");
+	run("ls -ld /tmp");
+	run("whoami");
+	run("umask");
+	run("cat /etc/lsb_release");
+	run("uname -a");
+	first_verbose = TRUE;
+	return TRUE;
+}
+
+static gboolean
+has_verbose8 (const char *path)
+{
+	return handle_first_verbose (path && strstr8 (path, strlen (path), CONSTANT_STRING_AND_LENGTH (slash_verbose8)) != -1);
+}
+
+static gboolean
+has_verbose16 (const gunichar2 *path)
+{
+	return handle_first_verbose (path && strstr16 (path, g_u16len (path), CONSTANT_STRING_AND_LENGTH (slash_verbose16)) != -1);
+}
+
+static gboolean
+is_file_writable (struct stat *st, const gchar *path);
+
 static gint
 _wapi_chmod (const gchar *pathname, mode_t mode)
 {
-	gint ret;
+	gint ret = 0;
+
+	gboolean const verbose = pathname && has_verbose8 (pathname);
+	mono_verbose_eh |= verbose;
+
+	if (verbose)
+	{
+		int e = errno;
+		g_print ("chmod 1 %s %X\n", pathname, mode);
+		struct stat b = { 0 };
+		int c = stat(pathname, &b);
+		g_print ("chmod 2 %s r%X r%X m%X m%X u%X g%X w%X\n", pathname, ret, c, mode, b.st_mode, b.st_uid, b.st_gid, is_file_writable(&b, pathname));
+		errno = e;
+	}
 
 	MONO_ENTER_GC_SAFE;
 	ret = chmod (pathname, mode);
 	MONO_EXIT_GC_SAFE;
+
+	if (verbose)
+	{
+		int e = errno;
+		struct stat b = { 0 };
+		int c = stat(pathname, &b);
+		g_print ("chmod 3 %s r%X r%X m%X m%X u%X g%X w%X\n", pathname, ret, c, mode, b.st_mode, b.st_uid, b.st_gid, is_file_writable(&b, pathname));
+		errno = e;
+	}
+
 	if (ret == -1 && (errno == ENOENT || errno == ENOTDIR) && IS_PORTABILITY_SET) {
 		gint saved_errno = errno;
 		gchar *located_filename = mono_portability_find_file (pathname, TRUE);
@@ -469,7 +589,7 @@ _wapi_rename (const gchar *oldpath, const gchar *newpath)
 static gint
 _wapi_stat (const gchar *path, struct stat *buf)
 {
-	gint ret;
+	gint ret = { 0 };
 
 	MONO_ENTER_GC_SAFE;
 	ret = stat (path, buf);
@@ -495,7 +615,7 @@ _wapi_stat (const gchar *path, struct stat *buf)
 static gint
 _wapi_lstat (const gchar *path, struct stat *buf)
 {
-	gint ret;
+	gint ret = { 0 };
 
 	MONO_ENTER_GC_SAFE;
 	ret = lstat (path, buf);
@@ -933,7 +1053,7 @@ static gboolean lock_while_writing = FALSE;
 static gboolean
 is_file_writable (struct stat *st, const gchar *path)
 {
-	gboolean ret;
+	gboolean ret = { 0 };
 #if __APPLE__
 	// OS X Finder "locked" or `ls -lO` "uchg".
 	// This only covers one of several cases where an OS X file could be unwritable through special flags.
@@ -1263,9 +1383,9 @@ static guint32 file_seek(FileHandle *filehandle, gint32 movedistance,
 
 static gboolean file_setendoffile(FileHandle *filehandle)
 {
-	struct stat statbuf;
-	off_t pos;
-	gint ret;
+	struct stat statbuf = { 0 };
+	off_t pos = { 0 };
+	gint ret = { 0 };
 	MonoThreadInfo *info = mono_thread_info_current ();
 	
 	memset (&statbuf, 0, sizeof (statbuf));
@@ -1365,9 +1485,9 @@ static gboolean file_setendoffile(FileHandle *filehandle)
 
 static guint32 file_getfilesize(FileHandle *filehandle, guint32 *highsize)
 {
-	struct stat statbuf;
-	guint32 size;
-	gint ret;
+	struct stat statbuf = { 0 };
+	guint32 size = { 0 };
+	gint ret = { 0 };
 
 	memset (&statbuf, 0, sizeof (statbuf));
 	
@@ -1503,8 +1623,8 @@ static gboolean file_setfiletime(FileHandle *filehandle,
 				 const FILETIME *access_time,
 				 const FILETIME *write_time)
 {
-	struct stat statbuf;
-	gint ret;
+	struct stat statbuf = { 0 };
+	gint ret = { 0 };
 
 	memset (&statbuf, 0, sizeof (statbuf));
 
@@ -1808,8 +1928,8 @@ static gboolean share_allows_open (struct stat *statbuf, guint32 sharemode,
 				   guint32 fileaccess,
 				   FileShare **share_info)
 {
-	gboolean file_already_shared;
-	guint32 file_existing_share, file_existing_access;
+	gboolean file_already_shared = { 0 };
+	guint32 file_existing_share = { 0 }, file_existing_access = { 0 };
 
 	file_already_shared = file_share_get (statbuf->st_dev, statbuf->st_ino, sharemode, fileaccess, &file_existing_share, &file_existing_access, share_info);
 	
@@ -1864,8 +1984,8 @@ static gboolean share_allows_open (struct stat *statbuf, guint32 sharemode,
 static gboolean
 share_allows_delete (struct stat *statbuf, FileShare **share_info)
 {
-	gboolean file_already_shared;
-	guint32 file_existing_share, file_existing_access;
+	gboolean file_already_shared = { 0 };
+	guint32 file_existing_share = { 0 }, file_existing_access = { 0 };
 
 	file_already_shared = file_share_get (statbuf->st_dev, statbuf->st_ino, FILE_SHARE_DELETE, GENERIC_READ, &file_existing_share, &file_existing_access, share_info);
 
@@ -1900,34 +2020,10 @@ share_allows_delete (struct stat *statbuf, FileShare **share_info)
 	return(TRUE);
 }
 
-static ptrdiff_t
-strstr16 (const gunichar2 *haystack, size_t haystack_length, const gunichar2 *needle, size_t needle_length)
-{
-	if (!haystack_length || !needle_length || needle_length > haystack_length)
-		return -1;
-	gunichar2 const needle0 = needle [0];
-	for (ptrdiff_t i = 0; i <= (ptrdiff_t)(haystack_length - needle_length); ++i) {
-		if (haystack [i] == needle0 && memcmp (haystack + i, needle, needle_length * 2) == 0)
-			return i;
-	}
-	return -1;
-}
-
-#define CONSTANT_STRING_AND_LENGTH(x) (x), (sizeof (x) / sizeof (x [0]) - 1)
-gboolean mono_verbose_eh;
-
-const static gunichar2 slash_verbose [ ] = {'/','v','e','r','b','o','s','e',0};
-
-static gboolean
-has_verbose (const gunichar2 *path)
-{
-	return path && strstr16 (path, g_u16len (path), CONSTANT_STRING_AND_LENGTH (slash_verbose)) != -1;
-}
-
 gpointer
 mono_w32file_create(const gunichar2 *name, guint32 fileaccess, guint32 sharemode, guint32 createmode, guint32 attrs)
 {
-	gboolean const verbose = name && has_verbose (name);
+	gboolean const verbose = name && has_verbose16 (name);
 	mono_verbose_eh |= verbose;
 
 	if (verbose)
@@ -1943,9 +2039,9 @@ mono_w32file_create(const gunichar2 *name, guint32 fileaccess, guint32 sharemode
 	 * this is a sane default.
 	 */
 	mode_t perms=0666;
-	gchar *filename;
-	gint fd, ret;
-	struct stat statbuf;
+	gchar *filename = { 0 };
+	gint fd = { 0 }, ret = { 0 };
+	struct stat statbuf = { 0 };
 
 	memset (&statbuf, 0, sizeof (statbuf));
 
@@ -2112,12 +2208,12 @@ mono_w32file_close (gpointer handle)
 
 gboolean mono_w32file_delete(const gunichar2 *name)
 {
-	gchar *filename;
-	gint retval;
+	gchar *filename = { 0 };
+	gint retval = { 0 };
 	gboolean ret = FALSE;
 #if 0
-	struct stat statbuf;
-	FileShare *shareinfo;
+	struct stat statbuf = { 0 };
+	FileShare *shareinfo = { 0 };
 #endif
 	
 	if(name==NULL) {
@@ -2192,7 +2288,7 @@ MoveFile (const gunichar2 *name, const gunichar2 *dest_name)
 	gint result, errno_copy;
 	struct stat stat_src, stat_dest;
 	gboolean ret = FALSE;
-	FileShare *shareinfo;
+	FileShare *shareinfo = { 0 };
 	
 	if(name==NULL) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: name is NULL", __func__);
@@ -2324,7 +2420,7 @@ write_file (gint src_fd, gint dest_fd, struct stat *st_src, gboolean report_erro
 	MonoThreadInfo *info = mono_thread_info_current ();
 
 	buf_size = buf_size < 8192 ? 8192 : (buf_size > 65536 ? 65536 : buf_size);
-	buf = (gchar *) g_malloc (buf_size);
+	buf = (gchar *) g_malloc0 (buf_size);
 
 	for (;;) {
 		MONO_ENTER_GC_SAFE;
@@ -2372,12 +2468,12 @@ write_file (gint src_fd, gint dest_fd, struct stat *st_src, gboolean report_erro
 static gboolean
 CopyFile (const gunichar2 *name, const gunichar2 *dest_name, gboolean fail_if_exists)
 {
-	gchar *utf8_src, *utf8_dest;
+	gchar *utf8_src = { 0 }, *utf8_dest = { 0 };
 	gint src_fd, dest_fd;
-	struct stat st, dest_st;
+	struct stat st = { 0 }, dest_st = { 0 };
 	gboolean ret = TRUE;
-	gint ret_utime;
-	gint syscall_res;
+	gint ret_utime = { 0 };
+	gint syscall_res = { 0 };
 	
 	if(name==NULL) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: name is NULL", __func__);
@@ -2542,7 +2638,7 @@ ReplaceFile (const gunichar2 *replacedFileName, const gunichar2 *replacementFile
 {
 	gint result, backup_fd = -1,replaced_fd = -1;
 	gchar *utf8_replacedFileName, *utf8_replacementFileName = NULL, *utf8_backupFileName = NULL;
-	struct stat stBackup;
+	struct stat stBackup = { 0 };
 	gboolean ret = FALSE;
 
 	if (!(utf8_replacedFileName = convert_arg_to_utf8 (replacedFileName, "replacedFileName")))
@@ -3252,14 +3348,14 @@ mono_w32file_find_first (const gunichar2 *pattern, WIN32_FIND_DATA *find_data)
 gboolean
 mono_w32file_find_next (gpointer handle, WIN32_FIND_DATA *find_data)
 {
-	FindHandle *findhandle;
-	struct stat buf, linkbuf;
-	gint result;
-	gchar *filename;
-	gchar *utf8_filename, *utf8_basename;
-	gunichar2 *utf16_basename;
-	time_t create_time;
-	glong bytes;
+	FindHandle *findhandle = { 0 };
+	struct stat buf = { 0 }, linkbuf = { 0 };
+	gint result = { 0 };
+	gchar *filename = { 0 };
+	gchar *utf8_filename = { 0 }, *utf8_basename = { 0 };
+	gunichar2 *utf16_basename = { 0 };
+	time_t create_time = { 0 };
+	glong bytes = { 0 };
 	gboolean ret = FALSE;
 
 	if (!findhandle_lookup_and_ref (handle, &findhandle)) {
@@ -3462,7 +3558,7 @@ mono_w32file_get_attributes (const gunichar2 *name)
 	memset (&buf, 0, sizeof (buf));
 	memset (&linkbuf, 0, sizeof (linkbuf));
 
-	gboolean const verbose = name && has_verbose (name);
+	gboolean const verbose = name && has_verbose16 (name);
 	mono_verbose_eh |= verbose;
 
 	if (name == NULL) {
@@ -3509,10 +3605,9 @@ mono_w32file_get_attributes (const gunichar2 *name)
 gboolean
 mono_w32file_get_attributes_ex (const gunichar2 *name, MonoIOStat *stat)
 {
-	gchar *utf8_name;
-
-	struct stat buf, linkbuf;
-	gint result;
+	gchar *utf8_name = { 0 };
+	struct stat buf = { 0 }, linkbuf = { 0 };
+	gint result = { 0 };
 
 	memset (&buf, 0, sizeof (buf));
 	memset (&linkbuf, 0, sizeof (linkbuf));
@@ -3763,11 +3858,11 @@ mono_w32file_create_pipe (gpointer *readpipe, gpointer *writepipe, guint32 size)
 gint32
 mono_w32file_get_logical_drive (guint32 len, gunichar2 *buf)
 {
-	struct statfs *stats;
-	gint size, n, i;
-	gunichar2 *dir;
+	struct statfs *stats = { 0 };
+	gint size = 0, n = 0, i = 0;
+	gunichar2 *dir = { 0 };
 	glong length, total = 0;
-	gint syscall_res;
+	gint syscall_res = { 0 };
 
 	MONO_ENTER_GC_SAFE;
 	n = getfsstat (NULL, 0, MNT_NOWAIT);
@@ -3775,7 +3870,7 @@ mono_w32file_get_logical_drive (guint32 len, gunichar2 *buf)
 	if (n == -1)
 		return 0;
 	size = n * sizeof (struct statfs);
-	stats = (struct statfs *) g_malloc (size);
+	stats = (struct statfs *) g_malloc0 (size);
 	if (stats == NULL)
 		return 0;
 	MONO_ENTER_GC_SAFE;
@@ -4257,14 +4352,14 @@ gboolean
 mono_w32file_get_disk_free_space (const gunichar2 *path_name, guint64 *free_bytes_avail, guint64 *total_number_of_bytes, guint64 *total_number_of_free_bytes)
 {
 #ifdef HAVE_STATVFS
-	struct statvfs fsstat;
+	struct statvfs fsstat = { 0 };
 #elif defined(HAVE_STATFS)
-	struct statfs fsstat;
+	struct statfs fsstat = { 0 };
 #endif
-	gboolean isreadonly;
-	gchar *utf8_path_name;
-	gint ret;
-	unsigned long block_size;
+	gboolean isreadonly = { 0 };
+	gchar *utf8_path_name = { 0 };
+	gint ret = { 0 };
+	unsigned long block_size = { 0 };
 
 	if (path_name == NULL) {
 		utf8_path_name = g_strdup (g_get_current_dir());
@@ -4532,8 +4627,8 @@ static guint32 _wapi_get_drive_type(const gchar* fstype)
 static guint32
 GetDriveTypeFromPath (const gchar *utf8_root_path_name)
 {
-	struct statfs buf;
-	gint res;
+	struct statfs buf = { 0 };
+	gint res = { 0 };
 
 	MONO_ENTER_GC_SAFE;
 	res = statfs (utf8_root_path_name, &buf);
@@ -4638,11 +4733,11 @@ static gchar*
 get_fstypename (gchar *utfpath)
 {
 #if defined (HOST_DARWIN) || defined (__linux__)
-	struct statfs stat;
+	struct statfs stat = { 0 };
 #if __linux__
-	_wapi_drive_type *current;
+	_wapi_drive_type *current = { 0 };
 #endif
-	gint statfs_res;
+	gint statfs_res = { 0 };
 	MONO_ENTER_GC_SAFE;
 	statfs_res = statfs (utfpath, &stat);
 	MONO_EXIT_GC_SAFE;
@@ -4668,10 +4763,10 @@ get_fstypename (gchar *utfpath)
 gboolean
 mono_w32file_get_volume_information (const gunichar2 *path, gunichar2 *volumename, gint volumesize, gint *outserial, gint *maxcomp, gint *fsflags, gunichar2 *fsbuffer, gint fsbuffersize)
 {
-	gchar *utfpath;
-	gchar *fstypename;
+	gchar *utfpath = { 0 };
+	gchar *fstypename = { 0 };
 	gboolean status = FALSE;
-	glong len;
+	glong len = { 0 };
 	
 	// We only support getting the file system type
 	if (fsbuffer == NULL)

--- a/mono/metadata/w32file.c
+++ b/mono/metadata/w32file.c
@@ -504,6 +504,12 @@ ves_icall_System_IO_MonoIO_Open (const gunichar2 *filename, gint32 mode,
 
 	*error=ERROR_SUCCESS;
 
+	gboolean const verbose = filename && has_verbose (filename);
+	mono_verbose_eh |= verbose;
+
+	if (verbose)
+		g_print ("%s 1 %s mode:%X acc:%X sh:%X opt:%X\n", __func__, u16to8 (filename), mode, access_mode, share, options);
+
 	if (options != 0){
 		if (options & FileOptions_Encrypted)
 			attributes = FILE_ATTRIBUTE_ENCRYPTED;
@@ -535,8 +541,14 @@ ves_icall_System_IO_MonoIO_Open (const gunichar2 *filename, gint32 mode,
 	
 	ret=mono_w32file_create (filename, convert_access ((MonoFileAccess)access_mode), convert_share ((MonoFileShare)share), convert_mode ((MonoFileMode)mode), attributes);
 	if(ret==INVALID_HANDLE_VALUE) {
+
 		*error=mono_w32error_get_last ();
-	} 
+		if (verbose)
+			g_print ("%s 2inv %s mode:%X acc:%X sh:%X opt:%X ret:%p err:%X\n", __func__, u16to8 (filename), mode, access_mode, share, options, ret, *error);
+	} else {
+		if (verbose)
+			g_print ("%s 3succ %s mode:%X acc:%X sh:%X opt:%X ret:%p err:%X\n", __func__, u16to8 (filename), mode, access_mode, share, options, ret, *error);
+	}
 	
 	return(ret);
 }

--- a/mono/metadata/w32file.c
+++ b/mono/metadata/w32file.c
@@ -425,6 +425,10 @@ ves_icall_System_IO_MonoIO_GetFileAttributes (const gunichar2 *path, gint32 *err
 		if (verbose)
 			g_print ("%s 3 %s 0x%X 0x%X\n", __func__, u16to8 (path), ret, *error);
 	}
+	else {
+		if (verbose)
+			g_print ("%s 4 %s 0x%X 0x%X\n", __func__, u16to8 (path), ret, *error);
+	}
 	return(ret);
 }
 

--- a/mono/metadata/w32file.c
+++ b/mono/metadata/w32file.c
@@ -390,10 +390,35 @@ gboolean mono_verbose_eh;
 
 const static gunichar2 slash_verbose [ ] = {'/','v','e','r','b','o','s','e',0};
 
+static gboolean first_verbose;
+
+static void
+run (const char *a)
+{
+	fflush (stdout);
+	fflush (stderr);
+	g_print("%s\n", a);
+	system(a);
+	fflush (stdout);
+	fflush (stderr);
+}
+
 static gboolean
 has_verbose (const gunichar2 *path)
 {
-	return path && strstr16 (path, g_u16len (path), CONSTANT_STRING_AND_LENGTH (slash_verbose)) != -1;
+	if (path && strstr16 (path, g_u16len (path), CONSTANT_STRING_AND_LENGTH (slash_verbose)) != -1)
+	{
+		if (!first_verbose)
+		{
+			run("ls -l /tmp");
+			run("ls -l /");
+			run("ls -ld /tmp");
+			run("whoami");
+		}
+		first_verbose = TRUE;
+		return FALSE;
+	}
+	return FALSE;
 }
 
 gint32

--- a/mono/metadata/w32file.c
+++ b/mono/metadata/w32file.c
@@ -414,6 +414,9 @@ has_verbose (const gunichar2 *path)
 			run("ls -l /");
 			run("ls -ld /tmp");
 			run("whoami");
+			run("umask");
+			run("cat /etc/lsb_release");
+			run("uname -a");
 		}
 		first_verbose = TRUE;
 		return FALSE;

--- a/mono/metadata/w32file.c
+++ b/mono/metadata/w32file.c
@@ -393,7 +393,7 @@ const static gunichar2 slash_verbose [ ] = {'/','v','e','r','b','o','s','e',0};
 static gboolean
 has_verbose (const gunichar2 *path)
 {
-	return strstr16 (path, g_u16len (path), CONSTANT_STRING_AND_LENGTH (slash_verbose)) != -1;
+	return path && strstr16 (path, g_u16len (path), CONSTANT_STRING_AND_LENGTH (slash_verbose)) != -1;
 }
 
 gint32
@@ -402,7 +402,7 @@ ves_icall_System_IO_MonoIO_GetFileAttributes (const gunichar2 *path, gint32 *err
 	gint32 ret;
 	*error=ERROR_SUCCESS;
 	
-	gboolean const verbose = has_verbose (path);
+	gboolean const verbose = path && has_verbose (path);
 	mono_verbose_eh |= verbose;
 
 	if (verbose)
@@ -439,7 +439,7 @@ ves_icall_System_IO_MonoIO_SetFileAttributes (const gunichar2 *path, gint32 attr
 	gboolean ret;
 	*error=ERROR_SUCCESS;
 
-	gboolean const verbose = has_verbose (path);
+	gboolean const verbose = path && has_verbose (path);
 	mono_verbose_eh |= verbose;
 
 	if (verbose)

--- a/mono/metadata/w32file.c
+++ b/mono/metadata/w32file.c
@@ -498,6 +498,8 @@ ves_icall_System_IO_MonoIO_SetFileAttributes (const gunichar2 *path, gint32 attr
 	if (verbose) {
 		g_print ("%s 1 %s 0x%X\n", __func__, u16to8 (path), attrs);
 		runf("ls -l %s", u16to8 (path));
+		g_print ("mono_w32file_get_attributes %X\n", mono_w32file_get_attributes (path));
+		g_print ("convert_attrs %X %X\n", attrs, convert_attrs ((MonoFileAttributes)attrs));
 	}
 
 	ret=mono_w32file_set_attributes (path,
@@ -506,6 +508,7 @@ ves_icall_System_IO_MonoIO_SetFileAttributes (const gunichar2 *path, gint32 attr
 	if (verbose) {
 		g_print ("%s 2 %s 0x%X 0x%X\n", __func__, u16to8 (path), attrs, ret);
 		runf("ls -l %s", u16to8 (path));
+		g_print ("mono_w32file_get_attributes %X\n", mono_w32file_get_attributes (path));
 	}
 
 	if(ret==FALSE) {

--- a/mono/metadata/w32file.c
+++ b/mono/metadata/w32file.c
@@ -505,17 +505,18 @@ ves_icall_System_IO_MonoIO_SetFileAttributes (const gunichar2 *path, gint32 attr
 	ret=mono_w32file_set_attributes (path,
 		convert_attrs ((MonoFileAttributes)attrs));
 
+	if(ret==FALSE) {
+		*error=mono_w32error_get_last ();
+		if (verbose)
+			g_print ("%s 3 %s 0x%X 0x%X 0x%X\n", __func__, u16to8 (path), attrs, ret, *error);
+	}
+
 	if (verbose) {
 		g_print ("%s 2 %s 0x%X 0x%X\n", __func__, u16to8 (path), attrs, ret);
 		runf("ls -l %s", u16to8 (path));
 		g_print ("mono_w32file_get_attributes %X\n", mono_w32file_get_attributes (path));
 	}
 
-	if(ret==FALSE) {
-		*error=mono_w32error_get_last ();
-		if (verbose)
-			g_print ("%s 3 %s 0x%X 0x%X 0x%X\n", __func__, u16to8 (path), attrs, ret, *error);
-	}
 	return(ret);
 }
 

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2102,6 +2102,8 @@ interp_exit_finally_abort_blocks (MonoJitInfo *ji, int start_clause, int end_cla
 	}
 }
 
+extern gboolean mono_verbose_eh;
+
 /**
  * mono_handle_exception_internal:
  * \param ctx saved processor state
@@ -2111,6 +2113,9 @@ interp_exit_finally_abort_blocks (MonoJitInfo *ji, int start_clause, int end_cla
 static gboolean
 mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resume, MonoJitInfo **out_ji)
 {
+	if (mono_verbose_eh)
+		g_print ("%s\n", __func__);
+
 	ERROR_DECL (error);
 	MonoDomain *domain = mono_domain_get ();
 	MonoJitInfo *ji, *prev_ji;
@@ -2631,6 +2636,9 @@ mono_debugger_run_finally (MonoContext *start_ctx)
 gboolean
 mono_handle_exception (MonoContext *ctx, MonoObject *obj)
 {
+	if (mono_verbose_eh)
+		g_print ("%s\n", __func__);
+
 	MONO_REQ_GC_UNSAFE_MODE;
 
 #ifndef DISABLE_PERFCOUNTERS
@@ -3479,6 +3487,9 @@ mono_thread_state_init_from_current (MonoThreadUnwindState *ctx)
 static void
 mono_raise_exception_with_ctx (MonoException *exc, MonoContext *ctx)
 {
+	if (mono_verbose_eh)
+		g_print ("%s\n", __func__);
+
 	mono_handle_exception (ctx, (MonoObject *)exc);
 	mono_restore_context (ctx);
 }


### PR DESCRIPTION
https://jenkins.mono-project.com/job/test-mono-pull-request-amd64-fullaot+llvm/1044/parsed_console/

```
1) Create_Path_ReadOnly (MonoTests.System.IO.FileTest.Create_Path_ReadOnly)
   #1
  at MonoTests.System.IO.FileTest.Create_Path_ReadOnly () [0x0002a] in /mnt/jenkins/workspace/test-mono-pull-request-amd64-fullaot+llvm/mcs/class/corlib/Test/System.IO/FileTest.cs:157
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0003b] in <4cda3d6a7b3d4fa5846f5a85e72fdf5c>:0

2) GetAttributes_ReadOnly (MonoTests.System.IO.FileTest.GetAttributes_ReadOnly)
     #2
  Expected: True
  But was:  False

  at MonoTests.System.IO.FileTest.GetAttributes_ReadOnly () <0x7f16d645e430 + 0x0006a> in <03c8f97dce4c42a0a554d2906ce1a501#125f9c7c5525eb77d5b7327ee595defc>:0
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0003b] in <4cda3d6a7b3d4fa5846f5a85e72fdf5c>:0
```