### PR TITLE
When csc fails, for any reason, retry once with -parallel-.

### DIFF
--- a/mcs/build/executable.make
+++ b/mcs/build/executable.make
@@ -138,8 +138,14 @@ $(topdir)/class/lib/$(PROFILE)/.stamp: | $(topdir)/class/lib/$(PROFILE)-$(HOST_P
 	$(if $(filter $(HOST_PLATFORM),$(BUILD_PLATFORM)),$(if $(filter $(BUILD_PLATFORM),win32),CYGWIN=winsymlinks:nativestrict) ln -s $(abspath $(topdir)/class/lib/$(PROFILE)-$(BUILD_PLATFORM)) $(abspath $(topdir)/class/lib/$(PROFILE)))
 endif
 
+# If csc fails, try again not parallel.
 $(build_lib): $(BUILT_SOURCES) $(EXTRA_SOURCES) $(response) $(build_libdir:=/.stamp)
+ifndef CSC_RETRY_SERIAL
 	$(PROGRAM_COMPILE) $(MCS_REFERENCES) -target:exe -out:$@ $(BUILT_SOURCES) $(EXTRA_SOURCES) @$(response)
+else
+	$(PROGRAM_COMPILE) $(MCS_REFERENCES) -target:exe -out:$@ $(BUILT_SOURCES) $(EXTRA_SOURCES) @$(response) \
+	|| $(PROGRAM_COMPILE) $(CSC_RETRY_SERIAL) $(MCS_REFERENCES) -target:exe -out:$@ $(BUILT_SOURCES) $(EXTRA_SOURCES) @$(response)
+endif
 ifdef PROGRAM_SNK
 	$(Q) $(SN) -R $@ $(PROGRAM_SNK)
 endif

--- a/mcs/build/library.make
+++ b/mcs/build/library.make
@@ -348,8 +348,14 @@ endif
 
 ifndef NO_BUILD
 
+# If csc fails, try again not parallel.
 $(build_lib): $(response) $(sn) $(BUILT_SOURCES) $(build_libdir)/.stamp $(GEN_RESOURCE_DEPS) $(MODULE_DEPS)
+ifndef CSC_RETRY_SERIAL
 	$(LIBRARY_COMPILE) $(LIBRARY_FLAGS) $(LIB_MCS_FLAGS) $(KEYFILE_MCS_FLAGS) $(GEN_RESOURCE_FLAGS) -target:library -out:$@ $(BUILT_SOURCES_cmdline) @$(response)
+else
+	$(LIBRARY_COMPILE) $(LIBRARY_FLAGS) $(LIB_MCS_FLAGS) $(KEYFILE_MCS_FLAGS) $(GEN_RESOURCE_FLAGS) -target:library -out:$@ $(BUILT_SOURCES_cmdline) @$(response) \
+	|| $(LIBRARY_COMPILE) $(CSC_RETRY_SERIAL) $(LIBRARY_FLAGS) $(LIB_MCS_FLAGS) $(KEYFILE_MCS_FLAGS) $(GEN_RESOURCE_FLAGS) -target:library -out:$@ $(BUILT_SOURCES_cmdline) @$(response)
+endif
 ifdef RESOURCE_STRINGS_FILES
 	$(Q) $(STRING_REPLACER) $(RESOURCE_STRINGS_FILES) $(IL_REPLACE_FILES) $@
 endif

--- a/mcs/build/rules.make
+++ b/mcs/build/rules.make
@@ -327,3 +327,10 @@ MDOC   =$(Q_MDOC) MONO_PATH="$(topdir)/class/lib/$(DEFAULT_PROFILE)$(PLATFORM_PA
 
 Q_MDOC_UP=$(if $(V),,@echo "MDOC-UP [$(PROFILE_DIRECTORY)] $(notdir $(@))";)
 MDOC_UP  =$(Q_MDOC_UP) MONO_PATH="$(topdir)/class/lib/$(DEFAULT_PROFILE)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(RUNTIME) $(topdir)/class/lib/$(DEFAULT_PROFILE)/mdoc.exe update --delete -o Documentation/en
+
+# Support serialized retry due to high failure rate on ARM.
+ifdef MCS_MODE
+CSC_RETRY_SERIAL=
+else
+CSC_RETRY_SERIAL=-parallel-
+endif

--- a/mcs/build/tests.make
+++ b/mcs/build/tests.make
@@ -242,8 +242,14 @@ ifdef HAVE_CS_TESTS
 $(test_lib_dir):
 	mkdir -p $@
 
+# If csc fails, try again not parallel.
 $(test_lib_output): $(test_assembly_dep) $(test_response) $(test_nunit_dep) $(test_lib_dir)
+ifndef CSC_RETRY_SERIAL
 	$(TEST_COMPILE) $(LIBRARY_FLAGS) -target:library -out:$@ $(test_flags) $(LOCAL_TEST_COMPILER_ONDOTNET_FLAGS) @$(test_response)
+else
+	$(TEST_COMPILE) $(LIBRARY_FLAGS) -target:library -out:$@ $(test_flags) $(LOCAL_TEST_COMPILER_ONDOTNET_FLAGS) @$(test_response) \
+	|| $(TEST_COMPILE) $(CSC_RETRY_SERIAL) $(LIBRARY_FLAGS) -target:library -out:$@ $(test_flags) $(LOCAL_TEST_COMPILER_ONDOTNET_FLAGS) @$(test_response)
+endif
 
 test_response_preprocessed = $(test_response)_preprocessed
 

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -4536,7 +4536,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		}
 
 		case OP_CHECK_THIS:
-			arm_ldrx (code, ARMREG_LR, sreg1, 0);
+			arm_ldrb (code, ARMREG_LR, sreg1, 0);
 			break;
 		case OP_NOT_NULL:
 		case OP_NOT_REACHED:


### PR DESCRIPTION
This might give us higher ARM CI success rates, and might be much slower.
This will double up actual errors for incorrect C# source.
