### PR TITLE
[crash] Catch exception for Debugger Crash test, reenable

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -2456,7 +2456,6 @@ public class DebuggerTests
 
 	[Test]
 	[Category("NotOnWindows")]
-	[Ignore("https://github.com/mono/mono/issues/11385")]
 	public void Crash () {
 		bool success = false;
 
@@ -2476,13 +2475,17 @@ public class DebuggerTests
 
 				break;
 			}
-		} finally {
-			try {
-				vm.Detach ();
-			} finally {
-				vm = null;
-			}
+		} catch (VMDisconnectedException exc) {
+			Assert.Fail ("Got VMDisconnectedException rather than crash event");
 		}
+
+		try {
+			vm.Detach ();
+		} catch (VMDisconnectedException exc) {
+			// This is fine
+		}
+
+		vm = null;
 
 		if (!success)
 			Assert.Fail ("Didn't get crash event");


### PR DESCRIPTION
This might be enough if the problem was with the uncaught exceptions.

For continued flake risks, can we have a tighter bound on how often this is flaking? We should be able to handle it with some retries. If it's flaking more often than that, a post-send pause might need to be enabled on the debuggee side. 