### PR TITLE
[sdks] Use curl to download llvm instead of wget.

### DIFF
--- a/sdks/builds/llvm.mk
+++ b/sdks/builds/llvm.mk
@@ -36,7 +36,7 @@ define LLVMDownloadTemplate
 ifeq ($(UNAME),Darwin)
 ifeq ($(DISABLE_DOWNLOAD_LLVM),)
 	mkdir -p $$(TOP)/sdks/builds/toolchains/$(1)-download
-	-wget --no-verbose -O - http://xamjenkinsartifact.blob.core.windows.net/$(2)/llvm-osx64-$(3).tar.gz | tar -xC $$(TOP)/sdks/builds/toolchains/$(1)-download -f -
+	-curl -sSL https://xamjenkinsartifact.blob.core.windows.net/$(2)/llvm-osx64-$(3).tar.gz | tar -xC $$(TOP)/sdks/builds/toolchains/$(1)-download -f -
 	touch $$@
 endif
 endif


### PR DESCRIPTION
Since macOS doesn't ship wget, only curl works out-of-the-box.