### PR TITLE
[Microsoft.Build.Engine] Fix race condition in TestTasks.dll compilation and embedding

### DIFF
--- a/mcs/class/Microsoft.Build.Engine/Makefile
+++ b/mcs/class/Microsoft.Build.Engine/Makefile
@@ -12,12 +12,7 @@ KEYFILE = ../msfinal.pub
 LIB_MCS_FLAGS =
 
 TEST_RESOURCE_FILES = \
-	$(wildcard Test/resources/*.csproj) \
-	Test/resources/TestTasks.dll
-
-ifndef MCS_MODE
-	TEST_RESOURCE_FILES += Test/resources/TestTasks.pdb
-endif
+	$(wildcard Test/resources/*.csproj)
 
 TEST_MCS_FLAGS = $(foreach r, $(TEST_RESOURCE_FILES), -resource:$(r),$(r))
 TEST_LIB_REFS = $(XBUILD_FRAMEWORK) $(XBUILD_UTILITIES) $(PARENT_PROFILE)System.Xml
@@ -32,13 +27,13 @@ CLEAN_FILES = Test/resources/TestTasks-$(PROFILE).dll Test/resources/TestTasks-$
 Test/resources/TestTasks-$(PROFILE).dll: Test/resources/TestTasks.cs
 	$(CSCOMPILE) /out:$@ Test/resources/TestTasks.cs /r:$(topdir)/class/lib/$(PROFILE)/$(PARENT_PROFILE)/mscorlib.dll /r:$(topdir)/class/lib/$(PROFILE)/$(XBUILD_FRAMEWORK).dll /r:$(topdir)/class/lib/$(PROFILE)/$(XBUILD_UTILITIES).dll /target:library
 
-test-local: compile-resources
+TEST_MCS_FLAGS += -resource:Test/resources/TestTasks-$(PROFILE).dll,Test/resources/TestTasks.dll
 
-compile-resources: Test/resources/TestTasks-$(PROFILE).dll
-	cp Test/resources/TestTasks-$(PROFILE).dll Test/resources/TestTasks.dll
 ifndef MCS_MODE
-	cp Test/resources/TestTasks-$(PROFILE).pdb Test/resources/TestTasks.pdb
+TEST_MCS_FLAGS += -resource:Test/resources/TestTasks-$(PROFILE).pdb,Test/resources/TestTasks.pdb
 endif
+
+test-local: Test/resources/TestTasks-$(PROFILE).dll
 
 include $(XBUILD_DIR)/xbuild_test.make
 include ../../build/library.make


### PR DESCRIPTION
Since we've started embedding test resources inside of the test assembly
we've sometimes seen a strange error on Jenkins during the test run:

```
Msg: Error initializing task StringTestTask: Could not load file or assembly 'Microsoft.Build.Utilities.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies.
Msg: Error initializing task StringTestTask: System.TypeLoadException: Could not load file or assembly 'Microsoft.Build.Utilities.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies.
  at (wrapper managed-to-native) System.RuntimeType.GetConstructors_native(System.RuntimeType,System.Reflection.BindingFlags)
...
```

However this was from an xbuild_12 run so how come it tried to load xbuild 14 stuff?

The reason is there's a race condition between when TestTasks.dll gets
built and when it's embedded inside of the test assembly.

If we're building the xbuild_12 and xbuild_14 profile at the same time
we could end up embedding the xbuild_14 version of TestTasks.dll instead
of the correct one since we're copying it to the same file name.

The fix is to remove the unnecessary copying logic since we can just tell
the compiler to embed the file under the correct name.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
