### PR TITLE
[2018-06] [sdb] Add back the mono_debugger_agent_parse_options () API function …

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -10648,4 +10648,10 @@ mono_debugger_agent_init (void)
 	mini_install_dbg_callbacks (&cbs);
 }
 
+void
+mono_debugger_agent_parse_options (char *options)
+{
+	sdb_options = options;
+}
+
 #endif /* DISABLE_SDB */

--- a/mono/mini/debugger-agent.h
+++ b/mono/mini/debugger-agent.h
@@ -33,6 +33,9 @@ struct _MonoDebuggerCallbacks {
 MONO_API void
 mono_debugger_agent_init (void);
 
+MONO_API void
+mono_debugger_agent_parse_options (char *options);
+
 void
 mono_debugger_agent_stub_init (void);
 


### PR DESCRIPTION
Backport of #9519.

/cc @marek-safar