### PR TITLE
Revert "Make a bunch of classes optional to the runtime. (#10804)"

### DIFF
--- a/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
+++ b/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
@@ -123,6 +123,10 @@
 		<!-- domain.c: mono_defaults.stack_frame_class -->
 		<!-- used in mini-exceptions.c to create array and MonoStackFrame instance, i.e. only fields are required to be preserved -->
 		<type fullname="System.Diagnostics.StackFrame" preserve="fields" />
+		
+		<!-- domain.c: mono_defaults.stack_trace_class -->
+		<!-- does not seems used outside the g_assert in domain.c (maybe it could be removed) -->
+		<type fullname="System.Diagnostics.StackTrace" preserve="fields" />
 
 		<!-- debugger-agent.c: create_event_list -->
 		<type fullname="System.Diagnostics.DebuggerNonUserCodeAttribute"/>
@@ -457,6 +461,11 @@
 			<method name=".ctor" />
 		</type>
 
+		<!-- console-unix.c: do_console_cancel_event -->
+		<type fullname="System.Console">
+			<method name="DoConsoleCancelEventInBackground" />
+		</type>
+
 		<!-- icalls - but (at least parts of them) are used thru interfaces at runtime and cannot be linked out -->
 		<type fullname="System.Globalization.DateTimeFormatInfo" preserve="fields" />
 		<type fullname="System.Globalization.CompareInfo" preserve="fields" />
@@ -481,12 +490,24 @@
 
 		<!-- fileio.h: shared structure between the managed and unmanaged worlds -->
 		<type fullname="System.IO.MonoIOStat" preserve="fields" />
+		
+		<!-- domain.c: mono_defaults.math_class
+			method-to-ir.c: empty branch (wrt Min/Max optimization)
+			mini-[x86|amd64].c needs the type but then only check for names
+			note: there's no fields (static type) but that will mark the type itself -->
+		<type fullname="System.Math" preserve="fields" />
 
 		<!-- appdomain.c: ves_icall_System_AppDomain_GetAssemblies -->
 		<type fullname="System.Reflection.Assembly" preserve="fields"/>
 
 		<type fullname="System.Reflection.AssemblyName" preserve="fields" />
 		<type fullname="System.Reflection.ConstructorInfo" preserve="fields" />
+
+		<!-- domain.c: mono_defaults.customattribute_data_class -->
+		<type fullname="System.Reflection.CustomAttributeData" preserve="fields">
+			<!-- custom-attrs.c: create_custom_attr_data - create an instance with the ctor using 4 arguments -->
+			<method signature="System.Void .ctor(System.Reflection.ConstructorInfo,System.Reflection.Assembly,System.IntPtr,System.UInt32)" />
+		</type>
 
 		<!-- reflection.c: create_cattr_named_arg - create an instance with the ctor using 2 parameters -->
 		<type fullname="System.Reflection.CustomAttributeNamedArgument">
@@ -660,6 +681,9 @@
 			<method name="DangerousRelease" />
 		</type>
 		
+		<!-- object-internals.h: defines MonoReflectionUnmanagedFunctionPointerAttribute, marshal.c: use it -->
+		<type fullname="System.Runtime.InteropServices.UnmanagedFunctionPointerAttribute" preserve="fields"/>
+
 		<!-- marshal.c: mono_mb_emit_exception_marshal_directive -->
 		<type fullname="System.Runtime.InteropServices.MarshalDirectiveException">
 			<method signature="System.Void .ctor(System.String)" />
@@ -789,6 +813,9 @@
 		<type fullname="System.Threading._ThreadPoolWaitCallback">
 		  <method name="PerformWaitCallback"/>
 		</type>
