### PR TITLE
[SDKS,Android] Install cmake when provisioning Android SDK

### DIFF
--- a/sdks/builds/android.mk
+++ b/sdks/builds/android.mk
@@ -54,12 +54,14 @@ $(eval $(call AndroidSDKProvisioningTemplate,build-tools_r$(ANDROID_BUILD_TOOLS_
 $(eval $(call AndroidSDKProvisioningTemplate,platform-tools_r27.0.1-darwin,platform-tools))
 $(eval $(call AndroidSDKProvisioningTemplate,sdk-tools-darwin-4333796,tools))
 $(eval $(call AndroidSDKProvisioningTemplate,emulator-darwin-4266726,emulator))
+$(eval $(call AndroidSDKProvisioningTemplate,cmake-3.6.4111459-darwin-x86_64,cmake/3.6.4111459))
 else
 ifeq ($(UNAME),Linux)
 $(eval $(call AndroidSDKProvisioningTemplate,build-tools_r$(ANDROID_BUILD_TOOLS_VERSION)-linux,build-tools/$(or $(ANDROID_BUILD_TOOLS_DIR),$(ANDROID_BUILD_TOOLS_VERSION))))
 $(eval $(call AndroidSDKProvisioningTemplate,platform-tools_r27.0.1-linux,platform-tools))
 $(eval $(call AndroidSDKProvisioningTemplate,sdk-tools-linux-4333796,tools))
 $(eval $(call AndroidSDKProvisioningTemplate,emulator-linux-4266726,emulator))
+$(eval $(call AndroidSDKProvisioningTemplate,cmake-3.6.4111459-linux-x86_64,cmake/3.6.4111459))
 else
 $(error "Unknown UNAME=$(UNAME)")
 endif

--- a/sdks/builds/unzip-android-archive.sh
+++ b/sdks/builds/unzip-android-archive.sh
@@ -15,14 +15,33 @@ trap cleanup 0
 #    $1: path to source archive
 #    $2: destination directory
 
-# This weird syntax is necessary because some zip archives do not contain a separate
-# entry for the root directory but merely a collection of its subdirectories (for instance
-# platform-tools). The very first entry in the archive is retrieved, then its path is read and
-# finally the part up to the first '/' of the path is retrieved as the root directory of
-# the archive. With platform-tools the last part is necessary because otherwise the root directory
-# would end up being reported as `platform-tools/adb` as this is the first entry in the archive and
-# there's no `platform-tools/` entry
-ZIP_ROOT_DIR=$(unzip -qql "$1" | head -n1 | tr -s ' ' | cut -d' ' -f5- | tr '/' ' ' | cut -d' ' -f1)
+#
+# Special case archives - archives which have no single root directory when unpacked and thus
+#                         the workaround below doesn't work for them.
+# Entry format: grep regex matching the END of path in $1 (no trailing $ necessary)
+#
+SPECIAL_CASE_ARCHIVES="
+    cmake-.*\.zip
+"
+
+HAVE_SPECIAL_CASE=no
+for sac in $SPECIAL_CASE_ARCHIVES; do
+	if echo $1 | grep "${sac}$" > /dev/null 2>&1; then
+		HAVE_SPECIAL_CASE=yes
+		break
+	fi
+done
+
+if [ "$HAVE_SPECIAL_CASE" == "no" ]; then
+	# This weird syntax is necessary because some zip archives do not contain a separate
+	# entry for the root directory but merely a collection of its subdirectories (for instance
+	# platform-tools). The very first entry in the archive is retrieved, then its path is read and
+	# finally the part up to the first '/' of the path is retrieved as the root directory of
+	# the archive. With platform-tools the last part is necessary because otherwise the root directory
+	# would end up being reported as `platform-tools/adb` as this is the first entry in the archive and
+	# there's no `platform-tools/` entry
+	ZIP_ROOT_DIR=$(unzip -qql "$1" | head -n1 | tr -s ' ' | cut -d' ' -f5- | tr '/' ' ' | cut -d' ' -f1)
+fi
 
 # We need a temporary directory because some archives (emulator) have their root directory named the
 # same as a file/directory inside it (emulator has emulator/emulator executable for instance) and
@@ -31,4 +50,9 @@ ARCHIVE_TEMP_DIR=$(mktemp -d -t unzip_android_archive_XXXXXXXX)
 
 unzip "$1" -d "$ARCHIVE_TEMP_DIR"
 mkdir -p "$2"
-find "$ARCHIVE_TEMP_DIR/$ZIP_ROOT_DIR/" -maxdepth 1 -not \( -name "$ZIP_ROOT_DIR" -and -type d \) -and -not -name . -and -not -name .. -exec mv -f '{}' "$2" ';'
+
+if [ -z "$ZIP_ROOT_DIR" ]; then
+	mv -f "$ARCHIVE_TEMP_DIR"/* "$2"
+else
+	find "$ARCHIVE_TEMP_DIR/$ZIP_ROOT_DIR/" -maxdepth 1 -not \( -name "$ZIP_ROOT_DIR" -and -type d \) -and -not -name . -and -not -name .. -exec mv -f '{}' "$2" ';'
+fi


### PR DESCRIPTION
Android NDK supports cmake in addition to the older make-based ndk-build as the
build system and Xamarin.Android is in the process of switching the build of its
native bits to cmake. The reason for this switch is that certain parts of
Xamarin.Android (libmonodroid) are built for both the host system and
the Android target. The host system build currently uses hand-crafted code
directly in .csproj to build the native bits while the Android build uses
ndk-build. This results in duplication of code, compiler parameters are
specified in two locations - it is easy to introduce incompatibilities, bug
fixes may be applied only in one scenario etc.

Using cmake allows us to use a single build "script" for all the targets, thus
making the build more reliable. Android SDK has a cmake package which contains
full support for NDK builds and allows us to easily use cmake across all the
supported platforms without having to install cmake on the host system.

This commit adds the cmake package to the Android SDK provisiong process and,
alas, at the same time adds a workaround to properly unpack the package. Unlike
other Android SDK packages, cmake doesn't unpack to a single subdirectory of the
zip root, instead all its files and directories are placed directly in the zip
root. This requires yet another workaround to install the package properly.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
