### PR TITLE
Take fast path only for delegate types not Delegate/MulticastDelegate.

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -4073,7 +4073,7 @@ mono_class_get_methods_by_name (MonoClass *klass, const char *name, guint32 bfla
 	compare_func = ((bflags & BFLAGS_IgnoreCase) || (mlisttype == MLISTTYPE_CaseInsensitive)) ? mono_utf8_strcasecmp : strcmp;
 
 	/* An optimization for calls made from Delegate:CreateDelegate () */
-	if (m_class_is_delegate (klass) && name && !strcmp (name, "Invoke") && (bflags == (BFLAGS_Public | BFLAGS_Static | BFLAGS_Instance))) {
+	if (m_class_is_delegate (klass) && klass != mono_defaults.delegate_class && klass != mono_defaults.multicastdelegate_class && name && !strcmp (name, "Invoke") && (bflags == (BFLAGS_Public | BFLAGS_Static | BFLAGS_Instance))) {
 		method = mono_get_delegate_invoke (klass);
 		g_assert (method);
 

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -397,6 +397,7 @@ TESTS_CS_SRC=		\
 	delegate13.cs		\
 	delegate14.cs		\
 	delegate15.cs		\
+	delegate16.cs		\
 	largeexp.cs		\
 	largeexp2.cs		\
 	marshalbyref1.cs	\

--- a/mono/tests/delegate16.cs
+++ b/mono/tests/delegate16.cs
@@ -1,0 +1,12 @@
+using System;
+
+public static class Program
+{
+	public static int Main ()
+	{
+		if (typeof(Delegate).GetMethod("Invoke") != null)
+			return 1;
+
+		return 0;
+	}
+}


### PR DESCRIPTION
Avoid optimization for Delegate:CreateDelegate when class is Delegate or MulticastDelegate. Fixes #11181.
