### PR TITLE
GetLastError does not warrant changing GC mode. It is one instruction, …

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -4940,7 +4940,6 @@ mono_marshal_set_last_error (void)
 	/* This icall is called just after a P/Invoke call before the P/Invoke
 	 * wrapper transitions the runtime back to running mode. */
 #ifdef WIN32
-	MONO_REQ_GC_SAFE_MODE;
 	mono_native_tls_set_value (last_error_tls_id, GINT_TO_POINTER (GetLastError ()));
 #else
 	mono_native_tls_set_value (last_error_tls_id, GINT_TO_POINTER (errno));
@@ -4953,7 +4952,6 @@ mono_marshal_set_last_error_windows (int error)
 #ifdef WIN32
 	/* This icall is called just after a P/Invoke call before the P/Invoke
 	 * wrapper transitions the runtime back to running mode. */
-	MONO_REQ_GC_SAFE_MODE;
 	mono_native_tls_set_value (last_error_tls_id, GINT_TO_POINTER (error));
 #endif
 }


### PR DESCRIPTION
…not a syscall, and call/ret.

Getting/setting thread locals generally is not either, except for the rare expansion path (unless
we switch to __declspec(thread) which is never a syscall and is much faster.)
