### PR TITLE
[sdks] One more update to get XA PR builds working on Linux

### DIFF
--- a/sdks/builds/mxe.mk
+++ b/sdks/builds/mxe.mk
@@ -3,7 +3,7 @@ ifeq ($(UNAME),Linux)
 LINUX_FLAVOR=$(shell ./determine-linux-flavor.sh)
 endif
 
-LINUX_WITH_MINGW=:Ubuntu:,:Debian:
+LINUX_WITH_MINGW=:Ubuntu:,:Debian:,:Debian GNU/Linux:
 LINUX_HAS_MINGW=$(if $(findstring :$(LINUX_FLAVOR):,$(LINUX_WITH_MINGW)),yes)
 
 ifeq ($(LINUX_HAS_MINGW),yes)


### PR DESCRIPTION
**Please port this to the `2018-{04,06,08}` branches, thanks!**

It turns out some Debian versions identify themselves as `Debian GNU/Linux`, add
this string to the list of distributions which have mingw. This *should* fix the
PR builds (fingers crossed)



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
