### PR TITLE
[checked-build] don't collect state transition backtraces on abort_blocking

### DIFF
--- a/mono/utils/mono-threads-state-machine.c
+++ b/mono/utils/mono-threads-state-machine.c
@@ -580,11 +580,11 @@ retry_state_change:
 	UNWRAP_THREAD_STATE (raw_state, cur_state, suspend_count, info);
 	switch (cur_state) {
 	case STATE_RUNNING: //thread already in runnable state
-		trace_state_change_with_func ("ABORT_BLOCKING", info, raw_state, cur_state, 0, func);
+		trace_state_change_sigsafe ("ABORT_BLOCKING", info, raw_state, cur_state, 0, func);
 		return AbortBlockingIgnore;
 
 	case STATE_ASYNC_SUSPEND_REQUESTED: //thread is runnable and have a pending suspend
-		trace_state_change_with_func ("ABORT_BLOCKING", info, raw_state, cur_state, 0, func);
+		trace_state_change_sigsafe ("ABORT_BLOCKING", info, raw_state, cur_state, 0, func);
 		return AbortBlockingIgnoreAndPoll;
 
 	case STATE_BLOCKING:


### PR DESCRIPTION
for the same reason as the other cases in this function - if we're in `RUNNING`
or `ASYNC_SUSPEND_REQUESTED` under hybrid suspend we're supposed to cooperatively
suspend.  If we call `backtrace()`, we might block waiting for the low-level
dynamic linker mutex on Linux which may be held by a thread that was
preemptively-suspended already.