### PR TITLE
[System] Use the legacy TLS provider on Lion and earlier macOSes. Fixes #9164.

### DIFF
--- a/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.cs
+++ b/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.cs
@@ -327,7 +327,7 @@ namespace Mono.Net.Security
 			case "default":
 #if MONO_FEATURE_APPLETLS
 				if (Platform.IsMacOS) {
-					if (Environment.OSVersion.Major <= 11) {
+					if (Environment.OSVersion.Version.Major <= 11) {
 						// The apple provider requires Apple API that was introduced in macOS 10.8 (Mountain Lion),
 						// so default to the legacy provider for earlier versions.
 						goto case "legacy";

--- a/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.cs
+++ b/mcs/class/System/Mono.Net.Security/MonoTlsProviderFactory.cs
@@ -326,8 +326,14 @@ namespace Mono.Net.Security
 			switch (type) {
 			case "default":
 #if MONO_FEATURE_APPLETLS
-				if (Platform.IsMacOS)
+				if (Platform.IsMacOS) {
+					if (Environment.OSVersion.Major <= 11) {
+						// The apple provider requires Apple API that was introduced in macOS 10.8 (Mountain Lion),
+						// so default to the legacy provider for earlier versions.
+						goto case "legacy";
+					}
 					goto case "apple";
+				}
 #endif
 #if MONO_FEATURE_BTLS
 				if (IsBtlsSupported ())


### PR DESCRIPTION
The apple TLS provider requires Apple API that was introduced in macOS 10.8
(Mountain Lion), which means that it won't work on older macOSes.

So default to the legacy provider for such older macOSes.

Fixes https://github.com/mono/mono/issues/9164.