### PR TITLE
[cxx] Port MonoPosixHelper to C++, except zlib, because there is some glib use,

### DIFF
--- a/support/Makefile.am
+++ b/support/Makefile.am
@@ -1,16 +1,14 @@
-if HOST_WIN32
-SUPPORT=
-else
-SUPPORT=libMonoSupportW.la
-endif
-
 if BUILD_SUPPORT
-lib_LTLIBRARIES = 				\
-	libMonoPosixHelper.la			\
-	$(SUPPORT)
 
-noinst_LTLIBRARIES=				\
-	libMonoSupportC.la
+lib_LTLIBRARIES = libMonoPosixHelper.la
+noinst_LTLIBRARIES = libMonoPosixHelper-cxx.la
+
+if !HOST_WIN32
+
+lib_LTLIBRARIES += libMonoSupportW.la
+noinst_LTLIBRARIES += libMonoSupportW-cxx.la
+
+endif
 endif
 
 AM_CPPFLAGS =					\
@@ -66,11 +64,11 @@ MPH_UNIX_SOURCE =				\
 
 if HOST_WIN32
 MPH_SOURCE = $(MPH_C_SOURCE)
-MPH_LIBS   = $(glib_libs)
 else
 MPH_SOURCE = $(MPH_C_SOURCE) $(MPH_UNIX_SOURCE)
-MPH_LIBS   = $(glib_libs)
 endif
+
+MPH_LIBS   = $(glib_libs)
 
 MINIZIP_SOURCE = \
 	minizip/crypt.h \
@@ -112,22 +110,18 @@ Z_SOURCE = zlib-helper.c $(ZLIB_SOURCES)
 Z_LIBS=
 endif
 
-# C; uses no glib
-libMonoSupportC_la_SOURCES = \
+libMonoPosixHelper_la_CFLAGS = @CXX_REMOVE_CFLAGS@
+libMonoPosixHelper_cxx_la_CFLAGS = @CXX_ADD_CFLAGS@
+
+libMonoPosixHelper_la_SOURCES =			\
 	$(Z_SOURCE)				\
 	$(MINIZIP_SOURCE)
 
-libMonoSupportC_la_CFLAGS = @CXX_REMOVE_CFLAGS@
-
-# optionally C++; uses some glib
-libMonoSupportW_la_CFLAGS = @CXX_ADD_CFLAGS@
-libMonoPosixHelper_la_CFLAGS = @CXX_ADD_CFLAGS@
-
-libMonoPosixHelper_la_SOURCES =			\
+libMonoPosixHelper_cxx_la_SOURCES =		\
 	$(MPH_SOURCE)
 
 libMonoPosixHelper_la_LIBADD =			\
-	libMonoSupportC.la			\
+	libMonoPosixHelper-cxx.la		\
 	$(MPH_LIBS)				\
 	$(Z_LIBS)				\
 	$(XATTR_LIB)
@@ -136,12 +130,18 @@ libMonoPosixHelper_la_LIBADD =			\
 libMonoPosixHelper_la_LDFLAGS = -no-undefined -avoid-version
 libMonoSupportW_la_LDFLAGS = -no-undefined -avoid-version
 
-libMonoSupportW_la_SOURCES =			\
+libMonoSupportW_la_CFLAGS = @CXX_REMOVE_CFLAGS@
+libMonoSupportW_cxx_la_CFLAGS = @CXX_ADD_CFLAGS@
+
+libMonoSupportW_la_SOURCES =
+
+libMonoSupportW_cxx_la_SOURCES =		\
 		supportw.c			\
 		support-heap.c			\
 		supportw.h
 
 libMonoSupportW_la_LIBADD =			\
+		libMonoSupportW-cxx.la	\
 		$(glib_libs)
 
 # 

--- a/support/Makefile.am
+++ b/support/Makefile.am
@@ -8,6 +8,9 @@ if BUILD_SUPPORT
 lib_LTLIBRARIES = 				\
 	libMonoPosixHelper.la			\
 	$(SUPPORT)
+
+noinst_LTLIBRARIES=				\
+	libMonoSupportC.la
 endif
 
 AM_CPPFLAGS =					\
