### PR TITLE
[Mono.Debugger.Soft] Make exposing Cecil metadata an option

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Makefile
+++ b/mcs/class/Mono.Debugger.Soft/Makefile
@@ -5,7 +5,7 @@ LIBRARY = Mono.Debugger.Soft.dll
 LIBRARY_SNK = ../mono.snk
 
 LIB_REFS = System Mono.Cecil System.Core
-LIB_MCS_FLAGS = /unsafe -D:MONO_DATACONVERTER_STATIC_METHODS /publicsign
+LIB_MCS_FLAGS = /unsafe -D:MONO_DATACONVERTER_STATIC_METHODS -D:ENABLE_CECIL /publicsign
 KEYFILE = $(LIBRARY_SNK)
 
 TEST_LIB_REFS = Mono.Cecil System System.Core

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft.csproj
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft.csproj
@@ -29,7 +29,7 @@
   <PropertyGroup Condition=" '$(Platform)' == 'net_4_x' ">
     <OutputPath>./../../class/lib/net_4_x-$(HostPlatform)</OutputPath>
     <IntermediateOutputPath>./../../class/obj/$(AssemblyName)-net_4_x-$(HostPlatform)</IntermediateOutputPath>
-    <DefineConstants>NET_4_0;NET_4_5;NET_4_6;MONO;WIN_PLATFORM;MONO_DATACONVERTER_STATIC_METHODS</DefineConstants>
+    <DefineConstants>NET_4_0;NET_4_5;NET_4_6;MONO;WIN_PLATFORM;MONO_DATACONVERTER_STATIC_METHODS;ENABLE_CECIL</DefineConstants>
   </PropertyGroup>
   <!-- @ALL_PROFILE_PROPERTIES@ -->
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/AssemblyMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/AssemblyMirror.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Reflection;
 using Mono.Debugger;
-using Mono.Cecil;
 using System.Collections.Generic;
 using System.IO;
+
+#if ENABLE_CECIL
+using Mono.Cecil;
+#endif
 
 namespace Mono.Debugger.Soft
 {
@@ -14,7 +17,6 @@ namespace Mono.Debugger.Soft
 		bool entry_point_set;
 		ModuleMirror main_module;
 		AssemblyName aname;
-		AssemblyDefinition meta;
 		AppDomainMirror domain;
 		byte[] metadata_blob;
 		bool? isDynamic;
@@ -23,6 +25,10 @@ namespace Mono.Debugger.Soft
 		Dictionary<string, long> typeCache = new Dictionary<string, long> ();
 		Dictionary<uint, long> tokenTypeCache = new Dictionary<uint, long> ();
 		Dictionary<uint, long> tokenMethodCache = new Dictionary<uint, long> ();
+
+#if ENABLE_CECIL
+		AssemblyDefinition meta;
+#endif
 
 		internal AssemblyMirror (VirtualMachine vm, long id) : base (vm, id) {
 		}
@@ -118,6 +124,7 @@ namespace Mono.Debugger.Soft
 			return GetType (name, false, false);
 		}
 
