### PR TITLE
[runtime] Make collect_threads helper pin MonoInternalThread objects

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -3758,7 +3758,7 @@ get_thread_dump (MonoThreadInfo *info, gpointer ud)
 
 typedef struct {
 	int nthreads, max_threads;
-	MonoInternalThread **threads;
+	guint32 *threads;
 } CollectThreadsUserData;
 
 static void
@@ -3768,7 +3768,7 @@ collect_thread (gpointer key, gpointer value, gpointer user)
 	MonoInternalThread *thread = (MonoInternalThread *)value;
 
 	if (ud->nthreads < ud->max_threads)
-		ud->threads [ud->nthreads ++] = thread;
+		ud->threads [ud->nthreads ++] = mono_gchandle_new (&thread->obj, TRUE);
 }
 
 /*
@@ -3776,7 +3776,7 @@ collect_thread (gpointer key, gpointer value, gpointer user)
  * THREADS should be an array allocated on the stack.
  */
 static int
-collect_threads (MonoInternalThread **thread_array, int max_threads)
+collect_threads (guint32 *thread_handles, int max_threads)
 {
 	CollectThreadsUserData ud;
 
@@ -3786,7 +3786,7 @@ collect_threads (MonoInternalThread **thread_array, int max_threads)
 
 	memset (&ud, 0, sizeof (ud));
 	/* This array contains refs, but its on the stack, so its ok */
-	ud.threads = thread_array;
+	ud.threads = thread_handles;
 	ud.max_threads = max_threads;
 
 	mono_threads_lock ();
@@ -3884,7 +3884,7 @@ mono_threads_perform_thread_dump (void)
 {
 	FILE* output_file = NULL;
 	ThreadDumpUserData ud;
-	MonoInternalThread *thread_array [128];
+	guint32 thread_array [128];
 	int tindex, nthreads;
 
 	if (!thread_dump_requested)
@@ -3915,8 +3915,13 @@ mono_threads_perform_thread_dump (void)
 	ud.frames = g_new0 (MonoStackFrameInfo, 256);
 	ud.max_frames = 256;
 
-	for (tindex = 0; tindex < nthreads; ++tindex)
-		dump_thread (thread_array [tindex], &ud, output_file != NULL ? output_file : stdout);
+	for (tindex = 0; tindex < nthreads; ++tindex) {
+		guint32 handle = thread_array [tindex];
+		MonoInternalThread *thread = (MonoInternalThread *) mono_gchandle_get_target (handle);
+		dump_thread (thread, &ud, output_file != NULL ? output_file : stdout);
+		mono_gchandle_free (handle);
+	}
+
 	if (output_file != NULL) {
 		fclose (output_file);
 	}
@@ -3931,7 +3936,7 @@ mono_threads_get_thread_dump (MonoArray **out_threads, MonoArray **out_stack_fra
 {
 
 	ThreadDumpUserData ud;
-	MonoInternalThread *thread_array [128];
+	guint32 thread_array [128];
 	MonoDomain *domain = mono_domain_get ();
 	MonoDebugSourceLocation *location;
 	int tindex, nthreads;
@@ -3954,7 +3959,9 @@ mono_threads_get_thread_dump (MonoArray **out_threads, MonoArray **out_stack_fra
 	goto_if_nok (error, leave);
 
 	for (tindex = 0; tindex < nthreads; ++tindex) {
-		MonoInternalThread *thread = thread_array [tindex];
+		guint32 handle = thread_array [tindex];
+		MonoInternalThread *thread = (MonoInternalThread *) mono_gchandle_get_target (handle);
+
 		MonoArray *thread_frames;
 		int i;
 
@@ -4010,6 +4017,8 @@ mono_threads_get_thread_dump (MonoArray **out_threads, MonoArray **out_stack_fra
 			}
 			mono_array_setref (thread_frames, i, sf);
 		}
+
+		mono_gchandle_free (handle);
 	}
 
 leave:
@@ -5907,31 +5916,41 @@ static size_t num_threads_summarized = 0;
 
 // mono_thread_internal_current doesn't always work in signal
 // handler contexts. This does.
-static MonoInternalThread *
-find_missing_thread (MonoNativeThreadId id)
+static gboolean
+find_missing_thread (MonoNativeThreadId id, guint32 *out)
 {
-	MonoInternalThread *thread_array [128];
+	guint32 thread_array [128];
 	int nthreads = collect_threads (thread_array, 128);
+	gboolean success = FALSE;
 
 	for (int i=0; i < nthreads; i++) {
-		MonoNativeThreadId tid = thread_get_tid (thread_array [i]);
-		if (tid == id)
-			return thread_array [i];
+		guint32 handle = thread_array [i];
+		MonoInternalThread *thread = (MonoInternalThread *) mono_gchandle_get_target (handle);
+		MonoNativeThreadId tid = thread_get_tid (thread);
+		if (tid == id) {
+			*out = handle;
+			success = TRUE;
+		} else {
+			mono_gchandle_free (handle);
+		}
 	}
-	return NULL;
+
+	return success;
 }
 
 static gboolean
 mono_threads_summarize_one (MonoThreadSummary *out, MonoContext *ctx)
 {
 	MonoDomain *domain;
+	guint32 handle;
 
 	MonoNativeThreadId current = mono_native_thread_id_get();
-	MonoInternalThread *thread = find_missing_thread (current);
 
 	// Not one of ours
-	if (!thread)
+	if (!find_missing_thread (current, &handle))
 		return FALSE;
+
+	MonoInternalThread *thread = (MonoInternalThread *) mono_gchandle_get_target (handle);
 
 	memset (out, 0, sizeof (*out));
 	domain = thread->obj.vtable->domain;
@@ -5949,6 +5968,8 @@ mono_threads_summarize_one (MonoThreadSummary *out, MonoContext *ctx)
 	/*g_assert (out->num_frames > 0);*/
 	/*if (out->num_frames == 0)*/
 		/*return FALSE;*/
+
+	mono_gchandle_free (handle);
 
 	return TRUE;
 }
@@ -6005,7 +6026,7 @@ mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes)
 		//
 		// Thankfully the memory behind these pointers is always leaked,
 		// we never have dangling pointers.
-		MonoInternalThread *thread_array [128];
+		guint32 thread_array [128];
 		int nthreads = collect_threads (thread_array, 128);
 
 		if (nthreads == 0)
@@ -6016,12 +6037,15 @@ mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes)
 		sigaddset(&sigset, SIGTERM);
 
 		for (int i=0; i < nthreads; i++) {
-			MonoNativeThreadId tid = thread_get_tid (thread_array [i]);
+			guint32 handle = thread_array [i];
+			MonoInternalThread *thread = (MonoInternalThread *) mono_gchandle_get_target (handle);
+
+			MonoNativeThreadId tid = thread_get_tid (thread);
 			if (current == tid)
 				continue;
 
 			// Request every other thread dumps themselves before us
-			MonoThreadInfo *info = thread_array [i]->thread_info;
+			MonoThreadInfo *info = thread->thread_info;
 
 			mono_memory_barrier ();
 			size_t old_num_summarized = num_threads_summarized;
@@ -6049,6 +6073,10 @@ mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes)
 				MOSTLY_ASYNC_SAFE_PRINTF("Waiting for signalled thread %zx to collect stacktrace. Status: %s\n", tid, name);
 				count--;
 			}
+
+			// Free the gchandle; we're done waiting on this one, no matter how the waiting went.
+			mono_gchandle_free (handle);
+
 			if (count == 0) {
 				// After timeout
 				// Thread may have been in lock or something, may have died


### PR DESCRIPTION
This fix is supposed to fix a big performance issue exposed by MERP. The preexisting race doesn't appear to be causing any instability currently, but it looks like it could if hit wrong.

== 
Edit: Elaboration

The function collect_threads returns a pointer to the thread, not a handle. We do pin already. This reference is freed when the thread is detached from the runtime. There is no guarantee that the unmanaged functions interacting with these threads will not run concurrently with threads being detached. In fact, one can observe that being the case when using MERP. 

When we being a dump, we collect a list of active threads. We walk them, and signal each thread one-by-one. While dumping one thread, it is not uncommon to find that a couple of other threads die. We run into a timeout while waiting for a thread on about 6-7 threads when dumping VS4M.

When one reruns collect_threads, we don't see that thread anymore.

Now there are a few problems here. Inside of MERP, I want to be able to check the MonoInternalThread to check the thread state so I can abort early if the thread has died. It'll be much faster than what I'm doing now. But when I do so, I run into some crashes due to memory unsafety. The MonoInternalThread has been freed I'm pretty sure, because the pinned reference is no longer pinned. This is the race I am discussing. 

I think that a good first step here is to make collect_threads pin the threads in question so that racing detachment doesn't lead to memory unsafety. 