### PR TITLE
[2018-08] Fix DeflateStream handling of zero-length reads from underlying stream.

### DIFF
--- a/mcs/class/System/Test/System.IO.Compression/DeflateStreamTest.cs
+++ b/mcs/class/System/Test/System.IO.Compression/DeflateStreamTest.cs
@@ -480,6 +480,61 @@ namespace MonoTests.System.IO.Compression
 
 			Assert.AreEqual(125387, byteCount);
 		}
+
+		[Test]
+		public void Issue10054_ZeroRead()
+		{
+			// "HelloWorld" as UTF8/DeflateStream(...,CompressionMode.Compress)
+			var buffer = new byte[] { 243, 72, 205, 201, 201, 15, 207, 47, 202, 73, 1, 0 };
+			var mem = new MemoryStream(buffer);
+			var chu = new ChunkedReader(mem);
+			var def = new DeflateStream(chu, CompressionMode.Decompress);
+			
+			var buffer2 = new byte[4096];
+			int read2 = 0;
+
+			chu.limit = 3;
+			read2 += def.Read(buffer2, read2, buffer2.Length - read2);
+			chu.limit = 100;
+			read2 += def.Read(buffer2, read2, buffer2.Length - read2);
+
+			var res = Encoding.UTF8.GetString(buffer2, 0, read2);
+			Assert.AreEqual("HelloWorld", res);
+		}
+
+		public class ChunkedReader : Stream
+		{
+			public int limit = 0;
+			private Stream baseStream;
+			
+			public ChunkedReader(Stream baseStream)
+			{
+				this.baseStream = baseStream;
+			}
+
+			public override int Read(byte[] buffer, int offset, int count)
+			{
+				int read = baseStream.Read(buffer, offset, Math.Min(count, this.limit));
+				this.limit -= read;
+				return read;
+			}
+
+			public override void Flush() => baseStream.Flush();
+			public override long Seek(long offset, SeekOrigin origin) => baseStream.Seek(offset, origin);
+			public override void SetLength(long value) => baseStream.SetLength(value);
+			public override void Write(byte[] buffer, int offset, int count) => baseStream.Write(buffer, offset, count);
+
+			public override bool CanRead => baseStream.CanRead;
+			public override bool CanSeek => baseStream.CanSeek;
+			public override bool CanWrite => baseStream.CanWrite;
+			public override long Length => baseStream.Length;
+
+			public override long Position
+			{
+				get => baseStream.Position;
+				set => baseStream.Position = value;
+			}
+		}
 	}
 }
 

--- a/support/zlib-helper.c
+++ b/support/zlib-helper.c
@@ -208,7 +208,9 @@ ReadZStream (ZStream *stream, guchar *buffer, gint length)
 			stream->eof = TRUE;
 			break;
 		} else if (status == Z_BUF_ERROR && stream->total_in == zs->total_in) {
-			stream->eof = TRUE;
+			if (zs->avail_in != 0) {
+				stream->eof = TRUE;
+			}
 			break;
 		} else if (status != Z_OK) {
 			return status;


### PR DESCRIPTION
Backport of #10329.

/cc @marek-safar