### PR TITLE
Make gensources.cs fail on missing files or zero-match wildcards

### DIFF
--- a/mcs/build/gensources.cs
+++ b/mcs/build/gensources.cs
@@ -168,7 +168,7 @@ public class ParseResult {
             )
                 continue;
 
-            var absolutePath = Path.Combine (entry.Directory, entry.Pattern);
+            var absolutePath = Path.Combine (entry.Directory, entry.Pattern).Trim ();
             var absoluteDirectory = Path.GetDirectoryName (absolutePath);
             var absolutePattern = Path.GetFileName (absolutePath);
 

--- a/mcs/build/gensources.cs
+++ b/mcs/build/gensources.cs
@@ -143,7 +143,8 @@ public class ParseResult {
 
         var relativeUri = Uri.UnescapeDataString (
             dirUri.MakeRelativeUri (pathUri).OriginalString
-        ).Replace ("/", SourcesParser.DirectorySeparator);
+        ).Replace ("/", SourcesParser.DirectorySeparator)
+         .Replace (SourcesParser.DirectorySeparator + SourcesParser.DirectorySeparator, SourcesParser.DirectorySeparator);
 
         if (SourcesParser.TraceLevel >= 4)
             Console.Error.WriteLine ($"// {fullPath} -> {relativeUri}");

--- a/mcs/build/gensources.cs
+++ b/mcs/build/gensources.cs
@@ -155,6 +155,7 @@ public class ParseResult {
         IEnumerable<ParseEntry> entries,
         string hostPlatformName, string profileName
     ) {
+        var patternChars = new [] { '*', '?' };
         foreach (var entry in entries) {
             if (
                 (hostPlatformName != null) &&
@@ -182,10 +183,25 @@ public class ParseResult {
                 continue;
             }
 
-            var matchingFiles = Directory.GetFiles (absoluteDirectory, absolutePattern);
-            foreach (var fileName in matchingFiles) {
-                var relativePath = GetRelativePath (fileName, LibraryDirectory);
-                yield return relativePath;
+            if (absolutePattern.IndexOfAny (patternChars) >= 0) {
+                var matchingFiles = Directory.GetFiles (absoluteDirectory, absolutePattern);
+                if (matchingFiles.Length == 0) {
+                    Console.Error.WriteLine ($"// No matches for pattern '{absolutePattern}'");
+                    ErrorCount += 1;
+                }
+
+                foreach (var fileName in matchingFiles) {
+                    var relativePath = GetRelativePath (fileName, LibraryDirectory);
+                    yield return relativePath;
+                }
+            } else {
+                if (!File.Exists (absolutePath)) {
+                    Console.Error.WriteLine ($"File does not exist: '{absolutePath}'");
+                    ErrorCount += 1;
+                } else {
+                    var relativePath = GetRelativePath (absolutePath, LibraryDirectory);
+                    yield return relativePath;
+                }
             }
         }
     }

--- a/mcs/build/library.make
+++ b/mcs/build/library.make
@@ -310,7 +310,7 @@ endif
 
 sourcefile = $(depsdir)/$(PROFILE_PLATFORM)_$(PROFILE)_$(LIBRARY_SUBDIR)_$(LIBRARY).sources
 $(sourcefile): $(PROFILE_sources) $(depsdir)/.stamp $(gensources)
-	$(GENSOURCES_RUNTIME) --debug $(gensources) "$@" "$(LIBRARY)" "$(PROFILE_PLATFORM)" "$(PROFILE)"
+	$(GENSOURCES_RUNTIME) --debug $(gensources) --strict "$@" "$(LIBRARY)" "$(PROFILE_PLATFORM)" "$(PROFILE)"
 
 library_CLEAN_FILES += $(sourcefile)
 


### PR DESCRIPTION
The gensources.cs currently checked in to master doesn't fail on missing files by default because it didn't work at the time. This turns that behavior on. It is currently only in my other in-progress branch so I'm moving it here.