### PR TITLE
[runtime-tests] Add xunit xml output option to test-runner.exe

### DIFF
--- a/mono/tests/test-runner.cs
+++ b/mono/tests/test-runner.cs
@@ -62,6 +62,7 @@ public class TestRunner
 		string mono_path = null;
 		string runtime_args = null;
 		string mono_gac_prefix = null;
+		string xunit_output_path = null;
 		var opt_sets = new List<string> ();
 
 		// Process options
@@ -134,6 +135,14 @@ public class TestRunner
 						return 1;
 					}
 					testsuiteName = args [i + 1];
+					i += 2;
+				} else if (args [i] == "--xunit") {
+					if (i + 1 >= args.Length) {
+						Console.WriteLine ("Missing argument to --xunit command line option.");
+						return 1;
+					}
+					xunit_output_path = args [i + 1].Substring(0, args [i + 1].Length);
+
 					i += 2;
 				} else if (args [i] == "--input-file") {
 					if (i + 1 >= args.Length) {
@@ -390,16 +399,72 @@ public class TestRunner
 
 		TimeSpan test_time = DateTime.UtcNow - test_start_time;
 
-		int npassed = passed.Count;
-		int nfailed = failed.Count;
-		int ntimedout = timedout.Count;
+		if (xunit_output_path != null) {
+			WriteXUnitOutput (xunit_output_path, testsuiteName, test_time, passed, failed, timedout);
+		}
+		else {
+			var xmlPath = String.Format ("TestResult-{0}.xml", testsuiteName);
+			WriteNUnitOutput (xmlPath, testsuiteName, test_time, passed, failed, timedout);
+			string babysitterXmlList = Environment.GetEnvironmentVariable("MONO_BABYSITTER_NUNIT_XML_LIST_FILE");
+			if (!String.IsNullOrEmpty(babysitterXmlList)) {
+				try {
+					string fullXmlPath = Path.GetFullPath(xmlPath);
+					File.AppendAllText(babysitterXmlList, fullXmlPath + Environment.NewLine);
+				} catch (Exception e) {
+					Console.WriteLine("Attempted to record XML path to file {0} but failed.", babysitterXmlList);
+				}
+			}
+		}
 
+		if (verbose) {
+			Console.WriteLine ();
+			Console.WriteLine ("Time: {0}", test_time.ToString (TEST_TIME_FORMAT));
+			Console.WriteLine ();
+			Console.WriteLine ("{0,4} test(s) passed", passed.Count);
+			Console.WriteLine ("{0,4} test(s) failed", failed.Count);
+			Console.WriteLine ("{0,4} test(s) timed out", timedout.Count);
+		} else {
+			Console.WriteLine ();
+			Console.WriteLine (String.Format ("{0} test(s) passed, {1} test(s) did not pass.", passed.Count, failed.Count));
+		}
+
+		if (failed.Count > 0) {
+			Console.WriteLine ();
+			Console.WriteLine ("Failed test(s):");
+			foreach (ProcessData pd in failed) {
+				Console.WriteLine ();
+				Console.WriteLine (pd.test);
+				DumpFile (pd.stdoutName, pd.stdout.ToString ());
+				DumpFile (pd.stderrName, pd.stderr.ToString ());
+			}
+		}
+
+		if (timedout.Count > 0) {
+			Console.WriteLine ();
+			Console.WriteLine ("Timed out test(s):");
+			foreach (ProcessData pd in timedout) {
+				Console.WriteLine ();
+				Console.WriteLine (pd.test);
+				DumpFile (pd.stdoutName, pd.stdout.ToString ());
+				DumpFile (pd.stderrName, pd.stderr.ToString ());
+			}
+		}
+
+		return (timedout.Count == 0 && failed.Count == 0) ? 0 : 1;
+	}
+	
+	static void DumpFile (string filename, string text) {
+		Console.WriteLine ("=============== {0} ===============", filename);
+		Console.WriteLine (text);
+		Console.WriteLine ("=============== EOF ===============");
+	}
+
+	static void WriteNUnitOutput (string path, string testsuiteName, TimeSpan test_time, List<ProcessData> passed, List<ProcessData> failed, List<ProcessData> timedout) {
 		XmlWriterSettings xmlWriterSettings = new XmlWriterSettings ();
 		xmlWriterSettings.NewLineOnAttributes = true;
 		xmlWriterSettings.Indent = true;
 
-		string xmlPath = String.Format ("TestResult-{0}.xml", testsuiteName);
-		using (XmlWriter writer = XmlWriter.Create (xmlPath, xmlWriterSettings)) {
+		using (XmlWriter writer = XmlWriter.Create (path, xmlWriterSettings)) {
 			// <?xml version="1.0" encoding="utf-8" standalone="no"?>
 			writer.WriteStartDocument ();
 			// <!--This file represents the results of running a test suite-->
@@ -407,8 +472,8 @@ public class TestRunner
 			// <test-results name="/home/charlie/Dev/NUnit/nunit-2.5/work/src/bin/Debug/tests/mock-assembly.dll" total="21" errors="1" failures="1" not-run="7" inconclusive="1" ignored="4" skipped="0" invalid="3" date="2010-10-18" time="13:23:35">
 			writer.WriteStartElement ("test-results");
 			writer.WriteAttributeString ("name", String.Format ("{0}-tests.dummy", testsuiteName));
-			writer.WriteAttributeString ("total", (npassed + nfailed + ntimedout).ToString());
-			writer.WriteAttributeString ("failures", (nfailed + ntimedout).ToString());
+			writer.WriteAttributeString ("total", (passed.Count + failed.Count + timedout.Count).ToString());
+			writer.WriteAttributeString ("failures", (failed.Count + timedout.Count).ToString());
 			writer.WriteAttributeString ("not-run", "0");
 			writer.WriteAttributeString ("date", DateTime.Now.ToString ("yyyy-MM-dd"));
 			writer.WriteAttributeString ("time", DateTime.Now.ToString ("HH:mm:ss"));
@@ -431,25 +496,25 @@ public class TestRunner
 			//   <test-suite name="corlib_test_net_4_5.dll" success="True" time="114.318" asserts="0">
 			writer.WriteStartElement ("test-suite");
 			writer.WriteAttributeString ("name", String.Format ("{0}-tests.dummy", testsuiteName));
-			writer.WriteAttributeString ("success", (nfailed + ntimedout == 0).ToString());
+			writer.WriteAttributeString ("success", (failed.Count + timedout.Count == 0).ToString());
 			writer.WriteAttributeString ("time", test_time.TotalSeconds.ToString(CultureInfo.InvariantCulture));
-			writer.WriteAttributeString ("asserts", (nfailed + ntimedout).ToString());
+			writer.WriteAttributeString ("asserts", (failed.Count + timedout.Count).ToString());
 			//     <results>
 			writer.WriteStartElement ("results");
 			//       <test-suite name="MonoTests" success="True" time="114.318" asserts="0">
 			writer.WriteStartElement ("test-suite");
 			writer.WriteAttributeString ("name","MonoTests");
-			writer.WriteAttributeString ("success", (nfailed + ntimedout == 0).ToString());
+			writer.WriteAttributeString ("success", (failed.Count + timedout.Count == 0).ToString());
 			writer.WriteAttributeString ("time", test_time.TotalSeconds.ToString(CultureInfo.InvariantCulture));
-			writer.WriteAttributeString ("asserts", (nfailed + ntimedout).ToString());
+			writer.WriteAttributeString ("asserts", (failed.Count + timedout.Count).ToString());
 			//         <results>
 			writer.WriteStartElement ("results");
 			//           <test-suite name="MonoTests" success="True" time="114.318" asserts="0">
 			writer.WriteStartElement ("test-suite");
 			writer.WriteAttributeString ("name", testsuiteName);
-			writer.WriteAttributeString ("success", (nfailed + ntimedout == 0).ToString());
+			writer.WriteAttributeString ("success", (failed.Count + timedout.Count == 0).ToString());
 			writer.WriteAttributeString ("time", test_time.TotalSeconds.ToString(CultureInfo.InvariantCulture));
-			writer.WriteAttributeString ("asserts", (nfailed + ntimedout).ToString());
+			writer.WriteAttributeString ("asserts", (failed.Count + timedout.Count).ToString());
 			//             <results>
 			writer.WriteStartElement ("results");
 			// Dump all passing tests first
@@ -516,59 +581,88 @@ public class TestRunner
 			// </test-results>
 			writer.WriteEndElement ();
 			writer.WriteEndDocument ();
-
-			string babysitterXmlList = Environment.GetEnvironmentVariable("MONO_BABYSITTER_NUNIT_XML_LIST_FILE");
-			if (!String.IsNullOrEmpty(babysitterXmlList)) {
-				try {
-					string fullXmlPath = Path.GetFullPath(xmlPath);
-					File.AppendAllText(babysitterXmlList, fullXmlPath + Environment.NewLine);
-				} catch (Exception e) {
-					Console.WriteLine("Attempted to record XML path to file {0} but failed.", babysitterXmlList);
-				}
-			}
 		}
-
-		if (verbose) {
-			Console.WriteLine ();
-			Console.WriteLine ("Time: {0}", test_time.ToString (TEST_TIME_FORMAT));
-			Console.WriteLine ();
-			Console.WriteLine ("{0,4} test(s) passed", npassed);
-			Console.WriteLine ("{0,4} test(s) failed", nfailed);
-			Console.WriteLine ("{0,4} test(s) timed out", ntimedout);
-		} else {
-			Console.WriteLine ();
-			Console.WriteLine (String.Format ("{0} test(s) passed, {1} test(s) did not pass.", npassed, nfailed));
-		}
-
-		if (nfailed > 0) {
-			Console.WriteLine ();
-			Console.WriteLine ("Failed test(s):");
-			foreach (ProcessData pd in failed) {
-				Console.WriteLine ();
-				Console.WriteLine (pd.test);
-				DumpFile (pd.stdoutName, pd.stdout.ToString ());
-				DumpFile (pd.stderrName, pd.stderr.ToString ());
-			}
-		}
-
-		if (ntimedout > 0) {
-			Console.WriteLine ();
-			Console.WriteLine ("Timed out test(s):");
-			foreach (ProcessData pd in timedout) {
-				Console.WriteLine ();
-				Console.WriteLine (pd.test);
-				DumpFile (pd.stdoutName, pd.stdout.ToString ());
-				DumpFile (pd.stderrName, pd.stderr.ToString ());
-			}
-		}
-
-		return (ntimedout == 0 && nfailed == 0) ? 0 : 1;
 	}
-	
-	static void DumpFile (string filename, string text) {
-		Console.WriteLine ("=============== {0} ===============", filename);
-		Console.WriteLine (text);
-		Console.WriteLine ("=============== EOF ===============");
+
+	static void WriteXUnitOutput (string path, string testsuiteName, TimeSpan test_time, List<ProcessData> passed, List<ProcessData> failed, List<ProcessData> timedout) {
+		XmlWriterSettings xmlWriterSettings = new XmlWriterSettings ();
+		xmlWriterSettings.Indent = true;
+
+		using (XmlWriter writer = XmlWriter.Create (path, xmlWriterSettings)) {
+
+			writer.WriteStartDocument ();
+
+			writer.WriteStartElement ("assemblies");
+
+			writer.WriteStartElement ("assembly");
+
+			writer.WriteAttributeString ("name", testsuiteName);
+			writer.WriteAttributeString ("environment", $"test-runner-version: {System.Reflection.Assembly.GetExecutingAssembly ().GetName ()}, clr-version: {Environment.Version}, os-version: {Environment.OSVersion}, platform: {Environment.OSVersion.Platform}, cwd: {Environment.CurrentDirectory}, machine-name: {Environment.MachineName}, user: {Environment.UserName}, user-domain: {Environment.UserDomainName}");
+			writer.WriteAttributeString ("test-framework", "test-runner");
+			writer.WriteAttributeString ("run-date", XmlConvert.ToString (DateTime.Now, "yyyy-MM-dd"));
+			writer.WriteAttributeString ("run-time", XmlConvert.ToString (DateTime.Now, "HH:mm:ss"));
+
+			writer.WriteAttributeString ("total", (passed.Count + failed.Count + timedout.Count).ToString ());
+			writer.WriteAttributeString ("errors", 0.ToString ());
+			writer.WriteAttributeString ("failed", (failed.Count + timedout.Count).ToString ());
+			writer.WriteAttributeString ("skipped", 0.ToString ());
+
+			writer.WriteAttributeString ("passed", passed.Count.ToString ());
+
+			writer.WriteStartElement ("collection");
+			writer.WriteAttributeString ("name", "tests");
+
+			foreach (var pd in passed) {
+				writer.WriteStartElement ("test");
+				writer.WriteAttributeString ("name", testsuiteName + ".tests." + pd.test);
+				writer.WriteAttributeString ("type", testsuiteName + ".tests");
+				writer.WriteAttributeString ("method", pd.test.ToString ());
+				writer.WriteAttributeString ("result", "Pass");
+				writer.WriteAttributeString ("time", pd.duration.TotalSeconds.ToString(CultureInfo.InvariantCulture));
+				writer.WriteEndElement (); // test element
+			}
+
+			foreach (var pd in failed) {
+				writer.WriteStartElement ("test");
+				writer.WriteAttributeString ("name", testsuiteName + ".tests." + pd.test);
+				writer.WriteAttributeString ("type", testsuiteName + ".tests");
+				writer.WriteAttributeString ("method", pd.test.ToString ());
+				writer.WriteAttributeString ("result", "Fail");
+				writer.WriteAttributeString ("time", pd.duration.TotalSeconds.ToString(CultureInfo.InvariantCulture));
+
+				writer.WriteStartElement ("failure");
+				writer.WriteAttributeString ("exception-type", "TestRunnerException");
+				writer.WriteStartElement ("message");
+				writer.WriteCData (FilterInvalidXmlChars ("STDOUT:\n" + pd.stdout.ToString () + "\n\nSTDERR:\n" + pd.stderr.ToString ()));
+				writer.WriteEndElement (); // message element
+				writer.WriteEndElement (); // failure element
+
+				writer.WriteEndElement(); // test element
+			}
+
+			foreach (var pd in timedout) {
+				writer.WriteStartElement ("test");
+				writer.WriteAttributeString ("name", testsuiteName + ".tests." + pd.test + "_timedout");
+				writer.WriteAttributeString ("type", testsuiteName + ".tests");
+				writer.WriteAttributeString ("method", pd.test.ToString ());
+				writer.WriteAttributeString ("result", "Fail");
+				writer.WriteAttributeString ("time", pd.duration.TotalSeconds.ToString(CultureInfo.InvariantCulture));
+
+				writer.WriteStartElement ("failure");
+				writer.WriteAttributeString ("exception-type", "TestRunnerException");
+				writer.WriteStartElement ("message");
+				writer.WriteCData (FilterInvalidXmlChars ("STDOUT:\n" + pd.stdout.ToString () + "\n\nSTDERR:\n" + pd.stderr.ToString ()));
+				writer.WriteEndElement (); // message element
+				writer.WriteEndElement (); // failure element
+
+				writer.WriteEndElement(); // test element
+			}
+
+			writer.WriteEndElement (); // collection
+			writer.WriteEndElement (); // assembly
+			writer.WriteEndElement (); // assemblies
+			writer.WriteEndDocument ();
+		}
 	}
 
 	static string FilterInvalidXmlChars (string text) {


### PR DESCRIPTION
The default behavior is still to produce an NUnit xml file but we can now produce xunit format too with the --xunit option.

Slightly refactored the xml reporting into distinct methods for NUnit/xunit.

Part of #9099


