### PR TITLE
[tests] reduce IO load in process-stress-3

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1208,8 +1208,7 @@ CI_DISABLED_TESTS = \
 # failing tests which we temporarily disable for PRs
 # so they don't interfere with other people's work
 CI_PR_DISABLED_TESTS = \
-	appdomain-threadpool-unload.exe \
-	process-stress-3.exe
+	appdomain-threadpool-unload.exe
 
 # appdomain-threadpool-unload.exe creates 100 appdomains, takes too long with llvm
 LLVM_DISABLED_TESTS = \

--- a/mono/tests/process-stress-3.cs
+++ b/mono/tests/process-stress-3.cs
@@ -16,7 +16,7 @@ class Driver
 
 		ProcessStartInfo psi = new ProcessStartInfo () {
 			FileName = "find",
-			Arguments = "../.. -maxdepth 3", // this test should be run from mono/tests, so that will list all files in the repo
+			Arguments = ". -maxdepth 3", // this test should be run from mono/tests, so that will list all test files
 			UseShellExecute = false,
 			RedirectStandardOutput = true,
 			RedirectStandardError = true,


### PR DESCRIPTION
The spawned process by the test iterates through the whole mono repo,
including submodules. On a loaded machine with a already slow I/O
device, 10 seconds could be a tight time budget. Instead of increasing
the timeout, let's try to reduce the generated output.

Fixes https://github.com/mono/mono/issues/6947 hopefully.
