### PR TITLE
[Linux,XA build] Fix building of Windows cross-compilers on Ubuntu Linux

### DIFF
--- a/sdks/builds/determine-linux-flavor.sh
+++ b/sdks/builds/determine-linux-flavor.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    FLAVOR=$NAME
+elif [ -n "$(which lsb_release)" ]; then
+    FLAVOR=$(lsb_release -si)
+elif [ -f /etc/lsb-release ]; then
+    . /etc/lsb-release
+    FLAVOR=$DISTRIB_ID
+elif [ -f /etc/debian_version ]; then
+    FLAVOR=Debian
+else
+    FLAVOR=$(uname -s)
+fi
+
+echo $FLAVOR

--- a/sdks/builds/mxe.mk
+++ b/sdks/builds/mxe.mk
@@ -1,4 +1,15 @@
+.PHONY: provision-mxe
 
+ifeq ($(UNAME),Linux)
+LINUX_FLAVOR=$(shell ./determine-linux-flavor.sh)
+endif
+
+ifeq ($(LINUX_FLAVOR),Ubuntu)
+MXE_PREFIX=/usr
+
+provision-mxe:
+	@echo $(LINUX_FLAVOR) Linux does not require mxe provisioning. mingw from packages is used instead
+else
 MXE_SRC?=$(TOP)/sdks/builds/toolchains/mxe
 MXE_PREFIX_DIR?=$(TOP)/sdks/out
 
@@ -15,5 +26,5 @@ $(MXE_PREFIX)/.stamp: $(MXE_SRC)/Makefile
 			OS_SHORT_NAME="disable-native-plugins" PATH="$$PATH:$(MXE_PREFIX)/bin:$(dir $(shell brew list gettext | grep bin/autopoint$))"
 	touch $@
 
-.PHONY: provision-mxe
 provision-mxe: $(MXE_PREFIX)/.stamp
+endif


### PR DESCRIPTION
Ubuntu Linux (possibly others too, but only Ubuntu is tested thus the
limitation) don't need to build or use `mxe`, they instead use mingw packaged
for the distribution, thus making the build faster.

This commit detects the Linux flavor in use and, if it's Ubuntu, configures the
build so that system mingw is used instead of mxe.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
