### PR TITLE
[runtime] Fix stored exception throws

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # There is no ordering of corlib versions, no old or new,
 # the runtime expects an exact match.
 #
-MONO_CORLIB_VERSION=BEAF66F4-BA36-44C5-974E-83C6F627DF8C
+MONO_CORLIB_VERSION=E06DCE2D-7852-4BBA-AD9F-54D67EEF1FF9
 
 #
 # Put a quoted #define in config.h.

--- a/mcs/class/referencesource/mscorlib/system/exception.cs
+++ b/mcs/class/referencesource/mscorlib/system/exception.cs
@@ -978,6 +978,8 @@ namespace System {
 
         // Mono addition: Used on iPhone
         IntPtr[] native_trace_ips;
+
+        int caught_in_unmanaged;
 #endif
 
     // See clr\src\vm\excep.h's EXCEPTION_COMPLUS definition:

--- a/mono/cil/cil-opcodes.xml
+++ b/mono/cil/cil-opcodes.xml
@@ -323,4 +323,5 @@
 <opcode name="mono_get_rgctx_arg" input="Pop0" output="PushI" args="InlineNone" o1="0xF0" o2="0x1C" flow="next" />
 <opcode name="mono_ldptr_profiler_allocation_count" input="Pop0" output="PushI" args="InlineNone" o1="0xF0" o2="0x1D" flow="next" />
 <opcode name="mono_ld_delegate_method_ptr" input="Pop1" output="PushI" args="InlineNone" o1="0xF0" o2="0x1E" flow="next" />
+<opcode name="mono_rethrow" input="PopRef" output="Push0" args="InlineNone" o1="0xF0" o2="0x1F" flow="throw" type="Objmodel" />
 </opdesc>

--- a/mono/cil/opcode.def
+++ b/mono/cil/opcode.def
@@ -323,6 +323,7 @@ OPDEF(CEE_MONO_GET_LAST_ERROR, "mono_get_last_error", Pop0, PushI, InlineNone, 0
 OPDEF(CEE_MONO_GET_RGCTX_ARG, "mono_get_rgctx_arg", Pop0, PushI, InlineNone, 0, 2, 0xF0, 0x1C, NEXT)
 OPDEF(CEE_MONO_LDPTR_PROFILER_ALLOCATION_COUNT, "mono_ldptr_profiler_allocation_count", Pop0, PushI, InlineNone, 0, 2, 0xF0, 0x1D, NEXT)
 OPDEF(CEE_MONO_LD_DELEGATE_METHOD_PTR, "mono_ld_delegate_method_ptr", Pop1, PushI, InlineNone, 0, 2, 0xF0, 0x1E, NEXT)
+OPDEF(CEE_MONO_RETHROW, "mono_rethrow", PopRef, Push0, InlineNone, 0, 2, 0xF0, 0x1F, ERROR)
 #ifndef OPALIAS
 #define _MONO_CIL_OPALIAS_DEFINED_
 #define OPALIAS(a,s,r)

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -1173,6 +1173,11 @@ emit_thread_interrupt_checkpoint_call (MonoMethodBuilder *mb, gpointer checkpoin
 	mono_mb_emit_byte (mb, CEE_DUP);
 	pos_noex = mono_mb_emit_branch (mb, CEE_BRFALSE);
 
+	mono_mb_emit_byte (mb, CEE_DUP);
+	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoException, caught_in_unmanaged));
+	mono_mb_emit_byte (mb, CEE_LDC_I4_1);
+	mono_mb_emit_byte (mb, CEE_STIND_I4);
+
 	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
 	mono_mb_emit_byte (mb, CEE_MONO_RETHROW);
 

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -1172,7 +1172,10 @@ emit_thread_interrupt_checkpoint_call (MonoMethodBuilder *mb, gpointer checkpoin
 	/* Throw the exception returned by the checkpoint function, if any */
 	mono_mb_emit_byte (mb, CEE_DUP);
 	pos_noex = mono_mb_emit_branch (mb, CEE_BRFALSE);
-	mono_mb_emit_byte (mb, CEE_THROW);
+
+	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+	mono_mb_emit_byte (mb, CEE_MONO_RETHROW);
+
 	mono_mb_patch_branch (mb, pos_noex);
 	mono_mb_emit_byte (mb, CEE_POP);
 	

--- a/mono/metadata/mono-basic-block.c
+++ b/mono/metadata/mono-basic-block.c
@@ -324,6 +324,7 @@ mono_opcode_has_static_branch (int opcode)
 	case MONO_CEE_THROW:
 	case MONO_CEE_RETHROW:
 	case MONO_CEE_ENDFINALLY:
+	case MONO_CEE_MONO_RETHROW:
 		return TRUE;
 	}
 	return FALSE;

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -268,6 +268,7 @@ struct _MonoException {
 	MonoObject *serialization_manager;
 	MonoObject *captured_traces;
 	MonoArray  *native_trace_ips;
+	gint32 caught_in_unmanaged;
 };
 
 typedef struct {

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -7056,6 +7056,10 @@ emit_trampolines (MonoAotCompile *acfg)
 		emit_trampoline (acfg, acfg->got_offset, info);
 		mono_tramp_info_free (info);
 
+		mono_arch_get_rethrow_preserve_exception (&info, TRUE);
+		emit_trampoline (acfg, acfg->got_offset, info);
+		mono_tramp_info_free (info);
+
 		mono_arch_get_throw_corlib_exception (&info, TRUE);
 		emit_trampoline (acfg, acfg->got_offset, info);
 		mono_tramp_info_free (info);

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -5315,8 +5315,8 @@ load_function_full (MonoAotModule *amodule, const char *name, MonoTrampInfo **ou
 					target = (gpointer)mono_exception_from_token;
 				} else if (!strcmp (ji->data.name, "mono_throw_exception")) {
 					target = (gpointer)mono_get_throw_exception ();
-				} else if (!strcmp (ji->data.name, "mono_rethrow_exception")) {
-					target = (gpointer)mono_get_rethrow_exception ();
+				} else if (!strcmp (ji->data.name, "mono_rethrow_preserve_exception")) {
+					target = (gpointer)mono_get_rethrow_preserve_exception ();
 				} else if (strstr (ji->data.name, "trampoline_func_") == ji->data.name) {
 					MonoTrampolineType tramp_type2 = (MonoTrampolineType)atoi (ji->data.name + strlen ("trampoline_func_"));
 					target = (gpointer)mono_get_trampoline_func (tramp_type2);
@@ -5335,8 +5335,8 @@ load_function_full (MonoAotModule *amodule, const char *name, MonoTrampInfo **ou
 					target = (gpointer)mini_get_dbg_callbacks ()->breakpoint_from_context;
 				} else if (!strcmp (ji->data.name, "throw_exception_addr")) {
 					target = mono_get_throw_exception_addr ();
-				} else if (!strcmp (ji->data.name, "rethrow_exception_addr")) {
-					target = mono_get_rethrow_exception_addr ();
+				} else if (!strcmp (ji->data.name, "rethrow_preserve_exception_addr")) {
+					target = mono_get_rethrow_preserve_exception_addr ();
 				} else if (strstr (ji->data.name, "generic_trampoline_")) {
 					target = mono_aot_get_trampoline (ji->data.name);
 				} else if (aot_jit_icall_hash && g_hash_table_lookup (aot_jit_icall_hash, ji->data.name)) {

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -5315,6 +5315,8 @@ load_function_full (MonoAotModule *amodule, const char *name, MonoTrampInfo **ou
 					target = (gpointer)mono_exception_from_token;
 				} else if (!strcmp (ji->data.name, "mono_throw_exception")) {
 					target = (gpointer)mono_get_throw_exception ();
+				} else if (!strcmp (ji->data.name, "mono_rethrow_exception")) {
+					target = (gpointer)mono_get_rethrow_exception ();
 				} else if (strstr (ji->data.name, "trampoline_func_") == ji->data.name) {
 					MonoTrampolineType tramp_type2 = (MonoTrampolineType)atoi (ji->data.name + strlen ("trampoline_func_"));
 					target = (gpointer)mono_get_trampoline_func (tramp_type2);
@@ -5333,6 +5335,8 @@ load_function_full (MonoAotModule *amodule, const char *name, MonoTrampInfo **ou
 					target = (gpointer)mini_get_dbg_callbacks ()->breakpoint_from_context;
 				} else if (!strcmp (ji->data.name, "throw_exception_addr")) {
 					target = mono_get_throw_exception_addr ();
+				} else if (!strcmp (ji->data.name, "rethrow_exception_addr")) {
+					target = mono_get_rethrow_exception_addr ();
 				} else if (strstr (ji->data.name, "generic_trampoline_")) {
 					target = mono_aot_get_trampoline (ji->data.name);
 				} else if (aot_jit_icall_hash && g_hash_table_lookup (aot_jit_icall_hash, ji->data.name)) {

--- a/mono/mini/exceptions-s390x.c
+++ b/mono/mini/exceptions-s390x.c
@@ -27,7 +27,8 @@
 
 #define S390_THROWSTACK_ACCPRM		S390_MINIMAL_STACK_SIZE
 #define S390_THROWSTACK_FPCPRM		(S390_THROWSTACK_ACCPRM+sizeof(gpointer))
-#define S390_THROWSTACK_RETHROW		(S390_THROWSTACK_FPCPRM+sizeof(gulong))
+#define S390_THROWSTACK_PRESERVE_IPS (S390_THROWSTACK_FPCPRM+sizeof(gulong))
+#define S390_THROWSTACK_RETHROW		(S390_THROWSTACK_PRESERVE_IPS+sizeof(gboolean))
 #define S390_THROWSTACK_INTREGS		(S390_THROWSTACK_RETHROW+sizeof(gboolean))
 #define S390_THROWSTACK_FLTREGS		(S390_THROWSTACK_INTREGS+(16*sizeof(gulong)))
 #define S390_THROWSTACK_ACCREGS		(S390_THROWSTACK_FLTREGS+(16*sizeof(gdouble)))
@@ -72,7 +73,7 @@
 static void throw_exception (MonoObject *, unsigned long, unsigned long, 
 		 gulong *, gdouble *, gint32 *, guint, gboolean);
 static gpointer mono_arch_get_throw_exception_generic (int, MonoTrampInfo **, 
-				int, gboolean, gboolean);
+				int, gboolean, gboolean, gboolean);
 static void handle_signal_exception (gpointer);
 
 /*========================= End of Prototypes ======================*/
@@ -240,7 +241,7 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 static void
 throw_exception (MonoObject *exc, unsigned long ip, unsigned long sp, 
 		 gulong *int_regs, gdouble *fp_regs, gint32 *acc_regs, 
-		 guint fpc, gboolean rethrow)
+		 guint fpc, gboolean rethrow, gboolean preserve_ips)
 {
 	ERROR_DECL (error);
 	MonoContext ctx;
@@ -269,6 +270,8 @@ throw_exception (MonoObject *exc, unsigned long ip, unsigned long sp,
 		if (!rethrow) {
 			mono_ex->stack_trace = NULL;
 			mono_ex->trace_ips = NULL;
+		} else if (preserve_ips) {
+			mono_ex->catch_in_unmanaged = TRUE
 		}
 	}
 	mono_error_assert_ok (error);
@@ -295,7 +298,7 @@ throw_exception (MonoObject *exc, unsigned long ip, unsigned long sp,
 
 static gpointer 
 mono_arch_get_throw_exception_generic (int size, MonoTrampInfo **info, 
-				int corlib, gboolean rethrow, gboolean aot)
+				int corlib, gboolean rethrow, gboolean aot, gboolean preserve_ips)
 {
 	guint8 *code, *start;
 	int alloc_size, pos, i;
@@ -358,6 +361,8 @@ mono_arch_get_throw_exception_generic (int size, MonoTrampInfo **info,
 	S390_SET  (code, s390_r1, (guint8 *)throw_exception);
 	s390_lghi (code, s390_r7, rethrow);
 	s390_stg  (code, s390_r7, 0, STK_BASE, S390_THROWSTACK_RETHROW);
+	s390_lghi (code, s390_r7, preserve_ips);
+	s390_stg  (code, s390_r7, 0, STK_BASE, S390_THROWSTACK_PRESERVE_IPS);
 	s390_basr (code, s390_r14, s390_r1);
 	/* we should never reach this breakpoint */
 	s390_break (code);
@@ -369,6 +374,7 @@ mono_arch_get_throw_exception_generic (int size, MonoTrampInfo **info,
 	if (info)
 		*info = mono_tramp_info_create (corlib ? "throw_corlib_exception" 
                                                       : (rethrow ? "rethrow_exception" 
+                                                      : (preserve_ips ? "rethrow_preserve_exception" 
                                                       : "throw_exception"), 
 						start, code - start, ji, unwind_ops);
 
@@ -396,7 +402,31 @@ mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 	if (info)
 		*info = NULL;
 
-	return (mono_arch_get_throw_exception_generic (SZ_THROW, info, FALSE, FALSE, aot));
+	return (mono_arch_get_throw_exception_generic (SZ_THROW, info, FALSE, FALSE, aot, FALSE));
+}
+
+/*========================= End of Function ========================*/
+
+/*------------------------------------------------------------------*/
+/*                                                                  */
+/* Name		- arch_get_rethrow_preserve_exception                    */
+/*                                                                  */
+/* Function	- Return a function pointer which can be used to       */
+/*                raise exceptions. This preserves the stored ips.  */
+/*                The returned function has the                     */
+/*                following signature:                              */
+/*                void (*func) (MonoException *exc);                */
+/*                                                                  */
+/*------------------------------------------------------------------*/
+
+gpointer 
+mono_arch_get_rethrow_preserve_exception (MonoTrampInfo **info, gboolean aot)
+{
+	g_assert (!aot);
+	if (info)
+		*info = NULL;
+
+	return (mono_arch_get_throw_exception_generic (SZ_THROW, info, FALSE, TRUE, aot, TRUE));
 }
 
 /*========================= End of Function ========================*/
@@ -419,7 +449,7 @@ mono_arch_get_rethrow_exception (MonoTrampInfo **info, gboolean aot)
 	if (info)
 		*info = NULL;
 
-	return (mono_arch_get_throw_exception_generic (SZ_THROW, info, FALSE, TRUE, aot));
+	return (mono_arch_get_throw_exception_generic (SZ_THROW, info, FALSE, TRUE, aot, FALSE));
 }
 
 /*========================= End of Function ========================*/
@@ -442,7 +472,7 @@ mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 	if (info)
 		*info = NULL;
 
-	return (mono_arch_get_throw_exception_generic (SZ_THROW, info, TRUE, FALSE, aot));
+	return (mono_arch_get_throw_exception_generic (SZ_THROW, info, TRUE, FALSE, aot, FALSE));
 }	
 
 /*========================= End of Function ========================*/

--- a/mono/mini/exceptions-wasm.c
+++ b/mono/mini/exceptions-wasm.c
@@ -25,6 +25,12 @@ wasm_rethrow_exception (void)
 }
 
 static void
+wasm_rethrow_preserve_exception (void)
+{
+	g_error ("wasm_rethrow_preserve_exception");
+}
+
+static void
 wasm_throw_corlib_exception (void)
 {
 	g_error ("wasm_throw_corlib_exception");
@@ -77,6 +83,14 @@ mono_arch_get_rethrow_exception (MonoTrampInfo **info, gboolean aot)
 {
 	if (info)
 		*info = mono_tramp_info_create ("rethrow_exception", (guint8*)wasm_rethrow_exception, 1, NULL, NULL);
+	return (gpointer)wasm_rethrow_exception;
+}
+
+gpointer
+mono_arch_get_rethrow_preserve_exception (MonoTrampInfo **info, gboolean aot)
+{
+	if (info)
+		*info = mono_tramp_info_create ("rethrow_preserve_exception", (guint8*)wasm_rethrow_preserve_exception, 1, NULL, NULL);
 	return (gpointer)wasm_rethrow_exception;
 }
 

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -5532,6 +5532,23 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 			THROW_EX_GENERAL (*(MonoException**)(frame->locals + exvar_offset), ip - 1, TRUE);
 			MINT_IN_BREAK;
 	   }
+	   MINT_IN_CASE(MINT_MONO_RETHROW) {
+			/* 
+			 * need to clarify what this should actually do:
+			 *
+			 * Takes an exception from the stack and rethrows it.
+			 * This is useful for wrappers that don't want to have to
+			 * use CEE_THROW and lose the exception stacktrace. 
+			 */
+
+			--sp;
+			frame->ex_handler = NULL;
+			if (!sp->data.p)
+				sp->data.p = mono_get_exception_null_reference ();
+
+			THROW_EX_GENERAL ((MonoException *)sp->data.p, ip, TRUE);
+			MINT_IN_BREAK;
+	   }
 	   MINT_IN_CASE(MINT_LD_DELEGATE_METHOD_PTR) {
 		   MonoDelegate *del;
 

--- a/mono/mini/interp/mintops.def
+++ b/mono/mini/interp/mintops.def
@@ -178,6 +178,7 @@ OPDEF(MINT_LEAVE_S_CHECK, "leave.s.check", 2, MintOpShortBranch)
 OPDEF(MINT_THROW, "throw", 1, MintOpNoArgs)
 OPDEF(MINT_RETHROW, "rethrow", 2, MintOpUShortInt)
 OPDEF(MINT_ENDFINALLY, "endfinally", 2, MintOpNoArgs)
+OPDEF(MINT_MONO_RETHROW, "mono_rethrow", 1, MintOpNoArgs)
 
 OPDEF(MINT_CHECKPOINT, "checkpoint", 1, MintOpNoArgs)
 OPDEF(MINT_SAFEPOINT, "safepoint", 1, MintOpNoArgs)

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -4321,6 +4321,12 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsig
 		case MONO_CUSTOM_PREFIX:
 			++td->ip;
 		        switch (*td->ip) {
+				case CEE_MONO_RETHROW:
+					CHECK_STACK (td, 1);
+					SIMPLE_OP (td, MINT_MONO_RETHROW);
+					td->sp = td->stack;
+					break;
+
 				case CEE_MONO_LD_DELEGATE_METHOD_PTR:
 					--td->sp;
 					td->ip += 1;

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -11739,6 +11739,26 @@ mono_ldptr:
 			start_new_bblock = 1;
 			break;
 		}
+		case MONO_CEE_MONO_RETHROW: {
+			if (sp [-1]->type != STACK_OBJ)
+				UNVERIFIED;
+
+			MONO_INST_NEW (cfg, ins, OP_RETHROW);
+			--sp;
+			ins->sreg1 = sp [0]->dreg;
+			cfg->cbb->out_of_line = TRUE;
+			MONO_ADD_INS (cfg->cbb, ins);
+			MONO_INST_NEW (cfg, ins, OP_NOT_REACHED);
+			MONO_ADD_INS (cfg->cbb, ins);
+			sp = stack_start;
+
+			link_bblock (cfg, cfg->cbb, end_bblock);
+			start_new_bblock = 1;
+			/* This can complicate code generation for llvm since the return value might not be defined */
+			if (COMPILE_LLVM (cfg))
+				INLINE_FAILURE ("mono_rethrow");
+			break;
+		}
 		case MONO_CEE_SIZEOF: {
 			guint32 val;
 			int ialign;

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -501,7 +501,7 @@ mono_amd64_patch (unsigned char* code, gpointer target);
 void
 mono_amd64_throw_exception (guint64 dummy1, guint64 dummy2, guint64 dummy3, guint64 dummy4,
 							guint64 dummy5, guint64 dummy6,
-							MonoContext *mctx, MonoObject *exc, gboolean rethrow);
+							MonoContext *mctx, MonoObject *exc, gboolean rethrow, gboolean preserve_ips);
 
 void
 mono_amd64_throw_corlib_exception (guint64 dummy1, guint64 dummy2, guint64 dummy3, guint64 dummy4,

--- a/mono/mini/mini-arm.h
+++ b/mono/mini/mini-arm.h
@@ -397,7 +397,7 @@ typedef struct MonoCompileArch {
 #define MONO_ARCH_INIT_TOP_LMF_ENTRY(lmf)
 
 void
-mono_arm_throw_exception (MonoObject *exc, mgreg_t pc, mgreg_t sp, mgreg_t *int_regs, gdouble *fp_regs);
+mono_arm_throw_exception (MonoObject *exc, mgreg_t pc, mgreg_t sp, mgreg_t *int_regs, gdouble *fp_regs, gboolean preserve_ips);
 
 void
 mono_arm_throw_exception_by_token (guint32 type_token, mgreg_t pc, mgreg_t sp, mgreg_t *int_regs, gdouble *fp_regs);

--- a/mono/mini/mini-arm64.h
+++ b/mono/mini/mini-arm64.h
@@ -258,7 +258,7 @@ guint8* mono_arm_emit_aotconst (gpointer ji, guint8 *code, guint8 *code_start, i
 
 void mono_arm_patch (guint8 *code, guint8 *target, int relocation);
 
-void mono_arm_throw_exception (gpointer arg, mgreg_t pc, mgreg_t *int_regs, gdouble *fp_regs, gboolean corlib, gboolean rethrow);
+void mono_arm_throw_exception (gpointer arg, mgreg_t pc, mgreg_t *int_regs, gdouble *fp_regs, gboolean corlib, gboolean rethrow, gboolean preserve_ips);
 
 void mono_arm_gsharedvt_init (void);
 

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -318,6 +318,12 @@ mono_get_throw_exception_addr (void)
 	return &throw_exception_func;
 }
 
+gpointer
+mono_get_rethrow_exception_addr (void)
+{
+	return &rethrow_exception_func;
+}
+
 static gboolean 
 is_address_protected (MonoJitInfo *ji, MonoJitExceptionInfo *ei, gpointer ip)
 {

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -114,7 +114,7 @@ typedef struct
 #define TRACE_IP_ENTRY_SIZE (sizeof (ExceptionTraceIp) / sizeof (gpointer))
 
 static gpointer restore_context_func, call_filter_func;
-static gpointer throw_exception_func, rethrow_exception_func;
+static gpointer throw_exception_func, rethrow_exception_func, rethrow_preserve_exception_func;
 static gpointer throw_corlib_exception_func;
 
 static MonoFtnPtrEHCallback ftnptr_eh_callback;
@@ -216,6 +216,7 @@ mono_exceptions_init (void)
 		call_filter_func = mono_aot_get_trampoline ("call_filter");
 		throw_exception_func = mono_aot_get_trampoline ("throw_exception");
 		rethrow_exception_func = mono_aot_get_trampoline ("rethrow_exception");
+		rethrow_preserve_exception_func = mono_aot_get_trampoline ("rethrow_preserve_exception");
 	} else {
 		MonoTrampInfo *info;
 
@@ -226,6 +227,8 @@ mono_exceptions_init (void)
 		throw_exception_func = mono_arch_get_throw_exception (&info, FALSE);
 		mono_tramp_info_register (info, NULL);
 		rethrow_exception_func = mono_arch_get_rethrow_exception (&info, FALSE);
+		mono_tramp_info_register (info, NULL);
+		rethrow_preserve_exception_func = mono_arch_get_rethrow_preserve_exception (&info, FALSE);
 		mono_tramp_info_register (info, NULL);
 	}
 
@@ -266,6 +269,13 @@ mono_get_rethrow_exception (void)
 {
 	g_assert (rethrow_exception_func);
 	return rethrow_exception_func;
+}
+
+gpointer
+mono_get_rethrow_preserve_exception (void)
+{
+	g_assert (rethrow_preserve_exception_func);
+	return rethrow_preserve_exception_func;
 }
 
 gpointer
@@ -319,9 +329,9 @@ mono_get_throw_exception_addr (void)
 }
 
 gpointer
-mono_get_rethrow_exception_addr (void)
+mono_get_rethrow_preserve_exception_addr (void)
 {
-	return &rethrow_exception_func;
+	return &rethrow_preserve_exception_func;
 }
 
 static gboolean 

--- a/mono/mini/mini-ppc.h
+++ b/mono/mini/mini-ppc.h
@@ -384,7 +384,7 @@ void
 mono_ppc_patch (guchar *code, const guchar *target);
 
 void
-mono_ppc_throw_exception (MonoObject *exc, unsigned long eip, unsigned long esp, mgreg_t *int_regs, gdouble *fp_regs, gboolean rethrow);
+mono_ppc_throw_exception (MonoObject *exc, unsigned long eip, unsigned long esp, mgreg_t *int_regs, gdouble *fp_regs, gboolean rethrow, gboolean preserve_ips);
 
 #ifdef __mono_ppc64__
 #define MONO_PPC_32_64_CASE(c32,c64)	c64

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3135,8 +3135,10 @@ mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 
 		result = runtime_invoke ((MonoObject *)obj, params, exc, info->compiled_method);
 	}
-	if (catchExcInMonoError && *exc != NULL)
+	if (catchExcInMonoError && *exc != NULL) {
+		((MonoException *)(*exc))->caught_in_unmanaged = TRUE;
 		mono_error_set_exception_instance (error, (MonoException*) *exc);
+	}
 	return result;
 }
 

--- a/mono/mini/mini-x86.h
+++ b/mono/mini/mini-x86.h
@@ -330,7 +330,7 @@ mono_x86_get_this_arg_offset (MonoMethodSignature *sig);
 
 void
 mono_x86_throw_exception (mgreg_t *regs, MonoObject *exc, 
-						  mgreg_t eip, gboolean rethrow);
+						  mgreg_t eip, gboolean rethrow, gboolean preserve_ips);
 
 void
 mono_x86_throw_corlib_exception (mgreg_t *regs, guint32 ex_token_index, 

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2466,6 +2466,7 @@ gpointer mono_get_restore_context               (void);
 gpointer mono_get_throw_exception_by_name       (void);
 gpointer mono_get_throw_corlib_exception        (void);
 gpointer mono_get_throw_exception_addr          (void);
+gpointer mono_get_rethrow_exception_addr          (void);
 ICALL_EXPORT
 MonoArray *ves_icall_get_trace                  (MonoException *exc, gint32 skip, MonoBoolean need_file_info);
 

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2350,6 +2350,7 @@ gpointer mono_arch_get_call_filter              (MonoTrampInfo **info, gboolean 
 gpointer mono_arch_get_restore_context          (MonoTrampInfo **info, gboolean aot);
 gpointer  mono_arch_get_throw_exception         (MonoTrampInfo **info, gboolean aot);
 gpointer  mono_arch_get_rethrow_exception       (MonoTrampInfo **info, gboolean aot);
+gpointer  mono_arch_get_rethrow_preserve_exception (MonoTrampInfo **info, gboolean aot);
 gpointer  mono_arch_get_throw_corlib_exception  (MonoTrampInfo **info, gboolean aot);
 gpointer  mono_arch_get_throw_pending_exception (MonoTrampInfo **info, gboolean aot);
 gboolean mono_arch_handle_exception             (void *sigctx, gpointer obj);
@@ -2461,12 +2462,13 @@ mono_find_jit_info_ext (MonoDomain *domain, MonoJitTlsData *jit_tls,
 
 gpointer mono_get_throw_exception               (void);
 gpointer mono_get_rethrow_exception             (void);
+gpointer mono_get_rethrow_preserve_exception             (void);
 gpointer mono_get_call_filter                   (void);
 gpointer mono_get_restore_context               (void);
 gpointer mono_get_throw_exception_by_name       (void);
 gpointer mono_get_throw_corlib_exception        (void);
 gpointer mono_get_throw_exception_addr          (void);
-gpointer mono_get_rethrow_exception_addr          (void);
+gpointer mono_get_rethrow_preserve_exception_addr          (void);
 ICALL_EXPORT
 MonoArray *ves_icall_get_trace                  (MonoException *exc, gint32 skip, MonoBoolean need_file_info);
 

--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -520,9 +520,9 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 	 */
 	if (aot) {
 		/* Not really a jit icall */
-		code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, "throw_exception_addr");
+		code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, "rethrow_exception_addr");
 	} else {
-		amd64_mov_reg_imm (code, AMD64_R11, (guint8*)mono_get_throw_exception_addr ());
+		amd64_mov_reg_imm (code, AMD64_R11, (guint8*)mono_get_rethrow_exception_addr ());
 	}
 	amd64_mov_reg_membase (code, AMD64_R11, AMD64_R11, 0, sizeof(gpointer));
 	amd64_mov_reg_reg (code, AMD64_ARG_REG1, AMD64_RAX, sizeof(mgreg_t));

--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -520,9 +520,9 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 	 */
 	if (aot) {
 		/* Not really a jit icall */
-		code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, "rethrow_exception_addr");
+		code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, "rethrow_preserve_exception_addr");
 	} else {
-		amd64_mov_reg_imm (code, AMD64_R11, (guint8*)mono_get_rethrow_exception_addr ());
+		amd64_mov_reg_imm (code, AMD64_R11, (guint8*)mono_get_rethrow_preserve_exception_addr ());
 	}
 	amd64_mov_reg_membase (code, AMD64_R11, AMD64_R11, 0, sizeof(gpointer));
 	amd64_mov_reg_reg (code, AMD64_ARG_REG1, AMD64_RAX, sizeof(mgreg_t));

--- a/mono/mini/tramp-arm.c
+++ b/mono/mini/tramp-arm.c
@@ -416,11 +416,11 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 	 */
 	if (aot) {
 		/* Not really a jit icall */
-		code = mono_arm_emit_aotconst (&ji, code, buf, ARMREG_IP, MONO_PATCH_INFO_JIT_ICALL_ADDR, "throw_exception_addr");
+		code = mono_arm_emit_aotconst (&ji, code, buf, ARMREG_IP, MONO_PATCH_INFO_JIT_ICALL_ADDR, "rethrow_exception_addr");
 	} else {
 		ARM_LDR_IMM (code, ARMREG_IP, ARMREG_PC, 0);
 		ARM_B (code, 0);
-		*(gpointer*)code = mono_get_throw_exception_addr ();
+		*(gpointer*)code = mono_get_rethrow_exception_addr ();
 		code += 4;
 	}
 	ARM_LDR_IMM (code, ARMREG_IP, ARMREG_IP, 0);

--- a/mono/mini/tramp-arm.c
+++ b/mono/mini/tramp-arm.c
@@ -416,11 +416,11 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 	 */
 	if (aot) {
 		/* Not really a jit icall */
-		code = mono_arm_emit_aotconst (&ji, code, buf, ARMREG_IP, MONO_PATCH_INFO_JIT_ICALL_ADDR, "rethrow_exception_addr");
+		code = mono_arm_emit_aotconst (&ji, code, buf, ARMREG_IP, MONO_PATCH_INFO_JIT_ICALL_ADDR, "rethrow_preserve_exception_addr");
 	} else {
 		ARM_LDR_IMM (code, ARMREG_IP, ARMREG_PC, 0);
 		ARM_B (code, 0);
-		*(gpointer*)code = mono_get_rethrow_exception_addr ();
+		*(gpointer*)code = mono_get_rethrow_preserve_exception_addr ();
 		code += 4;
 	}
 	ARM_LDR_IMM (code, ARMREG_IP, ARMREG_IP, 0);

--- a/mono/mini/tramp-arm64.c
+++ b/mono/mini/tramp-arm64.c
@@ -303,9 +303,9 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 	 */
 	if (aot) {
 		/* Not really a jit icall */
-		code = mono_arm_emit_aotconst (&ji, code, buf, ARMREG_IP0, MONO_PATCH_INFO_JIT_ICALL_ADDR, "throw_exception_addr");
+		code = mono_arm_emit_aotconst (&ji, code, buf, ARMREG_IP0, MONO_PATCH_INFO_JIT_ICALL_ADDR, "rethrow_exception_addr");
 	} else {
-		code = mono_arm_emit_imm64 (code, ARMREG_IP0, (guint64)mono_get_throw_exception_addr ());
+		code = mono_arm_emit_imm64 (code, ARMREG_IP0, (guint64)mono_get_rethrow_exception_addr ());
 	}
 	arm_ldrx (code, ARMREG_IP0, ARMREG_IP0, 0);
 	/* lr contains the return address, the trampoline will use it as the throw site */

--- a/mono/mini/tramp-arm64.c
+++ b/mono/mini/tramp-arm64.c
@@ -303,9 +303,9 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 	 */
 	if (aot) {
 		/* Not really a jit icall */
-		code = mono_arm_emit_aotconst (&ji, code, buf, ARMREG_IP0, MONO_PATCH_INFO_JIT_ICALL_ADDR, "rethrow_exception_addr");
+		code = mono_arm_emit_aotconst (&ji, code, buf, ARMREG_IP0, MONO_PATCH_INFO_JIT_ICALL_ADDR, "rethrow_preserve_exception_addr");
 	} else {
-		code = mono_arm_emit_imm64 (code, ARMREG_IP0, (guint64)mono_get_rethrow_exception_addr ());
+		code = mono_arm_emit_imm64 (code, ARMREG_IP0, (guint64)mono_get_rethrow_preserve_exception_addr ());
 	}
 	arm_ldrx (code, ARMREG_IP0, ARMREG_IP0, 0);
 	/* lr contains the return address, the trampoline will use it as the throw site */

--- a/mono/mini/tramp-ppc.c
+++ b/mono/mini/tramp-ppc.c
@@ -424,7 +424,7 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 	if (aot) {
 		g_error ("Not implemented");
 	} else {
-		ppc_load_func (code, PPC_CALL_REG, mono_get_throw_exception_addr ());
+		ppc_load_func (code, PPC_CALL_REG, mono_get_rethrow_exception_addr ());
 		ppc_ldr (code, PPC_CALL_REG, 0, PPC_CALL_REG);
 		ppc_mtctr (code, PPC_CALL_REG);
 	}

--- a/mono/mini/tramp-ppc.c
+++ b/mono/mini/tramp-ppc.c
@@ -424,7 +424,7 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 	if (aot) {
 		g_error ("Not implemented");
 	} else {
-		ppc_load_func (code, PPC_CALL_REG, mono_get_rethrow_exception_addr ());
+		ppc_load_func (code, PPC_CALL_REG, mono_get_rethrow_preserve_exception_addr ());
 		ppc_ldr (code, PPC_CALL_REG, 0, PPC_CALL_REG);
 		ppc_mtctr (code, PPC_CALL_REG);
 	}

--- a/mono/mini/tramp-s390x.c
+++ b/mono/mini/tramp-s390x.c
@@ -328,9 +328,9 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 	/*
 	 * Exception case:
 	 * We have an exception we want to throw in the caller's frame, so pop
-	 * the trampoline frame and throw from the caller.
+	 * the trampoline frame and throw from the caller. 
 	 */
-	S390_SET  (buf, s390_r1, (guint *)mono_get_throw_exception_addr ());
+	S390_SET  (buf, s390_r1, (guint *)mono_get_rethrow_exception_addr ());
 	s390_aghi (buf, STK_BASE, sizeof(trampStack_t));
 	s390_lg   (buf, s390_r1, 0, s390_r1, 0); 
 	s390_lmg  (buf, s390_r6, s390_r14, STK_BASE, S390_REG_SAVE_OFFSET);

--- a/mono/mini/tramp-s390x.c
+++ b/mono/mini/tramp-s390x.c
@@ -330,7 +330,7 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 	 * We have an exception we want to throw in the caller's frame, so pop
 	 * the trampoline frame and throw from the caller. 
 	 */
-	S390_SET  (buf, s390_r1, (guint *)mono_get_rethrow_exception_addr ());
+	S390_SET  (buf, s390_r1, (guint *)mono_get_rethrow_preserve_exception_addr ());
 	s390_aghi (buf, STK_BASE, sizeof(trampStack_t));
 	s390_lg   (buf, s390_r1, 0, s390_r1, 0); 
 	s390_lmg  (buf, s390_r6, s390_r14, STK_BASE, S390_REG_SAVE_OFFSET);

--- a/mono/mini/tramp-x86.c
+++ b/mono/mini/tramp-x86.c
@@ -343,9 +343,9 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 	 */
 	if (aot) {
 		/* Not really a jit icall */
-		code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, "throw_exception_addr");
+		code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, "rethrow_exception_addr");
 	} else {
-		x86_mov_reg_imm (code, X86_ECX, (guint8*)mono_get_throw_exception_addr ());
+		x86_mov_reg_imm (code, X86_ECX, (guint8*)mono_get_rethrow_exception_addr ());
 	}
 	x86_mov_reg_membase (code, X86_ECX, X86_ECX, 0, sizeof(target_mgreg_t));
 	x86_jump_reg (code, X86_ECX);

--- a/mono/mini/tramp-x86.c
+++ b/mono/mini/tramp-x86.c
@@ -343,9 +343,9 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 	 */
 	if (aot) {
 		/* Not really a jit icall */
-		code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, "rethrow_exception_addr");
+		code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, "rethrow_preserve_exception_addr");
 	} else {
-		x86_mov_reg_imm (code, X86_ECX, (guint8*)mono_get_rethrow_exception_addr ());
+		x86_mov_reg_imm (code, X86_ECX, (guint8*)mono_get_rethrow_preserve_exception_addr ());
 	}
 	x86_mov_reg_membase (code, X86_ECX, X86_ECX, 0, sizeof(target_mgreg_t));
 	x86_jump_reg (code, X86_ECX);

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -307,6 +307,7 @@ TESTS_CS_SRC=		\
 	exception16.cs		\
 	exception17.cs		\
 	exception18.cs		\
