### PR TITLE
[2018-06] [sdks] Switch the 32 bit cross compilers back to the old llvm 3.6, the new version has too many problems.

### DIFF
--- a/sdks/builds/download-llvm36.sh
+++ b/sdks/builds/download-llvm36.sh
@@ -7,15 +7,15 @@ JENKINS_LANE=$2
 
 URL=http://xamjenkinsartifact.blob.core.windows.net/$JENKINS_LANE/llvm-osx64-$LLVM_REV.tar.gz
 
-curl --output tmp.tar.gz $URL
+curl --output tmp36.tar.gz $URL
 
-rm -rf llvm-tmp
-mkdir -p llvm-tmp
-tar -xC llvm-tmp -f tmp.tar.gz
+rm -rf llvm-tmp36
+mkdir -p llvm-tmp36
+tar -xC llvm-tmp36 -f tmp36.tar.gz
 rm -rf ../out/ios-llvm36-32
 mkdir -p ../out/llvm-llvm36-32
-cp -r llvm-tmp/usr32/* ../out/llvm-llvm36-32
-rm -rf llvm-tmp tmp.tar.gz
+cp -r llvm-tmp36/usr32/* ../out/llvm-llvm36-32
+rm -rf llvm-tmp36 tmp36.tar.gz
 cd ../out
 ln -sf llvm-llvm36-32 ios-llvm36-32
 

--- a/sdks/builds/download-llvm36.sh
+++ b/sdks/builds/download-llvm36.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -ex
+
+LLVM_REV=$1
+JENKINS_LANE=$2
+
+URL=http://xamjenkinsartifact.blob.core.windows.net/$JENKINS_LANE/llvm-osx64-$LLVM_REV.tar.gz
+
+curl --output tmp.tar.gz $URL
+
+rm -rf llvm-tmp
+mkdir -p llvm-tmp
+tar -xC llvm-tmp -f tmp.tar.gz
+rm -rf ../out/ios-llvm36-32
+mkdir -p ../out/llvm-llvm36-32
+cp -r llvm-tmp/usr32/* ../out/llvm-llvm36-32
+rm -rf llvm-tmp tmp.tar.gz
+cd ../out
+ln -sf llvm-llvm36-32 ios-llvm36-32
+

--- a/sdks/builds/ios.mk
+++ b/sdks/builds/ios.mk
@@ -308,10 +308,14 @@ ifndef IGNORE_PACKAGE_LLVM
 	./download-llvm.sh $(LLVM_HASH) $(LLVM_JENKINS_LANE)
 	touch $@
 
-build-ios-llvm: .stamp-ios-llvm-$(LLVM_HASH)
+.stamp-ios-llvm-$(LLVM36_HASH):
+	./download-llvm36.sh $(LLVM36_HASH) $(LLVM36_JENKINS_LANE)
+	touch $@
+
+build-ios-llvm: .stamp-ios-llvm-$(LLVM_HASH) .stamp-ios-llvm-$(LLVM36_HASH)
 
 clean-ios-llvm: clean-llvm-llvm32 clean-llvm-llvm64
-	$(RM) -rf ../out/ios-llvm64 ../out/ios-llvm32 .stamp-ios-llvm-$(LLVM_HASH)
+	$(RM) -rf ../out/ios-llvm64 ../out/ios-llvm32 ../out/ios-llvm36-32 .stamp-ios-llvm-$(LLVM_HASH) .stamp-ios-llvm-$(LLVM36_HASH)
 
 else
 
@@ -405,6 +409,6 @@ endef
 
 ios-cross32_CONFIGURE_FLAGS=--build=i386-apple-darwin10
 ios-crosswatch_CONFIGURE_FLAGS=--build=i386-apple-darwin10 	--enable-cooperative-suspend
-$(eval $(call iOSCrossTemplate,cross32,arm,llvm32,arm-darwin,arm-apple-darwin10))
+$(eval $(call iOSCrossTemplate,cross32,arm,llvm36-32,arm-darwin,arm-apple-darwin10))
 $(eval $(call iOSCrossTemplate,cross64,aarch64,llvm64,aarch64-darwin,aarch64-apple-darwin10))
-$(eval $(call iOSCrossTemplate,crosswatch,armv7k,llvm32,armv7k-unknown-darwin,armv7k-apple-darwin))
+$(eval $(call iOSCrossTemplate,crosswatch,armv7k,llvm36-32,armv7k-unknown-darwin,armv7k-apple-darwin))

--- a/sdks/versions.mk
+++ b/sdks/versions.mk
@@ -8,7 +8,9 @@ MXE_HASH?=b9cbb53541a0e10fe4fe81f22bd586cb9cdc922a
 #LLVM_HASH?=3b82b3c9041eb997f627f881a67d20be37264e9c
 #LLVM_JENKINS_LANE=build-package-osx-llvm
 LLVM_HASH?=fc854b8ec5873d294b80afa3e6cf6a88c5c48886
+LLVM36_HASH?=0b3cb8ac12cd839f8110775d4085e822e8af4d7b
 LLVM_JENKINS_LANE=build-package-osx-llvm-release60
+LLVM36_JENKINS_LANE=build-package-osx-llvm
 LLVM_BRANCH=release_60
 
 # Android


### PR DESCRIPTION
backport of https://github.com/mono/mono/pull/9889