### PR TITLE
[SDKS] Build host runtime with correct bitness

### DIFF
--- a/sdks/builds/runtime.mk
+++ b/sdks/builds/runtime.mk
@@ -25,10 +25,20 @@
 #  _$(1)_PATH
 define RuntimeTemplate
 
-_runtime_$(1)_CFLAGS=$(if $(RELEASE),-O2 -g,-O0 -ggdb3 -fno-omit-frame-pointer) $$(_$(1)_CFLAGS) $$($(1)_CFLAGS)
-_runtime_$(1)_CXXFLAGS=$(if $(RELEASE),-O2 -g,-O0 -ggdb3 -fno-omit-frame-pointer) $$(_$(1)_CXXFLAGS) $$($(1)_CXXFLAGS)
-_runtime_$(1)_CPPFLAGS=$(if $(RELEASE),-O2 -g,-O0 -ggdb3 -fno-omit-frame-pointer) $$(_$(1)_CPPFLAGS) $$($(1)_CPPFLAGS)
-_runtime_$(1)_CXXCPPFLAGS=$(if $(RELEASE),-O2 -g,-O0 -ggdb3 -fno-omit-frame-pointer) $$(_$(1)_CXXCPPFLAGS) $$($(1)_CXXCPPFLAGS)
+_runtime_$(1)_BITNESS=$$(if $$(findstring i686,$(2)),-m32)
+
+ifeq ($$(_runtime_$(1)_BITNESS),)
+_runtime_$(1)_BITNESS=$$(if $$(findstring i386,$(2)),-m32)
+endif
+
+ifeq ($$(_runtime_$(1)_BITNESS),)
+_runtime_$(1)_BITNESS=$$(if $$(findstring x86_64,$(2)),-m64)
+endif
+
+_runtime_$(1)_CFLAGS=$(if $(RELEASE),-O2 -g,-O0 -ggdb3 -fno-omit-frame-pointer) $$(_$(1)_CFLAGS) $$($(1)_CFLAGS) $$(_runtime_$(1)_BITNESS)
+_runtime_$(1)_CXXFLAGS=$(if $(RELEASE),-O2 -g,-O0 -ggdb3 -fno-omit-frame-pointer) $$(_$(1)_CXXFLAGS) $$($(1)_CXXFLAGS) $$(_runtime_$(1)_BITNESS)
+_runtime_$(1)_CPPFLAGS=$(if $(RELEASE),-O2 -g,-O0 -ggdb3 -fno-omit-frame-pointer) $$(_$(1)_CPPFLAGS) $$($(1)_CPPFLAGS) $$(_runtime_$(1)_BITNESS)
+_runtime_$(1)_CXXCPPFLAGS=$(if $(RELEASE),-O2 -g,-O0 -ggdb3 -fno-omit-frame-pointer) $$(_$(1)_CXXCPPFLAGS) $$($(1)_CXXCPPFLAGS) $$(_runtime_$(1)_BITNESS)
 _runtime_$(1)_LDFLAGS=$$(_$(1)_LDFLAGS) $$($(1)_LDFLAGS)
 
 _runtime_$(1)_AC_VARS=$$(_$(1)_AC_VARS) $$($(1)_AC_VARS)


### PR DESCRIPTION
When building 32-bit binaries on a 64-bit system and vice versa, it is necessary
to pass the `-m32` or `-m64` compiler flags, respectively. Failure to do so will
result not only in linking problems (different binary architecture) but also in
problems when using some system headers which are sensitive to the architecture.
For instance, `ucontext.h` contains register set definitions for different
architectures and building Mono runtime with a 64-bit compiler targetting 32-bit
architecture results in this error:

```
   .../mono/mono/utils/mono-sigcontext.h:173:74: error: ‘REG_EIP’ undeclared (first use in this function); did you mean ‘REG_RIP’?
      #define UCONTEXT_REG_EIP(ctx) (((ucontext_t*)(ctx))->uc_mcontext.gregs [REG_EIP])
```
The issue here is that the compiler defines the `__x86_64__` macro which causes
`ucontext.h` to choose declarations for amd64 (which does not use `REG_EIP` but
has `REG_RIP` instead) while Mono runtime assumes its building for a 32-bit host
and uses 32-bit register names. Passing `-m32` to the compiler will fix the
issue as now the compiler will define the `__i386__` macro and all parties will
agree where they are and what they want.

This commit uses a rather baroque statement when constructing compiler flags to
build the Mono runtime to check whether the host triple targets 32 or 64-bit
host and adds the appropriate flag.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
