### PR TITLE
[corlib] Additional HashAlgorithm tests

### DIFF
--- a/mcs/class/corlib/Test/System.Security.Cryptography/HashAlgorithmTestBase.cs
+++ b/mcs/class/corlib/Test/System.Security.Cryptography/HashAlgorithmTestBase.cs
@@ -467,6 +467,43 @@ public abstract class HashAlgorithmTestBase {
 		hash.TransformFinalBlock (input, 0, input.Length);
 		Assert.IsNotNull (hash.Hash);
 	}
+
+	[Test]
+	public void Hash_NoExternalChanges ()
+	{
+		byte[] input = new byte [512];
+		for (int i = 0; i < input.Length; i++)
+			input[i] = (byte)(i % 0xFF);
+		hash.TransformFinalBlock (input, 0, input.Length);
+
+		byte[] brokenHash = hash.Hash;
+		Array.Clear (brokenHash, 0, brokenHash.Length);
+
+		// if the byte array is returned as a ref, both instance will be cleared.
+		Assert.AreNotEqual (hash.Hash, brokenHash, "ExternalChanges");
+	}
+
+	[Test]
+	[ExpectedException (typeof (ObjectDisposedException))]
+	public void Hash_DisposedException ()
+	{
+		hash.Dispose ();
+		// should fail since the hash object is disposed.
+		Assert.IsNull (hash.Hash);
+	}
+
+	[Test]
+	[ExpectedException (typeof (CryptographicUnexpectedOperationException))]
+	public void Hash_StateExeception ()
+	{
+		hash.Initialize ();
+		byte[] input = new byte [8];
+		byte[] output = new byte [8];
+		hash.TransformBlock (input, 0, input.Length, output, 0);
+
+		// should fail with CryptographicUnexpectedOperationException as TransformFinalBlock was not called.
+		Assert.IsNull (hash.Hash);
+	}
 }
 
 }

--- a/mcs/class/corlib/Test/System.Security.Cryptography/RSAPKCS1SignatureDeformatterTest.cs
+++ b/mcs/class/corlib/Test/System.Security.Cryptography/RSAPKCS1SignatureDeformatterTest.cs
@@ -363,14 +363,14 @@ namespace MonoTests.System.Security.Cryptography {
 			badSignature[0] = (byte) ~md5Signature [0];
 			HashAlgorithm hash = MD5.Create ();
 			try {
-				fmt.VerifySignature (hash, md5Signature);
+				fmt.VerifySignature (hash, badSignature);
 				Assert.Fail ("VerifyBadSignatureMD5Hash - Expected CryptographicUnexpectedOperationException but none");
 			}
 			catch (CryptographicUnexpectedOperationException) {
 				// this was expected
 			}
 			catch (NullReferenceException) {
-				// this wasn't expected - but that's the result from framework 1.1
+				// this wasn't expected - but that's the result from .NET Framework
 			}
 			catch (Exception e) {
 				Assert.Fail ("VerifyBadSignatureMD5Hash - Expected CryptographicUnexpectedOperationException but got: " + e.ToString ());
@@ -385,14 +385,14 @@ namespace MonoTests.System.Security.Cryptography {
 			byte[] badSignature = new byte [md5Signature.Length-1];
 			HashAlgorithm hash = MD5.Create ();
 			try {
-				fmt.VerifySignature (hash, md5Signature);
+				fmt.VerifySignature (hash, badSignature);
 				Assert.Fail ("VerifySignatureMD5HashBadSignatureLength - Expected CryptographicUnexpectedOperationException but none");
 			}
 			catch (CryptographicUnexpectedOperationException) {
 				// this was expected
 			}
 			catch (NullReferenceException) {
-				// this wasn't expected - but that's the result from framework 1.1
+				// this wasn't expected - but that's the result from .NET Framework
 			}
 			catch (Exception e) {
 				Assert.Fail ("VerifySignatureMD5HashBadSignatureLength - Expected CryptographicUnexpectedOperationException but got: " + e.ToString ());


### PR DESCRIPTION
Originated from PR #1283, they now pass because we're using referencesource code for the hash algorithm classes now.

In RSAPKCS1SignatureDeformatterTest.cs we weren't testing against the actual `badSignature` (it doesn't make a difference since the referencesource code or .NET Framework throws NullReferenceException anyway, but is more correct).

Closes #1283
