### PR TITLE
Fix Mono on FreeBSD/powerpc64

### DIFF
--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -4679,7 +4679,8 @@ mono_arch_register_lowlevel_calls (void)
 }
 
 #ifdef __mono_ppc64__
-#ifdef _LITTLE_ENDIAN
+/* XXX: Should this be testing on ABI? */
+#if G_BYTE_ORDER == G_LITTLE_ENDIAN
 #define patch_load_sequence(ip,val) do {\
 		guint16 *__load = (guint16*)(ip);	\
 		g_assert (sizeof (val) == sizeof (gsize)); \
@@ -4688,7 +4689,7 @@ mono_arch_register_lowlevel_calls (void)
 		__load [6] = (((guint64)(gsize)(val)) >> 16) & 0xffff;	\
 		__load [8] =  ((guint64)(gsize)(val))        & 0xffff;	\
 	} while (0)
-#elif defined _BIG_ENDIAN
+#elif G_BYTE_ORDER == G_BIG_ENDIAN
 #define patch_load_sequence(ip,val) do {\
 		guint16 *__load = (guint16*)(ip);	\
 		g_assert (sizeof (val) == sizeof (gsize)); \

--- a/mono/utils/mono-sigcontext.h
+++ b/mono/utils/mono-sigcontext.h
@@ -363,10 +363,10 @@ typedef struct ucontext {
 #elif defined(__FreeBSD__)
 	typedef ucontext_t os_ucontext;
 
-	#define UCONTEXT_REG_Rn(ctx, n)   ((ctx)->uc_mcontext.mc_gpr [(n)])
-	#define UCONTEXT_REG_FPRn(ctx, n) ((ctx)->uc_mcontext.mc_fpreg [(n)])
-	#define UCONTEXT_REG_NIP(ctx)     ((ctx)->uc_mcontext.mc_srr0)
-	#define UCONTEXT_REG_LNK(ctx)     ((ctx)->uc_mcontext.mc_lr)
+	#define UCONTEXT_REG_Rn(ctx, n)   (((os_ucontext*)(ctx))->uc_mcontext.mc_gpr [(n)])
+	#define UCONTEXT_REG_FPRn(ctx, n) (((os_ucontext*)(ctx))->uc_mcontext.mc_fpreg [(n)])
+	#define UCONTEXT_REG_NIP(ctx)     (((os_ucontext*)(ctx))->uc_mcontext.mc_srr0)
+	#define UCONTEXT_REG_LNK(ctx)     (((os_ucontext*)(ctx))->uc_mcontext.mc_lr)
 #elif defined(_AIX)
 	typedef ucontext_t os_ucontext;
 


### PR DESCRIPTION
Integrate these PRs that aren't branched properly:

	* Trampoline patching ifdefs were wrong. (#11125)

	* ucontext macros are wrong for this platform (#11020)

Tested on AIX, doesn't seem to regress there. I haven't myself
tested this on FreeBSD or Linux though.

Fixes #11021. Thanks to @lenoil98 for reporting and fixing these.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
