### PR TITLE
Remove pragma GCC diagnostic ignored "-Wmissing-prototypes".

### DIFF
--- a/mono/metadata/icalls.h
+++ b/mono/metadata/icalls.h
@@ -8,7 +8,6 @@
 #include <mono/utils/mono-publib.h>
 
 #ifdef ENABLE_ICALL_EXPORT
-#pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #define ICALL_DECL_EXPORT MONO_API
 #define ICALL_EXPORT MONO_API
 #else


### PR DESCRIPTION
1. I just expanded its reach.
2. It doesn't seem needed anywhere. Where it was intended to matter, we generate incorrect prototypes. I did some testing on Linux with configure export-icall.