### PR TITLE
[corlib]: Enable `HashCode` in all profiles.

### DIFF
--- a/mcs/class/corlib/CommonCrypto/RNGCryptoServiceProvider.cryptor.cs
+++ b/mcs/class/corlib/CommonCrypto/RNGCryptoServiceProvider.cryptor.cs
@@ -64,6 +64,11 @@ namespace System.Security.Cryptography {
 					
 			Cryptor.GetRandom (data);
 		}
+
+		unsafe internal void GetBytes (byte* data, IntPtr data_length)
+		{
+			Cryptor.GetRandom (data, data_length);
+		}
 		
 		public override void GetNonZeroBytes (byte[] data) 
 		{

--- a/mcs/class/corlib/System.Security.Cryptography/RNGCryptoServiceProvider.cs
+++ b/mcs/class/corlib/System.Security.Cryptography/RNGCryptoServiceProvider.cs
@@ -123,7 +123,20 @@ namespace System.Security.Cryptography {
 			}
 			Check ();
 		}
-		
+
+		unsafe internal void GetBytes (byte* data, IntPtr data_length)
+		{
+			if (_lock == null) {
+				_handle = RngGetBytes (_handle, data, data_length);
+			} else {
+				// using a global handle for randomness
+				lock (_lock) {
+					_handle = RngGetBytes (_handle, data, data_length);
+				}
+			}
+			Check ();
+		}
+
 		unsafe public override void GetNonZeroBytes (byte[] data)
 		{
 			if (data == null)

--- a/mcs/class/corlib/corefx/Interop.GetRandomBytes.Mono.cs
+++ b/mcs/class/corlib/corefx/Interop.GetRandomBytes.Mono.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+	static class MonoGetRandomBytesFallback
+	{
+		static object _rngAccess = new object ();
+		static RNGCryptoServiceProvider _rng;
+
+		internal static void GetRandomBytes (byte[] buffer)
+		{
+			lock (_rngAccess) {
+				if (_rng == null)
+					_rng = new RNGCryptoServiceProvider ();
+				_rng.GetBytes (buffer);
+			}
+		}
+
+		internal static unsafe void GetRandomBytes (byte* buffer, int length)
+		{
+			lock (_rngAccess) {
+				if (_rng == null)
+					_rng = new RNGCryptoServiceProvider ();
+				_rng.GetBytes (buffer, (IntPtr)length);
+			}
+		}
+	}
+
+	internal static unsafe void GetRandomBytes (byte* buffer, int length)
+	{
+		MonoGetRandomBytesFallback.GetRandomBytes (buffer, length);
+	}
+}

--- a/mcs/class/corlib/corlib.csproj
+++ b/mcs/class/corlib/corlib.csproj
@@ -260,6 +260,7 @@
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\Globalization\CompareInfo.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\Globalization\GlobalizationExtensions.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\HResults.cs" />
+    <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\HashCode.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\ISpanFormattable.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\Marvin.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\MathF.cs" />
@@ -1992,6 +1993,7 @@
     <Compile Include="System.Security.Cryptography\MD5CryptoServiceProvider.cs" />
     <Compile Include="System.Security.Cryptography\RNGCryptoServiceProvider.cs" />
     <Compile Include="System.Security.Cryptography\SHA1CryptoServiceProvider.cs" />
+    <Compile Include="corefx\Interop.GetRandomBytes.Mono.cs" />
     <Compile Include="corert\PreAllocatedOverlapped.platformnotsupported.cs" />
     <Compile Include="corert\ThreadPoolBoundHandle.platformnotsupported.cs" />
   </ItemGroup>
@@ -2007,6 +2009,7 @@
     <Compile Include="System\Environment.iOS.cs" />
     <Compile Include="System\Guid.MonoTouch.cs" />
     <Compile Include="System\NotSupportedException.iOS.cs" />
+    <Compile Include="corefx\Interop.GetRandomBytes.Mono.cs" />
     <Compile Include="corert\PreAllocatedOverlapped.platformnotsupported.cs" />
     <Compile Include="corert\ThreadPoolBoundHandle.platformnotsupported.cs" />
   </ItemGroup>
@@ -2022,6 +2025,7 @@
     <Compile Include="System\Environment.iOS.cs" />
     <Compile Include="System\Guid.MonoTouch.cs" />
     <Compile Include="System\NotSupportedException.iOS.cs" />
+    <Compile Include="corefx\Interop.GetRandomBytes.Mono.cs" />
     <Compile Include="corert\PreAllocatedOverlapped.platformnotsupported.cs" />
     <Compile Include="corert\ThreadPoolBoundHandle.platformnotsupported.cs" />
   </ItemGroup>
@@ -2037,13 +2041,13 @@
     <Compile Include="System\Environment.iOS.cs" />
     <Compile Include="System\Guid.MonoTouch.cs" />
     <Compile Include="System\NotSupportedException.iOS.cs" />
