### PR TITLE
[sdb] Disable an assert to avoid breaking debugging.

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -4616,7 +4616,6 @@ ss_update (SingleStepReq *req, MonoJitInfo *ji, SeqPoint *sp, DebuggerTlsData *t
 			for (int i=0; i < tls->frame_count; i++)
 				g_printerr ("\t [%p] Frame (%d / %d): %s\n", (gpointer)(gsize)mono_native_thread_id_get (), i, tls->frame_count, mono_method_full_name (tls->frames [i]->de.method, TRUE));
 		}
-		g_assert (method_in_stack);
 
 		tls->context.valid = FALSE;
 		tls->async_state.valid = FALSE;


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/8848.
Fixes https://github.com/mono/mono/issues/9262.
Fixes https://github.com/mono/mono/issues/8627.

Backport of https://github.com/mono/mono/pull/9983.