### PR TITLE
Fix some host64 target32 compilation warnings and errors.

### DIFF
--- a/mono/mini/exceptions-x86.c
+++ b/mono/mini/exceptions-x86.c
@@ -858,7 +858,7 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 	} else if (*lmf) {
 		g_assert ((((gsize)(*lmf)->previous_lmf) & 2) == 0);
 
-		if ((ji = mini_jit_info_table_find (domain, (gpointer)(*lmf)->eip, NULL))) {
+		if ((ji = mini_jit_info_table_find (domain, (gpointer)(uintptr_t)(*lmf)->eip, NULL))) {
 			frame->ji = ji;
 		} else {
 			if (!(*lmf)->method)

--- a/mono/mini/local-propagation.c
+++ b/mono/mini/local-propagation.c
@@ -677,7 +677,7 @@ mono_local_cprop (MonoCompile *cfg)
 						mono_inst_set_src_registers (ins, sregs);
 
 						if ((opcode2 == OP_VOIDCALL) || (opcode2 == OP_CALL) || (opcode2 == OP_LCALL) || (opcode2 == OP_FCALL))
-							((MonoCallInst*)ins)->fptr = (gpointer)ins->inst_imm;
+							((MonoCallInst*)ins)->fptr = (gpointer)(uintptr_t)ins->inst_imm;
 
 						/* Allow further iterations */
 						srcindex = -1;

--- a/mono/mini/mini-riscv.c
+++ b/mono/mini/mini-riscv.c
@@ -227,7 +227,7 @@ mono_arch_fregname (int reg)
 }
 
 gpointer
-mono_arch_get_this_arg_from_call (mgreg_t *regs, guint8 *code)
+mono_arch_get_this_arg_from_call (host_mgreg_t *regs, guint8 *code)
 {
 	return (gpointer) regs [RISCV_A0];
 }

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -5716,9 +5716,9 @@ mono_x86_get_this_arg_offset (MonoMethodSignature *sig)
 }
 
 gpointer
-mono_arch_get_this_arg_from_call (mgreg_t *regs, guint8 *code)
+mono_arch_get_this_arg_from_call (host_mgreg_t *regs, guint8 *code)
 {
-	guint32 esp = regs [X86_ESP];
+	host_mgreg_t esp = regs [X86_ESP];
 	gpointer res;
 	int offset;
 

--- a/mono/mini/mini-x86.h
+++ b/mono/mini/mini-x86.h
@@ -329,12 +329,12 @@ guint32
 mono_x86_get_this_arg_offset (MonoMethodSignature *sig);
 
 void
-mono_x86_throw_exception (mgreg_t *regs, MonoObject *exc, 
-						  mgreg_t eip, gboolean rethrow, gboolean preserve_ips);
+mono_x86_throw_exception (host_mgreg_t *regs, MonoObject *exc,
+						  host_mgreg_t eip, gboolean rethrow, gboolean preserve_ips);
 
 void
-mono_x86_throw_corlib_exception (mgreg_t *regs, guint32 ex_token_index, 
-								 mgreg_t eip, gint32 pc_offset);
+mono_x86_throw_corlib_exception (host_mgreg_t *regs, guint32 ex_token_index,
+								 host_mgreg_t eip, gint32 pc_offset);
 
 void 
 mono_x86_patch (unsigned char* code, gpointer target);

--- a/mono/mini/ssa.c
+++ b/mono/mini/ssa.c
@@ -1116,7 +1116,7 @@ fold_ins (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins, MonoInst **carray
 				ins->sreg2 = -1;
 
 				if ((opcode2 == OP_VOIDCALL) || (opcode2 == OP_CALL) || (opcode2 == OP_LCALL) || (opcode2 == OP_FCALL))
-					((MonoCallInst*)ins)->fptr = (gpointer)ins->inst_imm;
+					((MonoCallInst*)ins)->fptr = (gpointer)(uintptr_t)ins->inst_imm;
 			}
 		} else {
 			/* FIXME: Handle 3 op insns */


### PR DESCRIPTION
`uintptr_t` or `intptr_t`?

```
/s/mono/mono/mini/ssa.c:1119:35: warning: cast to 'gpointer' (aka 'void *') from smaller integer type 'target_mgreg_t' (aka 'int')
      [-Wint-to-void-pointer-cast]
                                        ((MonoCallInst*)ins)->fptr = (gpointer)ins->inst_imm;
                                                                     ^
/s/mono/mono/mini/local-propagation.c:680:37: warning: cast to 'gpointer' (aka 'void *') from smaller integer type 'target_mgreg_t' (aka 'int')
      [-Wint-to-void-pointer-cast]
                                                        ((MonoCallInst*)ins)->fptr = (gpointer)ins->inst_imm;
                                                                                     ^
/s/mono/mono/mini/mini-x86.c:5719:1: error: conflicting types for 'mono_arch_get_this_arg_from_call'
mono_arch_get_this_arg_from_call (mgreg_t *regs, guint8 *code)
^
/s/mono/mono/mini/mini.h:2406:10: note: previous declaration is here
gpointer mono_arch_get_this_arg_from_call       (host_mgreg_t *regs, guint8 *code);
         ^
/s/mono/mono/mini/mini-x86.c:5732:9: warning: cast to 'MonoObject **' (aka 'struct _MonoObject **') from smaller integer type 'guint32'
      (aka 'unsigned int') [-Wint-to-pointer-cast]
        res = ((MonoObject**)esp) [0];
               ^
```