### PR TITLE
[2018-06] [llvm] bump for armhf callingconv fix

### DIFF
--- a/llvm/SUBMODULES.json
+++ b/llvm/SUBMODULES.json
@@ -2,7 +2,7 @@
   {
       "name": "llvm", 
       "url": "git://github.com/mono/llvm.git",
-      "rev": "9f79399f87282524fee099b328bd8cbf07929daf",
+      "rev": "f80899cb3eb75f7f5640b4519e83bd96991bffb8",
       "remote-branch": "origin/master", 
       "branch": "master", 
       "directory": "llvm"

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -1066,18 +1066,16 @@ add_general (CallInfo *cinfo, ArgInfo *ainfo, int size, gboolean sign)
 		ainfo->storage = ArgOnStack;
 		if (ios_abi) {
 			/* Assume size == align */
-			cinfo->stack_usage = ALIGN_TO (cinfo->stack_usage, size);
-			ainfo->offset = cinfo->stack_usage;
-			ainfo->slot_size = size;
-			ainfo->sign = sign;
-			cinfo->stack_usage += size;
 		} else {
-			ainfo->offset = cinfo->stack_usage;
-			ainfo->slot_size = 8;
-			ainfo->sign = FALSE;
 			/* Put arguments into 8 byte aligned stack slots */
-			cinfo->stack_usage += 8;
+			size = 8;
+			sign = FALSE;
 		}
+		cinfo->stack_usage = ALIGN_TO (cinfo->stack_usage, size);
+		ainfo->offset = cinfo->stack_usage;
+		ainfo->slot_size = size;
+		ainfo->sign = sign;
+		cinfo->stack_usage += size;
 	} else {
 		ainfo->storage = ArgInIReg;
 		ainfo->reg = cinfo->gr;


### PR DESCRIPTION
Commit list for mono/llvm:

* mono/llvm@f80899cb3eb [mono] respect hardfloat/softloat setting in ARM ABI (#16)
* mono/llvm@f80899cb3eb (HEAD -> master, origin/master) [mono] respect hardfloat/softloat setting in ARM ABI (#16)
* mono/llvm@37e14bd72e6 Fix the mono calling convention on arm64+linux.
* mono/llvm@acb33f3436e Pack 32bits llc, opt and llvm-dis in archive as well
* mono/llvm@9b92b4b8760 Merge pull request #14 from lateralusX/lateralusX/build-llvm-windows-x64
* mono/llvm@e2ae3309b0c Fixes Mono LLVM usage on Windows x64.
* mono/llvm@384caa9849a Build LLVM Windows x64 using CMake + VS2015 or VS2017.
* mono/llvm@0b3cb8ac12c Emit an LSDA for methods without landing pads too since we need the information about the 'this' register.fbbfbae4fea [ci] Enable x86/amd64 backends. (#9)
* mono/llvm@8e14f6654ad Add 3.9 Packaging Scripts and Cross Compilation Support (#8)
* mono/llvm@bdb3a116dbf Change some code slighly in AArch64InstrInfo.cpp to work around a gcc optimizer problem. https://github.com/xamarin/xamarin-android/issues/1182.
* mono/llvm@3b82b3c9041 [ci] Really compile the 32 bit llvm as 32 bit.
* mono/llvm@73c983a02a2 [ci] Distribute 32 bit llvm-config.
* mono/llvm@0692a5ea231 [ci] Install 64-bit binaries into usr64 for consistency.
* mono/llvm@804c869e6b5 [ci] Fix 32 bit build.8dfa8ebfc25 [ci] Compile a 32 bit version of llvm as well.07582cba7cc [ci] Package llvm-config as well.
* mono/llvm@a9cfb50e5af [ci] Fix an rm statement which can fail.
* mono/llvm@a21fcae962a Add a jenkins build script.
* mono/llvm@21492ec92e2 Revert "Add a workaround to the problem where the amd64 JIT would make all calls as register indirect."
* mono/llvm@6aa74ae5723 Fix a regression caused by:
* mono/llvm@5056b9f2bcb Rename the temp labels used by DwarfMonoException so they don't collide with the ones used by the GNU EH frame.
* mono/llvm@975e3a69030 Align the size of the Mono EH table to 8 to prevent an ld assertion. Fixes #55553.
* mono/llvm@dbb6fdffdeb [arm] Handle CallingConv::Mono in getEffectiveCallingConv (), previously it would be handled by the default branch, which would fall through to the next switch case because llvm_unreachable() was a noop in release builds.
* mono/llvm@5b94bc7097e Avoid making the EH table symbol global, its not needed any more.
* mono/llvm@8b1520c8aae Merge pull request #6 from Xaltotun/feature/cmake_build
* mono/llvm@8d00fd38456 Fixed MONO_API_VERSION define for the cmake build. For #cmakedefine to work, the variable needs to be declared in the cmake script otherwise it will be commented out in the generated file.
* mono/llvm@73df95d02d3 Merge pull request #5 from alexanderkyte/mastere
* mono/llvm@51cd999c98 [mono] Fix MONO_API_VERSION usage with cmake

Diff: https://github.com/mono/llvm/compare/9f79399f87282524fee099b328bd8cbf07929daf...f80899cb3eb75f7f5640b4519e83bd96991bffb8


Backport https://github.com/mono/mono/pull/11607