### PR TITLE
[2018-08] Disable hybrid suspend default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5022,11 +5022,12 @@ if test x$enable_cooperative_suspend_default != xyes; then
 	X86 | AMD64)
 		dnl Some host/target confusion, there's no host_osx (and
 		dnl host_darwin would be true on iOS not just macOS).
-		if test x$target_osx = xyes; then
-			enable_hybrid_suspend_default=yes
-		elif test x$host_linux = xyes -o x$host_win32 = xyes; then
-			enable_hybrid_suspend_default=yes
-		fi
+		dnl if test x$target_osx = xyes; then
+		dnl 	enable_hybrid_suspend_default=yes
+		dnl elif test x$host_linux = xyes -o x$host_win32 = xyes; then
+		dnl 	enable_hybrid_suspend_default=yes
+		dnl fi
+		true
 		;;
 	esac
 fi


### PR DESCRIPTION
Earlier in the 2018-08 branch, Mono on desktop Linux, OSX and Windows would
default to hybrid suspend.  Turn that off for now (revert to preemptive suspend
by default).

Continue hybrid suspend work on 2018-10 and master.

