### PR TITLE
[class] Ensure 'cast_class' is initialized for array type classes.

### DIFF
--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -4159,9 +4159,15 @@ mono_class_init (MonoClass *klass)
 	klass_byval_arg = m_class_get_byval_arg (klass);
 	if (klass_byval_arg->type == MONO_TYPE_ARRAY || klass_byval_arg->type == MONO_TYPE_SZARRAY) {
 		MonoClass *element_class = klass->element_class;
+		MonoClass *cast_class = klass->cast_class;
+
 		if (!element_class->inited) 
 			mono_class_init (element_class);
 		if (mono_class_set_type_load_failure_causedby_class (klass, element_class, "Could not load array element class"))
+			goto leave;
+		if (!cast_class->inited)
+			mono_class_init (cast_class);
+		if (mono_class_set_type_load_failure_causedby_class (klass, element_class, "Could not load array cast class"))
 			goto leave;
 	}
 

--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -4167,7 +4167,7 @@ mono_class_init (MonoClass *klass)
 			goto leave;
 		if (!cast_class->inited)
 			mono_class_init (cast_class);
-		if (mono_class_set_type_load_failure_causedby_class (klass, element_class, "Could not load array cast class"))
+		if (mono_class_set_type_load_failure_causedby_class (klass, cast_class, "Could not load array cast class"))
 			goto leave;
 	}
 

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -692,8 +692,9 @@ TESTS_CS_SRC=		\
 	nested_type_visibility.cs	\
 	dynamic-method-churn.cs	\
 	verbose.cs \
-	generic-unmanaged-constraint.cs	\
-	bug-10834.cs
+	generic-unmanaged-constraint.cs \
+	bug-10834.cs \
+	bug-gh-9507.cs
 
 # some tests fail to compile on mcs
 if CSC_IS_ROSLYN

--- a/mono/tests/bug-gh-9507.cs
+++ b/mono/tests/bug-gh-9507.cs
@@ -1,0 +1,21 @@
+using type_with_special_array_cast = System.UInt64; // MonoClass<ulong[]>::cast_class = long
+using other_type = System.Double;
+
+public class TestIsInst<T>
+{
+	public T[] array;
+
+	public TestIsInst() {
+		array = new T[16];
+
+		if (array is other_type[]) // should not crash or throw NullReferenceException
+			throw new System.Exception("Unreachable");
+	}
+}
+
+public class Bug9507  // https://github.com/mono/mono/issues/9507
+{
+	public static void Main () {
+		var table = new TestIsInst<type_with_special_array_cast> ();
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/9507

Background: Monoclass:cast_class is used internally to allow for some interfaces to be assignable to each other if they share a "storage class" instead of the class's element class. This is used to i.e. implement IList<ulong> being assignable from IList<long> (IList<ulong> has cast_class=long)

Consider a GenericClass<T> with a T[] field. On instantiation with e.g. GenericClass<ulong> , the ulong[] array class will be generated. As above, ulong[] has cast_class=long
When mono_class_init() is called on an array class, its element_class is also initialized.
If GenericClass<T>:Method() uses any type/subtype checking (e.g. if (field is double[]) ), those may attempt to use cast_class, which is not ensured as initialized.
