### PR TITLE
[interp] check existence of InterpMethod before removing it from interp code hastable

### DIFF
--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -2483,7 +2483,8 @@ mono_jit_free_method (MonoDomain *domain, MonoMethod *method)
 	if (mono_use_interpreter) {
 		mono_domain_jit_code_hash_lock (domain);
 		/* InterpMethod is allocated in the domain mempool */
-		mono_internal_hash_table_remove (&info->interp_code_hash, method);
+		if (mono_internal_hash_table_lookup (&info->interp_code_hash, method))
+			mono_internal_hash_table_remove (&info->interp_code_hash, method);
 		mono_domain_jit_code_hash_unlock (domain);
 	}
 


### PR DESCRIPTION
When creating dynamic methods, we put those in a queue so they can be collected later via `mono_jit_free_method ()`. the interpreter part was assuming, as soon as we allocate a dynamic method, it will be executed eventually and therefore an InterpMethod must exist in `info.interp_code_hash`, but this isn't necessarily the case.

Fixes https://github.com/mono/mono/issues/9109

