### PR TITLE
[mscorlib] System.IO.Path, add support for systems that use volume paths (under NDA)

### DIFF
--- a/mcs/class/corlib/System.IO/Path.cs
+++ b/mcs/class/corlib/System.IO/Path.cs
@@ -62,9 +62,7 @@ namespace System.IO {
 
 		internal static readonly char[] PathSeparatorChars;
 		private static readonly bool dirEqualsVolume;
-#if HAS_VOLUME_PREFIXES
-		internal static readonly bool volumePaths;
-#endif
+
 		// class methods
 		public static string ChangeExtension (string path, string extension)
 		{
@@ -576,7 +574,7 @@ namespace System.IO {
 				c == AltDirectorySeparatorChar 	||
 				(!dirEqualsVolume && path.Length > 1 && path [1] == VolumeSeparatorChar)
 #if HAS_VOLUME_PREFIXES
-				|| (volumePaths && IsVolumePrefix (path))
+				|| IsVolumePrefix (path)
 #endif
 				);
 		}


### PR DESCRIPTION
Workbooks test:

```
(IsVolumePrefix (""), IsVolumePrefix ("fo"), IsVolumePrefix ("a"), IsVolumePrefix ("a:"), IsVolumePrefix ("delta?"))
=> (false, false, false, false, false)

(IsVolumePrefix ("a:/"), IsVolumePrefix ("a:/aasd"), IsVolumePrefix ("mount:/etc"))
=>
(true, true, true)
```
