### PR TITLE
[2018-06][tests] Add assembly-load-reference/Makefile to .gitignore

### DIFF
--- a/mono/tests/.gitignore
+++ b/mono/tests/.gitignore
@@ -36,3 +36,4 @@
 /reflection-load-dir
 /assemblyresolve_deps
 /mono_aot_*
+/assembly-load-reference/Makefile


### PR DESCRIPTION
Backport #10074 to 2018-06
