### PR TITLE
[checked,coop] Use unbalanced thread state transitions in mono_threads_attach_coop

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -5768,7 +5768,7 @@ mono_threads_attach_coop_internal (MonoDomain *domain, gpointer *cookie, MonoSta
 			*cookie = mono_threads_enter_gc_unsafe_region_cookie ();
 		} else {
 			/* thread state (BLOCKING|RUNNING) -> RUNNING */
-			*cookie = mono_threads_enter_gc_unsafe_region_internal (stackdata);
+			*cookie = mono_threads_enter_gc_unsafe_region_unbalanced_internal (stackdata);
 		}
 	}
 
@@ -5810,7 +5810,7 @@ mono_threads_detach_coop_internal (MonoDomain *orig, gpointer cookie, MonoStackD
 	if (mono_threads_is_blocking_transition_enabled ()) {
 		/* it won't do anything if cookie is NULL
 		 * thread state RUNNING -> (RUNNING|BLOCKING) */
-		mono_threads_exit_gc_unsafe_region_internal (cookie, stackdata);
+		mono_threads_exit_gc_unsafe_region_unbalanced_internal (cookie, stackdata);
 	}
 
 	if (orig != domain) {


### PR DESCRIPTION
The `mono_threads_attach_coop` / `mono_threads_detach_coop` icalls are called from
the wrapper around managed methods that will be called from native code `emit_managed_wrapper_ilgen` https://github.com/mono/mono/blob/cf0895fbb9ebe31c377d5b14101d714005be4d57/mono/metadata/marshal-ilgen.c#L5878-L5886

If the managed method throws an exception, the mono_threads_detach_coop will not
be called, and the checked build `mono_threads_enter_gc_unsafe_region_internal`/`mono_threads_exit_gc_unsafe_region_internal` accounting will be mis-matched which will break later checked mode checks.

(The unbalanced thread state transition is not a problem - the next outermost
exit_gc_unsafe will operate just fine - it's just the checked mode check that's
wrong)