### PR TITLE
Truncate MachineName (and UserDomainName) at first period

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -6542,7 +6542,7 @@ mono_icall_get_machine_name (MonoError *error)
 #if !defined(DISABLE_SOCKETS)
 	MonoStringHandle result;
 	char *buf;
-	int n;
+	int n, i;
 #if defined _SC_HOST_NAME_MAX
 	n = sysconf (_SC_HOST_NAME_MAX);
 	if (n == -1)
@@ -6552,6 +6552,13 @@ mono_icall_get_machine_name (MonoError *error)
 	
 	if (gethostname (buf, n) == 0){
 		buf [n] = 0;
+		// try truncating the string at the first dot
+		for (i = 0; i < n; i++) {
+			if (buf[i] == '.') {
+				buf[i] = '\0';
+				break;
+			}
+		}
 		result = mono_string_new_handle (mono_domain_get (), buf, error);
 	} else
 		result = MONO_HANDLE_CAST (MonoString, NULL_HANDLE);


### PR DESCRIPTION
Unix machines often put their FQDN as the host name, and domain
name is used for things such as yp. As such, truncate the FQDN to
just the hostname, as other Unix utilities seem to do.

Matches the .NET Core and .NET Framework behaviour, and MS seems to
require this for a future project. Fixes #9839.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
