### PR TITLE
[2018-08] [System]: Make `MobileAuthenticatedStream`s read buffer large enough to hold a full TLS record.

### DIFF
--- a/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
+++ b/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
@@ -77,7 +77,7 @@ namespace Mono.Net.Security
 			Settings = settings;
 			Provider = provider;
 
-			readBuffer = new BufferOffsetSize2 (16384);
+			readBuffer = new BufferOffsetSize2 (16500);
 			writeBuffer = new BufferOffsetSize2 (16384);
 			operation = Operation.None;
 		}


### PR DESCRIPTION
Backport of #10393.

/cc @baulig