+	exception-invokes.cs		\
 	exception19.cs		\
 	exception20.cs		\
 	typeload-unaligned.cs	\

--- a/mono/tests/exception-invokes.cs
+++ b/mono/tests/exception-invokes.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Reflection;
+
+class C
+{
+	const int StepSize = 5;
+	const int Iterations = 8;
+
+	public static void Main ()
+	{
+		AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(HandleException);
+		var args  = new object[] {C.Iterations * C.StepSize};
+		typeof (C).GetMethod ("InvokeChain", BindingFlags.NonPublic | BindingFlags.Instance).Invoke (new C (), args);
+	}
+
+	public static void HandleException (object sender, UnhandledExceptionEventArgs e)
+	{
+		var ex = e.ExceptionObject as Exception;
+
+		int iterations = 0;
+		while (ex != null) {
+			string fullTrace = ex.StackTrace;
+
+			string[] frames = fullTrace.Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
+			// Console.WriteLine("Split into {0} lines", frames.Length);
+
+			int count = 0;
+			for (int i=0; i < frames.Length; i++)
+			{
+				var words = frames [i].Split((char []) null, StringSplitOptions.RemoveEmptyEntries);
+				if (words.Length > 1 && words [0] == "at" && words [1].StartsWith("C.InvokeChain"))
+					count++;
+				// Console.WriteLine("Line: {0} {1}", frames [i], words.Length);
+			}
+
+			if (count != 0)
+			{
+				if (count > 1 && count != C.StepSize)
+				{
+					Console.WriteLine("Fail step size");
+					Environment.Exit(1);
+				}
+				if (count == C.StepSize)
+					iterations += 1;
+			}
+
+			ex = ex.InnerException;
+		}
+
+		if (iterations != C.Iterations) {
+			Console.WriteLine ("{0} iterations", iterations);
+			Environment.Exit (1);
+		}
+
+		// Prevents the runtime from printing the exception
+		Environment.Exit (0);
+	}
+
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private void InvokeChain (int depth)
+	{
+		if (depth == 0) {
+			Base ();
+		} else if (depth % C.StepSize == 0) {
+			//Console.WriteLine ("InvokeChain {0} indirect", depth);
+			typeof (C).GetMethod ("InvokeChain", BindingFlags.NonPublic | BindingFlags.Instance).Invoke (this, new object[] {depth - 1});
+		} else {
+			//Console.WriteLine ("InvokeChain {0} direct", depth);
+			InvokeChain (depth - 1);
+		}
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private void Base ()
+	{
+		throw new NotImplementedException ();
+	}
+}


### PR DESCRIPTION
On cooperative suspend, the wrapper frames capture the exception
in a MonoError, which then must be thrown. The problem with treating
it as a CIL THROW opcode is that every time you THROW, you completely
reset the stacktrace's collectin of saved frames.

The RETHROW opcode will force the JIT to rely on an in-flight exception,
that in our case has been taken our of the in-flight context.

In order to enable the runtime to store and multiplex in-flight
exceptions as MonoErrors, without losing throw context, I made these
places of THROW-ing into places where we directly make a JIT icall that
rethrows the exception in question. On each platform, we were already
using very similar control flow when we translated to a "throw".

The most impactful difference on the generated code is that an internal
runtime function that got "rethrow = FALSE" for this exception will now
see "rethrow = TRUE", and not zero out the pointers to the trace_ips.

I did a few prototypes here, and all of the other methods of doing this
either required very large churn in the codegen backend, or would leave
a dirty global state that would undermine the ability of the MonoError
to keep multiple ones in-flight.
