### PR TITLE
[cxx] Cast function pointers to gpointer esp. for thread create.

### DIFF
--- a/mono/metadata/attach.c
+++ b/mono/metadata/attach.c
@@ -491,7 +491,7 @@ transport_start_receive (void)
 	if (!listen_fd)
 		return;
 
-	internal = mono_thread_create_internal (mono_get_root_domain (), receiver_thread, NULL, MONO_THREAD_CREATE_FLAGS_NONE, error);
+	internal = mono_thread_create_internal (mono_get_root_domain (), (gpointer)receiver_thread, NULL, MONO_THREAD_CREATE_FLAGS_NONE, error);
 	mono_error_assert_ok (error);
 
 	receiver_thread_handle = mono_threads_open_thread_handle (internal->handle);

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -956,7 +956,7 @@ void
 mono_gc_init_finalizer_thread (void)
 {
 	ERROR_DECL (error);
-	gc_thread = mono_thread_create_internal (mono_domain_get (), finalizer_thread, NULL, MONO_THREAD_CREATE_FLAGS_NONE, error);
+	gc_thread = mono_thread_create_internal (mono_domain_get (), (gpointer)finalizer_thread, NULL, MONO_THREAD_CREATE_FLAGS_NONE, error);
 	mono_error_assert_ok (error);
 }
 

--- a/mono/metadata/threadpool-io.c
+++ b/mono/metadata/threadpool-io.c
@@ -582,7 +582,7 @@ initialize (void)
 	io_selector_running = TRUE;
 
 	ERROR_DECL (error);
-	if (!mono_thread_create_internal (mono_get_root_domain (), selector_thread, NULL, MONO_THREAD_CREATE_FLAGS_THREADPOOL | MONO_THREAD_CREATE_FLAGS_SMALL_STACK, error))
+	if (!mono_thread_create_internal (mono_get_root_domain (), (gpointer)selector_thread, NULL, (MonoThreadCreateFlags)(MONO_THREAD_CREATE_FLAGS_THREADPOOL | MONO_THREAD_CREATE_FLAGS_SMALL_STACK), error))
 		g_error ("initialize: mono_thread_create_internal () failed due to %s", mono_error_get_message (error));
 
 	mono_coop_mutex_unlock (&threadpool_io->updates_lock);

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -11230,7 +11230,7 @@ compile_methods (MonoAotCompile *acfg)
 			user_data [0] = acfg;
 			user_data [1] = frag;
 			
-			thread = mono_thread_create_internal (mono_domain_get (), compile_thread_main, (gpointer) user_data, MONO_THREAD_CREATE_FLAGS_NONE, error);
+			thread = mono_thread_create_internal (mono_domain_get (), (gpointer)compile_thread_main, (gpointer) user_data, MONO_THREAD_CREATE_FLAGS_NONE, error);
 			mono_error_assert_ok (error);
 
 			thread_handle = mono_threads_open_thread_handle (thread->handle);

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -1615,7 +1615,7 @@ start_debugger_thread (void)
 	ERROR_DECL (error);
 	MonoInternalThread *thread;
 
