### PR TITLE
[Mono.Debugger.Soft] Fix reading custom attribute named arguments on old protocol versions

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -1665,7 +1665,15 @@ namespace Mono.Debugger.Soft
 					CattrNamedArgInfo arg = new CattrNamedArgInfo ();
 					int arg_type = r.ReadByte ();
 					arg.is_property = arg_type == 0x54;
-					arg.id = r.ReadId ();
+
+					// 2.12 is the only version we can guarantee the server will send a field id
+					// It was added in https://github.com/mono/mono/commit/db0b932cd6c3c93976479ae3f6b5b2a885f681de
+					// In between 2.11 and 2.12
+					if (arg.is_property)
+						arg.id = r.ReadId ();
+					else if (Version.AtLeast (2, 12))
+						arg.id = r.ReadId ();
+
 					arg.value = r.ReadValue ();
 					info.named_args [j] = arg;
 				}

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/CustomAttributeDataMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/CustomAttributeDataMirror.cs
@@ -111,32 +111,34 @@ namespace Mono.Debugger.Soft {
 				var ctor_args = new object [attr.ctor_args.Length];
 				for (int j = 0; j < ctor_args.Length; ++j)
 					ctor_args [j] = CreateArg (vm, attr.ctor_args [j]);
-				var named_args = new object [attr.named_args.Length];
-				for (int j = 0; j < named_args.Length; ++j) {
+				var named_args = new List<object> (attr.named_args.Length);
+				for (int j = 0; j < attr.named_args.Length; ++j) {
 					CattrNamedArgInfo arg = attr.named_args [j];
 					CustomAttributeTypedArgumentMirror val;
+					CustomAttributeNamedArgumentMirror? named_arg = null;
 
 					val = CreateArg (vm, arg.value);
 
 					TypeMirror t = ctor.DeclaringType;
-					while (named_args [j] == null && t != null) {
+					while (named_arg == null && t != null) {
 						if (arg.is_property) {
 							foreach (var prop in t.GetProperties ()) {
 								if (prop.Id == arg.id)
-									named_args [j] = new CustomAttributeNamedArgumentMirror (prop, null, val);
+									named_arg = new CustomAttributeNamedArgumentMirror (prop, null, val);
 							}
-						} else {
+						} else if (vm.Version.AtLeast (2, 12)) { // we don't have the field ID before 2.12
 							foreach (var field in t.GetFields ()) {
 								if (field.Id == arg.id)
-									named_args [j] = new CustomAttributeNamedArgumentMirror (null, field, val);
+									named_arg = new CustomAttributeNamedArgumentMirror (null, field, val);
 							}
 						}
 						t = t.BaseType;
 					}
-					if (named_args [j] == null)
-						throw new NotImplementedException ();
+
+					if (named_arg.HasValue)
+						named_args.Add (named_arg.Value);
 				}
-				res [i] = new CustomAttributeDataMirror (ctor, ctor_args, named_args);
+				res [i] = new CustomAttributeDataMirror (ctor, ctor_args, named_args.ToArray ());
 			}
 
 			return res;


### PR DESCRIPTION
We were seeing random exceptions debugging an old protocol version, that would all happen after looking at Custom Attributes.

Turns out the client was always expecting the server to send a field id for named arguments in custom attributes. The server was fixed in https://github.com/mono/mono/commit/db0b932cd6c3c93976479ae3f6b5b2a885f681de without bumping the version, in between `2.11` and `2.12`

2.12 is then the only version in which can guarantee we can read named arguments for fields.