### PR TITLE
[2018-10] Do not truncate 64bit MERP hashes to 32bits.

### DIFF
--- a/mono/utils/mono-merp.c
+++ b/mono/utils/mono-merp.c
@@ -224,12 +224,12 @@ mono_encode_merp_params (MERPStruct *merp)
 	// Provided by icall
 	g_string_append_printf (output, "BlameModuleName: %s\n", merp->moduleName);
 	g_string_append_printf (output, "BlameModuleVersion: %s\n", merp->moduleVersion);
-	g_string_append_printf (output, "BlameModuleOffset: 0x%x\n", merp->moduleOffset);
+	g_string_append_printf (output, "BlameModuleOffset: 0x%llx\n", (unsigned long long)merp->moduleOffset);
 
 	g_string_append_printf (output, "ExceptionType: %s\n", get_merp_exctype (merp->exceptionArg));
 
-	g_string_append_printf (output, "StackChecksum: 0x%x\n", merp->hashes.offset_free_hash);
-	g_string_append_printf (output, "StackHash: 0x%x\n", merp->hashes.offset_rich_hash);
+	g_string_append_printf (output, "StackChecksum: 0x%llx\n", merp->hashes.offset_free_hash);
+	g_string_append_printf (output, "StackHash: 0x%llx\n", merp->hashes.offset_rich_hash);
 
 	// Provided by icall
 	g_string_append_printf (output, "OSVersion: %s\n", merp->osVersion);


### PR DESCRIPTION
This might invalidate all existing data however and perhaps 32bits is enough.
```
/s/mono/mono/utils/mono-merp.c:227:63: warning: format specifies type 'unsigned int' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
    g_string_append_printf (output, "BlameModuleOffset: 0x%x\n", merp->moduleOffset);
							  ~~     ^~~~~~~~~~~~~~~~~~
							  %zx
/s/mono/mono/utils/mono-merp.c:231:59: warning: format specifies type 'unsigned int' but the argument has type 'guint64' (aka 'unsigned long long')
  [-Wformat]
    g_string_append_printf (output, "StackChecksum: 0x%x\n", merp->hashes.offset_free_hash);
						      ~~     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
						      %llx
/s/mono/mono/utils/mono-merp.c:232:55: warning: format specifies type 'unsigned int' but the argument has type 'guint64' (aka 'unsigned long long')
  [-Wformat]
    g_string_append_printf (output, "StackHash: 0x%x\n", merp->hashes.offset_rich_hash);
						  ~~     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
						  %llx
```
The first one isn't really a truncation but fix the warning.
Or use guint32 for module offsets instead of size_t.

Backport of #11864.

/cc @alexanderkyte @jaykrell