### PR TITLE
[runtime] Enable usage of Runtime team sentry server

### DIFF
--- a/scripts/ci/run-upload-sentry.sh
+++ b/scripts/ci/run-upload-sentry.sh
@@ -6,10 +6,9 @@ export MONO_SENTRY_ROOT=`dirname "${BASH_SOURCE[0]}/../../"`
 if [[ ${CI_TAGS} == *'win-'* ]];
 then
 	echo "Skipping telemetry phase due to arch"
-elif [[ -n "${MONO_SENTRY_URL}" ]]
-then
-	# Define MONO_SENTRY_URL and MONO_SENTRY_OS in environment
-	${TESTCMD} --label=sentry-telemetry-upload --timeout=10m make -C mcs/tools/upload-to-sentry upload-crashes MONO_SENTRY_ROOT="$MONO_REPO_ROOT"
 else
-	echo "Skipping telemetry phase because URL missing"
+	export MONO_SENTRY_OS="${CI_TAGS}"
+	export MONO_SENTRY_URL="https://baaf612e845d407eb5f415c338bb6df9@sentry.io/1314141"
+	export MONO_SENTRY_ROOT="$MONO_REPO_ROOT"
+	${TESTCMD} --label=sentry-telemetry-upload --timeout=10m make -C mcs/tools/upload-to-sentry upload-crashes
 fi


### PR DESCRIPTION
Internal developers looking for access to this server should contact me on Slack.
Accounts should be forthcoming for runtime engineers. 