### PR TITLE
[sdks] Debian Linux doesn't need to build MXE

### DIFF
--- a/sdks/builds/mxe.mk
+++ b/sdks/builds/mxe.mk
@@ -3,7 +3,10 @@ ifeq ($(UNAME),Linux)
 LINUX_FLAVOR=$(shell ./determine-linux-flavor.sh)
 endif
 
-ifeq ($(LINUX_FLAVOR),Ubuntu)
+LINUX_WITH_MINGW=:Ubuntu:,:Debian:
+LINUX_HAS_MINGW=$(if $(findstring :$(LINUX_FLAVOR):,$(LINUX_WITH_MINGW)),yes)
+
+ifeq ($(LINUX_HAS_MINGW),yes)
 MXE_PREFIX=/usr
 
 .PHONY: provision-mxe


### PR DESCRIPTION
**When/if this PR is accepted, could we backport it to the `2018-{04,06,08}` branches as well? It fixes XA build on our PR bots, thanks!**

Debian and its derivatives include full mingw chain (both 64 and 32-bit) and so
they don't need to build the toolchain at all. However, the current detection of
Linux flavor takes into account only Ubuntu and all other distros are configured
to *require* MXE but they do *not* build them.

This commit fixes detection of distros which provide the mingw toolchain in a
way that makes it easy to extend the set of compatible distributions as needed.
In order to mark a distribution as one with MinGW one has to add the `:Distro:`
string to the `LINUX_WITH_MINGW` make variable in `mxe.mk`. The `Distro` string
is whatever the `determine-linux-flavor.sh` script returns.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
