### PR TITLE
[cxx][wasm] Fix mismatched extern "C".

### DIFF
--- a/mono/metadata/attach.c
+++ b/mono/metadata/attach.c
@@ -11,6 +11,7 @@
 
 #include <config.h>
 #include <glib.h>
+#include "attach.h"
 
 #ifdef HOST_WIN32
 #define DISABLE_ATTACH
@@ -39,7 +40,6 @@
 #include <mono/metadata/threads-types.h>
 #include <mono/metadata/gc-internals.h>
 #include <mono/utils/mono-threads.h>
-#include "attach.h"
 
 #include <mono/utils/w32api.h>
 

--- a/mono/metadata/attach.h
+++ b/mono/metadata/attach.h
@@ -8,8 +8,6 @@
 #include <glib.h>
 #include <mono/utils/mono-compiler.h>
 
-G_BEGIN_DECLS
-
 void
 mono_attach_parse_options (char *options);
 
@@ -24,7 +22,5 @@ mono_attach_maybe_start (void);
 
 void
 mono_attach_cleanup (void);
-
-G_END_DECLS
 
 #endif

--- a/mono/metadata/w32file.h
+++ b/mono/metadata/w32file.h
@@ -21,8 +21,6 @@
 #include <mono/utils/mono-compiler.h>
 #include <mono/metadata/icalls.h>
 
-G_BEGIN_DECLS
-
 /* This is a copy of System.IO.FileAccess */
 typedef enum {
 	FileAccess_Read=0x01,
@@ -501,7 +499,5 @@ mono_w32file_get_drive_type (const gunichar2 *root_path_name);
 
 gboolean
 mono_w32file_get_volume_information (const gunichar2 *path, gunichar2 *volumename, gint volumesize, gint *outserial, gint *maxcomp, gint *fsflags, gunichar2 *fsbuffer, gint fsbuffersize);
-
-G_END_DECLS
 
 #endif /* _MONO_METADATA_W32FILE_H_ */


### PR DESCRIPTION
[cxx][wasm] Fix mismatched extern "C".

https://jenkins.mono-project.com/job/test-mono-pull-request-wasm/4437/parsed_console/log.html
WASM-ERR: missing function: mono_attach_init

https://jenkins.mono-project.com/job/w/15060/parsed_console/log.html
attach.c:600:1: warning: no previous declaration for 'void mono_attach_parse_options(char*)' [-Wmissing-declarations]
attach.c:605:1: warning: no previous declaration for 'void mono_attach_init()' [-Wmissing-declarations]
attach.c:610:1: warning: no previous declaration for 'gboolean mono_attach_start()' [-Wmissing-declarations]
attach.c:616:1: warning: no previous declaration for 'void mono_attach_maybe_start()' [-Wmissing-declarations]
attach.c:621:1: warning: no previous declaration for 'void mono_attach_cleanup()' [-Wmissing-declarations]

https://jenkins.mono-project.com/job/test-mono-pull-request-wasm/4437/parsed_console/log.html
warning: unresolved symbol: mono_attach_cleanup
warning: unresolved symbol: mono_attach_init
warning: unresolved symbol: mono_attach_maybe_start
warning: unresolved symbol: mono_w32file_get_volume_information