### PR TITLE
Add lock around SynchronizedCollection<T>.Add()

### DIFF
--- a/mcs/class/System.ServiceModel/System.Collections.Generic/SynchronizedCollection.cs
+++ b/mcs/class/System.ServiceModel/System.Collections.Generic/SynchronizedCollection.cs
@@ -105,7 +105,9 @@ namespace System.Collections.Generic
 
 		public void Add (T item)
 		{
-			InsertItem (list.Count, item);
+			lock (root) {
+				InsertItem (list.Count, item);
+			}
 		}
 
 		public void Clear ()


### PR DESCRIPTION
This fixes a possible ArgumentOutOfRange exception when `SynchronizedCollection<T>.Remove(T)` is called simultaneously with `SynchronizedCollection<T>.Add(T)`.

Previously reported in https://bugzilla.xamarin.com/show_bug.cgi?id=43447

Note that the `IList.Add(object)` implementation is locked and doesn't have this problem, so the following usage is effectively a workaround for this bug:

    var collection = new SynchronizedCollection<int>();
    //....
    ((IList)collection).Add(1);

