### PR TITLE
[System.Reflection] Include corefx unit tests.

### DIFF
--- a/mcs/class/corlib/corlib_xtest.dll.sources
+++ b/mcs/class/corlib/corlib_xtest.dll.sources
@@ -15,12 +15,9 @@
 ../../../external/corefx/src/System.Reflection.Emit/tests/Utilities.cs
 
 ../../../external/corefx/src/System.Reflection/tests/Common.cs
-../../../external/corefx/src/System.Reflection/tests/ConstructorInfoTests.cs
-../../../external/corefx/src/System.Reflection/tests/FieldInfoTests.cs
-../../../external/corefx/src/System.Reflection/tests/ManifestResourceInfoTests.cs
-#../../../external/corefx/src/System.Reflection/tests/MemberInfoTests.cs
-../../../external/corefx/src/System.Reflection/tests/ParameterInfoTests.cs
-../../../external/corefx/src/System.Reflection/tests/PropertyInfoTests.cs
+
+../../../external/corefx/src/System.Reflection/tests/*.cs:AssemblyTests.cs,AssemblyNameTests.cs,EventInfoTests.cs,GetTypeTests.cs,MemberInfoTests.cs,MethodInfoTests.cs,ModuleTests.cs,TypeInfoTests.cs
+../../../external/corefx/src/System.Reflection.Extensions/tests/*.cs:RuntimeReflectionExtensionTestsWithQuirks.cs,RuntimeReflectionExtensionTests.cs
 
 #TODO: audit the commented out tests and fix or disable
 


### PR DESCRIPTION
All tests from `../../../external/corefx/src/System.Reflection/tests` and `../../../external/corefx/src/System.Reflection.Extensions/tests`. Some of them are excluded because the related types has not been imported yet.

Part of #9660.