### PR TITLE
[System] Refactor tests to use system-assigned ports whenever possible.

### DIFF
--- a/mcs/class/System/Test/System.Net.Security/SslStreamTest.cs
+++ b/mcs/class/System/Test/System.Net.Security/SslStreamTest.cs
@@ -73,7 +73,7 @@ public class SslStreamTest {
 	{
 		ClientServerState state = new ClientServerState ();
 		state.Client = new TcpClient ();
-		state.Listener = NetworkHelpers.StartTcpListener (IPAddress.Loopback, out IPEndPoint endPoint);
+		state.Listener = NetworkHelpers.CreateAndStartTcpListener (IPAddress.Loopback, out IPEndPoint endPoint);
 		state.ServerAuthenticated = new AutoResetEvent (false);
 		state.ClientAuthenticated = new AutoResetEvent (false);
 		state.ServerIOException = !server;

--- a/mcs/class/System/Test/System.Net.Security/SslStreamTest.cs
+++ b/mcs/class/System/Test/System.Net.Security/SslStreamTest.cs
@@ -71,11 +71,9 @@ public class SslStreamTest {
 
 	void AuthenticateClientAndServer (bool server, bool client)
 	{
-		IPEndPoint endPoint = new IPEndPoint (IPAddress.Parse ("127.0.0.1"), NetworkHelpers.FindFreePort ());
 		ClientServerState state = new ClientServerState ();
 		state.Client = new TcpClient ();
-		state.Listener = new TcpListener (endPoint);
-		state.Listener.Start ();
+		state.Listener = NetworkHelpers.StartTcpListener (IPAddress.Loopback, out IPEndPoint endPoint);
 		state.ServerAuthenticated = new AutoResetEvent (false);
 		state.ClientAuthenticated = new AutoResetEvent (false);
 		state.ServerIOException = !server;

--- a/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
@@ -3707,7 +3707,7 @@ namespace MonoTests.System.Net.Sockets
 #endif
 		public void ConnectedProperty ()
 		{
-			var listener = NetworkHelpers.StartTcpListener (out int port);
+			var listener = NetworkHelpers.CreateAndStartTcpListener (out int port);
 
 			var client = new Socket (AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 			client.Connect (IPAddress.Loopback, port);

--- a/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/SocketTest.cs
@@ -67,8 +67,7 @@ namespace MonoTests.System.Net.Sockets
 		[Ignore ("Bug #75158")] // Looks like MS fails after the .ctor, when you try to use the socket
 		public void IncompatibleAddress ()
 		{
-			IPEndPoint epIPv6 = new IPEndPoint (IPAddress.IPv6Any,
-								NetworkHelpers.FindFreePort ());
+			IPEndPoint epIPv6 = new IPEndPoint (IPAddress.IPv6Any, 0);
 
 			try {
 				using (Socket s = new Socket (AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.IP)) {
@@ -119,7 +118,7 @@ namespace MonoTests.System.Net.Sockets
 			Socket.Select (list, list, list, 1000);
 		}
 		
-		private bool BlockingConnect (bool block, int port)
+		private bool BlockingConnect (bool block, ref int port)
 		{
 			IPEndPoint ep = new IPEndPoint(IPAddress.Loopback, port);
 			Socket server = new Socket(AddressFamily.InterNetwork,
@@ -127,6 +126,8 @@ namespace MonoTests.System.Net.Sockets
 						   ProtocolType.Tcp);
 			server.Bind(ep);
 			server.Blocking=block;
+			ep = (IPEndPoint) server.LocalEndPoint;
+			port = ep.Port;
 
 			server.Listen(0);
 
@@ -167,12 +168,12 @@ namespace MonoTests.System.Net.Sockets
 		public void AcceptBlockingStatus()
 		{
 			bool block;
-			var port = NetworkHelpers.FindFreePort ();
+			int port = 0;
 	
-			block = BlockingConnect(true, port);
+			block = BlockingConnect(true, ref port);
 			Assert.AreEqual (block, true, "BlockingStatus01");
 
-			block = BlockingConnect(false, port);
+			block = BlockingConnect(false, ref port);
 			Assert.AreEqual (block, false, "BlockingStatus02");
 		}
 
@@ -238,7 +239,7 @@ namespace MonoTests.System.Net.Sockets
 #endif
 		public void SetSocketOptionBoolean ()
 		{
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, NetworkHelpers.FindFreePort ());
+			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, 0);
 			Socket sock = new Socket (ep.Address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 			try {
 				sock.SetSocketOption (SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
@@ -252,7 +253,7 @@ namespace MonoTests.System.Net.Sockets
 #endif
 		public void TestSelect1 ()
 		{
-			Socket srv = CreateServer (NetworkHelpers.FindFreePort ());
+			Socket srv = CreateServer (0);
 			ClientSocket clnt = new ClientSocket (srv.LocalEndPoint);
 			Socket acc = null;
 			try {
@@ -467,9 +468,7 @@ namespace MonoTests.System.Net.Sockets
 		{
 			Socket server = new Socket (AddressFamily.InterNetwork,
 				SocketType.Stream, ProtocolType.Tcp);
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback,
-							NetworkHelpers.FindFreePort ());
-			server.Bind (ep);
+			server.Bind (IPAddress.Loopback, out IPEndPoint ep);
 			server.Listen (1);
 
 			Socket client = new Socket (AddressFamily.InterNetwork, 
@@ -747,11 +746,10 @@ namespace MonoTests.System.Net.Sockets
 			Socket sock = new Socket (AddressFamily.InterNetwork,
 						  SocketType.Stream,
 						  ProtocolType.Tcp);
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
 			
 			Assert.AreEqual (false, sock.IsBound, "IsBoundTcp #1");
 			
-			sock.Bind (ep);
+			sock.Bind (IPAddress.Loopback, out IPEndPoint ep);
 			Assert.AreEqual (true, sock.IsBound, "IsBoundTcp #2");
 
 			sock.Listen (1);
@@ -781,11 +779,11 @@ namespace MonoTests.System.Net.Sockets
 			Socket sock = new Socket (AddressFamily.InterNetwork,
 						  SocketType.Dgram,
 						  ProtocolType.Udp);
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
 			
 			Assert.AreEqual (false, sock.IsBound, "IsBoundUdp #1");
 			
-			sock.Bind (ep);
+			sock.Bind (IPAddress.Loopback, out IPEndPoint ep);
+
 			Assert.AreEqual (true, sock.IsBound, "IsBoundUdp #2");
 			
 			sock.Close ();
@@ -1358,7 +1356,7 @@ namespace MonoTests.System.Net.Sockets
 						  SocketType.Stream,
 						  ProtocolType.Tcp);
 
-			sock.Bind (new IPEndPoint (IPAddress.Any, NetworkHelpers.FindFreePort ()));
+			sock.Bind (new IPEndPoint (IPAddress.Any, 0));
 			
 			sock.BeginAccept (BACallback, sock);
 			
@@ -1374,10 +1372,8 @@ namespace MonoTests.System.Net.Sockets
 			Socket sock = new Socket (AddressFamily.InterNetwork,
 						  SocketType.Stream,
 						  ProtocolType.Tcp);
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback,
-							NetworkHelpers.FindFreePort ());
 			
-			sock.Bind (ep);
+			sock.Bind (IPAddress.Loopback, out IPEndPoint ep);
 			sock.Listen (1);
 			
 			BACalledBack.Reset ();
@@ -1444,10 +1440,8 @@ namespace MonoTests.System.Net.Sockets
 			Socket sock = new Socket (AddressFamily.InterNetwork,
 						  SocketType.Stream,
 						  ProtocolType.Tcp);
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback,
-							NetworkHelpers.FindFreePort ());
 			
-			sock.Bind (ep);
+			sock.Bind (IPAddress.Loopback, out IPEndPoint ep);
 			sock.Listen (1);
 			
 			BADCalledBack.Reset ();
@@ -1515,10 +1509,7 @@ namespace MonoTests.System.Net.Sockets
 						 SocketType.Dgram,
 						 ProtocolType.Udp);
 			
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback,
-							NetworkHelpers.FindFreePort ());
-			
-			sock.Bind (ep);
+			sock.Bind (IPAddress.Loopback, out int _);
 			sock.Listen (1);
 			
 			try {
@@ -1545,16 +1536,10 @@ namespace MonoTests.System.Net.Sockets
 						 SocketType.Stream,
 						 ProtocolType.Tcp);
 			
-			IPEndPoint ep1 = new IPEndPoint (IPAddress.Loopback,
-							 NetworkHelpers.FindFreePort ());
-			
-			IPEndPoint ep2 = new IPEndPoint (IPAddress.Loopback,
-							 NetworkHelpers.FindFreePort ());
-			
-			sock.Bind (ep1);
+			sock.Bind (IPAddress.Loopback, out IPEndPoint ep1);
 			sock.Listen (1);
 
-			acc.Bind (ep2);
+			acc.Bind (IPAddress.Loopback, out IPEndPoint ep2);
 			
 			try {
 				sock.BeginAccept (acc, 256, BADCallback, sock);
@@ -1579,10 +1564,7 @@ namespace MonoTests.System.Net.Sockets
 						 SocketType.Stream,
 						 ProtocolType.Tcp);
 			
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback,
-							NetworkHelpers.FindFreePort ());
-			
-			sock.Bind (ep);
+			sock.Bind (IPAddress.Loopback, out IPEndPoint ep);
 			sock.Listen (1);
 			
 			BADCalledBack.Reset ();
@@ -1662,10 +1644,8 @@ namespace MonoTests.System.Net.Sockets
 			Socket acc = new Socket (AddressFamily.InterNetwork,
 						 SocketType.Stream,
 						 ProtocolType.Tcp);
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback,
-							NetworkHelpers.FindFreePort ());
 
-			sock.Bind (ep);
+			sock.Bind (IPAddress.Loopback, out int _);
 			sock.Listen (1);
 			
 			acc.Close ();
@@ -1715,9 +1695,8 @@ namespace MonoTests.System.Net.Sockets
 						    SocketType.Stream,
 						    ProtocolType.Tcp);
 			IPAddress ip = IPAddress.Loopback;
-			IPEndPoint ep = new IPEndPoint (ip, NetworkHelpers.FindFreePort ());
 
-			listen.Bind (ep);
+			listen.Bind (ip, out IPEndPoint ep);
 			listen.Listen (1);
 			
 			BCCalledBack.Reset ();
@@ -1768,9 +1747,8 @@ namespace MonoTests.System.Net.Sockets
 						  SocketType.Stream,
 						  ProtocolType.Tcp);
 			IPAddress ip = IPAddress.Loopback;
-			IPEndPoint ep = new IPEndPoint (ip, NetworkHelpers.FindFreePort ());
 
-			sock.Bind (ep);
+			sock.Bind (ip, out IPEndPoint ep);
 			sock.Listen (1);
 			
 			try {
@@ -1821,8 +1799,6 @@ namespace MonoTests.System.Net.Sockets
 			Socket listen = new Socket (AddressFamily.InterNetwork,
 						    SocketType.Stream,
 						    ProtocolType.Tcp);
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback,
-							NetworkHelpers.FindFreePort ());
 			IPAddress[] ips = new IPAddress[4];
 			
 			ips[0] = IPAddress.Parse ("127.0.0.4");
@@ -1830,7 +1806,7 @@ namespace MonoTests.System.Net.Sockets
 			ips[2] = IPAddress.Parse ("127.0.0.2");
 			ips[3] = IPAddress.Parse ("127.0.0.1");
 
-			listen.Bind (ep);
+			listen.Bind (IPAddress.Loopback, out IPEndPoint ep);
 			listen.Listen (1);
 			
 			BCCalledBack.Reset ();
@@ -1888,9 +1864,7 @@ namespace MonoTests.System.Net.Sockets
 			 * succeed it it can connect to at least one of the requested
 			 * addresses.
 			 */
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, NetworkHelpers.FindFreePort ());
-
-			listen.Bind (ep);
+			listen.Bind (IPAddress.Loopback, out IPEndPoint ep);
 			listen.Listen (1);
 			
 			BCCalledBack.Reset ();
@@ -1949,15 +1923,13 @@ namespace MonoTests.System.Net.Sockets
 						  SocketType.Stream,
 						  ProtocolType.Tcp);
 			IPAddress[] ips = new IPAddress[4];
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback,
-							NetworkHelpers.FindFreePort ());
 			
 			ips[0] = IPAddress.Parse ("127.0.0.4");
 			ips[1] = IPAddress.Parse ("127.0.0.3");
 			ips[2] = IPAddress.Parse ("127.0.0.2");
 			ips[3] = IPAddress.Parse ("127.0.0.1");
 			
-			sock.Bind (ep);
+			sock.Bind (IPAddress.Loopback, out IPEndPoint ep);
 			sock.Listen (1);
 			
 			try {
@@ -2021,9 +1993,8 @@ namespace MonoTests.System.Net.Sockets
 						  SocketType.Stream,
 						  ProtocolType.Tcp);
 			IPAddress ip = IPAddress.Loopback;
-			IPEndPoint ep = new IPEndPoint (ip, NetworkHelpers.FindFreePort ());
 			
-			sock.Bind (ep);
+			sock.Bind (ip, out IPEndPoint ep);
 			sock.Listen (1);
 			
 			try {
@@ -2094,9 +2065,8 @@ namespace MonoTests.System.Net.Sockets
 						    SocketType.Stream,
 						    ProtocolType.Tcp);
 			IPAddress ip = IPAddress.Loopback;
-			IPEndPoint ep = new IPEndPoint (ip, NetworkHelpers.FindFreePort ());
 			
-			listen.Bind (ep);
+			listen.Bind (ip, out IPEndPoint ep);
 			listen.Listen (1);
 			
 			sock.Connect (ip, ep.Port);
@@ -2189,15 +2159,11 @@ namespace MonoTests.System.Net.Sockets
 			Socket sock = new Socket (AddressFamily.InterNetwork,
 						  SocketType.Stream,
 						  ProtocolType.Tcp);
-			IPEndPoint ep1 = new IPEndPoint (IPAddress.Loopback,
-							NetworkHelpers.FindFreePort ());
-			IPEndPoint ep2 = new IPEndPoint (IPAddress.Loopback,
-							 NetworkHelpers.FindFreePort ());
 			
-			sock.Bind (ep1);
+			sock.Bind (IPAddress.Loopback, out IPEndPoint ep1);
 			
 			try {
-				sock.Bind (ep2);
+				sock.Bind (IPAddress.Loopback, out IPEndPoint ep2);
 				Assert.Fail ("BindTwice #1");
 			} catch (SocketException ex) {
 				Assert.AreEqual (10022, ex.ErrorCode, "BindTwice #2");
@@ -2218,10 +2184,8 @@ namespace MonoTests.System.Net.Sockets
 			Socket listen = new Socket (AddressFamily.InterNetwork,
 						    SocketType.Stream,
 						    ProtocolType.Tcp);
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback,
-							NetworkHelpers.FindFreePort ());
 			
-			listen.Bind (ep);
+			listen.Bind (IPAddress.Loopback, out IPEndPoint ep);
 			listen.Listen (1);
 			
 			sock.Connect (ep);
@@ -2250,9 +2214,8 @@ namespace MonoTests.System.Net.Sockets
 						    SocketType.Stream,
 						    ProtocolType.Tcp);
 			IPAddress ip = IPAddress.Loopback;
-			IPEndPoint ep = new IPEndPoint (ip, NetworkHelpers.FindFreePort ());
 
-			listen.Bind (ep);
+			listen.Bind (ip, out IPEndPoint ep);
 			listen.Listen (1);
 			
 			sock.Connect (ip, ep.Port);
@@ -2294,9 +2257,8 @@ namespace MonoTests.System.Net.Sockets
 						  SocketType.Stream,
 						  ProtocolType.Tcp);
 			IPAddress ip = IPAddress.Loopback;
