### PR TITLE
[cxx] Add extern "C" { } to many headers.

### DIFF
--- a/libgc/include/gc.h
+++ b/libgc/include/gc.h
@@ -42,11 +42,6 @@
 #   define GC_CONST
 #  endif
 
-# ifdef __cplusplus
-    extern "C" {
-# endif
-
-
 /* Define word and signed_word to be unsigned and signed types of the 	*/
 /* size as char * or void *.  There seems to be no way to do this	*/
 /* even semi-portably.  The following is probably no better/worse 	*/
@@ -64,6 +59,10 @@
   #include <stdint.h>
   typedef unsigned __int64 GC_word;
   typedef __int64 GC_signed_word;
+#endif
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 /* Public read-only variables */
@@ -501,7 +500,17 @@ GC_API GC_PTR GC_malloc_atomic_ignore_off_page GC_PROTO((size_t lb));
 #endif
 
 #if defined(__linux__) || defined(__GLIBC__)
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
 # include <features.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 # if (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 1 || __GLIBC__ > 2) \
      && !defined(__ia64__)
 #   ifndef GC_HAVE_BUILTIN_BACKTRACE
@@ -965,7 +974,17 @@ GC_API void (*GC_is_visible_print_proc)
 
 #if !defined(GC_USE_LD_WRAP) && \
     (defined(GC_PTHREADS) || defined(GC_SOLARIS_THREADS) || defined(GC_DARWIN_THREADS) || defined(GC_MACOSX_THREADS))
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
 # include "gc_pthread_redirects.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #endif
 
 # if defined(PCR) || defined(GC_SOLARIS_THREADS) || \
@@ -985,7 +1004,16 @@ extern void GC_thr_init(void);	/* Needed for Solaris/X86	*/
 #endif /* THREADS && !SRC_M3 */
 
 #if defined(GC_WIN32_THREADS) && !defined(__CYGWIN32__) && !defined(__CYGWIN__)
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
 # include <windows.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 # ifdef GC_INSIDE_DLL
    BOOL WINAPI GC_DllMain(HINSTANCE inst, ULONG reason, LPVOID reserved);
@@ -1081,6 +1109,10 @@ extern void GC_thr_init(void);	/* Needed for Solaris/X86	*/
     GC_API void GC_win32_free_heap ();
 #endif
 
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
 #if ( defined(_AMIGA) && !defined(GC_AMIGA_MAKINGLIB) )
   /* Allocation really goes through GC_amiga_allocwrapper_do */
 # include "gc_amiga_redirects.h"
@@ -1088,10 +1120,6 @@ extern void GC_thr_init(void);	/* Needed for Solaris/X86	*/
 
 #if defined(GC_REDIRECT_TO_LOCAL) && !defined(GC_LOCAL_ALLOC_H)
 #  include  "gc_local_alloc.h"
-#endif
-
-#ifdef __cplusplus
-    }  /* end of extern "C" */
 #endif
 
 #endif /* _GC_H */

--- a/libgc/include/gc_gcj.h
+++ b/libgc/include/gc_gcj.h
@@ -44,6 +44,10 @@
 #   include "gc.h"
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* The following allocators signal an out of memory condition with	*/
 /* return GC_oom_fn(bytes);						*/
 
@@ -109,5 +113,9 @@ extern int GC_gcj_debug_kind;
 #   define GC_GCJ_MALLOC_IGNORE_OFF_PAGE(s,d) \
 	GC_gcj_malloc_ignore_off_page(s,d)
 # endif
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif /* GC_GCJ_H */

--- a/libgc/include/gc_local_alloc.h
+++ b/libgc/include/gc_local_alloc.h
@@ -49,6 +49,10 @@
 #ifndef GC_LOCAL_ALLOC_H
 #define GC_LOCAL_ALLOC_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* We assume ANSI C for this interface.	*/
 
 GC_PTR GC_local_malloc(size_t bytes);
@@ -60,6 +64,10 @@ GC_PTR GC_local_malloc_atomic(size_t bytes);
 			     void * ptr_to_struct_containing_descr);
   GC_PTR GC_local_gcj_fast_malloc(size_t lw,
 			     void * ptr_to_struct_containing_descr);
+#endif
+
+#ifdef __cplusplus
+} // extern "C"
 #endif
 
 # ifdef GC_DEBUG

--- a/libgc/include/gc_pthread_redirects.h
+++ b/libgc/include/gc_pthread_redirects.h
@@ -15,6 +15,11 @@
 /* facility in thr_keycreate.  Alternatively, keep a redundant pointer	*/
 /* to thread specific data on the thread stack.			        */
 # include <thread.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
   int GC_thr_create(void *stack_base, size_t stack_size,
                     void *(*start_routine)(void *), void *arg, long flags,
                     thread_t *new_thread);
@@ -26,11 +31,22 @@
 # define thr_join GC_thr_join
 # define thr_suspend GC_thr_suspend
 # define thr_continue GC_thr_continue
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
 #endif /* GC_SOLARIS_THREADS */
 
 #if defined(GC_SOLARIS_PTHREADS)
+
 # include <pthread.h>
 # include <signal.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
   extern int GC_pthread_create(pthread_t *new_thread,
     			         const pthread_attr_t *attr,
           			 void * (*thread_execp)(void *), void *arg);
@@ -39,6 +55,11 @@
 # define pthread_join GC_pthread_join
 # define pthread_create GC_pthread_create
 # define pthread_detach GC_pthread_detach
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
 #endif
 
 #if defined(GC_SOLARIS_PTHREADS) || defined(GC_SOLARIS_THREADS)
@@ -50,6 +71,10 @@
 /* We treat these similarly. */
 # include <pthread.h>
 # include <signal.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
   int GC_pthread_create(pthread_t *new_thread,
                         const pthread_attr_t *attr,
@@ -85,6 +110,10 @@
 # endif
 # define pthread_sigmask GC_pthread_sigmask
 # define dlopen GC_dlopen
+#endif
+
+#ifdef __cplusplus
+} // extern "C"
 #endif
 
 #endif /* GC_xxxxx_THREADS */

--- a/libgc/include/private/gc_locks.h
+++ b/libgc/include/private/gc_locks.h
@@ -43,7 +43,17 @@
  *   
  */  
 # ifdef THREADS
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
    void GC_noop1 GC_PROTO((word));
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
 #  ifdef PCR_OBSOLETE	/* Faster, but broken with multiple lwp's	*/
 #    include  "th/PCR_Th.h"
 #    include  "th/PCR_ThCrSec.h"

--- a/libgc/include/private/gc_priv.h
+++ b/libgc/include/private/gc_priv.h
@@ -366,6 +366,10 @@ void GC_print_callers GC_PROTO((struct callinfo info[NFRAMES]));
 #   define BZERO(x,n) bzero((char *)(x),(int)(n))
 # endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(DARWIN)
 #	if defined(POWERPC)
 #		define GC_MACH_THREAD_STATE_FLAVOR PPC_THREAD_STATE
