### PR TITLE
[mcs] Add option to specify reference directory to compiler-tester

### DIFF
--- a/mcs/errors/Makefile
+++ b/mcs/errors/Makefile
@@ -34,7 +34,8 @@ TEST_SUPPORT_FILES = \
 	CS8009-lib.dll \
 	CSFriendAssembly-lib.dll \
 	dlls/first/CS1704-lib.dll \
-	dlls/second/CS1704-lib.dll
+	dlls/second/CS1704-lib.dll \
+	dlls/cs1703-2/System.dll
 
 -include $(mcs_topdir)/build/config.make
 
@@ -67,7 +68,7 @@ COMPILER = $(topdir)/class/lib/$(PROFILE)/mcs.exe
 TESTER = MONO_RUNTIME='$(RUNTIME)' $(TEST_RUNTIME) $(TEST_RUNTIME_FLAGS) $(LOCAL_RUNTIME_FLAGS) $(topdir)/class/lib/$(PROFILE)/compiler-tester.exe
 
 run-mcs-tests: $(TEST_SUPPORT_FILES)
-	$(TESTER) -mode:neg -files:$(TEST_PATTERN) -compiler:$(COMPILER) -issues:known-issues-$(PROFILE) -log:$(PROFILE).log $(TESTER_OPTIONS) $(TOPTIONS)
+	$(TESTER) -mode:neg -files:$(TEST_PATTERN) -compiler:$(COMPILER) -reference-dir:$(topdir)/class/lib/$(PROFILE) -issues:known-issues-$(PROFILE) -log:$(PROFILE).log $(TESTER_OPTIONS) $(TOPTIONS)
 
 endif
 
@@ -107,6 +108,10 @@ dlls/second/CS1703-lib.dll: dlls/second/CS1703-lib.cs
 
 dlls/second/CS1705-lib.dll: dlls/second/CS1705-lib.cs
 	$(CSCOMPILE) /r:$(topdir)/class/lib/$(PROFILE_DIRECTORY)/mscorlib.dll /target:library /warn:0 /publicsign /keyfile:key.snk /out:$@ $<
+
+dlls/cs1703-2/System.dll: $(topdir)/../external/binary-reference-assemblies/v2.0/System.dll
+	mkdir -p $(dir $@)
+	cp $< $@
 
 CS1701-lib.dll : CS1701-lib.cs
 	$(CSCOMPILE) /r:$(topdir)/class/lib/$(PROFILE_DIRECTORY)/mscorlib.dll /target:library /warn:0 /r:dlls/first/CS1701-lib.dll /out:$@ $<

--- a/mcs/errors/cs1703-2.cs
+++ b/mcs/errors/cs1703-2.cs
@@ -1,4 +1,3 @@
 // CS1703: An assembly `System' with the same identity has already been imported. Consider removing one of the references
 // Line: 0
-// Compiler options: -r:../../external/binary-reference-assemblies/v2.0/System.dll
-
+// Compiler options: -r:dlls/cs1703-2/System.dll

--- a/mcs/tests/Makefile
+++ b/mcs/tests/Makefile
@@ -71,10 +71,10 @@ KNOWN_ISSUES = known-issues-$(PROFILE)
 endif
 
 qcheck2:
-	$(TESTER) -mode:pos -files:$(TEST_PATTERN) -compiler:$(COMPILER) -issues:$(KNOWN_ISSUES) -log:$(PROFILE).log -il:ver-il-$(PROFILE).xml $(DEFINES) $(TOPTIONS)
+	$(TESTER) -mode:pos -files:$(TEST_PATTERN) -compiler:$(COMPILER) -reference-dir:$(topdir)/class/lib/$(PROFILE) -issues:$(KNOWN_ISSUES) -log:$(PROFILE).log -il:ver-il-$(PROFILE).xml $(DEFINES) $(TOPTIONS)
 
 gen-mt-tests:
-	$(TESTER) -mode:nunit -files:'v2' -compiler:$(COMPILER) -issues:known-issues-mt -compiler-options:"-lib:$(topdir)/class/lib/monotouch projects/MonoTouch/ivt.cs"
+	$(TESTER) -mode:nunit -files:'v2' -compiler:$(COMPILER) -reference-dir:$(topdir)/class/lib/$(PROFILE) -issues:known-issues-mt -compiler-options:"-lib:$(topdir)/class/lib/monotouch projects/MonoTouch/ivt.cs"
 
 
 TESTERVERBOSE=$(if $(V),-verbose,)

