### PR TITLE
[2018-06] Fix comparison of IntPtr with null in Mono

### DIFF
--- a/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/SQLite3.cs
+++ b/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/SQLite3.cs
@@ -804,7 +804,7 @@ namespace Mono.Data.Sqlite
       int enc;
       IntPtr p = UnsafeNativeMethods.sqlite3_context_collseq(context, out type, out enc, out len);
 
-      if (p != null) seq.Name = UTF8ToString(p, len);
+      if (p != IntPtr.Zero) seq.Name = UTF8ToString(p, len);
       seq.Type = (CollationTypeEnum)type;
       seq._func = func;
       seq.Encoding = (CollationEncodingEnum)enc;


### PR DESCRIPTION
Backport of https://github.com/mono/mono/pull/9800
`MonoCertificatePal.cs` does not exist in this branch yet.