### PR TITLE
Apply F# portable pdb debug fix for pinvokes & bump

### DIFF
--- a/packaging/MacSDK/fsharp.py
+++ b/packaging/MacSDK/fsharp.py
@@ -2,13 +2,16 @@ class FsharpPackage(GitHubTarballPackage):
     def __init__(self):
         GitHubTarballPackage.__init__(self,
             'fsharp', 'fsharp',
-            '4.1.33',
-            '561af8ba705fdbd84274702bc8073b9a94ba0a7d',
+            '4.1.34',
+            '662492595a63dffff8fac84939614743fd6d34f9',
             configure='./configure --prefix="%{package_prefix}"',
             override_properties={ 'make': 'make' })
 
         self.extra_stage_files = ['lib/mono/xbuild/Microsoft/VisualStudio/v/FSharp/Microsoft.FSharp.Targets']
-        self.sources.extend(['patches/fsharp-portable-pdb.patch', 'patches/fsharp-string-switchName.patch', 'patches/fsharp-path-overloads.patch'])
+        self.sources.extend(['patches/fsharp-portable-pdb.patch',
+                             'patches/fsharp-string-switchName.patch',
+                             'patches/fsharp-path-overloads.patch',
+                             'patches/fsharp-debug-pinvoke-fix.patch'])
 
     def prep(self):
         Package.prep(self)

--- a/packaging/MacSDK/patches/fsharp-debug-pinvoke-fix.patch
+++ b/packaging/MacSDK/patches/fsharp-debug-pinvoke-fix.patch
@@ -1,0 +1,24 @@
+diff --git a/src/absil/ilwrite.fs b/src/absil/ilwrite.fs
+index 8ea9dec..74b3d9d 100755
+--- a/src/absil/ilwrite.fs
++++ b/src/absil/ilwrite.fs
+@@ -2594,7 +2594,8 @@ let GenMethodDefAsRow cenv env midx (md: ILMethodDef) =
+                 SequencePoints=seqpoints }
+           cenv.AddCode code
+           addr
+-      | MethodBody.Abstract ->
++      | MethodBody.Abstract
++      | MethodBody.PInvoke _ ->
+           // Now record the PDB record for this method - we write this out later. 
+           if cenv.generatePdb then 
+             cenv.pdbinfo.Add  
+@@ -2607,8 +2608,7 @@ let GenMethodDefAsRow cenv env midx (md: ILMethodDef) =
+                 SequencePoints = [| |] }
+           0x0000
+       | MethodBody.Native -> 
+-          failwith "cannot write body of native method - Abstract IL cannot roundtrip mixed native/managed binaries"
+-      | _  -> 0x0000)
++          failwith "cannot write body of native method - Abstract IL cannot roundtrip mixed native/managed binaries")
+ 
+     UnsharedRow 
+        [| ULong  codeAddr  


### PR DESCRIPTION
It wasn't possible to debug any F# app that contained PInvokes.
The F# compiler omitted MethodDebuginformation for PInvokes which in
turn caused Mono to fail on an assertion.

```
* Assertion at metadata.c:1117, condition `idx < t->rows' not met
```



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
