### PR TITLE
[Reflection] Fix ParameterInfo's custom modifiers order

### DIFF
--- a/mcs/class/corlib/System.Reflection/MonoParameterInfo.cs
+++ b/mcs/class/corlib/System.Reflection/MonoParameterInfo.cs
@@ -315,15 +315,6 @@ namespace System.Reflection
 			return new MonoParameterInfo (type, member, marshalAs);
 		}
 
-		private Type[] GetCustomModifiers (bool optional) {
-			Type[] types = GetTypeModifiers (optional);
-			if (types == null)
-				return Type.EmptyTypes;
-			// Mono returns modifiers in the same order as they appear in the signatures.
-			// NetFX/CoreFX returns them in reversed order.
-			// So we just reverse the order to follow NetFX/CoreFX behavior.
-			Array.Reverse (types);
-			return types;			
-		}
+		private Type[] GetCustomModifiers (bool optional) => GetTypeModifiers (optional) ?? Type.EmptyTypes;
 	}
 }

--- a/mcs/class/corlib/System.Reflection/MonoParameterInfo.cs
+++ b/mcs/class/corlib/System.Reflection/MonoParameterInfo.cs
@@ -214,14 +214,7 @@ namespace System.Reflection
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		internal extern int GetMetadataToken ();
 
-		public
-		override
-		Type[] GetOptionalCustomModifiers () {
-			Type[] types = GetTypeModifiers (true);
-			if (types == null)
-				return Type.EmptyTypes;
-			return types;
-		}
+		public override Type[] GetOptionalCustomModifiers () => GetCustomModifiers (true);
 
 		internal object[] GetPseudoCustomAttributes () 
 		{
@@ -289,14 +282,7 @@ namespace System.Reflection
 			return attrsData;
 		}
 
-		public
-		override
-		Type[] GetRequiredCustomModifiers () {
-			Type[] types = GetTypeModifiers (false);
-			if (types == null)
-				return Type.EmptyTypes;
-			return types;
-		}
+		public override Type[] GetRequiredCustomModifiers () => GetCustomModifiers (false);
 
 		public override bool HasDefaultValue {
 			get { 
@@ -327,6 +313,17 @@ namespace System.Reflection
 		internal static ParameterInfo New (Type type, MemberInfo member, MarshalAsAttribute marshalAs)
 		{
 			return new MonoParameterInfo (type, member, marshalAs);
-		}		
+		}
+
+		private Type[] GetCustomModifiers (bool optional) {
+			Type[] types = GetTypeModifiers (optional);
+			if (types == null)
+				return Type.EmptyTypes;
+			// Mono returns modifiers in the same order as they appear in the signatures.
+			// NetFX/CoreFX returns them in reversed order.
+			// So we just reverse the order to follow NetFX/CoreFX behavior.
+			Array.Reverse (types);
+			return types;			
+		}
 	}
 }

--- a/mcs/class/corlib/System.Reflection/MonoProperty.cs
+++ b/mcs/class/corlib/System.Reflection/MonoProperty.cs
@@ -445,19 +445,11 @@ namespace System.Reflection {
 			method.Invoke (obj, invokeAttr, binder, parms, culture);
 		}
 
-		public override Type[] GetOptionalCustomModifiers () {
-			Type[] types = MonoPropertyInfo.GetTypeModifiers (this, true);
-			if (types == null)
-				return Type.EmptyTypes;
-			return types;
-		}
+		public override Type[] GetOptionalCustomModifiers () => GetCustomModifiers (true);
 
