### PR TITLE
Extend WasmHttpMessageHandler

### DIFF
--- a/sdks/wasm/WasmHttpMessageHandler.cs
+++ b/sdks/wasm/WasmHttpMessageHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -10,7 +11,6 @@ namespace WebAssembly.Net.Http.HttpClient
 {
     public class WasmHttpMessageHandler : HttpMessageHandler
     {
-
         static JSObject json;
         static JSObject fetch;
         static JSObject window;
@@ -29,6 +29,22 @@ namespace WebAssembly.Net.Http.HttpClient
         public static RequestMode Mode { get; set; }
             = RequestMode.Cors;
 
+
+        /// <summary>
+        /// Gets whether the current Browser supports streaming responses
+        /// </summary>
+        public static bool StreamingSupported { get; }
+
+        /// <summary>
+        /// Gets or sets whether responses should be streamed if supported
+        /// </summary>
+        public static bool StreamingEnabled { get; set; } = true;
+
+        static WasmHttpMessageHandler()
+        {
+            StreamingSupported = Runtime.InvokeJS("'body' in Response.prototype && typeof ReadableStream === 'function'") == "true";
+        }
+
         public WasmHttpMessageHandler()
         {
             handlerInit();
@@ -40,13 +56,13 @@ namespace WebAssembly.Net.Http.HttpClient
             json = (JSObject)WebAssembly.Runtime.GetGlobalObject("JSON");
             fetch = (JSObject)WebAssembly.Runtime.GetGlobalObject("fetch");
 
-            // install our global hook to create a Headers object.  
+            // install our global hook to create a Headers object.
             Runtime.InvokeJS(@"
                 BINDING.mono_wasm_get_global()[""__mono_wasm_headers_hook__""] = function () { return new Headers(); }
+                BINDING.mono_wasm_get_global()[""__mono_wasm_abortcontroller_hook__""] = function () { return new AbortController(); }
             ");
 
             global = (JSObject)WebAssembly.Runtime.GetGlobalObject("");
-
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -55,15 +71,14 @@ namespace WebAssembly.Net.Http.HttpClient
             cancellationToken.Register(() => tcs.TrySetCanceled());
 
             #pragma warning disable 4014
-            doFetch(tcs, request).ConfigureAwait(false);
+            doFetch(tcs, request, cancellationToken).ConfigureAwait(false);
             #pragma warning restore 4014
 
             return await tcs.Task;
         }
 
-        private async Task doFetch(TaskCompletionSource<HttpResponseMessage> tcs, HttpRequestMessage request)
+        private async Task doFetch(TaskCompletionSource<HttpResponseMessage> tcs, HttpRequestMessage request, CancellationToken cancellationToken)
         {
-
             try
             {
                 var requestObject = (JSObject)json.Invoke("parse", "{}");
@@ -91,7 +106,7 @@ namespace WebAssembly.Net.Http.HttpClient
                     else
                     {
                         requestObject.SetObjectProperty("body", await request.Content.ReadAsByteArrayAsync());
-                    }  
+                    }
                 }
 
                 // Process headers
@@ -112,6 +127,15 @@ namespace WebAssembly.Net.Http.HttpClient
                     }
                 }
 
+                JSObject abortController = null;
+                if (cancellationToken.CanBeCanceled)
+                {
+                    abortController = (JSObject)global.Invoke("__mono_wasm_abortcontroller_hook__");
+                    var signal = abortController.GetObjectProperty("signal");
+                    requestObject.SetObjectProperty("signal", signal);
+                    cancellationToken.Register(() => abortController?.Invoke("abort"));
+                }
+
                 var args = (JSObject)json.Invoke("parse", "[]");
                 args.Invoke("push", request.RequestUri.ToString());
                 args.Invoke("push", requestObject);
@@ -123,7 +147,7 @@ namespace WebAssembly.Net.Http.HttpClient
 
                 var t = await response;
 
-                var status = new WasmFetchResponse((JSObject)t);
+                var status = new WasmFetchResponse((JSObject)t, abortController);
 
                 //Console.WriteLine($"bodyUsed: {status.IsBodyUsed}");
                 //Console.WriteLine($"ok: {status.IsOK}");
@@ -132,24 +156,21 @@ namespace WebAssembly.Net.Http.HttpClient
                 //Console.WriteLine($"statusText: {status.StatusText}");
                 //Console.WriteLine($"type: {status.ResponseType}");
                 //Console.WriteLine($"url: {status.Url}");
-                byte[] buffer = null;
-                buffer = (byte[])await status.ArrayBuffer();
 
                 HttpResponseMessage httpresponse = new HttpResponseMessage((HttpStatusCode)Enum.Parse(typeof(HttpStatusCode), status.Status.ToString()));
 
-                if (buffer != null)
-                    httpresponse.Content = new ByteArrayContent(buffer);
-
-                buffer = null;
+                httpresponse.Content = StreamingSupported && StreamingEnabled
+                    ? new StreamContent(new WasmHttpReadStream(status))
+                    : (HttpContent)new WasmHttpContent(status);
 
                 // Fill the response headers
                 // CORS will only allow access to certain headers.
-                // If a request is made for a resource on another origin which returns the CORs headers, then the type is cors. 
-                // cors and basic responses are almost identical except that a cors response restricts the headers you can view to 
+                // If a request is made for a resource on another origin which returns the CORs headers, then the type is cors.
+                // cors and basic responses are almost identical except that a cors response restricts the headers you can view to
                 // `Cache-Control`, `Content-Language`, `Content-Type`, `Expires`, `Last-Modified`, and `Pragma`.
                 // View more information https://developers.google.com/web/updates/2015/03/introduction-to-fetch#response_types
                 //
-                // Note: Some of the headers may not even be valid header types in .NET thus we use TryAddWithoutValidation 
+                // Note: Some of the headers may not even be valid header types in .NET thus we use TryAddWithoutValidation
                 using (var respHeaders = status.Headers)
                 {
                     // Here we invoke the forEach on the headers object
@@ -166,34 +187,29 @@ namespace WebAssembly.Net.Http.HttpClient
                     ));
                 }
 
