### PR TITLE
Fix the bug with multiline TextBox which contains /t characters in the middle of text.

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Line.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Line.cs
@@ -528,7 +528,7 @@ namespace System.Windows.Forms
 					size = tag.SizeOfPosition (g, pos);
 					w = size.Width;
 					newWidth = widths[pos] + w;
-					add_width += w;
+					if (text[pos] == '\t') add_width += w;
 				}
 
 				if (Char.IsWhiteSpace (text[pos]))

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Line.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Line.cs
@@ -472,6 +472,7 @@ namespace System.Windows.Forms
 			int wrap_pos;
 			int prev_height;
 			int prev_ascent;
+			float add_width;
 
 			pos = 0;
 			len = this.text.Length;
@@ -493,6 +494,7 @@ namespace System.Windows.Forms
 			wrapped = false;
 
 			wrap_pos = 0;
+			add_width = 0;
 
 			while (pos < len) {
 
@@ -517,14 +519,16 @@ namespace System.Windows.Forms
 				{
 					// MeasureText doesn't measure trailing spaces, so we do the best we can for those
 					// in the else branch.
+					// It doesn't measure /t characters either, we need to add it manually with add_width.
 					size = TextBoxTextRenderer.MeasureText (g, text.ToString (0, pos + 1), tag.Font);
-					newWidth = widths[0] + size.Width;
+					newWidth = widths[0] + size.Width + add_width;
 				}
 				else
 				{
 					size = tag.SizeOfPosition (g, pos);
 					w = size.Width;
 					newWidth = widths[pos] + w;
+					add_width += w;
 				}
 
 				if (Char.IsWhiteSpace (text[pos]))


### PR DESCRIPTION
I don't know if there is a reported bug for that, I just found it and fixed it.

There is wrong cursor placement after the \t character. Example:

textBox1.Multiline = true;
textBox1.Text = "aa\taa\r\nbb\tbb\r\n";
Point pt = textBox1.GetPositionFromCharIndex(4); //pt.X is wrong for index 4 or any other char after \t in the line.





