### PR TITLE
[profiler] Reenable tests when using hybrid suspend

### DIFF
--- a/mono/profiler/Makefile.am
+++ b/mono/profiler/Makefile.am
@@ -36,9 +36,7 @@ suppression_DATA = mono-profiler-coverage.suppression
 #
 # See: https://bugzilla.xamarin.com/show_bug.cgi?id=57011
 if !ENABLE_COOP_SUSPEND
-if !ENABLE_HYBRID_SUSPEND
 check_targets = testlog
-endif
 endif
 
 endif


### PR DESCRIPTION
They got disabled with https://github.com/mono/mono/commit/282ee4bfd7ea91dc0015891010c71d8bd1421bc8 but now that hybrid suspend is the default on multiple platforms we should reenable them.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
