### PR TITLE
Fix/mitigate 5-60 second hang at shutdown (mono/tests/thread6.exe).

### DIFF
--- a/mono/metadata/threadpool-worker-default.c
+++ b/mono/metadata/threadpool-worker-default.c
@@ -525,7 +525,7 @@ worker_try_create (void)
 	ERROR_DECL (error);
 	MonoInternalThread *thread;
 	gint64 current_ticks;
-	gint32 now;
+	gint32 now = 0;
 	ThreadPoolWorkerCounter counter;
 
 	if (mono_runtime_is_shutting_down ())

--- a/mono/metadata/threadpool-worker-default.c
+++ b/mono/metadata/threadpool-worker-default.c
@@ -367,7 +367,7 @@ worker_park (void)
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_THREADPOOL, "[%p] worker parking",
 		GUINT_TO_POINTER (MONO_NATIVE_THREAD_ID_TO_UINT (mono_native_thread_id_get ())));
 
-	if (!mono_runtime_is_shutting_down ()) {
+	if (!mono_runtime_is_shutting_down () && !mono_thread_test_state (mono_thread_internal_current (), ThreadState_AbortRequested)) {
 		static gpointer rand_handle = NULL;
 		ThreadPoolWorkerCounter counter;
 

--- a/mono/metadata/threadpool-worker-default.c
+++ b/mono/metadata/threadpool-worker-default.c
@@ -657,8 +657,7 @@ monitor_sufficient_delay_since_last_dequeue (void)
 	if (worker.cpu_usage < CPU_USAGE_LOW) {
 		threshold = MONITOR_INTERVAL;
 	} else {
-		ThreadPoolWorkerCounter counter;
-		counter = COUNTER_READ ();
+		ThreadPoolWorkerCounter counter = COUNTER_READ ();
 		threshold = counter._.max_working * MONITOR_INTERVAL * 2;
 	}
 
@@ -1071,8 +1070,7 @@ static gboolean
 heuristic_should_adjust (void)
 {
 	if (worker.heuristic_last_dequeue > worker.heuristic_last_adjustment + worker.heuristic_adjustment_interval) {
-		ThreadPoolWorkerCounter counter;
-		counter = COUNTER_READ ();
+		ThreadPoolWorkerCounter counter = COUNTER_READ ();
 		if (counter._.working <= counter._.max_working)
 			return TRUE;
 	}
@@ -1089,10 +1087,9 @@ heuristic_adjust (void)
 		gint64 sample_duration = sample_end - worker.heuristic_sample_start;
 
 		if (sample_duration >= worker.heuristic_adjustment_interval / 2) {
-			ThreadPoolWorkerCounter counter;
 			gint16 new_thread_count;
 
-			counter = COUNTER_READ ();
+			ThreadPoolWorkerCounter counter = COUNTER_READ ();
 			new_thread_count = hill_climbing_update (counter._.max_working, sample_duration, completions, &worker.heuristic_adjustment_interval);
 
 			COUNTER_ATOMIC (counter, {
@@ -1123,11 +1120,9 @@ heuristic_notify_work_completed (void)
 gboolean
 mono_threadpool_worker_notify_completed (void)
 {
-	ThreadPoolWorkerCounter counter;
-
 	heuristic_notify_work_completed ();
 
-	counter = COUNTER_READ ();
+	ThreadPoolWorkerCounter counter = COUNTER_READ ();
 	return counter._.working <= counter._.max_working;
 }
 

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -237,6 +237,8 @@ gboolean mono_thread_current_check_pending_interrupt (void);
 void mono_thread_set_state (MonoInternalThread *thread, MonoThreadState state);
 void mono_thread_clr_state (MonoInternalThread *thread, MonoThreadState state);
 gboolean mono_thread_test_state (MonoInternalThread *thread, MonoThreadState test);
+gboolean
+mono_thread_test_state_locked (MonoInternalThread *thread, MonoThreadState test);
 gboolean mono_thread_test_and_set_state (MonoInternalThread *thread, MonoThreadState test, MonoThreadState set);
 void mono_thread_clear_and_set_state (MonoInternalThread *thread, MonoThreadState clear, MonoThreadState set);
 
@@ -336,7 +338,13 @@ mono_threads_exit_gc_safe_region_unbalanced_internal (gpointer cookie, MonoStack
 
 // Set directory to store thread dumps captured by SIGQUIT
 void
-mono_set_thread_dump_dir(gchar* dir);
+mono_set_thread_dump_dir (gchar* dir);
+
+void
+mono_lock_thread (MonoInternalThread *thread);
+
+void
+mono_unlock_thread (MonoInternalThread *thread);
 
 #ifdef TARGET_OSX
 #define MONO_MAX_SUMMARY_NAME_LEN 140
@@ -382,6 +390,7 @@ typedef struct {
 
 gboolean
 mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes);
+
 #endif
 
 #endif /* _MONO_METADATA_THREADS_TYPES_H_ */

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -95,8 +95,8 @@ extern int tkill (pid_t tid, int signal);
 
 #define SPIN_UNLOCK(i) i = 0
 
-#define LOCK_THREAD(thread) lock_thread((thread))
-#define UNLOCK_THREAD(thread) unlock_thread((thread))
+#define LOCK_THREAD(thread) (mono_lock_thread(thread))
+#define UNLOCK_THREAD(thread) (mono_unlock_thread(thread))
 
 typedef union {
 	gint32 ival;
@@ -472,8 +472,8 @@ static void ensure_synch_cs_set (MonoInternalThread *thread)
 	}
 }
 
-static inline void
-lock_thread (MonoInternalThread *thread)
+void
+mono_lock_thread (MonoInternalThread *thread)
 {
 	if (!thread->synch_cs)
 		ensure_synch_cs_set (thread);
@@ -483,8 +483,8 @@ lock_thread (MonoInternalThread *thread)
 	mono_coop_mutex_lock (thread->synch_cs);
 }
 
-static inline void
-unlock_thread (MonoInternalThread *thread)
+void
+mono_unlock_thread (MonoInternalThread *thread)
 {
 	mono_coop_mutex_unlock (thread->synch_cs);
 }
@@ -492,13 +492,13 @@ unlock_thread (MonoInternalThread *thread)
 static void
 lock_thread_handle (MonoInternalThreadHandle thread)
 {
-	lock_thread (mono_internal_thread_handle_ptr (thread));
+	mono_lock_thread (mono_internal_thread_handle_ptr (thread));
 }
 
 static void
 unlock_thread_handle (MonoInternalThreadHandle thread)
 {
-	unlock_thread (mono_internal_thread_handle_ptr (thread));
+	mono_unlock_thread (mono_internal_thread_handle_ptr (thread));
 }
 
 static inline gboolean
@@ -5157,11 +5157,17 @@ mono_thread_clr_state (MonoInternalThread *thread, MonoThreadState state)
 }
 
 gboolean
+mono_thread_test_state_locked (MonoInternalThread *thread, MonoThreadState test)
+{
+	return (thread->state & test) != 0;
+}
+
+gboolean
 mono_thread_test_state (MonoInternalThread *thread, MonoThreadState test)
 {
 	LOCK_THREAD (thread);
 
-	gboolean const ret = ((thread->state & test) != 0);
+	gboolean const ret = mono_thread_test_state_locked (thread, test);
 	
 	UNLOCK_THREAD (thread);
 	

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -4791,7 +4791,7 @@ gint64
 mono_w32file_get_file_size (gpointer handle, gint32 *error)
 {
 	gint64 length;
-	guint32 length_hi;
+	guint32 length_hi = 0;
 
 	length = GetFileSize (handle, &length_hi);
 	if(length==INVALID_FILE_SIZE) {

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -4566,8 +4566,7 @@ array_constructed:
 			ip ++;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_END_ABORT_PROT)
-			if (mono_threads_end_abort_protected_block ())
-				frame->ex = mono_thread_interruption_checkpoint ();
+			mono_threads_end_abort_protected_block ();
 			ip ++;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_ENDFINALLY)
@@ -4584,7 +4583,7 @@ array_constructed:
 				goto main_loop;
 			}
 			if (frame->ex)
-				THROW_EX (frame->ex, ip);
+				goto handle_catch;
 			ves_abort();
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_LEAVE) /* Fall through */
@@ -5207,7 +5206,80 @@ array_constructed:
 			goto main_loop;
 		}
 
+		/*
+		 * If an exception is set, we need to execute the fault handler, too,
+		 * otherwise, we continue normally.
+		 */
+		if (frame->ex)
+			goto handle_fault;
 		ves_abort();
+	}
+	handle_fault:
+	{
+		int i;
+		guint32 ip_offset;
+		MonoExceptionClause *clause;
+		GSList *old_list = finally_ips;
+		
+#if DEBUG_INTERP
+		if (tracing)
+			g_print ("* Handle fault\n");
+#endif
+		ip_offset = frame->ip - rtm->code;
+
+		for (i = 0; i < rtm->num_clauses; ++i) {
+			clause = &rtm->clauses [i];
+			if (clause->flags == MONO_EXCEPTION_CLAUSE_FAULT && MONO_OFFSET_IN_CLAUSE (clause, ip_offset)) {
+				ip = rtm->code + clause->handler_offset;
+				finally_ips = g_slist_prepend (finally_ips, (gpointer) ip);
+#if DEBUG_INTERP
+				if (tracing)
+					g_print ("* Executing handler at IL_%04x\n", clause->handler_offset);
+#endif
+			}
+		}
+
+		if (old_list != finally_ips && finally_ips) {
+			ip = finally_ips->data;
+			finally_ips = g_slist_remove (finally_ips, ip);
+			sp = frame->stack; /* spec says stack should be empty at endfinally so it should be at the start too */
+			vt_sp = (unsigned char *) sp + rtm->stack_size;
+			goto main_loop;
+		}
+	}
+	handle_catch:
+	{
+		/*
+		 * If the handler for the exception was found in this method, we jump
+		 * to it right away, otherwise we return and let the caller run
+		 * the finally, fault and catch blocks.
+		 * This same code should be present in the endfault opcode, but it
+		 * is corrently not assigned in the ECMA specs: LAMESPEC.
+		 */
+		if (frame->ex_handler) {
+#if DEBUG_INTERP
+			if (tracing)
+				g_print ("* Executing handler at IL_%04x\n", frame->ex_handler->handler_offset);
+#endif
+			ip = rtm->code + frame->ex_handler->handler_offset;
+			sp = frame->stack;
+			vt_sp = (unsigned char *) sp + rtm->stack_size;
+			sp->data.p = frame->ex;
+			++sp;
+			goto main_loop;
+		}
+		goto check_lmf;
+	}
+
+check_lmf:
+	{
+		/* make sure we don't miss to pop a LMF */
+		MonoLMF *lmf= mono_get_lmf ();
+		if (lmf && (gsize) lmf->previous_lmf & 2) {
+			MonoLMFExt *ext = (MonoLMFExt *) lmf;
+			if (ext->interp_exit && ext->interp_exit_data == frame->parent)
+				interp_pop_lmf (ext);
+		}
 	}
 
 exit_frame:

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -646,6 +646,7 @@ TESTS_CS_SRC=		\
 	generic-unloading.2.cs	\
 	namedmutex-destroy-race.cs	\
 	thread6.cs	\
+	thread7.cs	\
 	appdomain-threadpool-unload.cs	\
 	process-unref-race.cs	\
 	bug-46661.cs	\

--- a/mono/tests/thread7.cs
+++ b/mono/tests/thread7.cs
@@ -1,0 +1,58 @@
+//
+// Subset of thread6.cs, just to watch for the hang at end.
+// Note this test does not indicate success or failure well,
+// it just runs quickly or slowly.
+//
+using System;
+using System.Threading;
+
+public class Tests {
+
+	public static int Main() {
+		return test_0_regress_4413();
+	}
+
+	public static int test_0_regress_4413 () {
+		// Check that thread abort exceptions originating in another thread are not automatically rethrown
+		object o = new object ();
+		Thread t = null;
+		bool waiting = false;
+		Action a = delegate () {
+			t = Thread.CurrentThread;
+			while (true) {
+				lock (o) {
+					if (waiting) {
+						Monitor.Pulse (o);
+						break;
+					}
+				}
+
+				Thread.Sleep (10);
+			}
+			while (true) {
+				Thread.Sleep (1000);
+			}
+		};
+		var ar = a.BeginInvoke (null, null);
+		lock (o) {
+			waiting = true;
+			Monitor.Wait (o);
+		}
+
+		t.Abort ();
+
+		try {
+			try {
+				a.EndInvoke (ar);
+			} catch (ThreadAbortException) {
+			}
+		} catch (ThreadAbortException) {
+			// This will fail
+			Thread.ResetAbort ();
+			return 1;
+		}
+
+		return 0;
+	}
+}
+


### PR DESCRIPTION
Don't wait 5-60 seconds for work in threadpool on aborted threads.
This fixes #9000 and likely #7167.

Aborting already aborted threads is skipped, but interrupts on aborted threads are not.
This regressed with change 5f5c5e9 [threadpool] Replace parked_threads condition variable by a semaphore (#6222)

The skipping of syscall abort in aborted threads is circa here:
```
request_thread_abort:
	if (thread->state & (ThreadState_AbortRequested | ThreadState_Stopped))
	{
		UNLOCK_THREAD (thread);
		return FALSE;
	}
```

Otherwise there is a wait for a random duration between 5 and 60 seconds in mono/tests/thread6.cs,
which aborts a threadpool worker thread -- probably an inappropriate thing to do,
threadpool threads being a shared resource, however with the right amount of synchronization,
one can probably be sure to only abort one's own work, and the threadpool will survive by
spinning up additional threads, or in this case, shutting down in the expected rapid way.

Possibly there should be a notion of canceling a threadpool work item or task, instead
of the entire thread. Even if it is safe, it is defeating the efficiency of a threadpool.

There might be another fix involving doing more of the abort processing of aborted threads.