### PR TITLE
[bcl] add fullaotinterp_llvm preset

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1094,7 +1094,7 @@ AC_ARG_WITH(unreal,              [  --with-unreal=yes,no                If you w
 AC_ARG_WITH(wasm,                [  --with-wasm=yes,no                  If you want to build the WebAssembly (defaults to no)], [], [with_wasm=default])
 
 
-AC_ARG_WITH(runtime-preset, [  --with-runtime-preset=net_4_x,all,aot,aot_llvm,hybridaot,hybridaot_llvm,fullaot,fullaot_llvm,bitcode,unreal,fullaotinterp  Which default profile to build (defaults to net_4_x)],  [], [with_runtime_preset=net_4_x])
+AC_ARG_WITH(runtime-preset, [  --with-runtime-preset=net_4_x,all,aot,aot_llvm,hybridaot,hybridaot_llvm,fullaot,fullaot_llvm,bitcode,unreal,fullaotinterp,fullaotinterp_llvm  Which default profile to build (defaults to net_4_x)],  [], [with_runtime_preset=net_4_x])
 AC_ARG_WITH(spectre-mitigation,             [  --with-spectre-mitigation=yes,no   If you want to build the runtime with compiler flags that enable Spectre mitigation (defaults to no)], [], [with_spectre_mitigation=default])
 AC_ARG_WITH(spectre-indirect-branch-choice,   [  --with-spectre-indirect-branch-choice=keep,thunk,inline,extern   Convert indirect branches to the specified kind of thunk (defaults to inline)], [], [with_spectre_indirect_branch_choice=inline])
 AC_ARG_WITH(spectre-function-return-choice, [  --with-spectre-function-return-choice=keep,thunk,inline,extern   Convert function return instructions to the specified kind of thunk (defaults to inline)], [], [with_spectre_function_return_choice=inline])
@@ -1258,6 +1258,15 @@ elif test x$with_runtime_preset = xfullaotinterp; then
 
    AOT_BUILD_FLAGS="--aot=full,interp,$INVARIANT_AOT_OPTIONS"
    AOT_RUN_FLAGS="--full-aot-interp"
+elif test x$with_runtime_preset = xfullaotinterp_llvm; then
+   with_testing_aot_full_interp_default=yes
+   TEST_PROFILE=testing_aot_full_interp_llvm
+
+   # mscorlib.dll aot compilation crashes
+   mono_feature_disable_com='yes'
+
+   AOT_BUILD_FLAGS="-O=gsharedvt --llvm --aot=full,interp,$INVARIANT_AOT_OPTIONS"
+   AOT_RUN_FLAGS="--full-aot-interp"
 elif test x$with_runtime_preset = xaot; then
    with_profile4_x_default=yes
 
@@ -1399,6 +1408,7 @@ AM_CONDITIONAL(INSTALL_WASM, [test "x$with_wasm" != "xno"])
 AM_CONDITIONAL(FULL_AOT_TESTS, [test "x$TEST_PROFILE" = "xtesting_aot_full"] || [test "x$TEST_PROFILE" = "xwinaot"] || [test "x$TEST_PROFILE" = "xorbis"] || [test "x$TEST_PROFILE" = "xwasm"])
 AM_CONDITIONAL(HYBRID_AOT_TESTS, [test "x$TEST_PROFILE" = "xtesting_aot_hybrid"] || [test "x$TEST_PROFILE" = "xunreal"])
 AM_CONDITIONAL(AOT_FULL_INTERP_TESTS, [test "x$TEST_PROFILE" = "xtesting_aot_full_interp"])
+AM_CONDITIONAL(AOT_FULL_INTERP_LLVM_TESTS, [test "x$TEST_PROFILE" = "xtesting_aot_full_interp_llvm"])
 AM_CONDITIONAL(DEFAULT_TESTS, [test "x$TEST_PROFILE" = "xnet_4_x"])
 
 default_profile=net_4_x

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -207,6 +207,10 @@ if AOT_FULL_INTERP_TESTS
 PROFILE_MCS_FLAGS = -d:MOBILE,MOBILE_LEGACY
 endif
 
+if AOT_FULL_INTERP_LLVM_TESTS
+PROFILE_MCS_FLAGS = -d:MOBILE,MOBILE_LEGACY
+endif
+
 MCS_NO_UNSAFE = $(TOOLS_RUNTIME) $(CSC) -debug:portable \
 	-noconfig -nologo \
 	-nowarn:0162 -nowarn:0168 -nowarn:0219 -nowarn:0414 -nowarn:0618 \
@@ -1568,6 +1572,66 @@ PROFILE_DISABLED_TESTS += \
 	transparentproxy.exe
 endif
 
+if AOT_FULL_INTERP_LLVM_TESTS
+# AppDomain tests
+PROFILE_DISABLED_TESTS += \
+	appdomain1.exe \
+	appdomain2.exe \
+	appdomain-async-invoke.exe \
+	appdomain.exe \
+	appdomain-exit.exe \
+	appdomain-loader.exe \
+	appdomain-marshalbyref-assemblyload.exe \
+	appdomain-serialize-exception.exe \
+	appdomain-thread-abort.exe \
+	appdomain-threadpool-unload.exe \
+	appdomain-unload-asmload.exe \
+	appdomain-unload-callback.exe \
+	appdomain-unload-doesnot-raise-pending-events.exe \
+	appdomain-unload.exe \
+	assemblyresolve_event6.exe \
+	bug-335131.2.exe \
+	bug-415577.exe \
+	cross-domain.exe \
+	dataslot.exe \
+	delegate9.exe \
+	domain-stress.exe \
+	generic-marshalbyref.2.exe \
+	generic-unloading.2.exe \
+	generic-xdomain.2.exe \
+	hostname.exe \
+	marshal-valuetypes.exe \
+	monitor.exe \
+	pinvoke3.exe \
+	remoting4.exe \
+	stackframes-async.2.exe \
+	suspend-stress-test.exe \
+	thread6.exe \
+	threadpool-exceptions7.exe \
+	unhandled-exception-7.exe \
+	unhandled-exception-test-case.2.exe \
+	unload-appdomain-on-shutdown.exe \
+	xdomain-threads.exe
+
+# Tests which load assemblies which are not in the profile
+PROFILE_DISABLED_TESTS += \
+	assembly-load-remap.exe
+
+# Tests which needs named Mutex support
+PROFILE_DISABLED_TESTS += \
+	namedmutex-destroy-race.exe
+
+# Test which needs System.Web support
+PROFILE_DISABLED_TESTS += \
+	bug-80307.exe
+
+PROFILE_DISABLED_TESTS += \
+	bug-70561.exe \
+	transparentproxy.exe \
+	finalizer-exception.exe
+
+endif
+
 AOT_DISABLED_TESTS= \
 	constraints-load.exe \
 	calli_sig_check.exe
@@ -1957,7 +2021,9 @@ tailcall/coreclr/JIT/opt/Tailcall/TailcallVerifyWithPrefix.exe: \
 if !FULL_AOT_TESTS
 if !HYBRID_AOT_TESTS
 if !AOT_FULL_INTERP_TESTS
+if !AOT_FULL_INTERP_LLVM_TESTS
 TEST_DRIVER_HARD_KILL_FEATURE=-r:$(CLASS)/Mono.Posix.dll
+endif
 endif
 endif
 endif

--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -69,6 +69,7 @@ if   [[ ${CI_TAGS} == *'fullaot_llvm'* ]];       then EXTRA_CONF_FLAGS="${EXTRA_
 elif [[ ${CI_TAGS} == *'hybridaot_llvm'* ]];     then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --enable-llvm=yes --with-runtime-preset=hybridaot_llvm";
 elif [[ ${CI_TAGS} == *'aot_llvm'* ]];           then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --enable-llvm=yes --with-runtime-preset=aot_llvm ";
 elif [[ ${CI_TAGS} == *'jit_llvm'* ]];           then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --enable-llvm=yes"; export MONO_ENV_OPTIONS="$MONO_ENV_OPTIONS --llvm";
+elif [[ ${CI_TAGS} == *'fullaotinterp_llvm'* ]]; then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --enable-llvm=yes --with-runtime-preset=fullaotinterp_llvm";
 elif [[ ${CI_TAGS} == *'fullaotinterp'* ]];      then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-runtime-preset=fullaotinterp";
 elif [[ ${CI_TAGS} == *'fullaot'* ]];            then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-runtime-preset=fullaot";
 elif [[ ${CI_TAGS} == *'hybridaot'* ]];          then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-runtime-preset=hybridaot";

--- a/scripts/ci/run-test-testing_aot_full_interp_llvm.sh
+++ b/scripts/ci/run-test-testing_aot_full_interp_llvm.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -e
+
+${TESTCMD} --label=runtime --timeout=160m make -w -C mono/tests -k testfullaotinterp V=1
+
+# FIXME
+#${TESTCMD} --label=corlib --timeout=30m make -w -C mcs/class/corlib run-test
+#${TESTCMD} --label=profiler --timeout=30m make -w -C mono/profiler -k check
+#${TESTCMD} --label=System --timeout=10m make -w -C mcs/class/System run-test
+${TESTCMD} --label=System.XML --timeout=5m make -w -C mcs/class/System.XML run-test
+${TESTCMD} --label=Mono.Security --timeout=5m make -w -C mcs/class/Mono.Security run-test
+${TESTCMD} --label=System.Data --timeout=5m make -w -C mcs/class/System.Data run-test
+#${TESTCMD} --label=System.Web.Services --timeout=5m make -w -C mcs/class/System.Web.Services run-test
+#${TESTCMD} --label=I18N.CJK --timeout=5m make -w -C mcs/class/I18N/CJK run-test
+#${TESTCMD} --label=I18N.West --timeout=5m make -w -C mcs/class/I18N/West run-test
+#${TESTCMD} --label=I18N.MidEast --timeout=5m make -w -C mcs/class/I18N/MidEast run-test
+#${TESTCMD} --label=I18N.Rare --timeout=5m make -w -C mcs/class/I18N/Rare run-test
+#${TESTCMD} --label=I18N.Other --timeout=5m make -w -C mcs/class/I18N/Other run-test
+#${TESTCMD} --label=System.Transactions --timeout=5m make -w -C mcs/class/System.Transactions run-test
+${TESTCMD} --label=System.Core --timeout=15m make -w -C mcs/class/System.Core run-test
+${TESTCMD} --label=System.Xml.Linq --timeout=5m make -w -C mcs/class/System.Xml.Linq run-test
+${TESTCMD} --label=System.Runtime.Serialization --timeout=5m make -w -C mcs/class/System.Runtime.Serialization run-test
+${TESTCMD} --label=System.ServiceModel --timeout=15m make -w -C mcs/class/System.ServiceModel run-test
+${TESTCMD} --label=System.ServiceModel.Web --timeout=5m make -w -C mcs/class/System.ServiceModel.Web run-test
+${TESTCMD} --label=System.ComponentModel.DataAnnotations --timeout=5m make -w -C mcs/class/System.ComponentModel.DataAnnotations run-test
+${TESTCMD} --label=Mono.CSharp --timeout=5m make -w -C mcs/class/Mono.CSharp run-test
+${TESTCMD} --label=System.Numerics --timeout=5m make -w -C mcs/class/System.Numerics run-test
+${TESTCMD} --label=System.Net.Http --timeout=5m make -w -C mcs/class/System.Net.Http run-test
+${TESTCMD} --label=System.Json --timeout=5m make -w -C mcs/class/System.Json run-test
+
+${MONO_REPO_ROOT}/scripts/ci/run-upload-sentry.sh

--- a/scripts/ci/run-test-testing_aot_full_interp_llvm.sh
+++ b/scripts/ci/run-test-testing_aot_full_interp_llvm.sh
@@ -3,7 +3,7 @@
 ${TESTCMD} --label=runtime --timeout=160m make -w -C mono/tests -k testfullaotinterp V=1
 
 # FIXME
-#${TESTCMD} --label=corlib --timeout=30m make -w -C mcs/class/corlib run-test
+${TESTCMD} --label=corlib --timeout=30m make -w -C mcs/class/corlib run-test
 #${TESTCMD} --label=profiler --timeout=30m make -w -C mono/profiler -k check
 #${TESTCMD} --label=System --timeout=10m make -w -C mcs/class/System run-test
 ${TESTCMD} --label=System.XML --timeout=5m make -w -C mcs/class/System.XML run-test


### PR DESCRIPTION
That is, the AOT compiler uses the LLVM backend for BCL. AOT+LLVM is
used in the 'Release' configuration on Xamarin.iOS.

