### PR TITLE
[cxx] C++ does not have restrict.

### DIFF
--- a/mono/mini/mini-wasm.c
+++ b/mono/mini/mini-wasm.c
@@ -624,13 +624,13 @@ pthread_setschedparam(pthread_t thread, int policy, const struct sched_param *pa
 
 
 int
-pthread_attr_getstacksize (const pthread_attr_t *restrict attr, size_t *restrict stacksize)
+pthread_attr_getstacksize (const pthread_attr_t *attr, size_t *stacksize)
 {
 	return 65536; //wasm page size
 }
 
 int
-pthread_sigmask (int how, const sigset_t * restrict set, sigset_t * restrict oset)
+pthread_sigmask (int how, const sigset_t *set, sigset_t *oset)
 {
 	return 0;
 }


### PR DESCRIPTION
g++/clang++ do have `__restrict` and/or `__restrict__`.
On MacOSX, __restrict is preprocessed out of the headers for C++.
On Linux, __restrict is used and preserved for C++.
I didn't check others.

__restrict does not appear to be part of the function signature.
You cannot overload on it.
It is not in the mangled name.
If you declare one way and implement the other, there is no warning or error.

Therefore, remove restrict.

There are alternatives.
One could preserve it for C only.
One could preserve it for C and for Linux/C++.
One could preserve it based on autoconf, and check/assert autoconf results on Mac and Linux.

Perhaps as well we will autoconf or ifdef wasm away use of these functions?
 If we merely if them away, we still need them.