### PR TITLE
Fix non-interpreter 5-60 second hang at shutdown of thread6 (and thread7).

### DIFF
--- a/mono/metadata/threadpool-worker-default.c
+++ b/mono/metadata/threadpool-worker-default.c
@@ -487,9 +487,7 @@ worker_thread (gpointer unused)
 			mono_thread_internal_reset_abort (thread);
 
 		if (!work_item_try_pop ()) {
-			gboolean timeout;
-
-			timeout = worker_park ();
+			gboolean const timeout = worker_park ();
 			if (timeout)
 				break;
 
@@ -660,9 +658,7 @@ monitor_sufficient_delay_since_last_dequeue (void)
 	if (worker.cpu_usage < CPU_USAGE_LOW) {
 		threshold = MONITOR_INTERVAL;
 	} else {
-		ThreadPoolWorkerCounter counter;
-		counter = COUNTER_READ ();
-		threshold = counter._.max_working * MONITOR_INTERVAL * 2;
+		threshold = COUNTER_READ ()._.max_working * MONITOR_INTERVAL * 2;
 	}
 
 	return mono_msec_ticks () >= worker.heuristic_last_dequeue + threshold;
@@ -1074,8 +1070,7 @@ static gboolean
 heuristic_should_adjust (void)
 {
 	if (worker.heuristic_last_dequeue > worker.heuristic_last_adjustment + worker.heuristic_adjustment_interval) {
-		ThreadPoolWorkerCounter counter;
-		counter = COUNTER_READ ();
+		ThreadPoolWorkerCounter const counter = COUNTER_READ ();
 		if (counter._.working <= counter._.max_working)
 			return TRUE;
 	}
@@ -1092,11 +1087,9 @@ heuristic_adjust (void)
 		gint64 sample_duration = sample_end - worker.heuristic_sample_start;
 
 		if (sample_duration >= worker.heuristic_adjustment_interval / 2) {
-			ThreadPoolWorkerCounter counter;
-			gint16 new_thread_count;
 
-			counter = COUNTER_READ ();
-			new_thread_count = hill_climbing_update (counter._.max_working, sample_duration, completions, &worker.heuristic_adjustment_interval);
+			ThreadPoolWorkerCounter counter = COUNTER_READ ();
+			gint16 const new_thread_count = hill_climbing_update (counter._.max_working, sample_duration, completions, &worker.heuristic_adjustment_interval);
 
 			COUNTER_ATOMIC (counter, {
 				counter._.max_working = new_thread_count;
@@ -1126,11 +1119,9 @@ heuristic_notify_work_completed (void)
 gboolean
 mono_threadpool_worker_notify_completed (void)
 {
-	ThreadPoolWorkerCounter counter;
-
 	heuristic_notify_work_completed ();
 
-	counter = COUNTER_READ ();
+	ThreadPoolWorkerCounter const counter = COUNTER_READ ();
 	return counter._.working <= counter._.max_working;
 }
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -3523,7 +3523,7 @@ mono_thread_manage (void)
 		MONO_EXIT_GC_SAFE;
 		wait->num=0;
 		/* We must zero all InternalThread pointers to avoid making the GC unhappy. */
-		memset (wait->threads, 0, MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS * SIZEOF_VOID_P);
+		memset (wait->threads, 0, sizeof (wait->threads));
 		mono_g_hash_table_foreach (threads, build_wait_tids, wait);
 		mono_threads_unlock ();
 		if (wait->num > 0)
@@ -3548,7 +3548,7 @@ mono_thread_manage (void)
 
 		wait->num = 0;
 		/*We must zero all InternalThread pointers to avoid making the GC unhappy.*/
-		memset (wait->threads, 0, MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS * SIZEOF_VOID_P);
+		memset (wait->threads, 0, sizeof (wait->threads));
 		mono_g_hash_table_foreach (threads, abort_threads, wait);
 
 		mono_threads_unlock ();
@@ -3633,7 +3633,7 @@ void mono_thread_suspend_all_other_threads (void)
 		 */
 		wait->num = 0;
 		/*We must zero all InternalThread pointers to avoid making the GC unhappy.*/
-		memset (wait->threads, 0, MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS * SIZEOF_VOID_P);
+		memset (wait->threads, 0, sizeof (wait->threads));
 		mono_threads_lock ();
 		mono_g_hash_table_foreach (threads, collect_threads_for_suspend, wait);
 		mono_threads_unlock ();

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -646,6 +646,7 @@ TESTS_CS_SRC=		\
 	generic-unloading.2.cs	\
 	namedmutex-destroy-race.cs	\
 	thread6.cs	\
+	thread7.cs	\
 	appdomain-threadpool-unload.cs	\
 	process-unref-race.cs	\
 	bug-46661.cs	\

--- a/mono/tests/thread7.cs
+++ b/mono/tests/thread7.cs
@@ -1,0 +1,57 @@
+//
+// Subset of thread6.cs, just to watch for the hang at end.
+// Note this test does not indicate success or failure well,
+// it just runs quickly or slowly.
+//
+using System;
+using System.Threading;
+
+public class Tests {
+
+	public static int Main() {
+		return test_0_regress_4413();
+	}
+
+	public static int test_0_regress_4413 () {
+		// Check that thread abort exceptions originating in another thread are not automatically rethrown
+		object o = new object ();
+		Thread t = null;
+		bool waiting = false;
+		Action a = delegate () {
+			t = Thread.CurrentThread;
+			while (true) {
+				lock (o) {
+					if (waiting) {
+						Monitor.Pulse (o);
+						break;
+					}
+				}
+
+				Thread.Sleep (10);
+			}
+			while (true) {
+				Thread.Sleep (1000);
+			}
+		};
+		var ar = a.BeginInvoke (null, null);
+		lock (o) {
+			waiting = true;
+			Monitor.Wait (o);
+		}
+
+		t.Abort ();
+
+		try {
+			try {
+				a.EndInvoke (ar);
+			} catch (ThreadAbortException) {
+			}
+		} catch (ThreadAbortException) {
+			// This will fail
+			Thread.ResetAbort ();
+			return 1;
+		}
+
+		return 0;
+	}
+}

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -1708,7 +1708,7 @@ mono_thread_info_self_interrupt (void)
 /* Clear the interrupted flag of the current thread, set with
  * mono_thread_info_self_interrupt, so it can wait again */
 void
-mono_thread_info_clear_self_interrupt ()
+mono_thread_info_clear_self_interrupt (void)
 {
 	MonoThreadInfo *info;
 	MonoThreadInfoInterruptToken *previous_token;


### PR DESCRIPTION
(replacement for https://github.com/mono/mono/pull/9042 if it goes well)
regressed back in December with commit 5f5c5e97a08f7086d7c18af37352c4a03dc4c0d1

Because if there is an uncleared AbortRequest, suspend will be skipped, but the interrupt callback will still be called.

The skip is here:
```
request_thread_abort:
	if (thread->state & (ThreadState_AbortRequested | ThreadState_Stopped))
		return FALSE;
```

The interrupt callback anyway is, well, I debugged it a few days ago and don't see it now, would have to step through it again.

This is also the change that slowed down Alpine/muslc to be unusable. This change should be tested there too to see if it fixes it. The correlation between test/thread6 and anything else is unclear -- i.e. is thread abort so common, in the build?