### PR TITLE
[tests] Disable bug-80392.2.exe and monitor-wait-abort.exe on OSX

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1055,6 +1055,12 @@ PLATFORM_DISABLED_TESTS += bug-58782-plain-throw.exe bug-58782-capture-and-throw
 PLATFORM_DISABLED_TESTS += verbose.exe
 endif
 
+if HOST_DARWIN
+
+# see https://github.com/mono/mono/issues/10845
+PLATFORM_DISABLED_TESTS += bug-80392.2.exe monitor-wait-abort.exe
+endif
+
 if AMD64
 # #651684
 PLATFORM_DISABLED_TESTS += finally_guard.exe


### PR DESCRIPTION
They frequently fail, see https://github.com/mono/mono/issues/10845



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