+    <Compile Include="corefx\Interop.GetRandomBytes.Mono.cs" />
     <Compile Include="corert\PreAllocatedOverlapped.platformnotsupported.cs" />
     <Compile Include="corert\ThreadPoolBoundHandle.platformnotsupported.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(Platform)|$(HostPlatform)' == 'net_4_x|linux' ">
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\Interop\Unix\Interop.Libraries.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\Interop\Unix\System.Native\Interop.GetRandomBytes.cs" />
-    <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\HashCode.cs" />
     <Compile Include="..\Mono.Security\Mono.Security.Cryptography\ARC4Managed.cs" />
     <Compile Include="..\Mono.Security\Mono.Security.Cryptography\MD2Managed.cs" />
     <Compile Include="..\Mono.Security\Mono.Security.Cryptography\MD4Managed.cs" />
@@ -2064,7 +2068,6 @@
   <ItemGroup Condition=" '$(Platform)|$(HostPlatform)' == 'net_4_x|macos' ">
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\Interop\Unix\Interop.Libraries.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\Interop\Unix\System.Native\Interop.GetRandomBytes.cs" />
-    <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\HashCode.cs" />
     <Compile Include="..\Mono.Security\Mono.Security.Cryptography\ARC4Managed.cs" />
     <Compile Include="..\Mono.Security\Mono.Security.Cryptography\MD2Managed.cs" />
     <Compile Include="..\Mono.Security\Mono.Security.Cryptography\MD4Managed.cs" />
@@ -2085,7 +2088,6 @@
   <ItemGroup Condition=" '$(Platform)|$(HostPlatform)' == 'net_4_x|unix' ">
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\Interop\Unix\Interop.Libraries.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\Interop\Unix\System.Native\Interop.GetRandomBytes.cs" />
-    <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\HashCode.cs" />
     <Compile Include="..\Mono.Security\Mono.Security.Cryptography\ARC4Managed.cs" />
     <Compile Include="..\Mono.Security\Mono.Security.Cryptography\MD2Managed.cs" />
     <Compile Include="..\Mono.Security\Mono.Security.Cryptography\MD4Managed.cs" />
@@ -2106,7 +2108,6 @@
   <ItemGroup Condition=" '$(Platform)|$(HostPlatform)' == 'net_4_x|win32' ">
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\Interop\Windows\BCrypt\Interop.BCryptGenRandom.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\Interop\Windows\Interop.Libraries.cs" />
-    <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\HashCode.cs" />
     <Compile Include="..\..\..\external\corert\src\Common\src\Interop\Windows\Interop.Libraries.cs" />
     <Compile Include="..\..\..\external\corert\src\Common\src\Interop\Windows\mincore\Interop.MemAllocFree.cs" />
     <Compile Include="..\..\..\external\corert\src\Common\src\Interop\Windows\mincore\Interop.ThreadPoolIO.cs" />
@@ -2152,6 +2153,7 @@
     <Compile Include="System.Security.Cryptography\MD5CryptoServiceProvider.cs" />
     <Compile Include="System.Security.Cryptography\RNGCryptoServiceProvider.cs" />
     <Compile Include="System.Security.Cryptography\SHA1CryptoServiceProvider.cs" />
+    <Compile Include="corefx\Interop.GetRandomBytes.Mono.cs" />
     <Compile Include="corert\PreAllocatedOverlapped.platformnotsupported.cs" />
     <Compile Include="corert\ThreadPoolBoundHandle.platformnotsupported.cs" />
   </ItemGroup>
@@ -2170,6 +2172,7 @@
     <Compile Include="System.Security.Cryptography\MD5CryptoServiceProvider.cs" />
     <Compile Include="System.Security.Cryptography\RNGCryptoServiceProvider.cs" />
     <Compile Include="System.Security.Cryptography\SHA1CryptoServiceProvider.cs" />
+    <Compile Include="corefx\Interop.GetRandomBytes.Mono.cs" />
     <Compile Include="corert\PreAllocatedOverlapped.platformnotsupported.cs" />
     <Compile Include="corert\ThreadPoolBoundHandle.platformnotsupported.cs" />
   </ItemGroup>
@@ -2188,13 +2191,13 @@
     <Compile Include="System.Security.Cryptography\MD5CryptoServiceProvider.cs" />
     <Compile Include="System.Security.Cryptography\RNGCryptoServiceProvider.cs" />
     <Compile Include="System.Security.Cryptography\SHA1CryptoServiceProvider.cs" />
+    <Compile Include="corefx\Interop.GetRandomBytes.Mono.cs" />
     <Compile Include="corert\PreAllocatedOverlapped.platformnotsupported.cs" />
     <Compile Include="corert\ThreadPoolBoundHandle.platformnotsupported.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(Platform)' == 'winaot' ">
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\Interop\Windows\BCrypt\Interop.BCryptGenRandom.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\Interop\Windows\Interop.Libraries.cs" />
-    <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\HashCode.cs" />
     <Compile Include="..\..\..\external\corert\src\Common\src\Interop\Windows\Interop.Libraries.cs" />
     <Compile Include="..\..\..\external\corert\src\Common\src\Interop\Windows\mincore\Interop.MemAllocFree.cs" />
     <Compile Include="..\..\..\external\corert\src\Common\src\Interop\Windows\mincore\Interop.ThreadPoolIO.cs" />
