### PR TITLE
Really fix ToolStrip background

### DIFF
--- a/mcs/class/System.Drawing/System.Drawing/Color.cs
+++ b/mcs/class/System.Drawing/System.Drawing/Color.cs
@@ -160,7 +160,7 @@ namespace System.Drawing
 			} else {
 				c = new Color ();
 				c.state = (short) (ColorType.ARGB | ColorType.Known | ColorType.Named);
-				if ((n < 27) || (n > 169))
+				if ((n < 27) || (n >= 168))
 					c.state |= (short) ColorType.System;
 				c.Value = KnownColors.ArgbValues [n];
 			}

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ProfessionalColorTable.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ProfessionalColorTable.cs
@@ -217,32 +217,32 @@ namespace System.Windows.Forms
 					menu_item_selected_gradient_begin = Color.FromArgb (182, 189, 210);
 					menu_item_selected_gradient_end = Color.FromArgb (182, 189, 210);
 
-					menu_strip_gradient_begin = SystemColors.ButtonFace;
+					menu_strip_gradient_begin = SystemColors.Control;
 					menu_strip_gradient_end = Color.FromArgb (246, 245, 244);
 
 					overflow_button_gradient_begin = Color.FromArgb (225, 222, 217);
 					overflow_button_gradient_end = SystemColors.ButtonShadow;
 					overflow_button_gradient_middle = Color.FromArgb (216, 213, 206);
 
-					rafting_container_gradient_begin = SystemColors.ButtonFace;
+					rafting_container_gradient_begin = SystemColors.Control;
 					rafting_container_gradient_end = Color.FromArgb (246, 245, 244);
 
 					separator_dark = Color.FromArgb (166, 166, 166);
 					separator_light = SystemColors.ButtonHighlight;
 
-					status_strip_gradient_begin = SystemColors.ButtonFace;
+					status_strip_gradient_begin = SystemColors.Control;
 					status_strip_gradient_end = Color.FromArgb (246, 245, 244);
 
 					tool_strip_border = Color.FromArgb (219, 216, 209);
-					tool_strip_content_panel_gradient_begin = SystemColors.ButtonFace;
+					tool_strip_content_panel_gradient_begin = SystemColors.Control;
 					tool_strip_content_panel_gradient_end = Color.FromArgb (246, 245, 244);
 					tool_strip_drop_down_background = SystemColors.Window;
 
 					tool_strip_gradient_begin = Color.FromArgb (245, 244, 242);
-					tool_strip_gradient_end = SystemColors.ButtonFace;
+					tool_strip_gradient_end = SystemColors.Control;
 					tool_strip_gradient_middle = Color.FromArgb (234, 232, 228);
 
-					tool_strip_panel_gradient_begin = SystemColors.ButtonFace;
+					tool_strip_panel_gradient_begin = SystemColors.Control;
 					tool_strip_panel_gradient_end = Color.FromArgb (246, 245, 244);
 					break;
 				case ColorSchemes.NormalColor:
@@ -288,32 +288,32 @@ namespace System.Windows.Forms
 					menu_item_selected_gradient_begin = use_system_colors ? Color.FromArgb (193, 210, 238) : Color.FromArgb (255, 255, 222);
 					menu_item_selected_gradient_end = use_system_colors ? Color.FromArgb (193, 210, 238) : Color.FromArgb (255, 203, 136);
 
-					menu_strip_gradient_begin = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (158, 190, 245);
+					menu_strip_gradient_begin = use_system_colors ? SystemColors.Control : Color.FromArgb (158, 190, 245);
 					menu_strip_gradient_end = use_system_colors ? Color.FromArgb (251, 250, 247) : Color.FromArgb (196, 218, 250);
 
 					overflow_button_gradient_begin = use_system_colors ? Color.FromArgb (242, 240, 228) : Color.FromArgb (127, 177, 250);
 					overflow_button_gradient_end = use_system_colors ? SystemColors.ButtonShadow : Color.FromArgb (0, 53, 145);
 					overflow_button_gradient_middle = use_system_colors ? Color.FromArgb (238, 235, 220) : Color.FromArgb (82, 127, 208);
 
