### PR TITLE
[cxx] Fix typesafe-linkage problem due to varying MonoGCDescriptor.

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -707,6 +707,12 @@ mono_gc_alloc_fixed (size_t size, void *descr, MonoGCRootSource source, void *ke
 	return (MonoObject*)start;
 }
 
+MonoObject*
+mono_gc_alloc_fixed_no_descriptor (size_t size, MonoGCRootSource source, void *key, const char *msg)
+{
+	return mono_gc_alloc_fixed (size, 0, source, key, msg);
+}
+
 void
 mono_gc_free_fixed (void* addr)
 {

--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -161,6 +161,12 @@ gboolean mono_gc_user_markers_supported (void);
  * must not be stored in the returned memory)
  */
 MonoObject* mono_gc_alloc_fixed      (size_t size, MonoGCDescriptor descr, MonoGCRootSource source, void *key, const char *msg);
+
+// C++ callers outside of metadata (mini/tasklets.c) must use mono_gc_alloc_fixed_no_descriptor
+// instead of mono_gc_alloc_fixed, or else compile twice -- boehm and sgen.
+MonoObject*
+mono_gc_alloc_fixed_no_descriptor (size_t size, MonoGCRootSource source, void *key, const char *msg);
+
 void  mono_gc_free_fixed             (void* addr);
 
 /* make sure the gchandle was allocated for an object in domain */

--- a/mono/metadata/null-gc.c
+++ b/mono/metadata/null-gc.c
@@ -170,6 +170,12 @@ mono_gc_alloc_fixed (size_t size, void *descr, MonoGCRootSource source, void *ke
 	return (MonoObject*)g_malloc0 (size);
 }
 
+MonoObject*
+mono_gc_alloc_fixed_no_descriptor (size_t size, MonoGCRootSource source, void *key, const char *msg)
+{
+	return mono_gc_alloc_fixed (size, NULL, source, key, msg);
+}
+
 void
 mono_gc_free_fixed (void* addr)
 {

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -953,6 +953,12 @@ mono_gc_alloc_fixed (size_t size, MonoGCDescriptor descr, MonoGCRootSource sourc
 	return (MonoObject*)res;
 }
 
+MonoObject*
+mono_gc_alloc_fixed_no_descriptor (size_t size, MonoGCRootSource source, void *key, const char *msg)
+{
+	return mono_gc_alloc_fixed (size, NULL, source, key, msg);
+}
+
 /**
  * mono_gc_free_fixed:
  */

--- a/mono/mini/tasklets.c
+++ b/mono/mini/tasklets.c
@@ -113,7 +113,7 @@ continuation_store (MonoContinuation *cont, int state, MonoException **e)
 			mono_gc_free_fixed (cont->saved_stack);
 		cont->stack_used_size = num_bytes;
 		cont->stack_alloc_size = num_bytes * 1.1;
-		cont->saved_stack = mono_gc_alloc_fixed (cont->stack_alloc_size, NULL, MONO_ROOT_SOURCE_THREADING, NULL, "Tasklet Saved Stack");
+		cont->saved_stack = mono_gc_alloc_fixed_no_descriptor (cont->stack_alloc_size, MONO_ROOT_SOURCE_THREADING, NULL, "Tasklet Saved Stack");
 		tasklets_unlock ();
 	}
 	memcpy (cont->saved_stack, cont->return_sp, num_bytes);


### PR DESCRIPTION
Allow mono_gc_alloc_fixed subset outside of metadata (mini/tasklets.c), without breaking due to C++ typesafe linkage.
    
This enables avoiding externC workaround here:
https://github.com/mono/mono/pull/10160/files#diff-bd3a3d5c2bfd6af46373b3844de9c1d0R163