### PR TITLE
[2018-08] [System]: Fix `WebResponseStream.ReadAllAsyncInner()` return value.

### DIFF
--- a/mcs/class/System/System.Net/WebResponseStream.cs
+++ b/mcs/class/System/System.Net/WebResponseStream.cs
@@ -309,7 +309,7 @@ namespace System.Net
 						break;
 					ms.Write (buffer, 0, ret);
 				}
-				return ms.GetBuffer ();
+				return ms.ToArray ();
 			}
 		}
 


### PR DESCRIPTION
Backport of #10574.

/cc @marek-safar