### PR TITLE
[tests] Reenable bug-80392.2.exe

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1058,7 +1058,7 @@ endif
 if HOST_DARWIN
 
 # see https://github.com/mono/mono/issues/10845
-PLATFORM_DISABLED_TESTS += bug-80392.2.exe monitor-wait-abort.exe
+PLATFORM_DISABLED_TESTS += monitor-wait-abort.exe
 endif
 
 if AMD64


### PR DESCRIPTION
According to @kumpera it should be fixed by https://github.com/mono/mono/pull/10793.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
