### PR TITLE
Quash some "may be used uninitialized" warnings.

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -2384,7 +2384,7 @@ interp_entry_from_trampoline (gpointer ccontext_untyped, gpointer rmethod_untype
 	MonoMethodSignature *sig;
 	CallContext *ccontext = (CallContext*) ccontext_untyped;
 	InterpMethod *rmethod = (InterpMethod*) rmethod_untyped;
-	gpointer orig_domain, attach_cookie;
+	gpointer orig_domain = NULL, attach_cookie;
 	int i;
 
 	if (rmethod->needs_thread_attach)
@@ -2619,7 +2619,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 #endif
 	int i32;
 	unsigned char *vt_sp;
-	unsigned char *locals;
+	unsigned char *locals = NULL;
 	ERROR_DECL (error);
 	MonoObject *o = NULL;
 	MonoClass *c;

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -3395,7 +3395,7 @@ mini_handle_enum_has_flag (MonoCompile *cfg, MonoClass *klass, MonoInst *enum_th
 	}
 
 	{
-		MonoInst *load, *and_, *cmp, *ceq;
+		MonoInst *load = NULL, *and_, *cmp, *ceq;
 		int enum_reg = is_i4 ? alloc_ireg (cfg) : alloc_lreg (cfg);
 		int and_reg = is_i4 ? alloc_ireg (cfg) : alloc_lreg (cfg);
 		int dest_reg = alloc_ireg (cfg);
@@ -3413,7 +3413,7 @@ mini_handle_enum_has_flag (MonoCompile *cfg, MonoClass *klass, MonoInst *enum_th
 		ceq->type = STACK_I4;
 
 		if (!is_i4) {
-			load = mono_decompose_opcode (cfg, load);
+			load = load ? mono_decompose_opcode (cfg, load) : NULL;
 			and_ = mono_decompose_opcode (cfg, and_);
 			cmp = mono_decompose_opcode (cfg, cmp);
 			ceq = mono_decompose_opcode (cfg, ceq);


### PR DESCRIPTION
```
/s/mono/mono/mini/interp/interp.c: In function 'interp_entry_from_trampoline':
/s/mono/mono/mini/interp/interp.c:2422:3: warning: 'orig_domain' may be used uninitialized in this function [-Wmaybe-uninitialized]
   mono_threads_detach_coop (orig_domain, &attach_cookie);
   ^
/s/mono/mono/mini/interp/interp.c: In function 'interp_exec_method_full':
/s/mono/mono/mini/interp/interp.c:2695:4: warning: 'locals' may be used uninitialized in this function [-Wmaybe-uninitialized]
    memset (locals, 0, rtm->locals_size);
    ^
/s/mono/mono/mini/method-to-ir.c: In function 'mini_handle_enum_has_flag':
/s/mono/mono/mini/method-to-ir.c:3416:9: warning: 'load' may be used uninitialized in this function [-Wmaybe-uninitialized]
    load = mono_decompose_opcode (cfg, load);
         ^
```
At least the first two seem to be compiler weakness.