### PR TITLE
[cxx] More extern "C" per errors and a missed cast.

### DIFF
--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -276,7 +276,7 @@ MonoMethod* mono_gc_get_write_barrier (void);
 
 /* Fast valuetype copy */
 /* WARNING: [dest, dest + size] must be within the bounds of a single type, otherwise the GC will lose remset entries */
-void mono_gc_wbarrier_range_copy (gpointer dest, gconstpointer src, int size);
+G_EXTERN_C void mono_gc_wbarrier_range_copy (gpointer dest, gconstpointer src, int size);
 
 typedef void (*MonoRangeCopyFunction)(gpointer, gconstpointer, int size);
 

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -2124,7 +2124,7 @@ encode_cattr_value (MonoAssembly *assembly, char *buffer, char *p, char **retbuf
 		buffer = newbuf;
 	}
 	if (!argval)
-		argval = mono_object_get_data (arg);
+		argval = (const char*)mono_object_get_data (arg);
 	simple_type = type->type;
 handle_enum:
 	switch (simple_type) {

--- a/mono/mini/aot-runtime.h
+++ b/mono/mini/aot-runtime.h
@@ -255,10 +255,10 @@ mono_aot_register_jit_icall (const char *name, T addr)
 #endif // __cplusplus
 
 guint32  mono_aot_find_method_index         (MonoMethod *method);
-void     mono_aot_init_llvm_method          (gpointer aot_module, guint32 method_index);
-void     mono_aot_init_gshared_method_this  (gpointer aot_module, guint32 method_index, MonoObject *this_ins);
-void     mono_aot_init_gshared_method_mrgctx  (gpointer aot_module, guint32 method_index, MonoMethodRuntimeGenericContext *rgctx);
-void     mono_aot_init_gshared_method_vtable  (gpointer aot_module, guint32 method_index, MonoVTable *vtable);
+G_EXTERN_C void mono_aot_init_llvm_method          (gpointer aot_module, guint32 method_index);
+G_EXTERN_C void mono_aot_init_gshared_method_this  (gpointer aot_module, guint32 method_index, MonoObject *this_ins);
+G_EXTERN_C void mono_aot_init_gshared_method_mrgctx  (gpointer aot_module, guint32 method_index, MonoMethodRuntimeGenericContext *rgctx);
+G_EXTERN_C void mono_aot_init_gshared_method_vtable  (gpointer aot_module, guint32 method_index, MonoVTable *vtable);
 GHashTable *mono_aot_get_weak_field_indexes (MonoImage *image);
 
 /* This is an exported function */

--- a/mono/mini/jit-icalls.h
+++ b/mono/mini/jit-icalls.h
@@ -9,189 +9,187 @@
 #include "mini.h"
 #include <mono/metadata/icalls.h>
 
-void* mono_ldftn (MonoMethod *method);
+G_EXTERN_C void* mono_ldftn (MonoMethod *method);
 
-void* mono_ldvirtfn (MonoObject *obj, MonoMethod *method);
+G_EXTERN_C void* mono_ldvirtfn (MonoObject *obj, MonoMethod *method);
 
-void* mono_ldvirtfn_gshared (MonoObject *obj, MonoMethod *method);
+G_EXTERN_C void* mono_ldvirtfn_gshared (MonoObject *obj, MonoMethod *method);
 
-void mono_helper_stelem_ref_check (MonoArray *array, MonoObject *val);
+G_EXTERN_C void mono_helper_stelem_ref_check (MonoArray *array, MonoObject *val);
 
-gint64 mono_llmult (gint64 a, gint64 b);
+G_EXTERN_C gint64 mono_llmult (gint64 a, gint64 b);
 
-guint64 mono_llmult_ovf_un (guint64 a, guint64 b);
+G_EXTERN_C guint64 mono_llmult_ovf_un (guint64 a, guint64 b);
 
-guint64 mono_llmult_ovf (gint64 a, gint64 b);
+G_EXTERN_C guint64 mono_llmult_ovf (gint64 a, gint64 b);
 
-gint32 mono_idiv (gint32 a, gint32 b);
+G_EXTERN_C gint32 mono_idiv (gint32 a, gint32 b);
 
-guint32 mono_idiv_un (guint32 a, guint32 b);
+G_EXTERN_C guint32 mono_idiv_un (guint32 a, guint32 b);
 
-gint32 mono_irem (gint32 a, gint32 b);
+G_EXTERN_C gint32 mono_irem (gint32 a, gint32 b);
 
-guint32 mono_irem_un (guint32 a, guint32 b);
+G_EXTERN_C guint32 mono_irem_un (guint32 a, guint32 b);
 
-gint32 mono_imul (gint32 a, gint32 b);
+G_EXTERN_C gint32 mono_imul (gint32 a, gint32 b);
 
-gint32 mono_imul_ovf (gint32 a, gint32 b);
+G_EXTERN_C gint32 mono_imul_ovf (gint32 a, gint32 b);
 
-gint32 mono_imul_ovf_un (guint32 a, guint32 b);
+G_EXTERN_C gint32 mono_imul_ovf_un (guint32 a, guint32 b);
 
-double mono_fdiv (double a, double b);
+G_EXTERN_C double mono_fdiv (double a, double b);
 
-gint64 mono_lldiv (gint64 a, gint64 b);
+G_EXTERN_C gint64 mono_lldiv (gint64 a, gint64 b);
 
-gint64 mono_llrem (gint64 a, gint64 b);
+G_EXTERN_C gint64 mono_llrem (gint64 a, gint64 b);
 
-guint64 mono_lldiv_un (guint64 a, guint64 b);
+G_EXTERN_C guint64 mono_lldiv_un (guint64 a, guint64 b);
 
-guint64 mono_llrem_un (guint64 a, guint64 b);
+G_EXTERN_C guint64 mono_llrem_un (guint64 a, guint64 b);
 
-guint64 mono_lshl (guint64 a, gint32 shamt);
+G_EXTERN_C guint64 mono_lshl (guint64 a, gint32 shamt);
 
-guint64 mono_lshr_un (guint64 a, gint32 shamt);
+G_EXTERN_C guint64 mono_lshr_un (guint64 a, gint32 shamt);
 
-gint64 mono_lshr (gint64 a, gint32 shamt);
+G_EXTERN_C gint64 mono_lshr (gint64 a, gint32 shamt);
 
-MonoArray *mono_array_new_va (MonoMethod *cm, ...);
+G_EXTERN_C MonoArray *mono_array_new_va (MonoMethod *cm, ...);
 
-MonoArray *mono_array_new_1 (MonoMethod *cm, guint32 length);
+G_EXTERN_C MonoArray *mono_array_new_1 (MonoMethod *cm, guint32 length);
 
-MonoArray *mono_array_new_2 (MonoMethod *cm, guint32 length1, guint32 length2);
+G_EXTERN_C MonoArray *mono_array_new_2 (MonoMethod *cm, guint32 length1, guint32 length2);
 
-MonoArray *mono_array_new_3 (MonoMethod *cm, guint32 length1, guint32 length2, guint32 length3);
+G_EXTERN_C MonoArray *mono_array_new_3 (MonoMethod *cm, guint32 length1, guint32 length2, guint32 length3);
 
-MonoArray *mono_array_new_4 (MonoMethod *cm, guint32 length1, guint32 length2, guint32 length3, guint32 length4);
+G_EXTERN_C MonoArray *mono_array_new_4 (MonoMethod *cm, guint32 length1, guint32 length2, guint32 length3, guint32 length4);
 
-gpointer mono_class_static_field_address (MonoDomain *domain, MonoClassField *field);
+G_EXTERN_C gpointer mono_class_static_field_address (MonoDomain *domain, MonoClassField *field);
 
-gpointer mono_ldtoken_wrapper (MonoImage *image, int token, MonoGenericContext *context);
+G_EXTERN_C gpointer mono_ldtoken_wrapper (MonoImage *image, int token, MonoGenericContext *context);
 
-gpointer mono_ldtoken_wrapper_generic_shared (MonoImage *image, int token, MonoMethod *method);
+G_EXTERN_C gpointer mono_ldtoken_wrapper_generic_shared (MonoImage *image, int token, MonoMethod *method);
 
-guint64 mono_fconv_u8 (double v);
+G_EXTERN_C guint64 mono_fconv_u8 (double v);
 
-guint64 mono_rconv_u8 (float v);
+G_EXTERN_C guint64 mono_rconv_u8 (float v);
 
-gint64 mono_fconv_i8 (double v);
+G_EXTERN_C gint64 mono_fconv_i8 (double v);
 
-guint32 mono_fconv_u4 (double v);
+G_EXTERN_C guint32 mono_fconv_u4 (double v);
 
-gint64 mono_fconv_ovf_i8 (double v);
+G_EXTERN_C gint64 mono_fconv_ovf_i8 (double v);
 
-guint64 mono_fconv_ovf_u8 (double v);
+G_EXTERN_C guint64 mono_fconv_ovf_u8 (double v);
 
-gint64 mono_rconv_i8 (float v);
+G_EXTERN_C gint64 mono_rconv_i8 (float v);
 
-gint64 mono_rconv_ovf_i8 (float v);
+G_EXTERN_C gint64 mono_rconv_ovf_i8 (float v);
 
-guint64 mono_rconv_ovf_u8 (float v);
+G_EXTERN_C guint64 mono_rconv_ovf_u8 (float v);
 
-double mono_lconv_to_r8 (gint64 a);
+G_EXTERN_C double mono_lconv_to_r8 (gint64 a);
 
-double mono_conv_to_r8 (gint32 a);
+G_EXTERN_C double mono_conv_to_r8 (gint32 a);
 
-double mono_conv_to_r4 (gint32 a);
+G_EXTERN_C double mono_conv_to_r4 (gint32 a);
 
-float mono_lconv_to_r4 (gint64 a);
+G_EXTERN_C float mono_lconv_to_r4 (gint64 a);
 
-double mono_conv_to_r8_un (guint32 a);
+G_EXTERN_C double mono_conv_to_r8_un (guint32 a);
 
-double mono_lconv_to_r8_un (guint64 a);
+G_EXTERN_C double mono_lconv_to_r8_un (guint64 a);
 
-gpointer mono_helper_compile_generic_method (MonoObject *obj, MonoMethod *method, gpointer *this_arg);
+G_EXTERN_C gpointer mono_helper_compile_generic_method (MonoObject *obj, MonoMethod *method, gpointer *this_arg);
 
 ICALL_EXPORT
 MonoString*
 ves_icall_mono_ldstr (MonoDomain *domain, MonoImage *image, guint32 idx);
 
-MonoString *mono_helper_ldstr (MonoImage *image, guint32 idx);
+G_EXTERN_C MonoString *mono_helper_ldstr (MonoImage *image, guint32 idx);
 
-MonoString *mono_helper_ldstr_mscorlib (guint32 idx);
+G_EXTERN_C MonoString *mono_helper_ldstr_mscorlib (guint32 idx);
 
-MonoObject *mono_helper_newobj_mscorlib (guint32 idx);
+G_EXTERN_C MonoObject *mono_helper_newobj_mscorlib (guint32 idx);
 
-double mono_fsub (double a, double b);
+G_EXTERN_C double mono_fsub (double a, double b);
 
-double mono_fadd (double a, double b);
+G_EXTERN_C double mono_fadd (double a, double b);
 
-double mono_fmul (double a, double b);
+G_EXTERN_C double mono_fmul (double a, double b);
 
-double mono_fneg (double a);
+G_EXTERN_C double mono_fneg (double a);
 
-double mono_fconv_r4 (double a);
+G_EXTERN_C double mono_fconv_r4 (double a);
 
-gint8 mono_fconv_i1 (double a);
+G_EXTERN_C gint8 mono_fconv_i1 (double a);
 
-gint16 mono_fconv_i2 (double a);
+G_EXTERN_C gint16 mono_fconv_i2 (double a);
 
-gint32 mono_fconv_i4 (double a);
+G_EXTERN_C gint32 mono_fconv_i4 (double a);
 
-guint8 mono_fconv_u1 (double a);
+G_EXTERN_C guint8 mono_fconv_u1 (double a);
 
-guint16 mono_fconv_u2 (double a);
+G_EXTERN_C guint16 mono_fconv_u2 (double a);
 
-gboolean mono_fcmp_eq (double a, double b);
+G_EXTERN_C gboolean mono_fcmp_eq (double a, double b);
 
-gboolean mono_fcmp_ge (double a, double b);
+G_EXTERN_C gboolean mono_fcmp_ge (double a, double b);
 
-gboolean mono_fcmp_gt (double a, double b);
+G_EXTERN_C gboolean mono_fcmp_gt (double a, double b);
 
-gboolean mono_fcmp_le (double a, double b);
+G_EXTERN_C gboolean mono_fcmp_le (double a, double b);
 
-gboolean mono_fcmp_lt (double a, double b);
+G_EXTERN_C gboolean mono_fcmp_lt (double a, double b);
 
-gboolean mono_fcmp_ne_un (double a, double b);
+G_EXTERN_C gboolean mono_fcmp_ne_un (double a, double b);
 
-gboolean mono_fcmp_ge_un (double a, double b);
+G_EXTERN_C gboolean mono_fcmp_ge_un (double a, double b);
 
-gboolean mono_fcmp_gt_un (double a, double b);
+G_EXTERN_C gboolean mono_fcmp_gt_un (double a, double b);
 
-gboolean mono_fcmp_le_un (double a, double b);
+G_EXTERN_C gboolean mono_fcmp_le_un (double a, double b);
 
-gboolean mono_fcmp_lt_un (double a, double b);
+G_EXTERN_C gboolean mono_fcmp_lt_un (double a, double b);
 
-gboolean mono_fceq (double a, double b);
+G_EXTERN_C gboolean mono_fceq (double a, double b);
 
-gboolean mono_fcgt (double a, double b);
+G_EXTERN_C gboolean mono_fcgt (double a, double b);
 
-gboolean mono_fcgt_un (double a, double b);
+G_EXTERN_C gboolean mono_fcgt_un (double a, double b);
 
-gboolean mono_fclt (double a, double b);
+G_EXTERN_C gboolean mono_fclt (double a, double b);
 
-gboolean mono_fclt_un (double a, double b);
+G_EXTERN_C gboolean mono_fclt_un (double a, double b);
 
-gboolean mono_isfinite (double a);
+G_EXTERN_C gboolean mono_isfinite (double a);
 
-double   mono_fload_r4 (float *ptr);
+G_EXTERN_C double   mono_fload_r4 (float *ptr);
 
-void     mono_fstore_r4 (double val, float *ptr);
+G_EXTERN_C void     mono_fstore_r4 (double val, float *ptr);
 
-guint32  mono_fload_r4_arg (double val);
+G_EXTERN_C guint32  mono_fload_r4_arg (double val);
 
-void     mono_break (void);
+G_EXTERN_C void     mono_break (void);
 
-MonoException *mono_create_corlib_exception_0 (guint32 token);
+G_EXTERN_C MonoException *mono_create_corlib_exception_0 (guint32 token);
 
-MonoException *mono_create_corlib_exception_1 (guint32 token, MonoString *arg);
+G_EXTERN_C MonoException *mono_create_corlib_exception_1 (guint32 token, MonoString *arg);
 
-MonoException *mono_create_corlib_exception_2 (guint32 token, MonoString *arg1, MonoString *arg2);
+G_EXTERN_C MonoException *mono_create_corlib_exception_2 (guint32 token, MonoString *arg1, MonoString *arg2);
 
-MonoObject* mono_object_castclass_unbox (MonoObject *obj, MonoClass *klass);
+G_EXTERN_C MonoObject* mono_object_castclass_unbox (MonoObject *obj, MonoClass *klass);
 
-gpointer mono_get_native_calli_wrapper (MonoImage *image, MonoMethodSignature *sig, gpointer func);
+G_EXTERN_C gpointer mono_get_native_calli_wrapper (MonoImage *image, MonoMethodSignature *sig, gpointer func);
 
-MonoObject*
-mono_object_isinst_with_cache (MonoObject *obj, MonoClass *klass, gpointer *cache);
+G_EXTERN_C MonoObject* mono_object_isinst_with_cache (MonoObject *obj, MonoClass *klass, gpointer *cache);
 
-MonoObject*
-mono_object_castclass_with_cache (MonoObject *obj, MonoClass *klass, gpointer *cache);
+G_EXTERN_C MonoObject* mono_object_castclass_with_cache (MonoObject *obj, MonoClass *klass, gpointer *cache);
 
 ICALL_EXPORT
 void
 ves_icall_runtime_class_init (MonoVTable *vtable);
 
-void
+G_EXTERN_C void
 mono_generic_class_init (MonoVTable *vtable);
 
 ICALL_EXPORT
@@ -202,37 +200,36 @@ ICALL_EXPORT
 void
 ves_icall_mono_delegate_ctor_interp (MonoObject *this_obj, MonoObject *target, gpointer addr);
 
-MonoObject*
-mono_gsharedvt_constrained_call (gpointer mp, MonoMethod *cmethod, MonoClass *klass, gboolean deref_arg, gpointer *args);
+G_EXTERN_C MonoObject* mono_gsharedvt_constrained_call (gpointer mp, MonoMethod *cmethod, MonoClass *klass, gboolean deref_arg, gpointer *args);
 
-void mono_gsharedvt_value_copy (gpointer dest, gpointer src, MonoClass *klass);
+G_EXTERN_C void mono_gsharedvt_value_copy (gpointer dest, gpointer src, MonoClass *klass);
 
-gpointer mono_fill_class_rgctx (MonoVTable *vtable, int index);
+G_EXTERN_C gpointer mono_fill_class_rgctx (MonoVTable *vtable, int index);
 
-gpointer mono_fill_method_rgctx (MonoMethodRuntimeGenericContext *mrgctx, int index);
+G_EXTERN_C gpointer mono_fill_method_rgctx (MonoMethodRuntimeGenericContext *mrgctx, int index);
 
-gpointer mono_resolve_iface_call_gsharedvt (MonoObject *this_obj, int imt_slot, MonoMethod *imt_method, gpointer *out_arg);
+G_EXTERN_C gpointer mono_resolve_iface_call_gsharedvt (MonoObject *this_obj, int imt_slot, MonoMethod *imt_method, gpointer *out_arg);
 
-gpointer mono_resolve_vcall_gsharedvt (MonoObject *this_obj, int imt_slot, MonoMethod *imt_method, gpointer *out_arg);
+G_EXTERN_C gpointer mono_resolve_vcall_gsharedvt (MonoObject *this_obj, int imt_slot, MonoMethod *imt_method, gpointer *out_arg);
 
-MonoFtnDesc* mono_resolve_generic_virtual_call (MonoVTable *vt, int slot, MonoMethod *imt_method);
+G_EXTERN_C MonoFtnDesc* mono_resolve_generic_virtual_call (MonoVTable *vt, int slot, MonoMethod *imt_method);
 
-MonoFtnDesc* mono_resolve_generic_virtual_iface_call (MonoVTable *vt, int imt_slot, MonoMethod *imt_method);
+G_EXTERN_C MonoFtnDesc* mono_resolve_generic_virtual_iface_call (MonoVTable *vt, int imt_slot, MonoMethod *imt_method);
 
-gpointer mono_init_vtable_slot (MonoVTable *vtable, int slot);
+G_EXTERN_C gpointer mono_init_vtable_slot (MonoVTable *vtable, int slot);
 
-void mono_llvmonly_init_delegate (MonoDelegate *del);
+G_EXTERN_C void mono_llvmonly_init_delegate (MonoDelegate *del);
 
-void mono_llvmonly_init_delegate_virtual (MonoDelegate *del, MonoObject *target, MonoMethod *method);
+G_EXTERN_C void mono_llvmonly_init_delegate_virtual (MonoDelegate *del, MonoObject *target, MonoMethod *method);
 
-MonoObject* mono_get_assembly_object (MonoImage *image);
+G_EXTERN_C MonoObject* mono_get_assembly_object (MonoImage *image);
 
-MonoObject* mono_get_method_object (MonoMethod *method);
+G_EXTERN_C MonoObject* mono_get_method_object (MonoMethod *method);
 
-double mono_ckfinite (double d);
+G_EXTERN_C double mono_ckfinite (double d);
 
-void mono_throw_method_access (MonoMethod *caller, MonoMethod *callee);
+G_EXTERN_C void mono_throw_method_access (MonoMethod *caller, MonoMethod *callee);
 
-void mono_dummy_jit_icall (void);
+G_EXTERN_C void mono_dummy_jit_icall (void);
 
 #endif /* __MONO_JIT_ICALLS_H__ */

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -3656,15 +3656,13 @@ mono_llvm_match_exception (MonoJitInfo *jinfo, guint32 region_start, guint32 reg
 }
 
 #if defined(ENABLE_LLVM) && defined(HAVE_UNWIND_H)
-_Unwind_Reason_Code 
-mono_debug_personality (int a, _Unwind_Action b,
-uint64_t c, struct _Unwind_Exception *d, struct _Unwind_Context *e)
+G_EXTERN_C _Unwind_Reason_Code mono_debug_personality (int a, _Unwind_Action b,
+	uint64_t c, struct _Unwind_Exception *d, struct _Unwind_Context *e)
 {
 	g_assert_not_reached ();
 }
 #else
-void
-mono_debug_personality (void);
+G_EXTERN_C void mono_debug_personality (void);
 
 void
 mono_debug_personality (void)

--- a/mono/mini/mini-llvm-cpp.h
+++ b/mono/mini/mini-llvm-cpp.h
@@ -116,8 +116,7 @@ void
 mono_llvm_add_instr_attr (LLVMValueRef val, int index, AttrKind kind);
 
 #if defined(ENABLE_LLVM) && defined(HAVE_UNWIND_H)
-_Unwind_Reason_Code 
-mono_debug_personality (int a, _Unwind_Action b,
+G_EXTERN_C _Unwind_Reason_Code mono_debug_personality (int a, _Unwind_Action b,
 	uint64_t c, struct _Unwind_Exception *d, struct _Unwind_Context *e);
 #endif
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4472,9 +4472,8 @@ mini_init (const char *filename, const char *runtime_version)
 
 #ifdef MONO_ARCH_EMULATE_FREM
 // Wrapper to avoid taking address of overloaded function.
-G_EXTERN_C double mono_fmod (double a, double b);
-
-G_EXTERN_C double mono_fmod (double a, double b)
+static double
+mono_fmod (double a, double b)
 {
 	return fmod (a, b);
 }

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4472,8 +4472,9 @@ mini_init (const char *filename, const char *runtime_version)
 
 #ifdef MONO_ARCH_EMULATE_FREM
 // Wrapper to avoid taking address of overloaded function.
-static double
-mono_fmod (double a, double b)
+G_EXTERN_C double mono_fmod (double a, double b);
+
+G_EXTERN_C double mono_fmod (double a, double b)
 {
 	return fmod (a, b);
 }

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2429,7 +2429,7 @@ void     mono_free_altstack                     (MonoJitTlsData *tls);
 gpointer mono_altstack_restore_prot             (mgreg_t *regs, guint8 *code, gpointer *tramp_data, guint8* tramp);
 MonoJitInfo* mini_jit_info_table_find           (MonoDomain *domain, gpointer addr, MonoDomain **out_domain);
 MonoJitInfo* mini_jit_info_table_find_ext       (MonoDomain *domain, gpointer addr, gboolean allow_trampolines, MonoDomain **out_domain);
-void     mono_resume_unwind                     (MonoContext *ctx) MONO_LLVM_INTERNAL;
+G_EXTERN_C void mono_resume_unwind              (MonoContext *ctx) MONO_LLVM_INTERNAL;
 
 MonoJitInfo * mono_find_jit_info                (MonoDomain *domain, MonoJitTlsData *jit_tls, MonoJitInfo *res, MonoJitInfo *prev_ji, MonoContext *ctx, MonoContext *new_ctx, char **trace, MonoLMF **lmf, int *native_offset, gboolean *managed);
 
@@ -2438,16 +2438,16 @@ MONO_API gboolean mono_exception_walk_trace     (MonoException *ex, MonoExceptio
 void mono_restore_context                       (MonoContext *ctx);
 guint8* mono_jinfo_get_unwind_info              (MonoJitInfo *ji, guint32 *unwind_info_len);
 int  mono_jinfo_get_epilog_size                 (MonoJitInfo *ji);
-void     mono_llvm_rethrow_exception            (MonoObject *ex);
-void     mono_llvm_throw_exception              (MonoObject *ex);
-void     mono_llvm_throw_corlib_exception       (guint32 ex_token_index);
-void     mono_llvm_resume_exception             (void);
+G_EXTERN_C void mono_llvm_rethrow_exception     (MonoObject *ex);
+G_EXTERN_C void mono_llvm_throw_exception       (MonoObject *ex);
+G_EXTERN_C void mono_llvm_throw_corlib_exception (guint32 ex_token_index);
+G_EXTERN_C void mono_llvm_resume_exception      (void);
 void     mono_llvm_clear_exception              (void);
-MonoObject *mono_llvm_load_exception            (void);
+G_EXTERN_C MonoObject *mono_llvm_load_exception (void);
 void     mono_llvm_reset_exception              (void);
 void     mono_llvm_raise_exception              (MonoException *e);
 void     mono_llvm_reraise_exception            (MonoException *e);
-gint32 mono_llvm_match_exception                (MonoJitInfo *jinfo, guint32 region_start, guint32 region_end, gpointer rgctx, MonoObject *this_obj);
+G_EXTERN_C gint32 mono_llvm_match_exception     (MonoJitInfo *jinfo, guint32 region_start, guint32 region_end, gpointer rgctx, MonoObject *this_obj);
 
 gboolean
 mono_find_jit_info_ext (MonoDomain *domain, MonoJitTlsData *jit_tls, 
@@ -2688,7 +2688,7 @@ MonoMethod* mini_get_gsharedvt_in_sig_wrapper (MonoMethodSignature *sig);
 MonoMethod* mini_get_gsharedvt_out_sig_wrapper (MonoMethodSignature *sig);
 MonoMethodSignature* mini_get_gsharedvt_out_sig_wrapper_signature (gboolean has_this, gboolean has_ret, int param_count);
 gboolean mini_gsharedvt_runtime_invoke_supported (MonoMethodSignature *sig);
-void mono_interp_entry_from_trampoline (gpointer ccontext, gpointer imethod);
+G_EXTERN_C void mono_interp_entry_from_trampoline (gpointer ccontext, gpointer imethod);
 MonoMethod* mini_get_interp_in_wrapper (MonoMethodSignature *sig);
 MonoMethod* mini_get_interp_lmf_wrapper (void);
 

--- a/mono/utils/mono-tls.h
+++ b/mono/utils/mono-tls.h
@@ -86,16 +86,16 @@ gint32 mono_tls_get_tls_offset (MonoTlsKey key);
 gpointer mono_tls_get_tls_getter (MonoTlsKey key, gboolean name);
 gpointer mono_tls_get_tls_setter (MonoTlsKey key, gboolean name);
 
-MonoInternalThread *mono_tls_get_thread (void);
-MonoJitTlsData     *mono_tls_get_jit_tls (void);
-MonoDomain         *mono_tls_get_domain (void);
-SgenThreadInfo     *mono_tls_get_sgen_thread_info (void);
-MonoLMF           **mono_tls_get_lmf_addr (void);
+G_EXTERN_C MonoInternalThread *mono_tls_get_thread (void);
+G_EXTERN_C MonoJitTlsData     *mono_tls_get_jit_tls (void);
+G_EXTERN_C MonoDomain *mono_tls_get_domain (void);
+G_EXTERN_C SgenThreadInfo     *mono_tls_get_sgen_thread_info (void);
+G_EXTERN_C MonoLMF           **mono_tls_get_lmf_addr (void);
 
-void mono_tls_set_thread 	   (MonoInternalThread *value);
-void mono_tls_set_jit_tls 	   (MonoJitTlsData     *value);
-void mono_tls_set_domain 	   (MonoDomain         *value);
-void mono_tls_set_sgen_thread_info (SgenThreadInfo     *value);
-void mono_tls_set_lmf_addr 	   (MonoLMF           **value);
+G_EXTERN_C void mono_tls_set_thread 	   (MonoInternalThread *value);
+G_EXTERN_C void mono_tls_set_jit_tls 	   (MonoJitTlsData     *value);
+G_EXTERN_C void mono_tls_set_domain 	   (MonoDomain         *value);
+G_EXTERN_C void mono_tls_set_sgen_thread_info (SgenThreadInfo     *value);
+G_EXTERN_C void mono_tls_set_lmf_addr 	   (MonoLMF           **value);
 
 #endif /* __MONO_TLS_H__ */


### PR DESCRIPTION
Guessing a bit on the extern "C". Will see what CI says.

And what is with this function/name mismatch?

mono/metadata/marshal.c:                register_icall (mono_gc_wbarrier_generic_nostore, "wb_generic", "void ptr", FALSE);

The cast was lost because at the last moment I changed the parameter from argval to void_argval and assign to local, to reduce the semantic change (and then a cast later removed).