### PR TITLE
Update corlib post-build event to run ilasm for Unsafe.il, then pass it to cil-stringreplacer

### DIFF
--- a/mcs/class/corlib/corlib.csproj
+++ b/mcs/class/corlib/corlib.csproj
@@ -3009,11 +3009,13 @@
   </ItemGroup>
   <!-- @ALL_RESOURCES@ -->
   <PropertyGroup>
-    <PostBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">move $(TargetPath) $(TargetPath).tmp
-$(ProjectDir)\..\..\build\cil-stringreplacer.exe --mscorlib-debug $(TargetPath).tmp
-move $(TargetPath).tmp $(TargetPath)</PostBuildEvent>
-    <PostBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">move $(TargetPath) $(TargetPath).tmp
-$(ProjectDir)\..\..\build\cil-stringreplacer.exe --mscorlib-debug $(TargetPath).tmp
-move $(TargetPath).tmp $(TargetPath)</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">"$(MSBuildFrameworkToolsPath)\Ilasm.exe" /dll /noautoinherit /out:"$(TargetPath).il.tmp" "$(ProjectDir)\..\..\class\corlib\System.Runtime.CompilerServices\Unsafe.il"
+move "$(TargetPath)" "$(TargetPath).tmp"
+"$(ProjectDir)\..\..\build\cil-stringreplacer.exe" --mscorlib-debug --ilreplace="$(TargetPath).il.tmp" "$(TargetPath).tmp"
+move "$(TargetPath).tmp" "$(TargetPath)"</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">"$(MSBuildFrameworkToolsPath)\Ilasm.exe" /dll /noautoinherit /out:"$(TargetPath).il.tmp" "$(ProjectDir)\..\..\class\corlib\System.Runtime.CompilerServices\Unsafe.il"
+move "$(TargetPath)" "$(TargetPath).tmp"
+"$(ProjectDir)\..\..\build\cil-stringreplacer.exe" --mscorlib-debug --ilreplace="$(TargetPath).il.tmp" "$(TargetPath).tmp"
+move "$(TargetPath).tmp" "$(TargetPath)"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/msvc/scripts/corlib.post
+++ b/msvc/scripts/corlib.post
@@ -1,3 +1,4 @@
-move $(TargetPath) $(TargetPath).tmp
-$(ProjectDir)\..\..\build\cil-stringreplacer.exe --mscorlib-debug $(TargetPath).tmp
-move $(TargetPath).tmp $(TargetPath)
+"$(MSBuildFrameworkToolsPath)\Ilasm.exe" /dll /noautoinherit /out:"$(TargetPath).il.tmp" "$(ProjectDir)\..\..\class\corlib\System.Runtime.CompilerServices\Unsafe.il"
+move "$(TargetPath)" "$(TargetPath).tmp"
+"$(ProjectDir)\..\..\build\cil-stringreplacer.exe" --mscorlib-debug --ilreplace="$(TargetPath).il.tmp" "$(TargetPath).tmp"
+move "$(TargetPath).tmp" "$(TargetPath)"


### PR DESCRIPTION
This ensures that System.CompilerServices.Unsafe has implemented method bodies, necessary for Span and similar use cases.