### PR TITLE
[interp] Add inlining of small methods

### DIFF
--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -38,6 +38,10 @@ enum {
 	VAL_OBJ     = 3 + VAL_POINTER
 };
 
+enum {
+	INTERP_OPT_INLINE = 1
+};
+
 #if SIZEOF_VOID_P == 4
 typedef guint32 mono_u;
 typedef gint32  mono_i;
@@ -152,6 +156,7 @@ typedef struct {
 } ThreadContext;
 
 extern int mono_interp_traceopt;
+extern int mono_interp_opt;
 extern GSList *mono_interp_jit_classes;
 
 void

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -98,6 +98,8 @@ init_frame (InterpFrame *frame, InterpFrame *parent_frame, InterpMethod *rmethod
  * Used for testing.
  */
 GSList *mono_interp_jit_classes;
+/* Optimizations enabled with interpreter */
+int mono_interp_opt = INTERP_OPT_INLINE;
 /* If TRUE, interpreted code will be interrupted at function entry/backward branches */
 static gboolean ss_enabled;
 
@@ -5976,6 +5978,8 @@ interp_parse_options (const char *options)
 			mono_interp_jit_classes = g_slist_prepend (mono_interp_jit_classes, arg + 4);
 		if (strncmp (arg, "interp-only=", 4) == 0)
 			mono_interp_only_classes = g_slist_prepend (mono_interp_only_classes, arg + strlen ("interp-only="));
+		if (strncmp (arg, "-inline", 7) == 0)
+			mono_interp_opt &= ~INTERP_OPT_INLINE;
 	}
 }
 

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -6232,6 +6232,8 @@ mono_ee_interp_init (const char *opts)
 	set_context (NULL);
 
 	interp_parse_options (opts);
+	if (mini_get_debug_options ()->mdb_optimizations)
+		mono_interp_opt &= ~INTERP_OPT_INLINE;
 	mono_interp_transform_init ();
 
 	MonoEECallbacks c;

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -71,7 +71,6 @@ typedef struct
 	InterpMethod *rtm;
 	const unsigned char *il_code;
 	const unsigned char *ip;
-	const unsigned char *last_ip;
 	const unsigned char *in_start;
 	int code_size;
 	int body_start_offset;
@@ -5130,8 +5129,6 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 			td->last_new_ip = td->new_code + new_in_start_offset;
 		else if (td->is_bb_start [td->in_start - td->il_code])
 			td->is_bb_start [td->ip - td->il_code] = 1;
-			
-		td->last_ip = td->in_start;
 	}
 
 	g_assert (td->ip == end);

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1729,7 +1729,7 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 	}
 
 	g_assert (csignature->call_convention != MONO_CALL_FASTCALL);
-	if (op == -1 && !is_virtual && target_method && interp_method_check_inlining (td, target_method)) {
+	if ((mono_interp_opt & INTERP_OPT_INLINE) && op == -1 && !is_virtual && target_method && interp_method_check_inlining (td, target_method)) {
 		MonoMethodHeader *mheader = interp_method_get_header (target_method, error);
 		return_val_if_nok (error, FALSE);
 


### PR DESCRIPTION
Avoid call overhead by inlining small methods. We replace stinarg opcodes with storing of the arguments in locals allocated in the parent frame (for each argument).

TODO
- support for methods with locals
- maybe add inline costs to prevent over inlining

On microbenchmark inlining can improve up to 3.5x (less than the 5x that I observed with jit).

Contributes to #11531 