### PR TITLE
[2018-04]  [sdks] Only rebuild MXE when it doesn't exist, not when we just cloned the sources

### DIFF
--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -97,10 +97,7 @@ fi
 
 if [[ ${CI_TAGS} == *'product-sdks-android'* ]];
    then
-        echo "ANDROID_TOOLCHAIN_DIR=$HOME/android-toolchain" > sdks/Make.config
-        echo "ANDROID_TOOLCHAIN_CACHE_DIR=$HOME/android-archives" >> sdks/Make.config
-        echo "MXE_PREFIX_DIR=$HOME/android-toolchain" >> sdks/Make.config
-        echo "IGNORE_PROVISION_ANDROID=1" >> sdks/Make.config
+        echo "IGNORE_PROVISION_ANDROID=1" > sdks/Make.config
         echo "IGNORE_PROVISION_MXE=1" >> sdks/Make.config
         echo "DISABLE_CCACHE=1" >> sdks/Make.config
         ${TESTCMD} --label=provision-android --timeout=120m --fatal make -j4 -C sdks/builds provision-android

--- a/sdks/builds/android.mk
+++ b/sdks/builds/android.mk
@@ -2,9 +2,9 @@
 include runtime.mk
 
 ANDROID_URI?=https://dl.google.com/android/repository/
-ANDROID_TOOLCHAIN_PREFIX?=$(TOP)/sdks/builds/toolchains/android
-ANDROID_TOOLCHAIN_DIR?=$(TOP)/sdks/builds/toolchains/android
-ANDROID_TOOLCHAIN_CACHE_DIR?=$(TOP)/sdks/builds/toolchains/android
+ANDROID_TOOLCHAIN_PREFIX?=$(HOME)/android-toolchain/toolchains
+ANDROID_TOOLCHAIN_DIR?=$(HOME)/android-toolchain
+ANDROID_TOOLCHAIN_CACHE_DIR?=$(HOME)/android-archives
 
 ANT_URI?=https://archive.apache.org/dist/ant/binaries/
 

--- a/sdks/builds/mxe.mk
+++ b/sdks/builds/mxe.mk
@@ -11,7 +11,7 @@ provision-mxe:
 	@echo $(LINUX_FLAVOR) Linux does not require mxe provisioning. mingw from packages is used instead
 else
 MXE_SRC?=$(TOP)/sdks/builds/toolchains/mxe
-MXE_PREFIX_DIR?=$(TOP)/sdks/out
+MXE_PREFIX_DIR?=$(HOME)/android-toolchain
 
 # This is not overridable
 MXE_PREFIX:=$(MXE_PREFIX_DIR)/mxe-$(shell echo $(MXE_HASH) | head -c 7)

--- a/sdks/builds/mxe.mk
+++ b/sdks/builds/mxe.mk
@@ -1,4 +1,3 @@
-.PHONY: provision-mxe
 
 ifeq ($(UNAME),Linux)
 LINUX_FLAVOR=$(shell ./determine-linux-flavor.sh)
@@ -7,6 +6,7 @@ endif
 ifeq ($(LINUX_FLAVOR),Ubuntu)
 MXE_PREFIX=/usr
 
+.PHONY: provision-mxe
 provision-mxe:
 	@echo $(LINUX_FLAVOR) Linux does not require mxe provisioning. mingw from packages is used instead
 else
@@ -16,15 +16,15 @@ MXE_PREFIX_DIR?=$(TOP)/sdks/out
 # This is not overridable
 MXE_PREFIX:=$(MXE_PREFIX_DIR)/mxe-$(shell echo $(MXE_HASH) | head -c 7)
 
-$(MXE_SRC)/Makefile:
-	git clone -b xamarin https://github.com/xamarin/mxe.git $(dir $@)
-	cd $(dir $@) && git checkout $(MXE_HASH)
-
-$(MXE_PREFIX)/.stamp: $(MXE_SRC)/Makefile
+$(MXE_PREFIX)/.stamp:
+	rm -rf $(MXE_PREFIX) $(MXE_SRC)
+	git clone -b xamarin https://github.com/xamarin/mxe.git $(MXE_SRC) \
+		&& git -C $(MXE_SRC) checkout $(MXE_HASH)
 	$(MAKE) -C $(MXE_SRC) gcc cmake zlib pthreads dlfcn-win32 mman-win32 \
 		PREFIX="$(MXE_PREFIX)" MXE_TARGETS="i686-w64-mingw32.static x86_64-w64-mingw32.static" \
 			OS_SHORT_NAME="disable-native-plugins" PATH="$$PATH:$(MXE_PREFIX)/bin:$(dir $(shell brew list gettext | grep bin/autopoint$))"
 	touch $@
 
+.PHONY: provision-mxe
 provision-mxe: $(MXE_PREFIX)/.stamp
 endif


### PR DESCRIPTION
Backport of #9328.

/cc @luhenry