-					rafting_container_gradient_begin = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (158, 190, 245);
+					rafting_container_gradient_begin = use_system_colors ? SystemColors.Control : Color.FromArgb (158, 190, 245);
 					rafting_container_gradient_end = use_system_colors ? Color.FromArgb (251, 250, 247) : Color.FromArgb (196, 218, 250);
 
 					separator_dark = use_system_colors ? Color.FromArgb (197, 194, 184) : Color.FromArgb (106, 140, 203);
 					separator_light = use_system_colors ? SystemColors.ButtonHighlight : Color.FromArgb (241, 249, 255);
 
-					status_strip_gradient_begin = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (158, 190, 245);
+					status_strip_gradient_begin = use_system_colors ? SystemColors.Control : Color.FromArgb (158, 190, 245);
 					status_strip_gradient_end = use_system_colors ? Color.FromArgb (251, 250, 247) : Color.FromArgb (196, 218, 250);
 
 					tool_strip_border = use_system_colors ? Color.FromArgb (239, 237, 222) : Color.FromArgb (59, 97, 156);
-					tool_strip_content_panel_gradient_begin = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (158, 190, 245);
+					tool_strip_content_panel_gradient_begin = use_system_colors ? SystemColors.Control : Color.FromArgb (158, 190, 245);
 					tool_strip_content_panel_gradient_end = use_system_colors ? Color.FromArgb (251, 250, 247) : Color.FromArgb (196, 218, 250);
 					tool_strip_drop_down_background = use_system_colors ? Color.FromArgb (252, 252, 249) : Color.FromArgb (246, 246, 246);
 
 					tool_strip_gradient_begin = use_system_colors ? Color.FromArgb (251, 250, 246) : Color.FromArgb (227, 239, 255);
-					tool_strip_gradient_end = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (123, 164, 224);
+					tool_strip_gradient_end = use_system_colors ? SystemColors.Control : Color.FromArgb (123, 164, 224);
 					tool_strip_gradient_middle = use_system_colors ? Color.FromArgb (246, 244, 236) : Color.FromArgb (203, 225, 252);
 
-					tool_strip_panel_gradient_begin = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (158, 190, 245);
+					tool_strip_panel_gradient_begin = use_system_colors ? SystemColors.Control : Color.FromArgb (158, 190, 245);
 					tool_strip_panel_gradient_end = use_system_colors ? Color.FromArgb (251, 250, 247) : Color.FromArgb (196, 218, 250);
 					break;
 				case ColorSchemes.HomeStead:
@@ -361,32 +361,32 @@ namespace System.Windows.Forms
 					menu_item_selected_gradient_begin = use_system_colors ? Color.FromArgb (223, 227, 212) : Color.FromArgb (255, 255, 222);
 					menu_item_selected_gradient_end = use_system_colors ? Color.FromArgb (223, 227, 212) : Color.FromArgb (255, 203, 136);
 
-					menu_strip_gradient_begin = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (217, 217, 167);
+					menu_strip_gradient_begin = use_system_colors ? SystemColors.Control : Color.FromArgb (217, 217, 167);
 					menu_strip_gradient_end = use_system_colors ? Color.FromArgb (251, 250, 247) : Color.FromArgb (242, 241, 228);
 
 					overflow_button_gradient_begin = use_system_colors ? Color.FromArgb (242, 240, 228) : Color.FromArgb (186, 204, 150);
 					overflow_button_gradient_end = use_system_colors ? SystemColors.ButtonShadow : Color.FromArgb (96, 119, 107);
 					overflow_button_gradient_middle = use_system_colors ? Color.FromArgb (238, 235, 220) : Color.FromArgb (141, 160, 107);
 
-					rafting_container_gradient_begin = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (217, 217, 167);
+					rafting_container_gradient_begin = use_system_colors ? SystemColors.Control : Color.FromArgb (217, 217, 167);
 					rafting_container_gradient_end = use_system_colors ? Color.FromArgb (251, 250, 247) : Color.FromArgb (242, 241, 228);
 
 					separator_dark = use_system_colors ? Color.FromArgb (197, 194, 184) : Color.FromArgb (96, 128, 88);
 					separator_light = use_system_colors ? SystemColors.ButtonHighlight : Color.FromArgb (244, 247, 222);
 
