### PR TITLE
Add Mono.Android facade

### DIFF
--- a/mcs/class/Facades/Mono.Android/AssemblyInfo.cs
+++ b/mcs/class/Facades/Mono.Android/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2013 Xamarin Inc. (http://www.xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+[assembly: AssemblyTitle ("Mono.Android")]
+[assembly: AssemblyDescription ("Mono.Android")]
+[assembly: AssemblyDefaultAlias ("Mono.Android")]
+[assembly: AssemblyCompany ("Mono development team")]
+[assembly: AssemblyProduct ("Mono Common Language Infrastructure")]
+[assembly: AssemblyCopyright ("(c) Various Mono authors")]
+[assembly: AssemblyVersion ("4.0.1.0")]
+[assembly: AssemblyInformationalVersion ("4.0.0.0")]
+[assembly: AssemblyFileVersion ("4.0.0.0")]

--- a/mcs/class/Facades/Mono.Android/Makefile
+++ b/mcs/class/Facades/Mono.Android/Makefile
@@ -1,0 +1,21 @@
+MCS_BUILD_DIR = ../../../build
+
+thisdir = class/Facades/Mono.Android
+SUBDIRS =
+include $(MCS_BUILD_DIR)/rules.make
+
+LIBRARY_SUBDIR = Facades
+LIBRARY_INSTALL_DIR = $(mono_libdir)/mono/$(FRAMEWORK_VERSION)/Facades
+
+LIBRARY = Mono.Android.dll
+
+KEYFILE = ../../msfinal.pub
+SIGN_FLAGS = /delaysign /nowarn:1616,1699
+LIB_REFS = System
+LIB_MCS_FLAGS = $(SIGN_FLAGS) $(EXTRA_LIB_MCS_FLAGS)
+
+PLATFORM_DEBUG_FLAGS =
+
+NO_TEST = yes
+
+include $(MCS_BUILD_DIR)/library.make

--- a/mcs/class/Facades/Mono.Android/Mono.Android.dll.sources
+++ b/mcs/class/Facades/Mono.Android/Mono.Android.dll.sources
@@ -1,0 +1,2 @@
+../../../../external/corefx/src/System.Drawing.Primitives/ref/System.Drawing.Primitives.cs
+AssemblyInfo.cs

--- a/mcs/class/Facades/netstandard/Makefile
+++ b/mcs/class/Facades/netstandard/Makefile
@@ -46,7 +46,11 @@ else
 # the product repo like in the XI/XA case we need to pass in a reference
 # to the assembly containing drawing types like Rectangle etc. from there.
 # This needs to be passed in via EXTERNAL_FACADE_DRAWING_REFERENCE.
+ifdef EXTERNAL_FACADE_DRAWING_REFERENCE
 LIB_MCS_FLAGS += /r:$(EXTERNAL_FACADE_DRAWING_REFERENCE)
+else ifeq ($(PROFILE),monodroid)
+LIB_REFS += Facades/Mono.Android
+endif
 endif
 
 endif

--- a/mcs/class/Facades/subdirs.make
+++ b/mcs/class/Facades/subdirs.make
@@ -67,6 +67,10 @@ build_PARALLEL_SUBDIRS = $(basic_PARALLEL_SUBDIRS) System.Text.RegularExpression
 monodroid_SUBDIRS = $(monotouch_SUBDIRS)
 monodroid_PARALLEL_SUBDIRS = $(monotouch_PARALLEL_SUBDIRS)
 
+#fndef EXTERNAL_FACADE_DRAWING_REFERENCE
+monodroid_SUBDIRS += Mono.Android netstandard
+endif
+
 xammac_SUBDIRS = $(monotouch_SUBDIRS)
 xammac_PARALLEL_SUBDIRS = $(monotouch_PARALLEL_SUBDIRS)
 

--- a/mcs/class/Facades/subdirs.make
+++ b/mcs/class/Facades/subdirs.make
@@ -67,7 +67,7 @@ build_PARALLEL_SUBDIRS = $(basic_PARALLEL_SUBDIRS) System.Text.RegularExpression
 monodroid_SUBDIRS = $(monotouch_SUBDIRS)
 monodroid_PARALLEL_SUBDIRS = $(monotouch_PARALLEL_SUBDIRS)
 
-#fndef EXTERNAL_FACADE_DRAWING_REFERENCE
+ifndef EXTERNAL_FACADE_DRAWING_REFERENCE
 monodroid_SUBDIRS += Mono.Android netstandard
 endif
 


### PR DESCRIPTION
Since xunit tests (e.g. monodroid_corlib_xunit.dll) requires netstandard lib now (see https://github.com/mono/mono/pull/9873) and the netstandard requires Mono.Android on monodroid profile (Mono.Android implements System.Drawing) I am adding this dummy facade in order to successfully compile mono-runtimes on XA.

