### PR TITLE
Reading of Metadata and pdb blobs via Soft debugger protocol

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/AssemblyMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/AssemblyMirror.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using Mono.Debugger;
 using Mono.Cecil;
 using System.Collections.Generic;
+using System.IO;
 
 namespace Mono.Debugger.Soft
 {
@@ -15,8 +16,13 @@ namespace Mono.Debugger.Soft
 		AssemblyName aname;
 		AssemblyDefinition meta;
 		AppDomainMirror domain;
+		byte[] metadata_blob;
+		bool? isDynamic;
+		byte[] pdb_blob;
 		Dictionary<string, long> typeCacheIgnoreCase = new Dictionary<string, long> (StringComparer.InvariantCultureIgnoreCase);
 		Dictionary<string, long> typeCache = new Dictionary<string, long> ();
+		Dictionary<uint, long> tokenTypeCache = new Dictionary<uint, long> ();
+		Dictionary<uint, long> tokenMethodCache = new Dictionary<uint, long> ();
 
 		internal AssemblyMirror (VirtualMachine vm, long id) : base (vm, id) {
 		}
@@ -118,7 +124,14 @@ namespace Mono.Debugger.Soft
 		 */
 		public AssemblyDefinition Metadata {
 			get {
-				return meta;
+				if (meta != null)
+					return meta;
+
+				if (IsDynamic)
+					throw new NotSupportedException ();
+				
+				using (var ms = new MemoryStream (GetMetadataBlob ()))
+					return meta = AssemblyDefinition.ReadAssembly (ms);
 			}
 			set {
 				if (value.MainModule.Name != ManifestModule.Name)
@@ -127,6 +140,74 @@ namespace Mono.Debugger.Soft
 					throw new ArgumentException ("The supplied assembly's main module has guid '" + value.MainModule.Mvid + ", while the assembly in the debuggee has guid '" + ManifestModule.ModuleVersionId + "'.", "value");
 				meta = value;
 			}
+		}
+		
+		public byte[] GetMetadataBlob () {
+			if (metadata_blob != null)
+				return metadata_blob;
+			
+			vm.CheckProtocolVersion (2, 47);
+
+			return metadata_blob = vm.conn.Assembly_GetMetadataBlob (id);
+		}
+		
+		public bool IsDynamic {
+			get {
+				if (isDynamic.HasValue)
+					return isDynamic.Value;
+				
+				vm.CheckProtocolVersion (2, 47);
+
+				isDynamic = vm.conn.Assembly_IsDynamic (id);
+				return isDynamic.Value;
+			}
+		}	
+		
+		public bool HasPdb {
+			get {
+				return pdb_blob != null;
+			}
+		}
+
+		public bool HasFetchedPdb { get; private set; }
+		
+		public byte[] GetPdbBlob () {
+			if (HasFetchedPdb)
+				return pdb_blob;
+			
+			vm.CheckProtocolVersion (2, 47);
+			var blob = vm.conn.Assembly_GetPdbBlob (id);
+			if (blob != null && blob.Length > 0) {
+				pdb_blob = blob;
+			}
+			HasFetchedPdb = true;
+			return pdb_blob;
+		}
+
+		public TypeMirror GetType (uint token) {
+			vm.CheckProtocolVersion (2, 47);
+			if (IsDynamic)
+				throw new NotSupportedException ();
+			
+			long typeId;
+			if (!tokenTypeCache.TryGetValue (token, out typeId)) {
+				typeId = vm.conn.Assembly_GetType (id, token);
+				tokenTypeCache.Add (token, typeId);
+			}
+			return vm.GetType (typeId);
+		}
+
+		public MethodMirror GetMethod (uint token) {
+			vm.CheckProtocolVersion (2, 47);
+			if (IsDynamic)
+				throw new NotSupportedException ();
+			
+			long methodId;
+			if (!tokenMethodCache.TryGetValue (token, out methodId)) {
+				methodId = vm.conn.Assembly_GetMethod (id, token);
+				tokenMethodCache.Add (token, methodId);
+			}
+			return vm.GetMethod (methodId);
 		}
     }
 }

--- a/mono/metadata/debug-mono-ppdb.c
+++ b/mono/metadata/debug-mono-ppdb.c
@@ -376,6 +376,12 @@ mono_ppdb_lookup_location (MonoDebugMethodInfo *minfo, uint32_t offset)
 	return location;
 }
 
+MonoImage *
+mono_ppdb_get_image (MonoPPDBFile *ppdb)
+{
+    return  ppdb->image;
+}
+
 void
 mono_ppdb_get_seq_points (MonoDebugMethodInfo *minfo, char **source_file, GPtrArray **source_file_list, int **source_files, MonoSymSeqPoint **seq_points, int *n_seq_points)
 {

--- a/mono/metadata/debug-mono-ppdb.h
+++ b/mono/metadata/debug-mono-ppdb.h
@@ -38,4 +38,7 @@ mono_ppdb_lookup_locals (MonoDebugMethodInfo *minfo);
 MonoDebugMethodAsyncInfo*
 mono_ppdb_lookup_method_async_debug_info (MonoDebugMethodInfo *minfo);
 
+MonoImage *
+mono_ppdb_get_image (MonoPPDBFile *ppdb);
+
 #endif

--- a/mono/metadata/mono-debug.c
+++ b/mono/metadata/mono-debug.c
@@ -248,6 +248,12 @@ mono_debug_close_image (MonoImage *image)
 	mono_debugger_unlock ();
 }
 
+MonoDebugHandle *
+mono_debug_get_handle (MonoImage *image)
+{
+    return mono_debug_open_image (image, NULL, 0);
+}
+
 static MonoDebugHandle *
 mono_debug_open_image (MonoImage *image, const guint8 *raw_contents, int size)
 {

--- a/mono/metadata/mono-debug.h
+++ b/mono/metadata/mono-debug.h
@@ -178,6 +178,9 @@ mono_debug_lookup_method_addresses (MonoMethod *method);
 MONO_API MonoDebugMethodJitInfo*
 mono_debug_find_method (MonoMethod *method, MonoDomain *domain);
 
+MONO_API MonoDebugHandle *
+mono_debug_get_handle (MonoImage *image);
+
 MONO_API void
 mono_debug_free_method_jit_info (MonoDebugMethodJitInfo *jit);
 


### PR DESCRIPTION
This PR allows debugger clients to retrieve metadata and pdbs as blobs via soft debugger protocol. Debugger may use own metadata/symbol reader which makes possible to extract more information than *Mirror objects provide.
Added commands to get TypeMirror and MethodMirror from assembly by metadata token