### PR TITLE
[interp] Restore frame ip after running finally handler

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -5699,12 +5699,16 @@ interp_run_finally (StackFrameInfo *frame, int clause_index, gpointer handler_ip
 {
 	InterpFrame *iframe = (InterpFrame*)frame->interp_frame;
 	ThreadContext *context = (ThreadContext*)mono_native_tls_get_value (thread_context_id);
+	const unsigned short *old_ip = iframe->ip;
+
 
 	interp_exec_method_full (iframe, context, (guint16*)handler_ip, NULL, clause_index, NULL);
-	if (context->has_resume_state)
+	if (context->has_resume_state) {
 		return TRUE;
-	else
+	} else {
+		iframe->ip = old_ip;
 		return FALSE;
+	}
 }
 
 /*

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1484,7 +1484,6 @@ CI_DISABLED_TESTS = \
 	main-returns-background-resetabort.exe \
 	main-returns-background-abort-resetabort.exe	\
 	assemblyresolve_event3.exe \
-	delegate2.exe	\
 	finally_guard.exe \
 	generic-xdomain.2.exe
 


### PR DESCRIPTION
EH still uses the original ip for determining whether there are any abort protected blocks to be exited, once the frame is unwinded.

Fixes delegate2.exe

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
