### PR TITLE
Change platform specific sources overrides from hostplatform_libname to hostplatform_defaultprofile_libname

### DIFF
--- a/mcs/class/System.Security/System.Security.csproj
+++ b/mcs/class/System.Security/System.Security.csproj
@@ -410,117 +410,6 @@
       </ItemGroup>
     </When>
     <When Condition="'$(Platform)' == 'net_4_x'">
-      <ItemGroup>
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\AncestralNamespaceContextManager.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\AttributeSortOrder.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\C14NAncestralNamespaceContextManager.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\CanonicalXml.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\CanonicalXmlAttribute.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\CanonicalXmlCDataSection.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\CanonicalXmlComment.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\CanonicalXmlDocument.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\CanonicalXmlElement.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\CanonicalXmlEntityReference.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\CanonicalXmlNodeList.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\CanonicalXmlProcessingInstruction.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\CanonicalXmlSignificantWhitespace.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\CanonicalXmlText.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\CanonicalXmlWhitespace.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\CanonicalizationDispatcher.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\CertUsageType.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\CipherData.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\CipherReference.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\CryptoHelpers.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\CryptoSignedXmlRecursionException.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\DSAKeyValue.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\DSASignatureDescription.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\DataObject.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\DataReference.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\DocPosition.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\EncryptedData.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\EncryptedKey.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\EncryptedReference.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\EncryptedType.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\EncryptedXml.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\EncryptionMethod.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\EncryptionProperty.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\EncryptionPropertyCollection.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\ExcAncestralNamespaceContextManager.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\ExcCanonicalXml.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\ICanonicalizableNode.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\IRelDecryptor.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\KeyInfo.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\KeyInfoClause.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\KeyInfoEncryptedKey.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\KeyInfoName.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\KeyInfoNode.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\KeyInfoRetrievalMethod.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\KeyInfoX509Data.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\KeyReference.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\MyXmlDocument.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\NamespaceFrame.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\NamespaceSortOrder.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\RSAKeyValue.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\RSAPKCS1SHA1SignatureDescription.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\RSAPKCS1SHA256SignatureDescription.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\RSAPKCS1SHA384SignatureDescription.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\RSAPKCS1SHA512SignatureDescription.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\RSAPKCS1SignatureDescription.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\Reference.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\ReferenceList.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\ReferenceTargetType.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\Signature.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\SignedInfo.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\SignedXml.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\SignedXmlDebugLog.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\SymmetricKeyWrap.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\Transform.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\TransformChain.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\Utils.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\XmlDecryptionTransform.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\XmlDsigBase64Transform.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\XmlDsigC14NTransform.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\XmlDsigC14NWithCommentsTransform.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\XmlDsigEnvelopedSignatureTransform.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\XmlDsigExcC14NTransform.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\XmlDsigExcC14NWithCommentsTransform.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\XmlDsigXPathTransform.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\XmlDsigXsltTransform.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.Security.Cryptography.Xml\src\System\Security\Cryptography\Xml\XmlLicenseTransform.cs" />
-        <Compile Include="Mono.Security.Cryptography\ManagedProtection.cs" />
-        <Compile Include="System.Security.Cryptography.Pkcs\KeyAgreeKeyChoice.cs" />
-        <Compile Include="System.Security.Cryptography.X509Certificates\X509Certificate2UI.cs" />
-        <Compile Include="System.Security.Cryptography.X509Certificates\X509SelectionFlag.cs" />
-        <Compile Include="System.Security.Cryptography\MemoryProtectionScope.cs" />
-        <Compile Include="System.Security.Cryptography\ProtectedData.cs" />
-        <Compile Include="System.Security.Cryptography\ProtectedMemory.cs" />
-        <Compile Include="System.Security.Permissions\DataProtectionPermission.cs" />
-        <Compile Include="System.Security.Permissions\DataProtectionPermissionAttribute.cs" />
-        <Compile Include="System.Security.Permissions\DataProtectionPermissionFlags.cs" />
-        <Compile Include="System.Security.Permissions\PermissionHelper.cs" />
-      </ItemGroup>
-    </When>
-    <When Condition="'$(Platform)' == 'monotouch_watch'">
-      <ItemGroup>
-        <Compile Include="System.Security.Cryptography\ProtectedData.cs" />
-      </ItemGroup>
-    </When>
-    <When Condition="'$(Platform)' == 'monotouch_tv'">
-      <ItemGroup>
-        <Compile Include="System.Security.Cryptography\ProtectedData.cs" />
-      </ItemGroup>
-    </When>
-    <When Condition="'$(Platform)' == 'monotouch'">
-      <ItemGroup>
-        <Compile Include="System.Security.Cryptography\ProtectedData.cs" />
-      </ItemGroup>
-    </When>
-    <When Condition="'$(Platform)' == 'monodroid'">
-      <ItemGroup>
-        <Compile Include="System.Security.Cryptography\ProtectedData.cs" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
       <!--Per-host-platform files-->
       <Choose>
         <When Condition="'$(HostPlatform)' == 'win32'">
