### PR TITLE
[nunit-lite config] do not use legacy unhandled exception policy

### DIFF
--- a/mcs/tools/nunit-lite/nunit-lite-console/nunit-lite-console.exe.config.tmpl
+++ b/mcs/tools/nunit-lite/nunit-lite-console/nunit-lite-console.exe.config.tmpl
@@ -2,13 +2,7 @@
 <configuration>
   <!-- __INSERT_CUSTOM_APP_CONFIG_GLOBAL__ -->
   <runtime>
-    <!-- 
-      This is necessary to prevent the runner from terminating on
-      any unhandled exceptions which occur. We account for unhandled exceptions on
-      other threads with an event handler, but would still be terminated using the
-      new behavior.
-    -->
-    <legacyUnhandledExceptionPolicy enabled="1" />
+    <legacyUnhandledExceptionPolicy enabled="0" />
     <!-- __INSERT_CUSTOM_APP_CONFIG_RUNTIME__ -->
   </runtime>
 </configuration>


### PR DESCRIPTION
kinda suggested by this commit
https://github.com/mono/mono/commit/a05bc5465aa463f4f702c26c22f0312a376b337c

In case of https://github.com/mono/mono/pull/10181#issuecomment-414358584 it would provide more accurate stack traces. That is, instead of:

```
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0003b] in /mnt/jenkins/workspace/test-mono-pull-request-amd64/mcs/class/corlib/System.Reflection/MonoMethod.cs:305 
```

we would get
```
[ERROR] FATAL UNHANDLED EXCEPTION: System.InvalidOperationException: No operation in progress
  at System.Net.Sockets.Socket+<>c.<.cctor>b__313_3 (System.IAsyncResult ares) [0x0005e] in /Users/lewurm/work/mono-broken-EH/mcs/class/System/System.Net.Sockets/Socket.cs:962
  at System.Net.Sockets.SocketAsyncResult+<>c.<Complete>b__27_0 (System.Object state) [0x00000] in /Users/lewurm/work/mono-broken-EH/mcs/class/System/System.Net.Sockets/SocketAsyncResult.cs:157
  at System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem () [0x00015] in /Users/lewurm/work/mono-broken-EH/mcs/class/referencesource/mscorlib/system/threading/threadpool.cs:1281
  at System.Threading.ThreadPoolWorkQueue.Dispatch () [0x00074] in /Users/lewurm/work/mono-broken-EH/mcs/class/referencesource/mscorlib/system/threading/threadpool.cs:858
  at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback () [0x00000] in /Users/lewurm/work/mono-broken-EH/mcs/class/referencesource/mscorlib/system/threading/threadpool.cs:1213
```

not sure what it breaks though, so let's see what CI says.