### PR TITLE
[corlib]: Use 'RandomNumberGenerator' from CoreFX.

### DIFF
--- a/mcs/class/corlib/corefx/RandomNumberGeneratorImplementation.OSX.cs
+++ b/mcs/class/corlib/corefx/RandomNumberGeneratorImplementation.OSX.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.Private;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+
+namespace System.Security.Cryptography
+{
+	partial class RandomNumberGeneratorImplementation
+	{
+		const string libSystem = "/usr/lib/libSystem.dylib";
+
+		[DllImport (libSystem)]
+		extern static int CCRandomGenerateBytes (/* void* */ ref byte bytes, /* size_t */ IntPtr count);
+
+		private static void GetBytes (ref byte pbBuffer, int count)
+		{
+			Debug.Assert (count > 0);
+
+			if (CCRandomGenerateBytes (ref pbBuffer, (IntPtr)count) != 0)
+				throw new CryptographicException ("CCRandomGenerateBytes() failed.");
+		}
+	}
+}

--- a/mcs/class/corlib/corefx/RandomNumberGeneratorImplementation.Unix.cs
+++ b/mcs/class/corlib/corefx/RandomNumberGeneratorImplementation.Unix.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.Private;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+
+namespace System.Security.Cryptography
+{
+	partial class RandomNumberGeneratorImplementation
+	{
+#if MONO_FEATURE_BTLS
+		internal const string BTLS_DYLIB = "libmono-btls-shared";
+
+		[DllImport (BTLS_DYLIB)]
+		extern static int mono_btls_get_random_bytes (ref byte buffer, int num);
+#endif
+
+		private static void GetBytes (ref byte pbBuffer, int count)
+		{
+			Debug.Assert (count > 0);
+
+#if MONO_FEATURE_BTLS
+			var ret = mono_btls_get_random_bytes (ref pbBuffer, count);
+			if (ret != 1)
+				throw new CryptographicException ("mono_btls_get_random_bytes() failed.");
+#else
+			throw new CryptographicException ("mono_btls_get_random_bytes() not available.");
+#endif
+		}
+	}
+}

--- a/mcs/class/corlib/corlib.dll.sources
+++ b/mcs/class/corlib/corlib.dll.sources
@@ -1355,7 +1355,6 @@ ReferenceSources/AppContextDefaultValues.cs
 ../referencesource/mscorlib/system/security/cryptography/md5.cs
 ../referencesource/mscorlib/system/security/cryptography/passwordderivebytes.cs
 ../referencesource/mscorlib/system/security/cryptography/pkcs1maskgenerationmethod.cs
-../referencesource/mscorlib/system/security/cryptography/randomnumbergenerator.cs
 ../referencesource/mscorlib/system/security/cryptography/rc2.cs
 ../referencesource/mscorlib/system/security/cryptography/rc2cryptoserviceprovider.cs
 ../referencesource/mscorlib/system/security/cryptography/rfc2898derivebytes.cs
@@ -1776,3 +1775,6 @@ corert/RuntimeAugments.cs
 ../../../external/corefx/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509KeyStorageFlags.cs
 
 ../../../external/corefx/src/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/*.cs
+
+../../../external/corefx/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RandomNumberGenerator.cs
+../../../external/corefx/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RandomNumberGeneratorImplementation.cs

--- a/mcs/class/corlib/darwin_net_4_x_corlib.dll.sources
+++ b/mcs/class/corlib/darwin_net_4_x_corlib.dll.sources
@@ -2,3 +2,5 @@
 
 #../../../external/corefx/src/Common/src/CoreLib/Interop/Unix/System.Native/Interop.GetRandomBytes.cs
 #../../../external/corefx/src/Common/src/CoreLib/Interop/Unix/Interop.Libraries.cs
+
+corefx/RandomNumberGeneratorImplementation.OSX.cs

--- a/mcs/class/corlib/linux_net_4_x_corlib.dll.sources
+++ b/mcs/class/corlib/linux_net_4_x_corlib.dll.sources
@@ -2,3 +2,5 @@
 
 #../../../external/corefx/src/Common/src/CoreLib/Interop/Unix/System.Native/Interop.GetRandomBytes.cs
 #../../../external/corefx/src/Common/src/CoreLib/Interop/Unix/Interop.Libraries.cs
+
+corefx/RandomNumberGeneratorImplementation.Unix.cs

--- a/mcs/class/corlib/win32_net_4_x_corlib.dll.sources
+++ b/mcs/class/corlib/win32_net_4_x_corlib.dll.sources
@@ -2,3 +2,5 @@
 
 #../../../external/corefx/src/Common/src/CoreLib/Interop/Windows/BCrypt/Interop.BCryptGenRandom.cs
 #../../../external/corefx/src/Common/src/CoreLib/Interop/Windows/Interop.Libraries.cs
+
+../../../external/corefx/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RandomNumberGeneratorImplementation.Windows.cs

--- a/mono/btls/Makefile.am
+++ b/mono/btls/Makefile.am
@@ -7,6 +7,8 @@ MONO_BTLS_SOURCES_FILES = \
 	btls-key.h \
 	btls-pkcs12.c \
 	btls-pkcs12.h \
+	btls-rand.c \
+	btls-rand.h \
 	btls-ssl.c \
 	btls-ssl-ctx.c \
 	btls-ssl-ctx.h \

--- a/mono/btls/btls-rand.c
+++ b/mono/btls/btls-rand.c
@@ -1,0 +1,16 @@
+//
+//  btls-rand.c
+//  MonoBtls
+//
+//  Created by Martin Baulig on 5/29/18.
+//  Copyright © 2018 Xamarin. All rights reserved.
+//
+
+#include "btls-rand.h"
+
+int
+mono_btls_get_random_bytes (void *buffer, int num)
+{
+	int ret = RAND_bytes (buffer, num);
+	return ret == 1;
+}

--- a/mono/btls/btls-rand.h
+++ b/mono/btls/btls-rand.h
@@ -1,0 +1,17 @@
+//
+//  btls-rand.h
+//  MonoBtls
+//
+//  Created by Martin Baulig on 5/29/18.
+//  Copyright © 2018 Xamarin. All rights reserved.
+//
+
+#ifndef __btls__btls_rand__
+#define __btls__btls_rand__
+
+#include <openssl/rand.h>
+
+int
+mono_btls_get_random_bytes (void *buffer, int num);
+
+#endif /* __btls__btls_rand__ */


### PR DESCRIPTION
* Add new mono_btls_get_random_bytes() function.

* corefx/RandomNumberGeneratorImplementation.OSX.cs: copy from CoreFX
  and P/Invoke directly instead of calling a native wrapper function.

* corefx/corefx/RandomNumberGeneratorImplementation.Unix.cs:
  CoreFX uses OpenSSL here, but the same function also exists in boringssl.
  Use a custom implementation P/Invoking into the new mono_btls_get_random_bytes().

* On Windows, we use the native CoreFX implementation.

