### PR TITLE
[wasm]  Add wasm specific assemblies to the bcl out directory

### DIFF
--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -110,21 +110,19 @@ main.exe: $(APP_SOURCES)
 mini_tests.dll: $(MINI_TEST_SOURCES) mini-test-runner.cs
 	$(CSC) $(CSC_FLAGS) /unsafe -target:library -out:$@ -define:__MOBILE__,ARCH_32 $(BCL_DEPS) /r:$(WASM_BCL_DIR)/nunitlite.dll  $(MINI_TEST_SOURCES) mini-test-runner.cs
 
-binding_tests.dll: .stamp-bindings $(BINDING_TEST_SOURCES)
+binding_tests.dll: $(WASM_BCL_DIR)/WebAssembly.Bindings.dll $(BINDING_TEST_SOURCES)
 	$(CSC) $(CSC_FLAGS) /unsafe -target:library -out:$@ /r:$(WASM_BCL_DIR)/WebAssembly.Bindings.dll $(BCL_DEPS) /r:$(WASM_BCL_DIR)/nunitlite.dll $(BINDING_TEST_SOURCES)
 
-.stamp-bindings: bindings.cs
+$(WASM_BCL_DIR)/WebAssembly.Bindings.dll: bindings.cs
 	$(CSC) $(CSC_FLAGS) /target:library -out:$(WASM_BCL_DIR)/WebAssembly.Bindings.dll /r:$(WASM_BCL_DIR)/mscorlib.dll bindings.cs
-	touch $@
 
-.stamp-http: .stamp-bindings WasmHttpMessageHandler.cs
+$(WASM_BCL_DIR)/WebAssembly.Net.Http.dll: $(WASM_BCL_DIR)/WebAssembly.Bindings.dll WasmHttpMessageHandler.cs
 	$(CSC) $(CSC_FLAGS) /target:library -out:$(WASM_BCL_DIR)/WebAssembly.Net.Http.dll /r:$(WASM_BCL_DIR)/WebAssembly.Bindings.dll /r:$(WASM_BCL_DIR)/mscorlib.dll /r:$(WASM_BCL_DIR)/System.dll /r:$(WASM_BCL_DIR)/System.Core.dll /r:$(WASM_BCL_DIR)/System.Net.dll /r:$(WASM_BCL_DIR)/System.Net.Http.dll WasmHttpMessageHandler.cs
-	touch $@
 
 Simple.Dependency.dll: dependency.cs
 	$(CSC) $(CSC_FLAGS) /target:library -out:$@ /r:$(WASM_BCL_DIR)/mscorlib.dll /r:$(WASM_BCL_DIR)/System.Core.dll dependency.cs
 
-sample.dll: Simple.Dependency.dll sample.cs .stamp-bindings .stamp-http
+sample.dll: Simple.Dependency.dll sample.cs $(WASM_BCL_DIR)/WebAssembly.Bindings.dll $(WASM_BCL_DIR)/WebAssembly.Net.Http.dll
 	$(CSC) $(CSC_FLAGS) /target:library -out:$@ /r:Simple.Dependency.dll /r:$(WASM_BCL_DIR)/mscorlib.dll /r:$(WASM_BCL_DIR)/System.dll /r:$(WASM_BCL_DIR)/System.Core.dll /r:$(WASM_BCL_DIR)/System.Net.Http.dll /r:$(WASM_BCL_DIR)/WebAssembly.Bindings.dll /r:$(WASM_BCL_DIR)/WebAssembly.Net.Http.dll sample.cs
 
 OPTIONS_CS = $(TOP)/mcs/class/Mono.Options/Mono.Options/Options.cs
@@ -136,14 +134,14 @@ Mono.Cecil.dll: $(TOP)/mcs/class/lib/wasm_tools/Mono.Cecil.dll
 packager.exe: packager.cs Mono.Cecil.dll $(OPTIONS_CS)
 	$(CSC) $(CSC_FLAGS) /out:$@ /r:Mono.Cecil.dll packager.cs $(OPTIONS_CS) /r:$(API_REFS)/mscorlib.dll /r:$(API_REFS)/System.dll /r:$(API_REFS)/System.Core.dll
 
