### PR TITLE
[Reflection] Fix the issue with ToString method in MonoCMethod type

### DIFF
--- a/mcs/class/corlib/System.Reflection/MonoMethod.cs
+++ b/mcs/class/corlib/System.Reflection/MonoMethod.cs
@@ -878,20 +878,7 @@ namespace System.Reflection {
 		}
 
 		public override string ToString () {
-			StringBuilder sb = new StringBuilder ();
-			sb.Append ("Void ");
-			sb.Append (Name);
-			sb.Append ("(");
-			ParameterInfo[] p = GetParameters ();
-			for (int i = 0; i < p.Length; ++i) {
-				if (i > 0)
-					sb.Append (", ");
-				sb.Append (p[i].ParameterType.Name);
-			}
-			if (CallingConvention == CallingConventions.Any)
-				sb.Append (", ...");
-			sb.Append (")");
-			return sb.ToString ();
+			return "Void " + FormatNameAndSig (false);
 		}
 
 		public override IList<CustomAttributeData> GetCustomAttributesData () {

--- a/mcs/class/corlib/Test/System.Reflection/ConstructorInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/ConstructorInfoTest.cs
@@ -149,5 +149,14 @@ namespace MonoTests.System.Reflection
 
 			Assert.AreEqual (type.Module, co.Module);
 		}
+
+		delegate int D1 ();
+
+		[Test] // https://github.com/mono/mono/issues/10838
+		public void Issue10838 ()
+		{
+			var ctorInfo = typeof (D1).GetConstructors ()[0];
+			Assert.AreEqual ("Void .ctor(System.Object, IntPtr)", ctorInfo.ToString ());	
+		}		
 	}
 }

--- a/mcs/class/corlib/Test/System.Reflection/MethodInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/MethodInfoTest.cs
@@ -993,7 +993,7 @@ namespace MonoTests.System.Reflection
 			else
 				Assert.IsTrue (foundExpectedType, "#2-4");
 		}
-#endif	
+#endif
 	}
 	
 	// Helper class

--- a/mcs/class/corlib/Test/System.Reflection/MethodInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/MethodInfoTest.cs
@@ -993,17 +993,7 @@ namespace MonoTests.System.Reflection
 			else
 				Assert.IsTrue (foundExpectedType, "#2-4");
 		}
-#endif
-
-		delegate int D1 ();
-
-		[Test]
-		public void Issue10838 ()
-		{
-			var flags = BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance;
-			var members = typeof (D1).GetMembers (flags).OrderBy (m => m.MetadataToken);
-			Assert.AreEqual ("Void .ctor(System.Object, IntPtr)", members.First ().ToString ());
-		}		
+#endif	
 	}
 	
 	// Helper class

--- a/mcs/class/corlib/Test/System.Reflection/MethodInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/MethodInfoTest.cs
@@ -994,6 +994,16 @@ namespace MonoTests.System.Reflection
 				Assert.IsTrue (foundExpectedType, "#2-4");
 		}
 #endif
+
+		delegate int D1 ();
+
+		[Test]
+		public void Issue10838 ()
+		{
+			var flags = BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance;
+			var members = typeof (D1).GetMembers (flags).OrderBy (m => m.MetadataToken);
+			Assert.AreEqual ("Void .ctor(System.Object, IntPtr)", members.First ().ToString ());
+		}		
 	}
 	
 	// Helper class

--- a/mcs/tests/ver-il-net_4_x.xml
+++ b/mcs/tests/ver-il-net_4_x.xml
@@ -21,15 +21,9 @@
       <method name="System.Object Method(System.Object)" attrs="134">
         <size>10</size>
       </method>
-      <method name="Void .ctor(Object)" attrs="6278">
-        <size>8</size>
-      </method>
     </type>
     <type name="Del">
       <method name="System.Object Invoke(System.Object)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -52,6 +46,16 @@
     <type name="B`1[T]">
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="C">
+      <method name="Void .ctor(System.Object)" attrs="6278">
+        <size>8</size>
+      </method>
+    </type>
+    <type name="Del">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -118,9 +122,6 @@
       </method>
       <method name="System.Dynamic.DynamicMetaObject BindUnaryOperation(System.Dynamic.UnaryOperationBinder)" attrs="198">
         <size>61</size>
-      </method>
-      <method name="Void .ctor(DynamicObjectMock, Expression)" attrs="6278">
-        <size>22</size>
       </method>
     </type>
     <type name="DynamicObjectMock">
@@ -390,9 +391,6 @@
       <method name="Void .ctor()" attrs="6278">
         <size>8</size>
       </method>
-      <method name="Void .ctor(Object)" attrs="6278">
-        <size>8</size>
-      </method>
       <method name="Void .cctor()" attrs="6289">
         <size>34</size>
       </method>
@@ -406,23 +404,14 @@
       <method name="Void Invoke(System.Runtime.CompilerServices.CallSite, System.Object, Int32 ByRef)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Tester+&lt;InvokeMember_4&gt;c__DynamicSite33+Container0">
       <method name="Void Invoke(System.Runtime.CompilerServices.CallSite, System.Object, Int32 ByRef)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Tester+&lt;InvokeMember_8&gt;c__DynamicSite37+Container0">
       <method name="Void Invoke(System.Runtime.CompilerServices.CallSite, System.Object, System.Object ByRef)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -730,6 +719,31 @@
       </method>
       <method name="Boolean &lt;Main&gt;m__4E(Boolean)" attrs="145">
         <size>12</size>
+      </method>
+    </type>
+    <type name="AssertDynamicObject">
+      <method name="Void .ctor(DynamicObjectMock, System.Linq.Expressions.Expression)" attrs="6278">
+        <size>22</size>
+      </method>
+    </type>
+    <type name="Tester">
+      <method name="Void .ctor(System.Object)" attrs="6278">
+        <size>8</size>
+      </method>
+    </type>
+    <type name="Tester+&lt;InvokeMember_3&gt;c__DynamicSite32+Container0">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Tester+&lt;InvokeMember_4&gt;c__DynamicSite33+Container0">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Tester+&lt;InvokeMember_8&gt;c__DynamicSite37+Container0">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -1213,9 +1227,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Tester+&lt;AddCheckedTest&gt;c__AnonStorey1">
       <method name="System.Object &lt;&gt;m__0()" attrs="131">
@@ -1390,18 +1401,15 @@
         <size>12</size>
       </method>
     </type>
+    <type name="Tester+EmptyDelegate">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="dtest-007.cs">
     <type name="D">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
-    </type>
-    <type name="D2">
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -1537,9 +1545,6 @@
       <method name="Void Invoke(System.Runtime.CompilerServices.CallSite, System.Object, Int32 ByRef, System.String ByRef)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Tester+&lt;MemberGetError_Null&gt;c__AnonStorey1">
       <method name="Void .ctor()" attrs="6278">
@@ -1622,6 +1627,21 @@
       </method>
       <method name="Boolean &lt;Main&gt;m__8(Boolean)" attrs="145">
         <size>12</size>
+      </method>
+    </type>
+    <type name="D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="D2">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Tester+&lt;InvokeMember&gt;c__DynamicSite2+Container0">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -1882,9 +1902,6 @@
       <method name="System.Object Invoke(System.Object)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="DynamicAssignments">
       <method name="Int32 Main()" attrs="150">
@@ -1908,6 +1925,11 @@
     <type name="DynamicAssignments">
       <method name="System.Object &lt;Main&gt;m__0(System.Object)" attrs="145">
         <size>10</size>
+      </method>
+    </type>
+    <type name="D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -1957,15 +1979,9 @@
       <method name="Void Invoke(System.Object)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="C+D2">
       <method name="Void Invoke(System.Object ByRef)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -1982,6 +1998,16 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.Object ByRef, System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="C+D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="C+D2">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -2079,9 +2105,6 @@
       <method name="Int32 Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
@@ -2092,6 +2115,11 @@
     <type name="Test">
       <method name="Int32 &lt;Main&gt;m__0()" attrs="145">
         <size>9</size>
+      </method>
+    </type>
+    <type name="Test+D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -2116,25 +2144,29 @@
       <method name="Void Invoke(System.Runtime.CompilerServices.CallSite, T ByRef, System.Object)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
-    </type>
-    <type name="C+&lt;Main&gt;c__DynamicSite1+Container0">
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="C+&lt;Main&gt;c__DynamicSite1+Container1">
       <method name="Void Invoke(System.Runtime.CompilerServices.CallSite, S ByRef, System.Object)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
+    </type>
+    <type name="C+&lt;Main&gt;c__DynamicSite1+Container0">
+      <method name="System.Object Invoke(System.Runtime.CompilerServices.CallSite, System.Nullable`1[System.Int32] ByRef, System.Object)" attrs="454">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="C+&lt;Method&gt;c__DynamicSite0`1+Container0[T]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
     <type name="C+&lt;Main&gt;c__DynamicSite1+Container0">
-      <method name="System.Object Invoke(System.Runtime.CompilerServices.CallSite, System.Nullable`1[System.Int32] ByRef, System.Object)" attrs="454">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="C+&lt;Main&gt;c__DynamicSite1+Container1">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -2206,15 +2238,19 @@
       <method name="Void Invoke(System.Runtime.CompilerServices.CallSite, System.Object, Int32 ByRef)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Test+&lt;Main&gt;c__DynamicSite0+Container1">
       <method name="Void Invoke(System.Runtime.CompilerServices.CallSite, System.Object, UInt16 ByRef)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
+    </type>
+    <type name="Test+&lt;Main&gt;c__DynamicSite0+Container0">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Test+&lt;Main&gt;c__DynamicSite0+Container1">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -2286,7 +2322,7 @@
       <method name="Void Invoke(System.Runtime.CompilerServices.CallSite, System.Object, Z ByRef)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -2312,7 +2348,7 @@
       <method name="Void Invoke(System.Runtime.CompilerServices.CallSite, System.Type, System.Object, A ByRef)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -2360,7 +2396,7 @@
       <method name="Void Invoke(System.Runtime.CompilerServices.CallSite, System.Object, System.Object ByRef, System.Object ByRef)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -2640,15 +2676,9 @@
       <method name="Int32 Invoke(Int32 ByRef)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Test+&lt;Main&gt;c__DynamicSite0+Container0">
       <method name="System.Object Invoke(System.Runtime.CompilerServices.CallSite, System.Object, Int32 ByRef)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -2669,6 +2699,16 @@
       </method>
       <method name="Int32 &lt;Main&gt;m__2(Int32 ByRef)" attrs="145">
         <size>14</size>
+      </method>
+    </type>
+    <type name="Test+D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Test+&lt;Main&gt;c__DynamicSite0+Container0">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -2807,17 +2847,17 @@
     </type>
   </test>
   <test name="dtest-053.cs">
-    <type name="TestAttribute">
-      <method name="Void .ctor(Object[])" attrs="6278">
-        <size>8</size>
-      </method>
-    </type>
     <type name="C">
       <method name="Void Main()" attrs="150">
         <size>21</size>
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="TestAttribute">
+      <method name="Void .ctor(System.Object[])" attrs="6278">
+        <size>8</size>
       </method>
     </type>
   </test>
@@ -2872,15 +2912,9 @@
       <method name="Void Invoke(System.Runtime.CompilerServices.CallSite, System.Object, T ByRef)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="C+&lt;Test4&gt;c__AnonStorey2`1+&lt;&lt;&gt;m__0&gt;c__DynamicSite0+Container0[T]">
       <method name="Void Invoke(System.Runtime.CompilerServices.CallSite, System.Object, T ByRef)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -2898,6 +2932,16 @@
       </method>
       <method name="Void &lt;Test3`1&gt;m__1[T](T)" attrs="145">
         <size>105</size>
+      </method>
+    </type>
+    <type name="C+&lt;&lt;Test3`1&gt;m__1&gt;c__DynamicSite1`1+Container0[T]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="C+&lt;Test4&gt;c__AnonStorey2`1+&lt;&lt;&gt;m__0&gt;c__DynamicSite0+Container0[T]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -3024,15 +3068,19 @@
       <method name="Void Invoke(System.Runtime.CompilerServices.CallSite, System.Type, System.Object, Int32 ByRef)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="C`1+&lt;Test&gt;c__DynamicSite0+Container1[T]">
       <method name="Void Invoke(System.Runtime.CompilerServices.CallSite, System.Type, System.Object, Int32 ByRef)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
+    </type>
+    <type name="C`1+&lt;Test&gt;c__DynamicSite0+Container0[T]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="C`1+&lt;Test&gt;c__DynamicSite0+Container1[T]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -3106,11 +3154,6 @@
     </type>
   </test>
   <test name="dtest-064.cs">
-    <type name="A">
-      <method name="Void .ctor(Action)" attrs="6278">
-        <size>8</size>
-      </method>
-    </type>
     <type name="B">
       <method name="System.Decimal Test(System.Object)" attrs="145">
         <size>15</size>
@@ -3139,6 +3182,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="A">
+      <method name="Void .ctor(System.Action)" attrs="6278">
+        <size>8</size>
       </method>
     </type>
   </test>
@@ -3536,7 +3584,7 @@
       <method name="Void Invoke(System.Runtime.CompilerServices.CallSite, System.Object, Int32 ByRef)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -4046,9 +4094,6 @@
       <method name="System.String ToString()" attrs="198">
         <size>25</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6273">
-        <size>9</size>
-      </method>
     </type>
     <type name="X">
       <method name="Void Print(System.Object)" attrs="150">
@@ -4059,6 +4104,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="S">
+      <method name="Void .ctor(System.String)" attrs="6273">
+        <size>9</size>
       </method>
     </type>
   </test>
@@ -4477,9 +4527,6 @@
       <method name="W Jump()" attrs="486">
         <size>52</size>
       </method>
-      <method name="Void .ctor(Zoo`1, W)" attrs="6278">
-        <size>22</size>
-      </method>
     </type>
     <type name="X">
       <method name="Void Main()" attrs="150">
@@ -4492,6 +4539,11 @@
     <type name="Zoo`1[T]">
       <method name="IMonkey`1[U] GetTheMonkey[U](U)" attrs="134">
         <size>16</size>
+      </method>
+    </type>
+    <type name="Zoo`1+Monkey`2[T,V,W]">
+      <method name="Void .ctor(Zoo`1[V], W)" attrs="6278">
+        <size>22</size>
       </method>
     </type>
   </test>
@@ -4507,9 +4559,6 @@
     <type name="Stack`1+Node[T]">
       <method name="Void Hello(T)" attrs="486">
         <size>2</size>
-      </method>
-      <method name="Void .ctor(Stack`1)" attrs="6278">
-        <size>15</size>
       </method>
     </type>
     <type name="Stack`1+Foo`1[T,T]">
@@ -4582,6 +4631,11 @@
     <type name="A`1+Test`1[U,T]">
       <method name="Nested`1 Foo()" attrs="150">
         <size>10</size>
+      </method>
+    </type>
+    <type name="Stack`1+Node[T]">
+      <method name="Void .ctor(Stack`1[T])" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -4732,9 +4786,6 @@
       <method name="Void Invoke(T)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Foo`1[T]">
       <method name="Void add_MyEvent(Test`1[T])" attrs="2182">
@@ -4766,6 +4817,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -4853,15 +4907,9 @@
       <method name="Int32 Invoke(System.String, Int32)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="E">
       <method name="Int32 Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -4892,6 +4940,16 @@
         <size>0</size>
       </method>
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="E">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -5241,9 +5299,6 @@
       <method name="B Invoke(A)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Foo`1[T]">
       <method name="U Method[U](Test`2[T,U])" attrs="134">
@@ -5272,6 +5327,11 @@
     <type name="X">
       <method name="System.String &lt;Main&gt;m__0(Double)" attrs="145">
         <size>25</size>
+      </method>
+    </type>
+    <type name="Test`2[A,B]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -5348,11 +5408,6 @@
         <size>7</size>
       </method>
     </type>
-    <type name="Foo`1+Hello[T]">
-      <method name="Void .ctor(Foo`1)" attrs="6278">
-        <size>15</size>
-      </method>
-    </type>
     <type name="X">
       <method name="Void Main()" attrs="150">
         <size>2</size>
@@ -5366,6 +5421,11 @@
         <size>15</size>
       </method>
       <method name="Hello GetHello()" attrs="134">
+        <size>15</size>
+      </method>
+    </type>
+    <type name="Foo`1+Hello[T]">
+      <method name="Void .ctor(Foo`1[T])" attrs="6278">
         <size>15</size>
       </method>
     </type>
@@ -5434,9 +5494,6 @@
       <method name="Int32 Invoke(T, T)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="X">
       <method name="Int32 Add(Int32, Int32)" attrs="145">
@@ -5459,6 +5516,9 @@
         <size>0</size>
       </method>
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -5837,17 +5897,17 @@
         <size>7</size>
       </method>
     </type>
-    <type name="Queue`1+Enumerator[T]">
-      <method name="Void .ctor(Queue`1)" attrs="6278">
-        <size>15</size>
-      </method>
-    </type>
     <type name="X">
       <method name="Void Main()" attrs="150">
         <size>2</size>
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="Queue`1+Enumerator[T]">
+      <method name="Void .ctor(Queue`1[T])" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -5978,11 +6038,6 @@
         <size>7</size>
       </method>
     </type>
-    <type name="C5.HashSet`1[T]">
-      <method name="Void .ctor(IHasher`1)" attrs="6278">
-        <size>8</size>
-      </method>
-    </type>
     <type name="C5.KeyValuePairHasher`2[K,V]">
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
@@ -5994,6 +6049,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="C5.HashSet`1[T]">
+      <method name="Void .ctor(C5.IHasher`1[T])" attrs="6278">
+        <size>8</size>
       </method>
     </type>
   </test>
@@ -6424,9 +6484,6 @@
       <method name="Int32 Find(T ByRef)" attrs="134">
         <size>26</size>
       </method>
-      <method name="Void .ctor(IComparer`1)" attrs="6278">
-        <size>15</size>
-      </method>
     </type>
     <type name="A.X">
       <method name="Void Test()" attrs="150">
