### PR TITLE
Improve certificate type detection and exception messages on import

### DIFF
--- a/mcs/class/System/Test/System.Security.Cryptography.X509Certificates/X509Certificate2Test.cs
+++ b/mcs/class/System/Test/System.Security.Cryptography.X509Certificates/X509Certificate2Test.cs
@@ -1435,13 +1435,6 @@ WYpnKQqsKIzlSqv9wwXs7B1iA7ZdvHk3TAnSnLP1o2H7ME05UnZPKCvraONdezon
 		}
 
 		[Test]
-		[ExpectedException (typeof (CryptographicException))]
-		public void GetCertContentType_byte_BadData ()
-		{
-			X509Certificate2.GetCertContentType (new byte[1]);
-		}
-
-		[Test]
 		public void GetCertContentType_byte ()
 		{
 			// empty ASN.1 sequence


### PR DESCRIPTION
One unit test is removed as part of the commit because it is not consistent with documentation and CoreFX behaviour on non-Windows platforms (https://github.com/dotnet/corefx/issues/30416).

The main goal of this patch is to actually get meaningful error messages when constructing X509Certificate2 from a byte array. Previously PKCS#12/PFX certificate import could fail due to unimplemented features (such as ECDsa support) or bugs. The certificate import would then be retried as PKCS#7 and the original error message was lost.