### PR TITLE
[cxx] Fixes for Centos6/g++4.4/Android -- designated initializers, typeof, stdint, configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1046,7 +1046,8 @@ if test "x$enable_cxx" = "xyes"; then
 
 	# FIXME Centos6 requires a different flag for prerelease C++11.
 	#CXX_ADD_CFLAGS=' -xc++ -std=gnu++98 -fno-exceptions -fno-rtti '
-	CXX_ADD_CFLAGS=' -xc++ -std=gnu++11 -fno-exceptions -fno-rtti '
+	CXX_ADD_CFLAGS=' -xc++ -std=gnu++0x -fno-exceptions -fno-rtti '
+	# "c++0x" instead of C++11, for compat with Centos6/gcc4.4
 
 	# -std=gnu99 -xc++ is not allowed and errors.
 	CXX_REMOVE_CFLAGS=-std=gnu99

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -424,7 +424,7 @@ MONO_HANDLE_TYPECHECK_FOR (TYPE) (TYPE *a)			\
 typedef struct _MonoTypeofCastHelper *MonoTypeofCastHelper; // a pointer type unrelated to anything else
 #define MONO_TYPEOF_CAST(typeexpr, expr) __pragma(warning(suppress:4133))(0 ? (typeexpr) : (MonoTypeofCastHelper)(expr))
 #else
