### PR TITLE
Change getenv to g_getenv in sources build on Windows platforms.

### DIFF
--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1755,7 +1755,7 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsig
 	static char* verbose_method_name;
 
 	if (!verbose_method_inited) {
-		verbose_method_name = getenv ("MONO_VERBOSE_METHOD");
+		verbose_method_name = g_getenv ("MONO_VERBOSE_METHOD");
 		verbose_method_inited = TRUE;
 	}
 

--- a/mono/mini/main.c
+++ b/mono/mini/main.c
@@ -321,7 +321,9 @@ probe_embedded (const char *program, int *ref_argc, char **ref_argv [])
 		} else if (strncmp (kind, "options:", strlen ("options:")) == 0){
 			mono_parse_options_from (load_from_region (fd, offset, item_size), ref_argc, ref_argv);
 		} else if (strncmp (kind, "config_dir:", strlen ("config_dir:")) == 0){
-			mono_set_dirs (getenv ("MONO_PATH"), load_from_region (fd, offset, item_size));
+			char *mono_path_value = g_getenv ("MONO_PATH");
+			mono_set_dirs (mono_path_value, load_from_region (fd, offset, item_size));
+			g_free (mono_path_value);
 		} else if (strncmp (kind, "machineconfig:", strlen ("machineconfig:")) == 0) {
 			mono_register_machine_config (load_from_region (fd, offset, item_size));
 		} else if (strncmp (kind, "env:", strlen ("env:")) == 0){


### PR DESCRIPTION
There are Windows platforms (like UWP) that doesn't support getenv. The implementation of g_getenv makes it possible to replace the implementation at build time on none desktop platforms.
