### PR TITLE
[runtime] Initialize MethodBody objects by calling a ctor instead of accessing the object directly. This allows the MethodBody type to be removed by the linker.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # There is no ordering of corlib versions, no old or new,
 # the runtime expects an exact match.
 #
-MONO_CORLIB_VERSION=0CC970F6-6F25-4218-9427-3E4C3DC8DE33
+MONO_CORLIB_VERSION=5FEF1218-A70A-4752-9D8E-0A73E497190B
 
 #
 # Put a quoted #define in config.h.

--- a/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
+++ b/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
@@ -503,21 +503,7 @@
 		<type fullname="System.Reflection.Assembly" preserve="fields"/>
 
 		<type fullname="System.Reflection.AssemblyName" preserve="fields" />
-
-		<!-- custom-attr.c: create_custom_attr_data -->
-		<type fullname="System.Reflection.CustomAttributeData">
-			<method signature="System.Void .ctor(System.Reflection.ConstructorInfo,System.Reflection.Assembly,System.IntPtr,System.UInt32)" />
-		</type>
-
-		<!-- reflection.c: create_cattr_named_arg - create an instance with the ctor using 2 parameters -->
-		<type fullname="System.Reflection.CustomAttributeNamedArgument">
-			<method signature="System.Void .ctor(System.Reflection.MemberInfo,System.Object)" />
-		</type>
 		
-		<!-- reflection.c: create_cattr_typed_arg - create an instance with the ctor using 2 parameters -->
-		<type fullname="System.Reflection.CustomAttributeTypedArgument">
-			<method signature="System.Void .ctor(System.Type,System.Object)" />
-		</type>
 		<type fullname="System.Reflection.EventInfo" preserve="fields">
 			<method name="AddEventFrame" />
 			<method name="StaticAddEventAdapterFrame" />

--- a/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
+++ b/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
@@ -538,11 +538,6 @@
 			<method signature="System.Void .ctor()" />
 		</type>
 
-		<!-- reflection.c: mono_method_body_get_object -->
-		<type fullname="System.Reflection.MethodBody" preserve="fields" >
-			<!-- reflection.c mono_object_new_checked in method_body_object_construct -->
-			<method signature="System.Void .ctor()" />
-		</type>
 		<!-- domain.c: mono_defaults.method_info_class -->
 		<type fullname="System.Reflection.MethodInfo" preserve="nothing" />
 

--- a/mcs/class/corlib/ReferenceSources/MethodBase.cs
+++ b/mcs/class/corlib/ReferenceSources/MethodBase.cs
@@ -55,6 +55,7 @@ namespace System.Reflection
 		}
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		[PreserveDependency(".ctor(System.Reflection.ExceptionHandlingClause[],System.Reflection.LocalVariableInfo[],System.Byte[],System.Boolean,System.Int32,System.Int32)", "System.Reflection.MethodBody")]
 		internal extern static MethodBody GetMethodBodyInternal (IntPtr handle);
 
 		internal static MethodBody GetMethodBody (IntPtr handle) 

