### PR TITLE
[cxx] Just enough extern "C" for profilers, libtest, MonoSupportW, Mo…

### DIFF
--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -66,9 +66,11 @@
 #ifdef  __cplusplus
 #define G_BEGIN_DECLS  extern "C" {
 #define G_END_DECLS    }
+#define G_EXTERN_C     extern "C"
 #else
-#define G_BEGIN_DECLS
-#define G_END_DECLS
+#define G_BEGIN_DECLS  /* nothing */
+#define G_END_DECLS    /* nothing */
+#define G_EXTERN_C     /* nothing */
 #endif
 
 #ifdef __cplusplus
@@ -267,10 +269,15 @@ typedef guint32 gunichar;
 /*
  * Allocation
  */
+G_EXTERN_C // Used by MonoPosixHelper or MonoSupportW, at least.
 void g_free (void *ptr);
+G_EXTERN_C // Used by MonoPosixHelper or MonoSupportW, at least.
 gpointer g_realloc (gpointer obj, gsize size);
+G_EXTERN_C // Used by MonoPosixHelper or MonoSupportW, at least.
 gpointer g_malloc (gsize x);
+G_EXTERN_C // Used by MonoPosixHelper or MonoSupportW, at least.
 gpointer g_malloc0 (gsize x);
+G_EXTERN_C // Used by profilers, at least.
 gpointer g_calloc (gsize n, gsize x);
 gpointer g_try_malloc (gsize x);
 gpointer g_try_realloc (gpointer obj, gsize size);
@@ -283,6 +290,7 @@ gpointer g_try_realloc (gpointer obj, gsize size);
 #define g_renew(struct_type, mem, n_structs) ((struct_type*)g_realloc (mem, sizeof (struct_type) * n_structs))
 #define g_alloca(size)		(g_cast (alloca (size)))
 
+G_EXTERN_C // Used by libtest, at least.
 gpointer g_memdup (gconstpointer mem, guint byte_size);
 static inline gchar   *g_strdup (const gchar *str) { if (str) { return (gchar*) g_memdup (str, (guint)strlen (str) + 1); } return NULL; }
 gchar **g_strdupv (gchar **str_array);
@@ -307,7 +315,10 @@ typedef struct _GMemChunk GMemChunk;
 
 gboolean         g_hasenv(const gchar *variable);
 gchar *          g_getenv(const gchar *variable);
+
+G_EXTERN_C // sdks/wasm/driver.c is C and uses this
 gboolean         g_setenv(const gchar *variable, const gchar *value, gboolean overwrite);
+
 void             g_unsetenv(const gchar *variable);
 
 gchar*           g_win32_getlocale(void);
@@ -338,6 +349,7 @@ void    g_propagate_error (GError **dest, GError *src);
 /*
  * Strings utility
  */
+G_EXTERN_C // Used by libtest, at least.
 gchar       *g_strdup_printf  (const gchar *format, ...);
 gchar       *g_strdup_vprintf (const gchar *format, va_list args);
 gchar       *g_strndup        (const gchar *str, gsize n);
@@ -567,22 +579,28 @@ struct _GHashTableIter
 	gpointer dummy [8];
 };
 
+G_EXTERN_C // Used by MonoPosixHelper or MonoSupportW, at least.
 GHashTable     *g_hash_table_new             (GHashFunc hash_func, GEqualFunc key_equal_func);
 GHashTable     *g_hash_table_new_full        (GHashFunc hash_func, GEqualFunc key_equal_func,
 					      GDestroyNotify key_destroy_func, GDestroyNotify value_destroy_func);
+G_EXTERN_C // Used by MonoPosixHelper or MonoSupportW, at least.
 void            g_hash_table_insert_replace  (GHashTable *hash, gpointer key, gpointer value, gboolean replace);
 guint           g_hash_table_size            (GHashTable *hash);
 GList          *g_hash_table_get_keys        (GHashTable *hash);
 GList          *g_hash_table_get_values      (GHashTable *hash);
+G_EXTERN_C // Used by MonoPosixHelper or MonoSupportW, at least.
 gpointer        g_hash_table_lookup          (GHashTable *hash, gconstpointer key);
 gboolean        g_hash_table_lookup_extended (GHashTable *hash, gconstpointer key, gpointer *orig_key, gpointer *value);
