### PR TITLE
Fix a bunch of warnings.

### DIFF
--- a/mono/metadata/handle.c
+++ b/mono/metadata/handle.c
@@ -156,7 +156,11 @@ mono_handle_chunk_leak_check (HandleStack *handles) {
 #endif
 
 // There are deliberately locals and a constant NULL global with this same name.
+#ifdef __cplusplus
 extern MonoThreadInfo * const mono_thread_info_current_var = NULL;
+#else
+MonoThreadInfo * const mono_thread_info_current_var;
+#endif
 
 /* Actual handles implementation */
 MonoRawHandle

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -1882,10 +1882,12 @@ cache_generic_delegate_wrapper (GHashTable *cache, MonoMethod *orig_method, Mono
 	return res;
 }
 
+#ifndef ENABLE_ILGEN
 static void
 emit_delegate_begin_invoke_noilgen (MonoMethodBuilder *mb, MonoMethodSignature *sig)
 {
 }
+#endif
 
 /**
  * mono_marshal_get_delegate_begin_invoke:
@@ -2059,10 +2061,12 @@ mono_delegate_end_invoke (MonoDelegate *delegate, gpointer *params)
 	return res;
 }
 
+#ifndef ENABLE_ILGEN
 static void
 emit_delegate_end_invoke_noilgen (MonoMethodBuilder *mb, MonoMethodSignature *sig)
 {
 }
+#endif
 
 /**
  * mono_marshal_get_delegate_end_invoke:
@@ -2167,6 +2171,7 @@ free_signature_pointer_pair (SignaturePointerPair *pair)
 	g_free (pair);
 }
 
+#ifndef ENABLE_ILGEN
 static void
 mb_skip_visibility_noilgen (MonoMethodBuilder *mb)
 {
@@ -2186,6 +2191,7 @@ static void
 emit_delegate_invoke_internal_noilgen (MonoMethodBuilder *mb, MonoMethodSignature *sig, MonoMethodSignature *invoke_sig, gboolean static_method_with_first_arg_bound, gboolean callvirt, gboolean closed_over_null, MonoMethod *method, MonoMethod *target_method, MonoClass *target_class, MonoGenericContext *ctx, MonoGenericContainer *container)
 {
 }
+#endif
 
 MonoMethod *
 mono_marshal_get_delegate_invoke_internal (MonoMethod *method, gboolean callvirt, gboolean static_method_with_first_arg_bound, MonoMethod *target_method)
@@ -2791,6 +2797,7 @@ mono_marshal_get_runtime_invoke (MonoMethod *method, gboolean virtual_)
 	return mono_marshal_get_runtime_invoke_full (method, virtual_, need_direct_wrapper);
 }
 
+#ifndef ENABLE_ILGEN
 static void
 emit_runtime_invoke_body_noilgen (MonoMethodBuilder *mb, const char **param_names, MonoImage *image, MonoMethod *method,
 						  MonoMethodSignature *sig, MonoMethodSignature *callsig,
@@ -2802,6 +2809,7 @@ static void
 emit_runtime_invoke_dynamic_noilgen (MonoMethodBuilder *mb)
 {
 }
+#endif
 
 /*
  * mono_marshal_get_runtime_invoke_dynamic:
@@ -2958,10 +2966,12 @@ mono_marshal_get_runtime_invoke_for_sig (MonoMethodSignature *sig)
 	return res;
 }
 
+#ifndef ENABLE_ILGEN
 static void
 emit_icall_wrapper_noilgen (MonoMethodBuilder *mb, MonoMethodSignature *sig, gconstpointer func, MonoMethodSignature *csig2, gboolean check_exceptions)
 {
 }
+#endif
 
 /**
  * mono_marshal_get_icall_wrapper:
@@ -3007,6 +3017,7 @@ mono_marshal_get_icall_wrapper (MonoMethodSignature *sig, const char *name, gcon
 	return res;
 }
 
+#ifndef ENABLE_ILGEN
 static int
 emit_marshal_custom_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 					 MonoMarshalSpec *spec, 
@@ -3100,6 +3111,7 @@ emit_marshal_variant_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 {
 	g_assert_not_reached ();
 }
+#endif
 
 gboolean
 mono_pinvoke_is_unicode (MonoMethodPInvoke *piinfo)
@@ -3119,6 +3131,7 @@ mono_pinvoke_is_unicode (MonoMethodPInvoke *piinfo)
 	}
 }
 
+#ifndef ENABLE_ILGEN
 static int
 emit_marshal_array_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 					MonoMarshalSpec *spec, 
@@ -3137,6 +3150,7 @@ emit_marshal_array_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	}
 	return conv_arg;
 }
+#endif
 
 MonoType*
 mono_marshal_boolean_conv_in_get_local_type (MonoMarshalSpec *spec, guint8 *ldc_op /*out*/)
@@ -3184,6 +3198,7 @@ mono_marshal_boolean_managed_conv_in_get_conv_arg_class (MonoMarshalSpec *spec, 
 	return conv_arg_class;
 }
 
+#ifndef ENABLE_ILGEN
 static int
 emit_marshal_boolean_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		      MonoMarshalSpec *spec, 
@@ -3235,6 +3250,7 @@ emit_marshal_scalar_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 {
 	return conv_arg;
 }
+#endif
 
 int
 mono_emit_marshal (EmitMarshalContext *m, int argnum, MonoType *t, 
@@ -3314,6 +3330,7 @@ mono_emit_marshal (EmitMarshalContext *m, int argnum, MonoType *t,
 	}
 }
 
