### PR TITLE
[sdks] fix build for watchOS and tvOS

### DIFF
--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -24,8 +24,6 @@ win32_sources = \
 
 platform_sources = $(win32_sources)
 
-glib_libs = $(top_builddir)/mono/eglib/libeglib.la
-
 # Use -m here. This will use / as directory separator (C:/WINNT).
 # The files that use MONO_ASSEMBLIES and/or MONO_CFG_DIR replace the
 # / by \ if running under WIN32.
@@ -63,6 +61,8 @@ unix_sources = \
 
 platform_sources = $(unix_sources)
 endif
+
+glib_libs = $(top_builddir)/mono/eglib/libeglib.la
 
 if HOST_ANDROID
 platform_sources += ../../support/libm/complex.c

--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -89,8 +89,11 @@ if [[ ${CI_TAGS} == *'product-sdks-ios'* ]];
 	   echo "DISABLE_ANDROID=1" > sdks/Make.config
 	   echo "DISABLE_WASM=1" >> sdks/Make.config
 	   export device_test_suites="Mono.Runtime.Tests System.Core"
-	   ${TESTCMD} --label=runtimes --timeout=60m --fatal make -j4 -C sdks/builds package-ios-sim64 package-ios-target64
-	   ${TESTCMD} --label=cross --timeout=60m --fatal make -j4 -C sdks/builds package-ios-cross64 package-ios-cross32
+
+	   ${TESTCMD} --label=build-sim-runtimes --timeout=20m --fatal make -j4 -C sdks/builds package-ios-{sim64,sim32,simtv,simwatch}
+	   ${TESTCMD} --label=build-dev-runtimes --timeout=20m --fatal make -j4 -C sdks/builds package-ios-{target64,target32,targettv,targetwatch}
+	   ${TESTCMD} --label=build-cross-compilers --timeout=20m --fatal make -j4 -C sdks/builds package-ios-{cross64,cross32,crosswatch}
+
 	   ${TESTCMD} --label=bcl --timeout=60m --fatal make -j4 -C sdks/builds package-bcl
 	   ${TESTCMD} --label=build-tests --timeout=10m --fatal make -C sdks/ios compile-tests
 	   ${TESTCMD} --label=run-sim --timeout=20m make -C sdks/ios run-ios-sim-all


### PR DESCRIPTION
fixes regressions introduced by 5e9af502c052 and 2a8fcbd9fe5560de0d4d57d2da6cbb855f284f86. Also adding build targets to CI so we avoid breakages in the future.

parts of this PR need to be backported to `2018-06`