### PR TITLE
[Coop] Mostly convert 30+ JIT icalls (and embedding API).

### DIFF
--- a/mono/eglib/gerror.c
+++ b/mono/eglib/gerror.c
@@ -73,7 +73,8 @@ g_clear_error (GError **gerror)
 void
 g_error_free (GError *gerror)
 {
-	g_return_if_fail (gerror != NULL);
+	if (!gerror)
+		return;
 	
 	g_free (gerror->message);
 	g_free (gerror);

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -40,7 +40,7 @@
 #include <mono/utils/mono-counters.h>
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/unlocked.h>
-
+#include <mono/metadata/icall-decl.h>
 
 #if HAVE_BOEHM_GC
 
@@ -1177,7 +1177,7 @@ create_allocator (int atype, int tls_key, gboolean slowpath)
  always_slowpath:
 	if (atype == ATYPE_STRING) {
 		mono_mb_emit_ldarg (mb, 1);
-		mono_mb_emit_icall (mb, ves_icall_string_alloc);
+		mono_mb_emit_icall (mb, ves_icall_string_alloc_raw);
 	} else {
 		mono_mb_emit_ldarg (mb, 0);
 		mono_mb_emit_icall (mb, ves_icall_object_new_specific);

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -1177,7 +1177,7 @@ create_allocator (int atype, int tls_key, gboolean slowpath)
  always_slowpath:
 	if (atype == ATYPE_STRING) {
 		mono_mb_emit_ldarg (mb, 1);
-		mono_mb_emit_icall (mb, ves_icall_string_alloc_raw);
+		mono_mb_emit_icall (mb, ves_icall_string_alloc);
 	} else {
 		mono_mb_emit_ldarg (mb, 0);
 		mono_mb_emit_icall (mb, ves_icall_object_new_specific);

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -100,7 +100,7 @@ register_icall (gpointer func, const char *name, const char *sigstr, gboolean sa
 }
 
 mono_bstr
-mono_string_to_bstr (MonoStringHandle s, MonoError *error)
+mono_string_to_bstr_impl (MonoStringHandle s, MonoError *error)
 {
 	if (MONO_HANDLE_IS_NULL (s))
 		return NULL;
@@ -688,8 +688,8 @@ mono_cominterop_init (void)
 	The proper fix would be to emit warning, remove them from marshal.c when DISABLE_COM is used and
 	emit an exception in the generated IL.
 	*/
-	register_icall (mono_string_to_bstr_raw, "mono_string_to_bstr", "ptr obj", FALSE);
-	register_icall (mono_string_from_bstr_icall_raw, "mono_string_from_bstr_icall", "obj ptr", FALSE);
+	register_icall (mono_string_to_bstr, "mono_string_to_bstr", "ptr obj", FALSE);
+	register_icall (mono_string_from_bstr_icall, "mono_string_from_bstr_icall", "obj ptr", FALSE);
 	register_icall (mono_free_bstr, "mono_free_bstr", "void ptr", FALSE);
 }
 
@@ -2937,7 +2937,7 @@ mono_string_from_bstr (/*mono_bstr_const*/gpointer bstr)
 }
 
 MonoStringHandle
-mono_string_from_bstr_icall (mono_bstr_const bstr, MonoError *error)
+mono_string_from_bstr_icall_impl (mono_bstr_const bstr, MonoError *error)
 {
 	return mono_string_from_bstr_checked (bstr, error);
 }

--- a/mono/metadata/cominterop.h
+++ b/mono/metadata/cominterop.h
@@ -58,9 +58,6 @@ mono_cominterop_emit_marshal_safearray (EmitMarshalContext *m, int argnum,
 MONO_API MONO_RT_EXTERNAL_ONLY MonoString *
 mono_string_from_bstr (/*mono_bstr*/gpointer bstr);
 
-MonoString *
-mono_string_from_bstr_icall (mono_bstr_const bstr);
-
 MONO_API void 
 mono_free_bstr (/*mono_bstr_const*/gpointer bstr);
 

--- a/mono/metadata/gc-internals.h
+++ b/mono/metadata/gc-internals.h
@@ -231,12 +231,6 @@ typedef void (*MonoRangeCopyFunction)(gpointer, gconstpointer, int size);
 MonoRangeCopyFunction
 mono_gc_get_range_copy_func (void);
 
-
-/* helper for the managed alloc support */
-ICALL_EXPORT
-MonoString *
-ves_icall_string_alloc (int length);
-
 /* 
  * Functions supplied by the runtime and called by the GC. Currently only used
  * by SGEN.

--- a/mono/metadata/handle.h
+++ b/mono/metadata/handle.h
@@ -356,6 +356,7 @@ This is why we evaluate index and value before any call to MONO_HANDLE_RAW or ot
 		} while (0);						\
 	} while (0)
 
+// resultHandle = handle->field
 /* N.B. RESULT is evaluated before HANDLE */
 #define MONO_HANDLE_GET(RESULT, HANDLE, FIELD) do {			\
 		MonoObjectHandle __dest = MONO_HANDLE_CAST (MonoObject, RESULT);	\
@@ -495,8 +496,9 @@ be reviewed and probably changed FIXME.
 extern const MonoObjectHandle mono_null_value_handle;
 #define NULL_HANDLE mono_null_value_handle
 #define NULL_HANDLE_INIT { 0 }
-#define NULL_HANDLE_STRING (MONO_HANDLE_CAST (MonoString, NULL_HANDLE))
-#define NULL_HANDLE_ARRAY  (MONO_HANDLE_CAST (MonoArray,  NULL_HANDLE))
+#define NULL_HANDLE_STRING 		(MONO_HANDLE_CAST (MonoString, NULL_HANDLE))
+#define NULL_HANDLE_ARRAY  		(MONO_HANDLE_CAST (MonoArray,  NULL_HANDLE))
+#define NULL_HANDLE_STRING_BUILDER	(MONO_HANDLE_CAST (MonoStringBuilder, NULL_HANDLE))
 
 static inline MonoObjectHandle
 mono_handle_assign_raw (MonoObjectHandleOut dest, void *src)

--- a/mono/metadata/icall-decl.h
+++ b/mono/metadata/icall-decl.h
@@ -30,8 +30,8 @@
 #include "string-icalls.h"
 #include "threadpool-io.h"
 #include "threadpool.h"
-#include "utils/mono-digest.h"
-#include "utils/mono-forward-internal.h"
+#include "mono/utils/mono-digest.h"
+#include "mono/utils/mono-forward-internal.h"
 #include "w32event.h"
 #include "w32file.h"
 #include "w32mutex.h"
@@ -54,7 +54,10 @@ typedef enum {
 #define NOHANDLES(inner) inner
 #define HANDLES_REUSE_WRAPPER(...) /* nothing */
 
-// Generate prototypes for coop icall wrappers.
+// Generate prototypes for coop icall wrappers and coop icalls.
+#define MONO_HANDLE_REGISTER_ICALL(func, ret, nargs, argtypes) \
+	MONO_HANDLE_DECLARE (,,func, ret, nargs, argtypes); \
+	MONO_HANDLE_REGISTER_ICALL_DECLARE_RAW (func, ret, nargs, argtypes);
 #define ICALL_TYPE(id, name, first)	/* nothing */
 #define ICALL(id, name, func) 		/* nothing */
 #define HANDLES(id, name, func, ret, nargs, argtypes) \
@@ -66,6 +69,7 @@ typedef enum {
 #undef HANDLES
 #undef HANDLES_REUSE_WRAPPER
 #undef NOHANDLES
+#undef MONO_HANDLE_REGISTER_ICALL
 
 // This is sorted.
 // grep ICALL_EXPORT | sort | uniq

--- a/mono/metadata/icall-decl.h
+++ b/mono/metadata/icall-decl.h
@@ -56,7 +56,7 @@ typedef enum {
 
 // Generate prototypes for coop icall wrappers and coop icalls.
 #define MONO_HANDLE_REGISTER_ICALL(func, ret, nargs, argtypes) \
-	MONO_HANDLE_DECLARE (,,func, ret, nargs, argtypes); \
+	MONO_HANDLE_DECLARE (,,func ## _impl, ret, nargs, argtypes); \
 	MONO_HANDLE_REGISTER_ICALL_DECLARE_RAW (func, ret, nargs, argtypes);
 #define ICALL_TYPE(id, name, first)	/* nothing */
 #define ICALL(id, name, func) 		/* nothing */

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -1169,3 +1169,55 @@ HANDLES(COMOBJ_1, "CreateRCW", ves_icall_System_ComObject_CreateRCW, MonoObject,
 HANDLES(COMOBJ_2, "GetInterfaceInternal", ves_icall_System_ComObject_GetInterfaceInternal, gpointer, 3, (MonoComObject, MonoReflectionType, MonoBoolean))
 HANDLES(COMOBJ_3, "ReleaseInterfaces", ves_icall_System_ComObject_ReleaseInterfaces, void, 1, (MonoComObject))
 #endif
+
+// This is similar to HANDLES() but is for icalls passed to register_jit_icall.
+// There is no metadata for these. No signature matching.
+// Presently their wrappers are less efficient, but hopefully that can be fixed,
+// by making a direct call to them, inserting the LMF below them (possibly,
+// providing it to them via a function pointer, if it cannot be done in C),
+// and of course using managed-style coop handles within them.
+// Alternately, ilgen.
+//
+// This is not just for register_icall, for any time coop wrappers are needed,
+// that there is no metadata for. For example embedding API.
+
+// helper for the managed alloc support
+MONO_HANDLE_REGISTER_ICALL (ves_icall_string_alloc, MonoString, 1, (int))
+
+// Windows: Allocates with CoTaskMemAlloc.
+// Unix: Allocates with g_malloc.
+// Either way: Free with mono_marshal_free (Windows:CoTaskMemFree, Unix:g_free).
+MONO_HANDLE_REGISTER_ICALL (mono_string_to_utf8str, gpointer, 1, (MonoString))
+
+MONO_HANDLE_REGISTER_ICALL (mono_array_to_byte_byvalarray, void, 3, (gpointer, MonoArray, guint32))
+MONO_HANDLE_REGISTER_ICALL (mono_array_to_lparray, gpointer, 1, (MonoArray))
+MONO_HANDLE_REGISTER_ICALL (mono_array_to_savearray, gpointer, 1, (MonoArray))
+MONO_HANDLE_REGISTER_ICALL (mono_byvalarray_to_byte_array, void, 3, (MonoArray, const_char_ptr, guint32))
+MONO_HANDLE_REGISTER_ICALL (mono_delegate_to_ftnptr, gpointer, 1, (MonoDelegate))
+MONO_HANDLE_REGISTER_ICALL (mono_free_lparray, void, 2, (MonoArray, gpointer_ptr))
+MONO_HANDLE_REGISTER_ICALL (mono_ftnptr_to_delegate, MonoDelegate, 2, (MonoClass_ptr, gpointer))
+MONO_HANDLE_REGISTER_ICALL (mono_marshal_asany, gpointer, 3, (MonoObject, MonoMarshalNative, int))
+MONO_HANDLE_REGISTER_ICALL (mono_marshal_free_asany, void, 4, (MonoObject, gpointer, MonoMarshalNative, int))
+MONO_HANDLE_REGISTER_ICALL (mono_marshal_string_to_utf16_copy, gunichar2_ptr, 1, (MonoString))
+MONO_HANDLE_REGISTER_ICALL (mono_string_builder_to_utf16, gunichar2_ptr, 1, (MonoStringBuilder))
+MONO_HANDLE_REGISTER_ICALL (mono_string_builder_to_utf8, char_ptr, 1, (MonoStringBuilder))
+MONO_HANDLE_REGISTER_ICALL (mono_string_from_bstr_icall, MonoString, 1, (mono_bstr_const))
+MONO_HANDLE_REGISTER_ICALL (mono_string_from_byvalstr, MonoString, 2, (const_char_ptr, int))
+MONO_HANDLE_REGISTER_ICALL (mono_string_from_byvalwstr, MonoString, 2, (const_gunichar2_ptr, int))
+MONO_HANDLE_REGISTER_ICALL (mono_string_new_len_wrapper, MonoString, 2, (const_char_ptr, guint))
+MONO_HANDLE_REGISTER_ICALL (mono_string_new_wrapper_internal, MonoString, 1, (const_char_ptr))
+MONO_HANDLE_REGISTER_ICALL (mono_string_to_ansibstr, gpointer, 1, (MonoString))
+MONO_HANDLE_REGISTER_ICALL (mono_string_to_bstr, mono_bstr, 1, (MonoString))
+MONO_HANDLE_REGISTER_ICALL (mono_string_to_byvalstr, void, 3, (char_ptr, MonoString, int))
+MONO_HANDLE_REGISTER_ICALL (mono_string_to_byvalwstr, void, 3, (gunichar2_ptr, MonoString, int))
+MONO_HANDLE_REGISTER_ICALL (mono_string_to_utf16_internal, mono_unichar2_ptr, 1, (MonoString))
+MONO_HANDLE_REGISTER_ICALL (mono_string_to_utf32_internal, mono_unichar4_ptr, 1, (MonoString))
+MONO_HANDLE_REGISTER_ICALL (mono_string_utf16_to_builder, void, 2, (MonoStringBuilder, const_gunichar2_ptr))
+MONO_HANDLE_REGISTER_ICALL (mono_string_utf16_to_builder2, MonoStringBuilder, 1, (const_gunichar2_ptr))
+MONO_HANDLE_REGISTER_ICALL (mono_string_utf8_to_builder, void, 2, (MonoStringBuilder, const_char_ptr))
+MONO_HANDLE_REGISTER_ICALL (mono_string_utf8_to_builder2, MonoStringBuilder, 1, (const_char_ptr))
+MONO_HANDLE_REGISTER_ICALL (ves_icall_marshal_alloc, gpointer, 1, (gsize))
+MONO_HANDLE_REGISTER_ICALL (ves_icall_mono_marshal_xdomain_copy_value, MonoObject, 1, (MonoObject))
+MONO_HANDLE_REGISTER_ICALL (ves_icall_mono_string_from_utf16, MonoString, 1, (const_gunichar2_ptr))
+MONO_HANDLE_REGISTER_ICALL (ves_icall_mono_string_to_utf8, char_ptr, 1, (MonoString))
+MONO_HANDLE_REGISTER_ICALL (ves_icall_string_new_wrapper, MonoString, 1, (const_char_ptr))

--- a/mono/metadata/icall-table.c
+++ b/mono/metadata/icall-table.c
@@ -42,6 +42,7 @@
 #define NOHANDLES(inner) inner
 #define HANDLES(id, name, func, ...)	ICALL (id, name, func ## _raw)
 #define HANDLES_REUSE_WRAPPER		HANDLES
+#define MONO_HANDLE_REGISTER_ICALL(...) /* nothing  */
 
 // Generate Icall_ constants
 enum {
@@ -169,6 +170,7 @@ static const guchar icall_uses_handles [] = {
 #undef HANDLES
 #undef HANDLES_REUSE_WRAPPER
 #undef NOHANDLES
+#undef MONO_HANDLE_REGISTER_ICALL
 
 static int
 compare_method_imap (const void *key, const void *elem)

--- a/mono/metadata/icall-table.h
+++ b/mono/metadata/icall-table.h
@@ -454,7 +454,7 @@ MONO_HANDLE_DECLARE_RAW (id, name, func, rettype, n, argtypes)			\
 // Declare the function that takes/returns raw pointers and no MonoError.
 #define MONO_HANDLE_REGISTER_ICALL_DECLARE_RAW(func, rettype, n, argtypes)	\
 ICALL_EXPORT MONO_HANDLE_TYPE_RAWPOINTER (rettype)				\
-func ## _raw ( MONO_HANDLE_FOREACH_ARG_RAWPOINTER_ ## n argtypes)
+func ( MONO_HANDLE_FOREACH_ARG_RAWPOINTER_ ## n argtypes)
 
 // Implement ves_icall_foo_raw over ves_icall_foo.
 //
@@ -484,7 +484,7 @@ MONO_HANDLE_REGISTER_ICALL_DECLARE_RAW (func, rettype, n, argtypes)		\
 										\
 	MONO_HANDLE_RETURN_BEGIN (rettype)					\
 										\
-	func (MONO_HANDLE_REGISTER_ICALL_CALL_ ## n error);			\
+	func ## _impl (MONO_HANDLE_REGISTER_ICALL_CALL_ ## n error);			\
 										\
 	MONO_HANDLE_REGISTER_ICALL_OUT_ ## n argtypes				\
 										\

--- a/mono/metadata/icall-table.h
+++ b/mono/metadata/icall-table.h
@@ -60,8 +60,10 @@ typedef MonoPropertyInfo *MonoPropertyInfo_ref;
 typedef MonoType *MonoType_ptr;
 typedef MonoTypedRef *MonoTypedRef_ptr;
 typedef MonoStackCrawlMark *MonoStackCrawlMark_ptr;
+typedef MonoVTable *MonoVTable_ptr;
 typedef unsigned *unsigned_ptr;
 typedef mono_unichar2 *mono_unichar2_ptr;
+typedef mono_unichar4 *mono_unichar4_ptr;
 typedef WSABUF *WSABUF_ptr;
 
 typedef char **char_ptr_ref;
@@ -126,6 +128,7 @@ typedef MonoReflectionModuleHandle MonoReflectionModuleOutHandle;
 #define MONO_HANDLE_TYPE_WRAP_gsize   			ICALL_HANDLES_WRAP_NONE
 #define MONO_HANDLE_TYPE_WRAP_gssize   			ICALL_HANDLES_WRAP_NONE
 #define MONO_HANDLE_TYPE_WRAP_guchar_ptr		ICALL_HANDLES_WRAP_NONE
+#define MONO_HANDLE_TYPE_WRAP_guint     		ICALL_HANDLES_WRAP_NONE
 #define MONO_HANDLE_TYPE_WRAP_const_guchar_ptr		ICALL_HANDLES_WRAP_NONE
 #define MONO_HANDLE_TYPE_WRAP_guint32  			ICALL_HANDLES_WRAP_NONE
 #define MONO_HANDLE_TYPE_WRAP_guint64  			ICALL_HANDLES_WRAP_NONE
@@ -136,10 +139,14 @@ typedef MonoReflectionModuleHandle MonoReflectionModuleOutHandle;
 #define MONO_HANDLE_TYPE_WRAP_mono_bstr_const		ICALL_HANDLES_WRAP_NONE
 #define MONO_HANDLE_TYPE_WRAP_unsigned_ptr		ICALL_HANDLES_WRAP_NONE
 #define MONO_HANDLE_TYPE_WRAP_mono_unichar2_ptr		ICALL_HANDLES_WRAP_NONE
+#define MONO_HANDLE_TYPE_WRAP_mono_unichar4_ptr		ICALL_HANDLES_WRAP_NONE
 #define MONO_HANDLE_TYPE_WRAP_MonoImage_ptr		ICALL_HANDLES_WRAP_NONE
 #define MONO_HANDLE_TYPE_WRAP_MonoClassField_ptr	ICALL_HANDLES_WRAP_NONE
+#define MONO_HANDLE_TYPE_WRAP_MonoMarshalNative		ICALL_HANDLES_WRAP_NONE
 #define MONO_HANDLE_TYPE_WRAP_MonoProperty_ptr		ICALL_HANDLES_WRAP_NONE
 #define MONO_HANDLE_TYPE_WRAP_MonoProtocolType		ICALL_HANDLES_WRAP_NONE
+#define MONO_HANDLE_TYPE_WRAP_size_t			ICALL_HANDLES_WRAP_NONE
+#define MONO_HANDLE_TYPE_WRAP_MonoVTable_ptr		ICALL_HANDLES_WRAP_NONE
 #define MONO_HANDLE_TYPE_WRAP_WSABUF_ptr		ICALL_HANDLES_WRAP_NONE
 
 #define MONO_HANDLE_TYPE_WRAP_MonoAssemblyName_ref	ICALL_HANDLES_WRAP_VALUETYPE_REF
@@ -210,6 +217,7 @@ typedef MonoReflectionModuleHandle MonoReflectionModuleOutHandle;
 #define MONO_HANDLE_TYPE_WRAP_MonoReflectionType		ICALL_HANDLES_WRAP_OBJ
 #define MONO_HANDLE_TYPE_WRAP_MonoReflectionTypeBuilder		ICALL_HANDLES_WRAP_OBJ
 #define MONO_HANDLE_TYPE_WRAP_MonoString			ICALL_HANDLES_WRAP_OBJ
+#define MONO_HANDLE_TYPE_WRAP_MonoStringBuilder			ICALL_HANDLES_WRAP_OBJ
 #define MONO_HANDLE_TYPE_WRAP_MonoThreadObject			ICALL_HANDLES_WRAP_OBJ
 #define MONO_HANDLE_TYPE_WRAP_MonoW32ProcessStartInfo		ICALL_HANDLES_WRAP_OBJ
 
@@ -241,12 +249,53 @@ typedef MonoReflectionModuleHandle MonoReflectionModuleOutHandle;
 #define MONO_HANDLE_RETURN_END_ICALL_HANDLES_WRAP_NONE   	HANDLE_FUNCTION_RETURN_VAL (icall_result)
 #define MONO_HANDLE_RETURN_END_ICALL_HANDLES_WRAP_OBJ		HANDLE_FUNCTION_RETURN_OBJ (icall_result)
 
+// Convert raw handles to typed handles, just by casting and copying a pointer.
 #define MONO_HANDLE_MARSHAL(type, n)					MONO_HANDLE_DO (MONO_HANDLE_MARSHAL_, type) (type, n)
 #define MONO_HANDLE_MARSHAL_ICALL_HANDLES_WRAP_NONE(type, n)     	a ## n
 #define MONO_HANDLE_MARSHAL_ICALL_HANDLES_WRAP_OBJ(type, n)		*(type ## Handle*)&a ## n
 #define MONO_HANDLE_MARSHAL_ICALL_HANDLES_WRAP_OBJ_OUT(type, n)		*(type ## Handle*)&a ## n
 #define MONO_HANDLE_MARSHAL_ICALL_HANDLES_WRAP_OBJ_INOUT(type, n)	*(type ## Handle*)&a ## n
 #define MONO_HANDLE_MARSHAL_ICALL_HANDLES_WRAP_VALUETYPE_REF(type, n)	a ## n
+
+// Declare and initialize a local for an object in, out, inout parameters, upon input.
+#define MONO_HANDLE_REGISTER_ICALL_LOCALS(type, n)					MONO_HANDLE_DO (MONO_HANDLE_REGISTER_ICALL_LOCALS_, type) (type, n)
+#define MONO_HANDLE_REGISTER_ICALL_LOCALS_ICALL_HANDLES_WRAP_NONE(type, n)     		/* nothing */
+#define MONO_HANDLE_REGISTER_ICALL_LOCALS_ICALL_HANDLES_WRAP_OBJ(type, n)		type ## Handle a ## n = MONO_HANDLE_NEW (type, a ## n ## _raw);
+#define MONO_HANDLE_REGISTER_ICALL_LOCALS_ICALL_HANDLES_WRAP_OBJ_OUT(type, n)		unused_untested_looks_correct1 type ## Handle a ## n = MONO_HANDLE_NEW (type, NULL);
+#define MONO_HANDLE_REGISTER_ICALL_LOCALS_ICALL_HANDLES_WRAP_OBJ_INOUT(type, n)		unused_untested_looks_correct2 type ## Handle a ## n = MONO_HANDLE_NEW (type, *a ## n ## _raw);
+#define MONO_HANDLE_REGISTER_ICALL_LOCALS_ICALL_HANDLES_WRAP_VALUETYPE_REF(type, n)	FIXME restore mono_icall_handle_new_interior from e8b037642104527bd9b9ba70d502210b9c12d2b8 \
+											type ## Handle a ## n = mono_icall_handle_new_interior (a ## n ## _raw);
+// Produce all the locals, i.e. up to one per parameter.
+#define MONO_HANDLE_REGISTER_ICALL_LOCALS_0()					/* nothing  */
+#define MONO_HANDLE_REGISTER_ICALL_LOCALS_1(t0)					MONO_HANDLE_REGISTER_ICALL_LOCALS (t0, 0)
+#define MONO_HANDLE_REGISTER_ICALL_LOCALS_2(t0, t1)				MONO_HANDLE_REGISTER_ICALL_LOCALS_1 (t0) 				MONO_HANDLE_REGISTER_ICALL_LOCALS (t1, 1)
+#define MONO_HANDLE_REGISTER_ICALL_LOCALS_3(t0, t1, t2)				MONO_HANDLE_REGISTER_ICALL_LOCALS_2 (t0, t1) 				MONO_HANDLE_REGISTER_ICALL_LOCALS (t2, 2)
+#define MONO_HANDLE_REGISTER_ICALL_LOCALS_4(t0, t1, t2, t3)			MONO_HANDLE_REGISTER_ICALL_LOCALS_3 (t0, t1, t2)			MONO_HANDLE_REGISTER_ICALL_LOCALS (t3, 3)
+#define MONO_HANDLE_REGISTER_ICALL_LOCALS_5(t0, t1, t2, t3, t4)			MONO_HANDLE_REGISTER_ICALL_LOCALS_4 (t0, t1, t2, t3)			MONO_HANDLE_REGISTER_ICALL_LOCALS (t4, 4)
+#define MONO_HANDLE_REGISTER_ICALL_LOCALS_6(t0, t1, t2, t3, t4, t5)		MONO_HANDLE_REGISTER_ICALL_LOCALS_5 (t0, t1, t2, t3, t4) 		MONO_HANDLE_REGISTER_ICALL_LOCALS (t5, 5)
+#define MONO_HANDLE_REGISTER_ICALL_LOCALS_7(t0, t1, t2, t3, t4, t5, t6)		MONO_HANDLE_REGISTER_ICALL_LOCALS_6 (t0, t1, t2, t3, t4, t5) 		MONO_HANDLE_REGISTER_ICALL_LOCALS (t6, 6)
+#define MONO_HANDLE_REGISTER_ICALL_LOCALS_8(t0, t1, t2, t3, t4, t5, t6, t7)	MONO_HANDLE_REGISTER_ICALL_LOCALS_7 (t0, t1, t2, t3, t4, t5, t6) 	MONO_HANDLE_REGISTER_ICALL_LOCALS (t7, 7)
+#define MONO_HANDLE_REGISTER_ICALL_LOCALS_9(t0, t1, t2, t3, t4, t5, t6, t7, t8)	MONO_HANDLE_REGISTER_ICALL_LOCALS_8 (t0, t1, t2, t3, t4, t5, t6, t7)	MONO_HANDLE_REGISTER_ICALL_LOCALS (t8, 8)
+
+// Convert a typed handle to raw pointer upon output.
+#define MONO_HANDLE_REGISTER_ICALL_OUT(type, n)					MONO_HANDLE_DO (MONO_HANDLE_REGISTER_ICALL_OUT_, type) (type, n)
+#define MONO_HANDLE_REGISTER_ICALL_OUT_ICALL_HANDLES_WRAP_NONE(type, n)		/* nothing */
+#define MONO_HANDLE_REGISTER_ICALL_OUT_ICALL_HANDLES_WRAP_OBJ(type, n)		/* nothing */
+#define MONO_HANDLE_REGISTER_ICALL_OUT_ICALL_HANDLES_WRAP_OBJ_OUT(type, n)	unused_untested_looks_correct3 *a ## n ## _raw = MONO_HANDLE_RAW (a ## n);
+#define MONO_HANDLE_REGISTER_ICALL_OUT_ICALL_HANDLES_WRAP_OBJ_INOUT		unused_untested_looks_correct4 *a ## n ## _raw = MONO_HANDLE_RAW (a ## n);
+#define MONO_HANDLE_REGISTER_ICALL_OUT_ICALL_HANDLES_VALUETYPE_REF(type, n)	/* nothing */
+
+// Convert all the typed handles to raw pointers upon output, i.e. up to one per parameter.
+#define MONO_HANDLE_REGISTER_ICALL_OUT_0()					/* nothing  */
+#define MONO_HANDLE_REGISTER_ICALL_OUT_1(t0)					MONO_HANDLE_REGISTER_ICALL_OUT (t0, 0)
+#define MONO_HANDLE_REGISTER_ICALL_OUT_2(t0, t1)				MONO_HANDLE_REGISTER_ICALL_OUT_1 (t0) 					MONO_HANDLE_REGISTER_ICALL_OUT (t1, 1)
+#define MONO_HANDLE_REGISTER_ICALL_OUT_3(t0, t1, t2)				MONO_HANDLE_REGISTER_ICALL_OUT_2 (t0, t1) 				MONO_HANDLE_REGISTER_ICALL_OUT (t2, 2)
+#define MONO_HANDLE_REGISTER_ICALL_OUT_4(t0, t1, t2, t3)			MONO_HANDLE_REGISTER_ICALL_OUT_3 (t0, t1, t2)				MONO_HANDLE_REGISTER_ICALL_OUT (t3, 3)
+#define MONO_HANDLE_REGISTER_ICALL_OUT_5(t0, t1, t2, t3, t4)			MONO_HANDLE_REGISTER_ICALL_OUT_4 (t0, t1, t2, t3)			MONO_HANDLE_REGISTER_ICALL_OUT (t4, 4)
+#define MONO_HANDLE_REGISTER_ICALL_OUT_6(t0, t1, t2, t3, t4, t5)		MONO_HANDLE_REGISTER_ICALL_OUT_5 (t0, t1, t2, t3, t4) 			MONO_HANDLE_REGISTER_ICALL_OUT (t5, 5)
+#define MONO_HANDLE_REGISTER_ICALL_OUT_7(t0, t1, t2, t3, t4, t5, t6)		MONO_HANDLE_REGISTER_ICALL_OUT_6 (t0, t1, t2, t3, t4, t5) 		MONO_HANDLE_REGISTER_ICALL_OUT (t6, 6)
+#define MONO_HANDLE_REGISTER_ICALL_OUT_8(t0, t1, t2, t3, t4, t5, t6, t7)	MONO_HANDLE_REGISTER_ICALL_OUT_7 (t0, t1, t2, t3, t4, t5, t6) 		MONO_HANDLE_REGISTER_ICALL_OUT (t7, 7)
+#define MONO_HANDLE_REGISTER_ICALL_OUT_9(t0, t1, t2, t3, t4, t5, t6, t7, t8)	MONO_HANDLE_REGISTER_ICALL_OUT_8 (t0, t1, t2, t3, t4, t5, t6, t7)	MONO_HANDLE_REGISTER_ICALL_OUT (t8, 8)
 
 #define MONO_HANDLE_TYPE_TYPED(type)					MONO_HANDLE_DO (MONO_HANDLE_TYPE_TYPED_, type) (type)
 #define MONO_HANDLE_TYPE_TYPED_Void(type)				type
@@ -256,14 +305,16 @@ typedef MonoReflectionModuleHandle MonoReflectionModuleOutHandle;
 #define MONO_HANDLE_TYPE_TYPED_ICALL_HANDLES_WRAP_OBJ_INOUT(type)	type ## Handle
 #define MONO_HANDLE_TYPE_TYPED_ICALL_HANDLES_WRAP_VALUETYPE_REF(type)	type
 
+// Map a type to a raw handle, or itself.
 #define MONO_HANDLE_TYPE_RAWHANDLE(type)					MONO_HANDLE_DO (MONO_HANDLE_TYPE_RAWHANDLE_, type) (type)
 #define MONO_HANDLE_TYPE_RAWHANDLE_Void(type)					type
 #define MONO_HANDLE_TYPE_RAWHANDLE_ICALL_HANDLES_WRAP_NONE(type)		type
-#define MONO_HANDLE_TYPE_RAWHANDLE_ICALL_HANDLES_WRAP_OBJ(type)		MonoRawHandle
+#define MONO_HANDLE_TYPE_RAWHANDLE_ICALL_HANDLES_WRAP_OBJ(type)			MonoRawHandle
 #define MONO_HANDLE_TYPE_RAWHANDLE_ICALL_HANDLES_WRAP_OBJ_OUT(type)		MonoRawHandle
 #define MONO_HANDLE_TYPE_RAWHANDLE_ICALL_HANDLES_WRAP_OBJ_INOUT(type)		MonoRawHandle
 #define MONO_HANDLE_TYPE_RAWHANDLE_ICALL_HANDLES_WRAP_VALUETYPE_REF(type)	type
 
+// Map a type to a raw pointer, or itself.
 #define MONO_HANDLE_TYPE_RAWPOINTER(type)					MONO_HANDLE_DO (MONO_HANDLE_TYPE_RAWPOINTER_, type) (type)
 #define MONO_HANDLE_TYPE_RAWPOINTER_Void(type)					type
 #define MONO_HANDLE_TYPE_RAWPOINTER_ICALL_HANDLES_WRAP_NONE(type)		type
@@ -281,6 +332,14 @@ typedef MonoReflectionModuleHandle MonoReflectionModuleOutHandle;
 #define MONO_HANDLE_ARG_RAWHANDLE_ICALL_HANDLES_WRAP_OBJ_INOUT(type, n)	MONO_HANDLE_TYPE_RAWHANDLE (type) a ## n
 #define MONO_HANDLE_ARG_RAWHANDLE_ICALL_HANDLES_WRAP_VALUETYPE_REF(type, n)	MONO_HANDLE_TYPE_RAWHANDLE (type) a ## n
 
+// Type/name in raw pointer prototype and implementation.
+#define MONO_HANDLE_ARG_RAWPOINTER(type, n)					MONO_HANDLE_DO (MONO_HANDLE_ARG_RAWPOINTER_, type) (type, n)
+#define MONO_HANDLE_ARG_RAWPOINTER_ICALL_HANDLES_WRAP_NONE(type, n)		MONO_HANDLE_TYPE_RAWPOINTER (type) a ## n
+#define MONO_HANDLE_ARG_RAWPOINTER_ICALL_HANDLES_WRAP_OBJ(type, n)		MONO_HANDLE_TYPE_RAWPOINTER (type) a ## n ## _raw
+#define MONO_HANDLE_ARG_RAWPOINTER_ICALL_HANDLES_WRAP_OBJ_OUT(type, n)		unused_untested_looks_correct5 MONO_HANDLE_TYPE_RAWPOINTER (type) a ## n ## _raw
+#define MONO_HANDLE_ARG_RAWPOINTER_ICALL_HANDLES_WRAP_OBJ_INOUT(type, n)	unused_untested_looks_correct6 MONO_HANDLE_TYPE_RAWPOINTER (type) a ## n ## _raw
+#define MONO_HANDLE_ARG_RAWPOINTER_ICALL_HANDLES_WRAP_VALUETYPE_REF(type, n)	FIXME //MONO_HANDLE_TYPE_RAWPOINTER (type) a ## n
+
 // Generate a parameter list, types only, for a function accepting/returning typed handles.
 #define MONO_HANDLE_FOREACH_TYPE_TYPED_0()	   			     /* nothing */
 #define MONO_HANDLE_FOREACH_TYPE_TYPED_1(t0) 	   			     MONO_HANDLE_TYPE_TYPED (t0)
@@ -294,7 +353,7 @@ typedef MonoReflectionModuleHandle MonoReflectionModuleOutHandle;
 #define MONO_HANDLE_FOREACH_TYPE_TYPED_9(t0, t1, t2, t3, t4, t5, t6, t7, t8) MONO_HANDLE_FOREACH_TYPE_TYPED_8 (t0, t1, t2, t3, t4, t5, t6, t7)	,MONO_HANDLE_TYPE_TYPED (t8)
 
 // Generate a parameter list, types and names, for a function accepting raw handles and a MonoError,
-// and returning a raw pointer.
+// and returning a raw pointer. MonoError is not here, but added elsewhere.
 #define MONO_HANDLE_FOREACH_ARG_RAW_0()		  				/* nothing */
 #define MONO_HANDLE_FOREACH_ARG_RAW_1(t0) 	   	  			MONO_HANDLE_ARG_RAWHANDLE (t0, 0)
 #define MONO_HANDLE_FOREACH_ARG_RAW_2(t0, t1)	  				MONO_HANDLE_FOREACH_ARG_RAW_1 (t0),             		MONO_HANDLE_ARG_RAWHANDLE (t1, 1)
@@ -305,6 +364,30 @@ typedef MonoReflectionModuleHandle MonoReflectionModuleOutHandle;
 #define MONO_HANDLE_FOREACH_ARG_RAW_7(t0, t1, t2, t3, t4, t5, t6)		MONO_HANDLE_FOREACH_ARG_RAW_6 (t0, t1, t2, t3, t4, t5), 	MONO_HANDLE_ARG_RAWHANDLE (t6, 6)
 #define MONO_HANDLE_FOREACH_ARG_RAW_8(t0, t1, t2, t3, t4, t5, t6, t7)		MONO_HANDLE_FOREACH_ARG_RAW_7 (t0, t1, t2, t3, t4, t5, t6),	MONO_HANDLE_ARG_RAWHANDLE (t7, 7)
 #define MONO_HANDLE_FOREACH_ARG_RAW_9(t0, t1, t2, t3, t4, t5, t6, t7, t8)  	MONO_HANDLE_FOREACH_ARG_RAW_8 (t0, t1, t2, t3, t4, t5, t6, t7),	MONO_HANDLE_ARG_RAWHANDLE (t8, 8)
+
+// Generate a parameter list, types and names, for a function accepting raw pointers and no MonoError,
+// and returning a raw pointer.
+#define MONO_HANDLE_FOREACH_ARG_RAWPOINTER_0()		  				/* nothing */
+#define MONO_HANDLE_FOREACH_ARG_RAWPOINTER_1(t0) 	   	  			MONO_HANDLE_ARG_RAWPOINTER (t0, 0)
+#define MONO_HANDLE_FOREACH_ARG_RAWPOINTER_2(t0, t1)	  				MONO_HANDLE_FOREACH_ARG_RAWPOINTER_1 (t0),             			MONO_HANDLE_ARG_RAWPOINTER (t1, 1)
+#define MONO_HANDLE_FOREACH_ARG_RAWPOINTER_3(t0, t1, t2)	  			MONO_HANDLE_FOREACH_ARG_RAWPOINTER_2 (t0, t1),         			MONO_HANDLE_ARG_RAWPOINTER (t2, 2)
+#define MONO_HANDLE_FOREACH_ARG_RAWPOINTER_4(t0, t1, t2, t3)				MONO_HANDLE_FOREACH_ARG_RAWPOINTER_3 (t0, t1, t2),     			MONO_HANDLE_ARG_RAWPOINTER (t3, 3)
+#define MONO_HANDLE_FOREACH_ARG_RAWPOINTER_5(t0, t1, t2, t3, t4)			MONO_HANDLE_FOREACH_ARG_RAWPOINTER_4 (t0, t1, t2, t3), 			MONO_HANDLE_ARG_RAWPOINTER (t4, 4)
+#define MONO_HANDLE_FOREACH_ARG_RAWPOINTER_6(t0, t1, t2, t3, t4, t5)			MONO_HANDLE_FOREACH_ARG_RAWPOINTER_5 (t0, t1, t2, t3, t4), 		MONO_HANDLE_ARG_RAWPOINTER (t5, 5)
+#define MONO_HANDLE_FOREACH_ARG_RAWPOINTER_7(t0, t1, t2, t3, t4, t5, t6)		MONO_HANDLE_FOREACH_ARG_RAWPOINTER_6 (t0, t1, t2, t3, t4, t5), 		MONO_HANDLE_ARG_RAWPOINTER (t6, 6)
+#define MONO_HANDLE_FOREACH_ARG_RAWPOINTER_8(t0, t1, t2, t3, t4, t5, t6, t7)		MONO_HANDLE_FOREACH_ARG_RAWPOINTER_7 (t0, t1, t2, t3, t4, t5, t6),	MONO_HANDLE_ARG_RAWPOINTER (t7, 7)
+#define MONO_HANDLE_FOREACH_ARG_RAWPOINTER_9(t0, t1, t2, t3, t4, t5, t6, t7, t8)	MONO_HANDLE_FOREACH_ARG_RAWPOINTER_8 (t0, t1, t2, t3, t4, t5, t6, t7),	MONO_HANDLE_ARG_RAWPOINTER (t8, 8)
+
+#define MONO_HANDLE_REGISTER_ICALL_CALL_0 /*  nothing */
+#define MONO_HANDLE_REGISTER_ICALL_CALL_1 a0,
+#define MONO_HANDLE_REGISTER_ICALL_CALL_2 MONO_HANDLE_REGISTER_ICALL_CALL_1 a1,
+#define MONO_HANDLE_REGISTER_ICALL_CALL_3 MONO_HANDLE_REGISTER_ICALL_CALL_2 a2,
+#define MONO_HANDLE_REGISTER_ICALL_CALL_4 MONO_HANDLE_REGISTER_ICALL_CALL_3 a3,
+#define MONO_HANDLE_REGISTER_ICALL_CALL_5 MONO_HANDLE_REGISTER_ICALL_CALL_4 a4,
+#define MONO_HANDLE_REGISTER_ICALL_CALL_6 MONO_HANDLE_REGISTER_ICALL_CALL_5 a5,
+#define MONO_HANDLE_REGISTER_ICALL_CALL_7 MONO_HANDLE_REGISTER_ICALL_CALL_6 a6,
+#define MONO_HANDLE_REGISTER_ICALL_CALL_8 MONO_HANDLE_REGISTER_ICALL_CALL_7 a7,
+#define MONO_HANDLE_REGISTER_ICALL_CALL_9 MONO_HANDLE_REGISTER_ICALL_CALL_8 a8,
 
 // Call from the wrapper to the actual icall, passing on the
 // WRAP_NONE parameters directly, casting handles from raw to typed.
@@ -348,6 +431,7 @@ func ## _raw ( MONO_HANDLE_FOREACH_ARG_RAW_ ## n argtypes MONO_HANDLE_COMMA_ ## 
 
 // Implement ves_icall_foo_raw over ves_icall_foo.
 // Raw handles are converted to/from typed handles and the rest is passed through.
+// This is for functions in icall-def.h.
 
 #define MONO_HANDLE_IMPLEMENT(id, name, func, rettype, n, argtypes)	\
 										\
@@ -361,6 +445,48 @@ MONO_HANDLE_DECLARE_RAW (id, name, func, rettype, n, argtypes)			\
 	MONO_HANDLE_RETURN_BEGIN (rettype)					\
 										\
 	func (MONO_HANDLE_CALL_ ## n argtypes MONO_HANDLE_COMMA_ ## n error);	\
+										\
+	mono_error_set_pending_exception (error);				\
+										\
+	MONO_HANDLE_RETURN_END (rettype)					\
+}										\
+
+// Declare the function that takes/returns raw pointers and no MonoError.
+#define MONO_HANDLE_REGISTER_ICALL_DECLARE_RAW(func, rettype, n, argtypes)	\
+ICALL_EXPORT MONO_HANDLE_TYPE_RAWPOINTER (rettype)				\
+func ## _raw ( MONO_HANDLE_FOREACH_ARG_RAWPOINTER_ ## n argtypes)
+
+// Implement ves_icall_foo_raw over ves_icall_foo.
+//
+// Raw pointers are converted to/from handles and the rest is passed through.
+// The in/out/inout-ness of parameters must be correct. (unlike MONO_HANDLE_IMPLEMENT)
+// Valuetype-refs are not handled. (unlike MONO_HANDLE_IMPLEMENT)
+// Handle creation is less efficient than MONO_HANDLE_IMPLEMENT (marshal-ilgen.c) -- using TLS
+// and per-handle work.
+//
+// In future this should produce an array of IcallHandlesWrap and send that through
+// to emit_native_icall_wrapper_ilgen to gain its efficient handles.
+//
+// Or put the handles directly in the coop frame, or pointers to them.
+// i.e. one TLS access at function start and end.
+//
+// This is for functions passed to mono_register_jit_icall, etc.
+
+#define MONO_HANDLE_REGISTER_ICALL_IMPLEMENT(func, rettype, n, argtypes)	\
+										\
+MONO_HANDLE_REGISTER_ICALL_DECLARE_RAW (func, rettype, n, argtypes)		\
+{										\
+	HANDLE_FUNCTION_ENTER ();						\
+										\
+	ERROR_DECL (error);							\
+										\
+	MONO_HANDLE_REGISTER_ICALL_LOCALS_ ## n argtypes			\
+										\
+	MONO_HANDLE_RETURN_BEGIN (rettype)					\
+										\
+	func (MONO_HANDLE_REGISTER_ICALL_CALL_ ## n error);			\
+										\
+	MONO_HANDLE_REGISTER_ICALL_OUT_ ## n argtypes				\
 										\
 	mono_error_set_pending_exception (error);				\
 										\

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -8833,6 +8833,8 @@ ves_icall_System_Net_NetworkInformation_LinuxNetworkChange_CloseNLSocket (gpoint
 #define ICALL(id,name,func) /* nothing */
 #define NOHANDLES(inner)  /* nothing */
 
+#define MONO_HANDLE_REGISTER_ICALL(func, ret, nargs, argtypes) MONO_HANDLE_REGISTER_ICALL_IMPLEMENT (func, ret, nargs, argtypes)
+
 // Some native functions are exposed via multiple managed names.
 // Producing a wrapper for these results in duplicate wrappers with the same names,
 // which fails to compile. Do not produce such duplicate wrappers. Alternatively,
@@ -8851,3 +8853,4 @@ ves_icall_System_Net_NetworkInformation_LinuxNetworkChange_CloseNLSocket (gpoint
 #undef ICALL_TYPE
 #undef ICALL
 #undef NOHANDLES
+#undef MONO_HANDLE_REGISTER_ICALL

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -401,7 +401,7 @@ emit_ptr_to_object_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv 
 		mono_mb_emit_byte (mb, CEE_LDIND_REF);
 		mono_mb_emit_ldloc (mb, 0);
 		mono_mb_emit_icon (mb, mspec->data.array_data.num_elem);
-		mono_mb_emit_icall (mb, mono_byvalarray_to_byte_array_raw);
+		mono_mb_emit_icall (mb, mono_byvalarray_to_byte_array);
 		break;
 	}
 	case MONO_MARSHAL_CONV_STR_BYVALSTR: 
@@ -409,11 +409,11 @@ emit_ptr_to_object_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv 
 			mono_mb_emit_ldloc (mb, 1);
 			mono_mb_emit_ldloc (mb, 0);
 			mono_mb_emit_icon (mb, mspec->data.array_data.num_elem);
-			mono_mb_emit_icall (mb, mono_string_from_byvalstr_raw);
+			mono_mb_emit_icall (mb, mono_string_from_byvalstr);
 		} else {
 			mono_mb_emit_ldloc (mb, 1);
 			mono_mb_emit_ldloc (mb, 0);
-			mono_mb_emit_icall (mb, ves_icall_string_new_wrapper_raw);
+			mono_mb_emit_icall (mb, ves_icall_string_new_wrapper);
 		}
 		mono_mb_emit_byte (mb, CEE_STIND_REF);		
 		break;
@@ -422,11 +422,11 @@ emit_ptr_to_object_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv 
 			mono_mb_emit_ldloc (mb, 1);
 			mono_mb_emit_ldloc (mb, 0);
 			mono_mb_emit_icon (mb, mspec->data.array_data.num_elem);
-			mono_mb_emit_icall (mb, mono_string_from_byvalwstr_raw);
+			mono_mb_emit_icall (mb, mono_string_from_byvalwstr);
 		} else {
 			mono_mb_emit_ldloc (mb, 1);
 			mono_mb_emit_ldloc (mb, 0);
-			mono_mb_emit_icall (mb, ves_icall_mono_string_from_utf16_raw);
+			mono_mb_emit_icall (mb, ves_icall_mono_string_from_utf16);
 		}
 		mono_mb_emit_byte (mb, CEE_STIND_REF);		
 		break;		
@@ -435,9 +435,9 @@ emit_ptr_to_object_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv 
 		mono_mb_emit_ldloc (mb, 0);
 		mono_mb_emit_byte (mb, CEE_LDIND_I);
 #ifdef TARGET_WIN32
-		mono_mb_emit_icall (mb, ves_icall_mono_string_from_utf16_raw);
+		mono_mb_emit_icall (mb, ves_icall_mono_string_from_utf16);
 #else
-		mono_mb_emit_icall (mb, ves_icall_string_new_wrapper_raw);
+		mono_mb_emit_icall (mb, ves_icall_string_new_wrapper);
 #endif
 		mono_mb_emit_byte (mb, CEE_STIND_REF);	
 		break;
@@ -448,14 +448,14 @@ emit_ptr_to_object_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv 
 		mono_mb_emit_ldloc (mb, 1);
 		mono_mb_emit_ldloc (mb, 0);
 		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_icall (mb, ves_icall_string_new_wrapper_raw);
+		mono_mb_emit_icall (mb, ves_icall_string_new_wrapper);
 		mono_mb_emit_byte (mb, CEE_STIND_REF);		
 		break;
 	case MONO_MARSHAL_CONV_STR_LPWSTR:
 		mono_mb_emit_ldloc (mb, 1);
 		mono_mb_emit_ldloc (mb, 0);
 		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_icall (mb, ves_icall_mono_string_from_utf16_raw);
+		mono_mb_emit_icall (mb, ves_icall_mono_string_from_utf16);
 		mono_mb_emit_byte (mb, CEE_STIND_REF);
 		break;
 	case MONO_MARSHAL_CONV_OBJECT_STRUCT: {
@@ -504,7 +504,7 @@ emit_ptr_to_object_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv 
 		mono_mb_emit_op (mb, CEE_MONO_CLASSCONST, klass);
 		mono_mb_emit_ldloc (mb, 0);
 		mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_icall (mb, mono_ftnptr_to_delegate_raw);
+		mono_mb_emit_icall (mb, mono_ftnptr_to_delegate);
 		mono_mb_emit_byte (mb, CEE_STIND_REF);
 		break;
 	}
@@ -576,74 +576,74 @@ conv_to_icall (MonoMarshalConv conv, int *ind_store_type)
 		return (gpointer)mono_marshal_string_to_utf16;
 	case MONO_MARSHAL_CONV_LPWSTR_STR:
 		*ind_store_type = CEE_STIND_REF;
-		return (gpointer)ves_icall_mono_string_from_utf16_raw;
+		return (gpointer)ves_icall_mono_string_from_utf16;
 	case MONO_MARSHAL_CONV_LPTSTR_STR:
 		*ind_store_type = CEE_STIND_REF;
-		return (gpointer)ves_icall_string_new_wrapper_raw;
+		return (gpointer)ves_icall_string_new_wrapper;
 	case MONO_MARSHAL_CONV_UTF8STR_STR:
 	case MONO_MARSHAL_CONV_LPSTR_STR:
 		*ind_store_type = CEE_STIND_REF;
-		return (gpointer)ves_icall_string_new_wrapper_raw;
+		return (gpointer)ves_icall_string_new_wrapper;
 	case MONO_MARSHAL_CONV_STR_LPTSTR:
 #ifdef TARGET_WIN32
 		return (gpointer)mono_marshal_string_to_utf16;
 #else
-		return (gpointer)mono_string_to_utf8str_raw;
+		return (gpointer)mono_string_to_utf8str;
 #endif
 		// In Mono historically LPSTR was treated as a UTF8STR
 	case MONO_MARSHAL_CONV_STR_UTF8STR:
 	case MONO_MARSHAL_CONV_STR_LPSTR:
-		return (gpointer)mono_string_to_utf8str_raw;
+		return (gpointer)mono_string_to_utf8str;
 	case MONO_MARSHAL_CONV_STR_BSTR:
-		return (gpointer)mono_string_to_bstr_raw;
+		return (gpointer)mono_string_to_bstr;
 	case MONO_MARSHAL_CONV_BSTR_STR:
 		*ind_store_type = CEE_STIND_REF;
-		return (gpointer)mono_string_from_bstr_icall_raw;
+		return (gpointer)mono_string_from_bstr_icall;
 	case MONO_MARSHAL_CONV_STR_TBSTR:
 	case MONO_MARSHAL_CONV_STR_ANSIBSTR:
-		return (gpointer)mono_string_to_ansibstr_raw;
+		return (gpointer)mono_string_to_ansibstr;
 	case MONO_MARSHAL_CONV_SB_UTF8STR:
 	case MONO_MARSHAL_CONV_SB_LPSTR:
-		return (gpointer)mono_string_builder_to_utf8_raw;
+		return (gpointer)mono_string_builder_to_utf8;
 	case MONO_MARSHAL_CONV_SB_LPTSTR:
 #ifdef TARGET_WIN32
-		return (gpointer)mono_string_builder_to_utf16_raw;
+		return (gpointer)mono_string_builder_to_utf16;
 #else
-		return (gpointer)mono_string_builder_to_utf8_raw;
+		return (gpointer)mono_string_builder_to_utf8;
 #endif
 	case MONO_MARSHAL_CONV_SB_LPWSTR:
-		return (gpointer)mono_string_builder_to_utf16_raw;
+		return (gpointer)mono_string_builder_to_utf16;
 	case MONO_MARSHAL_CONV_ARRAY_SAVEARRAY:
-		return (gpointer)mono_array_to_savearray_raw;
+		return (gpointer)mono_array_to_savearray;
 	case MONO_MARSHAL_CONV_ARRAY_LPARRAY:
-		return (gpointer)mono_array_to_lparray_raw;
+		return (gpointer)mono_array_to_lparray;
 	case MONO_MARSHAL_FREE_LPARRAY:
-		return (gpointer)mono_free_lparray_raw;
+		return (gpointer)mono_free_lparray;
 	case MONO_MARSHAL_CONV_DEL_FTN:
-		return (gpointer)mono_delegate_to_ftnptr_raw;
+		return (gpointer)mono_delegate_to_ftnptr;
 	case MONO_MARSHAL_CONV_FTN_DEL:
 		*ind_store_type = CEE_STIND_REF;
-		return (gpointer)mono_ftnptr_to_delegate_raw;
+		return (gpointer)mono_ftnptr_to_delegate;
 	case MONO_MARSHAL_CONV_UTF8STR_SB:
 	case MONO_MARSHAL_CONV_LPSTR_SB:
 		*ind_store_type = CEE_STIND_REF;
-		return (gpointer)mono_string_utf8_to_builder_raw;
+		return (gpointer)mono_string_utf8_to_builder;
 	case MONO_MARSHAL_CONV_LPTSTR_SB:
 		*ind_store_type = CEE_STIND_REF;
 #ifdef TARGET_WIN32
-		return (gpointer)mono_string_utf16_to_builder_raw;
+		return (gpointer)mono_string_utf16_to_builder;
 #else
-		return (gpointer)mono_string_utf8_to_builder_raw;
+		return (gpointer)mono_string_utf8_to_builder;
 #endif
 	case MONO_MARSHAL_CONV_LPWSTR_SB:
 		*ind_store_type = CEE_STIND_REF;
-		return (gpointer)mono_string_utf16_to_builder_raw;
+		return (gpointer)mono_string_utf16_to_builder;
 	case MONO_MARSHAL_FREE_ARRAY:
 		return (gpointer)mono_marshal_free_array;
 	case MONO_MARSHAL_CONV_STR_BYVALSTR:
-		return (gpointer)mono_string_to_byvalstr_raw;
+		return (gpointer)mono_string_to_byvalstr;
 	case MONO_MARSHAL_CONV_STR_BYVALWSTR:
-		return (gpointer)mono_string_to_byvalwstr_raw;
+		return (gpointer)mono_string_to_byvalwstr;
 	default:
 		g_assert_not_reached ();
 	}
@@ -818,7 +818,7 @@ emit_object_to_ptr_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv 
 		mono_mb_emit_ldloc (mb, 0);	
 		mono_mb_emit_byte (mb, CEE_LDIND_REF);
 		mono_mb_emit_icon (mb, mspec->data.array_data.num_elem);
-		mono_mb_emit_icall (mb, mono_array_to_byte_byvalarray_raw);
+		mono_mb_emit_icall (mb, mono_array_to_byte_byvalarray);
 		mono_mb_patch_short_branch (mb, pos);
 		break;
 	}
@@ -2870,7 +2870,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			mono_mb_emit_byte (mb, CEE_ADD);
 		}
 		mono_mb_emit_byte (mb, CEE_MUL);
-		mono_mb_emit_icall (mb, ves_icall_marshal_alloc_raw);
+		mono_mb_emit_icall (mb, ves_icall_marshal_alloc);
 		mono_mb_emit_stloc (mb, dest);
 		mono_mb_emit_ldloc (mb, dest);
 		mono_mb_emit_stloc (mb, 3);
@@ -4587,7 +4587,7 @@ emit_marshal_asany_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		mono_mb_emit_ldarg (mb, argnum);
 		mono_mb_emit_icon (mb, encoding);
 		mono_mb_emit_icon (mb, t->attrs);
-		mono_mb_emit_icall (mb, mono_marshal_asany_raw);
+		mono_mb_emit_icall (mb, mono_marshal_asany);
 		mono_mb_emit_stloc (mb, conv_arg);
 		break;
 	}
@@ -4603,7 +4603,7 @@ emit_marshal_asany_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		mono_mb_emit_ldloc (mb, conv_arg);
 		mono_mb_emit_icon (mb, encoding);
 		mono_mb_emit_icon (mb, t->attrs);
-		mono_mb_emit_icall (mb, mono_marshal_free_asany_raw);
+		mono_mb_emit_icall (mb, mono_marshal_free_asany);
 		break;
 	}
 
@@ -4876,7 +4876,7 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		g_assert (m->retobj_var);
 		mono_mb_emit_icon (mb, mono_class_native_size (klass, NULL));
 		mono_mb_emit_byte (mb, CEE_CONV_I);
-		mono_mb_emit_icall (mb, ves_icall_marshal_alloc_raw);
+		mono_mb_emit_icall (mb, ves_icall_marshal_alloc);
 		mono_mb_emit_stloc (mb, 1);
 		mono_mb_emit_ldloc (mb, 1);
 		mono_mb_emit_stloc (mb, m->retobj_var);
@@ -5047,7 +5047,7 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	case MARSHAL_ACTION_MANAGED_CONV_RESULT:
 		if (conv_to_icall (conv, NULL) == mono_marshal_string_to_utf16)
 			/* We need to make a copy so the caller is able to free it */
-			mono_mb_emit_icall (mb, mono_marshal_string_to_utf16_copy_raw);
+			mono_mb_emit_icall (mb, mono_marshal_string_to_utf16_copy);
 		else
 			mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
 		mono_mb_emit_stloc (mb, 3);
@@ -5434,13 +5434,13 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 				switch (encoding) {
 				case MONO_NATIVE_LPWSTR:
-					mono_mb_emit_icall (mb, mono_string_utf16_to_builder2_raw);
+					mono_mb_emit_icall (mb, mono_string_utf16_to_builder2);
 					break;
 				case MONO_NATIVE_LPSTR:
-					mono_mb_emit_icall (mb, mono_string_utf8_to_builder2_raw);
+					mono_mb_emit_icall (mb, mono_string_utf8_to_builder2);
 					break;
 				case MONO_NATIVE_UTF8STR:
-					mono_mb_emit_icall (mb, mono_string_utf8_to_builder2_raw);
+					mono_mb_emit_icall (mb, mono_string_utf8_to_builder2);
 					break;
 				default:
 					g_assert_not_reached ();
@@ -5621,7 +5621,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			g_assert (encoding != -1);
 
 			mono_mb_emit_ldarg (mb, argnum);
-			mono_mb_emit_icall (mb, mono_string_utf8_to_builder2_raw);
+			mono_mb_emit_icall (mb, mono_string_utf8_to_builder2);
 			mono_mb_emit_stloc (mb, conv_arg);
 			break;
 		}
@@ -5706,7 +5706,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			/* Allocate and set dest */
 			mono_mb_emit_icon (mb, mono_class_native_size (klass, NULL));
 			mono_mb_emit_byte (mb, CEE_CONV_I);
-			mono_mb_emit_icall (mb, ves_icall_marshal_alloc_raw);
+			mono_mb_emit_icall (mb, ves_icall_marshal_alloc);
 			mono_mb_emit_stloc (mb, 1);
 			
 			/* Update argument pointer */
@@ -5770,7 +5770,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		/* Allocate and set dest */
 		mono_mb_emit_icon (mb, mono_class_native_size (klass, NULL));
 		mono_mb_emit_byte (mb, CEE_CONV_I);
-		mono_mb_emit_icall (mb, ves_icall_marshal_alloc_raw);
+		mono_mb_emit_icall (mb, ves_icall_marshal_alloc);
 		mono_mb_emit_byte (mb, CEE_DUP);
 		mono_mb_emit_stloc (mb, 1);
 		mono_mb_emit_stloc (mb, 3);

--- a/mono/metadata/marshal-internals.h
+++ b/mono/metadata/marshal-internals.h
@@ -35,22 +35,7 @@ mono_marshal_realloc_hglobal (gpointer ptr, size_t size);
 void
 mono_marshal_free_hglobal (void *ptr);
 
-// Allocates with CoTaskMemAlloc. Free with mono_marshal_free (CoTaskMemFree).
-gpointer
-mono_string_to_utf8str_handle (MonoStringHandle s, MonoError *error);
-
-#else
-
-// Allocates with g_malloc. Free with mono_marshal_free (g_free).
-#define mono_string_to_utf8str_handle mono_string_handle_to_utf8
-
 #endif // HOST_WIN32
-
-// Windows: Allocates with CoTaskMemAlloc.
-// Unix: Allocates with g_malloc.
-// Either way: Free with mono_marshal_free (Windows:CoTaskMemFree, Unix:g_free).
-gpointer
-mono_string_to_utf8str (MonoString *s);
 
 typedef enum {
 	TYPECHECK_OBJECT_ARG_POS = 0,

--- a/mono/metadata/marshal-windows.c
+++ b/mono/metadata/marshal-windows.c
@@ -13,6 +13,7 @@
 #include <windows.h>
 #include <objbase.h>
 #include "mono/metadata/marshal-windows-internals.h"
+#include "icall-decl.h"
 
 #if G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT)
 void*
@@ -79,7 +80,7 @@ ves_icall_System_Runtime_InteropServices_Marshal_StringToHGlobalAnsi (const guni
 }
 
 gpointer
-mono_string_to_utf8str_handle (MonoStringHandle s, MonoError *error)
+mono_string_to_utf8str (MonoStringHandle s, MonoError *error)
 {
 	char *as, *tmp;
 	glong len;

--- a/mono/metadata/marshal-windows.c
+++ b/mono/metadata/marshal-windows.c
@@ -80,7 +80,7 @@ ves_icall_System_Runtime_InteropServices_Marshal_StringToHGlobalAnsi (const guni
 }
 
 gpointer
-mono_string_to_utf8str (MonoStringHandle s, MonoError *error)
+mono_string_to_utf8str_impl (MonoStringHandle s, MonoError *error)
 {
 	char *as, *tmp;
 	glong len;

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -57,9 +57,9 @@
 #include <mono/utils/mono-threads.h>
 #include <mono/utils/mono-threads-coop.h>
 #include <mono/utils/mono-error-internals.h>
-
 #include <string.h>
 #include <errno.h>
+#include "icall-decl.h"
 
 /* #define DEBUG_RUNTIME_CODE */
 
@@ -100,15 +100,6 @@ delegate_hash_table_add (MonoDelegateHandle d);
 
 static void
 delegate_hash_table_remove (MonoDelegate *d);
-
-gpointer
-mono_delegate_handle_to_ftnptr (MonoDelegateHandle delegate, MonoError *error);
-
-MonoDelegateHandle
-mono_ftnptr_to_delegate_handle (MonoClass *klass, gpointer ftn, MonoError *error);
-
-static void
-mono_string_utf16len_to_builder (MonoStringBuilder *sb, const gunichar2 *text, guint32 len);
 
 /* Lazy class loading functions */
 //used by marshal-ilgen.c
@@ -206,35 +197,29 @@ mono_object_isinst_icall (MonoObject *obj, MonoClass *klass)
 	return result;
 }
 
-MonoString*
-ves_icall_mono_string_from_utf16 (const gunichar2 *data)
+MonoStringHandle
+ves_icall_mono_string_from_utf16 (const gunichar2 *data, MonoError *error)
 {
-	ERROR_DECL (error);
-	MonoString *result = mono_string_from_utf16_checked (data, error);
-	mono_error_set_pending_exception (error);
-	return result;
+	MonoString *s = mono_string_from_utf16_checked (data, error);
+	return_val_if_nok (error, NULL_HANDLE_STRING);
+	return MONO_HANDLE_NEW (MonoString, s);
 }
 
 char*
-ves_icall_mono_string_to_utf8 (MonoString *str)
+ves_icall_mono_string_to_utf8 (MonoStringHandle str, MonoError *error)
 {
-	ERROR_DECL (error);
-	char *result = mono_string_to_utf8_checked_internal (str, error);
-	mono_error_set_pending_exception (error);
-	return result;
+	return mono_string_handle_to_utf8 (str, error);
 }
 
-MonoString*
-ves_icall_string_new_wrapper (const char *text)
+MonoStringHandle
+ves_icall_string_new_wrapper (const char *text, MonoError *error)
 {
 	if (text) {
-		ERROR_DECL (error);
-		MonoString *res = mono_string_new_checked (mono_domain_get (), text, error);
-		mono_error_set_pending_exception (error);
-		return res;
+		MonoString *s = mono_string_new_checked (mono_domain_get (), text, error);
+		return_val_if_nok (error, NULL_HANDLE_STRING);
+		return MONO_HANDLE_NEW (MonoString, s);
 	}
-
-	return NULL;
+	return NULL_HANDLE_STRING;
 }
 
 void
@@ -248,39 +233,39 @@ mono_marshal_init (void)
 		marshal_mutex_initialized = TRUE;
 
 		register_icall (mono_marshal_string_to_utf16, "mono_marshal_string_to_utf16", "ptr obj", FALSE);
-		register_icall (mono_marshal_string_to_utf16_copy, "mono_marshal_string_to_utf16_copy", "ptr obj", FALSE);
-		register_icall (mono_string_to_utf16_internal, "mono_string_to_utf16_internal", "ptr obj", FALSE);
-		register_icall (ves_icall_mono_string_from_utf16, "ves_icall_mono_string_from_utf16", "obj ptr", FALSE);
-		register_icall (mono_string_from_byvalstr, "mono_string_from_byvalstr", "obj ptr int", FALSE);
-		register_icall (mono_string_from_byvalwstr, "mono_string_from_byvalwstr", "obj ptr int", FALSE);
-		register_icall (mono_string_new_wrapper_internal, "mono_string_new_wrapper_internal", "obj ptr", FALSE);
-		register_icall (ves_icall_string_new_wrapper, "ves_icall_string_new_wrapper", "obj ptr", FALSE);
-		register_icall (mono_string_new_len_wrapper, "mono_string_new_len_wrapper", "obj ptr int", FALSE);
-		register_icall (ves_icall_mono_string_to_utf8, "ves_icall_mono_string_to_utf8", "ptr obj", FALSE);
-		register_icall (mono_string_to_utf8str, "mono_string_to_utf8str", "ptr obj", FALSE);
-		register_icall (mono_string_to_ansibstr, "mono_string_to_ansibstr", "ptr object", FALSE);
-		register_icall (mono_string_builder_to_utf8, "mono_string_builder_to_utf8", "ptr object", FALSE);
-		register_icall (mono_string_builder_to_utf16, "mono_string_builder_to_utf16", "ptr object", FALSE);
-		register_icall (mono_array_to_savearray, "mono_array_to_savearray", "ptr object", FALSE);
-		register_icall (mono_array_to_lparray, "mono_array_to_lparray", "ptr object", FALSE);
-		register_icall (mono_free_lparray, "mono_free_lparray", "void object ptr", FALSE);
-		register_icall (mono_byvalarray_to_byte_array, "mono_byvalarray_to_byte_array", "void object ptr int32", FALSE);
-		register_icall (mono_array_to_byte_byvalarray, "mono_array_to_byte_byvalarray", "void ptr object int32", FALSE);
-		register_icall (mono_delegate_to_ftnptr, "mono_delegate_to_ftnptr", "ptr object", FALSE);
-		register_icall (mono_ftnptr_to_delegate, "mono_ftnptr_to_delegate", "object ptr ptr", FALSE);
-		register_icall (mono_marshal_asany, "mono_marshal_asany", "ptr object int32 int32", FALSE);
-		register_icall (mono_marshal_free_asany, "mono_marshal_free_asany", "void object ptr int32 int32", FALSE);
-		register_icall (ves_icall_marshal_alloc, "ves_icall_marshal_alloc", "ptr ptr", FALSE);
+		register_icall (mono_marshal_string_to_utf16_copy_raw, "mono_marshal_string_to_utf16_copy", "ptr obj", FALSE);
+		register_icall (mono_string_to_utf16_internal_raw, "mono_string_to_utf16_internal", "ptr obj", FALSE);
+		register_icall (ves_icall_mono_string_from_utf16_raw, "ves_icall_mono_string_from_utf16", "obj ptr", FALSE);
+		register_icall (mono_string_from_byvalstr_raw, "mono_string_from_byvalstr", "obj ptr int", FALSE);
+		register_icall (mono_string_from_byvalwstr_raw, "mono_string_from_byvalwstr", "obj ptr int", FALSE);
+		register_icall (mono_string_new_wrapper_internal_raw, "mono_string_new_wrapper_internal", "obj ptr", FALSE);
+		register_icall (ves_icall_string_new_wrapper_raw, "ves_icall_string_new_wrapper", "obj ptr", FALSE);
+		register_icall (mono_string_new_len_wrapper_raw, "mono_string_new_len_wrapper", "obj ptr int", FALSE);
+		register_icall (ves_icall_mono_string_to_utf8_raw, "ves_icall_mono_string_to_utf8", "ptr obj", FALSE);
+		register_icall (mono_string_to_utf8str_raw, "mono_string_to_utf8str", "ptr obj", FALSE);
+		register_icall (mono_string_to_ansibstr_raw, "mono_string_to_ansibstr", "ptr object", FALSE);
+		register_icall (mono_string_builder_to_utf8_raw, "mono_string_builder_to_utf8", "ptr object", FALSE);
+		register_icall (mono_string_builder_to_utf16_raw, "mono_string_builder_to_utf16", "ptr object", FALSE);
+		register_icall (mono_array_to_savearray_raw, "mono_array_to_savearray", "ptr object", FALSE);
+		register_icall (mono_array_to_lparray_raw, "mono_array_to_lparray", "ptr object", FALSE);
+		register_icall (mono_free_lparray_raw, "mono_free_lparray", "void object ptr", FALSE);
+		register_icall (mono_byvalarray_to_byte_array_raw, "mono_byvalarray_to_byte_array", "void object ptr int32", FALSE);
+		register_icall (mono_array_to_byte_byvalarray_raw, "mono_array_to_byte_byvalarray", "void ptr object int32", FALSE);
+		register_icall (mono_delegate_to_ftnptr_raw, "mono_delegate_to_ftnptr", "ptr object", FALSE);
+		register_icall (mono_ftnptr_to_delegate_raw, "mono_ftnptr_to_delegate", "object ptr ptr", FALSE);
+		register_icall (mono_marshal_asany_raw, "mono_marshal_asany", "ptr object int32 int32", FALSE);
+		register_icall (mono_marshal_free_asany_raw, "mono_marshal_free_asany", "void object ptr int32 int32", FALSE);
+		register_icall (ves_icall_marshal_alloc_raw, "ves_icall_marshal_alloc", "ptr ptr", FALSE);
 		register_icall (mono_marshal_free, "mono_marshal_free", "void ptr", FALSE);
 		register_icall (mono_marshal_set_last_error, "mono_marshal_set_last_error", "void", TRUE);
 		register_icall (mono_marshal_set_last_error_windows, "mono_marshal_set_last_error_windows", "void int32", TRUE);
-		register_icall (mono_string_utf8_to_builder, "mono_string_utf8_to_builder", "void ptr ptr", FALSE);
-		register_icall (mono_string_utf8_to_builder2, "mono_string_utf8_to_builder2", "object ptr", FALSE);
-		register_icall (mono_string_utf16_to_builder, "mono_string_utf16_to_builder", "void ptr ptr", FALSE);
-		register_icall (mono_string_utf16_to_builder2, "mono_string_utf16_to_builder2", "object ptr", FALSE);
+		register_icall (mono_string_utf8_to_builder_raw, "mono_string_utf8_to_builder", "void ptr ptr", FALSE);
+		register_icall (mono_string_utf8_to_builder2_raw, "mono_string_utf8_to_builder2", "object ptr", FALSE);
+		register_icall (mono_string_utf16_to_builder_raw, "mono_string_utf16_to_builder", "void ptr ptr", FALSE);
+		register_icall (mono_string_utf16_to_builder2_raw, "mono_string_utf16_to_builder2", "object ptr", FALSE);
 		register_icall (mono_marshal_free_array, "mono_marshal_free_array", "void ptr int32", FALSE);
-		register_icall (mono_string_to_byvalstr, "mono_string_to_byvalstr", "void ptr ptr int32", FALSE);
-		register_icall (mono_string_to_byvalwstr, "mono_string_to_byvalwstr", "void ptr ptr int32", FALSE);
+		register_icall (mono_string_to_byvalstr_raw, "mono_string_to_byvalstr", "void ptr ptr int32", FALSE);
+		register_icall (mono_string_to_byvalwstr_raw, "mono_string_to_byvalwstr", "void ptr ptr int32", FALSE);
 		register_dyn_icall (g_free, "g_free", "void ptr", FALSE);
 		register_icall_no_wrapper (mono_object_isinst_icall, "mono_object_isinst_icall", "object object ptr");
 		register_icall (mono_struct_delete_old, "mono_struct_delete_old", "void ptr ptr", FALSE);
@@ -328,24 +313,11 @@ mono_marshal_unlock_internal (void)
 	mono_marshal_unlock ();
 }
 
-/* This is a JIT icall, it sets the pending exception and return NULL on error */
+// This is a JIT icall, it sets the pending exception (in wrapper) and return NULL on error.
 gpointer
-mono_delegate_to_ftnptr (MonoDelegate *delegate_raw)
+mono_delegate_to_ftnptr (MonoDelegateHandle delegate, MonoError *error)
 {
-	HANDLE_FUNCTION_ENTER ();
-	ERROR_DECL (error);
-	MONO_HANDLE_DCL (MonoDelegate, delegate);
-	gpointer result = mono_delegate_handle_to_ftnptr (delegate, error);
-	mono_error_set_pending_exception (error);
-	HANDLE_FUNCTION_RETURN_VAL (result);
-}
-
-gpointer
-mono_delegate_handle_to_ftnptr (MonoDelegateHandle delegate, MonoError *error)
-{
-	HANDLE_FUNCTION_ENTER ();
 	gpointer result = NULL;
-	error_init (error);
 	MonoMethod *method, *wrapper;
 	MonoClass *klass;
 	uint32_t target_handle = 0;
@@ -406,7 +378,7 @@ mono_delegate_handle_to_ftnptr (MonoDelegateHandle delegate, MonoError *error)
 leave:
 	if (!is_ok (error) && target_handle != 0)
 		mono_gchandle_free_internal (target_handle);
-	HANDLE_FUNCTION_RETURN_VAL (result);
+	return result;
 }
 
 /* 
@@ -504,22 +476,10 @@ parse_unmanaged_function_pointer_attr (MonoClass *klass, MonoMethodPInvoke *piin
 	}
 }
 
-/* This is a JIT icall, it sets the pending exception and returns NULL on error */
-MonoDelegate*
-mono_ftnptr_to_delegate (MonoClass *klass, gpointer ftn)
-{
-	HANDLE_FUNCTION_ENTER ();
-	ERROR_DECL (error);
-	MonoDelegateHandle result = mono_ftnptr_to_delegate_handle (klass, ftn, error);
-	mono_error_set_pending_exception (error);
-	HANDLE_FUNCTION_RETURN_OBJ (result);
-}
-
+/* This is a JIT icall, it sets the pending exception (in wrapper) and returns NULL on error */
 MonoDelegateHandle
-mono_ftnptr_to_delegate_handle (MonoClass *klass, gpointer ftn, MonoError *error)
+mono_ftnptr_to_delegate (MonoClass *klass, gpointer ftn, MonoError *error)
 {
-	HANDLE_FUNCTION_ENTER ();
-	error_init (error);
 	guint32 gchandle;
 	MonoDelegateHandle d = MONO_HANDLE_NEW (MonoDelegate, NULL);
 
@@ -585,9 +545,8 @@ mono_ftnptr_to_delegate_handle (MonoClass *klass, gpointer ftn, MonoError *error
 	g_assert (!MONO_HANDLE_IS_NULL (d));
 	if (MONO_HANDLE_DOMAIN (d) != mono_domain_get ())
 		mono_error_set_not_supported (error, "Delegates cannot be marshalled from native code into a domain other than their home domain");
-
 leave:
-	HANDLE_FUNCTION_RETURN_REF (MonoDelegate, d);
+	return d;
 }
 
 void
@@ -628,49 +587,45 @@ mono_delegate_free_ftnptr (MonoDelegate *delegate)
 	}
 }
 
-/* This is a JIT icall, it sets the pending exception and returns NULL on error */
-MonoString *
-mono_string_from_byvalstr (const char *data, int max_len)
+/* This is a JIT icall, it sets the pending exception (in wrapper) and returns NULL on error */
+MonoStringHandle
+mono_string_from_byvalstr (const char *data, int max_len, MonoError *error)
 {
+	// FIXME This optimization ok to miss before wrapper? Or null is rare?
 	if (!data)
-		return NULL;
+		return NULL_HANDLE_STRING;
 
-	HANDLE_FUNCTION_ENTER ();
-	ERROR_DECL (error);
 	int len = 0;
-
 	while (len < max_len - 1 && data [len])
 		len++;
 
-	MonoStringHandle result = mono_string_new_utf8_len (mono_domain_get (), data, len, error);
-	mono_error_set_pending_exception (error);
-
-	HANDLE_FUNCTION_RETURN_OBJ (result);
+	// FIXMEcoop
+	MonoString *s = mono_string_new_len_checked (mono_domain_get (), data, len, error);
+	return_val_if_nok (error, NULL_HANDLE_STRING);
+	return MONO_HANDLE_NEW (MonoString, s);
 }
 
-/* This is a JIT icall, it sets the pending exception and return NULL on error */
-MonoString *
-mono_string_from_byvalwstr (gunichar2 *data, int max_len)
+/* This is a JIT icall, it sets the pending exception (in wrapper) and return NULL on error */
+MonoStringHandle
+mono_string_from_byvalwstr (const gunichar2 *data, int max_len, MonoError *error)
 {
+	// FIXME This optimization ok to miss before wrapper? Or null is rare?
 	if (!data)
-		return NULL;
+		return NULL_HANDLE_STRING;
 
-	ERROR_DECL (error);
-	MonoString *res = NULL;
-	int len = g_utf16_len (data);
+	// FIXME Check max_len while scanning data? mono_string_from_byvalstr does.
+	int len = 0;
+	while (data [len]) len++;
 
-	res = mono_string_new_utf16_checked (mono_domain_get (), data, MIN (len, max_len), error);
-	if (!mono_error_ok (error)) {
-		mono_error_set_pending_exception (error);
-		return NULL;
-	}
-	return res;
+	MonoString *res = mono_string_new_utf16_checked (mono_domain_get (), data, MIN (len, max_len), error);
+	return_val_if_nok (error, NULL_HANDLE_STRING);
+	return MONO_HANDLE_NEW (MonoString, res);
 }
 
 gpointer
-mono_array_to_savearray (MonoArray *array)
+mono_array_to_savearray (MonoArrayHandle array, MonoError *error)
 {
-	if (!array)
+	if (!MONO_HANDLE_BOOL (array))
 		return NULL;
 
 	g_assert_not_reached ();
@@ -678,22 +633,18 @@ mono_array_to_savearray (MonoArray *array)
 }
 
 gpointer
-mono_array_to_lparray (MonoArray *array)
+mono_array_to_lparray (MonoArrayHandle array_handle, MonoError *error)
 {
+	if (!MONO_HANDLE_BOOL (array_handle))
+		return NULL;
+
+	MonoArray *array = MONO_HANDLE_RAW (array_handle); // FIXMEcoop
+
 #ifndef DISABLE_COM
 	gpointer *nativeArray = NULL;
 	int nativeArraySize = 0;
-
 	int i = 0;
-	MonoClass *klass;
-	ERROR_DECL (error);
-#endif
-
-	if (!array)
-		return NULL;
-#ifndef DISABLE_COM
-	error_init (error);
-	klass = array->obj.vtable->klass;
+	MonoClass *klass = array->obj.vtable->klass;
 	MonoClass *klass_element_class = m_class_get_element_class (klass);
 
 	switch (m_class_get_byval_arg (klass_element_class)->type) {
@@ -702,11 +653,13 @@ mono_array_to_lparray (MonoArray *array)
 		break;
 	case MONO_TYPE_CLASS:
 		nativeArraySize = array->max_length;
-		nativeArray = (void **)g_malloc (sizeof(gpointer) * nativeArraySize);
-		for(i = 0; i < nativeArraySize; ++i) {
-			nativeArray[i] = mono_cominterop_get_com_interface (((MonoObject **)array->vector)[i], klass_element_class, error);
-			if (mono_error_set_pending_exception (error))
+		nativeArray = g_new (gpointer, nativeArraySize);
+		for (i = 0; i < nativeArraySize; ++i) {
+			nativeArray [i] = mono_cominterop_get_com_interface (((MonoObject **)array->vector)[i], klass_element_class, error);
+			if (!is_ok (error)) {
+				// FIXME? Returns uninitialized.
 				break;
+			}
 		}
 		return nativeArray;
 	case MONO_TYPE_U1:
@@ -741,70 +694,66 @@ mono_array_to_lparray (MonoArray *array)
 }
 
 void
-mono_free_lparray (MonoArray *array, gpointer* nativeArray)
+mono_free_lparray (MonoArrayHandle array, gpointer* nativeArray, MonoError *error)
 {
 #ifndef DISABLE_COM
-	MonoClass *klass;
-
-	if (!array)
+	if (!nativeArray || MONO_HANDLE_IS_NULL (array))
 		return;
 
-	if (!nativeArray)
-		return;
-	klass = array->obj.vtable->klass;
+	MonoClass * const klass = mono_handle_class (array);
 
 	if (m_class_get_byval_arg (m_class_get_element_class (klass))->type == MONO_TYPE_CLASS)
 		g_free (nativeArray);
 #endif
 }
 
+/* This is a JIT icall, it sets the pending exception (in wrapper) and returns on error */
 void
-mono_byvalarray_to_byte_array (MonoArray *arr, gpointer native_arr, guint32 elnum)
+mono_byvalarray_to_byte_array (MonoArrayHandle arr, const char *native_arr, guint32 elnum, MonoError *error)
 {
-	g_assert (m_class_get_element_class (mono_object_class (&arr->obj)) == mono_defaults.char_class);
+	g_assert (m_class_get_element_class (mono_handle_class (arr)) == mono_defaults.char_class);
 
 	GError *gerror = NULL;
-	gunichar2 *ut;
 	glong items_written;
-
-	ut = g_utf8_to_utf16 ((const gchar *)native_arr, elnum, NULL, &items_written, &gerror);
-
-	if (!gerror) {
-		memcpy (mono_array_addr_internal (arr, gunichar2, 0), ut, items_written * sizeof (gunichar2));
-		g_free (ut);
-	}
-	else
-		g_error_free (gerror);
-}
-
-/* This is a JIT icall, it sets the pending exception and returns on error */
-void
-mono_array_to_byte_byvalarray (gpointer native_arr, MonoArray *arr, guint32 elnum)
-{
-	char *as;
-	GError *gerror = NULL;
-
-	as = g_utf16_to_utf8 (mono_array_addr_internal (arr, gunichar2, 0), mono_array_length_internal (arr), NULL, NULL, &gerror);
+	gunichar2 *ut = g_utf8_to_utf16 (native_arr, elnum, NULL, &items_written, &gerror);
 	if (gerror) {
-		ERROR_DECL (error);
-		mono_error_set_argument (error, "string", gerror->message);
-		mono_error_set_pending_exception (error);
+		// FIXME set error?
 		g_error_free (gerror);
 		return;
 	}
+	gchandle_t gchandle = 0;
+	memcpy (MONO_ARRAY_HANDLE_PIN (arr, gunichar2, 0, &gchandle), ut, items_written * sizeof (gunichar2));
+	mono_gchandle_free_internal (gchandle);
+	g_free (ut);
+}
 
+/* This is a JIT icall, it sets the pending exception (in wrapper) and returns on error */
+void
+mono_array_to_byte_byvalarray (gpointer native_arr, MonoArrayHandle arr, guint32 elnum, MonoError *error)
+{
+	g_assert (m_class_get_element_class (mono_handle_class (arr)) == mono_defaults.char_class);
+
+	GError *gerror = NULL;
+
+	gchandle_t gchandle = 0;
+	char *as = g_utf16_to_utf8 (MONO_ARRAY_HANDLE_PIN (arr, gunichar2, 0, &gchandle), mono_array_handle_length (arr), NULL, NULL, &gerror);
+	mono_gchandle_free_internal (gchandle);
+	if (gerror) {
+		mono_error_set_argument (error, "string", gerror->message);
+		g_error_free (gerror);
+		return;
+	}
 	memcpy (native_arr, as, MIN (strlen (as), elnum));
 	g_free (as);
 }
 
-static MonoStringBuilder *
-mono_string_builder_new (int starting_string_length)
+static MonoStringBuilderHandle
+mono_string_builder_new (int starting_string_length, MonoError *error)
 {
 	static MonoClass *string_builder_class;
 	static MonoMethod *sb_ctor;
 	void *args [1];
 
-	ERROR_DECL (error);
 	int initial_len = starting_string_length;
 
 	if (initial_len < 0)
@@ -828,46 +777,49 @@ mono_string_builder_new (int starting_string_length)
 	// array will always be garbage collected.
 	args [0] = &initial_len;
 
-	MonoStringBuilder *sb = (MonoStringBuilder*)mono_object_new_checked (mono_domain_get (), string_builder_class, error);
+	MonoStringBuilderHandle sb = MONO_HANDLE_CAST (MonoStringBuilder, mono_object_new_handle (mono_domain_get (), string_builder_class, error));
 	mono_error_assert_ok (error);
 
-	MonoObject *exc;
-	mono_runtime_try_invoke (sb_ctor, sb, args, &exc, error);
-	g_assert (exc == NULL);
+	mono_runtime_try_invoke_handle (sb_ctor, MONO_HANDLE_CAST (MonoObject, sb), args, error);
 	mono_error_assert_ok (error);
 
-	g_assert (sb->chunkChars->max_length >= initial_len);
+	MonoArrayHandle chunkChars = MONO_HANDLE_NEW_GET (MonoArray, sb, chunkChars);
+	g_assert (MONO_HANDLE_GETVAL (chunkChars, max_length) >= initial_len);
 
 	return sb;
 }
 
 static void
-mono_string_utf16_to_builder_copy (MonoStringBuilder *sb, const gunichar2 *text, size_t string_len)
+mono_string_utf16_to_builder_copy (MonoStringBuilderHandle sb, const gunichar2 *text, size_t string_len, MonoError *error)
 {
-	gunichar2 *charDst = (gunichar2 *)sb->chunkChars->vector;
-	memcpy (charDst, text, sizeof (gunichar2) * string_len);
-
-	sb->chunkLength = string_len;
+	MonoArrayHandle chunkChars = MONO_HANDLE_NEW_GET (MonoArray, sb, chunkChars);
+	gchandle_t gchandle = 0;
+	memcpy (MONO_ARRAY_HANDLE_PIN (chunkChars, gunichar2, 0, &gchandle), text, sizeof (gunichar2) * string_len);
+	mono_gchandle_free_internal (gchandle);
+	MONO_HANDLE_SETRAW (sb, chunkLength, string_len);
 }
 
-MonoStringBuilder *
-mono_string_utf16_to_builder2 (const gunichar2 *text)
+MonoStringBuilderHandle
+mono_string_utf16_to_builder2 (const gunichar2 *text, MonoError *error)
 {
 	if (!text)
-		return NULL;
+		return NULL_HANDLE_STRING_BUILDER;
 
-	int len = g_utf16_len (text);
+	const gsize len = g_utf16_len (text);
 
-	MonoStringBuilder *sb = mono_string_builder_new (len);
-	mono_string_utf16len_to_builder (sb, text, len);
+	MonoStringBuilderHandle sb = mono_string_builder_new (len, error);
+	return_val_if_nok (error, NULL_HANDLE_STRING_BUILDER);
+
+	mono_string_utf16_to_builder_copy (sb, text, len, error);
+	return_val_if_nok (error, NULL_HANDLE_STRING_BUILDER);
 
 	return sb;
 }
 
 static void
-mono_string_utf8len_to_builder (MonoStringBuilder *sb, const char *text, gsize len)
+mono_string_utf8len_to_builder (MonoStringBuilderHandle sb, const char *text, gsize len, MonoError *error)
 {
-	if (!sb || !text)
+	if (!MONO_HANDLE_BOOL (sb) || !text)
 		return;
 
 	GError *gerror = NULL;
@@ -879,8 +831,8 @@ mono_string_utf8len_to_builder (MonoStringBuilder *sb, const char *text, gsize l
 		copied = capacity;
 
 	if (!gerror) {
-		MONO_OBJECT_SETREF_INTERNAL (sb, chunkPrevious, NULL);
-		mono_string_utf16_to_builder_copy (sb, ut, copied);
+		MONO_HANDLE_SETRAW (sb, chunkPrevious, NULL);
+		mono_string_utf16_to_builder_copy (sb, ut, copied, error);
 	} else
 		g_error_free (gerror);
 
@@ -888,40 +840,41 @@ mono_string_utf8len_to_builder (MonoStringBuilder *sb, const char *text, gsize l
 }
 
 void
-mono_string_utf8_to_builder (MonoStringBuilder *sb, const char *text)
+mono_string_utf8_to_builder (MonoStringBuilderHandle sb, const char *text, MonoError *error)
 {
-	return mono_string_utf8len_to_builder (sb, text, text ? strlen (text) : 0);
+	mono_string_utf8len_to_builder (sb, text, text ? strlen (text) : 0, error);
 }
 
-MonoStringBuilder *
-mono_string_utf8_to_builder2 (const char *text)
+MonoStringBuilderHandle
+mono_string_utf8_to_builder2 (const char *text, MonoError *error)
 {
 	if (!text)
-		return NULL;
+		return NULL_HANDLE_STRING_BUILDER;
 
-	int len = strlen (text);
-	MonoStringBuilder *sb = mono_string_builder_new (len);
-	mono_string_utf8len_to_builder (sb, text, len);
+	const gsize len = strlen (text);
+
+	MonoStringBuilderHandle sb = mono_string_builder_new (len, error);
+	return_val_if_nok (error, NULL_HANDLE_STRING_BUILDER);
+
+	mono_string_utf8len_to_builder (sb, text, len, error);
+	return_val_if_nok (error, NULL_HANDLE_STRING_BUILDER);
 
 	return sb;
 }
 
-void
-mono_string_utf16len_to_builder (MonoStringBuilder *sb, const gunichar2 *text, guint32 len)
+static void
+mono_string_utf16len_to_builder (MonoStringBuilderHandle sb, const gunichar2 *text, gsize len, MonoError *error)
 {
-	if (!sb || !text)
+	if (!MONO_HANDLE_BOOL (sb) || !text)
 		return;
-	
-	if (len > mono_string_builder_capacity (sb))
-		len = mono_string_builder_capacity (sb);
-
-	mono_string_utf16_to_builder_copy (sb, text, len);
+	len = MIN (len, mono_string_builder_capacity (sb));
+	mono_string_utf16_to_builder_copy (sb, text, len, error);
 }
 
 void
-mono_string_utf16_to_builder (MonoStringBuilder *sb, const gunichar2 *text)
+mono_string_utf16_to_builder (MonoStringBuilderHandle sb, const gunichar2 *text, MonoError *error)
 {
-	mono_string_utf16len_to_builder (sb, text, text ? g_utf16_len (text) : 0);
+	mono_string_utf16_to_builder_copy (sb, text, text ? g_utf16_len (text) : 0, error);
 }
 
 /**
@@ -934,33 +887,33 @@ mono_string_utf16_to_builder (MonoStringBuilder *sb, const gunichar2 *text)
  *
  * The return value must be released with mono_marshal_free.
  *
- * This is a JIT icall, it sets the pending exception and returns NULL on error.
+ * This is a JIT icall, it sets the pending exception (in wrapper) and returns NULL on error.
  */
 gchar*
-mono_string_builder_to_utf8 (MonoStringBuilder *sb)
+mono_string_builder_to_utf8 (MonoStringBuilderHandle sb, MonoError *error)
 {
-	if (!sb)
-		return NULL;
-
-	ERROR_DECL (error);
 	char *res = NULL;
+	GError *gerror = NULL;
+	char *tmp = NULL;
+	gunichar2 *str_utf16 = NULL;
+	glong byte_count;
 	guint len = 0;
 
-	gunichar2 *str_utf16 = mono_string_builder_to_utf16 (sb);
+	if (!MONO_HANDLE_BOOL (sb))
+		goto exit;
 
-	GError *gerror = NULL;
-	glong byte_count;
-	char *tmp = g_utf16_to_utf8 (str_utf16, mono_string_builder_string_length (sb), NULL, &byte_count, &gerror);
+	str_utf16 = mono_string_builder_to_utf16 (sb, error);
+	goto_if_nok (error, exit);
+
+	tmp = g_utf16_to_utf8 (str_utf16, mono_string_builder_string_length (sb), NULL, &byte_count, &gerror);
 	if (gerror) {
 		mono_error_set_execution_engine (error, "Failed to convert StringBuilder from utf16 to utf8");
-		mono_error_set_pending_exception (error);
 		goto exit;
 	}
 
 	len = mono_string_builder_capacity (sb) + 1;
 	res = (char *)mono_marshal_alloc (MAX (byte_count + 1, len), error);
-	if (!mono_error_ok (error)) {
-		mono_error_set_pending_exception (error);
+	if (!is_ok (error)) {
 		res = NULL;
 		goto exit;
 	}
@@ -968,8 +921,7 @@ mono_string_builder_to_utf8 (MonoStringBuilder *sb)
 	memcpy (res, tmp, byte_count);
 	res [byte_count] = 0;
 exit:
-	if (gerror)
-		g_error_free (gerror);
+	g_error_free (gerror);
 	mono_marshal_free (str_utf16);
 	g_free (tmp);
 	return res;
@@ -985,63 +937,62 @@ exit:
  *
  * The return value must be released with mono_marshal_free.
  *
- * This is a JIT icall, it sets the pending exception and returns NULL on error.
+ * This is a JIT icall, it sets the pending exception (in wrapper) and returns NULL on error.
  */
 gunichar2*
-mono_string_builder_to_utf16 (MonoStringBuilder *sb)
+mono_string_builder_to_utf16 (MonoStringBuilderHandle sb, MonoError *error)
 {
-	if (!sb)
+	if (!MONO_HANDLE_BOOL (sb))
 		return NULL;
 
-	ERROR_DECL (error);
-
-	g_assert (sb->chunkChars);
+	g_assert (MONO_HANDLE_GET_BOOL (sb, chunkChars));
 
 	guint len = mono_string_builder_capacity (sb);
 
 	if (len == 0)
-		len = 1; // Why?
+		len = 1; // why?
 
 	gunichar2 *str = (gunichar2 *)mono_marshal_alloc ((len + 1) * sizeof (gunichar2), error);
-	if (!mono_error_ok (error)) {
-		mono_error_set_pending_exception (error);
-		return NULL;
-	}
+	return_val_if_nok (error, NULL);
 
 	str [len] = 0;
-	str [0] = 0; // Cover the case when original len == 0.
+	str [0] = 0; // Cover the case of original len == 0.
 
-	MonoStringBuilder* chunk = sb;
+	MonoArrayHandle chunkChars = MONO_HANDLE_NEW (MonoArray, NULL);
+	MonoStringBuilderHandle chunk = MONO_HANDLE_NEW (MonoStringBuilder, MONO_HANDLE_RAW (sb));
 	do {
-		g_assert (chunk->chunkLength >= 0);
-		if (chunk->chunkLength > 0) {
+		const int chunkLength = MONO_HANDLE_GETVAL (chunk, chunkLength);
+		g_assert (chunkLength >= 0);
+		if (chunkLength > 0) {
 			// Check that we will not overrun our boundaries.
-			gunichar2 *source = (gunichar2 *)chunk->chunkChars->vector;
-
-			g_assert (chunk->chunkOffset >= 0);
-			g_assertf (chunk->chunkLength + chunk->chunkOffset <= len, "A chunk in the StringBuilder had a length longer than expected from the offset.");
-			memcpy (str + chunk->chunkOffset, source, chunk->chunkLength * sizeof (gunichar2));
+			MONO_HANDLE_GET (chunkChars, chunk, chunkChars);
+			const int chunkOffset = MONO_HANDLE_GETVAL (chunk, chunkOffset);
+			g_assert (chunkOffset >= 0);
+			g_assertf ((chunkOffset + chunkLength) >= chunkLength, "integer overflow");
+			g_assertf ((chunkOffset + chunkLength) <= len, "A chunk in the StringBuilder had a length longer than expected from the offset.");
+			gchandle_t gchandle = 0;
+			memcpy (str + chunkOffset, MONO_ARRAY_HANDLE_PIN (chunkChars, gunichar2, 0, &gchandle), chunkLength * sizeof (gunichar2));
+			mono_gchandle_free_internal (gchandle);
 		}
-		chunk = chunk->chunkPrevious;
-	} while (chunk != NULL);
+		MONO_HANDLE_GET (chunk, chunk, chunkPrevious);
+	} while (MONO_HANDLE_BOOL (chunk));
 
 	return str;
 }
 
-/* This is a JIT icall, it sets the pending exception and returns NULL on error. */
+#ifndef HOST_WIN32
+
+/* This is a JIT icall, it sets the pending exception (in wrapper) and returns NULL on error. */
 gpointer
-mono_string_to_utf8str (MonoString *s_raw)
+mono_string_to_utf8str (MonoStringHandle s, MonoError *error)
 {
-	HANDLE_FUNCTION_ENTER ();
-	ERROR_DECL (error);
-	MONO_HANDLE_DCL (MonoString, s);
-	gpointer result = mono_string_to_utf8str_handle (s, error);
-	mono_error_set_pending_exception (error);
-	HANDLE_FUNCTION_RETURN_VAL (result);
+	return mono_string_handle_to_utf8 (s, error);
 }
 
+#endif
+
 gpointer
-mono_string_to_ansibstr (MonoString *string_obj)
+mono_string_to_ansibstr (MonoStringHandle string_obj, MonoError *error)
 {
 	g_error ("UnmanagedMarshal.BStr is not implemented.");
 	return NULL;
@@ -1057,24 +1008,20 @@ mono_string_to_ansibstr (MonoString *string_obj)
  * into \p dst, it copies at most \p size bytes into the destination.
  */
 void
-mono_string_to_byvalstr (char *dst, MonoString *src, int size)
+mono_string_to_byvalstr (char *dst, MonoStringHandle src, int size, MonoError *error)
 {
-	ERROR_DECL (error);
-	char *s;
-	int len;
-
 	g_assert (dst != NULL);
 	g_assert (size > 0);
 
 	memset (dst, 0, size);
-	if (!src)
+	if (!MONO_HANDLE_BOOL (src))
 		return;
 
-	s = mono_string_to_utf8_checked_internal (src, error);
-	if (mono_error_set_pending_exception (error))
-		return;
-	const gsize len2 = strlen (s);
-	len = MIN (size, len2);
+	// FIXME convert right into dst instead of the double copy.
+
+	char *s = mono_string_handle_to_utf8 (src, error);
+	return_if_nok (error);
+	int len = MIN (size, strlen (s));
 	len -= (len >= size);
 	memcpy (dst, s, len);
 	dst [len] = 0;
@@ -1088,37 +1035,35 @@ mono_string_to_byvalstr (char *dst, MonoString *src, int size)
  * \param size the maximum number of wide characters to copy (each consumes 2 bytes)
  *
  * Copies the \c MonoString pointed to by \p src as a utf16 string into
- * \p dst, it copies at most \p size bytes into the destination (including
+ * \p dst, it copies at most \p size gunichar2s into the destination (including
  * a terminating 16-bit zero terminator).
  */
 void
-mono_string_to_byvalwstr (gunichar2 *dst, MonoString *src, int size)
+mono_string_to_byvalwstr (gunichar2 *dst, MonoStringHandle src, int size, MonoError *error)
 {
-	int len;
+	g_assert (dst);
+	g_assert (size > 0);
 
-	g_assert (dst != NULL);
-	g_assert (size > 1);
-
-	if (!src) {
-		memset (dst, 0, size * 2);
+	if (!MONO_HANDLE_BOOL (src)) {
+		memset (dst, 0, size * sizeof (gunichar2));
 		return;
 	}
 
-	len = MIN (size, (mono_string_length_internal (src)));
-	memcpy (dst, mono_string_chars_internal (src), len * 2);
-	len -= (size <= mono_string_length_internal (src));
+	gchandle_t gchandle = 0;
+	int len = MIN (size, mono_string_handle_length (src));
+	memcpy (dst, mono_string_handle_pin_chars (src, &gchandle), len * sizeof (gunichar2));
+	mono_gchandle_free_internal (gchandle);
+	len -= (size <= mono_string_handle_length (src));
 	dst [len] = 0;
 }
 
 /* this is an icall, it sets the pending exception and returns NULL on error */
-MonoString*
-mono_string_new_len_wrapper (const char *text, guint length)
+MonoStringHandle
+mono_string_new_len_wrapper (const char *text, guint length, MonoError *error)
 {
-	HANDLE_FUNCTION_ENTER ();
-	ERROR_DECL (error);
-	MonoStringHandle result = mono_string_new_utf8_len (mono_domain_get (), text, length, error);
-	mono_error_set_pending_exception (error);
-	HANDLE_FUNCTION_RETURN_OBJ (result);
+	MonoString *s = mono_string_new_len_checked (mono_domain_get (), text, length, error);
+	return_val_if_nok (error, NULL_HANDLE_STRING);
+	return MONO_HANDLE_NEW (MonoString, s);
 }
 
 guint
@@ -1183,7 +1128,6 @@ mono_type_to_stind (MonoType *type)
 {
 	if (type->byref)
 		return MONO_TYPE_IS_REFERENCE (type) ? CEE_STIND_REF : CEE_STIND_I;
-
 
 handle_enum:
 	switch (type->type) {
@@ -1306,8 +1250,6 @@ mono_delegate_begin_invoke (MonoDelegate *delegate, gpointer *params)
 static char*
 mono_signature_to_name (MonoMethodSignature *sig, const char *prefix)
 {
-	int i;
-	char *result;
 	GString *res = g_string_new ("");
 
 	if (prefix) {
@@ -1320,11 +1262,11 @@ mono_signature_to_name (MonoMethodSignature *sig, const char *prefix)
 	if (sig->hasthis)
 		g_string_append (res, "__this__");
 
-	for (i = 0; i < sig->param_count; ++i) {
+	for (int i = 0; i < sig->param_count; ++i) {
 		g_string_append_c (res, '_');
 		mono_type_get_desc (res, sig->params [i], FALSE);
 	}
-	result = res->str;
+	char *result = res->str;
 	g_string_free (res, FALSE);
 	return result;
 }
@@ -4889,18 +4831,11 @@ mono_marshal_alloc (gsize size, MonoError *error)
 	return res;
 }
 
-/* This is a JIT icall, it sets the pending exception and returns NULL on error. */
+/* This is a JIT icall, it sets the pending exception (in wrapper) and returns NULL on error. */
 void*
-ves_icall_marshal_alloc (gsize size)
+ves_icall_marshal_alloc (gsize size, MonoError *error)
 {
-	ERROR_DECL (error);
-	void *ret = mono_marshal_alloc (size, error);
-	if (!mono_error_ok (error)) {
-		mono_error_set_pending_exception (error);
-		return NULL;
-	}
-
-	return ret;
+	return mono_marshal_alloc (size, error);
 }
 
 #ifndef HOST_WIN32
@@ -4938,12 +4873,15 @@ mono_marshal_free_array (gpointer *ptr, int size)
 void *
 mono_marshal_string_to_utf16 (MonoString *s)
 {
+	// FIXME This should be an intrinsic.
+	// FIXMEcoop The input parameter is easy to deal with,
+	// but what happens with the result?
 	return s ? mono_string_chars_internal (s) : NULL;
 }
 
-/* This is a JIT icall, it sets the pending exception and returns NULL on error. */
-static void *
-mono_marshal_string_to_utf16_copy_handle (MonoStringHandle s, MonoError *error)
+/* This is a JIT icall, it sets the pending exception (in wrapper) and returns NULL on error. */
+gunichar2*
+mono_marshal_string_to_utf16_copy (MonoStringHandle s, MonoError *error)
 {
 	if (MONO_HANDLE_IS_NULL (s))
 		return NULL;
@@ -4951,30 +4889,11 @@ mono_marshal_string_to_utf16_copy_handle (MonoStringHandle s, MonoError *error)
 	gsize const length = mono_string_handle_length (s);
 	gunichar2 *res = (gunichar2 *)mono_marshal_alloc ((length + 1) * sizeof (*res), error);
 	return_val_if_nok (error, NULL);
-	uint32_t gchandle = 0;
+	gchandle_t gchandle = 0;
 	memcpy (res, mono_string_handle_pin_chars (s, &gchandle), length * sizeof (*res));
 	mono_gchandle_free_internal (gchandle);
 	res [length] = 0;
 	return res;
-}
-
-/* This is a JIT icall, it sets the pending exception and returns NULL on error. */
-void *
-mono_marshal_string_to_utf16_copy (MonoString *s_raw)
-{
-	if (!s_raw)
-		return NULL;
-
-	HANDLE_FUNCTION_ENTER ();
-	ERROR_DECL (error);
-	MONO_HANDLE_DCL (MonoString, s);
-
-	gpointer res = mono_marshal_string_to_utf16_copy_handle (s, error);
-	if (!mono_error_ok (error)) {
-		mono_error_set_pending_exception (error);
-		res = NULL;
-	}
-	HANDLE_FUNCTION_RETURN_VAL (res);
 }
 
 /**
@@ -5468,13 +5387,13 @@ ves_icall_System_Runtime_InteropServices_Marshal_GetDelegateForFunctionPointerIn
 	if (!mono_class_init_checked (klass, error))
 		return MONO_HANDLE_CAST (MonoDelegate, NULL_HANDLE);
 
-	return mono_ftnptr_to_delegate_handle (klass, ftn, error);
+	return mono_ftnptr_to_delegate (klass, ftn, error);
 }
 
 gpointer
 ves_icall_System_Runtime_InteropServices_Marshal_GetFunctionPointerForDelegateInternal (MonoDelegateHandle delegate, MonoError *error)
 {
-	return mono_delegate_handle_to_ftnptr (delegate, error);
+	return mono_delegate_to_ftnptr (delegate, error);
 }
 
 /**
@@ -5872,10 +5791,10 @@ mono_marshal_type_size (MonoType *type, MonoMarshalSpec *mspec, guint32 *align,
 
 /**
  * mono_marshal_asany:
- * This is a JIT icall, it sets the pending exception and returns NULL on error.
+ * This is a JIT icall, it sets the pending exception (in wrapper) and returns NULL on error.
  */
-static gpointer
-mono_marshal_asany_handle (MonoObjectHandle o, MonoMarshalNative string_encoding, int param_attrs, MonoError *error)
+gpointer
+mono_marshal_asany (MonoObjectHandle o, MonoMarshalNative string_encoding, int param_attrs, MonoError *error)
 {
 	if (MONO_HANDLE_IS_NULL (o))
 		return NULL;
@@ -5899,11 +5818,11 @@ mono_marshal_asany_handle (MonoObjectHandle o, MonoMarshalNative string_encoding
 	case MONO_TYPE_STRING:
 		switch (string_encoding) {
 		case MONO_NATIVE_LPWSTR:
-			return mono_marshal_string_to_utf16_copy_handle (MONO_HANDLE_CAST (MonoString, o), error);
+			return mono_marshal_string_to_utf16_copy (MONO_HANDLE_CAST (MonoString, o), error);
 		case MONO_NATIVE_LPSTR:
 		case MONO_NATIVE_UTF8STR:
 			// Same code path, because in Mono, we treated strings as Utf8
-			return mono_string_to_utf8str_handle (MONO_HANDLE_CAST (MonoString, o), error);
+			return mono_string_to_utf8str (MONO_HANDLE_CAST (MonoString, o), error);
 		default:
 			g_warning ("marshaling conversion %d not implemented", string_encoding);
 			g_assert_not_reached ();
@@ -5941,34 +5860,20 @@ mono_marshal_asany_handle (MonoObjectHandle o, MonoMarshalNative string_encoding
 	return NULL;
 }
 
-gpointer
-mono_marshal_asany (MonoObject *o_raw, MonoMarshalNative string_encoding, int param_attrs)
-{
-	if (!o_raw)
-		return NULL;
-	HANDLE_FUNCTION_ENTER ();
-	ERROR_DECL (error);
-	MONO_HANDLE_DCL (MonoObject, o);
-	gpointer result = mono_marshal_asany_handle (o, string_encoding, param_attrs, error);
-	mono_error_set_pending_exception (error);
-	HANDLE_FUNCTION_RETURN_VAL (result);
-}
-
 /**
  * mono_marshal_free_asany:
- * This is a JIT icall, it sets the pending exception
+ * This is a JIT icall, it sets the pending exception (in wrapper)
  */
 void
-mono_marshal_free_asany (MonoObject *o, gpointer ptr, MonoMarshalNative string_encoding, int param_attrs)
+mono_marshal_free_asany (MonoObjectHandle o, gpointer ptr, MonoMarshalNative string_encoding, int param_attrs, MonoError *error)
 {
-	ERROR_DECL (error);
 	MonoType *t;
 	MonoClass *klass;
 
-	if (o == NULL)
+	if (MONO_HANDLE_IS_NULL (o))
 		return;
 
-	t = m_class_get_byval_arg (mono_object_class (o));
+	t = m_class_get_byval_arg (mono_handle_class (o));
 	switch (t->type) {
 	case MONO_TYPE_STRING:
 		switch (string_encoding) {
@@ -5990,17 +5895,15 @@ mono_marshal_free_asany (MonoObject *o, gpointer ptr, MonoMarshalNative string_e
 			break;
 
 		if (param_attrs & PARAM_ATTRIBUTE_OUT) {
-			MonoMethod *method = mono_marshal_get_ptr_to_struct (o->vtable->klass);
+			MonoMethod *method = mono_marshal_get_ptr_to_struct (mono_handle_class (o));
 			gpointer pa [2];
 
 			pa [0] = &ptr;
-			pa [1] = o;
+			pa [1] = MONO_HANDLE_RAW (o);
 
 			mono_runtime_invoke_checked (method, NULL, pa, error);
-			if (!mono_error_ok (error)) {
-				mono_error_set_pending_exception (error);
+			if (!mono_error_ok (error))
 				return;
-			}
 		}
 
 		if (!((param_attrs & PARAM_ATTRIBUTE_OUT) && !(param_attrs & PARAM_ATTRIBUTE_IN))) {

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -614,8 +614,7 @@ mono_string_from_byvalwstr_impl (const gunichar2 *data, int max_len, MonoError *
 		return NULL_HANDLE_STRING;
 
 	// FIXME Check max_len while scanning data? mono_string_from_byvalstr does.
-	int len = 0;
-	while (data [len]) len++;
+	int len = g_utf16_len (data);
 
 	MonoString *res = mono_string_new_utf16_checked (mono_domain_get (), data, MIN (len, max_len), error);
 	return_val_if_nok (error, NULL_HANDLE_STRING);

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -198,7 +198,7 @@ mono_object_isinst_icall (MonoObject *obj, MonoClass *klass)
 }
 
 MonoStringHandle
-ves_icall_mono_string_from_utf16 (const gunichar2 *data, MonoError *error)
+ves_icall_mono_string_from_utf16_impl (const gunichar2 *data, MonoError *error)
 {
 	MonoString *s = mono_string_from_utf16_checked (data, error);
 	return_val_if_nok (error, NULL_HANDLE_STRING);
@@ -206,13 +206,13 @@ ves_icall_mono_string_from_utf16 (const gunichar2 *data, MonoError *error)
 }
 
 char*
-ves_icall_mono_string_to_utf8 (MonoStringHandle str, MonoError *error)
+ves_icall_mono_string_to_utf8_impl (MonoStringHandle str, MonoError *error)
 {
 	return mono_string_handle_to_utf8 (str, error);
 }
 
 MonoStringHandle
-ves_icall_string_new_wrapper (const char *text, MonoError *error)
+ves_icall_string_new_wrapper_impl (const char *text, MonoError *error)
 {
 	if (text) {
 		MonoString *s = mono_string_new_checked (mono_domain_get (), text, error);
@@ -233,39 +233,39 @@ mono_marshal_init (void)
 		marshal_mutex_initialized = TRUE;
 
 		register_icall (mono_marshal_string_to_utf16, "mono_marshal_string_to_utf16", "ptr obj", FALSE);
-		register_icall (mono_marshal_string_to_utf16_copy_raw, "mono_marshal_string_to_utf16_copy", "ptr obj", FALSE);
-		register_icall (mono_string_to_utf16_internal_raw, "mono_string_to_utf16_internal", "ptr obj", FALSE);
-		register_icall (ves_icall_mono_string_from_utf16_raw, "ves_icall_mono_string_from_utf16", "obj ptr", FALSE);
-		register_icall (mono_string_from_byvalstr_raw, "mono_string_from_byvalstr", "obj ptr int", FALSE);
-		register_icall (mono_string_from_byvalwstr_raw, "mono_string_from_byvalwstr", "obj ptr int", FALSE);
-		register_icall (mono_string_new_wrapper_internal_raw, "mono_string_new_wrapper_internal", "obj ptr", FALSE);
-		register_icall (ves_icall_string_new_wrapper_raw, "ves_icall_string_new_wrapper", "obj ptr", FALSE);
-		register_icall (mono_string_new_len_wrapper_raw, "mono_string_new_len_wrapper", "obj ptr int", FALSE);
-		register_icall (ves_icall_mono_string_to_utf8_raw, "ves_icall_mono_string_to_utf8", "ptr obj", FALSE);
-		register_icall (mono_string_to_utf8str_raw, "mono_string_to_utf8str", "ptr obj", FALSE);
-		register_icall (mono_string_to_ansibstr_raw, "mono_string_to_ansibstr", "ptr object", FALSE);
-		register_icall (mono_string_builder_to_utf8_raw, "mono_string_builder_to_utf8", "ptr object", FALSE);
-		register_icall (mono_string_builder_to_utf16_raw, "mono_string_builder_to_utf16", "ptr object", FALSE);
-		register_icall (mono_array_to_savearray_raw, "mono_array_to_savearray", "ptr object", FALSE);
-		register_icall (mono_array_to_lparray_raw, "mono_array_to_lparray", "ptr object", FALSE);
-		register_icall (mono_free_lparray_raw, "mono_free_lparray", "void object ptr", FALSE);
-		register_icall (mono_byvalarray_to_byte_array_raw, "mono_byvalarray_to_byte_array", "void object ptr int32", FALSE);
-		register_icall (mono_array_to_byte_byvalarray_raw, "mono_array_to_byte_byvalarray", "void ptr object int32", FALSE);
-		register_icall (mono_delegate_to_ftnptr_raw, "mono_delegate_to_ftnptr", "ptr object", FALSE);
-		register_icall (mono_ftnptr_to_delegate_raw, "mono_ftnptr_to_delegate", "object ptr ptr", FALSE);
-		register_icall (mono_marshal_asany_raw, "mono_marshal_asany", "ptr object int32 int32", FALSE);
-		register_icall (mono_marshal_free_asany_raw, "mono_marshal_free_asany", "void object ptr int32 int32", FALSE);
-		register_icall (ves_icall_marshal_alloc_raw, "ves_icall_marshal_alloc", "ptr ptr", FALSE);
+		register_icall (mono_marshal_string_to_utf16_copy, "mono_marshal_string_to_utf16_copy", "ptr obj", FALSE);
+		register_icall (mono_string_to_utf16_internal, "mono_string_to_utf16_internal", "ptr obj", FALSE);
+		register_icall (ves_icall_mono_string_from_utf16, "ves_icall_mono_string_from_utf16", "obj ptr", FALSE);
+		register_icall (mono_string_from_byvalstr, "mono_string_from_byvalstr", "obj ptr int", FALSE);
+		register_icall (mono_string_from_byvalwstr, "mono_string_from_byvalwstr", "obj ptr int", FALSE);
+		register_icall (mono_string_new_wrapper_internal, "mono_string_new_wrapper_internal", "obj ptr", FALSE);
+		register_icall (ves_icall_string_new_wrapper, "ves_icall_string_new_wrapper", "obj ptr", FALSE);
+		register_icall (mono_string_new_len_wrapper, "mono_string_new_len_wrapper", "obj ptr int", FALSE);
+		register_icall (ves_icall_mono_string_to_utf8, "ves_icall_mono_string_to_utf8", "ptr obj", FALSE);
+		register_icall (mono_string_to_utf8str, "mono_string_to_utf8str", "ptr obj", FALSE);
+		register_icall (mono_string_to_ansibstr, "mono_string_to_ansibstr", "ptr object", FALSE);
+		register_icall (mono_string_builder_to_utf8, "mono_string_builder_to_utf8", "ptr object", FALSE);
+		register_icall (mono_string_builder_to_utf16, "mono_string_builder_to_utf16", "ptr object", FALSE);
+		register_icall (mono_array_to_savearray, "mono_array_to_savearray", "ptr object", FALSE);
+		register_icall (mono_array_to_lparray, "mono_array_to_lparray", "ptr object", FALSE);
+		register_icall (mono_free_lparray, "mono_free_lparray", "void object ptr", FALSE);
+		register_icall (mono_byvalarray_to_byte_array, "mono_byvalarray_to_byte_array", "void object ptr int32", FALSE);
+		register_icall (mono_array_to_byte_byvalarray, "mono_array_to_byte_byvalarray", "void ptr object int32", FALSE);
+		register_icall (mono_delegate_to_ftnptr, "mono_delegate_to_ftnptr", "ptr object", FALSE);
+		register_icall (mono_ftnptr_to_delegate, "mono_ftnptr_to_delegate", "object ptr ptr", FALSE);
+		register_icall (mono_marshal_asany, "mono_marshal_asany", "ptr object int32 int32", FALSE);
+		register_icall (mono_marshal_free_asany, "mono_marshal_free_asany", "void object ptr int32 int32", FALSE);
+		register_icall (ves_icall_marshal_alloc, "ves_icall_marshal_alloc", "ptr ptr", FALSE);
 		register_icall (mono_marshal_free, "mono_marshal_free", "void ptr", FALSE);
 		register_icall (mono_marshal_set_last_error, "mono_marshal_set_last_error", "void", TRUE);
 		register_icall (mono_marshal_set_last_error_windows, "mono_marshal_set_last_error_windows", "void int32", TRUE);
-		register_icall (mono_string_utf8_to_builder_raw, "mono_string_utf8_to_builder", "void ptr ptr", FALSE);
-		register_icall (mono_string_utf8_to_builder2_raw, "mono_string_utf8_to_builder2", "object ptr", FALSE);
-		register_icall (mono_string_utf16_to_builder_raw, "mono_string_utf16_to_builder", "void ptr ptr", FALSE);
-		register_icall (mono_string_utf16_to_builder2_raw, "mono_string_utf16_to_builder2", "object ptr", FALSE);
+		register_icall (mono_string_utf8_to_builder, "mono_string_utf8_to_builder", "void ptr ptr", FALSE);
+		register_icall (mono_string_utf8_to_builder2, "mono_string_utf8_to_builder2", "object ptr", FALSE);
+		register_icall (mono_string_utf16_to_builder, "mono_string_utf16_to_builder", "void ptr ptr", FALSE);
+		register_icall (mono_string_utf16_to_builder2, "mono_string_utf16_to_builder2", "object ptr", FALSE);
 		register_icall (mono_marshal_free_array, "mono_marshal_free_array", "void ptr int32", FALSE);
-		register_icall (mono_string_to_byvalstr_raw, "mono_string_to_byvalstr", "void ptr ptr int32", FALSE);
-		register_icall (mono_string_to_byvalwstr_raw, "mono_string_to_byvalwstr", "void ptr ptr int32", FALSE);
+		register_icall (mono_string_to_byvalstr, "mono_string_to_byvalstr", "void ptr ptr int32", FALSE);
+		register_icall (mono_string_to_byvalwstr, "mono_string_to_byvalwstr", "void ptr ptr int32", FALSE);
 		register_dyn_icall (g_free, "g_free", "void ptr", FALSE);
 		register_icall_no_wrapper (mono_object_isinst_icall, "mono_object_isinst_icall", "object object ptr");
 		register_icall (mono_struct_delete_old, "mono_struct_delete_old", "void ptr ptr", FALSE);
@@ -315,7 +315,7 @@ mono_marshal_unlock_internal (void)
 
 // This is a JIT icall, it sets the pending exception (in wrapper) and return NULL on error.
 gpointer
-mono_delegate_to_ftnptr (MonoDelegateHandle delegate, MonoError *error)
+mono_delegate_to_ftnptr_impl (MonoDelegateHandle delegate, MonoError *error)
 {
 	gpointer result = NULL;
 	MonoMethod *method, *wrapper;
@@ -478,7 +478,7 @@ parse_unmanaged_function_pointer_attr (MonoClass *klass, MonoMethodPInvoke *piin
 
 /* This is a JIT icall, it sets the pending exception (in wrapper) and returns NULL on error */
 MonoDelegateHandle
-mono_ftnptr_to_delegate (MonoClass *klass, gpointer ftn, MonoError *error)
+mono_ftnptr_to_delegate_impl (MonoClass *klass, gpointer ftn, MonoError *error)
 {
 	guint32 gchandle;
 	MonoDelegateHandle d = MONO_HANDLE_NEW (MonoDelegate, NULL);
@@ -589,7 +589,7 @@ mono_delegate_free_ftnptr (MonoDelegate *delegate)
 
 /* This is a JIT icall, it sets the pending exception (in wrapper) and returns NULL on error */
 MonoStringHandle
-mono_string_from_byvalstr (const char *data, int max_len, MonoError *error)
+mono_string_from_byvalstr_impl (const char *data, int max_len, MonoError *error)
 {
 	// FIXME This optimization ok to miss before wrapper? Or null is rare?
 	if (!data)
@@ -607,7 +607,7 @@ mono_string_from_byvalstr (const char *data, int max_len, MonoError *error)
 
 /* This is a JIT icall, it sets the pending exception (in wrapper) and return NULL on error */
 MonoStringHandle
-mono_string_from_byvalwstr (const gunichar2 *data, int max_len, MonoError *error)
+mono_string_from_byvalwstr_impl (const gunichar2 *data, int max_len, MonoError *error)
 {
 	// FIXME This optimization ok to miss before wrapper? Or null is rare?
 	if (!data)
@@ -623,7 +623,7 @@ mono_string_from_byvalwstr (const gunichar2 *data, int max_len, MonoError *error
 }
 
 gpointer
-mono_array_to_savearray (MonoArrayHandle array, MonoError *error)
+mono_array_to_savearray_impl (MonoArrayHandle array, MonoError *error)
 {
 	if (!MONO_HANDLE_BOOL (array))
 		return NULL;
@@ -633,7 +633,7 @@ mono_array_to_savearray (MonoArrayHandle array, MonoError *error)
 }
 
 gpointer
-mono_array_to_lparray (MonoArrayHandle array_handle, MonoError *error)
+mono_array_to_lparray_impl (MonoArrayHandle array_handle, MonoError *error)
 {
 	if (!MONO_HANDLE_BOOL (array_handle))
 		return NULL;
@@ -694,7 +694,7 @@ mono_array_to_lparray (MonoArrayHandle array_handle, MonoError *error)
 }
 
 void
-mono_free_lparray (MonoArrayHandle array, gpointer* nativeArray, MonoError *error)
+mono_free_lparray_impl (MonoArrayHandle array, gpointer* nativeArray, MonoError *error)
 {
 #ifndef DISABLE_COM
 	if (!nativeArray || MONO_HANDLE_IS_NULL (array))
@@ -709,7 +709,7 @@ mono_free_lparray (MonoArrayHandle array, gpointer* nativeArray, MonoError *erro
 
 /* This is a JIT icall, it sets the pending exception (in wrapper) and returns on error */
 void
-mono_byvalarray_to_byte_array (MonoArrayHandle arr, const char *native_arr, guint32 elnum, MonoError *error)
+mono_byvalarray_to_byte_array_impl (MonoArrayHandle arr, const char *native_arr, guint32 elnum, MonoError *error)
 {
 	g_assert (m_class_get_element_class (mono_handle_class (arr)) == mono_defaults.char_class);
 
@@ -729,7 +729,7 @@ mono_byvalarray_to_byte_array (MonoArrayHandle arr, const char *native_arr, guin
 
 /* This is a JIT icall, it sets the pending exception (in wrapper) and returns on error */
 void
-mono_array_to_byte_byvalarray (gpointer native_arr, MonoArrayHandle arr, guint32 elnum, MonoError *error)
+mono_array_to_byte_byvalarray_impl (gpointer native_arr, MonoArrayHandle arr, guint32 elnum, MonoError *error)
 {
 	g_assert (m_class_get_element_class (mono_handle_class (arr)) == mono_defaults.char_class);
 
@@ -800,7 +800,7 @@ mono_string_utf16_to_builder_copy (MonoStringBuilderHandle sb, const gunichar2 *
 }
 
 MonoStringBuilderHandle
-mono_string_utf16_to_builder2 (const gunichar2 *text, MonoError *error)
+mono_string_utf16_to_builder2_impl (const gunichar2 *text, MonoError *error)
 {
 	if (!text)
 		return NULL_HANDLE_STRING_BUILDER;
@@ -840,13 +840,13 @@ mono_string_utf8len_to_builder (MonoStringBuilderHandle sb, const char *text, gs
 }
 
 void
-mono_string_utf8_to_builder (MonoStringBuilderHandle sb, const char *text, MonoError *error)
+mono_string_utf8_to_builder_impl (MonoStringBuilderHandle sb, const char *text, MonoError *error)
 {
 	mono_string_utf8len_to_builder (sb, text, text ? strlen (text) : 0, error);
 }
 
 MonoStringBuilderHandle
-mono_string_utf8_to_builder2 (const char *text, MonoError *error)
+mono_string_utf8_to_builder2_impl (const char *text, MonoError *error)
 {
 	if (!text)
 		return NULL_HANDLE_STRING_BUILDER;
@@ -872,7 +872,7 @@ mono_string_utf16len_to_builder (MonoStringBuilderHandle sb, const gunichar2 *te
 }
 
 void
-mono_string_utf16_to_builder (MonoStringBuilderHandle sb, const gunichar2 *text, MonoError *error)
+mono_string_utf16_to_builder_impl (MonoStringBuilderHandle sb, const gunichar2 *text, MonoError *error)
 {
 	mono_string_utf16_to_builder_copy (sb, text, text ? g_utf16_len (text) : 0, error);
 }
@@ -890,7 +890,7 @@ mono_string_utf16_to_builder (MonoStringBuilderHandle sb, const gunichar2 *text,
  * This is a JIT icall, it sets the pending exception (in wrapper) and returns NULL on error.
  */
 gchar*
-mono_string_builder_to_utf8 (MonoStringBuilderHandle sb, MonoError *error)
+mono_string_builder_to_utf8_impl (MonoStringBuilderHandle sb, MonoError *error)
 {
 	char *res = NULL;
 	GError *gerror = NULL;
@@ -902,7 +902,7 @@ mono_string_builder_to_utf8 (MonoStringBuilderHandle sb, MonoError *error)
 	if (!MONO_HANDLE_BOOL (sb))
 		goto exit;
 
-	str_utf16 = mono_string_builder_to_utf16 (sb, error);
+	str_utf16 = mono_string_builder_to_utf16_impl (sb, error);
 	goto_if_nok (error, exit);
 
 	tmp = g_utf16_to_utf8 (str_utf16, mono_string_builder_string_length (sb), NULL, &byte_count, &gerror);
@@ -940,7 +940,7 @@ exit:
  * This is a JIT icall, it sets the pending exception (in wrapper) and returns NULL on error.
  */
 gunichar2*
-mono_string_builder_to_utf16 (MonoStringBuilderHandle sb, MonoError *error)
+mono_string_builder_to_utf16_impl (MonoStringBuilderHandle sb, MonoError *error)
 {
 	if (!MONO_HANDLE_BOOL (sb))
 		return NULL;
@@ -984,7 +984,7 @@ mono_string_builder_to_utf16 (MonoStringBuilderHandle sb, MonoError *error)
 
 /* This is a JIT icall, it sets the pending exception (in wrapper) and returns NULL on error. */
 gpointer
-mono_string_to_utf8str (MonoStringHandle s, MonoError *error)
+mono_string_to_utf8str_impl (MonoStringHandle s, MonoError *error)
 {
 	return mono_string_handle_to_utf8 (s, error);
 }
@@ -992,7 +992,7 @@ mono_string_to_utf8str (MonoStringHandle s, MonoError *error)
 #endif
 
 gpointer
-mono_string_to_ansibstr (MonoStringHandle string_obj, MonoError *error)
+mono_string_to_ansibstr_impl (MonoStringHandle string_obj, MonoError *error)
 {
 	g_error ("UnmanagedMarshal.BStr is not implemented.");
 	return NULL;
@@ -1008,7 +1008,7 @@ mono_string_to_ansibstr (MonoStringHandle string_obj, MonoError *error)
  * into \p dst, it copies at most \p size bytes into the destination.
  */
 void
-mono_string_to_byvalstr (char *dst, MonoStringHandle src, int size, MonoError *error)
+mono_string_to_byvalstr_impl (char *dst, MonoStringHandle src, int size, MonoError *error)
 {
 	g_assert (dst != NULL);
 	g_assert (size > 0);
@@ -1039,7 +1039,7 @@ mono_string_to_byvalstr (char *dst, MonoStringHandle src, int size, MonoError *e
  * a terminating 16-bit zero terminator).
  */
 void
-mono_string_to_byvalwstr (gunichar2 *dst, MonoStringHandle src, int size, MonoError *error)
+mono_string_to_byvalwstr_impl (gunichar2 *dst, MonoStringHandle src, int size, MonoError *error)
 {
 	g_assert (dst);
 	g_assert (size > 0);
@@ -1059,7 +1059,7 @@ mono_string_to_byvalwstr (gunichar2 *dst, MonoStringHandle src, int size, MonoEr
 
 /* this is an icall, it sets the pending exception and returns NULL on error */
 MonoStringHandle
-mono_string_new_len_wrapper (const char *text, guint length, MonoError *error)
+mono_string_new_len_wrapper_impl (const char *text, guint length, MonoError *error)
 {
 	MonoString *s = mono_string_new_len_checked (mono_domain_get (), text, length, error);
 	return_val_if_nok (error, NULL_HANDLE_STRING);
@@ -4833,7 +4833,7 @@ mono_marshal_alloc (gsize size, MonoError *error)
 
 /* This is a JIT icall, it sets the pending exception (in wrapper) and returns NULL on error. */
 void*
-ves_icall_marshal_alloc (gsize size, MonoError *error)
+ves_icall_marshal_alloc_impl (gsize size, MonoError *error)
 {
 	return mono_marshal_alloc (size, error);
 }
@@ -4881,7 +4881,7 @@ mono_marshal_string_to_utf16 (MonoString *s)
 
 /* This is a JIT icall, it sets the pending exception (in wrapper) and returns NULL on error. */
 gunichar2*
-mono_marshal_string_to_utf16_copy (MonoStringHandle s, MonoError *error)
+mono_marshal_string_to_utf16_copy_impl (MonoStringHandle s, MonoError *error)
 {
 	if (MONO_HANDLE_IS_NULL (s))
 		return NULL;
@@ -5387,13 +5387,13 @@ ves_icall_System_Runtime_InteropServices_Marshal_GetDelegateForFunctionPointerIn
 	if (!mono_class_init_checked (klass, error))
 		return MONO_HANDLE_CAST (MonoDelegate, NULL_HANDLE);
 
-	return mono_ftnptr_to_delegate (klass, ftn, error);
+	return mono_ftnptr_to_delegate_impl (klass, ftn, error);
 }
 
 gpointer
 ves_icall_System_Runtime_InteropServices_Marshal_GetFunctionPointerForDelegateInternal (MonoDelegateHandle delegate, MonoError *error)
 {
-	return mono_delegate_to_ftnptr (delegate, error);
+	return mono_delegate_to_ftnptr_impl (delegate, error);
 }
 
 /**
@@ -5794,7 +5794,7 @@ mono_marshal_type_size (MonoType *type, MonoMarshalSpec *mspec, guint32 *align,
  * This is a JIT icall, it sets the pending exception (in wrapper) and returns NULL on error.
  */
 gpointer
-mono_marshal_asany (MonoObjectHandle o, MonoMarshalNative string_encoding, int param_attrs, MonoError *error)
+mono_marshal_asany_impl (MonoObjectHandle o, MonoMarshalNative string_encoding, int param_attrs, MonoError *error)
 {
 	if (MONO_HANDLE_IS_NULL (o))
 		return NULL;
@@ -5818,11 +5818,11 @@ mono_marshal_asany (MonoObjectHandle o, MonoMarshalNative string_encoding, int p
 	case MONO_TYPE_STRING:
 		switch (string_encoding) {
 		case MONO_NATIVE_LPWSTR:
-			return mono_marshal_string_to_utf16_copy (MONO_HANDLE_CAST (MonoString, o), error);
+			return mono_marshal_string_to_utf16_copy_impl (MONO_HANDLE_CAST (MonoString, o), error);
 		case MONO_NATIVE_LPSTR:
 		case MONO_NATIVE_UTF8STR:
 			// Same code path, because in Mono, we treated strings as Utf8
-			return mono_string_to_utf8str (MONO_HANDLE_CAST (MonoString, o), error);
+			return mono_string_to_utf8str_impl (MONO_HANDLE_CAST (MonoString, o), error);
 		default:
 			g_warning ("marshaling conversion %d not implemented", string_encoding);
 			g_assert_not_reached ();
@@ -5865,7 +5865,7 @@ mono_marshal_asany (MonoObjectHandle o, MonoMarshalNative string_encoding, int p
  * This is a JIT icall, it sets the pending exception (in wrapper)
  */
 void
-mono_marshal_free_asany (MonoObjectHandle o, gpointer ptr, MonoMarshalNative string_encoding, int param_attrs, MonoError *error)
+mono_marshal_free_asany_impl (MonoObjectHandle o, gpointer ptr, MonoMarshalNative string_encoding, int param_attrs, MonoError *error)
 {
 	MonoType *t;
 	MonoClass *klass;

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -960,6 +960,9 @@ mono_string_builder_to_utf16_impl (MonoStringBuilderHandle sb, MonoError *error)
 
 	MonoArrayHandle chunkChars = MONO_HANDLE_NEW (MonoArray, NULL);
 	MonoStringBuilderHandle chunk = MONO_HANDLE_NEW (MonoStringBuilder, MONO_HANDLE_RAW (sb));
+
+	MONO_ENTER_NO_SAFEPOINTS;
+
 	do {
 		const int chunkLength = MONO_HANDLE_GETVAL (chunk, chunkLength);
 		g_assert (chunkLength >= 0);
@@ -970,12 +973,12 @@ mono_string_builder_to_utf16_impl (MonoStringBuilderHandle sb, MonoError *error)
 			g_assert (chunkOffset >= 0);
 			g_assertf ((chunkOffset + chunkLength) >= chunkLength, "integer overflow");
 			g_assertf ((chunkOffset + chunkLength) <= len, "A chunk in the StringBuilder had a length longer than expected from the offset.");
-			gchandle_t gchandle = 0;
-			memcpy (str + chunkOffset, MONO_ARRAY_HANDLE_PIN (chunkChars, gunichar2, 0, &gchandle), chunkLength * sizeof (gunichar2));
-			mono_gchandle_free_internal (gchandle);
+			memcpy (str + chunkOffset, MONO_HANDLE_RAW (chunkChars)->vector, chunkLength * sizeof (gunichar2));
 		}
 		MONO_HANDLE_GET (chunk, chunk, chunkPrevious);
 	} while (MONO_HANDLE_BOOL (chunk));
+
+	MONO_EXIT_NO_SAFEPOINTS;
 
 	return str;
 }

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -835,8 +835,10 @@ mono_string_utf8len_to_builder (MonoStringBuilderHandle sb, const char *text, gs
 	if (!gerror) {
 		MONO_HANDLE_SETRAW (sb, chunkPrevious, NULL);
 		mono_string_utf16_to_builder_copy (sb, ut, copied, error);
-	} else
+	} else {
+		// FIXME? Set error?
 		g_error_free (gerror);
+	}
 
 	g_free (ut);
 }

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -960,7 +960,7 @@ mono_string_builder_to_utf16_impl (MonoStringBuilderHandle sb, MonoError *error)
 	return_val_if_nok (error, NULL);
 
 	str [len] = 0;
-	str [0] = 0; // Cover the case of original len == 0.
+	str [0] = 0; // Cover the case when original len == 0.
 
 	MonoArrayHandle chunkChars = MONO_HANDLE_NEW (MonoArray, NULL);
 	MonoStringBuilderHandle chunk = MONO_HANDLE_NEW (MonoStringBuilder, MONO_HANDLE_RAW (sb));

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -61,6 +61,9 @@
 #include <errno.h>
 #include "icall-decl.h"
 
+static void
+mono_string_utf16len_to_builder (MonoStringBuilderHandle sb, const gunichar2 *text, gsize len, MonoError *error);
+
 /* #define DEBUG_RUNTIME_CODE */
 
 #define OPDEF(a,b,c,d,e,f,g,h,i,j) \
@@ -809,7 +812,7 @@ mono_string_utf16_to_builder2_impl (const gunichar2 *text, MonoError *error)
 	MonoStringBuilderHandle sb = mono_string_builder_new (len, error);
 	return_val_if_nok (error, NULL_HANDLE_STRING_BUILDER);
 
-	mono_string_utf16_to_builder_copy (sb, text, len, error);
+	mono_string_utf16len_to_builder (sb, text, len, error);
 	return_val_if_nok (error, NULL_HANDLE_STRING_BUILDER);
 
 	return sb;

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -954,7 +954,7 @@ mono_string_builder_to_utf16_impl (MonoStringBuilderHandle sb, MonoError *error)
 	guint len = mono_string_builder_capacity (sb);
 
 	if (len == 0)
-		len = 1; // why?
+		len = 1; // Why?
 
 	gunichar2 *str = (gunichar2 *)mono_marshal_alloc ((len + 1) * sizeof (gunichar2), error);
 	return_val_if_nok (error, NULL);

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -4879,6 +4879,7 @@ mono_marshal_string_to_utf16 (MonoString *s)
 	// FIXME This should be an intrinsic.
 	// FIXMEcoop The input parameter is easy to deal with,
 	// but what happens with the result?
+	// See https://github.com/mono/mono/issues/12165.
 	return s ? mono_string_chars_internal (s) : NULL;
 }
 

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -874,7 +874,7 @@ mono_string_utf16len_to_builder (MonoStringBuilderHandle sb, const gunichar2 *te
 void
 mono_string_utf16_to_builder_impl (MonoStringBuilderHandle sb, const gunichar2 *text, MonoError *error)
 {
-	mono_string_utf16_to_builder_copy (sb, text, text ? g_utf16_len (text) : 0, error);
+	mono_string_utf16len_to_builder (sb, text, text ? g_utf16_len (text) : 0, error);
 }
 
 /**

--- a/mono/metadata/marshal.h
+++ b/mono/metadata/marshal.h
@@ -346,25 +346,10 @@ mono_marshal_type_size (MonoType *type, MonoMarshalSpec *mspec, guint32 *align,
 int            
 mono_type_native_stack_size (MonoType *type, guint32 *alignment);
 
-gpointer
-mono_string_to_ansibstr (MonoString *string_obj);
-
 mono_bstr
 mono_ptr_to_bstr (const gunichar2* ptr, int slen);
 
-gpointer
-mono_string_to_bstr(MonoString* str);
-
 void mono_delegate_free_ftnptr (MonoDelegate *delegate);
-
-gpointer
-mono_marshal_asany (MonoObject *obj, MonoMarshalNative string_encoding, int param_attrs);
-
-void
-mono_marshal_free_asany (MonoObject *o, gpointer ptr, MonoMarshalNative string_encoding, int param_attrs);
-
-void
-mono_free_lparray (MonoArray *array, gpointer* nativeArray);
 
 void
 mono_marshal_ftnptr_eh_callback (guint32 gchandle);
@@ -377,15 +362,6 @@ mono_type_to_ldind (MonoType *type);
 
 guint
 mono_type_to_stind (MonoType *type);
-
-void
-mono_byvalarray_to_byte_array (MonoArray *arr, gpointer native_arr, guint32 elnum);
-
-MonoString *
-mono_string_from_byvalstr (const char *data, int len);
-
-MonoString *
-mono_string_from_byvalwstr (gunichar2 *data, int len);
 
 /* functions to create various architecture independent helper functions */
 
@@ -520,69 +496,8 @@ mono_marshal_free_ccw (MonoObject* obj);
 void
 mono_cominterop_release_all_rcws (void); 
 
-ICALL_EXPORT
-MonoString*
-ves_icall_mono_string_from_utf16 (const gunichar2 *data);
-
-ICALL_EXPORT
-char*
-ves_icall_mono_string_to_utf8 (MonoString *str);
-
-void *
-mono_marshal_string_to_utf16_copy (MonoString *s);
-
-MonoString*
-mono_string_new_len_wrapper (const char *text, guint length);
-
-MonoDelegate*
-mono_ftnptr_to_delegate (MonoClass *klass, gpointer ftn);
-
 MONO_API void *
 mono_marshal_string_to_utf16 (MonoString *s);
-
-#ifndef HOST_WIN32
-gpointer
-mono_string_to_utf8str (MonoString *string_obj);
-#endif
-
-MonoStringBuilder *
-mono_string_utf8_to_builder2 (const char *text);
-
-MonoStringBuilder *
-mono_string_utf16_to_builder2 (const gunichar2 *text);
-
-gchar*
-mono_string_builder_to_utf8 (MonoStringBuilder *sb);
-
-gunichar2*
-mono_string_builder_to_utf16 (MonoStringBuilder *sb);
-
-void
-mono_string_utf8_to_builder (MonoStringBuilder *sb, const char *text);
-
-void
-mono_string_utf16_to_builder (MonoStringBuilder *sb, const gunichar2 *text);
-
-void
-mono_string_to_byvalstr (char *dst, MonoString *src, int size);
-
-void
-mono_string_to_byvalwstr (gunichar2 *dst, MonoString *src, int size);
-
-gpointer
-mono_delegate_to_ftnptr (MonoDelegate *delegate);
-
-gpointer
-mono_array_to_savearray (MonoArray *array);
-
-void
-mono_free_lparray (MonoArray *array, gpointer* nativeArray);
-
-void
-mono_array_to_byte_byvalarray (gpointer native_arr, MonoArray *arr, guint32 elnum);
-
-gpointer
-mono_array_to_lparray (MonoArray *array);
 
 void
 mono_marshal_set_last_error_windows (int error);
@@ -592,10 +507,6 @@ mono_struct_delete_old (MonoClass *klass, char *ptr);
 
 MonoObject*
 mono_object_isinst_icall (MonoObject *obj, MonoClass *klass);
-
-ICALL_EXPORT
-MonoString*
-ves_icall_string_new_wrapper (const char *text);
 
 int
 mono_emit_marshal (EmitMarshalContext *m, int argnum, MonoType *t, 
@@ -641,106 +552,21 @@ mono_marshal_need_free (MonoType *t, MonoMethodPInvoke *piinfo, MonoMarshalSpec 
 MonoObject* mono_marshal_get_type_object (MonoClass *klass);
 
 ICALL_EXPORT
-void*
-ves_icall_marshal_alloc (gsize size);
-
-ICALL_EXPORT
 void
 ves_icall_System_Runtime_InteropServices_Marshal_copy_to_unmanaged (MonoArrayHandle src, gint32 start_index,
 		gpointer dest, gint32 length, gconstpointer managed_source_addr, MonoError *error);
-
-ICALL_EXPORT
-void
-ves_icall_System_Runtime_InteropServices_Marshal_copy_from_unmanaged (gconstpointer src, gint32 start_index,
-	MonoArrayHandle dest, gint32 length, gpointer managed_dest_addr, MonoError *error);
-
-ICALL_EXPORT
-MonoStringHandle
-ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringAnsi (const char *ptr, MonoError *error);
-
-ICALL_EXPORT
-MonoStringHandle
-ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringAnsi_len (const char *ptr, gint32 len, MonoError *error);
-
-ICALL_EXPORT
-MonoStringHandle
-ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringUni (const gunichar2 *ptr, MonoError *error);
-
-ICALL_EXPORT
-MonoStringHandle
-ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringUni_len (const gunichar2 *ptr, gint32 len, MonoError *error);
-
-ICALL_EXPORT
-MonoStringHandle
-ves_icall_System_Runtime_InteropServices_Marshal_PtrToStringBSTR (mono_bstr_const ptr, MonoError *error);
-
-ICALL_EXPORT
-guint32
-ves_icall_System_Runtime_InteropServices_Marshal_GetComSlotForMethodInfoInternal (MonoReflectionMethodHandle m, MonoError *error);
 
 ICALL_EXPORT
 guint32 
 ves_icall_System_Runtime_InteropServices_Marshal_GetLastWin32Error (void);
 
 ICALL_EXPORT
-guint32 
-ves_icall_System_Runtime_InteropServices_Marshal_SizeOf (MonoReflectionTypeHandle rtype, MonoError *error);
-
-ICALL_EXPORT
-void
-ves_icall_System_Runtime_InteropServices_Marshal_StructureToPtr (MonoObjectHandle obj, gpointer dst, MonoBoolean delete_old, MonoError *error);
-
-ICALL_EXPORT
-void
-ves_icall_System_Runtime_InteropServices_Marshal_PtrToStructure (gconstpointer src, MonoObjectHandle dst, MonoError *error);
-
-ICALL_EXPORT
-MonoObjectHandle
-ves_icall_System_Runtime_InteropServices_Marshal_PtrToStructure_type (gconstpointer src, MonoReflectionTypeHandle type, MonoError *error);
-
-ICALL_EXPORT
-int
-ves_icall_System_Runtime_InteropServices_Marshal_OffsetOf (MonoReflectionTypeHandle type, MonoStringHandle field_name, MonoError *error);
-
-ICALL_EXPORT
 mono_bstr
 ves_icall_System_Runtime_InteropServices_Marshal_BufferToBSTR (const gunichar2 *ptr, int len);
 
 ICALL_EXPORT
-char*
-ves_icall_System_Runtime_InteropServices_Marshal_StringToHGlobalAnsi (const gunichar2 *s, int length, MonoError *error);
-
-ICALL_EXPORT
-gunichar2*
-ves_icall_System_Runtime_InteropServices_Marshal_StringToHGlobalUni (const gunichar2 *s, int length, MonoError *error);
-
-ICALL_EXPORT
-void
-ves_icall_System_Runtime_InteropServices_Marshal_DestroyStructure (gpointer src, MonoReflectionTypeHandle type, MonoError *error);
-
-ICALL_EXPORT
-void*
-ves_icall_System_Runtime_InteropServices_Marshal_AllocCoTaskMem (int size, MonoError *error);
-
-ICALL_EXPORT
-void*
-ves_icall_System_Runtime_InteropServices_Marshal_AllocCoTaskMemSize (gsize size, MonoError *error);
-
-ICALL_EXPORT
 void
 ves_icall_System_Runtime_InteropServices_Marshal_FreeCoTaskMem (void *ptr);
-
-ICALL_EXPORT
-gpointer 
-ves_icall_System_Runtime_InteropServices_Marshal_ReAllocCoTaskMem (gpointer ptr, int size, MonoError *error);
-
-ICALL_EXPORT
-void*
-ves_icall_System_Runtime_InteropServices_Marshal_AllocHGlobal (gsize size, MonoError *error);
-
-ICALL_EXPORT
-gpointer 
-ves_icall_System_Runtime_InteropServices_Marshal_ReAllocHGlobal (gpointer ptr, gsize size, MonoError *error);
 
 ICALL_EXPORT
 void
@@ -755,14 +581,6 @@ void*
 ves_icall_System_Runtime_InteropServices_Marshal_UnsafeAddrOfPinnedArrayElement (MonoArray *arrayobj, int index);
 
 ICALL_EXPORT
-MonoDelegateHandle
-ves_icall_System_Runtime_InteropServices_Marshal_GetDelegateForFunctionPointerInternal (void *ftn, MonoReflectionTypeHandle type, MonoError *error);
-
-ICALL_EXPORT
-gpointer
-ves_icall_System_Runtime_InteropServices_Marshal_GetFunctionPointerForDelegateInternal (MonoDelegateHandle delegate, MonoError *error);
-
-ICALL_EXPORT
 int
 ves_icall_System_Runtime_InteropServices_Marshal_AddRefInternal (MonoIUnknown *pUnk);
 
@@ -773,54 +591,6 @@ ves_icall_System_Runtime_InteropServices_Marshal_QueryInterfaceInternal (MonoIUn
 ICALL_EXPORT
 int
 ves_icall_System_Runtime_InteropServices_Marshal_ReleaseInternal (MonoIUnknown *pUnk);
-
-ICALL_EXPORT
-void*
-ves_icall_System_Runtime_InteropServices_Marshal_GetIUnknownForObjectInternal (MonoObjectHandle object, MonoError *error);
-
-ICALL_EXPORT
-MonoObjectHandle
-ves_icall_System_Runtime_InteropServices_Marshal_GetObjectForCCW (void* pUnk, MonoError *error);
-
-ICALL_EXPORT
-void*
-ves_icall_System_Runtime_InteropServices_Marshal_GetIDispatchForObjectInternal (MonoObjectHandle object, MonoError *error);
-
-ICALL_EXPORT
-void*
-ves_icall_System_Runtime_InteropServices_Marshal_GetCCW (MonoObjectHandle object, MonoReflectionTypeHandle type, MonoError *error);
-
-ICALL_EXPORT
-MonoBoolean
-ves_icall_System_Runtime_InteropServices_Marshal_IsComObject (MonoObjectHandle object, MonoError *error);
-
-ICALL_EXPORT
-gint32
-ves_icall_System_Runtime_InteropServices_Marshal_ReleaseComObjectInternal (MonoObjectHandle object, MonoError *error);
-
-ICALL_EXPORT
-MonoObjectHandle
-ves_icall_System_ComObject_CreateRCW (MonoReflectionTypeHandle ref_type, MonoError *error);
-
-ICALL_EXPORT
-void
-mono_System_ComObject_ReleaseInterfaces (MonoComObjectHandle obj);
-
-ICALL_EXPORT
-void
-ves_icall_System_ComObject_ReleaseInterfaces (MonoComObjectHandle obj, MonoError *error);
-
-ICALL_EXPORT
-gpointer
-ves_icall_System_ComObject_GetInterfaceInternal (MonoComObjectHandle obj, MonoReflectionTypeHandle ref_type, MonoBoolean throw_exception, MonoError *error);
-
-ICALL_EXPORT
-void
-ves_icall_Mono_Interop_ComInteropProxy_AddProxy (gpointer pUnk, MonoComInteropProxyHandle proxy, MonoError *error);
-
-ICALL_EXPORT
-MonoComInteropProxyHandle
-ves_icall_Mono_Interop_ComInteropProxy_FindProxy (gpointer pUnk, MonoError *error);
 
 MONO_API void
 mono_win32_compat_CopyMemory (gpointer dest, gconstpointer source, gsize length);
@@ -866,13 +636,6 @@ mono_marshal_emit_thread_force_interrupt_checkpoint (MonoMethodBuilder *mb);
 
 void
 mono_marshal_use_aot_wrappers (gboolean use);
-
-MonoObject *
-mono_marshal_xdomain_copy_value (MonoObject *val, MonoError *error);
-
-ICALL_EXPORT
-MonoObject *
-ves_icall_mono_marshal_xdomain_copy_value (MonoObject *val);
 
 int
 mono_mb_emit_save_args (MonoMethodBuilder *mb, MonoMethodSignature *sig, gboolean save_this);

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -69,9 +69,6 @@
 	} 							\
 } while (0)
 
-#define mono_string_builder_capacity(sb) sb->chunkOffset + sb->chunkChars->max_length
-#define mono_string_builder_string_length(sb) sb->chunkOffset + sb->chunkLength
-
 /* 
  * Macros which cache the results of lookups locally.
  * These should be used instead of the original versions, if the __GNUC__
@@ -258,6 +255,7 @@ TYPED_HANDLE_DECL (MonoAppDomain);
 TYPED_HANDLE_DECL (MonoAppDomainSetup);
 
 typedef struct _MonoStringBuilder MonoStringBuilder;
+TYPED_HANDLE_DECL (MonoStringBuilder);
 
 struct _MonoStringBuilder {
 	MonoObject object;
@@ -267,6 +265,20 @@ struct _MonoStringBuilder {
 	int chunkOffset;                  // The logial offset (sum of all characters in previous blocks)
 	int maxCapacity;
 };
+
+static inline int
+mono_string_builder_capacity (MonoStringBuilderHandle sbh)
+{
+	MonoStringBuilder *sb = MONO_HANDLE_RAW (sbh);
+	return sb->chunkOffset + sb->chunkChars->max_length;
+}
+
+static inline int
+mono_string_builder_string_length (MonoStringBuilderHandle sbh)
+{
+	MonoStringBuilder *sb = MONO_HANDLE_RAW (sbh);
+	return sb->chunkOffset + sb->chunkLength;
+}
 
 typedef struct {
 	MonoType *type;
@@ -2019,9 +2031,6 @@ MonoString *
 mono_string_new_size_checked (MonoDomain *domain, gint32 len, MonoError *error);
 
 MonoString*
-mono_string_new_internal (MonoDomain *domain, const char *text);
-
-MonoString*
 mono_ldstr_checked (MonoDomain *domain, MonoImage *image, uint32_t str_index, MonoError *error);
 
 MonoStringHandle
@@ -2218,17 +2227,8 @@ mono_string_length_internal (MonoString *s);
 MonoString*
 mono_string_empty_internal (MonoDomain *domain);
 
-MonoString*
-mono_string_new_wrapper_internal (const char *text);
-
 char*
 mono_string_to_utf8_checked_internal (MonoString *string_obj, MonoError *error);
-
-mono_unichar2*
-mono_string_to_utf16_internal (MonoString *string_obj);
-
-mono_unichar4*
-mono_string_to_utf32_internal (MonoString *string_obj);
 
 mono_bool
 mono_string_equal_internal (MonoString *s1, MonoString *s2);

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -2027,6 +2027,9 @@ mono_object_handle_isinst_mbyref (MonoObjectHandle obj, MonoClass *klass, MonoEr
 MonoStringHandle
 mono_string_new_size_handle (MonoDomain *domain, gint32 len, MonoError *error);
 
+MonoString*
+mono_string_new_len_checked (MonoDomain *domain, const char *text, guint length, MonoError *error);
+
 MonoString *
 mono_string_new_size_checked (MonoDomain *domain, gint32 len, MonoError *error);
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -278,7 +278,7 @@ mono_type_initialization_init (void)
 	type_initialization_hash = g_hash_table_new (NULL, NULL);
 	blocked_thread_hash = g_hash_table_new (NULL, NULL);
 	mono_coop_mutex_init (&ldstr_section);
-	mono_register_jit_icall (ves_icall_string_alloc_raw, "ves_icall_string_alloc", mono_create_icall_signature ("object int"), FALSE);
+	mono_register_jit_icall (ves_icall_string_alloc, "ves_icall_string_alloc", mono_create_icall_signature ("object int"), FALSE);
 }
 
 void
@@ -1072,7 +1072,7 @@ mono_class_insecure_overlapping (MonoClass *klass)
 #endif
 
 MonoStringHandle
-ves_icall_string_alloc (int length, MonoError *error)
+ves_icall_string_alloc_impl (int length, MonoError *error)
 {
 	MonoString *s = mono_string_new_size_checked (mono_domain_get (), length, error);
 	return_val_if_nok (error, NULL_HANDLE_STRING);
@@ -6672,18 +6672,15 @@ mono_string_new_utf8_len (MonoDomain *domain, const char *text, guint length, Mo
 }
 
 MonoString*
-<<<<<<< HEAD
-=======
 mono_string_new_len_checked (MonoDomain *domain, const char *text, guint length, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
 	error_init (error);
-	HANDLE_FUNCTION_RETURN_OBJ (mono_string_new_utf8_len_handle (domain, text, length, error));
+	HANDLE_FUNCTION_RETURN_OBJ (mono_string_new_utf8_len (domain, text, length, error));
 }
 
 static
 MonoString*
->>>>>>> [Coop] Mostly convert 30+ icalls used via register_icall.
 mono_string_new_internal (MonoDomain *domain, const char *text)
 {
 	ERROR_DECL (error);
@@ -6808,7 +6805,7 @@ mono_string_new_wtf8_len_checked (MonoDomain *domain, const char *text, guint le
 }
 
 MonoStringHandle
-mono_string_new_wrapper_internal (const char *text, MonoError *error)
+mono_string_new_wrapper_internal_impl (const char *text, MonoError *error)
 {
 	return MONO_HANDLE_NEW (MonoString, mono_string_new_internal (mono_domain_get (), text));
 }
@@ -6821,7 +6818,7 @@ mono_string_new_wrapper_internal (const char *text, MonoError *error)
 MonoString*
 mono_string_new_wrapper (const char *text)
 {
-	MONO_EXTERNAL_ONLY_GC_UNSAFE (MonoString*, mono_string_new_wrapper_internal_raw (text));
+	MONO_EXTERNAL_ONLY_GC_UNSAFE (MonoString*, mono_string_new_wrapper_internal (text));
 }
 
 /**
@@ -7654,7 +7651,7 @@ mono_string_to_utf8_ignore (MonoString *s)
 }
 
 mono_unichar2*
-mono_string_to_utf16_internal (MonoStringHandle s, MonoError *error)
+mono_string_to_utf16_internal_impl (MonoStringHandle s, MonoError *error)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
@@ -7685,11 +7682,11 @@ mono_string_to_utf16 (MonoString *string_obj)
 {
 	if (!string_obj)
 		return NULL;
-	MONO_EXTERNAL_ONLY (mono_unichar2*, mono_string_to_utf16_internal_raw (string_obj));
+	MONO_EXTERNAL_ONLY (mono_unichar2*, mono_string_to_utf16_internal (string_obj));
 }
 
 mono_unichar4*
-mono_string_to_utf32_internal (MonoStringHandle s, MonoError *error)
+mono_string_to_utf32_internal_impl (MonoStringHandle s, MonoError *error)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 	
@@ -7709,7 +7706,7 @@ mono_string_to_utf32_internal (MonoStringHandle s, MonoError *error)
 mono_unichar4*
 mono_string_to_utf32 (MonoString *string_obj)
 {
-	MONO_EXTERNAL_ONLY (mono_unichar4*, mono_string_to_utf32_internal_raw (string_obj));
+	MONO_EXTERNAL_ONLY (mono_unichar4*, mono_string_to_utf32_internal (string_obj));
 }
 
 /**

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -56,6 +56,7 @@
 #include <mono/utils/unlocked.h>
 #include "external-only.h"
 #include "monitor.h"
+#include "icall-decl.h"
 
 // If no symbols in an object file in a static library are referenced, its exports will not be exported.
 // There are a few workarounds:
@@ -277,7 +278,7 @@ mono_type_initialization_init (void)
 	type_initialization_hash = g_hash_table_new (NULL, NULL);
 	blocked_thread_hash = g_hash_table_new (NULL, NULL);
 	mono_coop_mutex_init (&ldstr_section);
-	mono_register_jit_icall (ves_icall_string_alloc, "ves_icall_string_alloc", mono_create_icall_signature ("object int"), FALSE);
+	mono_register_jit_icall (ves_icall_string_alloc_raw, "ves_icall_string_alloc", mono_create_icall_signature ("object int"), FALSE);
 }
 
 void
@@ -1070,14 +1071,12 @@ mono_class_insecure_overlapping (MonoClass *klass)
 }
 #endif
 
-MonoString*
-ves_icall_string_alloc (int length)
+MonoStringHandle
+ves_icall_string_alloc (int length, MonoError *error)
 {
-	ERROR_DECL (error);
-	MonoString *str = mono_string_new_size_checked (mono_domain_get (), length, error);
-	mono_error_set_pending_exception (error);
-
-	return str;
+	MonoString *s = mono_string_new_size_checked (mono_domain_get (), length, error);
+	return_val_if_nok (error, NULL_HANDLE_STRING);
+	return MONO_HANDLE_NEW (MonoString, s);
 }
 
 #define BITMAP_EL_SIZE (sizeof (gsize) * 8)
@@ -6673,6 +6672,18 @@ mono_string_new_utf8_len (MonoDomain *domain, const char *text, guint length, Mo
 }
 
 MonoString*
+<<<<<<< HEAD
+=======
+mono_string_new_len_checked (MonoDomain *domain, const char *text, guint length, MonoError *error)
+{
+	HANDLE_FUNCTION_ENTER ();
+	error_init (error);
+	HANDLE_FUNCTION_RETURN_OBJ (mono_string_new_utf8_len_handle (domain, text, length, error));
+}
+
+static
+MonoString*
+>>>>>>> [Coop] Mostly convert 30+ icalls used via register_icall.
 mono_string_new_internal (MonoDomain *domain, const char *text)
 {
 	ERROR_DECL (error);
@@ -6796,10 +6807,10 @@ mono_string_new_wtf8_len_checked (MonoDomain *domain, const char *text, guint le
 	return o;
 }
 
-MonoString*
-mono_string_new_wrapper_internal (const char *text)
+MonoStringHandle
+mono_string_new_wrapper_internal (const char *text, MonoError *error)
 {
-	return mono_string_new_internal (mono_domain_get (), text);
+	return MONO_HANDLE_NEW (MonoString, mono_string_new_internal (mono_domain_get (), text));
 }
 
 /**
@@ -6810,7 +6821,7 @@ mono_string_new_wrapper_internal (const char *text)
 MonoString*
 mono_string_new_wrapper (const char *text)
 {
-	MONO_EXTERNAL_ONLY_GC_UNSAFE (MonoString*, mono_string_new_wrapper_internal (text));
+	MONO_EXTERNAL_ONLY_GC_UNSAFE (MonoString*, mono_string_new_wrapper_internal_raw (text));
 }
 
 /**
@@ -7643,19 +7654,20 @@ mono_string_to_utf8_ignore (MonoString *s)
 }
 
 mono_unichar2*
-mono_string_to_utf16_internal (MonoString *s)
+mono_string_to_utf16_internal (MonoStringHandle s, MonoError *error)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	if (s == NULL)
+	// FIXME This optimization ok to miss before wrapper? Or null is rare?
+	if (MONO_HANDLE_RAW (s) == NULL)
 		return NULL;
 
-	int const length = s->length;
+	int const length = mono_string_handle_length (s);
 	mono_unichar2* const as = (mono_unichar2*)g_malloc ((length + 1) * sizeof (*as));
 	if (as) {
 		as [length] = 0;
 		if (length)
-			memcpy (as, mono_string_chars_internal (s), length * sizeof (*as));
+			memcpy (as, mono_string_chars_internal (MONO_HANDLE_RAW (s)), length * sizeof (*as));
 	}
 	return as;
 }
@@ -7671,18 +7683,21 @@ mono_string_to_utf16_internal (MonoString *s)
 mono_unichar2*
 mono_string_to_utf16 (MonoString *string_obj)
 {
-	MONO_EXTERNAL_ONLY (mono_unichar2*, mono_string_to_utf16_internal (string_obj));
+	if (!string_obj)
+		return NULL;
+	MONO_EXTERNAL_ONLY (mono_unichar2*, mono_string_to_utf16_internal_raw (string_obj));
 }
 
 mono_unichar4*
-mono_string_to_utf32_internal (MonoString *s)
+mono_string_to_utf32_internal (MonoStringHandle s, MonoError *error)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 	
-	if (s == NULL)
+	// FIXME This optimization ok to miss before wrapper? Or null is rare?
+	if (MONO_HANDLE_RAW (s) == NULL)
 		return NULL;
 		
-	return g_utf16_to_ucs4 (s->chars, s->length, NULL, NULL, NULL);
+	return g_utf16_to_ucs4 (MONO_HANDLE_RAW (s)->chars, mono_string_handle_length (s), NULL, NULL, NULL);
 }
 
 /**
@@ -7694,7 +7709,7 @@ mono_string_to_utf32_internal (MonoString *s)
 mono_unichar4*
 mono_string_to_utf32 (MonoString *string_obj)
 {
-	MONO_EXTERNAL_ONLY (mono_unichar4*, mono_string_to_utf32_internal (string_obj));
+	MONO_EXTERNAL_ONLY (mono_unichar4*, mono_string_to_utf32_internal_raw (string_obj));
 }
 
 /**
@@ -7722,19 +7737,11 @@ mono_string_from_utf16 (gunichar2 *data)
 MonoString *
 mono_string_from_utf16_checked (const gunichar2 *data, MonoError *error)
 {
-
 	MONO_REQ_GC_UNSAFE_MODE;
-
 	error_init (error);
-	MonoDomain *domain = mono_domain_get ();
-	int len = 0;
-
 	if (!data)
 		return NULL;
-
-	while (data [len]) len++;
-
-	return mono_string_new_utf16_checked (domain, data, len, error);
+	return mono_string_new_utf16_checked (mono_domain_get (), data, g_utf16_len (data), error);
 }
 
 /**

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -226,7 +226,7 @@ mono_remoting_marshal_init (void)
 		register_icall (type_from_handle, "type_from_handle", "object ptr", FALSE);
 		register_icall (mono_marshal_set_domain_by_id, "mono_marshal_set_domain_by_id", "int32 int32 int32", FALSE);
 		register_icall (mono_marshal_check_domain_image, "mono_marshal_check_domain_image", "int32 int32 ptr", FALSE);
-		register_icall (ves_icall_mono_marshal_xdomain_copy_value_raw, "ves_icall_mono_marshal_xdomain_copy_value", "object object", FALSE);
+		register_icall (ves_icall_mono_marshal_xdomain_copy_value, "ves_icall_mono_marshal_xdomain_copy_value", "object object", FALSE);
 		register_icall (mono_marshal_xdomain_copy_out_value, "mono_marshal_xdomain_copy_out_value", "void object object", FALSE);
 		register_icall (mono_remoting_wrapper, "mono_remoting_wrapper", "object ptr ptr", FALSE);
 		register_icall (mono_remoting_update_exception, "mono_remoting_update_exception", "object object", FALSE);
@@ -608,7 +608,7 @@ mono_marshal_xdomain_copy_out_value (MonoObject *src, MonoObject *dst)
 static void
 mono_marshal_emit_xdomain_copy_value (MonoMethodBuilder *mb, MonoClass *pclass)
 {
-	mono_mb_emit_icall (mb, ves_icall_mono_marshal_xdomain_copy_value_raw);
+	mono_mb_emit_icall (mb, ves_icall_mono_marshal_xdomain_copy_value);
 	mono_mb_emit_op (mb, CEE_CASTCLASS, pclass);
 }
 
@@ -2134,7 +2134,7 @@ mono_marshal_xdomain_copy_value (MonoObject* val_raw, MonoError *error)
  * Makes a copy of "val" suitable for the current domain.
  */
 MonoObjectHandle
-ves_icall_mono_marshal_xdomain_copy_value (MonoObjectHandle val, MonoError *error)
+ves_icall_mono_marshal_xdomain_copy_value_impl (MonoObjectHandle val, MonoError *error)
 {
 	return mono_marshal_xdomain_copy_value_handle (val, error);
 }

--- a/mono/metadata/sgen-mono-ilgen.c
+++ b/mono/metadata/sgen-mono-ilgen.c
@@ -33,6 +33,7 @@
 #include "utils/mono-threads-coop.h"
 #include "utils/mono-threads.h"
 #include "metadata/w32handle.h"
+#include "icall-decl.h"
 
 #define OPDEF(a,b,c,d,e,f,g,h,i,j) \
 	a = i,
@@ -192,7 +193,7 @@ emit_managed_allocater_ilgen (MonoMethodBuilder *mb, gboolean slowpath, gboolean
 			break;
 		case ATYPE_STRING:
 			mono_mb_emit_ldarg (mb, 1);
-			mono_mb_emit_icall (mb, ves_icall_string_alloc);
+			mono_mb_emit_icall (mb, ves_icall_string_alloc_raw);
 			break;
 		default:
 			g_assert_not_reached ();

--- a/mono/metadata/sgen-mono-ilgen.c
+++ b/mono/metadata/sgen-mono-ilgen.c
@@ -193,7 +193,7 @@ emit_managed_allocater_ilgen (MonoMethodBuilder *mb, gboolean slowpath, gboolean
 			break;
 		case ATYPE_STRING:
 			mono_mb_emit_ldarg (mb, 1);
-			mono_mb_emit_icall (mb, ves_icall_string_alloc_raw);
+			mono_mb_emit_icall (mb, ves_icall_string_alloc);
 			break;
 		default:
 			g_assert_not_reached ();

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -73,6 +73,7 @@
 #ifdef TARGET_ARM
 #include <mono/mini/mini-arm.h>
 #endif
+#include <mono/metadata/icall-decl.h>
 
 #ifdef _MSC_VER
 #pragma warning(disable:4102) // label' : unreferenced label
@@ -3981,7 +3982,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 			if (method->wrapper_type == MONO_WRAPPER_DYNAMIC_METHOD) {
 				s = (MonoString*)mono_method_get_wrapper_data (method, strtoken);
 			} else if (method->wrapper_type != MONO_WRAPPER_NONE) {
-				s = mono_string_new_wrapper_internal ((const char*)mono_method_get_wrapper_data (method, strtoken));
+				s = mono_string_new_wrapper_internal_raw ((const char*)mono_method_get_wrapper_data (method, strtoken));
 			} else {
 				g_assert_not_reached ();
 			}

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3982,7 +3982,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 			if (method->wrapper_type == MONO_WRAPPER_DYNAMIC_METHOD) {
 				s = (MonoString*)mono_method_get_wrapper_data (method, strtoken);
 			} else if (method->wrapper_type != MONO_WRAPPER_NONE) {
-				s = mono_string_new_wrapper_internal_raw ((const char*)mono_method_get_wrapper_data (method, strtoken));
+				s = mono_string_new_wrapper_internal ((const char*)mono_method_get_wrapper_data (method, strtoken));
 			} else {
 				g_assert_not_reached ();
 			}

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -8412,7 +8412,7 @@ calli_end:
 					EMIT_NEW_LDSTRLITCONST (cfg, iargs [0], str);
 				else
 					EMIT_NEW_PCONST (cfg, iargs [0], str);
-				*sp = mono_emit_jit_icall (cfg, mono_string_new_wrapper_internal_raw, iargs);
+				*sp = mono_emit_jit_icall (cfg, mono_string_new_wrapper_internal, iargs);
 			} else {
 				if (cfg->opt & MONO_OPT_SHARED) {
 					MonoInst *iargs [3];

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -69,6 +69,7 @@
 #include <mono/utils/mono-utils-debug.h>
 #include <mono/utils/mono-logger-internals.h>
 #include <mono/metadata/verify-internals.h>
+#include <mono/metadata/icall-decl.h>
 
 #include "trace.h"
 
@@ -8411,7 +8412,7 @@ calli_end:
 					EMIT_NEW_LDSTRLITCONST (cfg, iargs [0], str);
 				else
 					EMIT_NEW_PCONST (cfg, iargs [0], str);
-				*sp = mono_emit_jit_icall (cfg, mono_string_new_wrapper_internal, iargs);
+				*sp = mono_emit_jit_icall (cfg, mono_string_new_wrapper_internal_raw, iargs);
 			} else {
 				if (cfg->opt & MONO_OPT_SHARED) {
 					MonoInst *iargs [3];


### PR DESCRIPTION
[Coop] Mostly convert 30+ icalls used via register_icall.
And infrastructure to support that.
The infrastructure is not as ideal as it could be.
In future the C preprocessor wrappers should be marshal-ilgen wrappers,
so the handles are more efficiently created.

Some of the conversion is incomplete and just goes back to raw pointers,
but mostly it is good.

Some of the conversion is by replacing previously manual conversion
with more automatic conversion, but most of it is new.

Some is embedding API, not JIT icalls.