### PR TITLE
[runtime] Fix the invocation of update_submodules.sh during configure so it works for out-of-tree builds as well.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5501,7 +5501,7 @@ if test x"$GCC" = xyes; then
 fi
 
 # Update all submodules recursively to ensure everything is checked out
-$srcdir/scripts/update_submodules.sh
+(cd $srcdir && scripts/update_submodules.sh)
 
 AC_OUTPUT([
 Makefile


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->