### PR TITLE
[runtime] Make sigterm dumper send file to merp

### DIFF
--- a/mono/utils/mono-merp.c
+++ b/mono/utils/mono-merp.c
@@ -170,8 +170,8 @@ get_merp_exctype (MERPExcType exc)
 		case MERP_EXC_HANG: 
 			return "0x02000000";
 		case MERP_EXC_NONE:
-			// Exception type is optional
-			return "";
+			// Exception type documented as optional, not optional
+			g_assert_not_reached ();
 		default:
 			g_assert_not_reached ();
 	}
@@ -191,6 +191,11 @@ parse_exception_type (const char *signal)
 
 	if (!strcmp (signal, "SIGABRT"))
 		return MERP_EXC_SIGABRT;
+
+	// Force quit == hang?
+	// We need a default for this
+	if (!strcmp (signal, "SIGTERM"))
+		return MERP_EXC_HANG;
 
 	// FIXME: There are no other such signal
 	// strings passed to mono_handle_native_crash at the


### PR DESCRIPTION
Note that all of these changes that will change control flow and symbol visibility live behind an#ifdef TARGET_OSX. Only OSX CI need be considered here.