### PR TITLE
[runtime] Speed-up MERP timeout

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -6068,17 +6068,17 @@ mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes)
 			summarizing_thread = tid;
 			mono_threads_pthread_kill (info, SIGTERM);
 
-			// Number of seconds to give each dumping thread
-			int count = 4;
+			// Number of rounds of 40 milliseconds seconds to give each dumping thread
+			int count = 400;
 
 			while (old_num_summarized == num_threads_summarized && count > 0) {
 				if (thread->state & (ThreadState_Unstarted | ThreadState_Aborted | ThreadState_Stopped))
 					break;
 
-				sleep (1);
+				usleep (10);
 				mono_memory_barrier ();
 				const char *name = thread_summary_state_to_str (summarizing_thread_state);
-				MOSTLY_ASYNC_SAFE_PRINTF("Waiting for signalled thread %zx to collect stacktrace. Status: %s\n", tid, name);
+				MOSTLY_ASYNC_SAFE_PRINTF("Waiting for signalled thread %zx to collect stacktrace. Status: %s\n. Thread state: 0x%x\n", tid, name, thread->state);
 				count--;
 			}
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -6072,6 +6072,9 @@ mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes)
 			int count = 4;
 
 			while (old_num_summarized == num_threads_summarized && count > 0) {
+				if (thread->state & (ThreadState_Unstarted | ThreadState_Aborted | ThreadState_Stopped))
+					break;
+
 				sleep (1);
 				mono_memory_barrier ();
 				const char *name = thread_summary_state_to_str (summarizing_thread_state);


### PR DESCRIPTION
Now that https://github.com/mono/mono/pull/9809 is merged so this won't dereference freed objects, I added a speed increase of the timeout. 

Making a test branch first to get a package to make sure this fix works. Don't merge until I've confirmed so.