### PR TITLE
[cxx] wasm-specific fixes --casts, goto-around-init, marshaling, externC

### DIFF
--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -322,7 +322,8 @@ mono_gc_run_finalize (void *obj, void *data)
 	MONO_PROFILER_RAISE (gc_finalizing_object, (o));
 
 #ifdef HOST_WASM
-	gpointer params[] = { NULL };
+	gpointer params [1];
+	params [0] = NULL;
 	mono_runtime_try_invoke (finalizer, o, params, &exc, error);
 #else
 	runtime_invoke (o, NULL, &exc, NULL);

--- a/mono/mini/exceptions-wasm.c
+++ b/mono/mini/exceptions-wasm.c
@@ -54,7 +54,7 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 {
 	if (info)
 		*info = mono_tramp_info_create ("call_filter", (guint8*)wasm_call_filter, 1, NULL, NULL);
-	return wasm_call_filter;
+	return (gpointer)wasm_call_filter;
 }
 
 gpointer
@@ -62,14 +62,14 @@ mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 {
 	if (info)
 		*info = mono_tramp_info_create ("restore_context", (guint8*)wasm_restore_context, 1, NULL, NULL);
-	return wasm_restore_context;
+	return (gpointer)wasm_restore_context;
 }
 gpointer 
 mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 {
 	if (info)
 		*info = mono_tramp_info_create ("throw_corlib_exception", (guint8*)wasm_throw_corlib_exception, 1, NULL, NULL);
-	return wasm_throw_corlib_exception;
+	return (gpointer)wasm_throw_corlib_exception;
 }
 
 gpointer
@@ -77,7 +77,7 @@ mono_arch_get_rethrow_exception (MonoTrampInfo **info, gboolean aot)
 {
 	if (info)
 		*info = mono_tramp_info_create ("rethrow_exception", (guint8*)wasm_rethrow_exception, 1, NULL, NULL);
-	return wasm_rethrow_exception;
+	return (gpointer)wasm_rethrow_exception;
 }
 
 gpointer
@@ -85,7 +85,7 @@ mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 {
 	if (info)
 		*info = mono_tramp_info_create ("throw_exception", (guint8*)wasm_throw_exception, 1, NULL, NULL);
-	return wasm_throw_exception;
+	return (gpointer)wasm_throw_exception;
 }
 
 void

