### PR TITLE
[cxx] int vs. enum -- bit overload version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1022,12 +1022,17 @@ fi
 
 AC_ARG_ENABLE(cxx, [  --enable-cxx   compile some code as C++])
 
+# mono/corefx/native has a lot of invalid C++98 in its headers
+# dotnet/corefx/native looks a lot better, i.e. 44e5bdafb8d989a220c9cf1b94f31a64a6e4f052
+#CXXFLAGS_COMMON=' -std=gnu++98 -fno-exceptions -fno-rtti '
+CXXFLAGS_COMMON=' -std=gnu++0x -fno-exceptions -fno-rtti '
+# "c++0x" instead of C++11, for compat with Centos6/gcc4.4
+
+AC_SUBST(CXXFLAGS_COMMON)
+
 if test "x$enable_cxx" = "xyes"; then
 
-	# FIXME Centos6 requires a different flag for prerelease C++11.
-	#CXX_ADD_CFLAGS=' -xc++ -std=gnu++98 -fno-exceptions -fno-rtti '
-	CXX_ADD_CFLAGS=' -xc++ -std=gnu++0x -fno-exceptions -fno-rtti '
-	# "c++0x" instead of C++11, for compat with Centos6/gcc4.4
+	CXX_ADD_CFLAGS=" -xc++ $CXXFLAGS_COMMON "
 
 	# -std=gnu99 -xc++ is not allowed and errors.
 	CXX_REMOVE_CFLAGS=-std=gnu99
@@ -5546,6 +5551,7 @@ mono/mini/Makefile
 mono/profiler/Makefile
 mono/eglib/Makefile
 mono/eglib/eglib-config.h
+mono/eglib/test/Makefile
 m4/Makefile
 ikvm-native/Makefile
 scripts/Makefile

--- a/mono/eglib/eglib-remap.h
+++ b/mono/eglib/eglib-remap.h
@@ -296,3 +296,5 @@
 #define g_log_set_default_handler monoeg_log_set_default_handler
 #define g_set_print_handler monoeg_set_print_handler
 #define g_set_printerr_handler monoeg_set_printerr_handler
+
+#define g_size_to_int monoeg_size_to_int

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -113,29 +113,30 @@ public:
 // This alleviates a fair number of casts in porting C to C++.
 
 // Forward declare template with no generic implementation.
-template <size_t> struct mono_size_to_int;
+template <size_t> struct g_size_to_int;
 
 // Template specializations.
-template <> struct mono_size_to_int<1> { typedef int8_t T; };
-template <> struct mono_size_to_int<2> { typedef int16_t T; };
-template <> struct mono_size_to_int<4> { typedef int32_t T; };
-template <> struct mono_size_to_int<8> { typedef int64_t T; };
+template <> struct g_size_to_int<1> { typedef int8_t type; };
+template <> struct g_size_to_int<2> { typedef int16_t type; };
+template <> struct g_size_to_int<4> { typedef int32_t type; };
+template <> struct g_size_to_int<8> { typedef int64_t type; };
 
-#define MONO_SIZE_TO_INT(x) mono_size_to_int <sizeof (x)>::T
+template <typename T>
+using g_size_to_int_t = typename g_size_to_int <sizeof (T)>::type;
 
 #define G_ENUM_BINOP(Enum, op, opeq) 		\
 inline Enum					\
 operator op (Enum a, Enum b)			\
 {						\
-	typedef MONO_SIZE_TO_INT (a) T;		\
-	return (Enum)((T)a op (T)b);		\
+	typedef g_size_to_int_t <Enum> type; 	\
+	return static_cast<Enum>(static_cast<type>(a) op static_cast<type>(b)); \
 }						\
 						\
 inline Enum&					\
 operator opeq (Enum& a, Enum b)			\
 {						\
-	typedef MONO_SIZE_TO_INT (a) T; 	\
-	return (Enum&)((T&)a opeq (T)b);	\
+	typedef g_size_to_int_t <Enum> type; 	\
+	return (Enum&)((type&)(a) opeq static_cast<type>(b)); \
 }						\
 
 #define G_ENUM_FUNCTIONS(Enum)			\
