### PR TITLE
[runtime] Declare mono_aot_register_module in mkbundle stub

### DIFF
--- a/mcs/tools/mkbundle/bundle-mono-api.inc
+++ b/mcs/tools/mkbundle/bundle-mono-api.inc
@@ -18,7 +18,7 @@ typedef struct BundleMonoAPI
 {
 	void (*mono_register_bundled_assemblies) (const MonoBundledAssembly **assemblies);
 	void (*mono_register_config_for_assembly) (const char* assembly_name, const char* config_xml);
-	void (*mono_jit_set_aot_mode) (int mode);
+	void (*mono_jit_set_aot_mode) (MonoAotMode mode);
 	void (*mono_aot_register_module) (void* aot_info);
 	void (*mono_config_parse_memory) (const char *buffer);
 	void (*mono_register_machine_config) (const char *config_xml);

--- a/mcs/tools/mkbundle/template_common.inc
+++ b/mcs/tools/mkbundle/template_common.inc
@@ -47,6 +47,12 @@ validate_api_struct ()
 	exit (1);
 }
 
+#ifdef USE_DEFAULT_MONO_API_STRUCT
+// We don't export in jit.h
+// So declare here, and get it from mono
+void mono_aot_register_module (void *aot_info);
+#endif // USE_DEFAULT_MONO_API_STRUCT
+
 static void
 init_default_mono_api_struct ()
 {


### PR DESCRIPTION
Without this change, mkbundle cannot be run out-of-tree without using the new API struct

https://github.com/mono/mono/issues/9956