### PR TITLE
[tests] Propagate runtime exit code in test_op_il_seq_point.sh

### DIFF
--- a/mono/mini/iltests.il
+++ b/mono/mini/iltests.il
@@ -3136,48 +3136,6 @@ L_3:
        ret
   }
 
-  // Test that calli does signature checking
-  .method public static int32 calli_sig_check (string s) cil managed
-  {
-	.maxstack 16
-	ldc.i4.0
-	ret
-   }
-
-  .method public static int32 calli_sig_check_2 () cil managed
-  {
-	.maxstack 16
-
-	ldc.r4 1.13
-	ldftn int32 Tests::calli_sig_check(string)
-	calli int32(string)
-	ret
-   }
-
-	.method public static int32 test_0_calli_sig_check () cil managed
-	{
-	    .custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 0C 21 49 4E 54 45 52 50 52 45 54 45 52 00 00 )   // ...!INTERPRETER.
-		.custom instance void class [TestDriver]CategoryAttribute::'.ctor'(string) =  (01 00 08 21 46 55 4C 4C 41 4F 54 00 00 ) // ...!FULLAOT..
-		.custom instance void [TestDriver]CategoryAttribute::.ctor(string) = ( 01 00 08 21 42 49 54 43 4F 44 45 00 00 ) // ...!BITCODE..
-		.maxstack 16
-
-		.try {
-			call int32 Tests::calli_sig_check_2()
-			pop
-			leave L0
-		} catch [mscorlib]System.InvalidProgramException {
-			pop
-			leave L1
-		}
-
-		L0:
-			ldc.i4.1
-			ret
-		L1:
-			ldc.i4.0
-			ret
-	}
-
   .method public hidebysig static int32 test_1_box_r8_r4_autoconv () cil managed
   {
 		ldc.r8 1.234

--- a/mono/mini/test_op_il_seq_point.sh
+++ b/mono/mini/test_op_il_seq_point.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 DEFAULT_PROFILE=$1
 TEST_FILE=$2
@@ -38,26 +38,30 @@ clean_aot () {
 get_methods () {
 	if [ -z $4 ]; then
 		MONO_PATH=$1 $2 -v --compile-all=1 $3 | grep '^Method .*code length' | sed 's/emitted[^()]*//' | sort
+		return ${PIPESTATUS[0]}
 	else
 		clean_aot
 		MONO_PATH=$1 $2 -v $PLATFORM_AOT_ARGUMENT $3 | grep '^Method .*code length' | sed 's/emitted[^()]*//' | sort
+		return ${PIPESTATUS[0]}
 	fi
 }
 
 get_method () {
 	if [ -z $5 ]; then
 		MONO_VERBOSE_METHOD="$4" MONO_PATH=$1 $2 --compile-all=1 $3 | sed 's/0x[0-9a-fA-F]*/0x0/g'
+		return ${PIPESTATUS[0]}
 	else
 		clean_aot
 		MONO_VERBOSE_METHOD="$4" MONO_PATH=$1 $2 $PLATFORM_AOT_ARGUMENT $3 | sed 's/0x[0-9a-fA-F]*/0x0/g'
+		return ${PIPESTATUS[0]}
 	fi
 }
 
 diff_methods () {
 	TMP_FILE1=$(tmp_file)
 	TMP_FILE2=$(tmp_file)
-	echo "$(MONO_DEBUG=no-compact-seq-points,single-imm-size get_methods $1 $2 $3 $4)" >$TMP_FILE1
-	echo "$(MONO_DEBUG=single-imm-size get_methods $1 $2 $3 $4)" >$TMP_FILE2
+	echo "$(MONO_DEBUG=no-compact-seq-points,single-imm-size get_methods $1 $2 $3 $4 || echo Non-zero exit code for file1: $?)" >$TMP_FILE1
+	echo "$(MONO_DEBUG=single-imm-size get_methods $1 $2 $3 $4 || echo Non-zero exit code for file2: $?)" >$TMP_FILE2
 	diff $TMP_FILE1 $TMP_FILE2
 }
 
@@ -88,13 +92,16 @@ TMP_FILE=$(tmp_file)
 echo "$(diff_methods $MONO_PATH $RUNTIME $TEST_FILE $USE_AOT)" > $TMP_FILE
 
 CHANGES=0
+FAIL=0
 METHOD=""
 MIN_SIZE=10000
 
 while read line; do
 	if [ "$line" != "" ]; then
 		echo $line
-		if [[ ${line:0:1} == "<" ]]; then
+		if [[ "$line" == *"Non-zero exit code"* ]]; then
+			FAIL=1
+		elif [[ ${line:0:1} == "<" ]]; then
 			CHANGES=$((CHANGES+1))
 			SIZE=$(get_method_length "$line")
 			if [[ SIZE -lt MIN_SIZE ]]; then
@@ -109,7 +116,19 @@ TESTRESULT_FILE=TestResult-op_il_seq_point.tmp
 
 echo -n "              <test-case name=\"MonoTests.op_il_seq_point.${TEST_FILE}${USE_AOT}\" executed=\"True\" time=\"0\" asserts=\"0\" success=\"" >> $TESTRESULT_FILE
 
-if [ $CHANGES != 0 ]
+if [ $FAIL != 0 ]
+then
+	echo "False\">" >> $TESTRESULT_FILE
+	echo "                <failure>" >> $TESTRESULT_FILE
+	echo -n "                  <message><![CDATA[" >> $TESTRESULT_FILE
+	echo "Mono failed on $TEST_FILE" >> $TESTRESULT_FILE
+	echo "]]></message>" >> $TESTRESULT_FILE
+	echo "                  <stack-trace>" >> $TESTRESULT_FILE
+	echo "                  </stack-trace>" >> $TESTRESULT_FILE
+	echo "                </failure>" >> $TESTRESULT_FILE
+	echo "              </test-case>" >> $TESTRESULT_FILE
+	exit 1
+elif [ $CHANGES != 0 ]
 then
 	METHOD_NAME=$(get_method_name "$METHOD")
 

--- a/mono/mini/test_op_il_seq_point_headerfooter.sh
+++ b/mono/mini/test_op_il_seq_point_headerfooter.sh
@@ -1,9 +1,9 @@
-#!/bin/sh
+#!/bin/sh -e
 
 TESTRESULT_FILE=TestResult-op_il_seq_point.tmp
-TOTAL=$(grep -c "<test-case" $TESTRESULT_FILE)
-FAILURES=$(grep -c "<failure>" $TESTRESULT_FILE)
-if [ "$FAILURES" -eq "0" ]
+TOTAL=$(grep -c "<test-case" $TESTRESULT_FILE || true)
+FAILURES=$(grep -c "<failure>" $TESTRESULT_FILE || true)
+if [ "$FAILURES" -eq "0" ] && [ "$TOTAL" -ne "0" ]
 then
 	PASS="True"
 else

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -934,6 +934,7 @@ TESTS_IL_SRC=			\
 	invalid-token.il	\
 	call_missing_method.il	\
 	call_missing_class.il	\
+	calli_sig_check.il	\
 	ldfld_missing_field.il	\
 	ldfld_missing_class.il	\
 	find-method.2.il	\
@@ -1406,6 +1407,7 @@ endif
 # Could not resolve type with token 01000002 assembly:mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089 type:System.BrokenIComparable`1 member:<none>.
 PROFILE_DISABLED_TESTS += \
 	constraints-load.exe \
+	calli_sig_check.exe \
 	bug-515884.exe
 
 PROFILE_DISABLED_TESTS += \
@@ -1531,7 +1533,8 @@ PROFILE_DISABLED_TESTS += \
 endif
 
 AOT_DISABLED_TESTS= \
-	constraints-load.exe
+	constraints-load.exe \
+	calli_sig_check.exe
 
 CI_DISABLED_TESTS = \
 	main-returns-background-resetabort.exe \
@@ -1788,6 +1791,9 @@ INTERP_DISABLED_TESTS += tailcall/interface-conservestack/6.exe
 INTERP_DISABLED_TESTS += tailcall/interface-conservestack/7.exe
 INTERP_DISABLED_TESTS += tailcall/interface-conservestack/8.exe
 INTERP_DISABLED_TESTS += tailcall/interface-conservestack/9.exe
+
+# expected InvalidProgramException not thrown
+INTERP_DISABLED_TESTS += calli_sig_check.exe
 
 
 # bug-48015.exe: be careful when re-enabling, it happens that it returns with exit code 0, but doesn't actually execute the test.

--- a/mono/tests/calli_sig_check.il
+++ b/mono/tests/calli_sig_check.il
@@ -1,0 +1,43 @@
+// Test that calli does signature checking
+
+.assembly extern mscorlib{}
+.assembly calli_sig_check{}
+
+.method public static int32 calli_sig_check (string s) cil managed
+{
+	.maxstack 16
+	ldc.i4.0
+	ret
+}
+
+.method public static int32 calli_sig_check_2 () cil managed
+{
+	.maxstack 16
+
+	ldc.r4 1.13
+	ldftn int32 calli_sig_check(string)
+	calli int32(string)
+	ret
+}
+
+.method public static int32 test_0_calli_sig_check () cil managed
+{
+	.entrypoint
+	.maxstack 16
+
+	.try {
+		call int32 calli_sig_check_2()
+		pop
+		leave L0
+	} catch [mscorlib]System.InvalidProgramException {
+		pop
+		leave L1
+	}
+
+	L0:
+		ldc.i4.1
+		ret
+	L1:
+		ldc.i4.0
+		ret
+}


### PR DESCRIPTION
We weren't checking whether the runtime returned a zero exit code which means if the compilation failed we still reported success.

Now the exit code is propagated all the way up and we report an error both to make and to the xml result file.

Since iltests.exe contains a test with expected invalid IL this would now cause a failure. The easiest fix is to just move that test from mono/mini to mono/tests since all other tests are fine.

Fixes https://github.com/mono/mono/issues/11091
