### PR TITLE
[mcs] Fix test compilation to use common target and refactor mono-symbolicate test building

### DIFF
--- a/mcs/errors/Makefile
+++ b/mcs/errors/Makefile
@@ -47,14 +47,7 @@ ifdef VALID_PROFILE
 
 qcheck: run-mcs-tests 
 
-# again, run-test is when the tests actually happen, so
-# don't compile on make test.
-
-test-local:
-	@:
-
-run-test-local: clean-local
-	$(MAKE) run-mcs-tests
+run-test-local: test-local qcheck
 
 check: run-test-local
 
@@ -67,7 +60,9 @@ TESTER_OPTIONS = -compiler-options:"-v --break-on-ice -d:NET_4_0;NET_4_5"
 COMPILER = $(topdir)/class/lib/$(PROFILE)/mcs.exe
 TESTER = MONO_RUNTIME='$(RUNTIME)' $(TEST_RUNTIME) $(TEST_RUNTIME_FLAGS) $(LOCAL_RUNTIME_FLAGS) $(topdir)/class/lib/$(PROFILE)/compiler-tester.exe
 
-run-mcs-tests: $(TEST_SUPPORT_FILES)
+test-local: $(TEST_SUPPORT_FILES)
+
+run-mcs-tests: test-local
 	$(TESTER) -mode:neg -files:$(TEST_PATTERN) -compiler:$(COMPILER) -reference-dir:$(topdir)/class/lib/$(PROFILE) -issues:known-issues-$(PROFILE) -log:$(PROFILE).log $(TESTER_OPTIONS) $(TOPTIONS)
 
 endif
@@ -113,13 +108,13 @@ dlls/cs1703-2/System.dll: $(topdir)/../external/binary-reference-assemblies/v2.0
 	mkdir -p $(dir $@)
 	cp $< $@
 
-CS1701-lib.dll : CS1701-lib.cs
+CS1701-lib.dll : CS1701-lib.cs dlls/first/CS1701-lib.dll
 	$(CSCOMPILE) /r:$(topdir)/class/lib/$(PROFILE_DIRECTORY)/mscorlib.dll /target:library /warn:0 /r:dlls/first/CS1701-lib.dll /out:$@ $<
 
-CS1702-lib.dll : CS1702-lib.cs
+CS1702-lib.dll : CS1702-lib.cs dlls/first/CS1702-lib.dll
 	$(CSCOMPILE) /r:$(topdir)/class/lib/$(PROFILE_DIRECTORY)/mscorlib.dll /target:library /warn:0 /r:dlls/first/CS1702-lib.dll /out:$@ $<
 
-CS1705-lib.dll : CS1705-lib.cs
+CS1705-lib.dll : CS1705-lib.cs dlls/first/CS1705-lib.dll
 	$(CSCOMPILE) /r:$(topdir)/class/lib/$(PROFILE_DIRECTORY)/mscorlib.dll /target:library /warn:0 /r:dlls/first/CS1705-lib.dll /out:$@ $<
 
 CSFriendAssembly-lib.dll : CSFriendAssembly-lib.cs

--- a/mcs/tests/Makefile
+++ b/mcs/tests/Makefile
@@ -1,5 +1,5 @@
 #
-# use make run-test PROFILE=net_2_0
+# use make run-test
 #
 
 thisdir = tests
@@ -57,7 +57,14 @@ LOCAL_RUNTIME_FLAGS = --verify-all
 COMPILER = $(topdir)/class/lib/$(PROFILE)/mcs.exe
 TESTER = MONO_RUNTIME='$(RUNTIME)' $(TEST_RUNTIME) $(TEST_RUNTIME_FLAGS) $(LOCAL_RUNTIME_FLAGS) $(topdir)/class/lib/$(PROFILE)/compiler-tester.exe
 
-TEST_ILS := $(wildcard *-lib.il)
+TEST_IL := $(wildcard *-lib.il) dlls/test-883.il
+TEST_CS := \
+	dlls/test-679-2/test-679-lib-2.cs \
+	dlls/test-679-1/test-679-lib.cs \
+	dlls/test-939-common.cs \
+	dlls/test-939-1/test-939-lib.cs \
+	dlls/test-939-1/test-939-ref.cs \
+	dlls/test-939-2/test-939-lib.cs
 
 build-compiler-lib:
 	cd ../class/Mono.CSharp && $(MAKE) NO_DIR_CHECK=yes
