### PR TITLE
[Reflection] Use a type of actual argument in case when custom attribute ctor parameter is of System.Object type

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection/CustomAttributeDataTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/CustomAttributeDataTest.cs
@@ -36,9 +36,23 @@ using System.Runtime.InteropServices;
 
 namespace MonoTests.System.Reflection
 {
+	enum Levels { one, two, three }
+
 	class Attr : Attribute {
 		public Attr (byte[] arr) {
 		}
+	}
+
+	[AttributeUsage (AttributeTargets.Method)]
+	class TestAttrWithObjectCtorParam : Attribute {
+		object o;
+		public TestAttrWithObjectCtorParam (object o) => this.o = o;
+	}
+
+	[AttributeUsage (AttributeTargets.Method)]
+	class TestAttrWithEnumCtorParam : Attribute {
+		Levels level;
+		public TestAttrWithEnumCtorParam (Levels level) => this.level = level;
 	}
 
 	[TestFixture]
@@ -53,6 +67,16 @@ namespace MonoTests.System.Reflection
 
 		[Attr (new byte [] { 1, 2 })]
 		public void MethodWithAttr () {
+		}
+
+		[TestAttrWithObjectCtorParam (Levels.two)]
+		public void MethodDecoratedWithAttribute1 ()
+		{
+		}
+
+		[TestAttrWithEnumCtorParam (Levels.two)]
+		public void MethodDecoratedWithAttribute2 ()
+		{
 		}
 
 		public void MethodWithParamDecoratedWithPseudoCustomAttributes ([Optional, In, Out, MarshalAs (UnmanagedType.LPStr)] String s)
@@ -153,6 +177,33 @@ namespace MonoTests.System.Reflection
 
 			Assert.AreEqual (typeof (DllImportAttribute), dllImportAttributeData.AttributeType);
 			Assert.AreEqual ("libc", ctorArg.Value);
+		}
+
+		[Test]
+		// https://github.com/mono/mono/issues/10555
+		public void CustomAttributeCtor_TakesEnumArg ()
+		{
+			var method = GetMethod (nameof (MethodDecoratedWithAttribute1));
+			var data = method.CustomAttributes;
+			var ctorArg = data.First ().ConstructorArguments [0];
+
+			Assert.AreEqual (typeof (Levels), ctorArg.ArgumentType);
+			Assert.AreEqual (1, ctorArg.Value);
+			Assert.AreEqual (typeof (int), ctorArg.Value.GetType ());
+
+			method = GetMethod (nameof (MethodDecoratedWithAttribute2));
+			data = method.CustomAttributes;
+			ctorArg = data.First ().ConstructorArguments [0];
+
+			Assert.AreEqual (typeof (Levels), ctorArg.ArgumentType);
+			Assert.AreEqual (1, ctorArg.Value);
+			Assert.AreEqual (typeof (int), ctorArg.Value.GetType ());			
+		}
+
+		private MethodInfo GetMethod (string methodName)
+		{
+			var mi = typeof (CustomAttributeDataTest).FindMembers (MemberTypes.Method, BindingFlags.Instance | BindingFlags.Public, (m, criteria) => m.Name == methodName, null);
+			return (MethodInfo)(mi [0]);
 		}
 	}
 }

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -1332,8 +1332,13 @@ reflection_resolve_custom_attribute_data (MonoReflectionMethod *ref_method, Mono
 	for (i = 0; i < mono_method_signature (method)->param_count; ++i) {
 		MonoObject *obj = mono_array_get (typedargs, MonoObject*, i);
 		MonoObject *typedarg;
+		MonoType *t;
 
-		typedarg = create_cattr_typed_arg (mono_method_signature (method)->params [i], obj, error);
+		t = mono_method_signature (method)->params [i];
+		if (t->type == MONO_TYPE_OBJECT && obj)
+			t = m_class_get_byval_arg (obj->vtable->klass);
+		typedarg = create_cattr_typed_arg (t, obj, error);
+
 		goto_if_nok (error, leave);
 		mono_array_setref (typedargs, i, typedarg);
 	}


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/10555