### PR TITLE
[loader] Add null checks around domain_assemblies

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -1270,6 +1270,8 @@ add_assemblies_to_domain (MonoDomain *domain, MonoAssembly *ass, GHashTable *ht)
 	GSList *tmp;
 	gboolean destroy_ht = FALSE;
 
+	g_assert (ass != NULL);
+
 	if (!ass->aname.name)
 		return;
 
@@ -2194,6 +2196,7 @@ static MonoAssembly *
 mono_domain_assembly_search (MonoAssemblyName *aname,
 							 gpointer user_data)
 {
+	g_assert (aname != NULL);
 	MonoDomain *domain = mono_domain_get ();
 	GSList *tmp;
 	MonoAssembly *ass;
@@ -2208,6 +2211,7 @@ mono_domain_assembly_search (MonoAssemblyName *aname,
 	mono_domain_assemblies_lock (domain);
 	for (tmp = domain->domain_assemblies; tmp; tmp = tmp->next) {
 		ass = (MonoAssembly *)tmp->data;
+		g_assert (ass != NULL);
 		/* Dynamic assemblies can't match here in MS.NET */
 		gboolean ass_ref_only = mono_asmctx_get_kind (&ass->context) == MONO_ASMCTX_REFONLY;
 		if (assembly_is_dynamic (ass) || refonly != ass_ref_only || !mono_assembly_names_equal_flags (aname, &ass->aname, eq_flags))

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -654,6 +654,9 @@ mono_assembly_names_equal (MonoAssemblyName *l, MonoAssemblyName *r)
 gboolean
 mono_assembly_names_equal_flags (MonoAssemblyName *l, MonoAssemblyName *r, MonoAssemblyNameEqFlags flags)
 {
+	g_assert (l != NULL);
+	g_assert (r != NULL);
+
 	if (!l->name || !r->name)
 		return FALSE;
 
@@ -3952,6 +3955,8 @@ gboolean
 framework_assembly_sn_match (MonoAssemblyName *wanted_name, MonoAssemblyName *candidate_name)
 {
 #ifndef DISABLE_DESKTOP_LOADER
+	g_assert (wanted_name != NULL);
+	g_assert (candidate_name != NULL);
 	const AssemblyVersionMap *vmap = (AssemblyVersionMap *)g_hash_table_lookup (assembly_remapping_table, wanted_name->name);
 	if (vmap) {
 		if (!vmap->framework_facade_assembly) {


### PR DESCRIPTION
Try to catch situations leading to a segv in mono_domain_assembly_search by
checking that we never put NULL into domain_assemblies and that callers of
mono_assembly_names_equal_flags never pass NULL args to it.

