### PR TITLE
[2018-04] [interp] fix scope issue regarding `klass` var

### DIFF
--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -3215,11 +3215,10 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsig
 			ADD_CODE(td, get_data_item_index (td, field));
 			klass = NULL;
 			if (mt == MINT_TYPE_VT) {
-				MonoClass *klass = mono_class_from_mono_type (ftype);
+				klass = mono_class_from_mono_type (ftype);
 				int size = mono_class_value_size (klass, NULL);
 				PUSH_VT(td, size);
 				WRITE32(td, &size);
-				klass = ftype->data.klass;
 			} else {
 				if (mt == MINT_TYPE_O) 
 					klass = mono_class_from_mono_type (ftype);

--- a/mono/mini/objects.cs
+++ b/mono/mini/objects.cs
@@ -1907,6 +1907,22 @@ ncells ) {
 		return dataPtr [0] == 1.0f ? 0 : 1;
 	}
 
+	class SimpleContainer {
+		public Simple simple1;
+		public Simple simple2;
+
+		public static Simple constsimple;
+
+		public int SetFields () {
+			constsimple.a = 0x1337;
+			simple1 = simple2 = constsimple;
+			return simple1.a - simple2.a;
+		}
+	}
+
+	public static int test_0_dup_vtype () {
+		return new SimpleContainer ().SetFields ();
+	}
 }
 
 #if __MOBILE__


### PR DESCRIPTION
`klass` exists in the main loop, but we defined `klass` again inside the
block, so the outer `klass` never had the right value.

Fixes https://github.com/mono/mono/issues/9023

Backport of https://github.com/mono/mono/pull/9348#issuecomment-401305916