### PR TITLE
Don't override default LLVM's opt & llc args via llvmopts-add and llvmllc-add commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,5 @@ tmpinst-dir.stamp
 msvc/scripts/inputs/
 extensions-config.h
 *.mlpd
+llvm/build/
+llvm/usr/

--- a/man/mono.1
+++ b/man/mono.1
@@ -215,14 +215,14 @@ and
 options. This feature is experimental.
 .TP
 .I llvmopts=[options]
-Use this option to override (or add via `llvmopts-add`) the built-in set of flags passed to the
+Use this option to add more flags to the built-in set of flags passed to the
 LLVM optimizer.   The list of possible flags that can be passed can be
 obtained by calling the bundled 
 .I opt
 program that comes with Mono.
 .TP
 .I llvmllc=[options]
-Use this option to override (or add via `llvmllc-add`) the built-in set of flags passed to the
+Use this option to add more flags to the built-in set of flags passed to the
 LLVM static compiler (llc).   The list of possible flags that can be passed can be
 obtained by calling the bundled 
 .I llc

--- a/man/mono.1
+++ b/man/mono.1
@@ -215,14 +215,14 @@ and
 options. This feature is experimental.
 .TP
 .I llvmopts=[options]
-Use this option to override the built-in set of flags passed to the
+Use this option to override (or add via `llvmopts-add`) the built-in set of flags passed to the
 LLVM optimizer.   The list of possible flags that can be passed can be
 obtained by calling the bundled 
 .I opt
 program that comes with Mono.
 .TP
 .I llvmllc=[options]
