### PR TITLE
Add support for an output path in mono-api-diff

### DIFF
--- a/mcs/tools/mono-api-diff/mono-api-diff.cs
+++ b/mcs/tools/mono-api-diff/mono-api-diff.cs
@@ -34,7 +34,7 @@ namespace Mono.AssemblyCompare
 
 			var options = new OptionSet {
 				{ "h|help", "Show this help", v => showHelp = true },
-				{ "o|output=", "XML diff file output (omit for stdout)", v => output = v },
+				{ "o|out|output=", "XML diff file output (omit for stdout)", v => output = v },
 			};
 
 			try {

--- a/mcs/tools/mono-api-diff/mono-api-diff.cs
+++ b/mcs/tools/mono-api-diff/mono-api-diff.cs
@@ -25,8 +25,8 @@ namespace Mono.AssemblyCompare
 	{
 		static int Main (string [] args)
 		{
-			if (args.Length != 2) {
-				Console.WriteLine ("Usage: mono mono-api-diff.exe <assembly 1 xml> <assembly 2 xml>");
+			if (args.Length != 2 && args.Length != 3) {
+				Console.WriteLine ("Usage: mono mono-api-diff.exe <assembly 1 xml> <assembly 2 xml> [<output xml>]");
 				return 1;
 			}
 
@@ -34,7 +34,14 @@ namespace Mono.AssemblyCompare
 			XMLAssembly mono = CreateXMLAssembly (args [1]);
 			XmlDocument doc = ms.CompareAndGetDocument (mono);
 
-			XmlTextWriter writer = new XmlTextWriter (Console.Out);
+			string output = null;
+			if (args.Length == 3)
+				output = args [2];
+			StreamWriter outputStream = null;
+			if (!string.IsNullOrEmpty (output))
+				outputStream = new StreamWriter (output);
+
+			XmlTextWriter writer = new XmlTextWriter (outputStream ?? Console.Out);
 			writer.Formatting = Formatting.Indented;
 			doc.WriteTo (writer);
 

--- a/mcs/tools/mono-api-diff/mono-api-diff.cs
+++ b/mcs/tools/mono-api-diff/mono-api-diff.cs
@@ -61,9 +61,10 @@ namespace Mono.AssemblyCompare
 			if (!string.IsNullOrEmpty (output))
 				outputStream = new StreamWriter (output);
 
-			XmlTextWriter writer = new XmlTextWriter (outputStream ?? Console.Out);
-			writer.Formatting = Formatting.Indented;
-			doc.WriteTo (writer);
+			using (XmlTextWriter writer = new XmlTextWriter (outputStream ?? Console.Out)) {
+				writer.Formatting = Formatting.Indented;
+				doc.WriteTo (writer);
+			}
 
 			return 0;
 		}

--- a/mcs/tools/mono-api-diff/mono-api-diff.csproj
+++ b/mcs/tools/mono-api-diff/mono-api-diff.csproj
@@ -43,6 +43,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- @BUILT_SOURCES@ -->
   <ItemGroup>
+    <Compile Include="..\..\class\Mono.Options\Mono.Options\Options.cs" />
     <Compile Include="mono-api-diff.cs" />
   </ItemGroup>
   <ItemGroup></ItemGroup>

--- a/mcs/tools/mono-api-diff/mono-api-diff.exe.sources
+++ b/mcs/tools/mono-api-diff/mono-api-diff.exe.sources
@@ -1,1 +1,2 @@
 mono-api-diff.cs
+../../class/Mono.Options/Mono.Options/Options.cs


### PR DESCRIPTION
Rather than always writing to the std out, provide an option to write to a file. This makes things easier for tooling by not requiring `RedirectStandardOutput = true`