### PR TITLE
[crash] Split unmanaged method pointers into method ip + offset

### DIFF
--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -561,6 +561,7 @@ typedef struct {
 	} managed_data;
 	struct {
 		intptr_t ip;
+		gint32 offset;
 		const char *module;
 		gboolean is_trampoline;
 		gboolean has_name;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1398,8 +1398,6 @@ check_whitelisted_module (const char *in_name, const char **out_module)
 		return TRUE;
 	}
 
-	/*fprintf (stderr, "%s == %s\n", info.dli_fname, *out_module);*/
-
 	return FALSE;
 }
 
@@ -1415,26 +1413,11 @@ mono_make_portable_ip (intptr_t in_ip, intptr_t module_base)
 	// *CoreSymbolicationDT.framework version:	63750*/
 	intptr_t offset = in_ip - module_base;
 	intptr_t magic_value = offset + 0x100000000;
-
-	GHashTableIter iter;
-	char *file_suffix;
-	char *module_suffix;
-	g_hash_table_iter_init (&iter, native_library_whitelist);
-	while (g_hash_table_iter_next (&iter, (gpointer *) &file_suffix, (gpointer *) &module_suffix)) {
-		if (!g_str_has_suffix (in_name, file_suffix))
-			continue;
-		if (out_module)
-			*out_module = module_suffix;
-		return TRUE;
-	}
-
-	/*fprintf (stderr, "%s == %s\n", info.dli_fname, *out_module);*/
-
-	return FALSE;
+	return magic_value;
 }
 
 static gboolean
