### PR TITLE
Fix LogcatTextWriter writing garbage and/or crashing

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7959,7 +7959,7 @@ ves_icall_System_Runtime_InteropServices_WindowsRuntime_UnsafeNativeMethods_Wind
 ICALL_EXPORT void
 ves_icall_System_IO_LogcatTextWriter_Log (const char *appname, gint32 level, const char *message)
 {
-	g_log (appname, (GLogLevelFlags)level, message);
+	g_log (appname, (GLogLevelFlags)level, "%s", message);
 }
 
 static MonoIcallTableCallbacks icall_table;


### PR DESCRIPTION
This issue was introduced by https://github.com/mono/mono/commit/984f6484666c2ee6fefec949c81fdff1189c9488#diff-eba0fd0052bf3ec9dd60f2f3e90f19e1 which started getting used in Xamarin.Android 8.3.x.

The logger (used by Console.WriteLine on Android) would pass the message string directly to vasprintf, so using anything from the printf formatting logic (like url-encoded strings) would at best print random garbage, and at worst would crash, depending on what's located on the stack at that moment.

Fixes https://github.com/xamarin/xamarin-android/issues/1951
