### PR TITLE
Use __declspec(thread) with Visual C++, and __thread with Win32/gcc,

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4751,7 +4751,7 @@ fi
 AM_CONDITIONAL(DISABLE_ICALL_TABLES, test x$icall_tables = xno)
 
 if test "x$with_tls" = "x__thread"; then
-	AC_DEFINE(HAVE_KW_THREAD, 1, [Have __thread keyword])
+	AC_DEFINE(HAVE_KW_THREAD, __thread, [Have __thread keyword])
 	# Pass the information to libgc
 	CPPFLAGS="$CPPFLAGS -DUSE_COMPILER_TLS"
 	AC_MSG_CHECKING(if the tls_model attribute is supported)

--- a/configure.ac
+++ b/configure.ac
@@ -4751,7 +4751,7 @@ fi
 AM_CONDITIONAL(DISABLE_ICALL_TABLES, test x$icall_tables = xno)
 
 if test "x$with_tls" = "x__thread"; then
-	AC_DEFINE(HAVE_KW_THREAD, __thread, [Have __thread keyword])
+	AC_DEFINE(MONO_KEYWORD_THREAD, __thread, [Have __thread keyword])
 	# Pass the information to libgc
 	CPPFLAGS="$CPPFLAGS -DUSE_COMPILER_TLS"
 	AC_MSG_CHECKING(if the tls_model attribute is supported)

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1514,11 +1514,11 @@ mono_get_version_info (void)
 	GString *output;
 	output = g_string_new ("");
 
-#ifdef HAVE_KW_THREAD
+#ifdef MONO_KEYWORD_THREAD
 	g_string_append_printf (output, "\tTLS:           __thread\n");
 #else
 	g_string_append_printf (output, "\tTLS:           \n");
-#endif /* HAVE_KW_THREAD */
+#endif /* MONO_KEYWORD_THREAD */
 
 #ifdef MONO_ARCH_SIGSEGV_ON_ALTSTACK
 	g_string_append_printf (output, "\tSIGSEGV:       altstack\n");

--- a/mono/mini/trace.c
+++ b/mono/mini/trace.c
@@ -62,7 +62,7 @@ MonoCallSpec *mono_trace_set_options (const char *options)
 
 static
 #ifdef HAVE_KW_THREAD
-__thread 
+HAVE_KW_THREAD
 #endif
 int indent_level = 0;
 static guint64 start_time = 0;

--- a/mono/mini/trace.c
+++ b/mono/mini/trace.c
@@ -61,8 +61,8 @@ MonoCallSpec *mono_trace_set_options (const char *options)
 }
 
 static
-#ifdef HAVE_KW_THREAD
-HAVE_KW_THREAD
+#ifdef MONO_KEYWORD_THREAD
+MONO_KEYWORD_THREAD
 #endif
 int indent_level = 0;
 static guint64 start_time = 0;

--- a/mono/utils/gc_wrapper.h
+++ b/mono/utils/gc_wrapper.h
@@ -27,7 +27,8 @@
 	 * it if it is the included one.
 	 */
 #ifndef HOST_WIN32 // FIXME?
-#	if defined(HAVE_KW_THREAD) && !defined(__powerpc__)
+#	if defined(MONO_KEYWORD_THREAD) && !defined(__powerpc__)
+	
         /* The local alloc stuff is in pthread_support.c, but solaris uses solaris_threads.c */
         /* It is also disabled on solaris/x86 by libgc/configure.ac */
         /* 

--- a/mono/utils/gc_wrapper.h
+++ b/mono/utils/gc_wrapper.h
@@ -26,7 +26,7 @@
 	 * We had to fix a bug with include order in libgc, so only do
 	 * it if it is the included one.
 	 */
-	
+#ifndef HOST_WIN32 // FIXME?
 #	if defined(HAVE_KW_THREAD) && !defined(__powerpc__)
         /* The local alloc stuff is in pthread_support.c, but solaris uses solaris_threads.c */
         /* It is also disabled on solaris/x86 by libgc/configure.ac */
@@ -38,6 +38,7 @@
 #		    define GC_REDIRECT_TO_LOCAL
 #       endif
 #	endif
+#endif // HOST_WIN32
 
 #	define GC_INSIDE_DLL
 #	include <gc.h>

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -275,11 +275,11 @@ mono_native_state_add_version (JsonWriter *writer)
 
 	mono_json_writer_indent (writer);
 	mono_json_writer_object_key(writer, "tlc");
-#ifdef HAVE_KW_THREAD
+#ifdef MONO_KEYWORD_THREAD
 	mono_json_writer_printf (writer, "\"__thread\",\n");
 #else
 	mono_json_writer_printf (writer, "\"normal\",\n");
-#endif /* HAVE_KW_THREAD */
+#endif /* MONO_KEYWORD_THREAD */
 
 	mono_json_writer_indent (writer);
 	mono_json_writer_object_key(writer, "sigsgev");

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -65,8 +65,8 @@ static size_t thread_info_size;
 static MonoThreadInfoCallbacks threads_callbacks;
 static MonoThreadInfoRuntimeCallbacks runtime_callbacks;
 static MonoNativeTlsKey thread_info_key, thread_exited_key;
