### PR TITLE
[loader] Refonly load of problematic image is allowed.

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -101,6 +101,7 @@
 #include <mono/metadata/w32error.h>
 #include <mono/utils/w32api.h>
 #include <mono/utils/mono-merp.h>
+#include <mono/utils/mono-logger-internals.h>
 
 #include "decimal-ms.h"
 #include "number-ms.h"
@@ -5447,6 +5448,8 @@ ves_icall_System_Reflection_Assembly_InternalGetAssemblyName (MonoStringHandle f
 	dirname = g_path_get_dirname (filename);
 	replace_shadow_path (mono_domain_get (), dirname, &filename);
 	g_free (dirname);
+
+	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "InternalGetAssemblyName (\"%s\")", filename);
 
 	image = mono_image_open_full (filename, &status, TRUE);
 

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1552,6 +1552,9 @@ register_image (MonoImage *image)
 		g_hash_table_insert (loaded_images_by_name, (char *) image->assembly_name, image);
 	mono_images_unlock ();
 
+	if (mono_is_problematic_image (image)) {
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "Registering %s, problematic image '%s'", image->ref_only ? "REFONLY" : "default", image->name);
+	}
 	return image;
 }
 
@@ -1773,6 +1776,7 @@ mono_image_open_a_lot (const char *fname, MonoImageOpenStatus *status, gboolean 
 			//  to see it again when we go searching for an image
 			//  to load.
 			mono_images_unlock ();
+			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "Not returning problematic image '%s' refcount=%d", image->name, image->ref_count);
 			return NULL;
 		}
 		mono_image_addref (image);

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1763,7 +1763,7 @@ mono_image_open_a_lot (const char *fname, MonoImageOpenStatus *status, gboolean 
 	g_free (absfname);
 
 	if (image) { // Image already loaded
-		if (!load_from_context && mono_is_problematic_image (image)) {
+		if (!refonly && !load_from_context && mono_is_problematic_image (image)) {
 			// If we previously loaded a problematic image, don't
 			// return it if we're not in LoadFrom context.
 			//

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -11486,7 +11486,8 @@ mono_ldptr:
 						}
 					}
 
-					if ((invoke_context_used == 0 || !cfg->gsharedvt) || cfg->llvm_only) {
+					/* FIXME: SGEN support */
+					if (invoke_context_used == 0 || cfg->llvm_only) {
 						if (cfg->verbose_level > 3)
 							g_print ("converting (in B%d: stack: %d) %s", cfg->cbb->block_num, (int)(sp - stack_start), mono_disasm_code_one (NULL, method, ip + 6, NULL));
 						if ((handle_ins = handle_delegate_ctor (cfg, ctor_method->klass, target_ins, cmethod, context_used, FALSE))) {
@@ -11547,7 +11548,8 @@ mono_ldptr:
 					if (mono_security_core_clr_enabled ())
 						ensure_method_is_allowed_to_call_method (cfg, method, ctor_method);
 
-					if ((invoke_context_used == 0 || !cfg->gsharedvt) || cfg->llvm_only) {
+					/* FIXME: SGEN support */
+					if (invoke_context_used == 0 || cfg->llvm_only) {
 						if (cfg->verbose_level > 3)
 							g_print ("converting (in B%d: stack: %d) %s", cfg->cbb->block_num, (int)(sp - stack_start), mono_disasm_code_one (NULL, method, ip + 6, NULL));
 						if ((handle_ins = handle_delegate_ctor (cfg, ctor_method->klass, target_ins, cmethod, context_used, is_virtual))) {

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -2376,7 +2376,9 @@ lookup_start:
 
 	if (!code) {
 		if (mono_class_is_open_constructed_type (m_class_get_byval_arg (method->klass))) {
-			mono_error_set_invalid_operation (error, "Could not execute the method because the containing type is not fully instantiated.");
+			char *full_name = mono_type_get_full_name (method->klass);
+			mono_error_set_invalid_operation (error, "Could not execute the method because the containing type '%s', is not fully instantiated.", full_name);
+			g_free (full_name);
 			return NULL;
 		}
 


### PR DESCRIPTION
Followup for 9ad5255338386a22e7a861e8bcc7c195dc591b99

Note that on win32 we already did the right thing because of nested
conditionals in mono_image_open_a_lot, but on non-win32 we need the extra
check.

Fixes #9044 