### PR TITLE
[2018-06] [System]: Renegotiation in AppleTls requires OS X 10.12+.  #9234.

### DIFF
--- a/mcs/class/System/Mono.AppleTls/AppleTlsContext.cs
+++ b/mcs/class/System/Mono.AppleTls/AppleTlsContext.cs
@@ -341,9 +341,11 @@ namespace Mono.AppleTls
 				PeerDomainName = ServerName;
 			}
 
-			if (Options.AllowRenegotiation)
+			if (Options.AllowRenegotiation && Environment.OSVersion.Version >= MinRenegotiationVersion)
 				SetSessionOption (SslSessionOption.AllowRenegotiation, true);
 		}
+
+		static readonly Version MinRenegotiationVersion = new Version (16, 6);
 
 		void InitializeSession ()
 		{
@@ -956,7 +958,7 @@ namespace Mono.AppleTls
 #else
 				if (!IsServer)
 					return false;
-				if (Environment.OSVersion.Version < new Version (16, 6))
+				if (Environment.OSVersion.Version < MinRenegotiationVersion)
 					return false;
 				return true;
 #endif

--- a/mcs/class/System/Mono.AppleTls/AppleTlsContext.cs
+++ b/mcs/class/System/Mono.AppleTls/AppleTlsContext.cs
@@ -341,11 +341,18 @@ namespace Mono.AppleTls
 				PeerDomainName = ServerName;
 			}
 
-			if (Options.AllowRenegotiation && Environment.OSVersion.Version >= MinRenegotiationVersion)
+			if (Options.AllowRenegotiation && IsRenegotiationSupported ())
 				SetSessionOption (SslSessionOption.AllowRenegotiation, true);
 		}
 
-		static readonly Version MinRenegotiationVersion = new Version (16, 6);
+		static bool IsRenegotiationSupported ()
+		{
+#if MONOTOUCH
+			return false;
+#else
+			return Environment.OSVersion.Version >= new Version (16, 6);
+#endif
+		}
 
 		void InitializeSession ()
 		{
@@ -951,19 +958,7 @@ namespace Mono.AppleTls
 		extern static /* OSStatus */ SslStatus SSLReHandshake (/* SSLContextRef */ IntPtr context);
 #endif
 
-		public override bool CanRenegotiate {
-			get {
-#if MONOTOUCH
-				return false;
-#else
-				if (!IsServer)
-					return false;
-				if (Environment.OSVersion.Version < MinRenegotiationVersion)
-					return false;
-				return true;
-#endif
-			}
-		}
+		public override bool CanRenegotiate => IsServer && IsRenegotiationSupported ();
 
 		public override void Renegotiate ()
 		{


### PR DESCRIPTION
Backport of #9254.

/cc @baulig