-
                 tcs.SetResult(httpresponse);
-
-                httpresponse = null;
-                
-                status.Dispose();
             }
-            catch (Exception exception) 
+            catch (Exception exception)
             {
                 tcs.SetException(exception);
             }
-
-
         }
-        
+
         private string[][] GetHeadersAsStringArray(HttpRequestMessage request)
             => (from header in request.Headers.Concat(request.Content?.Headers ?? Enumerable.Empty<KeyValuePair<string, IEnumerable<string>>>())
-                    from headerValue in header.Value // There can be more than one value for each name
-                    select new[] { header.Key, headerValue }).ToArray();
+                from headerValue in header.Value // There can be more than one value for each name
+                select new[] { header.Key, headerValue }).ToArray();
 
         class WasmFetchResponse : IDisposable
         {
             private JSObject managedJSObject;
-            private int JSHandle;
+            private JSObject abortController;
+            private readonly int JSHandle;
 
-            public WasmFetchResponse(JSObject jsobject)
+            public WasmFetchResponse(JSObject jsobject, JSObject abortController)
             {
                 managedJSObject = jsobject;
+                this.abortController = abortController;
                 JSHandle = managedJSObject.JSHandle;
             }
 
@@ -206,6 +222,7 @@ namespace WebAssembly.Net.Http.HttpClient
             //public bool IsUseFinalURL => (bool)managedJSObject.GetObjectProperty("useFinalUrl");
             public bool IsBodyUsed => (bool)managedJSObject.GetObjectProperty("bodyUsed");
             public JSObject Headers => (JSObject)managedJSObject.GetObjectProperty("headers");
+            public JSObject Body => (JSObject)managedJSObject.GetObjectProperty("body");
 
             public Task<object> ArrayBuffer() => (Task<object>)managedJSObject.Invoke("arrayBuffer");
             public Task<object> Text() => (Task<object>)managedJSObject.Invoke("text");
@@ -222,10 +239,8 @@ namespace WebAssembly.Net.Http.HttpClient
             // Protected implementation of Dispose pattern.
             protected virtual void Dispose(bool disposing)
             {
-
                 if (disposing)
                 {
-
                     // Free any other managed objects here.
                     //
                 }
@@ -234,8 +249,178 @@ namespace WebAssembly.Net.Http.HttpClient
                 //
                 managedJSObject?.Dispose();
                 managedJSObject = null;
+
+                abortController?.Dispose();
+                abortController = null;
             }
 
+        }
+
+        class WasmHttpContent : HttpContent
+        {
+            byte[] _data;
+            WasmFetchResponse _status;
+
+            public WasmHttpContent(WasmFetchResponse status)
+            {
+                _status = status;
+            }
+
+            private async Task<byte[]> GetResponseData()
+            {
+                if (_data != null)
+                {
+                    return _data;
+                }
+
+                _data = (byte[])await _status.ArrayBuffer();
+                _status.Dispose();
+                _status = null;
+
+                return _data;
+            }
+
+            protected override async Task<Stream> CreateContentReadStreamAsync()
+            {
+                var data = await GetResponseData();
+                return new MemoryStream(data, writable: false);
+            }
+
+            protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
+            {
+                var data = await GetResponseData();
+                await stream.WriteAsync(data, 0, data.Length);
+            }
+
+            protected override bool TryComputeLength(out long length)
+            {
+                if (_data != null)
+                {
+                    length = _data.Length;
+                    return true;
+                }
+
+                length = 0;
+                return false;
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                _status?.Dispose();
+                base.Dispose(disposing);
+            }
+        }
+
+        class WasmHttpReadStream : Stream
+        {
+            WasmFetchResponse _status;
+            JSObject _reader;
+
+            byte[] _bufferedBytes;
+            int _position;
+
+            public WasmHttpReadStream(WasmFetchResponse status)
+            {
+                _status = status;
+            }
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position
+            {
+                get => throw new NotSupportedException();
+                set => throw new NotSupportedException();
+            }
+
+            public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                if (buffer == null)
+                {
+                    throw new ArgumentNullException(nameof(buffer));
+                }
+                if (offset < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(offset));
+                }
+                if (count < 0 || buffer.Length - offset < count)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(count));
+                }
+
+                if (_reader == null)
+                {
+                    using (var body = _status.Body)
+                    {
+                        _reader = (JSObject)body.Invoke("getReader");
+                    }
+                    _status.Dispose();
+                    _status = null;
+                }
+
+                if (_bufferedBytes != null && _position < _bufferedBytes.Length)
+                {
+                    return ReadBuffered();
+                }
+
+                var t = (Task<object>)_reader.Invoke("read");
+                using (var read = (JSObject)await t)
+                {
+                    if ((bool)read.GetObjectProperty("done"))
+                    {
+                        return 0;
+                    }
+
+                    _position = 0;
+                    _bufferedBytes = (byte[])read.GetObjectProperty("value");
+                }
+
+                return ReadBuffered();
+
+                int ReadBuffered()
+                {
+                    int n = _bufferedBytes.Length - _position;
+                    if (n > count)
+                        n = count;
+                    if (n <= 0)
+                        return 0;
+
+                    Buffer.BlockCopy(_bufferedBytes, _position, buffer, offset, n);
+                    _position += n;
+
+                    return n;
+                }
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                _status?.Dispose();
+            }
+
+            public override void Flush()
+            {
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                throw new PlatformNotSupportedException("Synchronous reads are not supported, use ReadAsync instead");
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                throw new NotSupportedException();
+            }
         }
 
     }