--- a/mono/mini/m2n-gen.cs
+++ b/mono/mini/m2n-gen.cs
@@ -98,7 +98,7 @@ class Driver {
 			Console.WriteLine ("{");
 
 			
-			Console.Write ($"\t{TypeToSigType (c [0])} (*func)(");
+			Console.Write ($"\ttypedef {TypeToSigType (c [0])} (*T)(");
 			for (int i = 1; i < c.Length; ++i) {
 				char p = c [i];
 				if (i > 1)
@@ -108,7 +108,7 @@ class Driver {
 			if (c.Length == 1)
 				Console.Write ("void");
 
-			Console.WriteLine (") = target_func;\n");
+			Console.WriteLine (");\n\tT func = (T)target_func;");
 
 			var ctx = new EmitCtx ();
 

--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -113,7 +113,7 @@ free_frame_state (void)
 	if (frames) {
 		int i;
 		for (i = 0; i < frames->len; ++i)
-			free_frame (g_ptr_array_index (frames, i));
+			free_frame ((DbgEngineStackFrame*)g_ptr_array_index (frames, i));
 		g_ptr_array_set_size (frames, 0);
 	}	
 }
@@ -123,7 +123,7 @@ compute_frames (void) {
 	if (frames) {
 		int i;
 		for (i = 0; i < frames->len; ++i)
-			free_frame (g_ptr_array_index (frames, i));
+			free_frame ((DbgEngineStackFrame*)g_ptr_array_index (frames, i));
 		g_ptr_array_set_size (frames, 0);
 	} else {
 		frames = g_ptr_array_new ();
@@ -221,7 +221,7 @@ create_breakpoint_events (GPtrArray *ss_reqs, GPtrArray *bp_reqs, MonoJitInfo *j
 static void
 process_breakpoint_events (void *_evts, MonoMethod *method, MonoContext *ctx, int il_offsets)
 {
-	BpEvents *evts = _evts;
+	BpEvents *evts = (BpEvents*)_evts;
 	if (evts) {
 		if (evts->is_ss)
 			mono_de_cancel_ss ();
@@ -256,7 +256,7 @@ ss_create_init_args (SingleStepReq *ss_req, SingleStepArgs *ss_args)
 		return DBG_NOT_SUSPENDED;
 	}
 
-	DbgEngineStackFrame *frame = g_ptr_array_index (frames, 0);
+	DbgEngineStackFrame *frame = (DbgEngineStackFrame*)g_ptr_array_index (frames, 0);
 	ss_req->start_method = ss_args->method = frame->method;
 	gboolean found_sp = mono_find_prev_seq_point_for_native_offset (frame->domain, frame->method, frame->native_offset, &ss_args->info, &ss_args->sp);
 	if (!found_sp)
@@ -465,9 +465,9 @@ mono_wasm_current_bp_id (void)
 	MonoLMFExt *ext = (MonoLMFExt*)lmf;
 
 	g_assert (ext->interp_exit);
-	MonoInterpFrameHandle *frame = ext->interp_exit_data;
+	MonoInterpFrameHandle *frame = (MonoInterpFrameHandle*)ext->interp_exit_data;
 	MonoJitInfo *ji = mini_get_interp_callbacks ()->frame_get_jit_info (frame);
-	guint8 *ip = mini_get_interp_callbacks ()->frame_get_ip (frame);
+	guint8 *ip = (guint8*)mini_get_interp_callbacks ()->frame_get_ip (frame);
 
 	g_assert (ji && !ji->is_trampoline);
 	MonoMethod *method = jinfo_get_method (ji);
@@ -558,7 +558,7 @@ describe_variable (MonoStackFrameInfo *info, MonoContext *ctx, gpointer ud)
 	ERROR_DECL (error);
 	MonoMethodHeader *header = NULL;
 
-	FrameDescData *data = ud;
+	FrameDescData *data = (FrameDescData*)ud;
 
 	//skip wrappers
 	if (info->type != FRAME_TYPE_MANAGED && info->type != FRAME_TYPE_INTERP) {
@@ -570,7 +570,7 @@ describe_variable (MonoStackFrameInfo *info, MonoContext *ctx, gpointer ud)
 		return FALSE;
 	}
 
-	InterpFrame *frame = info->interp_frame;
+	InterpFrame *frame = (InterpFrame*)info->interp_frame;
 	g_assert (frame);
 	MonoMethod *method = frame->imethod->method;
 	g_assert (method);

--- a/mono/mini/mini-wasm.c
+++ b/mono/mini/mini-wasm.c
@@ -210,7 +210,7 @@ mono_wasm_set_timeout (int timeout, int id)
 void
 mono_arch_register_icall (void)
 {
-	mono_add_internal_call ("System.Threading.WasmRuntime::SetTimeout", mono_wasm_set_timeout);
+	mono_add_internal_call ("System.Threading.WasmRuntime::SetTimeout", (gconstpointer)mono_wasm_set_timeout);
 }
 
 void

--- a/mono/mini/mini-wasm.c
+++ b/mono/mini/mini-wasm.c
@@ -267,15 +267,20 @@ pthread_setschedparam(pthread_t thread, int policy, const struct sched_param *pa
 	return 0;
 }
 
+#ifdef __cplusplus
+#define MONO_RESTRICT /* nothing */
+#else
+#define MONO_RESTRICT restrict
+#endif
 
 int
-pthread_attr_getstacksize (const pthread_attr_t *restrict attr, size_t *restrict stacksize)
+pthread_attr_getstacksize (const pthread_attr_t *MONO_RESTRICT attr, size_t *MONO_RESTRICT stacksize)
 {
 	return 65536; //wasm page size
 }
 
 int
-pthread_sigmask (int how, const sigset_t * restrict set, sigset_t * restrict oset)
+pthread_sigmask (int how, const sigset_t * MONO_RESTRICT set, sigset_t * MONO_RESTRICT oset)
 {
 	return 0;
 }

--- a/mono/mini/mini-wasm.h
+++ b/mono/mini/mini-wasm.h
@@ -54,7 +54,9 @@ typedef struct {
 
 void mono_wasm_debugger_init (void);
 
+G_BEGIN_DECLS
 void mono_wasm_enable_debugging (void);
+G_END_DECLS
 void mono_wasm_breakpoint_hit (void);
 void mono_wasm_set_timeout (int timeout, int id);
 

--- a/mono/mini/tramp-wasm.c
+++ b/mono/mini/tramp-wasm.c
@@ -53,7 +53,7 @@ mono_arch_get_interp_to_native_trampoline (MonoTrampInfo **info)
 {
 	if (info)
 		*info = mono_tramp_info_create ("interp_to_native_trampoline", (guint8*)mono_wasm_interp_to_native_trampoline, 1, NULL, NULL);
-	return mono_wasm_interp_to_native_trampoline;
+	return (gpointer)mono_wasm_interp_to_native_trampoline;
 }
 
 guint8*
@@ -61,13 +61,13 @@ mono_arch_create_sdb_trampoline (gboolean single_step, MonoTrampInfo **info, gbo
 {
 	g_assert (!aot);
 	const char *name;
-	gpointer code;
+	guint8* code;
 	if (single_step) {
 		name = "sdb_single_step_trampoline";
-		code = mono_wasm_single_step_hit;
+		code = (guint8*)mono_wasm_single_step_hit;
 	} else {
 		name = "sdb_breakpoint_trampoline";
-		code = mono_wasm_breakpoint_hit;
+		code = (guint8*)mono_wasm_breakpoint_hit;
 	}
 
 	if (info)

--- a/mono/mini/wasm_m2n_invoke.g.h
+++ b/mono/mini/wasm_m2n_invoke.g.h
@@ -5,8 +5,8 @@
 static void
 wasm_invoke_v (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(void) = target_func;
-
+	typedef void (*T)(void);
+	T func = (T)target_func;
 	func ();
 
 }
@@ -14,8 +14,8 @@ wasm_invoke_v (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_vi (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0) = target_func;
-
+	typedef void (*T)(int arg_0);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0]);
 
 }
@@ -23,8 +23,8 @@ wasm_invoke_vi (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_vii (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, int arg_1) = target_func;
-
+	typedef void (*T)(int arg_0, int arg_1);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], (int)margs->iargs [1]);
 
 }
@@ -32,8 +32,8 @@ wasm_invoke_vii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_viii (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, int arg_1, int arg_2) = target_func;
-
+	typedef void (*T)(int arg_0, int arg_1, int arg_2);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], (int)margs->iargs [1], (int)margs->iargs [2]);
 
 }
@@ -41,8 +41,8 @@ wasm_invoke_viii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_viiii (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, int arg_1, int arg_2, int arg_3) = target_func;
-
+	typedef void (*T)(int arg_0, int arg_1, int arg_2, int arg_3);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], (int)margs->iargs [1], (int)margs->iargs [2], (int)margs->iargs [3]);
 
 }