+G_EXTERN_C // Used by MonoPosixHelper or MonoSupportW, at least.
 void            g_hash_table_foreach         (GHashTable *hash, GHFunc func, gpointer user_data);
 gpointer        g_hash_table_find            (GHashTable *hash, GHRFunc predicate, gpointer user_data);
+G_EXTERN_C // Used by MonoPosixHelper or MonoSupportW, at least.
 gboolean        g_hash_table_remove          (GHashTable *hash, gconstpointer key);
 gboolean        g_hash_table_steal           (GHashTable *hash, gconstpointer key);
 void            g_hash_table_remove_all      (GHashTable *hash);
 guint           g_hash_table_foreach_remove  (GHashTable *hash, GHRFunc func, gpointer user_data);
 guint           g_hash_table_foreach_steal   (GHashTable *hash, GHRFunc func, gpointer user_data);
+G_EXTERN_C // Used by MonoPosixHelper or MonoSupportW, at least.
 void            g_hash_table_destroy         (GHashTable *hash);
 void            g_hash_table_print_stats     (GHashTable *table);
 
@@ -594,7 +612,9 @@ guint           g_spaced_primes_closest      (guint x);
 #define g_hash_table_insert(h,k,v)    g_hash_table_insert_replace ((h),(k),(v),FALSE)
 #define g_hash_table_replace(h,k,v)   g_hash_table_insert_replace ((h),(k),(v),TRUE)
 
+G_EXTERN_C // Used by MonoPosixHelper or MonoSupportW, at least.
 gboolean g_direct_equal (gconstpointer v1, gconstpointer v2);
+G_EXTERN_C // Used by MonoPosixHelper or MonoSupportW, at least.
 guint    g_direct_hash  (gconstpointer v1);
 gboolean g_int_equal    (gconstpointer v1, gconstpointer v2);
 guint    g_int_hash     (gconstpointer v1);
@@ -720,7 +740,9 @@ void           g_printerr             (const gchar *format, ...);
 GLogLevelFlags g_log_set_always_fatal (GLogLevelFlags fatal_mask);
 GLogLevelFlags g_log_set_fatal_mask   (const gchar *log_domain, GLogLevelFlags fatal_mask);
 void           g_logv                 (const gchar *log_domain, GLogLevelFlags log_level, const gchar *format, va_list args);
+G_EXTERN_C // Used by MonoPosixHelper or MonoSupportW, at least.
 void           g_log                  (const gchar *log_domain, GLogLevelFlags log_level, const gchar *format, ...);
+G_EXTERN_C // Used by MonoPosixHelper or MonoSupportW, at least.
 void           g_assertion_message    (const gchar *format, ...) G_GNUC_NORETURN;
 const char *   g_get_assertion_message (void);
 
@@ -916,9 +938,11 @@ gchar     *g_utf8_strdown (const gchar *str, gssize len);
 gint       g_unichar_to_utf8 (gunichar c, gchar *outbuf);
 gunichar  *g_utf8_to_ucs4_fast (const gchar *str, glong len, glong *items_written);
 gunichar  *g_utf8_to_ucs4 (const gchar *str, glong len, glong *items_read, glong *items_written, GError **err);
+G_EXTERN_C // Used by libtest, at least.
 gunichar2 *g_utf8_to_utf16 (const gchar *str, glong len, glong *items_read, glong *items_written, GError **err);
 gunichar2 *eg_utf8_to_utf16_with_nuls (const gchar *str, glong len, glong *items_read, glong *items_written, GError **err);
 gunichar2 *eg_wtf8_to_utf16 (const gchar *str, glong len, glong *items_read, glong *items_written, GError **err);
+G_EXTERN_C // Used by libtest, at least.
 gchar     *g_utf16_to_utf8 (const gunichar2 *str, glong len, glong *items_read, glong *items_written, GError **err);
 gunichar  *g_utf16_to_ucs4 (const gunichar2 *str, glong len, glong *items_read, glong *items_written, GError **err);
 gchar     *g_ucs4_to_utf8  (const gunichar *str, glong len, glong *items_read, glong *items_written, GError **err);

--- a/mono/eglib/gmodule.h
+++ b/mono/eglib/gmodule.h
@@ -25,7 +25,9 @@ G_ENUM_FUNCTIONS (GModuleFlags)
 
 typedef struct _GModule GModule;
 
+G_EXTERN_C // Used by libtest, at least.
 GModule *g_module_open (const gchar *file, GModuleFlags flags);
+G_EXTERN_C // Used by libtest, at least.
 gboolean g_module_symbol (GModule *module, const gchar *symbol_name,
 			  gpointer *symbol);
 const gchar *g_module_error (void);

