### PR TITLE
Add tools/scripts for running tests in Helix environment

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -62,3 +62,6 @@
 	path = external/llvm
 	url = git://github.com/mono/llvm.git
 	branch = release_60
+[submodule "external/helix-binaries"]
+	path = external/helix-binaries
+	url = git://github.com/mono/helix-binaries.git

--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,7 @@ AM_INIT_AUTOMAKE([1.9 dist-bzip2 tar-ustar no-dist-gzip foreign subdir-objects]
 AC_CONFIG_HEADERS([config.h])
 AM_MAINTAINER_MODE
 AM_EXTRA_RECURSIVE_TARGETS([test])
+AM_EXTRA_RECURSIVE_TARGETS([test-bundle])
 
 API_VER=2.0
 AC_SUBST(API_VER)

--- a/libgc/Makefile.am
+++ b/libgc/Makefile.am
@@ -186,3 +186,5 @@ EXTRA_DIST += configure.host
 	if $(CPP) $< >$@ ; then :; else rm -f $@; fi
 
 test:
+
+test-bundle:

--- a/mcs/errors/Makefile
+++ b/mcs/errors/Makefile
@@ -62,6 +62,13 @@ TESTER = MONO_RUNTIME='$(RUNTIME)' $(TEST_RUNTIME) $(TEST_RUNTIME_FLAGS) $(LOCAL
 
 test-local: $(TEST_SUPPORT_FILES)
 
+test-bundle:
+	mkdir -p $(TEST_BUNDLE_PATH)/tests/mcs-errors
+	cp -L -R dlls $(TEST_BUNDLE_PATH)/tests/mcs-errors/
+	cp -L *.cs *.inc *.dll *.snk *.pub $(TEST_BUNDLE_PATH)/tests/mcs-errors/
+	cp -L $(topdir)/class/lib/$(PROFILE)/compiler-tester.* $(TEST_BUNDLE_PATH)/tests/mcs-errors/
+	cp -L known-issues-$(PROFILE) $(TEST_BUNDLE_PATH)/tests/mcs-errors/known-issues-$(PROFILE)
+
 run-mcs-tests: test-local
 	$(TESTER) -mode:neg -files:$(TEST_PATTERN) -compiler:$(COMPILER) -reference-dir:$(topdir)/class/lib/$(PROFILE) -issues:known-issues-$(PROFILE) -log:$(PROFILE).log $(TESTER_OPTIONS) $(TOPTIONS)
 

--- a/mcs/packages/Makefile
+++ b/mcs/packages/Makefile
@@ -57,6 +57,10 @@ test-csi:
 	cat csi-test-output.txt && grep -q "hello world" csi-test-output.txt
 	rm csi-test-output.txt
 
+test-bundle:
+	mkdir -p $(TEST_BUNDLE_PATH)/tests/csi
+	cp -L $(ROSLYN_CSC_DIR)/* $(TEST_BUNDLE_PATH)/tests/csi/
+
 endif
 
 dist-local: dist-default

--- a/mcs/tests/Makefile
+++ b/mcs/tests/Makefile
@@ -86,6 +86,14 @@ run-test-local: test-local qcheck
 
 check: run-test-local
 
+test-bundle:
+	mkdir -p $(TEST_BUNDLE_PATH)/tests/mcs
+	cp -L -R dlls $(TEST_BUNDLE_PATH)/tests/mcs/
+	cp -L *.cs *.xml *.inc *.dll *.snk $(TEST_BUNDLE_PATH)/tests/mcs/
+	cp -L $(topdir)/class/lib/$(PROFILE)/compiler-tester.* $(TEST_BUNDLE_PATH)/tests/mcs/
+	cp -L $(KNOWN_ISSUES) $(TEST_BUNDLE_PATH)/tests/mcs/$(KNOWN_ISSUES)
+	cp -L ver-il-$(PROFILE).xml $(TEST_BUNDLE_PATH)/tests/mcs/ver-il-$(PROFILE).xml
+
 endif
 
 clean-local:

--- a/mcs/tools/Makefile
+++ b/mcs/tools/Makefile
@@ -51,7 +51,7 @@ net_4_5_dirs := \
 	gacutil
 
 build_SUBDIRS =
-build_PARALLEL_SUBDIRS := resgen gacutil security culevel upload-to-sentry commoncryptogenerator resx2sr linker cil-strip corcompare mono-api-diff mono-api-html
+build_PARALLEL_SUBDIRS := resgen gacutil security culevel upload-to-sentry mono-helix-client commoncryptogenerator resx2sr linker cil-strip corcompare mono-api-diff mono-api-html
 monodroid_tools_SUBDIRS =
 monodroid_tools_PARALLEL_SUBDIRS = cil-strip linker-analyzer mkbundle mdoc mono-symbolicate mono-api-diff mono-api-html
 monodroid_SUBDIRS = nunit-lite
@@ -61,7 +61,7 @@ net_4_x_PARALLEL_SUBDIRS = $(net_4_5_dirs)
 wasm_tools_SUBDIRS =
 wasm_tools_PARALLEL_SUBDIRS = linker
 
-DIST_SUBDIRS = $(net_4_5_dirs) cil-stringreplacer commoncryptogenerator resx2sr gensources upload-to-sentry
+DIST_SUBDIRS = $(net_4_5_dirs) cil-stringreplacer commoncryptogenerator resx2sr gensources upload-to-sentry mono-helix-client
 
 include ../build/rules.make
 

--- a/mcs/tools/mono-helix-client/HelixBase.cs
+++ b/mcs/tools/mono-helix-client/HelixBase.cs
@@ -1,0 +1,155 @@
+//
+// HelixBase.cs
+//
+// Authors:
+//	Alexander Köplinger  <alkpli@microsoft.com>
+//
+// Copyright (C) 2018 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Helix.Client;
+
+public class HelixBase
+{
+    protected IHelixApi _api;
+
+    public HelixBase ()
+    {
+        _api = ApiFactory.GetAuthenticated (GetEnvironmentVariable ("MONO_HELIX_API_KEY"));
+    }
+
+    protected string GetEnvironmentVariable (string variable)
+    {
+        return Environment.GetEnvironmentVariable (variable) ?? throw new ArgumentException ($"No value for '{variable}'.");
+    }
+
+    protected string McUrlEncode (string input)
+    {
+        // encodes the URL in a way Mission Control understands (% replaced with ~)
+        var result = WebUtility.UrlEncode (input);
+        return result.Replace ("%", "~");
+    }
+
+    public async Task<bool> WaitForJobCompletion (string correlationId)
+    {
+        bool success = false;
+        bool printedMcLink = false;
+
+        Console.WriteLine ($"Waiting for job '{correlationId}' to finish...");
+
+        int sleepTime = 0;
+
+        while (true)
+        {
+            await Task.Delay (sleepTime);
+            sleepTime = Math.Min (30000, sleepTime + 10000);
+
+            var statusContent = await _api.Job.DetailsAsync (correlationId);
+            if (String.IsNullOrEmpty (statusContent.JobList))
+            {
+                Console.WriteLine ("Job list isn't available yet.");
+                continue;
+            }
+
+            if (!printedMcLink)
+            {
+                var mcResultsUrl = $"https://mc.dot.net/#/user/{McUrlEncode (statusContent.Creator)}/{McUrlEncode (statusContent.Source)}/{McUrlEncode (statusContent.Type)}/{McUrlEncode (statusContent.Build)}";
+                Console.WriteLine ($"View test results on Mission Control: {mcResultsUrl}");
+                printedMcLink = true;
+            }
+
+            var isFinished = statusContent.WorkItems.Unscheduled == 0 &&
+                             statusContent.WorkItems.Waiting == 0 &&
+                             statusContent.WorkItems.Running == 0;
+
+            if (isFinished)
+            {
+                Console.WriteLine ("Job finished, fetching results...");
+
+                var resultsContent = (await _api.Aggregate.JobSummaryMethodAsync (new List<string> { "job.name" }, maxResultSets: 1, filtername: correlationId));
+
+                if (resultsContent.Count != 1)
+                    throw new InvalidOperationException ("No results found for job.");
+
+                resultsContent[0].Validate ();
+
+                var resultData = resultsContent[0].Data;
+                var workItemStatus = resultData.WorkItemStatus;
+                var analyses = resultData.Analysis;
+
+                if (workItemStatus.ContainsKey ("none"))
+                {
+                    Console.WriteLine ($"Still processing xunit data from {workItemStatus["none"]} work items. Stay tuned.");
+                    continue;
+                }
+
+                if (analyses.Count > 0)
+                {
+                    if (analyses.Count > 1)
+                        throw new InvalidOperationException ("Job contains multiple analyses, this shouldn't happen.");
+
+                    var analysis = analyses[0];
+
+                    if (analysis.Name != "xunit")
+                        throw new InvalidOperationException ($"Job contains unknown analysis '{analysis.Name}', this shouldn't happen.");
+
+                    if (analysis.Status == null)
+                        throw new InvalidOperationException ($"Job contains no status for analysis '{analysis.Name}', this shouldn't happen.");
+
+                    analysis.Status.TryGetValue ("pass", out int? pass);
+                    analysis.Status.TryGetValue ("skip", out int? skip);
+                    analysis.Status.TryGetValue ("fail", out int? fail);
+                    int? total = pass + skip + fail;
+
+                    if (total == null || total == 0)
+                        throw new InvalidOperationException ($"Job contains no test results, this shouldn't happen.");
+
+                    Console.WriteLine ("");
+                    Console.WriteLine ($"Tests run: {total}, Passed: {pass ?? 0}, Errors: 0, Failures: {fail ?? 0}, Inconclusive: 0");
+                    Console.WriteLine ($"  Not run: {skip ?? 0}, Invalid: 0, Ignored: 0, Skipped: {skip ?? 0}");
+                    Console.WriteLine ("");
+
+                    success = (fail == 0);
+                }
+
+                if (workItemStatus.ContainsKey ("fail"))
+                {
+                    success = false;
+                    Console.WriteLine ($"{workItemStatus["fail"]} work items failed.");
+                }
+            }
+            else
+            {
+                Console.WriteLine ($"Waiting for work items to finish: Unscheduled: {statusContent.WorkItems.Unscheduled}, Waiting: {statusContent.WorkItems.Waiting}, Running: {statusContent.WorkItems.Running}");
+                continue;
+            }
+
+            Console.WriteLine ($"Job {(success ? "SUCCEEDED" : "FAILED")}.");
+            return success;
+        }
+    }
+}

--- a/mcs/tools/mono-helix-client/HelixTestBase.cs
+++ b/mcs/tools/mono-helix-client/HelixTestBase.cs
@@ -44,7 +44,6 @@ public abstract class HelixTestBase : HelixBase
 
         _job = build
                     .WithTargetQueue (GetEnvironmentVariable ("MONO_HELIX_TARGET_QUEUE"))
-                    .WithCreator (GetEnvironmentVariable ("MONO_HELIX_CREATOR"))
                     .WithCorrelationPayloadDirectory (GetEnvironmentVariable ("MONO_HELIX_TEST_PAYLOAD_DIRECTORY"))
                     .WithCorrelationPayloadFiles (GetEnvironmentVariable ("MONO_HELIX_XUNIT_REPORTER_PATH"))
                     // these are well-known properties used by Mission Control

--- a/mcs/tools/mono-helix-client/HelixTestBase.cs
+++ b/mcs/tools/mono-helix-client/HelixTestBase.cs
@@ -1,0 +1,89 @@
+//
+// HelixTestBase.cs
+//
+// Authors:
+//	Alexander Köplinger  <alkpli@microsoft.com>
+//
+// Copyright (C) 2018 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Helix.Client;
+
+public abstract class HelixTestBase : HelixBase
+{
+    IJobDefinition _job;
+
+    protected HelixTestBase (string helixType) : base ()
+    {
+        var build = _api.Job.Define ()
+            .WithSource (GetEnvironmentVariable ("MONO_HELIX_SOURCE"))
+            .WithType (helixType)
+            .WithBuild (GetEnvironmentVariable ("MONO_HELIX_BUILD_MONIKER"));
+
+        _job = build
+                    .WithTargetQueue (GetEnvironmentVariable ("MONO_HELIX_TARGET_QUEUE"))
+                    .WithCreator (GetEnvironmentVariable ("MONO_HELIX_CREATOR"))
+                    .WithCorrelationPayloadDirectory (GetEnvironmentVariable ("MONO_HELIX_TEST_PAYLOAD_DIRECTORY"))
+                    .WithCorrelationPayloadFiles (GetEnvironmentVariable ("MONO_HELIX_XUNIT_REPORTER_PATH"))
+                    // these are well-known properties used by Mission Control
+                    .WithProperty ("architecture", GetEnvironmentVariable ("MONO_HELIX_ARCHITECTURE"))
+                    .WithProperty ("operatingSystem", GetEnvironmentVariable ("MONO_HELIX_OPERATINGSYSTEM"));
+    }
+
+    protected void CreateWorkItem (string name, string command, int timeoutInSeconds)
+    {
+        _job.DefineWorkItem (name)
+            .WithCommand ($"chmod +x $HELIX_CORRELATION_PAYLOAD/mono-test.sh; $HELIX_CORRELATION_PAYLOAD/mono-test.sh {command}; exit_code=$1; $HELIX_PYTHONPATH $HELIX_CORRELATION_PAYLOAD/xunit-reporter.py; exit $exit_code")
+            .WithEmptyPayload ()
+            .WithTimeout (TimeSpan.FromSeconds (timeoutInSeconds))
+            .AttachToJob ();
+    }
+
+    protected void CreateCustomWorkItem (string suite, int timeoutInSeconds = 900)
+    {
+        CreateWorkItem (suite, $"--{suite}", timeoutInSeconds);
+    }
+
+    protected void CreateNunitWorkItem (string assembly, string profile = "net_4_x", int timeoutInSeconds = 900)
+    {
+        var flakyTestRetries = Environment.GetEnvironmentVariable ("MONO_FLAKY_TEST_RETRIES") ?? "0";
+        CreateWorkItem (assembly, $"--nunit {profile}/tests/{assembly} --flaky-test-retries={flakyTestRetries}", timeoutInSeconds);
+    }
+
+    protected void CreateXunitWorkItem (string assembly, string profile = "net_4_x", int timeoutInSeconds = 900)
+    {
+        CreateWorkItem (assembly, $"--xunit {profile}/tests/{assembly}", timeoutInSeconds);
+    }
+
+    public async Task<string> SendJob ()
+    {
+        Console.WriteLine ($"Sending job to Helix...");
+        var sentJob = await _job.SendAsync ();
+
+        Console.WriteLine ($"Job '{sentJob.CorrelationId}' created.");
+
+        return sentJob.CorrelationId;
+    }
+}

--- a/mcs/tools/mono-helix-client/MainlineTests.cs
+++ b/mcs/tools/mono-helix-client/MainlineTests.cs
@@ -1,0 +1,157 @@
+//
+// MainlineTests.cs
+//
+// Authors:
+//	Alexander Köplinger  <alkpli@microsoft.com>
+//
+// Copyright (C) 2018 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+
+public class MainlineTests : HelixTestBase
+{
+    public MainlineTests () : base ("test/mainline/")
+    {
+    }
+
+    public HelixTestBase CreateJob ()
+    {
+        // xunit tests
+        CreateXunitWorkItem ("net_4_x_corlib_xunit-test.dll");
+        CreateXunitWorkItem ("net_4_x_System_xunit-test.dll");
+        CreateXunitWorkItem ("net_4_x_System.Xml_xunit-test.dll");
+        CreateXunitWorkItem ("net_4_x_System.Xml.Linq_xunit-test.dll");
+        CreateXunitWorkItem ("net_4_x_System.Threading.Tasks.Dataflow_xunit-test.dll");
+        CreateXunitWorkItem ("net_4_x_System.Security_xunit-test.dll");
+        CreateXunitWorkItem ("net_4_x_System.Runtime.Serialization_xunit-test.dll");
+        CreateXunitWorkItem ("net_4_x_System.Runtime.CompilerServices.Unsafe_xunit-test.dll");
+        CreateXunitWorkItem ("net_4_x_System.Numerics_xunit-test.dll");
+        CreateXunitWorkItem ("net_4_x_System.Json_xunit-test.dll");
+        CreateXunitWorkItem ("net_4_x_System.Drawing_xunit-test.dll");
+        CreateXunitWorkItem ("net_4_x_System.Data_xunit-test.dll");
+        CreateXunitWorkItem ("net_4_x_System.Core_xunit-test.dll");
+        CreateXunitWorkItem ("net_4_x_System.ComponentModel.Composition_xunit-test.dll");
+        CreateXunitWorkItem ("net_4_x_Mono.Profiler.Log_xunit-test.dll");
+        CreateXunitWorkItem ("net_4_x_Microsoft.CSharp_xunit-test.dll");
+
+        // NUnit tests
+        CreateNunitWorkItem ("net_4_x_corlib_test.dll");
+        CreateNunitWorkItem ("net_4_x_WindowsBase_test.dll");
+        CreateNunitWorkItem ("net_4_x_WebMatrix.Data_test.dll");
+        CreateNunitWorkItem ("net_4_x_System_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Xml_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Xml.Linq_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Xaml_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Windows.Forms_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Windows.Forms.DataVisualization_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Web_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Web.Services_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Web.Routing_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Web.Extensions_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Web.DynamicData_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Web.Abstractions_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Transactions_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Threading.Tasks.Dataflow_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.ServiceProcess_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.ServiceModel_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.ServiceModel.Web_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.ServiceModel.Discovery_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Security_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Runtime.Serialization_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Runtime.Serialization.Formatters.Soap_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Runtime.Remoting_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Runtime.DurableInstancing_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Runtime.Caching_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Numerics_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Net.Http_test.dll");
+        //CreateNunitWorkItem ("net_4_x_System.Messaging_test.dll"); // needs RabbitMQ installed and hangs on process exit
+        CreateNunitWorkItem ("net_4_x_System.Json_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Json.Microsoft_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.IdentityModel_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.IO.Compression_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.IO.Compression.FileSystem_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Drawing_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.DirectoryServices_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Design_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Data_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Data.Services_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Data.OracleClient_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Data.Linq_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Data.DataSetExtensions_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Core_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.Configuration_test.dll");
+        CreateNunitWorkItem ("net_4_x_System.ComponentModel.DataAnnotations_test.dll");
+        //CreateNunitWorkItem("net_4_x_monodoc_test.dll");  // fails one test and needs to get rid of CallerFilePath to locate test resources
+        CreateNunitWorkItem ("net_4_x_Novell.Directory.Ldap_test.dll");
+        CreateNunitWorkItem ("net_4_x_Mono.XBuild.Tasks_test.dll");
+        CreateNunitWorkItem ("net_4_x_Mono.Tasklets_test.dll");
+        CreateNunitWorkItem ("net_4_x_Mono.Security_test.dll");
+        CreateNunitWorkItem ("net_4_x_Mono.Runtime.Tests_test.dll");
+        CreateNunitWorkItem ("net_4_x_Mono.Posix_test.dll");
+        CreateNunitWorkItem ("net_4_x_Mono.Parallel_test.dll");
+        CreateNunitWorkItem ("net_4_x_Mono.Options_test.dll");
+        CreateNunitWorkItem ("net_4_x_Mono.Messaging_test.dll");
+        CreateNunitWorkItem ("net_4_x_Mono.Messaging.RabbitMQ_test.dll");
+        CreateNunitWorkItem ("net_4_x_Mono.Debugger.Soft_test.dll");
+        CreateNunitWorkItem ("net_4_x_Mono.Data.Tds_test.dll");
+        CreateNunitWorkItem ("net_4_x_Mono.Data.Sqlite_test.dll");
+        CreateNunitWorkItem ("net_4_x_Mono.CodeContracts_test.dll");
+        CreateNunitWorkItem ("net_4_x_Mono.CSharp_test.dll");
+        CreateNunitWorkItem ("net_4_x_Mono.C5_test.dll");
+        CreateNunitWorkItem ("net_4_x_I18N.West_test.dll");
+        CreateNunitWorkItem ("net_4_x_I18N.Rare_test.dll");
+        CreateNunitWorkItem ("net_4_x_I18N.Other_test.dll");
+        CreateNunitWorkItem ("net_4_x_I18N.MidEast_test.dll");
+        CreateNunitWorkItem ("net_4_x_I18N.CJK_test.dll");
+        CreateNunitWorkItem ("net_4_x_Cscompmgd_test.dll");
+        CreateNunitWorkItem ("net_4_x_Commons.Xml.Relaxng_test.dll");
+        CreateNunitWorkItem ("net_4_x_Microsoft.Build_test.dll");
+        CreateNunitWorkItem ("net_4_x_Microsoft.Build.Utilities_test.dll");
+        CreateNunitWorkItem ("net_4_x_Microsoft.Build.Tasks_test.dll");
+        CreateNunitWorkItem ("net_4_x_Microsoft.Build.Framework_test.dll");
+        CreateNunitWorkItem ("net_4_x_Microsoft.Build.Engine_test.dll");
+        CreateNunitWorkItem ("xbuild_12_Microsoft.Build_test.dll", profile: "xbuild_12");
+        CreateNunitWorkItem ("xbuild_12_Microsoft.Build.Utilities_test.dll", profile: "xbuild_12");
+        CreateNunitWorkItem ("xbuild_12_Microsoft.Build.Tasks_test.dll", profile: "xbuild_12");
+        CreateNunitWorkItem ("xbuild_12_Microsoft.Build.Framework_test.dll", profile: "xbuild_12");
+        CreateNunitWorkItem ("xbuild_12_Microsoft.Build.Engine_test.dll", profile: "xbuild_12");
+        CreateNunitWorkItem ("xbuild_14_Microsoft.Build_test.dll", profile: "xbuild_14");
+        CreateNunitWorkItem ("xbuild_14_Microsoft.Build.Utilities_test.dll", profile: "xbuild_14");
+        CreateNunitWorkItem ("xbuild_14_Microsoft.Build.Tasks_test.dll", profile: "xbuild_14");
+        CreateNunitWorkItem ("xbuild_14_Microsoft.Build.Framework_test.dll", profile: "xbuild_14");
+        CreateNunitWorkItem ("xbuild_14_Microsoft.Build.Engine_test.dll", profile: "xbuild_14");
+
+        // custom test suites
+        CreateCustomWorkItem ("mcs", timeoutInSeconds: 1800);
+        CreateCustomWorkItem ("mcs-errors", timeoutInSeconds: 1800);
+        CreateCustomWorkItem ("verify");
+        CreateCustomWorkItem ("aot-test", timeoutInSeconds: 1800);
+        CreateCustomWorkItem ("mini");
+        CreateCustomWorkItem ("symbolicate");
+        CreateCustomWorkItem ("csi");
+        CreateCustomWorkItem ("profiler");
+        CreateCustomWorkItem ("runtime", timeoutInSeconds: 1800);
+
+        return this;
+    }
+}

--- a/mcs/tools/mono-helix-client/Makefile
+++ b/mcs/tools/mono-helix-client/Makefile
@@ -1,0 +1,20 @@
+thisdir = tools/mono-helix-client
+SUBDIRS = 
+include ../../build/rules.make
+
+PROGRAM = mono-helix-client.exe
+NO_INSTALL = yes
+
+LIB_REFS = System System.Net.Http Facades/netstandard
+helix_binaries = $(topdir)/../external/helix-binaries
+LOCAL_MCS_FLAGS = -r:$(helix_binaries)/Microsoft.DotNet.Helix.Client.dll -r:$(helix_binaries)/Microsoft.DotNet.Helix.JobSender.dll -r:$(helix_binaries)/Microsoft.Rest.ClientRuntime.dll
+
+with_helix_client = MONO_PATH="$(helix_binaries)$(PLATFORM_PATH_SEPARATOR)$(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)" $(RUNTIME) $(RUNTIME_FLAGS) $(topdir)/class/lib/$(BUILD_TOOLS_PROFILE)/mono-helix-client.exe
+
+upload-to-helix:
+	MONO_HELIX_XUNIT_REPORTER_PATH="$(abspath $(helix_binaries)/xunit-reporter.py)" $(with_helix_client) --tests="$(MONO_HELIX_TYPE)" --correlationIdFile="$(MONO_HELIX_CORRELATION_ID_FILE)"
+
+wait-for-job-completion:
+	$(with_helix_client) --wait="$(MONO_HELIX_CORRELATION_ID)"
+
+include ../../build/executable.make

--- a/mcs/tools/mono-helix-client/mono-helix-client.cs
+++ b/mcs/tools/mono-helix-client/mono-helix-client.cs
@@ -1,0 +1,78 @@
+//
+// mono-helix-client.cs
+//
+// Authors:
+//	Alexander Köplinger  <alkpli@microsoft.com>
+//
+// Copyright (C) 2018 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+public class Program
+{
+    public static int Main (string[] args)
+    {
+        return MainAsync (args).GetAwaiter ().GetResult ();
+    }
+
+    public static async Task<int> MainAsync (string[] args)
+    {
+        string tests = "";
+        string correlationId = "";
+        string correlationIdFile = "";
+        bool waitForJobCompletion = false;
+
+        var options = new Mono.Options.OptionSet {
+            { "tests=", "Tests to run", param => { if (param != null) tests = param; } },
+            { "correlationIdFile=", "File to write correlation ID to", param => { if (param != null) correlationIdFile = param; } },
+            { "wait=", "Wait for job to complete", param => { if (param != null) { correlationId = param; waitForJobCompletion = true; } } },
+        };
+
+        try {
+            options.Parse (args);
+        } catch (Mono.Options.OptionException e) {
+            Console.WriteLine ("Option error: {0}", e.Message);
+            return 1;
+        }
+
+        if (tests == "mainline") {
+            var t = new MainlineTests ();
+            correlationId = await t.CreateJob ().SendJob ();
+
+            if (!String.IsNullOrEmpty (correlationIdFile))
+                File.WriteAllText (correlationIdFile, correlationId);
+
+            return 0;
+        }
+
+        if (waitForJobCompletion) {
+            var success = await new HelixBase ().WaitForJobCompletion (correlationId);
+            return success ? 0 : 1;
+        }
+
+        Console.Error.WriteLine ("Error: Invalid arguments.");
+        return 1;
+    }
+}

--- a/mcs/tools/mono-helix-client/mono-helix-client.exe.sources
+++ b/mcs/tools/mono-helix-client/mono-helix-client.exe.sources
@@ -1,0 +1,5 @@
+HelixBase.cs
+HelixTestBase.cs
+MainlineTests.cs
+mono-helix-client.cs
+../../class/Mono.Options/Mono.Options/Options.cs

--- a/mcs/tools/mono-symbolicate/Makefile
+++ b/mcs/tools/mono-symbolicate/Makefile
@@ -58,6 +58,10 @@ AOT_SUPPORTED = $(shell $(MONO) --aot 2>&1 | grep -q "AOT compilation is not sup
 
 test-local: $(TEST_EXE)
 
+test-bundle:
+	mkdir -p $(TEST_BUNDLE_PATH)/tests/symbolicate
+	cp -L $(TEST_EXE) $(TEST_EXE:.exe=.pdb) $(SYMBOLICATE_EXPECTED_FILE) $(TEST_BUNDLE_PATH)/tests/symbolicate/
+
 $(TEST_EXE): $(TEST_CS)
 	$(CSCOMPILE) $(TEST_CS) -r:$(LIB_PATH)/mscorlib.dll -r:$(LIB_PATH)/System.Core.dll -warn:0 -out:$(TEST_EXE)
 

--- a/mono/btls/Makefile.am
+++ b/mono/btls/Makefile.am
@@ -80,3 +80,7 @@ if HOST_WIN32
 else
 	$(install_sh) build-shared/libmono-btls-shared.* "$(DESTDIR)$(libdir)"
 endif
+
+test-bundle-local:
+	mkdir -p $(TEST_BUNDLE_PATH)
+	cp -L build-shared/libmono-btls-shared$(libsuffix) $(TEST_BUNDLE_PATH)/

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -805,6 +805,16 @@ testi: mono test.exe
 
 test-local: $(regtests)
 
+test-bundle-local:
+	mkdir -p $(TEST_BUNDLE_PATH)/tests/mini
+	cp -L $(regtests) TestDriver.dll MemoryIntrinsics.dll generics-variant-types.dll $(TEST_BUNDLE_PATH)/tests/mini/
+	cp -L mono-sgen $(TEST_BUNDLE_PATH)/
+	chmod +x $(TEST_BUNDLE_PATH)/mono-sgen
+if SUPPORT_BOEHM
+	cp -L mono-boehm $(TEST_BUNDLE_PATH)/
+	chmod +x $(TEST_BUNDLE_PATH)/mono-boehm
+endif
+
 # ensure the tests are actually correct
 checktests: $(regtests)
 	for i in $(regtests); do $(MINI_RUNTIME) $$i; done

--- a/mono/native/Makefile.am
+++ b/mono/native/Makefile.am
@@ -115,4 +115,6 @@ libmono_native_unified_la_LDFLAGS = $(MONO_NATIVE_UNIFIED_LDFLAGS)
 
 libmono_native_unified_la_LIBADD = $(MONO_NATIVE_LIBADD)
 
-
+test-bundle-local:
+	mkdir -p $(TEST_BUNDLE_PATH)
+	cp -L .libs/libmono-native$(libsuffix) $(TEST_BUNDLE_PATH)/

--- a/mono/profiler/Makefile.am
+++ b/mono/profiler/Makefile.am
@@ -161,6 +161,14 @@ MCS = $(TOOLS_RUNTIME) $(CSC) -lib:$(CLASS) -unsafe -nologo -noconfig -nowarn:01
 
 test-local: $(PLOG_TESTS)
 
+test-bundle-local:
+	mkdir -p $(TEST_BUNDLE_PATH)/tests/profiler/
+	cp -L .libs/libmono-profiler-log$(libsuffix) $(TEST_BUNDLE_PATH)/
+	cp -L $(PLOG_TESTS) $(TEST_BUNDLE_PATH)/tests/profiler/
+	cp -L ptestrunner.pl $(TEST_BUNDLE_PATH)/tests/profiler/
+	cp -L mprof-report $(TEST_BUNDLE_PATH)/
+	chmod +x $(TEST_BUNDLE_PATH)/mprof-report
+
 run-test: test
 	MONO_PATH=$(CLASS) perl $(srcdir)/ptestrunner.pl $(top_builddir) nunit TestResult-profiler.xml
 

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1996,12 +1996,17 @@ test-env-options:
 	MONO_ENV_OPTIONS="--version" $(RUNTIME) array-init.exe | grep -q Architecture:
 
 TESTS_REGULAR = $(TESTS_CS) $(TESTS_IL) $(TESTS_BENCH)
-
-generate-regular-test-list:
-	@echo $(TESTS_REGULAR) > $(TEST_LIST_PATH)
+TESTS_INCL_DEPS = $(shell find . -type f -name "*.exe" -o -name "*.dll" -o -name "*.netmodule" -o -name "*.config")
 
 # Target to precompile the test executables
 test-local: $(TESTS_REGULAR) $(TESTS_STRESS) $(TESTS_GSHARED) $(TESTSAOT_CS) $(TESTSAOT_IL) $(TESTSAOT_BENCH) $(TESTSAOT_STRESS) $(TESTSAOT_GSHARED) $(TESTS_TAILCALL) $(TESTSAOT_TAILCALL) compile-gac-loading compile-assembly-load-reference test-runner.exe
+
+test-bundle-local:
+	mkdir -p $(addprefix $(TEST_BUNDLE_PATH)/tests/runtime/,$(sort $(dir $(TESTS_INCL_DEPS))))
+	@echo $(TESTS_REGULAR) > $(TEST_BUNDLE_PATH)/tests/runtime/runtime-test-list.txt
+	sed -e 's,$$mono_libdir,$$test_root_dir,g' tests-config > $(TEST_BUNDLE_PATH)/tests/runtime/tests-config.tmpl
+	cp -L .libs/libtest$(libsuffix) $(TEST_BUNDLE_PATH)/tests/runtime/
+	$(foreach asset,$(TESTS_INCL_DEPS),cp -L $(asset) $(TEST_BUNDLE_PATH)/tests/runtime/$(dir $(asset));)
 
 # Precompile the test assemblies in parallel
 compile-tests:

--- a/po/mcs/Makefile.in.in
+++ b/po/mcs/Makefile.in.in
@@ -445,3 +445,5 @@ force:
 .NOEXPORT:
 
 test:
+
+test-bundle:

--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -147,6 +147,31 @@ mcs-do-run-test-profiles: test-support-files
 mcs-do-xunit-run-test-profiles: test-support-files
 	cd $(mcs_topdir) && $(MAKE) NO_DIR_CHECK=1 PROFILES='$(test_profiles)' run-xunit-test-profiles
 
+test-bundle-local:
+	mkdir -p $(TEST_BUNDLE_PATH)/_tmpinst/bin
+	cp -L mono-test.sh $(TEST_BUNDLE_PATH)
+	cp -L -R etc $(TEST_BUNDLE_PATH)/_tmpinst
+	rm $(TEST_BUNDLE_PATH)/_tmpinst/etc/mono/config
+	sed -e 's,$$mono_libdir,$$test_root_dir,g' -e 's,target="$(libgdiplus_install_loc)",target="$$test_root_dir/mono-libgdiplus$(libsuffix)",g' $(top_builddir)/data/config > $(TEST_BUNDLE_PATH)/_tmpinst/etc/mono/config.tmpl
+	echo '#! /bin/sh' > $(TEST_BUNDLE_PATH)/_tmpinst/bin/al
+	echo '#! /bin/sh' > $(TEST_BUNDLE_PATH)/_tmpinst/bin/mcs
+	echo '#! /bin/sh' > $(TEST_BUNDLE_PATH)/_tmpinst/bin/ilasm
+	echo '"$$MONO_EXECUTABLE" $$(dirname "$$MONO_EXECUTABLE")/net_4_x/al.exe "$$@"' >> $(TEST_BUNDLE_PATH)/_tmpinst/bin/al
+	echo '"$$MONO_EXECUTABLE" $$(dirname "$$MONO_EXECUTABLE")/net_4_x/mcs.exe "$$@"' >> $(TEST_BUNDLE_PATH)/_tmpinst/bin/mcs
+	echo '"$$MONO_EXECUTABLE" $$(dirname "$$MONO_EXECUTABLE")/net_4_x/ilasm.exe "$$@"' >> $(TEST_BUNDLE_PATH)/_tmpinst/bin/ilasm
+	chmod +x $(TEST_BUNDLE_PATH)/_tmpinst/bin/al
+	chmod +x $(TEST_BUNDLE_PATH)/_tmpinst/bin/mcs
+	chmod +x $(TEST_BUNDLE_PATH)/_tmpinst/bin/ilasm
+	for profile in $(test_profiles); do \
+		cp -L -R $(mcs_topdir)/class/lib/$$profile $(TEST_BUNDLE_PATH); \
+	done
+	cp -L $(top_srcdir)/external/xunit-binaries/*.dll $(top_srcdir)/external/xunit-binaries/*.exe $(top_srcdir)/external/xunit-binaries/*.config $(TEST_BUNDLE_PATH)/net_4_x/
+	cp -L $(top_srcdir)/external/xunit-binaries/xunit.execution.dotnet.dll $(TEST_BUNDLE_PATH)/net_4_x/tests/
+	$(MAKE) -C $(mcs_topdir)/tests test-bundle
+	$(MAKE) -C $(mcs_topdir)/errors test-bundle
+	$(MAKE) -C $(mcs_topdir)/packages test-bundle
+	$(MAKE) -C $(mcs_topdir)/tools/mono-symbolicate test-bundle
+
 if HOST_WIN32
 if CROSS_COMPILING
 cur_dir_cmd = pwd

--- a/runtime/mono-test.sh
+++ b/runtime/mono-test.sh
@@ -1,0 +1,287 @@
+#! /bin/sh -e
+
+test_suite="$1"
+test_argument_1="$2"
+test_argument_2="$3"
+xunit_results_path="$(pwd)/testResults.xml"
+
+cd "$(dirname "$0")" || exit 1
+
+r=$(pwd)
+MONO_CFG_DIR="$r/_tmpinst/etc"
+PATH="$r/_tmpinst/bin:$PATH"
+MONO_EXECUTABLE=${MONO_EXECUTABLE:-"$r/mono-sgen"}
+MONO_PATH="$r/net_4_x"
+export MONO_CFG_DIR MONO_PATH MONO_EXECUTABLE PATH
+
+sed "s,\$test_root_dir,$r,g" "$r/_tmpinst/etc/mono/config.tmpl" > "$r/_tmpinst/etc/mono/config"
+sed "s,\$test_root_dir,$r,g" "$r/tests/runtime/tests-config.tmpl" > "$r/tests/runtime/tests-config"
+
+chmod +x "${MONO_EXECUTABLE}"
+echo "---------------------------------------------------------------------------------------"
+"${MONO_EXECUTABLE}" --version
+echo "---------------------------------------------------------------------------------------"
+
+if [ "$test_suite" = "--xunit" ]; then
+    cd net_4_x || exit 1
+    export MONO_PATH="$r/net_4_x/tests:$MONO_PATH"
+    export REMOTE_EXECUTOR="$r/net_4_x/tests/RemoteExecutorConsoleApp.exe"
+    case "$test_argument_1" in
+        *"Mono.Profiler.Log"*)
+            # necessary for the runtime to find libmono-profiler-log
+            export LD_LIBRARY_PATH="$r:$LD_LIBRARY_PATH"
+            export DYLD_LIBRARY_PATH="$r:$LD_LIBRARY_PATH"
+            ;;
+    esac
+    case "$(uname)" in
+        "Darwin")
+            ADDITIONAL_TRAITS="-notrait category=nonosxtests"
+            ;;
+        "Linux")
+            ADDITIONAL_TRAITS="-notrait category=nonlinuxtests"
+            ;;
+    esac
+
+    "${MONO_EXECUTABLE}" --config "$r/_tmpinst/etc/mono/config" --debug "$r/net_4_x/xunit.console.exe" "$r/$test_argument_1" -noappdomain -noshadow -parallel none -xml "${xunit_results_path}" -notrait category=failing -notrait category=nonmonotests -notrait Benchmark=true -notrait category=outerloop $ADDITIONAL_TRAITS
+    exit $?
+fi
+
+if [ "$test_suite" = "--nunit" ]; then
+    cd net_4_x || exit 1
+    export MONO_PATH="$r/net_4_x/tests:$MONO_PATH"
+    case "$test_argument_1" in
+        *"Microsoft.Build"*)
+            export TESTING_MONO=a
+            export MSBuildExtensionsPath="$r/net_4_x/tests/xbuild/extensions"
+            export XBUILD_FRAMEWORK_FOLDERS_PATH="$r/net_4_x/tests/xbuild/frameworks"
+            case "$test_argument_1" in
+                "xbuild_12"*) export MONO_PATH="$r/xbuild_12:$r/xbuild_12/tests:$MONO_PATH" ;;
+                "xbuild_14"*) export MONO_PATH="$r/xbuild_14:$r/xbuild_14/tests:$MONO_PATH" ;;
+            esac
+            ;;
+        *"Mono.Messaging.RabbitMQ"*)
+            export MONO_MESSAGING_PROVIDER=Mono.Messaging.RabbitMQ.RabbitMQMessagingProvider,Mono.Messaging.RabbitMQ
+            ;;
+        *"System.Windows.Forms"*)
+            sudo apt install -y xvfb xauth
+            XVFBRUN="xvfb-run -a --"
+            ADDITIONAL_TEST_EXCLUDES="NotWithXvfb" # TODO: find out why this works on Jenkins?
+            ;;
+    esac
+    case "$test_argument_2" in
+        "--flaky-test-retries="*)
+            export MONO_FLAKY_TEST_RETRIES=$(echo "$test_argument_2" | cut -d "=" -f2)
+            ;;
+    esac
+    cp -f "$r/$test_argument_1.nunitlite.config" "$r/net_4_x/nunit-lite-console.exe.config"
+    MONO_REGISTRY_PATH="$HOME/.mono/registry" MONO_TESTS_IN_PROGRESS="yes" $XVFBRUN "${MONO_EXECUTABLE}" --config "$r/_tmpinst/etc/mono/config" --debug "$r/net_4_x/nunit-lite-console.exe" "$r/$test_argument_1" -exclude=NotWorking,CAS,$ADDITIONAL_TEST_EXCLUDES -labels -format:xunit -result:"${xunit_results_path}"
+    exit $?
+fi
+
+if [ "$test_suite" = "--verify" ]; then
+    verifiable_files=$(find net_4_x -maxdepth 1 -name "*.dll" -or -name "*.exe" | grep -v System.Runtime.CompilerServices.Unsafe.dll | grep -v Xunit.NetCore.Extensions.dll)
+    ok=true
+    for asm in $verifiable_files; do
+        echo "$asm"
+        if [ ! -f "$asm" ]; then continue; fi
+        if "${MONO_EXECUTABLE}" --config "$r/_tmpinst/etc/mono/config" --compile-all --verify-all --security=verifiable "$asm"; then
+            echo "$asm verified OK"
+        else
+            echo "$asm verification failed"
+            ok=false
+        fi
+    done;
+    if [ "$ok" = "true" ]; then
+        echo "<?xml version=\"1.0\" encoding=\"utf-8\"?><assemblies><assembly name=\"verify\" environment=\"Mono\" test-framework=\"custom\" run-date=\"$(date +%F)\" run-time=\"$(date +%T)\" total=\"1\" passed=\"1\" failed=\"0\" skipped=\"0\" errors=\"0\" time=\"0\"><collection total=\"1\" passed=\"1\" failed=\"0\" skipped=\"0\" name=\"Test collection for verify\" time=\"0\"><test name=\"verify.all\" type=\"verify\" method=\"all\" time=\"0\" result=\"Pass\"></test></collection></assembly></assemblies>" > "${xunit_results_path}";
+        exit 0
+    else
+        echo "<?xml version=\"1.0\" encoding=\"utf-8\"?><assemblies><assembly name=\"verify\" environment=\"Mono\" test-framework=\"custom\" run-date=\"$(date +%F)\" run-time=\"$(date +%T)\" total=\"1\" passed=\"0\" failed=\"1\" skipped=\"0\" errors=\"0\" time=\"0\"><collection total=\"1\" passed=\"0\" failed=\"1\" skipped=\"0\" name=\"Test collection for verify\" time=\"0\"><test name=\"verify.all\" type=\"verify\" method=\"all\" time=\"0\" result=\"Fail\"><failure exception-type=\"VerifyException\"><message><![CDATA[Verifying framework assemblies failed. Check the log for more details.]]></message></failure></test></collection></assembly></assemblies>" > "${xunit_results_path}";
+        exit 1
+    fi
+fi
+
+if [ "$test_suite" = "--mcs" ]; then
+    cd tests/mcs || exit 1
+    "${MONO_EXECUTABLE}" --config "$r/_tmpinst/etc/mono/config" --verify-all compiler-tester.exe -mode:pos -files:v4 -compiler:"$r/net_4_x/mcs.exe" -reference-dir:"$r/net_4_x" -issues:known-issues-net_4_x -log:net_4_x.log -il:ver-il-net_4_x.xml -resultXml:"${xunit_results_path}" -compiler-options:"-d:NET_4_0;NET_4_5 -debug"
+    exit $?
+fi
+
+if [ "$test_suite" = "--mcs-errors" ]; then
+    cd tests/mcs-errors || exit 1
+    "${MONO_EXECUTABLE}" --config "$r/_tmpinst/etc/mono/config" compiler-tester.exe -mode:neg -files:v4 -compiler:"$r/net_4_x/mcs.exe" -reference-dir:"$r/net_4_x" -issues:known-issues-net_4_x -log:net_4_x.log -resultXml:"${xunit_results_path}" -compiler-options:"-v --break-on-ice -d:NET_4_0;NET_4_5"
+    exit $?
+fi
+
+if [ "$test_suite" = "--aot-test" ]; then
+    failed=0
+    passed=0
+    failed_tests=""
+    profile="$r/net_4_x"
+    tmpfile=$(mktemp -t mono_aot_outputXXXXXX) || exit 1
+    rm -f "test-aot-*.stdout" "test-aot-*.stderr" "${xunit_results_path}.cases.xml"
+    for assembly in "$profile"/*.dll; do
+        asm_name=$(basename "$assembly")
+        echo "... $asm_name"
+        for conf in "|regular" "--gc=boehm|boehm"; do
+            name=$(echo $conf | cut -d\| -f 2)
+            params=$(echo $conf | cut -d\| -f 1)
+            test_name="${asm_name}|${name}"
+            echo "  $test_name"
+            if "${MONO_EXECUTABLE}" --config "$r/_tmpinst/etc/mono/config" $params --aot=outfile="$tmpfile" "$assembly" > "test-aot-${name}-${asm_name}.stdout" 2> "test-aot-${name}-${asm_name}.stderr"
+            then
+                passed=$((passed + 1))
+                resultstring="Pass"
+            else \
+                failed=$((failed + 1))
+                failed_tests="${failed_tests} $test_name"
+                resultstring="Fail"
+            fi
+            echo "<test name=\"aot-test.$name.$asm_name\" type=\"aot-test.$name\" method=\"$asm_name\" time=\"0\" result=\"$resultstring\">" >> "${xunit_results_path}.cases.xml"
+            if [ "$resultstring" = "Fail" ]; then
+                echo "<failure exception-type=\"AotTestException\"><message><![CDATA[
+                    STDOUT:
+                    $(cat "test-aot-${name}-${asm_name}.stdout")
+                    STDERR:
+                    $(cat "test-aot-${name}-${asm_name}.stderr")]]></message><stack-trace></stack-trace></failure>" >> "${xunit_results_path}.cases.xml"; fi
+            echo "</test>" >> "${xunit_results_path}.cases.xml"
+        done
+    done
+    echo "<?xml version=\"1.0\" encoding=\"utf-8\"?>\
+    <assemblies>\
+        <assembly name=\"aot-test\" environment=\"Mono\" test-framework=\"custom\" run-date=\"$(date +%F)\" run-time=\"$(date +%T)\" total=\"$((passed + failed))\" passed=\"$passed\" failed=\"$failed\" skipped=\"0\" errors=\"0\" time=\"0\">\
+            <collection total=\"$((passed + failed))\" passed=\"$passed\" failed=\"$failed\" skipped=\"0\" name=\"Test collection for aot-test\" time=\"0\">\
+                $(cat "${xunit_results_path}.cases.xml")
+            </collection>\
+        </assembly>\
+    </assemblies>" > "${xunit_results_path}";
+    rm "$tmpfile"
+    echo "${passed} test(s) passed. ${failed} test(s) did not pass."
+    if [ "${failed}" != 0 ]; then
+        echo ""
+        echo "Failed tests:"
+        echo ""
+        for i in ${failed_tests}; do
+            echo "${i}";
+        done
+        exit 1
+    fi
+    exit 0
+fi
+
+if [ "$test_suite" = "--mini" ]; then
+    cd tests/mini || exit 1
+
+    "${MONO_EXECUTABLE}" --config "$r/_tmpinst/etc/mono/config" --regression ./*.exe > regressiontests.out 2>&1
+    cat regressiontests.out
+    if grep -q "100% pass" regressiontests.out; then
+        resultstring="Pass"
+        failurescount=0
+        successcount=1
+    else
+        resultstring="Fail"
+        failurescount=1
+        successcount=0
+    fi
+    echo "<?xml version=\"1.0\" encoding=\"utf-8\"?>\
+        <assemblies>\
+            <assembly name=\"mini.regression-tests\" environment=\"Mono\" test-framework=\"custom\" run-date=\"$(date +%F)\" run-time=\"$(date +%T)\" total=\"1\" passed=\"$successcount\" failed=\"$failurescount\" skipped=\"0\" errors=\"0\" time=\"0\">\
+                <collection total=\"1\" passed=\"$successcount\" failed=\"$failurescount\" skipped=\"0\" name=\"Test collection for mini.regression-tests\" time=\"0\">\
+                    <test name=\"mini.regression-tests.all\" type=\"mini.regression-tests\" method=\"all\" time=\"0\" result=\"$resultstring\">" > "${xunit_results_path}"
+                    if [ "$resultstring" = "Fail" ]; then echo "<failure exception-type=\"MiniRegressionTestsException\"><message><![CDATA[$(cat regressiontests.out)]]></message><stack-trace></stack-trace></failure>" >> "${xunit_results_path}"; fi
+                echo "</test>
+                </collection>\
+            </assembly>\
+        </assemblies>" >> "${xunit_results_path}";
+    exit $failurescount
+fi
+
+if [ "$test_suite" = "--symbolicate" ]; then
+    cd tests/symbolicate || exit 1
+
+    "${MONO_EXECUTABLE}" --config "$r/_tmpinst/etc/mono/config" --aot 2>&1 | grep -q "AOT compilation is not supported" && echo "No AOT support, skipping tests." && exit 0
+
+    ok=true
+    for config in without-aot with-aot with-aot-msym; do
+        OUT_DIR="$config"
+        MSYM_DIR="$OUT_DIR/msymdir"
+        STACKTRACE_FILE="$OUT_DIR/stacktrace.out"
+        SYMBOLICATE_RAW_FILE="$OUT_DIR/symbolicate_raw.out"
+        SYMBOLICATE_RESULT_FILE="$OUT_DIR/symbolicate.result"
+        SYMBOLICATE_EXPECTED_FILE=symbolicate.expected
+
+        echo "Checking StackTraceDumper.exe in configuration $config..."
+        rm -rf "$OUT_DIR"
+        mkdir -p "$OUT_DIR"
+        mkdir -p "$MSYM_DIR"
+
+        cp StackTraceDumper.exe "$OUT_DIR"
+        cp StackTraceDumper.pdb "$OUT_DIR"
+
+        # store symbols
+        "${MONO_EXECUTABLE}" --config "$r/_tmpinst/etc/mono/config" "$r/net_4_x/mono-symbolicate.exe" store-symbols "$MSYM_DIR" "$OUT_DIR"
+        "${MONO_EXECUTABLE}" --config "$r/_tmpinst/etc/mono/config" "$r/net_4_x/mono-symbolicate.exe" store-symbols "$MSYM_DIR" "$r/net_4_x"
+
+        if [ "$config" = "with-aot" ]; then "${MONO_EXECUTABLE}" --config "$r/_tmpinst/etc/mono/config" -O=-inline --aot "$OUT_DIR/StackTraceDumper.exe"; fi
+        if [ "$config" = "with-aot-msym" ]; then "${MONO_EXECUTABLE}" --config "$r/_tmpinst/etc/mono/config" -O=-inline --aot=msym-dir="$MSYM_DIR" "$OUT_DIR/StackTraceDumper.exe"; fi
+
+        # check diff
+        "${MONO_EXECUTABLE}" --config "$r/_tmpinst/etc/mono/config" -O=-inline StackTraceDumper.exe > "$STACKTRACE_FILE"
+        "${MONO_EXECUTABLE}" --config "$r/_tmpinst/etc/mono/config" "$r/net_4_x/mono-symbolicate.exe" "$MSYM_DIR" "$STACKTRACE_FILE" > "$SYMBOLICATE_RAW_FILE"
+        tr "\\\\" "/" < "$SYMBOLICATE_RAW_FILE" | sed "s,) .* in .*/mcs/,) in mcs/," | sed "s,) .* in .*/external/,) in external/," | sed '/\[MVID\]/d' | sed '/\[AOTID\]/d' > "$SYMBOLICATE_RESULT_FILE"
+
+        DIFF=$(diff -up "$SYMBOLICATE_EXPECTED_FILE" "$SYMBOLICATE_RESULT_FILE")
+        if [ ! -z "$DIFF" ]; then
+            echo "ERROR: Symbolicate tests failed."
+            echo "If $SYMBOLICATE_RESULT_FILE is correct copy it to $SYMBOLICATE_EXPECTED_FILE."
+            echo "Otherwise runtime sequence points need to be fixed."
+            echo ""
+            echo "$DIFF"
+            ok=false
+        else
+            echo "Success."
+        fi
+    done
+
+    if [ "$ok" = "true" ]; then
+        echo "<?xml version=\"1.0\" encoding=\"utf-8\"?><assemblies><assembly name=\"symbolicate\" environment=\"Mono\" test-framework=\"custom\" run-date=\"$(date +%F)\" run-time=\"$(date +%T)\" total=\"1\" passed=\"1\" failed=\"0\" skipped=\"0\" errors=\"0\" time=\"0\"><collection total=\"1\" passed=\"1\" failed=\"0\" skipped=\"0\" name=\"Test collection for symbolicate\" time=\"0\"><test name=\"symbolicate.all\" type=\"symbolicate\" method=\"all\" time=\"0\" result=\"Pass\"></test></collection></assembly></assemblies>" > "${xunit_results_path}";
+        exit 0
+    else
+        echo "<?xml version=\"1.0\" encoding=\"utf-8\"?><assemblies><assembly name=\"symbolicate\" environment=\"Mono\" test-framework=\"custom\" run-date=\"$(date +%F)\" run-time=\"$(date +%T)\" total=\"1\" passed=\"0\" failed=\"1\" skipped=\"0\" errors=\"0\" time=\"0\"><collection total=\"1\" passed=\"0\" failed=\"1\" skipped=\"0\" name=\"Test collection for symbolicate\" time=\"0\"><test name=\"symbolicate.all\" type=\"symbolicate\" method=\"all\" time=\"0\" result=\"Fail\"><failure exception-type=\"SymbolicateException\"><message><![CDATA[Symbolicate tests failed. Check the log for more details.]]></message></failure></test></collection></assembly></assemblies>" > "${xunit_results_path}";
+        exit 1
+    fi
+
+fi
+
+if [ "$test_suite" = "--csi" ]; then
+    cd tests/csi || error 1
+    echo "Console.WriteLine (\"hello world: \" + DateTime.Now)" > csi-test.csx
+
+    ok=true
+    "${MONO_EXECUTABLE}" --config "$r/_tmpinst/etc/mono/config" csi.exe csi-test.csx > csi-test-output.txt || ok=false
+    cat csi-test-output.txt && grep -q "hello world" csi-test-output.txt || ok=false
+
+    if [ "$ok" = "true" ]; then
+        echo "<?xml version=\"1.0\" encoding=\"utf-8\"?><assemblies><assembly name=\"csi\" environment=\"Mono\" test-framework=\"custom\" run-date=\"$(date +%F)\" run-time=\"$(date +%T)\" total=\"1\" passed=\"1\" failed=\"0\" skipped=\"0\" errors=\"0\" time=\"0\"><collection total=\"1\" passed=\"1\" failed=\"0\" skipped=\"0\" name=\"Test collection for csi\" time=\"0\"><test name=\"csi.all\" type=\"csi\" method=\"all\" time=\"0\" result=\"Pass\"></test></collection></assembly></assemblies>" > "${xunit_results_path}";
+        exit 0
+    else
+        echo "<?xml version=\"1.0\" encoding=\"utf-8\"?><assemblies><assembly name=\"csi\" environment=\"Mono\" test-framework=\"custom\" run-date=\"$(date +%F)\" run-time=\"$(date +%T)\" total=\"1\" passed=\"0\" failed=\"1\" skipped=\"0\" errors=\"0\" time=\"0\"><collection total=\"1\" passed=\"0\" failed=\"1\" skipped=\"0\" name=\"Test collection for csi\" time=\"0\"><test name=\"csi.all\" type=\"csi\" method=\"all\" time=\"0\" result=\"Fail\"><failure exception-type=\"CsiException\"><message><![CDATA[csi.exe tests failed. Check the log for more details.]]></message></failure></test></collection></assembly></assemblies>" > "${xunit_results_path}";
+        exit 1
+    fi
+
+fi
+
+if [ "$test_suite" = "--profiler" ]; then
+    cd tests/profiler || exit 1
+
+    chmod +x "$r/mprof-report"
+    perl ptestrunner.pl out-of-tree xunit "${xunit_results_path}"
+    exit $?
+fi
+
+if [ "$test_suite" = "--runtime" ]; then
+    cd tests/runtime || exit 1
+
+    # TODO: only ported runtest-managed for now
+    "${MONO_EXECUTABLE}" --config "$r/_tmpinst/etc/mono/config" --debug test-runner.exe --verbose --xunit "${xunit_results_path}" --config tests-config --runtime "${MONO_EXECUTABLE}" --mono-path "$r/net_4_x" -j a --testsuite-name "runtime" --timeout 300 --disabled "$DISABLED_TESTS" $(cat runtime-test-list.txt)
+    exit $?
+fi

