### PR TITLE
[runtime] Don't init classes in ves_icall_RuntimeTypeHandle_is_subclass_of

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1754,12 +1754,7 @@ ves_icall_RuntimeTypeHandle_is_subclass_of (MonoType *childType, MonoType *baseT
 	MonoClass *baseClass;
 
 	childClass = mono_class_from_mono_type_internal (childType);
-	mono_class_init_checked (childClass, error);
-	goto_if_nok (error, done);
-
 	baseClass = mono_class_from_mono_type_internal (baseType);
-	mono_class_init_checked (baseClass, error);
-	goto_if_nok (error, done);
 
 	if (G_UNLIKELY (childType->byref)) {
 		result = !baseType->byref && baseClass == mono_defaults.object_class;


### PR DESCRIPTION

We must not get a TLE if referenced types are in an assembly that can't be
loaded.

Fixes https://github.com/mono/mono/issues/11123

TODO:
- [ ] Add test case.  (It's a bit annoying because we need to compile against an assembly that should be missing at execution time)