### PR TITLE
AOT: use 32 bit flags for as/ld when targetting x86 on linux

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -11269,6 +11269,8 @@ compile_asm (MonoAotCompile *acfg)
 #define AS_OPTIONS "-xarch=v9"
 #elif defined(TARGET_X86) && defined(TARGET_MACH)
 #define AS_OPTIONS "-arch i386"
+#elif defined(TARGET_X86) && !defined(TARGET_MACH)
+#define AS_OPTIONS "--32"
 #else
 #define AS_OPTIONS ""
 #endif
@@ -11306,6 +11308,8 @@ compile_asm (MonoAotCompile *acfg)
 #elif defined(TARGET_X86) && defined(TARGET_MACH)
 #define LD_NAME "clang"
 #define LD_OPTIONS "-m32 -dynamiclib"
+#elif defined(TARGET_X86) && !defined(TARGET_MACH)
+#define LD_OPTIONS "-m elf_i386"
 #elif defined(TARGET_ARM) && !defined(TARGET_ANDROID)
 #define LD_NAME "gcc"
 #define LD_OPTIONS "--shared"


### PR DESCRIPTION
So it works when running the 64bit as/ld on the host with a 32bit mono binary.