### PR TITLE
[2018-10] [threading] Implement 'pulse' transition for two-phase STW

### DIFF
--- a/mono/metadata/sgen-stw.c
+++ b/mono/metadata/sgen-stw.c
@@ -329,7 +329,7 @@ sgen_unified_suspend_stop_world (void)
 			if (!(suspend_count == 1))
 				g_error ("[%p] suspend_count = %d, but should be 1", mono_thread_info_get_tid (info), suspend_count);
 
-			info->client_info.skip = !mono_thread_info_begin_resume (info);
+			info->client_info.skip = !mono_thread_info_begin_pulse_resume_and_request_suspension (info);
 			if (!info->client_info.skip)
 				restart_counter += 1;
 

--- a/mono/utils/mono-threads-coop.h
+++ b/mono/utils/mono-threads-coop.h
@@ -46,6 +46,13 @@ mono_threads_are_safepoints_enabled (void)
 	return mono_threads_is_cooperative_suspension_enabled () || mono_threads_is_hybrid_suspension_enabled ();
 }
 
+static inline gboolean
+mono_threads_is_multiphase_stw_enabled (void)
+{
+	/* So far, hybrid suspend is the only one using a multi-phase STW */
+	return mono_threads_is_hybrid_suspension_enabled ();
+}
+
 static inline void
 mono_threads_safepoint (void)
 {

--- a/mono/utils/mono-threads-state-machine.c
+++ b/mono/utils/mono-threads-state-machine.c
@@ -470,6 +470,53 @@ If this turns to be a problem we should either implement [2] or make this an inv
 }
 
 /*
+Try to resume a suspended thread and atomically request that it suspend again.
+
+Returns one of the following values:
+- InitAsyncPulse: The thread is suspended with preemptive suspend and should be resumed.
+*/
+MonoPulseResult
+mono_threads_transition_request_pulse (MonoThreadInfo* info)
+{
+	int raw_state, cur_state, suspend_count;
+	g_assert (info != mono_thread_info_current ()); //One can't self pulse [3]
+
+retry_state_change:
+	UNWRAP_THREAD_STATE (raw_state, cur_state, suspend_count, info);
+	switch (cur_state) {
+	case STATE_BLOCKING_ASYNC_SUSPENDED:
+		if (!(suspend_count == 1))
+			mono_fatal_with_history ("suspend_count = %d, but should be == 1", suspend_count);
+		if (mono_atomic_cas_i32 (&info->thread_state, STATE_BLOCKING_SUSPEND_REQUESTED, raw_state) != raw_state)
+			goto retry_state_change;
+		trace_state_change ("PULSE", info, raw_state, STATE_BLOCKING_SUSPEND_REQUESTED, -1);
+		return PulseInitAsyncPulse; // Pulse worked and caller must do async pulse, thread pulses in BLOCKING
+/*
+
+STATE_RUNNING:
+STATE_BLOCKING:
+Only one suspend initiator at a time.  Current STW stopped the
+thread and now needs to resume it.  So thread must be in one of the suspended
+states if we get here.
+
+STATE_BLOCKING_SUSPEND_REQUESTED:
+STATE_ASYNC_SUSPEND_REQUESTED:
+Only one pulse operation can be in flight, so a pulse cannot witness an
+internal state of suspend
+
+STATE_ASYNC_SUSPENDED:
+Hybrid suspend shouldn't put GC Unsafe threads into async suspended state.
+
+STATE_BLOCKING_SELF_SUSPENDED:
+STATE_SELF_SUSPENDED:
+Don't expect these to be pulsed - they're not problematic.
+*/
+	default:
+		mono_fatal_with_history ("Cannot transition thread %p from %s with REQUEST_PULSE", mono_thread_info_get_tid (info), state_name (cur_state));
+	}
+}
+
+/*
 This performs the last step of preemptive suspend.
 
 Returns TRUE if the caller should wait for resume.

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -978,6 +978,25 @@ mono_thread_info_core_resume (MonoThreadInfo *info)
 	return res;
 }
 
+/*
+ *   Current thread must hold the global_suspend_semaphore.
+ *   The given MonoThreadInfo* is a suspended thread.
+ *   Must be using hybrid suspend.
+ */
+static gboolean
+mono_thread_info_core_pulse (MonoThreadInfo *info)
+{
+	gboolean res = FALSE;
+
+	switch (mono_threads_transition_request_pulse (info)) {
+	case PulseInitAsyncPulse:
+		resume_async_suspended (info);
+		res = TRUE;
+		break;
+	}
+	return res;
+}
+
 gboolean
 mono_thread_info_resume (MonoNativeThreadId tid)
 {
@@ -1117,6 +1136,21 @@ mono_thread_info_begin_resume (MonoThreadInfo *info)
 	return mono_thread_info_core_resume (info);
 }
 
