### PR TITLE
mono_field_get_type to mono_field_get_type_internal to skip GC mode machinery

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1215,6 +1215,9 @@ gboolean mono_is_corlib_image (MonoImage *image);
 MonoType*
 mono_field_get_type_checked (MonoClassField *field, MonoError *error);
 
+MonoType*
+mono_field_get_type_internal (MonoClassField *field);
+
 MonoClassField*
 mono_class_get_fields_internal (MonoClass* klass, gpointer *iter);
 

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -4771,6 +4771,27 @@ mono_field_get_name (MonoClassField *field)
 }
 
 /**
+ * mono_field_get_type_internal:
+ * \param field the \c MonoClassField to act on
+ * \returns \c MonoType of the field.
+ */
+MonoType*
+mono_field_get_type_internal (MonoClassField *field)
+{
+	MonoType *type = field->type;
+	if (type)
+		return type;
+
+	ERROR_DECL (error);
+	type = mono_field_get_type_checked (field, error);
+	if (!mono_error_ok (error)) {
+		mono_trace_warning (MONO_TRACE_TYPE, "Could not load field's type due to %s", mono_error_get_message (error));
+		mono_error_cleanup (error);
+	}
+	return type;
+}
+
+/**
  * mono_field_get_type:
  * \param field the \c MonoClassField to act on
  * \returns \c MonoType of the field.
@@ -4778,18 +4799,15 @@ mono_field_get_name (MonoClassField *field)
 MonoType*
 mono_field_get_type (MonoClassField *field)
 {
-	ERROR_DECL (error);
-	MonoType *type;
+	MonoType *type = field->type;
+	if (type)
+		return type;
+
 	MONO_ENTER_GC_UNSAFE;
-	type = mono_field_get_type_checked (field, error);
-	if (!mono_error_ok (error)) {
-		mono_trace_warning (MONO_TRACE_TYPE, "Could not load field's type due to %s", mono_error_get_message (error));
-		mono_error_cleanup (error);
-	}
+	type = mono_field_get_type_internal (field);
 	MONO_EXIT_GC_UNSAFE;
 	return type;
 }
-
 
 /**
  * mono_field_get_type_checked:
@@ -4802,8 +4820,10 @@ MonoType*
 mono_field_get_type_checked (MonoClassField *field, MonoError *error)
 {
 	error_init (error);
-	if (!field->type)
-		mono_field_resolve_type (field, error);
+	MonoType *type = field->type;
+	if (type)
+		return type;
+	mono_field_resolve_type (field, error);
 	return field->type;
 }
 
@@ -5532,11 +5552,11 @@ gboolean
 mono_method_can_access_field (MonoMethod *method, MonoClassField *field)
 {
 	/* FIXME: check all overlapping fields */
