### PR TITLE
[eglib] Fix URI to file name conversion

### DIFF
--- a/mono/eglib/gstr.c
+++ b/mono/eglib/gstr.c
@@ -724,9 +724,9 @@ decode (char p)
 	if (p >= '0' && p <= '9')
 		return p - '0';
 	if (p >= 'A' && p <= 'F')
-		return p - 'A';
+		return (p - 'A') + 10;
 	if (p >= 'a' && p <= 'f')
-		return p - 'a';
+		return (p - 'a') + 10;
 	g_assert_not_reached ();
 	return 0;
 }

--- a/mono/eglib/test/string-util.c
+++ b/mono/eglib/test/string-util.c
@@ -463,6 +463,8 @@ test_filename_from_uri (void)
 	fileit ("file:///%41", "/A");
 	fileit ("file:///home/miguel", "/home/miguel");
 	fileit ("file:///home/mig%20uel", "/home/mig uel");
+	fileit ("file:///home/c%2B%2B", "/home/c++");
+	fileit ("file:///home/c%2b%2b", "/home/c++");
 	ferrit ("/a");
 	ferrit ("a");
 	ferrit ("file://a");


### PR DESCRIPTION
Hexadecimal ASCII to decimal integer conversion must be 10-based.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
