### PR TITLE
[corlib] Use .NET Core implementation for Math.Round

### DIFF
--- a/mcs/class/corlib/Test/System/MathTest.cs
+++ b/mcs/class/corlib/Test/System/MathTest.cs
@@ -856,11 +856,13 @@ namespace MonoTests.System
 		{
 			double a = 1.5D;
 			double b = 2.5D;
+			double c = 0.5000000000000001; // https://github.com/mono/mono/issues/9989
 
 			Assert.AreEqual (2D, Math.Round (a), "#1");
 			Assert.AreEqual (2D, Math.Round (b), "#2");
-			Assert.IsTrue (Double.MaxValue == Math.Round (Double.MaxValue), "#3");
-			Assert.IsTrue (Double.MinValue == Math.Round (Double.MinValue), "#4");
+			Assert.AreEqual (1D, Math.Round (c), "#3");
+			Assert.IsTrue (Double.MaxValue == Math.Round (Double.MaxValue), "#4");
+			Assert.IsTrue (Double.MinValue == Math.Round (Double.MinValue), "#5");
 		}
 
 		[Test]

--- a/mono/metadata/sysmath.c
+++ b/mono/metadata/sysmath.c
@@ -83,19 +83,17 @@ ves_icall_System_Math_Floor (gdouble x)
 gdouble
 ves_icall_System_Math_Round (gdouble x)
 {
-	gdouble tmp, floor_tmp;
+	gdouble floor_tmp;
 
 	/* If the number has no fractional part do nothing This shortcut is necessary
 	 * to workaround precision loss in borderline cases on some platforms */
 	if (x == (gdouble)(gint64) x)
 		return x;
 
-	tmp = x + 0.5;
-	floor_tmp = floor (tmp);
+	floor_tmp = floor (x + 0.5);
 
-	if (floor_tmp == tmp) {
-		if (fmod (tmp, 2.0) != 0)
-			floor_tmp -= 1.0;
+	if ((x == (floor (x) + 0.5)) && (fmod (floor_tmp, 2.0) != 0)) {
+		floor_tmp -= 1.0;
 	}
 
 	return copysign (floor_tmp, x);


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/9989
Replaces our implementation with https://github.com/dotnet/coreclr/blob/master/src/System.Private.CoreLib/shared/System/Math.cs#L676-L683

Additionally, I tried to import CoreFX tests for Math (~900 tests) but there are 18 failures for some edge cases - I'll try to replace the whole Math.cs with CoreFX's one as part of my CoreFX corlib PR.