### PR TITLE
Fix const warning. And integer overflow for degenerate input. And C++.

### DIFF
--- a/sdks/wasm/driver.c
+++ b/sdks/wasm/driver.c
@@ -39,8 +39,8 @@ m_strdup (const char *str)
 	if (!str)
 		return NULL;
 
-	int len = strlen (str) + 1;
-	char *res = malloc (len);
+	size_t len = strlen (str) + 1;
+	char *res = (char*)malloc (len);
 	memcpy (res, str, len);
 	return res;
 }
@@ -116,18 +116,18 @@ static WasmAssembly *assemblies;
 static int assembly_count;
 
 EMSCRIPTEN_KEEPALIVE void
-mono_wasm_add_assembly (const char *name, const unsigned char *data, unsigned int size)
+mono_wasm_add_assembly (const char *const_name, const unsigned char *data, unsigned int size)
 {
-	int len = strlen (name);
-	if (!strcasecmp (".pdb", &name [len - 4])) {
-		char *new_name = m_strdup (name);
+	char *name = m_strdup (const_name);
+	size_t len = strlen (name);
+	if (len >= 4 && !strcasecmp (".pdb", &name [len - 4])) {
 		//FIXME handle debugging assemblies with .exe extension
-		strcpy (&new_name [len - 3], "dll");
-		mono_register_symfile_for_assembly (new_name, data, size);
+		memcpy (&name [len - 3], "dll", 3);
+		mono_register_symfile_for_assembly (name, data, size);
 		return;
 	}
 	WasmAssembly *entry = (WasmAssembly *)malloc(sizeof (MonoBundledAssembly));
-	entry->assembly.name = m_strdup (name);
+	entry->assembly.name = name;
 	entry->assembly.data = data;
 	entry->assembly.size = size;
 	entry->next = assemblies;


### PR DESCRIPTION
https://jenkins.mono-project.com/job/test-mono-pull-request-wasm-cxx/536/parsed_console/log.html

driver.c:254:11: warning: passing 'const char *' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
                strcpy (&name [len - 3], "dll");
                        ^~~~~~~~~~~~~~~
/mnt/jenkins/workspace/test-mono-pull-request-wasm-cxx/sdks/builds/toolchains/emsdk/emscripten/1.38.11/system/include/libc/string.h:31:31: note: passing argument to parameter here
char *strcpy (char *__restrict, const char *__restrict);