### PR TITLE
[2018-10] [sdks] futimens and futimes symbols are missing on anything earlier than 10.13

### DIFF
--- a/llvm/build.mk
+++ b/llvm/build.mk
@@ -60,6 +60,7 @@ $(LLVM_BUILD)/$(if $(NINJA),build.ninja,Makefile): $(LLVM_PATH)/CMakeLists.txt |
 		-DLLVM_TARGETS_TO_BUILD="X86;ARM;AArch64" \
 		$(EXTRA_LLVM_ARGS)	\
 		-DLLVM_ENABLE_ASSERTIONS=$(if $(INTERNAL_LLVM_ASSERTS),On,Off) \
+		-DHAVE_FUTIMENS=0 \
 		$(LLVM_CMAKE_ARGS) \
 		$(dir $<)
 


### PR DESCRIPTION
Backport of #11176.

/cc @luhenry 

Description:
This breaks when LLVM is built on 10.13+ and the runtimes are built on 10.12.