### PR TITLE
Add volatile to error message to improve debuggability.

### DIFF
--- a/mono/utils/checked-build.c
+++ b/mono/utils/checked-build.c
@@ -308,7 +308,7 @@ checked_build_thread_transition (const char *transition, void *info, int from_st
 }
 
 void
-mono_fatal_with_history (const char *msg, ...)
+mono_fatal_with_history (const char * volatile msg, ...)
 {
 	GString* err = g_string_sized_new (100);
 


### PR DESCRIPTION
https://jenkins.mono-project.com/job/test-mono-pull-request-coop/4300/testReport/junit/MonoTests/runtime/threadpool_exceptions5_exe_timedout/

`#22 0x000055da5ac70001 in mono_fatal_with_history (msg=<optimized out>) at checked-build.c:331`