### PR TITLE
Add missing constructor in System.Security.Policy.Evidence

### DIFF
--- a/mcs/class/corlib/System.Security.Policy/Evidence.cs
+++ b/mcs/class/corlib/System.Security.Policy/Evidence.cs
@@ -61,6 +61,14 @@ namespace System.Security.Policy {
 				Merge (evidence);	
 		}
 
+		public Evidence (EvidenceBase[] hostEvidence, EvidenceBase[] assemblyEvidence)
+		{
+			if (null != hostEvidence)
+				HostEvidenceList.AddRange (hostEvidence);
+			if (null != assemblyEvidence)
+				AssemblyEvidenceList.AddRange (assemblyEvidence);
+		}
+
 		[Obsolete]
 		public Evidence (object[] hostEvidence, object[] assemblyEvidence)
 		{


### PR DESCRIPTION
Fixes #7750.

This is my first contribution to mono, so please let me know if there's any additional procedure I may have to do for this that I'm not aware of. Thanks!