--- a/runtime/mono-test.sh
+++ b/runtime/mono-test.sh
@@ -49,6 +49,7 @@ fi
 if [ "$test_suite" = "--nunit" ]; then
     cd net_4_x || exit 1
     export MONO_PATH="$r/net_4_x/tests:$MONO_PATH"
+    export MONO_SYSTEMWEB_CACHEDEPENDENCY_SHARED_FSW=1
     case "$test_argument_1" in
         *"Microsoft.Build"*)
             export TESTING_MONO=a

--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -9,6 +9,9 @@ export TEST_HARNESS_VERBOSE=1
 
 source ${MONO_REPO_ROOT}/scripts/ci/util.sh
 
+helix_set_env_vars
+helix_send_build_start_event "build/source/$MONO_HELIX_TYPE/"
+
 make_timeout=300m
 
 if [[ ${CI_TAGS} == *'clang-sanitizer'* ]]; then
@@ -253,10 +256,13 @@ if [[ ${CI_TAGS} == *'linux-ppc64el'* ]]; then make_parallelism=-j1; fi
 make_continue=
 if [[ ${CI_TAGS} == *'checked-all'* ]]; then make_continue=-k; fi
 
-
 if [[ ${CI_TAGS} != *'mac-sdk'* ]]; # Mac SDK builds Mono itself
