### PR TITLE
[2018-06] [runtime] Fix Marshal.SizeOf (typeof (void)).

### DIFF
--- a/mcs/class/corlib/Test/System.Runtime.InteropServices/MarshalTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.InteropServices/MarshalTest.cs
@@ -121,6 +121,13 @@ namespace MonoTests.System.Runtime.InteropServices
 		}
 
 		[Test]
+		public unsafe void Sizeof_Void ()
+		{
+			int size = Marshal.SizeOf (typeof (void));
+			Assert.AreEqual (1, size);
+		}
+
+		[Test]
 		public void PtrToStringWithNull ()
 		{
 			Assert.IsNull (Marshal.PtrToStringAnsi (IntPtr.Zero), "A");

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -5111,6 +5111,8 @@ ves_icall_System_Runtime_InteropServices_Marshal_SizeOf (MonoReflectionTypeHandl
 
 	if (type->type == MONO_TYPE_PTR || type->type == MONO_TYPE_FNPTR) {
 		return sizeof (gpointer);
+	} else if (type->type == MONO_TYPE_VOID) {
+		return 1;
 	} else if (layout == TYPE_ATTRIBUTE_AUTO_LAYOUT) {
 		mono_error_set_argument (error, "t", "Type %s cannot be marshaled as an unmanaged structure.", m_class_get_name (klass));
 		return 0;


### PR DESCRIPTION
Backport of #10599.

/cc @lambdageek