### PR TITLE
[runtime] Icall for Buffer.Memcpy

### DIFF
--- a/mcs/class/corlib/ReferenceSources/Buffer.cs
+++ b/mcs/class/corlib/ReferenceSources/Buffer.cs
@@ -11,6 +11,9 @@ namespace System
 {
 	partial class Buffer
 	{
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
+		internal static extern unsafe bool InternalMemcpy (byte *dest, byte *src, int count);
+
 		public static int ByteLength (Array array)
 		{
 			// note: the other methods in this class also use ByteLength to test for
@@ -73,6 +76,11 @@ namespace System
 			}
 		}
 
+		internal static unsafe void Memcpy (byte *dest, byte *src, int len)
+		{
+			InternalMemcpy (dest, src, len);
+		}
+
 		[CLSCompliantAttribute (false)]
 		public static unsafe void MemoryCopy (void* source, void* destination, long destinationSizeInBytes, long sourceBytesToCopy)
 		{
@@ -83,13 +91,13 @@ namespace System
 			var src = (byte*)source;
 			var dst = (byte*)destination;
 			while (sourceBytesToCopy > int.MaxValue) {
-				Memcpy (dst, src, int.MaxValue);
+				InternalMemcpy (dst, src, int.MaxValue);
 				sourceBytesToCopy -= int.MaxValue;
 				src += int.MaxValue;
 				dst += int.MaxValue;
 			}
 
-			memcpy1 (dst, src, (int) sourceBytesToCopy);
+			InternalMemcpy (dst, src, (int) sourceBytesToCopy);
 		}
 
 		[CLSCompliantAttribute (false)]
@@ -102,129 +110,20 @@ namespace System
 			var src = (byte*)source;
 			var dst = (byte*)destination;
 			while (sourceBytesToCopy > int.MaxValue) {
-				Memcpy (dst, src, int.MaxValue);
+				InternalMemcpy (dst, src, int.MaxValue);
 				sourceBytesToCopy -= int.MaxValue;
 				src += int.MaxValue;
 				dst += int.MaxValue;
 			}
 
-			Memcpy (dst, src, (int) sourceBytesToCopy);
-		}
-
-		internal static unsafe void memcpy4 (byte *dest, byte *src, int size) {
-			/*while (size >= 32) {
-				// using long is better than int and slower than double
-				// FIXME: enable this only on correct alignment or on platforms
-				// that can tolerate unaligned reads/writes of doubles
-				((double*)dest) [0] = ((double*)src) [0];
-				((double*)dest) [1] = ((double*)src) [1];
-				((double*)dest) [2] = ((double*)src) [2];
-				((double*)dest) [3] = ((double*)src) [3];
-				dest += 32;
-				src += 32;
-				size -= 32;
-			}*/
-			while (size >= 16) {
-				((int*)dest) [0] = ((int*)src) [0];
-				((int*)dest) [1] = ((int*)src) [1];
-				((int*)dest) [2] = ((int*)src) [2];
-				((int*)dest) [3] = ((int*)src) [3];
-				dest += 16;
-				src += 16;
-				size -= 16;
-			}
-			while (size >= 4) {
-				((int*)dest) [0] = ((int*)src) [0];
-				dest += 4;
-				src += 4;
-				size -= 4;
-			}
-			while (size > 0) {
-				((byte*)dest) [0] = ((byte*)src) [0];
-				dest += 1;
-				src += 1;
-				--size;
-			}
-		}
-		internal static unsafe void memcpy2 (byte *dest, byte *src, int size) {
-			while (size >= 8) {
-				((short*)dest) [0] = ((short*)src) [0];
-				((short*)dest) [1] = ((short*)src) [1];
-				((short*)dest) [2] = ((short*)src) [2];
-				((short*)dest) [3] = ((short*)src) [3];
-				dest += 8;
-				src += 8;
-				size -= 8;
-			}
-			while (size >= 2) {
-				((short*)dest) [0] = ((short*)src) [0];
-				dest += 2;
-				src += 2;
-				size -= 2;
-			}
-			if (size > 0)
-				((byte*)dest) [0] = ((byte*)src) [0];
-		}
-		static unsafe void memcpy1 (byte *dest, byte *src, int size) {
-			while (size >= 8) {
-				((byte*)dest) [0] = ((byte*)src) [0];
-				((byte*)dest) [1] = ((byte*)src) [1];
-				((byte*)dest) [2] = ((byte*)src) [2];
-				((byte*)dest) [3] = ((byte*)src) [3];
-				((byte*)dest) [4] = ((byte*)src) [4];
-				((byte*)dest) [5] = ((byte*)src) [5];
-				((byte*)dest) [6] = ((byte*)src) [6];
-				((byte*)dest) [7] = ((byte*)src) [7];
-				dest += 8;
-				src += 8;
-				size -= 8;
-			}
-			while (size >= 2) {
-				((byte*)dest) [0] = ((byte*)src) [0];
-				((byte*)dest) [1] = ((byte*)src) [1];
-				dest += 2;
-				src += 2;
-				size -= 2;
-			}
-			if (size > 0)
-				((byte*)dest) [0] = ((byte*)src) [0];
-		}
-
-		internal static unsafe void Memcpy (byte *dest, byte *src, int len) {
-			// FIXME: if pointers are not aligned, try to align them
-			// so a faster routine can be used. Handle the case where
-			// the pointers can't be reduced to have the same alignment
-			// (just ignore the issue on x86?)
-			if ((((int)dest | (int)src) & 3) != 0) {
-				if (((int)dest & 1) != 0 && ((int)src & 1) != 0 && len >= 1) {
-					dest [0] = src [0];
-					++dest;
-					++src;
-					--len;
-				}
-				if (((int)dest & 2) != 0 && ((int)src & 2) != 0 && len >= 2) {
-					((short*)dest) [0] = ((short*)src) [0];
-					dest += 2;
-					src += 2;
-					len -= 2;
-				}
-				if ((((int)dest | (int)src) & 1) != 0) {
-					memcpy1 (dest, src, len);
-					return;
-				}
-				if ((((int)dest | (int)src) & 2) != 0) {
-					memcpy2 (dest, src, len);
-					return;
-				}
-			}
-			memcpy4 (dest, src, len);
+			InternalMemcpy (dst, src, (int) sourceBytesToCopy);
 		}
 
 		internal static unsafe void Memmove (byte *dest, byte *src, uint len)
 		{
             if (((nuint)dest - (nuint)src < len) || ((nuint)src - (nuint)dest < len))
 				goto PInvoke;
-			Memcpy (dest, src, (int) len);
+			InternalMemcpy (dest, src, (int) len);
 			return;
 
             PInvoke:

--- a/mcs/class/corlib/ReferenceSources/String.cs
+++ b/mcs/class/corlib/ReferenceSources/String.cs
@@ -235,25 +235,6 @@ namespace System
 			return countA - countB;
 		}
 
