### PR TITLE
[runtime] Fixes threadpool tests not to rely on arbitrary sleep timeout

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -436,10 +436,8 @@ TESTS_CS_SRC=		\
 	threadpool.cs		\
 	threadpool1.cs		\
 	threadpool-exceptions1.cs \
-	threadpool-exceptions2.cs \
 	threadpool-exceptions3.cs \
 	threadpool-exceptions4.cs \
-	threadpool-exceptions5.cs \
 	threadpool-exceptions6.cs \
 	base-definition.cs	\
 	bug-27420.cs		\
@@ -2866,7 +2864,9 @@ TESTS_UNHANDLED_EXCEPTION_255_SRC =	\
 	unhandled-exception-5.cs	\
 	unhandled-exception-6.cs	\
 	unhandled-exception-7.cs	\
-	unhandled-exception-8.cs
+	unhandled-exception-8.cs	\
+	threadpool-exceptions2.cs	\
+	threadpool-exceptions5.cs
 
 TESTS_UNHANDLED_EXCEPTION_1=$(filter-out $(DISABLED_TESTS),$(TESTS_UNHANDLED_EXCEPTION_1_SRC:.cs=.exe))
 TESTS_UNHANDLED_EXCEPTION_255=$(filter-out $(DISABLED_TESTS),$(TESTS_UNHANDLED_EXCEPTION_255_SRC:.cs=.exe))

--- a/mono/tests/threadpool-exceptions1.cs
+++ b/mono/tests/threadpool-exceptions1.cs
@@ -2,27 +2,21 @@ using System;
 using System.Threading;
 
 class Test {
-	static object monitor;
-
 	static int Main ()
 	{
-		monitor = new object ();
 		AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
 		ThreadPool.QueueUserWorkItem ((a) => {
 			throw new Exception ("From the threadpoool");
-			});
-		lock (monitor) {
-			Monitor.Wait (monitor);
-		}
-		Thread.Sleep (1000);
-		return 1;
+		});
+
+		// Should not finish, OnUnhandledException exit path is expected to be executed
+		Thread.Sleep (10000);
+
+		return 3;
 	}
 
 	static void OnUnhandledException (object sender, UnhandledExceptionEventArgs e)
 	{
-		lock (monitor) {
-			Monitor.Pulse (monitor);
-		}
 		Environment.Exit (0);
 	}
 }

