### PR TITLE
[2018-02] [llvm] Avoid using the preserveall calling convention in another place on watchos. (#9518)

### DIFF
--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -1019,6 +1019,14 @@ set_call_preserveall_cc (LLVMValueRef func)
 #endif
 }
 
+static void
+set_call_preserveall_cc (LLVMValueRef func)
+{
+#ifndef TARGET_WATCHOS
+	mono_llvm_set_call_preserveall_cc (func);
+#endif
+}
+
 /*
  * get_bb:
  *


### PR DESCRIPTION
[llvm] Avoid using the preserveall calling convention in another plac…

…e on watchos.

Fixes https://github.com/mono/mono/issues/9318.

backport of https://github.com/mono/mono/pull/9518

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->