### PR TITLE
[2018-06] Ignore some xunit tests for XA (non compatible with xunit 2.4)

### DIFF
--- a/mcs/class/System.Core/System.Core_xtest.dll.sources
+++ b/mcs/class/System.Core/System.Core_xtest.dll.sources
@@ -56,7 +56,7 @@
 ../../../external/corefx/src/System.Linq.Parallel/tests/Combinatorial/*.cs
 ../../../external/corefx/src/System.Linq.Parallel/tests/Helpers/*.cs
 #../../../external/corefx/src/System.Linq.Parallel/tests/QueryOperators/*.cs
-../../../external/corefx/src/System.Linq.Parallel/tests/*.cs:WithCancellationTests.cs,PlinqModesTests.cs,ExchangeTests.cs,EtwTests.cs
+../../../external/corefx/src/System.Linq.Parallel/tests/*.cs:WithCancellationTests.cs,PlinqModesTests.cs,ExchangeTests.cs,EtwTests.cs,ParallelEnumerableTests.cs
 ../../../external/corefx/src/Common/tests/System/Threading/ThreadPoolHelpers.cs
 ../../../external/corefx/src/Common/tests/System/Diagnostics/Tracing/TestEventListener.cs
 ../../../external/corefx/src/Common/tests/System/ShouldNotBeInvokedException.cs

--- a/mcs/class/corlib/corlib_xtest.dll.sources
+++ b/mcs/class/corlib/corlib_xtest.dll.sources
@@ -208,7 +208,7 @@
 ../../../external/corefx/src/Common/tests/System/EnumTypes.cs
 ../../../external/corefx/src/Common/tests/System/ObjectCloner.cs
 ../../../external/corefx/src/Common/tests/System/Diagnostics/DebuggerAttributes.cs
-../../../external/corefx/src/System.Collections/tests/Generic/SortedSet/*.cs
+../../../external/corefx/src/System.Collections/tests/Generic/SortedSet/*.cs:SortedSet.TreeSubSet.Tests.cs
 ../../../external/corefx/src/System.Collections/tests/Generic/HashSet/*.cs
 ../../../external/corefx/src/System.Collections/tests/Generic/Stack/*.cs
 ../../../external/corefx/src/System.Collections/tests/Generic/SortedList/*.cs
@@ -219,7 +219,7 @@
 ../../../external/corefx/src/System.Collections/tests/Generic/HashSet/*.cs
 ../../../external/corefx/src/System.Collections/tests/Generic/Dictionary/HashCollisionScenarios/*.cs
 ../../../external/corefx/src/System.Collections/tests/Generic/Dictionary/*.cs
-../../../external/corefx/src/System.Collections/tests/Generic/Comparers/*.cs
+../../../external/corefx/src/System.Collections/tests/Generic/Comparers/*.cs:EqualityComparer.Tests.cs
 ../../../external/corefx/src/System.Collections/tests/BitArray/*.cs:BitArray_GetSetTests.cs
 ../../../external/corefx/src/System.Collections/tests/*.cs
 


### PR DESCRIPTION
These tests were disabled during https://github.com/mono/mono/pull/9707/files
so this PR is basically a cherry-pick of those.
We'll enable them back once we sync our corefx fork (those tests were changed in the upstream).

Fixes https://github.com/mono/mono/issues/10606
Fixes https://github.com/mono/mono/issues/10607 (needs https://github.com/mono/corefx/pull/140 + "bump corefx")
Fixes https://github.com/mono/mono/issues/10608
Fixes https://github.com/mono/mono/issues/10609