### PR TITLE
[sdks] Ensure LLVM is cloned before trying to download

### DIFF
--- a/sdks/builds/llvm.mk
+++ b/sdks/builds/llvm.mk
@@ -32,7 +32,7 @@ $$(TOP)/sdks/out/$(1)-$(2)/.stamp-download:
 	touch $$@
 
 .PHONY: download-$(1)-$(2)
-download-$(1)-$(2): | setup-$(1)-$(2)
+download-$(1)-$(2): $(3) | setup-$(1)-$(2)
 	-$$(MAKE) $$(TOP)/sdks/out/$(1)-$(2)/.stamp-download
 
 .PHONY: provision-$(1)-$(2)


### PR DESCRIPTION
It would get the wrong LLVM hash otherwise.