### PR TITLE
Issue template: update help link to https://

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
-If you are new to the project get yourself familiar with http://mono-project.com/community/bugs/make-a-good-bug-report before filling the issue
+If you are new to the project get yourself familiar with https://www.mono-project.com/community/bugs/make-a-good-bug-report/ before filling the issue
 -->
 
 ## Steps to Reproduce


### PR DESCRIPTION
Since GitHub pages rolled out HTTPS support, links to `www.mono-project.com` can now be `https://` :) This also removes a `www.` 301 users currently hits.