### PR TITLE
[cxx] Port mono main to  be C++, and externC some Windows exports

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -188,15 +188,11 @@ endif
 endif
 
 mono_boehm_SOURCES =
-
 mono_boehm_CFLAGS = $(AM_CFLAGS) @CXX_REMOVE_CFLAGS@
 
 AM_CPPFLAGS = $(LIBGC_CPPFLAGS)
 
 mono_sgen_SOURCES =
-
-mono_SOURCES =
-
 mono_sgen_CFLAGS = $(AM_CFLAGS) @CXX_REMOVE_CFLAGS@
 
 # We build this after libmono was built so it contains the date when the final
@@ -241,7 +237,7 @@ LLVMMONOF=$(LLVM_LIBS) $(LLVM_LDFLAGS)
 endif
 
 mono_boehm_LDADD = \
-	libmain_a-main.o 	\
+	libmain_a-main.$(OBJEXT) \
 	$(MONO_LIB)		\
 	$(glib_libs)		\
 	$(LLVMMONOF)		\
@@ -252,7 +248,7 @@ mono_boehm_LDFLAGS = \
 	$(static_flags) $(monobinldflags) $(monobin_platform_ldflags) 
 
 mono_sgen_LDADD = \
-	libmain_a-main-sgen.o 	\
+	libmain_a-main-sgen.$(OBJEXT) \
 	$(MONO_SGEN_LIB)	\
 	$(glib_libs)		\
 	$(LLVMMONOF)		\

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -169,6 +169,14 @@ endif
 
 noinst_LTLIBRARIES = $(mini_common_lib)
 
+noinst_LIBRARIES = libmain.a
+
+libmain_a_SOURCES = main-sgen.c
+if SUPPORT_BOEHM
+libmain_a_SOURCES += main.c
+endif
+libmain_a_CFLAGS = $(AM_CFLAGS) @CXX_ADD_CFLAGS@
+
 if LOADED_LLVM
 lib_LTLIBRARIES += libmono-llvm.la
 libmono_llvm_la_SOURCES = mini-llvm.c mini-llvm-cpp.cpp llvm-jit.cpp
@@ -179,22 +187,15 @@ libmono_llvm_la_LDFLAGS=-Wl,-undefined -Wl,suppress -Wl,-flat_namespace
 endif
 endif
 
-mono_boehm_SOURCES = \
-	main.c
-
-mono_CFLAGS = $(AM_CFLAGS) @CXX_REMOVE_CFLAGS@
+mono_boehm_SOURCES =
 
 mono_boehm_CFLAGS = $(AM_CFLAGS) @CXX_REMOVE_CFLAGS@
 
 AM_CPPFLAGS = $(LIBGC_CPPFLAGS)
 
-# These files are stuck as C for now, because -xc++
-# can only be used when compiling, not linking.
-mono_sgen_SOURCES = \
-	main-sgen.c
+mono_sgen_SOURCES =
 
-mono_SOURCES = \
-	main-sgen.c
+mono_SOURCES =
 
 mono_sgen_CFLAGS = $(AM_CFLAGS) @CXX_REMOVE_CFLAGS@
 
@@ -203,13 +204,13 @@ mono_sgen_CFLAGS = $(AM_CFLAGS) @CXX_REMOVE_CFLAGS@
 if SUPPORT_BOEHM
 buildver-boehm.h: libmini.la $(monodir)/mono/metadata/libmonoruntime.la
 	@echo "const char *build_date = \"`date`\";" > buildver-boehm.h
-mono_boehm-main.$(OBJEXT): buildver-boehm.h
+libmain_a-main.$(OBJEXT): buildver-boehm.h
 endif
 
 buildver-sgen.h: libmini.la $(monodir)/mono/metadata/libmonoruntimesgen.la $(monodir)/mono/sgen/libmonosgen.la
 	@echo "const char *build_date = \"`date`\";" > buildver-sgen.h
-mono_sgen-main-sgen.$(OBJEXT): buildver-sgen.h
-main-sgen.$(OBJEXT): buildver-sgen.h
+
+libmain_a-main-sgen.$(OBJEXT): buildver-sgen.h
 
 if DTRACE_G_REQUIRED
 LIBMONO_DTRACE_OBJECT = .libs/mono-dtrace.$(OBJEXT)
@@ -240,6 +241,7 @@ LLVMMONOF=$(LLVM_LIBS) $(LLVM_LDFLAGS)
 endif
 
 mono_boehm_LDADD = \
+	libmain_a-main.o 	\
 	$(MONO_LIB)		\
 	$(glib_libs)		\
 	$(LLVMMONOF)		\
@@ -250,6 +252,7 @@ mono_boehm_LDFLAGS = \
 	$(static_flags) $(monobinldflags) $(monobin_platform_ldflags) 
 
 mono_sgen_LDADD = \
+	libmain_a-main-sgen.o 	\
 	$(MONO_SGEN_LIB)	\
 	$(glib_libs)		\
 	$(LLVMMONOF)		\
