### PR TITLE
[marshal] Emit GC Safe transitions around foreign internal calls.

### DIFF
--- a/mono/metadata/icall-internals.h
+++ b/mono/metadata/icall-internals.h
@@ -66,6 +66,12 @@ mono_icall_drive_info_get_drive_type (MonoString *root_path_name);
 #endif  /* !G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT) */
 
 void*
-mono_lookup_internal_call_full (MonoMethod *method, gboolean warn_on_missing, mono_bool *uses_handles);
+mono_lookup_internal_call_full (MonoMethod *method, gboolean warn_on_missing, mono_bool *uses_handles, mono_bool *foreign);
+
+MONO_PAL_API void
+mono_add_internal_call_with_flags (const char *name, const void* method, gboolean cooperative);
+
+MONO_PROFILER_API void
+mono_add_internal_call_internal (const char *name, gconstpointer method);
 
 #endif /* __MONO_METADATA_ICALL_INTERNALS_H__ */

--- a/mono/metadata/icall-internals.h
+++ b/mono/metadata/icall-internals.h
@@ -68,10 +68,33 @@ mono_icall_drive_info_get_drive_type (MonoString *root_path_name);
 void*
 mono_lookup_internal_call_full (MonoMethod *method, gboolean warn_on_missing, mono_bool *uses_handles, mono_bool *foreign);
 
+
 MONO_PAL_API void
 mono_add_internal_call_with_flags (const char *name, const void* method, gboolean cooperative);
 
 MONO_PROFILER_API void
 mono_add_internal_call_internal (const char *name, gconstpointer method);
+
+#ifdef __cplusplus
+
+#include <type_traits>
+
+template <typename T>
+inline typename std::enable_if<std::is_function<T>::value ||
+			       std::is_function<typename std::remove_pointer<T>::type>::value >::type
+mono_add_internal_call_with_flags (const char *name, T method, gboolean cooperative)
+{
+	return mono_add_internal_call_with_flags (name, (const void*)method, cooperative);
+}
+
+template <typename T>
+inline typename std::enable_if<std::is_function<T>::value ||
+			       std::is_function<typename std::remove_pointer<T>::type>::value >::type
+mono_add_internal_call_internal (const char *name, T method)
+{
+	return mono_add_internal_call_internal (name, (const void*)method);
+}
+
+#endif // __cplusplus
 
 #endif /* __MONO_METADATA_ICALL_INTERNALS_H__ */

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -8336,6 +8336,31 @@ mono_add_internal_call (const char *name, gconstpointer method)
 }
 
 /**
+ * mono_dangerous_add_raw_internal_call:
+ * \param name method specification to surface to the managed world
+ * \param method pointer to a C method to invoke when the method is called
+ *
+ * Similar to \c mono_add_internal_call but with more requirements for correct
+ * operation.
+ *
+ * A thread running a dangerous raw internal call will avoid a thread state
+ * transition on entry and exit, but it must take responsiblity for cooperating
+ * with the Mono runtime.
+ *
+ * The \p method must NOT:
+ *
+ * Run for an unbounded amount of time without calling the mono runtime.
+ * Additionally, the method must switch to GC Safe mode to perform all blocking
+ * operations: performing blocking I/O, taking locks, etc.
+ *
+ */
+void
+mono_dangerous_add_raw_internal_call (const char *name, gconstpointer method)
+{
+	mono_add_internal_call_with_flags (name, method, TRUE);
+}
+
+/**
  * mono_add_internal_call_with_flags:
  * \param name method specification to surface to the managed world
  * \param method pointer to a C method to invoke when the method is called

--- a/mono/metadata/loader-internals.h
+++ b/mono/metadata/loader-internals.h
@@ -5,15 +5,4 @@
 #ifndef _MONO_METADATA_LOADER_INTERNALS_H_
 #define _MONO_METADATA_LOADER_INTERNALS_H_
 
-#ifdef __cplusplus
-
-template <typename T>
-inline void
-mono_add_internal_call (const char *name, T method)
-{
-	return mono_add_internal_call (name, (const void*)method);
-}
-
-#endif // __cplusplus
-
 #endif

--- a/mono/metadata/loader.h
+++ b/mono/metadata/loader.h
@@ -59,6 +59,9 @@ mono_method_get_index      (MonoMethod *method);
 MONO_API MONO_RT_EXTERNAL_ONLY void
 mono_add_internal_call     (const char *name, const void* method);
 
+MONO_API MONO_RT_EXTERNAL_ONLY void
+mono_dangerous_add_raw_internal_call (const char *name, const void* method);
+
 MONO_API void*
 mono_lookup_internal_call (MonoMethod *method);
 

--- a/mono/metadata/loader.h
+++ b/mono/metadata/loader.h
@@ -56,7 +56,7 @@ mono_method_get_flags      (MonoMethod *method, uint32_t *iflags);
 MONO_API uint32_t
 mono_method_get_index      (MonoMethod *method);
 
-MONO_API void
+MONO_API MONO_RT_EXTERNAL_ONLY void
 mono_add_internal_call     (const char *name, const void* method);
 
 MONO_API void*

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -6229,11 +6229,12 @@ emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 	int thread_info_var = -1, stack_mark_var = -1, error_var = -1;
 	MonoMethodSignature *call_sig = csig;
 	gboolean uses_handles = FALSE;
+	gboolean foreign_icall = FALSE;
 	gboolean save_handles_to_locals = FALSE;
 	IcallHandlesLocal *handles_locals = NULL;
 	MonoMethodSignature *sig = mono_method_signature_internal (method);
 
-	(void) mono_lookup_internal_call_full (method, FALSE, &uses_handles);
+	(void) mono_lookup_internal_call_full (method, FALSE, &uses_handles, &foreign_icall);
 
 	/* If it uses handles and MonoError, it had better check exceptions */
 	g_assert (!uses_handles || check_exceptions);

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -6303,11 +6303,18 @@ emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 	gboolean save_handles_to_locals = FALSE;
 	IcallHandlesLocal *handles_locals = NULL;
 	MonoMethodSignature *sig = mono_method_signature_internal (method);
