### PR TITLE
Draw menu background with SystemColors.Menu to fix dark themes

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ProfessionalColorTable.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ProfessionalColorTable.cs
@@ -236,7 +236,7 @@ namespace System.Windows.Forms
 					tool_strip_border = Color.FromArgb (219, 216, 209);
 					tool_strip_content_panel_gradient_begin = SystemColors.ButtonFace;
 					tool_strip_content_panel_gradient_end = Color.FromArgb (246, 245, 244);
-					tool_strip_drop_down_background = SystemColors.Window;
+					tool_strip_drop_down_background = SystemColors.Menu;
 
 					tool_strip_gradient_begin = Color.FromArgb (245, 244, 242);
 					tool_strip_gradient_end = SystemColors.ButtonFace;
@@ -307,7 +307,7 @@ namespace System.Windows.Forms
 					tool_strip_border = use_system_colors ? Color.FromArgb (239, 237, 222) : Color.FromArgb (59, 97, 156);
 					tool_strip_content_panel_gradient_begin = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (158, 190, 245);
 					tool_strip_content_panel_gradient_end = use_system_colors ? Color.FromArgb (251, 250, 247) : Color.FromArgb (196, 218, 250);
-					tool_strip_drop_down_background = use_system_colors ? Color.FromArgb (252, 252, 249) : Color.FromArgb (246, 246, 246);
+					tool_strip_drop_down_background = use_system_colors ? SystemColors.Menu : Color.FromArgb (246, 246, 246);
 
 					tool_strip_gradient_begin = use_system_colors ? Color.FromArgb (251, 250, 246) : Color.FromArgb (227, 239, 255);
 					tool_strip_gradient_end = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (123, 164, 224);
@@ -380,7 +380,7 @@ namespace System.Windows.Forms
 					tool_strip_border = use_system_colors ? Color.FromArgb (239, 237, 222) : Color.FromArgb (96, 128, 88);
 					tool_strip_content_panel_gradient_begin = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (217, 217, 167);
 					tool_strip_content_panel_gradient_end = use_system_colors ? Color.FromArgb (251, 250, 247) : Color.FromArgb (242, 241, 228);
-					tool_strip_drop_down_background = use_system_colors ? Color.FromArgb (252, 252, 249) : Color.FromArgb (244, 244, 238);
+					tool_strip_drop_down_background = use_system_colors ? SystemColors.Menu : Color.FromArgb (244, 244, 238);
 
 					tool_strip_gradient_begin = use_system_colors ? Color.FromArgb (251, 250, 246) : Color.FromArgb (255, 255, 237);
 					tool_strip_gradient_end = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (181, 196, 143);
@@ -453,7 +453,7 @@ namespace System.Windows.Forms
 					tool_strip_border = use_system_colors ? Color.FromArgb (229, 228, 232) : Color.FromArgb (124, 124, 148);
 					tool_strip_content_panel_gradient_begin = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (215, 215, 229);
 					tool_strip_content_panel_gradient_end = use_system_colors ? Color.FromArgb (249, 248, 249) : Color.FromArgb (243, 243, 247);
-					tool_strip_drop_down_background = use_system_colors ? Color.FromArgb (251, 250, 251) : Color.FromArgb (253, 250, 255);
+					tool_strip_drop_down_background = use_system_colors ? SystemColors.Menu : Color.FromArgb (253, 250, 255);
 
 					tool_strip_gradient_begin = use_system_colors ? Color.FromArgb (248, 248, 249) : Color.FromArgb (249, 249, 255);
 					tool_strip_gradient_end = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (147, 145, 176);
@@ -526,7 +526,7 @@ namespace System.Windows.Forms
 					tool_strip_border = use_system_colors ? Color.FromArgb (238, 237, 240) : Color.FromArgb (238, 237, 240);
 					tool_strip_content_panel_gradient_begin = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (235, 233, 237);
 					tool_strip_content_panel_gradient_end = use_system_colors ? Color.FromArgb (251, 250, 251) : Color.FromArgb (251, 250, 251);
-					tool_strip_drop_down_background = use_system_colors ? Color.FromArgb (252, 252, 252) : Color.FromArgb (252, 252, 252);
+					tool_strip_drop_down_background = use_system_colors ? SystemColors.Menu : Color.FromArgb (252, 252, 252);
 
 					tool_strip_gradient_begin = use_system_colors ? Color.FromArgb (250, 250, 251) : Color.FromArgb (252, 252, 252);
 					tool_strip_gradient_end = use_system_colors ? SystemColors.ButtonFace : Color.FromArgb (235, 233, 237);
@@ -599,7 +599,7 @@ namespace System.Windows.Forms
 					tool_strip_border = Color.FromArgb (246, 246, 246);
 					tool_strip_content_panel_gradient_begin = SystemColors.ButtonFace;
 					tool_strip_content_panel_gradient_end = Color.FromArgb (253, 253, 253);
-					tool_strip_drop_down_background = Color.FromArgb (253, 253, 253);
+					tool_strip_drop_down_background = SystemColors.Menu;
 
 					tool_strip_gradient_begin = Color.FromArgb (252, 252, 252);
 					tool_strip_gradient_end = SystemColors.ButtonFace;


### PR DESCRIPTION
## Problem

Dropdown menus have light text on a light background in a dark theme:

![image](https://user-images.githubusercontent.com/1559108/47260376-2e26d780-d480-11e8-8330-86ecc82994df.png)

## Cause

The background is rendered here:

https://github.com/mono/mono/blob/4a6b11577fe06a58e6326b1c3a3bb58cfee6185c/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStripProfessionalRenderer.cs#L372-L375

`this.ColorTable.ToolStripDropDownBackground` is set to either `SystemColors.Window` or various hard coded shades of near-white in `ProfessionalColorTable`.

## Changes

Now that color comes from `SystemColors.Menu`, defined as "[Gets a Color structure that is the color of a menu's background](https://docs.microsoft.com/en-us/dotnet/api/system.drawing.systemcolors)", which looks better in a dark theme:

![image](https://user-images.githubusercontent.com/1559108/47260394-77772700-d480-11e8-85ad-03be8a59e56e.png)

It still looks fine in a normal theme as well:

![image](https://user-images.githubusercontent.com/1559108/47260396-7cd47180-d480-11e8-8989-4ee9448e9d05.png)

KeePass is not affected by this change, presumably thanks to its custom toolstrip renderer.