### PR TITLE
[2018-06] Treat EXDEV from clonefile the same way as ENOTSUP.

### DIFF
--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -2480,7 +2480,7 @@ CopyFile (const gunichar2 *name, const gunichar2 *dest_name, gboolean fail_if_ex
 #if HOST_DARWIN
 	if (clonefile_ptr != NULL) {
 		ret = _wapi_clonefile (utf8_src, utf8_dest, 0);
-		if (ret == 0 || errno != ENOTSUP) {
+		if (ret == 0 || (errno != ENOTSUP && errno != EXDEV)) {
 			g_free (utf8_src);
 			g_free (utf8_dest);
 			MONO_ENTER_GC_SAFE;


### PR DESCRIPTION
Backport of #10528.

/cc @akoeplinger