### PR TITLE
[interp] fix ftnptr_eh_callback

### DIFF
--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -2264,6 +2264,7 @@ stack_walk_adapter (MonoStackFrameInfo *frame, MonoContext *ctx, gpointer data)
 	case FRAME_TYPE_MANAGED_TO_NATIVE:
 	case FRAME_TYPE_TRAMPOLINE:
 	case FRAME_TYPE_INTERP_TO_MANAGED:
+	case FRAME_TYPE_INTERP_TO_MANAGED_WITH_CTX:
 		return FALSE;
 	case FRAME_TYPE_MANAGED:
 	case FRAME_TYPE_INTERP:
@@ -2309,6 +2310,7 @@ async_stack_walk_adapter (MonoStackFrameInfo *frame, MonoContext *ctx, gpointer 
 	case FRAME_TYPE_MANAGED_TO_NATIVE:
 	case FRAME_TYPE_TRAMPOLINE:
 	case FRAME_TYPE_INTERP_TO_MANAGED:
+	case FRAME_TYPE_INTERP_TO_MANAGED_WITH_CTX:
 		return FALSE;
 	case FRAME_TYPE_MANAGED:
 	case FRAME_TYPE_INTERP:

--- a/mono/mini/arch-stubs.c
+++ b/mono/mini/arch-stubs.c
@@ -81,6 +81,12 @@ mono_arch_undo_ip_adjustment (MonoContext *context)
 	g_assert_not_reached ();
 }
 
+void
+mono_arch_do_ip_adjustment (MonoContext *context)
+{
+	g_assert_not_reached ();
+}
+
 #endif
 
 #ifndef MONO_ARCH_HAVE_EXCEPTIONS_INIT

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -2474,7 +2474,7 @@ get_top_method_ji (gpointer ip, MonoDomain **domain, gpointer *out_ip)
 		g_assert (((gsize)lmf->previous_lmf) & 2);
 		MonoLMFExt *ext = (MonoLMFExt*)lmf;
 
-		g_assert (ext->interp_exit);
+		g_assert (ext->kind == MONO_LMFEXT_INTERP_EXIT || ext->kind == MONO_LMFEXT_INTERP_EXIT_WITH_CTX);
 		frame = (MonoInterpFrameHandle*)ext->interp_exit_data;
 		ji = mini_get_interp_callbacks ()->frame_get_jit_info (frame);
 		if (domain)
@@ -2633,7 +2633,7 @@ thread_interrupt (DebuggerTlsData *tls, MonoThreadInfo *info, MonoJitInfo *ji)
 
 				memcpy (&tls->async_last_frame, &data.last_frame, sizeof (StackFrameInfo));
 
