### PR TITLE
Update ARM memory model.

### DIFF
--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -4536,7 +4536,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		}
 
 		case OP_CHECK_THIS:
-			arm_ldrx (code, ARMREG_LR, sreg1, 0);
+			arm_ldrb (code, ARMREG_LR, sreg1, 0);
 			break;
 		case OP_NOT_NULL:
 		case OP_NOT_REACHED:


### PR DESCRIPTION
This has been seen to fix the test case in https://github.com/mono/mono/issues/8731 on ARM64.
I didn't try ARM32. Here it is duplicated:

```
using System;
using System.Threading;

class A
{
class obj { public int i; }

static int N = 100 * 100 * 100;
static obj[] reserve = new obj [N];
static obj[] ready = new obj [N];
static long writes;
static volatile int barrier;

static void Assert(bool expr)
{
 if (expr) return;
 ++barrier;
 Console.WriteLine($"assertion failed {writes}");
 Environment.Exit(1);
}

static void ThreadMain()
{
 for (int i = 0; i < N; ++i)
 {
  var o = ready[i];
  Assert(o == null || o.i == 1);
  if (i == N - 1 && o != null)
   return;
 }
}

static void Main()
{
 for (int i = 0; i < N; ++i)
  reserve[i] = new obj();
 while (true)
 {
  for (int i = 0; i < N; ++i)
    reserve[i].i = 0;
  for (int i = 0; i < N; ++i)
    ready[i] = null;
   ++barrier;
   var thread = new Thread (ThreadMain);
   thread.Start ();
   for (int i = 0; i < N; ++i)
   {
     var o = reserve[i];
     ++writes;
     o.i = 1;
     ready[i] = o;
   }
   thread.Join ();
  }
}
}
```