### PR TITLE
[System.Runtime.Serialization] Key should not be null in ReadSimpleDictionary for Dictionary<string, string>

### DIFF
--- a/mcs/class/System.Runtime.Serialization/Makefile
+++ b/mcs/class/System.Runtime.Serialization/Makefile
@@ -13,6 +13,8 @@ LIB_MCS_FLAGS = \
 		$(RESOURCE_FILES:%=/resource:%)
 TXT_RESOURCE_STRINGS = ../referencesource/System.Runtime.Serialization/System.Runtime.Serialization.txt
 
+XTEST_LIB_REFS = System System.Core System.Xml System.Xml.Linq System.Drawing Facades/System.Threading.Tasks
+
 ifneq (2.1, $(FRAMEWORK_VERSION))
 LIB_REFS += System.Data System.Configuration SMDiagnostics
 LIB_MCS_FLAGS += /d:NET_3_0

--- a/mcs/class/System.Runtime.Serialization/ReferenceSources/JsonFormatReaderGenerator_static.cs
+++ b/mcs/class/System.Runtime.Serialization/ReferenceSources/JsonFormatReaderGenerator_static.cs
@@ -508,7 +508,9 @@ namespace System.Runtime.Serialization.Json
 					var jsonMemberName = XmlObjectSerializerReadContextComplexJson.GetJsonMemberName (xmlReader);
 					object key = null;
 
-					if (keyParseMode == KeyParseMode.UsingParseEnum)
+					if (keyParseMode == KeyParseMode.AsString)
+						key = jsonMemberName;
+					else if (keyParseMode == KeyParseMode.UsingParseEnum)
 						key = Enum.Parse (keyType, jsonMemberName);
 					else if (keyParseMode == KeyParseMode.UsingCustomParse)
 						key = keyDataContract.ParseMethod.Invoke (null, new object [] {jsonMemberName});

--- a/mcs/class/System.Runtime.Serialization/System.Runtime.Serialization_xtest.dll.sources
+++ b/mcs/class/System.Runtime.Serialization/System.Runtime.Serialization_xtest.dll.sources
@@ -1,0 +1,5 @@
+#../../../external/corefx/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+../../../external/corefx/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+../../../external/corefx/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.RuntimeOnly.cs
+../../../external/corefx/src/Common/tests/System/Runtime/Serialization/Utils.cs
+../../../external/corefx/src/CoreFx.Private.TestUtilities/src/System/AssertExtensions.cs

--- a/mcs/class/System.Runtime.Serialization/Test/System.Runtime.Serialization.Json/JsonReaderTest.cs
+++ b/mcs/class/System.Runtime.Serialization/Test/System.Runtime.Serialization.Json/JsonReaderTest.cs
@@ -879,5 +879,30 @@ namespace MonoTests.System.Runtime.Serialization.Json
 				Assert.AreEqual (typeof (string []), result.GetType ());
 			}
 		}
+
+		[Test] //https://github.com/mono/mono/issues/9332
+		public void SimpleStringDictionaryTest ()
+		{
+			string json = "{\"key\": \"value\"}";
+
+			// Dictionary<string, string>:
+			using (var stream = new MemoryStream (Encoding.UTF8.GetBytes (json))) {
+				var serializer = new DataContractJsonSerializer (typeof (Dictionary<string, string>), 
+					new DataContractJsonSerializerSettings { UseSimpleDictionaryFormat = true });
+				
+				var obj = serializer.ReadObject (stream) as Dictionary<string, string>;
+				Assert.AreEqual ("value", obj ["key"]);
+			}
+
+			// Dictionary<int, string>:
+			json = "{\"42\": \"value\"}";
+			using (var stream = new MemoryStream (Encoding.UTF8.GetBytes (json))) {
+				var serializer = new DataContractJsonSerializer (typeof (Dictionary<int, string>), 
+					new DataContractJsonSerializerSettings { UseSimpleDictionaryFormat = true });
+				
+				var obj = serializer.ReadObject (stream) as Dictionary<int, string>;
+				Assert.AreEqual ("value", obj [42]);
+			}
+		}
 	}
 }

--- a/scripts/ci/run-test-default.sh
+++ b/scripts/ci/run-test-default.sh
@@ -76,6 +76,7 @@ ${TESTCMD} --label=System.Data.DSE --timeout=5m make -w -C mcs/class/System.Data
 ${TESTCMD} --label=System.Web.Abstractions --timeout=5m make -w -C mcs/class/System.Web.Abstractions run-test
 ${TESTCMD} --label=System.Web.Routing --timeout=5m make -w -C mcs/class/System.Web.Routing run-test
 ${TESTCMD} --label=System.Runtime.Serialization --timeout=5m make -w -C mcs/class/System.Runtime.Serialization run-test
+${TESTCMD} --label=System.Runtime.Serialization-xunit --timeout=5m make -w -C mcs/class/System.Runtime.Serialization run-xunit-test
 ${TESTCMD} --label=System.IdentityModel --timeout=5m make -w -C mcs/class/System.IdentityModel run-test
 ${TESTCMD} --label=System.ServiceModel --timeout=15m make -w -C mcs/class/System.ServiceModel run-test
 ${TESTCMD} --label=System.ServiceModel.Web --timeout=5m make -w -C mcs/class/System.ServiceModel.Web run-test


### PR DESCRIPTION
Fixes #9332 
Also brings CoreFX xunit tests for System.Runtime.Serialization
Few tests in DataContractJsonSerializer.cs fail but the failures don't relate to my fix. I'll file an issue for them or fix them if they are trivial.