### PR TITLE
Reduce BCL/test sensitivity to tailcall optimizations,

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Makefile
+++ b/mcs/class/Mono.Debugger.Soft/Makefile
@@ -1,6 +1,14 @@
 thisdir = class/Mono.Debugger.Soft
 include ../../build/rules.make
 
+# FIXME Turn off tailcall optimizations for debugger tests.
+# Most of the tailcalls can be manually eliminated, however
+# there are two tests that check for a precise stack within the BCL,
+# and either we'd have to remove those tailcalls, or turn off tailcall like here,
+# or maybe split up the debugger tests into tailcall and non-tailcall versions,
+# where non-tailcall is quite small.
+TEST_RUNTIME_FLAGS += --optimize=-tailc
+
 LIBRARY = Mono.Debugger.Soft.dll
 LIBRARY_SNK = ../mono.snk
 

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -1496,12 +1496,16 @@ public class Tests : TestsBase, ITest2
 
 		ig.Emit (OpCodes.Ldstr, "FOO");
 		ig.Emit (OpCodes.Call, typeof (Tests).GetMethod ("dyn_call"));
+		ig.Emit (OpCodes.Call, typeof (Tests).GetMethod ("NoTailcall"));
 		ig.Emit (OpCodes.Ret);
 
 		var del = (Action<int>)m.CreateDelegate (typeof (Action<int>));
 
 		del (0);
 	}
+
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	public static void NoTailcall () { }
 
 	public static void dyn_call (string s) {
 	}
@@ -1522,6 +1526,7 @@ public class Tests : TestsBase, ITest2
 		ILGenerator ig = mb.GetILGenerator ();
 		ig.Emit (OpCodes.Ldstr, "FOO");
 		ig.Emit (OpCodes.Call, typeof (Tests).GetMethod ("ref_emit_call"));
+		ig.Emit (OpCodes.Call, typeof (Tests).GetMethod ("NoTailcall"));
 		ig.Emit (OpCodes.Ret);
 
 		Type t = tb.CreateType ();

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-excfilter.il
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-excfilter.il
@@ -12,8 +12,8 @@
 	{
 		.entrypoint
 		call void class ExceptionFilterTest::Test ()
-		ret
-	}
+		call void class ExceptionFilterTest::NoTailcall ()
+		ret }
 
 	.method public static int32 Filter ([mscorlib]System.Exception exc) cil managed noinlining
 	{
@@ -46,4 +46,10 @@
 	end:
 		ret
 	}
+
+	.method static void NoTailcall () noinlining
+	{
+		ret
+	}
+
 }

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -3748,6 +3748,7 @@ public class DebuggerTests
 		// FIXME: This is racy
 		vm.Resume ();
 
+		// FIXME This test does not allow for tailcall optimization in Sleep.
 		Thread.Sleep (100);
 
 		vm.Suspend ();
@@ -4252,6 +4253,8 @@ public class DebuggerTests
 		vm.Suspend ();
 		Assert.AreEqual (ThreadState.WaitSleepJoin, thread.ThreadState, "#6");
 
+		// FIXME This test is deeply tied to BCL internals.
+		// FIXME This test does not allow for tailcall optimizations therein.
 		frames = thread.GetFrames ();
 		Assert.AreEqual (8, frames.Length, "#7");
 		Assert.AreEqual ("Wait_internal", frames [0].Method.Name, "#8.0");

