### PR TITLE
[2018-10] [sdks] Add cmake toolchain file for LLVM MXE builds

### DIFF
--- a/sdks/builds/.gitignore
+++ b/sdks/builds/.gitignore
@@ -43,3 +43,5 @@ bcl/
 desktop-x86/
 desktop-x86_64/
 toolchains/
+mxe-Win32.cmake
+mxe-Win64.cmake

--- a/sdks/builds/llvm.mk
+++ b/sdks/builds/llvm.mk
@@ -6,8 +6,6 @@ $(TOP)/sdks/builds/toolchains/llvm:
 	$(MAKE) -C $(TOP)/llvm -f build.mk $@/CMakeLists.txt \
 		LLVM_PATH="$@"
 
-$(LLVM_SRC)/CMakeLists.txt: | $(LLVM_SRC)
-
 LLVM36_SRC?=$(TOP)/sdks/builds/toolchains/llvm36
 
 $(TOP)/sdks/builds/toolchains/llvm36:
@@ -21,9 +19,9 @@ $(LLVM36_SRC)/configure: | $(LLVM36_SRC)
 # Parameters
 #  $(1): version
 #  $(2): target
-#  $(3): configure script
+#  $(3): src
 define LLVMProvisionTemplate
-_$(1)-$(2)_HASH = $$(shell git -C $$(dir $(3)) rev-parse HEAD)
+_$(1)-$(2)_HASH = $$(shell git -C $(3) rev-parse HEAD)
 _$(1)-$(2)_PACKAGE = $(1)-$(2)-$$(_$(1)-$(2)_HASH)-$$(UNAME).tar.gz
 _$(1)-$(2)_URL = "http://xamjenkinsartifact.blob.core.windows.net/mono-sdks/$$(_$(1)-$(2)_PACKAGE)"
 
@@ -32,11 +30,11 @@ $$(TOP)/sdks/out/$(1)-$(2)/.stamp-download:
 	touch $$@
 
 .PHONY: download-$(1)-$(2)
-download-$(1)-$(2): $(3) | setup-$(1)-$(2)
+download-$(1)-$(2): | $(3) setup-$(1)-$(2)
 	-$$(MAKE) $$(TOP)/sdks/out/$(1)-$(2)/.stamp-download
 
 .PHONY: provision-$(1)-$(2)
-provision-$(1)-$(2): $(3) | download-$(1)-$(2)
+provision-$(1)-$(2): | $(3) download-$(1)-$(2)
 	$$(if $$(wildcard $$(TOP)/sdks/out/$(1)-$(2)/.stamp-download),,$$(MAKE) package-$(1)-$(2))
 
 .PHONY: archive-$(1)-$(2)
@@ -44,12 +42,12 @@ archive-$(1)-$(2): package-$(1)-$(2)
 	tar -cvzf $$(TOP)/$$(_$(1)-$(2)_PACKAGE) -C $$(TOP)/sdks/out/$(1)-$(2) .
 endef
 
-$(eval $(call LLVMProvisionTemplate,llvm,llvm32,$(LLVM_SRC)/CMakeLists.txt))
-$(eval $(call LLVMProvisionTemplate,llvm,llvm64,$(LLVM_SRC)/CMakeLists.txt))
-$(eval $(call LLVMProvisionTemplate,llvm,llvmwin32,$(LLVM_SRC)/CMakeLists.txt))
-$(eval $(call LLVMProvisionTemplate,llvm,llvmwin64,$(LLVM_SRC)/CMakeLists.txt))
+$(eval $(call LLVMProvisionTemplate,llvm,llvm32,$(LLVM_SRC)))
+$(eval $(call LLVMProvisionTemplate,llvm,llvm64,$(LLVM_SRC)))
+$(eval $(call LLVMProvisionTemplate,llvm,llvmwin32,$(LLVM_SRC)))
+$(eval $(call LLVMProvisionTemplate,llvm,llvmwin64,$(LLVM_SRC)))
 ifeq ($(UNAME),Darwin)
-$(eval $(call LLVMProvisionTemplate,llvm36,llvm32,$(LLVM36_SRC)/configure))
+$(eval $(call LLVMProvisionTemplate,llvm36,llvm32,$(LLVM36_SRC)))
 endif
 
 ##
@@ -65,7 +63,7 @@ setup-llvm-$(1):
 	mkdir -p $$(TOP)/sdks/out/llvm-$(1)
 
 .PHONY: package-llvm-$(1)
-package-llvm-$(1): setup-llvm-$(1) $$(LLVM_SRC)/CMakeLists.txt
+package-llvm-$(1): setup-llvm-$(1) | $$(LLVM_SRC)
 	$$(MAKE) -C $$(TOP)/llvm -f build.mk install-llvm \
 		LLVM_PATH="$$(LLVM_SRC)" \
 		LLVM_BUILD="$$(TOP)/sdks/builds/llvm-$(1)" \
@@ -146,27 +144,29 @@ endif
 # Parameters
 #  $(1): target
 #  $(2): arch
+#  $(3): mxe
 define LLVMMxeTemplate
-
-_llvm-$(1)_CMAKE=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $$(UNAME),Darwin),.static)-cmake
 
 # -DCROSS_TOOLCHAIN_FLAGS_NATIVE is needed to compile the native tools (tlbgen) using the host compilers
 # -DLLVM_ENABLE_THREADS=0 is needed because mxe doesn't define std::mutex etc.
 # -DLLVM_BUILD_EXECUTION_ENGINE=Off is needed because it depends on threads
 _llvm-$(1)_CMAKE_ARGS = \
