### PR TITLE
[wasm] Update sample.cs usage and docs

### DIFF
--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -117,8 +117,8 @@ WebAssembly.Net.Http.dll: WebAssembly.Bindings.dll WasmHttpMessageHandler.cs
 Simple.Dependency.dll: dependency.cs
 	$(CSC) $(CSC_FLAGS) /target:library -out:$@ /r:$(WASM_BCL_DIR)/mscorlib.dll /r:$(WASM_BCL_DIR)/System.Core.dll dependency.cs
 
-sample.dll: Simple.Dependency.dll sample.cs
-	$(CSC) $(CSC_FLAGS) /target:library -out:$@ /r:Simple.Dependency.dll /r:$(WASM_BCL_DIR)/mscorlib.dll /r:$(WASM_BCL_DIR)/System.Core.dll sample.cs
+sample.dll: Simple.Dependency.dll sample.cs WebAssembly.Bindings.dll WebAssembly.Net.Http.dll
+	$(CSC) $(CSC_FLAGS) /target:library -out:$@ /r:Simple.Dependency.dll /r:$(WASM_BCL_DIR)/mscorlib.dll /r:$(WASM_BCL_DIR)/System.dll /r:$(WASM_BCL_DIR)/System.Core.dll /r:$(WASM_BCL_DIR)/System.Net.Http.dll /r:WebAssembly.Bindings.dll /r:WebAssembly.Net.Http.dll sample.cs
 
 OPTIONS_CS = $(TOP)/mcs/class/Mono.Options/Mono.Options/Options.cs
 

--- a/sdks/wasm/README.md
+++ b/sdks/wasm/README.md
@@ -34,6 +34,7 @@ Copy the sample code from the SDK. We'll assume that the $WASM_SDK variable poin
 ```
 cp $WASM_SDK/sample.html .
 cp $WASM_SDK/sample.cs .
+cp $WASM_SDK/dependency.cs .
 ```
 
 ### Step 3
@@ -41,7 +42,7 @@ cp $WASM_SDK/sample.cs .
 Compile and package your application.
 
 ```
-csc /target:library sample.cs
+csc /target:library -out:sample.dll /r:$(WASM_SDK)/bcl/System.Net.Http.dll /r:$(WASM_SDK)/framework/WebAssembly.Bindings.dll /r:$(WASM_SDK)/framework/WebAssembly.Net.Http.dll dependency.cs sample.cs
 mono $WASM_SDK/packager.exe sample.dll
 ```
 

--- a/sdks/wasm/WasmHttpMessageHandler.cs
+++ b/sdks/wasm/WasmHttpMessageHandler.cs
@@ -124,8 +124,7 @@ namespace WebAssembly.Net.Http.HttpClient
                 //Console.WriteLine($"type: {status.ResponseType}");
                 //Console.WriteLine($"url: {status.Url}");
                 byte[] buffer = null;
-                if (status.IsOK)
-                    buffer = (byte[])await status.ArrayBuffer();
+                buffer = (byte[])await status.ArrayBuffer();
 
                 HttpResponseMessage httpresponse = new HttpResponseMessage((HttpStatusCode)Enum.Parse(typeof(HttpStatusCode), status.Status.ToString()));
 

--- a/sdks/wasm/sample.cs
+++ b/sdks/wasm/sample.cs
@@ -1,5 +1,9 @@
 using System;
 using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using WebAssembly;
