### PR TITLE
[jit] Clean up the handling of the lower/higher parts of long values on 32 bit platforms.

### DIFF
--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -633,8 +633,8 @@ mono_decompose_long_opts (MonoCompile *cfg)
 
 			switch (tree->opcode) {
 			case OP_I8CONST:
-				MONO_EMIT_NEW_ICONST (cfg, MONO_LVREG_LS (tree->dreg), tree->inst_ls_word);
-				MONO_EMIT_NEW_ICONST (cfg, MONO_LVREG_MS (tree->dreg), tree->inst_ms_word);
+				MONO_EMIT_NEW_ICONST (cfg, MONO_LVREG_LS (tree->dreg), ins_get_l_low (tree));
+				MONO_EMIT_NEW_ICONST (cfg, MONO_LVREG_MS (tree->dreg), ins_get_l_high (tree));
 				break;
 			case OP_DUMMY_I8CONST:
 				MONO_EMIT_NEW_DUMMY_INIT (cfg, MONO_LVREG_LS (tree->dreg), OP_DUMMY_ICONST);
@@ -917,24 +917,24 @@ mono_decompose_long_opts (MonoCompile *cfg)
 				break;
 
 			case OP_LADD_IMM:
-				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_ADDCC_IMM, MONO_LVREG_LS (tree->dreg), MONO_LVREG_LS (tree->sreg1), tree->inst_ls_word);
-				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_ADC_IMM, MONO_LVREG_MS (tree->dreg), MONO_LVREG_MS (tree->sreg1), tree->inst_ms_word);
+				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_ADDCC_IMM, MONO_LVREG_LS (tree->dreg), MONO_LVREG_LS (tree->sreg1), ins_get_l_low (tree));
+				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_ADC_IMM, MONO_LVREG_MS (tree->dreg), MONO_LVREG_MS (tree->sreg1), ins_get_l_high (tree));
 				break;
 			case OP_LSUB_IMM:
-				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_SUBCC_IMM, MONO_LVREG_LS (tree->dreg), MONO_LVREG_LS (tree->sreg1), tree->inst_ls_word);
-				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_SBB_IMM, MONO_LVREG_MS (tree->dreg), MONO_LVREG_MS (tree->sreg1), tree->inst_ms_word);
+				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_SUBCC_IMM, MONO_LVREG_LS (tree->dreg), MONO_LVREG_LS (tree->sreg1), ins_get_l_low (tree));
+				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_SBB_IMM, MONO_LVREG_MS (tree->dreg), MONO_LVREG_MS (tree->sreg1), ins_get_l_high (tree));
 				break;
 			case OP_LAND_IMM:
-				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_AND_IMM, MONO_LVREG_LS (tree->dreg), MONO_LVREG_LS (tree->sreg1), tree->inst_ls_word);
-				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_AND_IMM, MONO_LVREG_MS (tree->dreg), MONO_LVREG_MS (tree->sreg1), tree->inst_ms_word);
+				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_AND_IMM, MONO_LVREG_LS (tree->dreg), MONO_LVREG_LS (tree->sreg1), ins_get_l_low (tree));
+				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_AND_IMM, MONO_LVREG_MS (tree->dreg), MONO_LVREG_MS (tree->sreg1), ins_get_l_high (tree));
 				break;
 			case OP_LOR_IMM:
-				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_OR_IMM, MONO_LVREG_LS (tree->dreg), MONO_LVREG_LS (tree->sreg1), tree->inst_ls_word);
-				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_OR_IMM, MONO_LVREG_MS (tree->dreg), MONO_LVREG_MS (tree->sreg1), tree->inst_ms_word);
+				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_OR_IMM, MONO_LVREG_LS (tree->dreg), MONO_LVREG_LS (tree->sreg1), ins_get_l_low (tree));
+				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_OR_IMM, MONO_LVREG_MS (tree->dreg), MONO_LVREG_MS (tree->sreg1), ins_get_l_high (tree));
 				break;
 			case OP_LXOR_IMM:
