### PR TITLE
[2018-08] mono_class_is_assignable_from to mono_class_is_assignable_from_internal to skip GC mode machinery

### DIFF
--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -2435,7 +2435,7 @@ apply_override (MonoClass *klass, MonoClass *override_class, MonoMethod **vtable
 		 * parent class becomes the actual interface/class containing the override, i.e.
 		 * IFace<T> in:
 		 * class Foo<T> : IFace<T>
-		 * This is needed so the mono_class_is_assignable_from () calls in the
+		 * This is needed so the mono_class_is_assignable_from_internal () calls in the
 		 * conflict resolution work.
 		 */
 		if (mono_class_is_ginst (override_class)) {
@@ -2484,9 +2484,9 @@ handle_dim_conflicts (MonoMethod **vtable, MonoClass *klass, GHashTable *conflic
 				MonoMethod *m2 = l2->data;
 				if (!m1 || !m2 || m1 == m2)
 					continue;
-				if (mono_class_is_assignable_from (m1->klass, m2->klass))
+				if (mono_class_is_assignable_from_internal (m1->klass, m2->klass))
 					l->data = NULL;
-				else if (mono_class_is_assignable_from (m2->klass, m1->klass))
+				else if (mono_class_is_assignable_from_internal (m2->klass, m1->klass))
 					l2->data = NULL;
 			}
 		}

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1199,6 +1199,9 @@ mono_class_has_variant_generic_params (MonoClass *klass);
 gboolean
 mono_class_is_variant_compatible (MonoClass *klass, MonoClass *oklass, gboolean check_for_reference_conv);
 
+mono_bool
+mono_class_is_assignable_from_internal (MonoClass *klass, MonoClass *oklass);
+
 gboolean mono_is_corlib_image (MonoImage *image);
 
 MonoType*

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -3288,7 +3288,7 @@ mono_gparam_is_reference_conversible (MonoClass *target, MonoClass *candidate, g
 		if (!pinfo || (pinfo->flags & GENERIC_PARAMETER_ATTRIBUTE_REFERENCE_TYPE_CONSTRAINT) == 0)
 			return FALSE;
 	}
-	if (!mono_class_is_assignable_from (target, candidate))
+	if (!mono_class_is_assignable_from_internal (target, candidate))
 		return FALSE;
 	return TRUE;
 }
