### PR TITLE
Fix my Cygwin build by building version.h before compiling mini.c.

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -1005,3 +1005,4 @@ Makefile.am: Makefile.am.in $(llvm_makefile_dep)
 
 endif
 
+mini.o: version.h


### PR DESCRIPTION
This was when I wasn't configuring with "w64". Maybe moot?