-Use this option to override the built-in set of flags passed to the
+Use this option to override (or add via `llvmllc-add`) the built-in set of flags passed to the
 LLVM static compiler (llc).   The list of possible flags that can be passed can be
 obtained by calling the bundled 
 .I llc

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -228,9 +228,7 @@ typedef struct MonoAotOptions {
 	char *instances_logfile_path;
 	char *logfile;
 	char *llvm_opts;
-	gboolean llvm_opts_add;
 	char *llvm_llc;
-	gboolean llvm_llc_add;
 	gboolean dump_json;
 	gboolean profile_only;
 	gboolean no_opt;
@@ -7715,14 +7713,8 @@ mono_aot_parse_options (const char *aot_options, MonoAotOptions *opts)
 			opts->verbose = TRUE;
 		} else if (str_begins_with (arg, "llvmopts=")){
 			opts->llvm_opts = g_strdup (arg + strlen ("llvmopts="));
-		} else if (str_begins_with (arg, "llvmopts-add=")){
-			opts->llvm_opts = g_strdup (arg + strlen ("llvmopts-add="));
-			opts->llvm_opts_add = TRUE;
 		} else if (str_begins_with (arg, "llvmllc=")){
 			opts->llvm_llc = g_strdup (arg + strlen ("llvmllc="));
-		} else if (str_begins_with (arg, "llvmllc-add=")){
-			opts->llvm_llc = g_strdup (arg + strlen ("llvmllc-add="));
-			opts->llvm_llc_add = TRUE;
 		} else if (!strcmp (arg, "deterministic")) {
 			opts->deterministic = TRUE;
 		} else if (!strcmp (arg, "no-opt")) {
@@ -9239,9 +9231,7 @@ emit_llvm_file (MonoAotCompile *acfg)
 	 * return OverwriteComplete;
 	 * Here, if 'Earlier' refers to a memset, and Later has no size info, it mistakenly thinks the memset is redundant.
 	 */
-	if (acfg->aot_opts.llvm_opts && !acfg->aot_opts.llvm_opts_add) {
-		opts = g_strdup (acfg->aot_opts.llvm_opts);
-	} else if (acfg->aot_opts.llvm_only) {
+	if (acfg->aot_opts.llvm_only) {
 		// FIXME: This doesn't work yet
 		opts = g_strdup ("");
 	} else {
@@ -9252,7 +9242,7 @@ emit_llvm_file (MonoAotCompile *acfg)
 #endif
 	}
 
-	if (acfg->aot_opts.llvm_opts_add) {
+	if (acfg->aot_opts.llvm_opts) {
 		opts = g_strdup_printf ("%s %s", opts, acfg->aot_opts.llvm_opts);
 	}
 
@@ -9318,12 +9308,7 @@ emit_llvm_file (MonoAotCompile *acfg)
 	}
 
 	if (acfg->aot_opts.llvm_llc) {
-		if (!acfg->aot_opts.llvm_llc_add) {
-			g_free (acfg->llc_args);
-			acfg->llc_args = g_string_new (acfg->aot_opts.llvm_llc);
-		} else {
-			g_string_append_printf (acfg->llc_args, " %s", acfg->aot_opts.llvm_llc);
-		}
+		g_string_append_printf (acfg->llc_args, " %s", acfg->aot_opts.llvm_llc);
 	}
 
 	command = g_strdup_printf ("\"%sllc\" %s -o \"%s\" \"%s.opt.bc\"", acfg->aot_opts.llvm_path, acfg->llc_args->str, output_fname, acfg->tmpbasename);

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -9239,7 +9239,7 @@ emit_llvm_file (MonoAotCompile *acfg)
 	 * return OverwriteComplete;
 	 * Here, if 'Earlier' refers to a memset, and Later has no size info, it mistakenly thinks the memset is redundant.
 	 */
-	if (acfg->aot_opts.llvm_opts && !cfg->aot_opts.llvm_opts_add) {
+	if (acfg->aot_opts.llvm_opts && !acfg->aot_opts.llvm_opts_add) {
 		opts = g_strdup (acfg->aot_opts.llvm_opts);
 	} else if (acfg->aot_opts.llvm_only) {
 		// FIXME: This doesn't work yet
@@ -9252,8 +9252,8 @@ emit_llvm_file (MonoAotCompile *acfg)
 #endif
 	}
 
-	if (cfg->aot_opts.llvm_opts_add) {
-		g_string_append_printf (opts, " %s", acfg->aot_opts.llvm_opts);
+	if (acfg->aot_opts.llvm_opts_add) {
+		opts = g_strdup_printf ("%s %s", opts, acfg->aot_opts.llvm_opts);
 	}
 
 	command = g_strdup_printf ("\"%sopt\" -f %s -o \"%s\" \"%s\"", acfg->aot_opts.llvm_path, opts, optbc, tempbc);
@@ -9322,7 +9322,7 @@ emit_llvm_file (MonoAotCompile *acfg)
 			g_free (acfg->llc_args);
 			acfg->llc_args = g_string_new (acfg->aot_opts.llvm_llc);
 		} else {
-			acfg->llc_args = g_string_append_printf (acfg->llc_args, " %s", acfg->aot_opts.llvm_llc);
+			g_string_append_printf (acfg->llc_args, " %s", acfg->aot_opts.llvm_llc);
 		}
 	}
 

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -7766,9 +7766,7 @@ mono_aot_parse_options (const char *aot_options, MonoAotOptions *opts)
 			printf ("    verbose\n");
 			printf ("    no-opt\n");
 			printf ("    llvmopts=\n");
-			printf ("    llvmopts-add=\n");
 			printf ("    llvmllc=\n");
-			printf ("    llvmllc-add=\n");
 			printf ("    clangxx=\n");
 			printf ("    help/?\n");
 			exit (0);
@@ -9240,10 +9238,9 @@ emit_llvm_file (MonoAotCompile *acfg)
 #else
 		opts = g_strdup ("-targetlibinfo -no-aa -basicaa -notti -instcombine -simplifycfg -inline-cost -inline -sroa -domtree -early-cse -lazy-value-info -correlated-propagation -simplifycfg -instcombine -simplifycfg -reassociate -domtree -loops -loop-simplify -lcssa -loop-rotate -licm -lcssa -loop-unswitch -instcombine -scalar-evolution -loop-simplify -lcssa -indvars -loop-idiom -loop-deletion -loop-unroll -memdep -gvn -memdep -memcpyopt -sccp -instcombine -lazy-value-info -correlated-propagation -domtree -memdep -adce -simplifycfg -instcombine -strip-dead-prototypes -domtree -verify");
 #endif
-	}
-
-	if (acfg->aot_opts.llvm_opts) {
-		opts = g_strdup_printf ("%s %s", opts, acfg->aot_opts.llvm_opts);
+		if (acfg->aot_opts.llvm_opts) {
+			opts = g_strdup_printf ("%s %s", opts, acfg->aot_opts.llvm_opts);
+		}
 	}
 
 	command = g_strdup_printf ("\"%sopt\" -f %s -o \"%s\" \"%s\"", acfg->aot_opts.llvm_path, opts, optbc, tempbc);


### PR DESCRIPTION
Currently we can pass custom arguments to LLVM's `opt` and `llc` via:
```
mono --aot=llvm,llvmopts="...",llvmllc="..."
```
but those completely override the default arguments mono uses (some of them are required).
E.g. lets say I need to add `-foo` to both opt and llc, I should do:

```
mono --aot=llvm,llvmllc="**-foo** -march=x86-64 -mattr=sse4.1 -asm-verbose=false 
-disable-gnu-eh-frame -enable-mono-eh-frame -mono-eh-frame-symbol=_mono_aot_p_eh_frame 
-disable-tail-calls -no-x86-call-frame-opt -relocation-model=pic 
-filetype=obj,llvmopts="**-foo** -O2 -disable-tail-calls"
```

So this PR introduces new commands `llvmopts-add` and `llvmllc-add` to be able to simply do:
`mono --aot=llvm,llvmopts-add="-foo",llvmllc-add="-foo"`

PS: let me know if you don't like the `-add` suffix

/cc: @migueldeicaza 