### PR TITLE
[2018-06][loader] Determine assembly load context from path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5528,6 +5528,7 @@ mono/arch/arm64/Makefile
 mono/arch/mips/Makefile
 mono/sgen/Makefile
 mono/tests/Makefile
+mono/tests/assembly-load-reference/Makefile
 mono/tests/tests-config
 mono/tests/gc-descriptors/Makefile
 mono/tests/testing_gac/Makefile

--- a/mono/dis/main.c
+++ b/mono/dis/main.c
@@ -1854,7 +1854,7 @@ try_load_from (MonoAssembly **assembly,
 	*assembly = NULL;
 	fullpath = g_build_filename (path1, path2, path3, path4, NULL);
 	if (g_file_test (fullpath, G_FILE_TEST_IS_REGULAR))
-		*assembly = mono_assembly_open_predicate (fullpath, refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT, predicate, user_data, NULL);
+		*assembly = mono_assembly_open_predicate (fullpath, refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT, predicate, user_data, NULL, NULL);
 
 	g_free (fullpath);
 	return (*assembly != NULL);

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2055,7 +2055,7 @@ try_load_from (MonoAssembly **assembly,
 		found = g_file_test (fullpath, G_FILE_TEST_IS_REGULAR);
 	
 	if (found)
-		*assembly = mono_assembly_open_predicate (fullpath, asmctx, predicate, user_data, NULL);
+		*assembly = mono_assembly_open_predicate (fullpath, asmctx, predicate, user_data, NULL, NULL);
 
 	g_free (fullpath);
 	return (*assembly != NULL);
@@ -2241,7 +2241,14 @@ ves_icall_System_Reflection_Assembly_LoadFrom (MonoStringHandle fname, MonoBoole
 	name = filename = mono_string_handle_to_utf8 (fname, error);
 	goto_if_nok (error, leave);
 	
-	MonoAssembly *ass = mono_assembly_open_predicate (filename, refOnly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_LOADFROM, NULL, NULL, &status);
+	MonoAssembly *requesting_assembly = NULL;
+	if (!refOnly) {
+		MonoMethod *executing_method = mono_runtime_get_caller_no_system_or_reflection ();
+		MonoAssembly *executing_assembly = executing_method ? m_class_get_image (executing_method->klass)->assembly : NULL;
+		requesting_assembly = executing_assembly;
+	}
+
+	MonoAssembly *ass = mono_assembly_open_predicate (filename, refOnly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_LOADFROM, NULL, NULL, requesting_assembly, &status);
 	
 	if (!ass) {
 		if (status == MONO_IMAGE_IMAGE_INVALID)
@@ -2273,7 +2280,10 @@ ves_icall_System_Reflection_Assembly_LoadFile_internal (MonoStringHandle fname, 
 	goto_if_nok (error, leave);
 
 	MonoImageOpenStatus status;
-	MonoAssembly *ass = mono_assembly_open_predicate (filename, MONO_ASMCTX_INDIVIDUAL, NULL, NULL, &status);
+
+	MonoMethod *executing_method = mono_runtime_get_caller_no_system_or_reflection ();
+	MonoAssembly *executing_assembly = executing_method ? m_class_get_image (executing_method->klass)->assembly : NULL;
+	MonoAssembly *ass = mono_assembly_open_predicate (filename, MONO_ASMCTX_INDIVIDUAL, NULL, NULL, executing_assembly, &status);
 	if (!ass) {
 		if (status == MONO_IMAGE_IMAGE_INVALID)
 			mono_error_set_bad_image_by_name (error, filename, "Invalid Image");

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -102,6 +102,9 @@ mono_domain_assembly_search (MonoAssemblyName *aname,
 static void
 mono_domain_fire_assembly_load (MonoAssembly *assembly, gpointer user_data);
 
+static gboolean
+mono_domain_asmctx_from_path (const char *fname, MonoAssembly *requesting_assembly, gpointer user_data, MonoAssemblyContextKind *out_asmctx);
+
 static void
 add_assemblies_to_domain (MonoDomain *domain, MonoAssembly *ass, GHashTable *hash);
 
@@ -280,6 +283,7 @@ mono_runtime_init_checked (MonoDomain *domain, MonoThreadStartCB start_cb, MonoT
 	mono_install_assembly_postload_search_hook ((MonoAssemblySearchFunc)mono_domain_assembly_postload_search, GUINT_TO_POINTER (FALSE));
 	mono_install_assembly_postload_refonly_search_hook ((MonoAssemblySearchFunc)mono_domain_assembly_postload_search, GUINT_TO_POINTER (TRUE));
 	mono_install_assembly_load_hook (mono_domain_fire_assembly_load, NULL);
+	mono_install_assembly_asmctx_from_path_hook (mono_domain_asmctx_from_path, NULL);
 
 	mono_thread_init (start_cb, attach_cb);
 
@@ -1354,6 +1358,21 @@ mono_domain_fire_assembly_load (MonoAssembly *assembly, gpointer user_data)
 	mono_error_cleanup (error);
 leave:
 	HANDLE_FUNCTION_RETURN ();
+}
+
+static gboolean
+mono_domain_asmctx_from_path (const char *fname, MonoAssembly *requesting_assembly, gpointer user_data, MonoAssemblyContextKind *out_asmctx)
+{
+	MonoDomain *domain = mono_domain_get ();
+	char **search_path = NULL;
+
+        for (search_path = domain->search_path; search_path && *search_path; search_path++) {
+		if (mono_path_filename_in_basedir (fname, *search_path)) {
+			*out_asmctx = MONO_ASMCTX_DEFAULT;
+			return TRUE;
+		}
+	}
+	return FALSE;
 }
 
 /*

--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -41,6 +41,10 @@ MonoAssembly* mono_assembly_load_full_nosearch (MonoAssemblyName *aname,
 						MonoImageOpenStatus *status);
 
 
+typedef gboolean (*MonoAssemblyAsmCtxFromPathFunc) (const char *absfname, MonoAssembly *requesting_assembly, gpointer user_data, MonoAssemblyContextKind *out_asmctx);
+
+void mono_install_assembly_asmctx_from_path_hook (MonoAssemblyAsmCtxFromPathFunc func, gpointer user_data);
+
 /* If predicate returns true assembly should be loaded, if false ignore it. */
 typedef gboolean (*MonoAssemblyCandidatePredicate)(MonoAssembly *, gpointer);
 

--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -48,6 +48,7 @@ MonoAssembly*          mono_assembly_open_predicate (const char *filename,
 						     MonoAssemblyContextKind asmctx,
 						     MonoAssemblyCandidatePredicate pred,
 						     gpointer user_data,
+						     MonoAssembly *requesting_assembly,
 						     MonoImageOpenStatus *status);
 
 MonoAssembly*          mono_assembly_load_from_predicate (MonoImage *image, const char *fname,

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -723,7 +723,7 @@ load_in_path (const char *basename, const char** search_path, MonoImageOpenStatu
 
 	for (i = 0; search_path [i]; ++i) {
 		fullpath = g_build_filename (search_path [i], basename, NULL);
-		result = mono_assembly_open_predicate (fullpath, asmctx, predicate, user_data, status);
+		result = mono_assembly_open_predicate (fullpath, asmctx, predicate, user_data, NULL, status);
 		g_free (fullpath);
 		if (result)
 			return result;
@@ -2058,13 +2058,16 @@ mono_assembly_open_full (const char *filename, MonoImageOpenStatus *status, gboo
 MonoAssembly *
 mono_assembly_open_a_lot (const char *filename, MonoImageOpenStatus *status, MonoAssemblyContextKind asmctx)
 {
-	return mono_assembly_open_predicate (filename, asmctx, NULL, NULL, status);
+	return mono_assembly_open_predicate (filename, asmctx, NULL, NULL, NULL, status);
+}
+
 }
 
 MonoAssembly *
 mono_assembly_open_predicate (const char *filename, MonoAssemblyContextKind asmctx,
 			      MonoAssemblyCandidatePredicate predicate,
 			      gpointer user_data,
+			      MonoAssembly *requesting_assembly,
 			      MonoImageOpenStatus *status)
 {
 	MonoImage *image;
@@ -2525,7 +2528,7 @@ mono_problematic_image_reprobe (MonoImage *image, MonoImageOpenStatus *status)
 MonoAssembly *
 mono_assembly_open (const char *filename, MonoImageOpenStatus *status)
 {
-	return mono_assembly_open_predicate (filename, MONO_ASMCTX_DEFAULT, NULL, NULL, status);
+	return mono_assembly_open_predicate (filename, MONO_ASMCTX_DEFAULT, NULL, NULL, NULL, status);
 }
 
 /**
@@ -3280,7 +3283,7 @@ probe_for_partial_name (const char *basepath, const char *fullname, MonoAssembly
 	if (fullpath == NULL)
 		return NULL;
 	else {
-		MonoAssembly *res = mono_assembly_open_predicate (fullpath, MONO_ASMCTX_DEFAULT, NULL, NULL, status);
+		MonoAssembly *res = mono_assembly_open_predicate (fullpath, MONO_ASMCTX_DEFAULT, NULL, NULL, NULL, status);
 		g_free (fullpath);
 		return res;
 	}
@@ -3817,7 +3820,7 @@ mono_assembly_load_from_gac (MonoAssemblyName *aname,  gchar *filename, MonoImag
 		paths = extra_gac_paths;
 		while (!result && *paths) {
 			fullpath = g_build_path (G_DIR_SEPARATOR_S, *paths, "lib", "mono", "gac", subpath, NULL);
-			result = mono_assembly_open_predicate (fullpath, asmctx, NULL, NULL, status);
+			result = mono_assembly_open_predicate (fullpath, asmctx, NULL, NULL, NULL, status);
 			g_free (fullpath);
 			paths++;
 		}
@@ -3831,7 +3834,7 @@ mono_assembly_load_from_gac (MonoAssemblyName *aname,  gchar *filename, MonoImag
 
 	fullpath = g_build_path (G_DIR_SEPARATOR_S, mono_assembly_getrootdir (),
 			"mono", "gac", subpath, NULL);
-	result = mono_assembly_open_predicate (fullpath, asmctx, NULL, NULL, status);
+	result = mono_assembly_open_predicate (fullpath, asmctx, NULL, NULL, NULL, status);
 	g_free (fullpath);
 
 	if (result)
@@ -4066,7 +4069,7 @@ mono_assembly_load_full_gac_base_default (MonoAssemblyName *aname,
 
 		if (basedir) {
 			fullpath = g_build_filename (basedir, filename, NULL);
-			result = mono_assembly_open_predicate (fullpath, asmctx, predicate, predicate_ud, status);
+			result = mono_assembly_open_predicate (fullpath, asmctx, predicate, predicate_ud, NULL, status);
 			g_free (fullpath);
 			if (result) {
 				result->in_gac = FALSE;

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1468,17 +1468,17 @@ load_reference_by_aname_individual_asmctx (MonoAssemblyName *aname, MonoAssembly
 	aname = mono_assembly_apply_binding (aname, &maped_name_pp);
 
 	reference = mono_assembly_loaded_full (aname, FALSE);
-	/* Still try to load from MONO_PATH or the GAC.  This is consistent
-	 * with what .NET Framework (4.7) actually does, rather than what the
-	 * documentation implies: If `LoadFile` is used to load an assembly
-	 * into "no context"/individual assembly context, the runtime will
-	 * still load assemblies from the GAC (e.g. `System.Runtime` will be
-	 * loaded if it wasn't already).
+	/* Still try to load from application base directory, MONO_PATH or the
+	 * GAC.  This is consistent with what .NET Framework (4.7) actually
+	 * does, rather than what the documentation implies: If `LoadFile` is
+	 * used to load an assembly into "no context"/individual assembly
+	 * context, the runtime will still load assemblies from the GAC or the
+	 * application base directory (e.g. `System.Runtime` will be loaded if
+	 * it wasn't already).
+	 * Moreover, those referenced assemblies are loaded in the default context.
 	 */
 	if (!reference)
-		reference = mono_assembly_load_full_nodomain (aname, MONO_ASMCTX_DEFAULT, status);
-	if (!reference)
-		reference = mono_assembly_invoke_search_hook_internal (aname, requesting, FALSE, TRUE);
+		reference = mono_assembly_load_full_internal (aname, requesting, NULL, MONO_ASMCTX_DEFAULT, status);
 	if (!reference)
 		reference = (MonoAssembly*)REFERENCE_MISSING;
 	return reference;

--- a/mono/metadata/attach.c
+++ b/mono/metadata/attach.c
@@ -276,7 +276,7 @@ mono_attach_load_agent (MonoDomain *domain, char *agent, char *args, MonoObject 
 	gpointer pa [1];
 	MonoImageOpenStatus open_status;
 
-	agent_assembly = mono_assembly_open_predicate (agent, MONO_ASMCTX_DEFAULT, NULL, NULL, &open_status);
+	agent_assembly = mono_assembly_open_predicate (agent, MONO_ASMCTX_DEFAULT, NULL, NULL, NULL, &open_status);
 	if (!agent_assembly) {
 		fprintf (stderr, "Cannot open agent assembly '%s': %s.\n", agent, mono_image_strerror (open_status));
 		g_free (agent);

--- a/mono/metadata/coree.c
+++ b/mono/metadata/coree.c
@@ -120,7 +120,7 @@ BOOL STDMETHODCALLTYPE _CorDllMain(HINSTANCE hInst, DWORD dwReason, LPVOID lpRes
 		 * probably be delayed until the first call to an exported function.
 		 */
 		if (image->tables [MONO_TABLE_ASSEMBLY].rows && ((MonoCLIImageInfo*) image->image_info)->cli_cli_header.ch_vtable_fixups.rva)
-			assembly = mono_assembly_open_predicate (file_name, MONO_ASMCTX_DEFAULT, NULL, NULL, NULL);
+			assembly = mono_assembly_open_predicate (file_name, MONO_ASMCTX_DEFAULT, NULL, NULL, NULL, NULL);
 
 		g_free (file_name);
 		break;
@@ -171,7 +171,7 @@ __int32 STDMETHODCALLTYPE _CorExeMain(void)
 		ExitProcess (1);
 	}
 
-	assembly = mono_assembly_open_predicate (file_name, MONO_ASMCTX_DEFAULT, NULL, NULL, NULL);
+	assembly = mono_assembly_open_predicate (file_name, MONO_ASMCTX_DEFAULT, NULL, NULL, NULL, NULL);
 	mono_close_exe_image ();
 	if (!assembly) {
 		g_free (file_name);

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -1010,10 +1010,10 @@ mono_domain_assembly_open (MonoDomain *domain, const char *name)
 		current = mono_domain_get ();
 
 		mono_domain_set (domain, FALSE);
-		ass = mono_assembly_open_predicate (name, MONO_ASMCTX_DEFAULT, NULL, NULL, NULL);
+		ass = mono_assembly_open_predicate (name, MONO_ASMCTX_DEFAULT, NULL, NULL, NULL, NULL);
 		mono_domain_set (current, FALSE);
 	} else {
-		ass = mono_assembly_open_predicate (name, MONO_ASMCTX_DEFAULT, NULL, NULL, NULL);
+		ass = mono_assembly_open_predicate (name, MONO_ASMCTX_DEFAULT, NULL, NULL, NULL, NULL);
 	}
 
 	return ass;

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1451,6 +1451,24 @@ get_caller_no_system_or_reflection (MonoMethod *m, gint32 no, gint32 ilo, gboole
 	return FALSE;
 }
 
+/**
+ * mono_runtime_get_caller_no_system_or_reflection:
+ *
+ * Walk the stack of the current thread and find the first managed method that
+ * is not in the mscorlib System or System.Reflection namespace.  This skips
+ * unmanaged callers and wrapper methods.
+ *
+ * \returns a pointer to the \c MonoMethod or NULL if we walked past all the
+ * callers.
+ */
+MonoMethod*
+mono_runtime_get_caller_no_system_or_reflection (void)
+{
+	MonoMethod *dest = NULL;
+	mono_stack_walk_no_il (get_caller_no_system_or_reflection, &dest);
+	return dest;
+}
+
 static MonoReflectionTypeHandle
 type_from_parsed_name (MonoTypeNameParse *info, MonoBoolean ignoreCase, MonoAssembly **caller_assembly, MonoError *error)
 {
@@ -1483,7 +1501,7 @@ type_from_parsed_name (MonoTypeNameParse *info, MonoBoolean ignoreCase, MonoAsse
 		 *
 		 * It would be nice if we had stack marks.
 		 */
-		mono_stack_walk_no_il (get_caller_no_system_or_reflection, &dest);
+		dest = mono_runtime_get_caller_no_system_or_reflection ();
 		if (!dest)
 			dest = m;
 	}

--- a/mono/metadata/mono-security.c
+++ b/mono/metadata/mono-security.c
@@ -632,7 +632,7 @@ void mono_invoke_protected_memory_method (MonoArray *data, MonoObject *scope, gb
 	if (system_security_assembly == NULL) {
 		system_security_assembly = mono_image_loaded ("System.Security");
 		if (!system_security_assembly) {
-			MonoAssembly *sa = mono_assembly_open_predicate ("System.Security.dll", MONO_ASMCTX_DEFAULT, NULL, NULL, NULL);
+			MonoAssembly *sa = mono_assembly_open_predicate ("System.Security.dll", MONO_ASMCTX_DEFAULT, NULL, NULL, NULL, NULL);
 			if (!sa)
 				g_assert_not_reached ();
 			system_security_assembly = mono_assembly_get_image (sa);

--- a/mono/metadata/reflection-internals.h
+++ b/mono/metadata/reflection-internals.h
@@ -115,5 +115,7 @@ mono_method_body_get_object_handle (MonoDomain *domain, MonoMethod *method, Mono
 MonoClass *
 mono_class_from_mono_type_handle (MonoReflectionTypeHandle h);
 
+MonoMethod*
+mono_runtime_get_caller_no_system_or_reflection (void);
 
 #endif /* __MONO_METADATA_REFLECTION_INTERNALS_H__ */

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -717,7 +717,7 @@ get_socket_assembly (void)
 
 		socket_assembly = mono_image_loaded ("System");
 		if (!socket_assembly) {
-			MonoAssembly *sa = mono_assembly_open_predicate ("System.dll", MONO_ASMCTX_DEFAULT, NULL, NULL, NULL);
+			MonoAssembly *sa = mono_assembly_open_predicate ("System.dll", MONO_ASMCTX_DEFAULT, NULL, NULL, NULL, NULL);
 		
 			if (!sa) {
 				g_assert_not_reached ();
@@ -2000,7 +2000,7 @@ ves_icall_System_Net_Sockets_Socket_GetSocketOption_obj_internal (gsize sock, gi
 		if (mono_posix_image == NULL) {
 			mono_posix_image = mono_image_loaded ("Mono.Posix");
 			if (!mono_posix_image) {
-				MonoAssembly *sa = mono_assembly_open_predicate ("Mono.Posix.dll", MONO_ASMCTX_DEFAULT, NULL, NULL, NULL);
+				MonoAssembly *sa = mono_assembly_open_predicate ("Mono.Posix.dll", MONO_ASMCTX_DEFAULT, NULL, NULL, NULL, NULL);
 				if (!sa) {
 					*werror = WSAENOPROTOOPT;
 					return;

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -549,7 +549,7 @@ mini_regression_list (int verbose, int count, char *images [])
 	
 	total_run =  total = 0;
 	for (i = 0; i < count; ++i) {
-		ass = mono_assembly_open_predicate (images [i], MONO_ASMCTX_DEFAULT, NULL, NULL, NULL);
+		ass = mono_assembly_open_predicate (images [i], MONO_ASMCTX_DEFAULT, NULL, NULL, NULL, NULL);
 		if (!ass) {
 			g_warning ("failed to load assembly: %s", images [i]);
 			continue;
@@ -715,7 +715,7 @@ mono_interp_regression_list (int verbose, int count, char *images [])
 
 	total_run = total = 0;
 	for (i = 0; i < count; ++i) {
-		MonoAssembly *ass = mono_assembly_open_predicate (images [i], MONO_ASMCTX_DEFAULT, NULL, NULL, NULL);
+		MonoAssembly *ass = mono_assembly_open_predicate (images [i], MONO_ASMCTX_DEFAULT, NULL, NULL, NULL, NULL);
 		if (!ass) {
 			g_warning ("failed to load assembly: %s", images [i]);
 			continue;
@@ -1310,7 +1310,7 @@ load_agent (MonoDomain *domain, char *desc)
 		args = NULL;
 	}
 
-	agent_assembly = mono_assembly_open_predicate (agent, MONO_ASMCTX_DEFAULT, NULL, NULL, &open_status);
+	agent_assembly = mono_assembly_open_predicate (agent, MONO_ASMCTX_DEFAULT, NULL, NULL, NULL, &open_status);
 	if (!agent_assembly) {
 		fprintf (stderr, "Cannot open agent assembly '%s': %s.\n", agent, mono_image_strerror (open_status));
 		g_free (agent);
@@ -2358,7 +2358,7 @@ mono_main (int argc, char* argv[])
 		apply_root_domain_configuration_file_bindings (domain, extra_bindings_config_file);
 	}
 
-	assembly = mono_assembly_open_predicate (aname, MONO_ASMCTX_DEFAULT, NULL, NULL, &open_status);
+	assembly = mono_assembly_open_predicate (aname, MONO_ASMCTX_DEFAULT, NULL, NULL, NULL, &open_status);
 	if (!assembly) {
 		fprintf (stderr, "Cannot open assembly '%s': %s.\n", aname, mono_image_strerror (open_status));
 		mini_cleanup (domain);

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1,6 +1,6 @@
 include $(top_srcdir)/mk/common.mk
 
-SUBDIRS = gc-descriptors . testing_gac
+SUBDIRS = gc-descriptors . testing_gac assembly-load-reference
 
 check-local:
 	ok=:; \
@@ -21,6 +21,7 @@ check-local:
 	$(MAKE) test-internalsvisibleto || ok=false; \
 	$(MAKE) rm-empty-logs || ok=false; \
 	$(MAKE) runtest-gac-loading || ok=false; \
+	$(MAKE) runtest-assembly-load-reference || ok=false; \
 	$$ok
 
 # These are not actually tests, but they are source files part of another test.
@@ -1532,7 +1533,7 @@ test-env-options:
 compile-tests:
 	$(MAKE) -j4 compile-tests-parallel
 
-compile-tests-parallel: $(TESTS_CS) $(TESTS_IL) $(TESTS_BENCH) $(TESTS_STRESS) $(TESTS_GSHARED) $(TESTSAOT_CS) $(TESTSAOT_IL) $(TESTSAOT_BENCH) $(TESTSAOT_STRESS) $(TESTSAOT_GSHARED) $(TESTS_TAILCALL) $(TESTSAOT_TAILCALL) compile-gac-loading
+compile-tests-parallel: $(TESTS_CS) $(TESTS_IL) $(TESTS_BENCH) $(TESTS_STRESS) $(TESTS_GSHARED) $(TESTSAOT_CS) $(TESTSAOT_IL) $(TESTSAOT_BENCH) $(TESTSAOT_STRESS) $(TESTSAOT_GSHARED) $(TESTS_TAILCALL) $(TESTSAOT_TAILCALL) compile-gac-loading compile-assembly-load-reference
 
 # Remove empty .stdout and .stderr files for wrench
 rm-empty-logs:
@@ -2497,6 +2498,13 @@ runtest-gac-loading: test-runner.exe
 
 compile-gac-loading:
 	$(MAKE) -C testing_gac compile-tests
+
+runtest-assembly-load-reference: test-runner.exe
+	$(MAKE) -C assembly-load-reference runtest
+
+compile-assembly-load-reference:
+	$(MAKE) -C assembly-load-reference compile-tests
+
 
 TESTS_STRESS_PROCESS_SRC=	\
 		process-stress-1.cs	\

--- a/mono/tests/assembly-load-reference/Makefile.am
+++ b/mono/tests/assembly-load-reference/Makefile.am
@@ -2,7 +2,17 @@ include $(top_srcdir)/mk/common.mk
 
 ### buildtree stuff
 
+RUNTIME_ARGS=--config tests-config --optimize=all --debug
+TEST_RUNTIME_ARGS ?= $(RUNTIME_ARGS)
+TEST_AOT_BUILD_FLAGS ?= $(AOT_BUILD_FLAGS)
+TEST_AOT_RUN_FLAGS ?= $(AOT_RUN_FLAGS)
+
 CLASS=$(mcs_topdir)/class/lib/$(DEFAULT_PROFILE)
+
+with_mono_path = MONO_PATH=$(CLASS)
+
+RUNTIME = $(with_mono_path) $(top_builddir)/runtime/mono-wrapper
+TOOLS_RUNTIME = MONO_PATH=$(mcs_topdir)/class/lib/build $(top_builddir)/runtime/mono-wrapper --aot-path=$(mcs_topdir)/class/lib/build
 
 if FULL_AOT_TESTS
 PROFILE_MCS_FLAGS = -d:MOBILE,MOBILE_LEGACY,FULL_AOT_DESKTOP 
@@ -20,27 +30,28 @@ else
 PLATFORM_PATH_SEPARATOR=:
 endif
 
-RUNTIME= $(top_builddir)/runtime/mono-wrapper
-TEST_RUNTIME = MONO_PATH=$(CLASS) $(RUNTIME)
-TOOLS_RUNTIME= MONO_PATH=$(mcs_topdir)/class/lib/build $(RUNTIME)
-
-TEST_RUNNER = ../test-runner.exe --runtime $(RUNTIME) --runtime-args "--assembly-loader=strict"
+TEST_RUNNER = ../test-runner.exe
 
 if HOST_WIN32
-TEST_RUNNER_ARGS=--runtime $(if $(MONO_EXECUTABLE),$(shell cygpath -w -a $(MONO_EXECUTABLE) | sed 's/\\/\\\\/g'),mono)
+TEST_RUNNER += --config tests-config --runtime "$(if $(MONO_EXECUTABLE),$(shell cygpath -w -a $(MONO_EXECUTABLE) | sed 's/\\/\\\\/g'),$(top_builddir)/runtime/mono-wrapper)"
 else
-TEST_RUNNER_ARGS=--runtime $(if $(MONO_EXECUTABLE),$(MONO_EXECUTABLE),mono)
+TEST_RUNNER += --config tests-config --runtime "$(if $(MONO_EXECUTABLE),$(MONO_EXECUTABLE),$(top_builddir)/runtime/mono-wrapper)"
 endif
 
-TEST_RUNNER_ARGS += $(if $(V), --verbose,)
+TEST_RUNNER += $(if $(V), --verbose,)
 
 if FULL_AOT_TESTS
-TEST_RUNNER += --runtime-args "$(AOT_RUN_FLAGS)"
+TEST_RUNNER += --runtime-args "$(TEST_AOT_RUN_FLAGS)"
 endif
 
 if HYBRID_AOT_TESTS
-TEST_RUNNER += --runtime-args "$(AOT_RUN_FLAGS)"
+TEST_RUNNER += --runtime-args "$(TEST_AOT_RUN_FLAGS)"
 endif
+
+TEST_RUNNER += --runtime-args "$(TEST_RUNTIME_FLAGS)"
+
+TEST_RUNNER += --mono-path "$(CLASS)"
+
 
 ### tools
 
@@ -67,6 +78,8 @@ TESTS_CS = \
 
 TESTS_EXE = $(TESTS_CS:.cs=.exe)
 
+TESTS_EXE_AOT = $(TESTS_EXE:.exe=.exe$(PLATFORM_AOT_SUFFIX))
+
 REFERENCED_ASMS = \
 	samedir/Mid.dll \
 	samedir/Dep.dll \
@@ -74,6 +87,31 @@ REFERENCED_ASMS = \
 	separatedir/middle/Dep.dll \
 	mainanddep/middle/Mid.dll \
 	mainanddep/Dep.dll
+
+REFERENCED_ASMS_AOT = $(REFERENCED_ASMS:.dll=.dll$(PLATFORM_AOT_SUFFIX))
+
+if FULL_AOT_TESTS
+TESTS_EXE_DEPEND=$(TESTS_EXE_AOT)
+REFERENCED_ASMS_DEPEND=$(REFERENCED_ASMS_AOT)
+else
+if HYBRID_AOT_TESTS
+TESTS_EXE_DEPEND=$(TESTS_EXE_AOT)
+REFERENCED_ASMS_DEPEND=$(REFERENCED_ASMS_AOT)
+else
+TESTS_EXE_DEPEND=$(TESTS_EXE)
+REFERENCED_ASMS_DEPEND=$(REFERENCED_ASMS)
+endif
+endif
+
+DISABLED_TESTS=
+
+# these don't work with full AOT
+if FULL_AOT_TESTS
+DISABLED_TESTS+= \
+	mainanddep/LoadFromMain.exe \
+	mainanddep/LoadFileMain.exe \
+	separatedir/LoadFileMain.exe
+endif
 
 runtest:
 	true
@@ -114,5 +152,14 @@ src/Mid.dll: src/Mid.cs src/Dep.dll
 %/LoadFileMain.exe: %/LoadFileMain.cs
 	$(MCS) -out:$@ $< -target:exe
 
-run-assembly-load-reference-tests: $(TESTS_EXE) $(REFERENCED_ASMS)
-	$(TOOLS_RUNTIME) $(TEST_RUNNER) $(TEST_RUNNER_ARGS) --testsuite-name $@ $(TESTS_EXE)
+%/LoadFromMain.exe$(PLATFORM_AOT_SUFFIX): %/LoadFromMain.exe
+	$(RUNTIME) $(TEST_AOT_BUILD_FLAGS) $<
+
+%/LoadFileMain.exe$(PLATFORM_AOT_SUFFIX): %/LoadFileMain.exe
+	$(RUNTIME) $(TEST_AOT_BUILD_FLAGS) $<
+
+%.dll$(PLATFORM_AOT_SUFFIX): %.dll
+	$(RUNTIME) $(TEST_AOT_BUILD_FLAGS) $<
+
+run-assembly-load-reference-tests: $(TESTS_EXE_DEPEND) $(REFERENCED_ASMS_DEPEND) 
+	$(TOOLS_RUNTIME) $(TEST_RUNNER) --testsuite-name $@ --disabled "$(DISABLED_TESTS)" $(TESTS_EXE)

--- a/mono/tests/assembly-load-reference/Makefile.am
+++ b/mono/tests/assembly-load-reference/Makefile.am
@@ -1,0 +1,118 @@
+include $(top_srcdir)/mk/common.mk
+
+### buildtree stuff
+
+CLASS=$(mcs_topdir)/class/lib/$(DEFAULT_PROFILE)
+
+if FULL_AOT_TESTS
+PROFILE_MCS_FLAGS = -d:MOBILE,MOBILE_LEGACY,FULL_AOT_DESKTOP 
+endif
+
+if HYBRID_AOT_TESTS
+PROFILE_MCS_FLAGS = -d:MOBILE,MOBILE_LEGACY 
+endif
+
+### test runner stuff
+
+if HOST_WIN32
+PLATFORM_PATH_SEPARATOR=;
+else
+PLATFORM_PATH_SEPARATOR=:
+endif
+
+RUNTIME= $(top_builddir)/runtime/mono-wrapper
+TEST_RUNTIME = MONO_PATH=$(CLASS) $(RUNTIME)
+TOOLS_RUNTIME= MONO_PATH=$(mcs_topdir)/class/lib/build $(RUNTIME)
+
+TEST_RUNNER = ../test-runner.exe --runtime $(RUNTIME) --runtime-args "--assembly-loader=strict"
+
+if HOST_WIN32
+TEST_RUNNER_ARGS=--runtime $(if $(MONO_EXECUTABLE),$(shell cygpath -w -a $(MONO_EXECUTABLE) | sed 's/\\/\\\\/g'),mono)
+else
+TEST_RUNNER_ARGS=--runtime $(if $(MONO_EXECUTABLE),$(MONO_EXECUTABLE),mono)
+endif
+
+TEST_RUNNER_ARGS += $(if $(V), --verbose,)
+
+if FULL_AOT_TESTS
+TEST_RUNNER += --runtime-args "$(AOT_RUN_FLAGS)"
+endif
+
+if HYBRID_AOT_TESTS
+TEST_RUNNER += --runtime-args "$(AOT_RUN_FLAGS)"
+endif
+
+### tools
+
+GACUTIL= $(mcs_topdir)/class/lib/build/gacutil.exe
+SN= $(mcs_topdir)/class/lib/build/sn.exe
+
+MCS= $(TOOLS_RUNTIME) $(CSC) -noconfig -nologo -debug:portable -target:library $(PROFILE_MCS_FLAGS)
+
+### testcase stuff
+
+EXTRA_DIST= README $(SIGNING_KEY) $(GACTESTLIB_SRCS) 
+
+### Test cases
+
+.PHONY: runtest compile-tests
+
+TESTS_CS = \
+	samedir/LoadFromMain.cs \
+	samedir/LoadFileMain.cs \
+	separatedir/LoadFromMain.cs \
+	separatedir/LoadFileMain.cs \
+	mainanddep/LoadFromMain.cs \
+	mainanddep/LoadFileMain.cs
+
+TESTS_EXE = $(TESTS_CS:.cs=.exe)
+
+REFERENCED_ASMS = \
+	samedir/Mid.dll \
+	samedir/Dep.dll \
+	separatedir/middle/Mid.dll \
+	separatedir/middle/Dep.dll \
+	mainanddep/middle/Mid.dll \
+	mainanddep/Dep.dll
+
+runtest:
+	true
+	$(MAKE) run-assembly-load-reference-tests
+
+
+compile-tests: compile-samedir compile-separatedir compile-mainanddep
+
+compile-samedir: samedir/LoadFromMain.exe samedir/LoadFileMain.exe samedir/Dep.dll samedir/Mid.dll
+
+samedir/%.dll: src/%.dll
+	cp $< $@
+
+compile-separatedir: separatedir/LoadFromMain.exe separatedir/LoadFileMain.exe separatedir/middle/Dep.dll separatedir/middle/Mid.dll
+
+separatedir/middle/%.dll: src/%.dll
+	mkdir -p $(@D)
+	cp $< $@
+
+compile-mainanddep: mainanddep/LoadFromMain.exe mainanddep/LoadFileMain.exe mainanddep/Dep.dll mainanddep/middle/Mid.dll
+
+mainanddep/Dep.dll: src/Dep.dll
+	cp $< $@
+
+mainanddep/middle/Mid.dll: src/Mid.dll
+	mkdir -p $(@D)
+	cp $< $@
+
+src/Dep.dll: src/Dep.cs
+	$(MCS) -out:$@ $< -target:library
+
+src/Mid.dll: src/Mid.cs src/Dep.dll
+	$(MCS) -out:$@ $< -r:src/Dep.dll -target:library
+
+%/LoadFromMain.exe: %/LoadFromMain.cs
+	$(MCS) -out:$@ $< -target:exe
+
+%/LoadFileMain.exe: %/LoadFileMain.cs
+	$(MCS) -out:$@ $< -target:exe
+
+run-assembly-load-reference-tests: $(TESTS_EXE) $(REFERENCED_ASMS)
+	$(TOOLS_RUNTIME) $(TEST_RUNNER) $(TEST_RUNNER_ARGS) --testsuite-name $@ $(TESTS_EXE)

--- a/mono/tests/assembly-load-reference/README
+++ b/mono/tests/assembly-load-reference/README
@@ -1,0 +1,13 @@
+Test loading references of assemblies loaded using LoadFrom and LoadFile.
+
+There are three variations of the same two tests: LoadFromMain and LoadFileMain.
+
+The differences are where we place the two additional assemblies Mid and Dep.
+Mid references Dep.
+
+samedir/
+  Main, Mid and Dep are all in the same directory - both LoadFile and LoadFrom expected to work.
+mainanddep/
+  Main and Dep are in the base dir, Mid is in mid/ - both LoadFrom and LoadFrom expected to work
+separatedir/
+  Main is in the base dir, Mid and Dep are in mid/ - LoadFrom expected to work, LoadFile expected to fail.

--- a/mono/tests/assembly-load-reference/mainanddep/LoadFileMain.cs
+++ b/mono/tests/assembly-load-reference/mainanddep/LoadFileMain.cs
@@ -1,0 +1,14 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+public class Test {
+	public static int Main ()
+	{
+		var p = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "middle", "Mid.dll");
+		var a = Assembly.LoadFile (p);
+		var t = a.GetType ("MyType");
+		Activator.CreateInstance (t);
+		return 0;
+	}
+}

--- a/mono/tests/assembly-load-reference/mainanddep/LoadFromMain.cs
+++ b/mono/tests/assembly-load-reference/mainanddep/LoadFromMain.cs
@@ -1,0 +1,14 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+public class Test {
+	public static int Main ()
+	{
+		var p = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "middle", "Mid.dll");
+		var a = Assembly.LoadFrom (p);
+		var t = a.GetType ("MyType");
+		Activator.CreateInstance (t);
+		return 0;
+	}
+}

--- a/mono/tests/assembly-load-reference/samedir/LoadFileMain.cs
+++ b/mono/tests/assembly-load-reference/samedir/LoadFileMain.cs
@@ -1,0 +1,14 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+public class Test {
+	public static int Main ()
+	{
+		var p = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "Mid.dll");
+		var a = Assembly.LoadFile (p);
+		var t = a.GetType ("MyType");
+		Activator.CreateInstance (t);
+		return 0;
+	}
+}

--- a/mono/tests/assembly-load-reference/samedir/LoadFromMain.cs
+++ b/mono/tests/assembly-load-reference/samedir/LoadFromMain.cs
@@ -1,0 +1,14 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+public class Test {
+	public static int Main ()
+	{
+		var p = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "Mid.dll");
+		var a = Assembly.LoadFrom (p);
+		var t = a.GetType ("MyType");
+		Activator.CreateInstance (t);
+		return 0;
+	}
+}

--- a/mono/tests/assembly-load-reference/separatedir/LoadFileMain.cs
+++ b/mono/tests/assembly-load-reference/separatedir/LoadFileMain.cs
@@ -1,0 +1,32 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+public class Test {
+	public static int Main ()
+	{
+		var p = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "middle", "Mid.dll");
+		var a = Assembly.LoadFile (p);
+		var t = a.GetType ("MyType");
+		bool caught = false;
+		try {
+			Activator.CreateInstance (t);
+		} catch (TargetInvocationException tie) {
+			if (tie.InnerException is FileNotFoundException) {
+				/* reference assembly loading throws FNFE */
+				caught = true;
+			} else {
+				Console.Error.WriteLine ($"Expected tie.InnerException to be FileNotFoundException, but got {tie.InnerException}");
+				return 1;
+			}
+		} catch (Exception e) {
+			Console.Error.WriteLine ($"Expected TargetInvocationException, but got {e}");
+			return 2;
+		}
+		if (!caught) {
+			Console.Error.WriteLine ($"Expected an exception, but got none");
+			return 3;
+		}
+		return 0;
+	}
+}

--- a/mono/tests/assembly-load-reference/separatedir/LoadFromMain.cs
+++ b/mono/tests/assembly-load-reference/separatedir/LoadFromMain.cs
@@ -1,0 +1,14 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+public class Test {
+	public static int Main ()
+	{
+		var p = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "middle", "Mid.dll");
+		var a = Assembly.LoadFrom (p);
+		var t = a.GetType ("MyType");
+		Activator.CreateInstance (t);
+		return 0;
+	}
+}

--- a/mono/tests/assembly-load-reference/src/Dep.cs
+++ b/mono/tests/assembly-load-reference/src/Dep.cs
@@ -1,0 +1,6 @@
+using System;
+
+public class OtherType {
+	public OtherType () {
+	}
+}

--- a/mono/tests/assembly-load-reference/src/Mid.cs
+++ b/mono/tests/assembly-load-reference/src/Mid.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Runtime.CompilerServices;
+
+public class MyType {
+	public MyType () {
+		Method ();
+	}
+
+	[MethodImpl (MethodImplOptions.NoInlining)]
+	public void Method () {
+		var a = new OtherType ();
+	}
+		
+}

--- a/mono/utils/mono-path.c
+++ b/mono/utils/mono-path.c
@@ -177,3 +177,27 @@ mono_path_resolve_symlinks (const char *path)
 #endif
 }
 
+/**
+ * mono_path_filename_in_basedir:
+ *
+ * Return \c TRUE if \p filename is in \p basedir
+ *
+ * Both paths must be absolute and using \c G_DIR_SEPARATOR for directory separators.
+ * If the file is in a subdirectory of \p basedir, returns \c FALSE.
+ * This function doesn't touch a filesystem, it looks solely at path names.
+ */
+gboolean
+mono_path_filename_in_basedir (const char *filename, const char *basedir)
+{
+	char *p = NULL;
+	if ((p = strstr (filename, basedir))) {
+		p += strlen (basedir);
+		if (*p != G_DIR_SEPARATOR)
+			return FALSE;
+		/* if it's in a subdir of the basedir, it doesn't count. */
+		if (strchr (p, G_DIR_SEPARATOR))
+			return FALSE;
+		return TRUE;
+	}
+	return FALSE;
+}

--- a/mono/utils/mono-path.h
+++ b/mono/utils/mono-path.h
@@ -10,6 +10,7 @@
 
 MONO_API gchar *mono_path_resolve_symlinks (const char *path);
 MONO_API gchar *mono_path_canonicalize (const char *path);
+gboolean mono_path_filename_in_basedir (const char *filename, const char *basedir);
 
 #endif /* __MONO_PATH_H */
 

--- a/tools/pedump/pedump.c
+++ b/tools/pedump/pedump.c
@@ -565,7 +565,7 @@ try_load_from (MonoAssembly **assembly, const gchar *path1, const gchar *path2,
 	*assembly = NULL;
 	fullpath = g_build_filename (path1, path2, path3, path4, NULL);
 	if (g_file_test (fullpath, G_FILE_TEST_IS_REGULAR))
-		*assembly = mono_assembly_open_predicate (fullpath, refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT, NULL, NULL, NULL);
+		*assembly = mono_assembly_open_predicate (fullpath, refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT, NULL, NULL, NULL, NULL);
 
 	g_free (fullpath);
 	return (*assembly != NULL);
@@ -791,7 +791,7 @@ main (int argc, char *argv [])
 
 		mono_verifier_set_mode (verifier_mode);
 
-		assembly = mono_assembly_open_predicate (file, MONO_ASMCTX_DEFAULT, NULL, NULL, NULL);
+		assembly = mono_assembly_open_predicate (file, MONO_ASMCTX_DEFAULT, NULL, NULL, NULL, NULL);
 		/*fake an assembly for netmodules so the verifier works*/
 		if (!assembly && (image = mono_image_open (file, &status)) && image->tables [MONO_TABLE_ASSEMBLY].rows == 0) {
 			assembly = g_new0 (MonoAssembly, 1);


### PR DESCRIPTION
This is a backport of #9858 to `2018-06`

Addresses #9753 #9542 #8575 
