### PR TITLE
Fix shutdown hangs e.g. thread6 and possibly Alpine/muslc problem.

### DIFF
--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -443,6 +443,8 @@ mono_method_desc_from_method (MonoMethod *method)
 void
 mono_method_desc_free (MonoMethodDesc *desc)
 {
+	if (!desc)
+		return;
 	if (desc->name_space)
 		g_free (desc->name_space);
 	else if (desc->klass)

--- a/mono/metadata/runtime.c
+++ b/mono/metadata/runtime.c
@@ -105,9 +105,9 @@ mono_runtime_try_shutdown (void)
 
 	/*TODO move the follow to here:
 	mono_thread_suspend_all_other_threads (); OR  mono_thread_wait_all_other_threads
+	*/
 
 	mono_runtime_quit ();
-	*/
 
 	return TRUE;
 }

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4731,6 +4731,9 @@ print_jit_stats (void)
 void
 mini_cleanup (MonoDomain *domain)
 {
+#if 0 // FIXME This function historically disabled,
+      // but now enabled, and just call mono_threadpool_cleanup.
+
 	if (mono_profiler_sampling_enabled ())
 		mono_runtime_shutdown_stat_profiler ();
 
@@ -4755,7 +4758,13 @@ mini_cleanup (MonoDomain *domain)
 	mono_runtime_cleanup (domain);
 #endif
 
+#endif // FIXME This function historically disabled,
+       // but now enabled, and just call mono_threadpool_cleanup.
+
 	mono_threadpool_cleanup ();
+
+#if 0 // FIXME This function historically disabled,
+      // but now enabled, and just call mono_threadpool_cleanup.
 
 	MONO_PROFILER_RAISE (runtime_shutdown_end, ());
 
@@ -4802,8 +4811,7 @@ mini_cleanup (MonoDomain *domain)
 
 	mono_counters_dump (MONO_COUNTER_SECTION_MASK | MONO_COUNTER_MONOTONIC, stdout);
 
-	if (mono_inject_async_exc_method)
-		mono_method_desc_free (mono_inject_async_exc_method);
+	mono_method_desc_free (mono_inject_async_exc_method);
 
 	mono_tls_free_keys ();
 
@@ -4814,6 +4822,9 @@ mini_cleanup (MonoDomain *domain)
 #ifndef HOST_WIN32
 	mono_w32handle_cleanup ();
 #endif
+
+#endif // FIXME This function historically disabled,
+       // but now enabled, and just call mono_threadpool_cleanup.
 }
 
 void


### PR DESCRIPTION
Prior to 5f5c5e97a08f7086d7c18af37352c4a03dc4c0d1, threadpool workers were in an interruptable wait, of random duration. There was coordination I believe with shutdown and that got lost.

The performance of shutting down the runtime became therefore random.
This is likely the cause of the AlpineLinux/muslc slowdown,  and can be seen more  easily by running mono/tests/thread6.exe. It used to run quickly, now randomly slowly.

This attempts to wake the workers, but still seems racy.
I am skeptical that there is an adequate replacement for an interruptable wait.
Or that we need in general to wait on multiple events, one of them being a shutdown event.

Unfortunately the wait on multiple events, I don't think composes with condition variables, mutexes, etc. i.e. this code needs either an undo or a different rewrite.

Really the world needs interruptable waits on condition variables  and effident mutexes. i.e. missing in Win32, unless you use the expensive kernel events/mutexes/semaphores.