@@ -77,14 +84,9 @@ gen-mt-tests:
 	$(TESTER) -mode:nunit -files:'v2' -compiler:$(COMPILER) -reference-dir:$(topdir)/class/lib/$(PROFILE) -issues:known-issues-mt -compiler-options:"-lib:$(topdir)/class/lib/monotouch projects/MonoTouch/ivt.cs"
 
 
-TESTERVERBOSE=$(if $(V),-verbose,)
+test-local: $(TEST_IL:.il=.dll) $(TEST_CS:.cs=.dll)
 
-test-local:
-	@:
-
-compile-all: $(TEST_ILS:.il=.dll)
-
-run-test-local: compile-all setup qcheck
+run-test-local: test-local qcheck
 
 check: run-test-local
 
@@ -108,11 +110,23 @@ csproj-local:
 
 CSCOMPILE_UTIL = $(CSCOMPILE) -noconfig -nologo -r:$(topdir)/class/lib/$(PROFILE)/mscorlib.dll
 
-setup:
-	$(CSCOMPILE_UTIL) -t:library dlls/test-679-2/test-679-lib-2.cs -out:dlls/test-679-2/test-679-lib-2.dll
-	$(CSCOMPILE_UTIL) -t:library dlls/test-679-1/test-679-lib.cs -r:dlls/test-679-2/test-679-lib-2.dll -out:dlls/test-679-1/test-679-lib.dll
-	$(CSCOMPILE_UTIL) -t:library dlls/test-939-common.cs -keyfile:key.snk -publicsign -out:dlls/test-939-common.dll
-	$(CSCOMPILE_UTIL) -t:library dlls/test-939-1/test-939-lib.cs -keyfile:key.snk -publicsign -out:dlls/test-939-1/test-939-lib.dll
-	$(CSCOMPILE_UTIL) -t:library dlls/test-939-1/test-939-ref.cs -r:dlls/test-939-1/test-939-lib.dll -keyfile:key.snk -publicsign -out:dlls/test-939-1/test-939-ref.dll
-	$(CSCOMPILE_UTIL) -t:library dlls/test-939-2/test-939-lib.cs -r:dlls/test-939-common.dll -keyfile:key.snk -publicsign -out:dlls/test-939-2/test-939-lib.dll
+dlls/test-679-2/test-679-lib-2.dll: dlls/test-679-2/test-679-lib-2.cs
+	$(CSCOMPILE_UTIL) -t:library -out:$@ dlls/test-679-2/test-679-lib-2.cs
+
+dlls/test-679-1/test-679-lib.dll: dlls/test-679-1/test-679-lib.cs dlls/test-679-2/test-679-lib-2.dll
+	$(CSCOMPILE_UTIL) -t:library -out:$@ -r:dlls/test-679-2/test-679-lib-2.dll dlls/test-679-1/test-679-lib.cs
+
+dlls/test-939-common.dll: dlls/test-939-common.cs key.snk
+	$(CSCOMPILE_UTIL) -t:library -out:$@ dlls/test-939-common.cs -keyfile:key.snk -publicsign
+
+dlls/test-939-1/test-939-lib.dll: dlls/test-939-1/test-939-lib.cs key.snk
+	$(CSCOMPILE_UTIL) -t:library -out:$@ dlls/test-939-1/test-939-lib.cs -keyfile:key.snk -publicsign
+
+dlls/test-939-1/test-939-ref.dll: dlls/test-939-1/test-939-ref.cs dlls/test-939-1/test-939-lib.dll key.snk
+	$(CSCOMPILE_UTIL) -t:library -out:$@ dlls/test-939-1/test-939-ref.cs -r:dlls/test-939-1/test-939-lib.dll -keyfile:key.snk -publicsign
+
+dlls/test-939-2/test-939-lib.dll: dlls/test-939-2/test-939-lib.cs dlls/test-939-common.dll key.snk
+	$(CSCOMPILE_UTIL) -t:library -out:$@ dlls/test-939-2/test-939-lib.cs -r:dlls/test-939-common.dll -keyfile:key.snk -publicsign
+
+dlls/test-883.dll: dlls/test-883.il
 	$(ILASM) -dll dlls/test-883.il

