### PR TITLE
[bcl] Include all .sources files in the tarball

### DIFF
--- a/mcs/build/library.make
+++ b/mcs/build/library.make
@@ -237,7 +237,7 @@ ifdef RESOURCE_DEFS
 $(foreach pair,$(RESOURCE_DEFS), $(eval $(call RESOURCE_template,$(word 1, $(subst $(ccomma), ,$(pair))), $(word 2, $(subst $(ccomma), ,$(pair))))))
 endif
 
-DISTFILES = $(wildcard *$(LIBRARY)*.sources) $(EXTRA_DISTFILES) $(DIST_LISTED_RESOURCES)
+DISTFILES = $(wildcard *.sources) $(EXTRA_DISTFILES) $(DIST_LISTED_RESOURCES)
 
 ASSEMBLY      = $(LIBRARY)
 ASSEMBLY_EXT  = .dll

--- a/mcs/class/System.Data/Makefile
+++ b/mcs/class/System.Data/Makefile
@@ -54,8 +54,6 @@ EXTRA_DISTFILES = \
 	Test/test-config-file			\
 	Test/System.Data/binserialize/*.bin	\
 	Test/ProviderTests/sql/*.sql	\
-	SqliteTest.db	\
-	corefx.common.sources	\
-	corefx.unix.sources
+	SqliteTest.db
 
 include ../../build/library.make

--- a/mcs/class/System.Runtime.Serialization/Makefile
+++ b/mcs/class/System.Runtime.Serialization/Makefile
@@ -36,8 +36,6 @@ TEST_LIB_REFS = System.ServiceModel System.Web.Services
 EXTRA_DISTFILES = $(RESOURCE_FILES) $(TEST_RESOURCE_FILES) \
 	Test/Resources/FrameworkTypes/* \
 	Test/Resources/Schemas/*.xsd \
-	Test/System.Runtime.Serialization/one.xml \
-	ReferenceSource.common.sources \
-	ReferenceSource.desktop.sources
+	Test/System.Runtime.Serialization/one.xml
 
 include ../../build/library.make

--- a/mcs/class/System.Web/Makefile
+++ b/mcs/class/System.Web/Makefile
@@ -273,8 +273,6 @@ EXTRA_DISTFILES = \
 	$(shell find Test/standalone-tests/ -name "*.cs" -type f -printf "'%p' " -o -name "*.cs.in" -type f -printf "'%p' ") \
 	$(shell find Test/standalone/ -path '*/.svn' -prune -o -type f -printf "'%p' ") \
 	$(shell find Test/tools/ -path '*/.svn' -prune -o -type f -printf "'%p' ") \
-	System.Web_standalone_test.dll.sources \
-	standalone-runner-support.dll.sources \
 	$(shell find Test/System.Web.Caching/CacheItemPriorityQueueTestData/ -name "Sequence*.*" -type f -printf "'%p' ") \
 	ASPState.sql
 

--- a/mcs/class/System.XML/Makefile
+++ b/mcs/class/System.XML/Makefile
@@ -42,7 +42,6 @@ xmlfiles_files = \
 EXTRA_DISTFILES = \
 	$(wildcard System.Xml.Serialization/standalone_tests/*.cs) \
 	$(wildcard System.Xml.Serialization/standalone_tests/*.output) \
-	common.sources	\
 	Test/XmlFiles/76102.xml		\
 	Test/XmlFiles/79683.dtd		\
 	Test/XmlFiles/496192.xml	\

--- a/mcs/class/System/Makefile
+++ b/mcs/class/System/Makefile
@@ -119,13 +119,6 @@ LIB_MCS_FLAGS += -d:CONFIGURATION_DEP
 endif
 
 EXTRA_DISTFILES = \
-	common.sources					\
-	common_networking.sources		\
-	unix_networkinfo.sources		\
-	linux_networkinfo.sources		\
-	macos_networkinfo.sources		\
-	win32_networkinfo.sources		\
-	corefx.unix.sources				\
 	Test/test-config-file				\
 	Test/System.Security.Cryptography.X509Certificates/pkits/Makefile	\
 	Test/System.Security.Cryptography.X509Certificates/pkits/README		\


### PR DESCRIPTION
https://github.com/mono/mono/commit/0f0e31842f1f394c4e95d3726c20af547e706278 added a new pipes_pns.sources file but we forgot to add it to EXTRA_DISTFILES so it gets included in the tarball.

Given that this happens almost all the time when we add a new .sources file we should just always include all *.sources



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
