### PR TITLE
[runtime] Enable application to register path for MERP restart

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # This can be reset to 0 when Mono's version number is bumped
 # since it's part of the corlib version (the prefix '1' in the full
 # version number is to ensure the number isn't treated as octal in C)
-MONO_CORLIB_COUNTER=16
+MONO_CORLIB_COUNTER=17
 MONO_CORLIB_VERSION=`printf "1%02d%02d%02d%03d" $MONO_VERSION_MAJOR $MONO_VERSION_MINOR 0 $MONO_CORLIB_COUNTER`
 
 AC_DEFINE_UNQUOTED(MONO_CORLIB_VERSION,$MONO_CORLIB_VERSION,[Version of the corlib-runtime interface])

--- a/mcs/class/corlib/Mono/Runtime.cs
+++ b/mcs/class/corlib/Mono/Runtime.cs
@@ -86,9 +86,9 @@ namespace Mono {
 		static extern void DisableMicrosoftTelemetry (IntPtr appBundleID, IntPtr appSignature, IntPtr appVersion, IntPtr merpGUIPath);
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
-		static extern void EnableMicrosoftTelemetry_internal (IntPtr appBundleID, IntPtr appSignature, IntPtr appVersion, IntPtr merpGUIPath, IntPtr eventType);
+		static extern void EnableMicrosoftTelemetry_internal (IntPtr appBundleID, IntPtr appSignature, IntPtr appVersion, IntPtr merpGUIPath, IntPtr eventType, IntPtr appPath);
 
-		static void EnableMicrosoftTelemetry (string appBundleID_str, string appSignature_str, string appVersion_str, string merpGUIPath_str, string eventType_str)
+		static void EnableMicrosoftTelemetry (string appBundleID_str, string appSignature_str, string appVersion_str, string merpGUIPath_str, string eventType_str, string appPath_str)
 		{
 			if (RuntimeInformation.IsOSPlatform (OSPlatform.OSX)) {
 				using (var appBundleID_chars = RuntimeMarshal.MarshalString (appBundleID_str))
@@ -96,8 +96,9 @@ namespace Mono {
 				using (var appVersion_chars = RuntimeMarshal.MarshalString (appVersion_str))
 				using (var merpGUIPath_chars = RuntimeMarshal.MarshalString (merpGUIPath_str))
 				using (var eventType_chars = RuntimeMarshal.MarshalString (eventType_str))
+				using (var appPath_chars = RuntimeMarshal.MarshalString (appPath_str))
 				{
-					EnableMicrosoftTelemetry_internal (appBundleID_chars.Value, appSignature_chars.Value, appVersion_chars.Value, merpGUIPath_chars.Value, eventType_chars.Value);
+					EnableMicrosoftTelemetry_internal (appBundleID_chars.Value, appSignature_chars.Value, appVersion_chars.Value, merpGUIPath_chars.Value, eventType_chars.Value, appPath_chars.Value);
 				}
 			} else {
 				throw new PlatformNotSupportedException("Merp support is currently only supported on OSX.");

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5657,10 +5657,10 @@ ves_icall_Mono_Runtime_DisableMicrosoftTelemetry (MonoError *error)
 }
 
 ICALL_EXPORT void
-ves_icall_Mono_Runtime_EnableMicrosoftTelemetry (char *appBundleID, char *appSignature, char *appVersion, char *merpGUIPath, char *eventType, MonoError *error)
+ves_icall_Mono_Runtime_EnableMicrosoftTelemetry (char *appBundleID, char *appSignature, char *appVersion, char *merpGUIPath, char *eventType, char *appPath, MonoError *error)
 {
 #ifdef TARGET_OSX
-	mono_merp_enable (appBundleID, appSignature, appVersion, merpGUIPath, eventType);
+	mono_merp_enable (appBundleID, appSignature, appVersion, merpGUIPath, eventType, appPath);
 
 	mono_get_runtime_callbacks ()->install_state_summarizer ();
 #else

--- a/mono/utils/mono-merp.c
+++ b/mono/utils/mono-merp.c
@@ -88,6 +88,7 @@ typedef struct {
 	MERPExcType exceptionArg; // Exception type (refer to merpcommon.h and mach/exception_types.h for more info (optional)
 
 	const char *serviceNameArg; // This is the Bootstrap service name that MERP GUI will create to receive mach_task_self on a port created. Bails out if MERP GUI fails to receive mach_task_self from the crashed app. (Required for crash log generation)
+	const char *servicePathArg; // The path to the executable, used to relaunch the crashed app.
 
 	const char *moduleName;
 	const char *moduleVersion;
@@ -108,6 +109,7 @@ typedef struct {
 	gboolean enable_merp;
 
 	const char *appBundleID;
+	const char *appPath;
 	const char *appSignature; 
 	const char *appVersion;
 	const char *merpGUIPath; 
@@ -212,6 +214,7 @@ mono_encode_merp_params (MERPStruct *merp)
 
 	// Provided by icall
 	g_string_append_printf (output, "ApplicationName: %s\n", merp->serviceNameArg);
+	g_string_append_printf (output, "ApplicationPath: %s\n", merp->servicePathArg);
 
 	// Provided by icall
 	g_string_append_printf (output, "BlameModuleName: %s\n", merp->moduleName);
@@ -327,6 +330,7 @@ mono_init_merp (const intptr_t crashed_pid, const char *signal, MonoStackHash *h
 	merp->exceptionArg = parse_exception_type (signal);
 
 	merp->serviceNameArg = config.appBundleID;
+	merp->servicePathArg = config.appPath;
 
 	merp->moduleName = "Mono Exception";
 	merp->moduleVersion = version;
@@ -536,11 +540,12 @@ mono_merp_disable (void)
 	g_free ((char*)config.appVersion);
 	g_free ((char*)config.merpGUIPath);
 	g_free ((char*)config.eventType);
+	g_free ((char*)config.appPath); 
 	memset (&config, 0, sizeof (config));
 }
 
 void
-mono_merp_enable (const char *appBundleID, const char *appSignature, const char *appVersion, const char *merpGUIPath, const char *eventType)
+mono_merp_enable (const char *appBundleID, const char *appSignature, const char *appVersion, const char *merpGUIPath, const char *eventType, const char *appPath)
 {
 	g_assert (!config.enable_merp);
 
@@ -549,6 +554,7 @@ mono_merp_enable (const char *appBundleID, const char *appSignature, const char 
 	config.appVersion = g_strdup (appVersion);
 	config.merpGUIPath = g_strdup (merpGUIPath);
 	config.eventType = g_strdup (eventType);
+	config.appPath = g_strdup (appPath);
 
 	config.log = g_getenv ("MONO_MERP_VERBOSE") != NULL;
 

--- a/mono/utils/mono-merp.h
+++ b/mono/utils/mono-merp.h
@@ -29,7 +29,7 @@ void mono_merp_disable (void);
  * See MERP documentation for information on the bundle ID, signature, and version fields
  */
 void
-mono_merp_enable (const char *appBundleID, const char *appSignature, const char *appVersion, const char *merpGUIPath, const char *eventType);
+mono_merp_enable (const char *appBundleID, const char *appSignature, const char *appVersion, const char *merpGUIPath, const char *eventType, const char *appPath);
 
 /**
  * Whether the MERP-based handler is registered


### PR DESCRIPTION
This path is not sent to Watson, for the privacy concerned. 

It is the .app that is launched when someone clicks "relaunch" on the MERP dialog box. 