### PR TITLE
Updating GenAPI binaries

### DIFF
--- a/mcs/Makefile
+++ b/mcs/Makefile
@@ -148,7 +148,7 @@ distcheck: dist-tarball
 # Targets for creating API diffs of the framework
 
 MONO_API_SNAPSHOT_PATH := $(topdir)../external/api-snapshot/
-GENAPI := $(MONO_API_SNAPSHOT_PATH)tools/genapi/GenAPI.exe
+GENAPI := $(MONO_API_SNAPSHOT_PATH)tools/genapi/Microsoft.DotNet.GenAPI.exe
 MONO_API_SNAPSHOT_PROFILE_PATH := $(MONO_API_SNAPSHOT_PATH)profiles/$(PROFILE)/
 MONO_API_ASSEMBLIES_IGNORED := $(addprefix $(topdir)class/lib/$(PROFILE)/, Mono.CSharp.dll SystemWebTestShim.dll standalone-runner-support.dll nunit.core.dll nunit.core.extensions.dll nunit.core.interfaces.dll nunit.framework.dll nunit.framework.extensions.dll nunit.mocks.dll nunit.util.dll nunit-console-runner.dll nunitlite.dll Mono.Profiler.Log.dll)
 MONO_API_ASSEMBLIES := $(filter-out $(MONO_API_ASSEMBLIES_IGNORED), $(wildcard $(topdir)class/lib/$(PROFILE)/*.dll)) $(wildcard $(topdir)class/lib/$(PROFILE)/Facades/*.dll)


### PR DESCRIPTION
Bumping api-snapshot submodule which brings in a newly
built GenAPI binaries along with a rename of the exe
to Microsoft.DotNet.GenAPI.exe