### PR TITLE
Restore typecheck to corlib version check, so that mixing old integer with new string errors w/o crash.

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -371,6 +371,8 @@ mono_get_corlib_version (void)
 	char *value;
 	MonoTypeEnum field_type;
 	const char *data = mono_class_get_field_default_value (field, &field_type);
+	if (field_type != MONO_TYPE_STRING)
+		return NULL;
 	mono_metadata_read_constant_value (data, field_type, &value, error);
 	mono_error_assert_ok (error);
 


### PR DESCRIPTION
i.e. to  avoid this crash https://gist.github.com/mhutch/d4e6f7b42e5d0fe31434af316264bd84

Instead it will give the admittedly ambiguous:
```
Corlib not in sync with this runtime: expected corlib string (BEAF66F4-BA36-44C5-974E-83C6F627DF8C) but not found or not string
```

Originally https://github.com/mono/mono/commit/c6b8cecb9d6c547d7c5d58721cbf472caa3aae9f#diff-d51dc4dc4a7d7b173dc78504e0be7fa7R372 but later lost.