+using WebAssembly.Net.Http.HttpClient;
 
 public class Math {
 	public static int IntAdd (int a, int b) {
@@ -17,4 +21,245 @@ public class Math {
 	public int First (int[] x) {
 		return x.FirstOrDefault ();
 	}
+}
+
+namespace GeoLocation
+{
+    class Program
+    {
+
+        static DOMObject navigator;
+        static DOMObject global;
+        static string BaseApiUrl = string.Empty;
+        static HttpClient httpClient;
+
+        static void Main(string[] args)
+        {
+            global = new DOMObject(string.Empty);
+            navigator = new DOMObject("navigator");
+
+            var httpMessageHandler = typeof(HttpClient).GetField("GetHttpMessageHandler",
+                                            BindingFlags.Static |
+                                            BindingFlags.NonPublic);
+
+            var window = (JSObject)WebAssembly.Runtime.GetGlobalObject("window");
+            using (var location = (JSObject)window.GetObjectProperty("location"))
+            {
+                BaseApiUrl = (string)location.GetObjectProperty("origin");
+            }
+
+            window = null;
+
+            // Setup the HttpClientHandler
+            httpMessageHandler.SetValue(null, (Func<HttpMessageHandler>)(() => {
+                return new WasmHttpMessageHandler();
+            }));
+
+            httpClient = new HttpClient() { BaseAddress = new Uri(BaseApiUrl) };
+
+        }
+
+        static int requests = 0;
+        static void GeoFindMe(JSObject output)
+        {
+            GeoLocation geoLocation;
+            try
+            {
+                geoLocation = new GeoLocation(navigator.GetProperty("geolocation"));
+            }
+            catch
+            {
+                output.SetObjectProperty("innerHTML", "<p>Geolocation is not supported by your browser</p>");
+                return;
+            }
+
+            output.SetObjectProperty("innerHTML", "<p>Locating…</p>");
+
+            geoLocation.OnSuccess += async (object sender, Position position) =>
+            {
+                using (position)
+                {
+                    using (var coords = position.Coordinates)
+                    {
+                        var latitude = coords.Latitude;
+                        var longitude = coords.Longitude;
+
+                        output.SetObjectProperty("innerHTML", $"<p>Latitude is {latitude} ° <br>Longitude is {longitude} °</p>");
+
+                        try {
+
+                            var ApiFile = $"https://maps.googleapis.com/maps/api/staticmap?center={latitude},{longitude}&zoom=13&size=300x300&sensor=false";
+
+                            var rspMsg = await httpClient.GetAsync(ApiFile);
+                            if (rspMsg.IsSuccessStatusCode)
+                            {
+
+                                var mimeType = getMimeType(rspMsg.Content?.ReadAsByteArrayAsync().Result);
+                                Console.WriteLine($"Request: {++requests}  ByteAsync: {rspMsg.Content?.ReadAsByteArrayAsync().Result.Length}  MimeType: {mimeType}");
+                                global.Invoke("showMyPosition", mimeType, Convert.ToBase64String(rspMsg.Content?.ReadAsByteArrayAsync().Result));
+                            }
+                            else
+                            {
+                                output.SetObjectProperty("innerHTML", $"<p>Latitude is {latitude} ° <br>Longitude is {longitude} </p><br>StatusCode: {rspMsg.StatusCode} <br>Response Message: {rspMsg.Content?.ReadAsStringAsync().Result}</p>");
+                            }
+                        }
+                        catch (Exception exc2)
+                        {
+                            Console.WriteLine($"GeoLocation HttpClient Exception: {exc2.Message}");
+                            Console.WriteLine($"GeoLocation HttpClient InnerException: {exc2.InnerException?.Message}");
+                        }
+
+                    }
+                }
+
+            };
+
+            geoLocation.OnError += (object sender, PositionError e) =>
+            {
+                output.SetObjectProperty("innerHTML", $"Unable to retrieve your location: Code: {e.Code} - {e.message}");
+            };
+
+            geoLocation.GetCurrentPosition();
+
+            geoLocation = null;
+        }
+
+        static string getMimeType (byte[] imageData)
+        {
+            if (imageData.Length < 4)
+                return string.Empty;
+
+            if (imageData[0] == 0x89 && imageData[1] == 0x50 && imageData[2] == 0x4E && imageData[3] == 0x47)
+                return "image/png";
+            else if (imageData[0] == 0xff && imageData[1] == 0xd8)
+                return "image/jpeg";
+            else if (imageData[0] == 0x47 && imageData[1] == 0x49 && imageData[2] == 0x46)
+                return "image/gif";
+            else
+                return string.Empty;
+
+        }
+    }
+
+    // Serves as a wrapper around a JSObject.
+    class DOMObject : IDisposable
+    {
+        public JSObject ManagedJSObject { get; private set; }
+
+        public DOMObject(object jsobject)
+        {
+            ManagedJSObject = jsobject as JSObject;
+            if (ManagedJSObject == null)
+                throw new NullReferenceException($"{nameof(jsobject)} must be of type JSObject and non null!");
+
+        }
+
+        public DOMObject(string globalName) : this((JSObject)Runtime.GetGlobalObject(globalName))
+        { }
+
+        public object GetProperty(string property)
+        {
+            return ManagedJSObject.GetObjectProperty(property);
+        }
+
+        public object Invoke(string method, params object[] args)
+        {
+            return ManagedJSObject.Invoke(method, args);
+        }
+
+        public void Dispose()
+        {
+            // Dispose of unmanaged resources.
+            Dispose(true);
+            // Suppress finalization.
+            GC.SuppressFinalize(this);
+        }
+
+        // Protected implementation of Dispose pattern.
+        protected virtual void Dispose(bool disposing)
+        {
+
+            if (disposing)
+            {
+
+                // Free any other managed objects here.
+                //
+            }
+
+            // Free any unmanaged objects here.
+            //
+            ManagedJSObject?.Dispose();
+            ManagedJSObject = null;
+        }
+
+    }
+
+    class PositionEventArgs : EventArgs
+    {
+        public Position Position { get; set; }
+    }
+
+    class GeoLocation : DOMObject
+    {
+
+
+        public event EventHandler<Position> OnSuccess;
+        public event EventHandler<PositionError> OnError;
+
+        public GeoLocation(object jsobject) : base(jsobject)
+        {
+        }
+
+        public void GetCurrentPosition()
+        {
+            var success = new Action<object>((pos) =>
+            {
+                OnSuccess?.Invoke(this, new Position(pos));
+            });
+
+            var error = new Action<object>((err) =>
+            {
+                OnError?.Invoke(this, new PositionError(err));
+            });
+
+            ManagedJSObject.Invoke("getCurrentPosition", success, error);
+        }
+
+    }
+
+    class Position : DOMObject
+    {
+
+        public Position(object jsobject) : base(jsobject)
+        {
+        }
+
+        public Coordinates Coordinates => new Coordinates(ManagedJSObject.GetObjectProperty("coords"));
+
+    }
+
+    class PositionError : DOMObject
+    {
+
+        public PositionError(object jsobject) : base(jsobject)
+        {
+        }
+
+        public int Code => (int)ManagedJSObject.GetObjectProperty("code");
+        public string message => (string)ManagedJSObject.GetObjectProperty("message");
+
+    }
+
+    class Coordinates : DOMObject
+    {
+
+        public Coordinates(object jsobject) : base(jsobject)
+        {
+        }
+
+        public double Latitude => (double)ManagedJSObject.GetObjectProperty("latitude");
+        public double Longitude => (double)ManagedJSObject.GetObjectProperty("longitude");
+
+    }
+
 }

--- a/sdks/wasm/sample.html
+++ b/sdks/wasm/sample.html
@@ -1,6 +1,14 @@
 <!doctype html>
 <html lang="en-us">
   <head>
+		<style>
+			body {
+				padding: 20px;
+				background-color:#ffffc9
+			  }
+				  
+			  p { margin : 0; }
+		</style>    	  
   </head>
   <body>
 	  C# output:
@@ -9,6 +17,9 @@
 	  <br>
 		  <button type="button" onclick="App.onClick()" id="button" disabled="true">Run</button>
 	  <br>
+
+	  <p><button onclick="App.geoFindMeCSharp()">Show my location</button></p>
+	  <div id="out"></div>	  
 	
 	<script type='text/javascript'>
 		var App = {
@@ -24,8 +35,28 @@
 				this.button = document.getElementById ("button");
 
 				this.button.disabled = false;
+
+				// initialize geolocation sample
+				BINDING.call_static_method("[sample] GeoLocation.Program:Main", []);
 			},
+            geoFindMeCSharp: function () {
+                BINDING.call_static_method("[sample] GeoLocation.Program:GeoFindMe", [ document.getElementById("out") ]);
+            }			
 		};
+
+        // Called from C# passing in the mime type of the image and the 
+        // image data converted from byte array to base64
+        function showMyPosition (mimeType, imageData)
+        {
+            var output = document.getElementById("out");
+
+            var img = new Image();
+            img.src = "data:" + mimeType + ";base64," + imageData;
+
+            output.appendChild(img);
+
+        }
+
       </script>
       <script type="text/javascript" src="runtime.js"></script>
       <script async type="text/javascript" src="mono.js"></script>


### PR DESCRIPTION
Extend C# sample to include:

- Calling JavaScript functions from C#
- Calling C# functions from JavaScript.
- Referencing JavaScript objects
- Getting and Setting JavaScrip object properties.
- Invoking JavaScript object functions with parameters.
- Setting up the default HttpClientHandler
- Instantiating a default WasmHttpMessageHandler.
- Setting up HttpClient calls
- Parsing and testing the correct results returned from the HtppClient.
- Obtaining a byte array and string array from response.
- Obtaining a reference to a global script function defined in the .html file and calling it.
- Working with DOM objects using the SDK's WebAssembly.Bindings.dll

resolves issue: https://github.com/mono/mono/issues/7548

Also includes a fix the WasmHttpMessageHandler.cs that fixes: https://github.com/mono/mono/issues/10842 