### PR TITLE
[profiler] account for nullbyte in allocated buffer

### DIFF
--- a/mono/profiler/aot.c
+++ b/mono/profiler/aot.c
@@ -109,7 +109,7 @@ parse_args (const char *desc)
 	const char *p;
 	gboolean in_quotes = FALSE;
 	char quote_char = '\0';
-	char *buffer = malloc (strlen (desc));
+	char *buffer = g_malloc (strlen (desc) + 1);
 	int buffer_pos = 0;
 
 	for (p = desc; *p; p++){


### PR DESCRIPTION
probably fixes https://github.com/mono/mono/issues/9106