### PR TITLE
[2018-10] Replace mono_object_get_class with mono_object_class to avoid gc transitions.

### DIFF
--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -1630,7 +1630,7 @@ test_toggleref_callback (MonoObject *obj)
 	MonoToggleRefStatus status = MONO_TOGGLE_REF_DROP;
 
 	if (!mono_toggleref_test_field) {
-		mono_toggleref_test_field = mono_class_get_field_from_name_full (mono_object_get_class (obj), "__test", NULL);
+		mono_toggleref_test_field = mono_class_get_field_from_name_full (mono_object_class (obj), "__test", NULL);
 		g_assert (mono_toggleref_test_field);
 	}
 

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -3368,7 +3368,7 @@ ves_icall_InternalInvoke (MonoReflectionMethod *method, MonoObject *this_arg, Mo
 					mono_gc_wbarrier_generic_store (exc, (MonoObject*) mono_error_convert_to_exception (error));
 					return NULL;
 				}
-				char *this_name = mono_type_get_full_name (mono_object_get_class (this_arg));
+				char *this_name = mono_type_get_full_name (mono_object_class (this_arg));
 				char *target_name = mono_type_get_full_name (m->klass);
 				char *msg = g_strdup_printf ("Object of type '%s' doesn't match target type '%s'", this_name, target_name);
 				mono_gc_wbarrier_generic_store (exc, (MonoObject*) mono_exception_from_name_msg (mono_defaults.corlib, "System.Reflection", "TargetException", msg));

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -2203,7 +2203,7 @@ mono_class_create_runtime_vtable (MonoDomain *domain, MonoClass *klass, MonoErro
 			return NULL;
 		}
 
-		if (mono_object_get_class ((MonoObject *)vt->type) != mono_defaults.runtimetype_class)
+		if (mono_object_class ((MonoObject *)vt->type) != mono_defaults.runtimetype_class)
 			/* This is unregistered in
 			   unregister_vtable_reflection_type() in
 			   domain.c. */
@@ -2236,7 +2236,7 @@ mono_class_create_runtime_vtable (MonoDomain *domain, MonoClass *klass, MonoErro
 			return NULL;
 		}
 
-		if (mono_object_get_class ((MonoObject *)vt->type) != mono_defaults.runtimetype_class)
+		if (mono_object_class ((MonoObject *)vt->type) != mono_defaults.runtimetype_class)
 			/* This is unregistered in
 			   unregister_vtable_reflection_type() in
 			   domain.c. */

--- a/mono/metadata/object.h
+++ b/mono/metadata/object.h
@@ -203,7 +203,7 @@ mono_object_get_vtable      (MonoObject *obj);
 MONO_API MonoDomain*
 mono_object_get_domain      (MonoObject *obj);
 
-MONO_API MonoClass*
+MONO_API MONO_RT_EXTERNAL_ONLY MonoClass*
 mono_object_get_class       (MonoObject *obj);
 
 MONO_API void*

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -464,7 +464,7 @@ static MonoException *
 mono_remoting_update_exception (MonoException *exc)
 {
 	MonoInternalThread *thread;
-	MonoClass *klass = mono_object_get_class ((MonoObject*)exc);
+	MonoClass *klass = mono_object_class ((MonoObject*)exc);
 
 	/* Serialization error can only happen when still in the target appdomain */
 	if (!(mono_class_get_flags (klass) & TYPE_ATTRIBUTE_SERIALIZABLE)) {
@@ -478,7 +478,7 @@ mono_remoting_update_exception (MonoException *exc)
 	}
 
 	thread = mono_thread_internal_current ();
-	if (mono_object_get_class ((MonoObject*)exc) == mono_defaults.threadabortexception_class &&
+	if (mono_object_class ((MonoObject*)exc) == mono_defaults.threadabortexception_class &&
 			thread->flags & MONO_THREAD_FLAG_APPDOMAIN_ABORT) {
 		mono_thread_internal_reset_abort (thread);
 		return mono_get_exception_appdomain_unloaded ();

--- a/mono/metadata/sgen-bridge.c
+++ b/mono/metadata/sgen-bridge.c
@@ -583,7 +583,7 @@ bridge_test_cross_reference2 (int num_sccs, MonoGCBridgeSCC **sccs, int num_xref
 	gboolean modified;
 
 	if (!mono_bridge_test_field) {
-		mono_bridge_test_field = mono_class_get_field_from_name_full (mono_object_get_class (sccs[0]->objs [0]), "__test", NULL);
+		mono_bridge_test_field = mono_class_get_field_from_name_full (mono_object_class (sccs[0]->objs [0]), "__test", NULL);
 		g_assert (mono_bridge_test_field);
 	}
 
@@ -633,7 +633,7 @@ bridge_test_positive_status (int num_sccs, MonoGCBridgeSCC **sccs, int num_xrefs
 	int i;
 
 	if (!mono_bridge_test_field) {
-		mono_bridge_test_field = mono_class_get_field_from_name_full (mono_object_get_class (sccs[0]->objs [0]), "__test", NULL);
+		mono_bridge_test_field = mono_class_get_field_from_name_full (mono_object_class (sccs[0]->objs [0]), "__test", NULL);
 		g_assert (mono_bridge_test_field);
 	}
 

--- a/mono/metadata/sgen-toggleref.c
+++ b/mono/metadata/sgen-toggleref.c
@@ -207,7 +207,7 @@ test_toggleref_callback (MonoObject *obj)
 	MonoToggleRefStatus status = MONO_TOGGLE_REF_DROP;
 
 	if (!mono_toggleref_test_field) {
-		mono_toggleref_test_field = mono_class_get_field_from_name_full (mono_object_get_class (obj), "__test", NULL);
+		mono_toggleref_test_field = mono_class_get_field_from_name_full (mono_object_class (obj), "__test", NULL);
 		g_assert (mono_toggleref_test_field);
 	}
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1185,7 +1185,7 @@ static guint32 WINAPI start_wrapper_internal(StartInfo *start_info, gsize *stack
 			MonoException *ex = mono_error_convert_to_exception (error);
 
 			g_assert (ex != NULL);
-			MonoClass *klass = mono_object_get_class (&ex->object);
+			MonoClass *klass = mono_object_class (&ex->object);
 			if ((mono_runtime_unhandled_exception_policy_get () != MONO_UNHANDLED_POLICY_LEGACY) &&
 			    !is_threadabort_exception (klass)) {
 				mono_unhandled_exception (&ex->object);

--- a/mono/mini/mini-wasm.c
+++ b/mono/mini/mini-wasm.c
@@ -552,7 +552,7 @@ mono_set_timeout_exec (int id)
 	}
 
 	if (exc) {
-		char *type_name = mono_type_get_full_name (mono_object_get_class (exc));
+		char *type_name = mono_type_get_full_name (mono_object_class (exc));
 		printf ("timeout callback threw a %s\n", type_name);
 		g_free (type_name);
 	}


### PR DESCRIPTION
Replacement for #11105.
Backport of #11077.
