### PR TITLE
[2018-04] [sdb] Disable an assert to avoid breaking debugging.

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -4734,7 +4734,6 @@ ss_update (SingleStepReq *req, MonoJitInfo *ji, SeqPoint *sp, DebuggerTlsData *t
 			for (int i=0; i < tls->frame_count; i++)
 				DEBUG_PRINTF (1, "\t [%p] Frame (%d / %d): %s\n", (gpointer)(gsize)mono_native_thread_id_get (), i, tls->frame_count, mono_method_full_name (tls->frames [i]->method, TRUE));
 		}
-		g_assert (method_in_stack);
 
 		tls->context.valid = FALSE;
 		tls->async_state.valid = FALSE;


### PR DESCRIPTION
Backport of https://github.com/mono/mono/pull/9981.