@@ -6453,9 +6510,6 @@
       <method name="Int32 Find(T ByRef)" attrs="134">
         <size>26</size>
       </method>
-      <method name="Void .ctor(IComparer`1)" attrs="6278">
-        <size>15</size>
-      </method>
     </type>
     <type name="B.X">
       <method name="Void Test()" attrs="150">
@@ -6478,6 +6532,16 @@
         <size>10</size>
       </method>
     </type>
+    <type name="A.TreeBag`1[T]">
+      <method name="Void .ctor(A.IComparer`1[T])" attrs="6278">
+        <size>15</size>
+      </method>
+    </type>
+    <type name="B.TreeBag`1[T]">
+      <method name="Void .ctor(B.IComparer`1[T])" attrs="6278">
+        <size>15</size>
+      </method>
+    </type>
   </test>
   <test name="gtest-106.cs">
     <type name="KeyValuePair`2[X,Y]">
@@ -6494,9 +6558,6 @@
       <method name="Int32 Find()" attrs="134">
         <size>26</size>
       </method>
-      <method name="Void .ctor(IComparer`1, T)" attrs="6278">
-        <size>22</size>
-      </method>
     </type>
     <type name="X">
       <method name="Void Main()" attrs="150">
@@ -6511,13 +6572,15 @@
         <size>10</size>
       </method>
     </type>
+    <type name="TreeBag`1[T]">
+      <method name="Void .ctor(IComparer`1[T], T)" attrs="6278">
+        <size>22</size>
+      </method>
+    </type>
   </test>
   <test name="gtest-107.cs">
     <type name="Mapper`2[T,V]">
       <method name="V Invoke(T)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -6548,6 +6611,9 @@
         <size>0</size>
       </method>
       <method name="V EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -6679,9 +6745,6 @@
       <method name="Void InsertionSort(Int32)" attrs="131">
         <size>27</size>
       </method>
-      <method name="Void .ctor(IComparer`1, Int32, T)" attrs="6278">
-        <size>27</size>
-      </method>
     </type>
     <type name="X">
       <method name="Void Main()" attrs="150">
@@ -6706,13 +6769,15 @@
         <size>16</size>
       </method>
     </type>
+    <type name="Sorting+Sorter`1[T]">
+      <method name="Void .ctor(IComparer`1[T], Int32, T)" attrs="6278">
+        <size>27</size>
+      </method>
+    </type>
   </test>
   <test name="gtest-113.cs">
     <type name="Mapper`2[T,V]">
       <method name="V Invoke(T)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -6743,6 +6808,11 @@
     <type name="X">
       <method name="Double &lt;Main&gt;m__0(Int32)" attrs="145">
         <size>21</size>
+      </method>
+    </type>
+    <type name="Mapper`2[T,V]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -6778,9 +6848,6 @@
   <test name="gtest-115.cs">
     <type name="Mapper`2[A,R]">
       <method name="R Invoke(A)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -6846,9 +6913,6 @@
       <method name="Void Dispose()" attrs="486">
         <size>31</size>
       </method>
-      <method name="Void .ctor(LinkedList`1)" attrs="6278">
-        <size>27</size>
-      </method>
     </type>
     <type name="SortedList`1[T]">
       <method name="Void Insert(T)" attrs="134">
@@ -6874,9 +6938,6 @@
         <size>26</size>
       </method>
       <method name="System.String get_Value()" attrs="2182">
-        <size>15</size>
-      </method>
-      <method name="Void .ctor(String)" attrs="6278">
         <size>15</size>
       </method>
     </type>
@@ -6915,6 +6976,21 @@
     <type name="MyTest">
       <method name="System.String &lt;Main&gt;m__0(Double)" attrs="145">
         <size>25</size>
+      </method>
+    </type>
+    <type name="Mapper`2[A,R]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="LinkedList`1+LinkedListEnumerator[T]">
+      <method name="Void .ctor(LinkedList`1[T])" attrs="6278">
+        <size>27</size>
+      </method>
+    </type>
+    <type name="MyString">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -7118,13 +7194,13 @@
       <method name="Void Invoke(T)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(T, System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -7139,15 +7215,9 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="A`1+Bar`1[T,U]">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -7172,6 +7242,16 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="A`1+Foo[T]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="A`1+Bar`1[T,U]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -7264,9 +7344,6 @@
       <method name="Void Invoke(A`1[T])" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Test">
       <method name="Void Main()" attrs="150">
@@ -7295,6 +7372,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -7800,9 +7880,6 @@
       <method name="Int32 Invoke(X)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="B">
       <method name="T`1[X] M[X]()" attrs="150">
@@ -7837,6 +7914,11 @@
       </method>
       <method name="Int32 &lt;N&gt;m__1(Int64)" attrs="145">
         <size>10</size>
+      </method>
+    </type>
+    <type name="T`1[X]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -7975,9 +8057,6 @@
       <method name="Void Invoke(Generic`1[T], T)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="X">
       <method name="Int32 Main()" attrs="150">
@@ -7992,6 +8071,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -8041,9 +8123,6 @@
       <method name="Int32 Invoke(Int32)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="FunEnumerable">
       <method name="Void .ctor(Int32, Int2Int)" attrs="6278">
@@ -8088,6 +8167,9 @@
         <size>0</size>
       </method>
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -8432,9 +8514,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="C">
       <method name="Void .ctor()" attrs="6278">
@@ -8459,6 +8538,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -8692,12 +8774,6 @@
       <method name="Void remove_DoSomething(System.EventHandler)" attrs="2182">
         <size>42</size>
       </method>
-      <method name="Void .ctor(Object[])" attrs="6278">
-        <size>12</size>
-      </method>
-      <method name="Void .ctor(Object[], Object)" attrs="6278">
-        <size>205</size>
-      </method>
     </type>
     <type name="Foo+&lt;Foo&gt;c__AnonStorey1">
       <method name="Void .ctor()" attrs="6278">
@@ -8710,6 +8786,14 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="Foo">
+      <method name="Void .ctor(System.Object[])" attrs="6278">
+        <size>12</size>
+      </method>
+      <method name="Void .ctor(System.Object[], System.Object)" attrs="6278">
+        <size>205</size>
       </method>
     </type>
   </test>
@@ -9067,9 +9151,6 @@
       <method name="Int32 Invoke(S)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="X">
       <method name="Void Main()" attrs="150">
@@ -9143,6 +9224,11 @@
     <type name="RedBlackTree`1+&lt;EnumerateRange&gt;c__Iterator0[S]">
       <method name="System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()" attrs="481">
         <size>14</size>
+      </method>
+    </type>
+    <type name="RedBlackTree`1+RangeTester[S]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -9156,9 +9242,6 @@
       <method name="Int32 Invoke(S)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="OrderedMultiDictionary`2[T,U]">
       <method name="Void .ctor()" attrs="6278">
@@ -9237,6 +9320,11 @@
     <type name="RedBlackTree`1+&lt;EnumerateRange&gt;c__Iterator0[S]">
       <method name="System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()" attrs="481">
         <size>14</size>
+      </method>
+    </type>
+    <type name="RedBlackTree`1+RangeTester[S]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -9253,9 +9341,6 @@
     </type>
     <type name="RedBlackTree`1+RangeTester[S]">
       <method name="Int32 Invoke(S)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -9282,6 +9367,9 @@
         <size>0</size>
       </method>
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -9924,11 +10012,6 @@
         <size>2</size>
       </method>
     </type>
-    <type name="Set`1+Locator+Replace[Element]">
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
-    </type>
     <type name="Set`1+Node[Element]">
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
@@ -9963,6 +10046,11 @@
     <type name="Set`1+&lt;locate&gt;c__AnonStorey0[Element]">
       <method name="Void &lt;&gt;m__0(Node)" attrs="131">
         <size>16</size>
+      </method>
+    </type>
+    <type name="Set`1+Locator+Replace[Element]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -10562,9 +10650,6 @@
       <method name="S Invoke(R)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="GuardedIndexedSorted`1[T]">
       <method name="Void .ctor()" attrs="6278">
@@ -10589,6 +10674,9 @@
         <size>0</size>
       </method>
       <method name="S EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -10865,9 +10953,6 @@
       <method name="Void .ctor(A)" attrs="6278">
         <size>10</size>
       </method>
-      <method name="Void .ctor(A, List`1)" attrs="6278">
-        <size>10</size>
-      </method>
     </type>
     <type name="Test">
       <method name="Void Main(System.String[])" attrs="150">
@@ -10875,6 +10960,11 @@
       </method>
       <method name="Void .ctor()" attrs="6276">
         <size>7</size>
+      </method>
+    </type>
+    <type name="List`1[A]">
+      <method name="Void .ctor(A, List`1[A])" attrs="6278">
+        <size>10</size>
       </method>
     </type>
   </test>
@@ -11006,9 +11096,6 @@
       <method name="Void Invoke(T)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="T">
       <method name="Void Foo[T](Handler`1[T])" attrs="134">
@@ -11040,6 +11127,11 @@
     <type name="T+&lt;Foo&gt;c__AnonStorey0`1[T]">
       <method name="Void &lt;&gt;m__0(System.IAsyncResult)" attrs="131">
         <size>19</size>
+      </method>
+    </type>
+    <type name="Handler`1[T]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -11198,9 +11290,6 @@
       <method name="Void Invoke(T)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="X">
       <method name="Void Foo[T](Handler`1[T])" attrs="150">
@@ -11232,6 +11321,11 @@
     <type name="X+&lt;Foo&gt;c__AnonStorey0`1[T]">
       <method name="Void &lt;&gt;m__0(System.IAsyncResult)" attrs="131">
         <size>13</size>
+      </method>
+    </type>
+    <type name="Handler`1[T]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -11415,9 +11509,6 @@
       <method name="Int32 Invoke(Int32)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(Int32, System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
@@ -11428,6 +11519,11 @@
     <type name="Test">
       <method name="Int32 &lt;Main&gt;m__0(Int32)" attrs="145">
         <size>10</size>
+      </method>
+    </type>
+    <type name="Test+TestDel">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -11554,11 +11650,6 @@
     </type>
   </test>
   <test name="gtest-286.cs">
-    <type name="TestAttribute">
-      <method name="Void .ctor(Type)" attrs="6278">
-        <size>15</size>
-      </method>
-    </type>
     <type name="C`1[T]">
       <method name="Void Foo()" attrs="150">
         <size>2</size>
@@ -11573,6 +11664,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="TestAttribute">
+      <method name="Void .ctor(System.Type)" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -11628,9 +11724,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="C">
       <method name="Void add_Ev1(D)" attrs="2177">
@@ -11666,14 +11759,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="gtest-290.cs">
     <type name="GenericEventHandler`2[U,V]">
       <method name="Void Invoke(U, V)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -11703,6 +11796,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="gtest-291.cs">
@@ -11721,9 +11817,6 @@
   <test name="gtest-292.cs">
     <type name="Test.Handler`1[TA]">
       <method name="Void Invoke(TA)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -11745,6 +11838,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -11853,14 +11949,6 @@
       <method name="Void Invoke(T)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
-    </type>
-    <type name="A">
-      <method name="Void .ctor(TestFunc`1)" attrs="6278">
-        <size>15</size>
-      </method>
     </type>
     <type name="TestClass">
       <method name="Int32 Main()" attrs="150">
@@ -11884,6 +11972,16 @@
     <type name="TestClass">
       <method name="Void &lt;a&gt;m__0(Int32)" attrs="145">
         <size>8</size>
+      </method>
+    </type>
+    <type name="TestFunc`1[T]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="A">
+      <method name="Void .ctor(TestFunc`1[System.Int32])" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -12078,9 +12176,6 @@
       <method name="Int32 Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Bar">
       <method name="Int32 g()" attrs="145">
@@ -12100,6 +12195,9 @@
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="gtest-308.cs">
@@ -12113,9 +12211,6 @@
     </type>
     <type name="Test+MyComparison`1[V]">
       <method name="Int32 Invoke(V, V)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -12162,6 +12257,9 @@
         <size>0</size>
       </method>
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -12445,9 +12543,6 @@
       <method name="Void Invoke(System.String)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="App">
       <method name="Void TestMethod[T](System.String, TGenericDelegate`1)" attrs="129">
@@ -12461,6 +12556,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="gtest-322.cs">
@@ -12471,9 +12569,6 @@
     </type>
     <type name="MyBase`2+Callback[K,V]">
       <method name="Void Invoke(K, V)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -12490,6 +12585,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -12527,9 +12625,6 @@
   <test name="gtest-324.cs">
     <type name="A">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -12574,6 +12669,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -12770,15 +12868,9 @@
       <method name="Void Invoke(Boolean)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Test+DelegateB">
       <method name="Int32 Invoke(Int32)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -12795,6 +12887,16 @@
         <size>0</size>
       </method>
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Test+DelegateA">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Test+DelegateB">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -12838,9 +12940,6 @@
       <method name="Void .ctor()" attrs="6278">
         <size>8</size>
       </method>
-      <method name="Void .ctor(Type)" attrs="6278">
-        <size>15</size>
-      </method>
     </type>
     <type name="N.C`1[T]">
       <method name="Void Bar()" attrs="134">
@@ -12865,6 +12964,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="TestAttribute">
+      <method name="Void .ctor(System.Type)" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -13234,9 +13338,6 @@
       <method name="R Invoke(T1, T2)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="X">
       <method name="Int32 f2(System.Collections.IList, System.Collections.IList)" attrs="145">
@@ -13251,6 +13352,9 @@
         <size>0</size>
       </method>
       <method name="R EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -13581,9 +13685,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Thing">
       <method name="Void Method(Handler, System.String[])" attrs="150">
@@ -13604,6 +13705,11 @@
       </method>
       <method name="Void &lt;Main&gt;m__1()" attrs="145">
         <size>2</size>
+      </method>
+    </type>
+    <type name="Thing+Handler">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -14082,15 +14188,9 @@
       <method name="Void .ctor()" attrs="6278">
         <size>8</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>8</size>
-      </method>
     </type>
     <type name="Func`2[TArg,TRet]">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -14107,6 +14207,16 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="DocAttribute">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>8</size>
+      </method>
+    </type>
+    <type name="Func`2[TArg,TRet]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -14226,11 +14336,11 @@
       <method name="Int32 Main()" attrs="150">
         <size>31</size>
       </method>
-      <method name="Void .ctor(Type)" attrs="6278">
-        <size>35</size>
-      </method>
       <method name="Void .cctor()" attrs="6289">
         <size>7</size>
+      </method>
+      <method name="Void .ctor(System.Type)" attrs="6278">
+        <size>35</size>
       </method>
     </type>
   </test>
@@ -14245,9 +14355,6 @@
     </type>
     <type name="Test+MemberFilter">
       <method name="Boolean Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -14270,6 +14377,11 @@
     <type name="Test">
       <method name="Boolean &lt;GetMethodGroup&gt;m__0()" attrs="145">
         <size>10</size>
+      </method>
+    </type>
+    <type name="Test+MemberFilter">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -14357,11 +14469,6 @@
     </type>
   </test>
   <test name="gtest-398.cs">
-    <type name="ToStr">
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
-    </type>
     <type name="GenericClass`1[T]">
       <method name="Void Method()" attrs="134">
         <size>43</size>
@@ -14389,6 +14496,9 @@
         <size>0</size>
       </method>
       <method name="System.String EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -14517,11 +14627,6 @@
         <size>7</size>
       </method>
     </type>
-    <type name="C`2[A,B]">
-      <method name="Void .ctor(IEnumerable`1)" attrs="6278">
-        <size>47</size>
-      </method>
-    </type>
     <type name="M">
       <method name="Void Main()" attrs="150">
         <size>2</size>
@@ -14533,6 +14638,9 @@
     <type name="C`2[A,B]">
       <method name="B &lt;C&gt;m__0(B)" attrs="145">
         <size>9</size>
+      </method>
+      <method name="Void .ctor(System.Collections.Generic.IEnumerable`1[B])" attrs="6278">
+        <size>47</size>
       </method>
     </type>
   </test>
@@ -14603,14 +14711,6 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
-      </method>
-    </type>
-    <type name="ConditionalParsing+T">
-      <method name="Void .ctor(String, Boolean)" attrs="6278">
-        <size>29</size>
-      </method>
-      <method name="Void .ctor(String, Boolean, Int32, Int32, Int32)" attrs="6278">
-        <size>8</size>
       </method>
     </type>
     <type name="ConditionalParsing+Const">
@@ -14688,6 +14788,14 @@
       </method>
       <method name="Void Test_23(System.String)" attrs="129">
         <size>16</size>
+      </method>
+    </type>
+    <type name="ConditionalParsing+T">
+      <method name="Void .ctor(System.String, Boolean)" attrs="6278">
+        <size>29</size>
+      </method>
+      <method name="Void .ctor(System.String, Boolean, Int32, Int32, Int32)" attrs="6278">
+        <size>8</size>
       </method>
     </type>
   </test>
@@ -15020,9 +15128,6 @@
       <method name="Void Invoke(T)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Test">
       <method name="Void Main()" attrs="150">
@@ -15037,6 +15142,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -15069,15 +15177,9 @@
       <method name="Void Invoke(System.Object)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="EventHandler`1[T]">
       <method name="Void Invoke(T)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -15117,6 +15219,16 @@
         <size>0</size>
       </method>
     </type>
+    <type name="EventHandler">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="EventHandler`1[T]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="gtest-428.cs">
     <type name="CInt">
@@ -15130,11 +15242,6 @@
         <size>9</size>
       </method>
     </type>
-    <type name="Klass">
-      <method name="Void .ctor(Nullable`1)" attrs="6278">
-        <size>15</size>
-      </method>
-    </type>
     <type name="MainClass">
       <method name="Int32 Main()" attrs="150">
         <size>203</size>
@@ -15145,6 +15252,9 @@
     </type>
     <type name="Klass">
       <method name="System.Nullable`1[CInt] get_Value()" attrs="2182">
+        <size>15</size>
+      </method>
+      <method name="Void .ctor(System.Nullable`1[CInt])" attrs="6278">
         <size>15</size>
       </method>
     </type>
@@ -15161,17 +15271,17 @@
         <size>9</size>
       </method>
     </type>
