### PR TITLE
[wasm] Remove dead code and add fetch callback to mono_load_runtime_and_bcl.

### DIFF
--- a/sdks/wasm/debug.html
+++ b/sdks/wasm/debug.html
@@ -11,26 +11,6 @@
 	  <br>
 	
 	<script type='text/javascript'>
-		function mono_wasm_set_breakpoint (assembly, method_token, iloffset) {
-			console.log (">>mono_wasm_set_breakpoint " + assembly + " method " +  method_token +  " off " + iloffset);
-			try {
-				return MonoRuntime.mono_wasm_set_breakpoint (assembly, method_token, iloffset);
-			} catch (e) {
-				console.log (e);
-				throw e;
-			}
-		}
-
-		function mono_wasm_clear_all_breakpoints () {
-			console.log (">>mono_wasm_clear_all_breakpoints");
-			try {
-				return MonoRuntime.mono_wasm_clear_all_breakpoints ();
-			} catch (e) {
-				console.log (e);
-				throw e;
-			}
-		}
-
 		var App = {
 			onClick: function () {
 				this.output.value = "...";

--- a/sdks/wasm/library_mono.js
+++ b/sdks/wasm/library_mono.js
@@ -72,14 +72,20 @@ var MonoSupportLib = {
 			return this.mono_wasm_set_bp (assembly, method_token, il_offset)
 		},
 
-		mono_load_runtime_and_bcl: function (vfs_prefix, deploy_prefix, enable_debugging, file_list, loaded_cb) {
+		mono_load_runtime_and_bcl: function (vfs_prefix, deploy_prefix, enable_debugging, file_list, loaded_cb, fetch_file_cb) {
 			Module.FS_createPath ("/", vfs_prefix, true, true);
 
 			var pending = 0;
 			var loaded_files = [];
 			file_list.forEach (function(file_name) {
 				++pending;
-				fetch (deploy_prefix + "/" + file_name, { credentials: 'same-origin' }).then (function (response) {
+				var fetch_promise = null;
+				if (fetch_file_cb)
+					fetch_promise = fetch_file_cb (deploy_prefix + "/" + file_name);
+				else
+					fetch_promise = fetch (deploy_prefix + "/" + file_name, { credentials: 'same-origin' });
+
+				fetch_promise.then (function (response) {
 					if (!response.ok)
 						throw "failed to load '" + file_name + "'";
 					loaded_files.push (response.url);


### PR DESCRIPTION
The mono_load_runtime_and_bcl allows upstream to remap requests and report download progress.

This cb semantics might change in the future when we implement more agressive loading.