### PR TITLE
[runtime] Implement tombstone scrubbing for our concurrent hashtables.

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -666,7 +666,8 @@ TESTS_CS_SRC=		\
 	tailcall-generic-cast-cs.cs \
 	tailcall-interface.cs \
 	bug-60843.cs	\
-	nested_type_visibility.cs
+	nested_type_visibility.cs	\
+	dynamic-method-churn.cs
 
 # some tests fail to compile on mcs
 if CSC_IS_ROSLYN

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1121,7 +1121,8 @@ PROFILE_DISABLED_TESTS += \
 	constant-division.exe	\
 	dynamic-method-resurrection.exe	\
 	assembly_append_ordering.exe \
-	assemblyresolve_event5.exe
+	assemblyresolve_event5.exe	\
+	dynamic-method-churn.exe
 
 # Test which needs System.Web support
 PROFILE_DISABLED_TESTS += \

--- a/mono/tests/dynamic-method-churn.cs
+++ b/mono/tests/dynamic-method-churn.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+
+class Program
+{
+	//See GH #9176
+	static int Main (string[] args) {
+		for (int i = 0; i < 20000; ++i) {
+			DynamicMethod dm = new DynamicMethod(
+				$"dm_{i}",
+				null,
+				new Type[0],
+				typeof(Program).Module);
+
+			ILGenerator il = dm.GetILGenerator();
+			il.Emit(OpCodes.Ret);
+
+			Action a = (Action) dm.CreateDelegate(typeof(Action));
+			a();
+			var m = a.Method;
+			m.Invoke (null, null);
+			if ((i % 50) == 0) {
+				GC.Collect ();
+				GC.WaitForPendingFinalizers ();
+			}
+		}
+		return 0;
+	}
+}


### PR DESCRIPTION
Tombstones must be scrubbed as they can end up taking up all space of a hashtable and make lookup fail.