-		internal static unsafe void CharCopy (char *dest, char *src, int count) {
-			// Same rules as for memcpy, but with the premise that 
-			// chars can only be aligned to even addresses if their
-			// enclosing types are correctly aligned
-			if ((((int)(byte*)dest | (int)(byte*)src) & 3) != 0) {
-				if (((int)(byte*)dest & 2) != 0 && ((int)(byte*)src & 2) != 0 && count > 0) {
-					((short*)dest) [0] = ((short*)src) [0];
-					dest++;
-					src++;
-					count--;
-				}
-				if ((((int)(byte*)dest | (int)(byte*)src) & 2) != 0) {
-					Buffer.memcpy2 ((byte*)dest, (byte*)src, count * 2);
-					return;
-				}
-			}
-			Buffer.memcpy4 ((byte*)dest, (byte*)src, count * 2);
-		}
-
 		#region Runtime method-to-ir dependencies
 
 		/* helpers used by the runtime as well as above or eslewhere in corlib */
@@ -305,7 +286,7 @@ namespace System
 
 		static unsafe void memcpy (byte *dest, byte *src, int size)
 		{
-			Buffer.Memcpy (dest, src, size);
+			Buffer.InternalMemcpy (dest, src, size);
 		}
 
 		/* Used by the runtime */

--- a/mcs/class/corlib/System.Runtime.InteropServices/Marshal.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/Marshal.cs
@@ -946,7 +946,7 @@ namespace System.Runtime.InteropServices
 				return *(short*)addr;
 
 			short s;
-			Buffer.Memcpy ((byte*)&s, (byte*)ptr, 2);
+			Buffer.InternalMemcpy ((byte*)&s, (byte*)ptr, 2);
 			return s;
 		}
 
@@ -958,7 +958,7 @@ namespace System.Runtime.InteropServices
 				return *(short*)addr;
 
 			short s;
-			Buffer.Memcpy ((byte*)&s, addr, 2);
+			Buffer.InternalMemcpy ((byte*)&s, addr, 2);
 			return s;
 		}
 
@@ -978,7 +978,7 @@ namespace System.Runtime.InteropServices
 				return *(int*)addr;
 
 			int s;
-			Buffer.Memcpy ((byte*)&s, addr, 4);
+			Buffer.InternalMemcpy ((byte*)&s, addr, 4);
 			return s;
 		}
 
@@ -991,7 +991,7 @@ namespace System.Runtime.InteropServices
 				return *(int*)addr;
 			else {
 				int s;
-				Buffer.Memcpy ((byte*)&s, addr, 4);
+				Buffer.InternalMemcpy ((byte*)&s, addr, 4);
 				return s;
 			}
 		}