-				if (data.last_frame.type == FRAME_TYPE_INTERP_TO_MANAGED) {
+				if (data.last_frame.type == FRAME_TYPE_INTERP_TO_MANAGED || data.last_frame.type == FRAME_TYPE_INTERP_TO_MANAGED_WITH_CTX) {
 					/*
 					 * Store the current lmf instead of the parent one, since that
 					 * contains the interp exit data.
@@ -4558,7 +4558,7 @@ user_break_cb (StackFrameInfo *frame, MonoContext *ctx, gpointer user_data)
 {
 	UserBreakCbData *data = (UserBreakCbData*)user_data;
 
-	if (frame->type == FRAME_TYPE_INTERP_TO_MANAGED) {
+	if (frame->type == FRAME_TYPE_INTERP_TO_MANAGED || frame->type == FRAME_TYPE_INTERP_TO_MANAGED_WITH_CTX) {
 		data->found = TRUE;
 		return TRUE;
 	}
@@ -6095,7 +6095,7 @@ do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, guint8 
 	if (invoke->has_ctx) {
 		/* Setup our lmf */
 		memset (&ext, 0, sizeof (ext));
-		ext.debugger_invoke = TRUE;
+		ext.kind = MONO_LMFEXT_DEBUGGER_INVOKE;
 		memcpy (&ext.ctx, &invoke->ctx, sizeof (MonoContext));
 
 		mono_push_lmf (&ext);

--- a/mono/mini/debugger-engine.c
+++ b/mono/mini/debugger-engine.c
@@ -660,7 +660,7 @@ get_top_method_ji (gpointer ip, MonoDomain **domain, gpointer *out_ip)
 		g_assert (((gsize)lmf->previous_lmf) & 2);
 		MonoLMFExt *ext = (MonoLMFExt*)lmf;
 
-		g_assert (ext->interp_exit);
+		g_assert (ext->kind == MONO_LMFEXT_INTERP_EXIT || ext->kind == MONO_LMFEXT_INTERP_EXIT_WITH_CTX);
 		frame = (MonoInterpFrameHandle*)ext->interp_exit_data;
 		ji = mini_get_interp_callbacks ()->frame_get_jit_info (frame);
 		if (domain)

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -1981,3 +1981,9 @@ mono_arch_undo_ip_adjustment (MonoContext *ctx)
 {
 	ctx->gregs [AMD64_RIP]++;
 }
+
+void
+mono_arch_do_ip_adjustment (MonoContext *ctx)
+{
+	ctx->gregs [AMD64_RIP]--;
+}

--- a/mono/mini/exceptions-arm.c
+++ b/mono/mini/exceptions-arm.c
@@ -639,3 +639,12 @@ mono_arch_undo_ip_adjustment (MonoContext *ctx)
 	if (mono_arm_thumb_supported ())
 		ctx->pc |= 1;
 }
+
+void
+mono_arch_do_ip_adjustment (MonoContext *ctx)
+{
+	/* Clear thumb bit */
+	ctx->pc &= ~1;
+
+	ctx->pc--;
+}

--- a/mono/mini/exceptions-arm64.c
+++ b/mono/mini/exceptions-arm64.c
@@ -605,3 +605,9 @@ mono_arch_undo_ip_adjustment (MonoContext *ctx)
 {
 	ctx->pc++;
 }
+
+void
+mono_arch_do_ip_adjustment (MonoContext *ctx)
+{
+	ctx->pc--;
+}

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -1174,7 +1174,8 @@ interp_frame_arg_set_storage (MonoInterpFrameHandle frame, MonoMethodSignature *
 	}
 }
 
-static MONO_NEVER_INLINE void
+/* MONO_NO_OPTIMIATION is needed due to usage of INTERP_PUSH_LMF_WITH_CTX. */
+static MONO_NO_OPTIMIZATION MONO_NEVER_INLINE void
 ves_pinvoke_method (InterpFrame *frame, MonoMethodSignature *sig, MonoFuncV addr, gboolean string_ctor, ThreadContext *context)
 {
 	MonoLMFExt ext;
@@ -1775,7 +1776,8 @@ interp_entry (InterpEntryData *data)
 	}
 }
 
-static MONO_NEVER_INLINE stackval *
+/* MONO_NO_OPTIMIATION is needed due to usage of INTERP_PUSH_LMF_WITH_CTX. */
+static MONO_NO_OPTIMIZATION MONO_NEVER_INLINE stackval *
 do_icall (ThreadContext *context, MonoMethodSignature *sig, int op, stackval *sp, gpointer ptr)
 {
 	MonoLMFExt ext;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2444,6 +2444,7 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 			MONO_STACKDATA (stackptr);
 
 			mono_threads_enter_gc_safe_region_unbalanced_internal (&stackptr);
+			mono_set_lmf (lmf);
 			ftnptr_eh_callback (handle);
 			g_error ("Did not expect ftnptr_eh_callback to return.");
 		}

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -146,16 +146,18 @@ struct MonoJitTlsData {
 #endif
 };
 
+#define MONO_LMFEXT_DEBUGGER_INVOKE 1
+#define MONO_LMFEXT_INTERP_EXIT 2
+#define MONO_LMFEXT_INTERP_EXIT_WITH_CTX 3
+
 /*
  * This structure is an extension of MonoLMF and contains extra information.
  */
 typedef struct {
 	struct MonoLMF lmf;
-	gboolean debugger_invoke;
-	gboolean interp_exit;
-	MonoContext ctx; /* if debugger_invoke is TRUE */
-	/* If interp_exit is TRUE */
-	gpointer interp_exit_data;
+	int kind;
+	MonoContext ctx; /* valid if kind == DEBUGGER_INVOKE || kind == INTERP_EXIT_WITH_CTX */
+	gpointer interp_exit_data; /* valid if kind == INTERP_EXIT || kind == INTERP_EXIT_WITH_CTX */
 } MonoLMFExt;
 
 typedef void (*MonoFtnPtrEHCallback) (guint32 gchandle);

