### PR TITLE
[profiler] Add xunit xml profiler tests output and allow tests to run from outside the build tree 

### DIFF
--- a/mono/profiler/Makefile.am
+++ b/mono/profiler/Makefile.am
@@ -162,7 +162,7 @@ MCS = $(TOOLS_RUNTIME) $(CSC) -lib:$(CLASS) -unsafe -nologo -noconfig -nowarn:01
 	$(MCS) -out:$@ $<
 
 testlog: $(PLOG_TESTS)
-	MONO_PATH=$(CLASS) perl $(srcdir)/ptestrunner.pl $(top_builddir)
+	MONO_PATH=$(CLASS) perl $(srcdir)/ptestrunner.pl $(top_builddir) nunit TestResult-profiler.xml
 
 check-local: $(check_targets)
 

--- a/mono/profiler/ptestrunner.pl
+++ b/mono/profiler/ptestrunner.pl
@@ -2,15 +2,24 @@
 
 use strict;
 
+sub print_usage
+{
+	die "Usage: ptestrunner.pl mono_build_dir <nunit|xunit> xml_report_filename\n";
+}
+
 # run the log profiler test suite
 
-my $builddir = shift || die "Usage: ptestrunner.pl mono_build_dir\n";
+my $builddir = shift || print_usage ();
+my $xml_report_type = shift || print_usage ();
+my $xml_report_filename = shift || print_usage ();
 my @errors = ();
 my $total_errors = 0; # this is reset before each test
 my $global_errors = 0;
+my $testcases_succeeded = 0;
+my $testcases_failed = 0;
 my $report;
-my $nunit_testcase_name;
-my $nunit_testcase_xml;
+my $testcase_name;
+my $testcase_xml;
 
 my $profbuilddir = $builddir . "/mono/profiler";
 my $minibuilddir = $builddir . "/mono/mini";
@@ -27,7 +36,7 @@ check_report_basics ($report);
 check_report_calls ($report, "T:Main (string[])" => 1);
 check_report_allocation ($report, "System.Object" => 1000000);
 report_errors ();
-add_nunit_testcase_result ();
+add_xml_testcase_result ();
 # test additional named threads and method calls
 $report = run_test ("test-busy.exe", "report,legacy,calls,alloc");
 check_report_basics ($report);
@@ -35,7 +44,7 @@ check_report_calls ($report, "T:Main (string[])" => 1);
 check_report_threads ($report, "BusyHelper");
 check_report_calls ($report, "T:test ()" => 10, "T:test3 ()" => 10, "T:test2 ()" => 1);
 report_errors ();
-add_nunit_testcase_result ();
+add_xml_testcase_result ();
 # test with the sampling profiler
 $report = run_test ("test-busy.exe", "report,legacy,sample");
 check_report_basics ($report);
@@ -44,7 +53,7 @@ check_report_threads ($report, "BusyHelper");
 # This seems to fail on osx, where the main thread gets the majority of SIGPROF signals
 #check_report_samples ($report, "T:test ()" => 40, "T:test3 ()" => 40);
 report_errors ();
-add_nunit_testcase_result ();
+add_xml_testcase_result ();
 # test lock events
 $report = run_test ("test-monitor.exe", "report,legacy,calls,alloc");
 check_report_basics ($report);
@@ -52,14 +61,14 @@ check_report_calls ($report, "T:Main (string[])" => 1);
 # we hope for at least some contention, this is not entirely reliable
 check_report_locks ($report, 1, 1);
 report_errors ();
-add_nunit_testcase_result ();
+add_xml_testcase_result ();
 # test exceptions
 $report = run_test ("test-excleave.exe", "report,legacy,calls");
 check_report_basics ($report);
 check_report_calls ($report, "T:Main (string[])" => 1, "T:throw_ex ()" => 1000);
 check_report_exceptions ($report, 1000, 1000, 1000);
 report_errors ();
-add_nunit_testcase_result ();
+add_xml_testcase_result ();
 # test heapshot
 $report = run_test_sgen ("test-heapshot.exe", "report,heapshot,legacy");
 if ($report ne "missing binary") {
@@ -67,7 +76,7 @@ if ($report ne "missing binary") {
 	check_report_heapshot ($report, 0, {"T" => 5000});
 	check_report_heapshot ($report, 1, {"T" => 5023});
 	report_errors ();
-	add_nunit_testcase_result ();
+	add_xml_testcase_result ();
 }
 # test heapshot traces
 $report = run_test_sgen ("test-heapshot.exe", "heapshot,output=traces.mlpd,legacy", "--traces traces.mlpd");
@@ -82,7 +91,7 @@ if ($report ne "missing binary") {
 		T => [5022, "T"]
 	);
 	report_errors ();
-	add_nunit_testcase_result ();
+	add_xml_testcase_result ();
 }
 # test traces
 $report = run_test ("test-traces.exe", "legacy,calls,alloc,output=traces.mlpd", "--maxframes=7 --traces traces.mlpd");
