### PR TITLE
[sgen] Use longs with nursery array fill

### DIFF
--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -5387,10 +5387,10 @@ mono_class_create_array_fill_type (void)
 	static gboolean inited = FALSE;
 
 	if (!inited) {
-		klass.element_class = mono_defaults.byte_class;
+		klass.element_class = mono_defaults.int64_class;
 		klass.rank = 1;
 		klass.instance_size = MONO_SIZEOF_MONO_ARRAY;
-		klass.sizes.element_size = 1;
+		klass.sizes.element_size = 8;
 		klass.size_inited = 1;
 		klass.name = "array_filler_type";
 

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -348,7 +348,7 @@ get_array_fill_vtable (void)
 
 		vtable->klass = klass;
 		bmap = 0;
-		vtable->gc_descr = mono_gc_make_descr_for_array (TRUE, &bmap, 0, 1);
+		vtable->gc_descr = mono_gc_make_descr_for_array (TRUE, &bmap, 0, 8);
 		vtable->rank = 1;
 
 		array_fill_vtable = vtable;
@@ -371,7 +371,9 @@ sgen_client_array_fill_range (char *start, size_t size)
 	/* Mark this as not a real object */
 	o->obj.synchronisation = (MonoThreadsSync *)GINT_TO_POINTER (-1);
 	o->bounds = NULL;
-	o->max_length = (mono_array_size_t)(size - MONO_SIZEOF_MONO_ARRAY);
+	/* We use array of int64 */
+	g_assert ((size - MONO_SIZEOF_MONO_ARRAY) % 8 == 0);
+	o->max_length = (mono_array_size_t)((size - MONO_SIZEOF_MONO_ARRAY) / 8);
 
 	return TRUE;
 }

--- a/mono/sgen/sgen-conf.h
+++ b/mono/sgen/sgen-conf.h
@@ -169,6 +169,15 @@ typedef mword SgenDescriptor;
 
 
 /*
+ * Max nursery size that we support.
+ *
+ * We depend on an array of longs to mark empty sections and we only support 4 byte indexes
+ */
+#if SIZEOF_VOID_P == 8
+#define SGEN_MAX_NURSERY_SIZE ((mword)1 << 35)
+#endif
+
+/*
  * Minimum allowance for nursery allocations, as a multiple of the size of nursery.
  *
  * We allow at least this much allocation to happen to the major heap from multiple

--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -3460,7 +3460,13 @@ sgen_gc_init (void)
 								"`nursery-size` must be at least %d bytes.", SGEN_MAX_NURSERY_WASTE);
 						continue;
 					}
-
+#ifdef SGEN_MAX_NURSERY_SIZE
+					if (val > SGEN_MAX_NURSERY_SIZE) {
+						sgen_env_var_error (MONO_GC_PARAMS_NAME, "Using default value.",
+								"`nursery-size` must be smaller than %lld bytes.", SGEN_MAX_NURSERY_SIZE);
+						continue;
+					}
+#endif
 					min_nursery_size = max_nursery_size = val;
 					dynamic_nursery = FALSE;
 				} else {


### PR DESCRIPTION
Hopefully this should allow us to support nurseries up to 32GB.

https://github.com/mono/mono/issues/9185

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
