### PR TITLE
[cxx] C++ constants must be initialized, even if to zeros (mono_null_…

### DIFF
--- a/mono/metadata/handle.c
+++ b/mono/metadata/handle.c
@@ -94,7 +94,7 @@ free_handle_chunk (HandleChunk *chunk)
 	g_free (chunk);
 }
 
-const MonoObjectHandle mono_null_value_handle;
+const MonoObjectHandle mono_null_value_handle = { 0 };
 
 #define THIS_IS_AN_OK_NUMBER_OF_HANDLES 100
 


### PR DESCRIPTION
…value_handle).

$ cat constants-must-be-initialized-error.cpp

const struct { char a; } b;

$ cc -c constants-must-be-initialized-error.cpp
constants-must-be-initialized-error.cpp:2:26: error: default initialization of an object of const type 'const struct (anonymous struct at
      constants-must-be-initialized-error.cpp:1:7)' without a user-provided default constructor
const struct { char a; } b;
                         ^
                           = {}
1 error generated.

$ cat constants-must-be-initialized-fixed.cpp
const struct { char a; } b = { 0 };

$ cc -c constants-must-be-initialized-fixed.cpp