### PR TITLE
[bcl] Fix ONO_PATH warning during resgen

### DIFF
--- a/mcs/build/library.make
+++ b/mcs/build/library.make
@@ -224,7 +224,7 @@ test-local run-test-local run-test-ondotnet-local:
 ccomma = ,
 define RESOURCE_template
 $(1).resources: $(2)
-	$(RESGEN) "$$<" "$$@"
+	$$(RESGEN) "$$<" "$$@"
 
 GEN_RESOURCE_DEPS += $(1).resources
 GEN_RESOURCE_FLAGS += -resource:$(1).resources


### PR DESCRIPTION
We'd get the following warning during the build:

```
'/Users/alexander/dev/mono/mcs/class/System.Data.Services.Client/ONO_PATH' in MONO_PATH doesn't exist or has wrong permissions.
```

The reason is that we didn't escape the $ symbol in the resgen template so the embedded $$MONO_PATH in the RESGEN variable ended up being mangled.

I'm kinda surprised this worked at all for so many years ¯\_(ツ)_/¯