--- a/mcs/class/Mono.Profiler.Log/Test/ProfilerTestRun.cs
+++ b/mcs/class/Mono.Profiler.Log/Test/ProfilerTestRun.cs
@@ -58,7 +58,8 @@ namespace MonoTests.Mono.Profiler.Log {
 				proc.StartInfo = new ProcessStartInfo {
 					UseShellExecute = false,
 					FileName = Path.GetFullPath (Path.Combine ("..", "..", "..", "runtime", "mono-wrapper")),
-					Arguments = $"--debug --profile=log:nodefaults,output={_output},{Options} log-profiler-test.exe {Name}",
+					// FIXME profiler test is broken by tailcall optimization
+					Arguments = $"--optimize=-tailc --debug --profile=log:nodefaults,output={_output},{Options} log-profiler-test.exe {Name}",
 				};
 
 				proc.Start ();

--- a/mcs/class/System.Web.Extensions/Test/System.Web.UI.WebControls/DataPagerFieldCollectionTest.cs
+++ b/mcs/class/System.Web.Extensions/Test/System.Web.UI.WebControls/DataPagerFieldCollectionTest.cs
@@ -33,6 +33,7 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Web.UI;
 using System.Web.UI.WebControls;
+using System.Runtime.CompilerServices;
 
 using NUnit.Framework;
 
@@ -42,12 +43,16 @@ namespace MonoTests.System.Web.UI.WebControls
 	{
 		EventRecorder recorder;
 
+		[MethodImplAttribute (MethodImplOptions.NoInlining)]
+		static void NoTailcall () { }
+
 		void RecordEvent (string suffix)
 		{
 			if (recorder == null)
 				return;
 
 			recorder.Record (suffix);
+			NoTailcall ();
 		}
 
 		public DataPagerFieldCollectionPoker ()
@@ -79,6 +84,7 @@ namespace MonoTests.System.Web.UI.WebControls
 		public void DoOnValidate (object value)
 		{
 			OnValidate (value);
+			NoTailcall ();
 		}
 
 		public void CatchFieldsChangedEvent ()
@@ -91,6 +97,7 @@ namespace MonoTests.System.Web.UI.WebControls
 			RecordEvent ("Enter");
 			base.OnValidate (o);
 			RecordEvent ("Leave");
+			NoTailcall ();
 		}
 
 		protected override void OnClearComplete ()
@@ -98,6 +105,7 @@ namespace MonoTests.System.Web.UI.WebControls
 			RecordEvent ("Enter");
 			base.OnClearComplete ();
 			RecordEvent ("Leave");
+			NoTailcall ();
 		}
 
 		protected override void OnInsertComplete (int index, object value)
@@ -105,6 +113,7 @@ namespace MonoTests.System.Web.UI.WebControls
 			RecordEvent ("Enter");
 			base.OnInsertComplete (index, value);
 			RecordEvent ("Leave");
+			NoTailcall ();
 		}
 
 		protected override void OnRemoveComplete (int index, object value)
@@ -112,12 +121,14 @@ namespace MonoTests.System.Web.UI.WebControls
 			RecordEvent ("Enter");
 			base.OnRemoveComplete (index, value);
 			RecordEvent ("Leave");
+			NoTailcall ();
 		}
 
 		void OnFieldsChanged (object sender, EventArgs args)
 		{
 			RecordEvent ("Enter");
 			RecordEvent ("Leave");
+			NoTailcall ();
 		}
 	}
 	

--- a/mcs/class/System.Web.Extensions/Test/System.Web.UI.WebControls/ListViewTest.cs
+++ b/mcs/class/System.Web.Extensions/Test/System.Web.UI.WebControls/ListViewTest.cs
@@ -36,6 +36,7 @@ using System.Reflection;
 using System.Web.UI;
 using System.Web.UI.HtmlControls;
 using System.Web.UI.WebControls;
+using System.Runtime.CompilerServices;
 
 using NUnit.Framework;
 using MonoTests.SystemWeb.Framework;
@@ -50,13 +51,17 @@ namespace MonoTests.System.Web.UI.WebControls
 		public StateBag StateBag {
 			get { return base.ViewState; }
 		}
-		
+
+		[MethodImplAttribute (MethodImplOptions.NoInlining)]
+		static void NoTailcall () { }
+
 		void RecordEvent (string suffix)
 		{
 			if (recorder == null)
 				return;
 
 			recorder.Record (suffix);
+			NoTailcall ();
 		}
 
 		public ListViewPoker ()
