### PR TITLE
[MacOS] On Mac, use the copyfile API to copy files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -521,7 +521,7 @@ AC_SUBST(export_ldflags)
 AC_PROG_LD
 AC_PROG_LD_GNU
 
-AC_CHECK_HEADERS(sys/filio.h sys/sockio.h netdb.h utime.h sys/utime.h semaphore.h sys/un.h linux/rtc.h sys/syscall.h sys/mkdev.h sys/uio.h sys/param.h sys/sysctl.h libproc.h sys/prctl.h)
+AC_CHECK_HEADERS(sys/filio.h sys/sockio.h netdb.h utime.h sys/utime.h semaphore.h sys/un.h linux/rtc.h sys/syscall.h sys/mkdev.h sys/uio.h sys/param.h sys/sysctl.h libproc.h sys/prctl.h copyfile.h)
 AC_CHECK_HEADERS(sys/param.h sys/socket.h sys/ipc.h sys/utsname.h alloca.h ucontext.h pwd.h sys/select.h netinet/tcp.h netinet/in.h unistd.h sys/types.h link.h asm/sigcontext.h sys/inotify.h arpa/inet.h complex.h unwind.h)
 AC_CHECK_HEADERS([linux/netlink.h linux/rtnetlink.h],
                   [], [], [#include <stddef.h>

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -940,6 +940,8 @@ static gboolean
 is_file_writable (struct stat *st, const gchar *path)
 {
 	gboolean ret;
+	gchar *located_path;
+
 #if __APPLE__
 	// OS X Finder "locked" or `ls -lO` "uchg".
 	// This only covers one of several cases where an OS X file could be unwritable through special flags.
@@ -959,12 +961,17 @@ is_file_writable (struct stat *st, const gchar *path)
 	if ((st->st_gid == getegid ()) && (st->st_mode & S_IWGRP))
 		return 1;
 
+	located_path = mono_portability_find_file (path, FALSE);
+
 	/* Fallback to using access(2). It's not ideal as it might not take into consideration euid/egid
 	 * but it's the only sane option we have on unix.
 	 */
 	MONO_ENTER_GC_SAFE;
-	ret = access (path, W_OK) == 0;
+	ret = access (located_path != NULL ? located_path : path, W_OK) == 0;
 	MONO_EXIT_GC_SAFE;
+
+	g_free (located_path);
+
 	return ret;
 }
 
@@ -2320,6 +2327,30 @@ write_file (gint src_fd, gint dest_fd, struct stat *st_src, gboolean report_erro
 	return TRUE ;
 }
 
+#if HAVE_COPYFILE_H
+static int
+_wapi_copyfile(const char *from, const char *to, copyfile_state_t state, copyfile_flags_t flags)
+{
+	gchar *located_from, *located_to;
+	int ret;
+
+	located_from = mono_portability_find_file (from, FALSE);
+	located_to = mono_portability_find_file (to, FALSE);
+
+	MONO_ENTER_GC_SAFE;
+	ret = copyfile (
+		located_from == NULL ? from : located_from,
+		located_to == NULL ? to : located_to,
+		state, flags);
+	MONO_EXIT_GC_SAFE;
+
+	g_free (located_from);
+	g_free (located_to);
+
+	return ret;
+}
+#endif
+
 static gboolean
 CopyFile (const gunichar2 *name, const gunichar2 *dest_name, gboolean fail_if_exists)
 {
@@ -2388,16 +2419,15 @@ CopyFile (const gunichar2 *name, const gunichar2 *dest_name, gboolean fail_if_ex
 			return (FALSE);
 		}
 	}
-	
-	/* FIXME: path is not translated (mono_portability_find_file) */
-	ret = copyfile (utf8_src, utf8_dest, NULL, COPYFILE_ALL | COPYFILE_CLONE | (fail_if_exists ? COPYFILE_EXCL : COPYFILE_UNLINK));
+
+	ret = _wapi_copyfile (utf8_src, utf8_dest, NULL, COPYFILE_ALL | COPYFILE_CLONE | (fail_if_exists ? COPYFILE_EXCL : COPYFILE_UNLINK));
 	g_free (utf8_src);
 	g_free (utf8_dest);
 	if (ret != 0) {
 		_wapi_set_last_error_from_errno ();
 		return FALSE;
 	}
-	
+
 	return TRUE;
 #else
 	src_fd = _wapi_open (utf8_src, O_RDONLY, 0);
@@ -2440,7 +2470,7 @@ CopyFile (const gunichar2 *name, const gunichar2 *dest_name, gboolean fail_if_ex
 		mono_w32error_set_last (ERROR_SHARING_VIOLATION);
 		return (FALSE);
 	}
-	
+
 	if (fail_if_exists) {
 		dest_fd = _wapi_open (utf8_dest, O_WRONLY | O_CREAT | O_EXCL, st.st_mode);
 	} else {

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -17,7 +17,7 @@
 #ifdef HAVE_COPYFILE_H
 #include <copyfile.h>
 #  if !defined(COPYFILE_CLONE)
-#    #define COPYFILE_CLONE 0
+#    #define COPYFILE_CLONE (1 << 24)
 #  endif
 #endif
 #if defined(HAVE_SYS_STATFS_H)
@@ -2367,7 +2367,7 @@ CopyFile (const gunichar2 *name, const gunichar2 *dest_name, gboolean fail_if_ex
 	}
 
 #if HAVE_COPYFILE_H
-	ret = copyfile (utf8_src, utf8_dest, NULL, COPYFILE_ALL | COPYFILE_CLONE | (fail_if_exists ? COPYFILE_EXCL : COPYFILE_UNLINK));
+	ret = copyfile (utf8_src, utf8_dest, NULL, COPYFILE_ALL | COPYFILE_CLONE | (fail_if_exists ? COPYFILE_EXCL : 0));
 	g_free (utf8_src);
 	g_free (utf8_dest);
 	if (ret != 0){


### PR DESCRIPTION
Rebase of #9038 with added fix for the failing unit tests. Note that there's a race condition in the check between `source file == destination file` and the `copyfile` call, but a similar race condition already exists there in the current code except the outcome is different.