### PR TITLE
[System.Reflection] CoreFX import for ExceptionHandlingClauseOptions

### DIFF
--- a/mcs/class/corlib/corlib.csproj
+++ b/mcs/class/corlib/corlib.csproj
@@ -390,6 +390,7 @@
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\Reflection\CustomAttributeFormatException.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\Reflection\DefaultMemberAttribute.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\Reflection\EventAttributes.cs" />
+    <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\Reflection\ExceptionHandlingClauseOptions.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\Reflection\FieldAttributes.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\Reflection\GenericParameterAttributes.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\Reflection\ICustomAttributeProvider.cs" />
@@ -876,7 +877,6 @@
     <Compile Include="..\referencesource\mscorlib\system\reflection\memberinfo.cs" />
     <Compile Include="..\referencesource\mscorlib\system\reflection\memberinfoserializationholder.cs" />
     <Compile Include="..\referencesource\mscorlib\system\reflection\methodbase.cs" />
-    <Compile Include="..\referencesource\mscorlib\system\reflection\methodbody.cs" />
     <Compile Include="..\referencesource\mscorlib\system\reflection\methodinfo.cs" />
     <Compile Include="..\referencesource\mscorlib\system\reflection\pointer.cs" />
     <Compile Include="..\referencesource\mscorlib\system\reflection\typedelegator.cs" />

--- a/mcs/class/corlib/corlib.dll.sources
+++ b/mcs/class/corlib/corlib.dll.sources
@@ -1182,6 +1182,7 @@ ReferenceSources/AppContextDefaultValues.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/Reflection/CallingConventions.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/Reflection/DefaultMemberAttribute.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/Reflection/EventAttributes.cs
+../../../external/corefx/src/Common/src/CoreLib/System/Reflection/ExceptionHandlingClauseOptions.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/Reflection/FieldAttributes.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/Reflection/GenericParameterAttributes.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/Reflection/ICustomAttributeProvider.cs
@@ -1216,7 +1217,6 @@ ReferenceSources/AppContextDefaultValues.cs
 ../referencesource/mscorlib/system/reflection/memberinfo.cs
 ../referencesource/mscorlib/system/reflection/memberinfoserializationholder.cs
 ../referencesource/mscorlib/system/reflection/methodbase.cs
-../referencesource/mscorlib/system/reflection/methodbody.cs
 ../referencesource/mscorlib/system/reflection/methodinfo.cs
 ../referencesource/mscorlib/system/reflection/pointer.cs
 ../referencesource/mscorlib/system/reflection/RuntimeReflectionExtensions.cs


### PR DESCRIPTION
Part of #9660.

Previously ExceptionHandlingClauseOptions was placed in referencesource  [methodbody.cs](https://github.com/mono/mono/blob/master/mcs/class/referencesource/mscorlib/system/reflection/methodbody.cs) where other content is hidden by `#if !MONO` condition.