--- a/mono/metadata/coree.h
+++ b/mono/metadata/coree.h
@@ -24,7 +24,7 @@
 #define STATUS_SUCCESS 0x00000000L
 #define STATUS_INVALID_IMAGE_FORMAT 0xC000007BL
 
-MONO_API STDAPI MonoFixupCorEE(HMODULE ModuleHandle);
+MONO_API HRESULT STDAPICALLTYPE MonoFixupCorEE(HMODULE ModuleHandle);
 
 /* Defined by the linker. */
 #ifndef _MSC_VER

--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -443,10 +443,13 @@ void mono_gc_register_altstack (gpointer stack, gint32 stack_size, gpointer alts
 
 gboolean mono_gc_is_critical_method (MonoMethod *method);
 
+G_EXTERN_C // due to THREAD_INFO_TYPE varying
 gpointer mono_gc_thread_attach (THREAD_INFO_TYPE *info);
 
+G_EXTERN_C // due to THREAD_INFO_TYPE varying
 void mono_gc_thread_detach_with_lock (THREAD_INFO_TYPE *info);
 
+G_EXTERN_C // due to THREAD_INFO_TYPE varying
 gboolean mono_gc_thread_in_critical_region (THREAD_INFO_TYPE *info);
 
 /* If set, print debugging messages around finalizers. */
@@ -458,4 +461,3 @@ extern gboolean mono_do_not_finalize;
 extern gchar **mono_do_not_finalize_class_names;
 
 #endif /* __MONO_METADATA_GC_INTERNAL_H__ */
-

--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -21,6 +21,8 @@ static int log_level = 1;
 #define DEBUG_PRINTF(level, ...) do { if (G_UNLIKELY ((level) <= log_level)) { fprintf (stdout, __VA_ARGS__); } } while (0)
 
 //functions exported to be used by JS
+G_BEGIN_DECLS
+
 EMSCRIPTEN_KEEPALIVE int mono_wasm_set_breakpoint (const char *assembly_name, int method_token, int il_offset);
 EMSCRIPTEN_KEEPALIVE int mono_wasm_remove_breakpoint (int bp_id);
 EMSCRIPTEN_KEEPALIVE int mono_wasm_current_bp_id (void);
@@ -38,6 +40,8 @@ extern void mono_wasm_add_long_var (gint64);
 extern void mono_wasm_add_float_var (float);
 extern void mono_wasm_add_double_var (double);
 extern void mono_wasm_add_string_var (const char*);
+
+G_END_DECLS
 
 //FIXME move all of those fields to the profiler object
 static gboolean debugger_enabled;
@@ -670,7 +674,7 @@ mono_debugger_tls_thread_id (DebuggerTlsData *debuggerTlsData)
 	return 1;
 }
 
-#else
+#else // HOST_WASM
 
 void
 mono_wasm_single_step_hit (void)
@@ -687,4 +691,4 @@ mono_wasm_debugger_init (void)
 {
 }
 
-#endif
+#endif // HOST_WASM

--- a/mono/mini/mini-wasm.c
+++ b/mono/mini/mini-wasm.c
@@ -352,7 +352,8 @@ mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig,
 {
 	return FALSE;
 }
-#endif
+
+#endif // DISABLE_JIT
 
 int
 mono_arch_get_argument_info (MonoMethodSignature *csig, int param_count, MonoJitArgumentInfo *arg_info)
@@ -380,12 +381,18 @@ mono_arch_get_delegate_invoke_impl (MonoMethodSignature *sig, gboolean has_targe
 }
 
 #ifdef HOST_WASM
+
 #include <emscripten.h>
+
 //functions exported to be used by JS
+G_BEGIN_DECLS
 EMSCRIPTEN_KEEPALIVE void mono_set_timeout_exec (int id);
+
 //JS functions imported that we use
 extern void mono_set_timeout (int t, int d);
-#endif
+G_END_DECLS
+
+#endif // HOST_WASM
 
 gpointer
 mono_arch_get_this_arg_from_call (mgreg_t *regs, guint8 *code)
