### PR TITLE
[2018-08] [sdks] Package what's missing for XA

### DIFF
--- a/mcs/build/Makefile
+++ b/mcs/build/Makefile
@@ -2,7 +2,7 @@ thisdir = build
 SUBDIRS = 
 include ../build/rules.make
 
-BUILT_FILES = common/Consts.cs
+BUILT_FILES = common/Consts.cs $(topdir)/class/lib/$(PROFILE_DIRECTORY)/Consts.cs
 
 all-local install-local test-local run-test-local csproj-local run-test-ondotnet-local uninstall-local doc-update-local: $(BUILT_FILES)
 	@:
@@ -10,7 +10,10 @@ all-local install-local test-local run-test-local csproj-local run-test-ondotnet
 clean-local:
 	-rm -f $(BUILT_FILES) deps/*
 
-common/Consts.cs: common/Consts.cs.in $(wildcard config.make)
+$(topdir)/class/lib/$(PROFILE_DIRECTORY):
+	mkdir -p $@
+
+common/Consts.cs $(topdir)/class/lib/$(PROFILE_DIRECTORY)/Consts.cs: common/Consts.cs.in $(wildcard config.make) | $(topdir)/class/lib/$(PROFILE_DIRECTORY)
 	test -n '$(MONO_VERSION)'
 	test -n '$(MONO_CORLIB_VERSION)'
 	sed -e 's,@''MONO_VERSION@,$(MONO_VERSION),' -e 's,@''MONO_CORLIB_VERSION@,$(MONO_CORLIB_VERSION),' $< > $@

--- a/mono/eglib/Makefile.am
+++ b/mono/eglib/Makefile.am
@@ -53,6 +53,9 @@ libeglib_la_SOURCES = \
 	unicode-data.h	\
 	$(os_files)
 
+eglibdir=$(datadir)/mono-$(API_VER)/mono/eglib
+eglib_DATA = eglib-config.h
+
 libeglib_la_CFLAGS = -g -Wall -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE
 
 AM_CPPFLAGS = -I$(srcdir)


### PR DESCRIPTION
Backport of https://github.com/mono/mono/pull/11253.

Description:
They require the additional files:
 - mono/eglib/eglib-config.h: that's to build `libmonodroid`
 - mcs/build/Consts.cs: that's to build `Mono.Posix` and `Mono.Data.Sqlite`