### PR TITLE
[crash] Remove duplicated il_offset

### DIFF
--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -143,11 +143,6 @@ mono_native_state_add_frame (JsonWriter *writer, MonoFrameSummary *frame)
 		mono_json_writer_object_key(writer, "il_offset");
 		mono_json_writer_printf (writer, "\"0x%05x\"\n", frame->managed_data.il_offset);
 
-		assert_has_space ();
-		mono_json_writer_indent (writer);
-		mono_json_writer_object_key(writer, "il_offset");
-		mono_json_writer_printf (writer, "\"0x%05x\"\n", frame->managed_data.il_offset);
-
 	} else {
 		assert_has_space ();
 		mono_json_writer_indent (writer);


### PR DESCRIPTION
This code is duplicated completely from the code directly above it (github doesn't show in this diff)