### PR TITLE
Mitigation for spawn FD closing taking forever with a big FD limit

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -183,6 +183,8 @@ case "$host" in
 		with_sgen_default_concurrent=yes
 		;;
 	*-*-*freebsd*)
+		dnl For close_my_fds
+		LDFLAGS="$LDFLAGS -lutil"
 		if test "x$PTHREAD_CFLAGS" = "x"; then
 			CPPFLAGS="$CPPFLAGS -DGC_FREEBSD_THREADS"
 			libmono_cflags=
@@ -197,7 +199,7 @@ case "$host" in
 			LDFLAGS="$LDFLAGS $PTHREAD_LIBS -L/usr/local/lib"
 			libmono_ldflags="$PTHREAD_LIBS"
 		fi
-		CPPFLAGS="$CPPFLAGS -DHOST_BSD"
+		CPPFLAGS="$CPPFLAGS -DHOST_BSD -D_WITH_GETLINE"
 		need_link_unlink=yes
 		AC_DEFINE(PTHREAD_POINTER_ID, 1, [pthread is a pointer])
 		libdl=

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -47,9 +47,13 @@
 #include <utime.h>
 #endif
 
-// For max_fd_count
+// For close_my_fds
 #if defined (_AIX)
 #include <procinfo.h>
+#elif defined (__FreeBSD__)
+#include <sys/sysctl.h>
+#include <sys/user.h>
+#include <libutil.h>
 #endif
 
 #include <mono/metadata/object-internals.h>
@@ -1602,7 +1606,7 @@ leave:
 /**
  * Gets the biggest numbered file descriptor for the current process; failing
  * that, the system's file descriptor limit. This is called by the fork child
- * in process_create.
+ * in close_my_fds.
  */
 static inline guint32
 max_fd_count (void)
@@ -1610,30 +1614,91 @@ max_fd_count (void)
 #if defined (_AIX)
 	struct procentry64 pe;
 	pid_t p;
-	p = getpid (); // will be called by the child in process_create
-	// getprocs 3rd/4th arg is for getting the associated FDs for a proc,
-	// but all we need is just the biggest FD, which is in procentry64
+	p = getpid ();
 	if (getprocs64 (&pe, sizeof (pe), NULL, 0, &p, 1) != -1) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS,
 			   "%s: maximum returned fd in child is %u",
 			   __func__, pe.pi_maxofile);
 		return pe.pi_maxofile; // biggest + 1
 	}
+#endif
+	// fallback to user/system limit if unsupported/error
+	return eg_getdtablesize ();
+}
+
+/**
+ * Closes all of the process' opened file descriptors, applying a strategy
+ * appropriate for the target system. This is called by the fork child in
+ * process_create.
+ */
+static void
+close_my_fds (void)
+{
 // TODO: Other platforms.
 //       * On Linux, we can just walk /proc/self/fd? Perhaps in that approach,
 //         you can also just enumerate and close FDs that way instead?
 //       * On macOS, use proc_pidinfo + PROC_PIDLISTFDS? See:
 //         http://blog.palominolabs.com/2012/06/19/getting-the-files-being-used-by-a-process-on-mac-os-x/
 //         (I have no idea how this plays out on i/watch/tvOS.)
-//       * On the BSDs, there's likely a sysctl for this.
+//       * On the other BSDs, there's likely a sysctl for this.
 //       * On Solaris, there exists posix_spawn_file_actions_addclosefrom_np,
 //         but that assumes we're using posix_spawn; we aren't, as we do some
 //         complex stuff between fork and exec. There's likely a way to get
 //         the FD list/count though (maybe look at addclosefrom source in
 //         illumos?) or just walk /proc/pid/fd like Linux?
+#if defined (__FreeBSD__)
+	/* FreeBSD lets us get a list of FDs. There's a MIB to access them
+	 * directly, but it uses a lot of nasty variable length structures. The
+	 * system library libutil provides a nicer way to get a fixed length
+	 * version instead. */
+	struct kinfo_file *kif;
+	int count, i;
+	/* this is malloced but we won't need to free once we exec/exit */
+	kif = kinfo_getfile (getpid (), &count);
+	if (kif) {
+		for (i = 0; i < count; i++) {
+			/* negative FDs look to be used by the OS */
+			if (kif [i].kf_fd > 2) /* no neg + no stdio */
+				close (kif [i].kf_fd);
+		}
+		return;
+	} else {
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS,
+			   "%s: kinfo_getfile failed, using fallback",
+			   __func__);
+	}
+#elif defined (_AIX)
+	struct procentry64 pe;
+	/* this array struct is 1 MB, we're NOT putting it on the stack.
+	 * likewise no need to free; getprocs will fail if we use the smalller
+	 * versions if we have a lot of FDs (is it worth it?)
+	 */
+	struct fdsinfo_100K *fds;
+	pid_t p;
+	p = getpid ();
+	fds = (struct fdsinfo_100K *) g_malloc0 (sizeof (struct fdsinfo_100K));
+	if (!fds) {
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS,
+			   "%s: fdsinfo alloc failed, using fallback",
+			   __func__);
+		goto fallback;
+	}
+
+	if (getprocs64 (&pe, sizeof (pe), fds, sizeof (struct fdsinfo_100K), &p, 1) != -1) {
+		for (int i = 3; i < pe.pi_maxofile; i++) {
+			if (fds->pi_ufd [i].fp != 0)
+				close (fds->pi_ufd [i].fp);
+		}
+	} else {
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS,
+			   "%s: getprocs64 failed, using fallback",
+			   __func__);
+	}
 #endif
-	// fallback to user/system limit if unsupported/error
-	return eg_getdtablesize ();
+fallback:
+	/* Fallback: Close FDs blindly, according to an FD limit */
+	for (guint32 i = max_fd_count () - 1; i > 2; i--)
+		close (i);
 }
 
 static gboolean
@@ -2017,9 +2082,8 @@ process_create (const gunichar2 *appname, const gunichar2 *cmdline,
 		dup2 (out_fd, 1);
 		dup2 (err_fd, 2);
 
-		/* Close all file descriptors */
-		for (i = max_fd_count () - 1; i > 2; i--)
-			close (i);
+		/* Close this child's file handles. */
+		close_my_fds ();
 
 #ifdef DEBUG_ENABLED
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: exec()ing [%s] in dir [%s]", __func__, cmd,


### PR DESCRIPTION
On systems with a large file descriptor limit, Mono takes a very
long time to spawn a new process; with informal testing on the AIX
CI builder, (with a POWER7) it took ~30 minutes. This is obviously
very undesirable, but hand our is forced - libraries the user might
be calling could be creating non-CLOEXEC files we're unaware of. As
such, we started from the FD limit and worked our way down until we
hit stdio. Using APIs such as posix_spawn aren't desirable as we do
some fiddling with the child before we exec; and even then, closing
FDs with posix_spawn relies on non-standard file actions like
Solaris' addclosefrom not present on many systems. (All of this is
unnecessary on Windows, of course.)

This presents an alternative way (currently only implemented on AIX
but with notes how for other platforms) to try to close the child's
loose FDs before exec; by trying to get the highest number FD in
use, then work our way down. In the event we can't, we simply fall
back to the old logic.

See #6555 for a discussion and the initial problem being mitigated.

----

Basic testing seems to work; even with an "unlimited" FD limit, it works - the returned FD seems congruent with procfs, and it starts on a small number that takes no time at all. Implementing this for other systems would be quite nice; maybe I'll try to poke how for FreeBSD. However, as suggested in the comments, perhaps straight-up enumeration might also be desirable instead, in which case, the close logic would need a slight rewrite for that.