### PR TITLE
[2018-08] [interp] use unsigned conversion for nuint

### DIFF
--- a/mono/mini/builtin-types.cs
+++ b/mono/mini/builtin-types.cs
@@ -421,6 +421,24 @@ public class BuiltinTests {
 		return 0;
 	}
 
+	static int NuintConstructor (nuint cap)
+	{
+		if (cap > (ulong) nint.MaxValue)
+			return 1;
+		return 0;
+	}
+
+	/* resembles https://github.com/xamarin/xamarin-macios/blob/bc492585d137d8c3d3a2ffc827db3cdaae3cc869/tests/monotouch-test/Foundation/MutableDataTest.cs#L62-L89 */
+	static int test_0_nint_maxintcmp ()
+	{
+		/* does not work on 32bit */
+		if (IntPtr.Size == 4)
+			return 0;
+
+		uint cap = (uint) Int32.MaxValue + 2;
+		return NuintConstructor (cap);
+	}
+
 
 	static int test_0_nuint_ctor ()
 	{

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -966,8 +966,11 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoMeth
 
 			if (arg_size < SIZEOF_VOID_P) { // 4 -> 8
 				switch (type_index) {
-				case 0: case 1:
+				case 0:
 					ADD_CODE (td, MINT_CONV_I8_I4);
+					break;
+				case 1:
+					ADD_CODE (td, MINT_CONV_I8_U4);
 					break;
 				case 2:
 					ADD_CODE (td, MINT_CONV_R8_R4);
@@ -1045,8 +1048,11 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoMeth
 #if SIZEOF_VOID_P == 8
 			if (src_size < dst_size) { // 4 -> 8
 				switch (type_index) {
-				case 0: case 1:
+				case 0:
 					ADD_CODE (td, MINT_CONV_I8_I4);
+					break;
+				case 1:
+					ADD_CODE (td, MINT_CONV_I8_U4);
 					break;
 				case 2:
 					ADD_CODE (td, MINT_CONV_R8_R4);


### PR DESCRIPTION
Backport of #11259.

/cc @lewurm 

Description:
Fixes `MutableDataTest.Constructor` on Xamarin.iOS with interpreter.

monotouch tests are looking good now with interp-only:
<img width="906" alt="screenshot 2018-10-19 at 11 22 07" src="https://user-images.githubusercontent.com/75403/47209686-3d7b2780-d391-11e8-887f-9e1f39de2026.png">
😬 