### PR TITLE
[mcs] Don't wrap exception expression in contextual return.

### DIFF
--- a/mcs/mcs/cs-parser.jay
+++ b/mcs/mcs/cs-parser.jay
@@ -1586,7 +1586,7 @@ constructor_body
 	 expression SEMICOLON
 	 {
 		lexer.parsing_block = 0;
-		current_block.AddStatement (new ContextualReturn ((Expression) $3));
+		current_block.AddStatement (CreateExpressionBodiedStatement ((Expression) $3));
 		var b = end_block (GetLocation ($4));
 		b.IsCompilerGenerated = true;
 		$$ = b;
@@ -1607,7 +1607,7 @@ expression_block
 	 lambda_arrow_expression SEMICOLON
 	 {
 		lexer.parsing_block = 0;
-		current_block.AddStatement (new ContextualReturn ((Expression) $3));
+		current_block.AddStatement (CreateExpressionBodiedStatement ((Expression) $3));
 		var b = end_block (GetLocation ($4));
 		b.IsCompilerGenerated = true;
 		$$ = b;
@@ -8028,6 +8028,14 @@ static bool IsUnaryOperator (Operator.OpType op)
 		return true;
 	}
 	return false;
+}
+
+static Statement CreateExpressionBodiedStatement (Expression expr)
+{
+	if (expr is ThrowExpression te)
+		return new StatementExpression (te);
+
+	return new ContextualReturn (expr);
 }
 
 void syntax_error (Location l, string msg)

--- a/mcs/mcs/statement.cs
+++ b/mcs/mcs/statement.cs
@@ -928,8 +928,7 @@ namespace Mono.CSharp {
 		public override Reachability MarkReachable (Reachability rc)
 		{
 			base.MarkReachable (rc);
-			expr.MarkReachable (rc);
-			return rc;
+			return expr.MarkReachable (rc);
 		}
 
 		public override bool Resolve (BlockContext ec)

--- a/mcs/tests/ver-il-net_4_x.xml
+++ b/mcs/tests/ver-il-net_4_x.xml
@@ -73699,7 +73699,7 @@
         <size>32</size>
       </method>
       <method name="Int32 Test()" attrs="134">
-        <size>10</size>
+        <size>2</size>
       </method>
       <method name="System.Object Foo()" attrs="129">
         <size>10</size>
@@ -73708,16 +73708,16 @@
         <size>23</size>
       </method>
       <method name="Void Test3(Int32 ByRef)" attrs="145">
-        <size>3</size>
+        <size>2</size>
       </method>
       <method name="Int32 get_Item(Int32)" attrs="2177">
-        <size>10</size>
+        <size>2</size>
       </method>
       <method name="Void add_Event(System.Action)" attrs="2182">
-        <size>3</size>
+        <size>2</size>
       </method>
       <method name="Void remove_Event(System.Action)" attrs="2182">
-        <size>3</size>
+        <size>2</size>
       </method>
       <method name="Void TestExpr_1(Boolean)" attrs="129">
         <size>21</size>
@@ -73744,7 +73744,7 @@
         <size>7</size>
       </method>
       <method name="Int32 TestExpr_6(Int32 ByRef)" attrs="145">
-        <size>10</size>
+        <size>2</size>
       </method>
       <method name="Int32 TestExpr_7(Int32 ByRef)" attrs="129">
         <size>15</size>


### PR DESCRIPTION
Fixes #9505