### PR TITLE
[cxx][jit][arm] Make ARM32-specific JIT code valid C++.

### DIFF
--- a/mono/arch/arm/arm-codegen.h
+++ b/mono/arch/arm/arm-codegen.h
@@ -21,7 +21,7 @@ typedef unsigned int armword_t;
 	void __inline _arm_emit(arminstr_t** p, arminstr_t i) {**p = i; (*p)++;}
 #	define ARM_EMIT(p, i) _arm_emit((arminstr_t**)&p, (arminstr_t)(i))
 #else
-#	define ARM_EMIT(p, i) do { arminstr_t *__ainstrp = (void*)(p); *__ainstrp = (arminstr_t)(i); (p) = (void*)(__ainstrp+1);} while (0)
+#	define ARM_EMIT(p, i) do { *(arminstr_t*)(p) = (arminstr_t)(i); *(void**)&(p) = (arminstr_t*)(p) + 1; } while (0)
 #endif
 
 #if defined(_MSC_VER) && !defined(ARM_NOIASM)

--- a/mono/mini/exceptions-arm.c
+++ b/mono/mini/exceptions-arm.c
@@ -378,10 +378,9 @@ mono_arm_get_exception_trampolines (gboolean aot)
 void
 mono_arch_exceptions_init (void)
 {
-	gpointer tramp;
-	GSList *tramps, *l;
-	
 	if (mono_aot_only) {
+		gpointer tramp;
+
 		tramp = mono_aot_get_trampoline ("llvm_throw_corlib_exception_trampoline");
 		mono_register_jit_icall (tramp, "llvm_throw_corlib_exception_trampoline", NULL, TRUE);
 		tramp = mono_aot_get_trampoline ("llvm_throw_corlib_exception_abs_trampoline");
@@ -389,6 +388,8 @@ mono_arch_exceptions_init (void)
 		tramp = mono_aot_get_trampoline ("llvm_resume_unwind_trampoline");
 		mono_register_jit_icall (tramp, "llvm_resume_unwind_trampoline", NULL, TRUE);
 	} else {
+		GSList *tramps, *l;
+
 		tramps = mono_arm_get_exception_trampolines (FALSE);
 		for (l = tramps; l; l = l->next) {
 			MonoTrampInfo *info = (MonoTrampInfo*)l->data;

--- a/mono/mini/exceptions-arm.c
+++ b/mono/mini/exceptions-arm.c
@@ -56,7 +56,7 @@ mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 	MonoJumpInfo *ji = NULL;
 	GSList *unwind_ops = NULL;
 
-	start = code = mono_global_codeman_reserve (128);
+	start = code = (guint8*)mono_global_codeman_reserve (128);
 
 	/* 
 	 * Move things to their proper place so we can restore all the registers with
@@ -109,7 +109,7 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 	GSList *unwind_ops = NULL;
 
 	/* call_filter (MonoContext *ctx, unsigned long eip, gpointer exc) */
-	start = code = mono_global_codeman_reserve (320);
+	start = code = (guint8*)mono_global_codeman_reserve (320);
 
 	/* save all the regs on the stack */
 	ARM_MOV_REG_REG (code, ARMREG_IP, ARMREG_SP);
@@ -220,7 +220,7 @@ get_throw_trampoline (int size, gboolean corlib, gboolean rethrow, gboolean llvm
 	GSList *unwind_ops = NULL;
 	int cfa_offset;
 
-	code = start = mono_global_codeman_reserve (size);
+	code = start = (guint8*)mono_global_codeman_reserve (size);
 
 	mono_add_unwind_op_def_cfa (unwind_ops, code, start, ARMREG_SP, 0);
 
@@ -378,7 +378,7 @@ mono_arm_get_exception_trampolines (gboolean aot)
 void
 mono_arch_exceptions_init (void)
 {
-	guint8 *tramp;
+	gpointer tramp;
 	GSList *tramps, *l;
 	
 	if (mono_aot_only) {
@@ -391,7 +391,7 @@ mono_arch_exceptions_init (void)
 	} else {
 		tramps = mono_arm_get_exception_trampolines (FALSE);
 		for (l = tramps; l; l = l->next) {
-			MonoTrampInfo *info = l->data;
+			MonoTrampInfo *info = (MonoTrampInfo*)l->data;
 
 			mono_register_jit_icall (info->code, g_strdup (info->name), NULL, TRUE);
 			mono_tramp_info_register (info, NULL);
@@ -446,9 +446,9 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 			regs [MONO_MAX_IREGS + i] = *(guint64*)&(new_ctx->fregs [8 + i]);
 #endif
 
-		mono_unwind_frame (unwind_info, unwind_info_len, ji->code_start, 
+		mono_unwind_frame (unwind_info, unwind_info_len, (guint8*)ji->code_start,
 						   (guint8*)ji->code_start + ji->code_size,
-						   ip, NULL, regs, MONO_MAX_IREGS + 8,
+						   (guint8*)ip, NULL, regs, MONO_MAX_IREGS + 8,
 						   save_locations, MONO_MAX_IREGS, &cfa);
 
 		for (i = 0; i < 16; ++i)
@@ -499,7 +499,7 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 		/* we substract 1, so that the IP points into the call instruction */
 		new_ctx->pc--;
 
-		*lmf = (gpointer)(((gsize)(*lmf)->previous_lmf) & ~3);
+		*lmf = (MonoLMF*)(((gsize)(*lmf)->previous_lmf) & ~3);
 
 		return TRUE;
 	}
@@ -520,7 +520,7 @@ handle_signal_exception (gpointer obj)
 
 	memcpy (&ctx, &jit_tls->ex_ctx, sizeof (MonoContext));
 
-	mono_handle_exception (&ctx, obj);
+	mono_handle_exception (&ctx, (MonoObject*)obj);
 
 	mono_restore_context (&ctx);
 }
@@ -532,7 +532,7 @@ handle_signal_exception (gpointer obj)
 static MONO_NEVER_INLINE gpointer
 get_handle_signal_exception_addr (void)
 {
-	return handle_signal_exception;
+	return (gpointer)handle_signal_exception;
 }
 
 /*
@@ -544,7 +544,7 @@ mono_arch_handle_exception (void *ctx, gpointer obj)
 #if defined(MONO_CROSS_COMPILE) || !defined(MONO_ARCH_HAVE_SIGCTX_TO_MONOCTX)
 	g_assert_not_reached ();
 #elif defined(MONO_ARCH_USE_SIGACTION)
-	arm_ucontext *sigctx = ctx;
+	arm_ucontext *sigctx = (arm_ucontext*)ctx;
 	/*
 	 * Handling the exception in the signal handler is problematic, since the original
 	 * signal is disabled, and we could run arbitrary code though the debugger. So
@@ -594,7 +594,7 @@ mono_arch_ip_from_context (void *sigctx)
 #ifdef MONO_CROSS_COMPILE
 	g_assert_not_reached ();
 #else
-	arm_ucontext *my_uc = sigctx;
+	arm_ucontext *my_uc = (arm_ucontext*)sigctx;
 	return (void*) UCONTEXT_REG_PC (my_uc);
 #endif
 }
@@ -611,7 +611,7 @@ mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), g
 	sp -= 16;
 	MONO_CONTEXT_SET_SP (ctx, sp);
 
-	mono_arch_setup_resume_sighandler_ctx (ctx, async_cb);
+	mono_arch_setup_resume_sighandler_ctx (ctx, (gpointer)async_cb);
 }
 
 /*

--- a/mono/mini/mini-arm-gsharedvt.c
+++ b/mono/mini/mini-arm-gsharedvt.c
@@ -68,18 +68,18 @@ get_arg_slots (ArgInfo *ainfo, int **out_slots)
 	switch (ainfo->storage) {
 	case RegTypeGeneral:
 		nsrc = 1;
-		src = g_malloc (nsrc * sizeof (int));
+		src = (int*)g_malloc (nsrc * sizeof (int));
 		src [0] = map_reg (sreg);
 		break;
 	case RegTypeIRegPair:
 		nsrc = 2;
-		src = g_malloc (nsrc * sizeof (int));
+		src = (int*)g_malloc (nsrc * sizeof (int));
 		src [0] = map_reg (sreg);
 		src [1] = map_reg (sreg + 1);
 		break;
 	case RegTypeStructByVal:
 		nsrc = ainfo->struct_size / 4;
-		src = g_malloc (nsrc * sizeof (int));
+		src = (int*)g_malloc (nsrc * sizeof (int));
 		g_assert (ainfo->size <= nsrc);
 		for (i = 0; i < ainfo->size; ++i)
 			src [i] = map_reg (sreg + i);
@@ -88,13 +88,13 @@ get_arg_slots (ArgInfo *ainfo, int **out_slots)
 		break;
 	case RegTypeBase:
 		nsrc = ainfo->size / 4;
-		src = g_malloc (nsrc * sizeof (int));
+		src = (int*)g_malloc (nsrc * sizeof (int));
 		for (i = 0; i < nsrc; ++i)
 			src [i] = map_stack_slot (sslot + i);
 		break;
 	case RegTypeBaseGen:
 		nsrc = 2;
-		src = g_malloc (nsrc * sizeof (int));
+		src = (int*)g_malloc (nsrc * sizeof (int));
 		src [0] = map_reg (ARMREG_R3);
 		src [1] = map_stack_slot (sslot);
 		break;
@@ -265,7 +265,7 @@ mono_arch_get_gsharedvt_call_info (gpointer addr, MonoMethodSignature *normal_si
 		g_free (dst);
 	}
 
-	info = mono_domain_alloc0 (mono_domain_get (), sizeof (GSharedVtCallInfo) + (map->len * sizeof (int)));
+	info = (GSharedVtCallInfo*)mono_domain_alloc0 (mono_domain_get (), sizeof (GSharedVtCallInfo) + (map->len * sizeof (int)));
 	info->addr = addr;
 	info->stack_usage = callee_cinfo->stack_usage;
 	info->ret_marshal = GSHAREDVT_RET_NONE;

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -470,7 +470,7 @@ emit_float_args (MonoCompile *cfg, MonoCallInst *inst, guint8 *code, int *max_le
 	set_code_cursor (cfg, code);
 
 	for (list = inst->float_args; list; list = list->next) {
-		FloatArgData *fad = list->data;
+		FloatArgData *fad = (FloatArgData*)list->data;
 		MonoInst *var = get_vreg_to_inst (cfg, fad->vreg);
 		gboolean imm = arm_is_fpimm8 (var->inst_offset);
 
@@ -632,7 +632,7 @@ get_delegate_invoke_impl (MonoTrampInfo **info, gboolean has_target, gboolean pa
 	GSList *unwind_ops = mono_arch_get_cie_program ();
 
 	if (has_target) {
-		start = code = mono_global_codeman_reserve (12);
+		start = code = (guint8*)mono_global_codeman_reserve (12);
 
 		/* Replace the this argument with the target */
 		ARM_LDR_IMM (code, ARMREG_IP, ARMREG_R0, MONO_STRUCT_OFFSET (MonoDelegate, method_ptr));
@@ -647,7 +647,7 @@ get_delegate_invoke_impl (MonoTrampInfo **info, gboolean has_target, gboolean pa
 		int size, i;
 
 		size = 8 + param_count * 4;
-		start = code = mono_global_codeman_reserve (size);
+		start = code = (guint8*)mono_global_codeman_reserve (size);
 
 		ARM_LDR_IMM (code, ARMREG_IP, ARMREG_R0, MONO_STRUCT_OFFSET (MonoDelegate, method_ptr));
 		/* slide down the arguments */
@@ -719,10 +719,10 @@ mono_arch_get_delegate_invoke_impl (MonoMethodSignature *sig, gboolean has_targe
 		}
 
 		if (mono_ee_features.use_aot_trampolines) {
-			start = mono_aot_get_trampoline ("delegate_invoke_impl_has_target");
+			start = (guint8*)mono_aot_get_trampoline ("delegate_invoke_impl_has_target");
 		} else {
 			MonoTrampInfo *info;
-			start = get_delegate_invoke_impl (&info, TRUE, 0);
+			start = (guint8*)get_delegate_invoke_impl (&info, TRUE, 0);
 			mono_tramp_info_register (info, NULL);
 		}
 		cached = start;
@@ -747,11 +747,11 @@ mono_arch_get_delegate_invoke_impl (MonoMethodSignature *sig, gboolean has_targe
 
 		if (mono_ee_features.use_aot_trampolines) {
 			char *name = g_strdup_printf ("delegate_invoke_impl_target_%d", sig->param_count);
-			start = mono_aot_get_trampoline (name);
+			start = (guint8*)mono_aot_get_trampoline (name);
 			g_free (name);
 		} else {
 			MonoTrampInfo *info;
-			start = get_delegate_invoke_impl (&info, FALSE, sig->param_count);
+			start = (guint8*)get_delegate_invoke_impl (&info, FALSE, sig->param_count);
 			mono_tramp_info_register (info, NULL);
 		}
 		cache [sig->param_count] = start;
@@ -1283,9 +1283,9 @@ get_call_info (MonoMemPool *mp, MonoMethodSignature *sig)
 	gboolean vtype_retaddr = FALSE;
 
 	if (mp)
-		cinfo = mono_mempool_alloc0 (mp, sizeof (CallInfo) + (sizeof (ArgInfo) * n));
+		cinfo = (CallInfo*)mono_mempool_alloc0 (mp, sizeof (CallInfo) + (sizeof (ArgInfo) * n));
 	else
-		cinfo = g_malloc0 (sizeof (CallInfo) + (sizeof (ArgInfo) * n));
+		cinfo = (CallInfo*)g_malloc0 (sizeof (CallInfo) + (sizeof (ArgInfo) * n));
 
 	cinfo->nargs = n;
 	gr = ARMREG_R0;
@@ -1690,7 +1690,7 @@ mono_arch_set_native_call_context_args (CallContext *ccontext, gpointer frame, M
 
 	ccontext->stack_size = ALIGN_TO (cinfo->stack_usage, MONO_ARCH_FRAME_ALIGNMENT);
 	if (ccontext->stack_size)
-		ccontext->stack = calloc (1, ccontext->stack_size);
+		ccontext->stack = (guint8*)calloc (1, ccontext->stack_size);
 
 	if (sig->ret->type != MONO_TYPE_VOID) {
 		ainfo = &cinfo->ret;
@@ -2619,7 +2619,7 @@ mono_arch_emit_call (MonoCompile *cfg, MonoCallInst *call)
 				/* We use the dreg to look up the instruction later. The hreg is used to
 				 * emit the instruction that loads the value into the FP reg.
 				 */
-				fad = mono_mempool_alloc0 (cfg->mempool, sizeof (FloatArgData));
+				fad = (FloatArgData*)mono_mempool_alloc0 (cfg->mempool, sizeof (FloatArgData));
 				fad->vreg = float_arg->dreg;
 				fad->hreg = ainfo->reg;
 
@@ -2667,7 +2667,7 @@ mono_arch_emit_outarg_vt (MonoCompile *cfg, MonoInst *ins, MonoInst *src)
 {
 	MonoCallInst *call = (MonoCallInst*)ins->inst_p0;
 	MonoInst *load;
-	ArgInfo *ainfo = ins->inst_p1;
+	ArgInfo *ainfo = (ArgInfo*)ins->inst_p1;
 	int ovf_size = ainfo->vtsize;
 	int doffset = ainfo->offset;
 	int struct_size = ainfo->struct_size;
@@ -2703,7 +2703,7 @@ mono_arch_emit_outarg_vt (MonoCompile *cfg, MonoInst *ins, MonoInst *src)
 				float_arg->flags |= MONO_INST_VOLATILE;
 				MONO_EMIT_NEW_UNALU (cfg, OP_FMOVE, float_arg->dreg, load->dreg);
 
-				fad = mono_mempool_alloc0 (cfg->mempool, sizeof (FloatArgData));
+				fad = (FloatArgData*)mono_mempool_alloc0 (cfg->mempool, sizeof (FloatArgData));
 				fad->vreg = float_arg->dreg;
 				fad->hreg = ainfo->reg + i;
 
@@ -3045,7 +3045,7 @@ mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, g
 					int size;
 
 					size = mono_class_value_size (klass, NULL);
-					nullable_buf = g_alloca (size);
+					nullable_buf = (guint8*)g_alloca (size);
 					g_assert (nullable_buf);
 
 					/* The argument pointed to by arg is either a boxed vtype or null */
@@ -3164,7 +3164,7 @@ mono_arch_finish_dyn_call (MonoDynCallInfo *info, guint8 *buf)
 void*
 mono_arch_instrument_prolog (MonoCompile *cfg, void *func, void *p, gboolean enable_arguments)
 {
-	guchar *code = p;
+	guchar *code = (guchar*)p;
 
 	code = mono_arm_emit_load_imm (code, ARMREG_R0, (guint32)cfg->method);
 	ARM_MOV_REG_IMM8 (code, ARMREG_R1, 0); /* NULL ebp for now */
@@ -3185,7 +3185,7 @@ enum {
 void*
 mono_arch_instrument_epilog (MonoCompile *cfg, void *func, void *p, gboolean enable_arguments)
 {
-	guchar *code = p;
+	guchar *code = (guchar*)p;
 	int save_mode = SAVE_NONE;
 	MonoMethod *method = cfg->method;
 	MonoType *ret_type = mini_get_underlying_type (mono_method_signature (method)->ret);
@@ -3989,7 +3989,7 @@ handle_thunk (MonoCompile *cfg, MonoDomain *domain, guchar *code, const guchar *
 static void
 arm_patch_general (MonoCompile *cfg, MonoDomain *domain, guchar *code, const guchar *target)
 {
-	guint32 *code32 = (void*)code;
+	guint32 *code32 = (guint32*)code;
 	guint32 ins = *code32;
 	guint32 prim = (ins >> 25) & 7;
 	guint32 tval = GPOINTER_TO_UINT (target);
@@ -4252,7 +4252,7 @@ emit_move_return_value (MonoCompile *cfg, MonoInst *ins, guint8 *code)
 	MonoCallInst *call;
 
 	call = (MonoCallInst*)ins;
-	cinfo = call->call_info;
+	cinfo = (CallInfo*)call->call_info;
 
 	switch (cinfo->ret.storage) {
 	case RegTypeStructByVal:
@@ -5049,7 +5049,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			break;
 		case OP_AOTCONST:
 			/* Load the GOT offset */
-			mono_add_patch_info (cfg, offset, (MonoJumpInfoType)ins->inst_i1, ins->inst_p0);
+			mono_add_patch_info (cfg, offset, (MonoJumpInfoType)(gsize)ins->inst_i1, ins->inst_p0);
 			ARM_LDR_IMM (code, ins->dreg, ARMREG_PC, 0);
 			ARM_B (code, 0);
 			*(gpointer*)code = NULL;
@@ -6177,9 +6177,9 @@ void
 mono_arch_register_lowlevel_calls (void)
 {
 	/* The signature doesn't matter */
-	mono_register_jit_icall (mono_arm_throw_exception, "mono_arm_throw_exception", mono_create_icall_signature ("void"), TRUE);
-	mono_register_jit_icall (mono_arm_throw_exception_by_token, "mono_arm_throw_exception_by_token", mono_create_icall_signature ("void"), TRUE);
-	mono_register_jit_icall (mono_arm_unaligned_stack, "mono_arm_unaligned_stack", mono_create_icall_signature ("void"), TRUE);
+	mono_register_jit_icall ((gconstpointer)mono_arm_throw_exception, "mono_arm_throw_exception", mono_create_icall_signature ("void"), TRUE);
+	mono_register_jit_icall ((gconstpointer)mono_arm_throw_exception_by_token, "mono_arm_throw_exception_by_token", mono_create_icall_signature ("void"), TRUE);
+	mono_register_jit_icall ((gconstpointer)mono_arm_unaligned_stack, "mono_arm_unaligned_stack", mono_create_icall_signature ("void"), TRUE);
 }
 
 #define patch_lis_ori(ip,val) do {\
@@ -6245,7 +6245,7 @@ mono_arch_patch_code_new (MonoCompile *cfg, MonoDomain *domain, guint8 *code, Mo
 		/* everything is dealt with at epilog output time */
 		break;
 	default:
-		arm_patch_general (cfg, domain, ip, target);
+		arm_patch_general (cfg, domain, ip, (const guchar*)target);
 		break;
 	}
 }
@@ -6292,7 +6292,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 
 	sig = mono_method_signature (method);
 	cfg->code_size = 256 + sig->param_count * 64;
-	code = cfg->native_code = g_malloc (cfg->code_size);
+	code = cfg->native_code = (guint8*)g_malloc (cfg->code_size);
 
 	mono_emit_unwind_op_def_cfa (cfg, code, ARMREG_SP, 0);
 
@@ -6664,7 +6664,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 		code = emit_save_lmf (cfg, code, alloc_size - lmf_offset);
 
 	if (tracing)
-		code = mono_arch_instrument_prolog (cfg, mono_trace_enter_method, code, TRUE);
+		code = (guint8*)mono_arch_instrument_prolog (cfg, (void*)mono_trace_enter_method, code, TRUE);
 
 	if (cfg->arch.seq_point_info_var) {
 		MonoInst *ins = cfg->arch.seq_point_info_var;
@@ -6765,7 +6765,7 @@ mono_arch_emit_epilog (MonoCompile *cfg)
 	mono_emit_unwind_op_remember_state (cfg, code);
 
 	if (mono_jit_trace_calls != NULL && mono_trace_eval (method)) {
-		code = mono_arch_instrument_epilog (cfg, mono_trace_leave_method, code, TRUE);
+		code = (guint8*)mono_arch_instrument_epilog (cfg, (void*)mono_trace_leave_method, code, TRUE);
 	}
 	pos = 0;
 
@@ -6919,7 +6919,7 @@ mono_arch_emit_exceptions (MonoCompile *cfg)
 	 */
 	for (patch_info = cfg->patch_info; patch_info; patch_info = patch_info->next) {
 		if (patch_info->type == MONO_PATCH_INFO_EXC) {
-			i = mini_exception_id_by_name (patch_info->data.target);
+			i = mini_exception_id_by_name ((const char*)patch_info->data.target);
 			if (!exc_throw_found [i]) {
 				max_epilog_size += 32;
 				exc_throw_found [i] = TRUE;
@@ -6936,7 +6936,7 @@ mono_arch_emit_exceptions (MonoCompile *cfg)
 			MonoClass *exc_class;
 			unsigned char *ip = patch_info->ip.i + cfg->native_code;
 
-			i = mini_exception_id_by_name (patch_info->data.target);
+			i = mini_exception_id_by_name ((const char*)patch_info->data.target);
 			if (exc_throw_pos [i]) {
 				arm_patch (ip, exc_throw_pos [i]);
 				patch_info->type = MONO_PATCH_INFO_NONE;
@@ -7107,9 +7107,9 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTC
 		size += 4 * count; /* The ARM_ADD_REG_IMM to pop the stack */
 
 	if (fail_tramp)
-		code = mono_method_alloc_generic_virtual_trampoline (domain, size);
+		code = (arminstr_t*)mono_method_alloc_generic_virtual_trampoline (domain, size);
 	else
-		code = mono_domain_code_reserve (domain, size);
+		code = (arminstr_t*)mono_domain_code_reserve (domain, size);
 	start = code;
 
 	unwind_ops = mono_arch_get_cie_program ();
@@ -7329,14 +7329,14 @@ mono_arch_set_breakpoint (MonoJitInfo *ji, guint8 *ip)
 	MonoDebugOptions *opt = mini_get_debug_options ();
 
 	if (ji->from_aot) {
-		SeqPointInfo *info = mono_arch_get_seq_point_info (mono_domain_get (), ji->code_start);
+		SeqPointInfo *info = (SeqPointInfo*)mono_arch_get_seq_point_info (mono_domain_get (), (guint8*)ji->code_start);
 
 		if (!breakpoint_tramp)
 			breakpoint_tramp = mini_get_breakpoint_trampoline ();
 
 		g_assert (native_offset % 4 == 0);
 		g_assert (info->bp_addrs [native_offset / 4] == 0);
-		info->bp_addrs [native_offset / 4] = opt->soft_breakpoints ? breakpoint_tramp : bp_trigger_page;
+		info->bp_addrs [native_offset / 4] = (guint8*)(opt->soft_breakpoints ? breakpoint_tramp : bp_trigger_page);
 	} else if (opt->soft_breakpoints) {
 		code += 4;
 		ARM_BLX_REG (code, ARMREG_LR);
@@ -7378,13 +7378,13 @@ mono_arch_clear_breakpoint (MonoJitInfo *ji, guint8 *ip)
 
 	if (ji->from_aot) {
 		guint32 native_offset = ip - (guint8*)ji->code_start;
-		SeqPointInfo *info = mono_arch_get_seq_point_info (mono_domain_get (), ji->code_start);
+		SeqPointInfo *info = (SeqPointInfo*)mono_arch_get_seq_point_info (mono_domain_get (), (guint8*)ji->code_start);
 
 		if (!breakpoint_tramp)
 			breakpoint_tramp = mini_get_breakpoint_trampoline ();
 
 		g_assert (native_offset % 4 == 0);
-		g_assert (info->bp_addrs [native_offset / 4] == (opt->soft_breakpoints ? breakpoint_tramp : bp_trigger_page));
+		g_assert (info->bp_addrs [native_offset / 4] == (guint8*)(opt->soft_breakpoints ? breakpoint_tramp : bp_trigger_page));
 		info->bp_addrs [native_offset / 4] = 0;
 	} else if (opt->soft_breakpoints) {
 		code += 4;
@@ -7441,7 +7441,7 @@ mono_arch_stop_single_stepping (void)
 gboolean
 mono_arch_is_single_step_event (void *info, void *sigctx)
 {
-	siginfo_t *sinfo = info;
+	siginfo_t *sinfo = (siginfo_t*)info;
 
 	if (!ss_trigger_page)
 		return FALSE;
@@ -7461,7 +7461,7 @@ mono_arch_is_single_step_event (void *info, void *sigctx)
 gboolean
 mono_arch_is_breakpoint_event (void *info, void *sigctx)
 {
-	siginfo_t *sinfo = info;
+	siginfo_t *sinfo = (siginfo_t*)info;
 
 	if (!ss_trigger_page)
 		return FALSE;
@@ -7515,7 +7515,7 @@ mono_arch_get_seq_point_info (MonoDomain *domain, guint8 *code)
 	// FIXME: Add a free function
 
 	mono_domain_lock (domain);
-	info = g_hash_table_lookup (domain_jit_info (domain)->arch_seq_points, 
+	info = (SeqPointInfo*)g_hash_table_lookup (domain_jit_info (domain)->arch_seq_points,
 								code);
 	mono_domain_unlock (domain);
 
@@ -7523,7 +7523,7 @@ mono_arch_get_seq_point_info (MonoDomain *domain, guint8 *code)
 		ji = mono_jit_info_table_find (domain, code);
 		g_assert (ji);
 
-		info = g_malloc0 (sizeof (SeqPointInfo) + ji->code_size);
+		info = (SeqPointInfo*)g_malloc0 (sizeof (SeqPointInfo) + ji->code_size);
 
 		info->ss_trigger_page = ss_trigger_page;
 		info->bp_trigger_page = bp_trigger_page;
@@ -7627,7 +7627,7 @@ static G_GNUC_UNUSED guint8*
 emit_aotconst (MonoCompile *cfg, guint8 *code, int dreg, int patch_type, gpointer data)
 {
 	/* OP_AOTCONST */
-	mono_add_patch_info (cfg, code - cfg->native_code, patch_type, data);
+	mono_add_patch_info (cfg, code - cfg->native_code, (MonoJumpInfoType)patch_type, data);
 	ARM_LDR_IMM (code, dreg, ARMREG_PC, 0);
 	ARM_B (code, 0);
 	*(gpointer*)code = NULL;
@@ -7642,7 +7642,7 @@ mono_arm_emit_aotconst (gpointer ji_list, guint8 *code, guint8 *buf, int dreg, i
 {
 	MonoJumpInfo **ji = (MonoJumpInfo**)ji_list;
 
-	*ji = mono_patch_info_list_prepend (*ji, code - buf, patch_type, data);
+	*ji = mono_patch_info_list_prepend (*ji, code - buf, (MonoJumpInfoType)patch_type, data);
 	ARM_LDR_IMM (code, dreg, ARMREG_PC, 0);
 	ARM_B (code, 0);
 	*(gpointer*)code = NULL;

--- a/mono/mini/tramp-arm-gsharedvt.c
+++ b/mono/mini/tramp-arm-gsharedvt.c
@@ -69,7 +69,7 @@ mono_arm_start_gsharedvt_call (GSharedVtCallInfo *info, gpointer *caller, gpoint
 			int nslots = (src >> 8) & 0xff;
 			int src_slot = src & 0xff;
 			int j;
-			gpointer *addr = caller [src_slot];
+			gpointer *addr = (gpointer*)caller [src_slot];
 
 			for (j = 0; j < nslots; ++j)
 				callee [dst + j] = addr [j];
@@ -77,28 +77,28 @@ mono_arm_start_gsharedvt_call (GSharedVtCallInfo *info, gpointer *caller, gpoint
 		}
 		case GSHAREDVT_ARG_BYREF_TO_BYVAL_I1: {
 			int src_slot = src & 0xff;
-			gpointer *addr = caller [src_slot];
+			gpointer *addr = (gpointer*)caller [src_slot];
 
 			callee [dst] = GINT_TO_POINTER ((int)*(gint8*)addr);
 			break;
 		}
 		case GSHAREDVT_ARG_BYREF_TO_BYVAL_I2: {
 			int src_slot = src & 0xff;
-			gpointer *addr = caller [src_slot];
+			gpointer *addr = (gpointer*)caller [src_slot];
 
 			callee [dst] = GINT_TO_POINTER ((int)*(gint16*)addr);
 			break;
 		}
 		case GSHAREDVT_ARG_BYREF_TO_BYVAL_U1: {
 			int src_slot = src & 0xff;
-			gpointer *addr = caller [src_slot];
+			gpointer *addr = (gpointer*)caller [src_slot];
 
 			callee [dst] = GUINT_TO_POINTER ((guint)*(guint8*)addr);
 			break;
 		}
 		case GSHAREDVT_ARG_BYREF_TO_BYVAL_U2: {
 			int src_slot = src & 0xff;
-			gpointer *addr = caller [src_slot];
+			gpointer *addr = (gpointer*)caller [src_slot];
 
 			callee [dst] = GUINT_TO_POINTER ((guint)*(guint16*)addr);
 			break;
@@ -112,8 +112,8 @@ mono_arm_start_gsharedvt_call (GSharedVtCallInfo *info, gpointer *caller, gpoint
 	/* The slot based approach above is very complicated, use a nested switch instead for fp regs */
 	// FIXME: Use this for the other cases as well
 	if (info->have_fregs) {
-		CallInfo *caller_cinfo = info->caller_cinfo;
-		CallInfo *callee_cinfo = info->callee_cinfo;
+		CallInfo *caller_cinfo = (CallInfo*)info->caller_cinfo;
+		CallInfo *callee_cinfo = (CallInfo*)info->callee_cinfo;
 		int aindex;
 
 		for (aindex = 0; aindex < caller_cinfo->nargs; ++aindex) {
@@ -170,7 +170,7 @@ mono_arm_start_gsharedvt_call (GSharedVtCallInfo *info, gpointer *caller, gpoint
 	}
 
 	if (info->vcall_offset != -1) {
-		MonoObject *this_obj = caller [0];
+		MonoObject *this_obj = (MonoObject*)caller [0];
 
 		if (G_UNLIKELY (!this_obj))
 			return NULL;
@@ -202,7 +202,7 @@ mono_arch_get_gsharedvt_trampoline (MonoTrampInfo **info, gboolean aot)
 	int lr_offset, fp, br_ret_index, args_size;
 
 	buf_len = 784;
-	buf = code = mono_global_codeman_reserve (buf_len);
+	buf = code = (guint8*)mono_global_codeman_reserve (buf_len);
 
 	arg_reg = ARMREG_R0;
 	/* Registers pushed by the arg trampoline */
@@ -291,7 +291,7 @@ mono_arch_get_gsharedvt_trampoline (MonoTrampInfo **info, gboolean aot)
 	} else {
 		ARM_LDR_IMM (code, ARMREG_IP, ARMREG_PC, 0);
 		ARM_B (code, 0);
-		*(gpointer*)code = mono_arm_start_gsharedvt_call;
+		*(gpointer*)code = (gpointer)mono_arm_start_gsharedvt_call;
 		code += 4;
 	}
 	ARM_MOV_REG_REG (code, ARMREG_LR, ARMREG_PC);


### PR DESCRIPTION
Lots of casts
One type change (local variable guint8*  tramp to gpointer)
Rewrite one key macro (ARM_EMIT).
Note this done with Linux/gcc. Android/clang might be different/stricter.
