### PR TITLE
[bcl] Disable a test which fails with linking.

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection/ParameterInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/ParameterInfoTest.cs
@@ -484,6 +484,8 @@ namespace MonoTests.System.Reflection
 		}
 
 		[Test] // https://github.com/mono/mono/issues/8312
+		// The linker removes the SkipWhile methods
+		[Category ("MobileNotWorking")]
 		public void ParameterInfoToStringForQueryableSkipWhile ()
 		{
 			var sb = new StringBuilder ();


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/4617.