### PR TITLE
[wasm/gc] It's valid to register for finalization an object without a finalizer. Don't register for fin objects added to refqueues under sgen.

### DIFF
--- a/sdks/builds/wasm.mk
+++ b/sdks/builds/wasm.mk
@@ -17,7 +17,7 @@ WASM_RUNTIME_CONFIGURE_FLAGS = \
 	--disable-support-build \
 	--disable-visibility-hidden \
 	--enable-maintainer-mode	\
-	--enable-minimal=ssa,com,jit,reflection_emit_save,reflection_emit,portability,assembly_remapping,attach,verifier,full_messages,appdomains,security,sgen_marksweep_conc,sgen_split_nursery,sgen_gc_bridge,logging,remoting,shared_perfcounters,sgen_debug_helpers,soft_debug,interpreter \
+	--enable-minimal=ssa,com,jit,reflection_emit_save,portability,assembly_remapping,attach,verifier,full_messages,appdomains,security,sgen_marksweep_conc,sgen_split_nursery,sgen_gc_bridge,logging,remoting,shared_perfcounters,sgen_debug_helpers,soft_debug,interpreter \
 	--host=wasm32 \
 	--enable-llvm-runtime \
 	--with-bitcode=yes


### PR DESCRIPTION
The refqueue change undo part of 87fb34d18a733168a91df8d2358f233a2382a62d.

This is due to how track resurrection weak refs are implemented under boehm and sgen. Sgen natively supports them so we don't
need to emulated it by registering them for finalization. This produces a lot of useless work for the GC.