### PR TITLE
[llvm] Fix passing vtypes received by value as arguments, they need to be copied

### DIFF
--- a/mono/mini/objects.cs
+++ b/mono/mini/objects.cs
@@ -1966,6 +1966,41 @@ ncells ) {
 	public static int test_0_dup_vtype () {
 		return new SimpleContainer ().SetFields ();
 	}
+
+	public struct Vec3 {
+		public int X, Y, Z;
+
+		[MethodImplAttribute (MethodImplOptions.NoInlining)]
+			public Vec3(int x, int y, int z) {
+			X = x;
+			Y = y;
+			Z = z;
+		}
+	}
+
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	public static int gh_11378_inner_1 (Vec3 p1, Vec3 p2) {
+		p1.X -= p2.X;
+		p1.Y -= p2.Y;
+		p1.Z -= p2.Z;
+
+		return (int)p2.Y;
+	}
+
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	public static int gh_11378_inner_2 (Vec3 c, Vec3 pos) {
+		return gh_11378_inner_1 (pos, c);
+	}
+
+	static int gh_11378_inner_3 (Vec3 c) {
+		var c2 = c;
+		return gh_11378_inner_2 (c, c2);
+	}
+
+	public static int test_2_gh_11378 () {
+		return gh_11378_inner_3 (new Vec3(0, 2, -20));
+	}
+
 }
 
 #if __MOBILE__


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/11378