### PR TITLE
Fix forceBuild not working for projects with unknown platform names (i.e. jay)

### DIFF
--- a/msvc/scripts/genproj.cs
+++ b/msvc/scripts/genproj.cs
@@ -141,11 +141,11 @@ public class SlnGenerator {
 		var fallbackProfileNames = new List<string> ();
 
 		foreach (var profile in profiles) {
-			if (!observedProfiles.Contains (profile))
+			if (!observedProfiles.Contains (profile) && !forceBuild)
 				continue;
 
 			var platformToBuild = profile;
-			var isBuildEnabled = true;			
+			var isBuildEnabled = true;
 
 			HashSet<string> projectProfiles;
 			if (
@@ -156,6 +156,9 @@ public class SlnGenerator {
 				platformToBuild = defaultPlatform;
 				isBuildEnabled = forceBuild;
 			}
+
+			if (!isBuildEnabled)
+				Console.Error.WriteLine($"// Project {guid} not set to build due to lack of appropriate profiles");
 
 			sln.WriteLine ("\t\t{0}.Debug|{1}.ActiveCfg = Debug|{2}", guid, profile, platformToBuild);
 			if (isBuildEnabled)

--- a/msvc/scripts/genproj.cs
+++ b/msvc/scripts/genproj.cs
@@ -139,6 +139,7 @@ public class SlnGenerator {
 	private void WriteProjectConfigurationPlatforms (StreamWriter sln, string guid, string defaultPlatform, bool forceBuild)
 	{
 		var fallbackProfileNames = new List<string> ();
+		var didBuildAnyProfile = false;
 
 		foreach (var profile in profiles) {
 			if (!observedProfiles.Contains (profile) && !forceBuild)
@@ -157,8 +158,8 @@ public class SlnGenerator {
 				isBuildEnabled = forceBuild;
 			}
 
-			if (!isBuildEnabled)
-				Console.Error.WriteLine($"// Project {guid} not set to build due to lack of appropriate profiles");
+			if (isBuildEnabled)
+				didBuildAnyProfile = true;
 
 			sln.WriteLine ("\t\t{0}.Debug|{1}.ActiveCfg = Debug|{2}", guid, profile, platformToBuild);
 			if (isBuildEnabled)
@@ -167,6 +168,9 @@ public class SlnGenerator {
 			if (isBuildEnabled)
 				sln.WriteLine ("\t\t{0}.Release|{1}.Build.0 = Release|{2}", guid, profile, platformToBuild);
 		}
+
+		if (!didBuildAnyProfile)
+			Console.Error.WriteLine($"// Project {guid} not set to build in any profile");
 
 		if (fallbackProfileNames.Count > 0)
 			Console.Error.WriteLine ($"// Project {guid} does not have profile(s) {string.Join(", ", fallbackProfileNames)} so using {defaultPlatform}");


### PR DESCRIPTION
This broke at some point and I didn't notice because it's a behavior divergence between msbuild and devenv (I was busy fixing msbuild-only bugs). As a result of some old broken logic in genproj (my fault probably but I forget), jay.vcxproj was not being set to build and VS would happily skip it even though some .csproj files depended on it, and as a result VS tried to build them and failed.

This should fix it but I'm submitting the PR since make -j + update-solution-files takes an eternity on my machine.