@@ -3417,7 +3417,7 @@ mono_gparam_is_assignable_from (MonoClass *target, MonoClass *candidate)
 			for (candidate_class = cinfo->constraints; *candidate_class; ++candidate_class) {
 				MonoClass *cc = *candidate_class;
 
-				if (mono_class_is_assignable_from (tc, cc))
+				if (mono_class_is_assignable_from_internal (tc, cc))
 					break;
 
 				/*
@@ -3443,11 +3443,29 @@ mono_gparam_is_assignable_from (MonoClass *target, MonoClass *candidate)
 	if (cinfo->constraints) {
 		for (candidate_class = cinfo->constraints; *candidate_class; ++candidate_class) {
 			MonoClass *cc = *candidate_class;
-			if (mono_class_is_assignable_from (target, cc))
+			if (mono_class_is_assignable_from_internal (target, cc))
 				return TRUE;
 		}
 	}
 	return FALSE;
+}
+
+/**
+ * mono_class_is_assignable_from_internal:
+ * \param klass the class to be assigned to
+ * \param oklass the source class
+ *
+ * \returns TRUE if an instance of class \p oklass can be assigned to an
+ * instance of class \p klass
+ */
+gboolean
+mono_class_is_assignable_from_internal (MonoClass *klass, MonoClass *oklass)
+{
+	gboolean result = FALSE;
+	ERROR_DECL (error);
+	mono_class_is_assignable_from_checked (klass, oklass, &result, error);
+	mono_error_cleanup (error);
+	return result;
 }
 
 /**
@@ -3458,14 +3476,12 @@ mono_gparam_is_assignable_from (MonoClass *target, MonoClass *candidate)
  * \returns TRUE if an instance of class \p oklass can be assigned to an
  * instance of class \p klass
  */
-gboolean
+mono_bool
 mono_class_is_assignable_from (MonoClass *klass, MonoClass *oklass)
 {
-	gboolean result = FALSE;
+	gboolean result;
 	MONO_ENTER_GC_UNSAFE;
-	ERROR_DECL (error);
-	mono_class_is_assignable_from_checked (klass, oklass, &result, error);
-	mono_error_cleanup (error);
+	result = mono_class_is_assignable_from_internal (klass, oklass);
 	MONO_EXIT_GC_UNSAFE;
 	return result;
 }
@@ -3525,7 +3541,7 @@ mono_class_is_assignable_from_checked (MonoClass *klass, MonoClass *oklass, gboo
 
 		if (constraints) {
 			for (i = 0; constraints [i]; ++i) {
-				if (mono_class_is_assignable_from (klass, constraints [i])) {
+				if (mono_class_is_assignable_from_internal (klass, constraints [i])) {
 					*result = TRUE;
 					return;
 				}
@@ -3594,7 +3610,7 @@ mono_class_is_assignable_from_checked (MonoClass *klass, MonoClass *oklass, gboo
 
 				//array covariant casts only operates on scalar to scalar
 				//This is so int[] can't be casted to IComparable<int>[]
-				if (!(m_class_is_valuetype (obj_klass) && !m_class_is_valuetype (iface_klass)) && mono_class_is_assignable_from (iface_klass, obj_klass)) {
+				if (!(m_class_is_valuetype (obj_klass) && !m_class_is_valuetype (iface_klass)) && mono_class_is_assignable_from_internal (iface_klass, obj_klass)) {
 					*result = TRUE;
 					return;
 				}
@@ -3781,7 +3797,7 @@ mono_class_implement_interface_slow (MonoClass *target, MonoClass *candidate)
 
 /*
  * Check if @oklass can be assigned to @klass.
- * This function does the same as mono_class_is_assignable_from but is safe to be used from mono_class_init context.
+ * This function does the same as mono_class_is_assignable_from_internal but is safe to be used from mono_class_init context.
  */
 gboolean
 mono_class_is_assignable_from_slow (MonoClass *target, MonoClass *candidate)
@@ -4754,7 +4770,7 @@ mono_class_is_delegate (MonoClass *klass)
 mono_bool
 mono_class_implements_interface (MonoClass* klass, MonoClass* iface)
 {
-	return mono_class_is_assignable_from (iface, klass);
+	return mono_class_is_assignable_from_internal (iface, klass);
 }
 
 /**

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -123,7 +123,7 @@ MONO_API mono_bool
 mono_class_is_subclass_of (MonoClass *klass, MonoClass *klassc, 
 						   mono_bool check_interfaces);
 
-MONO_API mono_bool
+MONO_API MONO_RT_EXTERNAL_ONLY mono_bool
 mono_class_is_assignable_from (MonoClass *klass, MonoClass *oklass);
 
 MONO_API MONO_RT_EXTERNAL_ONLY

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -1451,7 +1451,7 @@ mono_custom_attrs_construct_by_type (MonoCustomAttrInfo *cinfo, MonoClass *attr_
 		for (i = 0; i < cinfo->num_attrs; ++i) {
 			MonoMethod *ctor = cinfo->attrs[i].ctor;
 			g_assert (ctor);
-			if (mono_class_is_assignable_from (attr_klass, ctor->klass))
+			if (mono_class_is_assignable_from_internal (attr_klass, ctor->klass))
 				n++;
 		}
 	} else {
@@ -1463,7 +1463,7 @@ mono_custom_attrs_construct_by_type (MonoCustomAttrInfo *cinfo, MonoClass *attr_
 	n = 0;
 	for (i = 0; i < cinfo->num_attrs; ++i) {
 		MonoCustomAttrEntry *centry = &cinfo->attrs [i];
-		if (!attr_klass || mono_class_is_assignable_from (attr_klass, centry->ctor->klass)) {
+		if (!attr_klass || mono_class_is_assignable_from_internal (attr_klass, centry->ctor->klass)) {
 			create_custom_attr_into_array (cinfo->image, centry->ctor, centry->data,
 				centry->data_size, result, n, error);
 			goto_if_nok (error, exit);
@@ -1913,7 +1913,7 @@ mono_custom_attrs_has_attr (MonoCustomAttrInfo *ainfo, MonoClass *attr_klass)
 		if (centry->ctor == NULL)
 			continue;
 		MonoClass *klass = centry->ctor->klass;
-		if (klass == attr_klass || mono_class_has_parent (klass, attr_klass) || (MONO_CLASS_IS_INTERFACE (attr_klass) && mono_class_is_assignable_from (attr_klass, klass)))
+		if (klass == attr_klass || mono_class_has_parent (klass, attr_klass) || (MONO_CLASS_IS_INTERFACE (attr_klass) && mono_class_is_assignable_from_internal (attr_klass, klass)))
 			return TRUE;
 	}
 	return FALSE;
@@ -1946,7 +1946,7 @@ mono_custom_attrs_get_attr_checked (MonoCustomAttrInfo *ainfo, MonoClass *attr_k
 		if (centry->ctor == NULL)
 			continue;
 		MonoClass *klass = centry->ctor->klass;
-		if (attr_klass == klass || mono_class_is_assignable_from (attr_klass, klass))
+		if (attr_klass == klass || mono_class_is_assignable_from_internal (attr_klass, klass))
 			break;
 	}
 	if (centry == NULL)

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1746,7 +1746,7 @@ ves_icall_RuntimeTypeHandle_type_is_assignable_from (MonoReflectionTypeHandle re
 			 return m_class_is_valuetype (klass) == m_class_is_valuetype (klassc);
 		}
 	}
-	return mono_class_is_assignable_from (klass, klassc);
+	return mono_class_is_assignable_from_internal (klass, klassc);
 }
 
 ICALL_EXPORT MonoBoolean

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -1838,7 +1838,7 @@ get_method_constrained (MonoImage *image, MonoMethod *method, MonoClass *constra
 
 	error_init (error);
 
-	if (!mono_class_is_assignable_from (base_class, constrained_class)) {
+	if (!mono_class_is_assignable_from_internal (base_class, constrained_class)) {
 		char *base_class_name = mono_type_get_full_name (base_class);
 		char *constrained_class_name = mono_type_get_full_name (constrained_class);
 		mono_error_set_invalid_operation (error, "constrained call: %s is not assignable from %s", base_class_name, constrained_class_name);

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -7078,7 +7078,7 @@ mono_object_handle_isinst (MonoObjectHandle obj, MonoClass *klass, MonoError *er
 
 	MonoObjectHandle result = MONO_HANDLE_NEW (MonoObject, NULL);
 
-	if (!MONO_HANDLE_IS_NULL (obj) && mono_class_is_assignable_from (klass, mono_handle_class (obj)))
+	if (!MONO_HANDLE_IS_NULL (obj) && mono_class_is_assignable_from_internal (klass, mono_handle_class (obj)))
 		MONO_HANDLE_ASSIGN (result, obj);
 	return result;
 }
@@ -7119,14 +7119,14 @@ mono_object_handle_isinst_mbyref (MonoObjectHandle obj, MonoClass *klass, MonoEr
 
 		/* casting an array one of the invariant interfaces that must act as such */
 		if (m_class_is_array_special_interface (klass)) {
-			if (mono_class_is_assignable_from (klass, vt->klass)) {
+			if (mono_class_is_assignable_from_internal (klass, vt->klass)) {
 				MONO_HANDLE_ASSIGN (result, obj);
 				goto leave;
 			}
 		}
 
 		/*If the above check fails we are in the slow path of possibly raising an exception. So it's ok to it this way.*/
-		else if (mono_class_has_variant_generic_params (klass) && mono_class_is_assignable_from (klass, mono_handle_class (obj))) {
+		else if (mono_class_has_variant_generic_params (klass) && mono_class_is_assignable_from_internal (klass, mono_handle_class (obj))) {
 			MONO_HANDLE_ASSIGN (result, obj);
 			goto leave;
 		}

--- a/mono/metadata/verify.c
+++ b/mono/metadata/verify.c
@@ -2218,7 +2218,7 @@ verifier_class_is_assignable_from (MonoClass *target, MonoClass *candidate)
 		return FALSE;
 	}
 
-	if (mono_class_is_assignable_from (target, candidate))
+	if (mono_class_is_assignable_from_internal (target, candidate))
 		return TRUE;
 
 	if (!MONO_CLASS_IS_INTERFACE (target) || !mono_class_is_ginst (target) || m_class_get_rank (candidate) != 1)

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -4888,7 +4888,7 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 		icomparable_inst = mono_class_inflate_generic_class_checked (icomparable, &ctx, error);
 		mono_error_assert_ok (error); /* FIXME don't swallow the error */
 
-		if (mono_class_is_assignable_from (icomparable_inst, tclass)) {
+		if (mono_class_is_assignable_from_internal (icomparable_inst, tclass)) {
 			MonoClass *gcomparer_inst;
 			gcomparer = mono_class_load_from_name (mono_defaults.corlib, "System.Collections.Generic", "GenericComparer`1");
 			gcomparer_inst = mono_class_inflate_generic_class_checked (gcomparer, &ctx, error);
@@ -4916,7 +4916,7 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 		iface_inst = mono_class_inflate_generic_class_checked (iface, &ctx, error);
 		mono_error_assert_ok (error); /* FIXME don't swallow the error */
 
-		if (mono_class_is_assignable_from (iface_inst, tclass)) {
+		if (mono_class_is_assignable_from_internal (iface_inst, tclass)) {
 			MonoClass *gcomparer_inst;
 			ERROR_DECL (error);
 

--- a/mono/mini/branch-opts.c
+++ b/mono/mini/branch-opts.c
@@ -54,7 +54,7 @@ mono_branch_optimize_exception_target (MonoCompile *cfg, MonoBasicBlock *bb, con
 	for (i = 0; i < header->num_clauses; ++i) {
 		clause = &header->clauses [i];
 		if (MONO_OFFSET_IN_CLAUSE (clause, bb->real_offset)) {
-			if (clause->flags == MONO_EXCEPTION_CLAUSE_NONE && clause->data.catch_class && mono_class_is_assignable_from (clause->data.catch_class, exclass)) {
+			if (clause->flags == MONO_EXCEPTION_CLAUSE_NONE && clause->data.catch_class && mono_class_is_assignable_from_internal (clause->data.catch_class, exclass)) {
 				MonoBasicBlock *tbb;
 
 				/* get the basic block for the handler and 

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -3500,7 +3500,7 @@ create_event_list (EventKind event, GPtrArray *reqs, MonoJitInfo *ji, EventInfo 
 					if (mod->data.thread != mono_thread_internal_current ())
 						filtered = TRUE;
 				} else if (mod->kind == MOD_KIND_EXCEPTION_ONLY && ei) {
-					if (mod->data.exc_class && mod->subclasses && !mono_class_is_assignable_from (mod->data.exc_class, ei->exc->vtable->klass))
+					if (mod->data.exc_class && mod->subclasses && !mono_class_is_assignable_from_internal (mod->data.exc_class, ei->exc->vtable->klass))
 						filtered = TRUE;
 					if (mod->data.exc_class && !mod->subclasses && mod->data.exc_class != ei->exc->vtable->klass)
 						filtered = TRUE;
@@ -5287,10 +5287,10 @@ static gboolean
 obj_is_of_type (MonoObject *obj, MonoType *t)
 {
 	MonoClass *klass = obj->vtable->klass;
-	if (!mono_class_is_assignable_from (mono_class_from_mono_type (t), klass)) {
+	if (!mono_class_is_assignable_from_internal (mono_class_from_mono_type (t), klass)) {
 		if (mono_class_is_transparent_proxy (klass)) {
 			klass = ((MonoTransparentProxy *)obj)->remote_class->proxy_class;
-			if (mono_class_is_assignable_from (mono_class_from_mono_type (t), klass)) {
+			if (mono_class_is_assignable_from_internal (mono_class_from_mono_type (t), klass)) {
 				return TRUE;
 			}
 		}
@@ -6873,7 +6873,7 @@ event_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 				if (exc_class) {
 					req->modifiers [i].data.exc_class = exc_class;
 
-					if (!mono_class_is_assignable_from (mono_defaults.exception_class, exc_class)) {
+					if (!mono_class_is_assignable_from_internal (mono_defaults.exception_class, exc_class)) {
 						g_free (req);
 						return ERR_INVALID_ARGUMENT;
 					}
@@ -7847,7 +7847,7 @@ type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint
 
 		if (err != ERR_NONE)
 			return err;
-		if (mono_class_is_assignable_from (klass, oklass))
+		if (mono_class_is_assignable_from_internal (klass, oklass))
 			buffer_add_byte (buf, 1);
 		else
 			buffer_add_byte (buf, 0);

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -916,7 +916,7 @@ ves_array_element_address (InterpFrame *frame, MonoClass *required_type, MonoArr
 	if (frame->ex)
 		return NULL;
 
-	if (needs_typecheck && !mono_class_is_assignable_from (m_class_get_element_class (mono_object_class ((MonoObject *) ao)), m_class_get_element_class (required_type))) {
+	if (needs_typecheck && !mono_class_is_assignable_from_internal (m_class_get_element_class (mono_object_class ((MonoObject *) ao)), m_class_get_element_class (required_type))) {
 		frame->ex = mono_get_exception_array_type_mismatch ();
 		FILL_IN_TRACE (frame->ex, frame);
 		return NULL;

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -6060,7 +6060,7 @@ handle_call_res_devirt (MonoCompile *cfg, MonoMethod *cmethod, MonoInst *call_re
 		 *       return (EqualityComparer<T>)(object)new InternalStringComparer ();
 		 * #endif
 		 */
-		if (mono_class_is_assignable_from (inst, mono_class_from_mono_type (param_type)) && param_type->type != MONO_TYPE_STRING) {
+		if (mono_class_is_assignable_from_internal (inst, mono_class_from_mono_type (param_type)) && param_type->type != MONO_TYPE_STRING) {
 			MonoInst *typed_objref;
 			MonoClass *gcomparer_inst;
 

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -3022,7 +3022,7 @@ is_async_state_machine_class (MonoClass *klass)
 
 	iclass = mono_class_try_get_iasync_state_machine_class ();
 
-	if (iclass && m_class_is_valuetype (klass) && mono_class_is_assignable_from (iclass, klass))
+	if (iclass && m_class_is_valuetype (klass) && mono_class_is_assignable_from_internal (iclass, klass))
 		return TRUE;
 	return FALSE;
 }


### PR DESCRIPTION
Backport of #11081.

/cc @lambdageek @jaykrell

Description:
FIXME mono_class_is_assignable_from_checked