+	gboolean need_gc_safe = FALSE;
+	GCSafeTransitionBuilder gc_safe_transition_builder;
 
 	(void) mono_lookup_internal_call_full (method, FALSE, &uses_handles, &foreign_icall);
 
 	/* If it uses handles and MonoError, it had better check exceptions */
 	g_assert (!uses_handles || check_exceptions);
+
+	if (G_UNLIKELY (foreign_icall)) {
+		/* FIXME: we only want the transitions for hybrid suspend.  Q: What to do about AOT? */
+		need_gc_safe = gc_safe_transition_builder_init (&gc_safe_transition_builder, mb, FALSE);
+	}
 
 	if (uses_handles) {
 		MonoMethodSignature *ret;
@@ -6352,6 +6359,10 @@ emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 		ret->pinvoke = csig->pinvoke;
 
 		call_sig = ret;
+	}
+
+	if (G_UNLIKELY (need_gc_safe)) {
+		gc_safe_transition_builder_add_locals (&gc_safe_transition_builder);
 	}
 
 	if (uses_handles) {
@@ -6460,6 +6471,9 @@ emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 			mono_mb_emit_ldarg (mb, i + sig->hasthis);
 	}
 
+	if (G_UNLIKELY (need_gc_safe))
+		gc_safe_transition_builder_emit_enter (&gc_safe_transition_builder, &piinfo->method, aot);
+
 	if (aot) {
 		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
 		mono_mb_emit_op (mb, CEE_MONO_ICALL_ADDR, &piinfo->method);
@@ -6468,6 +6482,9 @@ emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 		g_assert (piinfo->addr);
 		mono_mb_emit_native_call (mb, call_sig, piinfo->addr);
 	}
