### PR TITLE
[cxx] [boehm] extern "C" and interface void*  instead of char* for use by  C++

### DIFF
--- a/libgc/include/gc.h
+++ b/libgc/include/gc.h
@@ -42,11 +42,6 @@
 #   define GC_CONST
 #  endif
 
-# ifdef __cplusplus
-    extern "C" {
-# endif
-
-
 /* Define word and signed_word to be unsigned and signed types of the 	*/
 /* size as char * or void *.  There seems to be no way to do this	*/
 /* even semi-portably.  The following is probably no better/worse 	*/
@@ -64,6 +59,10 @@
   #include <stdint.h>
   typedef unsigned __int64 GC_word;
   typedef __int64 GC_signed_word;
+#endif
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 /* Public read-only variables */
@@ -501,7 +500,17 @@ GC_API GC_PTR GC_malloc_atomic_ignore_off_page GC_PROTO((size_t lb));
 #endif
 
 #if defined(__linux__) || defined(__GLIBC__)
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
 # include <features.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 # if (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 1 || __GLIBC__ > 2) \
      && !defined(__ia64__)
 #   ifndef GC_HAVE_BUILTIN_BACKTRACE
@@ -965,7 +974,17 @@ GC_API void (*GC_is_visible_print_proc)
 
 #if !defined(GC_USE_LD_WRAP) && \
     (defined(GC_PTHREADS) || defined(GC_SOLARIS_THREADS) || defined(GC_DARWIN_THREADS) || defined(GC_MACOSX_THREADS))
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
 # include "gc_pthread_redirects.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #endif
 
 # if defined(PCR) || defined(GC_SOLARIS_THREADS) || \
@@ -985,7 +1004,16 @@ extern void GC_thr_init(void);	/* Needed for Solaris/X86	*/
 #endif /* THREADS && !SRC_M3 */
 
 #if defined(GC_WIN32_THREADS) && !defined(__CYGWIN32__) && !defined(__CYGWIN__)
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
 # include <windows.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 # ifdef GC_INSIDE_DLL
    BOOL WINAPI GC_DllMain(HINSTANCE inst, ULONG reason, LPVOID reserved);
@@ -1081,6 +1109,10 @@ extern void GC_thr_init(void);	/* Needed for Solaris/X86	*/
     GC_API void GC_win32_free_heap ();
 #endif
 
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
 #if ( defined(_AMIGA) && !defined(GC_AMIGA_MAKINGLIB) )
   /* Allocation really goes through GC_amiga_allocwrapper_do */
 # include "gc_amiga_redirects.h"
@@ -1088,10 +1120,6 @@ extern void GC_thr_init(void);	/* Needed for Solaris/X86	*/
 
 #if defined(GC_REDIRECT_TO_LOCAL) && !defined(GC_LOCAL_ALLOC_H)
 #  include  "gc_local_alloc.h"
-#endif
-
-#ifdef __cplusplus
-    }  /* end of extern "C" */
 #endif
 
 #endif /* _GC_H */

--- a/libgc/include/gc_gcj.h
+++ b/libgc/include/gc_gcj.h
@@ -44,6 +44,10 @@
 #   include "gc.h"
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* The following allocators signal an out of memory condition with	*/
 /* return GC_oom_fn(bytes);						*/
 
@@ -109,5 +113,9 @@ extern int GC_gcj_debug_kind;
 #   define GC_GCJ_MALLOC_IGNORE_OFF_PAGE(s,d) \
 	GC_gcj_malloc_ignore_off_page(s,d)
 # endif
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif /* GC_GCJ_H */

--- a/libgc/include/gc_local_alloc.h
+++ b/libgc/include/gc_local_alloc.h
@@ -49,6 +49,10 @@
 #ifndef GC_LOCAL_ALLOC_H
 #define GC_LOCAL_ALLOC_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* We assume ANSI C for this interface.	*/
 
 GC_PTR GC_local_malloc(size_t bytes);
@@ -60,6 +64,10 @@ GC_PTR GC_local_malloc_atomic(size_t bytes);
 			     void * ptr_to_struct_containing_descr);
   GC_PTR GC_local_gcj_fast_malloc(size_t lw,
 			     void * ptr_to_struct_containing_descr);
+#endif
+
+#ifdef __cplusplus
+} // extern "C"
 #endif
 
 # ifdef GC_DEBUG

--- a/libgc/include/gc_pthread_redirects.h
+++ b/libgc/include/gc_pthread_redirects.h
@@ -15,6 +15,11 @@
 /* facility in thr_keycreate.  Alternatively, keep a redundant pointer	*/
 /* to thread specific data on the thread stack.			        */
 # include <thread.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
   int GC_thr_create(void *stack_base, size_t stack_size,
                     void *(*start_routine)(void *), void *arg, long flags,
                     thread_t *new_thread);
@@ -26,11 +31,22 @@
 # define thr_join GC_thr_join
 # define thr_suspend GC_thr_suspend
 # define thr_continue GC_thr_continue
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
 #endif /* GC_SOLARIS_THREADS */
 
 #if defined(GC_SOLARIS_PTHREADS)
