### PR TITLE
[2018-10] [mini] use AOT trampolines in interp mixed mode

### DIFF
--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -1455,7 +1455,7 @@ mono_create_jump_trampoline (MonoDomain *domain, MonoMethod *method, gboolean ad
 
 	error_init (error);
 
-	if (mono_use_interpreter) {
+	if (mono_use_interpreter && !mono_aot_only) {
 		gpointer ret = mini_get_interp_callbacks ()->create_method_pointer (method, FALSE, error);
 		if (!mono_error_ok (error))
 			return NULL;


### PR DESCRIPTION
Fixes this on mscorlib/mixed mode on Xamarin.iOS:
```
[FAIL] NonExceptional.Serialization_Deserialization : System.Runtime.Serialization.SerializationException : An error occurred while deserializing the object. The serialized data is corrupt.Â 
[FAIL] NonExceptional.Serialize_Deserialize_FixedDateRule : System.Runtime.Serialization.SerializationException : An error occurred while deserializing the object. The serialized data is corrupt.Â 
[FAIL] NonExceptional.Serialize_Deserialize_FloatingDateRule : System.Runtime.Serialization.SerializationException : An error occurred while deserializing the object. The serialized data is corrupt.Â 
[FAIL] SerializationTests.Serialization_Deserialization : System.Runtime.Serialization.SerializationException : An error occurred while deserializing the object. The serialized data is corrupt.Â 
[FAIL] TimeZoneTest.CurrentTimeZone_SerializationRoundtrip : System.Runtime.Serialization.SerializationException : An error occurred while deserializing the object. The serialized data is corrupt.Â 
```


Backport of #11767.

/cc @lewurm 