### PR TITLE
[coop] mono_coop_cond_signal should switch to GC Safe thread state

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -2144,13 +2144,13 @@ ves_icall_System_Threading_WaitHandle_SignalAndWait_Internal (gpointer toSignal,
 
 	mono_thread_set_state (thread, ThreadState_WaitSleepJoin);
 	
-	MONO_ENTER_GC_SAFE;
 #ifdef HOST_WIN32
+	MONO_ENTER_GC_SAFE;
 	ret = mono_w32handle_convert_wait_ret (mono_win32_signal_object_and_wait (toSignal, toWait, ms, TRUE), 1);
+	MONO_EXIT_GC_SAFE;
 #else
 	ret = mono_w32handle_signal_and_wait (toSignal, toWait, ms, TRUE);
 #endif
-	MONO_EXIT_GC_SAFE;
 	
 	mono_thread_clr_state (thread, ThreadState_WaitSleepJoin);
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -206,7 +206,7 @@ get_method_from_ip (void *ip)
 	}
 
 	method = jinfo_get_method (ji);
-	method_name = mono_method_full_name (method, TRUE);
+	method_name = mono_method_get_name_full (method, TRUE, FALSE, MONO_TYPE_NAME_FORMAT_IL);
 	/* FIXME: unused ? */
 	location = mono_debug_lookup_source_location (method, (guint32)((guint8*)ip - (guint8*)ji->code_start), domain);
 

--- a/mono/utils/mono-coop-mutex.h
+++ b/mono/utils/mono-coop-mutex.h
@@ -109,13 +109,27 @@ mono_coop_cond_timedwait (MonoCoopCond *cond, MonoCoopMutex *mutex, guint32 time
 static inline void
 mono_coop_cond_signal (MonoCoopCond *cond)
 {
+	/*
+	 * On glibc using NTPL (ie Linux with an underlying futex), signaling a
+	 * condition variable can block in the __condvar_quiesce_and_switch_g1
+	 * operation. So switch to GC Safe mode here.
+	 */
+	MONO_ENTER_GC_SAFE;
 	mono_os_cond_signal (&cond->c);
+	MONO_EXIT_GC_SAFE;
 }
 
 static inline void
 mono_coop_cond_broadcast (MonoCoopCond *cond)
 {
+	/*
+	 * On glibc using NTPL (ie Linux with an underlying futex), signaling a
+	 * condition variable can block in the __condvar_quiesce_and_switch_g1
+	 * operation. So switch to GC Safe mode here.
+	 */
+	MONO_ENTER_GC_SAFE;
 	mono_os_cond_broadcast (&cond->c);
+	MONO_EXIT_GC_SAFE;
 }
 
 G_END_DECLS


### PR DESCRIPTION
1. Switch to GC Safe thread state in `mono_coop_cond_signal` and `mono_coop_cond_broadcast` because at least on Linux/glibc the underlying implementation can block on a futex (specifically in `__condvar_quiesce_and_switch_g1` in `glibc/ntpl/pthread_cond_common.c`).  If you'd like details:
   * glibc NTPL description of the implementation of pthread condition variable signaling [(pthread_cond_wait.c:193 on sourceware.org)](https://sourceware.org/git/?p=glibc.git;a=blob;f=nptl/pthread_cond_wait.c;h=3e1105418210288ef21c37730a59dc8bc619ab3b;hb=HEAD#l193) 
   * glibc NTPL implementation of `__condvar_quiesce_and_switch_g1` [(pthread_cond_common.c:341 on sourceware.org)](https://sourceware.org/git/?p=glibc.git;a=blob;f=nptl/pthread_cond_common.c;h=8e425eb01eceabec64e2bad3cfeb2ec51b6f6d72;hb=HEAD#l341) it can block at [(pthread_cond_common.c:412 on sourceware.org)](https://sourceware.org/git/?p=glibc.git;a=blob;f=nptl/pthread_cond_common.c;h=8e425eb01eceabec64e2bad3cfeb2ec51b6f6d72;hb=HEAD#l412)
2. make `mono_pmip` work again under coop and hybrid suspend inside GDB/LLDB (it used to call `mono_method_full_name` which would try to switch GC Unsafe thread state and then assert if the developer unwittingly called it from a thread that isn't currently attached).