### PR TITLE
[coop] Check async suspend status in ReqSuspendInitSuspendBlocking case

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1499,9 +1499,6 @@ CI_PR_DISABLED_TESTS = \
 # FIXME Hybrid Suspend - see https://github.com/mono/mono/issues/9959
 CI_PR_DISABLED_TESTS += sgen-new-threads-collect.exe
 
-# see https://github.com/mono/mono/issues/10031
-CI_PR_DISABLED_TESTS += unhandled-exception-2.exe unhandled-exception-4.exe
-
 # appdomain-threadpool-unload.exe creates 100 appdomains, takes too long with llvm
 LLVM_DISABLED_TESTS = \
 	finally_block_ending_in_dead_bb.exe \

--- a/mono/utils/mono-threads-windows.c
+++ b/mono/utils/mono-threads-windows.c
@@ -13,6 +13,7 @@
 #if defined(USE_WINDOWS_BACKEND)
 
 #include <mono/utils/mono-compiler.h>
+#include <mono/utils/mono-threads-coop.h>
 #include <mono/utils/mono-threads-debug.h>
 #include <mono/utils/mono-os-wait.h>
 #include <limits.h>
@@ -50,11 +51,16 @@ mono_threads_suspend_begin_async_suspend (MonoThreadInfo *info, gboolean interru
 		return FALSE;
 	}
 
-	/* We're in the middle of a self-suspend, resume and register */
 	if (!mono_threads_transition_finish_async_suspend (info)) {
+		/* We raced with self-suspend and lost.  Resume the native
+		 * thread.  It is still self-suspended, waiting to be resumed.
+		 * So suspend can continue.
+		 */
 		result = ResumeThread (handle);
 		g_assert (result == 1);
-		THREADS_SUSPEND_DEBUG ("FAILSAFE RESUME/1 %p -> %d\n", (void*)id, 0);
+		info->suspend_can_continue = TRUE;
+		THREADS_SUSPEND_DEBUG ("\tlost race with self suspend %p\n", (void*)id);
+		g_assert (mono_threads_is_hybrid_suspension_enabled ());
 		//XXX interrupt_kernel doesn't make sense in this case as the target is not in a syscall
 		return TRUE;
 	}

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -1135,6 +1135,13 @@ suspend_sync (MonoNativeThreadId tid, gboolean interrupt_kernel)
 		if (suspend_result != BeginSuspendOkNoWait)
 			mono_threads_wait_pending_operations ();
 		
+		if (!check_async_suspend (info, suspend_result)) {
+			mono_thread_info_core_resume (info);
+			mono_threads_wait_pending_operations ();
+			mono_hazard_pointer_clear (hp, 1);
+			return NULL;
+		}
+
 		// if we tried to preempt the thread already, do nothing.
 		// otherwise (if it's running in blocking mode) try to abort the syscall.
 		if (interrupt_kernel && !did_interrupt)

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -176,12 +176,6 @@ begin_suspend_for_blocking_thread (MonoThreadInfo *info, gboolean interrupt_kern
 static gboolean
 check_async_suspend (MonoThreadInfo *info, BeginSuspendResult result)
 {
-	if (mono_threads_is_cooperative_suspension_enabled () && !mono_threads_is_hybrid_suspension_enabled ()) {
-		/* Async suspend can't async fail on coop */
-		g_assert (result == BeginSuspendOkCooperative);
-		return TRUE;
-	}
-
 	switch (result) {
 	case BeginSuspendOkCooperative:
 		return TRUE;


### PR DESCRIPTION
So the issue is that calling `begin_suspend_for_blocking_thread` under hybrid
suspend will perform a preemptive suspension of the victim thread.

The preemptive suspend doesn't always succeed.
In particular, `thread_state_init_from_sigctx` or `thread_state_init_from_handle`
could return FALSE and `info->suspend_can_continue` will be set to FALSE.
When the `thread_state_init_*` functions return FALSE, they also set the
`MonoThreadUnwindState:valid` to FALSE.

So it is important to check the value of `MonoThreadInfo:suspend_can_continue`
before proceeding with a suspension.

As a result in `suspend_sync` in the `ReqSuspendInitSuspendRunning` case we call
`check_async_suspend` which checks (for preemptively suspended threads) whether
`suspend_can_continue` is true.  If it isn't, we resume the victim thread and
loop once more in `suspend_sync_nolock` and try again.

We didn't have a `check_async_suspend` call in the `ReqSuspendInitSuspendBlocking`
case, so a thread could be considered suspended even if we couldn't capture a
valid `MonoThreadUnwindState` for it.

That breaks the assertion the call to `mono_thread_info_get_last_managed` in
`async_suspend_critical` which needs a valid `MonoThreadUnwindState`.

Fixes https://github.com/mono/mono/issues/10031