@@ -50,8 +50,8 @@ wasm_invoke_viiii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_viiiii (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4) = target_func;
-
+	typedef void (*T)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], (int)margs->iargs [1], (int)margs->iargs [2], (int)margs->iargs [3], (int)margs->iargs [4]);
 
 }
@@ -59,8 +59,8 @@ wasm_invoke_viiiii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_viiiiii (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4, int arg_5) = target_func;
-
+	typedef void (*T)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4, int arg_5);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], (int)margs->iargs [1], (int)margs->iargs [2], (int)margs->iargs [3], (int)margs->iargs [4], (int)margs->iargs [5]);
 
 }
@@ -68,8 +68,8 @@ wasm_invoke_viiiiii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_i (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(void) = target_func;
-
+	typedef int (*T)(void);
+	T func = (T)target_func;
 	int res = func ();
 	*(int*)margs->retval = res;
 
@@ -78,8 +78,8 @@ wasm_invoke_i (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_ii (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(int arg_0) = target_func;
-
+	typedef int (*T)(int arg_0);
+	T func = (T)target_func;
 	int res = func ((int)margs->iargs [0]);
 	*(int*)margs->retval = res;
 
@@ -88,8 +88,8 @@ wasm_invoke_ii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_iii (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(int arg_0, int arg_1) = target_func;
-
+	typedef int (*T)(int arg_0, int arg_1);
+	T func = (T)target_func;
 	int res = func ((int)margs->iargs [0], (int)margs->iargs [1]);
 	*(int*)margs->retval = res;
 
@@ -98,8 +98,8 @@ wasm_invoke_iii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_iiii (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(int arg_0, int arg_1, int arg_2) = target_func;
-
+	typedef int (*T)(int arg_0, int arg_1, int arg_2);
+	T func = (T)target_func;
 	int res = func ((int)margs->iargs [0], (int)margs->iargs [1], (int)margs->iargs [2]);
 	*(int*)margs->retval = res;
 
@@ -108,8 +108,8 @@ wasm_invoke_iiii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_iiiii (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(int arg_0, int arg_1, int arg_2, int arg_3) = target_func;
-
+	typedef int (*T)(int arg_0, int arg_1, int arg_2, int arg_3);
+	T func = (T)target_func;
 	int res = func ((int)margs->iargs [0], (int)margs->iargs [1], (int)margs->iargs [2], (int)margs->iargs [3]);
 	*(int*)margs->retval = res;
 
@@ -118,8 +118,8 @@ wasm_invoke_iiiii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_iiiiii (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4) = target_func;
-
+	typedef int (*T)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4);
+	T func = (T)target_func;
 	int res = func ((int)margs->iargs [0], (int)margs->iargs [1], (int)margs->iargs [2], (int)margs->iargs [3], (int)margs->iargs [4]);
 	*(int*)margs->retval = res;
 
@@ -128,8 +128,8 @@ wasm_invoke_iiiiii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_iiiiiii (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4, int arg_5) = target_func;
-
+	typedef int (*T)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4, int arg_5);
+	T func = (T)target_func;
 	int res = func ((int)margs->iargs [0], (int)margs->iargs [1], (int)margs->iargs [2], (int)margs->iargs [3], (int)margs->iargs [4], (int)margs->iargs [5]);
 	*(int*)margs->retval = res;
 
@@ -138,8 +138,8 @@ wasm_invoke_iiiiiii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_iiiiiiii (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4, int arg_5, int arg_6) = target_func;
-
+	typedef int (*T)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4, int arg_5, int arg_6);
+	T func = (T)target_func;
 	int res = func ((int)margs->iargs [0], (int)margs->iargs [1], (int)margs->iargs [2], (int)margs->iargs [3], (int)margs->iargs [4], (int)margs->iargs [5], (int)margs->iargs [6]);
 	*(int*)margs->retval = res;
 
@@ -148,8 +148,8 @@ wasm_invoke_iiiiiiii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_iiiiiiiii (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4, int arg_5, int arg_6, int arg_7) = target_func;
-
+	typedef int (*T)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4, int arg_5, int arg_6, int arg_7);
+	T func = (T)target_func;
 	int res = func ((int)margs->iargs [0], (int)margs->iargs [1], (int)margs->iargs [2], (int)margs->iargs [3], (int)margs->iargs [4], (int)margs->iargs [5], (int)margs->iargs [6], (int)margs->iargs [7]);
 	*(int*)margs->retval = res;
 
@@ -158,8 +158,8 @@ wasm_invoke_iiiiiiiii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_iiliiii (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(int arg_0, gint64 arg_1, int arg_2, int arg_3, int arg_4, int arg_5) = target_func;
-
+	typedef int (*T)(int arg_0, gint64 arg_1, int arg_2, int arg_3, int arg_4, int arg_5);
+	T func = (T)target_func;
 	int res = func ((int)margs->iargs [0], get_long_arg (margs, 1), (int)margs->iargs [3], (int)margs->iargs [4], (int)margs->iargs [5], (int)margs->iargs [6]);
 	*(int*)margs->retval = res;
 
@@ -168,8 +168,8 @@ wasm_invoke_iiliiii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_l (void *target_func, InterpMethodArguments *margs)
 {
-	gint64 (*func)(void) = target_func;
-
+	typedef gint64 (*T)(void);
+	T func = (T)target_func;
 	gint64 res = func ();
 	*(gint64*)margs->retval = res;
 
@@ -178,8 +178,8 @@ wasm_invoke_l (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_ll (void *target_func, InterpMethodArguments *margs)
 {
-	gint64 (*func)(gint64 arg_0) = target_func;
-
+	typedef gint64 (*T)(gint64 arg_0);
+	T func = (T)target_func;
 	gint64 res = func (get_long_arg (margs, 0));
 	*(gint64*)margs->retval = res;
 
@@ -188,8 +188,8 @@ wasm_invoke_ll (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_li (void *target_func, InterpMethodArguments *margs)
 {
-	gint64 (*func)(int arg_0) = target_func;
-
+	typedef gint64 (*T)(int arg_0);
+	T func = (T)target_func;
 	gint64 res = func ((int)margs->iargs [0]);
 	*(gint64*)margs->retval = res;
 
@@ -198,8 +198,8 @@ wasm_invoke_li (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_lil (void *target_func, InterpMethodArguments *margs)
 {
-	gint64 (*func)(int arg_0, gint64 arg_1) = target_func;
-
+	typedef gint64 (*T)(int arg_0, gint64 arg_1);
+	T func = (T)target_func;
 	gint64 res = func ((int)margs->iargs [0], get_long_arg (margs, 1));
 	*(gint64*)margs->retval = res;
 
@@ -208,8 +208,8 @@ wasm_invoke_lil (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_lilii (void *target_func, InterpMethodArguments *margs)
 {
-	gint64 (*func)(int arg_0, gint64 arg_1, int arg_2, int arg_3) = target_func;
-
+	typedef gint64 (*T)(int arg_0, gint64 arg_1, int arg_2, int arg_3);
+	T func = (T)target_func;
 	gint64 res = func ((int)margs->iargs [0], get_long_arg (margs, 1), (int)margs->iargs [3], (int)margs->iargs [4]);
 	*(gint64*)margs->retval = res;
 
@@ -218,8 +218,8 @@ wasm_invoke_lilii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_dd (void *target_func, InterpMethodArguments *margs)
 {
-	double (*func)(double arg_0) = target_func;
-
+	typedef double (*T)(double arg_0);
+	T func = (T)target_func;
 	double res = func (margs->fargs [FIDX (0)]);
 	*(double*)margs->retval = res;
 
@@ -228,8 +228,8 @@ wasm_invoke_dd (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_ddd (void *target_func, InterpMethodArguments *margs)
 {
-	double (*func)(double arg_0, double arg_1) = target_func;
-
+	typedef double (*T)(double arg_0, double arg_1);
+	T func = (T)target_func;
 	double res = func (margs->fargs [FIDX (0)], margs->fargs [FIDX (1)]);
 	*(double*)margs->retval = res;
 
@@ -238,8 +238,8 @@ wasm_invoke_ddd (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_vif (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, float arg_1) = target_func;
-
+	typedef void (*T)(int arg_0, float arg_1);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], *(float*)&margs->fargs [FIDX (0)]);
 
 }
@@ -247,8 +247,8 @@ wasm_invoke_vif (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_viff (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, float arg_1, float arg_2) = target_func;
-
+	typedef void (*T)(int arg_0, float arg_1, float arg_2);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)]);
 
 }
@@ -256,8 +256,8 @@ wasm_invoke_viff (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_viffff (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, float arg_1, float arg_2, float arg_3, float arg_4) = target_func;
-
+	typedef void (*T)(int arg_0, float arg_1, float arg_2, float arg_3, float arg_4);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)], *(float*)&margs->fargs [FIDX (2)], *(float*)&margs->fargs [FIDX (3)]);
 
 }
@@ -265,8 +265,8 @@ wasm_invoke_viffff (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_vifffffi (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, float arg_1, float arg_2, float arg_3, float arg_4, float arg_5, int arg_6) = target_func;
-
+	typedef void (*T)(int arg_0, float arg_1, float arg_2, float arg_3, float arg_4, float arg_5, int arg_6);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)], *(float*)&margs->fargs [FIDX (2)], *(float*)&margs->fargs [FIDX (3)], *(float*)&margs->fargs [FIDX (4)], (int)margs->iargs [1]);
 
 }
@@ -274,8 +274,8 @@ wasm_invoke_vifffffi (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_ff (void *target_func, InterpMethodArguments *margs)
 {
-	float (*func)(float arg_0) = target_func;
-
+	typedef float (*T)(float arg_0);
+	T func = (T)target_func;
 	float res = func (*(float*)&margs->fargs [FIDX (0)]);
 	*(float*)margs->retval = res;
 
@@ -284,8 +284,8 @@ wasm_invoke_ff (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_fff (void *target_func, InterpMethodArguments *margs)
 {
-	float (*func)(float arg_0, float arg_1) = target_func;
-
+	typedef float (*T)(float arg_0, float arg_1);
+	T func = (T)target_func;
 	float res = func (*(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)]);
 	*(float*)margs->retval = res;
 
@@ -294,8 +294,8 @@ wasm_invoke_fff (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_di (void *target_func, InterpMethodArguments *margs)
 {
-	double (*func)(int arg_0) = target_func;
-
+	typedef double (*T)(int arg_0);
+	T func = (T)target_func;
 	double res = func ((int)margs->iargs [0]);
 	*(double*)margs->retval = res;
 
@@ -304,8 +304,8 @@ wasm_invoke_di (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_fi (void *target_func, InterpMethodArguments *margs)
 {
-	float (*func)(int arg_0) = target_func;
-
+	typedef float (*T)(int arg_0);
+	T func = (T)target_func;
 	float res = func ((int)margs->iargs [0]);
 	*(float*)margs->retval = res;
 
@@ -314,8 +314,8 @@ wasm_invoke_fi (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_iil (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(int arg_0, gint64 arg_1) = target_func;
-
+	typedef int (*T)(int arg_0, gint64 arg_1);
+	T func = (T)target_func;
 	int res = func ((int)margs->iargs [0], get_long_arg (margs, 1));
 	*(int*)margs->retval = res;
 
@@ -324,8 +324,8 @@ wasm_invoke_iil (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_iili (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(int arg_0, gint64 arg_1, int arg_2) = target_func;
-
+	typedef int (*T)(int arg_0, gint64 arg_1, int arg_2);
+	T func = (T)target_func;
 	int res = func ((int)margs->iargs [0], get_long_arg (margs, 1), (int)margs->iargs [3]);
 	*(int*)margs->retval = res;
 
@@ -334,8 +334,8 @@ wasm_invoke_iili (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_iillli (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(int arg_0, gint64 arg_1, gint64 arg_2, gint64 arg_3, int arg_4) = target_func;
-
+	typedef int (*T)(int arg_0, gint64 arg_1, gint64 arg_2, gint64 arg_3, int arg_4);
+	T func = (T)target_func;
 	int res = func ((int)margs->iargs [0], get_long_arg (margs, 1), get_long_arg (margs, 3), get_long_arg (margs, 5), (int)margs->iargs [7]);
 	*(int*)margs->retval = res;
 
@@ -344,8 +344,8 @@ wasm_invoke_iillli (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_idiii (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(double arg_0, int arg_1, int arg_2, int arg_3) = target_func;
-
+	typedef int (*T)(double arg_0, int arg_1, int arg_2, int arg_3);
+	T func = (T)target_func;
 	int res = func (margs->fargs [FIDX (0)], (int)margs->iargs [0], (int)margs->iargs [1], (int)margs->iargs [2]);
 	*(int*)margs->retval = res;
 
@@ -354,8 +354,8 @@ wasm_invoke_idiii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_lii (void *target_func, InterpMethodArguments *margs)
 {
-	gint64 (*func)(int arg_0, int arg_1) = target_func;
-
+	typedef gint64 (*T)(int arg_0, int arg_1);
+	T func = (T)target_func;
 	gint64 res = func ((int)margs->iargs [0], (int)margs->iargs [1]);
 	*(gint64*)margs->retval = res;
 
@@ -364,8 +364,8 @@ wasm_invoke_lii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_vid (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, double arg_1) = target_func;
-
+	typedef void (*T)(int arg_0, double arg_1);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], margs->fargs [FIDX (0)]);
 
 }
@@ -373,8 +373,8 @@ wasm_invoke_vid (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_viiiiiii (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4, int arg_5, int arg_6) = target_func;
-
+	typedef void (*T)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4, int arg_5, int arg_6);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], (int)margs->iargs [1], (int)margs->iargs [2], (int)margs->iargs [3], (int)margs->iargs [4], (int)margs->iargs [5], (int)margs->iargs [6]);
 
 }
@@ -382,8 +382,8 @@ wasm_invoke_viiiiiii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_villi (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, gint64 arg_1, gint64 arg_2, int arg_3) = target_func;
-
+	typedef void (*T)(int arg_0, gint64 arg_1, gint64 arg_2, int arg_3);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], get_long_arg (margs, 1), get_long_arg (margs, 3), (int)margs->iargs [5]);
 
 }
@@ -391,8 +391,8 @@ wasm_invoke_villi (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_did (void *target_func, InterpMethodArguments *margs)
 {
-	double (*func)(int arg_0, double arg_1) = target_func;
-
+	typedef double (*T)(int arg_0, double arg_1);
+	T func = (T)target_func;
 	double res = func ((int)margs->iargs [0], margs->fargs [FIDX (0)]);
 	*(double*)margs->retval = res;
 
@@ -401,8 +401,8 @@ wasm_invoke_did (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_didd (void *target_func, InterpMethodArguments *margs)
 {
-	double (*func)(int arg_0, double arg_1, double arg_2) = target_func;
-
+	typedef double (*T)(int arg_0, double arg_1, double arg_2);
+	T func = (T)target_func;
 	double res = func ((int)margs->iargs [0], margs->fargs [FIDX (0)], margs->fargs [FIDX (1)]);
 	*(double*)margs->retval = res;
 
@@ -411,8 +411,8 @@ wasm_invoke_didd (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_fif (void *target_func, InterpMethodArguments *margs)
 {
-	float (*func)(int arg_0, float arg_1) = target_func;
-
+	typedef float (*T)(int arg_0, float arg_1);
+	T func = (T)target_func;
 	float res = func ((int)margs->iargs [0], *(float*)&margs->fargs [FIDX (0)]);
 	*(float*)margs->retval = res;
 
@@ -421,8 +421,8 @@ wasm_invoke_fif (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_fiff (void *target_func, InterpMethodArguments *margs)
 {
-	float (*func)(int arg_0, float arg_1, float arg_2) = target_func;
-
+	typedef float (*T)(int arg_0, float arg_1, float arg_2);
+	T func = (T)target_func;
 	float res = func ((int)margs->iargs [0], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)]);
 	*(float*)margs->retval = res;
 
@@ -431,8 +431,8 @@ wasm_invoke_fiff (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_lill (void *target_func, InterpMethodArguments *margs)
 {
-	gint64 (*func)(int arg_0, gint64 arg_1, gint64 arg_2) = target_func;
-
+	typedef gint64 (*T)(int arg_0, gint64 arg_1, gint64 arg_2);
+	T func = (T)target_func;
 	gint64 res = func ((int)margs->iargs [0], get_long_arg (margs, 1), get_long_arg (margs, 3));
 	*(gint64*)margs->retval = res;
 
@@ -441,8 +441,8 @@ wasm_invoke_lill (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_vil (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, gint64 arg_1) = target_func;
-
+	typedef void (*T)(int arg_0, gint64 arg_1);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], get_long_arg (margs, 1));
 
 }

--- a/mono/utils/mono-threads-wasm.c
+++ b/mono/utils/mono-threads-wasm.c
@@ -130,7 +130,7 @@ mono_threads_platform_yield (void)
 void
 mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize)
 {
-	*staddr = (void*)wasm_get_stack_base ();
+	*staddr = (guint8*)wasm_get_stack_base ();
 	*stsize = wasm_get_stack_size ();
 }
 
@@ -169,8 +169,8 @@ mono_threads_schedule_background_job (background_job_cb cb)
 	if (!jobs)
 		schedule_background_exec ();
 
-	if (!g_slist_find (jobs, cb))
-		jobs = g_slist_prepend (jobs, cb);
+	if (!g_slist_find (jobs, (gconstpointer)cb))
+		jobs = g_slist_prepend (jobs, (gpointer)cb);
 }
 
 EMSCRIPTEN_KEEPALIVE void


### PR DESCRIPTION
https://jenkins.mono-project.com/job/test-mono-pull-request-wasm/3570/parsed_console/log.html

```/mnt/jenkins/workspace/test-mono-pull-request-wasm/mono/utils/mono-threads-wasm.c:133:12: error: assigning to 'guint8 *' (aka 'unsigned char *') from incompatible type 'void *'
        *staddr = (void*)wasm_get_stack_base ();
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/jenkins/workspace/test-mono-pull-request-wasm/mono/utils/mono-threads-wasm.c:172:7: error: no matching function for call to 'monoeg_g_slist_find'
        if (!g_slist_find (jobs, cb))
             ^~~~~~~~~~~~
                     ^
/mnt/jenkins/workspace/test-mono-pull-request-wasm/mono/utils/mono-threads-wasm.c:173:10: error: no matching function for call to 'monoeg_g_slist_prepend'
                jobs = g_slist_prepend (jobs, cb);
                       ^~~~~~~~~~~~~~~
3 errors generated.
```

https://jenkins.mono-project.com/job/test-mono-pull-request-wasm/3586/parsed_console/log.html

```
/mnt/jenkins/workspace/test-mono-pull-request-wasm/mono/metadata/gc.c:312:2: error: cannot jump from this goto statement to its label
        goto_if_nok (error, unhandled_error);
        ^
/mnt/jenkins/workspace/test-mono-pull-request-wasm/mono/utils/mono-error-internals.h:118:35: note: expanded from macro 'goto_if_nok'
#define goto_if_nok(error, label) goto_if (!is_ok (error), label)
                                  ^
/mnt/jenkins/workspace/test-mono-pull-request-wasm/mono/utils/mono-error-internals.h:116:48: note: expanded from macro 'goto_if'
#define goto_if(expr, label)      do { if (expr) goto label; } while (0)
                                                 ^
/mnt/jenkins/workspace/test-mono-pull-request-wasm/mono/metadata/gc.c:325:11: note: jump bypasses variable initialization
        gpointer params[] = { NULL };
```