### PR TITLE
Fix up behaviour of verbose method with arguments

### DIFF
--- a/man/mono.1
+++ b/man/mono.1
@@ -1883,7 +1883,7 @@ for example, to see managed frame names on gdb backtraces.
 \fBMONO_VERBOSE_METHOD\fR
 Enables the maximum JIT verbosity for the specified method. This is
 very helpfull to diagnose a miscompilation problems of a specific
-method.   This can be a comma-separated list of method names to
+method.   This can be a semicolon-separated list of method names to
 match.  If the name is simple, this applies to any method with that
 name, otherwise you can use a mono method description (see the section
 METHOD DESCRIPTIONS).

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3361,7 +3361,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 	if (!verbose_method_inited) {
 		char *env = g_getenv ("MONO_VERBOSE_METHOD");
 		if (env != NULL)
-			verbose_method_names = g_strsplit (env, ",", -1);
+			verbose_method_names = g_strsplit (env, ";", -1);
 		
 		verbose_method_inited = TRUE;
 	}

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -2029,12 +2029,12 @@ testbundle: console.exe
 
 test-verbose: verbose.exe
 	@echo "Testing MONO_VERBOSE_METHOD"
-	$(Q) MONO_VERBOSE_METHOD='Method' $(RUNTIME) verbose.exe
-	$(Q) MONO_VERBOSE_METHOD='Method(int)' $(RUNTIME) verbose.exe
-	$(Q) MONO_VERBOSE_METHOD='N1.Test:Method' $(RUNTIME) verbose.exe
-	$(Q) MONO_VERBOSE_METHOD='Test:Method' $(RUNTIME) verbose.exe
-	$(Q) MONO_VERBOSE_METHOD='Method(int,int)' $(RUNTIME) verbose.exe
-	$(Q) MONO_VERBOSE_METHOD='Method(int,string[])' $(RUNTIME) verbose.exe
+	$(Q) MONO_VERBOSE_METHOD='*:Method' $(RUNTIME) --compile-all verbose.exe
+	$(Q) MONO_VERBOSE_METHOD='*:Method(int)' $(RUNTIME) --compile-all verbose.exe
+	$(Q) MONO_VERBOSE_METHOD='N1.Test:Method' $(RUNTIME) --compile-all verbose.exe
+	$(Q) MONO_VERBOSE_METHOD='Test:Method' $(RUNTIME) --compile-all verbose.exe
+	$(Q) MONO_VERBOSE_METHOD='*:Method(int,string[])' $(RUNTIME) --compile-all verbose.exe
+	$(Q) MONO_VERBOSE_METHOD='*:Method(int);N2.*:Method(int,string[])' $(RUNTIME) --compile-all verbose.exe
 
 EXTRA_DIST += load-missing.il t-missing.cs load-exceptions.cs
 

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -21,7 +21,6 @@ check-local:
 	$(MAKE) test-internalsvisibleto || ok=false; \
 	$(MAKE) rm-empty-logs || ok=false; \
 	$(MAKE) runtest-gac-loading || ok=false; \
-	$(MAKE) test-verbose || ok=false; \
 	$$ok
 
 BUILT_SOURCES =
@@ -2026,15 +2025,6 @@ testbundle: console.exe
 	@$(MKBUNDLE) --static console.exe > mkbundle.stdout
 	@$(with_mono_path) MONO_CFG_DIR=$(mono_cfg_dir) ./a.out >> mkbundle.stdout
 	@- rm -rf a.out
-
-test-verbose: verbose.exe
-	@echo "Testing MONO_VERBOSE_METHOD"
-	$(Q) MONO_VERBOSE_METHOD='*:Method' $(RUNTIME) --compile-all verbose.exe
-	$(Q) MONO_VERBOSE_METHOD='*:Method(int)' $(RUNTIME) --compile-all verbose.exe
-	$(Q) MONO_VERBOSE_METHOD='N1.Test:Method' $(RUNTIME) --compile-all verbose.exe
-	$(Q) MONO_VERBOSE_METHOD='Test:Method' $(RUNTIME) --compile-all verbose.exe
-	$(Q) MONO_VERBOSE_METHOD='*:Method(int,string[])' $(RUNTIME) --compile-all verbose.exe
-	$(Q) MONO_VERBOSE_METHOD='*:Method(int);N2.*:Method(int,string[])' $(RUNTIME) --compile-all verbose.exe
 
 EXTRA_DIST += load-missing.il t-missing.cs load-exceptions.cs
 

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -21,6 +21,7 @@ check-local:
 	$(MAKE) test-internalsvisibleto || ok=false; \
 	$(MAKE) rm-empty-logs || ok=false; \
 	$(MAKE) runtest-gac-loading || ok=false; \
