### PR TITLE
Significant disambiguation between host and target.

### DIFF
--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -5133,8 +5133,6 @@ init_plt (MonoAotModule *amodule)
 guint8*
 mono_aot_get_plt_entry (guint8 *code)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoAotModule *amodule = find_aot_module (code);
 	guint8 *target = NULL;
 

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -2905,7 +2905,7 @@ decode_llvm_mono_eh_frame (MonoAotModule *amodule, MonoDomain *domain, MonoJitIn
 
 	if (is_thumb_code (amodule, code_start))
 		/* Clear thumb flag */
-		code_start = (guint8*)(((mgreg_t)code_start) & ~1);
+		code_start = (guint8*)(((gsize)code_start) & ~1);
 
 	fde = amodule->mono_eh_frame + table [(pos * 2) + 1];	
 	/* This won't overflow because there is +1 entry in the table */
@@ -2976,10 +2976,10 @@ decode_llvm_mono_eh_frame (MonoAotModule *amodule, MonoDomain *domain, MonoJitIn
 		jei->clause_index = clause_index;
 
 		if (is_thumb_code (amodule, (guint8 *)jei->try_start)) {
-			jei->try_start = (void*)((mgreg_t)jei->try_start & ~1);
-			jei->try_end = (void*)((mgreg_t)jei->try_end & ~1);
+			jei->try_start = (void*)((gsize)jei->try_start & ~1);
+			jei->try_end = (void*)((gsize)jei->try_end & ~1);
 			/* Make sure we transition to thumb when a handler starts */
-			jei->handler_start = (void*)((mgreg_t)jei->handler_start + 1);
+			jei->handler_start = (void*)((gsize)jei->handler_start + 1);
 		}
 	}
 
@@ -4975,7 +4975,7 @@ find_aot_module (guint8 *code)
 }
 
 void
