### PR TITLE
[System]: Make sure `HttpWebRequest` observes exceptions on timeout.  #10488.

### DIFF
--- a/mcs/class/System/System.Net/HttpWebRequest.cs
+++ b/mcs/class/System/System.Net/HttpWebRequest.cs
@@ -949,7 +949,7 @@ namespace System.Net
 #pragma warning disable 4014
 				// Make sure the workerTask's Exception is actually observed.
 				// Fixes https://github.com/mono/mono/issues/10488.
-				workerTask.ContinueWith (t => t.Exception?.GetHashCode ());
+				workerTask.ContinueWith (t => t.Exception?.GetHashCode (), TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.OnlyOnCanceled);
 #pragma warning restore 4014
 				throw new WebException (SR.net_timeout, WebExceptionStatus.Timeout);
 			} catch (Exception ex) {

--- a/mcs/class/System/System.Net/HttpWebRequest.cs
+++ b/mcs/class/System/System.Net/HttpWebRequest.cs
@@ -946,6 +946,11 @@ namespace System.Net
 				} catch {
 					// Ignore; we report the timeout.
 				}
+#pragma warning disable 4014
+				// Make sure the workerTask's Exception is actually observed.
+				// Fixes https://github.com/mono/mono/issues/10488.
+				workerTask.ContinueWith (t => t.Exception?.GetHashCode ());
+#pragma warning restore 4014
 				throw new WebException (SR.net_timeout, WebExceptionStatus.Timeout);
 			} catch (Exception ex) {
 				throw GetWebException (ex, aborted ());

--- a/mcs/class/System/System.Net/HttpWebRequest.cs
+++ b/mcs/class/System/System.Net/HttpWebRequest.cs
@@ -949,7 +949,7 @@ namespace System.Net
 #pragma warning disable 4014
 				// Make sure the workerTask's Exception is actually observed.
 				// Fixes https://github.com/mono/mono/issues/10488.
-				workerTask.ContinueWith (t => t.Exception?.GetHashCode (), TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.OnlyOnCanceled);
+				workerTask.ContinueWith (t => t.Exception?.GetHashCode (), TaskContinuationOptions.OnlyOnFaulted);
 #pragma warning restore 4014
 				throw new WebException (SR.net_timeout, WebExceptionStatus.Timeout);
 			} catch (Exception ex) {


### PR DESCRIPTION
`HttpWebRequest.RunWithTimeoutWorker()` needs to observe the worker task's exception
on timeout to prevent it from being thrown via the `TaskScheduler.UnobservedTaskException`
event.  Fixes #10488.