+
 # include <pthread.h>
 # include <signal.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
   extern int GC_pthread_create(pthread_t *new_thread,
     			         const pthread_attr_t *attr,
           			 void * (*thread_execp)(void *), void *arg);
@@ -39,6 +55,11 @@
 # define pthread_join GC_pthread_join
 # define pthread_create GC_pthread_create
 # define pthread_detach GC_pthread_detach
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
 #endif
 
 #if defined(GC_SOLARIS_PTHREADS) || defined(GC_SOLARIS_THREADS)
@@ -50,6 +71,10 @@
 /* We treat these similarly. */
 # include <pthread.h>
 # include <signal.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
   int GC_pthread_create(pthread_t *new_thread,
                         const pthread_attr_t *attr,
@@ -85,6 +110,10 @@
 # endif
 # define pthread_sigmask GC_pthread_sigmask
 # define dlopen GC_dlopen
+#endif
+
+#ifdef __cplusplus
+} // extern "C"
 #endif
 
 #endif /* GC_xxxxx_THREADS */

--- a/libgc/include/private/gc_locks.h
+++ b/libgc/include/private/gc_locks.h
@@ -43,7 +43,17 @@
  *   
  */  
 # ifdef THREADS
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
    void GC_noop1 GC_PROTO((word));
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
 #  ifdef PCR_OBSOLETE	/* Faster, but broken with multiple lwp's	*/
 #    include  "th/PCR_Th.h"
 #    include  "th/PCR_ThCrSec.h"

--- a/libgc/include/private/gc_priv.h
+++ b/libgc/include/private/gc_priv.h
@@ -1330,7 +1330,7 @@ void GC_initiate_gc GC_PROTO((void));
   				/* If the mark state is invalid, this	*/
   				/* becomes full colleection.  Otherwise */
   				/* it's partial.			*/
-void GC_push_all GC_PROTO((ptr_t bottom, ptr_t top));
+void GC_push_all (void* bottom, void* top);
 				/* Push everything in a range 		*/
   				/* onto mark stack.			*/
 void GC_push_selected GC_PROTO(( \

--- a/libgc/include/private/gc_priv.h
+++ b/libgc/include/private/gc_priv.h
@@ -366,6 +366,10 @@ void GC_print_callers GC_PROTO((struct callinfo info[NFRAMES]));
 #   define BZERO(x,n) bzero((char *)(x),(int)(n))
 # endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(DARWIN)
 #	if defined(POWERPC)
 #		define GC_MACH_THREAD_STATE_FLAVOR PPC_THREAD_STATE
@@ -413,7 +417,18 @@ void GC_print_callers GC_PROTO((struct callinfo info[NFRAMES]));
  * Stop and restart mutator threads.
  */
 # ifdef PCR
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
 #     include "th/PCR_ThCtl.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 #     define STOP_WORLD() \
  	PCR_ThCtl_SetExclusiveMode(PCR_ThCtl_ExclusiveMode_stopNormal, \
  				   PCR_allSigsBlocked, \
@@ -1959,6 +1974,10 @@ void GC_err_puts GC_PROTO((GC_CONST char *s));
 		/* was already done, or there was nothing to do for	*/
 		/* some other reason.					*/
 # endif /* PARALLEL_MARK */
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 # if defined(GC_PTHREADS) && !defined(GC_SOLARIS_THREADS)
   /* We define the thread suspension signal here, so that we can refer	*/

--- a/libgc/mark.c
+++ b/libgc/mark.c
@@ -1191,11 +1191,11 @@ void GC_mark_init()
  * Should only be used if there is no possibility of mark stack
  * overflow.
  */
-void GC_push_all(bottom, top)
-ptr_t bottom;
-ptr_t top;
+void GC_push_all(void* void_bottom, void* void_top)
 {
-    register word length;
+    ptr_t bottom = (ptr_t)void_bottom;
+    ptr_t top = (ptr_t)void_top;
+    word length;
     
     bottom = (ptr_t)(((word) bottom + ALIGNMENT-1) & ~(ALIGNMENT-1));
     top = (ptr_t)(((word) top) & ~(ALIGNMENT-1));

--- a/libgc/mark.c
+++ b/libgc/mark.c
@@ -1191,7 +1191,9 @@ void GC_mark_init()
  * Should only be used if there is no possibility of mark stack
  * overflow.
  */
-void GC_push_all(void* void_bottom, void* void_top)
+void GC_push_all(void_bottom, void_top)
+void* void_bottom;
+void* void_top;
 {
     ptr_t bottom = (ptr_t)void_bottom;
     ptr_t top = (ptr_t)void_top;


### PR DESCRIPTION
Add extern "C" correctly to boehm so it can be C, and used by C++.
Change char* to void*  for use by C++ callers.

This tracks mainline but just barely.

https://github.com/ivmai/bdwgc/blob/ae3d724f3645af119e1b2c2cefbb71c97d467546/mark.c#L1337

https://github.com/ivmai/bdwgc/commit/f4fbef0f7f0e3446856d2177535080158e16e403#diff-74e77959a62b8a560274f69789f50a94R1623

https://github.com/ivmai/bdwgc/commit/a825a2d612e749c08c24fca0f11eb2a523ce3b6b

etc.
