### PR TITLE
[2018-08] [cxx] One more MONO_API ahead of MONO_RT_EXTERNAL_ONLY.

### DIFF
--- a/mono/metadata/threads.h
+++ b/mono/metadata/threads.h
@@ -36,7 +36,7 @@ MONO_API MONO_RT_EXTERNAL_ONLY void mono_thread_stop (MonoThread *thread);
 MONO_API void mono_thread_new_init (intptr_t tid, void* stack_start,
 				  void* func);
 
-MONO_RT_EXTERNAL_ONLY MONO_API void
+MONO_API MONO_RT_EXTERNAL_ONLY void
 mono_thread_create (MonoDomain *domain, void* func, void* arg);
 
 MONO_API MonoThread *mono_thread_attach (MonoDomain *domain);


### PR DESCRIPTION
Backport of #9964.

/cc @jaykrell