### PR TITLE
[cxx] Port coop handles to valid C++.

### DIFF
--- a/mono/metadata/handle.c
+++ b/mono/metadata/handle.c
@@ -94,7 +94,7 @@ free_handle_chunk (HandleChunk *chunk)
 	g_free (chunk);
 }
 
-const MonoObjectHandle mono_null_value_handle;
+const MonoObjectHandle mono_null_value_handle = { 0 };
 
 #define THIS_IS_AN_OK_NUMBER_OF_HANDLES 100
 

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -405,7 +405,6 @@ MONO_HANDLE_TYPECHECK_FOR (TYPE) (TYPE *a)			\
 }
 
 #else
-
 #define TYPED_HANDLE_DECL(TYPE)						\
 	typedef struct { TYPE *__raw; } TYPED_HANDLE_PAYLOAD_NAME (TYPE) ; \
 	typedef TYPED_HANDLE_PAYLOAD_NAME (TYPE) * TYPED_HANDLE_NAME (TYPE); \

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -46,7 +46,9 @@
 // NOTE: Running this code depends on the ABI to pass a struct
 // with a pointer the same as a pointer. This is tied in with
 // marshaling. If this is not the case, turn off type-safety, perhaps per-OS per-CPU.
-#if defined (HOST_DARWIN) || defined (HOST_WIN32) || defined (HOST_ARM64) || defined (HOST_ARM) || defined (HOST_AMD64)
+#ifdef __cplusplus
+#define MONO_TYPE_SAFE_HANDLES 0 // FIXMEcxx
+#elif defined (HOST_DARWIN) || defined (HOST_WIN32) || defined (HOST_ARM64) || defined (HOST_ARM) || defined (HOST_AMD64)
 #define MONO_TYPE_SAFE_HANDLES 1
 #else
 #define MONO_TYPE_SAFE_HANDLES 0 // PowerPC, S390X, SPARC, MIPS, Linux/x86, BSD/x86, etc.
@@ -245,7 +247,7 @@ Icall macros
 	do {							\
 		void* __result = MONO_HANDLE_RAW (HANDLE);	\
 		CLEAR_ICALL_FRAME;				\
-		return __result;				\
+		return mono_typed_handle_cast_voidptr ((HANDLE), __result); \
 	} while (0); } while (0);
 
 #if MONO_TYPE_SAFE_HANDLES
@@ -326,7 +328,7 @@ mono_thread_info_push_stack_mark (MonoThreadInfo *info, void *mark)
 		CLEAR_ICALL_COMMON	\
 		void* __ret = MONO_HANDLE_RAW (HANDLE);	\
 		CLEAR_ICALL_FRAME	\
-		return __ret;	\
+		return mono_typed_handle_cast_voidptr ((HANDLE), __ret); \
 	} while (0); } while (0)
 
 /*
@@ -377,10 +379,8 @@ Handle macros/functions
  */
 
 #if MONO_TYPE_SAFE_HANDLES
-#define TYPED_HANDLE_DECL(TYPE)							\
-	typedef struct { TYPE **__raw; } TYPED_HANDLE_PAYLOAD_NAME (TYPE),	\
-					 TYPED_HANDLE_NAME (TYPE),		\
-					 TYPED_OUT_HANDLE_NAME (TYPE);		\
+
+#define MONO_TYPE_SAFE_HANDLE_FUNCTIONS(TYPE)			\
 /* Do not call these functions directly. Use MONO_HANDLE_NEW and MONO_HANDLE_CAST. */ \
 /* Another way to do this involved casting mono_handle_new function to a different type. */ \
 static inline MONO_ALWAYS_INLINE TYPED_HANDLE_NAME (TYPE) 	\
@@ -395,11 +395,84 @@ MONO_HANDLE_TYPECHECK_FOR (TYPE) (TYPE *a)			\
 	return a;						\
 }
 
+// FIXMEcxx
+// Have four variations is a bit much.
+// In short term, consider C++ just a third type-unsafe portable form.
+#ifdef __cplusplus
+extern "C++"
+{
+template <typename T>
+struct TypedHandle
+{
+	T** __raw;
+};
+
+template <typename T>
+inline T*
+mono_typed_handle_cast_voidptr (TypedHandle<T> handle, void* voidp)
+// Convert void* to the type T associated with handle.
+{
+	return (T*)voidp;
+}
+
+} // extern "C++"
+
+#define TYPED_HANDLE_DECL(TYPE)							\
+	typedef TypedHandle<TYPE>	TYPED_HANDLE_PAYLOAD_NAME (TYPE),	\
+					TYPED_HANDLE_NAME (TYPE),		\
+					TYPED_OUT_HANDLE_NAME (TYPE);		\
+MONO_TYPE_SAFE_HANDLE_FUNCTIONS (TYPE)
 #else
