### PR TITLE
[WIP] Detect endianess in runtime (BitConverter.IsLittleEndian)

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -188,6 +188,7 @@ create_domain_objects (MonoDomain *domain)
 	MonoStringHandle arg;
 	MonoVTable *string_vt;
 	MonoClassField *string_empty_fld;
+	MonoClassField *bitconverter_isle_fld;
 
 	if (domain != old_domain) {
 		mono_thread_push_appdomain_ref (domain);
@@ -208,6 +209,14 @@ create_domain_objects (MonoDomain *domain)
 	mono_error_assert_ok (error);
 	mono_field_static_set_value (string_vt, string_empty_fld, empty_str);
 	domain->empty_string = empty_str;
+
+	bitconverter_isle_fld = mono_class_get_field_from_name_full (mono_defaults.bitconverter_class, "IsLittleEndian", NULL);
+	if (bitconverter_isle_fld) {
+		gint x = 1;
+		MonoBoolean is_le = *((char*) &x); // 00 00 00 01 for little-endian and 01 00 00 00 for big-endian
+		MonoVTable *bitconverter_vt = mono_class_vtable_checked (domain, mono_defaults.bitconverter_class, error);
+		mono_field_static_set_value (bitconverter_vt, bitconverter_isle_fld, &is_le);
+	}
 
 	/*
 	 * Create an instance early since we can't do it when there is no memory.

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -941,6 +941,7 @@ typedef struct {
 	MonoClass *threadpool_wait_callback_class;
 	MonoMethod *threadpool_perform_wait_callback_method;
 	MonoClass *console_class;
+	MonoClass *bitconverter_class;
 } MonoDefaults;
 
 #ifdef DISABLE_REMOTING

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -783,6 +783,8 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 
 	mono_defaults.console_class = mono_class_try_load_from_name (
 		mono_defaults.corlib, "System", "Console");
+	mono_defaults.bitconverter_class = mono_class_try_load_from_name (
+		mono_defaults.corlib, "System", "BitConverter");
 
 	domain->friendly_name = g_path_get_basename (filename);
 


### PR DESCRIPTION
This PR also expects https://github.com/mono/corefx/blob/master/src/Common/src/CoreLib/System/BitConverter.cs#L25 to be unassigned (to avoid a redundant static cctor).