### PR TITLE
[corlib] Don't decrement ConditionalWeakTable::size on remove.

### DIFF
--- a/mcs/class/corlib/System.Runtime.CompilerServices/ConditionalWeakTable.cs
+++ b/mcs/class/corlib/System.Runtime.CompilerServices/ConditionalWeakTable.cs
@@ -225,7 +225,6 @@ namespace System.Runtime.CompilerServices
 					if (k == key) {
 						data [idx].key = GC.EPHEMERON_TOMBSTONE;
 						data [idx].value = null;
-						--size;
 						return true;
 					}
 					if (k == null)
@@ -325,7 +324,7 @@ namespace System.Runtime.CompilerServices
 			{
 				for (int i = 0; i < data.Length; i++)
 				{
-					data[i].key = GC.EPHEMERON_TOMBSTONE;
+					data[i].key = null;
 					data[i].value = null;
 				}
 


### PR DESCRIPTION
We can't decrement the size on removal as we use tombstones.
When using tombstones, the invariant to keep is on the number of null entries as those
are used as search stop-marks.

Without this change, it's possible that a long series of add/remove operations could leave the array with no null entries,
just tombstones and filled entries. In that case, search would degenerate into a linear search that would look into all array elements.

This change fixes worst-case perf of not-found searches to be bound to the load factor.

Additionally, clear the array to null entries, otherwise we fall into the above trap even more easily.