### PR TITLE
[corlib] Fix method access failures for __ComObject instances hosted …

### DIFF
--- a/mcs/class/corlib/ReferenceSources/RuntimeType.cs
+++ b/mcs/class/corlib/ReferenceSources/RuntimeType.cs
@@ -592,8 +592,10 @@ namespace System
 				{
 					AssemblyName assemblyname = new AssemblyName ();
 					assemblyname.Name = "GetTypeFromCLSIDDummyAssembly";
-					clsid_assemblybuilder = AppDomain.CurrentDomain.DefineDynamicAssembly (
-						assemblyname, AssemblyBuilderAccess.Run);
+					/* Dynamically created assembly is marked internal to corlib to allow
+					  __ComObject access for dynamic types. */
+					clsid_assemblybuilder = new AssemblyBuilder (assemblyname, null,
+						AssemblyBuilderAccess.Run, true);
 				}
 				ModuleBuilder modulebuilder = clsid_assemblybuilder.DefineDynamicModule (
 					clsid.ToString ());


### PR DESCRIPTION
…in dummy assembly.

Otherwise I get consistent access failures for CALLVIRT from mono_method_to_ir().

Stacktrace looks like this:

```
System.InvalidOperationException: WinForms_SeeInnerException ---> System.Reflection.TargetInvocationException: Exception has been thrown by the target of an        invocation. ---> System.MethodAccessException: Method `System.__ComObject..ctor()' is inaccessible from method `System.__ComObject..ctor()'
445286   at (wrapper managed-to-native) System.Object.__icall_wrapper_mono_throw_method_access(intptr,intptr)
445287   at System.__ComObject..ctor () [0x00000] in <430892d2beef407ea6b21748b72c1144>:0
445288   at (wrapper cominterop-invoke) System.__ComObject..ctor()
445289   at (wrapper managed-to-native) System.Reflection.MonoCMethod.InternalInvoke(System.Reflection.MonoCMethod,object,object[],System.Exception&)
445290   at System.Reflection.MonoCMethod.InternalInvoke (System.Object obj, System.Object[] parameters) [0x00002] in <b683bf5ced8643af8ec2e589dfb23c2b>:0
445291    --- End of inner exception stack trace ---
445292   at System.Reflection.MonoCMethod.InternalInvoke (System.Object obj, System.Object[] parameters) [0x00014] in <b683bf5ced8643af8ec2e589dfb23c2b>:0
445293   at System.RuntimeType.CreateInstanceMono (System.Boolean nonPublic) [0x000a8] in <b683bf5ced8643af8ec2e589dfb23c2b>:0
445294   at System.RuntimeType.CreateInstanceSlow (System.Boolean publicOnly, System.Boolean skipCheckThis, System.Boolean fillCache, System.Threading.StackCrawlMark& stackMark) [0x00009] in <b683bf5ced8643af8ec       2e589dfb23c2b>:0
445295   at System.RuntimeType.CreateInstanceDefaultCtor (System.Boolean publicOnly, System.Boolean skipCheckThis, System.Boolean fillCache, System.Threading.StackCrawlMark& stackMark) [0x00027] in <b683bf5ced86       43af8ec2e589dfb23c2b>:0
445296   at System.Activator.CreateInstance (System.Type type, System.Boolean nonPublic) [0x00020] in <b683bf5ced8643af8ec2e589dfb23c2b>:0
445297   at System.Activator.CreateInstance (System.Type type) [0x00000] in <b683bf5ced8643af8ec2e589dfb23c2b>:0
```

My understanding is that misleading exception message is due to exact same name used for dynamic type, in fact it means that some type in dummy assembly can't access internal method from corlib.

I'm testing with Mono crossbuilt for Windows on Linux/GCC.