### PR TITLE
[2018-10] [arm64] Fix passing r4/r8 arguments on the stack in the gsharedvt trampoline.

### DIFF
--- a/mono/mini/gshared.cs
+++ b/mono/mini/gshared.cs
@@ -1703,6 +1703,8 @@ public class Tests
 				   uint i1, uint i2, uint i3, uint i4);
 		int Structs (T t, int dummy1, int a2, int a3, int a4, int a5, int a6, int a7, int dummy8,
 					 BStruct s);
+		int Floats (T t, double d1, double d2, double d3, double d4, double d5, double d6, double d7, double d8,
+					double d9, double d10, float s11, float s12);
 		void Generic<T2> (T t, T2[] arr, int dummy1, int a2, int a3, int a4, int a5, int a6, int a7, int dummy8,
 						  T2 i1, T2 i2, T2 i3, T2 i4);
 	}
@@ -1736,7 +1738,10 @@ public class Tests
 							BStruct s) {
 			return s.a + s.b + s.c + s.d;
 		}
-
+		public int Floats (T t, double d1, double d2, double d3, double d4, double d5, double d6, double d7, double d8,
+						   double d9, double d10, float s11, float s12) {
+			return (int)d9 + (int)d10 + (int)s11 + (int)s12;
+		}
 		public void Generic<T2> (T t, T2[] arr, int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, T2 i1, T2 i2, T2 i3, T2 i4) {
 			arr [0] = i1;
 			arr [1] = i2;
@@ -1766,10 +1771,13 @@ public class Tests
 		int res6 = o.UInts (new EmptyStruct (), 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4);
 		if (res6 != 10)
 			return 6;
+		int res7 = o.Floats (new EmptyStruct (), 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 10.0, 20.0, 30.0f, 40.0f);
+		if (res7 != 100)
+			return 7;
 		int[] arr = new int [4];
 		o.Generic<int> (new EmptyStruct (), arr, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4);
 		if (arr [0] != 1 || arr [1] != 2 || arr [2] != 3 || arr [3] != 4)
-			return 7;
+			return 8;
 		return 0;
 	}
 

--- a/mono/mini/mini-arm64-gsharedvt.c
+++ b/mono/mini/mini-arm64-gsharedvt.c
@@ -105,6 +105,8 @@ get_arg_slots (ArgInfo *ainfo, int **out_slots)
 			src [i] = map_reg (sreg + i);
 		break;
 	case ArgOnStack:
+	case ArgOnStackR4:
+	case ArgOnStackR8:
 		nsrc = 1;
 		src = g_malloc (nsrc * sizeof (int));
 		src [0] = map_stack_slot (sslot);
@@ -253,7 +255,7 @@ mono_arch_get_gsharedvt_call_info (gpointer addr, MonoMethodSignature *normal_si
 		}
 		if (nsrc)
 			src [0] |= (arg_marshal << 18);
-		if (ainfo->storage == ArgOnStack && ainfo->slot_size != 8) {
+		if ((ainfo->storage == ArgOnStack || ainfo->storage == ArgOnStackR4) && ainfo->slot_size != 8) {
 			GSharedVtArgSize arg_size = GSHAREDVT_ARG_SIZE_NONE;
 
 			/*


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/11613.

Backport of #11741.

/cc @marek-safar @vargaz