### PR TITLE
[WIP] [jit] Add new OP_EXTEND/OP_INSERT opcodes to represent loading/storing fields of vtypes. Extend the alias analysis pass to convert loads/stores to the new opcodes. Only enabled for Span<T>/ReadOnlySpan<T> for now.

### DIFF
--- a/mono/mini/alias-analysis.c
+++ b/mono/mini/alias-analysis.c
@@ -266,10 +266,7 @@ handle_instruction:
 						if (ins->opcode == OP_LOADI4_MEMBASE || ins->opcode == OP_LOAD_MEMBASE) {
 							if (cfg->verbose_level > 2) { printf ("Converted to extract:"); mono_print_ins (ins); }
 							MonoInst *var = (MonoInst*)tmp->inst_p0;
-							if (ins->opcode == OP_LOADI4_MEMBASE)
-								ins->opcode = OP_EXTRACTI4;
-							else
-								ins->opcode = OP_EXTRACTI;
+							ins->opcode = mono_load_membase_to_extract (ins->opcode);
 							ins->sreg1 = var->dreg;
 							ins->inst_imm = mini_field_offset_to_field_index (var->klass, ins->inst_offset);
 							ins->klass = var->klass;

--- a/mono/mini/mini-codegen.c
+++ b/mono/mini/mini-codegen.c
@@ -504,6 +504,16 @@ mono_print_ins_index_strbuf (int i, MonoInst *ins)
 		case OP_CASTCLASS:
 			g_string_append_printf (sbuf, " %s", m_class_get_name (ins->klass));
 			break;
+		case OP_LOCAL: {
+			char *name = mono_type_full_name (ins->inst_vtype);
+			g_string_append_printf (sbuf, " [%s]", name);
+			g_free (name);
+			break;
+		}
+		case OP_EXTRACTI4:
+		case OP_EXTRACTI:
+			g_string_append_printf (sbuf, " + 0x%lx [findex=%d]", (long)ins->inst_offset, (int)ins->inst_imm);
+			break;
 		default:
 			break;
 		}

--- a/mono/mini/mini-ops.h
+++ b/mono/mini/mini-ops.h
@@ -185,6 +185,15 @@ MINI_OP(OP_FMOVE,	"fmove", FREG, FREG, NONE)
 MINI_OP(OP_VMOVE,   "vmove", VREG, VREG, NONE)
 MINI_OP(OP_RMOVE,	"rmove", FREG, FREG, NONE)
 
+/* Load the field at inst_offset from the vtype sreg1 */
+/* inst_imm is the field index of the field loaded */
+MINI_OP(OP_EXTRACTI4, "extracti4", IREG, VREG, NONE)
+MINI_OP(OP_EXTRACTI, "extracti", IREG, VREG, NONE)
+
+/* Set the field at inst_offset in the vtype sreg1 from sreg2, store the result into dreg */
+MINI_OP(OP_INSERTI4, "inserti4", VREG, VREG, IREG)
+MINI_OP(OP_INSERTI, "inserti", VREG, VREG, IREG)
+
 /*
  * All 4 of these are only available when soft float isn't active. They
  * perform no conversions; they simply move values back and forth.

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3553,6 +3553,9 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 	if (cfg->opt & MONO_OPT_ALIAS_ANALYSIS) {
 		MONO_TIME_TRACK (mono_jit_stats.jit_local_alias_analysis, mono_local_alias_analysis (cfg));
 		mono_cfg_dump_ir (cfg, "local_alias_analysis");
+		// FIXME: Add a separate opt for this
+		MONO_TIME_TRACK (mono_jit_stats.jit_scalar_repl, mono_scalar_repl (cfg));
+		mono_cfg_dump_ir (cfg, "scalar_repl");
 	}
 	/* Disable this for LLVM to make the IR easier to handle */
 	if (!COMPILE_LLVM (cfg)) {

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -4265,6 +4265,21 @@ mini_realloc_code_slow (MonoCompile *cfg, int size)
 	return cfg->native_code + cfg->code_len;
 }
 
+int
+mini_field_offset_to_field_index (MonoClass *klass, int offset)
+{
+	MonoClassField *fields = m_class_get_fields (klass);
+	int fcount = mono_class_get_field_count (klass);
+
+	for (int i = 0; i < fcount; ++i) {
+		MonoClassField *field = &fields [i];
+		if (field->offset - sizeof (MonoObject) == offset)
+			return i;
+	}
+	g_assert_not_reached ();
+	return -1;
+}
+
 #endif /* DISABLE_JIT */
 
 gboolean

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1987,6 +1987,10 @@ MONO_LLVM_INTERNAL const char* mono_inst_name                  (int op);
 int       mono_op_to_op_imm                 (int opcode);
 int       mono_op_imm_to_op                 (int opcode);
 int       mono_load_membase_to_load_mem     (int opcode);
+int       mono_load_membase_to_extract      (int opcode);
+int       mono_load_membase_to_insert       (int opcode);
+int       mono_insert_to_store_membase_reg  (int opcode);
+int       mono_extract_to_load_membase      (int opcode);
 guint     mono_type_to_load_membase         (MonoCompile *cfg, MonoType *type);
 guint     mono_type_to_store_membase        (MonoCompile *cfg, MonoType *type);
 guint32   mono_type_to_stloc_coerce         (MonoType *type);
@@ -2122,6 +2126,7 @@ void              mini_emit_memcpy (MonoCompile *cfg, int destreg, int doffset, 
 void              mini_emit_memset (MonoCompile *cfg, int destreg, int offset, int size, int val, int align);
 void              mini_emit_stobj (MonoCompile *cfg, MonoInst *dest, MonoInst *src, MonoClass *klass, gboolean native);
 void              mini_emit_initobj (MonoCompile *cfg, MonoInst *dest, const guchar *ip, MonoClass *klass);
+void              mini_emit_init_rvar (MonoCompile *cfg, int dreg, MonoType *rtype);
 int               mini_emit_sext_index_reg (MonoCompile *cfg, MonoInst *index);
 MonoInst*         mini_emit_ldelema_1_ins (MonoCompile *cfg, MonoClass *klass, MonoInst *arr, MonoInst *index, gboolean bcheck);
 MonoInst*         mini_emit_get_gsharedvt_info_klass (MonoCompile *cfg, MonoClass *klass, MonoRgctxInfoType rgctx_type);
@@ -2687,5 +2692,11 @@ MonoType*   mini_native_type_replace_type (MonoType *type) MONO_LLVM_INTERNAL;
 
 MonoMethod*
 mini_method_to_shared (MonoMethod *method); // null if not shared
+
+gboolean
+mini_is_scalar_repl_class (MonoClass *klass);
+
+int
+mini_field_offset_to_field_index (MonoClass *klass, int offset);
 
 #endif /* __MONO_MINI_H__ */

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1578,6 +1578,7 @@ typedef struct {
 	gdouble jit_handle_global_vregs;
 	gdouble jit_local_deadce;
 	gdouble jit_local_alias_analysis;
+	gdouble jit_scalar_repl;
 	gdouble jit_if_conversion;
 	gdouble jit_bb_ordering;
 	gdouble jit_compile_dominator_info;
@@ -2480,6 +2481,8 @@ extern void
 mono_local_deadce (MonoCompile *cfg);
 void
 mono_local_alias_analysis (MonoCompile *cfg);
+void
+mono_scalar_repl (MonoCompile *cfg);
 
 /* Generic sharing */
 


### PR DESCRIPTION
Part of #7249 