### PR TITLE
[2018-08] [sdks] Use separate temporary dirs for llvm36/llvm.

### DIFF
--- a/llvm/build.mk
+++ b/llvm/build.mk
@@ -70,11 +70,11 @@ install-llvm: build-llvm | $(LLVM_PREFIX)
 # FIXME: URL should be http://xamjenkinsartifact.blob.core.windows.net/build-package-osx-llvm-$(NEEDED_LLVM_BRANCH)/llvm-osx64-$(NEEDED_LLVM_VERSION).tar.gz
 .PHONY: download-llvm
 download-llvm:
-	wget --no-verbose -O - http://xamjenkinsartifact.blob.core.windows.net/build-package-osx-llvm-release60/llvm-osx64-$(NEEDED_LLVM_VERSION).tar.gz | tar xzf -
+	mkdir -p llvm-tmp && cd llvm-tmp && wget --no-verbose -O - http://xamjenkinsartifact.blob.core.windows.net/build-package-osx-llvm-release60/llvm-osx64-$(NEEDED_LLVM_VERSION).tar.gz | tar xzf -
 
 .PHONY: download-llvm36
 download-llvm36:
-	wget --no-verbose -O - http://xamjenkinsartifact.blob.core.windows.net/build-package-osx-llvm/llvm-osx64-$(NEEDED_LLVM36_VERSION).tar.gz | tar xzf -
+	mkdir -p llvm36-tmp && cd llvm36-tmp && wget --no-verbose -O - http://xamjenkinsartifact.blob.core.windows.net/build-package-osx-llvm/llvm-osx64-$(NEEDED_LLVM36_VERSION).tar.gz | tar xzf -
 
 .PHONY: clean-llvm
 clean-llvm:

--- a/sdks/builds/llvm.mk
+++ b/sdks/builds/llvm.mk
@@ -6,8 +6,9 @@ $(dir $(LLVM_SRC)):
 .stamp-llvm-download: | setup-llvm-llvm32 setup-llvm-llvm64
 	$(MAKE) -C $(TOP)/llvm -f build.mk download-llvm
 	$(RM) -r $(TOP)/sdks/out/ios-llvm32 $(TOP)/sdks/out/ios-llvm64
-	mv $(TOP)/llvm/usr32 $(TOP)/sdks/out/ios-llvm32
-	mv $(TOP)/llvm/usr64 $(TOP)/sdks/out/ios-llvm64
+	mv $(TOP)/llvm/llvm-tmp/usr32 $(TOP)/sdks/out/ios-llvm32
+	mv $(TOP)/llvm/llvm-tmp/usr64 $(TOP)/sdks/out/ios-llvm64
+	rm -rf $(TOP)/llvm/llvm-tmp
 	touch $@
 
 LLVM36_SRC?=$(TOP)/sdks/builds/toolchains/llvm36
@@ -18,7 +19,9 @@ $(dir $(LLVM36_SRC)):
 .stamp-llvm36-download:
 	$(MAKE) -C $(TOP)/llvm -f build.mk download-llvm36
 	$(RM) -r $(TOP)/sdks/out/ios-llvm36-32
-	mv $(TOP)/llvm/usr32 $(TOP)/sdks/out/ios-llvm36-32
+	mv $(TOP)/llvm/llvm36-tmp/usr32 $(TOP)/sdks/out/ios-llvm36-32
+	cp $(TOP)/llvm/llvm36-tmp/usr64/bin/{llc,opt} $(TOP)/sdks/out/ios-llvm36-32/bin/
+	rm -rf $(TOP)/llvm/llvm36-tmp
 	touch $@
 
 ##


### PR DESCRIPTION
Backport of #9944.

/cc @vargaz