### PR TITLE
[runtime] Fix debugger dumping when unused

### DIFF
--- a/mono/mini/debugger-state-machine.c
+++ b/mono/mini/debugger-state-machine.c
@@ -306,7 +306,7 @@ dump_thread_state (gpointer key, gpointer value, gpointer user_data)
 void
 mono_debugger_state (JsonWriter *writer)
 {
-	if (debugger_log == GINT_TO_POINTER (MONO_DEBUGGER_LOG_UNINIT))
+	if (!debugger_log || debugger_log == GINT_TO_POINTER (MONO_DEBUGGER_LOG_UNINIT))
 		return;
 
 	mono_coop_mutex_lock (&debugger_log_mutex);
@@ -435,7 +435,7 @@ mono_debugger_state (JsonWriter *writer)
 char *
 mono_debugger_state_str (void)
 {
-	if (debugger_log == GINT_TO_POINTER (MONO_DEBUGGER_LOG_UNINIT))
+	if (!debugger_log || debugger_log == GINT_TO_POINTER (MONO_DEBUGGER_LOG_UNINIT))
 		return NULL;
 
 	JsonWriter writer;


### PR DESCRIPTION
Somewhere in the daily rebasing to edit the PR, I lost the correct version of the early-exit. This fixes our native crash when we did not use the debugger. It's important to merge, or we'll crash before MERP/gdb dumping happens. 