### PR TITLE
Fix warnings.

### DIFF
--- a/libgc/include/gc_pthread_redirects.h
+++ b/libgc/include/gc_pthread_redirects.h
@@ -5,6 +5,14 @@
 
 #define GC_PTHREAD_REDIRECTS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void * GC_dlopen(const char *path, int mode);
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
 #if defined(GC_SOLARIS_THREADS)
 /* We need to intercept calls to many of the threads primitives, so 	*/
 /* that we can locate thread stacks and stop the world.			*/
@@ -26,7 +34,6 @@ extern "C" {
   int GC_thr_join(thread_t wait_for, thread_t *departed, void **status);
   int GC_thr_suspend(thread_t target_thread);
   int GC_thr_continue(thread_t target_thread);
-  void * GC_dlopen(const char *path, int mode);
 # define thr_create GC_thr_create
 # define thr_join GC_thr_join
 # define thr_suspend GC_thr_suspend
@@ -65,7 +72,6 @@ extern "C" {
 #if defined(GC_SOLARIS_PTHREADS) || defined(GC_SOLARIS_THREADS)
 # define dlopen GC_dlopen
 #endif /* SOLARIS_THREADS || SOLARIS_PTHREADS */
-
 
 #if !defined(GC_USE_LD_WRAP) && (defined(GC_PTHREADS) || defined(GC_DARWIN_THREADS) || defined(GC_MACOSX_THREADS)) && !defined(GC_SOLARIS_PTHREADS)
 /* We treat these similarly. */

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -2139,7 +2139,7 @@ ves_icall_mono_marshal_xdomain_copy_value (MonoObject *val)
 	return result;
 }
 
-void
+static void
 mono_context_set_icall (MonoAppContext *new_context_raw)
 {
 	HANDLE_FUNCTION_ENTER ();

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -55,6 +55,13 @@
 #include "utils/strenc.h"
 #include "utils/refcount.h"
 
+#if 0 // FIXME icall-decl.h sometimes breaks things because of Boehm's handling of dlopen.
+#include "icall-decl.h"
+#else
+guint32
+ves_icall_System_IO_DriveInfo_GetDriveType (const gunichar2 *root_path_name, gint32 root_path_name_length, MonoError *error);
+#endif
+
 #define NANOSECONDS_PER_MICROSECOND 1000LL
 #define TICKS_PER_MICROSECOND 10L
 #define TICKS_PER_MILLISECOND 10000L

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -226,9 +226,9 @@ MONO_SIG_HANDLER_FUNC (static, sigabrt_signal_handler)
 
 MONO_SIG_HANDLER_FUNC (static, sigterm_signal_handler)
 {
+#ifndef DISABLE_CRASH_REPORTING
 	MONO_SIG_HANDLER_GET_CONTEXT;
 
-#ifndef DISABLE_CRASH_REPORTING
 	// Note: this is only run from the non-controlling thread
 	MonoContext mctx;
 	gchar *output = NULL;

--- a/mono/sgen/sgen-memory-governor.c
+++ b/mono/sgen/sgen-memory-governor.c
@@ -301,41 +301,41 @@ sgen_output_log_entry (SgenLogEntry *entry, gint64 stw_time, int generation)
 
 	switch (entry->type) {
 		case SGEN_LOG_NURSERY:
-			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MINOR%s: (%s) time %.2fms, %s promoted %zdK major size: %zdK in use: %zdK los size: %zdK in use: %zdK",
+			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MINOR%s: (%s) time %.2fms, %s promoted %luK major size: %luK in use: %luK los size: %luK in use: %luK",
 				entry->is_overflow ? "_OVERFLOW" : "",
 				entry->reason ? entry->reason : "",
 				entry->time / 10000.0f,
 				(generation == GENERATION_NURSERY) ? full_timing_buff : "",
-				entry->promoted_size / 1024,
-				entry->major_size / 1024,
-				entry->major_size_in_use / 1024,
-				entry->los_size / 1024,
-				entry->los_size_in_use / 1024);
+				(unsigned long)entry->promoted_size / 1024,
+				(unsigned long)entry->major_size / 1024,
+				(unsigned long)entry->major_size_in_use / 1024,
+				(unsigned long)entry->los_size / 1024,
+				(unsigned long)entry->los_size_in_use / 1024);
 			break;
 		case SGEN_LOG_MAJOR_SERIAL:
-			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MAJOR%s: (%s) time %.2fms, %s los size: %zdK in use: %zdK",
+			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MAJOR%s: (%s) time %.2fms, %s los size: %luK in use: %luK",
 				entry->is_overflow ? "_OVERFLOW" : "",
 				entry->reason ? entry->reason : "",
 				(int)entry->time / 10000.0f,
 				full_timing_buff,
-				entry->los_size / 1024,
-				entry->los_size_in_use / 1024);
+				(unsigned long)entry->los_size / 1024,
+				(unsigned long)entry->los_size_in_use / 1024);
 			break;
 		case SGEN_LOG_MAJOR_CONC_START:
 			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MAJOR_CONCURRENT_START: (%s)", entry->reason ? entry->reason : "");
 			break;
 		case SGEN_LOG_MAJOR_CONC_FINISH:
