### PR TITLE
[2018-10] [wasm] Add missing include

### DIFF
--- a/mono/mini/mini-wasm.c
+++ b/mono/mini/mini-wasm.c
@@ -4,6 +4,7 @@
 #include <mono/metadata/assembly.h>
 #include <mono/metadata/metadata.h>
 #include <mono/metadata/loader-internals.h>
+#include <mono/metadata/icall-internals.h>
 #include <mono/metadata/seq-points-data.h>
 #include <mono/mini/aot-runtime.h>
 #include <mono/mini/seq-points.h>


### PR DESCRIPTION
Backport of #11335.

/cc @lambdageek 

Description:
Fixup for
https://github.com/mono/mono/commit/5e961c6deb27c6bfc46cdba99274bbe02f8f0562


