### PR TITLE
Eliminate of mgreg_t in favor of target_mgreg_t and host_mgreg_t. And one minor fix.

### DIFF
--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -489,7 +489,7 @@ get_throw_trampoline (MonoTrampInfo **info, gboolean rethrow, gboolean corlib, g
 	arg_offsets [1] = dummy_stack_space + sizeof (target_mgreg_t);
 	arg_offsets [2] = dummy_stack_space + sizeof (target_mgreg_t) * 2;
 	arg_offsets [3] = dummy_stack_space + sizeof (target_mgreg_t) * 3;
-	ctx_offset = dummy_stack_space + sizeof(mgreg_t) * 4;
+	ctx_offset = dummy_stack_space + sizeof (target_mgreg_t) * 4;
 	regs_offset = ctx_offset + MONO_STRUCT_OFFSET (MonoContext, gregs);
 
 	/* Save registers */

--- a/mono/mini/exceptions-riscv.c
+++ b/mono/mini/exceptions-riscv.c
@@ -124,7 +124,7 @@ mono_arch_exceptions_init (void)
 gboolean
 mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls, MonoJitInfo *ji,
                         MonoContext *ctx, MonoContext *new_ctx, MonoLMF **lmf,
-                        mgreg_t **save_locations, StackFrameInfo *frame)
+                        host_mgreg_t **save_locations, StackFrameInfo *frame)
 {
 	NOT_IMPLEMENTED;
 	return FALSE;
@@ -164,7 +164,7 @@ void
 mono_arch_setup_async_callback (MonoContext *ctx, void (*async_cb)(void *fun), gpointer user_data)
 {
 	// Allocate a stack frame and redirect PC.
-	MONO_CONTEXT_SET_SP (ctx, (mgreg_t) MONO_CONTEXT_GET_SP (ctx) - 32);
+	MONO_CONTEXT_SET_SP (ctx, (host_mgreg_t) MONO_CONTEXT_GET_SP (ctx) - 32);
 
 	mono_arch_setup_resume_sighandler_ctx (ctx, async_cb);
 }

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -580,7 +580,7 @@ mono_arch_unwindinfo_get_size (guchar code_count)
 	// of unwind codes. Adding extra bytes to the total size will make sure we can properly align the RUNTIME_FUNCTION
 	// struct. Since our UNWIND_INFO follows RUNTIME_FUNCTION struct in memory, it will automatically be DWORD aligned
 	// as well. Also make sure to allocate room for a padding UNWIND_CODE, if needed.
-	return (sizeof (mgreg_t) + sizeof (UNWIND_INFO)) -
+	return (sizeof (target_mgreg_t) + sizeof (UNWIND_INFO)) -
 		(sizeof (UNWIND_CODE) * ((MONO_MAX_UNWIND_CODES - ((code_count + 1) & ~1))));
 /* FIXME Something simpler should work:
 	return sizeof (UNWIND_INFO) + sizeof (UNWIND_CODE) * (code_count + (code_count & 1));

--- a/mono/mini/mini-arm64.h
+++ b/mono/mini/mini-arm64.h
@@ -89,13 +89,13 @@ struct SeqPointInfo {
 #define FP_PARAM_REGS 8
 
 typedef struct {
-	mgreg_t res, res2;
+	host_mgreg_t res, res2;
 	guint8 *ret;
 	double fpregs [FP_PARAM_REGS];
 	int n_fpargs, n_fpret, n_stackargs;
 	/* This should come last as the structure is dynamically extended */
 	/* The +1 is for r8 */
-	mgreg_t regs [PARAM_REGS + 1];
+	host_mgreg_t regs [PARAM_REGS + 1];
 } DynCallArgs;
 
 typedef struct {

--- a/mono/mini/mini-gc.c
+++ b/mono/mini/mini-gc.c
@@ -146,7 +146,7 @@ typedef struct {
 	MonoThreadUnwindState unwind_state;
 	MonoThreadInfo *info;
 	/* For debugging */
-	mgreg_t tid;
+	host_mgreg_t tid;
 	gpointer ref_to_track;
 	/* Number of frames collected during the !precise pass */
 	int nframes;
@@ -1869,7 +1869,7 @@ process_variables (MonoCompile *cfg)
 			set_slot_everywhere (gcfg, pos, SLOT_NOREF);
 			if (cfg->verbose_level > 1)
 				printf ("\tnoref%s at %s0x%x(fp) (R%d, slot = %d): %s\n", (is_arg ? " arg" : ""), ins->inst_offset < 0 ? "-" : "", (ins->inst_offset < 0) ? -(int)ins->inst_offset : (int)ins->inst_offset, vmv->vreg, pos, mono_type_full_name (ins->inst_vtype));
-			if (!t->byref && sizeof (mgreg_t) == 4 && (t->type == MONO_TYPE_I8 || t->type == MONO_TYPE_U8 || t->type == MONO_TYPE_R8)) {
+			if (!t->byref && sizeof (host_mgreg_t) == 4 && (t->type == MONO_TYPE_I8 || t->type == MONO_TYPE_U8 || t->type == MONO_TYPE_R8)) {
 				set_slot_everywhere (gcfg, pos + 1, SLOT_NOREF);
 				if (cfg->verbose_level > 1)
 					printf ("\tnoref at %s0x%x(fp) (R%d, slot = %d): %s\n", ins->inst_offset < 0 ? "-" : "", (ins->inst_offset < 0) ? -(int)(ins->inst_offset + 4) : (int)ins->inst_offset + 4, vmv->vreg, pos + 1, mono_type_full_name (ins->inst_vtype));
@@ -1971,10 +1971,10 @@ process_param_area_slots (MonoCompile *cfg)
 			if (MONO_TYPE_ISSTRUCT (t)) {
 				size = mini_type_stack_size_full (t, &align, FALSE);
 			} else {
-				size = sizeof (mgreg_t);
+				size = sizeof (target_mgreg_t);
 			}
 
-			for (i = 0; i < size / sizeof (mgreg_t); ++i) {
+			for (i = 0; i < size / sizeof (target_mgreg_t); ++i) {
 				g_assert (slot + i >= 0 && slot + i < gcfg->nslots);
 				is_param [slot + i] = TRUE;
 			}

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -1325,7 +1325,7 @@ sig_to_llvm_sig_full (EmitContext *ctx, MonoMethodSignature *sig, LLVMCallInfo *
 			ret_type = LLVMIntType (size * 8);
 		} else {
 			g_assert (cinfo->ret.nslots == 1 || cinfo->ret.nslots == 2);
-			ret_type = LLVMIntType (cinfo->ret.nslots * sizeof (mgreg_t) * 8);
+			ret_type = LLVMIntType (cinfo->ret.nslots * sizeof (target_mgreg_t) * 8);
 		}
 		break;
 	}
@@ -6175,7 +6175,7 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 				LLVMSetLinkage (info_var, LLVMPrivateLinkage);
 				LLVMSetExternallyInitialized (info_var, TRUE);
 				LLVMSetSection (info_var, "__DATA, __objc_imageinfo,regular,no_dead_strip");
-				LLVMSetAlignment (info_var, sizeof (mgreg_t));
+				LLVMSetAlignment (info_var, sizeof (target_mgreg_t));
 				mark_as_used (ctx->module, info_var);
 			}
 
@@ -6197,7 +6197,7 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 				LLVMSetLinkage (ref_var, LLVMPrivateLinkage);
 				LLVMSetExternallyInitialized (ref_var, TRUE);
 				LLVMSetSection (ref_var, "__DATA, __objc_selrefs, literal_pointers, no_dead_strip");
-				LLVMSetAlignment (ref_var, sizeof (mgreg_t));
+				LLVMSetAlignment (ref_var, sizeof (target_mgreg_t));
 				mark_as_used (ctx->module, ref_var);
 
 				g_hash_table_insert (ctx->module->objc_selector_to_var, g_strdup (name), ref_var);

--- a/mono/mini/mini-mips.c
+++ b/mono/mini/mini-mips.c
@@ -211,9 +211,8 @@ mips_emit_exc_by_name(guint8 *code, const char *name)
 	return code;
 }
 
-
 guint8 *
-mips_emit_load_const(guint8 *code, int dreg, mgreg_t v)
+mips_emit_load_const (guint8 *code, int dreg, target_mgreg_t v)
 {
 	if (mips_is_imm16 (v))
 		mips_addiu (code, dreg, mips_zero, ((guint32)v) & 0xffff);

--- a/mono/mini/mini-mips.h
+++ b/mono/mini/mini-mips.h
@@ -249,7 +249,7 @@ typedef struct MonoCompileArch {
 #define MONO_ARCH_NO_EMULATE_LONG_MUL_OPTS
 #endif
 
-#define MIPS_RET_ADDR_OFFSET	(-sizeof(gpointer))
+#define MIPS_RET_ADDR_OFFSET	(-sizeof (target_mgreg_t))
 #define MIPS_FP_ADDR_OFFSET	(-8)
 #define MIPS_STACK_ALIGNMENT	16
 #define MIPS_STACK_PARAM_OFFSET 16		/* from sp to first parameter */

--- a/mono/mini/mini-mips.h
+++ b/mono/mini/mini-mips.h
@@ -253,7 +253,7 @@ typedef struct MonoCompileArch {
 #define MIPS_FP_ADDR_OFFSET	(-8)
 #define MIPS_STACK_ALIGNMENT	16
 #define MIPS_STACK_PARAM_OFFSET 16		/* from sp to first parameter */
-#define MIPS_MINIMAL_STACK_SIZE (4*sizeof(mgreg_t) + 4*sizeof(mgreg_t))
+#define MIPS_MINIMAL_STACK_SIZE (4 * sizeof (target_mgreg_t) + 4 * sizeof (target_mgreg_t))
 #define MIPS_EXTRA_STACK_SIZE	16		/* from last parameter to top of frame */
 
 #if _MIPS_SIM == _ABIO32
@@ -420,6 +420,6 @@ typedef struct {
 	int offset;
 } MonoMIPSArgInfo;
 
-extern guint8 *mips_emit_load_const(guint8 *code, int dreg, mgreg_t v);
+guint8 *mips_emit_load_const (guint8 *code, int dreg, target_mgreg_t v);
 
 #endif /* __MONO_MINI_MIPS_H__ */  

--- a/mono/mini/mini-ppc.h
+++ b/mono/mini/mini-ppc.h
@@ -68,7 +68,7 @@ typedef struct MonoCompileArch {
  * To support this, code needs to follow the following conventions:
  * - for the size of a pointer use sizeof (gpointer)
  * - for the size of a register/stack slot use SIZEOF_REGISTER.
- * - for variables which contain values of registers, use mgreg_t.
+ * - for variables which contain values of registers, use host_mgreg_t or target_mgreg_t.
  * - for loading/saving pointers/ints, use the normal ppc_load_reg/ppc_save_reg ()
  *   macros.
  * - for loading/saving register sized quantities, use the ppc_ldr/ppc_str 
@@ -287,7 +287,7 @@ typedef struct {
 
 #define MONO_INIT_CONTEXT_FROM_FUNC(ctx,start_func) g_assert_not_reached ()
 
-#elif defined(__APPLE__)
+#elif defined (__APPLE__)
 
 typedef struct {
 	unsigned long sp;
@@ -305,11 +305,11 @@ typedef struct {
 #else
 
 typedef struct {
-	mgreg_t sp;
+	host_mgreg_t sp;
 #ifdef __mono_ppc64__
-	mgreg_t cr;
+	host_mgreg_t cr;
 #endif
-	mgreg_t lr;
+	host_mgreg_t lr;
 } MonoPPCStackFrame;
 
 #ifdef G_COMPILER_CODEWARRIOR
@@ -394,9 +394,6 @@ extern void mono_ppc_emitted (guint8 *code, gint64 length, const char *format, .
 #endif
 
 gboolean mono_ppc_is_direct_call_sequence (guint32 *code);
-
-void mono_ppc_patch_plt_entry (guint8 *code, gpointer *got, mgreg_t *regs, guint8 *addr);
-
 
 // Debugging macros for ELF ABI v2
 #ifdef DEBUG_ELFABIV2

--- a/mono/mini/mini-riscv.c
+++ b/mono/mini/mini-riscv.c
@@ -233,25 +233,25 @@ mono_arch_get_this_arg_from_call (host_mgreg_t *regs, guint8 *code)
 }
 
 MonoMethod *
-mono_arch_find_imt_method (mgreg_t *regs, guint8 *code)
+mono_arch_find_imt_method (host_mgreg_t *regs, guint8 *code)
 {
 	return (MonoMethod *) regs [MONO_ARCH_IMT_REG];
 }
 
 MonoVTable *
-mono_arch_find_static_call_vtable (mgreg_t *regs, guint8 *code)
+mono_arch_find_static_call_vtable (host_mgreg_t *regs, guint8 *code)
 {
 	return (MonoVTable *) regs [MONO_ARCH_VTABLE_REG];
 }
 
-mgreg_t
+host_mgreg_t
 mono_arch_context_get_int_reg (MonoContext *ctx, int reg)
 {
 	return ctx->gregs [reg];
 }
 
 void
-mono_arch_context_set_int_reg (MonoContext *ctx, int reg, mgreg_t val)
+mono_arch_context_set_int_reg (MonoContext *ctx, int reg, host_mgreg_t val)
 {
 	ctx->gregs [reg] = val;
 }

--- a/mono/mini/mini-riscv.h
+++ b/mono/mini/mini-riscv.h
@@ -162,7 +162,7 @@ typedef struct {
 
 #define MONO_CONTEXT_SET_LLVM_EXC_REG(ctx, exc) \
 	do { \
-		(ctx)->gregs [RISCV_A0] = (mgreg_t) exc; \
+		(ctx)->gregs [RISCV_A0] = (host_mgreg_t) exc; \
 	} while (0)
 
 #define MONO_INIT_CONTEXT_FROM_FUNC(ctx, func) \
@@ -176,10 +176,10 @@ struct MonoLMF {
 	// If the second-lowest bit of this field is set, this is a MonoLMFExt.
 	gpointer previous_lmf;
 	gpointer lmf_addr;
-	mgreg_t pc;
-	mgreg_t sp;
-	mgreg_t ra;
-	mgreg_t gregs [RISCV_N_GSREGS]; // s0..s11
+	host_mgreg_t pc;
+	host_mgreg_t sp;
+	host_mgreg_t ra;
+	host_mgreg_t gregs [RISCV_N_GSREGS]; // s0..s11
 	double fregs [RISCV_N_FSREGS]; // fs0..fs11
 };
 

--- a/mono/utils/mono-context.c
+++ b/mono/utils/mono-context.c
@@ -419,7 +419,7 @@ mono_sigctx_to_monoctx (void *sigctx, MonoContext *mctx)
 	mctx->pc = UCONTEXT_REG_PC (my_uc);
 	mctx->regs [ARMREG_SP] = UCONTEXT_REG_SP (my_uc);
 	mctx->cpsr = UCONTEXT_REG_CPSR (my_uc);
-	memcpy (&mctx->regs, &UCONTEXT_REG_R0 (my_uc), sizeof (mgreg_t) * 16);
+	memcpy (&mctx->regs, &UCONTEXT_REG_R0 (my_uc), sizeof (host_mgreg_t) * 16);
 #ifdef UCONTEXT_REG_VFPREGS
 	memcpy (&mctx->fregs, UCONTEXT_REG_VFPREGS (my_uc), sizeof (double) * 16);
 #endif
@@ -447,7 +447,7 @@ mono_monoctx_to_sigctx (MonoContext *mctx, void *ctx)
 	UCONTEXT_REG_SP (my_uc) = mctx->regs [ARMREG_SP];
 	UCONTEXT_REG_CPSR (my_uc) = mctx->cpsr;
 	/* The upper registers are not guaranteed to be valid */
-	memcpy (&UCONTEXT_REG_R0 (my_uc), &mctx->regs, sizeof (mgreg_t) * 12);
+	memcpy (&UCONTEXT_REG_R0 (my_uc), &mctx->regs, sizeof (host_mgreg_t) * 12);
 #ifdef UCONTEXT_REG_VFPREGS
 	memcpy (UCONTEXT_REG_VFPREGS (my_uc), &mctx->fregs, sizeof (double) * 16);
 #endif
@@ -464,7 +464,7 @@ mono_sigctx_to_monoctx (void *sigctx, MonoContext *mctx)
 #ifdef MONO_CROSS_COMPILE
 	g_assert_not_reached ();
 #else
-	memcpy (mctx->regs, UCONTEXT_GREGS (sigctx), sizeof (mgreg_t) * 31);
+	memcpy (mctx->regs, UCONTEXT_GREGS (sigctx), sizeof (host_mgreg_t) * 31);
 	mctx->pc = UCONTEXT_REG_PC (sigctx);
 	mctx->regs [ARMREG_SP] = UCONTEXT_REG_SP (sigctx);
 #ifdef __linux__
@@ -485,7 +485,7 @@ mono_monoctx_to_sigctx (MonoContext *mctx, void *sigctx)
 #ifdef MONO_CROSS_COMPILE
 	g_assert_not_reached ();
 #else
-	memcpy (UCONTEXT_GREGS (sigctx), mctx->regs, sizeof (mgreg_t) * 31);
+	memcpy (UCONTEXT_GREGS (sigctx), mctx->regs, sizeof (host_mgreg_t) * 31);
 	UCONTEXT_REG_PC (sigctx) = mctx->pc;
 	UCONTEXT_REG_SP (sigctx) = mctx->regs [ARMREG_SP];
 #endif
@@ -533,7 +533,7 @@ mono_sigctx_to_monoctx (void *sigctx, MonoContext *mctx)
 	mctx->sc_ir = UCONTEXT_REG_NIP(uc);
 	mctx->sc_sp = UCONTEXT_REG_Rn(uc, 1);
 
-	memcpy (&mctx->regs, &UCONTEXT_REG_Rn(uc, 0), sizeof (mgreg_t) * MONO_MAX_IREGS);
+	memcpy (&mctx->regs, &UCONTEXT_REG_Rn(uc, 0), sizeof (host_mgreg_t) * MONO_MAX_IREGS);
 	memcpy (&mctx->fregs, &UCONTEXT_REG_FPRn(uc, 0), sizeof (double) * MONO_MAX_FREGS);
 }
 
@@ -542,7 +542,7 @@ mono_monoctx_to_sigctx (MonoContext *mctx, void *sigctx)
 {
 	os_ucontext *uc = sigctx;
 
-	memcpy (&UCONTEXT_REG_Rn(uc, 0), &mctx->regs, sizeof (mgreg_t) * MONO_MAX_IREGS);
+	memcpy (&UCONTEXT_REG_Rn(uc, 0), &mctx->regs, sizeof (host_mgreg_t) * MONO_MAX_IREGS);
 	memcpy (&UCONTEXT_REG_FPRn(uc, 0), &mctx->fregs, sizeof (double) * MONO_MAX_FREGS);
 
 	/* The valid values for pc and sp are stored here and not in regs array */
@@ -578,7 +578,7 @@ mono_sigctx_to_monoctx (void *sigctx, MonoContext *mctx)
 #else
 	ucontext_t *uctx = sigctx;
 
-	memcpy (&mctx->gregs, &uctx->uc_mcontext.gregs, sizeof (mgreg_t) * G_N_ELEMENTS (mctx->gregs));
+	memcpy (&mctx->gregs, &uctx->uc_mcontext.gregs, sizeof (host_mgreg_t) * G_N_ELEMENTS (mctx->gregs));
 	memcpy (&mctx->fregs, &uctx->uc_mcontext.fpregs, sizeof (double) * G_N_ELEMENTS (mctx->fregs));
 #endif
 }
@@ -591,7 +591,7 @@ mono_monoctx_to_sigctx (MonoContext *mctx, void *sigctx)
 #else
 	ucontext_t *uctx = sigctx;
 
-	memcpy (&uctx->uc_mcontext.gregs, &mctx->gregs, sizeof (mgreg_t) * G_N_ELEMENTS (mctx->gregs));
+	memcpy (&uctx->uc_mcontext.gregs, &mctx->gregs, sizeof (host_mgreg_t) * G_N_ELEMENTS (mctx->gregs));
 	memcpy (&uctx->uc_mcontext.fpregs, &mctx->fregs, sizeof (double) * G_N_ELEMENTS (mctx->fregs));
 #endif
 }

--- a/mono/utils/mono-machine.h
+++ b/mono/utils/mono-machine.h
@@ -31,18 +31,6 @@ typedef gssize host_mgreg_t;
 typedef gsize host_umgreg_t;
 #endif
 
-// SIZEOF_REGISTER is target. mgreg_t is usually target, sometimes host.
-// There is a mismatch in cross (AOT) compilers, and the
-// never executed JIT and runtime truncate pointers.
-// When casting to/from pointers, use gsize or gssize.
-// When dealing with register context, use host_mgreg_t.
-// Or ifndef MONO_CROSS_COMPILE out runtime code.
-#if SIZEOF_REGISTER == 4
-typedef gint32 mgreg_t;
-#elif SIZEOF_REGISTER == 8
-typedef gint64 mgreg_t;
-#endif
-
 #if TARGET_SIZEOF_VOID_P == 4
 typedef gint32 target_mgreg_t;
 #else


### PR DESCRIPTION
This is mostly cosmetic, but agreed to, since mono cross compilers never carry a runtime.
The most important thing is that x86 and arm backends use mgreg_t instead of gpointer, and MONO_ABI_SIZEOF instead of sizeof (for structs).