### PR TITLE
[2018-04] [arm64] Make OP_CHECK_THIS read only a byte, to prevent unaligned access errors.

### DIFF
--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -4451,7 +4451,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		}
 
 		case OP_CHECK_THIS:
-			arm_ldrx (code, ARMREG_LR, sreg1, 0);
+			arm_ldrb (code, ARMREG_LR, sreg1, 0);
 			break;
 		case OP_NOT_NULL:
 		case OP_NOT_REACHED:


### PR DESCRIPTION
Backport of #9543.

/cc @marek-safar