### PR TITLE
[Reflection] Fixing bugs in MonoParameterInfo caught by xunit tests

### DIFF
--- a/mcs/class/corlib/System.Reflection/MonoParameterInfo.cs
+++ b/mcs/class/corlib/System.Reflection/MonoParameterInfo.cs
@@ -128,7 +128,7 @@ namespace System.Reflection
 		internal MonoParameterInfo (Type type, MemberInfo member, MarshalAsAttribute marshalAs) {
 			this.ClassImpl = type;
 			this.MemberImpl = member;
-			this.NameImpl = "";
+			this.NameImpl = null;
 			this.PositionImpl = -1;	// since parameter positions are zero-based, return type pos is -1
 			this.AttrsImpl = ParameterAttributes.Retval;
 			this.marshalAs = marshalAs;
@@ -155,6 +155,8 @@ namespace System.Reflection
 		public override
 		object RawDefaultValue {
 			get {
+				if (DefaultValue.GetType ().IsEnum)
+					return ((Enum)DefaultValue).GetValue ();
 				/*FIXME right now DefaultValue doesn't throw for reflection-only assemblies. Change this once the former is fixed.*/
 				return DefaultValue;
 			}

--- a/mcs/class/corlib/System.Reflection/MonoParameterInfo.cs
+++ b/mcs/class/corlib/System.Reflection/MonoParameterInfo.cs
@@ -155,7 +155,7 @@ namespace System.Reflection
 		public override
 		object RawDefaultValue {
 			get {
-				if (DefaultValue.GetType ().IsEnum)
+				if (DefaultValue != null && DefaultValue.GetType ().IsEnum)
 					return ((Enum)DefaultValue).GetValue ();
 				/*FIXME right now DefaultValue doesn't throw for reflection-only assemblies. Change this once the former is fixed.*/
 				return DefaultValue;


### PR DESCRIPTION
This PR fixes the bugs caught by [RawDefaultValue](https://github.com/mono/corefx/blob/411def5f278956f3c514c02ab76d9bb89428fef7/src/System.Runtime/tests/System/Reflection/ParameterInfoTests.cs#L22) and [VerifyParameterInfoGetRealObjectWorks](https://github.com/mono/corefx/blob/411def5f278956f3c514c02ab76d9bb89428fef7/src/System.Runtime/tests/System/Reflection/ParameterInfoTests.cs#L91) tests