### PR TITLE
[coop] Transition all functions in object.h to MONO_RT_EXTERNAL_ONLY

### DIFF
--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -213,7 +213,7 @@ common_sources = \
 	exception.c		\
 	exception.h		\
 	exception-internals.h	\
-	external-only.c		\
+	external-only.h		\
 	w32file.c		\
 	w32file.h		\
 	w32file-internals.h \

--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -213,6 +213,7 @@ common_sources = \
 	exception.c		\
 	exception.h		\
 	exception-internals.h	\
+	external-only.c		\
 	external-only.h		\
 	w32file.c		\
 	w32file.h		\

--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -213,7 +213,6 @@ common_sources = \
 	exception.c		\
 	exception.h		\
 	exception-internals.h	\
-	external-only.c		\
 	external-only.h		\
 	w32file.c		\
 	w32file.h		\

--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -421,4 +421,5 @@ libmonoruntimeinclude_HEADERS = \
 	verify.h		
 
 EXTRA_DIST = $(win32_sources) $(unix_sources) $(null_sources) runtime.h \
+		external-only.c \
 		threadpool-io-poll.c threadpool-io-epoll.c threadpool-io-kqueue.c sgen-dynarray.h

--- a/mono/metadata/attach.c
+++ b/mono/metadata/attach.c
@@ -320,7 +320,7 @@ mono_attach_load_agent (MonoDomain *domain, char *agent, char *args, MonoObject 
 			g_free (agent);
 			return 1;
 		}
-		mono_array_set (main_args, MonoString*, 0, args_str);
+		mono_array_set_internal (main_args, MonoString*, 0, args_str);
 	}
 
 

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -994,7 +994,7 @@ mono_class_inflate_generic_method_full_checked (MonoMethod *method, MonoClass *k
 		if (mono_class_is_gtd (iresult->declaring->klass))
 			iresult->context.class_inst = mono_class_get_generic_container (iresult->declaring->klass)->context.class_inst;
 	}
-	/* This can happen with some callers like mono_object_get_virtual_method () */
+	/* This can happen with some callers like mono_object_get_virtual_method_internal () */
 	if (!mono_class_is_gtd (iresult->declaring->klass) && !mono_class_is_ginst (iresult->declaring->klass))
 		iresult->context.class_inst = NULL;
 