--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -466,7 +466,7 @@ mono_wasm_current_bp_id (void)
 	g_assert (((guint64)lmf->previous_lmf) & 2);
 	MonoLMFExt *ext = (MonoLMFExt*)lmf;
 
-	g_assert (ext->interp_exit);
+	g_assert (ext->kind == MONO_LMFEXT_INTERP_EXIT || ext->kind == MONO_LMFEXT_INTERP_EXIT_WITH_CTX);
 	MonoInterpFrameHandle *frame = ext->interp_exit_data;
 	MonoJitInfo *ji = mini_get_interp_callbacks ()->frame_get_jit_info (frame);
 	guint8 *ip = mini_get_interp_callbacks ()->frame_get_ip (frame);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2337,6 +2337,7 @@ void     mono_arch_handle_altstack_exception    (void *sigctx, MONO_SIG_HANDLER_
 gboolean mono_handle_soft_stack_ovf             (MonoJitTlsData *jit_tls, MonoJitInfo *ji, void *ctx, MONO_SIG_HANDLER_INFO_TYPE *siginfo, guint8* fault_addr);
 void     mono_handle_hard_stack_ovf             (MonoJitTlsData *jit_tls, MonoJitInfo *ji, void *ctx, guint8* fault_addr);
 void     mono_arch_undo_ip_adjustment           (MonoContext *ctx);
+void     mono_arch_do_ip_adjustment             (MonoContext *ctx);
 gpointer mono_arch_ip_from_context              (void *sigctx);
 mgreg_t mono_arch_context_get_int_reg		    (MonoContext *ctx, int reg);
 void     mono_arch_context_set_int_reg		    (MonoContext *ctx, int reg, mgreg_t val);

--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -125,6 +125,12 @@ typedef SSIZE_T ssize_t;
 #define MONO_COLD
 #endif
 
+#ifdef __GNUC__
+#define MONO_NO_OPTIMIZATION __attribute__ ((optimize("O0")))
+#else
+#define MONO_NO_OPTIMIZATION
+#endif
+
 #if defined (__GNUC__) && defined (__GNUC_MINOR__) && defined (__GNUC_PATCHLEVEL__)
 #define MONO_GNUC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #endif

--- a/mono/utils/mono-stack-unwinding.h
+++ b/mono/utils/mono-stack-unwinding.h
@@ -26,7 +26,9 @@ typedef enum {
 	FRAME_TYPE_INTERP = 4,
 	/* Frame for transitioning from interpreter to managed code */
 	FRAME_TYPE_INTERP_TO_MANAGED = 5,
-	FRAME_TYPE_NUM = 6
+	/* same, but with MonoContext */
+	FRAME_TYPE_INTERP_TO_MANAGED_WITH_CTX = 6,
+	FRAME_TYPE_NUM = 7
 } MonoStackFrameType;
 
 typedef enum {


### PR DESCRIPTION
please look at the single commits. here's a `git log` copy/paste:

---------------------------------

[exceptions] ftnptr_eh_callback test that stresses n2m transitions.

on Xamarin.iOS it happens that the ftnptr_eh_callback calls into managed code, that is yet another native-to-managed transition.


----------------------------------


[exceptions] pop lmf stack before executing ftnptr_eh_callback


----------------------------------

[interp] always set LMF for interp_in wrapper.

partial revert of a33cbb873c487490f2a3c271b24c70c1c3fc0a2c



----------------------------------

[mini] ignore LMF if it isn't initialized

interp_in wrapper serves two purposes:

1) native to interp transition: usually this transition doesn't need a
    LMF marker, but in a ftnptr_eh_callback scenario it can be required.
    see ./mono/tests/install_eh_callback.cs
2) jitted code to interp. LMF marker is used to signal EH the transition.

The change of this commit is needed if we have a wrapper of kind 1), and it's called from native code by a thread that isn't attached to the runtime yet. Therefore LMF won't be initialized yet.