@@ -279,14 +464,14 @@ namespace WebAssembly.Net.Http.HttpClient
         Default,
 
         /// <summary>
-        /// The browser fetches the resource from the remote server without first looking in the cache, 
+        /// The browser fetches the resource from the remote server without first looking in the cache,
         /// and will not update the cache with the downloaded resource.
         /// </summary>
         [Export("no-store")]
         NoStore,
 
         /// <summary>
-        /// The browser fetches the resource from the remote server without first looking in the cache, 
+        /// The browser fetches the resource from the remote server without first looking in the cache,
         /// but then will update the cache with the downloaded resource.
         /// </summary>
         [Export(EnumValue = ConvertEnum.ToLower)]
@@ -324,14 +509,14 @@ namespace WebAssembly.Net.Http.HttpClient
         SameOrigin,
 
         /// <summary>
-        /// Prevents the method from being anything other than HEAD, GET or POST, and the headers from 
+        /// Prevents the method from being anything other than HEAD, GET or POST, and the headers from
         /// being anything other than simple headers.
         /// </summary>
         [Export("no-cors")]
         NoCors,
 
         /// <summary>
-        /// Allows cross-origin requests, for example to access various APIs offered by 3rd party vendors. 
+        /// Allows cross-origin requests, for example to access various APIs offered by 3rd party vendors.
         /// </summary>
         [Export(EnumValue = ConvertEnum.ToLower)]
         Cors,

--- a/sdks/wasm/WasmHttpMessageHandler.cs
+++ b/sdks/wasm/WasmHttpMessageHandler.cs
@@ -351,6 +351,12 @@ namespace WebAssembly.Net.Http.HttpClient
 
                 if (_reader == null)
                 {
+                    // If we've read everything, then _reader and _status will be null
+                    if (_status == null)
+                    {
+                        return 0;
+                    }
+
                     using (var body = _status.Body)
                     {
                         _reader = (JSObject)body.Invoke("getReader");
@@ -369,6 +375,8 @@ namespace WebAssembly.Net.Http.HttpClient
                 {
                     if ((bool)read.GetObjectProperty("done"))
                     {
+                        _reader.Dispose();
+                        _reader = null;
                         return 0;
                     }
 
@@ -395,6 +403,7 @@ namespace WebAssembly.Net.Http.HttpClient
 
             protected override void Dispose(bool disposing)
             {
+                _reader?.Dispose();
                 _status?.Dispose();
             }
 


### PR DESCRIPTION
- Adds support for HttpCompletionOption.ResponseHeadersRead by delaying reading of the response body into HttpContent
- Adds optional support for streaming responses in supported browsers
- Adds support for canceling in flight fetch requests