### PR TITLE
[2018-08] [System]: `MonoTlsStream` is now `IDisposable` and cleans up on error.

### DIFF
--- a/mcs/class/System/Makefile
+++ b/mcs/class/System/Makefile
@@ -41,6 +41,8 @@ USE_XTEST_REMOTE_EXECUTOR = YES
 XTEST_LIB_REFS = System System.Core System.Net Facades/System.Threading.Tasks Facades/System.Runtime.InteropServices.RuntimeInformation System.Net.Http
 LIB_MCS_FLAGS = -d:COREFX -d:CONFIGURATION_2_0 -d:XML_DEP -d:SECURITY_DEP $(REFERENCE_SOURCES_FLAGS) -unsafe $(RESOURCE_FILES:%=-resource:%) -nowarn:436
 
+LIB_MCS_FLAGS += -d:MONO_WEB_DEBUG -d:MONO_TLS_DEBUG
+
 ifndef NO_MONO_SECURITY
 MONO_SECURITY := Mono.Security
 LIB_MCS_FLAGS += -d:MONO_SECURITY_ALIAS

--- a/mcs/class/System/Makefile
+++ b/mcs/class/System/Makefile
@@ -41,8 +41,6 @@ USE_XTEST_REMOTE_EXECUTOR = YES
 XTEST_LIB_REFS = System System.Core System.Net Facades/System.Threading.Tasks Facades/System.Runtime.InteropServices.RuntimeInformation System.Net.Http
 LIB_MCS_FLAGS = -d:COREFX -d:CONFIGURATION_2_0 -d:XML_DEP -d:SECURITY_DEP $(REFERENCE_SOURCES_FLAGS) -unsafe $(RESOURCE_FILES:%=-resource:%) -nowarn:436
 
-LIB_MCS_FLAGS += -d:MONO_WEB_DEBUG -d:MONO_TLS_DEBUG
-
 ifndef NO_MONO_SECURITY
 MONO_SECURITY := Mono.Security
 LIB_MCS_FLAGS += -d:MONO_SECURITY_ALIAS

--- a/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
+++ b/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
@@ -77,7 +77,7 @@ namespace Mono.Net.Security
 			Settings = settings;
 			Provider = provider;
 
-			readBuffer = new BufferOffsetSize2 (16834);
+			readBuffer = new BufferOffsetSize2 (16384);
 			writeBuffer = new BufferOffsetSize2 (16384);
 			operation = Operation.None;
 		}

--- a/mcs/class/System/Mono.Net.Security/MonoTlsStream.cs
+++ b/mcs/class/System/Mono.Net.Security/MonoTlsStream.cs
@@ -157,20 +157,12 @@ namespace Mono.Net.Security
 #endif
 		}
 
-		void Dispose (bool disposing)
+		public void Dispose ()
 		{
-			if (Interlocked.CompareExchange (ref disposed, 1, 0) != 0)
-				return;
-
 			if (sslStream != null) {
 				sslStream.Dispose ();
 				sslStream = null;
 			}
-		}
-
-		public void Dispose ()
-		{
-			Dispose (true);
 		}
 	}
 }

--- a/mcs/class/System/Mono.Net.Security/MonoTlsStream.cs
+++ b/mcs/class/System/Mono.Net.Security/MonoTlsStream.cs
@@ -73,7 +73,6 @@ namespace Mono.Net.Security
 #endif
 
 		WebExceptionStatus status;
-		int disposed;
 
 		internal WebExceptionStatus ExceptionStatus {
 			get { return status; }

--- a/mcs/class/System/Mono.Net.Security/MonoTlsStream.cs
+++ b/mcs/class/System/Mono.Net.Security/MonoTlsStream.cs
@@ -137,7 +137,7 @@ namespace Mono.Net.Security
 					request.ServicePoint.UpdateClientCertificate (sslStream.InternalLocalCertificate);
 				else {
 					request.ServicePoint.UpdateClientCertificate (null);
-					sslStream?.Dispose ();
+					sslStream.Dispose ();
 					sslStream = null;
 				}
 			}

--- a/mcs/class/System/System.Net/WebConnection.cs
+++ b/mcs/class/System/System.Net/WebConnection.cs
@@ -412,6 +412,13 @@ namespace System.Net
 					networkStream = null;
 				}
 
+				if (monoTlsStream != null) {
+					try {
+						monoTlsStream.Dispose ();
+					} catch { }
+					monoTlsStream = null;
+				}
+
 				if (socket != null) {
 					try {
 						socket.Dispose ();

--- a/mcs/class/System/System.Net/WebConnection.cs
+++ b/mcs/class/System/System.Net/WebConnection.cs
@@ -405,6 +405,7 @@ namespace System.Net
 		void CloseSocket ()
 		{
 			lock (this) {
+				Debug ($"WC CLOSE SOCKET: Cnc={ID} NS={networkStream} TLS={monoTlsStream}");
 				if (networkStream != null) {
 					try {
 						networkStream.Dispose ();

--- a/mcs/class/System/System.Net/WebReadStream.cs
+++ b/mcs/class/System/System.Net/WebReadStream.cs
@@ -41,7 +41,7 @@ namespace System.Net
 		}
 
 #if MONO_WEB_DEBUG
-		internal string ME => $"WRS({GetType ().Name}:Op={operation.ID})";
+		internal string ME => $"WRS({GetType ().Name}:Op={Operation.ID})";
 #else
 		internal string ME => null;
 #endif


### PR DESCRIPTION
Backport of #10254.

/cc @marek-safar