### PR TITLE
Fix warnings and race condition in time keeping.

### DIFF
--- a/mono/utils/mono-time.c
+++ b/mono/utils/mono-time.c
@@ -108,42 +108,6 @@ mono_100ns_datetime (void)
 
 #include <time.h>
 
-#if 0
-static gint64
-get_boot_time (void)
-{
-#if defined (HAVE_SYS_PARAM_H) && defined (KERN_BOOTTIME)
-	int mib [2];
-	size_t size;
-	time_t now;
-	struct timeval boottime;
-
-	(void)time(&now);
-
-	mib [0] = CTL_KERN;
-	mib [1] = KERN_BOOTTIME;
-
-	size = sizeof(boottime);
-
-	if (sysctl(mib, 2, &boottime, &size, NULL, 0) != -1)
-		return (gint64)((now - boottime.tv_sec) * MTICKS_PER_SEC);
-#else
-	FILE *uptime = fopen ("/proc/uptime", "r");
-	if (uptime) {
-		double upt;
-		if (fscanf (uptime, "%lf", &upt) == 1) {
-			gint64 now = mono_100ns_datetime ();
-			fclose (uptime);
-			return now - (gint64)(upt * MTICKS_PER_SEC);
-		}
-		fclose (uptime);
-	}
-#endif
-	/* a made up uptime of 300 seconds */
-	return (gint64)300 * MTICKS_PER_SEC;
-}
-#endif
-
 /* Returns the number of milliseconds from boot time: this should be monotonic */
 /* Adapted from CoreCLR: https://github.com/dotnet/coreclr/blob/66d2738ea96fcce753dec1370e79a0c78f7b6adb/src/pal/src/misc/time.cpp */
 gint64


### PR DESCRIPTION
```
/s/mono/mono/utils/mono-time.c:23:34: warning: unused variable 's_TimebaseInfo' [-Wunused-variable]
static mach_timebase_info_data_t s_TimebaseInfo;

/s/mono/mono/utils/mono-time.c:112:1: warning: unused function 'get_boot_time' [-Wunused-function]
```