### PR TITLE
Adjust test (not runtime) to workaround Windows i386 GCC ABI bug.

### DIFF
--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -5616,20 +5616,24 @@ mono_test_marshal_return_lpwstr (void)
 	return res;
 }
 
-typedef struct {
+typedef
+#if defined (HOST_WIN32) && defined (HOST_X86) && defined (__GNUC__)
+// Workaround gcc ABI bug. It returns the struct in ST0 instead of edx:eax.
+// Mono and Visual C++ agree.
+union
+#else
+struct
+#endif
+{
 	double d;
 } SingleDoubleStruct;
 
 LIBTEST_API SingleDoubleStruct STDCALL
 mono_test_marshal_return_single_double_struct (void)
 {
-	SingleDoubleStruct res;
-
-	res.d = 3.0;
-
+	SingleDoubleStruct res = {3.0};
 	return res;
 }
-
 
 #ifndef TARGET_X86
 


### PR DESCRIPTION
https://gcc.gnu.org/bugzilla/show_activity.cgi?id=88352

Investigating my own PR breakage..I ended up building libtest with gcc and the runtime with msvc.
A runtime built with gcc would have behaved the same. Gcc has an ABI bug, that mono does not and probably should not implement, unless maybe gcc refuses to fix it.

Given:

libtest.c:
typedef struct {
        double d;
 } SingleDoubleStruct;

SingleDoubleStruct mono_test_marshal_return_single_double_struct (void);

Visual C++ and mono expect the return value in edx:eax.
Gcc returns it in ST0.
Changing struct to union fixes it.

Mono "actually" expects return value in local via pointer
in extra parameter, but it generates a wrapper to bridge
its custom (SysV?) ABI to the NT ABI.

Adjust the test to avoid the gcc bug.
The runtime is unchanged.