-				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_XOR_IMM, MONO_LVREG_LS (tree->dreg), MONO_LVREG_LS (tree->sreg1), tree->inst_ls_word);
-				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_XOR_IMM, MONO_LVREG_MS (tree->dreg), MONO_LVREG_MS (tree->sreg1), tree->inst_ms_word);
+				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_XOR_IMM, MONO_LVREG_LS (tree->dreg), MONO_LVREG_LS (tree->sreg1), ins_get_l_low (tree));
+				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_XOR_IMM, MONO_LVREG_MS (tree->dreg), MONO_LVREG_MS (tree->sreg1), ins_get_l_high (tree));
 				break;
 #ifdef TARGET_POWERPC
 /* FIXME This is normally handled in cprop. Proper fix or remove if no longer needed. */
@@ -1036,8 +1036,8 @@ mono_decompose_long_opts (MonoCompile *cfg)
 			/* Not yet used, since lcompare is decomposed before local cprop */
 			case OP_LCOMPARE_IMM: {
 				MonoInst *next = mono_inst_next (tree, FILTER_IL_SEQ_POINT);
-				guint32 low_imm = tree->inst_ls_word;
-				guint32 high_imm = tree->inst_ms_word;
+				guint32 low_imm = ins_get_l_low (tree);
+				guint32 high_imm = ins_get_l_high (tree);
 				int low_reg = MONO_LVREG_LS (tree->sreg1);
 				int high_reg = MONO_LVREG_MS (tree->sreg1);
 

--- a/mono/mini/local-propagation.c
+++ b/mono/mini/local-propagation.c
@@ -670,8 +670,7 @@ mono_local_cprop (MonoCompile *cfg)
 					if ((opcode2 != -1) && mono_arch_is_inst_imm (ins->opcode, opcode2, def->inst_c0) && ((srcindex == 1) || (ins->sreg2 == -1))) {
 						ins->opcode = opcode2;
 						if ((def->opcode == OP_I8CONST) && (sizeof (gpointer) == 4)) {
-							ins->inst_ls_word = def->inst_ls_word;
-							ins->inst_ms_word = def->inst_ms_word;
+							ins->inst_l = def->inst_l;
 						} else {
 							ins->inst_imm = def->inst_c0;
 						}

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -9027,12 +9027,11 @@ calli_end:
 #if SIZEOF_REGISTER == 8
 						ins->inst_imm = sp [1]->inst_l;
 #else
-						ins->inst_ls_word = sp [1]->inst_ls_word;
-						ins->inst_ms_word = sp [1]->inst_ms_word;
+						ins->inst_l = sp [1]->inst_l;
 #endif
-					}
-					else
+					} else {
 						ins->inst_imm = (gssize)(sp [1]->inst_c0);
+					}
 					ins->sreg2 = -1;
 
 					/* Might be followed by an instruction added by add_widen_op */
@@ -9069,11 +9068,10 @@ calli_end:
 				else
 					sp [-1]->inst_c0 = data;
 #else
-				sp [-1]->inst_ls_word = data;
 				if (il_op == MONO_CEE_CONV_U8)
-					sp [-1]->inst_ms_word = 0;
+					sp [-1]->inst_l = (guint32)data;
 				else
