### PR TITLE
[runtime] allocate volatile_{locals,args} bitset in image mempool

### DIFF
--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -6373,11 +6373,20 @@ emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 				case ICALL_HANDLES_WRAP_OBJ_OUT:
 					// FIXME better type
 					local = mono_mb_add_local (mb, mono_get_object_type ());
-					mono_bitset_set_safe (&mb->volatile_locals, local);
+
+					if (!mb->volatile_locals) {
+						char *mem = (char *)mono_image_alloc0 (get_method_image (method), csig->param_count + 1);
+						mb->volatile_locals = mono_bitset_mem_new (mem, csig->param_count + 1, 0);
+					}
+					mono_bitset_set (mb->volatile_locals, local);
 					break;
 				case ICALL_HANDLES_WRAP_VALUETYPE_REF:
 				case ICALL_HANDLES_WRAP_OBJ:
-					mono_bitset_set_safe (&mb->volatile_args, i);
+					if (!mb->volatile_args) {
+						char *mem = (char *)mono_image_alloc0 (get_method_image (method), csig->param_count + 1);
+						mb->volatile_args = mono_bitset_mem_new (mem, csig->param_count + 1, 0);
+					}
+					mono_bitset_set (mb->volatile_args, i);
 					break;
 				case ICALL_HANDLES_WRAP_NONE:
 					break;

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -6375,7 +6375,7 @@ emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 					local = mono_mb_add_local (mb, mono_get_object_type ());
 
 					if (!mb->volatile_locals) {
-						char *mem = (char *)mono_image_alloc0 (get_method_image (method), csig->param_count + 1);
+						char *mem = (char *)mono_image_alloc0 (get_method_image (method), mono_bitset_alloc_size (csig->param_count + 1));
 						mb->volatile_locals = mono_bitset_mem_new (mem, csig->param_count + 1, 0);
 					}
 					mono_bitset_set (mb->volatile_locals, local);
@@ -6383,7 +6383,7 @@ emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 				case ICALL_HANDLES_WRAP_VALUETYPE_REF:
 				case ICALL_HANDLES_WRAP_OBJ:
 					if (!mb->volatile_args) {
-						char *mem = (char *)mono_image_alloc0 (get_method_image (method), csig->param_count + 1);
+						char *mem = (char *)mono_image_alloc0 (get_method_image (method), mono_bitset_alloc_size (csig->param_count + 1));
 						mb->volatile_args = mono_bitset_mem_new (mem, csig->param_count + 1, 0);
 					}
 					mono_bitset_set (mb->volatile_args, i);

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -6375,7 +6375,7 @@ emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 					local = mono_mb_add_local (mb, mono_get_object_type ());
 
 					if (!mb->volatile_locals) {
-						char *mem = (char *)mono_image_alloc0 (get_method_image (method), mono_bitset_alloc_size (csig->param_count + 1));
+						char *mem = (char *)mono_image_alloc0 (get_method_image (method), mono_bitset_alloc_size (csig->param_count + 1, 0));
 						mb->volatile_locals = mono_bitset_mem_new (mem, csig->param_count + 1, 0);
 					}
 					mono_bitset_set (mb->volatile_locals, local);
@@ -6383,7 +6383,7 @@ emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 				case ICALL_HANDLES_WRAP_VALUETYPE_REF:
 				case ICALL_HANDLES_WRAP_OBJ:
 					if (!mb->volatile_args) {
-						char *mem = (char *)mono_image_alloc0 (get_method_image (method), mono_bitset_alloc_size (csig->param_count + 1));
+						char *mem = (char *)mono_image_alloc0 (get_method_image (method), mono_bitset_alloc_size (csig->param_count + 1, 0));
 						mb->volatile_args = mono_bitset_mem_new (mem, csig->param_count + 1, 0);
 					}
 					mono_bitset_set (mb->volatile_args, i);

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -2079,12 +2079,6 @@ mono_compile_create_vars (MonoCompile *cfg)
 		mono_apply_volatile (cfg->locals [i], header->volatile_locals, i);
 	}
 
-	mono_bitset_free (header->volatile_locals);
-	header->volatile_locals = NULL;
-
-	mono_bitset_free (header->volatile_args);
-	header->volatile_args = NULL;
-
 	if (cfg->verbose_level > 2)
 		g_print ("locals done\n");
 

--- a/mono/utils/monobitset.c
+++ b/mono/utils/monobitset.c
@@ -644,24 +644,6 @@ mono_bitset_foreach (MonoBitSet *set, MonoBitSetFunc func, gpointer data)
 	}
 }
 
-static void
-mono_bitset_resize (MonoBitSet **set, guint32 max_size)
-{
-	if (max_size == 0)
-		return;
-	if (!*set) {
-		*set = mono_bitset_new (max_size, 0);
-		return;
-	}
-	if ((*set)->size >= max_size)
-		return;
-	MonoBitSet *new_set = mono_bitset_new (max_size, (*set)->flags);
-	// mono_bitset_copyto uses the wrong size.
-	memcpy (&new_set->data, &(*set)->data, (*set)->size / 8);
-	mono_bitset_free (*set);
-	*set = new_set;
-}
-
 gboolean
 mono_bitset_test_safe (const MonoBitSet *set, guint32 pos)
 {

--- a/mono/utils/monobitset.c
+++ b/mono/utils/monobitset.c
@@ -662,13 +662,6 @@ mono_bitset_resize (MonoBitSet **set, guint32 max_size)
 	*set = new_set;
 }
 
-void
-mono_bitset_set_safe (MonoBitSet **set, guint32 pos)
-{
-	mono_bitset_resize (set, pos + 1);
-	mono_bitset_set (*set, pos);
-}
-
 gboolean
 mono_bitset_test_safe (const MonoBitSet *set, guint32 pos)
 {

--- a/mono/utils/monobitset.h
+++ b/mono/utils/monobitset.h
@@ -121,9 +121,6 @@ MONO_API void        mono_bitset_foreach      (MonoBitSet *set, MonoBitSetFunc f
 
 MONO_API void        mono_bitset_intersection_2 (MonoBitSet *dest, const MonoBitSet *src1, const MonoBitSet *src2);
 
-void
-mono_bitset_set_safe (MonoBitSet **set, guint32 pos);
-
 gboolean
 mono_bitset_test_safe (const MonoBitSet *set, guint32 pos);
 


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/11488, an regression introduced by https://github.com/mono/mono/pull/11294


