### PR TITLE
[wcf] pass on the ContentType of MTOM message response

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel.Channels/MtomMessageEncoder.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Channels/MtomMessageEncoder.cs
@@ -80,7 +80,7 @@ namespace System.ServiceModel.Channels
 			// FIXME: create proper quotas
 			return Message.CreateMessage (
 				XmlDictionaryReader.CreateMtomReader (
-					stream, encoding, quotas),
+					stream, new Encoding[1] { encoding }, contentType, quotas),
 				maxSizeOfHeaders,
 				MessageVersion);
 		}


### PR DESCRIPTION
Currently, when using MTOM encoding with WCF, the content-type of a response message is not passed to the XmlMtomReader, which results in an error when ensuring that the mediatype is 'multipart' and subtype is 'related'.

Fixes #10895 
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