+
+#define TYPED_HANDLE_DECL(TYPE)							\
+	typedef struct { TYPE **__raw; } TYPED_HANDLE_PAYLOAD_NAME (TYPE),	\
+					 TYPED_HANDLE_NAME (TYPE),		\
+					 TYPED_OUT_HANDLE_NAME (TYPE);		\
+MONO_TYPE_SAFE_HANDLE_FUNCTIONS (TYPE)
+#endif
+
+#else
+
+#ifdef __cplusplus
+extern "C++"
+{
+
+template <typename T>
+struct TypedHandle
+{
+	T* __raw;
+};
+
+template <typename T>
+inline T*
+mono_typed_handle_cast_voidptr (TypedHandle<T>* handle, void* voidp)
+// Convert void* to the type T associated with handle.
+{
+	return (T*)voidp;
+}
+
+} // extern "C++"
+
+#define TYPED_HANDLE_DECL(TYPE)							      \
+	typedef TypedHandle<TYPE>		   TYPED_HANDLE_PAYLOAD_NAME (TYPE) ; \
+	typedef TYPED_HANDLE_PAYLOAD_NAME (TYPE) * TYPED_HANDLE_NAME (TYPE); \
+	typedef TYPED_HANDLE_PAYLOAD_NAME (TYPE) * TYPED_OUT_HANDLE_NAME (TYPE)
+
+#else
+
 #define TYPED_HANDLE_DECL(TYPE)						\
 	typedef struct { TYPE *__raw; } TYPED_HANDLE_PAYLOAD_NAME (TYPE) ; \
 	typedef TYPED_HANDLE_PAYLOAD_NAME (TYPE) * TYPED_HANDLE_NAME (TYPE); \
 	typedef TYPED_HANDLE_PAYLOAD_NAME (TYPE) * TYPED_OUT_HANDLE_NAME (TYPE)
+
+#endif
+
+#endif
+
+#ifndef __cplusplus
+// Convert void* to the type associated with handle.
+// C allows this in context, C++ does not.
+#define mono_typed_handle_cast_voidptr(handle, voidp) (voidp)
 #endif
 
 /*
@@ -730,7 +803,8 @@ mono_array_handle_memcpy_refs (MonoArrayHandle dest, uintptr_t dest_idx, MonoArr
 gpointer
 mono_array_handle_pin_with_size (MonoArrayHandle handle, int size, uintptr_t index, uint32_t *gchandle);
 
-#define MONO_ARRAY_HANDLE_PIN(handle,type,index,gchandle_out) mono_array_handle_pin_with_size (MONO_HANDLE_CAST(MonoArray,(handle)), sizeof (type), (index), (gchandle_out))
+#define MONO_ARRAY_HANDLE_PIN(handle,type,index,gchandle_out) \
+	((type*)mono_array_handle_pin_with_size (MONO_HANDLE_CAST(MonoArray,(handle)), sizeof (type), (index), (gchandle_out)))
 
 gunichar2 *
 mono_string_handle_pin_chars (MonoStringHandle s, uint32_t *gchandle_out);

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -54,6 +54,7 @@
 #define MONO_TYPE_SAFE_HANDLES 0 // PowerPC, S390X, SPARC, MIPS, Linux/x86, BSD/x86, etc.
 #endif
 
+G_BEGIN_DECLS
 
 /*
 Handle stack.


### PR DESCRIPTION
In particular the conversion from void* to non-void*, with the
non-void* type being contextual (the function return type), was a problem.

There are already two forms of coop handles -- type-safe and type-unsafe.

In converting to C++ we are therefore faced with the prospect of creating
two more variations. For now, create just one more, type-unsafe.

This otherwise contributes to errors all around the tree, i.e. anywhere
one is returning a coop handle as a raw pointer.
i.e. all uses of `HANDLE_FUNCTION_RETURN_OBJ` and `ICALL_RETURN_OBJ`

Also C++ requires initialization of consts.
You cannot say:
	```const int i; // zero```
You have to say:
	```const int i = 0;```

Also void* to non-void* cast in `MONO_ARRAY_HANDLE_PIN` as required by C++.

This is probably the biggest seeming change, in conversion to valid C+, and at first glance people will think this is unwarranted premature improvement by taking advantage of C++.
However 1. It is mostly under ifdef so barely touches C
2. Something is required. We have to cast from void* to non-void*, and the non-void* in question is not directly in hand, in C++98. It isn't passed to the macros. It is 1. the return type of the function we are returning from, which is not capturable and 2. A type associated with a parameter to the macros -- which is what this leverages. With C++11 we could use `auto x = MONO_HANDLE_RAW (handle)`, and the majority of the change would fall away. auto is a notable virtue of C++11, but I do not want C++11 language dependencies at this point, nor to argue the merits/demerits of `auto` specifically.