### PR TITLE
[icalls] Replace gboolean and mono_bool by MonoBoolean.

### DIFF
--- a/mono/metadata/appdomain-icalls.h
+++ b/mono/metadata/appdomain-icalls.h
@@ -76,7 +76,7 @@ ves_icall_System_AppDomain_LoadAssembly            (MonoAppDomainHandle ad,
 						    MonoBoolean refonly,
 						    MonoError *error);
 ICALL_EXPORT
-gboolean
+MonoBoolean
 ves_icall_System_AppDomain_InternalIsFinalizingForUnload (gint32 domain_id, MonoError *error);
 
 ICALL_EXPORT

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2560,7 +2560,7 @@ ves_icall_System_AppDomain_InternalUnload (gint32 domain_id, MonoError *error)
 		mono_error_set_exception_instance (error, exc);
 }
 
-gboolean
+MonoBoolean
 ves_icall_System_AppDomain_InternalIsFinalizingForUnload (gint32 domain_id, MonoError *error)
 {
 	MonoDomain *domain = mono_domain_get_by_id (domain_id);

--- a/mono/metadata/file-mmap-posix.c
+++ b/mono/metadata/file-mmap-posix.c
@@ -470,7 +470,7 @@ mono_mmap_close (void *mmap_handle, MonoError *error)
 }
 
 void
