### PR TITLE
[interp] fixes for native types

### DIFF
--- a/mono/mini/builtin-types.cs
+++ b/mono/mini/builtin-types.cs
@@ -301,6 +301,18 @@ public class BuiltinTests {
 		return 0;
 	}
 
+	static int test_0_nint_tostring ()
+	{
+		int x = 1337;
+		if (((nint) x).ToString () != "1337")
+			return 1;
+		x = -1337;
+		if (((nint) x).ToString () != "-1337")
+			return 2;
+
+		return 0;
+	}
+
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]
 	static bool decimal_cmp (decimal a, decimal b)
 	{
@@ -693,6 +705,18 @@ public class BuiltinTests {
 			return 2;
 		if (x.ToString () != "10")
 			return 3;
+		return 0;
+	}
+
+	static int test_0_nuint_tostring ()
+	{
+		int x = 1337;
+		if (((nuint) x).ToString () != "1337")
+			return 1;
+		x = -1337;
+		if (((nuint) x).ToString () == "-1337")
+			return 2;
+
 		return 0;
 	}
 
@@ -1165,6 +1189,19 @@ public class BuiltinTests {
 			return 2;
 		if (x.ToString () != "10")
 			return 3;
+		return 0;
+	}
+
+	static int test_0_nfloat_tostring ()
+	{
+		float x = 1337.0f;
+		nfloat y = (nfloat) x;
+		if (y.ToString () != "1337")
+			return 1;
+		x = -1337.0f;
+		if (((nfloat) x).ToString () != "-1337")
+			return 2;
+
 		return 0;
 	}
 

--- a/mono/mini/builtin-types.cs
+++ b/mono/mini/builtin-types.cs
@@ -1025,10 +1025,94 @@ public class BuiltinTests {
 		return 0;
 	}
 
+	static int test_0_nfloat_isinfinity ()
+	{
+		var x = (nfloat) float.NaN;
+		if (nfloat.IsInfinity (x))
+			return 1;
+		if (nfloat.IsInfinity (12))
+			return 2;
+		if (!nfloat.IsInfinity (nfloat.PositiveInfinity))
+			return 3;
+		if (!nfloat.IsInfinity (nfloat.NegativeInfinity))
+			return 4;
+
+		return 0;
+	}
+
+	static int test_0_nfloat_isnegativeinfinity ()
+	{
+		var x = (nfloat) float.NaN;
+		if (nfloat.IsNegativeInfinity (x))
+			return 1;
+		if (nfloat.IsNegativeInfinity (12))
+			return 2;
+		if (nfloat.IsNegativeInfinity (nfloat.PositiveInfinity))
+			return 3;
+		if (!nfloat.IsNegativeInfinity (nfloat.NegativeInfinity))
+			return 4;
+
+		float f = float.NegativeInfinity;
+		nfloat n = (nfloat) f;
+		if (!nfloat.IsNegativeInfinity (n))
+			return 5;
+
+		double d = double.NegativeInfinity;
+		n = (nfloat) d;
+		if (!nfloat.IsNegativeInfinity (n))
+			return 6;
+
+		return 0;
+	}
+
+	static int test_0_nfloat_ispositiveinfinity ()
+	{
+		var x = (nfloat) float.NaN;
+		if (nfloat.IsPositiveInfinity (x))
+			return 1;
+		if (nfloat.IsPositiveInfinity (12))
+			return 2;
+		if (!nfloat.IsPositiveInfinity (nfloat.PositiveInfinity))
+			return 3;
+		if (nfloat.IsPositiveInfinity (nfloat.NegativeInfinity))
+			return 4;
+
+		float f = float.PositiveInfinity;
+		nfloat n = (nfloat) f;
+		if (!nfloat.IsPositiveInfinity (n))
+			return 5;
+
+		double d = double.PositiveInfinity;
+		n = (nfloat) d;
+		if (!nfloat.IsPositiveInfinity (n))
+			return 6;
+
+		return 0;
+	}
+
 	static int test_0_nfloat_isnan ()
 	{
 		var x = (nfloat) float.NaN;
-		return nfloat.IsNaN (x) ? 0 : 1;
+		if (!nfloat.IsNaN (x))
+			return 1;
+		if (nfloat.IsNaN (12))
+			return 2;
+		if (nfloat.IsNaN (nfloat.PositiveInfinity))
+			return 3;
+		if (nfloat.IsNaN (nfloat.NegativeInfinity))
+			return 4;
+
+		float f = float.NaN;
+		nfloat n = (nfloat) f;
+		if (!nfloat.IsNaN (n))
+			return 5;
+
+		double d = double.NaN;
+		n = (nfloat) d;
+		if (!nfloat.IsNaN (n))
+			return 6;
+
+		return 0;
 	}
 
 	static int test_0_nfloat_compareto ()

--- a/mono/mini/builtin-types.cs
+++ b/mono/mini/builtin-types.cs
@@ -270,14 +270,25 @@ public class BuiltinTests {
 		return 0;
 	}
 
-	// static int test_0_nint_call_boxed_equals ()
-	// {
-	// 	object x = new nint (10);
-	// 	object y = new nint (10);
-	// 	if (!x.Equals (y))
-	// 		return 1;
-	// 	return 0;
-	// }
+	static int test_0_nint_call_boxed_equals ()
+	{
+		object x = new nint (10);
+		object y = new nint (10);
+		if (!x.Equals (y))
+			return 1;
+		return 0;
+	}
+
+	static int test_0_nint_equals ()
+	{
+		if (!((nint) 0).Equals ((nint) 0))
+			return 1;
+		if (!((nint) 0).Equals ((object) (nint) 0))
+			return 2;
+		if (((nint) 0).Equals (null))
+			return 3;
+		return 0;
+	}
 
 	static int test_0_nint_call_boxed_funs ()
 	{
@@ -654,14 +665,25 @@ public class BuiltinTests {
 		return 0;
 	}
 
-	// static int test_0_nuint_call_boxed_equals ()
-	// {
-	// 	object x = new nuint (10);
-	// 	object y = new nuint (10);
-	// 	if (!x.Equals (y))
-	// 		return 1;
-	// 	return 0;
-	// }
+	static int test_0_nuint_call_boxed_equals ()
+	{
+		object x = new nuint (10);
+		object y = new nuint (10);
+		if (!x.Equals (y))
+			return 1;
+		return 0;
+	}
+
+	static int test_0_nuint_equals ()
+	{
+		if (!((nuint) 0).Equals ((nuint) 0))
+			return 1;
+		if (!((nuint) 0).Equals ((object) (nuint) 0))
+			return 2;
+		if (((nuint) 0).Equals (null))
+			return 3;
+		return 0;
+	}
 
 	static int test_0_nuint_call_boxed_funs ()
 	{
@@ -1031,14 +1053,25 @@ public class BuiltinTests {
 		return 0;
 	}
 
-	// static int test_0_nfloat_call_boxed_equals ()
-	// {
-	// 	object x = new nfloat (10f);
-	// 	object y = new nfloat (10f);
-	// 	if (!x.Equals (y))
-	// 		return 1;
-	// 	return 0;
-	// }
+	static int test_0_nfloat_call_boxed_equals ()
+	{
+		object x = new nfloat (10f);
+		object y = new nfloat (10f);
+		if (!x.Equals (y))
+			return 1;
+		return 0;
+	}
+
+	static int test_0_nfloat_equals ()
+	{
+		if (!((nfloat) 0).Equals ((nfloat) 0))
+			return 1;
+		if (!((nfloat) 0).Equals ((object) (nfloat) 0))
+			return 2;
+		if (((nfloat) 0).Equals (null))
+			return 3;
+		return 0;
+	}
 
 	static int test_0_nfloat_call_boxed_funs ()
 	{

--- a/mono/mini/builtin-types.cs
+++ b/mono/mini/builtin-types.cs
@@ -1,5 +1,11 @@
 // #define ARCH_32
-#define NINT_JIT_OPTIMIZED
+
+/* This is _NOT_ set by Xamarin.iOS. We can enable it in order to make sure
+ * methods are intrinsified (by throwing NotImplementedException), but some
+ * methods aren't intrinsified by JIT/interp. For example, conversion to
+ * decimal. Therefore JIT/interp should fall back to managed implementation.
+ */
+// #define NINT_JIT_OPTIMIZED
 
 using System;
 using System.Diagnostics;
@@ -27,6 +33,7 @@ public class BuiltinTests {
 	{
 		var x = (nint)10;
 		var y = (nint)20L;
+		int z = 30;
 
 		if ((int)x != 10)
 			return 1;
@@ -36,6 +43,8 @@ public class BuiltinTests {
 			return 3;
 		if ((long)y != 20L)
 			return 4;
+		if ((nint)z != 30)
+			return 5;
 		return 0;
 	}
 
@@ -259,6 +268,28 @@ public class BuiltinTests {
 		return 0;
 	}
 
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	static bool decimal_cmp (decimal a, decimal b)
+	{
+		return a == b;
+	}
+
+	static int test_0_nint_implicit_decimal ()
+	{
+		nint a = new nint (10);
+		nint b = new nint (9);
+		if (decimal_cmp (a, b))
+			return 1;
+		b++;
+		if (!decimal_cmp (a, b))
+			return 2;
+		if (!decimal_cmp ((nint) 10, b))
+			return 3;
+		if (!decimal_cmp (a, (nint) 10))
+			return 4;
+		return 0;
+	}
+
 	public int test_0_nint_unboxed_member_calls ()
 	{
 		var x = (nint)10;
@@ -270,6 +301,81 @@ public class BuiltinTests {
 			return 2;
 		return 0;
 	}
+
+	struct SomeNativeStructWithNint {
+		public nint a;
+		public static nint b;
+
+		public SomeNativeStructWithNint (nint a)
+		{
+			this.a = a;
+			b = a + 1;
+		}
+
+		public static nint GetAStatic (SomeNativeStructWithNint x)
+		{
+			return x.a;
+		}
+
+		public nint GetA ()
+		{
+			return a;
+		}
+	}
+
+	class SomeClassWithNint {
+		public nint a;
+
+		public SomeClassWithNint (nint a)
+		{
+			this.a = a;
+		}
+
+		public virtual nint GetAVirtual ()
+		{
+			return a;
+		}
+	}
+
+	public int test_0_nint_fieldload ()
+	{
+		var x = new SomeNativeStructWithNint ((nint) 20f);
+
+		if ((float) x.a != 20f)
+			return 1;
+
+		if ((int) x.a != 20)
+			return 2;
+
+		if ((float) SomeNativeStructWithNint.GetAStatic (x) != 20f)
+			return 3;
+
+		if ((float) x.GetA () != 20f)
+			return 4;
+
+		if ((int) SomeNativeStructWithNint.GetAStatic (x) != 20)
+			return 5;
+
+		if ((int) x.GetA () != 20)
+			return 6;
+
+		if ((float) SomeNativeStructWithNint.b != 21f)
+			return 7;
+
+		if ((int) SomeNativeStructWithNint.b != 21)
+			return 8;
+
+		SomeClassWithNint y = new SomeClassWithNint ((nint) 30f);
+
+		if ((int) y.GetAVirtual () != 30)
+			return 9;
+
+		if ((float) y.GetAVirtual () != 30f)
+			return 10;
+
+		return 0;
+	}
+
 
 	static int test_0_nuint_ctor ()
 	{
@@ -289,6 +395,7 @@ public class BuiltinTests {
 	{
 		var x = (nuint)10;
 		var y = (nuint)20L;
+		int z = 30;
 
 		if ((uint)x != 10)
 			return 1;
@@ -298,6 +405,8 @@ public class BuiltinTests {
 			return 3;
 		if ((ulong)y != 20L)
 			return 4;
+		if ((nuint)z != 30)
+			return 5;
 		return 0;
 	}
 
@@ -521,6 +630,22 @@ public class BuiltinTests {
 		return 0;
 	}
 
+	static int test_0_nuint_implicit_decimal ()
+	{
+		nuint a = new nuint (10);
+		nuint b = new nuint (9);
+		if (decimal_cmp (a, b))
+			return 1;
+		b++;
+		if (!decimal_cmp (a, b))
+			return 2;
+		if (!decimal_cmp ((nuint) 10, b))
+			return 3;
+		if (!decimal_cmp (a, (nuint) 10))
+			return 4;
+		return 0;
+	}
+
 	public int test_0_nuint_unboxed_member_calls ()
 	{
 		var x = (nuint)10;
@@ -530,6 +655,80 @@ public class BuiltinTests {
 #endif
 		if (x != nuint.Parse ("10"))
 			return 2;
+		return 0;
+	}
+
+	struct SomeNativeStructWithNuint {
+		public nuint a;
+		public static nuint b;
+
+		public SomeNativeStructWithNuint (nuint a)
+		{
+			this.a = a;
+			b = a + 1;
+		}
+
+		public static nuint GetAStatic (SomeNativeStructWithNuint x)
+		{
+			return x.a;
+		}
+
+		public nuint GetA ()
+		{
+			return a;
+		}
+	}
+
+	class SomeClassWithNuint {
+		public nuint a;
+
+		public SomeClassWithNuint (nuint a)
+		{
+			this.a = a;
+		}
+
+		public virtual nuint GetAVirtual ()
+		{
+			return a;
+		}
+	}
+
+	public int test_0_nuint_fieldload ()
+	{
+		var x = new SomeNativeStructWithNuint ((nuint) 20f);
+
+		if ((float) x.a != 20f)
+			return 1;
+
+		if ((int) x.a != 20)
+			return 2;
+
+		if ((float) SomeNativeStructWithNuint.GetAStatic (x) != 20f)
+			return 3;
+
+		if ((float) x.GetA () != 20f)
+			return 4;
+
+		if ((int) SomeNativeStructWithNuint.GetAStatic (x) != 20)
+			return 5;
+
+		if ((int) x.GetA () != 20)
+			return 6;
+
+		if ((float) SomeNativeStructWithNuint.b != 21f)
+			return 7;
+
+		if ((int) SomeNativeStructWithNuint.b != 21)
+			return 8;
+
+		SomeClassWithNuint y = new SomeClassWithNuint ((nuint) 30f);
+
+		if ((int) y.GetAVirtual () != 30)
+			return 9;
+
+		if ((float) y.GetAVirtual () != 30f)
+			return 10;
+
 		return 0;
 	}
 
@@ -562,6 +761,12 @@ public class BuiltinTests {
 		if ((double)y != 20)
 			return 4;
 #endif
+		int z = 30;
+		if ((nfloat) z != 30f)
+			return 5;
+
+		if ((int) x != 10)
+			return 6;
 		return 0;
 	}
 
@@ -780,6 +985,22 @@ public class BuiltinTests {
 		return 0;
 	}
 
+	static int test_0_nfloat_explicit_decimal ()
+	{
+		nfloat a = new nfloat (10);
+		nfloat b = new nfloat (9);
+		if (decimal_cmp ((decimal) a, (decimal) b))
+			return 1;
+		b += 1.0f;
+		if (!decimal_cmp ((decimal) a, (decimal) b))
+			return 2;
+		if (!decimal_cmp ((decimal) (nfloat) 10.0f, (decimal) b))
+			return 3;
+		if (!decimal_cmp ((decimal) a, (decimal) (nfloat) 10.0f))
+			return 4;
+		return 0;
+	}
+
 	public int test_0_nfloat_unboxed_member_calls ()
 	{
 		var x = (nfloat)10f;
@@ -789,6 +1010,80 @@ public class BuiltinTests {
 #endif
 		if (x != nfloat.Parse ("10"))
 			return 2;
+		return 0;
+	}
+
+	struct SomeNativeStructWithNfloat {
+		public nfloat a;
+		public static nfloat b;
+
+		public SomeNativeStructWithNfloat (nfloat a)
+		{
+			this.a = a;
+			b = a + 1;
+		}
+
+		public static nfloat GetAStatic (SomeNativeStructWithNfloat x)
+		{
+			return x.a;
+		}
+
+		public nfloat GetA ()
+		{
+			return a;
+		}
+	}
+
+	class SomeClassWithNfloat {
+		public nfloat a;
+
+		public SomeClassWithNfloat (nfloat a)
+		{
+			this.a = a;
+		}
+
+		public virtual nfloat GetAVirtual ()
+		{
+			return a;
+		}
+	}
+
+	public int test_0_nfloat_fieldload ()
+	{
+		var x = new SomeNativeStructWithNfloat ((nfloat) 20f);
+
+		if ((float) x.a != 20f)
+			return 1;
+
+		if ((int) x.a != 20)
+			return 2;
+
+		if ((float) SomeNativeStructWithNfloat.GetAStatic (x) != 20f)
+			return 3;
+
+		if ((float) x.GetA () != 20f)
+			return 4;
+
+		if ((int) SomeNativeStructWithNfloat.GetAStatic (x) != 20)
+			return 5;
+
+		if ((int) x.GetA () != 20)
+			return 6;
+
+		if ((float) SomeNativeStructWithNfloat.b != 21f)
+			return 7;
+
+		if ((int) SomeNativeStructWithNfloat.b != 21)
+			return 8;
+
+		SomeClassWithNfloat y = new SomeClassWithNfloat ((nfloat) 30f);
+
+		if ((int) y.GetAVirtual () != 30)
+			return 9;
+
+		if ((float) y.GetAVirtual () != 30f)
+			return 10;
+
 		return 0;
 	}
 

--- a/mono/mini/builtin-types.cs
+++ b/mono/mini/builtin-types.cs
@@ -248,6 +248,28 @@ public class BuiltinTests {
 		return 0;
 	}
 
+	static int test_0_nint_compareto ()
+	{
+		if (((nint) 0).CompareTo ((nint) 0) != 0)
+			return 1;
+		if (((nint) 0).CompareTo ((nint) 1) != -1)
+			return 2;
+		if (((nint) 1).CompareTo ((nint) 0) != 1)
+			return 3;
+
+		if (((nint) 0).CompareTo ((object)(nint) 0) != 0)
+			return 4;
+		if (((nint) 0).CompareTo ((object)(nint) 1) != -1)
+			return 5;
+		if (((nint) 1).CompareTo ((object)(nint) 0) != 1)
+			return 6;
+
+		if (((nint) 1).CompareTo (null) != 1)
+			return 7;
+
+		return 0;
+	}
+
 	// static int test_0_nint_call_boxed_equals ()
 	// {
 	// 	object x = new nint (10);
@@ -610,6 +632,28 @@ public class BuiltinTests {
 		return 0;
 	}
 
+	static int test_0_nuint_compareto ()
+	{
+		if (((nuint) 0).CompareTo ((nuint) 0) != 0)
+			return 1;
+		if (((nuint) 0).CompareTo ((nuint) 1) != -1)
+			return 2;
+		if (((nuint) 1).CompareTo ((nuint) 0) != 1)
+			return 3;
+
+		if (((nuint) 0).CompareTo ((object)(nuint) 0) != 0)
+			return 4;
+		if (((nuint) 0).CompareTo ((object)(nuint) 1) != -1)
+			return 5;
+		if (((nuint) 1).CompareTo ((object)(nuint) 0) != 1)
+			return 6;
+
+		if (((nuint) 1).CompareTo (null) != 1)
+			return 7;
+
+		return 0;
+	}
+
 	// static int test_0_nuint_call_boxed_equals ()
 	// {
 	// 	object x = new nuint (10);
@@ -963,6 +1007,28 @@ public class BuiltinTests {
 	{
 		var x = (nfloat) float.NaN;
 		return nfloat.IsNaN (x) ? 0 : 1;
+	}
+
+	static int test_0_nfloat_compareto ()
+	{
+		if (((nfloat) 0).CompareTo ((nfloat) 0) != 0)
+			return 1;
+		if (((nfloat) 0).CompareTo ((nfloat) 1) != -1)
+			return 2;
+		if (((nfloat) 1).CompareTo ((nfloat) 0) != 1)
+			return 3;
+
+		if (((nfloat) 0).CompareTo ((object)(nfloat) 0) != 0)
+			return 4;
+		if (((nfloat) 0).CompareTo ((object)(nfloat) 1) != -1)
+			return 5;
+		if (((nfloat) 1).CompareTo ((object)(nfloat) 0) != 1)
+			return 6;
+
+		if (((nfloat) 1).CompareTo (null) != 1)
+			return 7;
+
+		return 0;
 	}
 
 	// static int test_0_nfloat_call_boxed_equals ()

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -818,20 +818,6 @@ jit_call_supported (MonoMethod *method, MonoMethodSignature *sig)
 	return FALSE;
 }
 
-static inline gboolean
-type_size (MonoType *type)
-{
-	if (type->type == MONO_TYPE_I4 || type->type == MONO_TYPE_U4)
-		return 4;
-	else if (type->type == MONO_TYPE_I8 || type->type == MONO_TYPE_U8)
-		return 8;
-	else if (type->type == MONO_TYPE_R4 && !type->byref)
-		return 4;
-	else if (type->type == MONO_TYPE_R8 && !type->byref)
-		return 8;
-	return SIZEOF_VOID_P;
-}
-
 static int mono_class_get_magic_index (MonoClass *k)
 {
 	if (mono_class_is_magic_int (k))
@@ -863,6 +849,37 @@ interp_generate_mae_throw (TransformData *td, MonoMethod *method, MonoMethod *ta
 	td->sp -= 2;
 }
 
+/*
+ * These are additional locals that can be allocated as we transform the code.
+ * They are allocated past the method locals so they are accessed in the same
+ * way, with an offset relative to the frame->locals.
+ */
+static int
+create_interp_local (TransformData *td, MonoType *type)
+{
+	int align, size;
+	int offset = td->total_locals_size;
+
+	size = mono_type_size (type, &align);
+	offset = ALIGN_TO (offset, align);
+
+	td->total_locals_size = offset + size;
+
+	return offset;
+}
+
+static void
+dump_mint_code (TransformData *td)
+{
+	const guint16 *p = td->new_code;
+	while (p < td->new_ip) {
+		char *ins = mono_interp_dis_mintop (td->new_code, p);
+		g_print ("%s\n", ins);
+		g_free (ins);
+		p = mono_interp_dis_mintop_len (p);
+	}
+}
+
 static MonoMethodHeader*
 interp_method_get_header (MonoMethod* method, MonoError *error)
 {
@@ -874,6 +891,24 @@ interp_method_get_header (MonoMethod* method, MonoError *error)
 		return NULL;
 	else
 		return mono_method_get_header_internal (method, error);
+}
+
+/* stores top of stack as local and pushes address of it on stack */
+static void
+emit_store_value_as_local (TransformData *td, MonoType *src)
+{
+	int size = mini_magic_type_size (NULL, src);
+	int local_offset = create_interp_local (td, mini_native_type_replace_type (src));
+
+	store_local_general (td, local_offset, src);
+
+	size = ALIGN_TO (size, MINT_VT_ALIGNMENT);
+	ADD_CODE (td, MINT_LDLOC_VT);
+	ADD_CODE (td, local_offset);
+	WRITE32 (td, &size);
+
+	PUSH_VT (td, size);
+	PUSH_TYPE (td, STACK_TYPE_VT, NULL);
 }
 
 /* Return TRUE if call transformation is finished */
@@ -901,7 +936,7 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoMeth
 		if (!strcmp (".ctor", tm)) {
 			MonoType *arg = csignature->params [0];
 			/* depending on SIZEOF_VOID_P and the type of the value passed to the .ctor we either have to CONV it, or do nothing */
-			int arg_size = type_size (arg);
+			int arg_size = mini_magic_type_size (NULL, arg);
 
 			if (arg_size > SIZEOF_VOID_P) { // 8 -> 4
 				switch (type_index) {
@@ -946,8 +981,40 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoMeth
 			td->ip += 5;
 			return TRUE;
 		} else if (!strcmp ("op_Implicit", tm ) || !strcmp ("op_Explicit", tm)) {
-			int arg_size = type_size (csignature->params [0]);
-			if (arg_size > SIZEOF_VOID_P) { // 8 -> 4
+			MonoType *src = csignature->params [0];
+			MonoType *dst = csignature->ret;
+			int src_size = mini_magic_type_size (NULL, src);
+			int dst_size = mini_magic_type_size (NULL, dst);
+
+			gboolean store_value_as_local = FALSE;
+
+			switch (type_index) {
+			case 0: case 1:
+				if (!mini_magic_is_int_type (src) || !mini_magic_is_int_type (dst)) {
+					if (mini_magic_is_int_type (src))
+						store_value_as_local = TRUE;
+					else
+						return FALSE;
+				}
+				break;
+			case 2:
+				if (!mini_magic_is_float_type (src) || !mini_magic_is_float_type (dst)) {
+					if (mini_magic_is_float_type (src))
+						store_value_as_local = TRUE;
+					else
+						return FALSE;
+				}
+				break;
+			}
+
+			if (store_value_as_local) {
+				emit_store_value_as_local (td, src);
+
+				/* emit call to managed conversion method */
+				return FALSE;
+			}
+
+			if (src_size > dst_size) { // 8 -> 4
 				switch (type_index) {
 				case 0: case 1:
 					ADD_CODE (td, MINT_CONV_I4_I8);
@@ -958,7 +1025,7 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoMeth
 				}
 			}
 
-			if (arg_size < SIZEOF_VOID_P) { // 4 -> 8
+			if (src_size < dst_size) { // 4 -> 8
 				switch (type_index) {
 				case 0: case 1:
 					ADD_CODE (td, MINT_CONV_I8_I4);
@@ -1701,25 +1768,6 @@ get_basic_blocks (TransformData *td)
 		if (i == CEE_THROW)
 			cbb = get_bb (td, NULL, ip);
 	}
-}
-
-/*
- * These are additional locals that can be allocated as we transform the code.
- * They are allocated past the method locals so they are accessed in the same
- * way, with an offset relative to the frame->locals.
- */
-static int
-create_interp_local (TransformData *td, MonoType *type)
-{
-	int align, size;
-	int offset = td->total_locals_size;
-
-	size = mono_type_size (type, &align);
-	offset = ALIGN_TO (offset, align);
-
-	td->total_locals_size = offset + size;
-
-	return offset;
 }
 
 static void
@@ -4792,16 +4840,11 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsig
 	}
 
 	if (td->verbose_level) {
-		const guint16 *p = td->new_code;
 		g_print ("Runtime method: %s %p, VT stack size: %d\n", mono_method_full_name (method, TRUE), rtm, td->max_vt_sp);
 		g_print ("Calculated stack size: %d, stated size: %d\n", td->max_stack_height, header->max_stack);
-		while (p < td->new_ip) {
-			char *ins = mono_interp_dis_mintop (td->new_code, p);
-			g_print ("%s\n", ins);
-			g_free (ins);
-			p = mono_interp_dis_mintop_len (p);
-		}
+		dump_mint_code (td);
 	}
+
 	/* Check if we use excessive stack space */
 	if (td->max_stack_height > header->max_stack * 3)
 		g_warning ("Excessive stack space usage for method %s, %d/%d", method->name, td->max_stack_height, header->max_stack);

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1075,6 +1075,9 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoMeth
 		} else if (!strcmp ("Parse", tm)) {
 			/* white list */
 			return FALSE;
+		} else if (!strcmp ("ToString", tm)) {
+			/* white list */
+			return FALSE;
 		} else if (!strcmp ("IsNaN", tm) || !strcmp ("IsInfinity", tm) || !strcmp ("IsNegativeInfinity", tm) || !strcmp ("IsPositiveInfinity", tm)) {
 			g_assert (type_index == 2); // nfloat only
 			/* white list */

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1059,10 +1059,10 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoMeth
 			SET_TYPE (td->sp - 1, stack_type [mt], magic_class);
 			td->ip += 5;
 			return TRUE;
-		} else if (!strcmp ("CompareTo", tm)) {
+		} else if (!strcmp ("CompareTo", tm) || !strcmp ("Equals", tm)) {
 			MonoType *arg = csignature->params [0];
 
-			/* on 'System.n*::CompareTo (System.n*)' variant we need to push managed
+			/* on 'System.n*::{CompareTo,Equals} (System.n*)' variant we need to push managed
 			 * pointer instead of value */
 			if (arg->type == MONO_TYPE_VALUETYPE)
 				emit_store_value_as_local (td, arg);
@@ -3221,6 +3221,10 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsig
 
 			td->sp -= csignature->param_count;
 			if (mono_class_is_magic_int (klass) || mono_class_is_magic_float (klass)) {
+#if SIZEOF_VOID_P == 8
+				if (mono_class_is_magic_int (klass))
+					ADD_CODE(td, MINT_CONV_I8_U4);
+#endif
 				ADD_CODE (td, MINT_NEWOBJ_MAGIC);
 				ADD_CODE (td, get_data_item_index (td, mono_interp_get_imethod (domain, m, error)));
 				goto_if_nok (error, exit);

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1059,6 +1059,16 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoMeth
 			SET_TYPE (td->sp - 1, stack_type [mt], magic_class);
 			td->ip += 5;
 			return TRUE;
+		} else if (!strcmp ("CompareTo", tm)) {
+			MonoType *arg = csignature->params [0];
+
+			/* on 'System.n*::CompareTo (System.n*)' variant we need to push managed
+			 * pointer instead of value */
+			if (arg->type == MONO_TYPE_VALUETYPE)
+				emit_store_value_as_local (td, arg);
+
+			/* emit call to managed conversion method */
+			return FALSE;
 		} else if (!strcmp (".cctor", tm)) {
 			/* white list */
 			return FALSE;

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1075,7 +1075,7 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoMeth
 		} else if (!strcmp ("Parse", tm)) {
 			/* white list */
 			return FALSE;
-		} else if (!strcmp ("IsNaN", tm)) {
+		} else if (!strcmp ("IsNaN", tm) || !strcmp ("IsInfinity", tm) || !strcmp ("IsNegativeInfinity", tm) || !strcmp ("IsPositiveInfinity", tm)) {
 			g_assert (type_index == 2); // nfloat only
 			/* white list */
 			return FALSE;

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2752,6 +2752,9 @@ void        mono_simd_intrinsics_init (void);
 gboolean    mono_class_is_magic_int (MonoClass *klass);
 gboolean    mono_class_is_magic_float (MonoClass *klass);
 MonoInst*   mono_emit_native_types_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args);
+gsize       mini_magic_type_size (MonoCompile *cfg, MonoType *type);
+gboolean    mini_magic_is_int_type (MonoType *t);
+gboolean    mini_magic_is_float_type (MonoType *t);
 MonoType*   mini_native_type_replace_type (MonoType *type) MONO_LLVM_INTERNAL;
 
 MonoMethod*


### PR DESCRIPTION
please look at single commits.

------------------------

[interp] fix op_implicit/op_explicit conversions for native types
    
Conversion operators have been mostly broken in the interpreter, for example conversion from nint to float didn't work. While some conversions are easy to intrinsify (like nint -> I8), there are harder cases like nint -> decimal. The JIT actually falls back to the managed implementation, so let's do this in the interpreter as well.
    
However the managed implementation expects a pointer to the value type, i.e. the container type System.nfloat instead of float/double primitives. In such cases the value is going to be stored in a local and then the address of its storage is pushed on the stack before invoking the managed implementation of the conversion.
    
Added test cases for scenarios observed in Xamarin.iOS.

-----------------------

[interp] support ntype.CompareTo ()

-----------------------

[interp] support ntype.Equals ()

-----------------------

 [interp] support nfloat.*Infinity

-----------------------

[interp] support ntype.ToString ()

-----------------------

The conversion issue creeped everywhere in Xamarin.iOS since it heavily relies on nint/nuint/nfloat. With this PR we are getting close to a green monotouch tests 😁 
<img width="874" alt="screen shot 2018-09-21 at 23 24 36" src="https://user-images.githubusercontent.com/75403/45907566-b457eb80-bdf8-11e8-9cc7-b8cf311dd269.png">

needs backporting to 2018-06 and 2018-08
