### PR TITLE
[mini] do not emit safepoints for methods without calls and loops

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -2314,6 +2314,8 @@ mono_emit_call_args (MonoCompile *cfg, MonoMethodSignature *sig,
 	MonoType *sig_ret;
 	MonoCallInst *call;
 
+	cfg->has_calls = TRUE;
+
 	if (tailcall && cfg->llvm_only) {
 		// FIXME tailcall should not be changed this late.
 		// FIXME It really should not be changed due to llvm_only.

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1369,6 +1369,7 @@ typedef struct {
 	guint            compute_gc_maps : 1;
 	guint            soft_breakpoints : 1;
 	guint            arch_eh_jit_info : 1;
+	guint            has_calls : 1;
 	guint            has_emulated_ops : 1;
 	guint            has_indirection : 1;
 	guint            has_atomic_add_i4 : 1;


### PR DESCRIPTION
with this optimization, running Roslyn with mono on
`mono/tests/pinvoke11.cs` compiles:

* 2019 methods without safepoints, and
* 9443 methods with safepoints.

