### PR TITLE
[wcf] do not assume that message body is always Wrapped

### DIFF
--- a/mcs/class/System.ServiceModel/System.ServiceModel.Dispatcher/XmlMessagesFormatter.cs
+++ b/mcs/class/System.ServiceModel/System.ServiceModel.Dispatcher/XmlMessagesFormatter.cs
@@ -112,7 +112,7 @@ namespace System.ServiceModel.Dispatcher
 			foreach (var type in OperationKnownTypes)
 				xmlImporter.IncludeType (type);
 			XmlMembersMapping [] partsMapping = new XmlMembersMapping [1];
-			partsMapping [0] = xmlImporter.ImportMembersMapping (desc.WrapperName, desc.WrapperNamespace, members, true);
+			partsMapping [0] = xmlImporter.ImportMembersMapping (desc.WrapperName, desc.WrapperNamespace, members, desc.WrapperName != null);
 			bodySerializers [desc] = XmlSerializer.FromMappings (partsMapping) [0];
 			return bodySerializers [desc];
 		}


### PR DESCRIPTION
Currently, setting IsWrapped=false on a MessageContract leads to an error in serialization due to an empty element being present where the wrapper element would have been, instead of it being gone entirely.
The serialization then fails because the empty string is not valid localName (which of course is fine).
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
