### PR TITLE
[cxx] Slightly rework gc-internals.h THREAD_INFO_TYPE parameterization

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -2057,6 +2057,32 @@ mono_gc_ephemeron_array_add (MonoObject *obj)
 	return TRUE;
 }
 
+#ifdef __cplusplus
+
+// Provide overloads for clients compiled for sgen.
+
+struct _SgenThreadInfo;
+
+gpointer
+mono_gc_thread_attach (struct _SgenThreadInfo *info)
+{
+	return mono_gc_thread_attach ((MonoThreadInfo*)info);
+}
+
+void
+mono_gc_thread_detach_with_lock (struct _SgenThreadInfo *info)
+{
+	return mono_gc_thread_detach_with_lock ((MonoThreadInfo*)info);
+}
+
+gboolean
+mono_gc_thread_in_critical_region (struct _SgenThreadInfo *info)
+{
+	return mono_gc_thread_in_critical_region ((MonoThreadInfo*)info);
+}
+
+#endif // __cplusplus
+
 #else
 
 MONO_EMPTY_SOURCE_FILE (boehm_gc);

--- a/mono/metadata/null-gc.c
+++ b/mono/metadata/null-gc.c
@@ -589,6 +589,32 @@ mono_gc_ephemeron_array_add (MonoObject *obj)
 	return TRUE;
 }
 
+#ifdef __cplusplus
+
+// Provide overloads for clients compiled for sgen.
+
+struct _SgenThreadInfo;
+
+gpointer
+mono_gc_thread_attach (struct _SgenThreadInfo *info)
+{
+	return mono_gc_thread_attach ((MonoThreadInfo*)info);
+}
+
+void
+mono_gc_thread_detach_with_lock (struct _SgenThreadInfo *info)
+{
+	return mono_gc_thread_detach_with_lock ((MonoThreadInfo*)info);
+}
+
+gboolean
+mono_gc_thread_in_critical_region (struct _SgenThreadInfo *info)
+{
+	return mono_gc_thread_in_critical_region ((MonoThreadInfo*)info);
+}
+
+#endif // __cplusplus
+
 #else
 
 MONO_EMPTY_SOURCE_FILE (null_gc);

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -2987,4 +2987,28 @@ sgen_client_schedule_background_job (void (*cb)(void))
 
 #endif
 
+#ifdef __cplusplus
+
+// Provide overloads for clients compiled for boehm.
+
+gpointer
+mono_gc_thread_attach (MonoThreadInfo *info)
+{
+	return mono_gc_thread_attach ((SgenThreadInfo*)info);
+}
+
+void
+mono_gc_thread_detach_with_lock (MonoThreadInfo *info)
+{
+	return mono_gc_thread_detach_with_lock ((SgenThreadInfo*)info);
+}
+
+gboolean
+mono_gc_thread_in_critical_region (MonoThreadInfo *info)
+{
+	return mono_gc_thread_in_critical_region ((SgenThreadInfo*)info);
+}
+
+#endif // __cplusplus
+
 #endif


### PR DESCRIPTION
to not break w/ C++ typesafe linkage. All three GC implementations provide both overloads of three functions. This avoids the need for externC workaround here:
 https://github.com/mono/mono/pull/10160/files#diff-bd3a3d5c2bfd6af46373b3844de9c1d0R442
