### PR TITLE
Enable and correctly handle certificate revocation checks.

### DIFF
--- a/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsSettings.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Interface/MonoTlsSettings.cs
@@ -118,7 +118,7 @@ namespace Mono.Security.Interface
 
 		bool cloned = false;
 		bool checkCertName = true;
-		bool checkCertRevocationStatus = false;
+		bool checkCertRevocationStatus = true;
 		bool? useServicePointManagerCallback = null;
 		bool skipSystemValidators = false;
 		bool callbackNeedsChain = true;

--- a/mcs/class/System/Mono.AppleTls/AppleTlsContext.cs
+++ b/mcs/class/System/Mono.AppleTls/AppleTlsContext.cs
@@ -272,7 +272,7 @@ namespace Mono.AppleTls
 				ok = ValidateCertificate (certificates);
 			} catch (Exception ex) {
 				Debug ("Certificate validation failed: {0}", ex);
-				throw new TlsException (AlertDescription.CertificateUnknown, "Certificate validation threw exception.");
+				throw;
 			} finally {
 				if (trust != null)
 					trust.Dispose ();

--- a/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
@@ -199,6 +199,7 @@ namespace Mono.Btls
 				case MonoBtlsSslError.WantWrite:
 					return false;
 				default:
+					ctx.CheckLastError ();
 					throw GetException (status);
 				}
 			}

--- a/mcs/class/System/Mono.Btls/MonoBtlsX509VerifyParam.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsX509VerifyParam.cs
@@ -26,6 +26,7 @@
 #if SECURITY_DEP && MONO_FEATURE_BTLS
 using System;
 using System.IO;
+using System.Security.Cryptography.X509Certificates;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 
@@ -232,6 +233,27 @@ namespace Mono.Btls
 			var ret = mono_btls_x509_verify_param_set_mono_flags (
 				Handle.DangerousGetHandle (), flags);
 			CheckError (ret);
+		}
+
+		public X509RevocationMode GetCertRevocationMode ()
+		{
+			var flags = GetMonoFlags ();
+			if ((flags & (MonoBtlsX509VerifyFlags.CRL_CHECK | MonoBtlsX509VerifyFlags.CRL_CHECK_ALL)) != 0)
+				return X509RevocationMode.Online;
+			return X509RevocationMode.NoCheck;
+		}
+
+		public void SetCertRevocationMode (X509RevocationMode mode)
+		{
+			switch (mode) {
+			case X509RevocationMode.Offline:
+			case X509RevocationMode.Online:
+				SetMonoFlags (MonoBtlsX509VerifyFlags.CRL_CHECK | MonoBtlsX509VerifyFlags.CRL_CHECK_ALL);
+				break;
+			default:
+				SetMonoFlags (MonoBtlsX509VerifyFlags.DEFAULT);
+				break;
+			}
 		}
 
 		public void SetPurpose (MonoBtlsX509Purpose purpose)

--- a/mcs/class/System/Mono.Btls/X509ChainImplBtls.cs
+++ b/mcs/class/System/Mono.Btls/X509ChainImplBtls.cs
@@ -63,6 +63,9 @@ namespace Mono.Btls
 
 			policy = new X509ChainPolicy ();
 
+			using (var param = storeCtx.GetVerifyParam ())
+				policy.RevocationMode = param.GetCertRevocationMode ();
+
 			untrustedChain = storeCtx.GetUntrusted ();
 
 			if (untrustedChain != null) {
@@ -132,7 +135,7 @@ namespace Mono.Btls
 
 		public override X509ChainStatus[] ChainStatus {
 			get { 
-				return chainStatusList.ToArray();
+				return chainStatusList?.ToArray() ?? new X509ChainStatus[0];
 			}
 		}
 

--- a/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
+++ b/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
@@ -103,6 +103,8 @@ namespace Mono.Net.Security
 			private set;
 		}
 
+		public bool CheckCertRevocationStatus => Settings.CheckCertificateRevocationStatus;
+
 		internal void CheckThrow (bool authSuccessCheck, bool shutdownCheck = false)
 		{
 			if (lastException != null)
@@ -1106,11 +1108,6 @@ namespace Mono.Net.Security
 			}
 		}
 		public int KeyExchangeStrength {
-			get {
-				throw new NotImplementedException ();
-			}
-		}
-		public bool CheckCertRevocationStatus {
 			get {
 				throw new NotImplementedException ();
 			}

--- a/mcs/class/System/System.Net.Security/SslStream.cs
+++ b/mcs/class/System/System.Net.Security/SslStream.cs
@@ -156,6 +156,15 @@ namespace System.Net.Security
 			return sslStream.Impl;
 		}
 
+		void SetFromClientOptions (SslClientAuthenticationOptions options)
+		{
+			SetAndVerifyValidationCallback (options.RemoteCertificateValidationCallback);
+			SetAndVerifySelectionCallback (options.LocalCertificateSelectionCallback);
+
+			if (!explicitSettings)
+				settings.CheckCertificateRevocationStatus = options.CertificateRevocationCheckMode != X509RevocationMode.NoCheck;
+		}
+
 		void SetAndVerifyValidationCallback (RemoteCertificateValidationCallback callback)
 		{
 			if (validationCallback == null) {
@@ -268,8 +277,7 @@ namespace System.Net.Security
 
 		public Task AuthenticateAsClientAsync (SslClientAuthenticationOptions sslClientAuthenticationOptions, CancellationToken cancellationToken)
 		{
-			SetAndVerifyValidationCallback (sslClientAuthenticationOptions.RemoteCertificateValidationCallback);
-			SetAndVerifySelectionCallback (sslClientAuthenticationOptions.LocalCertificateSelectionCallback);
+			SetFromClientOptions (sslClientAuthenticationOptions);
 			return Impl2.AuthenticateAsClientAsync (new MNS.MonoSslClientAuthenticationOptions (sslClientAuthenticationOptions), cancellationToken);
 		}
 

--- a/mono/btls/btls-x509-verify-param.c
+++ b/mono/btls/btls-x509-verify-param.c
@@ -146,9 +146,6 @@ mono_btls_x509_verify_param_get_mono_flags (MonoBtlsX509VerifyParam *param)
 	MonoBtlsX509VerifyFlags current;
 	uint64_t flags;
 
-	if (!param->owns)
-		return -1;
-
 	current = 0;
 	flags = X509_VERIFY_PARAM_get_flags (param->param);
 


### PR DESCRIPTION
* `MonoTlsSettings.CheckCertificateRevocationStatus`: change default value to `true`.

* If a user-provided certificate validation callback threw an exception, propagate that
  exception rather than wrapping it in `TlsException`.

* `SslStream.AuthenticateAsClientAsync(SslClientAuthenticationOptions, CancellationToken)`:
  If no explicit `MonoTlsSettings` has been provided (via the Mono-specific constructor),
  then set its `CheckCertificateRevocationStatus` from the `SslClientAuthenticationOptions`.

* `MonoBtlsX509VerifyParam`: add `SetCertRevocationMode` and `GetCertRevocationMode`.

* `X509ChainImplBtls`:
  - set `X509ChainPolicy.RevocationMode` from the `MonoBtlsX509VerifyParam`.
  - `ChainStatus` now returns an empty array instead of null.

* `MonoBtlsProvider.CheckValidationResult`: add `MonoSslPolicyErrors.RemoteCertificateNameMismatch`.
