### PR TITLE
Fix a couple of failing DYNCALL scenarios on Windows x64.

### DIFF
--- a/mono/mini/aot-tests.cs
+++ b/mono/mini/aot-tests.cs
@@ -57,6 +57,13 @@ class Tests
 		public static T Get_T2 (double d, int i1, int i2, int i3, int i4, int i5, int i6, int i7, int i8, T t) {
 			return t;
 		}
+		public static T Get_T3 (double d, int i, T t) {
+			return t;
+		}
+		public static T Get_T4 (int i, double d, T t)
+		{
+			return t;
+		}
 	}
 
 	class Foo3<T> {
@@ -81,6 +88,54 @@ class Tests
 		float s = 2.0f;
 		var res = (float)typeof (Foo<float>).GetMethod ("Get_T").Invoke (null, new object [] { arg1, s });
 		if (res != 2.0f)
+			return 1;
+		return 0;
+	}
+
+	[Category ("DYNCALL")]
+	static int test_0_amd64_dyncall_double_int_double ()
+	{
+		double arg1 = 1.0f;
+		int arg2 = 1;
+		double s = 2.0f;
+		var res = (double)typeof (Foo2<double>).GetMethod ("Get_T3").Invoke (null, new object [] { arg1, arg2, s });
+		if (res != 2.0f)
+			return 1;
+		return 0;
+	}
+
+	[Category ("DYNCALL")]
+	static int test_0_amd64_dyncall_double_int_float ()
+	{
+		double arg1 = 1.0f;
+		int arg2 = 1;
+		float s = 2.0f;
+		var res = (float)typeof (Foo2<float>).GetMethod ("Get_T3").Invoke (null, new object [] { arg1, arg2, s });
+		if (res != 2.0f)
+			return 1;
+		return 0;
+	}
+
+	[Category ("DYNCALL")]
+	static int test_0_amd64_dyncall_int_double_int ()
+	{
+		int arg1 = 1;
+		double arg2 = 1.0f;
+		int s = 2;
+		var res = (int)typeof (Foo2<int>).GetMethod ("Get_T4").Invoke (null, new object [] { arg1, arg2, s });
+		if (res != 2)
+			return 1;
+		return 0;
+	}
+
+	[Category ("DYNCALL")]
+	static int test_0_amd64_dyncall_int_double_ref ()
+	{
+		int arg1 = 1;
+		double arg2 = 1.0f;
+		object s = new object ();
+		var res = (object)typeof (Foo2<object>).GetMethod ("Get_T4").Invoke (null, new object [] { arg1, arg2, s });
+		if (res != s)
 			return 1;
 		return 0;
 	}

--- a/mono/mini/aot-tests.cs
+++ b/mono/mini/aot-tests.cs
@@ -166,6 +166,58 @@ class Tests
 	}
 
 	[Category ("DYNCALL")]
+	static int test_0_amd64_dyncall_use_stack_float ()
+	{
+		float s = 10.0f;
+		var res = (float)typeof (Foo2<float>).GetMethod ("Get_T2").Invoke (null, new object [] { 1.0f, 2, 3, 4, 5, 6, 7, 8, 9, s });
+		if (res != s)
+			return 1;
+		return 0;
+	}
+
+	[Category ("DYNCALL")]
+	static int test_0_amd64_dyncall_use_stack_double ()
+	{
+		double s = 10.0f;
+		var res = (double)typeof (Foo2<double>).GetMethod ("Get_T2").Invoke (null, new object [] { 1.0f, 2, 3, 4, 5, 6, 7, 8, 9, s });
+		if (res != s)
+			return 1;
+		return 0;
+	}
+
+	[Category ("DYNCALL")]
+	static int test_0_amd64_dyncall_use_stack_int ()
+	{
+		int s = 10;
+		var res = (int)typeof (Foo2<int>).GetMethod ("Get_T2").Invoke (null, new object [] { 1.0f, 2, 3, 4, 5, 6, 7, 8, 9, s });
+		if (res != s)
+			return 1;
+		return 0;
+	}
+
+	[Category ("DYNCALL")]
+	static int test_0_amd64_dyncall_use_stack_ref ()
+	{
+		object s = new object ();
+		var res = (object)typeof (Foo2<object>).GetMethod ("Get_T2").Invoke (null, new object [] { 1.0f, 2, 3, 4, 5, 6, 7, 8, 9, s });
+		if (res != s)
+			return 1;
+		return 0;
+	}
+
+	[Category ("DYNCALL")]
+	static int test_0_amd64_dyncall_use_stack_struct ()
+	{
+		Struct1 s = new Struct1 ();
+		s.a = 10.0f;
+		s.b = 11.0f;
+		var res = (Struct1)typeof (Foo2<Struct1>).GetMethod ("Get_T2").Invoke (null, new object [] { 1.0f, 2, 3, 4, 5, 6, 7, 8, 9, s });
+		if (res.a != s.a || res.b != s.b)
+			return 1;
+		return 0;
+	}
+
+	[Category ("DYNCALL")]
 	[Category ("GSHAREDVT")]
 	static int test_0_arm64_dyncall_gsharedvt_out_hfa_double () {
 		/* gsharedvt out trampoline with double hfa argument */
@@ -266,7 +318,8 @@ class Tests
 		return 0;
 	}
 
