### PR TITLE
[2018-08] [jit] Fix a constant propagation problem on 32 bit with iconst+conv.i8, we would be setting inst_imm even for long opcodes.

### DIFF
--- a/mono/mini/ir-emit.h
+++ b/mono/mini/ir-emit.h
@@ -726,9 +726,7 @@ handle_gsharedvt_ldaddr (MonoCompile *cfg)
         MONO_INST_NEW ((cfg), (inst), (OP_LCOMPARE_IMM)); \
         inst->sreg1 = sr1;									\
         if (SIZEOF_REGISTER == 4 && COMPILE_LLVM (cfg))  { 	\
-			guint64 _l = (imm);								\
-			inst->inst_imm = _l & 0xffffffff;				\
-			inst->inst_offset = _l >> 32;						\
+			inst->inst_l = (imm); \
 		} else { \
 			inst->inst_imm = (imm);		 \
 		}								 \

--- a/mono/mini/local-propagation.c
+++ b/mono/mini/local-propagation.c
@@ -669,11 +669,13 @@ mono_local_cprop (MonoCompile *cfg)
 					opcode2 = mono_op_to_op_imm (ins->opcode);
 					if ((opcode2 != -1) && mono_arch_is_inst_imm (ins->opcode, opcode2, def->inst_c0) && ((srcindex == 1) || (ins->sreg2 == -1))) {
 						ins->opcode = opcode2;
-						if ((def->opcode == OP_I8CONST) && (sizeof (gpointer) == 4)) {
+						if ((def->opcode == OP_I8CONST) && (sizeof (gpointer) == 4))
 							ins->inst_l = def->inst_l;
-						} else {
+						else if (regtype == 'l' && sizeof (gpointer) == 4)
+							/* This can happen if the def was a result of an iconst+conv.i8, which is transformed into just an iconst */
+							ins->inst_l = def->inst_c0;
+						else
 							ins->inst_imm = def->inst_c0;
-						}
 						sregs [srcindex] = -1;
 						mono_inst_set_src_registers (ins, sregs);
 

--- a/mono/mini/local-propagation.c
+++ b/mono/mini/local-propagation.c
@@ -669,9 +669,9 @@ mono_local_cprop (MonoCompile *cfg)
 					opcode2 = mono_op_to_op_imm (ins->opcode);
 					if ((opcode2 != -1) && mono_arch_is_inst_imm (ins->opcode, opcode2, def->inst_c0) && ((srcindex == 1) || (ins->sreg2 == -1))) {
 						ins->opcode = opcode2;
-						if ((def->opcode == OP_I8CONST) && (sizeof (gpointer) == 4))
+						if ((def->opcode == OP_I8CONST) && TARGET_SIZEOF_VOID_P == 4)
 							ins->inst_l = def->inst_l;
-						else if (regtype == 'l' && sizeof (gpointer) == 4)
+						else if (regtype == 'l' && TARGET_SIZEOF_VOID_P == 4)
 							/* This can happen if the def was a result of an iconst+conv.i8, which is transformed into just an iconst */
 							ins->inst_l = def->inst_c0;
 						else

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -4527,6 +4527,7 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 			if (ins->opcode == OP_LCOMPARE_IMM) {
 				lhs = convert (ctx, lhs, LLVMInt64Type ());
 				rhs = LLVMConstInt (LLVMInt64Type (), GET_LONG_IMM (ins), FALSE);
+				g_assert (GET_LONG_IMM (ins) == ins->inst_l);
 			}
 			if (ins->opcode == OP_LCOMPARE) {
 				lhs = convert (ctx, lhs, LLVMInt64Type ());
@@ -4555,13 +4556,7 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 				else
 					cmp = LLVMBuildICmp (builder, cond_to_llvm_cond [rel], convert (ctx, lhs, IntPtrType ()), LLVMConstInt (IntPtrType (), ins->inst_imm, FALSE), "");
 			} else if (ins->opcode == OP_LCOMPARE_IMM) {
-				if (SIZEOF_REGISTER == 4 && COMPILE_LLVM (cfg))  {
-					/* The immediate is encoded in two fields */
-					guint64 l = ((guint64)(guint32)ins->inst_offset << 32) | ((guint32)ins->inst_imm);
-					cmp = LLVMBuildICmp (builder, cond_to_llvm_cond [rel], convert (ctx, lhs, LLVMInt64Type ()), LLVMConstInt (LLVMInt64Type (), l, FALSE), "");
-				} else {
-					cmp = LLVMBuildICmp (builder, cond_to_llvm_cond [rel], convert (ctx, lhs, LLVMInt64Type ()), LLVMConstInt (LLVMInt64Type (), ins->inst_imm, FALSE), "");
-				}
+				cmp = LLVMBuildICmp (builder, cond_to_llvm_cond [rel], lhs, rhs, "");
 			}
 			else if (ins->opcode == OP_COMPARE) {
 				if (LLVMGetTypeKind (LLVMTypeOf (lhs)) == LLVMPointerTypeKind && LLVMTypeOf (lhs) == LLVMTypeOf (rhs))


### PR DESCRIPTION
Backport of #10096.

/cc @lewurm @vargaz

Description of #10096:
