### PR TITLE
[runtime] Cache culture locale name in managed

### DIFF
--- a/mcs/class/corlib/System.Globalization/CultureInfo.cs
+++ b/mcs/class/corlib/System.Globalization/CultureInfo.cs
@@ -146,17 +146,26 @@ namespace System.Globalization
 			}
 		}
 
+		private static string current_culture_name;
+
 		internal static CultureInfo ConstructCurrentCulture ()
 		{
 			if (default_current_culture != null)
 				return default_current_culture;
 
-			var locale_name = get_current_locale_name ();
+			string locale_name;
+			if (current_culture_name != null)
+				locale_name = current_culture_name;
+			else
+				locale_name = get_current_locale_name ();
+
 			CultureInfo ci = null;
 
 			if (locale_name != null) {
 				try {
 					ci = CreateSpecificCulture (locale_name);
+					if (current_culture_name == null)
+						current_culture_name = locale_name;
 				} catch {
 				}
 			}


### PR DESCRIPTION
Every different locale getter in unmanaged attempts to
cache the result from this icall. Some of them fail to do so in a manner
that is correct.

CFLocaleCopyCurrent (); in get_darwin_locale ends up being called
thousands of times. In an app with a few dozen Console.WriteLines, it's easy to see
18mb of leaked memory through this.

Rather than trying to fix them all in unmanaged in a perfect manner, I
thought it better to also avoid the icall overhead and to cache it in
C#.

Without this fix, a memory traffic stress test (debian shootout's pidigits) leads to 66% of
memory pressure being due to this  icall. With this fix, it is 4.3%.

If this caching is wrong for correctness reasons (we expect it to change?),
I would like to point out that we have similar caching done in unmanaged
and that we should then bring both into a correct design.