### PR TITLE
Fix https://github.com/mono/mono/issues/11898

### DIFF
--- a/mono/metadata/marshal-internals.h
+++ b/mono/metadata/marshal-internals.h
@@ -14,7 +14,7 @@ MonoObjectHandle
 mono_marshal_xdomain_copy_value_handle (MonoObjectHandle val, MonoError *error);
 
 // On Windows platform implementation of bellow methods are hosted in separate source file
-// masrshal-windows.c or marshal-windows-*.c. On other platforms the implementation is still keept
+// marshal-windows.c or marshal-windows-*.c. On other platforms the implementation is still keept
 // in marshal.c still declared as static and in some places even inlined.
 #ifdef HOST_WIN32
 void*
@@ -35,9 +35,22 @@ mono_marshal_realloc_hglobal (gpointer ptr, size_t size);
 void
 mono_marshal_free_hglobal (void *ptr);
 
+// Allocates with CoTaskMemAlloc. Free with mono_marshal_free (CoTaskMemFree).
+gpointer
+mono_string_to_utf8str_handle (MonoStringHandle s, MonoError *error);
+
+#else
+
+// Allocates with g_malloc. Free with mono_marshal_free (g_free).
+#define mono_string_to_utf8str_handle mono_string_handle_to_utf8
+
+#endif // HOST_WIN32
+
+// Windows: Allocates with CoTaskMemAlloc.
+// Unix: Allocates with g_malloc.
+// Either way: Free with mono_marshal_free (Windows:CoTaskMemFree, Unix:g_free).
 gpointer
 mono_string_to_utf8str (MonoString *s);
-#endif  /* HOST_WIN32 */
 
 typedef enum {
 	TYPECHECK_OBJECT_ARG_POS = 0,

--- a/mono/metadata/marshal-windows.c
+++ b/mono/metadata/marshal-windows.c
@@ -113,16 +113,4 @@ mono_string_to_utf8str_handle (MonoStringHandle s, MonoError *error)
 	}
 }
 
-/* This is a JIT icall, it sets the pending exception and returns NULL on error. */
-gpointer
-mono_string_to_utf8str (MonoString *s_raw)
-{
-	HANDLE_FUNCTION_ENTER ();
-	ERROR_DECL (error);
-	MONO_HANDLE_DCL (MonoString, s);
-	gpointer result = mono_string_to_utf8str_handle (s, error);
-	mono_error_set_pending_exception (error);
-	HANDLE_FUNCTION_RETURN_VAL (result);
-}
-
 #endif /* HOST_WIN32 */

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -1039,8 +1039,6 @@ mono_string_builder_to_utf16 (MonoStringBuilder *sb)
 	return str;
 }
 
-#ifndef HOST_WIN32
-
 /* This is a JIT icall, it sets the pending exception and returns NULL on error. */
 gpointer
 mono_string_to_utf8str (MonoString *s_raw)
@@ -1048,17 +1046,10 @@ mono_string_to_utf8str (MonoString *s_raw)
 	HANDLE_FUNCTION_ENTER ();
 	ERROR_DECL (error);
 	MONO_HANDLE_DCL (MonoString, s);
-	gpointer result = mono_string_handle_to_utf8 (s, error);
+	gpointer result = mono_string_to_utf8str_handle (s, error);
 	mono_error_set_pending_exception (error);
 	HANDLE_FUNCTION_RETURN_VAL (result);
 }
-
-
-#else
-
-// Win32 version uses CoTaskMemAlloc.
-
-#endif
 
 gpointer
 mono_string_to_ansibstr (MonoString *string_obj)
@@ -5878,7 +5869,7 @@ mono_marshal_asany_handle (MonoObjectHandle o, MonoMarshalNative string_encoding
 		case MONO_NATIVE_LPSTR:
 		case MONO_NATIVE_UTF8STR:
 			// Same code path, because in Mono, we treated strings as Utf8
-			return mono_string_handle_to_utf8 (MONO_HANDLE_CAST (MonoString, o), error);
+			return mono_string_to_utf8str_handle (MONO_HANDLE_CAST (MonoString, o), error);
 		default:
 			g_warning ("marshaling conversion %d not implemented", string_encoding);
 			g_assert_not_reached ();


### PR DESCRIPTION
Fix https://github.com/mono/mono/issues/11898
This regressed six months ago at https://github.com/mono/mono/pull/9503/files#r238093574.

There are two identical sounding functions:

mono_string_handle_to_utf8:
  What we usually use. Sounds reasonable. Usually is reasonable.
  Allocates with malloc.

mono_string_to_utf8str_handle:
  What should be used here. Allocates with CoTaskMemAlloc.
  So it can be freed with marshal_free => CoTaskMemFree.

i.e. The allocator and the freeer need to agree.