### PR TITLE
[2018-08] [sdks] Rename LLVM_VERSION make var to LLVM_RELEASE, LLVM_VERSION is already used by versions.mk.

### DIFF
--- a/llvm/build.mk
+++ b/llvm/build.mk
@@ -10,7 +10,7 @@ top_srcdir ?= $(abspath $(CURDIR)/..)
 LLVM_PATH ?= $(abspath $(top_srcdir)/external/llvm)
 LLVM_BUILD ?= $(abspath $(top_srcdir)/llvm/build)
 LLVM_PREFIX ?= $(abspath $(top_srcdir)/llvm/usr)
-LLVM_VERSION ?= llvm
+LLVM_RELEASE ?= llvm
 
 CMAKE := $(or $(CMAKE),$(shell which cmake))
 NINJA := $(shell which ninja)
@@ -36,7 +36,7 @@ bump-current-llvm: __bump-current-version-llvm
 $(LLVM_BUILD) $(LLVM_PREFIX):
 	mkdir -p $@
 
-$(LLVM_PATH)/CMakeLists.txt: | reset-$(LLVM_VERSION)
+$(LLVM_PATH)/CMakeLists.txt: | reset-$(LLVM_RELEASE)
 
 $(LLVM_BUILD)/$(if $(NINJA),build.ninja,Makefile): $(LLVM_PATH)/CMakeLists.txt | $(LLVM_BUILD)
 	cd $(LLVM_BUILD) && $(CMAKE) \

--- a/sdks/builds/llvm.mk
+++ b/sdks/builds/llvm.mk
@@ -50,7 +50,7 @@ package-llvm-$(1): | $$(dir $(3))
 		LLVM_BUILD="$$(TOP)/sdks/builds/llvm-$(1)" \
 		LLVM_PREFIX="$$(TOP)/sdks/out/ios-$(1)" \
 		LLVM_CMAKE_ARGS="$$(_llvm-$(1)_CMAKE_ARGS)" \
-		LLVM_VERSION="$(5)"
+		LLVM_RELEASE="$(5)"
 
 .PHONY: download-llvm-$(1)
 download-llvm-$(1): $(4)


### PR DESCRIPTION
Backport of #9919.

/cc @vargaz