### PR TITLE
[profiler] account for nullbyte in allocated buffer in log- and coverageprofiler

### DIFF
--- a/mono/profiler/coverage.c
+++ b/mono/profiler/coverage.c
@@ -947,7 +947,7 @@ parse_args (const char *desc)
 	const char *p;
 	gboolean in_quotes = FALSE;
 	char quote_char = '\0';
-	char *buffer = malloc (strlen (desc));
+	char *buffer = g_malloc (strlen (desc) + 1);
 	int buffer_pos = 0;
 
 	for (p = desc; *p; p++){

--- a/mono/profiler/log-args.c
+++ b/mono/profiler/log-args.c
@@ -185,7 +185,7 @@ proflog_parse_args (ProfilerConfig *config, const char *desc)
 	const char *p;
 	gboolean in_quotes = FALSE;
 	char quote_char = '\0';
-	char *buffer = malloc (strlen (desc));
+	char *buffer = g_malloc (strlen (desc) + 1);
 	int buffer_pos = 0;
 
 	load_args_from_env_or_default (config);


### PR DESCRIPTION
similar to https://github.com/mono/mono/pull/9166

