### PR TITLE
Fix iOS SDK regression due to empty library.

### DIFF
--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -163,8 +163,10 @@ system_native_common_sources = \
 	../../external/corefx/src/Native/Unix/System.Native/pal_memory.c \
 	../../external/corefx/src/Native/Unix/System.Native/pal_memory.h
 
+libmono_system_net_security_native_la_SOURCES = system_net_security_native_empty.c
+
 if ENABLE_GSS
-libmono_system_net_security_native_la_SOURCES = \
+libmono_system_net_security_native_la_SOURCES += \
 	pal_config.h \
 	../../external/corefx/src/Native/Unix/Common/pal_compiler.h \
 	../../external/corefx/src/Native/Unix/Common/pal_types.h \

--- a/mono/metadata/system_net_security_native_empty.c
+++ b/mono/metadata/system_net_security_native_empty.c
@@ -1,0 +1,1 @@
+// Every library must have at least one source file.


### PR DESCRIPTION
https://jenkins.mono-project.com/job/test-mono-pull-request-amd64-osx-products-sdks-ios/4837/parsed_console/log.html

ld: warning: -undefined dynamic_lookup is deprecated on tvOS
ar: no archive members specified
usage:  ar -d [-TLsv] archive file ...
    ar -m [-TLsv] archive file ...
    ar -m [-abiTLsv] position archive file ...
    ar -p [-TLsv] archive [file ...]
    ar -q [-cTLsv] archive file ...
    ar -r [-cuTLsv] archive file ...
    ar -r [-abciuTLsv] position archive file ...
    ar -t [-TLsv] archive [file ...]
    ar -x [-ouTLsv] archive [file ...]
make[5]: *** [libmono-system-net-security-native.la] Error 1