+	$(MAKE) test-verbose || ok=false; \
 	$$ok
 
 BUILT_SOURCES =
@@ -687,7 +688,8 @@ TESTS_CS_SRC=		\
 	tailcall-interface.cs \
 	bug-60843.cs	\
 	nested_type_visibility.cs	\
-	dynamic-method-churn.cs
+	dynamic-method-churn.cs	\
+	verbose.cs
 
 # some tests fail to compile on mcs
 if CSC_IS_ROSLYN
@@ -2024,6 +2026,15 @@ testbundle: console.exe
 	@$(MKBUNDLE) --static console.exe > mkbundle.stdout
 	@$(with_mono_path) MONO_CFG_DIR=$(mono_cfg_dir) ./a.out >> mkbundle.stdout
 	@- rm -rf a.out
+
+test-verbose: verbose.exe
+	@echo "Testing MONO_VERBOSE_METHOD"
+	$(Q) MONO_VERBOSE_METHOD='Method' $(RUNTIME) verbose.exe
+	$(Q) MONO_VERBOSE_METHOD='Method(int)' $(RUNTIME) verbose.exe
+	$(Q) MONO_VERBOSE_METHOD='N1.Test:Method' $(RUNTIME) verbose.exe
+	$(Q) MONO_VERBOSE_METHOD='Test:Method' $(RUNTIME) verbose.exe
+	$(Q) MONO_VERBOSE_METHOD='Method(int,int)' $(RUNTIME) verbose.exe
+	$(Q) MONO_VERBOSE_METHOD='Method(int,string[])' $(RUNTIME) verbose.exe
 
 EXTRA_DIST += load-missing.il t-missing.cs load-exceptions.cs
 

--- a/mono/tests/verbose.cs
+++ b/mono/tests/verbose.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace N1
+{
+	public class Test
+	{
+		public static void Method()
+		{
+		}
+
+		public static int Main ()
+		{
+			Method();
+			N2.Test.Method(0);
+			N2.Test.Method();
+			N2.Test.Method(0, new string[0]);
+			return 0;
+		}
+	}
+}
+
+namespace N2
+{
+	public class Test
+	{
+		public static void Method(int n)
+		{
+		}
+
+		public static void Method()
+		{
+		}
+
+		public static void Method(int n, string[] args)
+		{
+		}
+	}
+}
+
+

--- a/mono/tests/verbose.cs
+++ b/mono/tests/verbose.cs
@@ -1,20 +1,137 @@
 using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+public class MainClass
