### PR TITLE
[2018-06] [corlib] Include all span helpers optimizations (#9548)

### DIFF
--- a/mcs/class/corlib/corlib.csproj
+++ b/mcs/class/corlib/corlib.csproj
@@ -232,6 +232,7 @@
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\SpanDebugView.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\SpanHelpers.BinarySearch.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\SpanHelpers.Byte.cs" />
+    <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\SpanHelpers.Char.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\SpanHelpers.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\SpanHelpers.T.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\String.Comparison.cs" />

--- a/mcs/class/corlib/corlib.dll.sources
+++ b/mcs/class/corlib/corlib.dll.sources
@@ -1623,10 +1623,7 @@ corert/RuntimeAugments.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/Span.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/Span.Fast.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/SpanDebugView.cs
-../../../external/corefx/src/Common/src/CoreLib/System/SpanHelpers.cs
-../../../external/corefx/src/Common/src/CoreLib/System/SpanHelpers.BinarySearch.cs
-../../../external/corefx/src/Common/src/CoreLib/System/SpanHelpers.Byte.cs
-../../../external/corefx/src/Common/src/CoreLib/System/SpanHelpers.T.cs
+../../../external/corefx/src/Common/src/CoreLib/System/SpanHelpers*.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/String.Comparison.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/String.Manipulation.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/String.Searching.cs


### PR DESCRIPTION
backport of https://github.com/mono/mono/pull/9548