@@ -413,7 +417,18 @@ void GC_print_callers GC_PROTO((struct callinfo info[NFRAMES]));
  * Stop and restart mutator threads.
  */
 # ifdef PCR
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
 #     include "th/PCR_ThCtl.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 #     define STOP_WORLD() \
  	PCR_ThCtl_SetExclusiveMode(PCR_ThCtl_ExclusiveMode_stopNormal, \
  				   PCR_allSigsBlocked, \
@@ -1959,6 +1974,10 @@ void GC_err_puts GC_PROTO((GC_CONST char *s));
 		/* was already done, or there was nothing to do for	*/
 		/* some other reason.					*/
 # endif /* PARALLEL_MARK */
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 # if defined(GC_PTHREADS) && !defined(GC_SOLARIS_THREADS)
   /* We define the thread suspension signal here, so that we can refer	*/

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -54,6 +54,15 @@
 #define G_END_DECLS
 #endif
 
+// These macros are duplicated in mono-compiler.h, mono-publib.h, glib.h for maximum reach and consistency.
+#ifdef  __cplusplus
+#define MONO_BEGIN_DECLS  extern "C" {
+#define MONO_END_DECLS    }
+#else
+#define MONO_BEGIN_DECLS /* nothing */
+#define MONO_END_DECLS   /* nothing */
+#endif
+
 G_BEGIN_DECLS
 
 /*

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -46,21 +46,14 @@
 
 #define __EGLIB_X11 1
 
+// FIXMEcxx in future G_BEGIN_DECLS should always be empty, and/or remove all uses,
+// and extern "C" added to MONO_API instead.
 #ifdef  __cplusplus
 #define G_BEGIN_DECLS  extern "C" {
 #define G_END_DECLS    }
 #else
-#define G_BEGIN_DECLS
-#define G_END_DECLS
-#endif
-
-// These macros are duplicated in mono-compiler.h, mono-publib.h, glib.h for maximum reach and consistency.
-#ifdef  __cplusplus
-#define MONO_BEGIN_DECLS  extern "C" {
-#define MONO_END_DECLS    }
-#else
-#define MONO_BEGIN_DECLS /* nothing */
-#define MONO_END_DECLS   /* nothing */
+#define G_BEGIN_DECLS  /* nothing */
+#define G_END_DECLS    /* nothing */
 #endif
 
 G_BEGIN_DECLS

--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -415,6 +415,9 @@ libmonoruntimesgen_la_LIBADD = libmonoruntime-config.la
 libmonoruntimeincludedir = $(includedir)/mono-$(API_VER)/mono/metadata
 
 # This list is sorted for easier searching.
+# These are public headers.
+# They may not use G_BEGIN_DECLS, guint, glib.h, etc.
+# debug-mono-symfile.h is an exception. It is only semi-public.
 libmonoruntimeinclude_HEADERS = \
 	appdomain.h		\
 	assembly.h		\

--- a/mono/metadata/appdomain-icalls.h
+++ b/mono/metadata/appdomain-icalls.h
@@ -12,7 +12,7 @@
 #include <mono/metadata/handle.h>
 #include <mono/metadata/object-internals.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 MonoAppDomainHandle
 ves_icall_System_AppDomain_getCurDomain            (MonoError *error);
@@ -119,6 +119,6 @@ ves_icall_System_AppDomain_InternalGetProcessGuid (MonoStringHandle newguid, Mon
 MonoBoolean
 ves_icall_System_CLRConfig_CheckThrowUnobservedTaskExceptions (MonoError *error);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /*__MONO_METADATA_APPDOMAIN_ICALLS_H__*/

--- a/mono/metadata/appdomain-icalls.h
+++ b/mono/metadata/appdomain-icalls.h
@@ -12,6 +12,8 @@
 #include <mono/metadata/handle.h>
 #include <mono/metadata/object-internals.h>
 
+MONO_BEGIN_DECLS
+
 MonoAppDomainHandle
 ves_icall_System_AppDomain_getCurDomain            (MonoError *error);
 
@@ -117,5 +119,6 @@ ves_icall_System_AppDomain_InternalGetProcessGuid (MonoStringHandle newguid, Mon
 MonoBoolean
 ves_icall_System_CLRConfig_CheckThrowUnobservedTaskExceptions (MonoError *error);
 
+MONO_END_DECLS
 
 #endif /*__MONO_METADATA_APPDOMAIN_ICALLS_H__*/

--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -11,7 +11,7 @@
 #include <mono/metadata/assembly.h>
 #include <mono/metadata/metadata-internals.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 /* Flag bits for mono_assembly_names_equal_flags (). */
 typedef enum {
@@ -84,6 +84,6 @@ mono_assembly_get_name_internal (MonoAssembly *assembly);
 MONO_PROFILER_API MonoImage*
 mono_assembly_get_image_internal (MonoAssembly *assembly);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_METADATA_ASSEMBLY_INTERNALS_H__ */

--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -11,6 +11,8 @@
 #include <mono/metadata/assembly.h>
 #include <mono/metadata/metadata-internals.h>
 
+MONO_BEGIN_DECLS
+
 /* Flag bits for mono_assembly_names_equal_flags (). */
 typedef enum {
 	/* Default comparison: all fields must match */
@@ -81,5 +83,7 @@ mono_assembly_get_name_internal (MonoAssembly *assembly);
 
 MONO_PROFILER_API MonoImage*
 mono_assembly_get_image_internal (MonoAssembly *assembly);
+
+MONO_END_DECLS
 
 #endif /* __MONO_METADATA_ASSEMBLY_INTERNALS_H__ */

--- a/mono/metadata/cil-coff.h
+++ b/mono/metadata/cil-coff.h
@@ -8,6 +8,8 @@
 #include <mono/metadata/metadata.h>
 #include <glib.h>
 
+MONO_BEGIN_DECLS
+
 /*
  * 25.2.1: Method header type values
  */
@@ -331,5 +333,7 @@ typedef struct {
 } MonoCLIImageInfo;
 
 MONO_API guint32       mono_cli_rva_image_map (MonoImage *image, guint32 rva);
+
+MONO_END_DECLS
 
 #endif /* __MONO_CIL_COFF_H__ */

--- a/mono/metadata/cil-coff.h
+++ b/mono/metadata/cil-coff.h
@@ -8,7 +8,7 @@
 #include <mono/metadata/metadata.h>
 #include <glib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 /*
  * 25.2.1: Method header type values
@@ -334,6 +334,6 @@ typedef struct {
 
 MONO_API guint32       mono_cli_rva_image_map (MonoImage *image, guint32 rva);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_CIL_COFF_H__ */

--- a/mono/metadata/class-init.h
+++ b/mono/metadata/class-init.h
@@ -10,7 +10,7 @@
 #include <mono/metadata/metadata.h>
 #include <mono/metadata/class-internals.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 void
 mono_classes_init (void);
@@ -87,6 +87,6 @@ mono_class_setup_runtime_info (MonoClass *klass, MonoDomain *domain, MonoVTable 
 MonoClass *
 mono_class_create_array_fill_type (void);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/metadata/class-inlines.h
+++ b/mono/metadata/class-inlines.h
@@ -9,7 +9,7 @@
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/tabledefs.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 static inline MonoType*
 mono_get_void_type (void)
@@ -119,6 +119,6 @@ mono_class_has_static_metadata (MonoClass *klass)
 	return m_class_get_type_token (klass) && !m_class_get_image (klass)->dynamic && !mono_class_is_ginst (klass);
 }
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/metadata/class-inlines.h
+++ b/mono/metadata/class-inlines.h
@@ -9,6 +9,8 @@
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/tabledefs.h>
 
+MONO_BEGIN_DECLS
+
 static inline MonoType*
 mono_get_void_type (void)
 {
@@ -32,7 +34,6 @@ mono_get_object_type (void)
 {
 	return m_class_get_byval_arg (mono_defaults.object_class);
 }
-
 
 static inline gboolean
 mono_class_is_def (MonoClass *klass)
@@ -117,5 +118,7 @@ mono_class_has_static_metadata (MonoClass *klass)
 {
 	return m_class_get_type_token (klass) && !m_class_get_image (klass)->dynamic && !mono_class_is_ginst (klass);
 }
+
+MONO_END_DECLS
 
 #endif

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -15,6 +15,8 @@
 #include "mono/utils/mono-error.h"
 #include "mono/sgen/gc-internal-agnostic.h"
 
+MONO_BEGIN_DECLS
+
 #define MONO_CLASS_IS_ARRAY(c) (m_class_get_rank (c))
 
 #define MONO_CLASS_HAS_STATIC_METADATA(klass) (m_class_get_type_token (klass) && !m_class_get_image (klass)->dynamic && !mono_class_is_ginst (klass))
@@ -1431,6 +1433,8 @@ mono_class_contextbound_bit_offset (int* byte_offset_out, guint8* mask_out);
 
 gboolean
 mono_class_init_checked (MonoClass *klass, MonoError *error);
+
+MONO_END_DECLS
 
 /*Now that everything has been defined, let's include the inline functions */
 #include <mono/metadata/class-inlines.h>

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -15,7 +15,7 @@
 #include "mono/utils/mono-error.h"
 #include "mono/sgen/gc-internal-agnostic.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 #define MONO_CLASS_IS_ARRAY(c) (m_class_get_rank (c))
 
@@ -1434,7 +1434,7 @@ mono_class_contextbound_bit_offset (int* byte_offset_out, guint8* mask_out);
 gboolean
 mono_class_init_checked (MonoClass *klass, MonoError *error);
 
-MONO_END_DECLS
+G_END_DECLS
 
 /*Now that everything has been defined, let's include the inline functions */
 #include <mono/metadata/class-inlines.h>

--- a/mono/metadata/cominterop-win32-internals.h
+++ b/mono/metadata/cominterop-win32-internals.h
@@ -15,6 +15,8 @@
 // cases even inline.
 #if defined(HOST_WIN32) && !G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT | HAVE_UWP_WINAPI_SUPPORT)
 
+MONO_BEGIN_DECLS
+
 guint32
 mono_marshal_win_safearray_get_dim (gpointer safearray);
 
@@ -35,6 +37,8 @@ mono_marshal_win_safearray_create_internal (UINT cDims, SAFEARRAYBOUND *rgsaboun
 
 int
 mono_marshal_win_safearray_set_value (gpointer safearray, gpointer indices, gpointer value);
+
+MONO_END_DECLS
 
 #endif /* HOST_WIN32 && !G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT | HAVE_UWP_WINAPI_SUPPORT) */
 

--- a/mono/metadata/cominterop-win32-internals.h
+++ b/mono/metadata/cominterop-win32-internals.h
@@ -15,7 +15,7 @@
 // cases even inline.
 #if defined(HOST_WIN32) && !G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT | HAVE_UWP_WINAPI_SUPPORT)
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 guint32
 mono_marshal_win_safearray_get_dim (gpointer safearray);
@@ -38,7 +38,7 @@ mono_marshal_win_safearray_create_internal (UINT cDims, SAFEARRAYBOUND *rgsaboun
 int
 mono_marshal_win_safearray_set_value (gpointer safearray, gpointer indices, gpointer value);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* HOST_WIN32 && !G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT | HAVE_UWP_WINAPI_SUPPORT) */
 

--- a/mono/metadata/cominterop.h
+++ b/mono/metadata/cominterop.h
@@ -14,7 +14,7 @@
 #include <mono/metadata/method-builder-ilgen.h>
 #include <mono/metadata/marshal.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 void
 mono_cominterop_init (void);
@@ -73,6 +73,6 @@ mono_class_try_get_com_object_class (void);
 void*
 mono_cominterop_get_com_interface (MonoObject* object, MonoClass* ic, MonoError *error);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_COMINTEROP_H__ */

--- a/mono/metadata/cominterop.h
+++ b/mono/metadata/cominterop.h
@@ -14,6 +14,8 @@
 #include <mono/metadata/method-builder-ilgen.h>
 #include <mono/metadata/marshal.h>
 
+MONO_BEGIN_DECLS
+
 void
 mono_cominterop_init (void);
 
@@ -70,5 +72,7 @@ mono_class_try_get_com_object_class (void);
 
 void*
 mono_cominterop_get_com_interface (MonoObject* object, MonoClass* ic, MonoError *error);
+
+MONO_END_DECLS
 
 #endif /* __MONO_COMINTEROP_H__ */

--- a/mono/metadata/coree-internals.h
+++ b/mono/metadata/coree-internals.h
@@ -12,6 +12,8 @@
 #ifdef HOST_WIN32
 #include <windows.h>
 
+MONO_BEGIN_DECLS
+
 BOOL STDMETHODCALLTYPE
 _CorDllMain (HINSTANCE hInst, DWORD dwReason, LPVOID lpReserved);
 
@@ -39,6 +41,9 @@ HMODULE WINAPI
 MonoLoadImage (LPCWSTR FileName);
 
 void mono_coree_set_act_ctx (const char *file_name);
+
+MONO_END_DECLS
+
 #endif /* HOST_WIN32 */
 
 #endif /* __MONO_COREE_INTERNALS_H__ */

--- a/mono/metadata/coree-internals.h
+++ b/mono/metadata/coree-internals.h
@@ -12,7 +12,7 @@
 #ifdef HOST_WIN32
 #include <windows.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 BOOL STDMETHODCALLTYPE
 _CorDllMain (HINSTANCE hInst, DWORD dwReason, LPVOID lpReserved);
@@ -42,7 +42,7 @@ MonoLoadImage (LPCWSTR FileName);
 
 void mono_coree_set_act_ctx (const char *file_name);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* HOST_WIN32 */
 

--- a/mono/metadata/coree.h
+++ b/mono/metadata/coree.h
@@ -21,6 +21,8 @@
 #include <mono/utils/w32api.h>
 #include "image.h"
 
+MONO_BEGIN_DECLS
+
 #define STATUS_SUCCESS 0x00000000L
 #define STATUS_INVALID_IMAGE_FORMAT 0xC000007BL
 
@@ -47,6 +49,8 @@ void mono_fixup_exe_image (MonoImage* image);
 
 /* Declared in image.c. */
 MonoImage* mono_image_open_from_module_handle (HMODULE module_handle, char* fname, gboolean has_entry_point, MonoImageOpenStatus* status);
+
+MONO_END_DECLS
 
 #endif /* HOST_WIN32 */
 

--- a/mono/metadata/coree.h
+++ b/mono/metadata/coree.h
@@ -21,7 +21,7 @@
 #include <mono/utils/w32api.h>
 #include "image.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 #define STATUS_SUCCESS 0x00000000L
 #define STATUS_INVALID_IMAGE_FORMAT 0xC000007BL
@@ -50,7 +50,7 @@ void mono_fixup_exe_image (MonoImage* image);
 /* Declared in image.c. */
 MonoImage* mono_image_open_from_module_handle (HMODULE module_handle, char* fname, gboolean has_entry_point, MonoImageOpenStatus* status);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* HOST_WIN32 */
 

--- a/mono/metadata/culture-info.h
+++ b/mono/metadata/culture-info.h
@@ -8,6 +8,8 @@
 #include <glib.h>
 #include <mono/metadata/object.h>
 
+MONO_BEGIN_DECLS
+
 #define NUM_DAYS 7
 #define NUM_MONTHS 13
 #define GROUP_SIZE 2
@@ -133,5 +135,6 @@ typedef struct {
 	const gint16 region_entry_index;
 } RegionInfoNameEntry;
 
-#endif
+MONO_END_DECLS
 
+#endif

--- a/mono/metadata/culture-info.h
+++ b/mono/metadata/culture-info.h
@@ -8,7 +8,7 @@
 #include <glib.h>
 #include <mono/metadata/object.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 #define NUM_DAYS 7
 #define NUM_MONTHS 13
@@ -135,6 +135,6 @@ typedef struct {
 	const gint16 region_entry_index;
 } RegionInfoNameEntry;
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/metadata/custom-attrs-internals.h
+++ b/mono/metadata/custom-attrs-internals.h
@@ -9,7 +9,7 @@
 #include <mono/metadata/object-internals.h>
 #include <mono/metadata/reflection.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 MonoCustomAttrInfo*
 mono_custom_attrs_from_builders (MonoImage *alloc_img, MonoImage *image, MonoArray *cattrs);
@@ -29,6 +29,7 @@ void
 mono_reflection_create_custom_attr_data_args_noalloc (MonoImage *image, MonoMethod *method, const guchar *data, guint32 len,
 													  gpointer **typed_args, gpointer **named_args, int *num_named_args,
 													  CattrNamedArg **named_arg_info, MonoError *error);
-MONO_END_DECLS
+
+G_END_DECLS
 
 #endif  /* __MONO_METADATA_REFLECTION_CUSTOM_ATTRS_INTERNALS_H__ */

--- a/mono/metadata/custom-attrs-internals.h
+++ b/mono/metadata/custom-attrs-internals.h
@@ -9,6 +9,8 @@
 #include <mono/metadata/object-internals.h>
 #include <mono/metadata/reflection.h>
 
+MONO_BEGIN_DECLS
+
 MonoCustomAttrInfo*
 mono_custom_attrs_from_builders (MonoImage *alloc_img, MonoImage *image, MonoArray *cattrs);
 
@@ -27,5 +29,6 @@ void
 mono_reflection_create_custom_attr_data_args_noalloc (MonoImage *image, MonoMethod *method, const guchar *data, guint32 len,
 													  gpointer **typed_args, gpointer **named_args, int *num_named_args,
 													  CattrNamedArg **named_arg_info, MonoError *error);
+MONO_END_DECLS
 
 #endif  /* __MONO_METADATA_REFLECTION_CUSTOM_ATTRS_INTERNALS_H__ */

--- a/mono/metadata/debug-internals.h
+++ b/mono/metadata/debug-internals.h
@@ -6,6 +6,8 @@
 #include <mono/metadata/mono-debug.h>
 #include <mono/utils/mono-compiler.h>
 
+MONO_BEGIN_DECLS
+
 struct _MonoDebugMethodInfo {
 	MonoMethod *method;
 	MonoDebugHandle *handle;
@@ -86,5 +88,7 @@ mono_debug_image_has_debug_info (MonoImage *image);
 
 MonoDebugSourceLocation *
 mono_debug_lookup_source_location_by_il (MonoMethod *method, guint32 il_offset, MonoDomain *domain);
+
+MONO_END_DECLS
 
 #endif /* __DEBUG_INTERNALS_H__ */

--- a/mono/metadata/debug-internals.h
+++ b/mono/metadata/debug-internals.h
@@ -6,7 +6,7 @@
 #include <mono/metadata/mono-debug.h>
 #include <mono/utils/mono-compiler.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 struct _MonoDebugMethodInfo {
 	MonoMethod *method;
@@ -89,6 +89,6 @@ mono_debug_image_has_debug_info (MonoImage *image);
 MonoDebugSourceLocation *
 mono_debug_lookup_source_location_by_il (MonoMethod *method, guint32 il_offset, MonoDomain *domain);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __DEBUG_INTERNALS_H__ */

--- a/mono/metadata/debug-mono-ppdb.h
+++ b/mono/metadata/debug-mono-ppdb.h
@@ -17,6 +17,8 @@
 #include <mono/metadata/metadata-internals.h>
 #include <mono/metadata/mono-debug.h>
 
+MONO_BEGIN_DECLS
+
 MonoPPDBFile*
 mono_ppdb_load_file (MonoImage *image, const guint8 *raw_contents, int size);
 
@@ -40,5 +42,7 @@ mono_ppdb_lookup_method_async_debug_info (MonoDebugMethodInfo *minfo);
 
 MonoImage *
 mono_ppdb_get_image (MonoPPDBFile *ppdb);
+
+MONO_END_DECLS
 
 #endif

--- a/mono/metadata/debug-mono-ppdb.h
+++ b/mono/metadata/debug-mono-ppdb.h
@@ -17,7 +17,7 @@
 #include <mono/metadata/metadata-internals.h>
 #include <mono/metadata/mono-debug.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 MonoPPDBFile*
 mono_ppdb_load_file (MonoImage *image, const guint8 *raw_contents, int size);
@@ -43,6 +43,6 @@ mono_ppdb_lookup_method_async_debug_info (MonoDebugMethodInfo *minfo);
 MonoImage *
 mono_ppdb_get_image (MonoPPDBFile *ppdb);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -18,6 +18,8 @@
 #include <mono/utils/mono-internal-hash.h>
 #include <mono/metadata/mempool-internals.h>
 
+MONO_BEGIN_DECLS
+
 /*
  * If this is set, the memory belonging to appdomains is not freed when a domain is
  * unloaded, and assemblies loaded by the appdomain are not unloaded either. This
@@ -618,5 +620,7 @@ mono_assembly_has_reference_assembly_attribute (MonoAssembly *assembly, MonoErro
 
 GPtrArray*
 mono_domain_get_assemblies (MonoDomain *domain, gboolean refonly);
+
+MONO_END_DECLS
 
 #endif /* __MONO_METADATA_DOMAIN_INTERNALS_H__ */

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -18,7 +18,7 @@
 #include <mono/utils/mono-internal-hash.h>
 #include <mono/metadata/mempool-internals.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 /*
  * If this is set, the memory belonging to appdomains is not freed when a domain is
@@ -621,6 +621,6 @@ mono_assembly_has_reference_assembly_attribute (MonoAssembly *assembly, MonoErro
 GPtrArray*
 mono_domain_get_assemblies (MonoDomain *domain, gboolean refonly);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_METADATA_DOMAIN_INTERNALS_H__ */

--- a/mono/metadata/dynamic-image-internals.h
+++ b/mono/metadata/dynamic-image-internals.h
@@ -10,6 +10,8 @@
 #include <mono/metadata/metadata-internals.h>
 #include <mono/metadata/object-internals.h>
 
+MONO_BEGIN_DECLS
+
 typedef struct {
 	guint32 import_lookup_table;
 	guint32 timestamp;
@@ -51,5 +53,6 @@ mono_dynamic_image_add_to_blob_cached (MonoDynamicImage *assembly, char *b1, int
 void
 mono_dynimage_alloc_table (MonoDynamicTable *table, guint nrows);
 
-#endif  /* __MONO_METADATA_DYNAMIC_IMAGE_INTERNALS_H__ */
+MONO_END_DECLS
 
+#endif  /* __MONO_METADATA_DYNAMIC_IMAGE_INTERNALS_H__ */

--- a/mono/metadata/dynamic-image-internals.h
+++ b/mono/metadata/dynamic-image-internals.h
@@ -10,7 +10,7 @@
 #include <mono/metadata/metadata-internals.h>
 #include <mono/metadata/object-internals.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 typedef struct {
 	guint32 import_lookup_table;
@@ -53,6 +53,6 @@ mono_dynamic_image_add_to_blob_cached (MonoDynamicImage *assembly, char *b1, int
 void
 mono_dynimage_alloc_table (MonoDynamicTable *table, guint nrows);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif  /* __MONO_METADATA_DYNAMIC_IMAGE_INTERNALS_H__ */

--- a/mono/metadata/dynamic-stream-internals.h
+++ b/mono/metadata/dynamic-stream-internals.h
@@ -9,6 +9,8 @@
 #include <mono/metadata/object.h>
 #include <mono/metadata/metadata-internals.h>
 
+MONO_BEGIN_DECLS
+
 void
 mono_dynstream_init (MonoDynamicStream *stream);
 
@@ -27,5 +29,6 @@ mono_dynstream_add_zero (MonoDynamicStream *stream, guint32 len);
 void
 mono_dynstream_data_align (MonoDynamicStream *stream);
 
-#endif  /* __MONO_METADATA_DYNAMIC_STREAM_INTERNALS_H__ */
+MONO_END_DECLS
 
+#endif  /* __MONO_METADATA_DYNAMIC_STREAM_INTERNALS_H__ */

--- a/mono/metadata/dynamic-stream-internals.h
+++ b/mono/metadata/dynamic-stream-internals.h
@@ -9,7 +9,7 @@
 #include <mono/metadata/object.h>
 #include <mono/metadata/metadata-internals.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 void
 mono_dynstream_init (MonoDynamicStream *stream);
@@ -29,6 +29,6 @@ mono_dynstream_add_zero (MonoDynamicStream *stream, guint32 len);
 void
 mono_dynstream_data_align (MonoDynamicStream *stream);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif  /* __MONO_METADATA_DYNAMIC_STREAM_INTERNALS_H__ */

--- a/mono/metadata/exception-internals.h
+++ b/mono/metadata/exception-internals.h
@@ -11,6 +11,8 @@
 #include <mono/metadata/handle.h>
 #include <mono/utils/mono-error.h>
 
+MONO_BEGIN_DECLS
+
 MonoExceptionHandle
 mono_get_exception_type_initialization_handle (const gchar *type_name, MonoExceptionHandle inner, MonoError *error);
 
@@ -83,5 +85,7 @@ mono_get_exception_out_of_memory_handle (void);
 
 MonoExceptionHandle
 mono_exception_new_argument_null (const char *arg, MonoError *error);
+
+MONO_END_DECLS
 
 #endif

--- a/mono/metadata/exception-internals.h
+++ b/mono/metadata/exception-internals.h
@@ -11,7 +11,7 @@
 #include <mono/metadata/handle.h>
 #include <mono/utils/mono-error.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 MonoExceptionHandle
 mono_get_exception_type_initialization_handle (const gchar *type_name, MonoExceptionHandle inner, MonoError *error);
@@ -86,6 +86,6 @@ mono_get_exception_out_of_memory_handle (void);
 MonoExceptionHandle
 mono_exception_new_argument_null (const char *arg, MonoError *error);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/metadata/file-mmap.h
+++ b/mono/metadata/file-mmap.h
@@ -18,6 +18,8 @@
 #include <mono/metadata/object-internals.h>
 #include <mono/utils/mono-compiler.h>
 
+G_BEGIN_DECLS
+
 void
 mono_mmap_close (void *mmap_handle, MonoError *error);
 
@@ -38,5 +40,7 @@ mono_mmap_map (void *handle, gint64 offset, gint64 *size, int access, void **mma
 
 gboolean
 mono_mmap_unmap (void *base_address, MonoError *error);
+
+G_END_DECLS
 
 #endif /* _MONO_METADATA_FILE_MMAP_H_ */

--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -18,7 +18,7 @@
 #include <mono/metadata/threads-types.h>
 #include <mono/sgen/gc-internal-agnostic.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 #define mono_domain_finalizers_lock(domain) mono_os_mutex_lock (&(domain)->finalizable_objects_hash_lock);
 #define mono_domain_finalizers_unlock(domain) mono_os_mutex_unlock (&(domain)->finalizable_objects_hash_lock);
@@ -426,6 +426,6 @@ extern gboolean mono_do_not_finalize;
 /* List of names of classes not to finalize. */
 extern gchar **mono_do_not_finalize_class_names;
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_METADATA_GC_INTERNAL_H__ */

--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -18,6 +18,8 @@
 #include <mono/metadata/threads-types.h>
 #include <mono/sgen/gc-internal-agnostic.h>
 
+MONO_BEGIN_DECLS
+
 #define mono_domain_finalizers_lock(domain) mono_os_mutex_lock (&(domain)->finalizable_objects_hash_lock);
 #define mono_domain_finalizers_unlock(domain) mono_os_mutex_unlock (&(domain)->finalizable_objects_hash_lock);
 
@@ -424,5 +426,6 @@ extern gboolean mono_do_not_finalize;
 /* List of names of classes not to finalize. */
 extern gchar **mono_do_not_finalize_class_names;
 
-#endif /* __MONO_METADATA_GC_INTERNAL_H__ */
+MONO_END_DECLS
 
+#endif /* __MONO_METADATA_GC_INTERNAL_H__ */

--- a/mono/metadata/icall-table.c
+++ b/mono/metadata/icall-table.c
@@ -36,7 +36,7 @@
 #include <mono/utils/mono-publib.h>
 #include <mono/utils/bsearch.h>
 
-MONO_BEGIN_DECLS // lack of prototypes
+G_BEGIN_DECLS // lack of prototypes
 
 /*
  * icall.c defines a lot of icalls as static, to avoid having to add prototypes for
@@ -446,7 +446,7 @@ lookup_icall_symbol (gpointer func)
 #endif
 }
 
-MONO_END_DECLS // lack of prototypes
+G_END_DECLS // lack of prototypes
 
 void
 mono_icall_table_init (void)

--- a/mono/metadata/icall-table.c
+++ b/mono/metadata/icall-table.c
@@ -36,6 +36,8 @@
 #include <mono/utils/mono-publib.h>
 #include <mono/utils/bsearch.h>
 
+G_BEGIN_DECLS // lack of prototypes
+
 /*
  * icall.c defines a lot of icalls as static, to avoid having to add prototypes for
  * them, just don't include any mono headers and emit dummy prototypes.
@@ -443,6 +445,8 @@ lookup_icall_symbol (gpointer func)
 	return NULL;
 #endif
 }
+
+G_END_DECLS // lack of prototypes
 
 void
 mono_icall_table_init (void)

--- a/mono/metadata/icall-table.c
+++ b/mono/metadata/icall-table.c
@@ -36,7 +36,7 @@
 #include <mono/utils/mono-publib.h>
 #include <mono/utils/bsearch.h>
 
-G_BEGIN_DECLS // lack of prototypes
+MONO_BEGIN_DECLS // lack of prototypes
 
 /*
  * icall.c defines a lot of icalls as static, to avoid having to add prototypes for
@@ -446,7 +446,7 @@ lookup_icall_symbol (gpointer func)
 #endif
 }
 
-G_END_DECLS // lack of prototypes
+MONO_END_DECLS // lack of prototypes
 
 void
 mono_icall_table_init (void)

--- a/mono/metadata/icall-table.h
+++ b/mono/metadata/icall-table.h
@@ -12,6 +12,8 @@
 
 #define MONO_ICALL_TABLE_CALLBACKS_VERSION 1
 
+G_BEGIN_DECLS
+
 typedef struct {
 	int version;
 	gpointer (*lookup) (char *classname, char *methodname, char *sigstart, gboolean *uses_handles);
@@ -23,5 +25,7 @@ mono_install_icall_table_callbacks (MonoIcallTableCallbacks *cb);
 
 MONO_API void
 mono_icall_table_init (void);
+
+G_END_DECLS
 
 #endif

--- a/mono/metadata/icall-table.h
+++ b/mono/metadata/icall-table.h
@@ -12,7 +12,7 @@
 
 #define MONO_ICALL_TABLE_CALLBACKS_VERSION 1
 
-G_BEGIN_DECLS
+MONO_BEGIN_DECLS
 
 typedef struct {
 	int version;
@@ -26,6 +26,6 @@ mono_install_icall_table_callbacks (MonoIcallTableCallbacks *cb);
 MONO_API void
 mono_icall_table_init (void);
 
-G_END_DECLS
+MONO_END_DECLS
 
 #endif

--- a/mono/metadata/icall-table.h
+++ b/mono/metadata/icall-table.h
@@ -12,7 +12,7 @@
 
 #define MONO_ICALL_TABLE_CALLBACKS_VERSION 1
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 typedef struct {
 	int version;
@@ -26,6 +26,6 @@ mono_install_icall_table_callbacks (MonoIcallTableCallbacks *cb);
 MONO_API void
 mono_icall_table_init (void);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -6669,7 +6669,9 @@ ves_icall_System_Environment_GetEnvironmentVariable_native (const gchar *utf8_na
  * arm-apple-darwin9.  We'll manually define the symbol on Apple as it does
  * in fact exist on all implementations (so far) 
  */
+G_BEGIN_DECLS
 gchar ***_NSGetEnviron(void);
+G_END_DECLS
 #define environ (*_NSGetEnviron())
 #else
 static char *mono_environ[1] = { NULL };

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -107,6 +107,8 @@
 #include <sys/utsname.h>
 #endif
 
+G_BEGIN_DECLS // lack of prototypes
+
 /* icalls are defined ICALL_EXPORT so they are not static */
 #ifdef __GNUC__
 #pragma GCC diagnostic ignored "-Wmissing-prototypes"
@@ -8475,3 +8477,5 @@ ves_icall_System_GC_RecordPressure (gint64 value, MonoError *error)
 {
 	mono_gc_add_memory_pressure (value);
 }
+
+G_END_DECLS // lack of prototypes

--- a/mono/metadata/image-internals.h
+++ b/mono/metadata/image-internals.h
@@ -8,7 +8,7 @@
 
 #include <mono/metadata/image.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 MonoImage *
 mono_find_image_owner (void *ptr);
@@ -25,6 +25,6 @@ mono_image_open_a_lot (const char *fname, MonoImageOpenStatus *status, gboolean 
 gboolean
 mono_is_problematic_image (MonoImage *image);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_METADATA_IMAGE_INTERNALS_H__ */

--- a/mono/metadata/image-internals.h
+++ b/mono/metadata/image-internals.h
@@ -8,6 +8,8 @@
 
 #include <mono/metadata/image.h>
 
+MONO_BEGIN_DECLS
+
 MonoImage *
 mono_find_image_owner (void *ptr);
 
@@ -22,5 +24,7 @@ mono_image_open_a_lot (const char *fname, MonoImageOpenStatus *status, gboolean 
 
 gboolean
 mono_is_problematic_image (MonoImage *image);
+
+MONO_END_DECLS
 
 #endif /* __MONO_METADATA_IMAGE_INTERNALS_H__ */

--- a/mono/metadata/locales.h
+++ b/mono/metadata/locales.h
@@ -15,6 +15,8 @@
 
 #include <mono/metadata/object-internals.h>
 
+MONO_BEGIN_DECLS
+
 /* This is a copy of System.Globalization.CompareOptions */
 typedef enum {
 	CompareOptions_None=0x00,
@@ -53,5 +55,7 @@ extern MonoString *ves_icall_System_String_InternalToUpper_Comp (MonoString *thi
 extern gunichar2 ves_icall_System_Char_InternalToUpper_Comp (gunichar2 c, MonoCultureInfo *cult);
 extern gunichar2 ves_icall_System_Char_InternalToLower_Comp (gunichar2 c, MonoCultureInfo *cult);
 extern void ves_icall_System_Text_Normalization_load_normalization_resource (guint8 **argProps, guint8** argMappedChars, guint8** argCharMapIndex, guint8** argHelperIndex, guint8** argMapIdxToComposite, guint8** argCombiningClass, MonoError *error);
+
+MONO_END_DECLS
 
 #endif /* _MONO_METADATA_FILEIO_H_ */

--- a/mono/metadata/locales.h
+++ b/mono/metadata/locales.h
@@ -15,7 +15,7 @@
 
 #include <mono/metadata/object-internals.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 /* This is a copy of System.Globalization.CompareOptions */
 typedef enum {
@@ -56,6 +56,6 @@ extern gunichar2 ves_icall_System_Char_InternalToUpper_Comp (gunichar2 c, MonoCu
 extern gunichar2 ves_icall_System_Char_InternalToLower_Comp (gunichar2 c, MonoCultureInfo *cult);
 extern void ves_icall_System_Text_Normalization_load_normalization_resource (guint8 **argProps, guint8** argMappedChars, guint8** argCharMapIndex, guint8** argHelperIndex, guint8** argMapIdxToComposite, guint8** argCombiningClass, MonoError *error);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* _MONO_METADATA_FILEIO_H_ */

--- a/mono/metadata/marshal-ilgen.h
+++ b/mono/metadata/marshal-ilgen.h
@@ -6,11 +6,11 @@
 #ifndef __MONO_MARSHAL_ILGEN_H__
 #define __MONO_MARSHAL_ILGEN_H__
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 MONO_API void
 mono_marshal_ilgen_init (void);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/metadata/marshal-ilgen.h
+++ b/mono/metadata/marshal-ilgen.h
@@ -6,7 +6,11 @@
 #ifndef __MONO_MARSHAL_ILGEN_H__
 #define __MONO_MARSHAL_ILGEN_H__
 
+MONO_BEGIN_DECLS
+
 MONO_API void
 mono_marshal_ilgen_init (void);
+
+MONO_END_DECLS
 
 #endif

--- a/mono/metadata/marshal-internals.h
+++ b/mono/metadata/marshal-internals.h
@@ -10,7 +10,7 @@
 #include <glib.h>
 #include <mono/metadata/object-internals.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 MonoObjectHandle
 mono_marshal_xdomain_copy_value_handle (MonoObjectHandle val, MonoError *error);
@@ -47,6 +47,6 @@ typedef enum {
 	TYPECHECK_CACHE_ARG_POS = 2
 } MarshalTypeCheckPositions;
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_METADATA_MARSHAL_INTERNALS_H__ */

--- a/mono/metadata/marshal-internals.h
+++ b/mono/metadata/marshal-internals.h
@@ -10,6 +10,8 @@
 #include <glib.h>
 #include <mono/metadata/object-internals.h>
 
+MONO_BEGIN_DECLS
+
 MonoObjectHandle
 mono_marshal_xdomain_copy_value_handle (MonoObjectHandle val, MonoError *error);
 
@@ -44,5 +46,7 @@ typedef enum {
 	TYPECHECK_CLASS_ARG_POS = 1,
 	TYPECHECK_CACHE_ARG_POS = 2
 } MarshalTypeCheckPositions;
+
+MONO_END_DECLS
 
 #endif /* __MONO_METADATA_MARSHAL_INTERNALS_H__ */

--- a/mono/metadata/mempool-internals.h
+++ b/mono/metadata/mempool-internals.h
@@ -10,6 +10,8 @@
 #include "mono/utils/mono-compiler.h"
 #include "mono/metadata/mempool.h"
 
+MONO_BEGIN_DECLS
+
 static inline GList*
 g_list_prepend_mempool (MonoMemPool *mp, GList *list, gpointer data)
 {
@@ -83,5 +85,7 @@ mono_mempool_strdup_printf (MonoMemPool *pool, const char *format, ...) MONO_ATT
 
 long
 mono_mempool_get_bytes_allocated (void);
+
+MONO_END_DECLS
 
 #endif

--- a/mono/metadata/mempool-internals.h
+++ b/mono/metadata/mempool-internals.h
@@ -10,7 +10,7 @@
 #include "mono/utils/mono-compiler.h"
 #include "mono/metadata/mempool.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 static inline GList*
 g_list_prepend_mempool (MonoMemPool *mp, GList *list, gpointer data)
@@ -86,6 +86,6 @@ mono_mempool_strdup_printf (MonoMemPool *pool, const char *format, ...) MONO_ATT
 long
 mono_mempool_get_bytes_allocated (void);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/metadata/mempool.h
+++ b/mono/metadata/mempool.h
@@ -7,6 +7,7 @@
 
 #include <mono/utils/mono-publib.h>
 
+// G_BEGIN_DECLS is not always available here. Fallback to what works.
 MONO_BEGIN_DECLS
 
 typedef struct _MonoMemPool MonoMemPool;

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -19,6 +19,8 @@
 #include <mono/utils/mono-error.h>
 #include "mono/utils/mono-conc-hashtable.h"
 
+MONO_BEGIN_DECLS
+
 struct _MonoType {
 	union {
 		MonoClass *klass; /* for VALUETYPE and CLASS */
@@ -1016,5 +1018,6 @@ mono_type_in_image (MonoType *type, MonoImage *image);
 MonoAssemblyContextKind
 mono_asmctx_get_kind (const MonoAssemblyContext *ctx);
 
-#endif /* __MONO_METADATA_INTERNALS_H__ */
+MONO_END_DECLS
 
+#endif /* __MONO_METADATA_INTERNALS_H__ */

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -19,7 +19,7 @@
 #include <mono/utils/mono-error.h>
 #include "mono/utils/mono-conc-hashtable.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 struct _MonoType {
 	union {
@@ -1018,6 +1018,6 @@ mono_type_in_image (MonoType *type, MonoImage *image);
 MonoAssemblyContextKind
 mono_asmctx_get_kind (const MonoAssemblyContext *ctx);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_METADATA_INTERNALS_H__ */

--- a/mono/metadata/method-builder-ilgen.h
+++ b/mono/metadata/method-builder-ilgen.h
@@ -14,6 +14,8 @@
 #include <mono/metadata/reflection.h>
 #include <mono/metadata/method-builder.h>
 
+MONO_BEGIN_DECLS
+
 MONO_API void
 mono_method_builder_ilgen_init (void);
 
@@ -121,5 +123,7 @@ mono_mb_set_clauses (MonoMethodBuilder *mb, int num_clauses, MonoExceptionClause
 
 void
 mono_mb_set_param_names (MonoMethodBuilder *mb, const char **param_names);
+
+MONO_END_DECLS
 
 #endif

--- a/mono/metadata/method-builder-ilgen.h
+++ b/mono/metadata/method-builder-ilgen.h
@@ -14,7 +14,7 @@
 #include <mono/metadata/reflection.h>
 #include <mono/metadata/method-builder.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 MONO_API void
 mono_method_builder_ilgen_init (void);
@@ -124,6 +124,6 @@ mono_mb_set_clauses (MonoMethodBuilder *mb, int num_clauses, MonoExceptionClause
 void
 mono_mb_set_param_names (MonoMethodBuilder *mb, const char **param_names);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/metadata/mono-conc-hash.h
+++ b/mono/metadata/mono-conc-hash.h
@@ -8,6 +8,7 @@
 
 #include <mono/metadata/mono-hash.h>
 
+MONO_BEGIN_DECLS
 
 typedef struct _MonoConcGHashTable MonoConcGHashTable;
 
@@ -18,5 +19,7 @@ void mono_conc_g_hash_table_foreach (MonoConcGHashTable *hash, GHFunc func, gpoi
 void mono_conc_g_hash_table_destroy (MonoConcGHashTable *hash);
 gpointer mono_conc_g_hash_table_insert (MonoConcGHashTable *h, gpointer k, gpointer v);
 gpointer mono_conc_g_hash_table_remove (MonoConcGHashTable *hash, gconstpointer key);
+
+MONO_END_DECLS
 
 #endif /* __MONO_CONC_G_HASH_H__ */

--- a/mono/metadata/mono-conc-hash.h
+++ b/mono/metadata/mono-conc-hash.h
@@ -8,7 +8,7 @@
 
 #include <mono/metadata/mono-hash.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 typedef struct _MonoConcGHashTable MonoConcGHashTable;
 
@@ -20,6 +20,6 @@ void mono_conc_g_hash_table_destroy (MonoConcGHashTable *hash);
 gpointer mono_conc_g_hash_table_insert (MonoConcGHashTable *h, gpointer k, gpointer v);
 gpointer mono_conc_g_hash_table_remove (MonoConcGHashTable *hash, gconstpointer key);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_CONC_G_HASH_H__ */

--- a/mono/metadata/mono-config-dirs.h
+++ b/mono/metadata/mono-config-dirs.h
@@ -8,6 +8,8 @@
 #include <config.h>
 #include <glib.h>
 
+G_BEGIN_DECLS
+
 const char*
 mono_config_get_assemblies_dir (void);
 
@@ -19,5 +21,7 @@ mono_config_get_bin_dir (void);
 
 const char*
 mono_config_get_reloc_lib_dir (void);
+
+G_END_DECLS
 
 #endif

--- a/mono/metadata/mono-config-dirs.h
+++ b/mono/metadata/mono-config-dirs.h
@@ -8,7 +8,7 @@
 #include <config.h>
 #include <glib.h>
 
-G_BEGIN_DECLS
+MONO_BEGIN_DECLS
 
 const char*
 mono_config_get_assemblies_dir (void);
@@ -22,6 +22,6 @@ mono_config_get_bin_dir (void);
 const char*
 mono_config_get_reloc_lib_dir (void);
 
-G_END_DECLS
+MONO_END_DECLS
 
 #endif

--- a/mono/metadata/mono-config-dirs.h
+++ b/mono/metadata/mono-config-dirs.h
@@ -8,7 +8,7 @@
 #include <config.h>
 #include <glib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 const char*
 mono_config_get_assemblies_dir (void);
@@ -22,6 +22,6 @@ mono_config_get_bin_dir (void);
 const char*
 mono_config_get_reloc_lib_dir (void);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/metadata/mono-endian.h
+++ b/mono/metadata/mono-endian.h
@@ -7,6 +7,8 @@
 
 #include <glib.h>
 
+G_BEGIN_DECLS
+
 typedef union {
 	guint32 ival;
 	float fval;
@@ -93,5 +95,7 @@ guint64 mono_read64 (const unsigned char *x);
 		mf.ival = read64 ((x));	\
 		*(dest) = mf.fval;	\
 	} while (0)
+
+G_END_DECLS
 
 #endif /* _MONO_METADATA_ENDIAN_H_ */

--- a/mono/metadata/mono-endian.h
+++ b/mono/metadata/mono-endian.h
@@ -7,7 +7,7 @@
 
 #include <glib.h>
 
-G_BEGIN_DECLS
+MONO_BEGIN_DECLS
 
 typedef union {
 	guint32 ival;
@@ -96,6 +96,6 @@ guint64 mono_read64 (const unsigned char *x);
 		*(dest) = mf.fval;	\
 	} while (0)
 
-G_END_DECLS
+MONO_END_DECLS
 
 #endif /* _MONO_METADATA_ENDIAN_H_ */

--- a/mono/metadata/mono-endian.h
+++ b/mono/metadata/mono-endian.h
@@ -7,7 +7,7 @@
 
 #include <glib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 typedef union {
 	guint32 ival;
@@ -96,6 +96,6 @@ guint64 mono_read64 (const unsigned char *x);
 		*(dest) = mf.fval;	\
 	} while (0)
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* _MONO_METADATA_ENDIAN_H_ */

--- a/mono/metadata/mono-hash.h
+++ b/mono/metadata/mono-hash.h
@@ -14,7 +14,7 @@
 
 #include <mono/metadata/mono-gc.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 /* do not change the values of this enum */
 typedef enum {
 	MONO_HASH_KEY_GC = 1,
@@ -39,5 +39,5 @@ MONO_API void     mono_g_hash_table_insert          (MonoGHashTable *h, gpointer
 MONO_API void     mono_g_hash_table_replace         (MonoGHashTable *h, gpointer k, gpointer v);
 MONO_API void     mono_g_hash_table_print_stats     (MonoGHashTable *table);
 
-MONO_END_DECLS
+G_END_DECLS
 #endif /* __MONO_G_HASH_H__ */

--- a/mono/metadata/mono-mlist.h
+++ b/mono/metadata/mono-mlist.h
@@ -11,6 +11,8 @@
 
 #include <mono/metadata/object.h>
 
+MONO_BEGIN_DECLS
+
 typedef struct _MonoMList MonoMList;
 MONO_RT_EXTERNAL_ONLY
 MONO_API MonoMList*  mono_mlist_alloc       (MonoObject *data);
@@ -30,5 +32,6 @@ MonoMList*  mono_mlist_append_checked       (MonoMList* list, MonoObject *data, 
 
 MONO_API MonoMList*  mono_mlist_remove_item (MonoMList* list, MonoMList *item);
 
-#endif /* __MONO_METADATA_MONO_MLIST_H__ */
+MONO_END_DECLS
 
+#endif /* __MONO_METADATA_MONO_MLIST_H__ */

--- a/mono/metadata/mono-mlist.h
+++ b/mono/metadata/mono-mlist.h
@@ -11,6 +11,7 @@
 
 #include <mono/metadata/object.h>
 
+// G_BEGIN_DECLS is not always available here. Fallback to what works.
 MONO_BEGIN_DECLS
 
 typedef struct _MonoMList MonoMList;

--- a/mono/metadata/mono-perfcounters.h
+++ b/mono/metadata/mono-perfcounters.h
@@ -9,6 +9,8 @@
 #include <mono/metadata/object.h>
 #include <mono/utils/mono-compiler.h>
 
+MONO_BEGIN_DECLS
+
 typedef struct _MonoCounterSample MonoCounterSample;
 
 void* mono_perfcounter_get_impl (MonoString* category, MonoString* counter, MonoString* instance,
@@ -32,5 +34,6 @@ MonoArray*  mono_perfcounter_instance_names  (MonoString *category);
 typedef gboolean (*PerfCounterEnumCallback) (char *category_name, char *name, unsigned char type, gint64 value, gpointer user_data);
 MONO_API void mono_perfcounter_foreach (PerfCounterEnumCallback cb, gpointer user_data);
 
-#endif /* __MONO_PERFCOUNTERS_H__ */
+MONO_END_DECLS
 
+#endif /* __MONO_PERFCOUNTERS_H__ */

--- a/mono/metadata/mono-perfcounters.h
+++ b/mono/metadata/mono-perfcounters.h
@@ -9,7 +9,7 @@
 #include <mono/metadata/object.h>
 #include <mono/utils/mono-compiler.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 typedef struct _MonoCounterSample MonoCounterSample;
 
@@ -34,6 +34,6 @@ MonoArray*  mono_perfcounter_instance_names  (MonoString *category);
 typedef gboolean (*PerfCounterEnumCallback) (char *category_name, char *name, unsigned char type, gint64 value, gpointer user_data);
 MONO_API void mono_perfcounter_foreach (PerfCounterEnumCallback cb, gpointer user_data);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_PERFCOUNTERS_H__ */

--- a/mono/metadata/mono-route.h
+++ b/mono/metadata/mono-route.h
@@ -19,10 +19,14 @@
 
 #include <mono/metadata/object-internals.h>
 
+MONO_BEGIN_DECLS
+
 in_addr_t gateway_from_rtm (struct rt_msghdr *rtm);
 
 /* Category icalls */
 extern MonoBoolean ves_icall_System_Net_NetworkInformation_MacOsIPInterfaceProperties_ParseRouteInfo_internal (MonoString *iface, MonoArray **gw_addr_list);
+
+MONO_END_DECLS
 
 #endif /* #if defined(HOST_DARWIN) || defined(HOST_BSD) */
 #endif /* __MONO_ROUTE_H__ */

--- a/mono/metadata/mono-route.h
+++ b/mono/metadata/mono-route.h
@@ -19,14 +19,14 @@
 
 #include <mono/metadata/object-internals.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 in_addr_t gateway_from_rtm (struct rt_msghdr *rtm);
 
 /* Category icalls */
 extern MonoBoolean ves_icall_System_Net_NetworkInformation_MacOsIPInterfaceProperties_ParseRouteInfo_internal (MonoString *iface, MonoArray **gw_addr_list);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* #if defined(HOST_DARWIN) || defined(HOST_BSD) */
 #endif /* __MONO_ROUTE_H__ */

--- a/mono/metadata/mono-security-windows-internals.h
+++ b/mono/metadata/mono-security-windows-internals.h
@@ -16,7 +16,7 @@
 #include "mono/metadata/metadata.h"
 #include "mono/metadata/metadata-internals.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 gint32
 mono_security_win_get_token_name (gpointer token, gunichar2 ** uniname);
@@ -33,7 +33,7 @@ mono_security_win_protect_machine (const gunichar2 *path, MonoError *error);
 gboolean
 mono_security_win_protect_user (const gunichar2 *path, MonoError *error);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* HOST_WIN32 */
 

--- a/mono/metadata/mono-security-windows-internals.h
+++ b/mono/metadata/mono-security-windows-internals.h
@@ -16,6 +16,8 @@
 #include "mono/metadata/metadata.h"
 #include "mono/metadata/metadata-internals.h"
 
+MONO_BEGIN_DECLS
+
 gint32
 mono_security_win_get_token_name (gpointer token, gunichar2 ** uniname);
 
@@ -30,6 +32,8 @@ mono_security_win_protect_machine (const gunichar2 *path, MonoError *error);
 
 gboolean
 mono_security_win_protect_user (const gunichar2 *path, MonoError *error);
+
+MONO_END_DECLS
 
 #endif /* HOST_WIN32 */
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -21,7 +21,7 @@
 #include "mono/utils/mono-tls.h"
 #include "mono/utils/mono-coop-mutex.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 /* Use this as MONO_CHECK_ARG (arg,expr,) in functions returning void */
 #define MONO_CHECK_ARG(arg, expr, retval) do {				\
@@ -2085,6 +2085,6 @@ mono_class_get_virtual_method (MonoClass *klass, MonoMethod *method, gboolean is
 MonoStringHandle
 mono_string_empty_handle (MonoDomain *domain);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_OBJECT_INTERNALS_H__ */

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -21,6 +21,8 @@
 #include "mono/utils/mono-tls.h"
 #include "mono/utils/mono-coop-mutex.h"
 
+MONO_BEGIN_DECLS
+
 /* Use this as MONO_CHECK_ARG (arg,expr,) in functions returning void */
 #define MONO_CHECK_ARG(arg, expr, retval) do {				\
 	if (G_UNLIKELY (!(expr)))					\
@@ -2082,5 +2084,7 @@ mono_class_get_virtual_method (MonoClass *klass, MonoMethod *method, gboolean is
 
 MonoStringHandle
 mono_string_empty_handle (MonoDomain *domain);
+
+MONO_END_DECLS
 
 #endif /* __MONO_OBJECT_INTERNALS_H__ */

--- a/mono/metadata/profiler-private.h
+++ b/mono/metadata/profiler-private.h
@@ -13,7 +13,7 @@
 #include <mono/utils/mono-os-mutex.h>
 #include <mono/utils/mono-os-semaphore.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 struct _MonoProfilerDesc {
 	MonoProfilerHandle next;
@@ -188,6 +188,6 @@ mono_profiler_clauses_enabled (void)
 			mono_profiler_raise_ ## name args; \
 	} while (0)
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif // __MONO_PROFILER_PRIVATE_H__

--- a/mono/metadata/profiler-private.h
+++ b/mono/metadata/profiler-private.h
@@ -13,6 +13,8 @@
 #include <mono/utils/mono-os-mutex.h>
 #include <mono/utils/mono-os-semaphore.h>
 
+MONO_BEGIN_DECLS
+
 struct _MonoProfilerDesc {
 	MonoProfilerHandle next;
 	MonoProfiler *prof;
@@ -185,5 +187,7 @@ mono_profiler_clauses_enabled (void)
 		if (MONO_PROFILER_ENABLED (name)) \
 			mono_profiler_raise_ ## name args; \
 	} while (0)
+
+MONO_END_DECLS
 
 #endif // __MONO_PROFILER_PRIVATE_H__

--- a/mono/metadata/property-bag.h
+++ b/mono/metadata/property-bag.h
@@ -12,6 +12,10 @@
 
 #include <mono/utils/mono-compiler.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct _MonoPropertyBagItem MonoPropertyBagItem;
 
 struct _MonoPropertyBagItem {
@@ -25,5 +29,9 @@ typedef struct {
 
 void* mono_property_bag_get (MonoPropertyBag *bag, int tag);
 void* mono_property_bag_add (MonoPropertyBag *bag, void *value);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif

--- a/mono/metadata/property-bag.h
+++ b/mono/metadata/property-bag.h
@@ -12,6 +12,7 @@
 
 #include <mono/utils/mono-compiler.h>
 
+// Neither MONO_BEGIN_DECLS nor G_BEGIN_DECLS is available here. Fallback to what works.
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/mono/metadata/rand.h
+++ b/mono/metadata/rand.h
@@ -18,7 +18,7 @@
 #include <mono/metadata/object.h>
 #include "mono/utils/mono-compiler.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 MonoBoolean
 ves_icall_System_Security_Cryptography_RNGCryptoServiceProvider_RngOpen (MonoError *error);
@@ -32,6 +32,6 @@ ves_icall_System_Security_Cryptography_RNGCryptoServiceProvider_RngGetBytes (gpo
 void
 ves_icall_System_Security_Cryptography_RNGCryptoServiceProvider_RngClose (gpointer handle, MonoError *error);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/metadata/rand.h
+++ b/mono/metadata/rand.h
@@ -18,6 +18,8 @@
 #include <mono/metadata/object.h>
 #include "mono/utils/mono-compiler.h"
 
+MONO_BEGIN_DECLS
+
 MonoBoolean
 ves_icall_System_Security_Cryptography_RNGCryptoServiceProvider_RngOpen (MonoError *error);
 
@@ -29,5 +31,7 @@ ves_icall_System_Security_Cryptography_RNGCryptoServiceProvider_RngGetBytes (gpo
 
 void
 ves_icall_System_Security_Cryptography_RNGCryptoServiceProvider_RngClose (gpointer handle, MonoError *error);
+
+MONO_END_DECLS
 
 #endif

--- a/mono/metadata/reflection-cache.h
+++ b/mono/metadata/reflection-cache.h
@@ -13,6 +13,8 @@
 #include <mono/metadata/mempool.h>
 #include <mono/utils/mono-error-internals.h>
 
+MONO_BEGIN_DECLS
+
 /*
  * We need to return always the same object for MethodInfo, FieldInfo etc..
  * but we need to consider the reflected type.
@@ -131,5 +133,7 @@ check_or_construct_handle (MonoDomain *domain, MonoClass *klass, gpointer item, 
 #define CHECK_OR_CONSTRUCT_HANDLE(t,p,k,construct,ud) \
 	(MONO_HANDLE_CAST (t, check_or_construct_handle ( \
 		domain, (k), (p), (ud), error, (ReflectionCacheConstructFunc_handle) (construct))))
+
+MONO_END_DECLS
 
 #endif /*__MONO_METADATA_REFLECTION_CACHE_H__*/

--- a/mono/metadata/reflection-cache.h
+++ b/mono/metadata/reflection-cache.h
@@ -13,7 +13,7 @@
 #include <mono/metadata/mempool.h>
 #include <mono/utils/mono-error-internals.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 /*
  * We need to return always the same object for MethodInfo, FieldInfo etc..
@@ -134,6 +134,6 @@ check_or_construct_handle (MonoDomain *domain, MonoClass *klass, gpointer item, 
 	(MONO_HANDLE_CAST (t, check_or_construct_handle ( \
 		domain, (k), (p), (ud), error, (ReflectionCacheConstructFunc_handle) (construct))))
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /*__MONO_METADATA_REFLECTION_CACHE_H__*/

--- a/mono/metadata/reflection-internals.h
+++ b/mono/metadata/reflection-internals.h
@@ -13,6 +13,8 @@
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-error.h>
 
+MONO_BEGIN_DECLS
+
 gboolean
 mono_reflection_parse_type_checked (char *name, MonoTypeNameParse *info, MonoError *error);
 
@@ -115,5 +117,6 @@ mono_method_body_get_object_handle (MonoDomain *domain, MonoMethod *method, Mono
 MonoClass *
 mono_class_from_mono_type_handle (MonoReflectionTypeHandle h);
 
+MONO_END_DECLS
 
 #endif /* __MONO_METADATA_REFLECTION_INTERNALS_H__ */

--- a/mono/metadata/reflection-internals.h
+++ b/mono/metadata/reflection-internals.h
@@ -13,7 +13,7 @@
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-error.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 gboolean
 mono_reflection_parse_type_checked (char *name, MonoTypeNameParse *info, MonoError *error);
@@ -117,6 +117,6 @@ mono_method_body_get_object_handle (MonoDomain *domain, MonoMethod *method, Mono
 MonoClass *
 mono_class_from_mono_type_handle (MonoReflectionTypeHandle h);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_METADATA_REFLECTION_INTERNALS_H__ */

--- a/mono/metadata/remoting.h
+++ b/mono/metadata/remoting.h
@@ -14,6 +14,8 @@
 #include <mono/metadata/object-internals.h>
 #include <mono/metadata/class-internals.h>
 
+MONO_BEGIN_DECLS
+
 void mono_remoting_init (void);
 
 #ifndef DISABLE_REMOTING
@@ -43,5 +45,7 @@ MonoMethod *
 mono_marshal_get_proxy_cancast (MonoClass *klass);
 
 #endif
+
+MONO_END_DECLS
 
 #endif

--- a/mono/metadata/remoting.h
+++ b/mono/metadata/remoting.h
@@ -14,7 +14,7 @@
 #include <mono/metadata/object-internals.h>
 #include <mono/metadata/class-internals.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 void mono_remoting_init (void);
 
@@ -46,6 +46,6 @@ mono_marshal_get_proxy_cancast (MonoClass *klass);
 
 #endif
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/metadata/runtime.h
+++ b/mono/metadata/runtime.h
@@ -16,7 +16,7 @@
 #include <mono/utils/mono-publib.h>
 #include <mono/utils/mono-compiler.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 gboolean mono_runtime_try_shutdown (void);
 
@@ -24,7 +24,7 @@ void mono_runtime_init_tls (void);
 
 MONO_PROFILER_API char* mono_runtime_get_aotid (void);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* _MONO_METADATA_RUNTIME_H_ */
 

--- a/mono/metadata/security-core-clr.h
+++ b/mono/metadata/security-core-clr.h
@@ -15,6 +15,8 @@
 #include <mono/metadata/reflection.h>
 #include <mono/utils/mono-compiler.h>
 
+MONO_BEGIN_DECLS
+
 typedef enum {
 	/* We compare these values as integers, so the order must not
 	   be changed. */
@@ -66,5 +68,7 @@ extern MONO_API gboolean mono_security_core_clr_require_elevated_permissions (vo
 
 extern MONO_API void mono_security_core_clr_set_options (MonoSecurityCoreCLROptions options);
 extern MONO_API MonoSecurityCoreCLROptions mono_security_core_clr_get_options (void);
+
+MONO_END_DECLS
 
 #endif	/* _MONO_METADATA_SECURITY_CORE_CLR_H_ */

--- a/mono/metadata/security-core-clr.h
+++ b/mono/metadata/security-core-clr.h
@@ -15,7 +15,7 @@
 #include <mono/metadata/reflection.h>
 #include <mono/utils/mono-compiler.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 typedef enum {
 	/* We compare these values as integers, so the order must not
@@ -69,6 +69,6 @@ extern MONO_API gboolean mono_security_core_clr_require_elevated_permissions (vo
 extern MONO_API void mono_security_core_clr_set_options (MonoSecurityCoreCLROptions options);
 extern MONO_API MonoSecurityCoreCLROptions mono_security_core_clr_get_options (void);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif	/* _MONO_METADATA_SECURITY_CORE_CLR_H_ */

--- a/mono/metadata/security-manager.h
+++ b/mono/metadata/security-manager.h
@@ -24,6 +24,7 @@
 #include "reflection.h"
 #include "tabledefs.h"
 
+MONO_BEGIN_DECLS
 
 /* Definitions */
 
@@ -69,5 +70,7 @@ void ves_icall_System_Security_SecurityManager_set_SecurityEnabled (MonoBoolean 
 #else
 #define mono_security_core_clr_enabled() (FALSE)
 #endif
+
+MONO_END_DECLS
 
 #endif /* _MONO_METADATA_SECURITY_MANAGER_H_ */

--- a/mono/metadata/security-manager.h
+++ b/mono/metadata/security-manager.h
@@ -24,7 +24,7 @@
 #include "reflection.h"
 #include "tabledefs.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 /* Definitions */
 
@@ -71,6 +71,6 @@ void ves_icall_System_Security_SecurityManager_set_SecurityEnabled (MonoBoolean 
 #define mono_security_core_clr_enabled() (FALSE)
 #endif
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* _MONO_METADATA_SECURITY_MANAGER_H_ */

--- a/mono/metadata/seq-points-data.h
+++ b/mono/metadata/seq-points-data.h
@@ -9,6 +9,8 @@
 
 #include <glib.h>
 
+G_BEGIN_DECLS
+
 #define MONO_SEQ_POINT_FLAG_NONEMPTY_STACK 1
 #define MONO_SEQ_POINT_FLAG_EXIT_IL 2
 
@@ -115,5 +117,7 @@ mono_seq_point_data_get (SeqPointData *data, guint32 methodToken, guint32 method
 
 gboolean
 mono_seq_point_data_get_il_offset (char *path, guint32 methodToken, guint32 methodIndex, guint32 native_offset, guint32 *il_offset);
+
+G_END_DECLS
 
 #endif /* __MONO_SEQ_POINTS_DATA_H__ */

--- a/mono/metadata/seq-points-data.h
+++ b/mono/metadata/seq-points-data.h
@@ -9,7 +9,7 @@
 
 #include <glib.h>
 
-G_BEGIN_DECLS
+MONO_BEGIN_DECLS
 
 #define MONO_SEQ_POINT_FLAG_NONEMPTY_STACK 1
 #define MONO_SEQ_POINT_FLAG_EXIT_IL 2
@@ -118,6 +118,6 @@ mono_seq_point_data_get (SeqPointData *data, guint32 methodToken, guint32 method
 gboolean
 mono_seq_point_data_get_il_offset (char *path, guint32 methodToken, guint32 methodIndex, guint32 native_offset, guint32 *il_offset);
 
-G_END_DECLS
+MONO_END_DECLS
 
 #endif /* __MONO_SEQ_POINTS_DATA_H__ */

--- a/mono/metadata/seq-points-data.h
+++ b/mono/metadata/seq-points-data.h
@@ -9,7 +9,7 @@
 
 #include <glib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 #define MONO_SEQ_POINT_FLAG_NONEMPTY_STACK 1
 #define MONO_SEQ_POINT_FLAG_EXIT_IL 2
@@ -118,6 +118,6 @@ mono_seq_point_data_get (SeqPointData *data, guint32 methodToken, guint32 method
 gboolean
 mono_seq_point_data_get_il_offset (char *path, guint32 methodToken, guint32 methodIndex, guint32 native_offset, guint32 *il_offset);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_SEQ_POINTS_DATA_H__ */

--- a/mono/metadata/sgen-bridge-internals.h
+++ b/mono/metadata/sgen-bridge-internals.h
@@ -19,6 +19,8 @@
 #include "mono/sgen/sgen-gc.h"
 #include "mono/metadata/sgen-bridge.h"
 
+MONO_BEGIN_DECLS
+
 extern volatile gboolean mono_bridge_processing_in_progress;
 extern MonoGCBridgeCallbacks mono_bridge_callbacks;
 
@@ -72,6 +74,8 @@ void sgen_tarjan_bridge_init (SgenBridgeProcessor *collector);
 void sgen_set_bridge_implementation (const char *name);
 void sgen_bridge_set_dump_prefix (const char *prefix);
 void sgen_init_bridge (void);
+
+MONO_END_DECLS
 
 #endif
 

--- a/mono/metadata/sgen-bridge-internals.h
+++ b/mono/metadata/sgen-bridge-internals.h
@@ -19,7 +19,7 @@
 #include "mono/sgen/sgen-gc.h"
 #include "mono/metadata/sgen-bridge.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 extern volatile gboolean mono_bridge_processing_in_progress;
 extern MonoGCBridgeCallbacks mono_bridge_callbacks;
@@ -75,7 +75,7 @@ void sgen_set_bridge_implementation (const char *name);
 void sgen_bridge_set_dump_prefix (const char *prefix);
 void sgen_init_bridge (void);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif
 

--- a/mono/metadata/sgen-client-mono.h
+++ b/mono/metadata/sgen-client-mono.h
@@ -14,7 +14,7 @@
 #include "utils/mono-mmap.h"
 #include "metadata/object-internals.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 typedef MonoObject GCObject;
 typedef MonoVTable* GCVTable;
@@ -729,6 +729,6 @@ gboolean sgen_has_managed_allocator (void);
 void sgen_scan_for_registered_roots_in_domain (MonoDomain *domain, int root_type);
 void sgen_null_links_for_domain (MonoDomain *domain);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/metadata/sgen-client-mono.h
+++ b/mono/metadata/sgen-client-mono.h
@@ -14,6 +14,8 @@
 #include "utils/mono-mmap.h"
 #include "metadata/object-internals.h"
 
+MONO_BEGIN_DECLS
+
 typedef MonoObject GCObject;
 typedef MonoVTable* GCVTable;
 
@@ -726,5 +728,7 @@ gboolean sgen_has_managed_allocator (void);
 
 void sgen_scan_for_registered_roots_in_domain (MonoDomain *domain, int root_type);
 void sgen_null_links_for_domain (MonoDomain *domain);
+
+MONO_END_DECLS
 
 #endif

--- a/mono/metadata/sgen-dynarray.h
+++ b/mono/metadata/sgen-dynarray.h
@@ -5,6 +5,8 @@
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
 
+MONO_BEGIN_DECLS
+
  // Growable array implementation used by sgen-new-bridge and sgen-tarjan-bridge.
 
 typedef struct {
@@ -345,3 +347,5 @@ dyn_array_ptr_set_all (DynPtrArray *dst, DynPtrArray *src)
 	}
 	dst->array.size = src->array.size;
 }
+
+MONO_END_DECLS

--- a/mono/metadata/sgen-dynarray.h
+++ b/mono/metadata/sgen-dynarray.h
@@ -5,7 +5,7 @@
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
  // Growable array implementation used by sgen-new-bridge and sgen-tarjan-bridge.
 
@@ -348,4 +348,4 @@ dyn_array_ptr_set_all (DynPtrArray *dst, DynPtrArray *src)
 	dst->array.size = src->array.size;
 }
 
-MONO_END_DECLS
+G_END_DECLS

--- a/mono/metadata/sgen-mono-ilgen.h
+++ b/mono/metadata/sgen-mono-ilgen.h
@@ -8,6 +8,11 @@
 
 #include "config.h"
 
+MONO_BEGIN_DECLS
+
 MONO_API void
 mono_sgen_mono_ilgen_init (void);
+
+MONO_END_DECLS
+
 #endif

--- a/mono/metadata/sgen-mono-ilgen.h
+++ b/mono/metadata/sgen-mono-ilgen.h
@@ -8,11 +8,11 @@
 
 #include "config.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 MONO_API void
 mono_sgen_mono_ilgen_init (void);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/metadata/sgen-toggleref.h
+++ b/mono/metadata/sgen-toggleref.h
@@ -15,7 +15,7 @@
 
 #include <mono/utils/mono-publib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 /* GC toggle ref support */
 
@@ -28,6 +28,6 @@ typedef enum {
 MONO_API void mono_gc_toggleref_register_callback (MonoToggleRefStatus (*proccess_toggleref) (MonoObject *obj));
 MONO_API void mono_gc_toggleref_add (MonoObject *object, mono_bool strong_ref);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/metadata/sre-internals.h
+++ b/mono/metadata/sre-internals.h
@@ -8,6 +8,8 @@
 
 #include <mono/metadata/object-internals.h>
 
+MONO_BEGIN_DECLS
+
 /* Keep in sync with System.Reflection.Emit.AssemblyBuilderAccess */
 enum MonoAssemblyBuilderAccess {
 	MonoAssemblyBuilderAccess_Run = 1,                /* 0b0001 */
@@ -153,5 +155,6 @@ mono_dynimage_save_encode_property_signature (MonoDynamicImage *assembly, MonoRe
 guint32
 mono_image_get_methodref_token (MonoDynamicImage *assembly, MonoMethod *method, gboolean create_typespec);
 
-#endif  /* __MONO_METADATA_SRE_INTERNALS_H__ */
+MONO_END_DECLS
 
+#endif  /* __MONO_METADATA_SRE_INTERNALS_H__ */

--- a/mono/metadata/sre-internals.h
+++ b/mono/metadata/sre-internals.h
@@ -8,7 +8,7 @@
 
 #include <mono/metadata/object-internals.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 /* Keep in sync with System.Reflection.Emit.AssemblyBuilderAccess */
 enum MonoAssemblyBuilderAccess {
@@ -155,6 +155,6 @@ mono_dynimage_save_encode_property_signature (MonoDynamicImage *assembly, MonoRe
 guint32
 mono_image_get_methodref_token (MonoDynamicImage *assembly, MonoMethod *method, gboolean create_typespec);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif  /* __MONO_METADATA_SRE_INTERNALS_H__ */

--- a/mono/metadata/string-icalls.h
+++ b/mono/metadata/string-icalls.h
@@ -19,6 +19,8 @@
 #include <mono/metadata/object.h>
 #include "mono/utils/mono-compiler.h"
 
+MONO_BEGIN_DECLS
+
 void
 ves_icall_System_String_ctor_RedirectToCreateString (void);
 
@@ -33,5 +35,7 @@ ves_icall_System_String_InternalIsInterned (MonoString *str);
 
 int
 ves_icall_System_String_GetLOSLimit (void);
+
+MONO_END_DECLS
 
 #endif /* _MONO_CLI_STRING_ICALLS_H_ */

--- a/mono/metadata/string-icalls.h
+++ b/mono/metadata/string-icalls.h
@@ -19,7 +19,7 @@
 #include <mono/metadata/object.h>
 #include "mono/utils/mono-compiler.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 void
 ves_icall_System_String_ctor_RedirectToCreateString (void);
@@ -36,6 +36,6 @@ ves_icall_System_String_InternalIsInterned (MonoString *str);
 int
 ves_icall_System_String_GetLOSLimit (void);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* _MONO_CLI_STRING_ICALLS_H_ */

--- a/mono/metadata/sysmath.h
+++ b/mono/metadata/sysmath.h
@@ -16,7 +16,7 @@
 #include <config.h>
 #include <glib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 gdouble
 ves_icall_System_Math_Floor (gdouble x);
@@ -150,6 +150,6 @@ ves_icall_System_MathF_FMod (float x, float y);
 float
 ves_icall_System_MathF_ModF (float x, float *d);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/metadata/sysmath.h
+++ b/mono/metadata/sysmath.h
@@ -16,6 +16,8 @@
 #include <config.h>
 #include <glib.h>
 
+G_BEGIN_DECLS
+
 gdouble
 ves_icall_System_Math_Floor (gdouble x);
 
@@ -147,5 +149,7 @@ ves_icall_System_MathF_FMod (float x, float y);
 
 float
 ves_icall_System_MathF_ModF (float x, float *d);
+
+G_END_DECLS
 
 #endif

--- a/mono/metadata/sysmath.h
+++ b/mono/metadata/sysmath.h
@@ -16,7 +16,7 @@
 #include <config.h>
 #include <glib.h>
 
-G_BEGIN_DECLS
+MONO_BEGIN_DECLS
 
 gdouble
 ves_icall_System_Math_Floor (gdouble x);
@@ -150,6 +150,6 @@ ves_icall_System_MathF_FMod (float x, float y);
 float
 ves_icall_System_MathF_ModF (float x, float *d);
 
-G_END_DECLS
+MONO_END_DECLS
 
 #endif

--- a/mono/metadata/threadpool-io.h
+++ b/mono/metadata/threadpool-io.h
@@ -10,6 +10,8 @@
 
 #include <mono/metadata/object-internals.h>
 
+MONO_BEGIN_DECLS
+
 typedef struct _MonoIOSelectorJob MonoIOSelectorJob;
 
 void
@@ -24,5 +26,7 @@ void
 mono_threadpool_io_remove_domain_jobs (MonoDomain *domain);
 void
 mono_threadpool_io_cleanup (void);
+
+MONO_END_DECLS
 
 #endif /* _MONO_METADATA_THREADPOOL_IO_H_ */

--- a/mono/metadata/threadpool-io.h
+++ b/mono/metadata/threadpool-io.h
@@ -10,7 +10,7 @@
 
 #include <mono/metadata/object-internals.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 typedef struct _MonoIOSelectorJob MonoIOSelectorJob;
 
@@ -27,6 +27,6 @@ mono_threadpool_io_remove_domain_jobs (MonoDomain *domain);
 void
 mono_threadpool_io_cleanup (void);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* _MONO_METADATA_THREADPOOL_IO_H_ */

--- a/mono/metadata/threadpool-worker.h
+++ b/mono/metadata/threadpool-worker.h
@@ -7,6 +7,8 @@
 
 #include <glib.h>
 
+MONO_BEGIN_DECLS
+
 typedef void (*MonoThreadPoolWorkerCallback)(void);
 
 void
@@ -33,5 +35,7 @@ mono_threadpool_worker_set_max (gint32 value);
 
 void
 mono_threadpool_worker_set_suspended (gboolean suspended);
+
+MONO_END_DECLS
 
 #endif /* _MONO_METADATA_THREADPOOL_WORKER_H */

--- a/mono/metadata/threadpool-worker.h
+++ b/mono/metadata/threadpool-worker.h
@@ -7,7 +7,7 @@
 
 #include <glib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 typedef void (*MonoThreadPoolWorkerCallback)(void);
 
@@ -36,6 +36,6 @@ mono_threadpool_worker_set_max (gint32 value);
 void
 mono_threadpool_worker_set_suspended (gboolean suspended);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* _MONO_METADATA_THREADPOOL_WORKER_H */

--- a/mono/metadata/threadpool.h
+++ b/mono/metadata/threadpool.h
@@ -11,7 +11,7 @@
 #include <mono/metadata/exception.h>
 #include <mono/metadata/object-internals.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 typedef struct _MonoNativeOverlapped MonoNativeOverlapped;
 
@@ -68,6 +68,6 @@ ves_icall_System_Threading_ThreadPool_IsThreadPoolHosted (MonoError *error);
 gboolean
 mono_threadpool_enqueue_work_item (MonoDomain *domain, MonoObject *work_item, MonoError *error);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif // _MONO_METADATA_THREADPOOL_H_

--- a/mono/metadata/threadpool.h
+++ b/mono/metadata/threadpool.h
@@ -11,6 +11,8 @@
 #include <mono/metadata/exception.h>
 #include <mono/metadata/object-internals.h>
 
+MONO_BEGIN_DECLS
+
 typedef struct _MonoNativeOverlapped MonoNativeOverlapped;
 
 void
@@ -65,5 +67,7 @@ ves_icall_System_Threading_ThreadPool_IsThreadPoolHosted (MonoError *error);
 
 gboolean
 mono_threadpool_enqueue_work_item (MonoDomain *domain, MonoObject *work_item, MonoError *error);
+
+MONO_END_DECLS
 
 #endif // _MONO_METADATA_THREADPOOL_H_

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -22,7 +22,7 @@
 #include "mono/utils/mono-threads.h"
 #include "mono/metadata/class-internals.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 /* This is a copy of System.Threading.ThreadState */
 typedef enum {
@@ -387,6 +387,6 @@ gboolean
 mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes);
 #endif
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* _MONO_METADATA_THREADS_TYPES_H_ */

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -22,6 +22,8 @@
 #include "mono/utils/mono-threads.h"
 #include "mono/metadata/class-internals.h"
 
+MONO_BEGIN_DECLS
+
 /* This is a copy of System.Threading.ThreadState */
 typedef enum {
 	ThreadState_Running = 0x00000000,
@@ -384,5 +386,7 @@ typedef struct {
 gboolean
 mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes);
 #endif
+
+MONO_END_DECLS
 
 #endif /* _MONO_METADATA_THREADS_TYPES_H_ */

--- a/mono/metadata/w32error.h
+++ b/mono/metadata/w32error.h
@@ -8,6 +8,8 @@
 #include <config.h>
 #include <glib.h>
 
+G_BEGIN_DECLS
+
 #if !defined(HOST_WIN32)
 
 #define ERROR_SUCCESS              0
@@ -89,5 +91,7 @@ mono_w32error_set_last (guint32 error);
 
 guint32
 mono_w32error_unix_to_win32 (guint32 error);
+
+G_END_DECLS
 
 #endif /* _MONO_METADATA_W32ERROR_H_ */

--- a/mono/metadata/w32error.h
+++ b/mono/metadata/w32error.h
@@ -8,7 +8,7 @@
 #include <config.h>
 #include <glib.h>
 
-G_BEGIN_DECLS
+MONO_BEGIN_DECLS
 
 #if !defined(HOST_WIN32)
 
@@ -92,6 +92,6 @@ mono_w32error_set_last (guint32 error);
 guint32
 mono_w32error_unix_to_win32 (guint32 error);
 
-G_END_DECLS
+MONO_END_DECLS
 
 #endif /* _MONO_METADATA_W32ERROR_H_ */

--- a/mono/metadata/w32error.h
+++ b/mono/metadata/w32error.h
@@ -8,7 +8,7 @@
 #include <config.h>
 #include <glib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 #if !defined(HOST_WIN32)
 
@@ -92,6 +92,6 @@ mono_w32error_set_last (guint32 error);
 guint32
 mono_w32error_unix_to_win32 (guint32 error);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* _MONO_METADATA_W32ERROR_H_ */

--- a/mono/metadata/w32event.h
+++ b/mono/metadata/w32event.h
@@ -12,6 +12,8 @@
 #include "object-internals.h"
 #include "w32handle-namespace.h"
 
+MONO_BEGIN_DECLS
+
 void
 mono_w32event_init (void);
 
@@ -46,5 +48,7 @@ typedef struct MonoW32HandleNamedEvent MonoW32HandleNamedEvent;
 
 MonoW32HandleNamespace*
 mono_w32event_get_namespace (MonoW32HandleNamedEvent *event);
+
+MONO_END_DECLS
 
 #endif /* _MONO_METADATA_W32EVENT_H_ */

--- a/mono/metadata/w32event.h
+++ b/mono/metadata/w32event.h
@@ -12,7 +12,7 @@
 #include "object-internals.h"
 #include "w32handle-namespace.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 void
 mono_w32event_init (void);
@@ -49,6 +49,6 @@ typedef struct MonoW32HandleNamedEvent MonoW32HandleNamedEvent;
 MonoW32HandleNamespace*
 mono_w32event_get_namespace (MonoW32HandleNamedEvent *event);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* _MONO_METADATA_W32EVENT_H_ */

--- a/mono/metadata/w32handle-namespace.h
+++ b/mono/metadata/w32handle-namespace.h
@@ -10,6 +10,8 @@
 
 #include "mono/metadata/w32handle.h"
 
+MONO_BEGIN_DECLS
+
 #define MONO_W32HANDLE_NAMESPACE_MAX_PATH 260
 
 typedef struct {
@@ -27,5 +29,7 @@ mono_w32handle_namespace_unlock (void);
 
 gpointer
 mono_w32handle_namespace_search_handle (MonoW32Type type, const gchar *name);
+
+MONO_END_DECLS
 
 #endif /* _MONO_METADATA_W32HANDLE_NAMESPACE_H_ */

--- a/mono/metadata/w32handle-namespace.h
+++ b/mono/metadata/w32handle-namespace.h
@@ -10,7 +10,7 @@
 
 #include "mono/metadata/w32handle.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 #define MONO_W32HANDLE_NAMESPACE_MAX_PATH 260
 
@@ -30,6 +30,6 @@ mono_w32handle_namespace_unlock (void);
 gpointer
 mono_w32handle_namespace_search_handle (MonoW32Type type, const gchar *name);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* _MONO_METADATA_W32HANDLE_NAMESPACE_H_ */

--- a/mono/metadata/w32handle.h
+++ b/mono/metadata/w32handle.h
@@ -14,6 +14,8 @@
 
 #include "mono/utils/mono-coop-mutex.h"
 
+MONO_BEGIN_DECLS
+
 #ifndef INVALID_HANDLE_VALUE
 #define INVALID_HANDLE_VALUE (gpointer)-1
 #endif
@@ -184,5 +186,6 @@ mono_w32handle_convert_wait_ret (guint32 res, guint32 numobjects)
 }
 #endif
 
+MONO_END_DECLS
 
 #endif /* _MONO_METADATA_W32HANDLE_H_ */

--- a/mono/metadata/w32handle.h
+++ b/mono/metadata/w32handle.h
@@ -14,7 +14,7 @@
 
 #include "mono/utils/mono-coop-mutex.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 #ifndef INVALID_HANDLE_VALUE
 #define INVALID_HANDLE_VALUE (gpointer)-1
@@ -186,6 +186,6 @@ mono_w32handle_convert_wait_ret (guint32 res, guint32 numobjects)
 }
 #endif
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* _MONO_METADATA_W32HANDLE_H_ */

--- a/mono/metadata/w32mutex.h
+++ b/mono/metadata/w32mutex.h
@@ -12,6 +12,8 @@
 #include "object-internals.h"
 #include "w32handle-namespace.h"
 
+MONO_BEGIN_DECLS
+
 void
 mono_w32mutex_init (void);
 
@@ -33,5 +35,7 @@ mono_w32mutex_get_namespace (MonoW32HandleNamedMutex *mutex);
 void
 mono_w32mutex_abandon (MonoInternalThread *internal);
 #endif
+
+MONO_END_DECLS
 
 #endif /* _MONO_METADATA_W32MUTEX_H_ */

--- a/mono/metadata/w32mutex.h
+++ b/mono/metadata/w32mutex.h
@@ -12,7 +12,7 @@
 #include "object-internals.h"
 #include "w32handle-namespace.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 void
 mono_w32mutex_init (void);
@@ -36,6 +36,6 @@ void
 mono_w32mutex_abandon (MonoInternalThread *internal);
 #endif
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* _MONO_METADATA_W32MUTEX_H_ */

--- a/mono/metadata/w32process-internals.h
+++ b/mono/metadata/w32process-internals.h
@@ -8,6 +8,8 @@
 #include <config.h>
 #include <glib.h>
 
+MONO_BEGIN_DECLS
+
 #ifndef HOST_WIN32
 
 typedef struct {
@@ -64,5 +66,7 @@ guint32
 mono_w32process_ver_language_name (guint32 lang, gunichar2 *lang_out, guint32 lang_len);
 
 #endif /* HOST_WIN32 */
+
+MONO_END_DECLS
 
 #endif /* _MONO_METADATA_W32PROCESS_INTERNALS_H_ */

--- a/mono/metadata/w32process-internals.h
+++ b/mono/metadata/w32process-internals.h
@@ -8,7 +8,7 @@
 #include <config.h>
 #include <glib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 #ifndef HOST_WIN32
 
@@ -67,6 +67,6 @@ mono_w32process_ver_language_name (guint32 lang, gunichar2 *lang_out, guint32 la
 
 #endif /* HOST_WIN32 */
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* _MONO_METADATA_W32PROCESS_INTERNALS_H_ */

--- a/mono/metadata/w32process-unix-internals.h
+++ b/mono/metadata/w32process-unix-internals.h
@@ -24,6 +24,8 @@
 #define USE_DEFAULT_BACKEND
 #endif
 
+MONO_BEGIN_DECLS
+
 typedef struct {
 	gpointer address_start;
 	gpointer address_end;
@@ -58,5 +60,7 @@ mono_w32process_module_equals (gconstpointer a, gconstpointer b)
 	MonoW32ProcessModule *compare = (MonoW32ProcessModule *)b;
 	return (want->device == compare->device && want->inode == compare->inode) ? 0 : 1;
 }
+
+MONO_END_DECLS
 
 #endif /* _MONO_METADATA_W32PROCESS_UNIX_INTERNALS_H_ */

--- a/mono/metadata/w32process-unix-internals.h
+++ b/mono/metadata/w32process-unix-internals.h
@@ -24,7 +24,7 @@
 #define USE_DEFAULT_BACKEND
 #endif
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 typedef struct {
 	gpointer address_start;
@@ -61,6 +61,6 @@ mono_w32process_module_equals (gconstpointer a, gconstpointer b)
 	return (want->device == compare->device && want->inode == compare->inode) ? 0 : 1;
 }
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* _MONO_METADATA_W32PROCESS_UNIX_INTERNALS_H_ */

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -89,7 +89,9 @@
  * arm-apple-darwin9.  We'll manually define the symbol on Apple as it does
  * in fact exist on all implementations (so far) 
  */
+G_BEGIN_DECLS
 gchar ***_NSGetEnviron(void);
+G_END_DECLS
 #define environ (*_NSGetEnviron())
 #else
 static char *mono_environ[1] = { NULL };

--- a/mono/metadata/w32process-win32-internals.h
+++ b/mono/metadata/w32process-win32-internals.h
@@ -9,6 +9,8 @@
 #include <config.h>
 #include <glib.h>
 
+MONO_BEGIN_DECLS
+
 // On platforms not using classic WIN API support the  implementation of bellow methods are hosted in separate source file
 // process-windows-*.c. On platforms using classic WIN API the implementation is still keept in process.c and still declared
 // static and in some places even inlined.
@@ -39,5 +41,7 @@ mono_icall_set_priority_class (gpointer handle, gint32 priorityClass);
 gboolean
 mono_process_win_enum_processes (DWORD *pids, DWORD count, DWORD *needed);
 #endif  /* !G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT) */
+
+MONO_END_DECLS
 
 #endif /* __MONO_METADATA_PROCESS_INTERNALS_H__ */

--- a/mono/metadata/w32process-win32-internals.h
+++ b/mono/metadata/w32process-win32-internals.h
@@ -9,7 +9,7 @@
 #include <config.h>
 #include <glib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 // On platforms not using classic WIN API support the  implementation of bellow methods are hosted in separate source file
 // process-windows-*.c. On platforms using classic WIN API the implementation is still keept in process.c and still declared
@@ -42,6 +42,6 @@ gboolean
 mono_process_win_enum_processes (DWORD *pids, DWORD count, DWORD *needed);
 #endif  /* !G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT) */
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_METADATA_PROCESS_INTERNALS_H__ */

--- a/mono/metadata/w32semaphore.h
+++ b/mono/metadata/w32semaphore.h
@@ -11,6 +11,8 @@
 #include "object.h"
 #include "w32handle-namespace.h"
 
+MONO_BEGIN_DECLS
+
 void
 mono_w32semaphore_init (void);
 
@@ -27,5 +29,7 @@ typedef struct MonoW32HandleNamedSemaphore MonoW32HandleNamedSemaphore;
 
 MonoW32HandleNamespace*
 mono_w32semaphore_get_namespace (MonoW32HandleNamedSemaphore *semaphore);
+
+MONO_END_DECLS
 
 #endif /* _MONO_METADATA_W32SEMAPHORE_H_ */

--- a/mono/metadata/w32semaphore.h
+++ b/mono/metadata/w32semaphore.h
@@ -11,7 +11,7 @@
 #include "object.h"
 #include "w32handle-namespace.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 void
 mono_w32semaphore_init (void);
@@ -30,6 +30,6 @@ typedef struct MonoW32HandleNamedSemaphore MonoW32HandleNamedSemaphore;
 MonoW32HandleNamespace*
 mono_w32semaphore_get_namespace (MonoW32HandleNamedSemaphore *semaphore);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* _MONO_METADATA_W32SEMAPHORE_H_ */

--- a/mono/metadata/w32socket-internals.h
+++ b/mono/metadata/w32socket-internals.h
@@ -19,6 +19,8 @@
 
 #include <mono/utils/w32api.h>
 
+MONO_BEGIN_DECLS
+
 #ifndef HAVE_SOCKLEN_T
 #define socklen_t int
 #endif
@@ -145,5 +147,7 @@ mono_w32socket_convert_error (gint error);
 
 gboolean
 mono_w32socket_duplicate (gpointer handle, gint32 targetProcessId, gpointer *duplicate_handle);
+
+MONO_END_DECLS
 
 #endif // __MONO_METADATA_W32SOCKET_INTERNALS_H__

--- a/mono/metadata/w32socket-internals.h
+++ b/mono/metadata/w32socket-internals.h
@@ -19,7 +19,7 @@
 
 #include <mono/utils/w32api.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 #ifndef HAVE_SOCKLEN_T
 #define socklen_t int
@@ -148,6 +148,6 @@ mono_w32socket_convert_error (gint error);
 gboolean
 mono_w32socket_duplicate (gpointer handle, gint32 targetProcessId, gpointer *duplicate_handle);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif // __MONO_METADATA_W32SOCKET_INTERNALS_H__

--- a/mono/metadata/w32socket.h
+++ b/mono/metadata/w32socket.h
@@ -16,6 +16,8 @@
 
 #include <mono/metadata/object-internals.h>
 
+MONO_BEGIN_DECLS
+
 #ifndef HOST_WIN32
 #define INVALID_SOCKET ((SOCKET)(guint32)(~0))
 #define SOCKET_ERROR (-1)
@@ -298,5 +300,7 @@ mono_network_init(void);
 
 void
 mono_network_cleanup(void);
+
+MONO_END_DECLS
 
 #endif /* _MONO_METADATA_W32SOCKET_H_ */

--- a/mono/metadata/w32socket.h
+++ b/mono/metadata/w32socket.h
@@ -16,7 +16,7 @@
 
 #include <mono/metadata/object-internals.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 #ifndef HOST_WIN32
 #define INVALID_SOCKET ((SOCKET)(guint32)(~0))
@@ -301,6 +301,6 @@ mono_network_init(void);
 void
 mono_network_cleanup(void);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* _MONO_METADATA_W32SOCKET_H_ */

--- a/mono/mini/abcremoval.h
+++ b/mono/mini/abcremoval.h
@@ -15,6 +15,7 @@
 
 #include "mini.h"
 
+MONO_BEGIN_DECLS
 
 /**
  * All handled value types (expressions) in variable definitions and branch
@@ -348,5 +349,6 @@ typedef struct MonoAdditionalVariableRelationsForBB {
 	MonoAdditionalVariableRelation relation2;
 } MonoAdditionalVariableRelationsForBB;
 
+MONO_END_DECLS
 
 #endif /* __MONO_ABCREMOVAL_H__ */

--- a/mono/mini/abcremoval.h
+++ b/mono/mini/abcremoval.h
@@ -15,7 +15,7 @@
 
 #include "mini.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 /**
  * All handled value types (expressions) in variable definitions and branch
@@ -349,6 +349,6 @@ typedef struct MonoAdditionalVariableRelationsForBB {
 	MonoAdditionalVariableRelation relation2;
 } MonoAdditionalVariableRelationsForBB;
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_ABCREMOVAL_H__ */

--- a/mono/mini/aot-compiler.h
+++ b/mono/mini/aot-compiler.h
@@ -7,6 +7,8 @@
 
 #include "mini.h"
 
+MONO_BEGIN_DECLS
+
 int mono_compile_assembly (MonoAssembly *ass, guint32 opts, const char *aot_options, gpointer **aot_state);
 int mono_compile_deferred_assemblies (guint32 opts, const char *aot_options, gpointer **aot_state);
 void* mono_aot_readonly_field_override (MonoClassField *field);
@@ -23,8 +25,6 @@ char*    mono_aot_get_direct_call_symbol    (MonoJumpInfoType type, gconstpointe
 int      mono_aot_get_method_index          (MonoMethod *method) MONO_LLVM_INTERNAL;
 MonoJumpInfo* mono_aot_patch_info_dup       (MonoJumpInfo* ji) MONO_LLVM_INTERNAL;
 
+MONO_END_DECLS
+
 #endif
-
-
-
-

--- a/mono/mini/aot-compiler.h
+++ b/mono/mini/aot-compiler.h
@@ -7,7 +7,7 @@
 
 #include "mini.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 int mono_compile_assembly (MonoAssembly *ass, guint32 opts, const char *aot_options, gpointer **aot_state);
 int mono_compile_deferred_assemblies (guint32 opts, const char *aot_options, gpointer **aot_state);
@@ -25,6 +25,6 @@ char*    mono_aot_get_direct_call_symbol    (MonoJumpInfoType type, gconstpointe
 int      mono_aot_get_method_index          (MonoMethod *method) MONO_LLVM_INTERNAL;
 MonoJumpInfo* mono_aot_patch_info_dup       (MonoJumpInfo* ji) MONO_LLVM_INTERNAL;
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/mini/aot-runtime.h
+++ b/mono/mini/aot-runtime.h
@@ -15,7 +15,7 @@
 
 #define MONO_AOT_TRAMP_PAGE_SIZE 16384
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 /* Constants used to encode different types of methods in AOT */
 enum {
@@ -266,6 +266,6 @@ typedef unsigned char* (*MonoLoadAotDataFunc)          (MonoAssembly *assembly, 
 typedef void  (*MonoFreeAotDataFunc)          (MonoAssembly *assembly, int size, gpointer user_data, void *handle);
 MONO_API void mono_install_load_aot_data_hook (MonoLoadAotDataFunc load_func, MonoFreeAotDataFunc free_func, gpointer user_data);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_AOT_RUNTIME_H__ */

--- a/mono/mini/aot-runtime.h
+++ b/mono/mini/aot-runtime.h
@@ -15,6 +15,8 @@
 
 #define MONO_AOT_TRAMP_PAGE_SIZE 16384
 
+MONO_BEGIN_DECLS
+
 /* Constants used to encode different types of methods in AOT */
 enum {
 	MONO_AOT_METHODREF_MIN = 240,
@@ -263,5 +265,7 @@ typedef unsigned char* (*MonoLoadAotDataFunc)          (MonoAssembly *assembly, 
 /* Not yet used */
 typedef void  (*MonoFreeAotDataFunc)          (MonoAssembly *assembly, int size, gpointer user_data, void *handle);
 MONO_API void mono_install_load_aot_data_hook (MonoLoadAotDataFunc load_func, MonoFreeAotDataFunc free_func, gpointer user_data);
+
+MONO_END_DECLS
 
 #endif /* __MONO_AOT_RUNTIME_H__ */

--- a/mono/mini/debugger-agent.h
+++ b/mono/mini/debugger-agent.h
@@ -8,7 +8,7 @@
 #include "mini.h"
 #include <mono/utils/mono-stack-unwinding.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 #define MONO_DBG_CALLBACKS_VERSION (2)
 // 2. debug_log parameters changed from MonoString* to MonoStringHandle
@@ -49,6 +49,6 @@ mono_debugger_agent_stub_init (void);
 MONO_API gboolean
 mono_debugger_agent_transport_handshake (void);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/mini/debugger-agent.h
+++ b/mono/mini/debugger-agent.h
@@ -8,6 +8,8 @@
 #include "mini.h"
 #include <mono/utils/mono-stack-unwinding.h>
 
+MONO_BEGIN_DECLS
+
 #define MONO_DBG_CALLBACKS_VERSION (2)
 // 2. debug_log parameters changed from MonoString* to MonoStringHandle
 
@@ -33,6 +35,9 @@ struct _MonoDebuggerCallbacks {
 typedef struct _DebuggerTlsData DebuggerTlsData;
 
 MONO_API void
+mono_debugger_agent_parse_options (char *options);
+
+MONO_API void
 mono_debugger_agent_init (void);
 
 MONO_API void
@@ -43,5 +48,7 @@ mono_debugger_agent_stub_init (void);
 
 MONO_API gboolean
 mono_debugger_agent_transport_handshake (void);
+
+MONO_END_DECLS
 
 #endif

--- a/mono/mini/dwarfwriter.h
+++ b/mono/mini/dwarfwriter.h
@@ -19,6 +19,8 @@
 
 #include <glib.h>
 
+MONO_BEGIN_DECLS
+
 typedef struct _MonoDwarfWriter MonoDwarfWriter;
 
 MonoDwarfWriter* mono_dwarf_writer_create (MonoImageWriter *writer, FILE *il_file, int il_file_start_line, gboolean emit_line_numbers);
@@ -39,5 +41,7 @@ mono_dwarf_writer_emit_method (MonoDwarfWriter *w, MonoCompile *cfg, MonoMethod 
 
 char *
 mono_dwarf_escape_path (const char *name);
+
+MONO_END_DECLS
 
 #endif

--- a/mono/mini/dwarfwriter.h
+++ b/mono/mini/dwarfwriter.h
@@ -19,7 +19,7 @@
 
 #include <glib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 typedef struct _MonoDwarfWriter MonoDwarfWriter;
 
@@ -42,6 +42,6 @@ mono_dwarf_writer_emit_method (MonoDwarfWriter *w, MonoCompile *cfg, MonoMethod 
 char *
 mono_dwarf_escape_path (const char *name);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/mini/image-writer.h
+++ b/mono/mini/image-writer.h
@@ -20,6 +20,8 @@
 
 #include <mono/utils/mono-compiler.h>
 
+G_BEGIN_DECLS
+
 typedef struct _MonoImageWriter MonoImageWriter;
 
 #if defined(TARGET_AMD64) && !defined(HOST_WIN32) && !defined(__APPLE__)
@@ -115,5 +117,7 @@ gboolean mono_img_writer_subsections_supported (MonoImageWriter *acfg);
 FILE * mono_img_writer_get_fp (MonoImageWriter *acfg);
 
 const char *mono_img_writer_get_temp_label_prefix (MonoImageWriter *acfg);
+
+G_END_DECLS
 
 #endif

--- a/mono/mini/jit-icalls.h
+++ b/mono/mini/jit-icalls.h
@@ -9,6 +9,8 @@
 
 #include "mini.h"
 
+MONO_BEGIN_DECLS
+
 void* mono_ldftn (MonoMethod *method);
 
 void* mono_ldvirtfn (MonoObject *obj, MonoMethod *method);
@@ -230,5 +232,7 @@ double mono_ckfinite (double d);
 void mono_throw_method_access (MonoMethod *caller, MonoMethod *callee);
 
 void mono_dummy_jit_icall (void);
+
+MONO_END_DECLS
 
 #endif /* __MONO_JIT_ICALLS_H__ */

--- a/mono/mini/jit-icalls.h
+++ b/mono/mini/jit-icalls.h
@@ -9,7 +9,7 @@
 
 #include "mini.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 void* mono_ldftn (MonoMethod *method);
 
@@ -233,6 +233,6 @@ void mono_throw_method_access (MonoMethod *caller, MonoMethod *callee);
 
 void mono_dummy_jit_icall (void);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_JIT_ICALLS_H__ */

--- a/mono/mini/lldb.h
+++ b/mono/mini/lldb.h
@@ -8,6 +8,8 @@
 #include "config.h"
 #include "mini.h"
 
+MONO_BEGIN_DECLS
+
 void mono_lldb_init (const char *options);
 
 void mono_lldb_save_method_info (MonoCompile *cfg);
@@ -17,5 +19,7 @@ void mono_lldb_save_trampoline_info (MonoTrampInfo *info);
 void mono_lldb_remove_method (MonoDomain *domain, MonoMethod *method, MonoJitDynamicMethodInfo *info);
 
 void mono_lldb_save_specific_trampoline_info (gpointer arg1, MonoTrampolineType tramp_type, MonoDomain *domain, gpointer code, guint32 code_len);
+
+MONO_END_DECLS
 
 #endif

--- a/mono/mini/lldb.h
+++ b/mono/mini/lldb.h
@@ -8,7 +8,7 @@
 #include "config.h"
 #include "mini.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 void mono_lldb_init (const char *options);
 
@@ -20,6 +20,6 @@ void mono_lldb_remove_method (MonoDomain *domain, MonoMethod *method, MonoJitDyn
 
 void mono_lldb_save_specific_trampoline_info (gpointer arg1, MonoTrampolineType tramp_type, MonoDomain *domain, gpointer code, guint32 code_len);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -18,7 +18,7 @@
 #endif
 #endif
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 #ifdef HOST_WIN32
 
@@ -643,6 +643,6 @@ mono_arch_unwindinfo_validate_size (GSList *unwind_ops, guint max_size)
 
 CallInfo* mono_arch_get_call_info (MonoMemPool *mp, MonoMethodSignature *sig);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_MINI_AMD64_H__ */

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -16,6 +16,11 @@
 #ifdef HAVE_SIGNAL_H
 #include <signal.h>
 #endif
+#endif
+
+MONO_BEGIN_DECLS
+
+#ifdef HOST_WIN32
 
 #if !defined(_MSC_VER)
 /* sigcontext surrogate */
@@ -638,5 +643,6 @@ mono_arch_unwindinfo_validate_size (GSList *unwind_ops, guint max_size)
 
 CallInfo* mono_arch_get_call_info (MonoMemPool *mp, MonoMethodSignature *sig);
 
-#endif /* __MONO_MINI_AMD64_H__ */  
+MONO_END_DECLS
 
+#endif /* __MONO_MINI_AMD64_H__ */

--- a/mono/mini/mini-arm.h
+++ b/mono/mini/mini-arm.h
@@ -11,6 +11,8 @@
 #include <mono/utils/mono-context.h>
 #include <glib.h>
 
+MONO_BEGIN_DECLS
+
 #if defined(ARM_FPU_NONE)
 #define MONO_ARCH_SOFT_FLOAT_FALLBACK 1
 #endif
@@ -435,5 +437,7 @@ mono_arm_emit_aotconst (gpointer ji, guint8 *code, guint8 *buf, int dreg, int pa
 
 CallInfo*
 mono_arch_get_call_info (MonoMemPool *mp, MonoMethodSignature *sig);
+
+MONO_END_DECLS
 
 #endif /* __MONO_MINI_ARM_H__ */

--- a/mono/mini/mini-arm.h
+++ b/mono/mini/mini-arm.h
@@ -11,7 +11,7 @@
 #include <mono/utils/mono-context.h>
 #include <glib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 #if defined(ARM_FPU_NONE)
 #define MONO_ARCH_SOFT_FLOAT_FALLBACK 1
@@ -438,6 +438,6 @@ mono_arm_emit_aotconst (gpointer ji, guint8 *code, guint8 *buf, int dreg, int pa
 CallInfo*
 mono_arch_get_call_info (MonoMemPool *mp, MonoMethodSignature *sig);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_MINI_ARM_H__ */

--- a/mono/mini/mini-arm64-gsharedvt.h
+++ b/mono/mini/mini-arm64-gsharedvt.h
@@ -5,6 +5,8 @@
 #ifndef __MINI_ARM64_GSHAREDVT_H__
 #define __MINI_ARM64_GSHAREDVT_H__
 
+MONO_BEGIN_DECLS
+
 /* Argument marshallings for calls between gsharedvt and normal code */
 typedef enum {
 	GSHAREDVT_ARG_NONE = 0,
@@ -84,5 +86,7 @@ typedef struct {
 
 gpointer
 mono_arm_start_gsharedvt_call (GSharedVtCallInfo *info, gpointer *caller, gpointer *callee, gpointer mrgctx_reg);
+
+MONO_END_DECLS
 
 #endif /* __MINI_ARM64_GSHAREDVT_H__ */

--- a/mono/mini/mini-arm64-gsharedvt.h
+++ b/mono/mini/mini-arm64-gsharedvt.h
@@ -5,7 +5,7 @@
 #ifndef __MINI_ARM64_GSHAREDVT_H__
 #define __MINI_ARM64_GSHAREDVT_H__
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 /* Argument marshallings for calls between gsharedvt and normal code */
 typedef enum {
@@ -87,6 +87,6 @@ typedef struct {
 gpointer
 mono_arm_start_gsharedvt_call (GSharedVtCallInfo *info, gpointer *caller, gpointer *callee, gpointer mrgctx_reg);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MINI_ARM64_GSHAREDVT_H__ */

--- a/mono/mini/mini-arm64.h
+++ b/mono/mini/mini-arm64.h
@@ -15,6 +15,8 @@
 #include <mono/arch/arm64/arm64-codegen.h>
 #include <mono/mini/mini-arm64-gsharedvt.h>
 
+MONO_BEGIN_DECLS
+
 #define MONO_ARCH_CPU_SPEC mono_arm64_cpu_desc
 
 #define MONO_MAX_IREGS 32
@@ -267,5 +269,7 @@ GSList* mono_arm_get_exception_trampolines (gboolean aot);
 void mono_arm_resume_unwind (gpointer arg, mgreg_t pc, mgreg_t *int_regs, gdouble *fp_regs, gboolean corlib, gboolean rethrow);
 
 CallInfo* mono_arch_get_call_info (MonoMemPool *mp, MonoMethodSignature *sig);
+
+MONO_END_DECLS
 
 #endif /* __MONO_MINI_ARM64_H__ */

--- a/mono/mini/mini-arm64.h
+++ b/mono/mini/mini-arm64.h
@@ -15,7 +15,7 @@
 #include <mono/arch/arm64/arm64-codegen.h>
 #include <mono/mini/mini-arm64-gsharedvt.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 #define MONO_ARCH_CPU_SPEC mono_arm64_cpu_desc
 
@@ -270,6 +270,6 @@ void mono_arm_resume_unwind (gpointer arg, mgreg_t pc, mgreg_t *int_regs, gdoubl
 
 CallInfo* mono_arch_get_call_info (MonoMemPool *mp, MonoMethodSignature *sig);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_MINI_ARM64_H__ */

--- a/mono/mini/mini-cross-helpers.c
+++ b/mono/mini/mini-cross-helpers.c
@@ -14,12 +14,15 @@
 #include "tasklets.h"
 #include <mono/metadata/abi-details.h>
 
+G_BEGIN_DECLS // FIXME This belongs in a header.
+
 void
 mono_dump_metadata_offsets (void);
 
 void
 mono_metadata_cross_helpers_run (void);
 
+G_END_DECLS // FIXME This belongs in a header.
 
 static void
 mono_dump_jit_offsets (void)

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -15,6 +15,8 @@
 #include "mini.h"
 #include "ee.h"
 
+MONO_BEGIN_DECLS
+
 /* Per-domain information maintained by the JIT */
 typedef struct
 {
@@ -566,6 +568,8 @@ gboolean MONO_SIG_HANDLER_SIGNATURE (mono_chain_signal);
 #ifdef TARGET_OSX
 void mini_register_sigterm_handler (void);
 #endif
+
+MONO_END_DECLS
 
 #endif /* __MONO_MINI_RUNTIME_H__ */
 

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2690,7 +2690,7 @@ enum {
 	SIMD_PREFETCH_MODE_2,
 };
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 const char *mono_arch_xregname (int reg);
 guint32     mono_arch_cpu_enumerate_simd_versions (void);
@@ -2712,6 +2712,6 @@ MonoType*   mini_native_type_replace_type (MonoType *type) MONO_LLVM_INTERNAL;
 MonoMethod*
 mini_method_to_shared (MonoMethod *method); // null if not shared
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_MINI_H__ */

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2690,6 +2690,8 @@ enum {
 	SIMD_PREFETCH_MODE_2,
 };
 
+MONO_BEGIN_DECLS
+
 const char *mono_arch_xregname (int reg);
 guint32     mono_arch_cpu_enumerate_simd_versions (void);
 
@@ -2709,5 +2711,7 @@ MonoType*   mini_native_type_replace_type (MonoType *type) MONO_LLVM_INTERNAL;
 
 MonoMethod*
 mini_method_to_shared (MonoMethod *method); // null if not shared
+
+MONO_END_DECLS
 
 #endif /* __MONO_MINI_H__ */

--- a/mono/sgen/gc-internal-agnostic.h
+++ b/mono/sgen/gc-internal-agnostic.h
@@ -22,6 +22,8 @@
 #include "mono/sgen/sgen-conf.h"
 #endif
 
+G_BEGIN_DECLS
+
 /* h indicates whether to hide or just tag.
  * (-!!h ^ p) is used instead of (h ? ~p : p) to avoid multiple mentions of p.
  */
@@ -119,5 +121,7 @@ FILE *mono_gc_get_logfile (void);
 void mono_gc_params_set (const char* options);
 /* equivalent to options set via MONO_GC_DEBUG */
 void mono_gc_debug_set (const char* options);
+
+G_END_DECLS
 
 #endif

--- a/mono/sgen/sgen-array-list.h
+++ b/mono/sgen/sgen-array-list.h
@@ -23,6 +23,8 @@
 
 #include <glib.h>
 
+G_BEGIN_DECLS
+
 #define SGEN_ARRAY_LIST_BUCKETS (32)
 #define SGEN_ARRAY_LIST_MIN_BUCKET_BITS (5)
 #define SGEN_ARRAY_LIST_MIN_BUCKET_SIZE (1 << SGEN_ARRAY_LIST_MIN_BUCKET_BITS)
@@ -136,5 +138,7 @@ guint32 sgen_array_list_find (SgenArrayList *array, gpointer ptr);
 gboolean sgen_array_list_default_cas_setter (volatile gpointer *slot, gpointer ptr, int data);
 gboolean sgen_array_list_default_is_slot_set (volatile gpointer *slot);
 void sgen_array_list_remove_nulls (SgenArrayList *array);
+
+G_END_DECLS
 
 #endif

--- a/mono/sgen/sgen-cardtable.h
+++ b/mono/sgen/sgen-cardtable.h
@@ -8,6 +8,8 @@
 #ifndef __MONO_SGEN_CARD_TABLE_INLINES_H__
 #define __MONO_SGEN_CARD_TABLE_INLINES_H__
 
+G_BEGIN_DECLS
+
 /*WARNING: This function returns the number of cards regardless of overflow in case of overlapping cards.*/
 mword sgen_card_table_number_of_cards_in_range (mword address, mword size);
 guint8* sgen_find_next_card (guint8 *card_data, guint8 *end);
@@ -126,5 +128,7 @@ sgen_card_table_get_card_offset (char *ptr, char *base)
 {
 	return (ptr - base) >> CARD_BITS;
 }
+
+G_END_DECLS
 
 #endif

--- a/mono/sgen/sgen-client.h
+++ b/mono/sgen/sgen-client.h
@@ -9,6 +9,8 @@
 
 #include "mono/sgen/sgen-pointer-queue.h"
 
+G_BEGIN_DECLS
+
 /*
  * Init whatever needs initing.  This is called relatively early in SGen initialization.
  * Must initialized the small ID for the current thread.
@@ -319,3 +321,5 @@ SgenThreadInfo* mono_thread_info_current (void);
 int mono_thread_info_get_small_id (void);
 
 #endif
+
+G_END_DECLS

--- a/mono/sgen/sgen-copy-object.h
+++ b/mono/sgen/sgen-copy-object.h
@@ -9,6 +9,8 @@
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
 
+G_BEGIN_DECLS
+
 /*
  * Defines
  *
@@ -142,3 +144,5 @@ copy_object_no_checks_par (GCObject *obj, SgenGrayQueue *queue)
 #undef COLLECTOR_PARALLEL_ALLOC_FOR_PROMOTION
 #undef collector_pin_object
 #undef COPY_OR_MARK_PARALLEL
+
+G_END_DECLS

--- a/mono/sgen/sgen-descriptor.h
+++ b/mono/sgen/sgen-descriptor.h
@@ -15,6 +15,8 @@
 
 #include <mono/sgen/sgen-conf.h>
 
+G_BEGIN_DECLS
+
 /*
  * ######################################################################
  * ########  GC descriptors
@@ -318,5 +320,6 @@ sgen_gc_descr_has_references (SgenDescriptor desc)
 		}	\
 	} while (0)
 
+G_END_DECLS
 
 #endif

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -38,6 +38,10 @@ typedef struct _SgenThreadInfo SgenThreadInfo;
 #include "mono/sgen/gc-internal-agnostic.h"
 #include "mono/sgen/sgen-thread-pool.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* The method used to clear the nursery */
 /* Clearing at nursery collections is the safest, but has bad interactions with caches.
  * Clearing at TLAB creation is much faster, but more complex and it might expose hard
@@ -1171,6 +1175,10 @@ sgen_dummy_use (gpointer v)
 #error "Implement sgen_dummy_use for your compiler"
 #endif
 }
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif /* HAVE_SGEN_GC */
 

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -38,9 +38,7 @@ typedef struct _SgenThreadInfo SgenThreadInfo;
 #include "mono/sgen/gc-internal-agnostic.h"
 #include "mono/sgen/sgen-thread-pool.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+G_BEGIN_DECLS
 
 /* The method used to clear the nursery */
 /* Clearing at nursery collections is the safest, but has bad interactions with caches.
@@ -1176,9 +1174,7 @@ sgen_dummy_use (gpointer v)
 #endif
 }
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+G_END_DECLS
 
 #endif /* HAVE_SGEN_GC */
 

--- a/mono/sgen/sgen-gray.h
+++ b/mono/sgen/sgen-gray.h
@@ -12,6 +12,8 @@
 
 #include "mono/sgen/sgen-protocol.h"
 
+G_BEGIN_DECLS
+
 /*
  * This gray queue has to be as optimized as possible, because it is in the core of
  * the mark/copy phase of the garbage collector. The memory access has then to be as
@@ -208,5 +210,7 @@ GRAY_OBJECT_DEQUEUE (SgenGrayQueue *queue, GCObject** obj, SgenDescriptor *desc,
 	}
 #endif
 }
+
+G_END_DECLS
 
 #endif

--- a/mono/sgen/sgen-hash-table.h
+++ b/mono/sgen/sgen-hash-table.h
@@ -11,6 +11,8 @@
 
 #include <glib.h>
 
+G_BEGIN_DECLS
+
 /* hash tables */
 
 typedef struct _SgenHashTableEntry SgenHashTableEntry;
@@ -75,6 +77,8 @@ void sgen_init_hash_table (void);
 			}						\
 		}							\
 	} while (0)
+
+G_END_DECLS
 
 #endif
 

--- a/mono/sgen/sgen-layout-stats.h
+++ b/mono/sgen/sgen-layout-stats.h
@@ -7,6 +7,8 @@
 #ifndef __MONO_SGEN_LAYOUT_STATS_H__
 #define __MONO_SGEN_LAYOUT_STATS_H__
 
+G_BEGIN_DECLS
+
 #ifdef SGEN_OBJECT_LAYOUT_STATISTICS
 
 #define SGEN_OBJECT_LAYOUT_BITMAP_BITS	16
@@ -47,5 +49,7 @@ void sgen_object_layout_dump (FILE *out);
 #define SGEN_OBJECT_LAYOUT_STATISTICS_COMMIT_BITMAP
 
 #endif
+
+G_END_DECLS
 
 #endif

--- a/mono/sgen/sgen-marksweep-drain-gray-stack.h
+++ b/mono/sgen/sgen-marksweep-drain-gray-stack.h
@@ -7,6 +7,8 @@
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
 
+G_BEGIN_DECLS
+
 /*
  * COPY_OR_MARK_FUNCTION_NAME must be defined to be the function name of the copy/mark
  * function.
@@ -356,3 +358,5 @@ DRAIN_GRAY_STACK_FUNCTION_NAME (SgenGrayQueue *queue)
 #undef SCAN_VTYPE_FUNCTION_NAME
 #undef SCAN_PTR_FIELD_FUNCTION_NAME
 #undef DRAIN_GRAY_STACK_FUNCTION_NAME
+
+G_END_DECLS

--- a/mono/sgen/sgen-memory-governor.h
+++ b/mono/sgen/sgen-memory-governor.h
@@ -8,6 +8,8 @@
 #ifndef __MONO_SGEN_MEMORY_GOVERNOR_H__
 #define __MONO_SGEN_MEMORY_GOVERNOR_H__
 
+G_BEGIN_DECLS
+
 /* Heap limits */
 void sgen_memgov_init (size_t max_heap, size_t soft_limit, gboolean debug_allowance, double min_allowance_ratio, double save_target);
 void sgen_memgov_release_space (mword size, int space);
@@ -62,5 +64,6 @@ void sgen_free_os_memory (void *addr, size_t size, SgenAllocFlags flags, MonoMem
 /* Error handling */
 void sgen_assert_memory_alloc (void *ptr, size_t requested_size, const char *assert_description);
 
-#endif
+G_END_DECLS
 
+#endif

--- a/mono/sgen/sgen-minor-copy-object.h
+++ b/mono/sgen/sgen-minor-copy-object.h
@@ -9,6 +9,8 @@
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
 
+G_BEGIN_DECLS
+
 #undef SERIAL_COPY_OBJECT
 #undef SERIAL_COPY_OBJECT_FROM_OBJ
 
@@ -259,3 +261,5 @@ SERIAL_COPY_OBJECT_FROM_OBJ (GCObject **obj_slot, SgenGrayQueue *queue)
 	}
 #endif
 }
+
+G_END_DECLS

--- a/mono/sgen/sgen-minor-scan-object.h
+++ b/mono/sgen/sgen-minor-scan-object.h
@@ -9,6 +9,10 @@
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern guint64 stat_scan_object_called_nursery;
 
 #undef SERIAL_SCAN_OBJECT
@@ -151,3 +155,7 @@ SERIAL_DRAIN_GRAY_STACK (SgenGrayQueue *queue)
 		(ops)->scan_ptr_field = SERIAL_SCAN_PTR_FIELD;		\
 		(ops)->drain_gray_stack = SERIAL_DRAIN_GRAY_STACK;	\
 	} while (0)
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/mono/sgen/sgen-minor-scan-object.h
+++ b/mono/sgen/sgen-minor-scan-object.h
@@ -9,9 +9,7 @@
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+G_BEGIN_DECLS
 
 extern guint64 stat_scan_object_called_nursery;
 
@@ -156,6 +154,4 @@ SERIAL_DRAIN_GRAY_STACK (SgenGrayQueue *queue)
 		(ops)->drain_gray_stack = SERIAL_DRAIN_GRAY_STACK;	\
 	} while (0)
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+G_END_DECLS

--- a/mono/sgen/sgen-pinning.h
+++ b/mono/sgen/sgen-pinning.h
@@ -12,6 +12,10 @@
 
 #include "mono/sgen/sgen-pointer-queue.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum {
 	PIN_TYPE_STACK,
 	PIN_TYPE_STATIC_DATA,
@@ -57,5 +61,9 @@ gboolean sgen_cement_lookup (GCObject *obj);
 gboolean sgen_cement_lookup_or_register (GCObject *obj);
 void sgen_pin_cemented_objects (void);
 void sgen_cement_clear_below_threshold (void);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif

--- a/mono/sgen/sgen-pinning.h
+++ b/mono/sgen/sgen-pinning.h
@@ -12,9 +12,7 @@
 
 #include "mono/sgen/sgen-pointer-queue.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+G_BEGIN_DECLS
 
 enum {
 	PIN_TYPE_STACK,
@@ -62,8 +60,6 @@ gboolean sgen_cement_lookup_or_register (GCObject *obj);
 void sgen_pin_cemented_objects (void);
 void sgen_cement_clear_below_threshold (void);
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+G_END_DECLS
 
 #endif

--- a/mono/sgen/sgen-pointer-queue.h
+++ b/mono/sgen/sgen-pointer-queue.h
@@ -12,6 +12,10 @@
 
 #include <glib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
 	void **data;
 	size_t size;
@@ -32,5 +36,9 @@ void* sgen_pointer_queue_pop (SgenPointerQueue *queue);
 gboolean sgen_pointer_queue_is_empty (SgenPointerQueue *queue);
 void sgen_pointer_queue_free (SgenPointerQueue *queue);
 gboolean sgen_pointer_queue_will_grow (SgenPointerQueue *queue);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif

--- a/mono/sgen/sgen-pointer-queue.h
+++ b/mono/sgen/sgen-pointer-queue.h
@@ -12,9 +12,7 @@
 
 #include <glib.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+G_BEGIN_DECLS
 
 typedef struct {
 	void **data;
@@ -37,8 +35,6 @@ gboolean sgen_pointer_queue_is_empty (SgenPointerQueue *queue);
 void sgen_pointer_queue_free (SgenPointerQueue *queue);
 gboolean sgen_pointer_queue_will_grow (SgenPointerQueue *queue);
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+G_END_DECLS
 
 #endif

--- a/mono/sgen/sgen-protocol.h
+++ b/mono/sgen/sgen-protocol.h
@@ -14,6 +14,10 @@
 
 #include "sgen-gc.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define PROTOCOL_HEADER_CHECK 0xde7ec7ab1ec0de
 /*
  * The version needs to be bumped every time we introduce breaking changes (like
@@ -244,4 +248,8 @@ gboolean sgen_binary_protocol_flush_buffers (gboolean force);
 #undef TYPE_POINTER
 #undef TYPE_BOOL
 
+#ifdef __cplusplus
+} // extern "C"
 #endif
+
+#endif // __MONO_SGENPROTOCOL_H__

--- a/mono/sgen/sgen-protocol.h
+++ b/mono/sgen/sgen-protocol.h
@@ -14,9 +14,7 @@
 
 #include "sgen-gc.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+G_BEGIN_DECLS
 
 #define PROTOCOL_HEADER_CHECK 0xde7ec7ab1ec0de
 /*
@@ -248,8 +246,6 @@ gboolean sgen_binary_protocol_flush_buffers (gboolean force);
 #undef TYPE_POINTER
 #undef TYPE_BOOL
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+G_END_DECLS
 
 #endif // __MONO_SGENPROTOCOL_H__

--- a/mono/sgen/sgen-qsort.h
+++ b/mono/sgen/sgen-qsort.h
@@ -9,6 +9,8 @@
 #ifndef __MONO_SGENQSORT_H__
 #define __MONO_SGENQSORT_H__
 
+G_BEGIN_DECLS
+
 /* Copied from non-inline implementation in sgen-qsort.c */
 #define DEF_QSORT_INLINE(name, type, compare) \
 static inline void \
@@ -73,5 +75,7 @@ qsort_##name (type array[], size_t count) \
 	type swap_tmp; \
 	qsort_rec_##name (array, 0, (ssize_t)count - 1, &pivot_tmp, &swap_tmp); \
 }
+
+G_END_DECLS
 
 #endif

--- a/mono/sgen/sgen-thread-pool.h
+++ b/mono/sgen/sgen-thread-pool.h
@@ -13,6 +13,8 @@
 #include "mono/sgen/sgen-pointer-queue.h"
 #include "mono/utils/mono-threads.h"
 
+G_BEGIN_DECLS
+
 #define SGEN_THREADPOOL_MAX_NUM_THREADS 8
 #define SGEN_THREADPOOL_MAX_NUM_CONTEXTS 3
 
@@ -66,5 +68,7 @@ void sgen_thread_pool_idle_wait (int context_id, SgenThreadPoolContinueIdleWaitF
 void sgen_thread_pool_wait_for_all_jobs (int context_id);
 
 int sgen_thread_pool_is_thread_pool_thread (MonoNativeThreadId thread);
+
+G_END_DECLS
 
 #endif

--- a/mono/sgen/sgen-workers.h
+++ b/mono/sgen/sgen-workers.h
@@ -13,6 +13,8 @@
 
 #include "mono/sgen/sgen-thread-pool.h"
 
+G_BEGIN_DECLS
+
 typedef struct _WorkerData WorkerData;
 typedef struct _WorkerContext WorkerContext;
 
@@ -89,5 +91,7 @@ SgenObjectOperations* sgen_workers_get_idle_func_object_ops (WorkerData *worker)
 int sgen_workers_get_job_split_count (int generation);
 void sgen_workers_foreach (int generation, SgenWorkerCallback callback);
 gboolean sgen_workers_is_worker_thread (MonoNativeThreadId id);
+
+G_END_DECLS
 
 #endif

--- a/mono/utils/Makefile.am
+++ b/mono/utils/Makefile.am
@@ -303,6 +303,9 @@ libmonoutils_la_CFLAGS = $(JEMALLOC_CFLAGS)
 libmonoutils_la_LDFLAGS = $(JEMALLOC_LDFLAGS)
 libmonoutilsincludedir = $(includedir)/mono-$(API_VER)/mono/utils
 
+# These are public headers.
+# They may not use G_BEGIN_DECLS, guint, glib.h, etc.
+# debug-mono-symfile.h is an exception. It is only semi-public.
 libmonoutilsinclude_HEADERS = 	\
 	mono-logger.h		\
 	mono-error.h		\

--- a/mono/utils/atomic.h
+++ b/mono/utils/atomic.h
@@ -17,6 +17,13 @@
 #include <glib.h>
 #include <mono/utils/mono-membar.h>
 
+#ifdef HOST_WIN32
+#define WIN32_LEAN_AND_MEAN 1
+#include <windows.h>
+#endif
+
+G_BEGIN_DECLS
+
 /*
 The current Nexus 7 arm-v7a fails with:
 F/MonoDroid( 1568): shared runtime initialization error: Cannot load library: reloc_library[1285]:    37 cannot locate '__sync_val_compare_and_swap_8'
@@ -25,11 +32,6 @@ Apple targets have historically being problematic, xcode 4.6 would miscompile th
 */
 
 #if defined(HOST_WIN32)
-
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#include <windows.h>
 
 static inline gint32
 mono_atomic_cas_i32 (volatile gint32 *dest, gint32 exch, gint32 comp)
@@ -497,5 +499,7 @@ mono_atomic_store_bool (volatile gboolean *dest, gboolean val)
 	/* both, gboolean and gint32, are int32_t; the purpose of these casts is to make things explicit */
 	mono_atomic_store_i32 ((volatile gint32 *)dest, (gint32)val);
 }
+
+G_END_DECLS
 
 #endif /* _WAPI_ATOMIC_H_ */

--- a/mono/utils/bsearch.h
+++ b/mono/utils/bsearch.h
@@ -9,6 +9,10 @@
 
 #include "mono/utils/mono-compiler.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef int (* BinarySearchComparer) (const void *key, const void *member);
 
 void *
@@ -18,5 +22,9 @@ mono_binary_search (
 	size_t array_length,
 	size_t member_size,
 	BinarySearchComparer comparer);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif

--- a/mono/utils/bsearch.h
+++ b/mono/utils/bsearch.h
@@ -9,9 +9,7 @@
 
 #include "mono/utils/mono-compiler.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+MONO_BEGIN_DECLS
 
 typedef int (* BinarySearchComparer) (const void *key, const void *member);
 
@@ -23,8 +21,6 @@ mono_binary_search (
 	size_t member_size,
 	BinarySearchComparer comparer);
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+MONO_END_DECLS
 
 #endif

--- a/mono/utils/bsearch.h
+++ b/mono/utils/bsearch.h
@@ -9,7 +9,10 @@
 
 #include "mono/utils/mono-compiler.h"
 
-MONO_BEGIN_DECLS
+// Neither MONO_BEGIN_DECLS nor G_BEGIN_DECLS is available here. Fallback to what works.
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef int (* BinarySearchComparer) (const void *key, const void *member);
 
@@ -21,6 +24,8 @@ mono_binary_search (
 	size_t member_size,
 	BinarySearchComparer comparer);
 
-MONO_END_DECLS
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif

--- a/mono/utils/checked-build.h
+++ b/mono/utils/checked-build.h
@@ -16,7 +16,7 @@
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-publib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 typedef enum {
 	MONO_CHECK_MODE_NONE = 0,
@@ -227,6 +227,6 @@ G_GNUC_NORETURN MONO_ATTR_FORMAT_PRINTF(1,2) void mono_fatal_with_history(const 
 
 #endif /* defined(ENABLE_CHECKED_BUILD_THREAD) */
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __CHECKED_BUILD_H__ */

--- a/mono/utils/checked-build.h
+++ b/mono/utils/checked-build.h
@@ -16,6 +16,8 @@
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-publib.h>
 
+MONO_BEGIN_DECLS
+
 typedef enum {
 	MONO_CHECK_MODE_NONE = 0,
 	MONO_CHECK_MODE_GC = 0x1,
@@ -224,5 +226,7 @@ G_GNUC_NORETURN MONO_ATTR_FORMAT_PRINTF(1,2) void mono_fatal_with_history(const 
 #define mono_fatal_with_history g_error
 
 #endif /* defined(ENABLE_CHECKED_BUILD_THREAD) */
+
+MONO_END_DECLS
 
 #endif /* __CHECKED_BUILD_H__ */

--- a/mono/utils/hazard-pointer.h
+++ b/mono/utils/hazard-pointer.h
@@ -13,6 +13,8 @@
 #include <mono/utils/mono-membar.h>
 #include <mono/utils/mono-publib.h>
 
+MONO_BEGIN_DECLS
+
 #define HAZARD_POINTER_COUNT 3
 
 typedef struct {
@@ -56,4 +58,7 @@ void mono_hazard_pointer_install_free_queue_size_callback (MonoHazardFreeQueueSi
 
 void mono_thread_smr_init (void);
 void mono_thread_smr_cleanup (void);
+
+MONO_END_DECLS
+
 #endif /*__MONO_HAZARD_POINTER_H__*/

--- a/mono/utils/hazard-pointer.h
+++ b/mono/utils/hazard-pointer.h
@@ -13,7 +13,7 @@
 #include <mono/utils/mono-membar.h>
 #include <mono/utils/mono-publib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 #define HAZARD_POINTER_COUNT 3
 
@@ -59,6 +59,6 @@ void mono_hazard_pointer_install_free_queue_size_callback (MonoHazardFreeQueueSi
 void mono_thread_smr_init (void);
 void mono_thread_smr_cleanup (void);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /*__MONO_HAZARD_POINTER_H__*/

--- a/mono/utils/json.h
+++ b/mono/utils/json.h
@@ -14,6 +14,8 @@
 
  #include <glib.h>
 
+G_BEGIN_DECLS
+
 #define JSON_INDENT_VALUE 2
 
 typedef struct JsonWriter {
@@ -33,5 +35,7 @@ void mono_json_writer_array_end(JsonWriter* writer);
 void mono_json_writer_object_begin(JsonWriter* writer);
 void mono_json_writer_object_end(JsonWriter* writer);
 void mono_json_writer_object_key(JsonWriter* writer, const gchar* format, ...);
+
+G_END_DECLS
 
 #endif

--- a/mono/utils/json.h
+++ b/mono/utils/json.h
@@ -14,7 +14,7 @@
 
  #include <glib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 #define JSON_INDENT_VALUE 2
 
@@ -36,6 +36,6 @@ void mono_json_writer_object_begin(JsonWriter* writer);
 void mono_json_writer_object_end(JsonWriter* writer);
 void mono_json_writer_object_key(JsonWriter* writer, const gchar* format, ...);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/utils/json.h
+++ b/mono/utils/json.h
@@ -14,7 +14,7 @@
 
  #include <glib.h>
 
-G_BEGIN_DECLS
+MONO_BEGIN_DECLS
 
 #define JSON_INDENT_VALUE 2
 
@@ -36,6 +36,6 @@ void mono_json_writer_object_begin(JsonWriter* writer);
 void mono_json_writer_object_end(JsonWriter* writer);
 void mono_json_writer_object_key(JsonWriter* writer, const gchar* format, ...);
 
-G_END_DECLS
+MONO_END_DECLS
 
 #endif

--- a/mono/utils/lock-free-alloc.h
+++ b/mono/utils/lock-free-alloc.h
@@ -31,6 +31,8 @@
 #include <mono/utils/lock-free-queue.h>
 #include <mono/utils/mono-mmap.h>
 
+MONO_BEGIN_DECLS
+
 typedef struct {
 	MonoLockFreeQueue partial;
 	unsigned int slot_size;
@@ -56,5 +58,7 @@ MONO_API gpointer mono_lock_free_alloc (MonoLockFreeAllocator *heap);
 MONO_API void mono_lock_free_free (gpointer ptr, size_t block_size);
 
 MONO_API gboolean mono_lock_free_allocator_check_consistency (MonoLockFreeAllocator *heap);
+
+MONO_END_DECLS
 
 #endif

--- a/mono/utils/lock-free-alloc.h
+++ b/mono/utils/lock-free-alloc.h
@@ -31,7 +31,7 @@
 #include <mono/utils/lock-free-queue.h>
 #include <mono/utils/mono-mmap.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 typedef struct {
 	MonoLockFreeQueue partial;
@@ -59,6 +59,6 @@ MONO_API void mono_lock_free_free (gpointer ptr, size_t block_size);
 
 MONO_API gboolean mono_lock_free_allocator_check_consistency (MonoLockFreeAllocator *heap);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/utils/lock-free-array-queue.h
+++ b/mono/utils/lock-free-array-queue.h
@@ -13,6 +13,8 @@
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-mmap.h>
 
+MONO_BEGIN_DECLS
+
 typedef struct _MonoLockFreeArrayChunk MonoLockFreeArrayChunk;
 
 typedef struct {
@@ -40,5 +42,7 @@ void mono_lock_free_array_queue_push (MonoLockFreeArrayQueue *q, gpointer entry_
 gboolean mono_lock_free_array_queue_pop (MonoLockFreeArrayQueue *q, gpointer entry_data_ptr);
 
 void mono_lock_free_array_queue_cleanup (MonoLockFreeArrayQueue *q);
+
+MONO_END_DECLS
 
 #endif

--- a/mono/utils/lock-free-array-queue.h
+++ b/mono/utils/lock-free-array-queue.h
@@ -13,7 +13,7 @@
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-mmap.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 typedef struct _MonoLockFreeArrayChunk MonoLockFreeArrayChunk;
 
@@ -43,6 +43,6 @@ gboolean mono_lock_free_array_queue_pop (MonoLockFreeArrayQueue *q, gpointer ent
 
 void mono_lock_free_array_queue_cleanup (MonoLockFreeArrayQueue *q);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/utils/lock-free-queue.h
+++ b/mono/utils/lock-free-queue.h
@@ -32,6 +32,8 @@
 #include <glib.h>
 #include <mono/utils/mono-publib.h>
 
+MONO_BEGIN_DECLS
+
 //#define QUEUE_DEBUG	1
 
 typedef struct _MonoLockFreeQueueNode MonoLockFreeQueueNode;
@@ -65,5 +67,7 @@ MONO_API void mono_lock_free_queue_node_unpoison (MonoLockFreeQueueNode *node);
 MONO_API void mono_lock_free_queue_enqueue (MonoLockFreeQueue *q, MonoLockFreeQueueNode *node);
 
 MONO_API MonoLockFreeQueueNode* mono_lock_free_queue_dequeue (MonoLockFreeQueue *q);
+
+MONO_END_DECLS
 
 #endif

--- a/mono/utils/lock-free-queue.h
+++ b/mono/utils/lock-free-queue.h
@@ -32,7 +32,7 @@
 #include <glib.h>
 #include <mono/utils/mono-publib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 //#define QUEUE_DEBUG	1
 
@@ -68,6 +68,6 @@ MONO_API void mono_lock_free_queue_enqueue (MonoLockFreeQueue *q, MonoLockFreeQu
 
 MONO_API MonoLockFreeQueueNode* mono_lock_free_queue_dequeue (MonoLockFreeQueue *q);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/utils/mach-support.h
+++ b/mono/utils/mach-support.h
@@ -17,7 +17,7 @@
 #include <mach/thread_act.h>
 #include <mach/thread_status.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 #define MONO_MACH_ARCH_SUPPORTED 1
 #if defined(__arm__)
@@ -37,7 +37,7 @@ int mono_mach_arch_get_thread_fpstate_size (void);
 kern_return_t mono_mach_arch_get_thread_states (thread_port_t thread, thread_state_t state, mach_msg_type_number_t *count, thread_state_t fpstate, mach_msg_type_number_t *fpcount);
 kern_return_t mono_mach_arch_set_thread_states (thread_port_t thread, thread_state_t state, mach_msg_type_number_t count, thread_state_t fpstate, mach_msg_type_number_t fpcount);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif
 #endif /* __MONO_MACH_SUPPORT_H__ */

--- a/mono/utils/mach-support.h
+++ b/mono/utils/mach-support.h
@@ -17,7 +17,7 @@
 #include <mach/thread_act.h>
 #include <mach/thread_status.h>
 
-G_BEGIN_DECLS
+MONO_BEGIN_DECLS
 
 #define MONO_MACH_ARCH_SUPPORTED 1
 #if defined(__arm__)
@@ -37,7 +37,7 @@ int mono_mach_arch_get_thread_fpstate_size (void);
 kern_return_t mono_mach_arch_get_thread_states (thread_port_t thread, thread_state_t state, mach_msg_type_number_t *count, thread_state_t fpstate, mach_msg_type_number_t *fpcount);
 kern_return_t mono_mach_arch_set_thread_states (thread_port_t thread, thread_state_t state, mach_msg_type_number_t count, thread_state_t fpstate, mach_msg_type_number_t fpcount);
 
-G_END_DECLS
+MONO_END_DECLS
 
 #endif
 #endif /* __MONO_MACH_SUPPORT_H__ */

--- a/mono/utils/mach-support.h
+++ b/mono/utils/mach-support.h
@@ -17,6 +17,8 @@
 #include <mach/thread_act.h>
 #include <mach/thread_status.h>
 
+G_BEGIN_DECLS
+
 #define MONO_MACH_ARCH_SUPPORTED 1
 #if defined(__arm__)
 typedef _STRUCT_MCONTEXT *mcontext_t;
@@ -34,6 +36,8 @@ int mono_mach_arch_get_thread_state_size (void);
 int mono_mach_arch_get_thread_fpstate_size (void);
 kern_return_t mono_mach_arch_get_thread_states (thread_port_t thread, thread_state_t state, mach_msg_type_number_t *count, thread_state_t fpstate, mach_msg_type_number_t *fpcount);
 kern_return_t mono_mach_arch_set_thread_states (thread_port_t thread, thread_state_t state, mach_msg_type_number_t count, thread_state_t fpstate, mach_msg_type_number_t fpcount);
+
+G_END_DECLS
 
 #endif
 #endif /* __MONO_MACH_SUPPORT_H__ */

--- a/mono/utils/memfuncs.h
+++ b/mono/utils/memfuncs.h
@@ -13,6 +13,8 @@
 
 #include <stdlib.h>
 
+G_BEGIN_DECLS
+
 /*
 These functions must be used when it's possible that either destination is not
 word aligned or size is not a multiple of word size.
@@ -21,5 +23,7 @@ void mono_gc_bzero_atomic (void *dest, size_t size);
 void mono_gc_bzero_aligned (void *dest, size_t size);
 void mono_gc_memmove_atomic (void *dest, const void *src, size_t size);
 void mono_gc_memmove_aligned (void *dest, const void *src, size_t size);
+
+G_END_DECLS
 
 #endif

--- a/mono/utils/memfuncs.h
+++ b/mono/utils/memfuncs.h
@@ -13,7 +13,7 @@
 
 #include <stdlib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 /*
 These functions must be used when it's possible that either destination is not
@@ -24,6 +24,6 @@ void mono_gc_bzero_aligned (void *dest, size_t size);
 void mono_gc_memmove_atomic (void *dest, const void *src, size_t size);
 void mono_gc_memmove_aligned (void *dest, const void *src, size_t size);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/utils/memfuncs.h
+++ b/mono/utils/memfuncs.h
@@ -13,7 +13,7 @@
 
 #include <stdlib.h>
 
-G_BEGIN_DECLS
+MONO_BEGIN_DECLS
 
 /*
 These functions must be used when it's possible that either destination is not
@@ -24,6 +24,6 @@ void mono_gc_bzero_aligned (void *dest, size_t size);
 void mono_gc_memmove_atomic (void *dest, const void *src, size_t size);
 void mono_gc_memmove_aligned (void *dest, const void *src, size_t size);
 
-G_END_DECLS
+MONO_END_DECLS
 
 #endif

--- a/mono/utils/mono-codeman.h
+++ b/mono/utils/mono-codeman.h
@@ -7,6 +7,8 @@
 
 #include <mono/utils/mono-publib.h>
 
+MONO_BEGIN_DECLS
+
 typedef struct _MonoCodeManager MonoCodeManager;
 
 typedef struct {
@@ -32,6 +34,8 @@ MONO_API void             mono_code_manager_install_callbacks (MonoCodeManagerCa
 /* find the extra block allocated to resolve branches close to code */
 typedef int    (*MonoCodeManagerFunc)      (void *data, int csize, int size, void *user_data);
 void            mono_code_manager_foreach  (MonoCodeManager *cman, MonoCodeManagerFunc func, void *user_data);
+
+MONO_END_DECLS
 
 #endif /* __MONO_CODEMAN_H__ */
 

--- a/mono/utils/mono-codeman.h
+++ b/mono/utils/mono-codeman.h
@@ -7,7 +7,7 @@
 
 #include <mono/utils/mono-publib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 typedef struct _MonoCodeManager MonoCodeManager;
 
@@ -35,7 +35,7 @@ MONO_API void             mono_code_manager_install_callbacks (MonoCodeManagerCa
 typedef int    (*MonoCodeManagerFunc)      (void *data, int csize, int size, void *user_data);
 void            mono_code_manager_foreach  (MonoCodeManager *cman, MonoCodeManagerFunc func, void *user_data);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_CODEMAN_H__ */
 

--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -173,6 +173,11 @@ typedef int32_t __mono_off32_t;
 #endif
 
 #if !defined(mmap)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Unified headers before API 21 do not declare mmap when LARGE_FILES are used (via -D_FILE_OFFSET_BITS=64)
  * which is always the case when Mono build targets Android. The problem here is that the unified headers
  * map `mmap` to `mmap64` if large files are enabled but this api exists only in API21 onwards. Therefore
@@ -180,6 +185,11 @@ typedef int32_t __mono_off32_t;
  * in this instance off_t is redeclared to be 64-bit and that's not what we want.
  */
 void* mmap (void*, size_t, int, int, int, __mono_off32_t);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
 #endif /* !mmap */
 
 #ifdef HAVE_SYS_SENDFILE_H
@@ -187,8 +197,18 @@ void* mmap (void*, size_t, int, int, int, __mono_off32_t);
 #endif
 
 #if !defined(sendfile)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* The same thing as with mmap happens with sendfile */
 ssize_t sendfile (int out_fd, int in_fd, __mono_off32_t* offset, size_t count);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
 #endif /* !sendfile */
 
 #endif /* __ANDROID_API__ < 21 */

--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -5,6 +5,15 @@
 #ifndef __UTILS_MONO_COMPILER_H__
 #define __UTILS_MONO_COMPILER_H__
 
+// These macros are duplicated in mono-compiler.h, mono-publib.h, glib.h for maximum reach and consistency.
+#ifdef  __cplusplus
+#define MONO_BEGIN_DECLS  extern "C" {
+#define MONO_END_DECLS    }
+#else
+#define MONO_BEGIN_DECLS /* nothing */
+#define MONO_END_DECLS   /* nothing */
+#endif
+
 /*
  * This file includes macros used in the runtime to encapsulate different
  * compiler behaviours.
@@ -174,9 +183,7 @@ typedef int32_t __mono_off32_t;
 
 #if !defined(mmap)
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+MONO_BEGIN_DECLS
 
 /* Unified headers before API 21 do not declare mmap when LARGE_FILES are used (via -D_FILE_OFFSET_BITS=64)
  * which is always the case when Mono build targets Android. The problem here is that the unified headers
@@ -186,9 +193,7 @@ extern "C" {
  */
 void* mmap (void*, size_t, int, int, int, __mono_off32_t);
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+MONO_END_DECLS
 
 #endif /* !mmap */
 
@@ -198,16 +203,12 @@ void* mmap (void*, size_t, int, int, int, __mono_off32_t);
 
 #if !defined(sendfile)
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+MONO_BEGIN_DECLS
 
 /* The same thing as with mmap happens with sendfile */
 ssize_t sendfile (int out_fd, int in_fd, __mono_off32_t* offset, size_t count);
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+MONO_END_DECLS
 
 #endif /* !sendfile */
 

--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -5,15 +5,6 @@
 #ifndef __UTILS_MONO_COMPILER_H__
 #define __UTILS_MONO_COMPILER_H__
 
-// These macros are duplicated in mono-compiler.h, mono-publib.h, glib.h for maximum reach and consistency.
-#ifdef  __cplusplus
-#define MONO_BEGIN_DECLS  extern "C" {
-#define MONO_END_DECLS    }
-#else
-#define MONO_BEGIN_DECLS /* nothing */
-#define MONO_END_DECLS   /* nothing */
-#endif
-
 /*
  * This file includes macros used in the runtime to encapsulate different
  * compiler behaviours.

--- a/mono/utils/mono-complex.h
+++ b/mono/utils/mono-complex.h
@@ -23,6 +23,8 @@
 
 #ifdef _MSC_VER
 
+MONO_BEGIN_DECLS
+
 #define double_complex _C_double_complex
 
 static inline
@@ -93,5 +95,7 @@ double_complex mono_double_complex_sub(double_complex left, double_complex right
 {
 	return left - right;
 }
+
+MONO_END_DECLS
 
 #endif

--- a/mono/utils/mono-complex.h
+++ b/mono/utils/mono-complex.h
@@ -23,7 +23,7 @@
 
 #ifdef _MSC_VER
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 #define double_complex _C_double_complex
 
@@ -96,6 +96,6 @@ double_complex mono_double_complex_sub(double_complex left, double_complex right
 	return left - right;
 }
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/utils/mono-conc-hashtable.h
+++ b/mono/utils/mono-conc-hashtable.h
@@ -16,6 +16,8 @@
 #include <mono/utils/mono-os-mutex.h>
 #include <glib.h>
 
+MONO_BEGIN_DECLS
+
 typedef struct _MonoConcurrentHashTable MonoConcurrentHashTable;
 
 MONO_API MonoConcurrentHashTable* mono_conc_hashtable_new (GHashFunc hash_func, GEqualFunc key_equal_func);
@@ -26,5 +28,7 @@ MONO_API gpointer mono_conc_hashtable_insert (MonoConcurrentHashTable *hash_tabl
 MONO_API gpointer mono_conc_hashtable_remove (MonoConcurrentHashTable *hash_table, gpointer key);
 MONO_API void mono_conc_hashtable_foreach (MonoConcurrentHashTable *hashtable, GHFunc func, gpointer userdata);
 MONO_API void mono_conc_hashtable_foreach_steal (MonoConcurrentHashTable *hashtable, GHRFunc func, gpointer userdata);
+
+MONO_END_DECLS
 
 #endif

--- a/mono/utils/mono-conc-hashtable.h
+++ b/mono/utils/mono-conc-hashtable.h
@@ -16,7 +16,7 @@
 #include <mono/utils/mono-os-mutex.h>
 #include <glib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 typedef struct _MonoConcurrentHashTable MonoConcurrentHashTable;
 
@@ -29,6 +29,6 @@ MONO_API gpointer mono_conc_hashtable_remove (MonoConcurrentHashTable *hash_tabl
 MONO_API void mono_conc_hashtable_foreach (MonoConcurrentHashTable *hashtable, GHFunc func, gpointer userdata);
 MONO_API void mono_conc_hashtable_foreach_steal (MonoConcurrentHashTable *hashtable, GHRFunc func, gpointer userdata);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -897,6 +897,8 @@ typedef struct ucontext MonoContext;
 
 #endif
 
+G_BEGIN_DECLS
+
 /*
  * The naming is misleading, the SIGCTX argument should be the platform's context
  * structure (ucontext_c on posix, CONTEXT on windows).
@@ -910,5 +912,7 @@ void mono_sigctx_to_monoctx (void *sigctx, MonoContext *mctx);
  * also in MonoContext.
  */
 void mono_monoctx_to_sigctx (MonoContext *mctx, void *sigctx);
+
+G_END_DECLS
 
 #endif /* __MONO_MONO_CONTEXT_H__ */

--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -897,7 +897,7 @@ typedef struct ucontext MonoContext;
 
 #endif
 
-G_BEGIN_DECLS
+MONO_BEGIN_DECLS
 
 /*
  * The naming is misleading, the SIGCTX argument should be the platform's context
@@ -913,6 +913,6 @@ void mono_sigctx_to_monoctx (void *sigctx, MonoContext *mctx);
  */
 void mono_monoctx_to_sigctx (MonoContext *mctx, void *sigctx);
 
-G_END_DECLS
+MONO_END_DECLS
 
 #endif /* __MONO_MONO_CONTEXT_H__ */

--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -897,7 +897,7 @@ typedef struct ucontext MonoContext;
 
 #endif
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 /*
  * The naming is misleading, the SIGCTX argument should be the platform's context
@@ -913,6 +913,6 @@ void mono_sigctx_to_monoctx (void *sigctx, MonoContext *mctx);
  */
 void mono_monoctx_to_sigctx (MonoContext *mctx, void *sigctx);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_MONO_CONTEXT_H__ */

--- a/mono/utils/mono-counters.h
+++ b/mono/utils/mono-counters.h
@@ -8,6 +8,8 @@
 #include <stdio.h>
 #include <mono/utils/mono-publib.h>
 
+MONO_BEGIN_DECLS
+
 enum {
 	/* Counter type, bits 0-7. */
 	MONO_COUNTER_INT,    /* 32 bit int */
@@ -98,6 +100,8 @@ typedef void (*MonoResourceCallback) (int resource_type, uintptr_t value, int is
 MONO_API int  mono_runtime_resource_limit        (int resource_type, uintptr_t soft_limit, uintptr_t hard_limit);
 MONO_API void mono_runtime_resource_set_callback (MonoResourceCallback callback);
 MONO_API void mono_runtime_resource_check_limit  (int resource_type, uintptr_t value);
+
+MONO_END_DECLS
 
 #endif /* __MONO_COUNTERS_H__ */
 

--- a/mono/utils/mono-dl-windows-internals.h
+++ b/mono/utils/mono-dl-windows-internals.h
@@ -11,8 +11,13 @@
 #ifdef HOST_WIN32
 #include "mono/utils/mono-dl.h"
 
+MONO_BEGIN_DECLS
+
 void*
 mono_dl_lookup_symbol_in_process (const char *symbol_name);
+
+MONO_END_DECLS
+
 #endif /* HOST_WIN32 */
 #endif /* __MONO_UTILS_DL_WINDOWS_H__ */
 

--- a/mono/utils/mono-dl-windows-internals.h
+++ b/mono/utils/mono-dl-windows-internals.h
@@ -11,12 +11,12 @@
 #ifdef HOST_WIN32
 #include "mono/utils/mono-dl.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 void*
 mono_dl_lookup_symbol_in_process (const char *symbol_name);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* HOST_WIN32 */
 #endif /* __MONO_UTILS_DL_WINDOWS_H__ */

--- a/mono/utils/mono-dl.h
+++ b/mono/utils/mono-dl.h
@@ -20,6 +20,8 @@
 #define MONO_SOLIB_EXT ".so"
 #endif
 
+MONO_BEGIN_DECLS
+
 typedef struct {
 	void *handle;
 	int main_module;
@@ -49,5 +51,6 @@ char* mono_dl_current_error_string (void);
 int mono_dl_get_executable_path (char *buf, int buflen);
 const char* mono_dl_get_system_dir (void);
 
-#endif /* __MONO_UTILS_DL_H__ */
+MONO_END_DECLS
 
+#endif /* __MONO_UTILS_DL_H__ */

--- a/mono/utils/mono-dl.h
+++ b/mono/utils/mono-dl.h
@@ -20,6 +20,7 @@
 #define MONO_SOLIB_EXT ".so"
 #endif
 
+// G_BEGIN_DECLS is not always available here. Fallback to what works.
 MONO_BEGIN_DECLS
 
 typedef struct {

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -8,6 +8,8 @@
 #include <mono/metadata/object-forward.h>
 #include "mono/utils/mono-compiler.h"
 
+MONO_BEGIN_DECLS
+
 /*Keep in sync with MonoError*/
 typedef struct {
 	unsigned short error_code;
@@ -270,5 +272,7 @@ mono_error_set_specific (MonoError *error, int error_code, const char *missing_m
 
 void
 mono_error_set_first_argument (MonoError *oerror, const char *first_argument);
+
+MONO_END_DECLS
 
 #endif

--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -8,7 +8,7 @@
 #include <mono/metadata/object-forward.h>
 #include "mono/utils/mono-compiler.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 /*Keep in sync with MonoError*/
 typedef struct {
@@ -273,6 +273,6 @@ mono_error_set_specific (MonoError *error, int error_code, const char *missing_m
 void
 mono_error_set_first_argument (MonoError *oerror, const char *first_argument);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/utils/mono-flight-recorder.h
+++ b/mono/utils/mono-flight-recorder.h
@@ -14,6 +14,8 @@
 #include <glib.h>
 #include <mono/utils/mono-coop-mutex.h>
 
+MONO_BEGIN_DECLS
+
 typedef struct {
 	long counter; // The number of messages allocated thus far, acts like a global, monotonic clock
 } MonoFlightRecorderHeader;
@@ -62,5 +64,7 @@ mono_flight_recorder_iter_destroy (MonoFlightRecorderIter *iter);
 // Mutex has to be held when called
 gboolean
 mono_flight_recorder_iter_next (MonoFlightRecorderIter *iter, MonoFlightRecorderHeader *header, gpointer *payload);
+
+MONO_END_DECLS
 
 #endif

--- a/mono/utils/mono-flight-recorder.h
+++ b/mono/utils/mono-flight-recorder.h
@@ -14,7 +14,7 @@
 #include <glib.h>
 #include <mono/utils/mono-coop-mutex.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 typedef struct {
 	long counter; // The number of messages allocated thus far, acts like a global, monotonic clock
@@ -65,6 +65,6 @@ mono_flight_recorder_iter_destroy (MonoFlightRecorderIter *iter);
 gboolean
 mono_flight_recorder_iter_next (MonoFlightRecorderIter *iter, MonoFlightRecorderHeader *header, gpointer *payload);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/utils/mono-hwcap.h
+++ b/mono/utils/mono-hwcap.h
@@ -16,6 +16,8 @@
 #include "mono/utils/mono-hwcap-vars.h"
 #undef MONO_HWCAP_VAR
 
+G_BEGIN_DECLS
+
 /* Call this function to perform hardware feature detection. Until
  * this function has been called, all feature variables will be
  * FALSE as a default.
@@ -51,5 +53,7 @@ void mono_hwcap_print (void);
  * the hardware or operating system are lying, work around that in
  * a different place, as with the rule above.
  */
+
+G_END_DECLS
 
 #endif /* __MONO_UTILS_HWCAP_H__ */

--- a/mono/utils/mono-hwcap.h
+++ b/mono/utils/mono-hwcap.h
@@ -16,7 +16,7 @@
 #include "mono/utils/mono-hwcap-vars.h"
 #undef MONO_HWCAP_VAR
 
-G_BEGIN_DECLS
+MONO_BEGIN_DECLS
 
 /* Call this function to perform hardware feature detection. Until
  * this function has been called, all feature variables will be
@@ -54,6 +54,6 @@ void mono_hwcap_print (void);
  * a different place, as with the rule above.
  */
 
-G_END_DECLS
+MONO_END_DECLS
 
 #endif /* __MONO_UTILS_HWCAP_H__ */

--- a/mono/utils/mono-hwcap.h
+++ b/mono/utils/mono-hwcap.h
@@ -16,7 +16,7 @@
 #include "mono/utils/mono-hwcap-vars.h"
 #undef MONO_HWCAP_VAR
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 /* Call this function to perform hardware feature detection. Until
  * this function has been called, all feature variables will be
@@ -54,6 +54,6 @@ void mono_hwcap_print (void);
  * a different place, as with the rule above.
  */
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_UTILS_HWCAP_H__ */

--- a/mono/utils/mono-internal-hash.h
+++ b/mono/utils/mono-internal-hash.h
@@ -11,6 +11,8 @@
 #ifndef __MONO_UTILS_MONO_INTERNAL_HASH__
 #define __MONO_UTILS_MONO_INTERNAL_HASH__
 
+G_BEGIN_DECLS
+
 /* A MonoInternalHashTable is a hash table that does not allocate hash
    nodes.  It can be used if the following conditions are fulfilled:
 
@@ -73,5 +75,7 @@ mono_internal_hash_table_insert (MonoInternalHashTable *table,
 
 gboolean
 mono_internal_hash_table_remove (MonoInternalHashTable *table, gpointer key);
+
+G_END_DECLS
 
 #endif

--- a/mono/utils/mono-internal-hash.h
+++ b/mono/utils/mono-internal-hash.h
@@ -11,7 +11,7 @@
 #ifndef __MONO_UTILS_MONO_INTERNAL_HASH__
 #define __MONO_UTILS_MONO_INTERNAL_HASH__
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 /* A MonoInternalHashTable is a hash table that does not allocate hash
    nodes.  It can be used if the following conditions are fulfilled:
@@ -76,6 +76,6 @@ mono_internal_hash_table_insert (MonoInternalHashTable *table,
 gboolean
 mono_internal_hash_table_remove (MonoInternalHashTable *table, gpointer key);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/utils/mono-internal-hash.h
+++ b/mono/utils/mono-internal-hash.h
@@ -11,7 +11,7 @@
 #ifndef __MONO_UTILS_MONO_INTERNAL_HASH__
 #define __MONO_UTILS_MONO_INTERNAL_HASH__
 
-G_BEGIN_DECLS
+MONO_BEGIN_DECLS
 
 /* A MonoInternalHashTable is a hash table that does not allocate hash
    nodes.  It can be used if the following conditions are fulfilled:
@@ -76,6 +76,6 @@ mono_internal_hash_table_insert (MonoInternalHashTable *table,
 gboolean
 mono_internal_hash_table_remove (MonoInternalHashTable *table, gpointer key);
 
-G_END_DECLS
+MONO_END_DECLS
 
 #endif

--- a/mono/utils/mono-io-portability.h
+++ b/mono/utils/mono-io-portability.h
@@ -9,6 +9,10 @@
 #include <mono/utils/mono-compiler.h>
 #include "config.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum {
         PORTABILITY_NONE        = 0x00,
         PORTABILITY_UNKNOWN     = 0x01,
@@ -40,6 +44,10 @@ extern int mono_io_portability_helpers;
 #define IS_PORTABILITY_CASE (mono_io_portability_helpers & PORTABILITY_CASE)
 #define IS_PORTABILITY_SET (mono_io_portability_helpers > 0)
 
+#endif
+
+#ifdef __cplusplus
+} // extern "C"
 #endif
 
 #endif

--- a/mono/utils/mono-io-portability.h
+++ b/mono/utils/mono-io-portability.h
@@ -9,9 +9,7 @@
 #include <mono/utils/mono-compiler.h>
 #include "config.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+G_BEGIN_DECLS
 
 enum {
         PORTABILITY_NONE        = 0x00,
@@ -46,8 +44,6 @@ extern int mono_io_portability_helpers;
 
 #endif
 
-#ifdef __cplusplus
-} // extern "C"
-#endif
+G_END_DECLS
 
 #endif

--- a/mono/utils/mono-linked-list-set.h
+++ b/mono/utils/mono-linked-list-set.h
@@ -14,7 +14,7 @@
 #include <mono/utils/hazard-pointer.h>
 #include <mono/utils/mono-membar.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 typedef struct _MonoLinkedListSetNode MonoLinkedListSetNode;
 
@@ -173,6 +173,6 @@ mono_lls_filter_accept_all (gpointer elem, gpointer dummy)
 #define MONO_LLS_FOREACH_SAFE(list, type, elem) \
 	MONO_LLS_FOREACH_FILTERED_SAFE ((list), type, elem, mono_lls_filter_accept_all, NULL)
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_SPLIT_ORDERED_LIST_H__ */

--- a/mono/utils/mono-linked-list-set.h
+++ b/mono/utils/mono-linked-list-set.h
@@ -14,6 +14,8 @@
 #include <mono/utils/hazard-pointer.h>
 #include <mono/utils/mono-membar.h>
 
+MONO_BEGIN_DECLS
+
 typedef struct _MonoLinkedListSetNode MonoLinkedListSetNode;
 
 struct _MonoLinkedListSetNode {
@@ -170,5 +172,7 @@ mono_lls_filter_accept_all (gpointer elem, gpointer dummy)
 
 #define MONO_LLS_FOREACH_SAFE(list, type, elem) \
 	MONO_LLS_FOREACH_FILTERED_SAFE ((list), type, elem, mono_lls_filter_accept_all, NULL)
+
+MONO_END_DECLS
 
 #endif /* __MONO_SPLIT_ORDERED_LIST_H__ */

--- a/mono/utils/mono-membar.h
+++ b/mono/utils/mono-membar.h
@@ -15,7 +15,6 @@
 
 #include <glib.h>
 
-
 #ifdef TARGET_WASM
 
 static inline void mono_memory_barrier (void)

--- a/mono/utils/mono-merp.h
+++ b/mono/utils/mono-merp.h
@@ -15,6 +15,8 @@
 #include <glib.h>
 #include <mono/metadata/threads-types.h>
 
+MONO_BEGIN_DECLS
+
 #ifdef TARGET_OSX
 
 /**
@@ -51,5 +53,7 @@ mono_merp_invoke (const intptr_t crashed_pid, const char *signal, const char *du
 
 
 #endif // TARGET_OSX
+
+MONO_END_DECLS
 
 #endif // MONO_UTILS_MERP

--- a/mono/utils/mono-merp.h
+++ b/mono/utils/mono-merp.h
@@ -15,7 +15,7 @@
 #include <glib.h>
 #include <mono/metadata/threads-types.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 #ifdef TARGET_OSX
 
@@ -54,6 +54,6 @@ mono_merp_invoke (const intptr_t crashed_pid, const char *signal, const char *du
 
 #endif // TARGET_OSX
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif // MONO_UTILS_MERP

--- a/mono/utils/mono-mmap-internals.h
+++ b/mono/utils/mono-mmap-internals.h
@@ -12,6 +12,8 @@
 
 #include "mono-compiler.h"
 
+MONO_BEGIN_DECLS
+
 void *
 mono_malloc_shared_area (int pid);
 
@@ -30,5 +32,6 @@ mono_valloc_set_limit (size_t size);
 int
 mono_pages_not_faulted (void *addr, size_t length);
 
-#endif /* __MONO_UTILS_MMAP_INTERNAL_H__ */
+MONO_END_DECLS
 
+#endif /* __MONO_UTILS_MMAP_INTERNAL_H__ */

--- a/mono/utils/mono-mmap-internals.h
+++ b/mono/utils/mono-mmap-internals.h
@@ -12,7 +12,7 @@
 
 #include "mono-compiler.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 void *
 mono_malloc_shared_area (int pid);
@@ -32,6 +32,6 @@ mono_valloc_set_limit (size_t size);
 int
 mono_pages_not_faulted (void *addr, size_t length);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_UTILS_MMAP_INTERNAL_H__ */

--- a/mono/utils/mono-mmap-windows-internals.h
+++ b/mono/utils/mono-mmap-windows-internals.h
@@ -12,8 +12,13 @@
 #include "mono/utils/mono-mmap.h"
 #include "mono/utils/mono-mmap-internals.h"
 
+MONO_BEGIN_DECLS
+
 int
 mono_mmap_win_prot_from_flags (int flags);
+
+MONO_END_DECLS
+
 #endif /* HOST_WIN32 */
 #endif /* __MONO_UTILS_MMAP_WINDOWS_H__ */
 

--- a/mono/utils/mono-mmap-windows-internals.h
+++ b/mono/utils/mono-mmap-windows-internals.h
@@ -12,12 +12,12 @@
 #include "mono/utils/mono-mmap.h"
 #include "mono/utils/mono-mmap-internals.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 int
 mono_mmap_win_prot_from_flags (int flags);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* HOST_WIN32 */
 #endif /* __MONO_UTILS_MMAP_WINDOWS_H__ */

--- a/mono/utils/mono-mmap.h
+++ b/mono/utils/mono-mmap.h
@@ -8,7 +8,7 @@
 #include <glib.h>
 #include <mono/utils/mono-publib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 enum {
 	/* protection */
@@ -95,7 +95,7 @@ typedef void  (*mono_file_map_release_fn) (void *addr);
 
 MONO_API void mono_file_map_set_allocator (mono_file_map_alloc_fn alloc, mono_file_map_release_fn release);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_UTILS_MMAP_H__ */
 

--- a/mono/utils/mono-mmap.h
+++ b/mono/utils/mono-mmap.h
@@ -8,6 +8,8 @@
 #include <glib.h>
 #include <mono/utils/mono-publib.h>
 
+MONO_BEGIN_DECLS
+
 enum {
 	/* protection */
 	MONO_MMAP_NONE = 0,
@@ -92,6 +94,8 @@ typedef void *(*mono_file_map_alloc_fn)   (size_t length);
 typedef void  (*mono_file_map_release_fn) (void *addr);
 
 MONO_API void mono_file_map_set_allocator (mono_file_map_alloc_fn alloc, mono_file_map_release_fn release);
+
+MONO_END_DECLS
 
 #endif /* __MONO_UTILS_MMAP_H__ */
 

--- a/mono/utils/mono-networkinterfaces.h
+++ b/mono/utils/mono-networkinterfaces.h
@@ -11,6 +11,8 @@
 #include <glib.h>
 #include <mono/utils/mono-compiler.h>
 
+G_BEGIN_DECLS
+
 /* never remove or reorder these enums values: they are used in corlib/System */
 
 typedef enum {
@@ -28,5 +30,6 @@ typedef enum {
 gpointer *mono_networkinterface_list (int *size);
 gint64    mono_network_get_data (char* name, MonoNetworkData data, MonoNetworkError *error);
 
-#endif /* __MONO_NETWORK_INTERFACES_H__ */
+G_END_DECLS
 
+#endif /* __MONO_NETWORK_INTERFACES_H__ */

--- a/mono/utils/mono-networkinterfaces.h
+++ b/mono/utils/mono-networkinterfaces.h
@@ -11,7 +11,7 @@
 #include <glib.h>
 #include <mono/utils/mono-compiler.h>
 
-G_BEGIN_DECLS
+MONO_BEGIN_DECLS
 
 /* never remove or reorder these enums values: they are used in corlib/System */
 
@@ -30,6 +30,6 @@ typedef enum {
 gpointer *mono_networkinterface_list (int *size);
 gint64    mono_network_get_data (char* name, MonoNetworkData data, MonoNetworkError *error);
 
-G_END_DECLS
+MONO_END_DECLS
 
 #endif /* __MONO_NETWORK_INTERFACES_H__ */

--- a/mono/utils/mono-networkinterfaces.h
+++ b/mono/utils/mono-networkinterfaces.h
@@ -11,7 +11,7 @@
 #include <glib.h>
 #include <mono/utils/mono-compiler.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 /* never remove or reorder these enums values: they are used in corlib/System */
 
@@ -30,6 +30,6 @@ typedef enum {
 gpointer *mono_networkinterface_list (int *size);
 gint64    mono_network_get_data (char* name, MonoNetworkData data, MonoNetworkError *error);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_NETWORK_INTERFACES_H__ */

--- a/mono/utils/mono-path.h
+++ b/mono/utils/mono-path.h
@@ -8,8 +8,12 @@
 #include <glib.h>
 #include <mono/utils/mono-publib.h>
 
+MONO_BEGIN_DECLS
+
 MONO_API gchar *mono_path_resolve_symlinks (const char *path);
 MONO_API gchar *mono_path_canonicalize (const char *path);
+
+MONO_END_DECLS
 
 #endif /* __MONO_PATH_H */
 

--- a/mono/utils/mono-path.h
+++ b/mono/utils/mono-path.h
@@ -8,12 +8,12 @@
 #include <glib.h>
 #include <mono/utils/mono-publib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 MONO_API gchar *mono_path_resolve_symlinks (const char *path);
 MONO_API gchar *mono_path_canonicalize (const char *path);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_PATH_H */
 

--- a/mono/utils/mono-poll.h
+++ b/mono/utils/mono-poll.h
@@ -23,6 +23,8 @@
 #include <sys/poll.h>
 #endif
 
+MONO_BEGIN_DECLS
+
 #define MONO_POLLIN		POLLIN
 #define MONO_POLLPRI		POLLPRI
 #define MONO_POLLOUT		POLLOUT
@@ -54,5 +56,6 @@ typedef struct {
 
 MONO_API int mono_poll (mono_pollfd *ufds, unsigned int nfds, int timeout);
 
-#endif /* MONO_POLL_H */
+MONO_END_DECLS
 
+#endif /* MONO_POLL_H */

--- a/mono/utils/mono-proclib.h
+++ b/mono/utils/mono-proclib.h
@@ -12,6 +12,8 @@
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-publib.h>
 
+MONO_BEGIN_DECLS
+
 /* never remove or reorder these enums values: they are used in corlib/System */
 
 typedef enum {
@@ -78,5 +80,6 @@ gint32    mono_cpu_usage (MonoCpuUsageState *prev);
 
 int       mono_atexit (void (*func)(void));
 
-#endif /* __MONO_PROC_LIB_H__ */
+MONO_END_DECLS
 
+#endif /* __MONO_PROC_LIB_H__ */

--- a/mono/utils/mono-proclib.h
+++ b/mono/utils/mono-proclib.h
@@ -12,7 +12,7 @@
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-publib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 /* never remove or reorder these enums values: they are used in corlib/System */
 
@@ -80,6 +80,6 @@ gint32    mono_cpu_usage (MonoCpuUsageState *prev);
 
 int       mono_atexit (void (*func)(void));
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_PROC_LIB_H__ */

--- a/mono/utils/mono-publib.h
+++ b/mono/utils/mono-publib.h
@@ -11,7 +11,6 @@
  * directives where needed.
  */
 
-// These macros are duplicated in mono-compiler.h, mono-publib.h, glib.h for maximum reach and consistency.
 #ifdef  __cplusplus
 #define MONO_BEGIN_DECLS  extern "C" {
 #define MONO_END_DECLS    }

--- a/mono/utils/mono-publib.h
+++ b/mono/utils/mono-publib.h
@@ -11,12 +11,13 @@
  * directives where needed.
  */
 
+// These macros are duplicated in mono-compiler.h, mono-publib.h, glib.h for maximum reach and consistency.
 #ifdef  __cplusplus
 #define MONO_BEGIN_DECLS  extern "C" {
 #define MONO_END_DECLS    }
 #else
-#define MONO_BEGIN_DECLS
-#define MONO_END_DECLS
+#define MONO_BEGIN_DECLS /* nothing */
+#define MONO_END_DECLS   /* nothing */
 #endif
 
 MONO_BEGIN_DECLS

--- a/mono/utils/mono-rand.h
+++ b/mono/utils/mono-rand.h
@@ -10,7 +10,7 @@
 #include "mono-compiler.h"
 #include "mono-error.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 gboolean
 mono_rand_open (void);
@@ -27,6 +27,6 @@ mono_rand_try_get_uint32 (gpointer *handle, guint32 *val, guint32 min, guint32 m
 void
 mono_rand_close (gpointer handle);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* _MONO_UTILS_RAND_H_ */

--- a/mono/utils/mono-rand.h
+++ b/mono/utils/mono-rand.h
@@ -10,6 +10,8 @@
 #include "mono-compiler.h"
 #include "mono-error.h"
 
+MONO_BEGIN_DECLS
+
 gboolean
 mono_rand_open (void);
 
@@ -24,5 +26,7 @@ mono_rand_try_get_uint32 (gpointer *handle, guint32 *val, guint32 min, guint32 m
 
 void
 mono_rand_close (gpointer handle);
+
+MONO_END_DECLS
 
 #endif /* _MONO_UTILS_RAND_H_ */

--- a/mono/utils/mono-state.h
+++ b/mono/utils/mono-state.h
@@ -19,7 +19,7 @@
 
 #define MONO_NATIVE_STATE_PROTOCOL_VERSION "0.0.1"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 void
 mono_summarize_native_state_begin (void);
@@ -30,7 +30,7 @@ mono_summarize_native_state_end (void);
 void
 mono_summarize_native_state_add_thread (MonoThreadSummary *thread, MonoContext *ctx);
 
-MONO_END_DECLS
+G_END_DECLS
 #endif // TARGET_OSX
 
 #endif // MONO_UTILS_NATIVE_STATE

--- a/mono/utils/mono-threads-api.h
+++ b/mono/utils/mono-threads-api.h
@@ -15,7 +15,7 @@
 #include <mono/utils/mono-publib.h>
 #include <mono/utils/mono-compiler.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 /*
 >>>> WARNING WARNING WARNING <<<<
@@ -140,6 +140,6 @@ http://www.mono-project.com/docs/advanced/runtime/docs/coop-suspend/#gc-unsafe-m
 		mono_threads_exit_gc_safe_region_unbalanced_internal (__gc_safe_unbalanced_cookie, &__gc_safe_unbalanced_dummy);	\
 	} while (0)
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_LOGGER_H__ */

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -71,6 +71,8 @@ typedef gsize (*MonoThreadStart)(gpointer);
 
 #endif /* #ifdef HOST_WIN32 */
 
+MONO_BEGIN_DECLS
+
 #ifndef MONO_INFINITE_WAIT
 #define MONO_INFINITE_WAIT ((guint32) 0xFFFFFFFF)
 #endif
@@ -718,5 +720,7 @@ void mono_threads_join_unlock (void);
 typedef void (*background_job_cb)(void);
 void mono_threads_schedule_background_job (background_job_cb cb);
 #endif
+
+MONO_END_DECLS
 
 #endif /* __MONO_THREADS_H__ */

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -71,7 +71,7 @@ typedef gsize (*MonoThreadStart)(gpointer);
 
 #endif /* #ifdef HOST_WIN32 */
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 #ifndef MONO_INFINITE_WAIT
 #define MONO_INFINITE_WAIT ((guint32) 0xFFFFFFFF)
@@ -721,6 +721,6 @@ typedef void (*background_job_cb)(void);
 void mono_threads_schedule_background_job (background_job_cb cb);
 #endif
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_THREADS_H__ */

--- a/mono/utils/mono-time.h
+++ b/mono/utils/mono-time.h
@@ -12,6 +12,8 @@
 #include <sys/time.h>
 #endif
 
+G_BEGIN_DECLS
+
 /* Returns the number of milliseconds from boot time: this should be monotonic
  *
  * Prefer to use mono_msec_ticks for elapsed time calculation. */
@@ -60,5 +62,6 @@ mono_stopwatch_elapsed_ms (MonoStopwatch *w)
 	return (mono_stopwatch_elapsed (w) + 500) / 1000;
 }
 
-#endif /* __UTILS_MONO_TIME_H__ */
+G_END_DECLS
 
+#endif /* __UTILS_MONO_TIME_H__ */

--- a/mono/utils/mono-time.h
+++ b/mono/utils/mono-time.h
@@ -12,7 +12,7 @@
 #include <sys/time.h>
 #endif
 
-G_BEGIN_DECLS
+MONO_BEGIN_DECLS
 
 /* Returns the number of milliseconds from boot time: this should be monotonic
  *
@@ -62,6 +62,6 @@ mono_stopwatch_elapsed_ms (MonoStopwatch *w)
 	return (mono_stopwatch_elapsed (w) + 500) / 1000;
 }
 
-G_END_DECLS
+MONO_END_DECLS
 
 #endif /* __UTILS_MONO_TIME_H__ */

--- a/mono/utils/mono-time.h
+++ b/mono/utils/mono-time.h
@@ -12,7 +12,7 @@
 #include <sys/time.h>
 #endif
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 /* Returns the number of milliseconds from boot time: this should be monotonic
  *
@@ -62,6 +62,6 @@ mono_stopwatch_elapsed_ms (MonoStopwatch *w)
 	return (mono_stopwatch_elapsed (w) + 500) / 1000;
 }
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __UTILS_MONO_TIME_H__ */

--- a/mono/utils/mono-tls.h
+++ b/mono/utils/mono-tls.h
@@ -58,7 +58,7 @@ typedef enum {
 #define MonoNativeTlsKey pthread_key_t
 #define mono_native_tls_get_value pthread_getspecific
 
-G_BEGIN_DECLS
+MONO_BEGIN_DECLS
 
 static inline int
 mono_native_tls_alloc (MonoNativeTlsKey *key, void *destructor)
@@ -78,11 +78,11 @@ mono_native_tls_set_value (MonoNativeTlsKey key, gpointer value)
 	return !pthread_setspecific (key, value);
 }
 
-G_END_DECLS
+MONO_END_DECLS
 
 #endif /* HOST_WIN32 */
 
-G_BEGIN_DECLS
+MONO_BEGIN_DECLS
 
 void mono_tls_init_gc_keys (void);
 void mono_tls_init_runtime_keys (void);
@@ -103,6 +103,6 @@ void mono_tls_set_domain (gpointer value);
 void mono_tls_set_sgen_thread_info (gpointer value);
 void mono_tls_set_lmf_addr (gpointer value);
 
-G_END_DECLS
+MONO_END_DECLS
 
 #endif /* __MONO_TLS_H__ */

--- a/mono/utils/mono-tls.h
+++ b/mono/utils/mono-tls.h
@@ -58,6 +58,8 @@ typedef enum {
 #define MonoNativeTlsKey pthread_key_t
 #define mono_native_tls_get_value pthread_getspecific
 
+G_BEGIN_DECLS
+
 static inline int
 mono_native_tls_alloc (MonoNativeTlsKey *key, void *destructor)
 {
@@ -76,7 +78,11 @@ mono_native_tls_set_value (MonoNativeTlsKey key, gpointer value)
 	return !pthread_setspecific (key, value);
 }
 
+G_END_DECLS
+
 #endif /* HOST_WIN32 */
+
+G_BEGIN_DECLS
 
 void mono_tls_init_gc_keys (void);
 void mono_tls_init_runtime_keys (void);
@@ -96,5 +102,7 @@ void mono_tls_set_jit_tls (gpointer value);
 void mono_tls_set_domain (gpointer value);
 void mono_tls_set_sgen_thread_info (gpointer value);
 void mono_tls_set_lmf_addr (gpointer value);
+
+G_END_DECLS
 
 #endif /* __MONO_TLS_H__ */

--- a/mono/utils/mono-tls.h
+++ b/mono/utils/mono-tls.h
@@ -58,7 +58,7 @@ typedef enum {
 #define MonoNativeTlsKey pthread_key_t
 #define mono_native_tls_get_value pthread_getspecific
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 static inline int
 mono_native_tls_alloc (MonoNativeTlsKey *key, void *destructor)
@@ -78,11 +78,11 @@ mono_native_tls_set_value (MonoNativeTlsKey key, gpointer value)
 	return !pthread_setspecific (key, value);
 }
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* HOST_WIN32 */
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 void mono_tls_init_gc_keys (void);
 void mono_tls_init_runtime_keys (void);
@@ -103,6 +103,6 @@ void mono_tls_set_domain (gpointer value);
 void mono_tls_set_sgen_thread_info (gpointer value);
 void mono_tls_set_lmf_addr (gpointer value);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_TLS_H__ */

--- a/mono/utils/mono-uri.h
+++ b/mono/utils/mono-uri.h
@@ -7,7 +7,10 @@
 #include <glib.h>
 #include <mono/utils/mono-publib.h>
 
+G_BEGIN_DECLS
+
 MONO_API gchar * mono_escape_uri_string (const gchar *string);
 
-#endif /* __MONO_URI_H */
+G_END_DECLS
 
+#endif /* __MONO_URI_H */

--- a/mono/utils/mono-uri.h
+++ b/mono/utils/mono-uri.h
@@ -7,10 +7,10 @@
 #include <glib.h>
 #include <mono/utils/mono-publib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 MONO_API gchar * mono_escape_uri_string (const gchar *string);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_URI_H */

--- a/mono/utils/mono-uri.h
+++ b/mono/utils/mono-uri.h
@@ -7,10 +7,10 @@
 #include <glib.h>
 #include <mono/utils/mono-publib.h>
 
-G_BEGIN_DECLS
+MONO_BEGIN_DECLS
 
 MONO_API gchar * mono_escape_uri_string (const gchar *string);
 
-G_END_DECLS
+MONO_END_DECLS
 
 #endif /* __MONO_URI_H */

--- a/mono/utils/monobitset.h
+++ b/mono/utils/monobitset.h
@@ -8,6 +8,8 @@
 #include <glib.h>
 #include <mono/utils/mono-publib.h>
 
+MONO_BEGIN_DECLS
+
 #define MONO_BITSET_BITS_PER_CHUNK (8 * sizeof (gsize))
 
 typedef struct {
@@ -120,5 +122,7 @@ MONO_API gboolean    mono_bitset_equal        (const MonoBitSet *src, const Mono
 MONO_API void        mono_bitset_foreach      (MonoBitSet *set, MonoBitSetFunc func, gpointer data);
 
 MONO_API void        mono_bitset_intersection_2 (MonoBitSet *dest, const MonoBitSet *src1, const MonoBitSet *src2);
+
+MONO_END_DECLS
 
 #endif /* __MONO_BITSET_H__ */

--- a/mono/utils/monobitset.h
+++ b/mono/utils/monobitset.h
@@ -8,7 +8,7 @@
 #include <glib.h>
 #include <mono/utils/mono-publib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 #define MONO_BITSET_BITS_PER_CHUNK (8 * sizeof (gsize))
 
@@ -123,6 +123,6 @@ MONO_API void        mono_bitset_foreach      (MonoBitSet *set, MonoBitSetFunc f
 
 MONO_API void        mono_bitset_intersection_2 (MonoBitSet *dest, const MonoBitSet *src1, const MonoBitSet *src2);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* __MONO_BITSET_H__ */

--- a/mono/utils/networking.h
+++ b/mono/utils/networking.h
@@ -37,7 +37,7 @@
 
 #include <mono/utils/mono-compiler.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 typedef enum {
 	MONO_HINT_UNSPECIFIED		= 0,
@@ -111,6 +111,6 @@ int mono_networking_get_ipv6_protocol (void);
 void mono_networking_init (void);
 void mono_networking_shutdown (void);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/utils/networking.h
+++ b/mono/utils/networking.h
@@ -37,6 +37,8 @@
 
 #include <mono/utils/mono-compiler.h>
 
+G_BEGIN_DECLS
+
 typedef enum {
 	MONO_HINT_UNSPECIFIED		= 0,
 	MONO_HINT_IPV4				= 1,
@@ -109,5 +111,6 @@ int mono_networking_get_ipv6_protocol (void);
 void mono_networking_init (void);
 void mono_networking_shutdown (void);
 
+G_END_DECLS
 
 #endif

--- a/mono/utils/networking.h
+++ b/mono/utils/networking.h
@@ -37,7 +37,7 @@
 
 #include <mono/utils/mono-compiler.h>
 
-G_BEGIN_DECLS
+MONO_BEGIN_DECLS
 
 typedef enum {
 	MONO_HINT_UNSPECIFIED		= 0,
@@ -111,6 +111,6 @@ int mono_networking_get_ipv6_protocol (void);
 void mono_networking_init (void);
 void mono_networking_shutdown (void);
 
-G_END_DECLS
+MONO_END_DECLS
 
 #endif

--- a/mono/utils/os-event.h
+++ b/mono/utils/os-event.h
@@ -11,7 +11,7 @@
 #include <mono/utils/mono-publib.h>
 #include "mono-os-mutex.h"
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 #ifndef MONO_INFINITE_WAIT
 #define MONO_INFINITE_WAIT ((guint32) 0xFFFFFFFF)
@@ -56,6 +56,6 @@ mono_os_event_wait_one (MonoOSEvent *event, guint32 timeout, gboolean alertable)
 MONO_API MonoOSEventWaitRet
 mono_os_event_wait_multiple (MonoOSEvent **events, gsize nevents, gboolean waitall, guint32 timeout, gboolean alertable);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* _MONO_UTILS_OS_EVENT_H_ */

--- a/mono/utils/os-event.h
+++ b/mono/utils/os-event.h
@@ -11,6 +11,8 @@
 #include <mono/utils/mono-publib.h>
 #include "mono-os-mutex.h"
 
+G_BEGIN_DECLS
+
 #ifndef MONO_INFINITE_WAIT
 #define MONO_INFINITE_WAIT ((guint32) 0xFFFFFFFF)
 #endif
@@ -53,5 +55,7 @@ mono_os_event_wait_one (MonoOSEvent *event, guint32 timeout, gboolean alertable)
 
 MONO_API MonoOSEventWaitRet
 mono_os_event_wait_multiple (MonoOSEvent **events, gsize nevents, gboolean waitall, guint32 timeout, gboolean alertable);
+
+G_END_DECLS
 
 #endif /* _MONO_UTILS_OS_EVENT_H_ */

--- a/mono/utils/os-event.h
+++ b/mono/utils/os-event.h
@@ -11,7 +11,7 @@
 #include <mono/utils/mono-publib.h>
 #include "mono-os-mutex.h"
 
-G_BEGIN_DECLS
+MONO_BEGIN_DECLS
 
 #ifndef MONO_INFINITE_WAIT
 #define MONO_INFINITE_WAIT ((guint32) 0xFFFFFFFF)
@@ -56,6 +56,6 @@ mono_os_event_wait_one (MonoOSEvent *event, guint32 timeout, gboolean alertable)
 MONO_API MonoOSEventWaitRet
 mono_os_event_wait_multiple (MonoOSEvent **events, gsize nevents, gboolean waitall, guint32 timeout, gboolean alertable);
 
-G_END_DECLS
+MONO_END_DECLS
 
 #endif /* _MONO_UTILS_OS_EVENT_H_ */

--- a/mono/utils/parse.h
+++ b/mono/utils/parse.h
@@ -11,6 +11,10 @@
 #include <glib.h>
 #include <stdlib.h>
 
+G_BEGIN_DECLS
+
 gboolean mono_gc_parse_environment_string_extract_number (const char *str, size_t *out);
+
+G_END_DECLS
 
 #endif

--- a/mono/utils/parse.h
+++ b/mono/utils/parse.h
@@ -11,10 +11,10 @@
 #include <glib.h>
 #include <stdlib.h>
 
-G_BEGIN_DECLS
+MONO_BEGIN_DECLS
 
 gboolean mono_gc_parse_environment_string_extract_number (const char *str, size_t *out);
 
-G_END_DECLS
+MONO_END_DECLS
 
 #endif

--- a/mono/utils/parse.h
+++ b/mono/utils/parse.h
@@ -11,10 +11,10 @@
 #include <glib.h>
 #include <stdlib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 gboolean mono_gc_parse_environment_string_extract_number (const char *str, size_t *out);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif

--- a/mono/utils/strenc.h
+++ b/mono/utils/strenc.h
@@ -14,10 +14,14 @@
 #include <glib.h>
 #include <mono/utils/mono-publib.h>
 
+MONO_BEGIN_DECLS
+
 extern MONO_API gunichar2 *mono_unicode_from_external (const gchar *in, gsize *bytes);
 extern MONO_API gchar *mono_utf8_from_external (const gchar *in);
 extern MONO_API gchar *mono_unicode_to_external (const gunichar2 *uni);
 extern MONO_API gboolean mono_utf8_validate_and_len (const gchar *source, glong* oLength, const gchar** oEnd);
 extern MONO_API gboolean mono_utf8_validate_and_len_with_bounds (const gchar *source, glong max_bytes, glong* oLength, const gchar** oEnd);
+
+MONO_END_DECLS
 
 #endif /* _MONO_STRENC_H_ */

--- a/mono/utils/strenc.h
+++ b/mono/utils/strenc.h
@@ -14,7 +14,7 @@
 #include <glib.h>
 #include <mono/utils/mono-publib.h>
 
-MONO_BEGIN_DECLS
+G_BEGIN_DECLS
 
 extern MONO_API gunichar2 *mono_unicode_from_external (const gchar *in, gsize *bytes);
 extern MONO_API gchar *mono_utf8_from_external (const gchar *in);
@@ -22,6 +22,6 @@ extern MONO_API gchar *mono_unicode_to_external (const gunichar2 *uni);
 extern MONO_API gboolean mono_utf8_validate_and_len (const gchar *source, glong* oLength, const gchar** oEnd);
 extern MONO_API gboolean mono_utf8_validate_and_len_with_bounds (const gchar *source, glong max_bytes, glong* oLength, const gchar** oEnd);
 
-MONO_END_DECLS
+G_END_DECLS
 
 #endif /* _MONO_STRENC_H_ */


### PR DESCRIPTION
Sometimes G_BEGIN/END_DECLS, sometimes MONO_BEGIN/END_DECLS, if they work,
else just plain extern "C".

- Predictable portable names for dlopen/dlsym (LoadLibrary/GetProcAddress).
- Letting C and C++ interoperate if/while the tree
  undergoes a transition from C to C++, including
  if some code stays as C indefinitely.
- Some might later be reverted, esp. outside of the dlopen/dlsym (LoadLibrary/GetProcAddress)
  interface or embedding interface.

Also add to some .c files, in particular for functions that do not have prototypes in .h files.

Adding it to all .c files is also an idea depending on policy,
i.e. to inhibit overloading.