-	thread = mono_thread_create_internal (mono_get_root_domain (), debugger_thread, NULL, MONO_THREAD_CREATE_FLAGS_DEBUGGER, error);
+	thread = mono_thread_create_internal (mono_get_root_domain (), (gpointer)debugger_thread, NULL, MONO_THREAD_CREATE_FLAGS_DEBUGGER, error);
 	mono_error_assert_ok (error);
 
 	debugger_thread_handle = mono_threads_open_thread_handle (thread->handle);

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -408,7 +408,7 @@ mini_regression_step (MonoImage *image, int verbose, int *total_run, int *total,
 #else
 					func = (TestMethod)(gpointer)cfg->native_code;
 #endif
-				func = (TestMethod)mono_create_ftnptr (mono_get_root_domain (), func);
+				func = (TestMethod)mono_create_ftnptr (mono_get_root_domain (), (gpointer)func);
 				result = func ();
 				if (result != expected) {
 					failed++;
@@ -1057,7 +1057,7 @@ jit_info_table_test (MonoDomain *domain)
 	*/
 
 	for (i = 0; i < num_threads; ++i) {
-		mono_thread_create_checked (domain, test_thread_func, &thread_datas [i], error);
+		mono_thread_create_checked (domain, (gpointer)test_thread_func, &thread_datas [i], error);
 		mono_error_assert_ok (error);
 	}
 }
@@ -1167,7 +1167,7 @@ compile_all_methods (MonoAssembly *ass, int verbose, guint32 opts, guint32 recom
 	 * Need to create a mono thread since compilation might trigger
 	 * running of managed code.
 	 */
-	mono_thread_create_checked (mono_domain_get (), compile_all_methods_thread_main, &args, error);
+	mono_thread_create_checked (mono_domain_get (), (gpointer)compile_all_methods_thread_main, &args, error);
 	mono_error_assert_ok (error);
 
 	mono_thread_manage ();

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -855,7 +855,7 @@ mono_runtime_setup_stat_profiler (void)
 	mono_atomic_store_i32 (&sampling_thread_running, 1);
 
 	MonoError error;
-	MonoInternalThread *thread = mono_thread_create_internal (mono_get_root_domain (), sampling_thread_func, NULL, MONO_THREAD_CREATE_FLAGS_NONE, &error);
+	MonoInternalThread *thread = mono_thread_create_internal (mono_get_root_domain (), (gpointer)sampling_thread_func, NULL, MONO_THREAD_CREATE_FLAGS_NONE, &error);
 	mono_error_assert_ok (&error);
 
 	sampling_thread = MONO_UINT_TO_NATIVE_THREAD_ID (thread->tid);

--- a/mono/sgen/sgen-thread-pool.c
+++ b/mono/sgen/sgen-thread-pool.c
@@ -285,7 +285,7 @@ sgen_thread_pool_start (void)
 	threadpool_shutdown = FALSE;
 
 	for (i = 0; i < threads_num; i++) {
-		mono_native_thread_create (&threads [i], thread_func, (void*)(gsize)i);
+		mono_native_thread_create (&threads [i], (gpointer)thread_func, (void*)(gsize)i);
 	}
 }
 


### PR DESCRIPTION
Longer term some functions accepting function pointers can/should take
a stronger type, and the parameters match w/o casting.
Also cast int to enum one same line.
One of these is under if 0.

Should fix the following:

attach.c:494:13: error: no matching function for call to 'mono_thread_create_internal'
        internal = mono_thread_create_internal (mono_get_root_domain (), receiver_thread, NULL, MONO_THREAD_CREATE_FLAGS_NONE, error);
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
../../mono/metadata/threads-types.h:82:1: note: candidate function not viable: no known conversion from 'gsize (void *)' (aka 'unsigned long (void *)') to 'gpointer' (aka 'void *') for 2nd argument
mono_thread_create_internal (MonoDomain *domain, gpointer func, gpointer arg, MonoThreadCreateFlags flags, MonoError *error);
^

threadpool-io.c:585:7: error: no matching function for call to 'mono_thread_create_internal'
        if (!mono_thread_create_internal (mono_get_root_domain (), selector_thread, NULL, MONO_THREAD_CREATE_FLAGS_THREADPOOL | MONO_THREAD_CREATE_FLAGS_SMALL_STACK, error))
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
../../mono/metadata/threads-types.h:82:1: note: candidate function not viable: no known conversion from 'gsize (gpointer)' (aka 'unsigned long (void *)') to 'gpointer' (aka 'void *') for 2nd argument
mono_thread_create_internal (MonoDomain *domain, gpointer func, gpointer arg, MonoThreadCreateFlags flags, MonoError *error);
^

gc.c:957:14: error: no matching function for call to 'mono_thread_create_internal'
        gc_thread = mono_thread_create_internal (mono_domain_get (), finalizer_thread, NULL, MONO_THREAD_CREATE_FLAGS_NONE, error);
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~
../../mono/metadata/threads-types.h:82:1: note: candidate function not viable: no known conversion from 'gsize (gpointer)' (aka 'unsigned long (void *)') to 'gpointer' (aka 'void *') for 2nd argument
mono_thread_create_internal (MonoDomain *domain, gpointer func, gpointer arg, MonoThreadCreateFlags flags, MonoError *error);
^

attach.c:494:13: error: no matching function for call to 'mono_thread_create_internal'
        internal = mono_thread_create_internal (mono_get_root_domain (), receiver_thread, NULL, MONO_THREAD_CREATE_FLAGS_NONE, error);
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
../../mono/metadata/threads-types.h:82:1: note: candidate function not viable: no known conversion from 'gsize (void *)' (aka 'unsigned long (void *)') to 'gpointer' (aka 'void *') for 2nd argument
mono_thread_create_internal (MonoDomain *domain, gpointer func, gpointer arg, MonoThreadCreateFlags flags, MonoError *error);
^

threadpool-io.c:585:7: error: no matching function for call to 'mono_thread_create_internal'
        if (!mono_thread_create_internal (mono_get_root_domain (), selector_thread, NULL, MONO_THREAD_CREATE_FLAGS_THREADPOOL | MONO_THREAD_CREATE_FLAGS_SMALL_STACK, error))
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
../../mono/metadata/threads-types.h:82:1: note: candidate function not viable: no known conversion from 'gsize (gpointer)' (aka 'unsigned long (void *)') to 'gpointer' (aka 'void *') for 2nd argument
mono_thread_create_internal (MonoDomain *domain, gpointer func, gpointer arg, MonoThreadCreateFlags flags, MonoError *error);
^

:411:24: error: no matching function for call to 'mono_create_ftnptr'
                                func = (TestMethod)mono_create_ftnptr (mono_get_root_domain (), func);
                                                   ^~~~~~~~~~~~~~~~~~
../../mono/mini/mini-runtime.h:432:11: note: candidate function not viable: no known conversion from 'TestMethod' (aka 'int (*)()') to 'gpointer' (aka 'void *') for 2nd argument; take the address of the argument with &
gpointer  mono_create_ftnptr                (MonoDomain *domain, gpointer addr);

driver.c:1170:2: error: no matching function for call to 'mono_thread_create_checked'
        mono_thread_create_checked (mono_domain_get (), compile_all_methods_thread_main, &args, error);
        ^~~~~~~~~~~~~~~~~~~~~~~~~~
../../mono/metadata/threads-types.h:441:1: note: candidate function not viable: no known conversion from 'void (CompileAllThreadArgs *)' to 'gpointer' (aka 'void *') for 2nd argument
mono_thread_create_checked (MonoDomain *domain, gpointer func, gpointer arg, MonoError *error);
^
