### PR TITLE
[2018-08] [sdks] futimens symbols are missing on anything earlier than 10.13

### DIFF
--- a/llvm/build.mk
+++ b/llvm/build.mk
@@ -54,6 +54,7 @@ $(LLVM_BUILD)/$(if $(NINJA),build.ninja,Makefile): $(LLVM_PATH)/CMakeLists.txt |
 		-DLLVM_TOOLS_TO_BUILD="opt;llc;llvm-config;llvm-dis" \
 		-DLLVM_TARGETS_TO_BUILD="X86;ARM;AArch64" \
 		-DLLVM_ENABLE_ASSERTIONS=$(if $(INTERNAL_LLVM_ASSERTS),On,Off) \
+		-DHAVE_FUTIMENS=0 \
 		$(LLVM_CMAKE_ARGS) \
 		$(dir $<)
 


### PR DESCRIPTION
This breaks when LLVM is built on 10.13+ and the runtimes are built on 10.12.