### PR TITLE
Add default msbuild parameters so 'msbuild bcl.sln' will succeed

### DIFF
--- a/Directory.Build.rsp
+++ b/Directory.Build.rsp
@@ -1,0 +1,1 @@
+/p:Configuration=Debug /p:Platform="net_4_x" /restore


### PR DESCRIPTION
By default ```msbuild bcl.sln``` will fail because of our non-standard platform names and the need to restore nuget packages. Add a default response file so it just works. (Response files can be suppressed)