### PR TITLE
System.Diagnostics.Process improvements for AIX

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -728,7 +728,12 @@ mono_thread_internal_set_priority (MonoInternalThread *internal, MonoThreadPrior
 #endif
 	if (res != 0) {
 		if (res == EPERM) {
+#if !defined(_AIX)
+			/* AIX doesn't like doing this and will spam this every time;
+			 * weirdly, i doesn't complain
+			 */
 			g_warning ("%s: pthread_setschedparam failed, error: \"%s\" (%d)", __func__, g_strerror (res), res);
+#endif
 			return;
 		}
 		g_error ("%s: pthread_setschedparam failed, error: \"%s\" (%d)", __func__, g_strerror (res), res);

--- a/mono/metadata/w32process-unix-default.c
+++ b/mono/metadata/w32process-unix-default.c
@@ -41,6 +41,7 @@
 #define MAXPATHLEN 242
 #endif
 
+/* XXX: why don't we just use proclib? */
 gchar*
 mono_w32process_get_name (pid_t pid)
 {

--- a/mono/metadata/w32process-unix-default.c
+++ b/mono/metadata/w32process-unix-default.c
@@ -158,6 +158,74 @@ open_process_map (int pid, const char *mode)
 GSList*
 mono_w32process_get_modules (pid_t pid)
 {
+#if defined(_AIX)
+	/* due to procfs, this won't work on i */
+	GSList *ret = NULL;
+	FILE *fp;
+	MonoW32ProcessModule *mod;
+	struct prmap module;
+	int i;
+	fpos64_t curpos;
+
+	char pidpath[32]; /* "/proc/<uint64_t max>/map" plus null, rounded */
+	char libpath[MAXPATHLEN + 1];
+	char membername[MAXPATHLEN + 1];
+	char combinedname[(MAXPATHLEN * 2) + 3]; /* lib, member, (), and nul */
+
+	sprintf (pidpath, "/proc/%d/map", pid);
+	if ((fp = fopen(pidpath, "r"))) {
+		while (fread (&module, sizeof (module), 1, fp) == 1
+			/* proc(4) declares such a struct to be the array terminator */
+			&& (module.pr_size != 0 && module.pr_mflags != 0)
+			&& (module.pr_mflags & MA_READ)) {
+
+			fgetpos64 (fp, &curpos); /* save our position */
+			fseeko (fp, module.pr_pathoff, SEEK_SET);
+			while ((libpath[i++] = fgetc (fp)));
+			i = 0;
+			while ((membername[i++] = fgetc (fp)));
+			i = 0;
+			fsetpos64 (fp, &curpos); /* back to normal */
+
+			mod = g_new0 (MonoW32ProcessModule, 1);
+			mod->address_start = module.pr_vaddr;
+			mod->address_end = module.pr_vaddr + module.pr_size;
+			mod->address_offset = module.pr_off;
+			mod->perms = g_strdup ("r--p"); /* XXX? */
+
+			/* AIX has what appears to be device, channel and inode information,
+			 * but it's in a string. Try parsing it.
+			 *
+			 * XXX: I believe it's fstype.devno.chano.inode, but I'm uncertain
+			 * as to how that maps out, so I only fill in the inode (like BSD)
+			 */
+			sscanf (module.pr_mapname, "%*[^.].%*lu.%*u.%lu", &(mod->inode));
+
+			if (membername[0]) {
+				snprintf(combinedname, MAXPATHLEN, "%s(%s)", libpath, membername); 
+				mod->filename = g_strdup (combinedname);
+			} else {
+				mod->filename = g_strdup (libpath);
+			}
+
+			if (g_slist_find_custom (ret, mod, mono_w32process_module_equals) == NULL) {
+				ret = g_slist_prepend (ret, mod);
+			} else {
+				mono_w32process_module_free (mod);
+			}
+		}
+	} else {
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: Can't open process map file for pid %d", __func__, pid);
+		return NULL;
+	}
+
+	if (ret)
+		ret = g_slist_reverse (ret);
+
+	fclose (fp);
+
+	return(ret);
+#else
 	GSList *ret = NULL;
 	FILE *fp;
 	MonoW32ProcessModule *mod;
@@ -281,6 +349,7 @@ mono_w32process_get_modules (pid_t pid)
 	fclose (fp);
 
 	return(ret);
+#endif
 }
 
 #endif

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -547,7 +547,7 @@ process_is_alive (pid_t pid)
 {
 #if defined(HOST_WATCHOS)
 	return TRUE; // TODO: Rewrite using sysctl
-#elif defined(HOST_DARWIN) || defined(__OpenBSD__) || defined(__FreeBSD__)
+#elif defined(HOST_DARWIN) || defined(__OpenBSD__) || defined(__FreeBSD__) || defined(_AIX)
 	if (pid == 0)
 		return FALSE;
 	if (kill (pid, 0) == 0)


### PR DESCRIPTION
AIX has a procfs with raw structures congruent with Solaris. For i,
which lacks procfs, fall back to a libc call.

This doesn't solve the Process weirdness that bungs up the test
suite, but I hope it's a start.

(I expect a lot of "fun" once CoreFX happens there...)

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
