### PR TITLE
[2018-10] [sdks/ios] Build libMonoPosixHelper for device architectures, so that zlib-helper.o is created.

### DIFF
--- a/sdks/builds/ios.mk
+++ b/sdks/builds/ios.mk
@@ -39,6 +39,8 @@ _ios-$(1)_CXX=$$(CCACHE) $$(PLATFORM_BIN)/clang++
 
 _ios-$(1)_AC_VARS= \
 	ac_cv_c_bigendian=no \
+	ac_cv_func_fstatat=no \
+	ac_cv_func_readlinkat=no \
 	ac_cv_func_getpwuid_r=no \
 	ac_cv_func_posix_getpwuid_r=yes \
 	ac_cv_header_curses_h=no \
@@ -84,7 +86,6 @@ _ios-$(1)_CONFIGURE_FLAGS = \
 	--disable-iconv \
 	--disable-mcs-build \
 	--disable-nls \
-	--disable-support-build \
 	--disable-visibility-hidden \
 	--enable-dtrace=no \
 	--enable-icall-export \


### PR DESCRIPTION
Backport of #10921.

/cc @luhenry @rolfbjarne

Description of #10921:
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->

xamarin-macios currently builds zlib-helper.o using mono's source code.

It would be preferrable to use a version built by mono, and since
zlib-helper.o is a byproduct of building libMonoPosixHelper, we need to build
libMonoPosixHelper (we already build it for simulator architectures), even
though we don't need/use libMonoPosixHelper itself.