### PR TITLE
[exceptions] continue program execution when mapping of stack overflow guard page fails

### DIFF
--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2791,7 +2791,7 @@ mono_setup_altstack (MonoJitTlsData *tls)
 				g_assert (gaddr == tls->stack_ovf_guard_base);
 				tls->stack_ovf_valloced = TRUE;
 			} else {
-				/* couldn't allocate guard page, continue without it */
+				g_warning ("couldn't allocate guard page, continue without it");
 				tls->stack_ovf_guard_base = NULL;
 				tls->stack_ovf_guard_size = 0;
 			}

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2787,8 +2787,14 @@ mono_setup_altstack (MonoJitTlsData *tls)
 		if (mono_mprotect (tls->stack_ovf_guard_base, tls->stack_ovf_guard_size, MONO_MMAP_NONE)) {
 			/* mprotect can fail for the main thread stack */
 			gpointer gaddr = mono_valloc (tls->stack_ovf_guard_base, tls->stack_ovf_guard_size, MONO_MMAP_NONE|MONO_MMAP_PRIVATE|MONO_MMAP_ANON|MONO_MMAP_FIXED, MONO_MEM_ACCOUNT_EXCEPTIONS);
-			g_assert (gaddr == tls->stack_ovf_guard_base);
-			tls->stack_ovf_valloced = TRUE;
+			if (gaddr) {
+				g_assert (gaddr == tls->stack_ovf_guard_base);
+				tls->stack_ovf_valloced = TRUE;
+			} else {
+				/* couldn't allocate guard page, continue without it */
+				tls->stack_ovf_guard_base = NULL;
+				tls->stack_ovf_guard_size = 0;
+			}
 		}
 	}
 

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2809,7 +2809,11 @@ mono_setup_altstack (MonoJitTlsData *tls)
 	sa.ss_flags = 0;
 	g_assert (sigaltstack (&sa, NULL) == 0);
 
-	mono_gc_register_altstack ((char*)tls->stack_ovf_guard_base + tls->stack_ovf_guard_size, (char*)staddr + stsize - ((char*)tls->stack_ovf_guard_base + tls->stack_ovf_guard_size), tls->signal_stack, tls->signal_stack_size);
+	if (tls->stack_ovf_guard_base)
+		mono_gc_register_altstack ((char*)tls->stack_ovf_guard_base + tls->stack_ovf_guard_size, (char*)staddr + stsize - ((char*)tls->stack_ovf_guard_base + tls->stack_ovf_guard_size), tls->signal_stack, tls->signal_stack_size);
+	else
+		mono_gc_register_altstack (staddr, stsize, tls->signal_stack, tls->signal_stack_size);
+
 }
 
 void


### PR DESCRIPTION
Related: https://github.com/mono/mono/issues/10415
