### PR TITLE
PPC JIT optimizations (System.Math instruction inlining)

### DIFF
--- a/mono/arch/ppc/ppc-codegen.h
+++ b/mono/arch/ppc/ppc-codegen.h
@@ -754,6 +754,23 @@ my and Ximian's copyright to this code. ;)
 
 /* this marks the end of my work, ct */
 
+/* Introduced in Power ISA 2.02 (P4?) */
+#define ppc_frinx(c,D,B,Rc) ppc_emit32(c, (63 << 26) | (D << 21) | (0 << 16) | (B << 11) | (392 << 1) | Rc)
+#define ppc_frin(c,D,B) ppc_frinx(c,D,B,0)
+#define ppc_frind(c,D,B) ppc_frinx(c,D,B,1)
+
+#define ppc_fripx(c,D,B,Rc) ppc_emit32(c, (63 << 26) | (D << 21) | (0 << 16) | (B << 11) | (456 << 1) | Rc)
+#define ppc_frip(c,D,B) ppc_fripx(c,D,B,0)
+#define ppc_fripd(c,D,B) ppc_fripx(c,D,B,1)
+
+#define ppc_frizx(c,D,B,Rc) ppc_emit32(c, (63 << 26) | (D << 21) | (0 << 16) | (B << 11) | (424 << 1) | Rc)
+#define ppc_friz(c,D,B) ppc_frizx(c,D,B,0)
+#define ppc_frizd(c,D,B) ppc_frizx(c,D,B,1)
+
+#define ppc_frimx(c,D,B,Rc) ppc_emit32(c, (63 << 26) | (D << 21) | (0 << 16) | (B << 11) | (488 << 1) | Rc)
+#define ppc_frim(c,D,B) ppc_frimx(c,D,B,0)
+#define ppc_frimd(c,D,B) ppc_frimx(c,D,B,1)
+
 /*
  * Introduced in Power ISA 2.03 (P5)
  * This is an A-form instruction like many of the FP arith ops,

--- a/mono/arch/ppc/ppc-codegen.h
+++ b/mono/arch/ppc/ppc-codegen.h
@@ -754,6 +754,16 @@ my and Ximian's copyright to this code. ;)
 
 /* this marks the end of my work, ct */
 
