### PR TITLE
Fix copy/paste error. Use size parameter for non-moving GC allocation…

### DIFF
--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -300,16 +300,16 @@ gc_alloc_fixed_non_heap_list (size_t size)
 	if (mono_gc_is_moving ())
 		return g_malloc0 (size);
 	else
-		return mono_gc_alloc_fixed (appdomain_list_size * sizeof (void*), MONO_GC_DESCRIPTOR_NULL, MONO_ROOT_SOURCE_DOMAIN, NULL, "Domain List");
+		return mono_gc_alloc_fixed (size, MONO_GC_DESCRIPTOR_NULL, MONO_ROOT_SOURCE_DOMAIN, NULL, "Domain List");
 }
 
 static void
 gc_free_fixed_non_heap_list (void *ptr)
 {
 	if (mono_gc_is_moving ())
-		return g_free (ptr);
+		g_free (ptr);
 	else
-		return mono_gc_free_fixed (ptr);
+		mono_gc_free_fixed (ptr);
 }
 /*
  * Allocate an id for domain and set domain->domain_id.


### PR DESCRIPTION
…. Remove return statements from void function to silence warnings.

