### PR TITLE
[2018-08] [w32handle] Add coop state transitions in mono_w32handle_lock_handles

### DIFF
--- a/mono/metadata/w32handle.c
+++ b/mono/metadata/w32handle.c
@@ -603,6 +603,7 @@ again:
 			if (iter == 1000)
 				iter = 10;
 
+			MONO_ENTER_GC_SAFE;
 #ifdef HOST_WIN32
 			SleepEx (iter, TRUE);
 #else
@@ -615,6 +616,7 @@ again:
 			sleepytime.tv_nsec = iter * 1000000;
 			nanosleep (&sleepytime, NULL);
 #endif /* HOST_WIN32 */
+			MONO_EXIT_GC_SAFE;
 
 			goto again;
 		}


### PR DESCRIPTION
Backport of #10910.

/cc @luhenry @lambdageek

Description of #10910:
If another thread locked at least one of the handles, and there is a
cooperative GC STW happening, this function will loop forever.

Add GC Safe transitions around the call to sleep to give this thread a chance
to suspend.

Fixes https://github.com/mono/mono/issues/10863