### PR TITLE
Add ability to add experiments without backward compatibility or support guarantees

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5043,6 +5043,26 @@ AM_CONDITIONAL([ENABLE_HYBRID_SUSPEND], [test x$enable_hybrid_suspend != xno])
 
 dnl End of thread suspend policy
 
+dnl ***************************
+dnl *** feature experiments ***
+dnl ***************************
+
+dnl When adding experiments, also add to mono/utils/mono-experiments.def
+AC_ARG_ENABLE(experiment, [ --enable-experiment=LIST       Enable experimental fatures from the comma-separate LIST.  Available experiments: ],[
+
+	if test x$enable_experiment != x ; then
+		AC_DEFINE(ENABLE_EXPERIMENTS,1,[Enable feature experiments])
+	fi
+	for feature in `echo "$enable_experiment" | sed -e "s/,/ /g"`; do
+		eval "mono_experiment_test_enable_$feature='yes'"
+	done
+
+	if test "x$mono_experiment_test_enable_all" = "xyes"; then
+		true
+	fi
+
+],[])
+
 dnl **********************
 dnl *** checked builds ***
 dnl **********************

--- a/configure.ac
+++ b/configure.ac
@@ -5048,7 +5048,7 @@ dnl *** feature experiments ***
 dnl ***************************
 
 dnl When adding experiments, also add to mono/utils/mono-experiments.def
