### PR TITLE
[cxx] wchar_t is not guint16, on Windows

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -1674,7 +1674,7 @@ make_sibling_path (const gchar *path, gint pathlen, const char *extension, Shado
 static gboolean
 shadow_copy_sibling (const gchar *src_pristine, gint srclen, const char *extension, ShadowCopySiblingExt extopt, const gchar *target_pristine, gint targetlen)
 {
-	guint16 *orig, *dest;
+	gunichar2 *orig, *dest;
 	gboolean copy_result;
 	gint32 copy_error;
 	gchar *src = NULL;
@@ -1856,7 +1856,7 @@ shadow_copy_create_ini (const char *shadow, const char *filename)
 {
 	char *dir_name;
 	char *ini_file;
-	guint16 *u16_ini;
+	gunichar2 *u16_ini;
 	gboolean result;
 	guint32 n;
 	HANDLE handle;
@@ -1968,7 +1968,7 @@ mono_make_shadow_copy (const char *filename, MonoError *oerror)
 {
 	ERROR_DECL (error);
 	gint filename_len, shadow_len;
-	guint16 *orig, *dest;
+	gunichar2 *orig, *dest;
 	guint32 attrs;
 	char *shadow;
 	gboolean copy_result;

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -258,7 +258,7 @@ mono_string_equal (MonoString *s1, MonoString *s2)
 guint
 mono_string_hash (MonoString *s)
 {
-	const guint16 *p = mono_string_chars (s);
+	const gunichar2 *p = mono_string_chars (s);
 	int i, len = mono_string_length (s);
 	guint h = 0;
 

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1686,7 +1686,7 @@ mono_image_open_a_lot (const char *fname, MonoImageOpenStatus *status, gboolean 
 	// then assemblies need to be loaded with LoadLibrary:
 	if (!refonly && coree_module_handle) {
 		HMODULE module_handle;
-		guint16 *fname_utf16;
+		gunichar2 *fname_utf16;
 		DWORD last_error;
 
 		absfname = mono_path_resolve_symlinks (fname);

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -753,13 +753,13 @@ mono_byvalarray_to_array (MonoArray *arr, gpointer native_arr, MonoClass *elclas
 
 	if (elclass == mono_defaults.byte_class) {
 		GError *gerror = NULL;
-		guint16 *ut;
+		gunichar2 *ut;
 		glong items_written;
 
 		ut = g_utf8_to_utf16 ((const gchar *)native_arr, elnum, NULL, &items_written, &gerror);
 
 		if (!gerror) {
-			memcpy (mono_array_addr (arr, guint16, 0), ut, items_written * sizeof (guint16));
+			memcpy (mono_array_addr (arr, gunichar2, 0), ut, items_written * sizeof (gunichar2));
 			g_free (ut);
 		}
 		else
@@ -5047,10 +5047,10 @@ ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringAnsi_len (const char
 }
 
 MonoStringHandle
-ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringUni (const guint16 *ptr, MonoError *error)
+ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringUni (const gunichar2 *ptr, MonoError *error)
 {
 	gsize len = 0;
-	const guint16 *t = ptr;
+	const gunichar2 *t = ptr;
 
 	if (!ptr)
 		return NULL_HANDLE_STRING;
@@ -5065,7 +5065,7 @@ ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringUni (const guint16 *
 }
 
 MonoStringHandle
-ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringUni_len (const guint16 *ptr, gint32 len, MonoError *error)
+ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringUni_len (const gunichar2 *ptr, gint32 len, MonoError *error)
 {
 	if (!ptr) {
 		mono_error_set_argument_null (error, "ptr", "");

--- a/mono/metadata/marshal.h
+++ b/mono/metadata/marshal.h
@@ -672,11 +672,11 @@ ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringAnsi_len (const char
 
 ICALL_EXPORT
 MonoStringHandle
-ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringUni (const guint16 *ptr, MonoError *error);
+ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringUni (const gunichar2 *ptr, MonoError *error);
 
 ICALL_EXPORT
 MonoStringHandle
-ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringUni_len (const guint16 *ptr, gint32 len, MonoError *error);
+ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringUni_len (const gunichar2 *ptr, gint32 len, MonoError *error);
 
 ICALL_EXPORT
 MonoStringHandle

--- a/mono/metadata/mono-perfcounters.c
+++ b/mono/metadata/mono-perfcounters.c
@@ -633,7 +633,7 @@ static int
 mono_string_compare_ascii (MonoString *str, const char *ascii_str)
 {
 	/* FIXME: make this case insensitive */
-	guint16 *strc = mono_string_chars (str);
+	const gunichar2 *strc = mono_string_chars (str);
 	while (*strc == *ascii_str++) {
 		if (*strc == 0)
 			return 0;

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1953,10 +1953,10 @@ MonoString*
 mono_string_new_wtf8_len_checked (MonoDomain *domain, const char *text, guint length, MonoError *error);
 
 MonoString *
-mono_string_new_utf16_checked (MonoDomain *domain, const guint16 *text, gint32 len, MonoError *error);
+mono_string_new_utf16_checked (MonoDomain *domain, const gunichar2 *text, gint32 len, MonoError *error);
 
 MonoStringHandle
-mono_string_new_utf16_handle (MonoDomain *domain, const guint16 *text, gint32 len, MonoError *error);
+mono_string_new_utf16_handle (MonoDomain *domain, const gunichar2 *text, gint32 len, MonoError *error);
 
 MonoStringHandle
 mono_string_new_utf8_len_handle (MonoDomain *domain, const char *text, guint length, MonoError *error);

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -6415,7 +6415,7 @@ mono_string_empty_handle (MonoDomain *domain)
  * \returns A newly created string object which contains \p text.
  */
 MonoString *
-mono_string_new_utf16 (MonoDomain *domain, const guint16 *text, gint32 len)
+mono_string_new_utf16 (MonoDomain *domain, const gunichar2 *text, gint32 len)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
@@ -6436,7 +6436,7 @@ mono_string_new_utf16 (MonoDomain *domain, const guint16 *text, gint32 len)
  * On error, returns NULL and sets \p error.
  */
 MonoString *
-mono_string_new_utf16_checked (MonoDomain *domain, const guint16 *text, gint32 len, MonoError *error)
+mono_string_new_utf16_checked (MonoDomain *domain, const gunichar2 *text, gint32 len, MonoError *error)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
@@ -6460,7 +6460,7 @@ mono_string_new_utf16_checked (MonoDomain *domain, const guint16 *text, gint32 l
  * On error, returns NULL and sets \p error.
  */
 MonoStringHandle
-mono_string_new_utf16_handle (MonoDomain *domain, const guint16 *text, gint32 len, MonoError *error)
+mono_string_new_utf16_handle (MonoDomain *domain, const gunichar2 *text, gint32 len, MonoError *error)
 {
 	return MONO_HANDLE_NEW (MonoString, mono_string_new_utf16_checked (domain, text, len, error));
 }
@@ -6595,7 +6595,7 @@ mono_string_new_utf8_len_handle (MonoDomain *domain, const char *text, guint len
 
 	GError *eg_error = NULL;
 	MonoStringHandle o = NULL_HANDLE_STRING;
-	guint16 *ut = NULL;
+	gunichar2 *ut = NULL;
 	glong items_written;
 
 	ut = eg_utf8_to_utf16_with_nuls (text, length, NULL, &items_written, &eg_error);
@@ -6667,7 +6667,7 @@ mono_string_new_checked (MonoDomain *domain, const char *text, MonoError *error)
 
 	GError *eg_error = NULL;
 	MonoString *o = NULL;
-	guint16 *ut;
+	gunichar2 *ut;
 	glong items_written;
 	int len;
 
@@ -6731,7 +6731,7 @@ mono_string_new_wtf8_len_checked (MonoDomain *domain, const char *text, guint le
 
 	GError *eg_error = NULL;
 	MonoString *o = NULL;
-	guint16 *ut = NULL;
+	gunichar2 *ut = NULL;
 	glong items_written;
 
 	ut = eg_wtf8_to_utf16 (text, length, NULL, &items_written, &eg_error);
@@ -7431,12 +7431,12 @@ mono_ldstr_metadata_sig (MonoDomain *domain, const char* sig, MonoError *error)
 	len2 = mono_metadata_decode_blob_size (str, &str);
 	len2 >>= 1;
 
-	o = mono_string_new_utf16_checked (domain, (guint16*)str, len2, error);
+	o = mono_string_new_utf16_checked (domain, (gunichar2*)str, len2, error);
 	return_val_if_nok (error, NULL);
 #if G_BYTE_ORDER != G_LITTLE_ENDIAN
 	{
 		int i;
-		guint16 *p2 = (guint16*)mono_string_chars (o);
+		gunichar2 *p2 = (gunichar2*)mono_string_chars (o);
 		for (i = 0; i < len2; ++i) {
 			*p2 = GUINT16_FROM_LE (*p2);
 			++p2;
@@ -7487,7 +7487,7 @@ mono_ldstr_utf8 (MonoImage *image, guint32 idx, MonoError *error)
 	len2 = mono_metadata_decode_blob_size (str, &str);
 	len2 >>= 1;
 
-	as = g_utf16_to_utf8 ((guint16*)str, len2, NULL, &written, &gerror);
+	as = g_utf16_to_utf8 ((gunichar2*)str, len2, NULL, &written, &gerror);
 	if (gerror) {
 		mono_error_set_argument (error, "string", gerror->message);
 		g_error_free (gerror);

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -6415,7 +6415,7 @@ mono_string_empty_handle (MonoDomain *domain)
  * \returns A newly created string object which contains \p text.
  */
 MonoString *
-mono_string_new_utf16 (MonoDomain *domain, const gunichar2 *text, gint32 len)
+mono_string_new_utf16 (MonoDomain *domain, const mono_unichar2 *text, gint32 len)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 

--- a/mono/utils/mono-publib.h
+++ b/mono/utils/mono-publib.h
@@ -87,7 +87,14 @@ typedef unsigned __int64	uint64_t;
 
 typedef int32_t		mono_bool;
 typedef uint8_t		mono_byte;
+#ifdef _WIN32
+MONO_END_DECLS
+#include <wchar.h>
+typedef wchar_t 	mono_unichar2;
+MONO_BEGIN_DECLS
+#else
 typedef uint16_t	mono_unichar2;
+#endif
 typedef uint32_t	mono_unichar4;
 
 typedef void	(*MonoFunc)	(void* data, void* user_data);


### PR DESCRIPTION
https://github.com/mono/mono/commit/675c94ec7a923a40c9e2dfdb098218f30226604b was incomplete.

https://jenkins.mono-project.com/job/x/12791/parsed_console/log.html

icall-windows.c: In function 'MonoStringHandle mono_icall_get_machine_name(MonoError*)':
icall-windows.c:65:75: error: invalid conversion from 'gunichar2* {aka wchar_t*}' to 'const guint16* {aka const short unsigned int*}' [-fpermissive]
   return mono_string_new_utf16_handle (mono_domain_get (), buf, len, error);
                                                                           ^
In file included from ../../mono/metadata/icall-internals.h:11:0,
                 from ../../mono/metadata/icall-windows-internals.h:13,
                 from icall-windows.c:14:
../../mono/metadata/object-internals.h:1963:1: note:   initializing argument 2 of 'MonoStringHandle mono_string_new_utf16_handle(MonoDomain*, const guint16*, gint32, MonoError*)'
 mono_string_new_utf16_handle (MonoDomain *domain, const guint16 *text, gint32 len, MonoError *error);
 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
icall-windows.c: In function 'MonoArray* mono_icall_get_environment_variable_names(MonoError*)':
icall-windows.c:136:101: error: invalid conversion from 'WCHAR* {aka wchar_t*}' to 'const guint16* {aka const short unsigned int*}' [-fpermissive]
     str = mono_string_new_utf16_checked (domain, env_string, (gint32)(equal_str - env_string), error);
                                                                                                     ^
In file included from ../../mono/metadata/icall-internals.h:11:0,
                 from ../../mono/metadata/icall-windows-internals.h:13,
                 from icall-windows.c:14:
../../mono/metadata/object-internals.h:1960:1: note:   initializing argument 2 of 'MonoString* mono_string_new_utf16_checked(MonoDomain*, const guint16*, gint32, MonoError*)'
 mono_string_new_utf16_checked (MonoDomain *domain, const guint16 *text, gint32 len, MonoError *error);
 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
icall-windows.c: In function 'void mono_icall_set_environment_variable(MonoString*, MonoString*)':
icall-windows.c:162:20: error: invalid conversion from 'mono_unichar2* {aka short unsigned int*}' to 'gunichar2* {aka wchar_t*}' [-fpermissive]
  utf16_name = name ? mono_string_chars (name) : NULL;
                    ^
icall-windows.c:168:34: error: invalid conversion from 'mono_unichar2* {aka short unsigned int*}' to 'gunichar2* {aka wchar_t*}' [-fpermissive]
  utf16_value = mono_string_chars (value);
                ~~~~~~~~~~~~~~~~~~^~~~~~~
icall-windows.c: In function 'MonoStringHandle mono_icall_get_windows_folder_path(int, MonoError*)':
icall-windows.c:188:76: error: invalid conversion from 'WCHAR* {aka wchar_t*}' to 'const guint16* {aka const short unsigned int*}' [-fpermissive]
   return mono_string_new_utf16_handle (mono_domain_get (), path, len, error);
                                                                            ^
In file included from ../../mono/metadata/icall-internals.h:11:0,
                 from ../../mono/metadata/icall-windows-internals.h:13,
                 from icall-windows.c:14:
../../mono/metadata/object-internals.h:1963:1: note:   initializing argument 2 of 'MonoStringHandle mono_string_new_utf16_handle(MonoDomain*, const guint16*, gint32, MonoError*)'
 mono_string_new_utf16_handle (MonoDomain *domain, const guint16 *text, gint32 len, MonoError *error);
 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
