### PR TITLE
[System]: Fix `WebResponseStream.ReadAllAsyncInner()` return value.

### DIFF
--- a/mcs/class/System/System.Net/WebResponseStream.cs
+++ b/mcs/class/System/System.Net/WebResponseStream.cs
@@ -309,7 +309,7 @@ namespace System.Net
 						break;
 					ms.Write (buffer, 0, ret);
 				}
-				return ms.GetBuffer ();
+				return ms.ToArray ();
 			}
 		}
 


### PR DESCRIPTION
We need to call `ToArray()` instead of `GetBuffer()` to truncate the buffer to the amount of bytes that we actually read.
