### PR TITLE
Fix iconv in eglib, remove GNU libiconv-ism

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1904,6 +1904,7 @@ if test x$host_win32 = xno; then
 	AC_CHECK_FUNCS(getrlimit)
 	AC_CHECK_FUNCS(prctl)
 	AC_CHECK_FUNCS(arc4random)
+	AC_CHECK_FUNCS(nl_langinfo)
 
 	AC_CHECK_FUNCS(sched_getaffinity)
 	AC_CHECK_FUNCS(sched_setaffinity)
@@ -4593,8 +4594,9 @@ if test $found_export_dynamic = no; then
 	LDFLAGS="${old_ldflags}"
 fi
 
-AC_CHECK_HEADERS(getopt.h sys/select.h sys/time.h sys/wait.h pwd.h iconv.h localcharset.h sys/types.h sys/resource.h)
-AC_CHECK_LIB([iconv], [locale_charset],[],[AC_CHECK_LIB([charset], [locale_charset],[LIBS+=" -liconv -lcharset"])])
+AC_CHECK_HEADERS(getopt.h sys/select.h sys/time.h sys/wait.h pwd.h iconv.h sys/types.h sys/resource.h)
+dnl giconv.c will check on HAVE_ICONV_H but we need this for link time
+AC_CHECK_LIB(iconv, iconv_open)
 AC_CHECK_HEADER(alloca.h, [HAVE_ALLOCA_H=1], [HAVE_ALLOCA_H=0])
 AC_SUBST(HAVE_ALLOCA_H)
 

--- a/mono/eglib/giconv.c
+++ b/mono/eglib/giconv.c
@@ -51,7 +51,7 @@ struct _GIConv {
 	Decoder decode;
 	Encoder encode;
 	gunichar c;
-#ifdef HAVE_ICONV
+#ifdef HAVE_LIBICONV
 	iconv_t cd;
 #endif
 };
@@ -112,7 +112,7 @@ static struct {
 GIConv
 g_iconv_open (const char *to_charset, const char *from_charset)
 {
-#ifdef HAVE_ICONV
+#ifdef HAVE_LIBICONV
 	iconv_t icd = (iconv_t) -1;
 #endif
 	Decoder decoder = NULL;
@@ -135,7 +135,7 @@ g_iconv_open (const char *to_charset, const char *from_charset)
 	}
 	
 	if (!encoder || !decoder) {
-#ifdef HAVE_ICONV
+#ifdef HAVE_LIBICONV
 		if ((icd = iconv_open (to_charset, from_charset)) == (iconv_t) -1)
 			return (GIConv) -1;
 #else
@@ -150,7 +150,7 @@ g_iconv_open (const char *to_charset, const char *from_charset)
 	cd->encode = encoder;
 	cd->c = -1;
 	
-#ifdef HAVE_ICONV
+#ifdef HAVE_LIBICONV
 	cd->cd = icd;
 #endif
 	
@@ -160,7 +160,7 @@ g_iconv_open (const char *to_charset, const char *from_charset)
 int
 g_iconv_close (GIConv cd)
 {
-#ifdef HAVE_ICONV
+#ifdef HAVE_LIBICONV
 	if (cd->cd != (iconv_t) -1)
 		iconv_close (cd->cd);
 #endif
@@ -179,7 +179,7 @@ g_iconv (GIConv cd, gchar **inbytes, gsize *inbytesleft,
 	gunichar c;
 	int rc = 0;
 	
-#ifdef HAVE_ICONV
+#ifdef HAVE_LIBICONV
 	if (cd->cd != (iconv_t) -1) {
 		/* Note: gsize may have a different size than size_t, so we need to
 		   remap inbytesleft and outbytesleft to size_t's. */


### PR DESCRIPTION
iconv in eglib was broken due to a broken define. Also fix linking
of iconv when iconv isn't in libc.

Also remove the usage of a GNU libcharset specific function and rely
on a standard POSIX function that outputs the same value on every
modern Unixoid I've tried it on. (Ubuntu/macOS/i/FreeBSD)

This comment explains a lot of things for the latter:

```c
/*
 * This function used used to use the "locale_charset" call in
 * libiconv's libcharset library. However, this isn't always
 * available on some systems, including ones with GNU libc. So,
 * instead use a function that's a standard part of POSIX2008.
 *
 * nl_langinfo is in POSIX2008 and should be on any sane modern
 * Unix. With a UTF-8 locale, it should return "UTF-8" - this
 * has been verified with Ubuntu 18.04, FreeBSD 11, and i 7.3.
 *
 * The motivation for using locale_charset was likely due to
 * the cruftiness of Unices back in ~2001; where you had to
 * manually query environment variables, and the values were
 * inconsistent between each other. Nowadays, if Linux, macOS,
 * AIX/PASE, and FreeBSD can all return the same values for a
 * UTF-8 locale, we can just use the value directly.
 *
 * It should be noted that by default, this function will give
 * values for the "C" locale, unless `setlocale (LC_ALL, "")`
 * is ran to init locales - driver.c in mini does this for us.
 */
```

This commit as a part of Mono has been tested on AIX and FreeBSD; but I have tested the individual values on Linux and macOS too.
