### PR TITLE
[mcs] Fix platform-specific build of "build" profile and remove more remnants of the "basic" profile

### DIFF
--- a/mcs/Makefile
+++ b/mcs/Makefile
@@ -35,7 +35,7 @@ all-local $(STD_TARGETS:=-local):
 	@:
 
 dir-check:
-	@if [ "$(NO_DIR_CHECK)" = "" -a "$(PROFILE)" != "basic" ]; then $(MAKE) -C ../runtime; fi
+	@if [ "$(NO_DIR_CHECK)" = "" ]; then $(MAKE) -C ../runtime; fi
 
 # fun specialty targets
 

--- a/mcs/build/Makefile
+++ b/mcs/build/Makefile
@@ -29,7 +29,6 @@ common/MonoNativeConfig.cs: common/MonoNativeConfig.cs.in $(wildcard config.make
 
 PLATFORMS = macos linux win32 unix
 PROFILES = \
-	basic \
 	build \
 	binary_reference_assemblies \
 	net_4_x \
@@ -52,7 +51,6 @@ DISTFILES = \
 	corcompare.make			\
 	corcompare-api.xsl		\
 	executable.make			\
-	gensources.cs			\
 	library.make			\
 	rules.make			\
 	tests.make			\

--- a/mcs/build/Makefile
+++ b/mcs/build/Makefile
@@ -37,6 +37,7 @@ PROFILES = \
 
 COMMON_SRCS = \
 	Consts.cs.in			\
+	MonoNativeConfig.cs.in	\
 	Locale.cs			\
 	MonoTODOAttribute.cs \
 	basic-profile-check.cs		\

--- a/mcs/build/library.make
+++ b/mcs/build/library.make
@@ -60,10 +60,8 @@ endif
 the_libdir_base = $(topdir)/class/$(lib_dir)/$(PROFILE_DIRECTORY)/$(if $(LIBRARY_SUBDIR),$(LIBRARY_SUBDIR)/)
 
 ifdef RESOURCE_STRINGS
-ifneq (basic, $(PROFILE))
 RESOURCE_STRINGS_FILES += $(RESOURCE_STRINGS:%=--resourcestrings:%)
 IL_REPLACE_FILES += $(IL_REPLACE:%=--ilreplace:%)
-endif
 endif
 
 ifdef ENFORCE_LIBRARY_WARN_AS_ERROR

--- a/mcs/build/profiles/build.make
+++ b/mcs/build/profiles/build.make
@@ -36,6 +36,8 @@ GENSOURCES =$(PROFILE_RUNTIME) $(RUNTIME_FLAGS) $(topdir)/class/lib/$(BUILD_TOOL
 
 MCS = $(BOOTSTRAP_MCS)
 
+PLATFORMS = macos linux win32 unix
+
 DEFAULT_REFERENCES = mscorlib
 
 PROFILE_MCS_FLAGS = -d:NET_4_0 -d:NET_4_5 -d:MONO -d:WIN_PLATFORM -d:BOOTSTRAP_BASIC -nowarn:1699 -nostdlib

--- a/mcs/build/rules.make
+++ b/mcs/build/rules.make
@@ -27,11 +27,7 @@ Q_MCS=$(if $(V),,@echo "$(if $(MCS_MODE),MCS,CSC)     [$(intermediate)$(PROFILE_
 Q_AOT=$(if $(V),,@echo "AOT     [$(intermediate)$(PROFILE_DIRECTORY)] $(notdir $(@))";)
 
 ifndef BUILD_TOOLS_PROFILE
-ifeq ($(PROFILE),basic)
-BUILD_TOOLS_PROFILE = basic
-else
 BUILD_TOOLS_PROFILE = build
-endif
 endif
 
 USE_MCS_FLAGS = /codepage:$(CODEPAGE) /nologo /noconfig /deterministic $(LOCAL_MCS_FLAGS) $(PLATFORM_MCS_FLAGS) $(PROFILE_MCS_FLAGS) $(MCS_FLAGS)

--- a/mcs/class/Facades/subdirs.make
+++ b/mcs/class/Facades/subdirs.make
@@ -45,15 +45,13 @@ monodroid_PARALLEL_SUBDIRS = $(common_SUBDIRS) $(mobile_only_SUBDIRS)
 net_4_x_SUBDIRS = $(common_DEPS_SUBDIRS)
 net_4_x_PARALLEL_SUBDIRS = $(common_SUBDIRS) System.Net.Http.Rtc
 
-basic_PARALLEL_SUBDIRS = System.Runtime System.Reflection System.Collections System.Resources.ResourceManager System.Globalization \
+build_PARALLEL_SUBDIRS = System.Runtime System.Reflection System.Collections System.Resources.ResourceManager System.Globalization \
 System.Threading.Tasks System.Collections.Concurrent System.Text.Encoding System.IO System.Threading System.Diagnostics.Debug \
 System.Linq.Expressions System.Dynamic.Runtime System.Linq System.Threading.Tasks.Parallel System.Xml.ReaderWriter \
 System.Diagnostics.Tools System.Reflection.Primitives System.Runtime.Extensions System.Runtime.InteropServices System.Text.Encoding.Extensions \
 System.Runtime.Numerics System.Xml.XDocument System.Reflection.Extensions System.IO.FileSystem.Primitives System.IO.FileSystem \
 System.Diagnostics.FileVersionInfo System.Security.Cryptography.Primitives System.Security.Cryptography.Algorithms System.ValueTuple \
-System.Text.Encoding.CodePages
-
-build_PARALLEL_SUBDIRS = $(basic_PARALLEL_SUBDIRS) System.Text.RegularExpressions System.Diagnostics.Contracts
+System.Text.Encoding.CodePages System.Text.RegularExpressions System.Diagnostics.Contracts
 
 xammac_SUBDIRS = $(monotouch_SUBDIRS)
 xammac_PARALLEL_SUBDIRS = $(monotouch_PARALLEL_SUBDIRS)

--- a/mcs/class/Makefile
+++ b/mcs/class/Makefile
@@ -38,7 +38,6 @@ build_PARALLEL_SUBDIRS = \
 	System.Drawing
 
 ifdef MCS_MODE
-basic_PARALLEL_SUBDIRS := ../mcs
 
 build_SUBDIRS += \
 	Mono.Security \

--- a/mcs/class/Mono.CompilerServices.SymbolWriter/Makefile
+++ b/mcs/class/Mono.CompilerServices.SymbolWriter/Makefile
@@ -9,12 +9,6 @@ LIB_MCS_FLAGS =
 
 NO_TEST = yes
 
-ifneq (basic, $(PROFILE))
-USE_BOOT_COMPILE = yes
-endif
-
-ifdef USE_BOOT_COMPILE
 LIBRARY_COMPILE = $(BOOT_COMPILE)
-endif
 
 include ../../build/library.make

--- a/mcs/class/System.Core/basic_System.Core.dll.sources
+++ b/mcs/class/System.Core/basic_System.Core.dll.sources
@@ -1,2 +1,0 @@
-#include net_4_x_System.Core.dll.sources
-#include pipes_pns.sources

--- a/mcs/class/System/basic_System.dll.sources
+++ b/mcs/class/System/basic_System.dll.sources
@@ -1,4 +1,0 @@
-#include net_4_x_System.dll.sources
-../../../external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.UnknownUnix.cs
-../../../external/corefx/src/Common/src/System/Net/ContextAwareResult.Unix.cs
-Internal.Cryptography/OidLookup.Managed.cs

--- a/mcs/class/corlib/Makefile
+++ b/mcs/class/corlib/Makefile
@@ -66,12 +66,8 @@ include il/il.make
 
 RESOURCE_STRINGS_FILES = --mscorlib-debug
 
-ifneq ($(PROFILE),basic)
 RESOURCE_STRINGS = ../referencesource/mscorlib/mscorlib.txt
-MODULE_DEPS = $(IL_REPLACE)
-endif
-
-MODULE_DEPS += LinkerDescriptor/mscorlib.xml
+MODULE_DEPS = $(IL_REPLACE) LinkerDescriptor/mscorlib.xml
 
 RESOURCE_FILES = \
 	resources/charinfo.nlp \


### PR DESCRIPTION
The platform specific build got lost in 8d8fd97dbfc6f4213e0fe9fca7574808dd8496d3 but we need it for monolite. The remnants of the "basic" profile are no longer needed.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
