### PR TITLE
Fix race condition in WaitAnyWithSecondMutexAbandoned test.

### DIFF
--- a/mcs/class/corlib/Test/System.Threading/WaitHandleTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/WaitHandleTest.cs
@@ -409,7 +409,7 @@ namespace MonoTests.System.Threading {
 					m.WaitOne ();
 				});
 				thread1.Start ();
-				thread1.Join (1000);
+				Assert.IsTrue (thread1.Join (Timeout.Infinite), "thread1.Join");
 				try {
 					m.WaitOne ();
 					Assert.Fail ("Expected AbandonedMutexException");
@@ -421,7 +421,7 @@ namespace MonoTests.System.Threading {
 					signalled = m.WaitOne (100);
 				});
 				thread2.Start ();
-				thread2.Join (1000);
+				Assert.IsTrue (thread2.Join (Timeout.Infinite), "thread2.Join");
 				Assert.IsFalse (signalled);
 
 				// Since this thread owns the Mutex releasing it shouldn't fail
@@ -489,7 +489,7 @@ namespace MonoTests.System.Threading {
 						m1.ReleaseMutex ();
 					});
 					thread1.Start ();
-					thread1.Join (1000);
+					Assert.IsTrue (thread1.Join (Timeout.Infinite), "thread1.Join");
 					thread2.Start ();
 					while (!mainProceed) {
 						Thread.Sleep (10);
@@ -502,7 +502,7 @@ namespace MonoTests.System.Threading {
 						Assert.AreEqual (m2, e.Mutex);
 					} finally {
 						thread2Proceed = true;
-						thread2.Join (1000);
+						Assert.IsTrue (thread2.Join (Timeout.Infinite), "thread2.Join");
 					}
 
 					// Current thread should own the second Mutex now
@@ -511,7 +511,7 @@ namespace MonoTests.System.Threading {
 						signalled = WaitHandle.WaitAny (new WaitHandle [] { m1, m2 }, 0);
 					});
 					thread3.Start ();
-					thread3.Join (1000);
+					Assert.IsTrue (thread3.Join (Timeout.Infinite), "thread3.Join");
 					Assert.AreEqual (0, signalled);
 
 					// Since this thread owns the second Mutex releasing it shouldn't fail
@@ -540,7 +540,7 @@ namespace MonoTests.System.Threading {
 						m1.WaitOne ();
 					});
 					thread.Start ();
-					thread.Join (1000);
+					Assert.IsTrue (thread.Join (Timeout.Infinite), "thread.Join");
 					WaitHandle.WaitAll (new WaitHandle [] { m1, m2 });
 				}
 			}


### PR DESCRIPTION
There is a small race condition during the completion of a native thread join call. During that period of time the tid is no longer included on the internal list tracking joinable threads so a thread that will join on the tid while another thread (like the finalizer thread) is waiting on native join to complete for the same tid, will cause the managed Thread.Join call to complete before the native join call has completed. This race could cause issues on some OS:es that clear's up some thread resources, like abandoned mutexes when the thread has exited. This race is hit by WaitAnyWithSecondMutexAbandoned since the call to Thread.Join will return before the thread owning the mutex has terminated meaning that it doesn't get ownership of the abandoned mutex as assumed by the test.

Fix makes sure Thread.Join won't complete until native thread join is complete. Increasing the join timeouts in the test also eliminates a timeout error making it harder to hit the problematic code path, primarily during reproduction in the debugger.

Fixes #8708