-	then
-	${TESTCMD} --label=make --timeout=${make_timeout} --fatal make ${make_parallelism} ${make_continue} -w V=1
+    then
+    build_error=0
+    ${TESTCMD} --label=make --timeout=${make_timeout} --fatal make ${make_parallelism} ${make_continue} -w V=1 || build_error=1
+    helix_send_build_done_event "build/source/$MONO_HELIX_TYPE/" $build_error
+
+    if [[ ${build_error} != 0 ]]; then echo "ERROR: The Mono build failed."; exit ${build_error}; fi
 fi
 
 if [[ ${CI_TAGS} == *'checked-coop'* ]]; then export MONO_CHECK_MODE=gc,thread; fi
@@ -270,6 +276,7 @@ elif [[ ${CI_TAGS} == *'stress-tests'* ]];             then ${MONO_REPO_ROOT}/sc
 elif [[ ${CI_TAGS} == *'interpreter'* ]];              then ${MONO_REPO_ROOT}/scripts/ci/run-test-interpreter.sh;
 elif [[ ${CI_TAGS} == *'mcs-compiler'* ]];             then ${MONO_REPO_ROOT}/scripts/ci/run-test-mcs.sh;
 elif [[ ${CI_TAGS} == *'mac-sdk'* ]];                  then ${MONO_REPO_ROOT}/scripts/ci/run-test-mac-sdk.sh;
