### PR TITLE
[mini] Add mini_target_safepoints_enabled

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -12993,7 +12993,7 @@ mono_compile_assembly (MonoAssembly *ass, guint32 opts, const char *aot_options,
 		acfg->is_full_aot = TRUE;
 	}
 
-	if (mono_threads_are_safepoints_enabled ())
+	if (mini_target_safepoints_enabled ())
 		acfg->flags = (MonoAotFileFlags)(acfg->flags | MONO_AOT_FILE_FLAG_SAFEPOINTS);
 
 	// The methods in dedup-emit amodules must be available on runtime startup

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -2436,6 +2436,13 @@ mono_main (int argc, char* argv[])
 		mono_load_coree (argv [i]);
 #endif
 
+#ifdef TARGET_WATCHOS
+	/* Always emit safepoints for this target, even if host doesn't use
+	 * them.
+	 */
+	mini_target_set_safepoints_enabled (TRUE);
+#endif
+
 	/* Parse gac loading options before loading assemblies. */
 	if (mono_compile_aot || action == DO_EXEC || action == DO_DEBUGGER) {
 		mono_config_parse (config_file);

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -6755,7 +6755,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_GC_SAFE_POINT: {
 			guint8 *br [1];
 
-			g_assert (mono_threads_are_safepoints_enabled ());
+			g_assert (mini_target_safepoints_enabled ());
 
 			amd64_test_membase_imm_size (code, ins->sreg1, 0, 1, 4);
 			br[0] = code; x86_branch8 (code, X86_CC_EQ, 0, FALSE);

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -6004,7 +6004,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_GC_SAFE_POINT: {
 			guint8 *buf [1];
 
-			g_assert (mono_threads_are_safepoints_enabled ());
+			g_assert (mini_target_safepoints_enabled ());
 
 			ARM_LDR_IMM (code, ARMREG_IP, ins->sreg1, 0);
 			ARM_CMP_REG_IMM (code, ARMREG_IP, 0, 0);

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -4665,7 +4665,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_GC_SAFE_POINT: {
 			guint8 *buf [1];
 
-			g_assert (mono_threads_are_safepoints_enabled ());
+			g_assert (mini_target_safepoints_enabled ());
 
 			arm_ldrx (code, ARMREG_IP1, ins->sreg1, 0);
 			/* Call it if it is non-null */

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4631,7 +4631,7 @@ register_icalls (void)
 	register_icall (mono_thread_interruption_checkpoint, "mono_thread_interruption_checkpoint", "object", FALSE);
 	register_icall (mono_thread_force_interruption_checkpoint_noraise, "mono_thread_force_interruption_checkpoint_noraise", "object", FALSE);
 
-	if (mono_threads_are_safepoints_enabled ())
+	if (mini_target_safepoints_enabled ())
 		register_icall (mono_threads_state_poll, "mono_threads_state_poll", "void", FALSE);
 
 #ifndef MONO_ARCH_NO_EMULATE_LONG_MUL_OPTS

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -4642,7 +4642,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_GC_SAFE_POINT: {
 			short *br;
 
-			g_assert (mono_threads_are_safepoints_enabled ());
+			g_assert (mini_target_safepoints_enabled ());
 
 			s390_ltg (code, s390_r0, 0, ins->sreg1, 0);	
 			s390_jz  (code, 0); CODEPTR(code, br);

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -4833,7 +4833,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_GC_SAFE_POINT: {
 			guint8 *br [1];
 
-			g_assert (mono_threads_are_safepoints_enabled ());
+			g_assert (mini_target_safepoints_enabled ());
 
 			x86_test_membase_imm (code, ins->sreg1, 0, 1);
 			br[0] = code; x86_branch8 (code, X86_CC_EQ, 0, FALSE);

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -2852,7 +2852,7 @@ mono_create_gc_safepoint (MonoCompile *cfg, MonoBasicBlock *bblock)
 	if (cfg->verbose_level > 1)
 		printf ("ADDING SAFE POINT TO BB %d\n", bblock->block_num);
 
-	g_assert (mono_threads_are_safepoints_enabled ());
+	g_assert (mini_target_safepoints_enabled ());
 	NEW_AOTCONST (cfg, poll_addr, MONO_PATCH_INFO_GC_SAFE_POINT_FLAG, (gpointer)&mono_polling_required);
 
 	MONO_INST_NEW (cfg, ins, OP_GC_SAFE_POINT);
@@ -2898,12 +2898,12 @@ mono_insert_safepoints (MonoCompile *cfg)
 {
 	MonoBasicBlock *bb;
 
-	if (!mono_threads_are_safepoints_enabled ())
+	if (!mini_target_safepoints_enabled ())
 		return;
 
 	if (cfg->method->wrapper_type == MONO_WRAPPER_MANAGED_TO_NATIVE) {
 		WrapperInfo *info = mono_marshal_get_wrapper_info (cfg->method);
-		g_assert (mono_threads_are_safepoints_enabled ());
+		g_assert (mini_target_safepoints_enabled ());
 		gpointer poll_func = (gpointer)&mono_threads_state_poll;
 
 		if (info && info->subtype == WRAPPER_SUBTYPE_ICALL_WRAPPER && info->d.icall.func == poll_func) {
@@ -3212,7 +3212,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 		cfg->gen_sdb_seq_points = FALSE;
 	}
 	/* coop requires loop detection to happen */
-	if (mono_threads_are_safepoints_enabled ())
+	if (mini_target_safepoints_enabled ())
 		cfg->opt |= MONO_OPT_LOOP;
 	if (cfg->backend->explicit_null_checks) {
 		/* some platforms have null pages, so we can't SIGSEGV */

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -88,6 +88,7 @@ MonoMethodDesc *mono_break_at_bb_method;
 int mono_break_at_bb_bb_num;
 gboolean mono_do_x86_stack_align = TRUE;
 gboolean mono_using_xdebug;
+static int target_safepoints_enabled = -1;
 
 /* Counters */
 static guint32 discarded_code;
@@ -4342,4 +4343,19 @@ mono_target_pagesize (void)
 	 * for those cases.
 	 */
 	return 4 * 1024;
+}
+
+gboolean
+mini_target_safepoints_enabled (void)
+{
+	/* if not explicitly set for the target, use the host value. */
+	if (G_UNLIKELY (target_safepoints_enabled == -1))
+		target_safepoints_enabled = mono_threads_are_safepoints_enabled ();
+	return target_safepoints_enabled > 0;
+}
+
+void
+mini_target_set_safepoints_enabled (gboolean enable)
+{
+	target_safepoints_enabled = enable ? 1 : 0;
 }

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2765,4 +2765,10 @@ MonoType*   mini_native_type_replace_type (MonoType *type) MONO_LLVM_INTERNAL;
 MonoMethod*
 mini_method_to_shared (MonoMethod *method); // null if not shared
 
+gboolean
+mini_target_safepoints_enabled (void);
+
+void
+mini_target_set_safepoints_enabled (gboolean enable);
+
 #endif /* __MONO_MINI_H__ */


### PR DESCRIPTION
Allows us to emit safepoints for the target even if the host doesn't need them.

Always emit safepoints when targeting watchOS. This should address https://github.com/mono/mono/issues/11765: due to https://github.com/mono/monodevelop/pull/6327, Mono was not emitting safepoints in the watchOS cross-compiler since the host had `MONO_THREADS_SUSPEND=preemptive` set.
