### PR TITLE
Detect Arm/Arm64 in RuntimeInformation

### DIFF
--- a/mcs/class/corlib/System.Runtime.InteropServices.RuntimeInformation/RuntimeInformation.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices.RuntimeInformation/RuntimeInformation.cs
@@ -35,6 +35,9 @@ namespace System.Runtime.InteropServices
 {
 	public static class RuntimeInformation
 	{
+		[DllImport("__Internal", CharSet = CharSet.Auto)]
+		static extern string mono_config_get_cpu ();
+
 		public static string FrameworkDescription {
 			get {
 				return "Mono " + Mono.Runtime.GetDisplayName ();
@@ -75,8 +78,17 @@ namespace System.Runtime.InteropServices
 		{
 			get
 			{
-				// TODO: very barebones implementation, doesn't respect ARM
-				return Environment.Is64BitOperatingSystem ? Architecture.X64 : Architecture.X86;
+				switch (mono_config_get_cpu ()) {
+				case "arm":
+				case "armv8":
+					return Environment.Is64BitOperatingSystem ? Architecture.Arm64 : Architecture.Arm;
+				case "x86":
+				case "x86-64":
+				// upstream only has these values; try to pretend we're x86 if nothing matches
+				// want more? bug: https://github.com/dotnet/corefx/issues/30706
+				default:
+					return Environment.Is64BitOperatingSystem ? Architecture.X64 : Architecture.X86;
+				}
 			}
 		}
 
@@ -84,8 +96,22 @@ namespace System.Runtime.InteropServices
 		{
 			get
 			{
-				// TODO: very barebones implementation, doesn't respect ARM			
-				return Environment.Is64BitProcess ? Architecture.X64 : Architecture.X86;
+				// we can use the runtime's compiled config options for DllMaps here
+				// process architecure for us is runtime architecture (OS is much harder)
+				// see for values: mono-config.c
+				switch (mono_config_get_cpu ()) {
+				case "x86":
+					return Architecture.X86;
+				case "x86-64":
+					return Architecture.X64;
+				case "arm":
+					return Architecture.Arm;
+				case "armv8":
+					return Architecture.Arm64;
+				// see comment in OSArchiteture default case
+				default:
+					return Environment.Is64BitProcess ? Architecture.X64 : Architecture.X86;
+				}
 			}
 		}
 	}

--- a/mcs/class/corlib/System.Runtime.InteropServices.RuntimeInformation/RuntimeInformation.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices.RuntimeInformation/RuntimeInformation.cs
@@ -30,13 +30,18 @@
 
 using System.IO;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace System.Runtime.InteropServices
 {
 	public static class RuntimeInformation
 	{
-		[DllImport("__Internal", CharSet = CharSet.Auto)]
-		static extern string mono_config_get_cpu ();
+		/* gets the runtime's arch from the value it uses for DllMap */
+		static extern string RuntimeArchitecture
+		{
+			[MethodImpl (MethodImplOptions.InternalCall)]
+			get;
+		}
 
 		public static string FrameworkDescription {
 			get {
@@ -78,7 +83,7 @@ namespace System.Runtime.InteropServices
 		{
 			get
 			{
-				switch (mono_config_get_cpu ()) {
+				switch (RuntimeArchitecture) {
 				case "arm":
 				case "armv8":
 					return Environment.Is64BitOperatingSystem ? Architecture.Arm64 : Architecture.Arm;
@@ -99,7 +104,7 @@ namespace System.Runtime.InteropServices
 				// we can use the runtime's compiled config options for DllMaps here
 				// process architecure for us is runtime architecture (OS is much harder)
 				// see for values: mono-config.c
-				switch (mono_config_get_cpu ()) {
+				switch (RuntimeArchitecture) {
 				case "x86":
 					return Architecture.X86;
 				case "x86-64":

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -734,6 +734,10 @@ HANDLES(ICALL(MARSHAL_34, "StructureToPtr", ves_icall_System_Runtime_InteropServ
 ICALL(MARSHAL_35, "UnsafeAddrOfPinnedArrayElement", ves_icall_System_Runtime_InteropServices_Marshal_UnsafeAddrOfPinnedArrayElement)
 HANDLES(ICALL(MARSHAL_41, "copy_from_unmanaged_fixed", ves_icall_System_Runtime_InteropServices_Marshal_copy_from_unmanaged))
 HANDLES(ICALL(MARSHAL_42, "copy_to_unmanaged_fixed", ves_icall_System_Runtime_InteropServices_Marshal_copy_to_unmanaged))
+
+ICALL_TYPE(RUNTIMEINFO, "System.Runtime.InteropServices.RuntimeInformation", RUNTIMEINFO_1)
+HANDLES(ICALL(RUNTIMEINFO_1, "get_RuntimeArchitecture", ves_icall_System_Runtime_InteropServices_RuntimeInformation_get_RuntimeArchitecture))
+
 #ifndef DISABLE_COM
 ICALL_TYPE(WINDOWSRUNTIME_UNM, "System.Runtime.InteropServices.WindowsRuntime.UnsafeNativeMethods", WINDOWSRUNTIME_UNM_0)
 HANDLES(ICALL(WINDOWSRUNTIME_UNM_0, "GetRestrictedErrorInfo", ves_icall_System_Runtime_InteropServices_WindowsRuntime_UnsafeNativeMethods_GetRestrictedErrorInfo))

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7664,7 +7664,7 @@ ves_icall_System_Runtime_InteropServices_Marshal_PrelinkAll (MonoReflectionTypeH
  * used by System.Runtime.InteropServices.RuntimeInformation.(OS|Process)Architecture;
  * which use them in different ways for filling in an enum
  */
-ICALL_EXPORT char*
+ICALL_EXPORT MonoStringHandle
 ves_icall_System_Runtime_InteropServices_RuntimeInformation_get_RuntimeArchitecture (MonoError *error)
 {
 	error_init (error);

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7660,6 +7660,17 @@ ves_icall_System_Runtime_InteropServices_Marshal_PrelinkAll (MonoReflectionTypeH
 	}
 }
 
+/*
+ * used by System.Runtime.InteropServices.RuntimeInformation.(OS|Process)Architecture;
+ * which use them in different ways for filling in an enum
+ */
+ICALL_EXPORT char*
+ves_icall_System_Runtime_InteropServices_RuntimeInformation_get_RuntimeArchitecture (MonoError *error)
+{
+	error_init (error);
+	return mono_string_new_handle (mono_domain_get (), mono_config_get_cpu (), error);
+}
+
 ICALL_EXPORT int
 ves_icall_Interop_Sys_DoubleToString(double value, char *format, char *buffer, int bufferLength)
 {


### PR DESCRIPTION
* For ProcessArchitecture, use the DllMap arch of the runtime.

* For OSArchitecture, make an educated guess combining ProcessArchitecture and Environment.Is64BitOperatingSystem.

* For non-Intel/ARM architectures, (supported by Mono and not on the chopping block are PPC32/64, z, and WebAssembly) please dogpile onto dotnet/corefx#30706.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=42403