@@ -644,11 +647,10 @@ endif
 
 if MONO_JEMALLOC_ENABLED
 libmonoldflags += $(JEMALLOC_LDFLAGS)
-mono_CFLAGS += $(JEMALLOC_CFLAGS)
 endif
 
 libmono_ee_interp_la_SOURCES = $(interp_sources)
-libmono_ee_interp_la_CFLAGS = $(mono_CFLAGS) @CXX_ADD_CFLAGS@
+libmono_ee_interp_la_CFLAGS = $(AM_CFLAGS) @CXX_ADD_CFLAGS@
 if BITCODE
 libmono_ee_interp_la_LDFLAGS = $(libmonoldflags)
 if DISABLE_INTERPRETER
@@ -661,7 +663,7 @@ extra_libmono_dbg_source = debugger-engine.c
 endif
 
 libmono_dbg_la_SOURCES = debugger-agent.c debugger-state-machine.c $(extra_libmono_dbg_source)
-libmono_dbg_la_CFLAGS = $(mono_CFLAGS) @CXX_ADD_CFLAGS@
+libmono_dbg_la_CFLAGS = $(AM_CFLAGS) @CXX_ADD_CFLAGS@
 if BITCODE
 if DISABLE_DEBUGGER_AGENT
 libmono_dbg_la_LIBADD = libmonosgen-2.0.la
@@ -684,7 +686,7 @@ endif
 # compile time dependencies on boehm/sgen.
 #
 libmini_la_SOURCES = $(common_sources) $(llvm_sources) $(llvm_runtime_sources) $(arch_sources) $(os_sources)
-libmini_la_CFLAGS = $(mono_CFLAGS) @CXX_ADD_CFLAGS@
+libmini_la_CFLAGS = $(AM_CFLAGS) @CXX_ADD_CFLAGS@
 
 libmonoboehm_2_0_la_SOURCES =
 libmonoboehm_2_0_la_CFLAGS = $(mono_boehm_CFLAGS) @CXX_ADD_CFLAGS@

--- a/mono/mini/mini-windows-dlldac.c
+++ b/mono/mini/mini-windows-dlldac.c
@@ -38,6 +38,7 @@ read_memory(PVOID user_context, LPCVOID base_address, PVOID buffer, SIZE_T size,
     return ReadProcessMemory ((HANDLE)user_context, base_address, buffer, size, read);
 }
 
+MONO_EXTERN_C
 MONO_API_EXPORT DWORD
 OutOfProcessFunctionTableCallbackEx (ReadMemoryFunction read_memory, PVOID user_context, PVOID table_address, PDWORD entries, PRUNTIME_FUNCTION *functions)
 {
@@ -65,6 +66,7 @@ OutOfProcessFunctionTableCallbackEx (ReadMemoryFunction read_memory, PVOID user_
 	return result;
 }
 
+MONO_EXTERN_C
 MONO_API_EXPORT DWORD
 OutOfProcessFunctionTableCallback (HANDLE process, PVOID table_address, PDWORD entries, PRUNTIME_FUNCTION *functions)
 {
@@ -73,6 +75,7 @@ OutOfProcessFunctionTableCallback (HANDLE process, PVOID table_address, PDWORD e
 #endif /* defined(TARGET_AMD64) && !defined(DISABLE_JIT) */
 
 #ifdef _MSC_VER
+MONO_EXTERN_C
 BOOL APIENTRY
 DllMain (HMODULE module_handle, DWORD reason, LPVOID reserved)
 {

--- a/mono/mini/mini-windows-dllmain.c
+++ b/mono/mini/mini-windows-dllmain.c
@@ -17,6 +17,7 @@
 #ifdef HOST_WIN32
 #include <windows.h>
 
+MONO_EXTERN_C
 BOOL APIENTRY DllMain (HMODULE module_handle, DWORD reason, LPVOID reserved)
 {
 	if (!mono_gc_dllmain (module_handle, reason, reserved))
@@ -39,4 +40,3 @@ BOOL APIENTRY DllMain (HMODULE module_handle, DWORD reason, LPVOID reserved)
 	return TRUE;
 }
 #endif
-


### PR DESCRIPTION
And overlaps with, so:
Cleanup confusing code in Makefile.am.ini. We don't compile/link "mono".
mono is a symlink.
So mono_CFLAGS is just an intermediate, equivalent to AM_CFLAGS, plus the "REMOVE_CXX_FLAGS", which is
a mistake, borne of me thinking mono_CFLAGS is [primary=mono]_CFLAGS like it might appear, but it isn't.
AM_CFLAGS already contains JEMALLOC_CFLAGS.
Adding it to mono_CFLAGS isn't needed.
Adding @CXX_REMOVE_CFLAGS@ to mono_CFLAGS then was unintended, leading to many warnings with g+4.4.
So this should fix those warnings and make the code just a tiny bit simpler.