### PR TITLE
[2018-10] Added missing cts.Cancel() in HttpClient Dispose() method

### DIFF
--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClient.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClient.cs
@@ -115,6 +115,8 @@ namespace System.Net.Http
 			if (disposing && !disposed) {
 				disposed = true;
 
+				//We don't use CancelPendingRequests() because we don't want to create new CancellationTokenSource
+				cts.Cancel ();
 				cts.Dispose ();
 			}
 			


### PR DESCRIPTION
Backport of #11442.

/cc @marek-safar @domino46

Description:
Fixes #11441