### PR TITLE
[2018-08] Remove extern "C" from MONO_LLVM_INTERNAL.

### DIFF
--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -89,7 +89,7 @@ typedef SSIZE_T ssize_t;
 
 #if !defined(_MSC_VER) && !defined(HOST_SOLARIS) && !defined(_WIN32) && !defined(__CYGWIN__) && !defined(MONOTOUCH) && HAVE_VISIBILITY_HIDDEN
 #if MONO_LLVM_LOADED
-#define MONO_LLVM_INTERNAL MONO_API
+#define MONO_LLVM_INTERNAL MONO_API_NO_EXTERN_C
 #else
 #define MONO_LLVM_INTERNAL
 #endif

--- a/mono/utils/mono-publib.h
+++ b/mono/utils/mono-publib.h
@@ -66,12 +66,14 @@ typedef unsigned __int64	uint64_t;
 #endif
 
 #if defined(MONO_DLL_EXPORT)
-	#define MONO_API MONO_EXTERN_C MONO_API_EXPORT
+	#define MONO_API_NO_EXTERN_C MONO_API_EXPORT
 #elif defined(MONO_DLL_IMPORT)
-	#define MONO_API MONO_EXTERN_C MONO_API_IMPORT
+	#define MONO_API_NO_EXTERN_C MONO_API_IMPORT
 #else
-	#define MONO_API MONO_EXTERN_C
+	#define MONO_API_NO_EXTERN_C /* nothing  */
 #endif
+
+#define MONO_API MONO_EXTERN_C MONO_API_NO_EXTERN_C
 
 // extern "C" extern int c; // warning: duplicate 'extern' declaration specifier [-Wduplicate-decl-specifier]
 //


### PR DESCRIPTION
Backport of #9939.

/cc @jaykrell