### PR TITLE
[cxx] Prefer gpointer/gconstpointer over char*, guint8* for untyped data -- fewer casts generally.

### DIFF
--- a/mono/metadata/dynamic-image-internals.h
+++ b/mono/metadata/dynamic-image-internals.h
@@ -46,7 +46,7 @@ MonoDynamicImage*
 mono_dynamic_image_create (MonoDynamicAssembly *assembly, char *assembly_name, char *module_name);
 
 guint32
-mono_dynamic_image_add_to_blob_cached (MonoDynamicImage *assembly, char *b1, int s1, char *b2, int s2);
+mono_dynamic_image_add_to_blob_cached (MonoDynamicImage *assembly, gconstpointer b1, int s1, gconstpointer b2, int s2);
 
 void
 mono_dynimage_alloc_table (MonoDynamicTable *table, guint nrows);

--- a/mono/metadata/dynamic-image.c
+++ b/mono/metadata/dynamic-image.c
@@ -369,9 +369,9 @@ mono_dynamic_image_create (MonoDynamicAssembly *assembly, char *assembly_name, c
 	/*g_print ("string heap create for image %p (%s)\n", image, module_name);*/
 	string_heap_init (&image->sheap);
 	mono_dynstream_add_data (&image->us, "", 1);
-	mono_dynamic_image_add_to_blob_cached (image, (char*) "", 1, NULL, 0);
+	mono_dynamic_image_add_to_blob_cached (image, "", 1, NULL, 0);
 	/* import tables... */
-	mono_dynstream_add_data (&image->code, (char*)entrycode, sizeof (entrycode));
+	mono_dynstream_add_data (&image->code, entrycode, sizeof (entrycode));
 	image->iat_offset = mono_dynstream_add_zero (&image->code, 8); /* two IAT entries */
 	image->idt_offset = mono_dynstream_add_zero (&image->code, 2 * sizeof (MonoIDT)); /* two IDT entries */
 	image->imp_names_offset = mono_dynstream_add_zero (&image->code, 2); /* flags for name entry */
@@ -416,7 +416,7 @@ mono_dynamic_image_create (MonoDynamicAssembly *assembly, char *assembly_name, c
 #endif /* DISABLE_REFLECTION_EMIT */
 
 guint32
-mono_dynamic_image_add_to_blob_cached (MonoDynamicImage *assembly, char *b1, int s1, char *b2, int s2)
+mono_dynamic_image_add_to_blob_cached (MonoDynamicImage *assembly, gconstpointer b1, int s1, gconstpointer b2, int s2)
 {
 	MONO_REQ_GC_NEUTRAL_MODE;
 

--- a/mono/metadata/dynamic-stream-internals.h
+++ b/mono/metadata/dynamic-stream-internals.h
@@ -19,7 +19,7 @@ guint32
 mono_dynstream_insert_mstring (MonoDynamicStream *sh, MonoString *str, MonoError *error);
 
 guint32
-mono_dynstream_add_data (MonoDynamicStream *stream, const char *data, guint32 len);
+mono_dynstream_add_data (MonoDynamicStream *stream, gconstpointer data, guint32 len);
 
 guint32
 mono_dynstream_add_zero (MonoDynamicStream *stream, guint32 len);

--- a/mono/metadata/dynamic-stream.c
+++ b/mono/metadata/dynamic-stream.c
@@ -87,7 +87,7 @@ mono_dynstream_insert_mstring (MonoDynamicStream *sh, MonoString *str, MonoError
 }
 
 guint32
-mono_dynstream_add_data (MonoDynamicStream *stream, const char *data, guint32 len)
+mono_dynstream_add_data (MonoDynamicStream *stream, gconstpointer data, guint32 len)
 {
 	MONO_REQ_GC_NEUTRAL_MODE;
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -3502,7 +3502,7 @@ mono_field_get_value_object_checked (MonoDomain *domain, MonoClassField *field, 
 	MonoObject *o;
 	MonoClass *klass;
 	MonoVTable *vtable = NULL;
-	gchar *v;
+	gpointer v;
 	gboolean is_static = FALSE;
 	gboolean is_ref = FALSE;
 	gboolean is_literal = FALSE;
@@ -3584,7 +3584,6 @@ mono_field_get_value_object_checked (MonoDomain *domain, MonoClassField *field, 
 		static MonoMethod *m;
 		gpointer args [2];
 		gpointer *ptr;
-		gpointer v;
 
 		if (!m) {
 			MonoClass *ptr_klass = mono_class_get_pointer_class ();
@@ -3623,7 +3622,7 @@ mono_field_get_value_object_checked (MonoDomain *domain, MonoClassField *field, 
 
 	o = mono_object_new_checked (domain, klass, error);
 	return_val_if_nok (error, NULL);
-	v = (gpointer)mono_object_get_data (o);
+	v = mono_object_get_data (o);
 
 	if (is_literal) {
 		get_default_field_value (domain, field, v, error);
@@ -6795,7 +6794,7 @@ mono_value_box_handle (MonoDomain *domain, MonoClass *klass, gpointer value, Mon
 
 	size = size - MONO_ABI_SIZEOF (MonoObject);
 
-	guint8 *data = mono_object_get_data (res);
+	gpointer data = mono_object_get_data (res);
 
 	if (mono_gc_is_moving ()) {
 		g_assert (size == mono_class_value_size (klass, NULL));
@@ -6860,7 +6859,7 @@ mono_value_box_checked (MonoDomain *domain, MonoClass *klass, gpointer value, Mo
 
 	size = size - MONO_ABI_SIZEOF (MonoObject);
 
-	guint8 *data = mono_object_get_data (res);
+	gpointer data = mono_object_get_data (res);
 	if (mono_gc_is_moving ()) {
 		g_assert (size == mono_class_value_size (klass, NULL));
 		mono_gc_wbarrier_value_copy (data, value, 1, klass);

--- a/mono/metadata/sre-encode.c
+++ b/mono/metadata/sre-encode.c
@@ -585,7 +585,7 @@ handle_enum:
 			g_free (swapped);
 		}
 #else
-		idx = mono_dynamic_image_add_to_blob_cached (assembly, blob_size, b-blob_size, (char*)mono_string_chars (str), len);
+		idx = mono_dynamic_image_add_to_blob_cached (assembly, blob_size, b-blob_size, mono_string_chars (str), len);
 #endif
 
 		g_free (buf);

--- a/mono/metadata/sre-save.c
+++ b/mono/metadata/sre-save.c
@@ -172,7 +172,7 @@ add_mono_string_to_blob_cached (MonoDynamicImage *assembly, MonoString *str)
 		g_free (swapped);
 	}
 #else
-	idx = mono_dynamic_image_add_to_blob_cached (assembly, blob_size, b-blob_size, (char*)mono_string_chars (str), len);
+	idx = mono_dynamic_image_add_to_blob_cached (assembly, blob_size, b-blob_size, mono_string_chars (str), len);
 #endif
 	return idx;
 }


### PR DESCRIPTION
This  tends to be more C++ compatible, and really is in this case.