-			IPEndPoint ep = new IPEndPoint (ip, NetworkHelpers.FindFreePort ());
 
-			sock.Bind (ep);
+			sock.Bind (ip, out IPEndPoint ep);
 			sock.Listen (1);
 			
 			try {
@@ -2354,8 +2316,6 @@ namespace MonoTests.System.Net.Sockets
 			Socket listen = new Socket (AddressFamily.InterNetwork,
 						    SocketType.Stream,
 						    ProtocolType.Tcp);
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback,
-							NetworkHelpers.FindFreePort ());
 			IPAddress[] ips = new IPAddress[4];
 			
 			ips[0] = IPAddress.Parse ("127.0.0.4");
@@ -2363,7 +2323,7 @@ namespace MonoTests.System.Net.Sockets
 			ips[2] = IPAddress.Parse ("127.0.0.2");
 			ips[3] = IPAddress.Parse ("127.0.0.1");
 
-			listen.Bind (ep);
+			listen.Bind (IPAddress.Loopback, out IPEndPoint ep);
 			listen.Listen (1);
 			
 			sock.Connect (ips, ep.Port);
@@ -2404,9 +2364,8 @@ namespace MonoTests.System.Net.Sockets
 			 * Bind to IPAddress.Any; Connect() will fail unless it can
 			 * connect to all the addresses in allIps.
 			 */
-			IPEndPoint ep = new IPEndPoint (IPAddress.Any, NetworkHelpers.FindFreePort ());
 
-			listen.Bind (ep);
+			listen.Bind (IPAddress.Any, out IPEndPoint ep);
 			listen.Listen (1);
 			
 			sock.Connect (allIps, ep.Port);
@@ -2452,15 +2411,13 @@ namespace MonoTests.System.Net.Sockets
 						  SocketType.Stream,
 						  ProtocolType.Tcp);
 			IPAddress[] ips = new IPAddress[4];
-			IPEndPoint ep = new IPEndPoint (IPAddress.Loopback,
-							NetworkHelpers.FindFreePort ());
 			
 			ips[0] = IPAddress.Parse ("127.0.0.4");
 			ips[1] = IPAddress.Parse ("127.0.0.3");
 			ips[2] = IPAddress.Parse ("127.0.0.2");
 			ips[3] = IPAddress.Parse ("127.0.0.1");
 			
-			sock.Bind (ep);
+			sock.Bind (IPAddress.Loopback, out IPEndPoint ep);
 			sock.Listen (1);
 			
 			try {
@@ -2522,9 +2479,8 @@ namespace MonoTests.System.Net.Sockets
 						  SocketType.Stream,
 						  ProtocolType.Tcp);
 			IPAddress ip = IPAddress.Loopback;
-			IPEndPoint ep = new IPEndPoint (ip, NetworkHelpers.FindFreePort ());
 			
-			sock.Bind (ep);
+			sock.Bind (ip, out IPEndPoint ep);
 			sock.Listen (1);
 			
 			try {
@@ -2584,9 +2540,8 @@ namespace MonoTests.System.Net.Sockets
 						    SocketType.Stream,
 						    ProtocolType.Tcp);
 			IPAddress ip = IPAddress.Loopback;
-			IPEndPoint ep = new IPEndPoint (ip, NetworkHelpers.FindFreePort ());
 			
-			listen.Bind (ep);
+			listen.Bind (ip, out IPEndPoint ep);
 			listen.Listen (1);
 			
 			sock.Connect (ip, ep.Port);
