### PR TITLE
[hybrid-suspend] Two phase STW

### DIFF
--- a/mono/metadata/sgen-stw.c
+++ b/mono/metadata/sgen-stw.c
@@ -256,34 +256,49 @@ sgen_unified_suspend_stop_world (void)
 	mono_threads_begin_global_suspend ();
 	THREADS_STW_DEBUG ("[GC-STW-BEGIN][%p] *** BEGIN SUSPEND *** \n", mono_thread_info_get_tid (mono_thread_info_current ()));
 
-	FOREACH_THREAD_EXCLUDE (info, MONO_THREAD_INFO_FLAGS_NO_GC) {
-		info->client_info.skip = FALSE;
-		info->client_info.suspend_done = FALSE;
+	for (MonoThreadSuspendPhase phase = MONO_THREAD_SUSPEND_PHASE_INITIAL; phase < MONO_THREAD_SUSPEND_PHASE_COUNT; phase++) {
+		gboolean need_next_phase = FALSE;
+		FOREACH_THREAD_EXCLUDE (info, MONO_THREAD_INFO_FLAGS_NO_GC) {
+			/* look at every thread in the first phase. */
+			if (phase == MONO_THREAD_SUSPEND_PHASE_INITIAL) {
+				info->client_info.skip = FALSE;
+				info->client_info.suspend_done = FALSE;
+			} else {
+				/* skip threads suspended by previous phase. */
+				/* threads with info->client_info->skip set to TRUE will be skipped by sgen_is_thread_in_current_stw. */
+				if (info->client_info.suspend_done)
+					continue;
+			}
 
-		int reason;
-		if (!sgen_is_thread_in_current_stw (info, &reason)) {
-			THREADS_STW_DEBUG ("[GC-STW-BEGIN-SUSPEND] IGNORE thread %p skip %s reason %d\n", mono_thread_info_get_tid (info), info->client_info.skip ? "true" : "false", reason);
-			continue;
-		}
+			int reason;
+			if (!sgen_is_thread_in_current_stw (info, &reason)) {
+				THREADS_STW_DEBUG ("[GC-STW-BEGIN-SUSPEND-%d] IGNORE thread %p skip %s reason %d\n", (int)phase, mono_thread_info_get_tid (info), info->client_info.skip ? "true" : "false", reason);
+				continue;
+			}
 
-		switch (mono_thread_info_begin_suspend (info, MONO_THREAD_SUSPEND_PHASE_MOPUP)) {
-		case MONO_THREAD_BEGIN_SUSPEND_SUSPENDED:
-			info->client_info.skip = FALSE;
+			switch (mono_thread_info_begin_suspend (info, phase)) {
+			case MONO_THREAD_BEGIN_SUSPEND_SUSPENDED:
+				info->client_info.skip = FALSE;
+				break;
+			case MONO_THREAD_BEGIN_SUSPEND_SKIP:
+				info->client_info.skip = TRUE;
+				break;
+			case MONO_THREAD_BEGIN_SUSPEND_NEXT_PHASE:
+				need_next_phase = TRUE;
+				break;
+			default:
+				g_assert_not_reached ();
+			}
+
+			THREADS_STW_DEBUG ("[GC-STW-BEGIN-SUSPEND-%d] SUSPEND thread %p skip %s\n", (int)phase, mono_thread_info_get_tid (info), info->client_info.skip ? "true" : "false");
+		} FOREACH_THREAD_END;
+
+		mono_thread_info_current ()->client_info.suspend_done = TRUE;
+		mono_threads_wait_pending_operations ();
+
+		if (!need_next_phase)
 			break;
-		case MONO_THREAD_BEGIN_SUSPEND_SKIP:
-			info->client_info.skip = TRUE;
-			break;
-		case MONO_THREAD_BEGIN_SUSPEND_NEXT_PHASE:
-			g_assert_not_reached ();
-		default:
-			g_assert_not_reached ();
-		}
-
-		THREADS_STW_DEBUG ("[GC-STW-BEGIN-SUSPEND] SUSPEND thread %p skip %s\n", mono_thread_info_get_tid (info), info->client_info.skip ? "true" : "false");
-	} FOREACH_THREAD_END
-
-	mono_thread_info_current ()->client_info.suspend_done = TRUE;
-	mono_threads_wait_pending_operations ();
+	}
 
 	for (;;) {
 		gint restart_counter = 0;

--- a/mono/metadata/sgen-stw.c
+++ b/mono/metadata/sgen-stw.c
@@ -266,7 +266,18 @@ sgen_unified_suspend_stop_world (void)
 			continue;
 		}
 
