### PR TITLE
[ci] Mono.Profiler.Log tests can run under coop (and hybrid) suspend

### DIFF
--- a/scripts/ci/run-test-default.sh
+++ b/scripts/ci/run-test-default.sh
@@ -60,7 +60,7 @@ ${TESTCMD} --label=Microsoft.Build.Tasks --timeout=5m make -w -C mcs/class/Micro
 ${TESTCMD} --label=Microsoft.Build.Utilities --timeout=5m make -w -C mcs/class/Microsoft.Build.Utilities run-test
 ${TESTCMD} --label=Mono.C5 --timeout=5m make -w -C mcs/class/Mono.C5 run-test
 ${TESTCMD} --label=Mono.Options --timeout=5m make -w -C mcs/class/Mono.Options run-test
-if [[ ${CI_TAGS} == *'win-'* ]] || [[ ${CI_TAGS} == *'coop-gc'* ]]
+if [[ ${CI_TAGS} == *'win-'* ]]
 then ${TESTCMD} --label=Mono.Profiler.Log-xunit --skip;
 else ${TESTCMD} --label=Mono.Profiler.Log-xunit --timeout=30m make -w -C mcs/class/Mono.Profiler.Log run-xunit-test
 fi


### PR DESCRIPTION
It was fixed by #8497

Fixes #7556
