### PR TITLE
[2018-04] [sdks] Debian Linux doesn\u0027t need to build MXE

### DIFF
--- a/sdks/builds/mxe.mk
+++ b/sdks/builds/mxe.mk
@@ -3,7 +3,10 @@ ifeq ($(UNAME),Linux)
 LINUX_FLAVOR=$(shell ./determine-linux-flavor.sh)
 endif
 
-ifeq ($(LINUX_FLAVOR),Ubuntu)
+LINUX_WITH_MINGW=:Ubuntu:,:Debian:
+LINUX_HAS_MINGW=$(if $(findstring :$(LINUX_FLAVOR):,$(LINUX_WITH_MINGW)),yes)
+
+ifeq ($(LINUX_HAS_MINGW),yes)
 MXE_PREFIX=/usr
 
 .PHONY: provision-mxe


### PR DESCRIPTION
Backport of #10817.

/cc @luhenry