### PR TITLE
[runtime] Add standardized disk dumper for mono crashes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # There is no ordering of corlib versions, no old or new,
 # the runtime expects an exact match.
 #
-MONO_CORLIB_VERSION=CBC2E3CC-A1C7-4BF9-B87C-F1DDF25E5E90
+MONO_CORLIB_VERSION=BEAF66F4-BA36-44C5-974E-83C6F627DF8C
 
 #
 # Put a quoted #define in config.h.

--- a/mcs/class/corlib/Mono/Runtime.cs
+++ b/mcs/class/corlib/Mono/Runtime.cs
@@ -105,6 +105,21 @@ namespace Mono {
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		static extern void SendMicrosoftTelemetry_internal (IntPtr payload, ulong portable_hash, ulong unportable_hash);
 
+		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		static extern void WriteStateToDisk_internal (IntPtr payload, ulong portable_hash, ulong unportable_hash);
+
+		static void
+		WriteStateToDisk (Exception exc)
+		{
+			ulong portable_hash;
+			ulong unportable_hash;
+			string payload_str = ExceptionToState_internal (exc, out portable_hash, out unportable_hash);
+			using (var payload_chars = RuntimeMarshal.MarshalString (payload_str))
+			{
+				WriteStateToDisk_internal (payload_chars.Value, portable_hash, unportable_hash);
+			}
+		}
+
 		static void SendMicrosoftTelemetry (string payload_str, ulong portable_hash, ulong unportable_hash)
 		{
 			if (RuntimeInformation.IsOSPlatform (OSPlatform.OSX)) {

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -96,6 +96,7 @@ HANDLES(ICALL(RUNTIME_3, "ExceptionToState_internal", ves_icall_Mono_Runtime_Exc
 HANDLES(ICALL(RUNTIME_4, "GetDisplayName", ves_icall_Mono_Runtime_GetDisplayName))
 HANDLES(ICALL(RUNTIME_12, "GetNativeStackTrace", ves_icall_Mono_Runtime_GetNativeStackTrace))
 HANDLES(ICALL(RUNTIME_13, "SendMicrosoftTelemetry_internal", ves_icall_Mono_Runtime_SendMicrosoftTelemetry))
+HANDLES(ICALL(RUNTIME_14, "WriteStateToFile_internal", ves_icall_Mono_Runtime_DumpTelemetry))
 
 ICALL_TYPE(RTCLASS, "Mono.RuntimeClassHandle", RTCLASS_1)
 HANDLES(ICALL(RTCLASS_1, "GetTypeFromClass", ves_icall_Mono_RuntimeClassHandle_GetTypeFromClass))

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5865,6 +5865,20 @@ ves_icall_Mono_Runtime_SendMicrosoftTelemetry (char *payload, guint64 portable_h
 #endif
 }
 
+ICALL_EXPORT void
+ves_icall_Mono_Runtime_DumpTelemetry (char *payload, guint64 portable_hash, guint64 unportable_hash, MonoError *error)
+{
+#ifndef DISABLE_CRASH_REPORTING
+	MonoStackHash hashes;
+	memset (&hashes, 0, sizeof (MonoStackHash));
+	hashes.offset_free_hash = portable_hash;
+	hashes.offset_rich_hash = unportable_hash;
+	mono_crash_dump (payload, &hashes);
+#else
+	return;
+#endif
+}
+
 ICALL_EXPORT MonoBoolean
 ves_icall_System_Reflection_AssemblyName_ParseAssemblyName (const char *name, MonoAssemblyName *aname, MonoBoolean *is_version_defined_arg, MonoBoolean *is_token_defined_arg)
 {

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -547,8 +547,8 @@ typedef struct {
 } MonoFrameSummary;
 
 typedef struct {
-	intptr_t offset_free_hash;
-	intptr_t offset_rich_hash;
+	guint64 offset_free_hash;
+	guint64 offset_rich_hash;
 } MonoStackHash;
 
 typedef struct {

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1336,14 +1336,14 @@ mono_get_portable_ip (intptr_t in_ip, intptr_t *out_ip, char *out_name)
 	return TRUE;
 }
 
-static intptr_t
-summarize_offset_free_hash (intptr_t accum, MonoFrameSummary *frame)
+static guint64
+summarize_offset_free_hash (guint64 accum, MonoFrameSummary *frame)
 {
 	if (!frame->is_managed)
 		return accum;
 
 	// See: mono_ptrarray_hash
-	intptr_t hash_accum = accum;
+	guint64 hash_accum = accum;
 
 	// The assembly and the method token, no offsets
 	hash_accum += mono_metadata_str_hash (frame->str_descr);
@@ -1352,11 +1352,11 @@ summarize_offset_free_hash (intptr_t accum, MonoFrameSummary *frame)
 	return hash_accum;
 }
 
-static intptr_t
-summarize_offset_rich_hash (intptr_t accum, MonoFrameSummary *frame)
+static guint64
+summarize_offset_rich_hash (guint64 accum, MonoFrameSummary *frame)
 {
 	// See: mono_ptrarray_hash
-	intptr_t hash_accum = accum;
+	guint64 hash_accum = accum;
 
 	if (!frame->is_managed) {
 		hash_accum += frame->unmanaged_data.ip;

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -517,13 +517,12 @@ mono_crash_dump (const char *jsonFile, MonoStackHash *hashes)
 {
 	size_t size = strlen (jsonFile);
 
-	pid_t pid = getpid ();
 	gboolean success = FALSE;
 
 	// Save up to 100 dump files for a given stacktrace hash
 	for (int increment = 0; increment < 100; increment++) {
 		FILE* fp;
-		char *name = g_strdup_printf ("mono_crash.%d.%d.json", hashes->offset_free_hash, increment);
+		char *name = g_strdup_printf ("mono_crash.%" PRIx64 " .%d.json", hashes->offset_free_hash, increment);
 
 		if ((fp = fopen (name, "ab"))) {
 			if (ftell (fp) == 0) {


### PR DESCRIPTION
In order to make it easier for nunit lite to make managed crashes and native crashes be written to disk with the same logic, I thought I'd expose the helper. 

The consumer of this is in: https://github.com/mono/NUnitLite/pull/13