### PR TITLE
[2018-10] [runtime] Disable stack guard for main thread on osx

### DIFF
--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2737,7 +2737,7 @@ mono_setup_altstack (MonoJitTlsData *tls)
 	 * On macOS Mojave we are encountering a bug when changing mapping for main thread
 	 * stack pages. Stack overflow on main thread will kill the app.
 	 */
-	gboolean disable_stack_guard = pthread_main_np ();
+	gboolean disable_stack_guard = mono_threads_platform_is_main_thread ();
 #else
 	gboolean disable_stack_guard = FALSE;
 #endif

--- a/mono/utils/mono-threads-mach.c
+++ b/mono/utils/mono-threads-mach.c
@@ -265,4 +265,9 @@ mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize)
 	*staddr -= *stsize;
 }
 
+gboolean
+mono_threads_platform_is_main_thread (void)
+{
+	return pthread_main_np () == 1;
+}
 #endif

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -586,6 +586,7 @@ mono_thread_platform_create_thread (MonoThreadStart thread_fn, gpointer thread_d
 	gsize* const stack_size, MonoNativeThreadId *tid);
 
 void mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize);
+gboolean mono_threads_platform_is_main_thread (void);
 void mono_threads_platform_init (void);
 gboolean mono_threads_platform_in_critical_region (MonoNativeThreadId tid);
 gboolean mono_threads_platform_yield (void);


### PR DESCRIPTION
Backport of #10899.

/cc @luhenry @BrzVlad

Description of #10899:
On macOS Mojave, it seems that changing the mapping of stack pages for main thread can lead to corruption bugs.

https://github.com/mono/mono/issues/10802



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
