### PR TITLE
Make the sendfile with 6 args check use AC_TRY_LINK

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3070,7 +3070,7 @@ if test x$host_win32 = xno; then
 	])
 
 	AC_MSG_CHECKING(for sendfile with 6 arguments)
-	AC_TRY_COMPILE([
+	AC_TRY_LINK([
 		#include <stdlib.h>
 		#include <sys/types.h>
 		#include <sys/socket.h>


### PR DESCRIPTION
This lets the linker catch any missing symbols, and fixes a problem
I had building AIX with CoreFX PAL. Fixes #8979, though there may
be more cases like this.

dotnet/corefx#30012 is blocking on this.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
