### PR TITLE
Fix System.Drawing on 64-bit macOS.

### DIFF
--- a/mcs/class/System.Drawing/System.Drawing/Graphics.cs
+++ b/mcs/class/System.Drawing/System.Drawing/Graphics.cs
@@ -1710,6 +1710,10 @@ namespace System.Drawing
 			IntPtr graphics;
 
 			if (GDIPlus.UseCocoaDrawable) {
+				if (hwnd == IntPtr.Zero) {
+					throw new NotSupportedException ("Opening display graphics is not supported");
+				}
+
 				CocoaContext context = MacSupport.GetCGContextForNSView (hwnd);
 				GDIPlus.GdipCreateFromContext_macosx (context.ctx, context.width, context.height, out graphics);
 


### PR DESCRIPTION
Carbon implementation now throws exception instead of crashing in the mismatched p/invoke calls.
Cocoa implementation now support 64-bit mode and uses the handle of `NSView` that is passed in instead of relying on `NSGraphicsContext.CurrentContext`. It also fixes handling of flipped views.

Requires up to date libgdiplus.