### PR TITLE
[corlib] Ensure that Console Streams are thread-safe

### DIFF
--- a/mcs/class/corlib/System/Console.cs
+++ b/mcs/class/corlib/System/Console.cs
@@ -243,7 +243,7 @@ namespace System
 			if (newError == null)
 				throw new ArgumentNullException ("newError");
 
-			stderr = newError;
+			stderr = TextWriter.Synchronized (newError);
 		}
 
 		[SecurityPermission (SecurityAction.Demand, UnmanagedCode = true)]
@@ -252,7 +252,7 @@ namespace System
 			if (newIn == null)
 				throw new ArgumentNullException ("newIn");
 
-			stdin = newIn;
+			stdin = TextReader.Synchronized (newIn);
 		}
 
 		[SecurityPermission (SecurityAction.Demand, UnmanagedCode = true)]
@@ -261,7 +261,7 @@ namespace System
 			if (newOut == null)
 				throw new ArgumentNullException ("newOut");
 
-			stdout = newOut;
+			stdout = TextWriter.Synchronized (newOut);
 		}
 
 		public static void Write (bool value)


### PR DESCRIPTION
The Console class wraps the standard system stream reader/writers on construction so as to expose them as thread-safe. However, the Set-Out/In/Err methods in referencesource do not do the same when they replace default targets.

CoreFX code does: https://github.com/mono/corefx/blob/1748f6492e8b96842f76e1a9e7b5d7e8ccfca480/src/System.Console/src/System/Console.cs#L412-L444

Possible fix for https://github.com/mono/mono/issues/11146