### PR TITLE
[2018-08] [System.Xml.Linq] Fix namespace conflict with new Xamarin.Mac namespace in test code.

### DIFF
--- a/mcs/class/System.Xml.Linq/Test/System.Xml.Schema/ExtensionsTest.cs
+++ b/mcs/class/System.Xml.Linq/Test/System.Xml.Schema/ExtensionsTest.cs
@@ -15,7 +15,6 @@ using NUnit.Framework;
 using System;
 using System.Xml;
 using System.IO;
-using Network =  System.Net;
 using System.Xml.Linq;
 using System.Xml.Schema;
 using System.Collections.Generic;
@@ -94,7 +93,7 @@ namespace MonoTests.System.Xml.Schema
 		{
 			// Create a resolver with default credentials.
 			XmlUrlResolver resolver = new XmlUrlResolver ();
-			resolver.Credentials = Network.CredentialCache.DefaultCredentials; 
+			resolver.Credentials = global::System.Net.CredentialCache.DefaultCredentials;
 			// Set the reader settings object to use the resolver.
 			XmlReaderSettings settings = new XmlReaderSettings ();
 			settings.XmlResolver = resolver;


### PR DESCRIPTION
Backport of #10164.

/cc @akoeplinger