-.stamp-build-debug-sample: $(DRIVER_CONF)/.stamp-build packager.exe .stamp-bindings .stamp-http sample.dll debug.html runtime.js
+.stamp-build-debug-sample: $(DRIVER_CONF)/.stamp-build packager.exe $(WASM_BCL_DIR)/WebAssembly.Bindings.dll $(WASM_BCL_DIR)/WebAssembly.Net.Http.dll sample.dll debug.html runtime.js
 	mono packager.exe -debug -out=debug_sample sample.dll
 	cp debug.html debug_sample
 	touch $@	
 
 TEST_ASSEMBLIES = $(WASM_BCL_DIR)/nunitlite.dll $(WASM_BCL_DIR)/tests/wasm_corlib_test.dll $(WASM_BCL_DIR)/tests/wasm_System_test.dll $(WASM_BCL_DIR)/tests/wasm_System.Core_test.dll
 
-.stamp-build-test-suite: $(DRIVER_CONF)/.stamp-build packager.exe .stamp-bindings binding_tests.dll .stamp-http mini_tests.dll main.exe runtime-tests.js
+.stamp-build-test-suite: $(DRIVER_CONF)/.stamp-build packager.exe $(WASM_BCL_DIR)/WebAssembly.Bindings.dll binding_tests.dll $(WASM_BCL_DIR)/WebAssembly.Net.Http.dll mini_tests.dll main.exe runtime-tests.js
 	mono --debug packager.exe --template=runtime-tests.js --appdir=bin/test-suite --builddir=obj/test-suite binding_tests.dll $(WASM_BCL_DIR)/WebAssembly.Net.Http.dll mini_tests.dll main.exe $(TEST_ASSEMBLIES)
 	ninja -v -C obj/test-suite
 	touch $@
@@ -232,8 +230,6 @@ run-all-%:
 	make -C . run-sm-$*
 	make -C . run-jsc-$*
 
-clean:
-
 package: build build-dbg-proxy build-framework-nuget
 	rm -rf tmp
 	mkdir tmp
@@ -260,7 +256,7 @@ package: build build-dbg-proxy build-framework-nuget
 	cp WasmHttpMessageHandler.cs tmp
 	cp $(TOP)/sdks/out/wasm-bcl/wasm/WebAssembly.Net.Http.dll tmp/framework
 	cp $(TOP)/sdks/out/wasm-bcl/wasm/WebAssembly.Net.Http.pdb tmp/framework
-	cp WebAssembly.Framework.0.1.0-alpha.nupkg tmp/framework	
+	cp WebAssembly.Framework.0.1.0-alpha.nupkg tmp/framework
 	cp sample.html tmp/
 	cp sample.cs tmp/
 	cp dependency.cs tmp/
@@ -287,17 +283,13 @@ canary:
 
 check-aot: do-aot-sample
 
-clean-mono:
-	rm -rf ./bin
-	rm -rf .stamp-build-debug-sample
-	rm -rf .stamp-build-test-suite
-	rm -rf .stamp-bindings
-	rm -rf .stamp-http
-	rm -rf WebAssembly.Bindings.dll
-	rm -rf WebAssembly.Net.Http.dll
-	rm -rf sample.dll
-	rm -rf Simple.Dependency.dll
-	rm -rf packager.exe
-	rm -rf mini_tests.dll
-	rm -rf main.exe
-	rm -rf binding-tests.dll
+clean:
+	$(RM) -r ./bin
+	$(RM) -r .stamp-build-debug-sample
+	$(RM) -r .stamp-build-test-suite
+	$(RM) -r sample.dll
+	$(RM) -r Simple.Dependency.dll
+	$(RM) -r packager.exe
+	$(RM) -r mini_tests.dll
+	$(RM) -r main.exe
+	$(RM) -r binding-tests.dll

