### PR TITLE
Split up debugprint of gsharedvt get_call_info from start_call.

### DIFF
--- a/mono/mini/tramp-amd64-gsharedvt.c
+++ b/mono/mini/tramp-amd64-gsharedvt.c
@@ -173,14 +173,17 @@ mono_amd64_start_gsharedvt_call (GSharedVtCallInfo *info, gpointer *caller, gpoi
 	if (info->vcall_offset != -1){
 		MonoObject *this_obj = (MonoObject*)caller [0];
 
-		DEBUG_AMD64_GSHAREDVT_PRINT ("%s thread:%p target is a vcall at offset %d\n", __func__, thread, info->vcall_offset / 8);
+		DEBUG_AMD64_GSHAREDVT_PRINT ("%s thread:%p target is a vcall at offset %d this_obj:%p\n", __func__, thread, info->vcall_offset / 8, this_obj);
 		if (G_UNLIKELY (!this_obj))
 			return NULL;
-		if (info->vcall_offset == MONO_GSHAREDVT_DEL_INVOKE_VT_OFFSET)
+		if (info->vcall_offset == MONO_GSHAREDVT_DEL_INVOKE_VT_OFFSET) {
 			/* delegate invoke */
+			DEBUG_AMD64_GSHAREDVT_PRINT ("%s thread:%p target delegate invoke %p\n", __func__, thread, ((MonoDelegate*)this_obj)->invoke_impl);
 			return ((MonoDelegate*)this_obj)->invoke_impl;
-		else
+		} else {
+			DEBUG_AMD64_GSHAREDVT_PRINT ("%s thread:%p target is %p\n", __func__, thread, *(gpointer*)((char*)this_obj->vtable + info->vcall_offset));
 			return *(gpointer*)((char*)this_obj->vtable + info->vcall_offset);
+		}
 	} else if (info->calli) {
 		/* The address to call is passed in the mrgctx reg */
 		return mrgctx_reg;

--- a/mono/utils/mono-logger-internals.h
+++ b/mono/utils/mono-logger-internals.h
@@ -34,6 +34,8 @@ typedef enum {
 	MONO_TRACE_GSHAREDVT_START_CALL = 1 << 19,
 } MonoTraceMask;
 
+G_ENUM_FUNCTIONS (MonoTraceMask)
+
 MONO_API_DATA GLogLevelFlags mono_internal_current_level;
 MONO_API_DATA MonoTraceMask mono_internal_current_mask;
 

--- a/mono/utils/mono-logger-internals.h
+++ b/mono/utils/mono-logger-internals.h
@@ -34,8 +34,6 @@ typedef enum {
 	MONO_TRACE_GSHAREDVT_START_CALL = 1 << 19,
 } MonoTraceMask;
 
-G_ENUM_FUNCTIONS (MonoTraceMask)
-
 MONO_API_DATA GLogLevelFlags mono_internal_current_level;
 MONO_API_DATA MonoTraceMask mono_internal_current_mask;
 

--- a/mono/utils/mono-logger-internals.h
+++ b/mono/utils/mono-logger-internals.h
@@ -30,6 +30,8 @@ typedef enum {
 	MONO_TRACE_IO_LAYER_HANDLE    = 1 << 15,
 	MONO_TRACE_TAILCALL           = 1 << 16,
 	MONO_TRACE_PROFILER           = 1 << 17,
+	MONO_TRACE_GSHAREDVT_GET_CALL_INFO = 1 << 18,
+	MONO_TRACE_GSHAREDVT_START_CALL = 1 << 19,
 } MonoTraceMask;
 
 MONO_API_DATA GLogLevelFlags mono_internal_current_level;

--- a/mono/utils/mono-logger.c
+++ b/mono/utils/mono-logger.c
@@ -312,6 +312,9 @@ mono_trace_set_mask_string (const char *value)
 		{ "w32handle", MONO_TRACE_IO_LAYER_HANDLE },
 		{ "tailcall", MONO_TRACE_TAILCALL },
 		{ "profiler", MONO_TRACE_PROFILER },
+		{ "gsharedvt_get_call_info", MONO_TRACE_GSHAREDVT_GET_CALL_INFO },
+		{ "gsharedvt_start_call", MONO_TRACE_GSHAREDVT_START_CALL },
+		{ "gsharedvt", MONO_TRACE_GSHAREDVT_GET_CALL_INFO | MONO_TRACE_GSHAREDVT_START_CALL },
 		{ "all", (MonoTraceMask)~0 }, // FIXMEcxx there is a better way -- operator overloads of enums
 		{ NULL, (MonoTraceMask)0 },
 	};

--- a/mono/utils/mono-logger.c
+++ b/mono/utils/mono-logger.c
@@ -302,20 +302,20 @@ mono_trace_set_mask_string (const char *value)
 		{ "io-layer-semaphore", MONO_TRACE_IO_LAYER_SEMAPHORE },
 		{ "io-layer-mutex", MONO_TRACE_IO_LAYER_MUTEX },
 		{ "io-layer-handle", MONO_TRACE_IO_LAYER_HANDLE },
-		{ "io-layer", MONO_TRACE_IO_LAYER_PROCESS
+		{ "io-layer", (MonoTraceMask)(MONO_TRACE_IO_LAYER_PROCESS
 		               | MONO_TRACE_IO_LAYER_SOCKET
 		               | MONO_TRACE_IO_LAYER_FILE
 		               | MONO_TRACE_IO_LAYER_EVENT
 		               | MONO_TRACE_IO_LAYER_SEMAPHORE
 		               | MONO_TRACE_IO_LAYER_MUTEX
-		               | MONO_TRACE_IO_LAYER_HANDLE },
+		               | MONO_TRACE_IO_LAYER_HANDLE) },
 		{ "w32handle", MONO_TRACE_IO_LAYER_HANDLE },
 		{ "tailcall", MONO_TRACE_TAILCALL },
 		{ "profiler", MONO_TRACE_PROFILER },
 		{ "gsharedvt_get_call_info", MONO_TRACE_GSHAREDVT_GET_CALL_INFO },
 		{ "gsharedvt_start_call", MONO_TRACE_GSHAREDVT_START_CALL },
 		{ "gsharedvt", MONO_TRACE_GSHAREDVT_GET_CALL_INFO | MONO_TRACE_GSHAREDVT_START_CALL },
-		{ "all", ~(MonoTraceMask)0 },
+		{ "all", (MonoTraceMask)~0 },
 		{ NULL, (MonoTraceMask)0 },
 	};
 

