### PR TITLE
[cxx] Fix bug with local variable dupe and global function dup.

### DIFF
--- a/mono/metadata/mono-security-windows.c
+++ b/mono/metadata/mono-security-windows.c
@@ -211,7 +211,7 @@ gpointer
 ves_icall_System_Security_Principal_WindowsImpersonationContext_DuplicateToken (gpointer token, MonoError *error)
 {
 	gpointer dupe = NULL;
-	return DuplicateToken (token, SecurityImpersonation, &dupe) ? dup : NULL;
+	return DuplicateToken (token, SecurityImpersonation, &dupe) ? dupe : NULL;
 }
 #endif /* G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT) */
 


### PR DESCRIPTION
https://jenkins.mono-project.com/job/x/12802/parsed_console/log.html

ves_icall_System_Security_Principal_WindowsImpersonationContext_DuplicateToken(gpointer, MonoError*)':
mono-security-windows.c:214:62: error: invalid conversion from 'int (*)(int)' to 'gpointer {aka void*}' [-fpermissive]
  return DuplicateToken (token, SecurityImpersonation, &dupe) ? dup : NULL;
                                                              ^
The code is confusing the local variable dupe with an 'e' at the end
with the function dup.
