### PR TITLE
[wasm] Modify HttpClient to use a default handler provider.

### DIFF
--- a/mcs/class/System.Net.Http/Makefile
+++ b/mcs/class/System.Net.Http/Makefile
@@ -10,9 +10,6 @@ LIB_MCS_FLAGS = $(EXTRA_LIB_MCS_FLAGS)
 ifeq (monodroid,$(PROFILE))
 LIB_MCS_FLAGS += -d:XAMARIN_MODERN
 endif
-ifeq (wasm,$(PROFILE))
-LIB_MCS_FLAGS += -d:WASM
-endif
 
 TEST_LIB_REFS = System System.Core
 TEST_MCS_FLAGS =

--- a/mcs/class/System.Net.Http/Makefile
+++ b/mcs/class/System.Net.Http/Makefile
@@ -10,6 +10,9 @@ LIB_MCS_FLAGS = $(EXTRA_LIB_MCS_FLAGS)
 ifeq (monodroid,$(PROFILE))
 LIB_MCS_FLAGS += -d:XAMARIN_MODERN
 endif
+ifeq (wasm,$(PROFILE))
+LIB_MCS_FLAGS += -d:WASM
+endif
 
 TEST_LIB_REFS = System System.Core
 TEST_MCS_FLAGS =

--- a/mcs/class/System.Net.Http/System.Net.Http.csproj
+++ b/mcs/class/System.Net.Http/System.Net.Http.csproj
@@ -184,6 +184,7 @@
     </When>
     <When Condition="'$(Platform)' == 'wasm'">
       <ItemGroup>
+        <Compile Include="System.Net.Http\HttpClient.wasm.cs" />
         <Compile Include="System.Net.Http\HttpClientHandler.cs" />
       </ItemGroup>
     </When>

--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClient.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClient.cs
@@ -44,7 +44,7 @@ namespace System.Net.Http
 		long buffer_size;
 		TimeSpan timeout;
 
