### PR TITLE
[coop] Thread.JoinInternal should not call mono_error_set_pending_exception

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -2047,10 +2047,10 @@ ves_icall_System_Threading_Thread_Join_internal (MonoThreadObjectHandle thread_h
 
 	mono_thread_clr_state (cur_thread, ThreadState_WaitSleepJoin);
 
-	mono_error_set_pending_exception (error);
-
 	if (ret == MONO_THREAD_INFO_WAIT_RET_SUCCESS_0) {
 		THREAD_DEBUG (g_message ("%s: join successful", __func__));
+
+		mono_error_assert_ok (error);
 
 		/* Wait for the thread to really exit */
 		MonoNativeThreadId tid = thread_get_tid (thread);

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -194,6 +194,8 @@ mono_error_get_message (MonoError *oerror)
 	case MONO_ERROR_FILE_NOT_FOUND:
 	case MONO_ERROR_MISSING_FIELD:
 		return error->full_message;
+	case MONO_ERROR_CLEANUP_CALLED_SENTINEL:
+		g_assert_not_reached ();
 	}
 
 	if (error->full_message_with_fields)


### PR DESCRIPTION

The icall was converted to use `HANDLES()`, so the icall wrapper will set the
pending exception from the `MonoError`.  If the icall does it, too, the second
use (in the wrapper) will assert that the `MonoError` is being reused after
cleanup without being reinitialized.

Also add an assertion in `mono_error_get_message` that we're not trying to get a
message from a cleaned up `MonoError`.

Fixes https://github.com/mono/mono/issues/9935

