### PR TITLE
Fix issue where GetCheckedIPs filters out addresses, when the AddressFamily is Unspecified

### DIFF
--- a/mcs/class/System/System.Net.Sockets/Socket.cs
+++ b/mcs/class/System/System.Net.Sockets/Socket.cs
@@ -1172,6 +1172,10 @@ namespace System.Net.Sockets
 			DnsEndPoint dep = e.RemoteEndPoint as DnsEndPoint;
 			if (dep != null) {
 				addresses = Dns.GetHostAddresses (dep.Host);
+
+				if (dep.AddressFamily == AddressFamily.Unspecified)
+					return true;
+
 				int last_valid = 0;
 				for (int i = 0; i < addresses.Length; ++i) {
 					if (addresses [i].AddressFamily != dep.AddressFamily)


### PR DESCRIPTION
GetCheckedIPs filters out endpoints that do not match the remote endpoint address family, however in the case the remote endpoint is unspecified, we shouldn't do this filtering. Filtering was added in https://github.com/mono/mono/pull/8041