### PR TITLE
Fixes #11779

### DIFF
--- a/mcs/class/System.Runtime.Remoting/Test/RemotingServicesTest.cs
+++ b/mcs/class/System.Runtime.Remoting/Test/RemotingServicesTest.cs
@@ -553,6 +553,39 @@ namespace MonoTests.Remoting
 			}
 		}
 
+		public interface IMarshalTest
+		{
+			void DoSomething();
+		}
+
+		public interface ITest2 : IMarshalTest
+		{
+			void DoSomethingElse();
+		}
+
+		public class TestClass : MarshalByRefObject, ITest2
+		{
+			public void DoSomething()
+			{
+			}
+
+			public void DoSomethingElse()
+			{
+			}
+		}
+
+		[Test]
+		public void MarshalBaseInterfaces()
+		{
+			TestClass test = new TestClass();
+			ObjRef obj = RemotingServices.Marshal(test, "TestClass", typeof(ITest2));
+			FieldInfo interfacesImplemented = obj.TypeInfo.GetType().GetField("interfacesImplemented", BindingFlags.NonPublic | BindingFlags.Instance);
+			string[] interfaces = (string[])interfacesImplemented.GetValue(obj.TypeInfo);
+			Assert.AreEqual(2, interfaces.Length);
+			Assert.IsTrue(interfaces[0].Contains("IMarshalTest"));
+			Assert.IsTrue(interfaces[1].Contains("ITest2"));
+		}
+
 		[Test]
 		[Ignore ("We cannot test RemotingConfiguration.Configure() because it keeps channels registered. If we really need to test it, do it as a standalone case")]
 		public void ConnectProxyCast ()

--- a/mcs/class/corlib/System.Runtime.Remoting/TypeInfo.cs
+++ b/mcs/class/corlib/System.Runtime.Remoting/TypeInfo.cs
@@ -46,7 +46,11 @@ namespace System.Runtime.Remoting
 			{
 				serverType = typeof (MarshalByRefObject).AssemblyQualifiedName;
 				serverHierarchy = new string[0];
-				interfacesImplemented = new string[] { type.AssemblyQualifiedName };
+				Type[] interfaces = type.GetInterfaces();
+				interfacesImplemented = new string[interfaces.Length + 1];
+				for(int n=0; n<interfaces.Length; n++)
+					interfacesImplemented[n] = interfaces[n].AssemblyQualifiedName;
+				interfacesImplemented[interfaces.Length] = type.AssemblyQualifiedName;
 			}
 			else
 			{


### PR DESCRIPTION
This adds any base interfaces to the remoting TypeInfo to match the
behavior of MS.NET