@@ -143,8 +144,8 @@ extern "C++" { /* in case within extern "C" */	\
 inline Enum					\
 operator~ (Enum a)				\
 {						\
-	typedef MONO_SIZE_TO_INT (a) T;		\
-	return (Enum)~(T)a;			\
+	typedef g_size_to_int_t <Enum> type; 	\
+	return static_cast<Enum>(~static_cast<type>(a)); \
 }						\
 						\
 G_ENUM_BINOP (Enum, |, |=) 			\

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -138,7 +138,7 @@ inline Enum					\
 operator op (Enum a, Enum b)			\
 {						\
 	typedef g_size_to_int_t (Enum) type; 	\
-	return static_cast<Enum>(static_cast<type>(a) op static_cast<type>(b)); \
+	return static_cast<Enum>(static_cast<type>(a) op b); \
 }						\
 						\
 inline Enum&					\

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -107,6 +107,56 @@ public:
 
 #endif
 
+#ifdef __cplusplus
+
+// Provide for bit operations on enums, but not all integer operations.
+// This alleviates a fair number of casts in porting C to C++.
+
+// Forward declare template with no generic implementation.
+template <size_t> struct mono_size_to_int;
+
+// Template specializations.
+template <> struct mono_size_to_int<1> { typedef int8_t T; };
+template <> struct mono_size_to_int<2> { typedef int16_t T; };
+template <> struct mono_size_to_int<4> { typedef int32_t T; };
+template <> struct mono_size_to_int<8> { typedef int64_t T; };
+
+#define MONO_SIZE_TO_INT(x) mono_size_to_int <sizeof (x)>::T
+
+#define G_ENUM_BINOP(Enum, op, opeq) 		\
+inline Enum					\
+operator op (Enum a, Enum b)			\
+{						\
+	typedef MONO_SIZE_TO_INT (a) T;		\
+	return (Enum)((T)a op (T)b);		\
+}						\
+						\
+inline Enum&					\
+operator opeq (Enum& a, Enum b)			\
+{						\
+	typedef MONO_SIZE_TO_INT (a) T; 	\
+	return (Enum&)((T&)a opeq (T)b);	\
+}						\
+
+#define G_ENUM_FUNCTIONS(Enum)			\
+extern "C++" { /* in case within extern "C" */	\
+inline Enum					\
+operator~ (Enum a)				\
+{						\
+	typedef MONO_SIZE_TO_INT (a) T;		\
+	return (Enum)~(T)a;			\
+}						\
+						\
+G_ENUM_BINOP (Enum, |, |=) 			\
+G_ENUM_BINOP (Enum, &, &=) 			\
+G_ENUM_BINOP (Enum, ^, ^=) 			\
+						\
+} /* extern "C++" */
+
+#else
+#define G_ENUM_FUNCTIONS(Enum) /* nothing */
+#endif
+
 G_BEGIN_DECLS
 
 /*
@@ -652,6 +702,8 @@ typedef enum {
 	G_LOG_LEVEL_MASK              = ~(G_LOG_FLAG_RECURSION | G_LOG_FLAG_FATAL)
 } GLogLevelFlags;
 
+G_ENUM_FUNCTIONS (GLogLevelFlags)
+
 void           g_printv               (const gchar *format, va_list args);
 void           g_print                (const gchar *format, ...);
 void           g_printerr             (const gchar *format, ...);
@@ -984,6 +1036,7 @@ typedef enum {
 	G_FILE_TEST_EXISTS = 1 << 4
 } GFileTest;
 
+G_ENUM_FUNCTIONS (GFileTest)
 
 gboolean   g_file_set_contents (const gchar *filename, const gchar *contents, gssize length, GError **gerror);
 gboolean   g_file_get_contents (const gchar *filename, gchar **contents, gsize *length, GError **gerror);

--- a/mono/eglib/gmodule.h
+++ b/mono/eglib/gmodule.h
@@ -20,6 +20,9 @@ typedef enum {
 	G_MODULE_BIND_LOCAL = 0x02,
 	G_MODULE_BIND_MASK = 0x03
 } GModuleFlags;
+
+G_ENUM_FUNCTIONS (GModuleFlags)
+
 typedef struct _GModule GModule;
 
 GModule *g_module_open (const gchar *file, GModuleFlags flags);

--- a/mono/eglib/gunicode.c
+++ b/mono/eglib/gunicode.c
@@ -60,7 +60,7 @@ g_unichar_type (gunichar c)
 			continue;
 		if (unicode_category_ranges [i].end <= cp)
 			continue;
-		return unicode_category [i] [cp - unicode_category_ranges [i].start];
+		return (GUnicodeType)(unicode_category [i] [cp - unicode_category_ranges [i].start]);
 	}
 
 	/*
@@ -86,7 +86,7 @@ g_unichar_type (gunichar c)
 	/* since the argument is UTF-16, we cannot check beyond FFFF */
 
 	/* It should match any of above */
-	return 0; // G_UNICODE_CONTROL
+	return (GUnicodeType)0; // G_UNICODE_CONTROL
 }
 
 GUnicodeBreakType

