### PR TITLE
[mini] Remove unneeded restriction on fast delegate creation for context-using generic delegate under gshared.

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -11465,8 +11465,7 @@ mono_ldptr:
 						}
 					}
 
-					/* FIXME: SGEN support */
-					if (invoke_context_used == 0 || cfg->llvm_only) {
+					if ((invoke_context_used == 0 || !cfg->gsharedvt) || cfg->llvm_only) {
 						if (cfg->verbose_level > 3)
 							g_print ("converting (in B%d: stack: %d) %s", cfg->cbb->block_num, (int)(sp - stack_start), mono_disasm_code_one (NULL, method, ip + 6, NULL));
 						if ((handle_ins = handle_delegate_ctor (cfg, ctor_method->klass, target_ins, cmethod, context_used, FALSE))) {
@@ -11527,8 +11526,7 @@ mono_ldptr:
 					if (mono_security_core_clr_enabled ())
 						ensure_method_is_allowed_to_call_method (cfg, method, ctor_method);
 
-					/* FIXME: SGEN support */
-					if (invoke_context_used == 0 || cfg->llvm_only) {
+					if ((invoke_context_used == 0 || !cfg->gsharedvt) || cfg->llvm_only) {
 						if (cfg->verbose_level > 3)
 							g_print ("converting (in B%d: stack: %d) %s", cfg->cbb->block_num, (int)(sp - stack_start), mono_disasm_code_one (NULL, method, ip + 6, NULL));
 						if ((handle_ins = handle_delegate_ctor (cfg, ctor_method->klass, target_ins, cmethod, context_used, is_virtual))) {


### PR DESCRIPTION
The only reason for the restriction was that handle_alloc previously would not handle generic instances.

This speeded up the following microbenchmark by 19x (3.38s x 0.17s):

```
class Driver {
	static T Identity<T> (T t) {
		return t;
	}

	[MethodImpl(MethodImplOptions.NoInlining)]
	static Func<T,T> MakeDelegate<T> () {
		return new Func<T, T> (Identity);
	}

	static void Main () {
		object o = new object ();
		for (int i = 0; i < 400 * 1000; ++i) {
			MakeDelegate<object>()(o);
		}
	}
}
```