### PR TITLE
[sdks] Add cmake toolchain file for LLVM MXE builds

### DIFF
--- a/sdks/builds/.gitignore
+++ b/sdks/builds/.gitignore
@@ -43,3 +43,5 @@ bcl/
 desktop-x86/
 desktop-x86_64/
 toolchains/
+mxe-Win32.cmake
+mxe-Win64.cmake

--- a/sdks/builds/mxe-Win32.cmake.in
+++ b/sdks/builds/mxe-Win32.cmake.in
@@ -1,0 +1,20 @@
+# the name of the target operating system
+set(CMAKE_SYSTEM_NAME Windows)
+
+# here is the target environment located
+set(CMAKE_FIND_ROOT_PATH @MXE_PATH@)
+
+# which compilers to use for C and C++
+set(CMAKE_C_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/i686-w64-mingw32@MXE_SUFFIX@-gcc)
+set(CMAKE_CXX_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/i686-w64-mingw32@MXE_SUFFIX@-g++)
+set(CMAKE_RC_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/i686-w64-mingw32@MXE_SUFFIX@-windres)
+
+# adjust the default behaviour of the FIND_XXX() commands:
+# search headers and libraries in the target environment, search
+# programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+set(BUILD_SHARED_LIBS ON)

--- a/sdks/builds/mxe-Win64.cmake.in
+++ b/sdks/builds/mxe-Win64.cmake.in
@@ -1,0 +1,20 @@
+# the name of the target operating system
+set(CMAKE_SYSTEM_NAME Windows)
+
+# here is the target environment located
+set(CMAKE_FIND_ROOT_PATH @MXE_PATH@)
+
+# which compilers to use for C and C++
+set(CMAKE_C_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/x86_64-w64-mingw32@MXE_SUFFIX@-gcc)
+set(CMAKE_CXX_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/x86_64-w64-mingw32@MXE_SUFFIX@-g++)
+set(CMAKE_RC_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/x86_64-w64-mingw32@MXE_SUFFIX@-windres)
+
+# adjust the default behaviour of the FIND_XXX() commands:
+# search headers and libraries in the target environment, search
+# programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+set(BUILD_SHARED_LIBS ON)

--- a/sdks/builds/wasm.mk
+++ b/sdks/builds/wasm.mk
@@ -153,7 +153,7 @@ _wasm-$(1)_CONFIGURE_FLAGS= \
 
 $$(eval $$(call CrossRuntimeTemplate,wasm-$(1),$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static),$(3)-unknown-none,$(4),$(5),$(6)))
 
-# wasm_TARGETS += wasm-$(1)-$$(CONFIGURATION)
+wasm_TARGETS += wasm-$(1)-$$(CONFIGURATION) $(5)
 
 endef
 


### PR DESCRIPTION
We couldn't compile `llvmwin{32,64}` on Linux because we would try to use `{i686,x86_64}-w64-mingw-cmake` but it wouldn't exist.