### PR TITLE
Temporary disable thread-suspend-suspended.exe and thread-suspend-sefsuspended.exe

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1071,7 +1071,8 @@ if HOST_WIN32
 PLATFORM_DISABLED_TESTS += async-exc-compilation.exe finally_guard.exe finally_block_ending_in_dead_bb.exe \
 	bug-18026.exe monitor.exe threadpool-exceptions5.exe process-unref-race.exe w32message.exe \
 	unhandled-exception-1.exe unhandled-exception-2.exe unhandled-exception-3.exe unhandled-exception-4.exe \
-	unhandled-exception-5.exe unhandled-exception-6.exe unhandled-exception-7.exe unhandled-exception-8.exe
+	unhandled-exception-5.exe unhandled-exception-6.exe unhandled-exception-7.exe unhandled-exception-8.exe \
+	thread-suspend-suspended.exe thread-suspend-selfsuspended.exe
 endif
 
 # test_virt.exe fails because callee takes more parameters than caller, 1 vs. 0, and


### PR DESCRIPTION
Only on Windows x86 while investigating root cause of failure (not replicating outside CI).
