### PR TITLE
Return filled FormattedValueType instead of null

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewCell.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewCell.cs
@@ -170,7 +170,7 @@ namespace System.Windows.Forms {
 
 		[Browsable (false)]
 		public virtual Type FormattedValueType {
-			get { return null; }
+			get { return this.ValueType; }
 		}
 
 		[Browsable (false)]


### PR DESCRIPTION
Implemented like in https://referencesource.microsoft.com/#system.windows.forms/winforms/Managed/System/WinForms/DataGridViewCell.cs

Background: 
With this fix the prototype of XCP-ng Center for Linux works better (Softfork of Citrix XenCenter) -> https://github.com/xcp-ng/xenadmin/issues/23 and https://github.com/xcp-ng/xenadmin/issues/23#issuecomment-401618433

Project: [XCP-ng - XenServer based, Community Powered](https://xcp-ng.org)

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
