### PR TITLE
[System]: `HttpWebRequest` now throws `WebExceptionStatus.RequestCanceled` on abort.  #9031.

### DIFF
--- a/mcs/class/System.Net.Http/Test/System.Net.Http/HttpClientTest.cs
+++ b/mcs/class/System.Net.Http/Test/System.Net.Http/HttpClientTest.cs
@@ -769,7 +769,7 @@ namespace MonoTests.System.Net.Http
 					client.SendAsync (request, HttpCompletionOption.ResponseHeadersRead).Wait ();
 					Assert.Fail ("#1");
 				} catch (AggregateException e) {
-					Assert.AreEqual (typeof (ProtocolViolationException), e.InnerException.GetType (), "#2");
+					Assert.AreEqual (typeof (InvalidOperationException), e.InnerException.GetType (), "#2");
 				}
 				Assert.IsNull (failed, "#102");
 			} finally {

--- a/mcs/class/System/System.Net/WebResponseStream.cs
+++ b/mcs/class/System/System.Net/WebResponseStream.cs
@@ -181,7 +181,7 @@ namespace System.Net
 				() => {
 					Operation.Abort ();
 					innerStream.Dispose ();
-				}, cancellationToken);
+				}, () => Operation.Aborted, cancellationToken);
 		}
 
 		bool CheckAuthHeader (string headerName)


### PR DESCRIPTION
Cleanup the internal `HttpWebRequest.RunWithTimeout()` function and use
`GetWebException()` everywhere to throw `WebException` with
`WebExceptionStatus.RequestCanceled` on abort.

New tests for this will be added to the web-tests by extending the existing
`Xamarin.WebTests.HttpInstrumentationTests.AbortDuringHandshake` to check the
synchronous and begin/end async APIs as well, using both `GET` and `POST`.

See https://github.com/xamarin/web-tests/blob/master/Xamarin.WebTests.Tests/Xamarin.WebTests.HttpInstrumentationTests/AbortDuringHandshake.cs.

Fixes issue #9031.
