### PR TITLE
[2018-08] [exceptions] Verbose logging for cfa_reg assertion

### DIFF
--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -871,44 +871,6 @@ mono_runtime_setup_stat_profiler (void)
 #endif /* defined(HOST_WATCHOS) */
 
 #ifndef MONO_CROSS_COMPILE
-static gchar
-conv_ascii_char (gchar s)
-{
-	if (s < 0x20)
-		return '.';
-	if (s > 0x7e)
-		return '.';
-	return s;
-}
-
-static void
-xxd_mem (gpointer d, int len)
-{
-	guint8 *data = (guint8 *) d;
-
-	for (int off = 0; off < len; off += 0x10) {
-		gchar *line = g_strdup_printf ("%p  ", data + off);
-
-		for (int i = 0; i < 0x10; i++) {
-			if ((i + off) >= len)
-				line = g_strdup_printf ("%s   ", line);
-			else
-				line = g_strdup_printf ("%s%02x ", line, data [off + i]);
-		}
-
-		line = g_strdup_printf ("%s ", line);
-
-		for (int i = 0; i < 0x10; i++) {
-			if ((i + off) >= len)
-				line = g_strdup_printf ("%s ", line);
-			else
-				line = g_strdup_printf ("%s%c", line, conv_ascii_char (data [off + i]));
-		}
-
-		mono_runtime_printf_err ("%s", line);
-	}
-}
-
 static void
 dump_memory_around_ip (void *ctx)
 {
@@ -918,7 +880,7 @@ dump_memory_around_ip (void *ctx)
 	gpointer native_ip = MONO_CONTEXT_GET_IP (&mctx);
 	if (native_ip) {
 		mono_runtime_printf_err ("Memory around native instruction pointer (%p):", native_ip);
-		xxd_mem (((guint8 *) native_ip) - 0x10, 0x40);
+		mono_dump_mem (((guint8 *) native_ip) - 0x10, 0x40);
 	} else {
 		mono_runtime_printf_err ("instruction pointer is NULL, skip dumping");
 	}

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -172,8 +172,8 @@ find_tramp (gpointer key, gpointer value, gpointer user_data)
 }
 
 /* debug function */
-G_GNUC_UNUSED static char*
-get_method_from_ip (void *ip)
+char*
+mono_get_method_from_ip (void *ip)
 {
 	MonoJitInfo *ji;
 	MonoMethod *method;
@@ -238,7 +238,7 @@ get_method_from_ip (void *ip)
 G_GNUC_UNUSED char *
 mono_pmip (void *ip)
 {
-	return get_method_from_ip (ip);
+	return mono_get_method_from_ip (ip);
 }
 
 /**

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2674,6 +2674,7 @@ gboolean mini_gsharedvt_runtime_invoke_supported (MonoMethodSignature *sig);
 void mono_interp_entry_from_trampoline (gpointer ccontext, gpointer imethod);
 MonoMethod* mini_get_interp_in_wrapper (MonoMethodSignature *sig);
 MonoMethod* mini_get_interp_lmf_wrapper (void);
+char* mono_get_method_from_ip (void *ip);
 
 /* SIMD support */
 

--- a/mono/mini/unwind.c
+++ b/mono/mini/unwind.c
@@ -14,6 +14,7 @@
 #include <mono/utils/mono-counters.h>
 #include <mono/utils/freebsd-dwarf.h>
 #include <mono/utils/hazard-pointer.h>
+#include <mono/utils/mono-logger-internals.h>
 #include <mono/metadata/threads-types.h>
 #include <mono/metadata/mono-endian.h>
 
@@ -637,7 +638,11 @@ mono_unwind_frame (guint8 *unwind_info, guint32 unwind_info_len,
 	if (save_locations)
 		memset (save_locations, 0, save_locations_len * sizeof (mgreg_t*));
 
-	g_assert (cfa_reg != -1);
+	if (cfa_reg == -1) {
+		mono_runtime_printf_err ("Unset cfa_reg in method %s. Memory around ip (%p):", mono_get_method_from_ip (ip), ip);
+		mono_dump_mem (ip - 0x10, 0x40);
+		g_assert_not_reached ();
+	}
 	cfa_val = (guint8*)regs [mono_dwarf_reg_to_hw_reg (cfa_reg)] + cfa_offset;
 	for (hwreg = 0; hwreg < NUM_HW_REGS; ++hwreg) {
 		if (reg_saved [hwreg] && locations [hwreg].loc_type == LOC_OFFSET) {

--- a/mono/utils/mono-logger-internals.h
+++ b/mono/utils/mono-logger-internals.h
@@ -161,6 +161,8 @@ void mono_log_write_recorder (const char *log_domain, GLogLevelFlags level, mono
 void mono_log_close_recorder (void);
 void mono_log_dump_recorder (void);
 
+void mono_dump_mem (gpointer d, int len);
+
 G_END_DECLS
 
 #endif /* __MONO_LOGGER_INTERNAL_H__ */


### PR DESCRIPTION
Historically very common and hard to reproduce assertion, which, in some cases, could be fixed just from this logging. Log example :

```
Unset cfa_reg in method <0x40011220 - (null) trampoline>. Memory around ip (0x40011220):
0x40011210  41 89 07 4c 8b 3c 24 48 83 c4 08 c3 00 00 00 00  A..L.<$H........
0x40011220  48 83 c7 10 b8 00 12 01 40 ff e0 00 00 00 00 00  H.......@.......
0x40011230  00 00 00 00 e8 c7 ef fe ff 08 f8 34 e0 55 55 55  ...........4.UUU
0x40011240  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
* Assertion: should not be reached at unwind.c:664
```




Backport of #11888.

/cc @BrzVlad 