### PR TITLE
[2018-08] Add pipeline to convert managed exception into telemetry format

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # There is no ordering of corlib versions, no old or new,
 # the runtime expects an exact match.
 #
-MONO_CORLIB_VERSION=40525B4A-F860-49BF-936E-6B29CBBF357C
+MONO_CORLIB_VERSION=72078E96-4A71-4CCD-83BC-B7CC78873FC0
 
 #
 # Put a quoted #define in config.h.

--- a/mcs/class/corlib/Mono/Runtime.cs
+++ b/mcs/class/corlib/Mono/Runtime.cs
@@ -81,12 +81,63 @@ namespace Mono {
 			return true;
 		}
 
+		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		static extern void ExceptionToState (Exception exc, out string payload, out IntPtr portable_hash, out IntPtr unportable_hash);
+
 #if !MOBILE 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
-		static extern void DisableMicrosoftTelemetry (IntPtr appBundleID, IntPtr appSignature, IntPtr appVersion, IntPtr merpGUIPath);
+		static extern void DisableMicrosoftTelemetry ();
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		static extern void EnableMicrosoftTelemetry_internal (IntPtr appBundleID, IntPtr appSignature, IntPtr appVersion, IntPtr merpGUIPath, IntPtr eventType, IntPtr appPath);
+
+		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		static extern void SendMicrosoftTelemetry_internal (IntPtr payload, IntPtr portable_hash, IntPtr unportable_hash);
+
+		static void SendMicrosoftTelemetry (string payload_str, IntPtr portable_hash, IntPtr unportable_hash)
+		{
+			if (RuntimeInformation.IsOSPlatform (OSPlatform.OSX)) {
+				using (var payload_chars = RuntimeMarshal.MarshalString (payload_str))
+				{
+					SendMicrosoftTelemetry_internal (payload_chars.Value, portable_hash, unportable_hash);
+				}
+			} else {
+				throw new PlatformNotSupportedException("Merp support is currently only supported on OSX.");
+			}
+		}
+
+		// Usage: 
+		//
+		// catch (Exception exc) {
+		//   var monoType = Type.GetType ("Mono.Runtime", false);
+		//   var m = monoType.GetMethod("SendExceptionToTelemetry", BindingFlags.NonPublic | BindingFlags.Static);
+		//   m.Invoke(null, new object[] { exc });
+		// }
+		static void SendExceptionToTelemetry (Exception exc)
+		{
+			string payload_str;
+			IntPtr portable_hash;
+			IntPtr unportable_hash;
+			ExceptionToState (exc, out payload_str, out portable_hash, out unportable_hash);
+			SendMicrosoftTelemetry (payload_str, portable_hash, unportable_hash);
+		}
+
+		static void EnableMicrosoftTelemetry (string appBundleID_str, string appSignature_str, string appVersion_str, string merpGUIPath_str, string eventType_str, string appPath_str)
+		{
+			if (RuntimeInformation.IsOSPlatform (OSPlatform.OSX)) {
+				using (var appBundleID_chars = RuntimeMarshal.MarshalString (appBundleID_str))
+				using (var appSignature_chars = RuntimeMarshal.MarshalString (appSignature_str))
+				using (var appVersion_chars = RuntimeMarshal.MarshalString (appVersion_str))
+				using (var merpGUIPath_chars = RuntimeMarshal.MarshalString (merpGUIPath_str))
+				using (var eventType_chars = RuntimeMarshal.MarshalString (eventType_str))
+				using (var appPath_chars = RuntimeMarshal.MarshalString (appPath_str))
+				{
+					EnableMicrosoftTelemetry_internal (appBundleID_chars.Value, appSignature_chars.Value, appVersion_chars.Value, merpGUIPath_chars.Value, eventType_chars.Value, appPath_chars.Value);
+				}
+			} else {
+				throw new PlatformNotSupportedException("Merp support is currently only supported on OSX.");
+			}
+		}
 
 		static void EnableMicrosoftTelemetry (string appBundleID_str, string appSignature_str, string appVersion_str, string merpGUIPath_str, string eventType_str, string appPath_str)
 		{

--- a/mcs/class/corlib/Test/System/ExceptionTest.cs
+++ b/mcs/class/corlib/Test/System/ExceptionTest.cs
@@ -13,6 +13,8 @@ using System;
 using System.Collections;
 using System.Runtime.Serialization;
 
+using System.Reflection;
+
 using NUnit.Framework;
 
 namespace MonoTests.System
@@ -399,6 +401,80 @@ namespace MonoTests.System
 
 			Assert.IsNull (a.InnerException.Source);
 		}
