### PR TITLE
[tailcall] Split up large tests for fine grained enable/disable, instead of large scale disable (F# and interface).

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4264,6 +4264,14 @@ esac
 #WASM hack
 fi
 
+MONO_ARCH_GSHAREDVT_SUPPORTED=0
+case "$HOST" in
+X86 | AMD64 | ARM | ARM64)
+	MONO_ARCH_GSHAREDVT_SUPPORTED=1 # keep in sync with mini-{x86,amd64,arm,arm64}.h
+	;;
+esac
+
+AM_CONDITIONAL(MONO_ARCH_GSHAREDVT_SUPPORTED, test $MONO_ARCH_GSHAREDVT_SUPPORTED = 1)
 
 dnl *************
 dnl *** VTUNE ***

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -1254,18 +1254,6 @@ mono_arch_get_argument_info (MonoMethodSignature *csig, int param_count, MonoJit
 	return args_size;
 }
 
-static const gboolean debug_tailcall = FALSE;
-
-static gboolean
-is_supported_tailcall_helper (gboolean value, const char *svalue)
-{
-	if (!value && debug_tailcall)
-		g_print ("%s %s\n", __func__, svalue);
-	return value;
-}
-
-#define IS_SUPPORTED_TAILCALL(x) (is_supported_tailcall_helper((x), #x))
-
 gboolean
 mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig, MonoMethodSignature *callee_sig)
 {

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -1795,18 +1795,6 @@ mono_arch_get_native_call_context_ret (CallContext *ccontext, gpointer frame, Mo
 	g_free (cinfo);
 }
 
-static const gboolean debug_tailcall = FALSE;
-
-static gboolean
-is_supported_tailcall_helper (gboolean value, const char *svalue)
-{
-	if (!value && debug_tailcall)
-		g_print ("%s %s\n", __func__, svalue);
-	return value;
-}
-
-#define IS_SUPPORTED_TAILCALL(x) (is_supported_tailcall_helper((x), #x))
-
 gboolean
 mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig, MonoMethodSignature *callee_sig)
 {

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -1795,6 +1795,8 @@ mono_arch_get_native_call_context_ret (CallContext *ccontext, gpointer frame, Mo
 	g_free (cinfo);
 }
 
+#ifndef DISABLE_JIT
+
 gboolean
 mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig, MonoMethodSignature *callee_sig)
 {
@@ -1821,8 +1823,6 @@ mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig,
 
 	return res;
 }
-
-#ifndef DISABLE_JIT
 
 static gboolean
 debug_omit_fp (void)

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -2748,18 +2748,6 @@ mono_arch_emit_setret (MonoCompile *cfg, MonoMethod *method, MonoInst *val)
 	}
 }
 
-static const gboolean debug_tailcall = FALSE;
-
-static gboolean
-is_supported_tailcall_helper (gboolean value, const char *svalue)
-{
-	if (!value && debug_tailcall)
-		g_print ("%s %s\n", __func__, svalue);
-	return value;
-}
-
-#define IS_SUPPORTED_TAILCALL(x) (is_supported_tailcall_helper((x), #x))
-
 gboolean
 mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig, MonoMethodSignature *callee_sig)
 {

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -2748,6 +2748,8 @@ mono_arch_emit_setret (MonoCompile *cfg, MonoMethod *method, MonoInst *val)
 	}
 }
 
+#ifndef DISABLE_JIT
+
 gboolean
 mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig, MonoMethodSignature *callee_sig)
 {
@@ -2777,6 +2779,8 @@ mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig,
 
 	return res;
 }
+
+#endif
 
 gboolean 
 mono_arch_is_inst_imm (int opcode, int imm_opcode, gint64 imm)

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -1344,6 +1344,8 @@ get_call_info (MonoMethodSignature *sig)
 	return cinfo;
 }
 
+#ifndef DISABLE_JIT
+
 gboolean
 mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig, MonoMethodSignature *callee_sig)
 {
@@ -1365,6 +1367,8 @@ mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig,
 
 	return res;
 }
+
+#endif
 
 /*
  * Set var information according to the calling convention. ppc version.

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -1344,18 +1344,6 @@ get_call_info (MonoMethodSignature *sig)
 	return cinfo;
 }
 
-static const gboolean debug_tailcall = FALSE;
-
-static gboolean
-is_supported_tailcall_helper (gboolean value, const char *svalue)
-{
-	if (!value && debug_tailcall)
-		g_print ("%s %s\n", __func__, svalue);
-	return value;
-}
-
-#define IS_SUPPORTED_TAILCALL(x) (is_supported_tailcall_helper((x), #x))
-
 gboolean
 mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig, MonoMethodSignature *callee_sig)
 {

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -7546,18 +7546,6 @@ mono_arch_opcode_supported (int opcode)
 /*                                                                  */
 /*------------------------------------------------------------------*/
 
-static const gboolean debug_tailcall = FALSE;
-
-static gboolean
-is_supported_tailcall_helper (gboolean value, const char *svalue)
-{
-	if (!value && debug_tailcall)
-		g_print ("%s %s\n", __func__, svalue);
-	return value;
-}
-
-#define IS_SUPPORTED_TAILCALL(x) (is_supported_tailcall_helper((x), #x))
-
 gboolean
 mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig, MonoMethodSignature *callee_sig)
 {

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -7546,6 +7546,8 @@ mono_arch_opcode_supported (int opcode)
 /*                                                                  */
 /*------------------------------------------------------------------*/
 
+#ifndef DISABLE_JIT
+
 gboolean
 mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig, MonoMethodSignature *callee_sig)
 {
@@ -7573,5 +7575,7 @@ mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig,
 
 	return res;
 }
+
+#endif
 
 /*========================= End of Function ========================*/

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -672,6 +672,8 @@ mono_arch_get_argument_info (MonoMethodSignature *csig, int param_count, MonoJit
 	return args_size;
 }
 
+#ifndef DISABLE_JIT
+
 gboolean
 mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig, MonoMethodSignature *callee_sig)
 {
@@ -700,6 +702,8 @@ exit:
 
 	return res;
 }
+
+#endif
 
 /*
  * Initialize the cpu to execute managed code.

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -672,18 +672,6 @@ mono_arch_get_argument_info (MonoMethodSignature *csig, int param_count, MonoJit
 	return args_size;
 }
 
-static const gboolean debug_tailcall = FALSE;
-
-static gboolean
-is_supported_tailcall_helper (gboolean value, const char *svalue)
-{
-	if (!value && debug_tailcall)
-		g_print ("%s %s\n", __func__, svalue);
-	return value;
-}
-
-#define IS_SUPPORTED_TAILCALL(x) (is_supported_tailcall_helper((x), #x))
-
 gboolean
 mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig, MonoMethodSignature *callee_sig)
 {
@@ -699,7 +687,7 @@ mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig,
 	 */
 	gboolean res = IS_SUPPORTED_TAILCALL (callee_info->stack_usage <= caller_info->stack_usage)
 				&& IS_SUPPORTED_TAILCALL (caller_info->ret.storage == callee_info->ret.storage);
