### PR TITLE
Fix ref return for structs in runtime invoke wrapper.

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -1822,6 +1822,12 @@ public class Tests : TestsBase, ITest2
 	public static ref string get_ref_string() {
 		return ref ref_return_string;
 	}
+
+
+	static BlittableStruct ref_return_struct = new BlittableStruct () { i = 1, d = 2.0 };
+	public static ref BlittableStruct get_ref_struct() {
+		return ref ref_return_struct;
+	}
 }
 
 public class SentinelClass : MarshalByRefObject {

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -4666,6 +4666,14 @@ public class DebuggerTests
 		m = t.GetMethod ("get_ref_string");
 		v = t.InvokeMethod (e.Thread, m, null);
 		AssertValue ("byref", v);
+
+		m = t.GetMethod ("get_ref_struct");
+		v = t.InvokeMethod (e.Thread, m, null);
+		Assert.IsTrue(v is StructMirror);
+
+		var mirror = (StructMirror)v;
+		AssertValue (1, mirror["i"]);
+		AssertValue (2.0, mirror["d"]);
 	}
 } // class DebuggerTests
 } // namespace


### PR DESCRIPTION
Use mono_mb_emit_op for CEE_LDOBJ to ensure wrapper data is added for
indirect load of a ref return value as method-to-ir expects this for wrappers.

Follow up to https://github.com/mono/mono/pull/10472