### PR TITLE
[runtime] Move accessors for hidden-yet-public debugger agent types into debugger-agent.h

### DIFF
--- a/mono/mini/debugger-agent.h
+++ b/mono/mini/debugger-agent.h
@@ -31,6 +31,22 @@ struct _MonoDebuggerCallbacks {
 };
 
 typedef struct _DebuggerTlsData DebuggerTlsData;
+typedef enum _MonoDebuggerThreadState MonoDebuggerThreadState;
+
+MonoGHashTable *
+mono_debugger_get_thread_states (void);
+
+gboolean
+mono_debugger_is_disconnected (void);
+
+gsize
+mono_debugger_tls_thread_id (DebuggerTlsData *debuggerTlsData);
+
+void
+mono_debugger_set_thread_state (DebuggerTlsData *ref, MonoDebuggerThreadState expected, MonoDebuggerThreadState set);
+
+MonoDebuggerThreadState
+mono_debugger_get_thread_state (DebuggerTlsData *ref);
 
 MONO_API void
 mono_debugger_agent_init (void);

--- a/mono/mini/debugger-engine.h
+++ b/mono/mini/debugger-engine.h
@@ -194,21 +194,6 @@ typedef int DbgEngineErrorCode;
 // Error codes MUST match those of sdb for now
 #define DE_ERR_NOT_IMPLEMENTED 100
 
-MonoGHashTable *
-mono_debugger_get_thread_states (void);
-
-gboolean
-mono_debugger_is_disconnected (void);
-
-gsize
-mono_debugger_tls_thread_id (DebuggerTlsData *debuggerTlsData);
-
-void
-mono_debugger_set_thread_state (DebuggerTlsData *ref, MonoDebuggerThreadState expected, MonoDebuggerThreadState set);
-
-MonoDebuggerThreadState
-mono_debugger_get_thread_state (DebuggerTlsData *ref);
-
 void mono_de_init (void);
 void mono_de_cleanup (void);
 void mono_de_set_log_level (int level, FILE *file);

--- a/mono/mini/debugger-state-machine.h
+++ b/mono/mini/debugger-state-machine.h
@@ -18,12 +18,12 @@
 #include <mono/utils/json.h>
 #include "debugger-agent.h"
 
-typedef enum {
+enum _MonoDebuggerThreadState {
 	MONO_DEBUGGER_STARTED = 0,
 	MONO_DEBUGGER_RESUMED = 1,
 	MONO_DEBUGGER_SUSPENDED = 2,
 	MONO_DEBUGGER_TERMINATED = 3,
-} MonoDebuggerThreadState;
+};
 
 void
 mono_debugger_log_init (void);


### PR DESCRIPTION
The code implementations of these functions live in debugger-agent.c.

Even though it makes the header seem more like it's a machine-generated way to wrap the
datatypes than the meaning-carrying MONO_API header, this will
allow for code which calls these functions to be moved between .c files
without having to change the header files.


