### PR TITLE
[mini helpers] strip more directives on arm

### DIFF
--- a/mono/mini/helpers.c
+++ b/mono/mini/helpers.c
@@ -264,7 +264,7 @@ mono_disassemble_code (MonoCompile *cfg, guint8 *code, int size, char *id)
 	 * The arm assembler inserts ELF directives instructing objdump to display 
 	 * everything as data.
 	 */
-	cmd = g_strdup_printf (ARCH_PREFIX "strip -x %s", o_file);
+	cmd = g_strdup_printf (ARCH_PREFIX "strip -s %s", o_file);
 	unused = system (cmd);
 	g_free (cmd);
 #endif


### PR DESCRIPTION
* `-s` removes all symbols.
* `-x` removes non-global symbols.

This is needed in order to get human readable output with `MONO_VERBOSE_METHOD=method`, so instead of:

```
Disassembly of section .text:

00000000 <.text>:
   0:   e92d4900        .word   0xe92d4900
   4:   e24dd05c        .word   0xe24dd05c
   8:   e1a0b00d        .word   0xe1a0b00d
   c:   e58b0030        .word   0xe58b0030
  10:   e58b1034        .word   0xe58b1034
[...]
```

It is this now:
```
Disassembly of section .text:

00000000 <.text>:
   0:   e92d4900        push    {r8, fp, lr}
   4:   e24dd05c        sub     sp, sp, #92     ; 0x5c
   8:   e1a0b00d        mov     fp, sp
   c:   e58b0030        str     r0, [fp, #48]   ; 0x30
  10:   e58b1034        str     r1, [fp, #52]   ; 0x34
[...]
```

This is needed due to a newer toolchain on our ARM bots. Tested on armv7 and aarch64.
