### PR TITLE
Reduce sensitivity to thread local win32 last error.

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -1799,7 +1799,7 @@ shadow_copy_create_ini (const char *shadow, const char *filename)
 	guint16 *u16_ini;
 	gboolean result;
 	guint32 n;
-	HANDLE *handle;
+	HANDLE handle;
 	gchar *full_path;
 
 	dir_name = g_path_get_dirname (shadow);
@@ -1815,14 +1815,15 @@ shadow_copy_create_ini (const char *shadow, const char *filename)
 	if (!u16_ini) {
 		return FALSE;
 	}
-	handle = (void **)mono_w32file_create (u16_ini, GENERIC_WRITE, FILE_SHARE_READ|FILE_SHARE_WRITE, CREATE_NEW, FileAttributes_Normal);
+	handle = mono_w32file_create (u16_ini, GENERIC_WRITE, FILE_SHARE_READ|FILE_SHARE_WRITE, CREATE_NEW, FileAttributes_Normal);
 	g_free (u16_ini);
 	if (handle == INVALID_HANDLE_VALUE) {
 		return FALSE;
 	}
 
 	full_path = mono_path_resolve_symlinks (filename);
-	result = mono_w32file_write (handle, full_path, strlen (full_path), &n);
+	gint32 win32error = 0;
+	result = mono_w32file_write (handle, full_path, strlen (full_path), &n, &win32error);
 	g_free (full_path);
 	mono_w32file_close (handle);
 	return result;

--- a/mono/metadata/sre-save.c
+++ b/mono/metadata/sre-save.c
@@ -2762,8 +2762,9 @@ static void
 checked_write_file (HANDLE f, gconstpointer buffer, guint32 numbytes)
 {
 	guint32 dummy;
-	if (!mono_w32file_write (f, buffer, numbytes, &dummy))
-		g_error ("mono_w32file_write returned %d\n", mono_w32error_get_last ());
+	gint32 win32error = 0;
+	if (!mono_w32file_write (f, buffer, numbytes, &dummy, &win32error))
+		g_error ("mono_w32file_write returned %d\n", win32error);
 }
 
 /*

--- a/mono/metadata/w32file-win32.c
+++ b/mono/metadata/w32file-win32.c
@@ -83,21 +83,25 @@ mono_w32file_delete (const gunichar2 *name)
 }
 
 gboolean
-mono_w32file_read(gpointer handle, gpointer buffer, guint32 numbytes, guint32 *bytesread)
+mono_w32file_read(gpointer handle, gpointer buffer, guint32 numbytes, guint32 *bytesread, gint32 *win32error)
 {
 	gboolean res;
 	MONO_ENTER_GC_SAFE;
 	res = ReadFile (handle, buffer, numbytes, (PDWORD)bytesread, NULL);
+	if (!res)
+		*win32error = GetLastError ();
 	MONO_EXIT_GC_SAFE;
 	return res;
 }
 
 gboolean
-mono_w32file_write (gpointer handle, gconstpointer buffer, guint32 numbytes, guint32 *byteswritten)
+mono_w32file_write (gpointer handle, gconstpointer buffer, guint32 numbytes, guint32 *byteswritten, gint32 *win32error)
 {
 	gboolean res;
 	MONO_ENTER_GC_SAFE;
 	res = WriteFile (handle, buffer, numbytes, (PDWORD)byteswritten, NULL);
+	if (!res)
+		*win32error = GetLastError ();
 	MONO_EXIT_GC_SAFE;
 	return res;
 }

--- a/mono/metadata/w32file.c
+++ b/mono/metadata/w32file.c
@@ -524,13 +524,11 @@ ves_icall_System_IO_MonoIO_Read (HANDLE handle, MonoArrayHandle dest,
 
 	guint32 buffer_handle = 0;
 	buffer = MONO_ARRAY_HANDLE_PIN (dest, guchar, dest_offset, &buffer_handle);
-	result = mono_w32file_read (handle, buffer, count, &n);
+	result = mono_w32file_read (handle, buffer, count, &n, io_error);
 	mono_gchandle_free (buffer_handle);
 
-	if (!result) {
-		*io_error=mono_w32error_get_last ();
+	if (!result)
 		return -1;
-	}
 
 	return (gint32)n;
 }
@@ -556,13 +554,11 @@ ves_icall_System_IO_MonoIO_Write (HANDLE handle, MonoArrayHandle src,
 	
 	guint32 src_handle = 0;
 	buffer = MONO_ARRAY_HANDLE_PIN (src, guchar, src_offset, &src_handle);
-	result = mono_w32file_write (handle, buffer, count, &n);
+	result = mono_w32file_write (handle, buffer, count, &n, io_error);
 	mono_gchandle_free (src_handle);
 
-	if (!result) {
-		*io_error=mono_w32error_get_last ();
+	if (!result)
 		return -1;
-	}
 
 	return (gint32)n;
 }

--- a/mono/metadata/w32file.h
+++ b/mono/metadata/w32file.h
@@ -383,10 +383,10 @@ gboolean
 mono_w32file_delete (const gunichar2 *name);
 
 gboolean
-mono_w32file_read (gpointer handle, gpointer buffer, guint32 numbytes, guint32 *bytesread);
+mono_w32file_read (gpointer handle, gpointer buffer, guint32 numbytes, guint32 *bytesread, gint32 *win32error);
 
 gboolean
-mono_w32file_write (gpointer handle, gconstpointer buffer, guint32 numbytes, guint32 *byteswritten);
+mono_w32file_write (gpointer handle, gconstpointer buffer, guint32 numbytes, guint32 *byteswritten, gint32 *win32error);
 
 gboolean
 mono_w32file_flush (gpointer handle);


### PR DESCRIPTION
It is too easily trashed, e.g. by mono_thread_info_uninstall_interrupt.

See https://github.com/Unity-Technologies/mono/commit/b6f1ba89f7ab285a0990e696e78798f7cf18dafb
Which this should be an alterate fix for, as discussed in https://github.com/mono/mono/pull/9104.

This is a small change, but ultimately we should be able to thread
gint32 *win32error around enough, such as to eliminate the thread local on Unix.
It doesn't appear to take much. Thread locals, it turns out, are not a good mechanism.
They are sensitive to loss as addressed here. They are slower to access than regular globals
or locals. They do have the advantage of "automatic threading through a callgraph", as long
as you are very careful with their use (https://github.com/Unity-Technologies/mono/commit/b6f1ba89f7ab285a0990e696e78798f7cf18dafb shows the problem).

As well we could/should move the GetLastError calls down one layer on Win32,
from w32file.c to w32file-win32.c.

But this change addresses only ReadFile/WriteFile.

Also remove unnecessary void** vs. void* cast.
Also combine Unix mono_w32file_read and mono_w32file_write.