### PR TITLE
System.Security: Fix unit tests to use SERIALNUMBER instead of OID.2.5.4.5.

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.X509/X501Name.cs
+++ b/mcs/class/Mono.Security/Mono.Security.X509/X501Name.cs
@@ -63,7 +63,7 @@ namespace Mono.Security.X509 {
 		static byte[] localityName = { 0x55, 0x04, 0x07 };
 		static byte[] stateOrProvinceName = { 0x55, 0x04, 0x08 };
 		static byte[] streetAddress = { 0x55, 0x04, 0x09 };
-		//static byte[] serialNumber = { 0x55, 0x04, 0x05 };
+		static byte[] serialNumber = { 0x55, 0x04, 0x05 };
 		static byte[] domainComponent = { 0x09, 0x92, 0x26, 0x89, 0x93, 0xF2, 0x2C, 0x64, 0x01, 0x19 };
 		static byte[] userid = { 0x09, 0x92, 0x26, 0x89, 0x93, 0xF2, 0x2C, 0x64, 0x01, 0x01 };
 		static byte[] email = { 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x09, 0x01 };
@@ -160,6 +160,8 @@ namespace Mono.Security.X509 {
 					sb.Append ("G=");
 				else if (poid.CompareValue (initial))
 					sb.Append ("I=");
+				else if (poid.CompareValue (serialNumber))
+					sb.Append ("SERIALNUMBER=");					
 				else {
 					// unknown OID
 					sb.Append ("OID.");	// NOTE: Not present as RFC2253

--- a/mcs/class/Mono.Security/Mono.Security.X509/X501Name.cs
+++ b/mcs/class/Mono.Security/Mono.Security.X509/X501Name.cs
@@ -236,6 +236,8 @@ namespace Mono.Security.X509 {
 					return new X520.GivenName ();
 				case "I":
 					return new X520.Initial ();
+				case "SERIALNUMBER":
+					return new X520.SerialNumber ();
 				default:
 					if (s.StartsWith ("OID.")) {
 						// MUST support it but it OID may be without it

--- a/mcs/class/Mono.Security/Test/Mono.Security.X509/X501NameTest.cs
+++ b/mcs/class/Mono.Security/Test/Mono.Security.X509/X501NameTest.cs
@@ -213,8 +213,8 @@ namespace MonoTests.Mono.Security.X509 {
 				0x13, 0x1D, 0x43, 0x56, 0x52, 0x3A, 0x31, 0x33, 0x34, 0x37, 0x31, 0x39, 0x36, 0x37, 0x2D, 0x55, 0x49, 0x44, 0x3A, 0x31, 0x32, 0x31, 
 				0x32, 0x31, 0x32, 0x31, 0x32, 0x31, 0x32, 0x31, 0x32 };
 			ASN1 asn = new ASN1 (sn);
-			Assert.AreEqual ("C=DK, O=Hedeby's Møbelhandel // CVR:13471967, CN=Hedeby's Møbelhandel - Salgsafdelingen, E=vhm@use.test.dk, OID.2.5.4.5=CVR:13471967-UID:121212121212", X501.ToString (asn), "ToString-1");
-			Assert.AreEqual ("OID.2.5.4.5=CVR:13471967-UID:121212121212, E=vhm@use.test.dk, CN=Hedeby's Møbelhandel - Salgsafdelingen, O=Hedeby's Møbelhandel // CVR:13471967, C=DK", X501.ToString (asn, true, ", ", false), "ToString-2");
+			Assert.AreEqual ("C=DK, O=Hedeby's Møbelhandel // CVR:13471967, CN=Hedeby's Møbelhandel - Salgsafdelingen, E=vhm@use.test.dk, SERIALNUMBER=CVR:13471967-UID:121212121212", X501.ToString (asn), "ToString-1");
+			Assert.AreEqual ("SERIALNUMBER=CVR:13471967-UID:121212121212, E=vhm@use.test.dk, CN=Hedeby's Møbelhandel - Salgsafdelingen, O=Hedeby's Møbelhandel // CVR:13471967, C=DK", X501.ToString (asn, true, ", ", false), "ToString-2");
 		}
 
 		[Test]

--- a/mcs/class/System/Mono.Btls/MonoBtlsUtils.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsUtils.cs
@@ -112,6 +112,9 @@ namespace Mono.Btls
 			case MonoBtlsX509NameEntryType.Initial:
 				sb.Append ("I=");
 				break;
+			case MonoBtlsX509NameEntryType.SerialNumber:
+				sb.Append ("SERIALNUMBER=");
+				break;
 			default:
 				// unknown OID
 				sb.Append ("OID.");     // NOTE: Not present as RFC2253

--- a/mcs/class/System/Test/System.Security.Cryptography.X509Certificates/X500DistinguishedNameTest.cs
+++ b/mcs/class/System/Test/System.Security.Cryptography.X509Certificates/X500DistinguishedNameTest.cs
@@ -315,7 +315,7 @@ namespace MonoTests.System.Security.Cryptography.X509Certificates {
 		[Test]
 		public void RFC3280MandatoryAttributeTypes ()
 		{
-			string expected = "dnQualifier=CA, OID.2.5.4.5=345, S=Maryland, DC=testcertificates, DC=gov, O=Test Certificates, C=US";
+			string expected = "dnQualifier=CA, SERIALNUMBER=345, S=Maryland, DC=testcertificates, DC=gov, O=Test Certificates, C=US";
 			X509Certificate2 cert = new X509Certificate2 (RFC3280MandatoryAttributeTypesCACert_crt);
 			// note: strangely the (also CryptoAPI based) certificate viewer in Windows seems to resolve 2.5.4.5 as "Serial Number"
 			Assert.AreEqual (expected, cert.SubjectName.Name, "SubjectName");
@@ -347,7 +347,7 @@ namespace MonoTests.System.Security.Cryptography.X509Certificates {
 				0x13, 0x1D, 0x43, 0x56, 0x52, 0x3A, 0x31, 0x33, 0x34, 0x37, 0x31, 0x39, 0x36, 0x37, 0x2D, 0x55, 0x49, 0x44, 0x3A, 0x31, 0x32, 0x31, 
 				0x32, 0x31, 0x32, 0x31, 0x32, 0x31, 0x32, 0x31, 0x32 };
 			X500DistinguishedName dn = new X500DistinguishedName (sn);
-			string subject = "OID.2.5.4.5=CVR:13471967-UID:121212121212, E=vhm@use.test.dk, CN=Hedeby's Møbelhandel - Salgsafdelingen, O=Hedeby's Møbelhandel // CVR:13471967, C=DK";
+			string subject = "SERIALNUMBER=CVR:13471967-UID:121212121212, E=vhm@use.test.dk, CN=Hedeby's Møbelhandel - Salgsafdelingen, O=Hedeby's Møbelhandel // CVR:13471967, C=DK";
 			Assert.AreEqual (subject, dn.Name, "Name");
 		}
 	}

--- a/mcs/class/System/Test/System.Security.Cryptography.X509Certificates/X509Certificate2Test.cs
+++ b/mcs/class/System/Test/System.Security.Cryptography.X509Certificates/X509Certificate2Test.cs
@@ -1679,7 +1679,7 @@ WYpnKQqsKIzlSqv9wwXs7B1iA7ZdvHk3TAnSnLP1o2H7ME05UnZPKCvraONdezon
 			// http://bugzilla.ximian.com/show_bug.cgi?id=77295
 			byte[] raw = Encoding.ASCII.GetBytes (t61string_cert);
 			X509Certificate2 cert = new X509Certificate2 (raw);
-			string subject = "OID.2.5.4.5=CVR:13471967-UID:121212121212, E=vhm@use.test.dk, CN=Hedeby's Møbelhandel - Salgsafdelingen, O=Hedeby's Møbelhandel // CVR:13471967, C=DK";
+			string subject = "SERIALNUMBER=CVR:13471967-UID:121212121212, E=vhm@use.test.dk, CN=Hedeby's Møbelhandel - Salgsafdelingen, O=Hedeby's Møbelhandel // CVR:13471967, C=DK";
 			Assert.AreEqual (subject, cert.Subject, "Subject");
 			Assert.AreEqual (subject, cert.SubjectName.Name, "SubjectName");
 			string issuer = "CN=KMD Intern Test - KUN TIL TEST/NO LIABILITY GIVEN, OU=KMD, O=KMD, C=DK";


### PR DESCRIPTION
Extracted from #9250. The SERIALNUMBER name is used on NetFX on Windows 10 (and likely older versions too).