-					status_strip_gradient_begin = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (217, 217, 167);
+					status_strip_gradient_begin = use_system_colors ? SystemColors.Control : Color.FromArgb (217, 217, 167);
 					status_strip_gradient_end = use_system_colors ? Color.FromArgb (251, 250, 247) : Color.FromArgb (242, 241, 228);
 
 					tool_strip_border = use_system_colors ? Color.FromArgb (239, 237, 222) : Color.FromArgb (96, 128, 88);
-					tool_strip_content_panel_gradient_begin = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (217, 217, 167);
+					tool_strip_content_panel_gradient_begin = use_system_colors ? SystemColors.Control : Color.FromArgb (217, 217, 167);
 					tool_strip_content_panel_gradient_end = use_system_colors ? Color.FromArgb (251, 250, 247) : Color.FromArgb (242, 241, 228);
 					tool_strip_drop_down_background = use_system_colors ? Color.FromArgb (252, 252, 249) : Color.FromArgb (244, 244, 238);
 
 					tool_strip_gradient_begin = use_system_colors ? Color.FromArgb (251, 250, 246) : Color.FromArgb (255, 255, 237);
-					tool_strip_gradient_end = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (181, 196, 143);
+					tool_strip_gradient_end = use_system_colors ? SystemColors.Control : Color.FromArgb (181, 196, 143);
 					tool_strip_gradient_middle = use_system_colors ? Color.FromArgb (246, 244, 236) : Color.FromArgb (206, 220, 167);
 
-					tool_strip_panel_gradient_begin = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (217, 217, 167);
+					tool_strip_panel_gradient_begin = use_system_colors ? SystemColors.Control : Color.FromArgb (217, 217, 167);
 					tool_strip_panel_gradient_end = use_system_colors ? Color.FromArgb (251, 250, 247) : Color.FromArgb (242, 241, 228);
 					break;
 				case ColorSchemes.Metallic:
@@ -434,32 +434,32 @@ namespace System.Windows.Forms
 					menu_item_selected_gradient_begin = use_system_colors ? Color.FromArgb (232, 233, 236) : Color.FromArgb (255, 255, 222);
 					menu_item_selected_gradient_end = use_system_colors ? Color.FromArgb (232, 233, 236) : Color.FromArgb (255, 203, 136);
 
-					menu_strip_gradient_begin = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (215, 215, 229);
+					menu_strip_gradient_begin = use_system_colors ? SystemColors.Control : Color.FromArgb (215, 215, 229);
 					menu_strip_gradient_end = use_system_colors ? Color.FromArgb (249, 248, 249) : Color.FromArgb (243, 243, 247);
 
 					overflow_button_gradient_begin = use_system_colors ? Color.FromArgb (233, 233, 235) : Color.FromArgb (186, 185, 206);
 					overflow_button_gradient_end = use_system_colors ? SystemColors.ButtonShadow : Color.FromArgb (118, 116, 146);
 					overflow_button_gradient_middle = use_system_colors ? Color.FromArgb (227, 226, 230) : Color.FromArgb (156, 155, 180);
 
-					rafting_container_gradient_begin = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (215, 215, 229);
+					rafting_container_gradient_begin = use_system_colors ? SystemColors.Control : Color.FromArgb (215, 215, 229);
 					rafting_container_gradient_end = use_system_colors ? Color.FromArgb (249, 248, 249) : Color.FromArgb (243, 243, 247);
 
 					separator_dark = use_system_colors ? Color.FromArgb (186, 186, 189) : Color.FromArgb (110, 109, 143);
 					separator_light = use_system_colors ? SystemColors.ButtonHighlight : Color.FromArgb (255, 255, 255);
 
-					status_strip_gradient_begin = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (215, 215, 229);
+					status_strip_gradient_begin = use_system_colors ? SystemColors.Control : Color.FromArgb (215, 215, 229);
 					status_strip_gradient_end = use_system_colors ? Color.FromArgb (249, 248, 249) : Color.FromArgb (243, 243, 247);
 
 					tool_strip_border = use_system_colors ? Color.FromArgb (229, 228, 232) : Color.FromArgb (124, 124, 148);