@@ -86,6 +91,7 @@ namespace MonoTests.System.Web.UI.WebControls
 			RecordEvent ("Enter");
 			base.OnItemCanceling (e);
 			RecordEvent ("Leave");
+			NoTailcall ();
 		}
 	
 		protected override void OnItemCommand (ListViewCommandEventArgs e)
@@ -93,6 +99,7 @@ namespace MonoTests.System.Web.UI.WebControls
 			RecordEvent ("Enter");
 			base.OnItemCommand (e);
 			RecordEvent ("Leave");
+			NoTailcall ();
 		}
 	
 		protected override void OnItemCreated (ListViewItemEventArgs e)
@@ -100,6 +107,7 @@ namespace MonoTests.System.Web.UI.WebControls
 			RecordEvent ("Enter");
 			base.OnItemCreated (e);
 			RecordEvent ("Leave");
+			NoTailcall ();
 		}
 	
 		protected override void OnItemDataBound (ListViewItemEventArgs e)
@@ -107,6 +115,7 @@ namespace MonoTests.System.Web.UI.WebControls
 			RecordEvent ("Enter");
 			base.OnItemDataBound (e);
 			RecordEvent ("Leave");
+			NoTailcall ();
 		}
 	
 		protected override void OnItemDeleted (ListViewDeletedEventArgs e)
@@ -114,6 +123,7 @@ namespace MonoTests.System.Web.UI.WebControls
 			RecordEvent ("Enter");
 			base.OnItemDeleted (e);
 			RecordEvent ("Leave");
+			NoTailcall ();
 		}
 	
 		protected override void OnItemDeleting (ListViewDeleteEventArgs e)
@@ -121,6 +131,7 @@ namespace MonoTests.System.Web.UI.WebControls
 			RecordEvent ("Enter");
 			base.OnItemDeleting (e);
 			RecordEvent ("Leave");
+			NoTailcall ();
 		}
 	
 		protected override void OnItemEditing (ListViewEditEventArgs e)
@@ -128,6 +139,7 @@ namespace MonoTests.System.Web.UI.WebControls
 			RecordEvent ("Enter");
 			base.OnItemEditing (e);
 			RecordEvent ("Leave");
+			NoTailcall ();
 		}
 	
 		protected override void OnItemInserted (ListViewInsertedEventArgs e)
@@ -135,6 +147,7 @@ namespace MonoTests.System.Web.UI.WebControls
 			RecordEvent ("Enter");
 			base.OnItemInserted (e);
 			RecordEvent ("Leave");
+			NoTailcall ();
 		}
 	
 		protected override void OnItemInserting (ListViewInsertEventArgs e)
@@ -142,6 +155,7 @@ namespace MonoTests.System.Web.UI.WebControls
 			RecordEvent ("Enter");
 			base.OnItemInserting (e);
 			RecordEvent ("Leave");
+			NoTailcall ();
 		}
 	
 		protected override void OnItemUpdated (ListViewUpdatedEventArgs e)
@@ -149,6 +163,7 @@ namespace MonoTests.System.Web.UI.WebControls
 			RecordEvent ("Enter");
 			base.OnItemUpdated (e);
 			RecordEvent ("Leave");
+			NoTailcall ();
 		}
 	
 		protected override void OnItemUpdating (ListViewUpdateEventArgs e)
@@ -156,6 +171,7 @@ namespace MonoTests.System.Web.UI.WebControls
 			RecordEvent ("Enter");
 			base.OnItemUpdating (e);
 			RecordEvent ("Leave");
+			NoTailcall ();
 		}
 	
 		protected override void OnLayoutCreated (EventArgs e)
@@ -163,6 +179,7 @@ namespace MonoTests.System.Web.UI.WebControls
 			RecordEvent ("Enter");
 			base.OnLayoutCreated (e);
 			RecordEvent ("Leave");
