### PR TITLE
Add GC Unsafe thread state transitions to MONO_API functions - Fourth Edition

### DIFF
--- a/mono/dis/dump.c
+++ b/mono/dis/dump.c
@@ -898,7 +898,7 @@ handle_enum:
 			break;
 		}
 		case MONO_TYPE_VALUETYPE:
-			if (mono_class_is_enum (sig->params [i]->data.klass)) {
+			if (m_class_is_enumtype (sig->params [i]->data.klass)) {
 				type = mono_class_enum_basetype (sig->params [i]->data.klass)->type;
 				goto handle_enum;
 			} else {

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -575,9 +575,11 @@ void
 mono_domain_set_config (MonoDomain *domain, const char *base_dir, const char *config_file_name)
 {
 	HANDLE_FUNCTION_ENTER ();
+	MONO_ENTER_GC_UNSAFE;
 	ERROR_DECL (error);
 	mono_domain_set_config_checked (domain, base_dir, config_file_name, error);
 	mono_error_cleanup (error);
+	MONO_EXIT_GC_UNSAFE;
 	HANDLE_FUNCTION_RETURN ();
 }
 

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -896,8 +896,9 @@ mono_domain_set (MonoDomain *domain, gboolean force)
 	if (!force && domain->state == MONO_APPDOMAIN_UNLOADED)
 		return FALSE;
 
+	MONO_ENTER_GC_UNSAFE;
 	mono_domain_set_internal (domain);
-
+	MONO_EXIT_GC_UNSAFE;
 	return TRUE;
 }
 

--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -3810,7 +3810,7 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 			gpointer iter = NULL;
 			guint32 first_field_idx = mono_class_get_first_field_idx (p);
 
-			while ((field = mono_class_get_fields (p, &iter))) {
+			while ((field = mono_class_get_fields_internal (p, &iter))) {
 				guint32 field_idx = first_field_idx + (field - p->fields);
 				if (MONO_TYPE_IS_REFERENCE (field->type) && mono_assembly_is_weak_field (p->image, field_idx + 1)) {
 					has_weak_fields = TRUE;

--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -2078,8 +2078,8 @@ foreach_override (gpointer key, gpointer value, gpointer user_data) {
 	MonoClass *override_class = mono_method_get_class (override);
 	
 	printf ("  Method '%s.%s:%s' has override '%s.%s:%s'\n",
-			mono_class_get_namespace (method_class), mono_class_get_name (method_class), mono_method_get_name (method),
-			mono_class_get_namespace (override_class), mono_class_get_name (override_class), mono_method_get_name (override));
+			m_class_get_name_space (method_class), m_class_get_name (method_class), mono_method_get_name (method),
+			m_class_get_name_space (override_class), m_class_get_name (override_class), mono_method_get_name (override));
 }
 static void
 print_overrides (GHashTable *override_map, const char *message) {

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1210,6 +1210,9 @@ MonoType*
 mono_field_get_type_checked (MonoClassField *field, MonoError *error);
 
 MonoClassField*
+mono_class_get_fields_internal (MonoClass* klass, gpointer *iter);
+
+MonoClassField*
 mono_class_get_fields_lazy (MonoClass* klass, gpointer *iter);
 
 gboolean

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -4417,6 +4417,16 @@ mono_class_num_events (MonoClass *klass)
 MonoClassField*
 mono_class_get_fields (MonoClass* klass, gpointer *iter)
 {
+	MonoClassField *result;
+	MONO_ENTER_GC_UNSAFE;
+	result = mono_class_get_fields_internal (klass, iter);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
+}
+
+MonoClassField*
+mono_class_get_fields_internal (MonoClass *klass, gpointer *iter)
+{
 	MonoClassField* field;
 	if (!iter)
 		return NULL;
@@ -5671,7 +5681,7 @@ mono_class_is_valid_enum (MonoClass *klass)
 	if (!mono_class_is_auto_layout (klass))
 		return FALSE;
 
-	while ((field = mono_class_get_fields (klass, &iter))) {
+	while ((field = mono_class_get_fields_internal (klass, &iter))) {
 		if (!(field->type->attrs & FIELD_ATTRIBUTE_STATIC)) {
 			if (found_base_field)
 				return FALSE;

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -4251,7 +4251,11 @@ mono_class_enum_basetype (MonoClass *klass)
 MonoClass*
 mono_class_get_parent (MonoClass *klass)
 {
-	return m_class_get_parent (klass);
+	MonoClass *result;
+	MONO_ENTER_GC_UNSAFE;
+	result = m_class_get_parent (klass);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
 }
 
 /**

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -4221,7 +4221,11 @@ mono_class_is_valuetype (MonoClass *klass)
 gboolean
 mono_class_is_enum (MonoClass *klass)
 {
-	return m_class_is_enumtype (klass);
+	gboolean result;
+	MONO_ENTER_GC_UNSAFE;
+	result = m_class_is_enumtype (klass);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
 }
 
 /**

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -4188,7 +4188,11 @@ mono_class_get_image (MonoClass *klass)
 MonoClass*
 mono_class_get_element_class (MonoClass *klass)
 {
-	return m_class_get_element_class (klass);
+	MonoClass *result;
+	MONO_ENTER_GC_UNSAFE;
+	result = m_class_get_element_class (klass);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
 }
 
 /**

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -4203,7 +4203,11 @@ mono_class_get_element_class (MonoClass *klass)
 gboolean
 mono_class_is_valuetype (MonoClass *klass)
 {
-	return m_class_is_valuetype (klass);
+	gboolean result;
+	MONO_ENTER_GC_UNSAFE;
+	result = m_class_is_valuetype (klass);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
 }
 
 /**

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -4291,7 +4291,11 @@ mono_class_get_rank (MonoClass *klass)
 const char*
 mono_class_get_name (MonoClass *klass)
 {
-	return m_class_get_name (klass);
+	const char *result;
+	MONO_ENTER_GC_UNSAFE;
+	result = m_class_get_name (klass);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
 }
 
 /**
@@ -4303,7 +4307,10 @@ mono_class_get_name (MonoClass *klass)
 const char*
 mono_class_get_namespace (MonoClass *klass)
 {
-	return m_class_get_name_space (klass);
+	const char *result;
+	MONO_ENTER_GC_UNSAFE;
+	result = m_class_get_name_space (klass);
+	MONO_EXIT_GC_UNSAFE;
 }
 
 /**

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -4690,7 +4690,11 @@ mono_class_get_nested_types (MonoClass* klass, gpointer *iter)
 mono_bool
 mono_class_is_delegate (MonoClass *klass)
 {
-	return m_class_is_delegate (klass);
+	mono_bool result;
+	MONO_ENTER_GC_UNSAFE;
+	result = m_class_is_delegate (klass);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
 }
 
 /**

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -214,6 +214,7 @@ mono_class_get_interfaces    (MonoClass* klass, void **iter);
 MONO_API MonoClass*
 mono_class_get_nested_types  (MonoClass* klass, void **iter);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API mono_bool
 mono_class_is_delegate       (MonoClass* klass);
 

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -192,6 +192,7 @@ mono_class_num_properties    (MonoClass *klass);
 MONO_API int
 mono_class_num_events        (MonoClass *klass);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoClassField*
 mono_class_get_fields        (MonoClass* klass, void **iter);
 

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -144,6 +144,7 @@ mono_class_get_image         (MonoClass *klass);
 MONO_API MonoClass*
 mono_class_get_element_class (MonoClass *klass);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API mono_bool
 mono_class_is_valuetype      (MonoClass *klass);
 

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -165,9 +165,11 @@ mono_class_get_rank          (MonoClass *klass);
 MONO_API uint32_t
 mono_class_get_flags         (MonoClass *klass);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API const char*
 mono_class_get_name          (MonoClass *klass);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API const char*
 mono_class_get_namespace     (MonoClass *klass);
 

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -141,6 +141,7 @@ mono_type_get_underlying_type (MonoType *type);
 MONO_API MonoImage*
 mono_class_get_image         (MonoClass *klass);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoClass*
 mono_class_get_element_class (MonoClass *klass);
 

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -148,6 +148,7 @@ MONO_RT_EXTERNAL_ONLY
 MONO_API mono_bool
 mono_class_is_valuetype      (MonoClass *klass);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API mono_bool
 mono_class_is_enum          (MonoClass *klass);
 

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -153,6 +153,7 @@ mono_class_is_enum          (MonoClass *klass);
 MONO_API MonoType*
 mono_class_enum_basetype    (MonoClass *klass);
 
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoClass*
 mono_class_get_parent        (MonoClass *klass);
 

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -1139,7 +1139,7 @@ objval_describe (MonoClass *klass, const char *addr)
 	for (p = klass; p != NULL; p = p->parent) {
 		gpointer iter = NULL;
 		int printed_header = FALSE;
-		while ((field = mono_class_get_fields (p, &iter))) {
+		while ((field = mono_class_get_fields_internal (p, &iter))) {
 			if (field->type->attrs & (FIELD_ATTRIBUTE_STATIC | FIELD_ATTRIBUTE_HAS_FIELD_RVA))
 				continue;
 
@@ -1210,7 +1210,7 @@ mono_class_describe_statics (MonoClass* klass)
 
 	for (p = klass; p != NULL; p = p->parent) {
 		gpointer iter = NULL;
-		while ((field = mono_class_get_fields (p, &iter))) {
+		while ((field = mono_class_get_fields_internal (p, &iter))) {
 			if (field->type->attrs & FIELD_ATTRIBUTE_LITERAL)
 				continue;
 			if (!(field->type->attrs & (FIELD_ATTRIBUTE_STATIC | FIELD_ATTRIBUTE_HAS_FIELD_RVA)))

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -922,6 +922,7 @@ mono_domain_unset (void)
 void
 mono_domain_set_internal_with_options (MonoDomain *domain, gboolean migrate_exception)
 {
+	MONO_REQ_GC_UNSAFE_MODE;
 	MonoInternalThread *thread;
 
 	if (mono_domain_get () == domain)

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -95,6 +95,7 @@ static void reference_queue_clear_for_domain (MonoDomain *domain);
 static void mono_runtime_do_background_work (void);
 
 static MonoReferenceQueue* mono_gc_reference_queue_new_internal (mono_reference_queue_callback callback);
+static gboolean mono_gc_reference_queue_add_internal (MonoReferenceQueue *queue, MonoObject *obj, void *user_data);
 
 
 static MonoThreadInfoWaitRet
@@ -1258,6 +1259,16 @@ mono_gc_reference_queue_new_internal (mono_reference_queue_callback callback)
  */
 gboolean
 mono_gc_reference_queue_add (MonoReferenceQueue *queue, MonoObject *obj, void *user_data)
+{
+	gboolean result;
+	MONO_ENTER_GC_UNSAFE;
+	result = mono_gc_reference_queue_add_internal (queue, obj, user_data);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
+}
+
+gboolean
+mono_gc_reference_queue_add_internal (MonoReferenceQueue *queue, MonoObject *obj, void *user_data)
 {
 	RefQueueEntry *entry;
 	if (queue->should_be_deleted)

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -94,6 +94,8 @@ static void mono_reference_queue_cleanup (void);
 static void reference_queue_clear_for_domain (MonoDomain *domain);
 static void mono_runtime_do_background_work (void);
 
+static MonoReferenceQueue* mono_gc_reference_queue_new_internal (mono_reference_queue_callback callback);
+
 
 static MonoThreadInfoWaitRet
 guarded_wait (MonoThreadHandle *thread_handle, guint32 timeout, gboolean alertable)
@@ -1220,6 +1222,16 @@ reference_queue_clear_for_domain (MonoDomain *domain)
  */
 MonoReferenceQueue*
 mono_gc_reference_queue_new (mono_reference_queue_callback callback)
+{
+	MonoReferenceQueue *result;
+	MONO_ENTER_GC_UNSAFE;
+	result = mono_gc_reference_queue_new_internal (callback);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
+}
+
+MonoReferenceQueue*
+mono_gc_reference_queue_new_internal (mono_reference_queue_callback callback)
 {
 	MonoReferenceQueue *res = g_new0 (MonoReferenceQueue, 1);
 	res->callback = callback;

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1083,7 +1083,7 @@ ves_icall_System_ValueType_InternalGetHashCode (MonoObject *this_obj, MonoArray 
 	 * This way, we can avoid costly reflection operations in managed code.
 	 */
 	iter = NULL;
-	while ((field = mono_class_get_fields (klass, &iter))) {
+	while ((field = mono_class_get_fields_internal (klass, &iter))) {
 		if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
 			continue;
 		if (mono_field_is_deleted (field))
@@ -1159,7 +1159,7 @@ ves_icall_System_ValueType_Equals (MonoObject *this_obj, MonoObject *that, MonoA
 	 * managed code.
 	 */
 	iter = NULL;
-	while ((field = mono_class_get_fields (klass, &iter))) {
+	while ((field = mono_class_get_fields_internal (klass, &iter))) {
 		if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
 			continue;
 		if (mono_field_is_deleted (field))
@@ -3842,7 +3842,7 @@ ves_icall_System_Enum_GetEnumValuesAndNames (MonoReflectionTypeHandle type, Mono
 	return_val_if_nok (error, FALSE);
 
 	iter = NULL;
-	while ((field = mono_class_get_fields (enumc, &iter))) {
+	while ((field = mono_class_get_fields_internal (enumc, &iter))) {
 		get_enum_field(domain, names, values, base_type, field, &j, &previous_value, &sorted, error);
 		if (!is_ok (error))
 			break;

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -78,6 +78,10 @@ static MonoNativeTlsKey loader_lock_nest_id;
 static void dllmap_cleanup (void);
 static void cached_module_cleanup(void);
 
+static void dllmap_insert_global (const char *dll, const char *func, const char *tdll, const char *tfunc);
+static void dllmap_insert_image (MonoImage *assembly, const char *dll, const char *func, const char *tdll, const char *tfun);
+
+
 /* Class lazy loading functions */
 GENERATE_GET_CLASS_WITH_CACHE (appdomain_unloaded_exception, "System", "AppDomainUnloadedException")
 
@@ -1051,11 +1055,22 @@ mono_dllmap_lookup (MonoImage *assembly, const char *dll, const char* func, cons
 void
 mono_dllmap_insert (MonoImage *assembly, const char *dll, const char *func, const char *tdll, const char *tfunc)
 {
+	if (!assembly)
+		dllmap_insert_global (dll, func, tdll, tfunc);
+	else {
+		MONO_ENTER_GC_UNSAFE;
+		dllmap_insert_image (assembly, dll, func, tdll, tfunc);
+		MONO_EXIT_GC_UNSAFE;
+	}
+}
+
+void
+dllmap_insert_global (const char *dll, const char *func, const char *tdll, const char *tfunc)
+{
 	MonoDllMap *entry;
 
-	mono_loader_init ();
+		mono_loader_init ();
 
-	if (!assembly) {
 		entry = (MonoDllMap *)g_malloc0 (sizeof (MonoDllMap));
 		entry->dll = dll? g_strdup (dll): NULL;
 		entry->target = tdll? g_strdup (tdll): NULL;
@@ -1066,7 +1081,16 @@ mono_dllmap_insert (MonoImage *assembly, const char *dll, const char *func, cons
 		entry->next = global_dll_map;
 		global_dll_map = entry;
 		global_loader_data_unlock ();
-	} else {
+}
+
+void
+dllmap_insert_image (MonoImage *assembly, const char *dll, const char *func, const char *tdll, const char *tfunc)
+{
+	MonoDllMap *entry;
+	g_assert (assembly != NULL);
+
+		mono_loader_init ();
+
 		entry = (MonoDllMap *)mono_image_alloc0 (assembly, sizeof (MonoDllMap));
 		entry->dll = dll? mono_image_strdup (assembly, dll): NULL;
 		entry->target = tdll? mono_image_strdup (assembly, tdll): NULL;
@@ -1077,7 +1101,6 @@ mono_dllmap_insert (MonoImage *assembly, const char *dll, const char *func, cons
 		entry->next = assembly->dll_map;
 		assembly->dll_map = entry;
 		mono_image_unlock (assembly);
-	}
 }
 
 static void

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -6341,7 +6341,7 @@ emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 		if (sig->hasthis) {
 			mono_mb_emit_byte (mb, CEE_LDARG_0);
 			/* TODO support adding wrappers to non-static struct methods */
-			g_assert (!mono_class_is_valuetype(mono_method_get_class (method)));
+			g_assert (!m_class_is_valuetype (mono_method_get_class (method)));
 			mono_mb_emit_icall (mb, mono_icall_handle_new);
 		}
 		for (int i = 0; i < sig->param_count; i++) {

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -5181,7 +5181,7 @@ ves_icall_System_Runtime_InteropServices_Marshal_OffsetOf (MonoReflectionTypeHan
 		MonoClassField* field;
 		int i = 0;
 		gpointer iter = NULL;
-		while ((field = mono_class_get_fields (klass, &iter))) {
+		while ((field = mono_class_get_fields_internal (klass, &iter))) {
 			if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
 				continue;
 			if (!strcmp (fname, mono_field_get_name (field))) {
@@ -5484,7 +5484,7 @@ mono_marshal_load_type_info (MonoClass* klass)
 	mono_native_tls_set_value (load_type_info_tls_id, loads_list);
 	
 	iter = NULL;
-	while ((field = mono_class_get_fields (klass, &iter))) {
+	while ((field = mono_class_get_fields_internal (klass, &iter))) {
 		if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
 			continue;
 		if (mono_field_is_deleted (field))
@@ -5511,7 +5511,7 @@ mono_marshal_load_type_info (MonoClass* klass)
 	packing = m_class_get_packing_size (klass) ? m_class_get_packing_size (klass) : 8;
 	iter = NULL;
 	j = 0;
-	while ((field = mono_class_get_fields (klass, &iter))) {
+	while ((field = mono_class_get_fields_internal (klass, &iter))) {
 		int size;
 		guint32 align;
 		

--- a/mono/metadata/mono-hash.c
+++ b/mono/metadata/mono-hash.c
@@ -434,6 +434,7 @@ mono_g_hash_table_destroy (MonoGHashTable *hash)
 static void
 mono_g_hash_table_insert_replace (MonoGHashTable *hash, gpointer key, gpointer value, gboolean replace)
 {
+	MONO_REQ_GC_UNSAFE_MODE;
 	int slot;
 	g_return_if_fail (hash != NULL);
 
@@ -464,7 +465,9 @@ mono_g_hash_table_insert_replace (MonoGHashTable *hash, gpointer key, gpointer v
 void
 mono_g_hash_table_insert (MonoGHashTable *h, gpointer k, gpointer v)
 {
+	MONO_ENTER_GC_UNSAFE;
 	mono_g_hash_table_insert_replace (h, k, v, FALSE);
+	MONO_EXIT_GC_UNSAFE;
 }
 
 /**

--- a/mono/metadata/mono-hash.c
+++ b/mono/metadata/mono-hash.c
@@ -53,6 +53,9 @@ struct _MonoGHashTable {
 	const char *msg;
 };
 
+MonoGHashTable *
+mono_g_hash_table_new_type_internal (GHashFunc hash_func, GEqualFunc key_equal_func, MonoGHashGCType type, MonoGCRootSource source, void *key, const char *msg);
+
 #if UNUSED
 static gboolean
 test_prime (int x)
@@ -141,6 +144,18 @@ static inline int mono_g_hash_table_find_slot (MonoGHashTable *hash, const MonoO
 MonoGHashTable *
 mono_g_hash_table_new_type (GHashFunc hash_func, GEqualFunc key_equal_func, MonoGHashGCType type, MonoGCRootSource source, void *key, const char *msg)
 {
+	MonoGHashTable *result;
+	MONO_ENTER_GC_UNSAFE;
+	result = mono_g_hash_table_new_type_internal (hash_func, key_equal_func, type, source, key, msg);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
+}
+
+
+MonoGHashTable *
+mono_g_hash_table_new_type_internal (GHashFunc hash_func, GEqualFunc key_equal_func, MonoGHashGCType type, MonoGCRootSource source, void *key, const char *msg)
+{
+	MONO_REQ_GC_UNSAFE_MODE;
 	MonoGHashTable *hash;
 
 	if (!hash_func)

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -819,7 +819,7 @@ compute_class_bitmap (MonoClass *klass, gsize *bitmap, int size, int offset, int
 
 	for (p = klass; p != NULL; p = m_class_get_parent (p)) {
 		gpointer iter = NULL;
-		while ((field = mono_class_get_fields (p, &iter))) {
+		while ((field = mono_class_get_fields_internal (p, &iter))) {
 			MonoType *type;
 
 			if (static_fields) {
@@ -934,7 +934,7 @@ compute_class_non_ref_bitmap (MonoClass *klass, gsize *bitmap, int size, int off
 
 	for (p = class; p != NULL; p = p->parent) {
 		gpointer iter = NULL;
-		while ((field = mono_class_get_fields (p, &iter))) {
+		while ((field = mono_class_get_fields_internal (p, &iter))) {
 			MonoType *type;
 
 			if (field->type->attrs & (FIELD_ATTRIBUTE_STATIC | FIELD_ATTRIBUTE_HAS_FIELD_RVA))
@@ -1132,7 +1132,7 @@ mono_class_compute_gc_descriptor (MonoClass *klass)
 
 					MonoClassField *p_fields = m_class_get_fields (p);
 					MonoImage *p_image = m_class_get_image (p);
-					while ((field = mono_class_get_fields (p, &iter))) {
+					while ((field = mono_class_get_fields_internal (p, &iter))) {
 						guint32 field_idx = first_field_idx + (field - p_fields);
 						if (MONO_TYPE_IS_REFERENCE (field->type) && mono_assembly_is_weak_field (p_image, field_idx + 1)) {
 							int pos = field->offset / sizeof (gpointer);
@@ -2082,7 +2082,7 @@ mono_class_create_runtime_vtable (MonoDomain *domain, MonoClass *klass, MonoErro
 	}
 
 	iter = NULL;
-	while ((field = mono_class_get_fields (klass, &iter))) {
+	while ((field = mono_class_get_fields_internal (klass, &iter))) {
 		if (!(field->type->attrs & FIELD_ATTRIBUTE_STATIC))
 			continue;
 		if (mono_field_is_deleted (field))
@@ -2519,7 +2519,7 @@ mono_class_has_special_static_fields (MonoClass *klass)
 	gpointer iter;
 
 	iter = NULL;
-	while ((field = mono_class_get_fields (klass, &iter))) {
+	while ((field = mono_class_get_fields_internal (klass, &iter))) {
 		g_assert (field->parent == klass);
 		if (mono_class_field_is_special_static (field))
 			return TRUE;

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -8173,7 +8173,7 @@ prepare_to_string_method (MonoObject *obj, void **target)
 	method = mono_object_get_virtual_method (obj, to_string);
 
 	// Unbox value type if needed
-	if (mono_class_is_valuetype (mono_method_get_class (method))) {
+	if (m_class_is_valuetype (mono_method_get_class (method))) {
 		*target = mono_object_unbox (obj);
 	}
 	return method;

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -4227,7 +4227,7 @@ mono_reflection_resolve_object (MonoImage *image, MonoObject *obj, MonoClass **h
 			MonoClassField *inflated_field;
 			gpointer iter = NULL;
 			mono_metadata_free_type (inflated);
-			while ((inflated_field = mono_class_get_fields (klass, &iter))) {
+			while ((inflated_field = mono_class_get_fields_internal (klass, &iter))) {
 				if (!strcmp (field->name, inflated_field->name))
 					break;
 			}

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1457,6 +1457,11 @@ mono_thread_detach_if_exiting (void)
 
 		thread = mono_thread_internal_current ();
 		if (thread) {
+			// Switch to GC Unsafe thread state before detaching;
+			// don't expect to undo this switch, hence unbalanced.
+			gpointer dummy;
+			(void) mono_threads_enter_gc_unsafe_region_unbalanced (&dummy);
+
 			mono_thread_detach_internal (thread);
 			mono_thread_info_detach ();
 			return TRUE;

--- a/mono/metadata/threads.h
+++ b/mono/metadata/threads.h
@@ -55,7 +55,7 @@ MONO_API void mono_threads_request_thread_dump (void);
 
 MONO_API mono_bool mono_thread_is_foreign (MonoThread *thread);
 
-extern MONO_API mono_bool mono_thread_detach_if_exiting (void);
+extern MONO_RT_EXTERNAL_ONLY MONO_API mono_bool mono_thread_detach_if_exiting (void);
 
 MONO_END_DECLS
 

--- a/mono/metadata/verify.c
+++ b/mono/metadata/verify.c
@@ -6207,9 +6207,9 @@ verify_class_for_overlapping_reference_fields (MonoClass *klass)
 
 
 	/*We must check for stuff overlapping reference fields.
-	  The outer loop uses mono_class_get_fields to ensure that MonoClass:fields get inited.
+	  The outer loop uses mono_class_get_fields_internal to ensure that MonoClass:fields get inited.
 	*/
-	while ((field = mono_class_get_fields (klass, &iter))) {
+	while ((field = mono_class_get_fields_internal (klass, &iter))) {
 		int fieldEnd = get_field_end (field);
 		gboolean is_valuetype = !MONO_TYPE_IS_REFERENCE (field->type);
 		++i;
@@ -6261,7 +6261,7 @@ verify_class_fields (MonoClass *klass)
 	if (mono_class_is_gtd (klass))
 		context = &mono_class_get_generic_container (klass)->context;
 
-	while ((field = mono_class_get_fields (klass, &iter)) != NULL) {
+	while ((field = mono_class_get_fields_internal (klass, &iter)) != NULL) {
 		if (!mono_type_is_valid_type_in_context (field->type, context)) {
 			g_hash_table_destroy (unique_fields);
 			return FALSE;
@@ -6306,7 +6306,7 @@ verify_valuetype_layout_with_target (MonoClass *klass, MonoClass *target_class)
 	if ((type >= MONO_TYPE_BOOLEAN && type <= MONO_TYPE_R8) || (type >= MONO_TYPE_I && type <= MONO_TYPE_U))
 		return TRUE;
 
-	while ((field = mono_class_get_fields (klass, &iter)) != NULL) {
+	while ((field = mono_class_get_fields_internal (klass, &iter)) != NULL) {
 		if (!field->type)
 			return FALSE;
 

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -4931,7 +4931,7 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 		MonoGenericContext ctx;
 		MonoType *args [16];
 
-		if (mono_class_is_enum (tclass)) {
+		if (m_class_is_enumtype (tclass)) {
 			MonoClass *enum_comparer_inst;
 			ERROR_DECL (error);
 
@@ -4953,7 +4953,7 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 		MonoGenericContext ctx;
 		MonoType *args [16];
 
-		if (mono_class_is_enum (tclass)) {
+		if (m_class_is_enumtype (tclass)) {
 			MonoClass *comparer_inst;
 			ERROR_DECL (error);
 

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -3925,7 +3925,7 @@ can_marshal_struct (MonoClass *klass)
 	info = mono_marshal_load_type_info (klass);
 
 	/* Only allow a few field types to avoid asserts in the marshalling code */
-	while ((field = mono_class_get_fields (klass, &iter))) {
+	while ((field = mono_class_get_fields_internal (klass, &iter))) {
 		if ((field->type->attrs & FIELD_ATTRIBUTE_STATIC))
 			continue;
 
@@ -4800,7 +4800,7 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 	}
 
 	iter = NULL;
-	while ((field = mono_class_get_fields (klass, &iter))) {
+	while ((field = mono_class_get_fields_internal (klass, &iter))) {
 		if (field->type->type == MONO_TYPE_GENERICINST)
 			add_generic_class_with_depth (acfg, mono_class_from_mono_type (field->type), depth + 1, "field");
 	}

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -5239,7 +5239,7 @@ buffer_add_value_full (Buffer *buf, MonoType *t, void *addr, MonoDomain *domain,
 
 		nfields = 0;
 		iter = NULL;
-		while ((f = mono_class_get_fields (klass, &iter))) {
+		while ((f = mono_class_get_fields_internal (klass, &iter))) {
 			if (f->type->attrs & FIELD_ATTRIBUTE_STATIC)
 				continue;
 			if (mono_field_is_deleted (f))
@@ -5249,7 +5249,7 @@ buffer_add_value_full (Buffer *buf, MonoType *t, void *addr, MonoDomain *domain,
 		buffer_add_int (buf, nfields);
 
 		iter = NULL;
-		while ((f = mono_class_get_fields (klass, &iter))) {
+		while ((f = mono_class_get_fields_internal (klass, &iter))) {
 			if (f->type->attrs & FIELD_ATTRIBUTE_STATIC)
 				continue;
 			if (mono_field_is_deleted (f))
@@ -5332,7 +5332,7 @@ decode_vtype (MonoType *t, MonoDomain *domain, guint8 *addr, guint8 *buf, guint8
 	}
 
 	nfields = decode_int (buf, &buf, limit);
-	while ((f = mono_class_get_fields (klass, &iter))) {
+	while ((f = mono_class_get_fields_internal (klass, &iter))) {
 		if (f->type->attrs & FIELD_ATTRIBUTE_STATIC)
 			continue;
 		if (mono_field_is_deleted (f))
@@ -7601,7 +7601,7 @@ type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint
 
 		buffer_add_int (buf, nfields);
 
-		while ((f = mono_class_get_fields (klass, &iter))) {
+		while ((f = mono_class_get_fields_internal (klass, &iter))) {
 			buffer_add_fieldid (buf, domain, f);
 			buffer_add_string (buf, f->name);
 			buffer_add_typeid (buf, domain, mono_class_from_mono_type (f->type));

--- a/mono/mini/dwarfwriter.c
+++ b/mono/mini/dwarfwriter.c
@@ -981,7 +981,7 @@ emit_class_dwarf_info (MonoDwarfWriter *w, MonoClass *klass, gboolean vtype)
 
 		/* Emit enum values */
 		iter = NULL;
-		while ((field = mono_class_get_fields (klass, &iter))) {
+		while ((field = mono_class_get_fields_internal (klass, &iter))) {
 			const char *p;
 			MonoTypeEnum def_type;
 
@@ -1040,7 +1040,7 @@ emit_class_dwarf_info (MonoDwarfWriter *w, MonoClass *klass, gboolean vtype)
 
 		/* Emit field types */
 		iter = NULL;
-		while ((field = mono_class_get_fields (klass, &iter))) {
+		while ((field = mono_class_get_fields_internal (klass, &iter))) {
 			if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
 				continue;
 
@@ -1048,7 +1048,7 @@ emit_class_dwarf_info (MonoDwarfWriter *w, MonoClass *klass, gboolean vtype)
 		}
 
 		iter = NULL;
-		has_children = parent_die || mono_class_get_fields (klass, &iter);
+		has_children = parent_die || mono_class_get_fields_internal (klass, &iter);
 
 		emit_label (w, die);
 
@@ -1069,7 +1069,7 @@ emit_class_dwarf_info (MonoDwarfWriter *w, MonoClass *klass, gboolean vtype)
 
 		/* Emit fields */
 		iter = NULL;
-		while ((field = mono_class_get_fields (klass, &iter))) {
+		while ((field = mono_class_get_fields_internal (klass, &iter))) {
 			if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
 				continue;
 

--- a/mono/mini/memory-access.c
+++ b/mono/mini/memory-access.c
@@ -241,7 +241,7 @@ create_write_barrier_bitmap (MonoCompile *cfg, MonoClass *klass, unsigned *wb_bi
 	MonoClassField *field;
 	gpointer iter = NULL;
 
-	while ((field = mono_class_get_fields (klass, &iter))) {
+	while ((field = mono_class_get_fields_internal (klass, &iter))) {
 		int foffset;
 
 		if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -4265,7 +4265,7 @@ handle_constrained_gsharedvt_call (MonoCompile *cfg, MonoMethod *cmethod, MonoMe
 	 */
 	supported = ((cmethod->klass == mono_defaults.object_class) || mono_class_is_interface (cmethod->klass) || (!m_class_is_valuetype (cmethod->klass) && m_class_get_image (cmethod->klass) != mono_defaults.corlib));
 	if (supported)
-		supported = (MONO_TYPE_IS_VOID (fsig->ret) || MONO_TYPE_IS_PRIMITIVE (fsig->ret) || MONO_TYPE_IS_REFERENCE (fsig->ret) || MONO_TYPE_ISSTRUCT (fsig->ret) || mono_class_is_enum (mono_class_from_mono_type (fsig->ret)) || mini_is_gsharedvt_type (fsig->ret));
+		supported = (MONO_TYPE_IS_VOID (fsig->ret) || MONO_TYPE_IS_PRIMITIVE (fsig->ret) || MONO_TYPE_IS_REFERENCE (fsig->ret) || MONO_TYPE_ISSTRUCT (fsig->ret) || m_class_is_enumtype (mono_class_from_mono_type (fsig->ret)) || mini_is_gsharedvt_type (fsig->ret));
 	if (supported) {
 		if (fsig->param_count == 0 || (!fsig->hasthis && fsig->param_count == 1)) {
 			supported = TRUE;
@@ -4340,7 +4340,7 @@ handle_constrained_gsharedvt_call (MonoCompile *cfg, MonoMethod *cmethod, MonoMe
 
 		if (mini_is_gsharedvt_type (fsig->ret)) {
 			ins = handle_unbox_gsharedvt (cfg, mono_class_from_mono_type (fsig->ret), ins);
-		} else if (MONO_TYPE_IS_PRIMITIVE (fsig->ret) || MONO_TYPE_ISSTRUCT (fsig->ret) || mono_class_is_enum (mono_class_from_mono_type (fsig->ret))) {
+		} else if (MONO_TYPE_IS_PRIMITIVE (fsig->ret) || MONO_TYPE_ISSTRUCT (fsig->ret) || m_class_is_enumtype (mono_class_from_mono_type (fsig->ret))) {
 			MonoInst *add;
 
 			/* Unbox */
@@ -9572,7 +9572,7 @@ calli_end:
 			    ip_in_bb (cfg, cfg->cbb, ip) &&
 			    (ip = il_read_callvirt (ip, end, &callvirt_token)) &&
 			    ip_in_bb (cfg, cfg->cbb, ip) &&
-			    mono_class_is_enum (klass) &&
+			    m_class_is_enumtype (klass) &&
 			    (enum_class = mini_get_class (method, constrained_token, generic_context)) &&
 			    (has_flag = mini_get_method (cfg, method, callvirt_token, NULL, generic_context)) &&
 			    has_flag->klass == mono_defaults.enum_class &&
@@ -9653,7 +9653,7 @@ calli_end:
 				break;
 			}
 
-			if (mono_class_is_enum (klass) && !(val->type == STACK_I8 && SIZEOF_VOID_P == 4)) {
+			if (m_class_is_enumtype (klass) && !(val->type == STACK_I8 && SIZEOF_VOID_P == 4)) {
 				/* Can't do this with 64 bit enums on 32 bit since the vtype decomp pass is ran after the long decomp pass */
 				if (val->opcode == OP_ICONST) {
 					MONO_INST_NEW (cfg, ins, OP_BOX_ICONST);

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -4629,7 +4629,7 @@ mini_emit_ldelema_1_ins (MonoCompile *cfg, MonoClass *klass, MonoInst *arr, Mono
 		static const int fast_log2 [] = { 1, 0, 1, -1, 2, -1, -1, -1, 3 };
 
 		EMIT_NEW_X86_LEA (cfg, ins, array_reg, index2_reg, fast_log2 [size], MONO_STRUCT_OFFSET (MonoArray, vector));
-		ins->klass = mono_class_get_element_class (klass);
+		ins->klass = m_class_get_element_class (klass);
 		ins->type = STACK_MP;
 
 		return ins;
@@ -4652,7 +4652,7 @@ mini_emit_ldelema_1_ins (MonoCompile *cfg, MonoClass *klass, MonoInst *arr, Mono
 	}
 	MONO_EMIT_NEW_BIALU (cfg, OP_PADD, add_reg, array_reg, mult_reg);
 	NEW_BIALU_IMM (cfg, ins, OP_PADD_IMM, add_reg, add_reg, MONO_STRUCT_OFFSET (MonoArray, vector));
-	ins->klass = mono_class_get_element_class (klass);
+	ins->klass = m_class_get_element_class (klass);
 	ins->type = STACK_MP;
 	MONO_ADD_INS (cfg->cbb, ins);
 

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -402,7 +402,7 @@ collect_field_info_nested (MonoClass *klass, GArray *fields_array, int offset, g
 		MonoClassField *field;
 
 		iter = NULL;
-		while ((field = mono_class_get_fields (klass, &iter))) {
+		while ((field = mono_class_get_fields_internal (klass, &iter))) {
 			if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
 				continue;
 			if (MONO_TYPE_ISSTRUCT (field->type)) {

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -1233,7 +1233,7 @@ is_hfa (MonoType *t, int *out_nfields, int *out_esize)
 
 	klass = mono_class_from_mono_type (t);
 	iter = NULL;
-	while ((field = mono_class_get_fields (klass, &iter))) {
+	while ((field = mono_class_get_fields_internal (klass, &iter))) {
 		if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
 			continue;
 		ftype = mono_field_get_type (field);

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -1124,7 +1124,7 @@ is_hfa (MonoType *t, int *out_nfields, int *out_esize, int *field_offsets)
 
 	klass = mono_class_from_mono_type (t);
 	iter = NULL;
-	while ((field = mono_class_get_fields (klass, &iter))) {
+	while ((field = mono_class_get_fields_internal (klass, &iter))) {
 		if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
 			continue;
 		ftype = mono_field_get_type (field);

--- a/mono/mini/mini-codegen.c
+++ b/mono/mini/mini-codegen.c
@@ -2720,7 +2720,7 @@ mini_type_is_hfa (MonoType *t, int *out_nfields, int *out_esize)
 
 	klass = mono_class_from_mono_type (t);
 	iter = NULL;
-	while ((field = mono_class_get_fields (klass, &iter))) {
+	while ((field = mono_class_get_fields_internal (klass, &iter))) {
 		if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
 			continue;
 		ftype = mono_field_get_type (field);

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2249,7 +2249,7 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 			error_init (error);
 			MonoMethod *get_message = system_exception_get_message == NULL ? NULL : mono_object_get_virtual_method (obj, system_exception_get_message);
 			MonoObject *message;
-			const char *type_name = mono_class_get_name (mono_object_class (mono_ex));
+			const char *type_name = m_class_get_name (mono_object_class (mono_ex));
 			char *msg = NULL;
 			if (get_message == NULL) {
 				message = NULL;

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -687,7 +687,7 @@ inflate_info (MonoRuntimeGenericContextInfoTemplate *oti, MonoGenericContext *co
 
 		mono_metadata_free_type (inflated_type);
 
-		mono_class_get_fields (inflated_class, &dummy);
+		mono_class_get_fields_internal (inflated_class, &dummy);
 		g_assert (m_class_get_fields (inflated_class));
 
 		return &m_class_get_fields (inflated_class) [i];

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -915,7 +915,7 @@ is_struct_returnable_via_regs  (MonoClass *klass, gboolean is_pinvoke)
 			return TRUE;
 		if (size > PPC_LARGEST_STRUCT_SIZE_TO_RETURN_VIA_REGISTERS)
 			return FALSE;
-		while ((f = mono_class_get_fields (klass, &iter))) {
+		while ((f = mono_class_get_fields_internal (klass, &iter))) {
 			if (!(f->type->attrs & FIELD_ATTRIBUTE_STATIC)) {
 				// TBD: Is there a better way to check for the basic types?
 				if (f->type->byref) {
@@ -990,7 +990,7 @@ has_only_a_r48_field (MonoClass *klass)
 	MonoClassField *f;
 	gboolean have_field = FALSE;
 	iter = NULL;
-	while ((f = mono_class_get_fields (klass, &iter))) {
+	while ((f = mono_class_get_fields_internal (klass, &iter))) {
 		if (!(f->type->attrs & FIELD_ATTRIBUTE_STATIC)) {
 			if (have_field)
 				return FALSE;

--- a/mono/profiler/aot.c
+++ b/mono/profiler/aot.c
@@ -341,9 +341,9 @@ add_class (MonoProfiler *prof, MonoClass *klass)
 
 	MonoClass *klass_nested_in = mono_class_get_nesting_type (klass);
 	if (klass_nested_in)
-		name = g_strdup_printf ("%s.%s/%s", mono_class_get_namespace (klass_nested_in), mono_class_get_name (klass_nested_in), mono_class_get_name (klass));
+		name = g_strdup_printf ("%s.%s/%s", m_class_get_name_space (klass_nested_in), m_class_get_name (klass_nested_in), m_class_get_name (klass));
 	else
-		name = g_strdup_printf ("%s.%s", mono_class_get_namespace (klass), mono_class_get_name (klass));
+		name = g_strdup_printf ("%s.%s", m_class_get_name_space (klass), m_class_get_name (klass));
 
 	id = prof->id ++;
 	emit_record (prof, AOTPROF_RECORD_TYPE, id);

--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -1679,8 +1679,8 @@ push_nesting (char *p, MonoClass *klass)
 		*p++ = '/';
 		*p = 0;
 	}
-	name = mono_class_get_name (klass);
-	nspace = mono_class_get_namespace (klass);
+	name = m_class_get_name (klass);
+	nspace = m_class_get_name_space (klass);
 	if (*nspace) {
 		strcpy (p, nspace);
 		p += strlen (nspace);

--- a/mono/profiler/vtune.c
+++ b/mono/profiler/vtune.c
@@ -84,7 +84,7 @@ method_jit_done (MonoProfiler *prof, MonoMethod *method, MonoJitInfo* jinfo)
 	MonoClass *klass = mono_method_get_class (method);
 	char *signature = mono_signature_get_desc (mono_method_signature (method), TRUE);
 	char *name = g_strdup_printf ("%s(%s)", mono_method_get_name (method), signature);
-	char *classname = g_strdup_printf ("%s%s%s", mono_class_get_namespace (klass), mono_class_get_namespace (klass)[0] != 0 ? "::" : "", mono_class_get_name (klass));
+	char *classname = g_strdup_printf ("%s%s%s", m_class_get_name_space (klass), m_class_get_name_space (klass)[0] != 0 ? "::" : "", m_class_get_name (klass));
 	gpointer code_start = mono_jit_info_get_code_start (jinfo);
 	int code_size = mono_jit_info_get_code_size (jinfo);
 


### PR DESCRIPTION
Part of #6921, this is a fourth PR that adds thread state transitions to switch to GC Unsafe state when embedders call API functions from outside of Mono.
