### PR TITLE
[2018-08] [tests] Add assembly-load-reference/Makefile to .gitignore

### DIFF
--- a/mono/tests/.gitignore
+++ b/mono/tests/.gitignore
@@ -47,3 +47,4 @@
 /array-coop-bigvt.cs
 /array-coop-int.cs
 /array-coop-smallvt.cs
+/assembly-load-reference/Makefile


### PR DESCRIPTION
Backport of #10074.

/cc @lambdageek