### PR TITLE
Fix strerror_r test macro (issue #9532)

### DIFF
--- a/support/errno.c
+++ b/support/errno.c
@@ -41,7 +41,7 @@ Mono_Posix_Stdlib_SetLastError (int error_number)
  * we assume that the XPG version is present.
  */
 
-#ifdef _GNU_SOURCE
+#if (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && ! _GNU_SOURCE
 #define mph_min(x,y) ((x) <= (y) ? (x) : (y))
 
 /* If you pass an invalid errno value to glibc 2.3.2's strerror_r, you get


### PR DESCRIPTION
According to strerror_r(3):
```
    The XSI-compliant version is provided if:
    (_POSIX_C_SOURCE >= 200112L) && !  _GNU_SOURCE
    Otherwise, the GNU-specific version is provided.
```

Fixes https://github.com/mono/mono/issues/9532

Signed-off-by: Joe Groocock <me@frebib.net>



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
