### PR TITLE
[runtime] Make merp eventType icall argument

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # This can be reset to 0 when Mono's version number is bumped
 # since it's part of the corlib version (the prefix '1' in the full
 # version number is to ensure the number isn't treated as octal in C)
-MONO_CORLIB_COUNTER=15
+MONO_CORLIB_COUNTER=16
 MONO_CORLIB_VERSION=`printf "1%02d%02d%02d%03d" $MONO_VERSION_MAJOR $MONO_VERSION_MINOR 0 $MONO_CORLIB_COUNTER`
 
 AC_DEFINE_UNQUOTED(MONO_CORLIB_VERSION,$MONO_CORLIB_VERSION,[Version of the corlib-runtime interface])

--- a/mcs/class/corlib/Mono/Runtime.cs
+++ b/mcs/class/corlib/Mono/Runtime.cs
@@ -86,17 +86,18 @@ namespace Mono {
 		static extern void DisableMicrosoftTelemetry (IntPtr appBundleID, IntPtr appSignature, IntPtr appVersion, IntPtr merpGUIPath);
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
-		static extern void EnableMicrosoftTelemetry_internal (IntPtr appBundleID, IntPtr appSignature, IntPtr appVersion, IntPtr merpGUIPath);
+		static extern void EnableMicrosoftTelemetry_internal (IntPtr appBundleID, IntPtr appSignature, IntPtr appVersion, IntPtr merpGUIPath, IntPtr eventType);
 
-		static void EnableMicrosoftTelemetry (string appBundleID_str, string appSignature_str, string appVersion_str, string merpGUIPath_str)
+		static void EnableMicrosoftTelemetry (string appBundleID_str, string appSignature_str, string appVersion_str, string merpGUIPath_str, string eventType_str)
 		{
 			if (RuntimeInformation.IsOSPlatform (OSPlatform.OSX)) {
 				using (var appBundleID_chars = RuntimeMarshal.MarshalString (appBundleID_str))
 				using (var appSignature_chars = RuntimeMarshal.MarshalString (appSignature_str))
 				using (var appVersion_chars = RuntimeMarshal.MarshalString (appVersion_str))
 				using (var merpGUIPath_chars = RuntimeMarshal.MarshalString (merpGUIPath_str))
+				using (var eventType_chars = RuntimeMarshal.MarshalString (eventType_str))
 				{
-					EnableMicrosoftTelemetry_internal (appBundleID_chars.Value, appSignature_chars.Value, appVersion_chars.Value, merpGUIPath_chars.Value);
+					EnableMicrosoftTelemetry_internal (appBundleID_chars.Value, appSignature_chars.Value, appVersion_chars.Value, merpGUIPath_chars.Value, eventType_chars.Value);
 				}
 			} else {
 				throw new PlatformNotSupportedException("Merp support is currently only supported on OSX.");

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5748,10 +5748,10 @@ ves_icall_Mono_Runtime_DisableMicrosoftTelemetry (MonoError *error)
 }
 
 ICALL_EXPORT void
-ves_icall_Mono_Runtime_EnableMicrosoftTelemetry (char *appBundleID, char *appSignature, char *appVersion, char *merpGUIPath, MonoError *error)
+ves_icall_Mono_Runtime_EnableMicrosoftTelemetry (char *appBundleID, char *appSignature, char *appVersion, char *merpGUIPath, char *eventType, MonoError *error)
 {
 #ifdef TARGET_OSX
-	mono_merp_enable (appBundleID, appSignature, appVersion, merpGUIPath);
+	mono_merp_enable (appBundleID, appSignature, appVersion, merpGUIPath, eventType);
 
 	mono_get_runtime_callbacks ()->install_state_summarizer ();
 #else

--- a/mono/utils/mono-merp.c
+++ b/mono/utils/mono-merp.c
@@ -111,6 +111,7 @@ typedef struct {
 	const char *appSignature; 
 	const char *appVersion;
 	const char *merpGUIPath; 
+	const char *eventType;
 	gboolean log;
 } MerpOptions;
 
@@ -342,7 +343,7 @@ mono_init_merp (const intptr_t crashed_pid, const char *signal, MonoStackHash *h
 	merp->systemManufacturer = "apple";
 	get_apple_model ((char *) merp->systemModel, sizeof (merp->systemModel));
 
-	merp->eventType = "MonoAppCrash";
+	merp->eventType = config.eventType;
 
 	merp->hashes = *hashes;
 }
@@ -534,11 +535,12 @@ mono_merp_disable (void)
 	g_free ((char*)config.appSignature);
 	g_free ((char*)config.appVersion);
 	g_free ((char*)config.merpGUIPath);
+	g_free ((char*)config.eventType);
 	memset (&config, 0, sizeof (config));
 }
 
 void
-mono_merp_enable (const char *appBundleID, const char *appSignature, const char *appVersion, const char *merpGUIPath)
+mono_merp_enable (const char *appBundleID, const char *appSignature, const char *appVersion, const char *merpGUIPath, const char *eventType)
 {
 	g_assert (!config.enable_merp);
 
@@ -546,6 +548,7 @@ mono_merp_enable (const char *appBundleID, const char *appSignature, const char 
 	config.appSignature = g_strdup (appSignature);
 	config.appVersion = g_strdup (appVersion);
 	config.merpGUIPath = g_strdup (merpGUIPath);
+	config.eventType = g_strdup (eventType);
 
 	config.log = g_getenv ("MONO_MERP_VERBOSE") != NULL;
 

--- a/mono/utils/mono-merp.h
+++ b/mono/utils/mono-merp.h
@@ -29,7 +29,7 @@ void mono_merp_disable (void);
  * See MERP documentation for information on the bundle ID, signature, and version fields
  */
 void
-mono_merp_enable (const char *appBundleID, const char *appSignature, const char *appVersion, const char *merpGUIPath);
+mono_merp_enable (const char *appBundleID, const char *appSignature, const char *appVersion, const char *merpGUIPath, const char *eventType);
 
 /**
  * Whether the MERP-based handler is registered


### PR DESCRIPTION
This enables the managed code to work with multiple app crash types on MERP, useful as the server side changes. This change was requested from @sgmunn . 