### PR TITLE
Enable incompatible-pointer warnings on Windows/gcc like the other gcc.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5506,8 +5506,7 @@ AC_CONFIG_COMMANDS([quiet-libtool], [sed -e 's/echo "copying selected/# "copying
 AC_CONFIG_COMMANDS([nolock-libtool], [sed -e 's/lock_old_archive_extraction=yes/lock_old_archive_extraction=no/g' < libtool > libtool.tmp && mv libtool.tmp libtool && chmod a+x libtool])
 
 # Anything involving -Werror must be done late because autoconf depends on compiling with warnings to be success.
-# FIXME Windows builds have unrelated preexisting problems here.
-if test x"$GCC" = xyes -a x$host_win32 = xno; then
+if test x"$GCC" = xyes; then
 
 	# incompatible-pointer-types requires gcc circa 5.x
 

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -422,7 +422,7 @@ MONO_HANDLE_TYPECHECK_FOR (TYPE) (TYPE *a)			\
 // Otherwise we are forced to evaluate twice, or use C++.
 #ifdef _MSC_VER
 typedef struct _MonoTypeofCastHelper *MonoTypeofCastHelper; // a pointer type unrelated to anything else
-#define MONO_TYPEOF_CAST(typeexpr, expr) (0 ? (typeexpr) : (MonoTypeofCastHelper)(expr))
+#define MONO_TYPEOF_CAST(typeexpr, expr) __pragma(warning(suppress:4133))(0 ? (typeexpr) : (MonoTypeofCastHelper)(expr))
 #else
 #define MONO_TYPEOF_CAST(typeexpr, expr) ((typeof (typeexpr))(expr))
 #endif

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -3866,7 +3866,8 @@ mono_local_time (const struct timeval *tv, struct tm *tm) {
 #ifdef HAVE_LOCALTIME_R
 	localtime_r(&tv->tv_sec, tm);
 #else
-	*tm = *localtime(&tv->tv_sec);
+	time_t const tv_sec = tv->tv_sec; // Copy due to Win32/Posix contradiction.
+	*tm = *localtime (&tv_sec);
 #endif
 }
 

--- a/mono/metadata/w32file-win32.c
+++ b/mono/metadata/w32file-win32.c
@@ -87,7 +87,7 @@ mono_w32file_read(gpointer handle, gpointer buffer, guint32 numbytes, guint32 *b
 {
 	gboolean res;
 	MONO_ENTER_GC_SAFE;
-	res = ReadFile (handle, buffer, numbytes, bytesread, NULL);
+	res = ReadFile (handle, buffer, numbytes, (PDWORD)bytesread, NULL);
 	MONO_EXIT_GC_SAFE;
 	return res;
 }
@@ -97,7 +97,7 @@ mono_w32file_write (gpointer handle, gconstpointer buffer, guint32 numbytes, gui
 {
 	gboolean res;
 	MONO_ENTER_GC_SAFE;
-	res = WriteFile (handle, buffer, numbytes, byteswritten, NULL);
+	res = WriteFile (handle, buffer, numbytes, (PDWORD)byteswritten, NULL);
 	MONO_EXIT_GC_SAFE;
 	return res;
 }
@@ -127,7 +127,7 @@ mono_w32file_seek (gpointer handle, gint32 movedistance, gint32 *highmovedistanc
 {
 	guint32 res;
 	MONO_ENTER_GC_SAFE;
-	res = SetFilePointer (handle, movedistance, highmovedistance, method);
+	res = SetFilePointer (handle, movedistance, (PLONG)highmovedistance, method);
 	MONO_EXIT_GC_SAFE;
 	return res;
 }
@@ -371,7 +371,7 @@ mono_w32file_get_volume_information (const gunichar2 *path, gunichar2 *volumenam
 {
 	gboolean res;
 	MONO_ENTER_GC_SAFE;
-	res = GetVolumeInformation (path, volumename, volumesize, outserial, maxcomp, fsflags, fsbuffer, fsbuffersize);
+	res = GetVolumeInformation (path, volumename, volumesize, (PDWORD)outserial, (PDWORD)maxcomp, (PDWORD)fsflags, fsbuffer, fsbuffersize);
 	MONO_EXIT_GC_SAFE;
 	return res;
 }

--- a/mono/metadata/w32process-win32.c
+++ b/mono/metadata/w32process-win32.c
@@ -403,14 +403,14 @@ ves_icall_Microsoft_Win32_NativeMethods_TerminateProcess (gpointer handle, gint3
 MonoBoolean
 ves_icall_Microsoft_Win32_NativeMethods_GetExitCodeProcess (gpointer handle, gint32 *exitcode, MonoError *error)
 {
-	return GetExitCodeProcess (handle, exitcode);
+	return GetExitCodeProcess (handle, (PDWORD)exitcode);
 }
 
 #if G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT)
 static inline MonoBoolean
 mono_icall_get_process_working_set_size (gpointer handle, gsize *min, gsize *max)
 {
-	return GetProcessWorkingSetSize (handle, min, max);
+	return GetProcessWorkingSetSize (handle, (PSIZE_T)min, (PSIZE_T)max);
 }
 #endif /* G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT) */
 

--- a/mono/metadata/w32process.c
+++ b/mono/metadata/w32process.c
@@ -28,9 +28,9 @@ mono_w32process_get_pid (gpointer handle)
 }
 
 static gboolean
-mono_w32process_try_get_modules (gpointer process, gpointer *modules, guint32 size, guint32 *needed)
+mono_w32process_try_get_modules (gpointer process, HMODULE *modules, guint32 size, PDWORD needed)
 {
-	return EnumProcessModules (process, (HMODULE *) modules, size, (LPDWORD) needed);
+	return EnumProcessModules (process, modules, size, needed);
 }
 
 static guint32
@@ -54,7 +54,7 @@ mono_w32process_module_get_information (gpointer process, gpointer module, MODUL
 static gboolean
 mono_w32process_get_fileversion_info (gunichar2 *filename, gpointer *data)
 {
-	guint32 handle;
+	DWORD handle;
 	gsize datasize;
 
 	g_assert (data);

--- a/mono/metadata/w32semaphore-win32.c
+++ b/mono/metadata/w32semaphore-win32.c
@@ -35,7 +35,7 @@ ves_icall_System_Threading_Semaphore_CreateSemaphore_internal (gint32 initialCou
 MonoBoolean
 ves_icall_System_Threading_Semaphore_ReleaseSemaphore_internal (gpointer handle, gint32 releaseCount, gint32 *prevcount)
 { 
-	return ReleaseSemaphore (handle, releaseCount, (LPLONG)prevcount);
+	return ReleaseSemaphore (handle, releaseCount, (PLONG)prevcount);
 }
 
 gpointer

--- a/mono/metadata/w32semaphore-win32.c
+++ b/mono/metadata/w32semaphore-win32.c
@@ -35,7 +35,7 @@ ves_icall_System_Threading_Semaphore_CreateSemaphore_internal (gint32 initialCou
 MonoBoolean
 ves_icall_System_Threading_Semaphore_ReleaseSemaphore_internal (gpointer handle, gint32 releaseCount, gint32 *prevcount)
 { 
-	return ReleaseSemaphore (handle, releaseCount, prevcount);
+	return ReleaseSemaphore (handle, releaseCount, (LPLONG)prevcount);
 }
 
 gpointer

--- a/mono/metadata/w32socket-win32.c
+++ b/mono/metadata/w32socket-win32.c
@@ -177,7 +177,7 @@ int mono_w32socket_recvbuffers (SOCKET s, WSABUF *lpBuffers, guint32 dwBufferCou
 {
 	int ret = SOCKET_ERROR;
 	MONO_ENTER_GC_SAFE;
-	ALERTABLE_SOCKET_CALL (FD_READ_BIT, blocking, TRUE, ret, WSARecv, s, lpBuffers, dwBufferCount, lpNumberOfBytesRecvd, lpFlags, lpOverlapped, lpCompletionRoutine);
+	ALERTABLE_SOCKET_CALL (FD_READ_BIT, blocking, TRUE, ret, WSARecv, s, lpBuffers, dwBufferCount, (PDWORD)lpNumberOfBytesRecvd, (PDWORD)lpFlags, lpOverlapped, lpCompletionRoutine);
 	MONO_EXIT_GC_SAFE;
 	return ret;
 }
@@ -204,7 +204,7 @@ int mono_w32socket_sendbuffers (SOCKET s, WSABUF *lpBuffers, guint32 dwBufferCou
 {
 	int ret = SOCKET_ERROR;
 	MONO_ENTER_GC_SAFE;
-	ALERTABLE_SOCKET_CALL (FD_WRITE_BIT, blocking, TRUE, ret, WSASend, s, lpBuffers, dwBufferCount, lpNumberOfBytesRecvd, lpFlags, lpOverlapped, lpCompletionRoutine);
+	ALERTABLE_SOCKET_CALL (FD_WRITE_BIT, blocking, TRUE, ret, WSASend, s, lpBuffers, dwBufferCount, (PDWORD)lpNumberOfBytesRecvd, lpFlags, lpOverlapped, lpCompletionRoutine);
 	MONO_EXIT_GC_SAFE;
 	return ret;
 }

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -1772,7 +1772,7 @@ mono_arch_unwindinfo_init_method_unwind_info (gpointer cfg)
 }
 
 void
-mono_arch_unwindinfo_install_method_unwind_info (gpointer *monoui, gpointer code, guint code_size)
+mono_arch_unwindinfo_install_method_unwind_info (PUNWIND_INFO *monoui, gpointer code, guint code_size)
 {
 	PUNWIND_INFO unwindinfo, targetinfo;
 	guchar codecount;
@@ -1780,7 +1780,7 @@ mono_arch_unwindinfo_install_method_unwind_info (gpointer *monoui, gpointer code
 	if (!*monoui)
 		return;
 
-	unwindinfo = (PUNWIND_INFO)*monoui;
+	unwindinfo = *monoui;
 	targetlocation = (guint64)&(((guchar*)code)[code_size]);
 	targetinfo = (PUNWIND_INFO) ALIGN_TO(targetlocation, sizeof (mgreg_t));
 

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -203,7 +203,7 @@ typedef struct MonoCompileArch {
 	gint32 async_point_count;
 	gpointer vret_addr_loc;
 #ifdef HOST_WIN32
-	gpointer unwindinfo;
+	struct _UNWIND_INFO* unwindinfo;
 #endif
 	gpointer seq_point_info_var;
 	gpointer ss_trigger_page_var;
@@ -584,8 +584,10 @@ mono_arch_unwindinfo_free_unwind_info (PUNWIND_INFO unwind_info);
 guint
 mono_arch_unwindinfo_init_method_unwind_info (gpointer cfg);
 
+#ifdef MONO_ARCH_HAVE_UNWIND_TABLE
 void
-mono_arch_unwindinfo_install_method_unwind_info (gpointer *monoui, gpointer code, guint code_size);
+mono_arch_unwindinfo_install_method_unwind_info (PUNWIND_INFO *monoui, gpointer code, guint code_size);
+#endif
 
 void
 mono_arch_unwindinfo_install_tramp_unwind_info (GSList *unwind_ops, gpointer code, guint code_size);

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -584,10 +584,8 @@ mono_arch_unwindinfo_free_unwind_info (PUNWIND_INFO unwind_info);
 guint
 mono_arch_unwindinfo_init_method_unwind_info (gpointer cfg);
 
-#ifdef MONO_ARCH_HAVE_UNWIND_TABLE
 void
 mono_arch_unwindinfo_install_method_unwind_info (PUNWIND_INFO *monoui, gpointer code, guint code_size);
-#endif
 
 void
 mono_arch_unwindinfo_install_tramp_unwind_info (GSList *unwind_ops, gpointer code, guint code_size);

--- a/winconfig.h
+++ b/winconfig.h
@@ -713,7 +713,7 @@
 #pragma warning(disable:4273) // inconsistent dll linkage
 #pragma warning(disable:4293) // shift count negative or too big, undefined behavior
 #pragma warning(disable:4305) // truncation from 'double' to 'float'
-#pragma warning(disable:4312: // 'type cast': conversion from 'MonoNativeThreadId' to 'gpointer' of greater size
+#pragma warning(disable:4312) // 'type cast': conversion from 'MonoNativeThreadId' to 'gpointer' of greater size
 #pragma warning(disable:4389) // signed/unsigned mismatch
 #pragma warning(disable:4456) // declaration of 'j' hides previous local declaration
 #pragma warning(disable:4457) // declaration of 'text' hides function parameter

--- a/winconfig.h
+++ b/winconfig.h
@@ -713,6 +713,7 @@
 #pragma warning(disable:4273) // inconsistent dll linkage
 #pragma warning(disable:4293) // shift count negative or too big, undefined behavior
 #pragma warning(disable:4305) // truncation from 'double' to 'float'
+#pragma warning(disable:4312: // 'type cast': conversion from 'MonoNativeThreadId' to 'gpointer' of greater size
 #pragma warning(disable:4389) // signed/unsigned mismatch
 #pragma warning(disable:4456) // declaration of 'j' hides previous local declaration
 #pragma warning(disable:4457) // declaration of 'text' hides function parameter


### PR DESCRIPTION
And suppress new warnings from typesafe coop handles.
And suppress other warnings.