### PR TITLE
Make coop handles typesafe.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -696,6 +696,12 @@ if test x"$GCC" = xyes; then
 		# We require C99 with some GNU extensions, e.g. `linux` macro
 		CFLAGS="$CFLAGS -std=gnu99"
 
+		# FIXME incompatible-pointer-types requires gcc 5.x but should only warn with 4.x, on every invocation
+		# FIXME Windows builds have unrelated preexisting problems here.
+		if test x$host_win32 = xno; then
+		  CFLAGS="$CFLAGS -Werror=incompatible-pointer-types"
+		fi
+
 		# The runtime code does not respect ANSI C strict aliasing rules
 		CFLAGS="$CFLAGS -fno-strict-aliasing"
 

--- a/mono/eglib/goutput.c
+++ b/mono/eglib/goutput.c
@@ -187,7 +187,7 @@ to_android_priority (GLogLevelFlags log_level)
 #define LOG_MESSAGE_MAX_LEN 4096
 
 static void
-android_log_line (gint log_priority, const gchar *log_domain, gchar *log_message, gint log_len)
+android_log_line (gint log_priority, const gchar *log_domain, const gchar *log_message, gint log_len)
 {
 	gchar log_buf [LOG_MESSAGE_MAX_LEN];
 
@@ -204,7 +204,7 @@ static void
 android_log (gint log_priority, const gchar *log_domain, const gchar *log_message)
 {
 	gint log_message_len, log_message_p_len;
-	gchar *log_message_p;
+	const gchar *log_message_p;
 
 	log_message_len = strlen (log_message);
 	if (log_message_len <= LOG_MESSAGE_MAX_LEN) {
@@ -213,7 +213,7 @@ android_log (gint log_priority, const gchar *log_domain, const gchar *log_messag
 	}
 
 	for (log_message_p = log_message; log_message_p < log_message + log_message_len;) {
-		gchar *p = strstr (log_message_p, "\n");
+		const gchar *p = strstr (log_message_p, "\n");
 		if (p == NULL) {
 			/* There is no more "\n". */
 			android_log_line (log_priority, log_domain, log_message_p, LOG_MESSAGE_MAX_LEN - 1);

--- a/mono/eglib/gspawn.c
+++ b/mono/eglib/gspawn.c
@@ -477,7 +477,8 @@ g_spawn_async_with_pipes (const gchar *working_directory,
 			}
 
 			execve (arg0, actual_args, envp);
-			write_all (info_pipe [1], &errno, sizeof (int));
+			int const err = errno;
+			write_all (info_pipe [1], &err, sizeof (int));
 			exit (0);
 		}
 	} else if ((flags & G_SPAWN_DO_NOT_REAP_CHILD) == 0) {

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -491,7 +491,7 @@ mono_domain_create_appdomain_checked (char *friendly_name, char *configuration_f
 	MonoDomain *result = NULL;
 
 	MonoClass *klass = mono_class_load_from_name (mono_defaults.corlib, "System", "AppDomainSetup");
-	MonoAppDomainSetupHandle setup = (MonoAppDomainSetupHandle)mono_object_new_handle (mono_domain_get (), klass, error);
+	MonoAppDomainSetupHandle setup = MONO_HANDLE_CAST (MonoAppDomainSetup, mono_object_new_handle (mono_domain_get (), klass, error));
 	goto_if_nok (error, leave);
 	MonoStringHandle config_file;
 	if (configuration_file != NULL) {
@@ -560,15 +560,15 @@ copy_app_domain_setup (MonoDomain *domain, MonoAppDomainSetupHandle setup, MonoE
 	caller_domain = mono_domain_get ();
 	ads_class = mono_class_load_from_name (mono_defaults.corlib, "System", "AppDomainSetup");
 
-	MonoAppDomainSetupHandle copy = (MonoAppDomainSetupHandle)mono_object_new_handle(domain, ads_class, error);
+	MonoAppDomainSetupHandle copy = MONO_HANDLE_CAST (MonoAppDomainSetup, mono_object_new_handle(domain, ads_class, error));
 	goto_if_nok (error, leave);
 
 	mono_domain_set_internal (domain);
 
-#define XCOPY_FIELD(dst,field,src,error)				\
+#define XCOPY_FIELD(type, dst, field, src, error)			\
 	do {								\
-		MonoObjectHandle src_val = MONO_HANDLE_NEW_GET (MonoObject, (src), field); \
-		MonoObjectHandle copied_val = mono_marshal_xdomain_copy_value_handle (src_val, error); \
+		TYPED_HANDLE_NAME (type) src_val = MONO_HANDLE_NEW_GET (type, (src), field); \
+		TYPED_HANDLE_NAME (type) copied_val = MONO_HANDLE_CAST (type, mono_marshal_xdomain_copy_value_handle (MONO_HANDLE_CAST (MonoObject, src_val), error)); \
 		goto_if_nok (error, leave);					\
 		MONO_HANDLE_SET ((dst),field,copied_val);		\
 	} while (0)
@@ -578,26 +578,26 @@ copy_app_domain_setup (MonoDomain *domain, MonoAppDomainSetupHandle setup, MonoE
 			MONO_HANDLE_SETVAL ((dst), field, type, MONO_HANDLE_GETVAL ((src),field)); \
 		} while (0)
 
-	XCOPY_FIELD (copy, application_base, setup, error);
-	XCOPY_FIELD (copy, application_name, setup, error);
-	XCOPY_FIELD (copy, cache_path, setup, error);
-	XCOPY_FIELD (copy, configuration_file, setup, error);
-	XCOPY_FIELD (copy, dynamic_base, setup, error);
-	XCOPY_FIELD (copy, license_file, setup, error);
-	XCOPY_FIELD (copy, private_bin_path, setup, error);
-	XCOPY_FIELD (copy, private_bin_path_probe, setup, error);
-	XCOPY_FIELD (copy, shadow_copy_directories, setup, error);
-	XCOPY_FIELD (copy, shadow_copy_files, setup, error);
+	XCOPY_FIELD (MonoString, copy, application_base, setup, error);
+	XCOPY_FIELD (MonoString, copy, application_name, setup, error);
+	XCOPY_FIELD (MonoString, copy, cache_path, setup, error);
+	XCOPY_FIELD (MonoString, copy, configuration_file, setup, error);
+	XCOPY_FIELD (MonoString, copy, dynamic_base, setup, error);
+	XCOPY_FIELD (MonoString, copy, license_file, setup, error);
+	XCOPY_FIELD (MonoString, copy, private_bin_path, setup, error);
+	XCOPY_FIELD (MonoString, copy, private_bin_path_probe, setup, error);
+	XCOPY_FIELD (MonoString, copy, shadow_copy_directories, setup, error);
+	XCOPY_FIELD (MonoString, copy, shadow_copy_files, setup, error);
 	COPY_VAL (copy, publisher_policy, MonoBoolean, setup);
 	COPY_VAL (copy, path_changed, MonoBoolean, setup);
 	COPY_VAL (copy, loader_optimization, int, setup);
 	COPY_VAL (copy, disallow_binding_redirects, MonoBoolean, setup);
 	COPY_VAL (copy, disallow_code_downloads, MonoBoolean, setup);
-	XCOPY_FIELD (copy, domain_initializer_args, setup, error);
+	XCOPY_FIELD (MonoArray, copy, domain_initializer_args, setup, error);
 	COPY_VAL (copy, disallow_appbase_probe, MonoBoolean, setup);
-	XCOPY_FIELD (copy, application_trust, setup, error);
-	XCOPY_FIELD (copy, configuration_bytes, setup, error);
-	XCOPY_FIELD (copy, serialized_non_primitives, setup, error);
+	XCOPY_FIELD (MonoObject, copy, application_trust, setup, error);
+	XCOPY_FIELD (MonoArray, copy, configuration_bytes, setup, error);
+	XCOPY_FIELD (MonoArray, copy, serialized_non_primitives, setup, error);
 
 #undef XCOPY_FIELD
 #undef COPY_VAL
@@ -624,7 +624,7 @@ mono_domain_create_appdomain_internal (char *friendly_name, MonoAppDomainSetupHa
 	/* FIXME: pin all those objects */
 	data = mono_domain_create();
 
-	MonoAppDomainHandle ad = (MonoAppDomainHandle)mono_object_new_handle (data, adclass, error);
+	MonoAppDomainHandle ad = MONO_HANDLE_CAST (MonoAppDomain, mono_object_new_handle (data, adclass, error));
 	goto_if_nok (error, leave);
 	MONO_HANDLE_SETVAL (ad, data, MonoDomain*, data);
 	data->domain = MONO_HANDLE_RAW (ad);
@@ -1222,7 +1222,7 @@ mono_try_assembly_resolve_handle (MonoDomain *domain, MonoStringHandle fname, Mo
 	params[1] = requesting ? MONO_HANDLE_RAW (requesting_handle) : NULL;
 	params [2] = &isrefonly;
 	MonoObject *exc = NULL;
-	MonoReflectionAssemblyHandle result = MONO_HANDLE_NEW (MonoReflectionAssembly, mono_runtime_try_invoke (method, domain->domain, params, &exc, error));
+	MonoReflectionAssemblyHandle result = MONO_HANDLE_CAST (MonoReflectionAssembly, MONO_HANDLE_NEW (MonoObject, mono_runtime_try_invoke (method, domain->domain, params, &exc, error)));
 	if (!is_ok (error) || exc != NULL) {
 		if (is_ok (error))
 			mono_error_set_exception_instance (error, (MonoException*)exc);
@@ -2368,7 +2368,7 @@ ves_icall_System_AppDomain_LoadAssembly (MonoAppDomainHandle ad, MonoStringHandl
 	gchar *name = NULL;
 	gboolean parsed;
 
-	g_assert (assRef);
+	g_assert (!MONO_HANDLE_IS_NULL (assRef));
 
 	name = mono_string_handle_to_utf8 (assRef, error);
 	goto_if_nok (error, fail);

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -1751,7 +1751,7 @@ ves_icall_System_ComObject_CreateRCW (MonoReflectionTypeHandle ref_type, MonoErr
 	 * Constructor does not need to be called. Will be called later.
 	 */
 	MonoVTable *vtable = mono_class_vtable_checked (domain, klass, error);
-	return_val_if_nok (error, NULL);
+	return_val_if_nok (error, NULL_HANDLE);
 	return mono_object_new_alloc_by_vtable (vtable, error);
 }
 

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -1902,7 +1902,7 @@ mono_reflection_get_custom_attrs_info_checked (MonoObjectHandle obj, MonoError *
 		cinfo = mono_custom_attrs_from_builders_handle (NULL, m_class_get_image (mhandle->klass), cattrs);
 	} else if (strcmp ("FieldBuilder", klass_name) == 0) {
 		MonoReflectionFieldBuilderHandle fb = MONO_HANDLE_CAST (MonoReflectionFieldBuilder, obj);
-		MonoReflectionTypeBuilderHandle tb = MONO_HANDLE_NEW_GET (MonoReflectionTypeBuilder, fb, typeb);
+		MonoReflectionTypeBuilderHandle tb = MONO_HANDLE_CAST (MonoReflectionTypeBuilder, MONO_HANDLE_NEW_GET (MonoReflectionType, fb, typeb));
 		MonoReflectionModuleBuilderHandle mb = MONO_HANDLE_NEW_GET (MonoReflectionModuleBuilder, tb, module);
 		MonoDynamicImage *dynamic_image = MONO_HANDLE_GETVAL (mb, dynamic_image);
 		MonoArrayHandle cattrs = MONO_HANDLE_NEW_GET (MonoArray, fb, cattrs);

--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -110,9 +110,9 @@ mono_exception_new_by_name_domain (MonoDomain *domain, MonoImage *image,
 
 	goto_if_ok (error, exit);
 return_null:
-	MONO_HANDLE_ASSIGN (o, NULL);
+	MONO_HANDLE_ASSIGN (o, NULL_HANDLE);
 exit:
-	HANDLE_FUNCTION_RETURN_REF (MonoException, o);
+	HANDLE_FUNCTION_RETURN_REF (MonoException, MONO_HANDLE_CAST (MonoException, o));
 }
 
 /**
@@ -307,7 +307,7 @@ mono_exception_new_by_name_msg (MonoImage *image, const char *name_space,
 	}
 	goto exit;
 return_null:
-	MONO_HANDLE_ASSIGN (ex, NULL);
+	MONO_HANDLE_ASSIGN (ex, NULL_HANDLE);
 exit:
 	HANDLE_FUNCTION_RETURN_REF (MonoException, ex)
 }
@@ -691,7 +691,7 @@ mono_exception_new_argument (const char *arg, const char *msg, MonoError *error)
 	ex = mono_exception_new_by_name_msg (mono_get_corlib (), "System", "ArgumentException", msg, error);
 
 	if (arg && !MONO_HANDLE_IS_NULL (ex)) {
-		MonoArgumentExceptionHandle argex = (MonoArgumentExceptionHandle)ex;
+		MonoArgumentExceptionHandle argex = MONO_HANDLE_CAST (MonoArgumentException, ex);
 		MonoStringHandle arg_str = mono_string_new_handle (MONO_HANDLE_DOMAIN (ex), arg, error);
 		MONO_HANDLE_SET (argex, param_name, arg_str);
 	}
@@ -1016,7 +1016,7 @@ mono_get_exception_reflection_type_load_checked (MonoArrayHandle types, MonoArra
 	}
 	g_assert (method);
 
-	MonoExceptionHandle exc = MONO_HANDLE_NEW (MonoException, mono_object_new_checked (mono_domain_get (), klass, error));
+	MonoExceptionHandle exc = MONO_HANDLE_CAST (MonoException, MONO_HANDLE_NEW (MonoObject, mono_object_new_checked (mono_domain_get (), klass, error)));
 	mono_error_assert_ok (error);
 
 	gpointer args [2];
@@ -1149,7 +1149,7 @@ ves_icall_Mono_Runtime_GetNativeStackTrace (MonoExceptionHandle exc, MonoError *
 	MonoStringHandle res;
 	error_init (error);
 
-	if (!exc) {
+	if (MONO_HANDLE_IS_NULL (exc)) {
 		mono_error_set_argument_null (error, "exception", "");
 		return NULL_HANDLE_STRING;
 	}

--- a/mono/metadata/handle.c
+++ b/mono/metadata/handle.c
@@ -244,7 +244,7 @@ retry:
 	goto retry;
 }
 
-MonoRawHandle
+gpointer
 #ifndef MONO_HANDLE_TRACK_OWNER
 mono_handle_new_interior (gpointer rawptr)
 #else

--- a/mono/metadata/handle.c
+++ b/mono/metadata/handle.c
@@ -94,7 +94,7 @@ free_handle_chunk (HandleChunk *chunk)
 	g_free (chunk);
 }
 
-const MonoObjectHandle mono_null_value_handle = NULL;
+const MonoObjectHandle mono_null_value_handle;
 
 #define THIS_IS_AN_OK_NUMBER_OF_HANDLES 100
 
@@ -107,7 +107,11 @@ chunk_element (HandleChunk *chunk, int idx)
 static HandleChunkElem*
 handle_to_chunk_element (MonoObjectHandle o)
 {
+#if MONO_TYPE_SAFE_HANDLES
+	return (HandleChunkElem*)o.__raw;
+#else
 	return (HandleChunkElem*)o;
+#endif
 }
 
 /* Given a HandleChunkElem* search through the current handle stack to find its chunk and offset. */

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -484,6 +484,7 @@ extern const MonoObjectHandle mono_null_value_handle;
 static inline void
 mono_handle_assign (MonoObjectHandleOut dest, MonoObjectHandle src)
 {
+	g_assert (dest);
 	MONO_HANDLE_SUPPRESS (dest->__raw = (gpointer)(src ? MONO_HANDLE_RAW (src) : NULL));
 }
 

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -48,7 +48,7 @@
 // NOTE: Running this code depends on the ABI to pass a struct
 // with a pointer the same as a pointer. This is tied in with
 // marshaling. If this is not the case, turn off type-safety, perhaps per-OS per-CPU.
-#if 1 //..checkedbuild...
+#if !defined (HOST_WASM) && (!defined (TARGET_X86) || defined (HOST_WIN32) || defined (HOST_DARWIN))
 #define MONO_TYPE_SAFE_HANDLES 1
 #else
 #define MONO_TYPE_SAFE_HANDLES 0

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -352,7 +352,6 @@ Handle macros/functions
 #ifdef MONO_HANDLE_TRACK_OWNER
 #define STRINGIFY_(x) #x
 #define STRINGIFY(x) STRINGIFY_(x)
-#define HANDLE_OWNER_STRINGIFY(file,lineno) (const char*) (file ":" STRINGIFY(lineno))
 #define HANDLE_OWNER (__FILE__ ":" STRINGIFY (__LINE__))
 #endif
 
@@ -444,7 +443,7 @@ Handle macros/functions
 #ifndef MONO_HANDLE_TRACK_OWNER
 #define MONO_HANDLE_NEW(TYPE, VALUE) (TYPED_HANDLE_NAME(TYPE))( mono_handle_new ((MonoObject*)(VALUE)) )
 #else
-#define MONO_HANDLE_NEW(TYPE, VALUE) (TYPED_HANDLE_NAME(TYPE))( mono_handle_new ((MonoObject*)(VALUE), HANDLE_OWNER_STRINGIFY(__FILE__, __LINE__)))
+#define MONO_HANDLE_NEW(TYPE, VALUE) (TYPED_HANDLE_NAME(TYPE))( mono_handle_new ((MonoObject*)(VALUE), HANDLE_OWNER))
 #endif
 
 #define MONO_HANDLE_CAST(TYPE, VALUE) (TYPED_HANDLE_NAME(TYPE))( VALUE )

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -155,10 +155,10 @@ typedef void (*GcScanFunc) (gpointer*, gpointer);
 
 #ifndef MONO_HANDLE_TRACK_OWNER
 MonoRawHandle mono_handle_new (MonoObject *object);
-MonoRawHandle mono_handle_new_interior (gpointer rawptr);
+gpointer mono_handle_new_interior (gpointer rawptr);
 #else
 MonoRawHandle mono_handle_new (MonoObject *object, const char* owner);
-MonoRawHandle mono_handle_new_interior (gpointer rawptr, const char *owner);
+gpointer mono_handle_new_interior (gpointer rawptr, const char *owner);
 #endif
 
 void mono_handle_stack_scan (HandleStack *stack, GcScanFunc func, gpointer gc_data, gboolean precise, gboolean check);

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -362,16 +362,24 @@ Handle macros/functions
  *
  * For example, TYPED_HANDLE_DECL(MonoObject) (see below) expands to:
  *
+ * #if MONO_TYPE_SAFE_HANDLES
+ *
  * typedef struct {
-#if MONO_TYPE_SAFE_HANDLES
  *   MonoObject **__raw;
-#else
+ * } MonoObjectHandlePayload;
+ *
+ * typedef MonoObjectHandlePayload MonoObjectHandle,
+ *                                 MonoObjectHandleOut;
+ * #else
+ *
+ * typedef struct {
  *   MonoObject *__raw;
-#endif
  * } MonoObjectHandlePayload;
  *
  * typedef MonoObjectHandlePayload* MonoObjectHandle;
  * typedef MonoObjectHandlePayload* MonoObjectHandleOut;
+ *
+ * #endif
  */
 
 #if MONO_TYPE_SAFE_HANDLES
@@ -389,16 +397,7 @@ Handle macros/functions
 /*
  * TYPED_VALUE_HANDLE_DECL(SomeType):
  *   Expands to a decl for handles to SomeType (which is a managed valuetype (likely a struct) of some sort) and to an internal payload struct.
- * For example TYPED_HANDLE_DECL(MonoMethodInfo) expands to:
- *
- * typedef struct {
-#if MONO_TYPE_SAFE_HANDLES
- *   MonoMethodInfo **__raw;
-#else
- *   MonoMethodInfo *__raw;
-#endif
- * } MonoMethodInfoHandlePayload;
- * typedef MonoMethodInfoHandlePayload* MonoMethodInfoHandle;
+ * It is currently identical to TYPED_HANDLE_DECL (valuetypes vs. referencetypes).
  */
 #define TYPED_VALUE_HANDLE_DECL(TYPE) TYPED_HANDLE_DECL(TYPE)
 

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -147,7 +147,7 @@ static inline void
 mono_stack_mark_init (MonoThreadInfo *info, HandleStackMark *stackmark)
 {
 #ifdef MONO_HANDLE_TRACK_SP
-	gpointer sptop = (gpointer)(intptr_t)&stackmark;
+	gpointer sptop = &stackmark;
 #endif
 	HandleStack *handles = (HandleStack *)info->handle_stack;
 	stackmark->size = handles->top->size;

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -125,11 +125,9 @@ typedef void (*GcScanFunc) (gpointer*, gpointer);
 
 #ifndef MONO_HANDLE_TRACK_OWNER
 MonoRawHandle mono_handle_new (MonoObject *object);
-MonoRawHandle mono_handle_new_full (gpointer rawptr, gboolean interior);
 MonoRawHandle mono_handle_new_interior (gpointer rawptr);
 #else
 MonoRawHandle mono_handle_new (MonoObject *object, const char* owner);
-MonoRawHandle mono_handle_new_full (gpointer rawptr, gboolean interior, const char *owner);
 MonoRawHandle mono_handle_new_interior (gpointer rawptr, const char *owner);
 #endif
 

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -336,7 +336,6 @@ Handle macros/functions
 #define MONO_HANDLE_PAYLOAD_OFFSET_(PayloadType) MONO_STRUCT_OFFSET(PayloadType, __raw)
 #define MONO_HANDLE_PAYLOAD_OFFSET(TYPE) MONO_HANDLE_PAYLOAD_OFFSET_(TYPED_HANDLE_PAYLOAD_NAME (TYPE))
 
-#define MONO_HANDLE_INIT ((void*) mono_null_value_handle)
 #define NULL_HANDLE mono_null_value_handle
 
 //XXX add functions to get/set raw, set field, set field to null, set array, set array to null

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -40,9 +40,7 @@
 //  8. mono_object_class (handle), instead of mono_handle_class
 //
 // None of those operations were likely intended.
-// Completely incidentally, the type-safe system is a little more expression-oriented than
-// the statement-based type-unsafe system, and might be valid C++ where type-unsafe is not (untested).
-
+//
 // FIXME Do this only on checked builds? Or certain architectures?
 // There is not runtime cost.
 // NOTE: Running this code depends on the ABI to pass a struct
@@ -659,7 +657,7 @@ static inline void
 mono_handle_assign (MonoObjectHandleOut dest, MonoObjectHandle src)
 {
 	g_assert (dest.__raw);
-	*dest.__raw = src.__raw ? *src.__raw : NULL;
+	MONO_HANDLE_SUPPRESS (*dest.__raw = src.__raw ? *src.__raw : NULL);
 }
 
 #else

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -393,8 +393,6 @@ Handle macros/functions
 #define MONO_HANDLE_PAYLOAD_OFFSET_(PayloadType) MONO_STRUCT_OFFSET(PayloadType, __raw)
 #define MONO_HANDLE_PAYLOAD_OFFSET(TYPE) MONO_HANDLE_PAYLOAD_OFFSET_(TYPED_HANDLE_PAYLOAD_NAME (TYPE))
 
-#define NULL_HANDLE mono_null_value_handle
-
 //XXX add functions to get/set raw, set field, set field to null, set array, set array to null
 #define MONO_HANDLE_DCL(TYPE, NAME) TYPED_HANDLE_NAME(TYPE) NAME = MONO_HANDLE_NEW (TYPE, (NAME ## _raw))
 
@@ -640,9 +638,6 @@ mono_handle_raw (MonoRawHandle raw_handle)
 typedef MonoThread MonoThreadObject;
 TYPED_HANDLE_DECL (MonoThreadObject);
 
-#define NULL_HANDLE_STRING MONO_HANDLE_CAST(MonoString, NULL_HANDLE)
-#define NULL_HANDLE_ARRAY (MONO_HANDLE_CAST (MonoArray, NULL_HANDLE))
-
 /*
 This is the constant for a handle that points nowhere.
 Constant handles may be initialized to it, but non-constant
@@ -650,6 +645,9 @@ handles must be NEW'ed. Uses of these are suspicious and should
 be reviewed and probably changed FIXME.
 */
 extern const MonoObjectHandle mono_null_value_handle;
+#define NULL_HANDLE mono_null_value_handle
+#define NULL_HANDLE_STRING MONO_HANDLE_CAST(MonoString, NULL_HANDLE)
+#define NULL_HANDLE_ARRAY (MONO_HANDLE_CAST (MonoArray, NULL_HANDLE))
 
 #if MONO_TYPE_SAFE_HANDLES
 

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -6228,13 +6228,13 @@ ves_icall_System_Reflection_Module_ResolveSignature (MonoImage *image, guint32 t
 
 	/* FIXME: Support other tables ? */
 	if (table != MONO_TABLE_STANDALONESIG)
-		return MONO_HANDLE_CAST (MonoArray, NULL);
+		return NULL_HANDLE_ARRAY;
 
 	if (image_is_dynamic (image))
-		return MONO_HANDLE_CAST (MonoArray, NULL);
+		return NULL_HANDLE_ARRAY;
 
 	if ((idx == 0) || (idx > tables [MONO_TABLE_STANDALONESIG].rows))
-		return MONO_HANDLE_CAST (MonoArray, NULL);
+		return NULL_HANDLE_ARRAY;
 
 	sig = mono_metadata_decode_row_col (&tables [MONO_TABLE_STANDALONESIG], idx - 1, 0);
 
@@ -6243,7 +6243,7 @@ ves_icall_System_Reflection_Module_ResolveSignature (MonoImage *image, guint32 t
 
 	MonoArrayHandle res = mono_array_new_handle (mono_domain_get (), mono_defaults.byte_class, len, error);
 	if (!is_ok (error))
-		return MONO_HANDLE_CAST (MonoArray, NULL);
+		return NULL_HANDLE_ARRAY;
 	uint32_t h;
 	gpointer array_base = MONO_ARRAY_HANDLE_PIN (res, guint8, 0, &h);
 	memcpy (array_base, ptr, len);
@@ -6410,7 +6410,7 @@ ves_icall_System_Delegate_AllocDelegateLike_internal (MonoDelegateHandle delegat
 	MonoClass *klass = mono_handle_class (delegate);
 	g_assert (mono_class_has_parent (klass, mono_defaults.multicastdelegate_class));
 
-	MonoMulticastDelegateHandle ret = (MonoMulticastDelegateHandle)mono_object_new_handle (MONO_HANDLE_DOMAIN (delegate), klass, error);
+	MonoMulticastDelegateHandle ret = MONO_HANDLE_CAST (MonoMulticastDelegate, mono_object_new_handle (MONO_HANDLE_DOMAIN (delegate), klass, error));
 	return_val_if_nok (error, MONO_HANDLE_CAST (MonoMulticastDelegate, NULL_HANDLE));
 
 	MONO_HANDLE_SETVAL (MONO_HANDLE_CAST (MonoDelegate, ret), invoke_impl, gpointer, mono_runtime_create_delegate_trampoline (klass));

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -6229,23 +6229,13 @@ mono_icall_handle_new (gpointer rawobj)
 #endif
 }
 
-MonoObjectHandle
+gpointer
 mono_icall_handle_new_interior (gpointer rawobj)
 {
 #ifdef MONO_HANDLE_TRACK_OWNER
-	MonoRawHandle const rawh = mono_handle_new_interior (rawobj, "<marshal args>");
+	return mono_handle_new_interior (rawobj, "<marshal args>");
 #else
-	MonoRawHandle const rawh = mono_handle_new_interior (rawobj);
-#endif
-#if MONO_TYPE_SAFE_HANDLES
-	// This is the only use of mono_handle_new_interior.
-	// It lacks the macro support of mono_handle_new.
-	//return *(MonoObjectHandle*)&rawh; // violates gcc -fstrict-aliasing
-	// Legal with gcc -fstrict-aliasing:
-	union { MonoRawHandle rawh; MonoObjectHandle objh; } type_pun = { rawh };
-	return type_pun.objh;
-#else
-	return rawh;
+	return mono_handle_new_interior (rawobj);
 #endif
 }
 

--- a/mono/metadata/marshal.h
+++ b/mono/metadata/marshal.h
@@ -638,7 +638,7 @@ mono_icall_end (MonoThreadInfo *info, HandleStackMark *stackmark, MonoError *err
 MonoObjectHandle
 mono_icall_handle_new (gpointer rawobj);
 
-MonoObjectHandle
+gpointer
 mono_icall_handle_new_interior (gpointer rawobj);
 
 void*

--- a/mono/metadata/reflection-cache.h
+++ b/mono/metadata/reflection-cache.h
@@ -95,7 +95,7 @@ cache_object_handle (MonoDomain *domain, MonoClass *klass, gpointer item, MonoOb
 }
 
 #define CACHE_OBJECT(t,p,o,k) ((t) (cache_object (domain, (k), (p), (o))))
-#define CACHE_OBJECT_HANDLE(t,p,o,k) ((t) (cache_object_handle (domain, (k), (p), (o))))
+#define CACHE_OBJECT_HANDLE(t,p,o,k) (MONO_HANDLE_CAST (t, cache_object_handle (domain, (k), (p), (o))))
 
 static inline MonoObjectHandle
 check_object_handle (MonoDomain* domain, MonoClass *klass, gpointer item)
@@ -107,8 +107,7 @@ check_object_handle (MonoDomain* domain, MonoClass *klass, gpointer item)
 	if (!hash)
 		return MONO_HANDLE_NEW (MonoObject, NULL);
 
-	MonoObjectHandle obj = MONO_HANDLE_NEW (MonoObject, mono_conc_g_hash_table_lookup (hash, &e));
-	return obj;
+	return MONO_HANDLE_NEW (MonoObject, mono_conc_g_hash_table_lookup (hash, &e));
 }
 
 
@@ -122,15 +121,15 @@ check_or_construct_handle (MonoDomain *domain, MonoClass *klass, gpointer item, 
 	if (!MONO_HANDLE_IS_NULL (obj))
 		return obj;
 	MONO_HANDLE_ASSIGN (obj, construct (domain, klass, item, user_data, error));
-	return_val_if_nok (error, NULL);
+	return_val_if_nok (error, NULL_HANDLE);
 	if (MONO_HANDLE_IS_NULL (obj))
 		return obj;
 	/* note no caching if there was an error in construction */
 	return cache_object_handle (domain, klass, item, obj);
 }
 
-
-#define CHECK_OR_CONSTRUCT_HANDLE(t,p,k,construct,ud) ((t) check_or_construct_handle (domain, (k), (p), (ud), error, (ReflectionCacheConstructFunc_handle) (construct)))
-
+#define CHECK_OR_CONSTRUCT_HANDLE(t,p,k,construct,ud) \
+	(MONO_HANDLE_CAST (t, check_or_construct_handle ( \
+		domain, (k), (p), (ud), error, (ReflectionCacheConstructFunc_handle) (construct))))
 
 #endif /*__MONO_METADATA_REFLECTION_CACHE_H__*/

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -229,7 +229,7 @@ static MonoReflectionAssemblyHandle
 assembly_object_construct (MonoDomain *domain, MonoClass *unused_klass, MonoAssembly *assembly, gpointer user_data, MonoError *error)
 {
 	error_init (error);
-	MonoReflectionAssemblyHandle res = (MonoReflectionAssemblyHandle) mono_object_new_handle (domain, mono_class_get_mono_assembly_class (), error);
+	MonoReflectionAssemblyHandle res = MONO_HANDLE_CAST (MonoReflectionAssembly, mono_object_new_handle (domain, mono_class_get_mono_assembly_class (), error));
 	return_val_if_nok (error, MONO_HANDLE_CAST (MonoReflectionAssembly, NULL_HANDLE));
 	MONO_HANDLE_SETVAL (res, assembly, MonoAssembly*, assembly);
 	return res;
@@ -246,7 +246,7 @@ MonoReflectionAssemblyHandle
 mono_assembly_get_object_handle (MonoDomain *domain, MonoAssembly *assembly, MonoError *error)
 {
 	error_init (error);
-	return CHECK_OR_CONSTRUCT_HANDLE (MonoReflectionAssemblyHandle, assembly, NULL, assembly_object_construct, NULL);
+	return CHECK_OR_CONSTRUCT_HANDLE (MonoReflectionAssembly, assembly, NULL, assembly_object_construct, NULL);
 }
 
 /**
@@ -268,7 +268,7 @@ module_object_construct (MonoDomain *domain, MonoClass *unused_klass, MonoImage 
 	char* basename;
 	
 	error_init (error);
-	MonoReflectionModuleHandle res = (MonoReflectionModuleHandle)mono_object_new_handle (domain, mono_class_get_mono_module_class (), error);
+	MonoReflectionModuleHandle res = MONO_HANDLE_CAST (MonoReflectionModule, mono_object_new_handle (domain, mono_class_get_mono_module_class (), error));
 	goto_if_nok (error, fail);
 
 	MONO_HANDLE_SETVAL (res, image, MonoImage *, image);
@@ -310,7 +310,7 @@ MonoReflectionModuleHandle
 mono_module_get_object_handle (MonoDomain *domain, MonoImage *image, MonoError *error)
 {
 	error_init (error);
-	return CHECK_OR_CONSTRUCT_HANDLE (MonoReflectionModuleHandle, image, NULL, module_object_construct, NULL);
+	return CHECK_OR_CONSTRUCT_HANDLE (MonoReflectionModule, image, NULL, module_object_construct, NULL);
 }
 
 /**
@@ -337,7 +337,7 @@ mono_module_file_get_object_handle (MonoDomain *domain, MonoImage *image, int ta
 	
 	error_init (error);
 
-	MonoReflectionModuleHandle res = (MonoReflectionModuleHandle)mono_object_new_handle (domain, mono_class_get_mono_module_class (), error);
+	MonoReflectionModuleHandle res = MONO_HANDLE_CAST (MonoReflectionModule, mono_object_new_handle (domain, mono_class_get_mono_module_class (), error));
 	goto_if_nok (error, fail);
 
 	table = &image->tables [MONO_TABLE_FILE];
@@ -597,7 +597,7 @@ method_object_construct (MonoDomain *domain, MonoClass *refclass, MonoMethod *me
 	else {
 		klass = mono_class_get_mono_method_class ();
 	}
-	MonoReflectionMethodHandle ret = (MonoReflectionMethodHandle)mono_object_new_handle (domain, klass, error);
+	MonoReflectionMethodHandle ret = MONO_HANDLE_CAST (MonoReflectionMethod, mono_object_new_handle (domain, klass, error));
 	goto_if_nok (error, fail);
 	MONO_HANDLE_SETVAL (ret, method, MonoMethod*, method);
 
@@ -629,7 +629,7 @@ mono_method_get_object_handle (MonoDomain *domain, MonoMethod *method, MonoClass
 	if (!refclass)
 		refclass = method->klass;
 
-	return CHECK_OR_CONSTRUCT_HANDLE (MonoReflectionMethodHandle, method, refclass, method_object_construct, NULL);
+	return CHECK_OR_CONSTRUCT_HANDLE (MonoReflectionMethod, method, refclass, method_object_construct, NULL);
 }
 /*
  * mono_method_get_object_checked:
@@ -697,7 +697,7 @@ field_object_construct (MonoDomain *domain, MonoClass *klass, MonoClassField *fi
 {
 	error_init (error);
 
-	MonoReflectionFieldHandle res = (MonoReflectionFieldHandle)mono_object_new_handle (domain, mono_class_get_mono_field_class (), error);
+	MonoReflectionFieldHandle res = MONO_HANDLE_CAST (MonoReflectionField, mono_object_new_handle (domain, mono_class_get_mono_field_class (), error));
 	goto_if_nok (error, fail);
 	MONO_HANDLE_SETVAL (res, klass, MonoClass *, klass);
 	MONO_HANDLE_SETVAL (res, field, MonoClassField *, field);
@@ -731,7 +731,7 @@ MonoReflectionFieldHandle
 mono_field_get_object_handle (MonoDomain *domain, MonoClass *klass, MonoClassField *field, MonoError *error)
 {
 	error_init (error);
-	return CHECK_OR_CONSTRUCT_HANDLE (MonoReflectionFieldHandle, field, klass, field_object_construct, NULL);
+	return CHECK_OR_CONSTRUCT_HANDLE (MonoReflectionField, field, klass, field_object_construct, NULL);
 }
 
 
@@ -777,7 +777,7 @@ property_object_construct (MonoDomain *domain, MonoClass *klass, MonoProperty *p
 {
 	error_init (error);
 
-	MonoReflectionPropertyHandle res = (MonoReflectionPropertyHandle)mono_object_new_handle (domain, mono_class_get_mono_property_class (), error);
+	MonoReflectionPropertyHandle res = MONO_HANDLE_CAST (MonoReflectionProperty, mono_object_new_handle (domain, mono_class_get_mono_property_class (), error));
 	goto_if_nok (error, fail);
 	MONO_HANDLE_SETVAL (res, klass, MonoClass *, klass);
 	MONO_HANDLE_SETVAL (res, property, MonoProperty *, property);
@@ -799,7 +799,7 @@ fail:
 MonoReflectionPropertyHandle
 mono_property_get_object_handle (MonoDomain *domain, MonoClass *klass, MonoProperty *property, MonoError *error)
 {
-	return CHECK_OR_CONSTRUCT_HANDLE (MonoReflectionPropertyHandle, property, klass, property_object_construct, NULL);
+	return CHECK_OR_CONSTRUCT_HANDLE (MonoReflectionProperty, property, klass, property_object_construct, NULL);
 }
 
 /**
@@ -842,7 +842,7 @@ event_object_construct (MonoDomain *domain, MonoClass *klass, MonoEvent *event, 
 {
 
 	error_init (error);
-	MonoReflectionMonoEventHandle mono_event = (MonoReflectionMonoEventHandle)mono_object_new_handle (domain, mono_class_get_mono_event_class (), error);
+	MonoReflectionMonoEventHandle mono_event = MONO_HANDLE_CAST (MonoReflectionMonoEvent, mono_object_new_handle (domain, mono_class_get_mono_event_class (), error));
 	if (!is_ok (error))
 		return MONO_HANDLE_CAST (MonoReflectionEvent, NULL_HANDLE);
 	MONO_HANDLE_SETVAL (mono_event, klass, MonoClass* , klass);
@@ -863,7 +863,7 @@ MonoReflectionEventHandle
 mono_event_get_object_handle (MonoDomain *domain, MonoClass *klass, MonoEvent *event, MonoError *error)
 {
 	error_init (error);
-	return CHECK_OR_CONSTRUCT_HANDLE (MonoReflectionEventHandle, event, klass, event_object_construct, NULL);
+	return CHECK_OR_CONSTRUCT_HANDLE (MonoReflectionEvent, event, klass, event_object_construct, NULL);
 }
 
 
@@ -936,7 +936,7 @@ add_parameter_object_to_array (MonoDomain *domain, MonoMethod *method, MonoObjec
 {
 	HANDLE_FUNCTION_ENTER ();
 	error_init (error);
-	MonoReflectionParameterHandle param = (MonoReflectionParameterHandle)mono_object_new_handle (domain, mono_class_get_mono_parameter_info_class (), error);
+	MonoReflectionParameterHandle param = MONO_HANDLE_CAST (MonoReflectionParameter, mono_object_new_handle (domain, mono_class_get_mono_parameter_info_class (), error));
 	goto_if_nok (error, leave);
 
 	MonoReflectionTypeHandle rt = mono_type_get_object_handle (domain, sig_param, error);
@@ -1026,7 +1026,7 @@ param_objects_construct (MonoDomain *domain, MonoClass *refclass, MonoMethodSign
 	mono_method_get_marshal_info (method, mspecs);
 
 	res = mono_array_new_handle (domain, mono_class_get_mono_parameter_info_class (), sig->param_count, error);
-	if (!res)
+	if (MONO_HANDLE_IS_NULL (res))
 		goto leave;
 
 	gboolean any_default_value = FALSE;
@@ -1064,7 +1064,7 @@ leave:
 	g_free (mspecs);
 
 	if (!is_ok (error))
-		return NULL;
+		return NULL_HANDLE_ARRAY;
 	
 	return res;
 }
@@ -1096,9 +1096,9 @@ mono_param_get_objects_internal (MonoDomain *domain, MonoMethod *method, MonoCla
 	/* Note: the cache is based on the address of the signature into the method
 	 * since we already cache MethodInfos with the method as keys.
 	 */
-	return CHECK_OR_CONSTRUCT_HANDLE (MonoArrayHandle, &method->signature, refclass, param_objects_construct, method);
+	return CHECK_OR_CONSTRUCT_HANDLE (MonoArray, &method->signature, refclass, param_objects_construct, method);
 fail:
-	return MONO_HANDLE_NEW (MonoArray, NULL_HANDLE);
+	return MONO_HANDLE_NEW (MonoArray, NULL);
 }
 
 /**
@@ -1119,7 +1119,7 @@ add_local_var_info_to_array (MonoDomain *domain, MonoMethodHeader *header, int i
 {
 	HANDLE_FUNCTION_ENTER ();
 	error_init (error);
-	MonoReflectionLocalVariableInfoHandle info = (MonoReflectionLocalVariableInfoHandle)mono_object_new_handle (domain, mono_class_get_local_variable_info_class (), error);
+	MonoReflectionLocalVariableInfoHandle info = MONO_HANDLE_CAST (MonoReflectionLocalVariableInfo, mono_object_new_handle (domain, mono_class_get_local_variable_info_class (), error));
 	goto_if_nok (error, leave);
 
 	MonoReflectionTypeHandle rt = mono_type_get_object_handle (domain, header->locals [idx], error);
@@ -1141,7 +1141,7 @@ add_exception_handling_clause_to_array (MonoDomain *domain, MonoMethodHeader *he
 {
 	HANDLE_FUNCTION_ENTER ();
 	error_init (error);
-	MonoReflectionExceptionHandlingClauseHandle info = (MonoReflectionExceptionHandlingClauseHandle)mono_object_new_handle (domain, mono_class_get_exception_handling_clause_class (), error);
+	MonoReflectionExceptionHandlingClauseHandle info = MONO_HANDLE_CAST (MonoReflectionExceptionHandlingClause, mono_object_new_handle (domain, mono_class_get_exception_handling_clause_class (), error));
 	goto_if_nok (error, leave);
 	MonoExceptionClause *clause = &header->clauses [idx];
 
@@ -1232,7 +1232,7 @@ method_body_object_construct (MonoDomain *domain, MonoClass *unused_class, MonoM
 	} else
 		local_var_sig_token = 0; //FIXME
 
-	MonoReflectionMethodBodyHandle ret = (MonoReflectionMethodBodyHandle)mono_object_new_handle (domain, mono_class_get_method_body_class (), error);
+	MonoReflectionMethodBodyHandle ret = MONO_HANDLE_CAST (MonoReflectionMethodBody, mono_object_new_handle (domain, mono_class_get_method_body_class (), error));
 	goto_if_nok (error, fail);
 
 	MONO_HANDLE_SETVAL (ret, init_locals, MonoBoolean, header->init_locals);
@@ -1269,7 +1269,7 @@ method_body_object_construct (MonoDomain *domain, MonoClass *unused_class, MonoM
 fail:
 	if (header)
 		mono_metadata_free_mh (header);
-	return NULL;
+	return MONO_HANDLE_CAST (MonoReflectionMethodBody, NULL_HANDLE);
 }
 
 /**
@@ -1284,7 +1284,7 @@ MonoReflectionMethodBodyHandle
 mono_method_body_get_object_handle (MonoDomain *domain, MonoMethod *method, MonoError *error)
 {
 	error_init (error);
-	return CHECK_OR_CONSTRUCT_HANDLE (MonoReflectionMethodBodyHandle, method, NULL, method_body_object_construct, NULL);
+	return CHECK_OR_CONSTRUCT_HANDLE (MonoReflectionMethodBody, method, NULL, method_body_object_construct, NULL);
 }
 
 

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -2053,7 +2053,7 @@ mono_marshal_xdomain_copy_value_handle (MonoObjectHandle val, MonoError *error)
 	case MONO_TYPE_R4:
 	case MONO_TYPE_R8: {
 		uint32_t gchandle = mono_gchandle_from_handle (val, TRUE);
-		MonoObjectHandle res = MONO_HANDLE_NEW (MonoObject, mono_value_box_checked (domain, klass, ((char*)val) + sizeof(MonoObject), error)); /* FIXME use handles in mono_value_box_checked */
+		MonoObjectHandle res = MONO_HANDLE_NEW (MonoObject, mono_value_box_checked (domain, klass, ((char*)MONO_HANDLE_RAW (val)) + sizeof(MonoObject), error)); /* FIXME use handles in mono_value_box_checked */
 		mono_gchandle_free (gchandle);
 		goto_if_nok (error, leave);
 		MONO_HANDLE_ASSIGN (result, res);

--- a/mono/metadata/sre-encode.c
+++ b/mono/metadata/sre-encode.c
@@ -239,7 +239,7 @@ encode_reflection_type (MonoDynamicImage *assembly, MonoReflectionTypeHandle typ
 
 	error_init (error);
 
-	if (!type) {
+	if (MONO_HANDLE_IS_NULL (type)) {
 		sigbuffer_add_value (buf, MONO_TYPE_VOID);
 		return;
 	}

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1487,7 +1487,7 @@ mono_thread_construct_internal (MonoThreadObjectHandle this_obj_handle)
 
 	internal->state = ThreadState_Unstarted;
 
-	int const thread_gchandle = mono_gchandle_from_handle ((MonoObjectHandle)this_obj_handle, TRUE);
+	int const thread_gchandle = mono_gchandle_from_handle (MONO_HANDLE_CAST (MonoObject, this_obj_handle), TRUE);
 
 	MonoThreadObject *this_obj = MONO_HANDLE_RAW (this_obj_handle);
 
@@ -1851,7 +1851,7 @@ byte_array_to_domain (MonoArrayHandle arr, MonoDomain *domain, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ()
 
-	if (!arr || MONO_HANDLE_IS_NULL (arr))
+	if (MONO_HANDLE_IS_NULL (arr))
 		return MONO_HANDLE_NEW (MonoArray, NULL);
 
 	if (MONO_HANDLE_DOMAIN (arr) == domain)

--- a/mono/metadata/w32file.c
+++ b/mono/metadata/w32file.c
@@ -515,7 +515,7 @@ ves_icall_System_IO_MonoIO_Read (HANDLE handle, MonoArrayHandle dest,
 
 	*io_error=ERROR_SUCCESS;
 
-	MONO_CHECK_ARG_NULL (dest, 0);
+	MONO_CHECK_ARG_NULL (MONO_HANDLE_RAW (dest), 0);
 
 	if (dest_offset > mono_array_handle_length (dest) - count) {
 		mono_error_set_argument (error, "array", "array too small. numBytes/offset wrong.");
@@ -547,7 +547,7 @@ ves_icall_System_IO_MonoIO_Write (HANDLE handle, MonoArrayHandle src,
 
 	*io_error=ERROR_SUCCESS;
 
-	MONO_CHECK_ARG_NULL (src, 0);
+	MONO_CHECK_ARG_NULL (MONO_HANDLE_RAW (src), 0);
 	
 	if (src_offset > mono_array_handle_length (src) - count) {
 		mono_error_set_argument (error, "array", "array too small. numBytes/offset wrong.");

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -1057,7 +1057,7 @@ ves_icall_System_Net_Sockets_Socket_LocalEndPoint_internal (gsize sock, gint32 a
 	salen = get_sockaddr_size (convert_family ((MonoAddressFamily)af));
 	if (salen == 0) {
 		*werror = WSAEAFNOSUPPORT;
-		return NULL;
+		return NULL_HANDLE;
 	}
 	sa = (salen <= 128) ? (gchar *)alloca (salen) : (gchar *)g_malloc0 (salen);
 
@@ -2013,7 +2013,7 @@ ves_icall_System_Net_Sockets_Socket_GetSocketOption_obj_internal (gsize sock, gi
 		obj_class = mono_class_load_from_name (mono_posix_image,
 						 "Mono.Posix",
 						 "PeerCredData");
-		MonoPeerCredDataHandle cred_data = (MonoPeerCredDataHandle)mono_object_new_handle (domain, obj_class, error);
+		MonoPeerCredDataHandle cred_data = MONO_HANDLE_CAST (MonoPeerCredData, mono_object_new_handle (domain, obj_class, error));
 		return_if_nok (error);
 
 		MONO_HANDLE_SETVAL (cred_data, pid, gint, cred.pid);

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -7271,8 +7271,8 @@ clean_path (gchar * path)
 	return clean;
 }
 
-static gchar *
-wrap_path (gchar * path)
+static const gchar *
+wrap_path (const gchar * path)
 {
 	int len;
 	if (!path)

--- a/mono/mini/exceptions-wasm.c
+++ b/mono/mini/exceptions-wasm.c
@@ -53,7 +53,7 @@ gpointer
 mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 {
 	if (info)
-		*info = mono_tramp_info_create ("call_filter", wasm_call_filter, 1, NULL, NULL);
+		*info = mono_tramp_info_create ("call_filter", (guint8*)wasm_call_filter, 1, NULL, NULL);
 	return wasm_call_filter;
 }
 
@@ -61,14 +61,14 @@ gpointer
 mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 {
 	if (info)
-		*info = mono_tramp_info_create ("restore_context", wasm_restore_context, 1, NULL, NULL);
+		*info = mono_tramp_info_create ("restore_context", (guint8*)wasm_restore_context, 1, NULL, NULL);
 	return wasm_restore_context;
 }
 gpointer 
 mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 {
 	if (info)
-		*info = mono_tramp_info_create ("throw_corlib_exception", wasm_throw_corlib_exception, 1, NULL, NULL);
+		*info = mono_tramp_info_create ("throw_corlib_exception", (guint8*)wasm_throw_corlib_exception, 1, NULL, NULL);
 	return wasm_throw_corlib_exception;
 }
 
@@ -76,7 +76,7 @@ gpointer
 mono_arch_get_rethrow_exception (MonoTrampInfo **info, gboolean aot)
 {
 	if (info)
-		*info = mono_tramp_info_create ("rethrow_exception", wasm_rethrow_exception, 1, NULL, NULL);
+		*info = mono_tramp_info_create ("rethrow_exception", (guint8*)wasm_rethrow_exception, 1, NULL, NULL);
 	return wasm_rethrow_exception;
 }
 
@@ -84,7 +84,7 @@ gpointer
 mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 {
 	if (info)
-		*info = mono_tramp_info_create ("throw_exception", wasm_throw_exception, 1, NULL, NULL);
+		*info = mono_tramp_info_create ("throw_exception", (guint8*)wasm_throw_exception, 1, NULL, NULL);
 	return wasm_throw_exception;
 }
 

--- a/mono/mini/tramp-wasm.c
+++ b/mono/mini/tramp-wasm.c
@@ -52,7 +52,7 @@ gpointer
 mono_arch_get_interp_to_native_trampoline (MonoTrampInfo **info)
 {
 	if (info)
-		*info = mono_tramp_info_create ("interp_to_native_trampoline", mono_wasm_interp_to_native_trampoline, 1, NULL, NULL);
+		*info = mono_tramp_info_create ("interp_to_native_trampoline", (guint8*)mono_wasm_interp_to_native_trampoline, 1, NULL, NULL);
 	return mono_wasm_interp_to_native_trampoline;
 }
 


### PR DESCRIPTION
Make coop handles typesafe.

Type-safe handles are a struct with a pointer to pointer.
The only operations allowed on them are the functions/macros in handle.h, and assignment
from same handle type to same handle type (which cannot be prohibited in C, but are ok anyway).

Type-unsafe handles are a pointer to a struct with a pointer.
Besides the type-safe operations, these can also be:
1. compared to NULL, instead of only MONO_HANDLE_IS_NULL
2. assigned from NULL, instead of only a handle
3. MONO_HANDLE_NEW (T) from anything, instead of only a T*
4. MONO_HANDLE_CAST from anything, instead of only another handle type
5. assigned from any void*, at least in C
6. Cast from any handle type to any handle type, without using MONO_HANDLE_CAST.
7. Cast from any handle type to any pointer type and vice versa, such as incorrect unboxing.
8. mono_object_class (handle), instead of mono_handle_class

None of those operations were likely intended and some are crashing sort of bugs,
esp. the last two, and possibly the use of NULL (NULL_HANDLE is not NULL, it is dereferencable,
yielding NULL).

There is no runtime cost.
NOTE: Running this code depends on the ABI to pass/return a struct
with a pointer the same as a pointer. This is tied in with
marshaling. If this is not the case, turn off type-safety, perhaps per-OS per-CPU. If it fails on all CPUs, make it a compile-only option. It is expected to actually work everywhere.