### PR TITLE
[driver] Parse config file under --regression mode also

### DIFF
--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -2437,7 +2437,7 @@ mono_main (int argc, char* argv[])
 #endif
 
 	/* Parse gac loading options before loading assemblies. */
-	if (mono_compile_aot || action == DO_EXEC || action == DO_DEBUGGER) {
+	if (mono_compile_aot || action == DO_EXEC || action == DO_DEBUGGER || action == DO_REGRESSION) {
 		mono_config_parse (config_file);
 	}
 


### PR DESCRIPTION
As of https://github.com/mono/mono/pull/11342 the regression tests (builtin-types.cs) call into System.Native incidentally as part of Interop.Sys type initialization. The --regression command line option was causing the --config part of the mono invocation to be ignored, resulting in a buried 'System.DllNotFoundException: System.Native' during the test run

/cc @baulig