### PR TITLE
Use clonefile instead of copyfile on macOS.

### DIFF
--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -2338,28 +2338,25 @@ write_file (gint src_fd, gint dest_fd, struct stat *st_src, gboolean report_erro
 static int
 _wapi_clonefile(const char *from, const char *to, int flags)
 {
-	if (clonefile_ptr != NULL) {
-		gchar *located_from, *located_to;
-		int ret;
+	gchar *located_from, *located_to;
+	int ret;
 
-		located_from = mono_portability_find_file (from, FALSE);
-		located_to = mono_portability_find_file (to, FALSE);
+	g_assert (clonefile_ptr != NULL);
 
-		MONO_ENTER_GC_SAFE;
-		ret = clonefile_ptr (
-			located_from == NULL ? from : located_from,
-			located_to == NULL ? to : located_to,
-			flags);
-		MONO_EXIT_GC_SAFE;
+	located_from = mono_portability_find_file (from, FALSE);
+	located_to = mono_portability_find_file (to, FALSE);
 
-		g_free (located_from);
-		g_free (located_to);
+	MONO_ENTER_GC_SAFE;
+	ret = clonefile_ptr (
+		located_from == NULL ? from : located_from,
+		located_to == NULL ? to : located_to,
+		flags);
+	MONO_EXIT_GC_SAFE;
 
-		return ret;
-	} else {
-		errno = ENOTSUP;
-		return -1;
-	}
+	g_free (located_from);
+	g_free (located_to);
+
+	return ret;
 }
 #endif
 

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -4913,7 +4913,7 @@ mono_w32file_init (void)
 #if HOST_DARWIN
 	libc_handle = dlopen ("/usr/lib/libc.dylib", 0);
 	g_assert (libc_handle);
-	clonefile_ptr = (clonefile_fn)dlsym (RTLD_DEFAULT, "clonefile");
+	clonefile_ptr = (clonefile_fn)dlsym (libc_handle, "clonefile");
 #endif
 
 	if (g_hasenv ("MONO_STRICT_IO_EMULATION"))


### PR DESCRIPTION
Alternative to #10008.

Note that `copyfile` is completely user-mode API implemented in `/usr/lib/system/libcopyfile.dylib`. As you can see in the [source code](https://opensource.apple.com/source/copyfile/copyfile-146.30.2/copyfile.c.auto.html) in the `copyfile_data` method it does exactly the same read+write loop as Mono and offers no performance benefits by itself.

Someone in Apple decided to break the `copyfile` API in macOS 10.13.2 by cloning simlinks instead of targets despite the fact that passed in flags do not include `COPYFILE_NOFOLLOW_SRC`. The reason for the change is also completely bogus - we don't support copying directories, so let's not follow symlinks because they could point to directories. Well, just before calling `clonefile` they check if the source is a link, so they could have skipped cloning symlinks instead.

Since the broken `copyfile` is apparently in the wild already the only way to fix it is to drop using it for cloning. And since cloning was the only performance benefit of the API it makes sense to drop its usage entirely.