### PR TITLE
strftime(%F) and strftime(%T) are unnecessary unportable shorthands that warn.

### DIFF
--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -84,6 +84,9 @@ extern int tkill (pid_t tid, int signal);
 #endif
 #endif
 
+#define MONO_STRFTIME_F "%Y-%m-%d" // %F in some systems, but this works on all.
+#define MONO_STRFTIME_T "%H:%M:%S" // %T in some systems, but this works on all.
+
 /*#define THREAD_DEBUG(a) do { a; } while (0)*/
 #define THREAD_DEBUG(a)
 /*#define THREAD_WAIT_DEBUG(a) do { a; } while (0)*/
@@ -3999,7 +4002,7 @@ mono_threads_perform_thread_dump (void)
 		struct tm tod;
 		mono_get_time_of_day (&tv);
 		mono_local_time(&tv, &tod);
-		strftime(time_str, sizeof(time_str), "%Y-%m-%d_%H-%M-%S", &tod);
+		strftime(time_str, sizeof(time_str), MONO_STRFTIME_F "_" MONO_STRFTIME_T, &tod);
 		ms = tv.tv_usec / 1000;
 		g_string_append_printf (path, "%s/%s.%03ld.tdump", thread_dump_dir, time_str, ms);
 		output_file = fopen (path->str, "w");

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -84,9 +84,6 @@ extern int tkill (pid_t tid, int signal);
 #endif
 #endif
 
-#define MONO_STRFTIME_F "%Y-%m-%d" // %F in some systems, but this works on all.
-#define MONO_STRFTIME_T "%H:%M:%S" // %T in some systems, but this works on all.
-
 /*#define THREAD_DEBUG(a) do { a; } while (0)*/
 #define THREAD_DEBUG(a)
 /*#define THREAD_WAIT_DEBUG(a) do { a; } while (0)*/

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -38,6 +38,10 @@
 #include "mono/sgen/gc-internal-agnostic.h"
 #include "mono/sgen/sgen-thread-pool.h"
 
