### PR TITLE
Fix bcl-size-diff command

### DIFF
--- a/mcs/tools/linker/Makefile
+++ b/mcs/tools/linker/Makefile
@@ -119,7 +119,7 @@ bcl-size-current: compile-tests
 		rm -rf $(LINKER_OUTPUT); \
 		mkdir $(LINKER_OUTPUT); \
 		echo Checking linked BCL size for $$app; \
-		$(LINKER) -a Tests/$$app; \
+		$(LINKER_DEFAULT) -a Tests/$$app; \
 		sizes=""; \
 		for asm in $(BCL_ASSEMBLIES); do \
 			if [ -f "$(LINKER_OUTPUT)/$$asm" ]; then size=$$(wc -c < "$(LINKER_OUTPUT)/$$asm" | tr -d "[:space:]"); else size="0"; fi; \


### PR DESCRIPTION
The BCL size regression (see https://github.com/mono/mono/pull/11041) was actually caused by changes in linker/Makefile: https://github.com/mono/mono/commit/539b14892000f3c4b13657161819680dd9aa098c#diff-f2d312cb75589935c2b11af219414f48L73
With this fix it's green again:

![image](https://user-images.githubusercontent.com/523221/47464597-5f8e0300-d7f2-11e8-88ac-b3e6e6129c81.png)
