### PR TITLE
[w32file] Fix usage of copyfile

### DIFF
--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -16,9 +16,6 @@
 #endif
 #ifdef HAVE_COPYFILE_H
 #include <copyfile.h>
-#  if !defined(COPYFILE_CLONE)
-#    define COPYFILE_CLONE (1 << 24)
-#  endif
 #endif
 #if defined(HAVE_SYS_STATFS_H)
 #include <sys/statfs.h>
@@ -2421,7 +2418,7 @@ CopyFile (const gunichar2 *name, const gunichar2 *dest_name, gboolean fail_if_ex
 		}
 	}
 
-	ret = _wapi_copyfile (utf8_src, utf8_dest, NULL, COPYFILE_ALL | COPYFILE_CLONE | (fail_if_exists ? COPYFILE_EXCL : COPYFILE_UNLINK));
+	ret = _wapi_copyfile (utf8_src, utf8_dest, NULL, COPYFILE_ALL | COPYFILE_ACL | COPYFILE_STAT | COPYFILE_XATTR | (fail_if_exists ? COPYFILE_EXCL : COPYFILE_UNLINK));
 	g_free (utf8_src);
 	g_free (utf8_dest);
 	if (ret != 0) {


### PR DESCRIPTION
When passing COPYFILE_CLONE, copyfile will not follow a symbolic link on the src file. This is a problem since it breaks File.Copy assumption which, when passed a symbolic link, follows the symbolic link instead of copying the symbolic link itself. The bug is visible as soon as you use `<Copy />` with msbuild and you try to access the copied file with `<Touch />` for example