### PR TITLE
[msbuild] Bump to point to HEAD of mono-2018-04 msbuild  …

### DIFF
--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,10 +3,10 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = '49a614cda8cedbc6b42e37d49e40cc89fbdac4fd')
+			revision = '8af44c5b9e727c096833a88fae05c3ddb76716d0')
 
 	def build (self):
-		self.sh ('./build.sh -host mono -configuration Release -skipTests')
+		self.sh ('./build.sh -hostType mono -configuration Release -skipTests')
 		self.sh ('zip msbuild-bin-logs.zip artifacts/Release-MONO/log/*')
 
 	def install (self):

--- a/scripts/ci/run-test-mac-sdk.sh
+++ b/scripts/ci/run-test-mac-sdk.sh
@@ -7,7 +7,7 @@ export PATH=${MONO_REPO_ROOT}/external/bockbuild/stage/bin:$PATH
 
 # Bundled MSBuild
 cd ${MONO_REPO_ROOT}/external/bockbuild/builds/msbuild-15/
-${TESTCMD} --label="msbuild-tests" --timeout=180m ./build.sh -host mono -configuration Release
+${TESTCMD} --label="msbuild-tests" --timeout=180m ./build.sh -hostType mono -configuration Release
 zip ${MONO_REPO_ROOT}/msbuild-test-results.zip artifacts/2/Release-MONO/TestResults/*
 
 # Bundled LLVM


### PR DESCRIPTION
.. once, msbuild has an updated branch for 2018-06/master, then this
will point to that.

This also picks up fix for https://github.com/xamarin/xamarin-android/issues/1845 .



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
