### PR TITLE
Paint ToolStrip background with ToolStrip.BackColor

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStrip.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStrip.cs
@@ -1018,8 +1018,8 @@ namespace System.Windows.Forms
 			base.OnPaintBackground (e);
 
 			Rectangle affected_bounds = new Rectangle (Point.Empty, this.Size);
-			ToolStripRenderEventArgs tsrea = new ToolStripRenderEventArgs (e.Graphics, this, affected_bounds, SystemColors.Control);
-			
+			ToolStripRenderEventArgs tsrea = new ToolStripRenderEventArgs (e.Graphics, this, affected_bounds, BackColor);
+
 			this.Renderer.DrawToolStripBackground (tsrea);
 		}
 


### PR DESCRIPTION
## Problem

ToolStrip and MenuStrip look pretty bad if you use a dark theme (such as Adwaita-dark in Ubuntu):

![image](https://user-images.githubusercontent.com/1559108/46361551-8e6dea80-c633-11e8-97d1-242612b4b5cf.png)

It doesn't seem to matter whether the app sets ToolStrip.BackColor to a value, it always has the same color.

I was not able to find an existing open issue for this.

## Cause

ToolStrip has a BackColor property, but aside from a getter/setter, it doesn't appear to be used. When it tries to render its own background, ToolStrip passes a background color of SystemColors.Control instead:

https://github.com/mono/mono/blob/f0921fd850b0c8e61d5954fa71471189d2a55447/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStrip.cs#L1015-L1024

MenuStrip inherits from ToolStrip, including this behavior.

## Changes

Now ToolStrip will pass its own BackColor property as the background color to use for rendering. This will allow applications to control the color of tool strips and menu strips.