### PR TITLE
[2018-06][ios] fix path for llvm invocation

### DIFF
--- a/sdks/ios/appbuilder/appbuilder.cs
+++ b/sdks/ios/appbuilder/appbuilder.cs
@@ -161,7 +161,7 @@ public class AppBuilder
 			aot_args += ",soft-debug";
 		if (isllvm) {
 			cross_runtime_args = "--llvm";
-			aot_args += ",llvm-path=$mono_sdkdir/ios-llvm64/bin,llvm-outfile=$llvm_outfile";
+			aot_args += ",llvm-path=$mono_sdkdir/llvm-llvm64/bin,llvm-outfile=$llvm_outfile";
 		}
 
 		Directory.CreateDirectory (builddir);


### PR DESCRIPTION
Seems like this change got lost when backporting https://github.com/mono/mono/pull/10445. The other branches, 2018-06 and 2018-10, are fine.

This should make the LLVM step on the iOS SDK lane green again.

Context: https://github.com/mono/mono/pull/10440#issuecomment-439461353

Note: The products do _not_ need this change.
