### PR TITLE
Reapply #10254 to 2018-06 and include change in #10393

### DIFF
--- a/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
+++ b/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
@@ -77,7 +77,7 @@ namespace Mono.Net.Security
 			Settings = settings;
 			Provider = provider;
 
-			readBuffer = new BufferOffsetSize2 (16834);
+			readBuffer = new BufferOffsetSize2 (16500);
 			writeBuffer = new BufferOffsetSize2 (16384);
 			operation = Operation.None;
 		}

--- a/mcs/class/System/Mono.Net.Security/MonoTlsStream.cs
+++ b/mcs/class/System/Mono.Net.Security/MonoTlsStream.cs
@@ -50,7 +50,7 @@ using System.Security.Cryptography;
 
 namespace Mono.Net.Security
 {
-	class MonoTlsStream
+	class MonoTlsStream : IDisposable
 	{
 #if SECURITY_DEP
 		readonly MonoTlsProvider provider;
@@ -136,6 +136,7 @@ namespace Mono.Net.Security
 					request.ServicePoint.UpdateClientCertificate (sslStream.InternalLocalCertificate);
 				else {
 					request.ServicePoint.UpdateClientCertificate (null);
+					sslStream.Dispose ();
 					sslStream = null;
 				}
 			}
@@ -153,6 +154,14 @@ namespace Mono.Net.Security
 #else
 			throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
 #endif
+		}
+
+		public void Dispose ()
+		{
+			if (sslStream != null) {
+				sslStream.Dispose ();
+				sslStream = null;
+			}
 		}
 	}
 }

--- a/mcs/class/System/System.Net/WebConnection.cs
+++ b/mcs/class/System/System.Net/WebConnection.cs
@@ -405,11 +405,19 @@ namespace System.Net
 		void CloseSocket ()
 		{
 			lock (this) {
+				Debug ($"WC CLOSE SOCKET: Cnc={ID} NS={networkStream} TLS={monoTlsStream}");
 				if (networkStream != null) {
 					try {
 						networkStream.Dispose ();
 					} catch { }
 					networkStream = null;
+				}
+
+				if (monoTlsStream != null) {
+					try {
+						monoTlsStream.Dispose ();
+					} catch { }
+					monoTlsStream = null;
 				}
 
 				if (socket != null) {

--- a/mcs/class/System/System.Net/WebReadStream.cs
+++ b/mcs/class/System/System.Net/WebReadStream.cs
@@ -41,7 +41,7 @@ namespace System.Net
 		}
 
 #if MONO_WEB_DEBUG
-		internal string ME => $"WRS({GetType ().Name}:Op={operation.ID})";
+		internal string ME => $"WRS({GetType ().Name}:Op={Operation.ID})";
 #else
 		internal string ME => null;
 #endif


### PR DESCRIPTION
The early change to make MonoTlsStream IDisposable had to be backed out of 2018-06. This restores that fix and includes the fix from #10393 that fixed the reason for the back out.