### PR TITLE
[eglib] Fix compilation warnings.

### DIFF
--- a/mono/eglib/eglib-remap.h
+++ b/mono/eglib/eglib-remap.h
@@ -278,9 +278,7 @@
 #define g_unichar_break_type monoeg_unichar_break_type
 #define g_unichar_isspace monoeg_unichar_isspace
 #define g_unichar_to_utf16 monoeg_unichar_to_utf16
-#define g_utf8_find_prev_char monoeg_utf8_find_prev_char
 #define g_utf8_get_char_validated monoeg_utf8_get_char_validated
-#define g_utf8_prev_char monoeg_utf8_prev_char
 #define g_utf8_to_ucs4 monoeg_utf8_to_ucs4
 
 

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -1065,8 +1065,6 @@ extern const guchar g_utf8_jump_table[256];
 
 gboolean  g_utf8_validate      (const gchar *str, gssize max_len, const gchar **end);
 gunichar  g_utf8_get_char_validated (const gchar *str, gssize max_len);
-gchar    *g_utf8_find_prev_char (const char *str, const char *p);
-gchar    *g_utf8_prev_char     (const char *str);
 #define   g_utf8_next_char(p)  ((p) + g_utf8_jump_table[(guchar)(*p)])
 gunichar  g_utf8_get_char      (const gchar *src);
 glong     g_utf8_strlen        (const gchar *str, gssize max);

--- a/mono/eglib/gmem.c
+++ b/mono/eglib/gmem.c
@@ -111,7 +111,7 @@ gpointer g_calloc (gsize n, gsize x)
 	gpointer ptr;
 	if (!x || !n)
 		return 0;
-		ptr = G_CALLOC_INTERNAL (n, x);
+	ptr = G_CALLOC_INTERNAL (n, x);
 	if (ptr)
 		return ptr;
 	g_error ("Could not allocate %i (%i * %i) bytes", x*n, n, x);

--- a/mono/eglib/gutf8.c
+++ b/mono/eglib/gutf8.c
@@ -287,28 +287,6 @@ g_utf8_get_char (const gchar *src)
 }
 
 gchar *
-g_utf8_find_prev_char (const gchar *str, const gchar *p)
-{
-	while (p > str) {
-		p--;
-		if ((*p & 0xc0) != 0xb0)
-			return (gchar *)p;
-	}
-	return NULL;
-}
-
-gchar *
-g_utf8_prev_char (const gchar *str)
-{
-	const gchar *p = str;
-	do {
-		p--;
-	} while ((*p & 0xc0) == 0xb0);
-	
-	return (gchar *)p;
-}
-
-gchar *
 g_utf8_offset_to_pointer (const gchar *str, glong offset)
 {
 	const gchar *p = str;
@@ -328,7 +306,7 @@ g_utf8_offset_to_pointer (const gchar *str, glong offset)
 			
 			// if we land in the middle of a character
 			// walk to the beginning
-			while ((*jump & 0xc0) == 0xb0)
+			while ((*jump & 0xc0) == 0x80)
 				jump --;
 			
 			// count how many characters we've actually walked


### PR DESCRIPTION
First one fixes gcc 7/8 warning for misleading indentation.

Second one corrects condition for leading utf-8 byte test - intended bitmask test is 11xxxxxx vs 10xxxxxx.