+
+	if (G_UNLIKELY (need_gc_safe))
+		gc_safe_transition_builder_emit_exit (&gc_safe_transition_builder);
 
 	if (uses_handles) {
 		if (MONO_TYPE_IS_REFERENCE (sig->ret)) {
@@ -6514,6 +6531,9 @@ emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 		mono_mb_emit_ldloc_addr (mb, error_var);
 		mono_mb_emit_icall (mb, mono_icall_end);
 	}
+
+	if (G_UNLIKELY (need_gc_safe))
+		gc_safe_transition_builder_cleanup (&gc_safe_transition_builder);
 
 	if (check_exceptions)
 		emit_thread_interrupt_checkpoint (mb);

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -1685,6 +1685,103 @@ mono_mb_emit_auto_layout_exception (MonoMethodBuilder *mb, MonoClass *klass)
 	mono_mb_emit_exception_marshal_directive (mb, msg);
 }
 
+typedef struct EmitGCSafeTransitionBuilder {
+	MonoMethodBuilder *mb;
+	gboolean func_param;
+	int coop_gc_stack_dummy;
+	int coop_gc_var;
+#ifndef DISABLE_COM
+	int coop_cominterop_fnptr;
+#endif
+} GCSafeTransitionBuilder;
+
+static gboolean
+gc_safe_transition_builder_init (GCSafeTransitionBuilder *builder, MonoMethodBuilder *mb, gboolean func_param)
+{
+	if (mono_threads_is_blocking_transition_enabled ()) {
+		builder->mb = mb;
+		builder->func_param = func_param;
+		builder->coop_gc_stack_dummy = -1;
+		builder->coop_gc_var = -1;
+#ifndef DISABLE_COM
+		builder->coop_cominterop_fnptr = -1;
+#endif
+		return TRUE;
+	} else
+		return FALSE;
+}
+
+/**
+ * adds locals for the gc safe transition to the method builder.
+ */
+static void
+gc_safe_transition_builder_add_locals (GCSafeTransitionBuilder *builder)
+{
+	MonoType *int_type = mono_get_int_type();
+	/* local 4, dummy local used to get a stack address for suspend funcs */
+	builder->coop_gc_stack_dummy = mono_mb_add_local (builder->mb, int_type);
+	/* local 5, the local to be used when calling the suspend funcs */
+	builder->coop_gc_var = mono_mb_add_local (builder->mb, int_type);
+#ifndef DISABLE_COM
+	if (!builder->func_param && MONO_CLASS_IS_IMPORT (builder->mb->method->klass)) {
+		builder->coop_cominterop_fnptr = mono_mb_add_local (builder->mb, int_type);
+	}
+#endif
+}
+
+/**
+ * emits
+ *     cookie = mono_threads_enter_gc_safe_region_unbalanced (ref dummy);
+ *
+ */
+static void
+gc_safe_transition_builder_emit_enter (GCSafeTransitionBuilder *builder, MonoMethod *method, gboolean aot)
+{
+
+	// Perform an extra, early lookup of the function address, so any exceptions
+	// potentially resulting from the lookup occur before entering blocking mode.
+	if (!builder->func_param && !MONO_CLASS_IS_IMPORT (builder->mb->method->klass) && aot) {
+		mono_mb_emit_byte (builder->mb, MONO_CUSTOM_PREFIX);
+		mono_mb_emit_op (builder->mb, CEE_MONO_ICALL_ADDR, method);
+		mono_mb_emit_byte (builder->mb, CEE_POP); // Result not needed yet
+	}
+
+#ifndef DISABLE_COM
+	if (!builder->func_param && MONO_CLASS_IS_IMPORT (builder->mb->method->klass)) {
+		mono_mb_emit_cominterop_get_function_pointer (builder->mb, method);
+		mono_mb_emit_stloc (builder->mb, builder->coop_cominterop_fnptr);
+	}
+#endif
+
+	mono_mb_emit_ldloc_addr (builder->mb, builder->coop_gc_stack_dummy);
+	mono_mb_emit_icall (builder->mb, mono_threads_enter_gc_safe_region_unbalanced);
+	mono_mb_emit_stloc (builder->mb, builder->coop_gc_var);
+}
+
+/**
+ * emits
+ *     mono_threads_exit_gc_safe_region_unbalanced (cookie, ref dummy);
+ *
+ */
+static void
+gc_safe_transition_builder_emit_exit (GCSafeTransitionBuilder *builder)
+{
+	mono_mb_emit_ldloc (builder->mb, builder->coop_gc_var);
+	mono_mb_emit_ldloc_addr (builder->mb, builder->coop_gc_stack_dummy);
+	mono_mb_emit_icall (builder->mb, mono_threads_exit_gc_safe_region_unbalanced);
+}
+
+static void
+gc_safe_transition_builder_cleanup (GCSafeTransitionBuilder *builder)
+{
+	builder->mb = NULL;
+	builder->coop_gc_stack_dummy = -1;
+	builder->coop_gc_var = -1;
+#ifndef DISABLE_COM
+	builder->coop_cominterop_fnptr = -1;
+#endif
+}
+
 /**
  * emit_native_wrapper_ilgen:
  * \param image the image to use for looking up custom marshallers
@@ -1706,15 +1803,15 @@ emit_native_wrapper_ilgen (MonoImage *image, MonoMethodBuilder *mb, MonoMethodSi
 	MonoClass *klass;
 	int i, argnum, *tmp_locals;
 	int type, param_shift = 0;
-	int coop_gc_stack_dummy, coop_gc_var;
-#ifndef DISABLE_COM
-	int coop_cominterop_fnptr;
-#endif
+	gboolean need_gc_safe = FALSE;
+	GCSafeTransitionBuilder gc_safe_transition_builder;
 
 	memset (&m, 0, sizeof (m));
 	m.mb = mb;
 	m.sig = sig;
 	m.piinfo = piinfo;
+
+	need_gc_safe = gc_safe_transition_builder_init (&gc_safe_transition_builder, mb, func_param);
 
 	/* we copy the signature, so that we can set pinvoke to 0 */
 	if (func_param) {
@@ -1749,16 +1846,8 @@ emit_native_wrapper_ilgen (MonoImage *image, MonoMethodBuilder *mb, MonoMethodSi
 		mono_mb_add_local (mb, sig->ret);
 	}
 
-	if (mono_threads_is_blocking_transition_enabled ()) {
-		/* local 4, dummy local used to get a stack address for suspend funcs */
-		coop_gc_stack_dummy = mono_mb_add_local (mb, int_type);
-		/* local 5, the local to be used when calling the suspend funcs */
-		coop_gc_var = mono_mb_add_local (mb, int_type);
-#ifndef DISABLE_COM
-		if (!func_param && MONO_CLASS_IS_IMPORT (mb->method->klass)) {
-			coop_cominterop_fnptr = mono_mb_add_local (mb, int_type);
-		}
-#endif
+	if (need_gc_safe) {
+	        gc_safe_transition_builder_add_locals (&gc_safe_transition_builder);
 	}
 
 	/*
@@ -1795,26 +1884,8 @@ emit_native_wrapper_ilgen (MonoImage *image, MonoMethodBuilder *mb, MonoMethodSi
 	}
 
 	// In coop mode need to register blocking state during native call
-	if (mono_threads_is_blocking_transition_enabled ()) {
-		// Perform an extra, early lookup of the function address, so any exceptions
-		// potentially resulting from the lookup occur before entering blocking mode.
-		if (!func_param && !MONO_CLASS_IS_IMPORT (mb->method->klass) && aot) {
-			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-			mono_mb_emit_op (mb, CEE_MONO_ICALL_ADDR, &piinfo->method);
-			mono_mb_emit_byte (mb, CEE_POP); // Result not needed yet
-		}
-
-#ifndef DISABLE_COM
-		if (!func_param && MONO_CLASS_IS_IMPORT (mb->method->klass)) {
-			mono_mb_emit_cominterop_get_function_pointer (mb, &piinfo->method);
-			mono_mb_emit_stloc (mb, coop_cominterop_fnptr);
-		}
-#endif
-
-		mono_mb_emit_ldloc_addr (mb, coop_gc_stack_dummy);
-		mono_mb_emit_icall (mb, mono_threads_enter_gc_safe_region_unbalanced);
-		mono_mb_emit_stloc (mb, coop_gc_var);
-	}
+	if (need_gc_safe)
+		gc_safe_transition_builder_emit_enter (&gc_safe_transition_builder, &piinfo->method, aot);
 
 	/* push all arguments */
 
@@ -1836,7 +1907,7 @@ emit_native_wrapper_ilgen (MonoImage *image, MonoMethodBuilder *mb, MonoMethodSi
 		if (!mono_threads_is_blocking_transition_enabled ()) {
 			mono_mb_emit_cominterop_call (mb, csig, &piinfo->method);
 		} else {
-			mono_mb_emit_ldloc (mb, coop_cominterop_fnptr);
+			mono_mb_emit_ldloc (mb, gc_safe_transition_builder.coop_cominterop_fnptr);
 			mono_mb_emit_cominterop_call_function_pointer (mb, csig);
 		}
 #else
@@ -1892,11 +1963,10 @@ emit_native_wrapper_ilgen (MonoImage *image, MonoMethodBuilder *mb, MonoMethodSi
 	}
 
 	/* Unblock before converting the result, since that can involve calls into the runtime */
-	if (mono_threads_is_blocking_transition_enabled ()) {
-		mono_mb_emit_ldloc (mb, coop_gc_var);
-		mono_mb_emit_ldloc_addr (mb, coop_gc_stack_dummy);
-		mono_mb_emit_icall (mb, mono_threads_exit_gc_safe_region_unbalanced);
-	}
+	if (need_gc_safe)
+		gc_safe_transition_builder_emit_exit (&gc_safe_transition_builder);
+
+	gc_safe_transition_builder_cleanup (&gc_safe_transition_builder);
 
 	/* convert the result */
 	if (!sig->ret->byref) {

--- a/mono/metadata/sgen-toggleref.c
+++ b/mono/metadata/sgen-toggleref.c
@@ -169,6 +169,8 @@ mono_gc_toggleref_add (MonoObject *object, mono_bool strong_ref)
 	if (!toggleref_callback)
 		return;
 
+	MONO_ENTER_GC_UNSAFE;
+
 	SGEN_LOG (4, "Adding toggleref %p %d", object, strong_ref);
 
 	sgen_gc_lock ();
@@ -179,6 +181,8 @@ mono_gc_toggleref_add (MonoObject *object, mono_bool strong_ref)
 	++toggleref_array_size;
 
 	sgen_gc_unlock ();
+
+	MONO_EXIT_GC_UNSAFE;
 }
 
 /**

--- a/mono/metadata/sgen-toggleref.h
+++ b/mono/metadata/sgen-toggleref.h
@@ -26,7 +26,7 @@ typedef enum {
 } MonoToggleRefStatus;
 
 MONO_API void mono_gc_toggleref_register_callback (MonoToggleRefStatus (*proccess_toggleref) (MonoObject *obj));
-MONO_API void mono_gc_toggleref_add (MonoObject *object, mono_bool strong_ref);
+MONO_API MONO_RT_EXTERNAL_ONLY void mono_gc_toggleref_add (MonoObject *object, mono_bool strong_ref);
 
 MONO_END_DECLS
 

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -2756,6 +2756,8 @@ mono_w32file_get_std_handle (gint stdhandle)
 static gboolean
 mono_w32file_read_or_write (gboolean read, gpointer handle, gpointer buffer, guint32 numbytes, guint32 *bytesread, gint32 *win32error)
 {
+	MONO_REQ_GC_UNSAFE_MODE;
+
 	FileHandle *filehandle;
 	gboolean ret = FALSE;
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -32,7 +32,6 @@
 #include <mono/metadata/assembly.h>
 #include <mono/metadata/assembly-internals.h>
 #include <mono/metadata/loader.h>
-#include <mono/metadata/loader-internals.h>
 #include <mono/metadata/tabledefs.h>
 #include <mono/metadata/class.h>
 #include <mono/metadata/object.h>

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -52,6 +52,7 @@
 #include <mono/metadata/runtime.h>
 #include <mono/metadata/reflection-internals.h>
 #include <mono/metadata/monitor.h>
+#include <mono/metadata/icall-internals.h>
 #define MONO_MATH_DECLARE_ALL 1
 #include <mono/utils/mono-math.h>
 #include <mono/utils/mono-compiler.h>
@@ -4564,17 +4565,17 @@ mono_fmod (double a, double b)
 static void
 register_icalls (void)
 {
-	mono_add_internal_call ("System.Diagnostics.StackFrame::get_frame_info",
+	mono_add_internal_call_internal ("System.Diagnostics.StackFrame::get_frame_info",
 				ves_icall_get_frame_info);
-	mono_add_internal_call ("System.Diagnostics.StackTrace::get_trace",
+	mono_add_internal_call_internal ("System.Diagnostics.StackTrace::get_trace",
 				ves_icall_get_trace);
-	mono_add_internal_call ("Mono.Runtime::mono_runtime_install_handlers",
+	mono_add_internal_call_internal ("Mono.Runtime::mono_runtime_install_handlers",
 				mono_runtime_install_handlers);
-	mono_add_internal_call ("Mono.Runtime::mono_runtime_cleanup_handlers",
+	mono_add_internal_call_internal ("Mono.Runtime::mono_runtime_cleanup_handlers",
 				mono_runtime_cleanup_handlers);
 
 #if defined(HOST_ANDROID) || defined(TARGET_ANDROID)
-	mono_add_internal_call ("System.Diagnostics.Debugger::Mono_UnhandledException_internal",
+	mono_add_internal_call_internal ("System.Diagnostics.Debugger::Mono_UnhandledException_internal",
 							mini_get_dbg_callbacks ()->unhandled_exception);
 #endif
 

--- a/mono/mini/mini-wasm.c
+++ b/mono/mini/mini-wasm.c
@@ -571,7 +571,7 @@ mono_wasm_set_timeout (int timeout, int id)
 void
 mono_arch_register_icall (void)
 {
-	mono_add_internal_call ("System.Threading.WasmRuntime::SetTimeout", mono_wasm_set_timeout);
+	mono_add_internal_call_internal ("System.Threading.WasmRuntime::SetTimeout", mono_wasm_set_timeout);
 }
 
 void

--- a/mono/mini/tasklets.c
+++ b/mono/mini/tasklets.c
@@ -6,6 +6,7 @@
 #include "tasklets.h"
 #include "mono/metadata/exception.h"
 #include "mono/metadata/gc-internals.h"
+#include "mono/metadata/icall-internals.h"
 #include "mini.h"
 #include "mini-runtime.h"
 #include "mono/metadata/loader-internals.h"
@@ -146,11 +147,11 @@ mono_tasklets_init (void)
 {
 	mono_os_mutex_init_recursive (&tasklets_mutex);
 
-	mono_add_internal_call ("Mono.Tasklets.Continuation::alloc", continuation_alloc);
-	mono_add_internal_call ("Mono.Tasklets.Continuation::free", continuation_free);
-	mono_add_internal_call ("Mono.Tasklets.Continuation::mark", continuation_mark_frame);
-	mono_add_internal_call ("Mono.Tasklets.Continuation::store", continuation_store);
-	mono_add_internal_call ("Mono.Tasklets.Continuation::restore", continuation_restore);
+	mono_add_internal_call_internal ("Mono.Tasklets.Continuation::alloc", continuation_alloc);
+	mono_add_internal_call_internal ("Mono.Tasklets.Continuation::free", continuation_free);
+	mono_add_internal_call_internal ("Mono.Tasklets.Continuation::mark", continuation_mark_frame);
+	mono_add_internal_call_internal ("Mono.Tasklets.Continuation::store", continuation_store);
+	mono_add_internal_call_internal ("Mono.Tasklets.Continuation::restore", continuation_restore);
 }
 
 void
@@ -204,11 +205,11 @@ continuation_restore (MonoContinuation *cont, int state)
 void
 mono_tasklets_init(void)
 {
-	mono_add_internal_call ("Mono.Tasklets.Continuation::alloc", continuation_alloc);
-	mono_add_internal_call ("Mono.Tasklets.Continuation::free", continuation_free);
-	mono_add_internal_call ("Mono.Tasklets.Continuation::mark", continuation_mark_frame);
-	mono_add_internal_call ("Mono.Tasklets.Continuation::store", continuation_store);
-	mono_add_internal_call ("Mono.Tasklets.Continuation::restore", continuation_restore);
+	mono_add_internal_call_internal ("Mono.Tasklets.Continuation::alloc", continuation_alloc);
+	mono_add_internal_call_internal ("Mono.Tasklets.Continuation::free", continuation_free);
+	mono_add_internal_call_internal ("Mono.Tasklets.Continuation::mark", continuation_mark_frame);
+	mono_add_internal_call_internal ("Mono.Tasklets.Continuation::store", continuation_store);
+	mono_add_internal_call_internal ("Mono.Tasklets.Continuation::restore", continuation_restore);
 
 }
 #endif

--- a/mono/native/pal-icalls.c
+++ b/mono/native/pal-icalls.c
@@ -12,8 +12,10 @@
 #include <glib.h>
 #include "mono/utils/mono-threads-api.h"
 #include "mono/utils/atomic.h"
-#include "metadata/loader-internals.h"
+#include "mono/metadata/loader-internals.h"
+#include "mono/metadata/icall-internals.h"
 #include "pal-icalls.h"
+
 
 /*
  * mono_pal_init:
@@ -28,10 +30,10 @@ mono_pal_init (void)
 {
 	volatile static gboolean module_initialized = FALSE;
 	if (mono_atomic_cas_i32 (&module_initialized, TRUE, FALSE) == FALSE) {
-		mono_add_internal_call ("Interop/Sys::Read", ves_icall_Interop_Sys_Read);
+		mono_add_internal_call_with_flags ("Interop/Sys::Read", ves_icall_Interop_Sys_Read, TRUE);
 
 #if defined(__APPLE__)
-		mono_add_internal_call ("Interop/RunLoop::CFRunLoopRun", ves_icall_Interop_RunLoop_CFRunLoopRun);
+		mono_add_internal_call_with_flags ("Interop/RunLoop::CFRunLoopRun", ves_icall_Interop_RunLoop_CFRunLoopRun, TRUE);
 #endif
 	}
 

--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -15,6 +15,7 @@
 #include <mono/metadata/assembly-internals.h>
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/debug-helpers.h>
+#include <mono/metadata/icall-internals.h>
 #include <mono/metadata/loader.h>
 #include <mono/metadata/loader-internals.h>
 #include <mono/metadata/metadata-internals.h>
@@ -3967,7 +3968,7 @@ runtime_initialized (MonoProfiler *profiler)
 	mono_coop_mutex_init (&log_profiler.api_mutex);
 
 #define ADD_ICALL(NAME) \
-	mono_add_internal_call ("Mono.Profiler.Log.LogProfiler::" EGLIB_STRINGIFY (NAME), proflog_icall_ ## NAME);
+	mono_add_internal_call_internal ("Mono.Profiler.Log.LogProfiler::" EGLIB_STRINGIFY (NAME), proflog_icall_ ## NAME);
 
 	ADD_ICALL (GetMaxStackTraceFrames);
 	ADD_ICALL (GetStackTraceFrames);


### PR DESCRIPTION
* Mark `mono_add_internal_call` external only.  Add `mono_add_internal_call_internal` and `mono_add_internal_call_with_flags` for the runtime.
   - icalls added using the external-only API are "foreign".
 
* Add coop transitions around `mono_gc_toggleref_add` (and mark it external only  - it's unused in the runtime).
* Change icall wrappers to call foreign icalls in GC Safe mode.
   - foreign icalls are not coop-aware, so if they perform a blocking operation under hybrid suspend they will hang indefinitely - this is bug #11138. With this change, we run them in GC Safe mode and rely on the runtime API to transition back to GC Unsafe (same as other embedder code).
   - this will require changes to watchOS support in xamarin-macios.

----

This is the `master` version.  `2018-08` backport is #11180 