### PR TITLE
Increase number of compiled LLVM methods on Windows x64.

### DIFF
--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -2166,6 +2166,10 @@ mono_arch_get_llvm_call_info (MonoCompile *cfg, MonoMethodSignature *sig)
 		case ArgGSharedVtOnStack:
 			linfo->args [i].storage = LLVMArgGSharedVt;
 			break;
+		case ArgValuetypeAddrInIReg:
+		case ArgValuetypeAddrOnStack:
+			linfo->args [i].storage = LLVMArgVtypeByRef;
+			break;
 		default:
 			cfg->exception_message = g_strdup ("ainfo->storage");
 			cfg->disable_llvm = TRUE;


### PR DESCRIPTION
* Add support for additional calling conventions supported on Windows x64.
* Add support for more call info storage types used on Windows x64.