+// Expand non-portable strftime shorthands.
+#define MONO_STRFTIME_F "%Y-%m-%d" // %F in some systems, but this works on all.
+#define MONO_STRFTIME_T "%H:%M:%S" // %T in some systems, but this works on all.
+
 /* The method used to clear the nursery */
 /* Clearing at nursery collections is the safest, but has bad interactions with caches.
  * Clearing at TLAB creation is much faster, but more complex and it might expose hard
@@ -123,7 +127,7 @@ extern guint64 stat_objects_copied_major;
 		struct tm tod;									\
 		time(&t);									\
 		localtime_r(&t, &tod);								\
-		strftime(logTime, sizeof(logTime), "%Y-%m-%d %H:%M:%S", &tod);			\
+		strftime(logTime, sizeof(logTime), MONO_STRFTIME_F " " MONO_STRFTIME_T, &tod);	\
 	} while (0)
 #else
 # define LOG_TIMESTAMP  \
@@ -132,7 +136,7 @@ extern guint64 stat_objects_copied_major;
 		struct tm *tod;									\
 		time(&t);									\
 		tod = localtime(&t);								\
-		strftime(logTime, sizeof(logTime), "%F %T", tod);				\
+		strftime(logTime, sizeof(logTime), MONO_STRFTIME_F " " MONO_STRFTIME_T, tod);	\
 	} while (0)
 #endif
 

--- a/mono/sgen/sgen-gc.h
+++ b/mono/sgen/sgen-gc.h
@@ -38,10 +38,6 @@
 #include "mono/sgen/gc-internal-agnostic.h"
 #include "mono/sgen/sgen-thread-pool.h"
 
-// Expand non-portable strftime shorthands.
-#define MONO_STRFTIME_F "%Y-%m-%d" // %F in some systems, but this works on all.
-#define MONO_STRFTIME_T "%H:%M:%S" // %T in some systems, but this works on all.
-
 /* The method used to clear the nursery */
 /* Clearing at nursery collections is the safest, but has bad interactions with caches.
  * Clearing at TLAB creation is much faster, but more complex and it might expose hard

--- a/mono/utils/mono-log-common.c
+++ b/mono/utils/mono-log-common.c
@@ -28,10 +28,7 @@
 #endif
 #include "mono-logger-internals.h"
 #include "mono-proclib.h"
-
-// Expand non-portable strftime shorthands.
-#define MONO_STRFTIME_F "%Y-%m-%d" // %F in some systems, but this works on all.
-#define MONO_STRFTIME_T "%H:%M:%S" // %T in some systems, but this works on all.
+#include "mono-time.h"
 
 static FILE *logFile = NULL;
 static void *logUserData = NULL;

--- a/mono/utils/mono-log-common.c
+++ b/mono/utils/mono-log-common.c
@@ -29,6 +29,10 @@
 #include "mono-logger-internals.h"
 #include "mono-proclib.h"
 
+// Expand non-portable strftime shorthands.
+#define MONO_STRFTIME_F "%Y-%m-%d" // %F in some systems, but this works on all.
+#define MONO_STRFTIME_T "%H:%M:%S" // %T in some systems, but this works on all.
+
 static FILE *logFile = NULL;
 static void *logUserData = NULL;
 
@@ -111,12 +115,12 @@ mono_log_write_logfile (const char *log_domain, GLogLevelFlags level, mono_bool 
 		struct tm tod;
 		time(&t);
 		localtime_r(&t, &tod);
-		strftime(logTime, sizeof(logTime), "%Y-%m-%d %H:%M:%S", &tod);
+		strftime(logTime, sizeof(logTime), MONO_STRFTIME_F " " MONO_STRFTIME_T, &tod);
 #else
 		struct tm *tod;
 		time(&t);
 		tod = localtime(&t);
-		strftime(logTime, sizeof(logTime), "%F %T", tod);
+		strftime(logTime, sizeof(logTime), MONO_STRFTIME_F " " MONO_STRFTIME_T, tod);
 #endif
 
 		pid = mono_process_current_pid ();

--- a/mono/utils/mono-log-windows.c
+++ b/mono/utils/mono-log-windows.c
@@ -27,6 +27,10 @@
 #include "mono-logger-internals.h"
 #include "mono-proclib.h"
 
+// Expand non-portable strftime shorthands.
+#define MONO_STRFTIME_F "%Y-%m-%d" // %F in some systems, but this works on all.
+#define MONO_STRFTIME_T "%H:%M:%S" // %T in some systems, but this works on all.
+
 static FILE *logFile = NULL;
 static void *logUserData = NULL;
 static const wchar_t *logFileName = L".//mono.log"; // FIXME double slash
@@ -96,7 +100,7 @@ mono_log_write_syslog(const char *domain, GLogLevelFlags level, mono_bool hdr, c
 	time(&t);
 	tod = localtime(&t);
 	pid = mono_process_current_pid ();
-	strftime(logTime, sizeof(logTime), "%F %T", tod);
+	strftime(logTime, sizeof(logTime), MONO_STRFTIME_F " " MONO_STRFTIME_T, tod);
 
 	fprintf (logFile, "%s level[%c] mono[%d]: %s\n", logTime, mapLogFileLevel (level), pid, message);
 

--- a/mono/utils/mono-log-windows.c
+++ b/mono/utils/mono-log-windows.c
@@ -26,10 +26,7 @@
 #include <process.h>
 #include "mono-logger-internals.h"
 #include "mono-proclib.h"
-
-// Expand non-portable strftime shorthands.
-#define MONO_STRFTIME_F "%Y-%m-%d" // %F in some systems, but this works on all.
-#define MONO_STRFTIME_T "%H:%M:%S" // %T in some systems, but this works on all.
+#include "mono-time.h"
 
 static FILE *logFile = NULL;
 static void *logUserData = NULL;

--- a/mono/utils/mono-time.h
+++ b/mono/utils/mono-time.h
@@ -59,5 +59,8 @@ mono_stopwatch_elapsed_ms (MonoStopwatch *w)
 	return (mono_stopwatch_elapsed (w) + 500) / 1000;
 }
 
-#endif /* __UTILS_MONO_TIME_H__ */
+// Expand non-portable strftime shorthands.
+#define MONO_STRFTIME_F "%Y-%m-%d" // %F in some systems, but this works on all.
+#define MONO_STRFTIME_T "%H:%M:%S" // %T in some systems, but this works on all.
 
+#endif /* __UTILS_MONO_TIME_H__ */


### PR DESCRIPTION
Expand them to their portable equivalents.