### PR TITLE
[2018-06] [interp] Compile method for errors when needed

### DIFF
--- a/mono/mini/ee.h
+++ b/mono/mini/ee.h
@@ -15,7 +15,7 @@
 #ifndef __MONO_EE_H__
 #define __MONO_EE_H__
 
-#define MONO_EE_API_VERSION 0x4
+#define MONO_EE_API_VERSION 0x5
 
 typedef struct _MonoInterpStackIter MonoInterpStackIter;
 
@@ -28,7 +28,7 @@ typedef gpointer MonoInterpFrameHandle;
 
 struct _MonoEECallbacks {
 	void (*entry_from_trampoline) (gpointer ccontext, gpointer imethod);
-	gpointer (*create_method_pointer) (MonoMethod *method, MonoError *error);
+	gpointer (*create_method_pointer) (MonoMethod *method, gboolean compile, MonoError *error);
 	MonoObject* (*runtime_invoke) (MonoMethod *method, void *obj, void **params, MonoObject **exc, MonoError *error);
 	void (*init_delegate) (MonoDelegate *del);
 	void (*delegate_ctor) (MonoObjectHandle this_obj, MonoObjectHandle target, gpointer addr, MonoError *error);

--- a/mono/mini/interp-stubs.c
+++ b/mono/mini/interp-stubs.c
@@ -107,7 +107,7 @@ stub_frame_iter_next (MonoInterpStackIter *iter, StackFrameInfo *frame)
 }
 
 static gpointer
-stub_create_method_pointer (MonoMethod *method, MonoError *error)
+stub_create_method_pointer (MonoMethod *method, gboolean compile, MonoError *error)
 {
 	g_assert_not_reached ();
 	return NULL;

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -1293,7 +1293,7 @@ interp_delegate_ctor (MonoObjectHandle this_obj, MonoObjectHandle target, gpoint
 	}
 
 	g_assert (imethod->method);
-	gpointer entry = mini_get_interp_callbacks ()->create_method_pointer (imethod->method, error);
+	gpointer entry = mini_get_interp_callbacks ()->create_method_pointer (imethod->method, FALSE, error);
 	return_if_nok (error);
 
 	MONO_HANDLE_SETVAL (MONO_HANDLE_CAST (MonoDelegate, this_obj), interp_method, gpointer, imethod);
@@ -2405,7 +2405,7 @@ interp_no_native_to_managed (void)
  * interpreter. Return NULL for methods which are not supported.
  */
 static gpointer
-interp_create_method_pointer (MonoMethod *method, MonoError *error)
+interp_create_method_pointer (MonoMethod *method, gboolean compile, MonoError *error)
 {
 #ifndef MONO_ARCH_HAVE_INTERP_NATIVE_TO_MANAGED
 	return interp_no_native_to_managed;
@@ -2414,6 +2414,12 @@ interp_create_method_pointer (MonoMethod *method, MonoError *error)
 	MonoDomain *domain = mono_domain_get ();
 	MonoJitDomainInfo *info;
 	InterpMethod *imethod = mono_interp_get_imethod (domain, method, error);
+
+	if (compile) {
+		/* Return any errors from method compilation */
+		mono_interp_transform_method (imethod, (ThreadContext*)mono_native_tls_get_value (thread_context_id), error);
+		return_val_if_nok (error, NULL);
+	}
 
 	/* HACK: method_ptr of delegate should point to a runtime method*/
 	if (method->wrapper_type && (method->wrapper_type == MONO_WRAPPER_DYNAMIC_METHOD ||

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -2262,7 +2262,7 @@ mono_jit_compile_method_with_opt (MonoMethod *method, guint32 opt, gboolean jit_
 		}
 	}
 	if (use_interp) {
-		code = mini_get_interp_callbacks ()->create_method_pointer (method, error);
+		code = mini_get_interp_callbacks ()->create_method_pointer (method, TRUE, error);
 		if (code)
 			return code;
 	}
@@ -2377,7 +2377,7 @@ lookup_start:
 		code = compile_special (method, target_domain, error);
 
 	if (!jit_only && !code && mono_aot_only && mono_use_interpreter && method->wrapper_type != MONO_WRAPPER_UNKNOWN)
-		code = mini_get_interp_callbacks ()->create_method_pointer (method, error);
+		code = mini_get_interp_callbacks ()->create_method_pointer (method, TRUE, error);
 
 	if (!code) {
 		if (mono_class_is_open_constructed_type (m_class_get_byval_arg (method->klass))) {

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -1456,7 +1456,7 @@ mono_create_jump_trampoline (MonoDomain *domain, MonoMethod *method, gboolean ad
 	error_init (error);
 
 	if (mono_use_interpreter && !mono_aot_only) {
-		gpointer ret = mini_get_interp_callbacks ()->create_method_pointer (method, error);
+		gpointer ret = mini_get_interp_callbacks ()->create_method_pointer (method, FALSE, error);
 		if (!mono_error_ok (error))
 			return NULL;
 		return ret;


### PR DESCRIPTION
Partial backport of https://github.com/mono/mono/pull/10095

This change is also needed for the following situation: On a native-to-managed transition the interpreter executes the `NATIVE_TO_MANAGED` wrapper. This wrapper makes sure that the thread is attached. However, doing `transform` requires an attached thread in some cases (e.g. when you run with `--debug`). This commit makes sure that we transform the `InterpMethod` when the thread is attached, that is, when the entry point for the native-to-managed transition is requested.

FYI: This is already in `2018-08` and up.