### PR TITLE
[2018-06] [arm64] Fix the alignment of valuetypes passed after small primitive types on IOS.

### DIFF
--- a/mono/mini/aot-tests.cs
+++ b/mono/mini/aot-tests.cs
@@ -222,6 +222,24 @@ class Tests
 		return (int)res;
 	}
 
+	struct Struct7 {
+		public string value;
+	}
+
+	class Foo7 {
+		public static string vtypeonstack_align (string s1, string s2, string s3, string s4, string s5, string s6, string s7, string s8, bool b, Struct7 s) {
+			return s.value;
+		}
+	}
+
+	[Category ("DYNCALL")]
+	static int test_0_arm64_ios_dyncall_vtypeonstack_align () {
+		var m = typeof (Foo7).GetMethod ("vtypeonstack_align");
+
+		string s = (string)m.Invoke (null, new object [] { null, null, null, null, null, null, null, null, true, new Struct7 () { value = "ABC" } });
+		return s == "ABC" ? 0 : 1;
+	}
+
 	class Foo6 {
 		public T reg_stack_split_inner<T> (int i, int j, T l) {
 			return l;

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -1196,6 +1196,7 @@ add_valuetype (CallInfo *cinfo, ArgInfo *ainfo, MonoType *t)
 			cinfo->fr = FP_PARAM_REGS;
 			size = ALIGN_TO (size, 8);
 			ainfo->storage = ArgVtypeOnStack;
+			cinfo->stack_usage = ALIGN_TO (cinfo->stack_usage, align);
 			ainfo->offset = cinfo->stack_usage;
 			ainfo->size = size;
 			ainfo->hfa = TRUE;
@@ -1215,6 +1216,7 @@ add_valuetype (CallInfo *cinfo, ArgInfo *ainfo, MonoType *t)
 	if (cinfo->gr + nregs > PARAM_REGS) {
 		size = ALIGN_TO (size, 8);
 		ainfo->storage = ArgVtypeOnStack;
+		cinfo->stack_usage = ALIGN_TO (cinfo->stack_usage, align);
 		ainfo->offset = cinfo->stack_usage;
 		ainfo->size = size;
 		cinfo->stack_usage += size;


### PR DESCRIPTION
Backport of #10525.

/cc @marek-safar