-    <type name="Klass">
-      <method name="Void .ctor(Nullable`1)" attrs="6278">
-        <size>15</size>
-      </method>
-    </type>
     <type name="MainClass">
       <method name="Int32 Main()" attrs="150">
         <size>44</size>
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="Klass">
+      <method name="Void .ctor(System.Nullable`1[CInt])" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -15990,9 +16100,6 @@
       </method>
     </type>
     <type name="Test`2+B[T,U]">
-      <method name="Void .ctor(Value`1)" attrs="6278">
-        <size>8</size>
-      </method>
       <method name="Void .cctor()" attrs="6289">
         <size>16</size>
       </method>
@@ -16003,6 +16110,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="Test`2+B[T,U]">
+      <method name="Void .ctor(Value`1[U])" attrs="6278">
+        <size>8</size>
       </method>
     </type>
   </test>
@@ -16656,11 +16768,6 @@
     </type>
   </test>
   <test name="gtest-503.cs">
-    <type name="TestAttribute">
-      <method name="Void .ctor(Type)" attrs="6278">
-        <size>8</size>
-      </method>
-    </type>
     <type name="C`1[T]">
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
@@ -16677,6 +16784,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="TestAttribute">
+      <method name="Void .ctor(System.Type)" attrs="6278">
+        <size>8</size>
       </method>
     </type>
   </test>
@@ -17051,9 +17163,6 @@
       <method name="Void Invoke(System.Object)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="E`1[T]">
       <method name="Void Test()" attrs="150">
@@ -17090,6 +17199,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -17655,9 +17767,6 @@
       <method name="Void .ctor()" attrs="6278">
         <size>13</size>
       </method>
-      <method name="Void .ctor(Wrapper`1)" attrs="6276">
-        <size>15</size>
-      </method>
     </type>
     <type name="Wrapper`1[U]">
       <method name="Void .ctor(U)" attrs="6273">
@@ -17677,6 +17786,9 @@
     </type>
     <type name="Blah`1+WrapperWrapper`1[T,N]">
       <method name="WrapperWrapper`1 NewWrapperWrapper(Wrapper`1[N])" attrs="134">
+        <size>15</size>
+      </method>
+      <method name="Void .ctor(Wrapper`1[N])" attrs="6276">
         <size>15</size>
       </method>
     </type>
@@ -18225,15 +18337,9 @@
       <method name="Void Invoke(T)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="A`1+Context`1+D2`1[T,U,V]">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -18285,6 +18391,16 @@
       </method>
       <method name="Void Test[U,V](D2`1)" attrs="150">
         <size>15</size>
+      </method>
+    </type>
+    <type name="A`1+Context`1+D[T,U]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="A`1+Context`1+D2`1[T,U,V]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -18372,9 +18488,6 @@
       <method name="A`1[PP] For[PP]()" attrs="198">
         <size>20</size>
       </method>
-      <method name="Void .ctor(A`1)" attrs="6278">
-        <size>15</size>
-      </method>
     </type>
     <type name="Test">
       <method name="Void Main()" attrs="150">
@@ -18385,6 +18498,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="B`3[U,X,V]">
+      <method name="Void .ctor(A`1[U])" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -18871,9 +18989,6 @@
       <method name="System.Tuple`2[D1,DR1] Invoke(D1)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Combinator">
       <method name="Parser`2[L1,LR1] Lazy[L1,LR1](System.Func`1[Parser`2[L1,LR1]])" attrs="150">
@@ -18905,6 +19020,11 @@
     <type name="Combinator">
       <method name="System.Tuple`2[System.Int32,System.Int32] &lt;Main&gt;m__0(Int32)" attrs="145">
         <size>15</size>
+      </method>
+    </type>
+    <type name="Parser`2[D1,DR1]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -19157,9 +19277,6 @@
       <method name="T Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="BaseClass">
       <method name="Void .ctor()" attrs="6278">
@@ -19189,6 +19306,9 @@
         <size>0</size>
       </method>
       <method name="T EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -19268,11 +19388,11 @@
       </method>
     </type>
     <type name="C">
-      <method name="Void .ctor(String&amp;)" attrs="6278">
-        <size>15</size>
-      </method>
       <method name="System.String D()" attrs="134">
         <size>14</size>
+      </method>
+      <method name="Void .ctor(System.String ByRef)" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -20127,9 +20247,6 @@
       <method name="System.Decimal op_Implicit(MoneyValue)" attrs="2198">
         <size>16</size>
       </method>
-      <method name="Void .ctor(Decimal)" attrs="6278">
-        <size>9</size>
-      </method>
     </type>
     <type name="Program">
       <method name="Void Main()" attrs="145">
@@ -20137,6 +20254,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="MoneyValue">
+      <method name="Void .ctor(System.Decimal)" attrs="6278">
+        <size>9</size>
       </method>
     </type>
   </test>
@@ -20600,16 +20722,10 @@
       <method name="Int32 GetHashCode()" attrs="198">
         <size>26</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>15</size>
-      </method>
     </type>
     <type name="Beta">
       <method name="Int32 GetHashCode()" attrs="198">
         <size>26</size>
-      </method>
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>15</size>
       </method>
     </type>
     <type name="Program">
@@ -20635,6 +20751,16 @@
       </method>
       <method name="Void .ctor(&lt;First&gt;__T, &lt;Second&gt;__T)" attrs="6278">
         <size>21</size>
+      </method>
+    </type>
+    <type name="Alpha">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>15</size>
+      </method>
+    </type>
+    <type name="Beta">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -20937,9 +21063,6 @@
       <method name="Void set_NewValue(System.Object)" attrs="2177">
         <size>8</size>
       </method>
-      <method name="Void .ctor(Object)" attrs="6278">
-        <size>16</size>
-      </method>
     </type>
     <type name="C">
       <method name="Void Main()" attrs="150">
@@ -20947,6 +21070,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="Foo">
+      <method name="Void .ctor(System.Object)" attrs="6278">
+        <size>16</size>
       </method>
     </type>
   </test>
@@ -20995,9 +21123,6 @@
       <method name="Int32 get_P()" attrs="2182">
         <size>14</size>
       </method>
-      <method name="Void .ctor(Object)" attrs="6278">
-        <size>16</size>
-      </method>
     </type>
     <type name="C">
       <method name="Int32 get_P2()" attrs="2182">
@@ -21023,6 +21148,9 @@
     <type name="S2">
       <method name="Void .ctor()" attrs="6278">
         <size>15</size>
+      </method>
+      <method name="Void .ctor(System.Object)" attrs="6278">
+        <size>16</size>
       </method>
     </type>
   </test>
@@ -21216,9 +21344,6 @@
       <method name="Void set_Whatever(System.String)" attrs="2502">
         <size>8</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6276">
-        <size>15</size>
-      </method>
     </type>
     <type name="BrokenOverrideProperty.DerivedClass">
       <method name="System.String get_Whatever()" attrs="2246">
@@ -21227,9 +21352,6 @@
       <method name="Void set_Whatever(System.String)" attrs="2246">
         <size>20</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>9</size>
-      </method>
     </type>
     <type name="BrokenOverrideProperty.MainClass">
       <method name="Int32 Main()" attrs="150">
@@ -21237,6 +21359,16 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="BrokenOverrideProperty.BaseClass">
+      <method name="Void .ctor(System.String)" attrs="6276">
+        <size>15</size>
+      </method>
+    </type>
+    <type name="BrokenOverrideProperty.DerivedClass">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>9</size>
       </method>
     </type>
   </test>
@@ -22464,15 +22596,9 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Tester+IntDelegate">
       <method name="Int32 Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -22591,6 +22717,16 @@
         <size>136</size>
       </method>
     </type>
+    <type name="Tester+EmptyDelegate">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Tester+IntDelegate">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="gtest-etree-02.cs">
     <type name="M">
@@ -22696,15 +22832,9 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="UnsafeDelegate">
       <method name="Int32* Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -22741,6 +22871,16 @@
         <size>0</size>
       </method>
       <method name="Int32* EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="EmptyDelegate">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="UnsafeDelegate">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -23073,29 +23213,29 @@
         <size>7</size>
       </method>
     </type>
-    <type name="FieldInfoBug.GenericClass`1[T]">
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>58</size>
-      </method>
-    </type>
     <type name="FieldInfoBug.GenericClass`1+&lt;GenericClass&gt;c__AnonStorey0[T]">
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
       </method>
     </type>
-  </test>
-  <test name="gtest-etree-23.cs">
-    <type name="Test.OrderBySpecification">
-      <method name="Void .ctor(Expression`1)" attrs="6278">
-        <size>8</size>
+    <type name="FieldInfoBug.GenericClass`1[T]">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>58</size>
       </method>
     </type>
+  </test>
+  <test name="gtest-etree-23.cs">
     <type name="Test.RateOrderById">
       <method name="Int32 Main()" attrs="150">
         <size>16</size>
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>45</size>
+      </method>
+    </type>
+    <type name="Test.OrderBySpecification">
+      <method name="Void .ctor(System.Linq.Expressions.Expression`1[System.Func`2[System.Object,System.Object]])" attrs="6278">
+        <size>8</size>
       </method>
     </type>
   </test>
@@ -23273,7 +23413,7 @@
       <method name="Void .ctor()" attrs="6278">
         <size>76</size>
       </method>
-      <method name="Void .ctor(Action`2)" attrs="6278">
+      <method name="Void .ctor(System.Action`2[System.Object,System.Object])" attrs="6278">
         <size>76</size>
       </method>
     </type>
@@ -23581,9 +23721,6 @@
       <method name="System.String Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Program">
       <method name="Void add_e(D)" attrs="2177">
@@ -23610,6 +23747,9 @@
         <size>0</size>
       </method>
       <method name="System.String EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -23662,9 +23802,6 @@
       <method name="System.String Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Rocks">
       <method name="Int32 Test_2[T](System.Collections.Generic.IEnumerable`1[T])" attrs="150">
@@ -23676,6 +23813,9 @@
         <size>0</size>
       </method>
       <method name="System.String EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -24184,9 +24324,6 @@
       <method name="TResult Invoke(T1)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="ExtensionTest.MyClass">
       <method name="Void Main()" attrs="150">
@@ -24217,13 +24354,15 @@
         <size>23</size>
       </method>
     </type>
+    <type name="ExtensionTest.Two.AxFunc`2[T1,TResult]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="gtest-exmethod-47.cs">
     <type name="D">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -24253,6 +24392,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -24380,7 +24522,7 @@
       <method name="TestStruct get_Default()" attrs="2198">
         <size>10</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6278">
+      <method name="Void .ctor(System.String)" attrs="6278">
         <size>2</size>
       </method>
     </type>
@@ -24750,9 +24892,6 @@
       </method>
     </type>
     <type name="Test">
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>71</size>
-      </method>
       <method name="Void .ctor(Int32)" attrs="6278">
         <size>71</size>
       </method>
@@ -24763,6 +24902,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="Test">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>71</size>
       </method>
     </type>
   </test>
@@ -25941,9 +26085,6 @@
       <method name="Void Invoke(TOut ByRef)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="IEnumerableTransform+&lt;Transform&gt;c__Iterator0`1[TOut]">
       <method name="TOut System.Collections.Generic.IEnumerator&lt;TOut&gt;.get_Current()" attrs="2529">
@@ -25997,6 +26138,11 @@
     <type name="IEnumerableTransform+&lt;Transform&gt;c__Iterator0`1[TOut]">
       <method name="System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()" attrs="481">
         <size>14</size>
+      </method>
+    </type>
+    <type name="IEnumerableTransform+EmitterFunc`1[TOut]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -26737,9 +26883,6 @@
       <method name="R Invoke(A1)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="MyTest">
       <method name="Void Main(System.String[])" attrs="150">
@@ -26824,21 +26967,20 @@
         <size>22</size>
       </method>
     </type>
+    <type name="Fun`2[A1,R]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="gtest-lambda-01.cs">
     <type name="IntFunc">
       <method name="Int32 Invoke(Int32)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="VoidFunc">
       <method name="Void Invoke(Int32)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -26885,21 +27027,25 @@
         <size>9</size>
       </method>
     </type>
+    <type name="IntFunc">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="VoidFunc">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="gtest-lambda-02.cs">
     <type name="funcs">
       <method name="System.String Invoke(System.String)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="funci">
       <method name="Int32 Invoke(Int32)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -26938,13 +27084,20 @@
         <size>19</size>
       </method>
     </type>
+    <type name="funcs">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="funci">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="gtest-lambda-03.cs">
     <type name="Func`2[TArg0,TResult]">
       <method name="TResult Invoke(TArg0)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -26972,13 +27125,15 @@
         <size>14</size>
       </method>
     </type>
+    <type name="Func`2[TArg0,TResult]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="gtest-lambda-04.cs">
     <type name="Func`2[TArg0,TResult]">
       <method name="TResult Invoke(TArg0)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -27009,6 +27164,11 @@
         <size>15</size>
       </method>
     </type>
+    <type name="Func`2[TArg0,TResult]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="gtest-lambda-05.cs">
     <type name="C">
@@ -27023,23 +27183,14 @@
       <method name="Int32 Invoke(Int32)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="C+ds">
       <method name="System.String Invoke(System.String)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="C+db">
       <method name="Boolean Invoke(Boolean)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -27106,6 +27257,21 @@
         <size>38</size>
       </method>
     </type>
+    <type name="C+di">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="C+ds">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="C+db">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="gtest-lambda-06.cs">
     <type name="TestClass">
@@ -27153,15 +27319,9 @@
       <method name="Void Invoke(T)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="TestClass+DF">
       <method name="Void Invoke(F)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -27214,21 +27374,25 @@
         <size>31</size>
       </method>
     </type>
+    <type name="TestClass+DT">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="TestClass+DF">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="gtest-lambda-07.cs">
     <type name="D">
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="E">
       <method name="Void Invoke(Boolean)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -27288,6 +27452,16 @@
         <size>2</size>
       </method>
     </type>
+    <type name="D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="E">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="gtest-lambda-08.cs">
     <type name="C">
@@ -27328,15 +27502,9 @@
       <method name="TD Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Func`2[TA,TR]">
       <method name="TR Invoke(TA)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -27382,6 +27550,16 @@
       </method>
       <method name="System.String &lt;Main&gt;m__2(System.String)" attrs="145">
         <size>13</size>
+      </method>
+    </type>
+    <type name="Func`1[TD]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Func`2[TA,TR]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -27435,9 +27613,6 @@
       <method name="Pair`2[T1,T2] Invoke(T1)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="C">
       <method name="Void Foo[TInput,TValue,TIntermediate](Group`2[TInput,TValue], System.Func`2[TValue,Group`2[TInput,TIntermediate]])" attrs="150">
@@ -27475,14 +27650,14 @@
       <method name="Pair`2[T1,T2] EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="gtest-lambda-12.cs">
     <type name="Func`1[TA]">
       <method name="Void Invoke(TA)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -27510,6 +27685,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -27616,11 +27794,6 @@
         <size>7</size>
       </method>
     </type>
-    <type name="Repro+Runner`1[T]">
-      <method name="Void .ctor(Action`1, T)" attrs="6278">
-        <size>8</size>
-      </method>
-    </type>
     <type name="Repro+&lt;AssertFoo&gt;c__AnonStorey0`1[T]">
       <method name="Void &lt;&gt;m__0(Int32)" attrs="131">
         <size>58</size>
@@ -27632,6 +27805,11 @@
     <type name="Repro">
       <method name="Void AssertFoo[T](System.Collections.Generic.IList`1[T])" attrs="145">
         <size>35</size>
+      </method>
+    </type>
+    <type name="Repro+Runner`1[T]">
+      <method name="Void .ctor(System.Action`1[T], T)" attrs="6278">
+        <size>8</size>
       </method>
     </type>
   </test>
@@ -27717,9 +27895,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
@@ -27730,6 +27905,11 @@
     <type name="Z">
       <method name="Void &lt;Z&gt;m__0()" attrs="145">
         <size>7</size>
+      </method>
+    </type>
+    <type name="TestMethod">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -28871,9 +29051,6 @@
       <method name="System.String Select[U](System.Func`2[TestA,U])" attrs="134">
         <size>15</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>15</size>
-      </method>
     </type>
     <type name="TestB">
       <method name="TestA Where(TestA, System.Func`2[TestA,System.Boolean])" attrs="150">
@@ -28892,6 +29069,11 @@
       </method>
       <method name="Boolean &lt;Main&gt;m__1(TestA)" attrs="145">
         <size>25</size>
+      </method>
+    </type>
+    <type name="TestA">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -30383,13 +30565,13 @@
       <method name="Int32 Invoke(Int32, Int32)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(Int32, Int32, System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -30397,9 +30579,6 @@
   <test name="gtest-optional-06.cs">
     <type name="D">
       <method name="Int32 Invoke(Int32)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -30419,6 +30598,9 @@
         <size>0</size>
       </method>
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -30441,11 +30623,11 @@
       <method name="Int32 Main()" attrs="150">
         <size>49</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6273">
-        <size>15</size>
-      </method>
       <method name="Void .ctor(Int32)" attrs="6278">
         <size>8</size>
+      </method>
+      <method name="Void .ctor(System.String)" attrs="6273">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -30519,14 +30701,14 @@
         <size>7</size>
       </method>
     </type>
-    <type name="Program`1[T]">
-      <method name="Void .ctor(Generic`1)" attrs="6278">
-        <size>8</size>
-      </method>
-    </type>
     <type name="Generic`1[T]">
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="Program`1[T]">
+      <method name="Void .ctor(Generic`1[T])" attrs="6278">
+        <size>8</size>
       </method>
     </type>
   </test>
@@ -30765,9 +30947,6 @@
       <method name="Void .ctor()" attrs="6273">
         <size>23</size>
       </method>
-      <method name="Void .ctor(Object)" attrs="6273">
-        <size>29</size>
-      </method>
     </type>
     <type name="CallerMemberTest+&lt;Enumerator&gt;c__Iterator0">
       <method name="Int32 System.Collections.Generic.IEnumerator&lt;int&gt;.get_Current()" attrs="2529">
