### PR TITLE
Revert "Get fault_addr in debugger stacks. (#9673)"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -425,10 +425,6 @@ if test x$host_darwin = xyes; then
    AC_DEFINE(HOST_DARWIN, 1, [Host Platform is Darwin])
 fi
 
-if test x$host_linux = xyes; then
-   AC_DEFINE(HOST_LINUX, 1, [Host Platform is Linux])
-fi
-
 # Defined for all targets/platforms using classic Windows API support.
 AC_DEFINE(HAVE_CLASSIC_WINAPI_SUPPORT, 1, [Use classic Windows API support])
 AC_DEFINE(HAVE_UWP_WINAPI_SUPPORT, 0, [Don't use UWP Windows API support])

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3392,14 +3392,7 @@ is_addr_implicit_null_check (void *addr)
 	return addr <= GUINT_TO_POINTER (mono_target_pagesize ());
 }
 
-// This function is separate from mono_sigsegv_signal_handler
-// so debug_fault_addr can be seen in debugger stacks.
-#ifdef MONO_SIG_HANDLER_DEBUG
-MONO_NEVER_INLINE
-MONO_SIG_HANDLER_FUNC_DEBUG (static, mono_sigsegv_signal_handler_debug)
-#else
 MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
-#endif
 {
 	MonoJitInfo *ji;
 	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
@@ -3500,27 +3493,6 @@ MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
 	}
 #endif
 }
-
-#ifdef MONO_SIG_HANDLER_DEBUG
-
-// This function is separate from mono_sigsegv_signal_handler_debug
-// so debug_fault_addr can be seen in debugger stacks.
-MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
-{
-#ifdef HOST_WIN32 // This is inactive as there were problems seen.
-	// Presumed EXCEPTION_ACCESS_VIOLATION and NumberParameters >= 2.
-	// ExceptionInformation is a fixed size array, so it is ok
-	// if this is incorrect, it will not index out of bounds.
-	gpointer const debug_fault_addr = (gpointer)_info->ExceptionRecord->ExceptionInformation [1];
-#elif defined (HAVE_SIG_INFO)
-	gpointer const debug_fault_addr = MONO_SIG_HANDLER_GET_INFO ()->si_addr;
-#else
-#error No extra parameter is passed, not even 0, to avoid any confusion.
-#endif
-	mono_sigsegv_signal_handler_debug (MONO_SIG_HANDLER_PARAMS_DEBUG);
-}
-
-#endif // MONO_SIG_HANDLER_DEBUG
 
 MONO_SIG_HANDLER_FUNC (, mono_sigint_signal_handler)
 {

--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -220,12 +220,5 @@ ssize_t sendfile (int out_fd, int in_fd, __mono_off32_t* offset, size_t count);
 #endif /* __ANDROID_API__ < 21 */
 #endif /* HOST_ANDROID && ANDROID_UNIFIED_HEADERS */
 
-#if defined (__clang__)
-#define MONO_ATTRIBUTE_NO_OPTIMIZE __attribute__((optnone))
-#elif __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 4)
-#define MONO_ATTRIBUTE_NO_OPTIMIZE __attribute__((optimize("O0")))
-#else
-#define MONO_ATTRIBUTE_NO_OPTIMIZE /* nothing */
-#endif
-
 #endif /* __UTILS_MONO_COMPILER_H__*/
+

--- a/mono/utils/mono-signal-handler.h
+++ b/mono/utils/mono-signal-handler.h
@@ -78,34 +78,25 @@
  */
 
 #ifdef HOST_WIN32
-#define MONO_SIG_HANDLER_INFO_TYPE EXCEPTION_POINTERS
-/* seh_vectored_exception_handler () passes in a CONTEXT* */
-#else
-/* sigaction */
-#define MONO_SIG_HANDLER_INFO_TYPE siginfo_t
-#endif
-
-// FIXME This should be defined (MONO_ARCH_USE_SIGACTION) || defined (HOST_WIN32)
-// But the correct value isn't coming through on Mac. A small C-only test does work on Mac.
-#if /*defined (HOST_WIN32) ||*/ defined (HOST_LINUX)
-#define MONO_SIG_HANDLER_DEBUG 1 // "with_fault_addr" but could be extended in future, so "debug"
-#endif
-
-#define MONO_SIG_HANDLER_SIGNATURE(ftn) ftn (int _dummy, MONO_SIG_HANDLER_INFO_TYPE *_info, void *context)
-#define MONO_SIG_HANDLER_FUNC(access, ftn) MONO_SIGNAL_HANDLER_FUNC (access, ftn, (int _dummy, MONO_SIG_HANDLER_INFO_TYPE *_info, void *context))
+#define MONO_SIG_HANDLER_SIGNATURE(ftn) ftn (int _dummy, EXCEPTION_POINTERS *_info, void *context)
+#define MONO_SIG_HANDLER_FUNC(access, ftn) MONO_SIGNAL_HANDLER_FUNC (access, ftn, (int _dummy, EXCEPTION_POINTERS *_info, void *context))
 #define MONO_SIG_HANDLER_PARAMS _dummy, _info, context
 #define MONO_SIG_HANDLER_GET_SIGNO() (_dummy)
 #define MONO_SIG_HANDLER_GET_INFO() (_info)
+#define MONO_SIG_HANDLER_INFO_TYPE EXCEPTION_POINTERS
+/* seh_vectored_exception_handler () passes in a CONTEXT* */
 #define MONO_SIG_HANDLER_GET_CONTEXT \
     void *ctx = context;
-
-#ifdef MONO_SIG_HANDLER_DEBUG
-// Same as MONO_SIG_HANDLER_FUNC but debug_fault_addr is added to params, and no_optimize.
-// The Krait workaround is not needed here, due to this not actually being the signal handler,
-// so MONO_SIGNAL_HANDLER_FUNC is combined into it.
-#define MONO_SIG_HANDLER_FUNC_DEBUG(access, ftn) access MONO_ATTRIBUTE_NO_OPTIMIZE void ftn \
-	(int _dummy, MONO_SIG_HANDLER_INFO_TYPE *_info, void *context, void * volatile debug_fault_addr G_GNUC_UNUSED)
-#define MONO_SIG_HANDLER_PARAMS_DEBUG MONO_SIG_HANDLER_PARAMS, debug_fault_addr
+#else
+/* sigaction */
+#define MONO_SIG_HANDLER_SIGNATURE(ftn) ftn (int _dummy, siginfo_t *_info, void *context)
+#define MONO_SIG_HANDLER_FUNC(access, ftn) MONO_SIGNAL_HANDLER_FUNC (access, ftn, (int _dummy, siginfo_t *_info, void *context))
+#define MONO_SIG_HANDLER_PARAMS _dummy, _info, context
+#define MONO_SIG_HANDLER_GET_SIGNO() (_dummy)
+#define MONO_SIG_HANDLER_GET_INFO() (_info)
+#define MONO_SIG_HANDLER_INFO_TYPE siginfo_t
+#define MONO_SIG_HANDLER_GET_CONTEXT \
+    void *ctx = context;
 #endif
 
-#endif // __MONO_SIGNAL_HANDLER_H__
+#endif


### PR DESCRIPTION
It broke Linux WebAssembly.

This reverts commit a6712d05bec184e69e3b175a4bc75cc34185a397.