### PR TITLE
 Get fault_addr in debugger stacks.

### DIFF
--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3392,7 +3392,14 @@ is_addr_implicit_null_check (void *addr)
 	return addr <= GUINT_TO_POINTER (mono_target_pagesize ());
 }
 
+// This function is separate from mono_sigsegv_signal_handler
+// so debug_fault_addr can be seen in debugger stacks.
+#ifdef MONO_SIG_HANDLER_DEBUG
+MONO_NEVER_INLINE
+MONO_SIG_HANDLER_FUNC_DEBUG (static, mono_sigsegv_signal_handler_debug)
+#else
 MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
+#endif
 {
 	MonoJitInfo *ji;
 	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
@@ -3493,6 +3500,27 @@ MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
 	}
 #endif
 }
+
+#ifdef MONO_SIG_HANDLER_DEBUG
+
+// This function is separate from mono_sigsegv_signal_handler_debug
+// so debug_fault_addr can be seen in debugger stacks.
+MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
+{
+#ifdef HOST_WIN32 // This is inactive as there were problems seen.
+	// Presumed EXCEPTION_ACCESS_VIOLATION and NumberParameters >= 2.
+	// ExceptionInformation is a fixed size array, so it is ok
+	// if this is incorrect, it will not index out of bounds.
+	gpointer const debug_fault_addr = (gpointer)_info->ExceptionRecord->ExceptionInformation [1];
+#elif defined (HAVE_SIG_INFO)
+	gpointer const debug_fault_addr = MONO_SIG_HANDLER_GET_INFO ()->si_addr;
+#else
+#error No extra parameter is passed, not even 0, to avoid any confusion.
+#endif
+	mono_sigsegv_signal_handler_debug (MONO_SIG_HANDLER_PARAMS_DEBUG);
+}
+
+#endif // MONO_SIG_HANDLER_DEBUG
 
 MONO_SIG_HANDLER_FUNC (, mono_sigint_signal_handler)
 {

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3381,7 +3381,19 @@ MONO_SIG_HANDLER_FUNC (, mono_sigill_signal_handler)
 }
 
 #if defined(MONO_ARCH_USE_SIGACTION) || defined(HOST_WIN32)
+
 #define HAVE_SIG_INFO
+#define MONO_SIG_HANDLER_DEBUG 1 // "with_fault_addr" but could be extended in future, so "debug"
+
+#ifdef MONO_SIG_HANDLER_DEBUG
+// Same as MONO_SIG_HANDLER_FUNC but debug_fault_addr is added to params, and no_optimize.
+// The Krait workaround is not needed here, due to this not actually being the signal handler,
+// so MONO_SIGNAL_HANDLER_FUNC is combined into it.
+#define MONO_SIG_HANDLER_FUNC_DEBUG(access, ftn) access MONO_ATTRIBUTE_NO_OPTIMIZE void ftn \
+	(int _dummy, MONO_SIG_HANDLER_INFO_TYPE *_info, void *context, void * volatile debug_fault_addr G_GNUC_UNUSED)
+#define MONO_SIG_HANDLER_PARAMS_DEBUG MONO_SIG_HANDLER_PARAMS, debug_fault_addr
+#endif
+
 #endif
 
 static gboolean
