### PR TITLE
Make icall handle parameters pointers to locals.

### DIFF
--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -80,7 +80,7 @@ struct g_cast
 private:
 	void * const x;
 public:
-	explicit g_cast (void *y) : x(y) { }
+	explicit g_cast (void volatile *y) : x((void*)y) { }
 	// Lack of rvalue constructor inhibits ternary operator.
 	// Either don't use ternary, or cast each side.
 	// sa = (salen <= 128) ? g_alloca (salen) : g_malloc (salen);

--- a/mono/metadata/handle-decl.h
+++ b/mono/metadata/handle-decl.h
@@ -68,14 +68,14 @@ Handle macros/functions
 			MONO_ALWAYS_INLINE					\
 			TYPE * GetRaw () { return __raw ? *__raw : NULL; }	\
 		)								\
-		TYPE **__raw;							\
+		TYPE * volatile *__raw;						\
 	} TYPED_HANDLE_NAME (TYPE),						\
 	  TYPED_OUT_HANDLE_NAME (TYPE),						\
 	  TYPED_IN_OUT_HANDLE_NAME (TYPE);					\
 /* Do not call these functions directly. Use MONO_HANDLE_NEW and MONO_HANDLE_CAST. */ \
 /* Another way to do this involved casting mono_handle_new function to a different type. */ \
 static inline MONO_ALWAYS_INLINE TYPED_HANDLE_NAME (TYPE) 	\
-MONO_HANDLE_CAST_FOR (TYPE) (gpointer a)			\
+MONO_HANDLE_CAST_FOR (TYPE) (MonoRawHandle a)			\
 {								\
 	TYPED_HANDLE_NAME (TYPE) b = { (TYPE**)a };		\
 	return b;						\

--- a/mono/metadata/handle.c
+++ b/mono/metadata/handle.c
@@ -104,36 +104,6 @@ chunk_element (HandleChunk *chunk, int idx)
 	return &chunk->elems[idx];
 }
 
-static HandleChunkElem*
-handle_to_chunk_element (MonoObjectHandle o)
-{
-	return (HandleChunkElem*)o.__raw;
-}
-
-/* Given a HandleChunkElem* search through the current handle stack to find its chunk and offset. */
-static HandleChunk*
-chunk_element_to_chunk_idx (HandleStack *stack, HandleChunkElem *elem, int *out_idx)
-{
-	HandleChunk *top = stack->top;
-	HandleChunk *cur = stack->bottom;
-
-	*out_idx = 0;
-
-	while (cur != NULL) {
-		HandleChunkElem *front = &cur->elems [0];
-		HandleChunkElem *back = &cur->elems [cur->size];
-
-		if (front <= elem && elem < back) {
-			*out_idx = (int)(elem - front);
-			return cur;
-		}
-
-		if (cur == top)
-			break; /* didn't find it. */
-		cur = cur->next;
-	}
-	return NULL;
-}
 
 #ifdef MONO_HANDLE_TRACK_OWNER
 #ifdef HAVE_BACKTRACE_SYMBOLS
@@ -240,54 +210,16 @@ retry:
 	goto retry;
 }
 
-gpointer
-#ifndef MONO_HANDLE_TRACK_OWNER
-mono_handle_new_interior (gpointer rawptr)
-#else
-mono_handle_new_interior (gpointer rawptr, const char *owner)
-#endif
-{
-	MonoThreadInfo *info = mono_thread_info_current ();
-	HandleStack *handles = info->handle_stack;
-	HandleChunk *top = handles->interior;
-#ifdef MONO_HANDLE_TRACK_SP
-	mono_handle_chunk_leak_check (handles);
-#endif
-
-	g_assert (top);
-
-	/*
-	 * Don't extend the chunk now, interior handles are
-	 * only used for icall arguments, they shouldn't
-	 * overflow.
-	 */
-	g_assert (top->size < OBJECTS_PER_HANDLES_CHUNK);
-	int idx = top->size;
-	gpointer *objslot = &top->elems [idx].o;
-	*objslot = NULL;
-	mono_memory_write_barrier ();
-	top->size++;
-	mono_memory_write_barrier ();
-	*objslot = rawptr;
-	SET_OWNER (top,idx);
-	SET_SP (handles, top, idx);
-	return objslot;
-}
-
 HandleStack*
 mono_handle_stack_alloc (void)
 {
 	HandleStack *stack = new_handle_stack ();
 	HandleChunk *chunk = new_handle_chunk ();
-	HandleChunk *interior = new_handle_chunk ();
 
 	chunk->prev = chunk->next = NULL;
 	chunk->size = 0;
-	interior->prev = interior->next = NULL;
-	interior->size = 0;
 	mono_memory_write_barrier ();
 	stack->top = stack->bottom = chunk;
-	stack->interior = interior;
 #ifdef MONO_HANDLE_TRACK_SP
 	stack->stackmark_sp = NULL;
 #endif
@@ -308,7 +240,6 @@ mono_handle_stack_free (HandleStack *stack)
 		c = next;
 	}
 	free_handle_chunk (c);
