### PR TITLE
[runtime] Fix return of uninit value

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -3527,7 +3527,7 @@ mono_field_get_value_object_checked (MonoDomain *domain, MonoClassField *field, 
 
 	error_init (error);
 
-	MonoObject *o;
+	MonoObject *o = NULL;
 	MonoClass *klass;
 	MonoVTable *vtable = NULL;
 	gpointer v;


### PR DESCRIPTION
We have a return on [line 3608](https://github.com/mono/mono/blob/892cad1dab3db16c269ae22b0d68b0bd1d5c0668/mono/metadata/object.c#L3608) that doesn't have any assignment to the variable "o" before that. Since it's stack memory, it will be garbage.
