### PR TITLE
Update roslyn automated tests

### DIFF
--- a/acceptance-tests/SUBMODULES.json
+++ b/acceptance-tests/SUBMODULES.json
@@ -2,7 +2,7 @@
   {
     "name": "roslyn", 
     "url": "git://github.com/kg/roslyn.git",
-    "rev": "4e8e106956c62501cb2248e8610e47fe96a36cd0",
+    "rev": "49888f434a301ae74ac0a42b64a2edb946512a27",
     "remote-branch": "origin/mono-roslyn-semantic-tests-2.8.2",
     "branch": "mono-roslyn-semantic-tests-2.8.2",
     "directory": "roslyn"

--- a/acceptance-tests/SUBMODULES.json
+++ b/acceptance-tests/SUBMODULES.json
@@ -1,8 +1,8 @@
 [
   {
     "name": "roslyn", 
-    "url": "git://github.com/kg/roslyn.git",
-    "rev": "49888f434a301ae74ac0a42b64a2edb946512a27",
+    "url": "git@github.com:kg/roslyn.git",
+    "rev": "71e1f7957ebe9a3ed6ef37fcc4efb744e583afcd",
     "remote-branch": "origin/mono-roslyn-semantic-tests-2.8.2",
     "branch": "mono-roslyn-semantic-tests-2.8.2",
     "directory": "roslyn"

--- a/acceptance-tests/SUBMODULES.json
+++ b/acceptance-tests/SUBMODULES.json
@@ -1,10 +1,10 @@
 [
   {
     "name": "roslyn", 
-    "url": "git@github.com:kg/roslyn.git",
-    "rev": "71e1f7957ebe9a3ed6ef37fcc4efb744e583afcd",
-    "remote-branch": "origin/mono-roslyn-semantic-tests-2.8.2",
-    "branch": "mono-roslyn-semantic-tests-2.8.2",
+    "url": "git@github.com:mono/roslyn.git",
+    "rev": "7a840bd5697ef6ea41f554a09d837636fba9d88d",
+    "remote-branch": "origin/mono-testing",
+    "branch": "mono-testing",
     "directory": "roslyn"
   }, 
   {

--- a/acceptance-tests/SUBMODULES.json
+++ b/acceptance-tests/SUBMODULES.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "roslyn", 
-    "url": "git@github.com:mono/roslyn.git",
+    "url": "git://github.com/mono/roslyn.git",
     "rev": "7a840bd5697ef6ea41f554a09d837636fba9d88d",
     "remote-branch": "origin/mono-testing",
     "branch": "mono-testing",

--- a/acceptance-tests/SUBMODULES.json
+++ b/acceptance-tests/SUBMODULES.json
@@ -2,7 +2,7 @@
   {
     "name": "roslyn", 
     "url": "git://github.com/kg/roslyn.git",
-    "rev": "54cc422bdab372a47b6222bc0a99e6fd2a25489e",
+    "rev": "5487734a50c952ee9422cb0c3ca660be162c4303",
     "remote-branch": "origin/mono-roslyn-semantic-tests-2.8.2",
     "branch": "mono-roslyn-semantic-tests-2.8.2",
     "directory": "roslyn"

--- a/acceptance-tests/SUBMODULES.json
+++ b/acceptance-tests/SUBMODULES.json
@@ -2,7 +2,7 @@
   {
     "name": "roslyn", 
     "url": "git://github.com/kg/roslyn.git",
-    "rev": "eb2e86f8caa39769e7b0f4e096da990a251125a6",
+    "rev": "54cc422bdab372a47b6222bc0a99e6fd2a25489e",
     "remote-branch": "origin/mono-roslyn-semantic-tests-2.8.2",
     "branch": "mono-roslyn-semantic-tests-2.8.2",
     "directory": "roslyn"

--- a/acceptance-tests/SUBMODULES.json
+++ b/acceptance-tests/SUBMODULES.json
@@ -1,10 +1,10 @@
 [
   {
     "name": "roslyn", 
-    "url": "git://github.com/mono/roslyn.git",
-    "rev": "380eec412868464a132cdcd3a45ef457fab6e060",
-    "remote-branch": "origin/mono-testing",
-    "branch": "mono-testing",
+    "url": "git://github.com/kg/roslyn.git",
+    "rev": "eb2e86f8caa39769e7b0f4e096da990a251125a6",
+    "remote-branch": "origin/mono-roslyn-semantic-tests-2.8.2",
+    "branch": "mono-roslyn-semantic-tests-2.8.2",
     "directory": "roslyn"
   }, 
   {

--- a/acceptance-tests/SUBMODULES.json
+++ b/acceptance-tests/SUBMODULES.json
@@ -2,7 +2,7 @@
   {
     "name": "roslyn", 
     "url": "git://github.com/kg/roslyn.git",
-    "rev": "5487734a50c952ee9422cb0c3ca660be162c4303",
+    "rev": "4e8e106956c62501cb2248e8610e47fe96a36cd0",
     "remote-branch": "origin/mono-roslyn-semantic-tests-2.8.2",
     "branch": "mono-roslyn-semantic-tests-2.8.2",
     "directory": "roslyn"

--- a/acceptance-tests/roslyn.mk
+++ b/acceptance-tests/roslyn.mk
@@ -1,5 +1,5 @@
 check-roslyn:
 	@$(MAKE) validate-roslyn RESET_VERSIONS=1
 	cd $(ROSLYN_PATH); \
-	./mono-testing.sh "$(XUNIT)" || exit; \
+	./build.sh --restore --build --test --mono || exit; \
 	echo "done"


### PR DESCRIPTION
Roslyn submodule was updated to enable more automated tests. This bumps our submodule revision, and uses roslyn's script to run tests instead of ours.

@monojenkins skip

Part of #6991