### PR TITLE
Fix process leak in process enumeration.

### DIFF
--- a/mcs/class/System/System.Diagnostics/Process.cs
+++ b/mcs/class/System/System.Diagnostics/Process.cs
@@ -508,9 +508,12 @@ namespace System.Diagnostics
 			int size = 0;
 
 			for (int i = 0; i < processes.Length; i++) {
+				var process = processes[i];
 				try {
-					if (String.Compare (processName, processes[i].ProcessName, true) == 0)
-						processes [size++] = processes[i];
+					if (String.Compare (processName, process.ProcessName, true) == 0)
+						processes [size++] = process;
+					else
+						process.Dispose();
 				} catch (SystemException) {
 					/* The process might exit between GetProcesses_internal and GetProcessById */
 				}


### PR DESCRIPTION
Dispose rejected ones.

This is https://github.com/mono/mono/issues/10143 and fix is from there.

I considered nulling skipped array elements, and then the tail, to help the GC, but I don't think it really helps, right?

Fixes https://github.com/mono/mono/issues/10143