+
+#if !MOBILE
+		// Ensure that we can convert a stacktrace to a
+		// telemetry message
+		//
+		[Test]
+		public void StacktraceToState ()
+		{
+			try {
+				throw new Exception ("#0");
+			} catch (Exception exc) {
+				var monoType = Type.GetType ("Mono.Runtime", false);
+				var convert = monoType.GetMethod("ExceptionToState", BindingFlags.NonPublic | BindingFlags.Static);
+				object [] convert_params = new object[] {exc};
+				var output = (Tuple<String, ulong, ulong>) convert.Invoke(null, convert_params);
+
+				var dump = output.Item1;
+				var portable_hash = output.Item2;
+				var unportable_hash = output.Item3;
+
+				Console.WriteLine ("Hashes {0} {1}", portable_hash, unportable_hash);
+
+				Assert.IsTrue (portable_hash != 0, "#1");
+				Assert.IsTrue (unportable_hash != 0, "#2");
+				Assert.IsTrue (dump.Length > 0, "#3");
+
+				// Console.WriteLine (dump);
+				// dump should look something like:
+				// {
+				//  "protocol_version" : "0.0.1",
+				//  "configuration" : {
+				//    "version" : "5.19.0 (managed_telemetry_pipeline/d342c73e320 Wed Aug 15 14:40:40 EDT 2018)",
+				//    "tlc" : "normal",
+				//    "sigsgev" : "altstack",
+				//    "notifications" : "kqueue",
+				//    "architecture" : "amd64",
+				//    "disabled_features" : "none",
+				//    "smallconfig" : "disabled",
+				//    "bigarrays" : "disabled",
+				//    "softdebug" : "enabled",
+				//    "interpreter" : "enabled",
+				//    "llvm_support" : "disabled",
+				//    "suspend" : "hybrid"
+				//  },
+				//  "memory" : {
+				//    "Resident Size" : "40693760",
+				//    "Virtual Size" : "4521312256",
+				//    "minor_gc_time" : "216992",
+				//    "major_gc_time" : "0",
+				//    "minor_gc_count" : "6",
+				//    "major_gc_count" : "0",
+				//    "major_gc_time_concurrent" : "0"
+				//  },
+				//  "threads" : [
+				//    {
+				//      "is_managed" : false,
+				//      "managed_thread_ptr" : "0x0",
+				//      "thread_info_addr" : "0x0",
+				//      "native_thread_id" : "0x0",
+				//      "managed_frames" : [
+				//        {
+				//          "is_managed" : "true",
+				//          "guid" : "43A03618-E657-44B0-B9FA-F63314A3C1B2",
+				//          "token" : "0x60008da",
+				//          "native_offset" : "0xb2",
+				//          "il_offset" : "0x00000"
+				//        }
+				//      ]
+				//    }
+				//  ]
+				//  }
+			}
+		}
+#endif
 
 		[Test]
 		public void StackTrace ()

--- a/mcs/class/corlib/Test/System/ExceptionTest.cs
+++ b/mcs/class/corlib/Test/System/ExceptionTest.cs
@@ -407,6 +407,7 @@ namespace MonoTests.System
 		// telemetry message
 		//
 		[Test]
