### PR TITLE
[2018-08] [cxx] MONO_API before MONO_RT_EXTERNAL_ONLY per 58efe9419268250709a6694abfa519b9b5d2c05c.

### DIFF
--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -140,16 +140,16 @@ mono_type_get_underlying_type (MonoType *type);
 MONO_API MonoImage*
 mono_class_get_image         (MonoClass *klass);
 
-MONO_RT_EXTERNAL_ONLY
-MONO_API MonoClass*
+MONO_API MONO_RT_EXTERNAL_ONLY
+MonoClass*
 mono_class_get_element_class (MonoClass *klass);
 
-MONO_RT_EXTERNAL_ONLY
-MONO_API mono_bool
+MONO_API MONO_RT_EXTERNAL_ONLY
+mono_bool
 mono_class_is_valuetype      (MonoClass *klass);
 
-MONO_RT_EXTERNAL_ONLY
-MONO_API mono_bool
+MONO_API MONO_RT_EXTERNAL_ONLY
+mono_bool
 mono_class_is_enum          (MonoClass *klass);
 
 MONO_API MonoType*

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -325,8 +325,8 @@ mono_unhandled_exception    (MonoObject *exc);
 MONO_API void
 mono_print_unhandled_exception (MonoObject *exc);
 
-MONO_RT_EXTERNAL_ONLY
-MONO_API void* 
+MONO_API MONO_RT_EXTERNAL_ONLY
+void*
 mono_compile_method	   (MonoMethod *method);
 
 /* accessors for fields and properties */


### PR DESCRIPTION
Backport of #9884.

/cc @jaykrell