--- a/mcs/class/corlib/System.Reflection/CustomAttributeData.cs
+++ b/mcs/class/corlib/System.Reflection/CustomAttributeData.cs
@@ -55,6 +55,7 @@ namespace System.Reflection {
 		{
 		}
 
+		// custom-attrs.c:create_custom_attr_data ()
 		internal CustomAttributeData (ConstructorInfo ctorInfo, Assembly assembly, IntPtr data, uint data_length)
 		{
 			this.ctorInfo = ctorInfo;

--- a/mcs/class/corlib/System.Reflection/MethodBody.cs
+++ b/mcs/class/corlib/System.Reflection/MethodBody.cs
@@ -35,22 +35,27 @@ using System.Runtime.InteropServices;
 namespace System.Reflection {
 
 	[ComVisible (true)]
-	[StructLayout (LayoutKind.Sequential)]
 	public
 	class MethodBody {
-#pragma warning disable 649
-		#region Sync with reflection.h
 		ExceptionHandlingClause[] clauses;
 		LocalVariableInfo[] locals;
 		byte[] il;
 		bool init_locals;
 		int sig_token;
 		int max_stack;
-		#endregion
-#pragma warning restore 649
 
 		protected
 		MethodBody () {
+		}
+
+		internal MethodBody (ExceptionHandlingClause[] clauses, LocalVariableInfo[] locals,
+							 byte[] il, bool init_locals, int sig_token, int max_stack) {
+			this.clauses = clauses;
+			this.locals = locals;
+			this.il = il;
+			this.init_locals = init_locals;
+			this.sig_token = sig_token;
+			this.max_stack = max_stack;
 		}
 
 		public

--- a/mcs/class/corlib/System/MonoCustomAttrs.cs
+++ b/mcs/class/corlib/System/MonoCustomAttrs.cs
@@ -292,6 +292,9 @@ namespace System
 		}
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		[PreserveDependency(".ctor(System.Reflection.ConstructorInfo,System.Reflection.Assembly,System.IntPtr,System.UInt32)", "System.Reflection.CustomAttributeData")]
+		[PreserveDependency(".ctor(System.Reflection.MemberInfo,System.Object)", "System.Reflection.CustomAttributeNamedArgument")]
+		[PreserveDependency(".ctor(System.Type,System.Object)", "System.Reflection.CustomAttributeTypedArgument")]
 		static extern CustomAttributeData [] GetCustomAttributesDataInternal (ICustomAttributeProvider obj);
 
 		internal static IList<CustomAttributeData> GetCustomAttributesData (ICustomAttributeProvider obj, bool inherit = false)

--- a/mcs/tools/linker/Makefile
+++ b/mcs/tools/linker/Makefile
@@ -15,6 +15,7 @@ TEST_CASES := \
 	mscorlib/test-methodimpl-01.cs \
 	mscorlib/test-reflection-01.cs \
 	mscorlib/test-reflection-02.cs \
+	mscorlib/test-reflection-03.cs \
 	mscorlib/test-string-01.cs \
 	mscorlib/test-string-02.cs \
 	mscorlib/test-string-03.cs \

--- a/mcs/tools/linker/Makefile
+++ b/mcs/tools/linker/Makefile
@@ -16,6 +16,7 @@ TEST_CASES := \
 	mscorlib/test-reflection-01.cs \
 	mscorlib/test-reflection-02.cs \
 	mscorlib/test-reflection-03.cs \
+	mscorlib/test-reflection-04.cs \
 	mscorlib/test-string-01.cs \
 	mscorlib/test-string-02.cs \
 	mscorlib/test-string-03.cs \

--- a/mcs/tools/linker/Tests/mscorlib/test-reflection-03.cs
+++ b/mcs/tools/linker/Tests/mscorlib/test-reflection-03.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Reflection;
+
+class X
+{
+	public static int Main ()
+	{
+		var body = typeof (X).GetMethod ("Main").GetMethodBody ();
+		Console.WriteLine (body.LocalVariables.Count);
+		if (body.LocalVariables.Count == 0)
+			return 1;
+		return 0;
+	}
+}

--- a/mcs/tools/linker/Tests/mscorlib/test-reflection-04.cs
+++ b/mcs/tools/linker/Tests/mscorlib/test-reflection-04.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Reflection;
+
+public sealed class FooAttribute : Attribute
+{
+	public FooAttribute (int i) {
+	}
+
+	public int AProperty {
+		get {
+			return 0;
+		}
+		set {
+		}
+	}
+}
+
+[Foo]
+[Foo (5, AProperty=6)]
+class Program {
+	public static int Main () {
+		var attrs = typeof (Program).GetCustomAttributesData ();
+		if (attrs.Count != 1)
+			return 1;
+		return 0;
+	}
+}

--- a/mcs/tools/linker/Tests/mscorlib/test-reflection-04.cs
+++ b/mcs/tools/linker/Tests/mscorlib/test-reflection-04.cs
@@ -15,7 +15,6 @@ public sealed class FooAttribute : Attribute
 	}
 }
 
-[Foo]
 [Foo (5, AProperty=6)]
 class Program {
 	public static int Main () {

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -972,12 +972,6 @@ TYPED_HANDLE_DECL (MonoReflectionParameter);
 
 struct _MonoReflectionMethodBody {
 	MonoObject object;
-	MonoArray *clauses;
-	MonoArray *locals;
-	MonoArray *il;
-	MonoBoolean init_locals;
-	guint32 local_var_sig_token;
-	guint32 max_stack;
 };
 
 /* Safely access System.Reflection.MethodBody from native code */

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -1196,7 +1196,7 @@ mono_method_body_get_object (MonoDomain *domain, MonoMethod *method)
 	HANDLE_FUNCTION_RETURN_OBJ (result);
 }
 
-/* WARNING: This method can return NULL on sucess */
+/* WARNING: This method can return NULL on success */
 static MonoReflectionMethodBodyHandle
 method_body_object_construct (MonoDomain *domain, MonoClass *unused_class, MonoMethod *method, gpointer user_data, MonoError *error)
 {
@@ -1248,17 +1248,23 @@ method_body_object_construct (MonoDomain *domain, MonoClass *unused_class, MonoM
 	} else
 		local_var_sig_token = 0; //FIXME
 
+	static MonoMethod *ctor;
+	if (!ctor) {
+		MonoMethod *tmp = mono_class_get_method_from_name_checked (mono_class_get_method_body_class (), ".ctor", 6, 0, error);
+		mono_error_assert_ok (error);
+		g_assert (tmp);
+
+		mono_memory_barrier ();
+		ctor = tmp;
+	}
+
 	MonoReflectionMethodBodyHandle ret;
 	ret = MONO_HANDLE_CAST (MonoReflectionMethodBody, mono_object_new_handle (domain, mono_class_get_method_body_class (), error));
 	goto_if_nok (error, fail);
 
-	MONO_HANDLE_SETVAL (ret, init_locals, MonoBoolean, header->init_locals);
-	MONO_HANDLE_SETVAL (ret, max_stack, guint32, header->max_stack);
-	MONO_HANDLE_SETVAL (ret, local_var_sig_token, guint32, local_var_sig_token);
 	MonoArrayHandle il_arr;
 	il_arr = mono_array_new_handle (domain, mono_defaults.byte_class, header->code_size, error);
 	goto_if_nok (error, fail);
-	MONO_HANDLE_SET (ret, il, il_arr);
 	uint32_t il_gchandle;
 	guint8* il_data;
 	il_data = MONO_ARRAY_HANDLE_PIN (il_arr, guint8, 0, &il_gchandle);
@@ -1269,7 +1275,6 @@ method_body_object_construct (MonoDomain *domain, MonoClass *unused_class, MonoM
 	MonoArrayHandle locals_arr;
 	locals_arr = mono_array_new_handle (domain, mono_class_get_local_variable_info_class (), header->num_locals, error);
 	goto_if_nok (error, fail);
-	MONO_HANDLE_SET (ret, locals, locals_arr);
 	for (i = 0; i < header->num_locals; ++i) {
 		if (!add_local_var_info_to_array (domain, header, i, locals_arr, error))
 			goto fail;
@@ -1279,11 +1284,27 @@ method_body_object_construct (MonoDomain *domain, MonoClass *unused_class, MonoM
 	MonoArrayHandle exn_clauses;
 	exn_clauses = mono_array_new_handle (domain, mono_class_get_exception_handling_clause_class (), header->num_clauses, error);
 	goto_if_nok (error, fail);
-	MONO_HANDLE_SET (ret, clauses, exn_clauses);
 	for (i = 0; i < header->num_clauses; ++i) {
 		if (!add_exception_handling_clause_to_array (domain, header, i, exn_clauses, error))
 			goto fail;
 	}
+
+	/*
+	  MethodBody (ExceptionHandlingClause[] clauses, LocalVariableInfo[] locals,
+	              byte[] il, bool init_locals, int sig_token, int max_stack)
+	*/
+	gpointer params [6];
+	MonoBoolean init_locals_param = header->init_locals;
+	gint32 sig_token_param = local_var_sig_token;
+	gint32 max_stack_param = header->max_stack;
+	params [0] = MONO_HANDLE_RAW (exn_clauses);
+	params [1] = MONO_HANDLE_RAW (locals_arr);
+	params [2] = MONO_HANDLE_RAW (il_arr);
+	params [3] = &init_locals_param;
+	params [4] = &sig_token_param;
+	params [5] = &max_stack_param;
+	mono_runtime_invoke_handle (ctor, MONO_HANDLE_CAST (MonoObject, ret), params, error);
+	mono_error_assert_ok (error);
 
 	mono_metadata_free_mh (header);
 	return ret;

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -1206,6 +1206,10 @@ method_body_object_construct (MonoDomain *domain, MonoClass *unused_class, MonoM
 	char *ptr;
 	unsigned char format, flags;
 	int i;
+	gpointer params [6];
+	MonoBoolean init_locals_param;
+	gint32 sig_token_param;
+	gint32 max_stack_param;
 
 	error_init (error);
 
@@ -1293,10 +1297,12 @@ method_body_object_construct (MonoDomain *domain, MonoClass *unused_class, MonoM
 	  MethodBody (ExceptionHandlingClause[] clauses, LocalVariableInfo[] locals,
 	              byte[] il, bool init_locals, int sig_token, int max_stack)
 	*/
-	gpointer params [6];
-	MonoBoolean init_locals_param = header->init_locals;
-	gint32 sig_token_param = local_var_sig_token;
-	gint32 max_stack_param = header->max_stack;
+	init_locals_param = header->init_locals;
+	sig_token_param = local_var_sig_token;
+	max_stack_param = header->max_stack;
+	mono_metadata_free_mh (header);
+	header = NULL;
+
 	params [0] = MONO_HANDLE_RAW (exn_clauses);
 	params [1] = MONO_HANDLE_RAW (locals_arr);
 	params [2] = MONO_HANDLE_RAW (il_arr);
@@ -1306,7 +1312,6 @@ method_body_object_construct (MonoDomain *domain, MonoClass *unused_class, MonoM
 	mono_runtime_invoke_handle (ctor, MONO_HANDLE_CAST (MonoObject, ret), params, error);
 	mono_error_assert_ok (error);
 
-	mono_metadata_free_mh (header);
 	return ret;
 fail:
 	if (header)


### PR DESCRIPTION
Contributes to #9333