### PR TITLE
[profiler] Don't raise events until the profiler transitions to the ready state.

### DIFF
--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -923,6 +923,7 @@ update_callback (volatile gpointer *location, gpointer new_, volatile gint32 *co
 	void \
 	mono_profiler_raise_ ## name params \
 	{ \
+		if (!mono_profiler_state.startup_done) return;	\
 		for (MonoProfilerHandle h = mono_profiler_state.profilers; h; h = h->next) { \
 			MonoProfiler ## type ## Callback cb = h->name ## _cb; \
 			if (cb) \


### PR DESCRIPTION
We can't raise event before that as the profiler depends on too much runtime
infrastructure at this point for it to reliably work.

For example, we need the threading infrastructure to be init'd so we can access the
thread-local profiler state to store events there.

Fixes https://github.com/mono/mono/issues/8866