--- a/mono/utils/mono-logger.c
+++ b/mono/utils/mono-logger.c
@@ -282,7 +282,7 @@ mono_trace_set_mask_string (const char *value)
 	const char *tok;
 	guint32 flags = 0;
 
-	static const struct { const char * const flag; const MonoTraceMask mask; } flag_mask_map[] = {
+	static const struct { const char * flag; MonoTraceMask mask; } flag_mask_map[] = {
 		{ "asm", MONO_TRACE_ASSEMBLY },
 		{ "type", MONO_TRACE_TYPE },
 		{ "dll", MONO_TRACE_DLLIMPORT },
@@ -302,20 +302,20 @@ mono_trace_set_mask_string (const char *value)
 		{ "io-layer-semaphore", MONO_TRACE_IO_LAYER_SEMAPHORE },
 		{ "io-layer-mutex", MONO_TRACE_IO_LAYER_MUTEX },
 		{ "io-layer-handle", MONO_TRACE_IO_LAYER_HANDLE },
-		{ "io-layer", (MonoTraceMask)(MONO_TRACE_IO_LAYER_PROCESS
+		{ "io-layer", MONO_TRACE_IO_LAYER_PROCESS
 		               | MONO_TRACE_IO_LAYER_SOCKET
 		               | MONO_TRACE_IO_LAYER_FILE
 		               | MONO_TRACE_IO_LAYER_EVENT
 		               | MONO_TRACE_IO_LAYER_SEMAPHORE
 		               | MONO_TRACE_IO_LAYER_MUTEX
-		               | MONO_TRACE_IO_LAYER_HANDLE) },
+		               | MONO_TRACE_IO_LAYER_HANDLE },
 		{ "w32handle", MONO_TRACE_IO_LAYER_HANDLE },
 		{ "tailcall", MONO_TRACE_TAILCALL },
 		{ "profiler", MONO_TRACE_PROFILER },
 		{ "gsharedvt_get_call_info", MONO_TRACE_GSHAREDVT_GET_CALL_INFO },
 		{ "gsharedvt_start_call", MONO_TRACE_GSHAREDVT_START_CALL },
 		{ "gsharedvt", MONO_TRACE_GSHAREDVT_GET_CALL_INFO | MONO_TRACE_GSHAREDVT_START_CALL },
-		{ "all", (MonoTraceMask)~0 }, // FIXMEcxx there is a better way -- operator overloads of enums
+		{ "all", ~(MonoTraceMask)0 },
 		{ NULL, (MonoTraceMask)0 },
 	};
 

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -597,6 +597,17 @@ void mono_threads_coop_end_global_suspend (void);
 MONO_API MonoNativeThreadId
 mono_native_thread_id_get (void);
 
+static inline gpointer
+mono_native_thread_id_get_ptr (void)
+{
+	// mono_native_thread_id_get is either a pointer,
+	// or a pointer-sized integer,
+	// or a smaller integer.
+	// Normalization to a pointer is useful for printf("%p").
+	// This form should avoid warnings on all platforms.
+	return (gpointer)(gsize)mono_native_thread_id_get ();
+}
+
 MONO_API gboolean
 mono_native_thread_id_equals (MonoNativeThreadId id1, MonoNativeThreadId id2);
 


### PR DESCRIPTION
Add MONO_DEBUG options, besides the ifdefs.
 This is because the runtime with it enabled fails compiling BCL, but is still useful on smaller scenarios.

Add function and thread to the printing -- a failing test is very multi-threaded and the output interleaves.

Enable it on checked builds to ensure it doesn't rot again -- but still guarded by debug options mostly.