--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -110,20 +110,22 @@ main.exe: $(APP_SOURCES)
 mini_tests.dll: $(MINI_TEST_SOURCES) mini-test-runner.cs
 	$(CSC) $(CSC_FLAGS) /unsafe -target:library -out:$@ -define:__MOBILE__,ARCH_32 $(BCL_DEPS) /r:$(WASM_BCL_DIR)/nunitlite.dll  $(MINI_TEST_SOURCES) mini-test-runner.cs
 
-binding_tests.dll: WebAssembly.Bindings.dll $(BINDING_TEST_SOURCES)
-	$(CSC) $(CSC_FLAGS) /unsafe -target:library -out:$@ /r:WebAssembly.Bindings.dll $(BCL_DEPS) /r:$(WASM_BCL_DIR)/nunitlite.dll $(BINDING_TEST_SOURCES)
+binding_tests.dll: .stamp-bindings $(BINDING_TEST_SOURCES)
+	$(CSC) $(CSC_FLAGS) /unsafe -target:library -out:$@ /r:$(WASM_BCL_DIR)/WebAssembly.Bindings.dll $(BCL_DEPS) /r:$(WASM_BCL_DIR)/nunitlite.dll $(BINDING_TEST_SOURCES)
 
-WebAssembly.Bindings.dll: bindings.cs
-	$(CSC) $(CSC_FLAGS) /target:library -out:$@ /r:$(WASM_BCL_DIR)/mscorlib.dll bindings.cs
+.stamp-bindings: bindings.cs
+	$(CSC) $(CSC_FLAGS) /target:library -out:$(WASM_BCL_DIR)/WebAssembly.Bindings.dll /r:$(WASM_BCL_DIR)/mscorlib.dll bindings.cs
+	touch $@
 
-WebAssembly.Net.Http.dll: WebAssembly.Bindings.dll WasmHttpMessageHandler.cs
-	$(CSC) $(CSC_FLAGS) /target:library -out:$@ /r:WebAssembly.Bindings.dll /r:$(WASM_BCL_DIR)/mscorlib.dll /r:$(WASM_BCL_DIR)/System.dll /r:$(WASM_BCL_DIR)/System.Core.dll /r:$(WASM_BCL_DIR)/System.Net.dll /r:$(WASM_BCL_DIR)/System.Net.Http.dll WasmHttpMessageHandler.cs
+.stamp-http: .stamp-bindings WasmHttpMessageHandler.cs
+	$(CSC) $(CSC_FLAGS) /target:library -out:$(WASM_BCL_DIR)/WebAssembly.Net.Http.dll /r:$(WASM_BCL_DIR)/WebAssembly.Bindings.dll /r:$(WASM_BCL_DIR)/mscorlib.dll /r:$(WASM_BCL_DIR)/System.dll /r:$(WASM_BCL_DIR)/System.Core.dll /r:$(WASM_BCL_DIR)/System.Net.dll /r:$(WASM_BCL_DIR)/System.Net.Http.dll WasmHttpMessageHandler.cs
+	touch $@
 
 Simple.Dependency.dll: dependency.cs
 	$(CSC) $(CSC_FLAGS) /target:library -out:$@ /r:$(WASM_BCL_DIR)/mscorlib.dll /r:$(WASM_BCL_DIR)/System.Core.dll dependency.cs
 
-sample.dll: Simple.Dependency.dll sample.cs WebAssembly.Bindings.dll WebAssembly.Net.Http.dll
-	$(CSC) $(CSC_FLAGS) /target:library -out:$@ /r:Simple.Dependency.dll /r:$(WASM_BCL_DIR)/mscorlib.dll /r:$(WASM_BCL_DIR)/System.dll /r:$(WASM_BCL_DIR)/System.Core.dll /r:$(WASM_BCL_DIR)/System.Net.Http.dll /r:WebAssembly.Bindings.dll /r:WebAssembly.Net.Http.dll sample.cs
+sample.dll: Simple.Dependency.dll sample.cs .stamp-bindings .stamp-http
+	$(CSC) $(CSC_FLAGS) /target:library -out:$@ /r:Simple.Dependency.dll /r:$(WASM_BCL_DIR)/mscorlib.dll /r:$(WASM_BCL_DIR)/System.dll /r:$(WASM_BCL_DIR)/System.Core.dll /r:$(WASM_BCL_DIR)/System.Net.Http.dll /r:$(WASM_BCL_DIR)/WebAssembly.Bindings.dll /r:$(WASM_BCL_DIR)/WebAssembly.Net.Http.dll sample.cs
 
 OPTIONS_CS = $(TOP)/mcs/class/Mono.Options/Mono.Options/Options.cs
 
