### PR TITLE
Fix one of many race conditions reported by valgrind.

### DIFF
--- a/mono/mini/mini-amd64-gsharedvt.c
+++ b/mono/mini/mini-amd64-gsharedvt.c
@@ -525,6 +525,9 @@ mono_arch_get_gsharedvt_call_info (gpointer addr, MonoMethodSignature *normal_si
 	g_free (caller_cinfo);
 
 	DEBUG_AMD64_GSHAREDVT_PRINT ("allocated an info at %p stack usage %d\n", info, info->stack_usage);
+
+	mono_memory_barrier ();
+
 	return info;
 }
 

--- a/mono/mini/mini-arm-gsharedvt.c
+++ b/mono/mini/mini-arm-gsharedvt.c
@@ -334,6 +334,8 @@ mono_arch_get_gsharedvt_call_info (gpointer addr, MonoMethodSignature *normal_si
 	info->callee_cinfo = callee_cinfo;
 	info->have_fregs = have_fregs;
 
+	mono_memory_barrier ();
+
 	return info;
 }
 

--- a/mono/mini/mini-arm64-gsharedvt.c
+++ b/mono/mini/mini-arm64-gsharedvt.c
@@ -405,6 +405,8 @@ mono_arch_get_gsharedvt_call_info (gpointer addr, MonoMethodSignature *normal_si
 
 	info->stack_usage = ALIGN_TO (info->stack_usage, MONO_ARCH_FRAME_ALIGNMENT);
 
+	mono_memory_barrier ();
+
 	return info;
 }
 

--- a/mono/mini/mini-x86-gsharedvt.c
+++ b/mono/mini/mini-x86-gsharedvt.c
@@ -204,6 +204,8 @@ mono_arch_get_gsharedvt_call_info (gpointer addr, MonoMethodSignature *normal_si
 	g_free (caller_cinfo);
 	g_free (callee_cinfo);
 
+	mono_memory_barrier ();
+
 	return info;
 }
 #endif


### PR DESCRIPTION
Possible data race during read of size 4 at 0xBD2F6EC by thread #7
==74298== Locks held: none
==74298==    at 0x944B6A4: gsharedvt_out_trampoline (in /s/mono/mcs/class/lib/testing_aot_full/mscorlib.dll.so)
==74298==    by 0x9FB1C63: ??? (in /s/mono/mcs/class/lib/testing_aot_full/System.Core.dll.so)
==74298==    by 0x944B69F: gsharedvt_out_trampoline (in /s/mono/mcs/class/lib/testing_aot_full/mscorlib.dll.so)
==74298==    by 0x9FC0765: ??? (in /s/mono/mcs/class/lib/testing_aot_full/System.Core.dll.so)
==74298==    by 0x944B69F: gsharedvt_out_trampoline (in /s/mono/mcs/class/lib/testing_aot_full/mscorlib.dll.so)
==74298==    by 0x9FC5A25: ??? (in /s/mono/mcs/class/lib/testing_aot_full/System.Core.dll.so)
==74298==    by 0x944B69F: gsharedvt_out_trampoline (in /s/mono/mcs/class/lib/testing_aot_full/mscorlib.dll.so)
==74298==    by 0x9FC0765: ??? (in /s/mono/mcs/class/lib/testing_aot_full/System.Core.dll.so)
==74298==    by 0x944B69F: gsharedvt_out_trampoline (in /s/mono/mcs/class/lib/testing_aot_full/mscorlib.dll.so)
==74298==    by 0x9FD0B71: ??? (in /s/mono/mcs/class/lib/testing_aot_full/System.Core.dll.so)
==74298==    by 0x9F67E82: ??? (in /s/mono/mcs/class/lib/testing_aot_full/System.Core.dll.so)
==74298==    by 0x9D3A63C: System_Linq_Parallel_QueryTask_BaseWork_object (in /s/mono/mcs/class/lib/testing_aot_full/System.Core.dll.so)
==74298==
==74298== This conflicts with a previous write of size 4 by thread #5
==74298== Locks held: none
==74298==    at 0x44CCF2: mono_arch_get_gsharedvt_call_info (mini-amd64-gsharedvt.c:424)