+			NoTailcall ();
 		}
 	
 		protected override void OnPagePropertiesChanged (EventArgs e)
@@ -170,13 +187,15 @@ namespace MonoTests.System.Web.UI.WebControls
 			RecordEvent ("Enter");
 			base.OnPagePropertiesChanged (e);
 			RecordEvent ("Leave");
+			NoTailcall ();
 		}
-	
+
 		protected override void OnPagePropertiesChanging (PagePropertiesChangingEventArgs e)
 		{
 			RecordEvent ("Enter");
 			base.OnPagePropertiesChanging (e);
 			RecordEvent ("Leave");
+			NoTailcall ();
 		}
 	
 		protected override void OnSelectedIndexChanged (EventArgs e)
@@ -184,6 +203,7 @@ namespace MonoTests.System.Web.UI.WebControls
 			RecordEvent ("Enter");
 			base.OnSelectedIndexChanged (e);
 			RecordEvent ("Leave");
+			NoTailcall ();
 		}
 	
 		protected override void OnSelectedIndexChanging (ListViewSelectEventArgs e)
@@ -191,6 +211,7 @@ namespace MonoTests.System.Web.UI.WebControls
 			RecordEvent ("Enter");
 			base.OnSelectedIndexChanging (e);
 			RecordEvent ("Leave");
+			NoTailcall ();
 		}
 	
 		protected override void OnSorted (EventArgs e)
@@ -198,6 +219,7 @@ namespace MonoTests.System.Web.UI.WebControls
 			RecordEvent ("Enter");
 			base.OnSorted (e);
 			RecordEvent ("Leave");
+			NoTailcall ();
 		}
 	
 		protected override void OnSorting (ListViewSortEventArgs e)
@@ -205,6 +227,7 @@ namespace MonoTests.System.Web.UI.WebControls
 			RecordEvent ("Enter");
 			base.OnSorting (e);
 			RecordEvent ("Leave");
+			NoTailcall ();
 		}
 	
 		protected override void OnTotalRowCountAvailable (PageEventArgs e)
@@ -212,6 +235,7 @@ namespace MonoTests.System.Web.UI.WebControls
 			RecordEvent ("Enter");
 			base.OnTotalRowCountAvailable (e);
 			RecordEvent ("Leave");
+			NoTailcall ();
 		}
 
 		public void DoSetPageProperties (int startRowIndex, int maximumRows, bool databind)

--- a/mcs/class/corlib/Test/System.Diagnostics/StackFrameTest.cs
+++ b/mcs/class/corlib/Test/System.Diagnostics/StackFrameTest.cs
@@ -12,6 +12,7 @@ using System.Diagnostics;
 using System.Reflection;
 using NUnit.Framework;
 using System.Runtime.ExceptionServices;
+using System.Runtime.CompilerServices;
 
 namespace MonoTests.System.Diagnostics
 {
@@ -181,7 +182,7 @@ namespace MonoTests.System.Diagnostics
 							 frame1.GetFileLineNumber (),
 							 "Line number (1)");
 
-			Assert.AreEqual (135,
+			Assert.AreEqual (136,
 							 frame2.GetFileLineNumber (),
 							 "Line number (2)");
 
@@ -264,11 +265,15 @@ namespace MonoTests.System.Diagnostics
 		protected StackFrame frame1;
 		protected StackFrame frame2;
 
+		[MethodImplAttribute (MethodImplOptions.NoInlining)]
+		static void NoTailcall () { }
+
 		[SetUp]
 		public void SetUp ()
 		{
 			// In order to get better test cases with stack traces
 			NestedSetUp ();
+			NoTailcall ();
 		}
 
 		private void NestedSetUp ()
@@ -321,7 +326,7 @@ namespace MonoTests.System.Diagnostics
 							 frame1.GetFileLineNumber (),
 							 "Line number (1)");
 
-			Assert.AreEqual (271,
+			Assert.AreEqual (275,
 							 frame2.GetFileLineNumber (),
 							 "Line number (2)");
 		}

