### PR TITLE
[System.Reflection] CoreFX import for RuntimeReflectionExtensions

### DIFF
--- a/mcs/class/corlib/corlib.csproj
+++ b/mcs/class/corlib/corlib.csproj
@@ -792,6 +792,7 @@
     <Compile Include="..\..\..\external\corefx\src\System.Runtime.Serialization.Formatters\src\System\Runtime\Serialization\SerializationObjectManager.cs" />
     <Compile Include="..\..\..\external\corefx\src\System.Runtime.Serialization.Formatters\src\System\Runtime\Serialization\ValueTypeFixupInfo.cs" />
     <Compile Include="..\..\..\external\corefx\src\System.Runtime\src\System\IO\FileAttributes.cs" />
+    <Compile Include="..\..\..\external\corefx\src\System.Runtime\src\System\Reflection\RuntimeReflectionExtensions.cs" />
     <Compile Include="..\..\..\external\corefx\src\System.Runtime\src\System\Runtime\ConstrainedExecution\PrePrepareMethodAttribute.cs" />
     <Compile Include="..\..\..\external\corefx\src\System.Runtime\src\System\Runtime\NgenServicingAttributes.cs" />
     <Compile Include="..\..\..\external\corefx\src\System.Security.AccessControl\src\System\Security\AccessControl\PrivilegeNotHeldException.cs" />
@@ -1013,7 +1014,6 @@
     <Compile Include="..\referencesource\mscorlib\system\iserviceobjectprovider.cs" />
     <Compile Include="..\referencesource\mscorlib\system\random.cs" />
     <Compile Include="..\referencesource\mscorlib\system\reflection\CustomAttributeExtensions.cs" />
-    <Compile Include="..\referencesource\mscorlib\system\reflection\RuntimeReflectionExtensions.cs" />
     <Compile Include="..\referencesource\mscorlib\system\reflection\emit\methodbuilder.cs" />
     <Compile Include="..\referencesource\mscorlib\system\reflection\emit\symboltype.cs" />
     <Compile Include="..\referencesource\mscorlib\system\reflection\mdimport.cs" />

--- a/mcs/class/corlib/corlib.dll.sources
+++ b/mcs/class/corlib/corlib.dll.sources
@@ -1195,6 +1195,7 @@ ReferenceSources/AppContextDefaultValues.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/Reflection/ReflectionTypeLoadException.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/Reflection/ResourceAttributes.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/Reflection/ResourceLocation.cs
+../../../external/corefx/src/System.Runtime/src/System/Reflection/RuntimeReflectionExtensions.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/Reflection/TargetException.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/Reflection/TargetInvocationException.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/Reflection/TargetParameterCountException.cs
@@ -1209,7 +1210,6 @@ ReferenceSources/AppContextDefaultValues.cs
 ../referencesource/mscorlib/system/reflection/memberinfoserializationholder.cs
 ../referencesource/mscorlib/system/reflection/methodbase.cs
 ../referencesource/mscorlib/system/reflection/methodinfo.cs
-../referencesource/mscorlib/system/reflection/RuntimeReflectionExtensions.cs
 ../referencesource/mscorlib/system/reflection/typedelegator.cs
 ../referencesource/mscorlib/system/reflection/typeinfo.cs
 

--- a/mcs/class/corlib/corlib_xtest.dll.sources
+++ b/mcs/class/corlib/corlib_xtest.dll.sources
@@ -17,7 +17,8 @@
 ../../../external/corefx/src/System.Reflection/tests/Common.cs
 
 ../../../external/corefx/src/System.Reflection/tests/*.cs:AssemblyTests.cs,AssemblyNameTests.cs,EventInfoTests.cs,GetTypeTests.cs,MemberInfoTests.cs,MethodInfoTests.cs,ModuleTests.cs,TypeInfoTests.cs
-../../../external/corefx/src/System.Reflection.Extensions/tests/*.cs:RuntimeReflectionExtensionTestsWithQuirks.cs,RuntimeReflectionExtensionTests.cs
+../../../external/corefx/src/System.Reflection.Extensions/tests/Definitions/PropertyDefinitions.cs
+../../../external/corefx/src/System.Reflection.Extensions/tests/*.cs
 
 #TODO: audit the commented out tests and fix or disable
 


### PR DESCRIPTION
Part of #9660.

The changes:
- included corefx version of RuntimeReflectionExtensions class;
- enabled related xunit tests.