-	-DCROSS_TOOLCHAIN_FLAGS_NATIVE=-DCMAKE_TOOLCHAIN_FILE=$(LLVM_SRC)/cmake/modules/NATIVE.cmake \
+	-DCROSS_TOOLCHAIN_FLAGS_NATIVE=-DCMAKE_TOOLCHAIN_FILE=$$(LLVM_SRC)/cmake/modules/NATIVE.cmake \
+	-DCMAKE_TOOLCHAIN_FILE=$$(LLVM_SRC)/cmake/modules/$(3).cmake \
 	-DLLVM_ENABLE_THREADS=Off \
 	-DLLVM_BUILD_EXECUTION_ENGINE=Off \
 	$$(llvm-$(1)_CMAKE_ARGS)
+
+$$(LLVM_SRC)/cmake/modules/$(3).cmake: $(3).cmake.in | $$(LLVM_SRC)
+	sed -e 's,@MXE_PATH@,$$(MXE_PREFIX),' -e 's,@MXE_SUFFIX@,$$(if $$(filter $(UNAME),Darwin),.static),' < $$< > $$@
 
 .PHONY: setup-llvm-$(1)
 setup-llvm-$(1):
 	mkdir -p $$(TOP)/sdks/out/llvm-$(1)
 
 .PHONY: package-llvm-$(1)
-package-llvm-$(1): setup-llvm-$(1) $$(LLVM_SRC)/CMakeLists.txt
+package-llvm-$(1): $$(LLVM_SRC)/cmake/modules/$(3).cmake setup-llvm-$(1) | $$(LLVM_SRC)
 	$$(MAKE) -C $$(TOP)/llvm -f build.mk install-llvm \
-		CMAKE=$$(_llvm-$(1)_CMAKE) \
 		LLVM_PATH="$$(LLVM_SRC)" \
 		LLVM_BUILD="$$(TOP)/sdks/builds/llvm-$(1)" \
 		LLVM_PREFIX="$$(TOP)/sdks/out/llvm-$(1)" \
@@ -175,7 +175,6 @@ package-llvm-$(1): setup-llvm-$(1) $$(LLVM_SRC)/CMakeLists.txt
 .PHONY: clean-llvm-$(1)
 clean-llvm-$(1)::
 	$$(MAKE) -C $$(TOP)/llvm -f build.mk clean-llvm \
-		CMAKE=$$(_llvm-$(1)_CMAKE) \
 		LLVM_PATH="$$(LLVM_SRC)" \
 		LLVM_BUILD="$$(TOP)/sdks/builds/llvm-$(1)" \
 		LLVM_PREFIX="$$(TOP)/sdks/out/llvm-$(1)"
@@ -184,6 +183,6 @@ endef
 
 ifneq ($(MXE_PREFIX),)
 llvm-llvmwin32_CMAKE_ARGS=-DLLVM_BUILD_32_BITS=On
-$(eval $(call LLVMMxeTemplate,llvmwin32,i686))
-$(eval $(call LLVMMxeTemplate,llvmwin64,x86_64))
+$(eval $(call LLVMMxeTemplate,llvmwin32,i686,mxe-Win32))
+$(eval $(call LLVMMxeTemplate,llvmwin64,x86_64,mxe-Win64))
 endif

--- a/sdks/builds/mxe-Win32.cmake.in
+++ b/sdks/builds/mxe-Win32.cmake.in
@@ -1,0 +1,20 @@
+# the name of the target operating system
+set(CMAKE_SYSTEM_NAME Windows)
+
+# here is the target environment located
+set(CMAKE_FIND_ROOT_PATH @MXE_PATH@)
+
+# which compilers to use for C and C++
+set(CMAKE_C_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/i686-w64-mingw32@MXE_SUFFIX@-gcc)
+set(CMAKE_CXX_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/i686-w64-mingw32@MXE_SUFFIX@-g++)
+set(CMAKE_RC_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/i686-w64-mingw32@MXE_SUFFIX@-windres)
+
+# adjust the default behaviour of the FIND_XXX() commands:
+# search headers and libraries in the target environment, search
+# programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+set(BUILD_SHARED_LIBS ON)

--- a/sdks/builds/mxe-Win64.cmake.in
+++ b/sdks/builds/mxe-Win64.cmake.in
@@ -1,0 +1,20 @@
+# the name of the target operating system
+set(CMAKE_SYSTEM_NAME Windows)
+
+# here is the target environment located
+set(CMAKE_FIND_ROOT_PATH @MXE_PATH@)
+
+# which compilers to use for C and C++
+set(CMAKE_C_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/x86_64-w64-mingw32@MXE_SUFFIX@-gcc)
+set(CMAKE_CXX_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/x86_64-w64-mingw32@MXE_SUFFIX@-g++)
+set(CMAKE_RC_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/x86_64-w64-mingw32@MXE_SUFFIX@-windres)
+
+# adjust the default behaviour of the FIND_XXX() commands:
+# search headers and libraries in the target environment, search
+# programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+set(BUILD_SHARED_LIBS ON)

--- a/sdks/builds/wasm.mk
+++ b/sdks/builds/wasm.mk
@@ -153,7 +153,7 @@ _wasm-$(1)_CONFIGURE_FLAGS= \
 
 $$(eval $$(call CrossRuntimeTemplate,wasm-$(1),$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static),$(3)-unknown-none,$(4),$(5),$(6)))
 
-# wasm_TARGETS += wasm-$(1)-$$(CONFIGURATION)
+wasm_TARGETS += wasm-$(1)-$$(CONFIGURATION) $(5)
 
 endef
 


### PR DESCRIPTION
Backport https://github.com/mono/mono/pull/11008

We couldn't compile llvmwin{32,64} on Linux because we would try to use {i686,x86_64}-w64-mingw-cmake but it wouldn't exist.