### PR TITLE
Fix IndexOutOfRangeException: No adapter found for index when getting network information

### DIFF
--- a/mcs/class/System/System.Net.NetworkInformation/Win32IPAddressCollection.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/Win32IPAddressCollection.cs
@@ -79,6 +79,25 @@ namespace System.Net.NetworkInformation {
 			return c;
 		}
 
+		public static Win32IPAddressCollection FromSocketAddress (Win32_SOCKET_ADDRESS addr)
+		{
+			Win32IPAddressCollection c = new Win32IPAddressCollection ();
+			if (addr.Sockaddr != IntPtr.Zero)
+				c.InternalAdd (addr.GetIPAddress ());
+			return c;
+		}
+
+		public static Win32IPAddressCollection FromWinsServer (IntPtr ptr)
+		{
+			Win32IPAddressCollection c = new Win32IPAddressCollection ();
+			Win32_IP_ADAPTER_WINS_SERVER_ADDRESS a;
+			for (IntPtr p = ptr; p != IntPtr.Zero; p = a.Next) {
+				a = (Win32_IP_ADAPTER_WINS_SERVER_ADDRESS) Marshal.PtrToStructure (p, typeof (Win32_IP_ADAPTER_WINS_SERVER_ADDRESS));
+				c.InternalAdd (a.Address.GetIPAddress ());
+			}
+			return c;
+		}
+
 		void AddSubsequentlyString (IntPtr head)
 		{
 			Win32_IP_ADDR_STRING a;

--- a/mcs/class/System/System.Net.NetworkInformation/Win32IPv4InterfaceProperties.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/Win32IPv4InterfaceProperties.cs
@@ -36,13 +36,13 @@ namespace System.Net.NetworkInformation {
 		[DllImport ("iphlpapi.dll")]
 		static extern int GetPerAdapterInfo (int IfIndex, Win32_IP_PER_ADAPTER_INFO pPerAdapterInfo, ref int pOutBufLen);
 
-		Win32_IP_ADAPTER_INFO ainfo;
+		Win32_IP_ADAPTER_ADDRESSES addr;
 		Win32_IP_PER_ADAPTER_INFO painfo;
 		Win32_MIB_IFROW mib;
 
-		public Win32IPv4InterfaceProperties (Win32_IP_ADAPTER_INFO ainfo, Win32_MIB_IFROW mib)
+		public Win32IPv4InterfaceProperties (Win32_IP_ADAPTER_ADDRESSES addr, Win32_MIB_IFROW mib)
 		{
-			this.ainfo = ainfo;
+			this.addr = addr;
 			this.mib = mib;
 
 			// get per-adapter info.
@@ -67,7 +67,7 @@ namespace System.Net.NetworkInformation {
 		}
 
 		public override bool IsDhcpEnabled {
-			get { return ainfo.DhcpEnabled != 0; }
+			get { return addr.DhcpEnabled; }
 		}
 
 		public override bool IsForwardingEnabled {
@@ -80,7 +80,7 @@ namespace System.Net.NetworkInformation {
 		}
 
 		public override bool UsesWins {
-			get { return ainfo.HaveWins; }
+			get { return addr.FirstWinsServerAddress != IntPtr.Zero; }
 		}
 	}
 

--- a/mcs/class/System/System.Net.NetworkInformation/Win32NetworkInterface.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/Win32NetworkInterface.cs
@@ -49,9 +49,12 @@ namespace System.Net.NetworkInformation {
 		{
 			IntPtr ptr = IntPtr.Zero;
 			int len = 0;
-			GetAdaptersAddresses (0, 0, IntPtr.Zero, ptr, ref len);
+			uint flags = Win32_IP_ADAPTER_ADDRESSES.GAA_FLAG_INCLUDE_WINS_INFO | Win32_IP_ADAPTER_ADDRESSES.GAA_FLAG_INCLUDE_GATEWAYS;
+			GetAdaptersAddresses (0, flags, IntPtr.Zero, ptr, ref len);
+			if (Marshal.SizeOf (typeof (Win32_IP_ADAPTER_ADDRESSES)) > len)
+				throw new NetworkInformationException ();
 			ptr = Marshal.AllocHGlobal(len);
-			int ret = GetAdaptersAddresses (0, 0, IntPtr.Zero, ptr, ref len);
+			int ret = GetAdaptersAddresses (0, flags, IntPtr.Zero, ptr, ref len);
 			if (ret != 0)
 				throw new NetworkInformationException (ret);
 
@@ -104,14 +107,6 @@ namespace System.Net.NetworkInformation {
 
 		[DllImport ("iphlpapi.dll", SetLastError = true)]
 		static extern int GetIfEntry (ref Win32_MIB_IFROW row);
-
-		public static Win32_IP_ADAPTER_INFO GetAdapterInfoByIndex (int index)
-		{
-			foreach (Win32_IP_ADAPTER_INFO info in GetAdaptersInfo ())
-				if (info.Index == index)
-					return info;
-			throw new IndexOutOfRangeException ("No adapter found for index " + index);
-		}
 
 		static Win32_IP_ADAPTER_INFO [] GetAdaptersInfo ()
 		{

--- a/mcs/class/System/System.Net.NetworkInformation/Win32NetworkInterfaceMarshal.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/Win32NetworkInterfaceMarshal.cs
@@ -109,20 +109,46 @@ namespace System.Net.NetworkInformation
 		public NetworkInterfaceType IfType;
 		public OperationalStatus OperStatus;
 		public int Ipv6IfIndex;
-		[MarshalAs (UnmanagedType.ByValArray, SizeConst = 16 * 4)]
+		[MarshalAs (UnmanagedType.ByValArray, SizeConst = 16)]
 		public uint [] ZoneIndices;
+		public IntPtr FirstPrefix; // to PIP_ADAPTER_PREFIX
+		public UInt64 TransmitLinkSpeed;
+		public UInt64 ReceiveLinkSpeed;
+		public IntPtr FirstWinsServerAddress; // to PIP_ADAPTER_WINS_SERVER_ADDRESS_LH
+		public IntPtr FirstGatewayAddress; // to PIP_ADAPTER_GATEWAY_ADDRESS_LH
+		public uint Ipv4Metric;
+		public uint Ipv6Metric;
+		public UInt64 Luid;
+		public Win32_SOCKET_ADDRESS Dhcpv4Server;
+		public uint CompartmentId;
+		public UInt64 NetworkGuid;
+		public int ConnectionType;
+		public int TunnelType;
+		public Win32_SOCKET_ADDRESS Dhcpv6Server;
+		[MarshalAs (UnmanagedType.ByValArray, SizeConst = MAX_DHCPV6_DUID_LENGTH)]
+		public byte [] Dhcpv6ClientDuid;
+		public ulong Dhcpv6ClientDuidLength;
+		public ulong Dhcpv6Iaid;
+		public IntPtr FirstDnsSuffix; // to PIP_ADAPTER_DNS_SUFFIX
 
-		// Note that Vista-only members and XP-SP1-only member are
-		// omitted.
+		//Flags For GetAdapterAddresses
+		public const int GAA_FLAG_INCLUDE_WINS_INFO = 0x0040;
+		public const int GAA_FLAG_INCLUDE_GATEWAYS = 0x0080;
 
 		const int MAX_ADAPTER_ADDRESS_LENGTH = 8;
+		const int MAX_DHCPV6_DUID_LENGTH = 130;
 
 		const int IP_ADAPTER_DDNS_ENABLED = 1;
+		const int IP_ADAPTER_DHCP_ENABLED = 4;
 		const int IP_ADAPTER_RECEIVE_ONLY = 8;
 		const int IP_ADAPTER_NO_MULTICAST = 0x10;
 
 		public bool DdnsEnabled {
 			get { return (Flags & IP_ADAPTER_DDNS_ENABLED) != 0; }
+		}
+
+		public bool DhcpEnabled {
+			get { return (Flags & IP_ADAPTER_DHCP_ENABLED) != 0; }
 		}
 
 		public bool IsReceiveOnly {
@@ -252,6 +278,22 @@ namespace System.Net.NetworkInformation
 	{
 		public Win32LengthFlagsUnion LengthFlags;
 		public IntPtr Next; // to Win32_IP_ADAPTER_MULTICAST_ADDRESS
+		public Win32_SOCKET_ADDRESS Address;
+	}
+
+	[StructLayout (LayoutKind.Sequential)]
+	struct Win32_IP_ADAPTER_GATEWAY_ADDRESS
+	{
+		public Win32LengthFlagsUnion LengthFlags;
+		public IntPtr Next; // to Win32_IP_ADAPTER_GATEWAY_ADDRESS
+		public Win32_SOCKET_ADDRESS Address;
+	}
+
+	[StructLayout (LayoutKind.Sequential)]
+	struct Win32_IP_ADAPTER_WINS_SERVER_ADDRESS
+	{
+		public Win32LengthFlagsUnion LengthFlags;
+		public IntPtr Next; // to Win32_IP_ADAPTER_WINS_SERVER_ADDRESS
 		public Win32_SOCKET_ADDRESS Address;
 	}
 


### PR DESCRIPTION
GetAllNetworkInterfaces (correctly) returns the loopback, however GetAdaptersInfo does not return information about the loopback 
msdn https://msdn.microsoft.com/en-us/library/windows/desktop/aa365917(v=vs.85).aspx 

The GetAdaptersInfo and GetInterfaceInfo functions do not return information about the IPv4 loopback interface. Information on the loopback interface is returned by the GetIpAddrTable function)

Instead of querying data from GetAdaptersInfo, instead use data from Win32_IP_ADAPTER_ADDRESSES

I've manually tested the output of the script below against .NetFW; If theres a better way to test networking changes to windows please tell me.


```
public void Test()
{
	var interfaces = NetworkInterface.GetAllNetworkInterfaces();
	foreach (NetworkInterface ni in interfaces)
	{
		var ipv4Properties = ni.GetIPProperties().GetIPv4Properties();
		UnityEngine.Debug.Log(ni.Name + " " + ipv4Properties.Index);
		var isDHCP = ipv4Properties.IsDhcpEnabled;
		UnityEngine.Debug.Log("isDHCP " + isDHCP);
		var iswins = ipv4Properties.UsesWins;
		UnityEngine.Debug.Log("UsesWins " + iswins);
		var dhcpserveraddrcol = ni.GetIPProperties().DhcpServerAddresses;
		foreach (var dhcp in dhcpserveraddrcol)
			UnityEngine.Debug.Log("dhcpserver " + dhcp.Address);
		var gatewayipaddressinformationcol = ni.GetIPProperties().GatewayAddresses;
		foreach (var gateway in gatewayipaddressinformationcol)
			UnityEngine.Debug.Log("gatewayserver " + gateway.Address);
		var unicastipaddresinformationcol = ni.GetIPProperties().UnicastAddresses;
		foreach (var unicast in unicastipaddresinformationcol)
			UnityEngine.Debug.Log("unicastserver " + unicast.Address);
		var winsipaddresscol = ni.GetIPProperties().WinsServersAddresses;
		foreach (var ftw in winsipaddresscol)
			UnityEngine.Debug.Log("winsserver " + ftw.Address);
	}
}