### PR TITLE
prevent endless recursion in ListView.ToString()

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ListView.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ListView.cs
@@ -3949,8 +3949,8 @@ namespace System.Windows.Forms
 		{
 			int count = this.Items.Count;
 
-			if (count == 0)
-				return string.Format ("System.Windows.Forms.ListView, Items.Count: 0");
+			if (count == 0 || VirtualMode)
+				return string.Format ("System.Windows.Forms.ListView, Items.Count: {0}", count);
 			else
 				return string.Format ("System.Windows.Forms.ListView, Items.Count: {0}, Items[0]: {1}", count, this.Items [0].ToString ());
 		}


### PR DESCRIPTION
do not access the Items[] in ListView.ToString() in VirtualMode
as this might cause an endless recursion if ToString() is called
from within the RetrieveVirtualItem event handler

Fixes #11049