-		public override Type[] GetRequiredCustomModifiers () {
-			Type[] types = MonoPropertyInfo.GetTypeModifiers (this, false);
-			if (types == null)
-				return Type.EmptyTypes;
-			return types;
-		}
+		public override Type[] GetRequiredCustomModifiers () => GetCustomModifiers (false);
+
+		private Type[] GetCustomModifiers (bool optional) => MonoPropertyInfo.GetTypeModifiers (this, optional) ?? Type.EmptyTypes;
 
 		public override IList<CustomAttributeData> GetCustomAttributesData () {
 			return CustomAttributeData.GetCustomAttributes (this);

--- a/mcs/class/corlib/Test/System.Reflection/ParameterInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/ParameterInfoTest.cs
@@ -11,7 +11,9 @@
 using System;
 using System.Threading;
 using System.Reflection;
+#if !FULL_AOT_RUNTIME
 using System.Reflection.Emit;
+#endif
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 using System.Collections.Generic;
@@ -513,6 +515,7 @@ namespace MonoTests.System.Reflection
 		public sealed class C { }
 		public sealed class D { }
 
+#if !FULL_AOT_RUNTIME
 		[Test]
 		// https://github.com/mono/mono/issues/11302
 		public void CustomModifiersOrder()
@@ -539,5 +542,6 @@ namespace MonoTests.System.Reflection
 			var optionalCustomModifiers = parameter.GetOptionalCustomModifiers ();
 			Assert.AreEqual (new[] { typeof (C), typeof (C), typeof (D), typeof (C) }, optionalCustomModifiers);
 		}
+#endif		
 	}
 }

--- a/mcs/class/corlib/Test/System.Reflection/ParameterInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/ParameterInfoTest.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Threading;
 using System.Reflection;
+using System.Reflection.Emit;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 using System.Collections.Generic;
@@ -505,6 +506,38 @@ namespace MonoTests.System.Reflection
 "System.Linq.Expressions.Expression`1[System.Func`3[TSource,System.Int32,System.Boolean]] predicate\n";
 			
 			Assert.AreEqual (expected, actual, "#1");
+		}
+
+		public sealed class A { }
+		public sealed class B { }
+		public sealed class C { }
+		public sealed class D { }
+
+		[Test]
+		// https://github.com/mono/mono/issues/11302
+		public void CustomModifiersOrder()
+		{
+			var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly (new AssemblyName ("SomeAssembly"), AssemblyBuilderAccess.RunAndSave);
+			var moduleBuilder = assemblyBuilder.DefineDynamicModule ("SomeAssembly", "SomeAssembly.dll");
+			var typeBuilder = moduleBuilder.DefineType ("SomeClass", TypeAttributes.Class);
+			var methodBuilder = typeBuilder.DefineMethod (
+				"SomeMethod",
+				MethodAttributes.Public,
+				CallingConventions.HasThis,
+				typeof (void),
+				null,
+				null,
+				new[] { typeof (int) },
+				new[] { new[] { typeof (A), typeof (B), typeof (A), typeof (A) } },
+				new[] { new[] { typeof (C), typeof (D), typeof (C), typeof (C) } });
+			methodBuilder.GetILGenerator ().Emit (OpCodes.Ret);
+			var type = typeBuilder.CreateType ();
+			var method = type.GetMethod ("SomeMethod");
+			var parameter = method.GetParameters () [0];
+			var requiredCustomModifiers = parameter.GetRequiredCustomModifiers ();
+			Assert.AreEqual (new[] { typeof (A), typeof (A), typeof (B), typeof (A) }, requiredCustomModifiers);            
+			var optionalCustomModifiers = parameter.GetOptionalCustomModifiers ();
+			Assert.AreEqual (new[] { typeof (C), typeof (C), typeof (D), typeof (C) }, optionalCustomModifiers);
 		}
 	}
 }

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7958,7 +7958,7 @@ type_array_from_modifiers (MonoImage *image, MonoType *type, int optional, MonoE
 	res = mono_array_new_handle (domain, mono_defaults.systemtype_class, count, error);
 	goto_if_nok (error, fail);
 	count = 0;
-	for (i = 0; i < cmods->count; ++i) {
+	for (i = cmods->count - 1; i >= 0; --i) {
 		if ((optional && !cmods->modifiers [i].required) || (!optional && cmods->modifiers [i].required)) {
 			if (!add_modifier_to_array (domain, image, &cmods->modifiers [i], res, count , error))
 				goto fail;


### PR DESCRIPTION
Mono returns custom modifiers in the same order as they appear in the signatures. NetFX/CoreFX returns them in reversed order. So we just reverse the order to follow NetFX/CoreFX behavior.

Fixes https://github.com/mono/mono/issues/11302