@@ -1015,7 +1015,7 @@ namespace System.Runtime.InteropServices
 				return *(long*)ptr;
 
 			long s;
-			Buffer.Memcpy ((byte*)&s, addr, 8);
+			Buffer.InternalMemcpy ((byte*)&s, addr, 8);
 			return s;
 		}
 
@@ -1027,7 +1027,7 @@ namespace System.Runtime.InteropServices
 				return *(long*)addr;
 			
 			long s;
-			Buffer.Memcpy ((byte*)&s, addr, 8);
+			Buffer.InternalMemcpy ((byte*)&s, addr, 8);
 			return s;
 		}
 
@@ -1381,7 +1381,7 @@ namespace System.Runtime.InteropServices
 			if (((uint)addr & 1) == 0)
 				*(short*)addr = val;
 			else
-				Buffer.Memcpy (addr, (byte*)&val, 2);
+				Buffer.InternalMemcpy (addr, (byte*)&val, 2);
 		}
 
 		public static unsafe void WriteInt16 (IntPtr ptr, int ofs, short val)
@@ -1391,7 +1391,7 @@ namespace System.Runtime.InteropServices
 			if (((uint)addr & 1) == 0)
 				*(short*)addr = val;
 			else {
-				Buffer.Memcpy (addr, (byte*)&val, 2);
+				Buffer.InternalMemcpy (addr, (byte*)&val, 2);
 			}
 		}
 
@@ -1425,7 +1425,7 @@ namespace System.Runtime.InteropServices
 			if (((uint)addr & 3) == 0) 
 				*(int*)addr = val;
 			else {
-				Buffer.Memcpy (addr, (byte*)&val, 4);
+				Buffer.InternalMemcpy (addr, (byte*)&val, 4);
 			}
 		}
 
@@ -1436,7 +1436,7 @@ namespace System.Runtime.InteropServices
 			if (((uint)addr & 3) == 0) 
 				*(int*)addr = val;
 			else {
-				Buffer.Memcpy (addr, (byte*)&val, 4);
+				Buffer.InternalMemcpy (addr, (byte*)&val, 4);
 			}
 		}
 
@@ -1456,7 +1456,7 @@ namespace System.Runtime.InteropServices
 			if (((uint)addr & 7) == 0) 
 				*(long*)addr = val;
 			else 
-				Buffer.Memcpy (addr, (byte*)&val, 8);
+				Buffer.InternalMemcpy (addr, (byte*)&val, 8);
 		}
 
 		public static unsafe void WriteInt64 (IntPtr ptr, int ofs, long val)
@@ -1468,7 +1468,7 @@ namespace System.Runtime.InteropServices
 			if (((uint)addr & 7) == 0) 
 				*(long*)addr = val;
 			else 
-				Buffer.Memcpy (addr, (byte*)&val, 8);
+				Buffer.InternalMemcpy (addr, (byte*)&val, 8);
 		}
 
 		[MonoTODO]

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -169,6 +169,7 @@ HANDLES(ICALL(ARRAY_13, "SetValueImpl",     ves_icall_System_Array_SetValueImpl)
 
 ICALL_TYPE(BUFFER, "System.Buffer", BUFFER_1)
 ICALL(BUFFER_1, "InternalBlockCopy", ves_icall_System_Buffer_BlockCopyInternal)
+ICALL(BUFFER_5, "InternalMemcpy", ves_icall_System_Buffer_MemcpyInternal)
 ICALL(BUFFER_2, "_ByteLength", ves_icall_System_Buffer_ByteLengthInternal)
 ICALL(BUFFER_3, "_GetByte", ves_icall_System_Buffer_GetByteInternal)
 ICALL(BUFFER_4, "_SetByte", ves_icall_System_Buffer_SetByteInternal)

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -6596,6 +6596,12 @@ ves_icall_System_Buffer_SetByteInternal (MonoArray *array, gint32 idx, gint8 val
 	mono_array_set (array, gint8, idx, value);
 }
 
+ICALL_EXPORT void
+ves_icall_System_Buffer_MemcpyInternal (gpointer dest, gpointer src, gint32 count)
+{
+	memcpy (dest, src, count);
+}
+
 ICALL_EXPORT MonoBoolean
 ves_icall_System_Buffer_BlockCopyInternal (MonoArray *src, gint32 src_offset, MonoArray *dest, gint32 dest_offset, gint32 count) 
 {


### PR DESCRIPTION
Jitted code is too slow. For small copying sizes (a couple of bytes) there is no difference in performance compared to the old code, while for larger sizes (in order of kb), doing an icall to memcpy is 4-5 times faster. Tested on x64 and arm64 using benchmarks from https://github.com/mono/mono/issues/9875.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
