### PR TITLE
[2018-08] Fix Mono Windows cross compiler using mono LLVM release_60 branch.

### DIFF
--- a/llvm/Makefile.am
+++ b/llvm/Makefile.am
@@ -9,6 +9,12 @@ else
 llvm_config=llvm-config
 endif
 
+if HAVE_ZLIB
+llvm_extra_libs=-lz
+else
+llvm_extra_libs=
+endif
+
 if INTERNAL_LLVM
 
 all-local: configure-llvm build-llvm install-llvm llvm_config.mk
@@ -16,7 +22,7 @@ all-local: configure-llvm build-llvm install-llvm llvm_config.mk
 clean-local: clean-llvm clean-llvm-config
 
 $(mono_build_root)/llvm/llvm_config.mk: install-llvm
-	$(top_srcdir)/llvm/build_llvm_config.sh $(top_srcdir)/llvm/usr/bin/$(llvm_config) $(LLVM_CODEGEN_LIBS) > $@
+	$(top_srcdir)/llvm/build_llvm_config.sh "$(top_srcdir)/llvm/usr/bin/$(llvm_config)" "$(LLVM_CODEGEN_LIBS)" "$(llvm_extra_libs)" > $@
 
 else
 all-local: llvm_config.mk
@@ -24,7 +30,7 @@ all-local: llvm_config.mk
 clean-local: clean-llvm-config
 
 $(mono_build_root)/llvm/llvm_config.mk: $(top_srcdir)/llvm/Makefile.am
-	$(top_srcdir)/llvm/build_llvm_config.sh $(EXTERNAL_LLVM_CONFIG) $(LLVM_CODEGEN_LIBS) > $@
+	$(top_srcdir)/llvm/build_llvm_config.sh "$(EXTERNAL_LLVM_CONFIG)" "$(LLVM_CODEGEN_LIBS)" "$(llvm_extra_libs)" > $@
 endif
 
 llvm_config.mk: $(mono_build_root)/llvm/llvm_config.mk

--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -139,8 +139,7 @@ if [[ ${CI_TAGS} == *'product-sdks-android'* ]];
             ${TESTCMD} --label=provision-mxe --timeout=240m --fatal make -j4 -C sdks/builds provision-mxe
         fi
         ${TESTCMD} --label=llvm --timeout=240m --fatal make -j4 -C sdks/builds provision-llvm-llvm{,win}{32,64}
-        # FIXME: ${TESTCMD} --label=runtimes --timeout=120m --fatal make -j4 -C sdks/builds package-android-{armeabi-v7a,arm64-v8a,x86,x86_64} package-android-host-{Darwin,mxe-Win64} package-android-cross-{arm,arm64,x86,x86_64}{,-win}
-        ${TESTCMD} --label=runtimes --timeout=120m --fatal make -j4 -C sdks/builds package-android-{armeabi-v7a,arm64-v8a,x86,x86_64} package-android-host-{Darwin,mxe-Win64} package-android-cross-{arm,arm64,x86,x86_64}
+        ${TESTCMD} --label=runtimes --timeout=120m --fatal make -j4 -C sdks/builds package-android-{armeabi-v7a,arm64-v8a,x86,x86_64} package-android-host-{Darwin,mxe-Win64} package-android-cross-{arm,arm64,x86,x86_64}{,-win}
         exit 0
 fi
 


### PR DESCRIPTION
Fix Mono Windows cross compiler using mono LLVM release_60 branch.

For scenario where llvm-config.exe can't be run (none WSL/CygWin build target) build will fallback to hard coded libraries not working with mono LLVM release_60 branch.

Added an exact mirror of what llvm-config.exe is returning for different components on mono LLVM master and mono LLVM release_60 branch.

The selected codegen libraries (passed in as extra_libs) was not handled in any cases so added them into the build script as well.

Above successfully builds using mono LLVM master and mono LLVM release_60 branches and links into Windows mono cross compiler build on Linux.

Backport of https://github.com/mono/mono/pull/10413.