### PR TITLE
Fix null reference exception in GetParentTypes when it starts at (or reaches?) System.Object

### DIFF
--- a/mcs/class/referencesource/mscorlib/system/runtime/serialization/formatterservices.cs
+++ b/mcs/class/referencesource/mscorlib/system/runtime/serialization/formatterservices.cs
@@ -146,7 +146,11 @@ namespace System.Runtime.Serialization {
             /*out*/ parentTypeCount = 0;
             bool unique = true;
             RuntimeType objectType = (RuntimeType)typeof(object);
-            for (RuntimeType t1 = parentType; t1 != objectType; t1 = (RuntimeType)t1.BaseType)
+            if (parentType == null)
+                throw new ArgumentNullException("parentType");
+            if (parentType == objectType)
+                return true;
+            for (RuntimeType t1 = parentType; (t1 != objectType) && (t1 != null); t1 = (RuntimeType)t1.BaseType)
             {
                 if (t1.IsInterface) continue;
                 string t1Name = t1.Name;


### PR DESCRIPTION
This is the surface level issue in https://github.com/mono/mono/issues/10945. Fixing it reveals another separate issue. I'm not sure how or why we're hitting it, but the code does appear to be incorrect, and it doesn't look like we ever modified formatterservices.cs, so I think it was always broken.