### PR TITLE
[System] align Nullable.Equals behaviour with .NET core

### DIFF
--- a/mcs/class/corlib/System/Nullable.cs
+++ b/mcs/class/corlib/System/Nullable.cs
@@ -110,23 +110,11 @@ namespace System
 
 		public override bool Equals (object other)
 		{
+			if (!has_value)
+				return other == null;
 			if (other == null)
-				return has_value == false;
-			if (!(other is Nullable<T>))
 				return false;
-
-			return Equals ((Nullable <T>) other);
-		}
-
-		bool Equals (Nullable<T> other)
-		{
-			if (other.has_value != has_value)
-				return false;
-
-			if (has_value == false)
-				return true;
-
-			return other.value.Equals (value);
+			return value.Equals (other);
 		}
 
 		public override int GetHashCode ()

--- a/mcs/class/corlib/Test/System/NullableTest.cs
+++ b/mcs/class/corlib/Test/System/NullableTest.cs
@@ -40,5 +40,19 @@ namespace MonoTests.System
 			Assert.AreSame (typeof (int), Nullable.GetUnderlyingType (typeof (Nullable<int>)), "#1");
 			Assert.IsNull (Nullable.GetUnderlyingType (typeof (Nullable<>)), "#2");
 		}
+
+		private struct MutatingStruct
+		{
+			public int Value;
+			public override bool Equals(object obj) => Value++.Equals(null);
+		}
+
+		[Test]
+		public void EqualsImpl ()
+		{
+			MutatingStruct? ms = new MutatingStruct () { Value = 1 };
+			ms.Equals (new object ());
+			Assert.AreEqual (ms.Value.Value, 2, "#1");
+		}
 	}
 }


### PR DESCRIPTION
Our `Nullable` implementation is slightly different regarding `Equals ()`.

mono:
https://github.com/mono/mono/blob/028ff0d34c8e8cbe1e819e49962775841972fc62/mcs/class/corlib/System/Nullable.cs#L111-L130

corefx:
https://github.com/mono/corefx/blob/ab816c3efdb1aedb4baa1b8d2fec8ee2f8e15683/src/Common/src/CoreLib/System/Nullable.cs#L62-L67

Fixes https://github.com/mono/mono/issues/9088