### PR TITLE
x86 mono_arch_get_patch_offset: add support for 0xe9/jmp eip+32b.

### DIFF
--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -5874,10 +5874,11 @@ mono_arch_get_patch_offset (guint8 *code)
 	else if ((code [0] >= 0xb8) && (code [0] < 0xb8 + 8))
 		/* mov <REG>, imm */
 		return 1;
-	else {
-		g_assert_not_reached ();
-		return -1;
-	}
+	else if (code [0] == 0xE9)
+		/* jmp eip+32b */
+		return 1;
+	g_assert_not_reached ();
+	return -1;
 }
 
 /**


### PR DESCRIPTION
I don't know what the specific code is or what changed, etc.

This addresses Mac/x86:

https://jenkins.mono-project.com/job/test-mono-pull-request-i386-osx/15364/parsed_console/log.html

```Unable to compile method 'int Tests:calli_sig_check_2 ()' due to: 'Invalid IL code in Tests:calli_sig_check_2 (): IL_000b: calli     0x11000044```

which then fails an assert and fails overall.

CI goes deep into bash w/o echoing commands but a repro is:

 cd mono/mini
 MONO_PATH=./../../mcs/class/lib/net_4_x lldb -- ./mono --aot iltests.exe

The code is meant to be invalid, and meant to raise an exception,
which is catchable/resumable (at least in the JIT case where
executing IL the first time, can raise an exception while caller is
running, vs. AOT where the codegen all happens offline -- leaving what?
A note made at AOT time that calling the code should raise an exception?).

It isn't meant to fail an assert in either case.