### PR TITLE
Make a bunch of classes optional to the runtime.

### DIFF
--- a/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
+++ b/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
@@ -123,10 +123,6 @@
 		<!-- domain.c: mono_defaults.stack_frame_class -->
 		<!-- used in mini-exceptions.c to create array and MonoStackFrame instance, i.e. only fields are required to be preserved -->
 		<type fullname="System.Diagnostics.StackFrame" preserve="fields" />
-		
-		<!-- domain.c: mono_defaults.stack_trace_class -->
-		<!-- does not seems used outside the g_assert in domain.c (maybe it could be removed) -->
-		<type fullname="System.Diagnostics.StackTrace" preserve="fields" />
 
 		<!-- debugger-agent.c: create_event_list -->
 		<type fullname="System.Diagnostics.DebuggerNonUserCodeAttribute"/>
@@ -461,11 +457,6 @@
 			<method name=".ctor" />
 		</type>
 
-		<!-- console-unix.c: do_console_cancel_event -->
-		<type fullname="System.Console">
-			<method name="DoConsoleCancelEventInBackground" />
-		</type>
-
 		<!-- icalls - but (at least parts of them) are used thru interfaces at runtime and cannot be linked out -->
 		<type fullname="System.Globalization.DateTimeFormatInfo" preserve="fields" />
 		<type fullname="System.Globalization.CompareInfo" preserve="fields" />
@@ -490,24 +481,12 @@
 
 		<!-- fileio.h: shared structure between the managed and unmanaged worlds -->
 		<type fullname="System.IO.MonoIOStat" preserve="fields" />
-		
-		<!-- domain.c: mono_defaults.math_class
-			method-to-ir.c: empty branch (wrt Min/Max optimization)
-			mini-[x86|amd64].c needs the type but then only check for names
-			note: there's no fields (static type) but that will mark the type itself -->
-		<type fullname="System.Math" preserve="fields" />
 
 		<!-- appdomain.c: ves_icall_System_AppDomain_GetAssemblies -->
 		<type fullname="System.Reflection.Assembly" preserve="fields"/>
 
 		<type fullname="System.Reflection.AssemblyName" preserve="fields" />
 		<type fullname="System.Reflection.ConstructorInfo" preserve="fields" />
-
-		<!-- domain.c: mono_defaults.customattribute_data_class -->
-		<type fullname="System.Reflection.CustomAttributeData" preserve="fields">
-			<!-- custom-attrs.c: create_custom_attr_data - create an instance with the ctor using 4 arguments -->
-			<method signature="System.Void .ctor(System.Reflection.ConstructorInfo,System.Reflection.Assembly,System.IntPtr,System.UInt32)" />
-		</type>
 
 		<!-- reflection.c: create_cattr_named_arg - create an instance with the ctor using 2 parameters -->
 		<type fullname="System.Reflection.CustomAttributeNamedArgument">
@@ -681,9 +660,6 @@
 			<method name="DangerousRelease" />
 		</type>
 		
-		<!-- object-internals.h: defines MonoReflectionUnmanagedFunctionPointerAttribute, marshal.c: use it -->
-		<type fullname="System.Runtime.InteropServices.UnmanagedFunctionPointerAttribute" preserve="fields"/>
-
 		<!-- marshal.c: mono_mb_emit_exception_marshal_directive -->
 		<type fullname="System.Runtime.InteropServices.MarshalDirectiveException">
 			<method signature="System.Void .ctor(System.String)" />
@@ -813,9 +789,6 @@
 		<type fullname="System.Threading._ThreadPoolWaitCallback">
 		  <method name="PerformWaitCallback"/>
 		</type>