+#ifndef ENABLE_ILGEN
 static void
 emit_create_string_hack_noilgen (MonoMethodBuilder *mb, MonoMethodSignature *csig, MonoMethod *res)
 {
@@ -3323,6 +3340,7 @@ static void
 emit_native_icall_wrapper_noilgen (MonoMethodBuilder *mb, MonoMethod *method, MonoMethodSignature *csig, gboolean check_exceptions, gboolean aot, MonoMethodPInvoke *pinfo)
 {
 }
+#endif
 
 /**
  * mono_marshal_get_native_wrapper:
@@ -3654,6 +3672,7 @@ mono_marshal_emit_managed_wrapper (MonoMethodBuilder *mb, MonoMethodSignature *i
 	get_marshal_cb ()->emit_managed_wrapper (mb, invoke_sig, mspecs, m, method, target_handle);
 }
 
+#ifndef ENABLE_ILGEN
 static void
 emit_managed_wrapper_noilgen (MonoMethodBuilder *mb, MonoMethodSignature *invoke_sig, MonoMarshalSpec **mspecs, EmitMarshalContext* m, MonoMethod *method, uint32_t target_handle)
 {
@@ -3690,6 +3709,7 @@ emit_managed_wrapper_noilgen (MonoMethodBuilder *mb, MonoMethodSignature *invoke
 		}
 	}
 }
+#endif
 
 static void 
 mono_marshal_set_callconv_from_modopt (MonoMethod *method, MonoMethodSignature *csig)
@@ -3899,10 +3919,12 @@ mono_marshal_get_managed_wrapper (MonoMethod *method, MonoClass *delegate_klass,
 	return res;
 }
 
+#ifndef ENABLE_ILGEN
 static void
 emit_vtfixup_ftnptr_noilgen (MonoMethodBuilder *mb, MonoMethod *method, int param_count, guint16 type)
 {
 }
+#endif
 
 gpointer
 mono_marshal_get_vtfixup_ftnptr (MonoImage *image, guint32 token, guint16 type)
@@ -3979,10 +4001,12 @@ mono_marshal_get_vtfixup_ftnptr (MonoImage *image, guint32 token, guint16 type)
 	return compiled_ptr;
 }
 
+#ifndef ENABLE_ILGEN
 static void
 emit_castclass_noilgen (MonoMethodBuilder *mb)
 {
 }
+#endif
 
 /**
  * mono_marshal_get_castclass_with_cache:
@@ -4047,10 +4071,12 @@ mono_marshal_isinst_with_cache (MonoObject *obj, MonoClass *klass, uintptr_t *ca
 	return isinst;
 }
 
+#ifndef ENABLE_ILGEN
 static void
 emit_isinst_noilgen (MonoMethodBuilder *mb)
 {
 }
+#endif
 
 /**
  * mono_marshal_get_isinst_with_cache:
@@ -4097,10 +4123,12 @@ mono_marshal_get_isinst_with_cache (void)
 	return cached;
 }
 
+#ifndef ENABLE_ILGEN
 static void
 emit_struct_to_ptr_noilgen (MonoMethodBuilder *mb, MonoClass *klass)
 {
 }
+#endif
 
 /**
  * mono_marshal_get_struct_to_ptr:
@@ -4148,10 +4176,12 @@ mono_marshal_get_struct_to_ptr (MonoClass *klass)
 	return res;
 }
 
+#ifndef ENABLE_ILGEN
 static void
 emit_ptr_to_struct_noilgen (MonoMethodBuilder *mb, MonoClass *klass)
 {
 }
+#endif
 
 /**
  * mono_marshal_get_ptr_to_struct:
@@ -4247,6 +4277,7 @@ mono_marshal_get_synchronized_inner_wrapper (MonoMethod *method)
 	return res;
 }
 
+#ifndef ENABLE_ILGEN
 static void
 emit_synchronized_wrapper_noilgen (MonoMethodBuilder *mb, MonoMethod *method, MonoGenericContext *ctx, MonoGenericContainer *container, MonoMethod *enter_method, MonoMethod *exit_method, MonoMethod *gettypefromhandle_method)
 {
@@ -4257,6 +4288,7 @@ emit_synchronized_wrapper_noilgen (MonoMethodBuilder *mb, MonoMethod *method, Mo
 	}
 
 }
+#endif
 
 /**
  * mono_marshal_get_synchronized_wrapper:
@@ -4353,10 +4385,12 @@ mono_marshal_get_synchronized_wrapper (MonoMethod *method)
 	return res;	
 }
 
+#ifndef ENABLE_ILGEN
 static void
 emit_unbox_wrapper_noilgen (MonoMethodBuilder *mb, MonoMethod *method)
 {
 }
+#endif
 
 /**
  * mono_marshal_get_unbox_wrapper:
@@ -4445,10 +4479,12 @@ record_slot_vstore (MonoObject *array, size_t index, MonoObject *value)
 }
 #endif
 
+#ifndef ENABLE_ILGEN
 static void
 emit_virtual_stelemref_noilgen (MonoMethodBuilder *mb, const char **param_names, MonoStelemrefKind kind)
 {
 }
+#endif
 
 static const char *strelemref_wrapper_name[] = {
 	"object", "sealed_class", "class", "class_small_idepth", "interface", "complex"
@@ -4546,10 +4582,12 @@ mono_marshal_get_virtual_stelemref_wrappers (int *nwrappers)
 	return res;
 }
 
+#ifndef ENABLE_ILGEN
 static void
 emit_stelemref_noilgen (MonoMethodBuilder *mb)
 {
 }
+#endif
 
 /**
  * mono_marshal_get_stelemref:
@@ -4590,10 +4628,12 @@ mono_marshal_get_stelemref (void)
 	return ret;
 }
 
+#ifndef ENABLE_ILGEN
 static void
 mb_emit_byte_noilgen (MonoMethodBuilder *mb, guint8 op)
 {
 }
+#endif
 
 /*
  * mono_marshal_get_gsharedvt_in_wrapper:
@@ -4661,10 +4701,12 @@ mono_marshal_get_gsharedvt_out_wrapper (void)
 	return ret;
 }
 
+#ifndef ENABLE_ILGEN
 static void
 emit_array_address_noilgen (MonoMethodBuilder *mb, int rank, int elem_size)
 {
 }
+#endif
 
 typedef struct {
 	int rank;
@@ -4764,10 +4806,12 @@ mono_marshal_get_array_address (int rank, int elem_size)
 	return ret;
 }
 
+#ifndef ENABLE_ILGEN
 static void
 emit_array_accessor_wrapper_noilgen (MonoMethodBuilder *mb, MonoMethod *method, MonoMethodSignature *sig, MonoGenericContext *ctx)
 {
 }
+#endif
 
 /*
  * mono_marshal_get_array_accessor_wrapper:
@@ -4850,7 +4894,7 @@ mono_marshal_alloc (gsize size, MonoError *error)
 
 	res = mono_marshal_alloc_co_task_mem (size);
 	if (!res)
-		mono_error_set_out_of_memory (error, "Could not allocate %lu bytes", size);
+		mono_error_set_out_of_memory (error, "Could not allocate %" G_GSIZE_FORMAT " bytes", size);
 
 	return res;
 }
@@ -5981,10 +6025,12 @@ mono_marshal_free_asany (MonoObject *o, gpointer ptr, MonoMarshalNative string_e
 	}
 }
 
+#ifndef ENABLE_ILGEN
 static void
 emit_generic_array_helper_noilgen (MonoMethodBuilder *mb, MonoMethod *method, MonoMethodSignature *csig)
 {
 }
+#endif
 
 /*
  * mono_marshal_get_generic_array_helper:
@@ -6084,10 +6130,12 @@ mono_marshal_find_nonzero_bit_offset (guint8 *buf, int len, int *byte_offset, gu
 	*bitmask = buf [i];
 }
 
+#ifndef ENABLE_ILGEN
 static void
 emit_thunk_invoke_wrapper_noilgen (MonoMethodBuilder *mb, MonoMethod *method, MonoMethodSignature *csig)
 {
 }
+#endif
 
 MonoMethod *
 mono_marshal_get_thunk_invoke_wrapper (MonoMethod *method)
@@ -6199,10 +6247,12 @@ mono_marshal_emit_native_wrapper (MonoImage *image, MonoMethodBuilder *mb, MonoM
 	get_marshal_cb ()->emit_native_wrapper (image, mb, sig, piinfo, mspecs, func, aot, check_exceptions, func_param);
 }
 
+#ifndef ENABLE_ILGEN
 static void
 emit_native_wrapper_noilgen (MonoImage *image, MonoMethodBuilder *mb, MonoMethodSignature *sig, MonoMethodPInvoke *piinfo, MonoMarshalSpec **mspecs, gpointer func, gboolean aot, gboolean check_exceptions, gboolean func_param)
 {
 }
+#endif
 
 static MonoMarshalCallbacks marshal_cb;
 static gboolean cb_inited = FALSE;
@@ -6216,6 +6266,7 @@ mono_install_marshal_callbacks (MonoMarshalCallbacks *cb)
 	cb_inited = TRUE;
 }
 
+#ifndef ENABLE_ILGEN
 static void
 install_noilgen (void)
 {
@@ -6263,6 +6314,7 @@ install_noilgen (void)
 	cb.mb_emit_byte = mb_emit_byte_noilgen;
 	mono_install_marshal_callbacks (&cb);
 }
+#endif
 
 static MonoMarshalCallbacks *
 get_marshal_cb (void)

--- a/mono/metadata/method-builder.c
+++ b/mono/metadata/method-builder.c
@@ -56,6 +56,7 @@ static MonoDisHelper marshal_dh = {
 static MonoMethodBuilderCallbacks mb_cb;
 static gboolean cb_inited = FALSE;
 
+#ifndef ENABLE_ILGEN
 static MonoMethodBuilder *
 new_base_noilgen (MonoClass *klass, MonoWrapperType type)
 {
@@ -139,7 +140,7 @@ create_method_noilgen (MonoMethodBuilder *mb, MonoMethodSignature *signature, in
 
 	return method;
 }
-
+#endif
 
 void
 mono_install_method_builder_callbacks (MonoMethodBuilderCallbacks *cb)
@@ -150,6 +151,7 @@ mono_install_method_builder_callbacks (MonoMethodBuilderCallbacks *cb)
 	cb_inited = TRUE;
 }
 
+#ifndef ENABLE_ILGEN
 static void
 install_noilgen (void)
 {
@@ -160,6 +162,7 @@ install_noilgen (void)
 	cb.create_method = create_method_noilgen;
 	mono_install_method_builder_callbacks (&cb);
 }
+#endif
 
 static MonoMethodBuilderCallbacks *
 get_mb_cb (void)

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -104,7 +104,7 @@ mono_gc_wbarrier_value_copy_internal (gpointer dest, gpointer src, int count, Mo
 	HEAVY_STAT (++stat_wbarrier_value_copy);
 	g_assert (m_class_is_valuetype (klass));
 
-	SGEN_LOG (8, "Adding value remset at %p, count %d, descr %p for class %s (%p)", dest, count, (gpointer)m_class_get_gc_descr (klass), m_class_get_name (klass), klass);
+	SGEN_LOG (8, "Adding value remset at %p, count %d, descr %p for class %s (%p)", dest, count, (gpointer)(intptr_t)m_class_get_gc_descr (klass), m_class_get_name (klass), klass);
 
 	if (sgen_ptr_in_nursery (dest) || ptr_on_stack (dest) || !sgen_gc_descr_has_references ((mword)m_class_get_gc_descr (klass))) {
 		size_t element_size = mono_class_value_size (klass, NULL);
@@ -1738,7 +1738,7 @@ report_registered_roots_by_type (int root_type)
 	RootRecord *root;
 	report.count = 0;
 	SGEN_HASH_TABLE_FOREACH (&sgen_roots_hash [root_type], void **, start_root, RootRecord *, root) {
-		SGEN_LOG (6, "Profiler root scan %p-%p (desc: %p)", start_root, root->end_root, (void*)root->root_desc);
+		SGEN_LOG (6, "Profiler root scan %p-%p (desc: %p)", start_root, root->end_root, (void*)(intptr_t)root->root_desc);
 		if (root_type == ROOT_TYPE_PINNED)
 			report_pinning_roots (&report, start_root, (void**)root->end_root);
 		else

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -104,7 +104,7 @@ mono_gc_wbarrier_value_copy_internal (gpointer dest, gpointer src, int count, Mo
 	HEAVY_STAT (++stat_wbarrier_value_copy);
 	g_assert (m_class_is_valuetype (klass));
 
-	SGEN_LOG (8, "Adding value remset at %p, count %d, descr %p for class %s (%p)", dest, count, (gpointer)(intptr_t)m_class_get_gc_descr (klass), m_class_get_name (klass), klass);
+	SGEN_LOG (8, "Adding value remset at %p, count %d, descr %p for class %s (%p)", dest, count, (gpointer)(uintptr_t)m_class_get_gc_descr (klass), m_class_get_name (klass), klass);
 
 	if (sgen_ptr_in_nursery (dest) || ptr_on_stack (dest) || !sgen_gc_descr_has_references ((mword)m_class_get_gc_descr (klass))) {
 		size_t element_size = mono_class_value_size (klass, NULL);

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -66,7 +66,7 @@
 // Constants to convert Unix times to the API expected by .NET and Windows
 #define CONVERT_BASE  116444736000000000ULL
 
-#define INVALID_HANDLE_VALUE (GINT_TO_POINTER (-1))
+#define INVALID_HANDLE_VALUE ((gpointer)-1)
 
 typedef struct {
 	guint64 device;
@@ -4868,14 +4868,11 @@ UnlockFile (gpointer handle, guint32 offset_low, guint32 offset_high, guint32 le
 #ifdef HAVE_LARGE_FILE_SUPPORT
 	offset = ((gint64)offset_high << 32) | offset_low;
 	length = ((gint64)length_high << 32) | length_low;
-
-	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: Unlocking fd %d, offset %" G_GINT64_FORMAT ", length %" G_GINT64_FORMAT, __func__, ((MonoFDHandle*) filehandle)->fd, (gint64) offset, (gint64) length);
 #else
 	offset = offset_low;
 	length = length_low;
-
-	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: Unlocking fd %p, offset %" G_GINT64_FORMAT ", length %" G_GINT64_FORMAT, __func__, ((MonoFDHandle*) filehandle)->fd, (gint64) offset, (gint64) length);
 #endif
+	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: Unlocking fd %d, offset %" G_GINT64_FORMAT ", length %" G_GINT64_FORMAT, __func__, ((MonoFDHandle*) filehandle)->fd, (gint64) offset, (gint64) length);
 
 	ret = _wapi_unlock_file_region (((MonoFDHandle*) filehandle)->fd, offset, length);
 

--- a/mono/metadata/w32handle.h
+++ b/mono/metadata/w32handle.h
@@ -10,20 +10,15 @@
 
 #ifdef HOST_WIN32
 #include <windows.h>
+#else
+#define INVALID_HANDLE_VALUE ((gpointer)-1)
 #endif
 
 #include "mono/utils/mono-coop-mutex.h"
 #include "mono/utils/mono-error.h"
 
-#ifndef INVALID_HANDLE_VALUE
-#define INVALID_HANDLE_VALUE ((gpointer)-1)
-#endif
-
 #define MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS 64
-
-#ifndef MONO_INFINITE_WAIT
 #define MONO_INFINITE_WAIT ((guint32) 0xFFFFFFFF)
-#endif
 
 typedef enum {
 	MONO_W32TYPE_UNUSED = 0,

--- a/mono/metadata/w32process-unix-internals.h
+++ b/mono/metadata/w32process-unix-internals.h
@@ -40,7 +40,7 @@ mono_w32process_get_name (pid_t pid);
 GSList*
 mono_w32process_get_modules (pid_t pid);
 
-static void
+static void G_GNUC_UNUSED
 mono_w32process_module_free (MonoW32ProcessModule *module)
 {
 	g_free (module->perms);
@@ -51,7 +51,7 @@ mono_w32process_module_free (MonoW32ProcessModule *module)
 /*
  * Used to look through the GSList* returned by mono_w32process_get_modules
  */
-static gint
+static gint G_GNUC_UNUSED
 mono_w32process_module_equals (gconstpointer a, gconstpointer b)
 {
 	MonoW32ProcessModule *want = (MonoW32ProcessModule *)a;

--- a/mono/mini/branch-opts.c
+++ b/mono/mini/branch-opts.c
@@ -114,6 +114,7 @@ mono_branch_optimize_exception_target (MonoCompile *cfg, MonoBasicBlock *bb, con
 	return NULL;
 }
 
+#ifdef MONO_ARCH_HAVE_CMOV_OPS
 static const int int_cmov_opcodes [] = {
 	OP_CMOV_IEQ,
 	OP_CMOV_INE_UN,
@@ -140,7 +141,7 @@ static const int long_cmov_opcodes [] = {
 	OP_CMOV_LGT_UN
 };
 
-static G_GNUC_UNUSED int
+static int
 br_to_br_un (int opcode)
 {
 	switch (opcode) {
@@ -161,6 +162,7 @@ br_to_br_un (int opcode)
 		return -1;
 	}
 }
+#endif
 
 /**
  * mono_replace_ins:

--- a/mono/mini/exceptions-arm.c
+++ b/mono/mini/exceptions-arm.c
@@ -238,7 +238,7 @@ get_throw_trampoline (int size, gboolean corlib, gboolean rethrow, gboolean llvm
 
 	cfa_offset = MONO_ARM_NUM_SAVED_REGS * sizeof (mgreg_t);
 	mono_add_unwind_op_def_cfa (unwind_ops, code, start, ARMREG_SP, cfa_offset);
-	mono_add_unwind_op_offset (unwind_ops, code, start, ARMREG_LR, - sizeof (mgreg_t));
+	mono_add_unwind_op_offset (unwind_ops, code, start, ARMREG_LR, -(ptrdiff_t)sizeof (mgreg_t));
 
 	/* Save fp regs */
 	if (!mono_arch_is_soft_float ()) {

--- a/mono/mini/helpers.c
+++ b/mono/mini/helpers.c
@@ -65,7 +65,7 @@ static const gint16 opidx [] = {
 /*This enables us to use the right tooling when building the cross compiler for iOS.*/
 #if defined (__APPLE__) && defined (TARGET_ARM) && (defined(__i386__) || defined(__x86_64__))
 
-#define ARCH_PREFIX "/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/"
+//#define ARCH_PREFIX "/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/"
 
 #endif
 

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -1229,6 +1229,7 @@ ves_pinvoke_method (InterpFrame *frame, MonoMethodSignature *sig, MonoFuncV addr
 	g_free (margs->fargs);
 	g_free (margs);
 #endif
+	goto exit_pinvoke; // prevent unused label warning in some configurations
 exit_pinvoke:
 	return;
 }
@@ -1888,7 +1889,7 @@ do_icall (InterpFrame *frame, MonoMethodSignature *sig, int op, stackval *sp, gp
 
 	interp_pop_lmf (&ext);
 
-
+	goto exit_icall; // prevent unused label warning in some configurations
 exit_icall:
 	return sp;
 }

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1663,9 +1663,8 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 		(target_method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL) == 0 && 
 		(target_method->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL) == 0 &&
 		!(target_method->iflags & METHOD_IMPL_ATTRIBUTE_NOINLINING)) {
-		MonoVTable *vt = mono_class_vtable_checked (domain, target_method->klass, error);
+		(void)mono_class_vtable_checked (domain, target_method->klass, error);
 		return_val_if_nok (error, FALSE);
-		int called_inited = vt->initialized;
 
 		if (method == target_method && *(td->ip + 5) == CEE_RET && !(csignature->hasthis && m_class_is_valuetype (target_method->klass))) {
 			int offset;

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -7352,8 +7352,6 @@ mono_arch_skip_single_step (MonoContext *ctx)
 	MONO_CONTEXT_SET_IP (ctx, (guint8*)MONO_CONTEXT_GET_IP (ctx) + 4);
 }
 
-#endif /* MONO_ARCH_SOFT_DEBUG_SUPPORTED */
-
 /*
  * mono_arch_get_seq_point_info:
  *
@@ -7390,6 +7388,8 @@ mono_arch_get_seq_point_info (MonoDomain *domain, guint8 *code)
 
 	return info;
 }
+
+#endif /* MONO_ARCH_SOFT_DEBUG_SUPPORTED */
 
 /*
  * mono_arch_set_target:

--- a/mono/sgen/sgen-debug.c
+++ b/mono/sgen/sgen-debug.c
@@ -158,7 +158,7 @@ static gboolean missing_remsets;
 			if (!sgen_get_remset ()->find_address ((char*)(ptr)) && !sgen_cement_lookup (*(ptr))) { \
 				GCVTable __vt = SGEN_LOAD_VTABLE (obj);	\
 				gboolean is_pinned = object_is_pinned (*(ptr));	\
-				SGEN_LOG (0, "Oldspace->newspace reference %p at offset %zd in object %p (%s.%s) not found in remsets%s.", *(ptr), (char*)(ptr) - (char*)(obj), (obj), sgen_client_vtable_get_namespace (__vt), sgen_client_vtable_get_name (__vt), is_pinned ? ", but object is pinned" : ""); \
+				SGEN_LOG (0, "Oldspace->newspace reference %p at offset %ld in object %p (%s.%s) not found in remsets%s.", *(ptr), (long)((char*)(ptr) - (char*)(obj)), (obj), sgen_client_vtable_get_namespace (__vt), sgen_client_vtable_get_name (__vt), is_pinned ? ", but object is pinned" : ""); \
 				sgen_binary_protocol_missing_remset ((obj), __vt, (int) ((char*)(ptr) - (char*)(obj)), *(ptr), (gpointer)LOAD_VTABLE(*(ptr)), is_pinned); \
 				if (!is_pinned)				\
 					missing_remsets = TRUE;		\
@@ -223,7 +223,7 @@ is_major_or_los_object_marked (GCObject *obj)
 	if (*(ptr) && !sgen_ptr_in_nursery ((char*)*(ptr)) && !is_major_or_los_object_marked ((GCObject*)*(ptr))) { \
 		if (!cards || !sgen_get_remset ()->find_address_with_cards (start, cards, (char*)(ptr))) { \
 			GCVTable __vt = SGEN_LOAD_VTABLE (obj);	\
-			SGEN_LOG (0, "major->major reference %p at offset %zd in object %p (%s.%s) not found in remsets.", *(ptr), (char*)(ptr) - (char*)(obj), (obj), sgen_client_vtable_get_namespace (__vt), sgen_client_vtable_get_name (__vt)); \
+			SGEN_LOG (0, "major->major reference %p at offset %ld in object %p (%s.%s) not found in remsets.", *(ptr), (long)((char*)(ptr) - (char*)(obj)), (obj), sgen_client_vtable_get_namespace (__vt), sgen_client_vtable_get_name (__vt)); \
 			sgen_binary_protocol_missing_remset ((obj), __vt, (int) ((char*)(ptr) - (char*)(obj)), *(ptr), (gpointer)LOAD_VTABLE(*(ptr)), object_is_pinned (*(ptr))); \
 			missing_remsets = TRUE;				\
 		}																\
@@ -267,7 +267,7 @@ sgen_check_mod_union_consistency (void)
 #undef HANDLE_PTR
 #define HANDLE_PTR(ptr,obj)	do {					\
 		if (*(ptr) && !LOAD_VTABLE (*(ptr)))						\
-			g_error ("Could not load vtable for obj %p slot %zd (size %zd)", obj, (char*)ptr - (char*)obj, (size_t)safe_object_get_size ((GCObject*)obj)); \
+			g_error ("Could not load vtable for obj %p slot %ld (size %ld)", obj, (long)((char*)ptr - (char*)obj), (long)safe_object_get_size ((GCObject*)obj)); \
 	} while (0)
 
 static void
@@ -383,7 +383,7 @@ describe_nursery_ptr (char *ptr, gboolean need_setup)
 		if ((char*)obj == ptr)
 			SGEN_LOG (0, "nursery-ptr %p", obj);
 		else
-			SGEN_LOG (0, "nursery-ptr %p (interior-ptr offset %zd)", obj, ptr - (char*)obj);
+			SGEN_LOG (0, "nursery-ptr %p (interior-ptr offset %ld)", obj, (long)(ptr - (char*)obj));
 		return (char*)obj;
 	}
 }
@@ -408,8 +408,8 @@ bad_pointer_spew (char *obj, char **slot)
 	char *ptr = *slot;
 	GCVTable vtable = LOAD_VTABLE ((GCObject*)obj);
 
-	SGEN_LOG (0, "Invalid object pointer %p at offset %zd in object %p (%s.%s):", ptr,
-			(char*)slot - obj,
+	SGEN_LOG (0, "Invalid object pointer %p at offset %ld in object %p (%s.%s):", ptr,
+			(long)((char*)slot - obj),
 			obj, sgen_client_vtable_get_namespace (vtable), sgen_client_vtable_get_name (vtable));
 	describe_pointer (ptr, FALSE);
 	broken_heap = TRUE;
@@ -421,8 +421,8 @@ missing_remset_spew (char *obj, char **slot)
 	char *ptr = *slot;
 	GCVTable vtable = LOAD_VTABLE ((GCObject*)obj);
 
-	SGEN_LOG (0, "Oldspace->newspace reference %p at offset %zd in object %p (%s.%s) not found in remsets.",
-			ptr, (char*)slot - obj, obj, 
+	SGEN_LOG (0, "Oldspace->newspace reference %p at offset %ld in object %p (%s.%s) not found in remsets.",
+			ptr, (long)((char*)slot - obj), obj,
 			sgen_client_vtable_get_namespace (vtable), sgen_client_vtable_get_name (vtable));
 
 	broken_heap = TRUE;
@@ -624,7 +624,7 @@ verify_scan_starts (char *start, char *end)
 	for (i = 0; i < sgen_nursery_section->num_scan_start; ++i) {
 		char *addr = sgen_nursery_section->scan_starts [i];
 		if (addr > start && addr < end)
-			SGEN_LOG (0, "NFC-BAD SCAN START [%zu] %p for obj [%p %p]", i, addr, start, end);
+			SGEN_LOG (0, "NFC-BAD SCAN START [%lu] %p for obj [%p %p]", (unsigned long)i, addr, start, end);
 	}
 }
 
@@ -715,8 +715,8 @@ static gboolean scan_object_for_specific_ref_precise = TRUE;
 #define HANDLE_PTR(ptr,obj) do {					\
 		if ((GCObject*)*(ptr) == key) {				\
 			GCVTable vtable = SGEN_LOAD_VTABLE (*(ptr));	\
-			g_print ("found ref to %p in object %p (%s.%s) at offset %zd\n", \
-					key, (obj), sgen_client_vtable_get_namespace (vtable), sgen_client_vtable_get_name (vtable), ((char*)(ptr) - (char*)(obj))); \
+			g_print ("found ref to %p in object %p (%s.%s) at offset %ld\n", \
+					key, (obj), sgen_client_vtable_get_namespace (vtable), sgen_client_vtable_get_name (vtable), (long)(((char*)(ptr) - (char*)(obj)))); \
 		}							\
 	} while (0)
 
@@ -739,8 +739,8 @@ scan_object_for_specific_ref (GCObject *obj, GCObject *key)
 		for (i = 0; i < size / sizeof (mword); ++i) {
 			if (words [i] == (mword)key) {
 				GCVTable vtable = SGEN_LOAD_VTABLE (obj);
-				g_print ("found possible ref to %p in object %p (%s.%s) at offset %zd\n",
-						key, obj, sgen_client_vtable_get_namespace (vtable), sgen_client_vtable_get_name (vtable), i * sizeof (mword));
+				g_print ("found possible ref to %p in object %p (%s.%s) at offset %ld\n",
+						key, obj, sgen_client_vtable_get_namespace (vtable), sgen_client_vtable_get_name (vtable), (long)(i * sizeof (mword)));
 			}
 		}
 	}
@@ -1063,7 +1063,7 @@ static FILE *heap_dump_file = NULL;
 void
 sgen_dump_occupied (char *start, char *end, char *section_start)
 {
-	fprintf (heap_dump_file, "<occupied offset=\"%zd\" size=\"%zd\"/>\n", start - section_start, end - start);
+	fprintf (heap_dump_file, "<occupied offset=\"%ld\" size=\"%ld\"/>\n", (long)(start - section_start), (long)(end - start));
 }
 
 void
@@ -1134,9 +1134,9 @@ dump_object (GCObject *obj, gboolean dump_location)
 	g_assert (j < sizeof (class_name));
 	class_name [j] = 0;
 
-	fprintf (heap_dump_file, "<object class=\"%s.%s\" size=\"%zd\"",
+	fprintf (heap_dump_file, "<object class=\"%s.%s\" size=\"%ld\"",
 			m_class_get_name_space (klass), class_name,
-			safe_object_get_size (obj));
+			(long)safe_object_get_size (obj));
 	if (dump_location) {
 		const char *location;
 		if (sgen_ptr_in_nursery (obj))
@@ -1179,9 +1179,9 @@ sgen_debug_dump_heap (const char *type, int num, const char *reason)
 	fprintf (heap_dump_file, "<other-mem-usage type=\"mempools\" size=\"%ld\"/>\n", mono_mempool_get_bytes_allocated ());
 #endif
 	sgen_dump_internal_mem_usage (heap_dump_file);
-	fprintf (heap_dump_file, "<pinned type=\"stack\" bytes=\"%zu\"/>\n", sgen_pin_stats_get_pinned_byte_count (PIN_TYPE_STACK));
+	fprintf (heap_dump_file, "<pinned type=\"stack\" bytes=\"%lu\"/>\n", (unsigned long)sgen_pin_stats_get_pinned_byte_count (PIN_TYPE_STACK));
 	/* fprintf (heap_dump_file, "<pinned type=\"static-data\" bytes=\"%d\"/>\n", pinned_byte_counts [PIN_TYPE_STATIC_DATA]); */
-	fprintf (heap_dump_file, "<pinned type=\"other\" bytes=\"%zu\"/>\n", sgen_pin_stats_get_pinned_byte_count (PIN_TYPE_OTHER));
+	fprintf (heap_dump_file, "<pinned type=\"other\" bytes=\"%lu\"/>\n", (unsigned long)sgen_pin_stats_get_pinned_byte_count (PIN_TYPE_OTHER));
 
 	fprintf (heap_dump_file, "<pinned-objects>\n");
 	pinned_objects = sgen_pin_stats_get_object_list ();

--- a/mono/sgen/sgen-descriptor.c
+++ b/mono/sgen/sgen-descriptor.c
@@ -129,7 +129,7 @@ mono_gc_make_descr_for_object (gsize *bitmap, int numbits, size_t obj_size)
 	}
 
 	if (first_set < 0) {
-		SGEN_LOG (6, "Ptrfree descriptor %p, size: %zd", (void*)desc, stored_size);
+		SGEN_LOG (6, "Ptrfree descriptor %p, size: %ld", (void*)desc, (long)stored_size);
 		if (stored_size <= MAX_RUNLEN_OBJECT_SIZE && stored_size <= SGEN_MAX_SMALL_OBJ_SIZE)
 			return DESC_TYPE_SMALL_PTRFREE | stored_size;
 		return DESC_TYPE_COMPLEX_PTRFREE;
@@ -142,7 +142,7 @@ mono_gc_make_descr_for_object (gsize *bitmap, int numbits, size_t obj_size)
 	/* we know the 2-word header is ptr-free */
 	if (last_set < BITMAP_NUM_BITS + OBJECT_HEADER_WORDS && stored_size <= SGEN_MAX_SMALL_OBJ_SIZE) {
 		desc = DESC_TYPE_BITMAP | ((*bitmap >> OBJECT_HEADER_WORDS) << LOW_TYPE_BITS);
-		SGEN_LOG (6, "Largebitmap descriptor %p, size: %zd, last set: %d", (void*)desc, stored_size, last_set);
+		SGEN_LOG (6, "Largebitmap descriptor %p, size: %ld, last set: %d", (void*)desc, (long)stored_size, last_set);
 		return desc;
 	}
 
@@ -153,7 +153,7 @@ mono_gc_make_descr_for_object (gsize *bitmap, int numbits, size_t obj_size)
 		 */
 		if (first_set < 256 && num_set < 256 && (first_set + num_set == last_set + 1)) {
 			desc = DESC_TYPE_RUN_LENGTH | stored_size | (first_set << 16) | (num_set << 24);
-			SGEN_LOG (6, "Runlen descriptor %p, size: %zd, first set: %d, num set: %d", (void*)desc, stored_size, first_set, num_set);
+			SGEN_LOG (6, "Runlen descriptor %p, size: %ld, first set: %d, num set: %d", (void*)desc, (long)stored_size, first_set, num_set);
 			return desc;
 		}
 	}

--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -1249,7 +1249,7 @@ scan_from_registered_roots (char *addr_start, char *addr_end, int root_type, Sca
 	void **start_root;
 	RootRecord *root;
 	SGEN_HASH_TABLE_FOREACH (&sgen_roots_hash [root_type], void **, start_root, RootRecord *, root) {
-		SGEN_LOG (6, "Precise root scan %p-%p (desc: %p)", start_root, root->end_root, (void*)root->root_desc);
+		SGEN_LOG (6, "Precise root scan %p-%p (desc: %p)", start_root, root->end_root, (void*)(intptr_t)root->root_desc);
 		precisely_scan_objects_from (start_root, (void**)root->end_root, addr_start, addr_end, root->root_desc, ctx);
 	} SGEN_HASH_TABLE_FOREACH_END;
 }

--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -1249,7 +1249,7 @@ scan_from_registered_roots (char *addr_start, char *addr_end, int root_type, Sca
 	void **start_root;
 	RootRecord *root;
 	SGEN_HASH_TABLE_FOREACH (&sgen_roots_hash [root_type], void **, start_root, RootRecord *, root) {
-		SGEN_LOG (6, "Precise root scan %p-%p (desc: %p)", start_root, root->end_root, (void*)(intptr_t)root->root_desc);
+		SGEN_LOG (6, "Precise root scan %p-%p (desc: %p)", start_root, root->end_root, (void*)(uintptr_t)root->root_desc);
 		precisely_scan_objects_from (start_root, (void**)root->end_root, addr_start, addr_end, root->root_desc, ctx);
 	} SGEN_HASH_TABLE_FOREACH_END;
 }

--- a/mono/sgen/sgen-nursery-allocator.c
+++ b/mono/sgen/sgen-nursery-allocator.c
@@ -797,7 +797,7 @@ sgen_build_nursery_fragments (GCMemSection *nursery_section, SgenGrayQueue *unpi
 		SGEN_LOG (1, "Nursery fully pinned");
 		for (pin_entry = pin_start; pin_entry < pin_end; ++pin_entry) {
 			GCObject *p = (GCObject *)*pin_entry;
-			SGEN_LOG (3, "Bastard pinning obj %p (%s), size: %zd", p, sgen_client_vtable_get_name (SGEN_LOAD_VTABLE (p)), sgen_safe_object_get_size (p));
+			SGEN_LOG (3, "Bastard pinning obj %p (%s), size: %ld", p, sgen_client_vtable_get_name (SGEN_LOAD_VTABLE (p)), (long)sgen_safe_object_get_size (p));
 		}
 	}
 	return fragment_total;

--- a/mono/sgen/sgen-pinning.c
+++ b/mono/sgen/sgen-pinning.c
@@ -210,7 +210,7 @@ sgen_dump_pin_queue (void)
 
 	for (i = 0; i < last_num_pinned; ++i) {
 		GCObject *ptr = (GCObject *)pin_queue.data [i];
-		SGEN_LOG (3, "Bastard pinning obj %p (%s), size: %zd", ptr, sgen_client_vtable_get_name (SGEN_LOAD_VTABLE (ptr)), sgen_safe_object_get_size (ptr));
+		SGEN_LOG (3, "Bastard pinning obj %p (%s), size: %ld", ptr, sgen_client_vtable_get_name (SGEN_LOAD_VTABLE (ptr)), (long)sgen_safe_object_get_size (ptr));
 	}
 }
 

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -5630,8 +5630,7 @@ mono_test_marshal_return_single_double_struct (void)
 	return res;
 }
 
-
-#ifndef TARGET_X86
+#ifndef HOST_X86
 
 LIBTEST_API int STDCALL
 mono_test_has_thiscall (void)

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -5630,7 +5630,8 @@ mono_test_marshal_return_single_double_struct (void)
 	return res;
 }
 
-#ifndef HOST_X86
+
+#ifndef TARGET_X86
 
 LIBTEST_API int STDCALL
 mono_test_has_thiscall (void)

--- a/mono/utils/mono-counters.c
+++ b/mono/utils/mono-counters.c
@@ -544,7 +544,7 @@ dump_counter (MonoCounter *counter, FILE *outfile) {
 			fprintf (outfile, ENTRY_FMT "%llu\n", counter->name, *(unsigned long long *)buffer);
 		break;
 	case MONO_COUNTER_WORD:
-		fprintf (outfile, ENTRY_FMT "%zd\n", counter->name, *(gssize*)buffer);
+		fprintf (outfile, ENTRY_FMT "%lld\n", counter->name, (long long)*(gssize*)buffer);
 		break;
 	case MONO_COUNTER_DOUBLE:
 		fprintf (outfile, ENTRY_FMT "%.4f\n", counter->name, *(double*)buffer);

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -569,6 +569,7 @@ get_type_name_as_mono_string (MonoErrorInternal *error, MonoDomain *domain, Mono
 	HANDLE_FUNCTION_RETURN_REF (MonoString, res);
 }
 
+#if 0
 static MonoExceptionHandle
 mono_error_prepare_exception_handle (MonoError *oerror, MonoError *error_out)
 // Can fail with out-of-memory
@@ -577,6 +578,7 @@ mono_error_prepare_exception_handle (MonoError *oerror, MonoError *error_out)
 	MonoExceptionHandle ex = MONO_HANDLE_NEW (MonoException, mono_error_prepare_exception (oerror, error_out));
 	HANDLE_FUNCTION_RETURN_REF (MonoException, ex);
 }
+#endif
 
 /*Can fail with out-of-memory*/
 MonoException*

--- a/mono/utils/mono-os-mutex.h
+++ b/mono/utils/mono-os-mutex.h
@@ -34,10 +34,7 @@
 
 G_BEGIN_DECLS
 
-#ifndef MONO_INFINITE_WAIT
 #define MONO_INFINITE_WAIT ((guint32) 0xFFFFFFFF)
-#endif
-
 
 #if !defined(HOST_WIN32)
 

--- a/mono/utils/mono-os-semaphore.h
+++ b/mono/utils/mono-os-semaphore.h
@@ -36,13 +36,11 @@
 
 #define MONO_HAS_SEMAPHORES 1
 
-#ifndef NSEC_PER_SEC
-#define NSEC_PER_SEC (1000 * 1000 * 1000)
-#endif
+#define MONO_NSEC_PER_SEC (1000 * 1000 * 1000)
+//usr/include/mach/clock_types.h:86:9: note: previous definition is here
+//#define NSEC_PER_SEC    1000000000ull   /* nanoseconds per second */
 
-#ifndef MONO_INFINITE_WAIT
 #define MONO_INFINITE_WAIT ((guint32) 0xFFFFFFFF)
-#endif
 
 G_BEGIN_DECLS
 
@@ -110,8 +108,8 @@ mono_os_sem_timedwait (MonoSemType *sem, guint32 timeout_ms, MonoSemFlags flags)
 
 	ts.tv_sec = timeout_ms / 1000;
 	ts.tv_nsec = (timeout_ms % 1000) * 1000000;
-	while (ts.tv_nsec >= NSEC_PER_SEC) {
-		ts.tv_nsec -= NSEC_PER_SEC;
+	while (ts.tv_nsec >= MONO_NSEC_PER_SEC) {
+		ts.tv_nsec -= MONO_NSEC_PER_SEC;
 		ts.tv_sec++;
 	}
 
@@ -139,7 +137,7 @@ retry:
 				ts.tv_nsec = 0;
 			} else {
 				ts.tv_sec--;
-				ts.tv_nsec += NSEC_PER_SEC;
+				ts.tv_nsec += MONO_NSEC_PER_SEC;
 			}
 		}
 		if (ts.tv_sec < 0) {
@@ -247,8 +245,8 @@ mono_os_sem_timedwait (MonoSemType *sem, guint32 timeout_ms, MonoSemFlags flags)
 
 	ts.tv_sec = timeout_ms / 1000 + t.tv_sec;
 	ts.tv_nsec = (timeout_ms % 1000) * 1000000 + t.tv_usec * 1000;
-	while (ts.tv_nsec >= NSEC_PER_SEC) {
-		ts.tv_nsec -= NSEC_PER_SEC;
+	while (ts.tv_nsec >= MONO_NSEC_PER_SEC) {
+		ts.tv_nsec -= MONO_NSEC_PER_SEC;
 		ts.tv_sec++;
 	}
 

--- a/mono/utils/mono-os-semaphore.h
+++ b/mono/utils/mono-os-semaphore.h
@@ -37,8 +37,6 @@
 #define MONO_HAS_SEMAPHORES 1
 
 #define MONO_NSEC_PER_SEC (1000 * 1000 * 1000)
-//usr/include/mach/clock_types.h:86:9: note: previous definition is here
-//#define NSEC_PER_SEC    1000000000ull   /* nanoseconds per second */
 
 #define MONO_INFINITE_WAIT ((guint32) 0xFFFFFFFF)
 

--- a/mono/utils/mono-threads-android.c
+++ b/mono/utils/mono-threads-android.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <inttypes.h>
 #include "glib.h"
+#include <mono/utils/mono-threads.h>
 
 static void
 slow_get_thread_bounds (guint8 *current, guint8 **staddr, size_t *stsize)

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -72,9 +72,7 @@ typedef gsize (*MonoThreadStart)(gpointer);
 
 #endif /* #ifdef HOST_WIN32 */
 
-#ifndef MONO_INFINITE_WAIT
 #define MONO_INFINITE_WAIT ((guint32) 0xFFFFFFFF)
-#endif
 
 typedef struct {
 	MonoRefCount ref;

--- a/mono/utils/os-event.h
+++ b/mono/utils/os-event.h
@@ -11,9 +11,7 @@
 #include <mono/utils/mono-publib.h>
 #include "mono-os-mutex.h"
 
-#ifndef MONO_INFINITE_WAIT
 #define MONO_INFINITE_WAIT ((guint32) 0xFFFFFFFF)
-#endif
 
 #define MONO_OS_EVENT_WAIT_MAXIMUM_OBJECTS 64
 


### PR DESCRIPTION
```
/s/mono/mono/mini/interp/transform.c:1666:15: warning: unused variable 'vt' [-Wunused-variable]
                MonoVTable *vt = mono_class_vtable_checked (domain, target_method->klass, error);
                            ^
/s/mono/mono/utils/mono-counters.c:547:55: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'gssize' (aka 'int') [-Wformat]
                fprintf (outfile, ENTRY_FMT "%zd\n", counter->name, *(gssize*)buffer);
                                             ~~~                    ^~~~~~~~~~~~~~~~
                                             %td

/s/mono/mono/sgen/sgen-debug.c:1066:72: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'int' [-Wformat]
        fprintf (heap_dump_file, "<occupied offset=\"%zd\" size=\"%zd\"/>\n", start - section_start, end - start);
                                                     ~~~                      ^~~~~~~~~~~~~~~~~~~~~
                                                     %d
/s/mono/mono/sgen/sgen-debug.c:1066:95: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'int' [-Wformat]
        fprintf (heap_dump_file, "<occupied offset=\"%zd\" size=\"%zd\"/>\n", start - section_start, end - start);
                                                                  ~~~                                ^~~~~~~~~~~
                                                                  %d
/s/mono/mono/sgen/sgen-debug.c:1139:4: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'mword' (aka 'unsigned int') [-Wformat]
                        safe_object_get_size (obj));
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~
/s/mono/mono/sgen/sgen-debug.c:37:30: note: expanded from macro 'safe_object_get_size'
                                ^
/s/mono/mono/sgen/sgen-memory-governor.c:309:5: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'unsigned int' [-Wformat]
                                entry->promoted_size / 1024,
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~

/s/mono/mono/sgen/sgen-debug.c:1139:4: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'mword' (aka 'unsigned long long') [-Wformat]
                        safe_object_get_size (obj));
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~
/s/mono/mono/sgen/sgen-debug.c:37:30: note: expanded from macro 'safe_object_get_size'
                                ^
/s/mono/mono/metadata/w32file-unix.c:70:9: warning: 'INVALID_HANDLE_VALUE' macro redefined [-Wmacro-redefined]
        ^
/s/mono/mono/metadata/w32handle.h:19:9: note: previous definition is here
        ^
/s/mono/mono/metadata/handle.c:159:31: warning: 'extern' variable has an initializer [-Wextern-initializer]
extern MonoThreadInfo * const mono_thread_info_current_var = NULL;
                              ^
/s/mono/mono/mini/branch-opts.c:117:18: warning: unused variable 'int_cmov_opcodes' [-Wunused-const-variable]
static const int int_cmov_opcodes [] = {
                 ^
/s/mono/mono/mini/branch-opts.c:130:18: warning: unused variable 'long_cmov_opcodes' [-Wunused-const-variable]
static const int long_cmov_opcodes [] = {
                 ^
/s/mono/mono/mini/interp/interp.c:1233:1: warning: unused label 'exit_pinvoke' [-Wunused-label]
exit_pinvoke:
^~~~~~~~~~~~~
/s/mono/mono/mini/interp/interp.c:1900:1: warning: unused label 'exit_icall' [-Wunused-label]
exit_icall:
^~~~~~~~~~~

/s/mono/mono/mini/interp/transform.c:1668:7: warning: unused variable 'called_inited' [-Wunused-variable]
                int called_inited = vt->initialized;
                    ^
/s/mono/mono/utils/mono-time.c:23:34: warning: unused variable 's_TimebaseInfo' [-Wunused-variable]
static mach_timebase_info_data_t s_TimebaseInfo;
                                 ^
/s/mono/mono/sgen/sgen-debug.c:1139:4: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'mword' (aka 'unsigned long long')
      [-Wformat]
                        safe_object_get_size (obj));
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~
/s/mono/mono/sgen/sgen-debug.c:37:30: note: expanded from macro 'safe_object_get_size'
                                ^
/s/mono/mono/sgen/sgen-descriptor.c:132:52: warning: cast to 'void *' from smaller integer type 'SgenDescriptor' (aka 'unsigned int')
      [-Wint-to-void-pointer-cast]
                SGEN_LOG (6, "Ptrfree descriptor %p, size: %zd", (void*)desc, stored_size);
                                                                 ^
/s/mono/mono/sgen/sgen-descriptor.c:145:70: warning: cast to 'void *' from smaller integer type 'SgenDescriptor' (aka 'unsigned int')
      [-Wint-to-void-pointer-cast]
                SGEN_LOG (6, "Largebitmap descriptor %p, size: %zd, last set: %d", (void*)desc, stored_size, last_set);
                                                                                   ^
/s/mono/mono/sgen/sgen-descriptor.c:156:80: warning: cast to 'void *' from smaller integer type 'SgenDescriptor' (aka 'unsigned int')
      [-Wint-to-void-pointer-cast]
                        SGEN_LOG (6, "Runlen descriptor %p, size: %zd, first set: %d, num set: %d", (void*)desc, stored_size, first_set, num_set);
                                                                                                    ^
/s/mono/mono/sgen/sgen-gc.c:1252:82: warning: cast to 'void *' from smaller integer type 'SgenDescriptor' (aka 'unsigned int') [-Wint-to-void-pointer-cast]
                SGEN_LOG (6, "Precise root scan %p-%p (desc: %p)", start_root, root->end_root, (void*)root->root_desc);
                                                                                               ^
/s/mono/mono/sgen/sgen-nursery-allocator.c:800:114: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'mword'
      (aka 'unsigned long long') [-Wformat]
  ...SGEN_LOG (3, "Bastard pinning obj %p (%s), size: %zd", p, sgen_client_vtable_get_name (SGEN_LOAD_VTABLE (p)), sgen_safe_object_get_size (p));
                                                      ~~~                                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                      %llu
/s/mono/mono/sgen/sgen-gc.h:143:69: note: expanded from macro 'SGEN_LOG'
                mono_gc_printf (sgen_gc_debug_file, "%s " format "\n", logTime, ##__VA_ARGS__); \
                                                                                  ^~~~~~~~~~~
/s/mono/mono/utils/mono-logger-internals.h:109:34: note: expanded from macro 'mono_gc_printf'
        fprintf (gc_log_file, format, ##__VA_ARGS__);   \
                                        ^~~~~~~~~~~
/s/mono/mono/sgen/sgen-pinning.c:213:117: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'mword'
      (aka 'unsigned long long') [-Wformat]
  ...SGEN_LOG (3, "Bastard pinning obj %p (%s), size: %zd", ptr, sgen_client_vtable_get_name (SGEN_LOAD_VTABLE (ptr)), sgen_safe_object_get_size (ptr));
                                                      ~~~                                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                      %llu
/s/mono/mono/sgen/sgen-gc.h:143:69: note: expanded from macro 'SGEN_LOG'
                mono_gc_printf (sgen_gc_debug_file, "%s " format "\n", logTime, ##__VA_ARGS__); \
                                                                                  ^~~~~~~~~~~
/s/mono/mono/utils/mono-logger-internals.h:109:34: note: expanded from macro 'mono_gc_printf'
        fprintf (gc_log_file, format, ##__VA_ARGS__);   \
                                        ^~~~~~~~~~~
/s/mono/mono/metadata/w32file-unix.c:70:9: warning: 'INVALID_HANDLE_VALUE' macro redefined [-Wmacro-redefined]
        ^
/s/mono/mono/metadata/w32handle.h:19:9: note: previous definition is here
        ^
/s/mono/mono/metadata/handle.c:159:31: warning: 'extern' variable has an initializer [-Wextern-initializer]
extern MonoThreadInfo * const mono_thread_info_current_var = NULL;
                              ^
/s/mono/mono/metadata/sgen-mono.c:107:95: warning: cast to 'gpointer' (aka 'void *') from smaller integer type 'MonoGCDescriptor' (aka 'unsigned int')
      [-Wint-to-void-pointer-cast]
        SGEN_LOG (8, "Adding value remset at %p, count %d, descr %p for class %s (%p)", dest, count, (gpointer)m_class_get_gc_descr (klass), m_clas...
                                                                                                     ^
/s/mono/mono/metadata/sgen-mono.c:1741:83: warning: cast to 'void *' from smaller integer type 'SgenDescriptor' (aka 'unsigned int')
      [-Wint-to-void-pointer-cast]
                SGEN_LOG (6, "Profiler root scan %p-%p (desc: %p)", start_root, root->end_root, (void*)root->root_desc);
                                                                                                ^
/s/mono/mono/mini/helpers.c:72:9: warning: 'ARCH_PREFIX' macro redefined [-Wmacro-redefined]
        ^
/s/mono/mono/mini/helpers.c:68:9: note: previous definition is here
        ^
/s/mono/mono/mini/ssa.c:1119:35: warning: cast to 'gpointer' (aka 'void *') from smaller integer type 'target_mgreg_t' (aka 'int')
      [-Wint-to-void-pointer-cast]
                                        ((MonoCallInst*)ins)->fptr = (gpointer)ins->inst_imm;
                                                                     ^
/s/mono/mono/mini/local-propagation.c:680:37: warning: cast to 'gpointer' (aka 'void *') from smaller integer type 'target_mgreg_t' (aka 'int')
      [-Wint-to-void-pointer-cast]
                                                        ((MonoCallInst*)ins)->fptr = (gpointer)ins->inst_imm;
                                                                                     ^
/s/mono/mono/mini/branch-opts.c:117:18: warning: unused variable 'int_cmov_opcodes' [-Wunused-const-variable]
static const int int_cmov_opcodes [] = {
                 ^
/s/mono/mono/mini/branch-opts.c:130:18: warning: unused variable 'long_cmov_opcodes' [-Wunused-const-variable]
static const int long_cmov_opcodes [] = {
                 ^
/s/mono/mono/mini/mini-arm.c:7363:1: warning: no previous prototype for function 'mono_arch_get_seq_point_info' [-Wmissing-prototypes]
mono_arch_get_seq_point_info (MonoDomain *domain, guint8 *code)
^
/s/mono/mono/mini/exceptions-arm.c:241:65: warning: implicit conversion from 'unsigned long' to 'int' changes value from 18446744073709551612 to -4
      [-Wconstant-conversion]
        mono_add_unwind_op_offset (unwind_ops, code, start, ARMREG_LR, - sizeof (mgreg_t));
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
/s/mono/mono/mini/mini-unwind.h:132:170: note: expanded from macro 'mono_add_unwind_op_offset'
  ...do { (op_list) = g_slist_append ((op_list), mono_create_unwind_op ((code) - (buf), DW_CFA_offset, (reg), (offset))); } while (0)
                                                 ~~~~~~~~~~~~~~~~~~~~~                                         ^~~~~~
/s/mono/mono/mini/interp/interp.c:1233:1: warning: unused label 'exit_pinvoke' [-Wunused-label]
exit_pinvoke:
^~~~~~~~~~~~~
/s/mono/mono/mini/interp/interp.c:1900:1: warning: unused label 'exit_icall' [-Wunused-label]
exit_icall:
^~~~~~~~~~~
/s/mono/mono/mini/interp/transform.c:1668:7: warning: unused variable 'called_inited' [-Wunused-variable]
                int called_inited = vt->initialized;
                    ^
                                 ^
/s/mono/mono/sgen/sgen-debug.c:1139:4: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'mword' (aka 'unsigned long long')
      [-Wformat]
                        safe_object_get_size (obj));
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~
/s/mono/mono/sgen/sgen-debug.c:37:30: note: expanded from macro 'safe_object_get_size'
                                ^
/s/mono/mono/sgen/sgen-descriptor.c:132:52: warning: cast to 'void *' from smaller integer type 'SgenDescriptor' (aka 'unsigned int')
      [-Wint-to-void-pointer-cast]
                SGEN_LOG (6, "Ptrfree descriptor %p, size: %zd", (void*)desc, stored_size);
                                                                 ^
/s/mono/mono/sgen/sgen-descriptor.c:145:70: warning: cast to 'void *' from smaller integer type 'SgenDescriptor' (aka 'unsigned int')
      [-Wint-to-void-pointer-cast]
                SGEN_LOG (6, "Largebitmap descriptor %p, size: %zd, last set: %d", (void*)desc, stored_size, last_set);
                                                                                   ^
/s/mono/mono/sgen/sgen-descriptor.c:156:80: warning: cast to 'void *' from smaller integer type 'SgenDescriptor' (aka 'unsigned int')
      [-Wint-to-void-pointer-cast]
                        SGEN_LOG (6, "Runlen descriptor %p, size: %zd, first set: %d, num set: %d", (void*)desc, stored_size, first_set, num_set);
                                                                                                    ^
/s/mono/mono/sgen/sgen-gc.c:1252:82: warning: cast to 'void *' from smaller integer type 'SgenDescriptor' (aka 'unsigned int') [-Wint-to-void-pointer-cast]
                SGEN_LOG (6, "Precise root scan %p-%p (desc: %p)", start_root, root->end_root, (void*)root->root_desc);
                                                                                               ^
/s/mono/mono/sgen/sgen-nursery-allocator.c:800:114: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'mword'
      (aka 'unsigned long long') [-Wformat]
  ...SGEN_LOG (3, "Bastard pinning obj %p (%s), size: %zd", p, sgen_client_vtable_get_name (SGEN_LOAD_VTABLE (p)), sgen_safe_object_get_size (p));
                                                      ~~~                                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                      %llu
/s/mono/mono/sgen/sgen-gc.h:143:69: note: expanded from macro 'SGEN_LOG'
                mono_gc_printf (sgen_gc_debug_file, "%s " format "\n", logTime, ##__VA_ARGS__); \
                                                                                  ^~~~~~~~~~~
/s/mono/mono/utils/mono-logger-internals.h:109:34: note: expanded from macro 'mono_gc_printf'
        fprintf (gc_log_file, format, ##__VA_ARGS__);   \
                                        ^~~~~~~~~~~

/s/mono/mono/sgen/sgen-pinning.c:213:117: warning: format specifies type 'ssize_t' (aka 'long') but the argument has type 'mword'
      (aka 'unsigned long long') [-Wformat]
  ...SGEN_LOG (3, "Bastard pinning obj %p (%s), size: %zd", ptr, sgen_client_vtable_get_name (SGEN_LOAD_VTABLE (ptr)), sgen_safe_object_get_size (ptr));
                                                      ~~~                                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                      %llu
/s/mono/mono/sgen/sgen-gc.h:143:69: note: expanded from macro 'SGEN_LOG'
                mono_gc_printf (sgen_gc_debug_file, "%s " format "\n", logTime, ##__VA_ARGS__); \
                                                                                  ^~~~~~~~~~~
/s/mono/mono/utils/mono-logger-internals.h:109:34: note: expanded from macro 'mono_gc_printf'
        fprintf (gc_log_file, format, ##__VA_ARGS__);   \
                                        ^~~~~~~~~~~

/s/mono/mono/metadata/w32file-unix.c:70:9: warning: 'INVALID_HANDLE_VALUE' macro redefined [-Wmacro-redefined]
        ^
/s/mono/mono/metadata/w32handle.h:19:9: note: previous definition is here
        ^

/s/mono/mono/metadata/handle.c:159:31: warning: 'extern' variable has an initializer [-Wextern-initializer]
extern MonoThreadInfo * const mono_thread_info_current_var = NULL;
                              ^

/s/mono/mono/metadata/sgen-mono.c:107:95: warning: cast to 'gpointer' (aka 'void *') from smaller integer type 'MonoGCDescriptor' (aka 'unsigned int')
      [-Wint-to-void-pointer-cast]
        SGEN_LOG (8, "Adding value remset at %p, count %d, descr %p for class %s (%p)", dest, count, (gpointer)m_class_get_gc_descr (klass), m_clas...
                                                                                                     ^
/s/mono/mono/metadata/sgen-mono.c:1741:83: warning: cast to 'void *' from smaller integer type 'SgenDescriptor' (aka 'unsigned int')
      [-Wint-to-void-pointer-cast]
                SGEN_LOG (6, "Profiler root scan %p-%p (desc: %p)", start_root, root->end_root, (void*)root->root_desc);
                                                                                                ^
```