### PR TITLE
[mono-api-tools] Split properly for cross-platform

### DIFF
--- a/mcs/tools/mono-api-html/ApiChange.cs
+++ b/mcs/tools/mono-api-html/ApiChange.cs
@@ -69,9 +69,9 @@ namespace Mono.ApiTools {
 				if (!change.HasIgnoredChanges) {
 					var isField = source.Name.LocalName == "field";
 					if (isField) {
-						State.LogDebugMessage ($"Comparison resulting in no changes (src: {source.GetFieldAttributes ()} dst: {target.GetFieldAttributes ()}) :\n{source}\n{target}\n\n");
+						State.LogDebugMessage ($"Comparison resulting in no changes (src: {source.GetFieldAttributes ()} dst: {target.GetFieldAttributes ()}) :{Environment.NewLine}{source}{Environment.NewLine}{target}{Environment.NewLine}{Environment.NewLine}");
 					} else {
-						State.LogDebugMessage ($"Comparison resulting in no changes (src: {source.GetMethodAttributes ()} dst: {target.GetMethodAttributes ()}) :\n{source}\n{target}\n\n");
+						State.LogDebugMessage ($"Comparison resulting in no changes (src: {source.GetMethodAttributes ()} dst: {target.GetMethodAttributes ()}) :{Environment.NewLine}{source}{Environment.NewLine}{target}{Environment.NewLine}{Environment.NewLine}");
 					}
 				}
 				return;

--- a/mcs/tools/mono-api-html/FieldComparer.cs
+++ b/mcs/tools/mono-api-html/FieldComparer.cs
@@ -56,9 +56,9 @@ namespace Mono.ApiTools {
 				if (srcNotSerialized != tgtNotSerialized) {
 					// this is not a breaking change, so only render it if it changed.
 					if (srcNotSerialized) {
-						change.AppendRemoved ("[NonSerialized]\n");
+						change.AppendRemoved ($"[NonSerialized]{Environment.NewLine}");
 					} else {
-						change.AppendAdded ("[NonSerialized]\n");
+						change.AppendAdded ($"[NonSerialized]{Environment.NewLine}");
 					}
 				}
 			}

--- a/mcs/tools/mono-api-html/HtmlFormatter.cs
+++ b/mcs/tools/mono-api-html/HtmlFormatter.cs
@@ -303,7 +303,7 @@ namespace Mono.ApiTools {
 		public override void Diff (TextWriter output, ApiChange apichange)
 		{
 			output.Write ("<div {0}>", apichange.Breaking ? "data-is-breaking" : "data-is-non-breaking");
-			foreach (var line in apichange.Member.ToString ().Split ('\n')) {
+			foreach (var line in apichange.Member.ToString ().Split (new[] { "\r\n", "\n" }, 0))) {
 				output.Write ('\t');
 				output.WriteLine (line);
 			}

--- a/mcs/tools/mono-api-html/HtmlFormatter.cs
+++ b/mcs/tools/mono-api-html/HtmlFormatter.cs
@@ -235,7 +235,7 @@ namespace Mono.ApiTools {
 				output.WriteLine ("<p>Removed value{0}:</p>", list.Count () > 1 ? "s" : String.Empty);
 				output.WriteLine ("<pre class='removed' data-is-breaking>");
 			} else {
-				output.WriteLine ("<p>Removed {0}:</p>\n", list.Count () > 1 ? member.GroupName : member.ElementName);
+				output.WriteLine ("<p>Removed {0}:</p>", list.Count () > 1 ? member.GroupName : member.ElementName);
 				output.WriteLine ("<pre>");
 			}
 			State.Indent++;
@@ -303,7 +303,7 @@ namespace Mono.ApiTools {
 		public override void Diff (TextWriter output, ApiChange apichange)
 		{
 			output.Write ("<div {0}>", apichange.Breaking ? "data-is-breaking" : "data-is-non-breaking");
-			foreach (var line in apichange.Member.ToString ().Split (new[] { "\r\n", "\n" }, 0))) {
+			foreach (var line in apichange.Member.ToString ().Split (new[] { Environment.NewLine }, 0)) {
 				output.Write ('\t');
 				output.WriteLine (line);
 			}

--- a/mcs/tools/mono-api-html/MarkdownFormatter.cs
+++ b/mcs/tools/mono-api-html/MarkdownFormatter.cs
@@ -191,7 +191,7 @@ namespace Mono.ApiTools {
 
 		public override void Diff (TextWriter output, ApiChange apichange)
 		{
-			foreach (var line in apichange.Member.ToString ().Split (new[] { "\r\n", "\n" }, 0))) {
+			foreach (var line in apichange.Member.ToString ().Split (new[] { Environment.NewLine }, 0)) {
 				if (line.Contains ("+++")) {
 					output.WriteLine ("-{0}", Clean (line, "+++", "---"));
 					output.WriteLine ("+{0}", Clean (line, "---", "+++"));

--- a/mcs/tools/mono-api-html/MarkdownFormatter.cs
+++ b/mcs/tools/mono-api-html/MarkdownFormatter.cs
@@ -191,7 +191,7 @@ namespace Mono.ApiTools {
 
 		public override void Diff (TextWriter output, ApiChange apichange)
 		{
-			foreach (var line in apichange.Member.ToString ().Split ('\n')) {
+			foreach (var line in apichange.Member.ToString ().Split (new[] { "\r\n", "\n" }, 0))) {
 				if (line.Contains ("+++")) {
 					output.WriteLine ("-{0}", Clean (line, "+++", "---"));
 					output.WriteLine ("+{0}", Clean (line, "---", "+++"));


### PR DESCRIPTION
When creating a diff on windows, the lines are split on the `\n` so the `\r\n` results in multiple lines:

**START SNIP**
Obsoleted methods:

```diff
 [Obsolete ("Use AddRoundRect instead.")]

 public void AddRoundedRect (SKRect rect, float rx, float ry, SKPathDirection dir);
```
**END SNIP**

This PR makes sure to use the platform line endings everywhere. When adding line endings, use the same that `StringBuilder` uses - platform endings. This makes it easy to split - just use the platform as that is what everyone is using.