### PR TITLE
Windows x64 LLVM assert support + MSVC only for none cross compiler build.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3814,6 +3814,27 @@ if test "x$enable_llvm" = "xdefault"; then
    enable_llvm=$enable_llvm_default
 fi
 
+enable_llvm_msvc_only="no"
+if test "x$enable_llvm" = "xyes"; then
+	if test "x$host_win32" = "xyes"; then
+		if test "x$cross_compiling" = "xno"; then
+			case "$target" in
+			x86_64*)
+				AC_MSG_WARN("LLVM for host=Windows and target=Windows is only supported on x64 MSVC builds. Disabling LLVM for GCC build.")
+				enable_llvm_msvc_only="yes"
+				;;
+			i686*)
+				AC_MSG_ERROR("LLVM for host=Windows and target=Windows is only supported for x64 builds.")
+				;;
+			esac
+		fi
+		if test "x$enable_loadedllvm" = "xyes"; then
+			AC_MSG_WARN("Loadable LLVM currently not supported on Windows. Disabling feature.")
+			enable_loadedllvm=no
+		fi
+	fi
+fi
+
 internal_llvm="no"
 if test "x$enable_llvm" = "xyes"; then
 	if test "x$with_llvm" != "x"; then
@@ -3859,34 +3880,53 @@ if test "x$enable_llvm" = "xyes"; then
 		EXTERNAL_LLVM_CONFIG_WIN32=$(cygpath -m $EXTERNAL_LLVM_CONFIG)
 		AC_SUBST(EXTERNAL_LLVM_CONFIG_WIN32)
 	fi
-	AC_DEFINE(ENABLE_LLVM, 1, [Enable the LLVM back end])
+	if test "x$enable_llvm_msvc_only" != "xyes"; then
+		AC_DEFINE(ENABLE_LLVM, 1, [Enable the LLVM back end])
+	else
+		AC_DEFINE(ENABLE_LLVM_MSVC_ONLY, 1, [Enable the LLVM back end])
+	fi
 fi # ENABLE_LLVM
 
 # AC_DEFINE necessary for correct restore behavior on Linux
-AM_CONDITIONAL(INTERNAL_LLVM, [test "x$internal_llvm" != "xno"])
+AM_CONDITIONAL(INTERNAL_LLVM, [test "x$internal_llvm" != "xno" && test "x$enable_llvm_msvc_only" != "xyes"])
 if test "x$internal_llvm" != "xno"; then
-   AC_DEFINE(INTERNAL_LLVM, 1, [LLVM used is being build during mono build])
+	if test "x$enable_llvm_msvc_only" != "xyes"; then
+		AC_DEFINE(INTERNAL_LLVM, 1, [LLVM used is being build during mono build])
+	else
+		AC_DEFINE(INTERNAL_LLVM_MSVC_ONLY, 1, [LLVM used is being build during mono build])
+	fi
 fi
 
-AM_CONDITIONAL(INTERNAL_LLVM_ASSERTS, [test "x$enable_llvm_asserts" != "xno"])
+AM_CONDITIONAL(INTERNAL_LLVM_ASSERTS, [test "x$enable_llvm_asserts" != "xno" && test "x$enable_llvm_msvc_only" != "xyes"])
 if test "x$enable_llvm_asserts" != "xno"; then
-   AC_DEFINE(INTERNAL_LLVM_ASSERTS, 1, [Build LLVM with assertions])
+	if test "x$enable_llvm_msvc_only" != "xyes"; then
+		AC_DEFINE(INTERNAL_LLVM_ASSERTS, 1, [Build LLVM with assertions])
+	else
+		AC_DEFINE(INTERNAL_LLVM_ASSERTS_MSVC_ONLY, 1, [Build LLVM with assertions])
+	fi
 fi
 
-AM_CONDITIONAL(ENABLE_LLVM, [test x$enable_llvm = xyes])
+AM_CONDITIONAL(ENABLE_LLVM, [test x$enable_llvm = xyes && test x$enable_llvm_msvc_only != xyes])
 
+AM_CONDITIONAL(LOADED_LLVM, [test x$enable_loadedllvm = xyes && test x$enable_llvm_msvc_only != xyes])
 if test "x$enable_loadedllvm" = "xyes"; then
