### PR TITLE
Fix invalid preprocessor check for BE that broke System.Decimal

### DIFF
--- a/mono/metadata/decimal-ms.c
+++ b/mono/metadata/decimal-ms.c
@@ -84,7 +84,7 @@ static const uint32_t ten_to_ten_div_4 = 2500000000U;
 typedef union {
 	uint64_t int64;
 	struct {
-#if BYTE_ORDER == G_BIG_ENDIAN
+#if G_BYTE_ORDER == G_BIG_ENDIAN
         uint32_t Hi;
         uint32_t Lo;
 #else
@@ -169,14 +169,8 @@ static const DECOVFL power_overflow[] = {
 };
 
 #define UInt32x32To64(a, b) ((uint64_t)((uint32_t)(a)) * (uint64_t)((uint32_t)(b)))
-#if G_BYTE_ORDER != G_LITTLE_ENDIAN
-/* hacky endian swap where losing the other end is OK, since we truncate to 32bit */
-#define Div64by32(num, den) ((uint32_t) (((uint64_t)(num) / (uint32_t)(den)) >> 32) )
-#define Mod64by32(num, den) ((uint32_t) (((uint64_t)(num) % (uint32_t)(den)) >> 32) )
-#else
 #define Div64by32(num, den) ((uint32_t)((uint64_t)(num) / (uint32_t)(den)))
 #define Mod64by32(num, den) ((uint32_t)((uint64_t)(num) % (uint32_t)(den)))
-#endif
 
 static double
 fnDblPower10(int ix)


### PR DESCRIPTION
This bug has been lurking for four years, being introduced in commit
5b2bb8c9017ab563d7ec819cf249b209c770423e. `BYTE_ORDER != G_BYTE_ORDER`.

Not thoroughly tested, but `System.Decimal` from csharp seems to return
sane results again. (related: is z or AIX CI available for PR checks?
if not, what test suite is `System.Decimal` under?)

Also remove my shoddy workaround from a few months ago, it got the
BCL building, but was incorrect.

cc @nealef (Linux/s390x might have been affected, but maybe not, if glib and glibc had congruent `BYTE_ORDER` and `G_BYTE_ORDER`....)