### PR TITLE
Fix regression with building PPC JIT

### DIFF
--- a/mono/mini/mini-ops.h
+++ b/mono/mini/mini-ops.h
@@ -1193,7 +1193,7 @@ MINI_OP(OP_AMD64_SAVE_SP_TO_LMF,         "amd64_save_sp_to_lmf", NONE, NONE, NON
 #if  defined(TARGET_POWERPC)
 MINI_OP(OP_PPC_SUBFIC,             "ppc_subfic", IREG, IREG, NONE)
 MINI_OP(OP_PPC_SUBFZE,             "ppc_subfze", IREG, IREG, NONE)
-MINI_OP(OP_CHECK_FINITE,           "ppc_check_finite", NONE, IREG, NONE)
+MINI_OP(OP_PPC_CHECK_FINITE,           "ppc_check_finite", NONE, IREG, NONE)
 #endif
 
 #if defined(TARGET_ARM) || defined(TARGET_ARM64)

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -2171,7 +2171,7 @@ mono_arch_decompose_opts (MonoCompile *cfg, MonoInst *ins)
 #else
 		MONO_EMIT_NEW_LOAD_MEMBASE_OP (cfg, OP_LOADI4_MEMBASE, msw_reg, basereg, offset+4);
 #endif
-		MONO_EMIT_NEW_UNALU (cfg, OP_CHECK_FINITE, -1, msw_reg);
+		MONO_EMIT_NEW_UNALU (cfg, OP_PPC_CHECK_FINITE, -1, msw_reg);
 		MONO_EMIT_NEW_UNALU (cfg, OP_FMOVE, ins->dreg, ins->sreg1);
 		ins->opcode = OP_NOP;
 		break;
@@ -4312,7 +4312,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			break;
 		case OP_CKFINITE:
 			g_assert_not_reached ();
-		case OP_CHECK_FINITE: {
+		case OP_PPC_CHECK_FINITE: {
 			ppc_rlwinm (code, ins->sreg1, ins->sreg1, 0, 1, 31);
 			ppc_addis (code, ins->sreg1, ins->sreg1, -32752);
 			ppc_rlwinmd (code, ins->sreg1, ins->sreg1, 1, 31, 31);

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -2171,7 +2171,7 @@ mono_arch_decompose_opts (MonoCompile *cfg, MonoInst *ins)
 #else
 		MONO_EMIT_NEW_LOAD_MEMBASE_OP (cfg, OP_LOADI4_MEMBASE, msw_reg, basereg, offset+4);
 #endif
-		MONO_EMIT_NEW_UNALU (cfg, OP_PPC_CHECK_FINITE, -1, msw_reg);
+		MONO_EMIT_NEW_UNALU (cfg, OP_CHECK_FINITE, -1, msw_reg);
 		MONO_EMIT_NEW_UNALU (cfg, OP_FMOVE, ins->dreg, ins->sreg1);
 		ins->opcode = OP_NOP;
 		break;
@@ -4312,7 +4312,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			break;
 		case OP_CKFINITE:
 			g_assert_not_reached ();
-		case OP_PPC_CHECK_FINITE: {
+		case OP_CHECK_FINITE: {
 			ppc_rlwinm (code, ins->sreg1, ins->sreg1, 0, 1, 31);
 			ppc_addis (code, ins->sreg1, ins->sreg1, -32752);
 			ppc_rlwinmd (code, ins->sreg1, ins->sreg1, 1, 31, 31);


### PR DESCRIPTION
d5547b1929afa91944ba941d66a93767ca534a97 made an incorrect change to `mini-ppc.c` that wouldn't build; revert that file.