### PR TITLE
[SDKS, LLVM] Disable detection and use of libxml2

### DIFF
--- a/sdks/builds/llvm.mk
+++ b/sdks/builds/llvm.mk
@@ -164,6 +164,7 @@ define LLVMMxeTemplate
 # -DLLVM_ENABLE_THREADS=0 is needed because mxe doesn't define std::mutex etc.
 # -DLLVM_BUILD_EXECUTION_ENGINE=Off is needed because it depends on threads
 # -DCROSS_TOOLCHAIN_FLAGS_NATIVE is needed to compile the native tools (tlbgen) using the host compilers
+# -DLLVM_ENABLE_LIBXML2=OFF is needed because xml2 is not used and it breaks 32-bit builds on 64-bit Linux hosts
 _llvm-$(1)_CMAKE_FLAGS = \
 	$$(llvm_CMAKE_FLAGS) \
 	-DCMAKE_INSTALL_PREFIX=$$(TOP)/sdks/out/llvm-$(1) \
@@ -171,6 +172,7 @@ _llvm-$(1)_CMAKE_FLAGS = \
 	-DCROSS_TOOLCHAIN_FLAGS_NATIVE=-DCMAKE_TOOLCHAIN_FILE=$$(LLVM_SRC)/cmake/modules/NATIVE.cmake \
 	-DCMAKE_TOOLCHAIN_FILE=$$(LLVM_SRC)/cmake/modules/$(3).cmake \
 	-DLLVM_BUILD_EXECUTION_ENGINE=Off \
+	-DLLVM_ENABLE_LIBXML2=OFF \
 	$$(llvm-$(1)_CMAKE_FLAGS)
 
 $$(LLVM_SRC)/cmake/modules/$(3).cmake: $(3).cmake.in | $$(LLVM_SRC)


### PR DESCRIPTION
Mono doesn't use libxml2 and neither do the LLVM bits used by Mono when building
the AOT cross-compilers. Presence of `-lxml2` on the command line breaks 32-bit
builds on 64-bit Linux hosts:

    libtool: link: cc -shared  -fPIC -DPIC  -Wl,--whole-archive ./.libs/libmini.a ./.libs/libmono-ee-interp.a ./.libs/libmono-dbg.a ../../mono/metadata/.libs/libmonoruntimesgen.a ../../mono/sgen/.libs/libmonosgen.a ../../mono/utils/.libs/libmonoutils.a ../../mono/eglib/.libs/libeglib.a -Wl,--no-whole-archive  -lLLVMBitWriter -lLLVMAnalysis -lLLVMProfileData -lLLVMObject -lLLVMMCParser -lLLVMMC -lLLVMBitReader -lLLVMCore -lLLVMBinaryFormat -lLLVMSupport -lLLVMDemangle -L$HOME/xamarin-android/external/mono/sdks/out/llvm-llvm32/lib -lz -ltinfo -lxml2 -lstdc++ -lm -lrt -ldl -lpthread  -O0 -ggdb3 -m32 -g -mno-tls-direct-seg-refs -Wl,-export-dynamic   -Wl,-soname -Wl,libmonosgen-2.0.so.1 -o .libs/libmonosgen-2.0.so.1.0.0
    mv -f .deps/libmini_la-aot-runtime-wasm.Tpo .deps/libmini_la-aot-runtime-wasm.Plo
    /usr/bin/ld: skipping incompatible //usr/lib/x86_64-linux-gnu/libxml2.so when searching for -lxml2
    /usr/bin/ld: skipping incompatible //usr/lib/x86_64-linux-gnu/libxml2.a when searching for -lxml2
    /usr/bin/ld: cannot find -lxml2
    collect2: error: ld returned 1 exit status
    make[7]: *** [Makefile:1495: libmonosgen-2.0.la] Error 1

Installation of `libxml2-dev` (on Ubuntu/Debian + friends) for the x86
architecture (or x86_64 architecture on 32-bit host) would be possible but then
it would break the 64-bit build because the 64-bit version of the library would
be absent. It would be a problem if Mono+LLVM actually used xml2, but since it
doesn't we can just disable the feature completely.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
