### PR TITLE
Add another Darwin file system

### DIFF
--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -4306,6 +4306,7 @@ typedef struct {
 static _wapi_drive_type _wapi_drive_types[] = {
 #if HOST_DARWIN
 	{ DRIVE_REMOTE, "afp" },
+	{ DRIVE_REMOTE, "afpfs" },
 	{ DRIVE_REMOTE, "autofs" },
 	{ DRIVE_CDROM, "cddafs" },
 	{ DRIVE_CDROM, "cd9660" },


### PR DESCRIPTION
This prevents a test failure when Time Machine partitions are mounted on the
host running the test.

The symptoms are:

```
1) GetDrivesValidInfo (MonoTests.System.IO.DriveInfoTest.GetDrivesValidInfo)
     DriveFormat=afpfs
  Expected: not Unknown
  But was:  Unknown

  at MonoTests.System.IO.DriveInfoTest.ValidateDriveInfo (System.IO.DriveInfo d) [0x00045] in /cvs/mono/mcs/class/corlib/Test/System.IO/DriveInfoTest.cs:85 
  at MonoTests.System.IO.DriveInfoTest.GetDrivesValidInfo () [0x0000e] in /cvs/mono/mcs/class/corlib/Test/System.IO/DriveInfoTest.cs:73 
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0003b] in /cvs/mono/mcs/class/corlib/System.Reflection/MonoMethod.cs:305 
```

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