@@ -134,15 +136,15 @@ Mono.Cecil.dll: $(TOP)/mcs/class/lib/wasm_tools/Mono.Cecil.dll
 packager.exe: packager.cs Mono.Cecil.dll $(OPTIONS_CS)
 	$(CSC) $(CSC_FLAGS) /out:$@ /r:Mono.Cecil.dll packager.cs $(OPTIONS_CS) /r:$(API_REFS)/mscorlib.dll /r:$(API_REFS)/System.dll /r:$(API_REFS)/System.Core.dll
 
-.stamp-build-debug-sample: $(DRIVER_CONF)/.stamp-build packager.exe WebAssembly.Bindings.dll WebAssembly.Net.Http.dll sample.dll debug.html runtime.js
+.stamp-build-debug-sample: $(DRIVER_CONF)/.stamp-build packager.exe .stamp-bindings .stamp-http sample.dll debug.html runtime.js
 	mono packager.exe -debug -out=debug_sample sample.dll
 	cp debug.html debug_sample
 	touch $@	
 
 TEST_ASSEMBLIES = $(WASM_BCL_DIR)/nunitlite.dll $(WASM_BCL_DIR)/tests/wasm_corlib_test.dll $(WASM_BCL_DIR)/tests/wasm_System_test.dll $(WASM_BCL_DIR)/tests/wasm_System.Core_test.dll
 
-.stamp-build-test-suite: $(DRIVER_CONF)/.stamp-build packager.exe WebAssembly.Bindings.dll binding_tests.dll WebAssembly.Net.Http.dll mini_tests.dll main.exe runtime-tests.js
-	mono --debug packager.exe --template=runtime-tests.js --appdir=bin/test-suite --builddir=obj/test-suite binding_tests.dll WebAssembly.Net.Http.dll mini_tests.dll main.exe $(TEST_ASSEMBLIES)
+.stamp-build-test-suite: $(DRIVER_CONF)/.stamp-build packager.exe .stamp-bindings binding_tests.dll .stamp-http mini_tests.dll main.exe runtime-tests.js
+	mono --debug packager.exe --template=runtime-tests.js --appdir=bin/test-suite --builddir=obj/test-suite binding_tests.dll $(WASM_BCL_DIR)/WebAssembly.Net.Http.dll mini_tests.dll main.exe $(TEST_ASSEMBLIES)
 	ninja -v -C obj/test-suite
 	touch $@
 
@@ -169,7 +171,7 @@ check-aot-mini run-aot-mini: build-aot-mini
 define AotTestTemplate
 
 build-aot-$(1): packager.exe runtime-tests.js main.exe WebAssembly.Bindings.dll binding_tests.dll $$(WASM_BCL_DIR)/nunitlite.dll $$(WASM_BCL_DIR)/tests/$(2)
-	mono packager.exe --emscripten-sdkdir=$$(EMSCRIPTEN_SDKDIR) --mono-sdkdir=$$(TOP)/sdks/out -appdir=bin/aot-$(1) --nobinding --builddir=obj/aot-$(1) --aot --template=runtime-tests.js main.exe WebAssembly.Bindings.dll binding_tests.dll $$(WASM_BCL_DIR)/tests/$(2)
+	mono packager.exe --emscripten-sdkdir=$$(EMSCRIPTEN_SDKDIR) --mono-sdkdir=$$(TOP)/sdks/out -appdir=bin/aot-$(1) --nobinding --builddir=obj/aot-$(1) --aot --template=runtime-tests.js main.exe $(WASM_BCL_DIR)/WebAssembly.Bindings.dll binding_tests.dll $$(WASM_BCL_DIR)/tests/$(2)
 	ninja -v -C obj/aot-$(1)
 
 clean-aot-$(1):
