### PR TITLE
Fix default colors for DataGridView

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridView.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridView.cs
@@ -174,7 +174,7 @@ namespace System.Windows.Forms {
 			columnHeadersBorderStyle = DataGridViewHeaderBorderStyle.Single;
 			columnHeadersDefaultCellStyle = new DataGridViewCellStyle();
 			columnHeadersDefaultCellStyle.BackColor = SystemColors.Control;
-			columnHeadersDefaultCellStyle.ForeColor = SystemColors.WindowText;
+			columnHeadersDefaultCellStyle.ForeColor = SystemColors.ControlText;
 			columnHeadersDefaultCellStyle.SelectionBackColor = SystemColors.Highlight;
 			columnHeadersDefaultCellStyle.SelectionForeColor = SystemColors.HighlightText;
 			columnHeadersDefaultCellStyle.Font = this.Font;
@@ -189,7 +189,7 @@ namespace System.Windows.Forms {
 			dataMember = String.Empty;
 			defaultCellStyle = new DataGridViewCellStyle();
 			defaultCellStyle.BackColor = SystemColors.Window;
-			defaultCellStyle.ForeColor = SystemColors.ControlText;
+			defaultCellStyle.ForeColor = SystemColors.WindowText;
 			defaultCellStyle.SelectionBackColor = SystemColors.Highlight;
 			defaultCellStyle.SelectionForeColor = SystemColors.HighlightText;
 			defaultCellStyle.Font = this.Font;

--- a/mcs/class/System.Windows.Forms/Test/System.Windows.Forms/DataGridViewTest.cs
+++ b/mcs/class/System.Windows.Forms/Test/System.Windows.Forms/DataGridViewTest.cs
@@ -2006,7 +2006,7 @@ namespace MonoTests.System.Windows.Forms
 		{
 			DataGridView grid = new DataGridView();
 			Assert.AreEqual (SystemColors.Control, grid.ColumnHeadersDefaultCellStyle.BackColor, "#A1");
-			Assert.AreEqual (SystemColors.WindowText,  grid.ColumnHeadersDefaultCellStyle.ForeColor, "#A2");
+			Assert.AreEqual (SystemColors.ControlText,  grid.ColumnHeadersDefaultCellStyle.ForeColor, "#A2");
 			Assert.AreEqual (SystemColors.Highlight, grid.ColumnHeadersDefaultCellStyle.SelectionBackColor, "#A3");
 			Assert.AreEqual (SystemColors.HighlightText, grid.ColumnHeadersDefaultCellStyle.SelectionForeColor, "#A4");
 			Assert.AreSame (grid.Font, grid.ColumnHeadersDefaultCellStyle.Font, "#A5");
@@ -2019,7 +2019,7 @@ namespace MonoTests.System.Windows.Forms
 		{
 			DataGridView grid = new DataGridView();
 			Assert.AreEqual (SystemColors.Window, grid.DefaultCellStyle.BackColor, "#A1");
-			Assert.AreEqual (SystemColors.ControlText,  grid.DefaultCellStyle.ForeColor, "#A2");
+			Assert.AreEqual (SystemColors.WindowText,  grid.DefaultCellStyle.ForeColor, "#A2");
 			Assert.AreEqual (SystemColors.Highlight, grid.DefaultCellStyle.SelectionBackColor, "#A3");
 			Assert.AreEqual (SystemColors.HighlightText, grid.DefaultCellStyle.SelectionForeColor, "#A4");
 			Assert.AreSame (grid.Font, grid.DefaultCellStyle.Font, "#A5");
@@ -2075,7 +2075,7 @@ namespace MonoTests.System.Windows.Forms
 		{
 			DataGridView grid = new DataGridView();
 			Assert.AreEqual (SystemColors.Control, grid.RowHeadersDefaultCellStyle.BackColor, "#A1");
-			Assert.AreEqual (SystemColors.WindowText, grid.RowHeadersDefaultCellStyle.ForeColor, "#A2");
+			Assert.AreEqual (SystemColors.ControlText, grid.RowHeadersDefaultCellStyle.ForeColor, "#A2");
 			Assert.AreEqual (SystemColors.Highlight, grid.RowHeadersDefaultCellStyle.SelectionBackColor, "#A3");
 			Assert.AreEqual (SystemColors.HighlightText, grid.RowHeadersDefaultCellStyle.SelectionForeColor, "#A4");
 			Assert.AreSame (grid.Font, grid.RowHeadersDefaultCellStyle.Font, "#A5");


### PR DESCRIPTION
## Problem

`DataGridView`'s default colors are currently as follows:

| Cell | Background | Foreground |
| --- | --- | --- |
| Header | `SystemColors.Control` | `SystemColors.WindowText` |
| Regular row | `SystemColors.Window` | `SystemColors.ControlText` |

For a typical theme, this is fine because both foreground colors are black.

For a dark theme, the `Control` colors are light-on-dark while the `Window` colors are black-on-white, so this results in black-on-dark for the header and light-on-white for the rows.

![image](https://user-images.githubusercontent.com/1559108/46364902-b6ae1700-c63c-11e8-9350-4a289f678b0b.png)

## Changes

Now `ControlText` is used as the foreground color for `Control`, and `WindowText` is used as the foreground color for `Window`.

![image](https://user-images.githubusercontent.com/1559108/46365200-9a5eaa00-c63d-11e8-8b49-330baf68c07e.png)
