### PR TITLE
Garbage Collect assemblies on domain unload

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -1393,10 +1393,10 @@ add_assemblies_to_domain (MonoDomain *domain, MonoAssembly *ass, GHashTable *ht)
 	/* FIXME: handle lazy loaded assemblies */
 
 	if (!g_hash_table_lookup (ht, ass)) {
-		mono_assembly_addref (ass);
+		mono_assembly_addref (ass, TRUE);
 		g_hash_table_insert (ht, ass, ass);
 		domain->domain_assemblies = g_slist_append (domain->domain_assemblies, ass);
-		mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Assembly %s[%p] added to domain %s, ref_count=%d", ass->aname.name, ass, domain->friendly_name, ass->ref_count);
+		mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Assembly %s[%p] added to domain %s, ref_count=%d, pin_count=%d", ass->aname.name, ass, domain->friendly_name, m_assembly_get_ref_count (ass), m_assembly_get_pin_count (ass));
 	}
 
 	if (ass->image->references) {

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -1393,7 +1393,7 @@ add_assemblies_to_domain (MonoDomain *domain, MonoAssembly *ass, GHashTable *ht)
 	/* FIXME: handle lazy loaded assemblies */
 
 	if (!g_hash_table_lookup (ht, ass)) {
-		mono_assembly_addref (ass, TRUE);
+		mono_assembly_addref_pin (ass);
 		g_hash_table_insert (ht, ass, ass);
 		domain->domain_assemblies = g_slist_append (domain->domain_assemblies, ass);
 		mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Assembly %s[%p] added to domain %s, ref_count=%d, pin_count=%d", ass->aname.name, ass, domain->friendly_name, m_assembly_get_ref_count (ass), m_assembly_get_pin_count (ass));

--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -31,6 +31,7 @@ typedef enum {
 	MONO_ANAME_EQ_MASK = 0x7
 } MonoAssemblyNameEqFlags;
 
+
 void
 mono_assembly_name_free_internal (MonoAssemblyName *aname);
 
@@ -114,5 +115,21 @@ mono_assembly_get_name_internal (MonoAssembly *assembly);
 
 MONO_PROFILER_API MonoImage*
 mono_assembly_get_image_internal (MonoAssembly *assembly);
+
+MONO_PROFILER_API void
+mono_assembly_close_internal (MonoAssembly *assembly, mono_bool drop_pinning);
+
+void
+mono_assembly_collect_unreachable (void);
+
+static inline
+gint32 m_assembly_get_ref_count (MonoAssembly *assembly) {
+	return (gint32)assembly->ref_count;
+}
+
+static inline
+gint32 m_assembly_get_pin_count (MonoAssembly *assembly) {
+	return assembly->pin_count;
+}
 
 #endif /* __MONO_METADATA_ASSEMBLY_INTERNALS_H__ */

--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -60,6 +60,11 @@ typedef struct MonoAssemblyLoadRequest {
 	MonoAssemblyCandidatePredicate predicate;
 	/* user_data for predicate. Optional. */
 	gpointer predicate_ud;
+	/* If TRUE, increment the pin_count of the returned assembly.  Caller
+	 * is responsible for decrementing.  FALSE is the backward-compatible
+	 * behavior; new callers should pass TRUE if possible.
+	 */
+	gboolean want_pinned;
 } MonoAssemblyLoadRequest;
 
 typedef struct MonoAssemblyOpenRequest {

--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -122,7 +122,10 @@ MONO_PROFILER_API MonoImage*
 mono_assembly_get_image_internal (MonoAssembly *assembly);
 
 MONO_PROFILER_API void
-mono_assembly_close_internal (MonoAssembly *assembly, mono_bool drop_pinning);
+mono_assembly_close_unpin (MonoAssembly *assembly);
+
+void
+mono_assembly_close_nounpin (MonoAssembly *assembly);
 
 void
 mono_assembly_collect_unreachable (void);

--- a/mono/metadata/assembly.h
+++ b/mono/metadata/assembly.h
@@ -45,7 +45,7 @@ MONO_API void          mono_assembly_get_assemblyref (MonoImage *image, int inde
 MONO_API void          mono_assembly_load_reference (MonoImage *image, int index);
 MONO_API void          mono_assembly_load_references (MonoImage *image, MonoImageOpenStatus *status);
 MONO_API MONO_RT_EXTERNAL_ONLY MonoImage*    mono_assembly_load_module (MonoAssembly *assembly, uint32_t idx);
-MONO_API void          mono_assembly_close      (MonoAssembly *assembly);
+MONO_API MONO_RT_EXTERNAL_ONLY void          mono_assembly_close      (MonoAssembly *assembly);
 MONO_API void          mono_assembly_setrootdir (const char *root_dir);
 MONO_API MONO_CONST_RETURN char *mono_assembly_getrootdir (void);
 MONO_API char         *mono_native_getrootdir (void);

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -647,4 +647,10 @@ mono_assembly_has_reference_assembly_attribute (MonoAssembly *assembly, MonoErro
 GPtrArray*
 mono_domain_get_assemblies (MonoDomain *domain, gboolean refonly);
 
+/* Passed by the assembly collector to mono_assembly_collect_mark_exe_image */
+typedef void (*MonoAssemblyGCImageMarkFunc)(MonoImage *, gpointer user_data);
+
+void
+mono_assembly_collect_mark_exe_image (MonoAssemblyGCImageMarkFunc func, gpointer user_data);
+
 #endif /* __MONO_METADATA_DOMAIN_INTERNALS_H__ */

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -2118,7 +2118,7 @@ mono_image_close_except_pools (MonoImage *image)
 	if (image->references && !image_is_dynamic (image)) {
 		for (i = 0; i < image->nreferences; i++) {
 			if (image->references [i] && image->references [i] != REFERENCE_MISSING) {
-				if (!mono_assembly_close_except_image_pools (image->references [i]))
+				if (!mono_assembly_close_except_image_pools (image->references [i], FALSE))
 					image->references [i] = NULL;
 			}
 		}

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -906,7 +906,9 @@ gboolean
 mono_metadata_generic_param_equal (MonoGenericParam *p1, MonoGenericParam *p2);
 
 void mono_dynamic_stream_reset  (MonoDynamicStream* stream);
-MONO_API void mono_assembly_addref       (MonoAssembly *assembly, gboolean pinning);
+MONO_API MONO_RT_EXTERNAL_ONLY void mono_assembly_addref       (MonoAssembly *assembly);
+MONO_PROFILER_API void mono_assembly_addref_pin (MonoAssembly *assembly);
+void mono_assembly_addref_nopin (MonoAssembly *assembly);
 void mono_assembly_load_friends (MonoAssembly* ass);
 gboolean mono_assembly_has_skip_verification (MonoAssembly* ass);
 

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -1321,6 +1321,7 @@ mono_reflection_dynimage_basic_init (MonoReflectionAssemblyBuilder *assemblyb)
 	MONO_PROFILER_RAISE (assembly_loading, (&assembly->assembly));
 	
 	assembly->assembly.ref_count = 1;
+	assembly->assembly.pin_count = 1; /* Added to domain, below */
 	assembly->assembly.dynamic = TRUE;
 	assembly->assembly.corlib_internal = assemblyb->corlib_internal;
 	assemblyb->assembly.assembly = (MonoAssembly*)assembly;

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -314,8 +314,11 @@ move_subclasses_not_in_image_foreach_func (MonoClass *klass, MonoClass *subclass
 		   we're removing an image containing a class which
 		   still has a subclass in another image. */
 
+		/* If the image is corlib, the subclasses may be from other
+		 * assemblies since corlib is unloaded last. */
+
 		while (subclass) {
-			g_assert (m_class_get_image (subclass) == image);
+			g_assert (image == mono_defaults.corlib || m_class_get_image (subclass) == image);
 			subclass = class_lookup_rgctx_template (subclass)->next_subclass;
 		}
 

--- a/mono/profiler/coverage.c
+++ b/mono/profiler/coverage.c
@@ -570,7 +570,7 @@ register_image (MonoImage *image)
 		 * otherwise they might be gone by the time we dump coverage data
 		 * during shutdown. This can happen with e.g. the corlib test suite.
 		 */
-		mono_assembly_addref (assembly, TRUE);
+		mono_assembly_addref_pin (assembly);
 
 		mono_conc_hashtable_insert (coverage_profiler.assemblies, assembly, assembly);
 	}
@@ -642,7 +642,7 @@ assembly_loaded (MonoProfiler *prof, MonoAssembly *assembly)
 		 * runtime initialization has finished and processing them when we get
 		 * the runtime_initialized callback.
 		 */
-		mono_assembly_addref (assembly, TRUE);
+		mono_assembly_addref_pin (assembly);
 		g_hash_table_insert (coverage_profiler.deferred_assemblies, assembly, assembly);
 		return;
 	}
@@ -682,7 +682,7 @@ process_deferred_assembly (gpointer key, gpointer value, gpointer userdata)
 	MonoAssembly *assembly = key;
 
 	assembly_loaded ((MonoProfiler *) userdata, assembly);
-	mono_assembly_close_internal (assembly, TRUE);
+	mono_assembly_close_unpin (assembly);
 }
 
 static gboolean
@@ -844,7 +844,7 @@ static void
 unref_coverage_assemblies (gpointer key, gpointer value, gpointer userdata)
 {
 	MonoAssembly *assembly = (MonoAssembly *)value;
-	mono_assembly_close_internal (assembly, TRUE);
+	mono_assembly_close_unpin (assembly);
 }
 
 static void

--- a/mono/profiler/coverage.c
+++ b/mono/profiler/coverage.c
@@ -570,7 +570,7 @@ register_image (MonoImage *image)
 		 * otherwise they might be gone by the time we dump coverage data
 		 * during shutdown. This can happen with e.g. the corlib test suite.
 		 */
-		mono_assembly_addref (assembly);
+		mono_assembly_addref (assembly, TRUE);
 
 		mono_conc_hashtable_insert (coverage_profiler.assemblies, assembly, assembly);
 	}
@@ -642,7 +642,7 @@ assembly_loaded (MonoProfiler *prof, MonoAssembly *assembly)
 		 * runtime initialization has finished and processing them when we get
 		 * the runtime_initialized callback.
 		 */
-		mono_assembly_addref (assembly);
+		mono_assembly_addref (assembly, TRUE);
 		g_hash_table_insert (coverage_profiler.deferred_assemblies, assembly, assembly);
 		return;
 	}
@@ -682,7 +682,7 @@ process_deferred_assembly (gpointer key, gpointer value, gpointer userdata)
 	MonoAssembly *assembly = key;
 
 	assembly_loaded ((MonoProfiler *) userdata, assembly);
-	mono_assembly_close (assembly);
+	mono_assembly_close_internal (assembly, TRUE);
 }
 
 static gboolean
@@ -844,7 +844,7 @@ static void
 unref_coverage_assemblies (gpointer key, gpointer value, gpointer userdata)
 {
 	MonoAssembly *assembly = (MonoAssembly *)value;
-	mono_assembly_close (assembly);
+	mono_assembly_close_internal (assembly, TRUE);
 }
 
 static void


### PR DESCRIPTION
This fixes #9658 - cyclic references among assemblies are not properly counted and assemblies are not unloaded at domain unload or app shutdown.

----

## Introducing a pin count ##

In `metadata-internals.h` a comment says:
> The number of appdomains which have this assembly loaded plus the number of 
> assemblies referencing this assembly through an entry in their `image->references`
> arrays. The latter is needed because entries in the `image->references` array
> might point to assemblies which are only loaded in some appdomains, and without
> the additional reference, they can be freed at any time.
> The `ref_count` is initially 0.

Note that this is broken for assemblies with cyclic references which
will never be unloaded even if every domain that referenced them is
unloaded.

To fix that, we keep a second `pin_count` which excludes image
references, but includes domain references.

The invariant is that `pin_count <= ref_count`.
* If `pin_count > 0`, we cannot free the assembly.
* If the `pin_count == 0`, the assembly may be garbage:
    - if `ref_count == 0` the assembly actually is garbage and we can free it eagerly.
    - if `ref_count > 0` we don't know if it's reachable or if it's part of a cycle.

We periodically (at domain unload) run a tracing GC that attempt to
free the cycles.


**WONTFIX**: There is a problem here for embedders: `mono_assembly_open()` and
other APIs that don't reference a domain will hand back assemblies
without incrementing their refcounts.  So once we start running a GC
on domain unload, the assembly will go away.  This was already a
problem, however, for embedders if there were multiple threads and
one of them called `mono_assembly_close()` that was open in both.

### Pre-pinning assemblies for the runtime ### 

There is a race here for Mono: If one thread tries to
open an assembly while another is running the GC, the fresh assembly
will be added to loaded_assemblies before its pinning count could be
incremented.  that means the GC may consider it garbage since it
hasn't been added to a domain or an `image->references` yet.  We add a flag on assembly open
asking to pre-pin the fresh assembly and then to transfer the pin to the image
or the domain (or drop it if two threads race to open and one
loses).

---

## GC Implementation ##

It's a mark-sweep collector.  We keep a `gc_mark` bit in `MonoAssembly` to indicate that the marking phase has seen an assembly.

We use a queue for assemblies that have been marked as reachable from the roots, but whose references haven't been scanned yet.

The roots are elements of `loaded_assemblies` with `pin_count > 0`.

After we're done marking, we collect all assemblies that haven't been marked into a free list.

An issue is that `mono_assembly_close_except_pools` would call `mono_image_close_except_pools` which recursively closes the referenced assemblies.  We don't want that - the free list is not in dependency order, so if references are recursively closed when they're in the free list, we may see the same `MonoAssembly*` after it has already been freed.

So instead we do two passes.

First pass. For each assembly in the free list we:
- remove it from `loaded_assemblies`
- decrement the refcount of each referenced assembly without closing it
- set all references to NULL, breaking links between assemblies.

Second pass.  Force-close each assembly in the free list.

---

## Add `exe_image` as a GC root

Problem: Mono keeps a reference to the main executable assembly in `exe_image` and calls `mono_image_close` on it at shutdown.

This happens after we already GC the root domain, so the `MonoAssembly` for the `MonoImage` exe image already went away.  And so did the references.  Because as far as the `MonoAssembly` was concerned it has a single pin - from the root domain.

So we add `exe_image` as an additional scannable root, and make sure to run another GC in `mono_close_exe_image`

---

## Problems ##

1.  I don't understand `coree.c` and it seems to be doing stuff with `exe_image`.  I guess Windows might break in some way.

2. It feels slow.   Corlib test seemed like it took noticeably longer than without GC.  This could just be because nunit is an aggressive (ab)user of domains.