-#ifdef HAVE_KW_THREAD
-static HAVE_KW_THREAD gint32 tls_small_id = -1;
+#ifdef MONO_KEYWORD_THREAD
+static MONO_KEYWORD_THREAD gint32 tls_small_id = -1;
 #else
 static MonoNativeTlsKey small_id_key;
 #endif
@@ -406,7 +406,7 @@ mono_thread_info_register_small_id (void)
 		return small_id;
 
 	small_id = mono_thread_small_id_alloc ();
-#ifdef HAVE_KW_THREAD
+#ifdef MONO_KEYWORD_THREAD
 	tls_small_id = small_id;
 #else
 	mono_native_tls_set_value (small_id_key, GUINT_TO_POINTER (small_id + 1));
@@ -521,7 +521,7 @@ unregister_thread (void *arg)
 	 * TLS destruction order is not reliable so small_id might be cleaned up
 	 * before us.
 	 */
-#ifndef HAVE_KW_THREAD
+#ifndef MONO_KEYWORD_THREAD
 	mono_native_tls_set_value (small_id_key, GUINT_TO_POINTER (info->small_id + 1));
 #endif
 
@@ -640,7 +640,7 @@ mono_thread_info_current (void)
 int
 mono_thread_info_get_small_id (void)
 {
-#ifdef HAVE_KW_THREAD
+#ifdef MONO_KEYWORD_THREAD
 	return tls_small_id;
 #else
 	gpointer val = mono_native_tls_get_value (small_id_key);
@@ -886,7 +886,7 @@ mono_thread_info_init (size_t info_size)
 
 	g_assert (res);
 
-#ifndef HAVE_KW_THREAD
+#ifndef MONO_KEYWORD_THREAD
 	res = mono_native_tls_alloc (&small_id_key, NULL);
 #endif
 	g_assert (res);

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -66,7 +66,7 @@ static MonoThreadInfoCallbacks threads_callbacks;
 static MonoThreadInfoRuntimeCallbacks runtime_callbacks;
 static MonoNativeTlsKey thread_info_key, thread_exited_key;
 #ifdef HAVE_KW_THREAD
-static __thread gint32 tls_small_id = -1;
+static HAVE_KW_THREAD gint32 tls_small_id = -1;
 #else
 static MonoNativeTlsKey small_id_key;
 #endif

--- a/mono/utils/mono-tls.c
+++ b/mono/utils/mono-tls.c
@@ -13,9 +13,10 @@
 #include "mono-tls.h"
 
 /*
- * On all platforms we should be able to use either __thread or pthread/TlsGetValue.
+ * On all platforms we should be able to use either __thread or __declspec (thread)
+ * or pthread/TlsGetValue.
  * Certain platforms will support fast tls only when using one of the thread local
- * storage backends. By default this is __thread if we have HAVE_KW_THREAD defined.
+ * storage backends. By default this is __thread if we have MONO_KEYWORD_THREAD defined.
  *
  * By default all platforms will call into these native getters whenever they need
  * to get a tls value. On certain platforms we can try to be faster than this and
@@ -35,7 +36,7 @@
  * So far, we never supported inlined fast tls on full-aot systems.
  */
 
-#ifdef USE_KW_THREAD
+#ifdef MONO_KEYWORD_THREAD
 
 /* tls attribute */
 #if HAVE_TLS_MODEL_ATTR
@@ -159,12 +160,12 @@
 
 /* Tls variables for each MonoTlsKey */
 
-static HAVE_KW_THREAD gpointer mono_tls_thread MONO_TLS_FAST;
-static HAVE_KW_THREAD gpointer mono_tls_jit_tls MONO_TLS_FAST;
-static HAVE_KW_THREAD gpointer mono_tls_domain MONO_TLS_FAST;
-static HAVE_KW_THREAD gpointer mono_tls_lmf MONO_TLS_FAST;
-static HAVE_KW_THREAD gpointer mono_tls_sgen_thread_info MONO_TLS_FAST;
-static HAVE_KW_THREAD gpointer mono_tls_lmf_addr MONO_TLS_FAST;
+static MONO_KEYWORD_THREAD gpointer mono_tls_thread MONO_TLS_FAST;
+static MONO_KEYWORD_THREAD gpointer mono_tls_jit_tls MONO_TLS_FAST;
+static MONO_KEYWORD_THREAD gpointer mono_tls_domain MONO_TLS_FAST;
+static MONO_KEYWORD_THREAD gpointer mono_tls_lmf MONO_TLS_FAST;
+static MONO_KEYWORD_THREAD gpointer mono_tls_sgen_thread_info MONO_TLS_FAST;
+static MONO_KEYWORD_THREAD gpointer mono_tls_lmf_addr MONO_TLS_FAST;
 
 #else
 
@@ -186,7 +187,7 @@ static MonoNativeTlsKey mono_tls_key_lmf_addr;
 
 static gint32 tls_offsets [TLS_KEY_NUM];
 
-#ifdef USE_KW_THREAD
+#ifdef MONO_KEYWORD_THREAD
 #define MONO_TLS_GET_VALUE(tls_var,tls_key) (tls_var)
 #define MONO_TLS_SET_VALUE(tls_var,tls_key,value) (tls_var = value)
 #else
@@ -197,7 +198,7 @@ static gint32 tls_offsets [TLS_KEY_NUM];
 void
 mono_tls_init_gc_keys (void)
 {
-#ifdef USE_KW_THREAD
+#ifdef MONO_KEYWORD_THREAD
 	MONO_THREAD_VAR_OFFSET (mono_tls_sgen_thread_info, tls_offsets [TLS_KEY_SGEN_THREAD_INFO]);
 #else
 	mono_native_tls_alloc (&mono_tls_key_sgen_thread_info, NULL);
@@ -208,7 +209,7 @@ mono_tls_init_gc_keys (void)
 void
 mono_tls_init_runtime_keys (void)
 {
-#ifdef USE_KW_THREAD
+#ifdef MONO_KEYWORD_THREAD
 	MONO_THREAD_VAR_OFFSET (mono_tls_thread, tls_offsets [TLS_KEY_THREAD]);
 	MONO_THREAD_VAR_OFFSET (mono_tls_jit_tls, tls_offsets [TLS_KEY_JIT_TLS]);
 	MONO_THREAD_VAR_OFFSET (mono_tls_domain, tls_offsets [TLS_KEY_DOMAIN]);
@@ -228,7 +229,7 @@ mono_tls_init_runtime_keys (void)
 void
 mono_tls_free_keys (void)
 {
-#ifndef USE_KW_THREAD
+#ifndef MONO_KEYWORD_THREAD
 	mono_native_tls_free (mono_tls_key_thread);
 	mono_native_tls_free (mono_tls_key_jit_tls);
 	mono_native_tls_free (mono_tls_key_domain);

--- a/mono/utils/mono-tls.c
+++ b/mono/utils/mono-tls.c
@@ -159,12 +159,12 @@
 
 /* Tls variables for each MonoTlsKey */
 
-static __thread gpointer mono_tls_thread MONO_TLS_FAST;
-static __thread gpointer mono_tls_jit_tls MONO_TLS_FAST;
-static __thread gpointer mono_tls_domain MONO_TLS_FAST;
-static __thread gpointer mono_tls_lmf MONO_TLS_FAST;
-static __thread gpointer mono_tls_sgen_thread_info MONO_TLS_FAST;
-static __thread gpointer mono_tls_lmf_addr MONO_TLS_FAST;
+static HAVE_KW_THREAD gpointer mono_tls_thread MONO_TLS_FAST;
+static HAVE_KW_THREAD gpointer mono_tls_jit_tls MONO_TLS_FAST;
+static HAVE_KW_THREAD gpointer mono_tls_domain MONO_TLS_FAST;
+static HAVE_KW_THREAD gpointer mono_tls_lmf MONO_TLS_FAST;
+static HAVE_KW_THREAD gpointer mono_tls_sgen_thread_info MONO_TLS_FAST;
+static HAVE_KW_THREAD gpointer mono_tls_lmf_addr MONO_TLS_FAST;
 
 #else
 

--- a/mono/utils/mono-tls.h
+++ b/mono/utils/mono-tls.h
@@ -28,10 +28,6 @@ typedef enum {
 	TLS_KEY_NUM = 5
 } MonoTlsKey;
 
-#ifdef HAVE_KW_THREAD
-#define USE_KW_THREAD
-#endif
-
 #ifdef HOST_WIN32
 
 #include <windows.h>

--- a/winconfig.h
+++ b/winconfig.h
@@ -290,9 +290,9 @@
 
 /* Have __thread keyword */
 #ifdef _MSC_VER
-#define HAVE_KW_THREAD __declspec (thread)
+#define MONO_KEYWORD_THREAD __declspec (thread)
 #else
-#define HAVE_KW_THREAD __thread
+#define MONO_KEYWORD_THREAD __thread
 #endif
 
 /* Have large file support */

--- a/winconfig.h
+++ b/winconfig.h
@@ -289,7 +289,11 @@
 /* #undef HAVE_KQUEUE */
 
 /* Have __thread keyword */
-/* #undef HAVE_KW_THREAD */
+#ifdef _MSC_VER
+#define HAVE_KW_THREAD __declspec (thread)
+#else
+#define HAVE_KW_THREAD __thread
+#endif
 
 /* Have large file support */
 /* #undef HAVE_LARGE_FILE_SUPPORT */


### PR DESCRIPTION
instead of slower TlsGetValue / TlsSetValue

Alternative proposal would be use fiber locals, which we do sometimes.