### PR TITLE
[wasm][binding] Allow the cleanup of transparent/bridged marshalled objects causing leaks.

### DIFF
--- a/sdks/wasm/WasmHttpMessageHandler.cs
+++ b/sdks/wasm/WasmHttpMessageHandler.cs
@@ -203,13 +203,19 @@ namespace WebAssembly.Net.Http.HttpClient
                         ((JSObject)other).Dispose();
                     });
 
-                    respHeaders.Invoke("forEach", foreachAction);
+                    try
+                    {
 
-                    // Do not remove the following line of code.  The httpresponse is used in the lambda above when parsing the Headers.
-                    // if a local is captured (used) by a lambda it becomes heap memory as we translate them into fields on an object.
-                    // The foreachAction is allocated when marshalled to JavaScript.  Since we do not know when JS is finished with the
-                    // Action we need to tell the Runtime to de-allocate the object and remove the instance from JS as well.
-                    WebAssembly.Runtime.FreeObject(foreachAction);
+                        respHeaders.Invoke("forEach", foreachAction);
+                    }
+                    finally
+                    {
+                        // Do not remove the following line of code.  The httpresponse is used in the lambda above when parsing the Headers.
+                        // if a local is captured (used) by a lambda it becomes heap memory as we translate them into fields on an object.
+                        // The foreachAction is allocated when marshalled to JavaScript.  Since we do not know when JS is finished with the
+                        // Action we need to tell the Runtime to de-allocate the object and remove the instance from JS as well.
+                        WebAssembly.Runtime.FreeObject(foreachAction);
+                    }
 
                 }
 

--- a/sdks/wasm/WasmHttpMessageHandler.cs
+++ b/sdks/wasm/WasmHttpMessageHandler.cs
@@ -193,7 +193,7 @@ namespace WebAssembly.Net.Http.HttpClient
                 {
                     // Here we invoke the forEach on the headers object
                     // Note: the Action takes 3 objects and not two.  The other seems to be the Header object.
-                    respHeaders.Invoke("forEach", new Action<object, object, object>((value, name, other) =>
+                    var foreachAction = new Action<object, object, object>((value, name, other) =>
                     {
 
                         if (!httpresponse.Headers.TryAddWithoutValidation((string)name, (string)value))
@@ -201,16 +201,19 @@ namespace WebAssembly.Net.Http.HttpClient
                                 if (!httpresponse.Content.Headers.TryAddWithoutValidation((string)name, (string)value))
                                     Console.WriteLine($"Warning: Can not add response header for name: {name} value: {value}");
                         ((JSObject)other).Dispose();
-                    }
-                    ));
+                    });
+
+                    respHeaders.Invoke("forEach", foreachAction);
+
+                    // Do not remove the following line of code.  The httpresponse is used in the lambda above when parsing the Headers.
+                    // if a local is captured (used) by a lambda it becomes heap memory as we translate them into fields on an object.
+                    // The foreachAction is allocated when marshalled to JavaScript.  Since we do not know when JS is finished with the
+                    // Action we need to tell the Runtime to de-allocate the object and remove the instance from JS as well.
+                    WebAssembly.Runtime.FreeObject(foreachAction);
+
                 }
 
                 tcs.SetResult(httpresponse);
-
-                // Do not remove the following line of code.  The httpresponse is used in the lambda above when parsing the Headers.
-                // if a local is captured (used) by a lambda it becomes heap memory as we translate them into fields on an object.
-                // If we do not null the field out it will not be GC'd
-                httpresponse = null;
 
                 signal?.Dispose();
             }

--- a/sdks/wasm/binding_support.js
+++ b/sdks/wasm/binding_support.js
@@ -170,6 +170,8 @@ var BindingSupportLib = {
 				});
 
 				this.call_method (this.setup_js_cont, null, "mo", [ mono_obj, cont_obj ]);
+				obj.__mono_js_cont__ = cont_obj.__mono_gchandle__;
+				cont_obj.__mono_js_task__ = obj.__mono_gchandle__;
 				return promise;
 			}
 