@@ -3507,10 +3519,7 @@ MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
 // so debug_fault_addr can be seen in debugger stacks.
 MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
 {
-#ifdef HOST_WIN32 // This is inactive as there were problems seen.
-	// Presumed EXCEPTION_ACCESS_VIOLATION and NumberParameters >= 2.
-	// ExceptionInformation is a fixed size array, so it is ok
-	// if this is incorrect, it will not index out of bounds.
+#ifdef HOST_WIN32
 	gpointer const debug_fault_addr = (gpointer)_info->ExceptionRecord->ExceptionInformation [1];
 #elif defined (HAVE_SIG_INFO)
 	gpointer const debug_fault_addr = MONO_SIG_HANDLER_GET_INFO ()->si_addr;

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3389,7 +3389,7 @@ MONO_SIG_HANDLER_FUNC (, mono_sigill_signal_handler)
 // Same as MONO_SIG_HANDLER_FUNC but debug_fault_addr is added to params, and no_optimize.
 // The Krait workaround is not needed here, due to this not actually being the signal handler,
 // so MONO_SIGNAL_HANDLER_FUNC is combined into it.
-#define MONO_SIG_HANDLER_FUNC_DEBUG(access, ftn) access MONO_ATTRIBUTE_NO_OPTIMIZE void ftn \
+#define MONO_SIG_HANDLER_FUNC_DEBUG(access, ftn) access MONO_NO_OPTIMIZATION void ftn \
 	(int _dummy, MONO_SIG_HANDLER_INFO_TYPE *_info, void *context, void * volatile debug_fault_addr G_GNUC_UNUSED)
 #define MONO_SIG_HANDLER_PARAMS_DEBUG MONO_SIG_HANDLER_PARAMS, debug_fault_addr
 #endif

--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -220,5 +220,12 @@ ssize_t sendfile (int out_fd, int in_fd, __mono_off32_t* offset, size_t count);
 #endif /* __ANDROID_API__ < 21 */
 #endif /* HOST_ANDROID && ANDROID_UNIFIED_HEADERS */
 
-#endif /* __UTILS_MONO_COMPILER_H__*/
+#if defined (__clang__)
+#define MONO_ATTRIBUTE_NO_OPTIMIZE __attribute__((optnone))
+#elif __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 4)
+#define MONO_ATTRIBUTE_NO_OPTIMIZE __attribute__((optimize("O0")))
+#else
+#define MONO_ATTRIBUTE_NO_OPTIMIZE /* nothing */
+#endif
 
+#endif /* __UTILS_MONO_COMPILER_H__*/

--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -125,10 +125,12 @@ typedef SSIZE_T ssize_t;
 #define MONO_COLD
 #endif
 
-#ifdef __GNUC__
+#if defined (__clang__)
+#define MONO_NO_OPTIMIZATION __attribute__ ((optnone))
+#elif __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 4)
 #define MONO_NO_OPTIMIZATION __attribute__ ((optimize("O0")))
 #else
-#define MONO_NO_OPTIMIZATION
+#define MONO_NO_OPTIMIZATION /* nothing */
 #endif
 
 #if defined (__GNUC__) && defined (__GNUC_MINOR__) && defined (__GNUC_PATCHLEVEL__)
@@ -219,13 +221,5 @@ ssize_t sendfile (int out_fd, int in_fd, __mono_off32_t* offset, size_t count);
 
 #endif /* __ANDROID_API__ < 21 */
 #endif /* HOST_ANDROID && ANDROID_UNIFIED_HEADERS */
-
-#if defined (__clang__)
-#define MONO_ATTRIBUTE_NO_OPTIMIZE __attribute__((optnone))
-#elif __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 4)
-#define MONO_ATTRIBUTE_NO_OPTIMIZE __attribute__((optimize("O0")))
-#else
-#define MONO_ATTRIBUTE_NO_OPTIMIZE /* nothing */
-#endif
 
 #endif /* __UTILS_MONO_COMPILER_H__*/

--- a/mono/utils/mono-signal-handler.h
+++ b/mono/utils/mono-signal-handler.h
@@ -78,8 +78,8 @@
  */
 
 #ifdef HOST_WIN32
-#define MONO_SIG_HANDLER_SIGNATURE(ftn) ftn (int _dummy, EXCEPTION_POINTERS *_info, void *context)
-#define MONO_SIG_HANDLER_FUNC(access, ftn) MONO_SIGNAL_HANDLER_FUNC (access, ftn, (int _dummy, EXCEPTION_POINTERS *_info, void *context))
+#define MONO_SIG_HANDLER_SIGNATURE(ftn) ftn (int _dummy, MONO_SIG_HANDLER_INFO_TYPE *_info, void *context)
+#define MONO_SIG_HANDLER_FUNC(access, ftn) MONO_SIGNAL_HANDLER_FUNC (access, ftn, (int _dummy, MONO_SIG_HANDLER_INFO_TYPE *_info, void *context))
 #define MONO_SIG_HANDLER_PARAMS _dummy, _info, context
 #define MONO_SIG_HANDLER_GET_SIGNO() (_dummy)
 #define MONO_SIG_HANDLER_GET_INFO() (_info)
@@ -89,8 +89,8 @@
     void *ctx = context;
 #else
 /* sigaction */
-#define MONO_SIG_HANDLER_SIGNATURE(ftn) ftn (int _dummy, siginfo_t *_info, void *context)
-#define MONO_SIG_HANDLER_FUNC(access, ftn) MONO_SIGNAL_HANDLER_FUNC (access, ftn, (int _dummy, siginfo_t *_info, void *context))
+#define MONO_SIG_HANDLER_SIGNATURE(ftn) ftn (int _dummy, MONO_SIG_HANDLER_INFO_TYPE *_info, void *context)
+#define MONO_SIG_HANDLER_FUNC(access, ftn) MONO_SIGNAL_HANDLER_FUNC (access, ftn, (int _dummy, MONO_SIG_HANDLER_INFO_TYPE *_info, void *context))
 #define MONO_SIG_HANDLER_PARAMS _dummy, _info, context
 #define MONO_SIG_HANDLER_GET_SIGNO() (_dummy)
 #define MONO_SIG_HANDLER_GET_INFO() (_info)

--- a/mono/utils/mono-signal-handler.h
+++ b/mono/utils/mono-signal-handler.h
@@ -85,27 +85,11 @@
 #define MONO_SIG_HANDLER_INFO_TYPE siginfo_t
 #endif
 
-// FIXME This should be defined (MONO_ARCH_USE_SIGACTION) || defined (HOST_WIN32)
-// But the correct value isn't coming through on Mac. A small C-only test does work on Mac.
-#if /*defined (HOST_WIN32) ||*/ defined (HOST_LINUX)
-#define MONO_SIG_HANDLER_DEBUG 1 // "with_fault_addr" but could be extended in future, so "debug"
-#endif
-
 #define MONO_SIG_HANDLER_SIGNATURE(ftn) ftn (int _dummy, MONO_SIG_HANDLER_INFO_TYPE *_info, void *context)
 #define MONO_SIG_HANDLER_FUNC(access, ftn) MONO_SIGNAL_HANDLER_FUNC (access, ftn, (int _dummy, MONO_SIG_HANDLER_INFO_TYPE *_info, void *context))
 #define MONO_SIG_HANDLER_PARAMS _dummy, _info, context
 #define MONO_SIG_HANDLER_GET_SIGNO() (_dummy)
 #define MONO_SIG_HANDLER_GET_INFO() (_info)
-#define MONO_SIG_HANDLER_GET_CONTEXT \
-    void *ctx = context;
-
-#ifdef MONO_SIG_HANDLER_DEBUG
-// Same as MONO_SIG_HANDLER_FUNC but debug_fault_addr is added to params, and no_optimize.
-// The Krait workaround is not needed here, due to this not actually being the signal handler,
-// so MONO_SIGNAL_HANDLER_FUNC is combined into it.
-#define MONO_SIG_HANDLER_FUNC_DEBUG(access, ftn) access MONO_ATTRIBUTE_NO_OPTIMIZE void ftn \
-	(int _dummy, MONO_SIG_HANDLER_INFO_TYPE *_info, void *context, void * volatile debug_fault_addr G_GNUC_UNUSED)
-#define MONO_SIG_HANDLER_PARAMS_DEBUG MONO_SIG_HANDLER_PARAMS, debug_fault_addr
-#endif
+#define MONO_SIG_HANDLER_GET_CONTEXT void *ctx = context;
 
 #endif // __MONO_SIGNAL_HANDLER_H__

--- a/mono/utils/mono-signal-handler.h
+++ b/mono/utils/mono-signal-handler.h
@@ -78,25 +78,19 @@
  */
 
 #ifdef HOST_WIN32
-#define MONO_SIG_HANDLER_SIGNATURE(ftn) ftn (int _dummy, MONO_SIG_HANDLER_INFO_TYPE *_info, void *context)
-#define MONO_SIG_HANDLER_FUNC(access, ftn) MONO_SIGNAL_HANDLER_FUNC (access, ftn, (int _dummy, MONO_SIG_HANDLER_INFO_TYPE *_info, void *context))
-#define MONO_SIG_HANDLER_PARAMS _dummy, _info, context
-#define MONO_SIG_HANDLER_GET_SIGNO() (_dummy)
-#define MONO_SIG_HANDLER_GET_INFO() (_info)
 #define MONO_SIG_HANDLER_INFO_TYPE EXCEPTION_POINTERS
 /* seh_vectored_exception_handler () passes in a CONTEXT* */
-#define MONO_SIG_HANDLER_GET_CONTEXT \
-    void *ctx = context;
 #else
 /* sigaction */
+#define MONO_SIG_HANDLER_INFO_TYPE siginfo_t
+#endif
+
 #define MONO_SIG_HANDLER_SIGNATURE(ftn) ftn (int _dummy, MONO_SIG_HANDLER_INFO_TYPE *_info, void *context)
 #define MONO_SIG_HANDLER_FUNC(access, ftn) MONO_SIGNAL_HANDLER_FUNC (access, ftn, (int _dummy, MONO_SIG_HANDLER_INFO_TYPE *_info, void *context))
 #define MONO_SIG_HANDLER_PARAMS _dummy, _info, context
 #define MONO_SIG_HANDLER_GET_SIGNO() (_dummy)
 #define MONO_SIG_HANDLER_GET_INFO() (_info)
-#define MONO_SIG_HANDLER_INFO_TYPE siginfo_t
 #define MONO_SIG_HANDLER_GET_CONTEXT \
     void *ctx = context;
-#endif
 
 #endif

--- a/mono/utils/mono-signal-handler.h
+++ b/mono/utils/mono-signal-handler.h
@@ -85,6 +85,12 @@
 #define MONO_SIG_HANDLER_INFO_TYPE siginfo_t
 #endif
 
+// FIXME This should be defined (MONO_ARCH_USE_SIGACTION) || defined (HOST_WIN32)
+// But the correct value isn't coming through on Mac. A small C-only test does work on Mac.
+#if /*defined (HOST_WIN32) ||*/ defined (HOST_LINUX)
+#define MONO_SIG_HANDLER_DEBUG 1 // "with_fault_addr" but could be extended in future, so "debug"
+#endif
+
 #define MONO_SIG_HANDLER_SIGNATURE(ftn) ftn (int _dummy, MONO_SIG_HANDLER_INFO_TYPE *_info, void *context)
 #define MONO_SIG_HANDLER_FUNC(access, ftn) MONO_SIGNAL_HANDLER_FUNC (access, ftn, (int _dummy, MONO_SIG_HANDLER_INFO_TYPE *_info, void *context))
 #define MONO_SIG_HANDLER_PARAMS _dummy, _info, context
@@ -93,4 +99,13 @@
 #define MONO_SIG_HANDLER_GET_CONTEXT \
     void *ctx = context;
 
+#ifdef MONO_SIG_HANDLER_DEBUG
+// Same as MONO_SIG_HANDLER_FUNC but debug_fault_addr is added to params, and no_optimize.
+// The Krait workaround is not needed here, due to this not actually being the signal handler,
+// so MONO_SIGNAL_HANDLER_FUNC is combined into it.
+#define MONO_SIG_HANDLER_FUNC_DEBUG(access, ftn) access MONO_ATTRIBUTE_NO_OPTIMIZE void ftn \
+	(int _dummy, MONO_SIG_HANDLER_INFO_TYPE *_info, void *context, void * volatile debug_fault_addr G_GNUC_UNUSED)
+#define MONO_SIG_HANDLER_PARAMS_DEBUG MONO_SIG_HANDLER_PARAMS, debug_fault_addr
 #endif
+
+#endif // __MONO_SIGNAL_HANDLER_H__


### PR DESCRIPTION
This time w/o breaking WebAssembly and w/ working on Mac.