+#if ENABLE_CECIL
 		/* 
 		 * An optional Cecil assembly which could be used to access metadata instead
 		 * of reading it from the debuggee.
@@ -146,6 +153,7 @@ namespace Mono.Debugger.Soft
 			using (var ms = new MemoryStream (GetMetadataBlob ()))
 				return meta = AssemblyDefinition.ReadAssembly (ms);
 		}
+#endif
 
 		public byte[] GetMetadataBlob () {
 			if (metadata_blob != null)

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Collections.Generic;
 using System.Text;
 using System.Diagnostics;
-using Mono.Cecil.Metadata;
 
 namespace Mono.Debugger.Soft
 {

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/CustomAttributeDataMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/CustomAttributeDataMirror.cs
@@ -4,7 +4,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Reflection;
 using System.Text;
-using Mono.Cecil.Metadata;
 
 namespace Mono.Debugger.Soft {
 

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/FieldInfoMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/FieldInfoMirror.cs
@@ -2,8 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Reflection;
+
+#if ENABLE_CECIL
 using C = Mono.Cecil;
-using Mono.Cecil.Metadata;
+#endif
 
 namespace Mono.Debugger.Soft
 {
@@ -14,8 +16,11 @@ namespace Mono.Debugger.Soft
 		TypeMirror type;
 		FieldAttributes attrs;
 		CustomAttributeDataMirror[] cattrs;
-		C.FieldDefinition meta;
 		bool inited;
+
+#if ENABLE_CECIL
+		C.FieldDefinition meta;
+#endif
 
 		public FieldInfoMirror (TypeMirror parent, long id, string name, TypeMirror type, FieldAttributes attrs) : base (parent.VirtualMachine, id) {
 			this.parent = parent;
@@ -167,6 +172,7 @@ namespace Mono.Debugger.Soft
 			return GetCAttrs (attributeType, inherit);
 		}
 
+#if ENABLE_CECIL
 		public C.FieldDefinition Metadata {		
 			get {
 				if (parent.Metadata == null)
@@ -184,10 +190,14 @@ namespace Mono.Debugger.Soft
 				return meta;
 			}
 		}
+#endif
 
 		CustomAttributeDataMirror[] GetCAttrs (TypeMirror type, bool inherit) {
+
+#if ENABLE_CECIL
 			if (cattrs == null && Metadata != null && !Metadata.HasCustomAttributes)
 				cattrs = new CustomAttributeDataMirror [0];
+#endif
 
 			// FIXME: Handle inherit
 			if (cattrs == null) {

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ILInstruction.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ILInstruction.cs
@@ -1,10 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using Mono.Cecil.Cil;
-using Mono.Cecil.Metadata;
 using System.IO;
 using System.Reflection;
+
+#if ENABLE_CECIL
+using Mono.Cecil.Cil;
+#else
+using System.Reflection.Emit;
+#endif
 
 namespace Mono.Debugger.Soft
 {

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ILInterpreter.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ILInterpreter.cs
@@ -1,6 +1,10 @@
 using System;
+
+#if ENABLE_CECIL
 using Mono.Cecil.Cil;
-using Mono.Cecil.Metadata;
+#else
+using System.Reflection.Emit;
+#endif
 
 namespace Mono.Debugger.Soft
 {

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/InterfaceMappingMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/InterfaceMappingMirror.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using C = Mono.Cecil;
-using Mono.Cecil.Metadata;
 
 namespace Mono.Debugger.Soft
 {

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/MethodBodyMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/MethodBodyMirror.cs
@@ -2,11 +2,15 @@ using System;
 using System.Globalization;
 using System.Collections.Generic;
 using System.Text;
-using Mono.Cecil.Cil;
-using Mono.Cecil.Metadata;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+
+#if ENABLE_CECIL
+using Mono.Cecil.Cil;
+#else
+using System.Reflection.Emit;
+#endif
 
 namespace Mono.Debugger.Soft
 {
@@ -84,11 +88,21 @@ namespace Mono.Debugger.Soft
 			if (!opcodes_inited) {
 				foreach (FieldInfo fi in typeof (OpCodes).GetFields (BindingFlags.Static|BindingFlags.Public)) {
 					var val = (OpCode)fi.GetValue (null);
+					bool isOneByteOpCode;
+					uint index;
 
-					if (val.Op1 == 0xff)
-						OneByteOpCode [val.Op2] = val;
+#if ENABLE_CECIL
+					isOneByteOpCode = val.Op1 == 0xff;
+					index = val.Op2;
+#else
+					uint value = (uint)val.Value;
+					isOneByteOpCode = value <= 0xff;
+					index = isOneByteOpCode ? value : value & 0xff;
+#endif
+					if (isOneByteOpCode)
+						OneByteOpCode [index] = val;
 					else
-						TwoBytesOpCode [val.Op2] = val;
+						TwoBytesOpCode [index] = val;
 				}
 				opcodes_inited = true;
 			}
@@ -139,9 +153,11 @@ namespace Mono.Debugger.Soft
 				case OperandType.ShortInlineVar :
 					instr.Operand = br.ReadByte ();
 					break;
+#if ENABLE_CECIL
 				case OperandType.ShortInlineArg :
 					instr.Operand = br.ReadByte ();
 					break;
+#endif
 				case OperandType.InlineSig :
 					br.ReadInt32 ();
 					//instr.Operand = GetCallSiteAt (br.ReadInt32 (), context);
@@ -152,9 +168,11 @@ namespace Mono.Debugger.Soft
 				case OperandType.InlineVar :
 					instr.Operand = br.ReadInt16 ();
 					break;
+#if ENABLE_CECIL
 				case OperandType.InlineArg :
 					instr.Operand = br.ReadInt16 ();
 					break;
+#endif
 				case OperandType.InlineI8 :
 					instr.Operand = br.ReadInt64 ();
 					break;

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/MethodMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/MethodMirror.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Reflection;
+
+#if ENABLE_CECIL
 using C = Mono.Cecil;
-using Mono.Cecil.Metadata;
+#endif
 
 namespace Mono.Debugger.Soft
 {
@@ -14,7 +16,6 @@ namespace Mono.Debugger.Soft
 		MethodInfo info;
 		TypeMirror declaring_type;
 		DebugInfo debug_info;
-		C.MethodDefinition meta;
 		CustomAttributeDataMirror[] cattrs;
 		ParameterInfoMirror[] param_info;
 		ParameterInfoMirror ret_param;
@@ -24,6 +25,10 @@ namespace Mono.Debugger.Soft
 		MethodBodyMirror body;
 		MethodMirror gmd;
 		TypeMirror[] type_args;
+
+#if ENABLE_CECIL
+		C.MethodDefinition meta;
+#endif
 
 		internal MethodMirror (VirtualMachine vm, long id) : base (vm, id) {
 		}
@@ -93,8 +98,10 @@ namespace Mono.Debugger.Soft
 		}
 
 		CustomAttributeDataMirror[] GetCAttrs (TypeMirror type, bool inherit) {
+#if ENABLE_CECIL
 			if (cattrs == null && meta != null && !Metadata.HasCustomAttributes)
 				cattrs = new CustomAttributeDataMirror [0];
+#endif
 
 			// FIXME: Handle inherit
 			if (cattrs == null) {
@@ -417,6 +424,7 @@ namespace Mono.Debugger.Soft
 			return null;
 		}
 
+#if ENABLE_CECIL
 		public C.MethodDefinition Metadata {
 			get {
 				if (meta == null)
@@ -424,6 +432,7 @@ namespace Mono.Debugger.Soft
 				return meta;
 			}
 		}
+#endif
 
 		//
 		// Evaluate the method on the client using an IL interpreter.

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ModuleMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/ModuleMirror.cs
@@ -1,6 +1,5 @@
 using System;
 using Mono.Debugger;
-using Mono.Cecil;
 
 namespace Mono.Debugger.Soft
 {

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/PropertyInfoMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/PropertyInfoMirror.cs
@@ -2,8 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Reflection;
+
+#if ENABLE_CECIL
 using C = Mono.Cecil;
-using Mono.Cecil.Metadata;
+#endif
 
 namespace Mono.Debugger.Soft
 {
@@ -14,7 +16,10 @@ namespace Mono.Debugger.Soft
 		PropertyAttributes attrs;
 		MethodMirror get_method, set_method;
 		CustomAttributeDataMirror[] cattrs;
+
+#if ENABLE_CECIL
 		C.PropertyDefinition meta;
+#endif
 
 		public PropertyInfoMirror (TypeMirror parent, long id, string name, MethodMirror get_method, MethodMirror set_method, PropertyAttributes attrs) : base (parent.VirtualMachine, id) {
 			this.parent = parent;
@@ -91,6 +96,7 @@ namespace Mono.Debugger.Soft
 			return new ParameterInfoMirror [0];
 		}
 
+#if ENABLE_CECIL
 		public C.PropertyDefinition Metadata {		
 			get {
 				if (parent.Metadata == null)
@@ -108,6 +114,7 @@ namespace Mono.Debugger.Soft
 				return meta;
 			}
 		}
+#endif
 
 		public CustomAttributeDataMirror[] GetCustomAttributes (bool inherit) {
 			return GetCAttrs (null, inherit);
@@ -120,8 +127,11 @@ namespace Mono.Debugger.Soft
 		}
 
 		CustomAttributeDataMirror[] GetCAttrs (TypeMirror type, bool inherit) {
+
+#if ENABLE_CECIL
 			if (cattrs == null && Metadata != null && !Metadata.HasCustomAttributes)
 				cattrs = new CustomAttributeDataMirror [0];
+#endif
 
 			// FIXME: Handle inherit
 			if (cattrs == null) {

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/TypeMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/TypeMirror.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using C = Mono.Cecil;
-using Mono.Cecil.Metadata;
 using System.Threading.Tasks;
+
+#if ENABLE_CECIL
+using C = Mono.Cecil;
+#endif
 
 namespace Mono.Debugger.Soft
 {
@@ -17,7 +19,6 @@ namespace Mono.Debugger.Soft
 		MethodMirror[] methods;
 		AssemblyMirror ass;
 		ModuleMirror module;
-		C.TypeDefinition meta;
 		FieldInfoMirror[] fields;
 		PropertyInfoMirror[] properties;
 		TypeInfo info;
@@ -29,6 +30,10 @@ namespace Mono.Debugger.Soft
 		TypeMirror[] type_args;
 		bool cached_base_type;
 		bool inited;
+
+#if ENABLE_CECIL
+		C.TypeDefinition meta;
+#endif
 
 		internal const BindingFlags DefaultBindingFlags =
 		BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance;
@@ -613,6 +618,7 @@ namespace Mono.Debugger.Soft
 			return res;
 		}
 
+#if ENABLE_CECIL
 		public C.TypeDefinition Metadata {
 			get {
 				if (meta == null) {
@@ -623,6 +629,7 @@ namespace Mono.Debugger.Soft
 				return meta;
 			}
 		}
+#endif
 
 		TypeInfo GetInfo () {
 			if (info == null)
@@ -705,8 +712,10 @@ namespace Mono.Debugger.Soft
 
 		void AppendCustomAttrs (IList<CustomAttributeDataMirror> attrs, TypeMirror type, bool inherit)
 		{
+#if ENABLE_CECIL
 			if (cattrs == null && Metadata != null && !Metadata.HasCustomAttributes)
 				cattrs = new CustomAttributeDataMirror [0];
+#endif
 
 			if (cattrs == null) {
 				CattrInfo[] info = vm.conn.Type_GetCustomAttributes (id, 0, false);

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
@@ -5,7 +5,6 @@ using System.Net;
 using System.Diagnostics;
 using System.Collections;
 using System.Collections.Generic;
-using Mono.Cecil.Metadata;
 
 namespace Mono.Debugger.Soft
 {


### PR DESCRIPTION
Not all downstream users of the Mono.Debugger.Soft library are using the feature where mirrors provide direct access to the Cecil metadata if the `AssemblyMirror` has been fed a Cecil `AssemblyDefinition`.

This PR introduces a define to opt-in to use the Cecil metadata, otherwise falls back to exposing System.Reflection.Emit opcodes in the Instruction API.