### PR TITLE
[LinkerDescriptor] remove remoting feature from MonoMethodMessage

### DIFF
--- a/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
+++ b/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
@@ -722,7 +722,7 @@
 		</type>
 
 		<!-- domain.c: mono_defaults.mono_method_message_class -->
-		<type fullname="System.Runtime.Remoting.Messaging.MonoMethodMessage" preserve="fields" feature="remoting" >
+		<type fullname="System.Runtime.Remoting.Messaging.MonoMethodMessage" preserve="fields">
 			<!-- object.c: mono_message_init -->
 			<method name="InitMessage" />
 		</type>


### PR DESCRIPTION
Fixes those failures on Xamarin.iOS:

> 2018-07-30 21:16:19.931 monotouchtest[49618:80799179] error: * Assertion at /Users/builder/jenkins/workspace/xamarin-macios-pr-builder/external/mono/mono/metadata/object.c:7896, condition 'init_message_method != NULL' not met
> 2018-07-30 21:16:19.931 monotouchtest[49618:80799179] critical: Stacktrace:
>
> 2018-07-30 21:16:19.932 monotouchtest[49618:80799179] critical:   at <unknown> <0xffffffff>
> 2018-07-30 21:16:19.932 monotouchtest[49618:80799179] critical:   at (wrapper managed-to-native) object.__icall_wrapper_mono_delegate_begin_invoke (object,intptr) <0x00012>
> 2018-07-30 21:16:19.932 monotouchtest[49618:80799179] critical:   at (wrapper delegate-begin-invoke) <Module>.begin_invoke_IAsyncResult__this___AsyncCallback_object (System.AsyncCallback,object) [0x00015] in <643e5a0761d140d1977f1bbd2bd72153>:0
> 2018-07-30 21:16:19.932 monotouchtest[49618:80799179] critical:   at MonoTouchFixtures.AVFoundation.AVAssetImageGeneratorTest.GenerateCGImagesAsynchronously () [0x00021] in /Users/builder/jenkins/workspace/xamarin-macios-pr-builder/tests/monotouch-test/AVFoundation/AVAssetImageGeneratorTest.cs:126
> 2018-07-30 21:16:19.933 monotouchtest[49618:80799179] critical:   at (wrapper runtime-invoke) object.runtime_invoke_void__this__ (object,intptr,intptr,intptr) [0x0004f] in <643e5a0761d140d1977f1bbd2bd72153>:0
> 2018-07-30 21:16:19.933 monotouchtest[49618:80799179] critical:   at <unknown> <0xffffffff>
> 2018-07-30 21:16:19.934 monotouchtest[49618:80799179] critical:   at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke (System.Reflection.MonoMethod,object,object[],System.Exception&) <0x00012>
> 2018-07-30 21:16:19.934 monotouchtest[49618:80799179] critical:   at System.Reflection.MonoMethod.Invoke (object,System.Reflection.BindingFlags,System.Reflection.Binder,object[],System.Globalization.CultureInfo) [0x0003b] in /Library/Frameworks/Xamarin.iOS.framework/Versions/11.15.0.36/src/Xamarin.iOS/mcs/class/corlib/System.Reflection/MonoMethod.cs:305
> 2018-07-30 21:16:19.934 monotouchtest[49618:80799179] critical:   at System.Reflection.MethodBase.Invoke (object,object[]) [0x00000] in /Library/Frameworks/Xamarin.iOS.framework/Versions/11.15.0.36/src/Xamarin.iOS/mcs/class/referencesource/mscorlib/system/reflection/methodbase.cs:229
> 2018-07-30 21:16:19.934 monotouchtest[49618:80799179] critical:   at NUnit.Framework.Internal.Reflect.InvokeMethod (System.Reflection.MethodInfo,object,object[]) [0x00009] in /Users/builder/jenkins/workspace/xamarin-macios-pr-builder/external/mono/external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/Reflect.cs:215
> 2018-07-30 21:16:19.935 monotouchtest[49618:80799179] critical:   at NUnit.Framework.Internal.Commands.TestMethodCommand.RunNonAsyncTestMethod (NUnit.Framework.Internal.TestExecutionContext) [0x00000] in /Users/builder/jenkins/workspace/xamarin-macios-pr-builder/external/mono/external/nunit-lite/NUnitLite-1.0.0/src/framework/Internal/Commands/TestMethodCommand.cs:114


Also see
https://github.com/xamarin/xamarin-macios/blob/10d98e67d88231fd41218a93b92d42914550ee10/tools/mtouch/Tuning.cs#L137

@akoeplinger mentions further:
> we even have custom code to preserve MonoMethodMessage in the XI linker:
> https://github.com/xamarin/xamarin-macios/blob/a563a66c342d2e982a9648fbfd5ce9c361bea07e/tools/linker/MonoTouch.Tuner/RemoveCode.cs#L178-L180

Fixes regression introduced by https://github.com/mono/mono/pull/8055


/cc @mrvoorhe  
