### PR TITLE
Hide detection fixes for events

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # There is no ordering of corlib versions, no old or new,
 # the runtime expects an exact match.
 #
-MONO_CORLIB_VERSION=1A934952-191D-42F2-8674-FE1472AAB632
+MONO_CORLIB_VERSION=7A6EDC32-7F43-403B-8F6F-53AB0AD74819
 
 #
 # Put a quoted #define in config.h.

--- a/mcs/class/corlib/ReferenceSources/RuntimeType.cs
+++ b/mcs/class/corlib/ReferenceSources/RuntimeType.cs
@@ -675,7 +675,7 @@ namespace System
 		extern int GetGenericParameterPosition ();
 
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
-		extern IntPtr GetEvents_native (IntPtr name, BindingFlags bindingAttr,  MemberListType listType);
+		extern IntPtr GetEvents_native (IntPtr name,  MemberListType listType);
 
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		extern IntPtr GetFields_native (IntPtr name, BindingFlags bindingAttr, MemberListType listType);
@@ -699,7 +699,7 @@ namespace System
 		{
 			var refh = new RuntimeTypeHandle (reflectedType);
 			using (var namePtr = new Mono.SafeStringMarshal (name))
-			using (var h = new Mono.SafeGPtrArrayHandle (GetEvents_native (namePtr.Value, bindingAttr, listType))) {
+			using (var h = new Mono.SafeGPtrArrayHandle (GetEvents_native (namePtr.Value, listType))) {
 				int n = h.Length;
 				var a = new RuntimeEventInfo[n];
 				for (int i = 0; i < n; i++) {

--- a/mcs/class/corlib/System.Reflection/MonoEvent.cs
+++ b/mcs/class/corlib/System.Reflection/MonoEvent.cs
@@ -63,15 +63,17 @@ namespace System.Reflection {
 
 	abstract class RuntimeEventInfo : EventInfo, ISerializable
 	{
-		internal BindingFlags BindingFlags {
-			get {
-				return 0;
-			}
-		}
+        internal abstract BindingFlags GetBindingFlags ();
 
 		public override Module Module {
 			get {
 				return GetRuntimeModule ();
+			}
+		}
+
+		internal BindingFlags BindingFlags {
+			get {
+				return GetBindingFlags ();
 			}
 		}
 
@@ -117,7 +119,20 @@ namespace System.Reflection {
 		IntPtr handle;
 #pragma warning restore 169
 
-		public override EventAttributes Attributes {
+		internal override BindingFlags GetBindingFlags ()
+		{
+			MonoEventInfo info = MonoEventInfo.GetEventInfo (this);
+
+			MethodInfo method = info.add_method;
+			if (method == null)
+				method = info.remove_method;
+			if (method == null)
+				method = info.raise_method;
+
+			return RuntimeType.FilterPreCalculate (method != null && method.IsPublic, GetDeclaringTypeInternal () != ReflectedType , method != null && method.IsStatic);
+		}
+
+        public override EventAttributes Attributes {
 			get {
 				return MonoEventInfo.GetEventInfo (this).attrs;
 			}

--- a/mcs/class/corlib/Test/System.Reflection/EventInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/EventInfoTest.cs
@@ -130,6 +130,25 @@ namespace MonoTests.System.Reflection
 			Assert.IsTrue ((int)ev.MetadataToken > 0);
 		}
 
+        [Test]
+        public void TestDerivedClassHidingEventWithPrivate ()
+        {
+			Type derived = typeof(Derived);
+			EventInfo[] events = derived.GetEvents (BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
+			Assert.AreEqual(0, events.Length, "MyEvent event is private in derived class and should be hidden.");
+
+			Type staticDerived2 = typeof(StaticDerived2);
+			EventInfo[] events2 = staticDerived2.GetEvents(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
+			Console.WriteLine(events2.Length);
+		}
+
+        [Test]
+		public void TestDerivedClassOveridingEventWithStatic () {
+			Type staticDerived2 = typeof(StaticDerived2);
+			EventInfo[] events = staticDerived2.GetEvents(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
+			Assert.AreEqual(0, events.Length, "MyEvent event is static in parent class and should be hidden.");
+		}
+
 #pragma warning disable 67
 		public class PrivateEvent
 		{
@@ -147,6 +166,35 @@ namespace MonoTests.System.Reflection
 			private event EventHandler priv;
 		}
 
+		private abstract class Base
+		{
+			public event Action MyEvent { add { } remove { } }
+			public int MyProp { get; }
+		}
+
+		private abstract class Derived : Base
+		{
+			private new event Action MyEvent { add { } remove { } }
+			private new int MyProp { get; }
+		}
+
+		private abstract class Derived2 : Derived
+		{
+		}
+
+		private class StaticBase
+		{
+			public event Action MyEvent { add { } remove { } }
+		}
+
+		private class StaticDerived : StaticBase
+		{
+			public new static event Action MyEvent { add { } remove { } }
+		}
+
+		private class StaticDerived2 : StaticDerived
+		{
+		}
 #pragma warning restore 67
 	}
 }

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -874,7 +874,7 @@ HANDLES(RT_1, "CreateInstanceInternal", ves_icall_System_Activator_CreateInstanc
 HANDLES(RT_2, "GetConstructors_native", ves_icall_RuntimeType_GetConstructors_native, GPtrArray_ptr, 2, (MonoReflectionType, guint32))
 HANDLES(RT_30, "GetCorrespondingInflatedConstructor", ves_icall_RuntimeType_GetCorrespondingInflatedMethod, MonoReflectionMethod, 2, (MonoReflectionType, MonoReflectionMethod))
 HANDLES_REUSE_WRAPPER(RT_31, "GetCorrespondingInflatedMethod", ves_icall_RuntimeType_GetCorrespondingInflatedMethod)
-HANDLES(RT_3, "GetEvents_native", ves_icall_RuntimeType_GetEvents_native, GPtrArray_ptr, 4, (MonoReflectionType, char_ptr, guint32, guint32))
+HANDLES(RT_3, "GetEvents_native", ves_icall_RuntimeType_GetEvents_native, GPtrArray_ptr, 3, (MonoReflectionType, char_ptr, guint32))
 HANDLES(RT_5, "GetFields_native", ves_icall_RuntimeType_GetFields_native, GPtrArray_ptr, 4, (MonoReflectionType, char_ptr, guint32, guint32))
 HANDLES(RT_6, "GetGenericArgumentsInternal", ves_icall_RuntimeType_GetGenericArguments, MonoArray, 2, (MonoReflectionType, MonoBoolean))
 HANDLES(RT_9, "GetGenericParameterPosition", ves_icall_RuntimeType_GetGenericParameterPosition, gint32, 1, (MonoReflectionType))


### PR DESCRIPTION
This PR fixes #11235 by removing BindingFlags checks from native code to instead
trust the checks made in managed code. This fixes the case when events were incorrectly returned from types that have overridden private or static events.

Fixes #11235 