### PR TITLE
[corlib] Bring back serialization ctors/methods for X509Certificate

### DIFF
--- a/mcs/class/System/Test/System.Security.Cryptography.X509Certificates/X509Cert20Test.cs
+++ b/mcs/class/System/Test/System.Security.Cryptography.X509Certificates/X509Cert20Test.cs
@@ -456,7 +456,7 @@ mgk3bWUV6ChegutbguiKrI/DbO7wPiDLxw==
 
 #if !MOBILE
 		[Test]
-		[ExpectedException (typeof (PlatformNotSupportedException))]
+		[ExpectedException (typeof (NullReferenceException))]
 		public void GetObjectData_Null ()
 		{
 			X509Certificate x = new X509Certificate ();
@@ -465,7 +465,6 @@ mgk3bWUV6ChegutbguiKrI/DbO7wPiDLxw==
 		}
 
 		[Test]
-		[ExpectedException (typeof (PlatformNotSupportedException))]
 		public void GetObjectData ()
 		{
 			X509Certificate x = new X509Certificate (cert1);
@@ -473,22 +472,27 @@ mgk3bWUV6ChegutbguiKrI/DbO7wPiDLxw==
 			Assert.IsNotNull (s, "ISerializable");
 			SerializationInfo info = new SerializationInfo (typeof (X509Certificate), new FormatterConverter ());
 			s.GetObjectData (info, new StreamingContext (StreamingContextStates.All));
+			Assert.AreEqual (1, info.MemberCount, "MemberCount");
+			byte[] raw = (byte[]) info.GetValue ("RawData", typeof (byte[]));
 		}
 #endif
 
 		[Test]
-		[ExpectedException (typeof (PlatformNotSupportedException))]
+		[ExpectedException (typeof (NullReferenceException))]
 		public void Ctor_Serialization_Null ()
 		{
 			new X509Certificate (null, new StreamingContext (StreamingContextStates.All));
 		}
 
 		[Test]
-		[ExpectedException (typeof (PlatformNotSupportedException))]
 		public void Ctor_Serialization ()
 		{
 			SerializationInfo info = new SerializationInfo (typeof (X509Certificate), new FormatterConverter ());
-			new X509Certificate (info, new StreamingContext (StreamingContextStates.All));
+			info.AddValue ("RawData", cert1);
+			X509Certificate x = new X509Certificate (info, new StreamingContext (StreamingContextStates.All));
+			Assert.AreEqual (cert1, x.GetRawCertData (), "GetRawCertData");
+			// decoding is done too
+			Assert.AreEqual ("02720006E8", x.GetSerialNumberString (), "SerialNumber");
 		}
 
 

--- a/mcs/class/corlib/System.Security.Cryptography.X509Certificates/X509Certificate.cs
+++ b/mcs/class/corlib/System.Security.Cryptography.X509Certificates/X509Certificate.cs
@@ -201,7 +201,8 @@ namespace System.Security.Cryptography.X509Certificates
 		[System.Diagnostics.CodeAnalysis.SuppressMessage ("Microsoft.Usage", "CA2229", Justification = "Public API has already shipped.")]
 		public X509Certificate (SerializationInfo info, StreamingContext context) : this ()
 		{
-			throw new PlatformNotSupportedException ();
+			byte[] raw = (byte[]) info.GetValue ("RawData", typeof (byte[]));
+			Import (raw, (string)null, X509KeyStorageFlags.DefaultKeySet);
 		}
 
 		public static X509Certificate CreateFromCertFile (string filename)
@@ -216,12 +217,14 @@ namespace System.Security.Cryptography.X509Certificates
 
 		void ISerializable.GetObjectData (SerializationInfo info, StreamingContext context)
 		{
-			throw new PlatformNotSupportedException ();
+			if (!X509Helper.IsValid (impl))
+				throw new NullReferenceException ();
+			// will throw a NRE if info is null (just like MS implementation)
+			info.AddValue ("RawData", impl.RawData);
 		}
 
 		void IDeserializationCallback.OnDeserialization (object sender)
 		{
-			throw new PlatformNotSupportedException ();
 		}
 
 		public IntPtr Handle {


### PR DESCRIPTION
They were replaced with PNSE in https://github.com/mono/mono/pull/9650
but that broke xUnit 2.4.0.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
