### PR TITLE
[2018-06] [interp] accept typed-by-ref as return type from a JIT call

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -2077,6 +2077,7 @@ do_jit_call (stackval *sp, unsigned char *vt_sp, ThreadContext *context, InterpF
 	case MONO_TYPE_R8:
 		sp->data.f = *(double*)res_buf;
 		break;
+	case MONO_TYPE_TYPEDBYREF:
 	case MONO_TYPE_VALUETYPE:
 		/* The result was written to vt_sp */
 		sp->data.p = vt_sp;


### PR DESCRIPTION
Backport of #11522.

/cc @lewurm 

Description:
happens on fullAOT + interp on mscorlib tests