### PR TITLE
Fix parameter problem in test_op_il_seq_point.sh.

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -808,8 +808,8 @@ check-seq-points:
 else
 check-seq-points: mono $(regtests)
 	rm -f TestResult-op_il_seq_point.xml
-	for i in $(regtests); do $(srcdir)/test_op_il_seq_point.sh $$i || ($(srcdir)/test_op_il_seq_point_headerfooter.sh; exit 1) || exit 1; done
-	for i in $(regtests); do $(srcdir)/test_op_il_seq_point.sh $$i --aot || ($(srcdir)/test_op_il_seq_point_headerfooter.sh; exit 1) || exit 1; done
+	for i in $(regtests); do $(srcdir)/test_op_il_seq_point.sh $(DEFAULT_PROFILE) $$i || ($(srcdir)/test_op_il_seq_point_headerfooter.sh; exit 1) || exit 1; done
+	for i in $(regtests); do $(srcdir)/test_op_il_seq_point.sh $(DEFAULT_PROFILE) $$i --aot || ($(srcdir)/test_op_il_seq_point_headerfooter.sh; exit 1) || exit 1; done
 	$(srcdir)/test_op_il_seq_point_headerfooter.sh
 endif
 

--- a/mono/mini/test_op_il_seq_point.sh
+++ b/mono/mini/test_op_il_seq_point.sh
@@ -8,8 +8,14 @@ TMP_FILE_PREFIX=$(basename $0).tmp
 BASEDIR=$(dirname $0)
 
 case "$(uname -s)" in
-	CYGWIN*) PLATFORM_PATH_SEPARATOR=';';;
-	*) PLATFORM_PATH_SEPARATOR=':';;
+	CYGWIN*)
+		PLATFORM_PATH_SEPARATOR=';'
+		PLATFORM_AOT_ARGUMENT=--aot=asmonly
+		;;
+	*)
+		PLATFORM_PATH_SEPARATOR=':'
+		PLATFORM_AOT_ARGUMENT=--aot
+		;;
 esac
 
 MONO_PATH=$BASEDIR/../../mcs/class/lib/$DEFAULT_PROFILE$PLATFORM_PATH_SEPARATOR$BASEDIR
@@ -22,7 +28,7 @@ tmp_file () {
 }
 
 clean_aot () {
-	rm -rf *.exe.so *.exe.dylib *.exe.dylib.dSYM *.exe.dll
+	rm -rf *.exe.so *.exe.dylib *.exe.dylib.dSYM *.exe.dll *.exe.s
 }
 
 # The test compares the generated native code size between a compilation with and without seq points.
@@ -34,7 +40,7 @@ get_methods () {
 		MONO_PATH=$1 $2 -v --compile-all=1 $3 | grep '^Method .*code length' | sed 's/emitted[^()]*//' | sort
 	else
 		clean_aot
-		MONO_PATH=$1 $2 -v --aot $3 | grep '^Method .*code length' | sed 's/emitted[^()]*//' | sort
+		MONO_PATH=$1 $2 -v $PLATFORM_AOT_ARGUMENT $3 | grep '^Method .*code length' | sed 's/emitted[^()]*//' | sort
 	fi
 }
 
@@ -43,7 +49,7 @@ get_method () {
 		MONO_VERBOSE_METHOD="$4" MONO_PATH=$1 $2 --compile-all=1 $3 | sed 's/0x[0-9a-fA-F]*/0x0/g'
 	else
 		clean_aot
-		MONO_VERBOSE_METHOD="$4" MONO_PATH=$1 $2 --aot $3 | sed 's/0x[0-9a-fA-F]*/0x0/g'
+		MONO_VERBOSE_METHOD="$4" MONO_PATH=$1 $2 $PLATFORM_AOT_ARGUMENT $3 | sed 's/0x[0-9a-fA-F]*/0x0/g'
 	fi
 }
 


### PR DESCRIPTION
Looks like: https://github.com/mono/mono/commit/e8029e1474b701184840f6e0abea51966d048831 caused issues in the parameters for this test since caller was not updated accordingly.

This fixes so that the caller pass needed additional argument + simplify the AOT use case for Windows since different tested versions will need different toolchain versions that in turn will cause additional complexity. Since the test doesn't validate the compile/link of AOT module (and don't handle errors)
anyways, Windows versions of this test will just generate assembler output.
