### PR TITLE
Pass arguments to LLVM's LLC via --aot=llvmllc

### DIFF
--- a/man/mono.1
+++ b/man/mono.1
@@ -221,6 +221,13 @@ obtained by calling the bundled
 .I opt
 program that comes with Mono.
 .TP
+.I llvmllc=[options]
+Use this option to override the built-in set of flags passed to the
+LLVM static compiler (llc).   The list of possible flags that can be passed can be
+obtained by calling the bundled 
+.I llc
+program that comes with Mono.
+.TP
 .I llvm-outfile=[filename]
 Gives the path for the temporary LLVM bitcode file created during AOT.
 .I dedup

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -227,6 +227,7 @@ typedef struct MonoAotOptions {
 	char *instances_logfile_path;
 	char *logfile;
 	char *llvm_opts;
+	char *llvm_llc;
 	gboolean dump_json;
 	gboolean profile_only;
 	gboolean no_opt;
@@ -7593,6 +7594,8 @@ mono_aot_parse_options (const char *aot_options, MonoAotOptions *opts)
 			opts->verbose = TRUE;
 		} else if (str_begins_with (arg, "llvmopts=")){
 			opts->llvm_opts = g_strdup (arg + strlen ("llvmopts="));
+		} else if (str_begins_with (arg, "llvmllc=")){
+			opts->llvm_llc = g_strdup (arg + strlen ("llvmllc="));
 		} else if (!strcmp (arg, "deterministic")) {
 			opts->deterministic = TRUE;
 		} else if (!strcmp (arg, "no-opt")) {
@@ -9164,6 +9167,12 @@ emit_llvm_file (MonoAotCompile *acfg)
 	} else {
 		output_fname = g_strdup_printf ("%s", acfg->llvm_sfile);
 	}
+
+	if (acfg->aot_opts.llvm_llc) {
+		g_free (acfg->llc_args);
+		acfg->llc_args = g_string_new (acfg->aot_opts.llvm_llc);
+	}
+
 	command = g_strdup_printf ("\"%sllc\" %s -o \"%s\" \"%s.opt.bc\"", acfg->aot_opts.llvm_path, acfg->llc_args->str, output_fname, acfg->tmpbasename);
 	g_free (output_fname);
 

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -7642,6 +7642,7 @@ mono_aot_parse_options (const char *aot_options, MonoAotOptions *opts)
 			printf ("    write-symbols\n");
 			printf ("    verbose\n");
 			printf ("    no-opt\n");
+			printf ("    llvmllc=\n");
 			printf ("    help/?\n");
 			exit (0);
 		} else {

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -7642,6 +7642,7 @@ mono_aot_parse_options (const char *aot_options, MonoAotOptions *opts)
 			printf ("    write-symbols\n");
 			printf ("    verbose\n");
 			printf ("    no-opt\n");
+			printf ("    llvmopts=\n");
 			printf ("    llvmllc=\n");
 			printf ("    help/?\n");
 			exit (0);


### PR DESCRIPTION
Currently we can override arguments passed to llvm's `opt` via `--aot=llvm,llvmopts="some args"`, this PR introduces a similar capability for `llc` - `llvmllc` parameter.
E.g. for my environment Mono uses the following arguments for llc:
```
-march=x86-64 -mattr=sse4.1 -asm-verbose=false -disable-gnu-eh-frame 
-enable-mono-eh-frame -mono-eh-frame-symbol=_mono_aot_fffff_eh_frame 
-disable-tail-calls -no-x86-call-frame-opt -relocation-model=pic 
-filetype=obj -o "mono_aot_IWvNWm/temp-llvm.o" "mono_aot_IWvNWm/temp.opt.bc"
```
what if I want to test some avx stuff, e.g. `-march=core-avx2 -O2` and test other parameters.