@@ -896,7 +785,27 @@
         </When>
       </Choose>
       <!--End of per-host-platform files-->
-    </Otherwise>
+    </When>
+    <When Condition="'$(Platform)' == 'monotouch_watch'">
+      <ItemGroup>
+        <Compile Include="System.Security.Cryptography\ProtectedData.cs" />
+      </ItemGroup>
+    </When>
+    <When Condition="'$(Platform)' == 'monotouch_tv'">
+      <ItemGroup>
+        <Compile Include="System.Security.Cryptography\ProtectedData.cs" />
+      </ItemGroup>
+    </When>
+    <When Condition="'$(Platform)' == 'monotouch'">
+      <ItemGroup>
+        <Compile Include="System.Security.Cryptography\ProtectedData.cs" />
+      </ItemGroup>
+    </When>
+    <When Condition="'$(Platform)' == 'monodroid'">
+      <ItemGroup>
+        <Compile Include="System.Security.Cryptography\ProtectedData.cs" />
+      </ItemGroup>
+    </When>
   </Choose>
   <!--End of per-profile files-->
   <!-- @ALL_SOURCES@ -->

--- a/mcs/class/System.Security/win32_net_4_x_System.Security.dll.exclude.sources
+++ b/mcs/class/System.Security/win32_net_4_x_System.Security.dll.exclude.sources
@@ -1,0 +1,1 @@
+#include win32_System.Security.dll.exclude.sources

--- a/mcs/class/System.Security/win32_net_4_x_System.Security.dll.sources
+++ b/mcs/class/System.Security/win32_net_4_x_System.Security.dll.sources
@@ -1,0 +1,1 @@
+#include win32_System.Security.dll.sources

--- a/mcs/class/corlib/Test/System.IO/BinaryReaderTest.cs
+++ b/mcs/class/corlib/Test/System.IO/BinaryReaderTest.cs
@@ -649,8 +649,10 @@ namespace MonoTests.System.IO
 			Assert.AreEqual (1, reader.Read (), "test#03");
 			Assert.AreEqual (2, reader.PeekChar (), "test#03");
 		} finally {
-			reader.Close ();
-			stream.Close ();
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 	
@@ -687,8 +689,10 @@ namespace MonoTests.System.IO
 			reader.Close ();
 			reader.PeekChar ();
 		} finally {
-			reader.Close ();
-			stream.Close ();
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 
@@ -706,8 +710,10 @@ namespace MonoTests.System.IO
 			reader.Close ();
 			reader.ReadBytes (1);
 		} finally {
-			reader.Close ();
-			stream.Close ();
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 
@@ -727,8 +733,10 @@ namespace MonoTests.System.IO
 			reader.Close ();
 			Assert.AreEqual (null, reader.BaseStream, "test#03");
 		} finally {
-			reader.Close ();
-			stream.Close ();
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 
@@ -767,8 +775,10 @@ namespace MonoTests.System.IO
 			Assert.AreEqual (0, bytes [0], "test#10");
 			Assert.AreEqual (0, bytes [1], "test#11");				
 		} finally {
-			reader.Close ();
-			stream.Close ();
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 	
@@ -804,8 +814,10 @@ namespace MonoTests.System.IO
 			Assert.AreEqual (0, chars [0], "test#08");
 			Assert.AreEqual (0, chars [1], "test#09");
 		} finally {
-			reader.Close ();
-			stream.Close ();
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 
 	}
