### PR TITLE
Fix Mono Windows cross compiler using mono LLVM release_60 branch.

### DIFF
--- a/llvm/Makefile.am
+++ b/llvm/Makefile.am
@@ -9,6 +9,12 @@ else
 llvm_config=llvm-config
 endif
 
+if HAVE_ZLIB
+llvm_extra_libs=-lz
+else
+llvm_extra_libs=
+endif
+
 if INTERNAL_LLVM
 
 all-local: configure-llvm build-llvm install-llvm llvm_config.mk
@@ -16,7 +22,7 @@ all-local: configure-llvm build-llvm install-llvm llvm_config.mk
 clean-local: clean-llvm clean-llvm-config
 
 $(mono_build_root)/llvm/llvm_config.mk: install-llvm
-	$(top_srcdir)/llvm/build_llvm_config.sh $(top_srcdir)/llvm/usr/bin/$(llvm_config) $(LLVM_CODEGEN_LIBS) > $@
+	$(top_srcdir)/llvm/build_llvm_config.sh "$(top_srcdir)/llvm/usr/bin/$(llvm_config)" "$(LLVM_CODEGEN_LIBS)" "$(llvm_extra_libs)" > $@
 
 else
 all-local: llvm_config.mk
@@ -24,7 +30,7 @@ all-local: llvm_config.mk
 clean-local: clean-llvm-config
 
 $(mono_build_root)/llvm/llvm_config.mk: $(top_srcdir)/llvm/Makefile.am
-	$(top_srcdir)/llvm/build_llvm_config.sh $(EXTERNAL_LLVM_CONFIG) $(LLVM_CODEGEN_LIBS) > $@
+	$(top_srcdir)/llvm/build_llvm_config.sh "$(EXTERNAL_LLVM_CONFIG)" "$(LLVM_CODEGEN_LIBS)" "$(llvm_extra_libs)" > $@
 endif
 
 llvm_config.mk: $(mono_build_root)/llvm/llvm_config.mk

--- a/llvm/build_llvm_config.sh
+++ b/llvm/build_llvm_config.sh
@@ -48,7 +48,11 @@ if [[ $use_llvm_config = 1 ]]; then
 	llvm_config_cflags=`$llvm_config --cflags`
 	llvm_system=`$llvm_config --system-libs`
 	llvm_core_components=`$llvm_config --libs analysis core bitwriter`
-	llvm_old_jit=`$llvm_config --libs mcjit jit 2>>/dev/null`
+	if [[ $llvm_api_version -lt 600 ]]; then
+		llvm_old_jit=`$llvm_config --libs mcjit jit 2>>/dev/null`
+	else
+		llvm_old_jit=`$llvm_config --libs mcjit 2>>/dev/null`
+	fi
 	llvm_new_jit=`$llvm_config --libs orcjit 2>>/dev/null`
 	llvm_extra=`$llvm_config --libs $extra_libs`
 
@@ -67,13 +71,66 @@ if [[ $llvm_host_win32 = 1 ]] && [[ $use_llvm_config = 0 ]]; then
 	with_llvm="$(dirname $with_llvm)"
 	llvm_config_path=$with_llvm/include/llvm/Config/llvm-config.h
 
+	# llvm-config.exe --mono-api-version
 	llvm_api_version=`awk '/MONO_API_VERSION/ { print $3 }' $llvm_config_path`
+
+	# llvm-config.exe --cflags, returned information currently not used.
 	llvm_config_cflags=
