### PR TITLE
Fix some warnings. Mostly benign but driver.c looks maybe crashy.

### DIFF
--- a/mono/mini/abcremoval.c
+++ b/mono/mini/abcremoval.c
@@ -1058,7 +1058,6 @@ add_non_null (MonoVariableRelationsEvaluationArea *area, MonoCompile *cfg, int r
  */
 static void
 process_block (MonoCompile *cfg, MonoBasicBlock *bb, MonoVariableRelationsEvaluationArea *area) {
-	int inst_index;
 	MonoInst *ins;
 	MonoAdditionalVariableRelationsForBB additional_relations;
 	GSList *dominated_bb, *l;
@@ -1087,7 +1086,6 @@ process_block (MonoCompile *cfg, MonoBasicBlock *bb, MonoVariableRelationsEvalua
 	apply_change_to_evaluation_area (area, &(additional_relations.relation1));
 	apply_change_to_evaluation_area (area, &(additional_relations.relation2));
 
-	inst_index = 0;
 	for (ins = bb->code; ins; ins = ins->next) {
 		MonoAdditionalVariableRelation *rel;
 		int array_var, index_var;

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -6385,12 +6385,11 @@ emit_method_info (MonoAotCompile *acfg, MonoCompile *cfg)
 	int pindex, buf_size, n_patches;
 	GPtrArray *patches;
 	MonoJumpInfo *patch_info;
-	guint32 method_index;
 	guint8 *p, *buf;
 
 	method = cfg->orig_method;
 
-	method_index = get_method_index (acfg, method);
+	(void)get_method_index (acfg, method);
 
 	/* Sort relocations */
 	patches = g_ptr_array_new ();

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -429,7 +429,6 @@ mini_regression_step (MonoImage *image, int verbose, int *total_run, int *total,
 		GTimer *timer, MonoDomain *domain)
 {
 	int result, expected, failed, cfailed, run, code_size;
-	TestMethod func;
 	double elapsed, comp_time, start_time;
 	char *n;
 	int i;
@@ -462,6 +461,7 @@ mini_regression_step (MonoImage *image, int verbose, int *total_run, int *total,
 		}
 		if (method_should_be_regression_tested (method, FALSE)) {
 			MonoCompile *cfg = NULL;
+			TestMethod func = NULL;
 
 			expected = atoi (method->name + 5);
 			run++;

--- a/mono/mini/mini-codegen.c
+++ b/mono/mini/mini-codegen.c
@@ -724,7 +724,7 @@ mono_print_ins_index_strbuf (int i, MonoInst *ins)
 	case OP_COND_EXC_INO:
 	case OP_COND_EXC_IC:
 	case OP_COND_EXC_INC:
-		g_string_append_printf (sbuf, " %s", ins->inst_p1);
+		g_string_append_printf (sbuf, " %s", (const char*)ins->inst_p1);
 		break;
 	default:
 		break;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1553,7 +1553,6 @@ summarize_frame_managed_walk (MonoMethod *method, gpointer ip, size_t frame_nati
 static gboolean
 summarize_frame (StackFrameInfo *frame, MonoContext *ctx, gpointer data)
 {
-	MonoSummarizeUserData *ud = (MonoSummarizeUserData *) data;
 	// Don't record trampolines between managed frames
 	if (frame->ji && frame->ji->is_trampoline)
 		return TRUE;


### PR DESCRIPTION
abcremoval.c: In function 'process_block':
abcremoval.c:1061:6: warning: variable 'inst_index' set but not used [-Wunused-but-set-variable]
  int inst_index;
      ^

driver.c: In function 'mini_regression_step':
driver.c:514:12: warning: 'func' may be used uninitialized in this function [-Wmaybe-uninitialized]
     result = func ();
            ^

aot-compiler.c: In function 'emit_method_info':
aot-compiler.c:6388:10: warning: variable 'method_index' set but not used [-Wunused-but-set-variable]
  guint32 method_index;
          ^

mini-codegen.c: In function 'mono_print_ins_index_strbuf':
mini-codegen.c:727:3: warning: format '%s' expects argument of type 'char *', but argument 3 has type 'gpointer' [-Wformat=]
   g_string_append_printf (sbuf, " %s", ins->inst_p1);
   ^
  CC       libmini_la-mini-exceptions.lo
mini-exceptions.c: In function 'summarize_frame':
mini-exceptions.c:1556:25: warning: unused variable 'ud' [-Wunused-variable]
  MonoSummarizeUserData *ud = (MonoSummarizeUserData *) data;

Probably from:
https://jenkins.mono-project.com/job/build-package-dpkg-mono-pullrequest/label=ubuntu-1404-amd64/326/console