### PR TITLE
[RFS][SDKs] Add configure script and update top level Makefile to use it.

### DIFF
--- a/sdks/Makefile
+++ b/sdks/Makefile
@@ -1,8 +1,48 @@
+TOP=$(realpath $(CURDIR)/../..)
+-include $(TOP)/sdks/Make.config
 
-all:
+
+all: build
+
+build::
 	$(MAKE) -C builds all
-	$(MAKE) -C android all
 
-clean:
+
+package::
+	$(MAKE) -C builds package
+
+clean::
 	$(MAKE) -C builds clean
+
+ifndef DISABLE_IOS
+build::
+	$(MAKE) -C ios build
+
+package::
+	$(MAKE) -C ios package
+
+clean::
+	$(MAKE) -C ios clean
+endif
+
+ifndef DISABLE_ANDROID
+build::
+	$(MAKE) -C android build
+
+package::
+	$(MAKE) -C android package
+
+clean::
 	$(MAKE) -C android clean
+endif
+
+ifndef DISABLE_WASM
+build::
+	$(MAKE) -C wasm build
+
+package::
+	$(MAKE) -C wasm package
+
+clean::
+	$(MAKE) -C wasm clean
+endif

--- a/sdks/configure
+++ b/sdks/configure
@@ -1,0 +1,80 @@
+#!/bin/sh -e
+
+function show_help () {
+cat <<EOL
+Usage: configure [options]
+    -h, --help       Displays this help
+    --ios            Enable IOS build (disabled by default)
+    --android        Enable Android build (disabled by default)
+    --wasm           Enable WebAssembly build (disabled by default)
+	--desktop        Enable Desktop build (disabled by default)
+    --disable-bcl    Disable BLC build (enabled by default)
+EOL
+}
+
+CONFIGURED_FILE=Make.local
+
+rm -f $CONFIGURED_FILE
+
+echo "# Configure arguments: $*" >> $CONFIGURED_FILE
+
+disable_ios=true
+disable_android=true
+disable_wasm=true
+disable_desktop=true
+disable_bcl=false
+
+
+while test x$1 != x; do
+	case $1 in
+	--ios)
+		$disable_ios = false
+		shift
+		;;
+	--android)
+		$disable_android = false
+		shift
+		;;
+	--wasm)
+		$disable_wasm = false
+		shift
+		;;
+	--desktop)
+		$disable_desktop = false
+		shift
+		;;
+	--disable-bcl)
+		$disable_bcl = false
+		shift
+		;;
+	--help|-h)
+		show_help
+		exit 0
+		;;
+	*)
+		echo Unknown configure argument $1 >&2
+		shift
+		;;
+	esac
+done
+
+# ifeq ($(DISABLE_IOS), true)
+if [ $disable_ios = true ]; then
+echo "DISABLE_IOS = 1" >> $CONFIGURED_FILE
+fi
+
+if [ $disable_android = true ]; then
+echo "DISABLE_ANDROID = 1" >> $CONFIGURED_FILE
+fi
+
+if [ $disable_wasm = true ]; then
+echo "DISABLE_WASM = 1" >> $CONFIGURED_FILE
+fi
+
+if [ $disable_desktop = true ]; then
+echo "DISABLE_DESKTOP = 1" >> $CONFIGURED_FILE
+fi
+
+if [ $disable_bcl = true ]; then
+echo "DISABLE_BCL = 1" >> $CONFIGURED_FILE
+fi


### PR DESCRIPTION
This still needs the iOS / Android targets to append to `TARGETS` but we should make it so that the standard `all, build, package, test, clean` targets work just fine in a well configured SDKs setup.