### PR TITLE
[2018-08] [Reflection] Fix issue with finding types in module using an asterisk as filter criteria

### DIFF
--- a/mcs/class/corlib/System.Reflection/Module.cs
+++ b/mcs/class/corlib/System.Reflection/Module.cs
@@ -213,7 +213,7 @@ namespace System.Reflection {
 		private static bool filter_by_type_name (Type m, object filterCriteria) {
 			string s = (string)filterCriteria;
 			if (s.Length > 0 && s [s.Length - 1] == '*')
-				return m.Name.StartsWithOrdinalUnchecked (s.Substring (0, s.Length - 1));
+				return m.Name.StartsWith (s.Substring (0, s.Length - 1), StringComparison.Ordinal);
 			
 			return m.Name == s;
 		}

--- a/mcs/class/corlib/Test/System.Reflection/ModuleTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/ModuleTest.cs
@@ -324,10 +324,14 @@ public class ModuleTest
 
 		Type[] t;
 
+		t = m.FindTypes (Module.FilterTypeName, "*");
+		Assert.AreNotEqual (0, t.Length, "#A0");
 		t = m.FindTypes (Module.FilterTypeName, "FindTypesTest*");
 		Assert.AreEqual (2, t.Length, "#A1");
 		Assert.AreEqual ("FindTypesTestFirstClass", t [0].Name, "#A2");
 		Assert.AreEqual ("FindTypesTestSecondClass", t [1].Name, "#A3");
+		t = m.FindTypes (Module.FilterTypeNameIgnoreCase, "*");
+		Assert.AreNotEqual (0, t.Length, "#B0");		
 		t = m.FindTypes (Module.FilterTypeNameIgnoreCase, "findtypestest*");
 		Assert.AreEqual (2, t.Length, "#B1");
 		Assert.AreEqual ("FindTypesTestFirstClass", t [0].Name, "#B2");


### PR DESCRIPTION
Backport of #10922.

/cc @marek-safar @MaximLipnin

Description of #10922:
Fixes https://github.com/mono/mono/issues/10876