### PR TITLE
Use argv for cli_launcher on OSes that don't return full path for process names; fix mono_w32process_get_path on Free/NetBSD

### DIFF
--- a/mono/metadata/w32process-unix-bsd.c
+++ b/mono/metadata/w32process-unix-bsd.c
@@ -99,17 +99,18 @@ mono_w32process_get_path (pid_t pid)
 #else
 	gsize path_len = PATH_MAX + 1;
 	gchar path [PATH_MAX + 1];
-	gint mib [3];
+	gint mib [4];
+	mib [0] = CTL_KERN;
 #if defined (__NetBSD__)
-	mib [0] = KERN_PROC_ARGS;
-	mib [1] = -1
-	mib [2] = KERN_PROC_PATHNAME;
+	mib [1] = KERN_PROC_ARGS;
+	mib [2] = pid;
+	mib [3] = KERN_PROC_PATHNAME;
 #else // FreeBSD
-	mib [0] = KERN_PROC;
-	mib [1] = KERN_PROC_PATHNAME;
-	mib [2] = -1;
+	mib [1] = KERN_PROC;
+	mib [2] = KERN_PROC_PATHNAME;
+	mib [3] = pid;
 #endif
-	if (sysctl (mib, 3, path, &path_len, NULL, 0) < 0) {
+	if (sysctl (mib, 4, path, &path_len, NULL, 0) < 0) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: sysctl() failed: %d", __func__, errno);
 		return NULL;
 	} else {

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -2231,7 +2231,20 @@ mono_main (int argc, char* argv[])
 		return 1;
 	}
 
-#if !defined(HOST_WIN32) && defined(HAVE_UNISTD_H)
+/*
+ * XXX: verify if other OSes need it; many platforms seem to have it so that
+ * mono_w32process_get_path -> mono_w32process_get_name, and the name is not
+ * necessarily a path instead of just the program name
+ */
+#if defined (_AIX) || defined (__FreeBSD__)
+	/*
+	 * mono_w32process_get_path on these can only return a name, not a path;
+	 * which may not be good for us if the mono command name isn't on $PATH,
+	 * like in CI scenarios. chances are argv based is fine if we inherited
+	 * the environment variables.
+	 */
+	mono_w32process_set_cli_launcher (argv [0]);
+#elif !defined(HOST_WIN32) && defined(HAVE_UNISTD_H)
 	/*
 	 * If we are not embedded, use the mono runtime executable to run managed exe's.
 	 */

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -2236,7 +2236,7 @@ mono_main (int argc, char* argv[])
  * mono_w32process_get_path -> mono_w32process_get_name, and the name is not
  * necessarily a path instead of just the program name
  */
-#if defined (_AIX) || defined (__FreeBSD__)
+#if defined (_AIX)
 	/*
 	 * mono_w32process_get_path on these can only return a name, not a path;
 	 * which may not be good for us if the mono command name isn't on $PATH,


### PR DESCRIPTION
Should fix process-leak test on AIX, maybe more. Also tested that it fixes the
same behaviour on FreeBSD. Other OSes may be affected; consult and test with the
files `w32process-unix-*.c`.

From comments:

```c
/*
 * XXX: verify if other OSes need it; many platforms seem to have it so that
 * mono_w32process_get_path -> mono_w32process_get_name, and the name is not
 * necessarily a path instead of just the program name
 */

/*
 * mono_w32process_get_path on these can only return a name, not a path;
 * which may not be good for us if the mono command name isn't on $PATH,
 * like in CI scenarios. chances are argv based is fine if we inherited
 * the environment variables.
 */
```