### PR TITLE
Revert "Disable flaky interp thread6 test. (#9059)"

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1319,7 +1319,6 @@ INTERP_DISABLED_TESTS = $(DISABLED_TESTS) \
 	tailcall/4.exe \
 	tailcall/8273.exe \
 	$(TAILCALL_DISABLED_TESTS_RUN) \
-	thread6.exe \
 	bug-60843.exe
 
 # bug-48015.exe: be careful when re-enabling, it happens that it returns with exit code 0, but doesn't actually execute the test.


### PR DESCRIPTION
This reverts commit 9bc218dc11d6d022743f5ddfecdf0ce2651c9118.
