### PR TITLE
[cxx][wasm] test.js:150: TypeError: Module.pump_message is not a function.

### DIFF
--- a/sdks/wasm/test.js
+++ b/sdks/wasm/test.js
@@ -147,7 +147,7 @@ for (var i = 0; i < arguments.length; ++i) {
 
 	if (res == "SUCCESS") {
 		while (mono_send_msg ("pump-test", arguments [i]) != "DONE") {
-			Module.pump_message ();
+			MONO.pump_message ();
 			print ("|");
 		}
 		print ("\nDONE")


### PR DESCRIPTION
https://jenkins.mono-project.com/job/test-mono-pull-request-wasm/3693/parsed_console/log.html

WASM: Regression tests: 6 ran, 0 failed in DevirtualizationTests
test.js:150: TypeError: Module.pump_message is not a function
			Module.pump_message ();
          ^
TypeError: Module.pump_message is not a function
    at test.js:150:11

Makefile:160: recipe for target 'run-v8-mini' failed
