### PR TITLE
Cleanup some confusing code.

### DIFF
--- a/mono/metadata/w32event-unix.c
+++ b/mono/metadata/w32event-unix.c
@@ -112,7 +112,7 @@ static gsize namedevent_typesize (void)
 void
 mono_w32event_init (void)
 {
-	static MonoW32HandleOps event_ops = {
+	static const MonoW32HandleOps event_ops = {
 		NULL,			/* close */
 		event_handle_signal,		/* signal */
 		event_handle_own,		/* own */
@@ -124,7 +124,7 @@ mono_w32event_init (void)
 		event_typesize, /* typesize */
 	};
 
-	static MonoW32HandleOps namedevent_ops = {
+	static const MonoW32HandleOps namedevent_ops = {
 		NULL,			/* close */
 		event_handle_signal,	/* signal */
 		event_handle_own,		/* own */

--- a/mono/metadata/w32handle.h
+++ b/mono/metadata/w32handle.h
@@ -56,7 +56,7 @@ typedef enum {
 
 typedef struct 
 {
-	void (*close)(gpointer handle, gpointer data);
+	void (*close)(gpointer data);
 
 	/* mono_w32handle_signal_and_wait */
 	void (*signal)(MonoW32Handle *handle_data);
@@ -112,7 +112,7 @@ void
 mono_w32handle_cleanup (void);
 
 void
-mono_w32handle_register_ops (MonoW32Type type, MonoW32HandleOps *ops);
+mono_w32handle_register_ops (MonoW32Type type, const MonoW32HandleOps *ops);
 
 gpointer
 mono_w32handle_new (MonoW32Type type, gpointer handle_specific);

--- a/mono/metadata/w32mutex-unix.c
+++ b/mono/metadata/w32mutex-unix.c
@@ -213,7 +213,7 @@ static gsize namedmutex_typesize (void)
 void
 mono_w32mutex_init (void)
 {
-	static MonoW32HandleOps mutex_ops = {
+	static const MonoW32HandleOps mutex_ops = {
 		NULL,			/* close */
 		mutex_handle_signal,	/* signal */
 		mutex_handle_own,	/* own */
@@ -225,7 +225,7 @@ mono_w32mutex_init (void)
 		mutex_typesize,	/* typesize */
 	};
 
-	static MonoW32HandleOps namedmutex_ops = {
+	static const MonoW32HandleOps namedmutex_ops = {
 		NULL,			/* close */
 		mutex_handle_signal,	/* signal */
 		mutex_handle_own,	/* own */

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -754,7 +754,7 @@ processes_cleanup (void)
 }
 
 static void
-process_close (gpointer handle, gpointer data)
+process_close (gpointer data)
 {
 	MonoW32HandleProcess *process_handle;
 
@@ -768,7 +768,7 @@ process_close (gpointer handle, gpointer data)
 	processes_cleanup ();
 }
 
-static MonoW32HandleOps process_ops = {
+static const MonoW32HandleOps process_ops = {
 	process_close,		/* close_shared */
 	NULL,				/* signal */
 	NULL,				/* own */

--- a/mono/metadata/w32semaphore-unix.c
+++ b/mono/metadata/w32semaphore-unix.c
@@ -103,7 +103,7 @@ static gsize namedsema_typesize (void)
 void
 mono_w32semaphore_init (void)
 {
-	static MonoW32HandleOps sem_ops = {
+	static const MonoW32HandleOps sem_ops = {
 		NULL,			/* close */
 		sem_handle_signal,		/* signal */
 		sem_handle_own,		/* own */
@@ -115,7 +115,7 @@ mono_w32semaphore_init (void)
 		sema_typesize,	/* typesize */
 	};
 
-	static MonoW32HandleOps namedsem_ops = {
+	static const MonoW32HandleOps namedsem_ops = {
 		NULL,			/* close */
 		sem_handle_signal,	/* signal */
 		sem_handle_own,		/* own */


### PR DESCRIPTION
  Had additional restructure not been ok, at least typedefing the function pointer
  would have helped.

Add const for efficiency -- make the copy-on-write faults count for more and
  not take extra readonly data with them.

Remove unused and actually confusing parameter -- it is just zeroed memory
and almost cannot be used for anything (granted, could hash it).