### PR TITLE
[2018-06] [sdks/ios] Build libMonoPosixHelper for device architectures, so that zlib-helper.o is created. (#10921)

### DIFF
--- a/sdks/builds/ios.mk
+++ b/sdks/builds/ios.mk
@@ -50,6 +50,8 @@ _ios-$(1)_CXX=$$(CCACHE) $$(PLATFORM_BIN)/clang++
 _ios-$(1)_AC_VARS= \
 	ac_cv_c_bigendian=no \
 	ac_cv_func_finite=no \
+	ac_cv_func_fstatat=no \
+	ac_cv_func_readlinkat=no \
 	ac_cv_func_getpwuid_r=no \
 	ac_cv_func_posix_getpwuid_r=yes \
 	ac_cv_header_curses_h=no \
@@ -95,7 +97,6 @@ _ios-$(1)_CONFIGURE_FLAGS = \
 	--disable-iconv \
 	--disable-mcs-build \
 	--disable-nls \
-	--disable-support-build \
 	--disable-visibility-hidden \
 	--enable-dtrace=no \
 	--enable-icall-export \


### PR DESCRIPTION
xamarin-macios currently builds zlib-helper.o using mono's source code.

It would be preferrable to use a version built by mono, and since
zlib-helper.o is a byproduct of building libMonoPosixHelper, we need to build
libMonoPosixHelper (we already build it for simulator architectures), even
though we don't need/use libMonoPosixHelper itself.

This is a backport of #10921.