### PR TITLE
Experiment to narrow down csc crashes.

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -6922,6 +6922,22 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 		}
 	}
 
+	// temporary
+	const char* method_klass_name_space;
+	method_klass_name_space = m_class_get_name_space (method->klass);
+	const char* method_klass_name;
+	method_klass_name = m_class_get_name (method->klass);
+
+	if (cfg->method == method &&
+			method_klass_name_space [0] == 'S' &&
+			method_klass_name [0] == 'B' &&
+			strcmp (method_klass_name_space, "System.Reflection.Metadata") == 0 &&
+			strcmp (method_klass_name, "BlobBuilder") == 0  &&
+			strcmp (method->name, ".ctor") == 0) {
+		EMIT_NEW_ARGLOAD (cfg, ins, 0);
+		MONO_EMIT_NULL_CHECK (cfg, ins->dreg, TRUE);
+	}
+
 	/* we use a separate basic block for the initialization code */
 	NEW_BBLOCK (cfg, init_localsbb);
 	if (cfg->method == method)


### PR DESCRIPTION
https://github.com/mono/mono/issues/11045

```
    // method line 600
    .method public hidebysig specialname rtspecialname
           instance default void '.ctor' ([opt] int32 capacity)  cil managed
    {
	.param [1] = int32(0x00000100)
        // Method begins at RVA 0x784b
	// Code size 59 (0x3b)
	.maxstack 8
	IL_0000:  ldarg.0
	IL_0001:  call instance void object::'.ctor'()
	IL_0006:  ldarg.1
	IL_0007:  ldc.i4.0
	IL_0008:  bge.s IL_0014

	IL_000a:  ldstr "capacity"
	IL_000f:  call void class System.Reflection.Throw::ArgumentOutOfRange(string)
	IL_0014:  ldsfld bool [System.Runtime.Extensions]System.BitConverter::IsLittleEndian
	IL_0019:  brtrue.s IL_0020

	IL_001b:  call void class System.Reflection.Throw::LitteEndianArchitectureRequired()

this._nextOrPrevious = this  -- null dereference on this line

1***	IL_0020:  ldarg.0      stack says "20"
	IL_0021:  ldarg.0
	IL_0022:  stfld class System.Reflection.Metadata.BlobBuilder System.Reflection.Metadata.BlobBuilder::_nextOrPrevious

tem_Reflection_Metadata_BlobBuilder__ctor:
0000000000000000	subq	$0x18, %rsp
0000000000000004	movq	%r14, (%rsp)
0000000000000008	movq	%r15, 0x8(%rsp)
000000000000000d	movq	%rdi, %r14            2*** rdi=this; r14=this
0000000000000010	movq	%rsi, %r15            rsi=capacity; r15=capacity
0000000000000013	movabsq	$0x101eddcf0, %rax
000000000000001d	testl	$0x1, (%rax)          ; poll
0000000000000023	je	0x33
0000000000000025	nop
0000000000000026	movabsq	$0x10ad91e80, %r11
0000000000000030	callq	*%r11                 ; poll success 3***
0000000000000033	testl	%r15d, %r15d          ; is capacity >= 0
0000000000000036	jge	0x53
0000000000000038	movabsq	$0x1037151c0, %rdi    ; if not, 0x101eddcf0
0000000000000042	leaq	(%rbp), %rbp
0000000000000046	movabsq	$0x1191a62b8, %r11
0000000000000050	callq	*%r11
0000000000000053	movq	%r14, 0x10(%r14)      ; 4*** this._nextOrPrevious = this
```

So, either rdi came in as null (or small),
or the poll point was taken and corrupted r14.
 Or capacity came in as 0, the exception was taken, but resumed, with corrupt r14, seems most unlikely.

Knowing which does not solve the problem but might help.

This PR safely experiments with putting a null check at the start of the function to narrow this down.

It is doubted that much of a repro is available here, outside the large scale of CI.