### PR TITLE
[cxx] Wrap fmod in mono_fmod for stronger future-proofing.

### DIFF
--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4457,6 +4457,15 @@ mini_init (const char *filename, const char *runtime_version)
 	return domain;
 }
 
+#ifdef MONO_ARCH_EMULATE_FREM
+// Wrapper to avoid taking address of overloaded function.
+static double
+mono_fmod (double a, double b)
+{
+	return fmod (a, b);
+}
+#endif
+
 static void
 register_icalls (void)
 {
@@ -4583,9 +4592,7 @@ register_icalls (void)
 	register_opcode_emulation (OP_LCONV_TO_R_UN, "__emul_lconv_to_r8_un", "double long", mono_lconv_to_r8_un, "mono_lconv_to_r8_un", FALSE);
 #endif
 #ifdef MONO_ARCH_EMULATE_FREM
-	// fmod is overloaded in C++, capture local to disambiguate -- an implied safe static cast.
-	double (*pfmod)(double, double) = fmod;
-	register_opcode_emulation (OP_FREM, "__emul_frem", "double double double", pfmod, "fmod", FALSE);
+	register_opcode_emulation (OP_FREM, "__emul_frem", "double double double", mono_fmod, "fmod", FALSE);
 	register_opcode_emulation (OP_RREM, "__emul_rrem", "float float float", fmodf, "fmodf", FALSE);
 #endif
 


### PR DESCRIPTION
Apparently the standard or implementers would be within their rights to change it to:
double fmod(double, double, double = 1);

which would break this. I don't think they can get away with it.
Taking address is discouraged, so that such evolution can occur compatibilty.
