### PR TITLE
[2018-06] [mini] return gracefully from compile_special if a method can not be compiled

### DIFF
--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -2176,7 +2176,7 @@ compile_special (MonoMethod *method, MonoDomain *target_domain, MonoError *error
 				if (mono_llvm_only) {
 					nm = mono_marshal_get_delegate_invoke (method, NULL);
 					gpointer compiled_ptr = mono_jit_compile_method_jit_only (nm, error);
-					mono_error_assert_ok (error);
+					return_val_if_nok (error, NULL);
 					return mono_get_addr_from_ftnptr (compiled_ptr);
 				}
 
@@ -2188,12 +2188,12 @@ compile_special (MonoMethod *method, MonoDomain *target_domain, MonoError *error
 			} else if (*name == 'B' && (strcmp (name, "BeginInvoke") == 0)) {
 				nm = mono_marshal_get_delegate_begin_invoke (method);
 				gpointer compiled_ptr = mono_jit_compile_method_jit_only (nm, error);
-				mono_error_assert_ok (error);
+				return_val_if_nok (error, NULL);
 				return mono_get_addr_from_ftnptr (compiled_ptr);
 			} else if (*name == 'E' && (strcmp (name, "EndInvoke") == 0)) {
 				nm = mono_marshal_get_delegate_end_invoke (method);
 				gpointer compiled_ptr = mono_jit_compile_method_jit_only (nm, error);
-				mono_error_assert_ok (error);
+				return_val_if_nok (error, NULL);
 				return mono_get_addr_from_ftnptr (compiled_ptr);
 			}
 		}


### PR DESCRIPTION
Backport of #9661.

/cc @lewurm