-					tool_strip_content_panel_gradient_begin = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (215, 215, 229);
+					tool_strip_content_panel_gradient_begin = use_system_colors ? SystemColors.Control : Color.FromArgb (215, 215, 229);
 					tool_strip_content_panel_gradient_end = use_system_colors ? Color.FromArgb (249, 248, 249) : Color.FromArgb (243, 243, 247);
 					tool_strip_drop_down_background = use_system_colors ? Color.FromArgb (251, 250, 251) : Color.FromArgb (253, 250, 255);
 
 					tool_strip_gradient_begin = use_system_colors ? Color.FromArgb (248, 248, 249) : Color.FromArgb (249, 249, 255);
-					tool_strip_gradient_end = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (147, 145, 176);
+					tool_strip_gradient_end = use_system_colors ? SystemColors.Control : Color.FromArgb (147, 145, 176);
 					tool_strip_gradient_middle = use_system_colors ? Color.FromArgb (240, 239, 241) : Color.FromArgb (225, 226, 236);
 
-					tool_strip_panel_gradient_begin = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (215, 215, 229);
+					tool_strip_panel_gradient_begin = use_system_colors ? SystemColors.Control : Color.FromArgb (215, 215, 229);
 					tool_strip_panel_gradient_end = use_system_colors ? Color.FromArgb (249, 248, 249) : Color.FromArgb (243, 243, 247);
 					break;
 				case ColorSchemes.MediaCenter:
@@ -507,32 +507,32 @@ namespace System.Windows.Forms
 					menu_item_selected_gradient_begin = use_system_colors ? Color.FromArgb (194, 207, 229) : Color.FromArgb (194, 207, 229);
 					menu_item_selected_gradient_end = use_system_colors ? Color.FromArgb (194, 207, 229) : Color.FromArgb (194, 207, 229);
 
-					menu_strip_gradient_begin = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (235, 233, 237);
+					menu_strip_gradient_begin = use_system_colors ? SystemColors.Control : Color.FromArgb (235, 233, 237);
 					menu_strip_gradient_end = use_system_colors ? Color.FromArgb (251, 250, 251) : Color.FromArgb (251, 250, 251);
 
 					overflow_button_gradient_begin = use_system_colors ? Color.FromArgb (241, 240, 242) : Color.FromArgb (242, 242, 242);
 					overflow_button_gradient_end = use_system_colors ? SystemColors.ButtonShadow : Color.FromArgb (167, 166, 170);
 					overflow_button_gradient_middle = use_system_colors ? Color.FromArgb (237, 235, 239) : Color.FromArgb (224, 224, 225);
 
-					rafting_container_gradient_begin = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (235, 233, 237);
+					rafting_container_gradient_begin = use_system_colors ? SystemColors.Control : Color.FromArgb (235, 233, 237);
 					rafting_container_gradient_end = use_system_colors ? Color.FromArgb (251, 250, 251) : Color.FromArgb (251, 250, 251);
 
 					separator_dark = use_system_colors ? Color.FromArgb (193, 193, 196) : Color.FromArgb (193, 193, 196);
 					separator_light = use_system_colors ? SystemColors.ButtonHighlight : Color.FromArgb (255, 255, 255);
 
-					status_strip_gradient_begin = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (235, 233, 237);
+					status_strip_gradient_begin = use_system_colors ? SystemColors.Control : Color.FromArgb (235, 233, 237);
 					status_strip_gradient_end = use_system_colors ? Color.FromArgb (251, 250, 251) : Color.FromArgb (251, 250, 251);
 
 					tool_strip_border = use_system_colors ? Color.FromArgb (238, 237, 240) : Color.FromArgb (238, 237, 240);
-					tool_strip_content_panel_gradient_begin = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (235, 233, 237);
+					tool_strip_content_panel_gradient_begin = use_system_colors ? SystemColors.Control : Color.FromArgb (235, 233, 237);
 					tool_strip_content_panel_gradient_end = use_system_colors ? Color.FromArgb (251, 250, 251) : Color.FromArgb (251, 250, 251);
 					tool_strip_drop_down_background = use_system_colors ? Color.FromArgb (252, 252, 252) : Color.FromArgb (252, 252, 252);
 
 					tool_strip_gradient_begin = use_system_colors ? Color.FromArgb (250, 250, 251) : Color.FromArgb (252, 252, 252);
