### PR TITLE
[wasm] [packager] Fix Duplicate assemblies in `config.js` file_list: [ ... ]

### DIFF
--- a/sdks/wasm/packager.cs
+++ b/sdks/wasm/packager.cs
@@ -291,7 +291,7 @@ class Driver {
 		File.Delete (runtime_js);
 		File.Copy (runtimeTemplate, runtime_js);
 
-		var file_list_str = string.Join (",", file_list.Select (f => $"\"{Path.GetFileName (f)}\""));
+		var file_list_str = string.Join (",", file_list.Select (f => $"\"{Path.GetFileName (f)}\"").Distinct());
 		var config = String.Format ("config = {{\n \tvfs_prefix: \"{0}\",\n \tdeploy_prefix: \"{1}\",\n \tenable_debugging: {2},\n \tfile_list: [ {3} ],\n", vfs_prefix, deploy_prefix, enable_debug ? "1" : "0", file_list_str);
 		if (add_binding || true)
 			config += "\tadd_bindings: function() { " + $"Module.mono_bindings_init (\"[{BINDINGS_ASM_NAME}]{BINDINGS_RUNTIME_CLASS_NAME}\");" + " }\n";


### PR DESCRIPTION

packager.exe should not write duplicate assembly entries to the list of assemblies to load when writing the config.js file_list: [].

resolves: https://github.com/mono/mono/issues/11187

