### PR TITLE
Add common "test" target for precompiling test assemblies

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,7 @@ AM_INIT_AUTOMAKE([1.9 dist-bzip2 tar-ustar no-dist-gzip foreign subdir-objects]
 
 AC_CONFIG_HEADERS([config.h])
 AM_MAINTAINER_MODE
+AM_EXTRA_RECURSIVE_TARGETS([test])
 
 API_VER=2.0
 AC_SUBST(API_VER)

--- a/libgc/Makefile.am
+++ b/libgc/Makefile.am
@@ -185,3 +185,4 @@ EXTRA_DIST += configure.host
 .S.s:
 	if $(CPP) $< >$@ ; then :; else rm -f $@; fi
 
+test:

--- a/mcs/Makefile
+++ b/mcs/Makefile
@@ -87,11 +87,13 @@ $(_boot_:%=profile-do--unreal--%):              profile-do--unreal--%:          
 $(_boot_:%=profile-do--wasm--%):              profile-do--wasm--%:              profile-do--build--%
 $(_boot_:%=profile-do--wasm_tools--%):         profile-do--wasm_tools--%:         profile-do--build--%
 
-testcorlib:
-	@cd class/corlib && $(MAKE) test run-test
+compiler-test:
+	$(MAKE) -C tests test
+	$(MAKE) -C errors test
 
-compiler-tests:
-	$(MAKE) TEST_SUBDIRS="tests errors" run-test-profiles
+run-compiler-test:
+	$(MAKE) -C tests run-test
+	$(MAKE) -C errors run-test
 
 package := mcs-$(VERSION)
 

--- a/mcs/Makefile
+++ b/mcs/Makefile
@@ -43,8 +43,8 @@ dir-check:
 
 PROFILES = net_4_x binary_reference_assemblies xbuild_12 xbuild_14
 
-.PHONY: all-profiles $(STD_TARGETS:=-profiles)
-all-profiles $(STD_TARGETS:=-profiles): %-profiles: profiles-do--%
+.PHONY: all-profiles compiler-test-profiles run-compiler-test-profiles $(STD_TARGETS:=-profiles)
+all-profiles compiler-test-profiles run-compiler-test-profiles $(STD_TARGETS:=-profiles): %-profiles: profiles-do--%
 	@:
 
 profiles-do--%:

--- a/mcs/errors/Makefile
+++ b/mcs/errors/Makefile
@@ -42,8 +42,8 @@ TEST_SUPPORT_FILES = \
 # mention all targets
 all-local $(STD_TARGETS:=-local):
 
-VALID_PROFILE := $(filter $(DEFAULT_PROFILE), $(PROFILE))
-ifdef VALID_PROFILE
+VALID_TEST_PROFILE := $(filter net_4_x, $(PROFILE))
+ifdef VALID_TEST_PROFILE
 
 qcheck: run-mcs-tests 
 

--- a/mcs/mcs/README
+++ b/mcs/mcs/README
@@ -16,12 +16,7 @@ Testing the Compiler
 	expected result, type:
 
 	  cd mcs		# The top-level 'mcs' directory
-	  make compiler-tests
-
-	If you want to test the installed compiler, you can run:
-
-	  cd mcs		# The top-level 'mcs' directory
-	  make test-installed-compiler
+	  make run-compiler-tests
 
 Full Bootstrap
 ==============

--- a/mcs/tests/Makefile
+++ b/mcs/tests/Makefile
@@ -21,8 +21,8 @@ USE_MCS_FLAGS :=
 # mention all targets
 all-local $(STD_TARGETS:=-local):
 
-VALID_PROFILE := $(filter $(DEFAULT_PROFILE), $(PROFILE))
-ifdef VALID_PROFILE
+VALID_TEST_PROFILE := $(filter net_4_x, $(PROFILE))
+ifdef VALID_TEST_PROFILE
 # casts
 bootstrap-cast.exe: gen-cast-test.cs
 	$(BOOT_COMPILE) -target:exe /out:$@ $<
@@ -46,12 +46,8 @@ test-casts: boot-casts.out mcs-casts.out
 	cmp $^
 	-rm -f bootstrap-cast.exe casts.cs casts-boot.exe casts-mcs.exe boot-casts.out mcs-casts.out
 
-TEST_PATTERN = 'v2'
-
-ifeq (net_4_x, $(PROFILE))
 TEST_PATTERN = 'v4'
 DEFINES = -compiler-options:"-d:NET_4_0;NET_4_5 -debug"
-endif
 
 LOCAL_RUNTIME_FLAGS = --verify-all
 COMPILER = $(topdir)/class/lib/$(PROFILE)/mcs.exe

--- a/mono/benchmark/Makefile.am
+++ b/mono/benchmark/Makefile.am
@@ -3,8 +3,9 @@ include $(top_srcdir)/mk/common.mk
 TEST_PROG=../mini/mono
 RUNTIME_ARGS="-O=all"
 
-CSC=mcs
-
+TOOLS_RUNTIME = MONO_PATH=$(mcs_topdir)/class/lib/build $(top_builddir)/runtime/mono-wrapper --aot-path=$(mcs_topdir)/class/lib/build
+MCS = $(TOOLS_RUNTIME) $(CSC) -noconfig -nologo -debug:portable -target:library $(PROFILE_MCS_FLAGS)
+ILASM = $(TOOLS_RUNTIME) $(mcs_topdir)/class/lib/build/ilasm.exe
 
 TESTSRC=			\
 	fib.cs 			\
@@ -52,12 +53,14 @@ TESTSI=$(TESTSI_TMP:.il=.exe)
 EXTRA_DIST=test-driver $(TESTSRC)
 
 %.exe: %.il
-	ilasm $< /OUTPUT=$@
+	$(ILASM) $< /OUTPUT=$@
 
 %.exe: %.cs
-	$(CSC) $<
+	$(MCS) $< -out:$@
 
-test: $(TEST_PROG) $(TESTSI)
+test-local: $(TEST_PROG) $(TESTSI)
+
+run-test: $(TEST_PROG) $(TESTSI)
 	@failed=0; \
 	passed=0; \
 	for i in $(TESTSI); do	\

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -803,6 +803,8 @@ cpu-riscv64.h: cpu-riscv64.md
 testi: mono test.exe
 	$(MINI_RUNTIME) -v -v --ncompile 1 --compile Test:$(mtest) test.exe
 
+test-local: $(regtests)
+
 # ensure the tests are actually correct
 checktests: $(regtests)
 	for i in $(regtests); do $(MINI_RUNTIME) $$i; done

--- a/mono/profiler/Makefile.am
+++ b/mono/profiler/Makefile.am
@@ -36,7 +36,7 @@ suppression_DATA = mono-profiler-coverage.suppression
 #
 # See: https://bugzilla.xamarin.com/show_bug.cgi?id=57011
 if !ENABLE_COOP_SUSPEND
-check_targets = testlog
+check_targets = run-test
 endif
 
 endif
@@ -159,7 +159,9 @@ MCS = $(TOOLS_RUNTIME) $(CSC) -lib:$(CLASS) -unsafe -nologo -noconfig -nowarn:01
 %.exe: %.cs
 	$(MCS) -out:$@ $<
 
-testlog: $(PLOG_TESTS)
+test-local: $(PLOG_TESTS)
+
+run-test: test
 	MONO_PATH=$(CLASS) perl $(srcdir)/ptestrunner.pl $(top_builddir) nunit TestResult-profiler.xml
 
 check-local: $(check_targets)

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -5,7 +5,7 @@ SUBDIRS = gc-descriptors . testing_gac assembly-load-reference
 check-local:
 	ok=:; \
 	$(MAKE) test-tailcall || ok=false; \
-	$(MAKE) test-jit || ok=false; \
+	if test x$(IGNORE_TEST_JIT) == x; then $(MAKE) test-jit || ok=false; fi; \
 	$(MAKE) test-generic-sharing || ok=false; \
 	$(MAKE) test-type-load || ok=false; \
 	$(MAKE) test-multi-netmodule || ok=false; \
@@ -1974,9 +1974,6 @@ test-platform:	test-iomap-regression
 endif
 endif
 
-# Target to precompile the test executables
-tests: compile-tests
-
 #
 # Test that no symbols are missed in eglib-remap.h
 #
@@ -1998,11 +1995,17 @@ test-eglib-remap:
 test-env-options:
 	MONO_ENV_OPTIONS="--version" $(RUNTIME) array-init.exe | grep -q Architecture:
 
+TESTS_REGULAR = $(TESTS_CS) $(TESTS_IL) $(TESTS_BENCH)
+
+generate-regular-test-list:
+	@echo $(TESTS_REGULAR) > $(TEST_LIST_PATH)
+
+# Target to precompile the test executables
+test-local: $(TESTS_REGULAR) $(TESTS_STRESS) $(TESTS_GSHARED) $(TESTSAOT_CS) $(TESTSAOT_IL) $(TESTSAOT_BENCH) $(TESTSAOT_STRESS) $(TESTSAOT_GSHARED) $(TESTS_TAILCALL) $(TESTSAOT_TAILCALL) compile-gac-loading compile-assembly-load-reference test-runner.exe
+
 # Precompile the test assemblies in parallel
 compile-tests:
-	$(MAKE) -j4 compile-tests-parallel
-
-compile-tests-parallel: $(TESTS_CS) $(TESTS_IL) $(TESTS_BENCH) $(TESTS_STRESS) $(TESTS_GSHARED) $(TESTSAOT_CS) $(TESTSAOT_IL) $(TESTSAOT_BENCH) $(TESTSAOT_STRESS) $(TESTSAOT_GSHARED) $(TESTS_TAILCALL) $(TESTSAOT_TAILCALL) compile-gac-loading compile-assembly-load-reference
+	$(MAKE) -j4 test
 
 # Remove empty .stdout and .stderr files for wrench
 rm-empty-logs:
@@ -2018,7 +2021,7 @@ runtest: compile-tests
 	failed_tests="";\
 	if [ "x$$V" = "x1" ]; then dump_action="dump-output"; else dump_action="no-dump"; fi; \
 	rm -f testlist testlist.sorted; \
-	for i in $(TESTS_CS) $(TESTS_IL) $(TESTS_BENCH); do echo $${i} >> testlist; sort testlist > testlist.sorted; done; \
+	for i in $(TESTS_REGULAR); do echo $${i} >> testlist; sort testlist > testlist.sorted; done; \
 	for i in `cat testlist.sorted`; do \
 		rm -f $${i}.so; \
 		$(with_mono_path) $(JITTEST_PROG_RUN) --aot $(TEST_AOT_BUILD_FLAGS) --debug $${i} > $${i}.aotlog 2>&1 || exit 1; \
@@ -2046,10 +2049,10 @@ runtest: compile-tests
 	fi
 
 runtest-managed: test-runner.exe compile-tests
-	$(TOOLS_RUNTIME) --debug $(TEST_RUNNER) -j a --testsuite-name "runtime" --timeout 300 --disabled "$(DISABLED_TESTS)" $(TESTS_CS) $(TESTS_IL) $(TESTS_BENCH)
+	$(TOOLS_RUNTIME) --debug $(TEST_RUNNER) -j a --testsuite-name "runtime" --timeout 300 --disabled "$(DISABLED_TESTS)" $(TESTS_REGULAR)
 
 runtest-managed-serial: test-runner.exe compile-tests
-	$(TOOLS_RUNTIME) --debug $(TEST_RUNNER) -j 1 --testsuite-name "runtime" --disabled "$(DISABLED_TESTS)" $(TESTS_CS) $(TESTS_IL) $(TESTS_BENCH)
+	$(TOOLS_RUNTIME) --debug $(TEST_RUNNER) -j 1 --testsuite-name "runtime" --disabled "$(DISABLED_TESTS)" $(TESTS_REGULAR)
 
 test-jit:
 	@if test x$(M) != x0; then $(MAKE) runtest-managed; else $(MAKE) runtest; fi
@@ -2061,10 +2064,10 @@ testtrace:
 	@$(MAKE) TEST_RUNTIME_ARGS="$${TEST_RUNTIME_ARGS} --trace" runtest
 
 testinterp: test-runner.exe compile-tests
-	$(TOOLS_RUNTIME) --debug $(TEST_RUNNER) -j a --runtime-args "--interpreter" --testsuite-name "runtime-interp" --timeout 300 --disabled "$(INTERP_DISABLED_TESTS)" $(TESTS_CS) $(TESTS_IL) $(TESTS_BENCH)
+	$(TOOLS_RUNTIME) --debug $(TEST_RUNNER) -j a --runtime-args "--interpreter" --testsuite-name "runtime-interp" --timeout 300 --disabled "$(INTERP_DISABLED_TESTS)" $(TESTS_REGULAR)
 
 testfullaotinterp: test-runner.exe compile-tests
-	$(TOOLS_RUNTIME) --debug $(TEST_RUNNER) -j a --runtime-args "--full-aot-interp" --testsuite-name "runtime-aot-interp" --timeout 300 --disabled "$(INTERP_DISABLED_TESTS)" $(TESTS_CS) $(TESTS_IL) $(TESTS_BENCH)
+	$(TOOLS_RUNTIME) --debug $(TEST_RUNNER) -j a --runtime-args "--full-aot-interp" --testsuite-name "runtime-aot-interp" --timeout 300 --disabled "$(INTERP_DISABLED_TESTS)" $(TESTS_REGULAR)
 
 testjitspeed: $(JITTEST_PROG) compile-tests
 	for i in $(TESTS_BENCH); do	\
@@ -2968,16 +2971,16 @@ test-pedump: test-runner.exe
 .PHONY: test-gac-loading test-eglib-remap
 
 runtest-gac-loading: test-runner.exe
-	$(MAKE) -C testing_gac runtest
+	$(MAKE) -C testing_gac run-test
 
 compile-gac-loading:
-	$(MAKE) -C testing_gac compile-tests
+	$(MAKE) -C testing_gac test
 
 runtest-assembly-load-reference: test-runner.exe
-	$(MAKE) -C assembly-load-reference runtest
+	$(MAKE) -C assembly-load-reference run-test
 
 compile-assembly-load-reference:
-	$(MAKE) -C assembly-load-reference compile-tests
+	$(MAKE) -C assembly-load-reference test
 
 
 TESTS_STRESS_PROCESS_SRC=	\
@@ -3098,6 +3101,6 @@ Mono.Runtime.Testing.dll: weakattribute.cs
 weak-fields.exe: weak-fields.cs Mono.Runtime.Testing.dll
 	$(MCS) -r:Mono.Runtime.Testing.dll -r:$(CLASS)/System.dll -r:$(CLASS)/System.Xml.dll -r:$(CLASS)/System.Core.dll -r:TestDriver.dll $(TEST_DRIVER_HARD_KILL_FEATURE) -out:$@ $<
 
-CLEANFILES = $(TESTS_CS) $(TESTS_IL) $(TESTS_BENCH) $(TESTS_STRESS) $(TESTSAOT_CS) $(TESTSAOT_IL) $(TESTSAOT_BENCH) $(TESTSAOT_STRESS) *.dll *.stdout *.aotlog *.exe stest.dat LeafAssembly.dll MidAssembly.dll appdomain-marshalbyref-assemblyload2/*.dll 
+CLEANFILES = $(TESTS_REGULAR) $(TESTS_STRESS) $(TESTSAOT_CS) $(TESTSAOT_IL) $(TESTSAOT_BENCH) $(TESTSAOT_STRESS) *.dll *.stdout *.aotlog *.exe stest.dat LeafAssembly.dll MidAssembly.dll appdomain-marshalbyref-assemblyload2/*.dll 
 CLEANFILES += $(TESTS_TAILCALL_COMPILE) $(TESTSAOT_TAILCALL)
 CLEANFILES += $(BUILT_SOURCES)

--- a/mono/tests/assembly-load-reference/Makefile.am
+++ b/mono/tests/assembly-load-reference/Makefile.am
@@ -66,7 +66,7 @@ EXTRA_DIST= README $(SIGNING_KEY) $(GACTESTLIB_SRCS)
 
 ### Test cases
 
-.PHONY: runtest compile-tests
+.PHONY: run-test test-local
 
 TESTS_CS = \
 	samedir/LoadFromMain.cs \
@@ -113,12 +113,12 @@ DISABLED_TESTS+= \
 	separatedir/LoadFileMain.exe
 endif
 
-runtest:
+run-test:
 	true
 	$(MAKE) run-assembly-load-reference-tests
 
 
-compile-tests: compile-samedir compile-separatedir compile-mainanddep
+test-local: compile-samedir compile-separatedir compile-mainanddep
 
 compile-samedir: samedir/LoadFromMain.exe samedir/LoadFileMain.exe samedir/Dep.dll samedir/Mid.dll
 

--- a/mono/tests/gc-descriptors/Makefile.am
+++ b/mono/tests/gc-descriptors/Makefile.am
@@ -13,7 +13,7 @@ else
 
 check-local: test
 
-test : descriptor-tests.exe
+test-local : descriptor-tests.exe
 
 descriptor-tests.exe : descriptor-tests.cs
 	$(MCS) -Warn:0 descriptor-tests.cs

--- a/mono/tests/testing_gac/Makefile.am
+++ b/mono/tests/testing_gac/Makefile.am
@@ -96,9 +96,9 @@ EXTRA_DIST= README $(SIGNING_KEY) $(GACTESTLIB_SRCS)
 
 ### Test cases
 
-.PHONY: runtest compile-tests prereqs
+.PHONY: run-test test-local prereqs
 
-runtest:
+run-test:
 	true
 if !FULL_AOT_TESTS
 if !HYBRID_AOT_TESTS
@@ -111,7 +111,7 @@ if !HYBRID_AOT_TESTS
 endif
 endif
 
-compile-tests: prereqs $(APP_SIGNED_V1_EXE) $(APP_BOTH_EXE) $(APP_SIGNED_V1_AOT)
+test-local: prereqs $(APP_SIGNED_V1_EXE) $(APP_BOTH_EXE) $(APP_SIGNED_V1_AOT)
 
 prereqs: $(GACTESTLIB_DLLS) $(GACTESTLIB_DLLS_AOT)
 	$(MAKE) gacinstall

--- a/mono/tests/tests-config.in
+++ b/mono/tests/tests-config.in
@@ -1,6 +1,7 @@
 <configuration>
 	<dllmap dll="cygwin1.dll" target="@LIBC@" />
 	<dllmap dll="libc" target="@LIBC@" />
+	<dllmap dll="System.Native" target="$mono_libdir/@MONO_NATIVE_LIBRARY_NAME@@libsuffix@" os="!windows" />
 	<dllmap os="windows" cpu="x86" dll="libtest" target="../../msvc/build/sgen/Win32/bin/Release/libtest.dll" />
 	<dllmap os="windows" cpu="x86-64" dll="libtest" target="../../msvc/build/sgen/x64/bin/Release/libtest.dll" />
 </configuration>

--- a/mono/unit-tests/Makefile.am
+++ b/mono/unit-tests/Makefile.am
@@ -109,6 +109,8 @@ TESTS = test-sgen-qsort test-memfuncs test-mono-linked-list-set test-conc-hashta
 
 AM_TESTS_ENVIRONMENT = export MONO_PATH=$(mcs_topdir)/class/lib/build;
 
+test-local: $(check_PROGRAMS)
+
 .NOTPARALLEL:
 
 check-local:

--- a/po/mcs/Makefile.in.in
+++ b/po/mcs/Makefile.in.in
@@ -443,3 +443,5 @@ force:
 # Tell versions [3.59,3.63) of GNU make not to export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.
 .NOEXPORT:
+
+test:

--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -135,12 +135,14 @@ TEST_SUPPORT_FILES = $(tmpinst)/bin/mono $(tmpinst)/bin/ilasm $(tmpinst)/bin/csc
 
 mcs-do-test-profiles:
 	cd $(mcs_topdir) && $(MAKE) NO_DIR_CHECK=1 PROFILES='$(test_profiles)' test-profiles
+	cd $(mcs_topdir) && $(MAKE) NO_DIR_CHECK=1 compiler-test
 
 mcs-do-xunit-test-profiles:
 	cd $(mcs_topdir) && $(MAKE) NO_DIR_CHECK=1 PROFILES='$(test_profiles)' xunit-test-profiles
 
 mcs-do-run-test-profiles: test-support-files
 	cd $(mcs_topdir) && $(MAKE) NO_DIR_CHECK=1 PROFILES='$(test_profiles)' run-test-profiles
+	cd $(mcs_topdir) && $(MAKE) NO_DIR_CHECK=1 run-compiler-test
 
 mcs-do-xunit-run-test-profiles: test-support-files
 	cd $(mcs_topdir) && $(MAKE) NO_DIR_CHECK=1 PROFILES='$(test_profiles)' run-xunit-test-profiles

--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -135,14 +135,14 @@ TEST_SUPPORT_FILES = $(tmpinst)/bin/mono $(tmpinst)/bin/ilasm $(tmpinst)/bin/csc
 
 mcs-do-test-profiles:
 	cd $(mcs_topdir) && $(MAKE) NO_DIR_CHECK=1 PROFILES='$(test_profiles)' test-profiles
-	cd $(mcs_topdir) && $(MAKE) NO_DIR_CHECK=1 compiler-test
+	cd $(mcs_topdir) && $(MAKE) NO_DIR_CHECK=1 PROFILES='$(test_profiles)' compiler-test-profiles
 
 mcs-do-xunit-test-profiles:
 	cd $(mcs_topdir) && $(MAKE) NO_DIR_CHECK=1 PROFILES='$(test_profiles)' xunit-test-profiles
 
 mcs-do-run-test-profiles: test-support-files
 	cd $(mcs_topdir) && $(MAKE) NO_DIR_CHECK=1 PROFILES='$(test_profiles)' run-test-profiles
-	cd $(mcs_topdir) && $(MAKE) NO_DIR_CHECK=1 run-compiler-test
+	cd $(mcs_topdir) && $(MAKE) NO_DIR_CHECK=1 PROFILES='$(test_profiles)' run-compiler-test-profiles
 
 mcs-do-xunit-run-test-profiles: test-support-files
 	cd $(mcs_topdir) && $(MAKE) NO_DIR_CHECK=1 PROFILES='$(test_profiles)' run-xunit-test-profiles

--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -2,10 +2,12 @@
 
 export MONO_REPO_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../" && pwd )"
 export TESTCMD=${MONO_REPO_ROOT}/scripts/ci/run-step.sh
-
+export CI=1
+export CI_PR=$([[ ${CI_TAGS} == *'pull-request'* ]] && echo 1 || true)
 export CI_CPU_COUNT=$(getconf _NPROCESSORS_ONLN || echo 4)
-
 export TEST_HARNESS_VERBOSE=1
+
+source ${MONO_REPO_ROOT}/scripts/ci/util.sh
 
 make_timeout=300m
 

--- a/scripts/ci/run-test-acceptance-tests.sh
+++ b/scripts/ci/run-test-acceptance-tests.sh
@@ -22,4 +22,4 @@ ${TESTCMD} --label=coreclr-runtest-basic --timeout=20m make -C acceptance-tests 
 ${TESTCMD} --label=coreclr-runtest-coremanglib --timeout=10m make -C acceptance-tests coreclr-runtest-coremanglib
 
 # run the GC stress tests (on PRs we only run a short version)
-${TESTCMD} --label=coreclr-gcstress --timeout=1200m make -C acceptance-tests coreclr-gcstress CI_PR=$([[ ${CI_TAGS} == *'pull-request'* ]] && echo 1 || true)
+${TESTCMD} --label=coreclr-gcstress --timeout=1200m make -C acceptance-tests coreclr-gcstress

--- a/scripts/ci/run-test-default.sh
+++ b/scripts/ci/run-test-default.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+source ${MONO_REPO_ROOT}/scripts/ci/util.sh
+
 ${TESTCMD} --label=mini --timeout=5m make -w -C mono/mini -k check check-seq-points EMIT_NUNIT=1
 if [[ ${CI_TAGS} == *'win-'* ]]
 then ${TESTCMD} --label=mini-aotcheck --skip;
@@ -10,8 +12,8 @@ then ${TESTCMD} --label=aot-test --skip;
 else ${TESTCMD} --label=aot-test --timeout=30m make -w -C mono/tests -j ${CI_CPU_COUNT} -k test-aot
 fi
 ${TESTCMD} --label=compile-bcl-tests --timeout=40m make -i -w -C runtime -j ${CI_CPU_COUNT} test xunit-test
-${TESTCMD} --label=compile-runtime-tests --timeout=40m make -w -C mono/tests -j ${CI_CPU_COUNT} tests
-${TESTCMD} --label=runtime --timeout=160m make -w -C mono/tests -k test-wrench V=1 CI=1 CI_PR=$([[ ${CI_TAGS} == *'pull-request'* ]] && echo 1 || true)
+${TESTCMD} --label=compile-runtime-tests --timeout=40m make -w -C mono/tests -j ${CI_CPU_COUNT} test
+${TESTCMD} --label=runtime --timeout=160m make -w -C mono/tests -k test-wrench V=1
 ${TESTCMD} --label=runtime-unit-tests --timeout=5m make -w -C mono/unit-tests -k check
 if [[ ${CI_TAGS} == *'osx-'* ]]; then ${TESTCMD} --label=corlib-btls --timeout=5m bash -c "export MONO_TLS_PROVIDER=btls && make -w -C mcs/class/corlib TEST_HARNESS_FLAGS=-include:X509Certificates run-test"; fi
 ${TESTCMD} --label=corlib --timeout=30m make -w -C mcs/class/corlib run-test
@@ -141,7 +143,6 @@ fi
 ${TESTCMD} --label=bundle-test-results --timeout=2m find . -name "TestResult*.xml" -exec tar -rvf TestResults.tar {} \;
 
 if [[ $CI_TAGS == *'apidiff'* ]]; then
-    source ${MONO_REPO_ROOT}/scripts/ci/util.sh
     if ${TESTCMD} --label=apidiff --timeout=15m --fatal make -w -C mcs -j ${CI_CPU_COUNT} mono-api-diff
     then report_github_status "success" "API Diff" "No public API changes found." || true
     else report_github_status "error" "API Diff" "The public API changed." "$BUILD_URL/Public_20API_20Diff/" || true
@@ -149,7 +150,6 @@ if [[ $CI_TAGS == *'apidiff'* ]]; then
 else ${TESTCMD} --label=apidiff --skip
 fi
 if [[ $CI_TAGS == *'csprojdiff'* ]]; then
-    source ${MONO_REPO_ROOT}/scripts/ci/util.sh
     make update-solution-files
     if ${TESTCMD} --label=csprojdiff --timeout=5m --fatal make -w -C mcs mono-csproj-diff
     then report_github_status "success" "Project Files Diff" "No csproj file changes found." || true

--- a/scripts/ci/run-test-interpreter.sh
+++ b/scripts/ci/run-test-interpreter.sh
@@ -6,8 +6,8 @@ export TEST_WITH_INTERPRETER=1
 ${TESTCMD} --label=interpreter-regression --timeout=10m make -C mono/mini richeck
 ${TESTCMD} --label=mixedmode-regression --timeout=10m make -C mono/mini mixedcheck
 ${TESTCMD} --label=fullaotmixed-regression --timeout=10m make -C mono/mini fullaotmixedcheck
-${TESTCMD} --label=compile-runtime-tests --timeout=40m make -w -C mono/tests -j ${CI_CPU_COUNT} tests
-${TESTCMD} --label=runtime-interp --timeout=160m make -w -C mono/tests -k testinterp V=1 CI=1 CI_PR=$([[ ${CI_TAGS} == *'pull-request'* ]] && echo 1 || true)
+${TESTCMD} --label=compile-runtime-tests --timeout=40m make -w -C mono/tests -j ${CI_CPU_COUNT} test
+${TESTCMD} --label=runtime-interp --timeout=160m make -w -C mono/tests -k testinterp V=1
 ${TESTCMD} --label=corlib --timeout=160m make -w -C mcs/class/corlib run-test V=1
 ${TESTCMD} --label=System --timeout=160m bash -c "export MONO_TLS_PROVIDER=legacy && make -w -C mcs/class/System run-test V=1"
 ${TESTCMD} --label=System.Core --timeout=160m make -w -C mcs/class/System.Core run-test V=1

--- a/scripts/ci/run-test-mac-sdk.sh
+++ b/scripts/ci/run-test-mac-sdk.sh
@@ -12,7 +12,7 @@ zip ${MONO_REPO_ROOT}/msbuild-test-results.zip artifacts/2/Release-MONO/TestResu
 
 # Bundled LLVM
 cd ${MONO_REPO_ROOT}/external/bockbuild/builds/mono
-${TESTCMD} --label="runtime-tests-llvm" --timeout=240m make -C mono/tests -k test-wrench MONO_ENV_OPTIONS=--llvm V=1 CI=1 M=1
+${TESTCMD} --label="runtime-tests-llvm" --timeout=240m make -C mono/tests -k test-wrench MONO_ENV_OPTIONS=--llvm V=1 M=1
 ${TESTCMD} --label="corlib-tests-llvm" --timeout=60m make -C mcs/class/corlib run-test PLATFORM_TEST_HARNESS_EXCLUDES=NotOnMac,MacNotWorking,LLVMNotWorking, MONO_ENV_OPTIONS=--llvm
 
 # Bundled libgdiplus

--- a/scripts/ci/run-test-stress-tests.sh
+++ b/scripts/ci/run-test-stress-tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 
-${TESTCMD} --label=check-stress --timeout=12h make -w -C mono/tests -k check-stress V=1 CI=1
+${TESTCMD} --label=check-stress --timeout=12h make -w -C mono/tests -k check-stress V=1

--- a/scripts/ci/run-test-testing_aot_full.sh
+++ b/scripts/ci/run-test-testing_aot_full.sh
@@ -12,7 +12,7 @@ else
 ${TESTCMD} --label=mini --timeout=25m make -j ${CI_CPU_COUNT} -w -C mono/mini -k fullaotcheck
 fi
 
-${TESTCMD} --label=runtime --timeout=160m make -w -C mono/tests -k test-wrench V=1 CI=1
+${TESTCMD} --label=runtime --timeout=160m make -w -C mono/tests -k test-wrench V=1
 ${TESTCMD} --label=corlib --timeout=30m make -w -C mcs/class/corlib run-test
 ${TESTCMD} --label=verify --timeout=15m make -w -C runtime mcs-compileall
 ${TESTCMD} --label=profiler --timeout=30m make -w -C mono/profiler -k check

--- a/scripts/ci/run-test-testing_aot_full_interp.sh
+++ b/scripts/ci/run-test-testing_aot_full_interp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-${TESTCMD} --label=runtime --timeout=160m make -w -C mono/tests -k testfullaotinterp V=1 CI=1
+${TESTCMD} --label=runtime --timeout=160m make -w -C mono/tests -k testfullaotinterp V=1
 
 # FIXME
 #${TESTCMD} --label=corlib --timeout=30m make -w -C mcs/class/corlib run-test

--- a/scripts/ci/run-test-testing_aot_hybrid.sh
+++ b/scripts/ci/run-test-testing_aot_hybrid.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 ${TESTCMD} --label=mini --timeout=25m make -j ${CI_CPU_COUNT} -w -C mono/mini -k aotcheck
-${TESTCMD} --label=runtime --timeout=160m make -w -C mono/tests -k test-wrench V=1 CI=1
+${TESTCMD} --label=runtime --timeout=160m make -w -C mono/tests -k test-wrench V=1
 ${TESTCMD} --label=corlib --timeout=30m make -w -C mcs/class/corlib run-test
 ${TESTCMD} --label=verify --timeout=15m make -w -C runtime mcs-compileall
 ${TESTCMD} --label=profiler --timeout=30m make -w -C mono/profiler -k check

--- a/scripts/ci/run-test-winaot.sh
+++ b/scripts/ci/run-test-winaot.sh
@@ -7,7 +7,7 @@ else
 ${TESTCMD} --label=mini --timeout=25m make -j ${CI_CPU_COUNT} -w -C mono/mini -k fullaotcheck
 fi
 
-${TESTCMD} --label=runtime --timeout=160m make -w -C mono/tests -k test-wrench V=1 CI=1
+${TESTCMD} --label=runtime --timeout=160m make -w -C mono/tests -k test-wrench V=1
 ${TESTCMD} --label=corlib --timeout=30m make -w -C mcs/class/corlib run-test
 ${TESTCMD} --label=verify --timeout=15m make -w -C runtime mcs-compileall
 ${TESTCMD} --label=profiler --timeout=30m make -w -C mono/profiler -k check


### PR DESCRIPTION
So we can precompile all tests across the repo using a simple "make test" in the root.

This is necessary for some upcoming Helix work.