### PR TITLE
Always use InvariantCulture calendars in X509Certificate on Mobile

### DIFF
--- a/mcs/class/corlib/System.Security.Cryptography.X509Certificates/X509Certificate.cs
+++ b/mcs/class/corlib/System.Security.Cryptography.X509Certificates/X509Certificate.cs
@@ -608,10 +608,13 @@ namespace System.Security.Cryptography.X509Certificates
 			if (!culture.DateTimeFormat.Calendar.IsValidDay (date.Year, date.Month, date.Day, 0)) {
 				// The most common case of culture failing to work is in the Um-AlQuara calendar. In this case,
 				// we can fall back to the Hijri calendar, otherwise fall back to the invariant culture.
+#if !MOBILE
 				if (culture.DateTimeFormat.Calendar is UmAlQuraCalendar) {
 					culture = culture.Clone () as CultureInfo;
 					culture.DateTimeFormat.Calendar = new HijriCalendar ();
-				} else {
+				} else
+#endif
+				{
 					culture = CultureInfo.InvariantCulture;
 				}
 			}


### PR DESCRIPTION
Allow the linker to remove UmAlQuraCalendar and HijriCalendar on mobile devices

Match the CoreFX X509Certificate changes: https://github.com/mono/corefx/commit/4eb1fc2abd2ffa70e402d22415d0209b21725a10

Fixes https://github.com/mono/mono/issues/10448
