### PR TITLE
Fixing ParameterInfo.RawDefaultValue for non-null default values of DateTime?` and decimal? 

### DIFF
--- a/mcs/class/corlib/System.Reflection/MonoParameterInfo.cs
+++ b/mcs/class/corlib/System.Reflection/MonoParameterInfo.cs
@@ -137,12 +137,12 @@ namespace System.Reflection
 		public override
 		object DefaultValue {
 			get {
-				if (ClassImpl == typeof (Decimal)) {
+				if (ClassImpl == typeof (Decimal) || ClassImpl == typeof (Decimal?)) {
 					/* default values for decimals are encoded using a custom attribute */
 					DecimalConstantAttribute[] attrs = (DecimalConstantAttribute[])GetCustomAttributes (typeof (DecimalConstantAttribute), false);
 					if (attrs.Length > 0)
 						return attrs [0].Value;
-				} else if (ClassImpl == typeof (DateTime)) {
+				} else if (ClassImpl == typeof (DateTime) || ClassImpl == typeof (DateTime?)) {
 					/* default values for DateTime are encoded using a custom attribute */
 					DateTimeConstantAttribute[] attrs = (DateTimeConstantAttribute[])GetCustomAttributes (typeof (DateTimeConstantAttribute), false);
 					if (attrs.Length > 0)

--- a/mcs/class/corlib/Test/System.Reflection/ParameterInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/ParameterInfoTest.cs
@@ -506,5 +506,25 @@ namespace MonoTests.System.Reflection
 			
 			Assert.AreEqual (expected, actual, "#1");
 		}
+
+		public class Dummy {
+			public void M1 (decimal? arg = 12.345M) { }
+			public void M2 ([Optional, DecimalConstant (1, 2, 3, 4, 5)] decimal? arg) { }
+			public void M3 (decimal? arg = null) { }
+			public void M4 ([Optional, DateTimeConstant (1L)] DateTime? arg) { }
+			public void M5 (DateTime? arg = null) { }			
+		}
+
+		[Test]
+		// https://github.com/mono/mono/issues/11303
+		public void RawDefaultValue_Nullable ()
+		{
+			var type = typeof (Dummy);
+			Assert.AreEqual (12.345M, type.GetMethod("M1").GetParameters () [0].RawDefaultValue);
+			Assert.AreEqual (new DecimalConstantAttribute (1, 2, 3, 4, 5).Value, type.GetMethod ("M2").GetParameters () [0].RawDefaultValue);
+			Assert.AreEqual (null, type.GetMethod ("M3").GetParameters () [0].RawDefaultValue);
+			Assert.AreEqual (new DateTime (1), type.GetMethod ("M4").GetParameters () [0].RawDefaultValue);
+			Assert.AreEqual (null, type.GetMethod ("M5").GetParameters () [0].RawDefaultValue);
+		}		
 	}
 }


### PR DESCRIPTION
Adding checks for `DateTime?` and `decimal?` to `DefaultValue` property getter will allow to retrieve correct values instead of  System.Reflection.Missing

Fixes https://github.com/mono/mono/issues/11303