### PR TITLE
[System.Xml.Linq] Fix namespace conflict with new Xamarin.Mac namespace in test code.

### DIFF
--- a/mcs/class/System.Xml.Linq/Test/System.Xml.Schema/ExtensionsTest.cs
+++ b/mcs/class/System.Xml.Linq/Test/System.Xml.Schema/ExtensionsTest.cs
@@ -15,7 +15,6 @@ using NUnit.Framework;
 using System;
 using System.Xml;
 using System.IO;
-using Network =  System.Net;
 using System.Xml.Linq;
 using System.Xml.Schema;
 using System.Collections.Generic;
@@ -94,7 +93,7 @@ namespace MonoTests.System.Xml.Schema
 		{
 			// Create a resolver with default credentials.
 			XmlUrlResolver resolver = new XmlUrlResolver ();
-			resolver.Credentials = Network.CredentialCache.DefaultCredentials; 
+			resolver.Credentials = global::System.Net.CredentialCache.DefaultCredentials;
 			// Set the reader settings object to use the resolver.
 			XmlReaderSettings settings = new XmlReaderSettings ();
 			settings.XmlResolver = resolver;


### PR DESCRIPTION
macOS 10.14 introduces a Network framework, which means Xamarin.Mac now has a Network namespace.

This conflicts with 'using Network = System.Net':

> mono/mcs/class/System.Xml.Linq/Test/System.Xml.Schema/ExtensionsTest.cs(97,27): error CS0576: Namespace '<global namespace>' contains a definition conflicting with alias 'Network'

so just remove the using and use the full 'System.Net' namespace instead.