+
+		<!-- domain.c: mono_defaults.stringbuilder_class -->
+		<type fullname="System.Text.StringBuilder" preserve="fields" />
 
 		<!-- cominterop.c -->
 		<type fullname="Mono.Interop.ComInteropProxy" feature="com" />

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -901,6 +901,7 @@ typedef struct {
 	MonoClass *array_class;
 	MonoClass *delegate_class;
 	MonoClass *multicastdelegate_class;
+	MonoClass *asyncresult_class;
 	MonoClass *manualresetevent_class;
 	MonoClass *typehandle_class;
 	MonoClass *fieldhandle_class;
@@ -921,18 +922,25 @@ typedef struct {
 	MonoClass *appdomain_class;
 	MonoClass *field_info_class;
 	MonoClass *method_info_class;
+	MonoClass *stringbuilder_class;
+	MonoClass *math_class;
 	MonoClass *stack_frame_class;
+	MonoClass *stack_trace_class;
 	MonoClass *marshal_class;
 	MonoClass *typed_reference_class;
 	MonoClass *argumenthandle_class;
 	MonoClass *monitor_class;
 	MonoClass *generic_ilist_class;
 	MonoClass *generic_nullable_class;
+	MonoClass *handleref_class;
 	MonoClass *attribute_class;
+	MonoClass *customattribute_data_class;
 	MonoClass *critical_finalizer_object; /* MAYBE NULL */
 	MonoClass *generic_ireadonlylist_class;
 	MonoClass *generic_ienumerator_class;
+	MonoClass *threadpool_wait_callback_class;
 	MonoMethod *threadpool_perform_wait_callback_method;
+	MonoClass *console_class;
 } MonoDefaults;
 
 #ifdef DISABLE_REMOTING
@@ -999,7 +1007,6 @@ GENERATE_GET_CLASS_WITH_CACHE_DECL (appdomain_unloaded_exception)
 
 GENERATE_GET_CLASS_WITH_CACHE_DECL (valuetype)
 
-GENERATE_TRY_GET_CLASS_WITH_CACHE_DECL(handleref)
 /* If you need a MonoType, use one of the mono_get_*_type () functions in class-inlines.h */
 extern MonoDefaults mono_defaults;
 

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -72,7 +72,6 @@ static MonoClass *mono_class_from_mono_type_internal (MonoType *type);
 static gboolean mono_class_is_subclass_of_internal (MonoClass *klass, MonoClass *klassc, gboolean check_interfaces);
 
 GENERATE_GET_CLASS_WITH_CACHE (valuetype, "System", "ValueType")
-GENERATE_TRY_GET_CLASS_WITH_CACHE (handleref, "System.Runtime.InteropServices", "HandleRef")
 
 static
 MonoImage *

--- a/mono/metadata/console-unix.c
+++ b/mono/metadata/console-unix.c
@@ -75,10 +75,6 @@ static struct termios mono_attr;
 /* static void console_restore_signal_handlers (void); */
 static void console_set_signal_handlers (void);
 
-
-static GENERATE_TRY_GET_CLASS_WITH_CACHE (console, "System", "Console");
-
-
 void
 mono_console_init (void)
 {
@@ -225,11 +221,11 @@ do_console_cancel_event (void)
 	static MonoMethod *System_Console_DoConsoleCancelEventBackground_method = (MonoMethod*)(intptr_t)-1;
 	ERROR_DECL (error);
 
-	if (mono_class_try_get_console_class () == NULL)
+	if (mono_defaults.console_class == NULL)
 		return;
 
 	if (System_Console_DoConsoleCancelEventBackground_method == (gpointer)(intptr_t)-1) {
-		System_Console_DoConsoleCancelEventBackground_method = mono_class_get_method_from_name_checked (mono_class_try_get_console_class (), "DoConsoleCancelEventInBackground", 0, 0, error);
+		System_Console_DoConsoleCancelEventBackground_method = mono_class_get_method_from_name_checked (mono_defaults.console_class, "DoConsoleCancelEventInBackground", 0, 0, error);
 		mono_error_assert_ok (error);
 	}
 	if (System_Console_DoConsoleCancelEventBackground_method == NULL)

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -48,7 +48,6 @@ static gboolean type_is_reference (MonoType *type);
 
 static GENERATE_GET_CLASS_WITH_CACHE (custom_attribute_typed_argument, "System.Reflection", "CustomAttributeTypedArgument");
 static GENERATE_GET_CLASS_WITH_CACHE (custom_attribute_named_argument, "System.Reflection", "CustomAttributeNamedArgument");
-static GENERATE_TRY_GET_CLASS_WITH_CACHE (customattribute_data, "System.Reflection", "CustomAttributeData");
 
 static MonoCustomAttrInfo*
 mono_custom_attrs_from_builders_handle (MonoImage *alloc_img, MonoImage *image, MonoArrayHandle cattrs);
@@ -1382,16 +1381,6 @@ ves_icall_System_Reflection_CustomAttributeData_ResolveArgumentsInternal (MonoRe
 	mono_error_set_pending_exception (error);
 }
 
-static MonoClass*
-try_get_cattr_data_class (MonoError* error)
-{
-	error_init (error);
-	MonoClass *res = mono_class_try_get_customattribute_data_class ();
-	if (!res)
-		mono_error_set_execution_engine (error, "Class System.Reflection.CustomAttributeData not found, probably removed by the linker");
-	return res;
-}
-
 static MonoObjectHandle
 create_custom_attr_data (MonoImage *image, MonoCustomAttrEntry *cattr, MonoError *error)
 {
@@ -1405,22 +1394,15 @@ create_custom_attr_data (MonoImage *image, MonoCustomAttrEntry *cattr, MonoError
 	error_init (error);
 
 	g_assert (image->assembly);
-	MonoObjectHandle attr;
-
-	MonoClass *cattr_data = try_get_cattr_data_class (error);
-	goto_if_nok (error, result_null);
 
 	if (!ctor) {
-		MonoMethod *tmp = mono_class_get_method_from_name_checked (cattr_data, ".ctor", 4, 0, error);
+		ctor = mono_class_get_method_from_name_checked (mono_defaults.customattribute_data_class, ".ctor", 4, 0, error);
 		mono_error_assert_ok (error);
-
-		mono_memory_barrier (); //safe publish!
-		ctor = tmp;
 	}
 
 	domain = mono_domain_get ();
 
-	attr = mono_object_new_handle (domain, cattr_data, error);
+	MonoObjectHandle attr = mono_object_new_handle (domain, mono_defaults.customattribute_data_class, error);
 	goto_if_nok (error, fail);
 
 	MonoReflectionMethodHandle ctor_obj;
@@ -1435,13 +1417,8 @@ create_custom_attr_data (MonoImage *image, MonoCustomAttrEntry *cattr, MonoError
 	params [3] = &cattr->data_size;
 
 	mono_runtime_invoke_handle (ctor, attr, params, error);
-	goto fail;
-result_null:
-	attr = MONO_HANDLE_CAST (MonoObject, mono_new_null ());
 fail:
 	HANDLE_FUNCTION_RETURN_REF (MonoObject, attr);
-
-
 }
 
 static void
@@ -1525,11 +1502,8 @@ mono_custom_attrs_data_construct (MonoCustomAttrInfo *cinfo, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
 
-	MonoArrayHandle result;
-	MonoClass *cattr_data = try_get_cattr_data_class (error);
-	goto_if_nok (error, return_null);
-
-	result = mono_array_new_handle (mono_domain_get (), cattr_data, cinfo->num_attrs, error);
+	error_init (error);
+	MonoArrayHandle result = mono_array_new_handle (mono_domain_get (), mono_defaults.customattribute_data_class, cinfo->num_attrs, error);
 	goto_if_nok (error, return_null);
 	for (int i = 0; i < cinfo->num_attrs; ++i) {
 		create_custom_attr_data_into_array (cinfo->image, &cinfo->attrs [i], result, i, error);
@@ -2248,15 +2222,9 @@ mono_reflection_get_custom_attrs_data_checked (MonoObjectHandle obj, MonoError *
 		if (!cinfo->cached)
 			mono_custom_attrs_free (cinfo);
 		goto_if_nok (error, leave);
-	} else  {
-		MonoClass *cattr_data = try_get_cattr_data_class (error);
-		goto_if_nok (error, return_null);
+	} else 
+		MONO_HANDLE_ASSIGN (result, mono_array_new_handle (mono_domain_get (), mono_defaults.customattribute_data_class, 0, error));
 
-		MONO_HANDLE_ASSIGN (result, mono_array_new_handle (mono_domain_get (), cattr_data, 0, error));
-	}
-	goto leave;
-return_null:
-	result = MONO_HANDLE_CAST (MonoArray, mono_new_null ());
 leave:
 	return result;
 }

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -663,6 +663,10 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	mono_defaults.multicastdelegate_class = mono_class_load_from_name (
 		mono_defaults.corlib, "System", "MulticastDelegate");
 
+	mono_defaults.asyncresult_class = mono_class_load_from_name (
+		mono_defaults.corlib, "System.Runtime.Remoting.Messaging", 
+		"AsyncResult");
+
 	mono_defaults.manualresetevent_class = mono_class_load_from_name (
 		mono_defaults.corlib, "System.Threading", "ManualResetEvent");
 
@@ -720,8 +724,17 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	mono_defaults.method_info_class = mono_class_load_from_name (
 		mono_defaults.corlib, "System.Reflection", "MethodInfo");
 
+	mono_defaults.stringbuilder_class = mono_class_load_from_name (
+		mono_defaults.corlib, "System.Text", "StringBuilder");
+
+	mono_defaults.math_class = mono_class_load_from_name (
+	        mono_defaults.corlib, "System", "Math");
+
 	mono_defaults.stack_frame_class = mono_class_load_from_name (
 	        mono_defaults.corlib, "System.Diagnostics", "StackFrame");
+
+	mono_defaults.stack_trace_class = mono_class_load_from_name (
+	        mono_defaults.corlib, "System.Diagnostics", "StackTrace");
 
 	mono_defaults.marshal_class = mono_class_load_from_name (
 	        mono_defaults.corlib, "System.Runtime.InteropServices", "Marshal");
@@ -742,8 +755,14 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 
 	mono_assembly_load_friends (ass);
 
+	mono_defaults.handleref_class = mono_class_try_load_from_name (
+		mono_defaults.corlib, "System.Runtime.InteropServices", "HandleRef");
+
 	mono_defaults.attribute_class = mono_class_load_from_name (
 		mono_defaults.corlib, "System", "Attribute");
+
+	mono_defaults.customattribute_data_class = mono_class_load_from_name (
+		mono_defaults.corlib, "System.Reflection", "CustomAttributeData");
 
 	mono_class_init (mono_defaults.array_class);
 	mono_defaults.generic_nullable_class = mono_class_load_from_name (
@@ -755,12 +774,15 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	mono_defaults.generic_ienumerator_class = mono_class_load_from_name (
 	        mono_defaults.corlib, "System.Collections.Generic", "IEnumerator`1");
 
-	MonoClass *threadpool_wait_callback_class = mono_class_load_from_name (
+	mono_defaults.threadpool_wait_callback_class = mono_class_load_from_name (
 		mono_defaults.corlib, "System.Threading", "_ThreadPoolWaitCallback");
 
 	mono_defaults.threadpool_perform_wait_callback_method = mono_class_get_method_from_name_checked (
-		threadpool_wait_callback_class, "PerformWaitCallback", 0, 0, error);
+		mono_defaults.threadpool_wait_callback_class, "PerformWaitCallback", 0, 0, error);
 	mono_error_assert_ok (error);
+
+	mono_defaults.console_class = mono_class_try_load_from_name (
+		mono_defaults.corlib, "System", "Console");
 
 	domain->friendly_name = g_path_get_basename (filename);
 

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -2178,7 +2178,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 				is_string = TRUE;
 				conv = mono_marshal_get_string_to_ptr_conv (m->piinfo, spec);
 			}
-			else if (eklass == mono_class_try_get_stringbuilder_class ()) {
+			else if (eklass == mono_defaults.stringbuilder_class) {
 				is_string = TRUE;
 				conv = mono_marshal_get_stringbuilder_to_ptr_conv (m->piinfo, spec);
 			}
@@ -2284,7 +2284,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 	case MARSHAL_ACTION_CONV_OUT:
 		/* Unicode character arrays are implicitly marshalled as [Out] under MS.NET */
-		need_convert = ((eklass == mono_defaults.char_class) && (encoding == MONO_NATIVE_LPWSTR)) || (eklass == mono_class_try_get_stringbuilder_class ()) || (t->attrs & PARAM_ATTRIBUTE_OUT);
+		need_convert = ((eklass == mono_defaults.char_class) && (encoding == MONO_NATIVE_LPWSTR)) || (eklass == mono_defaults.stringbuilder_class) || (t->attrs & PARAM_ATTRIBUTE_OUT);
 		need_free = mono_marshal_need_free (m_class_get_byval_arg (eklass), m->piinfo, spec);
 
 		if ((t->attrs & PARAM_ATTRIBUTE_OUT) && spec && spec->native == MONO_NATIVE_LPARRAY && spec->data.array_data.param_num != -1) {
@@ -2319,7 +2319,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			guint32 label1, label2, label3;
 			int index_var, src_ptr, loc, esize;
 
-			if ((eklass == mono_class_try_get_stringbuilder_class ()) || (eklass == mono_defaults.string_class))
+			if ((eklass == mono_defaults.stringbuilder_class) || (eklass == mono_defaults.string_class))
 				esize = TARGET_SIZEOF_VOID_P;
 			else if (eklass == mono_defaults.char_class)
 				esize = mono_pinvoke_is_unicode (m->piinfo) ? 2 : 1;
@@ -2351,7 +2351,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 			/* Emit marshalling code */
 
-			if (eklass == mono_class_try_get_stringbuilder_class ()) {
+			if (eklass == mono_defaults.stringbuilder_class) {
 				gboolean need_free2;
 				MonoMarshalConv conv = mono_marshal_get_ptr_to_stringbuilder_conv (m->piinfo, spec, &need_free2);
 
@@ -2494,7 +2494,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			is_string = TRUE;
 			conv = mono_marshal_get_ptr_to_string_conv (m->piinfo, spec, &need_free);
 		}
-		else if (eklass == mono_class_try_get_stringbuilder_class ()) {
+		else if (eklass == mono_defaults.stringbuilder_class) {
 			is_string = TRUE;
 			conv = mono_marshal_get_ptr_to_stringbuilder_conv (m->piinfo, spec, &need_free);
 		}
@@ -2656,7 +2656,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			is_string = TRUE;
 			conv = mono_marshal_get_string_to_ptr_conv (m->piinfo, spec);
 		}
-		else if (eklass == mono_class_try_get_stringbuilder_class ()) {
+		else if (eklass == mono_defaults.stringbuilder_class) {
 			is_string = TRUE;
 			conv = mono_marshal_get_stringbuilder_to_ptr_conv (m->piinfo, spec);
 		}
@@ -5241,7 +5241,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 				mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_DEL_FTN, NULL));
 				mono_mb_emit_stloc (mb, conv_arg);
 			}
-		} else if (klass == mono_class_try_get_stringbuilder_class ()) {
+		} else if (klass == mono_defaults.stringbuilder_class) {
 			MonoMarshalNative encoding = mono_marshal_get_string_encoding (m->piinfo, spec);
 			MonoMarshalConv conv = mono_marshal_get_stringbuilder_to_ptr_conv (m->piinfo, spec);
 
@@ -5336,7 +5336,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		break;
 
 	case MARSHAL_ACTION_CONV_OUT:
-		if (klass == mono_class_try_get_stringbuilder_class ()) {
+		if (klass == mono_defaults.stringbuilder_class) {
 			gboolean need_free;
 			MonoMarshalNative encoding;
 			MonoMarshalConv conv;
@@ -5474,7 +5474,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			mono_mb_emit_ldloc (mb, 0);
 			mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_FTN_DEL, NULL));
 			mono_mb_emit_stloc (mb, 3);
-		} else if (klass == mono_class_try_get_stringbuilder_class ()) {
+		} else if (klass == mono_defaults.stringbuilder_class) {
 			// FIXME:
 			char *msg = g_strdup_printf ("Return marshalling of stringbuilders is not implemented.");
 			mono_mb_emit_exception_marshal_directive (mb, msg);
@@ -5531,7 +5531,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			break;
 		}
 
-		if (klass == mono_class_try_get_stringbuilder_class ()) {
+		if (klass == mono_defaults.stringbuilder_class) {
 			MonoMarshalNative encoding;
 
 			encoding = mono_marshal_get_string_encoding (m->piinfo, spec);
@@ -5640,7 +5640,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			emit_struct_conv (mb, klass, FALSE);
 
 			mono_mb_patch_branch (mb, pos2);
-		} else if (klass == mono_class_try_get_stringbuilder_class ()) {
+		} else if (klass == mono_defaults.stringbuilder_class) {
 			// FIXME: What to do here ?
 		} else {
 			/* byval [Out] marshalling */

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -114,8 +114,7 @@ MonoDelegateHandle
 mono_ftnptr_to_delegate_handle (MonoClass *klass, gpointer ftn, MonoError *error);
 
 /* Lazy class loading functions */
-//used by marshal-ilgen.c
-GENERATE_TRY_GET_CLASS_WITH_CACHE (stringbuilder, "System.Text", "StringBuilder");
+static GENERATE_GET_CLASS_WITH_CACHE (string_builder, "System.Text", "StringBuilder");
 static GENERATE_TRY_GET_CLASS_WITH_CACHE (unmanaged_function_pointer_attribute, "System.Runtime.InteropServices", "UnmanagedFunctionPointerAttribute");
 
 static MonoImage*
@@ -834,8 +833,8 @@ mono_string_builder_new (int starting_string_length)
 		MonoMethodDesc *desc;
 		MonoMethod *m;
 
-		string_builder_class = mono_class_try_get_stringbuilder_class ();
-		g_assert (string_builder_class); //TODO don't swallow the error
+		string_builder_class = mono_class_get_string_builder_class ();
+		g_assert (string_builder_class);
 		desc = mono_method_desc_new (":.ctor(int)", FALSE);
 		m = mono_method_desc_search_in_class (desc, string_builder_class);
 		g_assert (m);
@@ -1502,7 +1501,7 @@ mono_marshal_need_free (MonoType *t, MonoMethodPInvoke *piinfo, MonoMarshalSpec 
 		return TRUE;
 	case MONO_TYPE_OBJECT:
 	case MONO_TYPE_CLASS:
-		if (t->data.klass == mono_class_try_get_stringbuilder_class ()) {
+		if (t->data.klass == mono_defaults.stringbuilder_class) {
 			gboolean need_free;
 			mono_marshal_get_ptr_to_stringbuilder_conv (piinfo, spec, &need_free);
 			return need_free;
@@ -3265,7 +3264,7 @@ mono_emit_marshal (EmitMarshalContext *m, int argnum, MonoType *t,
 			
 	switch (t->type) {
 	case MONO_TYPE_VALUETYPE:
-		if (t->data.klass == mono_class_try_get_handleref_class ())
+		if (t->data.klass == mono_defaults.handleref_class)
 			return get_marshal_cb ()->emit_marshal_handleref (m, argnum, t, spec, conv_arg, conv_arg_type, action);
 		
 		return get_marshal_cb ()->emit_marshal_vtype (m, argnum, t, spec, conv_arg, conv_arg_type, action);

--- a/mono/metadata/marshal.h
+++ b/mono/metadata/marshal.h
@@ -33,10 +33,6 @@ typedef const gunichar2 *mono_bstr_const;
 		mono_marshal_find_nonzero_bit_offset ((guint8*)&tmp, sizeof (tmp), (byte_offset), (bitmask)); \
 	} while (0)
 
-
-GENERATE_TRY_GET_CLASS_WITH_CACHE_DECL(stringbuilder)
-
-
 /*
  * This structure holds the state kept by the emit_ marshalling functions.
  * This is exported so it can be used by cominterop.c.

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -6385,7 +6385,7 @@ handle_enum:
 			t = mono_class_enum_basetype (type->data.klass)->type;
 			goto handle_enum;
 		}
-		if (type->data.klass == mono_class_try_get_handleref_class ()){
+		if (type->data.klass == mono_defaults.handleref_class){
 			*conv = MONO_MARSHAL_CONV_HANDLEREF;
 			return MONO_NATIVE_INT;
 		}

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -80,7 +80,6 @@ static GENERATE_GET_CLASS_WITH_CACHE (unhandled_exception_event_args, "System", 
 static GENERATE_GET_CLASS_WITH_CACHE (sta_thread_attribute, "System", "STAThreadAttribute")
 static GENERATE_GET_CLASS_WITH_CACHE (activation_services, "System.Runtime.Remoting.Activation", "ActivationServices")
 
-static GENERATE_GET_CLASS_WITH_CACHE (asyncresult, "System.Runtime.Remoting.Messaging", "AsyncResult");
 
 #define ldstr_lock() mono_coop_mutex_lock (&ldstr_section)
 #define ldstr_unlock() mono_coop_mutex_unlock (&ldstr_section)
@@ -7978,7 +7977,7 @@ mono_async_result_new (MonoDomain *domain, HANDLE handle, MonoObject *state, gpo
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	error_init (error);
-	MonoAsyncResult *res = (MonoAsyncResult *)mono_object_new_checked (domain, mono_class_get_asyncresult_class (), error);
+	MonoAsyncResult *res = (MonoAsyncResult *)mono_object_new_checked (domain, mono_defaults.asyncresult_class, error);
 	return_val_if_nok (error, NULL);
 	MonoObject *context = mono_runtime_capture_context (domain, error);
 	return_val_if_nok (error, NULL);

--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -19,7 +19,6 @@
 #include <mono/utils/mono-memory-model.h>
 
 static GENERATE_GET_CLASS_WITH_CACHE (runtime_helpers, "System.Runtime.CompilerServices", "RuntimeHelpers")
-static GENERATE_TRY_GET_CLASS_WITH_CACHE (math, "System", "Math")
 
 /* optimize the simple GetGenericValueImpl/SetGenericValueImpl generic icalls */
 static MonoInst*
@@ -133,7 +132,7 @@ llvm_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 		}
 	}
 	/* The LLVM backend supports these intrinsics */
-	if (cmethod->klass == mono_class_try_get_math_class ()) {
+	if (cmethod->klass == mono_defaults.math_class) {
 		if (strcmp (cmethod->name, "Sin") == 0) {
 			opcode = OP_SIN;
 		} else if (strcmp (cmethod->name, "Cos") == 0) {
@@ -1156,7 +1155,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 				mini_set_inline_failure (cfg, "MethodBase:GetCurrentMethod ()");
 			return ins;
 		}
-	} else if (cmethod->klass == mono_class_try_get_math_class ()) {
+	} else if (cmethod->klass == mono_defaults.math_class) {
 		/* 
 		 * There is general branchless code for Min/Max, but it does not work for 
 		 * all inputs:

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -56,9 +56,6 @@ static gboolean optimize_for_xen = TRUE;
 #define optimize_for_xen 0
 #endif
 
-static GENERATE_TRY_GET_CLASS_WITH_CACHE (math, "System", "Math")
-
-
 #define IS_IMM32(val) ((((guint64)val) >> 32) == 0)
 
 #define IS_REX(inst) (((inst) >= 0x40) && ((inst) <= 0x4f))
@@ -8252,7 +8249,7 @@ mono_arch_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMetho
 	MonoInst *ins = NULL;
 	int opcode = 0;
 
-	if (cmethod->klass == mono_class_try_get_math_class ()) {
+	if (cmethod->klass == mono_defaults.math_class) {
 		if (strcmp (cmethod->name, "Sin") == 0) {
 			opcode = OP_SIN;
 		} else if (strcmp (cmethod->name, "Cos") == 0) {

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -50,9 +50,6 @@ static gboolean optimize_for_xen = TRUE;
 #endif
 #endif
 
-static GENERATE_TRY_GET_CLASS_WITH_CACHE (math, "System", "Math")
-
-
 /* The single step trampoline */
 static gpointer ss_trampoline;
 
@@ -5787,7 +5784,7 @@ mono_arch_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMetho
 	MonoInst *ins = NULL;
 	int opcode = 0;
 
-	if (cmethod->klass == mono_class_try_get_math_class ()) {
+	if (cmethod->klass == mono_defaults.math_class) {
 		if (strcmp (cmethod->name, "Sin") == 0) {
 			opcode = OP_SIN;
 		} else if (strcmp (cmethod->name, "Cos") == 0) {


### PR DESCRIPTION
This reverts commit 577ab741b2b4eedc282d7c2072b05088a0f0cdb7.

To try to fix:

https://jenkins.mono-project.com/job/test-mono-pull-request-amd64/19377/parsed_console/log.html

     Mono issue #10276
    System.IO.Tests.MemoryStream_ConstructorTests.MemoryStream_Ctor_InvalidCapacities [FAIL]
      Assert.Throws() Failure
      Expected: typeof(System.OutOfMemoryException)
      Actual:   (No exception was thrown)
      Stack Trace:
          at System.IO.Tests.MemoryStream_ConstructorTests.MemoryStream_Ctor_InvalidCapacities () [0x0004a] in /mnt/jenkins/workspace/test-mono-pull-request-amd64/external/corefx/src/System.IO/tests/MemoryStream/MemoryStream.ConstructorTests.cs:38
          at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
          at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in /mnt/jenkins/workspace/test-mono-pull-request-amd64/mcs/class/corlib/System.Reflection/MonoMethod.cs:324
  Finished:    net_4_x_corlib_xunit-test
=== TEST EXECUTION SUMMARY ===
   net_4_x_corlib_xunit-test  Total: 91255, Errors: 0, Failed: 1, Skipped: 35, Time: 74.005s
make[2]: *** [run-xunit-test-lib] Error 1
../../build/tests.make:326: recipe for target 'run-xunit-test-lib' failed
make[2]: Leaving directory '/mnt/jenkins/workspace/test-mono-pull-request-amd64/mcs/class/corlib'
../../build/rules.make:216: recipe for target 'do-run-xunit-test' failed
make[1]: *** [do-run-xunit-test] Error 2
make[1]: Leaving directory '/mnt/jenkins/workspace/test-mono-pull-request-amd64/mcs/class/corlib'
/mnt/jenkins/workspace/test-mono-pull-request-amd64/scripts/ci/babysitter: Test suite terminated with code 2, will extract test results from XML. Halting.
*** end(93): corlib-xunit: Unstable
*** start: verify

https://jenkins.mono-project.com/job/test-mono-pull-request-amd64/19393/parsed_console/log.html

Unit.net Console Runner v2.4.0 (64-bit Desktop .NET 4.7.2, runtime: 4.0.30319.42000)
  Discovering: net_4_x_corlib_xunit-test
  Discovered:  net_4_x_corlib_xunit-test
  Starting:    net_4_x_corlib_xunit-test
    System.Reflection.Tests.MemberInfoTests.TestInheritedEventAccessors [SKIP]
      Mono issue #10277
    System.Reflection.Tests.MemberInfoTests.TestGenericMethodsInheritTheReflectedTypeOfTheirTemplate [SKIP]
      Mono issue #10276
    System.IO.Tests.MemoryStream_ConstructorTests.MemoryStream_Ctor_InvalidCapacities [FAIL]
      Assert.Throws() Failure
      Expected: typeof(System.OutOfMemoryException)
      Actual:   (No exception was thrown)
      Stack Trace:
          at System.IO.Tests.MemoryStream_ConstructorTests.MemoryStream_Ctor_InvalidCapacities () [0x0004a] in /mnt/jenkins/workspace/test-mono-pull-request-amd64/external/corefx/src/System.IO/tests/MemoryStream/MemoryStream.ConstructorTests.cs:38

