### PR TITLE
[rfc] [cxx] Mark the 14 functions used by MonoPosixHelper as extern "C".

### DIFF
--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -264,12 +264,22 @@ typedef guint32 gunichar;
 #define G_GUINT32_FORMAT PRIu32
 #define G_GINT32_FORMAT PRIi32
 
+#ifdef __cplusplus
+#define G_USED_BY_MONO_POSIX_HELPER extern "C"
+#else
+#define G_USED_BY_MONO_POSIX_HELPER /* nothing */
+#endif
+
 /*
  * Allocation
  */
+G_USED_BY_MONO_POSIX_HELPER
 void g_free (void *ptr);
+G_USED_BY_MONO_POSIX_HELPER
 gpointer g_realloc (gpointer obj, gsize size);
+G_USED_BY_MONO_POSIX_HELPER
 gpointer g_malloc (gsize x);
+G_USED_BY_MONO_POSIX_HELPER
 gpointer g_malloc0 (gsize x);
 gpointer g_calloc (gsize n, gsize x);
 gpointer g_try_malloc (gsize x);
@@ -567,22 +577,28 @@ struct _GHashTableIter
 	gpointer dummy [8];
 };
 
+G_USED_BY_MONO_POSIX_HELPER
 GHashTable     *g_hash_table_new             (GHashFunc hash_func, GEqualFunc key_equal_func);
 GHashTable     *g_hash_table_new_full        (GHashFunc hash_func, GEqualFunc key_equal_func,
 					      GDestroyNotify key_destroy_func, GDestroyNotify value_destroy_func);
+G_USED_BY_MONO_POSIX_HELPER
 void            g_hash_table_insert_replace  (GHashTable *hash, gpointer key, gpointer value, gboolean replace);
 guint           g_hash_table_size            (GHashTable *hash);
 GList          *g_hash_table_get_keys        (GHashTable *hash);
 GList          *g_hash_table_get_values      (GHashTable *hash);
+G_USED_BY_MONO_POSIX_HELPER
 gpointer        g_hash_table_lookup          (GHashTable *hash, gconstpointer key);
 gboolean        g_hash_table_lookup_extended (GHashTable *hash, gconstpointer key, gpointer *orig_key, gpointer *value);
+G_USED_BY_MONO_POSIX_HELPER
 void            g_hash_table_foreach         (GHashTable *hash, GHFunc func, gpointer user_data);
 gpointer        g_hash_table_find            (GHashTable *hash, GHRFunc predicate, gpointer user_data);
+G_USED_BY_MONO_POSIX_HELPER
 gboolean        g_hash_table_remove          (GHashTable *hash, gconstpointer key);
 gboolean        g_hash_table_steal           (GHashTable *hash, gconstpointer key);
 void            g_hash_table_remove_all      (GHashTable *hash);
 guint           g_hash_table_foreach_remove  (GHashTable *hash, GHRFunc func, gpointer user_data);
 guint           g_hash_table_foreach_steal   (GHashTable *hash, GHRFunc func, gpointer user_data);
+G_USED_BY_MONO_POSIX_HELPER
 void            g_hash_table_destroy         (GHashTable *hash);
 void            g_hash_table_print_stats     (GHashTable *table);
 
@@ -594,7 +610,9 @@ guint           g_spaced_primes_closest      (guint x);
 #define g_hash_table_insert(h,k,v)    g_hash_table_insert_replace ((h),(k),(v),FALSE)
 #define g_hash_table_replace(h,k,v)   g_hash_table_insert_replace ((h),(k),(v),TRUE)
 
+G_USED_BY_MONO_POSIX_HELPER
 gboolean g_direct_equal (gconstpointer v1, gconstpointer v2);
+G_USED_BY_MONO_POSIX_HELPER
 guint    g_direct_hash  (gconstpointer v1);
 gboolean g_int_equal    (gconstpointer v1, gconstpointer v2);
 guint    g_int_hash     (gconstpointer v1);
@@ -720,7 +738,9 @@ void           g_printerr             (const gchar *format, ...);
 GLogLevelFlags g_log_set_always_fatal (GLogLevelFlags fatal_mask);
 GLogLevelFlags g_log_set_fatal_mask   (const gchar *log_domain, GLogLevelFlags fatal_mask);
 void           g_logv                 (const gchar *log_domain, GLogLevelFlags log_level, const gchar *format, va_list args);
+G_USED_BY_MONO_POSIX_HELPER
 void           g_log                  (const gchar *log_domain, GLogLevelFlags log_level, const gchar *format, ...);
+G_USED_BY_MONO_POSIX_HELPER
 void           g_assertion_message    (const gchar *format, ...) G_GNUC_NORETURN;
 const char *   g_get_assertion_message (void);
 


### PR DESCRIPTION
This is an alternative to:
https://github.com/mono/mono/pull/10378
https://github.com/mono/mono/pull/10341

There are more:
We could mark the entire glib.h as extern "C", or slightly larger chunks.

This would enable us to leave MonoPosixHelper completely untouched.

I prefer closer to https://github.com/mono/mono/pull/10378, so that, e.g. we might in future templatize the hashtable, but presenting this data to decision making.

Even the templatization fantasy could be with new/alternate types though, possibly reusing existing, possibly under ifdef __cplusplus. Or we could convert MonoPosixHelper later anyway.

For further reference,  profilers use:
```
g_calloc
g_free
g_malloc
g_realloc
```