### PR TITLE
[native crash] dump memory around instruction pointer

### DIFF
--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2882,6 +2882,55 @@ print_stack_frame_to_string (StackFrameInfo *frame, MonoContext *ctx, gpointer d
 }
 
 #ifndef MONO_CROSS_COMPILE
+static gchar
+conv_ascii_char (gchar s)
+{
+	if (s < 0x20)
+		return '.';
+	if (s > 0x7e)
+		return '.';
+	return s;
+}
+
+static void
+xxd_mem (gpointer d, int len)
+{
+	guint8 *data = (guint8 *) d;
+
+	for (int off = 0; off < len; off += 0x10) {
+		g_printerr ("%p  ", data + off);
+
+		for (int i = 0; i < 0x10; i++) {
+			if ((i + off) >= len)
+				g_printerr ("   ");
+			else
+				g_printerr ("%02x ", data [off + i]);
+		}
+
+		g_printerr (" ");
+
+		for (int i = 0; i < 0x10; i++) {
+			if ((i + off) >= len)
+				g_printerr (" ");
+			else
+				g_printerr ("%c", conv_ascii_char (data [off + i]));
+		}
+
+		g_printerr ("\n");
+	}
+}
+
+static void
+dump_memory_around_ip (void *ctx)
+{
+#ifdef MONO_ARCH_HAVE_SIGCTX_TO_MONOCTX
+	MonoContext mctx;
+	mono_sigctx_to_monoctx (ctx, &mctx);
+	gpointer native_ip = MONO_CONTEXT_GET_IP (&mctx);
+	g_printerr ("Memory around native instruction pointer (%p):\n", native_ip);
+	xxd_mem (((guint8 *) native_ip) - 0x10, 0x40);
+#endif
+}
 
 static void print_process_map (void)
 {
@@ -2990,6 +3039,8 @@ mono_handle_native_crash (const char *signal, void *ctx, MONO_SIG_HANDLER_INFO_T
 	}
 
 	print_process_map ();
+
+	dump_memory_around_ip (ctx);
 
 #ifdef HAVE_BACKTRACE_SYMBOLS
  {


### PR DESCRIPTION
It can help to identify issues in generated code. We don't want to ship a disassembler, so we just do a hexdump. It looks like this:

```
Memory around native instruction pointer (0x10ca1b50e):
0x10ca1b4fe  48 c7 04 24 00 00 00 00 48 8b 44 24 10 48 8b f8  H..$....H.D$.H..
0x10ca1b50e  83 38 00 48 8d 64 24 00 49 bb 3a b5 a1 0c 01 00  .8.H.d$.I.:.....
0x10ca1b51e  00 00 41 ff d3 48 89 04 24 e9 00 00 00 00 48 8b  ..A..H..$.....H.
0x10ca1b52e  04 24 e9 00 00 00 00 48 83 c4 18 c3 e8 c1 1c 53  .$.....H.......S
```

Offline tools can be used to disassemble the code.