--- a/mcs/tests/gtest-exmethod-23.cs
+++ b/mcs/tests/gtest-exmethod-23.cs
@@ -1,4 +1,4 @@
-// Compiler options: -nostdlib -noconfig -r:mscorlib.dll -r:System.Core.dll -lib:../class/lib/net_4_x
+// Compiler options: -nostdlib -noconfig -r:mscorlib.dll -r:System.Core.dll -lib:$REF_DIR
 
 public static class T
 {

--- a/mcs/tests/test-695.cs
+++ b/mcs/tests/test-695.cs
@@ -1,4 +1,4 @@
-// Compiler options: -r:../class/lib/net_4_x/Mono.Cecil.dll
+// Compiler options: -r:$REF_DIR/Mono.Cecil.dll
 
 using System;
 using System.IO;

--- a/mcs/tests/test-814.cs
+++ b/mcs/tests/test-814.cs
@@ -1,4 +1,4 @@
-// Compiler options: -r:../class/lib/net_4_x/Mono.Cecil.dll
+// Compiler options: -r:$REF_DIR/Mono.Cecil.dll
 
 using System;
 using Mono.Cecil;

--- a/mcs/tests/test-937.cs
+++ b/mcs/tests/test-937.cs
@@ -1,4 +1,4 @@
-// Compiler options: /noconfig /nostdlib -r:../class/lib/net_4_x/Facades/System.Runtime.dll -r:../class/lib/net_4_x/mscorlib.dll
+// Compiler options: /noconfig /nostdlib -r:$REF_DIR/Facades/System.Runtime.dll -r:$REF_DIR/mscorlib.dll
 
 using System;
 

--- a/mcs/tests/test-async-76.cs
+++ b/mcs/tests/test-async-76.cs
@@ -1,4 +1,4 @@
-// Compiler options: -r:../class/lib/net_4_x/Mono.Cecil.dll
+// Compiler options: -r:$REF_DIR/Mono.Cecil.dll
 
 using System;
 using System.Threading.Tasks;

--- a/mcs/tools/compiler-tester/compiler-tester.cs
+++ b/mcs/tools/compiler-tester/compiler-tester.cs
@@ -430,6 +430,7 @@ namespace TestRunner {
 		string issue_file;
 		StreamWriter log_file;
 		protected string[] extra_compiler_options;
+		protected string reference_dir;
 		// protected string[] compiler_options;
 		// protected string[] dependencies;
 
@@ -482,6 +483,12 @@ namespace TestRunner {
 			}
 		}
 
+		public string ReferenceDirectory {
+			set {
+				reference_dir = value;
+			}
+		}
+
 		protected virtual bool GetExtraOptions (string file, out string[] compiler_options,
 							out string[] dependencies)
 		{
@@ -519,7 +526,7 @@ namespace TestRunner {
 			if (index != -1) {
 				compiler_options = line.Substring (index + options.Length).Trim().Split (' ');
 				for (int i = 0; i < compiler_options.Length; i++)
-					compiler_options[i] = compiler_options[i].TrimStart ();
+					compiler_options[i] = compiler_options[i].TrimStart ().Replace ("$REF_DIR", reference_dir);
 			}
 			index = line.IndexOf (depends);
 			if (index != -1) {
@@ -1630,6 +1637,8 @@ namespace TestRunner {
 				checker.Verbose = true;
 			if (GetOption ("safe-execution", args, false, out temp))
 				checker.SafeExecution = true;
+			if (GetOption ("reference-dir", args, true, out temp))
+				checker.ReferenceDirectory = temp;
 			if (GetOption ("compiler-options", args, true, out temp)) {
 				string[] extra = temp.Split (' ');
 				checker.ExtraCompilerOptions = extra;
@@ -1727,6 +1736,7 @@ namespace TestRunner {
 				"   \n" +
 				"   -compiler:FILE   The file which will be used to compiler tests\n" +
 				"   -compiler-options:OPTIONS  Add global compiler options\n" +
+				"   -reference-dir:DIRECTORY   Use this directory for $REF_DIR variable in tests\n" + 
 				"   -il:IL-FILE      XML file with expected IL details for each test\n" +
 				"   -issues:FILE     The list of expected failures\n" +
 				"   -log:FILE        Writes any output also to the file\n" +


### PR DESCRIPTION
We can use this to pass a directory the tests can use for -r or -lib.

Also fix cs1703-2.cs to not rely on binary outside repo during test.

Part of #9099