### PR TITLE
[dist] Ensure gensources.cs is included in tarballs

### DIFF
--- a/mcs/build/Makefile
+++ b/mcs/build/Makefile
@@ -40,7 +40,7 @@ DISTFILES = \
 	corcompare.make			\
 	corcompare-api.xsl		\
 	executable.make			\
-	gensources.sh			\
+	gensources.cs			\
 	library.make			\
 	rules.make			\
 	tests.make			\

--- a/mcs/build/Makefile
+++ b/mcs/build/Makefile
@@ -40,6 +40,7 @@ DISTFILES = \
 	corcompare.make			\
 	corcompare-api.xsl		\
 	executable.make			\
+	gensources.sh			\
 	gensources.cs			\
 	library.make			\
 	rules.make			\


### PR DESCRIPTION
```
06:34:59 DEBUG: make[8]: *** No rule to make target `../../build/gensources.cs', needed by `../../build/gensources.exe'.  Stop.
```