### PR TITLE
Fix issue where get offset could return 0 when the type is uninitialized

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -4754,6 +4754,7 @@ mono_field_get_flags (MonoClassField *field)
 guint32
 mono_field_get_offset (MonoClassField *field)
 {
+	mono_class_setup_fields(field->parent);
 	return field->offset;
 }
 


### PR DESCRIPTION
We have some example code that gets all the fields via reflection
```foreach (var field in type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public))```
Then later when we try to get the field offset, the type hasn't been initialized (unless your C# code does something earlier that initializes the type).
type.GetFields calls mono_class_get_fields_lazy, which doesn't setup all the field info (in this case the offset)