+elif [[ ${CI_TAGS} == *'helix-tests'* ]];              then ${MONO_REPO_ROOT}/scripts/ci/run-test-helix.sh;
 elif [[ ${CI_TAGS} == *'no-tests'* ]];                 then echo "Skipping tests.";
 else make check-ci;
 fi

--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -262,7 +262,11 @@ if [[ ${CI_TAGS} != *'mac-sdk'* ]]; # Mac SDK builds Mono itself
     ${TESTCMD} --label=make --timeout=${make_timeout} --fatal make ${make_parallelism} ${make_continue} -w V=1 || build_error=1
     helix_send_build_done_event "build/source/$MONO_HELIX_TYPE/" $build_error
 
-    if [[ ${build_error} != 0 ]]; then echo "ERROR: The Mono build failed."; exit ${build_error}; fi
+    if [[ ${build_error} != 0 ]]; then
+        echo "ERROR: The Mono build failed."
+        ${MONO_REPO_ROOT}/scripts/ci/run-upload-sentry.sh
+        exit ${build_error}
+    fi
 fi
 
 if [[ ${CI_TAGS} == *'checked-coop'* ]]; then export MONO_CHECK_MODE=gc,thread; fi

--- a/scripts/ci/run-test-helix.sh
+++ b/scripts/ci/run-test-helix.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -e
+
+source ${MONO_REPO_ROOT}/scripts/ci/util.sh
+
+helix_send_build_start_event "build/tests/$MONO_HELIX_TYPE/"
+${TESTCMD} --label=compile-runtime-tests --timeout=20m --fatal make -w -C mono -j ${CI_CPU_COUNT} test
+${TESTCMD} --label=compile-bcl-tests --timeout=40m --fatal make -i -w -C runtime -j ${CI_CPU_COUNT} test xunit-test
+# TODO: remove the explicit xbuild tests compile step once the nunitlite dependency bug is fixed
+${TESTCMD} --label=compile-xbuild_12 --timeout=5m --fatal make -w -C mcs/class -j ${CI_CPU_COUNT} test PROFILE=xbuild_12
+${TESTCMD} --label=compile-xbuild_14 --timeout=5m --fatal make -w -C mcs/class -j ${CI_CPU_COUNT} test PROFILE=xbuild_14
+${TESTCMD} --label=create-test-payload --timeout=5m --fatal make -w test-bundle TEST_BUNDLE_PATH="$MONO_REPO_ROOT/mono-test-bundle"
+helix_send_build_done_event "build/tests/$MONO_HELIX_TYPE/" 0
+
+# get libgdiplus from CI output
+if [[ ${CI_TAGS} == *'linux-amd64'* ]]; then
+    wget "https://xamjenkinsartifact.blob.core.windows.net/test-libgdiplus-mainline/280/debian-9-amd64/src/.libs/libgdiplus.so" -O "$MONO_REPO_ROOT/mono-test-bundle/mono-libgdiplus.so"
+else
+    echo "Unknown OS, couldn't determine appropriate libgdiplus."
+    exit 1
+fi
+
+export MONO_HELIX_TEST_PAYLOAD_DIRECTORY="$MONO_REPO_ROOT/mono-test-bundle"
+export MONO_HELIX_CORRELATION_ID_FILE="$MONO_REPO_ROOT/test-correlation-id.txt"
+${TESTCMD} --label=upload-helix-tests --timeout=5m --fatal make -w -C mcs/tools/mono-helix-client upload-to-helix
+
+# test suites which aren't ported to helix yet
+${TESTCMD} --label=mini-seq-points --timeout=5m make -w -C mono/mini -k check-seq-points
+${TESTCMD} --label=mini-aotcheck --timeout=5m make -j ${CI_CPU_COUNT} -w -C mono/mini -k aotcheck
+${TESTCMD} --label=runtime --timeout=20m make -w -C mono/tests test-wrench IGNORE_TEST_JIT=1 V=1
+${TESTCMD} --label=runtime-unit-tests --timeout=5m make -w -C mono/unit-tests -k check
+${TESTCMD} --label=monolinker --timeout=10m make -w -C mcs/tools/linker check
+
+# wait for helix tests to complete
+export MONO_HELIX_CORRELATION_ID=$(cat "$MONO_HELIX_CORRELATION_ID_FILE")
+${TESTCMD} --label=wait-helix-tests --timeout=40m make -w -C mcs/tools/mono-helix-client wait-for-job-completion