-   AC_DEFINE(MONO_LLVM_LOADED, 1, [The LLVM back end is dynamically loaded])
+	if test "x$enable_llvm_msvc_only" != "xyes"; then
+		AC_DEFINE(MONO_LLVM_LOADED, 1, [The LLVM back end is dynamically loaded])
+	fi
 fi
-AM_CONDITIONAL(LOADED_LLVM, [test x$enable_loadedllvm = xyes])
 
 if test "x$enable_llvm" = "xyes"; then
-   enable_llvm_runtime=yes
+	enable_llvm_runtime=yes
 fi
+
+AM_CONDITIONAL(ENABLE_LLVM_RUNTIME, [test x$enable_llvm_runtime = xyes && test x$enable_llvm_msvc_only != xyes])
 if test "x$enable_llvm_runtime" = "xyes"; then
-   AC_DEFINE(ENABLE_LLVM_RUNTIME, 1, [Runtime support code for llvm enabled])
+	if test "x$enable_llvm_msvc_only" != "xyes"; then
+		AC_DEFINE(ENABLE_LLVM_RUNTIME, 1, [Runtime support code for llvm enabled])
+	else
+		AC_DEFINE(ENABLE_LLVM_RUNTIME_MSVC_ONLY, 1, [Runtime support code for llvm enabled])
+	fi
 fi
-AM_CONDITIONAL(ENABLE_LLVM_RUNTIME, [test x$enable_llvm_runtime = xyes])
 
 TARGET="unknown"
 ACCESS_UNALIGNED="yes"
@@ -6213,7 +6253,7 @@ echo "
 	Engine:        $jit_status
 	BigArrays:     $enable_big_arrays
 	DTrace:        $enable_dtrace