@@ -3748,7 +3748,7 @@ mono_class_implement_interface_slow (MonoClass *target, MonoClass *candidate)
 			int j;
 			if (tb && tb->interfaces) {
 				for (j = mono_array_length_internal (tb->interfaces) - 1; j >= 0; --j) {
-					MonoReflectionType *iface = mono_array_get (tb->interfaces, MonoReflectionType*, j);
+					MonoReflectionType *iface = mono_array_get_internal (tb->interfaces, MonoReflectionType*, j);
 					MonoClass *iface_class;
 
 					/* we can't realize the type here since it can do pretty much anything. */

--- a/mono/metadata/console-unix.c
+++ b/mono/metadata/console-unix.c
@@ -481,7 +481,7 @@ ves_icall_System_ConsoleDriver_TtySetup (MonoStringHandle keypad, MonoStringHand
 
 	uint32_t h;
 	set_control_chars (MONO_ARRAY_HANDLE_PIN (control_chars_arr, gchar, 0, &h), mono_attr.c_cc);
-	mono_gchandle_free (h);
+	mono_gchandle_free_internal (h);
 	/* If initialized from another appdomain... */
 	if (setup_finished)
 		return TRUE;

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -1008,7 +1008,7 @@ mono_object_describe (MonoObject *obj)
 	}
 	klass = mono_object_class (obj);
 	if (klass == mono_defaults.string_class) {
-		char *utf8 = mono_string_to_utf8_checked ((MonoString*)obj, error);
+		char *utf8 = mono_string_to_utf8_checked_internal ((MonoString*)obj, error);
 		mono_error_cleanup (error); /* FIXME don't swallow the error */
 		if (utf8 && strlen (utf8) > 60) {
 			utf8 [57] = '.';
@@ -1017,9 +1017,9 @@ mono_object_describe (MonoObject *obj)
 			utf8 [60] = 0;
 		}
 		if (utf8) {
-			g_print ("String at %p, length: %d, '%s'\n", obj, mono_string_length ((MonoString*) obj), utf8);
+			g_print ("String at %p, length: %d, '%s'\n", obj, mono_string_length_internal ((MonoString*) obj), utf8);
 		} else {
-			g_print ("String at %p, length: %d, unable to decode UTF16\n", obj, mono_string_length ((MonoString*) obj));
+			g_print ("String at %p, length: %d, unable to decode UTF16\n", obj, mono_string_length_internal ((MonoString*) obj));
 		}
 		g_free (utf8);
 	} else if (klass->rank) {

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -227,15 +227,6 @@ mono_install_free_domain_hook (MonoFreeDomainFunc func)
 	free_domain_hook = func;
 }
 
-/**
- * mono_string_equal:
- * \param s1 First string to compare
- * \param s2 Second string to compare
- *
- * Compares two \c MonoString* instances ordinally for equality.
- *
- * \returns FALSE if the strings differ.
- */
 gboolean
 mono_string_equal_internal (MonoString *s1, MonoString *s2)
 {
@@ -250,19 +241,21 @@ mono_string_equal_internal (MonoString *s1, MonoString *s2)
 	return memcmp (mono_string_chars_internal (s1), mono_string_chars_internal (s2), l1 * 2) == 0;
 }
 
+/**
+ * mono_string_equal:
+ * \param s1 First string to compare
+ * \param s2 Second string to compare
+ *
+ * Compares two \c MonoString* instances ordinally for equality.
+ *
+ * \returns FALSE if the strings differ.
+ */
 gboolean
 mono_string_equal (MonoString *s1, MonoString *s2)
 {
 	MONO_EXTERNAL_ONLY (gboolean, mono_string_equal_internal (s1, s2));
 }
 
-/**
- * mono_string_hash:
- * \param s the string to hash
- *
- * Compute the hash for a \c MonoString*
- * \returns the hash for the string.
- */
 guint
 mono_string_hash_internal (MonoString *s)
 {
@@ -278,6 +271,13 @@ mono_string_hash_internal (MonoString *s)
 	return h;	
 }
 
+/**
+ * mono_string_hash:
+ * \param s the string to hash
+ *
+ * Compute the hash for a \c MonoString*
+ * \returns the hash for the string.
+ */
 guint
 mono_string_hash (MonoString *s)
 {

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -50,6 +50,7 @@
 #include <mono/metadata/profiler-private.h>
 #include <mono/metadata/coree.h>
 #include <mono/utils/mono-experiments.h>
+#include "external-only.h"
 
 //#define DEBUG_DOMAIN_UNLOAD 1
 
@@ -63,7 +64,7 @@
 } while (FALSE)
 
 #define GET_APPCONTEXT() (mono_thread_internal_current ()->current_appcontext)
-#define SET_APPCONTEXT(x) MONO_OBJECT_SETREF (mono_thread_internal_current (), current_appcontext, (x))
+#define SET_APPCONTEXT(x) MONO_OBJECT_SETREF_INTERNAL (mono_thread_internal_current (), current_appcontext, (x))
 
 static guint16 appdomain_list_size = 0;
 static guint16 appdomain_next = 0;
@@ -236,17 +237,23 @@ mono_install_free_domain_hook (MonoFreeDomainFunc func)
  * \returns FALSE if the strings differ.
  */
 gboolean
-mono_string_equal (MonoString *s1, MonoString *s2)
+mono_string_equal_internal (MonoString *s1, MonoString *s2)
 {
-	int l1 = mono_string_length (s1);
-	int l2 = mono_string_length (s2);
+	int l1 = mono_string_length_internal (s1);
+	int l2 = mono_string_length_internal (s2);
 
 	if (s1 == s2)
 		return TRUE;
 	if (l1 != l2)
 		return FALSE;
 
-	return memcmp (mono_string_chars (s1), mono_string_chars (s2), l1 * 2) == 0; 
+	return memcmp (mono_string_chars_internal (s1), mono_string_chars_internal (s2), l1 * 2) == 0;
+}
+
+gboolean
+mono_string_equal (MonoString *s1, MonoString *s2)
+{
+	MONO_EXTERNAL_ONLY (gboolean, mono_string_equal_internal (s1, s2));
 }
 
 /**
@@ -257,10 +264,10 @@ mono_string_equal (MonoString *s1, MonoString *s2)
  * \returns the hash for the string.
  */
 guint
-mono_string_hash (MonoString *s)
+mono_string_hash_internal (MonoString *s)
 {
-	const gunichar2 *p = mono_string_chars (s);
-	int i, len = mono_string_length (s);
+	const gunichar2 *p = mono_string_chars_internal (s);
+	int i, len = mono_string_length_internal (s);
 	guint h = 0;
 
 	for (i = 0; i < len; i++) {
@@ -269,6 +276,12 @@ mono_string_hash (MonoString *s)
 	}
 
 	return h;	
+}
+
+guint
+mono_string_hash (MonoString *s)
+{
+	MONO_EXTERNAL_ONLY (guint, mono_string_hash_internal (s));
 }
 
 static gboolean
@@ -423,14 +436,14 @@ mono_domain_create (void)
 	domain->mp = mono_mempool_new ();
 	domain->code_mp = mono_code_manager_new ();
 	domain->lock_free_mp = lock_free_mempool_new ();
-	domain->env = mono_g_hash_table_new_type ((GHashFunc)mono_string_hash, (GCompareFunc)mono_string_equal, MONO_HASH_KEY_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Environment Variable Table");
+	domain->env = mono_g_hash_table_new_type ((GHashFunc)mono_string_hash_internal, (GCompareFunc)mono_string_equal_internal, MONO_HASH_KEY_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Environment Variable Table");
 	domain->domain_assemblies = NULL;
 	domain->assembly_bindings = NULL;
 	domain->assembly_bindings_parsed = FALSE;
 	domain->class_vtable_array = g_ptr_array_new ();
 	domain->proxy_vtable_hash = g_hash_table_new ((GHashFunc)mono_ptrarray_hash, (GCompareFunc)mono_ptrarray_equal);
 	mono_jit_code_hash_init (&domain->jit_code_hash);
-	domain->ldstr_table = mono_g_hash_table_new_type ((GHashFunc)mono_string_hash, (GCompareFunc)mono_string_equal, MONO_HASH_KEY_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain String Pool Table");
+	domain->ldstr_table = mono_g_hash_table_new_type ((GHashFunc)mono_string_hash_internal, (GCompareFunc)mono_string_equal_internal, MONO_HASH_KEY_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain String Pool Table");
 	domain->num_jit_info_table_duplicates = 0;
 	domain->jit_info_table = mono_jit_info_table_new (domain);
 	domain->jit_info_free_queue = NULL;
@@ -923,7 +936,7 @@ mono_domain_set_internal_with_options (MonoDomain *domain, gboolean migrate_exce
 			return;
 
 		g_assert (thread->abort_exc->object.vtable->domain != domain);
-		MONO_OBJECT_SETREF (thread, abort_exc, mono_get_exception_thread_abort ());
+		MONO_OBJECT_SETREF_INTERNAL (thread, abort_exc, mono_get_exception_thread_abort ());
 		g_assert (thread->abort_exc->object.vtable->domain == domain);
 	}
 }

--- a/mono/metadata/dynamic-image.c
+++ b/mono/metadata/dynamic-image.c
@@ -358,7 +358,7 @@ mono_dynamic_image_create (MonoDynamicAssembly *assembly, char *assembly_name, c
 
 	mono_image_init (&image->image);
 
-	image->token_fixups = mono_g_hash_table_new_type ((GHashFunc)mono_object_hash, NULL, MONO_HASH_KEY_GC, MONO_ROOT_SOURCE_REFLECTION, NULL, "Reflection Dynamic Image Token Fixup Table");
+	image->token_fixups = mono_g_hash_table_new_type ((GHashFunc)mono_object_hash_internal, NULL, MONO_HASH_KEY_GC, MONO_ROOT_SOURCE_REFLECTION, NULL, "Reflection Dynamic Image Token Fixup Table");
 	image->method_to_table_idx = g_hash_table_new (NULL, NULL);
 	image->field_to_table_idx = g_hash_table_new (NULL, NULL);
 	image->method_aux_hash = g_hash_table_new (NULL, NULL);

--- a/mono/metadata/dynamic-stream.c
+++ b/mono/metadata/dynamic-stream.c
@@ -13,6 +13,7 @@
 #include "mono/metadata/metadata-internals.h"
 #include "mono/utils/checked-build.h"
 #include "mono/utils/mono-error-internals.h"
+#include "object-internals.h"
 
 void
 mono_dynstream_init (MonoDynamicStream *sh)
@@ -78,7 +79,7 @@ mono_dynstream_insert_mstring (MonoDynamicStream *sh, MonoString *str, MonoError
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	error_init (error);
-	char *name = mono_string_to_utf8_checked (str, error);
+	char *name = mono_string_to_utf8_checked_internal (str, error);
 	return_val_if_nok (error, -1);
 	guint32 idx;
 	idx = mono_dynstream_insert_string (sh, name);

--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -1150,7 +1150,7 @@ mono_exception_handle_get_native_backtrace (MonoExceptionHandle exc)
 	MONO_ENTER_GC_SAFE;
 	messages = backtrace_symbols (addr, len);
 	MONO_EXIT_GC_SAFE;
-	mono_gchandle_free (gchandle);
+	mono_gchandle_free_internal (gchandle);
 
 	for (i = 0; i < len; ++i) {
 		gpointer ip;
@@ -1253,7 +1253,7 @@ mono_invoke_unhandled_exception_hook (MonoObject *exc)
 		char *msg = NULL;
 		
 		if (str && is_ok (&inner_error)) {
-			msg = mono_string_to_utf8_checked (str, &inner_error);
+			msg = mono_string_to_utf8_checked_internal (str, &inner_error);
 			if (!is_ok (&inner_error)) {
 				msg = g_strdup_printf ("Nested exception while formatting original exception");
 				mono_error_cleanup (&inner_error);

--- a/mono/metadata/external-only.c
+++ b/mono/metadata/external-only.c
@@ -69,7 +69,7 @@ mono_gchandle_new_weakref (MonoObject *obj, mono_bool track_resurrection)
  * mono_gchandle_get_target:
  * \param gchandle a GCHandle's handle.
  *
- * The handle was previously created by calling \c mono_gchandle_new_internal or
+ * The handle was previously created by calling \c mono_gchandle_new or
  * \c mono_gchandle_new_weakref.
  *
  * \returns a pointer to the \c MonoObject* represented by the handle or

--- a/mono/metadata/external-only.c
+++ b/mono/metadata/external-only.c
@@ -6,18 +6,100 @@
  * Copyright 2018 Microsoft
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
+
+// FIXME In order to confirm this is all extern_only,
+// a variant of the runtime should be linked without it.
+
 #include "config.h"
 #include "class-internals.h"
 #include "object-internals.h"
+#include "class-init.h"
+#include "marshal.h"
+#include "object.h"
 
-/**
- * mono_array_length:
- * \param array a \c MonoArray*
- * \returns the total number of elements in the array. This works for
- * both vectors and multidimensional arrays.
+/* GC handles support
+ *
+ * A handle can be created to refer to a managed object and either prevent it
+ * from being garbage collected or moved or to be able to know if it has been
+ * collected or not (weak references).
+ * mono_gchandle_new () is used to prevent an object from being garbage collected
+ * until mono_gchandle_free() is called. Use a TRUE value for the pinned argument to
+ * prevent the object from being moved (this should be avoided as much as possible
+ * and this should be used only for shorts periods of time or performance will suffer).
+ * To create a weakref use mono_gchandle_new_weakref (): track_resurrection should
+ * usually be false (see the GC docs for more details).
+ * mono_gchandle_get_target () can be used to get the object referenced by both kinds
+ * of handle: for a weakref handle, if an object has been collected, it will return NULL.
  */
-uintptr_t
-mono_array_length (MonoArray *array)
+uint32_t
+mono_gchandle_new (MonoObject *obj, mono_bool pinned)
 {
-	return mono_array_length_internal (array);
+	MONO_EXTERNAL_ONLY (uint32_t, mono_gchandle_new_internal (obj, pinned));
+}
+
+uint32_t
+mono_gchandle_new_weakref (MonoObject *obj, mono_bool track_resurrection)
+{
+	MONO_EXTERNAL_ONLY (uint32_t, mono_gchandle_new_weakref_internal (obj, track_resurrection));
+}
+
+MonoObject*
+mono_gchandle_get_target (uint32_t gchandle)
+{
+	MONO_EXTERNAL_ONLY (MonoObject*, mono_gchandle_get_target_internal (gchandle));
+}
+
+void
+mono_gchandle_free (uint32_t gchandle)
+{
+	MONO_EXTERNAL_ONLY_VOID (mono_gchandle_free_internal (gchandle));
+}
+
+/* GC write barriers support */
+void
+mono_gc_wbarrier_set_field (MonoObject *obj, void* field_ptr, MonoObject* value)
+{
+	MONO_EXTERNAL_ONLY_VOID (mono_gc_wbarrier_set_field_internal (obj, field_ptr, value));
+}
+
+void
+mono_gc_wbarrier_set_arrayref (MonoArray *arr, void* slot_ptr, MonoObject* value)
+{
+	MONO_EXTERNAL_ONLY_VOID (mono_gc_wbarrier_set_arrayref_internal (arr, slot_ptr, value));
+}
+
+void
+mono_gc_wbarrier_arrayref_copy (void* dest_ptr, void* src_ptr, int count)
+{
+	MONO_EXTERNAL_ONLY_VOID (mono_gc_wbarrier_arrayref_copy_internal (dest_ptr, src_ptr, count));
+}
+
+void
+mono_gc_wbarrier_generic_store (void* ptr, MonoObject* value)
+{
+	MONO_EXTERNAL_ONLY_VOID (mono_gc_wbarrier_generic_store_internal (ptr, value));
+}
+
+void
+mono_gc_wbarrier_generic_store_atomic (void *ptr, MonoObject *value)
+{
+	MONO_EXTERNAL_ONLY_VOID (mono_gc_wbarrier_generic_store_atomic_internal (ptr, value));
+}
+
+void
+mono_gc_wbarrier_generic_nostore (void* ptr)
+{
+	MONO_EXTERNAL_ONLY_VOID (mono_gc_wbarrier_generic_nostore_internal (ptr));
+}
+
+void
+mono_gc_wbarrier_value_copy (void* dest, /*const*/ void* src, int count, MonoClass *klass)
+{
+	MONO_EXTERNAL_ONLY_VOID (mono_gc_wbarrier_value_copy_internal (dest, src, count, klass));
+}
+
+void
+mono_gc_wbarrier_object_copy (MonoObject* obj, MonoObject *src)
+{
+	MONO_EXTERNAL_ONLY_VOID (mono_gc_wbarrier_object_copy_internal (obj, src));
 }

--- a/mono/metadata/external-only.c
+++ b/mono/metadata/external-only.c
@@ -16,7 +16,6 @@
 #include "class-init.h"
 #include "marshal.h"
 #include "object.h"
-#include "external-only.h"
 
 /* GC handles support
  *

--- a/mono/metadata/external-only.c
+++ b/mono/metadata/external-only.c
@@ -96,12 +96,19 @@ mono_gchandle_free (uint32_t gchandle)
 }
 
 /* GC write barriers support */
+
+/**
+ * mono_gc_wbarrier_set_field:
+ */
 void
 mono_gc_wbarrier_set_field (MonoObject *obj, void* field_ptr, MonoObject* value)
 {
 	MONO_EXTERNAL_ONLY_VOID (mono_gc_wbarrier_set_field_internal (obj, field_ptr, value));
 }
 
+/**
+ * mono_gc_wbarrier_set_arrayref:
+ */
 void
 mono_gc_wbarrier_set_arrayref (MonoArray *arr, void* slot_ptr, MonoObject* value)
 {
@@ -114,12 +121,20 @@ mono_gc_wbarrier_arrayref_copy (void* dest_ptr, void* src_ptr, int count)
 	MONO_EXTERNAL_ONLY_VOID (mono_gc_wbarrier_arrayref_copy_internal (dest_ptr, src_ptr, count));
 }
 
+/**
+ * mono_gc_wbarrier_generic_store:
+ */
 void
 mono_gc_wbarrier_generic_store (void* ptr, MonoObject* value)
 {
 	MONO_EXTERNAL_ONLY_VOID (mono_gc_wbarrier_generic_store_internal (ptr, value));
 }
 
+/**
+ * mono_gc_wbarrier_generic_store_atomic_internal:
+ * Same as \c mono_gc_wbarrier_generic_store but performs the store
+ * as an atomic operation with release semantics.
+ */
 void
 mono_gc_wbarrier_generic_store_atomic (void *ptr, MonoObject *value)
 {
@@ -138,6 +153,11 @@ mono_gc_wbarrier_value_copy (void* dest, /*const*/ void* src, int count, MonoCla
 	MONO_EXTERNAL_ONLY_VOID (mono_gc_wbarrier_value_copy_internal (dest, src, count, klass));
 }
 
+/**
+ * mono_gc_wbarrier_object_copy:
+ *
+ * Write barrier to call when \p obj is the result of a clone or copy of an object.
+ */
 void
 mono_gc_wbarrier_object_copy (MonoObject* obj, MonoObject *src)
 {

--- a/mono/metadata/external-only.c
+++ b/mono/metadata/external-only.c
@@ -16,6 +16,7 @@
 #include "class-init.h"
 #include "marshal.h"
 #include "object.h"
+#include "external-only.h"
 
 /* GC handles support
  *

--- a/mono/metadata/external-only.h
+++ b/mono/metadata/external-only.h
@@ -6,7 +6,7 @@
  * Author:
  *   Jay Krell (jaykrell@microsoft.com)
  *
- * Copyright 2016 Microsoft
+ * Copyright 2018 Microsoft
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
 

--- a/mono/metadata/external-only.h
+++ b/mono/metadata/external-only.h
@@ -1,0 +1,30 @@
+/**
+ * \file
+ *   Shorthand and markers for functions only used by embedders.
+ * MONO_ENTER_GC_UNSAFE is also a good indication of external_only.
+ *
+ * Author:
+ *   Jay Krell (jaykrell@microsoft.com)
+ *
+ * Copyright 2016 Microsoft
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+#ifndef MONO_EXTERNAL_ONLY
+
+#define MONO_EXTERNAL_ONLY_GC_UNSAFE(t, expr) \
+	t result; 		\
+	MONO_ENTER_GC_UNSAFE; 	\
+	result = expr;		\
+	MONO_EXIT_GC_UNSAFE;	\
+	return result;
+
+#define MONO_EXTERNAL_ONLY_GC_UNSAFE_VOID(expr) \
+	MONO_ENTER_GC_UNSAFE; 	\
+	expr;			\
+	MONO_EXIT_GC_UNSAFE;	\
+
+#define MONO_EXTERNAL_ONLY(t, expr) return expr;
+#define MONO_EXTERNAL_ONLY_VOID(expr) expr;
+
+#endif /* MONO_EXTERNAL_ONLY */

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -346,14 +346,14 @@ This is why we evaluate index and value before any call to MONO_HANDLE_RAW or ot
 #define MONO_HANDLE_SETRAW(HANDLE, FIELD, VALUE) do {			\
 		MONO_HANDLE_SUPPRESS_SCOPE(1);				\
 		MonoObject *__val = MONO_HANDLE_SUPPRESS ((MonoObject*)(MONO_HANDLE_UNSUPPRESS (VALUE))); \
-		MONO_OBJECT_SETREF (MONO_HANDLE_RAW (MONO_HANDLE_UNSUPPRESS (HANDLE)), FIELD, __val); \
+		MONO_OBJECT_SETREF_INTERNAL (MONO_HANDLE_RAW (MONO_HANDLE_UNSUPPRESS (HANDLE)), FIELD, __val); \
 	} while (0)
 
 #define MONO_HANDLE_SET(HANDLE, FIELD, VALUE) do {			\
 		MonoObjectHandle __val = MONO_HANDLE_CAST (MonoObject, VALUE);	\
 		do {							\
 			MONO_HANDLE_SUPPRESS_SCOPE(1);			\
-			MONO_OBJECT_SETREF (MONO_HANDLE_RAW (MONO_HANDLE_UNSUPPRESS (HANDLE)), FIELD, MONO_HANDLE_RAW (__val)); \
+			MONO_OBJECT_SETREF_INTERNAL (MONO_HANDLE_RAW (MONO_HANDLE_UNSUPPRESS (HANDLE)), FIELD, MONO_HANDLE_RAW (__val)); \
 		} while (0);						\
 	} while (0)
 
@@ -397,7 +397,7 @@ This is why we evaluate index and value before any call to MONO_HANDLE_RAW or ot
 		{	/* FIXME scope needed by Centrinel */		\
 			/* FIXME mono_array_set is not an expression. */ \
 			MONO_HANDLE_SUPPRESS_SCOPE(1);			\
-			mono_array_set (MONO_HANDLE_RAW (MONO_HANDLE_UNSUPPRESS (HANDLE)), TYPE, __idx, __val); \
+			mono_array_set_internal (MONO_HANDLE_RAW (MONO_HANDLE_UNSUPPRESS (HANDLE)), TYPE, __idx, __val); \
 		}							\
 	} while (0)
 
@@ -412,7 +412,7 @@ This is why we evaluate index and value before any call to MONO_HANDLE_RAW or ot
 #define MONO_HANDLE_ARRAY_GETVAL(DEST, HANDLE, TYPE, IDX) do {		\
 		MonoArrayHandle __arr = (HANDLE);			\
 		uintptr_t __idx = (IDX);				\
-		TYPE __result = MONO_HANDLE_SUPPRESS (mono_array_get (MONO_HANDLE_RAW(__arr), TYPE, __idx)); \
+		TYPE __result = MONO_HANDLE_SUPPRESS (mono_array_get_internal (MONO_HANDLE_RAW(__arr), TYPE, __idx)); \
 		(DEST) =  __result;					\
 	} while (0)
 
@@ -444,7 +444,7 @@ This is why we evaluate index and value before any call to MONO_HANDLE_RAW or ot
 		MonoObjectHandle __obj = MONO_HANDLE_CAST (MonoObject, (HANDLE)); \
 		MonoClassField *__field = (FIELD);			\
 		MonoObjectHandle __value = MONO_HANDLE_CAST (MonoObject, (VALH)); \
-		MONO_HANDLE_SUPPRESS (mono_gc_wbarrier_generic_store (mono_handle_unsafe_field_addr (__obj, __field), MONO_HANDLE_RAW (__value))); \
+		MONO_HANDLE_SUPPRESS (mono_gc_wbarrier_generic_store_internal (mono_handle_unsafe_field_addr (__obj, __field), MONO_HANDLE_RAW (__value))); \
 	} while (0)
 
 /* Baked typed handles we all want */
@@ -519,12 +519,8 @@ mono_array_new_full_handle (MonoDomain *domain, MonoClass *array_class, uintptr_
 uintptr_t
 mono_array_handle_length (MonoArrayHandle arr);
 
-static inline void
-mono_handle_array_getref (MonoObjectHandleOut dest, MonoArrayHandle array, uintptr_t index)
-{
-	MONO_HANDLE_SUPPRESS (g_assert (dest.__raw));
-	MONO_HANDLE_SUPPRESS (*dest.__raw = (MonoObject*)mono_array_get(MONO_HANDLE_RAW (array), gpointer, index));
-}
+void
+mono_handle_array_getref (MonoObjectHandleOut dest, MonoArrayHandle array, uintptr_t index);
 
 #define mono_handle_class(o) MONO_HANDLE_SUPPRESS (mono_object_class (MONO_HANDLE_RAW (MONO_HANDLE_UNSUPPRESS (o))))
 
@@ -536,24 +532,12 @@ mono_gchandle_from_handle (MonoObjectHandle handle, mono_bool pinned);
 MonoObjectHandle
 mono_gchandle_get_target_handle (uint32_t gchandle);
 
-static inline gboolean
-mono_gchandle_target_equal (uint32_t gchandle, MonoObjectHandle equal)
-{
-	// This function serves to reduce coop handle creation.
-	MONO_HANDLE_SUPPRESS_SCOPE (1);
-	return mono_gchandle_get_target (gchandle) == MONO_HANDLE_RAW (equal);
-}
+gboolean
+mono_gchandle_target_equal (uint32_t gchandle, MonoObjectHandle equal);
 
-static inline void
+void
 mono_gchandle_target_is_null_or_equal (uint32_t gchandle, MonoObjectHandle equal, gboolean *is_null,
-	gboolean *is_equal)
-{
-	// This function serves to reduce coop handle creation.
-	MONO_HANDLE_SUPPRESS_SCOPE (1);
-	MonoObject *target = mono_gchandle_get_target (gchandle);
-	*is_null = target == NULL;
-	*is_equal = target == MONO_HANDLE_RAW (equal);
-}
+	gboolean *is_equal);
 
 void
 mono_gchandle_set_target_handle (guint32 gchandle, MonoObjectHandle obj);
@@ -592,23 +576,14 @@ mono_context_get_handle (void);
 void
 mono_context_set_handle (MonoAppContextHandle new_context);
 
-static inline guint32
-mono_gchandle_new_weakref_from_handle (MonoObjectHandle handle)
-{
-	return mono_gchandle_new_weakref (MONO_HANDLE_SUPPRESS (MONO_HANDLE_RAW (handle)), FALSE);
-}
+guint32
+mono_gchandle_new_weakref_from_handle (MonoObjectHandle handle);
 
-static inline int
-mono_handle_hash (MonoObjectHandle object)
-{
-	return mono_object_hash (MONO_HANDLE_SUPPRESS (MONO_HANDLE_RAW (object)));
-}
+int
+mono_handle_hash (MonoObjectHandle object);
 
-static inline guint32
-mono_gchandle_new_weakref_from_handle_track_resurrection (MonoObjectHandle handle)
-{
-	return mono_gchandle_new_weakref (MONO_HANDLE_SUPPRESS (MONO_HANDLE_RAW (handle)), TRUE);
-}
+guint32
+mono_gchandle_new_weakref_from_handle_track_resurrection (MonoObjectHandle handle);
 
 G_END_DECLS
 

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -555,8 +555,7 @@ ICALL(NUMBER_FORMATTER_1, "GetFormatterTables", ves_icall_System_NumberFormatter
 
 ICALL_TYPE(OBJ, "System.Object", OBJ_1)
 HANDLES(OBJ_1, "GetType", ves_icall_System_Object_GetType, MonoReflectionType, 1, (MonoObject))
-
-ICALL(OBJ_2, "InternalGetHashCode", mono_object_hash)
+ICALL(OBJ_2, "InternalGetHashCode", mono_object_hash_internal)
 ICALL(OBJ_3, "MemberwiseClone", ves_icall_System_Object_MemberwiseClone)
 
 ICALL_TYPE(ASSEM, "System.Reflection.Assembly", ASSEM_1a)
@@ -989,7 +988,7 @@ HANDLES(ITHREAD_1, "Thread_free_internal", ves_icall_System_Threading_InternalTh
 
 ICALL_TYPE(MONIT, "System.Threading.Monitor", MONIT_8)
 ICALL(MONIT_8, "Enter", ves_icall_System_Threading_Monitor_Monitor_Enter)
-ICALL(MONIT_1, "Exit", mono_monitor_exit)
+ICALL(MONIT_1, "Exit", mono_monitor_exit_internal)
 ICALL(MONIT_2, "Monitor_pulse", ves_icall_System_Threading_Monitor_Monitor_pulse)
 ICALL(MONIT_3, "Monitor_pulse_all", ves_icall_System_Threading_Monitor_Monitor_pulse_all)
 ICALL(MONIT_4, "Monitor_test_owner", ves_icall_System_Threading_Monitor_Monitor_test_owner)

--- a/mono/metadata/icall-windows.c
+++ b/mono/metadata/icall-windows.c
@@ -136,7 +136,7 @@ mono_icall_get_environment_variable_names (MonoError *error)
 				str = mono_string_new_utf16_checked (domain, env_string, (gint32)(equal_str - env_string), error);
 				goto_if_nok (error, cleanup);
 
-				mono_array_setref (names, n, str);
+				mono_array_setref_internal (names, n, str);
 				n++;
 			}
 			while (*env_string != '\0')
@@ -159,13 +159,13 @@ mono_icall_set_environment_variable (MonoString *name, MonoString *value)
 {
 	gunichar2 *utf16_name, *utf16_value;
 
-	utf16_name = name ? mono_string_chars (name) : NULL;
-	if ((value == NULL) || (mono_string_length (value) == 0) || (mono_string_chars (value)[0] == 0)) {
+	utf16_name = name ? mono_string_chars_internal (name) : NULL;
+	if ((value == NULL) || (mono_string_length_internal (value) == 0) || (mono_string_chars_internal (value)[0] == 0)) {
 		SetEnvironmentVariable (utf16_name, NULL);
 		return;
 	}
 
-	utf16_value = mono_string_chars (value);
+	utf16_value = mono_string_chars_internal (value);
 
 	SetEnvironmentVariable (utf16_name, utf16_value);
 }

--- a/mono/metadata/locales.c
+++ b/mono/metadata/locales.c
@@ -112,7 +112,7 @@ create_group_sizes_array (const gint *gs, gint ml, MonoError *error)
 	return_val_if_nok (error, NULL);
 
 	for(i = 0; i < len; i++)
-		mono_array_set (ret, gint32, i, gs [i]);
+		mono_array_set_internal (ret, gint32, i, gs [i]);
 
 	return ret;
 }
@@ -137,7 +137,7 @@ create_names_array_idx (const guint16 *names, int ml, MonoError *error)
 	for(i = 0; i < ml; i++) {
 		MonoString *s = mono_string_new_checked (domain, dtidx2string (names [i]), error);
 		return_val_if_nok (error, NULL);
-		mono_array_setref (ret, i, s);
+		mono_array_setref_internal (ret, i, s);
 	}
 
 	return ret;
@@ -169,7 +169,7 @@ create_names_array_idx_dynamic (const guint16 *names, int ml, MonoError *error)
 	for(i = 0; i < len; i++) {
 		MonoString *s = mono_string_new_checked (domain, pattern2string (names [i]), error);
 		return_val_if_nok (error, NULL);
-		mono_array_setref (ret, i, s);
+		mono_array_setref_internal (ret, i, s);
 	}
 
 	return ret;
@@ -185,7 +185,7 @@ ves_icall_System_Globalization_CalendarData_fill_calendar_data (MonoCalendarData
 	const CultureInfoEntry *ci;
 	char *n;
 
-	n = mono_string_to_utf8_checked (name, error);
+	n = mono_string_to_utf8_checked_internal (name, error);
 	if (mono_error_set_pending_exception (error))
 		return FALSE;
 	ne = (const CultureInfoNameEntry *)mono_binary_search (n, culture_name_entries, NUM_CULTURE_ENTRIES,
@@ -202,55 +202,55 @@ ves_icall_System_Globalization_CalendarData_fill_calendar_data (MonoCalendarData
 
 	MonoString *native_name = mono_string_new_checked (domain, idx2string (ci->nativename), error);
 	return_val_and_set_pending_if_nok (error, FALSE);
-	MONO_OBJECT_SETREF (this_obj, NativeName, native_name);
+	MONO_OBJECT_SETREF_INTERNAL (this_obj, NativeName, native_name);
 	MonoArray *short_date_patterns = create_names_array_idx_dynamic (dfe->short_date_patterns,
 									 NUM_SHORT_DATE_PATTERNS, error);
 	return_val_and_set_pending_if_nok (error, FALSE);
-	MONO_OBJECT_SETREF (this_obj, ShortDatePatterns, short_date_patterns);
+	MONO_OBJECT_SETREF_INTERNAL (this_obj, ShortDatePatterns, short_date_patterns);
 	MonoArray *year_month_patterns =create_names_array_idx_dynamic (dfe->year_month_patterns,
 									NUM_YEAR_MONTH_PATTERNS, error);
 	return_val_and_set_pending_if_nok (error, FALSE);
-	MONO_OBJECT_SETREF (this_obj, YearMonthPatterns, year_month_patterns);
+	MONO_OBJECT_SETREF_INTERNAL (this_obj, YearMonthPatterns, year_month_patterns);
 
 	MonoArray *long_date_patterns = create_names_array_idx_dynamic (dfe->long_date_patterns,
 									NUM_LONG_DATE_PATTERNS, error);
 	return_val_and_set_pending_if_nok (error, FALSE);
-	MONO_OBJECT_SETREF (this_obj, LongDatePatterns, long_date_patterns);
+	MONO_OBJECT_SETREF_INTERNAL (this_obj, LongDatePatterns, long_date_patterns);
 
 	MonoString *month_day_pattern = mono_string_new_checked (domain, pattern2string (dfe->month_day_pattern), error);
 	return_val_and_set_pending_if_nok (error, FALSE);
-	MONO_OBJECT_SETREF (this_obj, MonthDayPattern, month_day_pattern);
+	MONO_OBJECT_SETREF_INTERNAL (this_obj, MonthDayPattern, month_day_pattern);
 
 	MonoArray *day_names = create_names_array_idx (dfe->day_names, NUM_DAYS, error);
 	return_val_and_set_pending_if_nok (error, FALSE);
-	MONO_OBJECT_SETREF (this_obj, DayNames, day_names);
+	MONO_OBJECT_SETREF_INTERNAL (this_obj, DayNames, day_names);
 
 	MonoArray *abbr_day_names = create_names_array_idx (dfe->abbreviated_day_names, 
 							    NUM_DAYS, error);
 	return_val_and_set_pending_if_nok (error, FALSE);
-	MONO_OBJECT_SETREF (this_obj, AbbreviatedDayNames, abbr_day_names);
+	MONO_OBJECT_SETREF_INTERNAL (this_obj, AbbreviatedDayNames, abbr_day_names);
 
 	MonoArray *ss_day_names = create_names_array_idx (dfe->shortest_day_names, NUM_DAYS, error);
 	return_val_and_set_pending_if_nok (error, FALSE);
-	MONO_OBJECT_SETREF (this_obj, SuperShortDayNames, ss_day_names);
+	MONO_OBJECT_SETREF_INTERNAL (this_obj, SuperShortDayNames, ss_day_names);
 
 	MonoArray *month_names = create_names_array_idx (dfe->month_names, NUM_MONTHS, error);
 	return_val_and_set_pending_if_nok (error, FALSE);
-	MONO_OBJECT_SETREF (this_obj, MonthNames, month_names);
+	MONO_OBJECT_SETREF_INTERNAL (this_obj, MonthNames, month_names);
 
 	MonoArray *abbr_mon_names = create_names_array_idx (dfe->abbreviated_month_names,
 							    NUM_MONTHS, error);
 	return_val_and_set_pending_if_nok (error, FALSE);
-	MONO_OBJECT_SETREF (this_obj, AbbreviatedMonthNames, abbr_mon_names);
+	MONO_OBJECT_SETREF_INTERNAL (this_obj, AbbreviatedMonthNames, abbr_mon_names);
 
 	
 	MonoArray *gen_month_names = create_names_array_idx (dfe->month_genitive_names, NUM_MONTHS, error);
 	return_val_and_set_pending_if_nok (error, FALSE);
-	MONO_OBJECT_SETREF (this_obj, GenitiveMonthNames, gen_month_names);
+	MONO_OBJECT_SETREF_INTERNAL (this_obj, GenitiveMonthNames, gen_month_names);
 
 	MonoArray *gen_abbr_mon_names = create_names_array_idx (dfe->abbreviated_month_genitive_names, NUM_MONTHS, error);
 	return_val_and_set_pending_if_nok (error, FALSE);
-	MONO_OBJECT_SETREF (this_obj, GenitiveAbbreviatedMonthNames, gen_abbr_mon_names);
+	MONO_OBJECT_SETREF_INTERNAL (this_obj, GenitiveAbbreviatedMonthNames, gen_abbr_mon_names);
 
 	return TRUE;
 }
@@ -272,7 +272,7 @@ ves_icall_System_Globalization_CultureData_fill_culture_data (MonoCultureData *t
 		MonoString *_tmp_str = mono_string_new_checked ((domain), (expr), (err)); \
 		if (mono_error_set_pending_exception ((err)))		\
 			return;						\
-		MONO_OBJECT_SETREF((obj), field, _tmp_str);		\
+		MONO_OBJECT_SETREF_INTERNAL ((obj), field, _tmp_str);		\
 	} while (0)
 
 	SET_STR (this_obj, AMDesignator, domain, idx2string (dfe->am_designator), error);
@@ -284,13 +284,13 @@ ves_icall_System_Globalization_CultureData_fill_culture_data (MonoCultureData *t
 									NUM_LONG_TIME_PATTERNS, error);
 	if (mono_error_set_pending_exception (error))
 		return;
-	MONO_OBJECT_SETREF (this_obj, LongTimePatterns, long_time_patterns);
+	MONO_OBJECT_SETREF_INTERNAL (this_obj, LongTimePatterns, long_time_patterns);
 
 	MonoArray *short_time_patterns = create_names_array_idx_dynamic (dfe->short_time_patterns,
 									 NUM_SHORT_TIME_PATTERNS, error);
 	if (mono_error_set_pending_exception (error))
 		return;
-	MONO_OBJECT_SETREF (this_obj, ShortTimePatterns, short_time_patterns);
+	MONO_OBJECT_SETREF_INTERNAL (this_obj, ShortTimePatterns, short_time_patterns);
 	this_obj->FirstDayOfWeek = dfe->first_day_of_week;
 	this_obj->CalendarWeekRule = dfe->calendar_week_rule;
 }
@@ -314,7 +314,7 @@ ves_icall_System_Globalization_CultureData_fill_number_data (MonoNumberFormatInf
 		MonoString *_tmp_str = mono_string_new_checked ((domain), (expr), (err)); \
 		if (mono_error_set_pending_exception ((err)))		\
 			return;						\
-		MONO_OBJECT_SETREF((obj), field, _tmp_str);		\
+		MONO_OBJECT_SETREF_INTERNAL ((obj), field, _tmp_str);		\
 	} while (0)
 
 	SET_STR (number, currencyDecimalSeparator, domain, idx2string (nfe->currency_decimal_separator), error);
@@ -324,7 +324,7 @@ ves_icall_System_Globalization_CultureData_fill_number_data (MonoNumberFormatInf
 								  GROUP_SIZE, error);
 	if (mono_error_set_pending_exception (error))
 		return;
-	MONO_OBJECT_SETREF (number, currencyGroupSizes, currency_sizes_arr);
+	MONO_OBJECT_SETREF_INTERNAL (number, currencyGroupSizes, currency_sizes_arr);
 	number->currencyNegativePattern = nfe->currency_negative_pattern;
 	number->currencyPositivePattern = nfe->currency_positive_pattern;
 
@@ -339,7 +339,7 @@ ves_icall_System_Globalization_CultureData_fill_number_data (MonoNumberFormatInf
 								GROUP_SIZE, error);
 	if (mono_error_set_pending_exception (error))
 		return;
-	MONO_OBJECT_SETREF (number, numberGroupSizes, number_sizes_arr);
+	MONO_OBJECT_SETREF_INTERNAL (number, numberGroupSizes, number_sizes_arr);
 	number->numberNegativePattern = nfe->number_negative_pattern;
 	number->percentNegativePattern = nfe->percent_negative_pattern;
 	number->percentPositivePattern = nfe->percent_positive_pattern;
@@ -362,7 +362,7 @@ construct_culture (MonoCultureInfo *this_obj, const CultureInfoEntry *ci, MonoEr
 #define SET_STR(obj,field,domain,expr,err) do {				\
 		MonoString *_tmp_str = mono_string_new_checked ((domain), (expr), (err)); \
 		return_val_if_nok (err, FALSE);				\
-		MONO_OBJECT_SETREF((obj), field, _tmp_str);		\
+		MONO_OBJECT_SETREF_INTERNAL ((obj), field, _tmp_str);		\
 	} while (0)
 
 	SET_STR (this_obj, name, domain, idx2string (ci->name), error);
@@ -379,7 +379,7 @@ construct_culture (MonoCultureInfo *this_obj, const CultureInfoEntry *ci, MonoEr
 
 	MonoArray *native_calendar_names = create_names_array_idx (ci->native_calendar_names, NUM_CALENDARS, error);
 	return_val_if_nok (error, FALSE);
-	MONO_OBJECT_SETREF (this_obj, native_calendar_names, native_calendar_names);
+	MONO_OBJECT_SETREF_INTERNAL (this_obj, native_calendar_names, native_calendar_names);
 	this_obj->parent_lcid = ci->parent_lcid;
 	this_obj->datetime_index = ci->datetime_format_index;
 	this_obj->number_index = ci->number_format_index;
@@ -400,7 +400,7 @@ construct_region (MonoRegionInfo *this_obj, const RegionInfoEntry *ri, MonoError
 #define SET_STR(obj,field,domain,expr,err) do {				\
 		MonoString *_tmp_str = mono_string_new_checked ((domain), (expr), (err)); \
 		return_val_if_nok (err, FALSE);				\
-		MONO_OBJECT_SETREF((obj), field, _tmp_str);		\
+		MONO_OBJECT_SETREF_INTERNAL ((obj), field, _tmp_str);		\
 	} while (0)
 
 	this_obj->geo_id = ri->geo_id;
@@ -629,7 +629,7 @@ ves_icall_System_Globalization_CultureInfo_construct_internal_locale_from_name (
 	const CultureInfoNameEntry *ne;
 	char *n;
 	
-	n = mono_string_to_utf8_checked (name, error);
+	n = mono_string_to_utf8_checked_internal (name, error);
 	if (mono_error_set_pending_exception (error))
 		return FALSE;
 	ne = (const CultureInfoNameEntry *)mono_binary_search (n, culture_name_entries, NUM_CULTURE_ENTRIES,
@@ -687,7 +687,7 @@ ves_icall_System_Globalization_RegionInfo_construct_internal_region_from_name (M
 	const RegionInfoNameEntry *ne;
 	char *n;
 	
-	n = mono_string_to_utf8_checked (name, error);
+	n = mono_string_to_utf8_checked_internal (name, error);
 	if (mono_error_set_pending_exception (error))
 		return FALSE;
 	ne = (const RegionInfoNameEntry *)mono_binary_search (n, region_name_entries, NUM_REGION_ENTRIES,
@@ -743,7 +743,7 @@ ves_icall_System_Globalization_CultureInfo_internal_get_cultures (MonoBoolean ne
 
 	len = 0;
 	if (neutral)
-		mono_array_setref (ret, len++, NULL);
+		mono_array_setref_internal (ret, len++, NULL);
 
 	for (i = 0; i < NUM_CULTURE_ENTRIES; i++) {
 		ci = &culture_entries [i];
@@ -756,7 +756,7 @@ ves_icall_System_Globalization_CultureInfo_internal_get_cultures (MonoBoolean ne
 			if (!construct_culture (culture, ci, error))
 				goto fail;
 			culture->use_user_override = TRUE;
-			mono_array_setref (ret, len++, culture);
+			mono_array_setref_internal (ret, len++, culture);
 		}
 	}
 
@@ -782,7 +782,7 @@ void ves_icall_System_Globalization_CompareInfo_assign_sortkey (MonoCompareInfo 
 	MonoArray *arr;
 	gint32 keylen, i;
 
-	keylen=mono_string_length (source);
+	keylen=mono_string_length_internal (source);
 	
 	arr=mono_array_new_checked (mono_domain_get (), mono_get_byte_class (),
 				    keylen, error);
@@ -790,10 +790,10 @@ void ves_icall_System_Globalization_CompareInfo_assign_sortkey (MonoCompareInfo 
 		return;
 
 	for(i=0; i<keylen; i++) {
-		mono_array_set (arr, guint8, i, mono_string_chars (source)[i]);
+		mono_array_set_internal (arr, guint8, i, mono_string_chars_internal (source)[i]);
 	}
 	
-	MONO_OBJECT_SETREF (key, key, arr);
+	MONO_OBJECT_SETREF_INTERNAL (key, key, arr);
 }
 
 int ves_icall_System_Globalization_CompareInfo_internal_index (MonoCompareInfo *this_obj, MonoString *source, gint32 sindex, gint32 count, MonoString *value, gint32 options, MonoBoolean first)
@@ -867,8 +867,8 @@ static gint32 string_invariant_compare (MonoString *str1, gint32 off1,
 		length=len2;
 	}
 
-	ustr1 = mono_string_chars(str1)+off1;
-	ustr2 = mono_string_chars(str2)+off2;
+	ustr1 = mono_string_chars_internal (str1) + off1;
+	ustr2 = mono_string_chars_internal (str2) + off2;
 
 	pos = 0;
 
@@ -915,10 +915,10 @@ static gint32 string_invariant_indexof (MonoString *source, gint32 sindex,
 	gunichar2 *cmpstr;
 	gint32 pos,i;
 	
-	lencmpstr = mono_string_length(value);
+	lencmpstr = mono_string_length_internal (value);
 	
-	src = mono_string_chars(source);
-	cmpstr = mono_string_chars(value);
+	src = mono_string_chars_internal (source);
+	cmpstr = mono_string_chars_internal (value);
 
 	if(first) {
 		count -= lencmpstr;
@@ -950,7 +950,7 @@ static gint32 string_invariant_indexof_char (MonoString *source, gint32 sindex,
 	gint32 pos;
 	gunichar2 *src;
 
-	src = mono_string_chars(source);
+	src = mono_string_chars_internal (source);
 	if(first) {
 		for (pos = sindex; pos != count + sindex; pos++) {
 			if (src [pos] == value) {

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -3392,7 +3392,7 @@ emit_virtual_stelemref_ilgen (MonoMethodBuilder *mb, const char **param_names, M
 		if (!(vt->interface_bitmap [(uiid) >> 3] & (1 << ((uiid)&7))))
 			goto exception;
 		store:
-			mono_array_setref (array, index, value);
+			mono_array_setref_internal (array, index, value);
 			return;
 		exception:
 			mono_raise_exception (mono_get_exception_array_type_mismatch ());*/
@@ -5932,14 +5932,14 @@ emit_managed_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *invoke_s
 	if (sig->hasthis) {
 		if (target_handle) {
 			mono_mb_emit_icon (mb, (gint32)target_handle);
-			mono_mb_emit_icall (mb, mono_gchandle_get_target);
+			mono_mb_emit_icall (mb, mono_gchandle_get_target_internal);
 		} else {
 			/* fixme: */
 			g_assert_not_reached ();
 		}
 	} else if (closed) {
 		mono_mb_emit_icon (mb, (gint32)target_handle);
-		mono_mb_emit_icall (mb, mono_gchandle_get_target);
+		mono_mb_emit_icall (mb, mono_gchandle_get_target_internal);
 	}
 
 	for (i = 0; i < sig->param_count; i++) {

--- a/mono/metadata/marshal-windows.c
+++ b/mono/metadata/marshal-windows.c
@@ -111,7 +111,7 @@ mono_string_to_utf8str_handle (MonoStringHandle s, MonoError *error)
 
 	uint32_t gchandle = 0;
 	tmp = g_utf16_to_utf8 (mono_string_handle_pin_chars (s, &gchandle), mono_string_handle_length (s), NULL, &len, &gerror);
-	mono_gchandle_free (gchandle);
+	mono_gchandle_free_internal (gchandle);
 	if (gerror) {
 		mono_error_set_argument (error, "string", gerror->message);
 		g_error_free (gerror);

--- a/mono/metadata/monitor.c
+++ b/mono/metadata/monitor.c
@@ -467,7 +467,6 @@ alloc_mon (MonoObject *obj, gint32 id)
 	return mon;
 }
 
-
 static void
 discard_mon (MonoThreadsSync *mon)
 {
@@ -558,12 +557,6 @@ mono_monitor_inflate (MonoObject *obj)
 
 #define MONO_OBJECT_ALIGNMENT_SHIFT	3
 
-/*
- * mono_object_hash:
- * @obj: an object
- *
- * Calculate a hash code for @obj that is constant while @obj is alive.
- */
 int
 mono_object_hash_internal (MonoObject* obj)
 {
@@ -635,6 +628,12 @@ mono_object_hash_internal (MonoObject* obj)
 #endif
 }
 
+/*
+ * mono_object_hash:
+ * @obj: an object
+ *
+ * Calculate a hash code for @obj that is constant while @obj is alive.
+ */
 int
 mono_object_hash (MonoObject* obj)
 {
@@ -780,7 +779,7 @@ signal_monitor (gpointer mon_untyped)
 	mono_coop_mutex_unlock (mon->entry_mutex);
 }
 
-/* If allow_interruption==TRUE, the method will be interrumped if abort or suspend
+/* If allow_interruption==TRUE, the method will be interrupted if abort or suspend
  * is requested. In this case it returns -1.
  */ 
 static inline gint32 
@@ -1093,9 +1092,6 @@ mono_monitor_try_enter (MonoObject *obj, guint32 ms)
 	MONO_EXTERNAL_ONLY (gboolean, mono_monitor_try_enter_internal (obj, ms, FALSE) == 1);
 }
 
-/**
- * mono_monitor_exit:
- */
 void
 mono_monitor_exit_internal (MonoObject *obj)
 {
@@ -1121,6 +1117,9 @@ mono_monitor_exit_internal (MonoObject *obj)
 		mono_monitor_exit_flat (obj, lw);
 }
 
+/**
+ * mono_monitor_exit:
+ */
 void
 mono_monitor_exit (MonoObject *obj)
 {

--- a/mono/metadata/monitor.c
+++ b/mono/metadata/monitor.c
@@ -33,6 +33,7 @@
 #include <mono/utils/atomic.h>
 #include <mono/utils/w32api.h>
 #include <mono/utils/mono-os-wait.h>
+#include "external-only.h"
 
 /*
  * Pull the list of opcodes
@@ -331,7 +332,7 @@ mono_locks_dump (gboolean include_untaken)
 					to_recycle++;
 			} else {
 				if (!monitor_is_on_freelist ((MonoThreadsSync *)mon->data)) {
-					MonoObject *holder = (MonoObject *)mono_gchandle_get_target ((guint32)(gsize)mon->data);
+					MonoObject *holder = (MonoObject *)mono_gchandle_get_target_internal ((guint32)(gsize)mon->data);
 					if (mon_status_get_owner (mon->status)) {
 						g_print ("Lock %p in object %p held by thread %d, nest level: %d\n",
 							mon, holder, mon_status_get_owner (mon->status), mon->nest);
@@ -393,7 +394,7 @@ mon_new (gsize id)
 		new_ = NULL;
 		for (marray = monitor_allocated; marray; marray = marray->next) {
 			for (i = 0; i < marray->num_monitors; ++i) {
-				if (mono_gchandle_get_target ((guint32)(gsize)marray->monitors [i].data) == NULL) {
+				if (mono_gchandle_get_target_internal ((guint32)(gsize)marray->monitors [i].data) == NULL) {
 					new_ = &marray->monitors [i];
 					if (new_->wait_list) {
 						/* Orphaned events left by aborted threads */
@@ -403,7 +404,7 @@ mon_new (gsize id)
 							new_->wait_list = g_slist_remove (new_->wait_list, new_->wait_list->data);
 						}
 					}
-					mono_gchandle_free ((guint32)(gsize)new_->data);
+					mono_gchandle_free_internal ((guint32)(gsize)new_->data);
 					new_->data = monitor_freelist;
 					monitor_freelist = new_;
 				}
@@ -460,7 +461,7 @@ alloc_mon (MonoObject *obj, gint32 id)
 
 	mono_monitor_allocator_lock ();
 	mon = mon_new (id);
-	mon->data = (void *)(size_t)mono_gchandle_new_weakref (obj, TRUE);
+	mon->data = (void *)(size_t)mono_gchandle_new_weakref_internal (obj, TRUE);
 	mono_monitor_allocator_unlock ();
 
 	return mon;
@@ -471,7 +472,7 @@ static void
 discard_mon (MonoThreadsSync *mon)
 {
 	mono_monitor_allocator_lock ();
-	mono_gchandle_free ((guint32)(gsize)mon->data);
+	mono_gchandle_free_internal ((guint32)(gsize)mon->data);
 	mon_finalize (mon);
 	mono_monitor_allocator_unlock ();
 }
@@ -564,7 +565,7 @@ mono_monitor_inflate (MonoObject *obj)
  * Calculate a hash code for @obj that is constant while @obj is alive.
  */
 int
-mono_object_hash (MonoObject* obj)
+mono_object_hash_internal (MonoObject* obj)
 {
 #ifdef HAVE_MOVING_COLLECTOR
 	LockWord lw;
@@ -632,6 +633,12 @@ mono_object_hash (MonoObject* obj)
  */
 	return (GPOINTER_TO_UINT (obj) >> MONO_OBJECT_ALIGNMENT_SHIFT) * 2654435761u;
 #endif
+}
+
+int
+mono_object_hash (MonoObject* obj)
+{
+	MONO_EXTERNAL_ONLY (int, mono_object_hash_internal (obj));
 }
 
 static gboolean
@@ -1056,7 +1063,7 @@ mono_monitor_enter_internal (MonoObject *obj)
 gboolean
 mono_monitor_enter (MonoObject *obj)
 {
-	return mono_monitor_enter_internal (obj);
+	MONO_EXTERNAL_ONLY (gboolean, mono_monitor_enter_internal (obj));
 }
 
 /* Called from JITted code so we return guint32 instead of gboolean */
@@ -1083,14 +1090,14 @@ mono_monitor_try_enter (MonoObject *obj, guint32 ms)
 		mono_error_set_pending_exception (error);
 		return FALSE;
 	}
-	return mono_monitor_try_enter_internal (obj, ms, FALSE) == 1;
+	MONO_EXTERNAL_ONLY (gboolean, mono_monitor_try_enter_internal (obj, ms, FALSE) == 1);
 }
 
 /**
  * mono_monitor_exit:
  */
 void
-mono_monitor_exit (MonoObject *obj)
+mono_monitor_exit_internal (MonoObject *obj)
 {
 	LockWord lw;
 	
@@ -1112,6 +1119,12 @@ mono_monitor_exit (MonoObject *obj)
 		mono_monitor_exit_inflated (obj);
 	else
 		mono_monitor_exit_flat (obj, lw);
+}
+
+void
+mono_monitor_exit (MonoObject *obj)
+{
+	MONO_EXTERNAL_ONLY_VOID (mono_monitor_exit_internal (obj));
 }
 
 guint32
@@ -1182,17 +1195,8 @@ ves_icall_System_Threading_Monitor_Monitor_try_enter_with_atomic_var (MonoObject
 void
 mono_monitor_enter_v4 (MonoObject *obj, char *lock_taken)
 {
-	if (*lock_taken == 1) {
-		ERROR_DECL (error);
-		mono_error_set_argument (error, "lockTaken", "lockTaken is already true");
-		mono_error_set_pending_exception (error);
-		return;
-	}
-
-	MonoBoolean taken;
-
-	ves_icall_System_Threading_Monitor_Monitor_try_enter_with_atomic_var (obj, MONO_INFINITE_WAIT, &taken);
-	*lock_taken = taken;
+	g_assert (sizeof (MonoBoolean) == 1); // FIXME static_assert
+	mono_monitor_enter_v4_internal  (obj, (MonoBoolean*)lock_taken);
 }
 
 /* Called from JITted code */

--- a/mono/metadata/mono-conc-hash.c
+++ b/mono/metadata/mono-conc-hash.c
@@ -111,7 +111,7 @@ set_key (conc_table *table, int slot, gpointer key)
 {
 	gpointer *key_addr = &table->keys [slot];
 	if (table->gc_type & MONO_HASH_KEY_GC)
-		mono_gc_wbarrier_generic_store (key_addr, (MonoObject*)key);
+		mono_gc_wbarrier_generic_store_internal (key_addr, (MonoObject*)key);
 	else
 		*key_addr = key;
 }
@@ -121,7 +121,7 @@ set_key_to_tombstone (conc_table *table, int slot)
 {
 	gpointer *key_addr = &table->keys [slot];
 	if (table->gc_type & MONO_HASH_KEY_GC)
-		mono_gc_wbarrier_generic_store (key_addr, mono_domain_get()->ephemeron_tombstone);
+		mono_gc_wbarrier_generic_store_internal (key_addr, mono_domain_get()->ephemeron_tombstone);
 	else
 		*key_addr = PTR_TOMBSTONE;
 }
@@ -131,7 +131,7 @@ set_value (conc_table *table, int slot, gpointer value)
 {
 	gpointer *value_addr = &table->values [slot];
 	if (table->gc_type & MONO_HASH_VALUE_GC)
-		mono_gc_wbarrier_generic_store (value_addr, (MonoObject*)value);
+		mono_gc_wbarrier_generic_store_internal (value_addr, (MonoObject*)value);
 	else
 		*value_addr = value;
 }

--- a/mono/metadata/mono-hash.c
+++ b/mono/metadata/mono-hash.c
@@ -95,7 +95,7 @@ static inline void mono_g_hash_table_key_store (MonoGHashTable *hash, int slot, 
 {
 	MonoObject **key_addr = &hash->keys [slot];
 	if (hash->gc_type & MONO_HASH_KEY_GC)
-		mono_gc_wbarrier_generic_store (key_addr, key);
+		mono_gc_wbarrier_generic_store_internal (key_addr, key);
 	else
 		*key_addr = key;
 }
@@ -104,7 +104,7 @@ static inline void mono_g_hash_table_value_store (MonoGHashTable *hash, int slot
 {
 	MonoObject **value_addr = &hash->values [slot];
 	if (hash->gc_type & MONO_HASH_VALUE_GC)
-		mono_gc_wbarrier_generic_store (value_addr, value);
+		mono_gc_wbarrier_generic_store_internal (value_addr, value);
 	else
 		*value_addr = value;
 }

--- a/mono/metadata/mono-mlist.c
+++ b/mono/metadata/mono-mlist.c
@@ -74,7 +74,7 @@ mono_mlist_alloc_checked (MonoObject *data, MonoError *error)
 	}
 	res = (MonoMList*)mono_object_new_specific_checked (monolist_item_vtable, error);
 	return_val_if_nok (error, NULL);
-	MONO_OBJECT_SETREF (res, data, data);
+	MONO_OBJECT_SETREF_INTERNAL (res, data, data);
 	return res;
 }
 
@@ -97,7 +97,7 @@ mono_mlist_get_data (MonoMList* list)
 void
 mono_mlist_set_data (MonoMList* list, MonoObject *data)
 {
-	MONO_OBJECT_SETREF (list, data, data);
+	MONO_OBJECT_SETREF_INTERNAL (list, data, data);
 }
 
 /**
@@ -112,7 +112,7 @@ mono_mlist_set_next (MonoMList* list, MonoMList *next)
 	if (!list)
 		return next;
 
-	MONO_OBJECT_SETREF (list, next, next);
+	MONO_OBJECT_SETREF_INTERNAL (list, next, next);
 	return list;
 }
 
@@ -194,7 +194,7 @@ mono_mlist_prepend_checked (MonoMList* list, MonoObject *data, MonoError *error)
 	return_val_if_nok (error, NULL);
 
 	if (list)
-		MONO_OBJECT_SETREF (res, next, list);
+		MONO_OBJECT_SETREF_INTERNAL (res, next, list);
 	return res;
 }
 
@@ -234,7 +234,7 @@ mono_mlist_append_checked (MonoMList* list, MonoObject *data, MonoError *error)
 
 	if (list) {
 		MonoMList* last = mono_mlist_last (list);
-		MONO_OBJECT_SETREF (last, next, res);
+		MONO_OBJECT_SETREF_INTERNAL (last, next, res);
 		return list;
 	} else {
 		return res;
@@ -272,7 +272,7 @@ mono_mlist_remove_item (MonoMList* list, MonoMList *item)
 	}
 	prev = find_prev (list, item);
 	if (prev) {
-		MONO_OBJECT_SETREF (prev, next, item->next);
+		MONO_OBJECT_SETREF_INTERNAL (prev, next, item->next);
 		item->next = NULL;
 		return list;
 	} else {

--- a/mono/metadata/mono-route.c
+++ b/mono/metadata/mono-route.c
@@ -35,7 +35,7 @@ extern MonoBoolean ves_icall_System_Net_NetworkInformation_MacOsIPInterfacePrope
 
 	MonoDomain *domain = mono_domain_get ();
 
-	ifacename = mono_string_to_utf8_checked(iface, error);
+	ifacename = mono_string_to_utf8_checked_internal (iface, error);
 	if (mono_error_set_pending_exception (error))
 		return FALSE;
 
@@ -106,7 +106,7 @@ extern MonoBoolean ves_icall_System_Net_NetworkInformation_MacOsIPInterfacePrope
 
 		addr_string = mono_string_new_checked (domain, addr, error);
 		goto_if_nok (error, leave);
-		mono_array_setref (*gw_addr_list, gwnum, addr_string);
+		mono_array_setref_internal (*gw_addr_list, gwnum, addr_string);
 		gwnum++;
 	}
 leave:

--- a/mono/metadata/mono-security-windows.c
+++ b/mono/metadata/mono-security-windows.c
@@ -183,7 +183,7 @@ ves_icall_System_Security_Principal_WindowsIdentity_GetRoles (gpointer token)
 						mono_error_set_pending_exception (error);
 						return NULL;
 					}
-					mono_array_setref (array, i, str);
+					mono_array_setref_internal (array, i, str);
 					g_free (uniname);
 				}
 			}

--- a/mono/metadata/null-gc.c
+++ b/mono/metadata/null-gc.c
@@ -242,48 +242,48 @@ mono_gc_alloc_pinned_obj (MonoVTable *vtable, size_t size)
 }
 
 void
-mono_gc_wbarrier_set_field (MonoObject *obj, gpointer field_ptr, MonoObject* value)
+mono_gc_wbarrier_set_field_internal (MonoObject *obj, gpointer field_ptr, MonoObject* value)
 {
 	*(void**)field_ptr = value;
 }
 
 void
-mono_gc_wbarrier_set_arrayref (MonoArray *arr, gpointer slot_ptr, MonoObject* value)
+mono_gc_wbarrier_set_arrayref_internal (MonoArray *arr, gpointer slot_ptr, MonoObject* value)
 {
 	*(void**)slot_ptr = value;
 }
 
 void
-mono_gc_wbarrier_arrayref_copy (gpointer dest_ptr, gpointer src_ptr, int count)
+mono_gc_wbarrier_arrayref_copy_internal (gpointer dest_ptr, gpointer src_ptr, int count)
 {
 	mono_gc_memmove_aligned (dest_ptr, src_ptr, count * sizeof (gpointer));
 }
 
 void
-mono_gc_wbarrier_generic_store (gpointer ptr, MonoObject* value)
+mono_gc_wbarrier_generic_store_internal (gpointer ptr, MonoObject* value)
 {
 	*(void**)ptr = value;
 }
 
 void
-mono_gc_wbarrier_generic_store_atomic (gpointer ptr, MonoObject *value)
+mono_gc_wbarrier_generic_store_atomic_internal (gpointer ptr, MonoObject *value)
 {
 	mono_atomic_store_ptr (ptr, value);
 }
 
 void
-mono_gc_wbarrier_generic_nostore (gpointer ptr)
+mono_gc_wbarrier_generic_nostore_internal (gpointer ptr)
 {
 }
 
 void
-mono_gc_wbarrier_value_copy (gpointer dest, gpointer src, int count, MonoClass *klass)
+mono_gc_wbarrier_value_copy_internal (gpointer dest, gpointer src, int count, MonoClass *klass)
 {
 	mono_gc_memmove_atomic (dest, src, count * mono_class_value_size (klass, NULL));
 }
 
 void
-mono_gc_wbarrier_object_copy (MonoObject* obj, MonoObject *src)
+mono_gc_wbarrier_object_copy_internal (MonoObject* obj, MonoObject *src)
 {
 	/* do not copy the sync state */
 	mono_gc_memmove_aligned (mono_object_get_data (obj), (char*)src + MONO_ABI_SIZEOF (MonoObject),

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -3451,7 +3451,7 @@ mono_field_get_addr (MonoObject *obj, MonoVTable *vt, MonoClassField *field)
  * <pre>
  * int i;
  *
- * mono_field_get_value_internal (obj, int_field, &i);
+ * mono_field_get_value (obj, int_field, &i);
  * </pre>
  */
 void

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -4941,11 +4941,13 @@ mono_runtime_exec_managed_code (MonoDomain *domain,
 				MonoMainThreadFunc main_func,
 				gpointer main_args)
 {
+	// This function is external_only.
+
 	ERROR_DECL (error);
 	mono_thread_create_checked (domain, main_func, main_args, error);
 	mono_error_assert_ok (error);
 
-	MONO_EXTERNAL_ONLY_VOID (mono_thread_manage ());
+	mono_thread_manage ();
 }
 
 static void

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -57,6 +57,11 @@
 #include "external-only.h"
 #include "monitor.h"
 
+// Exports do not work portably/reliably if compiled separately.
+// They must be in .o/.obj files otherwise referenced.
+// .def files work better in this regard.
+#include "external-only.c"
+
 static void
 get_default_field_value (MonoDomain* domain, MonoClassField *field, void *value, MonoError *error);
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -4132,11 +4132,6 @@ mono_get_delegate_invoke_checked (MonoClass *klass, MonoError *error)
 	return im;
 }
 
-/**
- * mono_get_delegate_begin_invoke:
- * \param klass The delegate class
- * \returns the \c MonoMethod for the \c BeginInvoke method in the delegate class or NULL if \p klass is a broken delegate type
- */
 MonoMethod *
 mono_get_delegate_begin_invoke_internal (MonoClass *klass)
 {
@@ -4148,6 +4143,11 @@ mono_get_delegate_begin_invoke_internal (MonoClass *klass)
 	return result;
 }
 
+/**
+ * mono_get_delegate_begin_invoke:
+ * \param klass The delegate class
+ * \returns the \c MonoMethod for the \c BeginInvoke method in the delegate class or NULL if \p klass is a broken delegate type
+ */
 MonoMethod*
 mono_get_delegate_begin_invoke (MonoClass *klass)
 {

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -57,9 +57,13 @@
 #include "external-only.h"
 #include "monitor.h"
 
-// Exports do not work portably/reliably if compiled separately.
-// They must be in .o/.obj files otherwise referenced.
-// .def files work better in this regard.
+// If no symbols in an object file in a static library are referenced, its exports will not be exported.
+// There are a few workarounds:
+// 1. Link to .o/.obj files directly on the link command line,
+//     instead of putting them in static libraries.
+// 2. Use a Windows .def file, or exports on command line, or Unix equivalent.
+// 3. Have a reference to at least one symbol in the .o/.obj.
+//    That is effectively what this include does.
 #include "external-only.c"
 
 static void

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -2848,13 +2848,6 @@ leave:
 }
 #endif /* DISABLE_REMOTING */
 
-/**
- * mono_object_get_virtual_method:
- * \param obj object to operate on.
- * \param method method 
- * Retrieves the \c MonoMethod that would be called on \p obj if \p obj is passed as
- * the instance of a callvirt of \p method.
- */
 MonoMethod*
 mono_object_get_virtual_method_internal (MonoObject *obj_raw, MonoMethod *method)
 {
@@ -2867,6 +2860,13 @@ mono_object_get_virtual_method_internal (MonoObject *obj_raw, MonoMethod *method
 	HANDLE_FUNCTION_RETURN_VAL (result);
 }
 
+/**
+ * mono_object_get_virtual_method:
+ * \param obj object to operate on.
+ * \param method method
+ * Retrieves the \c MonoMethod that would be called on \p obj if \p obj is passed as
+ * the instance of a callvirt of \p method.
+ */
 MonoMethod*
 mono_object_get_virtual_method (MonoObject *obj, MonoMethod *method)
 {
@@ -2876,7 +2876,7 @@ mono_object_get_virtual_method (MonoObject *obj, MonoMethod *method)
 /**
  * mono_object_handle_get_virtual_method:
  * \param obj object to operate on.
- * \param method method 
+ * \param method method
  * Retrieves the \c MonoMethod that would be called on \p obj if \p obj is passed as
  * the instance of a callvirt of \p method.
  */
@@ -2998,7 +2998,7 @@ do_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **ex
  *
  * The params array contains the arguments to the method with the
  * same convention: \c MonoObject* pointers for object instances and
- * pointers to the value type otherwise. 
+ * pointers to the value type otherwise.
  * 
  * From unmanaged code you'll usually use the
  * \c mono_runtime_invoke variant.
@@ -3052,8 +3052,8 @@ mono_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **
  *
  * The params array contains the arguments to the method with the
  * same convention: \c MonoObject* pointers for object instances and
- * pointers to the value type otherwise. 
- * 
+ * pointers to the value type otherwise.
+ *
  * From unmanaged code you'll usually use the
  * mono_runtime_invoke() variant.
  *
@@ -3322,6 +3322,18 @@ handle_enum:
 	}
 }
 
+void
+mono_field_set_value_internal (MonoObject *obj, MonoClassField *field, void *value)
+{
+	void *dest;
+
+	if ((field->type->attrs & FIELD_ATTRIBUTE_STATIC))
+		return;
+
+	dest = (char*)obj + field->offset;
+	mono_copy_value (field->type, dest, value, FALSE);
+}
+
 /**
  * mono_field_set_value:
  * \param obj Instance object
@@ -3335,31 +3347,11 @@ handle_enum:
  * The value must be in the native format of the field type. 
  */
 void
-mono_field_set_value_internal (MonoObject *obj, MonoClassField *field, void *value)
-{
-	void *dest;
-
-	if ((field->type->attrs & FIELD_ATTRIBUTE_STATIC))
-		return;
-
-	dest = (char*)obj + field->offset;
-	mono_copy_value (field->type, dest, value, FALSE);
-}
-
-void
 mono_field_set_value (MonoObject *obj, MonoClassField *field, void *value)
 {
 	MONO_EXTERNAL_ONLY_GC_UNSAFE_VOID (mono_field_set_value_internal (obj, field, value));
 }
 
-/**
- * mono_field_static_set_value:
- * \param field \c MonoClassField describing the field to set
- * \param value The value to be set
- * Sets the value of the static field described by \p field
- * to the value passed in \p value.
- * The value must be in the native format of the field type. 
- */
 void
 mono_field_static_set_value_internal (MonoVTable *vt, MonoClassField *field, void *value)
 {
@@ -3385,6 +3377,14 @@ mono_field_static_set_value_internal (MonoVTable *vt, MonoClassField *field, voi
 	mono_copy_value (field->type, dest, value, FALSE);
 }
 
+/**
+ * mono_field_static_set_value:
+ * \param field \c MonoClassField describing the field to set
+ * \param value The value to be set
+ * Sets the value of the static field described by \p field
+ * to the value passed in \p value.
+ * The value must be in the native format of the field type. 
+ */
 void
 mono_field_static_set_value (MonoVTable *vt, MonoClassField *field, void *value)
 {
@@ -4087,11 +4087,6 @@ mono_nullable_box_handle (gpointer buf, MonoClass *klass, MonoError *error)
 	return MONO_HANDLE_NEW (MonoObject, mono_nullable_box (buf, klass, error));
 }
 
-/**
- * mono_get_delegate_invoke:
- * \param klass The delegate class
- * \returns the \c MonoMethod for the \c Invoke method in the delegate class or NULL if \p klass is a broken delegate type
- */
 MonoMethod *
 mono_get_delegate_invoke_internal (MonoClass *klass)
 {
@@ -4103,6 +4098,11 @@ mono_get_delegate_invoke_internal (MonoClass *klass)
 	return result;
 }
 
+/**
+ * mono_get_delegate_invoke:
+ * \param klass The delegate class
+ * \returns the \c MonoMethod for the \c Invoke method in the delegate class or NULL if \p klass is a broken delegate type
+ */
 MonoMethod*
 mono_get_delegate_invoke (MonoClass *klass)
 {
@@ -4177,11 +4177,6 @@ mono_get_delegate_begin_invoke_checked (MonoClass *klass, MonoError *error)
 	return im;
 }
 
-/**
- * mono_get_delegate_end_invoke:
- * \param klass The delegate class
- * \returns the \c MonoMethod for the \c EndInvoke method in the delegate class or NULL if \p klass is a broken delegate type
- */
 MonoMethod *
 mono_get_delegate_end_invoke_internal (MonoClass *klass)
 {
@@ -4193,6 +4188,11 @@ mono_get_delegate_end_invoke_internal (MonoClass *klass)
 	return result;
 }
 
+/**
+ * mono_get_delegate_end_invoke:
+ * \param klass The delegate class
+ * \returns the \c MonoMethod for the \c EndInvoke method in the delegate class or NULL if \p klass is a broken delegate type
+ */
 MonoMethod*
 mono_get_delegate_end_invoke (MonoClass *klass)
 {
@@ -4828,17 +4828,6 @@ mono_runtime_unhandled_exception_policy_get (void)
 	return runtime_unhandled_exception_policy;
 }
 
-/**
- * mono_unhandled_exception:
- * \param exc exception thrown
- * This is a VM internal routine.
- *
- * We call this function when we detect an unhandled exception
- * in the default domain.
- *
- * It invokes the \c UnhandledException event in \c AppDomain or prints
- * a warning to the console 
- */
 void
 mono_unhandled_exception_internal (MonoObject *exc_raw)
 {
@@ -4850,6 +4839,17 @@ mono_unhandled_exception_internal (MonoObject *exc_raw)
 	HANDLE_FUNCTION_RETURN ();
 }
 
+/**
+ * mono_unhandled_exception:
+ * \param exc exception thrown
+ * This is a VM internal routine.
+ *
+ * We call this function when we detect an unhandled exception
+ * in the default domain.
+ *
+ * It invokes the \c UnhandledException event in \c AppDomain or prints
+ * a warning to the console
+ */
 void
 mono_unhandled_exception (MonoObject *exc)
 {
@@ -4857,7 +4857,7 @@ mono_unhandled_exception (MonoObject *exc)
 }
 
 /**
- * mono_unhandled_exception:
+ * mono_unhandled_exception_checked:
  * @exc: exception thrown
  *
  * This is a VM internal routine.
@@ -4866,7 +4866,7 @@ mono_unhandled_exception (MonoObject *exc)
  * in the default domain.
  *
  * It invokes the * UnhandledException event in AppDomain or prints
- * a warning to the console 
+ * a warning to the console
  */
 void
 mono_unhandled_exception_checked (MonoObjectHandle exc, MonoError *error)
@@ -5826,7 +5826,7 @@ mono_object_new_alloc_specific (MonoVTable *vtable)
 /**
  * mono_object_new_alloc_specific_checked:
  * \param vtable virtual table for the object.
- * \param error holds the error return value.  
+ * \param error holds the error return value.
  *
  * This function allocates a new \c MonoObject with the type derived
  * from the \p vtable information. If the class of this object has a 
@@ -6416,11 +6416,6 @@ mono_string_empty_wrapper (void)
 	return mono_string_empty_internal (domain);
 }
 
-/**
- * mono_string_empty:
- *
- * Returns: The same empty string instance as the managed string.Empty
- */
 MonoString*
 mono_string_empty_internal (MonoDomain *domain)
 {
@@ -6429,6 +6424,11 @@ mono_string_empty_internal (MonoDomain *domain)
 	return domain->empty_string;
 }
 
+/**
+ * mono_string_empty:
+ *
+ * Returns: The same empty string instance as the managed string.Empty
+ */
 MonoString*
 mono_string_empty (MonoDomain *domain)
 {
@@ -6612,7 +6612,7 @@ mono_string_new_len (MonoDomain *domain, const char *text, guint length)
 }
 
 /**
- * mono_string_new_len_checked:
+ * mono_string_new_utf8_len_handle:
  * \param text a pointer to an utf8 string
  * \param length number of bytes in \p text to consider
  * \param error set on error
@@ -6714,7 +6714,7 @@ mono_string_new_checked (MonoDomain *domain, const char *text, MonoError *error)
 	}
 	
 	g_free (ut);
-    
+
 /*FIXME g_utf8_get_char, g_utf8_next_char and g_utf8_validate are not part of eglib.*/
 #if 0
 	gunichar2 *str;
@@ -6767,7 +6767,7 @@ mono_string_new_wtf8_len_checked (MonoDomain *domain, const char *text, guint le
 
 	if (!eg_error)
 		o = mono_string_new_utf16_checked (domain, ut, items_written, error);
-	else 
+	else
 		g_error_free (eg_error);
 
 	g_free (ut);
@@ -6775,17 +6775,17 @@ mono_string_new_wtf8_len_checked (MonoDomain *domain, const char *text, guint le
 	return o;
 }
 
-/**
- * mono_string_new_wrapper:
- * \param text pointer to UTF-8 characters.
- * Helper function to create a string object from \p text in the current domain.
- */
 MonoString*
 mono_string_new_wrapper_internal (const char *text)
 {
 	return mono_string_new_internal (mono_domain_get (), text);
 }
 
+/**
+ * mono_string_new_wrapper:
+ * \param text pointer to UTF-8 characters.
+ * Helper function to create a string object from \p text in the current domain.
+ */
 MonoString*
 mono_string_new_wrapper (const char *text)
 {
@@ -6811,7 +6811,7 @@ mono_value_box (MonoDomain *domain, MonoClass *klass, gpointer value)
 }
 
 /**
- * mono_value_box_checked:
+ * mono_value_box_handle:
  * \param domain the domain of the new object
  * \param class the class of the value
  * \param value a pointer to the unboxed data
@@ -6943,6 +6943,14 @@ mono_value_box_checked (MonoDomain *domain, MonoClass *klass, gpointer value, Mo
 	return res;
 }
 
+void
+mono_value_copy_internal (gpointer dest, gpointer src, MonoClass *klass)
+{
+	MONO_REQ_GC_UNSAFE_MODE;
+
+	mono_gc_wbarrier_value_copy_internal (dest, src, 1, klass);
+}
+
 /**
  * mono_value_copy:
  * \param dest destination pointer
@@ -6952,17 +6960,20 @@ mono_value_box_checked (MonoDomain *domain, MonoClass *klass, gpointer value, Mo
  * when \p klass contains reference fields.
  */
 void
-mono_value_copy_internal (gpointer dest, gpointer src, MonoClass *klass)
-{
-	MONO_REQ_GC_UNSAFE_MODE;
-
-	mono_gc_wbarrier_value_copy_internal (dest, src, 1, klass);
-}
-
-void
 mono_value_copy (gpointer dest, gpointer src, MonoClass *klass)
 {
 	mono_value_copy_internal (dest, src, klass);
+}
+
+void
+mono_value_copy_array_internal (MonoArray *dest, int dest_idx, gpointer src, int count)
+{
+	MONO_REQ_GC_UNSAFE_MODE;
+
+	int size = mono_array_element_size (dest->obj.vtable->klass);
+	char *d = mono_array_addr_with_size_fast (dest, size, dest_idx);
+	g_assert (size == mono_class_value_size (m_class_get_element_class (mono_object_class (dest)), NULL));
+	mono_gc_wbarrier_value_copy_internal (d, src, count, m_class_get_element_class (mono_object_class (dest)));
 }
 
 /**
@@ -6975,17 +6986,6 @@ mono_value_copy (gpointer dest, gpointer src, MonoClass *klass)
  * This function must be used when \p klass contains references fields.
  * Overlap is handled.
  */
-void
-mono_value_copy_array_internal (MonoArray *dest, int dest_idx, gpointer src, int count)
-{
-	MONO_REQ_GC_UNSAFE_MODE;
-
-	int size = mono_array_element_size (dest->obj.vtable->klass);
-	char *d = mono_array_addr_with_size_fast (dest, size, dest_idx);
-	g_assert (size == mono_class_value_size (m_class_get_element_class (mono_object_class (dest)), NULL));
-	mono_gc_wbarrier_value_copy_internal (d, src, count, m_class_get_element_class (mono_object_class (dest)));
-}
-
 void
 mono_value_copy_array (MonoArray *dest, int dest_idx, void* src, int count)
 {
@@ -7005,11 +7005,6 @@ mono_object_get_vtable (MonoObject *obj)
 	MONO_EXTERNAL_ONLY (MonoVTable*, mono_object_get_vtable_internal (obj));
 }
 
-/**
- * mono_object_get_domain:
- * \param obj object to query
- * \returns the \c MonoDomain where the object is hosted
- */
 MonoDomain*
 mono_object_get_domain_internal (MonoObject *obj)
 {
@@ -7018,6 +7013,11 @@ mono_object_get_domain_internal (MonoObject *obj)
 	return mono_object_domain (obj);
 }
 
+/**
+ * mono_object_get_domain:
+ * \param obj object to query
+ * \returns the \c MonoDomain where the object is hosted
+ */
 MonoDomain*
 mono_object_get_domain (MonoObject *obj)
 {
@@ -7036,11 +7036,6 @@ mono_object_get_class (MonoObject *obj)
 	MONO_EXTERNAL_ONLY_GC_UNSAFE (MonoClass*, mono_object_class (obj));
 }
 
-/**
- * mono_object_get_size:
- * \param o object to query
- * \returns the size, in bytes, of \p o
- */
 guint
 mono_object_get_size_internal (MonoObject* o)
 {
@@ -7063,10 +7058,23 @@ mono_object_get_size_internal (MonoObject* o)
 	}
 }
 
+/**
+ * mono_object_get_size:
+ * \param o object to query
+ * \returns the size, in bytes, of \p o
+ */
 unsigned
 mono_object_get_size (MonoObject *o)
 {
 	MONO_EXTERNAL_ONLY (unsigned, mono_object_get_size_internal (o));
+}
+
+gpointer
+mono_object_unbox_internal (MonoObject *obj)
+{
+	/* add assert for valuetypes? */
+	g_assert (m_class_is_valuetype (mono_object_class (obj)));
+	return mono_object_get_data (obj);
 }
 
 /**
@@ -7077,14 +7085,6 @@ mono_object_get_size (MonoObject *o)
  *
  * This method will assert if the object passed is not a valuetype.
  */
-gpointer
-mono_object_unbox_internal (MonoObject *obj)
-{
-	/* add assert for valuetypes? */
-	g_assert (m_class_is_valuetype (mono_object_class (obj)));
-	return mono_object_get_data (obj);
-}
-
 void*
 mono_object_unbox (MonoObject *obj)
 {
@@ -7266,7 +7266,7 @@ leave:
 /**
  * mono_object_castclass_mbyref:
  * \param obj an object
- * \param klass a pointer to a class 
+ * \param klass a pointer to a class
  * \returns \p obj if \p obj is derived from \p klass, returns NULL otherwise.
  */
 MonoObject *
@@ -7348,11 +7348,6 @@ mono_string_is_interned_lookup (MonoString *str, int insert, MonoError *error)
 	return NULL;
 }
 
-/**
- * mono_string_is_interned:
- * \param o String to probe
- * \returns Whether the string has been interned.
- */
 MonoString*
 mono_string_is_interned_internal (MonoString *o)
 {
@@ -7363,6 +7358,11 @@ mono_string_is_interned_internal (MonoString *o)
 	return result;
 }
 
+/**
+ * mono_string_is_interned:
+ * \param o String to probe
+ * \returns Whether the string has been interned.
+ */
 MonoString*
 mono_string_is_interned (MonoString *str)
 {
@@ -7372,7 +7372,7 @@ mono_string_is_interned (MonoString *str)
 /**
  * mono_string_intern:
  * \param o String to intern
- * Interns the string passed.  
+ * Interns the string passed.
  * \returns The interned string.
  */
 MonoString*
@@ -7626,14 +7626,6 @@ mono_utf16_to_utf8 (const gunichar2 *s, gsize slength, MonoError *error)
 	return as;
 }
 
-/**
- * mono_string_to_utf8_checked:
- * \param s a \c System.String
- * \param error a \c MonoError.
- * Converts a \c MonoString to its UTF-8 representation. May fail; check
- * \p error to determine whether the conversion was successful.
- * The resulting buffer should be freed with \c mono_free().
- */
 char *
 mono_string_to_utf8_checked_internal (MonoString *s, MonoError *error)
 {
@@ -7650,6 +7642,14 @@ mono_string_to_utf8_checked_internal (MonoString *s, MonoError *error)
 	return mono_utf16_to_utf8 (mono_string_chars_internal (s), s->length, error);
 }
 
+/**
+ * mono_string_to_utf8_checked:
+ * \param s a \c System.String
+ * \param error a \c MonoError.
+ * Converts a \c MonoString to its UTF-8 representation. May fail; check
+ * \p error to determine whether the conversion was successful.
+ * The resulting buffer should be freed with \c mono_free().
+ */
 char*
 mono_string_to_utf8_checked (MonoString *string_obj, MonoError *error)
 {
@@ -7697,14 +7697,6 @@ mono_string_to_utf8_ignore (MonoString *s)
 	return as;
 }
 
-/**
- * mono_string_to_utf16:
- * \param s a \c MonoString
- * \returns a null-terminated array of the UTF-16 chars
- * contained in \p s. The result must be freed with \c g_free().
- * This is a temporary helper until our string implementation
- * is reworked to always include the null-terminating char.
- */
 mono_unichar2*
 mono_string_to_utf16_internal (MonoString *s)
 {
@@ -7723,18 +7715,20 @@ mono_string_to_utf16_internal (MonoString *s)
 	return as;
 }
 
+/**
+ * mono_string_to_utf16:
+ * \param s a \c MonoString
+ * \returns a null-terminated array of the UTF-16 chars
+ * contained in \p s. The result must be freed with \c g_free().
+ * This is a temporary helper until our string implementation
+ * is reworked to always include the null-terminating char.
+ */
 mono_unichar2*
 mono_string_to_utf16 (MonoString *string_obj)
 {
 	MONO_EXTERNAL_ONLY (mono_unichar2*, mono_string_to_utf16_internal (string_obj));
 }
 
-/**
- * mono_string_to_utf32:
- * \param s a \c MonoString
- * \returns a null-terminated array of the UTF-32 (UCS-4) chars
- * contained in \p s. The result must be freed with \c g_free().
- */
 mono_unichar4*
 mono_string_to_utf32_internal (MonoString *s)
 {
@@ -7746,6 +7740,12 @@ mono_string_to_utf32_internal (MonoString *s)
 	return g_utf16_to_ucs4 (s->chars, s->length, NULL, NULL, NULL);
 }
 
+/**
+ * mono_string_to_utf32:
+ * \param s a \c MonoString
+ * \returns a null-terminated array of the UTF-32 (UCS-4) chars
+ * contained in \p s. The result must be freed with \c g_free().
+ */
 mono_unichar4*
 mono_string_to_utf32 (MonoString *string_obj)
 {
@@ -7911,14 +7911,8 @@ mono_get_eh_callbacks (void)
 	return &eh_callbacks;
 }
 
-/**
- * mono_raise_exception:
- * \param ex exception object
- * Signal the runtime that the exception \p ex has been raised in unmanaged code.
- * DEPRECATED. DO NOT ADD NEW CALLERS FOR THIS FUNCTION.
- */
 void
-mono_raise_exception_internal (MonoException *ex) 
+mono_raise_exception_internal (MonoException *ex)
 {
 	/* raise_exception doesn't return, so the transition to GC Unsafe is unbalanced */
 	MONO_STACKDATA (stackdata);
@@ -7926,8 +7920,14 @@ mono_raise_exception_internal (MonoException *ex)
 	mono_raise_exception_deprecated (ex);
 }
 
+/**
+ * mono_raise_exception:
+ * \param ex exception object
+ * Signal the runtime that the exception \p ex has been raised in unmanaged code.
+ * DEPRECATED. DO NOT ADD NEW CALLERS FOR THIS FUNCTION.
+ */
 void
-mono_raise_exception (MonoException *ex) 
+mono_raise_exception (MonoException *ex)
 {
 	MONO_EXTERNAL_ONLY_VOID (mono_raise_exception_internal (ex));
 }
@@ -8983,11 +8983,6 @@ mono_get_addr_from_ftnptr (gpointer descr)
 	return callbacks.get_addr_from_ftnptr (descr);
 }	
 
-/**
- * mono_string_chars:
- * \param s a \c MonoString
- * \returns a pointer to the UTF-16 characters stored in the \c MonoString
- */
 gunichar2 *
 mono_string_chars_internal (MonoString *s)
 {
@@ -8996,17 +8991,17 @@ mono_string_chars_internal (MonoString *s)
 	return s->chars;
 }
 
+/**
+ * mono_string_chars:
+ * \param s a \c MonoString
+ * \returns a pointer to the UTF-16 characters stored in the \c MonoString
+ */
 mono_unichar2*
 mono_string_chars (MonoString *s)
 {
 	MONO_EXTERNAL_ONLY (mono_unichar2*, mono_string_chars_internal (s));
 }
 
-/**
- * mono_string_length:
- * \param s MonoString
- * \returns the length in characters of the string
- */
 int
 mono_string_length_internal (MonoString *s)
 {
@@ -9015,6 +9010,11 @@ mono_string_length_internal (MonoString *s)
 	return s->length;
 }
 
+/**
+ * mono_string_length:
+ * \param s MonoString
+ * \returns the length in characters of the string
+ */
 int
 mono_string_length (MonoString *s)
 {
@@ -9064,7 +9064,7 @@ mono_array_addr_with_size (MonoArray *array, int size, uintptr_t idx)
 }
 
 MonoArray *
-mono_glist_to_array (GList *list, MonoClass *eclass, MonoError *error) 
+mono_glist_to_array (GList *list, MonoClass *eclass, MonoError *error)
 {
 	MonoDomain *domain = mono_domain_get ();
 	MonoArray *res;

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -57,11 +57,6 @@
 #include "external-only.h"
 #include "monitor.h"
 
-// Exports do not work portably/reliably if compiled separately.
-// They must be in .o/.obj files otherwise referenced.
-// .def files work better in this regard.
-#include "external-only.c"
-
 static void
 get_default_field_value (MonoDomain* domain, MonoClassField *field, void *value, MonoError *error);
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -113,7 +113,7 @@ mono_runtime_object_init (MonoObject *this_obj)
 }
 
 /**
- * mono_runtime_object_init_checked:
+ * mono_runtime_object_init_handle:
  * \param this_obj the object to initialize
  * \param error set on error.
  * This function calls the zero-argument constructor (which must

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -67,8 +67,8 @@ typedef void	    (*MonoMainThreadFunc)    (void* user_data);
 		mono_gc_wbarrier_arrayref_copy (__p, __s, (count));	\
 	} while (0)
 
-MONO_API mono_unichar2 *mono_string_chars  (MonoString *s);
-MONO_API int            mono_string_length (MonoString *s);
+MONO_API MONO_RT_EXTERNAL_ONLY mono_unichar2 *mono_string_chars  (MonoString *s);
+MONO_API MONO_RT_EXTERNAL_ONLY int            mono_string_length (MonoString *s);
 
 MONO_API MONO_RT_EXTERNAL_ONLY MonoObject *
 mono_object_new		    (MonoDomain *domain, MonoClass *klass);
@@ -107,13 +107,13 @@ MONO_API MONO_RT_EXTERNAL_ONLY
 MonoArray*
 mono_array_clone	    (MonoArray *array);
 
-MONO_API char*
+MONO_API MONO_RT_EXTERNAL_ONLY char*
 mono_array_addr_with_size   (MonoArray *array, int size, uintptr_t idx);
 
 MONO_API MONO_RT_EXTERNAL_ONLY uintptr_t
 mono_array_length           (MonoArray *array);
 
-MONO_API MonoString*
+MONO_API MONO_RT_EXTERNAL_ONLY MonoString*
 mono_string_empty	      (MonoDomain *domain);
 
 MONO_API MONO_RT_EXTERNAL_ONLY
@@ -132,7 +132,7 @@ MONO_API MONO_RT_EXTERNAL_ONLY
 MonoString*
 mono_ldstr		    (MonoDomain *domain, MonoImage *image, uint32_t str_index);
 
-MONO_API MonoString*
+MONO_API MONO_RT_EXTERNAL_ONLY MonoString*
 mono_string_is_interned	    (MonoString *str);
 
 MONO_API MONO_RT_EXTERNAL_ONLY
@@ -143,7 +143,7 @@ MONO_API MONO_RT_EXTERNAL_ONLY
 MonoString*
 mono_string_new		    (MonoDomain *domain, const char *text);
 
-MONO_API MonoString*
+MONO_API MONO_RT_EXTERNAL_ONLY MonoString*
 mono_string_new_wrapper	    (const char *text);
 
 MONO_API MONO_RT_EXTERNAL_ONLY
@@ -158,13 +158,13 @@ MONO_API MONO_RT_EXTERNAL_ONLY
 char *
 mono_string_to_utf8	    (MonoString *string_obj);
 
-MONO_API char *
+MONO_API MONO_RT_EXTERNAL_ONLY char *
 mono_string_to_utf8_checked (MonoString *string_obj, MonoError *error);
 
-MONO_API mono_unichar2 *
+MONO_API MONO_RT_EXTERNAL_ONLY mono_unichar2 *
 mono_string_to_utf16	    (MonoString *string_obj);
 
-MONO_API mono_unichar4 *
+MONO_API MONO_RT_EXTERNAL_ONLY mono_unichar4 *
 mono_string_to_utf32	    (MonoString *string_obj);
 
 MONO_API MONO_RT_EXTERNAL_ONLY MonoString *
@@ -173,13 +173,13 @@ mono_string_from_utf16	    (/*const*/ mono_unichar2 *data);
 MONO_API MONO_RT_EXTERNAL_ONLY MonoString *
 mono_string_from_utf32	    (/*const*/ mono_unichar4 *data);
 
-MONO_API mono_bool
+MONO_API MONO_RT_EXTERNAL_ONLY mono_bool
 mono_string_equal           (MonoString *s1, MonoString *s2);
 
-MONO_API unsigned int
+MONO_API MONO_RT_EXTERNAL_ONLY unsigned int
 mono_string_hash            (MonoString *s);
 
-MONO_API int
+MONO_API MONO_RT_EXTERNAL_ONLY int
 mono_object_hash            (MonoObject* obj);
 
 MONO_API MONO_RT_EXTERNAL_ONLY
@@ -189,22 +189,22 @@ mono_object_to_string (MonoObject *obj, MonoObject **exc);
 MONO_API MONO_RT_EXTERNAL_ONLY MonoObject *
 mono_value_box		    (MonoDomain *domain, MonoClass *klass, void* val);
 
-MONO_API void
+MONO_API MONO_RT_EXTERNAL_ONLY void
 mono_value_copy             (void* dest, /*const*/ void* src, MonoClass *klass);
 
-MONO_API void
+MONO_API MONO_RT_EXTERNAL_ONLY void
 mono_value_copy_array       (MonoArray *dest, int dest_idx, void* src, int count);
 
-MONO_API MonoVTable *
+MONO_API MONO_RT_EXTERNAL_ONLY MonoVTable*
 mono_object_get_vtable      (MonoObject *obj);
 
-MONO_API MonoDomain*
+MONO_API MONO_RT_EXTERNAL_ONLY MonoDomain*
 mono_object_get_domain      (MonoObject *obj);
 
 MONO_API MONO_RT_EXTERNAL_ONLY MonoClass*
 mono_object_get_class       (MonoObject *obj);
 
-MONO_API void*
+MONO_API MONO_RT_EXTERNAL_ONLY void*
 mono_object_unbox	    (MonoObject *obj);
 
 MONO_API MONO_RT_EXTERNAL_ONLY MonoObject *
@@ -219,19 +219,19 @@ mono_object_isinst_mbyref   (MonoObject *obj, MonoClass *klass);
 MONO_API MONO_RT_EXTERNAL_ONLY MonoObject *
 mono_object_castclass_mbyref (MonoObject *obj, MonoClass *klass);
 
-MONO_API mono_bool 
+MONO_API MONO_RT_EXTERNAL_ONLY mono_bool
 mono_monitor_try_enter       (MonoObject *obj, uint32_t ms);
 
-MONO_API mono_bool
+MONO_API MONO_RT_EXTERNAL_ONLY mono_bool
 mono_monitor_enter           (MonoObject *obj);
 
-MONO_API void
+MONO_API MONO_RT_EXTERNAL_ONLY void
 mono_monitor_enter_v4        (MonoObject *obj, char *lock_taken);
 
-MONO_API unsigned int
+MONO_API MONO_RT_EXTERNAL_ONLY unsigned int
 mono_object_get_size         (MonoObject *o);
 
-MONO_API void 
+MONO_API MONO_RT_EXTERNAL_ONLY void
 mono_monitor_exit            (MonoObject *obj);
 
 MONO_API MONO_RT_EXTERNAL_ONLY void
@@ -249,30 +249,30 @@ mono_runtime_object_init    (MonoObject *this_obj);
 MONO_API MONO_RT_EXTERNAL_ONLY void
 mono_runtime_class_init	    (MonoVTable *vtable);
 
-MONO_API MonoDomain *
+MONO_API MONO_RT_EXTERNAL_ONLY MonoDomain*
 mono_vtable_domain          (MonoVTable *vtable);
 
-MONO_API MonoClass *
+MONO_API MONO_RT_EXTERNAL_ONLY MonoClass*
 mono_vtable_class           (MonoVTable *vtable);
 
-MONO_API MonoMethod*
+MONO_API MONO_RT_EXTERNAL_ONLY MonoMethod*
 mono_object_get_virtual_method (MonoObject *obj, MonoMethod *method);
 
 MONO_API MONO_RT_EXTERNAL_ONLY MonoObject*
 mono_runtime_invoke	    (MonoMethod *method, void *obj, void **params,
 			     MonoObject **exc);
 
-MONO_API MonoMethod *
+MONO_API MONO_RT_EXTERNAL_ONLY MonoMethod*
 mono_get_delegate_invoke    (MonoClass *klass);
 
-MONO_API MonoMethod *
+MONO_API MONO_RT_EXTERNAL_ONLY MonoMethod*
 mono_get_delegate_begin_invoke (MonoClass *klass);
 
-MONO_API MonoMethod *
+MONO_API MONO_RT_EXTERNAL_ONLY MonoMethod*
 mono_get_delegate_end_invoke (MonoClass *klass);
 
 MONO_API MONO_RT_EXTERNAL_ONLY MonoObject*
-mono_runtime_delegate_invoke (MonoObject *delegate, void **params, 
+mono_runtime_delegate_invoke (MonoObject *delegate, void **params,
 			      MonoObject **exc);
 
 MONO_API MONO_RT_EXTERNAL_ONLY MonoObject*
@@ -285,7 +285,7 @@ mono_method_get_unmanaged_thunk (MonoMethod *method);
 MONO_API MONO_RT_EXTERNAL_ONLY MonoArray*
 mono_runtime_get_main_args  (void);
 
-MONO_API void
+MONO_API MONO_RT_EXTERNAL_ONLY void
 mono_runtime_exec_managed_code (MonoDomain *domain,
 				MonoMainThreadFunc main_func,
 				void* main_args);
@@ -298,7 +298,7 @@ MONO_API MONO_RT_EXTERNAL_ONLY int
 mono_runtime_exec_main	    (MonoMethod *method, MonoArray *args,
 			     MonoObject **exc);
 
-MONO_API int
+MONO_API MONO_RT_EXTERNAL_ONLY int
 mono_runtime_set_main_args  (int argc, char* argv[]);
 
 /* The following functions won't be available with mono was configured with remoting disabled. */
@@ -317,10 +317,10 @@ mono_store_remote_field_new (MonoObject *this_obj, MonoClass *klass, MonoClassFi
 
 /* #endif */
 
-MONO_API void
+MONO_API MONO_RT_EXTERNAL_ONLY void
 mono_unhandled_exception    (MonoObject *exc);
 
-MONO_API void
+MONO_API MONO_RT_EXTERNAL_ONLY void
 mono_print_unhandled_exception (MonoObject *exc);
 
 MONO_API MONO_RT_EXTERNAL_ONLY
@@ -328,13 +328,13 @@ void*
 mono_compile_method	   (MonoMethod *method);
 
 /* accessors for fields and properties */
-MONO_API void
+MONO_API MONO_RT_EXTERNAL_ONLY void
 mono_field_set_value (MonoObject *obj, MonoClassField *field, void *value);
 
-MONO_API void
+MONO_API MONO_RT_EXTERNAL_ONLY void
 mono_field_static_set_value (MonoVTable *vt, MonoClassField *field, void *value);
 
-MONO_API void
+MONO_API MONO_RT_EXTERNAL_ONLY void
 mono_field_get_value (MonoObject *obj, MonoClassField *field, void *value);
 
 MONO_API MONO_RT_EXTERNAL_ONLY void
@@ -349,7 +349,7 @@ mono_property_set_value (MonoProperty *prop, void *obj, void **params, MonoObjec
 MONO_API MONO_RT_EXTERNAL_ONLY MonoObject*
 mono_property_get_value (MonoProperty *prop, void *obj, void **params, MonoObject **exc);
 
-/* GC handles support 
+/* GC handles support
  *
  * A handle can be created to refer to a managed object and either prevent it
  * from being garbage collected or moved or to be able to know if it has been 
@@ -363,10 +363,10 @@ mono_property_get_value (MonoProperty *prop, void *obj, void **params, MonoObjec
  * mono_gchandle_get_target () can be used to get the object referenced by both kinds
  * of handle: for a weakref handle, if an object has been collected, it will return NULL.
  */
-MONO_API uint32_t      mono_gchandle_new         (MonoObject *obj, mono_bool pinned);
-MONO_API uint32_t      mono_gchandle_new_weakref (MonoObject *obj, mono_bool track_resurrection);
-MONO_API MonoObject*  mono_gchandle_get_target  (uint32_t gchandle);
-MONO_API void         mono_gchandle_free        (uint32_t gchandle);
+MONO_API MONO_RT_EXTERNAL_ONLY uint32_t     mono_gchandle_new         (MonoObject *obj, mono_bool pinned);
+MONO_API MONO_RT_EXTERNAL_ONLY uint32_t     mono_gchandle_new_weakref (MonoObject *obj, mono_bool track_resurrection);
+MONO_API MONO_RT_EXTERNAL_ONLY MonoObject*  mono_gchandle_get_target  (uint32_t gchandle);
+MONO_API MONO_RT_EXTERNAL_ONLY void         mono_gchandle_free        (uint32_t gchandle);
 
 /* Reference queue support
  *
@@ -380,25 +380,20 @@ MONO_API void         mono_gchandle_free        (uint32_t gchandle);
 typedef void (*mono_reference_queue_callback) (void *user_data);
 typedef struct _MonoReferenceQueue MonoReferenceQueue;
 
-MONO_API MonoReferenceQueue* mono_gc_reference_queue_new (mono_reference_queue_callback callback);
-MONO_API void mono_gc_reference_queue_free (MonoReferenceQueue *queue);
-MONO_API mono_bool mono_gc_reference_queue_add (MonoReferenceQueue *queue, MonoObject *obj, void *user_data);
-
-#define mono_gc_reference_queue_add_handle(queue, obj, user_data) \
-	(mono_gc_reference_queue_add ((queue), MONO_HANDLE_RAW (MONO_HANDLE_CAST (MonoObject, obj)), (user_data)))
-
+MONO_API MONO_RT_EXTERNAL_ONLY MonoReferenceQueue* mono_gc_reference_queue_new (mono_reference_queue_callback callback);
+MONO_API MONO_RT_EXTERNAL_ONLY void mono_gc_reference_queue_free (MonoReferenceQueue *queue);
+MONO_API MONO_RT_EXTERNAL_ONLY mono_bool mono_gc_reference_queue_add (MonoReferenceQueue *queue, MonoObject *obj, void *user_data);
 
 /* GC write barriers support */
-MONO_API void mono_gc_wbarrier_set_field     (MonoObject *obj, void* field_ptr, MonoObject* value);
-MONO_API void mono_gc_wbarrier_set_arrayref  (MonoArray *arr, void* slot_ptr, MonoObject* value);
-MONO_API void mono_gc_wbarrier_arrayref_copy (void* dest_ptr, void* src_ptr, int count);
-MONO_API void mono_gc_wbarrier_generic_store (void* ptr, MonoObject* value);
-MONO_API void mono_gc_wbarrier_generic_store_atomic (void *ptr, MonoObject *value);
-MONO_API void mono_gc_wbarrier_generic_nostore (void* ptr);
-MONO_API void mono_gc_wbarrier_value_copy    (void* dest, /*const*/ void* src, int count, MonoClass *klass);
-MONO_API void mono_gc_wbarrier_object_copy   (MonoObject* obj, MonoObject *src);
+MONO_API MONO_RT_EXTERNAL_ONLY void mono_gc_wbarrier_set_field     (MonoObject *obj, void* field_ptr, MonoObject* value);
+MONO_API MONO_RT_EXTERNAL_ONLY void mono_gc_wbarrier_set_arrayref  (MonoArray *arr, void* slot_ptr, MonoObject* value);
+MONO_API MONO_RT_EXTERNAL_ONLY void mono_gc_wbarrier_arrayref_copy (void* dest_ptr, void* src_ptr, int count);
+MONO_API MONO_RT_EXTERNAL_ONLY void mono_gc_wbarrier_generic_store (void* ptr, MonoObject* value);
+MONO_API MONO_RT_EXTERNAL_ONLY void mono_gc_wbarrier_generic_store_atomic (void *ptr, MonoObject *value);
+MONO_API MONO_RT_EXTERNAL_ONLY void mono_gc_wbarrier_generic_nostore (void* ptr);
+MONO_API MONO_RT_EXTERNAL_ONLY void mono_gc_wbarrier_value_copy    (void* dest, /*const*/ void* src, int count, MonoClass *klass);
+MONO_API MONO_RT_EXTERNAL_ONLY void mono_gc_wbarrier_object_copy   (MonoObject* obj, MonoObject *src);
 
 MONO_END_DECLS
 
 #endif
-

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -114,7 +114,7 @@ mono_class_get_ref_info_raw (MonoClass *klass)
 
 	if (ref_info_handle == 0)
 		return NULL;
-	return (MonoReflectionTypeBuilder*)mono_gchandle_get_target (ref_info_handle);
+	return (MonoReflectionTypeBuilder*)mono_gchandle_get_target_internal (ref_info_handle);
 }
 
 void
@@ -127,7 +127,7 @@ mono_class_set_ref_info (MonoClass *klass, MonoObjectHandle obj)
 	++class_ref_info_handle_count;
 
 	if (handle != candidate)
-		mono_gchandle_free (candidate);
+		mono_gchandle_free_internal (candidate);
 }
 
 void
@@ -137,7 +137,7 @@ mono_class_free_ref_info (MonoClass *klass)
 	guint32 handle = mono_class_get_ref_info_handle (klass);
 
 	if (handle) {
-		mono_gchandle_free (handle);
+		mono_gchandle_free_internal (handle);
 		mono_class_set_ref_info_handle (klass, 0);
 	}
 }
@@ -1263,7 +1263,7 @@ method_body_object_construct (MonoDomain *domain, MonoClass *unused_class, MonoM
 	guint8* il_data;
 	il_data = MONO_ARRAY_HANDLE_PIN (il_arr, guint8, 0, &il_gchandle);
 	memcpy (il_data, header->code, header->code_size);
-	mono_gchandle_free (il_gchandle);
+	mono_gchandle_free_internal (il_gchandle);
 
 	/* Locals */
 	MonoArrayHandle locals_arr;
@@ -3012,7 +3012,7 @@ mono_reflection_call_is_assignable_to (MonoClass *klass, MonoClass *oklass, Mono
 		mono_error_cleanup (&inner_error);
 		return FALSE;
 	} else
-		return *(MonoBoolean*)mono_object_unbox (res);
+		return *(MonoBoolean*)mono_object_unbox_internal (res);
 }
 
 /**

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -427,7 +427,7 @@ mono_remoting_wrapper (MonoMethod *method, gpointer *params)
 			}
 		}
 
-		res = mono_runtime_invoke_checked (method, m_class_is_valuetype (method->klass)? mono_object_unbox ((MonoObject*)this_obj): this_obj, mparams, error);
+		res = mono_runtime_invoke_checked (method, m_class_is_valuetype (method->klass)? mono_object_unbox_internal ((MonoObject*)this_obj): this_obj, mparams, error);
 		goto_if_nok (error, fail);
 
 		return res;
@@ -583,11 +583,11 @@ mono_marshal_xdomain_copy_out_value (MonoObject *src, MonoObject *dst)
 		if (mt == MONO_MARSHAL_COPY) {
 			int i, len = mono_array_length_internal ((MonoArray *)dst);
 			for (i = 0; i < len; i++) {
-				MonoObject *item = (MonoObject *)mono_array_get ((MonoArray *)src, gpointer, i);
+				MonoObject *item = (MonoObject *)mono_array_get_internal ((MonoArray *)src, gpointer, i);
 				MonoObject *item_copy = mono_marshal_xdomain_copy_value (item, error);
 				if (mono_error_set_pending_exception (error))
 					return;
-				mono_array_setref ((MonoArray *)dst, i, item_copy);
+				mono_array_setref_internal ((MonoArray *)dst, i, item_copy);
 			}
 		} else {
 			mono_array_full_copy ((MonoArray *)src, (MonoArray *)dst);
@@ -2073,7 +2073,7 @@ mono_marshal_xdomain_copy_value_handle (MonoObjectHandle val, MonoError *error)
 	case MONO_TYPE_R8: {
 		uint32_t gchandle = mono_gchandle_from_handle (val, TRUE);
 		MonoObjectHandle res = MONO_HANDLE_NEW (MonoObject, mono_value_box_checked (domain, klass, ((char*)MONO_HANDLE_RAW (val)) + sizeof(MonoObject), error)); /* FIXME use handles in mono_value_box_checked */
-		mono_gchandle_free (gchandle);
+		mono_gchandle_free_internal (gchandle);
 		goto_if_nok (error, leave);
 		MONO_HANDLE_ASSIGN (result, res);
 		break;
@@ -2081,8 +2081,8 @@ mono_marshal_xdomain_copy_value_handle (MonoObjectHandle val, MonoError *error)
 	case MONO_TYPE_STRING: {
 		MonoStringHandle str = MONO_HANDLE_CAST (MonoString, val);
 		uint32_t gchandle = mono_gchandle_from_handle (val, TRUE);
-		MonoStringHandle res = mono_string_new_utf16_handle (domain, mono_string_chars (MONO_HANDLE_RAW (str)), mono_string_handle_length (str), error);
-		mono_gchandle_free (gchandle);
+		MonoStringHandle res = mono_string_new_utf16_handle (domain, mono_string_chars_internal (MONO_HANDLE_RAW (str)), mono_string_handle_length (str), error);
+		mono_gchandle_free_internal (gchandle);
 		goto_if_nok (error, leave);
 		MONO_HANDLE_ASSIGN (result, res);
 		break;

--- a/mono/metadata/sgen-bridge.c
+++ b/mono/metadata/sgen-bridge.c
@@ -560,7 +560,7 @@ static gboolean
 test_scc (MonoGCBridgeSCC *scc, int i)
 {
 	int status = BRIDGE_DEAD;
-	mono_field_get_value (scc->objs [i], mono_bridge_test_field, &status);
+	mono_field_get_value_internal (scc->objs [i], mono_bridge_test_field, &status);
 	return status > 0;
 }
 
@@ -571,7 +571,7 @@ mark_scc (MonoGCBridgeSCC *scc, int value)
 	for (i = 0; i < scc->num_objs; ++i) {
 		if (!test_scc (scc, i)) {
 			int status = value;
-			mono_field_set_value (scc->objs [i], mono_bridge_test_field, &status);
+			mono_field_set_value_internal (scc->objs [i], mono_bridge_test_field, &status);
 		}
 	}
 }
@@ -602,7 +602,7 @@ bridge_test_cross_reference2 (int num_sccs, MonoGCBridgeSCC **sccs, int num_xref
 		for (j = 0; j < sccs [i]->num_objs; ++j) {
 			if (!test_scc (sccs [i], j)) {
 				int status = BRIDGE_SAME_SCC;
-				mono_field_set_value (sccs [i]->objs [j], mono_bridge_test_field, &status);
+				mono_field_set_value_internal (sccs [i]->objs [j], mono_bridge_test_field, &status);
 			}
 		}
 	}

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -129,7 +129,7 @@ mono_gc_wbarrier_value_copy_internal (gpointer dest, gpointer src, int count, Mo
 }
 
 /**
- * mono_gc_wbarrier_object_copy:
+ * mono_gc_wbarrier_object_copy_internal:
  *
  * Write barrier to call when \p obj is the result of a clone or copy of an object.
  */
@@ -157,7 +157,7 @@ mono_gc_wbarrier_object_copy_internal (MonoObject* obj, MonoObject *src)
 }
 
 /**
- * mono_gc_wbarrier_set_arrayref:
+ * mono_gc_wbarrier_set_arrayref_internal:
  */
 void
 mono_gc_wbarrier_set_arrayref_internal (MonoArray *arr, gpointer slot_ptr, MonoObject* value)
@@ -175,7 +175,7 @@ mono_gc_wbarrier_set_arrayref_internal (MonoArray *arr, gpointer slot_ptr, MonoO
 }
 
 /**
- * mono_gc_wbarrier_set_field:
+ * mono_gc_wbarrier_set_field_internal:
  */
 void
 mono_gc_wbarrier_set_field_internal (MonoObject *obj, gpointer field_ptr, MonoObject* value)

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -985,7 +985,7 @@ static gboolean use_managed_allocator = TRUE;
 
 #ifdef MANAGED_ALLOCATION
 /* FIXME: Do this in the JIT, where specialized allocation sequences can be created
- * for each class. This is currently not easy to do, as it is hard to generate basic 
+ * for each class. This is currently not easy to do, as it is hard to generate basic
  * blocks + branches, but it is easy with the linear IL codebase.
  *
  * For this to work we'd need to solve the TLAB race, first.  Now we
@@ -2273,7 +2273,7 @@ sgen_client_scan_thread_data (void *start_nursery, void *end_nursery, gboolean p
 /*
  * mono_gc_set_stack_end:
  *
- *   Set the end of the current threads stack to STACK_END. The stack space between 
+ *   Set the end of the current threads stack to STACK_END. The stack space between
  * STACK_END and the real end of the threads stack will not be scanned during collections.
  */
 void
@@ -2505,18 +2505,18 @@ sgen_client_metadata_for_object (GCObject *obj)
 }
 
 /**
- * mono_gchandle_new:
+ * mono_gchandle_new_internal:
  * \param obj managed object to get a handle for
  * \param pinned whether the object should be pinned
  * This returns a handle that wraps the object, this is used to keep a
  * reference to a managed object from the unmanaged world and preventing the
  * object from being disposed.
- * 
+ *
  * If \p pinned is false the address of the object can not be obtained, if it is
  * true the address of the object can be obtained.  This will also pin the
  * object so it will not be possible by a moving garbage collector to move the
- * object. 
- * 
+ * object.
+ *
  * \returns a handle that can be used to access the object from unmanaged code.
  */
 guint32
@@ -2526,7 +2526,7 @@ mono_gchandle_new_internal (MonoObject *obj, gboolean pinned)
 }
 
 /**
- * mono_gchandle_new_weakref:
+ * mono_gchandle_new_weakref_internal:
  * \param obj managed object to get a handle for
  * \param track_resurrection Determines how long to track the object, if this is set to TRUE, the object is tracked after finalization, if FALSE, the object is only tracked up until the point of finalization.
  *
@@ -2535,14 +2535,14 @@ mono_gchandle_new_internal (MonoObject *obj, gboolean pinned)
  * Unlike the \c mono_gchandle_new_internal the object can be reclaimed by the
  * garbage collector.  In this case the value of the GCHandle will be
  * set to zero.
- * 
+ *
  * If \p track_resurrection is TRUE the object will be tracked through
  * finalization and if the object is resurrected during the execution
  * of the finalizer, then the returned weakref will continue to hold
  * a reference to the object.   If \p track_resurrection is FALSE, then
  * the weak reference's target will become NULL as soon as the object
  * is passed on to the finalizer.
- * 
+ *
  * \returns a handle that can be used to access the object from
  * unmanaged code.
  */
@@ -2566,12 +2566,12 @@ mono_gchandle_is_in_domain (guint32 gchandle, MonoDomain *domain)
 }
 
 /**
- * mono_gchandle_free:
+ * mono_gchandle_free_internal:
  * \param gchandle a GCHandle's handle.
  *
  * Frees the \p gchandle handle.  If there are no outstanding
  * references, the garbage collector can reclaim the memory of the
- * object wrapped. 
+ * object wrapped.
  */
 void
 mono_gchandle_free_internal (guint32 gchandle)
@@ -2596,7 +2596,7 @@ mono_gchandle_free_domain (MonoDomain *unloading)
  * \param gchandle a GCHandle's handle.
  *
  * The handle was previously created by calling \c mono_gchandle_new_internal or
- * \c mono_gchandle_new_weakref. 
+ * \c mono_gchandle_new_weakref.
  *
  * \returns a pointer to the \c MonoObject* represented by the handle or
  * NULL for a collected object if using a weakref handle.

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -294,7 +294,7 @@ mono_reflection_method_count_clauses (MonoReflectionILGen *ilgen)
 
 	MonoILExceptionInfo *ex_info;
 	for (i = 0; i < mono_array_length_internal (ilgen->ex_handlers); ++i) {
-		ex_info = (MonoILExceptionInfo*)mono_array_addr (ilgen->ex_handlers, MonoILExceptionInfo, i);
+		ex_info = (MonoILExceptionInfo*)mono_array_addr_internal (ilgen->ex_handlers, MonoILExceptionInfo, i);
 		if (ex_info->handlers)
 			num_clauses += mono_array_length_internal (ex_info->handlers);
 		else
@@ -323,12 +323,12 @@ method_encode_clauses (MonoImage *image, MonoDynamicImage *assembly, MonoReflect
 
 	clause_index = 0;
 	for (i = mono_array_length_internal (ilgen->ex_handlers) - 1; i >= 0; --i) {
-		ex_info = (MonoILExceptionInfo*)mono_array_addr (ilgen->ex_handlers, MonoILExceptionInfo, i);
+		ex_info = (MonoILExceptionInfo*)mono_array_addr_internal (ilgen->ex_handlers, MonoILExceptionInfo, i);
 		finally_start = ex_info->start + ex_info->len;
 		if (!ex_info->handlers)
 			continue;
 		for (j = 0; j < mono_array_length_internal (ex_info->handlers); ++j) {
-			ex_block = (MonoILExceptionBlock*)mono_array_addr (ex_info->handlers, MonoILExceptionBlock, j);
+			ex_block = (MonoILExceptionBlock*)mono_array_addr_internal (ex_info->handlers, MonoILExceptionBlock, j);
 			clause = &(clauses [clause_index]);
 
 			clause->flags = ex_block->type;
@@ -1023,12 +1023,12 @@ mono_image_insert_string (MonoReflectionModuleBuilderHandle ref_module, MonoStri
 	g_assert (assembly != NULL);
 
 	if (assembly->save) {
-		int32_t length = mono_string_length (MONO_HANDLE_RAW (str));
+		int32_t length = mono_string_length_internal (MONO_HANDLE_RAW (str));
 		mono_metadata_encode_value (1 | (length * 2), b, &b);
 		idx = mono_image_add_stream_data (&assembly->us, buf, b-buf);
 		/* pinned */
 		uint32_t gchandle = mono_gchandle_from_handle (MONO_HANDLE_CAST (MonoObject, str), TRUE);
-		const char *p = (const char*)mono_string_chars (MONO_HANDLE_RAW (str));
+		const char *p = (const char*)mono_string_chars_internal (MONO_HANDLE_RAW (str));
 #if G_BYTE_ORDER != G_LITTLE_ENDIAN
 	{
 		char *swapped = g_malloc (2 * length);
@@ -1040,7 +1040,7 @@ mono_image_insert_string (MonoReflectionModuleBuilderHandle ref_module, MonoStri
 #else
 		mono_image_add_stream_data (&assembly->us, p, length * 2);
 #endif
-		mono_gchandle_free (gchandle);
+		mono_gchandle_free_internal (gchandle);
 		mono_image_add_stream_data (&assembly->us, "", 1);
 	} else {
 		idx = assembly->us.index ++;
@@ -1323,18 +1323,18 @@ mono_reflection_dynimage_basic_init (MonoReflectionAssemblyBuilder *assemblyb)
 	assembly->assembly.dynamic = TRUE;
 	assembly->assembly.corlib_internal = assemblyb->corlib_internal;
 	assemblyb->assembly.assembly = (MonoAssembly*)assembly;
-	assembly->assembly.basedir = mono_string_to_utf8_checked (assemblyb->dir, error);
+	assembly->assembly.basedir = mono_string_to_utf8_checked_internal (assemblyb->dir, error);
 	if (mono_error_set_pending_exception (error))
 		return;
 	if (assemblyb->culture) {
-		assembly->assembly.aname.culture = mono_string_to_utf8_checked (assemblyb->culture, error);
+		assembly->assembly.aname.culture = mono_string_to_utf8_checked_internal (assemblyb->culture, error);
 		if (mono_error_set_pending_exception (error))
 			return;
 	} else
 		assembly->assembly.aname.culture = g_strdup ("");
 
         if (assemblyb->version) {
-			char *vstr = mono_string_to_utf8_checked (assemblyb->version, error);
+			char *vstr = mono_string_to_utf8_checked_internal (assemblyb->version, error);
 			if (mono_error_set_pending_exception (error))
 				return;
 			char **version = g_strsplit (vstr, ".", 4);
@@ -1361,7 +1361,7 @@ mono_reflection_dynimage_basic_init (MonoReflectionAssemblyBuilder *assemblyb)
 	assembly->save = assemblybuilderaccess_can_save (assemblyb->access);
 	assembly->domain = domain;
 
-	char *assembly_name = mono_string_to_utf8_checked (assemblyb->name, error);
+	char *assembly_name = mono_string_to_utf8_checked_internal (assemblyb->name, error);
 	if (mono_error_set_pending_exception (error))
 		return;
 	image = mono_dynamic_image_create (assembly, assembly_name, g_strdup ("RefEmit_YouForgotToDefineAModule"));
@@ -1373,7 +1373,7 @@ mono_reflection_dynimage_basic_init (MonoReflectionAssemblyBuilder *assemblyb)
 		if (assemblyb->pktoken->max_length != MONO_PUBLIC_KEY_TOKEN_LENGTH - 1) {
 			g_error ("Public key token length invalid for assembly %s: %i", assembly->assembly.aname.name, assemblyb->pktoken->max_length);
 		}
-		memcpy (&assembly->assembly.aname.public_key_token, mono_array_addr (assemblyb->pktoken, guint8, 0), assemblyb->pktoken->max_length);		
+		memcpy (&assembly->assembly.aname.public_key_token, mono_array_addr_internal (assemblyb->pktoken, guint8, 0), assemblyb->pktoken->max_length);		
 	}
 
 	mono_domain_assemblies_lock (domain);
@@ -1986,7 +1986,7 @@ get_prop_name_and_type (MonoObject *prop, char **name, MonoType **type, MonoErro
 	MonoClass *klass = mono_object_class (prop);
 	if (strcmp (klass->name, "PropertyBuilder") == 0) {
 		MonoReflectionPropertyBuilder *pb = (MonoReflectionPropertyBuilder *)prop;
-		*name = mono_string_to_utf8_checked (pb->name, error);
+		*name = mono_string_to_utf8_checked_internal (pb->name, error);
 		return_if_nok (error);
 		*type = mono_reflection_type_get_handle ((MonoReflectionType*)pb->type, error);
 	} else {
@@ -2006,7 +2006,7 @@ get_field_name_and_type (MonoObject *field, char **name, MonoType **type, MonoEr
 	MonoClass *klass = mono_object_class (field);
 	if (strcmp (klass->name, "FieldBuilder") == 0) {
 		MonoReflectionFieldBuilder *fb = (MonoReflectionFieldBuilder *)field;
-		*name = mono_string_to_utf8_checked (fb->name, error);
+		*name = mono_string_to_utf8_checked_internal (fb->name, error);
 		return_if_nok (error);
 		*type = mono_reflection_type_get_handle ((MonoReflectionType*)fb->type, error);
 	} else {
@@ -2169,7 +2169,7 @@ handle_enum:
 			*p++ = 0xFF;
 			break;
 		}
-		str = mono_string_to_utf8_checked ((MonoString*)arg, error);
+		str = mono_string_to_utf8_checked_internal ((MonoString*)arg, error);
 		return_if_nok (error);
 		slen = strlen (str);
 		if ((p-buffer) + 10 + slen >= *buflen) {
@@ -2237,7 +2237,7 @@ handle_type:
 			eclass = mono_defaults.object_class;
 		}
 		if (eclass == mono_defaults.object_class && arg_eclass->valuetype) {
-			char *elptr = mono_array_addr ((MonoArray*)arg, char, 0);
+			char *elptr = mono_array_addr_internal ((MonoArray*)arg, char, 0);
 			int elsize = mono_class_array_element_size (arg_eclass);
 			for (i = 0; i < len; ++i) {
 				encode_cattr_value (assembly, buffer, p, &buffer, &p, buflen, m_class_get_byval_arg (arg_eclass), NULL, elptr, error);
@@ -2245,7 +2245,7 @@ handle_type:
 				elptr += elsize;
 			}
 		} else if (eclass->valuetype && arg_eclass->valuetype) {
-			char *elptr = mono_array_addr ((MonoArray*)arg, char, 0);
+			char *elptr = mono_array_addr_internal ((MonoArray*)arg, char, 0);
 			int elsize = mono_class_array_element_size (eclass);
 			for (i = 0; i < len; ++i) {
 				encode_cattr_value (assembly, buffer, p, &buffer, &p, buflen, m_class_get_byval_arg (eclass), NULL, elptr, error);
@@ -2254,7 +2254,7 @@ handle_type:
 			}
 		} else {
 			for (i = 0; i < len; ++i) {
-				encode_cattr_value (assembly, buffer, p, &buffer, &p, buflen, m_class_get_byval_arg (eclass), mono_array_get ((MonoArray*)arg, MonoObject*, i), NULL, error);
+				encode_cattr_value (assembly, buffer, p, &buffer, &p, buflen, m_class_get_byval_arg (eclass), mono_array_get_internal ((MonoArray*)arg, MonoObject*, i), NULL, error);
 				return_if_nok (error);
 			}
 		}
@@ -2470,7 +2470,7 @@ mono_reflection_get_custom_attrs_blob_checked (MonoReflectionAssembly *assembly,
 	*p++ = 1;
 	*p++ = 0;
 	for (i = 0; i < sig->param_count; ++i) {
-		arg = mono_array_get (ctorArgs, MonoObject*, i);
+		arg = mono_array_get_internal (ctorArgs, MonoObject*, i);
 		encode_cattr_value (assembly->assembly, buffer, p, &buffer, &p, &buflen, sig->params [i], arg, NULL, error);
 		goto_if_nok (error, leave);
 	}
@@ -2487,11 +2487,11 @@ mono_reflection_get_custom_attrs_blob_checked (MonoReflectionAssembly *assembly,
 			MonoType *ptype;
 			char *pname;
 
-			prop = (MonoObject *)mono_array_get (properties, gpointer, i);
+			prop = (MonoObject *)mono_array_get_internal (properties, gpointer, i);
 			get_prop_name_and_type (prop, &pname, &ptype, error);
 			goto_if_nok (error, leave);
 			*p++ = 0x54; /* PROPERTY signature */
-			encode_named_val (assembly, buffer, p, &buffer, &p, &buflen, ptype, pname, (MonoObject*)mono_array_get (propValues, gpointer, i), error);
+			encode_named_val (assembly, buffer, p, &buffer, &p, &buflen, ptype, pname, (MonoObject*)mono_array_get_internal (propValues, gpointer, i), error);
 			g_free (pname);
 			goto_if_nok (error, leave);
 		}
@@ -2503,11 +2503,11 @@ mono_reflection_get_custom_attrs_blob_checked (MonoReflectionAssembly *assembly,
 			MonoType *ftype;
 			char *fname;
 
-			field = (MonoObject *)mono_array_get (fields, gpointer, i);
+			field = (MonoObject *)mono_array_get_internal (fields, gpointer, i);
 			get_field_name_and_type (field, &fname, &ftype, error);
 			goto_if_nok (error, leave);
 			*p++ = 0x53; /* FIELD signature */
-			encode_named_val (assembly, buffer, p, &buffer, &p, &buflen, ftype, fname, (MonoObject*)mono_array_get (fieldValues, gpointer, i), error);
+			encode_named_val (assembly, buffer, p, &buffer, &p, &buflen, ftype, fname, (MonoObject*)mono_array_get_internal (fieldValues, gpointer, i), error);
 			g_free (fname);
 			goto_if_nok (error, leave);
 		}
@@ -2517,7 +2517,7 @@ mono_reflection_get_custom_attrs_blob_checked (MonoReflectionAssembly *assembly,
 	buflen = p - buffer;
 	result = mono_array_new_checked (mono_domain_get (), mono_defaults.byte_class, buflen, error);
 	goto_if_nok (error, leave);
-	p = mono_array_addr (result, char, 0);
+	p = mono_array_addr_internal (result, char, 0);
 	memcpy (p, buffer, buflen);
 leave:
 	g_free (buffer);
@@ -2833,7 +2833,7 @@ mono_marshal_spec_from_builder (MonoImage *image, MonoAssembly *assembly,
 				type_get_fully_qualified_name (marshaltyperef);
 		}
 		if (minfo->mcookie) {
-			res->data.custom_data.cookie = mono_string_to_utf8_checked (minfo->mcookie, error);
+			res->data.custom_data.cookie = mono_string_to_utf8_checked_internal (minfo->mcookie, error);
 			if (!is_ok (error)) {
 				image_g_free (image, res);
 				return NULL;
@@ -2988,7 +2988,7 @@ reflection_methodbuilder_to_mono_method (MonoClass *klass,
 		guint8 *code;
 
 		if (rmb->ilgen) {
-			code = mono_array_addr (rmb->ilgen->code, guint8, 0);
+			code = mono_array_addr_internal (rmb->ilgen->code, guint8, 0);
 			code_size = rmb->ilgen->code_len;
 			max_stack = rmb->ilgen->max_stack;
 			num_locals = rmb->ilgen->locals ? mono_array_length_internal (rmb->ilgen->locals) : 0;
@@ -2996,7 +2996,7 @@ reflection_methodbuilder_to_mono_method (MonoClass *klass,
 				num_clauses = mono_reflection_method_count_clauses (rmb->ilgen);
 		} else {
 			if (rmb->code) {
-				code = mono_array_addr (rmb->code, guint8, 0);
+				code = mono_array_addr_internal (rmb->code, guint8, 0);
 				code_size = mono_array_length_internal (rmb->code);
 				/* we probably need to run a verifier on the code... */
 				max_stack = 8; 
@@ -3018,7 +3018,7 @@ reflection_methodbuilder_to_mono_method (MonoClass *klass,
 
 		for (i = 0; i < num_locals; ++i) {
 			MonoReflectionLocalBuilder *lb = 
-				mono_array_get (rmb->ilgen->locals, MonoReflectionLocalBuilder*, i);
+				mono_array_get_internal (rmb->ilgen->locals, MonoReflectionLocalBuilder*, i);
 
 			header->locals [i] = image_g_new0 (image, MonoType, 1);
 			MonoType *type = mono_reflection_type_get_handle ((MonoReflectionType*)lb->type, error);
@@ -3054,7 +3054,7 @@ reflection_methodbuilder_to_mono_method (MonoClass *klass,
 
 		for (i = 0; i < count; i++) {
 			MonoReflectionGenericParam *gp =
-				mono_array_get (rmb->generic_params, MonoReflectionGenericParam*, i);
+				mono_array_get_internal (rmb->generic_params, MonoReflectionGenericParam*, i);
 			MonoType *gp_type = mono_reflection_type_get_handle ((MonoReflectionType*)gp, error);
 			mono_error_assert_ok (error);
 			MonoGenericParamFull *param = (MonoGenericParamFull *) gp_type->data.generic_param;
@@ -3113,7 +3113,7 @@ reflection_methodbuilder_to_mono_method (MonoClass *klass,
 		method_aux->param_names = image_g_new0 (image, char *, mono_method_signature_internal (m)->param_count + 1);
 		for (i = 0; i <= m->signature->param_count; ++i) {
 			MonoReflectionParamBuilder *pb;
-			if ((pb = mono_array_get (rmb->pinfo, MonoReflectionParamBuilder*, i))) {
+			if ((pb = mono_array_get_internal (rmb->pinfo, MonoReflectionParamBuilder*, i))) {
 				if ((i > 0) && (pb->attrs)) {
 					/* Make a copy since it might point to a shared type structure */
 					m->signature->params [i - 1] = mono_metadata_type_dup (klass->image, m->signature->params [i - 1]);
@@ -3159,7 +3159,7 @@ reflection_methodbuilder_to_mono_method (MonoClass *klass,
 	if (rmb->pinfo)		
 		for (i = 0; i < mono_array_length_internal (rmb->pinfo); ++i) {
 			MonoReflectionParamBuilder *pb;
-			if ((pb = mono_array_get (rmb->pinfo, MonoReflectionParamBuilder*, i))) {
+			if ((pb = mono_array_get_internal (rmb->pinfo, MonoReflectionParamBuilder*, i))) {
 				if (pb->marshal_info) {
 					if (specs == NULL)
 						specs = image_g_new0 (image, MonoMarshalSpec*, sig->param_count + 1);
@@ -3410,7 +3410,7 @@ ensure_runtime_vtable (MonoClass *klass, MonoError *error)
 		klass->methods = (MonoMethod **)mono_image_alloc (klass->image, sizeof (MonoMethod*) * num);
 		num = tb->ctors? mono_array_length_internal (tb->ctors): 0;
 		for (i = 0; i < num; ++i) {
-			MonoMethod *ctor = ctorbuilder_to_mono_method (klass, mono_array_get (tb->ctors, MonoReflectionCtorBuilder*, i), error);
+			MonoMethod *ctor = ctorbuilder_to_mono_method (klass, mono_array_get_internal (tb->ctors, MonoReflectionCtorBuilder*, i), error);
 			if (!ctor)
 				return FALSE;
 			klass->methods [i] = ctor;
@@ -3418,7 +3418,7 @@ ensure_runtime_vtable (MonoClass *klass, MonoError *error)
 		num = tb->num_methods;
 		j = i;
 		for (i = 0; i < num; ++i) {
-			MonoMethod *meth = methodbuilder_to_mono_method_raw (klass, mono_array_get (tb->methods, MonoReflectionMethodBuilder*, i), error); /* FIXME use handles */
+			MonoMethod *meth = methodbuilder_to_mono_method_raw (klass, mono_array_get_internal (tb->methods, MonoReflectionMethodBuilder*, i), error); /* FIXME use handles */
 			if (!meth)
 				return FALSE;
 			klass->methods [j++] = meth;
@@ -3520,7 +3520,7 @@ mono_reflection_get_dynamic_overrides (MonoClass *klass, MonoMethod ***overrides
 	if (tb->methods) {
 		for (i = 0; i < tb->num_methods; ++i) {
 			MonoReflectionMethodBuilder *mb = 
-				mono_array_get (tb->methods, MonoReflectionMethodBuilder*, i);
+				mono_array_get_internal (tb->methods, MonoReflectionMethodBuilder*, i);
 			if (mb->override_methods)
 				onum += mono_array_length_internal (mb->override_methods);
 		}
@@ -3532,10 +3532,10 @@ mono_reflection_get_dynamic_overrides (MonoClass *klass, MonoMethod ***overrides
 		onum = 0;
 		for (i = 0; i < tb->num_methods; ++i) {
 			MonoReflectionMethodBuilder *mb = 
-				mono_array_get (tb->methods, MonoReflectionMethodBuilder*, i);
+				mono_array_get_internal (tb->methods, MonoReflectionMethodBuilder*, i);
 			if (mb->override_methods) {
 				for (j = 0; j < mono_array_length_internal (mb->override_methods); ++j) {
-					m = mono_array_get (mb->override_methods, MonoReflectionMethod*, j);
+					m = mono_array_get_internal (mb->override_methods, MonoReflectionMethod*, j);
 
 					(*overrides) [onum * 2] = mono_reflection_method_get_handle ((MonoObject*)m, error);
 					return_if_nok (error);
@@ -3561,13 +3561,13 @@ modulebuilder_get_next_table_index (MonoReflectionModuleBuilder *mb, gint32 tabl
 		MonoArray *arr = mono_array_new_checked (mono_object_domain (&mb->module.obj), mono_defaults.int_class, 64, error);
 		return_val_if_nok (error, 0);
 		for (int i = 0; i < 64; i++) {
-			mono_array_set (arr, int, i, 1);
+			mono_array_set_internal (arr, int, i, 1);
 		}
-		MONO_OBJECT_SETREF (mb, table_indexes, arr);
+		MONO_OBJECT_SETREF_INTERNAL (mb, table_indexes, arr);
 	}
-	gint32 index = mono_array_get (mb->table_indexes, gint32, table);
+	gint32 index = mono_array_get_internal (mb->table_indexes, gint32, table);
 	gint32 next_index = index + num_fields;
-	mono_array_set (mb->table_indexes, gint32, table, next_index);
+	mono_array_set_internal (mb->table_indexes, gint32, table, next_index);
 	return index;
 }
 
@@ -3623,7 +3623,7 @@ typebuilder_setup_fields (MonoClass *klass, MonoError *error)
 
 	for (i = 0; i < fcount; ++i) {
 		MonoArray *rva_data;
-		fb = (MonoReflectionFieldBuilder *)mono_array_get (tb->fields, gpointer, i);
+		fb = (MonoReflectionFieldBuilder *)mono_array_get_internal (tb->fields, gpointer, i);
 		field = &klass->fields [i];
 		field->parent = klass;
 		field->name = string_to_utf8_image_raw (image, fb->name, error); /* FIXME use handles */
@@ -3645,7 +3645,7 @@ typebuilder_setup_fields (MonoClass *klass, MonoError *error)
 		}
 
 		if ((fb->attrs & FIELD_ATTRIBUTE_HAS_FIELD_RVA) && (rva_data = fb->rva_data)) {
-			char *base = mono_array_addr (rva_data, char, 0);
+			char *base = mono_array_addr_internal (rva_data, char, 0);
 			size_t size = mono_array_length_internal (rva_data);
 			char *data = (char *)mono_image_alloc (klass->image, size);
 			memcpy (data, base, size);
@@ -3700,7 +3700,7 @@ typebuilder_setup_properties (MonoClass *klass, MonoError *error)
 	properties = image_g_new0 (image, MonoProperty, info->count);
 	info->properties = properties;
 	for (i = 0; i < info->count; ++i) {
-		pb = mono_array_get (tb->properties, MonoReflectionPropertyBuilder*, i);
+		pb = mono_array_get_internal (tb->properties, MonoReflectionPropertyBuilder*, i);
 		properties [i].parent = klass;
 		properties [i].attrs = pb->attrs;
 		properties [i].name = string_to_utf8_image_raw (image, pb->name, error); /* FIXME use handles */
@@ -3751,7 +3751,7 @@ typebuilder_setup_events (MonoClass *klass, MonoError *error)
 	events = image_g_new0 (image, MonoEvent, info->count);
 	info->events = events;
 	for (i = 0; i < info->count; ++i) {
-		eb = mono_array_get (tb->events, MonoReflectionEventBuilder*, i);
+		eb = mono_array_get_internal (tb->events, MonoReflectionEventBuilder*, i);
 		events [i].parent = klass;
 		events [i].attrs = eb->attrs;
 		events [i].name = string_to_utf8_image_raw (image, eb->name, error); /* FIXME use handles */
@@ -3770,7 +3770,7 @@ typebuilder_setup_events (MonoClass *klass, MonoError *error)
 			events [i].other = image_g_new0 (image, MonoMethod*, mono_array_length_internal (eb->other_methods) + 1);
 			for (j = 0; j < mono_array_length_internal (eb->other_methods); ++j) {
 				MonoReflectionMethodBuilder *mb = 
-					mono_array_get (eb->other_methods,
+					mono_array_get_internal (eb->other_methods,
 									MonoReflectionMethodBuilder*, j);
 				events [i].other [j] = mb->mhandle;
 			}
@@ -4007,7 +4007,7 @@ free_dynamic_method (void *dynamic_method)
 	g_hash_table_remove (domain->method_to_dyn_method, method);
 	mono_domain_unlock (domain);
 	g_assert (dis_link);
-	mono_gchandle_free (dis_link);
+	mono_gchandle_free_internal (dis_link);
 
 	mono_runtime_free_method (domain, method);
 	g_free (data);
@@ -4036,7 +4036,7 @@ reflection_create_dynamic_method (MonoReflectionDynamicMethodHandle ref_mb, Mono
 	if (!(queue = dynamic_method_queue)) {
 		mono_loader_lock ();
 		if (!(queue = dynamic_method_queue))
-			queue = dynamic_method_queue = mono_gc_reference_queue_new (free_dynamic_method);
+			queue = dynamic_method_queue = mono_gc_reference_queue_new_internal (free_dynamic_method);
 		mono_loader_unlock ();
 	}
 
@@ -4058,7 +4058,7 @@ reflection_create_dynamic_method (MonoReflectionDynamicMethodHandle ref_mb, Mono
 	for (i = 0; i < mb->nrefs; i += 2) {
 		MonoClass *handle_class;
 		gpointer ref;
-		MonoObject *obj = mono_array_get (mb->refs, MonoObject*, i);
+		MonoObject *obj = mono_array_get_internal (mb->refs, MonoObject*, i);
 
 		if (strcmp (obj->vtable->klass->name, "DynamicMethod") == 0) {
 			MonoReflectionDynamicMethod *method = (MonoReflectionDynamicMethod*)obj;
@@ -4122,8 +4122,8 @@ reflection_create_dynamic_method (MonoReflectionDynamicMethodHandle ref_mb, Mono
 
 	release_data = g_new (DynamicMethodReleaseData, 1);
 	release_data->handle = handle;
-	release_data->domain = mono_object_get_domain ((MonoObject*)mb);
-	if (!mono_gc_reference_queue_add (queue, (MonoObject*)mb, release_data))
+	release_data->domain = mono_object_get_domain_internal ((MonoObject*)mb);
+	if (!mono_gc_reference_queue_add_internal (queue, (MonoObject*)mb, release_data))
 		g_free (release_data);
 
 	/* Fix up refs entries pointing at us */
@@ -4149,7 +4149,7 @@ reflection_create_dynamic_method (MonoReflectionDynamicMethodHandle ref_mb, Mono
 	mono_domain_lock (domain);
 	if (!domain->method_to_dyn_method)
 		domain->method_to_dyn_method = g_hash_table_new (NULL, NULL);
-	g_hash_table_insert (domain->method_to_dyn_method, handle, (gpointer)(size_t)mono_gchandle_new_weakref ((MonoObject *)mb, TRUE));
+	g_hash_table_insert (domain->method_to_dyn_method, handle, (gpointer)(size_t)mono_gchandle_new_weakref_internal ((MonoObject *)mb, TRUE));
 	mono_domain_unlock (domain);
 
 	return TRUE;
@@ -4361,7 +4361,7 @@ mono_reflection_resolve_object (MonoImage *image, MonoObject *obj, MonoClass **h
 
 		/* Find the method */
 
-		name = mono_string_to_utf8_checked (m->name, error);
+		name = mono_string_to_utf8_checked_internal (m->name, error);
 		goto_if_nok (error, return_null);
 		iter = NULL;
 		while ((method = mono_class_get_methods (klass, &iter))) {

--- a/mono/metadata/string-icalls.c
+++ b/mono/metadata/string-icalls.c
@@ -60,7 +60,7 @@ ves_icall_System_String_InternalIntern (MonoString *str)
 MonoString * 
 ves_icall_System_String_InternalIsInterned (MonoString *str)
 {
-	return mono_string_is_interned (str);
+	return mono_string_is_interned_internal (str);
 }
 
 int

--- a/mono/metadata/verify.c
+++ b/mono/metadata/verify.c
@@ -2746,7 +2746,7 @@ verify_delegate_compatibility (VerifyContext *ctx, MonoClass *delegate, ILStackD
 		return;
 	}
 	
-	invoke = mono_get_delegate_invoke (delegate);
+	invoke = mono_get_delegate_invoke_internal (delegate);
 	method = funptr->method;
 
 	if (!method || !mono_method_signature_internal (method)) {

--- a/mono/metadata/w32event-win32.c
+++ b/mono/metadata/w32event-win32.c
@@ -60,7 +60,7 @@ ves_icall_System_Threading_Events_CreateEvent_internal (MonoBoolean manual, Mono
 	*err = GetLastError ();
 	MONO_EXIT_GC_SAFE;
 	if (gchandle)
-		mono_gchandle_free (gchandle);
+		mono_gchandle_free_internal (gchandle);
 
 	return event;
 }
@@ -105,7 +105,7 @@ ves_icall_System_Threading_Events_OpenEvent_internal (MonoStringHandle name, gin
 	MONO_EXIT_GC_SAFE;
 
 	if (gchandle)
-		mono_gchandle_free (gchandle);
+		mono_gchandle_free_internal (gchandle);
 
 	return handle;
 }

--- a/mono/metadata/w32file.c
+++ b/mono/metadata/w32file.c
@@ -525,7 +525,7 @@ ves_icall_System_IO_MonoIO_Read (HANDLE handle, MonoArrayHandle dest,
 	guint32 buffer_handle = 0;
 	buffer = MONO_ARRAY_HANDLE_PIN (dest, guchar, dest_offset, &buffer_handle);
 	result = mono_w32file_read (handle, buffer, count, &n, io_error);
-	mono_gchandle_free (buffer_handle);
+	mono_gchandle_free_internal (buffer_handle);
 
 	if (!result)
 		return -1;
@@ -555,7 +555,7 @@ ves_icall_System_IO_MonoIO_Write (HANDLE handle, MonoArrayHandle src,
 	guint32 src_handle = 0;
 	buffer = MONO_ARRAY_HANDLE_PIN (src, guchar, src_offset, &src_handle);
 	result = mono_w32file_write (handle, buffer, count, &n, io_error);
-	mono_gchandle_free (src_handle);
+	mono_gchandle_free_internal (src_handle);
 
 	if (!result)
 		return -1;
@@ -848,7 +848,7 @@ mono_filesize_from_path (MonoString *string)
 	ERROR_DECL (error);
 	struct stat buf;
 	gint64 res;
-	char *path = mono_string_to_utf8_checked (string, error);
+	char *path = mono_string_to_utf8_checked_internal (string, error);
 	mono_error_raise_exception_deprecated (error); /* OK to throw, external only without a good alternative */
 
 	gint stat_res;

--- a/mono/metadata/w32mutex-win32.c
+++ b/mono/metadata/w32mutex-win32.c
@@ -48,7 +48,7 @@ ves_icall_System_Threading_Mutex_CreateMutex_internal (MonoBoolean owned, MonoSt
 		if (GetLastError () == ERROR_ALREADY_EXISTS)
 			*created = FALSE;
 		MONO_EXIT_GC_SAFE;
-		mono_gchandle_free (gchandle);
+		mono_gchandle_free_internal (gchandle);
 	}
 
 	return mutex;
@@ -77,7 +77,7 @@ ves_icall_System_Threading_Mutex_OpenMutex_internal (MonoStringHandle name, gint
 		*err = GetLastError ();
 	MONO_EXIT_GC_SAFE;
 	if (gchandle != 0)
-		mono_gchandle_free (gchandle);
+		mono_gchandle_free_internal (gchandle);
 
 	return ret;
 }

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -83,6 +83,7 @@
 #include <mono/utils/strenc.h>
 #include <mono/utils/mono-io-portability.h>
 #include <mono/utils/w32api.h>
+#include "object-internals.h"
 
 #ifndef MAXPATHLEN
 #define MAXPATHLEN 242
@@ -2058,7 +2059,7 @@ process_create (const gunichar2 *appname, const gunichar2 *cmdline,
 			MONO_HANDLE_ARRAY_GETREF (var, array, i);
 			gchandle_t gchandle = 0;
 			env_strings [i] = mono_unicode_to_external (mono_string_handle_pin_chars (var, &gchandle));
-			mono_gchandle_free (gchandle);
+			mono_gchandle_free_internal (gchandle);
 		}
 	} else {
 		gsize env_count = 0;
@@ -2461,10 +2462,10 @@ ves_icall_System_Diagnostics_Process_GetProcesses_internal (void)
 		return NULL;
 	}
 	if (sizeof (guint32) == sizeof (gpointer)) {
-		memcpy (mono_array_addr (procs, guint32, 0), pidarray, count * sizeof (gint32));
+		memcpy (mono_array_addr_internal (procs, guint32, 0), pidarray, count * sizeof (gint32));
 	} else {
 		for (i = 0; i < count; ++i)
-			*(mono_array_addr (procs, guint32, i)) = GPOINTER_TO_UINT (pidarray [i]);
+			*(mono_array_addr_internal (procs, guint32, i)) = GPOINTER_TO_UINT (pidarray [i]);
 	}
 	g_free (pidarray);
 

--- a/mono/metadata/w32process-win32.c
+++ b/mono/metadata/w32process-win32.c
@@ -162,7 +162,7 @@ mono_process_create_process (MonoCreateProcessCoop *coop, MonoW32ProcessInfo *mo
 					process_info);
 	}
 
-	mono_gchandle_free (cmd_gchandle);
+	mono_gchandle_free_internal (cmd_gchandle);
 
 	return result;
 }
@@ -322,7 +322,7 @@ ves_icall_System_Diagnostics_Process_CreateProcess_internal (MonoW32ProcessStart
 			MONO_HANDLE_ARRAY_GETREF (var, array, i);
 			gchandle_t gchandle = 0;
 			memcpy (ptr, mono_string_handle_pin_chars (var, &gchandle), mono_string_handle_length (var) * sizeof (gunichar2));
-			mono_gchandle_free (gchandle);
+			mono_gchandle_free_internal (gchandle);
 			ptr += mono_string_handle_length (var);
 			ptr += 1; // Skip over the null-separator
 		}
@@ -393,7 +393,7 @@ ves_icall_System_Diagnostics_Process_GetProcesses_internal (void)
 		goto exit;
 	}
 
-	memcpy (mono_array_addr (procs, guint32, 0), pids, needed);
+	memcpy (mono_array_addr_internal (procs, guint32, 0), pids, needed);
 exit:
 	g_free (pids);
 	return procs;

--- a/mono/metadata/w32process.c
+++ b/mono/metadata/w32process.c
@@ -145,7 +145,7 @@ process_set_field_object (MonoObject *obj, const gchar *fieldname, MonoObject *d
 	field = mono_class_get_field_from_name_full (klass, fieldname, NULL);
 	g_assert (field);
 
-	mono_gc_wbarrier_generic_store (((char *)obj) + field->offset, data);
+	mono_gc_wbarrier_generic_store_internal (((char *)obj) + field->offset, data);
 }
 
 static void
@@ -172,7 +172,7 @@ process_set_field_string (MonoObject *obj, const gchar *fieldname, const gunicha
 	string = mono_string_new_utf16_checked (domain, val, len, error);
 	return_if_nok (error);
 
-	mono_gc_wbarrier_generic_store (((char *)obj) + field->offset, (MonoObject*)string);
+	mono_gc_wbarrier_generic_store_internal (((char *)obj) + field->offset, (MonoObject*)string);
 }
 
 static void
@@ -198,7 +198,7 @@ process_set_field_string_char (MonoObject *obj, const gchar *fieldname, const gc
 	string = mono_string_new_checked (domain, val, error);
 	return_if_nok (error);
 
-	mono_gc_wbarrier_generic_store (((char *)obj) + field->offset, (MonoObject*)string);
+	mono_gc_wbarrier_generic_store_internal (((char *)obj) + field->offset, (MonoObject*)string);
 }
 
 static void
@@ -432,13 +432,13 @@ ves_icall_System_Diagnostics_FileVersionInfo_GetVersionInfo_internal (MonoObject
 
 	stash_system_image (m_class_get_image (mono_object_class (this_obj)));
 
-	mono_w32process_get_fileversion (this_obj, mono_string_chars (filename), error);
+	mono_w32process_get_fileversion (this_obj, mono_string_chars_internal (filename), error);
 	if (!mono_error_ok (error)) {
 		mono_error_set_pending_exception (error);
 		return;
 	}
 
-	process_set_field_string (this_obj, "filename", mono_string_chars (filename), mono_string_length (filename), error);
+	process_set_field_string (this_obj, "filename", mono_string_chars_internal (filename), mono_string_length_internal (filename), error);
 	if (!mono_error_ok (error)) {
 		mono_error_set_pending_exception (error);
 	}
@@ -597,7 +597,7 @@ ves_icall_System_Diagnostics_Process_GetModules_internal (MonoObject *this_obj, 
 				mono_error_set_pending_exception (error);
 				return NULL;
 			}
-			mono_array_setref (temp_arr, num_added++, module);
+			mono_array_setref_internal (temp_arr, num_added++, module);
 		}
 	}
 
@@ -609,7 +609,7 @@ ves_icall_System_Diagnostics_Process_GetModules_internal (MonoObject *this_obj, 
 				mono_error_set_pending_exception (error);
 				return NULL;
 			}
-			mono_array_setref (temp_arr, num_added++, module);
+			mono_array_setref_internal (temp_arr, num_added++, module);
 		}
 		g_ptr_array_free (assemblies, TRUE);
 	}
@@ -623,7 +623,7 @@ ves_icall_System_Diagnostics_Process_GetModules_internal (MonoObject *this_obj, 
 			return NULL;
 
 		for (i = 0; i < num_added; i++)
-			mono_array_setref (arr, i, mono_array_get (temp_arr, MonoObject*, i));
+			mono_array_setref_internal (arr, i, mono_array_get_internal (temp_arr, MonoObject*, i));
 	}
 
 	return arr;
@@ -706,7 +706,7 @@ static void
 mono_unpin_array (gchandle_t *gchandles, gsize count)
 {
 	for (gsize i = 0; i < count; ++i) {
-		mono_gchandle_free (gchandles [i]);
+		mono_gchandle_free_internal (gchandles [i]);
 		gchandles [i] = 0;
 	}
 }

--- a/mono/metadata/w32semaphore-unix.c
+++ b/mono/metadata/w32semaphore-unix.c
@@ -14,6 +14,7 @@
 #include "w32handle-namespace.h"
 #include "mono/utils/mono-logger-internals.h"
 #include "mono/metadata/w32handle.h"
+#include "object-internals.h"
 
 #define MAX_PATH 260
 
@@ -256,7 +257,7 @@ ves_icall_System_Threading_Semaphore_CreateSemaphore_internal (gint32 initialCou
 	if (!name)
 		sem = sem_create (initialCount, maximumCount);
 	else
-		sem = namedsem_create (initialCount, maximumCount, mono_string_chars (name));
+		sem = namedsem_create (initialCount, maximumCount, mono_string_chars_internal (name));
 
 	*error = mono_w32error_get_last ();
 
@@ -328,7 +329,7 @@ ves_icall_System_Threading_Semaphore_OpenSemaphore_internal (MonoString *name, g
 	/* w32 seems to guarantee that opening named objects can't race each other */
 	mono_w32handle_namespace_lock ();
 
-	utf8_name = g_utf16_to_utf8 (mono_string_chars (name), -1, NULL, NULL, NULL);
+	utf8_name = g_utf16_to_utf8 (mono_string_chars_internal (name), -1, NULL, NULL, NULL);
 
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_SEMAPHORE, "%s: Opening named sem [%s]", __func__, utf8_name);
 

--- a/mono/metadata/w32semaphore-win32.c
+++ b/mono/metadata/w32semaphore-win32.c
@@ -12,6 +12,7 @@
 
 #include <windows.h>
 #include <winbase.h>
+#include "object-internals.h"
 
 void
 mono_w32semaphore_init (void)
@@ -24,7 +25,7 @@ ves_icall_System_Threading_Semaphore_CreateSemaphore_internal (gint32 initialCou
 { 
 	HANDLE sem;
 
-	sem = CreateSemaphore (NULL, initialCount, maximumCount, name ? mono_string_chars (name) : NULL);
+	sem = CreateSemaphore (NULL, initialCount, maximumCount, name ? mono_string_chars_internal (name) : NULL);
 
 	*error = GetLastError ();
 
@@ -43,7 +44,7 @@ ves_icall_System_Threading_Semaphore_OpenSemaphore_internal (MonoString *name, g
 {
 	HANDLE sem;
 
-	sem = OpenSemaphore (rights, FALSE, mono_string_chars (name));
+	sem = OpenSemaphore (rights, FALSE, mono_string_chars_internal (name));
 
 	*error = GetLastError ();
 

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -939,8 +939,8 @@ create_object_handle_from_sockaddr (struct sockaddr *saddr, int sa_size, gint32 
 		MONO_HANDLE_ARRAY_SETVAL (data, guint8, 6, (address>>8) & 0xff);
 		MONO_HANDLE_ARRAY_SETVAL (data, guint8, 7, (address) & 0xff);
 	
-		mono_field_set_value (MONO_HANDLE_RAW (sockaddr_obj), domain->sockaddr_data_field, MONO_HANDLE_RAW (data)); /* FIXME: use handles for mono_field_set_value */
-		mono_field_set_value (MONO_HANDLE_RAW (sockaddr_obj), domain->sockaddr_data_length_field, &buffer_size); /* FIXME: use handles for mono_field_set_value */
+		mono_field_set_value_internal (MONO_HANDLE_RAW (sockaddr_obj), domain->sockaddr_data_field, MONO_HANDLE_RAW (data)); /* FIXME: use handles for mono_field_set_value */
+		mono_field_set_value_internal (MONO_HANDLE_RAW (sockaddr_obj), domain->sockaddr_data_length_field, &buffer_size); /* FIXME: use handles for mono_field_set_value */
 
 		return sockaddr_obj;
 	}
@@ -979,8 +979,8 @@ create_object_handle_from_sockaddr (struct sockaddr *saddr, int sa_size, gint32 
 		MONO_HANDLE_ARRAY_SETVAL (data, guint8, 27,
 					  (sa_in->sin6_scope_id >> 24) & 0xff);
 
-		mono_field_set_value (MONO_HANDLE_RAW (sockaddr_obj), domain->sockaddr_data_field, MONO_HANDLE_RAW (data)); /* FIXME: use handles for mono_field_set_value */
-		mono_field_set_value (MONO_HANDLE_RAW (sockaddr_obj), domain->sockaddr_data_length_field, &buffer_size); /* FIXME: use handles for mono_field_set_value */
+		mono_field_set_value_internal (MONO_HANDLE_RAW (sockaddr_obj), domain->sockaddr_data_field, MONO_HANDLE_RAW (data)); /* FIXME: use handles for mono_field_set_value */
+		mono_field_set_value_internal (MONO_HANDLE_RAW (sockaddr_obj), domain->sockaddr_data_length_field, &buffer_size); /* FIXME: use handles for mono_field_set_value */
 
 		return sockaddr_obj;
 	}
@@ -993,8 +993,8 @@ create_object_handle_from_sockaddr (struct sockaddr *saddr, int sa_size, gint32 
 		for (i = 0; i < sa_size; i++)
 			MONO_HANDLE_ARRAY_SETVAL (data, guint8, i + 2, saddr->sa_data [i]);
 		
-		mono_field_set_value (MONO_HANDLE_RAW (sockaddr_obj), domain->sockaddr_data_field, MONO_HANDLE_RAW (data)); /* FIXME: use handles for mono_field_set_value */
-		mono_field_set_value (MONO_HANDLE_RAW (sockaddr_obj), domain->sockaddr_data_length_field, &buffer_size); /* FIXME: use handles for mono_field_set_value */
+		mono_field_set_value_internal (MONO_HANDLE_RAW (sockaddr_obj), domain->sockaddr_data_field, MONO_HANDLE_RAW (data)); /* FIXME: use handles for mono_field_set_value */
+		mono_field_set_value_internal (MONO_HANDLE_RAW (sockaddr_obj), domain->sockaddr_data_length_field, &buffer_size); /* FIXME: use handles for mono_field_set_value */
 
 		return sockaddr_obj;
 	}
@@ -1125,7 +1125,7 @@ create_sockaddr_from_handle (MonoObjectHandle saddr_obj, socklen_t *sa_size, gin
 		
 		if (len < 8) {
 			mono_error_set_generic_error (error, "System", "SystemException", "");
-			mono_gchandle_free (gchandle);
+			mono_gchandle_free_internal (gchandle);
 			return NULL;
 		}
 
@@ -1138,7 +1138,7 @@ create_sockaddr_from_handle (MonoObjectHandle saddr_obj, socklen_t *sa_size, gin
 		sa->sin_port = htons (port);
 
 		*sa_size = sizeof (struct sockaddr_in);
-		mono_gchandle_free (gchandle);
+		mono_gchandle_free_internal (gchandle);
 		return (struct sockaddr *)sa;
 	}
 #ifdef HAVE_STRUCT_SOCKADDR_IN6
@@ -1150,7 +1150,7 @@ create_sockaddr_from_handle (MonoObjectHandle saddr_obj, socklen_t *sa_size, gin
 		
 		if (len < 28) {
 			mono_error_set_generic_error (error, "System", "SystemException", "");
-			mono_gchandle_free (gchandle);
+			mono_gchandle_free_internal (gchandle);
 			return NULL;
 		}
 
@@ -1166,7 +1166,7 @@ create_sockaddr_from_handle (MonoObjectHandle saddr_obj, socklen_t *sa_size, gin
 			sa->sin6_addr.s6_addr [i] = buf[8 + i];
 
 		*sa_size = sizeof (struct sockaddr_in6);
-		mono_gchandle_free (gchandle);
+		mono_gchandle_free_internal (gchandle);
 		return (struct sockaddr *)sa;
 	}
 #endif
@@ -1180,7 +1180,7 @@ create_sockaddr_from_handle (MonoObjectHandle saddr_obj, socklen_t *sa_size, gin
 		 */
 		if (len - 2 >= sizeof (sock_un->sun_path)) {
 			mono_error_set_exception_instance (error, mono_get_exception_index_out_of_range ());
-			mono_gchandle_free (gchandle);
+			mono_gchandle_free_internal (gchandle);
 			return NULL;
 		}
 		
@@ -1191,13 +1191,13 @@ create_sockaddr_from_handle (MonoObjectHandle saddr_obj, socklen_t *sa_size, gin
 			sock_un->sun_path [i] = buf[i + 2];
 		
 		*sa_size = len;
-		mono_gchandle_free (gchandle);
+		mono_gchandle_free_internal (gchandle);
 		return (struct sockaddr *)sock_un;
 	}
 #endif
 	else {
 		*werror = WSAEAFNOSUPPORT;
-		mono_gchandle_free (gchandle);
+		mono_gchandle_free_internal (gchandle);
 		return 0;
 	}
 }
@@ -1901,7 +1901,7 @@ ves_icall_System_Net_Sockets_Socket_GetSocketOption_arr_internal (gsize sock, gi
 
 	ret = mono_w32socket_getsockopt (sock, system_level, system_name, buf, &valsize);
 
-	mono_gchandle_free (gchandle);
+	mono_gchandle_free_internal (gchandle);
 
 	if (ret == SOCKET_ERROR)
 		*werror = mono_w32socket_get_last_error ();
@@ -2149,7 +2149,7 @@ ves_icall_System_Net_Sockets_Socket_SetSocketOption_internal (gsize sock, gint32
 			ret = mono_w32socket_setsockopt (sock, system_level, system_name, buf, valsize);
 			break;
 		}
-		mono_gchandle_free (gchandle);
+		mono_gchandle_free_internal (gchandle);
 	} else {
 		/* ReceiveTimeout/SendTimeout get here */
 		switch (name) {
@@ -2281,8 +2281,8 @@ ves_icall_System_Net_Sockets_Socket_IOControl_internal (gsize sock, gint32 code,
 
 	ret = mono_w32socket_ioctl (sock, code, i_buffer, i_len, o_buffer, o_len, &output_bytes);
 
-	mono_gchandle_free (i_gchandle);
-	mono_gchandle_free (o_gchandle);
+	mono_gchandle_free_internal (i_gchandle);
+	mono_gchandle_free_internal (o_gchandle);
 
 	if (ret == SOCKET_ERROR) {
 		*werror = mono_w32socket_get_last_error ();
@@ -2576,7 +2576,7 @@ ves_icall_System_Net_Sockets_Socket_SendFile_internal (gsize sock, MonoStringHan
 	uint32_t filename_gchandle;
 	gunichar2 *filename_chars = mono_string_handle_pin_chars (filename, &filename_gchandle);
 	file = mono_w32file_create (filename_chars, GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING, 0);
-	mono_gchandle_free (filename_gchandle);
+	mono_gchandle_free_internal (filename_gchandle);
 	if (file == INVALID_HANDLE_VALUE) {
 		*werror = mono_w32error_get_last ();
 		return FALSE;
@@ -2595,9 +2595,9 @@ ves_icall_System_Net_Sockets_Socket_SendFile_internal (gsize sock, MonoStringHan
 	ret = mono_w32socket_transmit_file (sock, file, &buffers, flags, blocking);
 
 	if (pre_buffer_gchandle)
-		mono_gchandle_free (pre_buffer_gchandle);
+		mono_gchandle_free_internal (pre_buffer_gchandle);
 	if (post_buffer_gchandle)
-		mono_gchandle_free (post_buffer_gchandle);
+		mono_gchandle_free_internal (post_buffer_gchandle);
 
 	if (!ret)
 		*werror = mono_w32socket_get_last_error ();

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -4265,7 +4265,7 @@ add_wrappers (MonoAotCompile *acfg)
 			continue;
 
 		if (!mono_class_is_gtd (klass)) {
-			method = mono_get_delegate_invoke (klass);
+			method = mono_get_delegate_invoke_internal (klass);
 
 			m = mono_marshal_get_delegate_invoke (method, NULL);
 
@@ -4297,7 +4297,7 @@ add_wrappers (MonoAotCompile *acfg)
 					MonoMethod *del_invoke;
 
 					/* Add wrappers needed by mono_ftnptr_to_delegate () */
-					invoke = mono_get_delegate_invoke (klass);
+					invoke = mono_get_delegate_invoke_internal (klass);
 					wrapper = mono_marshal_get_native_func_wrapper_aot (klass);
 					del_invoke = mono_marshal_get_delegate_invoke_internal (invoke, FALSE, TRUE, wrapper);
 					add_method (acfg, wrapper);
@@ -4313,7 +4313,7 @@ add_wrappers (MonoAotCompile *acfg)
 			 * Emit gsharedvt versions of the generic delegate-invoke wrappers
 			 */
 			/* Invoke */
-			method = mono_get_delegate_invoke (klass);
+			method = mono_get_delegate_invoke_internal (klass);
 			create_gsharedvt_inst (acfg, method, &ctx);
 
 			inst = mono_class_inflate_generic_method_checked (method, &ctx, error);
@@ -4328,7 +4328,7 @@ add_wrappers (MonoAotCompile *acfg)
 			add_extra_method (acfg, gshared);
 
 			/* begin-invoke */
-			method = mono_get_delegate_begin_invoke (klass);
+			method = mono_get_delegate_begin_invoke_internal (klass);
 			if (method) {
 				create_gsharedvt_inst (acfg, method, &ctx);
 
@@ -4345,7 +4345,7 @@ add_wrappers (MonoAotCompile *acfg)
 			}
 
 			/* end-invoke */
-			method = mono_get_delegate_end_invoke (klass);
+			method = mono_get_delegate_end_invoke_internal (klass);
 			if (method) {
 				create_gsharedvt_inst (acfg, method, &ctx);
 
@@ -4796,7 +4796,7 @@ add_generic_class_with_depth (MonoAotCompile *acfg, MonoClass *klass, int depth,
 	}
 
 	if (m_class_is_delegate (klass)) {
-		method = mono_get_delegate_invoke (klass);
+		method = mono_get_delegate_invoke_internal (klass);
 
 		method = mono_marshal_get_delegate_invoke (method, NULL);
 

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -1216,15 +1216,15 @@ decode_method_ref_with_target (MonoAotModule *module, MethodRef *ref, MonoMethod
 
 				switch (wrapper_type) {
 				case MONO_WRAPPER_DELEGATE_INVOKE:
-					invoke = mono_get_delegate_invoke (klass);
+					invoke = mono_get_delegate_invoke_internal (klass);
 					wrapper = mono_marshal_get_delegate_invoke (invoke, NULL);
 					break;
 				case MONO_WRAPPER_DELEGATE_BEGIN_INVOKE:
-					invoke = mono_get_delegate_begin_invoke (klass);
+					invoke = mono_get_delegate_begin_invoke_internal (klass);
 					wrapper = mono_marshal_get_delegate_begin_invoke (invoke);
 					break;
 				case MONO_WRAPPER_DELEGATE_END_INVOKE:
-					invoke = mono_get_delegate_end_invoke (klass);
+					invoke = mono_get_delegate_end_invoke_internal (klass);
 					wrapper = mono_marshal_get_delegate_end_invoke (invoke);
 					break;
 				default:

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -727,7 +727,7 @@ interp_regression_step (MonoImage *image, int verbose, int *total_run, int *tota
 				run++;
 				failed++;
 			} else {
-				result = *(gint32 *) mono_object_unbox (result_obj);
+				result = *(gint32 *) mono_object_unbox_internal (result_obj);
 				expected = atoi (method->name + 5);  // FIXME: oh no.
 				run++;
 
@@ -1287,7 +1287,7 @@ mono_jit_exec_internal (MonoDomain *domain, MonoAssembly *assembly, int argc, ch
 
 		res = mono_runtime_try_run_main (method, argc, argv, &exc);
 		if (exc) {
-			mono_unhandled_exception (exc);
+			mono_unhandled_exception_internal (exc);
 			mono_invoke_unhandled_exception_hook (exc);
 			g_assert_not_reached ();
 		}
@@ -1297,7 +1297,7 @@ mono_jit_exec_internal (MonoDomain *domain, MonoAssembly *assembly, int argc, ch
 		if (!is_ok (error)) {
 			MonoException *ex = mono_error_convert_to_exception (error);
 			if (ex) {
-				mono_unhandled_exception (&ex->object);
+				mono_unhandled_exception_internal (&ex->object);
 				mono_invoke_unhandled_exception_hook (&ex->object);
 				g_assert_not_reached ();
 			}
@@ -1431,7 +1431,7 @@ load_agent (MonoDomain *domain, char *desc)
 		if (main_args) {
 			MonoString *str = mono_string_new_checked (domain, args, error);
 			if (str)
-				mono_array_set (main_args, MonoString*, 0, str);
+				mono_array_set_internal (main_args, MonoString*, 0, str);
 		}
 	} else {
 		main_args = (MonoArray*)mono_array_new_checked (domain, mono_defaults.string_class, 0, error);

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -522,12 +522,12 @@ stackval_from_data (MonoType *type_, stackval *result, void *data, gboolean pinv
 		} else if (pinvoke) {
 			memcpy (result->data.vt, data, mono_class_native_size (type->data.klass, NULL));
 		} else {
-			mono_value_copy (result->data.vt, data, type->data.klass);
+			mono_value_copy_internal (result->data.vt, data, type->data.klass);
 		}
 		return;
 	case MONO_TYPE_GENERICINST: {
 		if (mono_type_generic_inst_is_valuetype (type)) {
-			mono_value_copy (result->data.vt, data, mono_class_from_mono_type_internal (type));
+			mono_value_copy_internal (result->data.vt, data, mono_class_from_mono_type_internal (type));
 			return;
 		}
 		stackval_from_data (m_class_get_byval_arg (type->data.generic_class->container_class), result, data, pinvoke);
@@ -608,7 +608,7 @@ stackval_to_data (MonoType *type_, stackval *val, void *data, gboolean pinvoke)
 	case MONO_TYPE_OBJECT:
 	case MONO_TYPE_ARRAY: {
 		gpointer *p = (gpointer *) data;
-		mono_gc_wbarrier_generic_store (p, val->data.o);
+		mono_gc_wbarrier_generic_store_internal (p, val->data.o);
 		return;
 	}
 	case MONO_TYPE_PTR: {
@@ -623,14 +623,14 @@ stackval_to_data (MonoType *type_, stackval *val, void *data, gboolean pinvoke)
 		} else if (pinvoke) {
 			memcpy (data, val->data.vt, mono_class_native_size (type->data.klass, NULL));
 		} else {
-			mono_value_copy (data, val->data.vt, type->data.klass);
+			mono_value_copy_internal (data, val->data.vt, type->data.klass);
 		}
 		return;
 	case MONO_TYPE_GENERICINST: {
 		MonoClass *container_class = type->data.generic_class->container_class;
 
 		if (m_class_is_valuetype (container_class) && !m_class_is_enumtype (container_class)) {
-			mono_value_copy (data, val->data.vt, mono_class_from_mono_type_internal (type));
+			mono_value_copy_internal (data, val->data.vt, mono_class_from_mono_type_internal (type));
 			return;
 		}
 		stackval_to_data (m_class_get_byval_arg (type->data.generic_class->container_class), val, data, pinvoke);
@@ -1286,7 +1286,7 @@ interp_delegate_ctor (MonoObjectHandle this_obj, MonoObjectHandle target, gpoint
 	InterpMethod *imethod = (InterpMethod*)addr;
 
 	if (!(imethod->method->flags & METHOD_ATTRIBUTE_STATIC)) {
-		MonoMethod *invoke = mono_get_delegate_invoke (mono_handle_class (this_obj));
+		MonoMethod *invoke = mono_get_delegate_invoke_internal (mono_handle_class (this_obj));
 		/* virtual invoke delegates must not have null check */
 		if (mono_method_signature_internal (imethod->method)->param_count == mono_method_signature_internal (invoke)->param_count
 				&& MONO_HANDLE_IS_NULL (target)) {
@@ -2871,7 +2871,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 				MonoObject *this_arg = (MonoObject*)sp->data.p;
 
 				if (m_class_is_valuetype (this_arg->vtable->klass)) {
-					gpointer unboxed = mono_object_unbox (this_arg);
+					gpointer unboxed = mono_object_unbox_internal (this_arg);
 					sp [0].data.p = unboxed;
 				}
 			}
@@ -3012,7 +3012,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 				child_frame.imethod = get_virtual_method (child_frame.imethod, this_arg);
 				if (m_class_is_valuetype (this_class) && m_class_is_valuetype (child_frame.imethod->method->klass)) {
 					/* unbox */
-					gpointer unboxed = mono_object_unbox (this_arg);
+					gpointer unboxed = mono_object_unbox_internal (this_arg);
 					sp [0].data.p = unboxed;
 				}
 			}
@@ -3527,7 +3527,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 		MINT_IN_CASE(MINT_STIND_REF) 
 			++ip;
 			sp -= 2;
-			mono_gc_wbarrier_generic_store (sp->data.p, sp [1].data.o);
+			mono_gc_wbarrier_generic_store_internal (sp->data.p, sp [1].data.o);
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_STIND_I1)
 			++ip;
@@ -3990,7 +3990,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 			if (method->wrapper_type == MONO_WRAPPER_DYNAMIC_METHOD) {
 				s = (MonoString*)mono_method_get_wrapper_data (method, strtoken);
 			} else if (method->wrapper_type != MONO_WRAPPER_NONE) {
-				s = mono_string_new_wrapper ((const char*)mono_method_get_wrapper_data (method, strtoken));
+				s = mono_string_new_wrapper_internal ((const char*)mono_method_get_wrapper_data (method, strtoken));
 			} else {
 				g_assert_not_reached ();
 			}
@@ -4247,7 +4247,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 			if (!(isinst_obj || ((m_class_get_rank (o->vtable->klass) == 0) && (m_class_get_element_class (o->vtable->klass) == m_class_get_element_class (c)))))
 				THROW_EX (mono_get_exception_invalid_cast (), ip);
 
-			sp [-1].data.p = mono_object_unbox (o);
+			sp [-1].data.p = mono_object_unbox_internal (o);
 			ip += 2;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_THROW)
@@ -4408,7 +4408,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 			if (!o)
 				THROW_EX (mono_get_exception_null_reference (), ip);
 			sp -= 2;
-			mono_gc_wbarrier_set_field (o, (char *) o + * (guint16 *)(ip + 1), sp [1].data.o);
+			mono_gc_wbarrier_set_field_internal (o, (char *) o + * (guint16 *)(ip + 1), sp [1].data.o);
 			ip += 2;
 			MINT_IN_BREAK;
 
@@ -4423,7 +4423,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 			i32 = mono_class_value_size (klass, NULL);
 
 			guint16 offset = * (guint16 *)(ip + 1);
-			mono_value_copy ((char *) o + offset, sp [1].data.p, klass);
+			mono_value_copy_internal ((char *) o + offset, sp [1].data.p, klass);
 
 			vt_sp -= ALIGN_TO (i32, MINT_VT_ALIGNMENT);
 			ip += 3;
@@ -4469,7 +4469,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 				mono_error_cleanup (error); /* FIXME: don't swallow the error */
 			} else
 #endif
-				mono_value_copy ((char *) o + field->offset, sp [-1].data.p, klass);
+				mono_value_copy_internal ((char *) o + field->offset, sp [-1].data.p, klass);
 
 			sp -= 2;
 			vt_sp -= ALIGN_TO (i32, MINT_VT_ALIGNMENT);
@@ -4592,7 +4592,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 
 			g_assert (!m_class_get_byval_arg (c)->byref);
 			if (MONO_TYPE_IS_REFERENCE (m_class_get_byval_arg (c)))
-				mono_gc_wbarrier_generic_store (sp [-2].data.o, sp [-1].data.o);
+				mono_gc_wbarrier_generic_store_internal (sp [-2].data.o, sp [-1].data.o);
 			else
 				stackval_to_data (m_class_get_byval_arg (c), &sp [-1], sp [-2].data.p, FALSE);
 			sp -= 2;
@@ -4719,10 +4719,10 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 			if (!s)
 				THROW_EX (mono_get_exception_null_reference (), ip);
 			i32 = sp [-1].data.i;
-			if (i32 < 0 || i32 >= mono_string_length (s))
+			if (i32 < 0 || i32 >= mono_string_length_internal (s))
 				THROW_EX (mono_get_exception_index_out_of_range (), ip);
 			--sp;
-			sp [-1].data.i = mono_string_chars(s)[i32];
+			sp [-1].data.i = mono_string_chars_internal (s)[i32];
 			++ip;
 			MINT_IN_BREAK;
 		}
@@ -4752,7 +4752,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 			o = sp [-1].data.o;
 			if (!o)
 				THROW_EX (mono_get_exception_null_reference (), ip);
-			sp [-1].data.i = mono_string_length ((MonoString*) o);
+			sp [-1].data.i = mono_string_length_internal ((MonoString*) o);
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_ARRAY_RANK)
 			o = sp [-1].data.o;
@@ -5848,7 +5848,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 				 * in ctor but we would need to handle AllocDelegateLike_internal separately
 				 */
 				ERROR_DECL (error);
-				MonoMethod *invoke = mono_get_delegate_invoke (del->object.vtable->klass);
+				MonoMethod *invoke = mono_get_delegate_invoke_internal (del->object.vtable->klass);
 				del->interp_invoke_impl = mono_interp_get_imethod (del->object.vtable->domain, mono_marshal_get_delegate_invoke (invoke, del), error);
 				mono_error_assert_ok (error);
 			}

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -73,7 +73,7 @@ ldvirtfn_internal (MonoObject *obj, MonoMethod *method, gboolean gshared)
 		return NULL;
 	}
 
-	res = mono_object_get_virtual_method (obj, method);
+	res = mono_object_get_virtual_method_internal (obj, method);
 
 	if (gshared && method->is_inflated && mono_method_get_context (method)->method_inst) {
 		MonoGenericContext context = { NULL, NULL };
@@ -1117,7 +1117,7 @@ mono_helper_compile_generic_method (MonoObject *obj, MonoMethod *method, gpointe
 		mono_error_set_pending_exception (error);
 		return NULL;
 	}
-	vmethod = mono_object_get_virtual_method (obj, method);
+	vmethod = mono_object_get_virtual_method_internal (obj, method);
 	g_assert (!mono_class_is_gtd (vmethod->klass));
 	g_assert (!mono_class_is_ginst (vmethod->klass) || !mono_class_get_generic_class (vmethod->klass)->context.class_inst->is_open);
 	g_assert (!context->method_inst || !context->method_inst->is_open);
@@ -1130,7 +1130,7 @@ mono_helper_compile_generic_method (MonoObject *obj, MonoMethod *method, gpointe
 
 	/* Since this is a virtual call, have to unbox vtypes */
 	if (m_class_is_valuetype (obj->vtable->klass))
-		*this_arg = mono_object_unbox (obj);
+		*this_arg = mono_object_unbox_internal (obj);
 	else
 		*this_arg = obj;
 
@@ -1400,7 +1400,7 @@ constrained_gsharedvt_call_setup (gpointer mp, MonoMethod *cmethod, MonoClass *k
 			*/
 			MonoObject *this_obj = *(MonoObject**)mp;
 
-			*this_arg = mono_object_unbox (this_obj);
+			*this_arg = mono_object_unbox_internal (this_obj);
 		} else {
 			/*
 			 * Calling a vtype method with a vtype receiver
@@ -1464,9 +1464,9 @@ void
 mono_gsharedvt_value_copy (gpointer dest, gpointer src, MonoClass *klass)
 {
 	if (m_class_is_valuetype (klass))
-		mono_value_copy (dest, src, klass);
+		mono_value_copy_internal (dest, src, klass);
 	else
-        mono_gc_wbarrier_generic_store (dest, *(MonoObject**)src);
+        mono_gc_wbarrier_generic_store_internal (dest, *(MonoObject**)src);
 }
 
 void
@@ -1904,7 +1904,7 @@ mono_llvmonly_init_delegate_virtual (MonoDelegate *del, MonoObject *target, Mono
 
 	g_assert (target);
 
-	method = mono_object_get_virtual_method (target, method);
+	method = mono_object_get_virtual_method_internal (target, method);
 
 	if (method->iflags & METHOD_IMPL_ATTRIBUTE_SYNCHRONIZED)
 		method = mono_marshal_get_synchronized_wrapper (method);

--- a/mono/mini/memory-access.c
+++ b/mono/mini/memory-access.c
@@ -416,7 +416,7 @@ mini_emit_memory_copy_internal (MonoCompile *cfg, MonoInst *dest, MonoInst *src,
 				if (size_ins)
 					mono_emit_jit_icall (cfg, mono_gsharedvt_value_copy, iargs);
 				else
-					mono_emit_jit_icall (cfg, mono_value_copy, iargs);
+					mono_emit_jit_icall (cfg, mono_value_copy_internal, iargs);
 			} else {
 				/* We don't unroll more than 5 stores to avoid code bloat. */
 				/*This is harmless and simplify mono_gc_get_range_copy_func */

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -4104,7 +4104,7 @@ handle_delegate_ctor (MonoCompile *cfg, MonoClass *klass, MonoInst *target, Mono
 	guint8 **code_slot;
 
 	if (virtual_ && !cfg->llvm_only) {
-		MonoMethod *invoke = mono_get_delegate_invoke (klass);
+		MonoMethod *invoke = mono_get_delegate_invoke_internal (klass);
 		g_assert (invoke);
 
 		//FIXME verify & fix any issue with removing invoke_context_used restriction
@@ -9216,7 +9216,7 @@ calli_end:
 					EMIT_NEW_LDSTRLITCONST (cfg, iargs [0], str);
 				else
 					EMIT_NEW_PCONST (cfg, iargs [0], str);
-				*sp = mono_emit_jit_icall (cfg, mono_string_new_wrapper, iargs);
+				*sp = mono_emit_jit_icall (cfg, mono_string_new_wrapper_internal, iargs);
 			} else {
 				if (cfg->opt & MONO_OPT_SHARED) {
 					MonoInst *iargs [3];
@@ -11480,7 +11480,7 @@ mono_ldptr:
 					MonoMethod *invoke;
 					int invoke_context_used;
 
-					invoke = mono_get_delegate_invoke (ctor_method->klass);
+					invoke = mono_get_delegate_invoke_internal (ctor_method->klass);
 					if (!invoke || !mono_method_signature_internal (invoke))
 						LOAD_ERROR;
 
@@ -11549,7 +11549,7 @@ mono_ldptr:
 					int invoke_context_used;
 					gboolean is_virtual = cmethod->flags & METHOD_ATTRIBUTE_VIRTUAL;
 
-					invoke = mono_get_delegate_invoke (ctor_method->klass);
+					invoke = mono_get_delegate_invoke_internal (ctor_method->klass);
 					if (!invoke || !mono_method_signature_internal (invoke))
 						LOAD_ERROR;
 

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -9495,9 +9495,9 @@ void
 default_mono_llvm_unhandled_exception (void)
 {
 	MonoJitTlsData *jit_tls = mono_get_jit_tls ();
-	MonoObject *target = mono_gchandle_get_target (jit_tls->thrown_exc);
+	MonoObject *target = mono_gchandle_get_target_internal (jit_tls->thrown_exc);
 
-	mono_unhandled_exception (target);
+	mono_unhandled_exception_internal (target);
 	mono_invoke_unhandled_exception_hook (target);
 	g_assert_not_reached ();
 }

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4767,7 +4767,7 @@ register_icalls (void)
 	register_icall (mono_helper_ldstr, "mono_helper_ldstr", "object ptr int", FALSE);
 	register_icall (mono_helper_ldstr_mscorlib, "mono_helper_ldstr_mscorlib", "object int", FALSE);
 	register_icall (mono_helper_newobj_mscorlib, "mono_helper_newobj_mscorlib", "object int", FALSE);
-	register_icall (mono_value_copy, "mono_value_copy", "void ptr ptr ptr", FALSE);
+	register_icall (mono_value_copy_internal, "mono_value_copy_internal", "void ptr ptr ptr", FALSE);
 	register_icall (mono_object_castclass_unbox, "mono_object_castclass_unbox", "object object ptr", FALSE);
 	register_icall (mono_break, "mono_break", NULL, TRUE);
 	register_icall (mono_create_corlib_exception_0, "mono_create_corlib_exception_0", "object int", TRUE);

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -578,7 +578,7 @@ common_call_trampoline (host_mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVTa
 
 		if (mono_object_is_transparent_proxy (this_arg)) {
 			/* Use the slow path for now */
-		    m = mono_object_get_virtual_method (this_arg, imt_method);
+		    m = mono_object_get_virtual_method_internal (this_arg, imt_method);
 			vtable_slot_to_patch = NULL;
 		} else {
 			if (imt_method->is_inflated && ((MonoMethodInflated*)imt_method)->context.method_inst) {
@@ -1264,7 +1264,7 @@ mono_delegate_trampoline (host_mgreg_t *regs, guint8 *code, gpointer *arg, guint
 			method->flags & METHOD_ATTRIBUTE_VIRTUAL && 
 			method->flags & METHOD_ATTRIBUTE_ABSTRACT &&
 			mono_class_is_abstract (method->klass)) {
-			method = mono_object_get_virtual_method (delegate->target, method);
+			method = mono_object_get_virtual_method_internal (delegate->target, method);
 			enable_caching = FALSE;
 		}
 
@@ -1600,7 +1600,7 @@ mono_create_delegate_trampoline_info (MonoDomain *domain, MonoClass *klass, Mono
 	if (tramp_info)
 		return tramp_info;
 
-	invoke = mono_get_delegate_invoke (klass);
+	invoke = mono_get_delegate_invoke_internal (klass);
 	g_assert (invoke);
 
 	tramp_info = (MonoDelegateTrampInfo *)mono_domain_alloc0 (domain, sizeof (MonoDelegateTrampInfo));
@@ -1646,7 +1646,7 @@ mono_create_delegate_trampoline (MonoDomain *domain, MonoClass *klass)
 gpointer
 mono_create_delegate_virtual_trampoline (MonoDomain *domain, MonoClass *klass, MonoMethod *method)
 {
-	MonoMethod *invoke = mono_get_delegate_invoke (klass);
+	MonoMethod *invoke = mono_get_delegate_invoke_internal (klass);
 	g_assert (invoke);
 
 	return mono_get_delegate_virtual_invoke_impl (mono_method_signature_internal (invoke), method);

--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -631,7 +631,7 @@ describe_variable (MonoStackFrameInfo *info, MonoContext *ctx, gpointer ud)
 			MonoString *str_obj = *(MonoString **)addr;
 			if (!str_obj)
 				mono_wasm_add_string_var (NULL);
-			char *str = mono_string_to_utf8_checked (str_obj, error);
+			char *str = mono_string_to_utf8_checked_internal (str_obj, error);
 			mono_error_assert_ok (error); /* FIXME report error */
 
 			mono_wasm_add_string_var (str);

--- a/mono/mini/trace.c
+++ b/mono/mini/trace.c
@@ -94,7 +94,7 @@ string_to_utf8 (MonoString *s)
 	if (!s->length)
 		return g_strdup ("");
 
-	as = g_utf16_to_utf8 (mono_string_chars (s), s->length, NULL, NULL, &gerror);
+	as = g_utf16_to_utf8 (mono_string_chars_internal (s), s->length, NULL, NULL, &gerror);
 	if (gerror) {
 		/* Happens with StringBuilders */
 		g_error_free (gerror);

--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -1197,7 +1197,7 @@ gc_reference (MonoObject *obj, MonoClass *klass, uintptr_t size, uintptr_t num, 
 
 	emit_event (logbuffer, TYPE_HEAP_OBJECT | TYPE_HEAP);
 	emit_obj (logbuffer, obj);
-	emit_ptr (logbuffer, mono_object_get_vtable (obj));
+	emit_ptr (logbuffer, mono_object_get_vtable_internal (obj));
 	emit_value (logbuffer, size);
 	emit_byte (logbuffer, mono_gc_get_generation (obj));
 	emit_value (logbuffer, num);
@@ -1503,7 +1503,7 @@ gc_alloc (MonoProfiler *prof, MonoObject *obj)
 {
 	int do_bt = (!log_config.enter_leave && mono_atomic_load_i32 (&log_profiler.runtime_inited) && log_config.num_frames) ? TYPE_ALLOC_BT : 0;
 	FrameData data;
-	uintptr_t len = mono_object_get_size (obj);
+	uintptr_t len = mono_object_get_size_internal (obj);
 	/* account for object alignment in the heap */
 	len += 7;
 	len &= ~7;
@@ -1525,7 +1525,7 @@ gc_alloc (MonoProfiler *prof, MonoObject *obj)
 	);
 
 	emit_event (logbuffer, do_bt | TYPE_ALLOC);
-	emit_ptr (logbuffer, mono_object_get_vtable (obj));
+	emit_ptr (logbuffer, mono_object_get_vtable_internal (obj));
 	emit_obj (logbuffer, obj);
 	emit_value (logbuffer, len);
 
@@ -1851,8 +1851,8 @@ class_loaded (MonoProfiler *prof, MonoClass *klass)
 static void
 vtable_loaded (MonoProfiler *prof, MonoVTable *vtable)
 {
-	MonoClass *klass = mono_vtable_class (vtable);
-	MonoDomain *domain = mono_vtable_domain (vtable);
+	MonoClass *klass = mono_vtable_class_internal (vtable);
+	MonoDomain *domain = mono_vtable_domain_internal (vtable);
 	uint32_t domain_id = domain ? mono_domain_get_id (domain) : 0;
 
 	ENTER_LOG (&vtable_loads_ctr, logbuffer,

--- a/mono/sgen/sgen-debug.c
+++ b/mono/sgen/sgen-debug.c
@@ -1014,7 +1014,7 @@ check_reference_for_xdomain (GCObject **ptr, GCObject *obj, MonoDomain *domain)
 
 	if (ref->vtable->klass == mono_defaults.string_class) {
 		ERROR_DECL (error);
-		str = mono_string_to_utf8_checked ((MonoString*)ref, error);
+		str = mono_string_to_utf8_checked_internal ((MonoString*)ref, error);
 		mono_error_cleanup (error);
 	} else
 		str = NULL;

--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -2976,10 +2976,10 @@ sgen_thread_detach_with_lock (SgenThreadInfo *p)
  */
 
 /**
- * mono_gc_wbarrier_arrayref_copy:
+ * mono_gc_wbarrier_arrayref_copy_internal:
  */
 void
-mono_gc_wbarrier_arrayref_copy (gpointer dest_ptr, gpointer src_ptr, int count)
+mono_gc_wbarrier_arrayref_copy_internal (gpointer dest_ptr, gpointer src_ptr, int count)
 {
 	HEAVY_STAT (++stat_wbarrier_arrayref_copy);
 	/*This check can be done without taking a lock since dest_ptr array is pinned*/
@@ -3004,10 +3004,10 @@ mono_gc_wbarrier_arrayref_copy (gpointer dest_ptr, gpointer src_ptr, int count)
 }
 
 /**
- * mono_gc_wbarrier_generic_nostore:
+ * mono_gc_wbarrier_generic_nostore_internal:
  */
 void
-mono_gc_wbarrier_generic_nostore (gpointer ptr)
+mono_gc_wbarrier_generic_nostore_internal (gpointer ptr)
 {
 	gpointer obj;
 
@@ -3037,22 +3037,22 @@ mono_gc_wbarrier_generic_nostore (gpointer ptr)
  * mono_gc_wbarrier_generic_store:
  */
 void
-mono_gc_wbarrier_generic_store (gpointer ptr, GCObject* value)
+mono_gc_wbarrier_generic_store_internal (gpointer ptr, GCObject* value)
 {
 	SGEN_LOG (8, "Wbarrier store at %p to %p (%s)", ptr, value, value ? sgen_client_vtable_get_name (SGEN_LOAD_VTABLE (value)) : "null");
 	SGEN_UPDATE_REFERENCE_ALLOW_NULL (ptr, value);
 	if (ptr_in_nursery (value) || sgen_concurrent_collection_in_progress)
-		mono_gc_wbarrier_generic_nostore (ptr);
+		mono_gc_wbarrier_generic_nostore_internal (ptr);
 	sgen_dummy_use (value);
 }
 
 /**
- * mono_gc_wbarrier_generic_store_atomic:
+ * mono_gc_wbarrier_generic_store_atomic_internal:
  * Same as \c mono_gc_wbarrier_generic_store but performs the store
  * as an atomic operation with release semantics.
  */
 void
-mono_gc_wbarrier_generic_store_atomic (gpointer ptr, GCObject *value)
+mono_gc_wbarrier_generic_store_atomic_internal (gpointer ptr, GCObject *value)
 {
 	HEAVY_STAT (++stat_wbarrier_generic_store_atomic);
 
@@ -3061,7 +3061,7 @@ mono_gc_wbarrier_generic_store_atomic (gpointer ptr, GCObject *value)
 	mono_atomic_store_ptr ((volatile gpointer *)ptr, value);
 
 	if (ptr_in_nursery (value) || sgen_concurrent_collection_in_progress)
-		mono_gc_wbarrier_generic_nostore (ptr);
+		mono_gc_wbarrier_generic_nostore_internal (ptr);
 
 	sgen_dummy_use (value);
 }

--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -3034,7 +3034,7 @@ mono_gc_wbarrier_generic_nostore_internal (gpointer ptr)
 }
 
 /**
- * mono_gc_wbarrier_generic_store:
+ * mono_gc_wbarrier_generic_store_internal:
  */
 void
 mono_gc_wbarrier_generic_store_internal (gpointer ptr, GCObject* value)

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -3648,11 +3648,10 @@ typedef struct _TestStruct {
 static gpointer
 lookup_mono_symbol (const char *symbol_name)
 {
-	gpointer symbol;
-	if (g_module_symbol (g_module_open (NULL, G_MODULE_BIND_LAZY), symbol_name, &symbol))
-		return symbol;
-	else
-		return NULL;
+	gpointer symbol = NULL;
+	const gboolean success = g_module_symbol (g_module_open (NULL, G_MODULE_BIND_LAZY), symbol_name, &symbol);
+	g_assertf (success, "%s", symbol_name);
+	return success ? symbol : NULL;
 }
 
 LIBTEST_API gpointer STDCALL

--- a/mono/unit-tests/test-mono-string.c
+++ b/mono/unit-tests/test-mono-string.c
@@ -14,7 +14,7 @@ new_string_ok (void)
 	MonoString *s = mono_string_new_checked (mono_domain_get (), "abcd", error);
 	static const gunichar2 u16s[] = { 0x61, 0x62, 0x63, 0x64, 0 }; /* u16 "abcd" */
 	mono_error_assert_ok (error);
-	gunichar2* c = mono_string_chars (s);
+	gunichar2* c = mono_string_chars_internal (s);
 
 	g_assert (c != NULL && !memcmp (&u16s, c, sizeof (u16s)));
 	return 0;
@@ -28,7 +28,7 @@ new_string_utf8 (void)
 	static const unsigned char bytes[] = { 0xE2, 0x98, 0x83, 0x00 }; /* U+2603 NUL */
 	MonoString *s = mono_string_new_checked (mono_domain_get (), (const char*)bytes, error);
 	mono_error_assert_ok (error);
-	gunichar2* c = mono_string_chars (s);
+	gunichar2* c = mono_string_chars_internal (s);
 	g_assert (c != NULL &&
 		  (c[0] == snowman) &&
 		  (c[1] == 0));

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -62,7 +62,7 @@ get_class (MonoErrorInternal *error)
 {
 	MonoClass *klass = NULL;
 	if (is_managed_exception (error))
-		klass = mono_object_class (mono_gchandle_get_target (error->exn.instance_handle));
+		klass = mono_object_class (mono_gchandle_get_target_internal (error->exn.instance_handle));
 	else
 		klass = error->exn.klass;
 	return klass;
@@ -134,7 +134,7 @@ mono_error_cleanup (MonoError *oerror)
 
 
 	if (has_instance_handle)
-		mono_gchandle_free (error->exn.instance_handle);
+		mono_gchandle_free_internal (error->exn.instance_handle);
 
 
 	g_free ((char*)error->full_message);
@@ -459,7 +459,7 @@ mono_error_set_exception_instance (MonoError *oerror, MonoException *exc)
 
 	mono_error_prepare (error);
 	error->error_code = MONO_ERROR_EXCEPTION_INSTANCE;
-	error->exn.instance_handle = mono_gchandle_new (exc ? &exc->object : NULL, FALSE);
+	error->exn.instance_handle = mono_gchandle_new_internal (exc ? &exc->object : NULL, FALSE);
 }
 
 void

--- a/msvc/libmonoruntime-common.targets
+++ b/msvc/libmonoruntime-common.targets
@@ -37,6 +37,8 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\environment.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\exception.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\exception-internals.h" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\external-only.c" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\external-only.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32file.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32file.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32file-internals.h" />

--- a/msvc/libmonoruntime-common.targets
+++ b/msvc/libmonoruntime-common.targets
@@ -37,7 +37,7 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\environment.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\exception.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\exception-internals.h" />
-    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\external-only.c" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\external-only.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\external-only.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32file.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32file.h" />

--- a/msvc/libmonoruntime-common.targets.filters
+++ b/msvc/libmonoruntime-common.targets.filters
@@ -100,6 +100,12 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\exception-internals.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common</Filter>
     </ClInclude>
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\external-only.c">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common</Filter>
+    </ClCompile>
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\external-only.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common</Filter>
+    </ClInclude>
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32file.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common</Filter>
     </ClCompile>

--- a/msvc/libmonoruntime-common.targets.filters
+++ b/msvc/libmonoruntime-common.targets.filters
@@ -100,9 +100,9 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\exception-internals.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common</Filter>
     </ClInclude>
-    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\external-only.c">
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\external-only.c">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common</Filter>
-    </ClCompile>
+    </ClInclude>
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\external-only.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common</Filter>
     </ClInclude>


### PR DESCRIPTION
In general this is achieved by renaming mono_foo to mono_foo_internal,
and mono_foo calls mono_foo_internal, possibly adding a GC mode change
to mono_foo and removing from mono_foo_internal.

Going forward though the wrapping could diverge further. For example, all the _internal functions could only accept/return coop handles, whereas currently they handle a lot of raw pointers.

This gives us leeway to limit gc mode changes to embedders,
and more generally to separate the runtime from the embedding API.