### PR TITLE
[cxx] Make some code valid C++, esp. adding casts and esp. not touching allocators. alternative to 10036

### DIFF
--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -286,6 +286,7 @@ common_sources = \
 	image-internals.h	\
 	jit-info.c		\
 	loader.c		\
+	loader-internals.h	\
 	locales.c		\
 	locales.h		\
 	lock-tracer.c		\

--- a/mono/metadata/callspec.c
+++ b/mono/metadata/callspec.c
@@ -36,12 +36,12 @@ mono_callspec_eval_exception (MonoClass *klass, MonoCallSpec *spec)
 
 		switch (op->op) {
 		case MONO_TRACEOP_EXCEPTION:
-			if (strcmp ("", op->data) == 0 &&
-			    strcmp ("all", op->data2) == 0)
+			if (strcmp ("", (const char*)op->data) == 0 &&
+			    strcmp ("all", (const char*)op->data2) == 0)
 				inc = 1;
-			else if (strcmp ("", op->data) == 0 ||
-				 strcmp (m_class_get_name_space (klass), op->data) == 0)
-				if (strcmp (m_class_get_name (klass), op->data2) == 0)
+			else if (strcmp ("", (const char*)op->data) == 0 ||
+				 strcmp (m_class_get_name_space (klass), (const char*)op->data) == 0)
+				if (strcmp (m_class_get_name (klass), (const char*)op->data2) == 0)
 					inc = 1;
 			break;
 		default:
@@ -86,7 +86,7 @@ gboolean mono_callspec_eval (MonoMethod *method, const MonoCallSpec *spec)
 				inc = 1;
 			break;
 		case MONO_TRACEOP_METHOD:
-			mdesc = op->data;
+			mdesc = (MonoMethodDesc*)op->data;
 			is_full = mono_method_desc_is_full (mdesc);
 			if (is_full &&
 			    mono_method_desc_full_match (mdesc, method))
@@ -95,18 +95,18 @@ gboolean mono_callspec_eval (MonoMethod *method, const MonoCallSpec *spec)
 				inc = 1;
 			break;
 		case MONO_TRACEOP_CLASS:
-			if (strcmp (m_class_get_name_space (method->klass), op->data) == 0)
-				if (strcmp (m_class_get_name (method->klass), op->data2) ==
+			if (strcmp (m_class_get_name_space (method->klass), (const char*)op->data) == 0)
+				if (strcmp (m_class_get_name (method->klass), (const char*)op->data2) ==
 				    0)
 					inc = 1;
 			break;
 		case MONO_TRACEOP_ASSEMBLY:
 			if (strcmp (mono_image_get_name (m_class_get_image (method->klass)),
-				    op->data) == 0)
+				    (const char*)op->data) == 0)
 				inc = 1;
 			break;
 		case MONO_TRACEOP_NAMESPACE:
-			if (strcmp (m_class_get_name_space (method->klass), op->data) == 0)
+			if (strcmp (m_class_get_name_space (method->klass), (const char*)op->data) == 0)
 				inc = 1;
 			break;
 		case MONO_TRACEOP_EXCEPTION:

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1068,9 +1068,6 @@ MonoJitICallInfo *
 mono_register_jit_icall_full (gconstpointer func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper, const char *c_symbol);
 
 #ifdef __cplusplus
