### PR TITLE
[2018-08] Add .NET 4.7.2 reference assemblies

### DIFF
--- a/mcs/class/reference-assemblies/Makefile
+++ b/mcs/class/reference-assemblies/Makefile
@@ -28,6 +28,7 @@ install-local:
 	$(MKINSTALLDIRS) $(PROFILE_DIR)/4.6.2-api/Facades
 	$(MKINSTALLDIRS) $(PROFILE_DIR)/4.7-api/Facades
 	$(MKINSTALLDIRS) $(PROFILE_DIR)/4.7.1-api/Facades
+	$(MKINSTALLDIRS) $(PROFILE_DIR)/4.7.2-api/Facades
 
 	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v2.0/*.dll $(PROFILE_DIR)/2.0-api
 	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v3.5/*.dll $(PROFILE_DIR)/3.5-api
@@ -40,6 +41,7 @@ install-local:
 	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v4.6.2/*.dll $(PROFILE_DIR)/4.6.2-api
 	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v4.7/*.dll $(PROFILE_DIR)/4.7-api
 	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v4.7.1/*.dll $(PROFILE_DIR)/4.7.1-api
+	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v4.7.2/*.dll $(PROFILE_DIR)/4.7.2-api
 
 	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v4.5/Facades/*.dll $(PROFILE_DIR)/4.5-api/Facades
 	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v4.5.1/Facades/*.dll $(PROFILE_DIR)/4.5.1-api/Facades
@@ -49,6 +51,7 @@ install-local:
 	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v4.6.2/Facades/*.dll $(PROFILE_DIR)/4.6.2-api/Facades
 	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v4.7/Facades/*.dll $(PROFILE_DIR)/4.7-api/Facades
 	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v4.7.1/Facades/*.dll $(PROFILE_DIR)/4.7.1-api/Facades
+	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/v4.7.2/Facades/*.dll $(PROFILE_DIR)/4.7.2-api/Facades
 
 	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/mono/*.dll $(PROFILE_DIR)/2.0-api
 	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/mono/*.dll $(PROFILE_DIR)/4.0-api
@@ -61,6 +64,8 @@ install-local:
 	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/mono/*.dll $(PROFILE_DIR)/4.7-api
 	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/mono/*.dll $(PROFILE_DIR)/4.7.1-api
 	rm -f $(PROFILE_DIR)/4.7.1-api/ICSharpCode.SharpZipLib.dll
+	$(INSTALL_LIB) ../../../external/binary-reference-assemblies/mono/*.dll $(PROFILE_DIR)/4.7.2-api
+	rm -f $(PROFILE_DIR)/4.7.2-api/ICSharpCode.SharpZipLib.dll
 
 	# Unfortunately, a few programs (most notably NUnit and FSharp) have hardcoded checks for <prefix>/lib/mono/4.0/mscorlib.dll or Mono.Posix.dll,
 	# so we need to place something there or those tools break. We decided to symlink to the reference assembly for now.
@@ -70,6 +75,7 @@ install-local:
 	ln -sf ../4.0-api/Mono.Posix.dll $(PROFILE_DIR)/4.0/Mono.Posix.dll
 
 DISTFILES =	\
+	$(wildcard ../../../external/binary-reference-assemblies/v4.7.2/Facades/*.dll)	\
 	$(wildcard ../../../external/binary-reference-assemblies/v4.7.1/Facades/*.dll)	\
 	$(wildcard ../../../external/binary-reference-assemblies/v4.7/Facades/*.dll)	\
 	$(wildcard ../../../external/binary-reference-assemblies/v4.6.2/Facades/*.dll)	\
@@ -78,6 +84,7 @@ DISTFILES =	\
 	$(wildcard ../../../external/binary-reference-assemblies/v4.5.2/Facades/*.dll)	\
 	$(wildcard ../../../external/binary-reference-assemblies/v4.5.1/Facades/*.dll)	\
 	$(wildcard ../../../external/binary-reference-assemblies/v4.5/Facades/*.dll)	\
+	$(wildcard ../../../external/binary-reference-assemblies/v4.7.2/*.dll)	\
 	$(wildcard ../../../external/binary-reference-assemblies/v4.7.1/*.dll)	\
 	$(wildcard ../../../external/binary-reference-assemblies/v4.7/*.dll)	\
 	$(wildcard ../../../external/binary-reference-assemblies/v4.6.2/*.dll)	\
@@ -90,6 +97,7 @@ DISTFILES =	\
 	$(wildcard ../../../external/binary-reference-assemblies/v3.5/*.dll)	\
 	$(wildcard ../../../external/binary-reference-assemblies/v2.0/*.dll)	\
 	$(wildcard ../../../external/binary-reference-assemblies/mono/*.dll)	\
+	$(wildcard ../../../external/binary-reference-assemblies/src/v4.7.2/Facades/*.cs)	\
 	$(wildcard ../../../external/binary-reference-assemblies/src/v4.7.1/Facades/*.cs)	\
 	$(wildcard ../../../external/binary-reference-assemblies/src/v4.7/Facades/*.cs)	\
 	$(wildcard ../../../external/binary-reference-assemblies/src/v4.6.2/Facades/*.cs)	\
@@ -98,6 +106,7 @@ DISTFILES =	\
 	$(wildcard ../../../external/binary-reference-assemblies/src/v4.5.2/Facades/*.cs)	\
 	$(wildcard ../../../external/binary-reference-assemblies/src/v4.5.1/Facades/*.cs)	\
 	$(wildcard ../../../external/binary-reference-assemblies/src/v4.5/Facades/*.cs)	\
+	$(wildcard ../../../external/binary-reference-assemblies/src/v4.7.2/*.cs)	\
 	$(wildcard ../../../external/binary-reference-assemblies/src/v4.7.1/*.cs)	\
 	$(wildcard ../../../external/binary-reference-assemblies/src/v4.7/*.cs)	\
 	$(wildcard ../../../external/binary-reference-assemblies/src/v4.6.2/*.cs)	\
@@ -110,6 +119,7 @@ DISTFILES =	\
 	$(wildcard ../../../external/binary-reference-assemblies/src/v3.5/*.cs)	\
 	$(wildcard ../../../external/binary-reference-assemblies/src/v2.0/*.cs)	\
 	$(wildcard ../../../external/binary-reference-assemblies/src/mono/*.cs)	\
+	../../../external/binary-reference-assemblies/v4.7.2/Makefile	\
 	../../../external/binary-reference-assemblies/v4.7.1/Makefile	\
 	../../../external/binary-reference-assemblies/v4.7/Makefile	\
 	../../../external/binary-reference-assemblies/v4.6.2/Makefile	\

--- a/mcs/mcs/ikvm.cs
+++ b/mcs/mcs/ikvm.cs
@@ -256,6 +256,7 @@ namespace Mono.CSharp
 			sdk_directory.Add ("4.6.2", new string [] { "4.6.2-api", "v4.0.30319" });
 			sdk_directory.Add ("4.7", new string [] { "4.7-api", "v4.0.30319" });
 			sdk_directory.Add ("4.7.1", new string [] { "4.7.1-api", "v4.0.30319" });
+			sdk_directory.Add ("4.7.2", new string [] { "4.7.2-api", "v4.0.30319" });
 			sdk_directory.Add ("4.x", new string [] { "4.5", "net_4_x", "v4.0.30319" });
 		}
 

--- a/mcs/tools/xbuild/Makefile
+++ b/mcs/tools/xbuild/Makefile
@@ -81,6 +81,8 @@ install-frameworks:
 	$(INSTALL_DATA) frameworks/net_4.7.xml $(DESTDIR)$(NETFRAMEWORK_DIR)/v4.7/RedistList/FrameworkList.xml
 	$(MKINSTALLDIRS) $(DESTDIR)$(NETFRAMEWORK_DIR)/v4.7.1/RedistList
 	$(INSTALL_DATA) frameworks/net_4.7.1.xml $(DESTDIR)$(NETFRAMEWORK_DIR)/v4.7.1/RedistList/FrameworkList.xml
+	$(MKINSTALLDIRS) $(DESTDIR)$(NETFRAMEWORK_DIR)/v4.7.2/RedistList
+	$(INSTALL_DATA) frameworks/net_4.7.2.xml $(DESTDIR)$(NETFRAMEWORK_DIR)/v4.7.2/RedistList/FrameworkList.xml
 
 install-pcl-targets:
 	$(MKINSTALLDIRS) $(DESTDIR)$(PORTABLE_TARGETS_DIR)
@@ -190,6 +192,7 @@ EXTRA_DISTFILES = \
 	frameworks/net_4.6.2.xml \
 	frameworks/net_4.7.xml \
 	frameworks/net_4.7.1.xml \
+	frameworks/net_4.7.2.xml \
 	targets/Microsoft.WebApplication.targets	\
 	$(NUGET_BUILDTASKS_REPO_DIR)/src/Microsoft.NuGet.Build.Tasks/ImportBeforeAfter/Microsoft.NuGet.ImportBefore.props	\
 	$(NUGET_BUILDTASKS_REPO_DIR)/src/Microsoft.NuGet.Build.Tasks/ImportBeforeAfter/Microsoft.NuGet.ImportAfter.targets	\

--- a/mcs/tools/xbuild/frameworks/net_4.7.2.xml
+++ b/mcs/tools/xbuild/frameworks/net_4.7.2.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FileList  Name=".NET Framework 4.7.2" TargetFrameworkDirectory="..\..\..\..\4.7.2-api">
+</FileList>


### PR DESCRIPTION
Backport of https://github.com/mono/mono/pull/11391 to 2018-08