### PR TITLE
[coop] Fix deadlock when unwinding

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -5283,14 +5283,11 @@ mono_thread_info_get_last_managed (MonoThreadInfo *info)
 
 	/*
 	 * The suspended thread might be holding runtime locks. Make sure we don't try taking
-	 * any runtime locks while unwinding. In coop case we shouldn't safepoint in regions
-	 * where we hold runtime locks.
+	 * any runtime locks while unwinding.
 	 */
-	if (!mono_threads_are_safepoints_enabled ())
-		mono_thread_info_set_is_async_context (TRUE);
+	mono_thread_info_set_is_async_context (TRUE);
 	mono_get_eh_callbacks ()->mono_walk_stack_with_state (last_managed, mono_thread_info_get_suspend_state (info), MONO_UNWIND_SIGNAL_SAFE, &ji);
-	if (!mono_threads_are_safepoints_enabled ())
-		mono_thread_info_set_is_async_context (FALSE);
+	mono_thread_info_set_is_async_context (FALSE);
 	return ji;
 }
 


### PR DESCRIPTION
At the moment of a safepoint, the runtime can be holding the loader lock. Fixes gsharing-valuetype-layout.exe timeouts.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
