### PR TITLE
[2018-06] [aot] Ensure shared got entries are initialized before loading methods

### DIFF
--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -105,7 +105,7 @@ typedef struct MonoAotModule {
 	guint32 image_table_len;
 	gboolean out_of_date;
 	gboolean plt_inited;
-	gboolean got_initializing;
+	gboolean got_initialized;
 	guint8 *mem_begin;
 	guint8 *mem_end;
 	guint8 *jit_code_start;
@@ -1942,10 +1942,15 @@ init_amodule_got (MonoAotModule *amodule)
 	int i, npatches;
 
 	/* These can't be initialized in load_aot_module () */
-	if (amodule->shared_got [0] || amodule->got_initializing)
+	if (amodule->got_initialized)
 		return;
 
-	amodule->got_initializing = TRUE;
+	mono_loader_lock ();
+
+	if (amodule->got_initialized) {
+		mono_loader_unlock ();
+		return;
+	}
 
 	mp = mono_mempool_new ();
 	npatches = amodule->info.nshared_got_entries;
@@ -1991,6 +1996,10 @@ init_amodule_got (MonoAotModule *amodule)
 	}
 
 	mono_mempool_destroy (mp);
+
+	mono_memory_barrier ();
+	amodule->got_initialized = TRUE;
+	mono_loader_unlock ();
 }
 
 static void


### PR DESCRIPTION
Backport of #11190.

/cc @luhenry @BrzVlad

Description:
Executing aot code that uses them would crash. Fixes random csc crashes.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
