### PR TITLE
[metadata] Add nullfs to list of recognized filesystems

### DIFF
--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -4415,6 +4415,7 @@ static _wapi_drive_type _wapi_drive_types[] = {
 	{ DRIVE_CDROM, "cddafs" },
 	{ DRIVE_CDROM, "cd9660" },
 	{ DRIVE_RAMDISK, "devfs" },
+	{ DRIVE_RAMDISK, "nullfs" },
 	{ DRIVE_FIXED, "exfat" },
 	{ DRIVE_RAMDISK, "fdesc" },
 	{ DRIVE_REMOTE, "ftp" },
@@ -4512,6 +4513,7 @@ static _wapi_drive_type _wapi_drive_types[] = {
 	{ DRIVE_RAMDISK, "securityfs" },
 	{ DRIVE_RAMDISK, "procfs"     }, // AIX procfs
 	{ DRIVE_RAMDISK, "namefs"     }, // AIX soft mounts
+	{ DRIVE_RAMDISK, "nullfs"     },
 	{ DRIVE_CDROM,   "iso9660"    },
 	{ DRIVE_CDROM,   "cdrfs"      }, // AIX ISO9660 CDs
 	{ DRIVE_CDROM,   "udfs"       }, // AIX UDF CDs


### PR DESCRIPTION
Noticed this today when the corlib test which checks for unknown filesystems failed. Turned out it was because of a .dmg I had mounted:

```
$ mount | grep nullfs
/Volumes/Skype Meetings App/Skype Meetings App.app on /private/var/folders/cs/kt8x25p14g9dlk_p192rd7th0000gn/T/AppTranslocation/957CCB05-C113-4897-9C80-700C2CE4809E (nullfs, local, nodev, nosuid, read-only, noowners, quarantine, nobrowse, mounted by alexander)
```