### PR TITLE
Fix canon names not being returned from mono_get_address_info

### DIFF
--- a/mono/utils/networking-posix.c
+++ b/mono/utils/networking-posix.c
@@ -75,7 +75,7 @@ mono_get_address_info (const char *hostname, int port, int flags, MonoAddressInf
 /* Some ancient libc don't define AI_ADDRCONFIG */
 #ifdef AI_ADDRCONFIG
 	if (flags & MONO_HINT_CONFIGURED_ONLY)
-		hints.ai_flags = AI_ADDRCONFIG;
+		hints.ai_flags |= AI_ADDRCONFIG;
 #endif
 	sprintf (service_name, "%d", port);
 


### PR DESCRIPTION
This fixes #8935.

How do we typically write automated tests for this? It relies on a known canon name for a given IP address, which seems like it could produce test flakiness between the need for working DNS and the need for the address<->cname pairing to remain constant.