### PR TITLE
[Reflection] CoreFX import for MethodInfo type

### DIFF
--- a/mcs/class/corlib/System.Reflection/MonoMethod.cs
+++ b/mcs/class/corlib/System.Reflection/MonoMethod.cs
@@ -229,6 +229,7 @@ namespace System.Reflection {
 			return get_base_method (this, true);
 		}
 
+		// TODO: Remove, needed only for MonoCustomAttribute
 		internal MethodInfo GetBaseMethod ()
 		{
 			return get_base_method (this, false);

--- a/mcs/class/corlib/System.Reflection/MonoMethod.cs
+++ b/mcs/class/corlib/System.Reflection/MonoMethod.cs
@@ -229,7 +229,7 @@ namespace System.Reflection {
 			return get_base_method (this, true);
 		}
 
-		internal override MethodInfo GetBaseMethod ()
+		internal MethodInfo GetBaseMethod ()
 		{
 			return get_base_method (this, false);
 		}

--- a/mcs/class/corlib/System/MonoCustomAttrs.cs
+++ b/mcs/class/corlib/System/MonoCustomAttrs.cs
@@ -555,7 +555,7 @@ namespace System
 			if (method == null || !method.IsVirtual)
 				return null;
 
-			MethodInfo baseMethod = method.GetBaseMethod ();
+			MethodInfo baseMethod = ((MonoMethod)method).GetBaseMethod ();
 			if (baseMethod != null && baseMethod != method) {
 				ParameterInfo[] parameters = property.GetIndexParameters ();
 				if (parameters != null && parameters.Length > 0) {
@@ -582,7 +582,7 @@ namespace System
 			if (method == null || !method.IsVirtual)
 				return null;
 
-			MethodInfo baseMethod = method.GetBaseMethod ();
+			MethodInfo baseMethod = ((MonoMethod)method).GetBaseMethod ();
 			if (baseMethod != null && baseMethod != method) {
 				BindingFlags flags = method.IsPublic ? BindingFlags.Public : BindingFlags.NonPublic;
 				flags |= method.IsStatic ? BindingFlags.Static : BindingFlags.Instance;
@@ -620,7 +620,7 @@ namespace System
 			if (method == null || !method.IsVirtual)
 				return null;
 
-			MethodInfo baseMethod = method.GetBaseMethod ();
+			MethodInfo baseMethod = ((MonoMethod)method).GetBaseMethod ();
 			if (baseMethod == method)
 				return null;
 

--- a/mcs/class/corlib/corlib.csproj
+++ b/mcs/class/corlib/corlib.csproj
@@ -461,6 +461,7 @@
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\Reflection\MemberTypes.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\Reflection\MethodAttributes.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\Reflection\MethodImplAttributes.cs" />
+    <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\Reflection\MethodInfo.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\Reflection\Missing.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\Reflection\ModuleResolveEventHandler.cs" />
     <Compile Include="..\..\..\external\corefx\src\Common\src\CoreLib\System\Reflection\ObfuscateAssemblyAttribute.cs" />
@@ -1030,7 +1031,6 @@
     <Compile Include="..\referencesource\mscorlib\system\reflection\mdimport.cs" />
     <Compile Include="..\referencesource\mscorlib\system\reflection\memberinfoserializationholder.cs" />
     <Compile Include="..\referencesource\mscorlib\system\reflection\methodbase.cs" />
-    <Compile Include="..\referencesource\mscorlib\system\reflection\methodinfo.cs" />
     <Compile Include="..\referencesource\mscorlib\system\resid.cs" />
     <Compile Include="..\referencesource\mscorlib\system\resources\__fastresourcecomparer.cs" />
     <Compile Include="..\referencesource\mscorlib\system\resources\__hresults.cs" />

--- a/mcs/class/corlib/corlib.dll.sources
+++ b/mcs/class/corlib/corlib.dll.sources
@@ -1190,6 +1190,7 @@ ReferenceSources/AppContextDefaultValues.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/Reflection/MemberTypes.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/Reflection/MethodAttributes.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/Reflection/MethodImplAttributes.cs
+../../../external/corefx/src/Common/src/CoreLib/System/Reflection/MethodInfo.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/Reflection/Missing.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/Reflection/ObfuscateAssemblyAttribute.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/Reflection/ObfuscationAttribute.cs
@@ -1218,7 +1219,6 @@ ReferenceSources/AppContextDefaultValues.cs
 ../referencesource/mscorlib/system/reflection/mdimport.cs
 ../referencesource/mscorlib/system/reflection/memberinfoserializationholder.cs
 ../referencesource/mscorlib/system/reflection/methodbase.cs
-../referencesource/mscorlib/system/reflection/methodinfo.cs
 
 ../referencesource/mscorlib/system/reflection/emit/methodbuilder.cs
 ../referencesource/mscorlib/system/reflection/emit/symboltype.cs

--- a/mcs/class/referencesource/mscorlib/system/attribute.cs
+++ b/mcs/class/referencesource/mscorlib/system/attribute.cs
@@ -68,7 +68,7 @@ namespace System {
                     custom_attributes.Add (param_attribute);
                 }
 
-                var base_method = method.GetBaseMethod ();
+                var base_method = ((MonoMethod)method).GetBaseMethod ();
                 if (base_method == method)
                     break;
 
@@ -103,14 +103,14 @@ namespace System {
             if (member.MemberType != MemberTypes.Method)
                 return false;
 
-            var method = ((MethodInfo) member).GetBaseMethod ();
+            var method = ((MonoMethod)(MethodInfo) member).GetBaseMethod ();
 
             while (true) {
                 var param = method.GetParametersInternal () [parameter.Position];
                 if (param.IsDefined (attributeType, false))
                     return true;
 
-                var base_method = method.GetBaseMethod ();
+                var base_method = ((MonoMethod)method).GetBaseMethod ();
                 if (base_method == method)
                     break;
 


### PR DESCRIPTION
Part of #9660.

Related CoreFX tests will be fully enabled after https://github.com/dotnet/corefx/pull/33101 is complete and ported to Mono fork.