### PR TITLE
[coop] Turn hybrid suspend on by default on desktop platforms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4997,6 +4997,31 @@ AC_ARG_WITH(lazy_gc_thread_creation, [  --with-lazy-gc-thread-creation=yes|no   
 	fi
 ], [with_lazy_gc_thread_creation=no])
 
+dnl *****************************
+dnl *** Thread suspend policy ***
+dnl *****************************
+
+dnl Set a default hybrid or cooperative suspend on some platforms
+
+dnl Coop default is set by the bitcode preset.
+
+dnl If coop isn't on by default, maybe hybrid should be?
+if test x$enable_cooperative_suspend_default != xyes; then
+	case $HOST in
+	X86 | AMD64)
+		dnl Some host/target confusion, there's no host_osx (and
+		dnl host_darwin would be true on iOS not just macOS).
+		if test x$target_osx = xyes; then
+			enable_hybrid_suspend_default=yes
+		elif test x$host_linux = xyes -o x$host_win32 = xyes; then
+			enable_hybrid_suspend_default=yes
+		fi
+		;;
+	esac
+fi
+
+dnl Now check if there were flags overriding the defaults
+
 AC_ARG_WITH(cooperative_gc,        [  --with-cooperative-gc=yes|no        Enable cooperative stop-the-world garbage collection (sgen only) (defaults to no)], [AC_MSG_WARN([--with-cooperative-gc is deprecated, use --enable-cooperative-suspend instead])], [with_cooperative_gc=default])
 AC_ARG_ENABLE(cooperative_suspend, [  --enable-cooperative-suspend      Enable cooperative stop-the-world garbage collection (sgen only) (defaults to no)], [], [enable_cooperative_suspend=default])
 
@@ -5030,6 +5055,12 @@ fi
 
 AM_CONDITIONAL([ENABLE_HYBRID_SUSPEND], [test x$enable_hybrid_suspend != xno])
 
