### PR TITLE
[wasm] Add .nuspec for generating the WebAssembly Framework NuGet package.

### DIFF
--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -174,6 +174,9 @@ build-managed: build-debug-sample build-test-suite $(WASM_BCL_DIR)/monolinker.ex
 build-dbg-proxy:
 	dotnet build ProxyDriver
 
+build-framework-nuget:
+	nuget pack WebAssembly.Framework.nuspec
+
 build: build-native build-managed
 
 CHAKRA=~/.jsvu/ch
@@ -202,7 +205,7 @@ run-all-%:
 
 clean:
 
-package: build build-dbg-proxy
+package: build build-dbg-proxy build-framework-nuget
 	rm -rf tmp
 	mkdir tmp
 	mkdir tmp/bcl
@@ -228,6 +231,7 @@ package: build build-dbg-proxy
 	cp WasmHttpMessageHandler.cs tmp
 	cp WebAssembly.Net.Http.dll tmp/framework
 	cp WebAssembly.Net.Http.pdb tmp/framework
+	cp WebAssembly.Framework.0.1.0-alpha.nupkg tmp/framework
 	cp sample.cs tmp/
 	cp README.md tmp/
 	cp server.py tmp/

--- a/sdks/wasm/WebAssembly.Framework.nuspec
+++ b/sdks/wasm/WebAssembly.Framework.nuspec
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
+  <metadata minClientVersion="">
+    <id>WebAssembly.Framework</id>
+    <version>0.1.0-alpha</version>
+    <title>WebAssembly Framework</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>The WebAssembly.Framework provides access to the JavaScript Bindings and an implementation of an HttpClientHandler that works under WebAssembly.</description>
+    <summary></summary>
+    <releaseNotes></releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <language></language>
+    <tags>WebAssembly;mono;bindings;Http</tags>
+  </metadata>
+  <files>
+    <!--file src="./WebAssembly.Framework/readme.txt" target="readme.txt" /-->
+    <file src="./WebAssembly.Bindings.dll" target="lib/portable/WebAssembly.Bindings.dll" />
+    <file src="./WebAssembly.Bindings.pdb" target="lib/portable/WebAssembly.Bindings.pdb" />
+    <file src="./WebAssembly.Net.Http.dll" target="lib/portable/WebAssembly.Net.Http.dll" />
+    <file src="./WebAssembly.Net.Http.pdb" target="lib/portable/WebAssembly.Net.Http.pdb" />
+  </files>
+</package>


### PR DESCRIPTION
Add NuGet nuspec for generating the WebAssembly Framework NuGet packages.

The generated nupkg will be copied to the generated package zip under the framework directory.
 