@@ -100,7 +109,7 @@ check_alloc_traces ($report,
 	T => [1010, "T:Main (string[])", "T:level3 (int)", "T:level2 (int)", "T:level1 (int)", "T:level0 (int)"]
 );
 report_errors ();
-add_nunit_testcase_result ();
+add_xml_testcase_result ();
 # test traces without enter/leave events
 $report = run_test ("test-traces.exe", "legacy,alloc,output=traces.mlpd", "--traces traces.mlpd");
 check_report_basics ($report);
@@ -112,9 +121,9 @@ check_alloc_traces ($report,
 	T => [1010, "T:Main (string[])", "T:level3 (int)", "T:level2 (int)", "T:level1 (int)", "T:level0 (int)"]
 );
 report_errors ();
-add_nunit_testcase_result ();
+add_xml_testcase_result ();
 
-emit_nunit_report();
+emit_xml_report();
 
 exit ($global_errors ? 1 : 0);
 
@@ -149,7 +158,7 @@ sub run_test_bin
 	@errors = ();
 	$total_errors = 0;
 	print "Checking $test_name with $option ...";
-	$nunit_testcase_name = "$test_name($option)";
+	$testcase_name = "$test_name($option)";
 	unless (-x $bin) {
 		print "missing $bin, skipped.\n";
 		return "missing binary";
@@ -173,31 +182,55 @@ sub report_errors
 	#print $report;
 }
 
+sub add_xml_testcase_result
+{
+	if ($xml_report_type eq "nunit") {
+		add_nunit_testcase_result (@_);
+	} elsif ($xml_report_type eq "xunit") {
+		add_xunit_testcase_result (@_);
+	} else {
+		die "Unknown XML report type '$xml_report_type'.";
+	}
+}
+
+sub emit_xml_report
+{
+	if ($xml_report_type eq "nunit") {
+		emit_nunit_report (@_);
+	} elsif ($xml_report_type eq "xunit") {
+		emit_xunit_report (@_);
+	} else {
+		die "Unknown XML report type '$xml_report_type'.";
+	}
+}
+
 sub add_nunit_testcase_result
 {
 	my $successbool;
 	if ($total_errors > 0) {
 		$successbool = "False";
+		$testcases_failed++;
 	} else {
 		$successbool = "True";
+		$testcases_succeeded++;
 	}
 
-	$nunit_testcase_xml .= "              <test-case name=\"MonoTests.profiler.$nunit_testcase_name\" executed=\"True\" success=\"$successbool\" time=\"0\" asserts=\"0\"";
+	$testcase_xml .= "              <test-case name=\"MonoTests.profiler.$testcase_name\" executed=\"True\" success=\"$successbool\" time=\"0\" asserts=\"0\"";
 	if ($total_errors > 0) {
-		$nunit_testcase_xml .=  ">\n";
-		$nunit_testcase_xml .=  "                <failure>\n";
-		$nunit_testcase_xml .=  "                  <message><![CDATA[";
+		$testcase_xml .=  ">\n";
+		$testcase_xml .=  "                <failure>\n";
+		$testcase_xml .=  "                  <message><![CDATA[";
 		foreach my $e (@errors) {
-			$nunit_testcase_xml .= "Error: $e\n";
+			$testcase_xml .= "Error: $e\n";
 		}
-		$nunit_testcase_xml .= "]]></message>\n";
-		$nunit_testcase_xml .=  "                  <stack-trace><![CDATA[";
-		$nunit_testcase_xml .=  $report;
-		$nunit_testcase_xml .=  "]]></stack-trace>\n";
-		$nunit_testcase_xml .=  "                </failure>\n";
-		$nunit_testcase_xml .=  "              </test-case>\n";
+		$testcase_xml .= "]]></message>\n";
+		$testcase_xml .=  "                  <stack-trace><![CDATA[";
+		$testcase_xml .=  $report;
+		$testcase_xml .=  "]]></stack-trace>\n";
+		$testcase_xml .=  "                </failure>\n";
+		$testcase_xml .=  "              </test-case>\n";
 	} else {
-		$nunit_testcase_xml .= " />\n";
+		$testcase_xml .= " />\n";
 	}
 }
 