-#define MONO_TYPEOF_CAST(typeexpr, expr) ((typeof (typeexpr))(expr))
+#define MONO_TYPEOF_CAST(typeexpr, expr) ((__typeof__ (typeexpr))(expr))
 #endif
 
 #if MONO_TYPE_SAFE_HANDLES

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -2599,7 +2599,11 @@ mono_marshal_get_runtime_invoke_full (MonoMethod *method, gboolean virtual_, gbo
 	const char *param_names [16];
 	WrapperInfo *info;
 	MonoWrapperMethodCacheKey *method_key;
-	MonoWrapperMethodCacheKey method_key_lookup_only = { .method = method, .virtual_ = virtual_, .need_direct_wrapper = need_direct_wrapper };
+	MonoWrapperMethodCacheKey method_key_lookup_only;
+	memset (&method_key_lookup_only, 0, sizeof (method_key_lookup_only));
+	method_key_lookup_only.method = method;
+	method_key_lookup_only.virtual_ = virtual_;
+	method_key_lookup_only.need_direct_wrapper = need_direct_wrapper;
 	method_key = &method_key_lookup_only;
 
 	g_assert (method);
@@ -2652,7 +2656,10 @@ mono_marshal_get_runtime_invoke_full (MonoMethod *method, gboolean virtual_, gbo
 		MonoMethodSignature *tmp_sig;
 
 		callsig = mono_marshal_get_runtime_invoke_sig (callsig);
-		MonoWrapperSignatureCacheKey sig_key = { .signature = callsig, .valuetype = m_class_is_valuetype (method->klass)};
+		MonoWrapperSignatureCacheKey sig_key;
+		memset (&sig_key, 0, sizeof (sig_key));
+		sig_key.signature = callsig;
+		sig_key.valuetype = m_class_is_valuetype (method->klass);
 
 		cache_table = &mono_method_get_wrapper_cache (method)->runtime_invoke_signature_cache;
 		sig_cache = get_cache (cache_table, (GHashFunc) wrapper_cache_signature_key_hash, (GCompareFunc) wrapper_cache_signature_key_equal);

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -402,7 +402,7 @@ static const struct msgstr_t {
 #undef PATCH_INFO
 };
 static const gint16 opidx [] = {
-#define PATCH_INFO(a,b) [MONO_PATCH_INFO_ ## a] = offsetof (struct msgstr_t, MSGSTRFIELD(__LINE__)),
+#define PATCH_INFO(a,b) offsetof (struct msgstr_t, MSGSTRFIELD(__LINE__)),
 #include "patch-info.h"
 #undef PATCH_INFO
 };

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -6723,12 +6723,12 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 		res_domains = g_ptr_array_new ();
 
 		mono_loader_lock ();
-		GetTypesForSourceFileArgs args = {
-			.ignore_case = ignore_case,
-			.basename = basename,
-			.res_classes  = res_classes,
-			.res_domains = res_domains
-		};
+		GetTypesForSourceFileArgs args;
+		memset (&args, 0, sizeof (args));
+		args.ignore_case = ignore_case;
+		args.basename = basename;
+		args.res_classes  = res_classes;
+		args.res_domains = res_domains;
 		mono_de_foreach_domain (get_types_for_source_file, &args);
 		mono_loader_unlock ();
 
@@ -6765,12 +6765,12 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 
 		mono_loader_lock ();
 
-		GetTypesArgs args = {
-			.info = &info,
-			.ignore_case = ignore_case,
-			.res_classes = res_classes,
-			.res_domains = res_domains
-		};
+		GetTypesArgs args;
+		memset (&args, 0, sizeof (args));
+		args.info = &info;
+		args.ignore_case = ignore_case;
+		args.res_classes = res_classes;
+		args.res_domains = res_domains;
 
 		mono_de_foreach_domain (get_types, &args);
 

--- a/mono/mini/debugger-engine.c
+++ b/mono/mini/debugger-engine.c
@@ -459,12 +459,12 @@ mono_de_set_breakpoint (MonoMethod *method, long il_offset, EventRequest *req, M
 
 	mono_loader_lock ();
 
-	CollectDomainData user_data = {
-		.bp = bp,
-		.methods = methods,
-		.method_domains = method_domains,
-		.method_seq_points = method_seq_points
-	};
+	CollectDomainData user_data;
+	memset (&user_data, 0, sizeof (user_data));
+	user_data.bp = bp;
+	user_data.methods = methods;
+	user_data.method_domains = method_domains;
+	user_data.method_seq_points = method_seq_points;
 	mono_de_foreach_domain (collect_domain_bp, &user_data);
 
 	for (i = 0; i < methods->len; ++i) {

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -102,7 +102,7 @@ static const struct msgstr_t {
 #undef OPTFLAG
 };
 static const gint16 opt_names [] = {
-#define OPTFLAG(id,shift,name,desc) [(shift)] = offsetof (struct msgstr_t, MSGSTRFIELD(__LINE__)),
+#define OPTFLAG(id,shift,name,desc) offsetof (struct msgstr_t, MSGSTRFIELD(__LINE__)),
 #include "optflags-def.h"
 #undef OPTFLAG
 };

--- a/mono/mini/helpers.c
+++ b/mono/mini/helpers.c
@@ -43,8 +43,8 @@ static const struct msgstr_t {
 #undef MINI_OP3
 };
 static const gint16 opidx [] = {
-#define MINI_OP(a,b,dest,src1,src2) [a - OP_LOAD] = offsetof (struct msgstr_t, MSGSTRFIELD(__LINE__)),
-#define MINI_OP3(a,b,dest,src1,src2,src3) [a - OP_LOAD] = offsetof (struct msgstr_t, MSGSTRFIELD(__LINE__)),
+#define MINI_OP(a,b,dest,src1,src2)       offsetof (struct msgstr_t, MSGSTRFIELD(__LINE__)),
+#define MINI_OP3(a,b,dest,src1,src2,src3) offsetof (struct msgstr_t, MSGSTRFIELD(__LINE__)),
 #include "mini-ops.h"
 #undef MINI_OP
 #undef MINI_OP3

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -710,7 +710,9 @@ sampling_thread_func (gpointer unused)
 	 * to do our work, the kernel may knock us back down to the normal thread
 	 * scheduling policy without telling us.
 	 */
-	struct sched_param sched = { .sched_priority = sched_get_priority_max (SCHED_FIFO) };
+	struct sched_param sched;
+	memset (&sched, 0, sizeof (sched));
+	sched.sched_priority = sched_get_priority_max (SCHED_FIFO);
 	pthread_setschedparam (pthread_self (), SCHED_FIFO, &sched);
 
 	MonoProfilerSampleMode mode;

--- a/mono/mini/optflags-def.h
+++ b/mono/mini/optflags-def.h
@@ -1,3 +1,5 @@
+// This file must be sorted based on the second column.
+// i.e. so that designated initializers are not required.
 OPTFLAG(PEEPHOLE ,0, "peephole",   "Peephole postpass")
 OPTFLAG(BRANCH   ,1, "branch",     "Branch optimizations")
 OPTFLAG(INLINE   ,2, "inline",     "Inline method calls")


### PR DESCRIPTION
 - No designated initializers.
 - stdint.h is there and featureful but needs to be convinced.
 - g++ has -std=gnu++0x, not gnu++11. Newer gcc/clang appears to honor it.
 - __typeof__ instead of typeof.