### PR TITLE
[runtime] Avoid warning about missing icalls when AOTing.

### DIFF
--- a/mono/metadata/icall-internals.h
+++ b/mono/metadata/icall-internals.h
@@ -65,4 +65,7 @@ guint32
 mono_icall_drive_info_get_drive_type (MonoString *root_path_name);
 #endif  /* !G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT) */
 
+void*
+mono_lookup_internal_call_full (MonoMethod *method, gboolean warn_on_missing, mono_bool *uses_handles);
+
 #endif /* __MONO_METADATA_ICALL_INTERNALS_H__ */

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -8291,7 +8291,7 @@ no_icall_table (void)
  * If the method is not found, warns and returns NULL.
  */
 gpointer
-mono_lookup_internal_call_full (MonoMethod *method, mono_bool *uses_handles)
+mono_lookup_internal_call_full (MonoMethod *method, gboolean warn_on_missing, mono_bool *uses_handles)
 {
 	char *sigstart;
 	char *tmpsig;
@@ -8384,13 +8384,15 @@ mono_lookup_internal_call_full (MonoMethod *method, mono_bool *uses_handles)
 		if (res)
 			return res;
 
-		g_warning ("cant resolve internal call to \"%s\" (tested without signature also)", mname);
-		g_print ("\nYour mono runtime and class libraries are out of sync.\n");
-		g_print ("The out of sync library is: %s\n", m_class_get_image (method->klass)->name);
-		g_print ("\nWhen you update one from git you need to update, compile and install\nthe other too.\n");
-		g_print ("Do not report this as a bug unless you're sure you have updated correctly:\nyou probably have a broken mono install.\n");
-		g_print ("If you see other errors or faults after this message they are probably related\n");
-		g_print ("and you need to fix your mono install first.\n");
+		if (warn_on_missing) {
+			g_warning ("cant resolve internal call to \"%s\" (tested without signature also)", mname);
+			g_print ("\nYour mono runtime and class libraries are out of sync.\n");
+			g_print ("The out of sync library is: %s\n", m_class_get_image (method->klass)->name);
+			g_print ("\nWhen you update one from git you need to update, compile and install\nthe other too.\n");
+			g_print ("Do not report this as a bug unless you're sure you have updated correctly:\nyou probably have a broken mono install.\n");
+			g_print ("If you see other errors or faults after this message they are probably related\n");
+			g_print ("and you need to fix your mono install first.\n");
+		}
 
 		return NULL;
 	}
@@ -8402,7 +8404,7 @@ mono_lookup_internal_call_full (MonoMethod *method, mono_bool *uses_handles)
 gpointer
 mono_lookup_internal_call (MonoMethod *method)
 {
-	return mono_lookup_internal_call_full (method, NULL);
+	return mono_lookup_internal_call_full (method, TRUE, NULL);
 }
 
 /*

--- a/mono/metadata/loader.h
+++ b/mono/metadata/loader.h
@@ -62,9 +62,6 @@ mono_add_internal_call     (const char *name, const void* method);
 MONO_API void*
 mono_lookup_internal_call (MonoMethod *method);
 
-void*
-mono_lookup_internal_call_full (MonoMethod *method, mono_bool *uses_handles);
-
 MONO_API const char*
 mono_lookup_icall_symbol (MonoMethod *m);
 

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -38,6 +38,7 @@
 #include "mono/metadata/threadpool.h"
 #include "mono/metadata/handle.h"
 #include "mono/metadata/custom-attrs-internals.h"
+#include "mono/metadata/icall-internals.h"
 #include "mono/utils/mono-counters.h"
 #include "mono/utils/mono-tls.h"
 #include "mono/utils/mono-memory-model.h"
@@ -6224,7 +6225,7 @@ emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 	IcallHandlesLocal *handles_locals = NULL;
 	MonoMethodSignature *sig = mono_method_signature (method);
 
-	(void) mono_lookup_internal_call_full (method, &uses_handles);
+	(void) mono_lookup_internal_call_full (method, FALSE, &uses_handles);
 
 	/* If it uses handles and MonoError, it had better check exceptions */
 	g_assert (!uses_handles || check_exceptions);

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -3408,7 +3408,8 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 			else if (!aot)
 				mono_lookup_pinvoke_call (method, &exc_class, &exc_arg);
 		} else {
-			piinfo->addr = mono_lookup_internal_call (method);
+			if (!aot || (method->klass == mono_defaults.string_class))
+				piinfo->addr = mono_lookup_internal_call (method);
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/10598.