-	free_handle_chunk (stack->interior);
 	free_handle_stack (stack);
 }
 
@@ -340,10 +271,6 @@ mono_handle_stack_free_domain (HandleStack *stack, MonoDomain *domain)
 			break;
 		cur = cur->next;
 	}
-	/* We don't examine the interior pointers here because the GC treats
-	 * them conservatively and anyway we don't have enough information here to
-	 * find the object's vtable.
-	 */
 }
 
 static void
@@ -385,39 +312,29 @@ mono_handle_stack_scan (HandleStack *stack, GcScanFunc func, gpointer gc_data, g
 		check_handle_stack_monotonic (stack);
 
 	/*
-	  We're called twice - on the imprecise pass we call func to pin the
-	  objects where the handle points to its interior.  On the precise
-	  pass, we scan all the objects where the handles point to the start of
+	  We're called twice - on the imprecise pass we do nothing.
+	  Interior pointers are retained in managed frames.
+	  On the precise pass, we scan all the objects where the handles point to the start of
 	  the object.
 
 	  Note that if we're running, we know the world is stopped.
 	*/
-	if (precise) {
-		HandleChunk *cur = stack->bottom;
-		HandleChunk *last = stack->top;
+	if (!precise)
+		return;
 
-		while (cur) {
-			for (int i = 0; i < cur->size; ++i) {
-				HandleChunkElem* elem = chunk_element (cur, i);
-				gpointer* obj_slot = &elem->o;
-				if (*obj_slot != NULL)
-					func (obj_slot, gc_data);
-			}
-			if (cur == last)
-				break;
-			cur = cur->next;
-		}
-	} else {
-		HandleChunk *cur = stack->interior;
+	HandleChunk *cur = stack->bottom;
+	HandleChunk *last = stack->top;
 
-		if (!cur)
-			return;
+	while (cur) {
 		for (int i = 0; i < cur->size; ++i) {
 			HandleChunkElem* elem = chunk_element (cur, i);
-			gpointer* ptr_slot = &elem->o;
-			if (*ptr_slot != NULL)
-				func (ptr_slot, gc_data);
+			gpointer* obj_slot = &elem->o;
+			if (*obj_slot != NULL)
+				func (obj_slot, gc_data);
 		}
+		if (cur == last)
+			break;
+		cur = cur->next;
 	}
 }
 
@@ -486,15 +403,6 @@ mono_array_handle_length (MonoArrayHandle arr)
 uint32_t
 mono_gchandle_from_handle (MonoObjectHandle handle, mono_bool pinned)
 {
-	/* FIXME: chunk_element_to_chunk_idx does a linear search through the
-	 * chunks and we only need it for the assert */
-	MonoThreadInfo *info = mono_thread_info_current ();
-	HandleStack *stack = info->handle_stack;
-	HandleChunkElem* elem = handle_to_chunk_element (handle);
-	int elem_idx = 0;
-	HandleChunk *chunk = chunk_element_to_chunk_idx (stack, elem, &elem_idx);
-	/* gchandles cannot deal with interior pointers */
-	g_assert (chunk != NULL);
 	return mono_gchandle_new (MONO_HANDLE_RAW (handle), pinned);
 }
 

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -288,8 +288,6 @@ mono_marshal_init (void)
 		register_icall (mono_threads_detach_coop, "mono_threads_detach_coop", "void ptr ptr", TRUE);
 		register_icall (mono_icall_start, "mono_icall_start", "ptr ptr ptr", TRUE);
 		register_icall (mono_icall_end, "mono_icall_end", "void ptr ptr ptr", TRUE);
-		register_icall (mono_icall_handle_new, "mono_icall_handle_new", "ptr ptr", TRUE);
-		register_icall (mono_icall_handle_new_interior, "mono_icall_handle_new_interior", "ptr ptr", TRUE);
 		register_icall (mono_marshal_get_type_object, "mono_marshal_get_type_object", "object ptr", TRUE);
 
 		mono_cominterop_init ();
@@ -6215,22 +6213,6 @@ mono_icall_end (MonoThreadInfo *info, HandleStackMark *stackmark, MonoError *err
 	mono_stack_mark_pop (info, stackmark);
 	if (G_UNLIKELY (!is_ok (error)))
 		mono_error_set_pending_exception (error);
-}
-
-MonoRawHandle
-mono_icall_handle_new (gpointer rawobj)
-{
-	return mono_handle_new ((MonoObject*)rawobj);
-}
-
-gpointer
-mono_icall_handle_new_interior (gpointer rawobj)
-{
-#ifdef MONO_HANDLE_TRACK_OWNER
-	return mono_handle_new_interior ((MonoObject*)rawobj, "<marshal args>");
-#else
-	return mono_handle_new_interior ((MonoObject*)rawobj);
-#endif
 }
 
 MonoObject*

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -609,6 +609,7 @@ struct _MonoMethodHeader {
 	unsigned int num_clauses : 15;
 	/* if num_locals != 0, then the following apply: */
 	unsigned int init_locals : 1;
+	unsigned volatile_args   : 1; // if 1, all args are volatile; used for handles() wrappers.
 	guint16      num_locals;
 	MonoExceptionClause *clauses;
 	MonoType    *locals [MONO_ZERO_LEN_ARRAY];

--- a/mono/metadata/method-builder-ilgen-internals.h
+++ b/mono/metadata/method-builder-ilgen-internals.h
@@ -22,8 +22,11 @@ struct _MonoMethodBuilder {
 	GList *locals_list;
 	gint locals;
 	gboolean dynamic;
-	gboolean skip_visibility, init_locals;
-	guint32 code_size, pos;
+	gboolean skip_visibility;
+	gboolean init_locals;
+	gboolean volatile_args;
+	guint32 code_size;
+	guint32 pos;
 	guchar *code;
 	gint num_clauses;
 	MonoExceptionClause *clauses;

--- a/mono/metadata/method-builder-ilgen.c
+++ b/mono/metadata/method-builder-ilgen.c
@@ -141,6 +141,7 @@ create_method_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *signature, int 
 	header->code_size = mb->pos;
 	header->num_locals = mb->locals;
 	header->init_locals = mb->init_locals;
+	header->volatile_args = mb->volatile_args; // FIXME This is overkill. Per arg/local flags?
 
 	header->num_clauses = mb->num_clauses;
 	header->clauses = mb->clauses;

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -2031,12 +2031,18 @@ mono_compile_create_vars (MonoCompile *cfg)
 	cfg->args = (MonoInst **)mono_mempool_alloc0 (cfg->mempool, (sig->param_count + sig->hasthis) * sizeof (MonoInst*));
 
 	if (sig->hasthis) {
-		cfg->args [0] = mono_compile_create_var (cfg, m_class_get_this_arg (cfg->method->klass), OP_ARG);
-		cfg->this_arg = cfg->args [0];
+		MonoInst* arg = mono_compile_create_var (cfg, m_class_get_this_arg (cfg->method->klass), OP_ARG);
+		if (header->volatile_args)
+			arg->flags |= MONO_INST_VOLATILE;
+		cfg->args [0] = arg;
+		cfg->this_arg = arg;
 	}
 
 	for (i = 0; i < sig->param_count; ++i) {
-		cfg->args [i + sig->hasthis] = mono_compile_create_var (cfg, sig->params [i], OP_ARG);
+		MonoInst* arg = mono_compile_create_var (cfg, sig->params [i], OP_ARG);
+		if (header->volatile_args)
+			arg->flags |= MONO_INST_VOLATILE;
+		cfg->args [i + sig->hasthis] = arg;
 	}
 
 	if (cfg->verbose_level > 2) {


### PR DESCRIPTION
Per discussion, handles for icall parameters allocated in managed (but not native),
can just be pointers to locals or parameters.

Currently the managed stack is scanned conservatively.
When this changes, there will be metadata provided to find these.

Note that we can just use address of volatile parameters, not volatile locals.
For ObjOut/ObjInOut, these might point then to native frames containing pointers, but the pointers
to pointers in managed frame should suffice. If not, volatile locals are about as good and easily implemented.

This brings coop icall cost from 3+handle managed/native transitions down to 3.
  (Sometimes handle==0, i.e. for icalls that just want MonoError parameter.)
This can be further reduced, i.e. to one.

FIXME: Tests that exercise every icall, coop and otherwise.
FIXME: Gcstress.

Collateral damage: The one rarely run assert that handles are not out of scope cannot be easily implemented so is removed.