### PR TITLE
[2018-06] [sdks] futimens and futimes symbols are missing on anything earlier than 10.13

### DIFF
--- a/sdks/builds/llvm.mk
+++ b/sdks/builds/llvm.mk
@@ -67,6 +67,7 @@ define LLVMTemplate
 _llvm-$(1)_CMAKE_FLAGS = \
 	$$(llvm_CMAKE_FLAGS) \
 	-DCMAKE_INSTALL_PREFIX=$$(TOP)/sdks/out/llvm-$(1) \
+	-DHAVE_FUTIMENS=0 \
 	$$(llvm-$(1)_CMAKE_FLAGS)
 
 .stamp-llvm-$(1)-configure: $$(LLVM_SRC)/CMakeLists.txt


### PR DESCRIPTION
This breaks when LLVM is built on 10.13+ and the runtimes are built on 10.12.