### PR TITLE
Add missing return from the function.

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -4327,6 +4327,7 @@ mono_class_get_namespace (MonoClass *klass)
 	MONO_ENTER_GC_UNSAFE;
 	result = m_class_get_name_space (klass);
 	MONO_EXIT_GC_UNSAFE;
+	return result;
 }
 
 /**


### PR DESCRIPTION
Was accidentally removed in 3780114620cd.