--- a/mcs/tools/mono-symbolicate/Makefile
+++ b/mcs/tools/mono-symbolicate/Makefile
@@ -16,7 +16,7 @@ MONO = MONO_PATH="$(LIB_PATH)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(RUNTIME) -
 
 MSYM_DIR = $(OUT_DIR)/msymdir
 TEST_CS = Test/StackTraceDumper.cs
-TEST_EXE = $(OUT_DIR)/StackTraceDumper.exe
+TEST_EXE = StackTraceDumper.exe
 STACKTRACE_FILE = $(OUT_DIR)/stacktrace.out
 SYMBOLICATE_RAW_FILE = $(OUT_DIR)/symbolicate_raw.out
 SYMBOLICATE_RESULT_FILE = $(OUT_DIR)/symbolicate.result
@@ -44,14 +44,22 @@ PREPARE_OUTDIR = @\
 	mkdir -p $(OUT_DIR); \
 	mkdir -p $(MSYM_DIR);
 
-COMPILE = \
-	$(CSCOMPILE) $(TEST_CS) -r:$(LIB_PATH)/mscorlib.dll -r:$(LIB_PATH)/System.Core.dll -warn:0 -out:$(TEST_EXE); \
+STORE_SYMBOLS = \
 	$(MONO) $(LIB_PATH)/$(PROGRAM) store-symbols $(MSYM_DIR) $(OUT_DIR); \
 	$(MONO) $(LIB_PATH)/$(PROGRAM) store-symbols $(MSYM_DIR) $(LIB_PATH);
+
+COPY_TEST = @\
+	cp $(TEST_EXE) $(OUT_DIR); \
+	cp $(TEST_EXE:.exe=.pdb) $(OUT_DIR);
 
 check: run-test
 
 AOT_SUPPORTED = $(shell $(MONO) --aot 2>&1 | grep -q "AOT compilation is not supported" && echo 0 || echo 1)
+
+test-local: $(TEST_EXE)
+
+$(TEST_EXE): $(TEST_CS)
+	$(CSCOMPILE) $(TEST_CS) -r:$(LIB_PATH)/mscorlib.dll -r:$(LIB_PATH)/System.Core.dll -warn:0 -out:$(TEST_EXE)
 
 run-test-local: run-test-without-aot run-test-with-aot run-test-with-aot-msym
 
@@ -59,7 +67,8 @@ run-test-without-aot: OUT_DIR = Test/without_aot
 run-test-without-aot: all
 	@echo "Checking $(TEST_EXE) without AOT in $(OUT_DIR)"
 	$(PREPARE_OUTDIR)
-	$(COMPILE)
+	$(COPY_TEST)
+	$(STORE_SYMBOLS)
 	$(CHECK_DIFF)
 
 run-test-with-aot: OUT_DIR = Test/with_aot
@@ -67,8 +76,9 @@ run-test-with-aot: all
 ifeq ($(AOT_SUPPORTED), 1)
 	@echo "Checking $(TEST_EXE) with AOT in $(OUT_DIR)"
 	$(PREPARE_OUTDIR)
-	$(COMPILE)
-	@$(MONO) --aot $(TEST_EXE) > /dev/null
+	$(COPY_TEST)
+	$(STORE_SYMBOLS)
+	@$(MONO) --aot $(OUT_DIR)/$(TEST_EXE) > /dev/null
 	$(CHECK_DIFF)
 endif
 
@@ -77,7 +87,8 @@ run-test-with-aot-msym: all
 ifeq ($(AOT_SUPPORTED), 1)
 	@echo "Checking $(TEST_EXE) with AOT (using .msym) in $(OUT_DIR)"
 	$(PREPARE_OUTDIR)
-	$(COMPILE)
-	@$(MONO) --aot=msym-dir=$(MSYM_DIR) $(TEST_EXE) > /dev/null
+	$(COPY_TEST)
+	$(STORE_SYMBOLS)
+	@$(MONO) --aot=msym-dir=$(MSYM_DIR) $(OUT_DIR)/$(TEST_EXE) > /dev/null
 	$(CHECK_DIFF)
 endif


### PR DESCRIPTION
Add proper dependencies to the test support files where they were missing.
Compile test files using the standard "make test" target.