-			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MAJOR_CONCURRENT_FINISH: (%s) time %.2fms, %s los size: %zdK in use: %zdK",
+			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MAJOR_CONCURRENT_FINISH: (%s) time %.2fms, %s los size: %luK in use: %luK",
 				entry->reason ? entry->reason : "",
 				entry->time / 10000.0f,
 				full_timing_buff,
-				entry->los_size / 1024,
-				entry->los_size_in_use / 1024);
+				(unsigned long)entry->los_size / 1024,
+				(unsigned long)entry->los_size_in_use / 1024);
 			break;
 		case SGEN_LOG_MAJOR_SWEEP_FINISH:
-			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MAJOR_SWEEP: major size: %zdK in use: %zdK",
-				entry->major_size / 1024,
-				entry->major_size_in_use / 1024);
+			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_GC, "GC_MAJOR_SWEEP: major size: %luK in use: %luK",
+				(unsigned long)entry->major_size / 1024,
+				(unsigned long)entry->major_size_in_use / 1024);
 			break;
 		default:
 			SGEN_ASSERT (0, FALSE, "Invalid log entry type");


### PR DESCRIPTION
This isn't correct for Win64 but that should be ok.
It is correct for all other platforms.

Ultimately  PRI64 and  casting to int64_t or uint64_t is the most portable and warning-free.
mingw warns for every use  of %ll for example, though the warning appears to be incorrect.

Or stop using sprintf. Portabilty problem, warning-farm, slow, overly general, not as reentrant as suspected, etc.

```
/s/mono/mono/sgen/sgen-memory-governor.c:309:5: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'unsigned int' [-Wformat]
                                entry->promoted_size / 1024,
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/s/mono/mono/sgen/sgen-memory-governor.c:310:5: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'unsigned int' [-Wformat]
                                entry->major_size / 1024,
                                ^~~~~~~~~~~~~~~~~~~~~~~~
/s/mono/mono/sgen/sgen-memory-governor.c:311:5: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'unsigned int' [-Wformat]
                                entry->major_size_in_use / 1024,
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/s/mono/mono/sgen/sgen-memory-governor.c:312:5: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'unsigned int' [-Wformat]
                                entry->los_size / 1024,
                                ^~~~~~~~~~~~~~~~~~~~~~
/s/mono/mono/sgen/sgen-memory-governor.c:313:5: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'unsigned int' [-Wformat]
                                entry->los_size_in_use / 1024);
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/s/mono/mono/sgen/sgen-memory-governor.c:321:5: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'unsigned int' [-Wformat]
                                entry->los_size / 1024,
                                ^~~~~~~~~~~~~~~~~~~~~~
/s/mono/mono/sgen/sgen-memory-governor.c:322:5: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'unsigned int' [-Wformat]
                                entry->los_size_in_use / 1024);
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/s/mono/mono/sgen/sgen-memory-governor.c:332:5: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'unsigned int' [-Wformat]
                                entry->los_size / 1024,
                                ^~~~~~~~~~~~~~~~~~~~~~
/s/mono/mono/sgen/sgen-memory-governor.c:333:5: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'unsigned int' [-Wformat]
                                entry->los_size_in_use / 1024);
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/s/mono/mono/sgen/sgen-memory-governor.c:337:5: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'unsigned int' [-Wformat]
                                entry->major_size / 1024,
                                ^~~~~~~~~~~~~~~~~~~~~~~~
/s/mono/mono/sgen/sgen-memory-governor.c:338:5: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'unsigned int' [-Wformat]
                                entry->major_size_in_use / 1024);
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

/s/mono/mono/metadata/w32file-unix.c:4688:1: warning: no previous prototype for function 'ves_icall_System_IO_DriveInfo_GetDriveType' [-Wmissing-prototypes]
ves_icall_System_IO_DriveInfo_GetDriveType (const gunichar2 *root_path_name, gint32 root_path_name_length, MonoError *error)
^

/s/mono/mono/metadata/remoting.c:2143:1: warning: no previous prototype for function 'mono_context_set_icall' [-Wmissing-prototypes]
mono_context_set_icall (MonoAppContext *new_context_raw)
^

/s/mono/mono/mini/mini-posix.c:229:2: warning: unused variable 'ctx' [-Wunused-variable]
        MONO_SIG_HANDLER_GET_CONTEXT;
```