### PR TITLE
[cxx] Adapt typesafe coop handles for standard/Visual C++.

### DIFF
--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -384,7 +384,7 @@ Handle macros/functions
 
 #if MONO_TYPE_SAFE_HANDLES
 #define TYPED_HANDLE_DECL(TYPE)							\
-	typedef struct TYPED_HANDLE_NAME (TYPE) {				\
+	typedef struct {							\
 		MONO_IF_CPLUSPLUS (						\
 			MONO_ALWAYS_INLINE					\
 			TYPE * GetRaw () { return __raw ? *__raw : NULL; }	\

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -376,11 +376,23 @@ Handle macros/functions
  * #endif
  */
 
+#ifdef __cplusplus
+#define MONO_IF_CPLUSPLUS(x) x
+#else
+#define MONO_IF_CPLUSPLUS(x) /* nothing */
+#endif
+
 #if MONO_TYPE_SAFE_HANDLES
 #define TYPED_HANDLE_DECL(TYPE)							\
-	typedef struct { TYPE **__raw; } TYPED_HANDLE_PAYLOAD_NAME (TYPE),	\
-					 TYPED_HANDLE_NAME (TYPE),		\
-					 TYPED_OUT_HANDLE_NAME (TYPE);		\
+	typedef struct TYPED_HANDLE_NAME (TYPE) {				\
+		MONO_IF_CPLUSPLUS (						\
+			MONO_ALWAYS_INLINE					\
+			TYPE * GetRaw () { return __raw ? *__raw : NULL; }	\
+		)								\
+		TYPE **__raw;							\
+	} TYPED_HANDLE_PAYLOAD_NAME (TYPE),					\
+	  TYPED_HANDLE_NAME (TYPE),						\
+	  TYPED_OUT_HANDLE_NAME (TYPE);						\
 /* Do not call these functions directly. Use MONO_HANDLE_NEW and MONO_HANDLE_CAST. */ \
 /* Another way to do this involved casting mono_handle_new function to a different type. */ \
 static inline MONO_ALWAYS_INLINE TYPED_HANDLE_NAME (TYPE) 	\
@@ -442,7 +454,11 @@ typedef struct _MonoTypeofCastHelper *MonoTypeofCastHelper; // a pointer type un
 #endif
 
 #define MONO_HANDLE_CAST(type, value) (MONO_HANDLE_CAST_FOR (type) ((value).__raw))
+#ifdef __cplusplus
+#define MONO_HANDLE_RAW(handle)     ((handle).GetRaw())
+#else
 #define MONO_HANDLE_RAW(handle)     (MONO_TYPEOF_CAST (*(handle).__raw, mono_handle_raw ((handle).__raw)))
+#endif
 #define MONO_HANDLE_IS_NULL(handle) (mono_handle_is_null ((handle).__raw))
 
 #else // MONO_TYPE_SAFE_HANDLES


### PR DESCRIPTION
W/o gcc/clang language extension `__typeof__`. This is not meant to be
long term idiomatic C++, just enough to get us by for now.

The solution does not quite work for type unsafe handles, because
checking for this == NULL is not defined. A non-member function
would be needed.

C++11 decltype could be used instead at the MONO_TYPEOF_CAST level,
but this solution is trivial C++98.