@@ -579,6 +586,9 @@ mono_arch_patch_code_new (MonoCompile *cfg, MonoDomain *domain, guint8 *code, Mo
 The following functions don't belong here, but are due to laziness.
 */
 gboolean mono_w32file_get_volume_information (const gunichar2 *path, gunichar2 *volumename, gint volumesize, gint *outserial, gint *maxcomp, gint *fsflags, gunichar2 *fsbuffer, gint fsbuffersize);
+
+G_BEGIN_DECLS
+
 void * getgrnam (const char *name);
 void * getgrgid (gid_t gid);
 int inotify_init (void);
@@ -586,6 +596,7 @@ int inotify_rm_watch (int fd, int wd);
 int inotify_add_watch (int fd, const char *pathname, uint32_t mask);
 int sem_timedwait (sem_t *sem, const struct timespec *abs_timeout);
 
+G_END_DECLS
 
 //w32file-wasm.c
 gboolean
@@ -606,6 +617,7 @@ mono_w32file_get_volume_information (const gunichar2 *path, gunichar2 *volumenam
 	return status;
 }
 
+G_BEGIN_DECLS
 
 //llvm builtin's that we should not have used in the first place
 
@@ -689,4 +701,7 @@ sem_timedwait (sem_t *sem, const struct timespec *abs_timeout)
 	return 0;
 	
 }
-#endif
+
+G_END_DECLS
+
+#endif // HOST_WASM

