### PR TITLE
[runtime] Make sigterm dumper connect to merp

### DIFF
--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -226,12 +226,20 @@ MONO_SIG_HANDLER_FUNC (static, sigterm_signal_handler)
 	// die. The dump ends with the exit(1) below
 	MonoContext mctx;
 	gchar *output = NULL;
+	MonoStackHash hashes;
 	mono_sigctx_to_monoctx (ctx, &mctx);
-	if (!mono_threads_summarize (&mctx, &output, NULL))
+	if (!mono_threads_summarize (&mctx, &output, &hashes))
 		g_assert_not_reached ();
 
-	// Only the dumping-supervisor thread exits mono_thread_summarize
-	MOSTLY_ASYNC_SAFE_PRINTF("Unhandled exception dump: \n######\n%s\n######\n", output);
+	if (mono_merp_enabled ()) {
+		pid_t crashed_pid = getpid ();
+		char *full_version = mono_get_runtime_build_info ();
+		mono_merp_invoke (crashed_pid, "SIGTERM", output, &hashes, full_version);
+	} else {
+		// Only the dumping-supervisor thread exits mono_thread_summarize
+		MOSTLY_ASYNC_SAFE_PRINTF("Unhandled exception dump: \n######\n%s\n######\n", output);
+		g_sleep (3);
+	}
 
 	mono_chain_signal (MONO_SIG_HANDLER_PARAMS);
 	exit (1);


### PR DESCRIPTION
It's currently used as part of the cooperative machinery but if you use it as an entry point / to trigger the dump in a non-crashing program, you won't see merp trigger. 