@@ -15,6 +18,8 @@ AM_CPPFLAGS =					\
 	-I$(top_srcdir)
 
 glib_libs = $(top_builddir)/mono/eglib/libeglib.la
+
+CFLAGS := $(filter-out @CXX_REMOVE_CFLAGS@, @CFLAGS@)
 
 # Source code which helps implement the ANSI C standards, and thus *should* be
 # portable to any platform having a C compiler.
@@ -107,12 +112,22 @@ Z_SOURCE = zlib-helper.c $(ZLIB_SOURCES)
 Z_LIBS=
 endif
 
-libMonoPosixHelper_la_SOURCES =			\
-	$(MPH_SOURCE)				\
+# C; uses no glib
+libMonoSupportC_la_SOURCES = \
 	$(Z_SOURCE)				\
 	$(MINIZIP_SOURCE)
 
+libMonoSupportC_la_CFLAGS = @CXX_REMOVE_CFLAGS@
+
+# optionally C++; uses some glib
+libMonoSupportW_la_CFLAGS = @CXX_ADD_CFLAGS@
+libMonoPosixHelper_la_CFLAGS = @CXX_ADD_CFLAGS@
+
+libMonoPosixHelper_la_SOURCES =			\
+	$(MPH_SOURCE)
+
 libMonoPosixHelper_la_LIBADD =			\
+	libMonoSupportC.la			\
 	$(MPH_LIBS)				\
 	$(Z_LIBS)				\
 	$(XATTR_LIB)

--- a/support/dirent.c
+++ b/support/dirent.c
@@ -79,7 +79,7 @@ Mono_Posix_Syscall_readdir (void *dirp, struct Mono_Posix_Syscall__Dirent *entry
 	}
 
 	errno = 0;
