### PR TITLE
Fix many warnings like: icall.c:666:2: warning: format string is not a string literal (potentially insecure) [-Wformat-security]

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -913,7 +913,7 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_InitializeArray (MonoAr
 		return;
 
 	if (!(field_type->attrs & FIELD_ATTRIBUTE_HAS_FIELD_RVA)) {
-		mono_error_set_argument (error, "field_handle", "Field '%s' doesn't have an RVA", mono_field_get_name (field_handle));
+		mono_error_set_argument_format (error, "field_handle", "Field '%s' doesn't have an RVA", mono_field_get_name (field_handle));
 		return;
 	}
 

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -781,7 +781,7 @@ mono_array_to_byvalarray (gpointer native_arr, MonoArray *arr, MonoClass *elclas
 		as = g_utf16_to_utf8 (mono_array_addr (arr, gunichar2, 0), mono_array_length (arr), NULL, NULL, &gerror);
 		if (gerror) {
 			ERROR_DECL (error);
-			mono_error_set_argument (error, "string", "%s", gerror->message);
+			mono_error_set_argument (error, "string", gerror->message);
 			mono_error_set_pending_exception (error);
 			g_error_free (gerror);
 			return;
@@ -5069,7 +5069,7 @@ ves_icall_System_Runtime_InteropServices_Marshal_SizeOf (MonoReflectionTypeHandl
 	if (type->type == MONO_TYPE_PTR || type->type == MONO_TYPE_FNPTR) {
 		return sizeof (gpointer);
 	} else if (layout == TYPE_ATTRIBUTE_AUTO_LAYOUT) {
-		mono_error_set_argument (error, "t", "Type %s cannot be marshaled as an unmanaged structure.", m_class_get_name (klass));
+		mono_error_set_argument_format (error, "t", "Type %s cannot be marshaled as an unmanaged structure.", m_class_get_name (klass));
 		return 0;
 	}
 
@@ -5218,7 +5218,7 @@ ves_icall_System_Runtime_InteropServices_Marshal_OffsetOf (MonoReflectionTypeHan
 		/* Get back original class instance */
 		klass = mono_class_from_mono_type (type);
 
-		mono_error_set_argument (error, "fieldName", "Field passed in is not a marshaled member of the type %s", m_class_get_name (klass));
+		mono_error_set_argument_format (error, "fieldName", "Field passed in is not a marshaled member of the type %s", m_class_get_name (klass));
 		return 0;
 	}
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -25,13 +25,10 @@
 #define MONO_CHECK_ARG(arg, expr, retval) do {				\
 	if (G_UNLIKELY (!(expr)))					\
 	{								\
-		char *msg = g_strdup_printf ("assertion `%s' failed",	\
-		#expr);							\
 		if (arg) {} /* check if the name exists */		\
 		ERROR_DECL (error);					\
-		mono_error_set_argument (error, #arg, msg);		\
+		mono_error_set_argument_format (error, #arg, "assertion `%s' failed", #expr); \
 		mono_error_set_pending_exception (error);		\
-		g_free (msg);						\
 		return retval;						\
 	} 								\
 } while (0)

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -7394,7 +7394,7 @@ mono_ldstr_utf8 (MonoImage *image, guint32 idx, MonoError *error)
 
 	as = g_utf16_to_utf8 ((guint16*)str, len2, NULL, &written, &gerror);
 	if (gerror) {
-		mono_error_set_argument (error, "string", "%s", gerror->message);
+		mono_error_set_argument (error, "string", gerror->message);
 		g_error_free (gerror);
 		return NULL;
 	}
@@ -7455,7 +7455,7 @@ mono_utf16_to_utf8 (const gunichar2 *s, gsize slength, MonoError *error)
 
 	as = g_utf16_to_utf8 (s, slength, NULL, &written, &gerror);
 	if (gerror) {
-		mono_error_set_argument (error, "string", "%s", gerror->message);
+		mono_error_set_argument (error, "string", gerror->message);
 		g_error_free (gerror);
 		return NULL;
 	}

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -1828,7 +1828,7 @@ mono_reflection_parse_type_checked (char *name, MonoTypeNameParse *info, MonoErr
 	if (ok) {
 		mono_identifier_unescape_info (info);
 	} else {
-		mono_error_set_argument (error, "typeName", "failed parse: %s", name);
+		mono_error_set_argument_format (error, "typeName", "failed parse: %s", name);
 	}
 	return (ok != 0);
 }
@@ -2412,7 +2412,7 @@ mono_reflection_bind_generic_parameters (MonoReflectionTypeHandle reftype, int t
 	guint gtd_type_argc = mono_class_get_generic_container (klass)->type_argc;
 	if (gtd_type_argc != type_argc) {
 		mono_loader_unlock ();
-		mono_error_set_argument (error, "types", "The generic type definition needs %d type arguments, but was instantiated with %d ", gtd_type_argc, type_argc);
+		mono_error_set_argument_format (error, "types", "The generic type definition needs %d type arguments, but was instantiated with %d ", gtd_type_argc, type_argc);
 		return NULL;
 	}
 

--- a/mono/metadata/sre-save.c
+++ b/mono/metadata/sre-save.c
@@ -357,16 +357,24 @@ method_encode_code (MonoDynamicImage *assembly, ReflectionMethodBuilder *mb, Mon
 			num_exception = mono_reflection_method_count_clauses (mb->ilgen);
 	} else {
 		code = mb->code;
-		if (code == NULL){
-			ERROR_DECL_VALUE (inner_error);
-			char *name = mono_string_to_utf8_checked (mb->name, &inner_error);
-			if (!is_ok (&inner_error)) {
+		if (code == NULL) {
+			ERROR_DECL (inner_error);
+			char *name = mono_string_to_utf8_checked (mb->name, inner_error);
+#if 1
+			// FIXME name and str are not used.
+			// Can the error message compatibly change?
+			if (!is_ok (inner_error))
 				name = g_strdup ("");
-				mono_error_cleanup (&inner_error);
-			}
 			char *str = g_strdup_printf ("Method %s does not have any IL associated", name);
 			mono_error_set_argument (error, NULL, "a method does not have any IL associated");
 			g_free (str);
+#else
+			if (!is_ok (inner_error))
+				mono_error_set_argument (error, NULL, "a method does not have any IL associated");
+			else
+				mono_error_set_argument_format (error, NULL, "Method %s does not have any IL associated", name);
+#endif
+			mono_error_cleanup (inner_error);
 			g_free (name);
 			return 0;
 		}

--- a/mono/metadata/sre-save.c
+++ b/mono/metadata/sre-save.c
@@ -360,20 +360,10 @@ method_encode_code (MonoDynamicImage *assembly, ReflectionMethodBuilder *mb, Mon
 		if (code == NULL) {
 			ERROR_DECL (inner_error);
 			char *name = mono_string_to_utf8_checked (mb->name, inner_error);
-#if 1
-			// FIXME name and str are not used.
-			// Can the error message compatibly change?
-			if (!is_ok (inner_error))
-				name = g_strdup ("");
-			char *str = g_strdup_printf ("Method %s does not have any IL associated", name);
-			mono_error_set_argument (error, NULL, "a method does not have any IL associated");
-			g_free (str);
-#else
 			if (!is_ok (inner_error))
 				mono_error_set_argument (error, NULL, "a method does not have any IL associated");
 			else
 				mono_error_set_argument_format (error, NULL, "Method %s does not have any IL associated", name);
-#endif
 			mono_error_cleanup (inner_error);
 			g_free (name);
 			return 0;

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -164,7 +164,10 @@ void
 mono_error_set_out_of_memory (MonoError *error, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(2,3);
 
 void
-mono_error_set_argument (MonoError *error, const char *argument, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(3,4);
+mono_error_set_argument_format (MonoError *error, const char *argument, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(3,4);
+
+void
+mono_error_set_argument (MonoError *error, const char *argument, const char *msg);
 
 void
 mono_error_set_argument_null (MonoError *oerror, const char *argument, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(3,4);

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -482,7 +482,7 @@ mono_error_set_out_of_memory (MonoError *oerror, const char *msg_format, ...)
 }
 
 void
-mono_error_set_argument (MonoError *oerror, const char *argument, const char *msg_format, ...)
+mono_error_set_argument_format (MonoError *oerror, const char *argument, const char *msg_format, ...)
 {
 	MonoErrorInternal *error = (MonoErrorInternal*)oerror;
 	mono_error_prepare (error);
@@ -491,6 +491,18 @@ mono_error_set_argument (MonoError *oerror, const char *argument, const char *ms
 	error->first_argument = argument;
 
 	set_error_message ();
+}
+
+void
+mono_error_set_argument (MonoError *oerror, const char *argument, const char *msg)
+{
+	MonoErrorInternal *error = (MonoErrorInternal*)oerror;
+	mono_error_prepare (error);
+
+	error->error_code = MONO_ERROR_ARGUMENT;
+	error->first_argument = argument;
+	if (msg && msg [0] && !(error->full_message = g_strdup (msg)))
+		error->flags |= MONO_ERROR_INCOMPLETE;
 }
 
 void


### PR DESCRIPTION
Most uses of mono_error_set_argument do not take a format string.
So rename mono_error_set_argument to mono_error_set_argument_format
and provide mono_error_set_argument that just takes one string, not to be formated.

Visit every call to mono_error_set_argument and change just a few to be mono_error_set_argument_format.

While there, notice that method_encode_code forms up extra data and does not use it.