### PR TITLE
Revert usage of gcc builtin for icache flush on ppc

### DIFF
--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -733,8 +733,6 @@ mono_arch_flush_icache (guint8 *code, gint size)
 {
 #ifdef MONO_CROSS_COMPILE
 	/* do nothing */
-#elif defined (__GNUC__)
-	__builtin___clear_cache (code, code + size);
 #else
 	register guint8 *p;
 	guint8 *endp, *start;


### PR DESCRIPTION
This is a no-op on gcc ppc for AIX, Linux, and FreeBSD, and should
not be used until gcc implements this. (It *does* on ARM, RISC-V,
Alpha, and MIPS, however - but not PowerPC or x86, based on a skim
of gcc source.)

Should fix #11527.