### PR TITLE
[runtime] Fix the freeing of BStr members in pinvoke.

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -5282,13 +5282,14 @@ mono_struct_delete_old (MonoClass *klass, char *ptr)
 			break;
 #endif
 		case MONO_MARSHAL_CONV_STR_LPSTR:
-		case MONO_MARSHAL_CONV_STR_BSTR:
 		case MONO_MARSHAL_CONV_STR_ANSIBSTR:
 		case MONO_MARSHAL_CONV_STR_TBSTR:
 		case MONO_MARSHAL_CONV_STR_UTF8STR:
 			mono_marshal_free (*(gpointer *)cpos);
 			break;
-
+		case MONO_MARSHAL_CONV_STR_BSTR:
+			mono_free_bstr (*(gpointer*)cpos);
+			break;
 		default:
 			continue;
 		}

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -7634,3 +7634,7 @@ mono_test_setjmp_and_call (VoidVoidCallback managedCallback, intptr_t *out_handl
 	}
 }
 
+LIBTEST_API void STDCALL
+mono_test_marshal_bstr (void *ptr)
+{
+}

--- a/mono/tests/marshal2.cs
+++ b/mono/tests/marshal2.cs
@@ -35,7 +35,8 @@ public class Tests {
 		public SimpleObj emb2;
 		public string s2;
 		public double x;
-		[MarshalAs (UnmanagedType.ByValArray, SizeConst=2)] public char[] a2;
+		[MarshalAs (UnmanagedType.ByValArray, SizeConst=2)]
+		public char[] a2;
 	}
 
 	[StructLayout (LayoutKind.Sequential, CharSet=CharSet.Ansi)]

--- a/mono/tests/pinvoke2.cs
+++ b/mono/tests/pinvoke2.cs
@@ -172,6 +172,13 @@ public unsafe class Tests {
 		}
 	}
 
+    [StructLayout(LayoutKind.Sequential)]
+    public struct BStrStruct
+    {
+        [MarshalAs(UnmanagedType.BStr)]
+        public string bstr;
+    }
+
 	[DllImport ("libnot-found", EntryPoint="not_found")]
 	public static extern int mono_library_not_found ();
 
@@ -2091,5 +2098,17 @@ public unsafe class Tests {
 			return 2;
 		return 0;
 	}
+
+	[DllImport ("libtest", EntryPoint="mono_test_marshal_bstr")]
+	public static extern int mono_test_marshal_bstr ([In] ref BStrStruct p);
+
+	public static int test_0_bstr () {
+		var p = new BStrStruct { bstr = "Hello" };
+
+		mono_test_marshal_bstr (ref p);
+
+		return 0;
+	}
+
 }
 


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/9010.