@@ -693,8 +695,27 @@ var BindingSupportLib = {
 				var gc_handle = obj.__mono_gchandle__;
 				if (typeof gc_handle  !== "undefined") {
 					this.wasm_unbind_js_obj_and_free(js_id);
-					delete obj.__mono_gchandle__;
-					delete obj.__mono_jshandle__;
+
+					// Windows Edge and Windows IE throws an exception `Object doesn't support this action` on
+					// certain host objects.
+					try {
+						delete obj.__mono_gchandle__;
+					}
+					catch (exc) {
+						if (obj.__mono_gchandle__)
+							obj.__mono_gchandle__ = undefined;
+					}
+
+					// Windows Edge and Windows IE throws an exception `Object doesn't support this action` on
+					// certain host objects.
+					try {
+						delete obj.__mono_jshandle__;
+					}
+					catch (exc) {
+						if (obj.__mono_jshandle__)
+							obj.__mono_jshandle__ = undefined;
+					}
+
 					this.mono_wasm_object_registry[js_id - 1] = undefined;
 					this.mono_wasm_free_list.push(js_id - 1);
 				}
@@ -704,6 +725,16 @@ var BindingSupportLib = {
 		mono_wasm_free_handle: function(handle) {
 			this.mono_wasm_unregister_obj(handle);
 		},
+		mono_wasm_free_object: function(mono_obj) {
+			var js_id = this.call_method (this.get_js_id, null, "m", [mono_obj]);
+			if (js_id)
+			{
+				var obj = this.mono_wasm_object_registry[js_id - 1];
+				if (typeof obj  !== "undefined" && obj !== null) {
+					this.call_method (this.unbind_raw_obj_and_free, null, "ii", [ obj.__mono_gchandle__ ]);
+				}
+			}
+		},		
 		mono_wasm_get_global: function() {
 			function testGlobal(obj) {
 				obj['___mono_wasm_global___'] = obj;
@@ -855,6 +886,16 @@ var BindingSupportLib = {
 
 		return BINDING.js_to_mono_obj (globalObj);
 	},
+	mono_wasm_release_handle: function(js_handle, is_exception) {
+		BINDING.bindings_lazy_init ();
+
+		BINDING.mono_wasm_free_handle(js_handle);
+	},	
+	mono_wasm_release_object: function(mono_obj, is_exception) {
+		BINDING.bindings_lazy_init ();
+
+		BINDING.mono_wasm_free_object(mono_obj);
+	},	
 
 };
 

--- a/sdks/wasm/binding_support.js
+++ b/sdks/wasm/binding_support.js
@@ -692,29 +692,17 @@ var BindingSupportLib = {
 		mono_wasm_unregister_obj: function(js_id) {
 			var obj = this.mono_wasm_object_registry[js_id - 1];
 			if (typeof obj  !== "undefined" && obj !== null) {
+				// if this is the global object then do not
+				// unregister it.
+				if (___mono_wasm_global___ && ___mono_wasm_global___ === obj)
+					return obj;
+
 				var gc_handle = obj.__mono_gchandle__;
 				if (typeof gc_handle  !== "undefined") {
 					this.wasm_unbind_js_obj_and_free(js_id);
 
-					// Windows Edge and Windows IE throws an exception `Object doesn't support this action` on
-					// certain host objects.
-					try {
-						delete obj.__mono_gchandle__;
-					}
-					catch (exc) {
-						if (obj.__mono_gchandle__)
-							obj.__mono_gchandle__ = undefined;
-					}
-
-					// Windows Edge and Windows IE throws an exception `Object doesn't support this action` on
-					// certain host objects.
-					try {
-						delete obj.__mono_jshandle__;
-					}
-					catch (exc) {
-						if (obj.__mono_jshandle__)
-							obj.__mono_jshandle__ = undefined;
-					}
+					obj.__mono_gchandle__ = undefined;
+					obj.__mono_jshandle__ = undefined;
 
 					this.mono_wasm_object_registry[js_id - 1] = undefined;
 					this.mono_wasm_free_list.push(js_id - 1);

--- a/sdks/wasm/bindings.cs
+++ b/sdks/wasm/bindings.cs
@@ -129,11 +129,8 @@ namespace WebAssembly
                 var gCHandle = obj.Handle;
                 obj.Handle.Free();
                 obj.JSHandle = -1;
-                obj.RawObject = null;
-                obj = null;
                 return (int)(IntPtr)gCHandle;
             }
-            obj = null;
             return 0;
 
         }

--- a/sdks/wasm/bindings.cs
+++ b/sdks/wasm/bindings.cs
@@ -45,7 +45,7 @@ namespace WebAssembly
 	///   Execute the provided string in the JavaScript context
         public static string InvokeJS(string str)
         {
-            int exception = 0;
+            int exception;
             var res = InvokeJS(str, out exception);
             if (exception != 0)
                 throw new JSException(res);
@@ -137,7 +137,7 @@ namespace WebAssembly
 
         public static void FreeObject (object obj)
         {
-            int exception = 0;
+            int exception;
             Runtime.ReleaseObject(obj, out exception);
             if (exception != 0)
                 throw new JSException($"Error releasing object on (raw-obj)");
@@ -365,7 +365,7 @@ namespace WebAssembly
 	/// </param>
         public static object GetGlobalObject(string str = null)
         {
-            int exception = 0;
+            int exception;
             var globalHandle = Runtime.GetGlobalObject(str, out exception);
 
             if (exception != 0)
@@ -543,7 +543,7 @@ namespace WebAssembly
 	/// </returns>
         public object Invoke(string method, params object[] args)
         {
-            int exception = 0;
+            int exception;
             var res = Runtime.InvokeJSWithArgs(JSHandle, method, args, out exception);
             if (exception != 0)
                 throw new JSException((string)res);
@@ -575,7 +575,7 @@ namespace WebAssembly
         public object GetObjectProperty(string expr)
         {
 
-            int exception = 0;
+            int exception;
             var propertyValue = Runtime.GetObjectProperty(JSHandle, expr, out exception);
 
             if (exception != 0)
@@ -599,7 +599,7 @@ namespace WebAssembly
         public void SetObjectProperty(string expr, object value, bool createIfNotExists = true, bool hasOwnProperty = false)
         {
 
-            int exception = 0;
+            int exception;
             var setPropResult = Runtime.SetObjectProperty(JSHandle, expr, value, createIfNotExists, hasOwnProperty, out exception);
             if (exception != 0)
                 throw new JSException($"Error setting {expr} on (js-obj js '{JSHandle}' mono '{(IntPtr)Handle} raw '{RawObject != null})");
@@ -609,7 +609,7 @@ namespace WebAssembly
         protected void FreeHandle()
         {
 
-            int exception = 0;
+            int exception;
             Runtime.ReleaseHandle(JSHandle, out exception);
             if (exception != 0)
                 throw new JSException($"Error releasing handle on (js-obj js '{JSHandle}' mono '{(IntPtr)Handle} raw '{RawObject != null})");

--- a/sdks/wasm/driver.c
+++ b/sdks/wasm/driver.c
@@ -13,6 +13,8 @@ extern MonoObject* mono_wasm_invoke_js_with_args (int js_handle, MonoString *met
 extern MonoObject* mono_wasm_get_object_property (int js_handle, MonoString *method, int *is_exception);
 extern MonoObject* mono_wasm_set_object_property (int js_handle, MonoString *method, MonoObject *value, int createIfNotExist, int hasOwnProperty, int *is_exception);
 extern MonoObject* mono_wasm_get_global_object (MonoString *globalName, int *is_exception);
+extern void* mono_wasm_release_handle (int js_handle, int *is_exception);
+extern void* mono_wasm_release_object (MonoObject* obj, int *is_exception);
 
 // Blazor specific custom routines - see dotnet_support.js for backing code
 extern void* mono_wasm_invoke_js_marshalled (MonoString **exceptionMessage, void *asyncHandleLongPtr, MonoString *funcName, MonoString *argsJson);
@@ -187,6 +189,8 @@ mono_wasm_load_runtime (const char *managed_path, int enable_debugging)
 	mono_add_internal_call ("WebAssembly.Runtime::GetObjectProperty", mono_wasm_get_object_property);
 	mono_add_internal_call ("WebAssembly.Runtime::SetObjectProperty", mono_wasm_set_object_property);
 	mono_add_internal_call ("WebAssembly.Runtime::GetGlobalObject", mono_wasm_get_global_object);
+	mono_add_internal_call ("WebAssembly.Runtime::ReleaseHandle", mono_wasm_release_handle);
+	mono_add_internal_call ("WebAssembly.Runtime::ReleaseObject", mono_wasm_release_object);
 
 	// Blazor specific custom routines - see dotnet_support.js for backing code		
 	mono_add_internal_call ("WebAssembly.JSInterop.InternalCalls::InvokeJSMarshalled", mono_wasm_invoke_js_marshalled);

--- a/sdks/wasm/sample.cs
+++ b/sdks/wasm/sample.cs
@@ -38,13 +38,11 @@ namespace GeoLocation
             global = new DOMObject(string.Empty);
             navigator = new DOMObject("navigator");
 
-            var window = (JSObject)WebAssembly.Runtime.GetGlobalObject("window");
-            using (var location = (JSObject)window.GetObjectProperty("location"))
-            {
-                BaseApiUrl = (string)location.GetObjectProperty("origin");
-            }
-
-            window.Dispose();
+            using (var window = (JSObject)WebAssembly.Runtime.GetGlobalObject("window"))
+                using (var location = (JSObject)window.GetObjectProperty("location"))
+                {
+                    BaseApiUrl = (string)location.GetObjectProperty("origin");
+                }
 
             httpClient = new HttpClient() { BaseAddress = new Uri(BaseApiUrl) };
 

--- a/sdks/wasm/sample.cs
+++ b/sdks/wasm/sample.cs
@@ -38,22 +38,13 @@ namespace GeoLocation
             global = new DOMObject(string.Empty);
             navigator = new DOMObject("navigator");
 
-            var httpMessageHandler = typeof(HttpClient).GetField("GetHttpMessageHandler",
-                                            BindingFlags.Static |
-                                            BindingFlags.NonPublic);
-
             var window = (JSObject)WebAssembly.Runtime.GetGlobalObject("window");
             using (var location = (JSObject)window.GetObjectProperty("location"))
             {
                 BaseApiUrl = (string)location.GetObjectProperty("origin");
             }
 
-            window = null;
-
-            // Setup the HttpClientHandler
-            httpMessageHandler.SetValue(null, (Func<HttpMessageHandler>)(() => {
-                return new WasmHttpMessageHandler();
-            }));
+            window.Dispose();
 
             httpClient = new HttpClient() { BaseAddress = new Uri(BaseApiUrl) };
 


### PR DESCRIPTION
- Example: When a delegate is marshalled to JS it is allocated so that it is not GC'd.  Since we do not know when JS is finished with the delegate we need a way, for right now, to tell the Runtime to de-allocate the object and remove the transparent/bridged instance from JS as well.  The side-effect of not doing this is that any local that is captured (used) by a lambda became heap memory and were allocated as fields on the object.  Since the delegate is never a candidate for GC the local that was captured was never released either.

- Fix an error with Windows Edge and Windows IE that threw an exception `Object doesn't support this action` on certain host objects.  This only affected Windows Edge and IE when using the JavaScript delete operator to clean up an object after being disposed.

- Cleanup marshalled Tasks after completion.  The marshalled tasks and their continuation objects were never un-allocated thus not allowing them to be GC'd.
