### PR TITLE
[runtime] Disables crashing appdomain-threadpool-unload.exe test

### DIFF
--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1522,6 +1522,9 @@ CI_PR_DISABLED_TESTS =
 # https://github.com/mono/mono/issues/8997
 CI_PR_DISABLED_TESTS += finalizer-thread.exe
 
+# https://github.com/mono/mono/issues/11392
+CI_PR_DISABLED_TESTS += appdomain-threadpool-unload.exe
+
 # appdomain-threadpool-unload.exe creates 100 appdomains, takes too long with llvm
 LLVM_DISABLED_TESTS = \
 	finally_block_ending_in_dead_bb.exe \


### PR DESCRIPTION
https://github.com/mono/mono/issues/11392