-
-		<!-- domain.c: mono_defaults.stringbuilder_class -->
-		<type fullname="System.Text.StringBuilder" preserve="fields" />
 
 		<!-- cominterop.c -->
 		<type fullname="Mono.Interop.ComInteropProxy" feature="com" />

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -940,7 +940,6 @@ typedef struct {
 	MonoClass *generic_ienumerator_class;
 	MonoClass *threadpool_wait_callback_class;
 	MonoMethod *threadpool_perform_wait_callback_method;
-	MonoClass *console_class;
 } MonoDefaults;
 
 #ifdef DISABLE_REMOTING

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -924,7 +924,6 @@ typedef struct {
 	MonoClass *stringbuilder_class;
 	MonoClass *math_class;
 	MonoClass *stack_frame_class;
-	MonoClass *stack_trace_class;
 	MonoClass *marshal_class;
 	MonoClass *typed_reference_class;
 	MonoClass *argumenthandle_class;

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -936,7 +936,6 @@ typedef struct {
 	MonoClass *critical_finalizer_object; /* MAYBE NULL */
 	MonoClass *generic_ireadonlylist_class;
 	MonoClass *generic_ienumerator_class;
-	MonoClass *threadpool_wait_callback_class;
 	MonoMethod *threadpool_perform_wait_callback_method;
 } MonoDefaults;
 

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -901,7 +901,6 @@ typedef struct {
 	MonoClass *array_class;
 	MonoClass *delegate_class;
 	MonoClass *multicastdelegate_class;
-	MonoClass *asyncresult_class;
 	MonoClass *manualresetevent_class;
 	MonoClass *typehandle_class;
 	MonoClass *fieldhandle_class;

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -929,7 +929,6 @@ typedef struct {
 	MonoClass *monitor_class;
 	MonoClass *generic_ilist_class;
 	MonoClass *generic_nullable_class;
-	MonoClass *handleref_class;
 	MonoClass *attribute_class;
 	MonoClass *customattribute_data_class;
 	MonoClass *critical_finalizer_object; /* MAYBE NULL */
@@ -1002,6 +1001,7 @@ GENERATE_GET_CLASS_WITH_CACHE_DECL (appdomain_unloaded_exception)
 
 GENERATE_GET_CLASS_WITH_CACHE_DECL (valuetype)
 
+GENERATE_TRY_GET_CLASS_WITH_CACHE_DECL(handleref)
 /* If you need a MonoType, use one of the mono_get_*_type () functions in class-inlines.h */
 extern MonoDefaults mono_defaults;
 

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -929,7 +929,6 @@ typedef struct {
 	MonoClass *generic_ilist_class;
 	MonoClass *generic_nullable_class;
 	MonoClass *attribute_class;
-	MonoClass *customattribute_data_class;
 	MonoClass *critical_finalizer_object; /* MAYBE NULL */
 	MonoClass *generic_ireadonlylist_class;
 	MonoClass *generic_ienumerator_class;

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -922,7 +922,6 @@ typedef struct {
 	MonoClass *field_info_class;
 	MonoClass *method_info_class;
 	MonoClass *stringbuilder_class;
-	MonoClass *math_class;
 	MonoClass *stack_frame_class;
 	MonoClass *marshal_class;
 	MonoClass *typed_reference_class;

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -921,7 +921,6 @@ typedef struct {
 	MonoClass *appdomain_class;
 	MonoClass *field_info_class;
 	MonoClass *method_info_class;
-	MonoClass *stringbuilder_class;
 	MonoClass *stack_frame_class;
 	MonoClass *marshal_class;
 	MonoClass *typed_reference_class;

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -72,6 +72,7 @@ static MonoClass *mono_class_from_mono_type_internal (MonoType *type);
 static gboolean mono_class_is_subclass_of_internal (MonoClass *klass, MonoClass *klassc, gboolean check_interfaces);
 
 GENERATE_GET_CLASS_WITH_CACHE (valuetype, "System", "ValueType")
+GENERATE_TRY_GET_CLASS_WITH_CACHE (handleref, "System.Runtime.InteropServices", "HandleRef")
 
 static
 MonoImage *

--- a/mono/metadata/console-unix.c
+++ b/mono/metadata/console-unix.c
@@ -75,6 +75,10 @@ static struct termios mono_attr;
 /* static void console_restore_signal_handlers (void); */
 static void console_set_signal_handlers (void);
 
+
+static GENERATE_TRY_GET_CLASS_WITH_CACHE (console, "System", "Console");
+
+
 void
 mono_console_init (void)
 {
@@ -221,11 +225,11 @@ do_console_cancel_event (void)
 	static MonoMethod *System_Console_DoConsoleCancelEventBackground_method = (MonoMethod*)(intptr_t)-1;
 	ERROR_DECL (error);
 
-	if (mono_defaults.console_class == NULL)
+	if (mono_class_try_get_console_class () == NULL)
 		return;
 
 	if (System_Console_DoConsoleCancelEventBackground_method == (gpointer)(intptr_t)-1) {
-		System_Console_DoConsoleCancelEventBackground_method = mono_class_get_method_from_name_checked (mono_defaults.console_class, "DoConsoleCancelEventInBackground", 0, 0, error);
+		System_Console_DoConsoleCancelEventBackground_method = mono_class_get_method_from_name_checked (mono_class_try_get_console_class (), "DoConsoleCancelEventInBackground", 0, 0, error);
 		mono_error_assert_ok (error);
 	}
 	if (System_Console_DoConsoleCancelEventBackground_method == NULL)

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -48,6 +48,7 @@ static gboolean type_is_reference (MonoType *type);
 
 static GENERATE_GET_CLASS_WITH_CACHE (custom_attribute_typed_argument, "System.Reflection", "CustomAttributeTypedArgument");
 static GENERATE_GET_CLASS_WITH_CACHE (custom_attribute_named_argument, "System.Reflection", "CustomAttributeNamedArgument");
+static GENERATE_TRY_GET_CLASS_WITH_CACHE (customattribute_data, "System.Reflection", "CustomAttributeData");
 
 static MonoCustomAttrInfo*
 mono_custom_attrs_from_builders_handle (MonoImage *alloc_img, MonoImage *image, MonoArrayHandle cattrs);
@@ -1380,6 +1381,16 @@ ves_icall_System_Reflection_CustomAttributeData_ResolveArgumentsInternal (MonoRe
 	mono_error_set_pending_exception (error);
 }
 
+static MonoClass*
+try_get_cattr_data_class (MonoError* error)
+{
+	error_init (error);
+	MonoClass *res = mono_class_try_get_customattribute_data_class ();
+	if (!res)
+		mono_error_set_execution_engine (error, "Class System.Reflection.CustomAttributeData not found, probably removed by the linker");
+	return res;
+}
+
 static MonoObjectHandle
 create_custom_attr_data (MonoImage *image, MonoCustomAttrEntry *cattr, MonoError *error)
 {
@@ -1393,15 +1404,22 @@ create_custom_attr_data (MonoImage *image, MonoCustomAttrEntry *cattr, MonoError
 	error_init (error);
 
 	g_assert (image->assembly);
+	MonoObjectHandle attr;
+
+	MonoClass *cattr_data = try_get_cattr_data_class (error);
+	goto_if_nok (error, result_null);
 
 	if (!ctor) {
-		ctor = mono_class_get_method_from_name_checked (mono_defaults.customattribute_data_class, ".ctor", 4, 0, error);
+		MonoMethod *tmp = mono_class_get_method_from_name_checked (cattr_data, ".ctor", 4, 0, error);
 		mono_error_assert_ok (error);
+
+		mono_memory_barrier (); //safe publish!
+		ctor = tmp;
 	}
 
 	domain = mono_domain_get ();
 
-	MonoObjectHandle attr = mono_object_new_handle (domain, mono_defaults.customattribute_data_class, error);
+	attr = mono_object_new_handle (domain, cattr_data, error);
 	goto_if_nok (error, fail);
 
 	MonoReflectionMethodHandle ctor_obj;
@@ -1416,8 +1434,13 @@ create_custom_attr_data (MonoImage *image, MonoCustomAttrEntry *cattr, MonoError
 	params [3] = &cattr->data_size;
 
 	mono_runtime_invoke_handle (ctor, attr, params, error);
+	goto fail;
+result_null:
+	attr = MONO_HANDLE_CAST (MonoObject, mono_new_null ());
 fail:
 	HANDLE_FUNCTION_RETURN_REF (MonoObject, attr);
+
+
 }
 
 static void
@@ -1501,8 +1524,11 @@ mono_custom_attrs_data_construct (MonoCustomAttrInfo *cinfo, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
 
-	error_init (error);
-	MonoArrayHandle result = mono_array_new_handle (mono_domain_get (), mono_defaults.customattribute_data_class, cinfo->num_attrs, error);
+	MonoArrayHandle result;
+	MonoClass *cattr_data = try_get_cattr_data_class (error);
+	goto_if_nok (error, return_null);
+
+	result = mono_array_new_handle (mono_domain_get (), cattr_data, cinfo->num_attrs, error);
 	goto_if_nok (error, return_null);
 	for (int i = 0; i < cinfo->num_attrs; ++i) {
 		create_custom_attr_data_into_array (cinfo->image, &cinfo->attrs [i], result, i, error);
@@ -2221,9 +2247,15 @@ mono_reflection_get_custom_attrs_data_checked (MonoObjectHandle obj, MonoError *
 		if (!cinfo->cached)
 			mono_custom_attrs_free (cinfo);
 		goto_if_nok (error, leave);
-	} else 
-		MONO_HANDLE_ASSIGN (result, mono_array_new_handle (mono_domain_get (), mono_defaults.customattribute_data_class, 0, error));
+	} else  {
+		MonoClass *cattr_data = try_get_cattr_data_class (error);
+		goto_if_nok (error, return_null);
 
+		MONO_HANDLE_ASSIGN (result, mono_array_new_handle (mono_domain_get (), cattr_data, 0, error));
+	}
+	goto leave;
+return_null:
+	result = MONO_HANDLE_CAST (MonoArray, mono_new_null ());
 leave:
 	return result;
 }

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -781,9 +781,6 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 		mono_defaults.threadpool_wait_callback_class, "PerformWaitCallback", 0, 0, error);
 	mono_error_assert_ok (error);
 
-	mono_defaults.console_class = mono_class_try_load_from_name (
-		mono_defaults.corlib, "System", "Console");
-
 	domain->friendly_name = g_path_get_basename (filename);
 
 	MONO_PROFILER_RAISE (domain_name, (domain, domain->friendly_name));

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -745,9 +745,6 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 
 	mono_assembly_load_friends (ass);
 
-	mono_defaults.handleref_class = mono_class_try_load_from_name (
-		mono_defaults.corlib, "System.Runtime.InteropServices", "HandleRef");
-
 	mono_defaults.attribute_class = mono_class_load_from_name (
 		mono_defaults.corlib, "System", "Attribute");
 

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -720,9 +720,6 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	mono_defaults.method_info_class = mono_class_load_from_name (
 		mono_defaults.corlib, "System.Reflection", "MethodInfo");
 
-	mono_defaults.stringbuilder_class = mono_class_load_from_name (
-		mono_defaults.corlib, "System.Text", "StringBuilder");
-
 	mono_defaults.stack_frame_class = mono_class_load_from_name (
 	        mono_defaults.corlib, "System.Diagnostics", "StackFrame");
 

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -663,10 +663,6 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	mono_defaults.multicastdelegate_class = mono_class_load_from_name (
 		mono_defaults.corlib, "System", "MulticastDelegate");
 
-	mono_defaults.asyncresult_class = mono_class_load_from_name (
-		mono_defaults.corlib, "System.Runtime.Remoting.Messaging", 
-		"AsyncResult");
-
 	mono_defaults.manualresetevent_class = mono_class_load_from_name (
 		mono_defaults.corlib, "System.Threading", "ManualResetEvent");
 

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -745,9 +745,6 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	mono_defaults.attribute_class = mono_class_load_from_name (
 		mono_defaults.corlib, "System", "Attribute");
 
-	mono_defaults.customattribute_data_class = mono_class_load_from_name (
-		mono_defaults.corlib, "System.Reflection", "CustomAttributeData");
-
 	mono_class_init (mono_defaults.array_class);
 	mono_defaults.generic_nullable_class = mono_class_load_from_name (
 		mono_defaults.corlib, "System", "Nullable`1");

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -723,9 +723,6 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	mono_defaults.stringbuilder_class = mono_class_load_from_name (
 		mono_defaults.corlib, "System.Text", "StringBuilder");
 
-	mono_defaults.math_class = mono_class_load_from_name (
-	        mono_defaults.corlib, "System", "Math");
-
 	mono_defaults.stack_frame_class = mono_class_load_from_name (
 	        mono_defaults.corlib, "System.Diagnostics", "StackFrame");
 

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -767,11 +767,11 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	mono_defaults.generic_ienumerator_class = mono_class_load_from_name (
 	        mono_defaults.corlib, "System.Collections.Generic", "IEnumerator`1");
 
-	mono_defaults.threadpool_wait_callback_class = mono_class_load_from_name (
+	MonoClass *threadpool_wait_callback_class = mono_class_load_from_name (
 		mono_defaults.corlib, "System.Threading", "_ThreadPoolWaitCallback");
 
 	mono_defaults.threadpool_perform_wait_callback_method = mono_class_get_method_from_name_checked (
-		mono_defaults.threadpool_wait_callback_class, "PerformWaitCallback", 0, 0, error);
+		threadpool_wait_callback_class, "PerformWaitCallback", 0, 0, error);
 	mono_error_assert_ok (error);
 
 	domain->friendly_name = g_path_get_basename (filename);

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -729,9 +729,6 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	mono_defaults.stack_frame_class = mono_class_load_from_name (
 	        mono_defaults.corlib, "System.Diagnostics", "StackFrame");
 
-	mono_defaults.stack_trace_class = mono_class_load_from_name (
-	        mono_defaults.corlib, "System.Diagnostics", "StackTrace");
-
 	mono_defaults.marshal_class = mono_class_load_from_name (
 	        mono_defaults.corlib, "System.Runtime.InteropServices", "Marshal");
 

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -63,9 +63,6 @@ static GENERATE_GET_CLASS_WITH_CACHE (date_time, "System", "DateTime");
 static GENERATE_TRY_GET_CLASS_WITH_CACHE (icustom_marshaler, "System.Runtime.InteropServices", "ICustomMarshaler");
 static GENERATE_TRY_GET_CLASS_WITH_CACHE (marshal, "System.Runtime.InteropServices", "Marshal");
 
-//used by marshal.c
-GENERATE_TRY_GET_CLASS_WITH_CACHE (stringbuilder, "System.Text", "StringBuilder");
-
 /* MonoMethod pointers to SafeHandle::DangerousAddRef and ::DangerousRelease */
 static MonoMethod *sh_dangerous_add_ref;
 static MonoMethod *sh_dangerous_release;

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -3264,7 +3264,7 @@ mono_emit_marshal (EmitMarshalContext *m, int argnum, MonoType *t,
 			
 	switch (t->type) {
 	case MONO_TYPE_VALUETYPE:
-		if (t->data.klass == mono_defaults.handleref_class)
+		if (t->data.klass == mono_class_try_get_handleref_class ())
 			return get_marshal_cb ()->emit_marshal_handleref (m, argnum, t, spec, conv_arg, conv_arg_type, action);
 		
 		return get_marshal_cb ()->emit_marshal_vtype (m, argnum, t, spec, conv_arg, conv_arg_type, action);

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -114,7 +114,8 @@ MonoDelegateHandle
 mono_ftnptr_to_delegate_handle (MonoClass *klass, gpointer ftn, MonoError *error);
 
 /* Lazy class loading functions */
-static GENERATE_GET_CLASS_WITH_CACHE (string_builder, "System.Text", "StringBuilder");
+//used by marshal-ilgen.c
+GENERATE_TRY_GET_CLASS_WITH_CACHE (stringbuilder, "System.Text", "StringBuilder");
 static GENERATE_TRY_GET_CLASS_WITH_CACHE (unmanaged_function_pointer_attribute, "System.Runtime.InteropServices", "UnmanagedFunctionPointerAttribute");
 
 static MonoImage*
@@ -833,8 +834,8 @@ mono_string_builder_new (int starting_string_length)
 		MonoMethodDesc *desc;
 		MonoMethod *m;
 
-		string_builder_class = mono_class_get_string_builder_class ();
-		g_assert (string_builder_class);
+		string_builder_class = mono_class_try_get_stringbuilder_class ();
+		g_assert (string_builder_class); //TODO don't swallow the error
 		desc = mono_method_desc_new (":.ctor(int)", FALSE);
 		m = mono_method_desc_search_in_class (desc, string_builder_class);
 		g_assert (m);

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -1501,7 +1501,7 @@ mono_marshal_need_free (MonoType *t, MonoMethodPInvoke *piinfo, MonoMarshalSpec 
 		return TRUE;
 	case MONO_TYPE_OBJECT:
 	case MONO_TYPE_CLASS:
-		if (t->data.klass == mono_defaults.stringbuilder_class) {
+		if (t->data.klass == mono_class_try_get_stringbuilder_class ()) {
 			gboolean need_free;
 			mono_marshal_get_ptr_to_stringbuilder_conv (piinfo, spec, &need_free);
 			return need_free;

--- a/mono/metadata/marshal.h
+++ b/mono/metadata/marshal.h
@@ -33,6 +33,10 @@ typedef const gunichar2 *mono_bstr_const;
 		mono_marshal_find_nonzero_bit_offset ((guint8*)&tmp, sizeof (tmp), (byte_offset), (bitmask)); \
 	} while (0)
 
+
+GENERATE_TRY_GET_CLASS_WITH_CACHE_DECL(stringbuilder)
+
+
 /*
  * This structure holds the state kept by the emit_ marshalling functions.
  * This is exported so it can be used by cominterop.c.

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -6385,7 +6385,7 @@ handle_enum:
 			t = mono_class_enum_basetype (type->data.klass)->type;
 			goto handle_enum;
 		}
-		if (type->data.klass == mono_defaults.handleref_class){
+		if (type->data.klass == mono_class_try_get_handleref_class ()){
 			*conv = MONO_MARSHAL_CONV_HANDLEREF;
 			return MONO_NATIVE_INT;
 		}

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -80,6 +80,7 @@ static GENERATE_GET_CLASS_WITH_CACHE (unhandled_exception_event_args, "System", 
 static GENERATE_GET_CLASS_WITH_CACHE (sta_thread_attribute, "System", "STAThreadAttribute")
 static GENERATE_GET_CLASS_WITH_CACHE (activation_services, "System.Runtime.Remoting.Activation", "ActivationServices")
 
+static GENERATE_GET_CLASS_WITH_CACHE (asyncresult, "System.Runtime.Remoting.Messaging", "AsyncResult");
 
 #define ldstr_lock() mono_coop_mutex_lock (&ldstr_section)
 #define ldstr_unlock() mono_coop_mutex_unlock (&ldstr_section)
@@ -7977,7 +7978,7 @@ mono_async_result_new (MonoDomain *domain, HANDLE handle, MonoObject *state, gpo
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	error_init (error);
-	MonoAsyncResult *res = (MonoAsyncResult *)mono_object_new_checked (domain, mono_defaults.asyncresult_class, error);
+	MonoAsyncResult *res = (MonoAsyncResult *)mono_object_new_checked (domain, mono_class_get_asyncresult_class (), error);
 	return_val_if_nok (error, NULL);
 	MonoObject *context = mono_runtime_capture_context (domain, error);
 	return_val_if_nok (error, NULL);

--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -19,6 +19,7 @@
 #include <mono/utils/mono-memory-model.h>
 
 static GENERATE_GET_CLASS_WITH_CACHE (runtime_helpers, "System.Runtime.CompilerServices", "RuntimeHelpers")
+static GENERATE_TRY_GET_CLASS_WITH_CACHE (math, "System", "Math")
 
 /* optimize the simple GetGenericValueImpl/SetGenericValueImpl generic icalls */
 static MonoInst*
@@ -132,7 +133,7 @@ llvm_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 		}
 	}
 	/* The LLVM backend supports these intrinsics */
-	if (cmethod->klass == mono_defaults.math_class) {
+	if (cmethod->klass == mono_class_try_get_math_class ()) {
 		if (strcmp (cmethod->name, "Sin") == 0) {
 			opcode = OP_SIN;
 		} else if (strcmp (cmethod->name, "Cos") == 0) {
@@ -1155,7 +1156,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 				mini_set_inline_failure (cfg, "MethodBase:GetCurrentMethod ()");
 			return ins;
 		}
-	} else if (cmethod->klass == mono_defaults.math_class) {
+	} else if (cmethod->klass == mono_class_try_get_math_class ()) {
 		/* 
 		 * There is general branchless code for Min/Max, but it does not work for 
 		 * all inputs:

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -56,6 +56,9 @@ static gboolean optimize_for_xen = TRUE;
 #define optimize_for_xen 0
 #endif
 
+static GENERATE_TRY_GET_CLASS_WITH_CACHE (math, "System", "Math")
+
+
 #define IS_IMM32(val) ((((guint64)val) >> 32) == 0)
 
 #define IS_REX(inst) (((inst) >= 0x40) && ((inst) <= 0x4f))
@@ -8249,7 +8252,7 @@ mono_arch_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMetho
 	MonoInst *ins = NULL;
 	int opcode = 0;
 
-	if (cmethod->klass == mono_defaults.math_class) {
+	if (cmethod->klass == mono_class_try_get_math_class ()) {
 		if (strcmp (cmethod->name, "Sin") == 0) {
 			opcode = OP_SIN;
 		} else if (strcmp (cmethod->name, "Cos") == 0) {

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -50,6 +50,9 @@ static gboolean optimize_for_xen = TRUE;
 #endif
 #endif
 
+static GENERATE_TRY_GET_CLASS_WITH_CACHE (math, "System", "Math")
+
+
 /* The single step trampoline */
 static gpointer ss_trampoline;
 
@@ -5784,7 +5787,7 @@ mono_arch_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMetho
 	MonoInst *ins = NULL;
 	int opcode = 0;
 
-	if (cmethod->klass == mono_defaults.math_class) {
+	if (cmethod->klass == mono_class_try_get_math_class ()) {
 		if (strcmp (cmethod->name, "Sin") == 0) {
 			opcode = OP_SIN;
 		} else if (strcmp (cmethod->name, "Cos") == 0) {


### PR DESCRIPTION
The majes the following classes optional to the runtime:

System.Reflection.CustomAttributeData
System.Text.StringBuilder
System.Math
System.Console
System.Diagnostics.StackTrace

This doesn't change the linker scripts so it's not ready to be merged.

Those are all types that can be clearly made optional. There are a lot of other types
we could, but there are deeper dependencies in places as threadpool or marshal.