### PR TITLE
library.make: track changes in *.sources

### DIFF
--- a/mcs/build/library.make
+++ b/mcs/build/library.make
@@ -295,8 +295,8 @@ endif
 # The library
 
 # If the directory contains the per profile include file, generate list file.
-PROFILE_sources := $(firstword $(if $(PROFILE_PLATFORM),$(wildcard $(PROFILE_PLATFORM)_$(PROFILE)_$(LIBRARY).sources)) $(wildcard $(PROFILE)_$(LIBRARY).sources) $(wildcard $(LIBRARY).sources))
-PROFILE_excludes = $(firstword $(if $(PROFILE_PLATFORM),$(wildcard $(PROFILE_PLATFORM)_$(PROFILE)_$(LIBRARY).exclude.sources)) $(wildcard $(PROFILE)_$(LIBRARY).exclude.sources))
+# TODO: depend on all *.sources for now and figure out how to list only needed files later
+PROFILE_sources = $(shell ls *.sources)
 
 gensources = $(topdir)/build/gensources.exe
 $(gensources): $(topdir)/build/gensources.cs
@@ -309,7 +309,7 @@ GENSOURCES_RUNTIME = MONO_PATH="$(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)$(PLAT
 endif
 
 sourcefile = $(depsdir)/$(PROFILE_PLATFORM)_$(PROFILE)_$(LIBRARY_SUBDIR)_$(LIBRARY).sources
-$(sourcefile): $(PROFILE_sources) $(PROFILE_excludes) $(depsdir)/.stamp $(gensources)
+$(sourcefile): $(PROFILE_sources) $(depsdir)/.stamp $(gensources)
 	$(GENSOURCES_RUNTIME) --debug $(gensources) "$@" "$(LIBRARY)" "$(PROFILE_PLATFORM)" "$(PROFILE)"
 
 library_CLEAN_FILES += $(sourcefile)

--- a/mcs/build/library.make
+++ b/mcs/build/library.make
@@ -296,7 +296,7 @@ endif
 
 # If the directory contains the per profile include file, generate list file.
 # TODO: depend on all *.sources for now and figure out how to list only needed files later
-PROFILE_sources = $(shell ls *.sources)
+PROFILE_sources = $(wildcard *.sources)
 
 gensources = $(topdir)/build/gensources.exe
 $(gensources): $(topdir)/build/gensources.cs


### PR DESCRIPTION
Currently if we change for example `corlib.dll.sources` and then execute `make` - the `make` won't rebuild the lib, because it depends only on `net_4_x_corlib.dll.sources` and doesn't depend on all `#include` inside it.
As a temporarily solution we can depend on all *.sources files in the directory so a change in any of them will trigger rebuild. Unfortunately changes in un-related profiles will also trigger the rebuild but it's better than nothing for now I guess. For better experience we should fetch all #includes recursively for the current profile