### PR TITLE
Fix warnings and a C++ error.

### DIFF
--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -7726,10 +7726,6 @@ emit_method_inner (EmitContext *ctx)
 	}
 
 	if (cfg->llvm_only) {
-		GHashTableIter iter;
-		MonoMethod *method;
-		GSList *callers, *l, *l2;
-
 		g_ptr_array_add (ctx->module->cfgs, cfg);
 
 		/*
@@ -9003,9 +8999,7 @@ void
 mono_llvm_fixup_aot_module (void)
 {
 	MonoLLVMModule *module = &aot_module;
-	GHashTableIter iter;
 	MonoMethod *method;
-	GSList *callers, *l;
 
 	if (!module->llvm_only)
 		return;
@@ -9019,7 +9013,7 @@ mono_llvm_fixup_aot_module (void)
 
 	GHashTable *patches_to_null = g_hash_table_new (mono_patch_info_hash, mono_patch_info_equal);
 	for (int sindex = 0; sindex < module->callsite_list->len; ++sindex) {
-		CallSite *site = g_ptr_array_index (module->callsite_list, sindex);
+		CallSite *site = (CallSite*)g_ptr_array_index (module->callsite_list, sindex);
 		method = site->method;
 		LLVMValueRef lmethod = (LLVMValueRef)g_hash_table_lookup (module->method_to_lmethod, method);
 


### PR DESCRIPTION
mono/master 32beba680eda59a95894713388116cf904eaf453 with no local edits

 With C++ accidentally enabled.
 make -C sdks/builds build-ios-cross32 build-android-cross-arm build-android-cross-x86
```
/s/mono/mono/mini/mini-llvm.c:7729:18: warning: unused variable 'iter' [-Wunused-variable]
                GHashTableIter iter;
                               ^
/s/mono/mono/mini/mini-llvm.c:7730:15: warning: unused variable 'method' [-Wunused-variable]
                MonoMethod *method;
                            ^
/s/mono/mono/mini/mini-llvm.c:7731:11: warning: unused variable 'callers' [-Wunused-variable]
                GSList *callers, *l, *l2;
                        ^
/s/mono/mono/mini/mini-llvm.c:7731:21: warning: unused variable 'l' [-Wunused-variable]
                GSList *callers, *l, *l2;
                                  ^
/s/mono/mono/mini/mini-llvm.c:7731:25: warning: unused variable 'l2' [-Wunused-variable]
                GSList *callers, *l, *l2;
                                      ^
/s/mono/mono/mini/mini-llvm.c:9022:13: error: cannot initialize a variable of type 'CallSite *' with an lvalue of type 'gpointer' (aka 'void *')
                CallSite *site = g_ptr_array_index (module->callsite_list, sindex);
                          ^      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

/s/mono/mono/mini/mini-llvm.c:9002:17: warning: unused variable 'iter' [-Wunused-variable]
        GHashTableIter iter;
                       ^
/s/mono/mono/mini/mini-llvm.c:9004:10: warning: unused variable 'callers' [-Wunused-variable]
        GSList *callers, *l;
                ^
/s/mono/mono/mini/mini-llvm.c:9004:20: warning: unused variable 'l' [-Wunused-variable]
        GSList *callers, *l;
```