### PR TITLE
[2018-08] [sdks] Fix llvm-llvm32 build

### DIFF
--- a/llvm/SUBMODULES.json
+++ b/llvm/SUBMODULES.json
@@ -2,7 +2,7 @@
   {
       "name": "llvm", 
       "url": "git://github.com/mono/llvm.git",
-      "rev": "fc854b8ec5873d294b80afa3e6cf6a88c5c48886",
+      "rev": "81376d161cb6c2230834b2dc096ccbdae8d93020",
       "remote-branch": "origin/release_60", 
       "branch": "release_60", 
       "directory": "llvm"

--- a/sdks/builds/llvm.mk
+++ b/sdks/builds/llvm.mk
@@ -20,7 +20,7 @@ $(LLVM36_SRC)/configure: | $(LLVM36_SRC)
 ifeq ($(UNAME),Darwin)
 ifeq ($(DISABLE_DOWNLOAD_LLVM),)
 	mkdir -p $(TOP)/sdks/builds/toolchains/llvm-download
-	$(MAKE) -C $(TOP)/llvm -f build.mk download-llvm \
+	-$(MAKE) -C $(TOP)/llvm -f build.mk download-llvm \
 		LLVM_PREFIX="$(TOP)/sdks/builds/toolchains/llvm-download/usr"
 	touch $@
 endif
@@ -120,7 +120,7 @@ clean-llvm-$(1)::
 
 endef
 
-llvm-llvm32_CMAKE_FLAGS=-DLLVM_BUILD_32_BITS=On
+llvm-llvm32_CMAKE_ARGS=-DLLVM_BUILD_32_BITS=On
 $(eval $(call LLVMTemplate,llvm32,i386))
 $(eval $(call LLVMTemplate,llvm64,x86_64))
 


### PR DESCRIPTION
Backport of https://github.com/mono/mono/pull/10611.