### PR TITLE
[exceptions] ftnptr_eh_callback test that stresses n2m transitions

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -7841,9 +7841,10 @@ mono_get_eh_callbacks (void)
 void
 mono_raise_exception (MonoException *ex) 
 {
-	MONO_ENTER_GC_UNSAFE;
+	/* raise_exception doesn't return, so the transition to GC Unsafe is unbalanced */
+	MONO_STACKDATA (stackdata);
+	mono_threads_enter_gc_unsafe_region_unbalanced_with_info (mono_thread_info_current (), &stackdata);
 	mono_raise_exception_deprecated (ex);
-	MONO_EXIT_GC_UNSAFE;
 }
 
 /*

--- a/mono/tests/install_eh_callback.cs
+++ b/mono/tests/install_eh_callback.cs
@@ -10,8 +10,15 @@ public class Tests {
 
 	[DllImport ("libtest")]
 	public static extern void mono_test_setjmp_and_call (VoidVoidDelegate del, out IntPtr handle);
+
+	[DllImport ("libtest")]
+	public static extern void mono_test_setup_ftnptr_eh_callback (VoidVoidDelegate del, VoidHandleHandleOutDelegate inside_eh_callback);
+
+	[DllImport ("libtest")]
+	public static extern void mono_test_cleanup_ftptr_eh_callback ();
 	
 	public delegate void VoidVoidDelegate ();
+	public delegate void VoidHandleHandleOutDelegate (uint handle, out int exception_handle);
 
 	public class SpecialExn : Exception {
 	}
@@ -35,7 +42,7 @@ public class Tests {
 		}
 
 		[MonoPInvokeCallback (typeof (VoidVoidDelegate))]
-		public static void M () {
+		public static void M1 () {
 			try {
 				callee (ref called);
 				throw new Exception ("unexpected return from callee");
@@ -44,13 +51,22 @@ public class Tests {
 				finally_called = true;
 			}
 		}
+
+		[MonoPInvokeCallback (typeof (VoidVoidDelegate))]
+		public static void M2 () {
+			try {
+				callee (ref called);
+				throw new Exception ("unexpected return from callee");
+			} catch (SomeOtherExn) {
+			}
+		}
 	}
 
 	public static int test_0_setjmp_exn_handler ()
 	{
 		IntPtr res;
 		Caller.Setup ();
-		VoidVoidDelegate f = new VoidVoidDelegate (Caller.M);
+		VoidVoidDelegate f = new VoidVoidDelegate (Caller.M1);
 			
 		try {
 			mono_test_setjmp_and_call (f, out res);
@@ -84,7 +100,71 @@ public class Tests {
 			return 6;
 		}
 	}
+
+	public class Caller2 {
+		public static bool rethrow_called;
+		public static bool exception_caught;
+		public static bool return_from_inner_managed_callback;
+
+		public static void Setup () {
+			rethrow_called = false;
+			exception_caught = false;
+			return_from_inner_managed_callback = false;
+		}
+
+		public static void RethrowException (uint original_exception) {
+			var e = (Exception) GCHandle.FromIntPtr ((IntPtr) original_exception).Target;
+			rethrow_called = true;
+			System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture (e).Throw ();
+		}
+
+		[MonoPInvokeCallback (typeof (VoidHandleHandleOutDelegate))]
+		public static void Del2 (uint original_exception, out int exception_handle) {
+			exception_handle = 0;
+			try {
+				RethrowException (original_exception);
+			} catch (Exception ex) {
+				var handle = GCHandle.Alloc (ex, GCHandleType.Normal);
+				exception_handle = GCHandle.ToIntPtr (handle).ToInt32 ();
+				exception_caught = true;
+			}
+			return_from_inner_managed_callback = true;
+		}
+	}
 		
+	public static int test_0_throw_and_raise_exception ()
+	{
+		Caller.Setup ();
+		Caller2.Setup ();
+		VoidVoidDelegate f = new VoidVoidDelegate (Caller.M2);
+		VoidHandleHandleOutDelegate del2 = new VoidHandleHandleOutDelegate (Caller2.Del2);
+		bool outer_managed_callback = false;
+		try {
+			mono_test_setup_ftnptr_eh_callback (f, del2);
+		} catch (Exception e) {
+			outer_managed_callback = true;
+		}
+
+		if (!outer_managed_callback) {
+			Console.Error.WriteLine ("outer managed callback did not throw exception");
+			return 1;
+		}
+		if (!Caller2.rethrow_called) {
+			Console.Error.WriteLine ("exception was not rethrown by eh callback");
+			return 2;
+		}
+		if (!Caller2.exception_caught) {
+			Console.Error.WriteLine ("rethrown exception was not caught");
+			return 3;
+		}
+		if (!Caller2.return_from_inner_managed_callback) {
+			Console.Error.WriteLine ("managed callback called from native eh callback did not return");
+			return 4;
+		}
+
+		mono_test_cleanup_ftptr_eh_callback ();
+		return 0;
+	}
 
 	static int Main ()
 	{


### PR DESCRIPTION
on Xamarin.iOS it happens that the ftnptr_eh_callback calls into managed
code, that is yet another native-to-managed transition.

This fails coop right now, see https://github.com/mono/mono/pull/10224#issuecomment-416646880
