### PR TITLE
Fix MonoTests.System.Linq.ParallelEnumerableTests.TestGroupBy frequently crashing on FullAOT/LLVM/Linux/amd64 CI.

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -6956,7 +6956,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 		/* Allocate locals */
 		locals_var = mono_compile_create_var (cfg, mono_get_int_type (), OP_LOCAL);
 		/* prevent it from being register allocated */
-		//locals_var->flags |= MONO_INST_VOLATILE;
+		locals_var->flags |= MONO_INST_VOLATILE;
 		cfg->gsharedvt_locals_var = locals_var;
 
 		dreg = alloc_ireg (cfg);


### PR DESCRIPTION
https://github.com/mono/mono/issues/10441
https://github.com/mono/mono/issues/9554
https://github.com/mono/mono/issues/9046

See https://github.com/mono/mono/commit/8dd12eab7fa2f2fac79cad5c751be7c2795683d4.

Note that I don't have a detailed analysis of the codegen before/after bad/good.
This is based on a lot of guessing and experimenting, and the experimenting is conclusive.
I had a greater than 10% failure rate without this, and 100% passing with.
It could be this covers up something else.
gsharedvt is obviously involved with the repro.
I don't have an explanation for the flakiness, or the Linux-specificity.
But the repro rates were high without this and zero with this, so this fixes it.
We can also bear this out in time with CI.
I looked into preserving more registers, i.e. in the nearby safepoint callout.
That didn't seem to work, but if it did, would explain flakiness.
 Oh, I also hacked JIT to not emit safe points and that didn't help, so that should rule that out.
Removing parallel from the test also made it not repro.

The way gsharedvt works, I doubt anyone will mind this pessimization.
In the test, we call memcpy frequently to copy 4 bytes. Actual calls. For a constant 4 bytes. With LLVM. To compute the hash of an int. You can see it in some of the repros.

It is still reasonable to suspect this is a problem of register preservation.