### PR TITLE
autoconf and CI infrastructure for hybrid suspend

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1104,6 +1104,7 @@ with_wasm_default=no
 
 with_bitcode_default=no
 enable_cooperative_suspend_default=no
+enable_hybrid_suspend_default=no
 
 INVARIANT_AOT_OPTIONS=nimt-trampolines=2000,ntrampolines=10000,nrgctx-fetch-trampolines=256,ngsharedvt-trampolines=4000
 
@@ -4992,7 +4993,7 @@ AC_ARG_WITH(lazy_gc_thread_creation, [  --with-lazy-gc-thread-creation=yes|no   
 AC_ARG_WITH(cooperative_gc,        [  --with-cooperative-gc=yes|no        Enable cooperative stop-the-world garbage collection (sgen only) (defaults to no)], [AC_MSG_WARN([--with-cooperative-gc is deprecated, use --enable-cooperative-suspend instead])], [with_cooperative_gc=default])
 AC_ARG_ENABLE(cooperative_suspend, [  --enable-cooperative-suspend      Enable cooperative stop-the-world garbage collection (sgen only) (defaults to no)], [], [enable_cooperative_suspend=default])
 
-if test x$enable_cooperative_suspend = xdefault -a test x$with_cooperative_gc != xdefault; then
+if test x$enable_cooperative_suspend = xdefault -a x$with_cooperative_gc != xdefault; then
 	enable_cooperative_suspend=$with_cooperative_gc
 fi
 
@@ -5006,7 +5007,11 @@ fi
 
 AM_CONDITIONAL([ENABLE_COOP_SUSPEND], [test x$enable_cooperative_suspend != xno])
 
-AC_ARG_ENABLE(hybrid_suspend, [ --enable-hybrid-suspend     Enable hybrid stop-the-world garbage collection (sgen only) - cooperative suspend for threads running managed and runtime code, and preemptive suspend for threads running native and P/Invoke code (defaults to no)], [], [enable_hybrid_suspend=no])
+AC_ARG_ENABLE(hybrid_suspend, [ --enable-hybrid-suspend     Enable hybrid stop-the-world garbage collection (sgen only) - cooperative suspend for threads running managed and runtime code, and preemptive suspend for threads running native and P/Invoke code (defaults to no)], [], [enable_hybrid_suspend=default])
+
+if test x$enable_hybrid_suspend = xdefault; then
+   enable_hybrid_suspend=$enable_hybrid_suspend_default
+fi
 
 if test x$enable_hybrid_suspend != xno -a x$enable_cooperative_suspend != xno ; then
 	AC_MSG_ERROR([Hybrid suspend and Cooperative suspend cannot be both enabled.])
@@ -5673,6 +5678,17 @@ if test x$enable_btls = xyes; then
 	fi
 fi
 
+thread_suspend_msg=
+if test x$buildsgen = xyes; then
+	if test x$enable_cooperative_suspend = xyes; then
+		thread_suspend_msg="Suspend:       Cooperative"
+	elif test x$enable_hybrid_suspend = xyes; then
+		thread_suspend_msg="Suspend:       Hybrid"
+	else
+		thread_suspend_msg="Suspend:       Preemptive"
+	fi
+fi
+	
 echo "
         mcs source:    $mcsdir
 	C# Compiler:   $csc_compiler
@@ -5681,6 +5697,7 @@ echo "
 	Host:	       $host
 	Target:	       $target
 	GC:	       $gc_msg 
+	$thread_suspend_msg
 	TLS:           $with_tls
 	SIGALTSTACK:   $with_sigaltstack
 	Engine:        $jit_status

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1565,6 +1565,8 @@ mono_get_version_info (void)
 #endif
 #endif
 
+	g_string_append_printf (output, "\tSuspend:       %s\n", mono_threads_suspend_policy_name ());
+
 	return g_string_free (output, FALSE);
 }
 

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -12,6 +12,7 @@
 #include <glib.h>
 #include <mono/utils/json.h>
 #include <mono/utils/mono-state.h>
+#include <mono/utils/mono-threads-coop.h>
 #include <mono/metadata/object-internals.h>
 
 #ifdef TARGET_OSX
@@ -342,11 +343,17 @@ mono_native_state_add_version (JsonWriter *writer)
 	mono_json_writer_object_key(writer, "llvm_support");
 #ifdef MONO_ARCH_LLVM_SUPPORTED
 #ifdef ENABLE_LLVM
-	mono_json_writer_printf (writer, "\"%d\"\n", LLVM_API_VERSION);
+	mono_json_writer_printf (writer, "\"%d\",\n", LLVM_API_VERSION);
 #else
-	mono_json_writer_printf (writer, "\"disabled\"\n");
+	mono_json_writer_printf (writer, "\"disabled\",\n");
 #endif
 #endif
+
+	const char *susp_policy = mono_threads_suspend_policy_name ();
+	mono_json_writer_indent (writer);
+	mono_json_writer_object_key (writer, "suspend");
+	mono_json_writer_printf (writer, "\"%s\"\n", susp_policy);
+
 
 	mono_json_writer_indent_pop (writer);
 	mono_json_writer_indent (writer);

--- a/mono/utils/mono-threads-coop.h
+++ b/mono/utils/mono-threads-coop.h
@@ -28,6 +28,9 @@ extern volatile size_t mono_polling_required;
 void
 mono_threads_state_poll (void);
 
+const char*
+mono_threads_suspend_policy_name (void);
+
 gboolean
 mono_threads_is_blocking_transition_enabled (void);
 

--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -40,8 +40,9 @@ if [[ ${CI_TAGS} == *'osx-amd64'* ]]; then CFLAGS="$CFLAGS -m64 -arch x86_64 -mm
 if [[ ${CI_TAGS} == *'win-i386'* ]]; then PLATFORM=Win32; EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --host=i686-w64-mingw32"; export MONO_EXECUTABLE="${MONO_REPO_ROOT}/msvc/build/sgen/Win32/bin/Release/mono-sgen.exe"; fi
 if [[ ${CI_TAGS} == *'win-amd64'* ]]; then PLATFORM=x64; EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --host=x86_64-w64-mingw32 --disable-boehm"; export MONO_EXECUTABLE="${MONO_REPO_ROOT}/msvc/build/sgen/x64/bin/Release/mono-sgen.exe"; fi
 
-if   [[ ${CI_TAGS} == *'coop-suspend'* ]];   then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --enable-cooperative-suspend";
+if   [[ ${CI_TAGS} == *'coop-suspend'* ]];   then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --disable-hybrid-suspend --enable-cooperative-suspend";
 elif [[ ${CI_TAGS} == *'hybrid-suspend'* ]]; then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --enable-hybrid-suspend";
+elif [[ ${CI_TAGS} == *'preemptive-suspend'* ]]; then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --disable-hybrid-suspend";
 fi
 
 if [[ ${CI_TAGS} == *'checked-coop'* ]]; then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --enable-checked-build=gc,thread"; fi


### PR DESCRIPTION
1. If `configure` enables SGen, print the suspend policy (preemptive, cooperative, hybrid) in the summary at the end.
2. Add a way for `configure.ac` to enable hybrid suspend by default based on presets, or arch, etc.  But do not enable it by default on any platform.
3. add a `preemptive-suspend` CI tag that explicitly disables coop and hybrid suspend; explicitly disable hybrid suspend when enabling coop suspend using CI tags.
4. Add `mono_threads_suspend_policy_name()` function that returns a description of the current suspend policy (subject to configure flags and environment variables)
5. Print suspend policy in `mono --version` and MERP error reporting mechanisms.