### PR TITLE
Avoid all Roslyn dependencies in --with-csc=mcs builds

### DIFF
--- a/mcs/class/aot-compiler/Makefile
+++ b/mcs/class/aot-compiler/Makefile
@@ -79,9 +79,6 @@ CSC_IMAGES = $(csc_aot_image) $(csc_SRM_image) $(csc_SCI_image) $(csc_MC_image) 
 clean-local:
 	-rm -f $(mscorlib_aot_image) $(mcs_aot_image) $(CSC_IMAGES) $(LOG_FILE)
 
-# AOT build profile to speed up build
-ifeq ($(PROFILE),build)
-
 IMAGES = $(mscorlib_aot_image)
 
 ifdef MCS_MODE
@@ -90,14 +87,17 @@ else
 IMAGES += $(CSC_IMAGES)
 endif
 
+
+
+# AOT build profile to speed up build
+ifeq ($(PROFILE),build)
+
 all-local: $(IMAGES)
 install-local:
 
 endif
 
 ifeq ($(PROFILE), $(DEFAULT_PROFILE))
-
-IMAGES = $(mscorlib_aot_image) $(mcs_aot_image) $(CSC_IMAGES)
 
 all-local: $(IMAGES)
 install-local:

--- a/mcs/packages/Makefile
+++ b/mcs/packages/Makefile
@@ -40,15 +40,19 @@ MSBUILD_ROSLYN_DIR = $(DESTDIR)$(mono_libdir)/mono/msbuild/15.0/bin/Roslyn
 
 install-local: install-prototypes
 	$(MKINSTALLDIRS) $(TARGET_DIR)
+ifndef MCS_MODE
 	$(INSTALL_LIB) $(ROSLYN_FILES_FOR_MONO) $(TARGET_DIR)
 	$(MKINSTALLDIRS) $(MSBUILD_ROSLYN_DIR)
 	$(INSTALL_LIB) $(ROSLYN_FILES_TO_COPY_FOR_MSBUILD) $(MSBUILD_ROSLYN_DIR)
 
 	(cd $(MSBUILD_ROSLYN_DIR); for asm in $(ROSLYN_FILES_FOR_MONO); do ln -fs ../../../../$(FRAMEWORK_VERSION)/$$(basename $$asm) . ; done)
+endif
 
 install-prototypes:
 	$(MKINSTALLDIRS) $(TARGET_DIR)/dim
+ifndef MCS_MODE
 	$(INSTALL_LIB) $(ROSLYN_DIM_FILES) $(TARGET_DIR)/dim
+endif
 
 run-test-local: test-csi
 

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -36,13 +36,17 @@ bin_SCRIPTS = \
 	mono-test-install	\
 	peverify		\
 	mcs			\
-	csc			\
-	csc-dim		\
-	vbc			\
-	csi			\
 	mono-package-runtime	\
 	mono-heapviz		\
 	$(scripts_mono_configuration_crypto)
+
+ifndef MCS_MODE
+bin_SCRIPTS += \
+	csc			\
+	csc-dim		\
+	vbc			\
+	csi
+endif
 
 if INSTALL_4_x
 bin_SCRIPTS += $(scripts_4_0)


### PR DESCRIPTION
A major driver for MCS_MODE is so distributions can do a 100% from-source build, distros will strip Roslyn from those, so we shouldn't need it there when not using it.