### PR TITLE
[coop] Separate host and target suspend policies

### DIFF
--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -1706,7 +1706,7 @@ typedef struct EmitGCSafeTransitionBuilder {
 static gboolean
 gc_safe_transition_builder_init (GCSafeTransitionBuilder *builder, MonoMethodBuilder *mb, gboolean func_param)
 {
-	if (mono_threads_is_blocking_transition_enabled ()) {
+	if (mono_threads_target_is_blocking_transition_enabled ()) {
 		builder->mb = mb;
 		builder->func_param = func_param;
 		builder->coop_gc_stack_dummy = -1;
@@ -1912,7 +1912,7 @@ emit_native_wrapper_ilgen (MonoImage *image, MonoMethodBuilder *mb, MonoMethodSi
 		mono_mb_emit_calli (mb, csig);
 	} else if (MONO_CLASS_IS_IMPORT (mb->method->klass)) {
 #ifndef DISABLE_COM
-		if (!mono_threads_is_blocking_transition_enabled ()) {
+		if (!mono_threads_target_is_blocking_transition_enabled ()) {
 			mono_mb_emit_cominterop_call (mb, csig, &piinfo->method);
 		} else {
 			mono_mb_emit_ldloc (mb, gc_safe_transition_builder.coop_cominterop_fnptr);
@@ -4172,7 +4172,7 @@ emit_thunk_invoke_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 	if (!MONO_TYPE_IS_VOID (sig->ret))
 		mono_mb_add_local (mb, sig->ret);
 
-	if (mono_threads_is_blocking_transition_enabled ()) {
+	if (mono_threads_target_is_blocking_transition_enabled ()) {
 		/* local 4, dummy local used to get a stack address for suspend funcs */
 		coop_gc_stack_dummy = mono_mb_add_local (mb, mono_get_int_type ());
 		/* local 5, the local to be used when calling the suspend funcs */
@@ -4184,7 +4184,7 @@ emit_thunk_invoke_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 	mono_mb_emit_byte (mb, CEE_LDNULL);
 	mono_mb_emit_byte (mb, CEE_STIND_REF);
 
-	if (mono_threads_is_blocking_transition_enabled ()) {
+	if (mono_threads_target_is_blocking_transition_enabled ()) {
 		mono_mb_emit_ldloc_addr (mb, coop_gc_stack_dummy);
 		mono_mb_emit_icall (mb, mono_threads_enter_gc_unsafe_region_unbalanced);
 		mono_mb_emit_stloc (mb, coop_gc_var);
@@ -4259,7 +4259,7 @@ emit_thunk_invoke_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 			mono_mb_emit_op (mb, CEE_BOX, mono_class_from_mono_type_internal (sig->ret));
 	}
 
-	if (mono_threads_is_blocking_transition_enabled ()) {
+	if (mono_threads_target_is_blocking_transition_enabled ()) {
 		mono_mb_emit_ldloc (mb, coop_gc_var);
 		mono_mb_emit_ldloc_addr (mb, coop_gc_stack_dummy);
 		mono_mb_emit_icall (mb, mono_threads_exit_gc_unsafe_region_unbalanced);

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -12993,7 +12993,7 @@ mono_compile_assembly (MonoAssembly *ass, guint32 opts, const char *aot_options,
 		acfg->is_full_aot = TRUE;
 	}
 
-	if (mono_threads_are_safepoints_enabled ())
+	if (mono_threads_target_are_safepoints_enabled ())
 		acfg->flags = (MonoAotFileFlags)(acfg->flags | MONO_AOT_FILE_FLAG_SAFEPOINTS);
 
 	// The methods in dedup-emit amodules must be available on runtime startup

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -2436,6 +2436,12 @@ mono_main (int argc, char* argv[])
 		mono_load_coree (argv [i]);
 #endif
 
+#if defined (MONO_CROSS_COMPILE) && defined (TARGET_WATCHOS)
+	/* Always use coop suspend for this target, even if host uses another policy.
+	 */
+	mono_threads_target_set_suspend_policy (MONO_THREADS_SUSPEND_FULL_COOP);
+#endif
+
 	/* Parse gac loading options before loading assemblies. */
 	if (mono_compile_aot || action == DO_EXEC || action == DO_DEBUGGER) {
 		mono_config_parse (config_file);

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1651,7 +1651,7 @@ mono_get_version_info (void)
 #endif
 #endif
 
-	g_string_append_printf (output, "\tSuspend:       %s\n", mono_threads_suspend_policy_name ());
+	g_string_append_printf (output, "\tSuspend:       %s\n", mono_threads_suspend_policy_name (mono_threads_host_suspend_policy ()));
 
 	return g_string_free (output, FALSE);
 }

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -6755,7 +6755,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_GC_SAFE_POINT: {
 			guint8 *br [1];
 
-			g_assert (mono_threads_are_safepoints_enabled ());
+			g_assert (mono_threads_target_are_safepoints_enabled ());
 
 			amd64_test_membase_imm_size (code, ins->sreg1, 0, 1, 4);
 			br[0] = code; x86_branch8 (code, X86_CC_EQ, 0, FALSE);

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -6004,7 +6004,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_GC_SAFE_POINT: {
 			guint8 *buf [1];
 
-			g_assert (mono_threads_are_safepoints_enabled ());
+			g_assert (mono_threads_target_are_safepoints_enabled ());
 
 			ARM_LDR_IMM (code, ARMREG_IP, ins->sreg1, 0);
 			ARM_CMP_REG_IMM (code, ARMREG_IP, 0, 0);

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -4665,7 +4665,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_GC_SAFE_POINT: {
 			guint8 *buf [1];
 
-			g_assert (mono_threads_are_safepoints_enabled ());
+			g_assert (mono_threads_target_are_safepoints_enabled ());
 
 			arm_ldrx (code, ARMREG_IP1, ins->sreg1, 0);
 			/* Call it if it is non-null */

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4631,7 +4631,7 @@ register_icalls (void)
 	register_icall (mono_thread_interruption_checkpoint, "mono_thread_interruption_checkpoint", "object", FALSE);
 	register_icall (mono_thread_force_interruption_checkpoint_noraise, "mono_thread_force_interruption_checkpoint_noraise", "object", FALSE);
 
-	if (mono_threads_are_safepoints_enabled ())
+	if (mono_threads_target_are_safepoints_enabled ())
 		register_icall (mono_threads_state_poll, "mono_threads_state_poll", "void", FALSE);
 
 #ifndef MONO_ARCH_NO_EMULATE_LONG_MUL_OPTS

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -4642,7 +4642,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_GC_SAFE_POINT: {
 			short *br;
 
-			g_assert (mono_threads_are_safepoints_enabled ());
+			g_assert (mono_threads_target_are_safepoints_enabled ());
 
 			s390_ltg (code, s390_r0, 0, ins->sreg1, 0);	
 			s390_jz  (code, 0); CODEPTR(code, br);

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -4833,7 +4833,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_GC_SAFE_POINT: {
 			guint8 *br [1];
 
-			g_assert (mono_threads_are_safepoints_enabled ());
+			g_assert (mono_threads_target_are_safepoints_enabled ());
 
 			x86_test_membase_imm (code, ins->sreg1, 0, 1);
 			br[0] = code; x86_branch8 (code, X86_CC_EQ, 0, FALSE);

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -2851,7 +2851,7 @@ mono_create_gc_safepoint (MonoCompile *cfg, MonoBasicBlock *bblock)
 	if (cfg->verbose_level > 1)
 		printf ("ADDING SAFE POINT TO BB %d\n", bblock->block_num);
 
-	g_assert (mono_threads_are_safepoints_enabled ());
+	g_assert (mono_threads_target_are_safepoints_enabled ());
 	NEW_AOTCONST (cfg, poll_addr, MONO_PATCH_INFO_GC_SAFE_POINT_FLAG, (gpointer)&mono_polling_required);
 
 	MONO_INST_NEW (cfg, ins, OP_GC_SAFE_POINT);
@@ -2897,12 +2897,12 @@ mono_insert_safepoints (MonoCompile *cfg)
 {
 	MonoBasicBlock *bb;
 
-	if (!mono_threads_are_safepoints_enabled ())
+	if (!mono_threads_target_are_safepoints_enabled ())
 		return;
 
 	if (cfg->method->wrapper_type == MONO_WRAPPER_MANAGED_TO_NATIVE) {
 		WrapperInfo *info = mono_marshal_get_wrapper_info (cfg->method);
-		g_assert (mono_threads_are_safepoints_enabled ());
+		g_assert (mono_threads_target_are_safepoints_enabled ());
 		gpointer poll_func = (gpointer)&mono_threads_state_poll;
 
 		if (info && info->subtype == WRAPPER_SUBTYPE_ICALL_WRAPPER && info->d.icall.func == poll_func) {
@@ -3211,7 +3211,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 		cfg->gen_sdb_seq_points = FALSE;
 	}
 	/* coop requires loop detection to happen */
-	if (mono_threads_are_safepoints_enabled ())
+	if (mono_threads_target_are_safepoints_enabled ())
 		cfg->opt |= MONO_OPT_LOOP;
 	if (cfg->backend->explicit_null_checks) {
 		/* some platforms have null pages, so we can't SIGSEGV */

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -439,7 +439,7 @@ mono_native_state_add_version (JsonWriter *writer)
 #endif
 #endif
 
-	const char *susp_policy = mono_threads_suspend_policy_name ();
+	const char *susp_policy = mono_threads_suspend_policy_name (mono_threads_host_suspend_policy ());
 	assert_has_space ();
 	mono_json_writer_indent (writer);
 	mono_json_writer_object_key (writer, "suspend");

--- a/mono/utils/mono-threads-coop.c
+++ b/mono/utils/mono-threads-coop.c
@@ -651,7 +651,7 @@ blocking_transition_getenv_compat (void)
 static gboolean
 blocking_transition_from_policy (MonoThreadsSuspendPolicy p)
 {
-	switch (mono_threads_host_suspend_policy ()) {
+	switch (p) {
 	case MONO_THREADS_SUSPEND_FULL_COOP:
 	case MONO_THREADS_SUSPEND_HYBRID:
 		return TRUE;


### PR DESCRIPTION
Always set target suspend policy to coop when cross-compiling to watchOS.

Target policy affects two places:
- safepoint generation in AOT in mini
- blocking transition insertion in marshal-ilgen

Everything else (primarily metadata) cares about host policy (same as before).

There's one tricky bit:  if `MONO_ENABLE_BLOCKING_TRANSITION` env var is set, it affects both host and target, for backward compatibility.  (although this variable wasn't widely publicized or used in production, afaik).

This addresses #11765 which was caused by mono/monodevelop#6327 where `MONO_THREADS_SUSPEND=preemptive` affected both host policy and the watchOS cross compiler target.  Now the env var is just about the host.