@@ -827,8 +839,10 @@ namespace MonoTests.System.IO
 			Assert.AreEqual (false, reader.ReadBoolean (), "test#04");
 			Assert.AreEqual (true, reader.ReadBoolean (), "test#05");		
 		} finally {
-			reader.Close ();
-			stream.Close ();
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 	
@@ -848,8 +862,10 @@ namespace MonoTests.System.IO
 			reader.ReadBoolean ();
 			reader.ReadBoolean ();
 		} finally {
-			reader.Close ();
-			stream.Close ();
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 	
@@ -872,8 +888,10 @@ namespace MonoTests.System.IO
 			Assert.AreEqual (0, reader.ReadByte (), "test#04");
 			Assert.AreEqual (13, reader.ReadByte (), "test#05");		
 		} finally {
-			reader.Close ();
-			stream.Close ();
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 	
@@ -894,8 +912,10 @@ namespace MonoTests.System.IO
 			reader.ReadByte ();
 			reader.ReadByte ();
 		} finally {
-			reader.Close ();
-			stream.Close ();
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 	
@@ -925,8 +945,10 @@ namespace MonoTests.System.IO
 			Assert.AreEqual (1, bytes.Length, "test#06");
 			
 		} finally {
-			reader.Close ();
-			stream.Close ();
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 	
@@ -945,8 +967,10 @@ namespace MonoTests.System.IO
 			reader = new BinaryReader (stream);
 			reader.ReadBytes (-1);		
 		} finally {
-			reader.Close ();
-			stream.Close ();
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 	
@@ -968,8 +992,10 @@ namespace MonoTests.System.IO
 			Assert.AreEqual (0, reader.ReadChar (), "test#04");
 			Assert.AreEqual (13, reader.ReadChar (), "test#05");
 		} finally {
-			reader.Close ();
-			stream.Close ();
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 	
@@ -990,8 +1016,10 @@ namespace MonoTests.System.IO
 			reader.ReadChar ();
 			reader.ReadChar ();
 		} finally {
-			reader.Close ();
-			stream.Close ();
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 
@@ -1018,8 +1046,10 @@ namespace MonoTests.System.IO
 			Assert.AreEqual (13, chars [0], "test#05");
 			Assert.AreEqual (1, chars.Length, "test#06");
 		} finally {
-			reader.Close ();
-			stream.Close ();
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 	
@@ -1037,8 +1067,10 @@ namespace MonoTests.System.IO
 			reader = new BinaryReader (stream);
 			reader.ReadChars (-1);
 		} finally {
-			reader.Close ();
-			stream.Close ();
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 	
@@ -1056,8 +1088,10 @@ namespace MonoTests.System.IO
 			reader = new BinaryReader (stream);		
 			Assert.AreEqual (-18295873486192640, reader.ReadDecimal (), "test#01");
 		} finally {
-			reader.Close ();
-			stream.Close ();
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}		
 	}
 	