--- a/mono/eglib/test/Makefile.am
+++ b/mono/eglib/test/Makefile.am
@@ -3,6 +3,7 @@ include $(top_srcdir)/mk/common.mk
 EXTRA_DIST = UTF-8.txt UTF-16BE.txt UTF-16LE.txt UTF-32BE.txt UTF-32LE.txt
 
 SOURCES = \
+	enum.cpp	\
 	test.c 		\
 	test.h 		\
 	tests.h 	\
@@ -33,7 +34,10 @@ SOURCES = \
 
 test_eglib_SOURCES = $(SOURCES)
 
-CFLAGS += -Wall -DEGLIB_TESTS=1 -D_FORTIFY_SOURCE=2 -I$(srcdir)/.. -I.. -DDRIVER_NAME=\"EGlib\"
+GLIB_TEST_FLAGS_COMMON = -Wall -DEGLIB_TESTS=1 -D_FORTIFY_SOURCE=2 -I$(srcdir)/.. -I.. -DDRIVER_NAME=\"EGlib\"
+CFLAGS += $(GLIB_TEST_FLAGS_COMMON)
+CXXFLAGS += $(GLIB_TEST_FLAGS_COMMON) @CXXFLAGS_COMMON@
+
 test_eglib_LDADD = ../libeglib.la $(LTLIBICONV)
 assertf_LDADD = ../libeglib.la $(LTLIBICONV)
 

--- a/mono/eglib/test/enum.cpp
+++ b/mono/eglib/test/enum.cpp
@@ -1,0 +1,67 @@
+#include "config.h"
+#include "glib.h"
+
+typedef enum {
+	Black = 0,
+	Red = 1,
+	Blue = 2,
+	Purple = Red | Blue, // 3
+	Green = 4,
+	Yellow = Red | Green, // 5
+	White = 7,
+} Color;
+
+G_ENUM_FUNCTIONS (Color)
+
+static void
+test_enum1 (void)
+{
+	const Color green = Green;
+	const Color blue = Blue;
+	const Color red = Red;
+	const Color white = White;
+	const Color purple = Purple;
+
+	g_assert ((red & blue) == Black);
+	g_assert ((red | blue | green) == White);
+	g_assert ((red | blue) == Purple);
+	g_assert ((white ^ purple) == green);
+
+	Color c = Black;
+	Color c2 = Black;
+	c |= red;
+	g_assert (c == Red);
+	c ^= red;
+	g_assert (c == Black);
+
+	c |= (c2 |= Red) | Blue;
+	g_assert (c == Purple);
+	g_assert (c2 == Red);
+
+	c = c2 = Black;
+	c |= (c2 |= Red) |= Blue;
+	g_assert (c == Purple);
+	g_assert (c2 == Purple);
+
+	c = red;
+	c &= red;
+	g_assert (c == Red);
+	c &= blue;
+	g_assert (c == Black);
+}
+
+#include "test.h"
+
+static RESULT
+test_enum (void)
+{
+	test_enum1 ();
+	return OK;
+}
+
+const static Test enum_tests [2] = {{"test_enum", test_enum}};
+
+extern "C"
+{
+DEFINE_TEST_GROUP_INIT (enum_tests_init, enum_tests)
+}

