### PR TITLE
[2018-08] [runtime] Don\u0027t init classes in ves_icall_RuntimeTypeHandle_is_subclass_of

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1758,12 +1758,7 @@ ves_icall_RuntimeTypeHandle_is_subclass_of (MonoType *childType, MonoType *baseT
 	MonoClass *baseClass;
 
 	childClass = mono_class_from_mono_type (childType);
-	mono_class_init_checked (childClass, error);
-	goto_if_nok (error, done);
-
 	baseClass = mono_class_from_mono_type (baseType);
-	mono_class_init_checked (baseClass, error);
-	goto_if_nok (error, done);
 
 	if (G_UNLIKELY (childType->byref)) {
 		result = !baseType->byref && baseClass == mono_defaults.object_class;


### PR DESCRIPTION
Backport of #11278.

/cc @lambdageek 

Description:

We must not get a TLE if referenced types are in an assembly that can't be
loaded.

Backported https://github.com/mono/mono/pull/11227 to fix https://github.com/mono/mono/issues/11123

