### PR TITLE
[2018-06] [runtime] Allow --enable-llvm to work with newer llvm versions as well.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3746,6 +3746,9 @@ if test "x$enable_llvm" = "xyes"; then
       if test "x$LLVM_CONFIG" = "xno"; then
    	     AC_MSG_ERROR([llvm-config not found.])
       fi
+      if test "x$with_llvm" = "x"; then
+         with_llvm=`$LLVM_CONFIG --prefix`
+      fi
    fi
 
    llvm_codegen="x86codegen"


### PR DESCRIPTION
Backport of #9186.

/cc @vargaz