### PR TITLE
Depend on all *_test.dll.sources for `make run-test`

### DIFF
--- a/mcs/build/library.make
+++ b/mcs/build/library.make
@@ -286,8 +286,8 @@ endif
 # The library
 
 # If the directory contains the per profile include file, generate list file.
-# TODO: depend on all *.sources for now and figure out how to list only needed files later
-PROFILE_sources = $(wildcard *.sources)
+# TODO: depend on all *.sources (except tests) for now and figure out how to list only needed files later
+PROFILE_sources = $(filter-out %_test.dll.exclude.sources %test.dll.sources, $(wildcard *.sources))
 
 ifneq "x" "x$(PROFILE_RUNTIME)"
 GENSOURCES_RUNTIME=$(PROFILE_RUNTIME)

--- a/mcs/build/library.make
+++ b/mcs/build/library.make
@@ -287,7 +287,7 @@ endif
 
 # If the directory contains the per profile include file, generate list file.
 # TODO: depend on all *.sources (except tests) for now and figure out how to list only needed files later
-PROFILE_sources = $(filter-out %_test.dll.exclude.sources %test.dll.sources, $(wildcard *.sources))
+PROFILE_sources = $(filter-out %test.dll.exclude.sources %test.dll.sources, $(wildcard *.sources))
 
 ifneq "x" "x$(PROFILE_RUNTIME)"
 GENSOURCES_RUNTIME=$(PROFILE_RUNTIME)

--- a/mcs/build/tests.make
+++ b/mcs/build/tests.make
@@ -272,7 +272,7 @@ endif
 
 # This handles .excludes/.sources pairs, as well as resolving the
 # includes that occur in .sources files
-$(test_response_preprocessed): $(test_sourcefile) $(wildcard $(test_sourcefile_excludes)) $(GENSOURCES_CS)
+$(test_response_preprocessed): $(test_sourcefile) $(wildcard *_test.dll.sources) $(wildcard *_test.dll.exclude.sources) $(GENSOURCES_CS)
 	$(GENSOURCES_RUNTIME) --debug $(GENSOURCES_EXE) --basedir:./Test --strict "$@" "$(test_sourcefile)" "$(test_sourcefile_excludes)"
 
 $(test_response): $(test_response_preprocessed)


### PR DESCRIPTION
Also, do not rebuild main library if test.sources were changed
