### PR TITLE
[2018-10] mono_class_enum_basetype to mono_class_enum_basetype_internal to skip GC mode machinery.

### DIFF
--- a/mono/dis/dump.c
+++ b/mono/dis/dump.c
@@ -897,7 +897,7 @@ handle_enum:
 		}
 		case MONO_TYPE_VALUETYPE:
 			if (m_class_is_enumtype (sig->params [i]->data.klass)) {
-				type = mono_class_enum_basetype (sig->params [i]->data.klass)->type;
+				type = mono_class_enum_basetype_internal (sig->params [i]->data.klass)->type;
 				goto handle_enum;
 			} else {
 				g_warning ("generic valutype not handled in custom attr value decoding");

--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -923,7 +923,7 @@ mono_class_create_bounded_array (MonoClass *eclass, guint32 rank, gboolean bound
 		mono_error_set_invalid_program (&prepared_error, "Arrays of System.TypedReference types are invalid.");
 		mono_class_set_failure (klass, mono_error_box (&prepared_error, klass->image));
 		mono_error_cleanup (&prepared_error);
-	} else if (eclass->enumtype && !mono_class_enum_basetype (eclass)) {
+	} else if (eclass->enumtype && !mono_class_enum_basetype_internal (eclass)) {
 		guint32 ref_info_handle = mono_class_get_ref_info_handle (eclass);
 		if (!ref_info_handle || eclass->wastypebuilder) {
 			g_warning ("Only incomplete TypeBuilder objects are allowed to be an enum without base_type");
@@ -3421,7 +3421,7 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 			}
 		}
 
-		if (!mono_class_enum_basetype (klass)) {
+		if (!mono_class_enum_basetype_internal (klass)) {
 			mono_class_set_type_load_failure (klass, "The enumeration's base type is invalid.");
 			return;
 		}
@@ -5132,7 +5132,7 @@ mono_class_setup_interfaces (MonoClass *klass, MonoError *error)
 		interfaces [1] = mono_class_bind_generic_parameters (
 			   mono_defaults.generic_ireadonlylist_class, 1, args, FALSE);
 		if (klass->element_class->enumtype) {
-			args [0] = mono_class_enum_basetype (klass->element_class);
+			args [0] = mono_class_enum_basetype_internal (klass->element_class);
 			interfaces [2] = mono_class_bind_generic_parameters (
 				mono_defaults.generic_ilist_class, 1, args, FALSE);
 			interfaces [3] = mono_class_bind_generic_parameters (

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1448,6 +1448,9 @@ mono_class_contextbound_bit_offset (int* byte_offset_out, guint8* mask_out);
 gboolean
 mono_class_init_checked (MonoClass *klass, MonoError *error);
 
+MonoType*
+mono_class_enum_basetype_internal (MonoClass *klass);
+
 /*Now that everything has been defined, let's include the inline functions */
 #include <mono/metadata/class-inlines.h>
 

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -557,9 +557,9 @@ MonoType*
 mono_type_get_underlying_type (MonoType *type)
 {
 	if (type->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (type->data.klass) && !type->byref)
-		return mono_class_enum_basetype (type->data.klass);
+		return mono_class_enum_basetype_internal (type->data.klass);
 	if (type->type == MONO_TYPE_GENERICINST && m_class_is_enumtype (type->data.generic_class->container_class) && !type->byref)
-		return mono_class_enum_basetype (type->data.generic_class->container_class);
+		return mono_class_enum_basetype_internal (type->data.generic_class->container_class);
 	return type;
 }
 
@@ -4017,7 +4017,7 @@ handle_enum:
 		return 8;
 	case MONO_TYPE_VALUETYPE:
 		if (m_class_is_enumtype (type->data.klass)) {
-			type = mono_class_enum_basetype (type->data.klass);
+			type = mono_class_enum_basetype_internal (type->data.klass);
 			klass = m_class_get_element_class (klass);
 			goto handle_enum;
 		}
@@ -4267,6 +4267,23 @@ mono_class_is_enum (MonoClass *klass)
 }
 
 /**
+ * mono_class_enum_basetype_internal:
+ * \param klass the \c MonoClass to act on
+ *
+ * Use this function to get the underlying type for an enumeration value.
+ * 
+ * \returns The underlying type representation for an enumeration.
+ */
+MonoType*
+mono_class_enum_basetype_internal (MonoClass *klass)
+{
+	if (m_class_get_element_class (klass) == klass)
+		/* SRE or broken types */
+		return NULL;
+	return m_class_get_byval_arg (m_class_get_element_class (klass));
+}
+
+/**
  * mono_class_enum_basetype:
  * \param klass the \c MonoClass to act on
  *
@@ -4279,11 +4296,7 @@ mono_class_enum_basetype (MonoClass *klass)
 {
 	MonoType *res;
 	MONO_ENTER_GC_UNSAFE;
-	if (m_class_get_element_class (klass) == klass)
-		/* SRE or broken types */
-		res = NULL;
-	else
-		res = m_class_get_byval_arg (m_class_get_element_class (klass));
+	res = mono_class_enum_basetype_internal (klass);
 	MONO_EXIT_GC_UNSAFE;
 	return res;
 }

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -152,7 +152,7 @@ MONO_API MONO_RT_EXTERNAL_ONLY
 mono_bool
 mono_class_is_enum          (MonoClass *klass);
 
-MONO_API MonoType*
+MONO_API MONO_RT_EXTERNAL_ONLY MonoType*
 mono_class_enum_basetype    (MonoClass *klass);
 
 MONO_API MONO_RT_EXTERNAL_ONLY

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -347,7 +347,7 @@ handle_enum:
 	}
 	case MONO_TYPE_VALUETYPE:
 		if (m_class_is_enumtype (t->data.klass)) {
-			type = mono_class_enum_basetype (t->data.klass)->type;
+			type = mono_class_enum_basetype_internal (t->data.klass)->type;
 			goto handle_enum;
 		} else {
 			MonoClass *k =  t->data.klass;
@@ -489,7 +489,7 @@ handle_enum:
 		return_val_if_nok (error, NULL);
 		basetype = m_class_get_byval_arg (tklass)->type;
 		if (basetype == MONO_TYPE_VALUETYPE && m_class_is_enumtype (tklass))
-			basetype = mono_class_enum_basetype (tklass)->type;
+			basetype = mono_class_enum_basetype_internal (tklass)->type;
 
 		if (basetype == MONO_TYPE_GENERICINST) {
 			MonoGenericClass * mgc = m_class_get_byval_arg (tklass)->data.generic_class;

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -376,10 +376,10 @@ array_set_value_impl (MonoArrayHandle arr, MonoObjectHandle value, guint32 pos, 
 	vsize = mono_class_value_size (vc, NULL);
 
 	if (et == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_class_get_byval_arg (ec)->data.klass))
-		et = mono_class_enum_basetype (m_class_get_byval_arg (ec)->data.klass)->type;
+		et = mono_class_enum_basetype_internal (m_class_get_byval_arg (ec)->data.klass)->type;
 
 	if (vt == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_class_get_byval_arg (vc)->data.klass))
-		vt = mono_class_enum_basetype (m_class_get_byval_arg (vc)->data.klass)->type;
+		vt = mono_class_enum_basetype_internal (m_class_get_byval_arg (vc)->data.klass)->type;
 
 #define ASSIGN_UNSIGNED(etype) G_STMT_START{\
 	switch (vt) { \
@@ -1155,7 +1155,7 @@ ves_icall_System_ValueType_Equals (MonoObject *this_obj, MonoObject *that, MonoA
 
 	klass = mono_object_class (this_obj);
 
-	if (m_class_is_enumtype (klass) && mono_class_enum_basetype (klass) && mono_class_enum_basetype (klass)->type == MONO_TYPE_I4)
+	if (m_class_is_enumtype (klass) && mono_class_enum_basetype_internal (klass) && mono_class_enum_basetype_internal (klass)->type == MONO_TYPE_I4)
 		return *(gint32*)mono_object_get_data (this_obj) == *(gint32*)mono_object_get_data (that);
 
 	/*
@@ -1667,7 +1667,7 @@ handle_enum:
 		MonoClass *klass = type->data.klass;
 		
 		if (m_class_is_enumtype (klass)) {
-			t = mono_class_enum_basetype (klass)->type;
+			t = mono_class_enum_basetype_internal (klass)->type;
 			goto handle_enum;
 		} else if (mono_is_corlib_image (m_class_get_image (klass))) {
 			if (strcmp (m_class_get_name_space (klass), "System") == 0) {
@@ -1709,9 +1709,9 @@ static MonoType*
 mono_type_get_underlying_type_ignore_byref (MonoType *type)
 {
 	if (type->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (type->data.klass))
-		return mono_class_enum_basetype (type->data.klass);
+		return mono_class_enum_basetype_internal (type->data.klass);
 	if (type->type == MONO_TYPE_GENERICINST && m_class_is_enumtype (type->data.generic_class->container_class))
-		return mono_class_enum_basetype (type->data.generic_class->container_class);
+		return mono_class_enum_basetype_internal (type->data.generic_class->container_class);
 	return type;
 }
 
@@ -3713,7 +3713,7 @@ ves_icall_System_Enum_ToObject (MonoReflectionTypeHandle enumType, guint64 value
 	mono_class_init_checked (enumc, error);
 	goto_if_nok (error, return_null);
 
-	etype = mono_class_enum_basetype (enumc);
+	etype = mono_class_enum_basetype_internal (enumc);
 
 	resultHandle = mono_object_new_handle (domain, enumc, error);
 	goto_if_nok (error, return_null);
@@ -3749,7 +3749,7 @@ ves_icall_System_Enum_get_value (MonoObjectHandle ehandle, MonoError *error)
 
 	g_assert (m_class_is_enumtype (mono_handle_class (ehandle)));
 
-	enumc = mono_class_from_mono_type (mono_class_enum_basetype (mono_handle_class (ehandle)));
+	enumc = mono_class_from_mono_type (mono_class_enum_basetype_internal (mono_handle_class (ehandle)));
 
 	resultHandle = mono_object_new_handle (MONO_HANDLE_DOMAIN (ehandle), enumc, error);
 	goto_if_nok (error, return_null);
@@ -3772,7 +3772,7 @@ ves_icall_System_Enum_get_underlying_type (MonoReflectionTypeHandle type, MonoEr
 	mono_class_init_checked (klass, error);
 	goto_if_nok (error, return_null);
 
-	etype = mono_class_enum_basetype (klass);
+	etype = mono_class_enum_basetype_internal (klass);
 	if (!etype) {
 		mono_error_set_argument (error, "enumType", "Type provided must be an Enum.");
 		goto return_null;
@@ -3795,7 +3795,7 @@ ves_icall_System_Enum_compare_value_to (MonoObjectHandle enumHandle, MonoObjectH
 
 	gpointer tdata = mono_handle_unbox_unsafe (enumHandle);
 	gpointer odata = mono_handle_unbox_unsafe (otherHandle);
-	MonoType *basetype = mono_class_enum_basetype (MONO_HANDLE_GETVAL (enumHandle, vtable)->klass);
+	MonoType *basetype = mono_class_enum_basetype_internal (MONO_HANDLE_GETVAL (enumHandle, vtable)->klass);
 	g_assert (basetype);
 
 #define COMPARE_ENUM_VALUES(ENUM_TYPE) do { \
@@ -3834,7 +3834,7 @@ ICALL_EXPORT int
 ves_icall_System_Enum_get_hashcode (MonoObjectHandle enumHandle, MonoError *error)
 {
 	gpointer data = mono_handle_unbox_unsafe (enumHandle);
-	MonoType *basetype = mono_class_enum_basetype (MONO_HANDLE_GETVAL (enumHandle, vtable)->klass);
+	MonoType *basetype = mono_class_enum_basetype_internal (MONO_HANDLE_GETVAL (enumHandle, vtable)->klass);
 	g_assert (basetype);
 
 	switch (basetype->type) {
@@ -3923,7 +3923,7 @@ ves_icall_System_Enum_GetEnumValuesAndNames (MonoReflectionTypeHandle type, Mono
 		return TRUE;
 	}
 
-	base_type = mono_class_enum_basetype (enumc)->type;
+	base_type = mono_class_enum_basetype_internal (enumc)->type;
 
 	nvalues = mono_class_num_fields (enumc) > 0 ? mono_class_num_fields (enumc) - 1 : 0;
 	MONO_HANDLE_ASSIGN(names, mono_array_new_handle (domain, mono_defaults.string_class, nvalues, error));

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -1029,7 +1029,7 @@ emit_struct_conv_full (MonoMethodBuilder *mb, MonoClass *klass, gboolean to_obje
 				int len;
 
 				if (m_class_is_enumtype (ftype->data.klass)) {
-					ftype = mono_class_enum_basetype (ftype->data.klass);
+					ftype = mono_class_enum_basetype_internal (ftype->data.klass);
 					goto handle_enum;
 				}
 
@@ -1421,7 +1421,7 @@ handle_enum:
 			goto handle_enum;
 		case MONO_TYPE_VALUETYPE:
 			if (type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (t->data.klass)) {
-				type = mono_class_enum_basetype (t->data.klass)->type;
+				type = mono_class_enum_basetype_internal (t->data.klass)->type;
 				goto handle_enum;
 			}
 			mono_mb_emit_byte (mb, CEE_LDIND_I);
@@ -1905,7 +1905,7 @@ emit_native_wrapper_ilgen (MonoImage *image, MonoMethodBuilder *mb, MonoMethodSi
 			case MONO_TYPE_VALUETYPE:
 				klass = sig->ret->data.klass;
 				if (m_class_is_enumtype (klass)) {
-					type = mono_class_enum_basetype (sig->ret->data.klass)->type;
+					type = mono_class_enum_basetype_internal (sig->ret->data.klass)->type;
 					goto handle_enum;
 				}
 				mono_emit_marshal (&m, 0, sig->ret, spec, 0, NULL, MARSHAL_ACTION_CONV_RESULT);

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -1185,7 +1185,7 @@ handle_enum:
 		return CEE_LDIND_R8;
 	case MONO_TYPE_VALUETYPE:
 		if (m_class_is_enumtype (type->data.klass)) {
-			type = mono_class_enum_basetype (type->data.klass);
+			type = mono_class_enum_basetype_internal (type->data.klass);
 			goto handle_enum;
 		}
 		return CEE_LDOBJ;
@@ -1240,7 +1240,7 @@ handle_enum:
 		return CEE_STIND_R8;
 	case MONO_TYPE_VALUETYPE:
 		if (m_class_is_enumtype (type->data.klass)) {
-			type = mono_class_enum_basetype (type->data.klass);
+			type = mono_class_enum_basetype_internal (type->data.klass);
 			goto handle_enum;
 		}
 		return CEE_STOBJ;
@@ -2499,7 +2499,7 @@ handle_enum:
 		return mono_get_int_type ();
 	case MONO_TYPE_VALUETYPE:
 		if (m_class_is_enumtype (t->data.klass)) {
-			t = mono_class_enum_basetype (t->data.klass);
+			t = mono_class_enum_basetype_internal (t->data.klass);
 			goto handle_enum;
 		}
 		return t;
@@ -5731,7 +5731,7 @@ mono_type_native_stack_size (MonoType *t, guint32 *align)
 		MonoClass *klass = mono_class_from_mono_type (t);
 
 		if (m_class_is_enumtype (klass))
-			return mono_type_native_stack_size (mono_class_enum_basetype (klass), align);
+			return mono_type_native_stack_size (mono_class_enum_basetype_internal (klass), align);
 		else {
 			size = mono_class_native_size (klass, align);
 			*align = *align + 3;

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -5104,7 +5104,7 @@ mono_type_size (MonoType *t, int *align)
 		return MONO_ABI_SIZEOF (gpointer);
 	case MONO_TYPE_VALUETYPE: {
 		if (m_class_is_enumtype (t->data.klass))
-			return mono_type_size (mono_class_enum_basetype (t->data.klass), align);
+			return mono_type_size (mono_class_enum_basetype_internal (t->data.klass), align);
 		else
 			return mono_class_value_size (t->data.klass, (guint32*)align);
 	}
@@ -5127,7 +5127,7 @@ mono_type_size (MonoType *t, int *align)
 
 		if (m_class_is_valuetype (container_class)) {
 			if (m_class_is_enumtype (container_class))
-				return mono_type_size (mono_class_enum_basetype (container_class), align);
+				return mono_type_size (mono_class_enum_basetype_internal (container_class), align);
 			else
 				return mono_class_value_size (mono_class_from_mono_type (t), (guint32*)align);
 		} else {
@@ -5234,7 +5234,7 @@ mono_type_stack_size_internal (MonoType *t, int *align, gboolean allow_open)
 		guint32 size;
 
 		if (m_class_is_enumtype (t->data.klass))
-			return mono_type_stack_size_internal (mono_class_enum_basetype (t->data.klass), align, allow_open);
+			return mono_type_stack_size_internal (mono_class_enum_basetype_internal (t->data.klass), align, allow_open);
 		else {
 			size = mono_class_value_size (t->data.klass, (guint32*)align);
 
@@ -5256,7 +5256,7 @@ mono_type_stack_size_internal (MonoType *t, int *align, gboolean allow_open)
 
 		if (m_class_is_valuetype (container_class)) {
 			if (m_class_is_enumtype (container_class))
-				return mono_type_stack_size_internal (mono_class_enum_basetype (container_class), align, allow_open);
+				return mono_type_stack_size_internal (mono_class_enum_basetype_internal (container_class), align, allow_open);
 			else {
 				guint32 size = mono_class_value_size (mono_class_from_mono_type (t), (guint32*)align);
 
@@ -6382,7 +6382,7 @@ handle_enum:
 	case MONO_TYPE_PTR: return MONO_NATIVE_UINT;
 	case MONO_TYPE_VALUETYPE: /*FIXME*/
 		if (m_class_is_enumtype (type->data.klass)) {
-			t = mono_class_enum_basetype (type->data.klass)->type;
+			t = mono_class_enum_basetype_internal (type->data.klass)->type;
 			goto handle_enum;
 		}
 		if (type->data.klass == mono_defaults.handleref_class){

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -3286,7 +3286,7 @@ handle_enum:
 	case MONO_TYPE_VALUETYPE:
 		/* note that 't' and 'type->type' can be different */
 		if (type->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (type->data.klass)) {
-			t = mono_class_enum_basetype (type->data.klass)->type;
+			t = mono_class_enum_basetype_internal (type->data.klass)->type;
 			goto handle_enum;
 		} else {
 			MonoClass *klass = mono_class_from_mono_type (type);

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -1411,7 +1411,7 @@ mono_get_object_from_blob (MonoDomain *domain, MonoType *type, const char *blob,
 		return_val_if_nok (error, NULL);
 		retval = mono_object_get_data (object);
 		if (m_class_is_enumtype (klass))
-			basetype = mono_class_enum_basetype (klass);
+			basetype = mono_class_enum_basetype_internal (klass);
 	} else {
 		retval = &object;
 	}

--- a/mono/metadata/sre-encode.c
+++ b/mono/metadata/sre-encode.c
@@ -560,7 +560,7 @@ handle_enum:
 		MonoClass *klass = val->vtable->klass;
 		
 		if (m_class_is_enumtype (klass)) {
-			*ret_type = mono_class_enum_basetype (klass)->type;
+			*ret_type = mono_class_enum_basetype_internal (klass)->type;
 			goto handle_enum;
 		} else if (mono_is_corlib_image (m_class_get_image (klass)) && strcmp (m_class_get_name_space (klass), "System") == 0 && strcmp (m_class_get_name (klass), "DateTime") == 0) {
 			len = 8;

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -2156,7 +2156,7 @@ handle_enum:
 		break;
 	case MONO_TYPE_VALUETYPE:
 		if (type->data.klass->enumtype) {
-			simple_type = mono_class_enum_basetype (type->data.klass)->type;
+			simple_type = mono_class_enum_basetype_internal (type->data.klass)->type;
 			goto handle_enum;
 		} else {
 			g_warning ("generic valutype %s not handled in custom attr value decoding", type->data.klass->name);
@@ -2323,7 +2323,7 @@ handle_type:
 		memcpy (p, str, slen);
 		p += slen;
 		g_free (str);
-		simple_type = mono_class_enum_basetype (klass)->type;
+		simple_type = mono_class_enum_basetype_internal (klass)->type;
 		goto handle_enum;
 	}
 	default:

--- a/mono/metadata/verify.c
+++ b/mono/metadata/verify.c
@@ -429,9 +429,9 @@ static MonoType*
 mono_type_get_underlying_type_any (MonoType *type)
 {
 	if (type->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (type->data.klass))
-		return mono_class_enum_basetype (type->data.klass);
+		return mono_class_enum_basetype_internal (type->data.klass);
 	if (type->type == MONO_TYPE_GENERICINST && m_class_is_enumtype (type->data.generic_class->container_class))
-		return mono_class_enum_basetype (type->data.generic_class->container_class);
+		return mono_class_enum_basetype_internal (type->data.generic_class->container_class);
 	return type;
 }
 

--- a/mono/mini/aot-runtime-wasm.c
+++ b/mono/mini/aot-runtime-wasm.c
@@ -48,7 +48,7 @@ handle_enum:
 		return 'V';
 	case MONO_TYPE_VALUETYPE:
 		if (m_class_is_enumtype (t->data.klass)) {
-			t = mono_class_enum_basetype (t->data.klass);
+			t = mono_class_enum_basetype_internal (t->data.klass);
 			goto handle_enum;
 		}
 

--- a/mono/mini/dwarfwriter.c
+++ b/mono/mini/dwarfwriter.c
@@ -967,7 +967,7 @@ emit_class_dwarf_info (MonoDwarfWriter *w, MonoClass *klass, gboolean vtype)
 	g_hash_table_insert (cache, klass, die);
 
 	if (m_class_is_enumtype (klass)) {
-		int size = mono_class_value_size (mono_class_from_mono_type (mono_class_enum_basetype (klass)), NULL);
+		int size = mono_class_value_size (mono_class_from_mono_type (mono_class_enum_basetype_internal (klass)), NULL);
 
 		emit_label (w, die);
 
@@ -975,7 +975,7 @@ emit_class_dwarf_info (MonoDwarfWriter *w, MonoClass *klass, gboolean vtype)
 		emit_string (w, full_name);
 		emit_uleb128 (w, size);
 		for (k = 0; k < G_N_ELEMENTS (basic_types); ++k)
-			if (basic_types [k].type == mono_class_enum_basetype (klass)->type)
+			if (basic_types [k].type == mono_class_enum_basetype_internal (klass)->type)
 				break;
 		g_assert (k < G_N_ELEMENTS (basic_types));
 		emit_symbol_diff (w, basic_types [k].die_name, ".Ldebug_info_start", 0);
@@ -996,7 +996,7 @@ emit_class_dwarf_info (MonoDwarfWriter *w, MonoClass *klass, gboolean vtype)
 
 			p = mono_class_get_field_default_value (field, &def_type);
 			/* len = */ mono_metadata_decode_blob_size (p, &p);
-			switch (mono_class_enum_basetype (klass)->type) {
+			switch (mono_class_enum_basetype_internal (klass)->type) {
 			case MONO_TYPE_U1:
 			case MONO_TYPE_I1:
 			case MONO_TYPE_BOOLEAN:

--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -208,7 +208,7 @@ enum_type:
 		return MINT_TYPE_O;
 	case MONO_TYPE_VALUETYPE:
 		if (m_class_is_enumtype (type->data.klass)) {
-			type = mono_class_enum_basetype (type->data.klass);
+			type = mono_class_enum_basetype_internal (type->data.klass);
 			goto enum_type;
 		} else
 			return MINT_TYPE_VT;

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -517,7 +517,7 @@ stackval_from_data (MonoType *type_, stackval *result, void *data, gboolean pinv
 		return;
 	case MONO_TYPE_VALUETYPE:
 		if (m_class_is_enumtype (type->data.klass)) {
-			stackval_from_data (mono_class_enum_basetype (type->data.klass), result, data, pinvoke);
+			stackval_from_data (mono_class_enum_basetype_internal (type->data.klass), result, data, pinvoke);
 			return;
 		} else if (pinvoke) {
 			memcpy (result->data.vt, data, mono_class_native_size (type->data.klass, NULL));
@@ -618,7 +618,7 @@ stackval_to_data (MonoType *type_, stackval *val, void *data, gboolean pinvoke)
 	}
 	case MONO_TYPE_VALUETYPE:
 		if (m_class_is_enumtype (type->data.klass)) {
-			stackval_to_data (mono_class_enum_basetype (type->data.klass), val, data, pinvoke);
+			stackval_to_data (mono_class_enum_basetype_internal (type->data.klass), val, data, pinvoke);
 			return;
 		} else if (pinvoke) {
 			memcpy (data, val->data.vt, mono_class_native_size (type->data.klass, NULL));
@@ -681,7 +681,7 @@ stackval_to_data_addr (MonoType *type_, stackval *val)
 		return &val->data.p;
 	case MONO_TYPE_VALUETYPE:
 		if (m_class_is_enumtype (type->data.klass))
-			return stackval_to_data_addr (mono_class_enum_basetype (type->data.klass), val);
+			return stackval_to_data_addr (mono_class_enum_basetype_internal (type->data.klass), val);
 		else
 			return val->data.vt;
 	case MONO_TYPE_TYPEDBYREF:

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1410,7 +1410,7 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 	if (constrained_class) {
 		if (m_class_is_enumtype (constrained_class) && !strcmp (target_method->name, "GetHashCode")) {
 			/* Use the corresponding method from the base type to avoid boxing */
-			MonoType *base_type = mono_class_enum_basetype (constrained_class);
+			MonoType *base_type = mono_class_enum_basetype_internal (constrained_class);
 			g_assert (base_type);
 			constrained_class = mono_class_from_mono_type (base_type);
 			target_method = mono_class_get_method_from_name_checked (constrained_class, target_method->name, 0, 0, error);

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -345,7 +345,7 @@ handle_enum:
 		return OP_FMOVE;
 	case MONO_TYPE_VALUETYPE:
 		if (m_class_is_enumtype (type->data.klass)) {
-			type = mono_class_enum_basetype (type->data.klass);
+			type = mono_class_enum_basetype_internal (type->data.klass);
 			goto handle_enum;
 		}
 		if (MONO_CLASS_IS_SIMD (cfg, mono_class_from_mono_type (type)))
@@ -865,7 +865,7 @@ handle_enum:
 		return;
 	case MONO_TYPE_VALUETYPE:
 		if (m_class_is_enumtype (type->data.klass)) {
-			type = mono_class_enum_basetype (type->data.klass);
+			type = mono_class_enum_basetype_internal (type->data.klass);
 			goto handle_enum;
 		} else {
 			inst->klass = klass;
@@ -1850,7 +1850,7 @@ handle_enum:
 		return calli? OP_FCALL_REG: virt? OP_FCALL_MEMBASE: OP_FCALL;
 	case MONO_TYPE_VALUETYPE:
 		if (m_class_is_enumtype (type->data.klass)) {
-			type = mono_class_enum_basetype (type->data.klass);
+			type = mono_class_enum_basetype_internal (type->data.klass);
 			goto handle_enum;
 		} else
 			return calli? OP_VCALL_REG: virt? OP_VCALL_MEMBASE: OP_VCALL;
@@ -2112,7 +2112,7 @@ handle_enum:
 			continue;
 		case MONO_TYPE_VALUETYPE:
 			if (m_class_is_enumtype (simple_type->data.klass)) {
-				simple_type = mono_class_enum_basetype (simple_type->data.klass);
+				simple_type = mono_class_enum_basetype_internal (simple_type->data.klass);
 				goto handle_enum;
 			}
 			if (args [i]->type != STACK_VTYPE)
@@ -5721,7 +5721,7 @@ handle_enum:
 		return 0;
 	case MONO_TYPE_VALUETYPE:
 		if (m_class_is_enumtype (type->data.klass)) {
-			type = mono_class_enum_basetype (type->data.klass);
+			type = mono_class_enum_basetype_internal (type->data.klass);
 			goto handle_enum;
 		}
 		return 0;
@@ -7701,7 +7701,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 
 				if (m_class_is_enumtype (constrained_class) && !strcmp (cmethod->name, "GetHashCode")) {
 					/* Use the corresponding method from the base type to avoid boxing */
-					MonoType *base_type = mono_class_enum_basetype (constrained_class);
+					MonoType *base_type = mono_class_enum_basetype_internal (constrained_class);
 					g_assert (base_type);
 					constrained_class = mono_class_from_mono_type (base_type);
 					cmethod = get_method_nofail (constrained_class, cmethod->name, 0, 0);
@@ -10184,7 +10184,7 @@ calli_end:
 					if (!addr)
 						addr = (char*)mono_vtable_get_static_field_data (vtable) + field->offset;
 					if (ro_type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (ftype->data.klass)) {
-						ro_type = mono_class_enum_basetype (ftype->data.klass)->type;
+						ro_type = mono_class_enum_basetype_internal (ftype->data.klass)->type;
 					}
 
 					GSHAREDVT_FAILURE (il_op);

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -3738,7 +3738,7 @@ get_shared_type (MonoType *t, MonoType *type)
 	/* Create a type variable with a constraint which encodes which types can match it */
 	ttype = type->type;
 	if (type->type == MONO_TYPE_VALUETYPE) {
-		ttype = mono_class_enum_basetype (type->data.klass)->type;
+		ttype = mono_class_enum_basetype_internal (type->data.klass)->type;
 	} else if (MONO_TYPE_IS_REFERENCE (type)) {
 		ttype = MONO_TYPE_OBJECT;
 	} else if (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR) {

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -521,7 +521,7 @@ type_to_llvm_type (EmitContext *ctx, MonoType *t)
 			return simd_class_to_llvm_type (ctx, klass);
 
 		if (m_class_is_enumtype (klass))
-			return type_to_llvm_type (ctx, mono_class_enum_basetype (klass));
+			return type_to_llvm_type (ctx, mono_class_enum_basetype_internal (klass));
 
 		ltype = (LLVMTypeRef)g_hash_table_lookup (ctx->module->llvm_types, klass);
 		if (!ltype) {

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -953,7 +953,7 @@ enum_parmtype:
 				MonoMarshalType *info;
 
 				if (m_class_is_enumtype (type->data.klass)) {
-					simpleType = mono_class_enum_basetype (type->data.klass)->type;
+					simpleType = mono_class_enum_basetype_internal (type->data.klass)->type;
 					fprintf (trFd, "{VALUETYPE} - ");
 					goto enum_parmtype;
 				}
@@ -1271,7 +1271,7 @@ handle_enum:
 	case MONO_TYPE_VALUETYPE: {
 		MonoMarshalType *info;
 		if (m_class_is_enumtype (type->data.klass)) {
-			type = mono_class_enum_basetype (type->data.klass);
+			type = mono_class_enum_basetype_internal (type->data.klass);
 			goto handle_enum;
 		} else {
 			int size, align;
@@ -1755,7 +1755,7 @@ enum_retvalue:
 		case MONO_TYPE_VALUETYPE: {
 			MonoClass *klass = mono_class_from_mono_type (sig->ret);
 			if (m_class_is_enumtype (klass)) {
-				simpleType = mono_class_enum_basetype (klass)->type;
+				simpleType = mono_class_enum_basetype_internal (klass)->type;
 				goto enum_retvalue;
 			}
 			size = mini_type_stack_size_full (m_class_get_byval_arg (klass), NULL, sig->pinvoke);
@@ -2762,7 +2762,7 @@ handle_enum:
 		break;
 	case MONO_TYPE_VALUETYPE:
 		if (m_class_is_enumtype (mono_method_signature (method)->ret->data.klass)) {
-			rtype = mono_class_enum_basetype (mono_method_signature (method)->ret->data.klass)->type;
+			rtype = mono_class_enum_basetype_internal (mono_method_signature (method)->ret->data.klass)->type;
 			goto handle_enum;
 		}
 		save_mode = SAVE_STRUCT;

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -359,7 +359,7 @@ handle_enum:
 		return OP_STORER8_MEMBASE_REG;
 	case MONO_TYPE_VALUETYPE:
 		if (m_class_is_enumtype (type->data.klass)) {
-			type = mono_class_enum_basetype (type->data.klass);
+			type = mono_class_enum_basetype_internal (type->data.klass);
 			goto handle_enum;
 		}
 		if (MONO_CLASS_IS_SIMD (cfg, mono_class_from_mono_type (type)))


### PR DESCRIPTION
Backport of #11079.

/cc @lambdageek @jaykrell

Description:
