### PR TITLE
[corlib] Throw AOORE for invalid input in Module.ResolveMember

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection/ModuleTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/ModuleTest.cs
@@ -318,6 +318,13 @@ public class ModuleTest
 	}
 
 	[Test]
+	public void ResolveInvalidMember () // https://github.com/mono/mono/issues/9604
+	{
+		Module m = typeof (ModuleTest).Module;
+		Assert.Throws<ArgumentOutOfRangeException> (() => m.ResolveMember(0x0A00F000));
+	}
+
+	[Test]
 	public void FindTypes ()
 	{
 		Module m = typeof (ModuleTest).Module;

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5989,7 +5989,12 @@ mono_memberref_is_method (MonoImage *image, guint32 token)
 	if (!image_is_dynamic (image)) {
 		guint32 cols [MONO_MEMBERREF_SIZE];
 		const char *sig;
-		mono_metadata_decode_row (&image->tables [MONO_TABLE_MEMBERREF], mono_metadata_token_index (token) - 1, cols, MONO_MEMBERREF_SIZE);
+		const MonoTableInfo *table = &image->tables [MONO_TABLE_MEMBERREF];
+		int idx = mono_metadata_token_index (token) - 1;
+		if (idx < 0 || table->rows <= idx) {
+			return FALSE;
+		}
+		mono_metadata_decode_row (table, idx, cols, MONO_MEMBERREF_SIZE);
 		sig = mono_metadata_blob_heap (image, cols [MONO_MEMBERREF_SIGNATURE]);
 		mono_metadata_decode_blob_size (sig, &sig);
 		return (*sig != 0x6);


### PR DESCRIPTION
Fixes: https://github.com/mono/mono/issues/9604 

`ResolveMember` crashes here https://github.com/mono/mono/blob/master/mono/metadata/metadata.c#L1158-L1159 (comes from [mono_memberref_is_method](https://github.com/mono/mono/blob/362d1d94e11ff0a44bac7aa6830a4783d9c70610/mono/metadata/icall.c#L6297))

All other resolvers such as [module_resolve_field_token](https://github.com/mono/mono/blob/362d1d94e11ff0a44bac7aa6830a4783d9c70610/mono/metadata/icall.c#L6239-L6242) have this kind of check for out-of-bounds.
