### PR TITLE
[2018-08] Fix MonoTests.System.Linq.ParallelEnumerableTests.TestGroupBy (Linux/amd64/FullAOT/LLVM).

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -2155,6 +2155,9 @@ static void
 arch_emit_unbox_trampoline (MonoAotCompile *acfg, MonoCompile *cfg, MonoMethod *method, const char *call_target)
 {
 #if defined(TARGET_AMD64)
+
+	// See mono_aot_get_unbox_trampoline.
+
 	guint8 buf [32];
 	guint8 *code;
 	int this_reg;

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -2150,14 +2150,13 @@ arch_emit_specific_trampoline (MonoAotCompile *acfg, int offset, int *tramp_size
  *
  *   Emit code for the unbox trampoline for METHOD used in the full-aot case.
  * CALL_TARGET is the symbol pointing to the native code of METHOD.
+ *
+ * See mono_aot_get_unbox_trampoline.
  */
 static void
 arch_emit_unbox_trampoline (MonoAotCompile *acfg, MonoCompile *cfg, MonoMethod *method, const char *call_target)
 {
 #if defined(TARGET_AMD64)
-
-	// See mono_aot_get_unbox_trampoline.
-
 	guint8 buf [32];
 	guint8 *code;
 	int this_reg;
@@ -9194,10 +9193,7 @@ static void
 emit_code (MonoAotCompile *acfg)
 {
 	int oindex, i, prev_index;
-#ifndef TARGET_AMD64
-	// See mono_aot_get_unbox_trampoline.
-	gboolean saved_unbox_info = FALSE;
-#endif
+	gboolean saved_unbox_info = FALSE; // See mono_aot_get_unbox_trampoline.
 	char symbol [MAX_SYMBOL_SIZE];
 
 	if (acfg->aot_opts.llvm_only)
@@ -9298,7 +9294,6 @@ emit_code (MonoAotCompile *acfg)
 			if (acfg->thumb_mixed && cfg->compile_llvm)
 				emit_set_arm_mode (acfg);
 
-#ifndef TARGET_AMD64
 			if (!saved_unbox_info) {
 				char user_symbol [128];
 				GSList *unwind_ops;
@@ -9311,11 +9306,17 @@ emit_code (MonoAotCompile *acfg)
 				mono_free_unwind_info (unwind_ops);
 
 				/* Save the unbox trampoline size */
+#ifdef TARGET_AMD64
+				// LLVM unbox trampolines vary in size, 6 or 9 bytes,
+				// due to the last instruction being 2 or 5 bytes.
+				// There is no need to describe interior bytes of instructions
+				// however, so state the size as if the last instruction is size 1.
+				emit_int32 (acfg, 5);
+#else
 				emit_symbol_diff (acfg, "ut_end", symbol, 0);
-
+#endif
 				saved_unbox_info = TRUE;
 			}
-#endif
 		}
 
 		if (cfg->compile_llvm) {

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -9194,7 +9194,10 @@ static void
 emit_code (MonoAotCompile *acfg)
 {
 	int oindex, i, prev_index;
+#ifndef TARGET_AMD64
+	// See mono_aot_get_unbox_trampoline.
 	gboolean saved_unbox_info = FALSE;
+#endif
 	char symbol [MAX_SYMBOL_SIZE];
 
 	if (acfg->aot_opts.llvm_only)
@@ -9295,6 +9298,7 @@ emit_code (MonoAotCompile *acfg)
 			if (acfg->thumb_mixed && cfg->compile_llvm)
 				emit_set_arm_mode (acfg);
 
+#ifndef TARGET_AMD64
 			if (!saved_unbox_info) {
 				char user_symbol [128];
 				GSList *unwind_ops;
@@ -9311,6 +9315,7 @@ emit_code (MonoAotCompile *acfg)
 
 				saved_unbox_info = TRUE;
 			}
+#endif
 		}
 
 		if (cfg->compile_llvm) {

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -5384,6 +5384,8 @@ mono_aot_get_trampoline (const char *name)
 	return code;
 }
 
+#if defined (MONOTOUCH) || !defined (HOST_AMD64)
+
 static gpointer
 read_unwind_info (MonoAotModule *amodule, MonoTrampInfo *info, const char *symbol_name)
 {
@@ -5409,6 +5411,8 @@ read_unwind_info (MonoAotModule *amodule, MonoTrampInfo *info, const char *symbo
 	/* If successful return the address of the following data */
 	return (guint32*)symbol_addr + 1;
 }
+
+#endif
 
 #ifdef MONOTOUCH
 #include <mach/mach.h>
@@ -5747,35 +5751,6 @@ mono_aot_get_static_rgctx_trampoline (gpointer ctx, gpointer addr)
 	return mono_create_ftnptr (mono_domain_get (), code);
 }
 
-#ifdef HOST_AMD64
-
-static guint
-mono_amd64_get_unbox_trampoline_size (gpointer code, guint candidate_code_size)
-{
-	// Assembler will encode this with an 8 or 32bit displacement, varying per thunk.
-	// FIXME Ideally we would not read code bytes -- cannot
-	// set a breakpoint here or have execute-only pages.
-
-	guint8 const * const p = (guint8 const*)code;
-	guint8 const modrm = p [2];
-	g_assert ((p [0] & 0x4F) == 0x48); 	// rex byte with 64bit override
-	g_assert (p [1] == 0x83); 		// add
-#ifdef HOST_WIN32
-	g_assert (modrm == 0xC1);		// rcx
-#else
-	g_assert (modrm == 0xC7);		// rdi
-#endif
-	g_assert (p [3] == sizeof (MonoObject));
-
-	guint8 const branch = p [4];
-
-	g_assert ((branch == 0xE9 || branch == 0xEB)
-		&& (candidate_code_size == 6 || candidate_code_size == 9));
-	return (branch == 0xE9) ? 9 : 6;
-}
-
-#endif
-
 gpointer
 mono_aot_get_unbox_trampoline (MonoMethod *method)
 {
@@ -5785,7 +5760,6 @@ mono_aot_get_unbox_trampoline (MonoMethod *method)
 	gpointer code;
 	guint32 *ut, *ut_end, *entry;
 	int low, high, entry_index = 0;
-	gpointer symbol_addr;
 	MonoTrampInfo *tinfo;
 
 	if (method->is_inflated && !mono_method_is_generic_sharable_full (method, FALSE, FALSE, FALSE)) {
@@ -5839,21 +5813,51 @@ mono_aot_get_unbox_trampoline (MonoMethod *method)
 
 	tinfo = mono_tramp_info_create (NULL, (guint8 *)code, 0, NULL, NULL);
 
-	// First trampoline's size is indicated by unbox_trampoline_p,
-	// and all trampolines are presumed to be the same size.
-	// FIXME Get the size of each trampoline from unwind info?
-
-	symbol_addr = read_unwind_info (amodule, tinfo, "unbox_trampoline_p");
+#ifdef HOST_AMD64
+	// Unbox trampoline size is tricky. See arch_emit_unbox_trampoline.
+	//
+	// For most architectures, the first unbox trampoline gets extra data so runtime
+	// can read its size. All unbox trampolines are presumed to be the same size.
+	// In the LLVM/x86 case, the jmp might be 2 bytes (0xEB) or 5 bytes (0xE9),
+	// the trampoline 6 or 9 bytes (the first instruction is 4 bytes).
+	//
+	// An exact size is not required. What is required is to cover the
+	// executed bytes, or at least the first instruction, or at least the
+	// instruction starts, and esp. not to overlap the following function.
+	//
+	// Overlapping the following function can be fatal, such
+	// as when it is gsharedvt and we need to find it and wrap it. It happened.
+	//
+	// Therefore, hardcode size as 5.
+	// There is no need to describe the interior bytes of instructions
+	// and the last instruction starts at offset 5.
+	//
+	// Alternatives include forcing the assembler to output 0xE9, if that is possible.
+	//   GNU as supports jmp.d32, Apple as nothing known.
+	//
+	// Or runtime disassembling of the thunk, very possible, but precludes
+	//   breakpoints and execute-only pages.
+	//
+	// Or having the assembler generate the size of every thunk, or even the entire TrampInfo.
+	//
+	// Or padding out with 3 bytes to a minimum size of 9 -- really the same as 5 or 6 though.
+	//    Rip cannot be in the padding just as well as it cannot be in the middle
+	//    of the last instruction.
+	//
+	// Or maybe alignment.
+	//
+	// Really these table entries are probably not needed at all.
+	// Stack walk through leaf function does not require metadata.
+	// Return address can be correctly assumed to be at *rsp.
+	tinfo->code_size = 5;
+#else
+	gpointer const symbol_addr = read_unwind_info (amodule, tinfo, "unbox_trampoline_p");
 	if (!symbol_addr) {
 		mono_tramp_info_free (tinfo);
 		return FALSE;
 	}
 
-	guint32 const code_size = *(guint32*)symbol_addr;
-#ifdef HOST_AMD64
-	tinfo->code_size = mono_amd64_get_unbox_trampoline_size (code, code_size);
-#else
-	tinfo->code_size = code_size;
+	tinfo->code_size = *(guint32*)symbol_addr;
 #endif
 	mono_aot_tramp_info_register (tinfo, NULL);
 

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -5810,13 +5810,43 @@ mono_aot_get_unbox_trampoline (MonoMethod *method)
 
 	tinfo = mono_tramp_info_create (NULL, (guint8 *)code, 0, NULL, NULL);
 
+	// First trampoline's size is indicated by unbox_trampoline_p,
+	// and all trampolines are presumed to be the same size.
+	// FIXME Get the size of each trampoline from unwind info?
+
 	symbol_addr = read_unwind_info (amodule, tinfo, "unbox_trampoline_p");
 	if (!symbol_addr) {
 		mono_tramp_info_free (tinfo);
 		return FALSE;
 	}
 
-	tinfo->code_size = *(guint32*)symbol_addr;
+	guint32 const code_size = *(guint32*)symbol_addr;
+	tinfo->code_size = code_size;
+
+#ifdef HOST_AMD64
+
+	// Assembler will encode this with an 8 or 32bit displacement, varying per thunk.
+	// FIXME Ideally we would not read code bytes -- cannot
+	// set a breakpoint here or have execute-only pages.
+
+	guint8 const * const p = (guint8 const*)code;
+	guint8 const modrm = p [2];
+	g_assert ((p [0] & 0x4F) == 0x48); 	// rex byte with 64bit override
+	g_assert (p [1] == 0x83); 		// add
+#ifdef HOST_WIN32
+	g_assert (modrm == 0xC1);		// rcx
+#else
+	g_assert (modrm == 0xC7);		// rdi
+#endif
+	g_assert (p [3] == MONO_ABI_SIZEOF (MonoObject));
+
+	guint8 const branch = p [4];
+
+	g_assert ((branch == 0xE9 || branch == 0xEB)
+		&& (code_size == 6 || code_size == 9));
+	tinfo->code_size = (branch == 0xE9) ? 9 : 6;
+#endif
+
 	mono_aot_tramp_info_register (tinfo, NULL);
 
 	/* The caller expects an ftnptr */

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -5384,8 +5384,6 @@ mono_aot_get_trampoline (const char *name)
 	return code;
 }
 
-#if defined (MONOTOUCH) || !defined (HOST_AMD64)
-
 static gpointer
 read_unwind_info (MonoAotModule *amodule, MonoTrampInfo *info, const char *symbol_name)
 {
@@ -5411,8 +5409,6 @@ read_unwind_info (MonoAotModule *amodule, MonoTrampInfo *info, const char *symbo
 	/* If successful return the address of the following data */
 	return (guint32*)symbol_addr + 1;
 }
-
-#endif
 
 #ifdef MONOTOUCH
 #include <mach/mach.h>
@@ -5813,44 +5809,6 @@ mono_aot_get_unbox_trampoline (MonoMethod *method)
 
 	tinfo = mono_tramp_info_create (NULL, (guint8 *)code, 0, NULL, NULL);
 
-#ifdef HOST_AMD64
-	// Unbox trampoline size is tricky. See arch_emit_unbox_trampoline.
-	//
-	// For most architectures, the first unbox trampoline gets extra data so runtime
-	// can read its size. All unbox trampolines are presumed to be the same size.
-	// In the LLVM/x86 case, the jmp might be 2 bytes (0xEB) or 5 bytes (0xE9),
-	// the trampoline 6 or 9 bytes (the first instruction is 4 bytes).
-	//
-	// An exact size is not required. What is required is to cover the
-	// executed bytes, or at least the first instruction, or at least the
-	// instruction starts, and esp. not to overlap the following function.
-	//
-	// Overlapping the following function can be fatal, such
-	// as when it is gsharedvt and we need to find it and wrap it. It happened.
-	//
-	// Therefore, hardcode size as 5.
-	// There is no need to describe the interior bytes of instructions
-	// and the last instruction starts at offset 5.
-	//
-	// Alternatives include forcing the assembler to output 0xE9, if that is possible.
-	//   GNU as supports jmp.d32, Apple as nothing known.
-	//
-	// Or runtime disassembling of the thunk, very possible, but precludes
-	//   breakpoints and execute-only pages.
-	//
-	// Or having the assembler generate the size of every thunk, or even the entire TrampInfo.
-	//
-	// Or padding out with 3 bytes to a minimum size of 9 -- really the same as 5 or 6 though.
-	//    Rip cannot be in the padding just as well as it cannot be in the middle
-	//    of the last instruction.
-	//
-	// Or maybe alignment.
-	//
-	// Really these table entries are probably not needed at all.
-	// Stack walk through leaf function does not require metadata.
-	// Return address can be correctly assumed to be at *rsp.
-	tinfo->code_size = 5;
-#else
 	gpointer const symbol_addr = read_unwind_info (amodule, tinfo, "unbox_trampoline_p");
 	if (!symbol_addr) {
 		mono_tramp_info_free (tinfo);
@@ -5858,7 +5816,6 @@ mono_aot_get_unbox_trampoline (MonoMethod *method)
 	}
 
 	tinfo->code_size = *(guint32*)symbol_addr;
-#endif
 	mono_aot_tramp_info_register (tinfo, NULL);
 
 	/* The caller expects an ftnptr */

--- a/mono/mini/aot-runtime.h
+++ b/mono/mini/aot-runtime.h
@@ -11,7 +11,7 @@
 #include "mini.h"
 
 /* Version number of the AOT file format */
-#define MONO_AOT_FILE_VERSION 148
+#define MONO_AOT_FILE_VERSION 149
 
 #define MONO_AOT_TRAMP_PAGE_SIZE 16384
 

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -338,7 +338,6 @@ mini_add_method_trampoline (MonoMethod *m, gpointer compiled_method, gboolean ad
 
 	// FIXME: This loads information from AOT (perf problem)
 	ji = mini_jit_info_table_find (mono_domain_get (), (char *)mono_get_addr_from_ftnptr (compiled_method), NULL);
-	g_assert (ji);
 	callee_gsharedvt = mini_jit_info_is_gsharedvt (ji);
 
 	callee_array_helper = FALSE;

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -338,6 +338,7 @@ mini_add_method_trampoline (MonoMethod *m, gpointer compiled_method, gboolean ad
 
 	// FIXME: This loads information from AOT (perf problem)
 	ji = mini_jit_info_table_find (mono_domain_get (), (char *)mono_get_addr_from_ftnptr (compiled_method), NULL);
+	g_assert (ji);
 	callee_gsharedvt = mini_jit_info_is_gsharedvt (ji);
 
 	callee_array_helper = FALSE;


### PR DESCRIPTION
Backport of #10615.

/cc @marek-safar