### PR TITLE
Show dot-folders in folder browser

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/FolderBrowserDialog.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/FolderBrowserDialog.cs
@@ -615,9 +615,6 @@ namespace System.Windows.Forms {
 				ArrayList folders = vfs.GetFoldersOnly ();
 				
 				foreach (FSEntry fsentry in folders) {
-					if (fsentry.Name.StartsWith ("."))
-						continue;
-					
 					FBTreeNode child = new FBTreeNode (fsentry.Name);
 					child.Tag = fsentry.FullName;
 					child.RealPath = fsentry.RealName == null ? fsentry.FullName : fsentry.RealName;
@@ -627,10 +624,8 @@ namespace System.Windows.Forms {
 					ArrayList sub_folders = vfs.GetFoldersOnly ();
 					
 					foreach (FSEntry fsentry_sub in sub_folders) {
-						if (!fsentry_sub.Name.StartsWith (".")) {
-							child.Nodes.Add (new TreeNode (String.Empty));
-							break;
-						}
+						child.Nodes.Add (new TreeNode (String.Empty));
+						break;
 					}
 					
 					node.Nodes.Add (child);


### PR DESCRIPTION
## Problem

Mono's `FolderBrowserDialog` always hides folders with names that start with ".".

Some important folders have such names, for example `.local/share/Steam/SteamApps/common/`, or `.local/share/MyApp/`.

This behavior could be seen as a sensible default if there was a way for developers to control it, since these folders are traditionally treated as "hidden." However, there is no way to control this behavior; the check is hard-coded, and so some of the folders that exist on disk and may be important to display simply never appear. If an application needs to allow a user to choose a folder with a name that starts with ".", or a folder *inside* a folder with a name that starts with ".", alternatives to the standard `FolderBrowserDialog` class must be pursued, such as a text box for manually editing a path.

Showing hidden folders may be awkward in some use cases, but hiding them is much worse when they're needed.

## Changes

This filter is now removed. Folders that start with "." now appear in the folder browser.