### PR TITLE
[MacSDK] Go back to incluging opt/llc after change in LLVM install process

### DIFF
--- a/packaging/MacSDK/mono.py
+++ b/packaging/MacSDK/mono.py
@@ -84,6 +84,13 @@ class MonoMasterPackage(Package):
             "LocalMachine")
         ensure_dir(registry_dir)
 
+        # LLVM build installs itself under the source tree; move tools to mono's install path
+        llvm_tools_path = os.path.join(self.workspace, 'llvm/usr/bin')
+        target = os.path.join(self.staged_prefix, 'bin')
+        ensure_dir(target)
+        for tool in ['opt','llc']:
+            shutil.move(os.path.join(llvm_tools_path, tool), target)
+
     def deploy(self):
         if bockbuild.cmd_options.arch == 'darwin-universal':
             os.symlink('mono-sgen64', '%s/bin/mono64' % self.staged_profile)


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/10243



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