+dnl End of thread suspend policy
+
+dnl **********************
+dnl *** checked builds ***
+dnl **********************
+
 AC_ARG_ENABLE(checked_build, [  --enable-checked-build=LIST      To enable checked build (expensive asserts), configure with a comma-separated LIST of checked build modules and then include that same list in the environment variable MONO_CHECK_MODE at runtime. Recognized checked build modules: all, gc, metadata, thread, private_types],[
 
 	if test x$enable_checked_build != x ; then
@@ -5062,6 +5093,8 @@ AC_ARG_ENABLE(checked_build, [  --enable-checked-build=LIST      To enable check
 		AC_DEFINE(ENABLE_CHECKED_BUILD_PRIVATE_TYPES, 1, [Enable private types checked build])
 	fi
 ], [])
+
+dnl End of checked builds
 
 AC_CHECK_HEADER([malloc.h], 
 		[AC_DEFINE([HAVE_USR_INCLUDE_MALLOC_H], [1], 
@@ -5687,9 +5720,9 @@ fi
 
 thread_suspend_msg=
 if test x$buildsgen = xyes; then
-	if test x$enable_cooperative_suspend = xyes; then
+	if test x$enable_cooperative_suspend != xno; then
 		thread_suspend_msg="Suspend:       Cooperative"
-	elif test x$enable_hybrid_suspend = xyes; then
+	elif test x$enable_hybrid_suspend != xno; then
 		thread_suspend_msg="Suspend:       Hybrid"
 	else
 		thread_suspend_msg="Suspend:       Preemptive"

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2311,9 +2311,11 @@ mono_gc_pthread_create (pthread_t *new_thread, const pthread_attr_t *attr, void 
 {
 	int res;
 
+	MONO_ENTER_GC_SAFE;
 	mono_threads_join_lock ();
 	res = pthread_create (new_thread, attr, start_routine, arg);
 	mono_threads_join_unlock ();
+	MONO_EXIT_GC_SAFE;
 
 	return res;
 }

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -826,8 +826,9 @@ gsharedvtcheck:
 hybridcheck:
 	$(MAKE) fullaotcheck HYBRID=1
 
+# FIXME: force preemptive suspend while interpreter doesn't support coop/hybird suspend
 fullaotmixedcheck:
-	$(MAKE) fullaotcheck MIXED=1
+	$(MAKE) fullaotcheck MIXED=1 MONO_THREADS_SUSPEND=preemptive
 
 fullaot_regtests = $(regtests)
 fullaot_testing_deps = generics-variant-types.dll TestDriver.dll MemoryIntrinsics.dll

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1811,7 +1811,6 @@ mono_enable_interp (const char *opts)
 #ifndef MONO_ARCH_INTERPRETER_SUPPORTED
 	g_error ("--interpreter not supported on this architecture.\n");
 #endif
-	mono_interp_threads_suspend_check ();
 
 }
 
@@ -2667,6 +2666,9 @@ mono_runtime_set_execution_mode (MonoEEMode mode)
 	default:
 		g_error ("Unknown execution-mode %d", mode);
 	}
+	
+	if (mono_use_interpreter)
+		mono_interp_threads_suspend_check ();
 }
 
 /**

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -76,6 +76,7 @@ static FILE *mini_stats_fd;
 static void mini_usage (void);
 static void mono_runtime_set_execution_mode (MonoEEMode mode);
 static int mono_jit_exec_internal (MonoDomain *domain, MonoAssembly *assembly, int argc, char *argv[]);
+static void mono_interp_threads_suspend_check (void);
 
 #ifdef HOST_WIN32
 /* Need this to determine whether to detach console */
@@ -1810,6 +1811,8 @@ mono_enable_interp (const char *opts)
 #ifndef MONO_ARCH_INTERPRETER_SUPPORTED
 	g_error ("--interpreter not supported on this architecture.\n");
 #endif
+	mono_interp_threads_suspend_check ();
+
 }
 
 /**
@@ -2702,6 +2705,16 @@ mono_jit_set_trace_options (const char* options)
 		return FALSE;
 	mono_jit_trace_calls = trace_opt;
 	return TRUE;
+}
+
+static void
+mono_interp_threads_suspend_check (void)
+{
+	// FIXME: Add safepoint support and GC thread state transitions to the interpreter
+	if (mono_threads_are_safepoints_enabled ()) {
+		g_warning ("Interpreter does not support safepoints. Cannot use %s suspend with the interpreter.", mono_threads_suspend_policy_name ());
+		mono_threads_suspend_override_policy (MONO_THREADS_SUSPEND_FULL_PREEMPTIVE);
+	}
 }
 
 /**

--- a/mono/utils/mono-threads-coop.h
+++ b/mono/utils/mono-threads-coop.h
@@ -53,6 +53,20 @@ mono_threads_safepoint (void)
 		mono_threads_state_poll ();
 }
 
+/* -1 and 0 also used:
+ * -1 means uninitialized
+ * 0 means unset
+ */
+typedef enum {
+	MONO_THREADS_SUSPEND_FULL_PREEMPTIVE = 1,
+	MONO_THREADS_SUSPEND_FULL_COOP,
+	MONO_THREADS_SUSPEND_HYBRID
+} MonoThreadsSuspendPolicy;
+
+/* Don't use this. */
+void mono_threads_suspend_override_policy (MonoThreadsSuspendPolicy new_policy);
+
+
 /*
  * The following are used when detaching a thread. We need to pass the MonoThreadInfo*
  * as a paramater as the thread info TLS key is being destructed, meaning that

--- a/sdks/builds/android.mk
+++ b/sdks/builds/android.mk
@@ -160,7 +160,9 @@ _android-$(1)_CONFIGURE_FLAGS= \
 	--with-btls-android-ndk=$$(ANDROID_TOOLCHAIN_DIR)/ndk \
 	--with-sigaltstack=yes \
 	--with-tls=pthread \
-	--without-ikvm-native
+	--without-ikvm-native \
+	--disable-cooperative-suspend \
+	--disable-hybrid-suspend
 
 .stamp-android-$(1)-toolchain: | $$(if $$(IGNORE_PROVISION_ANDROID),,provision-android)
 	python "$$(ANDROID_TOOLCHAIN_DIR)/ndk/build/tools/make_standalone_toolchain.py" --verbose --force --api=$$(ANDROID_SDK_VERSION_$(1)) --arch=$(2) --install-dir=$$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang

--- a/sdks/builds/ios.mk
+++ b/sdks/builds/ios.mk
@@ -119,6 +119,8 @@ _ios-$(1)_CONFIGURE_FLAGS = \
 	--with-tls=pthread \
 	--without-ikvm-native \
 	--without-sigaltstack \
+	--disable-cooperative-suspend \
+	--disable-hybird-suspend \
 	$$(ios-$(1)_CONFIGURE_FLAGS)
 
 .stamp-ios-$(1)-toolchain:
@@ -249,6 +251,8 @@ _ios-$(1)_CONFIGURE_FLAGS= \
 	--enable-monotouch \
 	--with-tls=pthread \
 	--without-ikvm-native \
+	--disable-cooperative-suspend \
+	--disable-hybrid-suspend \
 	$$(ios-$(1)_CONFIGURE_FLAGS)
 
 # _ios-$(1)_CONFIGURE_FLAGS += --enable-extension-module=xamarin


### PR DESCRIPTION
Use hybrid suspend by default on x86 and amd64 OSX, Windows and Linux.

Pass `--disable-hybrid-suspend` to configure to disable at build time, or set
the enrivonment variable `MONO_THREADS_SUSPEND=preemptive` when running Mono to use preemptive suspend (the previous default).

Pass `--disable-hybrid-suspend --enable-cooperative-suspend` to configure
cooperative suspend at build time.