### PR TITLE
Move icalls from utils to metadata.

### DIFF
--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -191,7 +191,7 @@ HANDLES(ICALL(CONSOLE_4, "SetEcho", ves_icall_System_ConsoleDriver_SetEcho))
 HANDLES(ICALL(CONSOLE_5, "TtySetup", ves_icall_System_ConsoleDriver_TtySetup))
 
 ICALL_TYPE(DTIME, "System.DateTime", DTIME_1)
-ICALL(DTIME_1, "GetSystemTimeAsFileTime", mono_100ns_datetime)
+ICALL(DTIME_1, "GetSystemTimeAsFileTime", ves_icall_System_DateTime_GetSystemTimeAsFileTime)
 
 ICALL_TYPE(DELEGATE, "System.Delegate", DELEGATE_1)
 HANDLES(ICALL(DELEGATE_1, "AllocDelegateLike_internal", ves_icall_System_Delegate_AllocDelegateLike_internal))
@@ -235,7 +235,7 @@ ICALL(PROCESS_10, "ProcessName_internal(intptr)", ves_icall_System_Diagnostics_P
 HANDLES(ICALL(PROCESS_13, "ShellExecuteEx_internal(System.Diagnostics.ProcessStartInfo,System.Diagnostics.Process/ProcInfo&)", ves_icall_System_Diagnostics_Process_ShellExecuteEx_internal))
 
 ICALL_TYPE(STOPWATCH, "System.Diagnostics.Stopwatch", STOPWATCH_1)
-ICALL(STOPWATCH_1, "GetTimestamp", mono_100ns_ticks)
+ICALL(STOPWATCH_1, "GetTimestamp", ves_icall_System_Diagnostics_Stopwatch_GetTimestamp)
 
 ICALL_TYPE(ENUM, "System.Enum", ENUM_1)
 HANDLES(ICALL(ENUM_1, "GetEnumValuesAndNames", ves_icall_System_Enum_GetEnumValuesAndNames))
@@ -1016,7 +1016,7 @@ HANDLES(ICALL(THREADP_13, "SetMaxThreadsNative", ves_icall_System_Threading_Thre
 HANDLES(ICALL(THREADP_14, "SetMinThreadsNative", ves_icall_System_Threading_ThreadPool_SetMinThreadsNative))
 
 ICALL_TYPE(TTIMER, "System.Threading.Timer", TTIMER_1)
-NOHANDLES(ICALL(TTIMER_1, "GetTimeMonotonic", mono_100ns_ticks))
+NOHANDLES(ICALL(TTIMER_1, "GetTimeMonotonic", ves_icall_System_Threading_Timer_GetTimeMonotonic))
 
 ICALL_TYPE(VOLATILE, "System.Threading.Volatile", VOLATILE_28)
 ICALL(VOLATILE_28, "Read(T&)", ves_icall_System_Threading_Volatile_Read_T)


### PR DESCRIPTION
Functions added here https://github.com/mono/mono/commit/58efe9419268250709a6694abfa519b9b5d2c05c#diff-eba0fd0052bf3ec9dd60f2f3e90f19e1R8483
but icall-def.h entries missed.

Might need to backport to 8/2018 but let's get it to master first.