-mono_mmap_configure_inheritability (void *mmap_handle, gboolean inheritability, MonoError *error)
+mono_mmap_configure_inheritability (void *mmap_handle, gint32 inheritability, MonoError *error)
 {
 	MmapHandle *h = (MmapHandle *)mmap_handle;
 	int fd, flags;
@@ -532,7 +532,7 @@ mono_mmap_map (void *handle, gint64 offset, gint64 *size, int access, void **mma
 	return COULD_NOT_MAP_MEMORY;
 }
 
-gboolean
+MonoBoolean
 mono_mmap_unmap (void *mmap_handle, MonoError *error)
 {
 	int res = 0;

--- a/mono/metadata/file-mmap-windows.c
+++ b/mono/metadata/file-mmap-windows.c
@@ -296,7 +296,7 @@ mono_mmap_close (void *mmap_handle, MonoError *error)
 }
 
 void
-mono_mmap_configure_inheritability (void *mmap_handle, gboolean inheritability, MonoError *error)
+mono_mmap_configure_inheritability (void *mmap_handle, gint32 inheritability, MonoError *error)
 {
 	g_assert (mmap_handle);
 	if (!SetHandleInformation (mmap_handle, HANDLE_FLAG_INHERIT, inheritability ? HANDLE_FLAG_INHERIT : 0)) {
@@ -406,7 +406,7 @@ mono_mmap_map (void *handle, gint64 offset, gint64 *size, int access, void **mma
 	return 0;
 }
 
-gboolean
+MonoBoolean
 mono_mmap_unmap (void *mmap_handle, MonoError *error)
 {
 	g_assert (mmap_handle);

--- a/mono/metadata/file-mmap.h
+++ b/mono/metadata/file-mmap.h
@@ -23,9 +23,10 @@ ICALL_EXPORT
 void
 mono_mmap_close (void *mmap_handle, MonoError *error);
 
+// inheritability is an enum with the values 0 and 1.
 ICALL_EXPORT
 void
-mono_mmap_configure_inheritability (void *mmap_handle, gboolean inheritability, MonoError *error);
+mono_mmap_configure_inheritability (void *mmap_handle, gint32 inheritability, MonoError *error);
 
 ICALL_EXPORT
 void
@@ -44,7 +45,7 @@ int
 mono_mmap_map (void *handle, gint64 offset, gint64 *size, int access, void **mmap_handle, void **base_address, MonoError *error);
 
 ICALL_EXPORT
-gboolean
+MonoBoolean
 mono_mmap_unmap (void *base_address, MonoError *error);
 
 #endif /* _MONO_METADATA_FILE_MMAP_H_ */

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5096,7 +5096,7 @@ leave:
 	HANDLE_FUNCTION_RETURN_VAL (result);
 }
 
-ICALL_EXPORT gboolean
+ICALL_EXPORT MonoBoolean
 ves_icall_System_Reflection_Assembly_GetManifestResourceInfoInternal (MonoReflectionAssemblyHandle assembly_h, MonoStringHandle name, MonoManifestResourceInfoHandle info_h, MonoError *error)
 {
 	error_init (error);
@@ -8036,7 +8036,7 @@ ves_icall_MonoCustomAttrs_IsDefinedInternal (MonoObjectHandle obj, MonoReflectio
 }
 
 ICALL_EXPORT MonoArrayHandle
-ves_icall_MonoCustomAttrs_GetCustomAttributesInternal (MonoObjectHandle obj, MonoReflectionTypeHandle attr_type, mono_bool pseudoattrs, MonoError *error)
+ves_icall_MonoCustomAttrs_GetCustomAttributesInternal (MonoObjectHandle obj, MonoReflectionTypeHandle attr_type, MonoBoolean pseudoattrs, MonoError *error)
 {
 	MonoClass *attr_class;
 	if (MONO_HANDLE_IS_NULL (attr_type))

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -2033,7 +2033,7 @@ ves_icall_MonoMethod_MakeGenericMethod_impl (MonoReflectionMethodHandle rmethod,
 
 ICALL_EXPORT
 gint32
-ves_icall_ModuleBuilder_getToken (MonoReflectionModuleBuilderHandle mb, MonoObjectHandle obj, gboolean create_open_instance, MonoError *error);
+ves_icall_ModuleBuilder_getToken (MonoReflectionModuleBuilderHandle mb, MonoObjectHandle obj, MonoBoolean create_open_instance, MonoError *error);
 
 ICALL_EXPORT
 gint32

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -4515,7 +4515,7 @@ mono_sre_generic_param_table_entry_free (GenericParamTableEntry *entry)
 }
 
 gint32
-ves_icall_ModuleBuilder_getToken (MonoReflectionModuleBuilderHandle mb, MonoObjectHandle obj, gboolean create_open_instance, MonoError *error)
+ves_icall_ModuleBuilder_getToken (MonoReflectionModuleBuilderHandle mb, MonoObjectHandle obj, MonoBoolean create_open_instance, MonoError *error)
 {
 	error_init (error);
 	if (MONO_HANDLE_IS_NULL (obj)) {

--- a/mono/metadata/w32socket-unix.c
+++ b/mono/metadata/w32socket-unix.c
@@ -1543,7 +1543,7 @@ mono_w32socket_convert_error (gint error)
 	}
 }
 
-gboolean
+MonoBoolean
 ves_icall_System_Net_Sockets_Socket_SupportPortReuse (MonoProtocolType proto, MonoError *error)
 {
 	error_init (error);

--- a/mono/metadata/w32socket-win32.c
+++ b/mono/metadata/w32socket-win32.c
@@ -357,7 +357,7 @@ mono_w32socket_convert_error (gint error)
 	return (error > 0 && error < WSABASEERR) ? error + WSABASEERR : error;
 }
 
-gboolean
+MonoBoolean
 ves_icall_System_Net_Sockets_Socket_SupportPortReuse (MonoProtocolType proto, MonoError *error)
 {
 	error_init (error);

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -810,7 +810,7 @@ ves_icall_System_Net_Sockets_Socket_Available_internal (gsize sock, gint32 *werr
 }
 
 void
-ves_icall_System_Net_Sockets_Socket_Blocking_internal (gsize sock, gboolean block, gint32 *werror, MonoError *error)
+ves_icall_System_Net_Sockets_Socket_Blocking_internal (gsize sock, MonoBoolean block, gint32 *werror, MonoError *error)
 {
 	int ret;
 	
@@ -823,7 +823,7 @@ ves_icall_System_Net_Sockets_Socket_Blocking_internal (gsize sock, gboolean bloc
 }
 
 gpointer
-ves_icall_System_Net_Sockets_Socket_Accept_internal (gsize sock, gint32 *werror, gboolean blocking, MonoError *error)
+ves_icall_System_Net_Sockets_Socket_Accept_internal (gsize sock, gint32 *werror, MonoBoolean blocking, MonoError *error)
 {
 	SOCKET newsock;
 
@@ -1308,7 +1308,7 @@ ves_icall_System_Net_Sockets_Socket_Poll_internal (gsize sock, gint mode,
 }
 
 void
-ves_icall_System_Net_Sockets_Socket_Connect_internal (gsize sock, MonoObjectHandle sockaddr, gint32 *werror, gboolean blocking, MonoError *error)
+ves_icall_System_Net_Sockets_Socket_Connect_internal (gsize sock, MonoObjectHandle sockaddr, gint32 *werror, MonoBoolean blocking, MonoError *error)
 {
 	struct sockaddr *sa;
 	socklen_t sa_size;
@@ -1359,7 +1359,7 @@ ves_icall_System_Net_Sockets_Socket_Duplicate_internal (gpointer handle, gint32 
 }
 
 gint32
-ves_icall_System_Net_Sockets_Socket_Receive_internal (gsize sock, gchar *buffer, gint32 count, gint32 flags, gint32 *werror, gboolean blocking, MonoError *error)
+ves_icall_System_Net_Sockets_Socket_Receive_internal (gsize sock, gchar *buffer, gint32 count, gint32 flags, gint32 *werror, MonoBoolean blocking, MonoError *error)
 {
 	int ret;
 	int recvflags = 0;
@@ -1383,7 +1383,7 @@ ves_icall_System_Net_Sockets_Socket_Receive_internal (gsize sock, gchar *buffer,
 }
 
 gint32
-ves_icall_System_Net_Sockets_Socket_Receive_array_internal (gsize sock, WSABUF *buffers, gint32 count, gint32 flags, gint32 *werror, gboolean blocking, MonoError *error)
+ves_icall_System_Net_Sockets_Socket_Receive_array_internal (gsize sock, WSABUF *buffers, gint32 count, gint32 flags, gint32 *werror, MonoBoolean blocking, MonoError *error)
 {
 	int ret;
 	guint32 recv;
@@ -1408,7 +1408,7 @@ ves_icall_System_Net_Sockets_Socket_Receive_array_internal (gsize sock, WSABUF *
 }
 
 gint32
-ves_icall_System_Net_Sockets_Socket_ReceiveFrom_internal (gsize sock, gchar *buffer, gint32 count, gint32 flags, MonoObjectHandle sockaddr, gint32 *werror, gboolean blocking, MonoError *error)
+ves_icall_System_Net_Sockets_Socket_ReceiveFrom_internal (gsize sock, gchar *buffer, gint32 count, gint32 flags, MonoObjectHandle sockaddr, gint32 *werror, MonoBoolean blocking, MonoError *error)
 {
 	int ret;
 	int recvflags = 0;
@@ -1457,7 +1457,7 @@ ves_icall_System_Net_Sockets_Socket_ReceiveFrom_internal (gsize sock, gchar *buf
 }
 
 gint32
-ves_icall_System_Net_Sockets_Socket_Send_internal (gsize sock, gchar *buffer, gint32 count, gint32 flags, gint32 *werror, gboolean blocking, MonoError *error)
+ves_icall_System_Net_Sockets_Socket_Send_internal (gsize sock, gchar *buffer, gint32 count, gint32 flags, gint32 *werror, MonoBoolean blocking, MonoError *error)
 {
 	int ret;
 	int sendflags = 0;
@@ -1483,7 +1483,7 @@ ves_icall_System_Net_Sockets_Socket_Send_internal (gsize sock, gchar *buffer, gi
 }
 
 gint32
-ves_icall_System_Net_Sockets_Socket_Send_array_internal (gsize sock, WSABUF *buffers, gint32 count, gint32 flags, gint32 *werror, gboolean blocking, MonoError *error)
+ves_icall_System_Net_Sockets_Socket_Send_array_internal (gsize sock, WSABUF *buffers, gint32 count, gint32 flags, gint32 *werror, MonoBoolean blocking, MonoError *error)
 {
 	int ret;
 	guint32 sent;
@@ -1508,7 +1508,7 @@ ves_icall_System_Net_Sockets_Socket_Send_array_internal (gsize sock, WSABUF *buf
 }
 
 gint32
-ves_icall_System_Net_Sockets_Socket_SendTo_internal (gsize sock, gchar *buffer, gint32 count, gint32 flags, MonoObjectHandle sockaddr, gint32 *werror, gboolean blocking, MonoError *error)
+ves_icall_System_Net_Sockets_Socket_SendTo_internal (gsize sock, gchar *buffer, gint32 count, gint32 flags, MonoObjectHandle sockaddr, gint32 *werror, MonoBoolean blocking, MonoError *error)
 {
 	int ret;
 	int sendflags = 0;
@@ -2556,8 +2556,8 @@ ves_icall_System_Net_Dns_GetHostName_internal (MonoStringHandleOut h_name, MonoE
 }
 
 #if G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT | HAVE_UWP_WINAPI_SUPPORT)
-gboolean
-ves_icall_System_Net_Sockets_Socket_SendFile_internal (gsize sock, MonoStringHandle filename, MonoArrayHandle pre_buffer, MonoArrayHandle post_buffer, gint flags, gint32 *werror, gboolean blocking, MonoError *error)
+MonoBoolean
+ves_icall_System_Net_Sockets_Socket_SendFile_internal (gsize sock, MonoStringHandle filename, MonoArrayHandle pre_buffer, MonoArrayHandle post_buffer, gint flags, gint32 *werror, MonoBoolean blocking, MonoError *error)
 {
 	HANDLE file;
 	gboolean ret;

--- a/mono/metadata/w32socket.h
+++ b/mono/metadata/w32socket.h
@@ -192,11 +192,11 @@ ves_icall_System_Net_Sockets_Socket_Available_internal (gsize sock, gint32 *werr
 
 ICALL_EXPORT
 void
-ves_icall_System_Net_Sockets_Socket_Blocking_internal (gsize sock, gboolean block, gint32 *werror, MonoError *error);
+ves_icall_System_Net_Sockets_Socket_Blocking_internal (gsize sock, MonoBoolean block, gint32 *werror, MonoError *error);
 
 ICALL_EXPORT
 gpointer
-ves_icall_System_Net_Sockets_Socket_Accept_internal (gsize sock, gint32 *werror, gboolean blocking, MonoError *error);
+ves_icall_System_Net_Sockets_Socket_Accept_internal (gsize sock, gint32 *werror, MonoBoolean blocking, MonoError *error);
 
 ICALL_EXPORT
 void
@@ -216,33 +216,33 @@ ves_icall_System_Net_Sockets_Socket_Bind_internal (gsize sock, MonoObjectHandle 
 
 ICALL_EXPORT
 void
-ves_icall_System_Net_Sockets_Socket_Connect_internal (gsize sock, MonoObjectHandle sockaddr, gint32 *werror, gboolean blocking, MonoError *error);
+ves_icall_System_Net_Sockets_Socket_Connect_internal (gsize sock, MonoObjectHandle sockaddr, gint32 *werror, MonoBoolean blocking, MonoError *error);
 
 ICALL_EXPORT
 gint32
 ves_icall_System_Net_Sockets_Socket_Receive_internal (gsize sock, gchar *buffer, gint32 count,
-						      gint32 flags, gint32 *werror, gboolean blocking, MonoError *error);
+						      gint32 flags, gint32 *werror, MonoBoolean blocking, MonoError *error);
 ICALL_EXPORT
 gint32
 ves_icall_System_Net_Sockets_Socket_Receive_array_internal (gsize sock, WSABUF *buffers, gint32 count, gint32 flags,
-							    gint32 *werror, gboolean blocking, MonoError *error);
+							    gint32 *werror, MonoBoolean blocking, MonoError *error);
 ICALL_EXPORT
 gint32
 ves_icall_System_Net_Sockets_Socket_ReceiveFrom_internal (gsize sock, gchar *buffer, gint32 count,
-							  gint32 flags, MonoObjectHandle sockaddr, gint32 *werror, gboolean blocking, MonoError *error);
+							  gint32 flags, MonoObjectHandle sockaddr, gint32 *werror, MonoBoolean blocking, MonoError *error);
 ICALL_EXPORT
 gint32
 ves_icall_System_Net_Sockets_Socket_Send_internal (gsize sock, gchar *buffer, gint32 count,
-						   gint32 flags, gint32 *werror, gboolean blocking, MonoError *error);
+						   gint32 flags, gint32 *werror, MonoBoolean blocking, MonoError *error);
 ICALL_EXPORT
 gint32
 ves_icall_System_Net_Sockets_Socket_Send_array_internal (gsize sock, WSABUF *buffers, gint32 count, gint32 flags,
-							 gint32 *werror, gboolean blocking, MonoError *error);
+							 gint32 *werror, MonoBoolean blocking, MonoError *error);
 ICALL_EXPORT
 gint32
 ves_icall_System_Net_Sockets_Socket_SendTo_internal (gsize sock, gchar *buffer, gint32 count,
 						     gint32 flags, MonoObjectHandle sockaddr, gint32 *werror,
-						     gboolean blocking, MonoError *error);
+						     MonoBoolean blocking, MonoError *error);
 ICALL_EXPORT
 void
 ves_icall_System_Net_Sockets_Socket_Select_internal (MonoArrayHandle sockets, gint32 timeout, gint32 *werror, MonoError *error);
@@ -298,16 +298,16 @@ MonoBoolean
 ves_icall_System_Net_Sockets_Socket_Duplicate_internal (gpointer handle, gint32 targetProcessId, gpointer *duplicate_handle, gint32 *werror, MonoError *error);
 
 ICALL_EXPORT
-gboolean
+MonoBoolean
 ves_icall_System_Net_Sockets_Socket_SendFile_internal (gsize sock, MonoStringHandle filename,
 						       MonoArrayHandle pre_buffer, MonoArrayHandle post_buffer,
-						       gint flags, gint32 *werror, gboolean blocking, MonoError *error);
+						       gint flags, gint32 *werror, MonoBoolean blocking, MonoError *error);
 
 ICALL_EXPORT void
 ves_icall_cancel_blocking_socket_operation (MonoThreadObjectHandle thread, MonoError *error);
 
 ICALL_EXPORT
-gboolean
+MonoBoolean
 ves_icall_System_Net_Sockets_Socket_SupportPortReuse (MonoProtocolType proto, MonoError *error);
 
 void


### PR DESCRIPTION
Though one of these is an enum, use gint32.

The enums MonoResolveTokenError and MonoProtocolType are also used in icalls, but that is left alone.

There's actually a bunch more of this I found later.
Not sure we want to fix them all, or none, etc. Maybe just leave it alone.