+gboolean
+mono_thread_info_begin_pulse_resume_and_request_suspension (MonoThreadInfo *info)
+{
+	/* For two-phase suspend, we want to atomically resume the thread and
+	 * request that it try to cooperatively suspend again.  Specifically,
+	 * we really don't want it to transition from GC Safe to GC Unsafe
+	 * because we then it could (in GC Unsafe) try to take a lock that's
+	 * held by another preemptively-suspended thread, essentially
+	 * recreating the same problem that two-phase suspend intends to
+	 * fix. */
+	if (!mono_threads_is_hybrid_suspension_enabled ())
+		return mono_thread_info_core_resume (info);
+	else
+		return mono_thread_info_core_pulse (info);
+}
 /*
 FIXME fix cardtable WB to be out of line and check with the runtime if the target is not the
 WB trampoline. Another option is to encode wb ranges in MonoJitInfo, but that is somewhat hard.

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -1146,10 +1146,10 @@ mono_thread_info_begin_pulse_resume_and_request_suspension (MonoThreadInfo *info
 	 * held by another preemptively-suspended thread, essentially
 	 * recreating the same problem that two-phase suspend intends to
 	 * fix. */
-	if (!mono_threads_is_hybrid_suspension_enabled ())
-		return mono_thread_info_core_resume (info);
-	else
+	if (mono_threads_is_multiphase_stw_enabled ())
 		return mono_thread_info_core_pulse (info);
+	else
+		return mono_thread_info_core_resume (info);
 }
 /*
 FIXME fix cardtable WB to be out of line and check with the runtime if the target is not the

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -656,6 +656,10 @@ typedef enum {
 } MonoResumeResult;
 
 typedef enum {
+	PulseInitAsyncPulse,
+} MonoPulseResult;
+
+typedef enum {
 	SelfSuspendResumed,
 	SelfSuspendNotifyAndWait,
 } MonoSelfSupendResult;
@@ -691,6 +695,7 @@ gboolean mono_threads_transition_detach (THREAD_INFO_TYPE *info);
 MonoRequestSuspendResult mono_threads_transition_request_suspension (THREAD_INFO_TYPE *info);
 MonoSelfSupendResult mono_threads_transition_state_poll (THREAD_INFO_TYPE *info);
 MonoResumeResult mono_threads_transition_request_resume (THREAD_INFO_TYPE* info);
+MonoPulseResult mono_threads_transition_request_pulse (THREAD_INFO_TYPE* info);
 gboolean mono_threads_transition_finish_async_suspend (THREAD_INFO_TYPE* info);
 MonoDoBlockingResult mono_threads_transition_do_blocking (THREAD_INFO_TYPE* info, const char* func);
 MonoDoneBlockingResult mono_threads_transition_done_blocking (THREAD_INFO_TYPE* info, const char* func);
@@ -750,6 +755,9 @@ G_EXTERN_C // due to THREAD_INFO_TYPE varying
 MonoThreadBeginSuspendResult mono_thread_info_begin_suspend (THREAD_INFO_TYPE *info, MonoThreadSuspendPhase phase);
 G_EXTERN_C // due to THREAD_INFO_TYPE varying
 gboolean mono_thread_info_begin_resume (THREAD_INFO_TYPE *info);
+G_EXTERN_C // due to THREAD_INFO_TYPE varying
+gboolean mono_thread_info_begin_pulse_resume_and_request_suspension (THREAD_INFO_TYPE *info);
+
 
 void mono_threads_add_to_pending_operation_set (THREAD_INFO_TYPE* info); //XXX rename to something to reflect the fact that this is used for both suspend and resume
 gboolean mono_threads_wait_pending_operations (void);


### PR DESCRIPTION
Backport #11708 to `2018-10`

----

This addresses the symptoms (ie invalid thread state transition assertions) from #11403 and #10722, at least for GC Safe threads.

With non-hybrid suspend, a pulse is just a resume.

With hybrid suspend, a `pulse` is a combination of a resume of a preemptively
suspended GC Unsafe thread and a request that it suspend again - as if we
atomically resumed the thread and then applied the initial phase of two-phase
suspend again.  If the now-running thread comes to a GC Safe -> GC Unsafe
transition it will suspend.  If not, we will preemptively suspend it again
during the mop-up phase.

The important thing is that we don't want the thread to transition to GC Unsafe
again: if it does so, it may try to take a lock that some other
async-suspended thread is holding, and it will never reach a safepoint ---
exactly the situation that two-phase suspend is supposed to solve.

----

This doesn't fix the underlying issue in #11403 - that we sometimes see a `MonoThreadInfo*` that relates to a GCD worker thread that isn't running (because the OS reuses a `pthread_t`).  But it does mean that we will resume it without asserting and then try to suspend it again once it's running and has non-zero stack and doesn't look like it's in a critical region anymore.

It's a fix for #10722 assuming that waiting for a resume after a self-suspend doesn't end up in what looks like a WOW64 API call - that would look like a GC Unsafe thread in a critical region which we would attempt to pulse. For now `mono_threads_transition_request_pulse` will assert if it sees a GC Unsafe thread.