-		info->client_info.skip = !mono_thread_info_begin_suspend (info);
+		switch (mono_thread_info_begin_suspend (info, MONO_THREAD_SUSPEND_PHASE_MOPUP)) {
+		case MONO_THREAD_BEGIN_SUSPEND_SUSPENDED:
+			info->client_info.skip = FALSE;
+			break;
+		case MONO_THREAD_BEGIN_SUSPEND_SKIP:
+			info->client_info.skip = TRUE;
+			break;
+		case MONO_THREAD_BEGIN_SUSPEND_NEXT_PHASE:
+			g_assert_not_reached ();
+		default:
+			g_assert_not_reached ();
+		}
 
 		THREADS_STW_DEBUG ("[GC-STW-BEGIN-SUSPEND] SUSPEND thread %p skip %s\n", mono_thread_info_get_tid (info), info->client_info.skip ? "true" : "false");
 	} FOREACH_THREAD_END
@@ -335,7 +346,18 @@ sgen_unified_suspend_stop_world (void)
 				continue;
 			}
 
-			info->client_info.skip = !mono_thread_info_begin_suspend (info);
+			switch (mono_thread_info_begin_suspend (info, MONO_THREAD_SUSPEND_PHASE_MOPUP)) {
+			case MONO_THREAD_BEGIN_SUSPEND_SUSPENDED:
+				info->client_info.skip = FALSE;
+				break;
+			case MONO_THREAD_BEGIN_SUSPEND_SKIP:
+				info->client_info.skip = TRUE;
+				break;
+			case MONO_THREAD_BEGIN_SUSPEND_NEXT_PHASE:
+				g_assert_not_reached ();
+			default:
+				g_assert_not_reached ();
+			}
 
 			THREADS_STW_DEBUG ("[GC-STW-RESTART] SUSPEND thread %p skip %s\n", mono_thread_info_get_tid (info), info->client_info.skip ? "true" : "false");
 		} FOREACH_THREAD_END

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1497,7 +1497,7 @@ CI_PR_DISABLED_TESTS = \
 	appdomain-threadpool-unload.exe
 
 # FIXME Hybrid Suspend - see https://github.com/mono/mono/issues/9959
-CI_PR_DISABLED_TESTS += sgen-new-threads-collect.exe
+# CI_PR_DISABLED_TESTS += sgen-new-threads-collect.exe
 
 # see https://github.com/mono/mono/issues/10031
 CI_PR_DISABLED_TESTS += unhandled-exception-2.exe unhandled-exception-4.exe

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -152,7 +152,7 @@ begin_suspend_for_running_thread (MonoThreadInfo *info, gboolean interrupt_kerne
 }
 
 static BeginSuspendResult
