### PR TITLE
Fix mcs mode aot

### DIFF
--- a/mcs/class/aot-compiler/Makefile
+++ b/mcs/class/aot-compiler/Makefile
@@ -79,9 +79,6 @@ CSC_IMAGES = $(csc_aot_image) $(csc_SRM_image) $(csc_SCI_image) $(csc_MC_image) 
 clean-local:
 	-rm -f $(mscorlib_aot_image) $(mcs_aot_image) $(CSC_IMAGES) $(LOG_FILE)
 
-# AOT build profile to speed up build
-ifeq ($(PROFILE),build)
-
 IMAGES = $(mscorlib_aot_image)
 
 ifdef MCS_MODE
@@ -90,14 +87,17 @@ else
 IMAGES += $(CSC_IMAGES)
 endif
 
+
+
+# AOT build profile to speed up build
+ifeq ($(PROFILE),build)
+
 all-local: $(IMAGES)
 install-local:
 
 endif
 
 ifeq ($(PROFILE), $(DEFAULT_PROFILE))
-
-IMAGES = $(mscorlib_aot_image) $(mcs_aot_image) $(CSC_IMAGES)
 
 all-local: $(IMAGES)
 install-local:

--- a/mcs/packages/Makefile
+++ b/mcs/packages/Makefile
@@ -40,15 +40,19 @@ MSBUILD_ROSLYN_DIR = $(DESTDIR)$(mono_libdir)/mono/msbuild/15.0/bin/Roslyn
 
 install-local: install-prototypes
 	$(MKINSTALLDIRS) $(TARGET_DIR)
+ifndef MCS_MODE
 	$(INSTALL_LIB) $(ROSLYN_FILES_FOR_MONO) $(TARGET_DIR)
 	$(MKINSTALLDIRS) $(MSBUILD_ROSLYN_DIR)
 	$(INSTALL_LIB) $(ROSLYN_FILES_TO_COPY_FOR_MSBUILD) $(MSBUILD_ROSLYN_DIR)
 
 	(cd $(MSBUILD_ROSLYN_DIR); for asm in $(ROSLYN_FILES_FOR_MONO); do ln -fs ../../../../$(FRAMEWORK_VERSION)/$$(basename $$asm) . ; done)
+endif
 
 install-prototypes:
 	$(MKINSTALLDIRS) $(TARGET_DIR)/dim
+ifndef MCS_MODE
 	$(INSTALL_LIB) $(ROSLYN_DIM_FILES) $(TARGET_DIR)/dim
+endif
 
 run-test-local: test-csi
 


### PR DESCRIPTION
We should avoid all dependency on Roslyn, when doing a --with-csc=mcs build, as a major use-case for this is Linux distributions which will need to strip out Roslyn for from-source builds.