### PR TITLE
[crash] Crash Reporter V2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2425,7 +2425,7 @@ if test x$host_win32 = xno; then
 	AC_CHECK_HEADERS(pthread.h)
 	AC_CHECK_HEADERS(pthread_np.h)
 	AC_CHECK_FUNCS(pthread_mutex_timedlock)
-	AC_CHECK_FUNCS(pthread_getattr_np pthread_attr_get_np pthread_setname_np pthread_cond_timedwait_relative_np)
+	AC_CHECK_FUNCS(pthread_getattr_np pthread_attr_get_np pthread_getname_np pthread_setname_np pthread_cond_timedwait_relative_np)
 	AC_CHECK_FUNCS(pthread_kill)
 	AC_MSG_CHECKING(for PTHREAD_MUTEX_RECURSIVE)
 	AC_TRY_COMPILE([ #include <pthread.h>], [
@@ -5766,7 +5766,7 @@ echo "
 	zlib:            $zlib_msg
 	BTLS:            $enable_btls$btls_platform_string
 	jemalloc:        $with_jemalloc (always use: $with_jemalloc_always)
-	crash reporting: $crash_reporting
+	crash reporting: $crash_reporting (private crashes: $crash_privacy)
 	$disabled
 "
 if test x$with_static_mono = xno -a "x$host_win32" != "xyes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # There is no ordering of corlib versions, no old or new,
 # the runtime expects an exact match.
 #
-MONO_CORLIB_VERSION=E06DCE2D-7852-4BBA-AD9F-54D67EEF1FF9
+MONO_CORLIB_VERSION=5F2CEB7B-13B1-4694-A0D5-3DD7EDE81388
 
 #
 # Put a quoted #define in config.h.
@@ -5766,7 +5766,7 @@ echo "
 	zlib:            $zlib_msg
 	BTLS:            $enable_btls$btls_platform_string
 	jemalloc:        $with_jemalloc (always use: $with_jemalloc_always)
-	crash reporting: $crash_reporting (private crashes: $crash_privacy)
+	crash reporting: $crash_reporting (private crashes: $with_crash_privacy)
 	$disabled
 "
 if test x$with_static_mono = xno -a "x$host_win32" != "xyes"; then

--- a/mcs/class/corlib/Mono/Runtime.cs
+++ b/mcs/class/corlib/Mono/Runtime.cs
@@ -169,7 +169,7 @@ namespace Mono {
 		static extern string DumpStateSingle_internal (out ulong portable_hash, out ulong unportable_hash);
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
-		static extern string DumpStateAll_internal (out ulong portable_hash, out ulong unportable_hash);
+		static extern string DumpStateTotal_internal (out ulong portable_hash, out ulong unportable_hash);
 
 		static Tuple<String, ulong, ulong>
 		DumpStateSingle ()
@@ -182,11 +182,11 @@ namespace Mono {
 		}
 
 		static Tuple<String, ulong, ulong>
-		DumpStateAll ()
+		DumpStateTotal ()
 		{
 			ulong portable_hash;
 			ulong unportable_hash;
-			string payload_str = DumpStateAll_internal (out portable_hash, out unportable_hash);
+			string payload_str = DumpStateTotal_internal (out portable_hash, out unportable_hash);
 
 			return new Tuple<String, ulong, ulong> (payload_str, portable_hash, unportable_hash);
 		}

--- a/mcs/class/corlib/Mono/Runtime.cs
+++ b/mcs/class/corlib/Mono/Runtime.cs
@@ -165,5 +165,43 @@ namespace Mono {
 		}
 #endif
 
+		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		static extern string DumpStateSingle_internal (out ulong portable_hash, out ulong unportable_hash);
+
+		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		static extern string DumpStateAll_internal (out ulong portable_hash, out ulong unportable_hash);
+
+		static Tuple<String, ulong, ulong>
+		DumpStateSingle ()
+		{
+			ulong portable_hash;
+			ulong unportable_hash;
+			string payload_str = DumpStateSingle_internal (out portable_hash, out unportable_hash);
+
+			return new Tuple<String, ulong, ulong> (payload_str, portable_hash, unportable_hash);
+		}
+
+		static Tuple<String, ulong, ulong>
+		DumpStateAll ()
+		{
+			ulong portable_hash;
+			ulong unportable_hash;
+			string payload_str = DumpStateAll_internal (out portable_hash, out unportable_hash);
+
+			return new Tuple<String, ulong, ulong> (payload_str, portable_hash, unportable_hash);
+		}
+
+		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		static extern void RegisterReportingForNativeLib_internal (IntPtr modulePathSuffix, IntPtr moduleName);
+
+		static void RegisterReportingForNativeLib (string modulePathSuffix_str, string moduleName_str)
+		{
+			using (var modulePathSuffix_chars = RuntimeMarshal.MarshalString (modulePathSuffix_str))
+			using (var moduleName_chars = RuntimeMarshal.MarshalString (moduleName_str))
+			{
+				RegisterReportingForNativeLib_internal (modulePathSuffix_chars.Value, moduleName_chars.Value);
+			}
+		}
+
 	}
 }

--- a/mcs/class/corlib/Mono/Runtime.cs
+++ b/mcs/class/corlib/Mono/Runtime.cs
@@ -106,17 +106,17 @@ namespace Mono {
 		static extern void SendMicrosoftTelemetry_internal (IntPtr payload, ulong portable_hash, ulong unportable_hash);
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
-		static extern void WriteStateToDisk_internal (IntPtr payload, ulong portable_hash, ulong unportable_hash);
+		static extern void WriteStateToFile_internal (IntPtr payload, ulong portable_hash, ulong unportable_hash);
 
 		static void
-		WriteStateToDisk (Exception exc)
+		WriteStateToFile (Exception exc)
 		{
 			ulong portable_hash;
 			ulong unportable_hash;
 			string payload_str = ExceptionToState_internal (exc, out portable_hash, out unportable_hash);
 			using (var payload_chars = RuntimeMarshal.MarshalString (payload_str))
 			{
-				WriteStateToDisk_internal (payload_chars.Value, portable_hash, unportable_hash);
+				WriteStateToFile_internal (payload_chars.Value, portable_hash, unportable_hash);
 			}
 		}
 

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1109,6 +1109,9 @@ mono_method_get_name_full (MonoMethod *method, gboolean signature, gboolean ret,
 char *
 mono_method_get_full_name (MonoMethod *method);
 
+const char*
+mono_wrapper_type_to_str (guint32 wrapper_type);
+
 MonoArrayType *mono_dup_array_type (MonoImage *image, MonoArrayType *a);
 MonoMethodSignature *mono_metadata_signature_deep_dup (MonoImage *image, MonoMethodSignature *sig);
 

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -59,8 +59,8 @@ static const gint16 opidx [] = {
 #undef WRAPPER
 };
 
-static const char*
-wrapper_type_to_str (guint32 wrapper_type)
+const char*
+mono_wrapper_type_to_str (guint32 wrapper_type)
 {
 	g_assert (wrapper_type < MONO_WRAPPER_NUM);
 
@@ -902,7 +902,7 @@ mono_method_get_name_full (MonoMethod *method, gboolean signature, gboolean ret,
 	}
 
 	if (method->wrapper_type != MONO_WRAPPER_NONE)
-		sprintf (wrapper, "(wrapper %s) ", wrapper_type_to_str (method->wrapper_type));
+		sprintf (wrapper, "(wrapper %s) ", mono_wrapper_type_to_str (method->wrapper_type));
 	else
 		strcpy (wrapper, "");
 
@@ -918,7 +918,7 @@ mono_method_get_name_full (MonoMethod *method, gboolean signature, gboolean ret,
 		}
 
 		if (method->wrapper_type != MONO_WRAPPER_NONE)
-			sprintf (wrapper, "(wrapper %s) ", wrapper_type_to_str (method->wrapper_type));
+			sprintf (wrapper, "(wrapper %s) ", mono_wrapper_type_to_str (method->wrapper_type));
 		else
 			strcpy (wrapper, "");
 		if (ret && sig) {

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -253,6 +253,8 @@ struct _MonoJitInfo {
 
 	/* FIXME: Embed this after the structure later*/
 	gpointer    gc_info; /* Currently only used by SGen */
+
+	gpointer    seq_points;
 	
 	MonoJitExceptionInfo clauses [MONO_ZERO_LEN_ARRAY];
 	/* There is an optional MonoGenericJitInfo after the clauses */

--- a/mono/metadata/icall-decl.h
+++ b/mono/metadata/icall-decl.h
@@ -379,5 +379,8 @@ ICALL_EXPORT void ves_icall_System_Runtime_RuntimeImports_ZeroMemory (guint8*, g
 ICALL_EXPORT void ves_icall_System_Runtime_RuntimeImports_ecvt_s(char*, size_t, double, int, int*, int*);
 ICALL_EXPORT void ves_icall_get_method_info (MonoMethod*, MonoMethodInfo*, MonoError*);
 ICALL_EXPORT void* ves_icall_System_Reflection_Assembly_GetManifestResourceInternal (MonoReflectionAssemblyHandle assembly_h, MonoStringHandle name, gint32* size, MonoReflectionModuleHandleOut ref_module, MonoError*);
+ICALL_EXPORT MonoStringHandle ves_icall_Mono_Runtime_DumpStateSingle (guint64 *portable_hash, guint64 *unportable_hash, MonoError *error);
+ICALL_EXPORT MonoStringHandle ves_icall_Mono_Runtime_DumpStateTotal (guint64 *portable_hash, guint64 *unportable_hash, MonoError *error);
+ICALL_EXPORT void ves_icall_Mono_Runtime_RegisterReportingForNativeLib (const char *path_suffix, const char *module_name);
 
 #endif // __MONO_METADATA_ICALL_H__

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -91,10 +91,13 @@ HANDLES(ICALL(TLS_PROVIDER_FACTORY_1, "IsBtlsSupported", ves_icall_Mono_TlsProvi
 
 ICALL_TYPE(RUNTIME, "Mono.Runtime", RUNTIME_1)
 HANDLES(ICALL(RUNTIME_1, "DisableMicrosoftTelemetry", ves_icall_Mono_Runtime_DisableMicrosoftTelemetry))
+HANDLES(ICALL(RUNTIME_15, "DumpStateSingle_internal", ves_icall_Mono_Runtime_DumpStateSingle))
+HANDLES(ICALL(RUNTIME_16, "DumpStateTotal_internal", ves_icall_Mono_Runtime_DumpStateTotal))
 HANDLES(ICALL(RUNTIME_2, "EnableMicrosoftTelemetry_internal", ves_icall_Mono_Runtime_EnableMicrosoftTelemetry))
 HANDLES(ICALL(RUNTIME_3, "ExceptionToState_internal", ves_icall_Mono_Runtime_ExceptionToState))
 HANDLES(ICALL(RUNTIME_4, "GetDisplayName", ves_icall_Mono_Runtime_GetDisplayName))
 HANDLES(ICALL(RUNTIME_12, "GetNativeStackTrace", ves_icall_Mono_Runtime_GetNativeStackTrace))
+HANDLES(ICALL(RUNTIME_17, "RegisterReportingForNativeLib_internal", ves_icall_Mono_Runtime_RegisterReportingForNativeLib))
 HANDLES(ICALL(RUNTIME_13, "SendMicrosoftTelemetry_internal", ves_icall_Mono_Runtime_SendMicrosoftTelemetry))
 HANDLES(ICALL(RUNTIME_14, "WriteStateToFile_internal", ves_icall_Mono_Runtime_DumpTelemetry))
 

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5909,7 +5909,10 @@ ves_icall_Mono_Runtime_RegisterReportingForNativeLib (const char *path_suffix, c
 #endif
 }
 
-#define MONO_MAX_SUMMARY_LEN_ICALL 1100
+// Number derived from trials on relevant hardware.
+// If it seems large, please confirm it's safe to shrink
+// before doing so.
+#define MONO_MAX_SUMMARY_LEN_ICALL 500000
 
 ICALL_EXPORT MonoStringHandle
 ves_icall_Mono_Runtime_DumpStateTotal (guint64 *portable_hash, guint64 *unportable_hash, MonoError *error)
@@ -5917,7 +5920,7 @@ ves_icall_Mono_Runtime_DumpStateTotal (guint64 *portable_hash, guint64 *unportab
 	MonoStringHandle result;
 
 #ifndef DISABLE_CRASH_REPORTING
-	char scratch [MONO_MAX_SUMMARY_LEN_ICALL];
+	char *scratch = g_malloc0 (MONO_MAX_SUMMARY_LEN_ICALL * sizeof (gchar));
 
 	char *out;
 	MonoStackHash hashes;
@@ -5938,6 +5941,9 @@ ves_icall_Mono_Runtime_DumpStateTotal (guint64 *portable_hash, guint64 *unportab
 	*portable_hash = (guint64) hashes.offset_free_hash;
 	*unportable_hash = (guint64) hashes.offset_rich_hash;
 	result = mono_string_new_handle (mono_domain_get (), out, error);
+
+	// out is now a pointer into garbage memory
+	g_free (scratch);
 #else
 	*portable_hash = 0;
 	*unportable_hash = 0;

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5866,6 +5866,77 @@ ves_icall_Mono_Runtime_DumpTelemetry (char *payload, guint64 portable_hash, guin
 #endif
 }
 
+ICALL_EXPORT MonoStringHandle
+ves_icall_Mono_Runtime_DumpStateSingle (guint64 *portable_hash, guint64 *unportable_hash, MonoError *error)
+{
+	MonoStringHandle result;
+
+#ifndef DISABLE_CRASH_REPORTING
+	MonoStackHash hashes;
+	memset (&hashes, 0, sizeof (MonoStackHash));
+	MonoContext *ctx = NULL;
+
+	MonoThreadSummary this_thread;
+	if (!mono_threads_summarize_one (&this_thread, ctx))
+		return mono_string_new_handle (mono_domain_get (), "", error);
+
+	*portable_hash = (guint64) this_thread.hashes.offset_free_hash;
+	*unportable_hash = (guint64) this_thread.hashes.offset_rich_hash;
+
+	JsonWriter writer;
+	mono_json_writer_init (&writer);
+	mono_native_state_init (&writer);
+	gboolean first_thread_added = TRUE;
+	mono_native_state_add_thread (&writer, &this_thread, NULL, first_thread_added);
+	char *output = mono_native_state_free (&writer, FALSE);
+	result = mono_string_new_handle (mono_domain_get (), output, error);
+	g_free (output);
+#else
+	*portable_hash = 0;
+	*unportable_hash = 0;
+	result = mono_string_new_handle (mono_domain_get (), "", error);
+#endif
+
+	return result;
+}
+
+
+ICALL_EXPORT void
+ves_icall_Mono_Runtime_RegisterReportingForNativeLib (const char *path_suffix, const char *module_name)
+{
+#ifndef DISABLE_CRASH_REPORTING
+	mono_get_eh_callbacks ()->mono_register_native_library (path_suffix, module_name);
+#endif
+}
+
+ICALL_EXPORT MonoStringHandle
+ves_icall_Mono_Runtime_DumpStateTotal (guint64 *portable_hash, guint64 *unportable_hash, MonoError *error)
+{
+	MonoStringHandle result;
+
+#ifndef DISABLE_CRASH_REPORTING
+	gchar *out;
+
+	MonoStackHash hashes;
+	memset (&hashes, 0, sizeof (MonoStackHash));
+	MonoContext *ctx = NULL;
+
+	gboolean success = mono_threads_summarize (ctx, &out, &hashes, TRUE);
+	if (!success)
+		return mono_string_new_handle (mono_domain_get (), "", error);
+
+	*portable_hash = (guint64) hashes.offset_free_hash;
+	*unportable_hash = (guint64) hashes.offset_rich_hash;
+	result = mono_string_new_handle (mono_domain_get (), out, error);
+#else
+	*portable_hash = 0;
+	*unportable_hash = 0;
+	result = mono_string_new_handle (mono_domain_get (), "", error);
+#endif
+
+	return result;
+}
+
 ICALL_EXPORT MonoBoolean
 ves_icall_System_Reflection_AssemblyName_ParseAssemblyName (const char *name, MonoAssemblyName *aname, MonoBoolean *is_version_defined_arg, MonoBoolean *is_token_defined_arg)
 {

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5920,7 +5920,7 @@ ves_icall_Mono_Runtime_DumpStateTotal (guint64 *portable_hash, guint64 *unportab
 	MonoStringHandle result;
 
 #ifndef DISABLE_CRASH_REPORTING
-	char *scratch = g_malloc0 (MONO_MAX_SUMMARY_LEN_ICALL * sizeof (gchar));
+	char *scratch = g_new0 (gchar, MONO_MAX_SUMMARY_LEN_ICALL);
 
 	char *out;
 	MonoStackHash hashes;

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5921,6 +5921,8 @@ ves_icall_Mono_Runtime_DumpStateTotal (guint64 *portable_hash, guint64 *unportab
 	memset (&hashes, 0, sizeof (MonoStackHash));
 	MonoContext *ctx = NULL;
 
+	mono_get_runtime_callbacks ()->install_state_summarizer ();
+
 	gboolean success = mono_threads_summarize (ctx, &out, &hashes, TRUE);
 	if (!success)
 		return mono_string_new_handle (mono_domain_get (), "", error);

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5923,7 +5923,7 @@ ves_icall_Mono_Runtime_DumpStateTotal (guint64 *portable_hash, guint64 *unportab
 
 	mono_get_runtime_callbacks ()->install_state_summarizer ();
 
-	gboolean success = mono_threads_summarize (ctx, &out, &hashes, TRUE);
+	gboolean success = mono_threads_summarize (ctx, &out, &hashes, TRUE, FALSE);
 	if (!success)
 		return mono_string_new_handle (mono_domain_get (), "", error);
 

--- a/mono/metadata/mono-debug.c
+++ b/mono/metadata/mono-debug.c
@@ -610,8 +610,8 @@ read_variable (MonoDebugVarInfo *var, guint8 *ptr, guint8 **rptr)
 	*rptr = ptr;
 }
 
-void
-mono_debug_free_method_jit_info (MonoDebugMethodJitInfo *jit)
+static void
+mono_debug_free_method_jit_info_full (MonoDebugMethodJitInfo *jit, gboolean stack)
 {
 	if (!jit)
 		return;
@@ -621,17 +621,23 @@ mono_debug_free_method_jit_info (MonoDebugMethodJitInfo *jit)
 	g_free (jit->locals);
 	g_free (jit->gsharedvt_info_var);
 	g_free (jit->gsharedvt_locals_var);
-	g_free (jit);
+	if (!stack)
+		g_free (jit);
+}
+
+void
+mono_debug_free_method_jit_info (MonoDebugMethodJitInfo *jit)
+{
+	return mono_debug_free_method_jit_info_full (jit, FALSE);
 }
 
 static MonoDebugMethodJitInfo *
-mono_debug_read_method (MonoDebugMethodAddress *address)
+mono_debug_read_method (MonoDebugMethodAddress *address, MonoDebugMethodJitInfo *jit)
 {
-	MonoDebugMethodJitInfo *jit;
 	guint32 i;
 	guint8 *ptr;
 
-	jit = g_new0 (MonoDebugMethodJitInfo, 1);
+	memset (jit, 0, sizeof (*jit));
 	jit->code_start = address->code_start;
 	jit->code_size = address->code_size;
 
@@ -677,7 +683,7 @@ mono_debug_read_method (MonoDebugMethodAddress *address)
 }
 
 static MonoDebugMethodJitInfo *
-find_method (MonoMethod *method, MonoDomain *domain)
+find_method (MonoMethod *method, MonoDomain *domain, MonoDebugMethodJitInfo *jit)
 {
 	MonoDebugDataTable *table;
 	MonoDebugMethodAddress *address;
@@ -688,19 +694,19 @@ find_method (MonoMethod *method, MonoDomain *domain)
 	if (!address)
 		return NULL;
 
-	return mono_debug_read_method (address);
+	return mono_debug_read_method (address, jit);
 }
 
 MonoDebugMethodJitInfo *
 mono_debug_find_method (MonoMethod *method, MonoDomain *domain)
 {
-	MonoDebugMethodJitInfo *res;
+	MonoDebugMethodJitInfo *res = g_new0 (MonoDebugMethodJitInfo, 1);
 
 	if (mono_debug_format == MONO_DEBUG_FORMAT_NONE)
 		return NULL;
 
 	mono_debugger_lock ();
-	res = find_method (method, domain);
+	find_method (method, domain, res);
 	mono_debugger_unlock ();
 	return res;
 }
@@ -715,10 +721,10 @@ mono_debug_lookup_method_addresses (MonoMethod *method)
 static gint32
 il_offset_from_address (MonoMethod *method, MonoDomain *domain, guint32 native_offset)
 {
-	MonoDebugMethodJitInfo *jit;
+	MonoDebugMethodJitInfo mem;
 	int i;
 
-	jit = find_method (method, domain);
+	MonoDebugMethodJitInfo *jit = find_method (method, domain, &mem);
 	if (!jit || !jit->line_numbers)
 		goto cleanup_and_fail;
 
@@ -726,13 +732,13 @@ il_offset_from_address (MonoMethod *method, MonoDomain *domain, guint32 native_o
 		MonoDebugLineNumberEntry lne = jit->line_numbers [i];
 
 		if (lne.native_offset <= native_offset) {
-			mono_debug_free_method_jit_info (jit);
+			mono_debug_free_method_jit_info_full (jit, TRUE);
 			return lne.il_offset;
 		}
 	}
 
 cleanup_and_fail:
-	mono_debug_free_method_jit_info (jit);
+	mono_debug_free_method_jit_info_full (jit, TRUE);
 	return -1;
 }
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -701,7 +701,7 @@ typedef struct {
 	gboolean (*mono_above_abort_threshold) (void);
 	void (*mono_clear_abort_threshold) (void);
 	void (*mono_reraise_exception) (MonoException *ex);
-	void (*mono_summarize_stack) (MonoDomain *domain, MonoThreadSummary *out, MonoContext *crash_ctx);
+	void (*mono_summarize_stack) (MonoThreadSummary *out, MonoContext *crash_ctx);
 	void (*mono_summarize_exception) (MonoException *exc, MonoThreadSummary *out);
 } MonoRuntimeExceptionHandlingCallbacks;
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -703,6 +703,7 @@ typedef struct {
 	void (*mono_reraise_exception) (MonoException *ex);
 	void (*mono_summarize_stack) (MonoThreadSummary *out, MonoContext *crash_ctx);
 	void (*mono_summarize_exception) (MonoException *exc, MonoThreadSummary *out);
+	void (*mono_register_native_library) (const char *module_path, const char *module_name);
 } MonoRuntimeExceptionHandlingCallbacks;
 
 MONO_COLD void mono_set_pending_exception (MonoException *exc);

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -701,7 +701,8 @@ typedef struct {
 	gboolean (*mono_above_abort_threshold) (void);
 	void (*mono_clear_abort_threshold) (void);
 	void (*mono_reraise_exception) (MonoException *ex);
-	void (*mono_summarize_stack) (MonoThreadSummary *out, MonoContext *crash_ctx);
+	void (*mono_summarize_managed_stack) (MonoThreadSummary *out);
+	void (*mono_summarize_unmanaged_stack) (MonoThreadSummary *out);
 	void (*mono_summarize_exception) (MonoException *exc, MonoThreadSummary *out);
 	void (*mono_register_native_library) (const char *module_path, const char *module_name);
 } MonoRuntimeExceptionHandlingCallbacks;

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -541,7 +541,7 @@ mono_set_pending_exception_handle (MonoExceptionHandle exc);
 #define MONO_MAX_SUMMARY_NAME_LEN 140
 #define MONO_MAX_THREAD_NAME_LEN 140
 #define MONO_MAX_SUMMARY_THREADS 32
-#define MONO_MAX_SUMMARY_FRAMES 40
+#define MONO_MAX_SUMMARY_FRAMES 80
 
 typedef struct {
 	gboolean is_managed;

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -553,6 +553,8 @@ typedef struct {
 		const char *guid;
 
 #ifndef MONO_PRIVATE_CRASHES
+		// We use ifdef to make it a compile-time error to store this 
+		// symbolicated string on release builds
 		char *name;
 #endif
 
@@ -571,6 +573,9 @@ typedef struct {
 } MonoStackHash;
 
 typedef struct {
+	gboolean done; // Needed because cond wait can have spurious wakeups
+	MonoSemType done_wait; // Readers are finished with this
+
 	gboolean is_managed;
 
 	char name [MONO_MAX_THREAD_NAME_LEN];

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -554,6 +554,7 @@ typedef struct {
 	} managed_data;
 	struct {
 		intptr_t ip;
+		const char *module;
 		gboolean is_trampoline;
 		gboolean has_name;
 	} unmanaged_data;

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -555,7 +555,7 @@ typedef struct {
 #ifndef MONO_PRIVATE_CRASHES
 		// We use ifdef to make it a compile-time error to store this 
 		// symbolicated string on release builds
-		char *name;
+		const char *name;
 #endif
 
 	} managed_data;
@@ -609,10 +609,10 @@ typedef struct {
 } MonoThreadSummary;
 
 gboolean
-mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent, gboolean critical_first);
+mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent, gboolean signal_handler_controller, gchar *mem, size_t provided_size);
 
 gboolean
-mono_threads_summarize_execute (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent);
+mono_threads_summarize_execute (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent, gchar *mem, size_t provided_size);
 
 gboolean
 mono_threads_summarize_one (MonoThreadSummary *out, MonoContext *ctx);

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -539,6 +539,7 @@ MONO_COLD void
 mono_set_pending_exception_handle (MonoExceptionHandle exc);
 
 #define MONO_MAX_SUMMARY_NAME_LEN 140
+#define MONO_MAX_THREAD_NAME_LEN 140
 #define MONO_MAX_SUMMARY_THREADS 32
 #define MONO_MAX_SUMMARY_FRAMES 40
 
@@ -566,7 +567,8 @@ typedef struct {
 typedef struct {
 	gboolean is_managed;
 
-	const char *name;
+	char name [MONO_MAX_THREAD_NAME_LEN];
+
 	intptr_t managed_thread_ptr;
 	intptr_t info_addr;
 	intptr_t native_thread_id;

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -571,6 +571,10 @@ typedef struct {
 	intptr_t info_addr;
 	intptr_t native_thread_id;
 
+	// Print reason we don't have a complete
+	// managed trace
+	const char *error_msg;
+
 	int num_managed_frames;
 	MonoFrameSummary managed_frames [MONO_MAX_SUMMARY_FRAMES];
 

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -589,6 +589,6 @@ typedef struct {
 } MonoThreadSummary;
 
 gboolean
-mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes);
+mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent);
 
 #endif /* _MONO_METADATA_THREADS_TYPES_H_ */

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -584,6 +584,7 @@ typedef struct {
 	MonoFrameSummary unmanaged_frames [MONO_MAX_SUMMARY_FRAMES];
 
 	MonoStackHash hashes;
+	MonoContext *ctx;
 } MonoThreadSummary;
 
 gboolean

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -591,4 +591,7 @@ typedef struct {
 gboolean
 mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent);
 
+gboolean
+mono_threads_summarize_one (MonoThreadSummary *out, MonoContext *ctx);
+
 #endif /* _MONO_METADATA_THREADS_TYPES_H_ */

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -594,7 +594,10 @@ typedef struct {
 } MonoThreadSummary;
 
 gboolean
-mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent);
+mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent, gboolean critical_first);
+
+gboolean
+mono_threads_summarize_execute (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent);
 
 gboolean
 mono_threads_summarize_one (MonoThreadSummary *out, MonoContext *ctx);

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -551,6 +551,11 @@ typedef struct {
 		int il_offset;
 		int native_offset;
 		const char *guid;
+
+#ifndef MONO_PRIVATE_CRASHES
+		char *name;
+#endif
+
 	} managed_data;
 	struct {
 		intptr_t ip;

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -576,6 +576,14 @@ typedef struct {
 	gboolean done; // Needed because cond wait can have spurious wakeups
 	MonoSemType done_wait; // Readers are finished with this
 
+	// For managed stack walking
+
+	MonoDomain *domain;
+	MonoJitTlsData *jit_tls;
+	MonoLMF *lmf;
+
+	// Emitted attributes
+
 	gboolean is_managed;
 
 	char name [MONO_MAX_THREAD_NAME_LEN];
@@ -595,7 +603,9 @@ typedef struct {
 	MonoFrameSummary unmanaged_frames [MONO_MAX_SUMMARY_FRAMES];
 
 	MonoStackHash hashes;
+
 	MonoContext *ctx;
+	MonoContext ctx_mem;
 } MonoThreadSummary;
 
 gboolean

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -6058,7 +6058,7 @@ mono_set_thread_dump_dir (gchar* dir) {
 
 #ifdef DISABLE_CRASH_REPORTING
 gboolean
-mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes)
+mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent)
 {
 	return FALSE;
 }
@@ -6111,7 +6111,7 @@ summarizer_state_init (SummarizerGlobalState *state, MonoNativeThreadId current,
 }
 
 static void
-summarizer_signal_other_threads (SummarizerGlobalState *state, MonoNativeThreadId current, int current_idx)
+summarizer_signal_other_threads (SummarizerGlobalState *state, MonoNativeThreadId current, int current_idx, gboolean silent)
 {
 	sigset_t sigset, old_sigset;
 	sigemptyset(&sigset);
@@ -6125,7 +6125,9 @@ summarizer_signal_other_threads (SummarizerGlobalState *state, MonoNativeThreadI
 
 	#ifdef HAVE_PTHREAD_KILL
 		pthread_kill (state->thread_array [i], SIGTERM);
-		MOSTLY_ASYNC_SAFE_PRINTF("Pkilling 0x%zx from 0x%zx\n", state->thread_array [i], current);
+
+		if (!silent)
+			MOSTLY_ASYNC_SAFE_PRINTF("Pkilling 0x%zx from 0x%zx\n", state->thread_array [i], current);
 	#else
 		g_error ("pthread_kill () is not supported by this platform");
 	#endif
@@ -6178,7 +6180,7 @@ summarizer_state_wait (SummarizerGlobalState *state)
 }
 
 gboolean
-mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes)
+mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent)
 {
 	static SummarizerGlobalState state;
 
@@ -6187,7 +6189,7 @@ mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes)
 	gboolean this_thread_controls = summarizer_state_init (&state, current, &current_idx);
 
 	if (this_thread_controls)
-		summarizer_signal_other_threads (&state, current, current_idx);
+		summarizer_signal_other_threads (&state, current, current_idx, silent);
 
 	MonoThreadSummary this_thread;
 	if (mono_threads_summarize_one (&this_thread, ctx)) {
@@ -6196,21 +6198,24 @@ mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes)
 		// FIXME: How many threads should be counted?
 		if (hashes)
 			*hashes = this_thread.hashes;
-		MOSTLY_ASYNC_SAFE_PRINTF("Thread 0x%zx reported itself.\n", current);
-	} else {
-		MOSTLY_ASYNC_SAFE_PRINTF("Thread 0x%zx couldn't report itself.\n", current);
+
+		if (!silent)
+			MOSTLY_ASYNC_SAFE_PRINTF("Thread 0x%zx reported itself.\n", current);
+	} else if (!silent) {
+			MOSTLY_ASYNC_SAFE_PRINTF("Thread 0x%zx couldn't report itself.\n", current);
 	}
 
 	// From summarizer, wait and dump.
 	if (this_thread_controls) {
-		MOSTLY_ASYNC_SAFE_PRINTF("Entering thread summarizer pause from 0x%zx\n", current);
+		if (!silent)
+			MOSTLY_ASYNC_SAFE_PRINTF("Entering thread summarizer pause from 0x%zx\n", current);
 		// Wait 2 seconds for all of the other threads to catch up
 		sleep (2);
-		MOSTLY_ASYNC_SAFE_PRINTF("Finished thread summarizer pause from 0x%zx.\n", current);
+		if (!silent)
+			MOSTLY_ASYNC_SAFE_PRINTF("Finished thread summarizer pause from 0x%zx.\n", current);
 
 		// Dump and cleanup all the stack memory
 		summarizer_state_term (&state, out);
-
 	} else {
 		// Wait here, keeping our stack memory alive
 		// for the dumper

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -6058,7 +6058,7 @@ mono_set_thread_dump_dir (gchar* dir) {
 
 #ifdef DISABLE_CRASH_REPORTING
 gboolean
-mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent)
+mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent, gboolean critical_first)
 {
 	return FALSE;
 }
@@ -6187,7 +6187,7 @@ summarizer_state_wait (SummarizerGlobalState *state)
 }
 
 gboolean
-mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent)
+mono_threads_summarize_execute (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent)
 {
 	static SummarizerGlobalState state;
 
@@ -6232,6 +6232,54 @@ mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gb
 	}
 
 	return TRUE;
+}
+
+gboolean 
+mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent, gboolean critical_first)
+{
+	// The staggered values are due to the need to use inc_i64 for the first value
+	static gint64 next_pending_request_id = 0;
+	static gint64 request_available_to_run = 1;
+	gint64 this_request_id = mono_atomic_inc_i64 ((volatile gint64 *) &next_pending_request_id);
+
+	// This is a global queue of summary requests. 
+	// It's not safe to signal a thread while they're in the
+	// middle of a dump. Dladdr is not reentrant. It's the one lock
+	// we rely on being able to take. 
+	//
+	// We don't use it in almost any other place in managed code, so 
+	// our problem is in the stack dumping code racing with the signalling code.
+	//
+	// A dump is wait-free to the degree that it's not going to loop indefinitely.
+	// If we're running from a crash handler block, we're not in any position to 
+	// wait for an in-flight dump to finish. If we crashed while dumping, we cannot dump.
+	// We should simply return so we can die cleanly.
+	//
+	// critical_first should be set only from a handler that expects itself to be the only
+	// entry point, where the runtime already being dumping means we can't dump.
+
+	gboolean success = FALSE;
+
+	// We use exponential backoff
+	while (TRUE) {
+		gint64 next_request_id = mono_atomic_load_i64 ((volatile gint64 *) &request_available_to_run);
+
+		if (next_request_id == this_request_id) {
+			success = mono_threads_summarize_execute (ctx, out, hashes, silent);
+
+			// Only the thread that gets the ticket can unblock future dumpers.
+			mono_atomic_inc_i64 ((volatile gint64 *) &request_available_to_run);
+			break;
+		} else if (critical_first) {
+			// We're done. We can't do anything.
+			MOSTLY_ASYNC_SAFE_PRINTF ("Attempted to dump for critical failure when already in dump. Error reporting crashed?");
+			break;
+		} else {
+			sleep (2);
+		}
+	}
+
+	return success;
 }
 
 #endif

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -6171,7 +6171,6 @@ summarizer_state_wait (SummarizerGlobalState *state)
 	// Loop until it's unset
 	guint32 not_done = 1;
 	while (not_done) {
-		MOSTLY_ASYNC_SAFE_PRINTF ("Waiting, seeing %d\n", not_done);
 		sleep (1);
 		mono_memory_barrier ();
 		not_done = mono_atomic_load_i32 (&state->summary_state);

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -6077,13 +6077,8 @@ mono_threads_summarize_one (MonoThreadSummary *out, MonoContext *ctx)
 		char *name = g_utf16_to_utf8 (thread->name, thread->name_len, NULL, NULL, NULL);
 		out->name = name;
 	}
-	mono_get_eh_callbacks ()->mono_summarize_stack (domain, out, ctx);
 
-	// FIXME: handle failure gracefully
-	// Enable when doing unmanaged
-	/*g_assert (out->num_frames > 0);*/
-	/*if (out->num_frames == 0)*/
-		/*return FALSE;*/
+	mono_get_eh_callbacks ()->mono_summarize_stack (domain, out, ctx);
 
 	mono_gchandle_free (handle);
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -6058,7 +6058,7 @@ mono_set_thread_dump_dir (gchar* dir) {
 
 #ifdef DISABLE_CRASH_REPORTING
 gboolean
-mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent, gboolean critical_first)
+mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent, gboolean signal_handler_controller, gchar *mem, size_t provided_size)
 {
 	return FALSE;
 }
@@ -6218,12 +6218,12 @@ summary_timedwait (SummarizerGlobalState *state, int timeout_seconds)
 }
 
 static void
-summarizer_state_term (SummarizerGlobalState *state, gchar **out)
+summarizer_state_term (SummarizerGlobalState *state, gchar **out, gchar *mem, size_t provided_size)
 {
 	// See the array writes
 	mono_memory_barrier ();
 
-	mono_summarize_native_state_begin ();
+	mono_summarize_native_state_begin (mem, provided_size);
 	for (int i=0; i < state->nthreads; i++) {
 		gpointer old_value = NULL;
 		while (TRUE) {
@@ -6273,7 +6273,7 @@ summarizer_state_wait (MonoThreadSummary *thread)
 }
 
 gboolean
-mono_threads_summarize_execute (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent)
+mono_threads_summarize_execute (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent, gchar *mem, size_t provided_size)
 {
 	static SummarizerGlobalState state;
 
@@ -6313,7 +6313,7 @@ mono_threads_summarize_execute (MonoContext *ctx, gchar **out, MonoStackHash *ha
 			MOSTLY_ASYNC_SAFE_PRINTF("Finished thread summarizer pause from 0x%zx.\n", current);
 
 		// Dump and cleanup all the stack memory
-		summarizer_state_term (&state, out);
+		summarizer_state_term (&state, out, mem, provided_size);
 	} else {
 		// Wait here, keeping our stack memory alive
 		// for the dumper
@@ -6328,7 +6328,7 @@ mono_threads_summarize_execute (MonoContext *ctx, gchar **out, MonoStackHash *ha
 }
 
 gboolean 
-mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent, gboolean critical_first)
+mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent, gboolean signal_handler_controller, gchar *mem, size_t provided_size)
 {
 	// The staggered values are due to the need to use inc_i64 for the first value
 	static gint64 next_pending_request_id = 0;
@@ -6348,7 +6348,7 @@ mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gb
 	// wait for an in-flight dump to finish. If we crashed while dumping, we cannot dump.
 	// We should simply return so we can die cleanly.
 	//
-	// critical_first should be set only from a handler that expects itself to be the only
+	// signal_handler_controller should be set only from a handler that expects itself to be the only
 	// entry point, where the runtime already being dumping means we should just give up
 
 	gboolean success = FALSE;
@@ -6357,12 +6357,12 @@ mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gb
 		gint64 next_request_id = mono_atomic_load_i64 ((volatile gint64 *) &request_available_to_run);
 
 		if (next_request_id == this_request_id) {
-			success = mono_threads_summarize_execute (ctx, out, hashes, silent);
+			success = mono_threads_summarize_execute (ctx, out, hashes, silent, mem, provided_size);
 
 			// Only the thread that gets the ticket can unblock future dumpers.
 			mono_atomic_inc_i64 ((volatile gint64 *) &request_available_to_run);
 			break;
-		} else if (critical_first) {
+		} else if (signal_handler_controller) {
 			// We're done. We can't do anything.
 			MOSTLY_ASYNC_SAFE_PRINTF ("Attempted to dump for critical failure when already in dump. Error reporting crashed?");
 			break;

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -6063,9 +6063,15 @@ mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gb
 	return FALSE;
 }
 
+gboolean
+mono_threads_summarize_one (MonoThreadSummary *out, MonoContext *ctx)
+{
+	return FALSE;
+}
+
 #else
 
-static gboolean
+gboolean
 mono_threads_summarize_one (MonoThreadSummary *out, MonoContext *ctx)
 {
 	memset (out, 0, sizeof (MonoThreadSummary));
@@ -6084,11 +6090,11 @@ mono_threads_summarize_one (MonoThreadSummary *out, MonoContext *ctx)
 	return TRUE;
 }
 
-static const int max_num_threads = 128;
+#define MAX_NUM_THREADS 128
 typedef struct {
-	MonoNativeThreadId thread_array [max_num_threads];
+	MonoNativeThreadId thread_array [MAX_NUM_THREADS];
+	MonoThreadSummary *all_threads [MAX_NUM_THREADS];
 	int nthreads;
-	MonoThreadSummary *all_threads [max_num_threads];
 	gint32 summary_state;
 } SummarizerGlobalState;
 
@@ -6098,7 +6104,7 @@ summarizer_state_init (SummarizerGlobalState *state, MonoNativeThreadId current,
 	gint32 started_state = mono_atomic_cas_i32 (&state->summary_state, 1 /* set */, 0 /* compare */);
 	gboolean not_started = started_state == 0;
 	if (not_started)
-		state->nthreads = collect_thread_ids (state->thread_array, max_num_threads);
+		state->nthreads = collect_thread_ids (state->thread_array, MAX_NUM_THREADS);
 
 	for (int i = 0; i < state->nthreads; i++) {
 		if (state->thread_array [i] == current) {

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -6156,8 +6156,12 @@ summarizer_state_term (SummarizerGlobalState *state, gchar **out)
 	*out = mono_summarize_native_state_end ();
 
 	// Clean up all of our state
-	memset (&state, 0, sizeof (state));
+	memset (state, 0, sizeof (*state));
+	mono_atomic_store_i32 ((volatile gint32 *)&state->summary_state, 0);
 	mono_memory_barrier ();
+
+	// Wait for other threads to continue
+	sleep (2);
 }
 
 static void
@@ -6165,9 +6169,12 @@ summarizer_state_wait (SummarizerGlobalState *state)
 {
 	// We saw this was set with a synchronized read
 	// Loop until it's unset
-	while (state->summary_state) {
-		g_usleep (100);
+	guint32 not_done = 1;
+	while (not_done) {
+		MOSTLY_ASYNC_SAFE_PRINTF ("Waiting, seeing %d\n", not_done);
+		sleep (1);
 		mono_memory_barrier ();
+		not_done = mono_atomic_load_i32 (&state->summary_state);
 	}
 }
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -6096,6 +6096,7 @@ typedef struct {
 	MonoThreadSummary *all_threads [MAX_NUM_THREADS];
 	int nthreads;
 	gint32 summary_state;
+	gboolean silent;
 } SummarizerGlobalState;
 
 static gboolean
@@ -6117,7 +6118,7 @@ summarizer_state_init (SummarizerGlobalState *state, MonoNativeThreadId current,
 }
 
 static void
-summarizer_signal_other_threads (SummarizerGlobalState *state, MonoNativeThreadId current, int current_idx, gboolean silent)
+summarizer_signal_other_threads (SummarizerGlobalState *state, MonoNativeThreadId current, int current_idx)
 {
 	sigset_t sigset, old_sigset;
 	sigemptyset(&sigset);
@@ -6132,7 +6133,7 @@ summarizer_signal_other_threads (SummarizerGlobalState *state, MonoNativeThreadI
 	#ifdef HAVE_PTHREAD_KILL
 		pthread_kill (state->thread_array [i], SIGTERM);
 
-		if (!silent)
+		if (!state->silent)
 			MOSTLY_ASYNC_SAFE_PRINTF("Pkilling 0x%zx from 0x%zx\n", state->thread_array [i], current);
 	#else
 		g_error ("pthread_kill () is not supported by this platform");
@@ -6194,8 +6195,10 @@ mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gb
 	MonoNativeThreadId current = mono_native_thread_id_get ();
 	gboolean this_thread_controls = summarizer_state_init (&state, current, &current_idx);
 
-	if (this_thread_controls)
-		summarizer_signal_other_threads (&state, current, current_idx, silent);
+	if (this_thread_controls) {
+		state.silent = silent;
+		summarizer_signal_other_threads (&state, current, current_idx);
+	}
 
 	MonoThreadSummary this_thread;
 	if (mono_threads_summarize_one (&this_thread, ctx)) {
@@ -6205,19 +6208,19 @@ mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gb
 		if (hashes)
 			*hashes = this_thread.hashes;
 
-		if (!silent)
+		if (!state.silent)
 			MOSTLY_ASYNC_SAFE_PRINTF("Thread 0x%zx reported itself.\n", current);
-	} else if (!silent) {
+	} else if (!state.silent) {
 			MOSTLY_ASYNC_SAFE_PRINTF("Thread 0x%zx couldn't report itself.\n", current);
 	}
 
 	// From summarizer, wait and dump.
 	if (this_thread_controls) {
-		if (!silent)
+		if (!state.silent)
 			MOSTLY_ASYNC_SAFE_PRINTF("Entering thread summarizer pause from 0x%zx\n", current);
 		// Wait 2 seconds for all of the other threads to catch up
 		sleep (2);
-		if (!silent)
+		if (!state.silent)
 			MOSTLY_ASYNC_SAFE_PRINTF("Finished thread summarizer pause from 0x%zx.\n", current);
 
 		// Dump and cleanup all the stack memory

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -6071,23 +6071,38 @@ mono_threads_summarize_one (MonoThreadSummary *out, MonoContext *ctx)
 
 #else
 
-gboolean
-mono_threads_summarize_one (MonoThreadSummary *out, MonoContext *ctx)
+static gboolean
+mono_threads_summarize_native_self (MonoThreadSummary *out, MonoContext *ctx)
 {
 	memset (out, 0, sizeof (MonoThreadSummary));
+	out->ctx = ctx;
 
 	MonoNativeThreadId current = mono_native_thread_id_get();
 	out->native_thread_id = (intptr_t) current;
+
+	mono_get_eh_callbacks ()->mono_summarize_unmanaged_stack (out);
+
 	mono_native_thread_get_name (current, out->name, MONO_MAX_SUMMARY_NAME_LEN);
-	mono_get_eh_callbacks ()->mono_summarize_stack (out, ctx);
-	out->ctx = ctx;
 
 	// FIXME: Figure out how to store and look these up?
 	/*MonoDomain *domain = thread->obj.vtable->domain;*/
 	/*out->managed_thread_ptr = (intptr_t) get_current_thread_ptr_for_domain (domain, thread);*/
 	/*out->info_addr = (intptr_t) thread->thread_info;*/
-
 	return TRUE;
+}
+
+// Not safe to call from signal handler
+gboolean
+mono_threads_summarize_one (MonoThreadSummary *out, MonoContext *ctx)
+{
+	gboolean success = mono_threads_summarize_native_self (out, ctx);
+
+	// Finish this on the same thread
+
+	if (success)
+		mono_get_eh_callbacks ()->mono_summarize_managed_stack (out);
+
+	return success;
 }
 
 #define MAX_NUM_THREADS 128
@@ -6103,7 +6118,6 @@ typedef struct {
 	MonoThreadSummary *all_threads [MAX_NUM_THREADS];
 
 	gboolean silent; // print to stdout
-
 } SummarizerGlobalState;
 
 static gboolean
@@ -6213,7 +6227,8 @@ summarizer_state_term (SummarizerGlobalState *state, gchar **out)
 	for (int i=0; i < state->nthreads; i++) {
 		gpointer old_value = NULL;
 		while (TRUE) {
-			// Lock it out with sentinel and get value set before that
+			// Lock array slot with sentinel and get value set previously
+			// This lets late dumpers know that they're late.
 			gpointer new_old_value = mono_atomic_cas_ptr ((volatile gpointer *) &state->all_threads [i], GINT_TO_POINTER(-1), old_value);
 
 			if (new_old_value != old_value)
@@ -6225,6 +6240,11 @@ summarizer_state_term (SummarizerGlobalState *state, gchar **out)
 		MonoThreadSummary *thread = (MonoThreadSummary *) old_value;
 		if (!thread)
 			continue;
+
+		// We are doing this dump on the controlling thread because this isn't
+		// an async context. There's still some reliance on malloc here, but it's
+		// much more stable to do it all from the controlling thread.
+		mono_get_eh_callbacks ()->mono_summarize_managed_stack (thread);
 
 		mono_summarize_native_state_add_thread (thread, thread->ctx);
 
@@ -6268,7 +6288,7 @@ mono_threads_summarize_execute (MonoContext *ctx, gchar **out, MonoStackHash *ha
 
 	MonoThreadSummary this_thread;
 
-	if (mono_threads_summarize_one (&this_thread, ctx)) {
+	if (mono_threads_summarize_native_self (&this_thread, ctx)) {
 		// Init the synchronization between the controlling thread and the 
 		// providing thread
 		mono_os_sem_init (&this_thread.done_wait, 0);
@@ -6276,13 +6296,6 @@ mono_threads_summarize_execute (MonoContext *ctx, gchar **out, MonoStackHash *ha
 		// Store a reference to our stack memory into global state
 		gboolean success = summarizer_post_dump (&state, &this_thread, current_idx);
 		if (!success && !state.silent)
-			MOSTLY_ASYNC_SAFE_PRINTF("Thread 0x%zx reported itself.\n", current);
-
-		// FIXME: How many threads should be counted?
-		if (hashes)
-			*hashes = this_thread.hashes;
-
-		if (!state.silent)
 			MOSTLY_ASYNC_SAFE_PRINTF("Thread 0x%zx reported itself.\n", current);
 	} else if (!state.silent) {
 			MOSTLY_ASYNC_SAFE_PRINTF("Thread 0x%zx couldn't report itself.\n", current);
@@ -6306,6 +6319,10 @@ mono_threads_summarize_execute (MonoContext *ctx, gchar **out, MonoStackHash *ha
 		// for the dumper
 		summarizer_state_wait (&this_thread);
 	}
+
+	// FIXME: How many threads should be counted?
+	if (hashes)
+		*hashes = this_thread.hashes;
 
 	return TRUE;
 }

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -3307,6 +3307,8 @@ decode_exception_debug_info (MonoAotModule *amodule, MonoDomain *domain,
 		else
 			mono_seq_point_info_free (seq_points);
 		mono_domain_unlock (domain);
+
+		jinfo->seq_points = seq_points;
 	}
 
 	/* Load debug info */

--- a/mono/mini/debugger-engine.c
+++ b/mono/mini/debugger-engine.c
@@ -302,7 +302,6 @@ mono_de_add_pending_breakpoints (MonoMethod *method, MonoJitInfo *ji)
 	int i, j;
 	MonoSeqPointInfo *seq_points;
 	MonoDomain *domain;
-	MonoMethod *jmethod;
 
 	if (!breakpoints)
 		return;
@@ -326,20 +325,18 @@ mono_de_add_pending_breakpoints (MonoMethod *method, MonoJitInfo *ji)
 		}
 
 		if (!found) {
-			MonoMethod *declaring = NULL;
+			seq_points = (MonoSeqPointInfo *) ji->seq_points;
 
-			jmethod = jinfo_get_method (ji);
-			if (jmethod->is_inflated)
-				declaring = mono_method_get_declaring_generic_method (jmethod);
+			if (!seq_points) {
+				MonoMethod *jmethod = jinfo_get_method (ji);
+				if (jmethod->is_inflated) {
+					MonoJitInfo *seq_ji;
+					MonoMethod *declaring = mono_method_get_declaring_generic_method (jmethod);
+					mono_jit_search_all_backends_for_jit_info (domain, declaring, &seq_ji);
+					seq_points = (MonoSeqPointInfo *) seq_ji->seq_points;
+				}
+			}
 
-			mono_domain_lock (domain);
-			seq_points = (MonoSeqPointInfo *)g_hash_table_lookup (domain_jit_info (domain)->seq_points, jmethod);
-			if (!seq_points && declaring)
-				seq_points = (MonoSeqPointInfo *)g_hash_table_lookup (domain_jit_info (domain)->seq_points, declaring);
-			mono_domain_unlock (domain);
-			if (!seq_points)
-				/* Could be AOT code */
-				continue;
 			g_assert (seq_points);
 
 			insert_breakpoint (seq_points, domain, ji, bp, NULL);
@@ -358,22 +355,8 @@ set_bp_in_method (MonoDomain *domain, MonoMethod *method, MonoSeqPointInfo *seq_
 	if (error)
 		error_init (error);
 
-	code = mono_jit_find_compiled_method_with_jit_info (domain, method, &ji);
-	if (!code) {
-		ERROR_DECL_VALUE (oerror);
-
-		/* Might be AOTed code */
-		mono_class_init (method->klass);
-		code = mono_aot_get_method (domain, method, &oerror);
-		if (code) {
-			mono_error_assert_ok (&oerror);
-			ji = mono_jit_info_table_find (domain, code);
-		} else {
-			/* Might be interpreted */
-			ji = mini_get_interp_callbacks ()->find_jit_info (domain, method);
-		}
-		g_assert (ji);
-	}
+	code = mono_jit_search_all_backends_for_jit_info (domain, method, &ji);
+	g_assert (ji);
 
 	insert_breakpoint (seq_points, domain, ji, bp, error);
 }
@@ -389,8 +372,8 @@ static void
 collect_domain_bp (gpointer key, gpointer value, gpointer user_data)
 {
 	GHashTableIter iter;
-	MonoDomain *domain = (MonoDomain*)key;
 	MonoSeqPointInfo *seq_points;
+	MonoDomain *domain = (MonoDomain*)key;
 	CollectDomainData *ud = (CollectDomainData*)user_data;
 	MonoMethod *m;
 

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1932,7 +1932,7 @@ collect_pred_seq_points (TransformData *td, InterpBasicBlock *bb, SeqPoint *seqp
 }
 
 static void
-save_seq_points (TransformData *td)
+save_seq_points (TransformData *td, MonoJitInfo *jinfo)
 {
 	InterpMethod *rtm = td->rtm;
 	GByteArray *array;
@@ -2019,6 +2019,8 @@ save_seq_points (TransformData *td)
 	mono_domain_lock (domain);
 	g_hash_table_insert (domain_jit_info (domain)->seq_points, rtm->method, info);
 	mono_domain_unlock (domain);
+
+	jinfo->seq_points = info;
 }
 
 static void
@@ -5017,7 +5019,7 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsig
 		}
 	}
 
-	save_seq_points (td);
+	save_seq_points (td, jinfo);
 
 exit:
 	mono_basic_block_free (original_bb);

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1497,7 +1497,7 @@ summarize_frame_internal (MonoMethod *method, gpointer ip, size_t native_offset,
 	
 #ifndef MONO_PRIVATE_CRASHES
 	if (method)
-		dest->managed_data.name = mono_method_get_name_full (method, TRUE, FALSE, MONO_TYPE_NAME_FORMAT_IL);
+		dest->managed_data.name = method->name;
 #endif
 
 	MonoDebugSourceLocation *location = NULL;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -129,6 +129,7 @@ static gboolean mono_exception_walk_trace_internal (MonoException *ex, MonoExcep
 
 static void mono_summarize_stack (MonoThreadSummary *out, MonoContext *crash_ctx);
 static void mono_summarize_exception (MonoException *exc, MonoThreadSummary *out);
+static void mono_crash_reporting_register_native_library (const char *module_path, const char *module_name);
 
 static gboolean
 first_managed (MonoStackFrameInfo *frame, MonoContext *ctx, gpointer addr)
@@ -238,6 +239,7 @@ mono_exceptions_init (void)
 	cbs.mono_walk_stack_with_state = mono_walk_stack_with_state;
 	cbs.mono_summarize_stack = mono_summarize_stack;
 	cbs.mono_summarize_exception = mono_summarize_exception;
+	cbs.mono_register_native_library = mono_crash_reporting_register_native_library;
 
 	if (mono_llvm_only) {
 		cbs.mono_raise_exception = mono_llvm_raise_exception;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1488,16 +1488,15 @@ summarize_frame_internal (MonoMethod *method, gpointer ip, size_t native_offset,
 	dest->unmanaged_data.ip = (intptr_t) ip;
 	dest->is_managed = managed;
 
-	if (method && method->wrapper_type != MONO_WRAPPER_NONE) {
+	if (method && method->wrapper_type != MONO_WRAPPER_NONE && method->wrapper_type < MONO_WRAPPER_NUM) {
 		dest->is_managed = FALSE;
 		dest->unmanaged_data.has_name = TRUE;
-		char *name = mono_method_get_name_full (method, TRUE, FALSE, MONO_TYPE_NAME_FORMAT_IL);
-		copy_summary_string_safe (dest->str_descr, name);
+		copy_summary_string_safe (dest->str_descr, mono_wrapper_type_to_str (method->wrapper_type));
 	}
 	
 #ifndef MONO_PRIVATE_CRASHES
 	if (method)
-		dest->managed_data.name = method->name;
+		dest->managed_data.name = (char *) method->name;
 #endif
 
 	MonoDebugSourceLocation *location = NULL;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1174,7 +1174,7 @@ mono_walk_stack (MonoJitStackWalk func, MonoUnwindOptions options, void *user_da
 static void
 mono_walk_stack_full (MonoJitStackWalk func, MonoContext *start_ctx, MonoDomain *domain, MonoJitTlsData *jit_tls, MonoLMF *lmf, MonoUnwindOptions unwind_options, gpointer user_data)
 {
-	gint il_offset, i;
+	gint il_offset;
 	MonoContext ctx, new_ctx;
 	StackFrameInfo frame;
 	gboolean res;
@@ -1217,14 +1217,28 @@ mono_walk_stack_full (MonoJitStackWalk func, MonoContext *start_ctx, MonoDomain 
 	}
 #endif
 
-	g_assert (start_ctx);
-	g_assert (domain);
-	g_assert (jit_tls);
+	if (!start_ctx) {
+		g_warning ("start_ctx required for stack walk");
+		return;
+	}
+
+	if (!domain) {
+		g_warning ("domain required for stack walk");
+		return;
+	}
+
+	if (!jit_tls) {
+		g_warning ("jit_tls required for stack walk");
+		return;
+	}
+
 	/*The LMF will be null if the target have no managed frames.*/
  	/* g_assert (lmf); */
 
-	if (async)
-		g_assert (unwind_options == MONO_UNWIND_NONE);
+	if (async && (unwind_options & MONO_UNWIND_LOOKUP_ACTUAL_METHOD)) {
+		g_warning ("async && (unwind_options & MONO_UNWIND_LOOKUP_ACTUAL_METHOD) not legal");
+		return;
+	}
 
 	memcpy (&ctx, start_ctx, sizeof (MonoContext));
 	memset (reg_locations, 0, sizeof (reg_locations));
@@ -1273,7 +1287,7 @@ mono_walk_stack_full (MonoJitStackWalk func, MonoContext *start_ctx, MonoDomain 
 
 next:
 		if (get_reg_locations) {
-			for (i = 0; i < MONO_MAX_IREGS; ++i)
+			for (int i = 0; i < MONO_MAX_IREGS; ++i)
 				if (new_reg_locations [i])
 					reg_locations [i] = new_reg_locations [i];
 		}
@@ -1295,6 +1309,12 @@ mono_summarize_exception (MonoException *exc, MonoThreadSummary *out)
 	return;
 }
 
+static void
+mono_summarize_exception (MonoException *exc, MonoThreadSummary *out, MonoError *error)
+{
+	return;
+}
+
 #else
 
 typedef struct {
@@ -1302,6 +1322,7 @@ typedef struct {
 	int num_frames;
 	int max_frames;
 	MonoStackHash *hashes;
+	const char *error;
 } MonoSummarizeUserData;
 
 static void
@@ -1325,7 +1346,9 @@ mono_get_portable_ip (intptr_t in_ip, intptr_t *out_ip, char *out_name)
 	Dl_info info;
 	int success = dladdr ((void*) mono_get_portable_ip, &info);
 	intptr_t this_module = (intptr_t) info.dli_fbase;
-	g_assert (success);
+
+	if (!success)
+		return FALSE;
 
 	success = dladdr ((void*)in_ip, &info);
 	if (!success)
@@ -1389,9 +1412,14 @@ static gboolean
 summarize_frame_internal (MonoMethod *method, gpointer ip, size_t native_offset, gboolean managed, gpointer user_data)
 {
 	MonoSummarizeUserData *ud = (MonoSummarizeUserData *) user_data;
-	g_assert (ud->num_frames + 1 < ud->max_frames);
+
+	gboolean valid_state = ud->num_frames + 1 < ud->max_frames;
+	if (!valid_state) {
+		ud->error = "Exceeded the maximum number of frames";
+		return TRUE;
+	}
+
 	MonoFrameSummary *dest = &ud->frames [ud->num_frames];
-	ud->num_frames++;
 
 	dest->unmanaged_data.ip = (intptr_t) ip;
 	dest->is_managed = managed;
@@ -1406,7 +1434,11 @@ summarize_frame_internal (MonoMethod *method, gpointer ip, size_t native_offset,
 	MonoDebugSourceLocation *location = NULL;
 
 	if (managed) {
-		g_assert (method);
+		if (!method) {
+			ud->error = "Managed method frame, but no provided managed method";
+			return TRUE;
+		}
+
 		MonoImage *image = mono_class_get_image (method->klass);
 		// Used for hashing, more stable across rebuilds than using GUID
 		copy_summary_string_safe (dest->str_descr, image->assembly_name);
@@ -1429,12 +1461,16 @@ summarize_frame_internal (MonoMethod *method, gpointer ip, size_t native_offset,
 	ud->hashes->offset_free_hash = summarize_offset_free_hash (ud->hashes->offset_free_hash, dest);
 	ud->hashes->offset_rich_hash = summarize_offset_rich_hash (ud->hashes->offset_rich_hash, dest);
 
+	// We return FALSE, so we're continuing walking
+	// And we increment the pointer because we're done with this cell in the array
+	ud->num_frames++;
 	return FALSE;
 }
 
 static gboolean
 summarize_frame (StackFrameInfo *frame, MonoContext *ctx, gpointer data)
 {
+	MonoSummarizeUserData *ud = (MonoSummarizeUserData *) data;
 	// Don't record trampolines between managed frames
 	if (frame->ji && frame->ji->is_trampoline)
 		return TRUE;
@@ -1442,10 +1478,12 @@ summarize_frame (StackFrameInfo *frame, MonoContext *ctx, gpointer data)
 	MonoMethod *method = NULL;
 	intptr_t ip = 0x0;
 	mono_get_portable_ip ((intptr_t) MONO_CONTEXT_GET_IP (ctx), &ip, NULL);
+	// Don't need to handle return status "success" because this ip is stored below only, NULL is okay
 
 	if (frame && frame->ji && frame->type != FRAME_TYPE_TRAMPOLINE)
 		method = jinfo_get_method (frame->ji);
 
+	method = jinfo_get_method (frame->ji);
 	gboolean is_managed = (method != NULL);
 
 	return summarize_frame_internal (method, (gpointer) ip, frame->native_offset, is_managed, data);
@@ -1484,8 +1522,12 @@ mono_summarize_stack (MonoDomain *domain, MonoThreadSummary *out, MonoContext *c
 	// 
 	// Summarize managed stack
 	// 
-	mono_walk_stack_with_ctx (summarize_frame, crash_ctx, MONO_UNWIND_LOOKUP_IL_OFFSET, &data);
+	mono_walk_stack_full (summarize_frame, out->ctx, out->domain, out->jit_tls, out->lmf, MONO_UNWIND_LOOKUP_IL_OFFSET, &data);
 	out->num_managed_frames = data.num_frames;
+
+	if (data.error != NULL)
+		out->error_msg = data.error;
+}
 
 	// 
 	// Summarize unmanaged stack

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1410,7 +1410,9 @@ check_whitelisted_module (const char *in_name, const char **out_module)
 static gboolean
 mono_get_portable_ip (intptr_t in_ip, intptr_t *out_ip, const char **out_module, char *out_name)
 {
-	// We're only able to get reliable info about pointers in this assembly
+	// Note: it's not safe for us to be interrupted while inside of dl_addr, because if we
+	// try to call dl_addr while interrupted while inside the lock, we will try to take a
+	// non-recursive lock twice on this thread, and will deadlock.
 	Dl_info info;
 	gboolean success = dladdr ((void*)in_ip, &info);
 	if (!success)
@@ -1480,12 +1482,13 @@ summarize_frame_internal (MonoMethod *method, gpointer ip, size_t native_offset,
 	if (method && method->wrapper_type != MONO_WRAPPER_NONE) {
 		dest->is_managed = FALSE;
 		dest->unmanaged_data.has_name = TRUE;
-		copy_summary_string_safe (dest->str_descr, mono_method_full_name (method, TRUE));
+		char *name = mono_method_get_name_full (method, TRUE, FALSE, MONO_TYPE_NAME_FORMAT_IL);
+		copy_summary_string_safe (dest->str_descr, name);
 	}
 	
 #ifndef MONO_PRIVATE_CRASHES
 	if (method)
-		dest->managed_data.name = mono_method_full_name (method, TRUE);
+		dest->managed_data.name = mono_method_get_name_full (method, TRUE, FALSE, MONO_TYPE_NAME_FORMAT_IL);
 #endif
 
 	MonoDebugSourceLocation *location = NULL;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1308,6 +1308,13 @@ mono_summarize_exception (MonoException *exc, MonoThreadSummary *out)
 	return;
 }
 
+static void
+mono_crash_reporting_register_native_library (const char *module_path, const char *module_name)
+{
+	return;
+}
+
+
 #else
 
 typedef struct {
@@ -1332,34 +1339,84 @@ copy_summary_string_safe (char *in, const char *out)
 	return;
 }
 
+static GHashTable *native_library_whitelist;
+
+static void
+mono_crash_reporting_register_native_library (const char *module_path, const char *module_name)
+{
+	Dl_info info;
+	if (!native_library_whitelist) {
+		native_library_whitelist = g_hash_table_new_full (NULL, NULL, NULL, g_free);
+
+		dladdr ((void*) mono_crash_reporting_register_native_library, &info);
+
+		if (info.dli_fname && strlen(info.dli_fname) > 0)
+			g_hash_table_insert (native_library_whitelist, g_strdup (info.dli_fname), g_strdup ("mono"));
+	}
+
+	// Examples: libsystem_pthread.dylib -> "pthread"
+	// Examples: libsystem_platform.dylib -> "platform"
+	// Examples: mono-sgen -> "mono" from above line
+	g_hash_table_insert (native_library_whitelist, g_strdup (module_path), g_strdup (module_name));
+}
+
 static gboolean
-mono_get_portable_ip (intptr_t in_ip, intptr_t *out_ip, char *out_name)
+mono_make_portable_ip (intptr_t in_ip, intptr_t module_base)
+{
+	// FIXME: Make generalize away from llvm tools?
+	// So lldb starts the pointer base at 0x100000000
+	// and expects to get pointers as (offset + constant)
+	//
+	// Quirk shared by:
+	// /usr/bin/symbols  -- symbols version:			@(#)PROGRAM:symbols  PROJECT:SamplingTools-63501
+	// *CoreSymbolicationDT.framework version:	63750*/
+	intptr_t offset = in_ip - module_base;
+	intptr_t magic_value = offset + 0x100000000;
+	return magic_value;
+}
+
+static gboolean
+check_whitelisted_module (const char *in_name, const char **out_module)
+{
+	if (!native_library_whitelist) {
+		if (g_str_has_suffix (in_name, "mono-sgen")) {
+			*out_module = "mono";
+			return TRUE;
+		}
+
+		return FALSE;
+	}
+
+	GHashTableIter iter;
+	char *file_suffix;
+	char *module_suffix;
+	g_hash_table_iter_init (&iter, native_library_whitelist);
+	while (g_hash_table_iter_next (&iter, (gpointer *) &file_suffix, (gpointer *) &module_suffix)) {
+		if (!g_str_has_suffix (in_name, file_suffix))
+			continue;
+		if (out_module)
+			*out_module = module_suffix;
+		return TRUE;
+	}
+
+	/*fprintf (stderr, "%s == %s\n", info.dli_fname, *out_module);*/
+
+	return FALSE;
+}
+
+static gboolean
+mono_get_portable_ip (intptr_t in_ip, intptr_t *out_ip, const char **out_module, char *out_name)
 {
 	// We're only able to get reliable info about pointers in this assembly
 	Dl_info info;
-	int success = dladdr ((void*) mono_get_portable_ip, &info);
-	intptr_t this_module = (intptr_t) info.dli_fbase;
-
+	gboolean success = dladdr ((void*)in_ip, &info);
 	if (!success)
 		return FALSE;
 
-	success = dladdr ((void*)in_ip, &info);
-	if (!success)
+	if (!check_whitelisted_module (info.dli_fname, out_module))
 		return FALSE;
 
-	if ((intptr_t) info.dli_fbase == this_module) {
-		// FIXME: Make generalize away from llvm tools?
-		// So lldb starts the pointer base at 0x100000000
-		// and expects to get pointers as (offset + constant)
-		//
-		// Quirk shared by:
-		// /usr/bin/symbols  -- symbols version:			@(#)PROGRAM:symbols  PROJECT:SamplingTools-63501
-		// *CoreSymbolicationDT.framework version:	63750*/
-		intptr_t offset = in_ip - this_module;
-		intptr_t magic_value = offset + 0x100000000;
-
-		*out_ip = magic_value;
-	}
+	*out_ip = mono_make_portable_ip (in_ip, (intptr_t) info.dli_fbase);
 
 #ifndef MONO_PRIVATE_CRASHES
 	if (info.dli_saddr && out_name)
@@ -1470,7 +1527,7 @@ summarize_frame (StackFrameInfo *frame, MonoContext *ctx, gpointer data)
 
 	MonoMethod *method = NULL;
 	intptr_t ip = 0x0;
-	mono_get_portable_ip ((intptr_t) MONO_CONTEXT_GET_IP (ctx), &ip, NULL);
+	mono_get_portable_ip ((intptr_t) MONO_CONTEXT_GET_IP (ctx), &ip, NULL, NULL);
 	// Don't need to handle return status "success" because this ip is stored below only, NULL is okay
 
 	if (frame && frame->ji && frame->type != FRAME_TYPE_TRAMPOLINE)
@@ -1532,8 +1589,9 @@ mono_summarize_stack (MonoThreadSummary *out, MonoContext *crash_ctx)
 
 	for (int i =0; i < out->num_unmanaged_frames; ++i) {
 		intptr_t ip = frame_ips [i];
+		MonoFrameSummary *frame = &out->unmanaged_frames [i];
 
-		int success = mono_get_portable_ip (ip, &out->unmanaged_frames [i].unmanaged_data.ip, (char *) &out->unmanaged_frames [i].str_descr);
+		int success = mono_get_portable_ip (ip, &frame->unmanaged_data.ip, &frame->unmanaged_data.module, (char *) frame->str_descr);
 		if (!success)
 			continue;
 

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -127,7 +127,7 @@ static gboolean mono_install_handler_block_guard (MonoThreadUnwindState *ctx);
 static void mono_uninstall_current_handler_block_guard (void);
 static gboolean mono_exception_walk_trace_internal (MonoException *ex, MonoExceptionFrameWalk func, gpointer user_data);
 
-static void mono_summarize_stack (MonoDomain *domain, MonoThreadSummary *out, MonoContext *crash_ctx);
+static void mono_summarize_stack (MonoThreadSummary *out, MonoContext *crash_ctx);
 static void mono_summarize_exception (MonoException *exc, MonoThreadSummary *out);
 
 static gboolean
@@ -1234,7 +1234,6 @@ mono_walk_stack_full (MonoJitStackWalk func, MonoContext *start_ctx, MonoDomain 
 
 	/*The LMF will be null if the target have no managed frames.*/
  	/* g_assert (lmf); */
-
 	if (async && (unwind_options & MONO_UNWIND_LOOKUP_ACTUAL_METHOD)) {
 		g_warning ("async && (unwind_options & MONO_UNWIND_LOOKUP_ACTUAL_METHOD) not legal");
 		return;
@@ -1298,19 +1297,13 @@ next:
 
 #ifdef DISABLE_CRASH_REPORTING
 static void
-mono_summarize_stack (MonoDomain *domain, MonoThreadSummary *out, MonoContext *crash_ctx)
+mono_summarize_stack (MonoThreadSummary *out, MonoContext *crash_ctx)
 {
 	return;
 }
 
 static void
 mono_summarize_exception (MonoException *exc, MonoThreadSummary *out)
-{
-	return;
-}
-
-static void
-mono_summarize_exception (MonoException *exc, MonoThreadSummary *out, MonoError *error)
 {
 	return;
 }
@@ -1507,7 +1500,7 @@ mono_summarize_exception (MonoException *exc, MonoThreadSummary *out)
 
 
 static void 
-mono_summarize_stack (MonoDomain *domain, MonoThreadSummary *out, MonoContext *crash_ctx)
+mono_summarize_stack (MonoThreadSummary *out, MonoContext *crash_ctx)
 {
 	MonoSummarizeUserData data;
 	memset (&data, 0, sizeof (MonoSummarizeUserData));

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1382,7 +1382,8 @@ check_whitelisted_module (const char *in_name, const char **out_module)
 {
 	if (!native_library_whitelist) {
 		if (g_str_has_suffix (in_name, "mono-sgen")) {
-			*out_module = "mono";
+			if (out_module)
+				*out_module = "mono";
 			return TRUE;
 		}
 
@@ -1479,9 +1480,13 @@ summarize_frame_internal (MonoMethod *method, gpointer ip, size_t native_offset,
 	if (method && method->wrapper_type != MONO_WRAPPER_NONE) {
 		dest->is_managed = FALSE;
 		dest->unmanaged_data.has_name = TRUE;
-
 		copy_summary_string_safe (dest->str_descr, mono_method_full_name (method, TRUE));
 	}
+	
+#ifndef MONO_PRIVATE_CRASHES
+	if (method)
+		dest->managed_data.name = mono_method_full_name (method, TRUE);
+#endif
 
 	MonoDebugSourceLocation *location = NULL;
 
@@ -1527,16 +1532,20 @@ summarize_frame (StackFrameInfo *frame, MonoContext *ctx, gpointer data)
 	if (frame->ji && frame->ji->is_trampoline)
 		return TRUE;
 
-	MonoMethod *method = NULL;
+	if (frame->ji && (frame->ji->is_trampoline || frame->ji->async))
+		return FALSE; // Keep unwinding
+
 	intptr_t ip = 0x0;
 	mono_get_portable_ip ((intptr_t) MONO_CONTEXT_GET_IP (ctx), &ip, NULL, NULL);
 	// Don't need to handle return status "success" because this ip is stored below only, NULL is okay
 
+	gboolean is_managed = (frame->type == FRAME_TYPE_MANAGED || frame->type == FRAME_TYPE_INTERP);
+	MonoMethod *method = NULL;
 	if (frame && frame->ji && frame->type != FRAME_TYPE_TRAMPOLINE)
 		method = jinfo_get_method (frame->ji);
 
-	method = jinfo_get_method (frame->ji);
-	gboolean is_managed = (method != NULL);
+	if (is_managed)
+		method = jinfo_get_method (frame->ji);
 
 	return summarize_frame_internal (method, (gpointer) ip, frame->native_offset, is_managed, data);
 }

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -127,7 +127,8 @@ static gboolean mono_install_handler_block_guard (MonoThreadUnwindState *ctx);
 static void mono_uninstall_current_handler_block_guard (void);
 static gboolean mono_exception_walk_trace_internal (MonoException *ex, MonoExceptionFrameWalk func, gpointer user_data);
 
-static void mono_summarize_stack (MonoThreadSummary *out, MonoContext *crash_ctx);
+static void mono_summarize_managed_stack (MonoThreadSummary *out);
+static void mono_summarize_unmanaged_stack (MonoThreadSummary *out);
 static void mono_summarize_exception (MonoException *exc, MonoThreadSummary *out);
 static void mono_crash_reporting_register_native_library (const char *module_path, const char *module_name);
 
@@ -237,7 +238,8 @@ mono_exceptions_init (void)
 
 	cbs.mono_walk_stack_with_ctx = mono_runtime_walk_stack_with_ctx;
 	cbs.mono_walk_stack_with_state = mono_walk_stack_with_state;
-	cbs.mono_summarize_stack = mono_summarize_stack;
+	cbs.mono_summarize_managed_stack = mono_summarize_managed_stack;
+	cbs.mono_summarize_unmanaged_stack = mono_summarize_unmanaged_stack;
 	cbs.mono_summarize_exception = mono_summarize_exception;
 	cbs.mono_register_native_library = mono_crash_reporting_register_native_library;
 
@@ -1298,8 +1300,15 @@ next:
 }
 
 #ifdef DISABLE_CRASH_REPORTING
-static void
-mono_summarize_stack (MonoThreadSummary *out, MonoContext *crash_ctx)
+
+static void 
+mono_summarize_managed_stack (MonoThreadSummary *out)
+{
+	return;
+}
+
+static void 
+mono_summarize_unmanaged_stack (MonoThreadSummary *out)
 {
 	return;
 }
@@ -1571,7 +1580,7 @@ mono_summarize_exception (MonoException *exc, MonoThreadSummary *out)
 
 
 static void 
-mono_summarize_stack (MonoThreadSummary *out, MonoContext *crash_ctx)
+mono_summarize_managed_stack (MonoThreadSummary *out)
 {
 	MonoSummarizeUserData data;
 	memset (&data, 0, sizeof (MonoSummarizeUserData));
@@ -1593,6 +1602,11 @@ mono_summarize_stack (MonoThreadSummary *out, MonoContext *crash_ctx)
 		out->error_msg = data.error;
 }
 
+// Always runs on the dumped thread
+static void 
+mono_summarize_unmanaged_stack (MonoThreadSummary *out)
+{
+	MONO_ARCH_CONTEXT_DEF
 	// 
 	// Summarize unmanaged stack
 	// 
@@ -1613,6 +1627,18 @@ mono_summarize_stack (MonoThreadSummary *out, MonoContext *crash_ctx)
 			out->unmanaged_frames [i].unmanaged_data.has_name = TRUE;
 	}
 #endif
+
+	out->lmf = mono_get_lmf ();
+
+	MonoThreadInfo *thread = mono_thread_info_current_unchecked ();
+	out->jit_tls = thread->jit_data;
+	out->domain = mono_domain_get ();
+
+	if (!out->ctx) {
+		out->ctx = &out->ctx_mem;
+		mono_arch_flush_register_windows ();
+		MONO_INIT_CONTEXT_FROM_FUNC (out->ctx, mono_summarize_unmanaged_stack);
+	}
 
 	return;
 }

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -119,7 +119,7 @@ static gpointer throw_corlib_exception_func;
 
 static MonoFtnPtrEHCallback ftnptr_eh_callback;
 
-static void mono_walk_stack_full (MonoJitStackWalk func, MonoContext *start_ctx, MonoDomain *domain, MonoJitTlsData *jit_tls, MonoLMF *lmf, MonoUnwindOptions unwind_options, gpointer user_data);
+static void mono_walk_stack_full (MonoJitStackWalk func, MonoContext *start_ctx, MonoDomain *domain, MonoJitTlsData *jit_tls, MonoLMF *lmf, MonoUnwindOptions unwind_options, gpointer user_data, gboolean crash_context);
 static void mono_raise_exception_with_ctx (MonoException *exc, MonoContext *ctx);
 static void mono_runtime_walk_stack_with_ctx (MonoJitStackWalk func, MonoContext *start_ctx, MonoUnwindOptions unwind_options, void *user_data);
 static gboolean mono_current_thread_has_handle_block_guard (void);
@@ -1114,7 +1114,7 @@ mono_walk_stack_with_ctx (MonoJitStackWalk func, MonoContext *start_ctx, MonoUnw
 		start_ctx = &extra_ctx;
 	}
 
-	mono_walk_stack_full (func, start_ctx, mono_domain_get (), thread->jit_data, mono_get_lmf (), unwind_options, user_data);
+	mono_walk_stack_full (func, start_ctx, mono_domain_get (), thread->jit_data, mono_get_lmf (), unwind_options, user_data, FALSE);
 }
 
 /**
@@ -1149,7 +1149,7 @@ mono_walk_stack_with_state (MonoJitStackWalk func, MonoThreadUnwindState *state,
 		(MonoDomain *)state->unwind_data [MONO_UNWIND_DATA_DOMAIN],
 		(MonoJitTlsData *)state->unwind_data [MONO_UNWIND_DATA_JIT_TLS],
 		(MonoLMF *)state->unwind_data [MONO_UNWIND_DATA_LMF],
-		unwind_options, user_data);
+		unwind_options, user_data, FALSE);
 }
 
 void
@@ -1170,13 +1170,14 @@ mono_walk_stack (MonoJitStackWalk func, MonoUnwindOptions options, void *user_da
  * \param thread the thread whose stack to walk, can be NULL to use the current thread
  * \param lmf the LMF of \p thread, can be NULL to use the LMF of the current thread
  * \param user_data data passed to the callback
+ * \param crash_context tells us that we're in a context where it's not safe to lock or allocate
  * This function walks the stack of a thread, starting from the state
  * represented by \p start_ctx. For each frame the callback
  * function is called with the relevant info. The walk ends when no more
  * managed stack frames are found or when the callback returns a TRUE value.
  */
 static void
-mono_walk_stack_full (MonoJitStackWalk func, MonoContext *start_ctx, MonoDomain *domain, MonoJitTlsData *jit_tls, MonoLMF *lmf, MonoUnwindOptions unwind_options, gpointer user_data)
+mono_walk_stack_full (MonoJitStackWalk func, MonoContext *start_ctx, MonoDomain *domain, MonoJitTlsData *jit_tls, MonoLMF *lmf, MonoUnwindOptions unwind_options, gpointer user_data, gboolean crash_context)
 {
 	gint il_offset;
 	MonoContext ctx, new_ctx;
@@ -1258,14 +1259,24 @@ mono_walk_stack_full (MonoJitStackWalk func, MonoContext *start_ctx, MonoDomain 
 			goto next;
 
 		if ((unwind_options & MONO_UNWIND_LOOKUP_IL_OFFSET) && frame.ji) {
-			MonoDebugSourceLocation *source;
+			MonoDebugSourceLocation *source = NULL;
 
-			source = mono_debug_lookup_source_location (jinfo_get_method (frame.ji), frame.native_offset, domain);
+			// Don't do this when we can be in a signal handler
+			if (!crash_context)
+				source = mono_debug_lookup_source_location (jinfo_get_method (frame.ji), frame.native_offset, domain);
 			if (source) {
 				il_offset = source->il_offset;
 			} else {
+				MonoSeqPointInfo *seq_points = NULL;
+
+				// It's more reliable to look into the global cache if possible
+				if (crash_context)
+					seq_points = (MonoSeqPointInfo *) frame.ji->seq_points;
+				else
+					seq_points = mono_get_seq_points (domain, jinfo_get_method (frame.ji));
+
 				SeqPoint sp;
-				if (mono_find_prev_seq_point_for_native_offset (domain, jinfo_get_method (frame.ji), frame.native_offset, NULL, &sp))
+				if (seq_points && mono_seq_point_find_prev_by_native_offset (seq_points, frame.native_offset, &sp))
 					il_offset = sp.il_offset;
 				else
 					il_offset = -1;
@@ -1473,7 +1484,7 @@ summarize_offset_rich_hash (guint64 accum, MonoFrameSummary *frame)
 }
 
 static gboolean
-summarize_frame_internal (MonoMethod *method, gpointer ip, size_t native_offset, gboolean managed, gpointer user_data)
+summarize_frame_internal (MonoMethod *method, gpointer ip, size_t native_offset, int il_offset, gboolean managed, gpointer user_data)
 {
 	MonoSummarizeUserData *ud = (MonoSummarizeUserData *) user_data;
 
@@ -1499,8 +1510,6 @@ summarize_frame_internal (MonoMethod *method, gpointer ip, size_t native_offset,
 		dest->managed_data.name = (char *) method->name;
 #endif
 
-	MonoDebugSourceLocation *location = NULL;
-
 	if (managed) {
 		if (!method) {
 			ud->error = "Managed method frame, but no provided managed method";
@@ -1515,16 +1524,11 @@ summarize_frame_internal (MonoMethod *method, gpointer ip, size_t native_offset,
 
 		dest->managed_data.native_offset = native_offset;
 		dest->managed_data.token = method->token;
-		location = mono_debug_lookup_source_location (method, native_offset, mono_domain_get ());
+		dest->managed_data.il_offset = il_offset;
 	} else {
 		dest->managed_data.token = -1;
 	}
 
-	if (location) {
-		dest->managed_data.il_offset = location->il_offset;
-
-		mono_debug_free_source_location (location);
-	}
 
 	ud->hashes->offset_free_hash = summarize_offset_free_hash (ud->hashes->offset_free_hash, dest);
 	ud->hashes->offset_rich_hash = summarize_offset_rich_hash (ud->hashes->offset_rich_hash, dest);
@@ -1534,6 +1538,23 @@ summarize_frame_internal (MonoMethod *method, gpointer ip, size_t native_offset,
 	ud->num_frames++;
 	return FALSE;
 }
+
+static gboolean
+summarize_frame_managed_walk (MonoMethod *method, gpointer ip, size_t native_offset, gboolean managed, gpointer user_data)
+{
+	int il_offset = -1;
+
+	if (managed && method) {
+		MonoDebugSourceLocation *location = mono_debug_lookup_source_location (method, native_offset, mono_domain_get ());
+		if (location) {
+			il_offset = location->il_offset;
+			mono_debug_free_source_location (location);
+		}
+	}
+
+	return summarize_frame_internal (method, ip, native_offset, il_offset, managed, user_data);
+}
+
 
 static gboolean
 summarize_frame (StackFrameInfo *frame, MonoContext *ctx, gpointer data)
@@ -1558,7 +1579,7 @@ summarize_frame (StackFrameInfo *frame, MonoContext *ctx, gpointer data)
 	if (is_managed)
 		method = jinfo_get_method (frame->ji);
 
-	return summarize_frame_internal (method, (gpointer) ip, frame->native_offset, is_managed, data);
+	return summarize_frame_internal (method, (gpointer) ip, frame->native_offset, frame->il_offset, is_managed, data);
 }
 
 static void
@@ -1573,7 +1594,7 @@ mono_summarize_exception (MonoException *exc, MonoThreadSummary *out)
 	data.frames = out->managed_frames;
 	data.hashes = &out->hashes;
 
-	mono_exception_walk_trace (exc, summarize_frame_internal, &data);
+	mono_exception_walk_trace (exc, summarize_frame_managed_walk, &data);
 	out->num_managed_frames = data.num_frames;
 }
 
@@ -1594,7 +1615,7 @@ mono_summarize_managed_stack (MonoThreadSummary *out)
 	// 
 	// Summarize managed stack
 	// 
-	mono_walk_stack_full (summarize_frame, out->ctx, out->domain, out->jit_tls, out->lmf, MONO_UNWIND_LOOKUP_IL_OFFSET, &data);
+	mono_walk_stack_full (summarize_frame, out->ctx, out->domain, out->jit_tls, out->lmf, MONO_UNWIND_LOOKUP_IL_OFFSET, &data, TRUE);
 	out->num_managed_frames = data.num_frames;
 
 	if (data.error != NULL)

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -229,15 +229,12 @@ MONO_SIG_HANDLER_FUNC (static, sigterm_signal_handler)
 	MONO_SIG_HANDLER_GET_CONTEXT;
 
 #ifndef DISABLE_CRASH_REPORTING
-	// Note: this function only returns for a single thread
-	// When it's invoked on other threads once the dump begins,
-	// those threads perform their dumps and then sleep until we
-	// die. The dump ends with the exit(1) below
+	// Note: this is only run from the non-controlling thread
 	MonoContext mctx;
 	gchar *output = NULL;
 	MonoStackHash hashes;
 	mono_sigctx_to_monoctx (ctx, &mctx);
-	if (!mono_threads_summarize (&mctx, &output, &hashes, FALSE))
+	if (!mono_threads_summarize_execute (&mctx, &output, &hashes, FALSE))
 		g_assert_not_reached ();
 
 #ifdef TARGET_OSX
@@ -1027,7 +1024,7 @@ dump_native_stacktrace (const char *signal, void *ctx)
 			if (!leave) {
 				mono_sigctx_to_monoctx (ctx, &mctx);
 				// Do before forking
-				if (!mono_threads_summarize (&mctx, &output, &hashes, FALSE))
+				if (!mono_threads_summarize (&mctx, &output, &hashes, FALSE, TRUE))
 					g_assert_not_reached ();
 			}
 

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -247,14 +247,13 @@ MONO_SIG_HANDLER_FUNC (static, sigterm_signal_handler)
 	} else
 #endif
 	{
-		// Only the dumping-supervisor thread exits mono_thread_summarize
-		MOSTLY_ASYNC_SAFE_PRINTF("Unhandled exception dump: \n######\n%s\n######\n", output);
-		sleep (3);
+		// Controlling thread gets the dump
+		if (output)
+			MOSTLY_ASYNC_SAFE_PRINTF("Unhandled exception dump: \n######\n%s\n######\n", output);
 	}
 #endif
 
 	mono_chain_signal (MONO_SIG_HANDLER_PARAMS);
-	exit (1);
 }
 
 #if (defined (USE_POSIX_BACKEND) && defined (SIGRTMIN)) || defined (SIGPROF)

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -237,7 +237,7 @@ MONO_SIG_HANDLER_FUNC (static, sigterm_signal_handler)
 	gchar *output = NULL;
 	MonoStackHash hashes;
 	mono_sigctx_to_monoctx (ctx, &mctx);
-	if (!mono_threads_summarize (&mctx, &output, &hashes))
+	if (!mono_threads_summarize (&mctx, &output, &hashes, FALSE))
 		g_assert_not_reached ();
 
 #ifdef TARGET_OSX
@@ -1021,7 +1021,7 @@ dump_native_stacktrace (const char *signal, void *ctx)
 			if (!leave) {
 				mono_sigctx_to_monoctx (ctx, &mctx);
 				// Do before forking
-				if (!mono_threads_summarize (&mctx, &output, &hashes))
+				if (!mono_threads_summarize (&mctx, &output, &hashes, FALSE))
 					g_assert_not_reached ();
 			}
 

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -413,8 +413,14 @@ void
 mini_register_sigterm_handler (void)
 {
 #ifndef DISABLE_CRASH_REPORTING
-	/* always catch SIGTERM, conditionals inside of handler */
-	add_signal_handler (SIGTERM, sigterm_signal_handler, 0);
+	static gboolean enabled;
+
+	if (!enabled) {
+		enabled = TRUE;
+
+		/* always catch SIGTERM, conditionals inside of handler */
+		add_signal_handler (SIGTERM, sigterm_signal_handler, 0);
+	}
 #endif
 }
 

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -1026,6 +1026,12 @@ dump_native_stacktrace (const char *signal, void *ctx)
 				// Do before forking
 				if (!mono_threads_summarize (&mctx, &output, &hashes, FALSE, TRUE))
 					g_assert_not_reached ();
+
+				// Wait for the other threads to clean up and exit their handlers
+				// We can't lock / wait indefinitely, in case one of these threads got stuck somehow
+				// while dumping. 
+				mono_runtime_printf_err ("\nWaiting for dumping threads to resume\n");
+				sleep (1);
 			}
 
 			// We want our crash, and don't have telemetry

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -234,7 +234,7 @@ MONO_SIG_HANDLER_FUNC (static, sigterm_signal_handler)
 	gchar *output = NULL;
 	MonoStackHash hashes;
 	mono_sigctx_to_monoctx (ctx, &mctx);
-	if (!mono_threads_summarize_execute (&mctx, &output, &hashes, FALSE))
+	if (!mono_threads_summarize_execute (&mctx, &output, &hashes, FALSE, NULL, 0))
 		g_assert_not_reached ();
 
 #ifdef TARGET_OSX
@@ -1024,7 +1024,7 @@ dump_native_stacktrace (const char *signal, void *ctx)
 			if (!leave) {
 				mono_sigctx_to_monoctx (ctx, &mctx);
 				// Do before forking
-				if (!mono_threads_summarize (&mctx, &output, &hashes, FALSE, TRUE))
+				if (!mono_threads_summarize (&mctx, &output, &hashes, FALSE, TRUE, NULL, 0))
 					g_assert_not_reached ();
 
 				// Wait for the other threads to clean up and exit their handlers

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4319,7 +4319,7 @@ mini_init (const char *filename, const char *runtime_version)
 #endif
 	callbacks.get_weak_field_indexes = mono_aot_get_weak_field_indexes;
 
-#ifdef TARGET_OSX
+#ifndef DISABLE_CRASH_REPORTING
 	callbacks.install_state_summarizer = mini_register_sigterm_handler;
 #endif
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -2544,6 +2544,8 @@ mono_jit_free_method (MonoDomain *domain, MonoMethod *method)
 	g_hash_table_remove (info->jump_trampoline_hash, method);
 	g_hash_table_remove (info->seq_points, method);
 
+	ji->ji->seq_points = NULL;
+
 	/* requires the domain lock - took above */
 	mono_conc_hashtable_remove (info->runtime_invoke_hash, method);
 
@@ -2591,6 +2593,36 @@ mono_jit_free_method (MonoDomain *domain, MonoMethod *method)
 	if (destroy)
 		mono_code_manager_destroy (ji->code_mp);
 	g_free (ji);
+}
+
+gpointer
+mono_jit_search_all_backends_for_jit_info (MonoDomain *domain, MonoMethod *method, MonoJitInfo **out_ji)
+{
+	gpointer code;
+	MonoJitInfo *ji;
+
+	code = mono_jit_find_compiled_method_with_jit_info (domain, method, &ji);
+	if (!code) {
+		ERROR_DECL_VALUE (oerror);
+
+		/* Might be AOTed code */
+		mono_class_init (method->klass);
+		code = mono_aot_get_method (domain, method, &oerror);
+		if (code) {
+			mono_error_assert_ok (&oerror);
+			ji = mono_jit_info_table_find (domain, code);
+		} else {
+			if (!is_ok (&oerror))
+				mono_error_cleanup (&oerror);
+
+			/* Might be interpreted */
+			ji = mini_get_interp_callbacks ()->find_jit_info (domain, method);
+		}
+	}
+
+	*out_ji = ji;
+
+	return code;
 }
 
 gpointer

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -451,6 +451,7 @@ MonoJumpInfoToken* mono_jump_info_token_new2 (MonoMemPool *mp, MonoImage *image,
 gpointer  mono_resolve_patch_target         (MonoMethod *method, MonoDomain *domain, guint8 *code, MonoJumpInfo *patch_info, gboolean run_cctors, MonoError *error) MONO_LLVM_INTERNAL;
 void mini_register_jump_site                (MonoDomain *domain, MonoMethod *method, gpointer ip);
 void mini_patch_jump_sites                  (MonoDomain *domain, MonoMethod *method, gpointer addr);
+gpointer  mono_jit_search_all_backends_for_jit_info (MonoDomain *domain, MonoMethod *method, MonoJitInfo **ji);
 gpointer  mono_jit_find_compiled_method_with_jit_info (MonoDomain *domain, MonoMethod *method, MonoJitInfo **ji);
 gpointer  mono_jit_find_compiled_method     (MonoDomain *domain, MonoMethod *method);
 gpointer  mono_jit_compile_method           (MonoMethod *method, MonoError *error);

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3874,7 +3874,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 	}
 
 	MONO_TIME_TRACK (mono_jit_stats.jit_gc_create_gc_map, mini_gc_create_gc_map (cfg));
-	MONO_TIME_TRACK (mono_jit_stats.jit_save_seq_point_info, mono_save_seq_point_info (cfg));
+	MONO_TIME_TRACK (mono_jit_stats.jit_save_seq_point_info, mono_save_seq_point_info (cfg, cfg->jit_info));
 
 	if (!cfg->compile_aot) {
 		mono_save_xdebug_info (cfg);

--- a/mono/mini/seq-points.c
+++ b/mono/mini/seq-points.c
@@ -99,7 +99,7 @@ collect_pred_seq_points (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins, GS
 }
 
 void
-mono_save_seq_point_info (MonoCompile *cfg)
+mono_save_seq_point_info (MonoCompile *cfg, MonoJitInfo *jinfo)
 {
 	MonoBasicBlock *bb;
 	GSList *bb_seq_points, *l;
@@ -244,6 +244,9 @@ mono_save_seq_point_info (MonoCompile *cfg)
 		else
 			mono_seq_point_info_free (cfg->seq_point_info);
 		mono_domain_unlock (domain);
+
+		g_assert (jinfo);
+		jinfo->seq_points = cfg->seq_point_info;
 	}
 
 	g_ptr_array_free (cfg->seq_points, TRUE);

--- a/mono/mini/seq-points.h
+++ b/mono/mini/seq-points.h
@@ -10,7 +10,7 @@
 #include <mono/metadata/seq-points-data.h>
 
 void
-mono_save_seq_point_info (MonoCompile *cfg);
+mono_save_seq_point_info (MonoCompile *cfg, MonoJitInfo *jinfo);
 
 MonoSeqPointInfo*
 mono_get_seq_points (MonoDomain *domain, MonoMethod *method);

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -98,6 +98,12 @@ mono_native_state_add_frame (JsonWriter *writer, MonoFrameSummary *frame)
 		mono_json_writer_object_key(writer, "native_offset");
 		mono_json_writer_printf (writer, "\"0x%x\",\n", frame->managed_data.native_offset);
 
+		if (frame->managed_data.name != NULL) {
+			mono_json_writer_indent (writer);
+			mono_json_writer_object_key(writer, "method_name");
+			mono_json_writer_printf (writer, "\"%s\",\n", frame->managed_data.name);
+		}
+
 		mono_json_writer_indent (writer);
 		mono_json_writer_object_key(writer, "il_offset");
 		mono_json_writer_printf (writer, "\"0x%05x\"\n", frame->managed_data.il_offset);

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -547,7 +547,7 @@ mono_crash_dump (const char *jsonFile, MonoStackHash *hashes)
 	// Save up to 100 dump files for a given stacktrace hash
 	for (int increment = 0; increment < 100; increment++) {
 		FILE* fp;
-		char *name = g_strdup_printf ("mono_crash.%" PRIx64 " .%d.json", hashes->offset_free_hash, increment);
+		char *name = g_strdup_printf ("mono_crash.%" PRIx64 ".%d.json", hashes->offset_free_hash, increment);
 
 		if ((fp = fopen (name, "ab"))) {
 			if (ftell (fp) == 0) {

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -168,7 +168,13 @@ mono_native_state_add_thread (JsonWriter *writer, MonoThreadSummary *thread, Mon
 	mono_json_writer_object_key(writer, "thread_info_addr");
 	mono_json_writer_printf (writer, "\"0x%x\",\n", (gpointer) thread->info_addr);
 
-	if (thread->name) {
+	if (thread->error_msg != NULL) {
+		mono_json_writer_indent (writer);
+		mono_json_writer_object_key(writer, "dumping_error");
+		mono_json_writer_printf (writer, "\"%s\",\n", thread->error_msg);
+	}
+
+	if (thread->name [0] != '\0') {
 		mono_json_writer_indent (writer);
 		mono_json_writer_object_key(writer, "thread_name");
 		mono_json_writer_printf (writer, "\"%s\",\n", thread->name);

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -26,19 +26,25 @@ extern GCStats mono_gc_stats;
 #include <mach/task_info.h>
 #endif
 
-#define MONO_MAX_SUMMARY_LEN 900
+#define MONO_MAX_SUMMARY_LEN 1100
 static JsonWriter writer;
 static GString static_gstr;
-static char output_dump_str [MONO_MAX_SUMMARY_LEN];
+static gchar output_dump_str [MONO_MAX_SUMMARY_LEN];
 
-static void mono_json_writer_init_static (void) {
+static void mono_json_writer_init_memory (gchar *output_dump_str, size_t len)
+{
 	static_gstr.len = 0;
-	static_gstr.allocated_len = MONO_MAX_SUMMARY_LEN;
+	static_gstr.allocated_len = len;
 	static_gstr.str = output_dump_str;
-	memset (output_dump_str, 0, sizeof (output_dump_str));
+	memset (output_dump_str, 0, len * sizeof (gchar));
 
 	writer.indent = 0;
 	writer.text = &static_gstr;
+}
+
+static void mono_json_writer_init_with_static (void) 
+{
+	return mono_json_writer_init_memory (output_dump_str, MONO_MAX_SUMMARY_LEN);
 }
 
 static void
@@ -505,9 +511,14 @@ mono_native_state_free (JsonWriter *writer, gboolean free_data)
 }
 
 void
-mono_summarize_native_state_begin (void)
+mono_summarize_native_state_begin (gchar *mem, size_t size)
 {
-	mono_json_writer_init_static ();
+	// Shared global mutable memory, only use when VM crashing
+	if (!mem)
+		mono_json_writer_init_with_static ();
+	else
+		mono_json_writer_init_memory (mem, size);
+
 	mono_native_state_init (&writer);
 }
 

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -98,11 +98,13 @@ mono_native_state_add_frame (JsonWriter *writer, MonoFrameSummary *frame)
 		mono_json_writer_object_key(writer, "native_offset");
 		mono_json_writer_printf (writer, "\"0x%x\",\n", frame->managed_data.native_offset);
 
+#ifndef MONO_PRIVATE_CRASHES
 		if (frame->managed_data.name != NULL) {
 			mono_json_writer_indent (writer);
 			mono_json_writer_object_key(writer, "method_name");
 			mono_json_writer_printf (writer, "\"%s\",\n", frame->managed_data.name);
 		}
+#endif
 
 		mono_json_writer_indent (writer);
 		mono_json_writer_object_key(writer, "il_offset");

--- a/mono/utils/mono-state.h
+++ b/mono/utils/mono-state.h
@@ -27,7 +27,7 @@ MONO_BEGIN_DECLS
  */
 
 void
-mono_summarize_native_state_begin (void);
+mono_summarize_native_state_begin (char *mem, size_t size);
 
 char *
 mono_summarize_native_state_end (void);

--- a/mono/utils/mono-state.h
+++ b/mono/utils/mono-state.h
@@ -27,7 +27,7 @@ MONO_BEGIN_DECLS
  */
 
 void
-mono_summarize_native_state_begin (char *mem, size_t size);
+mono_summarize_native_state_begin (char *mem, int size);
 
 char *
 mono_summarize_native_state_end (void);

--- a/mono/utils/mono-threads-posix.c
+++ b/mono/utils/mono-threads-posix.c
@@ -211,6 +211,19 @@ mono_native_thread_create (MonoNativeThreadId *tid, gpointer func, gpointer arg)
 	return pthread_create (tid, NULL, (void *(*)(void *)) func, arg) == 0;
 }
 
+size_t
+mono_native_thread_get_name (MonoNativeThreadId tid, char *name_out, size_t max_len)
+{
+#ifdef HAVE_PTHREAD_GETNAME_NP
+	int error = pthread_getname_np(tid, name_out, max_len);
+	if (error != 0)
+		return 0;
+	return strlen(name_out);
+#else
+	return 0;
+#endif
+}
+
 void
 mono_native_thread_set_name (MonoNativeThreadId tid, const char *name)
 {

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -620,6 +620,9 @@ mono_native_thread_create (MonoNativeThreadId *tid, T func, gpointer arg)
 MONO_API void
 mono_native_thread_set_name (MonoNativeThreadId tid, const char *name);
 
+size_t
+mono_native_thread_get_name (MonoNativeThreadId tid, char *name_out, size_t max_len);
+
 MONO_API gboolean
 mono_native_thread_join (MonoNativeThreadId tid);
 


### PR DESCRIPTION
This change set represents a major set of changes to the crash reporting mechanism. 

1) Coordination involving mandatory timeouts and signals have been changed greatly, to instead use semaphores and to end waiting as soon as possible. 

2) Dumping of unmanaged symbols outside of mono has been made possible. Embedders that want to get information on frames outside of mono-sgen can register the library with an icall. This carefully preserves both privacy (opt-in) and resiliency (can't crash/lose more info when misused).

3) The dumper has moved from a workflow that kills the runtime after a long delay into one that can dump individual threads or the entire runtime in a prompt manner. The runtime doesn't die at the end of the dump, but allows threads to resume what they were doing and returns to the caller. 

4) This has allowed for the addition of a number of tests that stress both parallel and concurrent dumping of threads. These run fairly quickly, and leave the runtime in a state to continue testing. 

5) With this lightweight testing setup created, a long burn-in testing period was done. Places we were using locks or trying to malloc resulted in crashes or hangs. After making the needed changes, it managed to run the dumping tests in a loop for a whole weekend on a Linux x64 configuration without any problems.

This has resulted in a dumper with dramatically improved stability and performance. 