--- a/mono/mini/mini-wasm.h
+++ b/mono/mini/mini-wasm.h
@@ -103,7 +103,12 @@ typedef struct {
 
 void mono_wasm_debugger_init (void);
 
+G_BEGIN_DECLS // sdks/wasm/driver.c is C and uses this
+
 void mono_wasm_enable_debugging (void);
+
+G_END_DECLS
+
 void mono_wasm_breakpoint_hit (void);
 void mono_wasm_set_timeout (int timeout, int id);
 

--- a/mono/utils/mono-threads-coop.h
+++ b/mono/utils/mono-threads-coop.h
@@ -71,9 +71,11 @@ void mono_threads_suspend_override_policy (MonoThreadsSuspendPolicy new_policy);
  * runtime assertion error when trying to switch the state of the current thread.
  */
 
+G_EXTERN_C // due to THREAD_INFO_TYPE varying
 gpointer
 mono_threads_enter_gc_safe_region_with_info (THREAD_INFO_TYPE *info, MonoStackData *stackdata);
 
+G_EXTERN_C // due to THREAD_INFO_TYPE varying
 gpointer
 mono_threads_enter_gc_safe_region_with_info (THREAD_INFO_TYPE *info, MonoStackData *stackdata);
 
@@ -84,9 +86,11 @@ mono_threads_enter_gc_safe_region_with_info (THREAD_INFO_TYPE *info, MonoStackDa
 
 #define MONO_EXIT_GC_SAFE_WITH_INFO	MONO_EXIT_GC_SAFE
 
+G_EXTERN_C // due to THREAD_INFO_TYPE varying
 gpointer
 mono_threads_enter_gc_unsafe_region_with_info (THREAD_INFO_TYPE *, MonoStackData *stackdata);
 
+G_EXTERN_C // due to THREAD_INFO_TYPE varying
 gpointer
 mono_threads_enter_gc_unsafe_region_with_info (THREAD_INFO_TYPE *, MonoStackData *stackdata);
 
@@ -97,6 +101,7 @@ mono_threads_enter_gc_unsafe_region_with_info (THREAD_INFO_TYPE *, MonoStackData
 
 #define MONO_EXIT_GC_UNSAFE_WITH_INFO	MONO_EXIT_GC_UNSAFE
 
+G_EXTERN_C // due to THREAD_INFO_TYPE varying
 gpointer
 mono_threads_enter_gc_unsafe_region_unbalanced_with_info (THREAD_INFO_TYPE *info, MonoStackData *stackdata);
 

--- a/mono/utils/mono-threads-wasm.c
+++ b/mono/utils/mono-threads-wasm.c
@@ -158,7 +158,7 @@ mono_threads_platform_in_critical_region (MonoNativeThreadId tid)
 	return FALSE;
 }
 
-
+G_EXTERN_C
 extern void schedule_background_exec (void);
 
 static GSList *jobs;
@@ -173,6 +173,7 @@ mono_threads_schedule_background_job (background_job_cb cb)
 		jobs = g_slist_prepend (jobs, cb);
 }
 
+G_EXTERN_C
 EMSCRIPTEN_KEEPALIVE void
 mono_background_exec (void)
 {

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -507,6 +507,7 @@ mono_thread_info_is_interrupt_state (THREAD_INFO_TYPE *info);
 void
 mono_thread_info_describe_interrupt_token (THREAD_INFO_TYPE *info, GString *text);
 
+G_EXTERN_C // due to THREAD_INFO_TYPE varying
 gboolean
 mono_thread_info_is_live (THREAD_INFO_TYPE *info);
 
@@ -675,7 +676,7 @@ MonoDoneBlockingResult mono_threads_transition_done_blocking (THREAD_INFO_TYPE* 
 MonoAbortBlockingResult mono_threads_transition_abort_blocking (THREAD_INFO_TYPE* info, const char* func);
 gboolean mono_threads_transition_peek_blocking_suspend_requested (THREAD_INFO_TYPE* info);
 
-
+G_EXTERN_C // due to THREAD_INFO_TYPE varying
 MonoThreadUnwindState* mono_thread_info_get_suspend_state (THREAD_INFO_TYPE *info);
 
 gpointer
@@ -684,8 +685,10 @@ mono_threads_enter_gc_unsafe_region_cookie (void);
 
 void mono_thread_info_wait_for_resume (THREAD_INFO_TYPE *info);
 /* Advanced suspend API, used for suspending multiple threads as once. */
+G_EXTERN_C // due to THREAD_INFO_TYPE varying
 gboolean mono_thread_info_is_running (THREAD_INFO_TYPE *info);
 gboolean mono_thread_info_is_live (THREAD_INFO_TYPE *info);
+G_EXTERN_C // due to THREAD_INFO_TYPE varying
 int mono_thread_info_suspend_count (THREAD_INFO_TYPE *info);
 int mono_thread_info_current_state (THREAD_INFO_TYPE *info);
 const char* mono_thread_state_name (int state);
@@ -720,8 +723,11 @@ typedef enum {
 	MONO_THREAD_BEGIN_SUSPEND_NEXT_PHASE = 2,
 } MonoThreadBeginSuspendResult;
 
+G_EXTERN_C // due to THREAD_INFO_TYPE varying
 gboolean mono_thread_info_in_critical_location (THREAD_INFO_TYPE *info);
+G_EXTERN_C // due to THREAD_INFO_TYPE varying
 MonoThreadBeginSuspendResult mono_thread_info_begin_suspend (THREAD_INFO_TYPE *info, MonoThreadSuspendPhase phase);
+G_EXTERN_C // due to THREAD_INFO_TYPE varying
 gboolean mono_thread_info_begin_resume (THREAD_INFO_TYPE *info);
 
 void mono_threads_add_to_pending_operation_set (THREAD_INFO_TYPE* info); //XXX rename to something to reflect the fact that this is used for both suspend and resume


### PR DESCRIPTION
…noPosixHelper, THREAD_INFO_TYPE, WebAssembly interop.

Some of this is redundant, i.e. in glib.h and mono-threads-coop.h.
But if someone removes otherwise unnecessary header wrappers, these become meaningful.

This is an alternative to:
https://github.com/mono/mono/pull/10160 Remove most G_BEGIN_DECLS but add back to make things work.
https://github.com/mono/mono/pull/10284 Port libtest to C++
https://github.com/mono/mono/pull/10294 Rework mono-threads.h THREAD_INFO_TYPE parameterization to not violate C++ typesafe linkage.
https://github.com/mono/mono/pull/10297 Fix typesafe linkage problem in gc-internals.h THREAD_INFO_TYPE parameterization.
https://github.com/mono/mono/pull/10341 Port all of MonoPosixHelper MonoSupportW to C++, including K&R zlib.
https://github.com/mono/mono/pull/10342 Port profilers to C++
https://github.com/mono/mono/pull/10378 Port all of MonoPosixHelper MonoSupportW to C++, except K&R zlib.
https://github.com/mono/mono/pull/10375 Eliminate THREAD_INFO_TYPE by suggestion, to fix typesafe linkage.
https://github.com/mono/mono/pull/10379 Mark the 14 functions used by MonoPosixHelper as extern "C" (basically this PR)

Most of the alternatives are very reasonable and remain viable, except porting K&R zlib.
Hopefully in future, SgenThreadInfo will derive from MonoThreadInfo, improving the THREAD_INFO_TYPE fixes.

These PRs whittled away at the problem from the other side:
https://github.com/mono/mono/pull/10271 Port pedump, monograph, monodis, unit-tests.
https://github.com/mono/mono/pull/10345 Port mono main to be C++
https://github.com/mono/mono/pull/10368 Port sgen-grep-binprot to C++