### PR TITLE
[2018-06] [sdks] Allow for overwriting llvm-{llvm32,llvm64} CC and CXX

### DIFF
--- a/sdks/builds/llvm.mk
+++ b/sdks/builds/llvm.mk
@@ -27,6 +27,8 @@ _llvm-$(1)_LDFLAGS= \
 	$$(if $$(filter $$(UNAME),Darwin),-mmacosx-version-min=10.9)
 
 _llvm-$(1)_CONFIGURE_ENVIRONMENT= \
+	$$(if $$(llvm-$(1)_CC),CC="$$(llvm-$(1)_CC)") \
+	$$(if $$(llvm-$(1)_CXX),CXX="$$(llvm-$(1)_CXX)") \
 	CXXFLAGS="$$(_llvm-$(1)_CXXFLAGS)" \
 	LDFLAGS="$$(_llvm-$(1)_LDFLAGS)"
 


### PR DESCRIPTION
Part of https://github.com/mono/mono/pull/10300 that applies to `mono:2018-06`.