### PR TITLE
[wasm] enable test_0_arm64_dyncall_vtypebyrefonstack

### DIFF
--- a/mono/mini/aot-tests.cs
+++ b/mono/mini/aot-tests.cs
@@ -410,7 +410,6 @@ class Tests
 	}
 
 	[Category ("DYNCALL")]
-	[Category ("!WASM")] //Interp fails
 	public static int test_0_arm64_dyncall_vtypebyrefonstack () {
 		var s = new LargeStruct () { a = 1, b = 2, c = 3, d = 4 };
 


### PR DESCRIPTION
It works on my machine. Test was introduced by https://github.com/mono/mono/pull/10517/