@@ -1071,8 +1105,10 @@ namespace MonoTests.System.IO
 			reader.ReadDecimal ();
 			reader.ReadDecimal ();		
 		} finally {
-			reader.Close ();
-			stream.Close ();
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 	
@@ -1085,8 +1121,10 @@ namespace MonoTests.System.IO
 			Assert.AreEqual (1.8913127797311212E-307d, reader.ReadDouble (), "test#01");
 			Assert.AreEqual (1.2024538023802026E+111d, reader.ReadDouble (), "test#02");	
 		} finally {
-			reader.Close ();
-			stream.Close ();
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 	
@@ -1117,8 +1155,10 @@ namespace MonoTests.System.IO
 			Assert.AreEqual (773, reader.ReadInt16 (), "test#03");
 			Assert.AreEqual (54, reader.ReadInt16 (), "test#04");		
 		} finally {
-			reader.Close ();
-			stream.Close ();			
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 	
@@ -1132,8 +1172,10 @@ namespace MonoTests.System.IO
 			reader.ReadInt16 ();
 			reader.ReadInt16 ();
 		} finally {
-			reader.Close ();
-			stream.Close ();
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 
@@ -1146,8 +1188,10 @@ namespace MonoTests.System.IO
 			Assert.AreEqual (723517761, reader.ReadInt32 (), "test#01");
 			Assert.AreEqual (3539717, reader.ReadInt32 (), "test#02");
 		} finally {
-			reader.Close ();
-			stream.Close ();
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 	
@@ -1161,8 +1205,10 @@ namespace MonoTests.System.IO
 			reader.ReadInt32 ();
 			reader.ReadInt32 ();
 		} finally {
-			reader.Close ();
-			stream.Close ();
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 
@@ -1175,8 +1221,10 @@ namespace MonoTests.System.IO
 			Assert.AreEqual (15202969475612993, reader.ReadInt64 (), "test#01");
 			Assert.AreEqual (2471354792417887522, reader.ReadInt64 (), "test#02");
 		} finally {
-			reader.Close ();
-			stream.Close ();
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 	
@@ -1192,8 +1240,10 @@ namespace MonoTests.System.IO
 			reader.ReadInt64 ();
 			reader.ReadInt64 ();
 		} finally {
-			reader.Close ();
-			stream.Close ();
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 	
@@ -1208,8 +1258,10 @@ namespace MonoTests.System.IO
 			Assert.AreEqual (-56, reader.ReadSByte (), "test#02");
 			Assert.AreEqual (32, reader.ReadSByte (), "test#03");
 		} finally {
-			reader.Close ();
-			stream.Close ();
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 	
@@ -1225,8 +1277,10 @@ namespace MonoTests.System.IO
 			reader.ReadSByte ();
 			reader.ReadSByte ();		
 		} finally {
-			reader.Close ();
-			stream.Close ();			
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 	
@@ -1255,8 +1309,10 @@ namespace MonoTests.System.IO
 			reader.ReadSingle ();
 			reader.ReadSingle ();
 		} finally {
-			reader.Close ();
-			stream.Close ();			
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 	
@@ -1275,8 +1331,10 @@ namespace MonoTests.System.IO
 			Assert.AreEqual ("mo", reader.ReadString (), "test#02");
 			Assert.AreEqual ("o::", reader.ReadString (), "test#03");
 		} finally {
-			reader.Close ();
-			stream.Close ();			
+			if (reader != null)
+				reader.Close ();
+			if (stream != null)
+				stream.Close ();
 		}
 	}
 


### PR DESCRIPTION
The commit https://github.com/mono/mono/commit/f602125d107b0966f8045670326124ad988291cc accidentally introduced a (hostplatform)_(libname) style sources file, making it get used for any scenario where the host platform was win32 and we didn't have a more specific sources file. We didn't notice this hazard when adding support for the hostplatform style so this PR changes the format to (hostplatform)_defaultprofile_(libname) to make it explicit that the sources file is intended to behave this way. The hazard is partly a result of us already naming common included sources files in a similar pattern, like win32_foo.sources, and then including them from a bunch of profiles.

This PR also updates the 'load entire folder' path used by genproj to check for any uses of the hazardous hostplatform style that were not also includes, and I didn't find any. I suspect we might have introduced one intentionally, but I don't have any way to identify those. @baulig do you know if there are any cases where we wanted to use a win32_xxx as both an include and a direct sources file so I can fix them?