-	d = readdir (dirp);
+	d = readdir ((DIR*)dirp);
 
 	if (d == NULL) {
 		return -1;
@@ -93,10 +93,10 @@ Mono_Posix_Syscall_readdir (void *dirp, struct Mono_Posix_Syscall__Dirent *entry
 gint32
 Mono_Posix_Syscall_readdir_r (void *dirp, struct Mono_Posix_Syscall__Dirent *entry, void **result)
 {
-	struct dirent *_entry = malloc (sizeof (struct dirent) + MPH_PATH_MAX + 1);
+	struct dirent *_entry = (struct dirent*)malloc (sizeof (struct dirent) + MPH_PATH_MAX + 1);
 	int r;
 
-	r = readdir_r (dirp, _entry, (struct dirent**) result);
+	r = readdir_r ((DIR*)dirp, _entry, (struct dirent**) result);
 
 	if (r == 0 && *result != NULL) {
 		copy_dirent (entry, _entry);
@@ -110,7 +110,7 @@ Mono_Posix_Syscall_readdir_r (void *dirp, struct Mono_Posix_Syscall__Dirent *ent
 int
 Mono_Posix_Syscall_rewinddir (void* dir)
 {
-	rewinddir (dir);
+	rewinddir ((DIR*)dir);
 	return 0;
 }
 

--- a/support/grp.c
+++ b/support/grp.c
@@ -76,8 +76,8 @@ copy_group (struct Mono_Posix_Syscall__Group *to, struct group *from)
 	count_members (from->gr_mem, &count, &buflen);
 
 	to->_gr_nmem_ = count;
-	cur = to->_gr_buf_ = (char*) malloc (buflen);
-	to_mem = to->gr_mem = malloc (sizeof(char*)*(count+1));
+	cur = (char*)(to->_gr_buf_ = malloc (buflen));
+	to_mem = (char**)(to->gr_mem = malloc (sizeof(char*)*(count+1)));
 	if (to->_gr_buf_ == NULL || to->gr_mem == NULL) {
 		free (to->_gr_buf_);
 		free (to->gr_mem);
@@ -162,7 +162,7 @@ Mono_Posix_Syscall_getgrnam_r (const char *name,
 	buflen = 2;
 
 	do {
-		buf2 = realloc (buf, buflen *= 2);
+		buf2 = (char*)realloc (buf, buflen *= 2);
 		if (buf2 == NULL) {
 			free (buf);
 			errno = ENOMEM;
@@ -205,7 +205,7 @@ Mono_Posix_Syscall_getgrgid_r (mph_gid_t gid,
 	buflen = 2;
 
 	do {
-		buf2 = realloc (buf, buflen *= 2);
+		buf2 = (char*)realloc (buf, buflen *= 2);
 		if (buf2 == NULL) {
 			free (buf);
 			errno = ENOMEM;

--- a/support/macros.c
+++ b/support/macros.c
@@ -12,6 +12,8 @@
 #include "mph.h" /* Don't remove or move after map.h! Works around issues with Android SDK unified headers */
 #include "map.h"
 
+G_BEGIN_DECLS
+
 int wifexited (int status)
 {
 	return WIFEXITED (status);
@@ -158,3 +160,4 @@ int helper_Mono_Posix_getpwnamuid (int mode, char *in_name, int in_uid,
 }
 #endif  /* def HAVE_GETPWNAM_R */
 
+G_END_DECLS

--- a/support/map.c
+++ b/support/map.c
@@ -83,6 +83,8 @@
 #include <errno.h>    /* errno, EOVERFLOW */
 #include <glib.h>     /* g* types, g_assert_not_reached() */
 
+G_BEGIN_DECLS
+
 #if defined (G_MININT8)
 #define CNM_MININT8 G_MININT8
 #else
@@ -9324,3 +9326,5 @@ int Mono_Posix_ToXattrFlags (int x, int *r)
 #endif /* ndef XATTR_REPLACE */
 	return 0;
 }
+
+G_END_DECLS

--- a/support/nl.c
+++ b/support/nl.c
@@ -24,6 +24,8 @@
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 
+G_BEGIN_DECLS
+
 #undef NL_DEBUG
 #define NL_DEBUG_STMT(a) do { } while (0)
 #define NL_DEBUG_PRINT(...)
@@ -284,7 +286,7 @@ ReadEvents (gpointer sock, gpointer buffer, gint32 count, gint32 size)
 #endif
 
 			NL_DEBUG_PRINT ("\tAttribute: %d %d (%s)", rtap->rta_len, rtap->rta_type, FIND_RTM_ATTRS_NAME (rtap->rta_type));
-			data = RTA_DATA (rtap);
+			data = (char*)RTA_DATA (rtap);
 			switch (rtap->rta_type) {
 			case RTA_DST:
 				have_dst = TRUE;
@@ -364,7 +366,13 @@ CloseNLSocket (gpointer sock)
 {
 	return close (GPOINTER_TO_INT (sock));
 }
+
+G_END_DECLS
+
 #else
+
+G_BEGIN_DECLS
+
 int
 ReadEvents (gpointer sock, gpointer buffer, gint32 count, gint32 size)
 {
@@ -382,5 +390,7 @@ CloseNLSocket (gpointer sock)
 {
 	return -1;
 }
-#endif /* linux/netlink.h + linux/rtnetlink.h */
 
+G_END_DECLS
+
+#endif /* linux/netlink.h + linux/rtnetlink.h */

--- a/support/old-map.c
+++ b/support/old-map.c
@@ -14,6 +14,8 @@
 #include "mph.h"
 #include "old-map.h"
 
+G_BEGIN_DECLS
+
 int map_Mono_Posix_AccessMode (int mode);
 int map_Mono_Posix_FileMode (int mode);
 int map_Mono_Posix_OpenFlags (int flags);
@@ -188,3 +190,4 @@ int map_Mono_Posix_PollEvents (int x)
 	return r;
 }
 
+G_END_DECLS

--- a/support/pwd.c
+++ b/support/pwd.c
@@ -129,7 +129,7 @@ Mono_Posix_Syscall_getpwnam_r (const char *name,
 	buflen = 2;
 
 	do {
-		buf2 = realloc (buf, buflen *= 2);
+		buf2 = (char*)realloc (buf, buflen *= 2);
 		if (buf2 == NULL) {
 			free (buf);
 			errno = ENOMEM;
@@ -172,7 +172,7 @@ Mono_Posix_Syscall_getpwuid_r (mph_uid_t uid,
 	buflen = 2;
 
 	do {
-		buf2 = realloc (buf, buflen *= 2);
+		buf2 = (char*)realloc (buf, buflen *= 2);
 		if (buf2 == NULL) {
 			free (buf);
 			errno = ENOMEM;

--- a/support/serial.c
+++ b/support/serial.c
@@ -46,6 +46,8 @@
 #include <IOKit/IOBSD.h>
 #endif
 
+G_BEGIN_DECLS
+
 /* This is a copy of System.IO.Ports.Handshake */
 typedef enum {
 	NoneHandshake = 0,
@@ -80,6 +82,8 @@ typedef enum {
 	Dtr = 8, /* Data terminal ready */
 	Rts = 16  /* Request to send */
 } MonoSerialSignal;
+
+G_ENUM_FUNCTIONS (MonoSerialSignal)
 
 /*
  * Silence the compiler, we do not need these prototypes to be public, since these are only
@@ -604,3 +608,4 @@ list_serial_devices (void)
 }
 #endif
 
+G_END_DECLS

--- a/support/signal.c
+++ b/support/signal.c
@@ -43,19 +43,19 @@ static int count_handlers (int signum);
 void*
 Mono_Posix_Stdlib_SIG_DFL (void)
 {
-	return SIG_DFL;
+	return (void*)SIG_DFL;
 }
 
 void*
 Mono_Posix_Stdlib_SIG_ERR (void)
 {
-	return SIG_ERR;
+	return (void*)SIG_ERR;
 }
 
 void*
 Mono_Posix_Stdlib_SIG_IGN (void)
 {
-	return SIG_IGN;
+	return (void*)SIG_IGN;
 }
 
 void
@@ -330,7 +330,7 @@ Mono_Unix_UnixSignal_install (int sig)
 		// We're still looking for a signal_info spot, and this one is available:
 		if (h == NULL && mph_int_get (&signals [i].signum) == 0) {
 			h = &signals [i];
-			h->handler = signal (sig, default_handler);
+			h->handler = (void*)signal (sig, default_handler);
 			if (h->handler == SIG_ERR) {
 				h->handler = NULL;
 				h = NULL;
@@ -397,7 +397,7 @@ Mono_Unix_UnixSignal_uninstall (void* info)
 	if (acquire_mutex (&signals_mutex) == -1)
 		return -1;
 
-	h = info;
+	h = (signal_info*)info;
 
 	if (h == NULL || h < signals || h > &signals [NUM_SIGNALS])
 		errno = EINVAL;
@@ -405,7 +405,7 @@ Mono_Unix_UnixSignal_uninstall (void* info)
 		/* last UnixSignal -- we can unregister */
 		int signum = mph_int_get (&h->signum);
 		if (h->have_handler && count_handlers (signum) == 1) {
-			mph_sighandler_t p = signal (signum, h->handler);
+			mph_sighandler_t p = (mph_sighandler_t)signal (signum, (void (*)(int))h->handler);
 			if (p != SIG_ERR)
 				r = 0;
 			h->handler      = NULL;

--- a/support/stdio.c
+++ b/support/stdio.c
@@ -168,13 +168,13 @@ gint32
 Mono_Posix_Stdlib_setvbuf (void* stream, void *buf, int mode, mph_size_t size)
 {
 	mph_return_if_size_t_overflow (size);
-	return setvbuf (stream, (char *) buf, mode, (size_t) size);
+	return setvbuf ((FILE*)stream, (char *) buf, mode, (size_t) size);
 }
 
 int 
 Mono_Posix_Stdlib_setbuf (void* stream, void* buf)
 {
-	setbuf (stream, buf);
+	setbuf ((FILE*)stream, (char*)buf);
 	return 0;
 }
 
@@ -187,49 +187,49 @@ Mono_Posix_Stdlib_fopen (char* path, char* mode)
 void*
 Mono_Posix_Stdlib_freopen (char* path, char* mode, void *stream)
 {
-	return freopen (path, mode, stream);
+	return freopen (path, mode, (FILE*)stream);
 }
 
 gint32
 Mono_Posix_Stdlib_fprintf (void* stream, char* format, char *message)
 {
-	return fprintf (stream, format, message);
+	return fprintf ((FILE*)stream, format, message);
 }
 
 gint32
 Mono_Posix_Stdlib_fgetc (void* stream)
 {
-	return fgetc (stream);
+	return fgetc ((FILE*)stream);
 }
 
 char*
 Mono_Posix_Stdlib_fgets (char* str, gint32 size, void* stream)
 {
-	return fgets (str, size, stream);
+	return fgets (str, size, (FILE*)stream);
 }
 
 gint32
 Mono_Posix_Stdlib_fputc (gint32 c, void* stream)
 {
-	return fputc (c, stream);
+	return fputc (c, (FILE*)stream);
 }
 
 gint32
 Mono_Posix_Stdlib_fputs (char* s, void* stream)
 {
-	return fputs (s, stream);
+	return fputs (s, (FILE*)stream);
 }
 
 gint32
 Mono_Posix_Stdlib_fclose (void* stream)
 {
-	return fclose (stream);
+	return fclose ((FILE*)stream);
 }
 
 gint32
 Mono_Posix_Stdlib_fflush (void* stream)
 {
-	return fflush (stream);
+	return fflush ((FILE*)stream);
 }
 
 gint32
@@ -237,39 +237,39 @@ Mono_Posix_Stdlib_fseek (void* stream, gint64 offset, int origin)
 {
 	mph_return_if_long_overflow (offset);
 
-	return fseek (stream, offset, origin);
+	return fseek ((FILE*)stream, offset, origin);
 }
 
 gint64
 Mono_Posix_Stdlib_ftell (void* stream)
 {
-	return ftell (stream);
+	return ftell ((FILE*)stream);
 }
 
 void*
 Mono_Posix_Stdlib_CreateFilePosition (void)
 {
-	fpos_t* pos = malloc (sizeof(fpos_t));
+	fpos_t* pos = (fpos_t*)malloc (sizeof(fpos_t));
 	return pos;
 }
 
 gint32
 Mono_Posix_Stdlib_fgetpos (void* stream, void *pos)
 {
-	return fgetpos (stream, (fpos_t*) pos);
+	return fgetpos ((FILE*)stream, (fpos_t*) pos);
 }
 
 gint32
 Mono_Posix_Stdlib_fsetpos (void* stream, void *pos)
 {
-	return fsetpos (stream, (fpos_t*) pos);
+	return fsetpos ((FILE*)stream, (fpos_t*) pos);
 }
 
 int
 Mono_Posix_Stdlib_rewind (void* stream)
 {
 	do {
-		rewind (stream);
+		rewind ((FILE*)stream);
 	} while (errno == EINTR);
 	mph_return_if_val_in_list5(errno, EAGAIN, EBADF, EFBIG, EINVAL, EIO);
 	mph_return_if_val_in_list5(errno, ENOSPC, ENXIO, EOVERFLOW, EPIPE, ESPIPE);
@@ -286,7 +286,7 @@ Mono_Posix_Stdlib_clearerr (void* stream)
 gint32
 Mono_Posix_Stdlib_ungetc (gint32 c, void* stream)
 {
-	return ungetc (c, stream);
+	return ungetc (c, (FILE*)stream);
 }
 
 gint32

--- a/support/support-heap.c
+++ b/support/support-heap.c
@@ -14,6 +14,8 @@
 #include <unistd.h>
 #include "supportw.h"
 
+G_BEGIN_DECLS
+
 gpointer HeapAlloc            (gpointer unused1, gint32 unused2, gint32 nbytes);
 gpointer HeapCreate           (gint32 flags, gint32 initial_size, gint32 max_size);
 gboolean HeapSetInformation   (gpointer handle, gpointer heap_info_class,
@@ -170,3 +172,5 @@ GetProcessHeap (void)
 	return process_heap;
 }
 /* end Heap* functions */
+
+G_END_DECLS

--- a/support/supportw.c
+++ b/support/supportw.c
@@ -20,6 +20,8 @@
 #include "mono/metadata/object.h"
 #include "mono/metadata/tabledefs.h"
 
+G_BEGIN_DECLS
+
 typedef struct {
 	const char *fname;
 	void *fnptr;
@@ -41,7 +43,7 @@ static int
 compare_names (const void *key, const void *p)
 {
 	FnPtr *ptr = (FnPtr *) p;
-	return strcmp (key, ptr->fname);
+	return strcmp ((const char*)key, ptr->fname);
 }
 
 static gpointer
@@ -49,7 +51,7 @@ get_function (const char *name)
 {
 	FnPtr *ptr;
 
-	ptr = bsearch (name, functions, NFUNCTIONS, sizeof (FnPtr),
+	ptr = (FnPtr*)bsearch (name, functions, NFUNCTIONS, sizeof (FnPtr),
 			compare_names);
 
 	if (ptr == NULL) {
@@ -67,7 +69,7 @@ supportw_register_delegate (const char *function_name, void *fnptr)
 
 	g_return_val_if_fail (function_name && fnptr, FALSE);
 
-	ptr = bsearch (function_name, functions, NFUNCTIONS, sizeof (FnPtr),
+	ptr = (FnPtr*)bsearch (function_name, functions, NFUNCTIONS, sizeof (FnPtr),
 			compare_names);
 
 	if (ptr == NULL) {
@@ -186,3 +188,5 @@ GetWindowLongA (gpointer hwnd, int a)
 {
 	return 0;
 }
+
+G_END_DECLS

--- a/support/sys-mman.c
+++ b/support/sys-mman.c
@@ -143,7 +143,12 @@ Mono_Posix_Syscall_mincore (void *start, mph_size_t length, unsigned char *vec)
 #else
 	mph_return_if_size_t_overflow (length);
 
-	return mincore (start, (size_t) length, (void*)vec);
+#ifdef __linux__
+	typedef unsigned char T;
+#else
+	typedef char T;
+#endif
+	return mincore (start, (size_t) length, (T*)vec);
 #endif
 }
 

--- a/support/sys-socket.c
+++ b/support/sys-socket.c
@@ -333,11 +333,11 @@ Mono_Posix_ToSockaddr (void* source, gint64 size, struct Mono_Posix__SockaddrHea
     } else if (address->type == Mono_Posix_SockaddrType_SockaddrUn) { \
         /* Use alloca() for up to 2048 bytes, use malloc() otherwise */ \
         need_free = addrlen > 2048;                                     \
-        addr = need_free ? malloc (addrlen) : alloca (addrlen);         \
+        addr = (struct sockaddr*)(need_free ? malloc (addrlen) : alloca (addrlen)); \
         if (!addr)                                                      \
             return -1;                                                  \
     } else {                                                            \
-        addr = alloca (addrlen);                                        \
+        addr = (struct sockaddr*)alloca (addrlen);                      \
     }
 
 
@@ -654,6 +654,8 @@ Mono_Posix_Syscall_CMSG_LEN (guint64 length)
 	return CMSG_LEN (length);
 }
 #endif
+
+G_END_DECLS
 
 /*
  * vim: noexpandtab

--- a/support/sys-stat.c
+++ b/support/sys-stat.c
@@ -27,7 +27,7 @@ G_BEGIN_DECLS
 int
 Mono_Posix_FromStat (struct Mono_Posix_Stat *from, void *_to)
 {
-	struct stat *to = _to;
+	struct stat *to = (struct stat*)_to;
 	memset (to, 0, sizeof(*to));
 
 	to->st_dev         = from->st_dev;
@@ -75,7 +75,7 @@ Mono_Posix_FromStat (struct Mono_Posix_Stat *from, void *_to)
 int
 Mono_Posix_ToStat (void *_from, struct Mono_Posix_Stat *to)
 {
-	struct stat *from = _from;
+	struct stat *from = (struct stat*)_from;
 	memset (to, 0, sizeof(*to));
 
 	to->st_dev        = from->st_dev;
@@ -204,8 +204,6 @@ Mono_Posix_Syscall_mknodat (int dirfd, const char *pathname, guint32 mode, mph_d
 }
 #endif
 
-G_END_DECLS
-
 gint64
 Mono_Posix_Syscall_get_utime_now ()
 {
@@ -268,6 +266,7 @@ Mono_Posix_Syscall_utimensat(int dirfd, const char *pathname, struct Mono_Posix_
 }
 #endif /* def HAVE_UTIMENSAT */
 
+G_END_DECLS
 
 /*
  * vim: noexpandtab

--- a/support/sys-statvfs.c
+++ b/support/sys-statvfs.c
@@ -41,7 +41,7 @@ G_BEGIN_DECLS
 int
 Mono_Posix_ToStatvfs (void *_from, struct Mono_Posix_Statvfs *to)
 {
-	struct statvfs *from = _from;
+	struct statvfs *from = (struct statvfs*)_from;
 
 	to->f_bsize   = from->f_bsize;
 	to->f_frsize  = from->f_frsize;
@@ -71,7 +71,7 @@ Mono_Posix_ToStatvfs (void *_from, struct Mono_Posix_Statvfs *to)
 int
 Mono_Posix_FromStatvfs (struct Mono_Posix_Statvfs *from, void *_to)
 {
-	struct statvfs *to = _to;
+	struct statvfs *to = (struct statvfs*)_to;
 	guint64 flag;
 
 	to->f_bsize   = from->f_bsize;
@@ -151,7 +151,7 @@ Mono_Posix_Syscall_fstatvfs (gint32 fd, struct Mono_Posix_Statvfs *buf)
 int
 Mono_Posix_ToStatvfs (void *_from, struct Mono_Posix_Statvfs *to)
 {
-	struct statfs *from = _from;
+	struct statfs *from = (struct statfs*)_from;
 
 	to->f_bsize   = from->f_bsize;
 	to->f_frsize  = from->f_bsize;
@@ -177,7 +177,7 @@ Mono_Posix_ToStatvfs (void *_from, struct Mono_Posix_Statvfs *to)
 int
 Mono_Posix_FromStatvfs (struct Mono_Posix_Statvfs *from, void *_to)
 {
-	struct statfs *to = _to;
+	struct statfs *to = (struct statfs*)_to;
 	guint64 flag;
 
 	to->f_bsize   = from->f_bsize;

--- a/support/sys-uio.c
+++ b/support/sys-uio.c
@@ -31,7 +31,7 @@ _mph_from_iovec_array (struct Mono_Posix_Iovec *iov, gint32 iovcnt)
 		return NULL;
 	}
 
-	v = malloc (iovcnt * sizeof (struct iovec));
+	v = (struct iovec*)malloc (iovcnt * sizeof (struct iovec));
 	if (!v) {
 		return NULL;
 	}
@@ -122,6 +122,7 @@ Mono_Posix_Syscall_pwritev (int dirfd, struct Mono_Posix_Iovec *iov, gint32 iovc
 }
 #endif /* def HAVE_PWRITEV */
 
+G_END_DECLS
 
 /*
  * vim: noexpandtab

--- a/support/x-struct-str.c
+++ b/support/x-struct-str.c
@@ -47,7 +47,7 @@ _mph_copy_structure_strings (
 			len[i] = -1;
 	}
 
-	cur = buf = malloc (buflen);
+	cur = buf = (char*)malloc (buflen);
 	if (buf == NULL) {
 		return NULL;
 	}
@@ -122,4 +122,3 @@ main ()
 	return 0;
 }
 #endif
-


### PR DESCRIPTION
and this reduces extern "C" therein.
zlib is K&R and does not use glib.
This is an alternative to https://github.com/mono/mono/pull/10341.
And addresses this comment https://github.com/mono/mono/pull/10160#pullrequestreview-148551783.

There are other alternatives.
 - This compiles more of the code as C++ than uses glib; make a more precise division instead.
 - Mark some/all of glib.h as extern "C" -- and leave this directory alone. (https://github.com/mono/mono/pull/10379)

extern "C" is applied a bit liberally here, probably redundantly, as  it is mostly already present and in .h files.