### PR TITLE
[cxx] Fix C++ compilation regression.

### DIFF
--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -4248,7 +4248,7 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsig
 					(cmethod->klass == mono_defaults.systemtype_class) &&
 					(strcmp (cmethod->name, "GetTypeFromHandle") == 0)) {
 				ADD_CODE (td, MINT_MONO_LDPTR);
-				gpointer systype = mono_type_get_object_checked (domain, handle, error);
+				gpointer systype = mono_type_get_object_checked (domain, (MonoType*)handle, error);
 				goto_if_nok (error, exit);
 				ADD_CODE (td, get_data_item_index (td, systype));
 				PUSH_SIMPLE_TYPE (td, STACK_TYPE_MP);


### PR DESCRIPTION
Caught by Aleksey Kliger.

transform.c(4251): error C2664: 'MonoReflectionType *mono_type_get_object_checked(MonoDomain *,MonoType *,MonoError *)': cannot convert argument 2 from 'gpointer' to 'MonoType *' [d:\j\workspace\d\msvc\libmono-dynamic.vcxproj]

Cast from void* to non-void*.