### PR TITLE
Improve *.sources and *.exclude.sources handling 

### DIFF
--- a/mcs/build/tests.make
+++ b/mcs/build/tests.make
@@ -93,7 +93,7 @@ endif
 tests_CLEAN_FILES += $(test_lib_output) $(test_lib_output:$(ASSEMBLY_EXT)=.pdb) $(test_response) $(test_makefrag)
 
 xtest_sourcefile = $(PROFILE_PLATFORM)_$(PROFILE)_$(ASSEMBLY:$(ASSEMBLY_EXT)=_xtest.dll.sources)
-xtest_sourcefile_excludes = $(PROFILE)_$(ASSEMBLY:$(ASSEMBLY_EXT)=_xtest.dll.exclude.sources)
+xtest_sourcefile_excludes = $(PROFILE_PLATFORM)_$(PROFILE)_$(ASSEMBLY:$(ASSEMBLY_EXT)=_xtest.dll.exclude.sources)
 
 xunit_test_lib = $(PROFILE)_$(ASSEMBLY:$(ASSEMBLY_EXT)=_xunit-test.dll)
 xtest_lib_output = $(test_lib_dir)/$(xunit_test_lib)

--- a/mcs/build/tests.make
+++ b/mcs/build/tests.make
@@ -72,7 +72,7 @@ test_nunit_ref = $(test_nunit_dep:%=-r:%)
 tests_CLEAN_FILES += TestResult*.xml
 
 test_sourcefile_base = $(ASSEMBLY:$(ASSEMBLY_EXT)=_test.dll.sources)
-test_sourcefile = $(firstword $(wildcard $(PROFILE_PLATFORM)_$(PROFILE)_$(test_sourcefile_base) $(PROFILE)_$(test_sourcefile_base) $(test_sourcefile_base)))
+test_sourcefile = $(firstword $(wildcard $(PROFILE_PLATFORM)_$(PROFILE)_$(test_sourcefile_base) $(PROFILE)_$(test_sourcefile_base) $(PROFILE_PLATFORM)_$(test_sourcefile_base) $(test_sourcefile_base)))
 
 ifeq ($(wildcard $(test_sourcefile)),)
 test_sourcefile = $(ASSEMBLY:$(ASSEMBLY_EXT)=_test.dll.sources)
@@ -82,7 +82,7 @@ test_lib = $(PROFILE)_$(ASSEMBLY:$(ASSEMBLY_EXT)=_test.dll)
 test_lib_output = $(test_lib_dir)/$(test_lib)
 
 test_excludes_base = $(ASSEMBLY:$(ASSEMBLY_EXT)=_test.dll).exclude.sources
-test_sourcefile_excludes = $(firstword $(wildcard $(PROFILE_PLATFORM)_$(PROFILE)_$(test_excludes_base) $(PROFILE)_$(test_excludes_base) $(test_excludes_base)))
+test_sourcefile_excludes = $(firstword $(wildcard $(PROFILE_PLATFORM)_$(PROFILE)_$(test_excludes_base) $(PROFILE)_$(test_excludes_base) $(PROFILE_PLATFORM)_$(test_excludes_base) $(test_excludes_base)))
 
 test_pdb = $(test_lib:.dll=.pdb)
 test_response = $(depsdir)/$(test_lib).response
@@ -95,8 +95,8 @@ endif
 tests_CLEAN_FILES += $(test_lib_output) $(test_lib_output:$(ASSEMBLY_EXT)=.pdb) $(test_response) $(test_makefrag)
 
 xtest_sourcefile_base = $(ASSEMBLY:$(ASSEMBLY_EXT)=_xtest.dll)
-xtest_sourcefile = $(firstword $(wildcard $(PROFILE_PLATFORM)_$(PROFILE)_$(xtest_sourcefile_base).sources $(PROFILE)_$(xtest_sourcefile_base).sources $(xtest_sourcefile_base).sources))
-xtest_sourcefile_excludes = $(firstword $(wildcard $(PROFILE_PLATFORM)_$(PROFILE)_$(xtest_sourcefile_base).exclude.sources $(PROFILE)_$(xtest_sourcefile_base).exclude.sources $(xtest_sourcefile_base).exclude.sources))
+xtest_sourcefile = $(firstword $(wildcard $(PROFILE_PLATFORM)_$(PROFILE)_$(xtest_sourcefile_base).sources $(PROFILE)_$(xtest_sourcefile_base).sources $(PROFILE_PLATFORM)_$(xtest_sourcefile_base).sources $(xtest_sourcefile_base).sources))
+xtest_sourcefile_excludes = $(firstword $(wildcard $(PROFILE_PLATFORM)_$(PROFILE)_$(xtest_sourcefile_base).exclude.sources $(PROFILE)_$(xtest_sourcefile_base).exclude.sources $(PROFILE_PLATFORM)_$(xtest_sourcefile_base).exclude.sources $(xtest_sourcefile_base).exclude.sources))
 
 xunit_test_lib = $(PROFILE)_$(ASSEMBLY:$(ASSEMBLY_EXT)=_xunit-test.dll)
 xtest_lib_output = $(test_lib_dir)/$(xunit_test_lib)

