### PR TITLE
[corlib] Use native memcpy for Buffer.Memcpy for larger sizes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # There is no ordering of corlib versions, no old or new,
 # the runtime expects an exact match.
 #
-MONO_CORLIB_VERSION=893F4575-474B-47A4-831E-E36181251FCB
+MONO_CORLIB_VERSION=109afe51-a298-4c14-a076-cfc83a5e755a
 
 #
 # Put a quoted #define in config.h.

--- a/mcs/class/corlib/ReferenceSources/Buffer.cs
+++ b/mcs/class/corlib/ReferenceSources/Buffer.cs
@@ -11,6 +11,9 @@ namespace System
 {
 	partial class Buffer
 	{
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
+		internal static extern unsafe void InternalMemcpy (byte *dest, byte *src, int count);
+
 		public static int ByteLength (Array array)
 		{
 			// note: the other methods in this class also use ByteLength to test for
@@ -191,6 +194,11 @@ namespace System
 		}
 
 		internal static unsafe void Memcpy (byte *dest, byte *src, int len) {
+			// For bigger lengths, we use the heavily optimized native code
+			if (len > 32) {
+				InternalMemcpy (dest, src, len);
+				return;
+			}
 			// FIXME: if pointers are not aligned, try to align them
 			// so a faster routine can be used. Handle the case where
 			// the pointers can't be reduced to have the same alignment

--- a/mcs/class/corlib/ReferenceSources/String.cs
+++ b/mcs/class/corlib/ReferenceSources/String.cs
@@ -242,25 +242,6 @@ namespace System
 			return countA - countB;
 		}
 
-		internal static unsafe void CharCopy (char *dest, char *src, int count) {
-			// Same rules as for memcpy, but with the premise that 
-			// chars can only be aligned to even addresses if their
-			// enclosing types are correctly aligned
-			if ((((int)(byte*)dest | (int)(byte*)src) & 3) != 0) {
-				if (((int)(byte*)dest & 2) != 0 && ((int)(byte*)src & 2) != 0 && count > 0) {
-					((short*)dest) [0] = ((short*)src) [0];
-					dest++;
-					src++;
-					count--;
-				}
-				if ((((int)(byte*)dest | (int)(byte*)src) & 2) != 0) {
-					Buffer.memcpy2 ((byte*)dest, (byte*)src, count * 2);
-					return;
-				}
-			}
-			Buffer.memcpy4 ((byte*)dest, (byte*)src, count * 2);
-		}
-
 		#region Runtime method-to-ir dependencies
 
 		/* helpers used by the runtime as well as above or eslewhere in corlib */

--- a/mono/metadata/icall-decl.h
+++ b/mono/metadata/icall-decl.h
@@ -167,6 +167,7 @@ ICALL_EXPORT void mono_ArgIterator_Setup (MonoArgIterator*, char*, char*);
 ICALL_EXPORT void ves_icall_Mono_Runtime_RegisterReportingForNativeLib (const char*, const char*);
 ICALL_EXPORT void ves_icall_System_Array_GetGenericValueImpl (MonoArray*, guint32, gpointer);
 ICALL_EXPORT void ves_icall_System_Array_SetGenericValueImpl (MonoArray*, guint32, gpointer);
+ICALL_EXPORT void ves_icall_System_Buffer_MemcpyInternal (gpointer dest, gconstpointer src, gint32 count);
 ICALL_EXPORT void ves_icall_System_Buffer_SetByteInternal (MonoArray*, gint32, gint8);
 ICALL_EXPORT void ves_icall_System_Environment_Exit (int);
 ICALL_EXPORT void ves_icall_System_GCHandle_FreeHandle (guint32 handle);

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -219,6 +219,7 @@ HANDLES(ARRAY_13, "SetValueImpl",  ves_icall_System_Array_SetValueImpl, void, 3,
 
 ICALL_TYPE(BUFFER, "System.Buffer", BUFFER_1)
 ICALL(BUFFER_1, "InternalBlockCopy", ves_icall_System_Buffer_BlockCopyInternal)
+NOHANDLES(ICALL(BUFFER_5, "InternalMemcpy", ves_icall_System_Buffer_MemcpyInternal))
 ICALL(BUFFER_2, "_ByteLength", ves_icall_System_Buffer_ByteLengthInternal)
 ICALL(BUFFER_3, "_GetByte", ves_icall_System_Buffer_GetByteInternal)
 ICALL(BUFFER_4, "_SetByte", ves_icall_System_Buffer_SetByteInternal)

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -6638,6 +6638,12 @@ ves_icall_System_Buffer_SetByteInternal (MonoArray *array, gint32 idx, gint8 val
 	mono_array_set_internal (array, gint8, idx, value);
 }
 
+void
+ves_icall_System_Buffer_MemcpyInternal (gpointer dest, gconstpointer src, gint32 count)
+{
+	memcpy (dest, src, count);
+}
+
 MonoBoolean
 ves_icall_System_Buffer_BlockCopyInternal (MonoArray *src, gint32 src_offset, MonoArray *dest, gint32 dest_offset, gint32 count) 
 {


### PR DESCRIPTION
Some observations
- We can't use Unsafe.CopyBlock here because it uses the cpblk instruction which is resolved to call to Buffer.Memcpy (except cpblk with iconst sizes which are unrolled)
- icall to memcpy is very fast compared to the managed implementation, it might even make sense to have cpblk call it directly but that is questionable.
- because native memcpy is so fast it doesn't make sense to optimize the managed implementation for large sizes (like doing block sized copy) because even though it would be faster than the current implementation it would still be much slower than native memcpy.
- aot + llvm doesn't offer any relevant gain

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
