### PR TITLE
[mono-api-html] Render something for fields with marshalling info.

### DIFF
--- a/mcs/tools/mono-api-html/FieldComparer.cs
+++ b/mcs/tools/mono-api-html/FieldComparer.cs
@@ -61,6 +61,18 @@ namespace Mono.ApiTools {
 						change.AppendAdded ($"[NonSerialized]{Environment.NewLine}");
 					}
 				}
+
+				var srcHasFieldMarshal = (source & FieldAttributes.HasFieldMarshal) != 0;
+				var tgtHasFieldMarshal = (target & FieldAttributes.HasFieldMarshal) != 0;
+				if (srcHasFieldMarshal != tgtHasFieldMarshal) {
+					// this is not a breaking change, so only render it if it changed.
+					if (srcHasFieldMarshal) {
+						change.AppendRemoved ("[MarshalAs]", false);
+					} else {
+						change.AppendAdded ("[MarshalAs]", false);
+					}
+					change.Append (Environment.NewLine);
+				}
 			}
 
 			// the visibility values are the same for MethodAttributes and FieldAttributes, so just use the same method.


### PR DESCRIPTION
Fixes this warning when comparing Xamarin.iOS.dll:

    Comparison resulting in no changes (src: Public, HasFieldMarshal dst: Public) :
    <field name="EdgeTessellationFactor" attrib="4102" fieldtype="System.UInt16[]" />
    <field name="EdgeTessellationFactor" attrib="6" fieldtype="System.UInt16[]" />