### PR TITLE
[mini] Increase inline cost linearly to number of calls.

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -83,6 +83,7 @@
 #include "mini-runtime.h"
 
 #define BRANCH_COST 10
+#define CALL_COST 10
 /* Used for the JIT */
 #define INLINE_LENGTH_LIMIT 20
 /* Used to LLVM JIT */
@@ -7555,7 +7556,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				UNVERIFIED;
 			}
 
-			inline_costs += 10 * num_calls++;
+			inline_costs += CALL_COST * MIN(10, num_calls++);
 
 			/*
 			 * Making generic calls out of gsharedvt methods.
@@ -8325,7 +8326,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				}
 			}
 
-			inline_costs += 10 * num_calls++;
+			inline_costs += CALL_COST * MIN(10, num_calls++);
 
 			/*
 			 * Synchronized wrappers.
@@ -10943,7 +10944,7 @@ field_access_end:
 			if (!MONO_TYPE_IS_VOID (info->sig->ret))
 				*sp++ = ins;
 
-			inline_costs += 10 * num_calls++;
+			inline_costs += CALL_COST * MIN(10, num_calls++);
 			break;
 		}
 
@@ -10967,7 +10968,7 @@ mono_ldptr:
 			g_assert (method->wrapper_type != MONO_WRAPPER_NONE);
 			ins = mini_emit_runtime_constant (cfg, ldptr_type, NULL);
 			*sp++ = ins;
-			inline_costs += 10 * num_calls++;
+			inline_costs += CALL_COST * MIN(10, num_calls++);
 			break;
 
 		case MONO_CEE_MONO_LDPTR: {
@@ -10977,7 +10978,7 @@ mono_ldptr:
 			ptr = mono_method_get_wrapper_data (method, token);
 			EMIT_NEW_PCONST (cfg, ins, ptr);
 			*sp++ = ins;
-			inline_costs += 10 * num_calls++;
+			inline_costs += CALL_COST * MIN(10, num_calls++);
 			/* Can't embed random pointers into AOT code */
 			DISABLE_AOT (cfg);
 			break;
@@ -10992,7 +10993,7 @@ mono_ldptr:
 			g_assert (callinfo);
 			EMIT_NEW_JIT_ICALL_ADDRCONST (cfg, ins, (char*)callinfo->name);
 			*sp++ = ins;
-			inline_costs += 10 * num_calls++;
+			inline_costs += CALL_COST * MIN(10, num_calls++);
 			break;
 		}
 		case MONO_CEE_MONO_ICALL_ADDR: {
@@ -11046,7 +11047,7 @@ mono_ldptr:
 			NEW_CLASSCONST (cfg, iargs [1], klass);
 			MONO_ADD_INS (cfg->cbb, iargs [1]);
 			*sp++ = mono_emit_jit_icall (cfg, ves_icall_object_new, iargs);
-			inline_costs += 10 * num_calls++;
+			inline_costs += CALL_COST * MIN(10, num_calls++);
 			break;
 		}
 		case MONO_CEE_MONO_OBJADDR:
@@ -11127,7 +11128,7 @@ mono_ldptr:
 			g_assert (method->wrapper_type != MONO_WRAPPER_NONE);
 			EMIT_NEW_CLASSCONST (cfg, ins, mono_method_get_wrapper_data (method, token));
 			*sp++ = ins;
-			inline_costs += 10 * num_calls++;
+			inline_costs += CALL_COST * MIN(10, num_calls++);
 			break;
 		case MONO_CEE_MONO_NOT_TAKEN:
 			g_assert (method->wrapper_type != MONO_WRAPPER_NONE);
@@ -11173,7 +11174,7 @@ mono_ldptr:
 			/* OP_DYN_CALL might need to allocate a dynamically sized param area */
 			cfg->flags |= MONO_CFG_HAS_ALLOCA;
 
-			inline_costs += 10 * num_calls++;
+			inline_costs += CALL_COST * MIN(10, num_calls++);
 			break;
 		}
 		case MONO_CEE_MONO_MEMORY_BARRIER: {
@@ -11588,7 +11589,7 @@ mono_ldptr:
 			ins = mono_emit_jit_icall (cfg, mono_ldftn, &argconst);
 			*sp++ = ins;
 
-			inline_costs += 10 * num_calls++;
+			inline_costs += CALL_COST * MIN(10, num_calls++);
 			break;
 		}
 		case MONO_CEE_LDVIRTFTN: {
@@ -11656,7 +11657,7 @@ mono_ldptr:
 			else
 				*sp++ = mono_emit_jit_icall (cfg, mono_ldvirtfn, args);
 
-			inline_costs += 10 * num_calls++;
+			inline_costs += CALL_COST * MIN(10, num_calls++);
 			break;
 		}
 		case MONO_CEE_LOCALLOC: {


### PR DESCRIPTION
The issue is that for large enough methods it is relatively easy to get an overflow of 'inline_costs', that will trigger negative value check later in this function, leading to 'Method too complex' exception. The reason for that obviously is that every next call get increasing penalty all the time, as 10 * (n - 1), and that accumulates fast enough when thousands of calls are involved.

