### PR TITLE
[2018-06] [tests] lower recursion depth of PerformNoPinAction

### DIFF
--- a/mono/mini/TestHelpers.cs
+++ b/mono/mini/TestHelpers.cs
@@ -32,7 +32,7 @@ namespace MonoTests.Helpers {
 
 		public static void PerformNoPinAction (Action act)
 		{
-			Thread thr = new Thread (() => NoPinActionHelper (1024, act));
+			Thread thr = new Thread (() => NoPinActionHelper (128, act));
 			thr.Start ();
 			thr.Join ();
 		}


### PR DESCRIPTION
Backport of #11065.

/cc @lewurm 

Description:
so it doesn't overflow the stack when running on macOS with `clang -O0`.