### PR TITLE
[sdb]: Properly version the `CMD_TYPE_GET_METHODS_BY_NAME_FLAGS` change.

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -420,7 +420,7 @@ namespace Mono.Debugger.Soft
 		 * with newer runtimes, and vice versa.
 		 */
 		internal const int MAJOR_VERSION = 2;
-		internal const int MINOR_VERSION = 47;
+		internal const int MINOR_VERSION = 48;
 
 		enum WPSuspendPolicy {
 			NONE = 0,
@@ -2325,7 +2325,10 @@ namespace Mono.Debugger.Soft
 		public long[] Type_GetMethodsByNameFlags (long id, string name, int flags, bool ignoreCase) {
 			flags |= ignoreCase ? (int)BindingFlagsExtensions.BINDING_FLAGS_IGNORE_CASE : 0;
 			int listType = ignoreCase ? (int)MemberListTypeExtensions.CaseInsensitive : (int)MemberListTypeExtensions.CaseSensitive;
-			PacketReader r = SendReceive (CommandSet.TYPE, (int)CmdType.CMD_TYPE_GET_METHODS_BY_NAME_FLAGS, new PacketWriter ().WriteId (id).WriteString (name).WriteInt (flags).WriteInt (listType));
+			var w = new PacketWriter ().WriteId (id).WriteString (name).WriteInt (flags);
+			if (Version.AtLeast (2, 48))
+				w.WriteInt (listType);
+			PacketReader r = SendReceive (CommandSet.TYPE, (int)CmdType.CMD_TYPE_GET_METHODS_BY_NAME_FLAGS, w);
 			int len = r.ReadInt ();
 			long[] res = new long [len];
 			for (int i = 0; i < len; ++i)

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -273,7 +273,7 @@ typedef struct {
 #define HEADER_LENGTH 11
 
 #define MAJOR_VERSION 2
-#define MINOR_VERSION 47
+#define MINOR_VERSION 48
 
 typedef enum {
 	CMD_SET_VM = 1,
@@ -7856,7 +7856,11 @@ type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint
 	case CMD_TYPE_GET_METHODS_BY_NAME_FLAGS: {
 		char *name = decode_string (p, &p, end);
 		int i, flags = decode_int (p, &p, end);
-		int mlisttype = decode_int (p, &p, end);
+		int mlisttype;
+		if (CHECK_PROTOCOL_VERSION (2, 48))
+			mlisttype = decode_int (p, &p, end);
+		else
+			mlisttype = 0; // MLISTTYPE_All
 		ERROR_DECL (error);
 		GPtrArray *array;
 


### PR DESCRIPTION
This adds proper versioning to the wire change that was introduced in #9762.

Fixes #10412.