### PR TITLE
Don't Merge - Cleanup after an Exception to prevent major memory leak

### DIFF
--- a/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
@@ -160,7 +160,7 @@ namespace Mono.Btls
 			}
 		}
 
-		static Exception GetException (MonoBtlsSslError status)
+               private Exception GetException (MonoBtlsSslError status)
 		{
 			string file;
 			int line;
@@ -179,6 +179,7 @@ namespace Mono.Btls
 				message = string.Format ("{0} {1}\n  at {2}:{3}", status, text, file, line);
 			else
 				message = string.Format ("{0} {1}", status, text);
+                       Dispose (true);
 			return new MonoBtlsException (message);
 		}
 

--- a/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
+++ b/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
@@ -393,8 +393,8 @@ namespace Mono.Net.Security
 			}
 
                        if (result.Error != null) {
-                               readBuffer = null;
-                               writeBuffer = null;
+				readBuffer = null;
+				writeBuffer = null;
 				result.Error.Throw ();
                        }
 		}

--- a/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
+++ b/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
@@ -392,8 +392,11 @@ namespace Mono.Net.Security
 				}
 			}
 
-			if (result.Error != null)
+                       if (result.Error != null) {
+                               readBuffer = null;
+                               writeBuffer = null;
 				result.Error.Throw ();
+                       }
 		}
 
 		protected abstract MobileTlsContext CreateContext (MonoSslAuthenticationOptions options);


### PR DESCRIPTION
This is an attempt to fix #8689. When an exception happens during the WebRequest there is no response generated but GetException is called in MonoBtlsContext to gather the stacktrace etc. That is formed into a message that is used to throw an exception. However, the stacktrace artifacts etc are left hanging around. Very quickly, using the test case shown in the #8689 issue memory use grows substantially. In addition the read and write buffers used by MobileAuthenicatedSteam are left hanging around as well. This patch will, when an exception is thrown, clean up these artifacts by disposing of things like MonoBtlsSsl, MonoBtlsSslCtx, MonoBtlsBio ... I'm not comfortable with use of Dispose() to do the cleanup but the Close methods of Ssl etc are protected so can't be performed in the same place as the Dispose().

Also, the size of the read and write buffers are 16834 and 16384 which seems like a transposition error for the 16834 case. 

I also wonder that even for successful HttpWebRequests and responses whether some cleanup is required when KeepAlive property is not set otherwise those same artifacts will stay alive (but because we don't have lots of stacktraces) the growth in memory footprint is not as extensive. For connections that are kept alive the Close() method should probably do the same cleanup.

This is a first pass effort designed to generate discussion on the issue which has become critical for a project we are looking to get into production.