-					tool_strip_gradient_end = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (235, 233, 237);
+					tool_strip_gradient_end = use_system_colors ? SystemColors.Control : Color.FromArgb (235, 233, 237);
 					tool_strip_gradient_middle = use_system_colors ? Color.FromArgb (245, 244, 246) : Color.FromArgb (245, 244, 246);
 
-					tool_strip_panel_gradient_begin = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (235, 233, 237);
+					tool_strip_panel_gradient_begin = use_system_colors ? SystemColors.Control : Color.FromArgb (235, 233, 237);
 					tool_strip_panel_gradient_end = use_system_colors ? Color.FromArgb (251, 250, 251) : Color.FromArgb (251, 250, 251);
 					break;
 				case ColorSchemes.Aero:
@@ -580,32 +580,32 @@ namespace System.Windows.Forms
 					menu_item_selected_gradient_begin = Color.FromArgb (194, 224, 255);
 					menu_item_selected_gradient_end = Color.FromArgb (194, 224, 255);
 
-					menu_strip_gradient_begin = SystemColors.ButtonFace;
+					menu_strip_gradient_begin = SystemColors.Control;
 					menu_strip_gradient_end = Color.FromArgb (253, 253, 253);
 
 					overflow_button_gradient_begin = Color.FromArgb (247, 247, 247);
 					overflow_button_gradient_end = SystemColors.ButtonShadow;
 					overflow_button_gradient_middle = Color.FromArgb (245, 245, 245);
 
-					rafting_container_gradient_begin = SystemColors.ButtonFace;
+					rafting_container_gradient_begin = SystemColors.Control;
 					rafting_container_gradient_end = Color.FromArgb (253, 253, 253);
 
 					separator_dark = Color.FromArgb (189, 189, 189);
 					separator_light = SystemColors.ButtonHighlight;
 
-					status_strip_gradient_begin = SystemColors.ButtonFace;
+					status_strip_gradient_begin = SystemColors.Control;
 					status_strip_gradient_end = Color.FromArgb (253, 253, 253);
 
 					tool_strip_border = Color.FromArgb (246, 246, 246);
-					tool_strip_content_panel_gradient_begin = SystemColors.ButtonFace;
+					tool_strip_content_panel_gradient_begin = SystemColors.Control;
 					tool_strip_content_panel_gradient_end = Color.FromArgb (253, 253, 253);
 					tool_strip_drop_down_background = Color.FromArgb (253, 253, 253);
 
 					tool_strip_gradient_begin = Color.FromArgb (252, 252, 252);
-					tool_strip_gradient_end = SystemColors.ButtonFace;
+					tool_strip_gradient_end = SystemColors.Control;
 					tool_strip_gradient_middle = Color.FromArgb (250, 250, 250);
 
-					tool_strip_panel_gradient_begin = SystemColors.ButtonFace;
+					tool_strip_panel_gradient_begin = SystemColors.Control;
 					tool_strip_panel_gradient_end = Color.FromArgb (253, 253, 253);
 					break;
 			}

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ProfessionalColorTable.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ProfessionalColorTable.cs
@@ -218,7 +218,7 @@ namespace System.Windows.Forms
 					menu_item_selected_gradient_end = Color.FromArgb (182, 189, 210);
 
 					menu_strip_gradient_begin = SystemColors.Control;
-					menu_strip_gradient_end = Color.FromArgb (246, 245, 244);
+					menu_strip_gradient_end = SystemColors.ControlLight;
 
 					overflow_button_gradient_begin = Color.FromArgb (225, 222, 217);
 					overflow_button_gradient_end = SystemColors.ButtonShadow;
@@ -238,7 +238,7 @@ namespace System.Windows.Forms
 					tool_strip_content_panel_gradient_end = Color.FromArgb (246, 245, 244);
 					tool_strip_drop_down_background = SystemColors.Window;
 
