### PR TITLE
[metadata] Compute interface offsets of ginst by inflating the GTD instead of doing it from the grounds up.

### DIFF
--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -1789,7 +1789,7 @@ setup_interface_offsets (MonoClass *klass, int cur_slot, gboolean overwrite)
 			}
 
 			if (!inflated->interface_id)
-				mono_class_init (inflated);
+				mono_class_setup_interface_id (inflated);
 
 			co_pair [i].ic = inflated;
 			co_pair [i].offset = gklass->interface_offsets_packed [i];

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -1628,7 +1628,6 @@ mono_class_interface_offset_with_variance (MonoClass *klass, MonoClass *itf, gbo
 			return m_class_get_interface_offsets_packed (klass) [found];
 
 		for (i = 0; i < klass_interface_offsets_count; i++) {
-			// printf ("\t%s\n", mono_type_get_full_name (klass->interfaces_packed [i]));
 			if (mono_class_get_generic_type_definition (m_class_get_interfaces_packed (klass) [i]) == gtd) {
 				found = i;
 				*non_exact_match = TRUE;

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -4398,7 +4398,7 @@ mono_reflection_resolve_object (MonoImage *image, MonoObject *obj, MonoClass **h
 		void *args [16];
 		args [0] = obj;
 		obj = mono_runtime_invoke_checked (resolve_method, NULL, args, error);
-		mono_error_assert_ok (error);
+		goto_if_nok (error, return_null);
 		g_assert (obj);
 		result = mono_reflection_resolve_object (image, obj, handle_class, context, error);
 		goto exit;

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -696,6 +696,7 @@ TESTS_CS_SRC=		\
 	verbose.cs \
 	generic-unmanaged-constraint.cs \
 	bug-10834.cs \
+	bug-10837.cs	\
 	bug-gh-9507.cs
 
 # some tests fail to compile on mcs

--- a/mono/tests/bug-10837.cs
+++ b/mono/tests/bug-10837.cs
@@ -1,0 +1,44 @@
+/*
+
+
+Packed interface table for class Repro.Derived
+
+*/
+using System;
+
+namespace Repro {
+	interface Interface<T0>
+	{
+	    void Problem();
+	}
+	class Base<T1> : Interface<T1>
+	{
+	    void Interface<T1>.Problem() {
+			Console.WriteLine("Base.Method()");
+			throw new Exception ();
+		}
+	}
+	class Derived<U> : Base<int>, Interface<U>
+	{
+	    void Interface<U>.Problem() { Console.WriteLine("Derived`2.Method()"); }
+		~Derived() {
+			
+		}
+	}
+	class FinalClass : Derived<int>, Interface<string>, Interface<int>
+	{
+	    void Interface<string>.Problem() {
+			Console.WriteLine("Derived.Method()");
+			throw new Exception ();
+		}
+	}
+	class Program
+	{
+	    public static void Main()
+	    {
+	        Interface<int> j = new FinalClass();
+	        j.Problem();
+	    }
+	}
+}
+


### PR DESCRIPTION
Say you have;
```c#
interface IBar<T> { T Bla(); }
class Foo<A,B>: IBar<A>, IBar<B> {
        int IBar<int>.Bla)() { ... }
}
```

The GTD of Foo will have the following interface offsets table:
```
4: IBar<A>
5: IBar<B>
```

With the existing code, if you have Foo<int,int> the interface offsets table will look like this:
```
4: IBar<int>
```

The problem with that is it will produce a hole in the vtable and subclasses of Foo<int,int> will have not on slot 5.

That would be just wasteful, unless you have this:

```c#
class Sub: Foo<int,int>, IBar<int> {
        int IBar<int>.Bla)() { ...  }
}
```

IOW, a subclass that overrides the interface implementation in Foo. The problem is that it's not always reliable to which iface offset
calls to `IBar<int>` will go through and thus it's possible to have calls made against instances of `Sub` to execute the code from its base
class.

The solution is to inflate the interface offsets table from the gtd as that will preserve the number of entries and will cause the
rest of the vtable layout code to fill the duplicated slots correctly.

Fixes #10837