### PR TITLE
Tweaks for AIX in BoringSSL CMake (Mono side)

### DIFF
--- a/mono/btls/CMakeLists.txt
+++ b/mono/btls/CMakeLists.txt
@@ -29,7 +29,12 @@ if (NOT "${BTLS_ARCH}" STREQUAL "")
 endif ()
 
 if (NOT MSVC)
-	set (C_CXX_FLAGS "-Wall -Wsign-compare -Wmissing-field-initializers -fPIC -ggdb -fvisibility=hidden")
+	if(${CMAKE_SYSTEM_NAME} MATCHES "AIX" OR ${CMAKE_SYSTEM_NAME} MATCHES "OS400")
+		# GCC+XCOFF doesn't support -fvisibility=hidden, and we would prefer XCOFF debugging info.
+		set (C_CXX_FLAGS "-Wall -Wsign-compare -Wmissing-field-initializers -fPIC -gxcoff")
+	else()
+		set (C_CXX_FLAGS "-Wall -Wsign-compare -Wmissing-field-initializers -fPIC -ggdb -fvisibility=hidden")
+	endif()
 endif ()
 
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${C_CXX_FLAGS} ${BTLS_CFLAGS}")


### PR DESCRIPTION
These changes will be duplicated on the BoringSSL submodule's side
too; as the options are combined. (Wait for that PR.)