### PR TITLE
Adding check for empty string to correctly get constructors in case of "*" search criteria

### DIFF
--- a/mcs/class/referencesource/mscorlib/system/rttype.cs
+++ b/mcs/class/referencesource/mscorlib/system/rttype.cs
@@ -2849,7 +2849,7 @@ namespace System
             RuntimeType.FilterHelper(bindingAttr, ref name, allowPrefixLookup, out prefixLookup, out ignoreCase, out listType);
 
 #if MONO
-            if (name != null && name != ConstructorInfo.ConstructorName && name != ConstructorInfo.TypeConstructorName)
+            if (!string.IsNullOrEmpty (name) && name != ConstructorInfo.ConstructorName && name != ConstructorInfo.TypeConstructorName)
                 return new ListBuilder<ConstructorInfo> (0);
             RuntimeConstructorInfo[] cache = GetConstructors_internal (bindingAttr, this);
 #else


### PR DESCRIPTION
The following code
```
MemberInfo[] members = typeof(MyClassWithCtor).GetMember("*", MemberTypes.Constructor, BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
```
returns an empty array because `*` passed as search criteria becomes unexpected empty string later.
But `.ctor` or `.ctor*` works as expected.

The fix is to add a check for empty string.