### PR TITLE
ifdef HAVE_ARRAY_ELEM_INIT is not actually guarding code that uses C99...

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3581,18 +3581,6 @@ ac_cv_c_socklen_t=yes
 	AC_MSG_RESULT(no)
 ])
 
-AC_MSG_CHECKING(for array element initializer support)
-AC_TRY_COMPILE([#include <sys/socket.h>], [
-	const int array[] = {[1] = 2,};
-], [
-	# Yes, we have it...
-	AC_MSG_RESULT(yes)
-	AC_DEFINE(HAVE_ARRAY_ELEM_INIT,1,[Supports C99 array initialization])
-], [
-	# We'll have to use signals
-	AC_MSG_RESULT(no)
-])
-
 AC_CHECK_FUNCS(execvp)
 
 dnl ****************************

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -41,7 +41,7 @@ struct MonoMethodDesc {
 	gboolean include_namespace, klass_glob, name_glob;
 };
 
-#ifdef HAVE_ARRAY_ELEM_INIT
+// This, instead of an array of pointers, to optimize away a pointer and a relocation per string.
 #define MSGSTRFIELD(line) MSGSTRFIELD1(line)
 #define MSGSTRFIELD1(line) str##line
 static const struct msgstr_t {
@@ -66,24 +66,6 @@ wrapper_type_to_str (guint32 wrapper_type)
 
 	return (const char*)&opstr + opidx [wrapper_type];
 }
-
-#else
-#define WRAPPER(a,b) b,
-static const char* const
-wrapper_type_names [MONO_WRAPPER_NUM + 1] = {
-#include "wrapper-types.h"
-	NULL
-};
-
-static const char*
-wrapper_type_to_str (guint32 wrapper_type)
-{
-	g_assert (wrapper_type < MONO_WRAPPER_NUM);
-
-	return wrapper_type_names [wrapper_type];
-}
-
-#endif
 
 static void
 append_class_name (GString *res, MonoClass *klass, gboolean include_namespace)

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -497,7 +497,7 @@ table_description [] = {
 	CUSTOMDEBUGINFORMATION_SCHEMA_OFFSET
 };
 
