### PR TITLE
Fix issue #9031

### DIFF
--- a/mcs/class/System/System.Net/HttpWebRequest.cs
+++ b/mcs/class/System/System.Net/HttpWebRequest.cs
@@ -899,6 +899,11 @@ namespace System.Net
 
 			try {
 				return TaskToApm.End<Stream> (asyncResult);
+			} catch (System.Threading.Tasks.TaskCanceledException tce) {
+				if (Aborted)
+					throw CreateRequestAbortedException ();
+				else
+					throw FlattenException (tce);
 			} catch (Exception e) {
 				throw FlattenException (e);
 			}
@@ -1194,6 +1199,11 @@ namespace System.Net
 
 			try {
 				return TaskToApm.End<HttpWebResponse> (asyncResult);
+			} catch (System.Threading.Tasks.TaskCanceledException tce) {
+				if (Aborted)
+					throw CreateRequestAbortedException ();
+				else
+					throw FlattenException (tce);
 			} catch (Exception e) {
 				throw FlattenException (e);
 			}

--- a/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
@@ -567,7 +567,7 @@ namespace MonoTests.System.Net
 		}
 
 		[Test]
-		[Category ("NotWorking")] // do not get consistent result on MS
+		// [Category ("NotWorking")] // do not get consistent result on MS
 		public void EndGetRequestStream_Request_Aborted ()
 		{
 			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();


### PR DESCRIPTION
Fixes issue #9031 by converting task cancellation into a request aborted exception if the Aborted flag is set when we see a cancellation. Also re-enabled the relevant test mentioned by the issue (it seems to pass now with this fix)