### PR TITLE
[2018-10] [System.Core]: Stub out `Interop.Sys.GetEUid` and `SetEUid`.

### DIFF
--- a/mcs/class/System.Core/System.Core.csproj
+++ b/mcs/class/System.Core/System.Core.csproj
@@ -916,7 +916,6 @@
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Fcntl.Pipe.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Fcntl.SetCloseOnExec.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.GetDomainSocketSizes.cs" />
-            <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.GetEUid.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.GetHostName.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.GetPeerID.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.GetPeerUserName.cs" />
@@ -927,7 +926,6 @@
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Pipe.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Poll.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Read.Pipe.cs" />
-            <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.SetEUid.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Stat.Pipe.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Stat.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Unlink.cs" />
@@ -982,6 +980,7 @@
             <Compile Include="System.Security.Cryptography\SHA256Cng.cs" />
             <Compile Include="System.Security.Cryptography\SHA384Cng.cs" />
             <Compile Include="System.Security.Cryptography\SHA512Cng.cs" />
+            <Compile Include="corefx\Interop.cs" />
           </ItemGroup>
         </When>
         <When Condition="'$(HostPlatform)' == 'macos'">
@@ -994,7 +993,6 @@
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Fcntl.Pipe.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Fcntl.SetCloseOnExec.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.GetDomainSocketSizes.cs" />
-            <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.GetEUid.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.GetHostName.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.GetPeerID.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.GetPeerUserName.cs" />
@@ -1005,7 +1003,6 @@
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Pipe.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Poll.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Read.Pipe.cs" />
-            <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.SetEUid.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Stat.Pipe.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Stat.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Unlink.cs" />
@@ -1060,6 +1057,7 @@
             <Compile Include="System.Security.Cryptography\SHA256Cng.cs" />
             <Compile Include="System.Security.Cryptography\SHA384Cng.cs" />
             <Compile Include="System.Security.Cryptography\SHA512Cng.cs" />
+            <Compile Include="corefx\Interop.cs" />
           </ItemGroup>
         </When>
         <When Condition="'$(HostPlatform)' == 'linux'">
@@ -1072,7 +1070,6 @@
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Fcntl.Pipe.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Fcntl.SetCloseOnExec.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.GetDomainSocketSizes.cs" />
-            <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.GetEUid.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.GetHostName.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.GetPeerID.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.GetPeerUserName.cs" />
@@ -1083,7 +1080,6 @@
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Pipe.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Poll.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Read.Pipe.cs" />
-            <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.SetEUid.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Stat.Pipe.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Stat.cs" />
             <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Unlink.cs" />
@@ -1138,6 +1134,7 @@
             <Compile Include="System.Security.Cryptography\SHA256Cng.cs" />
             <Compile Include="System.Security.Cryptography\SHA384Cng.cs" />
             <Compile Include="System.Security.Cryptography\SHA512Cng.cs" />
+            <Compile Include="corefx\Interop.cs" />
           </ItemGroup>
         </When>
       </Choose>

--- a/mcs/class/System.Core/corefx/Interop.cs
+++ b/mcs/class/System.Core/corefx/Interop.cs
@@ -1,0 +1,18 @@
+using System;
+
+internal static partial class Interop
+{
+	internal static partial class Sys
+	{
+		internal static uint GetEUid ()
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+		internal static int SetEUid (uint euid)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+	}
+}

--- a/mcs/class/System.Core/unix_net_4_x_System.Core.dll.sources
+++ b/mcs/class/System.Core/unix_net_4_x_System.Core.dll.sources
@@ -35,5 +35,8 @@ System.IO.Pipes/AnonymousPipeServerStream.Unix.cs
 ../../../external/corefx/src/Common/src/Interop/Unix/System.Native/Interop.Stat.cs
 ../../../external/corefx/src/Common/src/Interop/Unix/System.Native/Interop.Stat.Pipe.cs
 ../../../external/corefx/src/Common/src/Interop/Unix/System.Native/Interop.GetPeerID.cs
-../../../external/corefx/src/Common/src/Interop/Unix/System.Native/Interop.GetEUid.cs
-../../../external/corefx/src/Common/src/Interop/Unix/System.Native/Interop.SetEUid.cs
+
+# FIXME: the native side is not there yet.
+# ../../../external/corefx/src/Common/src/Interop/Unix/System.Native/Interop.GetEUid.cs
+# ../../../external/corefx/src/Common/src/Interop/Unix/System.Native/Interop.SetEUid.cs
+corefx/Interop.cs


### PR DESCRIPTION
Backport of #11366.

/cc @baulig 

Description:
This is a temporary fix; the native side still needs to be ported from c++ and tested.