-#ifdef HAVE_ARRAY_ELEM_INIT
+// This, instead of an array of pointers, to optimize away a pointer and a relocation per string.
 #define MSGSTRFIELD(line) MSGSTRFIELD1(line)
 #define MSGSTRFIELD1(line) str##line
 static const struct msgstr_t {
@@ -514,16 +514,6 @@ static const gint16 tableidx [] = {
 #include "mono/cil/tables.def"
 #undef TABLEDEF
 };
-
-#else
-#define TABLEDEF(a,b) b,
-static const char* const
-mono_tables_names [] = {
-#include "mono/cil/tables.def"
-	NULL
-};
-
-#endif
 
 /* If TRUE (but also see DISABLE_STICT_STRONG_NAMES #define), Mono will check
  * that the public key token, culture and version of a candidate assembly matches
@@ -551,11 +541,7 @@ mono_meta_table_name (int table)
 	if ((table < 0) || (table > MONO_TABLE_LAST))
 		return "";
 
-#ifdef HAVE_ARRAY_ELEM_INIT
 	return (const char*)&tablestr + tableidx [table];
-#else
-	return mono_tables_names [table];
-#endif
 }
 
 /* The guy who wrote the spec for this should not be allowed near a

--- a/mono/metadata/opcodes.c
+++ b/mono/metadata/opcodes.c
@@ -27,7 +27,7 @@ mono_opcodes [MONO_CEE_LAST + 1] = {
 
 #undef OPDEF
 
-#ifdef HAVE_ARRAY_ELEM_INIT
+// This, instead of an array of pointers, to optimize away a pointer and a relocation per string.
 #define MSGSTRFIELD(line) MSGSTRFIELD1(line)
 #define MSGSTRFIELD1(line) str##line
 static const struct msgstr_t {
@@ -53,22 +53,6 @@ mono_opcode_name (int opcode)
 {
 	return (const char*)&opstr + opidx [opcode];
 }
-
-#else
-#define OPDEF(a,b,c,d,e,f,g,h,i,j) b,
-static const char* const
-mono_opcode_names [MONO_CEE_LAST + 1] = {
-#include "mono/cil/opcode.def"
-	NULL
-};
-
-const char*
-mono_opcode_name (int opcode)
-{
-	return mono_opcode_names [opcode];
-}
-
-#endif
 
 MonoOpcodeEnum
 mono_opcode_value (const mono_byte **ip, const mono_byte *end)

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -392,7 +392,7 @@ typedef struct {
 /* This points to the current acfg in LLVM mode */
 static MonoAotCompile *llvm_acfg;
 
-#ifdef HAVE_ARRAY_ELEM_INIT
+// This, instead of an array of pointers, to optimize away a pointer and a relocation per string.
 #define MSGSTRFIELD(line) MSGSTRFIELD1(line)
 #define MSGSTRFIELD1(line) str##line
 static const struct msgstr_t {
@@ -415,22 +415,6 @@ get_patch_name (int info)
 {
 	return (const char*)&opstr + opidx [info];
 }
-
-#else
-#define PATCH_INFO(a,b) b,
-static const char* const
-patch_types [MONO_PATCH_INFO_NUM + 1] = {
-#include "patch-info.h"
-	NULL
-};
-
-static G_GNUC_UNUSED const char*
-get_patch_name (int info)
-{
-	return patch_types [info];
-}
-
-#endif
 
 static void 
 mono_flush_method_cache (MonoAotCompile *acfg);

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -88,7 +88,8 @@ int _CRT_glob = 0;
 typedef void (*OptFunc) (const char *p);
 
 #undef OPTFLAG
-#ifdef HAVE_ARRAY_ELEM_INIT
+
+// This, instead of an array of pointers, to optimize away a pointer and a relocation per string.
 #define MSGSTRFIELD(line) MSGSTRFIELD1(line)
 #define MSGSTRFIELD1(line) str##line
 
@@ -109,23 +110,6 @@ static const gint16 opt_names [] = {
 
 #define optflag_get_name(id) ((const char*)&opstr + opt_names [(id)])
 #define optflag_get_desc(id) (optflag_get_name(id) + 1 + strlen (optflag_get_name(id)))
-
-#else /* !HAVE_ARRAY_ELEM_INIT */
-typedef struct {
-	const char* name;
-	const char* desc;
-} OptName;
-
-#define OPTFLAG(id,shift,name,desc) {name,desc},
-static const OptName 
-opt_names [] = {
-#include "optflags-def.h"
-	{NULL, NULL}
-};
-#define optflag_get_name(id) (opt_names [(id)].name)
-#define optflag_get_desc(id) (opt_names [(id)].desc)
-
-#endif
 
 #define DEFAULT_OPTIMIZATIONS (	\
 	MONO_OPT_PEEPHOLE |	\

--- a/mono/mini/helpers.c
+++ b/mono/mini/helpers.c
@@ -26,7 +26,7 @@
 #undef MINI_OP3
 #endif
 
-#ifdef HAVE_ARRAY_ELEM_INIT
+// This, instead of an array of pointers, to optimize away a pointer and a relocation per string.
 #define MSGSTRFIELD(line) MSGSTRFIELD1(line)
 #define MSGSTRFIELD1(line) str##line
 static const struct msgstr_t {
@@ -49,20 +49,6 @@ static const gint16 opidx [] = {
 #undef MINI_OP
 #undef MINI_OP3
 };
-
-#else
-
-#define MINI_OP(a,b,dest,src1,src2) b,
-#define MINI_OP3(a,b,dest,src1,src2,src3) b,
-/* keep in sync with the enum in mini.h */
-static const char* const
-opnames[] = {
-#include "mini-ops.h"
-};
-#undef MINI_OP
-#undef MINI_OP3
-
-#endif
 
 #endif /* DISABLE_LOGGING */
 
@@ -90,11 +76,7 @@ const char*
 mono_inst_name (int op) {
 #ifndef DISABLE_LOGGING
 	if (op >= OP_LOAD && op <= OP_LAST)
-#ifdef HAVE_ARRAY_ELEM_INIT
 		return (const char*)&opstr + opidx [op - OP_LOAD];
-#else
-		return opnames [op - OP_LOAD];
-#endif
 	if (op < OP_LOAD)
 		return mono_opcode_name (op);
 	g_error ("unknown opcode name for %d", op);

--- a/mono/mini/simd-intrinsics.c
+++ b/mono/mini/simd-intrinsics.c
@@ -95,7 +95,7 @@ enum {
 	SIMD_EMIT_PREFETCH
 };
 
-#ifdef HAVE_ARRAY_ELEM_INIT
+// This, instead of an array of pointers, to optimize away a pointer and a relocation per string.
 #define MSGSTRFIELD(line) MSGSTRFIELD1(line)
 #define MSGSTRFIELD1(line) str##line
 static const struct msgstr_t {
@@ -113,23 +113,6 @@ enum {
 #include "simd-methods.h"
 };
 #define method_name(idx) ((const char*)&method_names + (idx))
-
-#else
-#define SIMD_METHOD(str,name) str,
-static const char * const method_names [] = {
-#include "simd-methods.h"
-	NULL
-};
-#undef SIMD_METHOD
-#define SIMD_METHOD(str,name) name,
-enum {
-#include "simd-methods.h"
-	SN_LAST
-};
-
-#define method_name(idx) (method_names [(idx)])
-
-#endif
 
 typedef struct {
 	guint16 name;

--- a/winconfig.h
+++ b/winconfig.h
@@ -107,9 +107,6 @@
 /* Enable DTrace probes */
 /* #undef ENABLE_DTRACE */
 
-/* Supports C99 array initialization */
-/* #undef HAVE_ARRAY_ELEM_INIT */
-
 /* Define to 1 if you have the <attr/xattr.h> header file. */
 /* #undef HAVE_ATTR_XATTR_H */
 


### PR DESCRIPTION
...array initialization, but rather code that is portable to C89 and C++98.

The alternative is also ok, just costs typically a pointer and a relocation per array element,
things most people wouldn't notice but was presumably the point here.
