### PR TITLE
[runtime] Second batch of GC Unsafe thread state transitions for the MONO_API

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -197,7 +197,7 @@ create_domain_objects (MonoDomain *domain)
 	 */
 	string_vt = mono_class_vtable_checked (domain, mono_defaults.string_class, error);
 	mono_error_assert_ok (error);
-	string_empty_fld = mono_class_get_field_from_name (mono_defaults.string_class, "Empty");
+	string_empty_fld = mono_class_get_field_from_name_full (mono_defaults.string_class, "Empty", NULL);
 	g_assert (string_empty_fld);
 	MonoString *empty_str = mono_string_new_checked (domain, "", error);
 	mono_error_assert_ok (error);
@@ -356,7 +356,7 @@ mono_get_corlib_version (void)
 
 	klass = mono_class_load_from_name (mono_defaults.corlib, "System", "Environment");
 	mono_class_init (klass);
-	field = mono_class_get_field_from_name (klass, "mono_corlib_version");
+	field = mono_class_get_field_from_name_full (klass, "mono_corlib_version", NULL);
 	if (!field)
 		goto exit;
 
@@ -395,7 +395,7 @@ mono_check_corlib_version_internal (void)
 
 	/* Check that the managed and unmanaged layout of MonoInternalThread matches */
 	guint32 native_offset = (guint32) MONO_STRUCT_OFFSET (MonoInternalThread, last);
-	guint32 managed_offset = mono_field_get_offset (mono_class_get_field_from_name (mono_defaults.internal_thread_class, "last"));
+	guint32 managed_offset = mono_field_get_offset (mono_class_get_field_from_name_full (mono_defaults.internal_thread_class, "last", NULL));
 	if (native_offset != managed_offset)
 		return g_strdup_printf ("expected InternalThread.last field offset %u, found %u. See InternalThread.last comment", native_offset, managed_offset);
 
@@ -719,7 +719,7 @@ mono_domain_has_type_resolve (MonoDomain *domain)
 	MonoObject *o;
 
 	if (field == NULL) {
-		field = mono_class_get_field_from_name (mono_defaults.appdomain_class, "TypeResolve");
+		field = mono_class_get_field_from_name_full (mono_defaults.appdomain_class, "TypeResolve", NULL);
 		g_assert (field);
 	}
 
@@ -1357,7 +1357,7 @@ mono_domain_fire_assembly_load (MonoAssembly *assembly, gpointer user_data)
 	mono_domain_assemblies_unlock (domain);
 
 	if (assembly_load_field == NULL) {
-		assembly_load_field = mono_class_get_field_from_name (klass, "AssemblyLoad");
+		assembly_load_field = mono_class_get_field_from_name_full (klass, "AssemblyLoad", NULL);
 		g_assert (assembly_load_field);
 	}
 

--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -25,6 +25,9 @@ typedef enum {
 	MONO_ANAME_EQ_MASK = 0x7
 } MonoAssemblyNameEqFlags;
 
