### PR TITLE
Cleanup confusing code in Makefile.am.in. We don't compile/link "mono".

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -182,8 +182,6 @@ endif
 mono_boehm_SOURCES = \
 	main.c
 
-mono_CFLAGS = $(AM_CFLAGS) @CXX_REMOVE_CFLAGS@
-
 mono_boehm_CFLAGS = $(AM_CFLAGS) @CXX_REMOVE_CFLAGS@
 
 AM_CPPFLAGS = $(LIBGC_CPPFLAGS)
@@ -644,11 +642,10 @@ endif
 
 if MONO_JEMALLOC_ENABLED
 libmonoldflags += $(JEMALLOC_LDFLAGS)
-mono_CFLAGS += $(JEMALLOC_CFLAGS)
 endif
 
 libmono_ee_interp_la_SOURCES = $(interp_sources)
-libmono_ee_interp_la_CFLAGS = $(mono_CFLAGS) @CXX_ADD_CFLAGS@
+libmono_ee_interp_la_CFLAGS = $(AM_CFLAGS) @CXX_ADD_CFLAGS@
 if BITCODE
 libmono_ee_interp_la_LDFLAGS = $(libmonoldflags)
 if DISABLE_INTERPRETER
@@ -661,7 +658,7 @@ extra_libmono_dbg_source = debugger-engine.c
 endif
 
 libmono_dbg_la_SOURCES = debugger-agent.c debugger-state-machine.c $(extra_libmono_dbg_source)
-libmono_dbg_la_CFLAGS = $(mono_CFLAGS) @CXX_ADD_CFLAGS@
+libmono_dbg_la_CFLAGS = $(AM_CFLAGS) @CXX_ADD_CFLAGS@
 if BITCODE
 if DISABLE_DEBUGGER_AGENT
 libmono_dbg_la_LIBADD = libmonosgen-2.0.la
@@ -684,7 +681,7 @@ endif
 # compile time dependencies on boehm/sgen.
 #
 libmini_la_SOURCES = $(common_sources) $(llvm_sources) $(llvm_runtime_sources) $(arch_sources) $(os_sources)
-libmini_la_CFLAGS = $(mono_CFLAGS) @CXX_ADD_CFLAGS@
+libmini_la_CFLAGS = $(AM_CFLAGS) @CXX_ADD_CFLAGS@
 
 libmonoboehm_2_0_la_SOURCES =
 libmonoboehm_2_0_la_CFLAGS = $(mono_boehm_CFLAGS) @CXX_ADD_CFLAGS@


### PR DESCRIPTION
mono is a symlink.
So mono_CFLAGS is just an intermediate, equivalent to AM_CFLAGS, plus the "REMOVE_CXX_FLAGS", which is
 a mistake, borne of me thinking mono_CFLAGS is [primary=mono]_CFLAGS like it might appear, but it isn't.
AM_CFLAGS already contains JEMALLOC_CFLAGS.
Adding it to mono_CFLAGS isn't needed.
Adding @CXX_REMOVE_CFLAGS@ to mono_CFLAGS then was unintended, leading to many warnings  with g+4.4.
So this should fix those warnings and make the code just a tiny bit simpler.