-					tool_strip_gradient_begin = Color.FromArgb (245, 244, 242);
+					tool_strip_gradient_begin = SystemColors.ControlLight;
 					tool_strip_gradient_end = SystemColors.Control;
 					tool_strip_gradient_middle = Color.FromArgb (234, 232, 228);
 
@@ -289,7 +289,7 @@ namespace System.Windows.Forms
 					menu_item_selected_gradient_end = use_system_colors ? Color.FromArgb (193, 210, 238) : Color.FromArgb (255, 203, 136);
 
 					menu_strip_gradient_begin = use_system_colors ? SystemColors.Control : Color.FromArgb (158, 190, 245);
-					menu_strip_gradient_end = use_system_colors ? Color.FromArgb (251, 250, 247) : Color.FromArgb (196, 218, 250);
+					menu_strip_gradient_end = use_system_colors ? SystemColors.ControlLight : Color.FromArgb (196, 218, 250);
 
 					overflow_button_gradient_begin = use_system_colors ? Color.FromArgb (242, 240, 228) : Color.FromArgb (127, 177, 250);
 					overflow_button_gradient_end = use_system_colors ? SystemColors.ButtonShadow : Color.FromArgb (0, 53, 145);
@@ -309,7 +309,7 @@ namespace System.Windows.Forms
 					tool_strip_content_panel_gradient_end = use_system_colors ? Color.FromArgb (251, 250, 247) : Color.FromArgb (196, 218, 250);
 					tool_strip_drop_down_background = use_system_colors ? Color.FromArgb (252, 252, 249) : Color.FromArgb (246, 246, 246);
 
-					tool_strip_gradient_begin = use_system_colors ? Color.FromArgb (251, 250, 246) : Color.FromArgb (227, 239, 255);
+					tool_strip_gradient_begin = use_system_colors ? SystemColors.ControlLight : Color.FromArgb (227, 239, 255);
 					tool_strip_gradient_end = use_system_colors ? SystemColors.Control : Color.FromArgb (123, 164, 224);
 					tool_strip_gradient_middle = use_system_colors ? Color.FromArgb (246, 244, 236) : Color.FromArgb (203, 225, 252);
 
@@ -362,7 +362,7 @@ namespace System.Windows.Forms
 					menu_item_selected_gradient_end = use_system_colors ? Color.FromArgb (223, 227, 212) : Color.FromArgb (255, 203, 136);
 
 					menu_strip_gradient_begin = use_system_colors ? SystemColors.Control : Color.FromArgb (217, 217, 167);
-					menu_strip_gradient_end = use_system_colors ? Color.FromArgb (251, 250, 247) : Color.FromArgb (242, 241, 228);
+					menu_strip_gradient_end = use_system_colors ? SystemColors.ControlLight : Color.FromArgb (242, 241, 228);
 
 					overflow_button_gradient_begin = use_system_colors ? Color.FromArgb (242, 240, 228) : Color.FromArgb (186, 204, 150);
 					overflow_button_gradient_end = use_system_colors ? SystemColors.ButtonShadow : Color.FromArgb (96, 119, 107);
@@ -382,7 +382,7 @@ namespace System.Windows.Forms
 					tool_strip_content_panel_gradient_end = use_system_colors ? Color.FromArgb (251, 250, 247) : Color.FromArgb (242, 241, 228);
 					tool_strip_drop_down_background = use_system_colors ? Color.FromArgb (252, 252, 249) : Color.FromArgb (244, 244, 238);
 
-					tool_strip_gradient_begin = use_system_colors ? Color.FromArgb (251, 250, 246) : Color.FromArgb (255, 255, 237);
+					tool_strip_gradient_begin = use_system_colors ? SystemColors.ControlLight : Color.FromArgb (255, 255, 237);
 					tool_strip_gradient_end = use_system_colors ? SystemColors.Control : Color.FromArgb (181, 196, 143);
 					tool_strip_gradient_middle = use_system_colors ? Color.FromArgb (246, 244, 236) : Color.FromArgb (206, 220, 167);
 
@@ -435,7 +435,7 @@ namespace System.Windows.Forms
 					menu_item_selected_gradient_end = use_system_colors ? Color.FromArgb (232, 233, 236) : Color.FromArgb (255, 203, 136);
 
 					menu_strip_gradient_begin = use_system_colors ? SystemColors.Control : Color.FromArgb (215, 215, 229);
