### PR TITLE
[cxx] Port support to C++. I wasn't going to go here, but it uses glib

### DIFF
--- a/support/Makefile.am
+++ b/support/Makefile.am
@@ -16,6 +16,8 @@ AM_CPPFLAGS =					\
 
 glib_libs = $(top_builddir)/mono/eglib/libeglib.la
 
+CFLAGS := $(filter-out @CXX_REMOVE_CFLAGS@, @CFLAGS@) @CXX_ADD_CFLAGS@
+
 # Source code which helps implement the ANSI C standards, and thus *should* be
 # portable to any platform having a C compiler.
 MPH_C_SOURCE =					\

--- a/support/adler32.c
+++ b/support/adler32.c
@@ -7,6 +7,10 @@
 
 #include "zutil.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define local static
 
 local uLong adler32_combine_(uLong adler1, uLong adler2, z_off64_t len2);
@@ -57,10 +61,7 @@ local uLong adler32_combine_(uLong adler1, uLong adler2, z_off64_t len2);
 #endif
 
 /* ========================================================================= */
-uLong ZEXPORT adler32(adler, buf, len)
-    uLong adler;
-    const Bytef *buf;
-    uInt len;
+uLong ZEXPORT adler32 (uLong adler, const Bytef *buf, uInt len)
 {
     unsigned long sum2;
     unsigned n;
@@ -128,10 +129,7 @@ uLong ZEXPORT adler32(adler, buf, len)
 }
 
 /* ========================================================================= */
-local uLong adler32_combine_(adler1, adler2, len2)
-    uLong adler1;
-    uLong adler2;
-    z_off64_t len2;
+local uLong adler32_combine_ (uLong adler1, uLong adler2, z_off64_t len2)
 {
     unsigned long sum1;
     unsigned long sum2;
@@ -152,18 +150,16 @@ local uLong adler32_combine_(adler1, adler2, len2)
 }
 
 /* ========================================================================= */
-uLong ZEXPORT adler32_combine(adler1, adler2, len2)
-    uLong adler1;
-    uLong adler2;
-    z_off_t len2;
+uLong ZEXPORT adler32_combine (uLong adler1, uLong adler2, z_off_t len2)
 {
     return adler32_combine_(adler1, adler2, len2);
 }
 
-uLong ZEXPORT adler32_combine64(adler1, adler2, len2)
-    uLong adler1;
-    uLong adler2;
-    z_off64_t len2;
+uLong ZEXPORT adler32_combine64 (uLong adler1, uLong adler2, z_off64_t len2)
 {
     return adler32_combine_(adler1, adler2, len2);
 }
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/support/compress.c
+++ b/support/compress.c
@@ -8,6 +8,10 @@
 #define ZLIB_INTERNAL
 #include "zlib.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ===========================================================================
      Compresses the source buffer into the destination buffer. The level
    parameter has the same meaning as in deflateInit.  sourceLen is the byte
@@ -19,12 +23,7 @@
    memory, Z_BUF_ERROR if there was not enough room in the output buffer,
    Z_STREAM_ERROR if the level parameter is invalid.
 */
