### PR TITLE
[System.Net.Http] Comment out dead code.

### DIFF
--- a/mcs/class/System.Net.Http/HttpClientEx.cs
+++ b/mcs/class/System.Net.Http/HttpClientEx.cs
@@ -80,7 +80,7 @@ namespace Foundation {
 		// almost identical to ModernHttpClient version but it uses the constants from monotouch.dll | Xamarin.[iOS|WatchOS|TVOS].dll
 		static Exception createExceptionForNSError(NSError error)
 		{
-			var webExceptionStatus = WebExceptionStatus.UnknownError;
+			// var webExceptionStatus = WebExceptionStatus.UnknownError;
 
 			var innerException = new NSErrorException(error);
 
@@ -107,118 +107,118 @@ namespace Foundation {
 #endif
 					// No more processing is required so just return.
 					return new OperationCanceledException(error.LocalizedDescription, innerException);
-				case NSUrlError.BadURL:
-				case NSUrlError.UnsupportedURL:
-				case NSUrlError.CannotConnectToHost:
-				case NSUrlError.ResourceUnavailable:
-				case NSUrlError.NotConnectedToInternet:
-				case NSUrlError.UserAuthenticationRequired:
-				case NSUrlError.InternationalRoamingOff:
-				case NSUrlError.CallIsActive:
-				case NSUrlError.DataNotAllowed:
-#if !MONOTOUCH_WATCH
-				case (NSUrlError) CFNetworkErrors.Socks5BadCredentials:
-				case (NSUrlError) CFNetworkErrors.Socks5UnsupportedNegotiationMethod:
-				case (NSUrlError) CFNetworkErrors.Socks5NoAcceptableMethod:
-				case (NSUrlError) CFNetworkErrors.HttpAuthenticationTypeUnsupported:
-				case (NSUrlError) CFNetworkErrors.HttpBadCredentials:
-				case (NSUrlError) CFNetworkErrors.HttpBadURL:
-#endif
-					webExceptionStatus = WebExceptionStatus.ConnectFailure;
-					break;
-				case NSUrlError.TimedOut:
-#if !MONOTOUCH_WATCH
-				case (NSUrlError) CFNetworkErrors.NetServiceTimeout:
-#endif
-					webExceptionStatus = WebExceptionStatus.Timeout;
-					break;
-				case NSUrlError.CannotFindHost:
-				case NSUrlError.DNSLookupFailed:
-#if !MONOTOUCH_WATCH
-				case (NSUrlError) CFNetworkErrors.HostNotFound:
-				case (NSUrlError) CFNetworkErrors.NetServiceDnsServiceFailure:
-#endif
-					webExceptionStatus = WebExceptionStatus.NameResolutionFailure;
-					break;
-				case NSUrlError.DataLengthExceedsMaximum:
-					webExceptionStatus = WebExceptionStatus.MessageLengthLimitExceeded;
-					break;
-				case NSUrlError.NetworkConnectionLost:
-#if !MONOTOUCH_WATCH
-				case (NSUrlError) CFNetworkErrors.HttpConnectionLost:
-#endif
-					webExceptionStatus = WebExceptionStatus.ConnectionClosed;
-					break;
-				case NSUrlError.HTTPTooManyRedirects:
-				case NSUrlError.RedirectToNonExistentLocation:
-#if !MONOTOUCH_WATCH
-				case (NSUrlError) CFNetworkErrors.HttpRedirectionLoopDetected:
-#endif
-					webExceptionStatus = WebExceptionStatus.ProtocolError;
-					break;
-				case NSUrlError.RequestBodyStreamExhausted:
-#if !MONOTOUCH_WATCH
-				case (NSUrlError) CFNetworkErrors.SocksUnknownClientVersion:
-				case (NSUrlError) CFNetworkErrors.SocksUnsupportedServerVersion:
-				case (NSUrlError) CFNetworkErrors.HttpParseFailure:
-#endif
-					webExceptionStatus = WebExceptionStatus.SendFailure;
-					break;
-				case NSUrlError.BadServerResponse:
-				case NSUrlError.ZeroByteResource:
-				case NSUrlError.CannotDecodeRawData:
-				case NSUrlError.CannotDecodeContentData:
-				case NSUrlError.CannotParseResponse:
-				case NSUrlError.FileDoesNotExist:
-				case NSUrlError.FileIsDirectory:
-				case NSUrlError.NoPermissionsToReadFile:
-				case NSUrlError.CannotLoadFromNetwork:
-				case NSUrlError.CannotCreateFile:
-				case NSUrlError.CannotOpenFile:
-				case NSUrlError.CannotCloseFile:
-				case NSUrlError.CannotWriteToFile:
-				case NSUrlError.CannotRemoveFile:
-				case NSUrlError.CannotMoveFile:
-				case NSUrlError.DownloadDecodingFailedMidStream:
-				case NSUrlError.DownloadDecodingFailedToComplete:
-#if !MONOTOUCH_WATCH
-				case (NSUrlError) CFNetworkErrors.Socks4RequestFailed:
-				case (NSUrlError) CFNetworkErrors.Socks4IdentdFailed:
-				case (NSUrlError) CFNetworkErrors.Socks4IdConflict:
-				case (NSUrlError) CFNetworkErrors.Socks4UnknownStatusCode:
-				case (NSUrlError) CFNetworkErrors.Socks5BadState:
-				case (NSUrlError) CFNetworkErrors.Socks5BadResponseAddr:
-				case (NSUrlError) CFNetworkErrors.CannotParseCookieFile:
-				case (NSUrlError) CFNetworkErrors.NetServiceUnknown:
-				case (NSUrlError) CFNetworkErrors.NetServiceCollision:
-				case (NSUrlError) CFNetworkErrors.NetServiceNotFound:
-				case (NSUrlError) CFNetworkErrors.NetServiceInProgress:
-				case (NSUrlError) CFNetworkErrors.NetServiceBadArgument:
-				case (NSUrlError) CFNetworkErrors.NetServiceInvalid:
-#endif
-					webExceptionStatus = WebExceptionStatus.ReceiveFailure;
-					break;
-				case NSUrlError.SecureConnectionFailed:
-					webExceptionStatus = WebExceptionStatus.SecureChannelFailure;
-					break;
-				case NSUrlError.ServerCertificateHasBadDate:
-				case NSUrlError.ServerCertificateHasUnknownRoot:
-				case NSUrlError.ServerCertificateNotYetValid:
-				case NSUrlError.ServerCertificateUntrusted:
-				case NSUrlError.ClientCertificateRejected:
-				case NSUrlError.ClientCertificateRequired:
-					webExceptionStatus = WebExceptionStatus.TrustFailure;
-					break;
-#if !MONOTOUCH_WATCH
-				case (NSUrlError) CFNetworkErrors.HttpProxyConnectionFailure:
-				case (NSUrlError) CFNetworkErrors.HttpBadProxyCredentials:
-				case (NSUrlError) CFNetworkErrors.PacFileError:
-				case (NSUrlError) CFNetworkErrors.PacFileAuth:
-				case (NSUrlError) CFNetworkErrors.HttpsProxyConnectionFailure:
-				case (NSUrlError) CFNetworkErrors.HttpsProxyFailureUnexpectedResponseToConnectMethod:
-					webExceptionStatus = WebExceptionStatus.RequestProhibitedByProxy;
-					break;
-#endif
+// 				case NSUrlError.BadURL:
+// 				case NSUrlError.UnsupportedURL:
+// 				case NSUrlError.CannotConnectToHost:
+// 				case NSUrlError.ResourceUnavailable:
+// 				case NSUrlError.NotConnectedToInternet:
+// 				case NSUrlError.UserAuthenticationRequired:
+// 				case NSUrlError.InternationalRoamingOff:
+// 				case NSUrlError.CallIsActive:
+// 				case NSUrlError.DataNotAllowed:
+// #if !MONOTOUCH_WATCH
+// 				case (NSUrlError) CFNetworkErrors.Socks5BadCredentials:
+// 				case (NSUrlError) CFNetworkErrors.Socks5UnsupportedNegotiationMethod:
+// 				case (NSUrlError) CFNetworkErrors.Socks5NoAcceptableMethod:
+// 				case (NSUrlError) CFNetworkErrors.HttpAuthenticationTypeUnsupported:
+// 				case (NSUrlError) CFNetworkErrors.HttpBadCredentials:
+// 				case (NSUrlError) CFNetworkErrors.HttpBadURL:
+// #endif
+// 					webExceptionStatus = WebExceptionStatus.ConnectFailure;
+// 					break;
+// 				case NSUrlError.TimedOut:
+// #if !MONOTOUCH_WATCH
+// 				case (NSUrlError) CFNetworkErrors.NetServiceTimeout:
+// #endif
+// 					webExceptionStatus = WebExceptionStatus.Timeout;
+// 					break;
+// 				case NSUrlError.CannotFindHost:
+// 				case NSUrlError.DNSLookupFailed:
+// #if !MONOTOUCH_WATCH
+// 				case (NSUrlError) CFNetworkErrors.HostNotFound:
+// 				case (NSUrlError) CFNetworkErrors.NetServiceDnsServiceFailure:
+// #endif
+// 					webExceptionStatus = WebExceptionStatus.NameResolutionFailure;
+// 					break;
+// 				case NSUrlError.DataLengthExceedsMaximum:
+// 					webExceptionStatus = WebExceptionStatus.MessageLengthLimitExceeded;
+// 					break;
+// 				case NSUrlError.NetworkConnectionLost:
+// #if !MONOTOUCH_WATCH
+// 				case (NSUrlError) CFNetworkErrors.HttpConnectionLost:
+// #endif
+// 					webExceptionStatus = WebExceptionStatus.ConnectionClosed;
+// 					break;
+// 				case NSUrlError.HTTPTooManyRedirects:
+// 				case NSUrlError.RedirectToNonExistentLocation:
+// #if !MONOTOUCH_WATCH
+// 				case (NSUrlError) CFNetworkErrors.HttpRedirectionLoopDetected:
+// #endif
+// 					webExceptionStatus = WebExceptionStatus.ProtocolError;
+// 					break;
+// 				case NSUrlError.RequestBodyStreamExhausted:
+// #if !MONOTOUCH_WATCH
+// 				case (NSUrlError) CFNetworkErrors.SocksUnknownClientVersion:
+// 				case (NSUrlError) CFNetworkErrors.SocksUnsupportedServerVersion:
+// 				case (NSUrlError) CFNetworkErrors.HttpParseFailure:
+// #endif
+// 					webExceptionStatus = WebExceptionStatus.SendFailure;
+// 					break;
+// 				case NSUrlError.BadServerResponse:
+// 				case NSUrlError.ZeroByteResource:
+// 				case NSUrlError.CannotDecodeRawData:
+// 				case NSUrlError.CannotDecodeContentData:
+// 				case NSUrlError.CannotParseResponse:
+// 				case NSUrlError.FileDoesNotExist:
+// 				case NSUrlError.FileIsDirectory:
+// 				case NSUrlError.NoPermissionsToReadFile:
+// 				case NSUrlError.CannotLoadFromNetwork:
+// 				case NSUrlError.CannotCreateFile:
+// 				case NSUrlError.CannotOpenFile:
+// 				case NSUrlError.CannotCloseFile:
+// 				case NSUrlError.CannotWriteToFile:
+// 				case NSUrlError.CannotRemoveFile:
+// 				case NSUrlError.CannotMoveFile:
+// 				case NSUrlError.DownloadDecodingFailedMidStream:
+// 				case NSUrlError.DownloadDecodingFailedToComplete:
+// #if !MONOTOUCH_WATCH
+// 				case (NSUrlError) CFNetworkErrors.Socks4RequestFailed:
+// 				case (NSUrlError) CFNetworkErrors.Socks4IdentdFailed:
+// 				case (NSUrlError) CFNetworkErrors.Socks4IdConflict:
+// 				case (NSUrlError) CFNetworkErrors.Socks4UnknownStatusCode:
+// 				case (NSUrlError) CFNetworkErrors.Socks5BadState:
+// 				case (NSUrlError) CFNetworkErrors.Socks5BadResponseAddr:
+// 				case (NSUrlError) CFNetworkErrors.CannotParseCookieFile:
+// 				case (NSUrlError) CFNetworkErrors.NetServiceUnknown:
+// 				case (NSUrlError) CFNetworkErrors.NetServiceCollision:
+// 				case (NSUrlError) CFNetworkErrors.NetServiceNotFound:
+// 				case (NSUrlError) CFNetworkErrors.NetServiceInProgress:
+// 				case (NSUrlError) CFNetworkErrors.NetServiceBadArgument:
+// 				case (NSUrlError) CFNetworkErrors.NetServiceInvalid:
+// #endif
+// 					webExceptionStatus = WebExceptionStatus.ReceiveFailure;
+// 					break;
+// 				case NSUrlError.SecureConnectionFailed:
+// 					webExceptionStatus = WebExceptionStatus.SecureChannelFailure;
+// 					break;
+// 				case NSUrlError.ServerCertificateHasBadDate:
+// 				case NSUrlError.ServerCertificateHasUnknownRoot:
+// 				case NSUrlError.ServerCertificateNotYetValid:
+// 				case NSUrlError.ServerCertificateUntrusted:
+// 				case NSUrlError.ClientCertificateRejected:
+// 				case NSUrlError.ClientCertificateRequired:
+// 					webExceptionStatus = WebExceptionStatus.TrustFailure;
+// 					break;
+// #if !MONOTOUCH_WATCH
+// 				case (NSUrlError) CFNetworkErrors.HttpProxyConnectionFailure:
+// 				case (NSUrlError) CFNetworkErrors.HttpBadProxyCredentials:
+// 				case (NSUrlError) CFNetworkErrors.PacFileError:
+// 				case (NSUrlError) CFNetworkErrors.PacFileAuth:
+// 				case (NSUrlError) CFNetworkErrors.HttpsProxyConnectionFailure:
+// 				case (NSUrlError) CFNetworkErrors.HttpsProxyFailureUnexpectedResponseToConnectMethod:
+// 					webExceptionStatus = WebExceptionStatus.RequestProhibitedByProxy;
+// 					break;
+// #endif
 				}
 			} 
 


### PR DESCRIPTION
Comment out code to convert NSUrlError to WebExceptionStatus, because the
result isn't used. Looking through git history it seems the resulting
WebExceptionStatus was never used.

Fixes this warning:

    HttpClientEx.cs(83,8): warning CS0219: The variable 'webExceptionStatus' is assigned but its value is never used