### PR TITLE
Fix `make dist`, broken by 6dc01610e5509c5b41a34dc688fb588268b3b0c5

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -280,7 +280,6 @@ endif
 wasm_sources = \
 	mini-wasm.c		\
 	mini-wasm.h		\
-	mini-wasm-debugger.c	\
 	debugger-engine.c	\
 	exceptions-wasm.c	\
 	tramp-wasm.c


### PR DESCRIPTION
```
04:07:52 make[3]: Leaving directory `/mnt/jenkins/workspace/release-tarball-mono/mono/mini'
04:07:52 
make[3]: *** No rule to make target `mini-wasm-debugger.c', needed by `distdir'.  Stop.
04:07:52 
make[2]: *** [distdir] Error 1
04:07:52 make[2]: Leaving directory `/mnt/jenkins/workspace/release-tarball-mono/mono'
```

https://jenkins.mono-project.com/view/Releases/job/release-tarball-mono/923/console