@@ -253,12 +255,12 @@ package: build build-dbg-proxy build-framework-nuget
 	rm tmp/release/.stamp-build
 	cp bindings.cs tmp
 	mkdir tmp/framework
-	cp WebAssembly.Bindings.dll tmp/framework
-	cp WebAssembly.Bindings.pdb tmp/framework
+	cp $(TOP)/sdks/out/wasm-bcl/wasm/WebAssembly.Bindings.dll tmp/framework
+	cp $(TOP)/sdks/out/wasm-bcl/wasm/WebAssembly.Bindings.pdb tmp/framework
 	cp WasmHttpMessageHandler.cs tmp
-	cp WebAssembly.Net.Http.dll tmp/framework
-	cp WebAssembly.Net.Http.pdb tmp/framework
-	cp WebAssembly.Framework.0.1.0-alpha.nupkg tmp/framework
+	cp $(TOP)/sdks/out/wasm-bcl/wasm/WebAssembly.Net.Http.dll tmp/framework
+	cp $(TOP)/sdks/out/wasm-bcl/wasm/WebAssembly.Net.Http.pdb tmp/framework
+	cp WebAssembly.Framework.0.1.0-alpha.nupkg tmp/framework	
 	cp sample.html tmp/
 	cp sample.cs tmp/
 	cp dependency.cs tmp/
@@ -284,3 +286,18 @@ canary:
 	/Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary --remote-debugging-port=9222
 
 check-aot: do-aot-sample
+
+clean-mono:
+	rm -rf ./bin
+	rm -rf .stamp-build-debug-sample
+	rm -rf .stamp-build-test-suite
+	rm -rf .stamp-bindings
+	rm -rf .stamp-http
+	rm -rf WebAssembly.Bindings.dll
+	rm -rf WebAssembly.Net.Http.dll
+	rm -rf sample.dll
+	rm -rf Simple.Dependency.dll
+	rm -rf packager.exe
+	rm -rf mini_tests.dll
+	rm -rf main.exe
+	rm -rf binding-tests.dll

--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -168,8 +168,8 @@ check-aot-mini run-aot-mini: build-aot-mini
 # $(3) - main.exe argument
 define AotTestTemplate
 
-build-aot-$(1): packager.exe runtime-tests.js main.exe WebAssembly.Bindings.dll binding_tests.dll $$(WASM_BCL_DIR)/nunitlite.dll $$(WASM_BCL_DIR)/tests/$(2)
-	mono packager.exe --emscripten-sdkdir=$$(EMSCRIPTEN_SDKDIR) --mono-sdkdir=$$(TOP)/sdks/out -appdir=bin/aot-$(1) --nobinding --builddir=obj/aot-$(1) --aot --template=runtime-tests.js main.exe $(WASM_BCL_DIR)/WebAssembly.Bindings.dll binding_tests.dll $$(WASM_BCL_DIR)/tests/$(2)
+build-aot-$(1): packager.exe runtime-tests.js main.exe $$(WASM_BCL_DIR)/WebAssembly.Bindings.dll binding_tests.dll $$(WASM_BCL_DIR)/nunitlite.dll $$(WASM_BCL_DIR)/tests/$(2)
+	mono packager.exe --emscripten-sdkdir=$$(EMSCRIPTEN_SDKDIR) --mono-sdkdir=$$(TOP)/sdks/out -appdir=bin/aot-$(1) --nobinding --builddir=obj/aot-$(1) --aot --template=runtime-tests.js main.exe $$(WASM_BCL_DIR)/WebAssembly.Bindings.dll binding_tests.dll $$(WASM_BCL_DIR)/tests/$(2)
 	ninja -v -C obj/aot-$(1)
 
 clean-aot-$(1):

