### PR TITLE
[WIP] Micro baby steps towards making m2i modular.

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -431,6 +431,7 @@ common_sources = \
 	trace.c			\
 	trace.h			\
 	patch-info.h		\
+	method-state.h	\
 	mini-ops.h		\
 	mini-arch.h		\
 	dominators.c		\

--- a/mono/mini/method-state.h
+++ b/mono/mini/method-state.h
@@ -1,0 +1,69 @@
+#ifndef __MONO_METHOD_STATE_H__
+#define __MONO_METHOD_STATE_H__
+
+/*
+This struct tracks the state required by the front-end when translating a particular method body.
+When there's inlining, another PMS will be computed and used.
+
+BIG WARNING:
+DON'T USE fields tagged with internal, use the accessors down this file, pretty please.
+
+Notes:
+
+Right now it's all static inline methods in this header to ensure O2 can optimize the indirection through those functions.
+Maybe a better name could be PerMethodFrontEndData
+*/
+typedef struct {
+	//Skip visibility checks
+	gboolean skip_visibility : 1; /* internal */
+	//Skip JIT internal verification
+	gboolean dont_verify : 1; /* internal */
+	//Skip verification of stlic
+	gboolean dont_verify_stloc : 1; /* internal */
+} PerMethodState;
+
+
+static void
+pms_init (PerMethodState *pms, MonoDomain *domain, MonoMethod *method)
+{
+	pms->skip_visibility = method->skip_visibility;
+	/* serialization and xdomain stuff may need access to private fields and methods */
+	pms->dont_verify = m_class_get_image (method->klass)->assembly->corlib_internal? TRUE: FALSE;
+	pms->dont_verify |= method->wrapper_type == MONO_WRAPPER_XDOMAIN_INVOKE;
+	pms->dont_verify |= method->wrapper_type == MONO_WRAPPER_XDOMAIN_DISPATCH;
+ 	pms->dont_verify |= method->wrapper_type == MONO_WRAPPER_MANAGED_TO_NATIVE; /* bug #77896 */
+	pms->dont_verify |= method->wrapper_type == MONO_WRAPPER_COMINTEROP;
+	pms->dont_verify |= method->wrapper_type == MONO_WRAPPER_COMINTEROP_INVOKE;
+
+	/* still some type unsafety issues in marshal wrappers... (unknown is PtrToStructure) */
+	pms->dont_verify_stloc = method->wrapper_type == MONO_WRAPPER_MANAGED_TO_NATIVE;
+	pms->dont_verify_stloc |= method->wrapper_type == MONO_WRAPPER_UNKNOWN;
+	pms->dont_verify_stloc |= method->wrapper_type == MONO_WRAPPER_NATIVE_TO_MANAGED;
+	pms->dont_verify_stloc |= method->wrapper_type == MONO_WRAPPER_STELEMREF;
+
+	/* SkipVerification is not allowed if core-clr is enabled */
+	if (!pms->dont_verify && mini_assembly_can_skip_verification (domain, method)) {
+		pms->dont_verify = TRUE;
+		pms->dont_verify_stloc = TRUE;
+	}
+}
+
+static gboolean
+pms_should_skip_dead_blocks (PerMethodState *pms)
+{
+	return !pms->dont_verify;
+}
+
+static gboolean
+pms_verify_stloc (PerMethodState *pms)
+{
+	return !pms->dont_verify_stloc;
+}
+
+static gboolean
+pms_should_check_visiblity (PerMethodState *pms)
+{
+	return !pms->dont_verify && !pms->skip_visibility;
+}
+
+#endif

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -1028,7 +1028,7 @@ mini_method_verify (MonoCompile *cfg, MonoMethod *method, gboolean fail_compile)
 	/*skip verification implies the assembly must be */
 	is_fulltrust = mono_verifier_is_method_full_trust (method) ||  mini_assembly_can_skip_verification (cfg->domain, method);
 
-	res = mono_method_verify_with_current_settings (method, cfg->skip_visibility, is_fulltrust);
+	res = mono_method_verify_with_current_settings (method, method->skip_visibility, is_fulltrust);
 
 	if (res) { 
 		for (tmp = res; tmp; tmp = tmp->next) {
@@ -3158,7 +3158,6 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 	cfg->compile_aot = compile_aot;
 	cfg->full_aot = full_aot;
 	cfg->disable_omit_fp = mini_debug_options.disable_omit_fp;
-	cfg->skip_visibility = method->skip_visibility;
 	cfg->orig_method = method;
 	cfg->gen_seq_points = !mini_debug_options.no_seq_points_compact_data || mini_debug_options.gen_sdb_seq_points;
 	cfg->gen_sdb_seq_points = mini_debug_options.gen_sdb_seq_points;

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1330,7 +1330,6 @@ typedef struct {
 	guint            ret_var_is_local : 1;
 	guint            ret_var_set : 1;
 	guint            unverifiable : 1;
-	guint            skip_visibility : 1;
 	guint            disable_reuse_registers : 1;
 	guint            disable_reuse_stack_slots : 1;
 	guint            disable_reuse_ref_stack_slots : 1;


### PR DESCRIPTION
This PR is about exploring the space for improving modularity of the JIT.

It started with me trying to move the CEE_CALL code to a different file, but after adding the 15th argument to the signature it became clear we need other improvements first.

Our JIT needs more structure to its passes and analyzes with clear input/outputs. This means, among other things,
not storing temporary pass state in MonoCompile - method_to_ir does it, a lot.

This PR does some nano cleanup around that. I working to expand it to basic block formation, but that will require more than code shuffling as it requires a better representation for EH regions.

This commit series can be though of high-risk since it will touch the ugly spaguetti innards of the JIT.