### PR TITLE
Reduce TLS accesses.

### DIFF
--- a/mono/metadata/handle.c
+++ b/mono/metadata/handle.c
@@ -155,15 +155,17 @@ mono_handle_chunk_leak_check (HandleStack *handles) {
 }
 #endif
 
+extern MonoThreadInfo * const mono_thread_info_current_var = NULL;
+
 /* Actual handles implementation */
 MonoRawHandle
 #ifndef MONO_HANDLE_TRACK_OWNER
-mono_handle_new (MonoObject *obj)
+mono_handle_new (MonoObject *obj, MonoThreadInfo *info)
 #else
-mono_handle_new (MonoObject *obj, const char *owner)
+mono_handle_new (MonoObject *obj, MonoThreadInfo *info, const char *owner)
 #endif
 {
-	MonoThreadInfo *info = mono_thread_info_current ();
+	info = info ? info : mono_thread_info_current ();
 	HandleStack *handles = info->handle_stack;
 	HandleChunk *top = handles->top;
 #ifdef MONO_HANDLE_TRACK_SP
@@ -366,9 +368,9 @@ mono_stack_mark_pop_value (MonoThreadInfo *info, HandleStackMark *stackmark, Mon
 	MonoObject *obj = value ? *((MonoObject**)value) : NULL;
 	mono_stack_mark_pop (info, stackmark);
 #ifndef MONO_HANDLE_TRACK_OWNER
-	return mono_handle_new (obj);
+	return mono_handle_new (obj, info);
 #else
-	return mono_handle_new (obj, "<mono_stack_mark_pop_value>");
+	return mono_handle_new (obj, info, "<mono_stack_mark_pop_value>");
 #endif
 }
 

--- a/mono/metadata/handle.c
+++ b/mono/metadata/handle.c
@@ -155,6 +155,7 @@ mono_handle_chunk_leak_check (HandleStack *handles) {
 }
 #endif
 
+// There are deliberately locals and a constant NULL global with this same name.
 extern MonoThreadInfo * const mono_thread_info_current_var = NULL;
 
 /* Actual handles implementation */

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -172,6 +172,7 @@ mono_stack_mark_pop (MonoThreadInfo *info, HandleStackMark *stackmark)
 #endif
 }
 
+// There are deliberately locals and a constant NULL global with this same name.
 extern MonoThreadInfo * const mono_thread_info_current_var;
 
 /*
@@ -180,6 +181,7 @@ Icall macros
 #define SETUP_ICALL_COMMON	\
 	do { \
 		ERROR_DECL (error);	\
+		/* There are deliberately locals and a constant NULL global with this same name. */ \
 		MonoThreadInfo *mono_thread_info_current_var = mono_thread_info_current (); \
 
 #define CLEAR_ICALL_COMMON	\
@@ -198,6 +200,7 @@ Icall macros
 	(RESULT) = g_cast (mono_stack_mark_pop_value (mono_thread_info_current_var, &__mark, (HANDLE)));
 
 #define HANDLE_FUNCTION_ENTER() do {				\
+	/* There are deliberately locals and a constant NULL global with this same name. */ \
 	MonoThreadInfo *mono_thread_info_current_var = mono_thread_info_current ();	\
 	SETUP_ICALL_FRAME					\
 

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -126,9 +126,9 @@ typedef void (*GcScanFunc) (gpointer*, gpointer);
 #endif
 
 #ifndef MONO_HANDLE_TRACK_OWNER
-MonoRawHandle mono_handle_new (MonoObject *object);
+MonoRawHandle mono_handle_new (MonoObject *object, MonoThreadInfo *info);
 #else
-MonoRawHandle mono_handle_new (MonoObject *object, const char* owner);
+MonoRawHandle mono_handle_new (MonoObject *object, MonoThreadInfo *info, const char* owner);
 #endif
 
 void mono_handle_stack_scan (HandleStack *stack, GcScanFunc func, gpointer gc_data, gboolean precise, gboolean check);
@@ -172,32 +172,33 @@ mono_stack_mark_pop (MonoThreadInfo *info, HandleStackMark *stackmark)
 #endif
 }
 
