### PR TITLE
[aix/ibmi] Build broken due to subtle difference between i and AIX

### DIFF
--- a/mono/utils/mono-hwcap-ppc.c
+++ b/mono/utils/mono-hwcap-ppc.c
@@ -26,7 +26,21 @@
 #include <string.h>
 #include <sys/auxv.h>
 #elif defined(_AIX)
+
 #include <sys/systemcfg.h>
+
+#if !defined(POWER_4_ANDUP)
+#define POWER_4_ANDUP (POWER_4|POWER_5)
+#endif
+
+#if !defined(__power_4_andup)
+#define __power_4_andup() (_system_configuration.implementation & POWER_4_ANDUP)
+#endif
+
+#if !defined(__power_5_andup)
+#define __power_5_andup() (_system_configuration.implementation & POWER_5)
+#endif
+
 #endif
 
 void


### PR DESCRIPTION
PASE is the Unix subsystem of IBM i, and is binary compatible with AIX. Since IBM i is not a Unix, there are some subtle differences between both environments.

There is an issue with the way PASE on IBM i 7.2 behaves differently than AIX with regards to the POWER_n_ANDUP defines for CPU compatibility. When trying to build on i as opposed to AIX, the following errors appear which break the build:

```
make[5]: Entering directory '/home/YVANJ/mono-on-i/mono/mono/utils'
  CC       libmonoutils_la-mono-hwcap-ppc.lo
mono-hwcap-ppc.c: In function 'mono_hwcap_arch_init':
mono-hwcap-ppc.c:67:6: error: implicit declaration of function '__power_4_andup' [-Werror=implicit-function-declaration]  if (__power_4_andup())
      ^~~~~~~~~~~~~~~
mono-hwcap-ppc.c:67:2: warning: nested extern declaration of '__power_4_andup' [-Wnested-externs]
  if (__power_4_andup())
  ^~
mono-hwcap-ppc.c:69:6: error: implicit declaration of function '__power_5_andup' [-Werror=implicit-function-declaration]  if (__power_5_andup())
      ^~~~~~~~~~~~~~~
mono-hwcap-ppc.c:69:2: warning: nested extern declaration of '__power_5_andup' [-Wnested-externs]
  if (__power_5_andup())
```

This commit adds `#ifdef`s to handle this condition so the build works on IBM i 7.2 now. The resulting application code should not differ from the AIX output, however, this patch fixes the build failure.


