### PR TITLE
Add myself as code owner of `mono/native` and some managed code.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,17 +42,21 @@
 /mcs/build @marek-safar @akoeplinger
 
 /mcs/class @marek-safar @akoeplinger
+/mcs/class/corlib/Mono @baulig
 /mcs/class/corlib/System.Reflection*/ @vargaz @lambdageek
+/mcs/class/corlib/System.Security.Cryptography.X509Certificates @baulig
 /mcs/class/Mono.Btls.Interface @baulig
 /mcs/class/Mono.Data.Tds @egorbo
 /mcs/class/Mono.Debugger.Soft @vargaz
 /mcs/class/Mono.Options @jonpryor
 /mcs/class/Mono.Profiler.Log @alexrp
 /mcs/class/Mono.Security/Mono.Security/Interface @baulig
+/mcs/class/System/Mono @baulig
 /mcs/class/System/Mono.AppleTls @baulig
 /mcs/class/System/Mono.Btls @baulig
 /mcs/class/System/Mono.Net.Security @baulig
 /mcs/class/System/Mono.Security.Interface @baulig
+/mcs/class/System/System.Security.Cryptography.X509Certificates @baulig
 /mcs/class/System.Data* @egorbo
 
 /mcs/errors @marek-safar
@@ -86,6 +90,8 @@
 /mono/mini/interp/* @lewurm @BrzVlad
 /mono/mini/*profiler* @alexrp
 /mono/mini/debugger-agent.c @DavidKarlas
+
+/mono/native @baulig
 
 /mono/profiler @alexrp @kumpera
 


### PR DESCRIPTION
Add myself as code owner of

- `mono/native`
- `/mcs/class/corlib/Mono` (dependency injector, mono native, pal, certificates)
- `mcs/class/corlib/System.Security.Cryptography.X509Certificates`
- `/mcs/class/System/Mono` (PAL, certificates and dependency injector)
- `/mcs/class/System/System.Security.Cryptography.X509Certificates`
