### PR TITLE
[2018-10] [crash] Fix merp invocation

### DIFF
--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -234,20 +234,11 @@ MONO_SIG_HANDLER_FUNC (static, sigterm_signal_handler)
 	gchar *output = NULL;
 	MonoStackHash hashes;
 	mono_sigctx_to_monoctx (ctx, &mctx);
+
+	// Will return when the dumping is done, so this thread can continue
+	// running. Returns FALSE on unrecoverable error.
 	if (!mono_threads_summarize_execute (&mctx, &output, &hashes, FALSE, NULL, 0))
 		g_assert_not_reached ();
-
-#ifdef TARGET_OSX
-	if (mono_merp_enabled ()) {
-		pid_t crashed_pid = getpid ();
-		mono_merp_invoke (crashed_pid, "SIGTERM", output, &hashes);
-	} else
-#endif
-	{
-		// Controlling thread gets the dump
-		if (output)
-			MOSTLY_ASYNC_SAFE_PRINTF("Unhandled exception dump: \n######\n%s\n######\n", output);
-	}
 #endif
 
 	mono_chain_signal (MONO_SIG_HANDLER_PARAMS);


### PR DESCRIPTION
Backport of #11435.

/cc @alexanderkyte 

Description:
The change which made the handler return (rather than crashing the
runtime) did not consider this control flow path that causes the sigterm
signal handler to trigger the merp dumper if we return.

We now always return.

This was previously so that a random sigterm could be used to trigger a
dump. This isn't really used, and won't work right now anyways
(we don't register it until right before we dump). My fix is to remove
it, and to make the signal handler only work as part of the dumper
machinery.

@monojenkins skip
