### PR TITLE
[runtime] Fix configure flag typos

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3839,7 +3839,7 @@ if test "x$internal_llvm" != "xno"; then
 fi
 
 AM_CONDITIONAL(INTERNAL_LLVM_ASSERTS, [test "x$enable_llvm_asserts" != "xno"])
-if test "x$internal_llvm_asserts" != "xno"; then
+if test "x$enable_llvm_asserts" != "xno"; then
    AC_DEFINE(INTERNAL_LLVM_ASSERTS, 1, [Build LLVM with assertions])
 fi
 


### PR DESCRIPTION
This doesn't make any functional change right now, but it clears
this up for readers and future users.


