### PR TITLE
Replaced because mkbundle generates failure since "error"

### DIFF
--- a/mcs/tools/mkbundle/template_common.inc
+++ b/mcs/tools/mkbundle/template_common.inc
@@ -54,7 +54,7 @@ init_default_mono_api_struct ()
 	mono_api.mono_register_bundled_assemblies = mono_register_bundled_assemblies;
 	mono_api.mono_register_config_for_assembly = mono_register_config_for_assembly;
 	mono_api.mono_jit_set_aot_mode = mono_jit_set_aot_mode;
-	mono_api.mono_aot_register_module = mono_aot_register_module;
+	mono_api.mono_aot_register_module = mono_jit_set_aot_mode;
 	mono_api.mono_config_parse_memory = mono_config_parse_memory;
 	mono_api.mono_register_machine_config = mono_register_machine_config;
 #endif // USE_DEFAULT_MONO_API_STRUCT


### PR DESCRIPTION
mono_api.mono_aot_register_module = mono_jit_set_aot_mode is correct because mkbundle generates successfully

Thanks! I have replaced and mkbundle generates successfully.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->

Result: It looks like successful generation of executable:
```
mkbundle --deps --static -L /usr/lib/mono/4.5 ExampleGame.exe -o ExampleGtk3-MonoGame_Linux -v -z --keeptemp
OS is: Linux
Sources: 1 Auto-dependencies: True
Attempting to load assembly: ExampleGame.exe
Assembly ExampleGame.exe loaded successfully.
Attempting to load assembly from: ./I18N.West.dll
Attempting to load assembly from: /usr/lib/mono/4.5/I18N.West.dll
Attempting to load assembly from: ./I18N.dll
Attempting to load assembly from: /usr/lib/mono/4.5/I18N.dll
Attempting to load assembly from: ./mscorlib
Attempting to load assembly from: /usr/lib/mono/4.5/mscorlib
Attempting to load assembly from: ./gtk-sharp
Attempting to load assembly from: ./glib-sharp
Attempting to load assembly from: ./mscorlib
Attempting to load assembly from: /usr/lib/mono/4.5/mscorlib
Attempting to load assembly from: ./System.Core
Attempting to load assembly from: /usr/lib/mono/4.5/System.Core
Attempting to load assembly from: ./mscorlib
Attempting to load assembly from: /usr/lib/mono/4.5/mscorlib
Attempting to load assembly from: ./System
Attempting to load assembly from: /usr/lib/mono/4.5/System
Attempting to load assembly from: ./mscorlib
Attempting to load assembly from: /usr/lib/mono/4.5/mscorlib
Attempting to load assembly from: ./Mono.Security
Attempting to load assembly from: /usr/lib/mono/4.5/Mono.Security
Attempting to load assembly from: ./mscorlib
Attempting to load assembly from: /usr/lib/mono/4.5/mscorlib
Attempting to load assembly from: ./System
Attempting to load assembly from: /usr/lib/mono/4.5/System
Attempting to load assembly from: ./System.Configuration
Attempting to load assembly from: /usr/lib/mono/4.5/System.Configuration
Attempting to load assembly from: ./mscorlib
Attempting to load assembly from: /usr/lib/mono/4.5/mscorlib
Attempting to load assembly from: ./System.Xml
Attempting to load assembly from: /usr/lib/mono/4.5/System.Xml
Attempting to load assembly from: ./mscorlib
Attempting to load assembly from: /usr/lib/mono/4.5/mscorlib
Attempting to load assembly from: ./System.Configuration
Attempting to load assembly from: /usr/lib/mono/4.5/System.Configuration
Attempting to load assembly from: ./System
Attempting to load assembly from: /usr/lib/mono/4.5/System
Attempting to load assembly from: ./System
Attempting to load assembly from: /usr/lib/mono/4.5/System
Attempting to load assembly from: ./System.Security
Attempting to load assembly from: /usr/lib/mono/4.5/System.Security
Attempting to load assembly from: ./mscorlib
Attempting to load assembly from: /usr/lib/mono/4.5/mscorlib
Attempting to load assembly from: ./System
Attempting to load assembly from: /usr/lib/mono/4.5/System
Attempting to load assembly from: ./System.Core
Attempting to load assembly from: /usr/lib/mono/4.5/System.Core
Attempting to load assembly from: ./System.Xml
Attempting to load assembly from: /usr/lib/mono/4.5/System.Xml
Attempting to load assembly from: ./System.Numerics
Attempting to load assembly from: /usr/lib/mono/4.5/System.Numerics
Attempting to load assembly from: ./mscorlib
Attempting to load assembly from: /usr/lib/mono/4.5/mscorlib
Attempting to load assembly from: ./System.Xml
Attempting to load assembly from: /usr/lib/mono/4.5/System.Xml
Attempting to load assembly from: ./System.Core
Attempting to load assembly from: /usr/lib/mono/4.5/System.Core
Attempting to load assembly from: ./mscorlib
Attempting to load assembly from: /usr/lib/mono/4.5/mscorlib
Attempting to load assembly from: ./gio-sharp
Attempting to load assembly from: ./glib-sharp
Attempting to load assembly from: ./mscorlib
Attempting to load assembly from: /usr/lib/mono/4.5/mscorlib
Attempting to load assembly from: ./System
Attempting to load assembly from: /usr/lib/mono/4.5/System
Attempting to load assembly from: ./gdk-sharp
Attempting to load assembly from: ./mscorlib
Attempting to load assembly from: /usr/lib/mono/4.5/mscorlib
Attempting to load assembly from: ./glib-sharp
Attempting to load assembly from: ./gio-sharp
Attempting to load assembly from: ./cairo-sharp
Attempting to load assembly from: ./mscorlib
Attempting to load assembly from: /usr/lib/mono/4.5/mscorlib
Attempting to load assembly from: ./pango-sharp
Attempting to load assembly from: ./mscorlib
Attempting to load assembly from: /usr/lib/mono/4.5/mscorlib
Attempting to load assembly from: ./glib-sharp
Attempting to load assembly from: ./cairo-sharp
Attempting to load assembly from: ./atk-sharp
Attempting to load assembly from: ./glib-sharp
Attempting to load assembly from: ./mscorlib
Attempting to load assembly from: /usr/lib/mono/4.5/mscorlib
Attempting to load assembly from: ./cairo-sharp
Attempting to load assembly from: ./pango-sharp
Attempting to load assembly from: ./MonoGame.Framework.Gtk3
Attempting to load assembly from: ./mscorlib
Attempting to load assembly from: /usr/lib/mono/4.5/mscorlib
Attempting to load assembly from: ./MonoGame.Framework
Attempting to load assembly from: ./mscorlib
Attempting to load assembly from: /usr/lib/mono/4.5/mscorlib
Attempting to load assembly from: ./System
Attempting to load assembly from: /usr/lib/mono/4.5/System
Attempting to load assembly from: ./System.Core
Attempting to load assembly from: /usr/lib/mono/4.5/System.Core
Attempting to load assembly from: ./System.Runtime.Serialization
Attempting to load assembly from: /usr/lib/mono/4.5/System.Runtime.Serialization
Attempting to load assembly from: ./mscorlib
Attempting to load assembly from: /usr/lib/mono/4.5/mscorlib
Attempting to load assembly from: ./System.Xml
Attempting to load assembly from: /usr/lib/mono/4.5/System.Xml
Attempting to load assembly from: ./System.ServiceModel.Internals
Attempting to load assembly from: /usr/lib/mono/4.5/System.ServiceModel.Internals
Attempting to load assembly from: ./mscorlib
Attempting to load assembly from: /usr/lib/mono/4.5/mscorlib
Attempting to load assembly from: ./System
Attempting to load assembly from: /usr/lib/mono/4.5/System
Attempting to load assembly from: ./System.Xml
Attempting to load assembly from: /usr/lib/mono/4.5/System.Xml
Attempting to load assembly from: ./System
Attempting to load assembly from: /usr/lib/mono/4.5/System
Attempting to load assembly from: ./System.Configuration
Attempting to load assembly from: /usr/lib/mono/4.5/System.Configuration
Attempting to load assembly from: ./System.Core
Attempting to load assembly from: /usr/lib/mono/4.5/System.Core
Attempting to load assembly from: ./gdk-sharp
Attempting to load assembly from: ./System.Drawing
Attempting to load assembly from: /usr/lib/mono/4.5/System.Drawing
Attempting to load assembly from: ./mscorlib
Attempting to load assembly from: /usr/lib/mono/4.5/mscorlib
Attempting to load assembly from: ./System
Attempting to load assembly from: /usr/lib/mono/4.5/System
Attempting to load assembly from: ./System
Attempting to load assembly from: /usr/lib/mono/4.5/System
Attempting to load assembly from: ./gtk-sharp
Attempting to load assembly from: ./cairo-sharp
Attempting to load assembly from: ./glib-sharp
Attempting to load assembly from: ./MonoGame.Framework
Attempting to load assembly from: ./gdk-sharp
Attempting to load assembly from: ./cairo-sharp
Attempting to load assembly from: ./mscorlib
Attempting to load assembly from: /usr/lib/mono/4.5/mscorlib
Attempting to load assembly from: ./I18N
Attempting to load assembly from: /usr/lib/mono/4.5/I18N
Attempting to load assembly from: ./mscorlib
Attempting to load assembly from: /usr/lib/mono/4.5/mscorlib
   embedding: /home/sourceskzboxer/Downloads/MonoGame.Framework.Gtk3-master/ExampleGame/bin/Debug/ExampleGame.exe
   compression ratio: 11.33%
 config from: /home/sourceskzboxer/Downloads/MonoGame.Framework.Gtk3-master/ExampleGame/bin/Debug/ExampleGame.exe.config
   embedding: /usr/lib/mono/4.5/mscorlib.dll
   compression ratio: 34.10%
   embedding: /home/sourceskzboxer/Downloads/MonoGame.Framework.Gtk3-master/ExampleGame/bin/Debug/gtk-sharp.dll
   compression ratio: 27.62%
 config from: /home/sourceskzboxer/Downloads/MonoGame.Framework.Gtk3-master/ExampleGame/bin/Debug/gtk-sharp.dll.config
   embedding: /home/sourceskzboxer/Downloads/MonoGame.Framework.Gtk3-master/ExampleGame/bin/Debug/glib-sharp.dll
   compression ratio: 40.08%
 config from: /home/sourceskzboxer/Downloads/MonoGame.Framework.Gtk3-master/ExampleGame/bin/Debug/glib-sharp.dll.config
   embedding: /usr/lib/mono/4.5/System.Core.dll
   compression ratio: 34.13%
   embedding: /usr/lib/mono/4.5/System.dll
   compression ratio: 38.26%
   embedding: /usr/lib/mono/4.5/Mono.Security.dll
   compression ratio: 41.24%
   embedding: /usr/lib/mono/4.5/System.Configuration.dll
   compression ratio: 40.60%
   embedding: /usr/lib/mono/4.5/System.Xml.dll
   compression ratio: 33.47%
   embedding: /usr/lib/mono/4.5/System.Security.dll
   compression ratio: 40.29%
   embedding: /usr/lib/mono/4.5/System.Numerics.dll
   compression ratio: 36.18%
   embedding: /home/sourceskzboxer/Downloads/MonoGame.Framework.Gtk3-master/ExampleGame/bin/Debug/gio-sharp.dll
   compression ratio: 27.72%
 config from: /home/sourceskzboxer/Downloads/MonoGame.Framework.Gtk3-master/ExampleGame/bin/Debug/gio-sharp.dll.config
   embedding: /home/sourceskzboxer/Downloads/MonoGame.Framework.Gtk3-master/ExampleGame/bin/Debug/gdk-sharp.dll
   compression ratio: 31.33%
 config from: /home/sourceskzboxer/Downloads/MonoGame.Framework.Gtk3-master/ExampleGame/bin/Debug/gdk-sharp.dll.config
   embedding: /home/sourceskzboxer/Downloads/MonoGame.Framework.Gtk3-master/ExampleGame/bin/Debug/cairo-sharp.dll
   compression ratio: 38.63%
   embedding: /home/sourceskzboxer/Downloads/MonoGame.Framework.Gtk3-master/ExampleGame/bin/Debug/pango-sharp.dll
   compression ratio: 35.88%
 config from: /home/sourceskzboxer/Downloads/MonoGame.Framework.Gtk3-master/ExampleGame/bin/Debug/pango-sharp.dll.config
   embedding: /home/sourceskzboxer/Downloads/MonoGame.Framework.Gtk3-master/ExampleGame/bin/Debug/atk-sharp.dll
   compression ratio: 30.80%
 config from: /home/sourceskzboxer/Downloads/MonoGame.Framework.Gtk3-master/ExampleGame/bin/Debug/atk-sharp.dll.config
   embedding: /home/sourceskzboxer/Downloads/MonoGame.Framework.Gtk3-master/ExampleGame/bin/Debug/MonoGame.Framework.Gtk3.dll
   compression ratio: 47.38%
   embedding: /home/sourceskzboxer/Downloads/MonoGame.Framework.Gtk3-master/ExampleGame/bin/Debug/MonoGame.Framework.dll
   compression ratio: 26.13%
 config from: /home/sourceskzboxer/Downloads/MonoGame.Framework.Gtk3-master/ExampleGame/bin/Debug/MonoGame.Framework.dll.config
   embedding: /usr/lib/mono/4.5/System.Runtime.Serialization.dll
   compression ratio: 32.97%
   embedding: /usr/lib/mono/4.5/System.ServiceModel.Internals.dll
   compression ratio: 39.08%
   embedding: /usr/lib/mono/4.5/System.Drawing.dll
   compression ratio: 36.98%
   embedding: /usr/lib/mono/4.5/I18N.West.dll
   compression ratio: 29.85%
   embedding: /usr/lib/mono/4.5/I18N.dll
   compression ratio: 31.50%
AS = as (default)
[execute cmd]: as -o temp.o temp.s 
Compiling:
CC = cc (default)
[execute cmd]: cc -o 'ExampleGtk3-MonoGame_Linux' -Wall  `pkg-config --cflags mono-2`  temp.c -lz `pkg-config --libs-only-L mono-2` -Wl,-Bstatic -lmono-2.0 -Wl,-Bdynamic    `pkg-config --libs-only-l mono-2 | sed -e "s/\-lmono-2.0 //"` temp.o -g 
temp.c: In function ‘init_default_mono_api_struct’:
temp.c:189:33: warning: assignment from incompatible pointer type [-Wincompatible-pointer-types]
  mono_api.mono_jit_set_aot_mode = mono_jit_set_aot_mode;
                                 ^
temp.c:190:36: warning: assignment from incompatible pointer type [-Wincompatible-pointer-types]
  mono_api.mono_aot_register_module = mono_jit_set_aot_mode;
                                    ^
temp.c: In function ‘install_dll_config_files’:
temp.c:206:65: warning: pointer targets in passing argument 2 of ‘mono_api.mono_register_config_for_assembly’ differ in signedness [-Wpointer-sign]
  mono_api.mono_register_config_for_assembly ("ExampleGame.exe", assembly_config_ExampleGame_exe);
                                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
temp.c:206:65: note: expected ‘const char *’ but argument is of type ‘const unsigned char *’
temp.c:208:63: warning: pointer targets in passing argument 2 of ‘mono_api.mono_register_config_for_assembly’ differ in signedness [-Wpointer-sign]
  mono_api.mono_register_config_for_assembly ("gtk-sharp.dll", assembly_config_gtk_sharp_dll);
                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
temp.c:208:63: note: expected ‘const char *’ but argument is of type ‘const unsigned char *’
temp.c:210:64: warning: pointer targets in passing argument 2 of ‘mono_api.mono_register_config_for_assembly’ differ in signedness [-Wpointer-sign]
  mono_api.mono_register_config_for_assembly ("glib-sharp.dll", assembly_config_glib_sharp_dll);
                                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
temp.c:210:64: note: expected ‘const char *’ but argument is of type ‘const unsigned char *’
temp.c:212:63: warning: pointer targets in passing argument 2 of ‘mono_api.mono_register_config_for_assembly’ differ in signedness [-Wpointer-sign]
  mono_api.mono_register_config_for_assembly ("gio-sharp.dll", assembly_config_gio_sharp_dll);
                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
temp.c:212:63: note: expected ‘const char *’ but argument is of type ‘const unsigned char *’
temp.c:214:63: warning: pointer targets in passing argument 2 of ‘mono_api.mono_register_config_for_assembly’ differ in signedness [-Wpointer-sign]
  mono_api.mono_register_config_for_assembly ("gdk-sharp.dll", assembly_config_gdk_sharp_dll);
                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
temp.c:214:63: note: expected ‘const char *’ but argument is of type ‘const unsigned char *’
temp.c:216:65: warning: pointer targets in passing argument 2 of ‘mono_api.mono_register_config_for_assembly’ differ in signedness [-Wpointer-sign]
  mono_api.mono_register_config_for_assembly ("pango-sharp.dll", assembly_config_pango_sharp_dll);
                                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
temp.c:216:65: note: expected ‘const char *’ but argument is of type ‘const unsigned char *’
temp.c:218:63: warning: pointer targets in passing argument 2 of ‘mono_api.mono_register_config_for_assembly’ differ in signedness [-Wpointer-sign]
  mono_api.mono_register_config_for_assembly ("atk-sharp.dll", assembly_config_atk_sharp_dll);
                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
temp.c:218:63: note: expected ‘const char *’ but argument is of type ‘const unsigned char *’
temp.c:220:72: warning: pointer targets in passing argument 2 of ‘mono_api.mono_register_config_for_assembly’ differ in signedness [-Wpointer-sign]
 no_api.mono_register_config_for_assembly ("MonoGame.Framework.dll", assembly_config_MonoGame_Framework_dll);
                                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
temp.c:220:72: note: expected ‘const char *’ but argument is of type ‘const unsigned char *’
At top level:
temp.c:196:13: warning: ‘install_aot_modules’ defined but not used [-Wunused-function]
 static void install_aot_modules (void) {
             ^~~~~~~~~~~~~~~~~~~
Done
Generated ExampleGtk3-MonoGame_Linux
```
Yay I can fix it. Because it means "mono_jit_set_aot_mode"