+void
+mono_assembly_name_free_internal (MonoAssemblyName *aname);
+
 gboolean
 mono_assembly_names_equal_flags (MonoAssemblyName *l, MonoAssemblyName *r, MonoAssemblyNameEqFlags flags);
 

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -2759,6 +2759,16 @@ mono_assembly_load_from (MonoImage *image, const char *fname,
 void
 mono_assembly_name_free (MonoAssemblyName *aname)
 {
+	MONO_ENTER_GC_UNSAFE;
+	mono_assembly_name_free_internal (aname);
+	MONO_EXIT_GC_UNSAFE;
+}
+
+void
+mono_assembly_name_free_internal (MonoAssemblyName *aname)
+{
+	MONO_REQ_GC_UNSAFE_MODE;
+
 	if (aname == NULL)
 		return;
 

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -3183,11 +3183,15 @@ mono_assembly_name_parse (const char *name, MonoAssemblyName *aname)
 MonoAssemblyName*
 mono_assembly_name_new (const char *name)
 {
+	MonoAssemblyName *result = NULL;
+	MONO_ENTER_GC_UNSAFE;
 	MonoAssemblyName *aname = g_new0 (MonoAssemblyName, 1);
 	if (mono_assembly_name_parse (name, aname))
-		return aname;
-	g_free (aname);
-	return NULL;
+		result = aname;
+	else
+		g_free (aname);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
 }
 
 /**

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -3200,7 +3200,11 @@ mono_assembly_name_new (const char *name)
 const char*
 mono_assembly_name_get_name (MonoAssemblyName *aname)
 {
-	return aname->name;
+	const char *result = NULL;
+	MONO_ENTER_GC_UNSAFE;
+	result = aname->name;
+	MONO_EXIT_GC_UNSAFE;
+	return result;
 }
 
 /**

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -3213,7 +3213,11 @@ mono_assembly_name_get_name (MonoAssemblyName *aname)
 const char*
 mono_assembly_name_get_culture (MonoAssemblyName *aname)
 {
-	return aname->culture;
+	const char *result = NULL;
+	MONO_ENTER_GC_UNSAFE;
+	result = aname->culture;
+	MONO_EXIT_GC_UNSAFE;
+	return result;
 }
 
 /**

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -1611,7 +1611,7 @@ test_toggleref_callback (MonoObject *obj)
 	MonoToggleRefStatus status = MONO_TOGGLE_REF_DROP;
 
 	if (!mono_toggleref_test_field) {
-		mono_toggleref_test_field = mono_class_get_field_from_name (mono_object_get_class (obj), "__test");
+		mono_toggleref_test_field = mono_class_get_field_from_name_full (mono_object_get_class (obj), "__test", NULL);
 		g_assert (mono_toggleref_test_field);
 	}
 

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1192,6 +1192,9 @@ mono_class_get_field_from_name_full (MonoClass *klass, const char *name, MonoTyp
 MonoVTable*
 mono_class_vtable_checked (MonoDomain *domain, MonoClass *klass, MonoError *error);
 
+void
+mono_class_is_assignable_from_checked (MonoClass *klass, MonoClass *oklass, gboolean *result, MonoError *error);
+
 gboolean
 mono_class_is_assignable_from_slow (MonoClass *target, MonoClass *candidate);
 

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -3435,9 +3435,11 @@ gboolean
 mono_class_is_assignable_from (MonoClass *klass, MonoClass *oklass)
 {
 	gboolean result = FALSE;
+	MONO_ENTER_GC_UNSAFE;
 	ERROR_DECL (error);
 	mono_class_is_assignable_from_checked (klass, oklass, &result, error);
 	mono_error_cleanup (error);
+	MONO_EXIT_GC_UNSAFE;
 	return result;
 }
 

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -65,6 +65,8 @@ static gboolean can_access_type (MonoClass *access_klass, MonoClass *member_klas
 static char* mono_assembly_name_from_token (MonoImage *image, guint32 type_token);
 static guint32 mono_field_resolve_flags (MonoClassField *field);
 
+static MonoProperty* mono_class_get_property_from_name_internal (MonoClass *klass, const char *name);
+
 static
 MonoImage *
 mono_method_get_image (MonoMethod *method)
@@ -2329,6 +2331,17 @@ mono_class_get_event_token (MonoEvent *event)
 MonoProperty*
 mono_class_get_property_from_name (MonoClass *klass, const char *name)
 {
+	MonoProperty *result = NULL;
+	MONO_ENTER_GC_UNSAFE;
+	result = mono_class_get_property_from_name_internal (klass, name);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
+}
+
+MonoProperty*
+mono_class_get_property_from_name_internal (MonoClass *klass, const char *name)
+{
+	MONO_REQ_GC_UNSAFE_MODE;
 	while (klass) {
 		MonoProperty* p;
 		gpointer iter = NULL;

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -67,6 +67,8 @@ static guint32 mono_field_resolve_flags (MonoClassField *field);
 
 static MonoProperty* mono_class_get_property_from_name_internal (MonoClass *klass, const char *name);
 
+static MonoClass *mono_class_from_mono_type_internal (MonoType *type);
+
 static
 MonoImage *
 mono_method_get_image (MonoMethod *method)
@@ -1812,6 +1814,16 @@ mono_ptr_class_get (MonoType *type)
  */
 MonoClass *
 mono_class_from_mono_type (MonoType *type)
+{
+	MonoClass *result;
+	MONO_ENTER_GC_UNSAFE;
+	result = mono_class_from_mono_type_internal (type);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
+}
+
+MonoClass *
+mono_class_from_mono_type_internal (MonoType *type)
 {
 	switch (type->type) {
 	case MONO_TYPE_OBJECT:

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -5015,12 +5015,12 @@ mono_find_method_in_metadata (MonoClass *klass, const char *name, int param_coun
 MonoMethod *
 mono_class_get_method_from_name_flags (MonoClass *klass, const char *name, int param_count, int flags)
 {
+	MonoMethod *method;
+	MONO_ENTER_GC_UNSAFE;
 	ERROR_DECL (error);
-	error_init (error);
-
-	MonoMethod * const method = mono_class_get_method_from_name_checked (klass, name, param_count, flags, error);
-
+	method = mono_class_get_method_from_name_checked (klass, name, param_count, flags, error);
 	mono_error_cleanup (error);
+	MONO_EXIT_GC_UNSAFE;
 	return method;
 }
 

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -4950,9 +4950,11 @@ MonoMethod *
 mono_class_get_method_from_name (MonoClass *klass, const char *name, int param_count)
 {
 	MonoMethod *result;
+	MONO_ENTER_GC_UNSAFE;
 	ERROR_DECL (error);
 	result = mono_class_get_method_from_name_checked (klass, name, param_count, 0, error);
 	mono_error_cleanup (error);
+	MONO_EXIT_GC_UNSAFE;
 	return result;
 }
 

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -2122,7 +2122,11 @@ mono_class_get_field (MonoClass *klass, guint32 field_token)
 MonoClassField *
 mono_class_get_field_from_name (MonoClass *klass, const char *name)
 {
-	return mono_class_get_field_from_name_full (klass, name, NULL);
+	MonoClassField *result;
+	MONO_ENTER_GC_UNSAFE;
+	result = mono_class_get_field_from_name_full (klass, name, NULL);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
 }
 
 /**
@@ -2141,6 +2145,8 @@ mono_class_get_field_from_name (MonoClass *klass, const char *name)
 MonoClassField *
 mono_class_get_field_from_name_full (MonoClass *klass, const char *name, MonoType *type)
 {
+	MONO_REQ_GC_UNSAFE_MODE;
+
 	int i;
 
 	mono_class_setup_fields (klass);

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -83,6 +83,7 @@ mono_ptr_class_get         (MonoType *type);
 MONO_API MonoClassField *
 mono_class_get_field       (MonoClass *klass, uint32_t field_token);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoClassField *
 mono_class_get_field_from_name (MonoClass *klass, const char *name);
 

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -273,7 +273,7 @@ mono_event_get_parent        (MonoEvent *event);
 MONO_API uint32_t
 mono_event_get_flags         (MonoEvent *event);
 
-MONO_API MonoMethod *
+MONO_RT_EXTERNAL_ONLY MONO_API MonoMethod *
 mono_class_get_method_from_name (MonoClass *klass, const char *name, int param_count);
 
 MONO_API char *

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -39,7 +39,7 @@ mono_class_from_name       (MonoImage *image, const char* name_space, const char
 MONO_RT_EXTERNAL_ONLY MONO_API MonoClass *
 mono_class_from_name_case  (MonoImage *image, const char* name_space, const char *name);
 
-MONO_API MonoMethod *
+MONO_RT_EXTERNAL_ONLY MONO_API MonoMethod *
 mono_class_get_method_from_name_flags (MonoClass *klass, const char *name, int param_count, int flags);
 
 MONO_RT_EXTERNAL_ONLY

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -726,8 +726,11 @@ mono_cominterop_emit_ptr_to_object_conv (MonoMethodBuilder *mb, MonoType *type, 
 		mono_mb_emit_icall (mb, cominterop_get_ccw_object);
 		pos_ccw = mono_mb_emit_short_branch (mb, CEE_BRTRUE_S);
 
-		if (!com_interop_proxy_get_proxy)
-			com_interop_proxy_get_proxy = mono_class_get_method_from_name_flags (mono_class_get_interop_proxy_class (), "GetProxy", 2, METHOD_ATTRIBUTE_PRIVATE);
+		if (!com_interop_proxy_get_proxy) {
+			ERROR_DECL (error);
+			com_interop_proxy_get_proxy = mono_class_get_method_from_name_checked (mono_class_get_interop_proxy_class (), "GetProxy", 2, METHOD_ATTRIBUTE_PRIVATE, error);
+			mono_error_assert_ok (error);
+		}
 #ifndef DISABLE_REMOTING
 		if (!get_transparent_proxy)
 			get_transparent_proxy = mono_class_get_method_from_name (mono_defaults.real_proxy_class, "GetTransparentProxy", 0);

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -506,8 +506,10 @@ static void cominterop_set_hr_error (MonoError *oerror, int hr)
 	MonoException* ex;
 	void* params[1] = {&hr};
 
-	if (!throw_exception_for_hr)
-		throw_exception_for_hr = mono_class_get_method_from_name (mono_defaults.marshal_class, "GetExceptionForHR", 1);
+	if (!throw_exception_for_hr) {
+		throw_exception_for_hr = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "GetExceptionForHR", 1, 0, error);
+		mono_error_assert_ok (error);
+	}
 
 	ex = (MonoException*)mono_runtime_invoke_checked (throw_exception_for_hr, NULL, params, error);
 	mono_error_assert_ok (error);
@@ -732,8 +734,11 @@ mono_cominterop_emit_ptr_to_object_conv (MonoMethodBuilder *mb, MonoType *type, 
 			mono_error_assert_ok (error);
 		}
 #ifndef DISABLE_REMOTING
-		if (!get_transparent_proxy)
-			get_transparent_proxy = mono_class_get_method_from_name (mono_defaults.real_proxy_class, "GetTransparentProxy", 0);
+		if (!get_transparent_proxy) {
+			ERROR_DECL (error);
+			get_transparent_proxy = mono_class_get_method_from_name_checked (mono_defaults.real_proxy_class, "GetTransparentProxy", 0, 0, error);
+			mono_error_assert_ok (error);
+		}
 #endif
 
 		mono_mb_add_local (mb, m_class_get_byval_arg (mono_class_get_interop_proxy_class ()));
@@ -1013,8 +1018,11 @@ mono_cominterop_get_native_wrapper (MonoMethod *method)
 		if (!strcmp(method->name, ".ctor")) {
 			static MonoMethod *ctor = NULL;
 
-			if (!ctor)
-				ctor = mono_class_get_method_from_name (mono_class_get_com_object_class (), ".ctor", 0);
+			if (!ctor) {
+				ERROR_DECL (error);
+				ctor = mono_class_get_method_from_name_checked (mono_class_get_com_object_class (), ".ctor", 0, 0, error);
+				mono_error_assert_ok (error);
+			}
 			mono_mb_emit_ldarg (mb, 0);
 			mono_mb_emit_managed_call (mb, ctor, NULL);
 			mono_mb_emit_byte (mb, CEE_RET);
@@ -1068,8 +1076,11 @@ mono_cominterop_get_native_wrapper (MonoMethod *method)
 			mono_mb_emit_managed_call (mb, adjusted_method, NULL);
 
 			if (!preserve_sig) {
-				if (!ThrowExceptionForHR)
-					ThrowExceptionForHR = mono_class_get_method_from_name (mono_defaults.marshal_class, "ThrowExceptionForHR", 1);
+				if (!ThrowExceptionForHR) {
+					ERROR_DECL (error);
+					ThrowExceptionForHR = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "ThrowExceptionForHR", 1, 0, error);
+					mono_error_assert_ok (error);
+				}
 				mono_mb_emit_managed_call (mb, ThrowExceptionForHR, NULL);
 
 				// load return value managed is expecting
@@ -1157,8 +1168,11 @@ mono_cominterop_get_invoke (MonoMethod *method)
 	if (!strcmp(method->name, ".ctor"))	{
 		static MonoMethod *cache_proxy = NULL;
 
-		if (!cache_proxy)
-			cache_proxy = mono_class_get_method_from_name (mono_class_get_interop_proxy_class (), "CacheProxy", 0);
+		if (!cache_proxy) {
+			ERROR_DECL (error);
+			cache_proxy = mono_class_get_method_from_name_checked (mono_class_get_interop_proxy_class (), "CacheProxy", 0, 0, error);
+			mono_error_assert_ok (error);
+		}
 
 		mono_mb_emit_ldarg (mb, 0);
 		mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoTransparentProxy, rp));
@@ -1213,16 +1227,27 @@ mono_cominterop_emit_marshal_com_interface (EmitMarshalContext *m, int argnum,
 	static MonoMethod* get_idispatch_for_object_internal = NULL;
 	static MonoMethod* marshal_release = NULL;
 	static MonoMethod* AddRef = NULL;
-	if (!get_object_for_iunknown)
-		get_object_for_iunknown = mono_class_get_method_from_name (mono_defaults.marshal_class, "GetObjectForIUnknown", 1);
-	if (!get_iunknown_for_object_internal)
-		get_iunknown_for_object_internal = mono_class_get_method_from_name (mono_defaults.marshal_class, "GetIUnknownForObjectInternal", 1);
-	if (!get_idispatch_for_object_internal)
-		get_idispatch_for_object_internal = mono_class_get_method_from_name (mono_defaults.marshal_class, "GetIDispatchForObjectInternal", 1);
-	if (!get_com_interface_for_object_internal)
-		get_com_interface_for_object_internal = mono_class_get_method_from_name (mono_defaults.marshal_class, "GetComInterfaceForObjectInternal", 2);
-	if (!marshal_release)
-		marshal_release = mono_class_get_method_from_name (mono_defaults.marshal_class, "Release", 1);
+	ERROR_DECL (error);
+	if (!get_object_for_iunknown) {
+		get_object_for_iunknown = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "GetObjectForIUnknown", 1, 0, error);
+		mono_error_assert_ok (error);
+	}
+	if (!get_iunknown_for_object_internal) {
+		get_iunknown_for_object_internal = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "GetIUnknownForObjectInternal", 1, 0, error);
+		mono_error_assert_ok (error);
+	}
+	if (!get_idispatch_for_object_internal) {
+		get_idispatch_for_object_internal = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "GetIDispatchForObjectInternal", 1, 0, error);
+		mono_error_assert_ok (error);
+	}
+	if (!get_com_interface_for_object_internal) {
+		get_com_interface_for_object_internal = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "GetComInterfaceForObjectInternal", 2, 0, error);
+		mono_error_assert_ok (error);
+	}
+	if (!marshal_release) {
+		marshal_release = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "Release", 1, 0, error);
+		mono_error_assert_ok (error);
+	}
 
 #ifdef DISABLE_JIT
 	switch (action) {
@@ -1441,8 +1466,10 @@ mono_cominterop_emit_marshal_com_interface (EmitMarshalContext *m, int argnum,
 		if (t->byref && t->attrs & PARAM_ATTRIBUTE_OUT) {
 			guint32 pos_null = 0;
 
-			if (!AddRef)
-				AddRef = mono_class_get_method_from_name (mono_defaults.marshal_class, "AddRef", 1);
+			if (!AddRef) {
+				AddRef = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "AddRef", 1, 0, error);
+				mono_error_assert_ok (error);
+			}
 
 			mono_mb_emit_ldarg (mb, argnum);
 			mono_mb_emit_byte (mb, CEE_LDC_I4_0);
@@ -1484,8 +1511,10 @@ mono_cominterop_emit_marshal_com_interface (EmitMarshalContext *m, int argnum,
 		int ccw_obj;
 		ccw_obj = mono_mb_add_local (mb, mono_get_object_type ());
 
-		if (!AddRef)
-			AddRef = mono_class_get_method_from_name (mono_defaults.marshal_class, "AddRef", 1);
+		if (!AddRef) {
+			AddRef = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "AddRef", 1, 0, error);
+			mono_error_assert_ok (error);
+		}
 
 		/* store return value */
 		mono_mb_emit_stloc (mb, ccw_obj);
@@ -2285,8 +2314,11 @@ cominterop_get_managed_wrapper_adjusted (MonoMethod *method)
 	int i;
 	gboolean preserve_sig = method->iflags & METHOD_IMPL_ATTRIBUTE_PRESERVE_SIG;
 
-	if (!get_hr_for_exception)
-		get_hr_for_exception = mono_class_get_method_from_name (mono_defaults.marshal_class, "GetHRForException", -1);
+	if (!get_hr_for_exception) {
+		ERROR_DECL (error);
+		get_hr_for_exception = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "GetHRForException", -1, 0, error);
+		mono_error_assert_ok (error);
+	}
 
 	sig = mono_method_signature (method);
 
@@ -2614,8 +2646,8 @@ cominterop_ccw_get_ids_of_names (MonoCCWInterface* ccwe, gpointer riid,
 	for (i=0; i < cNames; i++) {
 		methodname = mono_unicode_to_external (rgszNames[i]);
 
-		method = mono_class_get_method_from_name(klass, methodname, -1);
-		if (method) {
+		method = mono_class_get_method_from_name_checked(klass, methodname, -1, 0, error);
+		if (method && is_ok (error)) {
 			cinfo = mono_custom_attrs_from_method_checked (method, error);
 			mono_error_assert_ok (error); /* FIXME what's reasonable to do here */
 			if (cinfo) {
@@ -2633,6 +2665,8 @@ cominterop_ccw_get_ids_of_names (MonoCCWInterface* ccwe, gpointer riid,
 			else
 				rgDispId[i] = (gint32)method->token;
 		} else {
+			mono_error_cleanup (error);
+			error_init (error); /* reuse for next iteration */
 			rgDispId[i] = MONO_E_DISPID_UNKNOWN;
 			ret = MONO_E_DISP_E_UNKNOWNNAME;
 		}
@@ -2948,8 +2982,11 @@ mono_cominterop_emit_marshal_safearray (EmitMarshalContext *m, int argnum, MonoT
 
 			label3 = mono_mb_get_label (mb);
 
-			if (!get_value_impl)
-				get_value_impl = mono_class_get_method_from_name (mono_defaults.array_class, "GetValueImpl", 1);
+			if (!get_value_impl) {
+				ERROR_DECL (error);
+				get_value_impl = mono_class_get_method_from_name_checked (mono_defaults.array_class, "GetValueImpl", 1, 0, error);
+				mono_error_assert_ok (error);
+			}
 			g_assert (get_value_impl);
 
 			if (t->byref) {
@@ -2962,8 +2999,11 @@ mono_cominterop_emit_marshal_safearray (EmitMarshalContext *m, int argnum, MonoT
 
 			mono_mb_emit_managed_call (mb, get_value_impl, NULL);
 
-			if (!get_native_variant_for_object)
-				get_native_variant_for_object = mono_class_get_method_from_name (mono_defaults.marshal_class, "GetNativeVariantForObject", 2);
+			if (!get_native_variant_for_object) {
+				ERROR_DECL (error);
+				get_native_variant_for_object = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "GetNativeVariantForObject", 2, 0, error);
+				mono_error_assert_ok (error);
+			}
 			g_assert (get_native_variant_for_object);
 
 			elem_var =  mono_mb_add_local (mb, m_class_get_byval_arg (mono_class_get_variant_class ()));
@@ -2976,8 +3016,11 @@ mono_cominterop_emit_marshal_safearray (EmitMarshalContext *m, int argnum, MonoT
 			mono_mb_emit_ldloc_addr (mb, elem_var);
 			mono_mb_emit_icall (mb, mono_marshal_safearray_set_value);
 
-			if (!variant_clear)
-				variant_clear = mono_class_get_method_from_name (mono_class_get_variant_class (), "Clear", 0);
+			if (!variant_clear) {
+				ERROR_DECL (error);
+				variant_clear = mono_class_get_method_from_name_checked (mono_class_get_variant_class (), "Clear", 0, 0, error);
+				mono_error_assert_ok (error);
+			}
 
 			mono_mb_emit_ldloc_addr (mb, elem_var);
 			mono_mb_emit_managed_call (mb, variant_clear, NULL);
@@ -3078,12 +3121,18 @@ mono_cominterop_emit_marshal_safearray (EmitMarshalContext *m, int argnum, MonoT
 			mono_mb_emit_ldloc (mb, indices_var);
 			mono_mb_emit_icall (mb, mono_marshal_safearray_get_value);
 
-			if (!get_object_for_native_variant)
-				get_object_for_native_variant = mono_class_get_method_from_name (mono_defaults.marshal_class, "GetObjectForNativeVariant", 1);
+			if (!get_object_for_native_variant) {
+				ERROR_DECL (error);
+				get_object_for_native_variant = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "GetObjectForNativeVariant", 1, 0, error);
+				mono_error_assert_ok (error);
+			}
 			g_assert (get_object_for_native_variant);
 
-			if (!set_value_impl)
-				set_value_impl = mono_class_get_method_from_name (mono_defaults.array_class, "SetValueImpl", 2);
+			if (!set_value_impl) {
+				ERROR_DECL (error);
+				set_value_impl = mono_class_get_method_from_name_checked (mono_defaults.array_class, "SetValueImpl", 2, 0, error);
+				mono_error_assert_ok (error);
+			}
 			g_assert (set_value_impl);
 
 			elem_var = mono_mb_add_local (mb, object_type);

--- a/mono/metadata/console-unix.c
+++ b/mono/metadata/console-unix.c
@@ -224,8 +224,10 @@ do_console_cancel_event (void)
 	if (mono_defaults.console_class == NULL)
 		return;
 
-	if (System_Console_DoConsoleCancelEventBackground_method == ((gpointer)-1))
-		System_Console_DoConsoleCancelEventBackground_method = mono_class_get_method_from_name (mono_defaults.console_class, "DoConsoleCancelEventInBackground", 0);
+	if (System_Console_DoConsoleCancelEventBackground_method == ((gpointer)-1)) {
+		System_Console_DoConsoleCancelEventBackground_method = mono_class_get_method_from_name_checked (mono_defaults.console_class, "DoConsoleCancelEventInBackground", 0, 0, error);
+		mono_error_assert_ok (error);
+	}
 	if (System_Console_DoConsoleCancelEventBackground_method == NULL)
 		return;
 

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -883,7 +883,7 @@ create_custom_attr (MonoImage *image, MonoMethod *method, const guchar *data, gu
 		named += name_len;
 		if (named_type == CATTR_TYPE_FIELD) {
 			/* how this fail is a blackbox */
-			field = mono_class_get_field_from_name (mono_object_class (attr), name);
+			field = mono_class_get_field_from_name_full (mono_object_class (attr), name, NULL);
 			if (!field) {
 				mono_error_set_generic_error (error, "System.Reflection", "CustomAttributeFormatException", "Could not find a field with name %s", name);
 				goto fail;
@@ -1041,7 +1041,7 @@ mono_reflection_create_custom_attr_data_args (MonoImage *image, MonoMethod *meth
 		if (named_type == CATTR_TYPE_FIELD) {
 			/* Named arg is a field. */
 			MonoObject *obj;
-			MonoClassField *field = mono_class_get_field_from_name (attrklass, name);
+			MonoClassField *field = mono_class_get_field_from_name_full (attrklass, name, NULL);
 
 			if (!field) {
 				g_free (name);

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -581,8 +581,10 @@ create_cattr_typed_arg (MonoType *t, MonoObject *val, MonoError *error)
 
 	error_init (error);
 
-	if (!ctor)
-		ctor = mono_class_get_method_from_name (mono_class_get_custom_attribute_typed_argument_class (), ".ctor", 2);
+	if (!ctor) {
+		ctor = mono_class_get_method_from_name_checked (mono_class_get_custom_attribute_typed_argument_class (), ".ctor", 2, 0, error);
+		mono_error_assert_ok (error);
+	}
 	
 	params [0] = mono_type_get_object_checked (mono_domain_get (), t, error);
 	return_val_if_nok (error, NULL);
@@ -607,8 +609,10 @@ create_cattr_named_arg (void *minfo, MonoObject *typedarg, MonoError *error)
 
 	error_init (error);
 
-	if (!ctor)
-		ctor = mono_class_get_method_from_name (mono_class_get_custom_attribute_named_argument_class (), ".ctor", 2);
+	if (!ctor) {
+		ctor = mono_class_get_method_from_name_checked (mono_class_get_custom_attribute_named_argument_class (), ".ctor", 2, 0, error);
+		mono_error_assert_ok (error);
+	}
 
 	params [0] = minfo;
 	params [1] = typedarg;
@@ -1185,8 +1189,10 @@ create_custom_attr_data_handle (MonoImage *image, MonoCustomAttrEntry *cattr, Mo
 
 	g_assert (image->assembly);
 
-	if (!ctor)
-		ctor = mono_class_get_method_from_name (mono_defaults.customattribute_data_class, ".ctor", 4);
+	if (!ctor) {
+		ctor = mono_class_get_method_from_name_checked (mono_defaults.customattribute_data_class, ".ctor", 4, 0, error);
+		mono_error_assert_ok (error);
+	}
 
 	domain = mono_domain_get ();
 

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -477,6 +477,7 @@ mono_domain_create (void)
 static MonoDomain *
 mono_init_internal (const char *filename, const char *exe_filename, const char *runtime_version)
 {
+	ERROR_DECL (error);
 	static MonoDomain *domain = NULL;
 	MonoAssembly *ass = NULL;
 	MonoImageOpenStatus status = MONO_IMAGE_OK;
@@ -776,8 +777,9 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	mono_defaults.threadpool_wait_callback_class = mono_class_load_from_name (
 		mono_defaults.corlib, "System.Threading", "_ThreadPoolWaitCallback");
 
-	mono_defaults.threadpool_perform_wait_callback_method = mono_class_get_method_from_name (
-		mono_defaults.threadpool_wait_callback_class, "PerformWaitCallback", 0);
+	mono_defaults.threadpool_perform_wait_callback_method = mono_class_get_method_from_name_checked (
+		mono_defaults.threadpool_wait_callback_class, "PerformWaitCallback", 0, 0, error);
+	mono_error_assert_ok (error);
 
 	mono_defaults.console_class = mono_class_try_load_from_name (
 		mono_defaults.corlib, "System", "Console");

--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -467,7 +467,11 @@ mono_get_exception_null_reference (void)
 MonoException *
 mono_get_exception_execution_engine (const char *msg)
 {
-	return mono_exception_from_name_msg (mono_get_corlib (), "System", "ExecutionEngineException", msg);
+	MonoException *result;
+	MONO_ENTER_GC_UNSAFE;
+	result = mono_exception_from_name_msg (mono_get_corlib (), "System", "ExecutionEngineException", msg);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
 }
 
 /**

--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -1075,7 +1075,8 @@ mono_get_exception_runtime_wrapped_handle (MonoObjectHandle wrapped_exception, M
 	mono_error_assert_ok (error);
 	g_assert (!MONO_HANDLE_IS_NULL (o));
 
-	method = mono_class_get_method_from_name (klass, ".ctor", 1);
+	method = mono_class_get_method_from_name_checked (klass, ".ctor", 1, 0, error);
+	mono_error_assert_ok (error);
 	g_assert (method);
 
 	gpointer args [ ] = { MONO_HANDLE_RAW (wrapped_exception) };

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -292,7 +292,9 @@ mono_gc_run_finalize (void *obj, void *data)
 
 #ifndef HOST_WASM
 	if (!domain->finalize_runtime_invoke) {
-		MonoMethod *invoke = mono_marshal_get_runtime_invoke (mono_class_get_method_from_name_flags (mono_defaults.object_class, "Finalize", 0, 0), TRUE);
+		MonoMethod *finalize_method = mono_class_get_method_from_name_checked (mono_defaults.object_class, "Finalize", 0, 0, error);
+		mono_error_assert_ok (error);
+		MonoMethod *invoke = mono_marshal_get_runtime_invoke (finalize_method, TRUE);
 
 		domain->finalize_runtime_invoke = mono_compile_method_checked (invoke, error);
 		mono_error_assert_ok (error); /* expect this not to fail */

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -3473,7 +3473,7 @@ internal_execute_field_getter (MonoDomain *domain, MonoObject *this_arg, MonoArr
 	return_if_nok (error);
 		
 	do {
-		MonoClassField* field = mono_class_get_field_from_name (k, str);
+		MonoClassField* field = mono_class_get_field_from_name_full (k, str, NULL);
 		if (field) {
 			g_free (str);
 			MonoClass *field_klass =  mono_class_from_mono_type (field->type);
@@ -3521,7 +3521,7 @@ internal_execute_field_setter (MonoDomain *domain, MonoObject *this_arg, MonoArr
 	return_if_nok (error);
 		
 	do {
-		MonoClassField* field = mono_class_get_field_from_name (k, str);
+		MonoClassField* field = mono_class_get_field_from_name_full (k, str, NULL);
 		if (field) {
 			g_free (str);
 			MonoClass *field_klass =  mono_class_from_mono_type (field->type);

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -65,13 +65,24 @@ static GENERATE_TRY_GET_CLASS_WITH_CACHE (icustom_marshaler, "System.Runtime.Int
 static MonoMethod *sh_dangerous_add_ref;
 static MonoMethod *sh_dangerous_release;
 
+static MonoMethod*
+get_method_nofail (MonoClass *klass, const char *method_name, int num_params, int flags)
+{
+	MonoMethod *method;
+	ERROR_DECL (error);
+	method = mono_class_get_method_from_name_checked (klass, method_name, num_params, flags, error);
+	mono_error_assert_ok (error);
+	g_assertf (method, "Could not lookup method %s in %s", method_name, m_class_get_name (klass));
+	return method;
+}
+
 static void
 init_safe_handle ()
 {
-	sh_dangerous_add_ref = mono_class_get_method_from_name (
-		mono_class_try_get_safehandle_class (), "DangerousAddRef", 1);
-	sh_dangerous_release = mono_class_get_method_from_name (
-		mono_class_try_get_safehandle_class (), "DangerousRelease", 0);
+	sh_dangerous_add_ref = get_method_nofail (
+		mono_class_try_get_safehandle_class (), "DangerousAddRef", 1, 0);
+	sh_dangerous_release = get_method_nofail (
+		mono_class_try_get_safehandle_class (), "DangerousRelease", 0, 0);
 }
 
 static MonoImage*
@@ -1054,9 +1065,9 @@ emit_struct_conv_full (MonoMethodBuilder *mb, MonoClass *klass, gboolean to_obje
 					static MonoMethod *get_object_for_native_variant = NULL;
 
 					if (!variant_clear)
-						variant_clear = mono_class_get_method_from_name (mono_class_get_variant_class (), "Clear", 0);
+						variant_clear = get_method_nofail (mono_class_get_variant_class (), "Clear", 0, 0);
 					if (!get_object_for_native_variant)
-						get_object_for_native_variant = mono_class_get_method_from_name (mono_defaults.marshal_class, "GetObjectForNativeVariant", 1);
+						get_object_for_native_variant = get_method_nofail (mono_defaults.marshal_class, "GetObjectForNativeVariant", 1, 0);
 					mono_mb_emit_ldloc (mb, 1);
 					mono_mb_emit_ldloc (mb, 0);
 					mono_mb_emit_managed_call (mb, get_object_for_native_variant, NULL);
@@ -1069,7 +1080,7 @@ emit_struct_conv_full (MonoMethodBuilder *mb, MonoClass *klass, gboolean to_obje
 					static MonoMethod *get_native_variant_for_object = NULL;
 
 					if (!get_native_variant_for_object)
-						get_native_variant_for_object = mono_class_get_method_from_name (mono_defaults.marshal_class, "GetNativeVariantForObject", 2);
+						get_native_variant_for_object = get_method_nofail (mono_defaults.marshal_class, "GetNativeVariantForObject", 2, 0);
 
 					mono_mb_emit_ldloc (mb, 0);
 					mono_mb_emit_byte(mb, CEE_LDIND_REF);
@@ -4196,13 +4207,13 @@ emit_marshal_custom_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			goto handle_exception;
 		}
 
-		cleanup_native = mono_class_get_method_from_name (klass, "CleanUpNativeData", 1);
+		cleanup_native = get_method_nofail (klass, "CleanUpNativeData", 1, 0);
 		g_assert (cleanup_native);
-		cleanup_managed = mono_class_get_method_from_name (klass, "CleanUpManagedData", 1);
+		cleanup_managed = get_method_nofail (klass, "CleanUpManagedData", 1, 0);
 		g_assert (cleanup_managed);
-		marshal_managed_to_native = mono_class_get_method_from_name (klass, "MarshalManagedToNative", 1);
+		marshal_managed_to_native = get_method_nofail (klass, "MarshalManagedToNative", 1, 0);
 		g_assert (marshal_managed_to_native);
-		marshal_native_to_managed = mono_class_get_method_from_name (klass, "MarshalNativeToManaged", 1);
+		marshal_native_to_managed = get_method_nofail (klass, "MarshalNativeToManaged", 1, 0);
 		g_assert (marshal_native_to_managed);
 
 		mono_memory_barrier ();
@@ -4551,7 +4562,7 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			static MonoMethod *to_oadate;
 
 			if (!to_oadate)
-				to_oadate = mono_class_get_method_from_name (date_time_class, "ToOADate", 0);
+				to_oadate = get_method_nofail (date_time_class, "ToOADate", 0, 0);
 			g_assert (to_oadate);
 
 			conv_arg = mono_mb_add_local (mb, double_type);
@@ -4657,7 +4668,7 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 			if (!((t->attrs & PARAM_ATTRIBUTE_IN) && !(t->attrs & PARAM_ATTRIBUTE_OUT))) {
 				if (!from_oadate)
-					from_oadate = mono_class_get_method_from_name (date_time_class, "FromOADate", 1);
+					from_oadate = get_method_nofail (date_time_class, "FromOADate", 1, 0);
 				g_assert (from_oadate);
 
 				mono_mb_emit_ldarg (mb, argnum);
@@ -4854,12 +4865,8 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		if (encoding == MONO_NATIVE_VBBYREFSTR) {
 			static MonoMethod *m;
 
-			if (!m) {
-				ERROR_DECL (error);
-				m = mono_class_get_method_from_name_checked (mono_defaults.string_class, "get_Length", -1, 0, error);
-				mono_error_assert_ok (error);
-				g_assert (m);
-			}
+			if (!m)
+				m = get_method_nofail (mono_defaults.string_class, "get_Length", -1, 0);
 
 			if (!t->byref) {
 				char *msg = g_strdup_printf ("VBByRefStr marshalling requires a ref parameter.", encoding);
@@ -5050,6 +5057,7 @@ emit_marshal_safehandle_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			init_safe_handle ();
 
 		if (t->byref){
+			ERROR_DECL (error);
 			MonoMethod *ctor;
 			
 			/*
@@ -5061,9 +5069,10 @@ emit_marshal_safehandle_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			 * but we do not support that mechanism (getting to the original
 			 * handle) and it makes no difference where we create this
 			 */
-			ctor = mono_class_get_method_from_name (t->data.klass, ".ctor", 0);
-			if (ctor == NULL){
+			ctor = mono_class_get_method_from_name_checked (t->data.klass, ".ctor", 0, 0, error);
+			if (ctor == NULL || !is_ok (error)){
 				mono_mb_emit_exception (mb, "MissingMethodException", "paramterless constructor required");
+				mono_error_cleanup (error);
 				break;
 			}
 			/* refval = new SafeHandleDerived ()*/
@@ -5088,6 +5097,7 @@ emit_marshal_safehandle_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	}
 		
 	case MARSHAL_ACTION_CONV_RESULT: {
+		ERROR_DECL (error);
 		MonoMethod *ctor = NULL;
 		int intptr_handle_slot;
 		
@@ -5097,8 +5107,9 @@ emit_marshal_safehandle_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			break;
 		}
 
-		ctor = mono_class_get_method_from_name (t->data.klass, ".ctor", 0);
-		if (ctor == NULL){
+		ctor = mono_class_get_method_from_name_checked (t->data.klass, ".ctor", 0, 0, error);
+		if (ctor == NULL || !is_ok (error)){
+			mono_error_cleanup (error);
 			mono_mb_emit_byte (mb, CEE_POP);
 			mono_mb_emit_exception (mb, "MissingMethodException", "paramterless constructor required");
 			break;
@@ -5716,11 +5727,11 @@ emit_marshal_variant_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	MonoType *object_type = mono_get_object_type ();
 
 	if (!get_object_for_native_variant)
-		get_object_for_native_variant = mono_class_get_method_from_name (mono_defaults.marshal_class, "GetObjectForNativeVariant", 1);
+		get_object_for_native_variant = get_method_nofail (mono_defaults.marshal_class, "GetObjectForNativeVariant", 1, 0);
 	g_assert (get_object_for_native_variant);
 
 	if (!get_native_variant_for_object)
-		get_native_variant_for_object = mono_class_get_method_from_name (mono_defaults.marshal_class, "GetNativeVariantForObject", 2);
+		get_native_variant_for_object = get_method_nofail (mono_defaults.marshal_class, "GetNativeVariantForObject", 2, 0);
 	g_assert (get_native_variant_for_object);
 
 	switch (action) {
@@ -5747,7 +5758,7 @@ emit_marshal_variant_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		static MonoMethod *variant_clear = NULL;
 
 		if (!variant_clear)
-			variant_clear = mono_class_get_method_from_name (mono_class_get_variant_class (), "Clear", 0);
+			variant_clear = get_method_nofail (mono_class_get_variant_class (), "Clear", 0, 0);
 		g_assert (variant_clear);
 
 

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -4221,7 +4221,8 @@ emit_marshal_custom_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	if (!mono_class_is_assignable_from (ICustomMarshaler, mklass))
 		exception_msg = g_strdup_printf ("Custom marshaler '%s' does not implement the ICustomMarshaler interface.", m_class_get_name (mklass));
 
-	get_instance = mono_class_get_method_from_name_flags (mklass, "GetInstance", 1, METHOD_ATTRIBUTE_STATIC);
+	get_instance = mono_class_get_method_from_name_checked (mklass, "GetInstance", 1, METHOD_ATTRIBUTE_STATIC, error);
+	mono_error_assert_ok (error);
 	if (get_instance) {
 		MonoMethodSignature *get_sig = mono_method_signature (get_instance);
 		if ((get_sig->ret->type != MONO_TYPE_CLASS) ||
@@ -4854,7 +4855,9 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			static MonoMethod *m;
 
 			if (!m) {
-				m = mono_class_get_method_from_name_flags (mono_defaults.string_class, "get_Length", -1, 0);
+				ERROR_DECL (error);
+				m = mono_class_get_method_from_name_checked (mono_defaults.string_class, "get_Length", -1, 0, error);
+				mono_error_assert_ok (error);
 				g_assert (m);
 			}
 

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -46,6 +46,7 @@
 #include "mono/metadata/reflection-internals.h"
 #include "mono/metadata/threadpool.h"
 #include "mono/metadata/handle.h"
+#include "mono/metadata/object-internals.h"
 #include "mono/utils/mono-counters.h"
 #include "mono/utils/mono-tls.h"
 #include "mono/utils/mono-memory-model.h"
@@ -1290,7 +1291,9 @@ mono_delegate_begin_invoke (MonoDelegate *delegate, gpointer *params)
 
 	klass = delegate->object.vtable->klass;
 
-	method = mono_class_get_method_from_name (klass, "BeginInvoke", -1);
+	ERROR_DECL (begin_invoke_error);
+	method = mono_get_delegate_begin_invoke_checked (klass, begin_invoke_error);
+	mono_error_cleanup (begin_invoke_error); /* if we can't call BeginInvoke, fall back on Invoke */
 	if (!method)
 		method = mono_get_delegate_invoke (klass);
 	g_assert (method);
@@ -1972,7 +1975,8 @@ mono_delegate_end_invoke (MonoDelegate *delegate, gpointer *params)
 
 	klass = delegate->object.vtable->klass;
 
-	method = mono_class_get_method_from_name (klass, "EndInvoke", -1);
+	method = mono_get_delegate_end_invoke_checked (klass, error);
+	mono_error_assert_ok (error);
 	g_assert (method != NULL);
 
 	sig = mono_signature_no_pinvoke (method);
@@ -4050,8 +4054,11 @@ mono_marshal_get_struct_to_ptr (MonoClass *klass)
 	if (marshal_info->str_to_ptr)
 		return marshal_info->str_to_ptr;
 
-	if (!stoptr) 
-		stoptr = mono_class_get_method_from_name (mono_defaults.marshal_class, "StructureToPtr", 3);
+	if (!stoptr) {
+		ERROR_DECL (error);
+		stoptr = mono_class_get_method_from_name_checked (mono_defaults.marshal_class, "StructureToPtr", 3, 0, error);
+		mono_error_assert_ok (error);
+	}
 	g_assert (stoptr);
 
 	mb = mono_mb_new (klass, stoptr->name, MONO_WRAPPER_UNKNOWN);

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -6850,10 +6850,14 @@ mono_get_shared_generic_inst (MonoGenericContainer *container)
  * \returns TRUE if \p type represents a type passed by reference,
  * FALSE otherwise.
  */
-gboolean
+mono_bool
 mono_type_is_byref (MonoType *type)
 {
-	return type->byref;
+	mono_bool result;
+	MONO_ENTER_GC_UNSAFE;
+	result = type->byref;
+	MONO_EXIT_GC_UNSAFE;
+	return result;
 }
 
 /**

--- a/mono/metadata/method-builder-ilgen.c
+++ b/mono/metadata/method-builder-ilgen.c
@@ -548,11 +548,13 @@ mono_mb_emit_icall (MonoMethodBuilder *mb, gpointer func)
 void
 mono_mb_emit_exception_full (MonoMethodBuilder *mb, const char *exc_nspace, const char *exc_name, const char *msg)
 {
+	ERROR_DECL (error);
 	MonoMethod *ctor = NULL;
 
 	MonoClass *mme = mono_class_load_from_name (mono_defaults.corlib, exc_nspace, exc_name);
 	mono_class_init (mme);
-	ctor = mono_class_get_method_from_name (mme, ".ctor", 0);
+	ctor = mono_class_get_method_from_name_checked (mme, ".ctor", 0, 0, error);
+	mono_error_assert_ok (error);
 	g_assert (ctor);
 	mono_mb_emit_op (mb, CEE_NEWOBJ, ctor);
 	if (msg != NULL) {

--- a/mono/metadata/mono-config.c
+++ b/mono/metadata/mono-config.c
@@ -93,6 +93,8 @@
 #endif
 #endif
 
+static void mono_config_for_assembly_internal (MonoImage *assembly);
+
 /**
  * mono_config_get_os:
  *
@@ -606,6 +608,16 @@ mono_config_string_for_assembly_file (const char *filename)
 void 
 mono_config_for_assembly (MonoImage *assembly)
 {
+	MONO_ENTER_GC_UNSAFE;
+	mono_config_for_assembly_internal (assembly);
+	MONO_EXIT_GC_UNSAFE;
+}
+
+void
+mono_config_for_assembly_internal (MonoImage *assembly)
+{
+	MONO_REQ_GC_UNSAFE_MODE;
+
 	ParseState state = {NULL};
 	int got_it = 0, i;
 	char *aname, *cfg, *cfg_name;

--- a/mono/metadata/mono-security.c
+++ b/mono/metadata/mono-security.c
@@ -633,7 +633,9 @@ void mono_invoke_protected_memory_method (MonoArray *data, MonoObject *scope, gb
 
 	klass = mono_class_load_from_name (system_security_assembly,
 								  "System.Security.Cryptography", "ProtectedMemory");
-	method = mono_class_get_method_from_name (klass, encrypt ? "Protect" : "Unprotect", 2);
+	method = mono_class_get_method_from_name_checked (klass, encrypt ? "Protect" : "Unprotect", 2, 0, error);
+	mono_error_assert_ok (error);
+	g_assert (method);
 	params [0] = data;
 	params [1] = scope; /* MemoryProtectionScope.SameProcess */
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -698,6 +698,15 @@ mono_delegate_ctor_with_method (MonoObjectHandle this_obj, MonoObjectHandle targ
 gboolean
 mono_delegate_ctor	    (MonoObjectHandle this_obj, MonoObjectHandle target, gpointer addr, MonoError *error);
 
+MonoMethod *
+mono_get_delegate_invoke_checked (MonoClass *klass, MonoError *error);
+
+MonoMethod *
+mono_get_delegate_begin_invoke_checked (MonoClass *klass, MonoError *error);
+
+MonoMethod *
+mono_get_delegate_end_invoke_checked (MonoClass *klass, MonoError *error);
+
 void
 mono_runtime_free_method    (MonoDomain *domain, MonoMethod *method);
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -74,7 +74,7 @@
 #define mono_class_get_field_from_name_cached(klass,name) ({ \
 			static MonoClassField *tmp_field; \
 			if (!tmp_field) { \
-				tmp_field = mono_class_get_field_from_name ((klass), (name)); \
+				tmp_field = mono_class_get_field_from_name_full ((klass), (name), NULL); \
 				g_assert (tmp_field); \
 			}; \
 			tmp_field; })

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -1844,9 +1844,12 @@ static MonoVTable *mono_class_create_runtime_vtable (MonoDomain *domain, MonoCla
 MonoVTable *
 mono_class_vtable (MonoDomain *domain, MonoClass *klass)
 {
+	MonoVTable* vtable;
+	MONO_ENTER_GC_UNSAFE;
 	ERROR_DECL (error);
-	MonoVTable* vtable = mono_class_vtable_checked (domain, klass, error);
+	vtable = mono_class_vtable_checked (domain, klass, error);
 	mono_error_cleanup (error);
+	MONO_EXIT_GC_UNSAFE;
 	return vtable;
 }
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -4738,7 +4738,7 @@ mono_unhandled_exception_checked (MonoObjectHandle exc, MonoError *error)
 			mono_thread_info_current ()->runtime_thread))
 		return;
 
-	field = mono_class_get_field_from_name (mono_defaults.appdomain_class, "UnhandledException");
+	field = mono_class_get_field_from_name_full (mono_defaults.appdomain_class, "UnhandledException", NULL);
 	g_assert (field);
 
 	current_domain = mono_domain_get ();
@@ -7769,7 +7769,7 @@ mono_wait_handle_get_handle (MonoWaitHandle *handle)
 	MonoSafeHandle *sh;
 
 	if (!f_safe_handle) {
-		f_safe_handle = mono_class_get_field_from_name (mono_defaults.manualresetevent_class, "safeWaitHandle");
+		f_safe_handle = mono_class_get_field_from_name_full (mono_defaults.manualresetevent_class, "safeWaitHandle", NULL);
 		g_assert (f_safe_handle);
 	}
 

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -2964,7 +2964,8 @@ mono_reflection_call_is_assignable_to (MonoClass *klass, MonoClass *oklass, Mono
 	error_init (error);
 
 	if (method == NULL) {
-		method = mono_class_get_method_from_name (mono_class_get_type_builder_class (), "IsAssignableTo", 1);
+		method = mono_class_get_method_from_name_checked (mono_class_get_type_builder_class (), "IsAssignableTo", 1, 0, error);
+		mono_error_assert_ok (error);
 		g_assert (method);
 	}
 

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -893,7 +893,7 @@ mono_get_reflection_missing_object (MonoDomain *domain)
 		MonoClass *missing_klass;
 		missing_klass = mono_class_get_missing_class ();
 		mono_class_init (missing_klass);
-		missing_value_field = mono_class_get_field_from_name (missing_klass, "Value");
+		missing_value_field = mono_class_get_field_from_name_full (missing_klass, "Value", NULL);
 		g_assert (missing_value_field);
 	}
 	/* FIXME change mono_field_get_value_object_checked to return a handle */
@@ -912,7 +912,7 @@ get_dbnull_object (MonoDomain *domain, MonoError *error)
 	if (!dbnull_value_field) {
 		MonoClass *dbnull_klass;
 		dbnull_klass = mono_class_get_dbnull_class ();
-		dbnull_value_field = mono_class_get_field_from_name (dbnull_klass, "Value");
+		dbnull_value_field = mono_class_get_field_from_name_full (dbnull_klass, "Value", NULL);
 		g_assert (dbnull_value_field);
 	}
 	/* FIXME change mono_field_get_value_object_checked to return a handle */

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -167,6 +167,7 @@ mono_remoting_init (void)
 static void
 mono_remoting_marshal_init (void)
 {
+	ERROR_DECL (error);
 	MonoClass *klass;
 
 	static gboolean module_initialized = FALSE;
@@ -179,27 +180,34 @@ mono_remoting_marshal_init (void)
 
 #ifndef DISABLE_JIT
 	klass = mono_class_get_remoting_services_class ();
-	method_rs_serialize = mono_class_get_method_from_name (klass, "SerializeCallData", -1);
+	method_rs_serialize = mono_class_get_method_from_name_checked (klass, "SerializeCallData", -1, 0, error);
+ 	mono_error_assert_ok (error);
 	g_assert (method_rs_serialize);
-	method_rs_deserialize = mono_class_get_method_from_name (klass, "DeserializeCallData", -1);
+	method_rs_deserialize = mono_class_get_method_from_name_checked (klass, "DeserializeCallData", -1, 0, error);
+ 	mono_error_assert_ok (error);
 	g_assert (method_rs_deserialize);
-	method_rs_serialize_exc = mono_class_get_method_from_name (klass, "SerializeExceptionData", -1);
+	method_rs_serialize_exc = mono_class_get_method_from_name_checked (klass, "SerializeExceptionData", -1, 0, error);
+ 	mono_error_assert_ok (error);
 	g_assert (method_rs_serialize_exc);
 	
 	klass = mono_defaults.real_proxy_class;
-	method_rs_appdomain_target = mono_class_get_method_from_name (klass, "GetAppDomainTarget", -1);
+	method_rs_appdomain_target = mono_class_get_method_from_name_checked (klass, "GetAppDomainTarget", -1, 0, error);
+ 	mono_error_assert_ok (error);
 	g_assert (method_rs_appdomain_target);
 	
 	klass = mono_defaults.exception_class;
-	method_exc_fixexc = mono_class_get_method_from_name (klass, "FixRemotingException", -1);
+	method_exc_fixexc = mono_class_get_method_from_name_checked (klass, "FixRemotingException", -1, 0, error);
+ 	mono_error_assert_ok (error);
 	g_assert (method_exc_fixexc);
 
 	klass = mono_class_get_call_context_class ();
-	method_set_call_context = mono_class_get_method_from_name (klass, "SetCurrentCallContext", -1);
+	method_set_call_context = mono_class_get_method_from_name_checked (klass, "SetCurrentCallContext", -1, 0, error);
+ 	mono_error_assert_ok (error);
 	g_assert (method_set_call_context);
 
 	klass = mono_class_get_context_class ();
-	method_needs_context_sink = mono_class_get_method_from_name (klass, "get_NeedsContextSink", -1);
+	method_needs_context_sink = mono_class_get_method_from_name_checked (klass, "get_NeedsContextSink", -1, 0, error);
+ 	mono_error_assert_ok (error);
 	g_assert (method_needs_context_sink);
 #endif	
 
@@ -1457,7 +1465,9 @@ mono_marshal_get_ldfld_wrapper (MonoType *type)
 
 #ifndef DISABLE_REMOTING
 	if (!tp_load) {
-		tp_load = mono_class_get_method_from_name (mono_defaults.transparent_proxy_class, "LoadRemoteFieldNew", -1);
+		ERROR_DECL (error);
+		tp_load = mono_class_get_method_from_name_checked (mono_defaults.transparent_proxy_class, "LoadRemoteFieldNew", -1, 0, error);
+		mono_error_assert_ok (error);
 		g_assert (tp_load != NULL);
 	}
 #endif
@@ -1757,7 +1767,9 @@ mono_marshal_get_stfld_wrapper (MonoType *type)
 
 #ifndef DISABLE_REMOTING
 	if (!tp_store) {
-		tp_store = mono_class_get_method_from_name (mono_defaults.transparent_proxy_class, "StoreRemoteField", -1);
+		ERROR_DECL (error);
+		tp_store = mono_class_get_method_from_name_checked (mono_defaults.transparent_proxy_class, "StoreRemoteField", -1, 0, error);
+		mono_error_assert_ok (error);
 		g_assert (tp_store != NULL);
 	}
 #endif

--- a/mono/metadata/runtime.c
+++ b/mono/metadata/runtime.c
@@ -59,7 +59,7 @@ fire_process_exit_event (MonoDomain *domain, gpointer user_data)
 	gpointer pa [2];
 	MonoObject *delegate, *exc;
 
-	field = mono_class_get_field_from_name (mono_defaults.appdomain_class, "ProcessExit");
+	field = mono_class_get_field_from_name_full (mono_defaults.appdomain_class, "ProcessExit", NULL);
 	g_assert (field);
 
 	delegate = *(MonoObject **)(((char *)domain->domain) + field->offset);

--- a/mono/metadata/security-manager.c
+++ b/mono/metadata/security-manager.c
@@ -102,8 +102,10 @@ mono_get_context_capture_method (void)
 	/* older corlib revisions won't have the class (nor the method) */
 	MonoClass *execution_context = mono_class_try_get_execution_context_class ();
 	if (execution_context && !method) {
+		ERROR_DECL (error);
 		mono_class_init (execution_context);
-		method = mono_class_get_method_from_name (execution_context, "Capture", 0);
+		method = mono_class_get_method_from_name_checked (execution_context, "Capture", 0, 0, error);
+		mono_error_assert_ok (error);
 	}
 
 	return method;

--- a/mono/metadata/sgen-bridge.c
+++ b/mono/metadata/sgen-bridge.c
@@ -583,7 +583,7 @@ bridge_test_cross_reference2 (int num_sccs, MonoGCBridgeSCC **sccs, int num_xref
 	gboolean modified;
 
 	if (!mono_bridge_test_field) {
-		mono_bridge_test_field = mono_class_get_field_from_name (mono_object_get_class (sccs[0]->objs [0]), "__test");
+		mono_bridge_test_field = mono_class_get_field_from_name_full (mono_object_get_class (sccs[0]->objs [0]), "__test", NULL);
 		g_assert (mono_bridge_test_field);
 	}
 
@@ -633,7 +633,7 @@ bridge_test_positive_status (int num_sccs, MonoGCBridgeSCC **sccs, int num_xrefs
 	int i;
 
 	if (!mono_bridge_test_field) {
-		mono_bridge_test_field = mono_class_get_field_from_name (mono_object_get_class (sccs[0]->objs [0]), "__test");
+		mono_bridge_test_field = mono_class_get_field_from_name_full (mono_object_get_class (sccs[0]->objs [0]), "__test", NULL);
 		g_assert (mono_bridge_test_field);
 	}
 

--- a/mono/metadata/sgen-mono-ilgen.c
+++ b/mono/metadata/sgen-mono-ilgen.c
@@ -226,6 +226,7 @@ emit_managed_allocater_ilgen (MonoMethodBuilder *mb, gboolean slowpath, gboolean
 		mono_mb_emit_byte (mb, CEE_CONV_I);
 		mono_mb_emit_stloc (mb, size_var);
 	} else if (atype == ATYPE_VECTOR) {
+		ERROR_DECL (error);
 		MonoExceptionClause *clause;
 		int pos, pos_leave, pos_error;
 		MonoClass *oom_exc_class;
@@ -286,7 +287,8 @@ emit_managed_allocater_ilgen (MonoMethodBuilder *mb, gboolean slowpath, gboolean
 
 		oom_exc_class = mono_class_load_from_name (mono_defaults.corlib,
 				"System", "OutOfMemoryException");
-		ctor = mono_class_get_method_from_name (oom_exc_class, ".ctor", 0);
+		ctor = mono_class_get_method_from_name_checked (oom_exc_class, ".ctor", 0, 0, error);
+		mono_error_assert_ok (error);
 		g_assert (ctor);
 
 		mono_mb_emit_byte (mb, CEE_POP);

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2422,7 +2422,9 @@ mono_gc_precise_stack_mark_enabled (void)
 void
 mono_gc_collect (int generation)
 {
+	MONO_ENTER_GC_UNSAFE;
 	sgen_gc_collect (generation);
+	MONO_EXIT_GC_UNSAFE;
 }
 
 int

--- a/mono/metadata/sgen-toggleref.c
+++ b/mono/metadata/sgen-toggleref.c
@@ -203,7 +203,7 @@ test_toggleref_callback (MonoObject *obj)
 	MonoToggleRefStatus status = MONO_TOGGLE_REF_DROP;
 
 	if (!mono_toggleref_test_field) {
-		mono_toggleref_test_field = mono_class_get_field_from_name (mono_object_get_class (obj), "__test");
+		mono_toggleref_test_field = mono_class_get_field_from_name_full (mono_object_get_class (obj), "__test", NULL);
 		g_assert (mono_toggleref_test_field);
 	}
 

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -4338,7 +4338,8 @@ mono_reflection_resolve_object (MonoImage *image, MonoObject *obj, MonoClass **h
 			   !strcmp (oklass->name, "ConstructorOnTypeBuilderInst")) {
 		static MonoMethod *resolve_method;
 		if (!resolve_method) {
-			MonoMethod *m = mono_class_get_method_from_name_flags (mono_class_get_module_builder_class (), "RuntimeResolve", 1, 0);
+			MonoMethod *m = mono_class_get_method_from_name_checked (mono_class_get_module_builder_class (), "RuntimeResolve", 1, 0, error);
+			mono_error_assert_ok (error);
 			g_assert (m);
 			mono_memory_barrier ();
 			resolve_method = m;

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -1632,8 +1632,10 @@ mono_reflection_type_get_underlying_system_type (MonoReflectionTypeHandle t, Mon
 
 	error_init (error);
 
-	if (!method_get_underlying_system_type)
-		method_get_underlying_system_type = mono_class_get_method_from_name (mono_defaults.systemtype_class, "get_UnderlyingSystemType", 0);
+	if (!method_get_underlying_system_type) {
+		method_get_underlying_system_type = mono_class_get_method_from_name_checked (mono_defaults.systemtype_class, "get_UnderlyingSystemType", 0, 0, error);
+		mono_error_assert_ok (error);
+	}
 
 	MonoReflectionTypeHandle rt = MONO_HANDLE_NEW (MonoReflectionType, NULL);
 

--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -168,8 +168,10 @@ mono_threadpool_enqueue_work_item (MonoDomain *domain, MonoObject *work_item, Mo
 	if (!threadpool_class)
 		threadpool_class = mono_class_load_from_name (mono_defaults.corlib, "System.Threading", "ThreadPool");
 
-	if (!unsafe_queue_custom_work_item_method)
-		unsafe_queue_custom_work_item_method = mono_class_get_method_from_name (threadpool_class, "UnsafeQueueCustomWorkItem", 2);
+	if (!unsafe_queue_custom_work_item_method) {
+		unsafe_queue_custom_work_item_method = mono_class_get_method_from_name_checked (threadpool_class, "UnsafeQueueCustomWorkItem", 2, 0, error);
+		mono_error_assert_ok (error);
+	}
 	g_assert (unsafe_queue_custom_work_item_method);
 
 	f = FALSE;

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -574,7 +574,7 @@ get_current_thread_ptr_for_domain (MonoDomain *domain, MonoInternalThread *threa
 	guint32 offset;
 
 	if (!current_thread_field) {
-		current_thread_field = mono_class_get_field_from_name (mono_defaults.thread_class, "current_thread");
+		current_thread_field = mono_class_get_field_from_name_full (mono_defaults.thread_class, "current_thread", NULL);
 		g_assert (current_thread_field);
 	}
 

--- a/mono/metadata/w32process.c
+++ b/mono/metadata/w32process.c
@@ -142,7 +142,7 @@ process_set_field_object (MonoObject *obj, const gchar *fieldname, MonoObject *d
 	klass = mono_object_class (obj);
 	g_assert (klass);
 
-	field = mono_class_get_field_from_name (klass, fieldname);
+	field = mono_class_get_field_from_name_full (klass, fieldname, NULL);
 	g_assert (field);
 
 	mono_gc_wbarrier_generic_store (((char *)obj) + field->offset, data);
@@ -166,7 +166,7 @@ process_set_field_string (MonoObject *obj, const gchar *fieldname, const gunicha
 	klass = mono_object_class (obj);
 	g_assert (klass);
 
-	field = mono_class_get_field_from_name (klass, fieldname);
+	field = mono_class_get_field_from_name_full (klass, fieldname, NULL);
 	g_assert (field);
 
 	string = mono_string_new_utf16_checked (domain, val, len, error);
@@ -192,7 +192,7 @@ process_set_field_string_char (MonoObject *obj, const gchar *fieldname, const gc
 	klass = mono_object_class (obj);
 	g_assert (klass);
 
-	field = mono_class_get_field_from_name (klass, fieldname);
+	field = mono_class_get_field_from_name_full (klass, fieldname, NULL);
 	g_assert (field);
 
 	string = mono_string_new_checked (domain, val, error);
@@ -212,7 +212,7 @@ process_set_field_int (MonoObject *obj, const gchar *fieldname, guint32 val)
 	klass = mono_object_class (obj);
 	g_assert (klass);
 
-	field = mono_class_get_field_from_name (klass, fieldname);
+	field = mono_class_get_field_from_name_full (klass, fieldname, NULL);
 	g_assert (field);
 
 	*(guint32 *)(((char *)obj) + field->offset)=val;
@@ -229,7 +229,7 @@ process_set_field_intptr (MonoObject *obj, const gchar *fieldname, gpointer val)
 	klass = mono_object_class (obj);
 	g_assert (klass);
 
-	field = mono_class_get_field_from_name (klass, fieldname);
+	field = mono_class_get_field_from_name_full (klass, fieldname, NULL);
 	g_assert (field);
 
 	*(gpointer *)(((char *)obj) + field->offset) = val;
@@ -246,7 +246,7 @@ process_set_field_bool (MonoObject *obj, const gchar *fieldname, gboolean val)
 	klass = mono_object_class (obj);
 	g_assert (klass);
 
-	field = mono_class_get_field_from_name (klass, fieldname);
+	field = mono_class_get_field_from_name_full (klass, fieldname, NULL);
 	g_assert (field);
 
 	*(guint8 *)(((char *)obj) + field->offset) = val;

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -889,13 +889,13 @@ create_object_handle_from_sockaddr (struct sockaddr *saddr, int sa_size, gint32 
 	
 	/* Locate the SocketAddress data buffer in the object */
 	if (!domain->sockaddr_data_field) {
-		domain->sockaddr_data_field = mono_class_get_field_from_name (domain->sockaddr_class, "m_Buffer");
+		domain->sockaddr_data_field = mono_class_get_field_from_name_full (domain->sockaddr_class, "m_Buffer", NULL);
 		g_assert (domain->sockaddr_data_field);
 	}
 
 	/* Locate the SocketAddress data buffer length in the object */
 	if (!domain->sockaddr_data_length_field) {
-		domain->sockaddr_data_length_field = mono_class_get_field_from_name (domain->sockaddr_class, "m_Size");
+		domain->sockaddr_data_length_field = mono_class_get_field_from_name_full (domain->sockaddr_class, "m_Size", NULL);
 		g_assert (domain->sockaddr_data_length_field);
 	}
 
@@ -1107,13 +1107,13 @@ create_sockaddr_from_handle (MonoObjectHandle saddr_obj, socklen_t *sa_size, gin
 
 	/* Locate the SocketAddress data buffer in the object */
 	if (!domain->sockaddr_data_field) {
-		domain->sockaddr_data_field = mono_class_get_field_from_name (domain->sockaddr_class, "m_Buffer");
+		domain->sockaddr_data_field = mono_class_get_field_from_name_full (domain->sockaddr_class, "m_Buffer", NULL);
 		g_assert (domain->sockaddr_data_field);
 	}
 
 	/* Locate the SocketAddress data buffer length in the object */
 	if (!domain->sockaddr_data_length_field) {
-		domain->sockaddr_data_length_field = mono_class_get_field_from_name (domain->sockaddr_class, "m_Size");
+		domain->sockaddr_data_length_field = mono_class_get_field_from_name_full (domain->sockaddr_class, "m_Size", NULL);
 		g_assert (domain->sockaddr_data_length_field);
 	}
 
@@ -1560,7 +1560,7 @@ Socket_to_SOCKET (MonoObjectHandle sockobj)
 {
 	MonoClassField *field;
 	
-	field = mono_class_get_field_from_name (mono_handle_class (sockobj), "m_Handle");
+	field = mono_class_get_field_from_name_full (mono_handle_class (sockobj), "m_Handle", NULL);
 	MonoSafeHandleHandle safe_handle = MONO_HANDLE_NEW_GET_FIELD(sockobj, MonoSafeHandle, field);
 
 	if (MONO_HANDLE_IS_NULL (safe_handle))
@@ -1811,10 +1811,10 @@ ves_icall_System_Net_Sockets_Socket_GetSocketOption_obj_internal (gsize sock, gi
 		/* Locate and set the fields "bool enabled" and "int
 		 * lingerTime"
 		 */
-		field = mono_class_get_field_from_name(obj_class, "enabled");
+		field = mono_class_get_field_from_name_full (obj_class, "enabled", NULL);
 		MONO_HANDLE_SET_FIELD_VAL (obj, guint8, field, linger.l_onoff);
 
-		field = mono_class_get_field_from_name(obj_class, "lingerTime");
+		field = mono_class_get_field_from_name_full (obj_class, "lingerTime", NULL);
 		MONO_HANDLE_SET_FIELD_VAL (obj, guint32, field, linger.l_linger);
 
 		MONO_HANDLE_ASSIGN (obj_val, obj);
@@ -1926,7 +1926,7 @@ ipaddress_handle_to_struct_in_addr (MonoObjectHandle ipaddr)
 	struct in_addr inaddr;
 	MonoClassField *field;
 	
-	field = mono_class_get_field_from_name (mono_handle_class (ipaddr), "m_Address");
+	field = mono_class_get_field_from_name_full (mono_handle_class (ipaddr), "m_Address", NULL);
 	g_assert (field);
 
 	/* No idea why .net uses a 64bit type to hold a 32bit value...
@@ -1946,7 +1946,7 @@ ipaddress_handle_to_struct_in6_addr (MonoObjectHandle ipaddr)
 	MonoClassField *field;
 	int i;
 
-	field = mono_class_get_field_from_name (mono_handle_class (ipaddr), "m_Numbers");
+	field = mono_class_get_field_from_name_full (mono_handle_class (ipaddr), "m_Numbers", NULL);
 	g_assert (field);
 	MonoArrayHandle data = MONO_HANDLE_NEW_GET_FIELD (ipaddr, MonoArray, field);
 
@@ -2048,9 +2048,9 @@ ves_icall_System_Net_Sockets_Socket_SetSocketOption_internal (gsize sock, gint32
 			/* Dig out "bool enabled" and "int lingerTime"
 			 * fields
 			 */
-			field = mono_class_get_field_from_name (obj_class, "enabled");
+			field = mono_class_get_field_from_name_full (obj_class, "enabled", NULL);
 			linger.l_onoff = MONO_HANDLE_GET_FIELD_VAL (obj_val, guint8, field);
-			field = mono_class_get_field_from_name (obj_class, "lingerTime");
+			field = mono_class_get_field_from_name_full (obj_class, "lingerTime", NULL);
 			linger.l_linger = MONO_HANDLE_GET_FIELD_VAL (obj_val, guint32, field);
 			
 			valsize = sizeof (linger);
@@ -2068,14 +2068,14 @@ ves_icall_System_Net_Sockets_Socket_SetSocketOption_internal (gsize sock, gint32
 				/*
 				 *	Get group address
 				 */
-				field = mono_class_get_field_from_name (obj_class, "m_Group");
+				field = mono_class_get_field_from_name_full (obj_class, "m_Group", NULL);
 				g_assert (field);
 				MONO_HANDLE_ASSIGN (address, MONO_HANDLE_NEW_GET_FIELD (obj_val, MonoObject, field));
 				
 				if (!MONO_HANDLE_IS_NULL (address))
 					mreq6.ipv6mr_multiaddr = ipaddress_handle_to_struct_in6_addr (address);
 
-				field = mono_class_get_field_from_name (obj_class, "m_Interface");
+				field = mono_class_get_field_from_name_full (obj_class, "m_Interface", NULL);
 				mreq6.ipv6mr_interface = MONO_HANDLE_GET_FIELD_VAL (obj_val, guint64, field);
 				
 #if defined(__APPLE__) || defined(__FreeBSD__)
@@ -2110,7 +2110,7 @@ ves_icall_System_Net_Sockets_Socket_SetSocketOption_internal (gsize sock, gint32
 				 * members, so I have to dig the value out of
 				 * those :-(
 				 */
-				field = mono_class_get_field_from_name (obj_class, "group");
+				field = mono_class_get_field_from_name_full (obj_class, "group", NULL);
 				MONO_HANDLE_ASSIGN (address, MONO_HANDLE_NEW_GET_FIELD (obj_val, MonoObject, field));
 
 				/* address might not be defined and if so, set the address to ADDR_ANY.
@@ -2118,14 +2118,14 @@ ves_icall_System_Net_Sockets_Socket_SetSocketOption_internal (gsize sock, gint32
 				if (!MONO_HANDLE_IS_NULL (address))
 					mreq.imr_multiaddr = ipaddress_handle_to_struct_in_addr (address);
 
-				field = mono_class_get_field_from_name (obj_class, "localAddress");
+				field = mono_class_get_field_from_name_full (obj_class, "localAddress", NULL);
 				MONO_HANDLE_ASSIGN (address, MONO_HANDLE_NEW_GET_FIELD (obj_val, MonoObject, field));
 
 #ifdef HAVE_STRUCT_IP_MREQN
 				if (!MONO_HANDLE_IS_NULL (address))
 					mreq.imr_address = ipaddress_handle_to_struct_in_addr (address);
 
-				field = mono_class_get_field_from_name (obj_class, "ifIndex");
+				field = mono_class_get_field_from_name_full (obj_class, "ifIndex", NULL);
 				mreq.imr_ifindex = MONO_HANDLE_GET_FIELD_VAL (obj_val, gint32, field);
 #else
 				if (!MONO_HANDLE_IS_NULL (address))

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -1350,19 +1350,24 @@ decode_method_ref_with_target (MonoAotModule *module, MethodRef *ref, MonoMethod
 		method_type = decode_value (p, &p);
 		switch (method_type) {
 		case 0:
-			ref->method = mono_class_get_method_from_name (klass, ".ctor", m_class_get_rank (klass));
+			ref->method = mono_class_get_method_from_name_checked (klass, ".ctor", m_class_get_rank (klass), 0, error);
+			return_val_if_nok (error, FALSE);
 			break;
 		case 1:
-			ref->method = mono_class_get_method_from_name (klass, ".ctor", m_class_get_rank (klass) * 2);
+			ref->method = mono_class_get_method_from_name_checked (klass, ".ctor", m_class_get_rank (klass) * 2, 0, error);
+			return_val_if_nok (error, FALSE);
 			break;
 		case 2:
-			ref->method = mono_class_get_method_from_name (klass, "Get", -1);
+			ref->method = mono_class_get_method_from_name_checked (klass, "Get", -1, 0, error);
+			return_val_if_nok (error, FALSE);
 			break;
 		case 3:
-			ref->method = mono_class_get_method_from_name (klass, "Address", -1);
+			ref->method = mono_class_get_method_from_name_checked (klass, "Address", -1, 0, error);
+			return_val_if_nok (error, FALSE);
 			break;
 		case 4:
-			ref->method = mono_class_get_method_from_name (klass, "Set", -1);
+			ref->method = mono_class_get_method_from_name_checked (klass, "Set", -1, 0, error);
+			return_val_if_nok (error, FALSE);
 			break;
 		default:
 			mono_error_set_bad_image_by_name (error, module->aot_name, "Invalid METHODREF_ARRAY method type %d", method_type);
@@ -4667,7 +4672,8 @@ mono_aot_get_method (MonoDomain *domain, MonoMethod *method, MonoError *error)
 				/* Avoid recursion */
 				return NULL;
 
-			m = mono_class_get_method_from_name (mono_defaults.array_class, "GetGenericValueImpl", 2);
+			m = mono_class_get_method_from_name_checked (mono_defaults.array_class, "GetGenericValueImpl", 2, 0, error);
+			mono_error_assert_ok (error);
 			g_assert (m);
 
 			memset (&ctx, 0, sizeof (ctx));
@@ -4745,7 +4751,8 @@ mono_aot_get_method (MonoDomain *domain, MonoMethod *method, MonoError *error)
 					else
 						g_assert_not_reached ();
 					MonoClass *obj_array_class = mono_class_create_array (mono_defaults.object_class, rank);
-					MonoMethod *m = mono_class_get_method_from_name (obj_array_class, array_method->name, mono_method_signature (array_method)->param_count);
+					MonoMethod *m = mono_class_get_method_from_name_checked (obj_array_class, array_method->name, mono_method_signature (array_method)->param_count, 0, error);
+					mono_error_assert_ok (error);
 					g_assert (m);
 
 					m = mono_marshal_get_array_accessor_wrapper (m);

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -4330,7 +4330,7 @@ get_async_method_builder (DbgEngineStackFrame *frame)
 	gpointer builder;
 	guint8 *this_addr;
 
-	builder_field = mono_class_get_field_from_name (frame->method->klass, "<>t__builder");
+	builder_field = mono_class_get_field_from_name_full (frame->method->klass, "<>t__builder", NULL);
 	g_assert (builder_field);
 
 	this_addr = get_this_addr (frame);
@@ -4370,7 +4370,7 @@ get_this_async_id (DbgEngineStackFrame *frame)
 	if (!builder)
 		return 0;
 
-	builder_field = mono_class_get_field_from_name (frame->method->klass, "<>t__builder");
+	builder_field = mono_class_get_field_from_name_full (frame->method->klass, "<>t__builder", NULL);
 	g_assert (builder_field);
 
 	tls = (DebuggerTlsData *)mono_native_tls_get_value (debugger_tls_id);
@@ -4394,7 +4394,7 @@ get_this_async_id (DbgEngineStackFrame *frame)
 static gboolean
 set_set_notification_for_wait_completion_flag (DbgEngineStackFrame *frame)
 {
-	MonoClassField *builder_field = mono_class_get_field_from_name (frame->method->klass, "<>t__builder");
+	MonoClassField *builder_field = mono_class_get_field_from_name_full (frame->method->klass, "<>t__builder", NULL);
 	g_assert (builder_field);
 	gpointer builder = get_async_method_builder (frame);
 	g_assert (builder);

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -6540,8 +6540,11 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 
 #ifdef TRY_MANAGED_SYSTEM_ENVIRONMENT_EXIT
 		env_class = mono_class_try_load_from_name (mono_defaults.corlib, "System", "Environment");
-		if (env_class)
-			exit_method = mono_class_get_method_from_name (env_class, "Exit", 1);
+		if (env_class) {
+			ERROR_DECL (error);
+			exit_method = mono_class_get_method_from_name_checked (env_class, "Exit", 1, 0, error);
+			mono_error_assert_ok (error);
+		}
 #endif
 
 		mono_loader_lock ();

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -627,11 +627,16 @@ interp_regression_step (MonoImage *image, int verbose, int *total_run, int *tota
 					/* FIXME: there is an ordering problem if there're multiple attributes, do this instead:
 					 * MonoObject *obj = create_custom_attr (ainfo->image, centry->ctor, centry->data, centry->data_size, error); */
 					mono_error_cleanup (error);
-					MonoMethod *getter = mono_class_get_method_from_name (klass, "get_Category", -1);
+					error_init (error);
+					MonoMethod *getter = mono_class_get_method_from_name_checked (klass, "get_Category", -1, 0, error);
+					mono_error_cleanup (error);
+					error_init (error);
 					MonoObject *str = mini_get_interp_callbacks ()->runtime_invoke (getter, obj, NULL, &exc, error);
 					mono_error_cleanup (error);
+					error_init (error);
 					char *utf8_str = mono_string_to_utf8_checked ((MonoString *) str, error);
 					mono_error_cleanup (error);
+					error_init (error);
 					if (!strcmp (utf8_str, "!INTERPRETER")) {
 						g_print ("skip %s...\n", method->name);
 						filter = FALSE;

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1093,7 +1093,8 @@ no_intrinsic:
 			MonoType *base_type = mono_class_enum_basetype (constrained_class);
 			g_assert (base_type);
 			constrained_class = mono_class_from_mono_type (base_type);
-			target_method = mono_class_get_method_from_name (constrained_class, target_method->name, 0);
+			target_method = mono_class_get_method_from_name_checked (constrained_class, target_method->name, 0, 0, error);
+			mono_error_assert_ok (error);
 			g_assert (target_method);
 		}
 	}
@@ -2999,9 +3000,10 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsig
 			if (mono_class_is_nullable (klass)) {
 				MonoMethod *target_method;
 				if (m_class_is_enumtype (mono_class_get_nullable_param (klass)))
-					target_method = mono_class_get_method_from_name (klass, "UnboxExact", 1);
+					target_method = mono_class_get_method_from_name_checked (klass, "UnboxExact", 1, 0, error);
 				else
-					target_method = mono_class_get_method_from_name (klass, "Unbox", 1);
+					target_method = mono_class_get_method_from_name_checked (klass, "Unbox", 1, 0, error);
+				goto_if_nok (error, exit);
 				/* td->ip is incremented by interp_transform_call */
 				interp_transform_call (td, method, target_method, domain, generic_context, is_bb_start, body_start_offset, NULL, FALSE, error, FALSE);
 				goto_if_nok (error, exit);
@@ -3037,9 +3039,10 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsig
 			} else if (mono_class_is_nullable (klass)) {
 				MonoMethod *target_method;
 				if (m_class_is_enumtype (mono_class_get_nullable_param (klass)))
-					target_method = mono_class_get_method_from_name (klass, "UnboxExact", 1);
+					target_method = mono_class_get_method_from_name_checked (klass, "UnboxExact", 1, 0, error);
 				else
-					target_method = mono_class_get_method_from_name (klass, "Unbox", 1);
+					target_method = mono_class_get_method_from_name_checked (klass, "Unbox", 1, 0, error);
+				goto_if_nok (error, exit);
 				/* td->ip is incremented by interp_transform_call */
 				interp_transform_call (td, method, target_method, domain, generic_context, is_bb_start, body_start_offset, NULL, FALSE, error, FALSE);
 
@@ -3372,7 +3375,8 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsig
 			CHECK_TYPELOAD (klass);
 
 			if (mono_class_is_nullable (klass)) {
-				MonoMethod *target_method = mono_class_get_method_from_name (klass, "Box", 1);
+				MonoMethod *target_method = mono_class_get_method_from_name_checked (klass, "Box", 1, 0, error);
+				goto_if_nok (error, exit);
 				/* td->ip is incremented by interp_transform_call */
 				interp_transform_call (td, method, target_method, domain, generic_context, is_bb_start, body_start_offset, NULL, FALSE, error, FALSE);
 				goto_if_nok (error, exit);

--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -184,13 +184,13 @@ emit_span_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature
 {
 	MonoInst *ins;
 
-	MonoClassField *ptr_field = mono_class_get_field_from_name (cmethod->klass, "_pointer");
+	MonoClassField *ptr_field = mono_class_get_field_from_name_full (cmethod->klass, "_pointer", NULL);
 	if (!ptr_field)
 		/* Portable Span<T> */
 		return NULL;
 
 	if (!strcmp (cmethod->name, "get_Item")) {
-		MonoClassField *length_field = mono_class_get_field_from_name (cmethod->klass, "_length");
+		MonoClassField *length_field = mono_class_get_field_from_name_full (cmethod->klass, "_length", NULL);
 
 		g_assert (length_field);
 
@@ -223,7 +223,7 @@ emit_span_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature
 
 		return ins;
 	} else if (!strcmp (cmethod->name, "get_Length")) {
-		MonoClassField *length_field = mono_class_get_field_from_name (cmethod->klass, "_length");
+		MonoClassField *length_field = mono_class_get_field_from_name_full (cmethod->klass, "_length", NULL);
 		g_assert (length_field);
 
 		/*

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2234,7 +2234,10 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 	if (!resume) {
 		MonoContext ctx_cp = *ctx;
 		if (mono_trace_is_enabled ()) {
-			MonoMethod *system_exception_get_message = mono_class_get_method_from_name (mono_defaults.exception_class, "get_Message", 0);
+			ERROR_DECL (error);
+			MonoMethod *system_exception_get_message = mono_class_get_method_from_name_checked (mono_defaults.exception_class, "get_Message", 0, 0, error);
+			mono_error_cleanup (error);
+			error_init (error);
 			MonoMethod *get_message = system_exception_get_message == NULL ? NULL : mono_object_get_virtual_method (obj, system_exception_get_message);
 			MonoObject *message;
 			const char *type_name = mono_class_get_name (mono_object_class (mono_ex));

--- a/mono/mini/mini-native-types.c
+++ b/mono/mini/mini-native-types.c
@@ -438,7 +438,7 @@ mono_class_is_magic_float (MonoClass *klass)
 		magic_nfloat_class = klass;
 
 		/* Assert that we are using the matching assembly */
-		MonoClassField *value_field = mono_class_get_field_from_name (klass, "v");
+		MonoClassField *value_field = mono_class_get_field_from_name_full (klass, "v", NULL);
 		g_assert (value_field);
 		MonoType *t = mono_field_get_type (value_field);
 		MonoType *native = mini_native_type_replace_type (m_class_get_byval_arg (klass));

--- a/mono/mini/mini-wasm.c
+++ b/mono/mini/mini-wasm.c
@@ -178,7 +178,8 @@ mono_set_timeout_exec (int id)
 	MonoClass *klass = mono_class_load_from_name (mono_defaults.corlib, "System.Threading", "WasmRuntime");
 	g_assert (klass);
 
-	MonoMethod *method = mono_class_get_method_from_name (klass, "TimeoutCallback", -1);
+	MonoMethod *method = mono_class_get_method_from_name_checked (klass, "TimeoutCallback", -1, 0, error);
+	mono_error_assert_ok (error);
 	g_assert (method);
 
 	gpointer params[1] = { &id };


### PR DESCRIPTION
For hybrid suspend we need all entry points into the runtime from native code to be annotated with transitions to GC Unsafe mode.  This is the second set of changes after #8847. The overall project is #6921 

One sizeable change here is marking `mono_class_get_method_from_name` as external only - and updating the runtime to use `mono_class_get_method_from_name_checked`.