### PR TITLE
[runtime] Bundle mscorlib in mono

### DIFF
--- a/mcs/build/tests.make
+++ b/mcs/build/tests.make
@@ -231,8 +231,14 @@ ifneq ($(wildcard $(MKBUNDLE_TEST_BIN)),)
 TEST_HARNESS_EXEC=$(MKBUNDLE_TEST_BIN)
 TEST_HARNESS_EXCLUDES:=$(TEST_HARNESS_EXCLUDES),StaticLinkedAotNotWorking
 else 
+
+ifneq ($(wildcard $(topdir)/class/lib/$(PROFILE)/mono),)
+TEST_HARNESS_EXEC=$(topdir)/class/lib/$(PROFILE)/mono $(TEST_RUNTIME_FLAGS) $(TEST_COVERAGE_FLAGS) $(AOT_RUN_FLAGS) $(TEST_HARNESS)
+else 
 TEST_HARNESS_EXEC=$(TEST_RUNTIME) $(TEST_RUNTIME_FLAGS) $(TEST_COVERAGE_FLAGS) $(AOT_RUN_FLAGS) $(TEST_HARNESS)
-endif
+endif # bundled mscorlib
+
+endif # MKBUNDLE_TEST_BIN
 
 ## FIXME: i18n problem in the 'sed' command below
 run-test-lib: test-local test-local-aot-compile copy-nunitlite-appconfig

