### PR TITLE
[cxx] Eliminate THREAD_INFO_TYPE by suggestion, to fix typesafe linkage. @monojenkins skip

### DIFF
--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -437,11 +437,11 @@ void mono_gc_register_altstack (gpointer stack, gint32 stack_size, gpointer alts
 
 gboolean mono_gc_is_critical_method (MonoMethod *method);
 
-gpointer mono_gc_thread_attach (THREAD_INFO_TYPE *info);
+gpointer mono_gc_thread_attach (MonoThreadInfo *info);
 
-void mono_gc_thread_detach_with_lock (THREAD_INFO_TYPE *info);
+void mono_gc_thread_detach_with_lock (MonoThreadInfo *info);
 
-gboolean mono_gc_thread_in_critical_region (THREAD_INFO_TYPE *info);
+gboolean mono_gc_thread_in_critical_region (MonoThreadInfo *info);
 
 /* If set, print debugging messages around finalizers. */
 extern gboolean mono_log_finalizers;

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -73,9 +73,9 @@ static gboolean
 ptr_on_stack (void *ptr)
 {
 	gpointer stack_start = &stack_start;
-	SgenThreadInfo *info = mono_thread_info_current ();
+	MonoThreadInfo *info = mono_thread_info_current ();
 
-	if (ptr >= stack_start && ptr < (gpointer)info->client_info.info.stack_end)
+	if (ptr >= stack_start && ptr < (gpointer)info->stack_end)
 		return TRUE;
 	return FALSE;
 }
@@ -836,7 +836,7 @@ mono_gc_clear_domain (MonoDomain * domain)
 	sgen_clear_nursery_fragments ();
 
 	FOREACH_THREAD_ALL (info) {
-		mono_handle_stack_free_domain ((HandleStack*)info->client_info.info.handle_stack, domain);
+		mono_handle_stack_free_domain ((HandleStack*)info->handle_stack, domain);
 	} FOREACH_THREAD_END
 
 	if (sgen_mono_xdomain_checks && domain != mono_get_root_domain ()) {
@@ -1638,19 +1638,20 @@ static void
 report_stack_roots (void)
 {
 	GCRootReport report = {0};
-	FOREACH_THREAD_EXCLUDE (info, MONO_THREAD_INFO_FLAGS_NO_GC) {
+	FOREACH_THREAD_EXCLUDE (mono_thread_info, MONO_THREAD_INFO_FLAGS_NO_GC) {
+		SgenThreadInfo *info = (SgenThreadInfo*)mono_thread_info;
 		void *aligned_stack_start;
 
 		if (info->client_info.skip) {
 			continue;
-		} else if (!mono_thread_info_is_live (info)) {
+		} else if (!mono_thread_info_is_live (mono_thread_info)) {
 			continue;
 		} else if (!info->client_info.stack_start) {
 			continue;
 		}
 
 		g_assert (info->client_info.stack_start);
-		g_assert (info->client_info.info.stack_end);
+		g_assert (mono_thread_info->stack_end);
 
 		aligned_stack_start = (void*)(mword) ALIGN_TO ((mword)info->client_info.stack_start, SIZEOF_VOID_P);
 #ifdef HOST_WIN32
@@ -1671,7 +1672,7 @@ report_stack_roots (void)
 
 		g_assert (info->client_info.suspend_done);
 
-		report_conservative_roots (&report, aligned_stack_start, (void **)aligned_stack_start, (void **)info->client_info.info.stack_end);
+		report_conservative_roots (&report, aligned_stack_start, (void **)aligned_stack_start, (void **)mono_thread_info->stack_end);
 		report_conservative_roots (&report, aligned_stack_start, (void**)&info->client_info.ctx, (void**)(&info->client_info.ctx + 1));
 
 		report_handle_stack_roots (&report, info, FALSE);
@@ -2002,15 +2003,16 @@ mono_gc_get_gc_callbacks ()
 }
 
 gpointer
-mono_gc_thread_attach (SgenThreadInfo *info)
+mono_gc_thread_attach (MonoThreadInfo *info)
 {
-	return sgen_thread_attach (info);
+	return sgen_thread_attach ((SgenThreadInfo*)info);
 }
 
 void
 sgen_client_thread_attach (SgenThreadInfo* info)
 {
-	mono_tls_set_sgen_thread_info (info);
+	MonoThreadInfo *mono_thread_info = &info->client_info.info;
+	mono_tls_set_sgen_thread_info (mono_thread_info);
 
 	info->client_info.skip = FALSE;
 
@@ -2026,29 +2028,30 @@ sgen_client_thread_attach (SgenThreadInfo* info)
 	if (mono_gc_get_gc_callbacks ()->thread_attach_func)
 		info->client_info.runtime_data = mono_gc_get_gc_callbacks ()->thread_attach_func ();
 
-	sgen_binary_protocol_thread_register ((gpointer)mono_thread_info_get_tid (info));
+	sgen_binary_protocol_thread_register ((gpointer)mono_thread_info_get_tid (mono_thread_info));
 
-	SGEN_LOG (3, "registered thread %p (%p) stack end %p", info, (gpointer)mono_thread_info_get_tid (info), info->client_info.info.stack_end);
+	SGEN_LOG (3, "registered thread %p (%p) stack end %p", info, (gpointer)mono_thread_info_get_tid (mono_thread_info), mono_thread_info->stack_end);
 
-	info->client_info.info.handle_stack = mono_handle_stack_alloc ();
+	mono_thread_info->handle_stack = mono_handle_stack_alloc ();
 }
 
 void
-mono_gc_thread_detach_with_lock (SgenThreadInfo *info)
+mono_gc_thread_detach_with_lock (MonoThreadInfo *info)
 {
-	return sgen_thread_detach_with_lock (info);
+	return sgen_thread_detach_with_lock ((SgenThreadInfo*)info);
 }
 
 void
 sgen_client_thread_detach_with_lock (SgenThreadInfo *p)
 {
+	MonoThreadInfo *mono_thread_info = &p->client_info.info;
 	MonoNativeThreadId tid;
 
 	mono_tls_set_sgen_thread_info (NULL);
 
-	tid = mono_thread_info_get_tid (p);
+	tid = mono_thread_info_get_tid (mono_thread_info);
 
-	mono_threads_add_joinable_runtime_thread (&p->client_info.info);
+	mono_threads_add_joinable_runtime_thread (mono_thread_info);
 
 	if (mono_gc_get_gc_callbacks ()->thread_detach_func) {
 		mono_gc_get_gc_callbacks ()->thread_detach_func (p->client_info.runtime_data);
@@ -2058,8 +2061,8 @@ sgen_client_thread_detach_with_lock (SgenThreadInfo *p)
 	sgen_binary_protocol_thread_unregister ((gpointer)tid);
 	SGEN_LOG (3, "unregister thread %p (%p)", p, (gpointer)tid);
 
-	HandleStack *handles = (HandleStack*) p->client_info.info.handle_stack;
-	p->client_info.info.handle_stack = NULL;
+	HandleStack *handles = (HandleStack*) mono_thread_info->handle_stack;
+	mono_thread_info->handle_stack = NULL;
 	mono_handle_stack_free (handles);
 }
 
@@ -2079,7 +2082,7 @@ mono_gc_skip_thread_changing (gboolean skip)
 		 * If we skip scanning a thread with a non-empty handle stack, we may move an
 		 * object but fail to update the reference in the handle.
 		 */
-		HandleStack *stack = mono_thread_info_current ()->client_info.info.handle_stack;
+		HandleStack *stack = (HandleStack*)mono_thread_info_current ()->handle_stack;
 		g_assert (stack == NULL || mono_handle_stack_is_empty (stack));
 	}
 }
@@ -2091,8 +2094,9 @@ mono_gc_skip_thread_changed (gboolean skip)
 }
 
 gboolean
-mono_gc_thread_in_critical_region (SgenThreadInfo *info)
+mono_gc_thread_in_critical_region (MonoThreadInfo *mono_thread_info)
 {
+	SgenThreadInfo *info = (SgenThreadInfo*)mono_thread_info;
 	return info->client_info.in_critical_region;
 }
 
@@ -2162,22 +2166,23 @@ sgen_client_scan_thread_data (void *start_nursery, void *end_nursery, gboolean p
 	return;
 #endif
 
-	FOREACH_THREAD_EXCLUDE (info, MONO_THREAD_INFO_FLAGS_NO_GC) {
+	FOREACH_THREAD_EXCLUDE (mono_thread_info, MONO_THREAD_INFO_FLAGS_NO_GC) {
+		SgenThreadInfo *info = (SgenThreadInfo*)mono_thread_info;
 		int skip_reason = 0;
 		void *aligned_stack_start;
 
 		if (info->client_info.skip) {
-			SGEN_LOG (3, "Skipping dead thread %p, range: %p-%p, size: %zd", info, info->client_info.stack_start, info->client_info.info.stack_end, (char*)info->client_info.info.stack_end - (char*)info->client_info.stack_start);
+			SGEN_LOG (3, "Skipping dead thread %p, range: %p-%p, size: %zd", info, info->client_info.stack_start, mono_thread_info->stack_end, (char*)mono_thread_info->stack_end - (char*)info->client_info.stack_start);
 			skip_reason = 1;
-		} else if (!mono_thread_info_is_live (info)) {
-			SGEN_LOG (3, "Skipping non-running thread %p, range: %p-%p, size: %zd (state %x)", info, info->client_info.stack_start, info->client_info.info.stack_end, (char*)info->client_info.info.stack_end - (char*)info->client_info.stack_start, info->client_info.info.thread_state);
+		} else if (!mono_thread_info_is_live (mono_thread_info)) {
+			SGEN_LOG (3, "Skipping non-running thread %p, range: %p-%p, size: %zd (state %x)", info, info->client_info.stack_start, mono_thread_info->stack_end, (char*)mono_thread_info->stack_end - (char*)info->client_info.stack_start, info->client_info.info.thread_state);
 			skip_reason = 3;
 		} else if (!info->client_info.stack_start) {
 			SGEN_LOG (3, "Skipping starting or detaching thread %p", info);
 			skip_reason = 4;
 		}
 
-		sgen_binary_protocol_scan_stack ((gpointer)mono_thread_info_get_tid (info), info->client_info.stack_start, info->client_info.info.stack_end, skip_reason);
+		sgen_binary_protocol_scan_stack ((gpointer)mono_thread_info_get_tid (mono_thread_info), info->client_info.stack_start, mono_thread_info->stack_end, skip_reason);
 
 		if (skip_reason) {
 			if (precise) {
@@ -2185,14 +2190,14 @@ sgen_client_scan_thread_data (void *start_nursery, void *end_nursery, gboolean p
 				 * resumes running we may potentially move an object but fail to
 				 * update the reference in the handle.
 				 */
-				HandleStack *stack = info->client_info.info.handle_stack;
+				HandleStack *stack = mono_thread_info->handle_stack;
 				g_assert (stack == NULL || mono_handle_stack_is_empty (stack));
 			}
 			continue;
 		}
 
 		g_assert (info->client_info.stack_start);
-		g_assert (info->client_info.info.stack_end);
+		g_assert (mono_thread_info->stack_end);
 
 		aligned_stack_start = (void*)(mword) ALIGN_TO ((mword)info->client_info.stack_start, SIZEOF_VOID_P);
 #ifdef HOST_WIN32
@@ -2212,16 +2217,16 @@ sgen_client_scan_thread_data (void *start_nursery, void *end_nursery, gboolean p
 #endif
 
 		g_assert (info->client_info.suspend_done);
-		SGEN_LOG (3, "Scanning thread %p, range: %p-%p, size: %zd, pinned=%zd", info, info->client_info.stack_start, info->client_info.info.stack_end, (char*)info->client_info.info.stack_end - (char*)info->client_info.stack_start, sgen_get_pinned_count ());
+		SGEN_LOG (3, "Scanning thread %p, range: %p-%p, size: %zd, pinned=%zd", info, info->client_info.stack_start, mono_thread_info->stack_end, (char*)mono_thread_info->stack_end - (char*)info->client_info.stack_start, sgen_get_pinned_count ());
 		if (mono_gc_get_gc_callbacks ()->thread_mark_func && !conservative_stack_mark) {
-			mono_gc_get_gc_callbacks ()->thread_mark_func (info->client_info.runtime_data, (guint8 *)aligned_stack_start, (guint8 *)info->client_info.info.stack_end, precise, &ctx);
+			mono_gc_get_gc_callbacks ()->thread_mark_func (info->client_info.runtime_data, (guint8 *)aligned_stack_start, (guint8 *)mono_thread_info->stack_end, precise, &ctx);
 		} else if (!precise) {
 			if (!conservative_stack_mark) {
 				fprintf (stderr, "Precise stack mark not supported - disabling.\n");
 				conservative_stack_mark = TRUE;
 			}
 			//FIXME we should eventually use the new stack_mark from coop
-			sgen_conservatively_pin_objects_from ((void **)aligned_stack_start, (void **)info->client_info.info.stack_end, start_nursery, end_nursery, PIN_TYPE_STACK);
+			sgen_conservatively_pin_objects_from ((void **)aligned_stack_start, (void **)mono_thread_info->stack_end, start_nursery, end_nursery, PIN_TYPE_STACK);
 		}
 
 		if (!precise) {
@@ -2231,7 +2236,7 @@ sgen_client_scan_thread_data (void *start_nursery, void *end_nursery, gboolean p
 			{
 				// This is used on Coop GC for platforms where we cannot get the data for individual registers.
 				// We force a spill of all registers into the stack and pass a chunk of data into sgen.
-				//FIXME under coop, for now, what we need to ensure is that we scan any extra memory from info->client_info.info.stack_end to stack_mark
+				//FIXME under coop, for now, what we need to ensure is that we scan any extra memory from mono_thread_info->stack_end to stack_mark
 				MonoThreadUnwindState *state = &info->client_info.info.thread_saved_state [SELF_SUSPEND_STATE_INDEX];
 				if (state && state->gc_stackdata) {
 					sgen_conservatively_pin_objects_from ((void **)state->gc_stackdata, (void**)((char*)state->gc_stackdata + state->gc_stackdata_size),
@@ -2253,7 +2258,7 @@ sgen_client_scan_thread_data (void *start_nursery, void *end_nursery, gboolean p
 				memset (&ud, 0, sizeof (ud));
 				ud.start_nursery = (void**)start_nursery;
 				ud.end_nursery = (void**)end_nursery;
-				mono_handle_stack_scan ((HandleStack*)info->client_info.info.handle_stack, pin_handle_stack_interior_ptrs, &ud, precise, FALSE);
+				mono_handle_stack_scan ((HandleStack*)mono_thread_info->handle_stack, pin_handle_stack_interior_ptrs, &ud, precise, FALSE);
 			}
 		}
 	} FOREACH_THREAD_END
@@ -2268,13 +2273,13 @@ sgen_client_scan_thread_data (void *start_nursery, void *end_nursery, gboolean p
 void
 mono_gc_set_stack_end (void *stack_end)
 {
-	SgenThreadInfo *info;
+	MonoThreadInfo *info;
 
 	LOCK_GC;
 	info = mono_thread_info_current ();
 	if (info) {
-		SGEN_ASSERT (0, stack_end < info->client_info.info.stack_end, "Can only lower stack end");
-		info->client_info.info.stack_end = stack_end;
+		SGEN_ASSERT (0, stack_end < info->stack_end, "Can only lower stack end");
+		info->stack_end = stack_end;
 	}
 	UNLOCK_GC;
 }

--- a/mono/sgen/sgen-alloc.c
+++ b/mono/sgen/sgen-alloc.c
@@ -477,7 +477,8 @@ sgen_alloc_obj_mature (GCVTable vtable, size_t size)
 void
 sgen_clear_tlabs (void)
 {
-	FOREACH_THREAD_ALL (info) {
+	FOREACH_THREAD_ALL (mono_thread_info) {
+		SgenThreadInfo *info = (SgenThreadInfo*)mono_thread_info;
 		/* A new TLAB will be allocated when the thread does its first allocation */
 		info->tlab_start = NULL;
 		info->tlab_next = NULL;

--- a/mono/sgen/sgen-debug.c
+++ b/mono/sgen/sgen-debug.c
@@ -501,14 +501,15 @@ find_pinning_ref_from_thread (char *obj, size_t size)
 #ifndef SGEN_WITHOUT_MONO
 	char *endobj = obj + size;
 
-	FOREACH_THREAD_EXCLUDE (info, MONO_THREAD_INFO_FLAGS_NO_GC) {
+	FOREACH_THREAD_EXCLUDE (mono_thread_info, MONO_THREAD_INFO_FLAGS_NO_GC) {
+		SgenThreadInfo *info = (SgenThreadInfo*)mono_thread_info;
 		mword *ctxstart, *ctxcurrent, *ctxend;
 		char **start = (char**)info->client_info.stack_start;
 		if (info->client_info.skip)
 			continue;
 		while (start < (char**)info->client_info.info.stack_end) {
 			if (*start >= obj && *start < endobj)
-				SGEN_LOG (0, "Object %p referenced in thread %p (id %p) at %p, stack: %p-%p", obj, info, (gpointer)mono_thread_info_get_tid (info), start, info->client_info.stack_start, info->client_info.info.stack_end);
+				SGEN_LOG (0, "Object %p referenced in thread %p (id %p) at %p, stack: %p-%p", obj, info, (gpointer)mono_thread_info_get_tid (&info->client_info.info), start, info->client_info.stack_start, mono_thread_info->stack_end);
 			start++;
 		}
 
@@ -516,7 +517,7 @@ find_pinning_ref_from_thread (char *obj, size_t size)
 			mword w = *ctxcurrent;
 
 			if (w >= (mword)obj && w < (mword)obj + size)
-				SGEN_LOG (0, "Object %p referenced in saved reg %d of thread %p (id %p)", obj, (int) (ctxcurrent - ctxstart), info, (gpointer)mono_thread_info_get_tid (info));
+				SGEN_LOG (0, "Object %p referenced in saved reg %d of thread %p (id %p)", obj, (int) (ctxcurrent - ctxstart), info, (gpointer)mono_thread_info_get_tid (&info->client_info.info));
 		}
 	} FOREACH_THREAD_END
 #endif

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -18,8 +18,6 @@
 #ifdef HAVE_SGEN_GC
 
 typedef struct _SgenThreadInfo SgenThreadInfo;
-#undef THREAD_INFO_TYPE
-#define THREAD_INFO_TYPE SgenThreadInfo
 
 #include <glib.h>
 #include <stdio.h>

--- a/mono/utils/checked-build.c
+++ b/mono/utils/checked-build.c
@@ -282,7 +282,7 @@ translate_backtrace (gpointer native_trace[], int size)
 #endif
 
 void
-checked_build_thread_transition (const char *transition, void *info, int from_state, int suspend_count, int next_state, int suspend_count_delta, gboolean capture_backtrace)
+checked_build_thread_transition (const char *transition, MonoThreadInfo *info, int from_state, int suspend_count, int next_state, int suspend_count_delta, gboolean capture_backtrace)
 {
 	if (!mono_check_mode_enabled (MONO_CHECK_MODE_THREAD))
 		return;

--- a/mono/utils/checked-build.h
+++ b/mono/utils/checked-build.h
@@ -213,7 +213,9 @@ void check_metadata_store_local(void *from, void *to);
 		checked_build_thread_transition (transition, info, from_state, suspend_count, next_state, suspend_count_delta, FALSE); \
 } while (0)
 
-void checked_build_thread_transition(const char *transition, void *info, int from_state, int suspend_count, int next_state, int suspend_count_delta, gboolean capture_backtrace);
+struct _MonoThreadInfo;
+
+void checked_build_thread_transition(const char *transition, struct _MonoThreadInfo *info, int from_state, int suspend_count, int next_state, int suspend_count_delta, gboolean capture_backtrace);
 
 G_GNUC_NORETURN MONO_ATTR_FORMAT_PRINTF(1,2) void mono_fatal_with_history(const char *msg, ...);
 

--- a/mono/utils/mono-threads-coop.c
+++ b/mono/utils/mono-threads-coop.c
@@ -363,7 +363,7 @@ mono_threads_enter_gc_unsafe_region (gpointer *stackpointer)
 }
 
 gpointer
-mono_threads_enter_gc_unsafe_region_with_info (THREAD_INFO_TYPE *info, MonoStackData *stackdata)
+mono_threads_enter_gc_unsafe_region_with_info (MonoThreadInfo *info, MonoStackData *stackdata)
 {
 	gpointer cookie;
 

--- a/mono/utils/mono-threads-coop.h
+++ b/mono/utils/mono-threads-coop.h
@@ -72,10 +72,10 @@ void mono_threads_suspend_override_policy (MonoThreadsSuspendPolicy new_policy);
  */
 
 gpointer
-mono_threads_enter_gc_safe_region_with_info (THREAD_INFO_TYPE *info, MonoStackData *stackdata);
+mono_threads_enter_gc_safe_region_with_info (MonoThreadInfo *info, MonoStackData *stackdata);
 
 gpointer
-mono_threads_enter_gc_safe_region_with_info (THREAD_INFO_TYPE *info, MonoStackData *stackdata);
+mono_threads_enter_gc_safe_region_with_info (MonoThreadInfo *info, MonoStackData *stackdata);
 
 #define MONO_ENTER_GC_SAFE_WITH_INFO(info)	\
 	do {	\
@@ -85,10 +85,10 @@ mono_threads_enter_gc_safe_region_with_info (THREAD_INFO_TYPE *info, MonoStackDa
 #define MONO_EXIT_GC_SAFE_WITH_INFO	MONO_EXIT_GC_SAFE
 
 gpointer
-mono_threads_enter_gc_unsafe_region_with_info (THREAD_INFO_TYPE *, MonoStackData *stackdata);
+mono_threads_enter_gc_unsafe_region_with_info (MonoThreadInfo *, MonoStackData *stackdata);
 
 gpointer
-mono_threads_enter_gc_unsafe_region_with_info (THREAD_INFO_TYPE *, MonoStackData *stackdata);
+mono_threads_enter_gc_unsafe_region_with_info (MonoThreadInfo *, MonoStackData *stackdata);
 
 #define MONO_ENTER_GC_UNSAFE_WITH_INFO(info)	\
 	do {	\
@@ -98,7 +98,7 @@ mono_threads_enter_gc_unsafe_region_with_info (THREAD_INFO_TYPE *, MonoStackData
 #define MONO_EXIT_GC_UNSAFE_WITH_INFO	MONO_EXIT_GC_UNSAFE
 
 gpointer
-mono_threads_enter_gc_unsafe_region_unbalanced_with_info (THREAD_INFO_TYPE *info, MonoStackData *stackdata);
+mono_threads_enter_gc_unsafe_region_unbalanced_with_info (MonoThreadInfo *info, MonoStackData *stackdata);
 
 G_END_DECLS
 

--- a/mono/utils/mono-threads-state-machine.c
+++ b/mono/utils/mono-threads-state-machine.c
@@ -613,7 +613,7 @@ It returns one of:
 -Wait: Blocking state successfully aborted, there's a pending suspend to be processed though, wait for resume.
 */
 MonoAbortBlockingResult
-mono_threads_transition_abort_blocking (THREAD_INFO_TYPE* info, const char *func)
+mono_threads_transition_abort_blocking (MonoThreadInfo* info, const char *func)
 {
 	int raw_state, cur_state, suspend_count;
 

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -78,7 +78,7 @@ static size_t pending_suspends;
 
 static mono_mutex_t join_mutex;
 
-#define mono_thread_info_run_state(info) (((MonoThreadInfo*)info)->thread_state & THREAD_STATE_MASK)
+#define mono_thread_info_run_state(info) (info->thread_state & THREAD_STATE_MASK)
 
 /*warn at 50 ms*/
 #define SLEEP_DURATION_BEFORE_WARNING (50)
@@ -738,7 +738,7 @@ mono_thread_info_set_internal_thread_gchandle (MonoThreadInfo *info, guint32 gch
 }
 
 void
-mono_thread_info_unset_internal_thread_gchandle (THREAD_INFO_TYPE *info)
+mono_thread_info_unset_internal_thread_gchandle (MonoThreadInfo *info)
 {
 	g_assert (info);
 	g_assert (mono_thread_info_is_current (info));
@@ -1662,9 +1662,9 @@ mono_thread_info_usleep (guint64 us)
 }
 
 gpointer
-mono_thread_info_tls_get (THREAD_INFO_TYPE *info, MonoTlsKey key)
+mono_thread_info_tls_get (MonoThreadInfo *info, MonoTlsKey key)
 {
-	return ((MonoThreadInfo*)info)->tls [key];
+	return info->tls [key];
 }
 
 /*
@@ -1676,9 +1676,9 @@ mono_thread_info_tls_get (THREAD_INFO_TYPE *info, MonoTlsKey key)
  * be paired with setting the real TLS variable since this provides no GC tracking.
  */
 void
-mono_thread_info_tls_set (THREAD_INFO_TYPE *info, MonoTlsKey key, gpointer value)
+mono_thread_info_tls_set (MonoThreadInfo *info, MonoTlsKey key, gpointer value)
 {
-	((MonoThreadInfo*)info)->tls [key] = value;
+	info->tls [key] = value;
 }
 
 /*

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -80,32 +80,6 @@ typedef struct {
 	MonoOSEvent event;
 } MonoThreadHandle;
 
-/*
-THREAD_INFO_TYPE is a way to make the mono-threads module parametric - or sort of.
-The GC using mono-threads might extend the MonoThreadInfo struct to add its own
-data, this avoid a pointer indirection on what is on a lot of hot paths.
-
-But extending MonoThreadInfo has de disavantage that all functions here return type
-would require a cast, something like the following:
-
-typedef struct {
-	MonoThreadInfo info;
-	int stuff;
-}  MyThreadInfo;
-
-...
-((MyThreadInfo*)mono_thread_info_current ())->stuff = 1;
-
-While porting sgen to use mono-threads, the number of casts required was too much and
-code ended up looking horrible. So we use this cute little hack. The idea is that
-whomever is including this header can set the expected type to be used by functions here
-and reduce the number of casts drastically.
-
-*/
-#ifndef THREAD_INFO_TYPE
-#define THREAD_INFO_TYPE MonoThreadInfo
-#endif
-
 /* Mono Threads internal configuration knows*/
 
 /* If this is defined, use the signals backed on Mach. Debug only as signals can't be made usable on OSX. */
@@ -278,7 +252,7 @@ typedef struct _MonoThreadInfo {
 } MonoThreadInfo;
 
 typedef struct {
-	void* (*thread_attach)(THREAD_INFO_TYPE *info);
+	void* (*thread_attach)(MonoThreadInfo *info);
 	/*
 	This callback is called right before thread_detach_with_lock. This is called
 	without any locks held so it's the place for complicated cleanup.
@@ -286,15 +260,15 @@ typedef struct {
 	The thread must remain operational between this call and thread_detach_with_lock.
 	It must be possible to successfully suspend it after thread_detach completes.
 	*/
-	void (*thread_detach)(THREAD_INFO_TYPE *info);
+	void (*thread_detach)(MonoThreadInfo *info);
 	/*
 	This callback is called with @info still on the thread list.
 	This call is made while holding the suspend lock, so don't do callbacks.
 	SMR remains functional as its small_id has not been reclaimed.
 	*/
-	void (*thread_detach_with_lock)(THREAD_INFO_TYPE *info);
+	void (*thread_detach_with_lock)(MonoThreadInfo *info);
 	gboolean (*ip_in_critical_region) (MonoDomain *domain, gpointer ip);
-	gboolean (*thread_in_critical_region) (THREAD_INFO_TYPE *info);
+	gboolean (*thread_in_critical_region) (MonoThreadInfo *info);
 
 	// Called on the affected thread.
 	void (*thread_flags_changing) (MonoThreadInfoFlags old, MonoThreadInfoFlags new_);
@@ -314,10 +288,10 @@ typedef enum {
 	KeepSuspended = 0x4321,
 } SuspendThreadResult;
 
-typedef SuspendThreadResult (*MonoSuspendThreadCallback) (THREAD_INFO_TYPE *info, gpointer user_data);
+typedef SuspendThreadResult (*MonoSuspendThreadCallback) (MonoThreadInfo *info, gpointer user_data);
 
 MONO_API MonoThreadInfoFlags
-mono_thread_info_get_flags (THREAD_INFO_TYPE *info);
+mono_thread_info_get_flags (MonoThreadInfo *info);
 
 /*
  * Sets the thread info flags for the current thread. This function may invoke
@@ -328,7 +302,7 @@ MONO_API void
 mono_thread_info_set_flags (MonoThreadInfoFlags flags);
 
 static inline gboolean
-mono_threads_filter_exclude_flags (THREAD_INFO_TYPE *info, MonoThreadInfoFlags flags)
+mono_threads_filter_exclude_flags (MonoThreadInfo *info, MonoThreadInfoFlags flags)
 {
 	return !(mono_thread_info_get_flags (info) & flags);
 }
@@ -336,10 +310,10 @@ mono_threads_filter_exclude_flags (THREAD_INFO_TYPE *info, MonoThreadInfoFlags f
 /* Normal iteration; requires the world to be stopped. */
 
 #define FOREACH_THREAD_ALL(thread) \
-	MONO_LLS_FOREACH_FILTERED (mono_thread_info_list_head (), THREAD_INFO_TYPE, thread, mono_lls_filter_accept_all, NULL)
+	MONO_LLS_FOREACH_FILTERED (mono_thread_info_list_head (), MonoThreadInfo, thread, mono_lls_filter_accept_all, NULL)
 
 #define FOREACH_THREAD_EXCLUDE(thread, not_flags) \
-	MONO_LLS_FOREACH_FILTERED (mono_thread_info_list_head (), THREAD_INFO_TYPE, thread, mono_threads_filter_exclude_flags, not_flags)
+	MONO_LLS_FOREACH_FILTERED (mono_thread_info_list_head (), MonoThreadInfo, thread, mono_threads_filter_exclude_flags, not_flags)
 
 #define FOREACH_THREAD_END \
 	MONO_LLS_FOREACH_END
@@ -347,22 +321,22 @@ mono_threads_filter_exclude_flags (THREAD_INFO_TYPE *info, MonoThreadInfoFlags f
 /* Snapshot iteration; can be done anytime but is slower. */
 
 #define FOREACH_THREAD_SAFE_ALL(thread) \
-	MONO_LLS_FOREACH_FILTERED_SAFE (mono_thread_info_list_head (), THREAD_INFO_TYPE, thread, mono_lls_filter_accept_all, NULL)
+	MONO_LLS_FOREACH_FILTERED_SAFE (mono_thread_info_list_head (), MonoThreadInfo, thread, mono_lls_filter_accept_all, NULL)
 
 #define FOREACH_THREAD_SAFE_EXCLUDE(thread, not_flags) \
-	MONO_LLS_FOREACH_FILTERED_SAFE (mono_thread_info_list_head (), THREAD_INFO_TYPE, thread, mono_threads_filter_exclude_flags, not_flags)
+	MONO_LLS_FOREACH_FILTERED_SAFE (mono_thread_info_list_head (), MonoThreadInfo, thread, mono_threads_filter_exclude_flags, not_flags)
 
 #define FOREACH_THREAD_SAFE_END \
 	MONO_LLS_FOREACH_SAFE_END
 
 static inline MonoNativeThreadId
-mono_thread_info_get_tid (THREAD_INFO_TYPE *info)
+mono_thread_info_get_tid (MonoThreadInfo *info)
 {
 	return MONO_UINT_TO_NATIVE_THREAD_ID (((MonoThreadInfo*) info)->node.key);
 }
 
 static inline void
-mono_thread_info_set_tid (THREAD_INFO_TYPE *info, MonoNativeThreadId tid)
+mono_thread_info_set_tid (MonoThreadInfo *info, MonoNativeThreadId tid)
 {
 	((MonoThreadInfo*) info)->node.key = (uintptr_t) MONO_NATIVE_THREAD_ID_TO_UINT (tid);
 }
@@ -398,25 +372,25 @@ mono_threads_get_runtime_callbacks (void);
 MONO_API int
 mono_thread_info_register_small_id (void);
 
-MONO_API THREAD_INFO_TYPE *
+MONO_API MonoThreadInfo *
 mono_thread_info_attach (void);
 
 MONO_API void
 mono_thread_info_detach (void);
 
 gboolean
-mono_thread_info_try_get_internal_thread_gchandle (THREAD_INFO_TYPE *info, guint32 *gchandle);
+mono_thread_info_try_get_internal_thread_gchandle (MonoThreadInfo *info, guint32 *gchandle);
 
 void
-mono_thread_info_set_internal_thread_gchandle (THREAD_INFO_TYPE *info, guint32 gchandle);
+mono_thread_info_set_internal_thread_gchandle (MonoThreadInfo *info, guint32 gchandle);
 
 void
-mono_thread_info_unset_internal_thread_gchandle (THREAD_INFO_TYPE *info);
+mono_thread_info_unset_internal_thread_gchandle (MonoThreadInfo *info);
 
 gboolean
 mono_thread_info_is_exiting (void);
 
-THREAD_INFO_TYPE *
+MonoThreadInfo *
 mono_thread_info_current (void);
 
 MONO_API gboolean
@@ -426,7 +400,7 @@ MONO_API void*
 mono_thread_info_get_tools_data (void);
 
 
-THREAD_INFO_TYPE*
+MonoThreadInfo*
 mono_thread_info_current_unchecked (void);
 
 MONO_API int
@@ -435,7 +409,7 @@ mono_thread_info_get_small_id (void);
 MonoLinkedListSet*
 mono_thread_info_list_head (void);
 
-THREAD_INFO_TYPE*
+MonoThreadInfo*
 mono_thread_info_lookup (MonoNativeThreadId id);
 
 gboolean
@@ -445,7 +419,7 @@ void
 mono_thread_info_safe_suspend_and_run (MonoNativeThreadId id, gboolean interrupt_kernel, MonoSuspendThreadCallback callback, gpointer user_data);
 
 void
-mono_thread_info_setup_async_call (THREAD_INFO_TYPE *info, void (*target_func)(void*), void *user_data);
+mono_thread_info_setup_async_call (MonoThreadInfo *info, void (*target_func)(void*), void *user_data);
 
 void
 mono_thread_info_suspend_lock (void);
@@ -475,10 +449,10 @@ gint
 mono_thread_info_usleep (guint64 us);
 
 gpointer
-mono_thread_info_tls_get (THREAD_INFO_TYPE *info, MonoTlsKey key);
+mono_thread_info_tls_get (MonoThreadInfo *info, MonoTlsKey key);
 
 void
-mono_thread_info_tls_set (THREAD_INFO_TYPE *info, MonoTlsKey key, gpointer value);
+mono_thread_info_tls_set (MonoThreadInfo *info, MonoTlsKey key, gpointer value);
 
 void
 mono_thread_info_exit (gsize exit_code);
@@ -490,7 +464,7 @@ MONO_PAL_API void
 mono_thread_info_uninstall_interrupt (gboolean *interrupted);
 
 MonoThreadInfoInterruptToken*
-mono_thread_info_prepare_interrupt (THREAD_INFO_TYPE *info);
+mono_thread_info_prepare_interrupt (MonoThreadInfo *info);
 
 void
 mono_thread_info_finish_interrupt (MonoThreadInfoInterruptToken *token);
@@ -502,13 +476,13 @@ void
 mono_thread_info_clear_self_interrupt (void);
 
 gboolean
-mono_thread_info_is_interrupt_state (THREAD_INFO_TYPE *info);
+mono_thread_info_is_interrupt_state (MonoThreadInfo *info);
 
 void
-mono_thread_info_describe_interrupt_token (THREAD_INFO_TYPE *info, GString *text);
+mono_thread_info_describe_interrupt_token (MonoThreadInfo *info, GString *text);
 
 gboolean
-mono_thread_info_is_live (THREAD_INFO_TYPE *info);
+mono_thread_info_is_live (MonoThreadInfo *info);
 
 int
 mono_thread_info_get_system_max_stack_size (void);
@@ -523,7 +497,7 @@ mono_threads_close_thread_handle (MonoThreadHandle *handle);
 
 /*Use this instead of pthread_kill */
 int
-mono_threads_pthread_kill (THREAD_INFO_TYPE *info, int signum);
+mono_threads_pthread_kill (MonoThreadInfo *info, int signum);
 
 #endif /* !defined(HOST_WIN32) */
 
@@ -549,7 +523,7 @@ This begins async suspend. This function must do the following:
 
 If begin suspend fails the thread must be left uninterrupted and resumed.
 */
-gboolean mono_threads_suspend_begin_async_suspend (THREAD_INFO_TYPE *info, gboolean interrupt_kernel);
+gboolean mono_threads_suspend_begin_async_suspend (MonoThreadInfo *info, gboolean interrupt_kernel);
 
 /*
 This verifies the outcome of an async suspend operation.
@@ -557,7 +531,7 @@ This verifies the outcome of an async suspend operation.
 Some targets, such as posix, verify suspend results assynchronously. Suspend results must be
 available (in a non blocking way) after mono_threads_wait_pending_operations completes.
 */
-gboolean mono_threads_suspend_check_suspend_result (THREAD_INFO_TYPE *info);
+gboolean mono_threads_suspend_check_suspend_result (MonoThreadInfo *info);
 
 /*
 This begins async resume. This function must do the following:
@@ -566,11 +540,11 @@ This begins async resume. This function must do the following:
 - Notify the target to resume.
 - Register the thread for pending ack with mono_threads_add_to_pending_operation_set if needed.
 */
-gboolean mono_threads_suspend_begin_async_resume (THREAD_INFO_TYPE *info);
+gboolean mono_threads_suspend_begin_async_resume (MonoThreadInfo *info);
 
-void mono_threads_suspend_register (THREAD_INFO_TYPE *info); //ok
-void mono_threads_suspend_free (THREAD_INFO_TYPE *info);
-void mono_threads_suspend_abort_syscall (THREAD_INFO_TYPE *info);
+void mono_threads_suspend_register (MonoThreadInfo *info); //ok
+void mono_threads_suspend_free (MonoThreadInfo *info);
+void mono_threads_suspend_abort_syscall (MonoThreadInfo *info);
 gint mono_threads_suspend_search_alternative_signal (void);
 gint mono_threads_suspend_get_suspend_signal (void);
 gint mono_threads_suspend_get_restart_signal (void);
@@ -612,16 +586,16 @@ void mono_threads_install_dead_letter (void);
 /*
 This tells the suspend initiator that we completed suspend and will now be waiting for resume.
 */
-void mono_threads_notify_initiator_of_suspend (THREAD_INFO_TYPE* info);
+void mono_threads_notify_initiator_of_suspend (MonoThreadInfo* info);
 /*
 This tells the resume initiator that we completed resume duties and will return to runnable state.
 */
-void mono_threads_notify_initiator_of_resume (THREAD_INFO_TYPE* info);
+void mono_threads_notify_initiator_of_resume (MonoThreadInfo* info);
 
 /*
 This tells the resume initiator that we completed abort duties and will return to previous state.
 */
-void mono_threads_notify_initiator_of_abort (THREAD_INFO_TYPE* info);
+void mono_threads_notify_initiator_of_abort (MonoThreadInfo* info);
 
 /* Thread state machine functions */
 
@@ -664,30 +638,30 @@ typedef enum {
 } MonoAbortBlockingResult;
 
 
-void mono_threads_transition_attach (THREAD_INFO_TYPE* info);
-gboolean mono_threads_transition_detach (THREAD_INFO_TYPE *info);
-MonoRequestSuspendResult mono_threads_transition_request_suspension (THREAD_INFO_TYPE *info);
-MonoSelfSupendResult mono_threads_transition_state_poll (THREAD_INFO_TYPE *info);
-MonoResumeResult mono_threads_transition_request_resume (THREAD_INFO_TYPE* info);
-gboolean mono_threads_transition_finish_async_suspend (THREAD_INFO_TYPE* info);
-MonoDoBlockingResult mono_threads_transition_do_blocking (THREAD_INFO_TYPE* info, const char* func);
-MonoDoneBlockingResult mono_threads_transition_done_blocking (THREAD_INFO_TYPE* info, const char* func);
-MonoAbortBlockingResult mono_threads_transition_abort_blocking (THREAD_INFO_TYPE* info, const char* func);
-gboolean mono_threads_transition_peek_blocking_suspend_requested (THREAD_INFO_TYPE* info);
+void mono_threads_transition_attach (MonoThreadInfo* info);
+gboolean mono_threads_transition_detach (MonoThreadInfo *info);
+MonoRequestSuspendResult mono_threads_transition_request_suspension (MonoThreadInfo *info);
+MonoSelfSupendResult mono_threads_transition_state_poll (MonoThreadInfo *info);
+MonoResumeResult mono_threads_transition_request_resume (MonoThreadInfo* info);
+gboolean mono_threads_transition_finish_async_suspend (MonoThreadInfo* info);
+MonoDoBlockingResult mono_threads_transition_do_blocking (MonoThreadInfo* info, const char* func);
+MonoDoneBlockingResult mono_threads_transition_done_blocking (MonoThreadInfo* info, const char* func);
+MonoAbortBlockingResult mono_threads_transition_abort_blocking (MonoThreadInfo* info, const char* func);
+gboolean mono_threads_transition_peek_blocking_suspend_requested (MonoThreadInfo* info);
 
 
-MonoThreadUnwindState* mono_thread_info_get_suspend_state (THREAD_INFO_TYPE *info);
+MonoThreadUnwindState* mono_thread_info_get_suspend_state (MonoThreadInfo *info);
 
 gpointer
 mono_threads_enter_gc_unsafe_region_cookie (void);
 
 
-void mono_thread_info_wait_for_resume (THREAD_INFO_TYPE *info);
+void mono_thread_info_wait_for_resume (MonoThreadInfo *info);
 /* Advanced suspend API, used for suspending multiple threads as once. */
-gboolean mono_thread_info_is_running (THREAD_INFO_TYPE *info);
-gboolean mono_thread_info_is_live (THREAD_INFO_TYPE *info);
-int mono_thread_info_suspend_count (THREAD_INFO_TYPE *info);
-int mono_thread_info_current_state (THREAD_INFO_TYPE *info);
+gboolean mono_thread_info_is_running (MonoThreadInfo *info);
+gboolean mono_thread_info_is_live (MonoThreadInfo *info);
+int mono_thread_info_suspend_count (MonoThreadInfo *info);
+int mono_thread_info_current_state (MonoThreadInfo *info);
 const char* mono_thread_state_name (int state);
 gboolean mono_thread_is_gc_unsafe_mode (void);
 
@@ -720,17 +694,17 @@ typedef enum {
 	MONO_THREAD_BEGIN_SUSPEND_NEXT_PHASE = 2,
 } MonoThreadBeginSuspendResult;
 
-gboolean mono_thread_info_in_critical_location (THREAD_INFO_TYPE *info);
-MonoThreadBeginSuspendResult mono_thread_info_begin_suspend (THREAD_INFO_TYPE *info, MonoThreadSuspendPhase phase);
-gboolean mono_thread_info_begin_resume (THREAD_INFO_TYPE *info);
+gboolean mono_thread_info_in_critical_location (MonoThreadInfo *info);
+MonoThreadBeginSuspendResult mono_thread_info_begin_suspend (MonoThreadInfo *info, MonoThreadSuspendPhase phase);
+gboolean mono_thread_info_begin_resume (MonoThreadInfo *info);
 
-void mono_threads_add_to_pending_operation_set (THREAD_INFO_TYPE* info); //XXX rename to something to reflect the fact that this is used for both suspend and resume
+void mono_threads_add_to_pending_operation_set (MonoThreadInfo* info); //XXX rename to something to reflect the fact that this is used for both suspend and resume
 gboolean mono_threads_wait_pending_operations (void);
 void mono_threads_begin_global_suspend (void);
 void mono_threads_end_global_suspend (void);
 
 gboolean
-mono_thread_info_is_current (THREAD_INFO_TYPE *info);
+mono_thread_info_is_current (MonoThreadInfo *info);
 
 typedef enum {
 	MONO_THREAD_INFO_WAIT_RET_SUCCESS_0   =  0,


### PR DESCRIPTION
@monojenkins skip
This is a suggested alternative to https://github.com/mono/mono/pull/10294 and https://github.com/mono/mono/pull/10297.
As `THREAD_INFO_TYPE` wasn't covering up all that much.
Remove a hack instead of pile on?

In future we can still derive `SgenThreadInfo` from `MonoThreadInfo`, which will further clean this up.
We'd also win just by having both `stack_end` and `stack_start` in `MonoThreadInfo`, instead of one in `mono` and one in `sgen`.

A few lines of this are optional, where we have `info` and `mono_thread_info`, I replaced `info->client_info.info` with `mono_thread_info->`.

Also, the `FOREACH` macros could still be factored on `THREAD_INFO_TYPE`.
And the extern "C" functions could be as well.
I chose to eliminate `THREAD_INFO_TYPE` entirely, rather than just where it causes typesafe linkage violations, but there is flexibility here.

Also strengthened type in `checked-build.{c,h]` from `void*` to `MonoThreadInfo*`. (was `void*` and `THREAD_INFO_TYPE`).