--- a/mono/tests/threadpool-exceptions2.cs
+++ b/mono/tests/threadpool-exceptions2.cs
@@ -2,38 +2,46 @@ using System;
 using System.Threading;
 
 class Test {
-	static object monitor;
-	static int return_value = 2;
+
+	static ManualResetEvent mre = new ManualResetEvent (false);
 
 	static int Main ()
 	{
-		monitor = new object ();
 		AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
 		WaitCallback wcb = new WaitCallback ((a) => {
 			throw new Exception ("From the threadpoool");
 		});
 		wcb.BeginInvoke (wcb, OnCBFinished, null);
-		lock (monitor) {
-			Monitor.Wait (monitor);
-		}
-		Thread.Sleep (1000);
-		return 1;
+
+		if (!mre.WaitOne (10000))
+			return 2;
+
+		GC.Collect ();
+		GC.WaitForPendingFinalizers ();
+
+		/* expected exit code: 255 */
+		Thread.Sleep (10000);
+		return 0;
 	}
 
 	static void OnUnhandledException (object sender, UnhandledExceptionEventArgs e)
 	{
 		string str = e.ExceptionObject.ToString ();
-		if (str.IndexOf ("From the threadpool") != -1)
-			return_value = 3;
-		lock (monitor) {
-			Monitor.Pulse (monitor);
+		if (!str.Contains ("From OnCBFinished")) {
+			Environment.Exit (3);
+			return;
 		}
-		Environment.Exit (return_value);
+
+		if (!e.IsTerminating) {
+			Environment.Exit (4);
+			return;
+		}
+
+		mre.Set ();
 	}
 
 	static void OnCBFinished (object arg)
 	{
-		return_value = 0;
 		throw new Exception ("From OnCBFinished");
 	}
 }

--- a/mono/tests/threadpool-exceptions4.cs
+++ b/mono/tests/threadpool-exceptions4.cs
@@ -2,21 +2,18 @@ using System;
 using System.Threading;
 
 class Test {
-	static object monitor;
-
 	static int Main ()
 	{
-		monitor = new object ();
 		AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
 		WaitCallback wcb = new WaitCallback ((a) => {
 			throw new Exception ("From the threadpoool");
 		});
 		wcb.BeginInvoke (wcb, OnCBFinished, null);
-		lock (monitor) {
-			Monitor.Wait (monitor);
-		}
-		Thread.Sleep (1000);
-		return 1;
+
+		// Should not finish, OnUnhandledException exit path is expected to be executed
+		Thread.Sleep (10000);
+
+		return 2;
 	}
 
 	static void OnCBFinished (object arg)
@@ -26,9 +23,6 @@ class Test {
 
 	static void OnUnhandledException (object sender, UnhandledExceptionEventArgs e)
 	{
-		lock (monitor) {
-			Monitor.Pulse (monitor);
-		}
 		Environment.Exit (0);
 	}
 }

--- a/mono/tests/threadpool-exceptions5.cs
+++ b/mono/tests/threadpool-exceptions5.cs
@@ -2,37 +2,47 @@ using System;
 using System.Threading;
 
 class Test {
-	static object monitor;
-	static int return_value = 2;
+
+	static ManualResetEvent mre = new ManualResetEvent (false);
+
 	static int Main ()
 	{
-		monitor = new object ();
 		AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
 		WaitCallback wcb = new WaitCallback ((a) => {
 			Thread.CurrentThread.Abort();
 		});
+
 		wcb.BeginInvoke (wcb, OnCBFinished, null);
-		lock (monitor) {
-			Monitor.Wait (monitor);
-		}
-		Thread.Sleep (1000);
-		return 1;
+
+		if (!mre.WaitOne (10000))
+			return 2;
+
+		GC.Collect ();
+		GC.WaitForPendingFinalizers ();
+
+		/* expected exit code: 255 */
+		Thread.Sleep (10000);
+		return 0;
 	}
 
 	static void OnUnhandledException (object sender, UnhandledExceptionEventArgs e)
 	{
 		string str = e.ExceptionObject.ToString ();
-		if (str.IndexOf ("From the threadpool") != -1)
-			return_value = 3;
-		lock (monitor) {
-			Monitor.Pulse (monitor);
+		if (!str.Contains ("From OnCBFinished")) {
+			Environment.Exit (3);
+			return;
 		}
-		Environment.Exit (return_value);
+
+		if (!e.IsTerminating) {
+			Environment.Exit (4);
+			return;
+		}
+
+		mre.Set ();
 	}
 
 	static void OnCBFinished (object arg)
 	{
-		return_value = 0;
 		throw new Exception ("From OnCBFinished");
 	}
 }

--- a/mono/tests/threadpool-exceptions7.cs
+++ b/mono/tests/threadpool-exceptions7.cs
@@ -1,4 +1,3 @@
-
 using System;
 using System.Threading;
 
@@ -15,17 +14,22 @@ class Test {
 		AppDomain domain = AppDomain.CreateDomain ("test");
 		ThreadPool.QueueUserWorkItem (unused => {
 			domain.DoCallBack (() => {
+				AppDomain.CurrentDomain.SetData ("key", "checked");
+
 				// This will get a ThreadAbortedException
 				Thread.Sleep (10000);
-				});
 			});
-		Thread.Sleep (1000);
+		});
+
+		if (!SpinWait.SpinUntil (() => domain.GetData ("key") as string == "checked", 10000))
+			Environment.Exit (4);
+
 		AppDomain.Unload (domain);
 	}
 
 	static void OnUnhandledException (object sender, UnhandledExceptionEventArgs e)
 	{
-		Environment.Exit (1);
+		Environment.Exit (3);
 	}
 }
 


### PR DESCRIPTION

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
