### PR TITLE
[merp] Fix json formatting bug (symbolicator already has workaround)

### DIFF
--- a/mono/utils/mono-merp.c
+++ b/mono/utils/mono-merp.c
@@ -426,7 +426,7 @@ mono_merp_fingerprint_payload (const char *non_param_data, const MERPStruct *mer
 
 	mono_json_writer_indent (&writer);
 	mono_json_writer_object_key(&writer, "SystemModel:");
-	mono_json_writer_printf (&writer, "\"%s\"\n", merp->systemModel);
+	mono_json_writer_printf (&writer, "\"%s\",\n", merp->systemModel);
 
 	mono_json_writer_indent (&writer);
 	mono_json_writer_object_key(&writer, "EventType:");


### PR DESCRIPTION
The symbolicator already has a workaround with a regex, so this might not need a backport. 