### PR TITLE
Fix scheduling problem related to thread-suspend-suspended and thread-suspend-selfsuspended.

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1077,8 +1077,7 @@ if HOST_WIN32
 PLATFORM_DISABLED_TESTS += async-exc-compilation.exe finally_guard.exe finally_block_ending_in_dead_bb.exe \
 	bug-18026.exe monitor.exe threadpool-exceptions5.exe process-unref-race.exe w32message.exe \
 	unhandled-exception-1.exe unhandled-exception-2.exe unhandled-exception-3.exe unhandled-exception-4.exe \
-	unhandled-exception-5.exe unhandled-exception-6.exe unhandled-exception-7.exe unhandled-exception-8.exe \
-	thread-suspend-suspended.exe thread-suspend-selfsuspended.exe
+	unhandled-exception-5.exe unhandled-exception-6.exe unhandled-exception-7.exe unhandled-exception-8.exe
 endif
 
 # test_virt.exe fails because callee takes more parameters than caller, 1 vs. 0, and


### PR DESCRIPTION
thread-suspend-suspended and thread-suspend-selfsuspended tests has showed long execution times on low core Windows machines running wow64 (x86 binary on x64 OS). It looks like an OS related issue where ResumeThread Win32 API takes a lot longer time to complete when running a test scenario like thread-suspend-suspended and this additional time adds up over many iterations pushing it over to timeout.

NOTE, the same behavior has been identified running on .NET framework, so it's not a mono specific issue and only reproduce under wow64 on low core machines, like the Jenkins Windows builders that only have 2 cores.

Since the purpose of the test is to run GC when t1 is suspended, doing this more deterministic will fix the ResumeThread issue under wow64 on low core machines as well as making the tests more deterministic, always having t1 in a suspended state when running GC (that will test the suspend suspended scenario).

Full investigation can be found in, #10508.