+/*
+ * Introduced in Power ISA 2.03 (P5)
+ * This is an A-form instruction like many of the FP arith ops,
+ * but arranged slightly differently (swap record and reserved area)
+ */
+#define ppc_isel(c,D,A,B,C) ppc_emit32(c, (31 << 26) | (D << 21) | (A << 16) | (B << 11) | (C << 6) | (15 << 1) | 0)
+#define ppc_isellt(c,D,A,B) ppc_isel(c,D,A,B,0)
+#define ppc_iselgt(c,D,A,B) ppc_isel(c,D,A,B,1)
+#define ppc_iseleq(c,D,A,B) ppc_isel(c,D,A,B,2)
+
 /* PPC64 */
 
 /* The following FP instructions are not are available to 32-bit

--- a/mono/mini/cpu-ppc.md
+++ b/mono/mini/cpu-ppc.md
@@ -325,10 +325,11 @@ icompare_imm: src1:i len:12
 
 long_conv_to_ovf_i4_2: dest:i src1:i src2:i len:32
 
-long_min: dest:i src1:i src2:i len:8 clob:1
-long_min_un: dest:i src1:i src2:i len:8 clob:1
-long_max: dest:i src1:i src2:i len:8 clob:1
-long_max_un: dest:i src1:i src2:i len:8 clob:1
+# shouldn't use long stuff on ppc32
+#long_min: dest:i src1:i src2:i len:8 clob:1
+#long_min_un: dest:i src1:i src2:i len:8 clob:1
+#long_max: dest:i src1:i src2:i len:8 clob:1
+#long_max_un: dest:i src1:i src2:i len:8 clob:1
 int_min: dest:i src1:i src2:i len:8 clob:1
 int_max: dest:i src1:i src2:i len:8 clob:1
 int_min_un: dest:i src1:i src2:i len:8 clob:1

--- a/mono/mini/cpu-ppc.md
+++ b/mono/mini/cpu-ppc.md
@@ -212,6 +212,10 @@ got_entry: dest:i src1:b len:32
 abs: dest:f src1:f len:4
 sqrt: dest:f src1:f len:4
 sqrtf: dest:f src1:f len:4
+round: dest:f src1:f len:4
+ppc_trunc: dest:f src1:f len:4
+ppc_ceil: dest:f src1:f len:4
+ppc_floor: dest:f src1:f len:4
 adc: dest:i src1:i src2:i len:4
 addcc: dest:i src1:i src2:i len:4
 subcc: dest:i src1:i src2:i len:4

--- a/mono/mini/cpu-ppc.md
+++ b/mono/mini/cpu-ppc.md
@@ -209,7 +209,9 @@ endfilter: src1:i len:32
 aotconst: dest:i len:8
 load_gotaddr: dest:i len:32
 got_entry: dest:i src1:b len:32
+abs: dest:f src1:f len:4
 sqrt: dest:f src1:f len:4
+sqrtf: dest:f src1:f len:4
 adc: dest:i src1:i src2:i len:4
 addcc: dest:i src1:i src2:i len:4
 subcc: dest:i src1:i src2:i len:4

--- a/mono/mini/cpu-ppc.md
+++ b/mono/mini/cpu-ppc.md
@@ -325,6 +325,15 @@ icompare_imm: src1:i len:12
 
 long_conv_to_ovf_i4_2: dest:i src1:i src2:i len:32
 
+long_min: dest:i src1:i src2:i len:8 clob:1
+long_min_un: dest:i src1:i src2:i len:8 clob:1
+long_max: dest:i src1:i src2:i len:8 clob:1
+long_max_un: dest:i src1:i src2:i len:8 clob:1
+int_min: dest:i src1:i src2:i len:8 clob:1
+int_max: dest:i src1:i src2:i len:8 clob:1
+int_min_un: dest:i src1:i src2:i len:8 clob:1
+int_max_un: dest:i src1:i src2:i len:8 clob:1
+
 vcall2: len:20 clob:c
 vcall2_reg: src1:i len:8 clob:c
 vcall2_membase: src1:b len:16 clob:c

--- a/mono/mini/cpu-ppc64.md
+++ b/mono/mini/cpu-ppc64.md
@@ -391,6 +391,15 @@ long_xor_imm: dest:i src1:i clob:1 len:4
 lcompare: src1:i src2:i len:4
 lcompare_imm: src1:i len:12
 
+long_min: dest:i src1:i src2:i len:8 clob:1
+long_min_un: dest:i src1:i src2:i len:8 clob:1
+long_max: dest:i src1:i src2:i len:8 clob:1
+long_max_un: dest:i src1:i src2:i len:8 clob:1
+int_min: dest:i src1:i src2:i len:8 clob:1
+int_max: dest:i src1:i src2:i len:8 clob:1
+int_min_un: dest:i src1:i src2:i len:8 clob:1
+int_max_un: dest:i src1:i src2:i len:8 clob:1
+
 #long_conv_to_ovf_i4_2: dest:i src1:i src2:i len:30
 
 vcall2: len:36 clob:c

--- a/mono/mini/cpu-ppc64.md
+++ b/mono/mini/cpu-ppc64.md
@@ -216,6 +216,10 @@ got_entry: dest:i src1:b len:32
 abs: dest:f src1:f len:4
 sqrt: dest:f src1:f len:4
 sqrtf: dest:f src1:f len:4
+round: dest:f src1:f len:4
+ppc_trunc: dest:f src1:f len:4
+ppc_ceil: dest:f src1:f len:4
+ppc_floor: dest:f src1:f len:4
 adc: dest:i src1:i src2:i len:4
 addcc: dest:i src1:i src2:i len:4
 subcc: dest:i src1:i src2:i len:4

--- a/mono/mini/cpu-ppc64.md
+++ b/mono/mini/cpu-ppc64.md
@@ -213,7 +213,9 @@ endfilter: src1:i len:20
 aotconst: dest:i len:8
 load_gotaddr: dest:i len:32
 got_entry: dest:i src1:b len:32
+abs: dest:f src1:f len:4
 sqrt: dest:f src1:f len:4
+sqrtf: dest:f src1:f len:4
 adc: dest:i src1:i src2:i len:4
 addcc: dest:i src1:i src2:i len:4
 subcc: dest:i src1:i src2:i len:4

--- a/mono/mini/mini-ops.h
+++ b/mono/mini/mini-ops.h
@@ -1193,7 +1193,10 @@ MINI_OP(OP_AMD64_SAVE_SP_TO_LMF,         "amd64_save_sp_to_lmf", NONE, NONE, NON
 #if  defined(TARGET_POWERPC)
 MINI_OP(OP_PPC_SUBFIC,             "ppc_subfic", IREG, IREG, NONE)
 MINI_OP(OP_PPC_SUBFZE,             "ppc_subfze", IREG, IREG, NONE)
-MINI_OP(OP_PPC_CHECK_FINITE,           "ppc_check_finite", NONE, IREG, NONE)
+MINI_OP(OP_PPC_CHECK_FINITE,       "ppc_check_finite", NONE, IREG, NONE)
+MINI_OP(OP_PPC_CEIL,               "ppc_ceil", FREG, FREG, NONE)
+MINI_OP(OP_PPC_FLOOR,              "ppc_floor", FREG, FREG, NONE)
+MINI_OP(OP_PPC_TRUNC,              "ppc_trunc", FREG, FREG, NONE)
 #endif
 
 #if defined(TARGET_ARM) || defined(TARGET_ARM64)

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -65,6 +65,7 @@ enum {
 	PPC_ISA_2X            = 1 << 3,
 	PPC_ISA_64            = 1 << 4,
 	PPC_MOVE_FPR_GPR      = 1 << 5,
+	PPC_ISA_2_03          = 1 << 6,
 	PPC_HW_CAP_END
 };
 
@@ -555,6 +556,9 @@ mono_arch_init (void)
 
 	if (mono_hwcap_ppc_is_isa_2x)
 		cpu_hw_caps |= PPC_ISA_2X;
+
+	if (mono_hwcap_ppc_is_isa_2_03)
+		cpu_hw_caps |= PPC_ISA_2_03;
 
 	if (mono_hwcap_ppc_is_isa_64)
 		cpu_hw_caps |= PPC_ISA_64;
@@ -5672,7 +5676,7 @@ mono_arch_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMetho
 
 		/* Check for Min/Max for (u)int(32|64) */
 		opcode = 0;