-	llvm_system="-lshell32 -lpsapi -limagehlp"
-	llvm_core_components="-lLLVMBitWriter -lLLVMAnalysis -lLLVMTarget -lLLVMMC -lLLVMCore -lLLVMSupport"
-	llvm_old_jit="-lLLVMJIT -lLLVMCodeGen -lLLVMScalarOpts -lLLVMInstCombine -lLLVMTransformUtils -lLLVMipa -lLLVMAnalysis -lLLVMMCJIT -lLLVMTarget -lLLVMRuntimeDyld -lLLVMObject -lLLVMMCParser -lLLVMBitReader -lLLVMExecutionEngine -lLLVMMC -lLLVMCore -lLLVMSupport"
+
+	# llvm-config.exe --system-libs
+	if [[ $llvm_api_version -lt 600 ]]; then
+		llvm_system="-limagehlp -lpsapi -lshell32"
+	else
+		llvm_system="-lpsapi -lshell32 -lole32 -luuid -ladvapi32"
+	fi
+
+	# llvm-config.exe --libs analysis core bitwriter
+	if [[ $llvm_api_version -lt 600 ]]; then
+		llvm_core_components="-lLLVMBitWriter -lLLVMAnalysis -lLLVMTarget -lLLVMMC -lLLVMCore -lLLVMSupport"
+	else
+		llvm_core_components="-lLLVMBitWriter -lLLVMAnalysis -lLLVMProfileData -lLLVMObject -lLLVMMCParser -lLLVMMC -lLLVMBitReader -lLLVMCore -lLLVMBinaryFormat -lLLVMSupport -lLLVMDemangle"
+	fi
+
+	# llvm-config.exe --libs mcjit jit
+	if [[ $llvm_api_version -lt 600 ]]; then
+		llvm_old_jit="-lLLVMJIT -lLLVMCodeGen -lLLVMScalarOpts -lLLVMInstCombine -lLLVMTransformUtils -lLLVMipa -lLLVMAnalysis -lLLVMMCJIT -lLLVMTarget -lLLVMRuntimeDyld -lLLVMObject -lLLVMMCParser -lLLVMBitReader -lLLVMExecutionEngine -lLLVMMC -lLLVMCore -lLLVMSupport"
+	else
+		# Current build of LLVM 60 for cross Windows builds doesn't support LLVM JIT.
+		llvm_old_jit=
+	fi
+
+	# LLVM 36 doesn't support new JIT and LLVM 60 is build without LLVM JIT support for cross Windows builds.
 	llvm_new_jit=
