### PR TITLE
[2018-08] Ensure the finalization in DeflateStream is performed in the correct order.

### DIFF
--- a/mcs/class/System/System.IO.Compression/DeflateStream.cs
+++ b/mcs/class/System/System.IO.Compression/DeflateStream.cs
@@ -380,6 +380,9 @@ namespace System.IO.Compression
 				GC.SuppressFinalize (this);
 			
 				io_buffer = null;
+			} else {
+				// When we are in the finalizer we don't want to access the underlying stream anymore
+				base_stream = Stream.Null;
 			}
 
 			if (z_stream != null) {

--- a/mcs/class/System/System.IO.Compression/DeflateStream.cs
+++ b/mcs/class/System/System.IO.Compression/DeflateStream.cs
@@ -380,7 +380,9 @@ namespace System.IO.Compression
 				GC.SuppressFinalize (this);
 			
 				io_buffer = null;
-			
+			}
+
+			if (z_stream != null) {
 				z_stream.Dispose();
 			}
 


### PR DESCRIPTION
Backport of #10330.

/cc @marek-safar