### PR TITLE
Properly inflate pointer types in inflate_generic_type. 

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -737,6 +737,14 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 		nt->data.generic_class = gclass;
 		return nt;
 	}
+	case MONO_TYPE_PTR: {
+		MonoType *nt, *inflated = inflate_generic_type (image, type->data.type, context, error);
+		if (!inflated || !mono_error_ok (error))
+			return NULL;
+		nt = mono_metadata_type_dup (image, type);
+		nt->data.type = inflated;
+		return nt;
+	}
 	default:
 		return NULL;
 	}

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -207,7 +207,7 @@ MCS_NO_UNSAFE = $(TOOLS_RUNTIME) $(CSC) -debug:portable \
 	-noconfig -nologo \
 	-nowarn:0162 -nowarn:0168 -nowarn:0219 -nowarn:0414 -nowarn:0618 \
 	-nowarn:0169 -nowarn:1690 -nowarn:0649 -nowarn:0612 -nowarn:3021 \
-	-nowarn:0197 $(PROFILE_MCS_FLAGS)
+	-nowarn:0197 -langversion:7.3 $(PROFILE_MCS_FLAGS)
 MCS_NO_LIB = $(MCS_NO_UNSAFE) -unsafe
 
 MCS = $(MCS_NO_LIB)
@@ -689,7 +689,8 @@ TESTS_CS_SRC=		\
 	bug-60843.cs	\
 	nested_type_visibility.cs	\
 	dynamic-method-churn.cs	\
-	verbose.cs
+	verbose.cs \
+	generic-unmanaged-constraint.cs
 
 # some tests fail to compile on mcs
 if CSC_IS_ROSLYN

--- a/mono/tests/generic-unmanaged-constraint.cs
+++ b/mono/tests/generic-unmanaged-constraint.cs
@@ -1,0 +1,17 @@
+using System;
+  
+unsafe class Program
+{
+        public static int Main(string[] args)
+        {
+                return (int)(IntPtr)Generic<int>.GetPtr();
+        }
+}
+
+unsafe class Generic<T> where T : unmanaged
+{
+        public static T* GetPtr()
+        {
+                return (T*)null;
+        }
+}


### PR DESCRIPTION
Generic pointer types are encountered with 'unmanaged' constraint.

Fixes #10144