### PR TITLE
[mini] Don't regen Makefile.am if llvm/llvm_config.mk changes

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -1007,7 +1007,7 @@ endif
 
 if HAS_EXTENSION_MODULE
 else
-Makefile.am: Makefile.am.in $(llvm_makefile_dep)
+Makefile.am: Makefile.am.in
 	echo "##################### Generated from Makefile.am.in, do not modify ##########################" > $@
 	cat $< >> $@
 


### PR DESCRIPTION
The llvm/llvm_config.mk makefile fragment just includes make (not automake)
variable definitions.  So there is no need to regenerate the mini/Makefile.am
file if the fragment updates - the include will pick it up.