@@ -220,7 +253,7 @@ sub emit_nunit_report
 	} else {
 		$successbool = "True";
 	}
-	open (my $nunitxml, '>', 'TestResult-profiler.xml') or die "Could not write to 'TestResult-profiler.xml' $!";
+	open (my $nunitxml, '>', $xml_report_filename) or die "Could not write to '$xml_report_filename' $!";
 	print $nunitxml "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n";
 	print $nunitxml "<!--This file represents the results of running a test suite-->\n";
 	print $nunitxml "<test-results name=\"profiler-tests.dummy\" total=\"$total\" failures=\"$failed\" not-run=\"0\" date=\"" . strftime ("%F", localtime) . "\" time=\"" . strftime ("%T", localtime) . "\">\n";
@@ -232,7 +265,7 @@ sub emit_nunit_report
 	print $nunitxml "        <results>\n";
 	print $nunitxml "          <test-suite name=\"profiler\" success=\"$successbool\" time=\"0\" asserts=\"0\">\n";
 	print $nunitxml "            <results>\n";
-	print $nunitxml $nunit_testcase_xml;
+	print $nunitxml $testcase_xml;
 	print $nunitxml "            </results>\n";
 	print $nunitxml "          </test-suite>\n";
 	print $nunitxml "        </results>\n";
@@ -241,6 +274,51 @@ sub emit_nunit_report
 	print $nunitxml "  </test-suite>\n";
 	print $nunitxml "</test-results>\n";
 	close $nunitxml;
+}
+
+sub add_xunit_testcase_result
+{
+	my $testcase_simple_name = substr ($testcase_name, 0, index ($testcase_name, "("));
+	my $resultstring;
+	if ($total_errors > 0) {
+		$resultstring = "Fail";
+		$testcases_failed++;
+	} else {
+		$resultstring = "Pass";
+		$testcases_succeeded++;
+	}
+
+	$testcase_xml .= "        <test name=\"profiler.tests.$testcase_name\" type=\"profiler.tests\" method=\"$testcase_simple_name\" time=\"0\" result=\"$resultstring\"";
+	if ($total_errors > 0) {
+		$testcase_xml .=  ">\n";
+		$testcase_xml .=  "          <failure exception-type=\"ProfilerTestsException\">\n";
+		$testcase_xml .=  "            <message><![CDATA[";
+		foreach my $e (@errors) {
+			$testcase_xml .= "Error: $e\n";
+		}
+		$testcase_xml .= "\nSTDOUT/STDERR:\n";
+		$testcase_xml .=  $report;
+		$testcase_xml .= "]]></message>\n";
+		$testcase_xml .=  "          </failure>\n";
+		$testcase_xml .=  "        </test>\n";
+	} else {
+		$testcase_xml .= " />\n";
+	}
+}
+
+sub emit_xunit_report
+{
+	my $total = $testcases_succeeded + $testcases_failed;
+	open (my $xunitxml, '>', $xml_report_filename) or die "Could not write to '$xml_report_filename' $!";
+	print $xunitxml "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
+	print $xunitxml "<assemblies>\n";
+	print $xunitxml "  <assembly name=\"profiler\" environment=\"Mono\" test-framework=\"custom\" run-date=\"". strftime ("%F", localtime) . "\" run-time=\"" . strftime ("%T", localtime) . "\" total=\"$total\" passed=\"$testcases_succeeded\" failed=\"$testcases_failed\" skipped=\"0\" errors=\"0\" time=\"0\">\n";
+	print $xunitxml "    <collection total=\"$total\" passed=\"$testcases_succeeded\" failed=\"$testcases_failed\" skipped=\"0\" name=\"Test collection for profiler\" time=\"0\">\n";
+	print $xunitxml $testcase_xml;
+	print $xunitxml "    </collection>\n";
+	print $xunitxml "  </assembly>\n";
+	print $xunitxml "</assemblies>\n";
+	close $xunitxml;
 }
 
 sub get_delim_data


### PR DESCRIPTION
We need xunit xml output for Helix.

The new mode which doesn't rely on build tree paths can be enabled by passing the special value "out-of-tree" as the build dir.

Respects the MONO_EXECUTABLE env variable and bases everything off of that.

Also unified run_test and run_test_sgen since we only have sgen nowadays and we only need one.