### PR TITLE
[2018-10] Fix ref return for structs in runtime invoke wrapper.

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -1813,6 +1813,12 @@ public class Tests : TestsBase, ITest2
 	public static ref string get_ref_string() {
 		return ref ref_return_string;
 	}
+
+
+	static BlittableStruct ref_return_struct = new BlittableStruct () { i = 1, d = 2.0 };
+	public static ref BlittableStruct get_ref_struct() {
+		return ref ref_return_struct;
+	}
 }
 
 public class SentinelClass : MarshalByRefObject {

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -4630,6 +4630,14 @@ public class DebuggerTests
 		m = t.GetMethod ("get_ref_string");
 		v = t.InvokeMethod (e.Thread, m, null);
 		AssertValue ("byref", v);
+
+		m = t.GetMethod ("get_ref_struct");
+		v = t.InvokeMethod (e.Thread, m, null);
+		Assert.IsTrue(v is StructMirror);
+
+		var mirror = (StructMirror)v;
+		AssertValue (1, mirror["i"]);
+		AssertValue (2.0, mirror["d"]);
 	}
 } // class DebuggerTests
 } // namespace

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -1449,9 +1449,17 @@ handle_enum:
 
 	if (sig->ret->byref) {
 		/* perform indirect load and return by value */
+		int ldind_op;
 		MonoType* ret_byval = m_class_get_byval_arg (mono_class_from_mono_type (sig->ret));
 		g_assert (!ret_byval->byref);
-		mono_mb_emit_byte (mb, mono_type_to_ldind (ret_byval));
+		ldind_op = mono_type_to_ldind (ret_byval);
+		/* taken from similar code in mini-generic-sharing.c
+		 * we need to use mono_mb_emit_op to add method data when loading
+		 * a structure since method-to-ir needs this data for wrapper methods */
+		if (ldind_op == CEE_LDOBJ)
+			mono_mb_emit_op (mb, CEE_LDOBJ, mono_class_from_mono_type_internal (ret_byval));
+		else
+			mono_mb_emit_byte (mb, ldind_op);
 	}
 
 	switch (sig->ret->type) {

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -1457,7 +1457,7 @@ handle_enum:
 		 * we need to use mono_mb_emit_op to add method data when loading
 		 * a structure since method-to-ir needs this data for wrapper methods */
 		if (ldind_op == CEE_LDOBJ)
-			mono_mb_emit_op (mb, CEE_LDOBJ, mono_class_from_mono_type_internal (ret_byval));
+			mono_mb_emit_op (mb, CEE_LDOBJ, mono_class_from_mono_type (ret_byval));
 		else
 			mono_mb_emit_byte (mb, ldind_op);
 	}


### PR DESCRIPTION
Use mono_mb_emit_op for CEE_LDOBJ to ensure wrapper data is added for
indirect load of a ref return value as method-to-ir expects this for wrappers.

Backport https://github.com/mono/mono/pull/11514

/cc @joncham 