### PR TITLE
[tests] Bump timeout for System.Numerics with interpreter

### DIFF
--- a/scripts/ci/run-test-interpreter.sh
+++ b/scripts/ci/run-test-interpreter.sh
@@ -70,7 +70,7 @@ if [[ ${CI_TAGS} != *'pull-request'* ]] || [[ ${CI_TAGS} != *'arm'* ]]; then
 	${TESTCMD} --label=Mono.CSharp --timeout=5m make -w -C mcs/class/Mono.CSharp run-test V=1
 	${TESTCMD} --label=WindowsBase --timeout=5m make -w -C mcs/class/WindowsBase run-test V=1
 	${TESTCMD} --label=System.Numerics --timeout=5m make -w -C mcs/class/System.Numerics run-test V=1
-	${TESTCMD} --label=System.Numerics-xunit --timeout=5m make -w -C mcs/class/System.Numerics run-xunit-test V=1
+	${TESTCMD} --label=System.Numerics-xunit --timeout=20m make -w -C mcs/class/System.Numerics run-xunit-test V=1
 	${TESTCMD} --label=System.Runtime.DurableInstancing --timeout=5m make -w -C mcs/class/System.Runtime.DurableInstancing run-test V=1
 	${TESTCMD} --label=System.ServiceModel.Discovery --timeout=5m make -w -C mcs/class/System.ServiceModel.Discovery run-test V=1
 	${TESTCMD} --label=System.Xaml --timeout=5m make -w -C mcs/class/System.Xaml run-test V=1


### PR DESCRIPTION
New tests were included recently



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