-	[Category ("!FULLAOT-AMD64")]
+	[Category ("DYNCALL")]
+	[Category ("GSHAREDVT")]
 	static int test_42_arm64_dyncall_vtypebyval () {
 		var method = typeof (Foo5<string>).GetMethod ("vtype_by_val").MakeGenericMethod (new Type [] { typeof (int), typeof (long?), typeof (long?), typeof (long?), typeof (long?) });
 		long res = (long)method.Invoke (null, new object [] { 1, 2L, 3L, 4L, 42L });

--- a/mono/mini/aot-tests.cs
+++ b/mono/mini/aot-tests.cs
@@ -141,7 +141,6 @@ class Tests
 	}
 
 	[Category ("DYNCALL")]
-	[Category ("!FULLAOT-AMD64")]
 	static int test_0_arm64_dyncall_hfa_double () {
 		double arg1 = 1.0f;
 		// HFA with double members
@@ -155,7 +154,6 @@ class Tests
 	}
 
 	[Category ("DYNCALL")]
-	[Category ("!FULLAOT-AMD64")]
 	static int test_0_arm64_dyncall_hfa_float () {
 		double arg1 = 1.0f;
 		var s = new Struct2 ();
@@ -169,7 +167,6 @@ class Tests
 
 	[Category ("DYNCALL")]
 	[Category ("GSHAREDVT")]
-	[Category ("!FULLAOT-AMD64")]
 	static int test_0_arm64_dyncall_gsharedvt_out_hfa_double () {
 		/* gsharedvt out trampoline with double hfa argument */
 		double arg1 = 1.0f;
@@ -189,7 +186,6 @@ class Tests
 
 	[Category ("DYNCALL")]
 	[Category ("GSHAREDVT")]
-	[Category ("!FULLAOT-AMD64")]
 	static int test_0_arm64_dyncall_gsharedvt_out_hfa_float () {
 		/* gsharedvt out trampoline with double hfa argument */
 		double arg1 = 1.0f;
@@ -256,7 +252,6 @@ class Tests
 
 	[Category ("DYNCALL")]
 	[Category ("GSHAREDVT")]
-	[Category ("!FULLAOT-AMD64")]
 	static int test_0_arm64_dyncall_vtypebyref_ret () {
 		var s = new VTypeByRefStruct () { o1 = 1, o2 = 2, o3 = 3 };
 		Type t = typeof (Foo5<>).MakeGenericType (new Type [] { typeof (VTypeByRefStruct) });
@@ -271,6 +266,7 @@ class Tests
 		return 0;
 	}
 
+	[Category ("!FULLAOT-AMD64")]
 	static int test_42_arm64_dyncall_vtypebyval () {
 		var method = typeof (Foo5<string>).GetMethod ("vtype_by_val").MakeGenericMethod (new Type [] { typeof (int), typeof (long?), typeof (long?), typeof (long?), typeof (long?) });
 		long res = (long)method.Invoke (null, new object [] { 1, 2L, 3L, 4L, 42L });
@@ -325,7 +321,6 @@ class Tests
 	}
 
 	[Category ("DYNCALL")]
-	[Category ("!FULLAOT-AMD64")]
 	public static int test_0_dyncall_nullable () {
 		int? v;
 
@@ -475,7 +470,6 @@ class Tests
 	}
 
 	[Category ("DYNCALL")]
-	[Category ("!FULLAOT-AMD64")]
 	[Category ("!WASM")] //Interp fails	
 	public static int test_0_large_nullable_invoke () {
 		var s = new LargeStruct () { a = 1, b = 2, c = 3, d = 4 };

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -2618,6 +2618,8 @@ mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, g
 			float_param_reg_to_index [float_param_regs[i]] = i;
 		mono_memory_barrier ();
 		param_reg_to_index_inited = 1;
+	} else {
+		mono_memory_barrier ();
 	}
 
 	p->res = 0;

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -214,13 +214,13 @@ typedef struct MonoCompileArch {
 
 #ifdef TARGET_WIN32
 
-static AMD64_Reg_No param_regs [] = { AMD64_RCX, AMD64_RDX, AMD64_R8, AMD64_R9 };
+static const AMD64_Reg_No param_regs [] = { AMD64_RCX, AMD64_RDX, AMD64_R8, AMD64_R9 };
 
-static AMD64_XMM_Reg_No float_param_regs [] = { AMD64_XMM0, AMD64_XMM1, AMD64_XMM2, AMD64_XMM3 };
+static const AMD64_XMM_Reg_No float_param_regs [] = { AMD64_XMM0, AMD64_XMM1, AMD64_XMM2, AMD64_XMM3 };
 
-static AMD64_Reg_No return_regs [] = { AMD64_RAX };
+static const AMD64_Reg_No return_regs [] = { AMD64_RAX };
 
-static AMD64_XMM_Reg_No float_return_regs [] = { AMD64_XMM0 };
+static const AMD64_XMM_Reg_No float_return_regs [] = { AMD64_XMM0 };
 
 #define PARAM_REGS G_N_ELEMENTS(param_regs)
 #define FLOAT_PARAM_REGS G_N_ELEMENTS(float_param_regs)
@@ -235,6 +235,10 @@ static AMD64_XMM_Reg_No float_return_regs [] = { AMD64_XMM0 };
 
 static const AMD64_Reg_No param_regs [] = {AMD64_RDI, AMD64_RSI, AMD64_RDX,
 					   AMD64_RCX, AMD64_R8,  AMD64_R9};
+
+static const AMD64_XMM_Reg_No float_param_regs[] = {AMD64_XMM0, AMD64_XMM1, AMD64_XMM2,
+						     AMD64_XMM3, AMD64_XMM4, AMD64_XMM5,
+						     AMD64_XMM6, AMD64_XMM7};
 
 static const AMD64_Reg_No return_regs [] = {AMD64_RAX, AMD64_RDX};
 #endif


### PR DESCRIPTION
This PR fixes a couple of issues preventing DYNCALL to work in a couple of scenarios on Windows x64.

Fix incorrect float parameter handling on Winx64 DYNCALL:

The Winx64 calling convention handles parameters in a way that was not correctly implemented in some DYNCALL use cases. When using a method signature like this (double, int, double), the Winx64 ABI dictates that the first parameter goes into first floating point parameter register (XMM0), second parameter goes into second general register (RDX) and third floating point goes into third floating point
parameter register (XMM2). So above call should use registers XMM0, RDX and XMM2, but current DYNCALL implementation will just use next floating-point register, like XMM0, RDX and XMM1 and this will load wrong parameter registers as expected by callee.

For an example https://msdn.microsoft.com/en-us/library/zthk2dkh.aspx#Anchor_2

Fix makes sure mono_arch_start_dyn_call uses the already evaluated registry information for floating point parameters. Currently it assumes floating point registers are assigned in a linear fashion and that works for System V ABI, but not for Winx64’s ABI.

Commit also adds a couple of tests into aot-tests.cs that works with mixed signatures
together with DYNCALL.

Fix DYNCALL value type parameters to follow Windows x64 ABI:

Correctly handle use cases when parameter storage is ArgValuetypeAddInIReg or ArgValuetypeAddrOnStack. This is used for value types not fitting into registers on Windows x64.

Enable aot-tests.exe mini regression tests previously excluded using !FULLAOT-AMD64:

After fixes issues in DYNCALL Windows x64 ABI all aot-tests.exe previously excluded using !FULLAOT-AMD64 can now be reenabled since outstanding issues have been fixed. There is one new test still failing on Windows x64, test_42_arm64_dyncall_vtypebyval. Turns out that this was caused by problems to pass float/double parameters using DYNCALL when spilling over to stack (not using registers). There was also a problem with ArgValuetypeAddrOnStack on Windows x64 when spilling over to the stack that is now also fixed.

Added more tests into aot-tests.cs for the above scenarios as well.