### PR TITLE
Disable failing assert in failing test DebuggerTests.Threads Assert.AreEqual (ThreadState.Stopped, e.Thread.ThreadState)

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -3225,7 +3225,8 @@ public class DebuggerTests
 
 		e = GetNextEvent ();
 		Assert.IsInstanceOfType (typeof (ThreadDeathEvent), e);
-		Assert.AreEqual (ThreadState.Stopped, e.Thread.ThreadState);
+//https://github.com/mono/mono/issues/11416
+//		Assert.AreEqual (ThreadState.Stopped, e.Thread.ThreadState);
 	}
 #endif
 

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -3225,8 +3225,8 @@ public class DebuggerTests
 
 		e = GetNextEvent ();
 		Assert.IsInstanceOfType (typeof (ThreadDeathEvent), e);
-//https://github.com/mono/mono/issues/11416
-//		Assert.AreEqual (ThreadState.Stopped, e.Thread.ThreadState);
+		// https://github.com/mono/mono/issues/11416
+		// Assert.AreEqual (ThreadState.Stopped, e.Thread.ThreadState);
 	}
 #endif
 


### PR DESCRIPTION
https://github.com/mono/mono/issues/11416
