### PR TITLE
[interp] Fix abort after finally block

### DIFF
--- a/mono/mini/interp/mintops.def
+++ b/mono/mini/interp/mintops.def
@@ -561,7 +561,6 @@ OPDEF(MINT_SDB_BREAKPOINT, "sdb_breakpoint", 1, MintOpNoArgs)
 OPDEF(MINT_LD_DELEGATE_METHOD_PTR, "ld_delegate_method_ptr", 1, MintOpNoArgs)
 
 OPDEF(MINT_START_ABORT_PROT, "start_abort_protected", 1, MintOpNoArgs)
-OPDEF(MINT_END_ABORT_PROT, "end_abort_protected", 1, MintOpNoArgs)
 
 /*
  * This needs to be an opcode because we need to trigger the enter event after

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1995,7 +1995,8 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsig
 			int index = td->clause_indexes [in_offset];
 			if (index != -1) {
 				MonoExceptionClause *clause = &header->clauses [index];
-				if (clause->flags == MONO_EXCEPTION_CLAUSE_FINALLY &&
+				if ((clause->flags == MONO_EXCEPTION_CLAUSE_FINALLY ||
+					clause->flags == MONO_EXCEPTION_CLAUSE_FAULT) &&
 						in_offset == clause->handler_offset)
 					ADD_CODE (td, MINT_START_ABORT_PROT);
 			}
@@ -3983,9 +3984,6 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsig
 			break;
 		case CEE_ENDFINALLY: {
 			g_assert (td->clause_indexes [in_offset] != -1);
-			MonoExceptionClause *clause = &header->clauses [td->clause_indexes [in_offset]];
-			if (clause->flags == MONO_EXCEPTION_CLAUSE_FINALLY)
-				ADD_CODE (td, MINT_END_ABORT_PROT);
 			td->sp = td->stack;
 			SIMPLE_OP (td, MINT_ENDFINALLY);
 			ADD_CODE (td, td->clause_indexes [in_offset]);

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1319,8 +1319,6 @@ INTERP_DISABLED_TESTS = $(DISABLED_TESTS) \
 	tailcall/4.exe \
 	tailcall/8273.exe \
 	$(TAILCALL_DISABLED_TESTS_RUN) \
-	thread6.exe \
-	thread7.exe \
 	bug-60843.exe
 
 # bug-48015.exe: be careful when re-enabling, it happens that it returns with exit code 0, but doesn't actually execute the test.


### PR DESCRIPTION
The throwing of the pending exception after the finally blocks are executed was in unreachable code.

Refactor the code a bit and exit the abort protected block directly in endfinally. We throw the abort after all guarding finally blocks were invoked, to avoid throwing from inside a finally block. Guard also fault handler, which are called from EH.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