-AC_ARG_ENABLE(experiment, [ --enable-experiment=LIST       Enable experimental fatures from the comma-separate LIST.  Available experiments: ],[
+AC_ARG_ENABLE(experiment, [ --enable-experiment=LIST       Enable experimental fatures from the comma-separate LIST.  Available experiments: null],[
 
 	if test x$enable_experiment != x ; then
 		AC_DEFINE(ENABLE_EXPERIMENTS,1,[Enable feature experiments])
@@ -5058,9 +5058,13 @@ AC_ARG_ENABLE(experiment, [ --enable-experiment=LIST       Enable experimental f
 	done
 
 	if test "x$mono_experiment_test_enable_all" = "xyes"; then
+		eval "mono_experiment_test_enable_null='yes'"
 		true
 	fi
 
+	if test "x$mono_experiment_test_enable_null" = "xyes"; then
+		AC_DEFINE(ENABLE_EXPERIMENT_null, 1, [Enable experiment 'null'])
+	fi
 ],[])
 
 dnl **********************

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -49,6 +49,7 @@
 #include <mono/metadata/threads.h>
 #include <mono/metadata/profiler-private.h>
 #include <mono/metadata/coree.h>
+#include <mono/utils/mono-experiments.h>
 
 //#define DEBUG_DOMAIN_UNLOAD 1
 
@@ -535,7 +536,12 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	mono_root_domain = domain;
 
 	SET_APPDOMAIN (domain);
-	
+
+#if defined(ENABLE_EXPERIMENT_null)
+	if (mono_experiment_enabled (MONO_EXPERIMENT_null))
+		g_warning ("null experiment enabled");
+#endif
+
 	/* Get a list of runtimes supported by the exe */
 	if (exe_filename != NULL) {
 		/*

--- a/mono/utils/Makefile.am
+++ b/mono/utils/Makefile.am
@@ -71,6 +71,8 @@ monoutils_sources = \
 	mono-dl-wasm.c	\
 	mono-dl.h		\
 	mono-dl-windows-internals.h	\
+	mono-experiments.h	\
+	mono-experiments.c	\
 	mono-log-windows.c	\
 	mono-log-common.c	\
 	mono-log-posix.c	\
@@ -321,7 +323,7 @@ libmonoutilsinclude_HEADERS = 	\
 	mono-dl-fallback.h	\
 	mono-counters.h
 
-EXTRA_DIST = mono-embed.h mono-embed.c ../../support/libm/complex.c
+EXTRA_DIST = mono-embed.h mono-embed.c ../../support/libm/complex.c mono-experiments.def
 
 DIST_SUBDIRS = jemalloc
 

--- a/mono/utils/mono-experiments.c
+++ b/mono/utils/mono-experiments.c
@@ -1,0 +1,54 @@
+
+#include "config.h"
+#include <glib.h>
+#include "mono/utils/mono-lazy-init.h"
+#include "mono/utils/mono-experiments.h"
+
+mono_lazy_init_t mono_experiments_enabled_init;
+
+guint8 mono_experiments_enabled_table[] = {
+#define EXPERIMENT(id,ghurl) 0,
+#include "mono-experiments.def"
+#undef EXPERIMENT
+};
+
+static
+const char* mono_experiment_names[] = {
+#define EXPERIMENT(id,ghurl) #id,
+#include "mono-experiments.def"
+#undef EXPERIMENT
+};
+
+static int
+lookup_experiment_by_name (const char *exp_name)
+{
+	/* slow loop, but we only do this once, on demand. */
+	for (int i = 0; i < MONO_EXPERIMENT_NUM_EXPERIMENTS; i++) {
+		if (!strcmp (mono_experiment_names[i], exp_name))
+			return i;
+	}
+	return -1;
+}
+
+void
+mono_experiments_initialize_table (void)
+{
+	char *str = g_getenv ("MONO_EXPERIMENT");
+	if (str == NULL)
+		return;
+	char **experiments = g_strsplit (str, ",", 0);
+
+	char **exp_name = &experiments[0];
+	while (*exp_name) {
+		int exp_id = lookup_experiment_by_name (*exp_name);
+		if (exp_id < 0) {
+			g_warning ("This version of Mono does not include experiment '%s'.  Experiments have no stability, backward compatability or deprecation guarantees.", *exp_name);
+		} else {
+			mono_experiments_enabled_table [exp_id] = 1;
+		}
+		exp_name++;
+	}
+
+	g_free (str);
+	g_strfreev (experiments);
+}

--- a/mono/utils/mono-experiments.def
+++ b/mono/utils/mono-experiments.def
@@ -1,0 +1,32 @@
+/*
+ * Mono Experiments.
+ *
+ * Experiments are UNSUPPORTED.  Do not rely on experiments in production.
+ * Experiments are not guaranteed to be stable, backward compatible or
+ * available in future versions of Mono.
+ *
+ */
+
+/* Defining experiments:
+ * use the EXPERIMENT(id,"GH link") format.
+ *
+ * id: a unique identifier for the experiment.  Will be used in the
+ * MONO_EXPERIMENT=id1,id2,... environment variable to enable an experiment at
+ * runtime and a MONO_EXPERIMENT_id enumeration value that can be used to check
+ * for whether an experiment is enabled.
+ *
+ * GH Link: a URL of a GitHub tracking issue for the experiment.  The issue is
+ * closed when the experiment is removed from Mono.
+ *
+ * To add a compile-time check for an experiment, see configure.ac macro AC_ARG_ENABLE(experiment,...)
+ * To add a new compile-time constant ENABLE_EXPERIMENT_myfeaturename:
+ *   1. Add eval "mono_experiment_test_enable_myfeaturename='yes'" to the mono_experiment_test_enable_all block
+ *   2. Add a block like
+ *        if test "x$mono_experiment_test_enable_myfeaturename" = "xyes"; then
+ *        	AC_DEFINE(ENABLE_EXPERIMENT_myfeaturename, 1, [Enable experiment 'myfeaturename'])
+ *        fi
+ *   3. use both `#if defined (ENABLE_EXPERIMENT_myfeaturename)` and
+ *     `if (mono_experiment_enabled (MONO_EXPERIMENT_myfeaturename))` to check that the experiment
+ *     is compiled in and also enabled at runtime.
+ *     It is optional to add the compile-time check, but if you add it, add the runtime check too.
+ */

--- a/mono/utils/mono-experiments.def
+++ b/mono/utils/mono-experiments.def
@@ -30,3 +30,6 @@
  *     is compiled in and also enabled at runtime.
  *     It is optional to add the compile-time check, but if you add it, add the runtime check too.
  */
+#if defined(ENABLE_EXPERIMENT_null)
+EXPERIMENT(null,"https://github.com/mono/mono/issues/10877")
+#endif

--- a/mono/utils/mono-experiments.h
+++ b/mono/utils/mono-experiments.h
@@ -1,0 +1,29 @@
+
+#ifndef _MONO_EXPERIMENTS_H_
+#define _MONO_EXPERIMENTS_H_
+
+#include <glib.h>
+
+#include "mono/utils/mono-lazy-init.h"
+
+
+extern mono_lazy_init_t mono_experiments_enabled_init;
+
+extern guint8 mono_experiments_enabled_table[];
+
+void mono_experiments_initialize_table (void);
+
+static inline gboolean
+mono_experiment_enabled (int experiment_id) {
+	mono_lazy_initialize (&mono_experiments_enabled_init, mono_experiments_initialize_table);
+	return !!mono_experiments_enabled_table[experiment_id];
+}
+
+typedef enum MonoExperimentId {
+#define EXPERIMENT(id,ghurl) MONO_EXPERIMENT_ ## id ,
+#include "mono-experiments.def"
+#undef EXPERIMENT
+	MONO_EXPERIMENT_NUM_EXPERIMENTS
+} MonoExperimentId;
+
+#endif


### PR DESCRIPTION
Implement the idea from #9729

* A `configure` flag `--enable-experiment=LIST` to define compile-time constants for experiments
* Support for a `MONO_EXPERIMENT=LIST` environment variable and `mono_experiment_enabled` test function.

The idea is that experiments are experimental, unsupported and are not guaranteed to be backward compatible.  For small experiments a compile time check is enough.  Larger experiments can live behind the feature flag.

Each experiment also lists a GitHub tracking issue to disable and remove the experiment - either the experiment graduates to a mainline feature or it becomes gated by a regular `configure` flag or some other opt-in mechanism, or it is dropped.