### PR TITLE
Fix starting process with empty environment incorrectly inherits all variables

### DIFF
--- a/mcs/class/System/System.Diagnostics/Process.cs
+++ b/mcs/class/System/System.Diagnostics/Process.cs
@@ -691,22 +691,15 @@ namespace System.Diagnostics
 
 			if (startInfo.HaveEnvVars) {
 				List<string> envVariables = new List<string> ();
-				StringBuilder sb = null;
 
 				foreach (DictionaryEntry de in startInfo.EnvironmentVariables) {
 					if (de.Value == null)
 						continue;
 
-					if (sb == null)
-						sb = new StringBuilder ();
-					else
-						sb.Clear ();
-
-					sb.Append ((string) de.Key);
-					sb.Append ('=');
-					sb.Append ((string) de.Value);
-
-					envVariables.Add (sb.ToString ());
+					envVariables.Add (string.Concat (
+						(string) de.Key,
+						"=",
+						(string) de.Value));
 				}
 
 				procInfo.envVariables = envVariables.ToArray ();

--- a/mcs/class/System/System.Diagnostics/Process.cs
+++ b/mcs/class/System/System.Diagnostics/Process.cs
@@ -690,15 +690,12 @@ namespace System.Diagnostics
 			var procInfo = new ProcInfo ();
 
 			if (startInfo.HaveEnvVars) {
-				List<string> envVariables = null;
+				List<string> envVariables = new List<string> ();
 				StringBuilder sb = null;
 
 				foreach (DictionaryEntry de in startInfo.EnvironmentVariables) {
 					if (de.Value == null)
 						continue;
-
-					if (envVariables == null)
-						envVariables = new List<string> ();
 
 					if (sb == null)
 						sb = new StringBuilder ();
@@ -712,7 +709,7 @@ namespace System.Diagnostics
 					envVariables.Add (sb.ToString ());
 				}
 
-				procInfo.envVariables = envVariables?.ToArray ();
+				procInfo.envVariables = envVariables.ToArray ();
 			}
 
 			MonoIOError error;

--- a/mcs/class/System/Test/System.Diagnostics/ProcessTest.cs
+++ b/mcs/class/System/Test/System.Diagnostics/ProcessTest.cs
@@ -734,6 +734,53 @@ namespace MonoTests.System.Diagnostics
 
 		[Test]
 		[NUnit.Framework.Category ("MobileNotWorking")]
+		public void TestEnvironmentVariablesClearedDoNotInherit ()
+		{
+			if (!RunningOnUnix)
+				Assert.Ignore ("env not available on Windows");
+
+			var stdout = new StringBuilder ();
+
+			Process p = new Process ();
+			p.StartInfo = new ProcessStartInfo ("/usr/bin/env");
+			p.StartInfo.UseShellExecute = false;
+			p.StartInfo.RedirectStandardOutput = true;
+			p.OutputDataReceived += (s, e) => { if (e.Data != null) stdout.AppendLine (e.Data); };
+			p.StartInfo.Environment.Clear (); // i.e. don't inherit
+			p.StartInfo.Environment["HELLO"] = "123";
+
+			p.Start ();
+			p.BeginOutputReadLine ();
+			p.WaitForExit ();
+
+			Assert.AreEqual ("HELLO=123\n", stdout.ToString ());
+		}
+
+		[Test]
+		[NUnit.Framework.Category ("MobileNotWorking")]
+		public void TestEnvironmentVariablesClearedDoNotInheritEmpty ()
+		{
+			if (!RunningOnUnix)
+				Assert.Ignore ("env not available on Windows");
+
+			var stdout = new StringBuilder ();
+
+			Process p = new Process ();
+			p.StartInfo = new ProcessStartInfo ("/usr/bin/env");
+			p.StartInfo.UseShellExecute = false;
+			p.StartInfo.RedirectStandardOutput = true;
+			p.OutputDataReceived += (s, e) => { if (e.Data != null)	stdout.AppendLine (e.Data); };
+			p.StartInfo.Environment.Clear (); // i.e. don't inherit
+
+			p.Start ();
+			p.BeginOutputReadLine ();
+			p.WaitForExit ();
+
+			Assert.AreEqual ("", stdout.ToString ());
+		}
+
+		[Test]
+		[NUnit.Framework.Category ("MobileNotWorking")]
 		// This was for bug #459450
 		public void TestEventRaising ()
 		{


### PR DESCRIPTION
This pull request fixes starting a process with an empty environment variable collection in `ProcessStartInfo`. As per the issue it fixes a regression that it used to work but currently an empty environment variable collection works like it was never touched.

I also made a minor fix to remove the `StringBuilder` because a simple `string.Concat` does the job without the `StringBuilder` allocation and overhead.

I've included unit tests. Please let me know if you'd like any changes.

Fixes #8766