### PR TITLE
[2018-08] [System.Net.Http] Allow empty value in ProductHeaderValue

### DIFF
--- a/mcs/class/System.Net.Http/System.Net.Http.Headers/ProductHeaderValue.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http.Headers/ProductHeaderValue.cs
@@ -41,7 +41,7 @@ namespace System.Net.Http.Headers
 		public ProductHeaderValue (string name, string version)
 			: this (name)
 		{
-			if (version != null)
+			if (!string.IsNullOrEmpty (version))
 				Parser.Token.Check (version);
 
 			Version = version;

--- a/mcs/class/System.Net.Http/Test/System.Net.Http.Headers/ProductHeaderValueTest.cs
+++ b/mcs/class/System.Net.Http/Test/System.Net.Http.Headers/ProductHeaderValueTest.cs
@@ -63,6 +63,7 @@ namespace MonoTests.System.Net.Http.Headers
 		public void Ctor ()
 		{
 			new ProductHeaderValue ("aa", null);
+			new ProductHeaderValue ("aa", "");
 		}
 
 		[Test]


### PR DESCRIPTION
Backport of #10511.

/cc @marek-safar