--- a/mcs/class/corlib/Test/System.Reflection.Emit/DynamicMethodTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection.Emit/DynamicMethodTest.cs
@@ -475,6 +475,9 @@ namespace MonoTests.System.Reflection.Emit
 	        DynamicMethod dm = new DynamicMethod("Foo", typeof(object), null);
 	        ILGenerator ilgen = dm.GetILGenerator();
 	        ilgen.Emit(OpCodes.Call, typeof(MethodBase).GetMethod("GetCurrentMethod"));
+		// Call twice and pop to avoid tailcall optimization.
+	        ilgen.Emit(OpCodes.Call, typeof(MethodBase).GetMethod("GetCurrentMethod"));
+	        ilgen.Emit(OpCodes.Pop);
 	        ilgen.Emit(OpCodes.Ret);
 	        RetObj del = (RetObj)dm.CreateDelegate(typeof(RetObj));
 		    MethodInfo res = (MethodInfo)del();

--- a/mcs/tools/mono-symbolicate/Makefile
+++ b/mcs/tools/mono-symbolicate/Makefile
@@ -12,7 +12,7 @@ include ../../build/executable.make
 
 LIB_PATH = $(topdir)/class/lib/$(PROFILE)
 
-MONO = MONO_PATH="$(LIB_PATH)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(RUNTIME) -O=-inline
+MONO = MONO_PATH="$(LIB_PATH)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(RUNTIME) -O=-inline,-tailc
 
 MSYM_DIR = $(OUT_DIR)/msymdir
 TEST_CS = Test/StackTraceDumper.cs

--- a/mono/tests/exception18.cs
+++ b/mono/tests/exception18.cs
@@ -38,6 +38,19 @@ class C
 				throw new Exception (String.Format("Exception carried {0} frames along with it when it should have reported one.", frames));
 		}
 
+		/*
+		FIXME This is measuring internal BCL code, which contains a tailcall.
+		Without tailcall optimization:
+			System.FormatException: Input string was not in a correct format.
+			at System.Number.ParseDouble (System.ReadOnlySpan`1[T] value, System.Globalization.NumberStyles options, System.Globalization.NumberFormatInfo numfmt)
+			at System.Double.Parse (System.String s)
+			at C.Main ()
+
+		With tailcall optimization:
+			System.FormatException: Input string was not in a correct format.
+			at System.Number.ParseDouble (System.ReadOnlySpan`1[T] value, System.Globalization.NumberStyles options, System.Globalization.NumberFormatInfo numfmt)
+			at C.Main ()
+		*/
 		try {
 			try {
 				double.Parse ("foo");
@@ -46,8 +59,8 @@ class C
 			}
 		} catch (Exception ex) {
 			int frames = FrameCount (ex);
-			if (frames != 3)
-				throw new Exception (String.Format("Exception carried {0} frames along with it when it should have reported three.", frames));
+			if (frames != 2 && frames != 3)
+				throw new Exception (String.Format("Exception carried {0} frames along with it when it should have reported two or three.", frames));
 		}
 
 		try {
@@ -68,15 +81,20 @@ class C
 	}
 
 	[MethodImpl(MethodImplOptions.NoInlining)]
+	static void NoTailcall () { }
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
 	private void M1a ()
 	{
 		M2a ();
+		NoTailcall ();
 	}
 
 	[MethodImpl(MethodImplOptions.NoInlining)]
 	private void M1b ()
 	{
 		M2b ();
+		NoTailcall ();
 	}
 
 	[MethodImpl(MethodImplOptions.NoInlining)]


### PR DESCRIPTION
only where it is fairly obvious what the problem is.

There are other problems but they aren't understood.

In particular code likes to walk stack to precisely verify
it is "as expected" or to report data based on its caller.

One unusual API fails to take a parameter but instead the parameter
is the calling class, called from .cctor.