+		[Category("NotOnWindows")]
 		public void StacktraceToState ()
 		{
 			try {
@@ -420,8 +421,6 @@ namespace MonoTests.System
 				var dump = output.Item1;
 				var portable_hash = output.Item2;
 				var unportable_hash = output.Item3;
-
-				Console.WriteLine ("Hashes {0} {1}", portable_hash, unportable_hash);
 
 				Assert.IsTrue (portable_hash != 0, "#1");
 				Assert.IsTrue (unportable_hash != 0, "#2");

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -94,6 +94,7 @@ HANDLES(ICALL(RUNTIME_1, "DisableMicrosoftTelemetry", ves_icall_Mono_Runtime_Dis
 HANDLES(ICALL(RUNTIME_2, "EnableMicrosoftTelemetry_internal", ves_icall_Mono_Runtime_EnableMicrosoftTelemetry))
 HANDLES(ICALL(RUNTIME_3, "GetDisplayName", ves_icall_Mono_Runtime_GetDisplayName))
 HANDLES(ICALL(RUNTIME_12, "GetNativeStackTrace", ves_icall_Mono_Runtime_GetNativeStackTrace))
+HANDLES(ICALL(RUNTIME_13, "SendMicrosoftTelemetry", ves_icall_Mono_Runtime_SendMicrosoftTelemetry))
 
 ICALL_TYPE(RTCLASS, "Mono.RuntimeClassHandle", RTCLASS_1)
 HANDLES(ICALL(RTCLASS_1, "GetTypeFromClass", ves_icall_Mono_RuntimeClassHandle_GetTypeFromClass))

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -92,7 +92,8 @@ HANDLES(ICALL(TLS_PROVIDER_FACTORY_1, "IsBtlsSupported", ves_icall_Mono_TlsProvi
 ICALL_TYPE(RUNTIME, "Mono.Runtime", RUNTIME_1)
 HANDLES(ICALL(RUNTIME_1, "DisableMicrosoftTelemetry", ves_icall_Mono_Runtime_DisableMicrosoftTelemetry))
 HANDLES(ICALL(RUNTIME_2, "EnableMicrosoftTelemetry_internal", ves_icall_Mono_Runtime_EnableMicrosoftTelemetry))
-HANDLES(ICALL(RUNTIME_3, "GetDisplayName", ves_icall_Mono_Runtime_GetDisplayName))
+HANDLES(ICALL(RUNTIME_3, "ExceptionToState", ves_icall_Mono_Runtime_ExceptionToState))
+HANDLES(ICALL(RUNTIME_4, "GetDisplayName", ves_icall_Mono_Runtime_GetDisplayName))
 HANDLES(ICALL(RUNTIME_12, "GetNativeStackTrace", ves_icall_Mono_Runtime_GetNativeStackTrace))
 HANDLES(ICALL(RUNTIME_13, "SendMicrosoftTelemetry", ves_icall_Mono_Runtime_SendMicrosoftTelemetry))
 

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -92,10 +92,10 @@ HANDLES(ICALL(TLS_PROVIDER_FACTORY_1, "IsBtlsSupported", ves_icall_Mono_TlsProvi
 ICALL_TYPE(RUNTIME, "Mono.Runtime", RUNTIME_1)
 HANDLES(ICALL(RUNTIME_1, "DisableMicrosoftTelemetry", ves_icall_Mono_Runtime_DisableMicrosoftTelemetry))
 HANDLES(ICALL(RUNTIME_2, "EnableMicrosoftTelemetry_internal", ves_icall_Mono_Runtime_EnableMicrosoftTelemetry))
-HANDLES(ICALL(RUNTIME_3, "ExceptionToState", ves_icall_Mono_Runtime_ExceptionToState))
+HANDLES(ICALL(RUNTIME_3, "ExceptionToState_internal", ves_icall_Mono_Runtime_ExceptionToState))
 HANDLES(ICALL(RUNTIME_4, "GetDisplayName", ves_icall_Mono_Runtime_GetDisplayName))
 HANDLES(ICALL(RUNTIME_12, "GetNativeStackTrace", ves_icall_Mono_Runtime_GetNativeStackTrace))
-HANDLES(ICALL(RUNTIME_13, "SendMicrosoftTelemetry", ves_icall_Mono_Runtime_SendMicrosoftTelemetry))
+HANDLES(ICALL(RUNTIME_13, "SendMicrosoftTelemetry_internal", ves_icall_Mono_Runtime_SendMicrosoftTelemetry))
 
 ICALL_TYPE(RTCLASS, "Mono.RuntimeClassHandle", RTCLASS_1)
 HANDLES(ICALL(RTCLASS_1, "GetTypeFromClass", ves_icall_Mono_RuntimeClassHandle_GetTypeFromClass))

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -102,6 +102,7 @@
 #include <mono/metadata/w32error.h>
 #include <mono/utils/w32api.h>
 #include <mono/utils/mono-merp.h>
+#include <mono/utils/mono-state.h>
 #include <mono/utils/mono-logger-internals.h>
 
 #if !defined(HOST_WIN32) && defined(HAVE_SYS_UTSNAME_H)
@@ -5782,6 +5783,30 @@ ves_icall_Mono_Runtime_EnableMicrosoftTelemetry (char *appBundleID, char *appSig
 }
 
 ICALL_EXPORT void
+ves_icall_Mono_Runtime_ExceptionToState (MonoException *exc, char **payload, intptr_t *portable_hash, intptr_t *unportable_hash, MonoError *error)
+{
+#ifdef TARGET_OSX
+	MonoThreadSummary out;
+	mono_get_eh_callbacks ()->mono_summarize_exception (exc, &out);
+
+	intptr_t out_hash_port = (intptr_t) out.hashes.offset_free_hash;
+	intptr_t out_hash_unport = (intptr_t) out.hashes.offset_free_hash;
+
+	JsonWriter writer;
+	mono_json_writer_init (&writer);
+	mono_native_state_init (&writer);
+	char *output = mono_native_state_free (&writer, FALSE);
+
+	*payload = output;
+	*portable_hash = out_hash_port;
+	*unportable_hash = out_hash_unport;
+#else
+	// Icall has platform check in managed too.
+	g_assert_not_reached ();
+#endif
+}
+
+ICALL_EXPORT void
 ves_icall_Mono_Runtime_SendMicrosoftTelemetry (char *payload, intptr_t portable_hash, intptr_t unportable_hash, MonoError *error)
 {
 #ifdef TARGET_OSX
@@ -5789,7 +5814,6 @@ ves_icall_Mono_Runtime_SendMicrosoftTelemetry (char *payload, intptr_t portable_
 		g_error ("Cannot send telemetry without registering parameters first");
 
 	pid_t crashed_pid = getpid ();
-	char *full_version = mono_get_runtime_build_info ();
 
 	MonoStackHash hashes;
 	hashes.offset_free_hash = portable_hash;
@@ -5798,13 +5822,7 @@ ves_icall_Mono_Runtime_SendMicrosoftTelemetry (char *payload, intptr_t portable_
 	// Tells mono that we want to send the HANG EXC_TYPE.
 	const char *signal = "SIGTERM";
 
-	mono_merp_invoke (crashed_pid, signal, payload, &hashes, full_version);
-
-	// FIXME: 
-	// This leaves static memory in a bad state. (JsonWriter)
-	// We could fix this by making the helper functions take a pointer
-	// to the writer.
-	exit (1);
+	mono_merp_invoke (crashed_pid, signal, payload, &hashes);
 #else
 	// Icall has platform check in managed too.
 	g_assert_not_reached ();

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5781,6 +5781,36 @@ ves_icall_Mono_Runtime_EnableMicrosoftTelemetry (char *appBundleID, char *appSig
 #endif
 }
 
+ICALL_EXPORT void
+ves_icall_Mono_Runtime_SendMicrosoftTelemetry (char *payload, intptr_t portable_hash, intptr_t unportable_hash, MonoError *error)
+{
+#ifdef TARGET_OSX
+	if (!mono_merp_enabled ())
+		g_error ("Cannot send telemetry without registering parameters first");
+
+	pid_t crashed_pid = getpid ();
+	char *full_version = mono_get_runtime_build_info ();
+
+	MonoStackHash hashes;
+	hashes.offset_free_hash = portable_hash;
+	hashes.offset_rich_hash = unportable_hash;
+
+	// Tells mono that we want to send the HANG EXC_TYPE.
+	const char *signal = "SIGTERM";
+
+	mono_merp_invoke (crashed_pid, signal, payload, &hashes, full_version);
+
+	// FIXME: 
+	// This leaves static memory in a bad state. (JsonWriter)
+	// We could fix this by making the helper functions take a pointer
+	// to the writer.
+	exit (1);
+#else
+	// Icall has platform check in managed too.
+	g_assert_not_reached ();
+#endif
+}
+
 ICALL_EXPORT MonoBoolean
 ves_icall_System_Reflection_AssemblyName_ParseAssemblyName (const char *name, MonoAssemblyName *aname, MonoBoolean *is_version_defined_arg, MonoBoolean *is_token_defined_arg)
 {

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5817,6 +5817,7 @@ ves_icall_Mono_Runtime_SendMicrosoftTelemetry (char *payload, guint64 portable_h
 	pid_t crashed_pid = getpid ();
 
 	MonoStackHash hashes;
+	memset (&hashes, 0, sizeof (MonoStackHash));
 	hashes.offset_free_hash = portable_hash;
 	hashes.offset_rich_hash = unportable_hash;
 

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5782,24 +5782,25 @@ ves_icall_Mono_Runtime_EnableMicrosoftTelemetry (char *appBundleID, char *appSig
 #endif
 }
 
-ICALL_EXPORT void
-ves_icall_Mono_Runtime_ExceptionToState (MonoException *exc, char **payload, intptr_t *portable_hash, intptr_t *unportable_hash, MonoError *error)
+ICALL_EXPORT MonoStringHandle
+ves_icall_Mono_Runtime_ExceptionToState (MonoExceptionHandle exc_handle, guint64 *portable_hash_out, guint64 *unportable_hash_out, MonoError *error)
 {
-#ifdef TARGET_OSX
+#ifndef DISABLE_CRASH_REPORTING
+	// FIXME: Push handles down into mini/mini-exceptions.c
+	MonoException *exc = MONO_HANDLE_RAW (exc_handle);
 	MonoThreadSummary out;
 	mono_get_eh_callbacks ()->mono_summarize_exception (exc, &out);
 
-	intptr_t out_hash_port = (intptr_t) out.hashes.offset_free_hash;
-	intptr_t out_hash_unport = (intptr_t) out.hashes.offset_free_hash;
+	*portable_hash_out = (guint64) out.hashes.offset_free_hash;
+	*unportable_hash_out = (guint64) out.hashes.offset_rich_hash;
 
 	JsonWriter writer;
 	mono_json_writer_init (&writer);
 	mono_native_state_init (&writer);
+	gboolean first_thread_added = TRUE;
+	mono_native_state_add_thread (&writer, &out, NULL, first_thread_added);
 	char *output = mono_native_state_free (&writer, FALSE);
-
-	*payload = output;
-	*portable_hash = out_hash_port;
-	*unportable_hash = out_hash_unport;
+	return mono_string_new_handle (mono_domain_get (), output, error);
 #else
 	// Icall has platform check in managed too.
 	g_assert_not_reached ();
@@ -5807,7 +5808,7 @@ ves_icall_Mono_Runtime_ExceptionToState (MonoException *exc, char **payload, int
 }
 
 ICALL_EXPORT void
-ves_icall_Mono_Runtime_SendMicrosoftTelemetry (char *payload, intptr_t portable_hash, intptr_t unportable_hash, MonoError *error)
+ves_icall_Mono_Runtime_SendMicrosoftTelemetry (char *payload, guint64 portable_hash, guint64 unportable_hash, MonoError *error)
 {
 #ifdef TARGET_OSX
 	if (!mono_merp_enabled ())

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5785,6 +5785,8 @@ ves_icall_Mono_Runtime_EnableMicrosoftTelemetry (char *appBundleID, char *appSig
 ICALL_EXPORT MonoStringHandle
 ves_icall_Mono_Runtime_ExceptionToState (MonoExceptionHandle exc_handle, guint64 *portable_hash_out, guint64 *unportable_hash_out, MonoError *error)
 {
+	MonoStringHandle result;
+
 #ifndef DISABLE_CRASH_REPORTING
 	// FIXME: Push handles down into mini/mini-exceptions.c
 	MonoException *exc = MONO_HANDLE_RAW (exc_handle);
@@ -5800,11 +5802,15 @@ ves_icall_Mono_Runtime_ExceptionToState (MonoExceptionHandle exc_handle, guint64
 	gboolean first_thread_added = TRUE;
 	mono_native_state_add_thread (&writer, &out, NULL, first_thread_added);
 	char *output = mono_native_state_free (&writer, FALSE);
-	return mono_string_new_handle (mono_domain_get (), output, error);
+	result = mono_string_new_handle (mono_domain_get (), output, error);
+	g_free (output);
 #else
-	// Icall has platform check in managed too.
-	g_assert_not_reached ();
+	*portable_hash_out = 0;
+	*unportable_hash_out = 0;
+	result = mono_string_new_handle (mono_domain_get (), "", error);
 #endif
+
+	return result;
 }
 
 ICALL_EXPORT void

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -696,6 +696,7 @@ typedef struct {
 	void (*mono_clear_abort_threshold) (void);
 	void (*mono_reraise_exception) (MonoException *ex);
 	void (*mono_summarize_stack) (MonoDomain *domain, MonoThreadSummary *out, MonoContext *crash_ctx);
+	void (*mono_summarize_exception) (MonoException *exc, MonoThreadSummary *out);
 } MonoRuntimeExceptionHandlingCallbacks;
 
 MONO_COLD void mono_set_pending_exception (MonoException *exc);

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -5974,7 +5974,7 @@ mono_threads_summarize_one (MonoThreadSummary *out, MonoContext *ctx)
 
 	MonoInternalThread *thread = (MonoInternalThread *) mono_gchandle_get_target (handle);
 
-	memset (out, 0, sizeof (*out));
+	memset (out, 0, sizeof (MonoThreadSummary));
 	domain = thread->obj.vtable->domain;
 	out->native_thread_id = (intptr_t) thread_get_tid (thread);
 	out->managed_thread_ptr = (intptr_t) get_current_thread_ptr_for_domain (domain, thread);

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1467,6 +1467,8 @@ mono_summarize_stack (MonoDomain *domain, MonoThreadSummary *out, MonoContext *c
 static void
 mono_summarize_exception (MonoException *exc, MonoThreadSummary *out)
 {
+	memset (out, 0, sizeof (MonoThreadSummary));
+
 	MonoSummarizeUserData data;
 	data.max_frames = MONO_MAX_SUMMARY_FRAMES;
 	data.num_frames = 0;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1426,6 +1426,7 @@ static void
 mono_summarize_stack (MonoDomain *domain, MonoThreadSummary *out, MonoContext *crash_ctx)
 {
 	MonoSummarizeUserData data;
+	memset (&data, 0, sizeof (MonoSummarizeUserData));
 	data.max_frames = MONO_MAX_SUMMARY_FRAMES;
 	data.num_frames = 0;
 	data.frames = out->managed_frames;
@@ -1470,6 +1471,7 @@ mono_summarize_exception (MonoException *exc, MonoThreadSummary *out)
 	memset (out, 0, sizeof (MonoThreadSummary));
 
 	MonoSummarizeUserData data;
+	memset (&data, 0, sizeof (MonoSummarizeUserData));
 	data.max_frames = MONO_MAX_SUMMARY_FRAMES;
 	data.num_frames = 0;
 	data.frames = out->managed_frames;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -913,7 +913,13 @@ mono_exception_walk_trace_internal (MonoException *ex, MonoExceptionFrameWalk fu
 		memcpy (&trace_ip, mono_array_addr_fast (ta, ExceptionTraceIp, i), sizeof (ExceptionTraceIp));
 		gpointer ip = trace_ip.ip;
 		gpointer generic_info = trace_ip.generic_info;
-		MonoJitInfo *ji = mono_jit_info_table_find (domain, ip);
+
+		MonoJitInfo *ji = NULL;
+		if (trace_ip.ji) {
+			ji = trace_ip.ji;
+		} else {
+			ji = mono_jit_info_table_find (domain, ip);
+		}
 
 		if (ji == NULL) {
 			gboolean r;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -128,6 +128,7 @@ static void mono_uninstall_current_handler_block_guard (void);
 static gboolean mono_exception_walk_trace_internal (MonoException *ex, MonoExceptionFrameWalk func, gpointer user_data);
 
 static void mono_summarize_stack (MonoDomain *domain, MonoThreadSummary *out, MonoContext *crash_ctx);
+static void mono_summarize_exception (MonoException *exc, MonoThreadSummary *out);
 
 static gboolean
 first_managed (MonoStackFrameInfo *frame, MonoContext *ctx, gpointer addr)
@@ -233,6 +234,7 @@ mono_exceptions_init (void)
 	cbs.mono_walk_stack_with_ctx = mono_runtime_walk_stack_with_ctx;
 	cbs.mono_walk_stack_with_state = mono_walk_stack_with_state;
 	cbs.mono_summarize_stack = mono_summarize_stack;
+	cbs.mono_summarize_exception = mono_summarize_exception;
 
 	if (mono_llvm_only) {
 		cbs.mono_raise_exception = mono_llvm_raise_exception;
@@ -1355,21 +1357,16 @@ summarize_offset_rich_hash (intptr_t accum, MonoFrameSummary *frame)
 }
 
 static gboolean
-summarize_frame (StackFrameInfo *frame, MonoContext *ctx, gpointer data)
+summarize_frame_internal (MonoMethod *method, gpointer ip, size_t native_offset, gboolean managed, gpointer user_data)
 {
-	MonoMethod *method = NULL;
-	MonoSummarizeUserData *ud = (MonoSummarizeUserData *) data;
+	MonoSummarizeUserData *ud = (MonoSummarizeUserData *) user_data;
 	g_assert (ud->num_frames + 1 < ud->max_frames);
 	MonoFrameSummary *dest = &ud->frames [ud->num_frames];
 	ud->num_frames++;
 
-	mono_get_portable_ip ((intptr_t) MONO_CONTEXT_GET_IP (ctx), &dest->unmanaged_data.ip, NULL);
-	dest->unmanaged_data.is_trampoline = frame->ji && frame->ji->is_trampoline;
+	dest->unmanaged_data.ip = (intptr_t) ip;
+	dest->is_managed = managed;
 
-	if (frame->ji && frame->type != FRAME_TYPE_TRAMPOLINE)
-		method = jinfo_get_method (frame->ji);
-
-	dest->is_managed = (method != NULL);
 	if (method && method->wrapper_type != MONO_WRAPPER_NONE) {
 		dest->is_managed = FALSE;
 		dest->unmanaged_data.has_name = TRUE;
@@ -1379,16 +1376,17 @@ summarize_frame (StackFrameInfo *frame, MonoContext *ctx, gpointer data)
 
 	MonoDebugSourceLocation *location = NULL;
 
-	if (dest->is_managed) {
+	if (managed) {
+		g_assert (method);
 		MonoImage *image = mono_class_get_image (method->klass);
 		// Used for hashing, more stable across rebuilds than using GUID
 		copy_summary_string_safe (dest->str_descr, image->assembly_name);
 
 		dest->managed_data.guid = image->guid;
 
-		dest->managed_data.native_offset = frame->native_offset;
+		dest->managed_data.native_offset = native_offset;
 		dest->managed_data.token = method->token;
-		location = mono_debug_lookup_source_location (method, frame->native_offset, mono_domain_get ());
+		location = mono_debug_lookup_source_location (method, native_offset, mono_domain_get ());
 	} else {
 		dest->managed_data.token = -1;
 	}
@@ -1405,11 +1403,28 @@ summarize_frame (StackFrameInfo *frame, MonoContext *ctx, gpointer data)
 	return FALSE;
 }
 
+static gboolean
+summarize_frame (StackFrameInfo *frame, MonoContext *ctx, gpointer data)
+{
+	// Don't record trampolines between managed frames
+	if (frame->ji && frame->ji->is_trampoline)
+		return TRUE;
+
+	MonoMethod *method = NULL;
+	intptr_t ip = 0x0;
+	mono_get_portable_ip ((intptr_t) MONO_CONTEXT_GET_IP (ctx), &ip, NULL);
+
+	g_assert (frame->ji && frame->type != FRAME_TYPE_TRAMPOLINE);
+	method = jinfo_get_method (frame->ji);
+
+	gboolean is_managed = (method != NULL);
+
+	return summarize_frame_internal (method, (gpointer) ip, frame->native_offset, is_managed, data);
+}
+
 static void 
 mono_summarize_stack (MonoDomain *domain, MonoThreadSummary *out, MonoContext *crash_ctx)
 {
-	intptr_t frame_ips [MONO_MAX_SUMMARY_FRAMES];
-
 	MonoSummarizeUserData data;
 	data.max_frames = MONO_MAX_SUMMARY_FRAMES;
 	data.num_frames = 0;
@@ -1425,11 +1440,12 @@ mono_summarize_stack (MonoDomain *domain, MonoThreadSummary *out, MonoContext *c
 	mono_walk_stack_with_ctx (summarize_frame, crash_ctx, MONO_UNWIND_LOOKUP_IL_OFFSET, &data);
 	out->num_managed_frames = data.num_frames;
 
-
 	// 
 	// Summarize unmanaged stack
 	// 
 #ifdef HAVE_BACKTRACE_SYMBOLS
+	intptr_t frame_ips [MONO_MAX_SUMMARY_FRAMES];
+
 	out->num_unmanaged_frames = backtrace ((void **)frame_ips, MONO_MAX_SUMMARY_FRAMES);
 
 	for (int i =0; i < out->num_unmanaged_frames; ++i) {
@@ -1447,6 +1463,20 @@ mono_summarize_stack (MonoDomain *domain, MonoThreadSummary *out, MonoContext *c
 	return;
 }
 #endif
+
+static void
+mono_summarize_exception (MonoException *exc, MonoThreadSummary *out)
+{
+	MonoSummarizeUserData data;
+	data.max_frames = MONO_MAX_SUMMARY_FRAMES;
+	data.num_frames = 0;
+	data.frames = out->managed_frames;
+	data.hashes = &out->hashes;
+
+	mono_exception_walk_trace (exc, summarize_frame_internal, &data);
+	out->num_managed_frames = data.num_frames;
+}
+
 
 MonoBoolean
 ves_icall_get_frame_info (gint32 skip, MonoBoolean need_file_info, 

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -68,6 +68,7 @@
 #include <mono/utils/mono-signal-handler.h>
 #include <mono/utils/mono-threads.h>
 #include <mono/utils/os-event.h>
+#include <mono/utils/mono-state.h>
 #include <mono/mini/debugger-state-machine.h>
 
 #include "mini.h"
@@ -958,44 +959,6 @@ print_process_map (void)
 #endif
 }
 
-#ifndef DISABLE_CRASH_REPORTING
-static void
-mono_crash_dump (const char *jsonFile)
-{
-	size_t size = strlen (jsonFile);
-
-	pid_t pid = getpid ();
-	gboolean success = FALSE;
-
-	// Save up to 100 dump files for a pid, in case mono is embedded?
-	for (int increment = 0; increment < 100; increment++) {
-		FILE* fp;
-		char *name = g_strdup_printf ("mono_crash.%d.%d.json", pid, increment);
-
-		if ((fp = fopen (name, "ab"))) {
-			if (ftell (fp) == 0) {
-				fwrite (jsonFile, size, 1, fp);
-				success = TRUE;
-			}
-		} else {
-			// Couldn't make file and file doesn't exist
-			g_warning ("Didn't have permission to access %s for file dump\n", name);
-		}
-
-		/*cleanup*/
-		if (fp)
-			fclose (fp);
-
-		g_free (name);
-
-		if (success)
-			return;
-	}
-
-	return;
-}
-#endif /* DISABLE_CRASH_REPORTING */
-
 static void
 dump_native_stacktrace (const char *signal, void *ctx)
 {
@@ -1058,7 +1021,7 @@ dump_native_stacktrace (const char *signal, void *ctx)
 			// We want our crash, and don't have telemetry
 			// So we dump to disk
 			if (!leave && !dump_for_merp)
-				mono_crash_dump (output);
+				mono_crash_dump (output, &hashes);
 		}
 #endif
 

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -242,8 +242,7 @@ MONO_SIG_HANDLER_FUNC (static, sigterm_signal_handler)
 #ifdef TARGET_OSX
 	if (mono_merp_enabled ()) {
 		pid_t crashed_pid = getpid ();
-		char *full_version = mono_get_runtime_build_info ();
-		mono_merp_invoke (crashed_pid, "SIGTERM", output, &hashes, full_version);
+		mono_merp_invoke (crashed_pid, "SIGTERM", output, &hashes);
 	} else
 #endif
 	{
@@ -1096,9 +1095,7 @@ dump_native_stacktrace (const char *signal, void *ctx)
 					exit (1);
 				}
 
-				char *full_version = mono_get_runtime_build_info ();
-
-				mono_merp_invoke (crashed_pid, signal, output, &hashes, full_version);
+				mono_merp_invoke (crashed_pid, signal, output, &hashes);
 
 				exit (1);
 			}

--- a/mono/utils/mono-merp.h
+++ b/mono/utils/mono-merp.h
@@ -47,7 +47,7 @@ gboolean mono_merp_enabled (void);
  * when the registered telemetry application does not respond.
  */
 void
-mono_merp_invoke (const intptr_t crashed_pid, const char *signal, const char *dump_file, MonoStackHash *hashes, char *version);
+mono_merp_invoke (const intptr_t crashed_pid, const char *signal, const char *dump_file, MonoStackHash *hashes);
 
 
 #endif // TARGET_OSX

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -146,15 +146,11 @@ mono_native_state_add_frames (JsonWriter *writer, int num_frames, MonoFrameSumma
 	mono_json_writer_array_end (writer);
 }
 
-static void
-mono_native_state_add_thread (JsonWriter *writer, MonoThreadSummary *thread, MonoContext *ctx)
+void
+mono_native_state_add_thread (JsonWriter *writer, MonoThreadSummary *thread, MonoContext *ctx, gboolean first_thread)
 {
-	static gboolean not_first_thread;
-
-	if (not_first_thread) {
+	if (!first_thread) {
 		mono_json_writer_printf (writer, ",\n");
-	} else {
-		not_first_thread = TRUE;
 	}
 
 	mono_json_writer_indent (writer);
@@ -182,7 +178,8 @@ mono_native_state_add_thread (JsonWriter *writer, MonoThreadSummary *thread, Mon
 	mono_json_writer_object_key(writer, "native_thread_id");
 	mono_json_writer_printf (writer, "\"0x%x\",\n", (gpointer) thread->native_thread_id);
 
-	mono_native_state_add_ctx (writer, ctx);
+	if (ctx)
+		mono_native_state_add_ctx (writer, ctx);
 
 	if (thread->num_managed_frames > 0) {
 		mono_native_state_add_frames (writer, thread->num_managed_frames, thread->managed_frames, "managed_frames");
@@ -487,7 +484,7 @@ mono_native_state_free (JsonWriter *writer, gboolean free_data)
 
 	// Make this interface work like the g_string free does
 	if (!free_data)
-		g_strdup (writer->text->str);
+		output = g_strdup (writer->text->str);
 
 	mono_json_writer_destroy (writer);
 	return output;
@@ -509,7 +506,10 @@ mono_summarize_native_state_end (void)
 void
 mono_summarize_native_state_add_thread (MonoThreadSummary *thread, MonoContext *ctx)
 {
-	mono_native_state_add_thread (&writer, thread, ctx);
+	
+	static gboolean not_first_thread = FALSE;
+	mono_native_state_add_thread (&writer, thread, ctx, !not_first_thread);
+	not_first_thread = TRUE;
 }
 
 #endif // DISABLE_CRASH_REPORTING

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -512,4 +512,40 @@ mono_summarize_native_state_add_thread (MonoThreadSummary *thread, MonoContext *
 	not_first_thread = TRUE;
 }
 
+void
+mono_crash_dump (const char *jsonFile, MonoStackHash *hashes)
+{
+	size_t size = strlen (jsonFile);
+
+	pid_t pid = getpid ();
+	gboolean success = FALSE;
+
+	// Save up to 100 dump files for a given stacktrace hash
+	for (int increment = 0; increment < 100; increment++) {
+		FILE* fp;
+		char *name = g_strdup_printf ("mono_crash.%d.%d.json", hashes->offset_free_hash, increment);
+
+		if ((fp = fopen (name, "ab"))) {
+			if (ftell (fp) == 0) {
+				fwrite (jsonFile, size, 1, fp);
+				success = TRUE;
+			}
+		} else {
+			// Couldn't make file and file doesn't exist
+			g_warning ("Didn't have permission to access %s for file dump\n", name);
+		}
+
+		/*cleanup*/
+		if (fp)
+			fclose (fp);
+
+		g_free (name);
+
+		if (success)
+			return;
+	}
+
+	return;
+}
+
 #endif // DISABLE_CRASH_REPORTING

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -10,7 +10,6 @@
  */
 #include <config.h>
 #include <glib.h>
-#include <mono/utils/json.h>
 #include <mono/utils/mono-state.h>
 #include <mono/utils/mono-threads-coop.h>
 #include <mono/metadata/object-internals.h>
@@ -147,7 +146,6 @@ mono_native_state_add_frames (JsonWriter *writer, int num_frames, MonoFrameSumma
 	mono_json_writer_array_end (writer);
 }
 
-
 static void
 mono_native_state_add_thread (JsonWriter *writer, MonoThreadSummary *thread, MonoContext *ctx)
 {
@@ -268,10 +266,12 @@ mono_native_state_add_version (JsonWriter *writer)
 	mono_json_writer_object_key(writer, "configuration");
 	mono_json_writer_object_begin(writer);
 
-	char *build = mono_get_runtime_callbacks ()->get_runtime_build_info ();
 	mono_json_writer_indent (writer);
 	mono_json_writer_object_key(writer, "version");
+
+	char *build = mono_get_runtime_callbacks ()->get_runtime_build_info ();
 	mono_json_writer_printf (writer, "\"%s\",\n", build);
+	g_free (build);
 
 	mono_json_writer_indent (writer);
 	mono_json_writer_object_key(writer, "tlc");
@@ -467,17 +467,43 @@ mono_native_state_add_epilogue (JsonWriter *writer)
 }
 
 void
+mono_native_state_init (JsonWriter *writer)
+{
+	mono_native_state_add_prologue (writer);
+}
+
+char *
+mono_native_state_emit (JsonWriter *writer)
+{
+	mono_native_state_add_epilogue (writer);
+	return writer->text->str;
+}
+
+char *
+mono_native_state_free (JsonWriter *writer, gboolean free_data)
+{
+	mono_native_state_add_epilogue (writer);
+	char *output = NULL;
+
+	// Make this interface work like the g_string free does
+	if (!free_data)
+		g_strdup (writer->text->str);
+
+	mono_json_writer_destroy (writer);
+	return output;
+}
+
+void
 mono_summarize_native_state_begin (void)
 {
 	mono_json_writer_init_static ();
-	mono_native_state_add_prologue (&writer);
+	mono_native_state_init (&writer);
 }
 
 char *
 mono_summarize_native_state_end (void)
 {
-	mono_native_state_add_epilogue (&writer);
-	return writer.text->str;
+	return mono_native_state_emit (&writer);
 }
 
 void

--- a/mono/utils/mono-state.h
+++ b/mono/utils/mono-state.h
@@ -51,6 +51,9 @@ mono_native_state_free (JsonWriter *writer, gboolean free_data);
 void
 mono_native_state_add_thread (JsonWriter *writer, MonoThreadSummary *thread, MonoContext *ctx, gboolean first_thread);
 
+void
+mono_crash_dump (const char *jsonFile, MonoStackHash *hashes);
+
 MONO_END_DECLS
 #endif // DISABLE_CRASH_REPORTING
 

--- a/mono/utils/mono-state.h
+++ b/mono/utils/mono-state.h
@@ -22,6 +22,10 @@
 
 MONO_BEGIN_DECLS
 
+/*
+ * These use static memory, can only be called once
+ */
+
 void
 mono_summarize_native_state_begin (void);
 
@@ -31,6 +35,10 @@ mono_summarize_native_state_end (void);
 void
 mono_summarize_native_state_add_thread (MonoThreadSummary *thread, MonoContext *ctx);
 
+/*
+ * These use memory from the caller
+ */
+
 void
 mono_native_state_init (JsonWriter *writer);
 
@@ -39,6 +47,9 @@ mono_native_state_emit (JsonWriter *writer);
 
 char *
 mono_native_state_free (JsonWriter *writer, gboolean free_data);
+
+void
+mono_native_state_add_thread (JsonWriter *writer, MonoThreadSummary *thread, MonoContext *ctx, gboolean first_thread);
 
 MONO_END_DECLS
 #endif // DISABLE_CRASH_REPORTING

--- a/mono/utils/mono-state.h
+++ b/mono/utils/mono-state.h
@@ -16,6 +16,7 @@
 #include <mono/utils/mono-publib.h>
 #include <mono/utils/mono-context.h>
 #include <mono/metadata/threads-types.h>
+#include <mono/utils/json.h>
 
 #define MONO_NATIVE_STATE_PROTOCOL_VERSION "0.0.1"
 
@@ -29,6 +30,15 @@ mono_summarize_native_state_end (void);
 
 void
 mono_summarize_native_state_add_thread (MonoThreadSummary *thread, MonoContext *ctx);
+
+void
+mono_native_state_init (JsonWriter *writer);
+
+char *
+mono_native_state_emit (JsonWriter *writer);
+
+char *
+mono_native_state_free (JsonWriter *writer, gboolean free_data);
 
 MONO_END_DECLS
 #endif // DISABLE_CRASH_REPORTING


### PR DESCRIPTION
This enables a correctly-configured runtime to convert unhandled exceptions into telemetry-formatted dumps.

https://github.com/mono/mono/pull/10133