### PR TITLE
Remove 3 unused incorrectly written functions.

### DIFF
--- a/mono/dis/get.c
+++ b/mono/dis/get.c
@@ -1002,8 +1002,9 @@ dis_stringify_method_signature_full (MonoImage *m, MonoMethodSignature *method, 
 	g_string_append (result_ret, " (");
 	g_free (retval);
 
-	g_string_prepend (result, result_ret->str);
-	g_string_free (result_ret, FALSE);
+	g_string_append (result_ret, result->str);
+	g_string_free (result, TRUE);
+	result = result_ret;
 
 	if (show_method_tokens && methoddef_row)
 		g_string_append_printf (result, " /* 0x%X */ ",

--- a/mono/eglib/eglib-remap.h
+++ b/mono/eglib/eglib-remap.h
@@ -94,7 +94,6 @@
 #define g_list_length monoeg_g_list_length
 #define g_list_nth monoeg_g_list_nth
 #define g_list_nth_data monoeg_g_list_nth_data
-#define g_list_prepend monoeg_g_list_prepend
 #define g_list_remove monoeg_g_list_remove
 #define g_list_remove_all monoeg_g_list_remove_all
 #define g_list_remove_link monoeg_g_list_remove_link
@@ -205,9 +204,7 @@
 #define g_string_append_unichar monoeg_g_string_append_unichar
 #define g_string_append_printf monoeg_g_string_append_printf
 #define g_string_append_vprintf monoeg_g_string_append_vprintf
-#define g_string_erase monoeg_g_string_erase
 #define g_string_free monoeg_g_string_free
-#define g_string_insert monoeg_g_string_insert
 #define g_string_new monoeg_g_string_new
 #define g_string_new_len monoeg_g_string_new_len
 #define g_string_prepend monoeg_g_string_prepend

--- a/mono/eglib/eglib-remap.h
+++ b/mono/eglib/eglib-remap.h
@@ -94,6 +94,7 @@
 #define g_list_length monoeg_g_list_length
 #define g_list_nth monoeg_g_list_nth
 #define g_list_nth_data monoeg_g_list_nth_data
+#define g_list_prepend monoeg_g_list_prepend
 #define g_list_remove monoeg_g_list_remove
 #define g_list_remove_all monoeg_g_list_remove_all
 #define g_list_remove_link monoeg_g_list_remove_link
@@ -207,7 +208,6 @@
 #define g_string_free monoeg_g_string_free
 #define g_string_new monoeg_g_string_new
 #define g_string_new_len monoeg_g_string_new_len
-#define g_string_prepend monoeg_g_string_prepend
 #define g_string_printf monoeg_g_string_printf
 #define g_string_set_size monoeg_g_string_set_size
 #define g_string_sized_new monoeg_g_string_sized_new

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -304,10 +304,7 @@ GString     *g_string_append_c      (GString *string, gchar c);
 GString     *g_string_append        (GString *string, const gchar *val);
 GString     *g_string_append_len    (GString *string, const gchar *val, gssize len);
 GString     *g_string_truncate      (GString *string, gsize len);
-GString     *g_string_prepend       (GString *string, const gchar *val);
-GString     *g_string_insert        (GString *string, gssize pos, const gchar *val);
 GString     *g_string_set_size      (GString *string, gsize len);
-GString     *g_string_erase         (GString *string, gssize pos, gssize len);
 
 #define g_string_sprintfa g_string_append_printf
 

--- a/mono/eglib/gstring.c
+++ b/mono/eglib/gstring.c
@@ -146,41 +146,6 @@ g_string_append_unichar (GString *string, gunichar c)
 	return g_string_append_len (string, utf8, len);
 }
 
-GString *
-g_string_prepend (GString *string, const gchar *val)
-{
-	gssize len;
-	
-	g_return_val_if_fail (string != NULL, string);
-	g_return_val_if_fail (val != NULL, string);
-
-	len = strlen (val);
-	
-	GROW_IF_NECESSARY(string, len);	
-	memmove(string->str + len, string->str, string->len + 1);
-	memcpy(string->str, val, len);
-
-	return string;
-}
-
-GString *
-g_string_insert (GString *string, gssize pos, const gchar *val)
-{
-	gssize len;
-	
-	g_return_val_if_fail (string != NULL, string);
-	g_return_val_if_fail (val != NULL, string);
-	g_return_val_if_fail (pos <= string->len, string);
-
-	len = strlen (val);
-	
-	GROW_IF_NECESSARY(string, len);	
-	memmove(string->str + pos + len, string->str + pos, string->len - pos - len + 1);
-	memcpy(string->str + pos, val, len);
-
-	return string;
-}
-
 void
 g_string_append_printf (GString *string, const gchar *format, ...)
 {
@@ -252,25 +217,5 @@ g_string_set_size (GString *string, gsize len)
 	
 	string->len = len;
 	string->str[len] = 0;
-	return string;
-}
-
-GString *
-g_string_erase (GString *string, gssize pos, gssize len)
-{
-	g_return_val_if_fail (string != NULL, string);
-
-	/* Silent return */
-	if (pos >= string->len)
-		return string;
-
-	if (len == -1 || (pos + len) >= string->len) {
-		string->str[pos] = 0;
-	}
-	else {
-		memmove (string->str + pos, string->str + pos + len, string->len - (pos + len) + 1);
-		string->len -= len;
-	}
-
 	return string;
 }

--- a/mono/eglib/test/string.c
+++ b/mono/eglib/test/string.c
@@ -150,38 +150,6 @@ test_truncate (void)
 }
 
 static RESULT
-test_prepend (void)
-{
-	GString *s = g_string_new ("dingus");
-	g_string_prepend (s, "one");
-
-	if (strcmp (s->str, "onedingus") != 0)
-		return FAILED ("Failed, expected onedingus, got [%s]", s->str);
-
-	g_string_free (s, TRUE);
-
-	/* This is to force the code that where stuff does not fit in the allocated block */
-	s = g_string_sized_new (1);
-	g_string_prepend (s, "one");
-	if (strcmp (s->str, "one") != 0)
-		return FAILED ("Got erroneous result, expected [one] got [%s]", s->str);
-	g_string_free (s, TRUE);
-
-	/* This is to force the path where things fit */
-	s = g_string_new ("123123123123123123123123");
-	g_string_truncate (s, 1);
-	if (strcmp (s->str, "1") != 0)
-		return FAILED ("Expected [1] string, got [%s]", s->str);
-
-	g_string_prepend (s, "pre");
-	if (strcmp (s->str, "pre1") != 0)
-		return FAILED ("Expected [pre1], got [%s]", s->str);
-	g_string_free (s, TRUE);
-	
-	return NULL;
-}
-
-static RESULT
 test_appendlen (void)
 {
 	GString *s = g_string_new ("");
@@ -228,7 +196,6 @@ static Test string_tests [] = {
 	{"ctor+append", test_gstring },
 	{"ctor+sized", test_sized },
 	{"truncate", test_truncate },
-	{"prepend", test_prepend },
 	{"append_len", test_appendlen },
 	{"macros", test_macros },
 	{NULL, NULL}


### PR DESCRIPTION
g_string_prepend does not update string->len.

g_string_insert does not update string->len, and copies the wrong number of characters around,
	and does not allow for overlapping parameters

g_string_erase does not always update string->len.