-	LLVM Back End: $enable_llvm (dynamically loaded: $enable_loadedllvm, built in-tree: $internal_llvm, assertions: $enable_llvm_asserts)
+	LLVM Back End: $enable_llvm (dynamically loaded: $enable_loadedllvm, built in-tree: $internal_llvm, assertions: $enable_llvm_asserts, msvc only: $enable_llvm_msvc_only)
 	Spectre:       $spectre_mitigation_status
 	Mono.Native:   $mono_native_text
 

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -448,6 +448,12 @@ typedef struct {
 #define MONO_ARCH_DYN_CALL_PARAM_AREA 0
 
 #define MONO_ARCH_LLVM_SUPPORTED 1
+#if defined(HOST_WIN32) && defined(TARGET_WIN32) && !defined(_MSC_VER)
+// Only supported for Windows cross compiler builds, host == Win32, target != Win32
+// and only using MSVC for none cross compiler builds.
+#undef MONO_ARCH_LLVM_SUPPORTED
+#endif
+
 #define MONO_ARCH_HAVE_CARD_TABLE_WBARRIER 1
 #define MONO_ARCH_HAVE_SETUP_RESUME_FROM_SIGNAL_HANDLER_CTX 1
 #define MONO_ARCH_GC_MAPS_SUPPORTED 1

--- a/mono/mini/mini-x86.h
+++ b/mono/mini/mini-x86.h
@@ -214,7 +214,12 @@ typedef struct {
 #define MONO_ARCH_AOT_SUPPORTED 1
 
 #define MONO_ARCH_GSHARED_SUPPORTED 1
+
 #define MONO_ARCH_LLVM_SUPPORTED 1
+#if defined(HOST_WIN32) && defined(TARGET_WIN32)
+// Only supported for Windows cross compiler builds, host == Win32, target != Win32.
+#undef MONO_ARCH_LLVM_SUPPORTED
+#endif
 
 #define MONO_ARCH_SOFT_DEBUG_SUPPORTED 1
 

--- a/msvc/build-external-llvm.bat
+++ b/msvc/build-external-llvm.bat
@@ -9,10 +9,11 @@
 :: %3 LLVM install root directory.
 :: %4 Mono distribution root directory.
 :: %5 VS CFLAGS.
-:: %6 VS platform (Win32/x64)
-:: %7 VS configuration (Debug/Release)
-:: %8 VS target
-:: %9 MsBuild bin path, if used.
+:: %6 Additional CMake arguments.
+:: %7 VS platform (Win32/x64).
+:: %8 VS configuration (Debug/Release).
+:: %9 VS target.
+:: %10 MsBuild bin path, if used.
 :: --------------------------------------------------
 
 @echo off
@@ -33,10 +34,11 @@ set LLVM_BUILD_DIR=%~2
 set LLVM_INSTALL_DIR=%~3
 set MONO_DIST_DIR=%~4
 set VS_CFLAGS=%~5
-set VS_PLATFORM=%~6
-set VS_CONFIGURATION=%~7
-set VS_TARGET=%~8
-set MSBUILD_BIN_PATH=%~9
+set LLVM_ADDITIONAL_CMAKE_ARGS=%~6
+set VS_PLATFORM=%~7
+set VS_CONFIGURATION=%~8
+set VS_TARGET=%~9
+set MSBUILD_BIN_PATH=%~10
 
 :: Setup toolchain.
 :: set GIT=
@@ -211,6 +213,7 @@ if /i "%CMAKE_GENERATOR%" == "ninja" (
 -DLLVM_TOOLS_TO_BUILD="opt;llc;llvm-config;llvm-dis;llvm-mc;llvm-as" ^
 -DLLVM_ENABLE_LIBXML2=Off ^
 -DCMAKE_SYSTEM_PROCESSOR="%LLVM_ARCH%" ^
+%LLVM_ADDITIONAL_CMAKE_ARGS% ^
 %CMAKE_GENERATOR_ARGS% ^
 -G "%CMAKE_GENERATOR%" ^
 "%LLVM_DIR%"

--- a/msvc/build-external-llvm.vcxproj
+++ b/msvc/build-external-llvm.vcxproj
@@ -152,7 +152,10 @@
     <_LLVMCFlags Condition="'$(MONO_PREPROCESSOR_DEFINITIONS)' != ''">$(MONO_PREPROCESSOR_DEFINITIONS.Replace(";"," "))</_LLVMCFlags>
     <_LLVMCFlags>$(_LLVMCFlags.Trim())</_LLVMCFlags>
     <_LLVMCFlags Condition="'$(_LLVMCFlags)' != ''">-D$(_LLVMCFlags.Replace(" "," -D"))</_LLVMCFlags>
-    <_LLVMBuildCommand>build-external-llvm.bat &quot;$(_LLVMSourceDir)&quot; &quot;$(_LLVMBuildDir)&quot; &quot;$(_LLVMInstallDir)&quot; &quot;$(_MonoOutputDir)&quot; &quot;$(_LLVMCFlags)&quot; &quot;$(Platform)&quot; &quot;$(Configuration)&quot;</_LLVMBuildCommand>
+    <_LLVMEnableAsserts>-DLLVM_ENABLE_ASSERTIONS=Off</_LLVMEnableAsserts>
+    <_LLVMEnableAsserts Condition="'$(MONO_ENABLE_LLVM_ASSERTS)' == 'true'" >-DLLVM_ENABLE_ASSERTIONS=On</_LLVMEnableAsserts>
+    <_LLVMAdditionalCMakeArgs>$(_LLVMEnableAsserts)</_LLVMAdditionalCMakeArgs>
+    <_LLVMBuildCommand>build-external-llvm.bat &quot;$(_LLVMSourceDir)&quot; &quot;$(_LLVMBuildDir)&quot; &quot;$(_LLVMInstallDir)&quot; &quot;$(_MonoOutputDir)&quot; &quot;$(_LLVMCFlags)&quot; &quot;$(_LLVMAdditionalCMakeArgs)&quot; &quot;$(Platform)&quot; &quot;$(Configuration)&quot;</_LLVMBuildCommand>
   </PropertyGroup>
   <Target Name="_AfterBuildExternalLLVM" Condition="'$(MONO_ENABLE_LLVM)' == 'true' and '$(_MonoEnableInternalLLVM)' == 'true'">
     <Exec Command="$(_LLVMBuildCommand) &quot;Build&quot; &quot;$(MSBuildBinPath)\&quot;">

--- a/msvc/build-init.vcxproj
+++ b/msvc/build-init.vcxproj
@@ -166,4 +166,23 @@
   </Target>
 
   <Target Name="AfterBuild" DependsOnTargets="AfterBuildWinSetup" />
+
+  <Target Name="_BackupConfigFile" Condition="'$(_MonoConfigFileBackupExists)' != 'true'">
+    <Copy SourceFiles="$(MONO_DIR)/config.h" DestinationFiles="$(MONO_DIR)/cygconfig.h" />
+  </Target>
+
+  <Target Name="_CheckConfigFile">
+    <_CheckConfigurationProperty ConfFile="$(MONO_DIR)/config.h" ConfRegEx="#include.*cygconfig.h.*">
+      <Output TaskParameter="ConfPropertyFoundMatch" PropertyName="_MonoConfigFileBackupExists" />
+    </_CheckConfigurationProperty>
+  </Target>
+
+  <PropertyGroup>
+    <PrepareForBuildDependsOn>
+      _CheckConfigFile;
+      _BackupConfigFile;
+      $(PrepareForBuildDependsOn);
+    </PrepareForBuildDependsOn>
+  </PropertyGroup>
+
 </Project>

--- a/msvc/mono.external.targets
+++ b/msvc/mono.external.targets
@@ -170,7 +170,7 @@
         </PropertyGroup>
     </Target>
 
-    <Target Name="_SetupMonoLLVMBuildProperties" Condition="$(MONO_ENABLE_LLVM)=='true'">
+    <Target Name="_SetupMonoLLVMBuildProperties" Condition="$(MONO_ENABLE_LLVM) == 'true'">
 
         <_CheckConfigurationProperty ConfFile="$(MONO_DIR)/cygconfig.h" ConfRegEx=".*#define.*INTERNAL_LLVM_ASSERTS.*1" Condition="'$(MONO_ENABLE_LLVM_ASSERTS)' != 'true'">
             <Output TaskParameter="ConfPropertyFoundMatch" PropertyName="MONO_ENABLE_LLVM_ASSERTS" />

--- a/msvc/mono.external.targets
+++ b/msvc/mono.external.targets
@@ -163,6 +163,13 @@
         </PropertyGroup>
     </Target>
 
+    <Target Name="_CheckLLVMPlatformSupport" Condition="'$(MONO_ENABLE_LLVM)' == 'true'">
+        <warning Text="LLVM only supported on x64 builds, disabling LLVM support." Condition="'$(Platform)' != 'x64'" />
+        <PropertyGroup Condition="'$(Platform)' != 'x64'">
+            <MONO_ENABLE_LLVM>false</MONO_ENABLE_LLVM>
+        </PropertyGroup>
+    </Target>
+
     <Target Name="_SetupMonoLLVMBuildProperties" Condition="$(MONO_ENABLE_LLVM)=='true'">
 
         <_CheckConfigurationProperty ConfFile="$(MONO_DIR)/cygconfig.h" ConfRegEx=".*#define.*INTERNAL_LLVM_ASSERTS.*1" Condition="'$(MONO_ENABLE_LLVM_ASSERTS)' != 'true'">
@@ -220,7 +227,7 @@
 
     </Target>
 
-    <Target Name="_ConfigureExternalMonoLLVMBuildEnvironment" DependsOnTargets="_SetDefaultLLVMProperties;_CheckEnableLLVM;_CheckInternalLLVM;_CheckExternalLLVM" />
+    <Target Name="_ConfigureExternalMonoLLVMBuildEnvironment" DependsOnTargets="_SetDefaultLLVMProperties;_CheckEnableLLVM;_CheckInternalLLVM;_CheckExternalLLVM;_CheckLLVMPlatformSupport" />
     <Target Name="_ConfigureExternalMonoBTLSBuildEnvironment" DependsOnTargets="_CheckEnableBtls" />
     <Target Name="_ConfigureExternalMonoBuildEnvironment" DependsOnTargets="_ConfigureExternalMonoLLVMBuildEnvironment;_ConfigureExternalMonoBTLSBuildEnvironment" />
 

--- a/msvc/mono.external.targets
+++ b/msvc/mono.external.targets
@@ -113,6 +113,7 @@
         <_LLVMSourceDir Condition="'$(_LLVMSourceDir)' == ''">$(_MonoSourceDir)\external\llvm</_LLVMSourceDir>
         <_LLVMBuildDir>$([System.IO.Path]::GetFullPath('$(MONO_BUILD_DIR_PREFIX)$(Platform)\obj\external\llvm-build\$(Configuration)'))</_LLVMBuildDir>
         <_LLVMInstallDir>$(_LLVMBuildDir)\install</_LLVMInstallDir>
+        <_MonoLLVMConfig>$(_LLVMInstallDir)\bin\llvm-config.exe</_MonoLLVMConfig>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -159,7 +160,6 @@
         <PropertyGroup Condition="'$(MONO_EXTERNAL_LLVM_CONFIG)' == ''">
             <_MonoEnableExternalLLVM>false</_MonoEnableExternalLLVM>
             <_MonoEnableInternalLLVM>true</_MonoEnableInternalLLVM>
-            <_MonoLLVMConfig>$(_LLVMInstallDir)\bin\llvm-config.exe</_MonoLLVMConfig>
         </PropertyGroup>
     </Target>
 

--- a/msvc/mono.external.targets
+++ b/msvc/mono.external.targets
@@ -165,6 +165,10 @@
 
     <Target Name="_SetupMonoLLVMBuildProperties" Condition="$(MONO_ENABLE_LLVM)=='true'">
 
+        <_CheckConfigurationProperty ConfFile="$(MONO_DIR)/cygconfig.h" ConfRegEx=".*#define.*INTERNAL_LLVM_ASSERTS.*1" Condition="'$(MONO_ENABLE_LLVM_ASSERTS)' != 'true'">
+            <Output TaskParameter="ConfPropertyFoundMatch" PropertyName="MONO_ENABLE_LLVM_ASSERTS" />
+        </_CheckConfigurationProperty>
+
         <Error Text="LLVM config executable $(_MonoLLVMConfig) not found." Condition="!Exists($(_MonoLLVMConfig))" />
 
         <_GetLLVMConfiguration LLVMConfTool="$(_MonoLLVMConfig)" LLVMConfToolArg="--version">

--- a/msvc/mono.props
+++ b/msvc/mono.props
@@ -17,6 +17,8 @@
     <MONO_USE_STATIC_LIBMONO>false</MONO_USE_STATIC_LIBMONO>
     <!-- When true, mono binaries will link and include llvm. When false, mono binaries will not link and include llvm.  -->
     <MONO_ENABLE_LLVM>false</MONO_ENABLE_LLVM>
+    <!-- When true, enable LLVM asserts for internal LLVM build. When false, disable LLVM asserts for internal LLVM build.  -->
+    <MONO_ENABLE_LLVM_ASSERTS>false</MONO_ENABLE_LLVM_ASSERTS>
     <!-- When set, use an alternative LLVM source location for internal LLVM build.  -->
     <MONO_INTERNAL_LLVM_SOURCE_DIR></MONO_INTERNAL_LLVM_SOURCE_DIR>
     <!-- When set, use an external pre-build LLVM library instead of internal one.  -->

--- a/msvc/winsetup.bat
+++ b/msvc/winsetup.bat
@@ -73,6 +73,10 @@ for %%a in (%OPTIONAL_DEFINES%) do (
 
 echo #endif >> %CONFIG_H_TEMP%
 
+echo #if defined(ENABLE_LLVM) ^&^& defined(HOST_WIN32) ^&^& defined(TARGET_WIN32) ^&^& (!defined(TARGET_AMD64) ^|^| !defined(_MSC_VER)) >> %CONFIG_H_TEMP%
+echo #error LLVM for host=Windows and target=Windows is only supported on x64 MSVC build. >> %CONFIG_H_TEMP%
+echo #endif >> %CONFIG_H_TEMP%
+
 :: If the file is different, replace it.
 fc %CONFIG_H_TEMP% %CONFIG_H% >nul 2>&1 || move /y %CONFIG_H_TEMP% %CONFIG_H%
 del %CONFIG_H_TEMP% 2>nul


### PR DESCRIPTION
**Add support for LLVM asserts in internal LLVM build on Windows:**

Read and use of enable-llvm-asserts in autogen and include it in MSVC internal build LLVM.

**Only build LLVM using MSVC if not cross compiling:**

If not cross compiling, building runtime where host/target is Windows, only build and use LLVM as part of msvc build (only supported configuration), disabled on gcc build. This is needed so autogen.sh can be used to configure build using for example --enable-llvm, but only build on supported Windows configurations. NOTE, this will only be applied to none cross compiler builds since that LLVM build is currently x64, MSVC only.

Enforce 64-bit LLVM support when building using Visual Studio solution file.
