### PR TITLE
[cxx] Make WebAssembly to native transitions valid C++.

### DIFF
--- a/mono/mini/m2n-gen.cs
+++ b/mono/mini/m2n-gen.cs
@@ -98,7 +98,7 @@ class Driver {
 			Console.WriteLine ("{");
 
 			
-			Console.Write ($"\t{TypeToSigType (c [0])} (*func)(");
+			Console.Write ($"\ttypedef {TypeToSigType (c [0])} (*T)(");
 			for (int i = 1; i < c.Length; ++i) {
 				char p = c [i];
 				if (i > 1)
@@ -108,7 +108,7 @@ class Driver {
 			if (c.Length == 1)
 				Console.Write ("void");
 
-			Console.WriteLine (") = target_func;\n");
+			Console.WriteLine (");\n\tT func = (T)target_func;");
 
 			var ctx = new EmitCtx ();
 

--- a/mono/mini/wasm_m2n_invoke.g.h
+++ b/mono/mini/wasm_m2n_invoke.g.h
@@ -5,8 +5,8 @@
 static void
 wasm_invoke_v (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(void) = target_func;
-
+	typedef void (*T)(void);
+	T func = (T)target_func;
 	func ();
 
 }
@@ -14,8 +14,8 @@ wasm_invoke_v (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_vi (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0) = target_func;
-
+	typedef void (*T)(int arg_0);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0]);
 
 }
@@ -23,8 +23,8 @@ wasm_invoke_vi (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_vii (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, int arg_1) = target_func;
-
+	typedef void (*T)(int arg_0, int arg_1);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], (int)margs->iargs [1]);
 
 }
@@ -32,8 +32,8 @@ wasm_invoke_vii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_viii (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, int arg_1, int arg_2) = target_func;
-
+	typedef void (*T)(int arg_0, int arg_1, int arg_2);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], (int)margs->iargs [1], (int)margs->iargs [2]);
 
 }
@@ -41,8 +41,8 @@ wasm_invoke_viii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_viiii (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, int arg_1, int arg_2, int arg_3) = target_func;
-
+	typedef void (*T)(int arg_0, int arg_1, int arg_2, int arg_3);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], (int)margs->iargs [1], (int)margs->iargs [2], (int)margs->iargs [3]);
 
 }
@@ -50,8 +50,8 @@ wasm_invoke_viiii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_viiiii (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4) = target_func;
-
+	typedef void (*T)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], (int)margs->iargs [1], (int)margs->iargs [2], (int)margs->iargs [3], (int)margs->iargs [4]);
 
 }
@@ -59,8 +59,8 @@ wasm_invoke_viiiii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_viiiiii (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4, int arg_5) = target_func;
-
+	typedef void (*T)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4, int arg_5);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], (int)margs->iargs [1], (int)margs->iargs [2], (int)margs->iargs [3], (int)margs->iargs [4], (int)margs->iargs [5]);
 
 }
