### PR TITLE
[coop] Make mono_jit_thread_attach external only and switch to GC Safe

### DIFF
--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -455,7 +455,7 @@ MONO_API void
 mono_threads_detach_coop (gpointer cookie, gpointer *dummy);
 
 MonoDomain*
-mono_threads_attach_coop_internal (MonoDomain *domain, gpointer *cookie, MonoStackData *stackdata);
+mono_threads_attach_coop_internal (MonoDomain *domain, gpointer *cookie, MonoStackData *stackdata, gboolean attach_external_gc_safe);
 
 void
 mono_threads_detach_coop_internal (MonoDomain *orig_domain, gpointer cookie, MonoStackData *stackdata);

--- a/mono/mini/aot-runtime.h
+++ b/mono/mini/aot-runtime.h
@@ -11,7 +11,7 @@
 #include "mini.h"
 
 /* Version number of the AOT file format */
-#define MONO_AOT_FILE_VERSION 147
+#define MONO_AOT_FILE_VERSION 148
 
 #define MONO_AOT_TRAMP_PAGE_SIZE 16384
 

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -5096,7 +5096,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 			gpointer tls_jit = mono_tls_get_jit_tls ();
 
 			if (tls_domain != rtm->domain || !tls_jit) {
-				context->original_domain = mono_jit_thread_attach (rtm->domain);
+				context->original_domain = mono_jit_thread_attach_internal (rtm->domain);
 				/*
 				 * Make sure the JitTlsData contains the interp context, in case
 				 * we weren't yet attached at interp_entry time.

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -11245,7 +11245,7 @@ mono_ldptr:
 				EMIT_NEW_AOTCONST (cfg, addr, MONO_PATCH_INFO_JIT_THREAD_ATTACH, NULL);
 				ins = mini_emit_calli (cfg, helper_sig_jit_thread_attach, args, addr, NULL, NULL);
 			} else {
-				ins = mono_emit_jit_icall (cfg, mono_jit_thread_attach, args);
+				ins = mono_emit_jit_icall (cfg, mono_jit_thread_attach_internal, args);
 			}
 			MONO_EMIT_NEW_UNALU (cfg, OP_MOVE, cfg->orig_domain_var->dreg, ins->dreg);
 

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -427,7 +427,9 @@ void      mono_set_lmf                      (MonoLMF *lmf);
 void      mono_push_lmf                     (MonoLMFExt *ext);
 void      mono_pop_lmf                      (MonoLMF *lmf);
 MonoJitTlsData* mono_get_jit_tls            (void);
+MONO_RT_EXTERNAL_ONLY
 MONO_API MonoDomain* mono_jit_thread_attach (MonoDomain *domain);
+MonoDomain* mono_jit_thread_attach_internal (MonoDomain *domain);
 MONO_API void      mono_jit_set_domain      (MonoDomain *domain);
 
 gboolean  mono_method_same_domain           (MonoJitInfo *caller, MonoJitInfo *callee);


### PR DESCRIPTION
`mono_jit_thread_attach` had two uses:
* in preemptive suspend it was used for in all native-to-managed wrappers to attach a thread to the runtime and to switch the active domain;
* it is also used by embedders to attach foreign threads to the runtime.  There is no corresponding detach operation. For example, Xamarin.Mac uses this function in this way.

With hybrid suspend the first use isn't needed (hybrid and coop suspend use `mono_threads_attach_coop`/`mono_threads_detach_coop` in the n2m wrappers).

The second use, however is still present.  However in this case we actually want to attach the thread in BLOCKING (GC Safe) mode since we know the thread is foreign and isn't running any managed code yet.  When it calls a Mono API function or when it calls a managed delegate through a trampoline, we'll switch to GC Unsafe (and then switch back to GC Safe when the managed or mono API function returns).

One place where this is useful is when Xamarin.Mac users call managed delegates from Grand Central Dispatch worker threads - after the task runs, we need to leave the idle GCD worker in GC Safe so that if Mono performs a GC, we don't try to wait for the worker to cooperatively suspend itself.

Also bump the AOT file format so we don't have any stale AOT references to `mono_jit_thread_attach` from AOTd managed code.

**NOTE**: PR against 2018-08.  Sorry. I'll do a matching `master` PR soon.