### PR TITLE
cleanup: remove redundant condition

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -3990,7 +3990,7 @@ mono_threads_get_thread_dump (MonoArray **out_threads, MonoArray **out_stack_fra
 				if (location) {
 					sf->il_offset = location->il_offset;
 
-					if (location && location->source_file) {
+					if (location->source_file) {
 						MonoString *filename = mono_string_new_checked (domain, location->source_file, error);
 						goto_if_nok (error, leave);
 						MONO_OBJECT_SETREF (sf, filename, filename);


### PR DESCRIPTION
issue detected by cppcheck

[mono/metadata/threads.c:3993] -> [mono/metadata/threads.c:3991]:
(warning) Either the condition 'if(location&&location->source_file)'
is redundant or there is possible null pointer dereference: location.

condition is redundant indeed, it is nested in "if (location) {"



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
