### PR TITLE
Fix mkbundle alignment to work with Windows. See https://github.com/mono/mono/issues/8225.

### DIFF
--- a/mcs/tools/mkbundle/mkbundle.cs
+++ b/mcs/tools/mkbundle/mkbundle.cs
@@ -470,7 +470,7 @@ class MakeBundle {
 		// Modern bundling starts here
 		if (!custom_mode){
 			if (runtime != null){
-				// Nothing to do here, the user has chosen to manually specify --runtime nad libraries
+				// Nothing to do here, the user has chosen to manually specify --runtime and libraries
 			} else if (sdk_path != null) {
 				VerifySdk (sdk_path);
 			} else if (cross_target == "default" || cross_target == null){
@@ -655,7 +655,7 @@ class MakeBundle {
 
 	class PackageMaker {
 		Dictionary<string, Tuple<long,int>> locations = new Dictionary<string, Tuple<long,int>> ();
-		const int align = 4096;
+		const int align = 1 << 16;
 		Stream package;
 		
 		public PackageMaker (string output)

--- a/mcs/tools/mkbundle/mkbundle.cs
+++ b/mcs/tools/mkbundle/mkbundle.cs
@@ -689,6 +689,7 @@ class MakeBundle {
 
 		public void AddString (string entry, string text)
 		{
+			// FIXME Strings are over-aligned?
 			var bytes = Encoding.UTF8.GetBytes (text);
 			locations [entry] = Tuple.Create (package.Position, bytes.Length);
 			package.Write (bytes, 0, bytes.Length);
@@ -697,6 +698,7 @@ class MakeBundle {
 
 		public void AddStringPair (string entry, string key, string value)
 		{
+			// FIXME Strings are over-aligned?
 			var kbytes = Encoding.UTF8.GetBytes (key);
 			var vbytes = Encoding.UTF8.GetBytes (value);
 

--- a/mcs/tools/mkbundle/mkbundle.cs
+++ b/mcs/tools/mkbundle/mkbundle.cs
@@ -655,11 +655,13 @@ class MakeBundle {
 
 	class PackageMaker {
 		Dictionary<string, Tuple<long,int>> locations = new Dictionary<string, Tuple<long,int>> ();
-		int align = 1 << 16; // first alignment
+		int align = 4096; // first non-Windows alignment, saving on average 30K
 		Stream package;
 		
 		public PackageMaker (string output)
 		{
+			if (style == "windows")
+				align = 1 << 16; // first Windows alignment
 			package = File.Create (output, 128*1024);
 			if (IsUnix){
 				File.SetAttributes (output, unchecked ((FileAttributes) 0x80000000));
@@ -675,7 +677,7 @@ class MakeBundle {
 					Console.WriteLine ("At {0:x} with input {1}", package.Position, fileStream.Length);
 				fileStream.CopyTo (package);
 				package.Position = package.Position + (align - (package.Position % align));
-				align = 4096; // rest of alignment
+				align = 4096; // rest of alignment for all systems
 				return (int) ret;
 			}
 		}

--- a/mcs/tools/mkbundle/mkbundle.cs
+++ b/mcs/tools/mkbundle/mkbundle.cs
@@ -655,7 +655,7 @@ class MakeBundle {
 
 	class PackageMaker {
 		Dictionary<string, Tuple<long,int>> locations = new Dictionary<string, Tuple<long,int>> ();
-		const int align = 1 << 16;
+		int align = 1 << 16; // first alignment
 		Stream package;
 		
 		public PackageMaker (string output)
@@ -675,6 +675,7 @@ class MakeBundle {
 					Console.WriteLine ("At {0:x} with input {1}", package.Position, fileStream.Length);
 				fileStream.CopyTo (package);
 				package.Position = package.Position + (align - (package.Position % align));
+				align = 4096; // rest of alignment
 				return (int) ret;
 			}
 		}

--- a/mcs/tools/mkbundle/mkbundle.cs
+++ b/mcs/tools/mkbundle/mkbundle.cs
@@ -693,6 +693,7 @@ class MakeBundle {
 			var bytes = Encoding.UTF8.GetBytes (text);
 			locations [entry] = Tuple.Create (package.Position, bytes.Length);
 			package.Write (bytes, 0, bytes.Length);
+			package.WriteByte (0);
 			package.Position = package.Position + (align - (package.Position % align));
 		}
 


### PR DESCRIPTION
Consider doing this only for Windows.