@@ -2639,10 +2594,8 @@ namespace MonoTests.System.Net.Sockets
 		{
 			int i;
 
-			IPEndPoint endpoint = new IPEndPoint(IPAddress.Loopback, NetworkHelpers.FindFreePort ());
-
 			Socket listensock = new Socket (AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-			listensock.Bind (endpoint);
+			listensock.Bind (IPAddress.Loopback, out IPEndPoint endpoint);
 			listensock.Listen(1);
 
 			Socket sendsock = new Socket (AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
@@ -2699,10 +2652,8 @@ namespace MonoTests.System.Net.Sockets
 		{
 			int i;
 
-			IPEndPoint endpoint = new IPEndPoint(IPAddress.Loopback, NetworkHelpers.FindFreePort ());
-
 			Socket listensock = new Socket (AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-			listensock.Bind (endpoint);
+			listensock.Bind (IPAddress.Loopback, out IPEndPoint endpoint);
 			listensock.Listen(1);
 
 			Socket sendsock = new Socket (AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
@@ -2775,10 +2726,8 @@ namespace MonoTests.System.Net.Sockets
 			const int BUFFER_SIZE = 65 * 1024;
 			int i;
 
-			IPEndPoint endpoint = new IPEndPoint(IPAddress.Loopback, NetworkHelpers.FindFreePort ());
-
 			Socket listensock = new Socket (AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-			listensock.Bind (endpoint);
+			listensock.Bind (IPAddress.Loopback, out IPEndPoint endpoint);
 			listensock.Listen (1);
 
 			Socket sendsock = new Socket (AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
@@ -2867,8 +2816,7 @@ namespace MonoTests.System.Net.Sockets
 			CWRSocket = new Socket (AddressFamily.InterNetwork,
 						SocketType.Dgram,
 						ProtocolType.Udp);
-			CWRSocket.Bind (new IPEndPoint (IPAddress.Loopback,
-							NetworkHelpers.FindFreePort ()));
+			CWRSocket.Bind (IPAddress.Loopback, out int _);
 			
 			Thread recv_thread = new Thread (new ThreadStart (CWRReceiveThread));
 			CWRReady.Reset ();
@@ -3657,11 +3605,10 @@ namespace MonoTests.System.Net.Sockets
 #endif
 		public void ReceiveRemoteClosed ()
 		{
-			var port = NetworkHelpers.FindFreePort ();
 			Socket sock = new Socket (AddressFamily.InterNetwork,
 						  SocketType.Stream,
 						  ProtocolType.Tcp);
-			sock.Bind (new IPEndPoint (IPAddress.Loopback, port));
+			sock.Bind (IPAddress.Loopback, out int port);
 			sock.Listen (1);
 			
 			RRCReady.Reset ();
@@ -3701,8 +3648,7 @@ namespace MonoTests.System.Net.Sockets
 					supportsReuseAddress = false;
 				}
 
-				var ep = new IPEndPoint (IPAddress.Any, NetworkHelpers.FindFreePort ());
-				s.Bind (ep);
+				s.Bind (IPAddress.Any, out IPEndPoint ep);
 
 				if (supportsReuseAddress)
 					ss.SetSocketOption (SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
@@ -3737,8 +3683,7 @@ namespace MonoTests.System.Net.Sockets
 					supportsReuseAddress = false;
 				}
 
-				var ep = new IPEndPoint (IPAddress.Any, NetworkHelpers.FindFreePort ());
-				s.Bind (ep);
+				s.Bind (IPAddress.Any, out IPEndPoint ep);
 				s.Listen(1);
 
 				if (supportsReuseAddress)
@@ -3762,9 +3707,7 @@ namespace MonoTests.System.Net.Sockets
 #endif
 		public void ConnectedProperty ()
 		{
-			var port = NetworkHelpers.FindFreePort ();
-			var listener = new TcpListener (IPAddress.Loopback, port);
-			listener.Start();
+			var listener = NetworkHelpers.StartTcpListener (out int port);
 
 			var client = new Socket (AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 			client.Connect (IPAddress.Loopback, port);
@@ -4027,7 +3970,7 @@ namespace MonoTests.System.Net.Sockets
 			IPAddress mcast_addr = IPAddress.Parse ("239.255.255.250");
 
 			using (Socket s = new Socket (AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp)) {
-				s.Bind (new IPEndPoint (IPAddress.Any, NetworkHelpers.FindFreePort ()));
+				s.Bind (new IPEndPoint (IPAddress.Any, 0));
 				try {
 					s.SetSocketOption (SocketOptionLevel.IP, SocketOptionName.AddMembership,
 						new IPv6MulticastOption (mcast_addr));
@@ -4052,7 +3995,7 @@ namespace MonoTests.System.Net.Sockets
 			IPAddress mcast_addr = IPAddress.Parse ("239.255.255.250");
 
 			using (Socket s = new Socket (AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp)) {
-				s.Bind (new IPEndPoint (IPAddress.Any, NetworkHelpers.FindFreePort ()));
+				s.Bind (new IPEndPoint (IPAddress.Any, 0));
 				s.SetSocketOption (SocketOptionLevel.IP, SocketOptionName.AddMembership,
 					new MulticastOption (mcast_addr));
 			}
@@ -4094,7 +4037,7 @@ namespace MonoTests.System.Net.Sockets
 			IPAddress mcast_addr = IPAddress.Parse ("ff02::1");
 
 			using (Socket s = new Socket (AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp)) {
-				s.Bind (new IPEndPoint (IPAddress.IPv6Any, NetworkHelpers.FindFreePort ()));
+				s.Bind (new IPEndPoint (IPAddress.IPv6Any, 0));
 				s.SetSocketOption (SocketOptionLevel.IPv6, SocketOptionName.AddMembership,
 					new IPv6MulticastOption (mcast_addr));
 			}
@@ -4112,7 +4055,7 @@ namespace MonoTests.System.Net.Sockets
 			IPAddress mcast_addr = IPAddress.Parse ("ff02::1");
 
 			using (Socket s = new Socket (AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp)) {
-				s.Bind (new IPEndPoint (IPAddress.IPv6Any, NetworkHelpers.FindFreePort ()));
+				s.Bind (new IPEndPoint (IPAddress.IPv6Any, 0));
 				try {
 					s.SetSocketOption (SocketOptionLevel.IPv6, SocketOptionName.AddMembership,
 						new MulticastOption (mcast_addr));
@@ -4266,7 +4209,7 @@ namespace MonoTests.System.Net.Sockets
 			IPAddress mcast_addr = IPAddress.Parse ("239.255.255.250");
 
 			using (Socket s = new Socket (AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp)) {
-				s.Bind (new IPEndPoint (IPAddress.Any, NetworkHelpers.FindFreePort ()));
+				s.Bind (new IPEndPoint (IPAddress.Any, 0));
 				s.SetSocketOption (SocketOptionLevel.IP, SocketOptionName.AddMembership,
 					new MulticastOption (mcast_addr));
 				try {
@@ -4295,7 +4238,7 @@ namespace MonoTests.System.Net.Sockets
 			using (Socket s = new Socket (AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp)) {
 				MulticastOption option = new MulticastOption (mcast_addr);
 
-				s.Bind (new IPEndPoint (IPAddress.Any, NetworkHelpers.FindFreePort ()));
+				s.Bind (new IPEndPoint (IPAddress.Any, 0));
 				s.SetSocketOption (SocketOptionLevel.IP, SocketOptionName.AddMembership,
 					option);
 				s.SetSocketOption (SocketOptionLevel.IP, SocketOptionName.DropMembership,
@@ -4360,7 +4303,7 @@ namespace MonoTests.System.Net.Sockets
 			IPAddress mcast_addr = IPAddress.Parse ("ff02::1");
 
 			using (Socket s = new Socket (AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp)) {
-				s.Bind (new IPEndPoint (IPAddress.IPv6Any, NetworkHelpers.FindFreePort ()));
+				s.Bind (new IPEndPoint (IPAddress.IPv6Any, 0));
 				s.SetSocketOption (SocketOptionLevel.IPv6, SocketOptionName.AddMembership,
 					new IPv6MulticastOption (mcast_addr));
 				try {
@@ -4494,7 +4437,7 @@ namespace MonoTests.System.Net.Sockets
 		public void Shutdown_NoConnect ()
 		{
 			Socket s = new Socket (AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-			s.Bind (new IPEndPoint (IPAddress.Loopback, NetworkHelpers.FindFreePort ()));
+			s.Bind (new IPEndPoint (IPAddress.Loopback, 0));
 			s.Listen (1);
 			try {
 				s.Shutdown (SocketShutdown.Both);
@@ -4658,10 +4601,8 @@ namespace MonoTests.System.Net.Sockets
 			 */
 			using (var server = new Socket (AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp)) {
 
-				var host = new IPEndPoint (IPAddress.Loopback, NetworkHelpers.FindFreePort ());
-
 				server.DualMode = true;
-				server.Bind (host);
+				server.Bind (IPAddress.Loopback, out int _);
 				/*
 				 * Nothing to Accept the connect - we need a backlog to make sure we don't get 
 				 Connection refused.
@@ -4701,10 +4642,8 @@ namespace MonoTests.System.Net.Sockets
 			 */
 			using (var server = new Socket (AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp))
 			{
-				var host = new IPEndPoint (IPAddress.Loopback, NetworkHelpers.FindFreePort ());
-
 				server.DualMode = true;
-				server.Bind (host);
+				server.Bind (IPAddress.Loopback, out int _);
 				server.Listen (10);
 				
 				var ep = server.LocalEndPoint as IPEndPoint;
@@ -4750,9 +4689,8 @@ namespace MonoTests.System.Net.Sockets
 			/* see https://bugzilla.xamarin.com/show_bug.cgi?id=36941 */
 
 			using (Socket socket = new Socket (AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp)) {
-				IPEndPoint end_point = new IPEndPoint (IPAddress.Any, NetworkHelpers.FindFreePort ());
 				socket.SetSocketOption (SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, 1);
-				socket.Bind (end_point);
+				socket.Bind (IPAddress.Any, out int _);
 				socket.SetSocketOption (SocketOptionLevel.IP, SocketOptionName.MulticastTimeToLive, 19);
 			}
 		}

--- a/mcs/class/System/Test/System.Net.Sockets/TcpClientTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/TcpClientTest.cs
@@ -38,8 +38,7 @@ namespace MonoTests.System.Net.Sockets
 			Socket lSock = new Socket(AddressFamily.InterNetwork,
 				SocketType.Stream, ProtocolType.Tcp);
 			
-			var port = NetworkHelpers.FindFreePort ();
-			lSock.Bind(new IPEndPoint(IPAddress.Any, port));
+			lSock.Bind(IPAddress.Any, out int port);
 			lSock.Listen(-1);
 
 
@@ -84,9 +83,10 @@ namespace MonoTests.System.Net.Sockets
 #endif
 		public void CloseTest ()
 		{
-			var port = NetworkHelpers.FindFreePort ();
-			IPEndPoint localEP = new IPEndPoint (IPAddress.Loopback, port);
-			using (SocketResponder sr = new SocketResponder (localEP, s => CloseRequestHandler (s))) {
+			var port = 0;
+			IPEndPoint localEP;
+			using (SocketResponder sr = new SocketResponder (out localEP, s => CloseRequestHandler (s))) {
+				port = localEP.Port;
 				TcpClient tcpClient = new TcpClient (IPAddress.Loopback.ToString (), port);
 				NetworkStream ns = tcpClient.GetStream ();
 				Assert.IsNotNull (ns, "#A1");

--- a/mcs/class/System/Test/System.Net.Sockets/TcpListenerTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/TcpListenerTest.cs
@@ -29,7 +29,7 @@ namespace MonoTests.System.Net.Sockets
 		public void TcpListener ()
 		{
 			// listen with a new listener (IPv4 is the default)
-			TcpListener inListener = NetworkHelpers.StartTcpListener (out int port);
+			TcpListener inListener = NetworkHelpers.CreateAndStartTcpListener (out int port);
 			
 
 			// connect to it from a new socket
@@ -226,7 +226,7 @@ namespace MonoTests.System.Net.Sockets
 #endif
 		public void EndAcceptTcpClient ()
 		{
-			var listenerSocket = NetworkHelpers.StartTcpListener (IPAddress.Any, out int port);
+			var listenerSocket = NetworkHelpers.CreateAndStartTcpListener (IPAddress.Any, out int port);
 			listenerSocket.BeginAcceptTcpClient (new AsyncCallback (l => {
 				listenerSocket.EndAcceptTcpClient (l);
 			}), null);

--- a/mcs/class/System/Test/System.Net.Sockets/TcpListenerTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/TcpListenerTest.cs
@@ -28,10 +28,8 @@ namespace MonoTests.System.Net.Sockets
 #endif
 		public void TcpListener ()
 		{
-			var port = NetworkHelpers.FindFreePort ();
 			// listen with a new listener (IPv4 is the default)
-			TcpListener inListener = new TcpListener (port);
-			inListener.Start();
+			TcpListener inListener = NetworkHelpers.StartTcpListener (out int port);
 			
 
 			// connect to it from a new socket
@@ -130,7 +128,7 @@ namespace MonoTests.System.Net.Sockets
 		class MyListener : TcpListener
 		{
 			public MyListener ()
-				: base (IPAddress.Loopback, NetworkHelpers.FindFreePort ())
+				: base (IPAddress.Loopback, 0)
 			{
 			}
 
@@ -204,8 +202,7 @@ namespace MonoTests.System.Net.Sockets
 #endif
 		public void StartListenMoreThan5 ()
 		{
-			var port = NetworkHelpers.FindFreePort ();
-			TcpListener listen = new TcpListener (IPAddress.Loopback, port);
+			TcpListener listen = new TcpListener (IPAddress.Loopback, 0);
 
 			listen.Start (6);
 			listen.Stop ();
@@ -229,10 +226,7 @@ namespace MonoTests.System.Net.Sockets
 #endif
 		public void EndAcceptTcpClient ()
 		{
-			var port = NetworkHelpers.FindFreePort ();
-
-			var listenerSocket = new TcpListener (IPAddress.Any, port);
-			listenerSocket.Start ();
+			var listenerSocket = NetworkHelpers.StartTcpListener (IPAddress.Any, out int port);
 			listenerSocket.BeginAcceptTcpClient (new AsyncCallback (l => {
 				listenerSocket.EndAcceptTcpClient (l);
 			}), null);

--- a/mcs/class/System/Test/System.Net.Sockets/UdpClientTest.cs
+++ b/mcs/class/System/Test/System.Net.Sockets/UdpClientTest.cs
@@ -885,7 +885,7 @@ namespace MonoTests.System.Net.Sockets {
 #endif
 		public void CloseInReceive ()
 		{
-			UdpClient client = new UdpClient (NetworkHelpers.FindFreePort ());
+			UdpClient client = new UdpClient (0);
 
 			ManualResetEvent ready = new ManualResetEvent (false);
 			bool got_exc = false;
@@ -1024,8 +1024,8 @@ namespace MonoTests.System.Net.Sockets {
 #endif
 		public void BeginReceive ()
 		{
-			var port = NetworkHelpers.FindFreePort ();
-			UdpClient client = new UdpClient (port);
+			UdpClient client = new UdpClient (0);
+			var port = ((IPEndPoint) client.Client.LocalEndPoint).Port;
 			
 			BRCalledBack.Reset ();
 			
@@ -1053,8 +1053,8 @@ namespace MonoTests.System.Net.Sockets {
 #endif
 		public void Available ()
 		{
-			var port = NetworkHelpers.FindFreePort ();
-			using (UdpClient client = new UdpClient (port)) {
+			using (UdpClient client = new UdpClient (0)) {
+				var port = ((IPEndPoint) client.Client.LocalEndPoint).Port;
 				IPEndPoint ep = new IPEndPoint (IPAddress.Loopback, port);
 				byte[] bytes = new byte[] {10, 11, 12, 13};
 				
@@ -1149,10 +1149,9 @@ namespace MonoTests.System.Net.Sockets {
 			if (!Socket.OSSupportsIPv6)
 				Assert.Ignore ("IPv6 not enabled.");
 
-			int port1 = NetworkHelpers.FindFreePort ();
-			int port2 = NetworkHelpers.FindFreePort ();
-			using(var udpClient = new UdpClient (port1, AddressFamily.InterNetworkV6))
-			using(var udpClient2 = new UdpClient (port2, AddressFamily.InterNetworkV6))
+			using(var udpClient = new UdpClient (0, AddressFamily.InterNetworkV6)) {
+			var port1 = ((IPEndPoint) udpClient.Client.LocalEndPoint).Port;
+			using(var udpClient2 = new UdpClient (0, AddressFamily.InterNetworkV6))
 			{
 				var dataSent = new byte [] {1,2,3};
 				udpClient2.SendAsync (dataSent, dataSent.Length, "::1", port1);
@@ -1161,6 +1160,7 @@ namespace MonoTests.System.Net.Sockets {
 				var data = udpClient.Receive (ref endPoint);
 
 				Assert.AreEqual (dataSent.Length, data.Length);
+			}
 			}
 		}
 		

--- a/mcs/class/System/Test/System.Net.WebSockets/ClientWebSocketTest.cs
+++ b/mcs/class/System/Test/System.Net.WebSockets/ClientWebSocketTest.cs
@@ -26,7 +26,6 @@ namespace MonoTests.System.Net.WebSockets
 		public void Setup ()
 		{
 			socket = new ClientWebSocket ();
-			Port = NetworkHelpers.FindFreePort ();
 		}
 
 		HttpListener _listener;
@@ -35,10 +34,7 @@ namespace MonoTests.System.Net.WebSockets
 				if (_listener != null)
 					return _listener;
 
-				var tmp = new HttpListener ();
-				tmp.Prefixes.Add ("http://localhost:" + Port + "/");
-				tmp.Start ();
-				return _listener = tmp;
+				return HttpListener2Test.CreateAndStartListener ("http://localhost:", "/", out Port);
 			}
 		}
 

--- a/mcs/class/System/Test/System.Net.WebSockets/ClientWebSocketTest.cs
+++ b/mcs/class/System/Test/System.Net.WebSockets/ClientWebSocketTest.cs
@@ -34,7 +34,7 @@ namespace MonoTests.System.Net.WebSockets
 				if (_listener != null)
 					return _listener;
 
-				return NetworkHelpers.CreateAndStartHttpListener ("http://localhost:", "/", out Port);
+				return NetworkHelpers.CreateAndStartHttpListener ("http://localhost:", out Port, "/");
 			}
 		}
 

--- a/mcs/class/System/Test/System.Net.WebSockets/ClientWebSocketTest.cs
+++ b/mcs/class/System/Test/System.Net.WebSockets/ClientWebSocketTest.cs
@@ -34,7 +34,7 @@ namespace MonoTests.System.Net.WebSockets
 				if (_listener != null)
 					return _listener;
 
-				return HttpListener2Test.CreateAndStartListener ("http://localhost:", "/", out Port);
+				return NetworkHelpers.CreateAndStartHttpListener ("http://localhost:", "/", out Port);
 			}
 		}
 

--- a/mcs/class/System/Test/System.Net/HttpListenerRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpListenerRequestTest.cs
@@ -52,7 +52,7 @@ namespace MonoTests.System.Net
 			HttpListenerContext ctx;
 			HttpListenerRequest request;
 			NetworkStream ns;
-			HttpListener listener = HttpListener2Test.CreateAndStartListener (
+			HttpListener listener = NetworkHelpers.CreateAndStartHttpListener (
 				"http://127.0.0.1:", out var port, "/HasEntityBody/");
 
 			// POST with non-zero Content-Lenth
@@ -155,7 +155,7 @@ namespace MonoTests.System.Net
 #endif
 		public void HttpMethod ()
 		{
-			HttpListener listener = HttpListener2Test.CreateAndStartListener (
+			HttpListener listener = NetworkHelpers.CreateAndStartHttpListener (
 				"http://127.0.0.1:", out var port, "/HttpMethod/");
 			NetworkStream ns = HttpListener2Test.CreateNS (port);
 			HttpListener2Test.Send (ns, "pOsT /HttpMethod/ HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 3\r\n\r\n123");
@@ -174,7 +174,7 @@ namespace MonoTests.System.Net
 #endif
 		public void HttpBasicAuthScheme ()
 		{
-			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://*:", out var port, "/authTest/", AuthenticationSchemes.Basic);
+			HttpListener listener = NetworkHelpers.CreateAndStartHttpListener ("http://*:", out var port, "/authTest/", AuthenticationSchemes.Basic);
 			//dummy-wait for context
 			listener.BeginGetContext (null, listener);
 			NetworkStream ns = HttpListener2Test.CreateNS (port);
@@ -191,7 +191,7 @@ namespace MonoTests.System.Net
 #endif
 		public void HttpRequestUriIsNotDecoded ()
 		{
-			HttpListener listener = HttpListener2Test.CreateAndStartListener (
+			HttpListener listener = NetworkHelpers.CreateAndStartHttpListener (
 				"http://127.0.0.1:", out var port, "/RequestUriDecodeTest/");
 			NetworkStream ns = HttpListener2Test.CreateNS (port);
 			HttpListener2Test.Send (ns, "GET /RequestUriDecodeTest/?a=b&c=d%26e HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
@@ -221,7 +221,7 @@ namespace MonoTests.System.Net
 				if (ip.AddressFamily != AddressFamily.InterNetwork)
 					continue;
 
-				HttpListener listener = HttpListener2Test.CreateAndStartListener (
+				HttpListener listener = NetworkHelpers.CreateAndStartHttpListener (
 					"http://" + ip + ":", out var port, "/HttpRequestIsLocal/");
 				NetworkStream ns = HttpListener2Test.CreateNS (ip, port);
 				HttpListener2Test.Send (ns, "GET /HttpRequestIsLocal/ HTTP/1.0\r\n\r\n");
@@ -240,7 +240,7 @@ namespace MonoTests.System.Net
 		{
 			var key = "Product/1";
 
-			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://localhost:", out var port, "/", out var prefix);
+			HttpListener listener = NetworkHelpers.CreateAndStartHttpListener ("http://localhost:", out var port, "/", out var prefix);
 
 			var expectedUrl = prefix + key + "/";
 			var rawUrl = prefix + Uri.EscapeDataString (key) + "/";
@@ -264,7 +264,7 @@ namespace MonoTests.System.Net
 #endif
 		public void EmptyWrite ()
 		{
-			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://localhost:", out var port, "/", out var prefix);
+			HttpListener listener = NetworkHelpers.CreateAndStartHttpListener ("http://localhost:", out var port, "/", out var prefix);
 
 			Task.Run (() => {
 				var context = listener.GetContext ();
@@ -285,7 +285,7 @@ namespace MonoTests.System.Net
 #endif
 		public void HttpRequestIgnoreBadCookies ()
 		{
-			HttpListener listener = HttpListener2Test.CreateAndStartListener (
+			HttpListener listener = NetworkHelpers.CreateAndStartHttpListener (
 				"http://127.0.0.1:", out var port, "/HttpRequestIgnoreBadCookiesTest/");
 			NetworkStream ns = HttpListener2Test.CreateNS (port);
 			HttpListener2Test.Send (ns, "GET /HttpRequestIgnoreBadCookiesTest/?a=b HTTP/1.1\r\nHost: 127.0.0.1\r\nCookie: ELOQUA=GUID=5ca2346347357f4-f877-4eff-96aa-70fe0b677650; ELQSTATUS=OK; WRUID=609099666.123259461695; CommunityServer-UserCookie2101=lv=Thu, 26 Jul 2012 15:25:11 GMT&mra=Mon, 01 Oct 2012 17:40:05 GMT; PHPSESSID=1234dg3opfjb4qafp0oo645; __utma=9761706.1153317537.1357240270.1357240270.1357317902.2; __utmb=9761706.6.10.1357317902; __utmc=9761706; __utmz=9761706.1357240270.1.1.utmcsr=test.testdomain.com|utmccn=(referral)|utmcmd=referral|utmcct=/test/1234\r\n\r\n");

--- a/mcs/class/System/Test/System.Net/HttpListenerRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpListenerRequestTest.cs
@@ -52,9 +52,8 @@ namespace MonoTests.System.Net
 			HttpListenerContext ctx;
 			HttpListenerRequest request;
 			NetworkStream ns;
-			var port = NetworkHelpers.FindFreePort ();
 			HttpListener listener = HttpListener2Test.CreateAndStartListener (
-				"http://127.0.0.1:" + port + "/HasEntityBody/");
+				"http://127.0.0.1:", out var port, "/HasEntityBody/");
 
 			// POST with non-zero Content-Lenth
 			ns = HttpListener2Test.CreateNS (port);
@@ -156,9 +155,8 @@ namespace MonoTests.System.Net
 #endif
 		public void HttpMethod ()
 		{
-			var port = NetworkHelpers.FindFreePort ();
 			HttpListener listener = HttpListener2Test.CreateAndStartListener (
-				"http://127.0.0.1:" + port + "/HttpMethod/");
+				"http://127.0.0.1:", out var port, "/HttpMethod/");
 			NetworkStream ns = HttpListener2Test.CreateNS (port);
 			HttpListener2Test.Send (ns, "pOsT /HttpMethod/ HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 3\r\n\r\n123");
 			HttpListenerContext ctx = listener.GetContext ();
@@ -176,8 +174,7 @@ namespace MonoTests.System.Net
 #endif
 		public void HttpBasicAuthScheme ()
 		{
-			var port = NetworkHelpers.FindFreePort ();			
-			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://*:" + port + "/authTest/", AuthenticationSchemes.Basic);
+			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://*:", out var port, "/authTest/", AuthenticationSchemes.Basic);
 			//dummy-wait for context
 			listener.BeginGetContext (null, listener);
 			NetworkStream ns = HttpListener2Test.CreateNS (port);
@@ -194,9 +191,8 @@ namespace MonoTests.System.Net
 #endif
 		public void HttpRequestUriIsNotDecoded ()
 		{
-			var port = NetworkHelpers.FindFreePort ();
 			HttpListener listener = HttpListener2Test.CreateAndStartListener (
-				"http://127.0.0.1:" + port + "/RequestUriDecodeTest/");
+				"http://127.0.0.1:", out var port, "/RequestUriDecodeTest/");
 			NetworkStream ns = HttpListener2Test.CreateNS (port);
 			HttpListener2Test.Send (ns, "GET /RequestUriDecodeTest/?a=b&c=d%26e HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
 			HttpListenerContext ctx = listener.GetContext ();
@@ -211,7 +207,6 @@ namespace MonoTests.System.Net
 #endif
 		public void HttpRequestIsLocal ()
 		{
-			var port = NetworkHelpers.FindFreePort ();
 			var ips = new List<IPAddress> ();
 			ips.Add (IPAddress.Loopback);
 			foreach (var adapter in NetworkInterface.GetAllNetworkInterfaces ()) {
@@ -227,7 +222,7 @@ namespace MonoTests.System.Net
 					continue;
 
 				HttpListener listener = HttpListener2Test.CreateAndStartListener (
-					"http://" + ip + ":" + port + "/HttpRequestIsLocal/");
+					"http://" + ip + ":", out var port, "/HttpRequestIsLocal/");
 				NetworkStream ns = HttpListener2Test.CreateNS (ip, port);
 				HttpListener2Test.Send (ns, "GET /HttpRequestIsLocal/ HTTP/1.0\r\n\r\n");
 				HttpListenerContext ctx = listener.GetContext ();
@@ -243,15 +238,13 @@ namespace MonoTests.System.Net
 #endif
 		public void HttpRequestUriUnescape ()
 		{
-			var prefix = "http://localhost:" + NetworkHelpers.FindFreePort () + "/";
 			var key = "Product/1";
+
+			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://localhost:", out var port, "/", out var prefix);
 
 			var expectedUrl = prefix + key + "/";
 			var rawUrl = prefix + Uri.EscapeDataString (key) + "/";
 
-			HttpListener listener = new HttpListener ();
-			listener.Prefixes.Add (prefix);
-			listener.Start ();
 
 			var contextTask = listener.GetContextAsync ();
 
@@ -271,11 +264,7 @@ namespace MonoTests.System.Net
 #endif
 		public void EmptyWrite ()
 		{
-			var prefix = "http://localhost:" + NetworkHelpers.FindFreePort () + "/";
-
-			HttpListener listener = new HttpListener ();
-			listener.Prefixes.Add (prefix);
-			listener.Start ();
+			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://localhost:", out var port, "/", out var prefix);
 
 			Task.Run (() => {
 				var context = listener.GetContext ();
@@ -296,9 +285,8 @@ namespace MonoTests.System.Net
 #endif
 		public void HttpRequestIgnoreBadCookies ()
 		{
-			var port = NetworkHelpers.FindFreePort ();
 			HttpListener listener = HttpListener2Test.CreateAndStartListener (
-				"http://127.0.0.1:" + port + "/HttpRequestIgnoreBadCookiesTest/");
+				"http://127.0.0.1:", out var port, "/HttpRequestIgnoreBadCookiesTest/");
 			NetworkStream ns = HttpListener2Test.CreateNS (port);
 			HttpListener2Test.Send (ns, "GET /HttpRequestIgnoreBadCookiesTest/?a=b HTTP/1.1\r\nHost: 127.0.0.1\r\nCookie: ELOQUA=GUID=5ca2346347357f4-f877-4eff-96aa-70fe0b677650; ELQSTATUS=OK; WRUID=609099666.123259461695; CommunityServer-UserCookie2101=lv=Thu, 26 Jul 2012 15:25:11 GMT&mra=Mon, 01 Oct 2012 17:40:05 GMT; PHPSESSID=1234dg3opfjb4qafp0oo645; __utma=9761706.1153317537.1357240270.1357240270.1357317902.2; __utmb=9761706.6.10.1357317902; __utmc=9761706; __utmz=9761706.1357240270.1.1.utmcsr=test.testdomain.com|utmccn=(referral)|utmcmd=referral|utmcct=/test/1234\r\n\r\n");
 			HttpListenerContext ctx = listener.GetContext ();

--- a/mcs/class/System/Test/System.Net/HttpListenerTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpListenerTest.cs
@@ -187,8 +187,8 @@ namespace MonoTests.System.Net {
 #endif
 		public void TwoListeners_SameAddress ()
 		{
-			HttpListener listener1 = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", out var port, "/");
-			HttpListener listener2 = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", port, "/hola/");
+			HttpListener listener1 = NetworkHelpers.CreateAndStartHttpListener ("http://127.0.0.1:", out var port, "/");
+			HttpListener listener2 = NetworkHelpers.CreateAndStartHttpListener ("http://127.0.0.1:", port, "/hola/");
 		}
 
 		[Test]
@@ -200,8 +200,8 @@ namespace MonoTests.System.Net {
 		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TwoListeners_SameURL ()
 		{
-			HttpListener listener1 = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", out var port, "/hola/");
-			HttpListener listener2 = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", port, "/hola/");
+			HttpListener listener1 = NetworkHelpers.CreateAndStartHttpListener ("http://127.0.0.1:", out var port, "/hola/");
+			HttpListener listener2 = NetworkHelpers.CreateAndStartHttpListener ("http://127.0.0.1:", port, "/hola/");
 		}
 
 		[Test]
@@ -214,7 +214,7 @@ namespace MonoTests.System.Net {
 		public void MultipleSlashes ()
 		{
 			// this one throws on Start(), not when adding it.
-			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", out var port, "/hola////");
+			HttpListener listener = NetworkHelpers.CreateAndStartHttpListener ("http://127.0.0.1:", out var port, "/hola////");
 		}
 
 		[Test]
@@ -226,7 +226,7 @@ namespace MonoTests.System.Net {
 		[Category ("NotWorkingRuntimeInterpreter")]
 		public void PercentSign ()
 		{
-			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", out var port, "/hola%3E/");
+			HttpListener listener = NetworkHelpers.CreateAndStartHttpListener ("http://127.0.0.1:", out var port, "/hola%3E/");
 		}
 
 		[Test]
@@ -245,7 +245,7 @@ namespace MonoTests.System.Net {
 #endif
 		public void CloseTwice ()
 		{
-			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", out var port, "/hola/");
+			HttpListener listener = NetworkHelpers.CreateAndStartHttpListener ("http://127.0.0.1:", out var port, "/hola/");
 			listener.Close ();
 			listener.Close ();
 		}
@@ -256,7 +256,7 @@ namespace MonoTests.System.Net {
 #endif
 		public void StartStopStart ()
 		{
-			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", out var port, "/hola/");
+			HttpListener listener = NetworkHelpers.CreateAndStartHttpListener ("http://127.0.0.1:", out var port, "/hola/");
 			listener.Stop ();
 			listener.Start ();
 			listener.Close ();
@@ -268,7 +268,7 @@ namespace MonoTests.System.Net {
 #endif
 		public void StartStopDispose ()
 		{
-			using (HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", out var port, "/hola/")) {
+			using (HttpListener listener = NetworkHelpers.CreateAndStartHttpListener ("http://127.0.0.1:", out var port, "/hola/")) {
 				listener.Stop ();
 			}
 		}
@@ -289,7 +289,7 @@ namespace MonoTests.System.Net {
 #endif
 		public void AbortTwice ()
 		{
-			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://localhost:", out var port, "/hola/");
+			HttpListener listener = NetworkHelpers.CreateAndStartHttpListener ("http://localhost:", out var port, "/hola/");
 			listener.Abort ();
 			listener.Abort ();
 		}
@@ -405,7 +405,7 @@ namespace MonoTests.System.Net {
 #endif
 		public void CloseWhileBegin ()
 		{
-			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", out var _, "/closewhilebegin/");
+			HttpListener listener = NetworkHelpers.CreateAndStartHttpListener ("http://127.0.0.1:", out var _, "/closewhilebegin/");
 			CallMe cm = new CallMe ();
 			listener.BeginGetContext (cm.Callback, listener);
 			listener.Close ();
@@ -422,7 +422,7 @@ namespace MonoTests.System.Net {
 #endif
 		public void AbortWhileBegin ()
 		{
-			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", out var _, "/abortwhilebegin/");
+			HttpListener listener = NetworkHelpers.CreateAndStartHttpListener ("http://127.0.0.1:", out var _, "/abortwhilebegin/");
 			CallMe cm = new CallMe ();
 			listener.BeginGetContext (cm.Callback, listener);
 			listener.Abort ();
@@ -446,7 +446,7 @@ namespace MonoTests.System.Net {
 			//   at System.Net.HttpListener.GetContext()
 			//   at MonoTests.System.Net.HttpListenerTest.CloseWhileGet()
 
-			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", out var _, "/closewhileget/");
+			HttpListener listener = NetworkHelpers.CreateAndStartHttpListener ("http://127.0.0.1:", out var _, "/closewhileget/");
 			RunMe rm = new RunMe (1000, new ThreadStart (listener.Close), new object [0]);
 			rm.Start ();
 			HttpListenerContext ctx = listener.GetContext ();
@@ -465,7 +465,7 @@ namespace MonoTests.System.Net {
 			//   at System.Net.HttpListener.GetContext()
 			//   at MonoTests.System.Net.HttpListenerTest.CloseWhileGet()
 
-			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", out var _, "/abortwhileget/");
+			HttpListener listener = NetworkHelpers.CreateAndStartHttpListener ("http://127.0.0.1:", out var _, "/abortwhileget/");
 			RunMe rm = new RunMe (1000, new ThreadStart (listener.Abort), new object [0]);
 			rm.Start ();
 			HttpListenerContext ctx = listener.GetContext ();
@@ -540,7 +540,7 @@ namespace MonoTests.System.Net {
 #endif
 		public void ConnectionReuse ()
 		{
-			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://localhost:", out var port, "/", out var uri);
+			HttpListener listener = NetworkHelpers.CreateAndStartHttpListener ("http://localhost:", out var port, "/", out var uri);
 
 			IPEndPoint expectedIpEndPoint = CreateListenerRequest (listener, uri);
 
@@ -596,7 +596,7 @@ namespace MonoTests.System.Net {
 #endif
 		public void UserHeaderWithDoubleMultiValue ()
 		{
-			var l = HttpListener2Test.CreateAndStartListener ("http://localhost:", out var port, "/", out var uri);
+			var l = NetworkHelpers.CreateAndStartHttpListener ("http://localhost:", out var port, "/", out var uri);
 
 			l.BeginGetContext (ar => {
 				var ctx = l.EndGetContext (ar);
@@ -624,7 +624,7 @@ namespace MonoTests.System.Net {
 		public void HttpClientIsDisconnectedCheckForWriteException()
 		{
 			AutoResetEvent exceptionOccuredEvent = new AutoResetEvent (false);
-			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://localhost:", out var port, "/", out var uri,
+			HttpListener listener = NetworkHelpers.CreateAndStartHttpListener ("http://localhost:", out var port, "/", out var uri,
 				initializer: (v) => v.IgnoreWriteExceptions = false);
 			listener.BeginGetContext (result =>
 			{

--- a/mcs/class/System/Test/System.Net/HttpListenerTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpListenerTest.cs
@@ -38,18 +38,6 @@ using MonoTests.Helpers;
 namespace MonoTests.System.Net {
 	[TestFixture]
 	public class HttpListenerTest {
-
-		int? _port;
-		int port {
-			get { return _port ?? (_port = NetworkHelpers.FindFreePort ()).Value; }
-		}
-
-		[TearDown]
-		public void Teardown ()
-		{
-			_port = null;
-		}
-
 		[Test]
 #if FEATURE_NO_BSD_SOCKETS
 		[ExpectedException (typeof (PlatformNotSupportedException))]
@@ -199,14 +187,8 @@ namespace MonoTests.System.Net {
 #endif
 		public void TwoListeners_SameAddress ()
 		{
-			if (!CanOpenPort (port))
-				Assert.Ignore ("port");
-			HttpListener listener1 = new HttpListener ();
-			listener1.Prefixes.Add ("http://127.0.0.1:" + port + "/");
-			HttpListener listener2 = new HttpListener ();
-			listener2.Prefixes.Add ("http://127.0.0.1:" + port + "/hola/");
-			listener1.Start ();
-			listener2.Start ();
+			HttpListener listener1 = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", out var port, "/");
+			HttpListener listener2 = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", port, "/hola/");
 		}
 
 		[Test]
@@ -218,14 +200,8 @@ namespace MonoTests.System.Net {
 		[Category ("NotWorkingRuntimeInterpreter")]
 		public void TwoListeners_SameURL ()
 		{
-			if (!CanOpenPort (port))
-				Assert.Ignore ("port");
-			HttpListener listener1 = new HttpListener ();
-			listener1.Prefixes.Add ("http://127.0.0.1:" + port + "/hola/");
-			HttpListener listener2 = new HttpListener ();
-			listener2.Prefixes.Add ("http://127.0.0.1:" + port + "/hola/");
-			listener1.Start ();
-			listener2.Start ();
+			HttpListener listener1 = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", out var port, "/hola/");
+			HttpListener listener2 = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", port, "/hola/");
 		}
 
 		[Test]
@@ -237,12 +213,8 @@ namespace MonoTests.System.Net {
 		[Category ("NotWorkingRuntimeInterpreter")]
 		public void MultipleSlashes ()
 		{
-			if (!CanOpenPort (port))
-				Assert.Ignore ("port");
-			HttpListener listener = new HttpListener ();
-			listener.Prefixes.Add ("http://localhost:" + port + "/hola////");
 			// this one throws on Start(), not when adding it.
-			listener.Start ();
+			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", out var port, "/hola////");
 		}
 
 		[Test]
@@ -254,12 +226,7 @@ namespace MonoTests.System.Net {
 		[Category ("NotWorkingRuntimeInterpreter")]
 		public void PercentSign ()
 		{
-			if (!CanOpenPort (port))
-				Assert.Ignore ("port");
-			HttpListener listener = new HttpListener ();
-			listener.Prefixes.Add ("http://localhost:" + port + "/hola%3E/");
-			// this one throws on Start(), not when adding it.
-			listener.Start ();
+			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", out var port, "/hola%3E/");
 		}
 
 		[Test]
@@ -278,11 +245,7 @@ namespace MonoTests.System.Net {
 #endif
 		public void CloseTwice ()
 		{
-			if (!CanOpenPort (port))
-				Assert.Ignore ("port");
-			HttpListener listener = new HttpListener ();
-			listener.Prefixes.Add ("http://localhost:" + port + "/hola/");
-			listener.Start ();
+			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", out var port, "/hola/");
 			listener.Close ();
 			listener.Close ();
 		}
@@ -293,11 +256,7 @@ namespace MonoTests.System.Net {
 #endif
 		public void StartStopStart ()
 		{
-			if (!CanOpenPort (port))
-				Assert.Ignore ("port");
-			HttpListener listener = new HttpListener ();
-			listener.Prefixes.Add ("http://localhost:" + port + "/hola/");
-			listener.Start ();
+			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", out var port, "/hola/");
 			listener.Stop ();
 			listener.Start ();
 			listener.Close ();
@@ -309,11 +268,7 @@ namespace MonoTests.System.Net {
 #endif
 		public void StartStopDispose ()
 		{
-			if (!CanOpenPort (port))
-				Assert.Ignore ("port");
-			using (HttpListener listener = new HttpListener ()){
-				listener.Prefixes.Add ("http://localhost:" + port + "/hola/");
-				listener.Start ();
+			using (HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", out var port, "/hola/")) {
 				listener.Stop ();
 			}
 		}
@@ -334,11 +289,7 @@ namespace MonoTests.System.Net {
 #endif
 		public void AbortTwice ()
 		{
-			if (!CanOpenPort (port))
-				Assert.Ignore ("port");
-			HttpListener listener = new HttpListener ();
-			listener.Prefixes.Add ("http://localhost:" + port + "/hola/");
-			listener.Start ();
+			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://localhost:", out var port, "/hola/");
 			listener.Abort ();
 			listener.Abort ();
 		}
@@ -454,9 +405,7 @@ namespace MonoTests.System.Net {
 #endif
 		public void CloseWhileBegin ()
 		{
-			HttpListener listener = new HttpListener ();
-			listener.Prefixes.Add ("http://127.0.0.1:" + NetworkHelpers.FindFreePort () + "/closewhilebegin/");
-			listener.Start ();
+			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", out var _, "/closewhilebegin/");
 			CallMe cm = new CallMe ();
 			listener.BeginGetContext (cm.Callback, listener);
 			listener.Close ();
@@ -473,9 +422,7 @@ namespace MonoTests.System.Net {
 #endif
 		public void AbortWhileBegin ()
 		{
-			HttpListener listener = new HttpListener ();
-			listener.Prefixes.Add ("http://127.0.0.1:" + NetworkHelpers.FindFreePort () + "/abortwhilebegin/");
-			listener.Start ();
+			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", out var _, "/abortwhilebegin/");
 			CallMe cm = new CallMe ();
 			listener.BeginGetContext (cm.Callback, listener);
 			listener.Abort ();
@@ -499,9 +446,7 @@ namespace MonoTests.System.Net {
 			//   at System.Net.HttpListener.GetContext()
 			//   at MonoTests.System.Net.HttpListenerTest.CloseWhileGet()
 
-			HttpListener listener = new HttpListener ();
-			listener.Prefixes.Add ("http://127.0.0.1:" + NetworkHelpers.FindFreePort () + "/closewhileget/");
-			listener.Start ();
+			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", out var _, "/closewhileget/");
 			RunMe rm = new RunMe (1000, new ThreadStart (listener.Close), new object [0]);
 			rm.Start ();
 			HttpListenerContext ctx = listener.GetContext ();
@@ -520,9 +465,7 @@ namespace MonoTests.System.Net {
 			//   at System.Net.HttpListener.GetContext()
 			//   at MonoTests.System.Net.HttpListenerTest.CloseWhileGet()
 
-			HttpListener listener = new HttpListener ();
-			listener.Prefixes.Add ("http://127.0.0.1:" + NetworkHelpers.FindFreePort () + "/abortwhileget/");
-			listener.Start ();
+			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://127.0.0.1:", out var _, "/abortwhileget/");
 			RunMe rm = new RunMe (1000, new ThreadStart (listener.Abort), new object [0]);
 			rm.Start ();
 			HttpListenerContext ctx = listener.GetContext ();
@@ -597,11 +540,7 @@ namespace MonoTests.System.Net {
 #endif
 		public void ConnectionReuse ()
 		{
-			var uri = "http://localhost:" + NetworkHelpers.FindFreePort () + "/";
-
-			HttpListener listener = new HttpListener ();
-			listener.Prefixes.Add (uri);
-			listener.Start ();
+			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://localhost:", out var port, "/", out var uri);
 
 			IPEndPoint expectedIpEndPoint = CreateListenerRequest (listener, uri);
 
@@ -657,11 +596,8 @@ namespace MonoTests.System.Net {
 #endif
 		public void UserHeaderWithDoubleMultiValue ()
 		{
-			string uri = "http://localhost:" + NetworkHelpers.FindFreePort () + "/";
+			var l = HttpListener2Test.CreateAndStartListener ("http://localhost:", out var port, "/", out var uri);
 
-			var l = new HttpListener ();
-			l.Prefixes.Add (uri);
-			l.Start ();
 			l.BeginGetContext (ar => {
 				var ctx = l.EndGetContext (ar);
 
@@ -687,14 +623,9 @@ namespace MonoTests.System.Net {
 #endif
 		public void HttpClientIsDisconnectedCheckForWriteException()
 		{
-			string uri = "http://localhost:" + NetworkHelpers.FindFreePort () + "/";
-
 			AutoResetEvent exceptionOccuredEvent = new AutoResetEvent (false);
-			HttpListener listener = new HttpListener {
-				IgnoreWriteExceptions = false
-			};
-			listener.Prefixes.Add (uri);
-			listener.Start ();
+			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://localhost:", out var port, "/", out var uri,
+				initializer: (v) => v.IgnoreWriteExceptions = false);
 			listener.BeginGetContext (result =>
 			{
 				HttpListenerContext context = listener.EndGetContext (result);

--- a/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
@@ -2514,7 +2514,7 @@ namespace MonoTests.System.Net
 				this.completed = completed;
 				this.eh = exceptionHandler;
 
-				this.listener = HttpListener2Test.CreateAndStartListener ("http://localhost:", "/", out port, AuthenticationSchemes.Anonymous);
+				this.listener = NetworkHelpers.CreateAndStartHttpListener ("http://localhost:", "/", out port, AuthenticationSchemes.Anonymous);
 
 				this.listener.BeginGetContext (this.RequestHandler, null);
 			}

--- a/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
@@ -2514,7 +2514,7 @@ namespace MonoTests.System.Net
 				this.completed = completed;
 				this.eh = exceptionHandler;
 
-				this.listener = NetworkHelpers.CreateAndStartHttpListener ("http://localhost:", "/", out port, AuthenticationSchemes.Anonymous);
+				this.listener = NetworkHelpers.CreateAndStartHttpListener ("http://localhost:", out port, "/", AuthenticationSchemes.Anonymous);
 
 				this.listener.BeginGetContext (this.RequestHandler, null);
 			}

--- a/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpWebRequestTest.cs
@@ -108,10 +108,8 @@ namespace MonoTests.System.Net
 #endif
 		public void CloseRequestStreamAfterReadingResponse ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 				req.Timeout = 2000;
@@ -225,11 +223,9 @@ namespace MonoTests.System.Net
 			methods.Add ("whatever", "whatever");
 			methods.Add ("PUT", "PUT");
 
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
 			foreach (DictionaryEntry de in methods) {
-				using (SocketResponder responder = new SocketResponder (ep, s => EchoRequestHandler (s))) {
+				using (SocketResponder responder = new SocketResponder (out var ep, s => EchoRequestHandler (s))) {
+					string url = "http://" + ep.ToString () + "/test/";
 					HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 					req.Method = (string) de.Key;
 					req.Timeout = 2000;
@@ -256,10 +252,8 @@ namespace MonoTests.System.Net
 #endif
 		public void BeginGetRequestStream_Body_NotAllowed ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest request;
 
 				request = (HttpWebRequest) WebRequest.Create (url);
@@ -298,10 +292,8 @@ namespace MonoTests.System.Net
 #endif
 		public void BeginGetRequestStream_NoBuffering ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req;
 				Stream rs;
 				IAsyncResult ar;
@@ -353,10 +345,8 @@ namespace MonoTests.System.Net
 		[Category ("NotWorking")] // #5842
 		public void BeginGetResponse ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req;
 
 				req = (HttpWebRequest) WebRequest.Create (url);
@@ -451,10 +441,8 @@ namespace MonoTests.System.Net
 #endif
 		public void BeginGetRequestStream_Request_Aborted ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 				req.Abort ();
@@ -479,10 +467,8 @@ namespace MonoTests.System.Net
 #endif
 		public void BeginGetResponse_Request_Aborted ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 				req.Abort ();
@@ -507,10 +493,8 @@ namespace MonoTests.System.Net
 #endif
 		public void EndGetRequestStream_AsyncResult_Null ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 				req.BeginGetRequestStream (null, null);
@@ -533,10 +517,8 @@ namespace MonoTests.System.Net
 		[Category ("NotWorking")] // do not get consistent result on MS
 		public void EndGetRequestStream_Request_Aborted ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 				IAsyncResult ar = req.BeginGetRequestStream (null, null);
@@ -561,10 +543,8 @@ namespace MonoTests.System.Net
 		[Category ("NotWorking")]
 		public void EndGetResponse_AsyncResult_Invalid ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 				req.Timeout = 2000;
@@ -588,10 +568,8 @@ namespace MonoTests.System.Net
 #endif
 		public void EndGetResponse_AsyncResult_Null ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Timeout = 2000;
 				req.ReadWriteTimeout = 2000;
@@ -622,10 +600,8 @@ namespace MonoTests.System.Net
 #endif
 		public void GetRequestStream ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 				req.Timeout = 2000;
@@ -647,10 +623,8 @@ namespace MonoTests.System.Net
 #endif
 		public void GetRequestStream_Request_Aborted ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 				req.Abort ();
@@ -673,10 +647,8 @@ namespace MonoTests.System.Net
 		[Category ("NotWorking")] // #5842
 		public void GetRequestStream_Close_NotAllBytesWritten ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req;
 				Stream rs;
 
@@ -739,11 +711,9 @@ namespace MonoTests.System.Net
 		[Category ("NotWorking")] // #5842
 		public void GetRequestStream_Write_Overflow ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
 			// buffered, non-chunked
-			using (SocketResponder responder = new SocketResponder (ep, s => EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req;
 				Stream rs;
 				byte [] buffer;
@@ -793,7 +763,8 @@ namespace MonoTests.System.Net
 			}
 
 			// buffered, chunked
-			using (SocketResponder responder = new SocketResponder (ep, s => EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req;
 				Stream rs;
 				byte [] buffer;
@@ -829,7 +800,8 @@ namespace MonoTests.System.Net
 			}
 
 			// non-buffered, non-chunked
-			using (SocketResponder responder = new SocketResponder (ep, s => EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req;
 				Stream rs;
 				byte [] buffer;
@@ -881,7 +853,8 @@ namespace MonoTests.System.Net
 			}
 
 			// non-buffered, chunked
-			using (SocketResponder responder = new SocketResponder (ep, s => EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req;
 				Stream rs;
 				byte [] buffer;
@@ -945,10 +918,8 @@ namespace MonoTests.System.Net
 #endif
 		public void GetResponse_Request_Aborted ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 				req.Abort ();
@@ -971,10 +942,8 @@ namespace MonoTests.System.Net
 		[Ignore ("This does not timeout any more. That's how MS works when reading small responses")]
 		public void ReadTimeout ()
 		{
-			IPEndPoint localEP = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + localEP.ToString () + "/original/";
-
-			using (SocketResponder responder = new SocketResponder (localEP, s => RedirectRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var localEP, s => RedirectRequestHandler (s))) {
+				string url = "http://" + localEP.ToString () + "/original/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 				req.AllowAutoRedirect = false;
@@ -1004,11 +973,9 @@ namespace MonoTests.System.Net
 #endif
 		public void AllowAutoRedirect ()
 		{
-			IPEndPoint localEP = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + localEP.ToString () + "/original/";
-
 			// allow autoredirect
-			using (SocketResponder responder = new SocketResponder (localEP, s => RedirectRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var localEP, s => RedirectRequestHandler (s))) {
+				string url = "http://" + localEP.ToString () + "/original/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 				req.Timeout = 2000;
@@ -1030,7 +997,8 @@ namespace MonoTests.System.Net
 			}
 
 			// do not allow autoredirect
-			using (SocketResponder responder = new SocketResponder (localEP, s => RedirectRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var localEP, s => RedirectRequestHandler (s))) {
+				string url = "http://" + localEP.ToString () + "/original/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 				req.AllowAutoRedirect = false;
@@ -1053,10 +1021,8 @@ namespace MonoTests.System.Net
 #endif
 		public void PostAndRedirect_NoCL ()
 		{
-			IPEndPoint localEP = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + localEP.ToString () + "/original/";
-
-			using (SocketResponder responder = new SocketResponder (localEP, s => RedirectRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var localEP, s => RedirectRequestHandler (s))) {
+				string url = "http://" + localEP.ToString () + "/original/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 				req.Timeout = 2000;
@@ -1084,10 +1050,8 @@ namespace MonoTests.System.Net
 #endif
 		public void PostAndRedirect_CL ()
 		{
-			IPEndPoint localEP = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + localEP.ToString () + "/original/";
-
-			using (SocketResponder responder = new SocketResponder (localEP, s => RedirectRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var localEP, s => RedirectRequestHandler (s))) {
+				string url = "http://" + localEP.ToString () + "/original/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 				req.Timeout = 2000;
@@ -1115,10 +1079,8 @@ namespace MonoTests.System.Net
 #endif
 		public void PostAnd401 ()
 		{
-			IPEndPoint localEP = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + localEP.ToString () + "/original/";
-
-			using (SocketResponder responder = new SocketResponder (localEP, s => RedirectRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var localEP, s => RedirectRequestHandler (s))) {
+				string url = "http://" + localEP.ToString () + "/original/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 				req.Timeout = 2000;
@@ -1144,11 +1106,9 @@ namespace MonoTests.System.Net
 		[Category ("NotWorking")]
 		public void InternalServerError ()
 		{
-			IPEndPoint localEP = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + localEP.ToString () + "/original/";
-
 			// POST
-			using (SocketResponder responder = new SocketResponder (localEP, s => InternalErrorHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var localEP, s => InternalErrorHandler (s))) {
+				string url = "http://" + localEP.ToString () + "/original/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 				req.Timeout = 2000;
@@ -1174,7 +1134,8 @@ namespace MonoTests.System.Net
 			}
 
 			// GET
-			using (SocketResponder responder = new SocketResponder (localEP, s => InternalErrorHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var localEP, s => InternalErrorHandler (s))) {
+				string url = "http://" + localEP.ToString () + "/original/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -1201,11 +1162,9 @@ namespace MonoTests.System.Net
 		[Category ("NotWorking")] // #B3 fails; we get a SocketException: An existing connection was forcibly closed by the remote host
 		public void NoContentLength ()
 		{
-			IPEndPoint localEP = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + localEP.ToString () + "/original/";
-
 			// POST
-			using (SocketResponder responder = new SocketResponder (localEP, s => NoContentLengthHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var localEP, s => NoContentLengthHandler (s))) {
+				string url = "http://" + localEP.ToString () + "/original/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 				req.Timeout = 2000;
@@ -1248,7 +1207,8 @@ namespace MonoTests.System.Net
 			}
 
 			// GET
-			using (SocketResponder responder = new SocketResponder (localEP, s => NoContentLengthHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var localEP, s => NoContentLengthHandler (s))) {
+				string url = "http://" + localEP.ToString () + "/original/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -1279,10 +1239,8 @@ namespace MonoTests.System.Net
 #endif
 		public void NonStandardVerb ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/moved/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => VerbEchoHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => VerbEchoHandler (s))) {
+				string url = "http://" + ep.ToString () + "/moved/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "WhatEver";
 				req.KeepAlive = false;
@@ -1310,10 +1268,8 @@ namespace MonoTests.System.Net
 		[Category ("NotWorking")] // Assert #2 fails
 		public void NotModifiedSince ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => NotModifiedSinceHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => NotModifiedSinceHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.KeepAlive = false;
@@ -1448,11 +1404,9 @@ namespace MonoTests.System.Net
 #endif
 		public void TestTimeoutPropertyWithServerThatExistsAndRespondsButTooLate ()
 		{
-			var ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep + "/foobar/";
-
-			using (var responder = new SocketResponder (ep, TimeOutHandler))
+			using (var responder = new SocketResponder (out var ep, TimeOutHandler))
 			{
+				string url = "http://" + ep + "/foobar/";
 				TestTimeOut (url, WebExceptionStatus.Timeout);
 			}
 		}
@@ -2320,14 +2274,12 @@ namespace MonoTests.System.Net
 
 		void DoRequest (Action<HttpWebRequest, EventWaitHandle> request, Action<HttpListenerContext> processor)
 		{
-			int port = NetworkHelpers.FindFreePort ();
-
 			ManualResetEvent [] completed = new ManualResetEvent [2];
 			completed [0] = new ManualResetEvent (false);
 			completed [1] = new ManualResetEvent (false);
 			ExceptionDispatchInfo edi = null;
 
-			using (ListenerScope scope = new ListenerScope (processor, port, completed [0], e => { edi = ExceptionDispatchInfo.Capture (e); })) {
+			using (ListenerScope scope = new ListenerScope (processor, out var port, completed [0], e => { edi = ExceptionDispatchInfo.Capture (e); })) {
 				Uri address = new Uri (string.Format ("http://localhost:{0}", port));
 				HttpWebRequest client = (HttpWebRequest) WebRequest.Create (address);
 
@@ -2556,16 +2508,13 @@ namespace MonoTests.System.Net
 			Action<HttpListenerContext> processor;
 			Action<Exception> eh;
 
-			public ListenerScope (Action<HttpListenerContext> processor, int port, EventWaitHandle completed, Action<Exception> exceptionHandler)
+			public ListenerScope (Action<HttpListenerContext> processor, out int port, EventWaitHandle completed, Action<Exception> exceptionHandler)
 			{
 				this.processor = processor;
 				this.completed = completed;
 				this.eh = exceptionHandler;
 
-				this.listener = new HttpListener ();
-				this.listener.Prefixes.Add (string.Format ("http://localhost:{0}/", port));
-				this.listener.AuthenticationSchemes = AuthenticationSchemes.Anonymous;
-				this.listener.Start ();
+				this.listener = HttpListener2Test.CreateAndStartListener ("http://localhost:", "/", out port, AuthenticationSchemes.Anonymous);
 
 				this.listener.BeginGetContext (this.RequestHandler, null);
 			}
@@ -2685,10 +2634,8 @@ namespace MonoTests.System.Net
 #endif
 		public void CookieContainerTest ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString ();
-
-			using (SocketResponder responder = new SocketResponder (ep, s => CookieRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => CookieRequestHandler (s))) {
+				string url = "http://" + ep.ToString ();
 				CookieContainer container = new CookieContainer ();
 				container.Add(new Uri (url), new Cookie ("foo", "bar"));
 				HttpWebRequest request = (HttpWebRequest) WebRequest.Create (url);
@@ -2705,7 +2652,8 @@ namespace MonoTests.System.Net
 				Assert.AreEqual ("foo=bar", response.Headers.Get("Set-Cookie"), "#02");
 			}
 
-			using (SocketResponder responder = new SocketResponder (ep, s => CookieRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => CookieRequestHandler (s))) {
+				string url = "http://" + ep.ToString ();
 				CookieContainer container = new CookieContainer ();
 				HttpWebRequest request = (HttpWebRequest) WebRequest.Create (url);
 				request.CookieContainer = container;
@@ -2772,10 +2720,8 @@ namespace MonoTests.System.Net
 #endif
 		public void BeginRead ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 
@@ -2800,10 +2746,8 @@ namespace MonoTests.System.Net
 		[Category("MobileNotWorking")]
 		public void BeginWrite_Request_Aborted ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 
@@ -2830,10 +2774,8 @@ namespace MonoTests.System.Net
 #endif
 		public void CanRead ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 
@@ -2855,10 +2797,8 @@ namespace MonoTests.System.Net
 #endif
 		public void CanSeek ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 
@@ -2880,10 +2820,8 @@ namespace MonoTests.System.Net
 #endif
 		public void CanTimeout ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 
@@ -2905,10 +2843,8 @@ namespace MonoTests.System.Net
 #endif
 		public void CanWrite ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 
@@ -2931,10 +2867,8 @@ namespace MonoTests.System.Net
 #endif
 		public void Read ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 
@@ -2961,10 +2895,8 @@ namespace MonoTests.System.Net
 #endif
 		public void ReadByte ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 
@@ -2990,10 +2922,8 @@ namespace MonoTests.System.Net
 #endif
 		public void ReadTimeout ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 
@@ -3015,10 +2945,8 @@ namespace MonoTests.System.Net
 #endif
 		public void Seek ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 
@@ -3044,10 +2972,8 @@ namespace MonoTests.System.Net
 #endif
 		public void Write_Buffer_Null ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 
@@ -3073,10 +2999,8 @@ namespace MonoTests.System.Net
 #endif
 		public void Write_Count_Negative ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
 			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 
@@ -3104,10 +3028,8 @@ namespace MonoTests.System.Net
 #endif
 		public void Write_Count_Overflow ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 
@@ -3135,10 +3057,8 @@ namespace MonoTests.System.Net
 #endif
 		public void Write_Offset_Negative ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 
@@ -3166,10 +3086,8 @@ namespace MonoTests.System.Net
 #endif
 		public void Write_Offset_Overflow ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 
@@ -3197,10 +3115,8 @@ namespace MonoTests.System.Net
 #endif
 		public void Write_Request_Aborted ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 
@@ -3225,10 +3141,8 @@ namespace MonoTests.System.Net
 		[Category ("NotWorking")]
 		public void Write_Stream_Closed ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 
@@ -3255,10 +3169,8 @@ namespace MonoTests.System.Net
 #endif
 		public void WriteByte_Request_Aborted ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 
@@ -3285,10 +3197,8 @@ namespace MonoTests.System.Net
 #endif
 		public void WriteTimeout ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebRequestTest.EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "POST";
 

--- a/mcs/class/System/Test/System.Net/HttpWebResponseTest.cs
+++ b/mcs/class/System/Test/System.Net/HttpWebResponseTest.cs
@@ -29,10 +29,8 @@ namespace MonoTests.System.Net
 #endif
 		public void CharacterSet_Disposed ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -60,10 +58,8 @@ namespace MonoTests.System.Net
 #endif
 		public void Close_Disposed ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -82,10 +78,8 @@ namespace MonoTests.System.Net
 #endif
 		public void ContentEncoding_Disposed ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -113,10 +107,8 @@ namespace MonoTests.System.Net
 #endif
 		public void ContentLength_Disposed ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -136,10 +128,8 @@ namespace MonoTests.System.Net
 #endif
 		public void ContentType_Disposed ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -167,10 +157,8 @@ namespace MonoTests.System.Net
 #endif
 		public void Cookies_Disposed ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -208,10 +196,8 @@ namespace MonoTests.System.Net
 #endif
 		public void GetResponseHeader_Disposed ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -239,10 +225,8 @@ namespace MonoTests.System.Net
 #endif
 		public void GetResponseStream_Disposed ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -270,10 +254,8 @@ namespace MonoTests.System.Net
 #endif
 		public void Headers_Disposed ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -300,10 +282,8 @@ namespace MonoTests.System.Net
 #endif
 		public void LastModified_Disposed ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -331,10 +311,8 @@ namespace MonoTests.System.Net
 #endif
 		public void Method_Disposed ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -362,10 +340,8 @@ namespace MonoTests.System.Net
 #endif
 		public void ProtocolVersion_Disposed ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -393,10 +369,8 @@ namespace MonoTests.System.Net
 #endif
 		public void ResponseUri_Disposed ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -424,10 +398,8 @@ namespace MonoTests.System.Net
 #endif
 		public void Server_Disposed ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -455,10 +427,8 @@ namespace MonoTests.System.Net
 #endif
 		public void StatusCode_Disposed ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -478,10 +448,8 @@ namespace MonoTests.System.Net
 #endif
 		public void StatusDescription_Disposed ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -556,10 +524,8 @@ namespace MonoTests.System.Net
 #endif
 		public void BeginRead_Buffer_Null ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -608,10 +574,8 @@ namespace MonoTests.System.Net
 #endif
 		public void BeginWrite ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -641,10 +605,8 @@ namespace MonoTests.System.Net
 		[Category ("NotWorking")]
 		public void CanRead ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -671,10 +633,8 @@ namespace MonoTests.System.Net
 #endif
 		public void CanSeek ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -701,10 +661,8 @@ namespace MonoTests.System.Net
 #endif
 		public void CanTimeout ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -731,10 +689,8 @@ namespace MonoTests.System.Net
 #endif
 		public void CanWrite ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -761,10 +717,8 @@ namespace MonoTests.System.Net
 #endif
 		public void Read ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -801,10 +755,8 @@ namespace MonoTests.System.Net
 #endif
 		public void Read_Buffer_Null ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -853,10 +805,8 @@ namespace MonoTests.System.Net
 #endif
 		public void Read_Count_Negative ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -906,10 +856,8 @@ namespace MonoTests.System.Net
 #endif
 		public void Read_Count_Overflow ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -959,10 +907,8 @@ namespace MonoTests.System.Net
 #endif
 		public void Read_Offset_Negative ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -1012,10 +958,8 @@ namespace MonoTests.System.Net
 #endif
 		public void Read_Offset_Overflow ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -1063,10 +1007,8 @@ namespace MonoTests.System.Net
 		[Category ("NotWorking")]
 		public void Read_Stream_Closed ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req;
 				
 				req = (HttpWebRequest) WebRequest.Create (url);
@@ -1129,10 +1071,8 @@ namespace MonoTests.System.Net
 #endif
 		public void ReadTimeout ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -1159,10 +1099,8 @@ namespace MonoTests.System.Net
 #endif
 		public void Write ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -1194,10 +1132,8 @@ namespace MonoTests.System.Net
 #endif
 		public void WriteTimeout ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebResponseTest.FullResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;
@@ -1227,10 +1163,8 @@ namespace MonoTests.System.Net
 #endif
 		public void AutomaticDecompression ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => HttpWebResponseTest.GzipResponseHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => HttpWebResponseTest.GzipResponseHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				HttpWebRequest req = (HttpWebRequest) WebRequest.Create (url);
 				req.Method = "GET";
 				req.Timeout = 2000;

--- a/mcs/class/System/Test/System.Net/WebClientTest.cs
+++ b/mcs/class/System/Test/System.Net/WebClientTest.cs
@@ -1433,10 +1433,8 @@ namespace MonoTests.System.Net
 #endif
 		public void UploadValues1 ()
 		{
-			IPEndPoint ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString () + "/test/";
-
-			using (SocketResponder responder = new SocketResponder (ep, s => EchoRequestHandler (s))) {
+			using (SocketResponder responder = new SocketResponder (out var ep, s => EchoRequestHandler (s))) {
+				string url = "http://" + ep.ToString () + "/test/";
 				WebClient wc = new WebClient ();
 				wc.Encoding = Encoding.ASCII;
 
@@ -1888,13 +1886,9 @@ namespace MonoTests.System.Net
 #endif
 		public void UploadFileAsyncContentType ()
 		{
-			var port = NetworkHelpers.FindFreePort ();
-			var serverUri = "http://localhost:" + port + "/";
 			var filename = Path.GetTempFileName ();
 
-			HttpListener listener = new HttpListener ();
-			listener.Prefixes.Add (serverUri);
-			listener.Start ();
+			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://localhost:", out var port, "/", out var serverUri);
 
 			using (var client = new WebClient ())
 			{
@@ -1910,11 +1904,9 @@ namespace MonoTests.System.Net
 
 		public void UploadAsyncCancelEventTest (int port, Action<WebClient, Uri, EventWaitHandle> uploadAction)
 		{
-			var ep = NetworkHelpers.LocalEphemeralEndPoint ();
-			string url = "http://" + ep.ToString() + "/test/";
-
-			using (var responder = new SocketResponder (ep, s => EchoRequestHandler (s)))
+			using (var responder = new SocketResponder (out var ep, s => EchoRequestHandler (s)))
 			{
+				string url = "http://" + ep.ToString() + "/test/";
 				var webClient = new WebClient ();
 
 				var cancellationTokenSource = new CancellationTokenSource ();

--- a/mcs/class/System/Test/System.Net/WebClientTest.cs
+++ b/mcs/class/System/Test/System.Net/WebClientTest.cs
@@ -1888,7 +1888,7 @@ namespace MonoTests.System.Net
 		{
 			var filename = Path.GetTempFileName ();
 
-			HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://localhost:", out var port, "/", out var serverUri);
+			HttpListener listener = NetworkHelpers.CreateAndStartHttpListener ("http://localhost:", out var port, "/", out var serverUri);
 
 			using (var client = new WebClient ())
 			{

--- a/mcs/class/System/Test/System.Net/WebRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/WebRequestTest.cs
@@ -433,11 +433,7 @@ namespace MonoTests.System.Net {
 #endif
 	public void TestReceiveCancelation ()
 	{
-		var uri = "http://localhost:" + NetworkHelpers.FindFreePort () + "/";
-
-		HttpListener listener = new HttpListener ();
-		listener.Prefixes.Add (uri);
-		listener.Start ();
+		HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://localhost:", out var port, "/", out var uri);
 
 		try {
 			for (var i = 0; i < 10; i++) {

--- a/mcs/class/System/Test/System.Net/WebRequestTest.cs
+++ b/mcs/class/System/Test/System.Net/WebRequestTest.cs
@@ -433,7 +433,7 @@ namespace MonoTests.System.Net {
 #endif
 	public void TestReceiveCancelation ()
 	{
-		HttpListener listener = HttpListener2Test.CreateAndStartListener ("http://localhost:", out var port, "/", out var uri);
+		HttpListener listener = NetworkHelpers.CreateAndStartHttpListener ("http://localhost:", out var port, "/", out var uri);
 
 		try {
 			for (var i = 0; i < 10; i++) {

--- a/mcs/class/test-helpers/NetworkHelpers.cs
+++ b/mcs/class/test-helpers/NetworkHelpers.cs
@@ -44,5 +44,62 @@ namespace MonoTests.Helpers {
 
 			throw new ApplicationException ($"Could not find available local port after {counter} retries");
 		}
+
+		// Bind to the specified address using a system-assigned port.
+		// Returns the assigned port.
+		public static void Bind (this Socket socket, IPAddress address, out int port)
+		{
+			socket.Bind (new IPEndPoint (address, 0));
+			port = ((IPEndPoint) socket.LocalEndPoint).Port;
+		}
+
+
+		// Bind to the specified address using a system-assigned port.
+		// Returns the resulting end local end point.
+		public static void Bind (this Socket socket, IPAddress address, out IPEndPoint ep)
+		{
+			socket.Bind (new IPEndPoint (address, 0));
+			ep = (IPEndPoint) socket.LocalEndPoint;
+		}
+
+		// Creates and starts a TcpListener using a system-assigned port.
+		// Returns the assigned port.
+		public static TcpListener StartTcpListener (out int port)
+		{
+			var rv = new TcpListener (0);
+			rv.Start ();
+			port = ((IPEndPoint) rv.LocalEndpoint).Port;
+			return rv;
+		}
+
+		// Creates and starts a TcpListener using a system-assigned port.
+		// Returns the resulting local end point.
+		public static TcpListener StartTcpListener (out IPEndPoint ep)
+		{
+			var rv = new TcpListener (0);
+			rv.Start ();
+			ep = (IPEndPoint) rv.LocalEndpoint;
+			return rv;
+		}
+
+		// Creates and starts a TcpListener using the specified address and a system-assigned port.
+		// Returns the assigned port.
+		public static TcpListener StartTcpListener (IPAddress address, out int port)
+		{
+			var rv = new TcpListener (address, 0);
+			rv.Start ();
+			port = ((IPEndPoint) rv.LocalEndpoint).Port;
+			return rv;
+		}
+
+		// Creates and starts a TcpListener using the specified address and a system-assigned port.
+		// Returns the resulting local end point.
+		public static TcpListener StartTcpListener (IPAddress address, out IPEndPoint ep)
+		{
+			var rv = new TcpListener (address, 0);
+			rv.Start ();
+			ep = (IPEndPoint) rv.LocalEndpoint;
+			return rv;
+		}
 	}
 }

--- a/mcs/class/test-helpers/NetworkHelpers.cs
+++ b/mcs/class/test-helpers/NetworkHelpers.cs
@@ -101,5 +101,55 @@ namespace MonoTests.Helpers {
 			ep = (IPEndPoint) rv.LocalEndpoint;
 			return rv;
 		}
+
+		public static HttpListener CreateAndStartHttpListener (string host, int port, string path, AuthenticationSchemes? authSchemes = null, Action<HttpListener> initializer = null)
+		{
+			return CreateAndStartHttpListener (host, path, port, authSchemes, initializer);
+		}
+
+		public static HttpListener CreateAndStartHttpListener (string host, string path, int port, AuthenticationSchemes? authSchemes = null, Action<HttpListener> initializer = null)
+		{
+			var prefix = host + port + path;
+			HttpListener listener = new HttpListener ();
+			if (initializer != null)
+				initializer (listener);
+			if (authSchemes.HasValue)
+				listener.AuthenticationSchemes = authSchemes.Value;
+			listener.Prefixes.Add (prefix);
+			listener.Start ();
+			return listener;
+		}
+
+		public static HttpListener CreateAndStartHttpListener (string host, string path, out int port, AuthenticationSchemes? authSchemes = null, Action<HttpListener> initializer = null)
+		{
+			// There's no way to create an HttpListener with a system-assigned port.
+			// So we use NetworkHelpers.FindFreePort, and re-try if we fail because someone else has already used the port.
+			for (int i = 0; i < 10; i++) {
+				try {
+					var tentativePort = NetworkHelpers.FindFreePort ();
+					var listener = CreateAndStartHttpListener (host, path, tentativePort, authSchemes, initializer);
+					port = tentativePort;
+					return listener;
+				} catch (SocketException se) {
+					if (se.SocketErrorCode == SocketError.AddressAlreadyInUse)
+						continue;
+					throw;
+				}
+			}
+			throw new Exception ("Unable to create HttpListener after 10 attempts");
+		}
+
+		public static HttpListener CreateAndStartHttpListener (string host, out int port, string path, AuthenticationSchemes? authSchemes = null, Action<HttpListener> initializer = null)
+		{
+			return CreateAndStartHttpListener (host, path, out port, authSchemes, initializer);
+		}
+
+		public static HttpListener CreateAndStartHttpListener (string host, out int port, string path, out string uri, AuthenticationSchemes? authSchemes = null, Action<HttpListener> initializer = null)
+		{
+			var rv = CreateAndStartHttpListener (host, path, out port, authSchemes, initializer);
+			uri = host + port + path;
+			return rv;
+		}
+
 	}
 }

--- a/mcs/class/test-helpers/NetworkHelpers.cs
+++ b/mcs/class/test-helpers/NetworkHelpers.cs
@@ -64,7 +64,7 @@ namespace MonoTests.Helpers {
 
 		// Creates and starts a TcpListener using a system-assigned port.
 		// Returns the assigned port.
-		public static TcpListener StartTcpListener (out int port)
+		public static TcpListener CreateAndStartTcpListener (out int port)
 		{
 			var rv = new TcpListener (0);
 			rv.Start ();
@@ -74,7 +74,7 @@ namespace MonoTests.Helpers {
 
 		// Creates and starts a TcpListener using a system-assigned port.
 		// Returns the resulting local end point.
-		public static TcpListener StartTcpListener (out IPEndPoint ep)
+		public static TcpListener CreateAndStartTcpListener (out IPEndPoint ep)
 		{
 			var rv = new TcpListener (0);
 			rv.Start ();
@@ -84,7 +84,7 @@ namespace MonoTests.Helpers {
 
 		// Creates and starts a TcpListener using the specified address and a system-assigned port.
 		// Returns the assigned port.
-		public static TcpListener StartTcpListener (IPAddress address, out int port)
+		public static TcpListener CreateAndStartTcpListener (IPAddress address, out int port)
 		{
 			var rv = new TcpListener (address, 0);
 			rv.Start ();
@@ -94,7 +94,7 @@ namespace MonoTests.Helpers {
 
 		// Creates and starts a TcpListener using the specified address and a system-assigned port.
 		// Returns the resulting local end point.
-		public static TcpListener StartTcpListener (IPAddress address, out IPEndPoint ep)
+		public static TcpListener CreateAndStartTcpListener (IPAddress address, out IPEndPoint ep)
 		{
 			var rv = new TcpListener (address, 0);
 			rv.Start ();

--- a/mcs/class/test-helpers/NetworkHelpers.cs
+++ b/mcs/class/test-helpers/NetworkHelpers.cs
@@ -104,11 +104,6 @@ namespace MonoTests.Helpers {
 
 		public static HttpListener CreateAndStartHttpListener (string host, int port, string path, AuthenticationSchemes? authSchemes = null, Action<HttpListener> initializer = null)
 		{
-			return CreateAndStartHttpListener (host, path, port, authSchemes, initializer);
-		}
-
-		public static HttpListener CreateAndStartHttpListener (string host, string path, int port, AuthenticationSchemes? authSchemes = null, Action<HttpListener> initializer = null)
-		{
 			var prefix = host + port + path;
 			HttpListener listener = new HttpListener ();
 			if (initializer != null)
@@ -120,14 +115,14 @@ namespace MonoTests.Helpers {
 			return listener;
 		}
 
-		public static HttpListener CreateAndStartHttpListener (string host, string path, out int port, AuthenticationSchemes? authSchemes = null, Action<HttpListener> initializer = null)
+		public static HttpListener CreateAndStartHttpListener (string host, out int port, string path, AuthenticationSchemes? authSchemes = null, Action<HttpListener> initializer = null)
 		{
 			// There's no way to create an HttpListener with a system-assigned port.
 			// So we use NetworkHelpers.FindFreePort, and re-try if we fail because someone else has already used the port.
 			for (int i = 0; i < 10; i++) {
 				try {
 					var tentativePort = NetworkHelpers.FindFreePort ();
-					var listener = CreateAndStartHttpListener (host, path, tentativePort, authSchemes, initializer);
+					var listener = CreateAndStartHttpListener (host, tentativePort, path, authSchemes, initializer);
 					port = tentativePort;
 					return listener;
 				} catch (SocketException se) {
@@ -139,14 +134,9 @@ namespace MonoTests.Helpers {
 			throw new Exception ("Unable to create HttpListener after 10 attempts");
 		}
 
-		public static HttpListener CreateAndStartHttpListener (string host, out int port, string path, AuthenticationSchemes? authSchemes = null, Action<HttpListener> initializer = null)
-		{
-			return CreateAndStartHttpListener (host, path, out port, authSchemes, initializer);
-		}
-
 		public static HttpListener CreateAndStartHttpListener (string host, out int port, string path, out string uri, AuthenticationSchemes? authSchemes = null, Action<HttpListener> initializer = null)
 		{
-			var rv = CreateAndStartHttpListener (host, path, out port, authSchemes, initializer);
+			var rv = CreateAndStartHttpListener (host, out port, path, authSchemes, initializer);
 			uri = host + port + path;
 			return rv;
 		}

--- a/mcs/class/test-helpers/NetworkHelpers.cs
+++ b/mcs/class/test-helpers/NetworkHelpers.cs
@@ -102,6 +102,12 @@ namespace MonoTests.Helpers {
 			return rv;
 		}
 
+		// Creates and starts an HttpListener using the specified host, port,
+		// path and authSchemes.
+		//
+		// If specified, the initializer will be called immediately after the
+		// HttpListener is created (typical usage would be to set/change
+		// properties before starting the listener)
 		public static HttpListener CreateAndStartHttpListener (string host, int port, string path, AuthenticationSchemes? authSchemes = null, Action<HttpListener> initializer = null)
 		{
 			var prefix = host + port + path;
@@ -115,6 +121,15 @@ namespace MonoTests.Helpers {
 			return listener;
 		}
 
+		// Creates and starts an HttpListener using the specified host, path
+		// and authSchemes. The method will try to find an unused port, and
+		// use that (multiple attempts with random port numbers will be made).
+		//
+		// If specified, the initializer will be called immediately after the
+		// HttpListener is created (typical usage would be to set/change
+		// properties before starting the listener). Be aware that the
+		// initializer can be called multiple times (in case multiple creation
+		// attempts have to be made).
 		public static HttpListener CreateAndStartHttpListener (string host, out int port, string path, AuthenticationSchemes? authSchemes = null, Action<HttpListener> initializer = null)
 		{
 			// There's no way to create an HttpListener with a system-assigned port.
@@ -134,6 +149,17 @@ namespace MonoTests.Helpers {
 			throw new Exception ("Unable to create HttpListener after 10 attempts");
 		}
 
+		// Creates and starts an HttpListener using the specified host, path
+		// and authSchemes. The method will try to find an unused port, and
+		// use that (multiple attempts with random port numbers will be made).
+		//
+		// If specified, the initializer will be called immediately after the
+		// HttpListener is created (typical usage would be to set/change
+		// properties before starting the listener). Be aware that the
+		// initializer can be called multiple times (in case multiple creation
+		// attempts have to be made).
+		//
+		// The resulting uri will also be returned (this is just host + port + path).
 		public static HttpListener CreateAndStartHttpListener (string host, out int port, string path, out string uri, AuthenticationSchemes? authSchemes = null, Action<HttpListener> initializer = null)
 		{
 			var rv = CreateAndStartHttpListener (host, out port, path, authSchemes, initializer);

--- a/mcs/class/test-helpers/SocketResponder.cs
+++ b/mcs/class/test-helpers/SocketResponder.cs
@@ -67,6 +67,14 @@ namespace MonoTests.Helpers
 			listenTask = Task.Run ((Action) Listen);
 		}
 
+		// Starts listening on IPAddress.Loopback on a system-assigned port.
+		// Returns the resulting IPEndPoint (which contains the assigned port).
+		public SocketResponder (out IPEndPoint ep, SocketRequestHandler rh)
+			: this (new IPEndPoint (IPAddress.Loopback, 0), rh)
+		{
+			ep = (IPEndPoint) tcpListener.LocalEndpoint;
+		}
+
 		public void Dispose ()
 		{
 			if (disposed)


### PR DESCRIPTION
Refactor tests to use system-assigned ports whenever possible, so that we
avoid the potential race condition in NetworkHelpers.FindFreePort.

This should make it much less probable to run into spurious "Address already
in use" exceptions.

In some cases I kept the call to NetworkHelpers.FindFreePort:

* When the test is not binding/listening on a port, but instead trying to
  connect to an inexistent port (for tests that verifies error handling /
  exceptions). In this case there is still a race condition (if a test tries
  to verify that a connection fails, it may unexpectedly succeed instead).

* Sometimes the test doesn't actually use the port (the test is verifying
  something very different, for instance a ArgumentNullExceptions, which are
  thrown before the port is used).

* Some API doesn't allow for requesting a system assigned port:

    * HttpListener: in this case I elected to re-try a few times in case of
      "Address already in use" exceptions.

    * The 'UdpClient (string, port)' constructor (other constructors work
      fine): these turned out a bit complicated to work around (or would
      modify the test more than would be reasonable), so for these we still
      have to hope for the best.

Hopefully fixes https://github.com/xamarin/maccore/issues/604.