### PR TITLE
Make mono_coop_sem_timedwait interruptable.

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -646,6 +646,7 @@ TESTS_CS_SRC=		\
 	generic-unloading.2.cs	\
 	namedmutex-destroy-race.cs	\
 	thread6.cs	\
+	thread7.cs	\
 	appdomain-threadpool-unload.cs	\
 	process-unref-race.cs	\
 	bug-46661.cs	\

--- a/mono/tests/thread7.cs
+++ b/mono/tests/thread7.cs
@@ -1,0 +1,58 @@
+//
+// Subset of thread6.cs, just to watch for the hang at end.
+// Note this test does not indicate success or failure well,
+// it just runs quickly or slowly.
+//
+using System;
+using System.Threading;
+
+public class Tests {
+
+	public static int Main() {
+		return test_0_regress_4413();
+	}
+
+	public static int test_0_regress_4413 () {
+		// Check that thread abort exceptions originating in another thread are not automatically rethrown
+		object o = new object ();
+		Thread t = null;
+		bool waiting = false;
+		Action a = delegate () {
+			t = Thread.CurrentThread;
+			while (true) {
+				lock (o) {
+					if (waiting) {
+						Monitor.Pulse (o);
+						break;
+					}
+				}
+
+				Thread.Sleep (10);
+			}
+			while (true) {
+				Thread.Sleep (1000);
+			}
+		};
+		var ar = a.BeginInvoke (null, null);
+		lock (o) {
+			waiting = true;
+			Monitor.Wait (o);
+		}
+
+		t.Abort ();
+
+		try {
+			try {
+				a.EndInvoke (ar);
+			} catch (ThreadAbortException) {
+			}
+		} catch (ThreadAbortException) {
+			// This will fail
+			Thread.ResetAbort ();
+			return 1;
+		}
+
+		return 0;
+	}
+}
+

--- a/mono/utils/Makefile.am
+++ b/mono/utils/Makefile.am
@@ -89,6 +89,7 @@ monoutils_sources = \
 	mono-poll.c		\
 	mono-path.c		\
 	mono-os-semaphore.h	\
+	mono-coop-semaphore.c		\
 	mono-coop-semaphore.h		\
 	mono-sigcontext.h	\
 	mono-stdlib.c 		\

--- a/mono/utils/checked-build.c
+++ b/mono/utils/checked-build.c
@@ -308,7 +308,7 @@ checked_build_thread_transition (const char *transition, void *info, int from_st
 }
 
 void
-mono_fatal_with_history (const char *msg, ...)
+mono_fatal_with_history (const char * volatile msg, ...)
 {
 	GString* err = g_string_sized_new (100);
 

--- a/mono/utils/mono-coop-semaphore.c
+++ b/mono/utils/mono-coop-semaphore.c
@@ -1,0 +1,41 @@
+/**
+ * \file
+ */
+
+#include <config.h>
+#include "mono/utils/mono-coop-semaphore.h"
+#include "mono/utils/mono-threads.h"
+
+static void
+mono_coop_sem_interrupt (gpointer sem)
+{
+	mono_os_sem_post (&((MonoCoopSem*)sem)->s);
+}
+
+MonoSemTimedwaitRet
+mono_coop_sem_timedwait (MonoCoopSem *sem, guint timeout_ms, MonoSemFlags flags)
+{
+	MonoSemTimedwaitRet res;
+	gboolean const alertable = (flags & MONO_SEM_FLAGS_ALERTABLE) != 0;
+	gboolean interrupted = FALSE;
+
+	if (alertable) {
+		mono_thread_info_install_interrupt (mono_coop_sem_interrupt, sem, &interrupted);
+		if (interrupted)
+			return MONO_SEM_TIMEDWAIT_RET_ALERTED;
+	}
+
+	MONO_ENTER_GC_SAFE;
+
+	res = mono_os_sem_timedwait (&sem->s, timeout_ms, flags);
+
+	MONO_EXIT_GC_SAFE;
+
+	if (alertable)
+		mono_thread_info_uninstall_interrupt (&interrupted);
+
+	if (interrupted)
+		return MONO_SEM_TIMEDWAIT_RET_ALERTED;
+
+	return res;
+}

--- a/mono/utils/mono-coop-semaphore.h
+++ b/mono/utils/mono-coop-semaphore.h
@@ -33,6 +33,7 @@ mono_coop_sem_destroy (MonoCoopSem *sem)
 	mono_os_sem_destroy (&sem->s);
 }
 
+// FIXME alertable untimed wait interruptable also, like mono_coop_sem_timedwait?
 static inline gint
 mono_coop_sem_wait (MonoCoopSem *sem, MonoSemFlags flags)
 {
@@ -47,19 +48,8 @@ mono_coop_sem_wait (MonoCoopSem *sem, MonoSemFlags flags)
 	return res;
 }
 
-static inline MonoSemTimedwaitRet
-mono_coop_sem_timedwait (MonoCoopSem *sem, guint timeout_ms, MonoSemFlags flags)
-{
-	MonoSemTimedwaitRet res;
-
-	MONO_ENTER_GC_SAFE;
-
-	res = mono_os_sem_timedwait (&sem->s, timeout_ms, flags);
-
-	MONO_EXIT_GC_SAFE;
-
-	return res;
-}
+MonoSemTimedwaitRet
+mono_coop_sem_timedwait (MonoCoopSem *sem, guint timeout_ms, MonoSemFlags flags);
 
 static inline void
 mono_coop_sem_post (MonoCoopSem *sem)

--- a/msvc/libmonoutils-common.targets
+++ b/msvc/libmonoutils-common.targets
@@ -76,6 +76,7 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-poll.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-path.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-os-semaphore.h" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-coop-semaphore.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-coop-semaphore.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-sigcontext.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-stdlib.c" />

--- a/msvc/libmonoutils-common.targets.filters
+++ b/msvc/libmonoutils-common.targets.filters
@@ -175,6 +175,9 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-os-semaphore.h">
       <Filter>Header Files$(MonoUtilsFilterSubFolder)\common</Filter>
     </ClInclude>
+    <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-coop-semaphore.c">
+      <Filter>Source Files$(MonoUtilsFilterSubFolder)\common</Filter>
+    </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-coop-semaphore.h">
       <Filter>Header Files$(MonoUtilsFilterSubFolder)\common</Filter>
     </ClInclude>


### PR DESCRIPTION
This addresses regression from 5f5c5e9 [threadpool] Replace parked_threads condition variable by a semaphore (#6222)

While that change simplifies the code, it caused regression.
In particular, it appears there is no longer coordination between shutdown
and the threadpool, leading to hangs at shutdown, of a bounded random
but significant duration. i.e. because threadpool workers do a random wait,
and then check for shutdown in progress. Previously the wait was interrupted.

The hang is often long enough to cause mono/tests/thread6.exe to fail CI.
The hang is usually very obvious running mono/tests/thread6.exe, even if it is within
the threshold allowed by CI.
The hang is long enough to make building mono many times slower on Alpine/muslc.
  I'm guessing due to different random number generation?
  I'm guessing this is the same issue.
  But the problems with mono/tests/thread6.exe are severe enough.

This should fix #9000 and #7167.
The problem is not specific to Alpine/muslc, it is just more noticable there.
