### PR TITLE
[aot modes] rename FullAOT + interp and add interp-only mode

### DIFF
--- a/man/mono.1
+++ b/man/mono.1
@@ -244,9 +244,17 @@ any code generation at runtime.  This option only makes sense with \fBmscorlib.d
 Embedders can set
 
 .nf
-mono_jit_set_aot_mode (MONO_AOT_MODE_INTERP);
+mono_jit_set_aot_mode (MONO_AOT_MODE_FULL_INTERP);
 .fi
 .ne
+
+or,
+
+.nf
+mono_jit_set_aot_mode (MONO_AOT_MODE_INTERP_ONLY);
+.fi
+.ne
+
 .TP
 .I ld-flags
 Additional flags to pass to the C linker (if the current AOT mode calls for invoking it).

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1988,7 +1988,7 @@ mono_main (int argc, char* argv[])
 		} else if (strcmp (argv [i], "--hybrid-aot") == 0) {
 			mono_jit_set_aot_mode (MONO_AOT_MODE_HYBRID);
 		} else if (strcmp (argv [i], "--full-aot-interp") == 0) {
-			mono_jit_set_aot_mode (MONO_AOT_MODE_INTERP);
+			mono_jit_set_aot_mode (MONO_AOT_MODE_FULL_INTERP);
 		} else if (strcmp (argv [i], "--print-vtable") == 0) {
 			mono_print_vtable = TRUE;
 		} else if (strcmp (argv [i], "--stats") == 0) {
@@ -2599,7 +2599,7 @@ mono_runtime_set_execution_mode (MonoEEMode mode)
 		mono_set_partial_sharing_supported (TRUE);
 		break;
 
-	case MONO_AOT_MODE_INTERP:
+	case MONO_AOT_MODE_FULL_INTERP:
 		mono_aot_only = TRUE;
 		mono_use_interpreter = TRUE;
 
@@ -2614,6 +2614,7 @@ mono_runtime_set_execution_mode (MonoEEMode mode)
 		mono_ee_features.force_use_interpreter = TRUE;
 		break;
 
+	case MONO_AOT_MODE_INTERP_ONLY:
 	case MONO_EE_MODE_INTERP:
 		mono_use_interpreter = TRUE;
 

--- a/mono/mini/jit.h
+++ b/mono/mini/jit.h
@@ -55,11 +55,13 @@ typedef enum {
 	MONO_AOT_MODE_FULL,
 	/* Same as full, but use only llvm compiled code */
 	MONO_AOT_MODE_LLVMONLY,
-	/* Uses Interpreter, JIT is disabled and not allowed,
-	 * equivalent to "--full-aot --interpreter" */
-	MONO_AOT_MODE_INTERP,
+	/* Uses FullAOT and interpreter as fallback, JIT is disabled and not
+	 * allowed, equivalent to "--full-aot --interpreter" */
+	MONO_AOT_MODE_FULL_INTERP,
 	/* Same as INTERP, but use only llvm compiled code */
 	MONO_AOT_MODE_INTERP_LLVMONLY,
+	/* Force interpreter execution only */
+	MONO_AOT_MODE_INTERP_ONLY,
 	/* Sentinel value used internally by the runtime. We use a large number to avoid clashing with some internal values. */
 	MONO_AOT_MODE_LAST = 1000,
 } MonoAotMode;

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -2326,7 +2326,7 @@ lookup_start:
 	if (opt & MONO_OPT_AOT) {
 		MonoDomain *domain = NULL;
 
-		if (mono_aot_mode == MONO_AOT_MODE_INTERP && method->wrapper_type == MONO_WRAPPER_UNKNOWN) {
+		if (mono_aot_mode == MONO_AOT_MODE_FULL_INTERP && method->wrapper_type == MONO_WRAPPER_UNKNOWN) {
 			WrapperInfo *info = mono_marshal_get_wrapper_info (method);
 			g_assert (info);
 			if (info->subtype == WRAPPER_SUBTYPE_INTERP_IN || info->subtype == WRAPPER_SUBTYPE_INTERP_LMF)

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -221,8 +221,8 @@ mono_native_state_add_ee_info  (JsonWriter *writer)
 		/*case MONO_AOT_MODE_LLVMONLY:*/
 			/*aot_mode = "llvmonly";*/
 			/*break;*/
-		/*case MONO_AOT_MODE_INTERP:*/
-			/*aot_mode = "interp";*/
+		/*case MONO_AOT_MODE_FULL_INTERP:*/
+			/*aot_mode = "full_interp";*/
 			/*break;*/
 		/*case MONO_AOT_MODE_INTERP_LLVMONLY:*/
 			/*aot_mode = "interp_llvmonly";*/


### PR DESCRIPTION
usually we don't rename constants that are available via public API, but in this case `MONO_AOT_MODE_INTERP` wasn't available that long yet, so I argue we can still do it 😉 