### PR TITLE
[2018-08] [delegates] do not use CEE_CALLVIRT for non-virtual methods

### DIFF
--- a/mcs/class/corlib/Test/System/DelegateTest.cs
+++ b/mcs/class/corlib/Test/System/DelegateTest.cs
@@ -1144,8 +1144,6 @@ namespace MonoTests.System
 		}
 
 		[Test]
-		// Interp uses slowpath delegate invoke virtual wrapper which throws NRE also with JIT
-		[Category ("NotWorkingRuntimeInterpreter")]
 		public void DynamicInvokeOpenInstanceDelegate ()
 		{
 			var d1 = Delegate.CreateDelegate (typeof (Func<DelegateTest, int>), typeof(DelegateTest).GetMethod ("DynamicInvokeOpenInstanceDelegate_CB"));

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -3897,7 +3897,8 @@ emit_delegate_invoke_internal_ilgen (MonoMethodBuilder *mb, MonoMethodSignature 
 
 	if (callvirt) {
 		if (!closed_over_null) {
-			if (m_class_is_valuetype (target_class)) {
+			/* if target_method is not really virtual, turn it into a direct call */
+			if (!(target_method->flags & METHOD_ATTRIBUTE_VIRTUAL) || m_class_is_valuetype (target_class)) {
 				mono_mb_emit_ldarg (mb, 1);
 				for (i = 1; i < sig->param_count; ++i)
 					mono_mb_emit_ldarg (mb, i + 1);


### PR DESCRIPTION
Backport of #11433.

/cc @lewurm 

Description:
