### PR TITLE
[Coop] Convert ves_icall_System_Threading_Thread_GetAbortExceptionState.

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2296,7 +2296,6 @@ ves_icall_System_AppDomain_LoadAssemblyRaw (MonoAppDomainHandle ad,
 					    MonoBoolean refonly,
 					    MonoError *error)
 {
-	error_init (error);
 	MonoAssembly *ass;
 	MonoReflectionAssemblyHandle refass = MONO_HANDLE_CAST (MonoReflectionAssembly, NULL_HANDLE);
 	MonoDomain *domain = MONO_HANDLE_GETVAL(ad, data);
@@ -2363,7 +2362,6 @@ ves_icall_System_AppDomain_LoadAssemblyRaw (MonoAppDomainHandle ad,
 MonoReflectionAssemblyHandle
 ves_icall_System_AppDomain_LoadAssembly (MonoAppDomainHandle ad, MonoStringHandle assRef, MonoObjectHandle evidence, MonoBoolean refOnly, MonoError *error)
 {
-	error_init (error);
 	MonoDomain *domain = MONO_HANDLE_GETVAL (ad, data);
 	MonoImageOpenStatus status = MONO_IMAGE_OK;
 	MonoAssembly *ass;
@@ -2419,7 +2417,6 @@ fail:
 void
 ves_icall_System_AppDomain_InternalUnload (gint32 domain_id, MonoError *error)
 {
-	error_init (error);
 	MonoDomain * domain = mono_domain_get_by_id (domain_id);
 
 	if (NULL == domain) {
@@ -2448,7 +2445,6 @@ ves_icall_System_AppDomain_InternalUnload (gint32 domain_id, MonoError *error)
 gboolean
 ves_icall_System_AppDomain_InternalIsFinalizingForUnload (gint32 domain_id, MonoError *error)
 {
-	error_init (error);
 	MonoDomain *domain = mono_domain_get_by_id (domain_id);
 
 	if (!domain)
@@ -2460,7 +2456,6 @@ ves_icall_System_AppDomain_InternalIsFinalizingForUnload (gint32 domain_id, Mono
 void
 ves_icall_System_AppDomain_DoUnhandledException (MonoExceptionHandle exc, MonoError *error)
 {
-	error_init (error);
 	mono_unhandled_exception_checked (MONO_HANDLE_CAST (MonoObject, exc), error);
 	mono_error_assert_ok (error);
 }
@@ -2470,7 +2465,6 @@ ves_icall_System_AppDomain_ExecuteAssembly (MonoAppDomainHandle ad,
 					    MonoReflectionAssemblyHandle refass, MonoArrayHandle args,
 					    MonoError *error)
 {
-	error_init (error);
 	MonoImage *image;
 	MonoMethod *method;
 

--- a/mono/metadata/exception-internals.h
+++ b/mono/metadata/exception-internals.h
@@ -63,9 +63,15 @@ MonoExceptionHandle
 mono_exception_new_thread_interrupted (MonoError *error);
 
 MonoExceptionHandle
-mono_exception_new_thread_interrupted (MonoError *error);
+mono_exception_new_thread_abort (MonoError *error);
 
 MonoExceptionHandle
-mono_exception_new_thread_abort (MonoError *error);
+mono_exception_new_serialization (const char *msg, MonoError *error);
+
+MonoExceptionHandle
+mono_exception_new_invalid_operation (const char *msg, MonoError *error);
+
+MonoExceptionHandle
+mono_error_convert_to_exception_handle (MonoError *error);
 
 #endif

--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -520,6 +520,13 @@ mono_get_exception_invalid_operation (const char *msg)
 					"InvalidOperationException", msg);
 }
 
+MonoExceptionHandle
+mono_exception_new_invalid_operation (const char *msg, MonoError *error)
+{
+	return mono_exception_new_by_name_msg (mono_get_corlib (), "System",
+					"InvalidOperationException", msg, error);
+}
+
 /**
  * mono_get_exception_index_out_of_range:
  * \returns a new instance of the \c System.IndexOutOfRangeException
@@ -692,6 +699,14 @@ mono_exception_new_argument (const char *arg, const char *msg, MonoError *error)
 	}
 
 	return ex;
+}
+
+MonoExceptionHandle
+mono_exception_new_serialization (const char *msg, MonoError *error)
+{
+	return mono_exception_new_by_name_msg (mono_get_corlib (),
+		"System.Runtime.Serialization", "SerializationException",
+		"Could not serialize unhandled exception.", error);
 }
 
 /**
@@ -1437,4 +1452,12 @@ mono_error_set_argument_out_of_range (MonoError *error, const char *name)
 {
 	//FIXMEcoop
 	mono_error_set_exception_instance (error, mono_get_exception_argument_out_of_range (name));
+}
+
+MonoExceptionHandle
+mono_error_convert_to_exception_handle (MonoError *error)
+{
+	//FIXMEcoop mono_error_convert_to_exception is raw pointer
+	HANDLE_FUNCTION_ENTER ();
+	HANDLE_FUNCTION_RETURN_REF (MonoException, mono_error_convert_to_exception (error));
 }

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -966,7 +966,7 @@ HANDLES(ICALL(THREAD_1a, "ByteArrayToCurrentDomain(byte[])", ves_icall_System_Th
 HANDLES(ICALL(THREAD_1b, "ByteArrayToRootDomain(byte[])", ves_icall_System_Threading_Thread_ByteArrayToRootDomain))
 HANDLES(ICALL(THREAD_2, "ClrState(System.Threading.InternalThread,System.Threading.ThreadState)", ves_icall_System_Threading_Thread_ClrState))
 HANDLES(ICALL(THREAD_2a, "ConstructInternalThread", ves_icall_System_Threading_Thread_ConstructInternalThread))
-ICALL(THREAD_55, "GetAbortExceptionState", ves_icall_System_Threading_Thread_GetAbortExceptionState)
+HANDLES(ICALL(THREAD_55, "GetAbortExceptionState", ves_icall_System_Threading_Thread_GetAbortExceptionState))
 HANDLES(ICALL(THREAD_60, "GetCurrentThread", ves_icall_System_Threading_Thread_GetCurrentThread))
 HANDLES(ICALL(THREAD_7, "GetDomainID", ves_icall_System_Threading_Thread_GetDomainID))
 HANDLES(ICALL(THREAD_8, "GetName_internal(System.Threading.InternalThread)", ves_icall_System_Threading_Thread_GetName_internal))

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7605,7 +7605,6 @@ mono_TypedReference_MakeTypedReferenceInternal (MonoObject *target, MonoArray *f
 	MonoType *ftype = NULL;
 	guint8 *p = NULL;
 	int i;
-	ERROR_DECL (error);
 
 	memset (&res, 0, sizeof (res));
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1722,8 +1722,8 @@ mono_method_clear_object (MonoDomain *domain, MonoMethod *method);
 gsize*
 mono_class_compute_bitmap (MonoClass *klass, gsize *bitmap, int size, int offset, int *max_set, gboolean static_fields);
 
-MonoObject*
-mono_object_xdomain_representation (MonoObject *obj, MonoDomain *target_domain, MonoError *error);
+MonoObjectHandle
+mono_object_xdomain_representation (MonoObjectHandle obj, MonoDomain *target_domain, MonoError *error);
 
 gboolean
 mono_class_is_reflection_method_or_constructor (MonoClass *klass);

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -157,7 +157,8 @@ ves_icall_System_Threading_Thread_Abort (MonoInternalThreadHandle thread_handle,
 void
 ves_icall_System_Threading_Thread_ResetAbort (MonoThreadObjectHandle this_obj, MonoError *error);
 
-MonoObject* ves_icall_System_Threading_Thread_GetAbortExceptionState (MonoThread *thread);
+MonoObjectHandle
+ves_icall_System_Threading_Thread_GetAbortExceptionState (MonoThreadObjectHandle thread, MonoError *error);
 
 void
 ves_icall_System_Threading_Thread_Suspend (MonoThreadObjectHandle this_obj, MonoError *error);


### PR DESCRIPTION
Which involves:
	`serialize_object`
	`deserialize_object`
	`mono_object_xdomain_representation`

and then the other users of `mono_object_xdomain_representation`:
	`create_unhandled_exception_eventargs`
	`call_unhandled_exception_delegate`