@@ -30834,6 +31013,9 @@
       <method name="System.Object &lt;Main&gt;m__1(Char)" attrs="145">
         <size>24</size>
       </method>
+      <method name="Void .ctor(System.Object)" attrs="6273">
+        <size>29</size>
+      </method>
     </type>
   </test>
   <test name="gtest-optional-23.cs">
@@ -30847,14 +31029,14 @@
       <method name="Void .ctor()" attrs="6273">
         <size>17</size>
       </method>
-      <method name="Void .ctor(Object)" attrs="6273">
-        <size>21</size>
-      </method>
       <method name="Void TraceStatic2(Double, System.Decimal)" attrs="145">
         <size>2</size>
       </method>
       <method name="Void &lt;Main&gt;m__0()" attrs="145">
         <size>11</size>
+      </method>
+      <method name="Void .ctor(System.Object)" attrs="6273">
+        <size>21</size>
       </method>
     </type>
   </test>
@@ -30952,10 +31134,10 @@
       <method name="Void Main()" attrs="150">
         <size>10</size>
       </method>
-      <method name="Void .ctor(Int32, String[])" attrs="6278">
+      <method name="Void .ctor(Int32, System.String[])" attrs="6278">
         <size>8</size>
       </method>
-      <method name="Void .ctor(Int32, List`1)" attrs="6278">
+      <method name="Void .ctor(Int32, System.Collections.Generic.List`1[System.String])" attrs="6278">
         <size>8</size>
       </method>
     </type>
@@ -31095,7 +31277,7 @@
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -31467,9 +31649,6 @@
       <method name="System.String get_Bar()" attrs="2534">
         <size>15</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>15</size>
-      </method>
     </type>
     <type name="Test">
       <method name="Int32 Main()" attrs="150">
@@ -31477,6 +31656,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="Foo">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -31533,9 +31717,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="D">
       <method name="Void add_field(D`1[System.String])" attrs="2534">
@@ -31562,6 +31743,11 @@
     <type name="D">
       <method name="Void &lt;Main&gt;m__0()" attrs="145">
         <size>2</size>
+      </method>
+    </type>
+    <type name="D`1[T]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -31624,15 +31810,9 @@
       <method name="Void Invoke(T)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="C+D`2[T,U]">
       <method name="T Invoke(U)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -31652,6 +31832,16 @@
         <size>0</size>
       </method>
     </type>
+    <type name="C+D`1[T]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="C+D`2[T,U]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="gtest-variance-15.cs">
     <type name="C">
@@ -31667,9 +31857,6 @@
     </type>
     <type name="C+D`1[T]">
       <method name="Void Invoke(T)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -31692,6 +31879,11 @@
     <type name="C">
       <method name="Void &lt;Main&gt;m__0(System.Object)" attrs="145">
         <size>7</size>
+      </method>
+    </type>
+    <type name="C+D`1[T]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -31777,16 +31969,8 @@
     </type>
   </test>
   <test name="gtest-variance-20.cs">
-    <type name="DocAttribute">
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>8</size>
-      </method>
-    </type>
     <type name="Func`2[T1,TR]">
       <method name="TR Invoke(T1)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -31803,6 +31987,16 @@
         <size>0</size>
       </method>
       <method name="TR EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="DocAttribute">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>8</size>
+      </method>
+    </type>
+    <type name="Func`2[T1,TR]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -31823,9 +32017,6 @@
   <test name="gtest-variance-3.cs">
     <type name="Foo`1[T]">
       <method name="T Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -31855,14 +32046,14 @@
       <method name="T EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="gtest-variance-4.cs">
     <type name="Foo`1[T]">
       <method name="Int32 Invoke(T)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -31888,6 +32079,11 @@
     <type name="Test">
       <method name="Int32 &lt;Main&gt;m__0(System.Object)" attrs="145">
         <size>14</size>
+      </method>
+    </type>
+    <type name="Foo`1[T]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -31951,51 +32147,6 @@
     </type>
   </test>
   <test name="gtest-variance-6.cs">
-    <type name="Cov1`1[U]">
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
-    </type>
-    <type name="Cov2`1[U]">
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
-    </type>
-    <type name="Cov3`1[U]">
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
-    </type>
-    <type name="Cov4`1[U]">
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
-    </type>
-    <type name="Cov5`1[U]">
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
-    </type>
-    <type name="Contra5`1[U]">
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
-    </type>
-    <type name="Contra6`1[U]">
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
-    </type>
-    <type name="Contra7`1[U]">
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
-    </type>
-    <type name="Contra8`1[U]">
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
-    </type>
     <type name="Program">
       <method name="Void Main()" attrs="150">
         <size>2</size>
@@ -32121,13 +32272,55 @@
         <size>0</size>
       </method>
     </type>
+    <type name="Cov1`1[U]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Cov2`1[U]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Cov3`1[U]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Cov4`1[U]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Cov5`1[U]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Contra5`1[U]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Contra6`1[U]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Contra7`1[U]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Contra8`1[U]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="gtest-variance-7.cs">
     <type name="Covariant`1[T]">
       <method name="T Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -32135,15 +32328,9 @@
       <method name="Void Invoke(T)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="CoContra`2[TR,T]">
       <method name="TR Invoke(T)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -32151,15 +32338,9 @@
       <method name="Void Invoke(T)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Test`1[U]">
       <method name="Covariant`1[Contra`1[Contra`1[Covariant`1[Covariant`1[Covariant`1[Covariant`1[Covariant`1[U]]]]]]]] Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -32167,15 +32348,9 @@
       <method name="Contra`1[Covariant`1[Contra`1[Contra`1[Covariant`1[Covariant`1[Covariant`1[Covariant`1[Covariant`1[U]]]]]]]]] Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Test3`1[U]">
       <method name="Contra`1[Contra`1[Covariant`1[Covariant`1[Covariant`1[Covariant`1[Contra`1[Contra`1[U]]]]]]]] Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -32183,15 +32358,9 @@
       <method name="Contra`1[Contra`1[Covariant`1[Covariant`1[Contra`1[Contra`1[Contra`1[Contra`1[U]]]]]]]] Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Test5`1[U]">
       <method name="Contra`1[Contra`1[Covariant`1[Covariant`1[Contra`1[Contra`1[Contra`1[U]]]]]]] Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -32199,15 +32368,9 @@
       <method name="Void Invoke(Covariant`1[Contra`1[Contra`1[Covariant`1[Covariant`1[Covariant`1[Covariant`1[Covariant`1[U]]]]]]]])" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Both`2[U,V]">
       <method name="Void Invoke(CoContra`2[U,V])" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -32215,15 +32378,9 @@
       <method name="Void Invoke(CoContra`2[U,Contra`1[U]])" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Both3`2[U,V]">
       <method name="Void Invoke(CoContra`2[U,Contra`1[System.Int32]])" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -32231,15 +32388,9 @@
       <method name="Void Invoke(Both`2[V,U])" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Both5`2[U,V]">
       <method name="Void Invoke(Both`2[V,System.Int32])" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -32368,6 +32519,81 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Covariant`1[T]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Contra`1[T]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="CoContra`2[TR,T]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="None`1[T]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Test`1[U]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Test2`1[U]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Test3`1[U]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Test4`1[U]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Test5`1[U]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Test6`1[U]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Both`2[U,V]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Both2`2[U,V]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Both3`2[U,V]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Both4`2[U,V]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Both5`2[U,V]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -32519,16 +32745,6 @@
     </type>
   </test>
   <test name="test-101.cs">
-    <type name="Test.MyAttribute">
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>21</size>
-      </method>
-    </type>
-    <type name="Test.My2Attribute">
-      <method name="Void .ctor(String, Int32)" attrs="6278">
-        <size>32</size>
-      </method>
-    </type>
     <type name="Test.Test">
       <method name="Int32 Main()" attrs="150">
         <size>114</size>
@@ -32537,24 +32753,34 @@
         <size>7</size>
       </method>
     </type>
+    <type name="Test.MyAttribute">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>21</size>
+      </method>
+    </type>
+    <type name="Test.My2Attribute">
+      <method name="Void .ctor(System.String, Int32)" attrs="6278">
+        <size>32</size>
+      </method>
+    </type>
   </test>
   <test name="test-102.cs">
-    <type name="N1.MineAttribute">
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>15</size>
-      </method>
-    </type>
-    <type name="N1.ReturnAttribute">
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>15</size>
-      </method>
-    </type>
     <type name="N1.Foo">
       <method name="Int32 Main()" attrs="150">
         <size>292</size>
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="N1.MineAttribute">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>15</size>
+      </method>
+    </type>
+    <type name="N1.ReturnAttribute">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -32613,9 +32839,6 @@
       <method name="Int32 Invoke(Int32)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Test">
       <method name="Void async_callback(System.IAsyncResult)" attrs="145">
@@ -32627,6 +32850,9 @@
         <size>0</size>
       </method>
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -32650,9 +32876,6 @@
       <method name="Int32 Invoke(Int32)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Test">
       <method name="Void async_callback(System.IAsyncResult)" attrs="145">
@@ -32664,6 +32887,9 @@
         <size>0</size>
       </method>
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -32775,13 +33001,13 @@
       <method name="Boolean Invoke(Char)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(Char, System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
       <method name="Boolean EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -33042,16 +33268,6 @@
     </type>
   </test>
   <test name="test-128.cs">
-    <type name="SimpleAttribute">
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>15</size>
-      </method>
-    </type>
-    <type name="MineAttribute">
-      <method name="Void .ctor(Type[])" attrs="6278">
-        <size>15</size>
-      </method>
-    </type>
     <type name="Foo">
       <method name="Int32 MM()" attrs="150">
         <size>194</size>
@@ -33075,6 +33291,16 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="SimpleAttribute">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>15</size>
+      </method>
+    </type>
+    <type name="MineAttribute">
+      <method name="Void .ctor(System.Type[])" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -33117,17 +33343,17 @@
     </type>
   </test>
   <test name="test-131.cs">
-    <type name="SimpleAttribute">
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>15</size>
-      </method>
-    </type>
     <type name="Blah">
       <method name="Int32 Main()" attrs="150">
         <size>10</size>
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="SimpleAttribute">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -33375,9 +33601,6 @@
       <method name="Int32 Main()" attrs="150">
         <size>10</size>
       </method>
-      <method name="Void .ctor(EventHandler)" attrs="6278">
-        <size>15</size>
-      </method>
     </type>
     <type name="TestBaseClass">
       <method name="Void add_Blah(System.EventHandler)" attrs="2182">
@@ -33388,6 +33611,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="TestClass">
+      <method name="Void .ctor(System.EventHandler)" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -33623,9 +33851,6 @@
       <method name="Int64 Invoke(Int32)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Y">
       <method name="Void X.add_Foo(System.EventHandler)" attrs="2529">
@@ -33680,9 +33905,6 @@
       <method name="Int32 Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Static">
       <method name="Void add_Test(System.EventHandler)" attrs="2198">
@@ -33719,6 +33941,16 @@
         <size>0</size>
       </method>
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="MyDelegate">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Z+SomeEventHandler">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -34177,11 +34409,6 @@
     </type>
   </test>
   <test name="test-157.cs">
-    <type name="Test.MyAttribute">
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>21</size>
-      </method>
-    </type>
     <type name="Test.Test">
       <method name="Int32 Main()" attrs="150">
         <size>233</size>
@@ -34190,19 +34417,24 @@
         <size>7</size>
       </method>
     </type>
-  </test>
-  <test name="test-158.cs">
-    <type name="My">
-      <method name="Void .ctor(Object)" attrs="6278">
-        <size>15</size>
+    <type name="Test.MyAttribute">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>21</size>
       </method>
     </type>
+  </test>
+  <test name="test-158.cs">
     <type name="My+Test">
       <method name="Int32 Main()" attrs="150">
         <size>109</size>
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="My">
+      <method name="Void .ctor(System.Object)" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -34282,14 +34514,14 @@
       <method name="Int32 Main()" attrs="150">
         <size>10</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>19</size>
-      </method>
       <method name="Void .ctor(ZipEntry)" attrs="6278">
         <size>19</size>
       </method>
       <method name="System.DateTime get_DateTime()" attrs="2182">
         <size>15</size>
+      </method>
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>19</size>
       </method>
     </type>
   </test>
@@ -34302,9 +34534,6 @@
     <type name="C">
       <method name="Void .ctor(Int64)" attrs="6278">
         <size>9</size>
-      </method>
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>14</size>
       </method>
     </type>
     <type name="E">
@@ -34362,6 +34591,11 @@
         <size>7</size>
       </method>
     </type>
+    <type name="C">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>14</size>
+      </method>
+    </type>
   </test>
   <test name="test-163.cs">
     <type name="Blah">
@@ -34392,9 +34626,6 @@
       <method name="Int32 Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Y">
       <method name="Int32 Foo()" attrs="196">
@@ -34415,6 +34646,9 @@
         <size>0</size>
       </method>
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -34945,13 +35179,13 @@
       <method name="Int32 Invoke(Int32, Int32 ByRef)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(Int32, Int32 ByRef, System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
       <method name="Int32 EndInvoke(Int32 ByRef, System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -34993,17 +35227,17 @@
     </type>
   </test>
   <test name="test-186.cs">
-    <type name="TestBUG.myAttribute">
-      <method name="Void .ctor(String, String, String, Int32)" attrs="6278">
-        <size>8</size>
-      </method>
-    </type>
     <type name="TestBUG.Test">
       <method name="Int32 Main()" attrs="150">
         <size>10</size>
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="TestBUG.myAttribute">
+      <method name="Void .ctor(System.String, System.String, System.String, Int32)" attrs="6278">
+        <size>8</size>
       </method>
     </type>
   </test>
@@ -35132,9 +35366,6 @@
       <method name="System.String Invoke(System.String)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="X">
       <method name="Void Thread_func()" attrs="129">
@@ -35163,15 +35394,9 @@
       <method name="Int32 Invoke(Int32, Int32)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="NameSpace.TestDelegate">
       <method name="Int32 Invoke(Int32)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -35182,9 +35407,6 @@
     </type>
     <type name="TestNamespace.TestClass+NotWorkingDelegate">
       <method name="Single Invoke(Single, System.Object[])" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -35217,6 +35439,26 @@
         <size>0</size>
       </method>
       <method name="Single EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="I+GetTextFn">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="X+Foo">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="NameSpace.TestDelegate">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="TestNamespace.TestClass+NotWorkingDelegate">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -35669,17 +35911,17 @@
     </type>
   </test>
   <test name="test-205.cs">
-    <type name="A">
-      <method name="Void .ctor(Object)" attrs="6278">
-        <size>8</size>
-      </method>
-    </type>
     <type name="Test">
       <method name="Void Main()" attrs="150">
         <size>2</size>
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="A">
+      <method name="Void .ctor(System.Object)" attrs="6278">
+        <size>8</size>
       </method>
     </type>
   </test>
@@ -35702,9 +35944,6 @@
   <test name="test-207.cs">
     <type name="Test">
       <method name="Void Invoke(Int32)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -35730,6 +35969,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -35817,9 +36059,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="X">
       <method name="Void foo()" attrs="150">
@@ -35837,6 +36076,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -35881,7 +36123,7 @@
       <method name="Int32 Main(System.String[])" attrs="150">
         <size>84</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6278">
+      <method name="Void .ctor(System.String)" attrs="6278">
         <size>15</size>
       </method>
     </type>
@@ -35948,9 +36190,6 @@
       <method name="Void Invoke(System.String)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="cls">
       <method name="Void add_OnWhatever(OnWhateverDelegate)" attrs="2182">
@@ -35992,6 +36231,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-217.cs">
@@ -36029,13 +36271,13 @@
       <method name="Void Invoke(System.Object)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(System.Object, System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -36045,9 +36287,6 @@
       <method name="System.Type get_Type()" attrs="2182">
         <size>15</size>
       </method>
-      <method name="Void .ctor(Type)" attrs="6278">
-        <size>15</size>
-      </method>
     </type>
     <type name="Test">
       <method name="Void Main()" attrs="150">
@@ -36055,6 +36294,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="TestAttribute">
+      <method name="Void .ctor(System.Type)" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -36089,9 +36333,6 @@
       <method name="System.String get_Name()" attrs="2182">
         <size>15</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>15</size>
-      </method>
     </type>
     <type name="MonoBUG.FooList">
       <method name="Void Add(MonoBUG.Foo)" attrs="134">
@@ -36123,13 +36364,20 @@
       <method name="Void Reset()" attrs="134">
         <size>13</size>
       </method>
-      <method name="Void .ctor(FooList)" attrs="6278">
-        <size>32</size>
-      </method>
     </type>
     <type name="MonoBUG.FooList">
       <method name="FooEnumerator GetEnumerator()" attrs="134">
         <size>15</size>
+      </method>
+    </type>
+    <type name="MonoBUG.Foo">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>15</size>
+      </method>
+    </type>
+    <type name="MonoBUG.FooList+FooEnumerator">
+      <method name="Void .ctor(MonoBUG.FooList)" attrs="6278">
+        <size>32</size>
       </method>
     </type>
   </test>
@@ -36272,9 +36520,6 @@
       <method name="Void set_IsRequired(Boolean)" attrs="2182">
         <size>9</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>39</size>
-      </method>
     </type>
     <type name="t">
       <method name="Void Main()" attrs="150">
@@ -36290,6 +36535,9 @@
       </method>
       <method name="Void set_Separator(Char[])" attrs="2182">
         <size>9</size>
+      </method>
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>39</size>
       </method>
     </type>
   </test>
@@ -36429,9 +36677,6 @@
       <method name="Void set_Value(System.String)" attrs="2182">
         <size>9</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>15</size>
-      </method>
     </type>
     <type name="Z">
       <method name="Int32 get_IVal()" attrs="2198">
@@ -36448,6 +36693,11 @@
       </method>
       <method name="Void .cctor()" attrs="6289">
         <size>8</size>