--- a/mono/eglib/test/test.c
+++ b/mono/eglib/test/test.c
@@ -49,7 +49,7 @@ extern gint global_passed, global_tests;
 static gchar *last_result = NULL;
 
 static gboolean 
-run_test(Test *test, gchar **result_out)
+run_test(const Test *test, char **result_out)
 {
 	gchar *result; 
 
@@ -63,8 +63,8 @@ run_test(Test *test, gchar **result_out)
 }
 
 gboolean
-run_group(Group *group, gint iterations, gboolean quiet, 
-	gboolean time, gchar *tests_to_run_s)
+run_group(const Group *group, gint iterations, gboolean quiet,
+	gboolean time, const char *tests_to_run_s)
 {
 	Test *tests = group->handler();
 	gint i, j, passed = 0, total = 0;

--- a/mono/eglib/test/test.h
+++ b/mono/eglib/test/test.h
@@ -61,8 +61,8 @@ struct _Group {
 	LoadGroupHandler handler;
 };
 
-gboolean run_group(Group *group, gint iterations, gboolean quiet, 
-	gboolean time, gchar *tests);
+gboolean run_group(const Group *group, gint iterations, gboolean quiet,
+	gboolean time, const char *tests);
 #undef FAILED
 RESULT FAILED(const gchar *format, ...);
 gdouble get_timestamp (void);
@@ -72,8 +72,8 @@ void eg_strfreev (gchar **str_array);
 #define OK NULL
 
 #define DEFINE_TEST_GROUP_INIT(name, table) \
-	Test * (name) (void); \
-	Test * (name) (void) { return table; }
+	const Test * (name) (void); \
+	const Test * (name) (void) { return table; }
 
 #define DEFINE_TEST_GROUP_INIT_H(name) \
 	Test * (name) (void);

--- a/mono/eglib/test/tests.h
+++ b/mono/eglib/test/tests.h
@@ -23,7 +23,9 @@ DEFINE_TEST_GROUP_INIT_H(utf8_tests_init);
 DEFINE_TEST_GROUP_INIT_H(endian_tests_init);
 DEFINE_TEST_GROUP_INIT_H(module_tests_init);
 DEFINE_TEST_GROUP_INIT_H(memory_tests_init);
+DEFINE_TEST_GROUP_INIT_H(enum_tests_init);
 
+const
 static Group test_groups [] = {	
 	{"string",    string_tests_init}, 
 	{"strutil",   strutil_tests_init},
@@ -52,6 +54,6 @@ static Group test_groups [] = {
 	{"utf8",      utf8_tests_init},
 	{"endian",    endian_tests_init},
 	{"memory",    memory_tests_init},
+	{"enum",      enum_tests_init},
 	{NULL, NULL}
 };
-

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -205,6 +205,8 @@ typedef enum {
 	JIT_INFO_HAS_UNWIND_INFO = (1 << 4)
 } MonoJitInfoFlags;
 
+G_ENUM_FUNCTIONS (MonoJitInfoFlags)
+
 struct _MonoJitInfo {
 	/* NOTE: These first two elements (method and
 	   next_jit_code_hash) must be in the same order and at the

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -2670,7 +2670,7 @@ reflection_setup_internal_class_internal (MonoReflectionTypeBuilderHandle ref_tb
 		gboolean recursive_init = TRUE;
 
 		if (is_sre_type_builder (parent_klass)) {
-			MonoTypeBuilderState parent_state = MONO_HANDLE_GETVAL (MONO_HANDLE_CAST (MonoReflectionTypeBuilder, ref_parent), state);
+			MonoTypeBuilderState parent_state = (MonoTypeBuilderState)MONO_HANDLE_GETVAL (MONO_HANDLE_CAST (MonoReflectionTypeBuilder, ref_parent), state);
 
 			if (parent_state != MonoTypeBuilderNew) {
 				// Initialize types reachable from parent recursively
@@ -2733,7 +2733,7 @@ reflection_init_generic_class (MonoReflectionTypeBuilderHandle ref_tb, MonoError
 
 	error_init (error);
 
-	MonoTypeBuilderState ref_state = MONO_HANDLE_GETVAL (ref_tb, state);
+	MonoTypeBuilderState ref_state = (MonoTypeBuilderState)MONO_HANDLE_GETVAL (ref_tb, state);
 	g_assert (ref_state == MonoTypeBuilderFinished);
 
 	MonoType *type = MONO_HANDLE_GETVAL (MONO_HANDLE_CAST (MonoReflectionType, ref_tb), type);

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -34,7 +34,9 @@ typedef enum {
 	ThreadState_Suspended = 0x00000040,
 	ThreadState_AbortRequested = 0x00000080,
 	ThreadState_Aborted = 0x00000100
-} MonoThreadState; 
+} MonoThreadState;
+
+G_ENUM_FUNCTIONS (MonoThreadState)
 
 /* This is a copy of System.Threading.ApartmentState */
 typedef enum {

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -2440,14 +2440,14 @@ void
 ves_icall_System_Threading_Thread_ClrState (MonoInternalThreadHandle this_obj, guint32 state, MonoError *error)
 {
 	// InternalThreads are always pinned, so shallowly coop-handleize.
-	mono_thread_clr_state (mono_internal_thread_handle_ptr (this_obj), state);
+	mono_thread_clr_state (mono_internal_thread_handle_ptr (this_obj), (MonoThreadState)state);
 }
 
 void
 ves_icall_System_Threading_Thread_SetState (MonoInternalThreadHandle thread_handle, guint32 state, MonoError *error)
 {
 	// InternalThreads are always pinned, so shallowly coop-handleize.
-	mono_thread_set_state (mono_internal_thread_handle_ptr (thread_handle), state);
+	mono_thread_set_state (mono_internal_thread_handle_ptr (thread_handle), (MonoThreadState)state);
 }
 
 guint32
@@ -5168,7 +5168,7 @@ mono_thread_clear_and_set_state (MonoInternalThread *thread, MonoThreadState cle
 {
 	LOCK_THREAD (thread);
 
-	MonoThreadState const old_state = thread->state;
+	MonoThreadState const old_state = (MonoThreadState)thread->state;
 	MonoThreadState const new_state = (old_state & ~clear) | set;
 	thread->state = new_state;
 
@@ -5180,7 +5180,7 @@ mono_thread_clear_and_set_state (MonoInternalThread *thread, MonoThreadState cle
 void
 mono_thread_set_state (MonoInternalThread *thread, MonoThreadState state)
 {
-	mono_thread_clear_and_set_state (thread, 0, state);
+	mono_thread_clear_and_set_state (thread, (MonoThreadState)0, state);
 }
 
 /**
@@ -5193,7 +5193,7 @@ mono_thread_test_and_set_state (MonoInternalThread *thread, MonoThreadState test
 {
 	LOCK_THREAD (thread);
 	
-	MonoThreadState const old_state = thread->state;
+	MonoThreadState const old_state = (MonoThreadState)thread->state;
 
 	if ((old_state & test) != 0) {
 		UNLOCK_THREAD (thread);
@@ -5213,7 +5213,7 @@ mono_thread_test_and_set_state (MonoInternalThread *thread, MonoThreadState test
 void
 mono_thread_clr_state (MonoInternalThread *thread, MonoThreadState state)
 {
-	mono_thread_clear_and_set_state (thread, state, 0);
+	mono_thread_clear_and_set_state (thread, state, (MonoThreadState)0);
 }
 
 gboolean

--- a/mono/metadata/w32handle.c
+++ b/mono/metadata/w32handle.c
@@ -1002,10 +1002,10 @@ mono_w32handle_wait_multiple (gpointer *handles, gsize nhandles, gboolean waital
 		mono_w32handle_unlock_handles (handles_data, nhandles);
 
 		if (signalled) {
-			ret = MONO_W32HANDLE_WAIT_RET_SUCCESS_0 + lowest;
+			ret = (MonoW32HandleWaitRet)(MONO_W32HANDLE_WAIT_RET_SUCCESS_0 + lowest);
 			for (i = lowest; i < nhandles; i++) {
 				if (abandoned [i]) {
-					ret = MONO_W32HANDLE_WAIT_RET_ABANDONED_0 + lowest;
+					ret = (MonoW32HandleWaitRet)(MONO_W32HANDLE_WAIT_RET_ABANDONED_0 + lowest);
 					break;
 				}
 			}

--- a/mono/utils/checked-build.h
+++ b/mono/utils/checked-build.h
@@ -25,6 +25,8 @@ typedef enum {
 	MONO_CHECK_MODE_UNKNOWN = 0x8
 } MonoCheckMode;
 
+G_ENUM_FUNCTIONS (MonoCheckMode)
+
 mono_bool mono_check_mode_enabled (MonoCheckMode query);
 
 // This is for metadata writes which we have chosen not to check at the current time.

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -153,8 +153,6 @@ enum {
 	ASYNC_SUSPEND_STATE_INDEX = 1,
 };
 
-typedef struct _MonoThreadInfoInterruptToken MonoThreadInfoInterruptToken;
-
 /*
  * These flags control how the rest of the runtime will see and interact with
  * a thread.
@@ -176,6 +174,10 @@ typedef enum {
 	 */
 	MONO_THREAD_INFO_FLAGS_NO_SAMPLE = 2,
 } MonoThreadInfoFlags;
+
+G_ENUM_FUNCTIONS (MonoThreadInfoFlags)
+
+typedef struct _MonoThreadInfoInterruptToken MonoThreadInfoInterruptToken;
 
 typedef struct _MonoThreadInfo {
 	MonoLinkedListSetNode node;
@@ -704,12 +706,11 @@ gboolean mono_thread_is_gc_unsafe_mode (void);
  * BLOCKING_SUSPEND_REQUESTED state, in which case they are preemptively
  * suspended.
  */
-typedef enum {
-	MONO_THREAD_SUSPEND_PHASE_INITIAL = 0,
-	MONO_THREAD_SUSPEND_PHASE_MOPUP = 1,
-	// number of phases
-	MONO_THREAD_SUSPEND_PHASE_COUNT = 2,
-} MonoThreadSuspendPhase;
+#define MONO_THREAD_SUSPEND_PHASE_INITIAL (0)
+#define MONO_THREAD_SUSPEND_PHASE_MOPUP (1)
+// number of phases
+#define MONO_THREAD_SUSPEND_PHASE_COUNT (2)
+typedef int MonoThreadSuspendPhase;
 
 typedef enum {
 	MONO_THREAD_BEGIN_SUSPEND_SKIP = 0,

--- a/mono/utils/os-event-unix.c
+++ b/mono/utils/os-event-unix.c
@@ -182,7 +182,7 @@ mono_os_event_wait_multiple (MonoOSEvent **events, gsize nevents, gboolean waita
 			signalled = (count > 0);
 
 		if (signalled) {
-			ret = MONO_OS_EVENT_WAIT_RET_SUCCESS_0 + lowest;
+			ret = (MonoOSEventWaitRet)(MONO_OS_EVENT_WAIT_RET_SUCCESS_0 + lowest);
 			goto done;
 		}
 

--- a/msvc/test_eglib.vcxproj
+++ b/msvc/test_eglib.vcxproj
@@ -170,7 +170,7 @@
     <ClCompile Include="..\mono\eglib\test\dir.c" />
     <ClCompile Include="..\mono\eglib\test\driver.c" />
     <ClCompile Include="..\mono\eglib\test\endian.c" />
-    <ClCompile Include="..\mono\eglib\test\enum.cpp">
+    <ClCompile Include="..\mono\eglib\test\enum.cpp" />
     <ClCompile Include="..\mono\eglib\test\fake.c" />
     <ClCompile Include="..\mono\eglib\test\file.c" />
     <ClCompile Include="getopt.c" />

--- a/msvc/test_eglib.vcxproj
+++ b/msvc/test_eglib.vcxproj
@@ -170,6 +170,7 @@
     <ClCompile Include="..\mono\eglib\test\dir.c" />
     <ClCompile Include="..\mono\eglib\test\driver.c" />
     <ClCompile Include="..\mono\eglib\test\endian.c" />
+    <ClCompile Include="..\mono\eglib\test\enum.cpp">
     <ClCompile Include="..\mono\eglib\test\fake.c" />
     <ClCompile Include="..\mono\eglib\test\file.c" />
     <ClCompile Include="getopt.c" />

--- a/msvc/test_eglib.vcxproj.filters
+++ b/msvc/test_eglib.vcxproj.filters
@@ -13,6 +13,9 @@
     <ClCompile Include="..\mono\eglib\test\endian.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\mono\eglib\test\enum.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\mono\eglib\test\fake.c">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
There are at least three or so approaches to this.

1. Sprinkle around casts.
2. Overload operators.
2a. Bit-only (| & ^ |= &= ^=)   This is this PR and seemingly the consensus.
2b.  Also math (+ - ++ -- == !=)
3. typedef to int instead (https://github.com/mono/mono/pull/10231)

They all have tradeoffs.

1. Casts: The most line damage. Not huge, but the most.

2. Overloads: New idiom to some but an old idiom. Supported in this way by windows.h even.
  This is the most "C++y solution".

3. int: Highest level of source compat and semantic compat. Least line damage (just
change the declarations). Least debuggable and least typesafe.

In terms of semantic compat, even in C the guarantees aren't particularly strong.
Some enums will be int, some unsigned, depending on the values and the compiler.
Perhaps even other types, but I doubt it.

I observe C++ compilers don't tend toward unsigned the same way, so switching
to C++ will on some platforms lose unsignedness. Given we didn't have it portably
anyway, should be ok.

A typesafe enum has the properties that enum A cannot be silently assigned to enum B (ok,
there might be a warning), or from an integer.

A typesafe enum, bitfield or otherwise, can/will be shown symbolically by a debugger.
 (lldb does not handle bitfields, only strict enums)

A C enum might be debuggable, w/o typesafety.

A C enum can be freely mixed with other enums and integers.

A C++ enum is more restricted.

Using typedef int, is a maybe surprising option, but does provide the closest meaning to C enum.

Per guidance, this PR also changes one enum to #defines + int.
It might be reasonable to do similar for others.
It might be reasonable to provide more operators (see for example https://github.com/mono/mono/pull/10027/commits/648ed594c16f77954e16fed9ecfeddfdd6e49bcb#diff-b8c6c2ba344450884373fb00f33685adR245).