-	llvm_extra=
+
+	# Check codegen libs and add needed libraries.
+	case "$extra_libs" in
+		*x86codegen*)
+			# llvm-config.exe --libs x86codegen
+			if [[ $llvm_api_version -lt 600 ]]; then
+				llvm_extra="-lLLVMX86CodeGen -lLLVMX86Desc -lLLVMX86Info -lLLVMObject -lLLVMBitReader -lLLVMMCDisassembler -lLLVMX86AsmPrinter -lLLVMX86Utils -lLLVMSelectionDAG -lLLVMAsmPrinter -lLLVMMCParser -lLLVMCodeGen -lLLVMScalarOpts -lLLVMInstCombine -lLLVMTransformUtils -lLLVMipa -lLLVMAnalysis -lLLVMTarget -lLLVMMC -lLLVMCore -lLLVMSupport"
+			else
+				llvm_extra="-lLLVMX86CodeGen -lLLVMGlobalISel -lLLVMX86Desc -lLLVMX86Info -lLLVMMCDisassembler -lLLVMX86AsmPrinter -lLLVMX86Utils -lLLVMSelectionDAG -lLLVMAsmPrinter -lLLVMDebugInfoCodeView -lLLVMDebugInfoMSF -lLLVMCodeGen -lLLVMTarget -lLLVMScalarOpts -lLLVMInstCombine -lLLVMTransformUtils -lLLVMBitWriter -lLLVMAnalysis -lLLVMProfileData -lLLVMObject -lLLVMMCParser -lLLVMMC -lLLVMBitReader -lLLVMCore -lLLVMBinaryFormat -lLLVMSupport -lLLVMDemangle"
+			fi
+			;;
+		*armcodegen*)
+			# llvm-config.exe --libs armcodegen
+			if [[ $llvm_api_version -lt 600 ]]; then
+				llvm_extra="-lLLVMARMCodeGen -lLLVMSelectionDAG -lLLVMAsmPrinter -lLLVMMCParser -lLLVMCodeGen -lLLVMScalarOpts -lLLVMInstCombine -lLLVMTransformUtils -lLLVMipa -lLLVMAnalysis -lLLVMTarget -lLLVMCore -lLLVMARMDesc -lLLVMMCDisassembler -lLLVMARMInfo -lLLVMARMAsmPrinter -lLLVMMC -lLLVMSupport"
+			else
+				llvm_extra="-lLLVMARMCodeGen -lLLVMGlobalISel -lLLVMSelectionDAG -lLLVMAsmPrinter -lLLVMDebugInfoCodeView -lLLVMDebugInfoMSF -lLLVMCodeGen -lLLVMTarget -lLLVMScalarOpts -lLLVMInstCombine -lLLVMTransformUtils -lLLVMBitWriter -lLLVMAnalysis -lLLVMProfileData -lLLVMObject -lLLVMMCParser -lLLVMBitReader -lLLVMCore -lLLVMBinaryFormat -lLLVMARMDesc -lLLVMMCDisassembler -lLLVMARMInfo -lLLVMARMAsmPrinter -lLLVMARMUtils -lLLVMMC -lLLVMSupport -lLLVMDemangle"
+			fi
+			;;
+		*aarch64codegen*)
+			# llvm-config.exe --libs aarch64codegen
+			if [ [$llvm_api_version -lt 600 ]]; then
+				llvm_extra="-lLLVMAArch64CodeGen -lLLVMGlobalISel -lLLVMSelectionDAG -lLLVMAsmPrinter -lLLVMDebugInfoCodeView -lLLVMDebugInfoMSF -lLLVMCodeGen -lLLVMTarget -lLLVMScalarOpts -lLLVMInstCombine -lLLVMTransformUtils -lLLVMBitWriter -lLLVMAnalysis -lLLVMProfileData -lLLVMObject -lLLVMMCParser -lLLVMBitReader -lLLVMCore -lLLVMBinaryFormat -lLLVMAArch64Desc -lLLVMAArch64Info -lLLVMAArch64AsmPrinter -lLLVMMC -lLLVMAArch64Utils -lLLVMSupport -lLLVMDemangle"
+			else
+				llvm_extra="-lLLVMAArch64CodeGen -lLLVMSelectionDAG -lLLVMAsmPrinter -lLLVMMCParser -lLLVMCodeGen -lLLVMScalarOpts -lLLVMInstCombine -lLLVMTransformUtils -lLLVMipa -lLLVMAnalysis -lLLVMTarget -lLLVMCore -lLLVMAArch64Desc -lLLVMAArch64Info -lLLVMAArch64AsmPrinter -lLLVMMC -lLLVMAArch64Utils -lLLVMSupport"
+			fi
+			;;
+		*)
+			llvm_extra=$extra_libs
+	esac
 fi
 
 if [[ $llvm_config_cflags = *"stdlib=libc++"* ]]; then

--- a/llvm/build_llvm_config.sh
+++ b/llvm/build_llvm_config.sh
@@ -126,10 +126,10 @@ if [[ $llvm_host_win32 = 1 ]] && [[ $use_llvm_config = 0 ]]; then
 			;;
 		*aarch64codegen*)
 			# llvm-config.exe --libs aarch64codegen
