### PR TITLE
Fix MessageBox text color for dark themes

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/MessageBox.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/MessageBox.cs
@@ -200,7 +200,7 @@ namespace System.Windows.Forms
 
 			internal override void OnPaintInternal (PaintEventArgs e)
 			{
-				e.Graphics.DrawString (msgbox_text, this.Font, ThemeEngine.Current.ResPool.GetSolidBrush (Color.Black), text_rect);
+				e.Graphics.DrawString (msgbox_text, this.Font, ThemeEngine.Current.ResPool.GetSolidBrush (SystemColors.ControlText), text_rect);
 				if (icon_image != null) {
 					e.Graphics.DrawIcon(icon_image, space_border, space_border);
 				}


### PR DESCRIPTION
## Problem

`MessageBox` displays as black-on-dark in a dark theme:

![image](https://user-images.githubusercontent.com/1559108/47039608-f64f2580-d149-11e8-9c1d-1dd8d99d4cb8.png)

This can be difficult to read.

## Cause

The text is drawn with a hard coded color of `Color.Black`. This assumes that the background under the text will be light to contrast with black.

## Changes

Now the color is `SystemColors.ControlText` instead, to match the background of the popup.

In a normal theme this will still be black.