--- a/mcs/build/tests.make
+++ b/mcs/build/tests.make
@@ -80,7 +80,8 @@ endif
 test_lib = $(PROFILE)_$(ASSEMBLY:$(ASSEMBLY_EXT)=_test.dll)
 test_lib_output = $(test_lib_dir)/$(test_lib)
 
-test_sourcefile_excludes = $(test_lib).exclude.sources
+test_excludes_base = $(ASSEMBLY:$(ASSEMBLY_EXT)=_test.dll).exclude.sources
+test_sourcefile_excludes = $(firstword $(wildcard $(PROFILE_PLATFORM)_$(PROFILE)_$(test_excludes_base) $(PROFILE)_$(test_excludes_base) $(test_excludes_base)))
 
 test_pdb = $(test_lib:.dll=.pdb)
 test_response = $(depsdir)/$(test_lib).response
@@ -92,8 +93,9 @@ test_assembly_dep = $(the_assembly)
 endif
 tests_CLEAN_FILES += $(test_lib_output) $(test_lib_output:$(ASSEMBLY_EXT)=.pdb) $(test_response) $(test_makefrag)
 
-xtest_sourcefile = $(PROFILE_PLATFORM)_$(PROFILE)_$(ASSEMBLY:$(ASSEMBLY_EXT)=_xtest.dll.sources)
-xtest_sourcefile_excludes = $(PROFILE_PLATFORM)_$(PROFILE)_$(ASSEMBLY:$(ASSEMBLY_EXT)=_xtest.dll.exclude.sources)
+xtest_sourcefile_base = $(ASSEMBLY:$(ASSEMBLY_EXT)=_xtest.dll)
+xtest_sourcefile = $(firstword $(wildcard $(PROFILE_PLATFORM)_$(PROFILE)_$(xtest_sourcefile_base).sources $(PROFILE)_$(xtest_sourcefile_base).sources $(xtest_sourcefile_base).sources))
+xtest_sourcefile_excludes = $(firstword $(wildcard $(PROFILE_PLATFORM)_$(PROFILE)_$(xtest_sourcefile_base).exclude.sources $(PROFILE)_$(xtest_sourcefile_base).exclude.sources $(xtest_sourcefile_base).exclude.sources))
 
 xunit_test_lib = $(PROFILE)_$(ASSEMBLY:$(ASSEMBLY_EXT)=_xunit-test.dll)
 xtest_lib_output = $(test_lib_dir)/$(xunit_test_lib)

--- a/mcs/build/tests.make
+++ b/mcs/build/tests.make
@@ -71,7 +71,8 @@ test_nunit_dep = $(test_nunit_lib:%=$(topdir)/class/lib/$(PROFILE)/$(PARENT_PROF
 test_nunit_ref = $(test_nunit_dep:%=-r:%)
 tests_CLEAN_FILES += TestResult*.xml
 
-test_sourcefile = $(PROFILE)_$(ASSEMBLY:$(ASSEMBLY_EXT)=_test.dll.sources)
+test_sourcefile_base = $(ASSEMBLY:$(ASSEMBLY_EXT)=_test.dll.sources)
+test_sourcefile = $(firstword $(wildcard $(PROFILE_PLATFORM)_$(PROFILE)_$(test_sourcefile_base) $(PROFILE)_$(test_sourcefile_base) $(test_sourcefile_base)))
 
 ifeq ($(wildcard $(test_sourcefile)),)
 test_sourcefile = $(ASSEMBLY:$(ASSEMBLY_EXT)=_test.dll.sources)


### PR DESCRIPTION
Unifies algorithms to find correct *.sources files (and *.exclude.sources):

Example (profile=net_4_x, platform=win32):

take `win32_net_4_x_corlib_test.dll.sources`
else take `net_4_x_corlib_test.dll.sources`
else take `win32_corlib_test.dll.sources`
else take `corlib_test.dll.sources`

same for eclude.sources and xunit.

Fixes https://github.com/mono/mono/issues/11515