-			if [ [$llvm_api_version -lt 600 ]]; then
-				llvm_extra="-lLLVMAArch64CodeGen -lLLVMGlobalISel -lLLVMSelectionDAG -lLLVMAsmPrinter -lLLVMDebugInfoCodeView -lLLVMDebugInfoMSF -lLLVMCodeGen -lLLVMTarget -lLLVMScalarOpts -lLLVMInstCombine -lLLVMTransformUtils -lLLVMBitWriter -lLLVMAnalysis -lLLVMProfileData -lLLVMObject -lLLVMMCParser -lLLVMBitReader -lLLVMCore -lLLVMBinaryFormat -lLLVMAArch64Desc -lLLVMAArch64Info -lLLVMAArch64AsmPrinter -lLLVMMC -lLLVMAArch64Utils -lLLVMSupport -lLLVMDemangle"
-			else
+			if [[ $llvm_api_version -lt 600 ]]; then
 				llvm_extra="-lLLVMAArch64CodeGen -lLLVMSelectionDAG -lLLVMAsmPrinter -lLLVMMCParser -lLLVMCodeGen -lLLVMScalarOpts -lLLVMInstCombine -lLLVMTransformUtils -lLLVMipa -lLLVMAnalysis -lLLVMTarget -lLLVMCore -lLLVMAArch64Desc -lLLVMAArch64Info -lLLVMAArch64AsmPrinter -lLLVMMC -lLLVMAArch64Utils -lLLVMSupport"
+			else
+				llvm_extra="-lLLVMAArch64CodeGen -lLLVMGlobalISel -lLLVMSelectionDAG -lLLVMAsmPrinter -lLLVMDebugInfoCodeView -lLLVMDebugInfoMSF -lLLVMCodeGen -lLLVMTarget -lLLVMScalarOpts -lLLVMInstCombine -lLLVMTransformUtils -lLLVMBitWriter -lLLVMAnalysis -lLLVMProfileData -lLLVMObject -lLLVMMCParser -lLLVMBitReader -lLLVMCore -lLLVMBinaryFormat -lLLVMAArch64Desc -lLLVMAArch64Info -lLLVMAArch64AsmPrinter -lLLVMMC -lLLVMAArch64Utils -lLLVMSupport -lLLVMDemangle"
 			fi
 			;;
 		*)

--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -183,8 +183,8 @@ system_native_android_sources = \
 	pal-android.h \
 	pal-android.c
 
-if !TARGET_WIN32
-if !WASM
+if !HOST_WIN32
+if !HOST_WASM
 lib_LTLIBRARIES += libmono-system-native.la
 libmono_system_native_la_SOURCES = $(system_native_common_sources)
 if TARGET_OSX

--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -141,8 +141,7 @@ if [[ ${CI_TAGS} == *'product-sdks-android'* ]];
             ${TESTCMD} --label=provision-mxe --timeout=240m --fatal make -j4 -C sdks/builds provision-mxe
         fi
         ${TESTCMD} --label=llvm --timeout=240m --fatal make -j4 -C sdks/builds provision-llvm-llvm{,win}{32,64}
-        # FIXME: ${TESTCMD} --label=runtimes --timeout=120m --fatal make -j4 -C sdks/builds package-android-{armeabi-v7a,arm64-v8a,x86,x86_64} package-android-host-{Darwin,mxe-Win64} package-android-cross-{arm,arm64,x86,x86_64}{,-win}
-        ${TESTCMD} --label=runtimes --timeout=120m --fatal make -j4 -C sdks/builds package-android-{armeabi-v7a,arm64-v8a,x86,x86_64} package-android-host-{Darwin,mxe-Win64} package-android-cross-{arm,arm64,x86,x86_64}
+        ${TESTCMD} --label=runtimes --timeout=120m --fatal make -j4 -C sdks/builds package-android-{armeabi-v7a,arm64-v8a,x86,x86_64} package-android-host-{Darwin,mxe-Win64} package-android-cross-{arm,arm64,x86,x86_64}{,-win}
         exit 0
 fi
 


### PR DESCRIPTION
Fix Mono Windows cross compiler using mono LLVM release_60 branch.

For scenario where llvm-config.exe can't be run (none WSL/CygWin build target) build will fallback to hard coded libraries not working with mono LLVM release_60 branch.

Added an exact mirror of what llvm-config.exe is returning for different components on mono LLVM master and mono LLVM release_60 branch.

The selected codegen libraries (passed in as extra_libs) was not handled in any cases so added them into the build script as well.

Above successfully builds using mono LLVM master and mono LLVM release_60 branches and links into Windows mono cross compiler build on Linux.