-extern "C++" // in case of surrounding extern "C"
-{
-
 template <typename T>
 inline MonoJitICallInfo *
 mono_register_jit_icall (T func, const char *name, MonoMethodSignature *sig, gboolean is_save)
@@ -1084,8 +1081,6 @@ mono_register_jit_icall_full (T func, const char *name, MonoMethodSignature *sig
 {
 	return mono_register_jit_icall_full ((gconstpointer)func, name, sig, no_wrapper, c_symbol);
 }
-
-} // extern "C++"
 #endif // __cplusplus
 
 void

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1067,6 +1067,27 @@ mono_register_jit_icall (gconstpointer func, const char *name, MonoMethodSignatu
 MonoJitICallInfo *
 mono_register_jit_icall_full (gconstpointer func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper, const char *c_symbol);
 
+#ifdef __cplusplus
+extern "C++" // in case of surrounding extern "C"
+{
+
+template <typename T>
+inline MonoJitICallInfo *
+mono_register_jit_icall (T func, const char *name, MonoMethodSignature *sig, gboolean is_save)
+{
+	return mono_register_jit_icall ((gconstpointer)func, name, sig, is_save);
+}
+
+template <typename T>
+inline MonoJitICallInfo *
+mono_register_jit_icall_full (T func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper, const char *c_symbol)
+{
+	return mono_register_jit_icall_full ((gconstpointer)func, name, sig, no_wrapper, c_symbol);
+}
+
+} // extern "C++"
+#endif // __cplusplus
+
 void
 mono_register_jit_icall_wrapper (MonoJitICallInfo *info, gconstpointer wrapper);
 

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -80,8 +80,14 @@ mono_IUnknown_Release (MonoIUnknown *pUnk)
 /*
 Code shared between the DISABLE_COM and !DISABLE_COM
 */
+#ifdef __cplusplus
+template <typename T>
+static void
+register_icall (       T func, const char *name, const char *sigstr, gboolean save)
+#else
 static void
 register_icall (gpointer func, const char *name, const char *sigstr, gboolean save)
+#endif
 {
 	MonoMethodSignature *sig = mono_create_icall_signature (sigstr);
 
@@ -99,9 +105,6 @@ mono_string_to_bstr_handle (MonoStringHandle s)
 	mono_gchandle_free (gchandle);
 	return res;
 }
-
-// Cast the first parameter to gpointer; macros do not recurse.
-#define register_icall(func, name, sigstr, save) (register_icall ((gpointer)(func), (name), (sigstr), (save)))
 
 gpointer
 mono_string_to_bstr (MonoString* s_raw)

--- a/mono/metadata/file-mmap-posix.c
+++ b/mono/metadata/file-mmap-posix.c
@@ -387,7 +387,7 @@ mono_mmap_open_file (const gunichar2 *path, gint path_length, int mode, const gu
 	if (!mapName) {
 		char * c_path = mono_utf16_to_utf8 (path, path_length, error);
 		return_val_if_nok (error, NULL);
-		handle = open_file_map (c_path, -1, mode, capacity, access, options, ioerror);
+		handle = (MmapHandle*)open_file_map (c_path, -1, mode, capacity, access, options, ioerror);
 		g_free (c_path);
 		return handle;
 	}
@@ -416,7 +416,7 @@ mono_mmap_open_file (const gunichar2 *path, gint path_length, int mode, const gu
 		}
 		named_regions_unlock ();
 	} else
-		handle = open_memory_map (c_mapName, mode, capacity, access, options, ioerror);
+		handle = (MmapHandle*)open_memory_map (c_mapName, mode, capacity, access, options, ioerror);
 
 	g_free (c_mapName);
 	return handle;

--- a/mono/metadata/filewatcher.c
+++ b/mono/metadata/filewatcher.c
@@ -225,7 +225,7 @@ ves_icall_System_IO_InotifyWatcher_RemoveWatch (int fd, gint32 watch_descriptor)
 static void
 interrupt_kevent (gpointer data)
 {
-	int *kq_ptr = data;
+	int *kq_ptr = (int*)data;
 
 	/* Interrupt the kevent () call by closing the fd */
 	close (*kq_ptr);
@@ -252,7 +252,7 @@ ves_icall_System_IO_KqueueMonitor_kevent_notimeout (int *kq_ptr, gpointer change
 	}
 
 	MONO_ENTER_GC_SAFE;
-	res = kevent (*kq_ptr, changelist, nchanges, eventlist, nevents, NULL);
+	res = kevent (*kq_ptr, (const struct kevent*)changelist, nchanges, (struct kevent*)eventlist, nevents, NULL);
 	MONO_EXIT_GC_SAFE;
 
 	mono_thread_info_uninstall_interrupt (&interrupted);

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -807,7 +807,7 @@ finalize_domain_objects (void)
 	DomainFinalizationReq *req = NULL;
 	MonoDomain *domain;
 
-	if (UnlockedReadPointer ((gpointer)&domains_to_finalize)) {
+	if (UnlockedReadPointer ((gpointer volatile*)&domains_to_finalize)) {
 		mono_finalizer_lock ();
 		if (domains_to_finalize) {
 			req = (DomainFinalizationReq *)domains_to_finalize->data;

--- a/mono/metadata/icall-table.c
+++ b/mono/metadata/icall-table.c
@@ -211,7 +211,7 @@ static const char* const icall_names [] = {
 
 static const gconstpointer icall_functions [] = {
 #define ICALL_TYPE(id,name,first)
-#define ICALL(id,name,func) func,
+#define ICALL(id,name,func) ((gpointer)(func)),
 #define HANDLES(inner) inner
 #define NOHANDLES(inner) inner
 #include "metadata/icall-def.h"
@@ -256,7 +256,7 @@ static int
 compare_method_imap (const void *key, const void *elem)
 {
 	const char* method_name = (const char*)&icall_names_str + (*(guint16*)elem);
-	return strcmp (key, method_name);
+	return strcmp ((const char*)key, method_name);
 }
 
 static gsize
@@ -290,7 +290,7 @@ static int
 compare_class_imap (const void *key, const void *elem)
 {
 	const char* class_name = (const char*)&icall_type_names_str + (*(guint16*)elem);
-	return strcmp (key, class_name);
+	return strcmp ((const char*)key, class_name);
 }
 
 static const IcallTypeDesc*
@@ -308,7 +308,7 @@ static int
 compare_method_imap (const void *key, const void *elem)
 {
 	const char** method_name = (const char**)elem;
-	return strcmp (key, *method_name);
+	return strcmp ((const char*)key, *method_name);
 }
 
 static gsize

--- a/mono/metadata/loader-internals.h
+++ b/mono/metadata/loader-internals.h
@@ -1,0 +1,19 @@
+/**
+* \file
+*/
+
+#ifndef _MONO_METADATA_LOADER_INTERNALS_H_
+#define _MONO_METADATA_LOADER_INTERNALS_H_
+
+#ifdef __cplusplus
+
+template <typename T>
+inline void
+mono_add_internal_call (const char *name, T method)
+{
+	return mono_add_internal_call (name, (const void*)method);
+}
+
+#endif // __cplusplus
+
+#endif

--- a/mono/metadata/loader.h
+++ b/mono/metadata/loader.h
@@ -58,6 +58,20 @@ mono_method_get_index      (MonoMethod *method);
 MONO_API void
 mono_add_internal_call     (const char *name, const void* method);
 
+#ifdef __cplusplus
+extern "C++" // due to surrounding extern "C"
+{
+
+template <typename T>
+inline void
+mono_add_internal_call (const char *name, T method)
+{
+	return mono_add_internal_call (name, (const void*)method);
+}
+
+} // extern "C++"
+#endif // __cplusplus
+
 MONO_API void*
 mono_lookup_internal_call (MonoMethod *method);
 

--- a/mono/metadata/loader.h
+++ b/mono/metadata/loader.h
@@ -58,20 +58,6 @@ mono_method_get_index      (MonoMethod *method);
 MONO_API void
 mono_add_internal_call     (const char *name, const void* method);
 
-#ifdef __cplusplus
-extern "C++" // due to surrounding extern "C"
-{
-
-template <typename T>
-inline void
-mono_add_internal_call (const char *name, T method)
-{
-	return mono_add_internal_call (name, (const void*)method);
-}
-
-} // extern "C++"
-#endif // __cplusplus
-
 MONO_API void*
 mono_lookup_internal_call (MonoMethod *method);
 

--- a/mono/metadata/locales.c
+++ b/mono/metadata/locales.c
@@ -467,15 +467,15 @@ get_darwin_locale (void)
 	locale = CFLocaleCopyCurrent ();
 
 	if (locale) {
-		locale_language = CFLocaleGetValue (locale, kCFLocaleLanguageCode);
+		locale_language = (CFStringRef)CFLocaleGetValue (locale, kCFLocaleLanguageCode);
 		if (locale_language != NULL && CFStringGetBytes(locale_language, CFRangeMake (0, CFStringGetLength (locale_language)), kCFStringEncodingMacRoman, 0, FALSE, NULL, 0, &bytes_converted) > 0) {
 			len = bytes_converted + 1;
 
-			locale_country = CFLocaleGetValue (locale, kCFLocaleCountryCode);
+			locale_country = (CFStringRef)CFLocaleGetValue (locale, kCFLocaleCountryCode);
 			if (locale_country != NULL && CFStringGetBytes (locale_country, CFRangeMake (0, CFStringGetLength (locale_country)), kCFStringEncodingMacRoman, 0, FALSE, NULL, 0, &bytes_converted) > 0) {
 				len += bytes_converted + 1;
 
-				locale_script = CFLocaleGetValue (locale, kCFLocaleScriptCode);
+				locale_script = (CFStringRef)CFLocaleGetValue (locale, kCFLocaleScriptCode);
 				if (locale_script != NULL && CFStringGetBytes (locale_script, CFRangeMake (0, CFStringGetLength (locale_script)), kCFStringEncodingMacRoman, 0, FALSE, NULL, 0, &bytes_converted) > 0) {
 					len += bytes_converted + 1;
 				}

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -162,7 +162,7 @@ get_fixed_buffer_attr (MonoClassField *field, MonoType **out_etype, int *out_len
 															  &typed_args, &named_args, &num_named_args, &arginfo, error);
 		if (!is_ok (error))
 			return FALSE;
-		*out_etype = typed_args [0];
+		*out_etype = (MonoType*)typed_args [0];
 		*out_len = *(gint32*)typed_args [1];
 		g_free (typed_args);
 		g_free (named_args);
@@ -560,6 +560,7 @@ emit_ptr_to_object_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv 
 static gpointer
 conv_to_icall (MonoMarshalConv conv, int *ind_store_type)
 {
+#define return return (gpointer)
 	int dummy;
 	if (!ind_store_type)
 		ind_store_type = &dummy;
@@ -642,6 +643,7 @@ conv_to_icall (MonoMarshalConv conv, int *ind_store_type)
 	}
 
 	return NULL;
+#undef return
 }
 
 static void
@@ -1183,13 +1185,13 @@ emit_thread_interrupt_checkpoint (MonoMethodBuilder *mb)
 	if (strstr (mb->name, "mono_thread_interruption_checkpoint"))
 		return;
 	
-	emit_thread_interrupt_checkpoint_call (mb, mono_thread_interruption_checkpoint);
+	emit_thread_interrupt_checkpoint_call (mb, (gpointer)mono_thread_interruption_checkpoint);
 }
 
 static void
 emit_thread_force_interrupt_checkpoint (MonoMethodBuilder *mb)
 {
-	emit_thread_interrupt_checkpoint_call (mb, mono_thread_force_interruption_checkpoint_noraise);
+	emit_thread_interrupt_checkpoint_call (mb, (gpointer)mono_thread_force_interruption_checkpoint_noraise);
 }
 
 void

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -560,90 +560,88 @@ emit_ptr_to_object_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv 
 static gpointer
 conv_to_icall (MonoMarshalConv conv, int *ind_store_type)
 {
-#define return return (gpointer)
 	int dummy;
 	if (!ind_store_type)
 		ind_store_type = &dummy;
 	*ind_store_type = CEE_STIND_I;
 	switch (conv) {
 	case MONO_MARSHAL_CONV_STR_LPWSTR:
-		return mono_marshal_string_to_utf16;		
+		return (gpointer)mono_marshal_string_to_utf16;
 	case MONO_MARSHAL_CONV_LPWSTR_STR:
 		*ind_store_type = CEE_STIND_REF;
-		return ves_icall_mono_string_from_utf16;
+		return (gpointer)ves_icall_mono_string_from_utf16;
 	case MONO_MARSHAL_CONV_LPTSTR_STR:
 		*ind_store_type = CEE_STIND_REF;
-		return ves_icall_string_new_wrapper;
+		return (gpointer)ves_icall_string_new_wrapper;
 	case MONO_MARSHAL_CONV_UTF8STR_STR:
 	case MONO_MARSHAL_CONV_LPSTR_STR:
 		*ind_store_type = CEE_STIND_REF;
-		return ves_icall_string_new_wrapper;
+		return (gpointer)ves_icall_string_new_wrapper;
 	case MONO_MARSHAL_CONV_STR_LPTSTR:
 #ifdef TARGET_WIN32
-		return mono_marshal_string_to_utf16;
+		return (gpointer)mono_marshal_string_to_utf16;
 #else
-		return mono_string_to_utf8str;
+		return (gpointer)mono_string_to_utf8str;
 #endif
 		// In Mono historically LPSTR was treated as a UTF8STR
 	case MONO_MARSHAL_CONV_STR_UTF8STR:
 	case MONO_MARSHAL_CONV_STR_LPSTR:
-		return mono_string_to_utf8str;
+		return (gpointer)mono_string_to_utf8str;
 	case MONO_MARSHAL_CONV_STR_BSTR:
-		return mono_string_to_bstr;
+		return (gpointer)mono_string_to_bstr;
 	case MONO_MARSHAL_CONV_BSTR_STR:
 		*ind_store_type = CEE_STIND_REF;
-		return mono_string_from_bstr_icall;
+		return (gpointer)mono_string_from_bstr_icall;
 	case MONO_MARSHAL_CONV_STR_TBSTR:
 	case MONO_MARSHAL_CONV_STR_ANSIBSTR:
-		return mono_string_to_ansibstr;
+		return (gpointer)mono_string_to_ansibstr;
 	case MONO_MARSHAL_CONV_SB_UTF8STR:
 	case MONO_MARSHAL_CONV_SB_LPSTR:
-		return mono_string_builder_to_utf8;
+		return (gpointer)mono_string_builder_to_utf8;
 	case MONO_MARSHAL_CONV_SB_LPTSTR:
 #ifdef TARGET_WIN32
-		return mono_string_builder_to_utf16;
+		return (gpointer)mono_string_builder_to_utf16;
 #else
-		return mono_string_builder_to_utf8;
+		return (gpointer)mono_string_builder_to_utf8;
 #endif
 	case MONO_MARSHAL_CONV_SB_LPWSTR:
-		return mono_string_builder_to_utf16;
+		return (gpointer)mono_string_builder_to_utf16;
 	case MONO_MARSHAL_CONV_ARRAY_SAVEARRAY:
-		return mono_array_to_savearray;
+		return (gpointer)mono_array_to_savearray;
 	case MONO_MARSHAL_CONV_ARRAY_LPARRAY:
-		return mono_array_to_lparray;
+		return (gpointer)mono_array_to_lparray;
 	case MONO_MARSHAL_FREE_LPARRAY:
-		return mono_free_lparray;
+		return (gpointer)mono_free_lparray;
 	case MONO_MARSHAL_CONV_DEL_FTN:
-		return mono_delegate_to_ftnptr;
+		return (gpointer)mono_delegate_to_ftnptr;
 	case MONO_MARSHAL_CONV_FTN_DEL:
 		*ind_store_type = CEE_STIND_REF;
-		return mono_ftnptr_to_delegate;
+		return (gpointer)mono_ftnptr_to_delegate;
 	case MONO_MARSHAL_CONV_UTF8STR_SB:
 	case MONO_MARSHAL_CONV_LPSTR_SB:
 		*ind_store_type = CEE_STIND_REF;
-		return mono_string_utf8_to_builder;
+		return (gpointer)mono_string_utf8_to_builder;
 	case MONO_MARSHAL_CONV_LPTSTR_SB:
 		*ind_store_type = CEE_STIND_REF;
 #ifdef TARGET_WIN32
-		return mono_string_utf16_to_builder;
+		return (gpointer)mono_string_utf16_to_builder;
 #else
-		return mono_string_utf8_to_builder;
+		return (gpointer)mono_string_utf8_to_builder;
 #endif
 	case MONO_MARSHAL_CONV_LPWSTR_SB:
 		*ind_store_type = CEE_STIND_REF;
-		return mono_string_utf16_to_builder;
+		return (gpointer)mono_string_utf16_to_builder;
 	case MONO_MARSHAL_FREE_ARRAY:
-		return mono_marshal_free_array;
+		return (gpointer)mono_marshal_free_array;
 	case MONO_MARSHAL_CONV_STR_BYVALSTR:
-		return mono_string_to_byvalstr;
+		return (gpointer)mono_string_to_byvalstr;
 	case MONO_MARSHAL_CONV_STR_BYVALWSTR:
-		return mono_string_to_byvalwstr;
+		return (gpointer)mono_string_to_byvalwstr;
 	default:
 		g_assert_not_reached ();
 	}
 
 	return NULL;
-#undef return
 }
 
 static void

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -123,25 +123,33 @@ get_method_image (MonoMethod *method)
 	return m_class_get_image (method->klass);
 }
 
+#ifdef __cplusplus
+template <typename T>
+static void
+register_icall (T func, const char *name, const char *sigstr, gboolean no_wrapper)
+#else
 static void
 register_icall (gpointer func, const char *name, const char *sigstr, gboolean no_wrapper)
+#endif
 {
 	MonoMethodSignature *sig = mono_create_icall_signature (sigstr);
 
 	mono_register_jit_icall (func, name, sig, no_wrapper);
 }
 
+#ifdef __cplusplus
+template <typename T>
+static void
+register_icall_no_wrapper (T func , const char *name, const char *sigstr)
+#else
 static void
 register_icall_no_wrapper (gpointer func, const char *name, const char *sigstr)
+#endif
 {
 	MonoMethodSignature *sig = mono_create_icall_signature (sigstr);
 
 	mono_register_jit_icall (func, name, sig, TRUE);
 }
-
-// Cast the first parameter to gpointer; macros do not recurse.
-#define register_icall(func, name, sigstr, no_wrapper) (register_icall ((gpointer)(func), (name), (sigstr), (no_wrapper)))
-#define register_icall_no_wrapper(func, name, sigstr) (register_icall_no_wrapper ((gpointer)(func), (name), (sigstr)))
 
 MonoMethodSignature*
 mono_signature_no_pinvoke (MonoMethod *method)

--- a/mono/metadata/method-builder-ilgen.c
+++ b/mono/metadata/method-builder-ilgen.c
@@ -539,7 +539,8 @@ mono_mb_emit_native_call (MonoMethodBuilder *mb, MonoMethodSignature *sig, gpoin
 }
 
 void
-mono_mb_emit_icall (MonoMethodBuilder *mb, gpointer func)
+(mono_mb_emit_icall) (MonoMethodBuilder *mb, gpointer func)
+// Parens to not invoke macro.
 {
 	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
 	mono_mb_emit_op (mb, CEE_MONO_ICALL, func);

--- a/mono/metadata/method-builder-ilgen.c
+++ b/mono/metadata/method-builder-ilgen.c
@@ -539,8 +539,7 @@ mono_mb_emit_native_call (MonoMethodBuilder *mb, MonoMethodSignature *sig, gpoin
 }
 
 void
-(mono_mb_emit_icall) (MonoMethodBuilder *mb, gpointer func)
-// Parens to not invoke macro.
+mono_mb_emit_icall (MonoMethodBuilder *mb, gpointer func)
 {
 	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
 	mono_mb_emit_op (mb, CEE_MONO_ICALL, func);

--- a/mono/metadata/method-builder-ilgen.h
+++ b/mono/metadata/method-builder-ilgen.h
@@ -50,7 +50,19 @@ mono_mb_emit_managed_call (MonoMethodBuilder *mb, MonoMethod *method, MonoMethod
 void
 mono_mb_emit_icall (MonoMethodBuilder *mb, gpointer func);
 
-#define mono_mb_emit_icall(mb, function) mono_mb_emit_icall ((mb), (gpointer)(function))
+#ifdef __cplusplus
+extern "C++" // in case of surrounding extern "C"
+{
+
+template <typename T>
+inline void
+mono_mb_emit_icall (MonoMethodBuilder *mb, T func)
+{
+	mono_mb_emit_icall (mb, (gpointer)func);
+}
+
+} // extern "C++"
+#endif // __cplusplus
 
 int
 mono_mb_add_local (MonoMethodBuilder *mb, MonoType *type);

--- a/mono/metadata/method-builder-ilgen.h
+++ b/mono/metadata/method-builder-ilgen.h
@@ -50,6 +50,8 @@ mono_mb_emit_managed_call (MonoMethodBuilder *mb, MonoMethod *method, MonoMethod
 void
 mono_mb_emit_icall (MonoMethodBuilder *mb, gpointer func);
 
+#define mono_mb_emit_icall(mb, function) mono_mb_emit_icall ((mb), (gpointer)(function))
+
 int
 mono_mb_add_local (MonoMethodBuilder *mb, MonoType *type);
 

--- a/mono/metadata/method-builder-ilgen.h
+++ b/mono/metadata/method-builder-ilgen.h
@@ -51,17 +51,12 @@ void
 mono_mb_emit_icall (MonoMethodBuilder *mb, gpointer func);
 
 #ifdef __cplusplus
-extern "C++" // in case of surrounding extern "C"
-{
-
 template <typename T>
 inline void
 mono_mb_emit_icall (MonoMethodBuilder *mb, T func)
 {
 	mono_mb_emit_icall (mb, (gpointer)func);
 }
-
-} // extern "C++"
 #endif // __cplusplus
 
 int

--- a/mono/metadata/mono-conc-hash.c
+++ b/mono/metadata/mono-conc-hash.c
@@ -111,7 +111,7 @@ set_key (conc_table *table, int slot, gpointer key)
 {
 	gpointer *key_addr = &table->keys [slot];
 	if (table->gc_type & MONO_HASH_KEY_GC)
-		mono_gc_wbarrier_generic_store (key_addr, key);
+		mono_gc_wbarrier_generic_store (key_addr, (MonoObject*)key);
 	else
 		*key_addr = key;
 }
@@ -131,7 +131,7 @@ set_value (conc_table *table, int slot, gpointer value)
 {
 	gpointer *value_addr = &table->values [slot];
 	if (table->gc_type & MONO_HASH_VALUE_GC)
-		mono_gc_wbarrier_generic_store (value_addr, value);
+		mono_gc_wbarrier_generic_store (value_addr, (MonoObject*)value);
 	else
 		*value_addr = value;
 }

--- a/mono/metadata/mono-config.c
+++ b/mono/metadata/mono-config.c
@@ -315,7 +315,7 @@ dllmap_start (gpointer user_data,
 			if (strcmp (attribute_names [i], "dll") == 0)
 				info->dll = g_strdup (attribute_values [i]);
 			else if (strcmp (attribute_names [i], "target") == 0){
-				char *p = strstr (attribute_values [i], "$mono_libdir");
+				const char* p = strstr (attribute_values [i], "$mono_libdir");
 				if (p != NULL){
 					char *libdir = mono_native_getrootdir ();
 					size_t libdir_len = strlen (libdir);

--- a/mono/metadata/mono-hash.c
+++ b/mono/metadata/mono-hash.c
@@ -293,7 +293,7 @@ mono_g_hash_table_lookup_extended (MonoGHashTable *hash, gconstpointer key, gpoi
 
 	g_return_val_if_fail (hash != NULL, FALSE);
 
-	slot = mono_g_hash_table_find_slot (hash, key);
+	slot = mono_g_hash_table_find_slot (hash, (MonoObject*)key);
 
 	if (hash->keys [slot]) {
 		if (orig_key)
@@ -347,7 +347,7 @@ mono_g_hash_table_remove (MonoGHashTable *hash, gconstpointer key)
 	int slot, last_clear_slot;
 
 	g_return_val_if_fail (hash != NULL, FALSE);
-	slot = mono_g_hash_table_find_slot (hash, key);
+	slot = mono_g_hash_table_find_slot (hash, (MonoObject*)key);
 
 	if (!hash->keys [slot])
 		return FALSE;
@@ -456,7 +456,7 @@ mono_g_hash_table_insert_replace (MonoGHashTable *hash, gpointer key, gpointer v
 	if (hash->in_use > (hash->table_size * HASH_TABLE_MAX_LOAD_FACTOR))
 		rehash (hash);
 
-	slot = mono_g_hash_table_find_slot (hash, key);
+	slot = mono_g_hash_table_find_slot (hash, (MonoObject*)key);
 
 	if (hash->keys [slot]) {
 		if (replace) {

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -282,7 +282,7 @@ mono_type_initialization_init (void)
 	type_initialization_hash = g_hash_table_new (NULL, NULL);
 	blocked_thread_hash = g_hash_table_new (NULL, NULL);
 	mono_coop_mutex_init (&ldstr_section);
-	mono_register_jit_icall ((gpointer)ves_icall_string_alloc, "ves_icall_string_alloc", mono_create_icall_signature ("object int"), FALSE);
+	mono_register_jit_icall (ves_icall_string_alloc, "ves_icall_string_alloc", mono_create_icall_signature ("object int"), FALSE);
 }
 
 void

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -282,7 +282,7 @@ mono_type_initialization_init (void)
 	type_initialization_hash = g_hash_table_new (NULL, NULL);
 	blocked_thread_hash = g_hash_table_new (NULL, NULL);
 	mono_coop_mutex_init (&ldstr_section);
-	mono_register_jit_icall (ves_icall_string_alloc, "ves_icall_string_alloc", mono_create_icall_signature ("object int"), FALSE);
+	mono_register_jit_icall ((gpointer)ves_icall_string_alloc, "ves_icall_string_alloc", mono_create_icall_signature ("object int"), FALSE);
 }
 
 void
@@ -2823,7 +2823,7 @@ mono_upgrade_remote_class (MonoDomain *domain, MonoObjectHandle proxy_object, Mo
 		MONO_HANDLE_SETVAL (tproxy, remote_class, MonoRemoteClass*, fresh_remote_class);
 		MonoRealProxyHandle real_proxy = MONO_HANDLE_NEW (MonoRealProxy, NULL);
 		MONO_HANDLE_GET (real_proxy, tproxy, rp);
-		MONO_HANDLE_SETVAL (proxy_object, vtable, MonoVTable*, mono_remote_class_vtable (domain, fresh_remote_class, real_proxy, error));
+		MONO_HANDLE_SETVAL (proxy_object, vtable, MonoVTable*, (MonoVTable*)mono_remote_class_vtable (domain, fresh_remote_class, real_proxy, error));
 		goto_if_nok (error, leave);
 	}
 	

--- a/mono/metadata/pal-icalls.c
+++ b/mono/metadata/pal-icalls.c
@@ -12,7 +12,7 @@
 #include <glib.h>
 #include "mono/utils/mono-threads-api.h"
 #include "mono/utils/atomic.h"
-
+#include "loader-internals.h"
 #include "pal-icalls.h"
 
 /*

--- a/mono/metadata/pal-icalls.c
+++ b/mono/metadata/pal-icalls.c
@@ -28,10 +28,10 @@ mono_pal_init (void)
 {
 	volatile static gboolean module_initialized = FALSE;
 	if (mono_atomic_cas_i32 (&module_initialized, TRUE, FALSE) == FALSE) {
-		mono_add_internal_call ("Interop/Sys::Read", ves_icall_Interop_Sys_Read);
+		mono_add_internal_call ("Interop/Sys::Read", (gpointer)&ves_icall_Interop_Sys_Read);
 
 #if defined(__APPLE__)
-		mono_add_internal_call ("Interop/RunLoop::CFRunLoopRun", ves_icall_Interop_RunLoop_CFRunLoopRun);
+		mono_add_internal_call ("Interop/RunLoop::CFRunLoopRun", (gpointer)&ves_icall_Interop_RunLoop_CFRunLoopRun);
 #endif
 	}
 
@@ -56,7 +56,7 @@ static void
 interrupt_CFRunLoop (gpointer data)
 {
 	g_assert (data);
-	CFRunLoopStop (data);
+	CFRunLoopStop ((CFRunLoopRef)data);
 }
 
 void

--- a/mono/metadata/pal-icalls.c
+++ b/mono/metadata/pal-icalls.c
@@ -28,10 +28,10 @@ mono_pal_init (void)
 {
 	volatile static gboolean module_initialized = FALSE;
 	if (mono_atomic_cas_i32 (&module_initialized, TRUE, FALSE) == FALSE) {
-		mono_add_internal_call ("Interop/Sys::Read", (gpointer)&ves_icall_Interop_Sys_Read);
+		mono_add_internal_call ("Interop/Sys::Read", ves_icall_Interop_Sys_Read);
 
 #if defined(__APPLE__)
-		mono_add_internal_call ("Interop/RunLoop::CFRunLoopRun", (gpointer)&ves_icall_Interop_RunLoop_CFRunLoopRun);
+		mono_add_internal_call ("Interop/RunLoop::CFRunLoopRun", ves_icall_Interop_RunLoop_CFRunLoopRun);
 #endif
 	}
 

--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -30,7 +30,7 @@ load_profiler (MonoDl *module, const char *name, const char *desc)
 	char *err, *old_name = g_strdup_printf (OLD_INITIALIZER_NAME);
 	MonoProfilerInitializer func;
 
-	if (!(err = mono_dl_symbol (module, old_name, (gpointer) &func))) {
+	if (!(err = mono_dl_symbol (module, old_name, (gpointer*) &func))) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_PROFILER, "Found old-style startup symbol '%s' for the '%s' profiler; it has not been migrated to the new API.", old_name, name);
 		g_free (old_name);
 		return FALSE;
@@ -142,7 +142,8 @@ load_profiler_from_installation (const char *libname, const char *name, const ch
 void
 mono_profiler_load (const char *desc)
 {
-	char *col, *mname, *libname;
+	const char *col;
+	char *mname, *libname;
 
 	mname = libname = NULL;
 
@@ -319,7 +320,7 @@ mono_profiler_get_coverage_data (MonoProfilerHandle handle, MonoMethod *method, 
 
 	coverage_lock ();
 
-	MonoProfilerCoverageInfo *info = g_hash_table_lookup (mono_profiler_state.coverage_hash, method);
+	MonoProfilerCoverageInfo *info = (MonoProfilerCoverageInfo*)g_hash_table_lookup (mono_profiler_state.coverage_hash, method);
 
 	coverage_unlock ();
 
@@ -414,7 +415,7 @@ mono_profiler_coverage_instrumentation_enabled (MonoMethod *method)
 	gboolean cover = FALSE;
 
 	for (MonoProfilerHandle handle = mono_profiler_state.profilers; handle; handle = handle->next) {
-		MonoProfilerCoverageFilterCallback cb = handle->coverage_filter;
+		MonoProfilerCoverageFilterCallback cb = (MonoProfilerCoverageFilterCallback)handle->coverage_filter;
 
 		if (cb)
 			cover |= cb (handle->prof, method);
@@ -846,7 +847,7 @@ mono_profiler_cleanup (void)
 	MonoProfilerHandle head = mono_profiler_state.profilers;
 
 	while (head) {
-		MonoProfilerCleanupCallback cb = head->cleanup_callback;
+		MonoProfilerCleanupCallback cb = (MonoProfilerCleanupCallback)head->cleanup_callback;
 
 		if (cb)
 			cb (head->prof);
@@ -934,7 +935,7 @@ update_callback (volatile gpointer *location, gpointer new_, volatile gint32 *co
 	{ \
 		if (!mono_profiler_state.startup_done) return;	\
 		for (MonoProfilerHandle h = mono_profiler_state.profilers; h; h = h->next) { \
-			MonoProfiler ## type ## Callback cb = h->name ## _cb; \
+			MonoProfiler ## type ## Callback cb = (MonoProfiler ## type ## Callback)h->name ## _cb; \
 			if (cb) \
 				cb args; \
 		} \

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -187,7 +187,7 @@ clear_cached_object (MonoDomain *domain, gpointer o, MonoClass *klass)
 
 		if (mono_conc_g_hash_table_lookup_extended (domain->refobject_hash, &pe, &orig_pe, &orig_value)) {
 			mono_conc_g_hash_table_remove (domain->refobject_hash, &pe);
-			free_reflected_entry (orig_pe);
+			free_reflected_entry ((ReflectedEntry*)orig_pe);
 		}
 	}
 	mono_domain_unlock (domain);
@@ -196,7 +196,7 @@ clear_cached_object (MonoDomain *domain, gpointer o, MonoClass *klass)
 static void
 cleanup_refobject_hash (gpointer key, gpointer value, gpointer user_data)
 {
-	free_reflected_entry (key);
+	free_reflected_entry ((ReflectedEntry*)key);
 }
 
 void
@@ -1928,7 +1928,7 @@ mono_reflection_get_type_internal (MonoImage *rootimage, MonoImage* image, MonoT
 		mono_class_init (parent);
 
 		while ((klass = mono_class_get_nested_types (parent, &iter))) {
-			char *lastp;
+			const char *lastp;
 			char *nested_name, *nested_nspace;
 			gboolean match = TRUE;
 

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -108,6 +108,9 @@ register_icall (gpointer func, const char *name, const char *sigstr, gboolean sa
 	mono_register_jit_icall (func, name, sig, save);
 }
 
+#define register_icall(func, name, sigstr, save) \
+	(register_icall ((gpointer)(func), (name), (sigstr), (save)))
+
 static inline void
 remoting_lock (void)
 {

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -108,8 +108,20 @@ register_icall (gpointer func, const char *name, const char *sigstr, gboolean sa
 	mono_register_jit_icall (func, name, sig, save);
 }
 
-#define register_icall(func, name, sigstr, save) \
-	(register_icall ((gpointer)(func), (name), (sigstr), (save)))
+#ifdef __cplusplus
+extern "C++" // in case of surrounding extern "C"
+{
+
+template <typename T>
+static void
+register_icall (T func, const char *name, const char *sigstr, gboolean save)
+{
+	// This could also go directly to mono_register_jit_icall.
+	register_icall ((gpointer)func, name, sigstr, save);
+}
+
+} // extern "C++"
+#endif // __cplusplus
 
 static inline void
 remoting_lock (void)
@@ -232,7 +244,6 @@ mono_remoting_marshal_init (void)
 
 		register_icall (mono_context_get_icall, "mono_context_get_icall", "object", FALSE);
 		register_icall (mono_context_set_icall, "mono_context_set_icall", "void object", FALSE);
-
 	}
 
 	icalls_registered = TRUE;

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -100,23 +100,19 @@ static MonoMethod *method_set_call_context, *method_needs_context_sink, *method_
 static gpointer
 mono_compile_method_icall (MonoMethod *method);
 
+#ifdef __cplusplus
+template <typename T>
+static void
+register_icall (T func, const char *name, const char *sigstr, gboolean save)
+#else
 static void
 register_icall (gpointer func, const char *name, const char *sigstr, gboolean save)
+#endif
 {
 	MonoMethodSignature *sig = mono_create_icall_signature (sigstr);
 
 	mono_register_jit_icall (func, name, sig, save);
 }
-
-#ifdef __cplusplus
-template <typename T>
-static void
-register_icall (T func, const char *name, const char *sigstr, gboolean save)
-{
-	// This could also go directly to mono_register_jit_icall.
-	register_icall ((gpointer)func, name, sigstr, save);
-}
-#endif // __cplusplus
 
 static inline void
 remoting_lock (void)

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -109,9 +109,6 @@ register_icall (gpointer func, const char *name, const char *sigstr, gboolean sa
 }
 
 #ifdef __cplusplus
-extern "C++" // in case of surrounding extern "C"
-{
-
 template <typename T>
 static void
 register_icall (T func, const char *name, const char *sigstr, gboolean save)
@@ -119,8 +116,6 @@ register_icall (T func, const char *name, const char *sigstr, gboolean save)
 	// This could also go directly to mono_register_jit_icall.
 	register_icall ((gpointer)func, name, sigstr, save);
 }
-
-} // extern "C++"
 #endif // __cplusplus
 
 static inline void

--- a/mono/metadata/sgen-bridge.c
+++ b/mono/metadata/sgen-bridge.c
@@ -699,7 +699,7 @@ sgen_bridge_handle_gc_debug (const char *opt)
 	} else if (!strcmp (opt, "enable-bridge-accounting")) {
 		bridge_processor_config.accounting = TRUE;
 	} else if (g_str_has_prefix (opt, "bridge-dump=")) {
-		char *prefix = strchr (opt, '=') + 1;
+		const char* prefix = strchr (opt, '=') + 1;
 		set_dump_prefix(prefix);
 	} else if (g_str_has_prefix (opt, "bridge-compare-to=")) {
 		const char *name = strchr (opt, '=') + 1;

--- a/mono/metadata/sgen-client-mono.h
+++ b/mono/metadata/sgen-client-mono.h
@@ -379,8 +379,8 @@ static void
 mono_binary_protocol_alloc_generic (gpointer obj, gpointer vtable, size_t size, gboolean pinned)
 {
 #ifdef ENABLE_DTRACE
-	const char *name_space = sgen_client_vtable_get_namespace (vtable);
-	const char *name = sgen_client_vtable_get_name (vtable);
+	const char *name_space = sgen_client_vtable_get_namespace ((GCVTable)vtable);
+	const char *name = sgen_client_vtable_get_name ((GCVTable)vtable);
 
 	if (sgen_ptr_in_nursery (obj)) {
 		if (G_UNLIKELY (MONO_GC_NURSERY_OBJ_ALLOC_ENABLED ()))
@@ -411,7 +411,7 @@ sgen_client_binary_protocol_alloc_pinned (gpointer obj, gpointer vtable, size_t 
 static void G_GNUC_UNUSED
 sgen_client_binary_protocol_alloc_degraded (gpointer obj, gpointer vtable, size_t size, gpointer provenance)
 {
-	MONO_GC_MAJOR_OBJ_ALLOC_DEGRADED ((mword)obj, size, sgen_client_vtable_get_namespace (vtable), sgen_client_vtable_get_name (vtable));
+	MONO_GC_MAJOR_OBJ_ALLOC_DEGRADED ((mword)obj, size, sgen_client_vtable_get_namespace ((GCVTable)vtable), sgen_client_vtable_get_name ((GCVTable)vtable));
 }
 
 static void G_GNUC_UNUSED
@@ -436,8 +436,8 @@ sgen_client_binary_protocol_pin (gpointer obj, gpointer vtable, size_t size)
 	if (G_UNLIKELY (MONO_GC_OBJ_PINNED_ENABLED ())) {
 		int gen = sgen_ptr_in_nursery (obj) ? GENERATION_NURSERY : GENERATION_OLD;
 		MONO_GC_OBJ_PINNED ((mword)obj,
-				sgen_safe_object_get_size (obj),
-				sgen_client_vtable_get_namespace (vtable), sgen_client_vtable_get_name (vtable), gen);
+				sgen_safe_object_get_size ((GCObject*)obj),
+				sgen_client_vtable_get_namespace ((GCVTable)vtable), sgen_client_vtable_get_name ((GCVTable)vtable), gen);
 	}
 #endif
 }
@@ -478,7 +478,7 @@ sgen_client_binary_protocol_cement (gpointer ptr, gpointer vtable, size_t size)
 #ifdef ENABLE_DTRACE
 	if (G_UNLIKELY (MONO_GC_OBJ_CEMENTED_ENABLED())) {
 		MONO_GC_OBJ_CEMENTED ((mword)ptr, sgen_safe_object_get_size ((GCObject*)ptr),
-				sgen_client_vtable_get_namespace (vtable), sgen_client_vtable_get_name (vtable));
+				sgen_client_vtable_get_namespace ((GCVTable)vtable), sgen_client_vtable_get_name ((GCVTable)vtable));
 	}
 #endif
 }
@@ -490,7 +490,7 @@ sgen_client_binary_protocol_copy (gpointer from, gpointer to, gpointer vtable, s
 	if (G_UNLIKELY (MONO_GC_OBJ_MOVED_ENABLED ())) {
 		int dest_gen = sgen_ptr_in_nursery (to) ? GENERATION_NURSERY : GENERATION_OLD;
 		int src_gen = sgen_ptr_in_nursery (from) ? GENERATION_NURSERY : GENERATION_OLD;
-		MONO_GC_OBJ_MOVED ((mword)to, (mword)from, dest_gen, src_gen, size, sgen_client_vtable_get_namespace (vtable), sgen_client_vtable_get_name (vtable));
+		MONO_GC_OBJ_MOVED ((mword)to, (mword)from, dest_gen, src_gen, size, sgen_client_vtable_get_namespace ((GCVTable)vtable), sgen_client_vtable_get_name ((GCVTable)vtable));
 	}
 #endif
 }
@@ -500,8 +500,8 @@ sgen_client_binary_protocol_global_remset (gpointer ptr, gpointer value, gpointe
 {
 #ifdef ENABLE_DTRACE
 	if (G_UNLIKELY (MONO_GC_GLOBAL_REMSET_ADD_ENABLED ())) {
-		MONO_GC_GLOBAL_REMSET_ADD ((mword)ptr, (mword)value, sgen_safe_object_get_size (value),
-				sgen_client_vtable_get_namespace (value_vtable), sgen_client_vtable_get_name (value_vtable));
+		MONO_GC_GLOBAL_REMSET_ADD ((mword)ptr, (mword)value, sgen_safe_object_get_size ((GCObject*)value),
+				sgen_client_vtable_get_namespace ((GCVTable)value_vtable), sgen_client_vtable_get_name ((GCVTable)value_vtable));
 	}
 #endif
 }
@@ -534,7 +534,7 @@ sgen_client_binary_protocol_dislink_update (gpointer link, gpointer obj, gboolea
 		GCVTable vt = obj ? SGEN_LOAD_VTABLE (obj) : NULL;
 		MONO_GC_WEAK_UPDATE ((mword)link,
 				(mword)obj,
-				obj ? (mword)sgen_safe_object_get_size (obj) : (mword)0,
+				obj ? sgen_safe_object_get_size ((GCObject*)obj) : 0u,
 				obj ? sgen_client_vtable_get_namespace (vt) : NULL,
 				obj ? sgen_client_vtable_get_name (vt) : NULL,
 				track ? 1 : 0);

--- a/mono/metadata/sgen-dynarray.h
+++ b/mono/metadata/sgen-dynarray.h
@@ -250,7 +250,7 @@ dyn_array_ptr_set (DynPtrArray *da, int x, void *ptr)
 #ifdef OPTIMIZATION_SINGLETON_DYN_ARRAY
 	if (da->array.capacity == 1) {
 		g_assert (x == 0);
-		da->array.data = ptr;
+		da->array.data = (char*)ptr;
 	} else
 #endif
 	{

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -995,8 +995,6 @@ create_allocator (int atype, ManagedAllocatorVariant variant)
 	int num_params, i;
 
 	if (!registered) {
-// Cast the first parameter to gpointer; macros do not recurse.
-#define mono_register_jit_icall(func, name, sig, no_wrapper) (mono_register_jit_icall ((gpointer)(func), (name), (sig), (no_wrapper)))
 		mono_register_jit_icall (mono_gc_alloc_obj, "mono_gc_alloc_obj", mono_create_icall_signature ("object ptr int"), FALSE);
 		mono_register_jit_icall (mono_gc_alloc_vector, "mono_gc_alloc_vector", mono_create_icall_signature ("object ptr int int"), FALSE);
 		mono_register_jit_icall (mono_gc_alloc_string, "mono_gc_alloc_string", mono_create_icall_signature ("object ptr int int32"), FALSE);

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -995,6 +995,8 @@ create_allocator (int atype, ManagedAllocatorVariant variant)
 	int num_params, i;
 
 	if (!registered) {
+// Cast the first parameter to gpointer; macros do not recurse.
+#define mono_register_jit_icall(func, name, sig, no_wrapper) (mono_register_jit_icall ((gpointer)(func), (name), (sig), (no_wrapper)))
 		mono_register_jit_icall (mono_gc_alloc_obj, "mono_gc_alloc_obj", mono_create_icall_signature ("object ptr int"), FALSE);
 		mono_register_jit_icall (mono_gc_alloc_vector, "mono_gc_alloc_vector", mono_create_icall_signature ("object ptr int int"), FALSE);
 		mono_register_jit_icall (mono_gc_alloc_string, "mono_gc_alloc_string", mono_create_icall_signature ("object ptr int int32"), FALSE);
@@ -1444,9 +1446,9 @@ mono_gc_set_string_length (MonoString *str, gint32 new_length)
  */
 
 #define GC_ROOT_NUM 32
-#define SPECIAL_ADDRESS_FIN_QUEUE ((void*)1)
-#define SPECIAL_ADDRESS_CRIT_FIN_QUEUE ((void*)2)
-#define SPECIAL_ADDRESS_EPHEMERON ((void*)3)
+#define SPECIAL_ADDRESS_FIN_QUEUE ((mono_byte*)1)
+#define SPECIAL_ADDRESS_CRIT_FIN_QUEUE ((mono_byte*)2)
+#define SPECIAL_ADDRESS_EPHEMERON ((mono_byte*)3)
 
 typedef struct {
 	int count;		/* must be the first field */
@@ -1476,7 +1478,7 @@ report_gc_root (GCRootReport *report, void *address, void *object)
 static void
 single_arg_report_root (MonoObject **obj, void *gc_data)
 {
-	GCRootReport *report = gc_data;
+	GCRootReport *report = (GCRootReport*)gc_data;
 	if (*obj)
 		report_gc_root (report, obj, *obj);
 }
@@ -1484,7 +1486,7 @@ single_arg_report_root (MonoObject **obj, void *gc_data)
 static void
 two_args_report_root (void *address, MonoObject *obj, void *gc_data)
 {
-	GCRootReport *report = gc_data;
+	GCRootReport *report = (GCRootReport*)gc_data;
 	if (obj)
 		report_gc_root (report, address, obj);
 }
@@ -1568,12 +1570,12 @@ find_pinned_obj (char *addr)
 
 	if (idx != pinned_objects.next_slot) {
 		if (pinned_objects.data [idx] == addr)
-			return pinned_objects.data [idx];
+			return (GCObject*)pinned_objects.data [idx];
 		if (idx == 0)
 			return NULL;
 	}
 
-	GCObject *obj = pinned_objects.data [idx - 1];
+	GCObject *obj = (GCObject*)pinned_objects.data [idx - 1];
 	if (addr > (char*)obj && addr < ((char*)obj + sgen_safe_object_get_size (obj)))
 		return obj;
 	return NULL;
@@ -1611,7 +1613,7 @@ typedef struct {
 static void
 report_handle_stack_root (gpointer *ptr, gpointer user_data)
 {
-	ReportHandleStackRoot *ud = user_data;
+	ReportHandleStackRoot *ud = (ReportHandleStackRoot*)user_data;
 	GCRootReport *report = ud->report;
 	gpointer addr = ud->info->client_info.info.handle_stack;
 
@@ -1691,7 +1693,7 @@ report_pin_queue (void)
 	sgen_pointer_queue_sort_uniq (&pinned_objects);
 
 	for (int i = 0; i < pinned_objects.next_slot; ++i) {
-		GCObject *obj = pinned_objects.data [i];
+		GCObject *obj = (GCObject*)pinned_objects.data [i];
 		ssize_t size = sgen_safe_object_get_size (obj);
 
 		ssize_t addr = (ssize_t)obj;

--- a/mono/metadata/sre-save.c
+++ b/mono/metadata/sre-save.c
@@ -559,7 +559,7 @@ mono_image_basic_method (ReflectionMethodBuilder *mb, MonoDynamicImage *assembly
 				}
 				pb->table_idx = table->next_idx++;
 				if (pb->attrs & PARAM_ATTRIBUTE_HAS_DEFAULT) {
-					guint32 field_type = 0;
+					MonoTypeEnum field_type = (MonoTypeEnum)0;
 					mtable = &assembly->tables [MONO_TABLE_CONSTANT];
 					mtable->rows ++;
 					alloc_table (mtable, mtable->rows);

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -2733,7 +2733,7 @@ reflection_init_generic_class (MonoReflectionTypeBuilderHandle ref_tb, MonoError
 
 	error_init (error);
 
-	MonoTypeBuilderState ref_state = MONO_HANDLE_GETVAL (ref_tb, state);
+	MonoTypeBuilderState ref_state = (MonoTypeBuilderState)MONO_HANDLE_GETVAL (ref_tb, state);
 	g_assert (ref_state == MonoTypeBuilderFinished);
 
 	MonoType *type = MONO_HANDLE_GETVAL (MONO_HANDLE_CAST (MonoReflectionType, ref_tb), type);
@@ -3483,7 +3483,7 @@ mono_reflection_method_get_handle (MonoObject *method, MonoError *error)
 	if (mono_is_sre_method_on_tb_inst (klass)) {
 		MonoClass *handle_class;
 
-		MonoMethod *result =  mono_reflection_resolve_object (NULL, method, &handle_class, NULL, error);
+		MonoMethod *result = (MonoMethod*)mono_reflection_resolve_object (NULL, method, &handle_class, NULL, error);
 		return_val_if_nok (error, NULL);
 
 		return result;
@@ -3684,7 +3684,7 @@ typebuilder_setup_properties (MonoClass *klass, MonoError *error)
 
 	error_init (error);
 
-	info = mono_class_get_property_info (klass);
+	info = (MonoClassPropertyInfo*)mono_class_get_property_info (klass);
 	if (!info) {
 		info = mono_class_alloc0 (klass, sizeof (MonoClassPropertyInfo));
 		mono_class_set_property_info (klass, info);

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -44,7 +44,8 @@ typedef enum {
 } MonoThreadApartmentState;
 
 typedef enum {
-// These values match Windows, but are offset by 2.
+// These values match System.Threading.ThreadPriority.
+// These values match System.Diagnostics.ThreadPriorityLevel and Windows, but are offset by 2.
 	MONO_THREAD_PRIORITY_LOWEST       = 0,
 	MONO_THREAD_PRIORITY_BELOW_NORMAL = 1,
 	MONO_THREAD_PRIORITY_NORMAL       = 2,

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -44,6 +44,7 @@ typedef enum {
 } MonoThreadApartmentState;
 
 typedef enum {
+// These values match Windows, but are offset by 2.
 	MONO_THREAD_PRIORITY_LOWEST       = 0,
 	MONO_THREAD_PRIORITY_BELOW_NORMAL = 1,
 	MONO_THREAD_PRIORITY_NORMAL       = 2,

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -118,7 +118,7 @@ ICALL_EXPORT
 int ves_icall_System_Threading_Thread_GetPriority (MonoThreadObjectHandle this_obj, MonoError *error);
 
 ICALL_EXPORT
-void ves_icall_System_Threading_Thread_SetPriority (MonoThreadObjectHandle this_obj, int priority, MonoError *error);
+void ves_icall_System_Threading_Thread_SetPriority (MonoThreadObjectHandle this_obj, MonoThreadPriority priority, MonoError *error);
 
 ICALL_EXPORT
 MonoObject* ves_icall_System_Threading_Thread_GetCachedCurrentCulture (MonoInternalThread *this_obj);

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -119,7 +119,7 @@ ICALL_EXPORT
 int ves_icall_System_Threading_Thread_GetPriority (MonoThreadObjectHandle this_obj, MonoError *error);
 
 ICALL_EXPORT
-void ves_icall_System_Threading_Thread_SetPriority (MonoThreadObjectHandle this_obj, MonoThreadPriority priority, MonoError *error);
+void ves_icall_System_Threading_Thread_SetPriority (MonoThreadObjectHandle this_obj, int priority, MonoError *error);
 
 ICALL_EXPORT
 MonoObject* ves_icall_System_Threading_Thread_GetCachedCurrentCulture (MonoInternalThread *this_obj);

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1884,14 +1884,14 @@ ves_icall_System_Threading_Thread_GetPriority (MonoThreadObjectHandle this_obj, 
  */
 ICALL_EXPORT
 void
-ves_icall_System_Threading_Thread_SetPriority (MonoThreadObjectHandle this_obj, MonoThreadPriority priority, MonoError *error)
+ves_icall_System_Threading_Thread_SetPriority (MonoThreadObjectHandle this_obj, int priority, MonoError *error)
 {
 	MonoInternalThread *internal = thread_handle_to_internal_ptr (this_obj);
 
 	LOCK_THREAD (internal);
 	internal->priority = priority;
 	if (internal->thread_info != NULL)
-		mono_thread_internal_set_priority (internal, priority);
+		mono_thread_internal_set_priority (internal, (MonoThreadPriority)priority);
 	UNLOCK_THREAD (internal);
 }
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1884,14 +1884,14 @@ ves_icall_System_Threading_Thread_GetPriority (MonoThreadObjectHandle this_obj, 
  */
 ICALL_EXPORT
 void
-ves_icall_System_Threading_Thread_SetPriority (MonoThreadObjectHandle this_obj, int/*MonoThreadPriority FIXMEcxx*/ priority, MonoError *error)
+ves_icall_System_Threading_Thread_SetPriority (MonoThreadObjectHandle this_obj, MonoThreadPriority priority, MonoError *error)
 {
 	MonoInternalThread *internal = thread_handle_to_internal_ptr (this_obj);
 
 	LOCK_THREAD (internal);
 	internal->priority = priority;
 	if (internal->thread_info != NULL)
-		mono_thread_internal_set_priority (internal, (MonoThreadPriority)priority);
+		mono_thread_internal_set_priority (internal, priority);
 	UNLOCK_THREAD (internal);
 }
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -700,7 +700,7 @@ mono_thread_internal_set_priority (MonoInternalThread *internal, MonoThreadPrior
 	g_assert (internal->native_handle);
 
 	MONO_ENTER_GC_SAFE;
-	res = SetThreadPriority (internal->native_handle, priority - 2);
+	res = SetThreadPriority (internal->native_handle, (int)priority - 2);
 	last_error = GetLastError ();
 	MONO_EXIT_GC_SAFE;
 	if (!res)
@@ -998,8 +998,8 @@ mono_thread_detach_internal (MonoInternalThread *thread)
 	mono_release_type_locks (thread);
 
 	MONO_PROFILER_RAISE (thread_stopped, (thread->tid));
-	MONO_PROFILER_RAISE (gc_root_unregister, (info->stack_start_limit));
-	MONO_PROFILER_RAISE (gc_root_unregister, (info->handle_stack));
+	MONO_PROFILER_RAISE (gc_root_unregister, ((const mono_byte*)(info->stack_start_limit)));
+	MONO_PROFILER_RAISE (gc_root_unregister, ((const mono_byte*)(info->handle_stack)));
 
 	/*
 	 * This will signal async signal handlers that the thread has exited.
@@ -1071,7 +1071,7 @@ fire_attach_profiler_events (MonoNativeThreadId tid)
 	MonoThreadInfo *info = mono_thread_info_current ();
 
 	MONO_PROFILER_RAISE (gc_root_register, (
-		info->stack_start_limit,
+		(const mono_byte*)(info->stack_start_limit),
 		(char *) info->stack_end - (char *) info->stack_start_limit,
 		MONO_ROOT_SOURCE_STACK,
 		(void *) tid,
@@ -1121,7 +1121,7 @@ static guint32 WINAPI start_wrapper_internal(StartInfo *start_info, gsize *stack
 		return 0;
 	}
 
-	mono_thread_internal_set_priority (internal, internal->priority);
+	mono_thread_internal_set_priority (internal, (MonoThreadPriority)internal->priority);
 
 	tid = internal->tid;
 
@@ -1233,7 +1233,7 @@ start_wrapper (gpointer data)
 	info->runtime_thread = TRUE;
 
 	/* Run the actual main function of the thread */
-	res = start_wrapper_internal (start_info, info->stack_end);
+	res = start_wrapper_internal (start_info, (gsize*)info->stack_end);
 
 	mono_thread_info_exit (res);
 
@@ -1882,15 +1882,16 @@ ves_icall_System_Threading_Thread_GetPriority (MonoThreadObjectHandle this_obj, 
  *
  * Sets the priority of the given thread.
  */
+ICALL_EXPORT
 void
-ves_icall_System_Threading_Thread_SetPriority (MonoThreadObjectHandle this_obj, int priority, MonoError *error)
+ves_icall_System_Threading_Thread_SetPriority (MonoThreadObjectHandle this_obj, int/*MonoThreadPriority FIXMEcxx*/ priority, MonoError *error)
 {
 	MonoInternalThread *internal = thread_handle_to_internal_ptr (this_obj);
 
 	LOCK_THREAD (internal);
 	internal->priority = priority;
 	if (internal->thread_info != NULL)
-		mono_thread_internal_set_priority (internal, priority);
+		mono_thread_internal_set_priority (internal, (MonoThreadPriority)priority);
 	UNLOCK_THREAD (internal);
 }
 
@@ -2079,7 +2080,7 @@ ves_icall_System_Threading_Thread_Join_internal (MonoThreadObjectHandle thread_h
 
 		/* Wait for the thread to really exit */
 		MonoNativeThreadId tid = thread_get_tid (thread);
-		mono_thread_join ((gpointer)tid);
+		mono_thread_join ((gpointer)(gsize)tid);
 
 		return TRUE;
 	}
@@ -3103,7 +3104,7 @@ ves_icall_System_Threading_Volatile_Write_T (void *ptr, MonoObject *value)
 static void
 free_context (void *user_data)
 {
-	ContextStaticData *data = user_data;
+	ContextStaticData *data = (ContextStaticData*)user_data;
 
 	mono_threads_lock ();
 
@@ -5180,7 +5181,7 @@ mono_thread_clear_and_set_state (MonoInternalThread *thread, MonoThreadState cle
 void
 mono_thread_set_state (MonoInternalThread *thread, MonoThreadState state)
 {
-	mono_thread_clear_and_set_state (thread, 0, state);
+	mono_thread_clear_and_set_state (thread, (MonoThreadState)0, state);
 }
 
 /**
@@ -5213,7 +5214,7 @@ mono_thread_test_and_set_state (MonoInternalThread *thread, MonoThreadState test
 void
 mono_thread_clr_state (MonoInternalThread *thread, MonoThreadState state)
 {
-	mono_thread_clear_and_set_state (thread, state, 0);
+	mono_thread_clear_and_set_state (thread, state, (MonoThreadState)0);
 }
 
 gboolean
@@ -6175,7 +6176,7 @@ mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes)
 			g_assertf(prev_state == MONO_SUMMARY_EMPTY, "Summary memory was not in a clean state prior to entry", NULL);
 
 			if (summarizing_thread_state != MONO_SUMMARY_EXPECT) {
-				const char *name = thread_summary_state_to_str (summarizing_thread_state);
+				const char *name = thread_summary_state_to_str ((MonoSummaryState)summarizing_thread_state);
 				g_error ("Status after init wrong: %s\n", name);
 			}
 
@@ -6191,7 +6192,7 @@ mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes)
 
 				usleep (10);
 				mono_memory_barrier ();
-				const char *name = thread_summary_state_to_str (summarizing_thread_state);
+				const char *name = thread_summary_state_to_str ((MonoSummaryState)summarizing_thread_state);
 				MOSTLY_ASYNC_SAFE_PRINTF("Waiting for signalled thread %zx to collect stacktrace. Status: %s\n. Thread state: 0x%x\n", tid, name, thread->state);
 				count--;
 			}
@@ -6254,7 +6255,7 @@ mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes)
 	if (!not_started) {
 		gint32 restart_state = mono_atomic_cas_i32 (&summarizing_thread_state, MONO_SUMMARY_EXAMINE /* set */, MONO_SUMMARY_EXPECT /* compare */);
 		if (restart_state != MONO_SUMMARY_EXPECT) {
-			const char *name = thread_summary_state_to_str (summarizing_thread_state);
+			const char *name = thread_summary_state_to_str ((MonoSummaryState)summarizing_thread_state);
 			MOSTLY_ASYNC_SAFE_PRINTF ("Dumping thread could not obtain ownership of dumping memory. Timeout? Enum was %s", name);
 			goto fail;
 		}

--- a/mono/metadata/w32file.c
+++ b/mono/metadata/w32file.c
@@ -738,7 +738,7 @@ ves_icall_System_IO_MonoIO_DuplicateHandle (HANDLE source_process_handle, HANDLE
 
 	*target_handle = mono_w32handle_duplicate (source_handle_data);
 
-	mono_w32handle_unref (source_handle);
+	mono_w32handle_unref ((MonoW32Handle*)source_handle);
 #else
 	gboolean ret;
 

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -1550,7 +1550,7 @@ Socket_to_SOCKET (MonoObjectHandle sockobj)
 	if (MONO_HANDLE_IS_NULL (safe_handle))
 		return -1;
 
-	return (SOCKET)MONO_HANDLE_GETVAL (safe_handle, handle);
+	return (SOCKET)(gsize)MONO_HANDLE_GETVAL (safe_handle, handle);
 }
 
 #define POLL_ERRORS (MONO_POLLERR | MONO_POLLHUP | MONO_POLLNVAL)

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -11226,8 +11226,8 @@ compile_methods (MonoAotCompile *acfg)
 		g_free (methods);
 
 		for (i = 0; i < threads->len; ++i) {
-			mono_thread_info_wait_one_handle (g_ptr_array_index (threads, i), MONO_INFINITE_WAIT, FALSE);
-			mono_threads_close_thread_handle (g_ptr_array_index (threads, i));
+			mono_thread_info_wait_one_handle ((MonoThreadHandle*)g_ptr_array_index (threads, i), MONO_INFINITE_WAIT, FALSE);
+			mono_threads_close_thread_handle ((MonoThreadHandle*)g_ptr_array_index (threads, i));
 		}
 	} else {
 		methods_len = 0;
@@ -11573,7 +11573,7 @@ load_profile_file (MonoAotCompile *acfg, char *filename)
 			for (i = 0; i < len; ++i) {
 				int class_id = profread_int (infile);
 
-				gdata->argv [i] = g_hash_table_lookup (data->classes, GINT_TO_POINTER (class_id));
+				gdata->argv [i] = (ClassProfileData*)g_hash_table_lookup (data->classes, GINT_TO_POINTER (class_id));
 				g_assert (gdata->argv [i]);
 			}
 			g_hash_table_insert (data->ginsts, GINT_TO_POINTER (id), gdata);
@@ -11588,7 +11588,7 @@ load_profile_file (MonoAotCompile *acfg, char *filename)
 				int ginst_id = profread_int (infile);
 				char *class_name = profread_string (infile);
 
-				ImageProfileData *image = g_hash_table_lookup (data->images, GINT_TO_POINTER (image_id));
+				ImageProfileData *image = (ImageProfileData*)g_hash_table_lookup (data->images, GINT_TO_POINTER (image_id));
 				g_assert (image);
 
 				char *p = strrchr (class_name, '.');
@@ -11601,7 +11601,7 @@ load_profile_file (MonoAotCompile *acfg, char *filename)
 				cdata->name = g_strdup (p + 1);
 
 				if (ginst_id != -1) {
-					cdata->inst = g_hash_table_lookup (data->ginsts, GINT_TO_POINTER (ginst_id));
+					cdata->inst = (GInstProfileData*)g_hash_table_lookup (data->ginsts, GINT_TO_POINTER (ginst_id));
 					g_assert (cdata->inst);
 				}
 				g_free (class_name);
@@ -11629,7 +11629,7 @@ load_profile_file (MonoAotCompile *acfg, char *filename)
 			char *method_name = profread_string (infile);
 			char *sig = profread_string (infile);
 
-			ClassProfileData *klass = g_hash_table_lookup (data->classes, GINT_TO_POINTER (class_id));
+			ClassProfileData *klass = (ClassProfileData*)g_hash_table_lookup (data->classes, GINT_TO_POINTER (class_id));
 			g_assert (klass);
 
 			MethodProfileData *mdata = g_new0 (MethodProfileData, 1);
@@ -11640,7 +11640,7 @@ load_profile_file (MonoAotCompile *acfg, char *filename)
 			mdata->param_count = param_count;
 
 			if (ginst_id != -1) {
-				mdata->inst = g_hash_table_lookup (data->ginsts, GINT_TO_POINTER (ginst_id));
+				mdata->inst = (GInstProfileData*)g_hash_table_lookup (data->ginsts, GINT_TO_POINTER (ginst_id));
 				g_assert (mdata->inst);
 			}
 			g_hash_table_insert (data->methods, GINT_TO_POINTER (id), mdata);
@@ -11728,7 +11728,7 @@ resolve_profile_data (MonoAotCompile *acfg, ProfileData *data)
 		ImageProfileData *idata = (ImageProfileData*)value;
 
 		for (i = 0; i < assemblies->len; ++i) {
-			MonoAssembly *ass = g_ptr_array_index (assemblies, i);
+			MonoAssembly *ass = (MonoAssembly*)g_ptr_array_index (assemblies, i);
 
 			if (!strcmp (ass->aname.name, idata->name)) {
 				idata->image = ass->image;
@@ -12520,7 +12520,7 @@ mono_compile_deferred_assemblies (guint32 opts, const char *aot_options, gpointe
 
 	// FIXME: allow suffixes?
 	if (!astate->inflated_assembly) {
-		char *inflate = strstr (aot_options, "dedup-inflate");
+		const char* inflate = strstr (aot_options, "dedup-inflate");
 		if (!inflate)
 			return 0;
 		else 

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -1452,8 +1452,8 @@ static gboolean in_process;
 static void
 collect_assemblies (gpointer data, gpointer user_data)
 {
-	MonoAssembly *ass = data;
-	GSList **l = user_data;
+	MonoAssembly *ass = (MonoAssembly*)data;
+	GSList **l = (GSList**)user_data;
 
 	*l = g_slist_prepend (*l, ass);
 }
@@ -1486,7 +1486,7 @@ get_aot_config_hash (MonoAssembly *assembly)
 	 * to add it.
 	 */
 	for (l = assembly_list; l; l = l->next) {
-		MonoAssembly *ass = l->data;
+		MonoAssembly *ass = (MonoAssembly*)l->data;
 
 		g_string_append (s, "_");
 		g_string_append (s, ass->aname.name);
@@ -1556,7 +1556,7 @@ aot_cache_load_module (MonoAssembly *assembly, char **aot_name)
 
 		// FIXME: This cannot be used for mscorlib during startup, since entry_assembly is not set yet
 		for (l = config->apps; l; l = l->next) {
-			char *n = l->data;
+			char *n = (char*)l->data;
 
 			if ((entry_assembly && !strcmp (entry_assembly->aname.name, n)) || (!entry_assembly && !strcmp (assembly->aname.name, n)))
 				break;
@@ -1567,7 +1567,7 @@ aot_cache_load_module (MonoAssembly *assembly, char **aot_name)
 
 	if (!enabled) {
 		for (l = config->assemblies; l; l = l->next) {
-			char *n = l->data;
+			char *n = (char*)l->data;
 
 			if (!strcmp (assembly->aname.name, n))
 				break;
@@ -1583,7 +1583,7 @@ aot_cache_load_module (MonoAssembly *assembly, char **aot_name)
 		if (!home)
 			return NULL;
 		cache_dir = g_strdup_printf ("%s/Library/Caches/mono/aot-cache", home);
-		if (!g_file_test (cache_dir, G_FILE_TEST_EXISTS|G_FILE_TEST_IS_DIR))
+		if (!g_file_test (cache_dir, (GFileTest)(G_FILE_TEST_EXISTS|G_FILE_TEST_IS_DIR)))
 			g_mkdir_with_parents (cache_dir, 0777);
 	}
 
@@ -1746,7 +1746,7 @@ find_symbol (MonoDl *module, gpointer *globals, const char *name, gpointer *valu
 
 			//printf ("X: %s %s\n", (char*)globals [index * 2], name);
 
-			if (!strcmp (globals [index * 2], symbol)) {
+			if (!strcmp ((const char*)globals [index * 2], symbol)) {
 				global_index = index;
 				break;
 			}
@@ -1809,7 +1809,7 @@ open_aot_data (MonoAssembly *assembly, MonoAotFileInfo *info, void **ret_handle)
 	filename = g_strdup_printf ("%s.aotdata", assembly->image->name);
 	map = mono_file_map_open (filename);
 	g_assert (map);
-	data = mono_file_map (info->datafile_size, MONO_MMAP_READ, mono_file_map_fd (map), 0, ret_handle);
+	data = (guint8*)mono_file_map (info->datafile_size, MONO_MMAP_READ, mono_file_map_fd (map), 0, ret_handle);
 	g_assert (data);
 
 	return data;
@@ -1824,7 +1824,7 @@ check_usable (MonoAssembly *assembly, MonoAotFileInfo *info, guint8 *blob, char 
 	gboolean full_aot, interp, safepoints;
 	guint32 excluded_cpu_optimizations;
 
-	if (strcmp (assembly->image->guid, info->assembly_guid)) {
+	if (strcmp (assembly->image->guid, (const char*)info->assembly_guid)) {
 		msg = g_strdup_printf ("doesn't match assembly");
 		usable = FALSE;
 	}
@@ -2094,7 +2094,7 @@ if (container_assm_name && !container_amodule) {
 			GList *l;
 
 			for (l = mono_aot_paths; l; l = l->next) {
-				char *path = l->data;
+				char *path = (char*)l->data;
 
 				char *basename = g_path_get_basename (assembly->image->name);
 				aot_name = g_strdup_printf ("%s/%s%s", path, basename, MONO_SOLIB_EXT);
@@ -2209,7 +2209,7 @@ if (container_assm_name && !container_amodule) {
 		char *table = NULL;
 
 		if (info->flags & MONO_AOT_FILE_FLAG_SEPARATE_DATA)
-			table = amodule->tables [MONO_AOT_TABLE_IMAGE_TABLE];
+			table = (char *)amodule->tables [MONO_AOT_TABLE_IMAGE_TABLE];
 		else
 			table = (char *)info->image_table;
 		g_assert (table);
@@ -2250,33 +2250,33 @@ if (container_assm_name && !container_amodule) {
 	amodule->jit_code_start = (guint8 *)info->jit_code_start;
 	amodule->jit_code_end = (guint8 *)info->jit_code_end;
 	if (info->flags & MONO_AOT_FILE_FLAG_SEPARATE_DATA) {
-		amodule->blob = amodule->tables [MONO_AOT_TABLE_BLOB];
-		amodule->method_info_offsets = amodule->tables [MONO_AOT_TABLE_METHOD_INFO_OFFSETS];
-		amodule->ex_info_offsets = amodule->tables [MONO_AOT_TABLE_EX_INFO_OFFSETS];
-		amodule->class_info_offsets = amodule->tables [MONO_AOT_TABLE_CLASS_INFO_OFFSETS];
-		amodule->class_name_table = amodule->tables [MONO_AOT_TABLE_CLASS_NAME];
-		amodule->extra_method_table = amodule->tables [MONO_AOT_TABLE_EXTRA_METHOD_TABLE];
-		amodule->extra_method_info_offsets = amodule->tables [MONO_AOT_TABLE_EXTRA_METHOD_INFO_OFFSETS];
-		amodule->got_info_offsets = amodule->tables [MONO_AOT_TABLE_GOT_INFO_OFFSETS];
-		amodule->llvm_got_info_offsets = amodule->tables [MONO_AOT_TABLE_LLVM_GOT_INFO_OFFSETS];
-		amodule->weak_field_indexes = amodule->tables [MONO_AOT_TABLE_WEAK_FIELD_INDEXES];
+		amodule->blob = (guint8*)amodule->tables [MONO_AOT_TABLE_BLOB];
+		amodule->method_info_offsets = (guint32*)amodule->tables [MONO_AOT_TABLE_METHOD_INFO_OFFSETS];
+		amodule->ex_info_offsets = (guint32*)amodule->tables [MONO_AOT_TABLE_EX_INFO_OFFSETS];
+		amodule->class_info_offsets = (guint32*)amodule->tables [MONO_AOT_TABLE_CLASS_INFO_OFFSETS];
+		amodule->class_name_table = (guint16*)amodule->tables [MONO_AOT_TABLE_CLASS_NAME];
+		amodule->extra_method_table = (guint32*)amodule->tables [MONO_AOT_TABLE_EXTRA_METHOD_TABLE];
+		amodule->extra_method_info_offsets = (guint32*)amodule->tables [MONO_AOT_TABLE_EXTRA_METHOD_INFO_OFFSETS];
+		amodule->got_info_offsets = (guint32*)amodule->tables [MONO_AOT_TABLE_GOT_INFO_OFFSETS];
+		amodule->llvm_got_info_offsets = (guint32*)amodule->tables [MONO_AOT_TABLE_LLVM_GOT_INFO_OFFSETS];
+		amodule->weak_field_indexes = (guint32*)amodule->tables [MONO_AOT_TABLE_WEAK_FIELD_INDEXES];
 	} else {
-		amodule->blob = info->blob;
+		amodule->blob = (guint8*)info->blob;
 		amodule->method_info_offsets = (guint32 *)info->method_info_offsets;
 		amodule->ex_info_offsets = (guint32 *)info->ex_info_offsets;
 		amodule->class_info_offsets = (guint32 *)info->class_info_offsets;
 		amodule->class_name_table = (guint16 *)info->class_name_table;
 		amodule->extra_method_table = (guint32 *)info->extra_method_table;
 		amodule->extra_method_info_offsets = (guint32 *)info->extra_method_info_offsets;
-		amodule->got_info_offsets = info->got_info_offsets;
-		amodule->llvm_got_info_offsets = info->llvm_got_info_offsets;
-		amodule->weak_field_indexes = info->weak_field_indexes;
+		amodule->got_info_offsets = (guint32*)info->got_info_offsets;
+		amodule->llvm_got_info_offsets = (guint32*)info->llvm_got_info_offsets;
+		amodule->weak_field_indexes = (guint32*)info->weak_field_indexes;
 	}
 	amodule->unbox_trampolines = (guint32 *)info->unbox_trampolines;
 	amodule->unbox_trampolines_end = (guint32 *)info->unbox_trampolines_end;
 	amodule->unbox_trampoline_addresses = (guint32 *)info->unbox_trampoline_addresses;
 	amodule->unwind_info = (guint8 *)info->unwind_info;
-	amodule->mem_begin = amodule->jit_code_start;
+	amodule->mem_begin = (guint8*)amodule->jit_code_start;
 	amodule->mem_end = (guint8 *)info->mem_end;
 	amodule->plt = (guint8 *)info->plt;
 	amodule->plt_end = (guint8 *)info->plt_end;
@@ -2705,7 +2705,7 @@ mono_aot_get_weak_field_indexes (MonoImage *image)
 		return NULL;
 
 	/* Initialize weak field indexes from the cached copy */
-	guint32 *indexes = amodule->weak_field_indexes;
+	guint32 *indexes = (guint32*)amodule->weak_field_indexes;
 	int len  = indexes [0];
 	GHashTable *indexes_hash = g_hash_table_new (NULL, NULL);
 	for (int i = 0; i < len; ++i)
@@ -3114,7 +3114,7 @@ decode_exception_debug_info (MonoAotModule *amodule, MonoDomain *domain,
 			}
 		}
 
-		flags |= JIT_INFO_HAS_UNWIND_INFO;
+		flags = (MonoJitInfoFlags)(flags | JIT_INFO_HAS_UNWIND_INFO);
 
 		int num_llvm_clauses;
 		/* Get the length first */
@@ -5181,6 +5181,7 @@ mono_create_ftnptr_malloc (guint8 *code)
  *   Register a JIT icall which is called by trampolines in full-aot mode. This should
  * be called from mono_arch_init () during startup.
  */
+#undef mono_aot_register_jit_icall
 void
 mono_aot_register_jit_icall (const char *name, gpointer addr)
 {
@@ -5277,13 +5278,13 @@ load_function_full (MonoAotModule *amodule, const char *name, MonoTrampInfo **ou
 			 */
 			if (ji->type == MONO_PATCH_INFO_JIT_ICALL_ADDR) {
 				if (!strcmp (ji->data.name, "mono_get_lmf_addr")) {
-					target = mono_get_lmf_addr;
+					target = (gpointer)mono_get_lmf_addr;
 				} else if (!strcmp (ji->data.name, "mono_thread_force_interruption_checkpoint_noraise")) {
-					target = mono_thread_force_interruption_checkpoint_noraise;
+					target = (gpointer)mono_thread_force_interruption_checkpoint_noraise;
 				} else if (!strcmp (ji->data.name, "mono_exception_from_token")) {
-					target = mono_exception_from_token;
+					target = (gpointer)mono_exception_from_token;
 				} else if (!strcmp (ji->data.name, "mono_throw_exception")) {
-					target = mono_get_throw_exception ();
+					target = (gpointer)mono_get_throw_exception ();
 				} else if (strstr (ji->data.name, "trampoline_func_") == ji->data.name) {
 					MonoTrampolineType tramp_type2 = (MonoTrampolineType)atoi (ji->data.name + strlen ("trampoline_func_"));
 					target = (gpointer)mono_get_trampoline_func (tramp_type2);
@@ -5297,9 +5298,9 @@ load_function_full (MonoAotModule *amodule, const char *name, MonoTrampInfo **ou
 					target = mono_create_specific_trampoline (GUINT_TO_POINTER (slot), MONO_TRAMPOLINE_RGCTX_LAZY_FETCH, mono_get_root_domain (), NULL);
 					target = mono_create_ftnptr_malloc ((guint8 *)target);
 				} else if (!strcmp (ji->data.name, "debugger_agent_single_step_from_context")) {
-					target = mini_get_dbg_callbacks ()->single_step_from_context;
+					target = (gpointer)mini_get_dbg_callbacks ()->single_step_from_context;
 				} else if (!strcmp (ji->data.name, "debugger_agent_breakpoint_from_context")) {
-					target = mini_get_dbg_callbacks ()->breakpoint_from_context;
+					target = (gpointer)mini_get_dbg_callbacks ()->breakpoint_from_context;
 				} else if (!strcmp (ji->data.name, "throw_exception_addr")) {
 					target = mono_get_throw_exception_addr ();
 				} else if (strstr (ji->data.name, "generic_trampoline_")) {
@@ -5370,7 +5371,7 @@ mono_aot_get_trampoline_full (const char *name, MonoTrampInfo **out_tinfo)
 
 	if (mono_llvm_only) {
 		*out_tinfo = NULL;
-		return no_trampolines;
+		return (gpointer)no_trampolines;
 	}
 
 	return mono_create_ftnptr_malloc ((guint8 *)load_function_full (amodule, name, out_tinfo));
@@ -5688,7 +5689,7 @@ mono_aot_create_specific_trampoline (MonoImage *image, gpointer arg1, MonoTrampo
 
 	if (mono_llvm_only) {
 		*code_len = 1;
-		return no_specific_trampoline;
+		return (gpointer)no_specific_trampoline;
 	}
 
 	if (!inited) {
@@ -5876,7 +5877,7 @@ mono_aot_get_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTChec
 	MonoAotModule *amodule;
 
 	if (mono_llvm_only)
-		return no_imt_trampoline;
+		return (gpointer)no_imt_trampoline;
 
 	real_count = 0;
 	for (i = 0; i < count; ++i) {
@@ -6247,6 +6248,7 @@ mono_aot_get_unwind_info (MonoJitInfo *ji, guint32 *unwind_info_len)
 	return NULL;
 }
 
+#undef mono_aot_register_jit_icall
 void
 mono_aot_register_jit_icall (const char *name, gpointer addr)
 {

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -5181,7 +5181,6 @@ mono_create_ftnptr_malloc (guint8 *code)
  *   Register a JIT icall which is called by trampolines in full-aot mode. This should
  * be called from mono_arch_init () during startup.
  */
-#undef mono_aot_register_jit_icall
 void
 mono_aot_register_jit_icall (const char *name, gpointer addr)
 {
@@ -6248,7 +6247,6 @@ mono_aot_get_unwind_info (MonoJitInfo *ji, guint32 *unwind_info_len)
 	return NULL;
 }
 
-#undef mono_aot_register_jit_icall
 void
 mono_aot_register_jit_icall (const char *name, gpointer addr)
 {

--- a/mono/mini/aot-runtime.h
+++ b/mono/mini/aot-runtime.h
@@ -244,6 +244,7 @@ void     mono_aot_set_make_unreadable       (gboolean unreadable);
 gboolean mono_aot_is_pagefault              (void *ptr);
 void     mono_aot_handle_pagefault          (void *ptr);
 void     mono_aot_register_jit_icall        (const char *name, gpointer addr);
+#define mono_aot_register_jit_icall(name, addr) (mono_aot_register_jit_icall ((name), (gpointer)(addr)))
 guint32  mono_aot_find_method_index         (MonoMethod *method);
 void     mono_aot_init_llvm_method          (gpointer aot_module, guint32 method_index);
 void     mono_aot_init_gshared_method_this  (gpointer aot_module, guint32 method_index, MonoObject *this_ins);

--- a/mono/mini/aot-runtime.h
+++ b/mono/mini/aot-runtime.h
@@ -246,17 +246,12 @@ void     mono_aot_handle_pagefault          (void *ptr);
 void     mono_aot_register_jit_icall        (const char *name, gpointer addr);
 
 #ifdef __cplusplus
-extern "C++" // in case of surrounding extern "C"
-{
-
 template <typename T>
 inline void
 mono_aot_register_jit_icall (const char *name, T addr)
 {
 	mono_aot_register_jit_icall (name, (gpointer)addr);
 }
-
-} // extern "C++"
 #endif // __cplusplus
 
 guint32  mono_aot_find_method_index         (MonoMethod *method);

--- a/mono/mini/aot-runtime.h
+++ b/mono/mini/aot-runtime.h
@@ -244,7 +244,21 @@ void     mono_aot_set_make_unreadable       (gboolean unreadable);
 gboolean mono_aot_is_pagefault              (void *ptr);
 void     mono_aot_handle_pagefault          (void *ptr);
 void     mono_aot_register_jit_icall        (const char *name, gpointer addr);
-#define mono_aot_register_jit_icall(name, addr) (mono_aot_register_jit_icall ((name), (gpointer)(addr)))
+
+#ifdef __cplusplus
+extern "C++" // in case of surrounding extern "C"
+{
+
+template <typename T>
+inline void
+mono_aot_register_jit_icall (const char *name, T addr)
+{
+	mono_aot_register_jit_icall (name, (gpointer)addr);
+}
+
+} // extern "C++"
+#endif // __cplusplus
+
 guint32  mono_aot_find_method_index         (MonoMethod *method);
 void     mono_aot_init_llvm_method          (gpointer aot_module, guint32 method_index);
 void     mono_aot_init_gshared_method_this  (gpointer aot_module, guint32 method_index, MonoObject *this_ins);

--- a/mono/mini/debugger-engine.c
+++ b/mono/mini/debugger-engine.c
@@ -1169,7 +1169,7 @@ static gboolean
 ss_bp_is_unique (GSList *bps, GHashTable *ss_req_bp_cache, MonoMethod *method, guint32 il_offset)
 {
 	if (ss_req_bp_cache) {
-		MonoBreakpoint dummy = {method, il_offset, NULL, NULL};
+		MonoBreakpoint dummy = {method, (long)il_offset, NULL, NULL};
 		return !g_hash_table_lookup (ss_req_bp_cache, &dummy);
 	}
 	for (GSList *l = bps; l; l = l->next) {

--- a/mono/mini/debugger-state-machine.c
+++ b/mono/mini/debugger-state-machine.c
@@ -85,7 +85,7 @@ void
 mono_debugger_log_free (void)
 {
 	MonoFlightRecorder *log = debugger_log;
-	debugger_log = GINT_TO_POINTER (MONO_DEBUGGER_LOG_FREED);
+	debugger_log = (MonoFlightRecorder*)GINT_TO_POINTER (MONO_DEBUGGER_LOG_FREED);
 
 	mono_memory_barrier ();
 	mono_flight_recorder_free (log);

--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -1560,7 +1560,7 @@ mono_decompose_array_access_opts (MonoCompile *cfg)
 						MONO_INST_NEW (cfg, iargs [2], OP_MOVE);
 						iargs [2]->dreg = ins->sreg1;
 
-						dest = mono_emit_jit_icall (cfg, (gpointer)ves_icall_array_new, iargs);
+						dest = mono_emit_jit_icall (cfg, ves_icall_array_new, iargs);
 						dest->dreg = ins->dreg;
 					} else {
 						MonoClass *array_class = mono_class_create_array (ins->inst_newa_class, 1);
@@ -1577,7 +1577,7 @@ mono_decompose_array_access_opts (MonoCompile *cfg)
 						if (managed_alloc)
 							dest = mono_emit_method_call (cfg, managed_alloc, iargs, NULL);
 						else
-							dest = mono_emit_jit_icall (cfg,  (gpointer)ves_icall_array_new_specific, iargs);
+							dest = mono_emit_jit_icall (cfg, ves_icall_array_new_specific, iargs);
 						dest->dreg = ins->dreg;
 					}
 					break;

--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -1560,7 +1560,7 @@ mono_decompose_array_access_opts (MonoCompile *cfg)
 						MONO_INST_NEW (cfg, iargs [2], OP_MOVE);
 						iargs [2]->dreg = ins->sreg1;
 
-						dest = mono_emit_jit_icall (cfg, ves_icall_array_new, iargs);
+						dest = mono_emit_jit_icall (cfg, (gpointer)ves_icall_array_new, iargs);
 						dest->dreg = ins->dreg;
 					} else {
 						MonoClass *array_class = mono_class_create_array (ins->inst_newa_class, 1);
@@ -1577,7 +1577,7 @@ mono_decompose_array_access_opts (MonoCompile *cfg)
 						if (managed_alloc)
 							dest = mono_emit_method_call (cfg, managed_alloc, iargs, NULL);
 						else
-							dest = mono_emit_jit_icall (cfg, ves_icall_array_new_specific, iargs);
+							dest = mono_emit_jit_icall (cfg,  (gpointer)ves_icall_array_new_specific, iargs);
 						dest->dreg = ins->dreg;
 					}
 					break;

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -907,8 +907,9 @@ free_jit_info_data (ThreadData *td, JitInfoData *free)
 #define MODE_FREE	2
 
 static void
-test_thread_func (ThreadData *td)
+test_thread_func (gpointer void_arg)
 {
+	ThreadData* td = (ThreadData*)void_arg;
 	int mode = MODE_ALLOC;
 	int i = 0;
 	gulong lookup_successes = 0, lookup_failures = 0;
@@ -948,7 +949,7 @@ test_thread_func (ThreadData *td)
 				}
 			} else {
 				int pos = random () % MAX_ADDR;
-				char *addr = (char*)(gulong) pos;
+				char *addr = (char*)(uintptr_t)pos;
 				MonoJitInfo *ji;
 
 				ji = mono_jit_info_table_find (domain, addr);
@@ -1145,8 +1146,9 @@ compile_all_methods_thread_main_inner (CompileAllThreadArgs *args)
 }
 
 static void
-compile_all_methods_thread_main (CompileAllThreadArgs *args)
+compile_all_methods_thread_main (gpointer void_args)
 {
+	CompileAllThreadArgs *args = (CompileAllThreadArgs*)void_args;
 	guint32 i;
 	for (i = 0; i < args->recompilation_times; ++i)
 		compile_all_methods_thread_main_inner (args);

--- a/mono/mini/exceptions-arm64.c
+++ b/mono/mini/exceptions-arm64.c
@@ -237,9 +237,9 @@ get_throw_trampoline (int size, gboolean corlib, gboolean rethrow, gboolean llvm
 		gpointer icall_func;
 
 		if (resume_unwind)
-			icall_func = mono_arm_resume_unwind;
+			icall_func = (gpointer)mono_arm_resume_unwind;
 		else
-			icall_func = mono_arm_throw_exception;
+			icall_func = (gpointer)mono_arm_throw_exception;
 
 		code = mono_arm_emit_imm64 (code, ARMREG_LR, (guint64)icall_func);
 	}
@@ -356,7 +356,7 @@ mono_arch_exceptions_init (void)
 	} else {
 		tramps = mono_arm_get_exception_trampolines (FALSE);
 		for (l = tramps; l; l = l->next) {
-			MonoTrampInfo *info = l->data;
+			MonoTrampInfo *info = (MonoTrampInfo*)l->data;
 
 			mono_register_jit_icall (info->code, g_strdup (info->name), NULL, TRUE);
 			mono_tramp_info_register (info, NULL);
@@ -380,7 +380,7 @@ mono_arm_throw_exception (gpointer arg, mgreg_t pc, mgreg_t *int_regs, gdouble *
 	guint32 ex_token_index, ex_token;
 
 	if (!corlib)
-		exc = arg;
+		exc = (MonoObject*)arg;
 	else {
 		ex_token_index = (guint64)arg;
 		ex_token = MONO_TOKEN_TYPE_DEF | ex_token_index;
@@ -469,10 +469,10 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 		for (int i = 0; i < 8; i++)
 			(regs + MONO_MAX_IREGS) [i] = *((mgreg_t*)&new_ctx->fregs [8 + i]);
 
-		mono_unwind_frame (unwind_info, unwind_info_len, ji->code_start, 
+		mono_unwind_frame (unwind_info, unwind_info_len, (guint8*)ji->code_start,
 						   (guint8*)ji->code_start + ji->code_size,
-						   ip, NULL, regs, MONO_MAX_IREGS + 8,
-						   save_locations, MONO_MAX_IREGS, &cfa);
+						   (guint8*)ip, NULL, regs, MONO_MAX_IREGS + 8,
+						   save_locations, MONO_MAX_IREGS, (guint8**)&cfa);
 
 		memcpy (&new_ctx->regs, regs, sizeof (mgreg_t) * 32);
 		for (int i = 0; i < 8; i++)
@@ -483,7 +483,7 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 
 		if (*lmf && (*lmf)->gregs [MONO_ARCH_LMF_REG_SP] && (MONO_CONTEXT_GET_SP (ctx) >= (gpointer)(*lmf)->gregs [MONO_ARCH_LMF_REG_SP])) {
 			/* remove any unused lmf */
-			*lmf = (gpointer)(((gsize)(*lmf)->previous_lmf) & ~3);
+			*lmf = (MonoLMF*)(((gsize)(*lmf)->previous_lmf) & ~3);
 		}
 
 		/* we substract 1, so that the IP points into the call instruction */
@@ -508,7 +508,7 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 		/* we substract 1, so that the IP points into the call instruction */
 		new_ctx->pc--;
 
-		*lmf = (gpointer)(((gsize)(*lmf)->previous_lmf) & ~3);
+		*lmf = (MonoLMF*)(((gsize)(*lmf)->previous_lmf) & ~3);
 
 		return TRUE;
 	}
@@ -529,7 +529,7 @@ handle_signal_exception (gpointer obj)
 
 	memcpy (&ctx, &jit_tls->ex_ctx, sizeof (MonoContext));
 
-	mono_handle_exception (&ctx, obj);
+	mono_handle_exception (&ctx, (MonoObject*)obj);
 
 	mono_restore_context (&ctx);
 }
@@ -586,7 +586,7 @@ mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), g
 	sp -= 32;
 	MONO_CONTEXT_SET_SP (ctx, sp);
 
-	mono_arch_setup_resume_sighandler_ctx (ctx, async_cb);
+	mono_arch_setup_resume_sighandler_ctx (ctx, (gpointer)async_cb);
 }
 
 /*

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -2338,7 +2338,7 @@ static void
 interp_entry_from_trampoline (gpointer ccontext_untyped, gpointer rmethod_untyped)
 {
 	InterpFrame frame;
-	ThreadContext *context = mono_native_tls_get_value (thread_context_id);
+	ThreadContext *context = (ThreadContext*)mono_native_tls_get_value (thread_context_id);
 	InterpFrame *old_frame;
 	stackval result;
 	stackval *args;
@@ -2418,7 +2418,7 @@ static gpointer
 interp_create_method_pointer (MonoMethod *method, gboolean compile, MonoError *error)
 {
 #ifndef MONO_ARCH_HAVE_INTERP_NATIVE_TO_MANAGED
-	return interp_no_native_to_managed;
+	return (gpointer)interp_no_native_to_managed;
 #else
 	gpointer addr, entry_func, entry_wrapper;
 	MonoDomain *domain = mono_domain_get ();
@@ -2465,17 +2465,17 @@ interp_create_method_pointer (MonoMethod *method, gboolean compile, MonoError *e
 #else
 	if (!mono_native_to_interp_trampoline) {
 		if (mono_aot_only) {
-			mono_native_to_interp_trampoline = mono_aot_get_trampoline ("native_to_interp_trampoline");
+			mono_native_to_interp_trampoline = (MonoFuncV)mono_aot_get_trampoline ("native_to_interp_trampoline");
 		} else {
 			MonoTrampInfo *info;
-			mono_native_to_interp_trampoline = mono_arch_get_native_to_interp_trampoline (&info);
+			mono_native_to_interp_trampoline = (MonoFuncV)mono_arch_get_native_to_interp_trampoline (&info);
 			mono_tramp_info_register (info, NULL);
 		}
 	}
-	entry_wrapper = mono_native_to_interp_trampoline;
+	entry_wrapper = (gpointer)mono_native_to_interp_trampoline;
 	/* We need the lmf wrapper only when being called from mixed mode */
 	if (sig->pinvoke)
-		entry_func = interp_entry_from_trampoline;
+		entry_func = (gpointer)interp_entry_from_trampoline;
 	else
 		entry_func = mono_jit_compile_method_jit_only (mini_get_interp_lmf_wrapper (), error);
 #endif

--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -124,7 +124,7 @@ llvm_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 		if (opcode) {
 			MONO_INST_NEW (cfg, ins, opcode);
 			ins->type = STACK_R8;
-			ins->dreg = mono_alloc_dreg (cfg, ins->type);
+			ins->dreg = mono_alloc_dreg (cfg, (MonoStackType)ins->type);
 			ins->sreg1 = args [0]->dreg;
 			if (fsig->param_count == 2)
 				ins->sreg2 = args [1]->dreg;
@@ -146,7 +146,7 @@ llvm_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 		if (opcode && fsig->param_count == 1) {
 			MONO_INST_NEW (cfg, ins, opcode);
 			ins->type = STACK_R8;
-			ins->dreg = mono_alloc_dreg (cfg, ins->type);
+			ins->dreg = mono_alloc_dreg (cfg, (MonoStackType)ins->type);
 			ins->sreg1 = args [0]->dreg;
 			MONO_ADD_INS (cfg->cbb, ins);
 		}
@@ -177,7 +177,7 @@ llvm_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 		if (opcode && fsig->param_count == 2) {
 			MONO_INST_NEW (cfg, ins, opcode);
 			ins->type = fsig->params [0]->type == MONO_TYPE_I4 ? STACK_I4 : STACK_I8;
-			ins->dreg = mono_alloc_dreg (cfg, ins->type);
+			ins->dreg = mono_alloc_dreg (cfg, (MonoStackType)ins->type);
 			ins->sreg1 = args [0]->dreg;
 			ins->sreg2 = args [1]->dreg;
 			MONO_ADD_INS (cfg->cbb, ins);

--- a/mono/mini/ir-emit.h
+++ b/mono/mini/ir-emit.h
@@ -233,8 +233,8 @@ alloc_dreg (MonoCompile *cfg, MonoStackType stack_type)
 
 #define NEW_PATCH_INFO(cfg,dest,el1,el2) do {	\
         MONO_INST_NEW ((cfg), (dest), OP_PATCH_INFO); \
-		(dest)->inst_left = (gpointer)(el1);	\
-		(dest)->inst_right = (gpointer)(el2);	\
+		(dest)->inst_left = (MonoInst*)(el1);	\
+		(dest)->inst_right = (MonoInst*)(el2);	\
 	} while (0)
 
 #define NEW_AOTCONST_GOT_VAR(cfg,dest,patch_type,cons) do {			\
@@ -247,7 +247,7 @@ alloc_dreg (MonoCompile *cfg, MonoStackType stack_type)
 			(dest)->inst_p1 = group;			\
 		} else {						\
 			(dest)->inst_p0 = (cons);			\
-			(dest)->inst_i1 = (gpointer)(patch_type);	\
+			(dest)->inst_i1 = (MonoInst*)(patch_type);	\
 		}							\
 		(dest)->type = STACK_PTR;				\
 		(dest)->dreg = alloc_dreg ((cfg), STACK_PTR);	\
@@ -324,7 +324,7 @@ alloc_dreg (MonoCompile *cfg, MonoStackType stack_type)
 			NEW_AOTCONST ((cfg), (dest), MONO_PATCH_INFO_METHOD_RGCTX, (method)); \
 		} else {														\
 			MonoMethodRuntimeGenericContext *mrgctx;					\
-			mrgctx = mini_method_get_rgctx ((method));					\
+			mrgctx = (MonoMethodRuntimeGenericContext*)mini_method_get_rgctx ((method));					\
 			NEW_PCONST ((cfg), (dest), (mrgctx));						\
 		}																\
 	} while (0)

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -1910,7 +1910,7 @@ mono_llvmonly_init_delegate (MonoDelegate *del)
 
 		ftndesc = mini_create_llvmonly_ftndesc (mono_domain_get (), addr, arg);
 		mono_memory_barrier ();
-		*del->method_code = (gpointer)ftndesc;
+		*del->method_code = (guint8*)ftndesc;
 	}
 	del->method_ptr = ftndesc->addr;
 	del->extra_arg = ftndesc->arg;

--- a/mono/mini/lldb.c
+++ b/mono/mini/lldb.c
@@ -257,7 +257,7 @@ typedef struct {
 static int
 find_code_region (void *data, int csize, int size, void *user_data)
 {
-	UserData *ud = user_data;
+	UserData *ud = (UserData*)user_data;
 
 	if ((char*)ud->code >= (char*)data && (char*)ud->code < (char*)data + csize) {
 		ud->region_start = data;
@@ -373,7 +373,7 @@ emit_unwind_info (GSList *unwind_ops, Buffer *buf)
 	/* We use the unencoded version of the unwind info to make it easier to decode */
 	nunwind_ops = 0;
 	for (l = unwind_ops; l; l = l->next) {
-		MonoUnwindOp *op = l->data;
+		MonoUnwindOp *op = (MonoUnwindOp*)l->data;
 
 		/* lldb can't handle these */
 		if (op->op == DW_CFA_mono_advance_loc)
@@ -384,7 +384,7 @@ emit_unwind_info (GSList *unwind_ops, Buffer *buf)
 	buffer_add_byte (buf, ret_reg);
 	buffer_add_int (buf, nunwind_ops);
 	for (l = unwind_ops; l; l = l->next) {
-		MonoUnwindOp *op = l->data;
+		MonoUnwindOp *op = (MonoUnwindOp*)l->data;
 
 		if (op->op == DW_CFA_mono_advance_loc)
 			break;
@@ -425,8 +425,8 @@ typedef struct
 static int
 compare_by_addr (const void *arg1, const void *arg2)
 {
-	const FullSeqPoint *sp1 = arg1;
-	const FullSeqPoint *sp2 = arg2;
+	const FullSeqPoint *sp1 = (const FullSeqPoint *)arg1;
+	const FullSeqPoint *sp2 = (const FullSeqPoint *)arg2;
 
 	return sp1->native_offset - sp2->native_offset;
 }

--- a/mono/mini/main.c
+++ b/mono/mini/main.c
@@ -145,7 +145,7 @@ delete_bundled_libraries (void)
 	GSList *list;
 
 	for (list = bundle_library_paths; list != NULL; list = list->next){
-		unlink (list->data);
+		unlink ((const char*)list->data);
 	}
 	rmdir (bundled_dylibrary_directory);
 }
@@ -297,7 +297,7 @@ probe_embedded (const char *program, int *ref_argc, char **ref_argv [])
 		
 		if (mapaddress == NULL) {
 			char *error_message = NULL;
-			mapaddress = mono_file_map_error (directory_location - offset, MONO_MMAP_READ | MONO_MMAP_PRIVATE,
+			mapaddress = (guchar*)mono_file_map_error (directory_location - offset, MONO_MMAP_READ | MONO_MMAP_PRIVATE,
 				fd, offset, &maphandle, program, &error_message);
 			if (mapaddress == NULL) {
 				if (error_message)

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -82,8 +82,6 @@
 #include "mini-llvm.h"
 #include "mini-runtime.h"
 
-#define mono_emit_jit_icall(a, b, c) (mono_emit_jit_icall ((a), (gconstpointer)(b), (c)))
-
 #define BRANCH_COST 10
 #define CALL_COST 10
 /* Used for the JIT */
@@ -2728,8 +2726,7 @@ mono_emit_native_call (MonoCompile *cfg, gconstpointer func, MonoMethodSignature
 }
 
 MonoInst*
-// parens to avoid macro
-(mono_emit_jit_icall) (MonoCompile *cfg, gconstpointer func, MonoInst **args)
+mono_emit_jit_icall (MonoCompile *cfg, gconstpointer func, MonoInst **args)
 {
 	MonoJitICallInfo *info = mono_find_jit_icall_by_addr (func);
 

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -82,6 +82,8 @@
 #include "mini-llvm.h"
 #include "mini-runtime.h"
 
+#define mono_emit_jit_icall(a, b, c) (mono_emit_jit_icall ((a), (gconstpointer)(b), (c)))
+
 #define BRANCH_COST 10
 #define CALL_COST 10
 /* Used for the JIT */
@@ -2726,7 +2728,8 @@ mono_emit_native_call (MonoCompile *cfg, gconstpointer func, MonoMethodSignature
 }
 
 MonoInst*
-mono_emit_jit_icall (MonoCompile *cfg, gconstpointer func, MonoInst **args)
+// parens to avoid macro
+(mono_emit_jit_icall) (MonoCompile *cfg, gconstpointer func, MonoInst **args)
 {
 	MonoJitICallInfo *info = mono_find_jit_icall_by_addr (func);
 
@@ -3829,10 +3832,10 @@ handle_alloc (MonoCompile *cfg, MonoClass *klass, gboolean for_box, int context_
 		if (cfg->opt & MONO_OPT_SHARED) {
 			EMIT_NEW_DOMAINCONST (cfg, iargs [0]);
 			iargs [1] = data;
-			alloc_ftn = ves_icall_object_new;
+			alloc_ftn = (gpointer)ves_icall_object_new;
 		} else {
 			iargs [0] = data;
-			alloc_ftn = ves_icall_object_new_specific;
+			alloc_ftn = (gpointer)ves_icall_object_new_specific;
 		}
 
 		if (managed_alloc && !(cfg->opt & MONO_OPT_SHARED)) {
@@ -3853,12 +3856,12 @@ handle_alloc (MonoCompile *cfg, MonoClass *klass, gboolean for_box, int context_
 		EMIT_NEW_DOMAINCONST (cfg, iargs [0]);
 		EMIT_NEW_CLASSCONST (cfg, iargs [1], klass);
 
-		alloc_ftn = ves_icall_object_new;
+		alloc_ftn = (gpointer)ves_icall_object_new;
 	} else if (cfg->compile_aot && cfg->cbb->out_of_line && m_class_get_type_token (klass) && m_class_get_image (klass) == mono_defaults.corlib && !mono_class_is_ginst (klass)) {
 		/* This happens often in argument checking code, eg. throw new FooException... */
 		/* Avoid relocations and save some space by calling a helper function specialized to mscorlib */
 		EMIT_NEW_ICONST (cfg, iargs [0], mono_metadata_token_index (m_class_get_type_token (klass)));
-		alloc_ftn = mono_helper_newobj_mscorlib;
+		alloc_ftn = (gpointer)mono_helper_newobj_mscorlib;
 	} else {
 		MonoVTable *vtable = mono_class_vtable_checked (cfg->domain, klass, &cfg->error);
 
@@ -3878,7 +3881,7 @@ handle_alloc (MonoCompile *cfg, MonoClass *klass, gboolean for_box, int context_
 			EMIT_NEW_ICONST (cfg, iargs [1], size);
 			return mono_emit_method_call (cfg, managed_alloc, iargs, NULL);
 		}
-		alloc_ftn = ves_icall_object_new_specific;
+		alloc_ftn = (gpointer)ves_icall_object_new_specific;
 		EMIT_NEW_VTABLECONST (cfg, iargs [0], vtable);
 	}
 
@@ -9659,13 +9662,13 @@ calli_end:
 					ins->type = STACK_OBJ;
 					ins->klass = klass;
 					ins->inst_c0 = val->inst_c0;
-					ins->dreg = alloc_dreg (cfg, val->type);
+					ins->dreg = alloc_dreg (cfg, (MonoStackType)val->type);
 				} else {
 					MONO_INST_NEW (cfg, ins, OP_BOX);
 					ins->type = STACK_OBJ;
 					ins->klass = klass;
 					ins->sreg1 = val->dreg;
-					ins->dreg = alloc_dreg (cfg, val->type);
+					ins->dreg = alloc_dreg (cfg, (MonoStackType)val->type);
 				}
 				MONO_ADD_INS (cfg->cbb, ins);
 				*sp++ = ins;

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -6177,9 +6177,9 @@ void
 mono_arch_register_lowlevel_calls (void)
 {
 	/* The signature doesn't matter */
-	mono_register_jit_icall ((gconstpointer)mono_arm_throw_exception, "mono_arm_throw_exception", mono_create_icall_signature ("void"), TRUE);
-	mono_register_jit_icall ((gconstpointer)mono_arm_throw_exception_by_token, "mono_arm_throw_exception_by_token", mono_create_icall_signature ("void"), TRUE);
-	mono_register_jit_icall ((gconstpointer)mono_arm_unaligned_stack, "mono_arm_unaligned_stack", mono_create_icall_signature ("void"), TRUE);
+	mono_register_jit_icall (mono_arm_throw_exception, "mono_arm_throw_exception", mono_create_icall_signature ("void"), TRUE);
+	mono_register_jit_icall (mono_arm_throw_exception_by_token, "mono_arm_throw_exception_by_token", mono_create_icall_signature ("void"), TRUE);
+	mono_register_jit_icall (mono_arm_unaligned_stack, "mono_arm_unaligned_stack", mono_create_icall_signature ("void"), TRUE);
 }
 
 #define patch_lis_ori(ip,val) do {\

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -470,7 +470,7 @@ emit_float_args (MonoCompile *cfg, MonoCallInst *inst, guint8 *code, int *max_le
 	set_code_cursor (cfg, code);
 
 	for (list = inst->float_args; list; list = list->next) {
-		FloatArgData *fad = list->data;
+		FloatArgData *fad = (FloatArgData*)list->data;
 		MonoInst *var = get_vreg_to_inst (cfg, fad->vreg);
 		gboolean imm = arm_is_fpimm8 (var->inst_offset);
 
@@ -2667,7 +2667,7 @@ mono_arch_emit_outarg_vt (MonoCompile *cfg, MonoInst *ins, MonoInst *src)
 {
 	MonoCallInst *call = (MonoCallInst*)ins->inst_p0;
 	MonoInst *load;
-	ArgInfo *ainfo = ins->inst_p1;
+	ArgInfo *ainfo = (ArgInfo*)ins->inst_p1;
 	int ovf_size = ainfo->vtsize;
 	int doffset = ainfo->offset;
 	int struct_size = ainfo->struct_size;
@@ -3989,7 +3989,7 @@ handle_thunk (MonoCompile *cfg, MonoDomain *domain, guchar *code, const guchar *
 static void
 arm_patch_general (MonoCompile *cfg, MonoDomain *domain, guchar *code, const guchar *target)
 {
-	guint32 *code32 = (void*)code;
+	guint32 *code32 = (guint32*)code;
 	guint32 ins = *code32;
 	guint32 prim = (ins >> 25) & 7;
 	guint32 tval = GPOINTER_TO_UINT (target);
@@ -4252,7 +4252,7 @@ emit_move_return_value (MonoCompile *cfg, MonoInst *ins, guint8 *code)
 	MonoCallInst *call;
 
 	call = (MonoCallInst*)ins;
-	cinfo = call->call_info;
+	cinfo = (CallInfo*)call->call_info;
 
 	switch (cinfo->ret.storage) {
 	case RegTypeStructByVal:
@@ -5049,7 +5049,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			break;
 		case OP_AOTCONST:
 			/* Load the GOT offset */
-			mono_add_patch_info (cfg, offset, (MonoJumpInfoType)ins->inst_i1, ins->inst_p0);
+			mono_add_patch_info (cfg, offset, (MonoJumpInfoType)(gsize)ins->inst_i1, ins->inst_p0);
 			ARM_LDR_IMM (code, ins->dreg, ARMREG_PC, 0);
 			ARM_B (code, 0);
 			*(gpointer*)code = NULL;
@@ -6177,9 +6177,9 @@ void
 mono_arch_register_lowlevel_calls (void)
 {
 	/* The signature doesn't matter */
-	mono_register_jit_icall (mono_arm_throw_exception, "mono_arm_throw_exception", mono_create_icall_signature ("void"), TRUE);
-	mono_register_jit_icall (mono_arm_throw_exception_by_token, "mono_arm_throw_exception_by_token", mono_create_icall_signature ("void"), TRUE);
-	mono_register_jit_icall (mono_arm_unaligned_stack, "mono_arm_unaligned_stack", mono_create_icall_signature ("void"), TRUE);
+	mono_register_jit_icall ((gconstpointer)mono_arm_throw_exception, "mono_arm_throw_exception", mono_create_icall_signature ("void"), TRUE);
+	mono_register_jit_icall ((gconstpointer)mono_arm_throw_exception_by_token, "mono_arm_throw_exception_by_token", mono_create_icall_signature ("void"), TRUE);
+	mono_register_jit_icall ((gconstpointer)mono_arm_unaligned_stack, "mono_arm_unaligned_stack", mono_create_icall_signature ("void"), TRUE);
 }
 
 #define patch_lis_ori(ip,val) do {\
@@ -6245,7 +6245,7 @@ mono_arch_patch_code_new (MonoCompile *cfg, MonoDomain *domain, guint8 *code, Mo
 		/* everything is dealt with at epilog output time */
 		break;
 	default:
-		arm_patch_general (cfg, domain, ip, target);
+		arm_patch_general (cfg, domain, ip, (const guchar*)target);
 		break;
 	}
 }
@@ -6664,7 +6664,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 		code = emit_save_lmf (cfg, code, alloc_size - lmf_offset);
 
 	if (tracing)
-		code = mono_arch_instrument_prolog (cfg, mono_trace_enter_method, code, TRUE);
+		code = (guint8*)mono_arch_instrument_prolog (cfg, (void*)mono_trace_enter_method, code, TRUE);
 
 	if (cfg->arch.seq_point_info_var) {
 		MonoInst *ins = cfg->arch.seq_point_info_var;
@@ -6765,7 +6765,7 @@ mono_arch_emit_epilog (MonoCompile *cfg)
 	mono_emit_unwind_op_remember_state (cfg, code);
 
 	if (mono_jit_trace_calls != NULL && mono_trace_eval (method)) {
-		code = mono_arch_instrument_epilog (cfg, mono_trace_leave_method, code, TRUE);
+		code = (guint8*)mono_arch_instrument_epilog (cfg, (void*)mono_trace_leave_method, code, TRUE);
 	}
 	pos = 0;
 
@@ -6919,7 +6919,7 @@ mono_arch_emit_exceptions (MonoCompile *cfg)
 	 */
 	for (patch_info = cfg->patch_info; patch_info; patch_info = patch_info->next) {
 		if (patch_info->type == MONO_PATCH_INFO_EXC) {
-			i = mini_exception_id_by_name (patch_info->data.target);
+			i = mini_exception_id_by_name ((const char*)patch_info->data.target);
 			if (!exc_throw_found [i]) {
 				max_epilog_size += 32;
 				exc_throw_found [i] = TRUE;
@@ -6936,7 +6936,7 @@ mono_arch_emit_exceptions (MonoCompile *cfg)
 			MonoClass *exc_class;
 			unsigned char *ip = patch_info->ip.i + cfg->native_code;
 
-			i = mini_exception_id_by_name (patch_info->data.target);
+			i = mini_exception_id_by_name ((const char*)patch_info->data.target);
 			if (exc_throw_pos [i]) {
 				arm_patch (ip, exc_throw_pos [i]);
 				patch_info->type = MONO_PATCH_INFO_NONE;
@@ -7329,14 +7329,14 @@ mono_arch_set_breakpoint (MonoJitInfo *ji, guint8 *ip)
 	MonoDebugOptions *opt = mini_get_debug_options ();
 
 	if (ji->from_aot) {
-		SeqPointInfo *info = mono_arch_get_seq_point_info (mono_domain_get (), ji->code_start);
+		SeqPointInfo *info = (SeqPointInfo*)mono_arch_get_seq_point_info (mono_domain_get (), (guint8*)ji->code_start);
 
 		if (!breakpoint_tramp)
 			breakpoint_tramp = mini_get_breakpoint_trampoline ();
 
 		g_assert (native_offset % 4 == 0);
 		g_assert (info->bp_addrs [native_offset / 4] == 0);
-		info->bp_addrs [native_offset / 4] = opt->soft_breakpoints ? breakpoint_tramp : bp_trigger_page;
+		info->bp_addrs [native_offset / 4] = (guint8*)(opt->soft_breakpoints ? breakpoint_tramp : bp_trigger_page);
 	} else if (opt->soft_breakpoints) {
 		code += 4;
 		ARM_BLX_REG (code, ARMREG_LR);
@@ -7378,13 +7378,13 @@ mono_arch_clear_breakpoint (MonoJitInfo *ji, guint8 *ip)
 
 	if (ji->from_aot) {
 		guint32 native_offset = ip - (guint8*)ji->code_start;
-		SeqPointInfo *info = mono_arch_get_seq_point_info (mono_domain_get (), ji->code_start);
+		SeqPointInfo *info = (SeqPointInfo*)mono_arch_get_seq_point_info (mono_domain_get (), (guint8*)ji->code_start);
 
 		if (!breakpoint_tramp)
 			breakpoint_tramp = mini_get_breakpoint_trampoline ();
 
 		g_assert (native_offset % 4 == 0);
-		g_assert (info->bp_addrs [native_offset / 4] == (opt->soft_breakpoints ? breakpoint_tramp : bp_trigger_page));
+		g_assert (info->bp_addrs [native_offset / 4] == (guint8*)(opt->soft_breakpoints ? breakpoint_tramp : bp_trigger_page));
 		info->bp_addrs [native_offset / 4] = 0;
 	} else if (opt->soft_breakpoints) {
 		code += 4;
@@ -7441,7 +7441,7 @@ mono_arch_stop_single_stepping (void)
 gboolean
 mono_arch_is_single_step_event (void *info, void *sigctx)
 {
-	siginfo_t *sinfo = info;
+	siginfo_t *sinfo = (siginfo_t*)info;
 
 	if (!ss_trigger_page)
 		return FALSE;
@@ -7461,7 +7461,7 @@ mono_arch_is_single_step_event (void *info, void *sigctx)
 gboolean
 mono_arch_is_breakpoint_event (void *info, void *sigctx)
 {
-	siginfo_t *sinfo = info;
+	siginfo_t *sinfo = (siginfo_t*)info;
 
 	if (!ss_trigger_page)
 		return FALSE;

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -713,7 +713,7 @@ emit_call (MonoCompile *cfg, guint8* code, guint32 patch_type, gconstpointer dat
 	code = emit_imm64_template (code, ARMREG_LR);
 	arm_blrx (code, ARMREG_LR);
 	*/
-	mono_add_patch_info_rel (cfg, code - cfg->native_code, patch_type, data, MONO_R_ARM64_BL);
+	mono_add_patch_info_rel (cfg, code - cfg->native_code, (MonoJumpInfoType)patch_type, data, MONO_R_ARM64_BL);
 	arm_bl (code, code);
 	cfg->thunk_area += THUNK_SIZE;
 	return code;
@@ -723,9 +723,9 @@ static guint8*
 emit_aotconst_full (MonoCompile *cfg, MonoJumpInfo **ji, guint8 *code, guint8 *start, int dreg, guint32 patch_type, gconstpointer data)
 {
 	if (cfg)
-		mono_add_patch_info (cfg, code - cfg->native_code, patch_type, data);
+		mono_add_patch_info (cfg, code - cfg->native_code, (MonoJumpInfoType)patch_type, data);
 	else
-		*ji = mono_patch_info_list_prepend (*ji, code - start, patch_type, data);
+		*ji = mono_patch_info_list_prepend (*ji, code - start, (MonoJumpInfoType)patch_type, data);
 	/* See arch_emit_got_access () in aot-compiler.c */
 	arm_ldrx_lit (code, dreg, 0);
 	arm_nop (code);
@@ -1024,13 +1024,13 @@ mono_arch_flush_register_windows (void)
 MonoMethod*
 mono_arch_find_imt_method (mgreg_t *regs, guint8 *code)
 {
-	return (gpointer)regs [MONO_ARCH_RGCTX_REG];
+	return (MonoMethod*)regs [MONO_ARCH_RGCTX_REG];
 }
 
 MonoVTable*
 mono_arch_find_static_call_vtable (mgreg_t *regs, guint8 *code)
 {
-	return (gpointer)regs [MONO_ARCH_RGCTX_REG];
+	return (MonoVTable*)regs [MONO_ARCH_RGCTX_REG];
 }
 
 mgreg_t

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -32,6 +32,7 @@
 #include <mono/metadata/assembly.h>
 #include <mono/metadata/assembly-internals.h>
 #include <mono/metadata/loader.h>
+#include <mono/metadata/loader-internals.h>
 #include <mono/metadata/tabledefs.h>
 #include <mono/metadata/class.h>
 #include <mono/metadata/object.h>
@@ -667,8 +668,14 @@ mono_dynamic_code_hash_lookup (MonoDomain *domain, MonoMethod *method)
 	return res;
 }
 
+#ifdef __cplusplus
+template <typename T>
+static void
+register_opcode_emulation (int opcode, const char *name, const char *sigstr, T func, const char *symbol, gboolean no_wrapper)
+#else
 static void
 register_opcode_emulation (int opcode, const char *name, const char *sigstr, gpointer func, const char *symbol, gboolean no_wrapper)
+#endif
 {
 #ifndef DISABLE_JIT
 	mini_register_opcode_emulation (opcode, name, sigstr, func, symbol, no_wrapper);
@@ -688,8 +695,14 @@ register_opcode_emulation (int opcode, const char *name, const char *sigstr, gpo
  * If @avoid_wrapper is TRUE, no wrapper is generated. This is for perf critical icalls which
  * can't throw exceptions.
  */
+#ifdef __cplusplus
+template <typename T>
+static void
+register_icall (T func, const char *name, const char *sigstr, gboolean avoid_wrapper)
+#else
 static void
 register_icall (gpointer func, const char *name, const char *sigstr, gboolean avoid_wrapper)
+#endif
 {
 	MonoMethodSignature *sig;
 
@@ -701,8 +714,14 @@ register_icall (gpointer func, const char *name, const char *sigstr, gboolean av
 	mono_register_jit_icall_full (func, name, sig, avoid_wrapper, avoid_wrapper ? name : NULL);
 }
 
+#ifdef __cplusplus
+template <typename T>
+static void
+register_icall_no_wrapper (T func, const char *name, const char *sigstr)
+#else
 static void
 register_icall_no_wrapper (gpointer func, const char *name, const char *sigstr)
+#endif
 {
 	MonoMethodSignature *sig;
 
@@ -714,8 +733,14 @@ register_icall_no_wrapper (gpointer func, const char *name, const char *sigstr)
 	mono_register_jit_icall_full (func, name, sig, TRUE, name);
 }
 
+#ifdef __cplusplus
+template <typename T>
+static void
+register_icall_with_wrapper (T func, const char *name, const char *sigstr)
+#else
 static void
 register_icall_with_wrapper (gpointer func, const char *name, const char *sigstr)
+#endif
 {
 	MonoMethodSignature *sig;
 

--- a/mono/mini/mini-wasm.c
+++ b/mono/mini/mini-wasm.c
@@ -3,6 +3,7 @@
 #include <mono/metadata/mono-debug.h>
 #include <mono/metadata/assembly.h>
 #include <mono/metadata/metadata.h>
+#include <mono/metadata/loader-internals.h>
 #include <mono/metadata/seq-points-data.h>
 #include <mono/mini/aot-runtime.h>
 #include <mono/mini/seq-points.h>

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2042,6 +2042,16 @@ MonoInst *mono_get_got_var (MonoCompile *cfg);
 void      mono_add_seq_point (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins, int native_offset);
 void      mono_add_var_location (MonoCompile *cfg, MonoInst *var, gboolean is_reg, int reg, int offset, int from, int to);
 MonoInst* mono_emit_jit_icall (MonoCompile *cfg, gconstpointer func, MonoInst **args);
+
+#ifdef __cplusplus
+template <typename T>
+inline MonoInst*
+mono_emit_jit_icall (MonoCompile *cfg, T func, MonoInst **args)
+{
+	return mono_emit_jit_icall (cfg, (gconstpointer)func, args);
+}
+#endif // __cplusplus
+
 MonoInst* mono_emit_jit_icall_by_info (MonoCompile *cfg, int il_offset, MonoJitICallInfo *info, MonoInst **args);
 MonoInst* mono_emit_method_call (MonoCompile *cfg, MonoMethod *method, MonoInst **args, MonoInst *this_ins);
 void      mono_create_helper_signatures (void);
@@ -2077,6 +2087,15 @@ void      mono_add_ins_to_end               (MonoBasicBlock *bb, MonoInst *inst)
 void      mono_replace_ins                  (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins, MonoInst **prev, MonoBasicBlock *first_bb, MonoBasicBlock *last_bb);
 
 void              mini_register_opcode_emulation (int opcode, const char *name, const char *sigstr, gpointer func, const char *symbol, gboolean no_throw);
+
+#ifdef __cplusplus
+template <typename T>
+inline void
+mini_register_opcode_emulation (int opcode, const char *name, const char *sigstr, T func, const char *symbol, gboolean no_throw)
+{
+	mini_register_opcode_emulation (opcode, name, sigstr, (gpointer)func, symbol, no_throw);
+}
+#endif // __cplusplus
 
 void              mono_trampolines_init (void);
 void              mono_trampolines_cleanup (void);

--- a/mono/mini/tasklets.c
+++ b/mono/mini/tasklets.c
@@ -11,6 +11,8 @@
 
 #if defined(MONO_SUPPORT_TASKLETS)
 
+#include "mono/metadata/loader-internals.h"
+
 static mono_mutex_t tasklets_mutex;
 #define tasklets_lock() mono_os_mutex_lock(&tasklets_mutex)
 #define tasklets_unlock() mono_os_mutex_unlock(&tasklets_mutex)

--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -16,6 +16,7 @@
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/debug-helpers.h>
 #include <mono/metadata/loader.h>
+#include <mono/metadata/loader-internals.h>
 #include <mono/metadata/metadata-internals.h>
 #include <mono/metadata/mono-config.h>
 #include <mono/metadata/mono-gc.h>


### PR DESCRIPTION
This is an alternative to https://github.com/mono/mono/pull/10036.
Instead of macros, or casts, it uses templates.
The line damage of the casts does not seem good to me and I prefer templates or macros.