### PR TITLE
[2018-08] [crash] Fix async setting for crash reporter

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5909,11 +5909,7 @@ ves_icall_Mono_Runtime_DumpStateTotal (guint64 *portable_hash, guint64 *unportab
 
 	mono_get_runtime_callbacks ()->install_state_summarizer ();
 
-	// if this works
-	// - give back loader lock during stop
-	mono_thread_info_set_is_async_context (TRUE);
 	gboolean success = mono_threads_summarize (ctx, &out, &hashes, TRUE, FALSE, scratch, MONO_MAX_SUMMARY_LEN_ICALL);
-	mono_thread_info_set_is_async_context (FALSE);
 
 	if (!success)
 		return mono_string_new_handle (mono_domain_get (), "", error);

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -6263,7 +6263,14 @@ mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gb
 		gint64 next_request_id = mono_atomic_load_i64 ((volatile gint64 *) &request_available_to_run);
 
 		if (next_request_id == this_request_id) {
+			gboolean already_async = mono_thread_info_is_async_context ();
+			if (!already_async)
+				mono_thread_info_set_is_async_context (TRUE);
+
 			success = mono_threads_summarize_execute (ctx, out, hashes, silent, mem, provided_size);
+
+			if (!already_async)
+				mono_thread_info_set_is_async_context (FALSE);
 
 			// Only the thread that gets the ticket can unblock future dumpers.
 			mono_atomic_inc_i64 ((volatile gint64 *) &request_available_to_run);


### PR DESCRIPTION
Backport of #11464.

/cc @alexanderkyte 

Description:
We were previously only setting it from the icall. The icall was
therefore fine, while invocations associated with actual dumps
caused crashes like this:

```

thread #10, name = 'Thread Pool Worker'
    frame #0: 0x00007fff978dac22 libsystem_kernel.dylib`__psynch_mutexwait + 10
    frame #1: 0x00007fff979c5dfa libsystem_pthread.dylib`_pthread_mutex_lock_wait + 100
    frame #2: 0x00007fff979c3519 libsystem_pthread.dylib`_pthread_mutex_lock_slow + 285
    frame #3: 0x0000000108e0d4a9 mono`mono_loader_lock + 73
    frame #4: 0x0000000108dc9106 mono`mono_class_create_from_typedef + 182
    frame #5: 0x0000000108dc1f2c mono`mono_class_get_checked + 92
    frame #6: 0x0000000108e21da2 mono`mono_metadata_parse_type_internal + 1378
    frame #7: 0x0000000108e25e11 mono`mono_metadata_parse_mh_full + 1233
    frame #8: 0x0000000108ca4f79 mono`mono_debug_add_aot_method + 121
    frame #9: 0x0000000108cc6b1e mono`decode_exception_debug_info + 5918
    frame #10: 0x0000000108cc5047 mono`mono_aot_find_jit_info + 1367
    frame #11: 0x0000000108e082cc mono`mono_jit_info_table_find_internal + 204
    frame #12: 0x0000000108cdb035 mono`mini_jit_info_table_find_ext + 69
    frame #13: 0x0000000108cdad5c mono`mono_find_jit_info_ext + 124
    frame #14: 0x0000000108cdc3a5 mono`unwinder_unwind_frame + 229
    frame #15: 0x0000000108cdbade mono`mono_walk_stack_full + 798
    frame #16: 0x0000000108cda1a4 mono`mono_summarize_managed_stack + 100
    frame #17: 0x0000000108e6dc03 mono`mono_threads_summarize_execute + 1347
    frame #18: 0x0000000108e6df88 mono`mono_threads_summarize + 360

```

And
in ```decode_exception_debug_info``` we see 
```
 if (!async)
     mono_debug_add_aot_method (domain, method, code, p, buf_len);  
```