### PR TITLE
Restore sqrtf/-lm accidentally deleted in 4259352

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2634,6 +2634,11 @@ if test x$host_win32 = xno; then
 		fi
 	fi
 
+	dnl *********************************
+	dnl *** Checks for math functions ***
+	dnl *********************************
+	AC_SEARCH_LIBS(sqrtf, m)
+
 	dnl ****************************************************************
 	dnl *** Checks for working poll() (macosx defines it but doesn't ***
 	dnl *** have it in the library (duh))                            ***


### PR DESCRIPTION
Restore sqrtf/-lm accidentally deleted in https://github.com/mono/mono/commit/4259352d3a7d4b8d6b9980c4e2da844957710609