@@ -68,8 +68,8 @@ wasm_invoke_viiiiii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_i (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(void) = target_func;
-
+	typedef int (*T)(void);
+	T func = (T)target_func;
 	int res = func ();
 	*(int*)margs->retval = res;
 
@@ -78,8 +78,8 @@ wasm_invoke_i (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_ii (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(int arg_0) = target_func;
-
+	typedef int (*T)(int arg_0);
+	T func = (T)target_func;
 	int res = func ((int)margs->iargs [0]);
 	*(int*)margs->retval = res;
 
@@ -88,8 +88,8 @@ wasm_invoke_ii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_iii (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(int arg_0, int arg_1) = target_func;
-
+	typedef int (*T)(int arg_0, int arg_1);
+	T func = (T)target_func;
 	int res = func ((int)margs->iargs [0], (int)margs->iargs [1]);
 	*(int*)margs->retval = res;
 
@@ -98,8 +98,8 @@ wasm_invoke_iii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_iiii (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(int arg_0, int arg_1, int arg_2) = target_func;
-
+	typedef int (*T)(int arg_0, int arg_1, int arg_2);
+	T func = (T)target_func;
 	int res = func ((int)margs->iargs [0], (int)margs->iargs [1], (int)margs->iargs [2]);
 	*(int*)margs->retval = res;
 
@@ -108,8 +108,8 @@ wasm_invoke_iiii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_iiiii (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(int arg_0, int arg_1, int arg_2, int arg_3) = target_func;
-
+	typedef int (*T)(int arg_0, int arg_1, int arg_2, int arg_3);
+	T func = (T)target_func;
 	int res = func ((int)margs->iargs [0], (int)margs->iargs [1], (int)margs->iargs [2], (int)margs->iargs [3]);
 	*(int*)margs->retval = res;
 
@@ -118,8 +118,8 @@ wasm_invoke_iiiii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_iiiiii (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4) = target_func;
-
+	typedef int (*T)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4);
+	T func = (T)target_func;
 	int res = func ((int)margs->iargs [0], (int)margs->iargs [1], (int)margs->iargs [2], (int)margs->iargs [3], (int)margs->iargs [4]);
 	*(int*)margs->retval = res;
 
@@ -128,8 +128,8 @@ wasm_invoke_iiiiii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_iiiiiii (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4, int arg_5) = target_func;
-
+	typedef int (*T)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4, int arg_5);
+	T func = (T)target_func;
 	int res = func ((int)margs->iargs [0], (int)margs->iargs [1], (int)margs->iargs [2], (int)margs->iargs [3], (int)margs->iargs [4], (int)margs->iargs [5]);
 	*(int*)margs->retval = res;
 
@@ -138,8 +138,8 @@ wasm_invoke_iiiiiii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_iiiiiiii (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4, int arg_5, int arg_6) = target_func;
-
+	typedef int (*T)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4, int arg_5, int arg_6);
+	T func = (T)target_func;
 	int res = func ((int)margs->iargs [0], (int)margs->iargs [1], (int)margs->iargs [2], (int)margs->iargs [3], (int)margs->iargs [4], (int)margs->iargs [5], (int)margs->iargs [6]);
 	*(int*)margs->retval = res;
 
@@ -148,8 +148,8 @@ wasm_invoke_iiiiiiii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_iiiiiiiii (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4, int arg_5, int arg_6, int arg_7) = target_func;
-
+	typedef int (*T)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4, int arg_5, int arg_6, int arg_7);
+	T func = (T)target_func;
 	int res = func ((int)margs->iargs [0], (int)margs->iargs [1], (int)margs->iargs [2], (int)margs->iargs [3], (int)margs->iargs [4], (int)margs->iargs [5], (int)margs->iargs [6], (int)margs->iargs [7]);
 	*(int*)margs->retval = res;
 
@@ -158,8 +158,8 @@ wasm_invoke_iiiiiiiii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_iiliiii (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(int arg_0, gint64 arg_1, int arg_2, int arg_3, int arg_4, int arg_5) = target_func;
-
+	typedef int (*T)(int arg_0, gint64 arg_1, int arg_2, int arg_3, int arg_4, int arg_5);
+	T func = (T)target_func;
 	int res = func ((int)margs->iargs [0], get_long_arg (margs, 1), (int)margs->iargs [3], (int)margs->iargs [4], (int)margs->iargs [5], (int)margs->iargs [6]);
 	*(int*)margs->retval = res;
 
@@ -168,8 +168,8 @@ wasm_invoke_iiliiii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_l (void *target_func, InterpMethodArguments *margs)
 {
-	gint64 (*func)(void) = target_func;
-
+	typedef gint64 (*T)(void);
+	T func = (T)target_func;
 	gint64 res = func ();
 	*(gint64*)margs->retval = res;
 
@@ -178,8 +178,8 @@ wasm_invoke_l (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_ll (void *target_func, InterpMethodArguments *margs)
 {
-	gint64 (*func)(gint64 arg_0) = target_func;
-
+	typedef gint64 (*T)(gint64 arg_0);
+	T func = (T)target_func;
 	gint64 res = func (get_long_arg (margs, 0));
 	*(gint64*)margs->retval = res;
 
@@ -188,8 +188,8 @@ wasm_invoke_ll (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_li (void *target_func, InterpMethodArguments *margs)
 {
-	gint64 (*func)(int arg_0) = target_func;
-
+	typedef gint64 (*T)(int arg_0);
+	T func = (T)target_func;
 	gint64 res = func ((int)margs->iargs [0]);
 	*(gint64*)margs->retval = res;
 
@@ -198,8 +198,8 @@ wasm_invoke_li (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_lil (void *target_func, InterpMethodArguments *margs)
 {
-	gint64 (*func)(int arg_0, gint64 arg_1) = target_func;
-
+	typedef gint64 (*T)(int arg_0, gint64 arg_1);
+	T func = (T)target_func;
 	gint64 res = func ((int)margs->iargs [0], get_long_arg (margs, 1));
 	*(gint64*)margs->retval = res;
 
@@ -208,8 +208,8 @@ wasm_invoke_lil (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_lilii (void *target_func, InterpMethodArguments *margs)
 {
-	gint64 (*func)(int arg_0, gint64 arg_1, int arg_2, int arg_3) = target_func;
-
+	typedef gint64 (*T)(int arg_0, gint64 arg_1, int arg_2, int arg_3);
+	T func = (T)target_func;
 	gint64 res = func ((int)margs->iargs [0], get_long_arg (margs, 1), (int)margs->iargs [3], (int)margs->iargs [4]);
 	*(gint64*)margs->retval = res;
 
@@ -218,8 +218,8 @@ wasm_invoke_lilii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_dd (void *target_func, InterpMethodArguments *margs)
 {
-	double (*func)(double arg_0) = target_func;
-
+	typedef double (*T)(double arg_0);
+	T func = (T)target_func;
 	double res = func (margs->fargs [FIDX (0)]);
 	*(double*)margs->retval = res;
 
@@ -228,8 +228,8 @@ wasm_invoke_dd (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_ddd (void *target_func, InterpMethodArguments *margs)
 {
-	double (*func)(double arg_0, double arg_1) = target_func;
-
+	typedef double (*T)(double arg_0, double arg_1);
+	T func = (T)target_func;
 	double res = func (margs->fargs [FIDX (0)], margs->fargs [FIDX (1)]);
 	*(double*)margs->retval = res;
 
@@ -238,8 +238,8 @@ wasm_invoke_ddd (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_vif (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, float arg_1) = target_func;
-
+	typedef void (*T)(int arg_0, float arg_1);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], *(float*)&margs->fargs [FIDX (0)]);
 
 }
@@ -247,8 +247,8 @@ wasm_invoke_vif (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_viff (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, float arg_1, float arg_2) = target_func;
-
+	typedef void (*T)(int arg_0, float arg_1, float arg_2);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)]);
 
 }
@@ -256,8 +256,8 @@ wasm_invoke_viff (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_viffff (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, float arg_1, float arg_2, float arg_3, float arg_4) = target_func;
-
+	typedef void (*T)(int arg_0, float arg_1, float arg_2, float arg_3, float arg_4);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)], *(float*)&margs->fargs [FIDX (2)], *(float*)&margs->fargs [FIDX (3)]);
 
 }
@@ -265,8 +265,8 @@ wasm_invoke_viffff (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_vifffffi (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, float arg_1, float arg_2, float arg_3, float arg_4, float arg_5, int arg_6) = target_func;
-
+	typedef void (*T)(int arg_0, float arg_1, float arg_2, float arg_3, float arg_4, float arg_5, int arg_6);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)], *(float*)&margs->fargs [FIDX (2)], *(float*)&margs->fargs [FIDX (3)], *(float*)&margs->fargs [FIDX (4)], (int)margs->iargs [1]);
 
 }
@@ -274,8 +274,8 @@ wasm_invoke_vifffffi (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_ff (void *target_func, InterpMethodArguments *margs)
 {
-	float (*func)(float arg_0) = target_func;
-
+	typedef float (*T)(float arg_0);
+	T func = (T)target_func;
 	float res = func (*(float*)&margs->fargs [FIDX (0)]);
 	*(float*)margs->retval = res;
 
@@ -284,8 +284,8 @@ wasm_invoke_ff (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_fff (void *target_func, InterpMethodArguments *margs)
 {
-	float (*func)(float arg_0, float arg_1) = target_func;
-
+	typedef float (*T)(float arg_0, float arg_1);
+	T func = (T)target_func;
 	float res = func (*(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)]);
 	*(float*)margs->retval = res;
 
@@ -294,8 +294,8 @@ wasm_invoke_fff (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_di (void *target_func, InterpMethodArguments *margs)
 {
-	double (*func)(int arg_0) = target_func;
-
+	typedef double (*T)(int arg_0);
+	T func = (T)target_func;
 	double res = func ((int)margs->iargs [0]);
 	*(double*)margs->retval = res;
 
@@ -304,8 +304,8 @@ wasm_invoke_di (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_fi (void *target_func, InterpMethodArguments *margs)
 {
-	float (*func)(int arg_0) = target_func;
-
+	typedef float (*T)(int arg_0);
+	T func = (T)target_func;
 	float res = func ((int)margs->iargs [0]);
 	*(float*)margs->retval = res;
 
@@ -314,8 +314,8 @@ wasm_invoke_fi (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_iil (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(int arg_0, gint64 arg_1) = target_func;
-
+	typedef int (*T)(int arg_0, gint64 arg_1);
+	T func = (T)target_func;
 	int res = func ((int)margs->iargs [0], get_long_arg (margs, 1));
 	*(int*)margs->retval = res;
 
@@ -324,8 +324,8 @@ wasm_invoke_iil (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_iili (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(int arg_0, gint64 arg_1, int arg_2) = target_func;
-
+	typedef int (*T)(int arg_0, gint64 arg_1, int arg_2);
+	T func = (T)target_func;
 	int res = func ((int)margs->iargs [0], get_long_arg (margs, 1), (int)margs->iargs [3]);
 	*(int*)margs->retval = res;
 
@@ -334,8 +334,8 @@ wasm_invoke_iili (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_iillli (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(int arg_0, gint64 arg_1, gint64 arg_2, gint64 arg_3, int arg_4) = target_func;
-
+	typedef int (*T)(int arg_0, gint64 arg_1, gint64 arg_2, gint64 arg_3, int arg_4);
+	T func = (T)target_func;
 	int res = func ((int)margs->iargs [0], get_long_arg (margs, 1), get_long_arg (margs, 3), get_long_arg (margs, 5), (int)margs->iargs [7]);
 	*(int*)margs->retval = res;
 
@@ -344,8 +344,8 @@ wasm_invoke_iillli (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_idiii (void *target_func, InterpMethodArguments *margs)
 {
-	int (*func)(double arg_0, int arg_1, int arg_2, int arg_3) = target_func;
-
+	typedef int (*T)(double arg_0, int arg_1, int arg_2, int arg_3);
+	T func = (T)target_func;
 	int res = func (margs->fargs [FIDX (0)], (int)margs->iargs [0], (int)margs->iargs [1], (int)margs->iargs [2]);
 	*(int*)margs->retval = res;
 
@@ -354,8 +354,8 @@ wasm_invoke_idiii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_lii (void *target_func, InterpMethodArguments *margs)
 {
-	gint64 (*func)(int arg_0, int arg_1) = target_func;
-
+	typedef gint64 (*T)(int arg_0, int arg_1);
+	T func = (T)target_func;
 	gint64 res = func ((int)margs->iargs [0], (int)margs->iargs [1]);
 	*(gint64*)margs->retval = res;
 
@@ -364,8 +364,8 @@ wasm_invoke_lii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_vid (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, double arg_1) = target_func;
-
+	typedef void (*T)(int arg_0, double arg_1);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], margs->fargs [FIDX (0)]);
 
 }
@@ -373,8 +373,8 @@ wasm_invoke_vid (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_viiiiiii (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4, int arg_5, int arg_6) = target_func;
-
+	typedef void (*T)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4, int arg_5, int arg_6);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], (int)margs->iargs [1], (int)margs->iargs [2], (int)margs->iargs [3], (int)margs->iargs [4], (int)margs->iargs [5], (int)margs->iargs [6]);
 
 }
@@ -382,8 +382,8 @@ wasm_invoke_viiiiiii (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_villi (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, gint64 arg_1, gint64 arg_2, int arg_3) = target_func;
-
+	typedef void (*T)(int arg_0, gint64 arg_1, gint64 arg_2, int arg_3);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], get_long_arg (margs, 1), get_long_arg (margs, 3), (int)margs->iargs [5]);
 
 }
@@ -391,8 +391,8 @@ wasm_invoke_villi (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_did (void *target_func, InterpMethodArguments *margs)
 {
-	double (*func)(int arg_0, double arg_1) = target_func;
-
+	typedef double (*T)(int arg_0, double arg_1);
+	T func = (T)target_func;
 	double res = func ((int)margs->iargs [0], margs->fargs [FIDX (0)]);
 	*(double*)margs->retval = res;
 
@@ -401,8 +401,8 @@ wasm_invoke_did (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_didd (void *target_func, InterpMethodArguments *margs)
 {
-	double (*func)(int arg_0, double arg_1, double arg_2) = target_func;
-
+	typedef double (*T)(int arg_0, double arg_1, double arg_2);
+	T func = (T)target_func;
 	double res = func ((int)margs->iargs [0], margs->fargs [FIDX (0)], margs->fargs [FIDX (1)]);
 	*(double*)margs->retval = res;
 
@@ -411,8 +411,8 @@ wasm_invoke_didd (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_fif (void *target_func, InterpMethodArguments *margs)
 {
-	float (*func)(int arg_0, float arg_1) = target_func;
-
+	typedef float (*T)(int arg_0, float arg_1);
+	T func = (T)target_func;
 	float res = func ((int)margs->iargs [0], *(float*)&margs->fargs [FIDX (0)]);
 	*(float*)margs->retval = res;
 
@@ -421,8 +421,8 @@ wasm_invoke_fif (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_fiff (void *target_func, InterpMethodArguments *margs)
 {
-	float (*func)(int arg_0, float arg_1, float arg_2) = target_func;
-
+	typedef float (*T)(int arg_0, float arg_1, float arg_2);
+	T func = (T)target_func;
 	float res = func ((int)margs->iargs [0], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)]);
 	*(float*)margs->retval = res;
 
@@ -431,8 +431,8 @@ wasm_invoke_fiff (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_lill (void *target_func, InterpMethodArguments *margs)
 {
-	gint64 (*func)(int arg_0, gint64 arg_1, gint64 arg_2) = target_func;
-
+	typedef gint64 (*T)(int arg_0, gint64 arg_1, gint64 arg_2);
+	T func = (T)target_func;
 	gint64 res = func ((int)margs->iargs [0], get_long_arg (margs, 1), get_long_arg (margs, 3));
 	*(gint64*)margs->retval = res;
 
@@ -441,8 +441,8 @@ wasm_invoke_lill (void *target_func, InterpMethodArguments *margs)
 static void
 wasm_invoke_vil (void *target_func, InterpMethodArguments *margs)
 {
-	void (*func)(int arg_0, gint64 arg_1) = target_func;
-
+	typedef void (*T)(int arg_0, gint64 arg_1);
+	T func = (T)target_func;
 	func ((int)margs->iargs [0], get_long_arg (margs, 1));
 
 }


### PR DESCRIPTION
Function pointers do not convert silently to void*. Cast them.
Use a typedef to avoid duplicating the type, optionally.