-mono_aot_patch_plt_entry (guint8 *code, guint8 *plt_entry, gpointer *got, mgreg_t *regs, guint8 *addr)
+mono_aot_patch_plt_entry (guint8 *code, guint8 *plt_entry, gpointer *got, host_mgreg_t *regs, guint8 *addr)
 {
 	MonoAotModule *amodule;
 
@@ -5133,6 +5133,8 @@ init_plt (MonoAotModule *amodule)
 guint8*
 mono_aot_get_plt_entry (guint8 *code)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MonoAotModule *amodule = find_aot_module (code);
 	guint8 *target = NULL;
 
@@ -5175,7 +5177,7 @@ mono_aot_get_plt_entry (guint8 *code)
  *   Return the PLT info offset belonging to the plt entry called by CODE.
  */
 guint32
-mono_aot_get_plt_info_offset (mgreg_t *regs, guint8 *code)
+mono_aot_get_plt_info_offset (host_mgreg_t *regs, guint8 *code)
 {
 	guint8 *plt_entry = mono_aot_get_plt_entry (code);
 
@@ -6182,7 +6184,7 @@ mono_aot_plt_resolve (gpointer aot_module, guint32 plt_info_offset, guint8 *code
 }
 
 void
-mono_aot_patch_plt_entry (guint8 *code, guint8 *plt_entry, gpointer *got, mgreg_t *regs, guint8 *addr)
+mono_aot_patch_plt_entry (guint8 *code, guint8 *plt_entry, gpointer *got, host_mgreg_t *regs, guint8 *addr)
 {
 }
 
@@ -6195,7 +6197,7 @@ mono_aot_get_method_from_vt_slot (MonoDomain *domain, MonoVTable *vtable, int sl
 }
 
 guint32
-mono_aot_get_plt_info_offset (mgreg_t *regs, guint8 *code)
+mono_aot_get_plt_info_offset (host_mgreg_t *regs, guint8 *code)
 {
 	g_assert_not_reached ();
 

--- a/mono/mini/aot-runtime.h
+++ b/mono/mini/aot-runtime.h
@@ -220,12 +220,12 @@ gpointer  mono_aot_get_method               (MonoDomain *domain,
 gpointer  mono_aot_get_method_from_token    (MonoDomain *domain, MonoImage *image, guint32 token, MonoError *error);
 gboolean  mono_aot_is_got_entry             (guint8 *code, guint8 *addr);
 guint8*   mono_aot_get_plt_entry            (guint8 *code);
-guint32   mono_aot_get_plt_info_offset      (mgreg_t *regs, guint8 *code);
+guint32   mono_aot_get_plt_info_offset      (host_mgreg_t *regs, guint8 *code);
 gboolean  mono_aot_get_cached_class_info    (MonoClass *klass, MonoCachedClassInfo *res);
 gboolean  mono_aot_get_class_from_name      (MonoImage *image, const char *name_space, const char *name, MonoClass **klass);
 MonoJitInfo* mono_aot_find_jit_info         (MonoDomain *domain, MonoImage *image, gpointer addr);
 gpointer mono_aot_plt_resolve               (gpointer aot_module, guint32 plt_info_offset, guint8 *code, MonoError *error);
-void     mono_aot_patch_plt_entry           (guint8 *code, guint8 *plt_entry, gpointer *got, mgreg_t *regs, guint8 *addr);
+void     mono_aot_patch_plt_entry           (guint8 *code, guint8 *plt_entry, gpointer *got, host_mgreg_t *regs, guint8 *addr);
 gpointer mono_aot_get_method_from_vt_slot   (MonoDomain *domain, MonoVTable *vtable, int slot, MonoError *error);
 gpointer mono_aot_create_specific_trampoline   (MonoImage *image, gpointer arg1, MonoTrampolineType tramp_type, MonoDomain *domain, guint32 *code_len);
 gpointer mono_aot_get_trampoline            (const char *name);

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -137,7 +137,7 @@ typedef struct
 	MonoInterpFrameHandle interp_frame;
 	gpointer frame_addr;
 	int flags;
-	mgreg_t *reg_locations [MONO_MAX_IREGS];
+	host_mgreg_t *reg_locations [MONO_MAX_IREGS];
 	/*
 	 * Whenever ctx is set. This is FALSE for the last frame of running threads, since
 	 * the frame can become invalid.
@@ -3172,7 +3172,7 @@ process_frame (StackFrameInfo *info, MonoContext *ctx, gpointer user_data)
 	frame->interp_frame = info->interp_frame;
 	frame->frame_addr = info->frame_addr;
 	if (info->reg_locations)
-		memcpy (frame->reg_locations, info->reg_locations, MONO_MAX_IREGS * sizeof (mgreg_t*));
+		memcpy (frame->reg_locations, info->reg_locations, MONO_MAX_IREGS * sizeof (host_mgreg_t*));
 	if (ctx) {
 		frame->ctx = *ctx;
 		frame->has_ctx = TRUE;
@@ -5579,7 +5579,7 @@ add_var (Buffer *buf, MonoDebugMethodJitInfo *jit, MonoType *t, MonoDebugVarInfo
 	guint32 flags;
 	int reg;
 	guint8 *addr, *gaddr;
-	mgreg_t reg_val;
+	host_mgreg_t reg_val;
 
 	flags = var->index & MONO_DEBUG_VAR_ADDRESS_MODE_FLAGS;
 	reg = var->index & ~MONO_DEBUG_VAR_ADDRESS_MODE_FLAGS;
@@ -5661,7 +5661,7 @@ add_var (Buffer *buf, MonoDebugMethodJitInfo *jit, MonoType *t, MonoDebugVarInfo
 }
 
 static void
-set_var (MonoType *t, MonoDebugVarInfo *var, MonoContext *ctx, MonoDomain *domain, guint8 *val, mgreg_t **reg_locations, MonoContext *restore_ctx)
+set_var (MonoType *t, MonoDebugVarInfo *var, MonoContext *ctx, MonoDomain *domain, guint8 *val, host_mgreg_t **reg_locations, MonoContext *restore_ctx)
 {
 	guint32 flags;
 	int reg, size;
@@ -5678,7 +5678,7 @@ set_var (MonoType *t, MonoDebugVarInfo *var, MonoContext *ctx, MonoDomain *domai
 	switch (flags) {
 	case MONO_DEBUG_VAR_ADDRESS_MODE_REGISTER: {
 #ifdef MONO_ARCH_HAVE_CONTEXT_SET_INT_REG
-		mgreg_t v;
+		host_mgreg_t v;
 		gboolean is_signed = FALSE;
 
 		if (t->byref) {
@@ -6066,7 +6066,7 @@ do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, guint8 
 				NOT_IMPLEMENTED;
 
 			if (sig->params [i]->byref) {
-				arg_buf [i] = (guint8 *)g_alloca (sizeof (mgreg_t));
+				arg_buf [i] = g_newa (guint8, sizeof (gpointer));
 				*(gpointer*)arg_buf [i] = args [i];
 				args [i] = arg_buf [i];
 			}

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -239,8 +239,6 @@ void win32_seh_set_handler(int type, MonoW32ExceptionHandler handler)
 gpointer
 mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint8 *start = NULL;
 	guint8 *code;
 	MonoJumpInfo *ji = NULL;
@@ -294,8 +292,6 @@ mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint8 *start;
 	int i, gregs_offset;
 	guint8 *code;
@@ -384,8 +380,6 @@ mono_amd64_throw_exception (guint64 dummy1, guint64 dummy2, guint64 dummy3, guin
 							guint64 dummy5, guint64 dummy6,
 							MonoContext *mctx, MonoObject *exc, gboolean rethrow, gboolean preserve_ips)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ERROR_DECL (error);
 	MonoContext ctx;
 
@@ -416,8 +410,6 @@ mono_amd64_throw_corlib_exception (guint64 dummy1, guint64 dummy2, guint64 dummy
 								   guint64 dummy5, guint64 dummy6,
 								   MonoContext *mctx, guint32 ex_token_index, gint64 pc_offset)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint32 ex_token = MONO_TOKEN_TYPE_DEF | ex_token_index;
 	MonoException *ex;
 
@@ -436,8 +428,6 @@ mono_amd64_resume_unwind (guint64 dummy1, guint64 dummy2, guint64 dummy3, guint6
 						  guint64 dummy5, guint64 dummy6,
 						  MonoContext *mctx, guint32 dummy7, gint64 dummy8)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	/* Only the register parameters are valid */
 	MonoContext ctx;
 
@@ -457,8 +447,6 @@ mono_amd64_resume_unwind (guint64 dummy1, guint64 dummy2, guint64 dummy3, guint6
 static gpointer
 get_throw_trampoline (MonoTrampInfo **info, gboolean rethrow, gboolean corlib, gboolean llvm_abs, gboolean resume_unwind, const char *tramp_name, gboolean aot, gboolean preserve_ips)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint8* start;
 	guint8 *code;
 	MonoJumpInfo *ji = NULL;
@@ -627,8 +615,6 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 							 host_mgreg_t **save_locations,
 							 StackFrameInfo *frame)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	gpointer ip = MONO_CONTEXT_GET_IP (ctx);
 	int i;
 
@@ -753,8 +739,6 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 static void
 handle_signal_exception (gpointer obj)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
 	MonoContext ctx;
 
@@ -768,8 +752,6 @@ handle_signal_exception (gpointer obj)
 void
 mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), gpointer user_data)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint64 sp = ctx->gregs [AMD64_RSP];
 
 	ctx->gregs [AMD64_RDI] = (gsize)user_data;
@@ -795,8 +777,6 @@ mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), g
 gboolean
 mono_arch_handle_exception (void *sigctx, gpointer obj)
 {
-	mono_cross_compile_assert_not_reached ();
-
 #if defined(MONO_ARCH_USE_SIGACTION)
 	MonoContext mctx;
 
@@ -831,8 +811,6 @@ mono_arch_handle_exception (void *sigctx, gpointer obj)
 gpointer
 mono_arch_ip_from_context (void *sigctx)
 {
-	mono_cross_compile_assert_not_reached ();
-
 #if defined(MONO_ARCH_USE_SIGACTION)
 	ucontext_t *ctx = (ucontext_t*)sigctx;
 
@@ -848,8 +826,6 @@ mono_arch_ip_from_context (void *sigctx)
 static MonoObject*
 restore_soft_guard_pages (void)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
 	if (jit_tls->stack_ovf_guard_base)
 		mono_mprotect (jit_tls->stack_ovf_guard_base, jit_tls->stack_ovf_guard_size, MONO_MMAP_NONE);
@@ -872,8 +848,6 @@ restore_soft_guard_pages (void)
 static void
 prepare_for_guard_pages (MonoContext *mctx)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	gpointer *sp;
 	sp = (gpointer *)(mctx->gregs [AMD64_RSP]);
 	sp -= 1;
@@ -886,8 +860,6 @@ prepare_for_guard_pages (MonoContext *mctx)
 static void
 altstack_handle_and_restore (MonoContext *ctx, MonoObject *obj, gboolean stack_ovf)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoContext mctx;
 	MonoJitInfo *ji = mini_jit_info_table_find (mono_domain_get (), MONO_CONTEXT_GET_IP (ctx), NULL);
 
@@ -908,8 +880,6 @@ altstack_handle_and_restore (MonoContext *ctx, MonoObject *obj, gboolean stack_o
 void
 mono_arch_handle_altstack_exception (void *sigctx, MONO_SIG_HANDLER_INFO_TYPE *siginfo, gpointer fault_addr, gboolean stack_ovf)
 {
-	mono_cross_compile_assert_not_reached ();
-
 #if defined(MONO_ARCH_USE_SIGACTION)
 	MonoException *exc = NULL;
 	gpointer *sp;
@@ -949,8 +919,6 @@ mono_arch_handle_altstack_exception (void *sigctx, MONO_SIG_HANDLER_INFO_TYPE *s
 GSList*
 mono_amd64_get_exception_trampolines (gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoTrampInfo *info;
 	GSList *tramps = NULL;
 
@@ -971,8 +939,6 @@ mono_amd64_get_exception_trampolines (gboolean aot)
 void
 mono_arch_exceptions_init (void)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	GSList *tramps, *l;
 	gpointer tramp;
 
@@ -1002,8 +968,6 @@ mono_arch_exceptions_init (void)
 static void
 mono_arch_unwindinfo_create (gpointer* monoui)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	PUNWIND_INFO newunwindinfo;
 	*monoui = newunwindinfo = g_new0 (UNWIND_INFO, 1);
 	newunwindinfo->Version = 1;
@@ -1012,8 +976,6 @@ mono_arch_unwindinfo_create (gpointer* monoui)
 void
 mono_arch_unwindinfo_add_push_nonvol (PUNWIND_INFO unwindinfo, MonoUnwindOp *unwind_op)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	PUNWIND_CODE unwindcode;
 	guchar codeindex;
 
@@ -1037,8 +999,6 @@ mono_arch_unwindinfo_add_push_nonvol (PUNWIND_INFO unwindinfo, MonoUnwindOp *unw
 void
 mono_arch_unwindinfo_add_set_fpreg (PUNWIND_INFO unwindinfo, MonoUnwindOp *unwind_op)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	PUNWIND_CODE unwindcode;
 	guchar codeindex;
 
@@ -1065,8 +1025,6 @@ mono_arch_unwindinfo_add_set_fpreg (PUNWIND_INFO unwindinfo, MonoUnwindOp *unwin
 void
 mono_arch_unwindinfo_add_alloc_stack (PUNWIND_INFO unwindinfo, MonoUnwindOp *unwind_op)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	PUNWIND_CODE unwindcode;
 	guchar codeindex;
 	guchar codesneeded;
@@ -1160,8 +1118,6 @@ static RtlDeleteGrowableFunctionTablePtr g_rtl_delete_growable_function_table;
 static void
 init_table_no_lock (void)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	if (g_dyn_func_table_inited == FALSE) {
 		g_assert_checked (g_dynamic_function_table_begin == NULL);
 		g_assert_checked (g_dynamic_function_table_end == NULL);
@@ -1196,8 +1152,6 @@ init_table_no_lock (void)
 void
 mono_arch_unwindinfo_init_table (void)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	if (g_dyn_func_table_inited == FALSE) {
 
 		AcquireSRWLockExclusive (&g_dynamic_function_table_lock);
@@ -1211,8 +1165,6 @@ mono_arch_unwindinfo_init_table (void)
 static void
 terminate_table_no_lock (void)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	if (g_dyn_func_table_inited == TRUE) {
 		if (g_dynamic_function_table_begin != NULL) {
 			// Free all list elements.
@@ -1243,8 +1195,6 @@ terminate_table_no_lock (void)
 void
 mono_arch_unwindinfo_terminate_table (void)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	if (g_dyn_func_table_inited == TRUE) {
 
 		AcquireSRWLockExclusive (&g_dynamic_function_table_lock);
@@ -1258,8 +1208,6 @@ mono_arch_unwindinfo_terminate_table (void)
 static GList *
 fast_find_range_in_table_no_lock_ex (gsize begin_range, gsize end_range, gboolean *continue_search)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	GList *found_entry = NULL;
 
 	// Fast path, look at boundaries.
@@ -1288,8 +1236,6 @@ fast_find_range_in_table_no_lock_ex (gsize begin_range, gsize end_range, gboolea
 static inline DynamicFunctionTableEntry *
 fast_find_range_in_table_no_lock (gsize begin_range, gsize end_range, gboolean *continue_search)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	GList *found_entry = fast_find_range_in_table_no_lock_ex (begin_range, end_range, continue_search);
 	return (found_entry != NULL) ? (DynamicFunctionTableEntry *)found_entry->data : NULL;
 }
@@ -1297,8 +1243,6 @@ fast_find_range_in_table_no_lock (gsize begin_range, gsize end_range, gboolean *
 static GList *
 find_range_in_table_no_lock_ex (const gpointer code_block, gsize block_size)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	GList *found_entry = NULL;
 	gboolean continue_search = FALSE;
 
@@ -1328,8 +1272,6 @@ find_range_in_table_no_lock_ex (const gpointer code_block, gsize block_size)
 static inline DynamicFunctionTableEntry *
 find_range_in_table_no_lock (const gpointer code_block, gsize block_size)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	GList *found_entry = find_range_in_table_no_lock_ex (code_block, block_size);
 	return (found_entry != NULL) ? (DynamicFunctionTableEntry *)found_entry->data : NULL;
 }
@@ -1337,8 +1279,6 @@ find_range_in_table_no_lock (const gpointer code_block, gsize block_size)
 static GList *
 find_pc_in_table_no_lock_ex (const gpointer pc)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	GList *found_entry = NULL;
 	gboolean continue_search = FALSE;
 
@@ -1368,8 +1308,6 @@ find_pc_in_table_no_lock_ex (const gpointer pc)
 static inline DynamicFunctionTableEntry *
 find_pc_in_table_no_lock (const gpointer pc)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	GList *found_entry = find_pc_in_table_no_lock_ex (pc);
 	return (found_entry != NULL) ? (DynamicFunctionTableEntry *)found_entry->data : NULL;
 }
@@ -1378,8 +1316,6 @@ find_pc_in_table_no_lock (const gpointer pc)
 static void
 validate_table_no_lock (void)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	// Validation method checking that table is sorted as expected and don't include overlapped regions.
 	// Method will assert on failure to explicitly indicate what check failed.
 	if (g_dynamic_function_table_begin != NULL) {
@@ -1411,7 +1347,6 @@ validate_table_no_lock (void)
 static inline void
 validate_table_no_lock (void)
 {
-	mono_cross_compile_assert_not_reached ();
 }
 #endif /* ENABLE_CHECKED_BUILD_UNWINDINFO */
 
@@ -1421,8 +1356,6 @@ static PRUNTIME_FUNCTION MONO_GET_RUNTIME_FUNCTION_CALLBACK (DWORD64 ControlPc, 
 DynamicFunctionTableEntry *
 mono_arch_unwindinfo_insert_range_in_table (const gpointer code_block, gsize block_size)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	DynamicFunctionTableEntry *new_entry = NULL;
 
 	gsize begin_range = (gsize)code_block;
@@ -1522,8 +1455,6 @@ mono_arch_unwindinfo_insert_range_in_table (const gpointer code_block, gsize blo
 static void
 remove_range_in_table_no_lock (GList *entry)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	if (entry != NULL) {
 		if (entry == g_dynamic_function_table_end)
 			g_dynamic_function_table_end = entry->prev;
@@ -1558,8 +1489,6 @@ remove_range_in_table_no_lock (GList *entry)
 void
 mono_arch_unwindinfo_remove_pc_range_in_table (const gpointer code)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	AcquireSRWLockExclusive (&g_dynamic_function_table_lock);
 
 	GList *found_entry = find_pc_in_table_no_lock_ex (code);
@@ -1573,8 +1502,6 @@ mono_arch_unwindinfo_remove_pc_range_in_table (const gpointer code)
 void
 mono_arch_unwindinfo_remove_range_in_table (const gpointer code_block, gsize block_size)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	AcquireSRWLockExclusive (&g_dynamic_function_table_lock);
 
 	GList *found_entry = find_range_in_table_no_lock_ex (code_block, block_size);
@@ -1588,8 +1515,6 @@ mono_arch_unwindinfo_remove_range_in_table (const gpointer code_block, gsize blo
 PRUNTIME_FUNCTION
 mono_arch_unwindinfo_find_rt_func_in_table (const gpointer code, gsize code_size)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	PRUNTIME_FUNCTION found_rt_func = NULL;
 
 	gsize begin_range = (gsize)code;
@@ -1629,8 +1554,6 @@ mono_arch_unwindinfo_find_rt_func_in_table (const gpointer code, gsize code_size
 static inline PRUNTIME_FUNCTION
 mono_arch_unwindinfo_find_pc_rt_func_in_table (const gpointer pc)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return mono_arch_unwindinfo_find_rt_func_in_table (pc, 0);
 }
 
@@ -1638,8 +1561,6 @@ mono_arch_unwindinfo_find_pc_rt_func_in_table (const gpointer pc)
 static void
 validate_rt_funcs_in_table_no_lock (DynamicFunctionTableEntry *entry)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	// Validation method checking that runtime function table is sorted as expected and don't include overlapped regions.
 	// Method will assert on failure to explicitly indicate what check failed.
 	g_assert_checked (entry != NULL);
@@ -1671,15 +1592,12 @@ validate_rt_funcs_in_table_no_lock (DynamicFunctionTableEntry *entry)
 static inline void
 validate_rt_funcs_in_table_no_lock (DynamicFunctionTableEntry *entry)
 {
-	mono_cross_compile_assert_not_reached ();
 }
 #endif /* ENABLE_CHECKED_BUILD_UNWINDINFO */
 
 PRUNTIME_FUNCTION
 mono_arch_unwindinfo_insert_rt_func_in_table (const gpointer code, gsize code_size)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	PRUNTIME_FUNCTION new_rt_func = NULL;
 
 	gsize begin_range = (gsize)code;
@@ -1794,16 +1712,12 @@ mono_arch_unwindinfo_insert_rt_func_in_table (const gpointer code, gsize code_si
 static PRUNTIME_FUNCTION
 MONO_GET_RUNTIME_FUNCTION_CALLBACK ( DWORD64 ControlPc, IN PVOID Context )
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return mono_arch_unwindinfo_find_pc_rt_func_in_table ((gpointer)ControlPc);
 }
 
 static void
 initialize_unwind_info_internal_ex (GSList *unwind_ops, PUNWIND_INFO unwindinfo)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	if (unwind_ops != NULL && unwindinfo != NULL) {
 		MonoUnwindOp *unwind_op_data;
 		gboolean sp_alloced = FALSE;
@@ -1840,8 +1754,6 @@ initialize_unwind_info_internal_ex (GSList *unwind_ops, PUNWIND_INFO unwindinfo)
 static PUNWIND_INFO
 initialize_unwind_info_internal (GSList *unwind_ops)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	PUNWIND_INFO unwindinfo;
 
 	mono_arch_unwindinfo_create ((gpointer*)&unwindinfo);
@@ -1853,8 +1765,6 @@ initialize_unwind_info_internal (GSList *unwind_ops)
 guchar
 mono_arch_unwindinfo_get_code_count (GSList *unwind_ops)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	UNWIND_INFO unwindinfo = {0};
 	initialize_unwind_info_internal_ex (unwind_ops, &unwindinfo);
 	return unwindinfo.CountOfCodes;
@@ -1863,8 +1773,6 @@ mono_arch_unwindinfo_get_code_count (GSList *unwind_ops)
 PUNWIND_INFO
 mono_arch_unwindinfo_alloc_unwind_info (GSList *unwind_ops)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	if (!unwind_ops)
 		return NULL;
 
@@ -1874,16 +1782,12 @@ mono_arch_unwindinfo_alloc_unwind_info (GSList *unwind_ops)
 void
 mono_arch_unwindinfo_free_unwind_info (PUNWIND_INFO unwind_info)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	g_free (unwind_info);
 }
 
 guint
 mono_arch_unwindinfo_init_method_unwind_info (gpointer cfg)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoCompile * current_cfg = (MonoCompile *)cfg;
 	g_assert (current_cfg->arch.unwindinfo == NULL);
 	current_cfg->arch.unwindinfo = initialize_unwind_info_internal (current_cfg->unwind_ops);
@@ -1893,8 +1797,6 @@ mono_arch_unwindinfo_init_method_unwind_info (gpointer cfg)
 void
 mono_arch_unwindinfo_install_method_unwind_info (PUNWIND_INFO *monoui, gpointer code, guint code_size)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	PUNWIND_INFO unwindinfo, targetinfo;
 	guchar codecount;
 	guint64 targetlocation;
@@ -1942,8 +1844,6 @@ mono_arch_unwindinfo_install_method_unwind_info (PUNWIND_INFO *monoui, gpointer 
 void
 mono_arch_unwindinfo_install_tramp_unwind_info (GSList *unwind_ops, gpointer code, guint code_size)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	PUNWIND_INFO unwindinfo = initialize_unwind_info_internal (unwind_ops);
 	if (unwindinfo != NULL) {
 		mono_arch_unwindinfo_install_method_unwind_info (&unwindinfo, code, code_size);
@@ -1953,15 +1853,11 @@ mono_arch_unwindinfo_install_tramp_unwind_info (GSList *unwind_ops, gpointer cod
 void
 mono_arch_code_chunk_new (void *chunk, int size)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	mono_arch_unwindinfo_insert_range_in_table (chunk, size);
 }
 
 void mono_arch_code_chunk_destroy (void *chunk)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	mono_arch_unwindinfo_remove_pc_range_in_table (chunk);
 }
 #endif /* MONO_ARCH_HAVE_UNWIND_TABLE */
@@ -1970,8 +1866,6 @@ void mono_arch_code_chunk_destroy (void *chunk)
 MonoContinuationRestore
 mono_tasklets_arch_restore (void)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	static guint8* saved = NULL;
 	guint8 *code, *start;
 	int cont_reg = AMD64_R9; /* register usable on both call conventions */
@@ -2030,8 +1924,6 @@ mono_tasklets_arch_restore (void)
 void
 mono_arch_setup_resume_sighandler_ctx (MonoContext *ctx, gpointer func)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	/* 
 	 * When resuming from a signal handler, the stack should be misaligned, just like right after
 	 * a call.
@@ -2104,15 +1996,11 @@ mono_tasklets_arch_restore (void)
 void
 mono_arch_undo_ip_adjustment (MonoContext *ctx)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ctx->gregs [AMD64_RIP]++;
 }
 
 void
 mono_arch_do_ip_adjustment (MonoContext *ctx)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ctx->gregs [AMD64_RIP]--;
 }

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -467,7 +467,7 @@ get_throw_trampoline (MonoTrampInfo **info, gboolean rethrow, gboolean corlib, g
 	const guint kMaxCodeSize = 256;
 
 #ifdef TARGET_WIN32
-	const int dummy_stack_space = 6 * sizeof(host_mgreg_t);	/* Windows expects stack space allocated for all 6 dummy args. */
+	const int dummy_stack_space = 6 * sizeof(mgreg_t);	/* Windows expects stack space allocated for all 6 dummy args. */
 #else
 	const int dummy_stack_space = 0;
 #endif
@@ -498,47 +498,47 @@ get_throw_trampoline (MonoTrampInfo **info, gboolean rethrow, gboolean corlib, g
 	 */
 
 	arg_offsets [0] = dummy_stack_space + 0;
-	arg_offsets [1] = dummy_stack_space + sizeof(host_mgreg_t);
-	arg_offsets [2] = dummy_stack_space + sizeof(host_mgreg_t) * 2;
-	arg_offsets [3] = dummy_stack_space + sizeof(host_mgreg_t) * 3;
-	ctx_offset = dummy_stack_space + sizeof(host_mgreg_t) * 4;
+	arg_offsets [1] = dummy_stack_space + sizeof(mgreg_t);
+	arg_offsets [2] = dummy_stack_space + sizeof(mgreg_t) * 2;
+	arg_offsets [3] = dummy_stack_space + sizeof(mgreg_t) * 3;
+	ctx_offset = dummy_stack_space + sizeof(mgreg_t) * 4;
 	regs_offset = ctx_offset + MONO_STRUCT_OFFSET (MonoContext, gregs);
 
 	/* Save registers */
 	for (i = 0; i < AMD64_NREG; ++i)
 		if (i != AMD64_RSP)
-			amd64_mov_membase_reg (code, AMD64_RSP, regs_offset + (i * sizeof(host_mgreg_t)), i, sizeof(host_mgreg_t));
+			amd64_mov_membase_reg (code, AMD64_RSP, regs_offset + (i * sizeof(mgreg_t)), i, sizeof(mgreg_t));
 	/* Save RSP */
-	amd64_lea_membase (code, AMD64_RAX, AMD64_RSP, stack_size + sizeof(host_mgreg_t));
-	amd64_mov_membase_reg (code, AMD64_RSP, regs_offset + (AMD64_RSP * sizeof(host_mgreg_t)), X86_EAX, sizeof(host_mgreg_t));
+	amd64_lea_membase (code, AMD64_RAX, AMD64_RSP, stack_size + sizeof(mgreg_t));
+	amd64_mov_membase_reg (code, AMD64_RSP, regs_offset + (AMD64_RSP * sizeof(mgreg_t)), X86_EAX, sizeof(mgreg_t));
 	/* Save IP */
-	amd64_mov_reg_membase (code, AMD64_RAX, AMD64_RSP, stack_size, sizeof(host_mgreg_t));
-	amd64_mov_membase_reg (code, AMD64_RSP, regs_offset + (AMD64_RIP * sizeof(host_mgreg_t)), AMD64_RAX, sizeof(host_mgreg_t));
+	amd64_mov_reg_membase (code, AMD64_RAX, AMD64_RSP, stack_size, sizeof(mgreg_t));
+	amd64_mov_membase_reg (code, AMD64_RSP, regs_offset + (AMD64_RIP * sizeof(mgreg_t)), AMD64_RAX, sizeof(mgreg_t));
 	/* Set arg1 == ctx */
 	amd64_lea_membase (code, AMD64_RAX, AMD64_RSP, ctx_offset);
-	amd64_mov_membase_reg (code, AMD64_RSP, arg_offsets [0], AMD64_RAX, sizeof(host_mgreg_t));
+	amd64_mov_membase_reg (code, AMD64_RSP, arg_offsets [0], AMD64_RAX, sizeof(mgreg_t));
 	/* Set arg2 == exc/ex_token_index */
 	if (resume_unwind)
-		amd64_mov_membase_imm (code, AMD64_RSP, arg_offsets [1], 0, sizeof(host_mgreg_t));
+		amd64_mov_membase_imm (code, AMD64_RSP, arg_offsets [1], 0, sizeof(mgreg_t));
 	else
-		amd64_mov_membase_reg (code, AMD64_RSP, arg_offsets [1], AMD64_ARG_REG1, sizeof(host_mgreg_t));
+		amd64_mov_membase_reg (code, AMD64_RSP, arg_offsets [1], AMD64_ARG_REG1, sizeof(mgreg_t));
 	/* Set arg3 == rethrow/pc offset */
 	if (resume_unwind) {
-		amd64_mov_membase_imm (code, AMD64_RSP, arg_offsets [2], 0, sizeof(host_mgreg_t));
+		amd64_mov_membase_imm (code, AMD64_RSP, arg_offsets [2], 0, sizeof(mgreg_t));
 	} else if (corlib) {
 		if (llvm_abs)
 			/*
 			 * The caller doesn't pass in a pc/pc offset, instead we simply use the
 			 * caller ip. Negate the pc adjustment done in mono_amd64_throw_corlib_exception ().
 			 */
-			amd64_mov_membase_imm (code, AMD64_RSP, arg_offsets [2], 1, sizeof(host_mgreg_t));
+			amd64_mov_membase_imm (code, AMD64_RSP, arg_offsets [2], 1, sizeof(mgreg_t));
 		else
-			amd64_mov_membase_reg (code, AMD64_RSP, arg_offsets [2], AMD64_ARG_REG2, sizeof(host_mgreg_t));
+			amd64_mov_membase_reg (code, AMD64_RSP, arg_offsets [2], AMD64_ARG_REG2, sizeof(mgreg_t));
 	} else {
-		amd64_mov_membase_imm (code, AMD64_RSP, arg_offsets [2], rethrow, sizeof(host_mgreg_t));
+		amd64_mov_membase_imm (code, AMD64_RSP, arg_offsets [2], rethrow, sizeof(mgreg_t));
 
 		/* Set arg4 == preserve_ips */
-		amd64_mov_membase_imm (code, AMD64_RSP, arg_offsets [3], preserve_ips, sizeof(host_mgreg_t));
+		amd64_mov_membase_imm (code, AMD64_RSP, arg_offsets [3], preserve_ips, sizeof(mgreg_t));
 	}
 
 	if (aot) {

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -674,7 +674,7 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 			new_ctx->gregs [i] = regs [i];
  
 		/* The CFA becomes the new SP value */
-		new_ctx->gregs [AMD64_RSP] = (gsize)cfa;
+		new_ctx->gregs [AMD64_RSP] = (host_mgreg_t)(gsize)cfa;
 
 		/* Adjust IP */
 		new_ctx->gregs [AMD64_RIP] --;

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -772,7 +772,7 @@ mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), g
 
 	guint64 sp = ctx->gregs [AMD64_RSP];
 
-	ctx->gregs [AMD64_RDI] = (guint64)user_data;
+	ctx->gregs [AMD64_RDI] = (gsize)user_data;
 
 	/* Allocate a stack frame below the red zone */
 	sp -= 128;
@@ -784,7 +784,7 @@ mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), g
 	*(guint64*)sp = ctx->gregs [AMD64_RIP];
 #endif
 	ctx->gregs [AMD64_RSP] = sp;
-	ctx->gregs [AMD64_RIP] = (guint64)async_cb;
+	ctx->gregs [AMD64_RIP] = (gsize)async_cb;
 }
 
 /**

--- a/mono/mini/exceptions-arm.c
+++ b/mono/mini/exceptions-arm.c
@@ -501,7 +501,7 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 
 		frame->type = FRAME_TYPE_MANAGED_TO_NATIVE;
 		
-		if ((ji = mini_jit_info_table_find (domain, (gpointer)(*lmf)->ip, NULL))) {
+		if ((ji = mini_jit_info_table_find (domain, (gpointer)(gsize)(*lmf)->ip, NULL))) {
 			frame->ji = ji;
 		} else {
 			if (!(*lmf)->method)

--- a/mono/mini/exceptions-arm.c
+++ b/mono/mini/exceptions-arm.c
@@ -72,7 +72,7 @@ mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 
 	/* move pc to PC */
 	ARM_LDR_IMM (code, ARMREG_IP, ctx_reg, MONO_STRUCT_OFFSET (MonoContext, pc));
-	ARM_STR_IMM (code, ARMREG_IP, ctx_reg, MONO_STRUCT_OFFSET (MonoContext, regs) + (ARMREG_PC * sizeof (mgreg_t)));
+	ARM_STR_IMM (code, ARMREG_IP, ctx_reg, MONO_STRUCT_OFFSET (MonoContext, regs) + (ARMREG_PC * sizeof (host_mgreg_t)));
 
 	/* restore everything */
 	ARM_ADD_REG_IMM8 (code, ARMREG_IP, ctx_reg, MONO_STRUCT_OFFSET(MonoContext, regs));
@@ -102,6 +102,8 @@ mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	guint8 *code;
 	guint8* start;
 	int ctx_reg;
@@ -120,7 +122,7 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 	/* restore all the regs from ctx (in r0), but not sp, the stack pointer */
 	ctx_reg = ARMREG_R0;
 	ARM_LDR_IMM (code, ARMREG_IP, ctx_reg, MONO_STRUCT_OFFSET (MonoContext, pc));
-	ARM_ADD_REG_IMM8 (code, ARMREG_LR, ctx_reg, MONO_STRUCT_OFFSET(MonoContext, regs) + (MONO_ARM_FIRST_SAVED_REG * sizeof (mgreg_t)));
+	ARM_ADD_REG_IMM8 (code, ARMREG_LR, ctx_reg, MONO_STRUCT_OFFSET(MonoContext, regs) + (MONO_ARM_FIRST_SAVED_REG * sizeof (host_mgreg_t)));
 	ARM_LDM (code, ARMREG_LR, MONO_ARM_REGSAVE_MASK);
 	/* call handler at eip (r1) and set the first arg with the exception (r2) */
 	ARM_MOV_REG_REG (code, ARMREG_R0, ARMREG_R2);
@@ -144,8 +146,10 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 }
 
 void
-mono_arm_throw_exception (MonoObject *exc, mgreg_t pc, mgreg_t sp, mgreg_t *int_regs, gdouble *fp_regs, gboolean preserve_ips)
+mono_arm_throw_exception (MonoObject *exc, host_mgreg_t pc, host_mgreg_t sp, host_mgreg_t *int_regs, gdouble *fp_regs, gboolean preserve_ips)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ERROR_DECL (error);
 	MonoContext ctx;
 	gboolean rethrow = sp & 1;
@@ -159,7 +163,7 @@ mono_arm_throw_exception (MonoObject *exc, mgreg_t pc, mgreg_t sp, mgreg_t *int_
 	MONO_CONTEXT_SET_BP (&ctx, int_regs [ARMREG_FP - 4]);
 	MONO_CONTEXT_SET_SP (&ctx, sp);
 	MONO_CONTEXT_SET_IP (&ctx, pc);
-	memcpy (((guint8*)&ctx.regs) + (ARMREG_R4 * sizeof (mgreg_t)), int_regs, 8 * sizeof (mgreg_t));
+	memcpy (((guint8*)&ctx.regs) + (ARMREG_R4 * sizeof (host_mgreg_t)), int_regs, 8 * sizeof (host_mgreg_t));
 	memcpy (&ctx.fregs, fp_regs, sizeof (double) * 16);
 
 	if (mono_object_isinst_checked (exc, mono_defaults.exception_class, error)) {
@@ -178,7 +182,7 @@ mono_arm_throw_exception (MonoObject *exc, mgreg_t pc, mgreg_t sp, mgreg_t *int_
 }
 
 void
-mono_arm_throw_exception_by_token (guint32 ex_token_index, mgreg_t pc, mgreg_t sp, mgreg_t *int_regs, gdouble *fp_regs)
+mono_arm_throw_exception_by_token (guint32 ex_token_index, host_mgreg_t pc, host_mgreg_t sp, host_mgreg_t *int_regs, gdouble *fp_regs)
 {
 	guint32 ex_token = MONO_TOKEN_TYPE_DEF | ex_token_index;
 	/* Clear thumb bit */
@@ -188,8 +192,10 @@ mono_arm_throw_exception_by_token (guint32 ex_token_index, mgreg_t pc, mgreg_t s
 }
 
 void
-mono_arm_resume_unwind (guint32 dummy1, mgreg_t pc, mgreg_t sp, mgreg_t *int_regs, gdouble *fp_regs)
+mono_arm_resume_unwind (guint32 dummy1, host_mgreg_t pc, host_mgreg_t sp, host_mgreg_t *int_regs, gdouble *fp_regs)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MonoContext ctx;
 
 	pc &= ~1; /* clear the optional rethrow bit */
@@ -199,7 +205,7 @@ mono_arm_resume_unwind (guint32 dummy1, mgreg_t pc, mgreg_t sp, mgreg_t *int_reg
 	MONO_CONTEXT_SET_BP (&ctx, int_regs [ARMREG_FP - 4]);
 	MONO_CONTEXT_SET_SP (&ctx, sp);
 	MONO_CONTEXT_SET_IP (&ctx, pc);
-	memcpy (((guint8*)&ctx.regs) + (ARMREG_R4 * sizeof (mgreg_t)), int_regs, 8 * sizeof (mgreg_t));
+	memcpy (((guint8*)&ctx.regs) + (ARMREG_R4 * sizeof (host_mgreg_t)), int_regs, 8 * sizeof (host_mgreg_t));
 
 	mono_resume_unwind (&ctx);
 }
@@ -230,9 +236,9 @@ get_throw_trampoline (int size, gboolean corlib, gboolean rethrow, gboolean llvm
 	ARM_MOV_REG_REG (code, ARMREG_IP, ARMREG_SP);
 	ARM_PUSH (code, MONO_ARM_REGSAVE_MASK);
 
-	cfa_offset = MONO_ARM_NUM_SAVED_REGS * sizeof (mgreg_t);
+	cfa_offset = MONO_ARM_NUM_SAVED_REGS * sizeof (host_mgreg_t);
 	mono_add_unwind_op_def_cfa (unwind_ops, code, start, ARMREG_SP, cfa_offset);
-	mono_add_unwind_op_offset (unwind_ops, code, start, ARMREG_LR, - sizeof (mgreg_t));
+	mono_add_unwind_op_offset (unwind_ops, code, start, ARMREG_LR, - sizeof (host_mgreg_t));
 
 	/* Save fp regs */
 	if (!mono_arch_is_soft_float ()) {
@@ -275,7 +281,7 @@ get_throw_trampoline (int size, gboolean corlib, gboolean rethrow, gboolean llvm
 		ARM_MOV_REG_REG (code, ARMREG_R1, ARMREG_LR); /* caller ip */
 	}
 	/* int regs */
-	ARM_ADD_REG_IMM8 (code, ARMREG_R3, ARMREG_SP, (cfa_offset - (MONO_ARM_NUM_SAVED_REGS * sizeof (mgreg_t))));
+	ARM_ADD_REG_IMM8 (code, ARMREG_R3, ARMREG_SP, (cfa_offset - (MONO_ARM_NUM_SAVED_REGS * sizeof (host_mgreg_t))));
 	if (resume_unwind || corlib) {
 		/* fp regs */
 		ARM_ADD_REG_IMM8 (code, ARMREG_LR, ARMREG_SP, 8);
@@ -430,9 +436,11 @@ gboolean
 mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls, 
 							 MonoJitInfo *ji, MonoContext *ctx, 
 							 MonoContext *new_ctx, MonoLMF **lmf,
-							 mgreg_t **save_locations,
+							 host_mgreg_t **save_locations,
 							 StackFrameInfo *frame)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	gpointer ip = MONO_CONTEXT_GET_IP (ctx);
 
 	memset (frame, 0, sizeof (StackFrameInfo));
@@ -509,7 +517,7 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 		 * produce the register state which existed at the time of the call which
 		 * transitioned to native call, so we save the sp/fp/ip in the LMF.
 		 */
-		memcpy (&new_ctx->regs [0], &(*lmf)->iregs [0], sizeof (mgreg_t) * 13);
+		memcpy (&new_ctx->regs [0], &(*lmf)->iregs [0], sizeof (host_mgreg_t) * 13);
 		new_ctx->pc = (*lmf)->ip;
 		new_ctx->regs [ARMREG_SP] = (*lmf)->sp;
 		new_ctx->regs [ARMREG_FP] = (*lmf)->fp;
@@ -536,6 +544,8 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 static void
 handle_signal_exception (gpointer obj)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
 	MonoContext ctx;
 
@@ -553,6 +563,8 @@ handle_signal_exception (gpointer obj)
 static MONO_NEVER_INLINE gpointer
 get_handle_signal_exception_addr (void)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return (gpointer)handle_signal_exception;
 }
 
@@ -623,7 +635,9 @@ mono_arch_ip_from_context (void *sigctx)
 void
 mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), gpointer user_data)
 {
-	mgreg_t sp = (mgreg_t)MONO_CONTEXT_GET_SP (ctx);
+	mono_cross_compile_assert_not_reached ();
+
+	host_mgreg_t sp = (host_mgreg_t)MONO_CONTEXT_GET_SP (ctx);
 
 	// FIXME:
 	g_assert (!user_data);
@@ -643,8 +657,10 @@ mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), g
 void
 mono_arch_setup_resume_sighandler_ctx (MonoContext *ctx, gpointer func)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MONO_CONTEXT_SET_IP (ctx,func);
-	if ((mgreg_t)MONO_CONTEXT_GET_IP (ctx) & 1)
+	if ((host_mgreg_t)MONO_CONTEXT_GET_IP (ctx) & 1)
 		/* Transition to thumb */
 		ctx->cpsr |= (1 << 5);
 	else
@@ -655,6 +671,8 @@ mono_arch_setup_resume_sighandler_ctx (MonoContext *ctx, gpointer func)
 void
 mono_arch_undo_ip_adjustment (MonoContext *ctx)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ctx->pc++;
 
 	if (mono_arm_thumb_supported ())
@@ -664,6 +682,8 @@ mono_arch_undo_ip_adjustment (MonoContext *ctx)
 void
 mono_arch_do_ip_adjustment (MonoContext *ctx)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	/* Clear thumb bit */
 	ctx->pc &= ~1;
 

--- a/mono/mini/exceptions-arm.c
+++ b/mono/mini/exceptions-arm.c
@@ -72,7 +72,7 @@ mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 
 	/* move pc to PC */
 	ARM_LDR_IMM (code, ARMREG_IP, ctx_reg, MONO_STRUCT_OFFSET (MonoContext, pc));
-	ARM_STR_IMM (code, ARMREG_IP, ctx_reg, MONO_STRUCT_OFFSET (MonoContext, regs) + (ARMREG_PC * sizeof (host_mgreg_t)));
+	ARM_STR_IMM (code, ARMREG_IP, ctx_reg, MONO_STRUCT_OFFSET (MonoContext, regs) + (ARMREG_PC * sizeof (mgreg_t)));
 
 	/* restore everything */
 	ARM_ADD_REG_IMM8 (code, ARMREG_IP, ctx_reg, MONO_STRUCT_OFFSET(MonoContext, regs));
@@ -122,7 +122,7 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 	/* restore all the regs from ctx (in r0), but not sp, the stack pointer */
 	ctx_reg = ARMREG_R0;
 	ARM_LDR_IMM (code, ARMREG_IP, ctx_reg, MONO_STRUCT_OFFSET (MonoContext, pc));
-	ARM_ADD_REG_IMM8 (code, ARMREG_LR, ctx_reg, MONO_STRUCT_OFFSET(MonoContext, regs) + (MONO_ARM_FIRST_SAVED_REG * sizeof (host_mgreg_t)));
+	ARM_ADD_REG_IMM8 (code, ARMREG_LR, ctx_reg, MONO_STRUCT_OFFSET(MonoContext, regs) + (MONO_ARM_FIRST_SAVED_REG * sizeof (mgreg_t)));
 	ARM_LDM (code, ARMREG_LR, MONO_ARM_REGSAVE_MASK);
 	/* call handler at eip (r1) and set the first arg with the exception (r2) */
 	ARM_MOV_REG_REG (code, ARMREG_R0, ARMREG_R2);
@@ -236,9 +236,9 @@ get_throw_trampoline (int size, gboolean corlib, gboolean rethrow, gboolean llvm
 	ARM_MOV_REG_REG (code, ARMREG_IP, ARMREG_SP);
 	ARM_PUSH (code, MONO_ARM_REGSAVE_MASK);
 
-	cfa_offset = MONO_ARM_NUM_SAVED_REGS * sizeof (host_mgreg_t);
+	cfa_offset = MONO_ARM_NUM_SAVED_REGS * sizeof (mgreg_t);
 	mono_add_unwind_op_def_cfa (unwind_ops, code, start, ARMREG_SP, cfa_offset);
-	mono_add_unwind_op_offset (unwind_ops, code, start, ARMREG_LR, - sizeof (host_mgreg_t));
+	mono_add_unwind_op_offset (unwind_ops, code, start, ARMREG_LR, - sizeof (mgreg_t));
 
 	/* Save fp regs */
 	if (!mono_arch_is_soft_float ()) {
@@ -281,7 +281,7 @@ get_throw_trampoline (int size, gboolean corlib, gboolean rethrow, gboolean llvm
 		ARM_MOV_REG_REG (code, ARMREG_R1, ARMREG_LR); /* caller ip */
 	}
 	/* int regs */
-	ARM_ADD_REG_IMM8 (code, ARMREG_R3, ARMREG_SP, (cfa_offset - (MONO_ARM_NUM_SAVED_REGS * sizeof (host_mgreg_t))));
+	ARM_ADD_REG_IMM8 (code, ARMREG_R3, ARMREG_SP, (cfa_offset - (MONO_ARM_NUM_SAVED_REGS * sizeof (mgreg_t))));
 	if (resume_unwind || corlib) {
 		/* fp regs */
 		ARM_ADD_REG_IMM8 (code, ARMREG_LR, ARMREG_SP, 8);

--- a/mono/mini/exceptions-arm.c
+++ b/mono/mini/exceptions-arm.c
@@ -102,8 +102,6 @@ mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint8 *code;
 	guint8* start;
 	int ctx_reg;
@@ -148,8 +146,6 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 void
 mono_arm_throw_exception (MonoObject *exc, host_mgreg_t pc, host_mgreg_t sp, host_mgreg_t *int_regs, gdouble *fp_regs, gboolean preserve_ips)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ERROR_DECL (error);
 	MonoContext ctx;
 	gboolean rethrow = sp & 1;
@@ -194,8 +190,6 @@ mono_arm_throw_exception_by_token (guint32 ex_token_index, host_mgreg_t pc, host
 void
 mono_arm_resume_unwind (guint32 dummy1, host_mgreg_t pc, host_mgreg_t sp, host_mgreg_t *int_regs, gdouble *fp_regs)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoContext ctx;
 
 	pc &= ~1; /* clear the optional rethrow bit */
@@ -439,8 +433,6 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 							 host_mgreg_t **save_locations,
 							 StackFrameInfo *frame)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	gpointer ip = MONO_CONTEXT_GET_IP (ctx);
 
 	memset (frame, 0, sizeof (StackFrameInfo));
@@ -544,8 +536,6 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 static void
 handle_signal_exception (gpointer obj)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
 	MonoContext ctx;
 
@@ -563,8 +553,6 @@ handle_signal_exception (gpointer obj)
 static MONO_NEVER_INLINE gpointer
 get_handle_signal_exception_addr (void)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return (gpointer)handle_signal_exception;
 }
 
@@ -635,8 +623,6 @@ mono_arch_ip_from_context (void *sigctx)
 void
 mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), gpointer user_data)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	host_mgreg_t sp = (host_mgreg_t)MONO_CONTEXT_GET_SP (ctx);
 
 	// FIXME:
@@ -657,8 +643,6 @@ mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), g
 void
 mono_arch_setup_resume_sighandler_ctx (MonoContext *ctx, gpointer func)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MONO_CONTEXT_SET_IP (ctx,func);
 	if ((host_mgreg_t)MONO_CONTEXT_GET_IP (ctx) & 1)
 		/* Transition to thumb */
@@ -671,8 +655,6 @@ mono_arch_setup_resume_sighandler_ctx (MonoContext *ctx, gpointer func)
 void
 mono_arch_undo_ip_adjustment (MonoContext *ctx)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ctx->pc++;
 
 	if (mono_arm_thumb_supported ())
@@ -682,8 +664,6 @@ mono_arch_undo_ip_adjustment (MonoContext *ctx)
 void
 mono_arch_do_ip_adjustment (MonoContext *ctx)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	/* Clear thumb bit */
 	ctx->pc &= ~1;
 

--- a/mono/mini/exceptions-arm64.c
+++ b/mono/mini/exceptions-arm64.c
@@ -26,8 +26,6 @@
 gpointer
 mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint8 *start, *code;
 	MonoJumpInfo *ji = NULL;
 	GSList *unwind_ops = NULL;
@@ -76,8 +74,6 @@ mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint8 *code;
 	guint8* start;
 	int i, size, offset, gregs_offset, fregs_offset, ctx_offset, num_fregs, frame_size;
@@ -167,8 +163,6 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 static gpointer 
 get_throw_trampoline (int size, gboolean corlib, gboolean rethrow, gboolean llvm, gboolean resume_unwind, const char *tramp_name, MonoTrampInfo **info, gboolean aot, gboolean preserve_ips)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint8 *start, *code;
 	MonoJumpInfo *ji = NULL;
 	GSList *unwind_ops = NULL;
@@ -271,40 +265,30 @@ get_throw_trampoline (int size, gboolean corlib, gboolean rethrow, gboolean llvm
 gpointer 
 mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return get_throw_trampoline (256, FALSE, FALSE, FALSE, FALSE, "throw_exception", info, aot, FALSE);
 }
 
 gpointer
 mono_arch_get_rethrow_exception (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return get_throw_trampoline (256, FALSE, TRUE, FALSE, FALSE, "rethrow_exception", info, aot, FALSE);
 }
 
 gpointer
 mono_arch_get_rethrow_preserve_exception (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return get_throw_trampoline (256, FALSE, TRUE, FALSE, FALSE, "rethrow_preserve_exception", info, aot, TRUE);
 }
 
 gpointer 
 mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return get_throw_trampoline (256, TRUE, FALSE, FALSE, FALSE, "throw_corlib_exception", info, aot, FALSE);
 }
 
 GSList*
 mono_arm_get_exception_trampolines (gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoTrampInfo *info;
 	GSList *tramps = NULL;
 
@@ -377,8 +361,6 @@ mono_arm_get_exception_trampolines (gboolean aot)
 void
 mono_arch_exceptions_init (void)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	gpointer tramp;
 	GSList *tramps, *l;
 
@@ -410,8 +392,6 @@ mono_arch_exceptions_init (void)
 void
 mono_arm_throw_exception (gpointer arg, host_mgreg_t pc, host_mgreg_t *int_regs, gdouble *fp_regs, gboolean corlib, gboolean rethrow, gboolean preserve_ips)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ERROR_DECL (error);
 	MonoContext ctx;
 	MonoObject *exc = NULL;
@@ -455,8 +435,6 @@ mono_arm_throw_exception (gpointer arg, host_mgreg_t pc, host_mgreg_t *int_regs,
 void
 mono_arm_resume_unwind (gpointer arg, host_mgreg_t pc, host_mgreg_t *int_regs, gdouble *fp_regs, gboolean corlib, gboolean rethrow)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoContext ctx;
 
 	/* Adjust pc so it points into the call instruction */
@@ -485,8 +463,6 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 							 host_mgreg_t **save_locations,
 							 StackFrameInfo *frame)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	gpointer ip = MONO_CONTEXT_GET_IP (ctx);
 
 	memset (frame, 0, sizeof (StackFrameInfo));
@@ -568,8 +544,6 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 static void
 handle_signal_exception (gpointer obj)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
 	MonoContext ctx;
 
@@ -623,8 +597,6 @@ mono_arch_ip_from_context (void *sigctx)
 void
 mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), gpointer user_data)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	host_mgreg_t sp = (host_mgreg_t)MONO_CONTEXT_GET_SP (ctx);
 
 	// FIXME:
@@ -645,23 +617,17 @@ mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), g
 void
 mono_arch_setup_resume_sighandler_ctx (MonoContext *ctx, gpointer func)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MONO_CONTEXT_SET_IP (ctx,func);
 }
 
 void
 mono_arch_undo_ip_adjustment (MonoContext *ctx)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ctx->pc++;
 }
 
 void
 mono_arch_do_ip_adjustment (MonoContext *ctx)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ctx->pc--;
 }

--- a/mono/mini/exceptions-arm64.c
+++ b/mono/mini/exceptions-arm64.c
@@ -523,7 +523,7 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 			*((host_mgreg_t*)&new_ctx->fregs [8 + i]) = (regs + MONO_MAX_IREGS) [i];
 
 		new_ctx->pc = regs [ARMREG_LR];
-		new_ctx->regs [ARMREG_SP] = (host_mgreg_t)cfa;
+		new_ctx->regs [ARMREG_SP] = (host_mgreg_t)(gsize)cfa;
 
 		if (*lmf && (*lmf)->gregs [MONO_ARCH_LMF_REG_SP] && (MONO_CONTEXT_GET_SP (ctx) >= (gpointer)(*lmf)->gregs [MONO_ARCH_LMF_REG_SP])) {
 			/* remove any unused lmf */
@@ -625,7 +625,7 @@ mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), g
 {
 	mono_cross_compile_assert_not_reached ();
 
-	char* sp = (char*)MONO_CONTEXT_GET_SP (ctx);
+	host_mgreg_t sp = (host_mgreg_t)MONO_CONTEXT_GET_SP (ctx);
 
 	// FIXME:
 	g_assert (!user_data);

--- a/mono/mini/exceptions-arm64.c
+++ b/mono/mini/exceptions-arm64.c
@@ -26,6 +26,8 @@
 gpointer
 mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	guint8 *start, *code;
 	MonoJumpInfo *ji = NULL;
 	GSList *unwind_ops = NULL;
@@ -74,6 +76,8 @@ mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	guint8 *code;
 	guint8* start;
 	int i, size, offset, gregs_offset, fregs_offset, ctx_offset, num_fregs, frame_size;
@@ -163,6 +167,8 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 static gpointer 
 get_throw_trampoline (int size, gboolean corlib, gboolean rethrow, gboolean llvm, gboolean resume_unwind, const char *tramp_name, MonoTrampInfo **info, gboolean aot, gboolean preserve_ips)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	guint8 *start, *code;
 	MonoJumpInfo *ji = NULL;
 	GSList *unwind_ops = NULL;
@@ -265,30 +271,40 @@ get_throw_trampoline (int size, gboolean corlib, gboolean rethrow, gboolean llvm
 gpointer 
 mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return get_throw_trampoline (256, FALSE, FALSE, FALSE, FALSE, "throw_exception", info, aot, FALSE);
 }
 
 gpointer
 mono_arch_get_rethrow_exception (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return get_throw_trampoline (256, FALSE, TRUE, FALSE, FALSE, "rethrow_exception", info, aot, FALSE);
 }
 
 gpointer
 mono_arch_get_rethrow_preserve_exception (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return get_throw_trampoline (256, FALSE, TRUE, FALSE, FALSE, "rethrow_preserve_exception", info, aot, TRUE);
 }
 
 gpointer 
 mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return get_throw_trampoline (256, TRUE, FALSE, FALSE, FALSE, "throw_corlib_exception", info, aot, FALSE);
 }
 
 GSList*
 mono_arm_get_exception_trampolines (gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MonoTrampInfo *info;
 	GSList *tramps = NULL;
 
@@ -361,6 +377,8 @@ mono_arm_get_exception_trampolines (gboolean aot)
 void
 mono_arch_exceptions_init (void)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	gpointer tramp;
 	GSList *tramps, *l;
 
@@ -390,8 +408,10 @@ mono_arch_exceptions_init (void)
  * FP_REGS points to the 8 callee saved fp regs.
  */
 void
-mono_arm_throw_exception (gpointer arg, mgreg_t pc, mgreg_t *int_regs, gdouble *fp_regs, gboolean corlib, gboolean rethrow, gboolean preserve_ips)
+mono_arm_throw_exception (gpointer arg, host_mgreg_t pc, host_mgreg_t *int_regs, gdouble *fp_regs, gboolean corlib, gboolean rethrow, gboolean preserve_ips)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ERROR_DECL (error);
 	MonoContext ctx;
 	MonoObject *exc = NULL;
@@ -410,7 +430,7 @@ mono_arm_throw_exception (gpointer arg, mgreg_t pc, mgreg_t *int_regs, gdouble *
 
 	/* Initialize a ctx based on the arguments */
 	memset (&ctx, 0, sizeof (MonoContext));
-	memcpy (&(ctx.regs [0]), int_regs, sizeof (mgreg_t) * 32);
+	memcpy (&(ctx.regs [0]), int_regs, sizeof (host_mgreg_t) * 32);
 	for (int i = 0; i < 8; i++)
 		*((gdouble*)&ctx.fregs [ARMREG_D8 + i]) = fp_regs [i];
 	ctx.has_fregs = 1;
@@ -433,8 +453,10 @@ mono_arm_throw_exception (gpointer arg, mgreg_t pc, mgreg_t *int_regs, gdouble *
 }
 
 void
-mono_arm_resume_unwind (gpointer arg, mgreg_t pc, mgreg_t *int_regs, gdouble *fp_regs, gboolean corlib, gboolean rethrow)
+mono_arm_resume_unwind (gpointer arg, host_mgreg_t pc, host_mgreg_t *int_regs, gdouble *fp_regs, gboolean corlib, gboolean rethrow)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MonoContext ctx;
 
 	/* Adjust pc so it points into the call instruction */
@@ -442,7 +464,7 @@ mono_arm_resume_unwind (gpointer arg, mgreg_t pc, mgreg_t *int_regs, gdouble *fp
 
 	/* Initialize a ctx based on the arguments */
 	memset (&ctx, 0, sizeof (MonoContext));
-	memcpy (&(ctx.regs [0]), int_regs, sizeof (mgreg_t) * 32);
+	memcpy (&(ctx.regs [0]), int_regs, sizeof (host_mgreg_t) * 32);
 	for (int i = 0; i < 8; i++)
 		*((gdouble*)&ctx.fregs [ARMREG_D8 + i]) = fp_regs [i];
 	ctx.has_fregs = 1;
@@ -460,9 +482,11 @@ gboolean
 mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls, 
 							 MonoJitInfo *ji, MonoContext *ctx, 
 							 MonoContext *new_ctx, MonoLMF **lmf,
-							 mgreg_t **save_locations,
+							 host_mgreg_t **save_locations,
 							 StackFrameInfo *frame)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	gpointer ip = MONO_CONTEXT_GET_IP (ctx);
 
 	memset (frame, 0, sizeof (StackFrameInfo));
@@ -471,7 +495,7 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 	*new_ctx = *ctx;
 
 	if (ji != NULL) {
-		mgreg_t regs [MONO_MAX_IREGS + 8 + 1];
+		host_mgreg_t regs [MONO_MAX_IREGS + 8 + 1];
 		guint8 *cfa;
 		guint32 unwind_info_len;
 		guint8 *unwind_info;
@@ -484,22 +508,22 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 
 		unwind_info = mono_jinfo_get_unwind_info (ji, &unwind_info_len);
 
-		memcpy (regs, &new_ctx->regs, sizeof (mgreg_t) * 32);
+		memcpy (regs, &new_ctx->regs, sizeof (host_mgreg_t) * 32);
 		/* v8..v15 are callee saved */
 		for (int i = 0; i < 8; i++)
-			(regs + MONO_MAX_IREGS) [i] = *((mgreg_t*)&new_ctx->fregs [8 + i]);
+			(regs + MONO_MAX_IREGS) [i] = *((host_mgreg_t*)&new_ctx->fregs [8 + i]);
 
 		mono_unwind_frame (unwind_info, unwind_info_len, (guint8*)ji->code_start,
 						   (guint8*)ji->code_start + ji->code_size,
 						   (guint8*)ip, NULL, regs, MONO_MAX_IREGS + 8,
 						   save_locations, MONO_MAX_IREGS, (guint8**)&cfa);
 
-		memcpy (&new_ctx->regs, regs, sizeof (mgreg_t) * 32);
+		memcpy (&new_ctx->regs, regs, sizeof (host_mgreg_t) * 32);
 		for (int i = 0; i < 8; i++)
-			*((mgreg_t*)&new_ctx->fregs [8 + i]) = (regs + MONO_MAX_IREGS) [i];
+			*((host_mgreg_t*)&new_ctx->fregs [8 + i]) = (regs + MONO_MAX_IREGS) [i];
 
 		new_ctx->pc = regs [ARMREG_LR];
-		new_ctx->regs [ARMREG_SP] = (mgreg_t)cfa;
+		new_ctx->regs [ARMREG_SP] = (host_mgreg_t)cfa;
 
 		if (*lmf && (*lmf)->gregs [MONO_ARCH_LMF_REG_SP] && (MONO_CONTEXT_GET_SP (ctx) >= (gpointer)(*lmf)->gregs [MONO_ARCH_LMF_REG_SP])) {
 			/* remove any unused lmf */
@@ -520,7 +544,7 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 			return FALSE;
 
 		g_assert (MONO_ARCH_LMF_REGS == ((0x3ff << 19) | (1 << ARMREG_FP) | (1 << ARMREG_SP)));
-		memcpy (&new_ctx->regs [ARMREG_R19], &(*lmf)->gregs [0], sizeof (mgreg_t) * 10);
+		memcpy (&new_ctx->regs [ARMREG_R19], &(*lmf)->gregs [0], sizeof (host_mgreg_t) * 10);
 		new_ctx->regs [ARMREG_FP] = (*lmf)->gregs [MONO_ARCH_LMF_REG_FP];
 		new_ctx->regs [ARMREG_SP] = (*lmf)->gregs [MONO_ARCH_LMF_REG_SP];
 		new_ctx->pc = (*lmf)->pc;
@@ -544,6 +568,8 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 static void
 handle_signal_exception (gpointer obj)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
 	MonoContext ctx;
 
@@ -597,7 +623,9 @@ mono_arch_ip_from_context (void *sigctx)
 void
 mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), gpointer user_data)
 {
-	mgreg_t sp = (mgreg_t)MONO_CONTEXT_GET_SP (ctx);
+	mono_cross_compile_assert_not_reached ();
+
+	char* sp = (char*)MONO_CONTEXT_GET_SP (ctx);
 
 	// FIXME:
 	g_assert (!user_data);
@@ -617,17 +645,23 @@ mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), g
 void
 mono_arch_setup_resume_sighandler_ctx (MonoContext *ctx, gpointer func)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MONO_CONTEXT_SET_IP (ctx,func);
 }
 
 void
 mono_arch_undo_ip_adjustment (MonoContext *ctx)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ctx->pc++;
 }
 
 void
 mono_arch_do_ip_adjustment (MonoContext *ctx)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ctx->pc--;
 }

--- a/mono/mini/exceptions-mips.c
+++ b/mono/mini/exceptions-mips.c
@@ -42,8 +42,6 @@
 gpointer
 mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	int i;
 	guint8 *code;
 	static guint8 start [512];
@@ -102,8 +100,6 @@ mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	static guint8 start [320];
 	static int inited = 0;
 	guint8 *code;
@@ -183,8 +179,6 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 static void
 throw_exception (MonoObject *exc, unsigned long eip, unsigned long esp, gboolean rethrow, gboolean preserve_ips)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ERROR_DECL (error);
 	MonoContext ctx;
 
@@ -237,8 +231,6 @@ throw_exception (MonoObject *exc, unsigned long eip, unsigned long esp, gboolean
 static gpointer 
 mono_arch_get_throw_exception_generic (guint8 *start, int size, int corlib, gboolean rethrow, gboolean preserve_ips)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint8 *code;
 	int alloc_size, pos, i;
 
@@ -313,8 +305,6 @@ mono_arch_get_throw_exception_generic (guint8 *start, int size, int corlib, gboo
 gpointer
 mono_arch_get_rethrow_exception (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	static guint8 start [GENERIC_EXCEPTION_SIZE];
 	static int inited = 0;
 
@@ -368,8 +358,6 @@ mono_arch_get_rethrow_preserve_exception (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	static guint8 start [GENERIC_EXCEPTION_SIZE];
 	static int inited = 0;
 
@@ -387,8 +375,6 @@ mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 gpointer 
 mono_arch_get_throw_exception_by_name (void)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint8 *start, *code;
 	int size = 64;
 
@@ -410,8 +396,6 @@ mono_arch_get_throw_exception_by_name (void)
 gpointer
 mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	static guint8 start [GENERIC_EXCEPTION_SIZE];
 	static int inited = 0;
 
@@ -441,8 +425,6 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 							 host_mgreg_t **save_locations,
 							 StackFrameInfo *frame)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	memset (frame, 0, sizeof (StackFrameInfo));
 	frame->ji = ji;
 
@@ -519,8 +501,6 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 gpointer
 mono_arch_ip_from_context (void *sigctx)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return (gpointer)(gsize)UCONTEXT_REG_PC (sigctx);
 }
 
@@ -532,8 +512,6 @@ mono_arch_ip_from_context (void *sigctx)
 static void
 handle_signal_exception (gpointer obj)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
 	MonoContext ctx;
 
@@ -550,8 +528,6 @@ handle_signal_exception (gpointer obj)
 gboolean
 mono_arch_handle_exception (void *ctx, gpointer obj)
 {
-	mono_cross_compile_assert_not_reached ();
-
 #if defined(MONO_CROSS_COMPILE)
 	g_assert_not_reached ();
 #elif defined(MONO_ARCH_USE_SIGACTION)
@@ -600,7 +576,5 @@ mono_arch_handle_exception (void *ctx, gpointer obj)
 void
 mono_arch_setup_resume_sighandler_ctx (MonoContext *ctx, gpointer func)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MONO_CONTEXT_SET_IP (ctx,func);
 }

--- a/mono/mini/exceptions-mips.c
+++ b/mono/mini/exceptions-mips.c
@@ -42,6 +42,8 @@
 gpointer
 mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	int i;
 	guint8 *code;
 	static guint8 start [512];
@@ -100,6 +102,8 @@ mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	static guint8 start [320];
 	static int inited = 0;
 	guint8 *code;
@@ -179,6 +183,8 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 static void
 throw_exception (MonoObject *exc, unsigned long eip, unsigned long esp, gboolean rethrow, gboolean preserve_ips)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ERROR_DECL (error);
 	MonoContext ctx;
 
@@ -231,6 +237,8 @@ throw_exception (MonoObject *exc, unsigned long eip, unsigned long esp, gboolean
 static gpointer 
 mono_arch_get_throw_exception_generic (guint8 *start, int size, int corlib, gboolean rethrow, gboolean preserve_ips)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	guint8 *code;
 	int alloc_size, pos, i;
 
@@ -305,6 +313,8 @@ mono_arch_get_throw_exception_generic (guint8 *start, int size, int corlib, gboo
 gpointer
 mono_arch_get_rethrow_exception (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	static guint8 start [GENERIC_EXCEPTION_SIZE];
 	static int inited = 0;
 
@@ -358,6 +368,8 @@ mono_arch_get_rethrow_preserve_exception (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	static guint8 start [GENERIC_EXCEPTION_SIZE];
 	static int inited = 0;
 
@@ -375,6 +387,8 @@ mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 gpointer 
 mono_arch_get_throw_exception_by_name (void)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	guint8 *start, *code;
 	int size = 64;
 
@@ -396,6 +410,8 @@ mono_arch_get_throw_exception_by_name (void)
 gpointer
 mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	static guint8 start [GENERIC_EXCEPTION_SIZE];
 	static int inited = 0;
 
@@ -422,9 +438,11 @@ gboolean
 mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls, 
 							 MonoJitInfo *ji, MonoContext *ctx, 
 							 MonoContext *new_ctx, MonoLMF **lmf, 
-							 mgreg_t **save_locations,
+							 host_mgreg_t **save_locations,
 							 StackFrameInfo *frame)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	memset (frame, 0, sizeof (StackFrameInfo));
 	frame->ji = ji;
 
@@ -433,7 +451,7 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 	if (ji != NULL) {
 		int i;
 		gpointer ip = MONO_CONTEXT_GET_IP (ctx);
-		mgreg_t regs [MONO_MAX_IREGS + 1];
+		host_mgreg_t regs [MONO_MAX_IREGS + 1];
 		guint8 *cfa;
 		guint32 unwind_info_len;
 		guint8 *unwind_info;
@@ -456,7 +474,7 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 		for (i = 0; i < MONO_MAX_IREGS; ++i)
 			new_ctx->sc_regs [i] = regs [i];
 		new_ctx->sc_pc = regs [mips_ra];
-		new_ctx->sc_regs [mips_sp] = (mgreg_t)cfa;
+		new_ctx->sc_regs [mips_sp] = (host_mgreg_t)cfa;
 
 		/* we substract 8, so that the IP points into the call instruction */
 		MONO_CONTEXT_SET_IP (new_ctx, new_ctx->sc_pc - 8);
@@ -501,6 +519,8 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 gpointer
 mono_arch_ip_from_context (void *sigctx)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return (gpointer)(gsize)UCONTEXT_REG_PC (sigctx);
 }
 
@@ -512,6 +532,8 @@ mono_arch_ip_from_context (void *sigctx)
 static void
 handle_signal_exception (gpointer obj)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
 	MonoContext ctx;
 
@@ -528,6 +550,8 @@ handle_signal_exception (gpointer obj)
 gboolean
 mono_arch_handle_exception (void *ctx, gpointer obj)
 {
+	mono_cross_compile_assert_not_reached ();
+
 #if defined(MONO_CROSS_COMPILE)
 	g_assert_not_reached ();
 #elif defined(MONO_ARCH_USE_SIGACTION)
@@ -576,5 +600,7 @@ mono_arch_handle_exception (void *ctx, gpointer obj)
 void
 mono_arch_setup_resume_sighandler_ctx (MonoContext *ctx, gpointer func)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MONO_CONTEXT_SET_IP (ctx,func);
 }

--- a/mono/mini/exceptions-mips.c
+++ b/mono/mini/exceptions-mips.c
@@ -474,7 +474,7 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 		for (i = 0; i < MONO_MAX_IREGS; ++i)
 			new_ctx->sc_regs [i] = regs [i];
 		new_ctx->sc_pc = regs [mips_ra];
-		new_ctx->sc_regs [mips_sp] = (host_mgreg_t)cfa;
+		new_ctx->sc_regs [mips_sp] = (host_mgreg_t)(gsize)cfa;
 
 		/* we substract 8, so that the IP points into the call instruction */
 		MONO_CONTEXT_SET_IP (new_ctx, new_ctx->sc_pc - 8);

--- a/mono/mini/exceptions-ppc.c
+++ b/mono/mini/exceptions-ppc.c
@@ -182,8 +182,6 @@ typedef elf_fpreg_t elf_fpregset_t[ELF_NFPREG];
 guint8*
 mono_ppc_create_pre_code_ftnptr (guint8 *code)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoPPCFunctionDescriptor *ftnptr = (MonoPPCFunctionDescriptor*)code;
 
 	code += sizeof (MonoPPCFunctionDescriptor);
@@ -204,8 +202,6 @@ mono_ppc_create_pre_code_ftnptr (guint8 *code)
 gpointer
 mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint8 *start, *code;
 	int size = MONO_PPC_32_64_CASE (128, 172) + PPC_FTNPTR_SIZE;
 	MonoJumpInfo *ji = NULL;
@@ -243,8 +239,6 @@ mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 static guint8*
 emit_save_saved_regs (guint8 *code, int pos)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	int i;
 
 	for (i = MONO_MAX_FREGS - 1; i >= MONO_PPC_FIRST_SAVED_FREG; --i) {
@@ -268,8 +262,6 @@ emit_save_saved_regs (guint8 *code, int pos)
 gpointer
 mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint8 *start, *code;
 	int alloc_size, pos, i;
 	int size = MONO_PPC_32_64_CASE (320, 500) + PPC_FTNPTR_SIZE;
@@ -332,8 +324,6 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 void
 mono_ppc_throw_exception (MonoObject *exc, unsigned long eip, unsigned long esp, host_mgreg_t *int_regs, gdouble *fp_regs, gboolean rethrow, gboolean preserve_ips)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ERROR_DECL (error);
 	MonoContext ctx;
 
@@ -376,8 +366,6 @@ mono_ppc_throw_exception (MonoObject *exc, unsigned long eip, unsigned long esp,
 static gpointer
 mono_arch_get_throw_exception_generic (int size, MonoTrampInfo **info, int corlib, gboolean rethrow, gboolean aot, gboolean preserve_ips)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint8 *start, *code;
 	int alloc_size, pos;
 	MonoJumpInfo *ji = NULL;
@@ -495,8 +483,6 @@ mono_arch_get_rethrow_preserve_exception (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_rethrow_exception (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	int size = MONO_PPC_32_64_CASE (132, 224) + PPC_FTNPTR_SIZE;
 
 	if (aot)
@@ -519,8 +505,6 @@ mono_arch_get_rethrow_exception (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	int size = MONO_PPC_32_64_CASE (132, 224) + PPC_FTNPTR_SIZE;
 
 	if (aot)
@@ -538,8 +522,6 @@ mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	int size = MONO_PPC_32_64_CASE (168, 304) + PPC_FTNPTR_SIZE;
 
 	if (aot)
@@ -559,8 +541,6 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 							 host_mgreg_t **save_locations,
 							 StackFrameInfo *frame)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	gpointer ip = MONO_CONTEXT_GET_IP (ctx);
 	MonoPPCStackFrame *sframe;
 
@@ -650,8 +630,6 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 gpointer
 mono_arch_ip_from_context (void *sigctx)
 {
-	mono_cross_compile_assert_not_reached ();
-
 #ifdef MONO_CROSS_COMPILE
 	g_assert_not_reached ();
 #else
@@ -663,8 +641,6 @@ mono_arch_ip_from_context (void *sigctx)
 static void
 altstack_handle_and_restore (void *sigctx, gpointer obj)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoContext mctx;
 
 	mono_sigctx_to_monoctx (sigctx, &mctx);
@@ -675,8 +651,6 @@ altstack_handle_and_restore (void *sigctx, gpointer obj)
 void
 mono_arch_handle_altstack_exception (void *sigctx, MONO_SIG_HANDLER_INFO_TYPE *siginfo, gpointer fault_addr, gboolean stack_ovf)
 {
-	mono_cross_compile_assert_not_reached ();
-
 #ifdef MONO_CROSS_COMPILE
 	g_assert_not_reached ();
 #else
@@ -753,8 +727,6 @@ mono_arch_handle_altstack_exception (void *sigctx, MONO_SIG_HANDLER_INFO_TYPE *s
 static void
 handle_signal_exception (gpointer obj)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
 	MonoContext ctx;
 
@@ -768,8 +740,6 @@ handle_signal_exception (gpointer obj)
 static void
 setup_ucontext_return (void *uc, gpointer func)
 {
-	mono_cross_compile_assert_not_reached ();
-
 #if !defined(MONO_CROSS_COMPILE)
 	UCONTEXT_REG_LNK(uc) = UCONTEXT_REG_NIP(uc);
 #ifdef PPC_USES_FUNCTION_DESCRIPTOR
@@ -793,8 +763,6 @@ setup_ucontext_return (void *uc, gpointer func)
 gboolean
 mono_arch_handle_exception (void *ctx, gpointer obj)
 {
-	mono_cross_compile_assert_not_reached ();
-
 #if defined(MONO_ARCH_USE_SIGACTION) && defined(UCONTEXT_REG_Rn)
 	/*
 	 * Handling the exception in the signal handler is problematic, since the original
@@ -843,8 +811,6 @@ mono_arch_handle_exception (void *ctx, gpointer obj)
 void
 mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), gpointer user_data)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	uintptr_t sp = (uintptr_t) MONO_CONTEXT_GET_SP(ctx);
 	ctx->regs [PPC_FIRST_ARG_REG] = user_data;
 	sp -= PPC_MINIMAL_STACK_SIZE;
@@ -856,8 +822,6 @@ mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), g
 void
 mono_arch_setup_resume_sighandler_ctx (MonoContext *ctx, gpointer func)
 {
-	mono_cross_compile_assert_not_reached ();
-
 #ifdef PPC_USES_FUNCTION_DESCRIPTOR
 	MonoPPCFunctionDescriptor *handler_ftnptr = (MonoPPCFunctionDescriptor*)func;
 	MONO_CONTEXT_SET_IP(ctx, (gulong)handler_ftnptr->code);

--- a/mono/mini/exceptions-ppc.c
+++ b/mono/mini/exceptions-ppc.c
@@ -182,6 +182,8 @@ typedef elf_fpreg_t elf_fpregset_t[ELF_NFPREG];
 guint8*
 mono_ppc_create_pre_code_ftnptr (guint8 *code)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MonoPPCFunctionDescriptor *ftnptr = (MonoPPCFunctionDescriptor*)code;
 
 	code += sizeof (MonoPPCFunctionDescriptor);
@@ -202,6 +204,8 @@ mono_ppc_create_pre_code_ftnptr (guint8 *code)
 gpointer
 mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	guint8 *start, *code;
 	int size = MONO_PPC_32_64_CASE (128, 172) + PPC_FTNPTR_SIZE;
 	MonoJumpInfo *ji = NULL;
@@ -239,6 +243,8 @@ mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 static guint8*
 emit_save_saved_regs (guint8 *code, int pos)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	int i;
 
 	for (i = MONO_MAX_FREGS - 1; i >= MONO_PPC_FIRST_SAVED_FREG; --i) {
@@ -262,6 +268,8 @@ emit_save_saved_regs (guint8 *code, int pos)
 gpointer
 mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	guint8 *start, *code;
 	int alloc_size, pos, i;
 	int size = MONO_PPC_32_64_CASE (320, 500) + PPC_FTNPTR_SIZE;
@@ -322,8 +330,10 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 }
 
 void
-mono_ppc_throw_exception (MonoObject *exc, unsigned long eip, unsigned long esp, mgreg_t *int_regs, gdouble *fp_regs, gboolean rethrow, gboolean preserve_ips)
+mono_ppc_throw_exception (MonoObject *exc, unsigned long eip, unsigned long esp, host_mgreg_t *int_regs, gdouble *fp_regs, gboolean rethrow, gboolean preserve_ips)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ERROR_DECL (error);
 	MonoContext ctx;
 
@@ -335,7 +345,7 @@ mono_ppc_throw_exception (MonoObject *exc, unsigned long eip, unsigned long esp,
 	/*printf ("stack in throw: %p\n", esp);*/
 	MONO_CONTEXT_SET_BP (&ctx, esp);
 	MONO_CONTEXT_SET_IP (&ctx, eip);
-	memcpy (&ctx.regs, int_regs, sizeof (mgreg_t) * MONO_MAX_IREGS);
+	memcpy (&ctx.regs, int_regs, sizeof (host_mgreg_t) * MONO_MAX_IREGS);
 	memcpy (&ctx.fregs, fp_regs, sizeof (double) * MONO_MAX_FREGS);
 
 	if (mono_object_isinst_checked (exc, mono_defaults.exception_class, error)) {
@@ -366,6 +376,8 @@ mono_ppc_throw_exception (MonoObject *exc, unsigned long eip, unsigned long esp,
 static gpointer
 mono_arch_get_throw_exception_generic (int size, MonoTrampInfo **info, int corlib, gboolean rethrow, gboolean aot, gboolean preserve_ips)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	guint8 *start, *code;
 	int alloc_size, pos;
 	MonoJumpInfo *ji = NULL;
@@ -483,6 +495,8 @@ mono_arch_get_rethrow_preserve_exception (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_rethrow_exception (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	int size = MONO_PPC_32_64_CASE (132, 224) + PPC_FTNPTR_SIZE;
 
 	if (aot)
@@ -505,6 +519,8 @@ mono_arch_get_rethrow_exception (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	int size = MONO_PPC_32_64_CASE (132, 224) + PPC_FTNPTR_SIZE;
 
 	if (aot)
@@ -522,6 +538,8 @@ mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	int size = MONO_PPC_32_64_CASE (168, 304) + PPC_FTNPTR_SIZE;
 
 	if (aot)
@@ -538,9 +556,11 @@ gboolean
 mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls, 
 							 MonoJitInfo *ji, MonoContext *ctx, 
 							 MonoContext *new_ctx, MonoLMF **lmf,
-							 mgreg_t **save_locations,
+							 host_mgreg_t **save_locations,
 							 StackFrameInfo *frame)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	gpointer ip = MONO_CONTEXT_GET_IP (ctx);
 	MonoPPCStackFrame *sframe;
 
@@ -552,7 +572,7 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 
 	if (ji != NULL) {
 		int i;
-		mgreg_t regs [ppc_lr + 1];
+		host_mgreg_t regs [ppc_lr + 1];
 		guint8 *cfa;
 		guint32 unwind_info_len;
 		guint8 *unwind_info;
@@ -570,7 +590,7 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 			/* sframe->sp points just past the end of the LMF */
 			guint8 *lmf_addr = (guint8*)sframe->sp - sizeof (MonoLMF);
 			memcpy (&new_ctx->fregs [MONO_PPC_FIRST_SAVED_FREG], lmf_addr + G_STRUCT_OFFSET (MonoLMF, fregs), sizeof (double) * MONO_SAVED_FREGS);
-			memcpy (&new_ctx->regs [MONO_PPC_FIRST_SAVED_GREG], lmf_addr + G_STRUCT_OFFSET (MonoLMF, iregs), sizeof (mgreg_t) * MONO_SAVED_GREGS);
+			memcpy (&new_ctx->regs [MONO_PPC_FIRST_SAVED_GREG], lmf_addr + G_STRUCT_OFFSET (MonoLMF, iregs), sizeof (host_mgreg_t) * MONO_SAVED_GREGS);
 			/* the calling IP is in the parent frame */
 			sframe = (MonoPPCStackFrame*)sframe->sp;
 			/* we substract 4, so that the IP points into the call instruction */
@@ -611,7 +631,7 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 		MONO_CONTEXT_SET_IP (new_ctx, sframe->lr);*/
 		MONO_CONTEXT_SET_BP (new_ctx, (*lmf)->ebp);
 		MONO_CONTEXT_SET_IP (new_ctx, (*lmf)->eip);
-		memcpy (&new_ctx->regs [MONO_PPC_FIRST_SAVED_GREG], (*lmf)->iregs, sizeof (mgreg_t) * MONO_SAVED_GREGS);
+		memcpy (&new_ctx->regs [MONO_PPC_FIRST_SAVED_GREG], (*lmf)->iregs, sizeof (host_mgreg_t) * MONO_SAVED_GREGS);
 		memcpy (&new_ctx->fregs [MONO_PPC_FIRST_SAVED_FREG], (*lmf)->fregs, sizeof (double) * MONO_SAVED_FREGS);
 
 		frame->ji = ji;
@@ -630,6 +650,8 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 gpointer
 mono_arch_ip_from_context (void *sigctx)
 {
+	mono_cross_compile_assert_not_reached ();
+
 #ifdef MONO_CROSS_COMPILE
 	g_assert_not_reached ();
 #else
@@ -641,6 +663,8 @@ mono_arch_ip_from_context (void *sigctx)
 static void
 altstack_handle_and_restore (void *sigctx, gpointer obj)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MonoContext mctx;
 
 	mono_sigctx_to_monoctx (sigctx, &mctx);
@@ -651,6 +675,8 @@ altstack_handle_and_restore (void *sigctx, gpointer obj)
 void
 mono_arch_handle_altstack_exception (void *sigctx, MONO_SIG_HANDLER_INFO_TYPE *siginfo, gpointer fault_addr, gboolean stack_ovf)
 {
+	mono_cross_compile_assert_not_reached ();
+
 #ifdef MONO_CROSS_COMPILE
 	g_assert_not_reached ();
 #else
@@ -727,6 +753,8 @@ mono_arch_handle_altstack_exception (void *sigctx, MONO_SIG_HANDLER_INFO_TYPE *s
 static void
 handle_signal_exception (gpointer obj)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
 	MonoContext ctx;
 
@@ -740,6 +768,8 @@ handle_signal_exception (gpointer obj)
 static void
 setup_ucontext_return (void *uc, gpointer func)
 {
+	mono_cross_compile_assert_not_reached ();
+
 #if !defined(MONO_CROSS_COMPILE)
 	UCONTEXT_REG_LNK(uc) = UCONTEXT_REG_NIP(uc);
 #ifdef PPC_USES_FUNCTION_DESCRIPTOR
@@ -763,6 +793,8 @@ setup_ucontext_return (void *uc, gpointer func)
 gboolean
 mono_arch_handle_exception (void *ctx, gpointer obj)
 {
+	mono_cross_compile_assert_not_reached ();
+
 #if defined(MONO_ARCH_USE_SIGACTION) && defined(UCONTEXT_REG_Rn)
 	/*
 	 * Handling the exception in the signal handler is problematic, since the original
@@ -770,7 +802,7 @@ mono_arch_handle_exception (void *ctx, gpointer obj)
 	 * resume into the normal stack and do most work there if possible.
 	 */
 	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
-	mgreg_t sp;
+	host_mgreg_t sp;
 	void *sigctx = ctx;
 	int frame_size;
 	void *uc = sigctx;
@@ -785,9 +817,9 @@ mono_arch_handle_exception (void *ctx, gpointer obj)
 	frame_size = 224;
 	frame_size += 15;
 	frame_size &= ~15;
-	sp = (mgreg_t)(UCONTEXT_REG_Rn(uc, 1) & ~15);
-	sp = (mgreg_t)(sp - frame_size);
-	UCONTEXT_REG_Rn(uc, 1) = (mgreg_t)sp;
+	sp = (host_mgreg_t)(UCONTEXT_REG_Rn(uc, 1) & ~15);
+	sp = (host_mgreg_t)(sp - frame_size);
+	UCONTEXT_REG_Rn(uc, 1) = (host_mgreg_t)sp;
 	setup_ucontext_return (uc, handle_signal_exception);
 
 	return TRUE;
@@ -811,6 +843,8 @@ mono_arch_handle_exception (void *ctx, gpointer obj)
 void
 mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), gpointer user_data)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	uintptr_t sp = (uintptr_t) MONO_CONTEXT_GET_SP(ctx);
 	ctx->regs [PPC_FIRST_ARG_REG] = user_data;
 	sp -= PPC_MINIMAL_STACK_SIZE;
@@ -822,6 +856,8 @@ mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), g
 void
 mono_arch_setup_resume_sighandler_ctx (MonoContext *ctx, gpointer func)
 {
+	mono_cross_compile_assert_not_reached ();
+
 #ifdef PPC_USES_FUNCTION_DESCRIPTOR
 	MonoPPCFunctionDescriptor *handler_ftnptr = (MonoPPCFunctionDescriptor*)func;
 	MONO_CONTEXT_SET_IP(ctx, (gulong)handler_ftnptr->code);

--- a/mono/mini/exceptions-s390x.c
+++ b/mono/mini/exceptions-s390x.c
@@ -103,8 +103,6 @@ typedef enum {
 gpointer
 mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	static guint8 *start;
 	static int inited = 0;
 	guint8 *code;
@@ -245,8 +243,6 @@ throw_exception (MonoObject *exc, unsigned long ip, unsigned long sp,
 		 host_mgreg_t *int_regs, gdouble *fp_regs, gint32 *acc_regs,
 		 guint fpc, gboolean rethrow, gboolean preserve_ips)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ERROR_DECL (error);
 	MonoContext ctx;
 	int iReg;
@@ -304,8 +300,6 @@ static gpointer
 mono_arch_get_throw_exception_generic (int size, MonoTrampInfo **info, 
 				int corlib, gboolean rethrow, gboolean aot, gboolean preserve_ips)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint8 *code, *start;
 	int alloc_size, pos, i;
 	MonoJumpInfo *ji = NULL;
@@ -403,8 +397,6 @@ mono_arch_get_throw_exception_generic (int size, MonoTrampInfo **info,
 gpointer
 mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	g_assert (!aot);
 	if (info)
 		*info = NULL;
@@ -452,8 +444,6 @@ mono_arch_get_rethrow_preserve_exception (MonoTrampInfo **info, gboolean aot)
 gpointer 
 mono_arch_get_rethrow_exception (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	g_assert (!aot);
 	if (info)
 		*info = NULL;
@@ -477,8 +467,6 @@ mono_arch_get_rethrow_exception (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	g_assert (!aot);
 	if (info)
 		*info = NULL;
@@ -503,8 +491,6 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 			 host_mgreg_t **save_locations,
 			 StackFrameInfo *frame)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	gpointer ip = (gpointer) MONO_CONTEXT_GET_IP (ctx);
 
 	memset (frame, 0, sizeof (StackFrameInfo));
@@ -578,8 +564,6 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 static void
 handle_signal_exception (gpointer obj)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
 	MonoContext ctx;
 
@@ -604,8 +588,6 @@ handle_signal_exception (gpointer obj)
 gboolean
 mono_arch_handle_exception (void *sigctx, gpointer obj)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoContext mctx;
 
 	/*
@@ -642,8 +624,6 @@ mono_arch_handle_exception (void *sigctx, gpointer obj)
 void
 mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), gpointer user_data)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	uintptr_t sp = (uintptr_t) MONO_CONTEXT_GET_SP(ctx);
 
 	ctx->uc_mcontext.gregs[2] = (gsize)user_data;
@@ -669,8 +649,6 @@ mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), g
 gpointer
 mono_arch_ip_from_context (void *sigctx)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return ((gpointer) MONO_CONTEXT_GET_IP(((MonoContext *) sigctx)));
 }
 
@@ -689,8 +667,6 @@ mono_arch_ip_from_context (void *sigctx)
 gpointer
 mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	g_assert (!aot);
 	if (info)
 		*info = NULL;
@@ -713,8 +689,6 @@ mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 gboolean
 mono_arch_is_int_overflow (void *uc, void *info)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoContext *ctx;
 	guint8      *code;
 	guint64     *operand;

--- a/mono/mini/exceptions-s390x.c
+++ b/mono/mini/exceptions-s390x.c
@@ -103,6 +103,8 @@ typedef enum {
 gpointer
 mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	static guint8 *start;
 	static int inited = 0;
 	guint8 *code;
@@ -243,6 +245,8 @@ throw_exception (MonoObject *exc, unsigned long ip, unsigned long sp,
 		 gulong *int_regs, gdouble *fp_regs, gint32 *acc_regs, 
 		 guint fpc, gboolean rethrow, gboolean preserve_ips)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ERROR_DECL (error);
 	MonoContext ctx;
 	int iReg;
@@ -300,6 +304,8 @@ static gpointer
 mono_arch_get_throw_exception_generic (int size, MonoTrampInfo **info, 
 				int corlib, gboolean rethrow, gboolean aot, gboolean preserve_ips)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	guint8 *code, *start;
 	int alloc_size, pos, i;
 	MonoJumpInfo *ji = NULL;
@@ -397,6 +403,7 @@ mono_arch_get_throw_exception_generic (int size, MonoTrampInfo **info,
 gpointer
 mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
 
 	g_assert (!aot);
 	if (info)
@@ -445,6 +452,8 @@ mono_arch_get_rethrow_preserve_exception (MonoTrampInfo **info, gboolean aot)
 gpointer 
 mono_arch_get_rethrow_exception (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	g_assert (!aot);
 	if (info)
 		*info = NULL;
@@ -468,6 +477,8 @@ mono_arch_get_rethrow_exception (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	g_assert (!aot);
 	if (info)
 		*info = NULL;
@@ -489,9 +500,11 @@ gboolean
 mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls, 
 			 MonoJitInfo *ji, MonoContext *ctx, 
 			 MonoContext *new_ctx, MonoLMF **lmf,
-			 mgreg_t **save_locations,
+			 host_mgreg_t **save_locations,
 			 StackFrameInfo *frame)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	gpointer ip = (gpointer) MONO_CONTEXT_GET_IP (ctx);
 
 	memset (frame, 0, sizeof (StackFrameInfo));
@@ -504,7 +517,7 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 		guint8 *cfa;
 		guint32 unwind_info_len;
 		guint8 *unwind_info;
-		mgreg_t regs[16];
+		host_mgreg_t regs[16];
 
 		if (ji->is_trampoline)
 			frame->type = FRAME_TYPE_TRAMPOLINE;
@@ -565,6 +578,8 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 static void
 handle_signal_exception (gpointer obj)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
 	MonoContext ctx;
 
@@ -589,6 +604,8 @@ handle_signal_exception (gpointer obj)
 gboolean
 mono_arch_handle_exception (void *sigctx, gpointer obj)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MonoContext mctx;
 
 	/*
@@ -625,6 +642,8 @@ mono_arch_handle_exception (void *sigctx, gpointer obj)
 void
 mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), gpointer user_data)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	uintptr_t sp = (uintptr_t) MONO_CONTEXT_GET_SP(ctx);
 
 	ctx->uc_mcontext.gregs[2] = (unsigned long) user_data;
@@ -650,6 +669,8 @@ mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), g
 gpointer
 mono_arch_ip_from_context (void *sigctx)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return ((gpointer) MONO_CONTEXT_GET_IP(((MonoContext *) sigctx)));
 }
 
@@ -668,6 +689,8 @@ mono_arch_ip_from_context (void *sigctx)
 gpointer
 mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	g_assert (!aot);
 	if (info)
 		*info = NULL;
@@ -690,6 +713,8 @@ mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 gboolean
 mono_arch_is_int_overflow (void *uc, void *info)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MonoContext *ctx;
 	guint8      *code;
 	guint64     *operand;

--- a/mono/mini/exceptions-s390x.c
+++ b/mono/mini/exceptions-s390x.c
@@ -242,7 +242,7 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 
 static void
 throw_exception (MonoObject *exc, unsigned long ip, unsigned long sp, 
-		 gulong *int_regs, gdouble *fp_regs, gint32 *acc_regs, 
+		 host_mgreg_t *int_regs, gdouble *fp_regs, gint32 *acc_regs,
 		 guint fpc, gboolean rethrow, gboolean preserve_ips)
 {
 	mono_cross_compile_assert_not_reached ();

--- a/mono/mini/exceptions-s390x.c
+++ b/mono/mini/exceptions-s390x.c
@@ -646,12 +646,12 @@ mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), g
 
 	uintptr_t sp = (uintptr_t) MONO_CONTEXT_GET_SP(ctx);
 
-	ctx->uc_mcontext.gregs[2] = (unsigned long) user_data;
+	ctx->uc_mcontext.gregs[2] = (gsize)user_data;
 
 	sp -= S390_MINIMAL_STACK_SIZE;
 	*(unsigned long *)sp = MONO_CONTEXT_GET_SP(ctx);
 	MONO_CONTEXT_SET_BP(ctx, sp);
-	MONO_CONTEXT_SET_IP(ctx, (unsigned long) async_cb);
+	MONO_CONTEXT_SET_IP(ctx, (gsize)async_cb);
 }
 
 /*========================= End of Function ========================*/

--- a/mono/mini/exceptions-sparc.c
+++ b/mono/mini/exceptions-sparc.c
@@ -42,8 +42,6 @@
 gpointer
 mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	static guint32 *start;
 	static int inited = 0;
 	guint32 *code;
@@ -86,8 +84,6 @@ mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	static guint32 *start;
 	static int inited = 0;
 	guint32 *code;
@@ -173,8 +169,6 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 static void
 throw_exception (MonoObject *exc, gpointer sp, gpointer ip, gboolean rethrow, gboolean preserve_ips)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ERROR_DECL (error);
 	MonoContext ctx;
 	static void (*restore_context) (MonoContext *);
@@ -207,8 +201,6 @@ throw_exception (MonoObject *exc, gpointer sp, gpointer ip, gboolean rethrow, gb
 static gpointer 
 get_throw_exception (gboolean rethrow, gboolean preserve_ips)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint32 *start, *code;
 
 	code = start = mono_global_codeman_reserve (16 * sizeof (guint32));
@@ -242,8 +234,6 @@ get_throw_exception (gboolean rethrow, gboolean preserve_ips)
 gpointer
 mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	static guint32* start;
 	static int inited = 0;
 
@@ -264,8 +254,6 @@ mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_rethrow_exception (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	static guint32* start;
 	static int inited = 0;
 
@@ -315,8 +303,6 @@ mono_arch_get_rethrow_preserve_exception (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	static guint32 *start;
 	static int inited = 0;
 	guint32 *code;
@@ -384,8 +370,6 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 							 host_mgreg_t **save_locations,
 							 StackFrameInfo *frame)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	gpointer *window;
 
 	memset (frame, 0, sizeof (StackFrameInfo));
@@ -436,8 +420,6 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 gboolean
 mono_arch_handle_exception (void *sigctx, gpointer obj)
 {
-	mono_cross_compile_assert_not_reached ();
-
        MonoContext mctx;
        struct sigcontext *sc = sigctx;
        gpointer *window;
@@ -474,8 +456,6 @@ mono_arch_handle_exception (void *sigctx, gpointer obj)
 gpointer
 mono_arch_ip_from_context (void *sigctx)
 {
-	mono_cross_compile_assert_not_reached ();
-
        struct sigcontext *sc = sigctx;
        gpointer *ret;
 
@@ -493,8 +473,6 @@ mono_arch_ip_from_context (void *sigctx)
 gboolean
 mono_arch_handle_exception (void *sigctx, gpointer obj)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoContext mctx;
 	ucontext_t *ctx = (ucontext_t*)sigctx;
 	gpointer *window;
@@ -526,8 +504,6 @@ mono_arch_handle_exception (void *sigctx, gpointer obj)
 gpointer
 mono_arch_ip_from_context (void *sigctx)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ucontext_t *ctx = (ucontext_t*)sigctx;
 	return (gpointer)ctx->uc_mcontext.gregs [REG_PC];
 }

--- a/mono/mini/exceptions-sparc.c
+++ b/mono/mini/exceptions-sparc.c
@@ -42,6 +42,8 @@
 gpointer
 mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	static guint32 *start;
 	static int inited = 0;
 	guint32 *code;
@@ -84,6 +86,8 @@ mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	static guint32 *start;
 	static int inited = 0;
 	guint32 *code;
@@ -169,6 +173,8 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 static void
 throw_exception (MonoObject *exc, gpointer sp, gpointer ip, gboolean rethrow, gboolean preserve_ips)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ERROR_DECL (error);
 	MonoContext ctx;
 	static void (*restore_context) (MonoContext *);
@@ -201,6 +207,8 @@ throw_exception (MonoObject *exc, gpointer sp, gpointer ip, gboolean rethrow, gb
 static gpointer 
 get_throw_exception (gboolean rethrow, gboolean preserve_ips)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	guint32 *start, *code;
 
 	code = start = mono_global_codeman_reserve (16 * sizeof (guint32));
@@ -234,6 +242,8 @@ get_throw_exception (gboolean rethrow, gboolean preserve_ips)
 gpointer
 mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	static guint32* start;
 	static int inited = 0;
 
@@ -254,6 +264,8 @@ mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_rethrow_exception (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	static guint32* start;
 	static int inited = 0;
 
@@ -303,6 +315,8 @@ mono_arch_get_rethrow_preserve_exception (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	static guint32 *start;
 	static int inited = 0;
 	guint32 *code;
@@ -367,9 +381,11 @@ gboolean
 mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls, 
 							 MonoJitInfo *ji, MonoContext *ctx, 
 							 MonoContext *new_ctx, MonoLMF **lmf,
-							 mgreg_t **save_locations,
+							 host_mgreg_t **save_locations,
 							 StackFrameInfo *frame)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	gpointer *window;
 
 	memset (frame, 0, sizeof (StackFrameInfo));
@@ -420,6 +436,8 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 gboolean
 mono_arch_handle_exception (void *sigctx, gpointer obj)
 {
+	mono_cross_compile_assert_not_reached ();
+
        MonoContext mctx;
        struct sigcontext *sc = sigctx;
        gpointer *window;
@@ -456,6 +474,8 @@ mono_arch_handle_exception (void *sigctx, gpointer obj)
 gpointer
 mono_arch_ip_from_context (void *sigctx)
 {
+	mono_cross_compile_assert_not_reached ();
+
        struct sigcontext *sc = sigctx;
        gpointer *ret;
 
@@ -473,6 +493,8 @@ mono_arch_ip_from_context (void *sigctx)
 gboolean
 mono_arch_handle_exception (void *sigctx, gpointer obj)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MonoContext mctx;
 	ucontext_t *ctx = (ucontext_t*)sigctx;
 	gpointer *window;
@@ -504,6 +526,8 @@ mono_arch_handle_exception (void *sigctx, gpointer obj)
 gpointer
 mono_arch_ip_from_context (void *sigctx)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ucontext_t *ctx = (ucontext_t*)sigctx;
 	return (gpointer)ctx->uc_mcontext.gregs [REG_PC];
 }

--- a/mono/mini/exceptions-wasm.c
+++ b/mono/mini/exceptions-wasm.c
@@ -40,9 +40,11 @@ gboolean
 mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls, 
 							 MonoJitInfo *ji, MonoContext *ctx, 
 							 MonoContext *new_ctx, MonoLMF **lmf,
-							 mgreg_t **save_locations,
+							 host_mgreg_t **save_locations,
 							 StackFrameInfo *frame)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	if (ji)
 		g_error ("Can't unwind compiled code");
 
@@ -58,6 +60,8 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 gpointer
 mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	if (info)
 		*info = mono_tramp_info_create ("call_filter", (guint8*)wasm_call_filter, 1, NULL, NULL);
 	return (gpointer)wasm_call_filter;
@@ -66,6 +70,8 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	if (info)
 		*info = mono_tramp_info_create ("restore_context", (guint8*)wasm_restore_context, 1, NULL, NULL);
 	return (gpointer)wasm_restore_context;
@@ -73,6 +79,8 @@ mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 gpointer 
 mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	if (info)
 		*info = mono_tramp_info_create ("throw_corlib_exception", (guint8*)wasm_throw_corlib_exception, 1, NULL, NULL);
 	return (gpointer)wasm_throw_corlib_exception;
@@ -81,6 +89,8 @@ mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_rethrow_exception (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	if (info)
 		*info = mono_tramp_info_create ("rethrow_exception", (guint8*)wasm_rethrow_exception, 1, NULL, NULL);
 	return (gpointer)wasm_rethrow_exception;
@@ -97,6 +107,8 @@ mono_arch_get_rethrow_preserve_exception (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	if (info)
 		*info = mono_tramp_info_create ("throw_exception", (guint8*)wasm_throw_exception, 1, NULL, NULL);
 	return (gpointer)wasm_throw_exception;

--- a/mono/mini/exceptions-wasm.c
+++ b/mono/mini/exceptions-wasm.c
@@ -43,8 +43,6 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 							 host_mgreg_t **save_locations,
 							 StackFrameInfo *frame)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	if (ji)
 		g_error ("Can't unwind compiled code");
 
@@ -60,8 +58,6 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 gpointer
 mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	if (info)
 		*info = mono_tramp_info_create ("call_filter", (guint8*)wasm_call_filter, 1, NULL, NULL);
 	return (gpointer)wasm_call_filter;
@@ -70,8 +66,6 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	if (info)
 		*info = mono_tramp_info_create ("restore_context", (guint8*)wasm_restore_context, 1, NULL, NULL);
 	return (gpointer)wasm_restore_context;
@@ -79,8 +73,6 @@ mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 gpointer 
 mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	if (info)
 		*info = mono_tramp_info_create ("throw_corlib_exception", (guint8*)wasm_throw_corlib_exception, 1, NULL, NULL);
 	return (gpointer)wasm_throw_corlib_exception;
@@ -89,8 +81,6 @@ mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_rethrow_exception (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	if (info)
 		*info = mono_tramp_info_create ("rethrow_exception", (guint8*)wasm_rethrow_exception, 1, NULL, NULL);
 	return (gpointer)wasm_rethrow_exception;
@@ -107,8 +97,6 @@ mono_arch_get_rethrow_preserve_exception (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	if (info)
 		*info = mono_tramp_info_create ("throw_exception", (guint8*)wasm_throw_exception, 1, NULL, NULL);
 	return (gpointer)wasm_throw_exception;

--- a/mono/mini/exceptions-x86.c
+++ b/mono/mini/exceptions-x86.c
@@ -1040,13 +1040,13 @@ mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), g
 	 * So put it into a register, and branch to a trampoline which
 	 * pushes it.
 	 */
-	ctx->eax = (host_mgreg_t)user_data;
+	ctx->eax = (host_mgreg_t)(gsize)user_data;
 	ctx->ecx = ctx->eip;
-	ctx->edx = (host_mgreg_t)async_cb;
+	ctx->edx = (host_mgreg_t)(gsize)async_cb;
 
 	/*align the stack*/
 	ctx->esp = (ctx->esp - 16) & ~15;
-	ctx->eip = (host_mgreg_t)signal_exception_trampoline;
+	ctx->eip = (host_mgreg_t)(gsize)signal_exception_trampoline;
 }
 
 gboolean

--- a/mono/mini/exceptions-x86.c
+++ b/mono/mini/exceptions-x86.c
@@ -470,7 +470,7 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
  *   C function called from the throw trampolines.
  */
 void
-mono_x86_throw_exception (mgreg_t *regs, MonoObject *exc, 
+mono_x86_throw_exception (host_mgreg_t *regs, MonoObject *exc,
 						  host_mgreg_t eip, gboolean rethrow, gboolean preserve_ips)
 {
 	mono_cross_compile_assert_not_reached ();

--- a/mono/mini/exceptions-x86.c
+++ b/mono/mini/exceptions-x86.c
@@ -59,6 +59,8 @@ extern int (*gUnhandledExceptionHandler)(EXCEPTION_POINTERS*);
 
 LONG CALLBACK seh_unhandled_exception_filter(EXCEPTION_POINTERS* ep)
 {
+	mono_cross_compile_assert_not_reached ();
+
 #ifndef MONO_CROSS_COMPILE
 	if (mono_old_win_toplevel_exception_filter) {
 		return (*mono_old_win_toplevel_exception_filter)(ep);
@@ -79,6 +81,8 @@ LONG CALLBACK seh_unhandled_exception_filter(EXCEPTION_POINTERS* ep)
 static gpointer
 mono_win32_get_handle_stackoverflow (void)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	static guint8 *start = NULL;
 	guint8 *code;
 
@@ -137,6 +141,8 @@ mono_win32_get_handle_stackoverflow (void)
 static void 
 win32_handle_stack_overflow (EXCEPTION_POINTERS* ep, CONTEXT *sctx)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	SYSTEM_INFO si;
 	DWORD page_size;
 	MonoDomain *domain = mono_domain_get ();
@@ -194,6 +200,8 @@ win32_handle_stack_overflow (EXCEPTION_POINTERS* ep, CONTEXT *sctx)
  */
 LONG CALLBACK seh_vectored_exception_handler(EXCEPTION_POINTERS* ep)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	EXCEPTION_RECORD* er;
 	CONTEXT* ctx;
 	LONG res;
@@ -247,6 +255,8 @@ LONG CALLBACK seh_vectored_exception_handler(EXCEPTION_POINTERS* ep)
 
 void win32_seh_init()
 {
+	mono_cross_compile_assert_not_reached ();
+
 	/* install restore stack helper */
 	if (!restore_stack)
 		restore_stack = (void (*) (void*))mono_win32_get_handle_stackoverflow ();
@@ -257,6 +267,8 @@ void win32_seh_init()
 
 void win32_seh_cleanup()
 {
+	mono_cross_compile_assert_not_reached ();
+
 	if (mono_old_win_toplevel_exception_filter)
 		SetUnhandledExceptionFilter(mono_old_win_toplevel_exception_filter);
 	RemoveVectoredExceptionHandler (mono_win_vectored_exception_handle);
@@ -264,6 +276,8 @@ void win32_seh_cleanup()
 
 void win32_seh_set_handler(int type, MonoW32ExceptionHandler handler)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	switch (type) {
 	case SIGFPE:
 		fpe_handler = handler;
@@ -289,6 +303,8 @@ void win32_seh_set_handler(int type, MonoW32ExceptionHandler handler)
 gpointer
 mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	guint8 *start = NULL;
 	guint8 *code;
 	MonoJumpInfo *ji = NULL;
@@ -377,6 +393,8 @@ mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	guint8* start;
 	guint8 *code;
 	MonoJumpInfo *ji = NULL;
@@ -453,8 +471,10 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
  */
 void
 mono_x86_throw_exception (mgreg_t *regs, MonoObject *exc, 
-						  mgreg_t eip, gboolean rethrow, gboolean preserve_ips)
+						  host_mgreg_t eip, gboolean rethrow, gboolean preserve_ips)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ERROR_DECL (error);
 	MonoContext ctx;
 
@@ -495,9 +515,11 @@ mono_x86_throw_exception (mgreg_t *regs, MonoObject *exc,
 }
 
 void
-mono_x86_throw_corlib_exception (mgreg_t *regs, guint32 ex_token_index, 
-								 mgreg_t eip, gint32 pc_offset)
+mono_x86_throw_corlib_exception (host_mgreg_t *regs, guint32 ex_token_index, 
+								 host_mgreg_t eip, gint32 pc_offset)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	guint32 ex_token = MONO_TOKEN_TYPE_DEF | ex_token_index;
 	MonoException *ex;
 
@@ -512,9 +534,11 @@ mono_x86_throw_corlib_exception (mgreg_t *regs, guint32 ex_token_index,
 }
 
 static void
-mono_x86_resume_unwind (mgreg_t *regs, MonoObject *exc, 
-						mgreg_t eip, gboolean rethrow)
+mono_x86_resume_unwind (host_mgreg_t *regs, MonoObject *exc, 
+						host_mgreg_t eip, gboolean rethrow)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MonoContext ctx;
 
 	ctx.esp = regs [X86_ESP];
@@ -541,6 +565,8 @@ mono_x86_resume_unwind (mgreg_t *regs, MonoObject *exc,
 static guint8*
 get_throw_trampoline (const char *name, gboolean rethrow, gboolean llvm, gboolean corlib, gboolean llvm_abs, gboolean resume_unwind, MonoTrampInfo **info, gboolean aot, gboolean preserve_ips)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	guint8 *start, *code, *labels [16];
 	int i, stack_size, stack_offset, arg_offsets [5], regs_offset;
 	MonoJumpInfo *ji = NULL;
@@ -703,18 +729,24 @@ get_throw_trampoline (const char *name, gboolean rethrow, gboolean llvm, gboolea
 gpointer 
 mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return get_throw_trampoline ("throw_exception", FALSE, FALSE, FALSE, FALSE, FALSE, info, aot, FALSE);
 }
 
 gpointer 
 mono_arch_get_rethrow_exception (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return get_throw_trampoline ("rethrow_exception", TRUE, FALSE, FALSE, FALSE, FALSE, info, aot, FALSE);
 }
 
 gpointer 
 mono_arch_get_rethrow_preserve_exception (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return get_throw_trampoline ("rethrow_preserve_exception", TRUE, FALSE, FALSE, FALSE, FALSE, info, aot, TRUE);
 }
 
@@ -730,12 +762,16 @@ mono_arch_get_rethrow_preserve_exception (MonoTrampInfo **info, gboolean aot)
 gpointer 
 mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return get_throw_trampoline ("throw_corlib_exception", FALSE, FALSE, TRUE, FALSE, FALSE, info, aot, FALSE);
 }
 
 void
 mono_arch_exceptions_init (void)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	guint8 *tramp;
 	MonoTrampInfo *tinfo;
 
@@ -800,9 +836,11 @@ gboolean
 mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls, 
 							 MonoJitInfo *ji, MonoContext *ctx, 
 							 MonoContext *new_ctx, MonoLMF **lmf,
-							 mgreg_t **save_locations,
+							 host_mgreg_t **save_locations,
 							 StackFrameInfo *frame)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	gpointer ip = MONO_CONTEXT_GET_IP (ctx);
 
 	memset (frame, 0, sizeof (StackFrameInfo));
@@ -811,7 +849,7 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 	*new_ctx = *ctx;
 
 	if (ji != NULL) {
-		mgreg_t regs [MONO_MAX_IREGS + 1];
+		host_mgreg_t regs [MONO_MAX_IREGS + 1];
 		guint8 *cfa;
 		guint32 unwind_info_len;
 		guint8 *unwind_info;
@@ -898,6 +936,8 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 gpointer
 mono_arch_ip_from_context (void *sigctx)
 {
+	mono_cross_compile_assert_not_reached ();
+
 #if defined(HOST_WATCHOS)
 	printf("WARNING: mono_arch_ip_from_context() called!\n");
 	return (NULL);
@@ -923,6 +963,8 @@ mono_arch_ip_from_context (void *sigctx)
 static void
 handle_signal_exception (gpointer obj)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
 	MonoContext ctx;
 
@@ -941,6 +983,8 @@ handle_signal_exception (gpointer obj)
 gpointer
 mono_x86_get_signal_exception_trampoline (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	guint8 *start, *code;
 	MonoJumpInfo *ji = NULL;
 	GSList *unwind_ops = NULL;
@@ -988,24 +1032,28 @@ mono_x86_get_signal_exception_trampoline (MonoTrampInfo **info, gboolean aot)
 void
 mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), gpointer user_data)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	/*
 	 * Can't pass the obj on the stack, since we are executing on the
 	 * same stack. Can't save it into MonoJitTlsData, since it needs GC tracking.
 	 * So put it into a register, and branch to a trampoline which
 	 * pushes it.
 	 */
-	ctx->eax = (mgreg_t)user_data;
+	ctx->eax = (host_mgreg_t)user_data;
 	ctx->ecx = ctx->eip;
-	ctx->edx = (mgreg_t)async_cb;
+	ctx->edx = (host_mgreg_t)async_cb;
 
 	/*align the stack*/
 	ctx->esp = (ctx->esp - 16) & ~15;
-	ctx->eip = (mgreg_t)signal_exception_trampoline;
+	ctx->eip = (host_mgreg_t)signal_exception_trampoline;
 }
 
 gboolean
 mono_arch_handle_exception (void *sigctx, gpointer obj)
 {
+	mono_cross_compile_assert_not_reached ();
+
 #if defined(MONO_ARCH_USE_SIGACTION)
 	MonoContext mctx;
 	ucontext_t *ctx = (ucontext_t*)sigctx;
@@ -1050,8 +1098,10 @@ mono_arch_handle_exception (void *sigctx, gpointer obj)
 }
 
 static MonoObject*
-restore_soft_guard_pages ()
+restore_soft_guard_pages (void)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
 
 	if (jit_tls->stack_ovf_guard_base)
@@ -1074,6 +1124,8 @@ restore_soft_guard_pages ()
 static void
 prepare_for_guard_pages (MonoContext *mctx)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	gpointer *sp;
 	sp = (gpointer*)(mctx->esp);
 	sp -= 1;
@@ -1087,6 +1139,8 @@ prepare_for_guard_pages (MonoContext *mctx)
 static void
 altstack_handle_and_restore (MonoContext *ctx, gpointer obj, gboolean stack_ovf)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MonoContext mctx;
 
 	mctx = *ctx;
@@ -1103,6 +1157,8 @@ altstack_handle_and_restore (MonoContext *ctx, gpointer obj, gboolean stack_ovf)
 void
 mono_arch_handle_altstack_exception (void *sigctx, MONO_SIG_HANDLER_INFO_TYPE *siginfo, gpointer fault_addr, gboolean stack_ovf)
 {
+	mono_cross_compile_assert_not_reached ();
+
 #if defined(MONO_ARCH_USE_SIGACTION) && !defined(MONO_CROSS_COMPILE)
 	MonoException *exc = NULL;
 	ucontext_t *ctx = (ucontext_t*)sigctx;
@@ -1159,6 +1215,8 @@ mono_arch_handle_altstack_exception (void *sigctx, MONO_SIG_HANDLER_INFO_TYPE *s
 MonoContinuationRestore
 mono_tasklets_arch_restore (void)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	static guint8* saved = NULL;
 	guint8 *code, *start;
 
@@ -1210,6 +1268,8 @@ mono_tasklets_arch_restore (void)
 void
 mono_arch_setup_resume_sighandler_ctx (MonoContext *ctx, gpointer func)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	int align = (((gint32)MONO_CONTEXT_GET_SP (ctx)) % MONO_ARCH_FRAME_ALIGNMENT + 4);
 
 	if (align != 0)

--- a/mono/mini/exceptions-x86.c
+++ b/mono/mini/exceptions-x86.c
@@ -59,8 +59,6 @@ extern int (*gUnhandledExceptionHandler)(EXCEPTION_POINTERS*);
 
 LONG CALLBACK seh_unhandled_exception_filter(EXCEPTION_POINTERS* ep)
 {
-	mono_cross_compile_assert_not_reached ();
-
 #ifndef MONO_CROSS_COMPILE
 	if (mono_old_win_toplevel_exception_filter) {
 		return (*mono_old_win_toplevel_exception_filter)(ep);
@@ -81,8 +79,6 @@ LONG CALLBACK seh_unhandled_exception_filter(EXCEPTION_POINTERS* ep)
 static gpointer
 mono_win32_get_handle_stackoverflow (void)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	static guint8 *start = NULL;
 	guint8 *code;
 
@@ -141,8 +137,6 @@ mono_win32_get_handle_stackoverflow (void)
 static void 
 win32_handle_stack_overflow (EXCEPTION_POINTERS* ep, CONTEXT *sctx)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	SYSTEM_INFO si;
 	DWORD page_size;
 	MonoDomain *domain = mono_domain_get ();
@@ -200,8 +194,6 @@ win32_handle_stack_overflow (EXCEPTION_POINTERS* ep, CONTEXT *sctx)
  */
 LONG CALLBACK seh_vectored_exception_handler(EXCEPTION_POINTERS* ep)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	EXCEPTION_RECORD* er;
 	CONTEXT* ctx;
 	LONG res;
@@ -255,8 +247,6 @@ LONG CALLBACK seh_vectored_exception_handler(EXCEPTION_POINTERS* ep)
 
 void win32_seh_init()
 {
-	mono_cross_compile_assert_not_reached ();
-
 	/* install restore stack helper */
 	if (!restore_stack)
 		restore_stack = (void (*) (void*))mono_win32_get_handle_stackoverflow ();
@@ -267,8 +257,6 @@ void win32_seh_init()
 
 void win32_seh_cleanup()
 {
-	mono_cross_compile_assert_not_reached ();
-
 	if (mono_old_win_toplevel_exception_filter)
 		SetUnhandledExceptionFilter(mono_old_win_toplevel_exception_filter);
 	RemoveVectoredExceptionHandler (mono_win_vectored_exception_handle);
@@ -276,8 +264,6 @@ void win32_seh_cleanup()
 
 void win32_seh_set_handler(int type, MonoW32ExceptionHandler handler)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	switch (type) {
 	case SIGFPE:
 		fpe_handler = handler;
@@ -303,8 +289,6 @@ void win32_seh_set_handler(int type, MonoW32ExceptionHandler handler)
 gpointer
 mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint8 *start = NULL;
 	guint8 *code;
 	MonoJumpInfo *ji = NULL;
@@ -393,8 +377,6 @@ mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 gpointer
 mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint8* start;
 	guint8 *code;
 	MonoJumpInfo *ji = NULL;
@@ -473,8 +455,6 @@ void
 mono_x86_throw_exception (host_mgreg_t *regs, MonoObject *exc,
 						  host_mgreg_t eip, gboolean rethrow, gboolean preserve_ips)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ERROR_DECL (error);
 	MonoContext ctx;
 
@@ -518,8 +498,6 @@ void
 mono_x86_throw_corlib_exception (host_mgreg_t *regs, guint32 ex_token_index, 
 								 host_mgreg_t eip, gint32 pc_offset)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint32 ex_token = MONO_TOKEN_TYPE_DEF | ex_token_index;
 	MonoException *ex;
 
@@ -537,8 +515,6 @@ static void
 mono_x86_resume_unwind (host_mgreg_t *regs, MonoObject *exc, 
 						host_mgreg_t eip, gboolean rethrow)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoContext ctx;
 
 	ctx.esp = regs [X86_ESP];
@@ -565,8 +541,6 @@ mono_x86_resume_unwind (host_mgreg_t *regs, MonoObject *exc,
 static guint8*
 get_throw_trampoline (const char *name, gboolean rethrow, gboolean llvm, gboolean corlib, gboolean llvm_abs, gboolean resume_unwind, MonoTrampInfo **info, gboolean aot, gboolean preserve_ips)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint8 *start, *code, *labels [16];
 	int i, stack_size, stack_offset, arg_offsets [5], regs_offset;
 	MonoJumpInfo *ji = NULL;
@@ -729,24 +703,18 @@ get_throw_trampoline (const char *name, gboolean rethrow, gboolean llvm, gboolea
 gpointer 
 mono_arch_get_throw_exception (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return get_throw_trampoline ("throw_exception", FALSE, FALSE, FALSE, FALSE, FALSE, info, aot, FALSE);
 }
 
 gpointer 
 mono_arch_get_rethrow_exception (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return get_throw_trampoline ("rethrow_exception", TRUE, FALSE, FALSE, FALSE, FALSE, info, aot, FALSE);
 }
 
 gpointer 
 mono_arch_get_rethrow_preserve_exception (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return get_throw_trampoline ("rethrow_preserve_exception", TRUE, FALSE, FALSE, FALSE, FALSE, info, aot, TRUE);
 }
 
@@ -762,16 +730,12 @@ mono_arch_get_rethrow_preserve_exception (MonoTrampInfo **info, gboolean aot)
 gpointer 
 mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return get_throw_trampoline ("throw_corlib_exception", FALSE, FALSE, TRUE, FALSE, FALSE, info, aot, FALSE);
 }
 
 void
 mono_arch_exceptions_init (void)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint8 *tramp;
 	MonoTrampInfo *tinfo;
 
@@ -839,8 +803,6 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 							 host_mgreg_t **save_locations,
 							 StackFrameInfo *frame)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	gpointer ip = MONO_CONTEXT_GET_IP (ctx);
 
 	memset (frame, 0, sizeof (StackFrameInfo));
@@ -936,8 +898,6 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 gpointer
 mono_arch_ip_from_context (void *sigctx)
 {
-	mono_cross_compile_assert_not_reached ();
-
 #if defined(HOST_WATCHOS)
 	printf("WARNING: mono_arch_ip_from_context() called!\n");
 	return (NULL);
@@ -963,8 +923,6 @@ mono_arch_ip_from_context (void *sigctx)
 static void
 handle_signal_exception (gpointer obj)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
 	MonoContext ctx;
 
@@ -983,8 +941,6 @@ handle_signal_exception (gpointer obj)
 gpointer
 mono_x86_get_signal_exception_trampoline (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint8 *start, *code;
 	MonoJumpInfo *ji = NULL;
 	GSList *unwind_ops = NULL;
@@ -1032,8 +988,6 @@ mono_x86_get_signal_exception_trampoline (MonoTrampInfo **info, gboolean aot)
 void
 mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), gpointer user_data)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	/*
 	 * Can't pass the obj on the stack, since we are executing on the
 	 * same stack. Can't save it into MonoJitTlsData, since it needs GC tracking.
@@ -1052,8 +1006,6 @@ mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), g
 gboolean
 mono_arch_handle_exception (void *sigctx, gpointer obj)
 {
-	mono_cross_compile_assert_not_reached ();
-
 #if defined(MONO_ARCH_USE_SIGACTION)
 	MonoContext mctx;
 	ucontext_t *ctx = (ucontext_t*)sigctx;
@@ -1100,8 +1052,6 @@ mono_arch_handle_exception (void *sigctx, gpointer obj)
 static MonoObject*
 restore_soft_guard_pages (void)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
 
 	if (jit_tls->stack_ovf_guard_base)
@@ -1124,8 +1074,6 @@ restore_soft_guard_pages (void)
 static void
 prepare_for_guard_pages (MonoContext *mctx)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	gpointer *sp;
 	sp = (gpointer*)(mctx->esp);
 	sp -= 1;
@@ -1139,8 +1087,6 @@ prepare_for_guard_pages (MonoContext *mctx)
 static void
 altstack_handle_and_restore (MonoContext *ctx, gpointer obj, gboolean stack_ovf)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoContext mctx;
 
 	mctx = *ctx;
@@ -1157,8 +1103,6 @@ altstack_handle_and_restore (MonoContext *ctx, gpointer obj, gboolean stack_ovf)
 void
 mono_arch_handle_altstack_exception (void *sigctx, MONO_SIG_HANDLER_INFO_TYPE *siginfo, gpointer fault_addr, gboolean stack_ovf)
 {
-	mono_cross_compile_assert_not_reached ();
-
 #if defined(MONO_ARCH_USE_SIGACTION) && !defined(MONO_CROSS_COMPILE)
 	MonoException *exc = NULL;
 	ucontext_t *ctx = (ucontext_t*)sigctx;
@@ -1215,8 +1159,6 @@ mono_arch_handle_altstack_exception (void *sigctx, MONO_SIG_HANDLER_INFO_TYPE *s
 MonoContinuationRestore
 mono_tasklets_arch_restore (void)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	static guint8* saved = NULL;
 	guint8 *code, *start;
 
@@ -1268,8 +1210,6 @@ mono_tasklets_arch_restore (void)
 void
 mono_arch_setup_resume_sighandler_ctx (MonoContext *ctx, gpointer func)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	int align = (((gint32)MONO_CONTEXT_GET_SP (ctx)) % MONO_ARCH_FRAME_ALIGNMENT + 4);
 
 	if (align != 0)

--- a/mono/mini/ir-emit.h
+++ b/mono/mini/ir-emit.h
@@ -714,7 +714,7 @@ handle_gsharedvt_ldaddr (MonoCompile *cfg)
 
 #define	MONO_EMIT_NEW_ICOMPARE_IMM(cfg,sr1,imm) do { \
         MonoInst *inst; \
-        MONO_INST_NEW ((cfg), (inst), sizeof (mgreg_t) == 8 ? OP_ICOMPARE_IMM : OP_COMPARE_IMM); \
+        MONO_INST_NEW ((cfg), (inst), sizeof (target_mgreg_t) == 8 ? OP_ICOMPARE_IMM : OP_COMPARE_IMM); \
         inst->sreg1 = sr1; \
         inst->inst_imm = (imm);			 \
 	    MONO_ADD_INS ((cfg)->cbb, inst); \
@@ -758,7 +758,7 @@ handle_gsharedvt_ldaddr (MonoCompile *cfg)
         MONO_INST_NEW ((cfg), (inst), (op)); \
         inst->inst_destbasereg = base; \
         inst->inst_offset = offset; \
-        inst->inst_imm = (mgreg_t)(imm); \
+        inst->inst_imm = (target_mgreg_t)(imm); \
         MONO_ADD_INS ((cfg)->cbb, inst); \
 	} while (0)
 

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -3606,7 +3606,7 @@ mini_emit_check_array_type (MonoCompile *cfg, MonoInst *obj, MonoClass *array_cl
 				mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
 				return;
 			}
-			MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, vtable_reg, vtable);
+			MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, vtable_reg, (gssize)vtable);
 		}
 	}
 	

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -4305,7 +4305,7 @@ handle_constrained_gsharedvt_call (MonoCompile *cfg, MonoMethod *cmethod, MonoMe
 			/* Pass the arguments using a localloc-ed array using the format expected by runtime_invoke () */
 			MONO_INST_NEW (cfg, ins, OP_LOCALLOC_IMM);
 			ins->dreg = alloc_preg (cfg);
-			ins->inst_imm = fsig->param_count * sizeof (mgreg_t);
+			ins->inst_imm = fsig->param_count * sizeof (target_mgreg_t);
 			MONO_ADD_INS (cfg->cbb, ins);
 			args [4] = ins;
 

--- a/mono/mini/mini-amd64-gsharedvt.c
+++ b/mono/mini/mini-amd64-gsharedvt.c
@@ -262,8 +262,6 @@ handle_map_when_gsharedvt_on_stack (ArgInfo *reg_info, int *n, int **map, gboole
 gpointer
 mono_arch_get_gsharedvt_call_info (gpointer addr, MonoMethodSignature *normal_sig, MonoMethodSignature *gsharedvt_sig, gboolean gsharedvt_in, gint32 vcall_offset, gboolean calli)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	GSharedVtCallInfo *info;
 	CallInfo *caller_cinfo, *callee_cinfo;
 	MonoMethodSignature *caller_sig, *callee_sig;

--- a/mono/mini/mini-amd64-gsharedvt.c
+++ b/mono/mini/mini-amd64-gsharedvt.c
@@ -262,6 +262,8 @@ handle_map_when_gsharedvt_on_stack (ArgInfo *reg_info, int *n, int **map, gboole
 gpointer
 mono_arch_get_gsharedvt_call_info (gpointer addr, MonoMethodSignature *normal_sig, MonoMethodSignature *gsharedvt_sig, gboolean gsharedvt_in, gint32 vcall_offset, gboolean calli)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	GSharedVtCallInfo *info;
 	CallInfo *caller_cinfo, *callee_cinfo;
 	MonoMethodSignature *caller_sig, *callee_sig;

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -1096,8 +1096,6 @@ get_call_info (MonoMemPool *mp, MonoMethodSignature *sig)
 void
 mono_arch_set_native_call_context_args (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	CallInfo *cinfo = get_call_info (NULL, sig);
 	MonoEECallbacks *interp_cb = mini_get_interp_callbacks ();
 
@@ -1169,8 +1167,6 @@ mono_arch_set_native_call_context_args (CallContext *ccontext, gpointer frame, M
 void
 mono_arch_get_native_call_context_ret (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoEECallbacks *interp_cb = mini_get_interp_callbacks ();
 	CallInfo *cinfo;
 
@@ -2506,8 +2502,6 @@ dyn_call_supported (MonoMethodSignature *sig, CallInfo *cinfo)
 MonoDynCallInfo*
 mono_arch_dyn_call_prepare (MonoMethodSignature *sig)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ArchDynCallInfo *info;
 	CallInfo *cinfo;
 	int i;
@@ -2551,8 +2545,6 @@ mono_arch_dyn_call_prepare (MonoMethodSignature *sig)
 void
 mono_arch_dyn_call_free (MonoDynCallInfo *info)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ArchDynCallInfo *ainfo = (ArchDynCallInfo*)info;
 
 	g_free (ainfo->cinfo);
@@ -2562,8 +2554,6 @@ mono_arch_dyn_call_free (MonoDynCallInfo *info)
 int
 mono_arch_dyn_call_get_buf_size (MonoDynCallInfo *info)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ArchDynCallInfo *ainfo = (ArchDynCallInfo*)info;
 
 	/* Extend the 'regs' field dynamically */
@@ -2590,8 +2580,6 @@ mono_arch_dyn_call_get_buf_size (MonoDynCallInfo *info)
 void
 mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, guint8 *buf)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ArchDynCallInfo *dinfo = (ArchDynCallInfo*)info;
 	DynCallArgs *p = (DynCallArgs*)buf;
 	int arg_index, greg, i, pindex;
@@ -2794,8 +2782,6 @@ mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, g
 void
 mono_arch_finish_dyn_call (MonoDynCallInfo *info, guint8 *buf)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ArchDynCallInfo *dinfo = (ArchDynCallInfo*)info;
 	MonoMethodSignature *sig = dinfo->sig;
 	DynCallArgs *dargs = (DynCallArgs*)buf;
@@ -7825,8 +7811,6 @@ mono_arch_get_this_arg_reg (guint8 *code)
 gpointer
 mono_arch_get_this_arg_from_call (host_mgreg_t *regs, guint8 *code)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return (gpointer)regs [mono_arch_get_this_arg_reg (code)];
 }
 
@@ -8240,16 +8224,12 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTC
 MonoMethod*
 mono_arch_find_imt_method (host_mgreg_t *regs, guint8 *code)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return (MonoMethod*)regs [MONO_ARCH_IMT_REG];
 }
 
 MonoVTable*
 mono_arch_find_static_call_vtable (host_mgreg_t *regs, guint8 *code)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return (MonoVTable*) regs [MONO_ARCH_RGCTX_REG];
 }
 
@@ -8359,16 +8339,12 @@ mono_arch_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMetho
 host_mgreg_t
 mono_arch_context_get_int_reg (MonoContext *ctx, int reg)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return ctx->gregs [reg];
 }
 
 void
 mono_arch_context_set_int_reg (MonoContext *ctx, int reg, host_mgreg_t val)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ctx->gregs [reg] = val;
 }
 

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -1096,6 +1096,8 @@ get_call_info (MonoMemPool *mp, MonoMethodSignature *sig)
 void
 mono_arch_set_native_call_context_args (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	CallInfo *cinfo = get_call_info (NULL, sig);
 	MonoEECallbacks *interp_cb = mini_get_interp_callbacks ();
 
@@ -1108,7 +1110,7 @@ mono_arch_set_native_call_context_args (CallContext *ccontext, gpointer frame, M
 	if (sig->ret->type != MONO_TYPE_VOID) {
 		if (cinfo->ret.storage == ArgValuetypeAddrInIReg) {
 			gpointer ret_storage = interp_cb->frame_arg_to_storage ((MonoInterpFrameHandle)frame, sig, -1);
-			ccontext->gregs [cinfo->ret.reg] = (mgreg_t)ret_storage;
+			ccontext->gregs [cinfo->ret.reg] = (host_mgreg_t)ret_storage;
 		}
 	}
 
@@ -1167,6 +1169,8 @@ mono_arch_set_native_call_context_args (CallContext *ccontext, gpointer frame, M
 void
 mono_arch_get_native_call_context_ret (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MonoEECallbacks *interp_cb = mini_get_interp_callbacks ();
 	CallInfo *cinfo;
 
@@ -2502,6 +2506,8 @@ dyn_call_supported (MonoMethodSignature *sig, CallInfo *cinfo)
 MonoDynCallInfo*
 mono_arch_dyn_call_prepare (MonoMethodSignature *sig)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ArchDynCallInfo *info;
 	CallInfo *cinfo;
 	int i;
@@ -2545,6 +2551,8 @@ mono_arch_dyn_call_prepare (MonoMethodSignature *sig)
 void
 mono_arch_dyn_call_free (MonoDynCallInfo *info)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ArchDynCallInfo *ainfo = (ArchDynCallInfo*)info;
 
 	g_free (ainfo->cinfo);
@@ -2554,6 +2562,8 @@ mono_arch_dyn_call_free (MonoDynCallInfo *info)
 int
 mono_arch_dyn_call_get_buf_size (MonoDynCallInfo *info)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ArchDynCallInfo *ainfo = (ArchDynCallInfo*)info;
 
 	/* Extend the 'regs' field dynamically */
@@ -2580,6 +2590,8 @@ mono_arch_dyn_call_get_buf_size (MonoDynCallInfo *info)
 void
 mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, guint8 *buf)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ArchDynCallInfo *dinfo = (ArchDynCallInfo*)info;
 	DynCallArgs *p = (DynCallArgs*)buf;
 	int arg_index, greg, i, pindex;
@@ -2782,6 +2794,8 @@ mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, g
 void
 mono_arch_finish_dyn_call (MonoDynCallInfo *info, guint8 *buf)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ArchDynCallInfo *dinfo = (ArchDynCallInfo*)info;
 	MonoMethodSignature *sig = dinfo->sig;
 	DynCallArgs *dargs = (DynCallArgs*)buf;
@@ -7809,8 +7823,10 @@ mono_arch_get_this_arg_reg (guint8 *code)
 }
 
 gpointer
-mono_arch_get_this_arg_from_call (mgreg_t *regs, guint8 *code)
+mono_arch_get_this_arg_from_call (host_mgreg_t *regs, guint8 *code)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return (gpointer)regs [mono_arch_get_this_arg_reg (code)];
 }
 
@@ -8222,14 +8238,18 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTC
 }
 
 MonoMethod*
-mono_arch_find_imt_method (mgreg_t *regs, guint8 *code)
+mono_arch_find_imt_method (host_mgreg_t *regs, guint8 *code)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return (MonoMethod*)regs [MONO_ARCH_IMT_REG];
 }
 
 MonoVTable*
-mono_arch_find_static_call_vtable (mgreg_t *regs, guint8 *code)
+mono_arch_find_static_call_vtable (host_mgreg_t *regs, guint8 *code)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return (MonoVTable*) regs [MONO_ARCH_RGCTX_REG];
 }
 
@@ -8336,15 +8356,19 @@ mono_arch_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMetho
 }
 #endif
 
-mgreg_t
+host_mgreg_t
 mono_arch_context_get_int_reg (MonoContext *ctx, int reg)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return ctx->gregs [reg];
 }
 
 void
-mono_arch_context_set_int_reg (MonoContext *ctx, int reg, mgreg_t val)
+mono_arch_context_set_int_reg (MonoContext *ctx, int reg, host_mgreg_t val)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ctx->gregs [reg] = val;
 }
 

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -342,7 +342,7 @@ struct CallInfo {
 
 typedef struct {
 	/* General registers */
-	mgreg_t gregs [AMD64_NREG];
+	host_mgreg_t gregs [AMD64_NREG];
 	/* Floating registers */
 	double fregs [AMD64_XMM_NREG];
 	/* Stack usage, used for passing params on stack */

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -1710,7 +1710,7 @@ mono_arch_set_native_call_context_args (CallContext *ccontext, gpointer frame, M
 		ainfo = &cinfo->ret;
 		if (ainfo->storage == RegTypeStructByAddr) {
 			storage = interp_cb->frame_arg_to_storage ((MonoInterpFrameHandle)frame, sig, -1);
-			ccontext->gregs [cinfo->ret.reg] = (gsize)storage;
+			ccontext->gregs [cinfo->ret.reg] = (host_mgreg_t)(gsize)storage;
 		}
 	}
 
@@ -1771,7 +1771,7 @@ mono_arch_get_native_call_context_args (CallContext *ccontext, gpointer frame, M
 	if (sig->ret->type != MONO_TYPE_VOID) {
 		ainfo = &cinfo->ret;
 		if (ainfo->storage == RegTypeStructByAddr) {
-			storage = (gpointer) ccontext->gregs [cinfo->ret.reg];
+			storage = (gpointer)(gsize)ccontext->gregs [cinfo->ret.reg];
 			interp_cb->frame_arg_set_storage ((MonoInterpFrameHandle)frame, sig, -1, storage);
 		}
 	}
@@ -2983,13 +2983,13 @@ mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, g
 	pindex = 0;
 
 	if (sig->hasthis || dinfo->cinfo->vret_arg_index == 1) {
-		p->regs [greg ++] = (mgreg_t)*(args [arg_index ++]);
+		p->regs [greg ++] = (mgreg_t)(gsize)*(args [arg_index ++]);
 		if (!sig->hasthis)
 			pindex = 1;
 	}
 
 	if (dinfo->cinfo->ret.storage == RegTypeStructByAddr)
-		p->regs [greg ++] = (mgreg_t)ret;
+		p->regs [greg ++] = (mgreg_t)(gsize)ret;
 
 	for (i = pindex; i < sig->param_count; i++) {
 		MonoType *t = dinfo->param_types [i];
@@ -3010,7 +3010,7 @@ mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, g
 		}
 
 		if (t->byref) {
-			p->regs [slot] = (mgreg_t)*arg;
+			p->regs [slot] = (mgreg_t)(gsize)*arg;
 			continue;
 		}
 
@@ -3019,7 +3019,7 @@ mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, g
 		case MONO_TYPE_PTR:
 		case MONO_TYPE_I:
 		case MONO_TYPE_U:
-			p->regs [slot] = (mgreg_t)*arg;
+			p->regs [slot] = (mgreg_t)(gsize)*arg;
 			break;
 		case MONO_TYPE_U1:
 			p->regs [slot] = *(guint8*)arg;
@@ -3041,8 +3041,8 @@ mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, g
 			break;
 		case MONO_TYPE_I8:
 		case MONO_TYPE_U8:
-			p->regs [slot ++] = (mgreg_t)arg [0];
-			p->regs [slot] = (mgreg_t)arg [1];
+			p->regs [slot ++] = (mgreg_t)(gsize)arg [0];
+			p->regs [slot] = (mgreg_t)(gsize)arg [1];
 			break;
 		case MONO_TYPE_R4:
 			if (ainfo->storage == RegTypeFP) {
@@ -3058,13 +3058,13 @@ mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, g
 				p->fpregs [ainfo->reg / 2] = *(double*)arg;
 				p->has_fpregs = 1;
 			} else {
-				p->regs [slot ++] = (mgreg_t)arg [0];
-				p->regs [slot] = (mgreg_t)arg [1];
+				p->regs [slot ++] = (mgreg_t)(gsize)arg [0];
+				p->regs [slot] = (mgreg_t)(gsize)arg [1];
 			}
 			break;
 		case MONO_TYPE_GENERICINST:
 			if (MONO_TYPE_IS_REFERENCE (t)) {
-				p->regs [slot] = (mgreg_t)*arg;
+				p->regs [slot] = (mgreg_t)(gsize)*arg;
 				break;
 			} else {
 				if (t->type == MONO_TYPE_GENERICINST && mono_class_is_nullable (mono_class_from_mono_type (t))) {
@@ -3122,7 +3122,7 @@ mono_arch_finish_dyn_call (MonoDynCallInfo *info, guint8 *buf)
 	case MONO_TYPE_I:
 	case MONO_TYPE_U:
 	case MONO_TYPE_PTR:
-		*(gpointer*)ret = (gpointer)res;
+		*(gpointer*)ret = (gpointer)(gsize)res;
 		break;
 	case MONO_TYPE_I1:
 		*(gint8*)ret = res;
@@ -3196,9 +3196,9 @@ mono_arch_instrument_prolog (MonoCompile *cfg, void *func, void *p, gboolean ena
 {
 	guchar *code = (guchar*)p;
 
-	code = mono_arm_emit_load_imm (code, ARMREG_R0, (guint32)cfg->method);
+	code = mono_arm_emit_load_imm (code, ARMREG_R0, (guint32)(gsize)cfg->method);
 	ARM_MOV_REG_IMM8 (code, ARMREG_R1, 0); /* NULL ebp for now */
-	code = mono_arm_emit_load_imm (code, ARMREG_R2, (guint32)func);
+	code = mono_arm_emit_load_imm (code, ARMREG_R2, (guint32)(gsize)func);
 	code = emit_call_reg (code, ARMREG_R2);
 	return code;
 }
@@ -3304,8 +3304,8 @@ mono_arch_instrument_epilog (MonoCompile *cfg, void *func, void *p, gboolean ena
 		break;
 	}
 
-	code = mono_arm_emit_load_imm (code, ARMREG_R0, (guint32)cfg->method);
-	code = mono_arm_emit_load_imm (code, ARMREG_IP, (guint32)func);
+	code = mono_arm_emit_load_imm (code, ARMREG_R0, (guint32)(gsize)cfg->method);
+	code = mono_arm_emit_load_imm (code, ARMREG_IP, (guint32)(gsize)func);
 	code = emit_call_reg (code, ARMREG_IP);
 
 	switch (save_mode) {
@@ -3928,7 +3928,7 @@ emit_thunk (guint8 *code, gconstpointer target)
 		ARM_BX (code, ARMREG_IP);
 	else
 		ARM_MOV_REG_REG (code, ARMREG_PC, ARMREG_IP);
-	*(guint32*)code = (guint32)target;
+	*(guint32*)code = (guint32)(gsize)target;
 	code += 4;
 	mono_arch_flush_icache (p, code - p);
 }
@@ -3992,7 +3992,7 @@ handle_thunk (MonoCompile *cfg, MonoDomain *domain, guchar *code, const guchar *
 					/* Free entry */
 					target_thunk = p;
 					break;
-				} else if (((guint32*)p) [2] == (guint32)target) {
+				} else if (((guint32*)p) [2] == (guint32)(gsize)target) {
 					/* Thunk already points to target */
 					target_thunk = p;
 					break;
@@ -4110,7 +4110,7 @@ arm_patch_general (MonoCompile *cfg, MonoDomain *domain, guchar *code, const guc
 			g_assert (code32 [-4] == ccode [0]);
 			g_assert (code32 [-3] == ccode [1]);
 			g_assert (code32 [-1] == ccode [2]);
-			code32 [-2] = (guint32)target;
+			code32 [-2] = (guint32)(gsize)target;
 			return;
 		}
 		/*patching from JIT*/
@@ -4118,7 +4118,7 @@ arm_patch_general (MonoCompile *cfg, MonoDomain *domain, guchar *code, const guc
 			g_assert (code32 [1] == ccode [1]);
 			g_assert (code32 [3] == ccode [2]);
 			g_assert (code32 [4] == ccode [3]);
-			code32 [2] = (guint32)target;
+			code32 [2] = (guint32)(gsize)target;
 			return;
 		}
 		g_assert_not_reached ();
@@ -4139,7 +4139,7 @@ arm_patch_general (MonoCompile *cfg, MonoDomain *domain, guchar *code, const guc
 		g_assert (code32 [-2] == ccode [1]);
 		g_assert (code32 [0] == ccode [2]);
 
-		code32 [-1] = (guint32)target;
+		code32 [-1] = (guint32)(gsize)target;
 	} else {
 		guint32 ccode [4];
 		guint32 *tmp = ccode;
@@ -4150,12 +4150,12 @@ arm_patch_general (MonoCompile *cfg, MonoDomain *domain, guchar *code, const guc
 		ARM_BX (emit, ARMREG_IP);
 		if (ins == ccode [2]) {
 			g_assert_not_reached (); // should be -2 ...
-			code32 [-1] = (guint32)target;
+			code32 [-1] = (guint32)(gsize)target;
 			return;
 		}
 		if (ins == ccode [0]) {
 			/* handles both thunk jump code and the far call sequence */
-			code32 [2] = (guint32)target;
+			code32 [2] = (guint32)(gsize)target;
 			return;
 		}
 		g_assert_not_reached ();
@@ -4805,7 +4805,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 					} else {
 						ARM_LDR_IMM (code, dreg, ARMREG_PC, 0);
 						ARM_B (code, 0);
-						*(int*)code = (int)ss_trigger_page;
+						*(int*)code = (int)(gsize)ss_trigger_page;
 						code += 4;
 					}
 					ARM_LDR_IMM (code, dreg, dreg, 0);
@@ -5702,7 +5702,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				/* FIXME: we can optimize the imm load by dealing with part of 
 				 * the displacement in LDFD (aligning to 512).
 				 */
-				code = mono_arm_emit_load_imm (code, ARMREG_LR, (guint32)ins->inst_p0);
+				code = mono_arm_emit_load_imm (code, ARMREG_LR, (guint32)(gsize)ins->inst_p0);
 				ARM_FLDD (code, ins->dreg, ARMREG_LR, 0);
 			}
 			break;
@@ -5715,7 +5715,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				if (!cfg->r4fp)
 					ARM_CVTS (code, ins->dreg, ins->dreg);
 			} else {
-				code = mono_arm_emit_load_imm (code, ARMREG_LR, (guint32)ins->inst_p0);
+				code = mono_arm_emit_load_imm (code, ARMREG_LR, (guint32)(gsize)ins->inst_p0);
 				ARM_FLDS (code, ins->dreg, ARMREG_LR, 0);
 				if (!cfg->r4fp)
 					ARM_CVTS (code, ins->dreg, ins->dreg);
@@ -6214,8 +6214,8 @@ mono_arch_register_lowlevel_calls (void)
 
 #define patch_lis_ori(ip,val) do {\
 		guint16 *__lis_ori = (guint16*)(ip);	\
-		__lis_ori [1] = (((guint32)(val)) >> 16) & 0xffff;	\
-		__lis_ori [3] = ((guint32)(val)) & 0xffff;	\
+		__lis_ori [1] = (((guint32)(gsize)(val)) >> 16) & 0xffff;	\
+		__lis_ori [3] = ((guint32)(gsize)(val)) & 0xffff;	\
 	} while (0)
 
 void
@@ -6235,7 +6235,7 @@ mono_arch_patch_code_new (MonoCompile *cfg, MonoDomain *domain, guint8 *code, Mo
 		 * otherwise the displacements.
 		 */
 		for (i = 0; i < ji->data.table->table_size; i++)
-			jt [i] = code + (int)ji->data.table->table [i];
+			jt [i] = code + (int)(gsize)ji->data.table->table [i];
 		break;
 	}
 	case MONO_PATCH_INFO_IP:
@@ -7044,7 +7044,7 @@ mono_arch_find_static_call_vtable (host_mgreg_t *regs, guint8 *code)
 {
 	mono_cross_compile_assert_not_reached ();
 
-	return (MonoVTable*) regs [MONO_ARCH_RGCTX_REG];
+	return (MonoVTable*)(gsize)regs [MONO_ARCH_RGCTX_REG];
 }
 
 GSList*
@@ -7064,7 +7064,7 @@ mono_arch_get_cie_program (void)
 #define BRANCH_SIZE (1 * 4)
 #define CALL_SIZE (2 * 4)
 #define WMC_SIZE (8 * 4)
-#define DISTANCE(A, B) (((gint32)(B)) - ((gint32)(A)))
+#define DISTANCE(A, B) (((gint32)(gssize)(B)) - ((gint32)(gssize)(A)))
 
 static arminstr_t *
 arm_emit_value_and_patch_ldr (arminstr_t *code, arminstr_t *target, guint32 value)
@@ -7261,11 +7261,11 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTC
 			}
 
 			if (imt_method)
-				code = arm_emit_value_and_patch_ldr (code, imt_method, (guint32)item->key);
+				code = arm_emit_value_and_patch_ldr (code, imt_method, (guint32)(gsize)item->key);
 
 			/*must emit after unconditional branch*/
 			if (vtable_target) {
-				code = arm_emit_value_and_patch_ldr (code, vtable_target, (guint32)vtable);
+				code = arm_emit_value_and_patch_ldr (code, vtable_target, (guint32)(gsize)vtable);
 				item->chunk_size += 4;
 				vtable_target = NULL;
 			}
@@ -7296,7 +7296,7 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTC
 			int j;
 			arminstr_t *space_start = constant_pool_starts [i];
 			for (j = i - 1; j >= 0 && !imt_entries [j]->is_equals; --j) {
-				space_start = arm_emit_value_and_patch_ldr (space_start, (arminstr_t*)imt_entries [j]->code_target, (guint32)imt_entries [j]->key);
+				space_start = arm_emit_value_and_patch_ldr (space_start, (arminstr_t*)imt_entries [j]->code_target, (guint32)(gsize)imt_entries [j]->key);
 			}
 		}
 	}
@@ -7381,7 +7381,7 @@ mono_arch_set_breakpoint (MonoJitInfo *ji, guint8 *ip)
 		/* Read from another trigger page */
 		ARM_LDR_IMM (code, dreg, ARMREG_PC, 0);
 		ARM_B (code, 0);
-		*(int*)code = (int)bp_trigger_page;
+		*(int*)code = (int)(gssize)bp_trigger_page;
 		code += 4;
 		ARM_LDR_IMM (code, dreg, dreg, 0);
 

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -775,8 +775,6 @@ mono_arch_get_delegate_virtual_invoke_impl (MonoMethodSignature *sig, MonoMethod
 gpointer
 mono_arch_get_this_arg_from_call (host_mgreg_t *regs, guint8 *code)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return (gpointer)regs [ARMREG_R0];
 }
 
@@ -1650,8 +1648,6 @@ arg_need_temp (ArgInfo *ainfo)
 static gpointer
 arg_get_storage (CallContext *ccontext, ArgInfo *ainfo)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	switch (ainfo->storage) {
 		case RegTypeIRegPair:
 		case RegTypeGeneral:
@@ -1670,8 +1666,6 @@ arg_get_storage (CallContext *ccontext, ArgInfo *ainfo)
 static void
 arg_get_val (CallContext *ccontext, ArgInfo *ainfo, gpointer dest)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	int reg_size = ainfo->size * sizeof (host_mgreg_t);
 	g_assert (arg_need_temp (ainfo));
 	memcpy (dest, &ccontext->gregs [ainfo->reg], reg_size);
@@ -1681,8 +1675,6 @@ arg_get_val (CallContext *ccontext, ArgInfo *ainfo, gpointer dest)
 static void
 arg_set_val (CallContext *ccontext, ArgInfo *ainfo, gpointer src)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	int reg_size = ainfo->size * sizeof (host_mgreg_t);
 	g_assert (arg_need_temp (ainfo));
 	memcpy (&ccontext->gregs [ainfo->reg], src, reg_size);
@@ -1693,8 +1685,6 @@ arg_set_val (CallContext *ccontext, ArgInfo *ainfo, gpointer src)
 void
 mono_arch_set_native_call_context_args (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoEECallbacks *interp_cb = mini_get_interp_callbacks ();
 	CallInfo *cinfo = get_call_info (NULL, sig);
 	gpointer storage;
@@ -1737,8 +1727,6 @@ mono_arch_set_native_call_context_args (CallContext *ccontext, gpointer frame, M
 void
 mono_arch_set_native_call_context_ret (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoEECallbacks *interp_cb = mini_get_interp_callbacks ();
 	CallInfo *cinfo = get_call_info (NULL, sig);
 	gpointer storage;
@@ -1761,8 +1749,6 @@ mono_arch_set_native_call_context_ret (CallContext *ccontext, gpointer frame, Mo
 void
 mono_arch_get_native_call_context_args (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoEECallbacks *interp_cb = mini_get_interp_callbacks ();
 	CallInfo *cinfo = get_call_info (NULL, sig);
 	gpointer storage;
@@ -1796,8 +1782,6 @@ mono_arch_get_native_call_context_args (CallContext *ccontext, gpointer frame, M
 void
 mono_arch_get_native_call_context_ret (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	MonoEECallbacks *interp_cb = mini_get_interp_callbacks ();
 	CallInfo *cinfo = get_call_info (NULL, sig);
 	ArgInfo *ainfo;
@@ -2915,8 +2899,6 @@ dyn_call_supported (CallInfo *cinfo, MonoMethodSignature *sig)
 MonoDynCallInfo*
 mono_arch_dyn_call_prepare (MonoMethodSignature *sig)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ArchDynCallInfo *info;
 	CallInfo *cinfo;
 	int i;
@@ -2943,8 +2925,6 @@ mono_arch_dyn_call_prepare (MonoMethodSignature *sig)
 void
 mono_arch_dyn_call_free (MonoDynCallInfo *info)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ArchDynCallInfo *ainfo = (ArchDynCallInfo*)info;
 
 	g_free (ainfo->cinfo);
@@ -2954,8 +2934,6 @@ mono_arch_dyn_call_free (MonoDynCallInfo *info)
 int
 mono_arch_dyn_call_get_buf_size (MonoDynCallInfo *info)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ArchDynCallInfo *ainfo = (ArchDynCallInfo*)info;
 
 	g_assert (ainfo->cinfo->stack_usage % MONO_ARCH_FRAME_ALIGNMENT == 0);
@@ -2965,8 +2943,6 @@ mono_arch_dyn_call_get_buf_size (MonoDynCallInfo *info)
 void
 mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, guint8 *buf)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ArchDynCallInfo *dinfo = (ArchDynCallInfo*)info;
 	CallInfo *cinfo = dinfo->cinfo;
 	DynCallArgs *p = (DynCallArgs*)buf;
@@ -3105,8 +3081,6 @@ mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, g
 void
 mono_arch_finish_dyn_call (MonoDynCallInfo *info, guint8 *buf)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ArchDynCallInfo *ainfo = (ArchDynCallInfo*)info;
 	DynCallArgs *p = (DynCallArgs*)buf;
 	MonoType *ptype = ainfo->rtype;
@@ -7042,8 +7016,6 @@ mono_arch_find_imt_method (host_mgreg_t *regs, guint8 *code)
 MonoVTable*
 mono_arch_find_static_call_vtable (host_mgreg_t *regs, guint8 *code)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return (MonoVTable*)(gsize)regs [MONO_ARCH_RGCTX_REG];
 }
 
@@ -7090,8 +7062,6 @@ gpointer
 mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTCheckItem **imt_entries, int count,
 	gpointer fail_tramp)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	int size, i;
 	arminstr_t *code, *start;
 	gboolean large_offsets = FALSE;
@@ -7327,16 +7297,12 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTC
 host_mgreg_t
 mono_arch_context_get_int_reg (MonoContext *ctx, int reg)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return ctx->regs [reg];
 }
 
 void
 mono_arch_context_set_int_reg (MonoContext *ctx, int reg, host_mgreg_t val)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ctx->regs [reg] = val;
 }
 

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -773,8 +773,10 @@ mono_arch_get_delegate_virtual_invoke_impl (MonoMethodSignature *sig, MonoMethod
 }
 
 gpointer
-mono_arch_get_this_arg_from_call (mgreg_t *regs, guint8 *code)
+mono_arch_get_this_arg_from_call (host_mgreg_t *regs, guint8 *code)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return (gpointer)regs [ARMREG_R0];
 }
 
@@ -1648,6 +1650,8 @@ arg_need_temp (ArgInfo *ainfo)
 static gpointer
 arg_get_storage (CallContext *ccontext, ArgInfo *ainfo)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	switch (ainfo->storage) {
 		case RegTypeIRegPair:
 		case RegTypeGeneral:
@@ -1666,7 +1670,9 @@ arg_get_storage (CallContext *ccontext, ArgInfo *ainfo)
 static void
 arg_get_val (CallContext *ccontext, ArgInfo *ainfo, gpointer dest)
 {
-	int reg_size = ainfo->size * sizeof (mgreg_t);
+	mono_cross_compile_assert_not_reached ();
+
+	int reg_size = ainfo->size * sizeof (host_mgreg_t);
 	g_assert (arg_need_temp (ainfo));
 	memcpy (dest, &ccontext->gregs [ainfo->reg], reg_size);
 	memcpy ((mgreg_t*)dest + ainfo->size, ccontext->stack + ainfo->offset, ainfo->struct_size - reg_size);
@@ -1675,6 +1681,8 @@ arg_get_val (CallContext *ccontext, ArgInfo *ainfo, gpointer dest)
 static void
 arg_set_val (CallContext *ccontext, ArgInfo *ainfo, gpointer src)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	int reg_size = ainfo->size * sizeof (mgreg_t);
 	g_assert (arg_need_temp (ainfo));
 	memcpy (&ccontext->gregs [ainfo->reg], src, reg_size);
@@ -1685,6 +1693,8 @@ arg_set_val (CallContext *ccontext, ArgInfo *ainfo, gpointer src)
 void
 mono_arch_set_native_call_context_args (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MonoEECallbacks *interp_cb = mini_get_interp_callbacks ();
 	CallInfo *cinfo = get_call_info (NULL, sig);
 	gpointer storage;
@@ -1700,7 +1710,7 @@ mono_arch_set_native_call_context_args (CallContext *ccontext, gpointer frame, M
 		ainfo = &cinfo->ret;
 		if (ainfo->storage == RegTypeStructByAddr) {
 			storage = interp_cb->frame_arg_to_storage ((MonoInterpFrameHandle)frame, sig, -1);
-			ccontext->gregs [cinfo->ret.reg] = (mgreg_t)storage;
+			ccontext->gregs [cinfo->ret.reg] = (gsize)storage;
 		}
 	}
 
@@ -1727,6 +1737,8 @@ mono_arch_set_native_call_context_args (CallContext *ccontext, gpointer frame, M
 void
 mono_arch_set_native_call_context_ret (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MonoEECallbacks *interp_cb = mini_get_interp_callbacks ();
 	CallInfo *cinfo = get_call_info (NULL, sig);
 	gpointer storage;
@@ -1749,6 +1761,8 @@ mono_arch_set_native_call_context_ret (CallContext *ccontext, gpointer frame, Mo
 void
 mono_arch_get_native_call_context_args (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MonoEECallbacks *interp_cb = mini_get_interp_callbacks ();
 	CallInfo *cinfo = get_call_info (NULL, sig);
 	gpointer storage;
@@ -1782,6 +1796,8 @@ mono_arch_get_native_call_context_args (CallContext *ccontext, gpointer frame, M
 void
 mono_arch_get_native_call_context_ret (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	MonoEECallbacks *interp_cb = mini_get_interp_callbacks ();
 	CallInfo *cinfo = get_call_info (NULL, sig);
 	ArgInfo *ainfo;
@@ -2899,6 +2915,8 @@ dyn_call_supported (CallInfo *cinfo, MonoMethodSignature *sig)
 MonoDynCallInfo*
 mono_arch_dyn_call_prepare (MonoMethodSignature *sig)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ArchDynCallInfo *info;
 	CallInfo *cinfo;
 	int i;
@@ -2925,6 +2943,8 @@ mono_arch_dyn_call_prepare (MonoMethodSignature *sig)
 void
 mono_arch_dyn_call_free (MonoDynCallInfo *info)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ArchDynCallInfo *ainfo = (ArchDynCallInfo*)info;
 
 	g_free (ainfo->cinfo);
@@ -2934,6 +2954,8 @@ mono_arch_dyn_call_free (MonoDynCallInfo *info)
 int
 mono_arch_dyn_call_get_buf_size (MonoDynCallInfo *info)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ArchDynCallInfo *ainfo = (ArchDynCallInfo*)info;
 
 	g_assert (ainfo->cinfo->stack_usage % MONO_ARCH_FRAME_ALIGNMENT == 0);
@@ -2943,6 +2965,8 @@ mono_arch_dyn_call_get_buf_size (MonoDynCallInfo *info)
 void
 mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, guint8 *buf)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ArchDynCallInfo *dinfo = (ArchDynCallInfo*)info;
 	CallInfo *cinfo = dinfo->cinfo;
 	DynCallArgs *p = (DynCallArgs*)buf;
@@ -3081,6 +3105,8 @@ mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, g
 void
 mono_arch_finish_dyn_call (MonoDynCallInfo *info, guint8 *buf)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ArchDynCallInfo *ainfo = (ArchDynCallInfo*)info;
 	DynCallArgs *p = (DynCallArgs*)buf;
 	MonoType *ptype = ainfo->rtype;
@@ -7014,8 +7040,10 @@ mono_arch_find_imt_method (mgreg_t *regs, guint8 *code)
 }
 
 MonoVTable*
-mono_arch_find_static_call_vtable (mgreg_t *regs, guint8 *code)
+mono_arch_find_static_call_vtable (host_mgreg_t *regs, guint8 *code)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return (MonoVTable*) regs [MONO_ARCH_RGCTX_REG];
 }
 
@@ -7294,15 +7322,17 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTC
 	return start;
 }
 
-mgreg_t
+host_mgreg_t
 mono_arch_context_get_int_reg (MonoContext *ctx, int reg)
 {
 	return ctx->regs [reg];
 }
 
 void
-mono_arch_context_set_int_reg (MonoContext *ctx, int reg, mgreg_t val)
+mono_arch_context_set_int_reg (MonoContext *ctx, int reg, host_mgreg_t val)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ctx->regs [reg] = val;
 }
 

--- a/mono/mini/mini-arm.h
+++ b/mono/mini/mini-arm.h
@@ -228,7 +228,7 @@ struct CallInfo {
 
 typedef struct {
 	/* General registers */
-	mgreg_t gregs [PARAM_REGS];
+	host_mgreg_t gregs [PARAM_REGS];
 	/* Floating registers */
 	float fregs [FP_PARAM_REGS * 2];
 	/* Stack usage, used for passing params on stack */
@@ -246,12 +246,12 @@ struct SeqPointInfo {
 
 typedef struct {
 	double fpregs [FP_PARAM_REGS];
-	mgreg_t res, res2;
+	host_mgreg_t res, res2;
 	guint8 *ret;
 	guint32 has_fpregs;
 	guint32 n_stackargs;
 	/* This should come last as the structure is dynamically extended */
-	mgreg_t regs [PARAM_REGS];
+	host_mgreg_t regs [PARAM_REGS];
 } DynCallArgs;
 
 void arm_patch (guchar *code, const guchar *target);
@@ -397,13 +397,13 @@ typedef struct MonoCompileArch {
 #define MONO_ARCH_INIT_TOP_LMF_ENTRY(lmf)
 
 void
-mono_arm_throw_exception (MonoObject *exc, mgreg_t pc, mgreg_t sp, mgreg_t *int_regs, gdouble *fp_regs, gboolean preserve_ips);
+mono_arm_throw_exception (MonoObject *exc, host_mgreg_t pc, host_mgreg_t sp, host_mgreg_t *int_regs, gdouble *fp_regs, gboolean preserve_ips);
 
 void
-mono_arm_throw_exception_by_token (guint32 type_token, mgreg_t pc, mgreg_t sp, mgreg_t *int_regs, gdouble *fp_regs);
+mono_arm_throw_exception_by_token (guint32 type_token, host_mgreg_t pc, host_mgreg_t sp, host_mgreg_t *int_regs, gdouble *fp_regs);
 
 void
-mono_arm_resume_unwind (guint32 dummy1, mgreg_t pc, mgreg_t sp, mgreg_t *int_regs, gdouble *fp_regs);
+mono_arm_resume_unwind (guint32 dummy1, host_mgreg_t pc, host_mgreg_t sp, host_mgreg_t *int_regs, gdouble *fp_regs);
 
 gboolean
 mono_arm_thumb_supported (void);

--- a/mono/mini/mini-arm.h
+++ b/mono/mini/mini-arm.h
@@ -259,7 +259,7 @@ guint8* mono_arm_emit_load_imm (guint8 *code, int dreg, guint32 val);
 int mono_arm_is_rotated_imm8 (guint32 val, gint *rot_amount);
 
 void
-mono_arm_throw_exception_by_token (guint32 type_token, mgreg_t pc, mgreg_t sp, mgreg_t *int_regs, gdouble *fp_regs);
+mono_arm_throw_exception_by_token (guint32 type_token, host_mgreg_t pc, host_mgreg_t sp, host_mgreg_t *int_regs, gdouble *fp_regs);
 
 gpointer
 mono_arm_start_gsharedvt_call (GSharedVtCallInfo *info, gpointer *caller, gpointer *callee, gpointer mrgctx_reg, double *caller_fregs, double *callee_fregs);

--- a/mono/mini/mini-arm.h
+++ b/mono/mini/mini-arm.h
@@ -280,9 +280,9 @@ struct MonoLMF {
 	gpointer    lmf_addr;
 	/* This is only set in trampoline LMF frames */
 	MonoMethod *method;
-	mgreg_t    sp;
-	mgreg_t    ip;
-	mgreg_t    fp;
+	host_mgreg_t sp;
+	host_mgreg_t ip;
+	host_mgreg_t fp;
 	/* Currently only used in trampolines on armhf to hold d0-d15. We don't really
 	 * need to put d0-d7 in the LMF, but it simplifies the trampoline code.
 	 */
@@ -291,7 +291,7 @@ struct MonoLMF {
 	 * 0-4 should be considered undefined (execpt in the magic tramp)
 	 * sp is saved at IP.
 	 */
-	mgreg_t    iregs [14];
+	host_mgreg_t iregs [14];
 };
 
 typedef struct MonoCompileArch {

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -5275,6 +5275,8 @@ gpointer
 mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTCheckItem **imt_entries, int count,
 								gpointer fail_tramp)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	int i, buf_len, imt_reg;
 	guint8 *buf, *code;
 

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -225,8 +225,6 @@ mono_arch_get_delegate_virtual_invoke_impl (MonoMethodSignature *sig, MonoMethod
 gpointer
 mono_arch_get_this_arg_from_call (host_mgreg_t *regs, guint8 *code)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return (gpointer)regs [ARMREG_R0];
 }
 
@@ -1026,32 +1024,24 @@ mono_arch_flush_register_windows (void)
 MonoMethod*
 mono_arch_find_imt_method (host_mgreg_t *regs, guint8 *code)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return (MonoMethod*)regs [MONO_ARCH_RGCTX_REG];
 }
 
 MonoVTable*
 mono_arch_find_static_call_vtable (host_mgreg_t *regs, guint8 *code)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return (MonoVTable*)regs [MONO_ARCH_RGCTX_REG];
 }
 
 host_mgreg_t
 mono_arch_context_get_int_reg (MonoContext *ctx, int reg)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return ctx->regs [reg];
 }
 
 void
 mono_arch_context_set_int_reg (MonoContext *ctx, int reg, host_mgreg_t val)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ctx->regs [reg] = val;
 }
 
@@ -1636,8 +1626,6 @@ dyn_call_supported (CallInfo *cinfo, MonoMethodSignature *sig)
 MonoDynCallInfo*
 mono_arch_dyn_call_prepare (MonoMethodSignature *sig)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ArchDynCallInfo *info;
 	CallInfo *cinfo;
 	int i;
@@ -1676,8 +1664,6 @@ mono_arch_dyn_call_prepare (MonoMethodSignature *sig)
 void
 mono_arch_dyn_call_free (MonoDynCallInfo *info)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ArchDynCallInfo *ainfo = (ArchDynCallInfo*)info;
 
 	g_free (ainfo->cinfo);
@@ -1688,8 +1674,6 @@ mono_arch_dyn_call_free (MonoDynCallInfo *info)
 int
 mono_arch_dyn_call_get_buf_size (MonoDynCallInfo *info)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ArchDynCallInfo *ainfo = (ArchDynCallInfo*)info;
 
 	g_assert (ainfo->cinfo->stack_usage % MONO_ARCH_FRAME_ALIGNMENT == 0);
@@ -1715,8 +1699,6 @@ bitcast_r8_to_r4 (double f)
 void
 mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, guint8 *buf)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ArchDynCallInfo *dinfo = (ArchDynCallInfo*)info;
 	DynCallArgs *p = (DynCallArgs*)buf;
 	int aindex, arg_index, greg, i, pindex;
@@ -1890,8 +1872,6 @@ mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, g
 void
 mono_arch_finish_dyn_call (MonoDynCallInfo *info, guint8 *buf)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	ArchDynCallInfo *ainfo = (ArchDynCallInfo*)info;
 	CallInfo *cinfo = ainfo->cinfo;
 	DynCallArgs *args = (DynCallArgs*)buf;
@@ -5275,8 +5255,6 @@ gpointer
 mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTCheckItem **imt_entries, int count,
 								gpointer fail_tramp)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	int i, buf_len, imt_reg;
 	guint8 *buf, *code;
 

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -223,8 +223,10 @@ mono_arch_get_delegate_virtual_invoke_impl (MonoMethodSignature *sig, MonoMethod
 }
 
 gpointer
-mono_arch_get_this_arg_from_call (mgreg_t *regs, guint8 *code)
+mono_arch_get_this_arg_from_call (host_mgreg_t *regs, guint8 *code)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return (gpointer)regs [ARMREG_R0];
 }
 
@@ -1022,26 +1024,34 @@ mono_arch_flush_register_windows (void)
 }
 
 MonoMethod*
-mono_arch_find_imt_method (mgreg_t *regs, guint8 *code)
+mono_arch_find_imt_method (host_mgreg_t *regs, guint8 *code)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return (MonoMethod*)regs [MONO_ARCH_RGCTX_REG];
 }
 
 MonoVTable*
-mono_arch_find_static_call_vtable (mgreg_t *regs, guint8 *code)
+mono_arch_find_static_call_vtable (host_mgreg_t *regs, guint8 *code)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return (MonoVTable*)regs [MONO_ARCH_RGCTX_REG];
 }
 
-mgreg_t
+host_mgreg_t
 mono_arch_context_get_int_reg (MonoContext *ctx, int reg)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return ctx->regs [reg];
 }
 
 void
-mono_arch_context_set_int_reg (MonoContext *ctx, int reg, mgreg_t val)
+mono_arch_context_set_int_reg (MonoContext *ctx, int reg, host_mgreg_t val)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ctx->regs [reg] = val;
 }
 
@@ -1453,7 +1463,7 @@ mono_arch_set_native_call_context_args (CallContext *ccontext, gpointer frame, M
 		ainfo = &cinfo->ret;
 		if (ainfo->storage == ArgVtypeByRef) {
 			storage = interp_cb->frame_arg_to_storage ((MonoInterpFrameHandle)frame, sig, -1);
-			ccontext->gregs [cinfo->ret.reg] = (mgreg_t)storage;
+			ccontext->gregs [cinfo->ret.reg] = (gsize)storage;
 		}
 	}
 
@@ -1626,6 +1636,8 @@ dyn_call_supported (CallInfo *cinfo, MonoMethodSignature *sig)
 MonoDynCallInfo*
 mono_arch_dyn_call_prepare (MonoMethodSignature *sig)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ArchDynCallInfo *info;
 	CallInfo *cinfo;
 	int i;
@@ -1664,6 +1676,8 @@ mono_arch_dyn_call_prepare (MonoMethodSignature *sig)
 void
 mono_arch_dyn_call_free (MonoDynCallInfo *info)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ArchDynCallInfo *ainfo = (ArchDynCallInfo*)info;
 
 	g_free (ainfo->cinfo);
@@ -1674,6 +1688,8 @@ mono_arch_dyn_call_free (MonoDynCallInfo *info)
 int
 mono_arch_dyn_call_get_buf_size (MonoDynCallInfo *info)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ArchDynCallInfo *ainfo = (ArchDynCallInfo*)info;
 
 	g_assert (ainfo->cinfo->stack_usage % MONO_ARCH_FRAME_ALIGNMENT == 0);
@@ -1699,6 +1715,8 @@ bitcast_r8_to_r4 (double f)
 void
 mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, guint8 *buf)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ArchDynCallInfo *dinfo = (ArchDynCallInfo*)info;
 	DynCallArgs *p = (DynCallArgs*)buf;
 	int aindex, arg_index, greg, i, pindex;
@@ -1872,6 +1890,8 @@ mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, g
 void
 mono_arch_finish_dyn_call (MonoDynCallInfo *info, guint8 *buf)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	ArchDynCallInfo *ainfo = (ArchDynCallInfo*)info;
 	CallInfo *cinfo = ainfo->cinfo;
 	DynCallArgs *args = (DynCallArgs*)buf;
@@ -5544,4 +5564,3 @@ mono_arch_get_call_info (MonoMemPool *mp, MonoMethodSignature *sig)
 {
 	return get_call_info (mp, sig);
 }
-

--- a/mono/mini/mini-arm64.h
+++ b/mono/mini/mini-arm64.h
@@ -233,7 +233,7 @@ struct CallInfo {
 
 typedef struct {
 	/* General registers + ARMREG_R8 for indirect returns */
-	mgreg_t gregs [PARAM_REGS + 1];
+	host_mgreg_t gregs [PARAM_REGS + 1];
 	/* Floating registers */
 	double fregs [FP_PARAM_REGS];
 	/* Stack usage, used for passing params on stack */
@@ -258,13 +258,13 @@ guint8* mono_arm_emit_aotconst (gpointer ji, guint8 *code, guint8 *code_start, i
 
 void mono_arm_patch (guint8 *code, guint8 *target, int relocation);
 
-void mono_arm_throw_exception (gpointer arg, mgreg_t pc, mgreg_t *int_regs, gdouble *fp_regs, gboolean corlib, gboolean rethrow, gboolean preserve_ips);
+void mono_arm_throw_exception (gpointer arg, host_mgreg_t pc, host_mgreg_t *int_regs, gdouble *fp_regs, gboolean corlib, gboolean rethrow, gboolean preserve_ips);
 
 void mono_arm_gsharedvt_init (void);
 
 GSList* mono_arm_get_exception_trampolines (gboolean aot);
 
-void mono_arm_resume_unwind (gpointer arg, mgreg_t pc, mgreg_t *int_regs, gdouble *fp_regs, gboolean corlib, gboolean rethrow);
+void mono_arm_resume_unwind (gpointer arg, host_mgreg_t pc, host_mgreg_t *int_regs, gdouble *fp_regs, gboolean corlib, gboolean rethrow);
 
 CallInfo* mono_arch_get_call_info (MonoMemPool *mp, MonoMethodSignature *sig);
 

--- a/mono/mini/mini-arm64.h
+++ b/mono/mini/mini-arm64.h
@@ -73,8 +73,8 @@ struct MonoLMF {
 	 */
 	gpointer    previous_lmf;
 	gpointer    lmf_addr;
-	mgreg_t    pc;
-	mgreg_t    gregs [MONO_ARCH_NUM_LMF_REGS];
+	host_mgreg_t pc;
+	host_mgreg_t gregs [MONO_ARCH_NUM_LMF_REGS];
 };
 
 /* Structure used by the sequence points in AOTed code */

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -788,7 +788,7 @@ get_generic_info_from_stack_frame (MonoJitInfo *ji, MonoContext *ctx)
 	 * its prolog.
 	 */
 	if (gi->nlocs) {
-		int offset = (host_mgreg_t)MONO_CONTEXT_GET_IP (ctx) - (host_mgreg_t)ji->code_start;
+		int offset = (gsize)MONO_CONTEXT_GET_IP (ctx) - (gsize)ji->code_start;
 		int i;
 
 		for (i = 0; i < gi->nlocs; ++i) {

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -407,7 +407,7 @@ static gboolean
 arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 				   MonoJitInfo *ji, MonoContext *ctx,
 				   MonoContext *new_ctx, MonoLMF **lmf,
-				   mgreg_t **save_locations,
+				   host_mgreg_t **save_locations,
 				   StackFrameInfo *frame)
 {
 	if (!ji && *lmf) {
@@ -606,7 +606,7 @@ gboolean
 mono_find_jit_info_ext (MonoDomain *domain, MonoJitTlsData *jit_tls, 
 						MonoJitInfo *prev_ji, MonoContext *ctx,
 						MonoContext *new_ctx, char **trace, MonoLMF **lmf,
-						mgreg_t **save_locations,
+						host_mgreg_t **save_locations,
 						StackFrameInfo *frame)
 {
 	gboolean err;
@@ -629,7 +629,7 @@ mono_find_jit_info_ext (MonoDomain *domain, MonoJitTlsData *jit_tls,
 		target_domain = domain;
 
 	if (save_locations)
-		memset (save_locations, 0, MONO_MAX_IREGS * sizeof (mgreg_t*));
+		memset (save_locations, 0, MONO_MAX_IREGS * sizeof (host_mgreg_t*));
 
 	err = arch_unwind_frame (target_domain, jit_tls, ji, ctx, new_ctx, lmf, save_locations, frame);
 	if (!err)
@@ -723,7 +723,7 @@ unwinder_unwind_frame (Unwinder *unwinder,
 					   MonoDomain *domain, MonoJitTlsData *jit_tls,
 					   MonoJitInfo *prev_ji, MonoContext *ctx,
 					   MonoContext *new_ctx, char **trace, MonoLMF **lmf,
-					   mgreg_t **save_locations,
+					   host_mgreg_t **save_locations,
 					   StackFrameInfo *frame)
 {
 	gpointer parent;
@@ -788,7 +788,7 @@ get_generic_info_from_stack_frame (MonoJitInfo *ji, MonoContext *ctx)
 	 * its prolog.
 	 */
 	if (gi->nlocs) {
-		int offset = (mgreg_t)MONO_CONTEXT_GET_IP (ctx) - (mgreg_t)ji->code_start;
+		int offset = (host_mgreg_t)MONO_CONTEXT_GET_IP (ctx) - (host_mgreg_t)ji->code_start;
 		int i;
 
 		for (i = 0; i < gi->nlocs; ++i) {
@@ -1178,8 +1178,8 @@ mono_walk_stack_full (MonoJitStackWalk func, MonoContext *start_ctx, MonoDomain 
 	MonoContext ctx, new_ctx;
 	StackFrameInfo frame;
 	gboolean res;
-	mgreg_t *reg_locations [MONO_MAX_IREGS];
-	mgreg_t *new_reg_locations [MONO_MAX_IREGS];
+	host_mgreg_t *reg_locations [MONO_MAX_IREGS];
+	host_mgreg_t *new_reg_locations [MONO_MAX_IREGS];
 	gboolean get_reg_locations = unwind_options & MONO_UNWIND_REG_LOCATIONS;
 	gboolean async = mono_thread_info_is_async_context ();
 	Unwinder unwinder;

--- a/mono/mini/mini-gc.c
+++ b/mono/mini/mini-gc.c
@@ -2418,7 +2418,7 @@ create_map (MonoCompile *cfg)
 		p += encoded_size;
 
 		/* Callsite table */
-		p = (guint8*)ALIGN_TO ((mgreg_t)p, map->callsite_entry_size);
+		p = (guint8*)ALIGN_TO ((gsize)p, map->callsite_entry_size);
 		if (map->callsite_entry_size == 1) {
 			guint8 *offsets = p;
 			for (i = 0; i < ncallsites; ++i)

--- a/mono/mini/mini-gc.c
+++ b/mono/mini/mini-gc.c
@@ -698,7 +698,7 @@ slot_type_to_string (GCSlotType type)
 	}
 }
 
-static inline mgreg_t
+static inline host_mgreg_t
 get_frame_pointer (MonoContext *ctx, int frame_reg)
 {
 #if defined(TARGET_AMD64)
@@ -713,14 +713,14 @@ get_frame_pointer (MonoContext *ctx, int frame_reg)
 			return ctx->ebp;
 #elif defined(TARGET_ARM)
 		if (frame_reg == ARMREG_SP)
-			return (mgreg_t)MONO_CONTEXT_GET_SP (ctx);
+			return (host_mgreg_t)MONO_CONTEXT_GET_SP (ctx);
 		else if (frame_reg == ARMREG_FP)
-			return (mgreg_t)MONO_CONTEXT_GET_BP (ctx);
+			return (host_mgreg_t)MONO_CONTEXT_GET_BP (ctx);
 #elif defined(TARGET_S390X)
 		if (frame_reg == S390_SP)
-			return (mgreg_t)MONO_CONTEXT_GET_SP (ctx);
+			return (host_mgreg_t)MONO_CONTEXT_GET_SP (ctx);
 		else if (frame_reg == S390_FP)
-			return (mgreg_t)MONO_CONTEXT_GET_BP (ctx);
+			return (host_mgreg_t)MONO_CONTEXT_GET_BP (ctx);
 #endif
 		g_assert_not_reached ();
 		return 0;
@@ -748,8 +748,8 @@ conservative_pass (TlsData *tls, guint8 *stack_start, guint8 *stack_end)
 	int scanned = 0, scanned_precisely, scanned_conservatively, scanned_registers;
 	gboolean res;
 	StackFrameInfo frame;
-	mgreg_t *reg_locations [MONO_MAX_IREGS];
-	mgreg_t *new_reg_locations [MONO_MAX_IREGS];
+	host_mgreg_t *reg_locations [MONO_MAX_IREGS];
+	host_mgreg_t *new_reg_locations [MONO_MAX_IREGS];
 	guint8 *bitmaps;
 	FrameInfo *fi;
 	guint32 precise_regmask;
@@ -814,7 +814,7 @@ conservative_pass (TlsData *tls, guint8 *stack_start, guint8 *stack_end)
 			}
 		}
 
-		g_assert ((mgreg_t)stack_limit % SIZEOF_SLOT == 0);
+		g_assert ((gsize)stack_limit % SIZEOF_SLOT == 0);
 
 		res = mono_find_jit_info_ext (frame.domain ? frame.domain : tls->unwind_state.unwind_data [MONO_UNWIND_DATA_DOMAIN], tls->unwind_state.unwind_data [MONO_UNWIND_DATA_JIT_TLS], NULL, &ctx, &new_ctx, NULL, &lmf, new_reg_locations, &frame);
 		if (!res)
@@ -919,7 +919,7 @@ conservative_pass (TlsData *tls, guint8 *stack_start, guint8 *stack_end)
 		}
 
 		/* The embedded callsite table requires this */
-		g_assert (((mgreg_t)emap % 4) == 0);
+		g_assert (((gsize)emap % 4) == 0);
 
 		/*
 		 * Debugging aid to control the number of frames scanned precisely
@@ -1231,10 +1231,10 @@ precise_pass (TlsData *tls, guint8 *stack_start, guint8 *stack_end, void *gc_dat
 	 * Debugging aid to check for missed refs.
 	 */
 	if (tls->ref_to_track) {
-		mgreg_t *p;
+		gpointer *p;
 
-		for (p = (mgreg_t*)stack_start; p < (mgreg_t*)stack_end; ++p)
-			if (*p == (mgreg_t)tls->ref_to_track)
+		for (p = (gpointer*)stack_start; p < (gpointer*)stack_end; ++p)
+			if (*p == tls->ref_to_track)
 				printf ("REF AT %p.\n", p);
 	}
 }

--- a/mono/mini/mini-mips.c
+++ b/mono/mini/mini-mips.c
@@ -5551,6 +5551,8 @@ gpointer
 mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTCheckItem **imt_entries, int count,
 								gpointer fail_tramp)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	int i;
 	int size = 0;
 	guint8 *code, *start, *patch;

--- a/mono/mini/mini-mips.c
+++ b/mono/mini/mini-mips.c
@@ -655,8 +655,10 @@ mono_arch_get_delegate_virtual_invoke_impl (MonoMethodSignature *sig, MonoMethod
 }
 
 gpointer
-mono_arch_get_this_arg_from_call (mgreg_t *regs, guint8 *code)
+mono_arch_get_this_arg_from_call (host_mgreg_t *regs, guint8 *code)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	g_assert(regs);
 	return (gpointer)regs [mips_a0];
 }
@@ -5525,7 +5527,7 @@ mono_arch_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMetho
 	return NULL;
 }
 
-mgreg_t
+host_mgreg_t
 mono_arch_context_get_int_reg (MonoContext *ctx, int reg)
 {
 	return ctx->sc_regs [reg];
@@ -5684,14 +5686,18 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTC
 }
 
 MonoMethod*
-mono_arch_find_imt_method (mgreg_t *regs, guint8 *code)
+mono_arch_find_imt_method (host_mgreg_t *regs, guint8 *code)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return (MonoMethod*) regs [MONO_ARCH_IMT_REG];
 }
 
 MonoVTable*
-mono_arch_find_static_call_vtable (mgreg_t *regs, guint8 *code)
+mono_arch_find_static_call_vtable (host_mgreg_t *regs, guint8 *code)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return (MonoVTable*) regs [MONO_ARCH_RGCTX_REG];
 }
 

--- a/mono/mini/mini-mips.c
+++ b/mono/mini/mini-mips.c
@@ -657,8 +657,6 @@ mono_arch_get_delegate_virtual_invoke_impl (MonoMethodSignature *sig, MonoMethod
 gpointer
 mono_arch_get_this_arg_from_call (host_mgreg_t *regs, guint8 *code)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	g_assert(regs);
 	return (gpointer)regs [mips_a0];
 }
@@ -5551,8 +5549,6 @@ gpointer
 mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTCheckItem **imt_entries, int count,
 								gpointer fail_tramp)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	int i;
 	int size = 0;
 	guint8 *code, *start, *patch;
@@ -5690,16 +5686,12 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTC
 MonoMethod*
 mono_arch_find_imt_method (host_mgreg_t *regs, guint8 *code)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return (MonoMethod*) regs [MONO_ARCH_IMT_REG];
 }
 
 MonoVTable*
 mono_arch_find_static_call_vtable (host_mgreg_t *regs, guint8 *code)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return (MonoVTable*) regs [MONO_ARCH_RGCTX_REG];
 }
 

--- a/mono/mini/mini-mips.h
+++ b/mono/mini/mini-mips.h
@@ -210,7 +210,7 @@ struct MonoLMF {
 	gpointer	lmf_addr;
 	MonoMethod	*method;
 	gpointer	eip;
-	mgreg_t     iregs [MONO_SAVED_GREGS];
+	host_mgreg_t    iregs [MONO_SAVED_GREGS];
 	mips_freg	fregs [MONO_SAVED_FREGS];
 	gulong		magic;
 };

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -5598,6 +5598,8 @@ gpointer
 mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTCheckItem **imt_entries, int count,
 								gpointer fail_tramp)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	int i;
 	int size = 0;
 	guint8 *code, *start;
@@ -5737,9 +5739,11 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTC
 }
 
 MonoMethod*
-mono_arch_find_imt_method (mgreg_t *regs, guint8 *code)
+mono_arch_find_imt_method (host_mgreg_t *regs, guint8 *code)
 {
-	mgreg_t *r = (mgreg_t*)regs;
+	mono_cross_compile_assert_not_reached ();
+
+	host_mgreg_t *r = (host_mgreg_t*)regs;
 
 	return (MonoMethod*)(gsize) r [MONO_ARCH_IMT_REG];
 }
@@ -5772,6 +5776,8 @@ mono_arch_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMetho
 host_mgreg_t
 mono_arch_context_get_int_reg (MonoContext *ctx, int reg)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	if (reg == ppc_r1)
 		return (mgreg_t)(gsize)MONO_CONTEXT_GET_SP (ctx);
 

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -468,9 +468,9 @@ mono_arch_get_delegate_virtual_invoke_impl (MonoMethodSignature *sig, MonoMethod
 }
 
 gpointer
-mono_arch_get_this_arg_from_call (mgreg_t *regs, guint8 *code)
+mono_arch_get_this_arg_from_call (host_mgreg_t *r, guint8 *code)
 {
-	mgreg_t *r = (mgreg_t*)regs;
+	mono_cross_compile_assert_not_reached ();
 
 	return (gpointer)(gsize)r [ppc_r3];
 }
@@ -5745,11 +5745,11 @@ mono_arch_find_imt_method (mgreg_t *regs, guint8 *code)
 }
 
 MonoVTable*
-mono_arch_find_static_call_vtable (mgreg_t *regs, guint8 *code)
+mono_arch_find_static_call_vtable (host_mgreg_t *regs, guint8 *code)
 {
-	mgreg_t *r = (mgreg_t*)regs;
+	mono_cross_compile_assert_not_reached ();
 
-	return (MonoVTable*)(gsize) r [MONO_ARCH_RGCTX_REG];
+	return (MonoVTable*)(gsize) regs [MONO_ARCH_RGCTX_REG];
 }
 
 GSList*
@@ -5769,7 +5769,7 @@ mono_arch_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMetho
 	return NULL;
 }
 
-mgreg_t
+host_mgreg_t
 mono_arch_context_get_int_reg (MonoContext *ctx, int reg)
 {
 	if (reg == ppc_r1)

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -470,8 +470,6 @@ mono_arch_get_delegate_virtual_invoke_impl (MonoMethodSignature *sig, MonoMethod
 gpointer
 mono_arch_get_this_arg_from_call (host_mgreg_t *r, guint8 *code)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return (gpointer)(gsize)r [ppc_r3];
 }
 
@@ -5598,8 +5596,6 @@ gpointer
 mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTCheckItem **imt_entries, int count,
 								gpointer fail_tramp)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	int i;
 	int size = 0;
 	guint8 *code, *start;
@@ -5741,8 +5737,6 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTC
 MonoMethod*
 mono_arch_find_imt_method (host_mgreg_t *regs, guint8 *code)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	host_mgreg_t *r = (host_mgreg_t*)regs;
 
 	return (MonoMethod*)(gsize) r [MONO_ARCH_IMT_REG];
@@ -5751,8 +5745,6 @@ mono_arch_find_imt_method (host_mgreg_t *regs, guint8 *code)
 MonoVTable*
 mono_arch_find_static_call_vtable (host_mgreg_t *regs, guint8 *code)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return (MonoVTable*)(gsize) regs [MONO_ARCH_RGCTX_REG];
 }
 
@@ -5776,8 +5768,6 @@ mono_arch_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMetho
 host_mgreg_t
 mono_arch_context_get_int_reg (MonoContext *ctx, int reg)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	if (reg == ppc_r1)
 		return (mgreg_t)(gsize)MONO_CONTEXT_GET_SP (ctx);
 

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -5773,7 +5773,7 @@ host_mgreg_t
 mono_arch_context_get_int_reg (MonoContext *ctx, int reg)
 {
 	if (reg == ppc_r1)
-		return (mgreg_t)MONO_CONTEXT_GET_SP (ctx);
+		return (mgreg_t)(gsize)MONO_CONTEXT_GET_SP (ctx);
 
 	return ctx->regs [reg];
 }

--- a/mono/mini/mini-ppc.h
+++ b/mono/mini/mini-ppc.h
@@ -384,7 +384,7 @@ void
 mono_ppc_patch (guchar *code, const guchar *target);
 
 void
-mono_ppc_throw_exception (MonoObject *exc, unsigned long eip, unsigned long esp, mgreg_t *int_regs, gdouble *fp_regs, gboolean rethrow, gboolean preserve_ips);
+mono_ppc_throw_exception (MonoObject *exc, unsigned long eip, unsigned long esp, host_mgreg_t *int_regs, gdouble *fp_regs, gboolean rethrow, gboolean preserve_ips);
 
 #ifdef __mono_ppc64__
 #define MONO_PPC_32_64_CASE(c32,c64)	c64

--- a/mono/mini/mini-ppc.h
+++ b/mono/mini/mini-ppc.h
@@ -52,7 +52,7 @@ struct MonoLMF {
 	gulong     eip;
 	/* Add a dummy field to force iregs to be aligned when cross compiling from x86 */
 	gulong     dummy;
-	mgreg_t    iregs [MONO_SAVED_GREGS]; /* 13..31 */
+	host_mgreg_t iregs [MONO_SAVED_GREGS]; /* 13..31 */
 	gdouble    fregs [MONO_SAVED_FREGS]; /* 14..31 */
 };
 

--- a/mono/mini/mini-profiler.c
+++ b/mono/mini/mini-profiler.c
@@ -179,7 +179,7 @@ memdup_with_type (gpointer data, MonoType *t)
 static guint8 *
 get_int_reg (MonoContext *ctx, guint32 reg)
 {
-	return (guint8 *) mono_arch_context_get_int_reg (ctx, reg);
+	return (guint8 *)(gsize)mono_arch_context_get_int_reg (ctx, reg);
 }
 
 static gpointer

--- a/mono/mini/mini-profiler.c
+++ b/mono/mini/mini-profiler.c
@@ -193,9 +193,9 @@ get_variable_buffer (MonoDebugMethodJitInfo *jit, MonoDebugVarInfo *var, MonoCon
 		/*
 		 * This is kind of a special case: All other address modes ultimately
 		 * produce an address to where the actual value is located, but this
-		 * address mode gets us the value itself as an mgreg_t value.
+		 * address mode gets us the value itself as an host_mgreg_t value.
 		 */
-		mgreg_t value = (mgreg_t) get_int_reg (ctx, reg);
+		host_mgreg_t value = (host_mgreg_t) get_int_reg (ctx, reg);
 
 		return memdup_with_type (&value, var->type);
 	}

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -1639,7 +1639,7 @@ mono_resolve_patch_target (MonoMethod *method, MonoDomain *domain, guint8 *code,
 
 		mono_gc_get_nursery (&shift_bits, &size);
 
-		target = (gpointer)(mgreg_t)shift_bits;
+		target = (gpointer)(gssize)shift_bits;
 		break;
 	}
 	case MONO_PATCH_INFO_CASTCLASS_CACHE: {

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -7126,6 +7126,7 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain,
 								MonoIMTCheckItem **imt_entries, int count,
 								gpointer fail_tramp)
 {
+	mono_cross_compile_assert_not_reached ();
 	int i;
 	int size = 0;
 	guchar *code, *start;

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -2272,7 +2272,7 @@ mono_arch_allocate_vars (MonoCompile *cfg)
 	/* Reserve space to save LMF and caller saved registers */
 	/*------------------------------------------------------*/
 	if (cfg->method->save_lmf)
-		offset += MONO_ABI_SIZEOF (MonoLMF);
+		offset += sizeof (MonoLMF);
 
 	/*------------------------------------------------------*/
 	/* align the offset 					*/
@@ -2687,7 +2687,7 @@ mono_arch_instrument_prolog (MonoCompile *cfg, void *func, void *p,
 
 	parmOffset = cfg->stack_usage - S390_TRACE_STACK_SIZE - cfg->arch.fpSize;
 	if (cfg->method->save_lmf)
-		parmOffset -= MONO_ABI_MONO_ABI_SIZEOF (MonoLMF);
+		parmOffset -= sizeof(MonoLMF);
 	fpOffset   = parmOffset + (5*sizeof(gpointer));
 	baseReg = STK_BASE;
 
@@ -2739,7 +2739,7 @@ mono_arch_instrument_epilog (MonoCompile *cfg, void *func, void *p, gboolean ena
 
 	saveOffset = cfg->stack_usage - S390_TRACE_STACK_SIZE - cfg->arch.fpSize;
 	if (method->save_lmf)
-		saveOffset -= MONO_ABI_MONO_ABI_SIZEOF (MonoLMF);
+		saveOffset -= sizeof(MonoLMF);
 
 handle_enum:
 	switch (rtype) {
@@ -4440,7 +4440,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				/*----------------------------------*/
 				/* we have to adjust lmf ebp value  */
 				/*----------------------------------*/
-				int lmfOffset = cfg->stack_usage - MONO_ABI_MONO_ABI_SIZEOF (MonoLMF);
+				int lmfOffset = cfg->stack_usage - sizeof(MonoLMF);
 
 				s390_lgr (code, s390_r13, cfg->frame_reg);
 				if (s390_is_imm16(lmfOffset)) {
@@ -6361,7 +6361,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 		/*---------------------------------------------------------------*/
 		/* build the MonoLMF structure on the stack - see mini-s390x.h   */
 		/*---------------------------------------------------------------*/
-		lmfOffset = alloc_size - MONO_ABI_MONO_ABI_SIZEOF (MonoLMF);	
+		lmfOffset = alloc_size - sizeof(MonoLMF);	
 											
 		s390_lgr   (code, s390_r13, cfg->frame_reg);		
 		s390_aghi  (code, s390_r13, lmfOffset);					

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -7126,7 +7126,6 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain,
 								MonoIMTCheckItem **imt_entries, int count,
 								gpointer fail_tramp)
 {
-	mono_cross_compile_assert_not_reached ();
 	int i;
 	int size = 0;
 	guchar *code, *start;

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -2272,7 +2272,7 @@ mono_arch_allocate_vars (MonoCompile *cfg)
 	/* Reserve space to save LMF and caller saved registers */
 	/*------------------------------------------------------*/
 	if (cfg->method->save_lmf)
-		offset += sizeof (MonoLMF);
+		offset += MONO_ABI_SIZEOF (MonoLMF);
 
 	/*------------------------------------------------------*/
 	/* align the offset 					*/
@@ -2687,7 +2687,7 @@ mono_arch_instrument_prolog (MonoCompile *cfg, void *func, void *p,
 
 	parmOffset = cfg->stack_usage - S390_TRACE_STACK_SIZE - cfg->arch.fpSize;
 	if (cfg->method->save_lmf)
-		parmOffset -= sizeof(MonoLMF);
+		parmOffset -= MONO_ABI_MONO_ABI_SIZEOF (MonoLMF);
 	fpOffset   = parmOffset + (5*sizeof(gpointer));
 	baseReg = STK_BASE;
 
@@ -2739,7 +2739,7 @@ mono_arch_instrument_epilog (MonoCompile *cfg, void *func, void *p, gboolean ena
 
 	saveOffset = cfg->stack_usage - S390_TRACE_STACK_SIZE - cfg->arch.fpSize;
 	if (method->save_lmf)
-		saveOffset -= sizeof(MonoLMF);
+		saveOffset -= MONO_ABI_MONO_ABI_SIZEOF (MonoLMF);
 
 handle_enum:
 	switch (rtype) {
@@ -4440,7 +4440,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				/*----------------------------------*/
 				/* we have to adjust lmf ebp value  */
 				/*----------------------------------*/
-				int lmfOffset = cfg->stack_usage - sizeof(MonoLMF);
+				int lmfOffset = cfg->stack_usage - MONO_ABI_MONO_ABI_SIZEOF (MonoLMF);
 
 				s390_lgr (code, s390_r13, cfg->frame_reg);
 				if (s390_is_imm16(lmfOffset)) {
@@ -6361,7 +6361,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 		/*---------------------------------------------------------------*/
 		/* build the MonoLMF structure on the stack - see mini-s390x.h   */
 		/*---------------------------------------------------------------*/
-		lmfOffset = alloc_size - sizeof(MonoLMF);	
+		lmfOffset = alloc_size - MONO_ABI_MONO_ABI_SIZEOF (MonoLMF);	
 											
 		s390_lgr   (code, s390_r13, cfg->frame_reg);		
 		s390_aghi  (code, s390_r13, lmfOffset);					
@@ -6871,10 +6871,10 @@ mono_arch_get_patch_offset (guint8 *code)
 /*                                                                  */
 /*------------------------------------------------------------------*/
 
-mgreg_t
+host_mgreg_t
 mono_arch_context_get_int_reg (MonoContext *ctx, int reg)
 {
-	return ((mgreg_t) ctx->uc_mcontext.gregs[reg]);
+	return ctx->uc_mcontext.gregs[reg];
 }
 
 /*========================= End of Function ========================*/
@@ -6888,7 +6888,7 @@ mono_arch_context_get_int_reg (MonoContext *ctx, int reg)
 /*------------------------------------------------------------------*/
 
 void
-mono_arch_context_set_int_reg (MonoContext *ctx, int reg, mgreg_t val)
+mono_arch_context_set_int_reg (MonoContext *ctx, int reg, host_mgreg_t val)
 {
 	ctx->uc_mcontext.gregs[reg] = val;
 }
@@ -6904,7 +6904,7 @@ mono_arch_context_set_int_reg (MonoContext *ctx, int reg, mgreg_t val)
 /*------------------------------------------------------------------*/
 
 gpointer
-mono_arch_get_this_arg_from_call (mgreg_t *regs, guint8 *code)
+mono_arch_get_this_arg_from_call (host_mgreg_t *regs, guint8 *code)
 {
 	return (gpointer) regs [s390_r2];
 }
@@ -7268,7 +7268,7 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain,
 /*------------------------------------------------------------------*/
 
 MonoMethod*
-mono_arch_find_imt_method (mgreg_t *regs, guint8 *code)
+mono_arch_find_imt_method (host_mgreg_t *regs, guint8 *code)
 {
 	return ((MonoMethod *) regs [MONO_ARCH_IMT_REG]);
 }
@@ -7284,11 +7284,9 @@ mono_arch_find_imt_method (mgreg_t *regs, guint8 *code)
 /*------------------------------------------------------------------*/
 
 MonoVTable*
-mono_arch_find_static_call_vtable (mgreg_t *regs, guint8 *code)
+mono_arch_find_static_call_vtable (host_mgreg_t *regs, guint8 *code)
 {
-	mgreg_t *r = (mgreg_t*)regs;
-
-	return (MonoVTable*)(gsize) r [MONO_ARCH_RGCTX_REG];
+	return (MonoVTable*)(gsize) regs [MONO_ARCH_RGCTX_REG];
 }
 
 /*========================= End of Function ========================*/

--- a/mono/mini/mini-sparc.c
+++ b/mono/mini/mini-sparc.c
@@ -2265,6 +2265,8 @@ gpointer
 mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTCheckItem **imt_entries, int count,
 								gpointer fail_tramp)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	int i;
 	int size = 0;
 	guint32 *code, *start;

--- a/mono/mini/mini-sparc.c
+++ b/mono/mini/mini-sparc.c
@@ -2265,8 +2265,6 @@ gpointer
 mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTCheckItem **imt_entries, int count,
 								gpointer fail_tramp)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	int i;
 	int size = 0;
 	guint32 *code, *start;

--- a/mono/mini/mini-sparc.c
+++ b/mono/mini/mini-sparc.c
@@ -2368,7 +2368,7 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTC
 }
 
 MonoMethod*
-mono_arch_find_imt_method (mgreg_t *regs, guint8 *code)
+mono_arch_find_imt_method (host_mgreg_t *regs, guint8 *code)
 {
 #ifdef SPARCV9
 	g_assert_not_reached ();
@@ -2378,7 +2378,7 @@ mono_arch_find_imt_method (mgreg_t *regs, guint8 *code)
 }
 
 gpointer
-mono_arch_get_this_arg_from_call (mgreg_t *regs, guint8 *code)
+mono_arch_get_this_arg_from_call (host_mgreg_t *regs, guint8 *code)
 {
 	mono_sparc_flushw ();
 
@@ -4391,7 +4391,7 @@ mono_arch_get_argument_info (MonoMethodSignature *csig, int param_count, MonoJit
 	return 0;
 }
 
-mgreg_t
+host_mgreg_t
 mono_arch_context_get_int_reg (MonoContext *ctx, int reg)
 {
 	/* FIXME: implement */

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -538,7 +538,7 @@ mini_add_method_wrappers_llvmonly (MonoMethod *m, gpointer compiled_method, gboo
  * from JITted and LLVM compiled code.
  */
 static gpointer
-common_call_trampoline (mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVTable *vt, gpointer *vtable_slot, MonoError *error)
+common_call_trampoline (host_mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVTable *vt, gpointer *vtable_slot, MonoError *error)
 {
 	gpointer addr, compiled_method;
 	gboolean generic_shared = FALSE;
@@ -877,7 +877,7 @@ common_call_trampoline (mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVTable *
  * This trampoline handles normal calls from JITted code.
  */
 gpointer
-mono_magic_trampoline (mgreg_t *regs, guint8 *code, gpointer arg, guint8* tramp)
+mono_magic_trampoline (host_mgreg_t *regs, guint8 *code, gpointer arg, guint8* tramp)
 {
 	gpointer res;
 	ERROR_DECL (error);
@@ -904,7 +904,7 @@ mono_magic_trampoline (mgreg_t *regs, guint8 *code, gpointer arg, guint8* tramp)
  * This trampoline handles virtual calls.
  */
 static gpointer
-mono_vcall_trampoline (mgreg_t *regs, guint8 *code, int slot, guint8 *tramp)
+mono_vcall_trampoline (host_mgreg_t *regs, guint8 *code, int slot, guint8 *tramp)
 {
 	gpointer res;
 	MONO_ENTER_GC_UNSAFE;
@@ -983,7 +983,7 @@ leave:
 
 #ifndef DISABLE_REMOTING
 gpointer
-mono_generic_virtual_remoting_trampoline (mgreg_t *regs, guint8 *code, MonoMethod *m, guint8 *tramp)
+mono_generic_virtual_remoting_trampoline (host_mgreg_t *regs, guint8 *code, MonoMethod *m, guint8 *tramp)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
@@ -1036,7 +1036,7 @@ mono_generic_virtual_remoting_trampoline (mgreg_t *regs, guint8 *code, MonoMetho
  */
 #ifdef MONO_ARCH_AOT_SUPPORTED
 gpointer
-mono_aot_trampoline (mgreg_t *regs, guint8 *code, guint8 *token_info, 
+mono_aot_trampoline (host_mgreg_t *regs, guint8 *code, guint8 *token_info, 
 					 guint8* tramp)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
@@ -1083,7 +1083,7 @@ mono_aot_trampoline (mgreg_t *regs, guint8 *code, guint8 *token_info,
  *   This trampoline handles calls made from AOT code through the PLT table.
  */
 gpointer
-mono_aot_plt_trampoline (mgreg_t *regs, guint8 *code, guint8 *aot_module, 
+mono_aot_plt_trampoline (host_mgreg_t *regs, guint8 *code, guint8 *aot_module, 
 						 guint8* tramp)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
@@ -1109,13 +1109,12 @@ mono_aot_plt_trampoline (mgreg_t *regs, guint8 *code, guint8 *aot_module,
 #endif
 
 static gpointer
-mono_rgctx_lazy_fetch_trampoline (mgreg_t *regs, guint8 *code, gpointer data, guint8 *tramp)
+mono_rgctx_lazy_fetch_trampoline (host_mgreg_t *regs, guint8 *code, gpointer data, guint8 *tramp)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	guint32 slot = GPOINTER_TO_UINT (data);
-	mgreg_t *r = (mgreg_t*)regs;
-	gpointer arg = (gpointer)(gssize)r [MONO_ARCH_VTABLE_REG];
+	gpointer arg = (gpointer)(gssize)regs [MONO_ARCH_VTABLE_REG];
 	guint32 index = MONO_RGCTX_SLOT_INDEX (slot);
 	gboolean mrgctx = MONO_RGCTX_SLOT_IS_MRGCTX (slot);
 	ERROR_DECL (error);
@@ -1142,7 +1141,7 @@ mono_rgctx_lazy_fetch_trampoline (mgreg_t *regs, guint8 *code, gpointer data, gu
  * This is called once the first time a delegate is invoked, so it must be fast.
  */
 gpointer
-mono_delegate_trampoline (mgreg_t *regs, guint8 *code, gpointer *arg, guint8* tramp)
+mono_delegate_trampoline (host_mgreg_t *regs, guint8 *code, gpointer *arg, guint8* tramp)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 

--- a/mono/mini/mini-unwind.h
+++ b/mono/mini/mini-unwind.h
@@ -13,9 +13,9 @@
 
 #include "mini.h"
 
-/* This is the same as mgreg_t, except on 32 bit bit platforms with callee saved fp regs */
+/* This is the same as host_mgreg_t, except on 32 bit bit platforms with callee saved fp regs */
 #ifndef mono_unwind_reg_t
-#define mono_unwind_reg_t mgreg_t
+#define mono_unwind_reg_t host_mgreg_t
 #endif
 
 /*
@@ -181,7 +181,7 @@ void
 mono_unwind_frame (guint8 *unwind_info, guint32 unwind_info_len, 
 				   guint8 *start_ip, guint8 *end_ip, guint8 *ip, guint8 **mark_locations,
 				   mono_unwind_reg_t *regs, int nregs,
-				   mgreg_t **save_locations, int save_locations_len,
+				   host_mgreg_t **save_locations, int save_locations_len,
 				   guint8 **out_cfa);
 
 void mono_unwind_init (void);

--- a/mono/mini/mini-wasm.c
+++ b/mono/mini/mini-wasm.c
@@ -395,7 +395,7 @@ G_END_DECLS
 #endif // HOST_WASM
 
 gpointer
-mono_arch_get_this_arg_from_call (mgreg_t *regs, guint8 *code)
+mono_arch_get_this_arg_from_call (host_mgreg_t *regs, guint8 *code)
 {
 	g_error ("mono_arch_get_this_arg_from_call");
 }
@@ -447,14 +447,14 @@ mono_arch_free_jit_tls_data (MonoJitTlsData *tls)
 
 
 MonoMethod*
-mono_arch_find_imt_method (mgreg_t *regs, guint8 *code)
+mono_arch_find_imt_method (host_mgreg_t *regs, guint8 *code)
 {
 	g_error ("mono_arch_find_static_call_vtable");
 	return (MonoMethod*) regs [MONO_ARCH_IMT_REG];
 }
 
 MonoVTable*
-mono_arch_find_static_call_vtable (mgreg_t *regs, guint8 *code)
+mono_arch_find_static_call_vtable (host_mgreg_t *regs, guint8 *code)
 {
 	g_error ("mono_arch_find_static_call_vtable");
 	return (MonoVTable*) regs [MONO_ARCH_RGCTX_REG];
@@ -480,7 +480,7 @@ mono_arch_cpu_optimizations (guint32 *exclude_mask)
 	return 0;
 }
 
-mgreg_t
+host_mgreg_t
 mono_arch_context_get_int_reg (MonoContext *ctx, int reg)
 {
 	g_error ("mono_arch_context_get_int_reg");

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -5632,8 +5632,6 @@ gpointer
 mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTCheckItem **imt_entries, int count,
 	gpointer fail_tramp)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	int i;
 	int size = 0;
 	guint8 *code, *start;
@@ -5763,16 +5761,12 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTC
 MonoMethod*
 mono_arch_find_imt_method (host_mgreg_t *regs, guint8 *code)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return (MonoMethod*) regs [MONO_ARCH_IMT_REG];
 }
 
 MonoVTable*
 mono_arch_find_static_call_vtable (host_mgreg_t *regs, guint8 *code)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return (MonoVTable*) regs [MONO_ARCH_RGCTX_REG];
 }
 
@@ -6177,8 +6171,6 @@ mono_arch_get_delegate_virtual_invoke_impl (MonoMethodSignature *sig, MonoMethod
 host_mgreg_t
 mono_arch_context_get_int_reg (MonoContext *ctx, int reg)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	switch (reg) {
 	case X86_EAX: return ctx->eax;
 	case X86_EBX: return ctx->ebx;
@@ -6197,8 +6189,6 @@ mono_arch_context_get_int_reg (MonoContext *ctx, int reg)
 void
 mono_arch_context_set_int_reg (MonoContext *ctx, int reg, host_mgreg_t val)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	switch (reg) {
 	case X86_EAX:
 		ctx->eax = val;

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -5759,13 +5759,13 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTC
 }
 
 MonoMethod*
-mono_arch_find_imt_method (mgreg_t *regs, guint8 *code)
+mono_arch_find_imt_method (host_mgreg_t *regs, guint8 *code)
 {
 	return (MonoMethod*) regs [MONO_ARCH_IMT_REG];
 }
 
 MonoVTable*
-mono_arch_find_static_call_vtable (mgreg_t *regs, guint8 *code)
+mono_arch_find_static_call_vtable (host_mgreg_t *regs, guint8 *code)
 {
 	return (MonoVTable*) regs [MONO_ARCH_RGCTX_REG];
 }
@@ -6168,7 +6168,7 @@ mono_arch_get_delegate_virtual_invoke_impl (MonoMethodSignature *sig, MonoMethod
 	return code;
 }
 
-mgreg_t
+host_mgreg_t
 mono_arch_context_get_int_reg (MonoContext *ctx, int reg)
 {
 	switch (reg) {
@@ -6187,7 +6187,7 @@ mono_arch_context_get_int_reg (MonoContext *ctx, int reg)
 }
 
 void
-mono_arch_context_set_int_reg (MonoContext *ctx, int reg, mgreg_t val)
+mono_arch_context_set_int_reg (MonoContext *ctx, int reg, host_mgreg_t val)
 {
 	switch (reg) {
 	case X86_EAX:

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -5632,6 +5632,8 @@ gpointer
 mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTCheckItem **imt_entries, int count,
 	gpointer fail_tramp)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	int i;
 	int size = 0;
 	guint8 *code, *start;
@@ -5761,12 +5763,16 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTC
 MonoMethod*
 mono_arch_find_imt_method (host_mgreg_t *regs, guint8 *code)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return (MonoMethod*) regs [MONO_ARCH_IMT_REG];
 }
 
 MonoVTable*
 mono_arch_find_static_call_vtable (host_mgreg_t *regs, guint8 *code)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return (MonoVTable*) regs [MONO_ARCH_RGCTX_REG];
 }
 
@@ -6171,6 +6177,8 @@ mono_arch_get_delegate_virtual_invoke_impl (MonoMethodSignature *sig, MonoMethod
 host_mgreg_t
 mono_arch_context_get_int_reg (MonoContext *ctx, int reg)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	switch (reg) {
 	case X86_EAX: return ctx->eax;
 	case X86_EBX: return ctx->ebx;
@@ -6189,6 +6197,8 @@ mono_arch_context_get_int_reg (MonoContext *ctx, int reg)
 void
 mono_arch_context_set_int_reg (MonoContext *ctx, int reg, host_mgreg_t val)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	switch (reg) {
 	case X86_EAX:
 		ctx->eax = val;

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2763,10 +2763,4 @@ MonoType*   mini_native_type_replace_type (MonoType *type) MONO_LLVM_INTERNAL;
 MonoMethod*
 mini_method_to_shared (MonoMethod *method); // null if not shared
 
-#ifdef MONO_CROSS_COMPILE
-#define mono_cross_compile_assert_not_reached() g_error ("%s cross compiled run?", __func__);
-#else
-#define mono_cross_compile_assert_not_reached() /* nothing */
-#endif
-
 #endif /* __MONO_MINI_H__ */

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2120,20 +2120,20 @@ gpointer          mono_create_static_rgctx_trampoline (MonoMethod *m, gpointer a
 gpointer          mono_create_ftnptr_arg_trampoline (gpointer arg, gpointer addr);
 MonoVTable*       mono_find_class_init_trampoline_by_addr (gconstpointer addr);
 guint32           mono_find_rgctx_lazy_fetch_trampoline_by_addr (gconstpointer addr);
-gpointer          mono_magic_trampoline (mgreg_t *regs, guint8 *code, gpointer arg, guint8* tramp);
+gpointer          mono_magic_trampoline (host_mgreg_t *regs, guint8 *code, gpointer arg, guint8* tramp);
 #ifndef DISABLE_REMOTING
-gpointer          mono_generic_virtual_remoting_trampoline (mgreg_t *regs, guint8 *code, MonoMethod *m, guint8 *tramp);
+gpointer          mono_generic_virtual_remoting_trampoline (host_mgreg_t *regs, guint8 *code, MonoMethod *m, guint8 *tramp);
 #endif
-gpointer          mono_delegate_trampoline (mgreg_t *regs, guint8 *code, gpointer *tramp_data, guint8* tramp);
-gpointer          mono_aot_trampoline (mgreg_t *regs, guint8 *code, guint8 *token_info, 
+gpointer          mono_delegate_trampoline (host_mgreg_t *regs, guint8 *code, gpointer *tramp_data, guint8* tramp);
+gpointer          mono_aot_trampoline (host_mgreg_t *regs, guint8 *code, guint8 *token_info, 
 									   guint8* tramp);
-gpointer          mono_aot_plt_trampoline (mgreg_t *regs, guint8 *code, guint8 *token_info, 
+gpointer          mono_aot_plt_trampoline (host_mgreg_t *regs, guint8 *code, guint8 *token_info, 
 										   guint8* tramp);
-void              mono_class_init_trampoline (mgreg_t *regs, guint8 *code, MonoVTable *vtable, guint8 *tramp);
-void              mono_generic_class_init_trampoline (mgreg_t *regs, guint8 *code, MonoVTable *vtable, guint8 *tramp);
-void              mono_monitor_enter_trampoline (mgreg_t *regs, guint8 *code, MonoObject *obj, guint8 *tramp);
-void              mono_monitor_enter_v4_trampoline (mgreg_t *regs, guint8 *code, MonoObject *obj, guint8 *tramp);
-void              mono_monitor_exit_trampoline (mgreg_t *regs, guint8 *code, MonoObject *obj, guint8 *tramp);
+void              mono_class_init_trampoline (host_mgreg_t *regs, guint8 *code, MonoVTable *vtable, guint8 *tramp);
+void              mono_generic_class_init_trampoline (host_mgreg_t *regs, guint8 *code, MonoVTable *vtable, guint8 *tramp);
+void              mono_monitor_enter_trampoline (host_mgreg_t *regs, guint8 *code, MonoObject *obj, guint8 *tramp);
+void              mono_monitor_enter_v4_trampoline (host_mgreg_t *regs, guint8 *code, MonoObject *obj, guint8 *tramp);
+void              mono_monitor_exit_trampoline (host_mgreg_t *regs, guint8 *code, MonoObject *obj, guint8 *tramp);
 gconstpointer     mono_get_trampoline_func (MonoTrampolineType tramp_type);
 gpointer          mini_get_vtable_trampoline (MonoVTable *vt, int slot_index);
 const char*       mono_get_generic_trampoline_simple_name (MonoTrampolineType tramp_type);
@@ -2343,7 +2343,7 @@ gboolean
 mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls, 
 						MonoJitInfo *ji, MonoContext *ctx, 
 						MonoContext *new_ctx, MonoLMF **lmf,
-						mgreg_t **save_locations,
+						host_mgreg_t **save_locations,
 						StackFrameInfo *frame_info);
 gpointer  mono_arch_get_throw_exception_by_name (void);
 gpointer mono_arch_get_call_filter              (MonoTrampInfo **info, gboolean aot);
@@ -2360,14 +2360,14 @@ void     mono_handle_hard_stack_ovf             (MonoJitTlsData *jit_tls, MonoJi
 void     mono_arch_undo_ip_adjustment           (MonoContext *ctx);
 void     mono_arch_do_ip_adjustment             (MonoContext *ctx);
 gpointer mono_arch_ip_from_context              (void *sigctx);
-mgreg_t mono_arch_context_get_int_reg		    (MonoContext *ctx, int reg);
-void     mono_arch_context_set_int_reg		    (MonoContext *ctx, int reg, mgreg_t val);
+host_mgreg_t mono_arch_context_get_int_reg      (MonoContext *ctx, int reg);
+void     mono_arch_context_set_int_reg		(MonoContext *ctx, int reg, host_mgreg_t val);
 void     mono_arch_flush_register_windows       (void);
 gboolean mono_arch_is_inst_imm                  (int opcode, int imm_opcode, gint64 imm);
 gboolean mono_arch_is_int_overflow              (void *sigctx, void *info);
 void     mono_arch_invalidate_method            (MonoJitInfo *ji, void *func, gpointer func_arg);
 guint32  mono_arch_get_patch_offset             (guint8 *code);
-gpointer*mono_arch_get_delegate_method_ptr_addr (guint8* code, mgreg_t *regs);
+gpointer*mono_arch_get_delegate_method_ptr_addr (guint8* code, host_mgreg_t *regs);
 void     mono_arch_create_vars                  (MonoCompile *cfg) MONO_LLVM_INTERNAL;
 void     mono_arch_save_unwind_info             (MonoCompile *cfg);
 void     mono_arch_register_lowlevel_calls      (void);
@@ -2377,19 +2377,19 @@ gpointer mono_arch_get_ftnptr_arg_trampoline  (gpointer arg, gpointer addr);
 gpointer  mono_arch_get_llvm_imt_trampoline     (MonoDomain *domain, MonoMethod *method, int vt_offset);
 gpointer mono_arch_get_gsharedvt_arg_trampoline (MonoDomain *domain, gpointer arg, gpointer addr);
 void     mono_arch_patch_callsite               (guint8 *method_start, guint8 *code, guint8 *addr);
-void     mono_arch_patch_plt_entry              (guint8 *code, gpointer *got, mgreg_t *regs, guint8 *addr);
-void     mono_arch_nullify_class_init_trampoline(guint8 *code, mgreg_t *regs);
+void     mono_arch_patch_plt_entry              (guint8 *code, gpointer *got, host_mgreg_t *regs, guint8 *addr);
+void     mono_arch_nullify_class_init_trampoline(guint8 *code, host_mgreg_t *regs);
 int      mono_arch_get_this_arg_reg             (guint8 *code);
-gpointer mono_arch_get_this_arg_from_call       (mgreg_t *regs, guint8 *code);
+gpointer mono_arch_get_this_arg_from_call       (host_mgreg_t *regs, guint8 *code);
 gpointer mono_arch_get_delegate_invoke_impl     (MonoMethodSignature *sig, gboolean has_target);
 gpointer mono_arch_get_delegate_virtual_invoke_impl (MonoMethodSignature *sig, MonoMethod *method, int offset, gboolean load_imt_reg);
 gpointer mono_arch_create_specific_trampoline   (gpointer arg1, MonoTrampolineType tramp_type, MonoDomain *domain, guint32 *code_len);
-MonoMethod* mono_arch_find_imt_method           (mgreg_t *regs, guint8 *code);
-MonoVTable* mono_arch_find_static_call_vtable   (mgreg_t *regs, guint8 *code);
+MonoMethod* mono_arch_find_imt_method           (host_mgreg_t *regs, guint8 *code);
+MonoVTable* mono_arch_find_static_call_vtable   (host_mgreg_t *regs, guint8 *code);
 gpointer    mono_arch_build_imt_trampoline      (MonoVTable *vtable, MonoDomain *domain, MonoIMTCheckItem **imt_entries, int count, gpointer fail_tramp);
 void    mono_arch_notify_pending_exc            (MonoThreadInfo *info);
 guint8* mono_arch_get_call_target               (guint8 *code);
-guint32 mono_arch_get_plt_info_offset           (guint8 *plt_entry, mgreg_t *regs, guint8 *code);
+guint32 mono_arch_get_plt_info_offset           (guint8 *plt_entry, host_mgreg_t *regs, guint8 *code);
 GSList *mono_arch_get_trampolines               (gboolean aot);
 gpointer mono_arch_get_interp_to_native_trampoline (MonoTrampInfo **info);
 gpointer mono_arch_get_native_to_interp_trampoline (MonoTrampInfo **info);
@@ -2430,7 +2430,7 @@ gboolean mono_thread_state_init_from_monoctx    (MonoThreadUnwindState *ctx, Mon
 
 void     mono_setup_altstack                    (MonoJitTlsData *tls);
 void     mono_free_altstack                     (MonoJitTlsData *tls);
-gpointer mono_altstack_restore_prot             (mgreg_t *regs, guint8 *code, gpointer *tramp_data, guint8* tramp);
+gpointer mono_altstack_restore_prot             (host_mgreg_t *regs, guint8 *code, gpointer *tramp_data, guint8* tramp);
 MonoJitInfo* mini_jit_info_table_find           (MonoDomain *domain, gpointer addr, MonoDomain **out_domain);
 MonoJitInfo* mini_jit_info_table_find_ext       (MonoDomain *domain, gpointer addr, gboolean allow_trampolines, MonoDomain **out_domain);
 G_EXTERN_C void mono_resume_unwind              (MonoContext *ctx) MONO_LLVM_INTERNAL;
@@ -2457,7 +2457,7 @@ gboolean
 mono_find_jit_info_ext (MonoDomain *domain, MonoJitTlsData *jit_tls, 
 						MonoJitInfo *prev_ji, MonoContext *ctx,
 						MonoContext *new_ctx, char **trace, MonoLMF **lmf,
-						mgreg_t **save_locations,
+						host_mgreg_t **save_locations,
 						StackFrameInfo *frame);
 
 gpointer mono_get_throw_exception               (void);
@@ -2762,5 +2762,11 @@ MonoType*   mini_native_type_replace_type (MonoType *type) MONO_LLVM_INTERNAL;
 
 MonoMethod*
 mini_method_to_shared (MonoMethod *method); // null if not shared
+
+#ifdef MONO_CROSS_COMPILE
+#define mono_cross_compile_assert_not_reached() g_error ("%s cross compiled run?", __func__);
+#else
+#define mono_cross_compile_assert_not_reached() /* nothing */
+#endif
 
 #endif /* __MONO_MINI_H__ */

--- a/mono/mini/tramp-amd64-gsharedvt.c
+++ b/mono/mini/tramp-amd64-gsharedvt.c
@@ -43,6 +43,8 @@
 gpointer
 mono_amd64_start_gsharedvt_call (GSharedVtCallInfo *info, gpointer *caller, gpointer *callee, gpointer mrgctx_reg)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	int i;
 
 #ifdef DEBUG_AMD64_GSHAREDVT
@@ -91,21 +93,21 @@ mono_amd64_start_gsharedvt_call (GSharedVtCallInfo *info, gpointer *caller, gpoi
 		case GSHAREDVT_ARG_BYREF_TO_BYVAL_U1: {
 			guint8 *addr = (guint8*)caller [source_reg];
 
-			callee [dest_reg] = (gpointer)(mgreg_t)*addr;
+			callee [dest_reg] = (gpointer)(host_mgreg_t)*addr;
 			DEBUG_AMD64_GSHAREDVT_PRINT ("[%d] <- (u1) [%d] (%p) <- (%p)\n", dest_reg, source_reg, &callee [dest_reg], &caller [source_reg]);
 			break;
 		}
 		case GSHAREDVT_ARG_BYREF_TO_BYVAL_U2: {
 			guint16 *addr = (guint16*)caller [source_reg];
 
-			callee [dest_reg] = (gpointer)(mgreg_t)*addr;
+			callee [dest_reg] = (gpointer)(host_mgreg_t)*addr;
 			DEBUG_AMD64_GSHAREDVT_PRINT ("[%d] <- (u2) [%d] (%p) <- (%p)\n", dest_reg, source_reg, &callee [dest_reg], &caller [source_reg]);
 			break;
 		}
 		case GSHAREDVT_ARG_BYREF_TO_BYVAL_U4: {
 			guint32 *addr = (guint32*)caller [source_reg];
 
-			callee [dest_reg] = (gpointer)(mgreg_t)*addr;
+			callee [dest_reg] = (gpointer)(host_mgreg_t)*addr;
 			DEBUG_AMD64_GSHAREDVT_PRINT ("[%d] <- (u4) [%d] (%p) <- (%p)\n", dest_reg, source_reg, &callee [dest_reg], &caller [source_reg]);
 			break;
 		}
@@ -148,6 +150,8 @@ mono_amd64_start_gsharedvt_call (GSharedVtCallInfo *info, gpointer *caller, gpoi
 gpointer
 mono_arch_get_gsharedvt_arg_trampoline (MonoDomain *domain, gpointer arg, gpointer addr)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	guint8 *code, *start;
 	int buf_len;
 
@@ -170,6 +174,8 @@ mono_arch_get_gsharedvt_arg_trampoline (MonoDomain *domain, gpointer arg, gpoint
 gpointer
 mono_arch_get_gsharedvt_trampoline (MonoTrampInfo **info, gboolean aot)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	guint8 *code, *buf;
 	int buf_len, cfa_offset;
 	GSList *unwind_ops = NULL;

--- a/mono/mini/tramp-amd64-gsharedvt.c
+++ b/mono/mini/tramp-amd64-gsharedvt.c
@@ -43,8 +43,6 @@
 gpointer
 mono_amd64_start_gsharedvt_call (GSharedVtCallInfo *info, gpointer *caller, gpointer *callee, gpointer mrgctx_reg)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	int i;
 
 #ifdef DEBUG_AMD64_GSHAREDVT
@@ -150,8 +148,6 @@ mono_amd64_start_gsharedvt_call (GSharedVtCallInfo *info, gpointer *caller, gpoi
 gpointer
 mono_arch_get_gsharedvt_arg_trampoline (MonoDomain *domain, gpointer arg, gpointer addr)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint8 *code, *start;
 	int buf_len;
 
@@ -174,8 +170,6 @@ mono_arch_get_gsharedvt_arg_trampoline (MonoDomain *domain, gpointer arg, gpoint
 gpointer
 mono_arch_get_gsharedvt_trampoline (MonoTrampInfo **info, gboolean aot)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint8 *code, *buf;
 	int buf_len, cfa_offset;
 	GSList *unwind_ops = NULL;

--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -203,8 +203,10 @@ mono_arch_create_llvm_native_thunk (MonoDomain *domain, guint8 *addr)
 #endif /* !DISABLE_JIT */
 
 void
-mono_arch_patch_plt_entry (guint8 *code, gpointer *got, mgreg_t *regs, guint8 *addr)
+mono_arch_patch_plt_entry (guint8 *code, gpointer *got, host_mgreg_t *regs, guint8 *addr)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	gint32 disp;
 	gpointer *plt_jump_table_entry;
 
@@ -810,8 +812,10 @@ mono_arch_get_call_target (guint8 *code)
  *   Return the PLT info offset belonging to the plt entry PLT_ENTRY.
  */
 guint32
-mono_arch_get_plt_info_offset (guint8 *plt_entry, mgreg_t *regs, guint8 *code)
+mono_arch_get_plt_info_offset (guint8 *plt_entry, host_mgreg_t *regs, guint8 *code)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return *(guint32*)(plt_entry + 6);
 }
 

--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -205,8 +205,6 @@ mono_arch_create_llvm_native_thunk (MonoDomain *domain, guint8 *addr)
 void
 mono_arch_patch_plt_entry (guint8 *code, gpointer *got, host_mgreg_t *regs, guint8 *addr)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	gint32 disp;
 	gpointer *plt_jump_table_entry;
 
@@ -814,8 +812,6 @@ mono_arch_get_call_target (guint8 *code)
 guint32
 mono_arch_get_plt_info_offset (guint8 *plt_entry, host_mgreg_t *regs, guint8 *code)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return *(guint32*)(plt_entry + 6);
 }
 

--- a/mono/mini/tramp-arm.c
+++ b/mono/mini/tramp-arm.c
@@ -61,8 +61,10 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *code_ptr, guint8 *addr)
 }
 
 void
-mono_arch_patch_plt_entry (guint8 *code, gpointer *got, mgreg_t *regs, guint8 *addr)
+mono_arch_patch_plt_entry (guint8 *code, gpointer *got, host_mgreg_t *regs, guint8 *addr)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	guint8 *jump_entry;
 
 	/* Patch the jump table entry used by the plt entry */
@@ -1103,8 +1105,9 @@ mono_arch_get_call_target (guint8 *code)
 }
 
 guint32
-mono_arch_get_plt_info_offset (guint8 *plt_entry, mgreg_t *regs, guint8 *code)
+mono_arch_get_plt_info_offset (guint8 *plt_entry, host_mgreg_t *regs, guint8 *code)
 {
+	mono_cross_compile_assert_not_reached ();
 	/* The offset is stored as the 4th word of the plt entry */
 	return ((guint32*)plt_entry) [3];
 }
@@ -1115,14 +1118,16 @@ mono_arch_get_plt_info_offset (guint8 *plt_entry, mgreg_t *regs, guint8 *code)
 guint8*
 mono_arm_get_thumb_plt_entry (guint8 *code)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	int s, j1, j2, imm10, imm11, i1, i2, imm32;
 	guint8 *bl, *base;
 	guint16 t1, t2;
 	guint8 *target;
 
 	/* code should be right after a BL */
-	code = (guint8*)((mgreg_t)code & ~1);
-	base = (guint8*)((mgreg_t)code & ~3);
+	code = (guint8*)((host_mgreg_t)code & ~1);
+	base = (guint8*)((host_mgreg_t)code & ~3);
 	bl = code - 4;
 	t1 = ((guint16*)bl) [0];
 	t2 = ((guint16*)bl) [1];

--- a/mono/mini/tramp-arm.c
+++ b/mono/mini/tramp-arm.c
@@ -536,7 +536,7 @@ mono_arch_get_unbox_trampoline (MonoMethod *m, gpointer addr)
 	ARM_LDR_IMM (code, ARMREG_IP, ARMREG_PC, 4);
 	ARM_ADD_REG_IMM8 (code, ARMREG_R0, ARMREG_R0, MONO_ABI_SIZEOF (MonoObject));
 	code = emit_bx (code, ARMREG_IP);
-	*(guint32*)code = (guint32)addr;
+	*(guint32*)code = (guint32)(gsize)addr;
 	code += 4;
 	mono_arch_flush_icache (start, code - start);
 	MONO_PROFILER_RAISE (jit_code_buffer, (start, code - start, MONO_PROFILER_CODE_BUFFER_UNBOX_TRAMPOLINE, m));
@@ -563,9 +563,9 @@ mono_arch_get_static_rgctx_trampoline (gpointer arg, gpointer addr)
 
 	ARM_LDR_IMM (code, MONO_ARCH_RGCTX_REG, ARMREG_PC, 0);
 	ARM_LDR_IMM (code, ARMREG_PC, ARMREG_PC, 0);
-	*(guint32*)code = (guint32)arg;
+	*(guint32*)code = (guint32)(gsize)arg;
 	code += 4;
-	*(guint32*)code = (guint32)addr;
+	*(guint32*)code = (guint32)(gsize)addr;
 	code += 4;
 
 	g_assert ((code - start) <= buf_len);
@@ -593,9 +593,9 @@ mono_arch_get_ftnptr_arg_trampoline (gpointer arg, gpointer addr)
 
 	ARM_LDR_IMM (code, ARMREG_IP, ARMREG_PC, 0);
 	ARM_LDR_IMM (code, ARMREG_PC, ARMREG_PC, 0);
-	*(guint32*)code = (guint32)arg;
+	*(guint32*)code = (guint32)(gsize)arg;
 	code += 4;
-	*(guint32*)code = (guint32)addr;
+	*(guint32*)code = (guint32)(gsize)addr;
 	code += 4;
 
 	g_assert ((code - start) <= buf_len);
@@ -1126,8 +1126,8 @@ mono_arm_get_thumb_plt_entry (guint8 *code)
 	guint8 *target;
 
 	/* code should be right after a BL */
-	code = (guint8*)((host_mgreg_t)code & ~1);
-	base = (guint8*)((host_mgreg_t)code & ~3);
+	code = (guint8*)((gsize)code & ~1);
+	base = (guint8*)((gsize)code & ~3);
 	bl = code - 4;
 	t1 = ((guint16*)bl) [0];
 	t2 = ((guint16*)bl) [1];

--- a/mono/mini/tramp-arm.c
+++ b/mono/mini/tramp-arm.c
@@ -63,8 +63,6 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *code_ptr, guint8 *addr)
 void
 mono_arch_patch_plt_entry (guint8 *code, gpointer *got, host_mgreg_t *regs, guint8 *addr)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint8 *jump_entry;
 
 	/* Patch the jump table entry used by the plt entry */
@@ -1107,7 +1105,6 @@ mono_arch_get_call_target (guint8 *code)
 guint32
 mono_arch_get_plt_info_offset (guint8 *plt_entry, host_mgreg_t *regs, guint8 *code)
 {
-	mono_cross_compile_assert_not_reached ();
 	/* The offset is stored as the 4th word of the plt entry */
 	return ((guint32*)plt_entry) [3];
 }
@@ -1118,8 +1115,6 @@ mono_arch_get_plt_info_offset (guint8 *plt_entry, host_mgreg_t *regs, guint8 *co
 guint8*
 mono_arm_get_thumb_plt_entry (guint8 *code)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	int s, j1, j2, imm10, imm11, i1, i2, imm32;
 	guint8 *bl, *base;
 	guint16 t1, t2;

--- a/mono/mini/tramp-arm64.c
+++ b/mono/mini/tramp-arm64.c
@@ -26,7 +26,6 @@
 #include "interp/interp.h"
 #endif
 
-#define CallContext Arm64CallContext
 
 void
 mono_arch_patch_callsite (guint8 *method_start, guint8 *code_ptr, guint8 *addr)

--- a/mono/mini/tramp-arm64.c
+++ b/mono/mini/tramp-arm64.c
@@ -37,8 +37,6 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *code_ptr, guint8 *addr)
 void
 mono_arch_patch_plt_entry (guint8 *code, gpointer *got, host_mgreg_t *regs, guint8 *addr)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint32 ins;
 	guint64 slot_addr;
 	int disp;
@@ -94,8 +92,6 @@ mono_arch_get_call_target (guint8 *code)
 guint32
 mono_arch_get_plt_info_offset (guint8 *plt_entry, host_mgreg_t *regs, guint8 *code)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	/* The offset is stored as the 5th word of the plt entry */
 	return ((guint32*)plt_entry) [4];
 }

--- a/mono/mini/tramp-arm64.c
+++ b/mono/mini/tramp-arm64.c
@@ -26,6 +26,7 @@
 #include "interp/interp.h"
 #endif
 
+#define CallContext Arm64CallContext
 
 void
 mono_arch_patch_callsite (guint8 *method_start, guint8 *code_ptr, guint8 *addr)
@@ -35,8 +36,10 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *code_ptr, guint8 *addr)
 }
 
 void
-mono_arch_patch_plt_entry (guint8 *code, gpointer *got, mgreg_t *regs, guint8 *addr)
+mono_arch_patch_plt_entry (guint8 *code, gpointer *got, host_mgreg_t *regs, guint8 *addr)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	guint32 ins;
 	guint64 slot_addr;
 	int disp;
@@ -90,8 +93,10 @@ mono_arch_get_call_target (guint8 *code)
 }
 
 guint32
-mono_arch_get_plt_info_offset (guint8 *plt_entry, mgreg_t *regs, guint8 *code)
+mono_arch_get_plt_info_offset (guint8 *plt_entry, host_mgreg_t *regs, guint8 *code)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	/* The offset is stored as the 5th word of the plt entry */
 	return ((guint32*)plt_entry) [4];
 }
@@ -644,13 +649,13 @@ mono_arch_get_interp_to_native_trampoline (MonoTrampInfo **info)
 	start = code = (guint8 *) mono_global_codeman_reserve (buf_len);
 
 	/* allocate frame */
-	framesize += 2 * sizeof (mgreg_t);
+	framesize += 2 * sizeof (host_mgreg_t);
 
 	off_methodargs = framesize;
-	framesize += sizeof (mgreg_t);
+	framesize += sizeof (host_mgreg_t);
 
 	off_targetaddr = framesize;
-	framesize += sizeof (mgreg_t);
+	framesize += sizeof (host_mgreg_t);
 
 	framesize = ALIGN_TO (framesize, MONO_ARCH_FRAME_ALIGNMENT);
 
@@ -681,9 +686,9 @@ mono_arch_get_interp_to_native_trampoline (MonoTrampInfo **info)
 	arm_bcc (code, ARMCOND_EQ, 0);
 	arm_ldrx (code, ARMREG_R2, ARMREG_IP1, 0);
 	arm_strx (code, ARMREG_R2, ARMREG_IP0, 0);
-	arm_addx_imm (code, ARMREG_IP0, ARMREG_IP0, sizeof (mgreg_t));
-	arm_addx_imm (code, ARMREG_IP1, ARMREG_IP1, sizeof (mgreg_t));
-	arm_subx_imm (code, ARMREG_R0, ARMREG_R0, sizeof (mgreg_t));
+	arm_addx_imm (code, ARMREG_IP0, ARMREG_IP0, sizeof (host_mgreg_t));
+	arm_addx_imm (code, ARMREG_IP1, ARMREG_IP1, sizeof (host_mgreg_t));
+	arm_subx_imm (code, ARMREG_R0, ARMREG_R0, sizeof (host_mgreg_t));
 	arm_b (code, label_start_copy);
 	mono_arm_patch (label_exit_copy, code, MONO_R_ARM64_BCC);
 
@@ -692,7 +697,7 @@ mono_arch_get_interp_to_native_trampoline (MonoTrampInfo **info)
 
 	/* set all general purpose registers from CallContext */
 	for (i = 0; i < PARAM_REGS + 1; i++)
-		arm_ldrx (code, i, ARMREG_IP0, MONO_STRUCT_OFFSET (CallContext, gregs) + i * sizeof (mgreg_t));
+		arm_ldrx (code, i, ARMREG_IP0, MONO_STRUCT_OFFSET (CallContext, gregs) + i * sizeof (host_mgreg_t));
 
 	/* set all floating registers from CallContext  */
 	for (i = 0; i < FP_PARAM_REGS; i++)
@@ -709,7 +714,7 @@ mono_arch_get_interp_to_native_trampoline (MonoTrampInfo **info)
 
 	/* set all general purpose registers to CallContext */
 	for (i = 0; i < PARAM_REGS; i++)
-		arm_strx (code, i, ARMREG_IP0, MONO_STRUCT_OFFSET (CallContext, gregs) + i * sizeof (mgreg_t));
+		arm_strx (code, i, ARMREG_IP0, MONO_STRUCT_OFFSET (CallContext, gregs) + i * sizeof (host_mgreg_t));
 
 	/* set all floating registers to CallContext  */
 	for (i = 0; i < FP_PARAM_REGS; i++)
@@ -749,7 +754,7 @@ mono_arch_get_native_to_interp_trampoline (MonoTrampInfo **info)
 	start = code = (guint8 *) mono_global_codeman_reserve (buf_len);
 
 	/* Allocate frame (FP + LR + CallContext) */
-	offset = 2 * sizeof (mgreg_t);
+	offset = 2 * sizeof (host_mgreg_t);
 	ccontext_offset = offset;
 	offset += sizeof (CallContext);
 	framesize = ALIGN_TO (offset, MONO_ARCH_FRAME_ALIGNMENT);
@@ -768,7 +773,7 @@ mono_arch_get_native_to_interp_trampoline (MonoTrampInfo **info)
 
 	/* save all general purpose registers into the CallContext */
 	for (i = 0; i < PARAM_REGS + 1; i++)
-		arm_strx (code, i, ARMREG_FP, ccontext_offset + MONO_STRUCT_OFFSET (CallContext, gregs) + i * sizeof (mgreg_t));
+		arm_strx (code, i, ARMREG_FP, ccontext_offset + MONO_STRUCT_OFFSET (CallContext, gregs) + i * sizeof (host_mgreg_t));
 
 	/* save all floating registers into the CallContext  */
 	for (i = 0; i < FP_PARAM_REGS; i++)
@@ -786,7 +791,7 @@ mono_arch_get_native_to_interp_trampoline (MonoTrampInfo **info)
 
 	/* load the return values from the context */
 	for (i = 0; i < PARAM_REGS; i++)
-		arm_ldrx (code, i, ARMREG_FP, ccontext_offset + MONO_STRUCT_OFFSET (CallContext, gregs) + i * sizeof (mgreg_t));
+		arm_ldrx (code, i, ARMREG_FP, ccontext_offset + MONO_STRUCT_OFFSET (CallContext, gregs) + i * sizeof (host_mgreg_t));
 
 	for (i = 0; i < FP_PARAM_REGS; i++)
 		arm_ldrfpx (code, i, ARMREG_FP, ccontext_offset + MONO_STRUCT_OFFSET (CallContext, fregs) + i * sizeof (double));

--- a/mono/mini/tramp-mips.c
+++ b/mono/mini/tramp-mips.c
@@ -104,7 +104,6 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *orig_code, guint8 *addr)
 void
 mono_arch_patch_plt_entry (guint8 *code, gpointer *got, host_mgreg_t *regs, guint8 *addr)
 {
-	mono_cross_compile_assert_not_reached ();
 	g_assert_not_reached ();
 }
 

--- a/mono/mini/tramp-mips.c
+++ b/mono/mini/tramp-mips.c
@@ -102,8 +102,9 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *orig_code, guint8 *addr)
 }
 
 void
-mono_arch_patch_plt_entry (guint8 *code, gpointer *got, mgreg_t *regs, guint8 *addr)
+mono_arch_patch_plt_entry (guint8 *code, gpointer *got, host_mgreg_t *regs, guint8 *addr)
 {
+	mono_cross_compile_assert_not_reached ();
 	g_assert_not_reached ();
 }
 

--- a/mono/mini/tramp-ppc.c
+++ b/mono/mini/tramp-ppc.c
@@ -191,8 +191,6 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *code_ptr, guint8 *addr)
 void
 mono_arch_patch_plt_entry (guint8 *code, gpointer *got, host_mgreg_t *regs, guint8 *addr)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint32 ins1, ins2, offset;
 
 	/* Patch the jump table entry used by the plt entry */
@@ -686,7 +684,6 @@ mono_arch_get_call_target (guint8 *code)
 guint32
 mono_arch_get_plt_info_offset (guint8 *plt_entry, host_mgreg_t *regs, guint8 *code)
 {
-	mono_cross_compile_assert_not_reached ();
 #ifdef PPC_USES_FUNCTION_DESCRIPTOR
 	return ((guint32*)plt_entry) [8];
 #else

--- a/mono/mini/tramp-ppc.c
+++ b/mono/mini/tramp-ppc.c
@@ -189,8 +189,10 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *code_ptr, guint8 *addr)
 }
 
 void
-mono_arch_patch_plt_entry (guint8 *code, gpointer *got, mgreg_t *regs, guint8 *addr)
+mono_arch_patch_plt_entry (guint8 *code, gpointer *got, host_mgreg_t *regs, guint8 *addr)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	guint32 ins1, ins2, offset;
 
 	/* Patch the jump table entry used by the plt entry */
@@ -682,8 +684,9 @@ mono_arch_get_call_target (guint8 *code)
 }
 
 guint32
-mono_arch_get_plt_info_offset (guint8 *plt_entry, mgreg_t *regs, guint8 *code)
+mono_arch_get_plt_info_offset (guint8 *plt_entry, host_mgreg_t *regs, guint8 *code)
 {
+	mono_cross_compile_assert_not_reached ();
 #ifdef PPC_USES_FUNCTION_DESCRIPTOR
 	return ((guint32*)plt_entry) [8];
 #else

--- a/mono/mini/tramp-s390x.c
+++ b/mono/mini/tramp-s390x.c
@@ -159,8 +159,9 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *orig_code, guint8 *addr)
 /*------------------------------------------------------------------*/
 
 void
-mono_arch_patch_plt_entry (guint8 *code, gpointer *got, mgreg_t *regs, guint8 *addr)
+mono_arch_patch_plt_entry (guint8 *code, gpointer *got, host_mgreg_t *regs, guint8 *addr)
 {
+	mono_cross_compile_assert_not_reached ();
 	g_assert_not_reached ();
 }
 
@@ -289,7 +290,7 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 				
 	/* Set arguments */
 
-	/* Arg 1: mgreg_t *regs */
+	/* Arg 1: host_mgreg_t *regs */
 	s390_la  (buf, s390_r2, 0, LMFReg, G_STRUCT_OFFSET(MonoLMF, gregs[0]));
 		
 	/* Arg 2: code (next address to the instruction that called us) */

--- a/mono/mini/tramp-s390x.c
+++ b/mono/mini/tramp-s390x.c
@@ -161,7 +161,6 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *orig_code, guint8 *addr)
 void
 mono_arch_patch_plt_entry (guint8 *code, gpointer *got, host_mgreg_t *regs, guint8 *addr)
 {
-	mono_cross_compile_assert_not_reached ();
 	g_assert_not_reached ();
 }
 

--- a/mono/mini/tramp-sparc.c
+++ b/mono/mini/tramp-sparc.c
@@ -70,7 +70,6 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *code, guint8 *addr)
 void
 mono_arch_patch_plt_entry (guint8 *code, gpointer *got, host_mgreg_t *regs, guint8 *addr)
 {
-	mono_cross_compile_assert_not_reached ();
 	g_assert_not_reached ();
 }
 

--- a/mono/mini/tramp-sparc.c
+++ b/mono/mini/tramp-sparc.c
@@ -68,8 +68,9 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *code, guint8 *addr)
 }
 
 void
-mono_arch_patch_plt_entry (guint8 *code, gpointer *got, mgreg_t *regs, guint8 *addr)
+mono_arch_patch_plt_entry (guint8 *code, gpointer *got, host_mgreg_t *regs, guint8 *addr)
 {
+	mono_cross_compile_assert_not_reached ();
 	g_assert_not_reached ();
 }
 

--- a/mono/mini/tramp-wasm.c
+++ b/mono/mini/tramp-wasm.c
@@ -27,21 +27,18 @@ mono_arch_create_rgctx_lazy_fetch_trampoline (guint32 slot, MonoTrampInfo **info
 void
 mono_arch_patch_plt_entry (guint8 *code, gpointer *got, host_mgreg_t *regs, guint8 *addr)
 {
-	mono_cross_compile_assert_not_reached ();
 	g_error ("mono_arch_patch_plt_entry");
 }
 
 void
 mono_arch_patch_callsite (guint8 *method_start, guint8 *orig_code, guint8 *addr)
 {
-	mono_cross_compile_assert_not_reached ();
 	g_error ("mono_arch_patch_callsite");
 }
 
 gpointer
 mono_arch_get_unbox_trampoline (MonoMethod *m, gpointer addr)
 {
-	mono_cross_compile_assert_not_reached ();
 	g_error ("mono_arch_get_unbox_trampoline");
 	return NULL;
 }

--- a/mono/mini/tramp-wasm.c
+++ b/mono/mini/tramp-wasm.c
@@ -25,20 +25,23 @@ mono_arch_create_rgctx_lazy_fetch_trampoline (guint32 slot, MonoTrampInfo **info
 }
 
 void
-mono_arch_patch_plt_entry (guint8 *code, gpointer *got, mgreg_t *regs, guint8 *addr)
+mono_arch_patch_plt_entry (guint8 *code, gpointer *got, host_mgreg_t *regs, guint8 *addr)
 {
+	mono_cross_compile_assert_not_reached ();
 	g_error ("mono_arch_patch_plt_entry");
 }
 
 void
 mono_arch_patch_callsite (guint8 *method_start, guint8 *orig_code, guint8 *addr)
 {
+	mono_cross_compile_assert_not_reached ();
 	g_error ("mono_arch_patch_callsite");
 }
 
 gpointer
 mono_arch_get_unbox_trampoline (MonoMethod *m, gpointer addr)
 {
+	mono_cross_compile_assert_not_reached ();
 	g_error ("mono_arch_get_unbox_trampoline");
 	return NULL;
 }
@@ -89,7 +92,7 @@ mono_arch_get_call_target (guint8 *code)
  *   Return the PLT info offset belonging to the plt entry PLT_ENTRY.
  */
 guint32
-mono_arch_get_plt_info_offset (guint8 *plt_entry, mgreg_t *regs, guint8 *code)
+mono_arch_get_plt_info_offset (guint8 *plt_entry, host_mgreg_t *regs, guint8 *code)
 {
 	g_error ("mono_arch_get_plt_info_offset");
 	return *(guint32*)(plt_entry + 6);

--- a/mono/mini/tramp-x86-gsharedvt.c
+++ b/mono/mini/tramp-x86-gsharedvt.c
@@ -16,8 +16,6 @@
 gpointer
 mono_x86_start_gsharedvt_call (GSharedVtCallInfo *info, gpointer *caller, gpointer *callee, gpointer mrgctx_reg)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	int i;
 	int *map = info->map;
 

--- a/mono/mini/tramp-x86-gsharedvt.c
+++ b/mono/mini/tramp-x86-gsharedvt.c
@@ -16,6 +16,8 @@
 gpointer
 mono_x86_start_gsharedvt_call (GSharedVtCallInfo *info, gpointer *caller, gpointer *callee, gpointer mrgctx_reg)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	int i;
 	int *map = info->map;
 

--- a/mono/mini/tramp-x86.c
+++ b/mono/mini/tramp-x86.c
@@ -124,8 +124,10 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *orig_code, guint8 *addr)
 }
 
 void
-mono_arch_patch_plt_entry (guint8 *code, gpointer *got, mgreg_t *regs, guint8 *addr)
+mono_arch_patch_plt_entry (guint8 *code, gpointer *got, host_mgreg_t *regs, guint8 *addr)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	guint32 offset;
 
 	/* Patch the jump table entry used by the plt entry */
@@ -576,8 +578,10 @@ mono_arch_get_call_target (guint8 *code)
 }
 
 guint32
-mono_arch_get_plt_info_offset (guint8 *plt_entry, mgreg_t *regs, guint8 *code)
+mono_arch_get_plt_info_offset (guint8 *plt_entry, host_mgreg_t *regs, guint8 *code)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	return *(guint32*)(plt_entry + 6);
 }
 
@@ -648,7 +652,7 @@ mono_arch_create_sdb_trampoline (gboolean single_step, MonoTrampInfo **info, gbo
 	mono_add_unwind_op_offset (unwind_ops, code, buf, X86_NREG, -cfa_offset);
 
 	x86_push_reg (code, X86_EBP);
-	cfa_offset += sizeof(mgreg_t);
+	cfa_offset += sizeof(host_mgreg_t);
 	mono_add_unwind_op_def_cfa_offset (unwind_ops, code, buf, cfa_offset);
 	mono_add_unwind_op_offset (unwind_ops, code, buf, X86_EBP, - cfa_offset);
 

--- a/mono/mini/tramp-x86.c
+++ b/mono/mini/tramp-x86.c
@@ -126,8 +126,6 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *orig_code, guint8 *addr)
 void
 mono_arch_patch_plt_entry (guint8 *code, gpointer *got, host_mgreg_t *regs, guint8 *addr)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	guint32 offset;
 
 	/* Patch the jump table entry used by the plt entry */
@@ -580,8 +578,6 @@ mono_arch_get_call_target (guint8 *code)
 guint32
 mono_arch_get_plt_info_offset (guint8 *plt_entry, host_mgreg_t *regs, guint8 *code)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	return *(guint32*)(plt_entry + 6);
 }
 

--- a/mono/mini/type-checking.c
+++ b/mono/mini/type-checking.c
@@ -123,7 +123,7 @@ mini_emit_isninst_cast_inst (MonoCompile *cfg, int klass_reg, MonoClass *klass, 
 		MONO_EMIT_NEW_CLASSCONST (cfg, const_reg, klass);
 		MONO_EMIT_NEW_BIALU (cfg, OP_COMPARE, -1, stype, const_reg);
 	} else {
-		MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, stype, klass);
+		MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, stype, (gsize)klass);
 	}
 	MONO_EMIT_NEW_BRANCH_BLOCK (cfg, OP_PBEQ, true_target);
 }
@@ -240,7 +240,7 @@ mini_emit_class_check_branch (MonoCompile *cfg, int klass_reg, MonoClass *klass,
 		MONO_EMIT_NEW_CLASSCONST (cfg, const_reg, klass);
 		MONO_EMIT_NEW_BIALU (cfg, OP_COMPARE, -1, klass_reg, const_reg);
 	} else {
-		MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, klass_reg, klass);
+		MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, klass_reg, (gsize)klass);
 	}
 	MONO_EMIT_NEW_BRANCH_BLOCK (cfg, branch_op, target);
 }
@@ -511,10 +511,10 @@ handle_castclass (MonoCompile *cfg, MonoClass *klass, MonoInst *src, int context
 					mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
 					return NULL;
 				}
-				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, vtable_reg, vt);
+				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, vtable_reg, (gsize)vt);
 			} else {
 				MONO_EMIT_NEW_LOAD_MEMBASE (cfg, klass_reg, vtable_reg, MONO_STRUCT_OFFSET (MonoVTable, klass));
-				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, klass_reg, klass);
+				MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, klass_reg, (gsize)klass);
 			}
 			MONO_EMIT_NEW_COND_EXC (cfg, NE_UN, "InvalidCastException");
 		} else {
@@ -715,10 +715,10 @@ handle_isinst (MonoCompile *cfg, MonoClass *klass, MonoInst *src, int context_us
 						mono_cfg_set_exception (cfg, MONO_EXCEPTION_MONO_ERROR);
 						return NULL;
 					}
-					MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, vtable_reg, vt);
+					MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, vtable_reg, (gsize)vt);
 				} else {
 					MONO_EMIT_NEW_LOAD_MEMBASE (cfg, klass_reg, vtable_reg, MONO_STRUCT_OFFSET (MonoVTable, klass));
-					MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, klass_reg, klass);
+					MONO_EMIT_NEW_BIALU_IMM (cfg, OP_COMPARE_IMM, -1, klass_reg, (gsize)klass);
 				}
 				MONO_EMIT_NEW_BRANCH_BLOCK (cfg, OP_PBNE_UN, false_bb);
 				MONO_EMIT_NEW_BRANCH_BLOCK (cfg, OP_BR, is_null_bb);

--- a/mono/mini/unwind.c
+++ b/mono/mini/unwind.c
@@ -520,9 +520,11 @@ void
 mono_unwind_frame (guint8 *unwind_info, guint32 unwind_info_len, 
 				   guint8 *start_ip, guint8 *end_ip, guint8 *ip, guint8 **mark_locations,
 				   mono_unwind_reg_t *regs, int nregs,
-				   mgreg_t **save_locations, int save_locations_len,
+				   host_mgreg_t **save_locations, int save_locations_len,
 				   guint8 **out_cfa)
 {
+	mono_cross_compile_assert_not_reached ();
+
 	Loc locations [NUM_HW_REGS];
 	guint8 reg_saved [NUM_HW_REGS];
 	int pos, reg, hwreg, cfa_reg = -1, cfa_offset = 0, offset;
@@ -635,7 +637,7 @@ mono_unwind_frame (guint8 *unwind_info, guint32 unwind_info_len,
 	}
 
 	if (save_locations)
-		memset (save_locations, 0, save_locations_len * sizeof (mgreg_t*));
+		memset (save_locations, 0, save_locations_len * sizeof (host_mgreg_t*));
 
 	g_assert (cfa_reg != -1);
 	cfa_val = (guint8*)regs [mono_dwarf_reg_to_hw_reg (cfa_reg)] + cfa_offset;
@@ -646,9 +648,9 @@ mono_unwind_frame (guint8 *unwind_info, guint32 unwind_info_len,
 			if (IS_DOUBLE_REG (dwarfreg))
 				regs [hwreg] = *(guint64*)(cfa_val + locations [hwreg].offset);
 			else
-				regs [hwreg] = *(mgreg_t*)(cfa_val + locations [hwreg].offset);
+				regs [hwreg] = *(host_mgreg_t*)(cfa_val + locations [hwreg].offset);
 			if (save_locations && hwreg < save_locations_len)
-				save_locations [hwreg] = (mgreg_t*)(cfa_val + locations [hwreg].offset);
+				save_locations [hwreg] = (host_mgreg_t*)(cfa_val + locations [hwreg].offset);
 		}
 	}
 
@@ -909,7 +911,7 @@ decode_lsda (guint8 *lsda, guint8 *code, MonoJitExceptionInfo *ex_info, gpointer
 		*this_offset = -1;
 	}
 	ncall_sites = decode_uleb128 (p, &p);
-	p = (guint8*)ALIGN_TO ((mgreg_t)p, 4);
+	p = (guint8*)ALIGN_TO ((gsize)p, 4);
 
 	if (ex_info_len)
 		*ex_info_len = ncall_sites;

--- a/mono/mini/unwind.c
+++ b/mono/mini/unwind.c
@@ -523,8 +523,6 @@ mono_unwind_frame (guint8 *unwind_info, guint32 unwind_info_len,
 				   host_mgreg_t **save_locations, int save_locations_len,
 				   guint8 **out_cfa)
 {
-	mono_cross_compile_assert_not_reached ();
-
 	Loc locations [NUM_HW_REGS];
 	guint8 reg_saved [NUM_HW_REGS];
 	int pos, reg, hwreg, cfa_reg = -1, cfa_offset = 0, offset;

--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -62,16 +62,16 @@ typedef __uint128_t MonoContextSimdReg;
 #if defined (TARGET_WASM)
 
 typedef struct {
-	mgreg_t wasm_sp;
-	mgreg_t wasm_bp;
-	mgreg_t llvm_exc_reg;
-	mgreg_t wasm_ip;
-	mgreg_t wasm_pc;
+	host_mgreg_t wasm_sp;
+	host_mgreg_t wasm_bp;
+	host_mgreg_t llvm_exc_reg;
+	host_mgreg_t wasm_ip;
+	host_mgreg_t wasm_pc;
 } MonoContext;
 
-#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->wasm_ip = (mgreg_t)(ip); } while (0);
-#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->wasm_bp = (mgreg_t)(bp); } while (0);
-#define MONO_CONTEXT_SET_SP(ctx,sp) do { (ctx)->wasm_sp = (mgreg_t)(sp); } while (0);
+#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->wasm_ip = (host_mgreg_t)(ip); } while (0);
+#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->wasm_bp = (host_mgreg_t)(bp); } while (0);
+#define MONO_CONTEXT_SET_SP(ctx,sp) do { (ctx)->wasm_sp = (host_mgreg_t)(sp); } while (0);
 
 #define MONO_CONTEXT_GET_IP(ctx) ((gpointer)((ctx)->wasm_ip))
 #define MONO_CONTEXT_GET_BP(ctx) ((gpointer)((ctx)->wasm_bp))
@@ -144,23 +144,23 @@ struct sigcontext {
 #include <mono/arch/x86/x86-codegen.h>
 
 typedef struct {
-	mgreg_t eax;
-	mgreg_t ebx;
-	mgreg_t ecx;
-	mgreg_t edx;
-	mgreg_t ebp;
-	mgreg_t esp;
-	mgreg_t esi;
-	mgreg_t edi;
-	mgreg_t eip;
+	host_mgreg_t eax;
+	host_mgreg_t ebx;
+	host_mgreg_t ecx;
+	host_mgreg_t edx;
+	host_mgreg_t ebp;
+	host_mgreg_t esp;
+	host_mgreg_t esi;
+	host_mgreg_t edi;
+	host_mgreg_t eip;
 #ifdef __APPLE__
     MonoContextSimdReg fregs [X86_XMM_NREG];
 #endif
 } MonoContext;
 
-#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->eip = (mgreg_t)(ip); } while (0); 
-#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->ebp = (mgreg_t)(bp); } while (0); 
-#define MONO_CONTEXT_SET_SP(ctx,sp) do { (ctx)->esp = (mgreg_t)(sp); } while (0); 
+#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->eip = (host_mgreg_t)(ip); } while (0); 
+#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->ebp = (host_mgreg_t)(bp); } while (0); 
+#define MONO_CONTEXT_SET_SP(ctx,sp) do { (ctx)->esp = (host_mgreg_t)(sp); } while (0); 
 
 #define MONO_CONTEXT_GET_IP(ctx) ((gpointer)((ctx)->eip))
 #define MONO_CONTEXT_GET_BP(ctx) ((gpointer)((ctx)->ebp))
@@ -201,14 +201,14 @@ typedef struct {
 	"1: pop 0x20(%0)\n"     \
 	:	\
 	: "a" (&(ctx)),	\
-		[eax] MONO_CONTEXT_OFFSET (eax, 0, mgreg_t), \
-		[ebx] MONO_CONTEXT_OFFSET (ebx, 0, mgreg_t), \
-		[ecx] MONO_CONTEXT_OFFSET (ecx, 0, mgreg_t), \
-		[edx] MONO_CONTEXT_OFFSET (edx, 0, mgreg_t), \
-		[ebp] MONO_CONTEXT_OFFSET (ebp, 0, mgreg_t), \
-		[esp] MONO_CONTEXT_OFFSET (esp, 0, mgreg_t), \
-		[esi] MONO_CONTEXT_OFFSET (esi, 0, mgreg_t), \
-		[edi] MONO_CONTEXT_OFFSET (edi, 0, mgreg_t) \
+		[eax] MONO_CONTEXT_OFFSET (eax, 0, host_mgreg_t), \
+		[ebx] MONO_CONTEXT_OFFSET (ebx, 0, host_mgreg_t), \
+		[ecx] MONO_CONTEXT_OFFSET (ecx, 0, host_mgreg_t), \
+		[edx] MONO_CONTEXT_OFFSET (edx, 0, host_mgreg_t), \
+		[ebp] MONO_CONTEXT_OFFSET (ebp, 0, host_mgreg_t), \
+		[esp] MONO_CONTEXT_OFFSET (esp, 0, host_mgreg_t), \
+		[esi] MONO_CONTEXT_OFFSET (esi, 0, host_mgreg_t), \
+		[edi] MONO_CONTEXT_OFFSET (edi, 0, host_mgreg_t) \
 	: "memory")
 
 #ifdef UCONTEXT_REG_XMM
@@ -272,7 +272,7 @@ struct sigcontext {
 #endif
 
 typedef struct {
-	mgreg_t gregs [AMD64_NREG];
+	host_mgreg_t gregs [AMD64_NREG];
 #if defined(MONO_HAVE_SIMD_REG)
 	MonoContextSimdReg fregs [AMD64_XMM_NREG];
 #else
@@ -280,9 +280,9 @@ typedef struct {
 #endif
 } MonoContext;
 
-#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->gregs [AMD64_RIP] = (mgreg_t)(ip); } while (0);
-#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->gregs [AMD64_RBP] = (mgreg_t)(bp); } while (0);
-#define MONO_CONTEXT_SET_SP(ctx,esp) do { (ctx)->gregs [AMD64_RSP] = (mgreg_t)(esp); } while (0);
+#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->gregs [AMD64_RIP] = (host_mgreg_t)(ip); } while (0);
+#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->gregs [AMD64_RBP] = (host_mgreg_t)(bp); } while (0);
+#define MONO_CONTEXT_SET_SP(ctx,esp) do { (ctx)->gregs [AMD64_RSP] = (host_mgreg_t)(esp); } while (0);
 
 #define MONO_CONTEXT_GET_IP(ctx) ((gpointer)((ctx)->gregs [AMD64_RIP]))
 #define MONO_CONTEXT_GET_BP(ctx) ((gpointer)((ctx)->gregs [AMD64_RBP]))
@@ -320,23 +320,23 @@ G_EXTERN_C void mono_context_get_current (void *);
 			"movq %%rdx, %c[rip](%0)\n"	\
 			: 	\
 			: "a" (&(ctx)),	\
-				[rax] MONO_CONTEXT_OFFSET (gregs, AMD64_RAX, mgreg_t),	\
-				[rcx] MONO_CONTEXT_OFFSET (gregs, AMD64_RCX, mgreg_t),	\
-				[rdx] MONO_CONTEXT_OFFSET (gregs, AMD64_RDX, mgreg_t),	\
-				[rbx] MONO_CONTEXT_OFFSET (gregs, AMD64_RBX, mgreg_t),	\
-				[rsp] MONO_CONTEXT_OFFSET (gregs, AMD64_RSP, mgreg_t),	\
-				[rbp] MONO_CONTEXT_OFFSET (gregs, AMD64_RBP, mgreg_t),	\
-				[rsi] MONO_CONTEXT_OFFSET (gregs, AMD64_RSI, mgreg_t),	\
-				[rdi] MONO_CONTEXT_OFFSET (gregs, AMD64_RDI, mgreg_t),	\
-				[r8] MONO_CONTEXT_OFFSET (gregs, AMD64_R8, mgreg_t), \
-				[r9] MONO_CONTEXT_OFFSET (gregs, AMD64_R9, mgreg_t), \
-				[r10] MONO_CONTEXT_OFFSET (gregs, AMD64_R10, mgreg_t),	\
-				[r11] MONO_CONTEXT_OFFSET (gregs, AMD64_R11, mgreg_t),	\
-				[r12] MONO_CONTEXT_OFFSET (gregs, AMD64_R12, mgreg_t),	\
-				[r13] MONO_CONTEXT_OFFSET (gregs, AMD64_R13, mgreg_t),	\
-				[r14] MONO_CONTEXT_OFFSET (gregs, AMD64_R14, mgreg_t),	\
-				[r15] MONO_CONTEXT_OFFSET (gregs, AMD64_R15, mgreg_t),	\
-				[rip] MONO_CONTEXT_OFFSET (gregs, AMD64_RIP, mgreg_t)	\
+				[rax] MONO_CONTEXT_OFFSET (gregs, AMD64_RAX, host_mgreg_t),	\
+				[rcx] MONO_CONTEXT_OFFSET (gregs, AMD64_RCX, host_mgreg_t),	\
+				[rdx] MONO_CONTEXT_OFFSET (gregs, AMD64_RDX, host_mgreg_t),	\
+				[rbx] MONO_CONTEXT_OFFSET (gregs, AMD64_RBX, host_mgreg_t),	\
+				[rsp] MONO_CONTEXT_OFFSET (gregs, AMD64_RSP, host_mgreg_t),	\
+				[rbp] MONO_CONTEXT_OFFSET (gregs, AMD64_RBP, host_mgreg_t),	\
+				[rsi] MONO_CONTEXT_OFFSET (gregs, AMD64_RSI, host_mgreg_t),	\
+				[rdi] MONO_CONTEXT_OFFSET (gregs, AMD64_RDI, host_mgreg_t),	\
+				[r8] MONO_CONTEXT_OFFSET (gregs, AMD64_R8, host_mgreg_t), \
+				[r9] MONO_CONTEXT_OFFSET (gregs, AMD64_R9, host_mgreg_t), \
+				[r10] MONO_CONTEXT_OFFSET (gregs, AMD64_R10, host_mgreg_t),	\
+				[r11] MONO_CONTEXT_OFFSET (gregs, AMD64_R11, host_mgreg_t),	\
+				[r12] MONO_CONTEXT_OFFSET (gregs, AMD64_R12, host_mgreg_t),	\
+				[r13] MONO_CONTEXT_OFFSET (gregs, AMD64_R13, host_mgreg_t),	\
+				[r14] MONO_CONTEXT_OFFSET (gregs, AMD64_R14, host_mgreg_t),	\
+				[r15] MONO_CONTEXT_OFFSET (gregs, AMD64_R15, host_mgreg_t),	\
+				[rip] MONO_CONTEXT_OFFSET (gregs, AMD64_RIP, host_mgreg_t)	\
 			: "rdx", "memory");	\
 	} while (0)
 
@@ -397,16 +397,16 @@ G_EXTERN_C void mono_context_get_current (void *);
 #include <mono/arch/arm/arm-codegen.h>
 
 typedef struct {
-	mgreg_t pc;
-	mgreg_t regs [16];
+	host_mgreg_t pc;
+	host_mgreg_t regs [16];
 	double fregs [16];
-	mgreg_t cpsr;
+	host_mgreg_t cpsr;
 } MonoContext;
 
 /* we have the stack pointer, not the base pointer in sigcontext */
-#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->pc = (mgreg_t)ip; } while (0); 
-#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->regs [ARMREG_FP] = (mgreg_t)bp; } while (0); 
-#define MONO_CONTEXT_SET_SP(ctx,bp) do { (ctx)->regs [ARMREG_SP] = (mgreg_t)bp; } while (0); 
+#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->pc = (host_mgreg_t)ip; } while (0); 
+#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->regs [ARMREG_FP] = (host_mgreg_t)bp; } while (0); 
+#define MONO_CONTEXT_SET_SP(ctx,bp) do { (ctx)->regs [ARMREG_SP] = (host_mgreg_t)bp; } while (0); 
 
 #define MONO_CONTEXT_GET_IP(ctx) ((gpointer)((ctx)->pc))
 #define MONO_CONTEXT_GET_BP(ctx) ((gpointer)((ctx)->regs [ARMREG_FP]))
@@ -416,7 +416,7 @@ typedef struct {
 
 #define MONO_CONTEXT_GET_CURRENT(ctx) do { \
 	gpointer _dummy; \
-    ctx.regs [ARMREG_SP] = (mgreg_t)&_dummy; \
+    ctx.regs [ARMREG_SP] = (host_mgreg_t)&_dummy; \
 } while (0);
 
 #else
@@ -453,20 +453,20 @@ typedef struct {
 #include <mono/arch/arm64/arm64-codegen.h>
 
 typedef struct {
-	mgreg_t regs [32];
+	host_mgreg_t regs [32];
 	/* FIXME not fully saved in trampolines */
 	MonoContextSimdReg fregs [32];
-	mgreg_t pc;
+	host_mgreg_t pc;
 	/*
 	 * fregs might not be initialized if this context was created from a
 	 * ucontext.
 	 */
-	mgreg_t has_fregs;
+	host_mgreg_t has_fregs;
 } MonoContext;
 
-#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->pc = (mgreg_t)ip; } while (0)
-#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->regs [ARMREG_FP] = (mgreg_t)bp; } while (0);
-#define MONO_CONTEXT_SET_SP(ctx,bp) do { (ctx)->regs [ARMREG_SP] = (mgreg_t)bp; } while (0);
+#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->pc = (host_mgreg_t)ip; } while (0)
+#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->regs [ARMREG_FP] = (host_mgreg_t)bp; } while (0);
+#define MONO_CONTEXT_SET_SP(ctx,bp) do { (ctx)->regs [ARMREG_SP] = (host_mgreg_t)bp; } while (0);
 
 #define MONO_CONTEXT_GET_IP(ctx) (gpointer)((ctx)->pc)
 #define MONO_CONTEXT_GET_BP(ctx) (gpointer)((ctx)->regs [ARMREG_FP])
@@ -559,7 +559,7 @@ typedef struct {
 typedef struct {
 	gulong sc_ir;          // pc 
 	gulong sc_sp;          // r1
-	mgreg_t regs [32];
+	host_mgreg_t regs [32];
 	double fregs [32];
 } MonoContext;
 
@@ -647,17 +647,17 @@ typedef struct {
 #else /* !defined(__mono_ppc64__) */
 
 typedef struct {
-	mgreg_t sc_ir;          // pc
-	mgreg_t sc_sp;          // r1
-	mgreg_t regs [32];
+	host_mgreg_t sc_ir;          // pc
+	host_mgreg_t sc_sp;          // r1
+	host_mgreg_t regs [32];
 	double fregs [32];
 } MonoContext;
 
 /* we have the stack pointer, not the base pointer in sigcontext */
-#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->sc_ir = (mgreg_t)ip; } while (0);
+#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->sc_ir = (host_mgreg_t)ip; } while (0);
 /* FIXME: should be called SET_SP */
-#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->sc_sp = (mgreg_t)bp; } while (0);
-#define MONO_CONTEXT_SET_SP(ctx,sp) do { (ctx)->sc_sp = (mgreg_t)sp; } while (0);
+#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->sc_sp = (host_mgreg_t)bp; } while (0);
+#define MONO_CONTEXT_SET_SP(ctx,sp) do { (ctx)->sc_sp = (host_mgreg_t)sp; } while (0);
 
 #define MONO_CONTEXT_GET_IP(ctx) ((gpointer)((ctx)->sc_ir))
 #define MONO_CONTEXT_GET_BP(ctx) ((gpointer)((ctx)->regs [ppc_r31]))
@@ -742,7 +742,7 @@ typedef struct {
 #elif defined(__sparc__) || defined(sparc) /* defined(__mono_ppc__) */
 
 typedef struct MonoContext {
-	mgreg_t regs [15];
+	host_mgreg_t regs [15];
 	guint8 *ip;
 	gpointer *sp;
 	gpointer *fp;
@@ -811,14 +811,14 @@ typedef struct MonoContext {
 #include <mono/arch/mips/mips-codegen.h>
 
 typedef struct {
-	mgreg_t	    sc_pc;
-	mgreg_t		sc_regs [32];
+	host_mgreg_t	    sc_pc;
+	host_mgreg_t		sc_regs [32];
 	gfloat		sc_fpregs [32];
 } MonoContext;
 
-#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->sc_pc = (mgreg_t)(ip); } while (0);
-#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->sc_regs[mips_fp] = (mgreg_t)(bp); } while (0);
-#define MONO_CONTEXT_SET_SP(ctx,sp) do { (ctx)->sc_regs[mips_sp] = (mgreg_t)(sp); } while (0);
+#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->sc_pc = (host_mgreg_t)(ip); } while (0);
+#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->sc_regs[mips_fp] = (host_mgreg_t)(bp); } while (0);
+#define MONO_CONTEXT_SET_SP(ctx,sp) do { (ctx)->sc_regs[mips_sp] = (host_mgreg_t)(sp); } while (0);
 
 #define MONO_CONTEXT_GET_IP(ctx) ((gpointer)((ctx)->sc_pc))
 #define MONO_CONTEXT_GET_BP(ctx) ((gpointer)((ctx)->sc_regs[mips_fp]))

--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -69,13 +69,13 @@ typedef struct {
 	host_mgreg_t wasm_pc;
 } MonoContext;
 
-#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->wasm_ip = (host_mgreg_t)(ip); } while (0);
-#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->wasm_bp = (host_mgreg_t)(bp); } while (0);
-#define MONO_CONTEXT_SET_SP(ctx,sp) do { (ctx)->wasm_sp = (host_mgreg_t)(sp); } while (0);
+#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->wasm_ip = (host_mgreg_t)(gsize)(ip); } while (0);
+#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->wasm_bp = (host_mgreg_t)(gsize)(bp); } while (0);
+#define MONO_CONTEXT_SET_SP(ctx,sp) do { (ctx)->wasm_sp = (host_mgreg_t)(gsize)(sp); } while (0);
 
-#define MONO_CONTEXT_GET_IP(ctx) ((gpointer)((ctx)->wasm_ip))
-#define MONO_CONTEXT_GET_BP(ctx) ((gpointer)((ctx)->wasm_bp))
-#define MONO_CONTEXT_GET_SP(ctx) ((gpointer)((ctx)->wasm_sp))
+#define MONO_CONTEXT_GET_IP(ctx) ((gpointer)(gsize)((ctx)->wasm_ip))
+#define MONO_CONTEXT_GET_BP(ctx) ((gpointer)(gsize)((ctx)->wasm_bp))
+#define MONO_CONTEXT_GET_SP(ctx) ((gpointer)(gsize)((ctx)->wasm_sp))
 
 #elif (defined(__i386__) && !defined(MONO_CROSS_COMPILE)) || (defined(TARGET_X86))
 
@@ -158,13 +158,13 @@ typedef struct {
 #endif
 } MonoContext;
 
-#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->eip = (host_mgreg_t)(ip); } while (0); 
-#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->ebp = (host_mgreg_t)(bp); } while (0); 
-#define MONO_CONTEXT_SET_SP(ctx,sp) do { (ctx)->esp = (host_mgreg_t)(sp); } while (0); 
+#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->eip = (host_mgreg_t)(gsize)(ip); } while (0);
+#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->ebp = (host_mgreg_t)(gsize)(bp); } while (0);
+#define MONO_CONTEXT_SET_SP(ctx,sp) do { (ctx)->esp = (host_mgreg_t)(gsize)(sp); } while (0);
 
-#define MONO_CONTEXT_GET_IP(ctx) ((gpointer)((ctx)->eip))
-#define MONO_CONTEXT_GET_BP(ctx) ((gpointer)((ctx)->ebp))
-#define MONO_CONTEXT_GET_SP(ctx) ((gpointer)((ctx)->esp))
+#define MONO_CONTEXT_GET_IP(ctx) ((gpointer)(gsize)((ctx)->eip))
+#define MONO_CONTEXT_GET_BP(ctx) ((gpointer)(gsize)((ctx)->ebp))
+#define MONO_CONTEXT_GET_SP(ctx) ((gpointer)(gsize)((ctx)->esp))
 
 /*We set EAX to zero since we are clobering it anyway*/
 #ifdef _MSC_VER
@@ -280,13 +280,13 @@ typedef struct {
 #endif
 } MonoContext;
 
-#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->gregs [AMD64_RIP] = (host_mgreg_t)(ip); } while (0);
-#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->gregs [AMD64_RBP] = (host_mgreg_t)(bp); } while (0);
-#define MONO_CONTEXT_SET_SP(ctx,esp) do { (ctx)->gregs [AMD64_RSP] = (host_mgreg_t)(esp); } while (0);
+#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->gregs [AMD64_RIP] = (host_mgreg_t)(gsize)(ip); } while (0);
+#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->gregs [AMD64_RBP] = (host_mgreg_t)(gsize)(bp); } while (0);
+#define MONO_CONTEXT_SET_SP(ctx,esp) do { (ctx)->gregs [AMD64_RSP] = (host_mgreg_t)(gsize)(esp); } while (0);
 
-#define MONO_CONTEXT_GET_IP(ctx) ((gpointer)((ctx)->gregs [AMD64_RIP]))
-#define MONO_CONTEXT_GET_BP(ctx) ((gpointer)((ctx)->gregs [AMD64_RBP]))
-#define MONO_CONTEXT_GET_SP(ctx) ((gpointer)((ctx)->gregs [AMD64_RSP]))
+#define MONO_CONTEXT_GET_IP(ctx) ((gpointer)(gsize)((ctx)->gregs [AMD64_RIP]))
+#define MONO_CONTEXT_GET_BP(ctx) ((gpointer)(gsize)((ctx)->gregs [AMD64_RBP]))
+#define MONO_CONTEXT_GET_SP(ctx) ((gpointer)(gsize)((ctx)->gregs [AMD64_RSP]))
 
 #if defined (HOST_WIN32) && !defined(__GNUC__)
 /* msvc doesn't support inline assembly, so have to use a separate .asm file */
@@ -404,19 +404,19 @@ typedef struct {
 } MonoContext;
 
 /* we have the stack pointer, not the base pointer in sigcontext */
-#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->pc = (host_mgreg_t)ip; } while (0); 
-#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->regs [ARMREG_FP] = (host_mgreg_t)bp; } while (0); 
-#define MONO_CONTEXT_SET_SP(ctx,bp) do { (ctx)->regs [ARMREG_SP] = (host_mgreg_t)bp; } while (0); 
+#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->pc = (host_mgreg_t)(gsize)ip; } while (0);
+#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->regs [ARMREG_FP] = (host_mgreg_t)(gsize)bp; } while (0);
+#define MONO_CONTEXT_SET_SP(ctx,bp) do { (ctx)->regs [ARMREG_SP] = (host_mgreg_t)(gsize)bp; } while (0);
 
-#define MONO_CONTEXT_GET_IP(ctx) ((gpointer)((ctx)->pc))
-#define MONO_CONTEXT_GET_BP(ctx) ((gpointer)((ctx)->regs [ARMREG_FP]))
-#define MONO_CONTEXT_GET_SP(ctx) ((gpointer)((ctx)->regs [ARMREG_SP]))
+#define MONO_CONTEXT_GET_IP(ctx) ((gpointer)(gsize)((ctx)->pc))
+#define MONO_CONTEXT_GET_BP(ctx) ((gpointer)(gsize)((ctx)->regs [ARMREG_FP]))
+#define MONO_CONTEXT_GET_SP(ctx) ((gpointer)(gsize)((ctx)->regs [ARMREG_SP]))
 
 #if defined(HOST_WATCHOS)
 
 #define MONO_CONTEXT_GET_CURRENT(ctx) do { \
 	gpointer _dummy; \
-    ctx.regs [ARMREG_SP] = (host_mgreg_t)&_dummy; \
+    ctx.regs [ARMREG_SP] = (host_mgreg_t)(gsize)&_dummy; \
 } while (0);
 
 #else
@@ -464,13 +464,13 @@ typedef struct {
 	host_mgreg_t has_fregs;
 } MonoContext;
 
-#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->pc = (host_mgreg_t)ip; } while (0)
-#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->regs [ARMREG_FP] = (host_mgreg_t)bp; } while (0);
-#define MONO_CONTEXT_SET_SP(ctx,bp) do { (ctx)->regs [ARMREG_SP] = (host_mgreg_t)bp; } while (0);
+#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->pc = (host_mgreg_t)(gsize)ip; } while (0)
+#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->regs [ARMREG_FP] = (host_mgreg_t)(gsize)bp; } while (0);
+#define MONO_CONTEXT_SET_SP(ctx,bp) do { (ctx)->regs [ARMREG_SP] = (host_mgreg_t)(gsize)bp; } while (0);
 
-#define MONO_CONTEXT_GET_IP(ctx) (gpointer)((ctx)->pc)
-#define MONO_CONTEXT_GET_BP(ctx) (gpointer)((ctx)->regs [ARMREG_FP])
-#define MONO_CONTEXT_GET_SP(ctx) (gpointer)((ctx)->regs [ARMREG_SP])
+#define MONO_CONTEXT_GET_IP(ctx) (gpointer)(gsize)((ctx)->pc)
+#define MONO_CONTEXT_GET_BP(ctx) (gpointer)(gsize)((ctx)->regs [ARMREG_FP])
+#define MONO_CONTEXT_GET_SP(ctx) (gpointer)(gsize)((ctx)->regs [ARMREG_SP])
 
 #if defined (HOST_APPLETVOS)
 
@@ -564,13 +564,13 @@ typedef struct {
 } MonoContext;
 
 /* we have the stack pointer, not the base pointer in sigcontext */
-#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->sc_ir = (gulong)ip; } while (0);
-#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->sc_sp = (gulong)bp; } while (0);
-#define MONO_CONTEXT_SET_SP(ctx,sp) do { (ctx)->sc_sp = (gulong)sp; } while (0);
+#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->sc_ir = (gulong)(gsize)ip; } while (0);
+#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->sc_sp = (gulong)(gsize)bp; } while (0);
+#define MONO_CONTEXT_SET_SP(ctx,sp) do { (ctx)->sc_sp = (gulong)(gsize)sp; } while (0);
 
-#define MONO_CONTEXT_GET_IP(ctx) ((gpointer)((ctx)->sc_ir))
-#define MONO_CONTEXT_GET_BP(ctx) ((gpointer)((ctx)->regs [ppc_r31]))
-#define MONO_CONTEXT_GET_SP(ctx) ((gpointer)((ctx)->sc_sp))
+#define MONO_CONTEXT_GET_IP(ctx) ((gpointer)(gsize)((ctx)->sc_ir))
+#define MONO_CONTEXT_GET_BP(ctx) ((gpointer)(gsize)((ctx)->regs [ppc_r31]))
+#define MONO_CONTEXT_GET_SP(ctx) ((gpointer)(gsize)((ctx)->sc_sp))
 
 #define MONO_CONTEXT_GET_CURRENT(ctx)	\
 	__asm__ __volatile__(	\
@@ -654,14 +654,14 @@ typedef struct {
 } MonoContext;
 
 /* we have the stack pointer, not the base pointer in sigcontext */
-#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->sc_ir = (host_mgreg_t)ip; } while (0);
+#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->sc_ir = (host_mgreg_t)(gsize)ip; } while (0);
 /* FIXME: should be called SET_SP */
-#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->sc_sp = (host_mgreg_t)bp; } while (0);
-#define MONO_CONTEXT_SET_SP(ctx,sp) do { (ctx)->sc_sp = (host_mgreg_t)sp; } while (0);
+#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->sc_sp = (host_mgreg_t)(gsize)bp; } while (0);
+#define MONO_CONTEXT_SET_SP(ctx,sp) do { (ctx)->sc_sp = (host_mgreg_t)(gsize)sp; } while (0);
 
-#define MONO_CONTEXT_GET_IP(ctx) ((gpointer)((ctx)->sc_ir))
-#define MONO_CONTEXT_GET_BP(ctx) ((gpointer)((ctx)->regs [ppc_r31]))
-#define MONO_CONTEXT_GET_SP(ctx) ((gpointer)((ctx)->sc_sp))
+#define MONO_CONTEXT_GET_IP(ctx) ((gpointer)(gsize)((ctx)->sc_ir))
+#define MONO_CONTEXT_GET_BP(ctx) ((gpointer)(gsize)((ctx)->regs [ppc_r31]))
+#define MONO_CONTEXT_GET_SP(ctx) ((gpointer)(gsize)((ctx)->sc_sp))
 
 #define MONO_CONTEXT_GET_CURRENT(ctx)	\
 	__asm__ __volatile__(	\
@@ -816,13 +816,13 @@ typedef struct {
 	gfloat		sc_fpregs [32];
 } MonoContext;
 
-#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->sc_pc = (host_mgreg_t)(ip); } while (0);
-#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->sc_regs[mips_fp] = (host_mgreg_t)(bp); } while (0);
-#define MONO_CONTEXT_SET_SP(ctx,sp) do { (ctx)->sc_regs[mips_sp] = (host_mgreg_t)(sp); } while (0);
+#define MONO_CONTEXT_SET_IP(ctx,ip) do { (ctx)->sc_pc = (host_mgreg_t)(gsize)(ip); } while (0);
+#define MONO_CONTEXT_SET_BP(ctx,bp) do { (ctx)->sc_regs[mips_fp] = (host_mgreg_t)(gsize)(bp); } while (0);
+#define MONO_CONTEXT_SET_SP(ctx,sp) do { (ctx)->sc_regs[mips_sp] = (host_mgreg_t)(gsize)(sp); } while (0);
 
-#define MONO_CONTEXT_GET_IP(ctx) ((gpointer)((ctx)->sc_pc))
-#define MONO_CONTEXT_GET_BP(ctx) ((gpointer)((ctx)->sc_regs[mips_fp]))
-#define MONO_CONTEXT_GET_SP(ctx) ((gpointer)((ctx)->sc_regs[mips_sp]))
+#define MONO_CONTEXT_GET_IP(ctx) ((gpointer)(gsize)((ctx)->sc_pc))
+#define MONO_CONTEXT_GET_BP(ctx) ((gpointer)(gsize)((ctx)->sc_regs[mips_fp]))
+#define MONO_CONTEXT_GET_SP(ctx) ((gpointer)(gsize)((ctx)->sc_regs[mips_sp]))
 
 #define MONO_CONTEXT_GET_CURRENT(ctx)	\
 	__asm__ __volatile__(	\

--- a/mono/utils/mono-machine.h
+++ b/mono/utils/mono-machine.h
@@ -25,8 +25,10 @@
 // This is for example x32, arm6432, mipsn32, Alpha/NT.
 #ifdef __mono_ilp32__
 typedef gint64 host_mgreg_t;
+typedef guint64 host_umgreg_t;
 #else
 typedef gssize host_mgreg_t;
+typedef gsize host_umgreg_t;
 #endif
 
 // SIZEOF_REGISTER is target. mgreg_t is usually target, sometimes host.

--- a/mono/utils/mono-machine.h
+++ b/mono/utils/mono-machine.h
@@ -20,6 +20,21 @@
 #include "config.h"
 #include <glib.h>
 
+// __ILP32__ means integer, long, and pointers are 32bits, and nothing about registers.
+// __mono_ilp32__ means integer, long, and pointers are 32bits, and 64bit registers.
+// This is for example x32, arm6432, mipsn32, Alpha/NT.
+#ifdef __mono_ilp32__
+typedef gint64 host_mgreg_t;
+#else
+typedef gssize host_mgreg_t;
+#endif
+
+// SIZEOF_REGISTER is target. mgreg_t is usually target, sometimes host.
+// There is a mismatch in cross (AOT) compilers, and the
+// never executed JIT and runtime truncate pointers.
+// When casting to/from pointers, use gsize or gssize.
+// When dealing with register context, use host_mgreg_t.
+// Or ifndef MONO_CROSS_COMPILE out runtime code.
 #if SIZEOF_REGISTER == 4
 typedef gint32 mgreg_t;
 #elif SIZEOF_REGISTER == 8

--- a/mono/utils/mono-stack-unwinding.h
+++ b/mono/utils/mono-stack-unwinding.h
@@ -100,7 +100,7 @@ typedef struct {
 	guint32 unwind_info_len;
 	guint8 *unwind_info;
 
-	mgreg_t **reg_locations;
+	host_mgreg_t **reg_locations;
 } MonoStackFrameInfo;
 
 /*Index into MonoThreadState::unwind_data. */


### PR DESCRIPTION
mgreg_t often to vs. host_mgreg_t to fix C++ cross compilation.

This is much noiser alternative to https://github.com/mono/mono/pull/10881
