### PR TITLE
[Mono.Profiler.Log] Use full path for temporary .mlpd's

### DIFF
--- a/mcs/class/Mono.Profiler.Log/Test/ProfilerTestRun.cs
+++ b/mcs/class/Mono.Profiler.Log/Test/ProfilerTestRun.cs
@@ -46,7 +46,7 @@ namespace MonoTests.Mono.Profiler.Log {
 			_currentProcess = Process.GetCurrentProcess();
 			Name = name;
 			Options = options;
-			_output = $"test-{_id++}.mlpd";
+			_output = Path.GetFullPath ($"test-{_id++}.mlpd");
 		}
 
 		public void Run (Action<IReadOnlyList<LogEvent>> action)


### PR DESCRIPTION
So they don't depend on the working dir.