### PR TITLE
Revert CharUnicodeInfo to reference-sources (Big Endian issue)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # This can be reset to 0 when Mono's version number is bumped
 # since it's part of the corlib version (the prefix '1' in the full
 # version number is to ensure the number isn't treated as octal in C)
-MONO_CORLIB_COUNTER=25
+MONO_CORLIB_COUNTER=26
 MONO_CORLIB_VERSION=`printf "1%02d%02d%02d%03d" $MONO_VERSION_MAJOR $MONO_VERSION_MINOR 0 $MONO_CORLIB_COUNTER`
 
 AC_DEFINE_UNQUOTED(MONO_CORLIB_VERSION,$MONO_CORLIB_VERSION,[Version of the corlib-runtime interface])

--- a/mcs/class/corlib/corlib.csproj
+++ b/mcs/class/corlib/corlib.csproj
@@ -294,7 +294,6 @@
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\FormatException.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\FormattableString.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\Gen2GcCallback.cs" />
-    <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\Globalization\CharUnicodeInfo.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\Globalization\CompareInfo.Invariant.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\Globalization\CompareInfo.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\Globalization\GlobalizationExtensions.cs" />
@@ -671,7 +670,6 @@
     <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\src\System\Array.cs" />
     <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\src\System\ByReference.cs" />
     <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\src\System\Collections\Generic\ArraySortHelper.cs" />
-    <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\src\System\Globalization\CharUnicodeInfoData.cs" />
     <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\src\System\Globalization\GlobalizationMode.cs" />
     <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\src\System\InsufficientMemoryException.cs" />
     <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\src\System\MissingFieldException.cs" />
@@ -791,6 +789,7 @@
     <Compile Include="..\referencesource\mscorlib\system\globalization\calendaralgorithmtype.cs" />
     <Compile Include="..\referencesource\mscorlib\system\globalization\calendardata.cs" />
     <Compile Include="..\referencesource\mscorlib\system\globalization\calendarweekrule.cs" />
+    <Compile Include="..\referencesource\mscorlib\system\globalization\charunicodeinfo.cs" />
     <Compile Include="..\referencesource\mscorlib\system\globalization\chineselunisolarcalendar.cs" />
     <Compile Include="..\referencesource\mscorlib\system\globalization\culturenotfoundexception.cs" />
     <Compile Include="..\referencesource\mscorlib\system\globalization\culturetypes.cs" />

--- a/mcs/class/corlib/corlib.dll.sources
+++ b/mcs/class/corlib/corlib.dll.sources
@@ -1076,8 +1076,10 @@ ReferenceSources/AppContextDefaultValues.cs
 ../referencesource/mscorlib/system/globalization/CalendricalCalculationsHelper.cs
 ../referencesource/mscorlib/system/globalization/calendardata.cs
 ../referencesource/mscorlib/system/globalization/calendarweekrule.cs
-../../../external/corefx/src/Common/src/CoreLib/System/Globalization/CharUnicodeInfo.cs
-../../../external/corert/src/System.Private.CoreLib/src/System/Globalization/CharUnicodeInfoData.cs
+../referencesource/mscorlib/system/globalization/charunicodeinfo.cs
+# TODO: make CoreFX's CharUnicodeInfo BE compatible
+#../../../external/corefx/src/Common/src/CoreLib/System/Globalization/CharUnicodeInfo.cs
+#../../../external/corert/src/System.Private.CoreLib/src/System/Globalization/CharUnicodeInfoData.cs
 ../referencesource/mscorlib/system/globalization/chineselunisolarcalendar.cs
 #../referencesource/mscorlib/system/globalization/compareinfo.cs
 ../referencesource/mscorlib/system/globalization/culturenotfoundexception.cs

--- a/mcs/class/referencesource/mscorlib/system/globalization/charunicodeinfo.cs
+++ b/mcs/class/referencesource/mscorlib/system/globalization/charunicodeinfo.cs
@@ -483,7 +483,9 @@ namespace System.Globalization {
             return (InternalGetUnicodeCategory(ch)) ;
         }
 
-        internal static UnicodeCategory GetUnicodeCategory(int ch) => GetUnicodeCategory((int)ch);
+#if MONO
+        public static UnicodeCategory GetUnicodeCategory(int ch) => GetUnicodeCategory((int)ch);
+#endif
 
         public static UnicodeCategory GetUnicodeCategory(String s, int index)
         {

--- a/mcs/class/referencesource/mscorlib/system/globalization/charunicodeinfo.cs
+++ b/mcs/class/referencesource/mscorlib/system/globalization/charunicodeinfo.cs
@@ -483,6 +483,8 @@ namespace System.Globalization {
             return (InternalGetUnicodeCategory(ch)) ;
         }
 
+        internal static UnicodeCategory GetUnicodeCategory(int ch) => GetUnicodeCategory((int)ch);
+
         public static UnicodeCategory GetUnicodeCategory(String s, int index)
         {
             if (s==null)

--- a/mcs/class/referencesource/mscorlib/system/globalization/charunicodeinfo.cs
+++ b/mcs/class/referencesource/mscorlib/system/globalization/charunicodeinfo.cs
@@ -484,7 +484,7 @@ namespace System.Globalization {
         }
 
 #if MONO
-        public static UnicodeCategory GetUnicodeCategory(int ch) => GetUnicodeCategory((char)ch);
+        public static UnicodeCategory GetUnicodeCategory(int codePoint) => GetUnicodeCategory((char)codePoint);
 #endif
 
         public static UnicodeCategory GetUnicodeCategory(String s, int index)

--- a/mcs/class/referencesource/mscorlib/system/globalization/charunicodeinfo.cs
+++ b/mcs/class/referencesource/mscorlib/system/globalization/charunicodeinfo.cs
@@ -484,7 +484,7 @@ namespace System.Globalization {
         }
 
 #if MONO
-        public static UnicodeCategory GetUnicodeCategory(int ch) => GetUnicodeCategory((int)ch);
+        public static UnicodeCategory GetUnicodeCategory(int ch) => GetUnicodeCategory((char)ch);
 #endif
 
         public static UnicodeCategory GetUnicodeCategory(String s, int index)


### PR DESCRIPTION
Temporarily switch back to ref-source impl for `CharUnicodeInfo` which contains a few special BE patches while I am trying to upstream them.

Fixes #9684