-	if (!res && !debug_tailcall)
+	if (!res && !mono_tailcall_print_enabled ())
 		goto exit;
 
 	// Limit stack_usage to 1G.

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2469,6 +2469,17 @@ MONO_API gboolean mono_breakpoint_clean_code (guint8 *method_start, guint8 *code
 MonoCallSpec *mono_trace_set_options           (const char *options);
 gboolean       mono_trace_eval                  (MonoMethod *method);
 
+gboolean
+mono_tailcall_print_enabled (void);
+
+void
+mono_tailcall_print (const char *format, ...);
+
+gboolean
+mono_is_supported_tailcall_helper (gboolean value, const char *svalue);
+
+#define IS_SUPPORTED_TAILCALL(x) (mono_is_supported_tailcall_helper((x), #x))
+
 extern void
 mono_perform_abc_removal (MonoCompile *cfg);
 extern void

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -696,6 +696,163 @@ if HOST_DARWIN
 TESTS_CS_SRC += bug-8417.cs
 endif
 
+if CROSS_COMPILING # FIXME build vs. host vs. target
+TAILCALL_INTERFACE_CONSERVESTACK_IL=
+TAILCALL_FSHARP_DEEPTAIL_IL=
+else
+if HOST_WASM # FIXME build problem
+TAILCALL_INTERFACE_CONSERVESTACK_IL=
+TAILCALL_FSHARP_DEEPTAIL_IL=
+else
+if HOST_WIN32 # FIXME build problem
+TAILCALL_INTERFACE_CONSERVESTACK_IL=
+TAILCALL_FSHARP_DEEPTAIL_IL=
+else
+# These tests are produced by splitting up tailcall-interface-conservestack.il.
+TAILCALL_INTERFACE_CONSERVESTACK_IL=\
+	tailcall/interface-conservestack/1.il \
+	tailcall/interface-conservestack/10.il \
+	tailcall/interface-conservestack/11.il \
+	tailcall/interface-conservestack/12.il \
+	tailcall/interface-conservestack/13.il \
+	tailcall/interface-conservestack/14.il \
+	tailcall/interface-conservestack/15.il \
+	tailcall/interface-conservestack/16.il \
+	tailcall/interface-conservestack/17.il \
+	tailcall/interface-conservestack/18.il \
+	tailcall/interface-conservestack/19.il \
+	tailcall/interface-conservestack/2.il \
+	tailcall/interface-conservestack/20.il \
+	tailcall/interface-conservestack/21.il \
+	tailcall/interface-conservestack/22.il \
+	tailcall/interface-conservestack/23.il \
+	tailcall/interface-conservestack/24.il \
+	tailcall/interface-conservestack/25.il \
+	tailcall/interface-conservestack/26.il \
+	tailcall/interface-conservestack/27.il \
+	tailcall/interface-conservestack/28.il \
+	tailcall/interface-conservestack/29.il \
+	tailcall/interface-conservestack/3.il \
+	tailcall/interface-conservestack/30.il \
+	tailcall/interface-conservestack/31.il \
+	tailcall/interface-conservestack/32.il \
+	tailcall/interface-conservestack/33.il \
+	tailcall/interface-conservestack/34.il \
+	tailcall/interface-conservestack/35.il \
+	tailcall/interface-conservestack/36.il \
+	tailcall/interface-conservestack/37.il \
+	tailcall/interface-conservestack/38.il \
+	tailcall/interface-conservestack/39.il \
+	tailcall/interface-conservestack/4.il \
+	tailcall/interface-conservestack/40.il \
+	tailcall/interface-conservestack/41.il \
+	tailcall/interface-conservestack/42.il \
+	tailcall/interface-conservestack/43.il \
+	tailcall/interface-conservestack/44.il \
+	tailcall/interface-conservestack/45.il \
+	tailcall/interface-conservestack/46.il \
+	tailcall/interface-conservestack/47.il \
+	tailcall/interface-conservestack/48.il \
+	tailcall/interface-conservestack/49.il \
+	tailcall/interface-conservestack/5.il \
+	tailcall/interface-conservestack/50.il \
+	tailcall/interface-conservestack/51.il \
+	tailcall/interface-conservestack/52.il \
+	tailcall/interface-conservestack/53.il \
+	tailcall/interface-conservestack/6.il \
+	tailcall/interface-conservestack/7.il \
+	tailcall/interface-conservestack/8.il \
+	tailcall/interface-conservestack/9.il
+
+# These tests are produced by splitting up tailcall/fsharp-deeptail.il.
+TAILCALL_FSHARP_DEEPTAIL_IL=\
+	tailcall/fsharp-deeptail/Seq.filter-length1.il \
+	tailcall/fsharp-deeptail/Seq.filter-length2.il \
+	tailcall/fsharp-deeptail/Seq.filter-length3.il \
+	tailcall/fsharp-deeptail/StaticTailCallLoop_DateTime_.il \
+	tailcall/fsharp-deeptail/StaticTailCallLoop_int_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_DateTime_.Method1_DateTime_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_DateTime_.Method1_byte_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_DateTime_.Method1_int_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_DateTime_.Method1_string_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_DatstringeTime_.Method1_string_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_byte_.Method1_DateTime_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_byte_.Method1_byte_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_byte_.Method1_int_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_byte_.Method1_string_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_int_.Method1_DateTime_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_int_.Method1_byte_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_int_.Method1_int_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_int_.Method1_string_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_string_.Method1_DateTime_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_string_.Method1_byte_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_string_.Method1_int_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_DateTime_.Method1_DateTime_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_DateTime_.Method1_byte_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_DateTime_.Method1_int_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_DateTime_.Method1_string_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_DatstringeTime_.Method1_string_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_byte_.Method1_DateTime_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_byte_.Method1_byte_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_byte_.Method1_int_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_byte_.Method1_string_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_int_.Method1_DateTime_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_int_.Method1_byte_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_int_.Method1_int_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_int_.Method1_string_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_string_.Method1_DateTime_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_string_.Method1_byte_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_string_.Method1_int_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_DateTime_.Method1_DateTime_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_DateTime_.Method1_byte_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_DateTime_.Method1_int_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_DateTime_.Method1_string_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_byte_.Method1_DateTime_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_byte_.Method1_byte_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_byte_.Method1_int_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_byte_.Method1_string_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_int_.Method1_DateTime_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_int_.Method1_byte_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_int_.Method1_int_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_int_.Method1_string_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_string_.Method1_DateTime_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_string_.Method1_byte_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_string_.Method1_int_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_string_.Method1_string_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClass_DateTime_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClass_int_.il \
+	tailcall/fsharp-deeptail/TailCallLoopGenericClass_string_.il \
+	tailcall/fsharp-deeptail/TailCallLoop_DateTime_.il \
+	tailcall/fsharp-deeptail/TailCallLoop_int_.il \
+	tailcall/fsharp-deeptail/mutualTail1IsEven.il \
+	tailcall/fsharp-deeptail/mutualTail1IsOdd.il \
+	tailcall/fsharp-deeptail/simpleTail1.il \
+	tailcall/fsharp-deeptail/simpleTail2.il
+
+$(TAILCALL_FSHARP_DEEPTAIL_IL): tailcall/fsharp-deeptail.stamp
+
+$(TAILCALL_INTERFACE_CONSERVESTACK_IL): tailcall/interface-conservestack.stamp
+
+tailcall/fsharp-deeptail.stamp: tailcall/split-fsharp$(EXEEXT) tailcall/fsharp-deeptail.il
+	./tailcall/split-fsharp$(EXEEXT) < $(srcdir)/tailcall/fsharp-deeptail.il
+	touch -f $@
+
+tailcall/interface-conservestack.stamp: split-tailcall-interface-conservestack$(EXEEXT) tailcall-interface-conservestack.il
+	./split-tailcall-interface-conservestack$(EXEEXT) < $(srcdir)/tailcall-interface-conservestack.il
+	touch -f $@
+
+noinst_PROGRAMS = tailcall/split-fsharp split-tailcall-interface-conservestack
+
+tailcall_split_fsharp_SOURCES=tailcall/split-fsharp.cpp
+
+split_tailcall_interface_conservestack_SOURCES=split-tailcall-interface-conservestack.cpp
+
+endif # HOST_WIN32
+endif # HOST_WASM
+endif # CROSS_COMPILING
+
+BUILT_SOURCES=$(TAILCALL_FSHARP_DEEPTAIL_IL) $(TAILCALL_INTERFACE_CONSERVESTACK_IL)
+
 TESTS_IL_SRC=			\
 	tailcall/2.il	     \
 	tailcall/3.il	     \
@@ -703,6 +860,7 @@ TESTS_IL_SRC=			\
 	tailcall/fsharp-deeptail.il	     \
 	tailcall/fsharp-shallowtail.il	 \
 	tailcall/fsharp-shallownotail.il \
+	$(TAILCALL_FSHARP_DEEPTAIL_IL) \
 	gptail1.il		\
 	itail1.il		\
 	itaili1.il		\
@@ -719,7 +877,7 @@ TESTS_IL_SRC=			\
 	tailcall-rgctxb.il 	\
 	tailcall-rgctxb-static.il \
 	tailcall-mrgctx.il 	\
-	tailcall-interface-conservestack.il \
+	$(TAILCALL_INTERFACE_CONSERVESTACK_IL) \
 	tailcall-interface-justrun.il \
 	field-access.il		\
 	method-access.il	\
@@ -891,29 +1049,15 @@ PLATFORM_DISABLED_TESTS += async-exc-compilation.exe finally_guard.exe finally_b
 	unhandled-exception-5.exe unhandled-exception-6.exe unhandled-exception-7.exe unhandled-exception-8.exe
 endif
 
-PLATFORM_DISABLED_TESTS += tailcall-interface-conservestack.exe
-PLATFORM_DISABLED_TESTS += tailcall/2.exe
-PLATFORM_DISABLED_TESTS += tailcall/3.exe
-PLATFORM_DISABLED_TESTS += tailcall/4.exe
-PLATFORM_DISABLED_TESTS += tailcall/8273.exe
-PLATFORM_DISABLED_TESTS += tailcall-rgctxb-static.exe
-PLATFORM_DISABLED_TESTS += tailcall/coreclr/JIT/Methodical/tailcall/test_virt.exe # fix pending
+# test_virt.exe fails because callee takes more parameters than caller, 1 vs. 0, and
+# x86 passes no parameters in registers, so it is a stack imbalance.
+PLATFORM_DISABLED_TESTS += tailcall/coreclr/JIT/Methodical/tailcall/test_virt.exe
+
 endif
 
 if POWERPC
 # bug #71274
 PLATFORM_DISABLED_TESTS += finalizer-abort.exe finalizer-exception.exe finalizer-exit.exe
-PLATFORM_DISABLED_TESTS += tailcall-generic-cast-conservestack-il.exe
-PLATFORM_DISABLED_TESTS += tailcall-mrgctx.exe # MONO_ARCH_HAVE_VOLATILE_NON_PARAM_REGISTER 0
-PLATFORM_DISABLED_TESTS += tailcall-rgctxa.exe # MONO_ARCH_HAVE_VOLATILE_NON_PARAM_REGISTER 0
-PLATFORM_DISABLED_TESTS += tailcall-virt.exe
-PLATFORM_DISABLED_TESTS += tailcall/2.exe
-PLATFORM_DISABLED_TESTS += tailcall/3.exe
-PLATFORM_DISABLED_TESTS += tailcall/4.exe
-PLATFORM_DISABLED_TESTS += tailcall/8273.exe
-PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail.exe
-PLATFORM_DISABLED_TESTS += tailcall-interface-conservestack.exe
-PLATFORM_DISABLED_TESTS += ivtail1.exe
 endif
 
 if POWERPC64
@@ -923,38 +1067,118 @@ PLATFORM_DISABLED_TESTS += monitor.exe threadpool-exceptions5.exe appdomain-unlo
 	pinvoke_ppcs.exe pinvoke_ppci.exe pinvoke_ppcf.exe pinvoke_ppcd.exe abort-cctor.exe load-exceptions.exe \
 	sgen-domain-unload-2.exe sgen-weakref-stress.exe sgen-cementing-stress.exe sgen-new-threads-dont-join-stw.exe \
 	sgen-new-threads-dont-join-stw-2.exe sgen-new-threads-collect.exe sgen-bridge.exe
-PLATFORM_DISABLED_TESTS += tailcall-generic-cast-conservestack-il.exe
-PLATFORM_DISABLED_TESTS += tailcall-mrgctx.exe # MONO_ARCH_HAVE_VOLATILE_NON_PARAM_REGISTER 0
-PLATFORM_DISABLED_TESTS += tailcall-rgctxa.exe # MONO_ARCH_HAVE_VOLATILE_NON_PARAM_REGISTER 0
-PLATFORM_DISABLED_TESTS += tailcall-virt.exe
-PLATFORM_DISABLED_TESTS += tailcall/2.exe
-PLATFORM_DISABLED_TESTS += tailcall/3.exe
-PLATFORM_DISABLED_TESTS += tailcall/4.exe
-PLATFORM_DISABLED_TESTS += tailcall/8273.exe
-PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail.exe
-PLATFORM_DISABLED_TESTS += tailcall/coreclr/JIT/Directed/tailcall/tailcall.exe
-PLATFORM_DISABLED_TESTS += tailcall/coreclr/JIT/Methodical/tailcall/test_virt.exe
-PLATFORM_DISABLED_TESTS += tailcall/coreclr/JIT/Methodical/nonvirtualcall/tailcall.exe
-PLATFORM_DISABLED_TESTS += tailcall-interface-conservestack.exe
-PLATFORM_DISABLED_TESTS += ivtail1.exe
 PLATFORM_DISABLED_TESTS += appdomain-threadpool-unload.exe
 PLATFORM_DISABLED_TESTS += bug-60848.exe
 endif
 
 if ARM
 PLATFORM_DISABLED_TESTS += filter-stack.exe weak-fields.exe
+
+# Most ARM problems are due to extra_arg and cannot be easily fixed, except for easy
+# bitcode-specific fix which has been declined. A few are uncertain and should be investigated,
+# but still probably extra_arg.
+PLATFORM_DISABLED_TESTS += ivtail1.exe
 PLATFORM_DISABLED_TESTS += tailcall-generic-cast-conservestack-il.exe
-PLATFORM_DISABLED_TESTS += tailcall-mrgctx.exe # MONO_ARCH_HAVE_VOLATILE_NON_PARAM_REGISTER 0
-PLATFORM_DISABLED_TESTS += tailcall-rgctxa.exe # MONO_ARCH_HAVE_VOLATILE_NON_PARAM_REGISTER 0
+PLATFORM_DISABLED_TESTS += tailcall-mrgctx.exe
+PLATFORM_DISABLED_TESTS += tailcall-rgctxa.exe
 PLATFORM_DISABLED_TESTS += tailcall-virt.exe
+PLATFORM_DISABLED_TESTS += tailcall/coreclr/JIT/Directed/tailcall/tailcall.exe
 PLATFORM_DISABLED_TESTS += tailcall/2.exe
 PLATFORM_DISABLED_TESTS += tailcall/3.exe
 PLATFORM_DISABLED_TESTS += tailcall/4.exe
-PLATFORM_DISABLED_TESTS += tailcall/8273.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_string_.Method1_string_.exe
+
+# FIXME These presumably take an extra parameter though this should be confirmed.
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_DateTime_.Method1_DateTime_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_DateTime_.Method1_byte_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_DateTime_.Method1_int_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_DateTime_.Method1_string_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_DatstringeTime_.Method1_string_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_byte_.Method1_DateTime_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_byte_.Method1_byte_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_byte_.Method1_int_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_byte_.Method1_string_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_int_.Method1_DateTime_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_int_.Method1_byte_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_int_.Method1_int_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_int_.Method1_string_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_string_.Method1_DateTime_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_string_.Method1_byte_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_string_.Method1_int_.exe
+
+# Interface calls cannot be tailcalls on ARM due to extra_arg. Bitcode could easily work however.
 PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_DateTime_.Method1_DateTime_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_DateTime_.Method1_byte_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_DateTime_.Method1_int_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_DateTime_.Method1_string_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_DatstringeTime_.Method1_string_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_byte_.Method1_DateTime_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_byte_.Method1_byte_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_byte_.Method1_int_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_byte_.Method1_string_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_int_.Method1_DateTime_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_int_.Method1_byte_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_int_.Method1_int_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_int_.Method1_string_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_string_.Method1_DateTime_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_string_.Method1_byte_.exe
+PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_string_.Method1_int_.exe
+
+# Interface calls cannot be tailcalls on ARM due to extra_arg. Bitcode could easily work however.
 PLATFORM_DISABLED_TESTS += tailcall-interface-conservestack.exe
-PLATFORM_DISABLED_TESTS += ivtail1.exe
-PLATFORM_DISABLED_TESTS += tailcall/coreclr/JIT/Directed/tailcall/tailcall.exe  # interface
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/1.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/10.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/11.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/12.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/13.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/14.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/15.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/16.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/17.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/18.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/19.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/2.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/20.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/21.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/22.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/23.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/24.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/25.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/26.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/27.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/28.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/29.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/3.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/30.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/31.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/32.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/33.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/34.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/35.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/36.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/37.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/38.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/39.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/4.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/40.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/41.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/42.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/43.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/44.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/45.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/46.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/47.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/48.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/49.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/5.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/50.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/51.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/52.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/6.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/7.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/8.exe
+PLATFORM_DISABLED_TESTS += tailcall/interface-conservestack/9.exe
 endif
 
 if ARM64
@@ -964,17 +1188,6 @@ endif
 if MIPS
 # monitor.exe is racy
 PLATFORM_DISABLED_TESTS += filter-stack.exe monitor.exe
-PLATFORM_DISABLED_TESTS += tailcall-generic-cast-conservestack-il.exe
-PLATFORM_DISABLED_TESTS += tailcall-mrgctx.exe # MONO_ARCH_HAVE_VOLATILE_NON_PARAM_REGISTER 0
-PLATFORM_DISABLED_TESTS += tailcall-rgctxa.exe # MONO_ARCH_HAVE_VOLATILE_NON_PARAM_REGISTER 0
-PLATFORM_DISABLED_TESTS += tailcall-virt.exe
-PLATFORM_DISABLED_TESTS += tailcall/2.exe
-PLATFORM_DISABLED_TESTS += tailcall/3.exe
-PLATFORM_DISABLED_TESTS += tailcall/4.exe
-PLATFORM_DISABLED_TESTS += tailcall/8273.exe
-PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail.exe
-PLATFORM_DISABLED_TESTS += tailcall-interface-conservestack.exe
-PLATFORM_DISABLED_TESTS += ivtail1.exe
 endif
 
 if S390X
@@ -986,17 +1199,6 @@ PLATFORM_DISABLED_TESTS += \
 	sgen-bridge.exe \
 	sgen-bridge-major-fragmentation.exe \
 	sgen-bridge-xref.exe
-PLATFORM_DISABLED_TESTS += tailcall-generic-cast-conservestack-il.exe
-PLATFORM_DISABLED_TESTS += tailcall-mrgctx.exe # MONO_ARCH_HAVE_VOLATILE_NON_PARAM_REGISTER 0
-PLATFORM_DISABLED_TESTS += tailcall-rgctxa.exe # MONO_ARCH_HAVE_VOLATILE_NON_PARAM_REGISTER 0
-PLATFORM_DISABLED_TESTS += tailcall-virt.exe
-PLATFORM_DISABLED_TESTS += tailcall/2.exe
-PLATFORM_DISABLED_TESTS += tailcall/3.exe
-PLATFORM_DISABLED_TESTS += tailcall/4.exe
-PLATFORM_DISABLED_TESTS += tailcall/8273.exe
-PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail.exe
-PLATFORM_DISABLED_TESTS += tailcall-interface-conservestack.exe
-PLATFORM_DISABLED_TESTS += ivtail1.exe
 endif
 
 PROFILE_DISABLED_TESTS= \
@@ -1181,24 +1383,78 @@ PROFILE_DISABLED_TESTS += \
 PROFILE_DISABLED_TESTS += \
 	weak-fields.exe
 
-PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail.exe
+# Some, probably all, of these tests use gsharedvt.
+# gsharedvt is very much at odds with tailcall, and they fail as a result.
+# RegularAOT and HybridAOT should be ok.
+#
+# The tests might be tweakable but then they will less resemble real world code.
+#
+# FullAOT should probably be changed to intersect tailcall signatures called
+# and all generic signatures provided, and compile more functions.
+# As well, gsharedvt can probably be a tailcall sometimes, like if parameters
+# fit in registers and there is no out conversion. Maybe it already does that.
+#
+# gsharedvt should be viable when only wrapping "in" but not "out",
+# as long as "in" does not expand parameter stack size, which it should never do.
+if MONO_ARCH_GSHAREDVT_SUPPORTED
 PROFILE_DISABLED_TESTS += tailcall-interface-conservestack.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail.exe
+PROFILE_DISABLED_TESTS += tailcall/interface-conservestack/26.exe
+PROFILE_DISABLED_TESTS += tailcall/interface-conservestack/31.exe
+PROFILE_DISABLED_TESTS += tailcall/interface-conservestack/33.exe
+PROFILE_DISABLED_TESTS += tailcall/interface-conservestack/34.exe
+PROFILE_DISABLED_TESTS += tailcall/interface-conservestack/35.exe
+PROFILE_DISABLED_TESTS += tailcall/interface-conservestack/36.exe
+PROFILE_DISABLED_TESTS += tailcall/interface-conservestack/37.exe
+PROFILE_DISABLED_TESTS += tailcall/interface-conservestack/41.exe
+PROFILE_DISABLED_TESTS += tailcall/interface-conservestack/43.exe
+PROFILE_DISABLED_TESTS += tailcall/interface-conservestack/44.exe
+PROFILE_DISABLED_TESTS += tailcall/interface-conservestack/45.exe
+PROFILE_DISABLED_TESTS += tailcall/interface-conservestack/46.exe
+PROFILE_DISABLED_TESTS += tailcall/interface-conservestack/47.exe
+PROFILE_DISABLED_TESTS += tailcall/interface-conservestack/51.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_string_.Method1_int_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_int_.Method1_byte_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_DateTime_.Method1_DateTime_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_string_.Method1_int_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_string_.Method1_DateTime_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_byte_.Method1_int_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_byte_.Method1_byte_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_byte_.Method1_string_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_byte_.Method1_byte_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_int_.Method1_string_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_byte_.Method1_int_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_string_.Method1_byte_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_byte_.Method1_DateTime_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_DateTime_.Method1_byte_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_int_.Method1_int_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_DateTime_.Method1_string_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_int_.Method1_byte_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_byte_.Method1_string_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_DateTime_.Method1_byte_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_int_.Method1_DateTime_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_DateTime_.Method1_int_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_int_.Method1_DateTime_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_string_.Method1_DateTime_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_string_.Method1_byte_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_byte_.Method1_DateTime_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_DateTime_.Method1_int_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_DateTime_.Method1_DateTime_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_int_.Method1_int_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_DateTime_.Method1_string_.exe
+PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_int_.Method1_string_.exe
 
-endif
+endif # MONO_ARCH_GSHAREDVT_SUPPORTED
+endif # FULL_AOT_TESTS
 
 if HYBRID_AOT_TESTS
 PROFILE_DISABLED_TESTS += \
 	bug-80307.exe \
 	namedmutex-destroy-race.exe
-
-PROFILE_DISABLED_TESTS += tailcall/fsharp-deeptail.exe
 endif
 
 AOT_DISABLED_TESTS= \
 	constraints-load.exe
-
-# tailcall/fsharp FullAOT stack overflow in CI but not locally.
-AOT_DISABLED_TESTS += tailcall/fsharp-deeptail.exe
 
 CI_DISABLED_TESTS = \
 	main-returns-background-resetabort.exe \
@@ -1322,6 +1578,124 @@ INTERP_DISABLED_TESTS = $(DISABLED_TESTS) \
 	tailcall/8273.exe \
 	$(TAILCALL_DISABLED_TESTS_RUN) \
 	bug-60843.exe
+# FIXME
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/Seq.filter-length1.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/Seq.filter-length2.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/Seq.filter-length3.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/StaticTailCallLoop_DateTime_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/StaticTailCallLoop_int_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_DateTime_.Method1_DateTime_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_DateTime_.Method1_byte_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_DateTime_.Method1_int_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_DateTime_.Method1_string_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_DatstringeTime_.Method1_string_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_byte_.Method1_DateTime_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_byte_.Method1_byte_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_byte_.Method1_int_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_byte_.Method1_string_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_int_.Method1_DateTime_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_int_.Method1_byte_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_int_.Method1_int_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_int_.Method1_string_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_string_.Method1_DateTime_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_string_.Method1_byte_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractClass_string_.Method1_int_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_DateTime_.Method1_DateTime_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_DateTime_.Method1_byte_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_DateTime_.Method1_int_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_DateTime_.Method1_string_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_DatstringeTime_.Method1_string_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_byte_.Method1_DateTime_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_byte_.Method1_byte_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_byte_.Method1_int_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_byte_.Method1_string_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_int_.Method1_DateTime_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_int_.Method1_byte_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_int_.Method1_int_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_int_.Method1_string_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_string_.Method1_DateTime_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_string_.Method1_byte_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethodAbstractInterface_string_.Method1_int_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_DateTime_.Method1_DateTime_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_DateTime_.Method1_byte_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_DateTime_.Method1_int_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_DateTime_.Method1_string_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_byte_.Method1_DateTime_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_byte_.Method1_byte_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_byte_.Method1_int_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_byte_.Method1_string_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_int_.Method1_DateTime_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_int_.Method1_byte_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_int_.Method1_int_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_int_.Method1_string_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_string_.Method1_DateTime_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_string_.Method1_byte_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_string_.Method1_int_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClassAndMethod_string_.Method1_string_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClass_DateTime_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClass_int_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoopGenericClass_string_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoop_DateTime_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/TailCallLoop_int_.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/mutualTail1IsEven.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/mutualTail1IsOdd.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/simpleTail1.exe
+INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/simpleTail2.exe
+
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/1.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/10.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/11.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/12.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/13.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/14.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/15.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/16.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/17.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/18.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/19.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/2.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/20.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/21.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/22.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/23.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/24.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/25.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/26.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/27.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/28.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/29.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/3.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/30.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/31.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/32.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/33.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/34.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/35.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/36.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/37.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/38.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/39.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/4.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/40.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/41.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/42.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/43.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/44.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/45.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/46.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/47.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/48.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/49.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/5.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/50.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/51.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/52.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/53.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/6.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/7.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/8.exe
+INTERP_DISABLED_TESTS += tailcall/interface-conservestack/9.exe
+
 
 # bug-48015.exe: be careful when re-enabling, it happens that it returns with exit code 0, but doesn't actually execute the test.
 # bug-60862.exe: missing support to map IP->method; only works on platforms with altstack support.
@@ -2619,3 +2993,4 @@ weak-fields.exe: weak-fields.cs Mono.Runtime.Testing.dll
 
 CLEANFILES = $(TESTS_CS) $(TESTS_IL) $(TESTS_BENCH) $(TESTS_STRESS) $(TESTSAOT_CS) $(TESTSAOT_IL) $(TESTSAOT_BENCH) $(TESTSAOT_STRESS) *.dll *.stdout *.aotlog *.exe stest.dat LeafAssembly.dll MidAssembly.dll appdomain-marshalbyref-assemblyload2/*.dll 
 CLEANFILES += $(TESTS_TAILCALL_COMPILE) $(TESTSAOT_TAILCALL)
+CLEANFILES += $(BUILT_SOURCES)

--- a/mono/tests/split-tailcall-interface-conservestack.cpp
+++ b/mono/tests/split-tailcall-interface-conservestack.cpp
@@ -1,0 +1,88 @@
+// This program is used to split tailcall-interface-conservestack.il into separate tests.
+//
+// Algorithm is just to split on special inserted markers.
+//
+// mkdir tailcall/interface-conservestack
+// rm tailcall-interface-conservestack-*
+// git rm tailcall-interface-conservestack-*
+// g++ split-tailcall-interface-conservestack.cpp && ./a.out < tailcall-interface-conservestack.il
+// git add tailcall/interface-conservestack/*.il
+//
+// Note This is valid C++98 for use with older compilers, where C++11 would be desirable.
+#include <stdlib.h>
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <string>
+#include <assert.h>
+using namespace std;
+#include <sys/stat.h>
+#ifdef _WIN32
+#include <direct.h>
+#endif
+
+typedef vector<string> strings_t;
+struct test_t
+{
+	strings_t content;
+};
+typedef vector<test_t> tests_t;
+
+static void
+CreateDir (const char *a)
+{
+#ifdef _WIN32
+	_mkdir (a);
+#else
+	mkdir (a, 0777);
+#endif
+}
+
+int main()
+{
+	string line;
+	strings_t prefix;
+	tests_t tests;
+	test_t test_dummy;
+	test_t *test = &test_dummy;
+	strings_t suffix;
+
+	while (getline(cin, line) && line != "// test-split-prefix do not remove or edit this line")
+		prefix.push_back(line);
+
+	while (getline (cin, line))
+	{
+		if (!line.length()) // tests are delimited by empty lines
+		{
+			tests.resize(tests.size() + 1);
+			test = &tests.back();
+			assert(getline(cin, line));
+			if (line == "// test-split-suffix do not remove or edit this line")
+				break;
+		}
+		test->content.push_back(line);
+	}
+	while (getline (cin, line))
+		suffix.push_back(line);
+
+	int i = 0;
+
+	CreateDir ("tailcall");
+	CreateDir ("tailcall/interface-conservestack");
+
+	for (tests_t::iterator test = tests.begin(); test != tests.end(); ++test)
+	{
+		char buffer[99];
+		sprintf(buffer, "%d", ++i);
+		//printf("%s\n", buffer);
+		ofstream output((string("tailcall/interface-conservestack/") + buffer + ".il").c_str());
+		for (strings_t::const_iterator s = prefix.begin(); s != prefix.end(); ++s)
+			output << *s << endl;
+		output << endl;
+		for (strings_t::const_iterator s = test->content.begin(); s != test->content.end(); ++s)
+			output << *s << endl;
+		output << endl;
+		for (strings_t::const_iterator s = suffix.begin(); s != suffix.end(); ++s)
+			output << *s << endl;
+	}
+}

--- a/mono/tests/tailcall-interface-conservestack.il
+++ b/mono/tests/tailcall-interface-conservestack.il
@@ -18,16 +18,17 @@ extends [mscorlib]System.ValueType
 .field public int32 x
 .field public int32 y
 }
+
 .class interface private abstract I1
 {
 
 .method public newslot abstract virtual instance void perturb_interface_offset1() { }
 
-.method public newslot abstract virtual instance int32 F1(class I2 i2, int32 counter, int64 initial_stack, int64 current_stack) noinlining
+.method public newslot abstract virtual instance void F1(class I2 i2, int64 counter, int64 initial_stack, int64 current_stack) noinlining
 {
 }
 
-.method public newslot abstract virtual instance int32 GF1<TF>(class I2 i2, int32 counter, int64 initial_stack, int64 current_stack) noinlining
+.method public newslot abstract virtual instance void GF1<TF>(class I2 i2, int64 counter, int64 initial_stack, int64 current_stack) noinlining
 {
 }
 
@@ -44,15 +45,15 @@ extends [mscorlib]System.ValueType
 {
 }
 
-.method public newslot abstract virtual instance int32 F1(class GI2`1<!TC> i2, int32 counter, int64 initial_stack, int64 current_stack) noinlining
+.method public newslot abstract virtual instance void F1(class GI2`1<!TC> i2, int64 counter, int64 initial_stack, int64 current_stack) noinlining
 {
 }
 
-.method public newslot abstract virtual instance int32 GF1<TF>(class GI2`1<!TC> i2, int32 counter, int64 initial_stack, int64 current_stack) noinlining
+.method public newslot abstract virtual instance void GF1<TF>(class GI2`1<!TC> i2, int64 counter, int64 initial_stack, int64 current_stack) noinlining
 {
 }
 
-.method public newslot abstract virtual instance int32 HF1<TF>(class GI2`1<!!TF> i2, int32 counter, int64 initial_stack, int64 current_stack) noinlining
+.method public newslot abstract virtual instance void HF1<TF>(class GI2`1<!!TF> i2, int64 counter, int64 initial_stack, int64 current_stack) noinlining
 {
 }
 }
@@ -65,11 +66,11 @@ extends [mscorlib]System.ValueType
 
 .method public newslot abstract virtual instance void perturb_interface_offset3() { }
 
-.method public newslot abstract virtual instance int32 F2(class I1 i1, int32 counter, int64 initial_stack, int64 current_stack) noinlining
+.method public newslot abstract virtual instance void F2(class I1 i1, int64 counter, int64 initial_stack, int64 current_stack) noinlining
 {
 }
 
-.method public newslot abstract virtual instance int32 GF2<TF>(class I1 i1, int32 counter, int64 initial_stack, int64 current_stack) noinlining
+.method public newslot abstract virtual instance void GF2<TF>(class I1 i1, int64 counter, int64 initial_stack, int64 current_stack) noinlining
 {
 }
 
@@ -94,21 +95,21 @@ extends [mscorlib]System.ValueType
 {
 }
 
-.method public newslot abstract virtual instance int32 F2(class GI1`1<!TC> i1, int32 counter, int64 initial_stack, int64 current_stack) noinlining
+.method public newslot abstract virtual instance void F2(class GI1`1<!TC> i1, int64 counter, int64 initial_stack, int64 current_stack) noinlining
 {
 }
-.method public newslot abstract virtual instance int32 GF2<TF>(class GI1`1<!TC> i1, int32 counter, int64 initial_stack, int64 current_stack) noinlining
+.method public newslot abstract virtual instance void GF2<TF>(class GI1`1<!TC> i1, int64 counter, int64 initial_stack, int64 current_stack) noinlining
 {
 }
-.method public newslot abstract virtual instance int32 HF2<TF>(class GI1`1<!!TF> i1, int32 counter, int64 initial_stack, int64 current_stack) noinlining
+.method public newslot abstract virtual instance void HF2<TF>(class GI1`1<!!TF> i1, int64 counter, int64 initial_stack, int64 current_stack) noinlining
 {
 }
 }
 
 .class public C1 implements I1
 {
-.field private static int32 i
-.field public static int32 errors
+.field static int64 i
+.field public static int64 errors
 
 .method private newslot virtual final instance void I1.perturb_interface_offset1()
 {
@@ -116,99 +117,125 @@ extends [mscorlib]System.ValueType
 ret
 }
 
-.method public static int32 check(int64 stack1, int64 stack2)
+.method public static void check(int64 stack1, int64 stack2)
 {
-.locals init (int32 V_0)
-ldsfld int32 C1::i
-ldc.i4.1
+ldsfld int64 C1::i
+ldc.i8 1
 add
-stsfld int32 C1::i
-ldarg.0
-ldarg.1
-bne.un.s IL_0013
-ldc.i4.0
-br.s IL_0014
-IL_0013:
-ldc.i4.1
-IL_0014:
-stloc.0
-ldloc.0
-brtrue.s IL_001a
-ldc.i4.0
+stsfld int64 C1::i
+
+ldarg 0
+ldarg 1
+bne.un IL_0013
+
+//ldstr "{0}"
+//ldsfld int64 C1::i
+//box [mscorlib]System.Int64
+//call void [mscorlib]System.Console::WriteLine(string, object)
 ret
 
-IL_001a:
-ldsfld int32 C1::errors
-ldc.i4.1
+IL_0013:
+ldsfld int64 C1::errors
+ldc.i8 1
 add
-stsfld int32 C1::errors
-ldstr "{0} tailcall failure"
-ldsfld int32 C1::i
-box [mscorlib]System.Int32
-call void [mscorlib]System.Console::WriteLine(string, object)
-ldloc.0
+stsfld int64 C1::errors
+
+ldstr "{0} tailcall failure stack1:{1:X} stack2:{2:X} delta:{3}"
+
+ldc.i4 4
+newarr [mscorlib]System.Object
+
+dup
+ldc.i4 0
+ldsfld int64 C1::i
+box [mscorlib]System.Int64
+stelem.ref
+
+dup
+ldc.i4 1
+ldarg 0
+box [mscorlib]System.Int64
+stelem.ref
+
+dup
+ldc.i4 2
+ldarg 1
+box [mscorlib]System.Int64
+stelem.ref
+
+dup
+ldc.i4 3
+ldarg 0
+ldarg 1
+sub
+box [mscorlib]System.Int64
+stelem.ref
+
+call void class [mscorlib]System.Console::WriteLine(string, object[])
 ret
 }
-.method private newslot virtual final instance int32 I1.F1(class I2 i2, int32 counter, int64 initial_stack, int64 current_stack) noinlining
+.method private newslot virtual final instance void I1.F1(class I2 i2, int64 counter, int64 initial_stack, int64 current_stack) noinlining
 {
 .override I1::F1
-.locals init (int32 V_0)
-ldarg.2
-ldc.i4.0
-ble.s IL_0014
-ldarg.1
-ldarg.0
-ldarg.2
-ldc.i4.1
+
+ldarg 2
+ldc.i8 0
+ble IL_0014
+
+ldarg 1
+ldarg 0
+ldarg 2
+ldc.i8 1
 sub
-ldarg.3
-ldloca.s V_0
+ldarg 3
+ldarga counter
 conv.u
 conv.u8
 tail.
-callvirt instance int32 I2::F2(class I1, int32, int64, int64)
+callvirt instance void I2::F2(class I1, int64, int64, int64)
 ret
+
 IL_0014:
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
-ldarg.s current_stack
-tail.
-call int32 C1::check(int64, int64)
+ldarg current_stack
+call void C1::check(int64, int64)
 ret
 }
-.method private newslot virtual final instance int32 I1.GF1<TF>(class I2 i2, int32 counter, int64 initial_stack, int64 current_stack) noinlining
+
+.method private newslot virtual final instance void I1.GF1<TF>(class I2 i2, int64 counter, int64 initial_stack, int64 current_stack) noinlining
 {
 .override I1::GF1
-.locals init (int32 V_0)
-ldarg.2
-ldc.i4.0
-ble.s IL_0014
-ldarg.1
-ldarg.0
-ldarg.2
-ldc.i4.1
+
+ldarg 2
+ldc.i8 0
+ble IL_0014
+
+ldarg 1
+ldarg 0
+ldarg 2
+ldc.i8 1
 sub
-ldarg.3
-ldloca.s V_0
+ldarg 3
+ldarga counter
 conv.u
 conv.u8
 tail.
-callvirt instance int32 I2::GF2<!!0>(class I1, int32, int64, int64)
+callvirt instance void I2::GF2<!!0>(class I1, int64, int64, int64)
 ret
+
 IL_0014:
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
-ldarg.s current_stack
-tail.
-call int32 C1::check(int64, int64)
+ldarg current_stack
+call void C1::check(int64, int64)
 ret
 }
 .method public instance void .ctor()
 {
-ldarg.0
-tail.
+ldarg 0
 call instance void [mscorlib]System.Object::.ctor()
 ret
 }
@@ -226,111 +253,104 @@ ret
 .override method instance void class GI1`1<!TC>::perturb_interface_offset2()
 ret
 }
-.method public static int32 check(int64 stack1, int64 stack2)
+.method public static void check(int64 stack1, int64 stack2)
 {
-ldarg.0
-ldarg.1
-tail.
-call int32 C1::check(int64, int64)
+ldarg 0
+ldarg 1
+call void C1::check(int64, int64)
 ret
 }
-.method private newslot virtual final instance int32 'GI1<TC>.F1'(class GI2`1<!TC> i2, int32 counter, int64 initial_stack, int64 current_stack) noinlining
+.method private newslot virtual final instance void 'GI1<TC>.F1'(class GI2`1<!TC> i2, int64 counter, int64 initial_stack, int64 current_stack) noinlining
 {
-.override method instance int32 class GI1`1<!TC>::F1(class GI2`1<!0>,
-int32,
-int64,
-int64)
-.locals init (int32 V_0)
-ldarg.2
-ldc.i4.0
-ble.s IL_0014
-ldarg.1
-ldarg.0
-ldarg.2
-ldc.i4.1
+.override method instance void class GI1`1<!TC>::F1(class GI2`1<!0>, int64, int64, int64)
+
+ldarg 2
+ldc.i8 0
+ble IL_0014
+
+ldarg 1
+ldarg 0
+ldarg 2
+ldc.i8 1
 sub
-ldarg.3
-ldloca.s V_0
+ldarg 3
+ldarga counter
 conv.u
 conv.u8
 tail.
-callvirt instance int32 class GI2`1<!TC>::F2(class GI1`1<!0>, int32, int64, int64)
+callvirt instance void class GI2`1<!TC>::F2(class GI1`1<!0>, int64, int64, int64)
 ret
+
 IL_0014:
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
-ldarg.s current_stack
-tail.
-call int32 class GC1`1<!TC>::check(int64, int64)
+ldarg current_stack
+call void class GC1`1<!TC>::check(int64, int64)
 ret
 }
-.method private newslot virtual final instance int32 'GI1<TC>.GF1'<TF>(class GI2`1<!TC> i2, int32 counter, int64 initial_stack, int64 current_stack) noinlining
+.method private newslot virtual final instance void 'GI1<TC>.GF1'<TF>(class GI2`1<!TC> i2, int64 counter, int64 initial_stack, int64 current_stack) noinlining
 {
-.override method instance int32 class GI1`1<!TC>::GF1<[1]>(class GI2`1<!0>,
-int32,
-int64,
-int64)
-.locals init (int32 V_0)
-ldarg.2
-ldc.i4.0
-ble.s IL_0014
-ldarg.1
-ldarg.0
-ldarg.2
-ldc.i4.1
+.override method instance void class GI1`1<!TC>::GF1<[1]>(class GI2`1<!0>, int64, int64, int64)
+
+ldarg 2
+ldc.i8 0
+ble IL_0014
+ldarg 1
+ldarg 0
+ldarg 2
+ldc.i8 1
 sub
-ldarg.3
-ldloca.s V_0
+ldarg 3
+ldarga counter
 conv.u
 conv.u8
 tail.
-callvirt instance int32 class GI2`1<!TC>::GF2<!!0>(class GI1`1<!0>, int32, int64, int64)
+callvirt instance void class GI2`1<!TC>::GF2<!!0>(class GI1`1<!0>, int64, int64, int64)
 ret
+
 IL_0014:
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
-ldarg.s current_stack
-tail.
-call int32 class GC1`1<!TC>::check(int64, int64)
+ldarg current_stack
+call void class GC1`1<!TC>::check(int64, int64)
 ret
 }
-.method private newslot virtual final instance int32 'GI1<TC>.HF1'<TF>(class GI2`1<!!TF> i2, int32 counter, int64 initial_stack, int64 current_stack) noinlining
+
+.method private newslot virtual final instance void 'GI1<TC>.HF1'<TF>(class GI2`1<!!TF> i2, int64 counter, int64 initial_stack, int64 current_stack) noinlining
 {
-.override method instance int32 class GI1`1<!TC>::HF1<[1]>(class GI2`1<!!TF>,
-int32,
-int64,
-int64)
-.locals init (int32 V_0)
-ldarg.2
-ldc.i4.0
-ble.s IL_0014
-ldarg.1
-ldarg.0
-ldarg.2
-ldc.i4.1
+.override method instance void class GI1`1<!TC>::HF1<[1]>(class GI2`1<!!TF>, int64, int64, int64)
+
+ldarg 2
+ldc.i8 0
+ble IL_0014
+
+ldarg 1
+ldarg 0
+ldarg 2
+ldc.i8 1
 sub
-ldarg.3
-ldloca.s V_0
+ldarg 3
+ldarga counter
 conv.u
 conv.u8
 tail.
-callvirt instance int32 class GI2`1<!!0>::HF2<!0>(class GI1`1<!!0>, int32, int64, int64)
+callvirt instance void class GI2`1<!!0>::HF2<!0>(class GI1`1<!!0>, int64, int64, int64)
 ret
+
 IL_0014:
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
-ldarg.s current_stack
-tail.
-call int32 class GC1`1<!TC>::check(int64, int64)
+ldarg current_stack
+call void class GC1`1<!TC>::check(int64, int64)
 ret
 }
+
 .method public instance void .ctor()
 {
-ldarg.0
-tail.
+ldarg 0
 call instance void [mscorlib]System.Object::.ctor()
 ret
 }
@@ -353,74 +373,74 @@ ret
 .override I2::perturb_interface_offset3
 ret
 }
-.method private static int32 check(int64 stack1, int64 stack2)
+
+.method private static void check(int64 stack1, int64 stack2)
 {
-ldarg.0
-ldarg.1
-tail.
-call int32 C1::check(int64, int64)
+ldarg 0
+ldarg 1
+call void C1::check(int64, int64)
 ret
 }
-.method private newslot virtual final instance int32 I2.F2(class I1 i1, int32 counter, int64 initial_stack, int64 current_stack) noinlining
+
+.method private newslot virtual final instance void I2.F2(class I1 i1, int64 counter, int64 initial_stack, int64 current_stack) noinlining
 {
 .override I2::F2
-.locals init (int32 V_0)
-ldarg.2
-ldc.i4.0
-ble.s IL_0014
-ldarg.1
-ldarg.0
-ldarg.2
-ldc.i4.1
+
+ldarg 2
+ldc.i8 0
+ble IL_0014
+
+ldarg 1
+ldarg 0
+ldarg 2
+ldc.i8 1
 sub
-ldarg.3
-ldloca.s V_0
+ldarg 3
+ldarga counter
 conv.u
 conv.u8
 tail.
-callvirt instance int32 I1::F1(class I2, int32, int64, int64)
+callvirt instance void I1::F1(class I2, int64, int64, int64)
 ret
+
 IL_0014:
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
-ldarg.s current_stack
-tail.
-call int32 C2::check(int64, int64)
+ldarg current_stack
+call void C2::check(int64, int64)
 ret
 }
-.method private newslot virtual final instance int32 I2.GF2<TF>(class I1 i1, int32 counter, int64 initial_stack, int64 current_stack) noinlining
+.method private newslot virtual final instance void I2.GF2<TF>(class I1 i1, int64 counter, int64 initial_stack, int64 current_stack) noinlining
 {
 .override I2::GF2
-.locals init (int32 V_0)
-ldarg.2
-ldc.i4.0
-ble.s IL_0014
-ldarg.1
-ldarg.0
-ldarg.2
-ldc.i4.1
+
+ldarg 2
+ldc.i8 0
+ble IL_0014
+ldarg 1
+ldarg 0
+ldarg 2
+ldc.i8 1
 sub
-ldarg.3
-ldloca.s V_0
+ldarg 3
+ldarga counter
 conv.u
 conv.u8
 tail.
-callvirt instance int32 I1::GF1<!!0>(class I2, int32, int64, int64)
+callvirt instance void I1::GF1<!!0>(class I2, int64, int64, int64)
 ret
 IL_0014:
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
-ldarg.s current_stack
-tail.
-call int32 C2::check(int64, int64)
+ldarg current_stack
+call void C2::check(int64, int64)
 ret
 }
 .method public instance void .ctor()
 {
-ldarg.0
-tail.
+ldarg 0
 call instance void [mscorlib]System.Object::.ctor()
 ret
 }
@@ -448,111 +468,102 @@ ret
 .override method instance void class GI2`1<!TC>::perturb_interface_offset4()
 ret
 }
-.method public static int32 check(int64 stack1, int64 stack2)
+.method public static void check(int64 stack1, int64 stack2)
 {
-ldarg.0
-ldarg.1
-tail.
-call int32 C1::check(int64, int64)
+ldarg 0
+ldarg 1
+call void C1::check(int64, int64)
 ret
 }
-.method private newslot virtual final instance int32 'GI2<TC>.F2'(class GI1`1<!TC> i1, int32 counter, int64 initial_stack, int64 current_stack) noinlining
+.method private newslot virtual final instance void 'GI2<TC>.F2'(class GI1`1<!TC> i1, int64 counter, int64 initial_stack, int64 current_stack) noinlining
 {
-.override method instance int32 class GI2`1<!TC>::F2(class GI1`1<!0>,
-int32,
-int64,
-int64)
-.locals init (int32 V_0)
-ldarg.2
-ldc.i4.0
-ble.s IL_0014
-ldarg.1
-ldarg.0
-ldarg.2
-ldc.i4.1
+.override method instance void class GI2`1<!TC>::F2(class GI1`1<!0>, int64, int64, int64)
+
+ldarg 2
+ldc.i8 0
+ble IL_0014
+
+ldarg 1
+ldarg 0
+ldarg 2
+ldc.i8 1
 sub
-ldarg.3
-ldloca.s V_0
+ldarg 3
+ldarga counter
 conv.u
 conv.u8
 tail.
-callvirt instance int32 class GI1`1<!TC>::F1(class GI2`1<!0>, int32, int64, int64)
+callvirt instance void class GI1`1<!TC>::F1(class GI2`1<!0>, int64, int64, int64)
 ret
+
 IL_0014:
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
-ldarg.s current_stack
-tail.
-call int32 class GC2`1<!TC>::check(int64, int64)
+ldarg current_stack
+call void class GC2`1<!TC>::check(int64, int64)
 ret
 }
-.method private newslot virtual final instance int32 'GI2<TC>.GF2'<TF>(class GI1`1<!TC> i1, int32 counter, int64 initial_stack, int64 current_stack) noinlining
+.method private newslot virtual final instance void 'GI2<TC>.GF2'<TF>(class GI1`1<!TC> i1, int64 counter, int64 initial_stack, int64 current_stack) noinlining
 {
-.override method instance int32 class GI2`1<!TC>::GF2<[1]>(class GI1`1<!0>,
-int32,
-int64,
-int64)
-.locals init (int32 V_0)
-ldarg.2
-ldc.i4.0
-ble.s IL_0014
-ldarg.1
-ldarg.0
-ldarg.2
-ldc.i4.1
+.override method instance void class GI2`1<!TC>::GF2<[1]>(class GI1`1<!0>, int64, int64, int64)
+
+ldarg 2
+ldc.i8 0
+ble IL_0014
+
+ldarg 1
+ldarg 0
+ldarg 2
+ldc.i8 1
 sub
-ldarg.3
-ldloca.s V_0
+ldarg 3
+ldarga counter
 conv.u
 conv.u8
 tail.
-callvirt instance int32 class GI1`1<!TC>::GF1<!!0>(class GI2`1<!0>, int32, int64, int64)
+callvirt instance void class GI1`1<!TC>::GF1<!!0>(class GI2`1<!0>, int64, int64, int64)
 ret
+
 IL_0014:
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
-ldarg.s current_stack
-tail.
-call int32 class GC2`1<!TC>::check(int64, int64)
+ldarg current_stack
+call void class GC2`1<!TC>::check(int64, int64)
 ret
 }
-.method private newslot virtual final instance int32 'GI2<TC>.HF2'<TF>(class GI1`1<!!TF> i1, int32 counter, int64 initial_stack, int64 current_stack) noinlining
+.method private newslot virtual final instance void 'GI2<TC>.HF2'<TF>(class GI1`1<!!TF> i1, int64 counter, int64 initial_stack, int64 current_stack) noinlining
 {
-.override method instance int32 class GI2`1<!TC>::HF2<[1]>(class GI1`1<!!TF>,
-int32,
-int64,
-int64)
-.locals init (int32 V_0)
-ldarg.2
-ldc.i4.0
-ble.s IL_0014
-ldarg.1
-ldarg.0
-ldarg.2
-ldc.i4.1
+.override method instance void class GI2`1<!TC>::HF2<[1]>(class GI1`1<!!TF>, int64, int64, int64)
+
+ldarg 2
+ldc.i8 0
+ble IL_0014
+ldarg 1
+ldarg 0
+ldarg 2
+ldc.i8 1
 sub
-ldarg.3
-ldloca.s V_0
+ldarg 3
+ldarga counter
 conv.u
 conv.u8
 tail.
-callvirt instance int32 class GI1`1<!!0>::HF1<!0>(class GI2`1<!!0>, int32, int64, int64)
+callvirt instance void class GI1`1<!!0>::HF1<!0>(class GI2`1<!!0>, int64, int64, int64)
 ret
+
 IL_0014:
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
-ldarg.s current_stack
-tail.
-call int32 class GC2`1<!TC>::check(int64, int64)
+ldarg current_stack
+call void class GC2`1<!TC>::check(int64, int64)
 ret
 }
 .method public instance void .ctor()
 {
-ldarg.0
-tail.
+ldarg 0
 call instance void [mscorlib]System.Object::.ctor()
 ret
 }
@@ -561,8 +572,7 @@ ret
 {
 .method public instance void .ctor()
 {
-ldarg.0
-tail.
+ldarg 0
 call instance void [mscorlib]System.Object::.ctor()
 ret
 }
@@ -571,27 +581,26 @@ ret
 {
 .method public instance void .ctor()
 {
-ldarg.0
-tail.
+ldarg 0
 call instance void [mscorlib]System.Object::.ctor()
 ret
 }
 }
 .class interface private abstract IC
 {
-.method public newslot abstract virtual instance !!T cast1<T>(object o, int32 counter, int64 stack) noinlining
+.method public newslot abstract virtual instance !!T cast1<T>(object o, int64 counter, int64 stack) noinlining
 {
 }
-.method public newslot abstract virtual instance class B cast2(object o, int32 counter, int64 stack) noinlining
+.method public newslot abstract virtual instance class B cast2(object o, int64 counter, int64 stack) noinlining
 {
 }
-.method public newslot abstract virtual instance !!T cast3<T>(object o, int32 counter, int64 stack) noinlining
+.method public newslot abstract virtual instance !!T cast3<T>(object o, int64 counter, int64 stack) noinlining
 {
 }
-.method public newslot abstract virtual instance class B[] cast4(object o, int32 counter, int64 stack) noinlining
+.method public newslot abstract virtual instance class B[] cast4(object o, int64 counter, int64 stack) noinlining
 {
 }
-.method public newslot abstract virtual instance !!T[] cast5<T>(object o, int32 counter, int64 stack) noinlining
+.method public newslot abstract virtual instance !!T[] cast5<T>(object o, int64 counter, int64 stack) noinlining
 {
 }
 }
@@ -599,171 +608,171 @@ ret
 {
 .method public static void check(int64 stack1, int64 stack2) noinlining
 {
-ldarg.0
-ldarg.1
-call int32 C1::check(int64, int64)
-pop
+ldarg 0
+ldarg 1
+call void C1::check(int64, int64)
 ret
 }
-.method public instance !!T cast1<T>(object o, int32 counter, int64 stack) noinlining
+
+.method public instance !!T cast1<T>(object o, int64 counter, int64 stack) noinlining
 {
-.locals init (int32 V_0)
-ldarg.2
-ldc.i4.0
-ble.s IL_0013
-ldarg.0
-ldarg.1
-ldarg.2
-ldc.i4.1
+ldarg 2
+ldc.i8 0
+ble IL_0013
+
+ldarg 0
+ldarg 1
+ldarg 2
+ldc.i8 1
 sub
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
 tail.
-call instance !!0 C::cast1<!!0>(object, int32, int64)
+call instance !!0 C::cast1<!!0>(object, int64, int64)
 ret
+
 IL_0013:
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
-ldarg.3
+ldarg 3
 call void C::check(int64, int64)
-ldarg.1
+ldarg 1
 unbox.any !!T
 ret
 }
-.method public instance class B cast2(object o, int32 counter, int64 stack) noinlining
+.method public instance class B cast2(object o, int64 counter, int64 stack) noinlining
 {
-.locals init (int32 V_0)
-ldarg.2
-ldc.i4.0
-ble.s IL_0013
-ldarg.0
-ldarg.1
-ldarg.2
-ldc.i4.1
+ldarg 2
+ldc.i8 0
+ble IL_0013
+
+ldarg 0
+ldarg 1
+ldarg 2
+ldc.i8 1
 sub
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
 tail.
-call instance class B C::cast2(object, int32, int64)
+call instance class B C::cast2(object, int64, int64)
 ret
+
 IL_0013:
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
-ldarg.3
+ldarg 3
 call void C::check(int64, int64)
-ldarg.0
-ldarg.1
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
+ldarg 0
+ldarg 1
+ldc.i8 99
+ldc.i8 0
 tail.
-call instance !!0 C::cast1<class B>(object, int32, int64)
+call instance !!0 C::cast1<class B>(object, int64, int64)
 ret
 }
-.method public instance !!T cast3<T>(object o, int32 counter, int64 stack) noinlining
+.method public instance !!T cast3<T>(object o, int64 counter, int64 stack) noinlining
 {
-.locals init (int32 V_0)
-ldarg.2
-ldc.i4.0
-ble.s IL_0013
-ldarg.0
-ldarg.1
-ldarg.2
-ldc.i4.1
+ldarg 2
+ldc.i8 0
+ble IL_0013
+
+ldarg 0
+ldarg 1
+ldarg 2
+ldc.i8 1
 sub
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
 tail.
-call instance !!0 C::cast3<!!0>(object, int32, int64)
+call instance !!0 C::cast3<!!0>(object, int64, int64)
 ret
+
 IL_0013:
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
-ldarg.3
+ldarg 3
 call void C::check(int64, int64)
-ldarg.0
-ldarg.1
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
+ldarg 0
+ldarg 1
+ldc.i8 99
+ldc.i8 0
 tail.
-call instance !!0 C::cast1<!!0>(object, int32, int64)
+call instance !!0 C::cast1<!!0>(object, int64, int64)
 ret
 }
-.method public instance class B[] cast4(object o, int32 counter, int64 stack) noinlining
+.method public instance class B[] cast4(object o, int64 counter, int64 stack) noinlining
 {
-.locals init (int32 V_0)
-ldarg.2
-ldc.i4.0
-ble.s IL_0013
-ldarg.0
-ldarg.1
-ldarg.2
-ldc.i4.1
+ldarg 2
+ldc.i8 0
+ble IL_0013
+
+ldarg 0
+ldarg 1
+ldarg 2
+ldc.i8 1
 sub
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
 tail.
-call instance class B[] C::cast4(object, int32, int64)
+call instance class B[] C::cast4(object, int64, int64)
 ret
+
 IL_0013:
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
-ldarg.3
+ldarg 3
 call void C::check(int64, int64)
-ldarg.0
-ldarg.1
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
+ldarg 0
+ldarg 1
+ldc.i8 99
+ldc.i8 0
 tail.
-call instance !!0 C::cast1<class B[]>(object, int32, int64)
+call instance !!0 C::cast1<class B[]>(object, int64, int64)
 ret
 }
-.method public instance !!T[] cast5<T>(object o, int32 counter, int64 stack) noinlining
+.method public instance !!T[] cast5<T>(object o, int64 counter, int64 stack) noinlining
 {
-.locals init (int32 V_0)
-ldarg.2
-ldc.i4.0
-ble.s IL_0013
-ldarg.0
-ldarg.1
-ldarg.2
-ldc.i4.1
+ldarg 2
+ldc.i8 0
+ble IL_0013
+
+ldarg 0
+ldarg 1
+ldarg 2
+ldc.i8 1
 sub
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
 tail.
-call instance !!0[] C::cast5<!!0>(object, int32, int64)
+call instance !!0[] C::cast5<!!0>(object, int64, int64)
 ret
+
 IL_0013:
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
-ldarg.3
+ldarg 3
 call void C::check(int64, int64)
-ldarg.0
-ldarg.1
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
+ldarg 0
+ldarg 1
+ldc.i8 99
+ldc.i8 0
 tail.
-call instance !!0 C::cast1<!!0[]>(object, int32, int64)
+call instance !!0 C::cast1<!!0[]>(object, int64, int64)
 ret
 }
 .method public instance void .ctor()
 {
-ldarg.0
-tail.
+ldarg 0
 call instance void [mscorlib]System.Object::.ctor()
 ret
 }
@@ -772,942 +781,846 @@ ret
 {
 .method public static void check(int64 stack1, int64 stack2) noinlining
 {
-ldarg.0
-ldarg.1
-tail.
+ldarg 0
+ldarg 1
 call void C::check(int64, int64)
 ret
 }
-.method public static !!T cast1<T>(object o, int32 counter, int64 stack) noinlining
+.method public static !!T cast1<T>(object o, int64 counter, int64 stack) noinlining
 {
-.locals init (int32 V_0)
-ldarg.1
-ldc.i4.0
-ble.s IL_0012
-ldarg.0
-ldarg.1
-ldc.i4.1
+ldarg 1
+ldc.i8 0
+ble IL_0012
+
+ldarg 0
+ldarg 1
+ldc.i8 1
 sub
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
 tail.
-call !!0 class D`1<!T1>::cast1<!!0>(object, int32, int64)
+call !!0 class D`1<!T1>::cast1<!!0>(object, int64, int64)
 ret
+
 IL_0012:
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
-ldarg.2
+ldarg 2
 call void class D`1<!T1>::check(int64, int64)
-ldarg.0
+ldarg 0
 unbox.any !!T
 ret
 }
-.method public instance class B cast2(object o, int32 counter, int64 stack) noinlining
+.method public instance class B cast2(object o, int64 counter, int64 stack) noinlining
 {
-.locals init (int32 V_0)
-ldarg.2
-ldc.i4.0
-ble.s IL_0013
-ldarg.0
-ldarg.1
-ldarg.2
-ldc.i4.1
+ldarg 2
+ldc.i8 0
+ble IL_0013
+
+ldarg 0
+ldarg 1
+ldarg 2
+ldc.i8 1
 sub
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
 tail.
-call instance class B class D`1<!T1>::cast2(object, int32, int64)
+call instance class B class D`1<!T1>::cast2(object, int64, int64)
 ret
+
 IL_0013:
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
-ldarg.3
+ldarg 3
 call void class D`1<!T1>::check(int64, int64)
-ldarg.1
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
+ldarg 1
+ldc.i8 99
+ldc.i8 0
 tail.
-call !!0 class D`1<!T1>::cast1<class B>(object, int32, int64)
+call !!0 class D`1<!T1>::cast1<class B>(object, int64, int64)
 ret
 }
-.method public instance !!T cast3<T>(object o, int32 counter, int64 stack) noinlining
+.method public instance !!T cast3<T>(object o, int64 counter, int64 stack) noinlining
 {
-.locals init (int32 V_0)
-ldarg.2
-ldc.i4.0
-ble.s IL_0013
-ldarg.0
-ldarg.1
-ldarg.2
-ldc.i4.1
+ldarg 2
+ldc.i8 0
+ble IL_0013
+
+ldarg 0
+ldarg 1
+ldarg 2
+ldc.i8 1
 sub
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
 tail.
-call instance !!0 class D`1<!T1>::cast3<!!0>(object, int32, int64)
+call instance !!0 class D`1<!T1>::cast3<!!0>(object, int64, int64)
 ret
+
 IL_0013:
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
-ldarg.3
+ldarg 3
 call void class D`1<!T1>::check(int64, int64)
-ldarg.1
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
+ldarg 1
+ldc.i8 99
+ldc.i8 0
 tail.
-call !!0 class D`1<!T1>::cast1<!!0>(object, int32, int64)
+call !!0 class D`1<!T1>::cast1<!!0>(object, int64, int64)
 ret
 }
-.method public instance class B[] cast4(object o, int32 counter, int64 stack) noinlining
+.method public instance class B[] cast4(object o, int64 counter, int64 stack) noinlining
 {
-.locals init (int32 V_0)
-ldarg.2
-ldc.i4.0
-ble.s IL_0013
-ldarg.0
-ldarg.1
-ldarg.2
-ldc.i4.1
+ldarg 2
+ldc.i8 0
+ble IL_0013
+
+ldarg 0
+ldarg 1
+ldarg 2
+ldc.i8 1
 sub
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
 tail.
-call instance class B[] class D`1<!T1>::cast4(object, int32, int64)
+call instance class B[] class D`1<!T1>::cast4(object, int64, int64)
 ret
+
 IL_0013:
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
-ldarg.3
+ldarg 3
 call void class D`1<!T1>::check(int64, int64)
-ldarg.1
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
+ldarg 1
+ldc.i8 99
+ldc.i8 0
 tail.
-call !!0 class D`1<!T1>::cast1<class B[]>(object, int32, int64)
+call !!0 class D`1<!T1>::cast1<class B[]>(object, int64, int64)
 ret
 }
-.method public instance !!T[] cast5<T>(object o, int32 counter, int64 stack) noinlining
+.method public instance !!T[] cast5<T>(object o, int64 counter, int64 stack) noinlining
 {
-.locals init (int32 V_0)
-ldarg.2
-ldc.i4.0
-ble.s IL_0013
-ldarg.0
-ldarg.1
-ldarg.2
-ldc.i4.1
+ldarg 2
+ldc.i8 0
+ble IL_0013
+
+ldarg 0
+ldarg 1
+ldarg 2
+ldc.i8 1
 sub
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
 tail.
-call instance !!0[] class D`1<!T1>::cast5<!!0>(object, int32, int64)
+call instance !!0[] class D`1<!T1>::cast5<!!0>(object, int64, int64)
 ret
+
 IL_0013:
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
-ldarg.3
+ldarg 3
 call void class D`1<!T1>::check(int64, int64)
-ldarg.1
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
+ldarg 1
+ldc.i8 99
+ldc.i8 0
 tail.
-call !!0 class D`1<!T1>::cast1<!!0[]>(object, int32, int64)
+call !!0 class D`1<!T1>::cast1<!!0[]>(object, int64, int64)
 ret
 }
-.method public instance !T1 cast6(object o, int32 counter, int64 stack) noinlining
+.method public instance !T1 cast6(object o, int64 counter, int64 stack) noinlining
 {
-.locals init (int32 V_0)
-ldarg.2
-ldc.i4.0
-ble.s IL_0013
-ldarg.0
-ldarg.1
-ldarg.2
-ldc.i4.1
+ldarg 2
+ldc.i8 0
+ble IL_0013
+
+ldarg 0
+ldarg 1
+ldarg 2
+ldc.i8 1
 sub
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
 tail.
-call instance !0 class D`1<!T1>::cast6(object, int32, int64)
+call instance !0 class D`1<!T1>::cast6(object, int64, int64)
 ret
+
 IL_0013:
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
-ldarg.3
+ldarg 3
 call void class D`1<!T1>::check(int64, int64)
-ldarg.1
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
+ldarg 1
+ldc.i8 99
+ldc.i8 0
 tail.
-call !!0 class D`1<!T1>::cast1<!0>(object, int32, int64)
+call !!0 class D`1<!T1>::cast1<!0>(object, int64, int64)
 ret
 }
-.method public instance !T1 cast7<T>(object o, int32 counter, int64 stack) noinlining
+.method public instance !T1 cast7<T>(object o, int64 counter, int64 stack) noinlining
 {
-.locals init (int32 V_0)
-ldarg.2
-ldc.i4.0
-ble.s IL_0013
-ldarg.0
-ldarg.1
-ldarg.2
-ldc.i4.1
+ldarg 2
+ldc.i8 0
+ble IL_0013
+
+ldarg 0
+ldarg 1
+ldarg 2
+ldc.i8 1
 sub
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
 tail.
-call instance !0 class D`1<!T1>::cast7<!!0>(object, int32, int64)
+call instance !0 class D`1<!T1>::cast7<!!0>(object, int64, int64)
 ret
+
 IL_0013:
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
-ldarg.3
+ldarg 3
 call void class D`1<!T1>::check(int64, int64)
-ldarg.1
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
+ldarg 1
+ldc.i8 99
+ldc.i8 0
 tail.
-call !!0 class D`1<!T1>::cast1<!0>(object, int32, int64)
+call !!0 class D`1<!T1>::cast1<!0>(object, int64, int64)
 ret
 }
-.method public instance !T1[] cast8(object o, int32 counter, int64 stack) noinlining
+.method public instance !T1[] cast8(object o, int64 counter, int64 stack) noinlining
 {
-.locals init (int32 V_0)
-ldarg.2
-ldc.i4.0
-ble.s IL_0013
-ldarg.0
-ldarg.1
-ldarg.2
-ldc.i4.1
+ldarg 2
+ldc.i8 0
+ble IL_0013
+
+ldarg 0
+ldarg 1
+ldarg 2
+ldc.i8 1
 sub
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
 tail.
-call instance !0[] class D`1<!T1>::cast8(object, int32, int64)
+call instance !0[] class D`1<!T1>::cast8(object, int64, int64)
 ret
+
 IL_0013:
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
-ldarg.3
+ldarg 3
 call void class D`1<!T1>::check(int64, int64)
-ldarg.0
-ldarg.1
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
+ldarg 0
+ldarg 1
+ldc.i8 99
+ldc.i8 0
 tail.
-call instance !!0 class D`1<!T1>::cast3<!0[]>(object, int32, int64)
+call instance !!0 class D`1<!T1>::cast3<!0[]>(object, int64, int64)
 ret
 }
-.method public instance !T1[] cast9<T>(object o, int32 counter, int64 stack) noinlining
+.method public instance !T1[] cast9<T>(object o, int64 counter, int64 stack) noinlining
 {
-.locals init (int32 V_0)
-ldarg.2
-ldc.i4.0
-ble.s IL_0013
-ldarg.0
-ldarg.1
-ldarg.2
-ldc.i4.1
+ldarg 2
+ldc.i8 0
+ble IL_0013
+
+ldarg 0
+ldarg 1
+ldarg 2
+ldc.i8 1
 sub
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
 tail.
-call instance !0[] class D`1<!T1>::cast9<!!0>(object, int32, int64)
+call instance !0[] class D`1<!T1>::cast9<!!0>(object, int64, int64)
 ret
+
 IL_0013:
-ldloca.s V_0
+ldarga counter
 conv.u
 conv.u8
-ldarg.3
+ldarg 3
 call void class D`1<!T1>::check(int64, int64)
-ldarg.0
-ldarg.1
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
+ldarg 0
+ldarg 1
+ldc.i8 99
+ldc.i8 0
 tail.
-call instance !!0 class D`1<!T1>::cast3<!0[]>(object, int32, int64)
+call instance !!0 class D`1<!T1>::cast3<!0[]>(object, int64, int64)
 ret
 }
 .method public instance void .ctor()
 {
-ldarg.0
-tail.
+ldarg 0
 call instance void [mscorlib]System.Object::.ctor()
 ret
 }
 }
 .class private C3
 {
-.field private int32 i
-.method private instance void print(object o) noinlining
+.method static void print() noinlining
 {
-ldarg.0
-ldarg.0
-ldfld int32 C3::i
-ldc.i4.1
-add
-stfld int32 C3::i
 ret
 }
-.method public instance void Main() noinlining
+
+.method static void print(object o) noinlining
 {
-.locals init (class D`1<class A> V_0, class D`1<class B> V_1, class D`1<class B[]> V_2, class C V_3, class B V_4, class B[] V_5, int32 V_6, class I1 V_7, class I2 V_8, int32 V_9, class GI1`1<object> V_10, class GI1`1<object[]> V_11, class GI1`1<int32> V_12, class GI1`1<int32[]> V_13, class GI1`1<valuetype Point> V_14, class GI1`1<valuetype Point[]> V_15, class GI2`1<object> V_16, class GI2`1<object[]> V_17, class GI2`1<int32> V_18, class GI2`1<int32[]> V_19, class GI2`1<valuetype Point> V_20, class GI2`1<valuetype Point[]> V_21)
-newobj instance void class D`1<class A>::.ctor()
-stloc.0
-newobj instance void class D`1<class B>::.ctor()
-stloc.1
-newobj instance void class D`1<class B[]>::.ctor()
-stloc.2
-newobj instance void C::.ctor()
-stloc.3
-newobj instance void B::.ctor()
-stloc.s V_4
-ldc.i4.1
-newarr B
-stloc.s V_5
-
-newobj instance void C1::.ctor()
-stloc.s V_7
-newobj instance void C2::.ctor()
-stloc.s V_8
-
-newobj instance void class GC1`1<object>::.ctor()
-stloc.s V_10
-newobj instance void class GC1`1<object[]>::.ctor()
-stloc.s V_11
-newobj instance void class GC1`1<int32>::.ctor()
-stloc.s V_12
-newobj instance void class GC1`1<int32[]>::.ctor()
-stloc.s V_13
-newobj instance void class GC1`1<valuetype Point>::.ctor()
-stloc.s V_14
-newobj instance void class GC1`1<valuetype Point[]>::.ctor()
-stloc.s V_15
-newobj instance void class GC2`1<object>::.ctor()
-stloc.s V_16
-newobj instance void class GC2`1<object[]>::.ctor()
-stloc.s V_17
-newobj instance void class GC2`1<int32>::.ctor()
-stloc.s V_18
-newobj instance void class GC2`1<int32[]>::.ctor()
-stloc.s V_19
-newobj instance void class GC2`1<valuetype Point>::.ctor()
-stloc.s V_20
-newobj instance void class GC2`1<valuetype Point[]>::.ctor()
-stloc.s V_21
-
-ldc.i4.0
-stloc.s V_9
-
-ldarg.0
-ldloc.0
-ldloc.s V_4
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
-callvirt instance class B class D`1<class A>::cast2(object, int32, int64)
-call instance void C3::print(object)
-
-ldarg.0
-ldloc.0
-ldloc.s V_4
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
-callvirt instance !!0 class D`1<class A>::cast3<class B>(object, int32, int64)
-call instance void C3::print(object)
-
-ldarg.0
-ldloc.0
-ldloc.s V_5
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
-callvirt instance !!0 class D`1<class A>::cast3<class B[]>(object, int32, int64)
-call instance void C3::print(object)
-
-ldarg.0
-ldloc.0
-ldloc.s V_5
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
-callvirt instance class B[] class D`1<class A>::cast4(object, int32, int64)
-call instance void C3::print(object)
-
-ldarg.0
-ldloc.0
-ldloc.s V_5
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
-callvirt instance !!0[] class D`1<class A>::cast5<class B>(object, int32, int64)
-call instance void C3::print(object)
-
-ldarg.0
-ldloc.1
-ldloc.s V_4
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
-callvirt instance !0 class D`1<class B>::cast6(object, int32, int64)
-call instance void C3::print(object)
-
-ldarg.0
-ldloc.1
-ldloc.s V_4
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
-callvirt instance !0 class D`1<class B>::cast7<class A>(object, int32, int64)
-call instance void C3::print(object)
-
-ldarg.0
-ldloc.2
-ldloc.s V_5
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
-callvirt instance !0 class D`1<class B[]>::cast7<class A[]>(object, int32, int64)
-call instance void C3::print(object)
-
-ldarg.0
-ldloc.1
-ldloc.s V_5
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
-callvirt instance !0[] class D`1<class B>::cast8(object, int32, int64)
-call instance void C3::print(object)
-
-ldarg.0
-ldloc.1
-ldloc.s V_5
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
-callvirt instance !0[] class D`1<class B>::cast9<class A>(object, int32, int64)
-call instance void C3::print(object)
-
-ldarg.0
-ldloc.3
-ldloc.s V_4
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
-callvirt instance class B C::cast2(object, int32, int64)
-call instance void C3::print(object)
-
-
-ldc.i4.0
-
-
-ldarg.0
-ldloc.3
-ldloc.s V_4
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
-callvirt instance !!0 C::cast3<class B>(object, int32, int64)
-call instance void C3::print(object)
-
-ldarg.0
-ldloc.3
-ldloc.s V_5
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
-callvirt instance !!0 C::cast3<class B[]>(object, int32, int64)
-call instance void C3::print(object)
-
-ldarg.0
-ldloc.3
-ldloc.s V_5
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
-callvirt instance class B[] C::cast4(object, int32, int64)
-call instance void C3::print(object)
-
-ldarg.0
-ldloc.3
-ldloc.s V_5
-ldc.i4.s 100
-ldc.i4.0
-conv.i8
-callvirt instance !!0[] C::cast5<class B>(object, int32, int64)
-call instance void C3::print(object)
-
-ldloc.s V_7
-ldloc.s V_8
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 I1::F1(class I2, int32, int64, int64)
-add
-
-ldloc.s V_7
-ldloc.s V_8
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 I1::GF1<object>(class I2, int32, int64, int64)
-add
-
-ldloc.s V_7
-ldloc.s V_8
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 I1::GF1<class A>(class I2, int32, int64, int64)
-add
-
-ldloc.s V_7
-ldloc.s V_8
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 I1::GF1<class A[]>(class I2, int32, int64, int64)
-add
-
-ldloc.s V_7
-ldloc.s V_8
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 I1::GF1<int32>(class I2, int32, int64, int64)
-add
-
-ldloc.s V_7
-ldloc.s V_8
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 I1::GF1<int32[]>(class I2, int32, int64, int64)
-add
-
-// This is the only failure on desktop.
-ldloc.s V_10
-ldloc.s V_16
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<object>::F1(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_10
-ldloc.s V_16
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<object>::GF1<object>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_10
-ldloc.s V_16
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<object>::GF1<class A>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_10
-ldloc.s V_16
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<object>::GF1<class A[]>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_10
-ldloc.s V_16
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<object>::GF1<int32>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_10
-ldloc.s V_16
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<object>::GF1<int32[]>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_11
-ldloc.s V_17
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<object[]>::GF1<object[]>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_11
-ldloc.s V_17
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<object[]>::GF1<class A>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_11
-ldloc.s V_17
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<object[]>::GF1<class A[]>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_11
-ldloc.s V_17
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<object[]>::GF1<int32>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_11
-ldloc.s V_17
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<object[]>::GF1<int32[]>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_12
-ldloc.s V_18
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<int32>::GF1<object>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_12
-ldloc.s V_18
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<int32>::GF1<class A>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_12
-ldloc.s V_18
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<int32>::GF1<class A[]>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_12
-ldloc.s V_18
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<int32>::GF1<int32>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_12
-ldloc.s V_18
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<int32>::GF1<int32[]>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_13
-ldloc.s V_19
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<int32[]>::GF1<object>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_13
-ldloc.s V_19
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<int32[]>::GF1<class A>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_13
-ldloc.s V_19
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<int32[]>::GF1<class A[]>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_13
-ldloc.s V_19
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<int32[]>::GF1<int32>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_13
-ldloc.s V_19
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<int32[]>::GF1<int32[]>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_14
-ldloc.s V_20
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<valuetype Point>::GF1<object>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_14
-ldloc.s V_20
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<valuetype Point>::GF1<class A>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_14
-ldloc.s V_20
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<valuetype Point>::GF1<class A[]>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_14
-ldloc.s V_20
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<valuetype Point>::GF1<int32>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_14
-ldloc.s V_20
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<valuetype Point>::GF1<int32[]>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_15
-ldloc.s V_21
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<valuetype Point[]>::GF1<object>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_15
-ldloc.s V_21
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<valuetype Point[]>::GF1<class A>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_15
-ldloc.s V_21
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<valuetype Point[]>::GF1<class A[]>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_15
-ldloc.s V_21
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<valuetype Point[]>::GF1<int32>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldloc.s V_15
-ldloc.s V_21
-ldc.i4.s 100
-ldloca.s V_6
-conv.u
-conv.u8
-ldc.i4.0
-conv.i8
-callvirt instance int32 class GI1`1<valuetype Point[]>::GF1<int32[]>(class GI2`1<!0>, int32, int64, int64)
-add
-
-ldsfld int32 C1::errors
-add
-dup
-stloc.s V_9
-brfalse.s IL_0591
-
-ldstr "failure {0}"
-br.s IL_0596
-
-IL_0591:
-ldstr "success"
-
-IL_0596:
-ldloc.s V_9
-box [mscorlib]System.Int32
-call void [mscorlib]System.Console::WriteLine(string, object)
-ldloc.s V_9
-tail.
-call void [mscorlib]System.Environment::Exit(int32)
+call void C3::print()
 ret
 }
 
 .method public static void Main(string[] args) noinlining
 {
 .entrypoint
-newobj instance void C3::.ctor()
-tail.
-call instance void C3::Main()
+.locals init (
+	class D`1<class A> V_0,
+	class D`1<class B> V_1,
+	class D`1<class B[]> V_2,
+	class C V_3,
+	class B V_4,
+	class B[] V_5,
+	int64 V_6,
+	class I1 V_7,
+	class I2 V_8,
+	int64 V_9,
+	class GI1`1<object> V_10,
+	class GI1`1<object[]> V_11,
+	class GI1`1<int64> V_12,
+	class GI1`1<int64[]> V_13,
+	class GI1`1<valuetype Point> V_14,
+	class GI1`1<valuetype Point[]> V_15,
+	class GI2`1<object> V_16,
+	class GI2`1<object[]> V_17,
+	class GI2`1<int64> V_18,
+	class GI2`1<int64[]> V_19,
+	class GI2`1<valuetype Point> V_20,
+	class GI2`1<valuetype Point[]> V_21,
+	int64 depth
+	)
+
+ldc.i8 9999999
+stloc depth
+newobj instance void class D`1<class A>::.ctor()
+stloc 0
+newobj instance void class D`1<class B>::.ctor()
+stloc 1
+newobj instance void class D`1<class B[]>::.ctor()
+stloc 2
+newobj instance void C::.ctor()
+stloc 3
+newobj instance void B::.ctor()
+stloc V_4
+ldc.i8 1
+newarr B
+stloc V_5
+
+newobj instance void C1::.ctor()
+stloc V_7
+newobj instance void C2::.ctor()
+stloc V_8
+
+newobj instance void class GC1`1<object>::.ctor()
+stloc V_10
+newobj instance void class GC1`1<object[]>::.ctor()
+stloc V_11
+newobj instance void class GC1`1<int64>::.ctor()
+stloc V_12
+newobj instance void class GC1`1<int64[]>::.ctor()
+stloc V_13
+newobj instance void class GC1`1<valuetype Point>::.ctor()
+stloc V_14
+newobj instance void class GC1`1<valuetype Point[]>::.ctor()
+stloc V_15
+newobj instance void class GC2`1<object>::.ctor()
+stloc V_16
+newobj instance void class GC2`1<object[]>::.ctor()
+stloc V_17
+newobj instance void class GC2`1<int64>::.ctor()
+stloc V_18
+newobj instance void class GC2`1<int64[]>::.ctor()
+stloc V_19
+newobj instance void class GC2`1<valuetype Point>::.ctor()
+stloc V_20
+newobj instance void class GC2`1<valuetype Point[]>::.ctor()
+stloc V_21
+
+// test-split-prefix do not remove or edit this line
+
+ldloc 0
+ldloc V_4
+ldloc depth
+ldc.i8 0
+callvirt instance class B class D`1<class A>::cast2(object, int64, int64)
+call void C3::print(object)
+
+ldloc 0
+ldloc V_4
+ldloc depth
+ldc.i8 0
+callvirt instance !!0 class D`1<class A>::cast3<class B>(object, int64, int64)
+call void C3::print(object)
+
+ldloc 0
+ldloc V_5
+ldloc depth
+ldc.i8 0
+conv.i8
+callvirt instance !!0 class D`1<class A>::cast3<class B[]>(object, int64, int64)
+call void C3::print(object)
+
+ldloc 0
+ldloc V_5
+ldloc depth
+ldc.i8 0
+callvirt instance class B[] class D`1<class A>::cast4(object, int64, int64)
+call void C3::print(object)
+
+ldloc 0
+ldloc V_5
+ldloc depth
+ldc.i8 0
+callvirt instance !!0[] class D`1<class A>::cast5<class B>(object, int64, int64)
+call void C3::print(object)
+
+ldloc 1
+ldloc V_4
+ldloc depth
+ldc.i8 0
+callvirt instance !0 class D`1<class B>::cast6(object, int64, int64)
+call void C3::print(object)
+
+ldloc 1
+ldloc V_4
+ldloc depth
+ldc.i8 0
+callvirt instance !0 class D`1<class B>::cast7<class A>(object, int64, int64)
+call void C3::print(object)
+
+ldloc 2
+ldloc V_5
+ldloc depth
+ldc.i8 0
+callvirt instance !0 class D`1<class B[]>::cast7<class A[]>(object, int64, int64)
+call void C3::print(object)
+
+ldloc 1
+ldloc V_5
+ldloc depth
+ldc.i8 0
+callvirt instance !0[] class D`1<class B>::cast8(object, int64, int64)
+call void C3::print(object)
+
+ldloc 1
+ldloc V_5
+ldloc depth
+ldc.i8 0
+callvirt instance !0[] class D`1<class B>::cast9<class A>(object, int64, int64)
+call void C3::print(object)
+
+ldloc 3
+ldloc V_4
+ldloc depth
+ldc.i8 0
+callvirt instance class B C::cast2(object, int64, int64)
+call void C3::print(object)
+
+ldloc 3
+ldloc V_4
+ldloc depth
+ldc.i8 0
+callvirt instance !!0 C::cast3<class B>(object, int64, int64)
+call void C3::print(object)
+
+ldloc 3
+ldloc V_5
+ldloc depth
+ldc.i8 0
+callvirt instance !!0 C::cast3<class B[]>(object, int64, int64)
+call void C3::print(object)
+
+ldloc 3
+ldloc V_5
+ldloc depth
+ldc.i8 0
+callvirt instance class B[] C::cast4(object, int64, int64)
+call void C3::print(object)
+
+ldloc 3
+ldloc V_5
+ldloc depth
+ldc.i8 0
+callvirt instance !!0[] C::cast5<class B>(object, int64, int64)
+call void C3::print(object)
+
+ldloc V_7
+ldloc V_8
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void I1::F1(class I2, int64, int64, int64)
+
+ldloc V_7
+ldloc V_8
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void I1::GF1<object>(class I2, int64, int64, int64)
+
+ldloc V_7
+ldloc V_8
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void I1::GF1<class A>(class I2, int64, int64, int64)
+
+ldloc V_7
+ldloc V_8
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void I1::GF1<class A[]>(class I2, int64, int64, int64)
+
+ldloc V_7
+ldloc V_8
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void I1::GF1<int64>(class I2, int64, int64, int64)
+
+ldloc V_7
+ldloc V_8
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void I1::GF1<int64[]>(class I2, int64, int64, int64)
+
+// This is the only failure on desktop.
+ldloc V_10
+ldloc V_16
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<object>::F1(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_10
+ldloc V_16
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<object>::GF1<object>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_10
+ldloc V_16
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<object>::GF1<class A>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_10
+ldloc V_16
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<object>::GF1<class A[]>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_10
+ldloc V_16
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<object>::GF1<int64>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_10
+ldloc V_16
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<object>::GF1<int64[]>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_11
+ldloc V_17
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<object[]>::GF1<object[]>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_11
+ldloc V_17
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<object[]>::GF1<class A>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_11
+ldloc V_17
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<object[]>::GF1<class A[]>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_11
+ldloc V_17
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<object[]>::GF1<int64>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_11
+ldloc V_17
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<object[]>::GF1<int64[]>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_12
+ldloc V_18
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<int64>::GF1<object>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_12
+ldloc V_18
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<int64>::GF1<class A>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_12
+ldloc V_18
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<int64>::GF1<class A[]>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_12
+ldloc V_18
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<int64>::GF1<int64>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_12
+ldloc V_18
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<int64>::GF1<int64[]>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_13
+ldloc V_19
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<int64[]>::GF1<object>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_13
+ldloc V_19
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<int64[]>::GF1<class A>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_13
+ldloc V_19
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<int64[]>::GF1<class A[]>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_13
+ldloc V_19
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<int64[]>::GF1<int64>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_13
+ldloc V_19
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<int64[]>::GF1<int64[]>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_14
+ldloc V_20
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<valuetype Point>::GF1<object>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_14
+ldloc V_20
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<valuetype Point>::GF1<class A>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_14
+ldloc V_20
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<valuetype Point>::GF1<class A[]>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_14
+ldloc V_20
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<valuetype Point>::GF1<int64>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_14
+ldloc V_20
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<valuetype Point>::GF1<int64[]>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_15
+ldloc V_21
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<valuetype Point[]>::GF1<object>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_15
+ldloc V_21
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<valuetype Point[]>::GF1<class A>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_15
+ldloc V_21
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<valuetype Point[]>::GF1<class A[]>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_15
+ldloc V_21
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<valuetype Point[]>::GF1<int64>(class GI2`1<!0>, int64, int64, int64)
+
+ldloc V_15
+ldloc V_21
+ldloc depth
+ldloca V_6
+conv.u
+conv.u8
+ldc.i8 0
+callvirt instance void class GI1`1<valuetype Point[]>::GF1<int64[]>(class GI2`1<!0>, int64, int64, int64)
+
+// test-split-suffix do not remove or edit this line
+
+ldsfld int64 C1::errors
+dup
+stloc V_9
+brfalse IL_0591
+
+ldstr "failure {0}"
+br IL_0596
+
+IL_0591:
+ldstr "success"
+
+IL_0596:
+ldloc V_9
+box [mscorlib]System.Int64
+call void [mscorlib]System.Console::WriteLine(string, object)
+ldloc V_9
+conv.i4
+call void [mscorlib]System.Environment::Exit(int32)
 ret
 }
 
-.method public instance void .ctor()
-{
-ldarg.0
-tail.
-call instance void [mscorlib]System.Object::.ctor()
-ret
-}
 }

--- a/mono/tests/tailcall-interface.cs
+++ b/mono/tests/tailcall-interface.cs
@@ -20,10 +20,10 @@ interface I1
 	void perturb_interface_offset1 ( );
 
 	[MethodImpl (NoInlining)]
-	int F1 (I2 i2, int counter, long initial_stack, long current_stack = 0);
+	int F1 (I2 i2, long counter, long initial_stack, long current_stack = 0);
 
 	[MethodImpl (NoInlining)]
-	int GF1<TF> (I2 i2, int counter, long initial_stack, long current_stack = 0);
+	int GF1<TF> (I2 i2, long counter, long initial_stack, long current_stack = 0);
 }
 
 interface GI1<TC>
@@ -32,13 +32,13 @@ interface GI1<TC>
 	void perturb_interface_offset2 ( );
 
 	[MethodImpl (NoInlining)]
-	int F1 (GI2<TC> i2, int counter, long initial_stack, long current_stack = 0);
+	int F1 (GI2<TC> i2, long counter, long initial_stack, long current_stack = 0);
 
 	[MethodImpl (NoInlining)]
-	int GF1<TF> (GI2<TC> i2, int counter, long initial_stack, long current_stack = 0);
+	int GF1<TF> (GI2<TC> i2, long counter, long initial_stack, long current_stack = 0);
 
 	[MethodImpl (NoInlining)]
-	int HF1<TF> (GI2<TF> i2, int counter, long initial_stack, long current_stack = 0);
+	int HF1<TF> (GI2<TF> i2, long counter, long initial_stack, long current_stack = 0);
 }
 
 interface I2
@@ -48,10 +48,10 @@ interface I2
 	void perturb_interface_offset3 ( );
 
 	[MethodImpl (NoInlining)]
-	int F2 (I1 i1, int counter, long initial_stack, long current_stack = 0);
+	int F2 (I1 i1, long counter, long initial_stack, long current_stack = 0);
 
 	[MethodImpl (NoInlining)]
-	int GF2<TF> (I1 i1, int counter, long initial_stack, long current_stack = 0);
+	int GF2<TF> (I1 i1, long counter, long initial_stack, long current_stack = 0);
 }
 
 interface GI2<TC>
@@ -62,13 +62,13 @@ interface GI2<TC>
 	void perturb_interface_offset4 ( );
 
 	[MethodImpl (NoInlining)]
-	int F2 (GI1<TC> i1, int counter, long initial_stack, long current_stack = 0);
+	int F2 (GI1<TC> i1, long counter, long initial_stack, long current_stack = 0);
 
 	[MethodImpl (NoInlining)]
-	int GF2<TF> (GI1<TC> i1, int counter, long initial_stack, long current_stack = 0);
+	int GF2<TF> (GI1<TC> i1, long counter, long initial_stack, long current_stack = 0);
 
 	[MethodImpl (NoInlining)]
-	int HF2<TF> (GI1<TF> i1, int counter, long initial_stack, long current_stack = 0);
+	int HF2<TF> (GI1<TF> i1, long counter, long initial_stack, long current_stack = 0);
 }
 
 unsafe public class C1 : I1
@@ -93,21 +93,19 @@ unsafe public class C1 : I1
 	}
 
 	[MethodImpl (NoInlining)]
-	int I1.F1 (I2 i2, int counter, long initial_stack, long current_stack)
+	int I1.F1 (I2 i2, long counter, long initial_stack, long current_stack)
 	{
-		int local;
 		if (counter > 0)
-			return i2.F2 (this, counter - 1, initial_stack, (long)&local);
-		return check ((long)&local, current_stack);
+			return i2.F2 (this, counter - 1, initial_stack, (long)&counter);
+		return check ((long)&counter, current_stack);
 	}
 
 	[MethodImpl (NoInlining)]
-	int I1.GF1<TF> (I2 i2, int counter, long initial_stack, long current_stack)
+	int I1.GF1<TF> (I2 i2, long counter, long initial_stack, long current_stack)
 	{
-		int local;
 		if (counter > 0)
-			return i2.GF2<TF> (this, counter - 1, initial_stack, (long)&local);
-		return check ((long)&local, current_stack);
+			return i2.GF2<TF> (this, counter - 1, initial_stack, (long)&counter);
+		return check ((long)&counter, current_stack);
 	}
 }
 
@@ -122,30 +120,27 @@ unsafe public class GC1<TC> : GI1<TC>
 	}
 
 	[MethodImpl (NoInlining)]
-	int GI1<TC>.F1 (GI2<TC> i2, int counter, long initial_stack, long current_stack)
+	int GI1<TC>.F1 (GI2<TC> i2, long counter, long initial_stack, long current_stack)
 	{
-		int local;
 		if (counter > 0)
-			return i2.F2 (this, counter - 1, initial_stack, (long)&local);
-		return check ((long)&local, current_stack);
+			return i2.F2 (this, counter - 1, initial_stack, (long)&counter);
+		return check ((long)&counter, current_stack);
 	}
 
 	[MethodImpl (NoInlining)]
-	int GI1<TC>.GF1<TF> (GI2<TC> i2, int counter, long initial_stack, long current_stack)
+	int GI1<TC>.GF1<TF> (GI2<TC> i2, long counter, long initial_stack, long current_stack)
 	{
-		int local;
 		if (counter > 0)
-			return i2.GF2<TF> (this, counter - 1, initial_stack, (long)&local);
-		return check ((long)&local, current_stack);
+			return i2.GF2<TF> (this, counter - 1, initial_stack, (long)&counter);
+		return check ((long)&counter, current_stack);
 	}
 
 	[MethodImpl (NoInlining)]
-	int GI1<TC>.HF1<TF> (GI2<TF> i2, int counter, long initial_stack, long current_stack)
+	int GI1<TC>.HF1<TF> (GI2<TF> i2, long counter, long initial_stack, long current_stack)
 	{
-		int local;
 		if (counter > 0)
-			return i2.HF2<TC> (this, counter - 1, initial_stack, (long)&local);
-		return check ((long)&local, current_stack);
+			return i2.HF2<TC> (this, counter - 1, initial_stack, (long)&counter);
+		return check ((long)&counter, current_stack);
 	}
 }
 
@@ -161,21 +156,19 @@ unsafe public class C2 : I2
 	}
 
 	[MethodImpl (NoInlining)]
-	int I2.F2 (I1 i1, int counter, long initial_stack, long current_stack)
+	int I2.F2 (I1 i1, long counter, long initial_stack, long current_stack)
 	{
-		int local;
 		if (counter > 0)
-			return i1.F1 (this, counter - 1, initial_stack, (long)&local);
-		return check ((long)&local, current_stack);
+			return i1.F1 (this, counter - 1, initial_stack, (long)&counter);
+		return check ((long)&counter, current_stack);
 	}
 
 	[MethodImpl (NoInlining)]
-	int I2.GF2<TF> (I1 i1, int counter, long initial_stack, long current_stack)
+	int I2.GF2<TF> (I1 i1, long counter, long initial_stack, long current_stack)
 	{
-		int local;
 		if (counter > 0)
-			return i1.GF1<TF> (this, counter - 1, initial_stack, (long)&local);
-		return check ((long)&local, current_stack);
+			return i1.GF1<TF> (this, counter - 1, initial_stack, (long)&counter);
+		return check ((long)&counter, current_stack);
 	}
 }
 
@@ -192,30 +185,27 @@ unsafe public class GC2<TC> : GI2<TC>
 	}
 
 	[MethodImpl (NoInlining)]
-	int GI2<TC>.F2 (GI1<TC> i1, int counter, long initial_stack, long current_stack)
+	int GI2<TC>.F2 (GI1<TC> i1, long counter, long initial_stack, long current_stack)
 	{
-		int local;
 		if (counter > 0)
-			return i1.F1 (this, counter - 1, initial_stack, (long)&local);
-		return check ((long)&local, current_stack);
+			return i1.F1 (this, counter - 1, initial_stack, (long)&counter);
+		return check ((long)&counter, current_stack);
 	}
 
 	[MethodImpl (NoInlining)]
-	int GI2<TC>.GF2<TF> (GI1<TC> i1, int counter, long initial_stack, long current_stack)
+	int GI2<TC>.GF2<TF> (GI1<TC> i1, long counter, long initial_stack, long current_stack)
 	{
-		int local;
 		if (counter > 0)
-			return i1.GF1<TF> (this, counter - 1, initial_stack, (long)&local);
-		return check ((long)&local, current_stack);
+			return i1.GF1<TF> (this, counter - 1, initial_stack, (long)&counter);
+		return check ((long)&counter, current_stack);
 	}
 
 	[MethodImpl (NoInlining)]
-	int GI2<TC>.HF2<TF> (GI1<TF> i1, int counter, long initial_stack, long current_stack)
+	int GI2<TC>.HF2<TF> (GI1<TF> i1, long counter, long initial_stack, long current_stack)
 	{
-		int local;
 		if (counter > 0)
-			return i1.HF1<TC> (this, counter - 1, initial_stack, (long)&local);
-		return check ((long)&local, current_stack);
+			return i1.HF1<TC> (this, counter - 1, initial_stack, (long)&counter);
+		return check ((long)&counter, current_stack);
 	}
 }
 
@@ -226,19 +216,19 @@ public class B { }
 interface IC
 {
 	[MethodImpl (NoInlining)]
-	T cast1<T> (object o, int counter = 100, long stack = 0);
+	T cast1<T> (object o, long counter = 100, long stack = 0);
 
 	[MethodImpl (NoInlining)]
-	B cast2 (object o, int counter = 100, long stack = 0);
+	B cast2 (object o, long counter = 100, long stack = 0);
 
 	[MethodImpl (NoInlining)]
-	T cast3<T> (object o, int counter = 100, long stack = 0);
+	T cast3<T> (object o, long counter = 100, long stack = 0);
 
 	[MethodImpl (NoInlining)]
-	B[] cast4 (object o, int counter = 100, long stack = 0);
+	B[] cast4 (object o, long counter = 100, long stack = 0);
 
 	[MethodImpl (NoInlining)]
-	T[] cast5<T> (object o, int counter = 100, long stack = 0);
+	T[] cast5<T> (object o, long counter = 100, long stack = 0);
 }
 
 unsafe public class C
@@ -250,52 +240,47 @@ unsafe public class C
 	}
 
 	[MethodImpl (NoInlining)]
-	public T cast1<T> (object o, int counter = 100, long stack = 0)
+	public T cast1<T> (object o, long counter = 100, long stack = 0)
 	{
-		int local;
 		if (counter > 0)
-			return cast1<T> (o, counter - 1, (long)&local);
-		check ((long)&local, stack);
+			return cast1<T> (o, counter - 1, (long)&counter);
+		check ((long)&counter, stack);
 		return (T)o;
 	}
 
 	[MethodImpl (NoInlining)]
-	public B cast2 (object o, int counter = 100, long stack = 0)
+	public B cast2 (object o, long counter = 100, long stack = 0)
 	{
-		int local;
 		if (counter > 0)
-			return cast2 (o, counter - 1, (long)&local);
-		check ((long)&local, stack);
+			return cast2 (o, counter - 1, (long)&counter);
+		check ((long)&counter, stack);
 		return cast1<B> (o);
 	}
 
 	[MethodImpl (NoInlining)]
-	public T cast3<T> (object o, int counter = 100, long stack = 0)
+	public T cast3<T> (object o, long counter = 100, long stack = 0)
 	{
-		int local;
 		if (counter > 0)
-			return cast3<T> (o, counter - 1, (long)&local);
-		check ((long)&local, stack);
+			return cast3<T> (o, counter - 1, (long)&counter);
+		check ((long)&counter, stack);
 		return cast1<T> (o);
 	}
 
 	[MethodImpl (NoInlining)]
-	public B[] cast4 (object o, int counter = 100, long stack = 0)
+	public B[] cast4 (object o, long counter = 100, long stack = 0)
 	{
-		int local;
 		if (counter > 0)
-			return cast4 (o, counter - 1, (long)&local);
-		check ((long)&local, stack);
+			return cast4 (o, counter - 1, (long)&counter);
+		check ((long)&counter, stack);
 		return cast1<B[]> (o);
 	}
 
 	[MethodImpl (NoInlining)]
-	public T[] cast5<T> (object o, int counter = 100, long stack = 0)
+	public T[] cast5<T> (object o, long counter = 100, long stack = 0)
 	{
-		int local;
 		if (counter > 0)
-			return cast5<T> (o, counter - 1, (long)&local);
-		check ((long)&local, stack);
+			return cast5<T> (o, counter - 1, (long)&counter);
+		check ((long)&counter, stack);
 		return cast1<T[]> (o);
 	}
 }
@@ -309,92 +294,83 @@ unsafe public class D<T1>
 	}
 
 	[MethodImpl (NoInlining)]
-	public static T cast1<T> (object o, int counter = 100, long stack = 0)
+	public static T cast1<T> (object o, long counter = 100, long stack = 0)
 	{
-		int local;
 		if (counter > 0)
-			return cast1<T> (o, counter - 1, (long)&local);
-		check ((long)&local, stack);
+			return cast1<T> (o, counter - 1, (long)&counter);
+		check ((long)&counter, stack);
 		return (T)o;
 	}
 
 	[MethodImpl (NoInlining)]
-	public B cast2 (object o, int counter = 100, long stack = 0)
+	public B cast2 (object o, long counter = 100, long stack = 0)
 	{
-		int local;
 		if (counter > 0)
-			return cast2 (o, counter - 1, (long)&local);
-		check ((long)&local, stack);
+			return cast2 (o, counter - 1, (long)&counter);
+		check ((long)&counter, stack);
 		return cast1<B> (o);
 	}
 
 	[MethodImpl (NoInlining)]
-	public T cast3<T> (object o, int counter = 100, long stack = 0)
+	public T cast3<T> (object o, long counter = 100, long stack = 0)
 	{
-		int local;
 		if (counter > 0)
-			return cast3<T> (o, counter - 1, (long)&local);
-		check ((long)&local, stack);
+			return cast3<T> (o, counter - 1, (long)&counter);
+		check ((long)&counter, stack);
 		return cast1<T> (o);
 	}
 
 	[MethodImpl (NoInlining)]
-	public B[] cast4 (object o, int counter = 100, long stack = 0)
+	public B[] cast4 (object o, long counter = 100, long stack = 0)
 	{
-		int local;
 		if (counter > 0)
-			return cast4 (o, counter - 1, (long)&local);
-		check ((long)&local, stack);
+			return cast4 (o, counter - 1, (long)&counter);
+		check ((long)&counter, stack);
 		return cast1<B[]> (o);
 	}
 
 	[MethodImpl (NoInlining)]
-	public T[] cast5<T> (object o, int counter = 100, long stack = 0)
+	public T[] cast5<T> (object o, long counter = 100, long stack = 0)
 	{
-		int local;
 		if (counter > 0)
-			return cast5<T> (o, counter - 1, (long)&local);
-		check ((long)&local, stack);
+			return cast5<T> (o, counter - 1, (long)&counter);
+		check ((long)&counter, stack);
 		return cast1<T[]> (o);
 	}
 
 	[MethodImpl (NoInlining)]
-	public T1 cast6 (object o, int counter = 100, long stack = 0)
+	public T1 cast6 (object o, long counter = 100, long stack = 0)
 	{
-		int local;
 		if (counter > 0)
-			return cast6 (o, counter - 1, (long)&local);
-		check ((long)&local, stack);
+			return cast6 (o, counter - 1, (long)&counter);
+		check ((long)&counter, stack);
 		return cast1<T1> (o);
 	}
 
 	[MethodImpl (NoInlining)]
-	public T1 cast7<T> (object o, int counter = 100, long stack = 0)
+	public T1 cast7<T> (object o, long counter = 100, long stack = 0)
 	{
-		int local;
 		if (counter > 0)
-			return cast7<T> (o, counter - 1, (long)&local);
-		check ((long)&local, stack);
+			return cast7<T> (o, counter - 1, (long)&counter);
+		check ((long)&counter, stack);
 		return cast1<T1> (o);
 	}
 
 	[MethodImpl (NoInlining)]
-	public T1[] cast8 (object o, int counter = 100, long stack = 0)
+	public T1[] cast8 (object o, long counter = 100, long stack = 0)
 	{
-		int local;
 		if (counter > 0)
-			return cast8 (o, counter - 1, (long)&local);
-		check ((long)&local, stack);
+			return cast8 (o, counter - 1, (long)&counter);
+		check ((long)&counter, stack);
 		return cast3<T1[]> (o);
 	}
 
 	[MethodImpl (NoInlining)]
-	public T1[] cast9<T> (object o, int counter = 100, long stack = 0)
+	public T1[] cast9<T> (object o, long counter = 100, long stack = 0)
 	{
-		int local;
 		if (counter > 0)
-			return cast9<T> (o, counter - 1, (long)&local);
-		check ((long)&local, stack);
+			return cast9<T> (o, counter - 1, (long)&counter);
+		check ((long)&counter, stack);
 		return cast3<T1[]> (o);
 	}
 }

--- a/mono/tests/tailcall-rgctxb-static.il
+++ b/mono/tests/tailcall-rgctxb-static.il
@@ -37,9 +37,9 @@ unsafe struct A<T>
     static public int f1 (int counter, long initial_stack, long current_stack)
     {
 	int local;
-	object a = new T[101];
 	if (counter > 0)
 	    return f2 (counter - 1, initial_stack, (long)&local);
+	object a = new T[10];
 	return check ((long)&local, current_stack);
     }
 
@@ -47,9 +47,9 @@ unsafe struct A<T>
     static public int f2 (int counter, long initial_stack, long current_stack)
     {
 	int local;
-	object a = new T[101];
 	if (counter > 0)
 	    return f1 (counter - 1, initial_stack, (long)&local);
+	object a = new T[11];
 	return check ((long)&local, current_stack);
     }
 }

--- a/mono/tests/tailcall/fsharp-deeptail.il
+++ b/mono/tests/tailcall/fsharp-deeptail.il
@@ -182,25 +182,25 @@ type TailCallLoopImplementGenericInterface<'T1>(resultA: 'T1) =
 
 let create<'T> result = TailCallLoopImplementGenericInterface<'T>(result) :> InterfaceTailCallLoopGenericInterface<'T>
 
-RunTest "TailCallLoopGenericClassAndMethodAbstractClass<byte>.Method1<byte>"      ((create<byte>(3uy)).Method1<byte>(10000000, 4uy))      (3uy, 4uy)
-RunTest "TailCallLoopGenericClassAndMethodAbstractClass<byte>.Method1<int>"      ((create<byte>(3uy)).Method1<int>(10000000, 4))      (3uy, 4)
-RunTest "TailCallLoopGenericClassAndMethodAbstractClass<byte>.Method1<DateTime>"      ((create<byte>(3uy)).Method1<DateTime>(10000000, DateTime.MinValue))      (3uy, DateTime.MinValue)
-RunTest "TailCallLoopGenericClassAndMethodAbstractClass<byte>.Method1<string>"      ((create<byte>(3uy)).Method1<string>(10000000, "abc"))      (3uy, "abc")
+RunTest "TailCallLoopGenericClassAndMethodAbstractInterface<byte>.Method1<byte>"      ((create<byte>(3uy)).Method1<byte>(10000000, 4uy))      (3uy, 4uy)
+RunTest "TailCallLoopGenericClassAndMethodAbstractInterface<byte>.Method1<int>"      ((create<byte>(3uy)).Method1<int>(10000000, 4))      (3uy, 4)
+RunTest "TailCallLoopGenericClassAndMethodAbstractInterface<byte>.Method1<DateTime>"      ((create<byte>(3uy)).Method1<DateTime>(10000000, DateTime.MinValue))      (3uy, DateTime.MinValue)
+RunTest "TailCallLoopGenericClassAndMethodAbstractInterface<byte>.Method1<string>"      ((create<byte>(3uy)).Method1<string>(10000000, "abc"))      (3uy, "abc")
 
-RunTest "TailCallLoopGenericClassAndMethodAbstractClass<int>.Method1<byte>"      ((create<int>(3)).Method1<byte>(10000000, 4uy))      (3, 4uy)
-RunTest "TailCallLoopGenericClassAndMethodAbstractClass<int>.Method1<int>"      ((create<int>(3)).Method1<int>(10000000, 4))      (3, 4)
-RunTest "TailCallLoopGenericClassAndMethodAbstractClass<int>.Method1<DateTime>"      ((create<int>(3)).Method1<DateTime>(10000000, DateTime.MinValue))      (3, DateTime.MinValue)
-RunTest "TailCallLoopGenericClassAndMethodAbstractClass<int>.Method1<string>"      ((create<int>(3)).Method1<string>(10000000, "abc"))      (3, "abc")
+RunTest "TailCallLoopGenericClassAndMethodAbstractInterface<int>.Method1<byte>"      ((create<int>(3)).Method1<byte>(10000000, 4uy))      (3, 4uy)
+RunTest "TailCallLoopGenericClassAndMethodAbstractInterface<int>.Method1<int>"      ((create<int>(3)).Method1<int>(10000000, 4))      (3, 4)
+RunTest "TailCallLoopGenericClassAndMethodAbstractInterface<int>.Method1<DateTime>"      ((create<int>(3)).Method1<DateTime>(10000000, DateTime.MinValue))      (3, DateTime.MinValue)
+RunTest "TailCallLoopGenericClassAndMethodAbstractInterface<int>.Method1<string>"      ((create<int>(3)).Method1<string>(10000000, "abc"))      (3, "abc")
 
-RunTest "TailCallLoopGenericClassAndMethodAbstractClass<DateTime>.Method1<byte>"      ((create<DateTime>(DateTime.MaxValue)).Method1<byte>(10000000, 4uy))      (DateTime.MaxValue, 4uy)
-RunTest "TailCallLoopGenericClassAndMethodAbstractClass<DateTime>.Method1<int>"      ((create<DateTime>(DateTime.MaxValue)).Method1<int>(10000000, 4))      (DateTime.MaxValue, 4)
-RunTest "TailCallLoopGenericClassAndMethodAbstractClass<DateTime>.Method1<DateTime>"      ((create<DateTime>(DateTime.MaxValue)).Method1<DateTime>(10000000, DateTime.MinValue))      (DateTime.MaxValue, DateTime.MinValue)
-RunTest "TailCallLoopGenericClassAndMethodAbstractClass<DateTime>.Method1<string>"      ((create<DateTime>(DateTime.MaxValue)).Method1<string>(10000000, "abc"))      (DateTime.MaxValue, "abc")
+RunTest "TailCallLoopGenericClassAndMethodAbstractInterface<DateTime>.Method1<byte>"      ((create<DateTime>(DateTime.MaxValue)).Method1<byte>(10000000, 4uy))      (DateTime.MaxValue, 4uy)
+RunTest "TailCallLoopGenericClassAndMethodAbstractInterface<DateTime>.Method1<int>"      ((create<DateTime>(DateTime.MaxValue)).Method1<int>(10000000, 4))      (DateTime.MaxValue, 4)
+RunTest "TailCallLoopGenericClassAndMethodAbstractInterface<DateTime>.Method1<DateTime>"      ((create<DateTime>(DateTime.MaxValue)).Method1<DateTime>(10000000, DateTime.MinValue))      (DateTime.MaxValue, DateTime.MinValue)
+RunTest "TailCallLoopGenericClassAndMethodAbstractInterface<DateTime>.Method1<string>"      ((create<DateTime>(DateTime.MaxValue)).Method1<string>(10000000, "abc"))      (DateTime.MaxValue, "abc")
 
-RunTest "TailCallLoopGenericClassAndMethodAbstractClass<string>.Method1<byte>"      ((create<string>("qq")).Method1<byte>(10000000, 4uy))      ("qq", 4uy)
-RunTest "TailCallLoopGenericClassAndMethodAbstractClass<string>.Method1<int>"      ((create<string>("qq")).Method1<int>(10000000, 4))      ("qq", 4)
-RunTest "TailCallLoopGenericClassAndMethodAbstractClass<string>.Method1<DateTime>"      ((create<string>("qq")).Method1<DateTime>(10000000, DateTime.MinValue))      ("qq", DateTime.MinValue)
-RunTest "TailCallLoopGenericClassAndMethodAbstractClass<DatstringeTime>.Method1<string>"      ((create<string>("qq")).Method1<string>(10000000, "abc"))      ("qq", "abc")
+RunTest "TailCallLoopGenericClassAndMethodAbstractInterface<string>.Method1<byte>"      ((create<string>("qq")).Method1<byte>(10000000, 4uy))      ("qq", 4uy)
+RunTest "TailCallLoopGenericClassAndMethodAbstractInterface<string>.Method1<int>"      ((create<string>("qq")).Method1<int>(10000000, 4))      ("qq", 4)
+RunTest "TailCallLoopGenericClassAndMethodAbstractInterface<string>.Method1<DateTime>"      ((create<string>("qq")).Method1<DateTime>(10000000, DateTime.MinValue))      ("qq", DateTime.MinValue)
+RunTest "TailCallLoopGenericClassAndMethodAbstractInterface<DatstringeTime>.Method1<string>"      ((create<string>("qq")).Method1<string>(10000000, "abc"))      ("qq", "abc")
 
 // Generic tail call within a type
 type TailCallLoopGenericClass<'T1>(resultA: 'T1) =
@@ -612,8 +612,8 @@ callvirt instance class [mscorlib]System.Tuple`2<!0,!!0> class Fsharp/AbstractTa
 ldstr "qq"
 ldc.i4.4
 newobj instance void class [mscorlib]System.Tuple`2<string,int32>::.ctor(!0, !1)
-
 call void Fsharp::RunTest<class [mscorlib]System.Tuple`2<string,int32>>(string, !!0, !!0)
+
 ldstr "TailCallLoopGenericClassAndMethodAbstractClass<string>.Method1<DateTime>"
 ldstr "qq"
 newobj instance void class Fsharp/TailCallLoopGenericClassAndMethodAbstractClass`1<string>::.ctor(!0)
@@ -636,7 +636,7 @@ ldstr "abc"
 newobj instance void class [mscorlib]System.Tuple`2<string,string>::.ctor(!0, !1)
 call void Fsharp::RunTest<class [mscorlib]System.Tuple`2<string,string>>(string, !!0, !!0)
 
-ldstr "TailCallLoopGenericClassAndMethodAbstractClass<byte>.Method1<byte>"
+ldstr "TailCallLoopGenericClassAndMethodAbstractInterface<byte>.Method1<byte>"
 ldc.i4.3
 call class Fsharp/InterfaceTailCallLoopGenericInterface`1<!!0> Fsharp::create<uint8>(!!0)
 call int32 Fsharp::get_HugeInt()
@@ -647,7 +647,7 @@ ldc.i4.4
 newobj instance void class [mscorlib]System.Tuple`2<uint8,uint8>::.ctor(!0, !1)
 call void Fsharp::RunTest<class [mscorlib]System.Tuple`2<uint8,uint8>>(string, !!0, !!0)
 
-ldstr "TailCallLoopGenericClassAndMethodAbstractClass<byte>.Method1<int>"
+ldstr "TailCallLoopGenericClassAndMethodAbstractInterface<byte>.Method1<int>"
 ldc.i4.3
 call class Fsharp/InterfaceTailCallLoopGenericInterface`1<!!0> Fsharp::create<uint8>(!!0)
 call int32 Fsharp::get_HugeInt()
@@ -658,7 +658,7 @@ ldc.i4.4
 newobj instance void class [mscorlib]System.Tuple`2<uint8,int32>::.ctor(!0, !1)
 call void Fsharp::RunTest<class [mscorlib]System.Tuple`2<uint8,int32>>(string, !!0, !!0)
 
-ldstr "TailCallLoopGenericClassAndMethodAbstractClass<byte>.Method1<DateTime>"
+ldstr "TailCallLoopGenericClassAndMethodAbstractInterface<byte>.Method1<DateTime>"
 ldc.i4.3
 call class Fsharp/InterfaceTailCallLoopGenericInterface`1<!!0> Fsharp::create<uint8>(!!0)
 call int32 Fsharp::get_HugeInt()
@@ -669,7 +669,7 @@ ldsfld valuetype [mscorlib]System.DateTime [mscorlib]System.DateTime::MinValue
 newobj instance void class [mscorlib]System.Tuple`2<uint8,valuetype [mscorlib]System.DateTime>::.ctor(!0, !1)
 call void Fsharp::RunTest<class [mscorlib]System.Tuple`2<uint8,valuetype [mscorlib]System.DateTime>>(string, !!0, !!0)
 
-ldstr "TailCallLoopGenericClassAndMethodAbstractClass<byte>.Method1<string>"
+ldstr "TailCallLoopGenericClassAndMethodAbstractInterface<byte>.Method1<string>"
 ldc.i4.3
 call class Fsharp/InterfaceTailCallLoopGenericInterface`1<!!0> Fsharp::create<uint8>(!!0)
 call int32 Fsharp::get_HugeInt()
@@ -680,7 +680,7 @@ ldstr "abc"
 newobj instance void class [mscorlib]System.Tuple`2<uint8,string>::.ctor(!0, !1)
 call void Fsharp::RunTest<class [mscorlib]System.Tuple`2<uint8,string>>(string, !!0, !!0)
 
-ldstr "TailCallLoopGenericClassAndMethodAbstractClass<int>.Method1<byte>"
+ldstr "TailCallLoopGenericClassAndMethodAbstractInterface<int>.Method1<byte>"
 ldc.i4.3
 call class Fsharp/InterfaceTailCallLoopGenericInterface`1<!!0> Fsharp::create<int32>(!!0)
 call int32 Fsharp::get_HugeInt()
@@ -691,7 +691,7 @@ ldc.i4.4
 newobj instance void class [mscorlib]System.Tuple`2<int32,uint8>::.ctor(!0, !1)
 call void Fsharp::RunTest<class [mscorlib]System.Tuple`2<int32,uint8>>(string, !!0, !!0)
 
-ldstr "TailCallLoopGenericClassAndMethodAbstractClass<int>.Method1<int>"
+ldstr "TailCallLoopGenericClassAndMethodAbstractInterface<int>.Method1<int>"
 ldc.i4.3
 call class Fsharp/InterfaceTailCallLoopGenericInterface`1<!!0> Fsharp::create<int32>(!!0)
 call int32 Fsharp::get_HugeInt()
@@ -702,7 +702,7 @@ ldc.i4.4
 newobj instance void class [mscorlib]System.Tuple`2<int32,int32>::.ctor(!0, !1)
 call void Fsharp::RunTest<class [mscorlib]System.Tuple`2<int32,int32>>(string, !!0, !!0)
 
-ldstr "TailCallLoopGenericClassAndMethodAbstractClass<int>.Method1<DateTime>"
+ldstr "TailCallLoopGenericClassAndMethodAbstractInterface<int>.Method1<DateTime>"
 ldc.i4.3
 call class Fsharp/InterfaceTailCallLoopGenericInterface`1<!!0> Fsharp::create<int32>(!!0)
 call int32 Fsharp::get_HugeInt()
@@ -713,7 +713,7 @@ ldsfld valuetype [mscorlib]System.DateTime [mscorlib]System.DateTime::MinValue
 newobj instance void class [mscorlib]System.Tuple`2<int32,valuetype [mscorlib]System.DateTime>::.ctor(!0, !1)
 call void Fsharp::RunTest<class [mscorlib]System.Tuple`2<int32,valuetype [mscorlib]System.DateTime>>(string, !!0, !!0)
 
-ldstr "TailCallLoopGenericClassAndMethodAbstractClass<int>.Method1<string>"
+ldstr "TailCallLoopGenericClassAndMethodAbstractInterface<int>.Method1<string>"
 ldc.i4.3
 call class Fsharp/InterfaceTailCallLoopGenericInterface`1<!!0> Fsharp::create<int32>(!!0)
 call int32 Fsharp::get_HugeInt()
@@ -724,7 +724,7 @@ ldstr "abc"
 newobj instance void class [mscorlib]System.Tuple`2<int32,string>::.ctor(!0, !1)
 call void Fsharp::RunTest<class [mscorlib]System.Tuple`2<int32,string>>(string, !!0, !!0)
 
-ldstr "TailCallLoopGenericClassAndMethodAbstractClass<DateTime>.Method1<byte>"
+ldstr "TailCallLoopGenericClassAndMethodAbstractInterface<DateTime>.Method1<byte>"
 ldsfld valuetype [mscorlib]System.DateTime [mscorlib]System.DateTime::MaxValue
 call class Fsharp/InterfaceTailCallLoopGenericInterface`1<!!0> Fsharp::create<valuetype [mscorlib]System.DateTime>(!!0)
 call int32 Fsharp::get_HugeInt()
@@ -735,7 +735,7 @@ ldc.i4.4
 newobj instance void class [mscorlib]System.Tuple`2<valuetype [mscorlib]System.DateTime,uint8>::.ctor(!0, !1)
 call void Fsharp::RunTest<class [mscorlib]System.Tuple`2<valuetype [mscorlib]System.DateTime,uint8>>(string, !!0, !!0)
 
-ldstr "TailCallLoopGenericClassAndMethodAbstractClass<DateTime>.Method1<int>"
+ldstr "TailCallLoopGenericClassAndMethodAbstractInterface<DateTime>.Method1<int>"
 ldsfld valuetype [mscorlib]System.DateTime [mscorlib]System.DateTime::MaxValue
 call class Fsharp/InterfaceTailCallLoopGenericInterface`1<!!0> Fsharp::create<valuetype [mscorlib]System.DateTime>(!!0)
 call int32 Fsharp::get_HugeInt()
@@ -746,7 +746,7 @@ ldc.i4.4
 newobj instance void class [mscorlib]System.Tuple`2<valuetype [mscorlib]System.DateTime,int32>::.ctor(!0, !1)
 call void Fsharp::RunTest<class [mscorlib]System.Tuple`2<valuetype [mscorlib]System.DateTime,int32>>(string, !!0, !!0)
 
-ldstr "TailCallLoopGenericClassAndMethodAbstractClass<DateTime>.Method1<DateTime>"
+ldstr "TailCallLoopGenericClassAndMethodAbstractInterface<DateTime>.Method1<DateTime>"
 ldsfld valuetype [mscorlib]System.DateTime [mscorlib]System.DateTime::MaxValue
 call class Fsharp/InterfaceTailCallLoopGenericInterface`1<!!0> Fsharp::create<valuetype [mscorlib]System.DateTime>(!!0)
 call int32 Fsharp::get_HugeInt()
@@ -757,7 +757,7 @@ ldsfld valuetype [mscorlib]System.DateTime [mscorlib]System.DateTime::MinValue
 newobj instance void class [mscorlib]System.Tuple`2<valuetype [mscorlib]System.DateTime,valuetype [mscorlib]System.DateTime>::.ctor(!0, !1)
 call void Fsharp::RunTest<class [mscorlib]System.Tuple`2<valuetype [mscorlib]System.DateTime,valuetype [mscorlib]System.DateTime>>(string, !!0, !!0)
 
-ldstr "TailCallLoopGenericClassAndMethodAbstractClass<DateTime>.Method1<string>"
+ldstr "TailCallLoopGenericClassAndMethodAbstractInterface<DateTime>.Method1<string>"
 ldsfld valuetype [mscorlib]System.DateTime [mscorlib]System.DateTime::MaxValue
 call class Fsharp/InterfaceTailCallLoopGenericInterface`1<!!0> Fsharp::create<valuetype [mscorlib]System.DateTime>(!!0)
 call int32 Fsharp::get_HugeInt()
@@ -768,7 +768,7 @@ ldstr "abc"
 newobj instance void class [mscorlib]System.Tuple`2<valuetype [mscorlib]System.DateTime,string>::.ctor(!0, !1)
 call void Fsharp::RunTest<class [mscorlib]System.Tuple`2<valuetype [mscorlib]System.DateTime,string>>(string, !!0, !!0)
 
-ldstr "TailCallLoopGenericClassAndMethodAbstractClass<string>.Method1<byte>"
+ldstr "TailCallLoopGenericClassAndMethodAbstractInterface<string>.Method1<byte>"
 ldstr "qq"
 call class Fsharp/InterfaceTailCallLoopGenericInterface`1<!!0> Fsharp::create<string>(!!0)
 call int32 Fsharp::get_HugeInt()
@@ -779,7 +779,7 @@ ldc.i4.4
 newobj instance void class [mscorlib]System.Tuple`2<string,uint8>::.ctor(!0, !1)
 call void Fsharp::RunTest<class [mscorlib]System.Tuple`2<string,uint8>>(string, !!0, !!0)
 
-ldstr "TailCallLoopGenericClassAndMethodAbstractClass<string>.Method1<int>"
+ldstr "TailCallLoopGenericClassAndMethodAbstractInterface<string>.Method1<int>"
 ldstr "qq"
 call class Fsharp/InterfaceTailCallLoopGenericInterface`1<!!0> Fsharp::create<string>(!!0)
 call int32 Fsharp::get_HugeInt()
@@ -790,7 +790,7 @@ ldc.i4.4
 newobj instance void class [mscorlib]System.Tuple`2<string,int32>::.ctor(!0, !1)
 call void Fsharp::RunTest<class [mscorlib]System.Tuple`2<string,int32>>(string, !!0, !!0)
 
-ldstr "TailCallLoopGenericClassAndMethodAbstractClass<string>.Method1<DateTime>"
+ldstr "TailCallLoopGenericClassAndMethodAbstractInterface<string>.Method1<DateTime>"
 ldstr "qq"
 call class Fsharp/InterfaceTailCallLoopGenericInterface`1<!!0> Fsharp::create<string>(!!0)
 call int32 Fsharp::get_HugeInt()
@@ -801,7 +801,7 @@ ldsfld valuetype [mscorlib]System.DateTime [mscorlib]System.DateTime::MinValue
 newobj instance void class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.DateTime>::.ctor(!0, !1)
 call void Fsharp::RunTest<class [mscorlib]System.Tuple`2<string,valuetype [mscorlib]System.DateTime>>(string, !!0, !!0)
 
-ldstr "TailCallLoopGenericClassAndMethodAbstractClass<DatstringeTime>.Method1<string>"
+ldstr "TailCallLoopGenericClassAndMethodAbstractInterface<DatstringeTime>.Method1<string>"
 ldstr "qq"
 call class Fsharp/InterfaceTailCallLoopGenericInterface`1<!!0> Fsharp::create<string>(!!0)
 call int32 Fsharp::get_HugeInt()

--- a/mono/tests/tailcall/split-fsharp.cpp
+++ b/mono/tests/tailcall/split-fsharp.cpp
@@ -1,0 +1,174 @@
+//
+// This program is used to split fsharp-deeptail.il into separate tests.
+//
+// Algorithm is just to split on the newline delimited ldstr opcodes
+// within the main@ function, and generate file names from the ldstr,
+// replacing special characters with underscores.
+//
+// git rm fsharp-deeptail-*
+// rm fsharp-deeptail-*
+// g++ split-fsharp.cpp  && ./a.out < fsharp-deeptail.il
+// git add fsharp-deeptail/*
+//
+// Note This is valid C++98 for use with older compilers, where C++11 would be desirable.
+#include <stdlib.h>
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <string>
+#include <assert.h>
+#include <string.h>
+#include <set>
+#include <stdio.h>
+using namespace std;
+#include <sys/stat.h>
+#ifdef _WIN32
+#include <direct.h>
+#endif
+
+typedef vector<string> strings_t;
+
+struct test_t
+{
+	string name;
+	strings_t content;
+};
+
+typedef vector<test_t> tests_t;
+
+static void
+CreateDir (const char *a)
+{
+#ifdef _WIN32
+	_mkdir (a);
+#else
+	mkdir (a, 0777);
+#endif
+}
+
+int main ()
+{
+	typedef set<string> names_t; // consider map<string, vector<string>> tests;
+	names_t names;
+	string line;
+	strings_t prefix;
+	tests_t tests;
+	test_t test_dummy;
+	test_t *test = &test_dummy;
+	strings_t suffix;
+
+	while (getline (cin, line))
+	{
+		prefix.push_back (line);
+		if (line == ".entrypoint")
+			break;
+	}
+
+	CreateDir ("tailcall");
+	CreateDir ("tailcall/fsharp-deeptail");
+
+	const string marker_ldstr = "ldstr \"";	// start of each test, and contains name
+	const string marker_ldc_i4_0 = "ldc.i4.0";	// start of suffix
+
+	while (getline (cin, line))
+	{
+		// tests are delimited by empty lines
+		if (line.length() == 0)
+		{
+			if (tests.size() && tests.back().name.length())
+			{
+				names_t::iterator a = names.find(tests.back().name);
+				if (a != names.end())
+				{
+					fprintf(stderr, "duplicate %s\n", a->c_str());
+					exit(1);
+				}
+				names.insert(names.end(), tests.back().name);
+			}
+			tests.resize (tests.size () + 1);
+			test = &tests.back ();
+			assert (getline (cin, line));
+			// tests start with ldstr
+			//printf("%s\n", line.c_str());
+			const bool ldstr = line.length () >= marker_ldstr.length () && memcmp(line.c_str (), marker_ldstr.c_str (), marker_ldstr.length ()) == 0;
+			const bool ldc_i4_0 = line.length () >= marker_ldc_i4_0.length () && memcmp(line.c_str (), marker_ldc_i4_0.c_str (), marker_ldc_i4_0.length ()) == 0;
+			assert (ldstr || ldc_i4_0);
+			if (ldc_i4_0)
+			{
+				suffix.push_back (line);
+				break;
+			}
+			string name1 = &line [marker_ldstr.length ()];
+			*strchr ((char*)name1.c_str (), '"') = 0; // truncate at quote
+			test->name = name1.c_str ();
+#if 1
+			// Change some chars to underscores.
+			for (string::iterator c = test->name.begin(); c != test->name.end(); ++c)
+				if (strchr("<>", *c))
+					*c = '_';
+#else
+			// remove some chars
+			while (true)
+			{
+				size_t c;
+				if ((c = test->name.find('<')) != string::npos)
+				{
+					test->name = test->name.replace(c, 1, "_");
+					continue;
+				}
+				if ((c = test->name.find('>')) != string::npos)
+				{
+					test->name = test->name.replace(c, 1, "_");
+					continue;
+				}
+				if ((c = test->name.find("..")) != string::npos)
+				{
+					test->name = test->name.replace(c, 2, "_");
+					continue;
+				}
+				if ((c = test->name.find("__")) != string::npos)
+				{
+					test->name = test->name.replace(c, 2, "_");
+					continue;
+				}
+				if ((c = test->name.find('.')) != string::npos)
+				{
+					test->name = test->name.replace(c, 1, "_");
+					continue;
+				}
+				break;
+			}
+#endif
+			//printf("%s\n", test->name.c_str());
+		}
+		test->content.push_back (line);
+	}
+	while (getline (cin, line))
+		suffix.push_back (line);
+
+	for (tests_t::const_iterator t = tests.begin(); t != tests.end(); ++t)
+	{
+		if (t->name.length() == 0)
+			continue;
+		//printf("%s\n", t->name.c_str());
+		ofstream output(("tailcall/fsharp-deeptail/" + t->name + ".il").c_str());
+		for (strings_t::const_iterator a = prefix.begin(); a != prefix.end(); ++a)
+			output << a->c_str () << endl;
+		output << endl;
+		for (strings_t::const_iterator a = t->content.begin(); a != t->content.end(); ++a)
+			output << a->c_str () << endl;
+		output << endl;
+		for (strings_t::const_iterator a = suffix.begin(); a != suffix.end(); ++a)
+			output << a->c_str () << endl;
+	}
+#if 0
+	for (names_t::const_iterator t = names.begin(); t != names.end(); ++t)
+		fputs(("\ttailcall/fsharp-deeptail/" + *t + ".il \\\n").c_str(), stdout);
+	for (names_t::const_iterator t = names.begin(); t != names.end(); ++t)
+		fputs(("INTERP_DISABLED_TESTS += tailcall/fsharp-deeptail/" + *t + ".exe\n").c_str(), stdout);
+	for (names_t::const_iterator t = names.begin(); t != names.end(); ++t)
+		fputs(("#PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/" + *t + ".exe\n").c_str(), stdout);
+	for (names_t::const_iterator t = names.begin(); t != names.end(); ++t)
+		fputs(("PLATFORM_DISABLED_TESTS += tailcall/fsharp-deeptail/" + *t + ".exe\n").c_str(), stdout);
+#endif
+}


### PR DESCRIPTION
Centralize tailcall debugprint.
Tweak tests to account for x86 frame alignment -- this way they pass, and in the real world, we might consume a little stack instead of zero, but not a lot. The test checks for zero.