-		if (1) { /* XXX: Check for POWER5 and maybe 64-bitness? */
+		if (cpu_hw_caps & PPC_ISA_2X) {
 			if (strcmp (cmethod->name, "Min") == 0) {
 				if (fsig->params [0]->type == MONO_TYPE_I4)
 					opcode = OP_IMIN;

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -5682,19 +5682,23 @@ mono_arch_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMetho
 					opcode = OP_IMIN;
 				if (fsig->params [0]->type == MONO_TYPE_U4)
 					opcode = OP_IMIN_UN;
+#ifdef __mono_ppc64__
 				else if (fsig->params [0]->type == MONO_TYPE_I8)
 					opcode = OP_LMIN;
 				else if (fsig->params [0]->type == MONO_TYPE_U8)
 					opcode = OP_LMIN_UN;
+#endif
 			} else if (strcmp (cmethod->name, "Max") == 0) {
 				if (fsig->params [0]->type == MONO_TYPE_I4)
 					opcode = OP_IMAX;
 				if (fsig->params [0]->type == MONO_TYPE_U4)
 					opcode = OP_IMAX_UN;
+#ifdef __mono_ppc64__
 				else if (fsig->params [0]->type == MONO_TYPE_I8)
 					opcode = OP_LMAX;
 				else if (fsig->params [0]->type == MONO_TYPE_U8)
 					opcode = OP_LMAX_UN;
+#endif
 			}
 			/*
 			 * TODO: Floating point version with fsel, but fsel has

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -4266,19 +4266,19 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			ppc_cmpl (code, 0, 0, ins->sreg1, ins->sreg2);
 			ppc_iselgt (code, ins->dreg, ins->sreg1, ins->sreg2);
 			break;
-		case OP_LMIN:
+		CASE_PPC64 (OP_LMIN)
 			ppc_cmpl (code, 0, 1, ins->sreg1, ins->sreg2);
 			ppc_isellt (code, ins->dreg, ins->sreg1, ins->sreg2);
 			break;
-		case OP_LMIN_UN:
+		CASE_PPC64 (OP_LMIN_UN)
 			ppc_cmpl (code, 0, 1, ins->sreg1, ins->sreg2);
 			ppc_isellt (code, ins->dreg, ins->sreg1, ins->sreg2);
 			break;
-		case OP_LMAX:
+		CASE_PPC64 (OP_LMAX)
 			ppc_cmp (code, 0, 1, ins->sreg1, ins->sreg2);
 			ppc_iselgt (code, ins->dreg, ins->sreg1, ins->sreg2);
 			break;
-		case OP_LMAX_UN:
+		CASE_PPC64 (OP_LMAX_UN)
 			ppc_cmpl (code, 0, 1, ins->sreg1, ins->sreg2);
 			ppc_iselgt (code, ins->dreg, ins->sreg1, ins->sreg2);
 			break;

--- a/mono/utils/mono-hwcap-ppc.c
+++ b/mono/utils/mono-hwcap-ppc.c
@@ -60,6 +60,16 @@ mono_hwcap_arch_init (void)
 		if (hwcap & (0x00080000 | 0x00040000 | 0x00020000 | 0x00010000 | 0x00000800 | 0x00001000))
 			mono_hwcap_ppc_is_isa_2x = TRUE;
 
+		/* PPC_FEATURE_POWER4, PPC_FEATURE_POWER5, PPC_FEATURE_POWER5_PLUS,
+		   PPC_FEATURE_CELL_BE, PPC_FEATURE_PA6T, PPC_FEATURE_ARCH_2_05 */
+		if (hwcap & (0x00080000 | 0x00040000 | 0x00020000 | 0x00010000 | 0x00000800 | 0x00001000))
+			mono_hwcap_ppc_is_isa_2x = TRUE;
+
+		/* PPC_FEATURE_POWER5, PPC_FEATURE_POWER5_PLUS,
+		   PPC_FEATURE_CELL_BE, PPC_FEATURE_PA6T, PPC_FEATURE_ARCH_2_05 */
+		if (hwcap & (0x00040000 | 0x00020000 | 0x00010000 | 0x00000800 | 0x00001000))
+			mono_hwcap_ppc_is_isa_2_03 = TRUE;
+
 		/* PPC_FEATURE_64 */
 		if (hwcap & 0x40000000)
 			mono_hwcap_ppc_is_isa_64 = TRUE;
@@ -76,26 +86,22 @@ mono_hwcap_arch_init (void)
 			mono_hwcap_ppc_has_multiple_ls_units = TRUE;
 	}
 #elif defined(_AIX)
-	if (__cpu64())
-		mono_hwcap_ppc_is_isa_64 = TRUE;
-	if (__power_4_andup())
-		mono_hwcap_ppc_is_isa_2x = TRUE;
-	if (__power_5_andup())
+	/* Compatible platforms for Mono (V7R1, 6.1.9) require at least P4. */
+	mono_hwcap_ppc_is_isa_64 = TRUE;
+	mono_hwcap_ppc_is_isa_2x = TRUE;
+	if (__power_5_andup()) {
+		mono_hwcap_ppc_is_isa_2_03 = TRUE;
 		mono_hwcap_ppc_has_icache_snoop = TRUE;
+	}
 	/* not on POWER8 */
 	if (__power_4() || __power_5() || __power_6() || __power_7())
 		mono_hwcap_ppc_has_multiple_ls_units = TRUE;
 	/*
-	 * I dont see a way to get extended POWER6 and the PV_6_1
-	 * def seems to be trigged on the POWER6 here despite not
-	 * having these extended instructions, so POWER7 it is
+	 * This instruction is only available in POWER6 "raw mode" and unlikely
+	 * to work; I couldn't get it to work on the POWER6s I tried.
 	 */
 	/*
-	 * WARNING: reports that this doesn't actually work, try
-	 * to re-enable after more investigation
-	 */
-	/*
-	if (__power_7_andup())
+	if (__power_6())
 		mono_hwcap_ppc_has_move_fpr_gpr = TRUE;
 	 */
 #endif

--- a/mono/utils/mono-hwcap-vars.h
+++ b/mono/utils/mono-hwcap-vars.h
@@ -27,6 +27,7 @@ MONO_HWCAP_VAR(arm_has_thumb2)
 
 MONO_HWCAP_VAR(ppc_has_icache_snoop)
 MONO_HWCAP_VAR(ppc_is_isa_2x)
+MONO_HWCAP_VAR(ppc_is_isa_2_03)
 MONO_HWCAP_VAR(ppc_is_isa_64)
 MONO_HWCAP_VAR(ppc_has_move_fpr_gpr)
 MONO_HWCAP_VAR(ppc_has_multiple_ls_units)


### PR DESCRIPTION
Optimizes a bunch of functions with expensive function call overhead into neat one or two instructions inlined. Optimizations are based on amd64 mini instruction emitting. Instructions used are still within the POWER5 optimizations applied.

`rcheck` in mini passes, and output seems sane from prodding code. Linux, PASE, and ppc32 are untested. Floating point I know can be.... delicate, but since amd64 tries to take the HW shortcuts, and IEEE floating point should be consistent, try this.

Functions affected:

* `System.Math`

  *  `Min (int32, int32)`

  *  `Min (uint32, uint32)`

  *  `Min (int64, int64)` (don't enable long int arith functions on ppc32 though, based on implications in mini for ppc32)

  *  `Min (uint64, uint64)`

  *  `Sqrt (double)`

  *  `Abs (double)`

  *  `Round (double)`

  *  `Truncate (double)`

  *  `Ceiling (double)`

  *  `Floor (double)`

* `System.MathF`

  *  `Sqrt (float)`

Other easy wins to add later: It'd be nice to add the double/float overloads for Min/Max working, (even if fsel is a bit wonky, compare-and-branch inlining could work?) integer modulo on POWER9, popcount/trailing zeroes on POWER9. (I don't have anything past POWER7 to test with.)