-					sp [-1]->inst_ms_word = (data < 0) ? -1 : 0;
+					sp [-1]->inst_l = data;
 #endif
 				sp [-1]->dreg = alloc_dreg (cfg, STACK_I8);
 			}

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -210,7 +210,7 @@ mini_llvm_ins_info[] = {
 #undef MINI_OP3
 
 #if SIZEOF_VOID_P == 4
-#define GET_LONG_IMM(ins) (((guint64)(ins)->inst_ms_word << 32) | (guint64)(guint32)(ins)->inst_ls_word)
+#define GET_LONG_IMM(ins) ((ins)->inst_l)
 #else
 #define GET_LONG_IMM(ins) ((ins)->inst_imm)
 #endif

--- a/mono/mini/mini-mips.c
+++ b/mono/mini/mini-mips.c
@@ -2152,9 +2152,9 @@ mono_arch_decompose_long_opts (MonoCompile *cfg, MonoInst *ins)
 
 	case OP_LADD_IMM:
 		tmp1 = mono_alloc_ireg (cfg);
-		MONO_EMIT_NEW_BIALU_IMM (cfg, OP_IADD_IMM, ins->dreg+1, ins->sreg1+1, ins->inst_ls_word);
+		MONO_EMIT_NEW_BIALU_IMM (cfg, OP_IADD_IMM, ins->dreg+1, ins->sreg1+1, ins_get_l_low (ins));
 		MONO_EMIT_NEW_BIALU (cfg, OP_MIPS_SLTU, tmp1, ins->dreg+1, ins->sreg1+1);
-		MONO_EMIT_NEW_BIALU_IMM (cfg, OP_IADD_IMM, ins->dreg+2, ins->sreg1+2, ins->inst_ms_word);
+		MONO_EMIT_NEW_BIALU_IMM (cfg, OP_IADD_IMM, ins->dreg+2, ins->sreg1+2, ins_get_l_high (ins));
 		MONO_EMIT_NEW_BIALU (cfg, OP_IADD, ins->dreg+2, ins->dreg+2, tmp1);
 		NULLIFY_INS(ins);
 		break;
@@ -2170,9 +2170,9 @@ mono_arch_decompose_long_opts (MonoCompile *cfg, MonoInst *ins)
 
 	case OP_LSUB_IMM:
 		tmp1 = mono_alloc_ireg (cfg);
-		MONO_EMIT_NEW_BIALU_IMM (cfg, OP_ISUB_IMM, ins->dreg+1, ins->sreg1+1, ins->inst_ls_word);
+		MONO_EMIT_NEW_BIALU_IMM (cfg, OP_ISUB_IMM, ins->dreg+1, ins->sreg1+1, ins_get_l_low (ins));
 		MONO_EMIT_NEW_BIALU (cfg, OP_MIPS_SLTU, tmp1, ins->sreg1+1, ins->dreg+1);
-		MONO_EMIT_NEW_BIALU_IMM (cfg, OP_ISUB_IMM, ins->dreg+2, ins->sreg1+2, ins->inst_ms_word);
+		MONO_EMIT_NEW_BIALU_IMM (cfg, OP_ISUB_IMM, ins->dreg+2, ins->sreg1+2, ins_get_l_high (ins));
 		MONO_EMIT_NEW_BIALU (cfg, OP_ISUB, ins->dreg+2, ins->dreg+2, tmp1);
 		NULLIFY_INS(ins);
 		break;

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -586,12 +586,12 @@ mono_decompose_op_imm (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins)
 
 		/* Load the 64bit constant using decomposed ops */
 		MONO_INST_NEW (cfg, temp, OP_ICONST);
-		temp->inst_c0 = ins->inst_ls_word;
+		temp->inst_c0 = ins_get_l_low (ins);
 		temp->dreg = MONO_LVREG_LS (dreg);
 		mono_bblock_insert_before_ins (bb, ins, temp);
 
 		MONO_INST_NEW (cfg, temp, OP_ICONST);
-		temp->inst_c0 = ins->inst_ms_word;
+		temp->inst_c0 = ins_get_l_high (ins);
 		temp->dreg = MONO_LVREG_MS (dreg);
 	} else {
 		dreg = mono_alloc_ireg (cfg);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -111,8 +111,6 @@
 #endif
 #define MINI_LS_WORD_OFFSET (MINI_LS_WORD_IDX * 4)
 #define MINI_MS_WORD_OFFSET (MINI_MS_WORD_IDX * 4)
-#define inst_ls_word data.op[MINI_LS_WORD_IDX].const_val
-#define inst_ms_word data.op[MINI_MS_WORD_IDX].const_val
 
 #define MONO_LVREG_LS(lvreg)	((lvreg) + 1)
 #define MONO_LVREG_MS(lvreg)	((lvreg) + 2)
@@ -850,6 +848,20 @@ enum {
 
 #define inst_phi_args   data.op[1].phi_args
 #define inst_eh_blocks	 data.op[1].exception_clauses
+
+/* Return the lower 32 bits of the 64 bit immediate in INS */
+static inline guint32
+ins_get_l_low (MonoInst *ins)
+{
+	return (guint32)(ins->data.i8const & 0xffffffff);
+}
+
+/* Return the higher 32 bits of the 64 bit immediate in INS */
+static inline guint32
+ins_get_l_high (MonoInst *ins)
+{
+	return (guint32)((ins->data.i8const >> 32) & 0xffffffff);
+}
 
 static inline void
 mono_inst_set_src_registers (MonoInst *ins, int *regs)


### PR DESCRIPTION
Instead of accessing them using the inst_ls_word/inst_ms_word macros which use the union in MonoInst.data, access them normally using
MonoInst.Data.i8const.




<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->