### PR TITLE
[runtime] Fix internal llvm

### DIFF
--- a/llvm/build.mk
+++ b/llvm/build.mk
@@ -1,10 +1,10 @@
-top_srcdir ?= $(abspath $(CURDIR)/..)
+abs_top_srcdir ?= $(abspath $(CURDIR)/..)
 
-LLVM_BUILD ?= $(abspath $(top_srcdir)/llvm/build)
-LLVM_PREFIX ?= $(abspath $(top_srcdir)/llvm/usr)
+LLVM_BUILD ?= $(abspath $(abs_top_srcdir)/llvm/build)
+LLVM_PREFIX ?= $(abspath $(abs_top_srcdir)/llvm/usr)
 
-# LLVM_BRANCH  := $(shell git -C "$(top_srcdir)/external/llvm" rev-parse --abbrev-ref HEAD)
-LLVM_VERSION := $(shell git -C "$(top_srcdir)/external/llvm" rev-parse HEAD)
+# LLVM_BRANCH  := $(shell git -C "$(abs_top_srcdir)/external/llvm" rev-parse --abbrev-ref HEAD)
+LLVM_VERSION := $(shell git -C "$(abs_top_srcdir)/external/llvm" rev-parse HEAD)
 
 # FIXME: URL should be http://xamjenkinsartifact.blob.core.windows.net/build-package-osx-llvm-$(LLVM_BRANCH)/llvm-osx64-$(LLVM_VERSION).tar.gz
 LLVM_DOWNLOAD_LOCATION = "http://xamjenkinsartifact.blob.core.windows.net/build-package-osx-llvm-release60/llvm-osx64-$(LLVM_VERSION).tar.gz"
@@ -17,7 +17,7 @@ $(LLVM_BUILD) $(LLVM_PREFIX):
 
 EXTRA_LLVM_ARGS = $(if $(filter $(LLVM_TARGET),wasm32), -DLLVM_BUILD_32_BITS=On -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="WebAssembly",)
 
-$(LLVM_BUILD)/$(if $(NINJA),build.ninja,Makefile): $(top_srcdir)/external/llvm/CMakeLists.txt | $(LLVM_BUILD) $(LLVM_PREFIX)
+$(LLVM_BUILD)/$(if $(NINJA),build.ninja,Makefile): $(abs_top_srcdir)/external/llvm/CMakeLists.txt | $(LLVM_BUILD) $(LLVM_PREFIX)
 	cd $(LLVM_BUILD) && $(CMAKE) \
 		$(if $(NINJA),-G Ninja) \
 		-DCMAKE_INSTALL_PREFIX="$(LLVM_PREFIX)" \
@@ -31,7 +31,7 @@ $(LLVM_BUILD)/$(if $(NINJA),build.ninja,Makefile): $(top_srcdir)/external/llvm/C
 		$(EXTRA_LLVM_ARGS)	\
 		-DLLVM_ENABLE_ASSERTIONS=$(if $(INTERNAL_LLVM_ASSERTS),On,Off) \
 		$(LLVM_CMAKE_ARGS) \
-		$(dir $<)
+		$(abs_top_srcdir)/external/llvm
 
 .PHONY: configure-llvm
 configure-llvm: $(LLVM_BUILD)/$(if $(NINJA),build.ninja,Makefile)


### PR DESCRIPTION
Previously:

```
remake[2]: Leaving directory '/home/builder/mono/po'
Making all in llvm
Reading makefiles...
remake[2]: Entering directory '/home/builder/mono/llvm'
Updating goal targets....
 File 'all' does not exist.
   File 'all-am' does not exist.
     File 'all-local' does not exist.
       File 'configure-llvm' does not exist.
         File '/home/builder/mono/llvm/build/Makefile' does not exist.
        Must remake target '/home/builder/mono/llvm/build/Makefile'.
Makefile:604: update target '/home/builder/mono/llvm/build/Makefile' due to: ../external/llvm/CMakeLists.txt
##>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
cd /home/builder/mono/llvm/build && /usr/bin/cmake \
         \
        -DCMAKE_INSTALL_PREFIX="/home/builder/mono/llvm/usr" \
        -DCMAKE_BUILD_TYPE=Release \
        -DLLVM_BUILD_TESTS=Off \
        -DLLVM_INCLUDE_TESTS=Off \
        -DLLVM_BUILD_EXAMPLES=Off \
        -DLLVM_INCLUDE_EXAMPLES=Off \
        -DLLVM_TOOLS_TO_BUILD="opt;llc;llvm-config;llvm-dis" \
        -DLLVM_TARGETS_TO_BUILD="X86;ARM;AArch64" \
                \
        -DLLVM_ENABLE_ASSERTIONS=Off \
         \
        ../external/llvm/
##<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
CMake Error: The source directory "/home/builder/mono/llvm/external/llvm" does not exist.
Specify --help for usage, or press the help button on the CMake GUI.
Makefile:604: recipe for target '/home/builder/mono/llvm/build/Makefile' failed
Makefile:603: *** [/home/builder/mono/llvm/build/Makefile] Error 1

#0  /home/builder/mono/llvm/build/Makefile at /home/builder/mono/llvm/Makefile:603
#1  configure-llvm at /home/builder/mono/llvm/Makefile:620
#2  all-local at /home/builder/mono/llvm/Makefile:570
#3  all-am at /home/builder/mono/llvm/Makefile:455
#4  all at /home/builder/mono/llvm/Makefile:377
remake[2]: Leaving directory '/home/builder/mono/llvm'
Makefile:544: recipe for target 'all-recursive' failed
Makefile:543: *** [all-recursive] Error 1
```