+{
+	class TestCase
+	{
+		public string MethodSpec;
+		public string[] ExpectedMethods;
+	}
+
+	public static int Main (string[] args)
+	{
+		var testCase = new TestCase {
+			MethodSpec = "*:Method",
+			ExpectedMethods = new[] {
+				"N1.Test:Method ()",
+				"N2.Test:Method ()",
+				"N2.Test:Method (int)",
+				"N2.Test:Method (int,string[])",
+			},
+		};
+		if (!RunTest (testCase))
+			return 1;
+
+		testCase = new TestCase {
+			MethodSpec = "*:Method (int)",
+			ExpectedMethods = new[] {
+				"N2.Test:Method (int)",
+			},
+		};
+		if (!RunTest (testCase))
+			return 2;
+
+		testCase = new TestCase
+		{
+			MethodSpec = "N1.Test:Method",
+			ExpectedMethods = new[] {
+				"N1.Test:Method ()",
+			},
+		};
+		if (!RunTest (testCase))
+			return 3;
+
+		testCase = new TestCase {
+			MethodSpec = "Test:Method",
+			ExpectedMethods = new[] {
+				"N1.Test:Method ()",
+				"N2.Test:Method ()",
+				"N2.Test:Method (int)",
+				"N2.Test:Method (int,string[])",
+			},
+		};
+		if (!RunTest (testCase))
+			return 4;
+
+		testCase = new TestCase {
+			MethodSpec = "*:Method(int,string[])",
+			ExpectedMethods = new[] {
+				"N2.Test:Method (int,string[])",
+			},
+		};
+		if (!RunTest (testCase))
+			return 5;
+
+		testCase = new TestCase {
+			MethodSpec = "*:Method();N2.*:Method(int,string[])",
+			ExpectedMethods = new[] {
+				"N1.Test:Method ()",
+				"N2.Test:Method ()",
+				"N2.Test:Method (int,string[])",
+			},
+		};
+		if (!RunTest (testCase))
+			return 6;
+
+		return 0;
+	}
+
+	static bool RunTest (TestCase testCase)
+	{
+		var thisProcess = typeof (MainClass).Assembly.Location;
+
+		var process = StartCompileAssemblyProcess (thisProcess, testCase.MethodSpec);
+		var output = process.StandardOutput.ReadToEnd ();
+		process.WaitForExit ();
+
+		var lines = output.Split (new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+		foreach (var expectedMethod in testCase.ExpectedMethods) {
+			var sortedExpectedMethods = testCase.ExpectedMethods.OrderBy (x => x).ToArray ();
+
+			var regex = new Regex ("converting method void (?<methodName>.*)");
+			var matches = regex.Matches (output);
+			var sortedJittedMethods = matches.Cast<Match> ().Select (x => x.Groups["methodName"])
+			                           .SelectMany (x => x.Captures.Cast<Capture> ())
+			                           .Select (x => x.Value)
+			                           .OrderBy (x => x)
+			                           .ToArray ();
+
+			if (sortedJittedMethods.Length != sortedExpectedMethods.Length)
+				return false;
+
+			for (int i = 0; i < sortedJittedMethods.Length; ++i) {
+				if (sortedJittedMethods[i] != sortedExpectedMethods[i])
+					return false;
+			}
+
+		}
+
+		return true;
+	}
+
+	static Process StartCompileAssemblyProcess (string process, string methodSpec)
+	{
+		var psi = new ProcessStartInfo (process) {
+			UseShellExecute = false,
+			RedirectStandardOutput = true,
+		};
+		psi.EnvironmentVariables.Add ("MONO_ENV_OPTIONS", "--compile-all");
+		psi.EnvironmentVariables.Add ("MONO_VERBOSE_METHOD", methodSpec);
+
+		return Process.Start (psi);
+	}
+}
 
 namespace N1
 {
 	public class Test
 	{
-		public static void Method()
+		public static void Method ()
 		{
-		}
-
-		public static int Main ()
-		{
-			Method();
-			N2.Test.Method(0);
-			N2.Test.Method();
-			N2.Test.Method(0, new string[0]);
-			return 0;
 		}
 	}
 }
@@ -23,15 +140,15 @@ namespace N2
 {
 	public class Test
 	{
-		public static void Method(int n)
+		public static void Method (int n)
 		{
 		}
 
-		public static void Method()
+		public static void Method ()
 		{
 		}
 
-		public static void Method(int n, string[] args)
+		public static void Method (int n, string[] args)
 		{
 		}
 	}

--- a/mono/tests/verbose.cs
+++ b/mono/tests/verbose.cs
@@ -119,10 +119,8 @@ public class MainClass
 			UseShellExecute = false,
 			RedirectStandardOutput = true,
 		};
-		psi.EnvironmentVariables.Add ("MONO_ENV_OPTIONS", "--compile-all");
-
-		var envMethodSpec = string.Format("'{0}'", methodSpec);
-		psi.EnvironmentVariables.Add ("MONO_VERBOSE_METHOD", envMethodSpec);
+		psi.EnvironmentVariables["MONO_ENV_OPTIONS"] = "--compile-all";
+		psi.EnvironmentVariables["MONO_VERBOSE_METHOD"] = methodSpec;
 
 		return Process.Start (psi);
 	}

--- a/mono/tests/verbose.cs
+++ b/mono/tests/verbose.cs
@@ -120,7 +120,9 @@ public class MainClass
 			RedirectStandardOutput = true,
 		};
 		psi.EnvironmentVariables.Add ("MONO_ENV_OPTIONS", "--compile-all");
-		psi.EnvironmentVariables.Add ("MONO_VERBOSE_METHOD", methodSpec);
+
+		var envMethodSpec = string.Format("'{0}'", methodSpec);
+		psi.EnvironmentVariables.Add ("MONO_VERBOSE_METHOD", envMethodSpec);
 
 		return Process.Start (psi);
 	}


### PR DESCRIPTION
Given a method spec which looks like:
`MainClass:Do(int,int,int)`

Via f024e820a025aacc1cf80eb82a8aee4552c3ac11 the code would match 3 methods:
`MainClass:Do(int`, `int`, `int)`, crashing the runtime.

Accept the multiple method matches via `;`, rather than `,`.

Now, the behaviour is changed so:
`MainClass:Do(int,int,int);MainClass:Do(int,int)`

Get parsed as:
`MainClass:Do(int,int,int)`
`MainClass:Do(int,int)`

## Notes:

Fixing the behaviour so it would actually support commas, it would mean not to use g_splitenv, which would complicate the PR.

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
