### PR TITLE
mono_method_signature to mono_method_signature_internal to skip GC mode machinery

### DIFF
--- a/mono/dis/dump.c
+++ b/mono/dis/dump.c
@@ -968,7 +968,7 @@ dump_table_customattr (MonoImage *m)
 		method = get_method (m, mtoken, NULL);
 		meth = mono_get_method_checked (m, mtoken, NULL, NULL, error);
 		if (meth) {
-			params = custom_attr_params (m, mono_method_signature (meth), mono_metadata_blob_heap (m, cols [MONO_CUSTOM_ATTR_VALUE]));
+			params = custom_attr_params (m, mono_method_signature_internal (meth), mono_metadata_blob_heap (m, cols [MONO_CUSTOM_ATTR_VALUE]));
 			fprintf (output, "%d: %s: %s [%s]\n", i, desc, method, params);
 			g_free (params);
 		} else {

--- a/mono/dis/get.c
+++ b/mono/dis/get.c
@@ -1947,7 +1947,7 @@ get_method_core (MonoImage *m, guint32 token, gboolean fullsig, MonoGenericConta
 
 	mh = mono_get_method_checked (m, token, NULL, (MonoGenericContext *) container, error);
 	if (mh) {
-		if (mono_method_signature (mh)->is_inflated)
+		if (mono_method_signature_internal (mh)->is_inflated)
 			container = mono_method_get_generic_container (((MonoMethodInflated *) mh)->declaring);
 		esname = get_escaped_name (mh->name);
 		sig = dis_stringify_type (m, m_class_get_byval_arg (mh->klass), TRUE);

--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -1917,8 +1917,8 @@ mono_signature_get_full_desc (MonoMethodSignature *sig, gboolean include_namespa
 }
 static void
 print_method_signatures (MonoMethod *im, MonoMethod *cm) {
-	char *im_sig = mono_signature_get_full_desc (mono_method_signature (im), TRUE);
-	char *cm_sig = mono_signature_get_full_desc (mono_method_signature (cm), TRUE);
+	char *im_sig = mono_signature_get_full_desc (mono_method_signature_internal (im), TRUE);
+	char *cm_sig = mono_signature_get_full_desc (mono_method_signature_internal (cm), TRUE);
 	printf ("(IM \"%s\", CM \"%s\")", im_sig, cm_sig);
 	g_free (im_sig);
 	g_free (cm_sig);
@@ -1962,8 +1962,8 @@ check_interface_method_override (MonoClass *klass, MonoMethod *im, MonoMethod *c
 				TRACE_INTERFACE_VTABLE (printf ("[FULL SLOT REFUSED]"));
 			}
 		}
-		cmsig = mono_method_signature (cm);
-		imsig = mono_method_signature (im);
+		cmsig = mono_method_signature_internal (cm);
+		imsig = mono_method_signature_internal (im);
 		if (!cmsig || !imsig) {
 			mono_class_set_type_load_failure (klass, "Could not resolve the signature of a virtual method");
 			return FALSE;
@@ -2004,8 +2004,8 @@ check_interface_method_override (MonoClass *klass, MonoMethod *im, MonoMethod *c
 			TRACE_INTERFACE_VTABLE (printf ("[RANK CHECK FAILED]"));
 			return FALSE;
 		}
-		cmsig = mono_method_signature (cm);
-		imsig = mono_method_signature (im);
+		cmsig = mono_method_signature_internal (cm);
+		imsig = mono_method_signature_internal (im);
 		if (!cmsig || !imsig) {
 			mono_class_set_type_load_failure (klass, "Could not resolve the signature of a virtual method");
 			return FALSE;
@@ -2560,7 +2560,7 @@ print_unimplemented_interface_method_info (MonoClass *klass, MonoClass *ic, Mono
 		mono_trace_warning (MONO_TRACE_TYPE, " at slot %d: %s (%d) overrides %s (%d)", im_slot, overrides [index*2+1]->name,
 			 overrides [index*2+1]->slot, overrides [index*2]->name, overrides [index*2]->slot);
 	}
-	method_signature = mono_signature_get_desc (mono_method_signature (im), FALSE);
+	method_signature = mono_signature_get_desc (mono_method_signature_internal (im), FALSE);
 	type_name = mono_type_full_name (m_class_get_byval_arg (klass));
 	mono_trace_warning (MONO_TRACE_TYPE, "no implementation for interface method %s::%s(%s) in class %s",
 			    mono_type_get_name (m_class_get_byval_arg (ic)), im->name, method_signature, type_name);
@@ -2576,7 +2576,7 @@ print_unimplemented_interface_method_info (MonoClass *klass, MonoClass *ic, Mono
 	mcount = mono_class_get_method_count (klass);
 	for (index = 0; index < mcount; ++index) {
 		MonoMethod *cm = klass->methods [index];
-		method_signature = mono_signature_get_desc (mono_method_signature (cm), TRUE);
+		method_signature = mono_signature_get_desc (mono_method_signature_internal (cm), TRUE);
 
 		mono_trace_warning (MONO_TRACE_TYPE, "METHOD %s(%s)", cm->name, method_signature);
 		g_free (method_signature);
@@ -3087,8 +3087,8 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 				while ((m1 = mono_class_get_virtual_methods (k, &k_iter))) {
 					MonoMethodSignature *cmsig, *m1sig;
 
-					cmsig = mono_method_signature (cm);
-					m1sig = mono_method_signature (m1);
+					cmsig = mono_method_signature_internal (cm);
+					m1sig = mono_method_signature_internal (m1);
 
 					if (!cmsig || !m1sig) /* FIXME proper error message, use signature_checked? */
 						goto fail;

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -832,6 +832,9 @@ mono_class_get_context (MonoClass *klass);
 MONO_PROFILER_API MonoMethodSignature*
 mono_method_signature_checked (MonoMethod *m, MonoError *err);
 
+MONO_PROFILER_API MonoMethodSignature*
+mono_method_signature_internal (MonoMethod *m);
+
 MonoGenericContext*
 mono_method_get_context_general (MonoMethod *method, gboolean uninflated);
 

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -944,7 +944,7 @@ mono_class_inflate_generic_method_checked (MonoMethod *method, MonoGenericContex
  * On failure returns NULL and sets \p error.
  *
  * BEWARE: All non-trivial fields are invalid, including klass, signature, and header.
- *         Use mono_method_signature() and mono_method_get_header() to get the correct values.
+ *         Use mono_method_signature_internal () and mono_method_get_header () to get the correct values.
  */
 MonoMethod*
 mono_class_inflate_generic_method_full_checked (MonoMethod *method, MonoClass *klass_hint, MonoGenericContext *context, MonoError *error)
@@ -1016,7 +1016,7 @@ mono_class_inflate_generic_method_full_checked (MonoMethod *method, MonoClass *k
 
 	UnlockedAdd (&mono_inflated_methods_size,  sizeof (MonoMethodInflated));
 
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 	if (!sig) {
 		char *name = mono_type_get_full_name (method->klass);
 		mono_error_set_bad_image (error, mono_method_get_image (method), "Could not resolve signature of method %s:%s", name, method->name);
@@ -5190,7 +5190,7 @@ mono_class_get_method_from_name_checked (MonoClass *klass, const char *name,
 
 			if (method->name[0] == name [0] && 
 				!strcmp (name, method->name) &&
-				(param_count == -1 || mono_method_signature (method)->param_count == param_count) &&
+				(param_count == -1 || mono_method_signature_internal (method)->param_count == param_count) &&
 				((method->flags & flags) == flags)) {
 				res = method;
 				break;

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -269,7 +269,7 @@ cominterop_method_signature (MonoMethod* method)
 {
 	MonoMethodSignature *res;
 	MonoImage *image = m_class_get_image (method->klass);
-	MonoMethodSignature *sig = mono_method_signature (method);
+	MonoMethodSignature *sig = mono_method_signature_internal (method);
 	gboolean preserve_sig = method->iflags & METHOD_IMPL_ATTRIBUTE_PRESERVE_SIG;
 	int sigsize;
 	int i;
@@ -945,7 +945,7 @@ cominterop_get_native_wrapper_adjusted (MonoMethod *method)
 	MonoMethodPInvoke *piinfo = (MonoMethodPInvoke *) method;
 	int i;
 
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 
 	// create unmanaged wrapper
 	mb_native = mono_mb_new (method->klass, method->name, MONO_WRAPPER_MANAGED_TO_NATIVE);
@@ -1057,7 +1057,7 @@ mono_cominterop_get_native_wrapper (MonoMethod *method)
 		mono_class_setup_methods (method->klass);
 	g_assert (!mono_class_has_failure (method->klass)); /*FIXME do proper error handling*/
 
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 	mb = mono_mb_new (method->klass, method->name, MONO_WRAPPER_COMINTEROP);
 
 #ifndef DISABLE_JIT
@@ -1950,7 +1950,7 @@ cominterop_setup_marshal_context (EmitMarshalContext *m, MonoMethod *method)
 {
 	MonoMethodSignature *sig, *csig;
 	MonoImage *method_klass_image = m_class_get_image (method->klass);
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 	/* we copy the signature, so that we can modify it */
 	/* FIXME: which to use? */
 	csig = mono_metadata_signature_dup_full (method_klass_image, sig);
@@ -2093,12 +2093,12 @@ cominterop_get_ccw_checked (MonoObjectHandle object, MonoClass* itf, MonoError *
 			MonoMethod *wrapper_method, *adjust_method;
 			MonoMethod *method = m_class_get_methods (iface) [i];
 			MonoMethodSignature* sig_adjusted;
-			MonoMethodSignature* sig = mono_method_signature (method);
+			MonoMethodSignature* sig = mono_method_signature_internal (method);
 			gboolean preserve_sig = method->iflags & METHOD_IMPL_ATTRIBUTE_PRESERVE_SIG;
 
 			mb = mono_mb_new (iface, method->name, MONO_WRAPPER_NATIVE_TO_MANAGED);
 			adjust_method = cominterop_get_managed_wrapper_adjusted (method);
-			sig_adjusted = mono_method_signature (adjust_method);
+			sig_adjusted = mono_method_signature_internal (adjust_method);
 			
 			mspecs = g_new (MonoMarshalSpec*, sig_adjusted->param_count + 1);
 			mono_method_get_marshal_info (method, mspecs);
@@ -2329,7 +2329,7 @@ cominterop_get_managed_wrapper_adjusted (MonoMethod *method)
 		mono_error_assert_ok (error);
 	}
 
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 
 	/* create unmanaged wrapper */
 	mb = mono_mb_new (method->klass, method->name, MONO_WRAPPER_COMINTEROP);

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -846,7 +846,7 @@ create_custom_attr (MonoImage *image, MonoMethod *method, const guchar *data, gu
 
 	/*g_print ("got attr %s\n", method->klass->name);*/
 
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 	if (sig->param_count < 32) {
 		params = params_buf;
 		memset (params, 0, sizeof (void*) * sig->param_count);
@@ -857,9 +857,9 @@ create_custom_attr (MonoImage *image, MonoMethod *method, const guchar *data, gu
 
 	/* skip prolog */
 	p += 2;
-	for (i = 0; i < mono_method_signature (method)->param_count; ++i) {
+	for (i = 0; i < mono_method_signature_internal (method)->param_count; ++i) {
 		MonoObject *param_obj;
-		params [i] = load_cattr_value (image, mono_method_signature (method)->params [i], &param_obj, p, data_end, &p, error);
+		params [i] = load_cattr_value (image, mono_method_signature_internal (method)->params [i], &param_obj, p, data_end, &p, error);
 		if (param_obj)
 			params [i] = param_obj;
 		goto_if_nok (error, fail);
@@ -947,8 +947,8 @@ create_custom_attr (MonoImage *image, MonoMethod *method, const guchar *data, gu
 			}
 
 			/* can we have more that 1 arg in a custom attr named property? */
-			prop_type = prop->get? mono_method_signature (prop->get)->ret :
-			     mono_method_signature (prop->set)->params [mono_method_signature (prop->set)->param_count - 1];
+			prop_type = prop->get? mono_method_signature_internal (prop->get)->ret :
+			     mono_method_signature_internal (prop->set)->params [mono_method_signature_internal (prop->set)->param_count - 1];
 
 			MonoObject *param_obj;
 			pparams [0] = load_cattr_value (image, prop_type, &param_obj, named, data_end, &named, error);
@@ -1030,13 +1030,13 @@ mono_reflection_create_custom_attr_data_args (MonoImage *image, MonoMethod *meth
 	/* Parse each argument corresponding to the signature's parameters from
 	 * the blob and store in typedargs.
 	 */
-	typedargs = mono_array_new_checked (domain, mono_get_object_class (), mono_method_signature (method)->param_count, error);
+	typedargs = mono_array_new_checked (domain, mono_get_object_class (), mono_method_signature_internal (method)->param_count, error);
 	return_if_nok (error);
 
-	for (i = 0; i < mono_method_signature (method)->param_count; ++i) {
+	for (i = 0; i < mono_method_signature_internal (method)->param_count; ++i) {
 		MonoObject *obj;
 
-		obj = load_cattr_value_boxed (domain, image, mono_method_signature (method)->params [i], p, data_end, &p, error);
+		obj = load_cattr_value_boxed (domain, image, mono_method_signature_internal (method)->params [i], p, data_end, &p, error);
 		return_if_nok (error);
 		mono_array_setref (typedargs, i, obj);
 	}
@@ -1124,8 +1124,8 @@ mono_reflection_create_custom_attr_data_args (MonoImage *image, MonoMethod *meth
 				goto fail;
 			}
 
-			prop_type = prop->get? mono_method_signature (prop->get)->ret :
-			     mono_method_signature (prop->set)->params [mono_method_signature (prop->set)->param_count - 1];
+			prop_type = prop->get? mono_method_signature_internal (prop->get)->ret :
+			     mono_method_signature_internal (prop->set)->params [mono_method_signature_internal (prop->set)->param_count - 1];
 
 			arginfo [j].type = prop_type;
 			arginfo [j].prop = prop;
@@ -1168,7 +1168,7 @@ mono_reflection_create_custom_attr_data_args_noalloc (MonoImage *image, MonoMeth
 	const char *named;
 	guint32 i, j, num_named;
 	CattrNamedArg *arginfo = NULL;
-	MonoMethodSignature *sig = mono_method_signature (method);
+	MonoMethodSignature *sig = mono_method_signature_internal (method);
 
 	*typed_args = NULL;
 	*named_args = NULL;
@@ -1274,8 +1274,8 @@ mono_reflection_create_custom_attr_data_args_noalloc (MonoImage *image, MonoMeth
 				goto fail;
 			}
 
-			prop_type = prop->get? mono_method_signature (prop->get)->ret :
-			     mono_method_signature (prop->set)->params [mono_method_signature (prop->set)->param_count - 1];
+			prop_type = prop->get? mono_method_signature_internal (prop->get)->ret :
+			     mono_method_signature_internal (prop->set)->params [mono_method_signature_internal (prop->set)->param_count - 1];
 
 			arginfo [j].type = prop_type;
 			arginfo [j].prop = prop;
@@ -1331,12 +1331,12 @@ reflection_resolve_custom_attribute_data (MonoReflectionMethod *ref_method, Mono
 	if (!typedargs || !namedargs)
 		goto leave;
 
-	for (i = 0; i < mono_method_signature (method)->param_count; ++i) {
+	for (i = 0; i < mono_method_signature_internal (method)->param_count; ++i) {
 		MonoObject *obj = mono_array_get (typedargs, MonoObject*, i);
 		MonoObject *typedarg;
 		MonoType *t;
 
-		t = mono_method_signature (method)->params [i];
+		t = mono_method_signature_internal (method)->params [i];
 		if (t->type == MONO_TYPE_OBJECT && obj)
 			t = m_class_get_byval_arg (obj->vtable->klass);
 		typedarg = create_cattr_typed_arg (t, obj, error);

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -454,9 +454,9 @@ mono_method_desc_match (MonoMethodDesc *desc, MonoMethod *method)
 		return FALSE;
 	if (!desc->args)
 		return TRUE;
-	if (desc->num_args != mono_method_signature (method)->param_count)
+	if (desc->num_args != mono_method_signature_internal (method)->param_count)
 		return FALSE;
-	sig = mono_signature_get_desc (mono_method_signature (method), desc->include_namespace);
+	sig = mono_signature_get_desc (mono_method_signature_internal (method), desc->include_namespace);
 	if (strcmp (sig, desc->args)) {
 		g_free (sig);
 		return FALSE;

--- a/mono/metadata/debug-mono-ppdb.c
+++ b/mono/metadata/debug-mono-ppdb.c
@@ -537,7 +537,7 @@ mono_ppdb_lookup_locals (MonoDebugMethodInfo *minfo)
 	if (!method->token)
 		return NULL;
 
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 	if (!sig)
 		return NULL;
 

--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -188,7 +188,7 @@ create_exception_two_strings (MonoClass *klass, MonoStringHandle a1, MonoStringH
 		
 		if (strcmp (".ctor", mono_method_get_name (m)))
 			continue;
-		sig = mono_method_signature (m);
+		sig = mono_method_signature_internal (m);
 		if (sig->param_count != count)
 			continue;
 
@@ -827,7 +827,7 @@ mono_get_exception_type_initialization_handle (const gchar *type_name, MonoExcep
 	iter = NULL;
 	while ((method = mono_class_get_methods (klass, &iter))) {
 		if (!strcmp (".ctor", mono_method_get_name (method))) {
-			MonoMethodSignature *sig = mono_method_signature (method);
+			MonoMethodSignature *sig = mono_method_signature_internal (method);
 
 			if (sig->param_count == 2 && sig->params [0]->type == MONO_TYPE_STRING && mono_class_from_mono_type (sig->params [1]) == mono_defaults.exception_class)
 				break;
@@ -1028,7 +1028,7 @@ mono_get_exception_reflection_type_load_checked (MonoArrayHandle types, MonoArra
 	iter = NULL;
 	while ((method = mono_class_get_methods (klass, &iter))) {
 		if (!strcmp (".ctor", mono_method_get_name (method))) {
-			MonoMethodSignature *sig = mono_method_signature (method);
+			MonoMethodSignature *sig = mono_method_signature_internal (method);
 
 			if (sig->param_count == 2 && sig->params [0]->type == MONO_TYPE_SZARRAY && sig->params [1]->type == MONO_TYPE_SZARRAY)
 				break;

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1995,7 +1995,7 @@ ves_icall_System_MonoMethodInfo_get_retval_marshal (MonoMethod *method, MonoErro
 	MonoDomain *domain = mono_domain_get (); 
 	MonoReflectionMarshalAsAttributeHandle res = MONO_HANDLE_NEW (MonoReflectionMarshalAsAttribute, NULL);
 
-	MonoMarshalSpec **mspecs = g_new (MonoMarshalSpec*, mono_method_signature (method)->param_count + 1);
+	MonoMarshalSpec **mspecs = g_new (MonoMarshalSpec*, mono_method_signature_internal (method)->param_count + 1);
 	mono_method_get_marshal_info (method, mspecs);
 
 	if (mspecs [0]) {
@@ -2004,7 +2004,7 @@ ves_icall_System_MonoMethodInfo_get_retval_marshal (MonoMethod *method, MonoErro
 	}
 		
 leave:
-	for (int i = mono_method_signature (method)->param_count; i >= 0; i--)
+	for (int i = mono_method_signature_internal (method)->param_count; i >= 0; i--)
 		if (mspecs [i])
 			mono_metadata_free_marshal_spec (mspecs [i]);
 	g_free (mspecs);
@@ -3251,7 +3251,7 @@ ICALL_EXPORT MonoBoolean
 ves_icall_MonoMethod_get_IsGenericMethod (MonoReflectionMethodHandle ref_method, MonoError *erro)
 {
 	MonoMethod *method = MONO_HANDLE_GETVAL (ref_method, method);
-	return mono_method_signature (method)->generic_param_count != 0;
+	return mono_method_signature_internal (method)->generic_param_count != 0;
 }
 
 ICALL_EXPORT MonoBoolean
@@ -3311,7 +3311,7 @@ ves_icall_MonoMethod_GetGenericArguments (MonoReflectionMethodHandle ref_method,
 		}
 	}
 
-	int count = mono_method_signature (method)->generic_param_count;
+	int count = mono_method_signature_internal (method)->generic_param_count;
 	MonoArrayHandle res = mono_array_new_handle (domain, mono_defaults.systemtype_class, count, error);
 	return_val_if_nok (error, MONO_HANDLE_CAST (MonoArray, NULL_HANDLE));
 
@@ -3334,7 +3334,7 @@ ves_icall_InternalInvoke (MonoReflectionMethod *method, MonoObject *this_arg, Mo
 	 * greater flexibility.
 	 */
 	MonoMethod *m = method->method;
-	MonoMethodSignature *sig = mono_method_signature (m);
+	MonoMethodSignature *sig = mono_method_signature_internal (m);
 	MonoImage *image;
 	int pcount;
 	void *obj = this_arg;
@@ -3573,7 +3573,7 @@ ves_icall_InternalExecute (MonoReflectionMethod *method, MonoObject *this_arg, M
 	ERROR_DECL (error);
 	MonoDomain *domain = mono_object_domain (method); 
 	MonoMethod *m = method->method;
-	MonoMethodSignature *sig = mono_method_signature (m);
+	MonoMethodSignature *sig = mono_method_signature_internal (m);
 	MonoArray *out_args;
 	MonoObject *result;
 	int i, j, outarg_count = 0;
@@ -4237,7 +4237,7 @@ property_accessor_override (MonoMethod *method1, MonoMethod *method2)
 			method2 = ((MonoMethodInflated*) method2)->declaring;
 	}
 
-	return mono_metadata_signature_equal (mono_method_signature (method1), mono_method_signature (method2));
+	return mono_metadata_signature_equal (mono_method_signature_internal (method1), mono_method_signature_internal (method2));
 }
 
 static gboolean
@@ -6459,7 +6459,7 @@ ves_icall_System_Delegate_CreateDelegate_internal (MonoReflectionTypeHandle ref_
 	MonoClass *delegate_class = mono_class_from_mono_type (type);
 	gpointer func;
 	MonoMethod *method = MONO_HANDLE_GETVAL (info, method);
-	MonoMethodSignature *sig = mono_method_signature(method);
+	MonoMethodSignature *sig = mono_method_signature_internal (method);
 
 	mono_class_init_checked (delegate_class, error);
 	return_val_if_nok (error, NULL_HANDLE);
@@ -7914,7 +7914,7 @@ ves_icall_ParameterInfo_GetTypeModifiers (MonoReflectionParameterHandle param, M
 
 	image = m_class_get_image (method->klass);
 	pos = MONO_HANDLE_GETVAL (param, PositionImpl);
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 	if (pos == -1)
 		type = sig->ret;
 	else
@@ -7928,10 +7928,10 @@ get_property_type (MonoProperty *prop)
 {
 	MonoMethodSignature *sig;
 	if (prop->get) {
-		sig = mono_method_signature (prop->get);
+		sig = mono_method_signature_internal (prop->get);
 		return sig->ret;
 	} else if (prop->set) {
-		sig = mono_method_signature (prop->set);
+		sig = mono_method_signature_internal (prop->set);
 		return sig->params [sig->param_count - 1];
 	}
 	return NULL;
@@ -8338,7 +8338,7 @@ mono_lookup_internal_call_full (MonoMethod *method, gboolean warn_on_missing, mo
 	sigstart = mname + typelen + 2 + mlen;
 	*sigstart = 0;
 
-	tmpsig = mono_signature_get_desc (mono_method_signature (method), TRUE);
+	tmpsig = mono_signature_get_desc (mono_method_signature_internal (method), TRUE);
 	siglen = strlen (tmpsig);
 	if (typelen + mlen + siglen + 6 > sizeof (mname)) {
 		g_free (classname);

--- a/mono/metadata/loader.h
+++ b/mono/metadata/loader.h
@@ -35,7 +35,7 @@ mono_method_get_signature_full (MonoMethod *method, MonoImage *image, uint32_t t
 MONO_API MONO_RT_EXTERNAL_ONLY MonoMethodSignature*
 mono_method_get_signature  (MonoMethod *method, MonoImage *image, uint32_t token);
 
-MONO_API MonoMethodSignature*
+MONO_API MONO_RT_EXTERNAL_ONLY MonoMethodSignature*
 mono_method_signature      (MonoMethod *method);
 
 MONO_API MONO_RT_EXTERNAL_ONLY MonoMethodHeader*

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -3941,7 +3941,7 @@ static void
 emit_synchronized_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, MonoGenericContext *ctx, MonoGenericContainer *container, MonoMethod *enter_method, MonoMethod *exit_method, MonoMethod *gettypefromhandle_method)
 {
 	int i, pos, pos2, this_local, taken_local, ret_local = 0;
-	MonoMethodSignature *sig = mono_method_signature (method);
+	MonoMethodSignature *sig = mono_method_signature_internal (method);
 	MonoExceptionClause *clause;
 
 	/* result */
@@ -4035,7 +4035,7 @@ emit_synchronized_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 static void
 emit_unbox_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method)
 {
-	MonoMethodSignature *sig = mono_method_signature (method);
+	MonoMethodSignature *sig = mono_method_signature_internal (method);
 
 	mono_mb_emit_ldarg (mb, 0); 
 	mono_mb_emit_icon (mb, MONO_ABI_SIZEOF (MonoObject));
@@ -4080,7 +4080,7 @@ static void
 emit_thunk_invoke_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, MonoMethodSignature *csig)
 {
 	MonoImage *image = get_method_image (method);
-	MonoMethodSignature *sig = mono_method_signature (method);
+	MonoMethodSignature *sig = mono_method_signature_internal (method);
 	int param_count = sig->param_count + sig->hasthis + 1;
 	int pos_leave, coop_gc_var, coop_gc_stack_dummy;
 	MonoExceptionClause *clause;
@@ -6231,7 +6231,7 @@ emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 	gboolean uses_handles = FALSE;
 	gboolean save_handles_to_locals = FALSE;
 	IcallHandlesLocal *handles_locals = NULL;
-	MonoMethodSignature *sig = mono_method_signature (method);
+	MonoMethodSignature *sig = mono_method_signature_internal (method);
 
 	(void) mono_lookup_internal_call_full (method, FALSE, &uses_handles);
 

--- a/mono/metadata/metadata-verify.c
+++ b/mono/metadata/metadata-verify.c
@@ -4317,7 +4317,7 @@ mono_verifier_is_sig_compatible (MonoImage *image, MonoMethod *method, MonoMetho
 	if (!mono_verifier_is_enabled_for_image (image))
 		return TRUE;
 
-	original_sig = mono_method_signature (method);
+	original_sig = mono_method_signature_internal (method);
 	if (original_sig->call_convention == MONO_CALL_VARARG) {
 		if (original_sig->hasthis != signature->hasthis)
 			return FALSE;

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -2918,7 +2918,7 @@ collect_method_images (MonoMethodInflated *method, CollectData *data)
 	 * Dynamic assemblies have no references, so the images they depend on can be unloaded before them.
 	 */
 	if (image_is_dynamic (m_class_get_image (m->klass)))
-		collect_signature_images (mono_method_signature (m), data);
+		collect_signature_images (mono_method_signature_internal (m), data);
 }
 
 static void
@@ -2997,7 +2997,7 @@ inflated_method_in_image (gpointer key, gpointer value, gpointer data)
 	// https://bugzilla.novell.com/show_bug.cgi?id=458168
 	g_assert (m_class_get_image (method->declaring->klass) == image ||
 		(method->context.class_inst && ginst_in_image (method->context.class_inst, image)) ||
-			  (method->context.method_inst && ginst_in_image (method->context.method_inst, image)) || (((MonoMethod*)method)->signature && signature_in_image (mono_method_signature ((MonoMethod*)method), image)));
+			  (method->context.method_inst && ginst_in_image (method->context.method_inst, image)) || (((MonoMethod*)method)->signature && signature_in_image (mono_method_signature_internal ((MonoMethod*)method), image)));
 
 	return TRUE;
 }
@@ -3035,7 +3035,7 @@ check_gmethod (gpointer key, gpointer value, gpointer data)
 	if (method->context.method_inst)
 		g_assert (!ginst_in_image (method->context.method_inst, image));
 	if (((MonoMethod*)method)->signature)
-		g_assert (!signature_in_image (mono_method_signature ((MonoMethod*)method), image));
+		g_assert (!signature_in_image (mono_method_signature_internal ((MonoMethod*)method), image));
 }
 
 /*

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -1245,7 +1245,7 @@ mono_method_get_imt_slot (MonoMethod *method)
 	if (method->is_inflated)
 		method = ((MonoMethodInflated*)method)->declaring;
 
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 	hashes_count = sig->param_count + 4;
 	hashes_start = (guint32 *)g_malloc (hashes_count * sizeof (guint32));
 	hashes = hashes_start;
@@ -2910,11 +2910,11 @@ mono_class_get_virtual_method (MonoClass *klass, MonoMethod *method, gboolean is
 #ifndef DISABLE_REMOTING
 	if (is_proxy) {
 		/* It may be an interface, abstract class method or generic method */
-		if (!res || mono_method_signature (res)->generic_param_count)
+		if (!res || mono_method_signature_internal (res)->generic_param_count)
 			res = method;
 
 		/* generic methods demand invoke_with_check */
-		if (mono_method_signature (res)->generic_param_count)
+		if (mono_method_signature_internal (res)->generic_param_count)
 			res = mono_marshal_get_remoting_invoke_with_check (res, error);
 		else {
 #ifndef DISABLE_COM
@@ -4452,7 +4452,7 @@ prepare_run_main (MonoMethod *method, int argc, char *argv[])
 	argc--;
 	argv++;
 
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 	if (!sig) {
 		g_print ("Unable to load Main method.\n");
 		exit (-1);
@@ -4953,7 +4953,7 @@ do_exec_main_checked (MonoMethod *method, MonoArray *args, MonoError *error)
 	pa [0] = args;
 
 	/* FIXME: check signature of method */
-	if (mono_method_signature (method)->ret->type == MONO_TYPE_I4) {
+	if (mono_method_signature_internal (method)->ret->type == MONO_TYPE_I4) {
 		MonoObject *res;
 		res = mono_runtime_invoke_checked (method, NULL, pa, error);
 		if (is_ok (error))
@@ -4987,7 +4987,7 @@ do_try_exec_main (MonoMethod *method, MonoArray *args, MonoObject **exc)
 	pa [0] = args;
 
 	/* FIXME: check signature of method */
-	if (mono_method_signature (method)->ret->type == MONO_TYPE_I4) {
+	if (mono_method_signature_internal (method)->ret->type == MONO_TYPE_I4) {
 		ERROR_DECL_VALUE (inner_error);
 		MonoObject *res;
 		res = mono_runtime_try_invoke (method, NULL, pa, exc, &inner_error);
@@ -5326,7 +5326,7 @@ mono_runtime_try_invoke_array (MonoMethod *method, void *obj, MonoArray *params,
 
 	error_init (error);
 
-	MonoMethodSignature *sig = mono_method_signature (method);
+	MonoMethodSignature *sig = mono_method_signature_internal (method);
 	gpointer *pa = NULL;
 	MonoObject *res;
 	int i;
@@ -8146,7 +8146,7 @@ mono_message_invoke (MonoObject *target, MonoMethodMessage *msg,
 
 	domain = mono_domain_get (); 
 	method = msg->method->method;
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 
 	for (i = 0; i < sig->param_count; i++) {
 		if (sig->params [i]->byref) 
@@ -8452,7 +8452,7 @@ mono_method_call_message_new (MonoMethod *method, gpointer *params, MonoMethod *
 	error_init (error);
 
 	MonoDomain *domain = mono_domain_get ();
-	MonoMethodSignature *sig = mono_method_signature (method);
+	MonoMethodSignature *sig = mono_method_signature_internal (method);
 	MonoMethodMessage *msg;
 	int i, count;
 
@@ -8515,7 +8515,7 @@ mono_method_return_message_restore (MonoMethod *method, gpointer *params, MonoAr
 
 	error_init (error);
 
-	MonoMethodSignature *sig = mono_method_signature (method);
+	MonoMethodSignature *sig = mono_method_signature_internal (method);
 	int i, j, type, size, out_len;
 	
 	if (out_args == NULL)

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -1334,7 +1334,7 @@ get_default_param_value_blobs (MonoMethod *method, char **blobs, guint32 *types)
 
 	MonoClass *klass = method->klass;
 	MonoImage *image = m_class_get_image (klass);
-	MonoMethodSignature *methodsig = mono_method_signature (method);
+	MonoMethodSignature *methodsig = mono_method_signature_internal (method);
 
 	MonoTableInfo *constt;
 	MonoTableInfo *methodt;
@@ -2502,7 +2502,7 @@ reflection_bind_generic_method_parameters (MonoMethod *method, MonoArrayHandle t
 	if (method->is_inflated)
 		method = ((MonoMethodInflated *) method)->declaring;
 
-	int count = mono_method_signature (method)->generic_param_count;
+	int count = mono_method_signature_internal (method)->generic_param_count;
 	if (count != mono_array_handle_length (types)) {
 		mono_error_set_argument (error, "typeArguments", "Incorrect number of generic arguments");
 		return NULL;

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -405,7 +405,7 @@ mono_remoting_wrapper (MonoMethod *method, gpointer *params)
 	if (mono_class_is_contextbound (this_obj->remote_class->proxy_class) && this_obj->rp->context == (MonoObject *) mono_context_get ())
 	{
 		int i;
-		MonoMethodSignature *sig = mono_method_signature (method);
+		MonoMethodSignature *sig = mono_method_signature_internal (method);
 		int count = sig->param_count;
 		gpointer* mparams = g_newa (gpointer, count);
 
@@ -722,7 +722,7 @@ mono_marshal_get_xappdomain_dispatch (MonoMethod *method, int *marshal_types, in
 	if ((res = mono_marshal_remoting_find_in_cache (method, MONO_WRAPPER_XDOMAIN_DISPATCH)))
 		return res;
 
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 	copy_return = (sig->ret->type != MONO_TYPE_VOID && ret_marshal_type != MONO_MARSHAL_SERIALIZE);
 
 	j = 0;
@@ -995,7 +995,7 @@ mono_marshal_get_xappdomain_invoke (MonoMethod *method, MonoError *error)
 		return method;
 
 	/* we cant remote methods without this pointer */
-	if (!mono_method_signature (method)->hasthis)
+	if (!mono_method_signature_internal (method)->hasthis)
 		return method;
 
 	mono_remoting_marshal_init ();
@@ -1187,7 +1187,7 @@ mono_marshal_get_xappdomain_invoke (MonoMethod *method, MonoError *error)
 
 	xdomain_method = mono_marshal_get_xappdomain_dispatch (method, marshal_types, complex_count, complex_out_count, ret_marshal_type);
 	mono_marshal_emit_load_domain_method (mb, xdomain_method);
-	mono_mb_emit_calli (mb, mono_method_signature (xdomain_method));
+	mono_mb_emit_calli (mb, mono_method_signature_internal (xdomain_method));
 
 	if (copy_return)
 		mono_mb_emit_stloc (mb, loc_return);
@@ -1363,7 +1363,7 @@ mono_marshal_get_remoting_invoke_with_check (MonoMethod *method, MonoError *erro
 		return method;
 
 	/* we cant remote methods without this pointer */
-	g_assert (mono_method_signature (method)->hasthis);
+	g_assert (mono_method_signature_internal (method)->hasthis);
 
 	if ((res = mono_marshal_remoting_find_in_cache (method, MONO_WRAPPER_REMOTING_INVOKE_WITH_CHECK)))
 		return res;
@@ -1389,7 +1389,7 @@ mono_marshal_get_remoting_invoke_with_check (MonoMethod *method, MonoError *erro
 			mono_mb_free (mb);
 			return NULL;
 		}
-		mono_mb_emit_managed_call (mb, native, mono_method_signature (native));
+		mono_mb_emit_managed_call (mb, native, mono_method_signature_internal (native));
 		mono_mb_emit_byte (mb, CEE_RET);
 		
 		mono_mb_patch_branch (mb, pos_rem);
@@ -1400,12 +1400,12 @@ mono_marshal_get_remoting_invoke_with_check (MonoMethod *method, MonoError *erro
 		mono_mb_free (mb);
 		return NULL;
 	}
-	mono_mb_emit_managed_call (mb, native, mono_method_signature (native));
+	mono_mb_emit_managed_call (mb, native, mono_method_signature_internal (native));
 	mono_mb_emit_byte (mb, CEE_RET);
 
 	/* not a proxy */
 	mono_mb_patch_branch (mb, pos);
-	mono_mb_emit_managed_call (mb, method, mono_method_signature (method));
+	mono_mb_emit_managed_call (mb, method, mono_method_signature_internal (method));
 	mono_mb_emit_byte (mb, CEE_RET);
 #endif
 

--- a/mono/metadata/security-core-clr.c
+++ b/mono/metadata/security-core-clr.c
@@ -223,7 +223,7 @@ get_default_ctor (MonoClass *klass)
 			continue;
 		if ((method->name[0] != '.') || strcmp (".ctor", method->name))
 			continue;
-		sig = mono_method_signature (method);
+		sig = mono_method_signature_internal (method);
 		if (sig && (sig->param_count == 0))
 			return method;
 	}

--- a/mono/metadata/sre-save.c
+++ b/mono/metadata/sre-save.c
@@ -1812,7 +1812,7 @@ fixup_method (MonoReflectionILGen *ilgen, gpointer value, MonoDynamicImage *asse
 		case MONO_TABLE_METHODSPEC:
 			if (!strcmp (iltoken_member_class_name, "MonoMethod")) {
 				MonoMethod *m = ((MonoReflectionMethod*)iltoken->member)->method;
-				g_assert (mono_method_signature (m)->generic_param_count);
+				g_assert (mono_method_signature_internal (m)->generic_param_count);
 				continue;
 			} else if (!strcmp (iltoken_member_class_name, "MethodBuilder")) {
 				g_assert_not_reached ();

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -3439,7 +3439,7 @@ encode_method_ref (MonoAotCompile *acfg, MonoMethod *method, guint8 *buf, guint8
 				encode_value (1, p, &p);
 				encode_klass_ref (acfg, method->klass, p, &p);
 			} else {
-				MonoMethodSignature *sig = mono_method_signature (method);
+				MonoMethodSignature *sig = mono_method_signature_internal (method);
 				WrapperInfo *info = mono_marshal_get_wrapper_info (method);
 
 				encode_value (0, p, &p);
@@ -3458,7 +3458,7 @@ encode_method_ref (MonoAotCompile *acfg, MonoMethod *method, guint8 *buf, guint8
 		default:
 			g_assert_not_reached ();
 		}
-	} else if (mono_method_signature (method)->is_inflated) {
+	} else if (mono_method_signature_internal (method)->is_inflated) {
 		/* 
 		 * This is a generic method, find the original token which referenced it and
 		 * encode that.
@@ -3517,9 +3517,9 @@ encode_method_ref (MonoAotCompile *acfg, MonoMethod *method, guint8 *buf, guint8
 			/* Encode directly */
 			encode_value ((MONO_AOT_METHODREF_ARRAY << 24), p, &p);
 			encode_klass_ref (acfg, method->klass, p, &p);
-			if (!strcmp (method->name, ".ctor") && mono_method_signature (method)->param_count == m_class_get_rank (method->klass))
+			if (!strcmp (method->name, ".ctor") && mono_method_signature_internal (method)->param_count == m_class_get_rank (method->klass))
 				encode_value (0, p, &p);
-			else if (!strcmp (method->name, ".ctor") && mono_method_signature (method)->param_count == m_class_get_rank (method->klass) * 2)
+			else if (!strcmp (method->name, ".ctor") && mono_method_signature_internal (method)->param_count == m_class_get_rank (method->klass) * 2)
 				encode_value (1, p, &p);
 			else if (!strcmp (method->name, "Get"))
 				encode_value (2, p, &p);
@@ -4051,7 +4051,7 @@ add_wrappers (MonoAotCompile *acfg)
 			skip = TRUE;
 
 		/* Skip methods which can not be handled by get_runtime_invoke () */
-		sig = mono_method_signature (method);
+		sig = mono_method_signature_internal (method);
 		if (!sig)
 			continue;
 		if ((sig->ret->type == MONO_TYPE_PTR) ||
@@ -4237,7 +4237,7 @@ add_wrappers (MonoAotCompile *acfg)
 		method = mono_get_method_checked (acfg->image, token, NULL, NULL, error);
 		g_assert (mono_error_ok (error)); /* FIXME don't swallow the error */
 
-		sig = mono_method_signature (method);
+		sig = mono_method_signature_internal (method);
 
 		if (sig->hasthis && (method->klass->marshalbyref || method->klass == mono_defaults.object_class)) {
 			m = mono_marshal_get_remoting_invoke_with_check (method);
@@ -4447,7 +4447,7 @@ add_wrappers (MonoAotCompile *acfg)
 		if (method->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL) {
 			if (acfg->aot_opts.llvm_only) {
 				/* The wrappers have a different signature (hasthis is not set) so need to add this too */
-				add_gsharedvt_wrappers (acfg, mono_method_signature (method), FALSE, TRUE, FALSE);
+				add_gsharedvt_wrappers (acfg, mono_method_signature_internal (method), FALSE, TRUE, FALSE);
 			}
 		}
 	}
@@ -4481,7 +4481,7 @@ add_wrappers (MonoAotCompile *acfg)
 					break;
 			if (j < cattr->num_attrs) {
 				MonoCustomAttrEntry *e = &cattr->attrs [j];
-				MonoMethodSignature *sig = mono_method_signature (e->ctor);
+				MonoMethodSignature *sig = mono_method_signature_internal (e->ctor);
 				const char *p = (const char*)e->data;
 				const char *named;
 				int slen, num_named, named_type;
@@ -4993,7 +4993,7 @@ add_types_from_method_header (MonoAotCompile *acfg, MonoMethod *method)
 
 	depth = GPOINTER_TO_UINT (g_hash_table_lookup (acfg->method_depth, method));
 
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 
 	if (sig) {
 		for (j = 0; j < sig->param_count; ++j)
@@ -6647,7 +6647,7 @@ emit_klass_info (MonoAotCompile *acfg, guint32 token)
 	for (i = 0; i < m_class_get_vtable_size (klass); ++i) {
 		MonoMethod *cm = klass_vtable [i];
 
-		if (cm && mono_method_signature (cm)->is_inflated && !g_hash_table_lookup (acfg->token_info_hash, cm))
+		if (cm && mono_method_signature_internal (cm)->is_inflated && !g_hash_table_lookup (acfg->token_info_hash, cm))
 			cant_encode = TRUE;
 	}
 
@@ -8167,7 +8167,7 @@ compile_method (MonoAotCompile *acfg, MonoMethod *method)
 
 		if (!cfg->method->wrapper_type || cfg->method->wrapper_type == MONO_WRAPPER_DELEGATE_INVOKE)
 			/* These only need out wrappers */
-			add_gsharedvt_wrappers (acfg, mono_method_signature (cfg->method), FALSE, TRUE, FALSE);
+			add_gsharedvt_wrappers (acfg, mono_method_signature_internal (cfg->method), FALSE, TRUE, FALSE);
 
 		for (l = cfg->signatures; l; l = l->next) {
 			MonoMethodSignature *sig = mono_metadata_signature_dup ((MonoMethodSignature*)l->data);
@@ -8178,7 +8178,7 @@ compile_method (MonoAotCompile *acfg, MonoMethod *method)
 	} else if (mono_aot_mode_is_full (&acfg->aot_opts) && mono_aot_mode_is_interp (&acfg->aot_opts)) {
 		/* The interpreter uses these wrappers to call aot-ed code */
 		if (!cfg->method->wrapper_type || cfg->method->wrapper_type == MONO_WRAPPER_DELEGATE_INVOKE)
-			add_gsharedvt_wrappers (acfg, mono_method_signature (cfg->method), FALSE, TRUE, TRUE);
+			add_gsharedvt_wrappers (acfg, mono_method_signature_internal (cfg->method), FALSE, TRUE, TRUE);
 	}
 
 	/* 
@@ -8220,7 +8220,7 @@ compile_method (MonoAotCompile *acfg, MonoMethod *method)
 		MonoMethodHeader *header;
 		int i;
 		
-		sig = mono_method_signature (method);
+		sig = mono_method_signature_internal (method);
 		args = (MonoInst **)mono_mempool_alloc (acfg->mempool, sizeof (MonoInst*) * (sig->param_count + sig->hasthis));
 		for (i = 0; i < sig->param_count + sig->hasthis; ++i) {
 			args [i] = (MonoInst *)mono_mempool_alloc (acfg->mempool, sizeof (MonoInst));
@@ -8799,7 +8799,7 @@ append_mangled_wrapper (GString *s, MonoMethod *method)
 	default:
 		g_assert_not_reached ();
 	}
-	return success && append_mangled_signature (s, mono_method_signature (method));
+	return success && append_mangled_signature (s, mono_method_signature_internal (method));
 }
 
 static void
@@ -8879,12 +8879,12 @@ append_mangled_method (GString *s, MonoMethod *method)
 		g_string_append_printf (s, "_%s");
 		append_mangled_context (s, &container->context);
 
-		return append_mangled_signature (s, mono_method_signature (method));
+		return append_mangled_signature (s, mono_method_signature_internal (method));
 	} else {
 		g_string_append_printf (s, "_");
 		append_mangled_klass (s, method->klass);
 		g_string_append_printf (s, "_%s_", method->name);
-		if (!append_mangled_signature (s, mono_method_signature (method))) {
+		if (!append_mangled_signature (s, mono_method_signature_internal (method))) {
 			g_string_free (s, TRUE);
 			return FALSE;
 		}
@@ -9518,7 +9518,7 @@ mono_aot_method_hash (MonoMethod *method)
 
 	/* Similar to the hash in mono_method_get_imt_slot () */
 
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 
 	if (mono_class_is_ginst (method->klass))
 		class_ginst = mono_class_get_generic_class (method->klass)->context.class_inst;
@@ -9630,7 +9630,7 @@ mono_aot_get_array_helper_from_wrapper (MonoMethod *method)
 		helper_name = g_strdup_printf ("InternalArray__%s", mname);
 	else
 		helper_name = g_strdup_printf ("InternalArray__%s_%s", iname, mname);
-	m = get_method_nofail (mono_defaults.array_class, helper_name, mono_method_signature (method)->param_count, 0);
+	m = get_method_nofail (mono_defaults.array_class, helper_name, mono_method_signature_internal (method)->param_count, 0);
 	g_assert (m);
 	g_free (helper_name);
 	g_free (s);
@@ -11792,7 +11792,7 @@ resolve_profile_data (MonoAotCompile *acfg, ProfileData *data)
 
 			if (strcmp (m->name, mdata->name))
 				continue;
-			MonoMethodSignature *sig = mono_method_signature (m);
+			MonoMethodSignature *sig = mono_method_signature_internal (m);
 			if (!sig)
 				continue;
 			if (sig->param_count != mdata->param_count)

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -867,8 +867,8 @@ sig_matches_target (MonoAotModule *module, MonoMethod *target, guint8 *buf, guin
 	gboolean res;
 	guint8 *p = buf;
 	
-	sig = decode_signature_with_target (module, mono_method_signature (target), p, &p);
-	res = sig && mono_metadata_signature_equal (mono_method_signature (target), sig);
+	sig = decode_signature_with_target (module, mono_method_signature_internal (target), p, &p);
+	res = sig && mono_metadata_signature_equal (mono_method_signature_internal (target), sig);
 	g_free (sig);
 	*endbuf = p;
 	return res;
@@ -4718,7 +4718,7 @@ mono_aot_get_method (MonoDomain *domain, MonoMethod *method, MonoError *error)
 			MonoGenericContext ctx;
 			MonoType *args [16];
 
-			if (mono_method_signature (method)->params [1]->type == MONO_TYPE_OBJECT)
+			if (mono_method_signature_internal (method)->params [1]->type == MONO_TYPE_OBJECT)
 				/* Avoid recursion */
 				return NULL;
 
@@ -4749,16 +4749,16 @@ mono_aot_get_method (MonoDomain *domain, MonoMethod *method, MonoError *error)
 		/* Same for CompareExchange<T> and Exchange<T> */
 		/* Same for Volatile.Read<T>/Write<T> */
 		if (method_index == 0xffffff && method->wrapper_type == MONO_WRAPPER_MANAGED_TO_NATIVE && m_class_get_image (method->klass) == mono_defaults.corlib && 
-			((!strcmp (klass_name_space, "System.Threading") && !strcmp (klass_name, "Interlocked") && (!strcmp (method->name, "CompareExchange") || !strcmp (method->name, "Exchange")) && MONO_TYPE_IS_REFERENCE (mini_type_get_underlying_type (mono_method_signature (method)->params [1]))) ||
-			 (!strcmp (klass_name_space, "System.Threading") && !strcmp (klass_name, "Volatile") && (!strcmp (method->name, "Read") && MONO_TYPE_IS_REFERENCE (mini_type_get_underlying_type (mono_method_signature (method)->ret)))) ||
-			 (!strcmp (klass_name_space, "System.Threading") && !strcmp (klass_name, "Volatile") && (!strcmp (method->name, "Write") && MONO_TYPE_IS_REFERENCE (mini_type_get_underlying_type (mono_method_signature (method)->params [1])))))) {
+			((!strcmp (klass_name_space, "System.Threading") && !strcmp (klass_name, "Interlocked") && (!strcmp (method->name, "CompareExchange") || !strcmp (method->name, "Exchange")) && MONO_TYPE_IS_REFERENCE (mini_type_get_underlying_type (mono_method_signature_internal (method)->params [1]))) ||
+			 (!strcmp (klass_name_space, "System.Threading") && !strcmp (klass_name, "Volatile") && (!strcmp (method->name, "Read") && MONO_TYPE_IS_REFERENCE (mini_type_get_underlying_type (mono_method_signature_internal (method)->ret)))) ||
+			 (!strcmp (klass_name_space, "System.Threading") && !strcmp (klass_name, "Volatile") && (!strcmp (method->name, "Write") && MONO_TYPE_IS_REFERENCE (mini_type_get_underlying_type (mono_method_signature_internal (method)->params [1])))))) {
 			MonoMethod *m;
 			MonoGenericContext ctx;
 			MonoType *args [16];
 			gpointer iter = NULL;
 
 			while ((m = mono_class_get_methods (method->klass, &iter))) {
-				if (mono_method_signature (m)->generic_param_count && !strcmp (m->name, method->name))
+				if (mono_method_signature_internal (m)->generic_param_count && !strcmp (m->name, method->name))
 					break;
 			}
 			g_assert (m);
@@ -4795,13 +4795,13 @@ mono_aot_get_method (MonoDomain *domain, MonoMethod *method, MonoError *error)
 					int rank;
 
 					if (!strcmp (array_method->name, "Set"))
-						rank = mono_method_signature (array_method)->param_count - 1;
+						rank = mono_method_signature_internal (array_method)->param_count - 1;
 					else if (!strcmp (array_method->name, "Get") || !strcmp (array_method->name, "Address"))
-						rank = mono_method_signature (array_method)->param_count;
+						rank = mono_method_signature_internal (array_method)->param_count;
 					else
 						g_assert_not_reached ();
 					MonoClass *obj_array_class = mono_class_create_array (mono_defaults.object_class, rank);
-					MonoMethod *m = mono_class_get_method_from_name_checked (obj_array_class, array_method->name, mono_method_signature (array_method)->param_count, 0, error);
+					MonoMethod *m = mono_class_get_method_from_name_checked (obj_array_class, array_method->name, mono_method_signature_internal (array_method)->param_count, 0, error);
 					mono_error_assert_ok (error);
 					g_assert (m);
 

--- a/mono/mini/debug-mini.c
+++ b/mono/mini/debug-mini.c
@@ -236,7 +236,7 @@ mono_debug_close_method (MonoCompile *cfg)
 
 	method = cfg->method;
 	header = cfg->header;
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 
 	jit = info->jit;
 	jit->code_start = cfg->native_code;
@@ -552,14 +552,14 @@ deserialize_debug_info (MonoMethod *method, guint8 *code_start, guint8 *buf, gui
 
 	if (jit->has_var_info) {
 		jit->num_locals = header->num_locals;
-		jit->num_params = mono_method_signature (method)->param_count;
+		jit->num_params = mono_method_signature_internal (method)->param_count;
 		jit->params = g_new0 (MonoDebugVarInfo, jit->num_params);
 		jit->locals = g_new0 (MonoDebugVarInfo, jit->num_locals);
 
 		for (i = 0; i < jit->num_params; ++i)
 			deserialize_variable (&jit->params [i], p, &p);
 
-		if (mono_method_signature (method)->hasthis) {
+		if (mono_method_signature_internal (method)->hasthis) {
 			jit->this_var = g_new0 (MonoDebugVarInfo, 1);
 			deserialize_variable (jit->this_var, p, &p);
 		}

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -5963,7 +5963,7 @@ do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, guint8 
 	m = decode_methodid (p, &p, end, &domain, &err);
 	if (err != ERR_NONE)
 		return err;
-	sig = mono_method_signature (m);
+	sig = mono_method_signature_internal (m);
 
 	if (m_class_is_valuetype (m->klass))
 		this_buf = (guint8 *)g_alloca (mono_class_instance_size (m->klass));
@@ -7441,7 +7441,7 @@ buffer_add_cattrs (Buffer *buf, MonoDomain *domain, MonoImage *image, MonoClass 
 				for (j = 0; j < mono_array_length (typed_args); ++j) {
 					MonoObject *val = mono_array_get (typed_args, MonoObject*, j);
 
-					t = mono_method_signature (attr->ctor)->params [j];
+					t = mono_method_signature_internal (attr->ctor)->params [j];
 
 					buffer_add_cattr_arg (buf, t, domain, val);
 				}
@@ -8098,7 +8098,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 		break;
 	}
 	case CMD_METHOD_GET_PARAM_INFO: {
-		MonoMethodSignature *sig = mono_method_signature (method);
+		MonoMethodSignature *sig = mono_method_signature_internal (method);
 		guint32 i;
 		char **names;
 
@@ -8209,7 +8209,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 			guint8 attrs = 0;
 			if (method->is_generic)
 				attrs |= (1 << 0);
-			if (mono_method_signature (method)->generic_param_count)
+			if (mono_method_signature_internal (method)->generic_param_count)
 				attrs |= (1 << 1);
 			buffer_add_byte (buf, attrs);
 			if (method->is_generic || method->is_inflated) {
@@ -8237,7 +8237,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 				buffer_add_id (buf, 0);
 			}
 			if (CHECK_PROTOCOL_VERSION (2, 15)) {
-				if (mono_method_signature (method)->generic_param_count) {
+				if (mono_method_signature_internal (method)->generic_param_count) {
 					int count, i;
 
 					if (method->is_inflated) {
@@ -8254,7 +8254,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 					} else if (method->is_generic) {
 						MonoGenericContainer *container = mono_method_get_generic_container (method);
 
-						count = mono_method_signature (method)->generic_param_count;
+						count = mono_method_signature_internal (method)->generic_param_count;
 						buffer_add_int (buf, count);
 						for (i = 0; i < count; i++) {
 							MonoGenericParam *param = mono_generic_container_get_param (container, i);
@@ -8663,7 +8663,7 @@ frame_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 
 	jit = frame->jit;
 
-	sig = mono_method_signature (frame->actual_method);
+	sig = mono_method_signature_internal (frame->actual_method);
 
 	if (!(jit->has_var_info || frame->de.ji->is_interp) || !mono_get_seq_points (frame->de.domain, frame->actual_method))
 		/*

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -382,7 +382,7 @@ method_should_be_regression_tested (MonoMethod *method, gboolean interp)
 			continue;
 
 		MonoClass *klass = centry->ctor->klass;
-		if (strcmp (m_class_get_name (klass), "CategoryAttribute") || mono_method_signature (centry->ctor)->param_count != 1)
+		if (strcmp (m_class_get_name (klass), "CategoryAttribute") || mono_method_signature_internal (centry->ctor)->param_count != 1)
 			continue;
 
 		gpointer *typed_args, *named_args;
@@ -1177,7 +1177,7 @@ compile_all_methods_thread_main_inner (CompileAllThreadArgs *args)
 
 		if (mono_class_is_gtd (method->klass))
 			continue;
-		sig = mono_method_signature (method);
+		sig = mono_method_signature_internal (method);
 		if (!sig) {
 			char * desc = mono_method_full_name (method, TRUE);
 			g_print ("Could not retrieve method signature for %s\n", desc);

--- a/mono/mini/dwarfwriter.c
+++ b/mono/mini/dwarfwriter.c
@@ -1770,7 +1770,7 @@ mono_dwarf_writer_emit_method (MonoDwarfWriter *w, MonoCompile *cfg, MonoMethod 
 
 	emit_section_change (w, ".debug_info", 0);
 
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 	header = mono_method_get_header_checked (method, error);
 	mono_error_assert_ok (error); /* FIXME don't swallow the error */
 

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -573,17 +573,17 @@ load_arg(TransformData *td, int n)
 	MonoClass *klass = NULL;
 	MonoType *type;
 
-	gboolean hasthis = mono_method_signature (td->method)->hasthis;
+	gboolean hasthis = mono_method_signature_internal (td->method)->hasthis;
 	if (hasthis && n == 0)
 		type = m_class_get_byval_arg (td->method->klass);
 	else
-		type = mono_method_signature (td->method)->params [hasthis ? n - 1 : n];
+		type = mono_method_signature_internal (td->method)->params [hasthis ? n - 1 : n];
 
 	mt = mint_type (type);
 	if (mt == MINT_TYPE_VT) {
 		gint32 size;
 		klass = mono_class_from_mono_type (type);
-		if (mono_method_signature (td->method)->pinvoke)
+		if (mono_method_signature_internal (td->method)->pinvoke)
 			size = mono_class_native_size (klass, NULL);
 		else
 			size = mono_class_value_size (klass, NULL);
@@ -622,17 +622,17 @@ store_arg(TransformData *td, int n)
 	CHECK_STACK (td, 1);
 	MonoType *type;
 
-	gboolean hasthis = mono_method_signature (td->method)->hasthis;
+	gboolean hasthis = mono_method_signature_internal (td->method)->hasthis;
 	if (hasthis && n == 0)
 		type = m_class_get_byval_arg (td->method->klass);
 	else
-		type = mono_method_signature (td->method)->params [n - !!hasthis];
+		type = mono_method_signature_internal (td->method)->params [n - !!hasthis];
 
 	mt = mint_type (type);
 	if (mt == MINT_TYPE_VT) {
 		gint32 size;
 		MonoClass *klass = mono_class_from_mono_type (type);
-		if (mono_method_signature (td->method)->pinvoke)
+		if (mono_method_signature_internal (td->method)->pinvoke)
 			size = mono_class_native_size (klass, NULL);
 		else
 			size = mono_class_value_size (klass, NULL);
@@ -652,11 +652,11 @@ static void
 store_inarg(TransformData *td, int n)
 {
 	MonoType *type;
-	gboolean hasthis = mono_method_signature (td->method)->hasthis;
+	gboolean hasthis = mono_method_signature_internal (td->method)->hasthis;
 	if (hasthis && n == 0)
 		type = m_class_get_byval_arg (td->method->klass);
 	else
-		type = mono_method_signature (td->method)->params [n - !!hasthis];
+		type = mono_method_signature_internal (td->method)->params [n - !!hasthis];
 
 	int mt = mint_type (type);
 	if (hasthis && n == 0) {
@@ -667,7 +667,7 @@ store_inarg(TransformData *td, int n)
 	if (mt == MINT_TYPE_VT) {
 		MonoClass *klass = mono_class_from_mono_type (type);
 		gint32 size;
-		if (mono_method_signature (td->method)->pinvoke)
+		if (mono_method_signature_internal (td->method)->pinvoke)
 			size = mono_class_native_size (klass, NULL);
 		else
 			size = mono_class_value_size (klass, NULL);
@@ -1379,7 +1379,7 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 				return_if_nok (error);
 			} else
 				target_method = (MonoMethod *)mono_method_get_wrapper_data (method, token);
-			csignature = mono_method_signature (target_method);
+			csignature = mono_method_signature_internal (target_method);
 
 			if (generic_context) {
 				csignature = mono_inflate_generic_signature (csignature, generic_context, error);
@@ -1389,7 +1389,7 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 			}
 		}
 	} else {
-		csignature = mono_method_signature (target_method);
+		csignature = mono_method_signature_internal (target_method);
 	}
 
 	if (check_visibility && target_method && !mono_method_can_access_method (method, target_method))
@@ -1636,7 +1636,7 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 
 		if (op == MINT_CALLRUN) {
 			ADD_CODE (td, get_data_item_index (td, target_method));
-			ADD_CODE (td, get_data_item_index (td, mono_method_signature (target_method)));
+			ADD_CODE (td, get_data_item_index (td, mono_method_signature_internal (target_method)));
 		}
 	} else if (!calli && !is_virtual && jit_call_supported (target_method, csignature)) {
 		ADD_CODE(td, MINT_JIT_CALL);
@@ -2050,7 +2050,7 @@ emit_seq_point (TransformData *td, int il_offset, InterpBasicBlock *cbb, gboolea
 static void
 generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsigned char *is_bb_start, MonoGenericContext *generic_context, MonoError *error)
 {
-	MonoMethodSignature *signature = mono_method_signature (method);
+	MonoMethodSignature *signature = mono_method_signature_internal (method);
 	MonoImage *image = m_class_get_image (method->klass);
 	MonoDomain *domain = rtm->domain;
 	MonoClass *constrained_class = NULL;
@@ -3248,7 +3248,7 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsig
 				goto_if_nok (error, exit);
 			}
 
-			csignature = mono_method_signature (m);
+			csignature = mono_method_signature_internal (m);
 			klass = m->klass;
 
 			if (!mono_class_init (klass)) {
@@ -5052,7 +5052,7 @@ mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, Mon
 	MonoMethod *method = imethod->method;
 	MonoImage *image = m_class_get_image (method->klass);
 	MonoMethodHeader *header = NULL;
-	MonoMethodSignature *signature = mono_method_signature (method);
+	MonoMethodSignature *signature = mono_method_signature_internal (method);
 	const unsigned char *ip, *end;
 	const MonoOpcode *opcode;
 	MonoMethod *m;
@@ -5084,7 +5084,7 @@ mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, Mon
 
 	MONO_PROFILER_RAISE (jit_begin, (method));
 
-	if (mono_method_signature (method)->is_inflated)
+	if (mono_method_signature_internal (method)->is_inflated)
 		generic_context = mono_method_get_context (method);
 	else {
 		MonoGenericContainer *generic_container = mono_method_get_generic_container (method);
@@ -5102,9 +5102,9 @@ mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, Mon
 		}
 
 		/* assumes all internal calls with an array this are built in... */
-		if (method->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL && (! mono_method_signature (method)->hasthis || m_class_get_rank (method->klass) == 0)) {
+		if (method->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL && (! mono_method_signature_internal (method)->hasthis || m_class_get_rank (method->klass) == 0)) {
 			nm = mono_marshal_get_native_wrapper (method, TRUE, FALSE);
-			signature = mono_method_signature (nm);
+			signature = mono_method_signature_internal (nm);
 		} else {
 			const char *name = method->name;
 			if (m_class_get_parent (method->klass) == mono_defaults.multicastdelegate_class) {

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -702,7 +702,7 @@ mono_array_new_va (MonoMethod *cm, ...)
 	int rank;
 	int i, d;
 
-	pcount = mono_method_signature (cm)->param_count;
+	pcount = mono_method_signature_internal (cm)->param_count;
 	rank = m_class_get_rank (cm->klass);
 
 	va_start (ap, cm);
@@ -749,7 +749,7 @@ mono_array_new_1 (MonoMethod *cm, guint32 length)
 	int pcount;
 	int rank;
 
-	pcount = mono_method_signature (cm)->param_count;
+	pcount = mono_method_signature_internal (cm)->param_count;
 	rank = m_class_get_rank (cm->klass);
 
 	lengths [0] = length;
@@ -784,7 +784,7 @@ mono_array_new_2 (MonoMethod *cm, guint32 length1, guint32 length2)
 	int pcount;
 	int rank;
 
-	pcount = mono_method_signature (cm)->param_count;
+	pcount = mono_method_signature_internal (cm)->param_count;
 	rank = m_class_get_rank (cm->klass);
 
 	lengths [0] = length1;
@@ -820,7 +820,7 @@ mono_array_new_3 (MonoMethod *cm, guint32 length1, guint32 length2, guint32 leng
 	int pcount;
 	int rank;
 
-	pcount = mono_method_signature (cm)->param_count;
+	pcount = mono_method_signature_internal (cm)->param_count;
 	rank = m_class_get_rank (cm->klass);
 
 	lengths [0] = length1;
@@ -857,7 +857,7 @@ mono_array_new_4 (MonoMethod *cm, guint32 length1, guint32 length2, guint32 leng
 	int pcount;
 	int rank;
 
-	pcount = mono_method_signature (cm)->param_count;
+	pcount = mono_method_signature_internal (cm)->param_count;
 	rank = m_class_get_rank (cm->klass);
 
 	lengths [0] = length1;
@@ -942,7 +942,7 @@ mono_ldtoken_wrapper (MonoImage *image, int token, MonoGenericContext *context)
 gpointer
 mono_ldtoken_wrapper_generic_shared (MonoImage *image, int token, MonoMethod *method)
 {
-	MonoMethodSignature *sig = mono_method_signature (method);
+	MonoMethodSignature *sig = mono_method_signature_internal (method);
 	MonoGenericContext *generic_context;
 
 	if (sig->is_inflated) {
@@ -1367,7 +1367,7 @@ constrained_gsharedvt_call_setup (gpointer mp, MonoMethod *cmethod, MonoClass *k
 		klass = this_obj->vtable->klass;
 	}
 
-	if (mono_method_signature (cmethod)->pinvoke) {
+	if (mono_method_signature_internal (cmethod)->pinvoke) {
 		/* Object.GetType () */
 		m = mono_marshal_get_native_wrapper (cmethod, TRUE, FALSE);
 	} else {
@@ -1884,7 +1884,7 @@ mono_llvmonly_init_delegate (MonoDelegate *del)
 		if (mono_error_set_pending_exception (error))
 			return;
 
-		if (m_class_is_valuetype (m->klass) && mono_method_signature (m)->hasthis)
+		if (m_class_is_valuetype (m->klass) && mono_method_signature_internal (m)->hasthis)
 		    addr = mono_aot_get_unbox_trampoline (m);
 
 		gpointer arg = mini_get_delegate_arg (del->method, addr);

--- a/mono/mini/liveness.c
+++ b/mono/mini/liveness.c
@@ -602,7 +602,7 @@ mono_analyze_liveness (MonoCompile *cfg)
 				 * VOLATILE, since that would prevent it from being allocated to
 				 * registers.
 				 */
-				 if (!cfg->disable_deadce_vars && !(cfg->gshared && mono_method_signature (cfg->method)->hasthis && cfg->varinfo [vi->idx] == cfg->args [0]))
+				 if (!cfg->disable_deadce_vars && !(cfg->gshared && mono_method_signature_internal (cfg->method)->hasthis && cfg->varinfo [vi->idx] == cfg->args [0]))
 					 cfg->varinfo [vi->idx]->flags |= MONO_INST_IS_DEAD;
 			}
 			vi->range.first_use.abs_pos = 0;

--- a/mono/mini/memory-access.c
+++ b/mono/mini/memory-access.c
@@ -434,7 +434,7 @@ mini_emit_memory_copy_internal (MonoCompile *cfg, MonoInst *dest, MonoInst *src,
 		iargs [0] = dest;
 		iargs [1] = src;
 		iargs [2] = size_ins;
-		mini_emit_calli (cfg, mono_method_signature (mini_get_memcpy_method ()), iargs, memcpy_ins, NULL, NULL);
+		mini_emit_calli (cfg, mono_method_signature_internal (mini_get_memcpy_method ()), iargs, memcpy_ins, NULL, NULL);
 	} else {
 		mini_emit_memcpy_const_size (cfg, dest, src, size, align);
 	}

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -1446,7 +1446,7 @@ mono_arch_compute_omit_fp (MonoCompile *cfg)
 
 	header = cfg->header;
 
-	sig = mono_method_signature (cfg->method);
+	sig = mono_method_signature_internal (cfg->method);
 
 	if (!cfg->arch.cinfo)
 		cfg->arch.cinfo = get_call_info (cfg->mempool, sig);
@@ -1557,7 +1557,7 @@ mono_arch_fill_argument_info (MonoCompile *cfg)
 	int i;
 	CallInfo *cinfo;
 
-	sig = mono_method_signature (cfg->method);
+	sig = mono_method_signature_internal (cfg->method);
 
 	cinfo = cfg->arch.cinfo;
 
@@ -1623,7 +1623,7 @@ mono_arch_allocate_vars (MonoCompile *cfg)
 	gint32 *offsets;
 	CallInfo *cinfo;
 
-	sig = mono_method_signature (cfg->method);
+	sig = mono_method_signature_internal (cfg->method);
 
 	cinfo = cfg->arch.cinfo;
 	sig_ret = mini_get_underlying_type (sig->ret);
@@ -1845,7 +1845,7 @@ mono_arch_create_vars (MonoCompile *cfg)
 	MonoMethodSignature *sig;
 	CallInfo *cinfo;
 
-	sig = mono_method_signature (cfg->method);
+	sig = mono_method_signature_internal (cfg->method);
 
 	if (!cfg->arch.cinfo)
 		cfg->arch.cinfo = get_call_info (cfg->mempool, sig);
@@ -2419,7 +2419,7 @@ mono_arch_emit_outarg_vt (MonoCompile *cfg, MonoInst *ins, MonoInst *src)
 void
 mono_arch_emit_setret (MonoCompile *cfg, MonoMethod *method, MonoInst *val)
 {
-	MonoType *ret = mini_get_underlying_type (mono_method_signature (method)->ret);
+	MonoType *ret = mini_get_underlying_type (mono_method_signature_internal (method)->ret);
 
 	if (ret->type == MONO_TYPE_R4) {
 		if (COMPILE_LLVM (cfg))
@@ -7065,7 +7065,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 		}
 	}
 
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 	pos = 0;
 
 	cinfo = cfg->arch.cinfo;
@@ -7575,7 +7575,7 @@ mono_arch_instrument_prolog (MonoCompile *cfg, void *func, void *p, gboolean ena
 
 	if (enable_arguments) {
 		/* Allocate a new area on the stack and save arguments there */
-		sig = mono_method_signature (cfg->method);
+		sig = mono_method_signature_internal (cfg->method);
 
 		n = sig->param_count + sig->hasthis;
 
@@ -7624,7 +7624,7 @@ mono_arch_instrument_epilog (MonoCompile *cfg, void *func, void *p, gboolean ena
 	guchar *code = (guchar *)p;
 	int save_mode = SAVE_NONE;
 	MonoMethod *method = cfg->method;
-	MonoType *ret_type = mini_get_underlying_type (mono_method_signature (method)->ret);
+	MonoType *ret_type = mini_get_underlying_type (mono_method_signature_internal (method)->ret);
 	
 	switch (ret_type->type) {
 	case MONO_TYPE_VOID:

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -1855,7 +1855,7 @@ mono_arch_compute_omit_fp (MonoCompile *cfg)
 
 	header = cfg->header;
 
-	sig = mono_method_signature (cfg->method);
+	sig = mono_method_signature_internal (cfg->method);
 
 	if (!cfg->arch.cinfo)
 		cfg->arch.cinfo = get_call_info (cfg->mempool, sig);
@@ -1922,7 +1922,7 @@ mono_arch_allocate_vars (MonoCompile *cfg)
 	ArgInfo *ainfo;
 	guint32 ualign;
 
-	sig = mono_method_signature (cfg->method);
+	sig = mono_method_signature_internal (cfg->method);
 
 	if (!cfg->arch.cinfo)
 		cfg->arch.cinfo = get_call_info (cfg->mempool, sig);
@@ -2211,7 +2211,7 @@ mono_arch_create_vars (MonoCompile *cfg)
 	CallInfo *cinfo;
 	int i;
 
-	sig = mono_method_signature (cfg->method);
+	sig = mono_method_signature_internal (cfg->method);
 
 	if (!cfg->arch.cinfo)
 		cfg->arch.cinfo = get_call_info (cfg->mempool, sig);
@@ -2756,7 +2756,7 @@ mono_arch_emit_outarg_vt (MonoCompile *cfg, MonoInst *ins, MonoInst *src)
 void
 mono_arch_emit_setret (MonoCompile *cfg, MonoMethod *method, MonoInst *val)
 {
-	MonoType *ret = mini_get_underlying_type (mono_method_signature (method)->ret);
+	MonoType *ret = mini_get_underlying_type (mono_method_signature_internal (method)->ret);
 
 	if (!ret->byref) {
 		if (ret->type == MONO_TYPE_I8 || ret->type == MONO_TYPE_U8) {
@@ -3192,7 +3192,7 @@ mono_arch_instrument_epilog (MonoCompile *cfg, void *func, void *p, gboolean ena
 	guchar *code = (guchar*)p;
 	int save_mode = SAVE_NONE;
 	MonoMethod *method = cfg->method;
-	MonoType *ret_type = mini_get_underlying_type (mono_method_signature (method)->ret);
+	MonoType *ret_type = mini_get_underlying_type (mono_method_signature_internal (method)->ret);
 	int rtype = ret_type->type;
 	int save_offset = cfg->param_area;
 	save_offset += 7;
@@ -5761,7 +5761,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			break;
 
 		case OP_SETFRET: {
-			MonoType *sig_ret = mini_get_underlying_type (mono_method_signature (cfg->method)->ret);
+			MonoType *sig_ret = mini_get_underlying_type (mono_method_signature_internal (cfg->method)->ret);
 			if (sig_ret->type == MONO_TYPE_R4) {
 				if (cfg->r4fp) {
 					if (IS_HARD_FLOAT) {
@@ -6294,7 +6294,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 	if (mono_jit_trace_calls != NULL && mono_trace_eval (method))
 		tracing = 1;
 
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 	cfg->code_size = 256 + sig->param_count * 64;
 	code = cfg->native_code = g_malloc (cfg->code_size);
 

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -2064,7 +2064,7 @@ mono_arch_create_vars (MonoCompile *cfg)
 	MonoMethodSignature *sig;
 	CallInfo *cinfo;
 
-	sig = mono_method_signature (cfg->method);
+	sig = mono_method_signature_internal (cfg->method);
 	if (!cfg->arch.cinfo)
 		cfg->arch.cinfo = get_call_info (cfg->mempool, sig);
 	cinfo = cfg->arch.cinfo;
@@ -2114,7 +2114,7 @@ mono_arch_allocate_vars (MonoCompile *cfg)
 	 * Compute cfg->stack_offset and update cfg->used_int_regs.
 	 */
 
-	sig = mono_method_signature (cfg->method);
+	sig = mono_method_signature_internal (cfg->method);
 
 	if (!cfg->arch.cinfo)
 		cfg->arch.cinfo = get_call_info (cfg->mempool, sig);
@@ -2724,7 +2724,7 @@ mono_arch_emit_setret (MonoCompile *cfg, MonoMethod *method, MonoInst *val)
 	MonoMethodSignature *sig;
 	CallInfo *cinfo;
 
-	sig = mono_method_signature (cfg->method);
+	sig = mono_method_signature_internal (cfg->method);
 	if (!cfg->arch.cinfo)
 		cfg->arch.cinfo = get_call_info (cfg->mempool, sig);
 	cinfo = cfg->arch.cinfo;
@@ -4996,7 +4996,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 	guint8 *code;
 	int cfa_offset, max_offset;
 
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 	cfg->code_size = 256 + sig->param_count * 64;
 	code = cfg->native_code = g_malloc (cfg->code_size);
 

--- a/mono/mini/mini-gc.c
+++ b/mono/mini/mini-gc.c
@@ -1625,7 +1625,7 @@ static void
 process_variables (MonoCompile *cfg)
 {
 	MonoCompileGC *gcfg = cfg->gc_info;
-	MonoMethodSignature *sig = mono_method_signature (cfg->method);
+	MonoMethodSignature *sig = mono_method_signature_internal (cfg->method);
 	int i, locals_min_slot, locals_max_slot, cindex;
 	MonoBasicBlock *bb;
 	MonoInst *tmp;
@@ -2036,7 +2036,7 @@ compute_frame_size (MonoCompile *cfg)
 	int i, locals_min_offset, locals_max_offset, cfa_min_offset, cfa_max_offset;
 	int min_offset, max_offset;
 	MonoCompileGC *gcfg = cfg->gc_info;
-	MonoMethodSignature *sig = mono_method_signature (cfg->method);
+	MonoMethodSignature *sig = mono_method_signature_internal (cfg->method);
 	GSList *l;
 
 	/* Compute min/max offsets from the fp */

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -1065,8 +1065,8 @@ class_type_info (MonoDomain *domain, MonoClass *klass, MonoRgctxInfoType info_ty
 			gmethod = mini_get_shared_method_full (method, SHARE_MODE_GSHAREDVT, error);
 			if (!gmethod)
 				return NULL;
-			sig = mono_method_signature (method);
-			gsig = mono_method_signature (gmethod);
+			sig = mono_method_signature_internal (method);
+			gsig = mono_method_signature_internal (gmethod);
 
 			addr = mini_add_method_wrappers_llvmonly (method, addr, TRUE, FALSE, &arg);
 			return mini_create_llvmonly_ftndesc (domain, addr, arg);
@@ -1083,8 +1083,8 @@ class_type_info (MonoDomain *domain, MonoClass *klass, MonoRgctxInfoType info_ty
 			gmethod = mini_get_shared_method_full (method, SHARE_MODE_GSHAREDVT, error);
 			if (!gmethod)
 				return NULL;
-			sig = mono_method_signature (method);
-			gsig = mono_method_signature (gmethod);
+			sig = mono_method_signature_internal (method);
+			gsig = mono_method_signature_internal (gmethod);
 
 			addr = mini_get_gsharedvt_wrapper (FALSE, addr, sig, gsig, -1, FALSE);
 			addr = mono_create_static_rgctx_trampoline (method, addr);
@@ -1952,7 +1952,7 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 		g_assert (ji);
 		callee_gsharedvt = mini_jit_info_is_gsharedvt (ji);
 		if (callee_gsharedvt)
-			callee_gsharedvt = mini_is_gsharedvt_variable_signature (mono_method_signature (jinfo_get_method (ji)));
+			callee_gsharedvt = mini_is_gsharedvt_variable_signature (mono_method_signature_internal (jinfo_get_method (ji)));
 		if (callee_gsharedvt) {
 			/* No need for a wrapper */
 			return mini_create_llvmonly_ftndesc (domain, addr, mini_method_get_rgctx (m));
@@ -2147,7 +2147,7 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 
 			g_assert (method->is_inflated);
 
-			sig = mono_method_signature (method);
+			sig = mono_method_signature_internal (method);
 			gsig = call_sig;
 
 			if (mono_llvm_only) {
@@ -2155,7 +2155,7 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 					/* The virtual case doesn't go through this code */
 					g_assert (!virtual_);
 
-					sig = mono_method_signature (jinfo_get_method (callee_ji));
+					sig = mono_method_signature_internal (jinfo_get_method (callee_ji));
 					gpointer out_wrapper = mini_get_gsharedvt_wrapper (FALSE, NULL, sig, gsig, -1, FALSE);
 					MonoFtnDesc *out_wrapper_arg = mini_create_llvmonly_ftndesc (domain, callee_ji->code_start, mini_method_get_rgctx (method));
 
@@ -2194,8 +2194,8 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 
 			if (mono_llvm_only) {
 				/* Both wrappers receive an extra <addr, rgctx> argument */
-				sig = mono_method_signature (method);
-				gsig = mono_method_signature (jinfo_get_method (callee_ji));
+				sig = mono_method_signature_internal (method);
+				gsig = mono_method_signature_internal (jinfo_get_method (callee_ji));
 
 				/* Return a function descriptor */
 
@@ -2215,14 +2215,14 @@ instantiate_info (MonoDomain *domain, MonoRuntimeGenericContextInfoTemplate *oti
 				} else {
 					addr = mini_create_llvmonly_ftndesc (domain, addr, mini_method_get_rgctx (method));
 				}
-			} else if (call_sig == mono_method_signature (method)) {
+			} else if (call_sig == mono_method_signature_internal (method)) {
 			} else {
-				sig = mono_method_signature (method);
-				gsig = mono_method_signature (jinfo_get_method (callee_ji)); 
+				sig = mono_method_signature_internal (method);
+				gsig = mono_method_signature_internal (jinfo_get_method (callee_ji)); 
 
 				addr = mini_get_gsharedvt_wrapper (TRUE, callee_ji->code_start, sig, gsig, -1, FALSE);
 
-				sig = mono_method_signature (method);
+				sig = mono_method_signature_internal (method);
 				gsig = call_sig;
 
 				addr = mini_get_gsharedvt_wrapper (FALSE, addr, sig, gsig, -1, FALSE);
@@ -3041,7 +3041,7 @@ is_async_method (MonoMethod *method)
 	attr_class = mono_class_try_get_iasync_state_machine_class ();
 
 	/* Do less expensive checks first */
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 	if (attr_class && sig && ((sig->ret->type == MONO_TYPE_VOID) ||
 				(sig->ret->type == MONO_TYPE_CLASS && !strcmp (m_class_get_name (sig->ret->data.generic_class->container_class), "Task")) ||
 				(sig->ret->type == MONO_TYPE_GENERICINST && !strcmp (m_class_get_name (sig->ret->data.generic_class->container_class), "Task`1")))) {
@@ -4153,7 +4153,7 @@ mini_is_gsharedvt_sharable_method (MonoMethod *method)
 		return FALSE;
 	}
 
-	sig = mono_method_signature (mono_method_get_declaring_generic_method (method));
+	sig = mono_method_signature_internal (mono_method_get_declaring_generic_method (method));
 	if (!sig)
 		return FALSE;
 

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -6867,7 +6867,7 @@ mono_llvm_check_method_supported (MonoCompile *cfg)
 	int i, j;
 
 #ifdef TARGET_WASM
-	if (mono_method_signature (cfg->method)->call_convention == MONO_CALL_VARARG) {
+	if (mono_method_signature_internal (cfg->method)->call_convention == MONO_CALL_VARARG) {
 		cfg->exception_message = g_strdup ("vararg callconv");
 		cfg->disable_llvm = TRUE;
 		return;
@@ -7184,7 +7184,7 @@ emit_method_inner (EmitContext *ctx)
 	}
 #endif
 
-	sig = mono_method_signature (cfg->method);
+	sig = mono_method_signature_internal (cfg->method);
 	ctx->sig = sig;
 
 	linfo = get_llvm_call_info (cfg, sig);
@@ -7709,14 +7709,14 @@ mono_llvm_create_vars (MonoCompile *cfg)
 {
 	MonoMethodSignature *sig;
 
-	sig = mono_method_signature (cfg->method);
+	sig = mono_method_signature_internal (cfg->method);
 	if (cfg->gsharedvt && cfg->llvm_only) {
 		gboolean vretaddr = FALSE;
 
 		if (mini_is_gsharedvt_variable_signature (sig) && sig->ret->type != MONO_TYPE_VOID) {
 			vretaddr = TRUE;
 		} else {
-			MonoMethodSignature *sig = mono_method_signature (cfg->method);
+			MonoMethodSignature *sig = mono_method_signature_internal (cfg->method);
 			LLVMCallInfo *linfo;
 
 			linfo = get_llvm_call_info (cfg, sig);

--- a/mono/mini/mini-mips.c
+++ b/mono/mini/mini-mips.c
@@ -1331,7 +1331,7 @@ mono_arch_compute_omit_fp (MonoCompile *cfg)
 
 	header = cfg->header;
 
-	sig = mono_method_signature (cfg->method);
+	sig = mono_method_signature_internal (cfg->method);
 
 	if (!cfg->arch.cinfo)
 		cfg->arch.cinfo = get_call_info (cfg->mempool, sig);
@@ -1395,7 +1395,7 @@ mono_arch_allocate_vars (MonoCompile *cfg)
 #endif
 	CallInfo *cinfo;
 
-	sig = mono_method_signature (cfg->method);
+	sig = mono_method_signature_internal (cfg->method);
 
 	if (!cfg->arch.cinfo)
 		cfg->arch.cinfo = get_call_info (cfg->mempool, sig);
@@ -1611,7 +1611,7 @@ mono_arch_create_vars (MonoCompile *cfg)
 {
 	MonoMethodSignature *sig;
 
-	sig = mono_method_signature (cfg->method);
+	sig = mono_method_signature_internal (cfg->method);
 
 	if (MONO_TYPE_ISSTRUCT (sig->ret)) {
 		cfg->vret_addr = mono_compile_create_var (cfg, mono_get_int_type (), OP_ARG);
@@ -1924,7 +1924,7 @@ mono_arch_emit_outarg_vt (MonoCompile *cfg, MonoInst *ins, MonoInst *src)
 void
 mono_arch_emit_setret (MonoCompile *cfg, MonoMethod *method, MonoInst *val)
 {
-	MonoType *ret = mini_get_underlying_type (mono_method_signature (method)->ret);
+	MonoType *ret = mini_get_underlying_type (mono_method_signature_internal (method)->ret);
 
 	if (!ret->byref) {
 #if (SIZEOF_REGISTER == 4)
@@ -3074,7 +3074,7 @@ emit_load_volatile_arguments(MonoCompile *cfg, guint8 *code)
 	CallInfo *cinfo;
 	int i;
 
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 
 	if (!cfg->arch.cinfo)
 		cfg->arch.cinfo = get_call_info (cfg->mempool, sig);
@@ -4647,7 +4647,7 @@ mips_adjust_stackframe(MonoCompile *cfg)
 		g_print ("\tra_offset %d/0x%x delta %d/0x%x\n", ra_offset, ra_offset, delta, delta);
 	}
 
-	sig = mono_method_signature (cfg->method);
+	sig = mono_method_signature_internal (cfg->method);
 	if (sig && sig->ret && MONO_TYPE_ISSTRUCT (sig->ret)) {
 		cfg->vret_addr->inst_offset += delta;
 	}
@@ -4798,7 +4798,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 	if (tracing)
 		cfg->flags |= MONO_CFG_HAS_CALLS;
 	
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 	cfg->code_size = 768 + sig->param_count * 20;
 	code = cfg->native_code = g_malloc (cfg->code_size);
 
@@ -5167,7 +5167,7 @@ mono_arch_instrument_epilog (MonoCompile *cfg, void *func, void *p, gboolean ena
 	guchar *code = p;
 	int save_mode = SAVE_NONE;
 	MonoMethod *method = cfg->method;
-	int rtype = mini_get_underlying_type (mono_method_signature (method)->ret)->type;
+	int rtype = mini_get_underlying_type (mono_method_signature_internal (method)->ret)->type;
 	int save_offset = MIPS_STACK_PARAM_OFFSET;
 
 	g_assert ((save_offset & (MIPS_STACK_ALIGNMENT-1)) == 0);

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -1418,7 +1418,7 @@ mono_arch_allocate_vars (MonoCompile *m)
 		m->used_int_regs |= 1 << frame_reg;
 	}
 
-	sig = mono_method_signature (m->method);
+	sig = mono_method_signature_internal (m->method);
 	
 	offset = 0;
 	curinst = 0;
@@ -1561,7 +1561,7 @@ mono_arch_allocate_vars (MonoCompile *m)
 void
 mono_arch_create_vars (MonoCompile *cfg)
 {
-	MonoMethodSignature *sig = mono_method_signature (cfg->method);
+	MonoMethodSignature *sig = mono_method_signature_internal (cfg->method);
 
 	if (MONO_TYPE_ISSTRUCT (sig->ret)) {
 		cfg->vret_addr = mono_compile_create_var (cfg, mono_get_int_type (), OP_ARG);
@@ -1840,7 +1840,7 @@ mono_arch_emit_outarg_vt (MonoCompile *cfg, MonoInst *ins, MonoInst *src)
 void
 mono_arch_emit_setret (MonoCompile *cfg, MonoMethod *method, MonoInst *val)
 {
-	MonoType *ret = mini_get_underlying_type (mono_method_signature (method)->ret);
+	MonoType *ret = mini_get_underlying_type (mono_method_signature_internal (method)->ret);
 	if (!ret->byref) {
 #ifndef __mono_ppc64__
 		if (ret->type == MONO_TYPE_I8 || ret->type == MONO_TYPE_U8) {
@@ -1900,7 +1900,7 @@ mono_arch_instrument_epilog (MonoCompile *cfg, void *func, void *p, gboolean ena
 	guchar *code = p;
 	int save_mode = SAVE_NONE;
 	MonoMethod *method = cfg->method;
-	int rtype = mini_get_underlying_type (mono_method_signature (method)->ret)->type;
+	int rtype = mini_get_underlying_type (mono_method_signature_internal (method)->ret)->type;
 	int save_offset = PPC_STACK_PARAM_OFFSET + cfg->param_area;
 	save_offset += 15;
 	save_offset &= ~15;
@@ -4846,7 +4846,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 	if (mono_jit_trace_calls != NULL && mono_trace_eval (method))
 		tracing = 1;
 
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 	cfg->code_size = 512 + sig->param_count * 32;
 	code = cfg->native_code = g_malloc (cfg->code_size);
 

--- a/mono/mini/mini-profiler.c
+++ b/mono/mini/mini-profiler.c
@@ -34,7 +34,7 @@ emit_fill_call_ctx (MonoCompile *cfg, MonoInst *method, MonoInst *ret)
 	MONO_EMIT_NEW_STORE_MEMBASE (cfg, OP_STORE_MEMBASE_REG, alloc->dreg, MONO_STRUCT_OFFSET (MonoProfilerCallContext, method), method->dreg);
 
 	if (ret) {
-		MonoInst *var = mono_compile_create_var (cfg, mono_method_signature (cfg->method)->ret, OP_LOCAL);
+		MonoInst *var = mono_compile_create_var (cfg, mono_method_signature_internal (cfg->method)->ret, OP_LOCAL);
 
 		MonoInst *store, *addr;
 
@@ -254,7 +254,7 @@ get_variable_buffer (MonoDebugMethodJitInfo *jit, MonoDebugVarInfo *var, MonoCon
 gpointer
 mini_profiler_context_get_this (MonoProfilerCallContext *ctx)
 {
-	if (!mono_method_signature (ctx->method)->hasthis)
+	if (!mono_method_signature_internal (ctx->method)->hasthis)
 		return NULL;
 
 	if (ctx->interp_frame)
@@ -271,7 +271,7 @@ mini_profiler_context_get_this (MonoProfilerCallContext *ctx)
 gpointer
 mini_profiler_context_get_argument (MonoProfilerCallContext *ctx, guint32 pos)
 {
-	MonoMethodSignature *sig = mono_method_signature (ctx->method);
+	MonoMethodSignature *sig = mono_method_signature_internal (ctx->method);
 
 	if (pos >= sig->param_count)
 		return NULL;
@@ -320,7 +320,7 @@ mini_profiler_context_get_result (MonoProfilerCallContext *ctx)
 	if (!ctx->return_value)
 		return NULL;
 
-	return memdup_with_type (ctx->return_value, mono_method_signature (ctx->method)->ret);
+	return memdup_with_type (ctx->return_value, mono_method_signature_internal (ctx->method)->ret);
 }
 
 void

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -2711,7 +2711,7 @@ create_runtime_invoke_info (MonoDomain *domain, MonoMethod *method, gpointer com
 	if (mono_llvm_only && method->string_ctor)
 		info->sig = mono_marshal_get_string_ctor_signature (method);
 	else
-		info->sig = mono_method_signature (method);
+		info->sig = mono_method_signature_internal (method);
 
 	invoke = mono_marshal_get_runtime_invoke (method, FALSE);
 	info->vtable = mono_class_vtable_checked (domain, method->klass, error);
@@ -3008,7 +3008,7 @@ mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 					ji = mini_jit_info_table_find (mono_domain_get (), (char *)mono_get_addr_from_ftnptr (compiled_method), NULL);
 					callee_gsharedvt = mini_jit_info_is_gsharedvt (ji);
 					if (callee_gsharedvt)
-						callee_gsharedvt = mini_is_gsharedvt_variable_signature (mono_method_signature (jinfo_get_method (ji)));
+						callee_gsharedvt = mini_is_gsharedvt_variable_signature (mono_method_signature_internal (jinfo_get_method (ji)));
 				}
 
 				if (!callee_gsharedvt)
@@ -3072,7 +3072,7 @@ mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 		}
 	}
 	if (info->dyn_call_info) {
-		MonoMethodSignature *sig = mono_method_signature (method);
+		MonoMethodSignature *sig = mono_method_signature_internal (method);
 		gpointer *args;
 		int i, pindex, buf_size;
 		guint8 *buf;
@@ -3566,13 +3566,13 @@ mono_jit_create_remoting_trampoline (MonoDomain *domain, MonoMethod *method, Mon
 
 	error_init (error);
 
-	if ((method->flags & METHOD_ATTRIBUTE_VIRTUAL) && mono_method_signature (method)->generic_param_count) {
+	if ((method->flags & METHOD_ATTRIBUTE_VIRTUAL) && mono_method_signature_internal (method)->generic_param_count) {
 		return mono_create_specific_trampoline (method, MONO_TRAMPOLINE_GENERIC_VIRTUAL_REMOTING,
 			domain, NULL);
 	}
 
 	if ((method->flags & METHOD_ATTRIBUTE_ABSTRACT) ||
-	    (mono_method_signature (method)->hasthis && (mono_class_is_marshalbyref (method->klass) || method->klass == mono_defaults.object_class)))
+	    (mono_method_signature_internal (method)->hasthis && (mono_class_is_marshalbyref (method->klass) || method->klass == mono_defaults.object_class)))
 		nm = mono_marshal_get_remoting_invoke_for_target (method, target, error);
 	else
 		nm = method;
@@ -3675,7 +3675,7 @@ is_callee_gsharedvt_variable (gpointer addr)
 	g_assert (ji);
 	callee_gsharedvt = mini_jit_info_is_gsharedvt (ji);
 	if (callee_gsharedvt)
-		callee_gsharedvt = mini_is_gsharedvt_variable_signature (mono_method_signature (jinfo_get_method (ji)));
+		callee_gsharedvt = mini_is_gsharedvt_variable_signature (mono_method_signature_internal (jinfo_get_method (ji)));
 	return callee_gsharedvt;
 }
 
@@ -5042,7 +5042,7 @@ mono_precompile_assembly (MonoAssembly *ass, void *user_data)
 			mono_error_assert_ok (error);
 		}
 #ifndef DISABLE_REMOTING
-		if (mono_class_is_marshalbyref (method->klass) && mono_method_signature (method)->hasthis) {
+		if (mono_class_is_marshalbyref (method->klass) && mono_method_signature_internal (method)->hasthis) {
 			invoke = mono_marshal_get_remoting_invoke_with_check (method, error);
 			mono_error_assert_ok (error);
 			mono_compile_method_checked (invoke, error);

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -1034,7 +1034,7 @@ enter_method (MonoMethod *method, RegParm *rParm, char *sp)
 	if (rParm == NULL)
 		return;
 	
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 	
 	cinfo = get_call_info (NULL, sig);
 
@@ -1150,7 +1150,7 @@ leave_method (MonoMethod *method, ...)
 	fprintf (trFd, "LEAVE: %s", fname);
 	g_free (fname);
 
-	type = mono_method_signature (method)->ret;
+	type = mono_method_signature_internal (method)->ret;
 
 handle_enum:
 	switch (type->type) {
@@ -1365,7 +1365,7 @@ handle_enum:
 		break;
 	default:
 		fprintf (trFd, "(unknown return type %x)", 
-			mono_method_signature (method)->ret->type);
+			mono_method_signature_internal (method)->ret->type);
 	}
 
 	ip = ((gint64) __builtin_extract_return_addr (__builtin_return_address (0)));
@@ -2085,7 +2085,7 @@ mono_arch_allocate_vars (MonoCompile *cfg)
 	if (frame_reg != STK_BASE) 
 		cfg->used_int_regs |= (1LL << frame_reg);		
 
-	sig     = mono_method_signature (cfg->method);
+	sig     = mono_method_signature_internal (cfg->method);
 	
 	cinfo   = get_call_info (cfg->mempool, sig);
 
@@ -2306,7 +2306,7 @@ mono_arch_create_vars (MonoCompile *cfg)
 	MonoMethodSignature *sig;
 	CallInfo *cinfo;
 
-	sig = mono_method_signature (cfg->method);
+	sig = mono_method_signature_internal (cfg->method);
 
 	cinfo = get_call_info (cfg->mempool, sig);
 
@@ -2651,7 +2651,7 @@ mono_arch_emit_outarg_vt (MonoCompile *cfg, MonoInst *ins, MonoInst *src)
 void
 mono_arch_emit_setret (MonoCompile *cfg, MonoMethod *method, MonoInst *val)
 {
-	MonoType *ret = mini_get_underlying_type (mono_method_signature (method)->ret);
+	MonoType *ret = mini_get_underlying_type (mono_method_signature_internal (method)->ret);
 
 	if (!ret->byref) {
 		if (ret->type == MONO_TYPE_R4) {
@@ -2729,7 +2729,7 @@ mono_arch_instrument_epilog (MonoCompile *cfg, void *func, void *p, gboolean ena
 	int   	   save_mode = SAVE_NONE,
 		   saveOffset;
 	MonoMethod *method = cfg->method;
-	int rtype = mini_get_underlying_type (mono_method_signature (method)->ret)->type;
+	int rtype = mini_get_underlying_type (mono_method_signature_internal (method)->ret)->type;
 
 	set_code_cursor (cfg, code);
 	/*-----------------------------------------*/
@@ -2761,8 +2761,8 @@ handle_enum:
 		save_mode = SAVE_R8;
 		break;
 	case MONO_TYPE_VALUETYPE:
-		if (m_class_is_enumtype (mono_method_signature (method)->ret->data.klass)) {
-			rtype = mono_class_enum_basetype_internal (mono_method_signature (method)->ret->data.klass)->type;
+		if (m_class_is_enumtype (mono_method_signature_internal (method)->ret->data.klass)) {
+			rtype = mono_class_enum_basetype_internal (mono_method_signature_internal (method)->ret->data.klass)->type;
 			goto handle_enum;
 		}
 		save_mode = SAVE_STRUCT;
@@ -4275,7 +4275,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_TAILCALL_MEMBASE : {
 			MonoCallInst *call = (MonoCallInst *) ins;
 			MonoMethod *method = call->method;
-			MonoMethodSignature *sig = mono_method_signature(method);
+			MonoMethodSignature *sig = mono_method_signature_internal (method);
 			CallInfo *cinfo = get_call_info (NULL, sig);
 			int32_t stackUsage = (cinfo->sz.stack_size - S390_MINIMAL_STACK_SIZE),
 				stackOffset = S390_MINIMAL_STACK_SIZE;
@@ -6249,7 +6249,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 	}
 
 	/* load arguments allocated to register from the stack */
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 	pos = 0;
 
 	cinfo = get_call_info (cfg->mempool, sig);

--- a/mono/mini/mini-sparc.c
+++ b/mono/mini/mini-sparc.c
@@ -747,7 +747,7 @@ mono_arch_get_global_int_regs (MonoCompile *cfg)
 	MonoMethodSignature *sig;
 	CallInfo *cinfo;
 
-	sig = mono_method_signature (cfg->method);
+	sig = mono_method_signature_internal (cfg->method);
 
 	cinfo = get_call_info (cfg, sig, FALSE);
 
@@ -793,7 +793,7 @@ mono_arch_allocate_vars (MonoCompile *cfg)
 
 	header = cfg->header;
 
-	sig = mono_method_signature (cfg->method);
+	sig = mono_method_signature_internal (cfg->method);
 
 	cinfo = get_call_info (cfg, sig, FALSE);
 
@@ -1027,7 +1027,7 @@ mono_arch_create_vars (MonoCompile *cfg)
 {
 	MonoMethodSignature *sig;
 
-	sig = mono_method_signature (cfg->method);
+	sig = mono_method_signature_internal (cfg->method);
 
 	if (MONO_TYPE_ISSTRUCT ((sig->ret))) {
 		cfg->vret_addr = mono_compile_create_var (cfg, mono_get_int_type (), OP_ARG);
@@ -1342,8 +1342,8 @@ mono_arch_emit_outarg_vt (MonoCompile *cfg, MonoInst *ins, MonoInst *src)
 void
 mono_arch_emit_setret (MonoCompile *cfg, MonoMethod *method, MonoInst *val)
 {
-	CallInfo *cinfo = get_call_info (cfg, mono_method_signature (method), FALSE);
-	MonoType *ret = mini_get_underlying_type (mono_method_signature (method)->ret);
+	CallInfo *cinfo = get_call_info (cfg, mono_method_signature_internal (method), FALSE);
+	MonoType *ret = mini_get_underlying_type (mono_method_signature_internal (method)->ret);
 
 	switch (cinfo->ret.storage) {
 	case ArgInIReg:
@@ -2116,7 +2116,7 @@ emit_load_volatile_arguments (MonoCompile *cfg, guint32 *code)
 
 	/* FIXME: Generate intermediate code instead */
 
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 
 	cinfo = get_call_info (cfg, sig, FALSE);
 	
@@ -2928,7 +2928,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			code = emit_move_return_value (ins, code);
 			break;
 		case OP_SETFRET:
-			if (mono_method_signature (cfg->method)->ret->type == MONO_TYPE_R4)
+			if (mono_method_signature_internal (cfg->method)->ret->type == MONO_TYPE_R4)
 				sparc_fdtos (code, ins->sreg1, sparc_f0);
 			else {
 #ifdef SPARCV9
@@ -3707,7 +3707,7 @@ mono_arch_instrument_prolog (MonoCompile *cfg, void *func, void *p, gboolean ena
 {
 	int i;
 	guint32 *code = (guint32*)p;
-	MonoMethodSignature *sig = mono_method_signature (cfg->method);
+	MonoMethodSignature *sig = mono_method_signature_internal (cfg->method);
 	CallInfo *cinfo;
 
 	/* Save registers to stack */
@@ -3778,7 +3778,7 @@ mono_arch_instrument_epilog (MonoCompile *cfg, void *func, void *p, gboolean ena
 	int save_mode = SAVE_NONE;
 	MonoMethod *method = cfg->method;
 
-	switch (mini_get_underlying_type (mono_method_signature (method)->ret)->type) {
+	switch (mini_get_underlying_type (mono_method_signature_internal (method)->ret)->type) {
 	case MONO_TYPE_VOID:
 		/* special case string .ctor icall */
 		if (strcmp (".ctor", method->name) && method->klass == mono_defaults.string_class)
@@ -3929,7 +3929,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 	}
 */
 
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 
 	cinfo = get_call_info (cfg, sig, FALSE);
 
@@ -4111,7 +4111,7 @@ mono_arch_emit_epilog (MonoCompile *cfg)
 	 * The V8 ABI requires that calls to functions which return a structure
 	 * return to %i7+12
 	 */
-	if (!v64 && mono_method_signature (cfg->method)->pinvoke && MONO_TYPE_ISSTRUCT(mono_method_signature (cfg->method)->ret))
+	if (!v64 && mono_method_signature_internal (cfg->method)->pinvoke && MONO_TYPE_ISSTRUCT(mono_method_signature_internal (cfg->method)->ret))
 		sparc_jmpl_imm (code, sparc_i7, 12, sparc_g0);
 	else
 		sparc_ret (code);

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -379,14 +379,14 @@ mini_add_method_trampoline (MonoMethod *m, gpointer compiled_method, gboolean ad
 
 	if (ji && !ji->is_trampoline)
 		jmethod = jinfo_get_method (ji);
-	if (callee_gsharedvt && mini_is_gsharedvt_variable_signature (mono_method_signature (jmethod))) {
+	if (callee_gsharedvt && mini_is_gsharedvt_variable_signature (mono_method_signature_internal (jmethod))) {
 		MonoMethodSignature *sig, *gsig;
 
 		/* Here m is a generic instance, while ji->method is the gsharedvt method implementing it */
 
 		/* Call from normal/gshared code to gsharedvt code with variable signature */
-		sig = mono_method_signature (m);
-		gsig = mono_method_signature (jmethod);
+		sig = mono_method_signature_internal (m);
+		gsig = mono_method_signature_internal (jmethod);
 
 		addr = mini_get_gsharedvt_wrapper (TRUE, addr, sig, gsig, -1, FALSE);
 
@@ -492,7 +492,7 @@ mini_add_method_wrappers_llvmonly (MonoMethod *m, gpointer compiled_method, gboo
 		jmethod = jinfo_get_method (ji);
 
 	if (callee_gsharedvt)
-		callee_gsharedvt = mini_is_gsharedvt_variable_signature (mono_method_signature (jmethod));
+		callee_gsharedvt = mini_is_gsharedvt_variable_signature (mono_method_signature_internal (jmethod));
 
 	if (!caller_gsharedvt && callee_gsharedvt) {
 		MonoMethodSignature *sig, *gsig;
@@ -501,8 +501,8 @@ mini_add_method_wrappers_llvmonly (MonoMethod *m, gpointer compiled_method, gboo
 		/* Here m is a generic instance, while ji->method is the gsharedvt method implementing it */
 
 		/* Call from normal/gshared code to gsharedvt code with variable signature */
-		sig = mono_method_signature (m);
-		gsig = mono_method_signature (jmethod);
+		sig = mono_method_signature_internal (m);
+		gsig = mono_method_signature_internal (jmethod);
 
 		wrapper_addr = mini_get_gsharedvt_wrapper (TRUE, addr, sig, gsig, -1, FALSE);
 
@@ -521,7 +521,7 @@ mini_add_method_wrappers_llvmonly (MonoMethod *m, gpointer compiled_method, gboo
 		/*
 		 * The callee uses the gsharedvt calling convention, have to add an out wrapper.
 		 */
-		gpointer out_wrapper = mini_get_gsharedvt_wrapper (FALSE, NULL, mono_method_signature (m), NULL, -1, FALSE);
+		gpointer out_wrapper = mini_get_gsharedvt_wrapper (FALSE, NULL, mono_method_signature_internal (m), NULL, -1, FALSE);
 		MonoFtnDesc *out_wrapper_arg = mini_create_llvmonly_ftndesc (mono_domain_get (), addr, *out_arg);
 
 		addr = out_wrapper;
@@ -1306,7 +1306,7 @@ mono_delegate_trampoline (host_mgreg_t *regs, guint8 *code, gpointer *arg, guint
 
 	multicast = ((MonoMulticastDelegate*)delegate)->delegates != NULL;
 	if (!multicast && !callvirt) {
-		if (method && (method->flags & METHOD_ATTRIBUTE_STATIC) && mono_method_signature (method)->param_count == mono_method_signature (invoke)->param_count + 1)
+		if (method && (method->flags & METHOD_ATTRIBUTE_STATIC) && mono_method_signature_internal (method)->param_count == mono_method_signature_internal (invoke)->param_count + 1)
 			/* Closed static delegate */
 			code = impl_this;
 		else
@@ -1605,9 +1605,9 @@ mono_create_delegate_trampoline_info (MonoDomain *domain, MonoClass *klass, Mono
 
 	tramp_info = (MonoDelegateTrampInfo *)mono_domain_alloc0 (domain, sizeof (MonoDelegateTrampInfo));
 	tramp_info->invoke = invoke;
-	tramp_info->invoke_sig = mono_method_signature (invoke);
-	tramp_info->impl_this = mono_arch_get_delegate_invoke_impl (mono_method_signature (invoke), TRUE);
-	tramp_info->impl_nothis = mono_arch_get_delegate_invoke_impl (mono_method_signature (invoke), FALSE);
+	tramp_info->invoke_sig = mono_method_signature_internal (invoke);
+	tramp_info->impl_this = mono_arch_get_delegate_invoke_impl (mono_method_signature_internal (invoke), TRUE);
+	tramp_info->impl_nothis = mono_arch_get_delegate_invoke_impl (mono_method_signature_internal (invoke), FALSE);
 	tramp_info->method = method;
 	if (method) {
 		error_init (error);
@@ -1649,7 +1649,7 @@ mono_create_delegate_virtual_trampoline (MonoDomain *domain, MonoClass *klass, M
 	MonoMethod *invoke = mono_get_delegate_invoke (klass);
 	g_assert (invoke);
 
-	return mono_get_delegate_virtual_invoke_impl (mono_method_signature (invoke), method);
+	return mono_get_delegate_virtual_invoke_impl (mono_method_signature_internal (invoke), method);
 }
 
 gpointer

--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -586,7 +586,7 @@ describe_variable (MonoStackFrameInfo *info, MonoContext *ctx, gpointer ud)
 	int pos = data->variable;
 	if (pos < 0) {
 		pos = -pos - 1;
-		type = mono_method_signature (method)->params [pos];
+		type = mono_method_signature_internal (method)->params [pos];
 		addr = mini_get_interp_callbacks ()->frame_get_arg (frame, pos);
 	} else {
 		header = mono_method_get_header_checked (method, error);

--- a/mono/mini/mini-wasm.c
+++ b/mono/mini/mini-wasm.c
@@ -203,7 +203,7 @@ mono_arch_create_vars (MonoCompile *cfg)
 	CallInfo *cinfo;
 	MonoType *sig_ret;
 
-	sig = mono_method_signature (cfg->method);
+	sig = mono_method_signature_internal (cfg->method);
 
 	if (!cfg->arch.cinfo)
 		cfg->arch.cinfo = get_call_info (cfg->mempool, sig);
@@ -270,7 +270,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 void
 mono_arch_emit_setret (MonoCompile *cfg, MonoMethod *method, MonoInst *val)
 {
-	MonoType *ret = mini_get_underlying_type (mono_method_signature (method)->ret);
+	MonoType *ret = mini_get_underlying_type (mono_method_signature_internal (method)->ret);
 
 	if (!ret->byref) {
 		if (ret->type == MONO_TYPE_R4) {

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -981,7 +981,7 @@ needs_stack_frame (MonoCompile *cfg)
 		return cfg->arch.need_stack_frame;
 
 	header = cfg->header;
-	sig = mono_method_signature (cfg->method);
+	sig = mono_method_signature_internal (cfg->method);
 
 	if (cfg->disable_omit_fp)
 		result = TRUE;
@@ -1025,7 +1025,7 @@ mono_arch_allocate_vars (MonoCompile *cfg)
 	CallInfo *cinfo;
 
 	header = cfg->header;
-	sig = mono_method_signature (cfg->method);
+	sig = mono_method_signature_internal (cfg->method);
 
 	if (!cfg->arch.cinfo)
 		cfg->arch.cinfo = get_call_info (cfg->mempool, sig);
@@ -1192,7 +1192,7 @@ mono_arch_create_vars (MonoCompile *cfg)
 	MonoMethodSignature *sig;
 	CallInfo *cinfo;
 
-	sig = mono_method_signature (cfg->method);
+	sig = mono_method_signature_internal (cfg->method);
 
 	if (!cfg->arch.cinfo)
 		cfg->arch.cinfo = get_call_info (cfg->mempool, sig);
@@ -1657,7 +1657,7 @@ mono_arch_emit_outarg_vt (MonoCompile *cfg, MonoInst *ins, MonoInst *src)
 void
 mono_arch_emit_setret (MonoCompile *cfg, MonoMethod *method, MonoInst *val)
 {
-	MonoType *ret = mini_get_underlying_type (mono_method_signature (method)->ret);
+	MonoType *ret = mini_get_underlying_type (mono_method_signature_internal (method)->ret);
 
 	if (!ret->byref) {
 		if (ret->type == MONO_TYPE_R4) {
@@ -1691,7 +1691,7 @@ void*
 mono_arch_instrument_prolog (MonoCompile *cfg, void *func, void *p, gboolean enable_arguments)
 {
 	guchar *code = (guchar*)p;
-	MonoMethodSignature *sig = mono_method_signature (cfg->method);
+	MonoMethodSignature *sig = mono_method_signature_internal (cfg->method);
 	int argument_copy_size = 0;
 	const guint32* param_regs;
 	int stack_size;
@@ -1774,7 +1774,7 @@ mono_arch_instrument_epilog (MonoCompile *cfg, void *func, void *p, gboolean ena
 	guchar *code = (guchar*)p;
 	int arg_size = 0, stack_usage = 0, save_mode = SAVE_NONE;
 	MonoMethod *method = cfg->method;
-	MonoType *ret_type = mini_get_underlying_type (mono_method_signature (method)->ret);
+	MonoType *ret_type = mini_get_underlying_type (mono_method_signature_internal (method)->ret);
 
 	switch (ret_type->type) {
 	case MONO_TYPE_VOID:
@@ -5330,7 +5330,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 	}
 
 	/* load arguments allocated to register from the stack */
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 	pos = 0;
 
 	cinfo = cfg->arch.cinfo;
@@ -5364,7 +5364,7 @@ void
 mono_arch_emit_epilog (MonoCompile *cfg)
 {
 	MonoMethod *method = cfg->method;
-	MonoMethodSignature *sig = mono_method_signature (method);
+	MonoMethodSignature *sig = mono_method_signature_internal (method);
 	int i, quad, pos;
 	guint32 stack_to_pop;
 	guint8 *code;

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -2018,7 +2018,7 @@ mono_compile_create_vars (MonoCompile *cfg)
 
 	header = cfg->header;
 
-	sig = mono_method_signature (cfg->method);
+	sig = mono_method_signature_internal (cfg->method);
 	
 	if (!MONO_TYPE_IS_VOID (sig->ret)) {
 		cfg->ret = mono_compile_create_var (cfg, sig->ret, OP_ARG);
@@ -2460,7 +2460,7 @@ create_jit_info (MonoCompile *cfg, MonoMethod *method_to_compile)
 
 	if (cfg->arch_eh_jit_info) {
 		MonoJitArgumentInfo *arg_info;
-		MonoMethodSignature *sig = mono_method_signature (cfg->method_to_register);
+		MonoMethodSignature *sig = mono_method_signature_internal (cfg->method_to_register);
 
 		/*
 		 * This cannot be computed during stack walking, as

--- a/mono/mini/simd-intrinsics.c
+++ b/mono/mini/simd-intrinsics.c
@@ -1280,7 +1280,7 @@ simd_intrinsic_emit_binary_op (MonoCompile *cfg, int opcode, int flags, MonoClas
 static MonoInst*
 simd_intrinsic_emit_binary (const SimdIntrinsic *intrinsic, MonoCompile *cfg, MonoMethod *cmethod, MonoInst **args)
 {
-	MonoMethodSignature *sig = mono_method_signature (cmethod);
+	MonoMethodSignature *sig = mono_method_signature_internal (cmethod);
 
 	g_assert (sig->param_count == 2);
 
@@ -1399,7 +1399,7 @@ static MonoInst*
 simd_intrinsic_emit_setter (const SimdIntrinsic *intrinsic, MonoCompile *cfg, MonoMethod *cmethod, MonoInst **args)
 {
 	MonoInst *ins;
-	MonoMethodSignature *sig = mono_method_signature (cmethod);
+	MonoMethodSignature *sig = mono_method_signature_internal (cmethod);
 	int size, align;
 	gboolean indirect;
 	int dreg;
@@ -1528,7 +1528,7 @@ simd_intrinsic_emit_getter_op (MonoCompile *cfg, int index, MonoClass *klass, Mo
 static MonoInst*
 simd_intrinsic_emit_getter (const SimdIntrinsic *intrinsic, MonoCompile *cfg, MonoMethod *cmethod, MonoInst **args)
 {
-	MonoMethodSignature *sig = mono_method_signature (cmethod);
+	MonoMethodSignature *sig = mono_method_signature_internal (cmethod);
 
 	return simd_intrinsic_emit_getter_op (cfg, intrinsic->opcode, cmethod->klass, sig->ret, args [0]);
 }
@@ -1538,7 +1538,7 @@ simd_intrinsic_emit_long_getter (const SimdIntrinsic *intrinsic, MonoCompile *cf
 {
 	MonoInst *ins;
 	int vreg;
-	gboolean is_r8 = mono_method_signature (cmethod)->ret->type == MONO_TYPE_R8;
+	gboolean is_r8 = mono_method_signature_internal (cmethod)->ret->type == MONO_TYPE_R8;
 
 	vreg = load_simd_vreg (cfg, cmethod, args [0], NULL);
 
@@ -1565,7 +1565,7 @@ simd_intrinsic_emit_ctor (const SimdIntrinsic *intrinsic, MonoCompile *cfg, Mono
 	MonoInst *ins = NULL;
 	int i, addr_reg;
 	gboolean is_ldaddr = (args [0]->opcode == OP_LDADDR && args [0]->inst_left->opcode != OP_ARG);
-	MonoMethodSignature *sig = mono_method_signature (cmethod);
+	MonoMethodSignature *sig = mono_method_signature_internal (cmethod);
 	int store_op = mono_type_to_store_membase (cfg, sig->params [0]);
 	int arg_size = mono_type_size (sig->params [0], &i);
 	int opcode;
@@ -1657,7 +1657,7 @@ simd_intrinsic_emit_cast (const SimdIntrinsic *intrinsic, MonoCompile *cfg, Mono
 
 	if (cmethod->is_inflated)
 		/* Vector<T> */
-		klass = mono_class_from_mono_type (mono_method_signature (cmethod)->ret);
+		klass = mono_class_from_mono_type (mono_method_signature_internal (cmethod)->ret);
 	else
 		klass = cmethod->klass;
 
@@ -1761,7 +1761,7 @@ simd_intrinsic_emit_shuffle (const SimdIntrinsic *intrinsic, MonoCompile *cfg, M
 {
 	MonoInst *ins;
 	int vreg, vreg2 = -1;
-	int param_count = mono_method_signature (cmethod)->param_count;
+	int param_count = mono_method_signature_internal (cmethod)->param_count;
 
 	if (args [param_count - 1]->opcode != OP_ICONST) {
 		/*TODO Shuffle with non literals is not yet supported */
@@ -2088,7 +2088,7 @@ mono_emit_simd_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 	if (!strcmp ("VectorOperations", class_name)) {
 		if (!(cmethod->flags & METHOD_ATTRIBUTE_STATIC))
 			goto on_exit;
-		class_name = m_class_get_name (mono_class_from_mono_type (mono_method_signature (cmethod)->params [0]));
+		class_name = m_class_get_name (mono_class_from_mono_type (mono_method_signature_internal (cmethod)->params [0]));
 	} else if (!m_class_is_simd_type (cmethod->klass))
 		goto on_exit;
 
@@ -2187,7 +2187,7 @@ static MonoInst*
 emit_vector_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, MonoInst **args)
 {
 	const SimdIntrinsic *intrins;
-	MonoMethodSignature *sig = mono_method_signature (cmethod);
+	MonoMethodSignature *sig = mono_method_signature_internal (cmethod);
 	MonoType *type = m_class_get_byval_arg (cmethod->klass);
 
 	if (!m_class_is_simd_type (cmethod->klass))
@@ -2234,7 +2234,7 @@ emit_vector_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignatu
 
 			ins = simd_intrinsic_emit_binary (intrins, cfg, cmethod, args);
 			/* The end result is in the lowest element */
-			return simd_intrinsic_emit_getter_op (cfg, 0, cmethod->klass, mono_method_signature (cmethod)->ret, ins);
+			return simd_intrinsic_emit_getter_op (cfg, 0, cmethod->klass, mono_method_signature_internal (cmethod)->ret, ins);
 		}
 		break;
 	case SN_Abs: {

--- a/mono/mini/trace.c
+++ b/mono/mini/trace.c
@@ -166,7 +166,7 @@ mono_trace_enter_method (MonoMethod *method, char *ebp)
 		goto unlock;
 	}
 
-	sig = mono_method_signature (method);
+	sig = mono_method_signature_internal (method);
 
 	arg_info = g_newa (MonoJitArgumentInfo, sig->param_count + 1);
 
@@ -185,13 +185,13 @@ mono_trace_enter_method (MonoMethod *method, char *ebp)
 
 	mono_arch_get_argument_info (sig, sig->param_count, arg_info);
 
-	if (MONO_TYPE_ISSTRUCT (mono_method_signature (method)->ret)) {
-		g_assert (!mono_method_signature (method)->ret->byref);
+	if (MONO_TYPE_ISSTRUCT (mono_method_signature_internal (method)->ret)) {
+		g_assert (!mono_method_signature_internal (method)->ret->byref);
 
 		printf ("VALUERET:%p, ", *((gpointer *)(ebp + 8)));
 	}
 
-	if (mono_method_signature (method)->hasthis) {
+	if (mono_method_signature_internal (method)->hasthis) {
 		gpointer *this_obj = (gpointer *)(ebp + arg_info [0].offset);
 		if (m_class_is_valuetype (method->klass)) {
 			printf ("value:%p, ", *arg_in_stack_slot(this_obj, gpointer *));
@@ -215,11 +215,11 @@ mono_trace_enter_method (MonoMethod *method, char *ebp)
 		}
 	}
 
-	for (i = 0; i < mono_method_signature (method)->param_count; ++i) {
+	for (i = 0; i < mono_method_signature_internal (method)->param_count; ++i) {
 		gpointer *cpos = (gpointer *)(ebp + arg_info [i + 1].offset);
 		int size = arg_info [i + 1].size;
 
-		MonoType *type = mono_method_signature (method)->params [i];
+		MonoType *type = mono_method_signature_internal (method)->params [i];
 		
 		if (type->byref) {
 			printf ("[BYREF:%p], ", *arg_in_stack_slot(cpos, gpointer *));
@@ -348,7 +348,7 @@ mono_trace_leave_method (MonoMethod *method, ...)
 		}
 	}
 
-	type = mini_get_underlying_type (mono_method_signature (method)->ret);
+	type = mini_get_underlying_type (mono_method_signature_internal (method)->ret);
 
 	switch (type->type) {
 	case MONO_TYPE_VOID:
@@ -443,7 +443,7 @@ mono_trace_leave_method (MonoMethod *method, ...)
 		break;
 	}
 	default:
-		printf ("(unknown return type %x)", mono_method_signature (method)->ret->type);
+		printf ("(unknown return type %x)", mono_method_signature_internal (method)->ret->type);
 	}
 
 	//printf (" ip: %p\n", MONO_RETURN_ADDRESS_N (1));

--- a/mono/profiler/coverage.c
+++ b/mono/profiler/coverage.c
@@ -277,7 +277,7 @@ dump_method (gpointer key, gpointer value, gpointer userdata)
 	image = mono_class_get_image (klass);
 	image_name = mono_image_get_name (image);
 
-	method_signature = mono_signature_get_desc (mono_method_signature (method), TRUE);
+	method_signature = mono_signature_get_desc (mono_method_signature_internal (method), TRUE);
 	class_name = parse_generic_type_names (mono_type_get_name (m_class_get_byval_arg (klass)));
 	method_name = mono_method_get_name (method);
 

--- a/mono/profiler/vtune.c
+++ b/mono/profiler/vtune.c
@@ -82,7 +82,7 @@ method_jit_done (MonoProfiler *prof, MonoMethod *method, MonoJitInfo* jinfo)
 	MonoDebugSourceLocation *sourceLoc;
 	MonoDebugMethodJitInfo *dmji;
 	MonoClass *klass = mono_method_get_class (method);
-	char *signature = mono_signature_get_desc (mono_method_signature (method), TRUE);
+	char *signature = mono_signature_get_desc (mono_method_signature_internal (method), TRUE);
 	char *name = g_strdup_printf ("%s(%s)", mono_method_get_name (method), signature);
 	char *classname = g_strdup_printf ("%s%s%s", m_class_get_name_space (klass), m_class_get_name_space (klass)[0] != 0 ? "::" : "", m_class_get_name (klass));
 	gpointer code_start = mono_jit_info_get_code_start (jinfo);

--- a/tools/pedump/pedump.c
+++ b/tools/pedump/pedump.c
@@ -378,11 +378,11 @@ dump_verify_info (MonoImage *image, int flags, gboolean valid_only)
 			if (errors) {
 				MonoClass *klass = mono_method_get_class (method);
 				char *name = mono_type_full_name (m_class_get_byval_arg (klass));
-				if (mono_method_signature (method) == NULL) {
+				if (mono_method_signature_internal (method) == NULL) {
 					g_print ("In method: %s::%s(ERROR)\n", name, mono_method_get_name (method));
 				} else {
 					char *sig;
-					sig = mono_signature_get_desc (mono_method_signature (method), FALSE);	
+					sig = mono_signature_get_desc (mono_method_signature_internal (method), FALSE);	
 					g_print ("In method: %s::%s(%s)\n", name, mono_method_get_name (method), sig);
 					g_free (sig);
 				}


### PR DESCRIPTION
FIXME Should be mono_method_signature_checked.
And let's hope all the machinery is otherwise in place and this wasn't covering for it missing.