### PR TITLE
Add check for a generic method when invoking in debugger

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -4594,5 +4594,17 @@ public class DebuggerTests
 		AssertValue (3.0, f);
 
 	}
+
+	[Test]
+	public void InvokeGenericMethod () {
+		Event e = run_until ("bp1");
+		StackFrame frame = e.Thread.GetFrames()[0];
+		TypeMirror t = frame.Method.DeclaringType;
+		MethodMirror m;
+		m = t.GetMethod ("generic_method");
+		AssertThrows<ArgumentException> (delegate {
+				t.InvokeMethod (e.Thread, m, null);
+			});
+	}
 } // class DebuggerTests
 } // namespace

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -5965,7 +5965,11 @@ do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, guint8 
 		this_buf = (guint8 *)g_alloca (mono_class_instance_size (m->klass));
 	else
 		this_buf = (guint8 *)g_alloca (sizeof (MonoObject*));
-	if (m_class_is_valuetype (m->klass) && (m->flags & METHOD_ATTRIBUTE_STATIC)) {
+
+	if (m->is_generic) {
+		DEBUG_PRINTF (1, "[%p] Error: Attemtping to invoke uninflated generic method %s.\n", (gpointer)(gsize)mono_native_thread_id_get (), mono_method_full_name (m, TRUE));
+		return ERR_INVALID_ARGUMENT;
+	} else if (m_class_is_valuetype (m->klass) && (m->flags & METHOD_ATTRIBUTE_STATIC)) {
 		/* Should be null */
 		int type = decode_byte (p, &p, end);
 		if (type != VALUE_TYPE_ID_NULL) {

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -5967,7 +5967,7 @@ do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, guint8 
 		this_buf = (guint8 *)g_alloca (sizeof (MonoObject*));
 
 	if (m->is_generic) {
-		DEBUG_PRINTF (1, "[%p] Error: Attemtping to invoke uninflated generic method %s.\n", (gpointer)(gsize)mono_native_thread_id_get (), mono_method_full_name (m, TRUE));
+		DEBUG_PRINTF (1, "[%p] Error: Attempting to invoke uninflated generic method %s.\n", (gpointer)(gsize)mono_native_thread_id_get (), mono_method_full_name (m, TRUE));
 		return ERR_INVALID_ARGUMENT;
 	} else if (m_class_is_valuetype (m->klass) && (m->flags & METHOD_ATTRIBUTE_STATIC)) {
 		/* Should be null */


### PR DESCRIPTION
VSTU will try to invoke a generic (uninflated) method in certain
situations, which was causing the Mono debugger to assert and crash
Unity. Added a check for this situation before the invoke so the
debugger can return an error to the client. Previously, this case
wasn't caught until the method was in JIT compilation, which will
assert when this situation is detected.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