+extern MonoThreadInfo * const mono_thread_info_current_var;
+
 /*
 Icall macros
 */
 #define SETUP_ICALL_COMMON	\
 	do { \
 		ERROR_DECL (error);	\
-		MonoThreadInfo *__info = mono_thread_info_current ();	\
-		error_init (error);	\
+		MonoThreadInfo *mono_thread_info_current_var = mono_thread_info_current (); \
 
 #define CLEAR_ICALL_COMMON	\
 	mono_error_set_pending_exception (error);
 
 #define SETUP_ICALL_FRAME	\
 	HandleStackMark __mark;	\
-	mono_stack_mark_init (__info, &__mark);
+	mono_stack_mark_init (mono_thread_info_current_var, &__mark);
 
 #define CLEAR_ICALL_FRAME	\
-	mono_stack_mark_record_size (__info, &__mark, __FUNCTION__);	\
-	mono_stack_mark_pop (__info, &__mark);
+	mono_stack_mark_record_size (mono_thread_info_current_var, &__mark, __FUNCTION__);	\
+	mono_stack_mark_pop (mono_thread_info_current_var, &__mark);
 
 #define CLEAR_ICALL_FRAME_VALUE(RESULT, HANDLE)				\
-	mono_stack_mark_record_size (__info, &__mark, __FUNCTION__);	\
-	(RESULT) = g_cast (mono_stack_mark_pop_value (__info, &__mark, (HANDLE)));
+	mono_stack_mark_record_size (mono_thread_info_current_var, &__mark, __FUNCTION__);	\
+	(RESULT) = g_cast (mono_stack_mark_pop_value (mono_thread_info_current_var, &__mark, (HANDLE)));
 
 #define HANDLE_FUNCTION_ENTER() do {				\
-	MonoThreadInfo *__info = mono_thread_info_current ();	\
+	MonoThreadInfo *mono_thread_info_current_var = mono_thread_info_current ();	\
 	SETUP_ICALL_FRAME					\
 
 #define HANDLE_FUNCTION_RETURN()		\
@@ -245,10 +246,10 @@ mono_thread_info_push_stack_mark (MonoThreadInfo *info, void *mark)
 #define SETUP_STACK_WATERMARK	\
 	int __dummy;	\
 	__builtin_unwind_init ();	\
-	void *__old_stack_mark = mono_thread_info_push_stack_mark (__info, &__dummy);
+	void *__old_stack_mark = mono_thread_info_push_stack_mark (mono_thread_info_current_var, &__dummy);
 
 #define CLEAR_STACK_WATERMARK	\
-	mono_thread_info_pop_stack_mark (__info, __old_stack_mark);
+	mono_thread_info_pop_stack_mark (mono_thread_info_current_var, __old_stack_mark);
 
 #else
 #define SETUP_STACK_WATERMARK
@@ -311,12 +312,12 @@ typedef struct _MonoTypeofCastHelper *MonoTypeofCastHelper; // a pointer type un
 #ifndef MONO_HANDLE_TRACK_OWNER
 
 #define MONO_HANDLE_NEW(type, object) \
-	(MONO_HANDLE_CAST_FOR (type) (mono_handle_new (MONO_HANDLE_TYPECHECK_FOR (type) (object))))
+	(MONO_HANDLE_CAST_FOR (type) (mono_handle_new (MONO_HANDLE_TYPECHECK_FOR (type) (object), mono_thread_info_current_var)))
 
 #else
 
 #define MONO_HANDLE_NEW(type, object) \
-	(MONO_HANDLE_CAST_FOR (type) (mono_handle_new (MONO_HANDLE_TYPECHECK_FOR (type) (object), HANDLE_OWNER)))
+	(MONO_HANDLE_CAST_FOR (type) (mono_handle_new (MONO_HANDLE_TYPECHECK_FOR (type) (object), mono_thread_info_current_var, HANDLE_OWNER)))
 
 #endif
 


### PR DESCRIPTION
Functions with HANDLE_FUNCTION_ENTER, only call mono_thread_info_current once,
instead of 1 + per-MONO_HANDLE_NEW.

This can be extended in future in multiple potential ways.
 1 Macro split from HANDLE_FUNCTION_ENTER.
   This is easiest/no downside, i.e. for functions that do not HANDLE_FUNCTION_ENTER
   but that do multiple MONO_HANDLE_NEW, call other macro
   just to mono_thread_info_current () into local.
 2 Pass TLS as separate parameter. Probably not actually, see 4.
 3 Store TLS in handles -- too large? Probably not actually, see next.
 4 Store TLS in MonoError. i.e. MonoError is "call context", chained
   up to "thread context".