-mono_get_portable_ip (intptr_t in_ip, intptr_t *out_ip, const char **out_module, char *out_name)
+mono_get_portable_ip (intptr_t in_ip, intptr_t *out_ip, gint32 *out_offset, const char **out_module, char *out_name)
 {
 	// Note: it's not safe for us to be interrupted while inside of dl_addr, because if we
 	// try to call dl_addr while interrupted while inside the lock, we will try to take a
@@ -1447,7 +1430,8 @@ mono_get_portable_ip (intptr_t in_ip, intptr_t *out_ip, const char **out_module,
 	if (!check_whitelisted_module (info.dli_fname, out_module))
 		return FALSE;
 
-	*out_ip = mono_make_portable_ip (in_ip, (intptr_t) info.dli_fbase);
+	*out_ip = mono_make_portable_ip ((intptr_t) info.dli_saddr, (intptr_t) info.dli_fbase);
+	*out_offset = in_ip - (intptr_t) info.dli_saddr;
 
 #ifndef MONO_PRIVATE_CRASHES
 	if (info.dli_saddr && out_name)
@@ -1483,7 +1467,7 @@ summarize_offset_rich_hash (guint64 accum, MonoFrameSummary *frame)
 	} else {
 		hash_accum += mono_metadata_str_hash (frame->str_descr);
 		hash_accum += frame->managed_data.token;
-		hash_accum += frame->managed_data.native_offset;
+		hash_accum += frame->managed_data.il_offset;
 	}
 
 	return hash_accum;
@@ -1505,7 +1489,7 @@ summarize_frame_internal (MonoMethod *method, gpointer ip, size_t native_offset,
 	dest->unmanaged_data.ip = (intptr_t) ip;
 	dest->is_managed = managed;
 
-	if (method && method->wrapper_type != MONO_WRAPPER_NONE && method->wrapper_type < MONO_WRAPPER_NUM) {
+	if (!managed && method && method->wrapper_type != MONO_WRAPPER_NONE && method->wrapper_type < MONO_WRAPPER_NUM) {
 		dest->is_managed = FALSE;
 		dest->unmanaged_data.has_name = TRUE;
 		copy_summary_string_safe (dest->str_descr, mono_wrapper_type_to_str (method->wrapper_type));
@@ -1546,19 +1530,23 @@ summarize_frame_internal (MonoMethod *method, gpointer ip, size_t native_offset,
 }
 
 static gboolean
-summarize_frame_managed_walk (MonoMethod *method, gpointer ip, size_t native_offset, gboolean managed, gpointer user_data)
+summarize_frame_managed_walk (MonoMethod *method, gpointer ip, size_t frame_native_offset, gboolean managed, gpointer user_data)
 {
 	int il_offset = -1;
 
 	if (managed && method) {
-		MonoDebugSourceLocation *location = mono_debug_lookup_source_location (method, native_offset, mono_domain_get ());
+		MonoDebugSourceLocation *location = mono_debug_lookup_source_location (method, frame_native_offset, mono_domain_get ());
 		if (location) {
 			il_offset = location->il_offset;
 			mono_debug_free_source_location (location);
 		}
 	}
 
-	return summarize_frame_internal (method, ip, native_offset, il_offset, managed, user_data);
+	intptr_t portable_ip = 0;
+	gint32 offset = 0;
+	mono_get_portable_ip ((intptr_t) ip, &portable_ip, &offset, NULL, NULL);
+
+	return summarize_frame_internal (method, (gpointer) portable_ip, frame_native_offset, il_offset, managed, user_data);
 }
 
 
@@ -1573,8 +1561,9 @@ summarize_frame (StackFrameInfo *frame, MonoContext *ctx, gpointer data)
 	if (frame->ji && (frame->ji->is_trampoline || frame->ji->async))
 		return FALSE; // Keep unwinding
 
-	intptr_t ip = 0x0;
-	mono_get_portable_ip ((intptr_t) MONO_CONTEXT_GET_IP (ctx), &ip, NULL, NULL);
+	intptr_t ip = 0;
+	gint32 offset = 0;
+	mono_get_portable_ip ((intptr_t) MONO_CONTEXT_GET_IP (ctx), &ip, &offset, NULL, NULL);
 	// Don't need to handle return status "success" because this ip is stored below only, NULL is okay
 
 	gboolean is_managed = (frame->type == FRAME_TYPE_MANAGED || frame->type == FRAME_TYPE_INTERP);
@@ -1585,7 +1574,7 @@ summarize_frame (StackFrameInfo *frame, MonoContext *ctx, gpointer data)
 	if (is_managed)
 		method = jinfo_get_method (frame->ji);
 
-	return summarize_frame_internal (method, (gpointer) ip, frame->native_offset, frame->il_offset, is_managed, data);
+	return summarize_frame_internal (method, (gpointer) ip, offset, frame->il_offset, is_managed, data);
 }
 
 static void
@@ -1645,7 +1634,7 @@ mono_summarize_unmanaged_stack (MonoThreadSummary *out)
 		intptr_t ip = frame_ips [i];
 		MonoFrameSummary *frame = &out->unmanaged_frames [i];
 
-		int success = mono_get_portable_ip (ip, &frame->unmanaged_data.ip, &frame->unmanaged_data.module, (char *) frame->str_descr);
+		int success = mono_get_portable_ip (ip, &frame->unmanaged_data.ip, &frame->unmanaged_data.offset, &frame->unmanaged_data.module, (char *) frame->str_descr);
 		if (!success)
 			continue;
 

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1361,28 +1361,49 @@ copy_summary_string_safe (char *in, const char *out)
 	return;
 }
 
-static GHashTable *native_library_whitelist;
+typedef struct {
+	char *suffix;
+	char *exported_name;
+} MonoLibWhitelistEntry;
+
+static GList *native_library_whitelist;
 
 static void
 mono_crash_reporting_register_native_library (const char *module_path, const char *module_name)
 {
-	Dl_info info;
-	if (!native_library_whitelist) {
-		native_library_whitelist = g_hash_table_new_full (NULL, NULL, NULL, g_free);
-
-		dladdr ((void*) mono_crash_reporting_register_native_library, &info);
-
-		if (info.dli_fname && strlen(info.dli_fname) > 0)
-			g_hash_table_insert (native_library_whitelist, g_strdup (info.dli_fname), g_strdup ("mono"));
-	}
-
 	// Examples: libsystem_pthread.dylib -> "pthread"
 	// Examples: libsystem_platform.dylib -> "platform"
 	// Examples: mono-sgen -> "mono" from above line
-	g_hash_table_insert (native_library_whitelist, g_strdup (module_path), g_strdup (module_name));
+	MonoLibWhitelistEntry *entry = g_new0 (MonoLibWhitelistEntry, 1);
+	entry->suffix = g_strdup (module_path);
+	entry->exported_name = g_strdup (module_name);
+	native_library_whitelist = g_list_append (native_library_whitelist, entry);
 }
 
 static gboolean
+check_whitelisted_module (const char *in_name, const char **out_module)
+{
+	if (g_str_has_suffix (in_name, "mono-sgen")) {
+		if (out_module)
+			*out_module = "mono";
+		return TRUE;
+	}
+
+	for (GList *cursor = native_library_whitelist; cursor; cursor = cursor->next) {
+		MonoLibWhitelistEntry *iter = (MonoLibWhitelistEntry *) cursor->data;
+		if (!g_str_has_suffix (in_name, iter->suffix))
+			continue;
+		if (out_module)
+			*out_module = iter->exported_name;
+		return TRUE;
+	}
+
+	/*fprintf (stderr, "%s == %s\n", info.dli_fname, *out_module);*/
+
+	return FALSE;
+}
+
+static intptr_t
 mono_make_portable_ip (intptr_t in_ip, intptr_t module_base)
 {
 	// FIXME: Make generalize away from llvm tools?
@@ -1394,21 +1415,6 @@ mono_make_portable_ip (intptr_t in_ip, intptr_t module_base)
 	// *CoreSymbolicationDT.framework version:	63750*/
 	intptr_t offset = in_ip - module_base;
 	intptr_t magic_value = offset + 0x100000000;
-	return magic_value;
-}
-
-static gboolean
-check_whitelisted_module (const char *in_name, const char **out_module)
-{
-	if (!native_library_whitelist) {
-		if (g_str_has_suffix (in_name, "mono-sgen")) {
-			if (out_module)
-				*out_module = "mono";
-			return TRUE;
-		}
-
-		return FALSE;
-	}
 
 	GHashTableIter iter;
 	char *file_suffix;

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -143,14 +143,37 @@ mono_native_state_add_frame (JsonWriter *writer, MonoFrameSummary *frame)
 		mono_json_writer_object_key(writer, "il_offset");
 		mono_json_writer_printf (writer, "\"0x%05x\"\n", frame->managed_data.il_offset);
 
+		assert_has_space ();
+		mono_json_writer_indent (writer);
+		mono_json_writer_object_key(writer, "il_offset");
+		mono_json_writer_printf (writer, "\"0x%05x\"\n", frame->managed_data.il_offset);
+
 	} else {
 		assert_has_space ();
 		mono_json_writer_indent (writer);
 		mono_json_writer_object_key (writer, "native_address");
-		if (frame->unmanaged_data.ip)
-			mono_json_writer_printf (writer, "\"%p\"", (void *) frame->unmanaged_data.ip);
-		else
-			mono_json_writer_printf (writer, "\"outside mono-sgen\"");
+		if (frame->unmanaged_data.ip) {
+			mono_json_writer_printf (writer, "\"0x%" PRIx64 "\"", frame->unmanaged_data.ip);
+		} else
+			mono_json_writer_printf (writer, "\"unregistered\"");
+
+		if (frame->unmanaged_data.ip) {
+			mono_json_writer_printf (writer, ",\n");
+
+			assert_has_space ();
+			mono_json_writer_indent (writer);
+			mono_json_writer_object_key (writer, "native_offset");
+			mono_json_writer_printf (writer, "\"0x%05x\"", frame->unmanaged_data.offset);
+		}
+
+		if (frame->unmanaged_data.module) {
+			mono_json_writer_printf (writer, ",\n");
+
+			assert_has_space ();
+			mono_json_writer_indent (writer);
+			mono_json_writer_object_key (writer, "native_module");
+			mono_json_writer_printf (writer, "\"%s\"", frame->unmanaged_data.module);
+		}
 
 		if (frame->unmanaged_data.has_name) {
 			mono_json_writer_printf (writer, ",\n");


### PR DESCRIPTION
The VS4M team is making a tool that makes a symbolication lookup table. This enables symbolication without access to the relevant binary. 

For unmanaged, it's much harder to precompute things because we were presenting the instruction address. From the address, any lookup needs to find the function enclosing this interior pointer.

To make it easier, this reports the address of the native method as well as the offset. A lookup table can simply key on the function start address with this now. 

ie:

  ``` 
      {
        "native_address" : "0x1003a6340",
        "native_offset" : "0x00046",
        "native_module" : "mono"
      }
```

 ```
$ nm mini/mono-sgen | grep '1003a6340' 

00000001003a6340 t _mono_runtime_run_main_checked

```

```
$ nm mini/mono-sgen | grep ' t ' | sort -n

00000001000a4e90 t _alloc_ireg
00000001000a4eb0 t _decompose_long_opcode
00000001000aae90 t _mono_decompose_long_opts
00000001000aaea0 t _mono_decompose_vtype_opts
00000001000ae130 t _m_class_get_byval_arg
00000001000ae150 t _alloc_dreg
............
```

