### PR TITLE
Use __declspec(thread) with Visual C++, and __thread with Win32/gcc,

### DIFF
--- a/mono/mini/trace.c
+++ b/mono/mini/trace.c
@@ -60,6 +60,7 @@ MonoCallSpec *mono_trace_set_options (const char *options)
 	return &trace_spec;
 }
 
+// comment only
 static
 #ifdef HAVE_KW_THREAD
 __thread 


### PR DESCRIPTION
instead of much slower TlsGetValue / TlsSetValue.