-#if !XAMARIN_MODERN
+#if !XAMARIN_MODERN && !WASM
 		public HttpClient ()
 			: this (new HttpClientHandler (), true)
 		{

--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClient.wasm.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClient.wasm.cs
@@ -1,33 +1,36 @@
 using System;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
-namespace System.Net.Http {
-	public partial class HttpClient {
+namespace System.Net.Http
+{
+    public partial class HttpClient
+    {
 
         private static Func<HttpMessageHandler> GetHttpMessageHandler;
 
-		public HttpClient ()
-			: this (GetDefaultHandler (), true)
-		{
-		}
+        public HttpClient()
+            : this(GetDefaultHandler(), true)
+        {
+        }
 
-		static HttpMessageHandler GetDefaultHandler ()
-		{
+        static HttpMessageHandler GetDefaultHandler()
+        {
 
             if (GetHttpMessageHandler == null)
                 return GetFallback("No custom HttpClientHandler registered");
 
             var handler = GetHttpMessageHandler();
-			if (handler == null)
-			    return GetFallback ($"Custom HttpMessageHandler is not valid");
+            if (handler == null)
+                return GetFallback($"Custom HttpMessageHandler is not valid");
 
-			return handler;
-		}
+            return handler;
+        }
 
-		static HttpMessageHandler GetFallback (string message)
-		{
-			Console.WriteLine (message + ". Defaulting to System.Net.Http.HttpClientHandler");
-			return new HttpClientHandler ();
-		}
-	}
+        static HttpMessageHandler GetFallback(string message)
+        {
+            //Console.WriteLine(message + ". Defaulting to System.Net.Http.HttpClientHandler");
+            return new HttpClientHandler();
+        }
+    }
 }

--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClient.wasm.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClient.wasm.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Reflection;
+
+namespace System.Net.Http {
+	public partial class HttpClient {
+
+        public static Func<HttpMessageHandler> GetHttpMessageHandler;
+
+		public HttpClient ()
+			: this (GetDefaultHandler (), true)
+		{
+		}
+
+		static HttpMessageHandler GetDefaultHandler ()
+		{
+
+            if (GetHttpMessageHandler == null)
+                return GetFallback("No custom HttpClientHandler registered");
+
+            var handler = GetHttpMessageHandler();
+			if (handler == null)
+			    return GetFallback ($"Custom HttpMessageHandler is not valid");
+
+			return handler;
+		}
+
+		static HttpMessageHandler GetFallback (string message)
+		{
+			Console.WriteLine (message + ". Defaulting to System.Net.Http.HttpClientHandler");
+			return new HttpClientHandler ();
+		}
+	}
+}

--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClient.wasm.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClient.wasm.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 namespace System.Net.Http {
 	public partial class HttpClient {
 
-        public static Func<HttpMessageHandler> GetHttpMessageHandler;
+        private static Func<HttpMessageHandler> GetHttpMessageHandler;
 
 		public HttpClient ()
 			: this (GetDefaultHandler (), true)

--- a/mcs/class/System.Net.Http/wasm_System.Net.Http.dll.sources
+++ b/mcs/class/System.Net.Http/wasm_System.Net.Http.dll.sources
@@ -1,0 +1,2 @@
+#include System.Net.Http.dll.sources
+System.Net.Http/HttpClient.wasm.cs

--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -98,7 +98,7 @@ do-runtime:
 	make -j4 -C ../builds package-bcl
 	make build-native
 
-BCL_DEPS=/r:$(WASM_BCL_DIR)/mscorlib.dll /r:$(WASM_BCL_DIR)/System.Core.dll /r:$(WASM_BCL_DIR)/System.dll
+BCL_DEPS=/r:$(WASM_BCL_DIR)/mscorlib.dll /r:$(WASM_BCL_DIR)/System.Core.dll /r:$(WASM_BCL_DIR)/System.dll /r:$(WASM_BCL_DIR)/System.Net.Http.dll
 
 main.exe: $(APP_SOURCES)
 	$(CSC) $(CSC_FLAGS) /unsafe -out:$@ $(BCL_DEPS) /r:$(WASM_BCL_DIR)/nunitlite.dll  $(APP_SOURCES)

--- a/sdks/wasm/bindings-test.cs
+++ b/sdks/wasm/bindings-test.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Net.Http;
 
 using NUnit.Framework;
 using WebAssembly;
@@ -269,7 +270,25 @@ public class TestClass {
 		taDouble = (double[])obj.GetObjectProperty ("typedArray");
 	}	
 
+	public static HttpClient client;
+	public static void SetMessageHandler () {
+		
+		HttpClient.GetHttpMessageHandler = () => {
+			return new FakeHttpClientHandler ();
+		};
 
+		client = new HttpClient();
+	}	
+
+}
+
+
+public class FakeHttpClientHandler : HttpClientHandler
+{
+	public FakeHttpClientHandler () : base()
+	{
+		Console.WriteLine("Creating Fake HttpClientHandler.");
+	}
 }
 
 [TestFixture]
@@ -919,6 +938,16 @@ public class BindingTests {
 		Assert.AreEqual (18, TestClass.taDouble.Length);
 		Assert.AreEqual (3.14d, TestClass.taDouble[0]);
 		Assert.AreEqual (3.14d, TestClass.taDouble[TestClass.taDouble.Length - 1]);
+	}
+
+
+	[Test]
+	public static void HttpMessageHandler () {
+		Runtime.InvokeJS (@"
+			call_test_method (""SetMessageHandler"", ""o"", [  ]);
+		");
+		Assert.AreNotEqual (null, HttpClient.GetHttpMessageHandler);
+		Assert.AreNotEqual (null, TestClass.client);
 	}
 
 }

--- a/sdks/wasm/test.js
+++ b/sdks/wasm/test.js
@@ -73,7 +73,7 @@ var Module = {
 	},
 };
 
-var assemblies = [ "mscorlib.dll", "System.dll", "System.Core.dll", "Mono.Security.dll", "main.exe", "nunitlite.dll", "mini_tests.dll", "wasm_corlib_test.dll", "wasm_System_test.dll", "wasm_System.Core_test.dll", "binding_tests.dll" ];
+var assemblies = [ "mscorlib.dll", "System.dll", "System.Core.dll", "System.Net.Http.dll", "Mono.Security.dll", "main.exe", "nunitlite.dll", "mini_tests.dll", "wasm_corlib_test.dll", "wasm_System_test.dll", "wasm_System.Core_test.dll", "binding_tests.dll" ];
 
 load ("mono.js");
 Module.finish_loading ();


### PR DESCRIPTION
- Add a private static variable to HttpClient called `Func<HttpMessageHandler> GetHttpMessageHandler` that will be used to obtain the default message handler and can be set for example as follows:

```
		var httpMessageHandler = typeof(HttpClient).GetField("GetHttpMessageHandler", 
                            BindingFlags.Static | 
                            BindingFlags.NonPublic);

                httpMessageHandler.SetValue(null, (Func<HttpClientHandler>) (() => {
			return new MyHttpClientHandler ();
		}));
```

- If a handler is not set or returns null the default implementation HttpClientHandler will be returned.

- Add HttpClient.wasm.cs implementation to handle the default HttpClient
- Add simple test to the wasm test harness bindings-test.
- Reference https://github.com/mono/mono/issues/9941



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