--- a/scripts/ci/util.sh
+++ b/scripts/ci/util.sh
@@ -24,7 +24,6 @@ function helix_set_env_vars {
     else echo "Couldn't determine operating system for Helix."; return 1; fi
 
     if [[ ${CI_TAGS} == *'pull-request'* ]]; then
-        export MONO_HELIX_CREATOR="$ghprbPullAuthorLogin"
         export MONO_HELIX_TARGET_QUEUE="debian.9.amd64.open"
         export MONO_HELIX_SOURCE="pr/jenkins/mono/mono/$ghprbTargetBranch/"
         export MONO_HELIX_BUILD_MONIKER="$(git rev-parse HEAD)"
@@ -35,9 +34,8 @@ function helix_set_env_vars {
         build_ver=$(echo "$version_number" | cut -d . -f 3)
         blame_rev=$(git blame configure.ac HEAD | grep AC_INIT | sed 's/ .*//')
         patch_ver=$(git log "$blame_rev"..HEAD --oneline | wc -l | sed 's/ //g')
-        export MONO_HELIX_CREATOR="monojenkins"
         export MONO_HELIX_TARGET_QUEUE="debian.9.amd64"
-        export MONO_HELIX_SOURCE="official/mono/mono/$MONO_BRANCH/v4/"
+        export MONO_HELIX_SOURCE="official/mono/mono/$MONO_BRANCH/"
         export MONO_HELIX_BUILD_MONIKER=$(printf %d.%d.%d.%d "$major_ver" "$minor_ver" "$build_ver" "$patch_ver")
     fi
 }

--- a/scripts/ci/util.sh
+++ b/scripts/ci/util.sh
@@ -9,3 +9,64 @@ function report_github_status {
 
     wget -qO- --header "Content-Type: application/json" --post-data "{\"state\": \"$1\", \"context\":\"$2\", \"description\": \"$3\", \"target_url\": \"$4\"}" "https://api.github.com/repos/mono/mono/statuses/${ghprbActualCommit}?access_token=${GITHUB_STATUS_AUTH_TOKEN}"
 }
+
+function helix_set_env_vars {
+    if [[ ${CI_TAGS} != *'helix'* ]]; then return 0; fi;
+
+    if   [[ ${CI_TAGS} == *'-i386'*  ]]; then export MONO_HELIX_ARCHITECTURE="x86";
+    elif [[ ${CI_TAGS} == *'-amd64'* ]]; then export MONO_HELIX_ARCHITECTURE="x64";
+    elif [[ ${CI_TAGS} == *'-arm64'* ]]; then export MONO_HELIX_ARCHITECTURE="arm64";
+    elif [[ ${CI_TAGS} == *'-armel'* ]]; then export MONO_HELIX_ARCHITECTURE="armel";
+    elif [[ ${CI_TAGS} == *'-armhf'* ]]; then export MONO_HELIX_ARCHITECTURE="armhf";
+    else echo "Couldn't determine architecture for Helix."; return 1; fi
+
+    if [[ ${CI_TAGS} == *'linux-'* ]]; then export MONO_HELIX_OPERATINGSYSTEM="Debian 9";
+    else echo "Couldn't determine operating system for Helix."; return 1; fi
+
+    if [[ ${CI_TAGS} == *'pull-request'* ]]; then
+        export MONO_HELIX_CREATOR="$ghprbPullAuthorLogin"
+        export MONO_HELIX_TARGET_QUEUE="debian.9.amd64.open"
+        export MONO_HELIX_SOURCE="pr/jenkins/mono/mono/$ghprbTargetBranch/"
+        export MONO_HELIX_BUILD_MONIKER="$(git rev-parse HEAD)"
+    else
+        version_number=$(grep AC_INIT configure.ac | sed -e 's/AC_INIT(mono, \[//' -e 's/\],//')
+        major_ver=$(echo "$version_number" | cut -d . -f 1)
+        minor_ver=$(echo "$version_number" | cut -d . -f 2)
+        build_ver=$(echo "$version_number" | cut -d . -f 3)
+        blame_rev=$(git blame configure.ac HEAD | grep AC_INIT | sed 's/ .*//')
+        patch_ver=$(git log "$blame_rev"..HEAD --oneline | wc -l | sed 's/ //g')
+        export MONO_HELIX_CREATOR="monojenkins"
+        export MONO_HELIX_TARGET_QUEUE="debian.9.amd64"
+        export MONO_HELIX_SOURCE="official/mono/mono/$MONO_BRANCH/v4/"
+        export MONO_HELIX_BUILD_MONIKER=$(printf %d.%d.%d.%d "$major_ver" "$minor_ver" "$build_ver" "$patch_ver")
+    fi
+}
+
+function helix_send_build_start_event {
+    if [[ ${CI_TAGS} != *'helix-telemetry'* ]]; then return 0; fi;
+    if [ -z "$MONO_HELIX_API_KEY" ]; then echo "No Helix API key, skipping telementry event."; return 0; fi;
+    if [ -z "$1" ]; then echo "No type."; return 1; fi;
+
+    mkdir -p "helix-telemetry/${1}"
+    wget -O- --method="POST" --header='Content-Type: application/json' --header='Accept: application/json' --body-data="{
+        \"QueueId\": \"${MONO_HELIX_TARGET_QUEUE}\",
+        \"Source\": \"${MONO_HELIX_SOURCE}\",
+        \"Type\": \"${1}\",
+        \"Build\": \"${MONO_HELIX_BUILD_MONIKER}\",
+        \"Properties\": { \"architecture\": \"${MONO_HELIX_ARCHITECTURE}\", \"operatingSystem\": \"${MONO_HELIX_OPERATINGSYSTEM}\"}
+        }" "https://helix.dot.net/api/2018-03-14/telemetry/job?access_token=${MONO_HELIX_API_KEY}" > "helix-telemetry/${1}/job-token.txt"
+    helix_job_token=$(cat "helix-telemetry/${1}/job-token.txt" | sed 's/"//g')
+
+    wget -O- --method="POST" --header='Accept: application/json' --header="X-Helix-Job-Token: ${helix_job_token}" "https://helix.dot.net/api/2018-03-14/telemetry/job/build?buildUri=${BUILD_URL}" > "helix-telemetry/${1}/build-id.txt"
+}
+
+function helix_send_build_done_event {
+    if [[ ${CI_TAGS} != *'helix-telemetry'*  ]]; then return 0; fi;
+    if [ -z "$MONO_HELIX_API_KEY" ]; then echo "No Helix API key, skipping telementry event."; return 0; fi;
+    if [ -z "$1" ]; then echo "No type."; return 1; fi;
+    if [ -z "$2" ]; then echo "No error count."; return 1; fi;
+
+    helix_job_token=$(cat "helix-telemetry/${1}/job-token.txt" | sed 's/"//g')
+    helix_build_id=$(cat "helix-telemetry/$1/build-id.txt" | sed 's/"//g')
+    wget -O- --method="POST" --header='Accept: application/json' --header="X-Helix-Job-Token: ${helix_job_token}" "https://helix.dot.net/api/2018-03-14/telemetry/job/build/${helix_build_id}/finish?errorCount=${2}&warningCount=0"
+}

--- a/support/Makefile.am
+++ b/support/Makefile.am
@@ -129,6 +129,10 @@ libMonoSupportW_la_SOURCES =			\
 libMonoSupportW_la_LIBADD =			\
 		$(glib_libs)
 
+test-bundle-local:
+	mkdir -p $(TEST_BUNDLE_PATH)
+	cp -L .libs/libMonoPosixHelper$(libsuffix) $(TEST_BUNDLE_PATH)/
+
 # 
 # Use this target to refresh the values in map.[ch]
 #


### PR DESCRIPTION
- Adding a new client tool for sending jobs which uses the Helix SDK to create jobs in the Helix environment.
- Add targets to bundle tests and add a script to run them in Helix
- Workaround an issue with System.Web tests in the Helix environment due to FileSystemWatcher

https://github.com/mono/mono/issues/9099