### PR TITLE
Wasm Bindings enhancements

### DIFF
--- a/sdks/README.md
+++ b/sdks/README.md
@@ -44,11 +44,11 @@ make build-bcl package-bcl
 Go to the `wasm` directory for building and testing WebAssembly. Right now the following targets are available:
 
 - build: Build the test runner and test suites
-- run-mini: Run mini test suite
-- run-corlib: Run corlib test suite
-- run-system: Run System test suite
-- run-system-core: Run System.Core test suite
-
+- run-all-mini: Run mini test suite
+- run-all-corlib: Run corlib test suite
+- run-all-system: Run System test suite
+- run-all-system-core: Run System.Core test suite
+- run-all-binding: Run bindings test suite
 
 For bcl or runtime changes, you must manually run the corresponding build/package steps in `builds`.
 For test suite changes, it's enough to just rerun the local target.

--- a/sdks/wasm/binding_support.js
+++ b/sdks/wasm/binding_support.js
@@ -2,9 +2,10 @@
 var BindingSupportLib = {
 	$BINDING__postset: 'BINDING.export_functions (Module);',
 	$BINDING: {
-		BINDING_ASM: "binding_tests",
-		js_objects_table: [],
-
+		BINDING_ASM: "[binding_tests]WebAssembly.Runtime",
+		mono_wasm_object_registry: [],
+		mono_wasm_ref_counter: 0,
+		mono_wasm_free_list: [],
 		mono_bindings_init: function (binding_asm) {
 			this.BINDING_ASM = binding_asm;
 		},
@@ -36,19 +37,38 @@ var BindingSupportLib = {
 			this.mono_obj_array_new = Module.cwrap ('mono_wasm_obj_array_new', 'number', ['number']);
 			this.mono_obj_array_set = Module.cwrap ('mono_wasm_obj_array_set', 'void', ['number', 'number', 'number']);
 
-			this.binding_module = this.assembly_load (this.BINDING_ASM);
-			var wasm_runtime_class = this.find_class (this.binding_module, "WebAssembly", "Runtime")
+			var binding_fqn_asm = this.BINDING_ASM.substring(this.BINDING_ASM.indexOf ("[") + 1, this.BINDING_ASM.indexOf ("]")).trim();
+			var binding_fqn_class = this.BINDING_ASM.substring (this.BINDING_ASM.indexOf ("]") + 1).trim();
+			
+			this.binding_module = this.assembly_load (binding_fqn_asm);
+			if (!this.binding_module)
+				throw "Can't find bindings module assembly: " + binding_fqn_asm;
+
+			if (binding_fqn_class !== null && typeof binding_fqn_class !== "undefined")
+			{
+				var namespace = "WebAssembly";
+				var classname = binding_fqn_class.length > 0 ? binding_fqn_class : "Runtime";
+				if (binding_fqn_class.indexOf(".") != -1) {
+					var idx = binding_fqn_class.lastIndexOf(".");
+					namespace = binding_fqn_class.substring (0, idx);
+					classname = binding_fqn_class.substring (idx + 1);
+				}
+			}
+
+			var wasm_runtime_class = this.find_class (this.binding_module, namespace, classname)
 			if (!wasm_runtime_class)
-				throw "Can't find WebAssembly.Runtime class";
+				throw "Can't find " + binding_fqn_class + " class";
 
 			var get_method = function(method_name) {
 				var res = BINDING.find_method (wasm_runtime_class, method_name, -1)
 				if (!res)
-					throw "Can't find method WebAssembly.Runtime:" + method_name;
+					throw "Can't find method " + namespace + "." + classname + ":" + method_name;
 				return res;
 			}
 			this.bind_js_obj = get_method ("BindJSObject");
 			this.bind_existing_obj = get_method ("BindExistingObject");
+			this.unbind_js_obj = get_method ("UnBindJSObject");
+			this.unbind_js_obj_and_fee = get_method ("UnBindJSObjectAndFree");			
 			this.get_js_id = get_method ("GetJSObjectId");
 			this.get_raw_mono_obj = get_method ("GetMonoObject");
 
@@ -68,7 +88,7 @@ var BindingSupportLib = {
 
 		get_js_obj: function (js_handle) {
 			if (js_handle > 0)
-				return this.js_objects_table [js_handle - 1];
+				return this.mono_wasm_require_handle(js_handle);
 			return null;
 		},
 		
@@ -209,6 +229,16 @@ var BindingSupportLib = {
 			return this.call_method (this.bind_existing_obj, null, "mi", [mono_obj, js_id]);
 		},
 
+		wasm_unbind_js_obj: function (js_obj_id)
+		{
+			return this.call_method (this.unbind_js_obj, null, "i", [js_obj_id]);
+		},		
+
+		wasm_unbind_js_obj_and_free: function (js_obj_id)
+		{
+			return this.call_method (this.unbind_js_obj_and_fee, null, "i", [js_obj_id]);
+		},		
+
 		wasm_get_js_id: function (mono_obj)
 		{
 			return this.call_method (this.get_js_id, null, "m", [mono_obj]);
@@ -232,20 +262,20 @@ var BindingSupportLib = {
 		},
 
 		get_task_and_bind: function (tcs, js_obj) {
-			var task_gchandle = this.call_method (this.tcs_get_task_and_bind, null, "oi", [ tcs, this.js_objects_table.length + 1 ]);
+			var gc_handle = this.mono_wasm_free_list.length ? this.mono_wasm_free_list.pop() : this.mono_wasm_ref_counter++;
+			var task_gchandle = this.call_method (this.tcs_get_task_and_bind, null, "oi", [ tcs, gc_handle + 1 ]);
 			js_obj.__mono_gchandle__ = task_gchandle;
-			this.js_objects_table.push (js_obj);
+			this.mono_wasm_object_registry[gc_handle] = js_obj;
 			return this.wasm_get_raw_obj (js_obj.__mono_gchandle__);
 		},
 
 		extract_mono_obj: function (js_obj) {
-			//halp JS ppl, is this enough?
-			if (js_obj == null || js_obj == undefined)
+			//help JS ppl, is this enough?
+			if (js_obj === null || typeof js_obj === "undefined")
 				return 0;
 
 			if (!js_obj.__mono_gchandle__) {
-				js_obj.__mono_gchandle__ = this.wasm_binding_obj_new(this.js_objects_table.length + 1);
-				this.js_objects_table.push(js_obj);
+				this.mono_wasm_register_obj(js_obj);
 			}
 
 			return this.wasm_get_raw_obj (js_obj.__mono_gchandle__);
@@ -257,15 +287,15 @@ var BindingSupportLib = {
 
 			var js_id = this.wasm_get_js_id (mono_obj);
 			if (js_id > 0)
-				return this.js_objects_table [js_id - 1];
+				return this.mono_wasm_require_handle(js_id);
 
+			var gcHandle = this.mono_wasm_free_list.length ? this.mono_wasm_free_list.pop() : this.mono_wasm_ref_counter++;
 			var js_obj = {
-				__mono_gchandle__: this.wasm_bind_existing(mono_obj, this.js_objects_table.length + 1),
+				__mono_gchandle__: this.wasm_bind_existing(mono_obj, gcHandle + 1),
 				is_mono_bridged_obj: true
 			};
 
-			this.js_objects_table.push(js_obj);
-
+			this.mono_wasm_object_registry[gcHandle] = js_obj;
 			return js_obj;
 		},
 
@@ -405,7 +435,46 @@ var BindingSupportLib = {
 			return function() {
 				return BINDING.call_method (method, null, signature, arguments);
 			};
-		}
+		},
+		// Object wrapping helper functions to handle reference handles that will
+		// be used in managed code.
+		mono_wasm_register_obj: function(obj) {
+
+			var gc_handle = undefined;
+			if (obj !== null && typeof obj !== "undefined") {
+				gc_handle = obj.__mono_gchandle__;
+				if (typeof gc_handle === "undefined") {
+					var handle = this.mono_wasm_free_list.length ?
+								this.mono_wasm_free_list.pop() : this.mono_wasm_ref_counter++;
+					gc_handle = handle + 1;
+					obj.__mono_gchandle__ = this.wasm_binding_obj_new(gc_handle);
+						
+				}
+				this.mono_wasm_object_registry[handle] = obj;
+			}
+			return gc_handle;
+		},
+		mono_wasm_require_handle: function(handle) {
+			if (handle > 0)
+				return this.mono_wasm_object_registry[handle - 1];
+			return null;
+		},
+		mono_wasm_unregister_obj: function(js_id) {
+			var obj = this.mono_wasm_object_registry[js_id - 1]
+			if (typeof obj  !== "undefined" && obj !== null) {
+				var gc_handle = obj.__mono_gchandle__;
+				if (typeof gc_handle  !== "undefined") {
+					this.wasm_unbind_js_obj_and_free(js_id);
+					delete obj.__mono_gchandle__;
+					this.mono_wasm_free_list.push(js_id - 1);
+					return obj;
+				}
+			}
+			return null;
+		},
+		mono_wasm_free_handle: function(handle) {
+			this.mono_wasm_unregister_obj(handle);
+		},
 	},
 
 	mono_wasm_invoke_js_with_args: function(js_handle, method_name, args, is_exception) {

--- a/sdks/wasm/binding_support.js
+++ b/sdks/wasm/binding_support.js
@@ -125,6 +125,10 @@ var BindingSupportLib = {
 				};
 			}
 			case 6: {// Task
+
+				if (typeof Promise === "undefined" || typeof Promise.resolve === "undefined")
+					throw new Error ("Promises are not supported thus C# Tasks can not work in this context.");
+
 				var obj = this.extract_js_obj (mono_obj);
 				var cont_obj = null;
 				var promise = new Promise (function (resolve, reject) {
@@ -150,7 +154,7 @@ var BindingSupportLib = {
 		},
 
 		create_task_completion_source: function () {
-			return this.call_method (this.create_tcs, null, "", []);
+			return this.call_method (this.create_tcs, null, "i", [ -1 ]);
 		},
 
 		set_task_result: function (tcs, result) {
@@ -216,7 +220,7 @@ var BindingSupportLib = {
 		},
 
 		try_extract_mono_obj:function (js_obj) {
-			if (js_obj == null || js_obj == undefined || !js_obj.__mono_gchandle__)
+			if (js_obj === null || typeof js_obj === "undefined" || typeof js_obj.__mono_gchandle__ === "undefined")
 				return 0;
 			return this.wasm_get_raw_obj (js_obj.__mono_gchandle__);
 		},

--- a/sdks/wasm/bindings-test.cs
+++ b/sdks/wasm/bindings-test.cs
@@ -100,6 +100,21 @@ public class TestClass {
 		return task;
 	}
 
+	public static TaskCompletionSource<object> tcs3;
+	public static Task task3;
+	public static object MkTaskNull () {
+		tcs3 = new TaskCompletionSource<object> ();
+		task3 = tcs3.Task;
+		return task3;
+	}
+
+	public static Task<object> taskString;
+	public static object MkTaskString () {
+		tcs3 = new TaskCompletionSource<object> ();
+		taskString = tcs3.Task;
+		return taskString;
+	}
+
 	public static Task<object> the_promise;
 	public static void InvokePromise (object obj) {
 		the_promise = (Task<object>)obj;
@@ -248,14 +263,14 @@ public class BindingTests {
 		Runtime.InvokeJS (@"
 			var tsk = call_test_method (""MkTask"", """", [ ]);
 			tsk.then (function (value) {
-				print ('PassTaskToJS cont with value ' + value);
+				Module.print ('PassTaskToJS cont with value ' + value);
 			});
 		");
 		Assert.AreEqual (0, TestClass.int_val);
 		TestClass.tcs.SetResult (99);
 		//FIXME our test harness doesn't suppport async tests.
 		// So manually verify it for now by checking stdout for `PassTaskToJS cont with value 99`
-		// Assert.AreEqual (99, TestClass.int_val);
+		//Assert.AreEqual (99, TestClass.int_val);
 	}
 
 
@@ -266,7 +281,7 @@ public class BindingTests {
 			var tsk = call_test_method (""MkTask"", """", [ ]);
 			tsk.then (function (value) {},
 			function (reason) {
-				print ('PassTaskToJS2 cont failed due to ' + reason);
+				Module.print ('PassTaskToJS2 cont failed due to ' + reason);
 			});
 		");
 		Assert.AreEqual (0, TestClass.int_val);
@@ -276,6 +291,65 @@ public class BindingTests {
 		// Assert.AreEqual (99, TestClass.int_val);
 	}
 
+	[Test]
+	public static void PassTaskToJS3 () {
+		TestClass.int_val = 0;
+		Runtime.InvokeJS (@"
+			var tsk = call_test_method (""MkTaskNull"", """", [ ]);
+			tsk.then( () => {
+  				Module.print('PassTaskToJS3 cont without value '); // Success!
+			}, reason => {
+  				Module.print('PassTaskToJS3 cont failed due to ' + reason); // Error!
+			} );
+		");
+		Assert.AreEqual (0, TestClass.int_val);
+		TestClass.tcs3.SetResult (null);
+	}
+
+	[Test]
+	public static void PassTaskToJS4 () {
+		TestClass.int_val = 0;
+		Runtime.InvokeJS (@"
+			var tsk = call_test_method (""MkTaskNull"", """", [ ]);
+			tsk.then( value => {
+  				Module.print(value); // Success!
+			}, reason => {
+  				Module.print('PassTaskToJS4 cont failed due to ' + reason); // Error!
+			} );
+		");
+		Assert.AreEqual (0, TestClass.int_val);
+		TestClass.tcs3.SetException (new Exception ("it failed"));
+	}	
+	
+	[Test]
+	public static void PassTaskToJS5 () {
+		TestClass.int_val = 0;
+		Runtime.InvokeJS (@"
+			var tsk = call_test_method (""MkTaskString"", """", [ ]);
+			tsk.then( success => {
+  				Module.print('PassTaskToJS5 cont with value ' + success); // Success!
+			}, reason => {
+  				Module.print('PassTaskToJS5 cont failed due to ' + reason); // Error!
+			} );
+		");
+		Assert.AreEqual (0, TestClass.int_val);
+		TestClass.tcs3.SetResult ("Success");
+	}
+
+	[Test]
+	public static void PassTaskToJS6 () {
+		TestClass.int_val = 0;
+		Runtime.InvokeJS (@"
+			var tsk = call_test_method (""MkTaskString"", """", [ ]);
+			tsk.then( success => {
+  				Module.print('PassTaskToJS6 cont with value ' + success); // Success!
+			}, reason => {
+  				Module.print('PassTaskToJS6 cont failed due to ' + reason); // Error!
+			} );
+		");
+		Assert.AreEqual (0, TestClass.int_val);
+		TestClass.tcs3.SetException (new Exception ("it failed"));
+	}	
 
 	[Test]
 	public static void PassPromiseToCS () {

--- a/sdks/wasm/bindings-test.cs
+++ b/sdks/wasm/bindings-test.cs
@@ -122,6 +122,13 @@ public class TestClass {
 			Console.WriteLine ("Promise result is {0}", t.Result);
 		}, null, TaskContinuationOptions.ExecuteSynchronously); //must be sync cuz the mainloop pump is gone
 	}
+
+	public static List<JSObject> js_objs_to_dispose = new List<JSObject>();
+	public static void DisposeObject(JSObject obj)
+	{
+		js_objs_to_dispose.Add(obj);
+		obj.Dispose();
+	}	
 }
 
 [TestFixture]
@@ -398,4 +405,24 @@ public class BindingTests {
 
 		Assert.AreNotEqual (0, TestClass.int_val);
 	}
+
+	[Test]
+	public static void DisposeObject () {
+		Runtime.InvokeJS (@"
+			var obj1 = {
+			};
+			var obj2 = {
+			};
+			var obj3 = {
+			};
+			call_test_method (""DisposeObject"", ""o"", [ obj3 ]);
+			call_test_method (""DisposeObject"", ""o"", [ obj2 ]);
+			call_test_method (""DisposeObject"", ""o"", [ obj1 ]);
+		");
+
+		Assert.AreEqual (TestClass.js_objs_to_dispose [0].JSHandle, -1);
+		Assert.AreEqual (TestClass.js_objs_to_dispose [1].JSHandle, -1);		
+		Assert.AreEqual (TestClass.js_objs_to_dispose [2].JSHandle, -1);		
+	}
+
 }

--- a/sdks/wasm/bindings.cs
+++ b/sdks/wasm/bindings.cs
@@ -23,6 +23,10 @@ namespace WebAssembly {
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		internal static extern object InvokeJSWithArgs (int js_obj_handle, string method, object[] _params, out int exceptional_result);
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        internal static extern object GetObjectProperty(int js_obj_handle, string propertyName, out int exceptional_result);
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        internal static extern object SetObjectProperty(int js_obj_handle, string propertyName, object value, bool createIfNotExists, bool hasOwnProperty, out int exceptional_result);
 
 		public static string InvokeJS (string str)
 		{
@@ -162,6 +166,7 @@ namespace WebAssembly {
 				case TypeCode.UInt16:
 				case TypeCode.Int32:
 				case TypeCode.UInt32:
+				case TypeCode.Boolean:
 					res += "i";
 					break;
 				case TypeCode.Int64:
@@ -247,6 +252,31 @@ namespace WebAssembly {
 				throw new JSException ((string)res);
 			return res;
 		}
+
+
+        public object GetObjectProperty(string expr)
+        {
+
+            int exception = 0;
+            var propertyValue = Runtime.GetObjectProperty(JSHandle, expr, out exception);
+
+            if (exception != 0)
+                throw new JSException((string)propertyValue);
+
+            return propertyValue;
+
+        }
+
+        public void SetObjectProperty(string expr, object value, bool createIfNotExists = true, bool hasOwnProperty = false)
+        {
+
+            int exception = 0;
+            var setPropResult = Runtime.SetObjectProperty(JSHandle, expr, value, createIfNotExists, hasOwnProperty, out exception);
+            if (exception != 0)
+                throw new JSException($"Error setting {expr} on (js-obj js '{JSHandle}' mono '{(IntPtr)Handle} raw '{RawObject != null})");
+
+        }
+
 
 		public override string ToString () {
 			return $"(js-obj js '{JSHandle}' mono '{(IntPtr)Handle} raw '{RawObject != null})";

--- a/sdks/wasm/driver.c
+++ b/sdks/wasm/driver.c
@@ -121,7 +121,6 @@ MonoAssembly* mono_assembly_load (MonoAssemblyName *aname, const char *basedir, 
 MonoAssemblyName* mono_assembly_name_new (const char *name);
 void mono_assembly_name_free (MonoAssemblyName *aname);
 const char* mono_image_get_name (MonoImage *image);
-const char* mono_class_get_name (MonoClass *klass);
 MonoString* mono_string_new (MonoDomain *domain, const char *text);
 void mono_add_internal_call (const char *name, const void* method);
 MonoString * mono_string_from_utf16 (char *data);
@@ -132,9 +131,6 @@ MonoClass* mono_get_object_class (void);
 int mono_class_is_delegate (MonoClass* klass);
 const char* mono_class_get_name (MonoClass *klass);
 const char* mono_class_get_namespace (MonoClass *klass);
-char * mono_type_get_full_name (MonoClass *klass);
-MonoClass *mono_class_from_mono_type (MonoType *type);
-MonoClass *mono_class_get_parent (MonoClass *klass);
 
 #define mono_array_get(array,type,index) ( *(type*)mono_array_addr ((array), type, (index)) ) 
 #define mono_array_addr(array,type,index) ((type*)(void*) mono_array_addr_with_size (array, sizeof (type), index))

--- a/sdks/wasm/driver.c
+++ b/sdks/wasm/driver.c
@@ -284,15 +284,11 @@ mono_wasm_string_from_js (const char *str)
 static int
 class_is_task (MonoClass *klass)
 {
-	static const char *GENERIC_TASK = "System.Threading.Tasks.Task`1";
-	static const char *JUST_A_TASK = "System.Threading.Tasks.Task";
-
-	const char *FULL_NAME = mono_type_get_full_name (klass);
-	// First generic
-	if (strncmp(FULL_NAME, GENERIC_TASK, strlen(GENERIC_TASK)) == 0)
+	if (!strcmp ("System.Threading.Tasks", mono_class_get_namespace (klass)) && 
+		(!strcmp ("Task", mono_class_get_name (klass)) || !strcmp ("Task`1", mono_class_get_name (klass))))
 		return 1;
-	// Then normal task
-	return !strcmp(FULL_NAME, JUST_A_TASK);
+
+	return 0;
 }
 
 #define MARSHAL_TYPE_INT 1

--- a/sdks/wasm/test.js
+++ b/sdks/wasm/test.js
@@ -123,7 +123,7 @@ if (!send_message)
 //Ok, this is temporary
 //this is a super big hack (move it to a decently named assembly, at the very least)
 var binding_test_module = assembly_load ("binding_tests");
-Module.mono_bindings_init("binding_tests");
+Module.mono_bindings_init("[binding_tests]WebAssembly.Runtime");
 
 //binding test suite support code
 var binding_test_class = find_class (binding_test_module, "", "TestClass");


### PR DESCRIPTION
The following PR enhances the WASM bindings.

- Add JSObject property getter and setter
- Make JSObject disposable
- The dispose will remove the object from the tracked object list and will allow the reference counter to be recycled later.
- By keeping a recycled list of references and reusing those will keep the tracked objects array from growing out of hand.
- Modify the way the bindings init works by passing in of the Assembly and Class `[asm]namespace.class`.  This allows for clients to provide their own implementations if need be.
- Fix a problem with Promise implementation that caused intermittent NullReferenceExceptions and Memory Exceptions.