-					menu_strip_gradient_end = use_system_colors ? Color.FromArgb (249, 248, 249) : Color.FromArgb (243, 243, 247);
+					menu_strip_gradient_end = use_system_colors ? SystemColors.ControlLight : Color.FromArgb (243, 243, 247);
 
 					overflow_button_gradient_begin = use_system_colors ? Color.FromArgb (233, 233, 235) : Color.FromArgb (186, 185, 206);
 					overflow_button_gradient_end = use_system_colors ? SystemColors.ButtonShadow : Color.FromArgb (118, 116, 146);
@@ -455,7 +455,7 @@ namespace System.Windows.Forms
 					tool_strip_content_panel_gradient_end = use_system_colors ? Color.FromArgb (249, 248, 249) : Color.FromArgb (243, 243, 247);
 					tool_strip_drop_down_background = use_system_colors ? Color.FromArgb (251, 250, 251) : Color.FromArgb (253, 250, 255);
 
-					tool_strip_gradient_begin = use_system_colors ? Color.FromArgb (248, 248, 249) : Color.FromArgb (249, 249, 255);
+					tool_strip_gradient_begin = use_system_colors ? SystemColors.ControlLight : Color.FromArgb (249, 249, 255);
 					tool_strip_gradient_end = use_system_colors ? SystemColors.Control : Color.FromArgb (147, 145, 176);
 					tool_strip_gradient_middle = use_system_colors ? Color.FromArgb (240, 239, 241) : Color.FromArgb (225, 226, 236);
 
@@ -508,7 +508,7 @@ namespace System.Windows.Forms
 					menu_item_selected_gradient_end = use_system_colors ? Color.FromArgb (194, 207, 229) : Color.FromArgb (194, 207, 229);
 
 					menu_strip_gradient_begin = use_system_colors ? SystemColors.Control : Color.FromArgb (235, 233, 237);
-					menu_strip_gradient_end = use_system_colors ? Color.FromArgb (251, 250, 251) : Color.FromArgb (251, 250, 251);
+					menu_strip_gradient_end = use_system_colors ? SystemColors.ControlLight : Color.FromArgb (251, 250, 251);
 
 					overflow_button_gradient_begin = use_system_colors ? Color.FromArgb (241, 240, 242) : Color.FromArgb (242, 242, 242);
 					overflow_button_gradient_end = use_system_colors ? SystemColors.ButtonShadow : Color.FromArgb (167, 166, 170);
@@ -528,7 +528,7 @@ namespace System.Windows.Forms
 					tool_strip_content_panel_gradient_end = use_system_colors ? Color.FromArgb (251, 250, 251) : Color.FromArgb (251, 250, 251);
 					tool_strip_drop_down_background = use_system_colors ? Color.FromArgb (252, 252, 252) : Color.FromArgb (252, 252, 252);
 
-					tool_strip_gradient_begin = use_system_colors ? Color.FromArgb (250, 250, 251) : Color.FromArgb (252, 252, 252);
+					tool_strip_gradient_begin = use_system_colors ? SystemColors.ControlLight : Color.FromArgb (252, 252, 252);
 					tool_strip_gradient_end = use_system_colors ? SystemColors.Control : Color.FromArgb (235, 233, 237);
 					tool_strip_gradient_middle = use_system_colors ? Color.FromArgb (245, 244, 246) : Color.FromArgb (245, 244, 246);
 
@@ -581,7 +581,7 @@ namespace System.Windows.Forms
 					menu_item_selected_gradient_end = Color.FromArgb (194, 224, 255);
 
 					menu_strip_gradient_begin = SystemColors.Control;
-					menu_strip_gradient_end = Color.FromArgb (253, 253, 253);
+					menu_strip_gradient_end = SystemColors.ControlLight;
 
 					overflow_button_gradient_begin = Color.FromArgb (247, 247, 247);
 					overflow_button_gradient_end = SystemColors.ButtonShadow;
@@ -601,7 +601,7 @@ namespace System.Windows.Forms
 					tool_strip_content_panel_gradient_end = Color.FromArgb (253, 253, 253);
 					tool_strip_drop_down_background = Color.FromArgb (253, 253, 253);
 