-begin_suspend_for_blocking_thread (MonoThreadInfo *info, gboolean interrupt_kernel, gboolean *did_interrupt)
+begin_suspend_for_blocking_thread (MonoThreadInfo *info, gboolean interrupt_kernel, MonoThreadSuspendPhase phase, gboolean *did_interrupt)
 {
 	// if a thread can't transition to blocking, we certainly shouldn't be
 	// trying to suspend it like it's blocking.
@@ -163,7 +163,18 @@ begin_suspend_for_blocking_thread (MonoThreadInfo *info, gboolean interrupt_kern
 		if (did_interrupt) {
 			*did_interrupt = interrupt_kernel;
 		}
-		return begin_preemptive_suspend (info, interrupt_kernel);
+		switch (phase) {
+		case MONO_THREAD_SUSPEND_PHASE_INITIAL:
+			/* In hybrid suspend, in the first phase, a thread in
+			 * blocking can continue running (and possibly
+			 * self-suspend).  We'll preemptively suspend it in the
+			 * second phase. */
+			return BeginSuspendOkNoWait;
+		case MONO_THREAD_SUSPEND_PHASE_MOPUP:
+			return begin_preemptive_suspend (info, interrupt_kernel);
+		default:
+			g_assert_not_reached ();
+		}
 	} else {
 		if (did_interrupt)
 			*did_interrupt = FALSE;
@@ -993,32 +1004,71 @@ cleanup:
 	return result;
 }
 
+static MonoThreadBeginSuspendResult
+begin_suspend_request_suspension_cordially (MonoThreadInfo *info);
+
+static MonoThreadBeginSuspendResult
+begin_suspend_peek_and_preempt (MonoThreadInfo *info);
+
+
 MonoThreadBeginSuspendResult
 mono_thread_info_begin_suspend (MonoThreadInfo *info, MonoThreadSuspendPhase phase)
 {
-	g_assert (phase == MONO_THREAD_SUSPEND_PHASE_MOPUP);
+	if (phase == MONO_THREAD_SUSPEND_PHASE_MOPUP && mono_threads_is_hybrid_suspension_enabled ())
+		return begin_suspend_peek_and_preempt (info);
+	else
+		return begin_suspend_request_suspension_cordially (info);
+}
+
+MonoThreadBeginSuspendResult
+begin_suspend_request_suspension_cordially (MonoThreadInfo *info)
+{
+	/* Ask the thread nicely to suspend.  In hybrid suspend, blocking
+	 * threads are transitioned to blocking_suspend_requested, but not
+	 * preemptively suspend in the current phase.
+	 */
 	switch (mono_threads_transition_request_suspension (info)) {
 	case ReqSuspendAlreadySuspended:
 		return MONO_THREAD_BEGIN_SUSPEND_SUSPENDED;
 	case ReqSuspendAlreadySuspendedBlocking:
-		// This state should not be possible if we're using preemptive
-		// suspend on a blocking thread - there can only be a single
-		// suspend initiator at a time (guarded by
-		// mono_thread_info_suspend_lock), and we expect the victim
-		// thread to finish the two-phase preemptive suspension
-		// procedure (and reach the ReqSuspendAlreadySuspended stage)
-		// before the next suspend initiator can begin.
-		g_assert (mono_threads_is_blocking_transition_enabled () && !mono_threads_is_hybrid_suspension_enabled ());
+		if (mono_threads_is_hybrid_suspension_enabled ()) {
+			/* This should only happen in the second phase of
+			 * hybrid suspend. It means that the first phase asked
+			 * the thread to suspend but did not signal it to
+			 * suspend preemptively. */
+			g_assert_not_reached ();
+		} else {
+			// This state should not be possible if we're using preemptive
+			// suspend on a blocking thread - there can only be a single
+			// suspend initiator at a time (guarded by
+			// mono_thread_info_suspend_lock), and we expect the victim
+			// thread to finish the two-phase preemptive suspension
+			// procedure (and reach the ReqSuspendAlreadySuspended stage)
+			// before the next suspend initiator can begin.
+			g_assert (mono_threads_is_blocking_transition_enabled ());
 
-		return MONO_THREAD_BEGIN_SUSPEND_SUSPENDED;
+			return MONO_THREAD_BEGIN_SUSPEND_SUSPENDED;
+		}
 	case ReqSuspendInitSuspendBlocking:
 		// in full cooperative mode just leave BLOCKING
 		// threads running until they try to return to RUNNING, so
 		// nothing to do, in hybrid coop preempt the thread.
-		if (begin_suspend_for_blocking_thread (info, FALSE, NULL) != BeginSuspendFail)
-			return MONO_THREAD_BEGIN_SUSPEND_SUSPENDED;
-		else
+		switch (begin_suspend_for_blocking_thread (info, FALSE, MONO_THREAD_SUSPEND_PHASE_INITIAL, NULL)) {
+		case BeginSuspendFail:
 			return MONO_THREAD_BEGIN_SUSPEND_SKIP;
+		case BeginSuspendOkNoWait:
+			if (mono_threads_is_hybrid_suspension_enabled ())
+				return MONO_THREAD_BEGIN_SUSPEND_NEXT_PHASE;
+			else {
+				g_assert (mono_threads_is_cooperative_suspension_enabled ());
+				return MONO_THREAD_BEGIN_SUSPEND_SUSPENDED;
+			}
+		case BeginSuspendOkPreemptive:
+		case BeginSuspendOkCooperative:
+			return MONO_THREAD_BEGIN_SUSPEND_SUSPENDED;
+		default:
+			g_assert_not_reached ();
+		}
 	case ReqSuspendInitSuspendRunning:
 		// in full preemptive mode this should be a preemptive suspend
 		// in full and hybrid cooperative modes this should be a coop suspend
@@ -1029,6 +1079,34 @@ mono_thread_info_begin_suspend (MonoThreadInfo *info, MonoThreadSuspendPhase pha
 	default:
 		g_assert_not_reached ();
 	}
+}
+
+MonoThreadBeginSuspendResult
+begin_suspend_peek_and_preempt (MonoThreadInfo *info)
+{
+	/* This only makes sense for two-phase hybrid suspension:
+	 * requires that a suspension request transition was already performed for 'info',
+	 * and if it is still in blocking_suspend_requested, preemptively suspends it.
+	 */
+	g_assert (mono_threads_is_hybrid_suspension_enabled ());
+	if (mono_threads_transition_peek_blocking_suspend_requested (info)) {
+		// in full cooperative mode just leave BLOCKING
+		// threads running until they try to return to RUNNING, so
+		// nothing to do, in hybrid coop preempt the thread.
+		switch (begin_suspend_for_blocking_thread (info, FALSE, MONO_THREAD_SUSPEND_PHASE_MOPUP, NULL)) {
+		case BeginSuspendFail:
+			return MONO_THREAD_BEGIN_SUSPEND_SKIP;
+		case BeginSuspendOkNoWait:
+		case BeginSuspendOkCooperative:
+			/* can't happen - should've suspended in the previous phase */
+			g_assert_not_reached ();
+		case BeginSuspendOkPreemptive:
+			return MONO_THREAD_BEGIN_SUSPEND_SUSPENDED;
+		default:
+			g_assert_not_reached ();
+		}
+	} else
+		return MONO_THREAD_BEGIN_SUSPEND_SUSPENDED;
 }
 
 gboolean
@@ -1133,7 +1211,7 @@ suspend_sync (MonoNativeThreadId tid, gboolean interrupt_kernel)
 		return info;
 	case ReqSuspendInitSuspendBlocking: {
 		gboolean did_interrupt = FALSE;
-		suspend_result = begin_suspend_for_blocking_thread (info, interrupt_kernel, &did_interrupt);
+		suspend_result = begin_suspend_for_blocking_thread (info, interrupt_kernel, MONO_THREAD_SUSPEND_PHASE_MOPUP, &did_interrupt);
 		if (suspend_result == BeginSuspendFail) {
 			mono_hazard_pointer_clear (hp, 1);
 			return NULL;

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -669,6 +669,8 @@ gboolean mono_threads_transition_finish_async_suspend (THREAD_INFO_TYPE* info);
 MonoDoBlockingResult mono_threads_transition_do_blocking (THREAD_INFO_TYPE* info, const char* func);
 MonoDoneBlockingResult mono_threads_transition_done_blocking (THREAD_INFO_TYPE* info, const char* func);
 MonoAbortBlockingResult mono_threads_transition_abort_blocking (THREAD_INFO_TYPE* info, const char* func);
+gboolean mono_threads_transition_peek_blocking_suspend_requested (THREAD_INFO_TYPE* info);
+
 
 MonoThreadUnwindState* mono_thread_info_get_suspend_state (THREAD_INFO_TYPE *info);
 


### PR DESCRIPTION
Implement a two-phase hybrid suspend scheme:
1. In the _entente phase_ put all threads in the suspend request state (either `ASYNC_SUSPEND_REQUESTED` or `BLOCKING_SUSPEND_REQUESTED`).  Wait for pending operations (but only wait for the async ones) and let all threads try to self-suspend.
2. In the _aggressive mop-up phase_ - preemptively suspend any threads that are still in `BLOCKING_SUSPEND_REQUESTED`.

