### PR TITLE
[2018-10] [sdks] Package what’s missing for XA

### DIFF
--- a/mcs/build/Makefile
+++ b/mcs/build/Makefile
@@ -2,7 +2,7 @@ thisdir = build
 SUBDIRS = 
 include ../build/rules.make
 
-BUILT_FILES = common/Consts.cs common/MonoNativeConfig.cs
+BUILT_FILES = common/Consts.cs $(topdir)/class/lib/$(PROFILE_DIRECTORY)/Consts.cs common/MonoNativeConfig.cs
 
 all-local install-local test-local run-test-local csproj-local run-test-ondotnet-local uninstall-local doc-update-local: $(BUILT_FILES)
 	@:
@@ -10,7 +10,10 @@ all-local install-local test-local run-test-local csproj-local run-test-ondotnet
 clean-local:
 	-rm -f $(BUILT_FILES) deps/*
 
-common/Consts.cs: common/Consts.cs.in $(wildcard config.make)
+$(topdir)/class/lib/$(PROFILE_DIRECTORY):
+	mkdir -p $@
+
+common/Consts.cs $(topdir)/class/lib/$(PROFILE_DIRECTORY)/Consts.cs: common/Consts.cs.in $(wildcard config.make) | $(topdir)/class/lib/$(PROFILE_DIRECTORY)
 	test -n '$(MONO_VERSION)'
 	test -n '$(MONO_CORLIB_VERSION)'
 	sed -e 's,@''MONO_VERSION@,$(MONO_VERSION),' -e 's,@''MONO_CORLIB_VERSION@,$(MONO_CORLIB_VERSION),' $< > $@

--- a/mono/eglib/Makefile.am
+++ b/mono/eglib/Makefile.am
@@ -56,6 +56,10 @@ libeglib_la_SOURCES = \
 	$(os_files)
 
 CFLAGS := $(filter-out @CXX_REMOVE_CFLAGS@, @CFLAGS@) @CXX_ADD_CFLAGS@
+
+eglibdir=$(datadir)/mono-$(API_VER)/mono/eglib
+eglib_DATA = eglib-config.h
+
 libeglib_la_CFLAGS = -g -Wall -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE
 
 AM_CPPFLAGS = -I$(srcdir)


### PR DESCRIPTION
Backport of #11253.

/cc @luhenry 

Description:
They require the additional files:
 - mono/eglib/eglib-config.h: that's to build `libmonodroid`
 - mcs/build/Consts.cs: that's to build `Mono.Posix` and `Mono.Data.Sqlite`