### PR TITLE
Fix configure error message to match scripts/ci.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,7 +57,7 @@ AC_SUBST(MONO_CORLIB_VERSION)
 
 case $host_os in
 *cygwin* )
-		 echo "Run configure using ./configure --host=i686-pc-mingw32"
+		 echo "Run configure using ./configure --host=i686-w64-mingw32 or --host=x86_64-w64-mingw32"
 		 exit 1
 esac
 


### PR DESCRIPTION
Doing what the error says leads to many compilation errors, i.e. building for Cygwin, which is quite 
broken. Following CI is looking promising.