### PR TITLE
[packaging] Remove installation of openssl via brew on macOS

### DIFF
--- a/scripts/ci/pipeline/osx-package.groovy
+++ b/scripts/ci/pipeline/osx-package.groovy
@@ -29,15 +29,6 @@ node ("osx-amd64") {
                 stage('Build') {
                     utils.reportGitHubStatus (isPr ? env.ghprbActualCommit : commitHash, 'PKG-mono', env.BUILD_URL, 'PENDING', 'Building...')
 
-                    // install openssl for .net core (remove once msbuild uses a 2.x version which doesn't rely on openssl)
-                    sh 'brew update && brew install openssl'
-                    sh 'mkdir -p /usr/local/lib'
-                    sh 'rm /usr/local/lib/libcrypto.1.0.0.dylib || true'
-                    sh 'rm /usr/local/lib/libssl.1.0.0.dylib || true'
-                    sh 'ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/'
-                    sh 'ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/'
-
-
                     // workaround for libtiff issue
                     sh 'make -C external/bockbuild/builds/tiff-4.0.8-x86 clean || true'
                     sh 'make -C external/bockbuild/builds/tiff-4.0.8-x64 clean || true'


### PR DESCRIPTION
We're now using an msbuild version which uses .NET Core 2.x which no longer needs openssl.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