--- a/mcs/class/aot-compiler/Makefile
+++ b/mcs/class/aot-compiler/Makefile
@@ -30,6 +30,7 @@ csc_SCI_image = $(images_dir)/System.Collections.Immutable.dll$(PLATFORM_AOT_SUF
 
 mscorlib_dll = $(the_libdir)/mscorlib.dll
 mscorlib_aot_image = $(mscorlib_dll)$(PLATFORM_AOT_SUFFIX)
+runtime_with_mscorlib = $(the_libdir)/mono
 
 # The $(dir $(RUNTIME)) is necessary to get path to the mono binary in case when we cross-compile
 # or just compile from a different directory than the top source dir
@@ -72,6 +73,26 @@ $(csc_SRM_image): $(csc_SRM_dll) $(runtime_dep)
 $(csc_SCI_image): $(csc_SCI_dll) $(runtime_dep)
 	$(Q_AOT) MONO_PATH='$(the_libdir)' > $(LOG_FILE) 2>&1 $(RUNTIME) --aot=bind-to-runtime-version$(profile_arg),outfile=$(csc_SCI_image) --debug $(csc_SCI_dll) || (cat $(LOG_FILE); exit 1)
 
+MKBUNDLE_EXE = $(topdir)/class/lib/$(PROFILE)/mkbundle.exe
+
+$(MKBUNDLE_EXE): $(topdir)/tools/mkbundle/mkbundle.cs
+	make -C $(topdir)/tools/mkbundle
+
+ifneq ($(AOT_MODE),)
+RUNTIME_AOT_MODE=--aot-mode $(AOT_MODE)
+else
+RUNTIME_AOT_MODE=
+endif
+
+ifneq ($(AOT_BUILD_ATTRS),)
+RUNTIME_AOT_ARGS=--aot-args $(AOT_BUILD_ATTRS),direct-icalls
+else
+RUNTIME_AOT_ARGS=--aot-args direct-icalls
+endif
+
+$(runtime_with_mscorlib): $(mscorlib_dll) $(runtime_dep) $(MKBUNDLE_EXE)
+	$(Q_AOT) MONO_PATH='$(the_libdir)' PKG_CONFIG_PATH="$(topdir)/../data" $(RUNTIME) $(MKBUNDLE_EXE) -L $(the_libdir) -v --deps  $(mscorlib_dll) -o $(runtime_with_mscorlib) $(RUNTIME_AOT_MODE) --aot-runtime $(RUNTIME) $(RUNTIME_AOT_ARGS) --in-tree $(topdir)/.. --i18n all --no-managed-entry-point
+
 ifdef ENABLE_AOT
 
 CSC_IMAGES = $(csc_aot_image) $(csc_SRM_image) $(csc_SCI_image) $(csc_MC_image) $(csc_MCS_image)
@@ -82,7 +103,7 @@ clean-local:
 # AOT build profile to speed up build
 ifeq ($(PROFILE),build)
 
-IMAGES = $(mscorlib_aot_image)
+IMAGES = $(CORLIB_IMAGE)
 
 ifdef MCS_MODE
 IMAGES += $(mcs_aot_image)
@@ -97,7 +118,13 @@ endif
 
 ifeq ($(PROFILE), $(DEFAULT_PROFILE))
 
-IMAGES = $(mscorlib_aot_image) $(mcs_aot_image) $(CSC_IMAGES)
+ifndef DISABLE_BUNDLE_CORLIB
+CORLIB_IMAGE = $(runtime_with_mscorlib)
+else
+CORLIB_IMAGE = $(mscorlib_aot_image)
+endif
+
+IMAGES = $(CORLIB_IMAGE) $(mcs_aot_image) $(CSC_IMAGES)
 
 all-local: $(IMAGES)
 install-local:

--- a/mcs/tools/mkbundle/mkbundle.cs
+++ b/mcs/tools/mkbundle/mkbundle.cs
@@ -82,6 +82,7 @@ class MakeBundle {
 	static bool aot_compile = false;
 	static string aot_args = "static";
 	static DirectoryInfo aot_temp_dir = null;
+	static bool no_managed_entry_point = false;
 	static string aot_mode = "";
 	static string aot_runtime = null;
 	static string aot_dedup_assembly = null;
@@ -453,6 +454,9 @@ class MakeBundle {
 				aot_args = String.Format("static,{0}", args [++i]);
 				aot_compile = true;
 				static_link = true;
+				break;
+			case "--no-managed-entry-point":
+				no_managed_entry_point = true;
 				break;
 			case "--mono-api-struct-path":
 				if (i+1 == top) {
@@ -1085,8 +1089,10 @@ typedef struct {
 			tc.WriteLine ("\n}\n");
 			tc.WriteLine ("#endif\n");
 
-
-			tc.WriteLine ("static char *image_name = \"{0}\";", prog);
+			if (no_managed_entry_point)
+				tc.WriteLine ("static char *image_name = NULL;", prog);
+			else
+				tc.WriteLine ("static char *image_name = \"{0}\";", prog);
 
 			if (ctor_func != null) {
 				tc.WriteLine ("\nextern void {0} (void);", ctor_func);

--- a/mcs/tools/mkbundle/template.c
+++ b/mcs/tools/mkbundle/template.c
@@ -1,5 +1,8 @@
 void mono_mkbundle_init ()
 {
+	init_default_mono_api_struct ();
+	validate_api_struct ();
+
 	install_dll_config_files ();
 	mono_api.mono_register_bundled_assemblies(bundled);
 

--- a/mcs/tools/mkbundle/template_common.inc
+++ b/mcs/tools/mkbundle/template_common.inc
@@ -18,8 +18,6 @@ void initialize_mono_api (const BundleMonoAPI *info)
 	mono_api.mono_register_machine_config = info->mono_register_machine_config;
 }
 
-#ifdef USE_COMPRESSED_ASSEMBLY
-
 static int
 validate_api_pointer (const char *name, void *ptr)
 {
@@ -68,4 +66,3 @@ init_default_mono_api_struct ()
 #endif // USE_DEFAULT_MONO_API_STRUCT
 }
 
-#endif

--- a/mcs/tools/mkbundle/template_main.c
+++ b/mcs/tools/mkbundle/template_main.c
@@ -61,7 +61,8 @@ int main (int argc, char* argv[])
 			newargs[k++] = mono_options[i++];
 	}
 
-	newargs [k++] = image_name;
+	if (image_name != NULL)
+		newargs [k++] = image_name;
 
 	for (i = 1; i < argc; i++) {
 		newargs [k++] = argv [i];


### PR DESCRIPTION
I put this together in 20 minutes and did topical testing on my VPS. Seems to work there for simple hello world apps, thought I'd put it through the testing paces on CI.

This optimization was discussed in channel and I thought I'd throw together the proof of concept before it slipped away. If we're always AOTing mscorlib, why not link it to mono in the most optimized way? 

Making sure that we're using direct-icalls seemed like a good start.

A nice workflow improvement made by this is that MONO_PATH doesn't need to be set for the binary to work for simple applications. In addition, the corlib version mismatch problem that often leads to strange local bugs cannot happen because each mono will be closely bundled with it's corlib. 

