### PR TITLE
Empty array is not passed per documentation to CreateProcess.

### DIFF
--- a/mono/metadata/w32process-win32.c
+++ b/mono/metadata/w32process-win32.c
@@ -306,11 +306,13 @@ ves_icall_System_Diagnostics_Process_CreateProcess_internal (MonoW32ProcessStart
 		MonoArrayHandle array = MONO_HANDLE_NEW (MonoArray, process_info->env_variables);
 		MonoStringHandle var = MONO_HANDLE_NEW (MonoString, NULL);
 		gsize const array_length = mono_array_handle_length (array);
-		gsize len = 1; // nul-terminated
+
+		// nul-separated and nul-terminated
+		gsize len = array_length + 1 + !array_length;
 
 		for (gsize i = 0; i < array_length; i++) {
 			MONO_HANDLE_ARRAY_GETREF (var, array, i);
-			len += mono_string_handle_length (var) + 1; // nul-separated
+			len += mono_string_handle_length (var);
 		}
 
 		gunichar2 *ptr = g_new0 (gunichar2, len);


### PR DESCRIPTION
It is not clear how this should be represented.

https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-createprocessa

"Note that an ANSI environment block is terminated by two zero bytes: one for the last string,
one more to terminate the block.
A Unicode environment block is terminated by four zero bytes: two for the last string,
two more to terminate the block."

Is unambiguous however.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
