### PR TITLE
Use passwordless import in the `X509Certificate(byte[])` constructor.

### DIFF
--- a/mcs/class/System/System.Security.Cryptography.X509Certificates/X509Certificate2.cs
+++ b/mcs/class/System/System.Security.Cryptography.X509Certificates/X509Certificate2.cs
@@ -67,8 +67,15 @@ namespace System.Security.Cryptography.X509Certificates {
 		}
 
 		public X509Certificate2 (byte[] rawData)
-			: base (rawData)
 		{
+			// MONO: temporary hack until `X509CertificateImplApple` derives from
+			//       `X509Certificate2Impl`.
+			if (rawData != null && rawData.Length != 0) {
+				using (var safePasswordHandle = new SafePasswordHandle ((string)null)) {
+					var impl = X509Helper.Import (rawData, safePasswordHandle, X509KeyStorageFlags.DefaultKeySet);
+					ImportHandle (impl);
+				}
+			}
 		}
 
 		public X509Certificate2 (byte[] rawData, string password)

--- a/mcs/class/corlib/System.Security.Cryptography.X509Certificates/X509Certificate.cs
+++ b/mcs/class/corlib/System.Security.Cryptography.X509Certificates/X509Certificate.cs
@@ -92,11 +92,8 @@ namespace System.Security.Cryptography.X509Certificates
 
 		public X509Certificate (byte[] data)
 		{
-			if (data != null && data.Length != 0) {
-				// For compat reasons, this constructor treats passing a null or empty data set as the same as calling the nullary constructor.
-				using (var safePasswordHandle = new SafePasswordHandle ((string)null))
-					impl = X509Helper.Import (data, safePasswordHandle, X509KeyStorageFlags.DefaultKeySet);
-			}
+			if (data != null && data.Length != 0)
+				impl = X509Helper.Import (data);
 		}
 
 		public X509Certificate (byte[] rawData, string password)

--- a/mcs/class/corlib/System.Security.Cryptography.X509Certificates/X509Helper.cs
+++ b/mcs/class/corlib/System.Security.Cryptography.X509Certificates/X509Helper.cs
@@ -70,6 +70,11 @@ namespace System.Security.Cryptography.X509Certificates
 			return new CryptographicException (Locale.GetText ("Certificate instance is empty."));
 		}
 
+		public static X509CertificateImpl Import (byte[] rawData)
+		{
+			return CertificateProvider.Import (rawData);
+		}
+
 		public static X509CertificateImpl Import (byte[] rawData, SafePasswordHandle password, X509KeyStorageFlags keyStorageFlags)
 		{
 			return CertificateProvider.Import (rawData, password, keyStorageFlags);


### PR DESCRIPTION
The `X509Certificate(byte[])` constructor should call `CertificateProvider.Import(byte[])`
to use the native apple implementation if possible.

Fixes #10805