### PR TITLE
Include build_llvm_config.sh in tarballs

### DIFF
--- a/llvm/Makefile.am
+++ b/llvm/Makefile.am
@@ -1,5 +1,5 @@
 
-EXTRA_DIST=SUBMODULES.json build.mk
+EXTRA_DIST=SUBMODULES.json build.mk build_llvm_config.sh
 
 if ENABLE_LLVM
 if INTERNAL_LLVM


### PR DESCRIPTION
Turns out this file was missing.

Haven't tested in-tree llvm from tarballs, I assume it's broken.

Fixes #9456