-					tool_strip_gradient_begin = Color.FromArgb (252, 252, 252);
+					tool_strip_gradient_begin = SystemColors.ControlLight;
 					tool_strip_gradient_end = SystemColors.Control;
 					tool_strip_gradient_middle = Color.FromArgb (250, 250, 250);
 

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Theme.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Theme.cs
@@ -329,6 +329,11 @@ namespace System.Windows.Forms
 			set { SetSystemColors (KnownColor.ControlLightLight, value); }
 		}
 
+		public virtual Color ColorButtonFace {
+			get { return SystemColors.ButtonFace;}
+			set { SetSystemColors (KnownColor.ButtonFace, value); }
+		}
+
 		public virtual Color ColorInfoText {
 			get { return SystemColors.InfoText;}
 			set { SetSystemColors (KnownColor.InfoText, value); }

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/X11DesktopColors.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/X11DesktopColors.cs
@@ -114,6 +114,7 @@ namespace System.Windows.Forms {
 						ThemeEngine.Current.ColorControlLight = ColorFromGdkColor (style.light[0]);
 						ThemeEngine.Current.ColorControlLightLight = ControlPaint.Light (ThemeEngine.Current.ColorControlLight);
 						ThemeEngine.Current.ColorControlDarkDark = ControlPaint.Dark (ThemeEngine.Current.ColorControlDark);
+						ThemeEngine.Current.ColorButtonFace = ColorFromGdkColor (style.bg[0]);
 
 						// We don't want ControlLight to disappear on a white background!
 						if (ThemeEngine.Current.ColorControlLight.ToArgb () == Color.White.ToArgb ()) {


### PR DESCRIPTION
## Problem

Even after #10942, menus and toolstrips still look awful with a dark theme:

![toolstrip](https://user-images.githubusercontent.com/1559108/46361551-8e6dea80-c633-11e8-97d1-242612b4b5cf.png)

## Previous attempt

#10942 was a first stab in the dark at what was going on here, before I managed to get mono to compile for testing. I was hopeful that it would address this, but the problem was different.

## Another red herring

Later I thought the problem might be that `SystemColors.ButtonFace.IsSystemColor` was `false`. It looked like this might have caused the runtime to interpret `ButtonFace`'s special 168 value as an RGB code instead of a system color marker.

This fix had no effect (see below for true cause), but I'll include it anyway; the lower bound of the upper system colors block needs to decrease from 170 to 168 to allow `ButtonFace` and `ButtonHighlight` to be considered system colors:

https://github.com/mono/mono/blob/44db64c620c2c957a49b3f5a69cb09c19c1c8c1a/mcs/class/System.Drawing/System.Drawing/KnownColor.cs#L200-L203

## Actual cause

The toolstrip color comes from `ProfessionalColorTable.ToolStripGradientBegin` and `ProfessionalColorTable.ToolStripGradientEnd`. The latter color is hard coded to a light shade, but the former defaults to `SystemColors.ButtonFace`.

These are the colors that are loaded from the GTK system theme:

https://github.com/mono/mono/blob/b104565ccfde477fc7b6308f2d3e4efff0af5848/mcs/class/System.Windows.Forms/System.Windows.Forms/X11DesktopColors.cs#L111-L116

Note that `ButtonFace` is not among them. This means that it uses a compile time default, and is not a good choice for the background of a control. `ToolStrip` is using it anyway, but other controls use `SystemColors.Control` instead.

## Changes

There are two obvious ways to fix this:

1. Use `SystemColors.Control` instead of `SystemColors.ButtonFace` in `ProfessionalColorTable`
2. Load `SystemColors.ButtonFace` from the system theme

This pull request does both. In addition, it also sets the other end of the toolstrip gradients to `SystemColors.ControlLight` instead of a hard coded value. The choice of `ControlLight` was made because in those cases where alternate hard coded values were available for both sides of the gradient, the "other" side was consistently lighter. Now it looks better:

![image](https://user-images.githubusercontent.com/1559108/47258840-efd0ee80-d466-11e8-842f-2fed8b3b9d82.png)
