### PR TITLE
[do-not-merge] [bockbuild] make macOS package with debug flags enabled

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -39,7 +39,7 @@
 	url = git://github.com/mono/corefx.git
 [submodule "external/bockbuild"]
 	path = external/bockbuild
-	url = git://github.com/mono/bockbuild.git
+	url = git://github.com/lewurm/bockbuild.git
 [submodule "external/linker"]
 	path = external/linker
 	url = git://github.com/mono/linker.git

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -2095,7 +2095,7 @@ free_strings:
 	if (argv)
 		g_strfreev (argv);
 
-	g_printerr ("XXX-MONO: %s: returning handle %p for pid %d\n", __func__, handle, pid);
+	g_printerr ("XXX-MONO: %s: returning handle %p for pid %d from %d\n", __func__, handle, pid, getpid());
 
 	/* Check if something needs to be cleaned up. */
 	processes_cleanup ();

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -680,7 +680,7 @@ process_wait (MonoW32Handle *handle_data, guint32 timeout, gboolean *alerted)
 	}
 
 	/* Process must have exited */
-	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s (%p, %" G_GUINT32_FORMAT "): Waited successfully", __func__, handle_data, timeout);
+	g_printerr ("XXX-MONO: %s (%p, %" G_GUINT32_FORMAT "): Waited successfully", __func__, handle_data, timeout);
 
 	status = process->status;
 	if (WIFSIGNALED (status))

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -1842,8 +1842,7 @@ process_create (const gunichar2 *appname, const gunichar2 *cmdline,
 		g_free (token);
 	}
 
-	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: Exec prog [%s] args [%s]",
-		__func__, prog, args_after_prog);
+	g_printerr ("XXX-MONO: %s: Exec prog [%s] args [%s]\n", __func__, prog, args_after_prog);
 
 	/* Check for CLR binaries; if found, we will try to invoke
 	 * them using the same mono binary that started us.
@@ -2096,7 +2095,7 @@ free_strings:
 	if (argv)
 		g_strfreev (argv);
 
-	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: returning handle %p for pid %d", __func__, handle, pid);
+	g_printerr ("XXX-MONO: %s: returning handle %p for pid %d\n", __func__, handle, pid);
 
 	/* Check if something needs to be cleaned up. */
 	processes_cleanup ();


### PR DESCRIPTION
@monojenkins skip

@akoeplinger @alexischr I want to get a macOS package that is compiled with `CFLAGS='-O0 -ggdb3'`, is that the correct way to do it?

Context: https://github.com/xamarin/xamarin-android/pull/2357