-int ZEXPORT compress2 (dest, destLen, source, sourceLen, level)
-    Bytef *dest;
-    uLongf *destLen;
-    const Bytef *source;
-    uLong sourceLen;
-    int level;
+int ZEXPORT compress2 (Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen, int level)
 {
     z_stream stream;
     int err;
@@ -59,11 +58,7 @@ int ZEXPORT compress2 (dest, destLen, source, sourceLen, level)
 
 /* ===========================================================================
  */
-int ZEXPORT compress (dest, destLen, source, sourceLen)
-    Bytef *dest;
-    uLongf *destLen;
-    const Bytef *source;
-    uLong sourceLen;
+int ZEXPORT compress (Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen)
 {
     return compress2(dest, destLen, source, sourceLen, Z_DEFAULT_COMPRESSION);
 }
@@ -72,9 +67,12 @@ int ZEXPORT compress (dest, destLen, source, sourceLen)
      If the default memLevel or windowBits for deflateInit() is changed, then
    this function needs to be updated.
  */
-uLong ZEXPORT compressBound (sourceLen)
-    uLong sourceLen;
+uLong ZEXPORT compressBound (uLong sourceLen)
 {
     return sourceLen + (sourceLen >> 12) + (sourceLen >> 14) +
            (sourceLen >> 25) + 13;
 }
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/support/crc32.c
+++ b/support/crc32.c
@@ -64,6 +64,10 @@
 #  define TBLS 1
 #endif /* BYFOUR */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Local functions for crc concatenation */
 local unsigned long gf2_matrix_times OF((unsigned long *mat,
                                          unsigned long vec));
@@ -105,7 +109,7 @@ local void make_crc_table OF((void));
   allow for word-at-a-time CRC calculation for both big-endian and little-
   endian machines, where a word is four bytes.
 */
-local void make_crc_table()
+local void make_crc_table (void)
 {
     unsigned long c;
     int n, k;
@@ -182,9 +186,7 @@ local void make_crc_table()
 }
 
 #ifdef MAKECRCH
-local void write_table(out, table)
-    FILE *out;
-    const unsigned long FAR *table;
+local void write_table (FILE *out, const unsigned long FAR *table)
 {
     int n;
 
@@ -204,7 +206,7 @@ local void write_table(out, table)
 /* =========================================================================
  * This function can be used by asm versions of crc32()
  */
-const unsigned long FAR * ZEXPORT get_crc_table()
+const unsigned long FAR * ZEXPORT get_crc_table (void)
 {
 #ifdef DYNAMIC_CRC_TABLE
     if (crc_table_empty)
@@ -218,10 +220,7 @@ const unsigned long FAR * ZEXPORT get_crc_table()
 #define DO8 DO1; DO1; DO1; DO1; DO1; DO1; DO1; DO1
 
 /* ========================================================================= */
-unsigned long ZEXPORT crc32(crc, buf, len)
-    unsigned long crc;
-    const unsigned char FAR *buf;
-    uInt len;
+unsigned long ZEXPORT crc32 (unsigned long crc, const unsigned char FAR *buf, uInt len)
 {
     if (buf == Z_NULL) return 0UL;
 
@@ -261,13 +260,10 @@ unsigned long ZEXPORT crc32(crc, buf, len)
 #define DOLIT32 DOLIT4; DOLIT4; DOLIT4; DOLIT4; DOLIT4; DOLIT4; DOLIT4; DOLIT4
 
 /* ========================================================================= */
-local unsigned long crc32_little(crc, buf, len)
-    unsigned long crc;
-    const unsigned char FAR *buf;
-    unsigned len;
+local unsigned long crc32_little (unsigned long crc, const unsigned char FAR *buf, unsigned len)
 {
-    register u4 c;
-    register const u4 FAR *buf4;
+    u4 c;
+    const u4 FAR *buf4;
 
     c = (u4)crc;
     c = ~c;
@@ -301,13 +297,10 @@ local unsigned long crc32_little(crc, buf, len)
 #define DOBIG32 DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4
 
 /* ========================================================================= */
-local unsigned long crc32_big(crc, buf, len)
-    unsigned long crc;
-    const unsigned char FAR *buf;
-    unsigned len;
+local unsigned long crc32_big (unsigned long crc, const unsigned char FAR *buf, unsigned len)
 {
-    register u4 c;
-    register const u4 FAR *buf4;
+    u4 c;
+    const u4 FAR *buf4;
 
     c = REV((u4)crc);
     c = ~c;
@@ -341,9 +334,7 @@ local unsigned long crc32_big(crc, buf, len)
 #define GF2_DIM 32      /* dimension of GF(2) vectors (length of CRC) */
 
 /* ========================================================================= */
-local unsigned long gf2_matrix_times(mat, vec)
-    unsigned long *mat;
-    unsigned long vec;
+local unsigned long gf2_matrix_times (unsigned long *mat, unsigned long vec)
 {
     unsigned long sum;
 
@@ -358,9 +349,7 @@ local unsigned long gf2_matrix_times(mat, vec)
 }
 
 /* ========================================================================= */
-local void gf2_matrix_square(square, mat)
-    unsigned long *square;
-    unsigned long *mat;
+local void gf2_matrix_square (unsigned long *square, unsigned long *mat)
 {
     int n;
 
@@ -369,10 +358,7 @@ local void gf2_matrix_square(square, mat)
 }
 
 /* ========================================================================= */
-local uLong crc32_combine_(crc1, crc2, len2)
-    uLong crc1;
-    uLong crc2;
-    z_off64_t len2;
+local uLong crc32_combine_ (uLong crc1, uLong crc2, z_off64_t len2)
 {
     int n;
     unsigned long row;
@@ -425,18 +411,16 @@ local uLong crc32_combine_(crc1, crc2, len2)
 }
 
 /* ========================================================================= */
-uLong ZEXPORT crc32_combine(crc1, crc2, len2)
-    uLong crc1;
-    uLong crc2;
-    z_off_t len2;
+uLong ZEXPORT crc32_combine (uLong crc1, uLong crc2, z_off_t len2)
 {
     return crc32_combine_(crc1, crc2, len2);
 }
 
-uLong ZEXPORT crc32_combine64(crc1, crc2, len2)
-    uLong crc1;
-    uLong crc2;
-    z_off64_t len2;
+uLong ZEXPORT crc32_combine64 (uLong crc1, uLong crc2, z_off64_t len2)
 {
     return crc32_combine_(crc1, crc2, len2);
 }
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/support/deflate.c
+++ b/support/deflate.c
@@ -51,6 +51,11 @@
 
 #include "deflate.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern
 const char deflate_copyright[] =
    " deflate 1.2.5 Copyright 1995-2010 Jean-loup Gailly and Mark Adler ";
 /*
@@ -195,11 +200,7 @@ struct static_tree_desc_s {int dummy;}; /* for buggy compilers */
     zmemzero((Bytef *)s->head, (unsigned)(s->hash_size-1)*sizeof(*s->head));
 
 /* ========================================================================= */
-int ZEXPORT deflateInit_(strm, level, version, stream_size)
-    z_streamp strm;
-    int level;
-    const char *version;
-    int stream_size;
+int ZEXPORT deflateInit_ (z_streamp strm, int level, const char *version, int stream_size)
 {
     return deflateInit2_(strm, level, Z_DEFLATED, MAX_WBITS, DEF_MEM_LEVEL,
                          Z_DEFAULT_STRATEGY, version, stream_size);
@@ -207,16 +208,15 @@ int ZEXPORT deflateInit_(strm, level, version, stream_size)
 }
 
 /* ========================================================================= */
-int ZEXPORT deflateInit2_(strm, level, method, windowBits, memLevel, strategy,
-                  version, stream_size)
-    z_streamp strm;
-    int  level;
-    int  method;
-    int  windowBits;
-    int  memLevel;
-    int  strategy;
-    const char *version;
-    int stream_size;
+int ZEXPORT deflateInit2_ (
+    z_streamp strm,
+    int  level,
+    int  method,
+    int  windowBits,
+    int  memLevel,
+    int  strategy,
+    const char *version,
+    int stream_size)
 {
     deflate_state *s;
     int wrap = 1;
@@ -308,10 +308,7 @@ int ZEXPORT deflateInit2_(strm, level, method, windowBits, memLevel, strategy,
 }
 
 /* ========================================================================= */
-int ZEXPORT deflateSetDictionary (strm, dictionary, dictLength)
-    z_streamp strm;
-    const Bytef *dictionary;
-    uInt  dictLength;
+int ZEXPORT deflateSetDictionary (z_streamp strm, const Bytef *dictionary, uInt  dictLength)
 {
     deflate_state *s;
     uInt length = dictLength;
@@ -350,8 +347,7 @@ int ZEXPORT deflateSetDictionary (strm, dictionary, dictLength)
 }
 
 /* ========================================================================= */
-int ZEXPORT deflateReset (strm)
-    z_streamp strm;
+int ZEXPORT deflateReset (z_streamp strm)
 {
     deflate_state *s;
 
@@ -386,9 +382,7 @@ int ZEXPORT deflateReset (strm)
 }
 
 /* ========================================================================= */
-int ZEXPORT deflateSetHeader (strm, head)
-    z_streamp strm;
-    gz_headerp head;
+int ZEXPORT deflateSetHeader (z_streamp strm, gz_headerp head)
 {
     if (strm == Z_NULL || strm->state == Z_NULL) return Z_STREAM_ERROR;
     if (strm->state->wrap != 2) return Z_STREAM_ERROR;
@@ -397,10 +391,7 @@ int ZEXPORT deflateSetHeader (strm, head)
 }
 
 /* ========================================================================= */
-int ZEXPORT deflatePrime (strm, bits, value)
-    z_streamp strm;
-    int bits;
-    int value;
+int ZEXPORT deflatePrime (z_streamp strm, int bits, int value)
 {
     if (strm == Z_NULL || strm->state == Z_NULL) return Z_STREAM_ERROR;
     strm->state->bi_valid = bits;
@@ -409,10 +400,7 @@ int ZEXPORT deflatePrime (strm, bits, value)
 }
 
 /* ========================================================================= */
-int ZEXPORT deflateParams(strm, level, strategy)
-    z_streamp strm;
-    int level;
-    int strategy;
+int ZEXPORT deflateParams (z_streamp strm, int level, int strategy)
 {
     deflate_state *s;
     compress_func func;
@@ -448,12 +436,7 @@ int ZEXPORT deflateParams(strm, level, strategy)
 }
 
 /* ========================================================================= */
-int ZEXPORT deflateTune(strm, good_length, max_lazy, nice_length, max_chain)
-    z_streamp strm;
-    int good_length;
-    int max_lazy;
-    int nice_length;
-    int max_chain;
+int ZEXPORT deflateTune (z_streamp strm, int good_length, int max_lazy, int nice_length, int max_chain)
 {
     deflate_state *s;
 
@@ -483,9 +466,7 @@ int ZEXPORT deflateTune(strm, good_length, max_lazy, nice_length, max_chain)
  * upper bound of about 14% expansion does not seem onerous for output buffer
  * allocation.
  */
-uLong ZEXPORT deflateBound(strm, sourceLen)
-    z_streamp strm;
-    uLong sourceLen;
+uLong ZEXPORT deflateBound (z_streamp strm, uLong sourceLen)
 {
     deflate_state *s;
     uLong complen, wraplen;
@@ -545,9 +526,7 @@ uLong ZEXPORT deflateBound(strm, sourceLen)
  * IN assertion: the stream state is correct and there is enough room in
  * pending_buf.
  */
-local void putShortMSB (s, b)
-    deflate_state *s;
-    uInt b;
+local void putShortMSB (deflate_state *s, uInt b)
 {
     put_byte(s, (Byte)(b >> 8));
     put_byte(s, (Byte)(b & 0xff));
@@ -559,8 +538,7 @@ local void putShortMSB (s, b)
  * to avoid allocating a large strm->next_out buffer and copying into it.
  * (See also read_buf()).
  */
-local void flush_pending(strm)
-    z_streamp strm;
+local void flush_pending (z_streamp strm)
 {
     unsigned len = strm->state->pending;
 
@@ -579,9 +557,7 @@ local void flush_pending(strm)
 }
 
 /* ========================================================================= */
-int ZEXPORT deflate (strm, flush)
-    z_streamp strm;
-    int flush;
+int ZEXPORT deflate (z_streamp strm, int flush)
 {
     int old_flush; /* value of flush param for previous deflate call */
     deflate_state *s;
@@ -892,8 +868,7 @@ int ZEXPORT deflate (strm, flush)
 }
 
 /* ========================================================================= */
-int ZEXPORT deflateEnd (strm)
-    z_streamp strm;
+int ZEXPORT deflateEnd (z_streamp strm)
 {
     int status;
 
@@ -927,9 +902,7 @@ int ZEXPORT deflateEnd (strm)
  * To simplify the source, this is not supported for 16-bit MSDOS (which
  * doesn't have enough memory anyway to duplicate compression states).
  */
-int ZEXPORT deflateCopy (dest, source)
-    z_streamp dest;
-    z_streamp source;
+int ZEXPORT deflateCopy (z_streamp dest, z_streamp source)
 {
 #ifdef MAXSEG_64K
     return Z_STREAM_ERROR;
@@ -989,10 +962,7 @@ int ZEXPORT deflateCopy (dest, source)
  * allocating a large strm->next_in buffer and copying from it.
  * (See also flush_pending()).
  */
-local int read_buf(strm, buf, size)
-    z_streamp strm;
-    Bytef *buf;
-    unsigned size;
+local int read_buf (z_streamp strm, Bytef *buf, unsigned size)
 {
     unsigned len = strm->avail_in;
 
@@ -1019,8 +989,7 @@ local int read_buf(strm, buf, size)
 /* ===========================================================================
  * Initialize the "longest match" routines for a new zlib stream
  */
-local void lm_init (s)
-    deflate_state *s;
+local void lm_init (deflate_state *s)
 {
     s->window_size = (ulg)2L*s->w_size;
 
@@ -1060,14 +1029,14 @@ local void lm_init (s)
 /* For 80x86 and 680x0, an optimized version will be provided in match.asm or
  * match.S. The code will be functionally equivalent.
  */
-local uInt longest_match(s, cur_match)
-    deflate_state *s;
-    IPos cur_match;                             /* current match */
+local uInt longest_match (
+    deflate_state *s,
+    IPos cur_match)                             /* current match */
 {
     unsigned chain_length = s->max_chain_length;/* max hash chain length */
-    register Bytef *scan = s->window + s->strstart; /* current string */
-    register Bytef *match;                       /* matched string */
-    register int len;                           /* length of current match */
+    Bytef *scan = s->window + s->strstart; /* current string */
+    Bytef *match;                       /* matched string */
+    int len;                           /* length of current match */
     int best_len = s->prev_length;              /* best match length so far */
     int nice_match = s->nice_match;             /* stop if match long enough */
     IPos limit = s->strstart > (IPos)MAX_DIST(s) ?
@@ -1082,13 +1051,13 @@ local uInt longest_match(s, cur_match)
     /* Compare two bytes at a time. Note: this is not always beneficial.
      * Try with and without -DUNALIGNED_OK to check.
      */
-    register Bytef *strend = s->window + s->strstart + MAX_MATCH - 1;
-    register ush scan_start = *(ushf*)scan;
-    register ush scan_end   = *(ushf*)(scan+best_len-1);
+    Bytef *strend = s->window + s->strstart + MAX_MATCH - 1;
+    ush scan_start = *(ushf*)scan;
+    ush scan_end   = *(ushf*)(scan+best_len-1);
 #else
-    register Bytef *strend = s->window + s->strstart + MAX_MATCH;
-    register Byte scan_end1  = scan[best_len-1];
-    register Byte scan_end   = scan[best_len];
+    Bytef *strend = s->window + s->strstart + MAX_MATCH;
+    Byte scan_end1  = scan[best_len-1];
+    Byte scan_end   = scan[best_len];
 #endif
 
     /* The code is optimized for HASH_BITS >= 8 and MAX_MATCH-2 multiple of 16.
@@ -1209,14 +1178,14 @@ local uInt longest_match(s, cur_match)
 /* ---------------------------------------------------------------------------
  * Optimized version for FASTEST only
  */
-local uInt longest_match(s, cur_match)
-    deflate_state *s;
-    IPos cur_match;                             /* current match */
+local uInt longest_match (
+    deflate_state *s,
+    IPos cur_match)                             /* current match */
 {
-    register Bytef *scan = s->window + s->strstart; /* current string */
-    register Bytef *match;                       /* matched string */
-    register int len;                           /* length of current match */
-    register Bytef *strend = s->window + s->strstart + MAX_MATCH;
+    Bytef *scan = s->window + s->strstart; /* current string */
+    Bytef *match;                       /* matched string */
+    int len;                           /* length of current match */
+    Bytef *strend = s->window + s->strstart + MAX_MATCH;
 
     /* The code is optimized for HASH_BITS >= 8 and MAX_MATCH-2 multiple of 16.
      * It is easy to get rid of this optimization if necessary.
@@ -1268,10 +1237,7 @@ local uInt longest_match(s, cur_match)
 /* ===========================================================================
  * Check that the match at match_start is indeed a match.
  */
-local void check_match(s, start, match, length)
-    deflate_state *s;
-    IPos start, match;
-    int length;
+local void check_match (deflate_state *s, IPos start, IPos match, int length)
 {
     /* check that the match is indeed a match */
     if (zmemcmp(s->window + match,
@@ -1302,11 +1268,10 @@ local void check_match(s, start, match, length)
  *    performed for at least two bytes (required for the zip translate_eol
  *    option -- not supported here).
  */
-local void fill_window(s)
-    deflate_state *s;
+local void fill_window (deflate_state *s)
 {
-    register unsigned n, m;
-    register Posf *p;
+    unsigned n, m;
+    Posf *p;
     unsigned more;    /* Amount of free space at the end of the window. */
     uInt wsize = s->w_size;
 
@@ -1459,9 +1424,7 @@ local void fill_window(s)
  * NOTE: this function should be optimized to avoid extra copying from
  * window to pending_buf.
  */
-local block_state deflate_stored(s, flush)
-    deflate_state *s;
-    int flush;
+local block_state deflate_stored (deflate_state *s, int flush)
 {
     /* Stored blocks are limited to 0xffff bytes, pending_buf is limited
      * to pending_buf_size, and each stored block has a 5 byte header:
@@ -1517,9 +1480,7 @@ local block_state deflate_stored(s, flush)
  * new strings in the dictionary only for unmatched strings or for short
  * matches. It is used only for the fast compression options.
  */
-local block_state deflate_fast(s, flush)
-    deflate_state *s;
-    int flush;
+local block_state deflate_fast (deflate_state *s, int flush)
 {
     IPos hash_head;       /* head of the hash chain */
     int bflush;           /* set if current block must be flushed */
@@ -1613,9 +1574,7 @@ local block_state deflate_fast(s, flush)
  * evaluation for matches: a match is finally adopted only if there is
  * no better match at the next window position.
  */
-local block_state deflate_slow(s, flush)
-    deflate_state *s;
-    int flush;
+local block_state deflate_slow (deflate_state *s, int flush)
 {
     IPos hash_head;          /* head of hash chain */
     int bflush;              /* set if current block must be flushed */
@@ -1738,9 +1697,7 @@ local block_state deflate_slow(s, flush)
  * one.  Do not maintain a hash table.  (It will be regenerated if this run of
  * deflate switches away from Z_RLE.)
  */
-local block_state deflate_rle(s, flush)
-    deflate_state *s;
-    int flush;
+local block_state deflate_rle (deflate_state *s, int flush)
 {
     int bflush;             /* set if current block must be flushed */
     uInt prev;              /* byte at distance one to match */
@@ -1804,9 +1761,7 @@ local block_state deflate_rle(s, flush)
  * For Z_HUFFMAN_ONLY, do not look for matches.  Do not maintain a hash table.
  * (It will be regenerated if this run of deflate switches away from Huffman.)
  */
-local block_state deflate_huff(s, flush)
-    deflate_state *s;
-    int flush;
+local block_state deflate_huff (deflate_state *s, int flush)
 {
     int bflush;             /* set if current block must be flushed */
 
@@ -1832,3 +1787,7 @@ local block_state deflate_huff(s, flush)
     FLUSH_BLOCK(s, flush == Z_FINISH);
     return flush == Z_FINISH ? finish_done : block_done;
 }
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/support/deflate.h
+++ b/support/deflate.h
@@ -15,6 +15,10 @@
 
 #include "zutil.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* define NO_GZIP when compiling if you want to disable gzip header and
    trailer creation by deflate().  NO_GZIP would be used to avoid linking in
    the crc code when it is not needed.  For shared libraries, gzip encoding
@@ -337,6 +341,10 @@ void ZLIB_INTERNAL _tr_stored_block OF((deflate_state *s, charf *buf,
 # define _tr_tally_lit(s, c, flush) flush = _tr_tally(s, 0, c)
 # define _tr_tally_dist(s, distance, length, flush) \
               flush = _tr_tally(s, distance, length)
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* DEFLATE_H */

--- a/support/dirent.c
+++ b/support/dirent.c
@@ -79,7 +79,7 @@ Mono_Posix_Syscall_readdir (void *dirp, struct Mono_Posix_Syscall__Dirent *entry
 	}
 
 	errno = 0;
-	d = readdir (dirp);
+	d = readdir ((DIR*)dirp);
 
 	if (d == NULL) {
 		return -1;
@@ -93,10 +93,10 @@ Mono_Posix_Syscall_readdir (void *dirp, struct Mono_Posix_Syscall__Dirent *entry
 gint32
 Mono_Posix_Syscall_readdir_r (void *dirp, struct Mono_Posix_Syscall__Dirent *entry, void **result)
 {
-	struct dirent *_entry = malloc (sizeof (struct dirent) + MPH_PATH_MAX + 1);
+	struct dirent *_entry = (struct dirent*)malloc (sizeof (struct dirent) + MPH_PATH_MAX + 1);
 	int r;
 
-	r = readdir_r (dirp, _entry, (struct dirent**) result);
+	r = readdir_r ((DIR*)dirp, _entry, (struct dirent**) result);
 
 	if (r == 0 && *result != NULL) {
 		copy_dirent (entry, _entry);
@@ -110,7 +110,7 @@ Mono_Posix_Syscall_readdir_r (void *dirp, struct Mono_Posix_Syscall__Dirent *ent
 int
 Mono_Posix_Syscall_rewinddir (void* dir)
 {
-	rewinddir (dir);
+	rewinddir ((DIR*)dir);
 	return 0;
 }
 

--- a/support/grp.c
+++ b/support/grp.c
@@ -76,8 +76,8 @@ copy_group (struct Mono_Posix_Syscall__Group *to, struct group *from)
 	count_members (from->gr_mem, &count, &buflen);
 
 	to->_gr_nmem_ = count;
-	cur = to->_gr_buf_ = (char*) malloc (buflen);
-	to_mem = to->gr_mem = malloc (sizeof(char*)*(count+1));
+	cur = (char*)(to->_gr_buf_ = (char*) malloc (buflen));
+	to_mem = (char**)(to->gr_mem = malloc (sizeof(char*)*(count+1)));
 	if (to->_gr_buf_ == NULL || to->gr_mem == NULL) {
 		free (to->_gr_buf_);
 		free (to->gr_mem);
@@ -162,7 +162,7 @@ Mono_Posix_Syscall_getgrnam_r (const char *name,
 	buflen = 2;
 
 	do {
-		buf2 = realloc (buf, buflen *= 2);
+		buf2 = (char*)realloc (buf, buflen *= 2);
 		if (buf2 == NULL) {
 			free (buf);
 			errno = ENOMEM;
@@ -205,7 +205,7 @@ Mono_Posix_Syscall_getgrgid_r (mph_gid_t gid,
 	buflen = 2;
 
 	do {
-		buf2 = realloc (buf, buflen *= 2);
+		buf2 = (char*)realloc (buf, buflen *= 2);
 		if (buf2 == NULL) {
 			free (buf);
 			errno = ENOMEM;

--- a/support/infback.c
+++ b/support/infback.c
@@ -15,6 +15,10 @@
 #include "inflate.h"
 #include "inffast.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* function prototypes */
 local void fixedtables OF((struct inflate_state FAR *state));
 
@@ -25,12 +29,7 @@ local void fixedtables OF((struct inflate_state FAR *state));
    windowBits is in the range 8..15, and window is a user-supplied
    window and output buffer that is 2**windowBits bytes.
  */
-int ZEXPORT inflateBackInit_(strm, windowBits, window, version, stream_size)
-z_streamp strm;
-int windowBits;
-unsigned char FAR *window;
-const char *version;
-int stream_size;
+int ZEXPORT inflateBackInit_ (z_streamp strm, int windowBits, unsigned char FAR *window, const char *version, int stream_size)
 {
     struct inflate_state FAR *state;
 
@@ -70,8 +69,7 @@ int stream_size;
    used for threaded applications, since the rewriting of the tables and virgin
    may not be thread-safe.
  */
-local void fixedtables(state)
-struct inflate_state FAR *state;
+local void fixedtables (struct inflate_state FAR *state)
 {
 #ifdef BUILDFIXED
     static int virgin = 1;
@@ -238,12 +236,7 @@ struct inflate_state FAR *state;
    inflateBack() can also return Z_STREAM_ERROR if the input parameters
    are not correct, i.e. strm is Z_NULL or the state was not initialized.
  */
-int ZEXPORT inflateBack(strm, in, in_desc, out, out_desc)
-z_streamp strm;
-in_func in;
-void FAR *in_desc;
-out_func out;
-void FAR *out_desc;
+int ZEXPORT inflateBack (z_streamp strm, in_func in, void FAR *in_desc, out_func out, void FAR *out_desc)
 {
     struct inflate_state FAR *state;
     unsigned char FAR *next;    /* next input */
@@ -620,8 +613,7 @@ void FAR *out_desc;
     return ret;
 }
 
-int ZEXPORT inflateBackEnd(strm)
-z_streamp strm;
+int ZEXPORT inflateBackEnd (z_streamp strm)
 {
     if (strm == Z_NULL || strm->state == Z_NULL || strm->zfree == (free_func)0)
         return Z_STREAM_ERROR;
@@ -630,3 +622,7 @@ z_streamp strm;
     Tracev((stderr, "inflate: end\n"));
     return Z_OK;
 }
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/support/inffast.c
+++ b/support/inffast.c
@@ -8,6 +8,10 @@
 #include "inflate.h"
 #include "inffast.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef ASMINF
 
 /* Allow machine dependent optimization for post-increment or pre-increment.
@@ -64,9 +68,9 @@
       requires strm->avail_out >= 258 for each loop to avoid checking for
       output space.
  */
-void ZLIB_INTERNAL inflate_fast(strm, start)
-z_streamp strm;
-unsigned start;         /* inflate()'s starting value for strm->avail_out */
+void ZLIB_INTERNAL inflate_fast (
+z_streamp strm,
+unsigned start)         /* inflate()'s starting value for strm->avail_out */
 {
     struct inflate_state FAR *state;
     unsigned char FAR *in;      /* local strm->next_in */
@@ -338,3 +342,7 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
  */
 
 #endif /* !ASMINF */
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/support/inffast.h
+++ b/support/inffast.h
@@ -8,4 +8,12 @@
    subject to change. Applications should only use zlib.h.
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void ZLIB_INTERNAL inflate_fast OF((z_streamp strm, unsigned start));
+
+#ifdef __cplusplus
+}
+#endif

--- a/support/inflate.c
+++ b/support/inflate.c
@@ -85,6 +85,10 @@
 #include "inflate.h"
 #include "inffast.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef MAKEFIXED
 #  ifndef BUILDFIXED
 #    define BUILDFIXED
@@ -100,8 +104,7 @@ local int updatewindow OF((z_streamp strm, unsigned out));
 local unsigned syncsearch OF((unsigned FAR *have, unsigned char FAR *buf,
                               unsigned len));
 
-int ZEXPORT inflateReset(strm)
-z_streamp strm;
+int ZEXPORT inflateReset (z_streamp strm)
 {
     struct inflate_state FAR *state;
 
@@ -127,9 +130,7 @@ z_streamp strm;
     return Z_OK;
 }
 
-int ZEXPORT inflateReset2(strm, windowBits)
-z_streamp strm;
-int windowBits;
+int ZEXPORT inflateReset2 (z_streamp strm, int windowBits)
 {
     int wrap;
     struct inflate_state FAR *state;
@@ -165,11 +166,7 @@ int windowBits;
     return inflateReset(strm);
 }
 
-int ZEXPORT inflateInit2_(strm, windowBits, version, stream_size)
-z_streamp strm;
-int windowBits;
-const char *version;
-int stream_size;
+int ZEXPORT inflateInit2_ (z_streamp strm, int windowBits, const char *version, int stream_size)
 {
     int ret;
     struct inflate_state FAR *state;
@@ -198,18 +195,12 @@ int stream_size;
     return ret;
 }
 
-int ZEXPORT inflateInit_(strm, version, stream_size)
-z_streamp strm;
-const char *version;
-int stream_size;
+int ZEXPORT inflateInit_ (z_streamp strm, const char *version, int stream_size)
 {
     return inflateInit2_(strm, DEF_WBITS, version, stream_size);
 }
 
-int ZEXPORT inflatePrime(strm, bits, value)
-z_streamp strm;
-int bits;
-int value;
+int ZEXPORT inflatePrime (z_streamp strm, int bits, int value)
 {
     struct inflate_state FAR *state;
 
@@ -237,8 +228,7 @@ int value;
    used for threaded applications, since the rewriting of the tables and virgin
    may not be thread-safe.
  */
-local void fixedtables(state)
-struct inflate_state FAR *state;
+local void fixedtables (struct inflate_state FAR *state)
 {
 #ifdef BUILDFIXED
     static int virgin = 1;
@@ -301,7 +291,7 @@ struct inflate_state FAR *state;
 
     a.out > inffixed.h
  */
-void makefixed()
+void makefixed (void)
 {
     unsigned low, size;
     struct inflate_state state;
@@ -355,9 +345,7 @@ void makefixed()
    output will fall in the output data, making match copies simpler and faster.
    The advantage may be dependent on the size of the processor's data caches.
  */
-local int updatewindow(strm, out)
-z_streamp strm;
-unsigned out;
+local int updatewindow (z_streamp strm, unsigned out)
 {
     struct inflate_state FAR *state;
     unsigned copy, dist;
@@ -586,9 +574,7 @@ unsigned out;
    will return Z_BUF_ERROR if it has not reached the end of the stream.
  */
 
-int ZEXPORT inflate(strm, flush)
-z_streamp strm;
-int flush;
+int ZEXPORT inflate (z_streamp strm, int flush)
 {
     struct inflate_state FAR *state;
     unsigned char FAR *next;    /* next input */
@@ -1235,8 +1221,7 @@ int flush;
     return ret;
 }
 
-int ZEXPORT inflateEnd(strm)
-z_streamp strm;
+int ZEXPORT inflateEnd (z_streamp strm)
 {
     struct inflate_state FAR *state;
     if (strm == Z_NULL || strm->state == Z_NULL || strm->zfree == (free_func)0)
@@ -1249,10 +1234,7 @@ z_streamp strm;
     return Z_OK;
 }
 
-int ZEXPORT inflateSetDictionary(strm, dictionary, dictLength)
-z_streamp strm;
-const Bytef *dictionary;
-uInt dictLength;
+int ZEXPORT inflateSetDictionary (z_streamp strm, const Bytef *dictionary, uInt dictLength)
 {
     struct inflate_state FAR *state;
     unsigned long id;
@@ -1291,9 +1273,7 @@ uInt dictLength;
     return Z_OK;
 }
 
-int ZEXPORT inflateGetHeader(strm, head)
-z_streamp strm;
-gz_headerp head;
+int ZEXPORT inflateGetHeader (z_streamp strm, gz_headerp head)
 {
     struct inflate_state FAR *state;
 
@@ -1319,10 +1299,7 @@ gz_headerp head;
    called again with more data and the *have state.  *have is initialized to
    zero for the first call.
  */
-local unsigned syncsearch(have, buf, len)
-unsigned FAR *have;
-unsigned char FAR *buf;
-unsigned len;
+local unsigned syncsearch (unsigned FAR *have, unsigned char FAR *buf, unsigned len)
 {
     unsigned got;
     unsigned next;
@@ -1342,8 +1319,7 @@ unsigned len;
     return next;
 }
 
-int ZEXPORT inflateSync(strm)
-z_streamp strm;
+int ZEXPORT inflateSync (z_streamp strm)
 {
     unsigned len;               /* number of bytes to look at or looked at */
     unsigned long in, out;      /* temporary to save total_in and total_out */
@@ -1393,8 +1369,7 @@ z_streamp strm;
    block. When decompressing, PPP checks that at the end of input packet,
    inflate is waiting for these length bytes.
  */
-int ZEXPORT inflateSyncPoint(strm)
-z_streamp strm;
+int ZEXPORT inflateSyncPoint (z_streamp strm)
 {
     struct inflate_state FAR *state;
 
@@ -1403,9 +1378,7 @@ z_streamp strm;
     return state->mode == STORED && state->bits == 0;
 }
 
-int ZEXPORT inflateCopy(dest, source)
-z_streamp dest;
-z_streamp source;
+int ZEXPORT inflateCopy (z_streamp dest, z_streamp source)
 {
     struct inflate_state FAR *state;
     struct inflate_state FAR *copy;
@@ -1450,9 +1423,7 @@ z_streamp source;
     return Z_OK;
 }
 
-int ZEXPORT inflateUndermine(strm, subvert)
-z_streamp strm;
-int subvert;
+int ZEXPORT inflateUndermine (z_streamp strm, int subvert)
 {
     struct inflate_state FAR *state;
 
@@ -1467,8 +1438,7 @@ int subvert;
 #endif
 }
 
-long ZEXPORT inflateMark(strm)
-z_streamp strm;
+long ZEXPORT inflateMark (z_streamp strm)
 {
     struct inflate_state FAR *state;
 
@@ -1478,3 +1448,7 @@ z_streamp strm;
         (state->mode == COPY ? state->length :
             (state->mode == MATCH ? state->was - state->length : 0));
 }
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/support/inftrees.c
+++ b/support/inftrees.c
@@ -8,6 +8,11 @@
 
 #define MAXBITS 15
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern
 const char inflate_copyright[] =
    " inflate 1.2.5 Copyright 1995-2010 Mark Adler ";
 /*
@@ -29,13 +34,7 @@ const char inflate_copyright[] =
    table index bits.  It will differ if the request is greater than the
    longest code or if it is less than the shortest code.
  */
-int ZLIB_INTERNAL inflate_table(type, lens, codes, table, bits, work)
-codetype type;
-unsigned short FAR *lens;
-unsigned codes;
-code FAR * FAR *table;
-unsigned FAR *bits;
-unsigned short FAR *work;
+int ZLIB_INTERNAL inflate_table (codetype type, unsigned short FAR *lens, unsigned codes, code FAR * FAR *table, unsigned FAR *bits, unsigned short FAR *work)
 {
     unsigned len;               /* a code's length in bits */
     unsigned sym;               /* index of code symbols */
@@ -328,3 +327,7 @@ unsigned short FAR *work;
     *bits = root;
     return 0;
 }
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/support/inftrees.h
+++ b/support/inftrees.h
@@ -8,6 +8,10 @@
    subject to change. Applications should only use zlib.h.
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Structure for decoding tables.  Each entry provides either the
    information needed to do the operation requested by the code that
    indexed that table entry, or it provides a pointer to another
@@ -60,3 +64,7 @@ typedef enum {
 int ZLIB_INTERNAL inflate_table OF((codetype type, unsigned short FAR *lens,
                              unsigned codes, code FAR * FAR *table,
                              unsigned FAR *bits, unsigned short FAR *work));
+
+#ifdef __cplusplus
+}
+#endif

--- a/support/macros.c
+++ b/support/macros.c
@@ -12,6 +12,8 @@
 #include "mph.h" /* Don't remove or move after map.h! Works around issues with Android SDK unified headers */
 #include "map.h"
 
+G_BEGIN_DECLS // FIXMEcxx?
+
 int wifexited (int status)
 {
 	return WIFEXITED (status);
@@ -158,3 +160,4 @@ int helper_Mono_Posix_getpwnamuid (int mode, char *in_name, int in_uid,
 }
 #endif  /* def HAVE_GETPWNAM_R */
 
+G_END_DECLS // FIXMEcxx?

--- a/support/minizip/crypt.h
+++ b/support/minizip/crypt.h
@@ -51,7 +51,7 @@ static int update_keys(unsigned long* pkeys,const unsigned long* pcrc_32_tab,int
     (*(pkeys+1)) += (*(pkeys+0)) & 0xff;
     (*(pkeys+1)) = (*(pkeys+1)) * 134775813L + 1;
     {
-      register int keyshift = (int)((*(pkeys+1)) >> 24);
+      int keyshift = (int)((*(pkeys+1)) >> 24);
       (*(pkeys+2)) = CRC32((*(pkeys+2)), keyshift);
     }
     return c;

--- a/support/minizip/ioapi.c
+++ b/support/minizip/ioapi.c
@@ -13,20 +13,8 @@
 #include "zlib.h"
 #include "ioapi.h"
 
-
-
-/* I've found an old Unix (a SunOS 4.1.3_U1) without all SEEK_* defined.... */
-
-#ifndef SEEK_CUR
-#define SEEK_CUR    1
-#endif
-
-#ifndef SEEK_END
-#define SEEK_END    2
-#endif
-
-#ifndef SEEK_SET
-#define SEEK_SET    0
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 static
@@ -72,10 +60,7 @@ int ZCALLBACK ferror_file_func OF((
    voidpf stream));
 
 static
-voidpf ZCALLBACK fopen_file_func (opaque, filename, mode)
-   voidpf opaque;
-   const char* filename;
-   int mode;
+voidpf ZCALLBACK fopen_file_func (voidpf opaque, const char* filename, int mode)
 {
     FILE* file = NULL;
     const char* mode_fopen = NULL;
@@ -94,11 +79,7 @@ voidpf ZCALLBACK fopen_file_func (opaque, filename, mode)
 }
 
 static
-uLong ZCALLBACK fread_file_func (opaque, stream, buf, size)
-   voidpf opaque;
-   voidpf stream;
-   void* buf;
-   uLong size;
+uLong ZCALLBACK fread_file_func (voidpf opaque, voidpf stream, void* buf, uLong size)
 {
     uLong ret;
     ret = (uLong)fread(buf, 1, (size_t)size, (FILE *)stream);
@@ -106,11 +87,7 @@ uLong ZCALLBACK fread_file_func (opaque, stream, buf, size)
 }
 
 static
-uLong ZCALLBACK fwrite_file_func (opaque, stream, buf, size)
-   voidpf opaque;
-   voidpf stream;
-   const void* buf;
-   uLong size;
+uLong ZCALLBACK fwrite_file_func (voidpf opaque, voidpf stream, const void* buf, uLong size)
 {
     uLong ret;
     ret = (uLong)fwrite(buf, 1, (size_t)size, (FILE *)stream);
@@ -118,9 +95,7 @@ uLong ZCALLBACK fwrite_file_func (opaque, stream, buf, size)
 }
 
 static
-long ZCALLBACK ftell_file_func (opaque, stream)
-   voidpf opaque;
-   voidpf stream;
+long ZCALLBACK ftell_file_func (voidpf opaque, voidpf stream)
 {
     long ret;
     ret = ftell((FILE *)stream);
@@ -128,11 +103,7 @@ long ZCALLBACK ftell_file_func (opaque, stream)
 }
 
 static
-long ZCALLBACK fseek_file_func (opaque, stream, offset, origin)
-   voidpf opaque;
-   voidpf stream;
-   uLong offset;
-   int origin;
+long ZCALLBACK fseek_file_func (voidpf opaque, voidpf stream, uLong offset, int origin)
 {
     int fseek_origin=0;
     long ret;
@@ -155,9 +126,7 @@ long ZCALLBACK fseek_file_func (opaque, stream, offset, origin)
 }
 
 static
-int ZCALLBACK fclose_file_func (opaque, stream)
-   voidpf opaque;
-   voidpf stream;
+int ZCALLBACK fclose_file_func (voidpf opaque, voidpf stream)
 {
     int ret;
     ret = fclose((FILE *)stream);
@@ -165,17 +134,14 @@ int ZCALLBACK fclose_file_func (opaque, stream)
 }
 
 static
-int ZCALLBACK ferror_file_func (opaque, stream)
-   voidpf opaque;
-   voidpf stream;
+int ZCALLBACK ferror_file_func (voidpf opaque, voidpf stream)
 {
     int ret;
     ret = ferror((FILE *)stream);
     return ret;
 }
 
-void fill_fopen_filefunc (pzlib_filefunc_def)
-  zlib_filefunc_def* pzlib_filefunc_def;
+void fill_fopen_filefunc (zlib_filefunc_def* pzlib_filefunc_def)
 {
     pzlib_filefunc_def->zopen_file = fopen_file_func;
     pzlib_filefunc_def->zread_file = fread_file_func;
@@ -186,3 +152,7 @@ void fill_fopen_filefunc (pzlib_filefunc_def)
     pzlib_filefunc_def->zerror_file = ferror_file_func;
     pzlib_filefunc_def->opaque = NULL;
 }
+
+#ifdef __cplusplus
+}
+#endif

--- a/support/minizip/unzip.c
+++ b/support/minizip/unzip.c
@@ -41,17 +41,13 @@ woven in by Terry Thorsen 1/2003.
 #include "zlib.h"
 #include "unzip.h"
 
-#ifdef STDC
-#  include <stddef.h>
-#  include <string.h>
-#  include <stdlib.h>
-#endif
-#ifdef NO_ERRNO_H
-    extern int errno;
-#else
-#   include <errno.h>
-#endif
+#include <stddef.h>
+#include <string.h>
+#include <errno.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #ifndef local
 #  define local static
@@ -83,9 +79,6 @@ woven in by Terry Thorsen 1/2003.
 
 #define SIZECENTRALDIRITEM (0x2e)
 #define SIZEZIPLOCALHEADER (0x1e)
-
-
-
 
 const char unz_copyright[] =
    " unzip 1.01 Copyright 1998-2004 Gilles Vollant - http://www.winimage.com/zLibDll";
@@ -168,10 +161,7 @@ local int unzlocal_getByte OF((
     voidpf filestream,
     int *pi));
 
-local int unzlocal_getByte(pzlib_filefunc_def,filestream,pi)
-    const zlib_filefunc_def* pzlib_filefunc_def;
-    voidpf filestream;
-    int *pi;
+local int unzlocal_getByte (const zlib_filefunc_def* pzlib_filefunc_def, voidpf filestream, int *pi)
 {
     unsigned char c;
     int err = (int)ZREAD(*pzlib_filefunc_def,filestream,&c,1);
@@ -198,10 +188,7 @@ local int unzlocal_getShort OF((
     voidpf filestream,
     uLong *pX));
 
-local int unzlocal_getShort (pzlib_filefunc_def,filestream,pX)
-    const zlib_filefunc_def* pzlib_filefunc_def;
-    voidpf filestream;
-    uLong *pX;
+local int unzlocal_getShort (const zlib_filefunc_def* pzlib_filefunc_def, voidpf filestream, uLong *pX)
 {
     uLong x ;
     int i;
@@ -226,10 +213,7 @@ local int unzlocal_getLong OF((
     voidpf filestream,
     uLong *pX));
 
-local int unzlocal_getLong (pzlib_filefunc_def,filestream,pX)
-    const zlib_filefunc_def* pzlib_filefunc_def;
-    voidpf filestream;
-    uLong *pX;
+local int unzlocal_getLong (const zlib_filefunc_def* pzlib_filefunc_def, voidpf filestream, uLong *pX)
 {
     uLong x ;
     int i;
@@ -300,10 +284,7 @@ local int strcmpcasenosensitive_internal (const char *fileName1, const char *fil
         (like 1 on Unix, 2 on Windows)
 
 */
-static int unzStringFileNameCompare (fileName1,fileName2,iCaseSensitivity)
-    const char* fileName1;
-    const char* fileName2;
-    int iCaseSensitivity;
+static int unzStringFileNameCompare (const char* fileName1, const char* fileName2, int iCaseSensitivity)
 {
     if (iCaseSensitivity==0)
         iCaseSensitivity=CASESENSITIVITYDEFAULTVALUE;
@@ -326,9 +307,7 @@ local uLong unzlocal_SearchCentralDir OF((
     const zlib_filefunc_def* pzlib_filefunc_def,
     voidpf filestream));
 
-local uLong unzlocal_SearchCentralDir(pzlib_filefunc_def,filestream)
-    const zlib_filefunc_def* pzlib_filefunc_def;
-    voidpf filestream;
+local uLong unzlocal_SearchCentralDir (const zlib_filefunc_def* pzlib_filefunc_def, voidpf filestream)
 {
     unsigned char* buf;
     uLong uSizeFile;
@@ -392,9 +371,7 @@ local uLong unzlocal_SearchCentralDir(pzlib_filefunc_def,filestream)
      Else, the return value is a unzFile Handle, usable with other function
        of this unzip package.
 */
-extern unzFile ZEXPORT unzOpen2 (path, pzlib_filefunc_def)
-    const char *path;
-    zlib_filefunc_def* pzlib_filefunc_def;
+unzFile ZEXPORT unzOpen2 (const char *path, zlib_filefunc_def* pzlib_filefunc_def)
 {
     unz_s us;
     unz_s *s;
@@ -495,8 +472,7 @@ extern unzFile ZEXPORT unzOpen2 (path, pzlib_filefunc_def)
 }
 
 
-extern unzFile ZEXPORT unzOpen (path)
-    const char *path;
+unzFile ZEXPORT unzOpen (const char *path)
 {
     return unzOpen2(path, NULL);
 }
@@ -506,8 +482,7 @@ extern unzFile ZEXPORT unzOpen (path)
   If there is files inside the .Zip opened with unzipOpenCurrentFile (see later),
     these files MUST be closed with unzipCloseCurrentFile before call unzipClose.
   return UNZ_OK if there is no problem. */
-extern int ZEXPORT unzClose (file)
-    unzFile file;
+int ZEXPORT unzClose (unzFile file)
 {
     unz_s* s;
     if (file==NULL)
@@ -527,9 +502,7 @@ extern int ZEXPORT unzClose (file)
   Write info about the ZipFile in the *pglobal_info structure.
   No preparation of the structure is needed
   return UNZ_OK if there is no problem. */
-extern int ZEXPORT unzGetGlobalInfo (file,pglobal_info)
-    unzFile file;
-    unz_global_info *pglobal_info;
+int ZEXPORT unzGetGlobalInfo (unzFile file, unz_global_info *pglobal_info)
 {
     unz_s* s;
     if (file==NULL)
@@ -570,21 +543,16 @@ local int unzlocal_GetCurrentFileInfoInternal OF((unzFile file,
                                                   char *szComment,
                                                   uLong commentBufferSize));
 
-local int unzlocal_GetCurrentFileInfoInternal (file,
-                                              pfile_info,
-                                              pfile_info_internal,
-                                              szFileName, fileNameBufferSize,
-                                              extraField, extraFieldBufferSize,
-                                              szComment,  commentBufferSize)
-    unzFile file;
-    unz_file_info *pfile_info;
-    unz_file_info_internal *pfile_info_internal;
-    char *szFileName;
-    uLong fileNameBufferSize;
-    void *extraField;
-    uLong extraFieldBufferSize;
-    char *szComment;
-    uLong commentBufferSize;
+local int unzlocal_GetCurrentFileInfoInternal (
+    unzFile file,
+    unz_file_info *pfile_info,
+    unz_file_info_internal *pfile_info_internal,
+    char *szFileName,
+    uLong fileNameBufferSize,
+    void *extraField,
+    uLong extraFieldBufferSize,
+    char *szComment,
+    uLong commentBufferSize)
 {
     unz_s* s;
     unz_file_info file_info;
@@ -742,19 +710,15 @@ local int unzlocal_GetCurrentFileInfoInternal (file,
   No preparation of the structure is needed
   return UNZ_OK if there is no problem.
 */
-extern int ZEXPORT unzGetCurrentFileInfo (file,
-                                          pfile_info,
-                                          szFileName, fileNameBufferSize,
-                                          extraField, extraFieldBufferSize,
-                                          szComment,  commentBufferSize)
-    unzFile file;
-    unz_file_info *pfile_info;
-    char *szFileName;
-    uLong fileNameBufferSize;
-    void *extraField;
-    uLong extraFieldBufferSize;
-    char *szComment;
-    uLong commentBufferSize;
+int ZEXPORT unzGetCurrentFileInfo (
+    unzFile file,
+    unz_file_info *pfile_info,
+    char *szFileName,
+    uLong fileNameBufferSize,
+    void *extraField,
+    uLong extraFieldBufferSize,
+    char *szComment,
+    uLong commentBufferSize)
 {
     return unzlocal_GetCurrentFileInfoInternal(file,pfile_info,NULL,
                                                 szFileName,fileNameBufferSize,
@@ -766,8 +730,7 @@ extern int ZEXPORT unzGetCurrentFileInfo (file,
   Set the current file of the zipfile to the first file.
   return UNZ_OK if there is no problem
 */
-extern int ZEXPORT unzGoToFirstFile (file)
-    unzFile file;
+int ZEXPORT unzGoToFirstFile (unzFile file)
 {
     int err=UNZ_OK;
     unz_s* s;
@@ -788,8 +751,7 @@ extern int ZEXPORT unzGoToFirstFile (file)
   return UNZ_OK if there is no problem
   return UNZ_END_OF_LIST_OF_FILE if the actual file was the latest.
 */
-extern int ZEXPORT unzGoToNextFile (file)
-    unzFile file;
+int ZEXPORT unzGoToNextFile (unzFile file)
 {
     unz_s* s;
     int err;
@@ -822,10 +784,7 @@ extern int ZEXPORT unzGoToNextFile (file)
   UNZ_OK if the file is found. It becomes the current file.
   UNZ_END_OF_LIST_OF_FILE if the file is not found
 */
-extern int ZEXPORT unzLocateFile (file, szFileName, iCaseSensitivity)
-    unzFile file;
-    const char *szFileName;
-    int iCaseSensitivity;
+int ZEXPORT unzLocateFile (unzFile file, const char *szFileName, int iCaseSensitivity)
 {
     unz_s* s;
     int err;
@@ -1000,12 +959,7 @@ local int unzlocal_CheckCurrentFileCoherencyHeader (unz_s *s, uInt *piSizeVar,
   Open for reading data the current file in the zipfile.
   If there is no error and the file is opened, the return value is UNZ_OK.
 */
-extern int ZEXPORT unzOpenCurrentFile3 (file, method, level, raw, password)
-    unzFile file;
-    int* method;
-    int* level;
-    int raw;
-    const char* password;
+int ZEXPORT unzOpenCurrentFile3 (unzFile file, int* method, int* level, int raw, const char* password)
 {
     int err=UNZ_OK;
     uInt iSizeVar;
@@ -1086,7 +1040,7 @@ extern int ZEXPORT unzOpenCurrentFile3 (file, method, level, raw, password)
       pfile_in_zip_read_info->stream.zalloc = (alloc_func)0;
       pfile_in_zip_read_info->stream.zfree = (free_func)0;
       pfile_in_zip_read_info->stream.opaque = (voidpf)0;
-      pfile_in_zip_read_info->stream.next_in = (voidpf)0;
+      pfile_in_zip_read_info->stream.next_in = (Bytef*)0;
       pfile_in_zip_read_info->stream.avail_in = 0;
 
       err=inflateInit2(&pfile_in_zip_read_info->stream, -MAX_WBITS);
@@ -1145,17 +1099,12 @@ extern int ZEXPORT unzOpenCurrentFile3 (file, method, level, raw, password)
     return UNZ_OK;
 }
 
-extern int ZEXPORT unzOpenCurrentFile (file)
-    unzFile file;
+int ZEXPORT unzOpenCurrentFile (unzFile file)
 {
     return unzOpenCurrentFile3(file, NULL, NULL, 0, NULL);
 }
 
-extern int ZEXPORT unzOpenCurrentFile2 (file,method,level,raw)
-    unzFile file;
-    int* method;
-    int* level;
-    int raw;
+int ZEXPORT unzOpenCurrentFile2 (unzFile file, int* method, int* level, int raw)
 {
     return unzOpenCurrentFile3(file, method, level, raw, NULL);
 }
@@ -1170,10 +1119,7 @@ extern int ZEXPORT unzOpenCurrentFile2 (file,method,level,raw)
   return <0 with error code if there is an error
     (UNZ_ERRNO for IO error, or zLib error for uncompress error)
 */
-extern int ZEXPORT unzReadCurrentFile  (file, buf, len)
-    unzFile file;
-    voidp buf;
-    unsigned len;
+int ZEXPORT unzReadCurrentFile  (unzFile file, voidp buf, unsigned len)
 {
     int err=UNZ_OK;
     uInt iRead = 0;
@@ -1331,8 +1277,7 @@ extern int ZEXPORT unzReadCurrentFile  (file, buf, len)
 /*
   Give the current position in uncompressed data
 */
-extern z_off_t ZEXPORT unztell (file)
-    unzFile file;
+z_off_t ZEXPORT unztell (unzFile file)
 {
     unz_s* s;
     file_in_zip_read_info_s* pfile_in_zip_read_info;
@@ -1351,8 +1296,7 @@ extern z_off_t ZEXPORT unztell (file)
 /*
   return 1 if the end of file was reached, 0 elsewhere
 */
-extern int ZEXPORT unzeof (file)
-    unzFile file;
+int ZEXPORT unzeof (unzFile file)
 {
     unz_s* s;
     file_in_zip_read_info_s* pfile_in_zip_read_info;
@@ -1384,10 +1328,7 @@ extern int ZEXPORT unzeof (file)
   the return value is the number of bytes copied in buf, or (if <0)
     the error code
 */
-extern int ZEXPORT unzGetLocalExtrafield (file,buf,len)
-    unzFile file;
-    voidp buf;
-    unsigned len;
+int ZEXPORT unzGetLocalExtrafield (unzFile file, voidp buf, unsigned len)
 {
     unz_s* s;
     file_in_zip_read_info_s* pfile_in_zip_read_info;
@@ -1435,8 +1376,7 @@ extern int ZEXPORT unzGetLocalExtrafield (file,buf,len)
   Close the file in zip opened with unzipOpenCurrentFile
   Return UNZ_CRCERROR if all the file was read but the CRC is not good
 */
-extern int ZEXPORT unzCloseCurrentFile (file)
-    unzFile file;
+int ZEXPORT unzCloseCurrentFile (unzFile file)
 {
     int err=UNZ_OK;
 
@@ -1478,10 +1418,7 @@ extern int ZEXPORT unzCloseCurrentFile (file)
   uSizeBuf is the size of the szComment buffer.
   return the number of byte copied or an error code <0
 */
-extern int ZEXPORT unzGetGlobalComment (file, szComment, uSizeBuf)
-    unzFile file;
-    char *szComment;
-    uLong uSizeBuf;
+int ZEXPORT unzGetGlobalComment (unzFile file, char *szComment, uLong uSizeBuf)
 {
     unz_s* s;
     uLong uReadThis ;
@@ -1509,8 +1446,7 @@ extern int ZEXPORT unzGetGlobalComment (file, szComment, uSizeBuf)
 }
 
 /* Additions by RX '2004 */
-extern uLong ZEXPORT unzGetOffset (file)
-    unzFile file;
+uLong ZEXPORT unzGetOffset (unzFile file)
 {
     unz_s* s;
 
@@ -1524,3 +1460,7 @@ extern uLong ZEXPORT unzGetOffset (file)
          return 0;
     return s->pos_in_central_dir;
 }
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/support/minizip/zip.c
+++ b/support/minizip/zip.c
@@ -16,18 +16,12 @@
 #include <time.h>
 #include "zlib.h"
 #include "zip.h"
+#include <stddef.h>
+#include <errno.h>
 
-#ifdef STDC
-#  include <stddef.h>
-#  include <string.h>
-#  include <stdlib.h>
+#ifdef __cplusplus
+extern "C" {
 #endif
-#ifdef NO_ERRNO_H
-    extern int errno;
-#else
-#   include <errno.h>
-#endif
-
 
 #ifndef local
 #  define local static
@@ -58,20 +52,6 @@
 #define SIZEZIPLOCALHEADER (0x1e)
 */
 
-/* I've found an old Unix (a SunOS 4.1.3_U1) without all SEEK_* defined.... */
-
-#ifndef SEEK_CUR
-#define SEEK_CUR    1
-#endif
-
-#ifndef SEEK_END
-#define SEEK_END    2
-#endif
-
-#ifndef SEEK_SET
-#define SEEK_SET    0
-#endif
-
 #ifndef DEF_MEM_LEVEL
 #if MAX_MEM_LEVEL >= 8
 #  define DEF_MEM_LEVEL 8
@@ -79,6 +59,7 @@
 #  define DEF_MEM_LEVEL  MAX_MEM_LEVEL
 #endif
 #endif
+extern
 const char zip_copyright[] =
    " zip 1.01 Copyright 1998-2004 Gilles Vollant - http://www.winimage.com/zLibDll";
 
@@ -258,11 +239,11 @@ local int add_data_in_datablock(linkedlist_data *ll, const void *buf, uLong len)
 
 local int ziplocal_putValue OF((const zlib_filefunc_def* pzlib_filefunc_def,
                                 voidpf filestream, uLong x, int nbByte));
-local int ziplocal_putValue (pzlib_filefunc_def, filestream, x, nbByte)
-    const zlib_filefunc_def* pzlib_filefunc_def;
-    voidpf filestream;
-    uLong x;
-    int nbByte;
+local int ziplocal_putValue (
+    const zlib_filefunc_def* pzlib_filefunc_def,
+    voidpf filestream,
+    uLong x,
+    int nbByte)
 {
     unsigned char buf[4];
     int n;
@@ -286,10 +267,7 @@ local int ziplocal_putValue (pzlib_filefunc_def, filestream, x, nbByte)
 }
 
 local void ziplocal_putValue_inmemory OF((void* dest, uLong x, int nbByte));
-local void ziplocal_putValue_inmemory (dest, x, nbByte)
-    void* dest;
-    uLong x;
-    int nbByte;
+local void ziplocal_putValue_inmemory (void* dest, uLong x, int nbByte)
 {
     unsigned char* buf=(unsigned char*)dest;
     int n;
@@ -330,10 +308,7 @@ local int ziplocal_getByte OF((
     voidpf filestream,
     int *pi));
 
-local int ziplocal_getByte(pzlib_filefunc_def,filestream,pi)
-    const zlib_filefunc_def* pzlib_filefunc_def;
-    voidpf filestream;
-    int *pi;
+local int ziplocal_getByte (const zlib_filefunc_def* pzlib_filefunc_def, voidpf filestream, int *pi)
 {
     unsigned char c;
     int err = (int)ZREAD(*pzlib_filefunc_def,filestream,&c,1);
@@ -360,10 +335,7 @@ local int ziplocal_getShort OF((
     voidpf filestream,
     uLong *pX));
 
-local int ziplocal_getShort (pzlib_filefunc_def,filestream,pX)
-    const zlib_filefunc_def* pzlib_filefunc_def;
-    voidpf filestream;
-    uLong *pX;
+local int ziplocal_getShort (const zlib_filefunc_def* pzlib_filefunc_def, voidpf filestream, uLong *pX)
 {
     uLong x ;
     int i;
@@ -388,10 +360,7 @@ local int ziplocal_getLong OF((
     voidpf filestream,
     uLong *pX));
 
-local int ziplocal_getLong (pzlib_filefunc_def,filestream,pX)
-    const zlib_filefunc_def* pzlib_filefunc_def;
-    voidpf filestream;
-    uLong *pX;
+local int ziplocal_getLong (const zlib_filefunc_def* pzlib_filefunc_def, voidpf filestream, uLong *pX)
 {
     uLong x ;
     int i;
@@ -430,9 +399,7 @@ local uLong ziplocal_SearchCentralDir OF((
     const zlib_filefunc_def* pzlib_filefunc_def,
     voidpf filestream));
 
-local uLong ziplocal_SearchCentralDir(pzlib_filefunc_def,filestream)
-    const zlib_filefunc_def* pzlib_filefunc_def;
-    voidpf filestream;
+local uLong ziplocal_SearchCentralDir (const zlib_filefunc_def* pzlib_filefunc_def, voidpf filestream)
 {
     unsigned char* buf;
     uLong uSizeFile;
@@ -489,11 +456,11 @@ local uLong ziplocal_SearchCentralDir(pzlib_filefunc_def,filestream)
 #endif /* !NO_ADDFILEINEXISTINGZIP*/
 
 /************************************************************/
-extern zipFile ZEXPORT zipOpen2 (pathname, append, globalcomment, pzlib_filefunc_def)
-    const char *pathname;
-    int append;
-    zipcharpc* globalcomment;
-    zlib_filefunc_def* pzlib_filefunc_def;
+zipFile ZEXPORT zipOpen2 (
+    const char *pathname,
+    int append,
+    zipcharpc* globalcomment,
+    zlib_filefunc_def* pzlib_filefunc_def)
 {
     zip_internal ziinit;
     zip_internal* zi;
@@ -608,7 +575,7 @@ extern zipFile ZEXPORT zipOpen2 (pathname, append, globalcomment, pzlib_filefunc
 
         if (size_comment>0)
         {
-            ziinit.globalcomment = ALLOC(size_comment+1);
+            ziinit.globalcomment = (char*)ALLOC(size_comment+1);
             if (ziinit.globalcomment)
             {
                size_comment = ZREAD(ziinit.z_filefunc, ziinit.filestream,ziinit.globalcomment,size_comment);
@@ -673,35 +640,28 @@ extern zipFile ZEXPORT zipOpen2 (pathname, append, globalcomment, pzlib_filefunc
     }
 }
 
-extern zipFile ZEXPORT zipOpen (pathname, append)
-    const char *pathname;
-    int append;
+zipFile ZEXPORT zipOpen (const char *pathname, int append)
 {
     return zipOpen2(pathname,append,NULL,NULL);
 }
 
-extern int ZEXPORT zipOpenNewFileInZip3 (file, filename, zipfi,
-                                         extrafield_local, size_extrafield_local,
-                                         extrafield_global, size_extrafield_global,
-                                         comment, method, level, raw,
-                                         windowBits, memLevel, strategy,
-                                         password, crcForCrypting)
-    zipFile file;
-    const char* filename;
-    const zip_fileinfo* zipfi;
-    const void* extrafield_local;
-    uInt size_extrafield_local;
-    const void* extrafield_global;
-    uInt size_extrafield_global;
-    const char* comment;
-    int method;
-    int level;
-    int raw;
-    int windowBits;
-    int memLevel;
-    int strategy;
-    const char* password;
-    uLong crcForCrypting;
+int ZEXPORT zipOpenNewFileInZip3 (
+    zipFile file,
+    const char* filename,
+    const zip_fileinfo* zipfi,
+    const void* extrafield_local,
+    uInt size_extrafield_local,
+    const void* extrafield_global,
+    uInt size_extrafield_global,
+    const char* comment,
+    int method,
+    int level,
+    int raw,
+    int windowBits,
+    int memLevel,
+    int strategy,
+    const char* password,
+    uLong crcForCrypting)
 {
     zip_internal* zi;
     uInt size_filename;
@@ -889,21 +849,18 @@ extern int ZEXPORT zipOpenNewFileInZip3 (file, filename, zipfi,
     return err;
 }
 
-extern int ZEXPORT zipOpenNewFileInZip2(file, filename, zipfi,
-                                        extrafield_local, size_extrafield_local,
-                                        extrafield_global, size_extrafield_global,
-                                        comment, method, level, raw)
-    zipFile file;
-    const char* filename;
-    const zip_fileinfo* zipfi;
-    const void* extrafield_local;
-    uInt size_extrafield_local;
-    const void* extrafield_global;
-    uInt size_extrafield_global;
-    const char* comment;
-    int method;
-    int level;
-    int raw;
+int ZEXPORT zipOpenNewFileInZip2(
+    zipFile file,
+    const char* filename,
+    const zip_fileinfo* zipfi,
+    const void* extrafield_local,
+    uInt size_extrafield_local,
+    const void* extrafield_global,
+    uInt size_extrafield_global,
+    const char* comment,
+    int method,
+    int level,
+    int raw)
 {
     return zipOpenNewFileInZip3 (file, filename, zipfi,
                                  extrafield_local, size_extrafield_local,
@@ -913,20 +870,17 @@ extern int ZEXPORT zipOpenNewFileInZip2(file, filename, zipfi,
                                  NULL, 0);
 }
 
-extern int ZEXPORT zipOpenNewFileInZip (file, filename, zipfi,
-                                        extrafield_local, size_extrafield_local,
-                                        extrafield_global, size_extrafield_global,
-                                        comment, method, level)
-    zipFile file;
-    const char* filename;
-    const zip_fileinfo* zipfi;
-    const void* extrafield_local;
-    uInt size_extrafield_local;
-    const void* extrafield_global;
-    uInt size_extrafield_global;
-    const char* comment;
-    int method;
-    int level;
+int ZEXPORT zipOpenNewFileInZip (
+    zipFile file,
+    const char* filename,
+    const zip_fileinfo* zipfi,
+    const void* extrafield_local,
+    uInt size_extrafield_local,
+    const void* extrafield_global,
+    uInt size_extrafield_global,
+    const char* comment,
+    int method,
+    int level)
 {
     return zipOpenNewFileInZip2 (file, filename, zipfi,
                                  extrafield_local, size_extrafield_local,
@@ -955,10 +909,7 @@ local int zipFlushWriteBuffer(zip_internal *zi)
     return err;
 }
 
-extern int ZEXPORT zipWriteInFileInZip (file, buf, len)
-    zipFile file;
-    const void* buf;
-    unsigned len;
+int ZEXPORT zipWriteInFileInZip (zipFile file, const void* buf, unsigned len)
 {
     zip_internal* zi;
     int err=ZIP_OK;
@@ -970,9 +921,9 @@ extern int ZEXPORT zipWriteInFileInZip (file, buf, len)
     if (zi->in_opened_file_inzip == 0)
         return ZIP_PARAMERROR;
 
-    zi->ci.stream.next_in = (void*)buf;
+    zi->ci.stream.next_in = (Bytef*)buf;
     zi->ci.stream.avail_in = len;
-    zi->ci.crc32 = crc32(zi->ci.crc32,buf,len);
+    zi->ci.crc32 = crc32(zi->ci.crc32, (const Bytef*)buf,len);
 
     while ((err==ZIP_OK) && (zi->ci.stream.avail_in>0))
     {
@@ -1020,10 +971,7 @@ extern int ZEXPORT zipWriteInFileInZip (file, buf, len)
     return err;
 }
 
-extern int ZEXPORT zipCloseFileInZipRaw (file, uncompressed_size, crc32)
-    zipFile file;
-    uLong uncompressed_size;
-    uLong crc32;
+int ZEXPORT zipCloseFileInZipRaw (zipFile file, uLong uncompressed_size, uLong crc32)
 {
     zip_internal* zi;
     uLong compressed_size;
@@ -1116,15 +1064,12 @@ extern int ZEXPORT zipCloseFileInZipRaw (file, uncompressed_size, crc32)
     return err;
 }
 
-extern int ZEXPORT zipCloseFileInZip (file)
-    zipFile file;
+int ZEXPORT zipCloseFileInZip (zipFile file)
 {
     return zipCloseFileInZipRaw (file,0,0);
 }
 
-extern int ZEXPORT zipClose (file, global_comment)
-    zipFile file;
-    const char* global_comment;
+int ZEXPORT zipClose (zipFile file, const char* global_comment)
 {
     zip_internal* zi;
     int err = 0;
@@ -1209,3 +1154,7 @@ extern int ZEXPORT zipClose (file, global_comment)
 
     return err;
 }
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/support/nl.c
+++ b/support/nl.c
@@ -284,7 +284,7 @@ ReadEvents (gpointer sock, gpointer buffer, gint32 count, gint32 size)
 #endif
 
 			NL_DEBUG_PRINT ("\tAttribute: %d %d (%s)", rtap->rta_len, rtap->rta_type, FIND_RTM_ATTRS_NAME (rtap->rta_type));
-			data = RTA_DATA (rtap);
+			data = (char*)RTA_DATA (rtap);
 			switch (rtap->rta_type) {
 			case RTA_DST:
 				have_dst = TRUE;

--- a/support/old-map.c
+++ b/support/old-map.c
@@ -14,6 +14,8 @@
 #include "mph.h"
 #include "old-map.h"
 
+G_BEGIN_DECLS // FIXMEcxx?
+
 int map_Mono_Posix_AccessMode (int mode);
 int map_Mono_Posix_FileMode (int mode);
 int map_Mono_Posix_OpenFlags (int flags);
@@ -188,3 +190,4 @@ int map_Mono_Posix_PollEvents (int x)
 	return r;
 }
 
+G_END_DECLS // FIXMEcxx?

--- a/support/pwd.c
+++ b/support/pwd.c
@@ -129,7 +129,7 @@ Mono_Posix_Syscall_getpwnam_r (const char *name,
 	buflen = 2;
 
 	do {
-		buf2 = realloc (buf, buflen *= 2);
+		buf2 = (char*)realloc (buf, buflen *= 2);
 		if (buf2 == NULL) {
 			free (buf);
 			errno = ENOMEM;
@@ -172,7 +172,7 @@ Mono_Posix_Syscall_getpwuid_r (mph_uid_t uid,
 	buflen = 2;
 
 	do {
-		buf2 = realloc (buf, buflen *= 2);
+		buf2 = (char*)realloc (buf, buflen *= 2);
 		if (buf2 == NULL) {
 			free (buf);
 			errno = ENOMEM;

--- a/support/serial.c
+++ b/support/serial.c
@@ -46,6 +46,8 @@
 #include <IOKit/IOBSD.h>
 #endif
 
+G_BEGIN_DECLS
+
 /* This is a copy of System.IO.Ports.Handshake */
 typedef enum {
 	NoneHandshake = 0,
@@ -72,14 +74,20 @@ typedef enum {
 } MonoStopBits;
 
 /* This is a copy of System.IO.Ports.SerialSignal */
-typedef enum {
+enum _MonoSerialSignal {
 	NoneSignal,
 	Cd = 1, /* Carrier detect */
 	Cts = 2, /* Clear to send */
 	Dsr = 4, /* Data set ready */
 	Dtr = 8, /* Data terminal ready */
 	Rts = 16  /* Request to send */
-} MonoSerialSignal;
+};
+
+#ifdef __cplusplus
+typedef int MonoSerialSignal;
+#else
+typedef enum _MonoSerialSignal MonoSerialSignal;
+#endif
 
 /*
  * Silence the compiler, we do not need these prototypes to be public, since these are only
@@ -604,3 +612,4 @@ list_serial_devices (void)
 }
 #endif
 
+G_END_DECLS

--- a/support/signal.c
+++ b/support/signal.c
@@ -43,19 +43,19 @@ static int count_handlers (int signum);
 void*
 Mono_Posix_Stdlib_SIG_DFL (void)
 {
-	return SIG_DFL;
+	return (void*)SIG_DFL;
 }
 
 void*
 Mono_Posix_Stdlib_SIG_ERR (void)
 {
-	return SIG_ERR;
+	return (void*)SIG_ERR;
 }
 
 void*
 Mono_Posix_Stdlib_SIG_IGN (void)
 {
-	return SIG_IGN;
+	return (void*)SIG_IGN;
 }
 
 void
@@ -330,7 +330,7 @@ Mono_Unix_UnixSignal_install (int sig)
 		// We're still looking for a signal_info spot, and this one is available:
 		if (h == NULL && mph_int_get (&signals [i].signum) == 0) {
 			h = &signals [i];
-			h->handler = signal (sig, default_handler);
+			h->handler = (void*)signal (sig, default_handler);
 			if (h->handler == SIG_ERR) {
 				h->handler = NULL;
 				h = NULL;
@@ -397,7 +397,7 @@ Mono_Unix_UnixSignal_uninstall (void* info)
 	if (acquire_mutex (&signals_mutex) == -1)
 		return -1;
 
-	h = info;
+	h = (signal_info*)info;
 
 	if (h == NULL || h < signals || h > &signals [NUM_SIGNALS])
 		errno = EINVAL;
@@ -405,7 +405,7 @@ Mono_Unix_UnixSignal_uninstall (void* info)
 		/* last UnixSignal -- we can unregister */
 		int signum = mph_int_get (&h->signum);
 		if (h->have_handler && count_handlers (signum) == 1) {
-			mph_sighandler_t p = signal (signum, h->handler);
+			mph_sighandler_t p = (mph_sighandler_t)signal (signum, (void (*)(int))h->handler);
 			if (p != SIG_ERR)
 				r = 0;
 			h->handler      = NULL;

--- a/support/stdio.c
+++ b/support/stdio.c
@@ -168,13 +168,13 @@ gint32
 Mono_Posix_Stdlib_setvbuf (void* stream, void *buf, int mode, mph_size_t size)
 {
 	mph_return_if_size_t_overflow (size);
-	return setvbuf (stream, (char *) buf, mode, (size_t) size);
+	return setvbuf ((FILE*)stream, (char *) buf, mode, (size_t) size);
 }
 
 int 
 Mono_Posix_Stdlib_setbuf (void* stream, void* buf)
 {
-	setbuf (stream, buf);
+	setbuf ((FILE*)stream, (char*)buf);
 	return 0;
 }
 
@@ -187,49 +187,49 @@ Mono_Posix_Stdlib_fopen (char* path, char* mode)
 void*
 Mono_Posix_Stdlib_freopen (char* path, char* mode, void *stream)
 {
-	return freopen (path, mode, stream);
+	return freopen (path, mode, (FILE*)stream);
 }
 
 gint32
 Mono_Posix_Stdlib_fprintf (void* stream, char* format, char *message)
 {
-	return fprintf (stream, format, message);
+	return fprintf ((FILE*)stream, format, message);
 }
 
 gint32
 Mono_Posix_Stdlib_fgetc (void* stream)
 {
-	return fgetc (stream);
+	return fgetc ((FILE*)stream);
 }
 
 char*
 Mono_Posix_Stdlib_fgets (char* str, gint32 size, void* stream)
 {
-	return fgets (str, size, stream);
+	return fgets (str, size, (FILE*)stream);
 }
 
 gint32
 Mono_Posix_Stdlib_fputc (gint32 c, void* stream)
 {
-	return fputc (c, stream);
+	return fputc (c, (FILE*)stream);
 }
 
 gint32
 Mono_Posix_Stdlib_fputs (char* s, void* stream)
 {
-	return fputs (s, stream);
+	return fputs (s, (FILE*)stream);
 }
 
 gint32
 Mono_Posix_Stdlib_fclose (void* stream)
 {
-	return fclose (stream);
+	return fclose ((FILE*)stream);
 }
 
 gint32
 Mono_Posix_Stdlib_fflush (void* stream)
 {
-	return fflush (stream);
+	return fflush ((FILE*)stream);
 }
 
 gint32
@@ -237,39 +237,39 @@ Mono_Posix_Stdlib_fseek (void* stream, gint64 offset, int origin)
 {
 	mph_return_if_long_overflow (offset);
 
-	return fseek (stream, offset, origin);
+	return fseek ((FILE*)stream, offset, origin);
 }
 
 gint64
 Mono_Posix_Stdlib_ftell (void* stream)
 {
-	return ftell (stream);
+	return ftell ((FILE*)stream);
 }
 
 void*
 Mono_Posix_Stdlib_CreateFilePosition (void)
 {
-	fpos_t* pos = malloc (sizeof(fpos_t));
+	fpos_t* pos = (fpos_t*)malloc (sizeof(fpos_t));
 	return pos;
 }
 
 gint32
 Mono_Posix_Stdlib_fgetpos (void* stream, void *pos)
 {
-	return fgetpos (stream, (fpos_t*) pos);
+	return fgetpos ((FILE*)stream, (fpos_t*) pos);
 }
 
 gint32
 Mono_Posix_Stdlib_fsetpos (void* stream, void *pos)
 {
-	return fsetpos (stream, (fpos_t*) pos);
+	return fsetpos ((FILE*)stream, (fpos_t*) pos);
 }
 
 int
 Mono_Posix_Stdlib_rewind (void* stream)
 {
 	do {
-		rewind (stream);
+		rewind ((FILE*)stream);
 	} while (errno == EINTR);
 	mph_return_if_val_in_list5(errno, EAGAIN, EBADF, EFBIG, EINVAL, EIO);
 	mph_return_if_val_in_list5(errno, ENOSPC, ENXIO, EOVERFLOW, EPIPE, ESPIPE);
@@ -286,7 +286,7 @@ Mono_Posix_Stdlib_clearerr (void* stream)
 gint32
 Mono_Posix_Stdlib_ungetc (gint32 c, void* stream)
 {
-	return ungetc (c, stream);
+	return ungetc (c, (FILE*)stream);
 }
 
 gint32

--- a/support/support-heap.c
+++ b/support/support-heap.c
@@ -14,6 +14,8 @@
 #include <unistd.h>
 #include "supportw.h"
 
+G_BEGIN_DECLS
+
 gpointer HeapAlloc            (gpointer unused1, gint32 unused2, gint32 nbytes);
 gpointer HeapCreate           (gint32 flags, gint32 initial_size, gint32 max_size);
 gboolean HeapSetInformation   (gpointer handle, gpointer heap_info_class,
@@ -170,3 +172,5 @@ GetProcessHeap (void)
 	return process_heap;
 }
 /* end Heap* functions */
+
+G_END_DECLS

--- a/support/supportw.c
+++ b/support/supportw.c
@@ -20,6 +20,8 @@
 #include "mono/metadata/object.h"
 #include "mono/metadata/tabledefs.h"
 
+G_BEGIN_DECLS
+
 typedef struct {
 	const char *fname;
 	void *fnptr;
@@ -41,7 +43,7 @@ static int
 compare_names (const void *key, const void *p)
 {
 	FnPtr *ptr = (FnPtr *) p;
-	return strcmp (key, ptr->fname);
+	return strcmp ((const char*)key, ptr->fname);
 }
 
 static gpointer
@@ -49,7 +51,7 @@ get_function (const char *name)
 {
 	FnPtr *ptr;
 
-	ptr = bsearch (name, functions, NFUNCTIONS, sizeof (FnPtr),
+	ptr = (FnPtr*)bsearch (name, functions, NFUNCTIONS, sizeof (FnPtr),
 			compare_names);
 
 	if (ptr == NULL) {
@@ -67,7 +69,7 @@ supportw_register_delegate (const char *function_name, void *fnptr)
 
 	g_return_val_if_fail (function_name && fnptr, FALSE);
 
-	ptr = bsearch (function_name, functions, NFUNCTIONS, sizeof (FnPtr),
+	ptr = (FnPtr*)bsearch (function_name, functions, NFUNCTIONS, sizeof (FnPtr),
 			compare_names);
 
 	if (ptr == NULL) {
@@ -186,3 +188,5 @@ GetWindowLongA (gpointer hwnd, int a)
 {
 	return 0;
 }
+
+G_END_DECLS

--- a/support/sys-mman.c
+++ b/support/sys-mman.c
@@ -143,7 +143,12 @@ Mono_Posix_Syscall_mincore (void *start, mph_size_t length, unsigned char *vec)
 #else
 	mph_return_if_size_t_overflow (length);
 
-	return mincore (start, (size_t) length, (char*)vec);
+#ifdef __linux__
+	typedef unsigned char T;
+#else
+	typedef char T;
+#endif
+	return mincore (start, (size_t) length, (T*)vec);
 #endif
 }
 

--- a/support/sys-mman.c
+++ b/support/sys-mman.c
@@ -143,7 +143,7 @@ Mono_Posix_Syscall_mincore (void *start, mph_size_t length, unsigned char *vec)
 #else
 	mph_return_if_size_t_overflow (length);
 
-	return mincore (start, (size_t) length, (void*)vec);
+	return mincore (start, (size_t) length, (char*)vec);
 #endif
 }
 

--- a/support/sys-socket.c
+++ b/support/sys-socket.c
@@ -333,11 +333,11 @@ Mono_Posix_ToSockaddr (void* source, gint64 size, struct Mono_Posix__SockaddrHea
     } else if (address->type == Mono_Posix_SockaddrType_SockaddrUn) { \
         /* Use alloca() for up to 2048 bytes, use malloc() otherwise */ \
         need_free = addrlen > 2048;                                     \
-        addr = need_free ? malloc (addrlen) : alloca (addrlen);         \
+        addr = (struct sockaddr*)(need_free ? malloc (addrlen) : alloca (addrlen)); \
         if (!addr)                                                      \
             return -1;                                                  \
     } else {                                                            \
-        addr = alloca (addrlen);                                        \
+        addr = (struct sockaddr*)alloca (addrlen);                      \
     }
 
 
@@ -654,6 +654,8 @@ Mono_Posix_Syscall_CMSG_LEN (guint64 length)
 	return CMSG_LEN (length);
 }
 #endif
+
+G_END_DECLS
 
 /*
  * vim: noexpandtab

--- a/support/sys-stat.c
+++ b/support/sys-stat.c
@@ -27,7 +27,7 @@ G_BEGIN_DECLS
 int
 Mono_Posix_FromStat (struct Mono_Posix_Stat *from, void *_to)
 {
-	struct stat *to = _to;
+	struct stat *to = (struct stat*)_to;
 	memset (to, 0, sizeof(*to));
 
 	to->st_dev         = from->st_dev;
@@ -75,7 +75,7 @@ Mono_Posix_FromStat (struct Mono_Posix_Stat *from, void *_to)
 int
 Mono_Posix_ToStat (void *_from, struct Mono_Posix_Stat *to)
 {
-	struct stat *from = _from;
+	struct stat *from = (struct stat*)_from;
 	memset (to, 0, sizeof(*to));
 
 	to->st_dev        = from->st_dev;

--- a/support/sys-statvfs.c
+++ b/support/sys-statvfs.c
@@ -41,7 +41,7 @@ G_BEGIN_DECLS
 int
 Mono_Posix_ToStatvfs (void *_from, struct Mono_Posix_Statvfs *to)
 {
-	struct statvfs *from = _from;
+	struct statvfs *from = (struct statvfs*)_from;
 
 	to->f_bsize   = from->f_bsize;
 	to->f_frsize  = from->f_frsize;
@@ -71,7 +71,7 @@ Mono_Posix_ToStatvfs (void *_from, struct Mono_Posix_Statvfs *to)
 int
 Mono_Posix_FromStatvfs (struct Mono_Posix_Statvfs *from, void *_to)
 {
-	struct statvfs *to = _to;
+	struct statvfs *to = (struct statvfs*)_to;
 	guint64 flag;
 
 	to->f_bsize   = from->f_bsize;
@@ -151,7 +151,7 @@ Mono_Posix_Syscall_fstatvfs (gint32 fd, struct Mono_Posix_Statvfs *buf)
 int
 Mono_Posix_ToStatvfs (void *_from, struct Mono_Posix_Statvfs *to)
 {
-	struct statfs *from = _from;
+	struct statfs *from = (struct statfs*)_from;
 
 	to->f_bsize   = from->f_bsize;
 	to->f_frsize  = from->f_bsize;
@@ -177,7 +177,7 @@ Mono_Posix_ToStatvfs (void *_from, struct Mono_Posix_Statvfs *to)
 int
 Mono_Posix_FromStatvfs (struct Mono_Posix_Statvfs *from, void *_to)
 {
-	struct statfs *to = _to;
+	struct statfs *to = (struct statfs*)_to;
 	guint64 flag;
 
 	to->f_bsize   = from->f_bsize;

--- a/support/sys-uio.c
+++ b/support/sys-uio.c
@@ -31,7 +31,7 @@ _mph_from_iovec_array (struct Mono_Posix_Iovec *iov, gint32 iovcnt)
 		return NULL;
 	}
 
-	v = malloc (iovcnt * sizeof (struct iovec));
+	v = (struct iovec*)malloc (iovcnt * sizeof (struct iovec));
 	if (!v) {
 		return NULL;
 	}
@@ -122,6 +122,7 @@ Mono_Posix_Syscall_pwritev (int dirfd, struct Mono_Posix_Iovec *iov, gint32 iovc
 }
 #endif /* def HAVE_PWRITEV */
 
+G_END_DECLS
 
 /*
  * vim: noexpandtab

--- a/support/trees.c
+++ b/support/trees.c
@@ -40,6 +40,10 @@
 #  include <ctype.h>
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ===========================================================================
  * Constants
  */
@@ -190,10 +194,10 @@ local void gen_trees_header OF((void));
 #ifdef DEBUG
 local void send_bits      OF((deflate_state *s, int value, int length));
 
-local void send_bits(s, value, length)
-    deflate_state *s;
-    int value;  /* value to send */
-    int length; /* number of bits */
+local void send_bits (
+    deflate_state *s,
+    int value,  /* value to send */
+    int length) /* number of bits */
 {
     Tracevv((stderr," l %2d v %4x ", length, value));
     Assert(length > 0 && length <= 15, "invalid length");
@@ -236,7 +240,7 @@ local void send_bits(s, value, length)
 /* ===========================================================================
  * Initialize the various 'constant' tables.
  */
-local void tr_static_init()
+local void tr_static_init (void)
 {
 #if defined(GEN_TREES_H) || !defined(STDC)
     static int static_init_done = 0;
@@ -383,8 +387,7 @@ void gen_trees_header()
 /* ===========================================================================
  * Initialize the tree data structures for a new zlib stream.
  */
-void ZLIB_INTERNAL _tr_init(s)
-    deflate_state *s;
+void ZLIB_INTERNAL _tr_init (deflate_state *s)
 {
     tr_static_init();
 
@@ -412,8 +415,7 @@ void ZLIB_INTERNAL _tr_init(s)
 /* ===========================================================================
  * Initialize a new block.
  */
-local void init_block(s)
-    deflate_state *s;
+local void init_block (deflate_state *s)
 {
     int n; /* iterates over tree elements */
 
@@ -456,10 +458,10 @@ local void init_block(s)
  * when the heap property is re-established (each father smaller than its
  * two sons).
  */
-local void pqdownheap(s, tree, k)
-    deflate_state *s;
-    ct_data *tree;  /* the tree to restore */
-    int k;               /* node to move down */
+local void pqdownheap (
+    deflate_state *s,
+    ct_data *tree,	/* the tree to restore */
+    int k)               /* node to move down */
 {
     int v = s->heap[k];
     int j = k << 1;  /* left son of k */
@@ -491,9 +493,9 @@ local void pqdownheap(s, tree, k)
  *     The length opt_len is updated; static_len is also updated if stree is
  *     not null.
  */
-local void gen_bitlen(s, desc)
-    deflate_state *s;
-    tree_desc *desc;    /* the tree descriptor */
+local void gen_bitlen (
+    deflate_state *s,
+    tree_desc *desc)    /* the tree descriptor */
 {
     ct_data *tree        = desc->dyn_tree;
     int max_code         = desc->max_code;
@@ -578,10 +580,10 @@ local void gen_bitlen(s, desc)
  * OUT assertion: the field code is set for all tree elements of non
  *     zero code length.
  */
-local void gen_codes (tree, max_code, bl_count)
-    ct_data *tree;             /* the tree to decorate */
-    int max_code;              /* largest code with non zero frequency */
-    ushf *bl_count;            /* number of codes at each bit length */
+local void gen_codes (
+    ct_data *tree,             /* the tree to decorate */
+    int max_code,              /* largest code with non zero frequency */
+    ushf *bl_count)            /* number of codes at each bit length */
 {
     ush next_code[MAX_BITS+1]; /* next code value for each bit length */
     ush code = 0;              /* running code value */
@@ -620,9 +622,9 @@ local void gen_codes (tree, max_code, bl_count)
  *     and corresponding code. The length opt_len is updated; static_len is
  *     also updated if stree is not null. The field max_code is set.
  */
-local void build_tree(s, desc)
-    deflate_state *s;
-    tree_desc *desc; /* the tree descriptor */
+local void build_tree (
+    deflate_state *s,
+    tree_desc *desc) /* the tree descriptor */
 {
     ct_data *tree         = desc->dyn_tree;
     const ct_data *stree  = desc->stat_desc->static_tree;
@@ -708,10 +710,10 @@ local void build_tree(s, desc)
  * Scan a literal or distance tree to determine the frequencies of the codes
  * in the bit length tree.
  */
-local void scan_tree (s, tree, max_code)
-    deflate_state *s;
-    ct_data *tree;   /* the tree to be scanned */
-    int max_code;    /* and its largest code of non zero frequency */
+local void scan_tree (
+    deflate_state *s,
+    ct_data *tree,   /* the tree to be scanned */
+    int max_code)    /* and its largest code of non zero frequency */
 {
     int n;                     /* iterates over all tree elements */
     int prevlen = -1;          /* last emitted length */
@@ -753,10 +755,10 @@ local void scan_tree (s, tree, max_code)
  * Send a literal or distance tree in compressed form, using the codes in
  * bl_tree.
  */
-local void send_tree (s, tree, max_code)
-    deflate_state *s;
-    ct_data *tree; /* the tree to be scanned */
-    int max_code;       /* and its largest code of non zero frequency */
+local void send_tree (
+    deflate_state *s,
+    ct_data *tree, /* the tree to be scanned */
+    int max_code)       /* and its largest code of non zero frequency */
 {
     int n;                     /* iterates over all tree elements */
     int prevlen = -1;          /* last emitted length */
@@ -804,8 +806,7 @@ local void send_tree (s, tree, max_code)
  * Construct the Huffman tree for the bit lengths and return the index in
  * bl_order of the last bit length code to send.
  */
-local int build_bl_tree(s)
-    deflate_state *s;
+local int build_bl_tree (deflate_state *s)
 {
     int max_blindex;  /* index of last bit length code of non zero freq */
 
@@ -839,9 +840,9 @@ local int build_bl_tree(s)
  * lengths of the bit length codes, the literal tree and the distance tree.
  * IN assertion: lcodes >= 257, dcodes >= 1, blcodes >= 4.
  */
-local void send_all_trees(s, lcodes, dcodes, blcodes)
-    deflate_state *s;
-    int lcodes, dcodes, blcodes; /* number of codes for each tree */
+local void send_all_trees (
+    deflate_state *s,
+    int lcodes, int dcodes, int blcodes) /* number of codes for each tree */
 {
     int rank;                    /* index in bl_order */
 
@@ -868,11 +869,11 @@ local void send_all_trees(s, lcodes, dcodes, blcodes)
 /* ===========================================================================
  * Send a stored block
  */
-void ZLIB_INTERNAL _tr_stored_block(s, buf, stored_len, last)
-    deflate_state *s;
-    charf *buf;       /* input block */
-    ulg stored_len;   /* length of input block */
-    int last;         /* one if this is the last block for a file */
+void ZLIB_INTERNAL _tr_stored_block (
+    deflate_state *s,
+    charf *buf,       /* input block */
+    ulg stored_len,   /* length of input block */
+    int last)         /* one if this is the last block for a file */
 {
     send_bits(s, (STORED_BLOCK<<1)+last, 3);    /* send block type */
 #ifdef DEBUG
@@ -893,8 +894,7 @@ void ZLIB_INTERNAL _tr_stored_block(s, buf, stored_len, last)
  * To simplify the code, we assume the worst case of last real code encoded
  * on one bit only.
  */
-void ZLIB_INTERNAL _tr_align(s)
-    deflate_state *s;
+void ZLIB_INTERNAL _tr_align (deflate_state *s)
 {
     send_bits(s, STATIC_TREES<<1, 3);
     send_code(s, END_BLOCK, static_ltree);
@@ -922,11 +922,11 @@ void ZLIB_INTERNAL _tr_align(s)
  * Determine the best encoding for the current block: dynamic trees, static
  * trees or store, and output the encoded block to the zip file.
  */
-void ZLIB_INTERNAL _tr_flush_block(s, buf, stored_len, last)
-    deflate_state *s;
-    charf *buf;       /* input block, or NULL if too old */
-    ulg stored_len;   /* length of input block */
-    int last;         /* one if this is the last block for a file */
+void ZLIB_INTERNAL _tr_flush_block (
+    deflate_state *s,
+    charf *buf,       /* input block, or NULL if too old */
+    ulg stored_len,   /* length of input block */
+    int last)         /* one if this is the last block for a file */
 {
     ulg opt_lenb, static_lenb; /* opt_len and static_len in bytes */
     int max_blindex = 0;  /* index of last bit length code of non zero freq */
@@ -1023,10 +1023,10 @@ void ZLIB_INTERNAL _tr_flush_block(s, buf, stored_len, last)
  * Save the match info and tally the frequency counts. Return true if
  * the current block must be flushed.
  */
-int ZLIB_INTERNAL _tr_tally (s, dist, lc)
-    deflate_state *s;
-    unsigned dist;  /* distance of matched string */
-    unsigned lc;    /* match length-MIN_MATCH or unmatched char (if dist==0) */
+int ZLIB_INTERNAL _tr_tally (
+    deflate_state *s,
+    unsigned dist,  /* distance of matched string */
+    unsigned lc)    /* match length-MIN_MATCH or unmatched char (if dist==0) */
 {
     s->d_buf[s->last_lit] = (ush)dist;
     s->l_buf[s->last_lit++] = (uch)lc;
@@ -1073,10 +1073,10 @@ int ZLIB_INTERNAL _tr_tally (s, dist, lc)
 /* ===========================================================================
  * Send the block data compressed using the given Huffman trees
  */
-local void compress_block(s, ltree, dtree)
-    deflate_state *s;
-    ct_data *ltree; /* literal tree */
-    ct_data *dtree; /* distance tree */
+local void compress_block (
+    deflate_state *s,
+    ct_data *ltree, /* literal tree */
+    ct_data *dtree) /* distance tree */
 {
     unsigned dist;      /* distance of matched string */
     int lc;             /* match length or unmatched char (if dist == 0) */
@@ -1134,8 +1134,7 @@ local void compress_block(s, ltree, dtree)
  *   (7 {BEL}, 8 {BS}, 11 {VT}, 12 {FF}, 26 {SUB}, 27 {ESC}).
  * IN assertion: the fields Freq of dyn_ltree are set.
  */
-local int detect_data_type(s)
-    deflate_state *s;
+local int detect_data_type (deflate_state *s)
 {
     /* black_mask is the bit mask of black-listed bytes
      * set bits 0..6, 14..25, and 28..31
@@ -1168,11 +1167,11 @@ local int detect_data_type(s)
  * method would use a table)
  * IN assertion: 1 <= len <= 15
  */
-local unsigned bi_reverse(code, len)
-    unsigned code; /* the value to invert */
-    int len;       /* its bit length */
+local unsigned bi_reverse (
+    unsigned code, /* the value to invert */
+    int len)       /* its bit length */
 {
-    register unsigned res = 0;
+    unsigned res = 0;
     do {
         res |= code & 1;
         code >>= 1, res <<= 1;
@@ -1183,8 +1182,7 @@ local unsigned bi_reverse(code, len)
 /* ===========================================================================
  * Flush the bit buffer, keeping at most 7 bits in it.
  */
-local void bi_flush(s)
-    deflate_state *s;
+local void bi_flush (deflate_state *s)
 {
     if (s->bi_valid == 16) {
         put_short(s, s->bi_buf);
@@ -1200,8 +1198,7 @@ local void bi_flush(s)
 /* ===========================================================================
  * Flush the bit buffer and align the output on a byte boundary
  */
-local void bi_windup(s)
-    deflate_state *s;
+local void bi_windup (deflate_state *s)
 {
     if (s->bi_valid > 8) {
         put_short(s, s->bi_buf);
@@ -1219,11 +1216,11 @@ local void bi_windup(s)
  * Copy a stored block, storing first the length and its
  * one's complement if requested.
  */
-local void copy_block(s, buf, len, header)
-    deflate_state *s;
-    charf    *buf;    /* the input data */
-    unsigned len;     /* its length */
-    int      header;  /* true if block header must be written */
+local void copy_block (
+    deflate_state *s,
+    charf    *buf,    /* the input data */
+    unsigned len,     /* its length */
+    int      header)  /* true if block header must be written */
 {
     bi_windup(s);        /* align on byte boundary */
     s->last_eob_len = 8; /* enough lookahead for inflate */
@@ -1242,3 +1239,7 @@ local void copy_block(s, buf, len, header)
         put_byte(s, *buf++);
     }
 }
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/support/uncompr.c
+++ b/support/uncompr.c
@@ -8,6 +8,10 @@
 #define ZLIB_INTERNAL
 #include "zlib.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* ===========================================================================
      Decompresses the source buffer into the destination buffer.  sourceLen is
    the byte length of the source buffer. Upon entry, destLen is the total
@@ -21,11 +25,7 @@
    enough memory, Z_BUF_ERROR if there was not enough room in the output
    buffer, or Z_DATA_ERROR if the input data was corrupted.
 */
-int ZEXPORT uncompress (dest, destLen, source, sourceLen)
-    Bytef *dest;
-    uLongf *destLen;
-    const Bytef *source;
-    uLong sourceLen;
+int ZEXPORT uncompress (Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen)
 {
     z_stream stream;
     int err;
@@ -57,3 +57,7 @@ int ZEXPORT uncompress (dest, destLen, source, sourceLen)
     err = inflateEnd(&stream);
     return err;
 }
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/support/x-struct-str.c
+++ b/support/x-struct-str.c
@@ -47,7 +47,7 @@ _mph_copy_structure_strings (
 			len[i] = -1;
 	}
 
-	cur = buf = malloc (buflen);
+	cur = buf = (char*)malloc (buflen);
 	if (buf == NULL) {
 		return NULL;
 	}
@@ -122,4 +122,3 @@ main ()
 	return 0;
 }
 #endif
-

--- a/support/zlib-helper.c
+++ b/support/zlib-helper.c
@@ -17,6 +17,8 @@
 #include <string.h>
 #include <stdlib.h>
 
+G_BEGIN_DECLS
+
 #ifndef MONO_API
 #define MONO_API
 #endif
@@ -251,3 +253,4 @@ WriteZStream (ZStream *stream, guchar *buffer, gint length)
 	return length;
 }
 
+G_END_DECLS

--- a/support/zutil.c
+++ b/support/zutil.c
@@ -7,6 +7,10 @@
 
 #include "zutil.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef NO_DUMMY_DECL
 struct internal_state      {int dummy;}; /* for buggy compilers */
 #endif
@@ -130,8 +134,7 @@ void ZLIB_INTERNAL z_error (m)
 /* exported to allow conversion of error code to string for compress() and
  * uncompress()
  */
-const char * ZEXPORT zError(err)
-    int err;
+const char * ZEXPORT zError (int err)
 {
     return ERR_MSG(err);
 }
@@ -146,10 +149,7 @@ const char * ZEXPORT zError(err)
 
 #ifndef HAVE_MEMCPY
 
-void ZLIB_INTERNAL zmemcpy(dest, source, len)
-    Bytef* dest;
-    const Bytef* source;
-    uInt  len;
+void ZLIB_INTERNAL zmemcpy (Bytef* dest, const Bytef* source, uInt len)
 {
     if (len == 0) return;
     do {
@@ -157,10 +157,7 @@ void ZLIB_INTERNAL zmemcpy(dest, source, len)
     } while (--len != 0);
 }
 
-int ZLIB_INTERNAL zmemcmp(s1, s2, len)
-    const Bytef* s1;
-    const Bytef* s2;
-    uInt  len;
+int ZLIB_INTERNAL zmemcmp (const Bytef* s1, const Bytef* s2, uInt len)
 {
     uInt j;
 
@@ -170,9 +167,7 @@ int ZLIB_INTERNAL zmemcmp(s1, s2, len)
     return 0;
 }
 
-void ZLIB_INTERNAL zmemzero(dest, len)
-    Bytef* dest;
-    uInt  len;
+void ZLIB_INTERNAL zmemzero (Bytef* dest, uInt len)
 {
     if (len == 0) return;
     do {
@@ -297,22 +292,21 @@ extern voidp  calloc OF((uInt items, uInt size));
 extern void   free   OF((voidpf ptr));
 #endif
 
-voidpf ZLIB_INTERNAL zcalloc (opaque, items, size)
-    voidpf opaque;
-    unsigned items;
-    unsigned size;
+voidpf ZLIB_INTERNAL zcalloc (voidpf opaque, unsigned items, unsigned size)
 {
     if (opaque) items += size - size; /* make compiler happy */
     return sizeof(uInt) > 2 ? (voidpf)malloc(items * size) :
                               (voidpf)calloc(items, size);
 }
 
-void ZLIB_INTERNAL zcfree (opaque, ptr)
-    voidpf opaque;
-    voidpf ptr;
+void ZLIB_INTERNAL zcfree (voidpf opaque, voidpf ptr)
 {
     free(ptr);
     if (opaque) return; /* make compiler happy */
 }
 
 #endif /* MY_ZCALLOC */
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/support/zutil.h
+++ b/support/zutil.h
@@ -29,6 +29,14 @@
 #  include <stdlib.h>
 #endif
 
+#ifdef DEBUG
+#  include <stdio.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef local
 #  define local static
 #endif
@@ -243,7 +251,6 @@ extern const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 
 /* Diagnostic functions */
 #ifdef DEBUG
-#  include <stdio.h>
    extern int ZLIB_INTERNAL z_verbose;
    extern void ZLIB_INTERNAL z_error OF((char *m));
 #  define Assert(cond,msg) {if(!(cond)) z_error(msg);}
@@ -270,5 +277,9 @@ void ZLIB_INTERNAL zcfree  OF((voidpf opaque, voidpf ptr));
            (*((strm)->zalloc))((strm)->opaque, (items), (size))
 #define ZFREE(strm, addr)  (*((strm)->zfree))((strm)->opaque, (voidpf)(addr))
 #define TRY_FREE(s, p) {if (p) ZFREE(s, p);}
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZUTIL_H */


### PR DESCRIPTION
and therefore leads to sprinkling or blanketing externC there.

This lets us cut down the externC in glib further.
Alternatively, only about four files in support use glib, those could be made
into a separate library.

Ideally some of the `void*` would be `FILE*` or `DIR*` or `void (*MonoSignalHandler)(int)`
but the .h file says not to edit, so `void*` remains.

Care/caution is taken also to mark pretty much everything as extern "C".
Much already was. nm used to verify.

Most of zlib here is not used on most platforms.
Consider compiling it anyway.
Makefile.am was temporarily hacked up for that purpose.
