### PR TITLE
[interp] add different API to enable interpreter in embedding scenario

### DIFF
--- a/man/mono.1
+++ b/man/mono.1
@@ -244,9 +244,13 @@ any code generation at runtime.  This option only makes sense with \fBmscorlib.d
 Embedders can set
 
 .nf
-mono_jit_set_aot_mode (MONO_AOT_MODE_INTERP);
+mono_jit_set_aot_mode (MONO_AOT_MODE_FULL);
+mono_runtime_use_interpreter (TRUE);
 .fi
 .ne
+
+in order to use it.
+
 .TP
 .I ld-flags
 Additional flags to pass to the C linker (if the current AOT mode calls for invoking it).

--- a/mono/mini/jit.h
+++ b/mono/mini/jit.h
@@ -55,17 +55,15 @@ typedef enum {
 	MONO_AOT_MODE_FULL,
 	/* Same as full, but use only llvm compiled code */
 	MONO_AOT_MODE_LLVMONLY,
-	/* Uses Interpreter, JIT is disabled and not allowed,
-	 * equivalent to "--full-aot --interpreter" */
-	MONO_AOT_MODE_INTERP,
-	/* Same as INTERP, but use only llvm compiled code */
-	MONO_AOT_MODE_INTERP_LLVMONLY,
 	/* Sentinel value used internally by the runtime. We use a large number to avoid clashing with some internal values. */
 	MONO_AOT_MODE_LAST = 1000,
 } MonoAotMode;
 
 MONO_API void
 mono_jit_set_aot_mode      (MonoAotMode mode);
+
+MONO_API void
+mono_runtime_use_interpreter (mono_bool enabled);
 
 /*
  * Returns whether the runtime was invoked for the purpose of AOT-compiling an

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -104,7 +104,7 @@ gboolean mono_aot_only = FALSE;
 /* Same as mono_aot_only, but only LLVM compiled code is used, no trampolines */
 gboolean mono_llvm_only = FALSE;
 MonoAotMode mono_aot_mode = MONO_AOT_MODE_NONE;
-MonoEEFeatures mono_ee_features;
+MonoEEFeatures mono_ee_features = {0};
 
 const char *mono_build_date;
 gboolean mono_do_signal_chaining;
@@ -2326,7 +2326,7 @@ lookup_start:
 	if (opt & MONO_OPT_AOT) {
 		MonoDomain *domain = NULL;
 
-		if (mono_aot_mode == MONO_AOT_MODE_INTERP && method->wrapper_type == MONO_WRAPPER_UNKNOWN) {
+		if (mono_aot_mode == MONO_AOT_MODE_FULL && mono_use_interpreter && method->wrapper_type == MONO_WRAPPER_UNKNOWN) {
 			WrapperInfo *info = mono_marshal_get_wrapper_info (method);
 			g_assert (info);
 			if (info->subtype == WRAPPER_SUBTYPE_INTERP_IN || info->subtype == WRAPPER_SUBTYPE_INTERP_LMF)

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -378,7 +378,8 @@ extern MonoEEFeatures mono_ee_features;
 //XXX this enum *MUST extend MonoAotMode as they are consumed together.
 typedef enum {
 	/* Always execute with interp, will use JIT to produce trampolines */
-	MONO_EE_MODE_INTERP = MONO_AOT_MODE_LAST,
+	MONO_EE_MODE_INTERP_ONLY = MONO_AOT_MODE_LAST,
+	MONO_EE_MODE_INTERP_FALLBACK,
 } MonoEEMode;
 
 

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -221,8 +221,8 @@ mono_native_state_add_ee_info  (JsonWriter *writer)
 		/*case MONO_AOT_MODE_LLVMONLY:*/
 			/*aot_mode = "llvmonly";*/
 			/*break;*/
-		/*case MONO_AOT_MODE_INTERP:*/
-			/*aot_mode = "interp";*/
+		/*case MONO_AOT_MODE_FULL_INTERP:*/
+			/*aot_mode = "full_interp";*/
 			/*break;*/
 		/*case MONO_AOT_MODE_INTERP_LLVMONLY:*/
 			/*aot_mode = "interp_llvmonly";*/

--- a/sdks/wasm/driver.c
+++ b/sdks/wasm/driver.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 
 
 typedef enum {
@@ -16,11 +17,6 @@ typedef enum {
 	MONO_AOT_MODE_FULL,
 	/* Same as full, but use only llvm compiled code */
 	MONO_AOT_MODE_LLVMONLY,
-	/* Uses Interpreter, JIT is disabled and not allowed,
-	 * equivalent to "--full-aot --interpreter" */
-	MONO_AOT_MODE_INTERP,
-	/* Same as INTERP, but use only llvm compiled code */
-	MONO_AOT_MODE_INTERP_LLVMONLY,
 } MonoAotMode;
 
 typedef enum {
@@ -84,11 +80,13 @@ typedef struct MonoArray_ MonoArray;
 typedef struct MonoThread_ MonoThread;
 typedef struct _MonoAssemblyName MonoAssemblyName;
 
+typedef int32_t mono_bool;
 
 //JS funcs
 extern MonoObject* mono_wasm_invoke_js_with_args (int js_handle, MonoString *method, MonoArray *args, int *is_exception);
 
 void mono_jit_set_aot_mode (MonoAotMode mode);
+void mono_runtime_use_interpreter (mono_bool enabled);
 MonoDomain*  mono_jit_init_version (const char *root_domain_name, const char *runtime_version);
 MonoAssembly* mono_assembly_open (const char *filename, MonoImageOpenStatus *status);
 int mono_jit_exec (MonoDomain *domain, MonoAssembly *assembly, int argc, char *argv[]);
@@ -198,7 +196,8 @@ mono_wasm_load_runtime (const char *managed_path, int enable_debugging)
 {
 	monoeg_g_setenv ("MONO_LOG_LEVEL", "debug", 1);
 	monoeg_g_setenv ("MONO_LOG_MASK", "gc", 1);
-	mono_jit_set_aot_mode (MONO_AOT_MODE_INTERP_LLVMONLY);
+	mono_jit_set_aot_mode (MONO_AOT_MODE_LLVMONLY);
+	mono_runtime_use_interpreter (1);
 	if (enable_debugging)
 		mono_wasm_enable_debugging ();
 	mono_set_assemblies_path (m_strdup (managed_path));


### PR DESCRIPTION
Squezzing the interpreter into `mono_jit_set_aot_mode` was hackish and
doesn't scale. `mono_runtime_use_interpreter` is orthogonal to
`mono_jit_set_aot_mode`. For example, if we want to add HybridAOT +
interpreter we don't need to add another AOT mode with this approach.

At the moment calling those two functions requires a certain order,
which we will get rid of in the future.