+      </method>
+    </type>
+    <type name="Y">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -36635,13 +36885,13 @@
       <method name="Void Invoke(System.String, System.Object[])" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(System.String, System.Object[], System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -36920,9 +37170,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="A">
       <method name="Void add_Bar(Foo)" attrs="2182">
@@ -36946,6 +37193,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -36986,9 +37236,6 @@
     </type>
     <type name="test_delegate">
       <method name="System.Delegate Invoke(Int32)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -37065,6 +37312,9 @@
         <size>0</size>
       </method>
       <method name="System.Delegate EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -37174,14 +37424,6 @@
       <method name="Int32 Invoke(Int32, Int32)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
-    </type>
-    <type name="Blah+List">
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Blah">
       <method name="Int32 Adder(Int32[])" attrs="150">
@@ -37204,6 +37446,16 @@
         <size>0</size>
       </method>
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Blah+MyDelegate">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Blah+List">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -37305,12 +37557,12 @@
       <method name="Void Main()" attrs="150">
         <size>2</size>
       </method>
-      <method name="Void .ctor(String, Object[])" attrs="6275">
+      <method name="Void .ctor(System.String, System.Object[])" attrs="6275">
         <size>8</size>
       </method>
     </type>
     <type name="UnsupportedClassVersionError">
-      <method name="Void .ctor(String)" attrs="6275">
+      <method name="Void .ctor(System.String)" attrs="6275">
         <size>14</size>
       </method>
     </type>
@@ -37422,13 +37674,13 @@
       <method name="Void Invoke(Int32, Int32)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(Int32, Int32, System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -37519,11 +37771,6 @@
     </type>
   </test>
   <test name="test-274.cs">
-    <type name="MyClass">
-      <method name="Void .ctor(String[])" attrs="6278">
-        <size>8</size>
-      </method>
-    </type>
     <type name="ChildClass">
       <method name="Void .ctor()" attrs="6278">
         <size>12</size>
@@ -37537,13 +37784,15 @@
         <size>7</size>
       </method>
     </type>
+    <type name="MyClass">
+      <method name="Void .ctor(System.String[])" attrs="6278">
+        <size>8</size>
+      </method>
+    </type>
   </test>
   <test name="test-275.cs">
     <type name="DelType">
       <method name="Int32 Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -37589,6 +37838,11 @@
       </method>
       <method name="Int32 &lt;Main&gt;m__1()" attrs="145">
         <size>10</size>
+      </method>
+    </type>
+    <type name="DelType">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -37796,9 +38050,6 @@
       <method name="Int32 Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Y">
       <method name="D GetIt()" attrs="129">
@@ -37813,6 +38064,9 @@
         <size>0</size>
       </method>
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -37871,9 +38125,6 @@
       <method name="System.Object Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="MainClass">
       <method name="Int32 Main()" attrs="150">
@@ -37890,6 +38141,9 @@
       <method name="System.Object EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-288.cs">
@@ -37903,7 +38157,7 @@
       <method name="Int32 Main(System.String[])" attrs="150">
         <size>65</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6278">
+      <method name="Void .ctor(System.String)" attrs="6278">
         <size>26</size>
       </method>
     </type>
@@ -37975,9 +38229,6 @@
       <method name="Void Invoke(System.Object)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="EntryPoint">
       <method name="Void add_FooEvent(EventHandler)" attrs="2193">
@@ -37992,6 +38243,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -38059,9 +38313,6 @@
       <method name="Void .ctor()" attrs="6278">
         <size>14</size>
       </method>
-      <method name="Void .ctor(String, Boolean)" attrs="6278">
-        <size>15</size>
-      </method>
     </type>
     <type name="DerivedTest">
       <method name="System.String Method()" attrs="134">
@@ -38072,9 +38323,6 @@
       </method>
       <method name="Void Main()" attrs="150">
         <size>2</size>
-      </method>
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>17</size>
       </method>
     </type>
     <type name="ObsoleteClass2">
@@ -38098,13 +38346,20 @@
         <size>7</size>
       </method>
     </type>
+    <type name="Test">
+      <method name="Void .ctor(System.String, Boolean)" attrs="6278">
+        <size>15</size>
+      </method>
+    </type>
+    <type name="DerivedTest">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>17</size>
+      </method>
+    </type>
   </test>
   <test name="test-295.cs">
     <type name="MyAttribute">
       <method name="System.Object get_my()" attrs="2182">
-        <size>15</size>
-      </method>
-      <method name="Void .ctor(Object)" attrs="6278">
         <size>15</size>
       </method>
     </type>
@@ -38117,6 +38372,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="MyAttribute">
+      <method name="Void .ctor(System.Object)" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -38143,7 +38403,7 @@
       </method>
     </type>
     <type name="My">
-      <method name="Void .ctor(Object)" attrs="6278">
+      <method name="Void .ctor(System.Object)" attrs="6278">
         <size>15</size>
       </method>
     </type>
@@ -38864,11 +39124,6 @@
     </type>
   </test>
   <test name="test-325.cs">
-    <type name="RequestAttribute">
-      <method name="Void .ctor(String, String, String[])" attrs="6278">
-        <size>8</size>
-      </method>
-    </type>
     <type name="MyClass">
       <method name="Int32 SomeRequest()" attrs="150">
         <size>10</size>
@@ -38880,13 +39135,15 @@
         <size>7</size>
       </method>
     </type>
+    <type name="RequestAttribute">
+      <method name="Void .ctor(System.String, System.String, System.String[])" attrs="6278">
+        <size>8</size>
+      </method>
+    </type>
   </test>
   <test name="test-326.cs">
     <type name="Mapper">
       <method name="Double Invoke(Int32)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -38909,6 +39166,11 @@
     <type name="X">
       <method name="Double &lt;Main&gt;m__0(Int32)" attrs="145">
         <size>14</size>
+      </method>
+    </type>
+    <type name="Mapper">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -38951,7 +39213,7 @@
       <method name="Void .ctor()" attrs="6278">
         <size>8</size>
       </method>
-      <method name="Void .ctor(Object)" attrs="6278">
+      <method name="Void .ctor(System.Object)" attrs="6278">
         <size>22</size>
       </method>
     </type>
@@ -39085,15 +39347,9 @@
       <method name="Void Invoke(Int32, Int32)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="X+D">
       <method name="Void Invoke(Int32 ByRef)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -39113,21 +39369,25 @@
         <size>0</size>
       </method>
     </type>
+    <type name="X+B">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="X+D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-336.cs">
     <type name="Foo">
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Bar">
       <method name="Void Invoke(Int32)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -39158,6 +39418,16 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Foo">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Bar">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -39354,9 +39624,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="X">
       <method name="Void add_y(Y)" attrs="2182">
@@ -39388,6 +39655,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -39492,9 +39762,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="C">
       <method name="Void add_Ev1(D)" attrs="2177">
@@ -39553,6 +39820,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-35.cs">
@@ -39599,9 +39869,6 @@
       <method name="Void Invoke(System.String, System.Object[])" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Test.Testee">
       <method name="Void Bar(System.String, System.Object[])" attrs="145">
@@ -39619,6 +39886,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -39709,13 +39979,13 @@
       <method name="Void Invoke(Boolean)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(Boolean, System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -39844,9 +40114,6 @@
       <method name="Int32 Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Delegable">
       <method name="Void add_MyDelegate(System.EventHandler)" attrs="2182">
@@ -39892,6 +40159,9 @@
         <size>0</size>
       </method>
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -39998,12 +40268,12 @@
       <method name="Void Main()" attrs="150">
         <size>2</size>
       </method>
-      <method name="Void .ctor(Boolean&amp;)" attrs="6278">
+      <method name="Void .ctor(Boolean ByRef)" attrs="6278">
         <size>11</size>
       </method>
     </type>
     <type name="Y">
-      <method name="Void .ctor(Boolean&amp;)" attrs="6278">
+      <method name="Void .ctor(Boolean ByRef)" attrs="6278">
         <size>9</size>
       </method>
     </type>
@@ -40276,10 +40546,10 @@
       <method name="Void Main()" attrs="150">
         <size>16</size>
       </method>
-      <method name="Void .ctor(Decimal)" attrs="6278">
+      <method name="SuperDecimal op_Implicit(System.Decimal)" attrs="2198">
         <size>15</size>
       </method>
-      <method name="SuperDecimal op_Implicit(System.Decimal)" attrs="2198">
+      <method name="Void .ctor(System.Decimal)" attrs="6278">
         <size>15</size>
       </method>
     </type>
@@ -40414,9 +40684,6 @@
       <method name="Void set_LongValue(Int64)" attrs="2182">
         <size>2</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>22</size>
-      </method>
     </type>
     <type name="Blah2">
       <method name="Void .ctor()" attrs="6278">
@@ -40442,6 +40709,9 @@
       </method>
       <method name="Void set_ArrayValue(Int64[])" attrs="2182">
         <size>2</size>
+      </method>
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>22</size>
       </method>
     </type>
   </test>
@@ -40518,24 +40788,13 @@
       <method name="System.String get_Name()" attrs="2182">
         <size>15</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>25</size>
-      </method>
       <method name="Void .ctor()" attrs="6278">
         <size>8</size>
       </method>
     </type>
     <type name="B">
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>25</size>
-      </method>
       <method name="Void .ctor()" attrs="6278">
         <size>8</size>
-      </method>
-    </type>
-    <type name="C">
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>25</size>
       </method>
     </type>
     <type name="Tester">
@@ -40559,13 +40818,30 @@
       <method name="A Invoke(System.String)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(System.String, System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
       <method name="A EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="A">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>25</size>
+      </method>
+    </type>
+    <type name="B">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>25</size>
+      </method>
+    </type>
+    <type name="C">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>25</size>
+      </method>
+    </type>
+    <type name="Tester+MethodHandler">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -40575,17 +40851,11 @@
       <method name="System.String get_Name()" attrs="2182">
         <size>15</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>25</size>
-      </method>
       <method name="Void .ctor()" attrs="6278">
         <size>8</size>
       </method>
     </type>
     <type name="B">
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>25</size>
-      </method>
       <method name="Void .ctor()" attrs="6278">
         <size>8</size>
       </method>
@@ -40593,9 +40863,6 @@
     <type name="C">
       <method name="System.String get_Value()" attrs="2182">
         <size>15</size>
-      </method>
-      <method name="Void .ctor(String, String)" attrs="6278">
-        <size>32</size>
       </method>
     </type>
     <type name="Tester">
@@ -40619,13 +40886,30 @@
       <method name="System.String Invoke(C)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(C, System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
       <method name="System.String EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="A">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>25</size>
+      </method>
+    </type>
+    <type name="B">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>25</size>
+      </method>
+    </type>
+    <type name="C">
+      <method name="Void .ctor(System.String, System.String)" attrs="6278">
+        <size>32</size>
+      </method>
+    </type>
+    <type name="Tester+MethodHandler">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -40635,17 +40919,11 @@
       <method name="System.String get_Name()" attrs="2182">
         <size>15</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>25</size>
-      </method>
       <method name="Void .ctor()" attrs="6278">
         <size>8</size>
       </method>
     </type>
     <type name="B">
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>25</size>
-      </method>
       <method name="Void .ctor()" attrs="6278">
         <size>8</size>
       </method>
@@ -40653,9 +40931,6 @@
     <type name="C">
       <method name="System.String get_Value()" attrs="2182">
         <size>15</size>
-      </method>
-      <method name="Void .ctor(String, String)" attrs="6278">
-        <size>32</size>
       </method>
     </type>
     <type name="Tester">
@@ -40673,13 +40948,30 @@
       <method name="Void Invoke(C, C, C)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(C, C, C, System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="A">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>25</size>
+      </method>
+    </type>
+    <type name="B">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>25</size>
+      </method>
+    </type>
+    <type name="C">
+      <method name="Void .ctor(System.String, System.String)" attrs="6278">
+        <size>32</size>
+      </method>
+    </type>
+    <type name="Tester+MethodHandler">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -40703,11 +40995,6 @@
     <type name="PropertyCheckAttribute">
       <method name="Void .ctor()" attrs="6278">
         <size>8</size>
-      </method>
-    </type>
-    <type name="AccessorCheckAttribute">
-      <method name="Void .ctor(MethodAttributes)" attrs="6278">
-        <size>15</size>
       </method>
     </type>
     <type name="Test">
@@ -40758,6 +41045,9 @@
     </type>
     <type name="AccessorCheckAttribute">
       <method name="System.Reflection.MethodAttributes get_Attributes()" attrs="2182">
+        <size>15</size>
+      </method>
+      <method name="Void .ctor(System.Reflection.MethodAttributes)" attrs="6278">
         <size>15</size>
       </method>
     </type>
@@ -41116,14 +41406,14 @@
         <size>13</size>
       </method>
     </type>
-    <type name="M1">
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>15</size>
-      </method>
-    </type>
     <type name="M2">
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="M1">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -41836,12 +42126,6 @@
       <method name="Void .ctor()" attrs="6275">
         <size>8</size>
       </method>
-      <method name="Void .ctor(Type)" attrs="6275">
-        <size>8</size>
-      </method>
-      <method name="Void .ctor(String)" attrs="6275">
-        <size>8</size>
-      </method>
       <method name="Void .ctor(Int32)" attrs="6275">
         <size>8</size>
       </method>
@@ -41872,6 +42156,14 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="MyAttr">
+      <method name="Void .ctor(System.Type)" attrs="6275">
+        <size>8</size>
+      </method>
+      <method name="Void .ctor(System.String)" attrs="6275">
+        <size>8</size>
       </method>
     </type>
   </test>
@@ -41960,9 +42252,6 @@
       <method name="System.Enum get_Val2()" attrs="2182">
         <size>15</size>
       </method>
-      <method name="Void .ctor(Object)" attrs="6278">
-        <size>2</size>
-      </method>
     </type>
     <type name="Valtest">
       <method name="Int32 Main()" attrs="150">
@@ -41970,6 +42259,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="Value">
+      <method name="Void .ctor(System.Object)" attrs="6278">
+        <size>2</size>
       </method>
     </type>
   </test>
@@ -42054,9 +42348,6 @@
       <method name="Int32 Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="B">
       <method name="Void .ctor()" attrs="6278">
@@ -42065,9 +42356,6 @@
     </type>
     <type name="B+D">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -42098,13 +42386,20 @@
         <size>0</size>
       </method>
     </type>
+    <type name="A+D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="B+D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-469.cs">
     <type name="Del">
       <method name="Void Invoke(Int32)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -42138,6 +42433,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -42180,17 +42478,17 @@
     </type>
   </test>
   <test name="test-471.cs">
-    <type name="AAttribute">
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>15</size>
-      </method>
-    </type>
     <type name="MainClass">
       <method name="Int32 Main()" attrs="150">
         <size>52</size>
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="AAttribute">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -42213,9 +42511,6 @@
   <test name="test-473.cs">
     <type name="SignalHandler">
       <method name="Void Invoke(Int32)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -42294,6 +42589,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-474.cs">
@@ -42316,9 +42614,6 @@
     </type>
     <type name="Z+X">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -42345,14 +42640,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-475.cs">
     <type name="MyDelegate">
       <method name="Void Invoke(Int32)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -42381,6 +42676,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -42417,14 +42715,14 @@
         <size>7</size>
       </method>
     </type>
-    <type name="Test.TestAttribute">
-      <method name="Void .ctor(TestEnum2)" attrs="6278">
-        <size>8</size>
-      </method>
-    </type>
     <type name="Test.Test2Attribute">
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="Test.TestAttribute">
+      <method name="Void .ctor(Test.TestEnum2)" attrs="6278">
+        <size>8</size>
       </method>
     </type>
   </test>
@@ -42481,9 +42779,6 @@
       <method name="Void Invoke(Int32)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(Int32, System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
@@ -42496,13 +42791,15 @@
         <size>2</size>
       </method>
     </type>
+    <type name="C+D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-481.cs">
     <type name="TestDelegate">
       <method name="Void Invoke(Int32 ByRef)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -42522,6 +42819,11 @@
     <type name="TestClass">
       <method name="Void &lt;Main&gt;m__0(Int32 ByRef)" attrs="145">
         <size>5</size>
+      </method>
+    </type>
+    <type name="TestDelegate">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -42594,11 +42896,11 @@
       <method name="Int32 Main()" attrs="150">
         <size>33</size>
       </method>
-      <method name="Void .ctor(Object)" attrs="6273">
-        <size>73</size>
-      </method>
       <method name="Void .cctor()" attrs="6289">
         <size>7</size>
+      </method>
+      <method name="Void .ctor(System.Object)" attrs="6273">
+        <size>73</size>
       </method>
     </type>
   </test>
@@ -42751,16 +43053,6 @@
     </type>
   </test>
   <test name="test-492.cs">
-    <type name="Test.My1Attribute">
-      <method name="Void .ctor(Object)" attrs="6278">
-        <size>20</size>
-      </method>
-    </type>
-    <type name="Test.My2Attribute">
-      <method name="Void .ctor(String[])" attrs="6278">
-        <size>22</size>
-      </method>
-    </type>
     <type name="Test.My3Attribute">
       <method name="Void .ctor(Byte)" attrs="6278">
         <size>25</size>
@@ -42772,6 +43064,16 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="Test.My1Attribute">
+      <method name="Void .ctor(System.Object)" attrs="6278">
+        <size>20</size>
+      </method>
+    </type>
+    <type name="Test.My2Attribute">
+      <method name="Void .ctor(System.String[])" attrs="6278">
+        <size>22</size>
       </method>
     </type>
   </test>
@@ -42814,13 +43116,13 @@
       <method name="Void Invoke(Agresso.Foundation.Function, System.Text.StringBuilder ByRef)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(Agresso.Foundation.Function, System.Text.StringBuilder ByRef, System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.Text.StringBuilder ByRef, System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -42878,7 +43180,7 @@
       <method name="Void .ctor()" attrs="6278">
         <size>8</size>
       </method>
-      <method name="Void .ctor(EventHandler)" attrs="6278">
+      <method name="Void .ctor(System.EventHandler)" attrs="6278">
         <size>55</size>
       </method>
     </type>
@@ -42964,9 +43266,6 @@
       <method name="Boolean Invoke(System.Object)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Tests">
       <method name="Void DumpException(FilterStackFrame)" attrs="150">
@@ -42984,6 +43283,11 @@
     <type name="Tests">
       <method name="Boolean &lt;foo&gt;m__0(System.Object)" attrs="145">
         <size>10</size>
+      </method>
+    </type>
+    <type name="Tests+FilterStackFrame">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -43149,9 +43453,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="BaseClass">
       <method name="Void add_OnEvent(DelegateHandler)" attrs="2534">
@@ -43177,6 +43478,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -43398,13 +43702,13 @@
       <method name="Void Invoke(System.Object, System.Object[])" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(System.Object, System.Object[], System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -43628,9 +43932,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Test">
       <method name="Void OnFooTest()" attrs="145">
@@ -43657,6 +43958,11 @@
     <type name="Test">
       <method name="Void &lt;Main&gt;m__0()" attrs="145">
         <size>36</size>
+      </method>
+    </type>
+    <type name="FooHandler">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -43714,9 +44020,6 @@
       <method name="IInterface Invoke(concrete)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="concrete">
       <method name="Void .ctor()" attrs="6278">
@@ -43739,6 +44042,9 @@
         <size>0</size>
       </method>
       <method name="IInterface EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -43815,9 +44121,6 @@
       <method name="Void Invoke(Int32)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(Int32, System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
@@ -43830,13 +44133,13 @@
         <size>2</size>
       </method>
     </type>
-  </test>
-  <test name="test-542.cs">
-    <type name="ARec">
-      <method name="Void .ctor(Decimal)" attrs="6278">
-        <size>15</size>
+    <type name="ClassMain+D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
+  </test>
+  <test name="test-542.cs">
     <type name="X">
       <method name="Void Main()" attrs="150">
         <size>2</size>
@@ -43850,6 +44153,9 @@
         <size>21</size>
       </method>
       <method name="System.Decimal Round(System.Decimal, Int32)" attrs="145">
+        <size>15</size>
+      </method>
+      <method name="Void .ctor(System.Decimal)" attrs="6278">
         <size>15</size>
       </method>
     </type>
@@ -43966,9 +44272,6 @@
       <method name="System.Object Invoke(Do)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Do">
       <method name="Void Register(Get)" attrs="134">
@@ -44000,6 +44303,9 @@
         <size>0</size>
       </method>
       <method name="System.Object EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -44151,13 +44457,13 @@
       <method name="Void Invoke(Int32)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(Int32, System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -44411,9 +44717,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="preservesig_test.TestClass">
       <method name="Void add_e(D)" attrs="2182">
@@ -44428,6 +44731,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -44468,9 +44774,6 @@
   <test name="test-57.cs">
     <type name="EventHandler">
       <method name="Void Invoke(Int32, Int32)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -44516,6 +44819,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -44639,9 +44945,6 @@
       <method name="Int32 Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Test1.TestItem1">
       <method name="Int32 Test()" attrs="134">
@@ -44687,6 +44990,11 @@
     <type name="Test1.CC">
       <method name="Int32 &lt;Main&gt;m__0()" attrs="145">
         <size>10</size>
+      </method>
+    </type>
+    <type name="Test1.TestDelegate1">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -45167,9 +45475,6 @@
       <method name="System.String op_Implicit(Test.String)" attrs="2198">
         <size>28</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>15</size>
-      </method>
     </type>
     <type name="TestCompiler.MainClass">
       <method name="Int32 Main()" attrs="150">
@@ -45177,6 +45482,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="Test.String">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -45231,13 +45541,13 @@
       <method name="Void Invoke(IntPtr, IntPtr)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(IntPtr, IntPtr, System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -45416,9 +45726,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="X">
       <method name="Void add_XX(MyEvent)" attrs="2182">
@@ -45433,6 +45740,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -45618,9 +45928,6 @@
       <method name="Int64 Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Y">
       <method name="Void X.add_Foo(MyDelegate)" attrs="2529">
@@ -45650,6 +45957,9 @@
         <size>0</size>
       </method>
       <method name="Int64 EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -46083,9 +46393,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Test+&lt;TestFunc&gt;c__AnonStorey0">
       <method name="Void .ctor()" attrs="6278">
@@ -46097,6 +46404,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -46165,9 +46475,6 @@
       <method name="Void .ctor()" attrs="6278">
         <size>8</size>
       </method>
-      <method name="Void .ctor(Object)" attrs="6278">
-        <size>20</size>
-      </method>
     </type>
     <type name="TestProp">
       <method name="Void .ctor()" attrs="6278">
@@ -46180,6 +46487,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="A">
+      <method name="Void .ctor(System.Object)" attrs="6278">
+        <size>20</size>
       </method>
     </type>
   </test>
@@ -46332,9 +46644,6 @@
       <method name="System.Object Invoke(Int32)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Program">
       <method name="Boolean Test_4(D)" attrs="134">
@@ -46346,6 +46655,9 @@
         <size>0</size>
       </method>
       <method name="System.Object EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -46421,14 +46733,14 @@
       <method name="Void .ctor(Double)" attrs="6278">
         <size>14</size>
       </method>
-      <method name="Void .ctor(Decimal)" attrs="6278">
-        <size>9</size>
-      </method>
       <method name="Decimal2 op_Explicit(System.Decimal)" attrs="2198">
         <size>15</size>
       </method>
       <method name="System.Decimal op_Implicit(Decimal2)" attrs="2198">
         <size>16</size>
+      </method>
+      <method name="Void .ctor(System.Decimal)" attrs="6278">
+        <size>9</size>
       </method>
     </type>
   </test>
@@ -46868,9 +47180,6 @@
       <method name="Int32 Invoke(Int32)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(Int32, System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
@@ -46881,6 +47190,11 @@
     <type name="Test">
       <method name="Int32 &lt;Main&gt;m__0(Int32)" attrs="145">
         <size>10</size>
+      </method>
+    </type>
+    <type name="Test+D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -46951,9 +47265,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Test">
       <method name="Int32 Main()" attrs="150">
@@ -46974,6 +47285,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -47019,11 +47333,6 @@
         <size>18</size>
       </method>
     </type>
-    <type name="BugClass+Foo">
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
-    </type>
     <type name="Bug">
       <method name="Void Main()" attrs="150">
         <size>2</size>
@@ -47045,6 +47354,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -47312,7 +47624,7 @@
       <method name="Void Main()" attrs="150">
         <size>2</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6278">
+      <method name="Void .ctor(System.String)" attrs="6278">
         <size>26</size>
       </method>
     </type>
@@ -47424,11 +47736,6 @@
     </type>
   </test>
   <test name="test-700.cs">
-    <type name="FooAttribute">
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>8</size>
-      </method>
-    </type>
     <type name="Test">
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
@@ -47440,6 +47747,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="FooAttribute">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>8</size>
       </method>
     </type>
   </test>
@@ -47464,7 +47776,7 @@
       <method name="Void .ctor(Int32)" attrs="6278">
         <size>9</size>
       </method>
-      <method name="Void .ctor(String, Int32)" attrs="6278">
+      <method name="Void .ctor(System.String, Int32)" attrs="6278">
         <size>16</size>
       </method>
     </type>
@@ -47616,13 +47928,6 @@
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
       </method>
-    </type>
-    <type name="A+ADelegate">
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
-    </type>
-    <type name="A">
       <method name="ADelegate Delegate2(Boolean)" attrs="150">
         <size>50</size>
       </method>
@@ -47635,6 +47940,9 @@
         <size>0</size>
       </method>
       <method name="ADelegate EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -47665,7 +47973,7 @@
       </method>
     </type>
     <type name="MethodSignature">
-      <method name="Void .ctor(String, Type, Type[])" attrs="6278">
+      <method name="Void .ctor(System.String, System.Type, System.Type[])" attrs="6278">
         <size>23</size>
       </method>
     </type>
@@ -47918,9 +48226,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="N.Child">
       <method name="Void OnExample()" attrs="134">
@@ -47952,6 +48257,11 @@
       </method>
       <method name="Void remove_Example(ExampleHandler)" attrs="2246">
         <size>42</size>
+      </method>
+    </type>
+    <type name="N.Parent+ExampleHandler">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -48036,9 +48346,6 @@
       <method name="Int32 Invoke(Int32 ByRef)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="B">
       <method name="Int32 Main()" attrs="150">
@@ -48053,6 +48360,9 @@
         <size>0</size>
       </method>
       <method name="Int32 EndInvoke(Int32 ByRef, System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -48164,13 +48474,13 @@
       <method name="Int32 Invoke(Int32)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(Int32, System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -48276,9 +48586,6 @@
       <method name="Void Invoke(T)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Test">
       <method name="Void add_Event(System.EventHandler)" attrs="2182">
@@ -48310,6 +48617,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -48673,9 +48983,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Bug.A">
       <method name="Void add_E(Bug.D)" attrs="3526">
@@ -48712,6 +49019,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -48890,9 +49200,6 @@
       <method name="Void Invoke(System.String)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="StaticDelegateWithSameNameAsInstance">
       <method name="Void set_MyProvider(Provider)" attrs="2177">
@@ -48904,6 +49211,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -49137,10 +49447,10 @@
       </method>
     </type>
     <type name="Foo">
-      <method name="Void .ctor(Object)" attrs="6278">
+      <method name="Void .ctor(System.Object)" attrs="6278">
         <size>18</size>
       </method>
-      <method name="Void .ctor(String, Object[])" attrs="6278">
+      <method name="Void .ctor(System.String, System.Object[])" attrs="6278">
         <size>8</size>
       </method>
     </type>
@@ -49439,9 +49749,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="E">
       <method name="Void add_temp(D)" attrs="2182">
@@ -49479,6 +49786,11 @@
     <type name="A">
       <method name="Void &lt;Test&gt;m__0()" attrs="145">
         <size>2</size>
+      </method>
+    </type>
+    <type name="D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -50461,21 +50773,10 @@
       <method name="Void Invoke(System.Object, PersonArrivedArgs)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
-    </type>
-    <type name="PersonArrivedArgs">
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>15</size>
-      </method>
     </type>
     <type name="Greeter">
       <method name="Void HandlePersonArrived(System.Object, PersonArrivedArgs)" attrs="134">
         <size>19</size>
-      </method>
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>15</size>
       </method>
     </type>
     <type name="Room">
@@ -50506,6 +50807,19 @@
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="PersonArrivedArgs">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>15</size>
+      </method>
+    </type>
+    <type name="Greeter">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -50571,11 +50885,11 @@
       </method>
     </type>
     <type name="MainClass+DC">
-      <method name="Void .ctor(Guid)" attrs="6278">
-        <size>9</size>
-      </method>
       <method name="System.Guid get_Id()" attrs="2182">
         <size>15</size>
+      </method>
+      <method name="Void .ctor(System.Guid)" attrs="6278">
+        <size>9</size>
       </method>
     </type>
   </test>
@@ -50593,9 +50907,6 @@
       <method name="Int32 get_Item(System.Object)" attrs="2182">
         <size>10</size>
       </method>
-      <method name="Void .ctor(Object)" attrs="6278">
-        <size>19</size>
-      </method>
       <method name="Void .ctor(Int32)" attrs="6276">
         <size>15</size>
       </method>
@@ -50606,6 +50917,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>9</size>
+      </method>
+    </type>
+    <type name="A">
+      <method name="Void .ctor(System.Object)" attrs="6278">
+        <size>19</size>
       </method>
     </type>
   </test>
@@ -51081,7 +51397,7 @@
       </method>
     </type>
     <type name="ConditionalAttributeTesting.SomeAttribute">
-      <method name="Void .ctor(String)" attrs="6278">
+      <method name="Void .ctor(System.String)" attrs="6278">
         <size>8</size>
       </method>
     </type>
@@ -51643,9 +51959,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="C+E`1[T]">
       <method name="Void add_EEvent(EMethod)" attrs="2182">
@@ -51660,6 +51973,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -52060,7 +52376,7 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -52576,9 +52892,6 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Program+DelegateInt">
       <method name="Int32 Invoke(System.String)" attrs="454">
@@ -52588,9 +52901,6 @@
         <size>0</size>
       </method>
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -52609,6 +52919,16 @@
       </method>
       <method name="Int32 &lt;Main&gt;m__0()" attrs="145">
         <size>9</size>
+      </method>
+    </type>
+    <type name="Program+DelegateVoid">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Program+DelegateInt">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -52759,7 +53079,7 @@
       </method>
     </type>
     <type name="ConditionalAttributeTesting.SomeAttribute">
-      <method name="Void .ctor(String)" attrs="6278">
+      <method name="Void .ctor(System.String)" attrs="6278">
         <size>8</size>
       </method>
     </type>
@@ -52905,13 +53225,13 @@
       <method name="Void Invoke(System.Object, N1.A)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(System.Object, N1.A, System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -52966,9 +53286,6 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="M">
       <method name="Void set_Item(Int32, Int32)" attrs="2177">
@@ -52987,6 +53304,11 @@
     <type name="B">
       <method name="Void Bar(Int32)" attrs="150">
         <size>2</size>
+      </method>
+    </type>
+    <type name="D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -53033,9 +53355,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="X">
       <method name="Int32 Main()" attrs="150">
@@ -53060,14 +53379,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-02.cs">
     <type name="S">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -53094,14 +53413,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-03.cs">
     <type name="S">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -53128,14 +53447,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-04.cs">
     <type name="S">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -53162,14 +53481,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-05.cs">
     <type name="S">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -53204,14 +53523,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-06.cs">
     <type name="S">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -53238,14 +53557,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-07.cs">
     <type name="D">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -53278,14 +53597,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-08.cs">
     <type name="S">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -53312,6 +53631,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-09.cs">
@@ -53325,9 +53647,6 @@
     </type>
     <type name="X+D">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -53346,6 +53665,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-10.cs">
@@ -53362,9 +53684,6 @@
     </type>
     <type name="S+T">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -53388,6 +53707,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-100.cs">
@@ -53409,9 +53731,6 @@
   <test name="test-anon-101.cs">
     <type name="Foo">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -53444,6 +53763,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-102.cs">
@@ -53451,15 +53773,9 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Foo">
       <method name="Simple Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -53509,13 +53825,20 @@
         <size>7</size>
       </method>
     </type>
+    <type name="Simple">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Foo">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-103.cs">
     <type name="Foo`1[S]">
       <method name="Void Invoke(S)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -53541,6 +53864,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -53594,9 +53920,6 @@
   <test name="test-anon-105.cs">
     <type name="Hello">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -53662,13 +53985,15 @@
         <size>14</size>
       </method>
     </type>
+    <type name="Hello">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-106.cs">
     <type name="Foo`2[R,S]">
       <method name="Void Invoke(R, S)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -53699,6 +54024,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -53768,9 +54096,6 @@
       <method name="Int32 Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="X">
       <method name="Void Main()" attrs="150">
@@ -53803,14 +54128,14 @@
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-109.cs">
     <type name="Foo">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -53909,26 +54234,20 @@
         <size>12</size>
       </method>
     </type>
+    <type name="Foo">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-11.cs">
     <type name="D">
       <method name="Void Invoke(Int32)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="E">
       <method name="Void Invoke(Int32 ByRef)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
-    </type>
-    <type name="F">
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -53981,6 +54300,21 @@
         <size>2</size>
       </method>
     </type>
+    <type name="D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="E">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="F">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-110.cs">
     <type name="X">
@@ -54030,9 +54364,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Test`1[R]">
       <method name="Void World[S,T](S, T)" attrs="134">
@@ -54068,14 +54399,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-112.cs">
     <type name="Foo">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -54113,6 +54444,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-113.cs">
@@ -54126,9 +54460,6 @@
     </type>
     <type name="X+ModuleBinder`1[T]">
       <method name="T Invoke(System.Object)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -54148,6 +54479,11 @@
     <type name="X">
       <method name="TDelegate &lt;CreateMethodUnscoped`1&gt;m__0[TDelegate](System.Object)" attrs="145">
         <size>15</size>
+      </method>
+    </type>
+    <type name="X+ModuleBinder`1[T]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -54175,15 +54511,9 @@
       <method name="Void Invoke(V)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Bar`1[W]">
       <method name="Void Invoke(W)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -54235,22 +54565,26 @@
         <size>7</size>
       </method>
     </type>
+    <type name="Foo`1[V]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Bar`1[W]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-116.cs">
     <type name="TestFunc`1[T]">
       <method name="Void Invoke(T)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="A">
       <method name="Void Main()" attrs="150">
         <size>2</size>
-      </method>
-      <method name="Void .ctor(TestFunc`1)" attrs="6278">
-        <size>8</size>
       </method>
     </type>
     <type name="TestClass">
@@ -54274,6 +54608,16 @@
         <size>2</size>
       </method>
     </type>
+    <type name="TestFunc`1[T]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="A">
+      <method name="Void .ctor(TestFunc`1[System.Int32])" attrs="6278">
+        <size>8</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-117.cs">
     <type name="C">
@@ -54286,9 +54630,6 @@
     </type>
     <type name="C+Func`1[T]">
       <method name="T Invoke(T)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -54313,6 +54654,11 @@
         <size>10</size>
       </method>
     </type>
+    <type name="C+Func`1[T]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-118.cs">
     <type name="C">
@@ -54328,9 +54674,6 @@
     </type>
     <type name="C+Func`2[TR,TA]">
       <method name="TR Invoke(TA)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -54362,6 +54705,11 @@
       </method>
       <method name="System.String &lt;Main&gt;m__3(Int32)" attrs="145">
         <size>14</size>
+      </method>
+    </type>
+    <type name="C+Func`2[TR,TA]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -54399,9 +54747,6 @@
       <method name="Boolean Invoke(System.Object)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="X">
       <method name="Int32 Main()" attrs="150">
@@ -54425,6 +54770,11 @@
     <type name="X">
       <method name="Boolean &lt;Main&gt;m__0(System.Object)" attrs="145">
         <size>20</size>
+      </method>
+    </type>
+    <type name="predicate">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -54457,9 +54807,6 @@
   <test name="test-anon-121.cs">
     <type name="EmptyDelegate">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -54497,6 +54844,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-122.cs">
@@ -54504,15 +54854,9 @@
       <method name="Int32 Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="D2">
       <method name="Int64 Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -54557,6 +54901,16 @@
         <size>10</size>
       </method>
     </type>
+    <type name="D1">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="D2">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-123.cs">
     <type name="MemberAccessData">
@@ -54594,9 +54948,6 @@
     </type>
     <type name="C+D">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -54652,6 +55003,11 @@
       </method>
       <method name="Void &lt;Main&gt;m__6()" attrs="145">
         <size>4</size>
+      </method>
+    </type>
+    <type name="C+D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -54874,11 +55230,6 @@
     </type>
   </test>
   <test name="test-anon-125.cs">
-    <type name="HS`1[T]">
-      <method name="Void .ctor(IEqualityComparer`1)" attrs="6278">
-        <size>8</size>
-      </method>
-    </type>
     <type name="Test">
       <method name="Int32 Main()" attrs="150">
         <size>16</size>
@@ -54898,6 +55249,11 @@
     <type name="Test">
       <method name="Void Foo[T](System.Collections.Generic.IEqualityComparer`1[T])" attrs="145">
         <size>28</size>
+      </method>
+    </type>
+    <type name="HS`1[T]">
+      <method name="Void .ctor(System.Collections.Generic.IEqualityComparer`1[T])" attrs="6278">
+        <size>8</size>
       </method>
     </type>
   </test>
@@ -54952,9 +55308,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="C">
       <method name="Void Main()" attrs="150">
@@ -54982,6 +55335,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -55013,13 +55369,13 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -55035,9 +55391,6 @@
     </type>
     <type name="Test+Creator`1[T]">
       <method name="T Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -55070,14 +55423,14 @@
       <method name="T EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-13.cs">
     <type name="D">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -55105,6 +55458,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-130.cs">
@@ -55112,15 +55468,9 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Foo">
       <method name="Simple Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -55168,6 +55518,16 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="Simple">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Foo">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -55273,9 +55633,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Test+&lt;Main&gt;c__AnonStorey0">
       <method name="Void &lt;&gt;m__0()" attrs="131">
@@ -55290,6 +55647,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -55348,9 +55708,6 @@
       <method name="Void Invoke(System.Object)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Foo`1[T]">
       <method name="Void add_handler(Handler`1[T])" attrs="2177">
@@ -55385,6 +55742,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -55470,9 +55830,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Test+&lt;Test_1&gt;c__AnonStorey0`1[T]">
       <method name="Void &lt;&gt;m__0()" attrs="131">
@@ -55514,6 +55871,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-14.cs">
@@ -55532,9 +55892,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="X">
       <method name="Void add_Click(T)" attrs="2193">
@@ -55551,6 +55908,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-140.cs">
@@ -55561,9 +55921,6 @@
     </type>
     <type name="Test1.Foo">
       <method name="Int32 Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -55603,6 +55960,9 @@
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-141.cs">
@@ -55640,9 +56000,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
@@ -55653,6 +56010,11 @@
     <type name="Test">
       <method name="Void &lt;Test_3`1&gt;m__0[T]()" attrs="145">
         <size>12</size>
+      </method>
+    </type>
+    <type name="Test+D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -55795,21 +56157,10 @@
       <method name="TResult Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="GeneratorNext`1[T]">
       <method name="Void Invoke(T ByRef)" attrs="454">
         <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
-    </type>
-    <type name="GeneratorEnumerable`1[T]">
-      <method name="Void .ctor(Func`1)" attrs="6278">
-        <size>8</size>
       </method>
     </type>
     <type name="GeneratorExpression">
@@ -55857,6 +56208,21 @@
         <size>0</size>
       </method>
     </type>
+    <type name="Func`1[TResult]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="GeneratorNext`1[T]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="GeneratorEnumerable`1[T]">
+      <method name="Void .ctor(Func`1[GeneratorNext`1[T]])" attrs="6278">
+        <size>8</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-149.cs">
     <type name="Test">
@@ -55897,16 +56263,6 @@
       </method>
     </type>
     <type name="Foo+foo_fn">
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
-    </type>
-    <type name="Foo+Inner">
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>8</size>
-      </method>
-    </type>
-    <type name="Foo+foo_fn">
       <method name="Inner Invoke(System.String)" attrs="454">
         <size>0</size>
       </method>
@@ -55920,6 +56276,16 @@
     <type name="Foo">
       <method name="Inner &lt;Main&gt;m__0(System.String)" attrs="145">
         <size>21</size>
+      </method>
+    </type>
+    <type name="Foo+foo_fn">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Foo+Inner">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>8</size>
       </method>
     </type>
   </test>
@@ -55947,9 +56313,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="SomeGenericClass`1+&lt;FailsToCompile&gt;c__AnonStorey0[SomeType]">
       <method name="Void .ctor()" attrs="6278">
@@ -55971,14 +56334,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-151.cs">
     <type name="Bla">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -56009,6 +56372,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -56065,9 +56431,6 @@
       <method name="Void Invoke(System.Collections.Generic.List`1[System.Int32] ByRef)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="TestComp.Program+MyClass">
       <method name="Void MyTemplate(MyDelegate)" attrs="129">
@@ -56085,6 +56448,11 @@
     <type name="TestComp.Program+MyClass">
       <method name="Void &lt;UseATemplate&gt;m__0(System.Collections.Generic.List`1[System.Int32] ByRef)" attrs="145">
         <size>17</size>
+      </method>
+    </type>
+    <type name="TestComp.Program+MyClass+MyDelegate">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -56140,9 +56508,6 @@
       <method name="Void SomeAction()" attrs="134">
         <size>19</size>
       </method>
-      <method name="Void .ctor(Action`1)" attrs="6273">
-        <size>15</size>
-      </method>
     </type>
     <type name="Program">
       <method name="Void Main()" attrs="150">
@@ -56160,6 +56525,11 @@
     <type name="Program">
       <method name="System.Object &lt;Main&gt;m__0(System.Object)" attrs="145">
         <size>9</size>
+      </method>
+    </type>
+    <type name="Thing`1[TFirst]">
+      <method name="Void .ctor(System.Action`1[TFirst])" attrs="6273">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -56190,9 +56560,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="C+&lt;cf&gt;c__AnonStorey0`1[T]">
       <method name="Void &lt;&gt;m__0()" attrs="131">
@@ -56209,14 +56576,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-157.cs">
     <type name="Foo">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -56247,6 +56614,11 @@
     <type name="X`1[T]">
       <method name="Void &lt;Test&gt;m__0()" attrs="145">
         <size>8</size>
+      </method>
+    </type>
+    <type name="Foo">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -56332,9 +56704,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="X">
       <method name="Void Main()" attrs="150">
@@ -56355,6 +56724,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -56437,9 +56809,6 @@
       <method name="Void Invoke(System.Object)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="T">
       <method name="Void Assert(System.Object)" attrs="129">
@@ -56485,6 +56854,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -56712,9 +57086,6 @@
       <method name="Int32 Invoke(Int32)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Test">
       <method name="Void Run(RunDelegate)" attrs="134">
@@ -56738,6 +57109,11 @@
       </method>
       <method name="Int32 &lt;Main&gt;m__2(Int32)" attrs="145">
         <size>42</size>
+      </method>
+    </type>
+    <type name="Test+RunDelegate">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -56767,9 +57143,6 @@
   <test name="test-anon-17.cs">
     <type name="ClickEvent">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -56809,6 +57182,11 @@
     <type name="X">
       <method name="Void &lt;Main&gt;m__0()" attrs="145">
         <size>18</size>
+      </method>
+    </type>
+    <type name="ClickEvent">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -56978,9 +57356,6 @@
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Foo">
       <method name="Void Main()" attrs="145">
@@ -56991,6 +57366,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="F">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -57005,9 +57385,6 @@
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Foo">
       <method name="Void Main()" attrs="145">
@@ -57018,6 +57395,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="F">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -57111,9 +57493,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="DelegateTest">
       <method name="Void Main(System.String[])" attrs="150">
@@ -57138,14 +57517,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-19.cs">
     <type name="S">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -57180,14 +57559,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-20.cs">
     <type name="D">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -57225,14 +57604,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-21.cs">
     <type name="D">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -57273,14 +57652,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-22.cs">
     <type name="D">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -57318,14 +57697,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-23.cs">
     <type name="D">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -57363,14 +57742,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-24.cs">
     <type name="D">
       <method name="Int32 Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -57400,14 +57779,14 @@
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-25.cs">
     <type name="D">
       <method name="Int32 Invoke(Int32)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -57437,6 +57816,9 @@
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-26.cs">
@@ -57450,9 +57832,6 @@
     </type>
     <type name="TestGotoLabels.GotoLabelsTest+MyDelegate">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -57474,13 +57853,15 @@
         <size>12</size>
       </method>
     </type>
+    <type name="TestGotoLabels.GotoLabelsTest+MyDelegate">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-27.cs">
     <type name="D">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -57516,6 +57897,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -57568,15 +57952,9 @@
       <method name="System.String Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="X+Bar">
       <method name="Void Invoke(System.String)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -57604,6 +57982,16 @@
         <size>8</size>
       </method>
     </type>
+    <type name="X+Foo">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="X+Bar">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-30.cs">
     <type name="X">
@@ -57618,9 +58006,6 @@
     </type>
     <type name="Program+D">
       <method name="Void Invoke(X)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -57647,6 +58032,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-31.cs">
@@ -57660,9 +58048,6 @@
     </type>
     <type name="X+test">
       <method name="System.Object Invoke(System.Reflection.MethodInfo)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -57684,21 +58069,20 @@
         <size>26</size>
       </method>
     </type>
+    <type name="X+test">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-32.cs">
     <type name="StringSender">
       <method name="Void Invoke(System.String)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="VoidDelegate">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -57740,13 +58124,20 @@
         <size>0</size>
       </method>
     </type>
+    <type name="StringSender">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="VoidDelegate">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-33.cs">
     <type name="Do">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -57784,6 +58175,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-34.cs">
@@ -57797,9 +58191,6 @@
     </type>
     <type name="Delegates.Space+DoCopy">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -57839,6 +58230,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-35.cs">
@@ -57852,9 +58246,6 @@
     </type>
     <type name="ExceptionWithAnonMethod+EmptyCallback">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -57878,6 +58269,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-36.cs">
@@ -57896,15 +58290,9 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="TestMethod2">
       <method name="Void Invoke(System.Object)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -57929,6 +58317,16 @@
         <size>2</size>
       </method>
     </type>
+    <type name="TestMethod">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="TestMethod2">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-37.cs">
     <type name="DelegateInit">
@@ -57946,9 +58344,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
@@ -57961,21 +58356,20 @@
         <size>12</size>
       </method>
     </type>
+    <type name="DelegateInit+FooDelegate">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-38.cs">
     <type name="Simple">
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Foo">
       <method name="Simple Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -58025,21 +58419,25 @@
         <size>0</size>
       </method>
     </type>
+    <type name="Simple">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Foo">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-39.cs">
     <type name="Simple">
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Foo">
       <method name="Simple Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -58081,6 +58479,16 @@
         <size>0</size>
       </method>
       <method name="Simple EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Simple">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Foo">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -58090,15 +58498,9 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Foo">
       <method name="Simple Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -58143,21 +58545,25 @@
         <size>0</size>
       </method>
     </type>
+    <type name="Simple">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Foo">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-41.cs">
     <type name="Simple">
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Foo">
       <method name="Simple Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -58207,21 +58613,25 @@
         <size>0</size>
       </method>
     </type>
+    <type name="Simple">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Foo">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-42.cs">
     <type name="Simple">
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Foo">
       <method name="Simple Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -58263,21 +58673,25 @@
         <size>9</size>
       </method>
     </type>
+    <type name="Simple">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Foo">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-43.cs">
     <type name="Simple">
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Foo">
       <method name="Simple Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -58327,21 +58741,25 @@
         <size>0</size>
       </method>
     </type>
+    <type name="Simple">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Foo">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-44.cs">
     <type name="Simple">
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Foo">
       <method name="Simple Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -58401,13 +58819,20 @@
         <size>0</size>
       </method>
     </type>
+    <type name="Simple">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Foo">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-45.cs">
     <type name="TestFunc">
       <method name="Void Invoke(Int32)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -58440,13 +58865,15 @@
         <size>8</size>
       </method>
     </type>
+    <type name="TestFunc">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-46.cs">
     <type name="Foo">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -58484,14 +58911,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-47.cs">
     <type name="Foo">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -58539,14 +58966,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-48.cs">
     <type name="Foo">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -58592,6 +59019,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -58684,9 +59114,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="X">
       <method name="Void Main()" attrs="150">
@@ -58712,6 +59139,11 @@
         <size>12</size>
       </method>
     </type>
+    <type name="FooDelegate">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-52.cs">
     <type name="X">
@@ -58724,9 +59156,6 @@
     </type>
     <type name="X+A">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -58770,14 +59199,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-53.cs">
     <type name="Foo">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -58820,14 +59249,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-54.cs">
     <type name="Hello">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -58868,6 +59297,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-55.cs">
@@ -58887,9 +59319,6 @@
     </type>
     <type name="Foo+Hello">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -58913,14 +59342,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-56.cs">
     <type name="QueueHandler">
       <method name="Void Invoke(Observable)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -58945,6 +59374,11 @@
         <size>12</size>
       </method>
     </type>
+    <type name="QueueHandler">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-57.cs">
     <type name="X">
@@ -58960,9 +59394,6 @@
     </type>
     <type name="X+TestDelegate">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -58986,6 +59417,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-58.cs">
@@ -59002,9 +59436,6 @@
     </type>
     <type name="X+TestDelegate">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -59033,6 +59464,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-59.cs">
@@ -59049,9 +59483,6 @@
     </type>
     <type name="X+TestDelegate">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -59085,6 +59516,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-60.cs">
@@ -59101,9 +59535,6 @@
     </type>
     <type name="X+TestDelegate">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -59145,6 +59576,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-61.cs">
@@ -59161,9 +59595,6 @@
     </type>
     <type name="X+TestDelegate">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -59187,6 +59618,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-62.cs">
@@ -59194,16 +59628,10 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="X">
       <method name="Void Main()" attrs="150">
         <size>2</size>
-      </method>
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>15</size>
       </method>
     </type>
     <type name="Y">
@@ -59234,6 +59662,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="X">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>15</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-63.cs">
@@ -59247,9 +59683,6 @@
     </type>
     <type name="X+A">
       <method name="Int32 Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -59296,6 +59729,9 @@
         <size>0</size>
       </method>
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -59351,9 +59787,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="TestClass">
       <method name="Int32 Main(System.String[])" attrs="150">
@@ -59378,6 +59811,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-66.cs">
@@ -59391,9 +59827,6 @@
     </type>
     <type name="Test+TestEventHandler">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -59426,6 +59859,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-67.cs">
@@ -59436,15 +59872,9 @@
       <method name="Void .ctor(ReturnStringDelegate)" attrs="6278">
         <size>8</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>33</size>
-      </method>
     </type>
     <type name="ClassOne+ReturnStringDelegate">
       <method name="System.String Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -59464,21 +59894,25 @@
         <size>0</size>
       </method>
     </type>
+    <type name="ClassOne">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>33</size>
+      </method>
+    </type>
+    <type name="ClassOne+ReturnStringDelegate">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-68.cs">
     <type name="D1">
       <method name="Void Invoke(Int32)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="D2">
       <method name="Void Invoke(System.String ByRef)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -59520,13 +59954,20 @@
         <size>9</size>
       </method>
     </type>
+    <type name="D1">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="D2">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-69.cs">
     <type name="TargetAccessDelegate">
       <method name="System.Object Invoke(System.Object)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -59559,6 +60000,9 @@
       <method name="System.Object EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-70.cs">
@@ -59583,9 +60027,6 @@
     </type>
     <type name="C+D">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -59629,6 +60070,11 @@
         <size>17</size>
       </method>
     </type>
+    <type name="C+D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-71.cs">
     <type name="Program">
@@ -59641,9 +60087,6 @@
     </type>
     <type name="Program+FdCb">
       <method name="Int32 Invoke(Int32)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -59670,6 +60113,9 @@
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-72.cs">
@@ -59694,9 +60140,6 @@
       <method name="Boolean Invoke(System.Object, System.Object ByRef)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Test">
       <method name="Void AddOperator(UnaryOperator)" attrs="134">
@@ -59710,14 +60153,14 @@
       <method name="Boolean EndInvoke(System.Object ByRef, System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-73.cs">
     <type name="D">
       <method name="Void Invoke(System.Object)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -59748,6 +60191,11 @@
         <size>32</size>
       </method>
     </type>
+    <type name="D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-74.cs">
     <type name="Foo">
@@ -59757,9 +60205,6 @@
     </type>
     <type name="Foo+SimpleDelegate">
       <method name="System.String[,] Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -59781,13 +60226,15 @@
         <size>42</size>
       </method>
     </type>
+    <type name="Foo+SimpleDelegate">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-75.cs">
     <type name="D">
       <method name="Boolean Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -59839,13 +60286,15 @@
         <size>10</size>
       </method>
     </type>
+    <type name="D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-76.cs">
     <type name="FactoryDelegate">
       <method name="System.Object Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -59876,14 +60325,14 @@
       <method name="System.Object EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-77.cs">
     <type name="D">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -59916,6 +60365,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-78.cs">
@@ -59923,15 +60375,9 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="D2">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -59973,6 +60419,16 @@
         <size>19</size>
       </method>
     </type>
+    <type name="D1">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="D2">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-79.cs">
     <type name="Test">
@@ -59991,9 +60447,6 @@
     </type>
     <type name="Test+D">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -60016,6 +60469,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -60072,15 +60528,9 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="C+Cmd2">
       <method name="Int32 Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -60128,21 +60578,25 @@
         <size>0</size>
       </method>
     </type>
+    <type name="C+Cmd">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="C+Cmd2">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-82.cs">
     <type name="StringSender">
       <method name="Void Invoke(System.String)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="VoidDelegate">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -60171,9 +60625,6 @@
     </type>
     <type name="MainClass+D">
       <method name="Int32 Invoke(Int32)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -60276,6 +60727,21 @@
         <size>10</size>
       </method>
     </type>
+    <type name="StringSender">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="VoidDelegate">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="MainClass+D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-83.cs">
     <type name="C">
@@ -60304,9 +60770,6 @@
       <method name="C Invoke(Int32)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="C">
       <method name="Int32 Main()" attrs="150">
@@ -60332,6 +60795,11 @@
         <size>12</size>
       </method>
     </type>
+    <type name="D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-85.cs">
     <type name="X">
@@ -60344,9 +60812,6 @@
     </type>
     <type name="X+D">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -60363,6 +60828,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -60391,9 +60859,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Bug.A+&lt;A&gt;c__AnonStorey0">
       <method name="Void &lt;&gt;m__0()" attrs="131">
@@ -60410,14 +60875,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-87.cs">
     <type name="Bug.D">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -60428,16 +60893,10 @@
       <method name="Int32 Main()" attrs="150">
         <size>26</size>
       </method>
-      <method name="Void .ctor(BB)" attrs="6278">
-        <size>52</size>
-      </method>
     </type>
     <type name="Bug.BB">
       <method name="Void Foo()" attrs="134">
         <size>2</size>
-      </method>
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>19</size>
       </method>
     </type>
     <type name="Bug.AA+&lt;AA&gt;c__AnonStorey0">
@@ -60455,6 +60914,19 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="Bug.AA">
+      <method name="Void .ctor(Bug.BB)" attrs="6278">
+        <size>52</size>
+      </method>
+    </type>
+    <type name="Bug.BB">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>19</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-88.cs">
@@ -60471,9 +60943,6 @@
     </type>
     <type name="C+D">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -60521,6 +60990,11 @@
         <size>4</size>
       </method>
     </type>
+    <type name="C+D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-anon-89.cs">
     <type name="C">
@@ -60542,9 +61016,6 @@
     </type>
     <type name="C+D">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -60586,6 +61057,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-90.cs">
@@ -60602,9 +61076,6 @@
     </type>
     <type name="C+D">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -60636,6 +61107,9 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-91.cs">
@@ -60662,9 +61136,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="C+&lt;Test&gt;c__AnonStorey0">
       <method name="Void &lt;&gt;m__0()" attrs="131">
@@ -60689,14 +61160,14 @@
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-92.cs">
     <type name="D">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -60727,6 +61198,11 @@
     <type name="MainClass">
       <method name="Void Test(System.Collections.IEnumerable)" attrs="145">
         <size>34</size>
+      </method>
+    </type>
+    <type name="D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -60846,9 +61322,6 @@
       <method name="Int32 Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="A">
       <method name="Void add_Event(D)" attrs="3524">
@@ -60907,6 +61380,9 @@
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-96.cs">
@@ -60928,9 +61404,6 @@
     </type>
     <type name="Program+D">
       <method name="Int32 Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -60965,6 +61438,9 @@
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
     </type>
   </test>
   <test name="test-anon-97.cs">
@@ -60978,9 +61454,6 @@
     </type>
     <type name="Space+DoCopy">
       <method name="Void Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -61013,6 +61486,9 @@
         <size>0</size>
       </method>
       <method name="Void EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -61956,9 +62432,6 @@
       </method>
       <method name="S op_Addition(S, S)" attrs="2198">
         <size>40</size>
-      </method>
-      <method name="Void .ctor(Int32, String)" attrs="6278">
-        <size>24</size>
       </method>
     </type>
     <type name="Base">
@@ -63392,6 +63865,11 @@
         <size>9</size>
       </method>
     </type>
+    <type name="S">
+      <method name="Void .ctor(Int32, System.String)" attrs="6278">
+        <size>24</size>
+      </method>
+    </type>
   </test>
   <test name="test-async-14.cs">
     <type name="C">
@@ -63452,9 +63930,6 @@
       <method name="Void SetValue(Int32)" attrs="134">
         <size>9</size>
       </method>
-      <method name="Void .ctor(Int32, String)" attrs="6278">
-        <size>16</size>
-      </method>
     </type>
     <type name="Tester">
       <method name="System.Threading.Tasks.Task`1[T] NewInitTestGen[T]()" attrs="129">
@@ -63504,6 +63979,11 @@
     <type name="Tester+&lt;NewInitCol&gt;c__async1">
       <method name="Int32 &lt;&gt;m__0()" attrs="145">
         <size>9</size>
+      </method>
+    </type>
+    <type name="S">
+      <method name="Void .ctor(Int32, System.String)" attrs="6278">
+        <size>16</size>
       </method>
     </type>
   </test>
@@ -64051,11 +64531,6 @@
         <size>7</size>
       </method>
     </type>
-    <type name="asyncAttribute+async">
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
-    </type>
     <type name="A+&lt;async&gt;c__async1">
       <method name="Void MoveNext()" attrs="486">
         <size>63</size>
@@ -64100,9 +64575,6 @@
     </type>
     <type name="AwaitNS.Formals+D">
       <method name="Void Invoke(Int32)" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -64265,6 +64737,16 @@
         <size>13</size>
       </method>
     </type>
+    <type name="asyncAttribute+async">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="AwaitNS.Formals+D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
   </test>
   <test name="test-async-23.cs">
     <type name="MyContext">
@@ -64296,13 +64778,6 @@
       <method name="Void MoveNext()" attrs="486">
         <size>197</size>
       </method>
-    </type>
-    <type name="MyContext">
-      <method name="Void .ctor(ManualResetEvent)" attrs="6278">
-        <size>15</size>
-      </method>
-    </type>
-    <type name="TestPostContext+&lt;Test&gt;c__async0">
       <method name="Void SetStateMachine(System.Runtime.CompilerServices.IAsyncStateMachine)" attrs="486">
         <size>13</size>
       </method>
@@ -64310,14 +64785,16 @@
         <size>21</size>
       </method>
     </type>
+    <type name="MyContext">
+      <method name="Void .ctor(System.Threading.ManualResetEvent)" attrs="6278">
+        <size>15</size>
+      </method>
+    </type>
   </test>
   <test name="test-async-24.cs">
     <type name="Struct">
       <method name="System.Threading.Tasks.Task`1[System.Boolean] AsyncMethod()" attrs="134">
         <size>46</size>
-      </method>
-      <method name="Void .ctor(Object)" attrs="6278">
-        <size>9</size>
       </method>
     </type>
     <type name="C">
@@ -64337,6 +64814,11 @@
       </method>
       <method name="Int32 &lt;&gt;m__0()" attrs="145">
         <size>10</size>
+      </method>
+    </type>
+    <type name="Struct">
+      <method name="Void .ctor(System.Object)" attrs="6278">
+        <size>9</size>
       </method>
     </type>
   </test>
@@ -65505,9 +65987,6 @@
       <method name="T Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="X">
       <method name="Void Main()" attrs="150">
@@ -65554,6 +66033,11 @@
     <type name="X">
       <method name="System.Threading.Tasks.Task &lt;Main&gt;m__0()" attrs="145">
         <size>33</size>
+      </method>
+    </type>
+    <type name="ActualValueDelegate`1[T]">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -66792,16 +67276,6 @@
         <size>7</size>
       </method>
     </type>
-    <type name="CB">
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>8</size>
-      </method>
-    </type>
-    <type name="DeviceDetails">
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>8</size>
-      </method>
-    </type>
     <type name="BB">
       <method name="System.Threading.Tasks.Task`1[System.String] GetUser()" attrs="134">
         <size>19</size>
@@ -66830,6 +67304,16 @@
       </method>
       <method name="Void SetStateMachine(System.Runtime.CompilerServices.IAsyncStateMachine)" attrs="486">
         <size>13</size>
+      </method>
+    </type>
+    <type name="CB">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>8</size>
+      </method>
+    </type>
+    <type name="DeviceDetails">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>8</size>
       </method>
     </type>
   </test>
@@ -67181,9 +67665,6 @@
       <method name="CLSDelegate Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="CLSDelegate">
       <method name="Void .ctor()" attrs="6278">
@@ -67279,6 +67760,9 @@
         <size>0</size>
       </method>
       <method name="CLSDelegate EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -67466,9 +67950,6 @@
       <method name="UInt32 Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="CLSClass">
       <method name="Void Main()" attrs="150">
@@ -67480,9 +67961,6 @@
     </type>
     <type name="CLSClass+MyDelegate">
       <method name="UInt32 Invoke()" attrs="454">
-        <size>0</size>
-      </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -67532,6 +68010,16 @@
       </method>
       <method name="Void Test(Int32[,,], Boolean)" attrs="134">
         <size>2</size>
+      </method>
+    </type>
+    <type name="MyDelegate">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
+      </method>
+    </type>
+    <type name="CLSClass+MyDelegate">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -67757,7 +68245,7 @@
       <method name="Void Main()" attrs="150">
         <size>2</size>
       </method>
-      <method name="Void .ctor(ITopic)" attrs="6278">
+      <method name="Void .ctor(Test.ITopic)" attrs="6278">
         <size>32</size>
       </method>
     </type>
@@ -68297,13 +68785,15 @@
       <method name="Void Invoke(System.Runtime.CompilerServices.CallSite, System.Object, System.Object ByRef, System.Object ByRef)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="C">
       <method name="Int32 &lt;Test_4&gt;m__0()" attrs="145">
         <size>10</size>
+      </method>
+    </type>
+    <type name="C+&lt;Test_3&gt;c__DynamicSite2+Container0">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -70578,9 +71068,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="X+&lt;GetIt&gt;c__Iterator0">
       <method name="System.Object System.Collections.Generic.IEnumerator&lt;object&gt;.get_Current()" attrs="2529">
@@ -70631,6 +71118,11 @@
     <type name="X+&lt;GetIt&gt;c__Iterator0">
       <method name="System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()" attrs="481">
         <size>14</size>
+      </method>
+    </type>
+    <type name="X+A">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -70733,9 +71225,6 @@
       <method name="Void Dispose()" attrs="486">
         <size>2</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>8</size>
-      </method>
     </type>
     <type name="UploadAction">
       <method name="Void RunOnThread(System.Action)" attrs="150">
@@ -70787,6 +71276,11 @@
       </method>
       <method name="System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()" attrs="481">
         <size>14</size>
+      </method>
+    </type>
+    <type name="D">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>8</size>
       </method>
     </type>
   </test>
@@ -70841,9 +71335,6 @@
       <method name="Void .ctor()" attrs="6278">
         <size>14</size>
       </method>
-      <method name="Void .ctor(Object)" attrs="6276">
-        <size>8</size>
-      </method>
     </type>
     <type name="B">
       <method name="Void set_Item(Int32, Int32)" attrs="2246">
@@ -70867,6 +71358,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="A">
+      <method name="Void .ctor(System.Object)" attrs="6276">
+        <size>8</size>
       </method>
     </type>
   </test>
@@ -70921,13 +71417,13 @@
       <method name="Int32 Invoke(Int32)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
       <method name="System.IAsyncResult BeginInvoke(Int32, System.AsyncCallback, System.Object)" attrs="454">
         <size>0</size>
       </method>
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
+        <size>0</size>
+      </method>
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
         <size>0</size>
       </method>
     </type>
@@ -71449,9 +71945,6 @@
       <method name="Int32 EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="X">
       <method name="Int32 Main()" attrs="150">
@@ -71462,6 +71955,11 @@
       </method>
       <method name="Int32 &lt;d&gt;m__0(Int32)" attrs="145">
         <size>10</size>
+      </method>
+    </type>
+    <type name="D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -72000,17 +72498,17 @@
         <size>7</size>
       </method>
     </type>
-    <type name="Bar">
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>15</size>
-      </method>
-    </type>
     <type name="PartialAbstractCompilationError">
       <method name="Void Main()" attrs="150">
         <size>22</size>
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="Bar">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>
@@ -72364,9 +72862,6 @@
       <method name="Void Invoke()" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Mono.Sms.Core.Agenda">
       <method name="Void AddContact()" attrs="150">
@@ -72398,6 +72893,11 @@
     <type name="Mono.Sms.Main">
       <method name="Void &lt;Test&gt;m__0()" attrs="145">
         <size>7</size>
+      </method>
+    </type>
+    <type name="Mono.Sms.Contacts+ContactsHandler">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -72638,22 +73138,22 @@
         <size>7</size>
       </method>
     </type>
-    <type name="CustomAttributes.AttributeA">
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>8</size>
-      </method>
-    </type>
-    <type name="CustomAttributes.AttributeB">
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>8</size>
-      </method>
-    </type>
     <type name="X">
       <method name="Void Main()" attrs="150">
         <size>2</size>
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="CustomAttributes.AttributeA">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>8</size>
+      </method>
+    </type>
+    <type name="CustomAttributes.AttributeB">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>8</size>
       </method>
     </type>
   </test>
@@ -72967,11 +73467,11 @@
       </method>
     </type>
     <type name="S">
-      <method name="Void .ctor(Decimal)" attrs="6278">
-        <size>8</size>
-      </method>
       <method name="System.Decimal get_Property()" attrs="2179">
         <size>14</size>
+      </method>
+      <method name="Void .ctor(System.Decimal)" attrs="6278">
+        <size>8</size>
       </method>
     </type>
   </test>
@@ -72983,29 +73483,21 @@
       <method name="Int32 Main()" attrs="150">
         <size>41</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>9</size>
-      </method>
       <method name="Void .ctor(Int32)" attrs="6278">
         <size>20</size>
       </method>
       <method name="Void .cctor()" attrs="6289">
         <size>7</size>
       </method>
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>9</size>
+      </method>
     </type>
   </test>
   <test name="test-primary-ctor-03.cs">
-    <type name="D">
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>8</size>
-      </method>
-    </type>
     <type name="Base">
       <method name="System.String get_Prop()" attrs="2182">
         <size>14</size>
-      </method>
-      <method name="Void .ctor(Object)" attrs="6276">
-        <size>19</size>
       </method>
     </type>
     <type name="X">
@@ -73016,24 +73508,34 @@
         <size>7</size>
       </method>
     </type>
-  </test>
-  <test name="test-primary-ctor-04.cs">
-    <type name="Derived">
-      <method name="Void .ctor(Int32, Byte&amp;, Int32&amp;)" attrs="6278">
-        <size>24</size>
+    <type name="D">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>8</size>
       </method>
     </type>
     <type name="Base">
-      <method name="Void .ctor(Int32&amp;)" attrs="6275">
-        <size>11</size>
+      <method name="Void .ctor(System.Object)" attrs="6276">
+        <size>19</size>
       </method>
     </type>
+  </test>
+  <test name="test-primary-ctor-04.cs">
     <type name="X">
       <method name="Int32 Main()" attrs="150">
         <size>74</size>
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="Derived">
+      <method name="Void .ctor(Int32, Byte ByRef, Int32 ByRef)" attrs="6278">
+        <size>24</size>
+      </method>
+    </type>
+    <type name="Base">
+      <method name="Void .ctor(Int32 ByRef)" attrs="6275">
+        <size>11</size>
       </method>
     </type>
   </test>
@@ -73099,10 +73601,10 @@
       </method>
     </type>
     <type name="S3">
-      <method name="Void .ctor(Int32, String)" attrs="6278">
+      <method name="Void .ctor(Int32, System.String)" attrs="6278">
         <size>9</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6278">
+      <method name="Void .ctor(System.String)" attrs="6278">
         <size>8</size>
       </method>
     </type>
@@ -73128,11 +73630,6 @@
     </type>
   </test>
   <test name="test-primary-ctor-09.cs">
-    <type name="A">
-      <method name="Void .ctor(Func`2)" attrs="6278">
-        <size>14</size>
-      </method>
-    </type>
     <type name="PC">
       <method name="Void .ctor(Int32)" attrs="6278">
         <size>50</size>
@@ -73155,6 +73652,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="A">
+      <method name="Void .ctor(System.Func`2[System.Int32,System.Int32])" attrs="6278">
+        <size>14</size>
       </method>
     </type>
   </test>
@@ -73188,9 +73690,6 @@
       <method name="Int32&amp; EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="X">
       <method name="Void Main()" attrs="150">
@@ -73204,6 +73703,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="D">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -73883,9 +74387,6 @@
       <method name="System.Nullable`1[System.ValueTuple`2[System.Int32,System.Int32]] Method(System.ValueTuple`2[System.Int32,System.Int32] ByRef)" attrs="134">
         <size>18</size>
       </method>
-      <method name="Void .ctor(ValueTuple`2)" attrs="6278">
-        <size>8</size>
-      </method>
     </type>
     <type name="Del">
       <method name="System.ValueTuple`2[System.Int32,System.Int32] Invoke(System.ValueTuple`2[System.Int32,System.Int32])" attrs="454">
@@ -73897,9 +74398,6 @@
       <method name="System.ValueTuple`2[System.Int32,System.Int32] EndInvoke(System.IAsyncResult)" attrs="454">
         <size>0</size>
       </method>
-      <method name="Void .ctor(Object, IntPtr)" attrs="6278">
-        <size>0</size>
-      </method>
     </type>
     <type name="Test">
       <method name="Int32 Main()" attrs="150">
@@ -73907,6 +74405,16 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="C">
+      <method name="Void .ctor(System.ValueTuple`2[System.Int32,System.Int32])" attrs="6278">
+        <size>8</size>
+      </method>
+    </type>
+    <type name="Del">
+      <method name="Void .ctor(System.Object, IntPtr)" attrs="6278">
+        <size>0</size>
       </method>
     </type>
   </test>
@@ -74055,9 +74563,6 @@
       <method name="Void Dispose()" attrs="486">
         <size>13</size>
       </method>
-      <method name="Void .ctor(String)" attrs="6278">
-        <size>15</size>
-      </method>
     </type>
     <type name="Test">
       <method name="Int32 Main()" attrs="150">
@@ -74065,6 +74570,11 @@
       </method>
       <method name="Void .ctor()" attrs="6278">
         <size>7</size>
+      </method>
+    </type>
+    <type name="MyClass">
+      <method name="Void .ctor(System.String)" attrs="6278">
+        <size>15</size>
       </method>
     </type>
   </test>


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/10838.

The new behavior is similar to coreclr's one: https://github.com/dotnet/coreclr/blob/af4ec7c89d0192ad14392da04e8c097da8ec9e48/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs#L145