### PR TITLE
Fix u16to8 for non-Windows.

### DIFF
--- a/mono/eglib/eglib-remap.h
+++ b/mono/eglib/eglib-remap.h
@@ -291,3 +291,7 @@
 #define g_log_set_default_handler monoeg_log_set_default_handler
 #define g_set_print_handler monoeg_set_print_handler
 #define g_set_printerr_handler monoeg_set_printerr_handler
+
+#define g_utf16len monoeg_g_utf16len
+#define u8to16 monoeg_g_u8to16
+#define u16to8 monoeg_g_u16to8

--- a/mono/eglib/giconv.c
+++ b/mono/eglib/giconv.c
@@ -1020,6 +1020,30 @@ g_utf8_to_ucs4 (const gchar *str, glong len, glong *items_read, glong *items_wri
 	return outbuf;
 }
 
+gunichar2*
+u8to16 (const gchar *str)
+{
+	return g_utf8_to_utf16 (str, (glong)strlen (str), NULL, NULL, NULL);
+}
+
+gsize
+g_u16len (const gunichar2 *s)
+{
+#ifdef G_OS_WIN32
+	return wcslen (s);
+#else
+	const gunichar2 *t = s;
+	while (*s++) ;
+	return (gsize)(s - t - 1);
+#endif
+}
+
+gchar*
+u16to8 (const gunichar2 *str)
+{
+	return g_utf16_to_utf8 (str, (glong)g_u16len (str), NULL, NULL, NULL);
+}
+
 gchar *
 g_utf16_to_utf8 (const gunichar2 *str, glong len, glong *items_read, glong *items_written, GError **err)
 {
@@ -1031,11 +1055,8 @@ g_utf16_to_utf8 (const gunichar2 *str, glong len, glong *items_read, glong *item
 	
 	g_return_val_if_fail (str != NULL, NULL);
 	
-	if (len < 0) {
-		len = 0;
-		while (str[len])
-			len++;
-	}
+	if (len < 0)
+		len = (glong)g_u16len (str);
 	
 	inptr = (char *) str;
 	inleft = len * 2;
@@ -1112,11 +1133,8 @@ g_utf16_to_ucs4 (const gunichar2 *str, glong len, glong *items_read, glong *item
 	
 	g_return_val_if_fail (str != NULL, NULL);
 	
-	if (len < 0) {
-		len = 0;
-		while (str[len])
-			len++;
-	}
+	if (len < 0)
+		len = (glong)g_u16len (str);
 	
 	inptr = (char *) str;
 	inleft = len * 2;

--- a/mono/eglib/giconv.c
+++ b/mono/eglib/giconv.c
@@ -1027,7 +1027,7 @@ u8to16 (const gchar *str)
 }
 
 gsize
-g_u16len (const gunichar2 *s)
+g_utf16len (const gunichar2 *s)
 {
 #ifdef G_OS_WIN32
 	return wcslen (s);
@@ -1041,7 +1041,7 @@ g_u16len (const gunichar2 *s)
 gchar*
 u16to8 (const gunichar2 *str)
 {
-	return g_utf16_to_utf8 (str, (glong)g_u16len (str), NULL, NULL, NULL);
+	return g_utf16_to_utf8 (str, (glong)g_utf16len (str), NULL, NULL, NULL);
 }
 
 gchar *
@@ -1056,7 +1056,7 @@ g_utf16_to_utf8 (const gunichar2 *str, glong len, glong *items_read, glong *item
 	g_return_val_if_fail (str != NULL, NULL);
 	
 	if (len < 0)
-		len = (glong)g_u16len (str);
+		len = (glong)g_utf16len (str);
 	
 	inptr = (char *) str;
 	inleft = len * 2;
@@ -1134,7 +1134,7 @@ g_utf16_to_ucs4 (const gunichar2 *str, glong len, glong *items_read, glong *item
 	g_return_val_if_fail (str != NULL, NULL);
 	
 	if (len < 0)
-		len = (glong)g_u16len (str);
+		len = (glong)g_utf16len (str);
 	
 	inptr = (char *) str;
 	inleft = len * 2;

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -797,13 +797,17 @@ gunichar  *g_utf16_to_ucs4 (const gunichar2 *str, glong len, glong *items_read, 
 gchar     *g_ucs4_to_utf8  (const gunichar *str, glong len, glong *items_read, glong *items_written, GError **err);
 gunichar2 *g_ucs4_to_utf16 (const gunichar *str, glong len, glong *items_read, glong *items_written, GError **err);
 
-#define u8to16(str) g_utf8_to_utf16(str, (glong)strlen(str), NULL, NULL, NULL)
+#define g_u16len monoeg_g_u16len
+gsize
+g_u16len (const gunichar2 *str);
 
-#ifdef G_OS_WIN32
-#define u16to8(str) g_utf16_to_utf8((gunichar2 *) (str), (glong)wcslen((wchar_t *) (str)), NULL, NULL, NULL)
-#else
-#define u16to8(str) g_utf16_to_utf8(str, (glong)strlen(str), NULL, NULL, NULL)
-#endif
+#define u8to16 monoeg_g_u8to16
+gunichar2*
+u8to16 (const gchar *str);
+
+#define u16to8 monoeg_g_u16to8
+gchar*
+u16to8 (const gunichar2 *str);
 
 /*
  * Path

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -797,15 +797,12 @@ gunichar  *g_utf16_to_ucs4 (const gunichar2 *str, glong len, glong *items_read, 
 gchar     *g_ucs4_to_utf8  (const gunichar *str, glong len, glong *items_read, glong *items_written, GError **err);
 gunichar2 *g_ucs4_to_utf16 (const gunichar *str, glong len, glong *items_read, glong *items_written, GError **err);
 
-#define g_utf16len monoeg_g_utf16len
 gsize
 g_utf16len (const gunichar2 *str);
 
-#define u8to16 monoeg_g_u8to16
 gunichar2*
 u8to16 (const gchar *str);
 
-#define u16to8 monoeg_g_u16to8
 gchar*
 u16to8 (const gunichar2 *str);
 

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -797,9 +797,9 @@ gunichar  *g_utf16_to_ucs4 (const gunichar2 *str, glong len, glong *items_read, 
 gchar     *g_ucs4_to_utf8  (const gunichar *str, glong len, glong *items_read, glong *items_written, GError **err);
 gunichar2 *g_ucs4_to_utf16 (const gunichar *str, glong len, glong *items_read, glong *items_written, GError **err);
 
-#define g_u16len monoeg_g_u16len
+#define g_utf16len monoeg_g_utf16len
 gsize
-g_u16len (const gunichar2 *str);
+g_utf16len (const gunichar2 *str);
 
 #define u8to16 monoeg_g_u8to16
 gunichar2*


### PR DESCRIPTION
Fix u16to8 for non-Windows. I was about to use this for debugging and it didn't compile,
because it passes gunichar2* to strlen.
