### PR TITLE
cleanup: fix string formatting

### DIFF
--- a/mono/mini/helpers.c
+++ b/mono/mini/helpers.c
@@ -192,9 +192,9 @@ mono_disassemble_code (MonoCompile *cfg, guint8 *code, int size, char *id)
 			}
 		}
 		if (cindex == 0) {
-			fprintf (ofd, "\n.byte %d", (unsigned int) code [i]);
+			fprintf (ofd, "\n.byte %u", (unsigned int) code [i]);
 		} else {
-			fprintf (ofd, ",%d", (unsigned int) code [i]);
+			fprintf (ofd, ",%u", (unsigned int) code [i]);
 		}
 		cindex++;
 		if (cindex == 64)


### PR DESCRIPTION
[mono/mini/helpers.c:195]: (warning) %d in format string (no. 1)
requires 'int' but the argument type is 'unsigned int'.

[mono/mini/helpers.c:197]: (warning) %d in format string (no. 1)
requires 'int' but the argument type is 'unsigned int'.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
