### PR TITLE
Fix lack of symbols in System.Native support lib on AIX

### DIFF
--- a/mono/native/Makefile.am
+++ b/mono/native/Makefile.am
@@ -48,6 +48,8 @@ ios_sources = \
 
 linux_sources = $(unix_sources)
 
+aix_sources = $(unix_sources)
+
 unix_sources = \
 	pal-icalls.h \
 	pal-icalls.c \
@@ -72,7 +74,7 @@ macos_sources += $(gss_sources)
 ios_sources += $(gss_sources)
 endif
 
-EXTRA_libmono_native_la_SOURCES = $(common_sources) $(macos_sources) $(ios_sources) $(linux_sources) $(unix_sources) $(gss_sources)
+EXTRA_libmono_native_la_SOURCES = $(common_sources) $(macos_sources) $(ios_sources) $(linux_sources) $(aix_sources) $(unix_sources) $(gss_sources)
 
 if MONO_NATIVE_PLATFORM_MACOS
 platform_sources = $(macos_sources)
@@ -82,6 +84,10 @@ platform_sources = $(ios_sources)
 else
 if MONO_NATIVE_PLATFORM_LINUX
 platform_sources = $(linux_sources)
+else
+if MONO_NATIVE_PLATFORM_AIX
+platform_sources = $(aix_sources)
+endif
 endif
 endif
 endif


### PR DESCRIPTION
I forgot to fix Makefile.am to check for AIX and include the unix
sources if so. Actually fixes #11895.