--- a/sdks/wasm/WebAssembly.Framework.nuspec
+++ b/sdks/wasm/WebAssembly.Framework.nuspec
@@ -16,9 +16,9 @@
   </metadata>
   <files>
     <!--file src="./WebAssembly.Framework/readme.txt" target="readme.txt" /-->
-    <file src="./WebAssembly.Bindings.dll" target="lib/portable/WebAssembly.Bindings.dll" />
-    <file src="./WebAssembly.Bindings.pdb" target="lib/portable/WebAssembly.Bindings.pdb" />
-    <file src="./WebAssembly.Net.Http.dll" target="lib/portable/WebAssembly.Net.Http.dll" />
-    <file src="./WebAssembly.Net.Http.pdb" target="lib/portable/WebAssembly.Net.Http.pdb" />
+    <file src="../out/wasm-bcl/wasm/WebAssembly.Bindings.dll" target="lib/portable/WebAssembly.Bindings.dll" />
+    <file src="../out/wasm-bcl/wasm/WebAssembly.Bindings.pdb" target="lib/portable/WebAssembly.Bindings.pdb" />
+    <file src="../out/wasm-bcl/wasm/WebAssembly.Net.Http.dll" target="lib/portable/WebAssembly.Net.Http.dll" />
+    <file src="../out/wasm-bcl/wasm/WebAssembly.Net.Http.pdb" target="lib/portable/WebAssembly.Net.Http.pdb" />
   </files>
 </package>

--- a/sdks/wasm/binding_support.js
+++ b/sdks/wasm/binding_support.js
@@ -2,7 +2,7 @@
 var BindingSupportLib = {
 	$BINDING__postset: 'BINDING.export_functions (Module);',
 	$BINDING: {
-		BINDING_ASM: "[binding_tests]WebAssembly.Runtime",
+		BINDING_ASM: "[WebAssembly.Bindings]WebAssembly.Runtime",
 		mono_wasm_object_registry: [],
 		mono_wasm_ref_counter: 0,
 		mono_wasm_free_list: [],

--- a/sdks/wasm/packager.cs
+++ b/sdks/wasm/packager.cs
@@ -300,7 +300,7 @@ class Driver {
 			Import (resolved, kind);
 		}
 		if (add_binding)
-			Import (ResolveFramework (BINDINGS_ASM_NAME + ".dll"), AssemblyKind.Framework);
+			Import (ResolveBcl (BINDINGS_ASM_NAME + ".dll"), AssemblyKind.Framework);
 
 		if (builddir != null) {
 			emit_ninja = true;

--- a/sdks/wasm/packager.cs
+++ b/sdks/wasm/packager.cs
@@ -37,7 +37,6 @@ class Driver {
 
 	enum AssemblyKind {
 		User,
-		Framework,
 		Bcl,
 		None,
 	}
@@ -101,10 +100,6 @@ class Driver {
 		return ResolveWithExtension (app_prefix, asm_name);
 	}
 
-	static string ResolveFramework (string asm_name) {
-		return ResolveWithExtension (framework_prefix, asm_name);
-	}
-
 	static string ResolveBcl (string asm_name) {
 		return ResolveWithExtension (bcl_prefix, asm_name);
 	}
@@ -116,11 +111,6 @@ class Driver {
 	static string Resolve (string asm_name, out AssemblyKind kind) {
 		kind = AssemblyKind.User;
 		var asm = ResolveUser (asm_name);
-		if (asm != null)
-			return asm;
-
-		kind = AssemblyKind.Framework;
-		asm = ResolveFramework (asm_name);
 		if (asm != null)
 			return asm;
 
@@ -300,7 +290,7 @@ class Driver {
 			Import (resolved, kind);
 		}
 		if (add_binding)
-			Import (ResolveBcl (BINDINGS_ASM_NAME + ".dll"), AssemblyKind.Framework);
+			Import (ResolveBcl (BINDINGS_ASM_NAME + ".dll"), AssemblyKind.Bcl);
 
 		if (builddir != null) {
 			emit_ninja = true;


### PR DESCRIPTION
- Small cleanup to the initialisation of the Bindings.

resolves https://github.com/mono/mono/issues/11856