### PR TITLE
[ci] Disable sgen-new-threads-collect.exe until #9959 is addressed

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1493,6 +1493,9 @@ CI_DISABLED_TESTS = \
 CI_PR_DISABLED_TESTS = \
 	appdomain-threadpool-unload.exe
 
+# FIXME Hybrid Suspend - see https://github.com/mono/mono/issues/9959
+CI_PR_DISABLED_TESTS += sgen-new-threads-collect.exe
+
 # appdomain-threadpool-unload.exe creates 100 appdomains, takes too long with llvm
 LLVM_DISABLED_TESTS = \
 	finally_block_ending_in_dead_bb.exe \


### PR DESCRIPTION
The test times out due to an issue in hyrbid suspend.  Turn off the test
temporarily while we work on a solution.

https://github.com/mono/mono/issues/9959
https://github.com/mono/mono/issues/9921


