### PR TITLE
Linker-supplied __ImageBase must be extern "C".

### DIFF
--- a/mono/metadata/coree.h
+++ b/mono/metadata/coree.h
@@ -34,8 +34,7 @@ MONO_API HRESULT STDAPICALLTYPE MonoFixupCorEE(HMODULE ModuleHandle);
 #define __ImageBase _image_base__
 #endif
 #endif
-extern IMAGE_DOS_HEADER __ImageBase;
-
+G_BEGIN_DECLS extern IMAGE_DOS_HEADER __ImageBase; G_END_DECLS
 extern HMODULE coree_module_handle;
 
 HMODULE WINAPI MonoLoadImage(LPCWSTR FileName);


### PR DESCRIPTION
https://jenkins.mono-project.com/job/w/15083/parsed_console/log.html
assembly.obj : error LNK2001: unresolved external symbol "struct _IMAGE_DOS_HEADER __ImageBase" (?__ImageBase@@3U_IMAGE_DOS_HEADER@@A) [d:\j\workspace\w\msvc\libmono-dynamic.vcxproj]

d:\j\workspace\w\msvc/./build/boehm/Win32\bin\ReleaseCxx\mono-2.0-boehm.dll : fatal error LNK1120: 1 unresolved externals [d:\j\workspace\w\msvc\libmono-dynamic.vcxproj]

Since it is data, extern "C" w/o braces is confusing, but maybe valid, so begin/end form is used.
