### PR TITLE
[2018-06] [corlib] Disable broken corefx tests

### DIFF
--- a/mcs/class/corlib/corlib_xtest.dll.sources
+++ b/mcs/class/corlib/corlib_xtest.dll.sources
@@ -208,7 +208,7 @@
 ../../../external/corefx/src/Common/tests/System/EnumTypes.cs
 ../../../external/corefx/src/Common/tests/System/ObjectCloner.cs
 ../../../external/corefx/src/Common/tests/System/Diagnostics/DebuggerAttributes.cs
-../../../external/corefx/src/System.Collections/tests/Generic/SortedSet/*.cs
+../../../external/corefx/src/System.Collections/tests/Generic/SortedSet/*.cs:SortedSet.TreeSubSet.Tests.cs
 ../../../external/corefx/src/System.Collections/tests/Generic/HashSet/*.cs
 ../../../external/corefx/src/System.Collections/tests/Generic/Stack/*.cs
 ../../../external/corefx/src/System.Collections/tests/Generic/SortedList/*.cs


### PR DESCRIPTION
Backport of #9707.

/cc @marek-safar