### PR TITLE
[tests] reduce recursion depth

### DIFF
--- a/mcs/class/corlib/Test/System.Threading.Tasks/Task_T_Test.cs
+++ b/mcs/class/corlib/Test/System.Threading.Tasks/Task_T_Test.cs
@@ -80,12 +80,12 @@ namespace MonoTests.System.Threading.Tasks
 		{
 			ParallelTestHelper.Repeat (delegate {
 				var t = CreateNestedFuture(10);
-				var t2 = CreateNestedFuture(100);
-				var t3 = CreateNestedFuture(100);
+				var t2 = CreateNestedFuture(20);
+				var t3 = CreateNestedFuture(30);
 
 				Assert.AreEqual (11, t.Result);
-				Assert.AreEqual (101, t2.Result);
-				Assert.AreEqual (101, t3.Result);
+				Assert.AreEqual (21, t2.Result);
+				Assert.AreEqual (31, t3.Result);
 		   }, 50);
 		}
 


### PR DESCRIPTION
so it doesn't trigger a stack overflow on Xamarin.iOS with interpreter on a debug build (`CFLAGS=-O0`).