-	int can = can_access_member (method->klass, field->parent, NULL, mono_field_get_type (field)->attrs & FIELD_ATTRIBUTE_FIELD_ACCESS_MASK);
+	int can = can_access_member (method->klass, field->parent, NULL, mono_field_get_type_internal (field)->attrs & FIELD_ATTRIBUTE_FIELD_ACCESS_MASK);
 	if (!can) {
 		MonoClass *nested = m_class_get_nested_in (method->klass);
 		while (nested) {
-			can = can_access_member (nested, field->parent, NULL, mono_field_get_type (field)->attrs & FIELD_ATTRIBUTE_FIELD_ACCESS_MASK);
+			can = can_access_member (nested, field->parent, NULL, mono_field_get_type_internal (field)->attrs & FIELD_ATTRIBUTE_FIELD_ACCESS_MASK);
 			if (can)
 				return TRUE;
 			nested = m_class_get_nested_in (nested);

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1841,7 +1841,7 @@ ves_icall_System_Reflection_FieldInfo_get_marshal_info (MonoReflectionFieldHandl
 	    (gklass && gklass->context.class_inst->is_open))
 		return MONO_HANDLE_CAST (MonoReflectionMarshalAsAttribute, NULL_HANDLE);
 
-	MonoType *ftype = mono_field_get_type (field);
+	MonoType *ftype = mono_field_get_type_internal (field);
 	if (ftype && !(ftype->attrs & FIELD_ATTRIBUTE_HAS_FIELD_MARSHAL))
 		return MONO_HANDLE_CAST (MonoReflectionMarshalAsAttribute, NULL_HANDLE);
 

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -779,9 +779,9 @@ mono_image_get_fieldref_token (MonoDynamicImage *assembly, MonoClassField *field
 
 	if (mono_class_is_ginst (field->parent) && mono_class_get_generic_class (field->parent)->container_class && mono_class_get_generic_class (field->parent)->container_class->fields) {
 		int index = field - field->parent->fields;
-		type = mono_field_get_type (&mono_class_get_generic_class (field->parent)->container_class->fields [index]);
+		type = mono_field_get_type_internal (&mono_class_get_generic_class (field->parent)->container_class->fields [index]);
 	} else {
-		type = mono_field_get_type (field);
+		type = mono_field_get_type_internal (field);
 	}
 	token = mono_image_get_memberref_token (assembly, m_class_get_byval_arg (field->parent),
 											mono_field_get_name (field),

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -3459,7 +3459,7 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsig
 			token = read32 (td->ip + 1);
 			field = interp_field_from_token (method, token, &klass, generic_context, error);
 			goto_if_nok (error, exit);
-			MonoType *ftype = mono_field_get_type (field);
+			MonoType *ftype = mono_field_get_type_internal (field);
 			gboolean is_static = !!(ftype->attrs & FIELD_ATTRIBUTE_STATIC);
 			mono_class_init (klass);
 #ifndef DISABLE_REMOTING
@@ -3511,7 +3511,7 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsig
 			token = read32 (td->ip + 1);
 			field = interp_field_from_token (method, token, &klass, generic_context, error);
 			goto_if_nok (error, exit);
-			MonoType *ftype = mono_field_get_type (field);
+			MonoType *ftype = mono_field_get_type_internal (field);
 			gboolean is_static = !!(ftype->attrs & FIELD_ATTRIBUTE_STATIC);
 			mono_class_init (klass);
 
@@ -3572,7 +3572,7 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsig
 			token = read32 (td->ip + 1);
 			field = interp_field_from_token (method, token, &klass, generic_context, error);
 			goto_if_nok (error, exit);
-			MonoType *ftype = mono_field_get_type (field);
+			MonoType *ftype = mono_field_get_type_internal (field);
 			gboolean is_static = !!(ftype->attrs & FIELD_ATTRIBUTE_STATIC);
 			mono_class_init (klass);
 			mt = mint_type (ftype);
@@ -3623,7 +3623,7 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsig
 			token = read32 (td->ip + 1);
 			field = interp_field_from_token (method, token, &klass, generic_context, error);
 			goto_if_nok (error, exit);
-			mono_field_get_type (field);
+			mono_field_get_type_internal (field);
 			ADD_CODE(td, MINT_LDSFLDA);
 			ADD_CODE(td, get_data_item_index (td, field));
 			td->ip += 5;
@@ -3634,7 +3634,7 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsig
 			token = read32 (td->ip + 1);
 			field = interp_field_from_token (method, token, &klass, generic_context, error);
 			goto_if_nok (error, exit);
-			MonoType *ftype = mono_field_get_type (field);
+			MonoType *ftype = mono_field_get_type_internal (field);
 			mt = mint_type (ftype);
 			klass = NULL;
 			if (mt == MINT_TYPE_VT) {
@@ -3668,7 +3668,7 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, unsig
 			token = read32 (td->ip + 1);
 			field = interp_field_from_token (method, token, &klass, generic_context, error);
 			goto_if_nok (error, exit);
-			MonoType *ftype = mono_field_get_type (field);
+			MonoType *ftype = mono_field_get_type_internal (field);
 			mt = mint_type (ftype);
 
 			/* the vtable of the field might not be initialized at this point */

--- a/mono/mini/memory-access.c
+++ b/mono/mini/memory-access.c
@@ -250,7 +250,7 @@ create_write_barrier_bitmap (MonoCompile *cfg, MonoClass *klass, unsigned *wb_bi
 		if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
 			continue;
 		foffset = m_class_is_valuetype (klass) ? field->offset - MONO_ABI_SIZEOF (MonoObject): field->offset;
-		if (mini_type_is_reference (mono_field_get_type (field))) {
+		if (mini_type_is_reference (mono_field_get_type_internal (field))) {
 			g_assert ((foffset % TARGET_SIZEOF_VOID_P) == 0);
 			*wb_bitmap |= 1 << ((offset + foffset) / TARGET_SIZEOF_VOID_P);
 		} else {

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -9762,7 +9762,7 @@ calli_end:
 				ensure_method_is_allowed_to_access_field (cfg, method, field);
 			*/
 
-			ftype = mono_field_get_type (field);
+			ftype = mono_field_get_type_internal (field);
 
 			/*
 			 * LDFLD etc. is usable on static fields as well, so convert those cases to

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -1240,7 +1240,7 @@ is_hfa (MonoType *t, int *out_nfields, int *out_esize)
 	while ((field = mono_class_get_fields_internal (klass, &iter))) {
 		if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
 			continue;
-		ftype = mono_field_get_type (field);
+		ftype = mono_field_get_type_internal (field);
 		ftype = mini_get_underlying_type (ftype);
 
 		if (MONO_TYPE_ISSTRUCT (ftype)) {

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -1125,7 +1125,7 @@ is_hfa (MonoType *t, int *out_nfields, int *out_esize, int *field_offsets)
 	while ((field = mono_class_get_fields_internal (klass, &iter))) {
 		if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
 			continue;
-		ftype = mono_field_get_type (field);
+		ftype = mono_field_get_type_internal (field);
 		ftype = mini_get_underlying_type (ftype);
 
 		if (MONO_TYPE_ISSTRUCT (ftype)) {

--- a/mono/mini/mini-codegen.c
+++ b/mono/mini/mini-codegen.c
@@ -2725,7 +2725,7 @@ mini_type_is_hfa (MonoType *t, int *out_nfields, int *out_esize)
 	while ((field = mono_class_get_fields_internal (klass, &iter))) {
 		if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
 			continue;
-		ftype = mono_field_get_type (field);
+		ftype = mono_field_get_type_internal (field);
 		ftype = mini_native_type_replace_type (ftype);
 
 		if (MONO_TYPE_ISSTRUCT (ftype)) {

--- a/mono/mini/mini-native-types.c
+++ b/mono/mini/mini-native-types.c
@@ -444,7 +444,7 @@ mono_class_is_magic_float (MonoClass *klass)
 		/* Assert that we are using the matching assembly */
 		MonoClassField *value_field = mono_class_get_field_from_name_full (klass, "v", NULL);
 		g_assert (value_field);
-		MonoType *t = mono_field_get_type (value_field);
+		MonoType *t = mono_field_get_type_internal (value_field);
 		MonoType *native = mini_native_type_replace_type (m_class_get_byval_arg (klass));
 		if (t->type != native->type)
 			g_error ("Assembly used for native types '%s' doesn't match this runtime, %s is mapped to %s, expecting %s.\n", m_class_get_image (klass)->name, m_class_get_name (klass), mono_type_full_name (t), mono_type_full_name (native));

--- a/mono/mini/simd-intrinsics.c
+++ b/mono/mini/simd-intrinsics.c
@@ -2622,7 +2622,7 @@ mono_emit_simd_field_load (MonoCompile *cfg, MonoClassField *field, MonoInst *ad
 			if (cfg->verbose_level > 1)
 				printf ("  SIMD intrinsic field access: %s\n", field->name);
 
-			simd_inst = simd_intrinsic_emit_getter_op (cfg, index, field->parent, mono_field_get_type (field), addr);
+			simd_inst = simd_intrinsic_emit_getter_op (cfg, index, field->parent, mono_field_get_type_internal (field), addr);
 			goto on_exit;
 		}
 	}


### PR DESCRIPTION
But also optimize mono_field_get_type in the common case, to "short circuit"
and skip ditto.