### PR TITLE
[ci] Re-Enable V8 tests on wasm

### DIFF
--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -211,8 +211,7 @@ if [[ ${CI_TAGS} == *'webassembly'* ]] || [[ ${CI_TAGS} == *'wasm'* ]];
         if [[ ${CI_TAGS} != *'no-tests'* ]]; then
             ${TESTCMD} --label=wasm-build --timeout=60m --fatal make -j ${CI_CPU_COUNT} -C sdks/wasm build
             ${TESTCMD} --label=ch-mini-test --timeout=60m make -C sdks/wasm run-ch-mini
-            #V8 upgrade broke this: https://github.com/mono/mono/issues/11908
-            #${TESTCMD} --label=v8-mini-test --timeout=60m make -C sdks/wasm run-v8-mini
+            ${TESTCMD} --label=v8-mini-test --timeout=60m make -C sdks/wasm run-v8-mini
             ${TESTCMD} --label=sm-mini-test --timeout=60m make -C sdks/wasm run-sm-mini
             ${TESTCMD} --label=jsc-mini-test --timeout=60m make -C sdks/wasm run-jsc-mini
             #The following tests are not passing yet, so enabling them would make us perma-red
@@ -220,8 +219,7 @@ if [[ ${CI_TAGS} == *'webassembly'* ]] || [[ ${CI_TAGS} == *'wasm'* ]];
             #${TESTCMD} --label=mini-system --timeout=60m make -C sdks/wasm run-all-system
             # Chakra crashes with System.Core. See https://github.com/mono/mono/issues/8345
             ${TESTCMD} --label=ch-system-core --timeout=60m make -C sdks/wasm run-ch-system-core
-            #V8 upgrade broke this: https://github.com/mono/mono/issues/11908
-            #${TESTCMD} --label=v8-system-core --timeout=60m make -C sdks/wasm run-v8-system-core
+            ${TESTCMD} --label=v8-system-core --timeout=60m make -C sdks/wasm run-v8-system-core
             ${TESTCMD} --label=sm-system-core --timeout=60m make -C sdks/wasm run-sm-system-core
             ${TESTCMD} --label=jsc-system-core --timeout=60m make -C sdks/wasm run-jsc-system-core
             ${TESTCMD} --label=aot-mini --timeout=60m make -j ${CI_CPU_COUNT} -C sdks/wasm run-aot-mini


### PR DESCRIPTION
-  Found latest V8 version: v7.3.16.  Works

Resolves: https://github.com/mono/mono/issues/11908