@@ -2233,6 +2236,7 @@
     <Compile Include="CommonCrypto\RC4CommonCrypto.cs" />
     <Compile Include="CommonCrypto\RNGCryptoServiceProvider.cryptor.cs" />
     <Compile Include="CommonCrypto\RijndaelManaged.cs" />
+    <Compile Include="corefx\Interop.GetRandomBytes.Mono.cs" />
     <Compile Include="corert\PreAllocatedOverlapped.platformnotsupported.cs" />
     <Compile Include="corert\ThreadPoolBoundHandle.platformnotsupported.cs" />
   </ItemGroup>

--- a/mcs/class/corlib/corlib.dll.sources
+++ b/mcs/class/corlib/corlib.dll.sources
@@ -1542,6 +1542,7 @@ corefx/AwaitTaskContinuation.cs
 corefx/SynchronizationContext.cs
 corefx/SR.cs
 corefx/CompareInfo.cs
+corefx/Interop.GetRandomBytes.Mono.cs
 corefx/MemoryExtensions.cs
 corefx/GlobalizationMode.cs
 corefx/MemoryMarshal.cs
@@ -1612,6 +1613,7 @@ corert/RuntimeAugments.cs
 ../../../external/corefx/src/System.ObjectModel/src/System/Collections/ObjectModel/ReadOnlyDictionary.cs
 
 ../../../external/corefx/src/Common/src/CoreLib/System/Gen2GcCallback.cs
+../../../external/corefx/src/Common/src/CoreLib/System/HashCode.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/HResults.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/MathF.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/Marvin.cs

--- a/mcs/class/corlib/linux_net_4_x_corlib.dll.exclude.sources
+++ b/mcs/class/corlib/linux_net_4_x_corlib.dll.exclude.sources
@@ -1,0 +1,1 @@
+#include unix_net_4_x_corlib.dll.exclude.sources

--- a/mcs/class/corlib/macos_net_4_x_corlib.dll.exclude.sources
+++ b/mcs/class/corlib/macos_net_4_x_corlib.dll.exclude.sources
@@ -1,0 +1,1 @@
+#include unix_net_4_x_corlib.dll.exclude.sources

--- a/mcs/class/corlib/macos_net_4_x_corlib.dll.sources
+++ b/mcs/class/corlib/macos_net_4_x_corlib.dll.sources
@@ -1,4 +1,1 @@
-#include net_4_x_corlib.dll.sources
-
-../../../external/corefx/src/Common/src/CoreLib/Interop/Unix/System.Native/Interop.GetRandomBytes.cs
-../../../external/corefx/src/Common/src/CoreLib/Interop/Unix/Interop.Libraries.cs
+#include unix_net_4_x_corlib.dll.sources

--- a/mcs/class/corlib/net_4_x_corlib.dll.sources
+++ b/mcs/class/corlib/net_4_x_corlib.dll.sources
@@ -1,4 +1,2 @@
 #include corlib.dll.sources
 
-../../../external/corefx/src/Common/src/CoreLib/System/HashCode.cs
-

--- a/mcs/class/corlib/unix_net_4_x_corlib.dll.exclude.sources
+++ b/mcs/class/corlib/unix_net_4_x_corlib.dll.exclude.sources
@@ -1,0 +1,1 @@
+corefx/Interop.GetRandomBytes.Mono.cs

--- a/mcs/class/corlib/win32_net_4_x_corlib.dll.exclude.sources
+++ b/mcs/class/corlib/win32_net_4_x_corlib.dll.exclude.sources
@@ -1,2 +1,4 @@
 corert/PreAllocatedOverlapped.platformnotsupported.cs
 corert/ThreadPoolBoundHandle.platformnotsupported.cs
+
+corefx/Interop.GetRandomBytes.Mono.cs

--- a/mcs/class/corlib/winaot_corlib.dll.exclude.sources
+++ b/mcs/class/corlib/winaot_corlib.dll.exclude.sources
@@ -1,3 +1,5 @@
 corert/Interop.MemAllocFree.cs
 corert/PreAllocatedOverlapped.platformnotsupported.cs
 corert/ThreadPoolBoundHandle.platformnotsupported.cs
+
+corefx/Interop.GetRandomBytes.Mono.cs


### PR DESCRIPTION
* `HashCode` is now enabled in all profiles.

* Added `RNGCryptoServiceProvider` based fallback implementation.

* Added internal `RNGCryptoServiceProvider.GetRandom(byte*,IntPtr)` overload.

* The fallback implementation is enabled by default in `corlib.dll.sources`,
  platforms which provide a native implementation need to add it to their
  `.exclude.sources`.
