### PR TITLE
Free the thread_info_key and thread_exited_key during unload

### DIFF
--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -859,6 +859,8 @@ mono_cleanup (void)
 {
 	mono_close_exe_image ();
 
+	mono_thread_info_cleanup ();
+
 	mono_defaults.corlib = NULL;
 
 	mono_config_cleanup ();

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -866,6 +866,13 @@ mono_thread_info_set_inited (void)
 }
 
 void
+mono_thread_info_cleanup ()
+{
+	mono_native_tls_free (thread_info_key);
+	mono_native_tls_free (thread_exited_key);
+}
+
+void
 mono_thread_info_init (size_t info_size)
 {
 	gboolean res;

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -365,6 +365,8 @@ mono_thread_info_set_tid (THREAD_INFO_TYPE *info, MonoNativeThreadId tid)
 	((MonoThreadInfo*) info)->node.key = (uintptr_t) MONO_NATIVE_THREAD_ID_TO_UINT (tid);
 }
 
+void
+mono_thread_info_cleanup (void);
 
 /*
  * @thread_info_size is sizeof (GcThreadInfo), a struct the GC defines to make it possible to have


### PR DESCRIPTION
Fixes a crash where pthread_key_clean_all will call destructors that should have been freed before unload.
