### PR TITLE
[2018-10] [crash] Force lldb/gdb traces to appear during hangs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2850,6 +2850,7 @@ if test x$host_win32 = xno; then
 	AC_CHECK_FUNCS(setpgid)
 	AC_CHECK_FUNCS(system)
 	AC_CHECK_FUNCS(fork execv execve)
+	AC_CHECK_FUNCS(waitpid)
 	AC_CHECK_FUNCS(accept4)
 	AC_CHECK_FUNCS(localtime_r)
 	AC_CHECK_FUNCS(mkdtemp)
@@ -4533,6 +4534,7 @@ AC_DEFINE(HAVE_UWP_WINAPI_SUPPORT, 0, [Don't use UWP Windows API support])
 AC_CHECK_FUNCS(strlcpy stpcpy strtok_r rewinddir vasprintf)
 AC_CHECK_FUNCS(getrlimit)
 AC_CHECK_FUNCS(fork execv execve)
+AC_CHECK_FUNCS(waitpid)
 
 AC_ARG_WITH([overridable-allocators], [  --with-overridable-allocators	allow g_*alloc/g_free to call custom allocators set via g_mem_set_vtable])
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -57,6 +57,10 @@
 #include <mono/metadata/exception-internals.h>
 #include <mono/utils/mono-state.h>
 
+#ifdef HAVE_SYS_WAIT_H
+#include <sys/wait.h>
+#endif
+
 #ifdef HAVE_SIGNAL_H
 #include <signal.h>
 #endif
@@ -6105,6 +6109,7 @@ mono_threads_summarize_one (MonoThreadSummary *out, MonoContext *ctx)
 	return success;
 }
 
+#define TIMEOUT_CRASH_REPORTER_FATAL 30
 #define MAX_NUM_THREADS 128
 typedef struct {
 	gint32 has_owner; // state of this memory
@@ -6119,6 +6124,99 @@ typedef struct {
 
 	gboolean silent; // print to stdout
 } SummarizerGlobalState;
+
+#if defined(HAVE_KILL) && !defined(HOST_ANDROID) && defined(HAVE_WAITPID) && ((!defined(HOST_DARWIN) && defined(SYS_fork)) || HAVE_FORK)
+#define HAVE_MONO_SUMMARIZER_SUPERVISOR 1
+#endif
+
+typedef struct {
+	MonoSemType supervisor;
+	pid_t pid;
+	pid_t supervisor_pid;
+} SummarizerSupervisorState;
+
+#ifndef HAVE_MONO_SUMMARIZER_SUPERVISOR
+static void
+summarizer_supervisor_wait (SummarizerSupervisorState *state)
+{
+	return;
+}
+
+static pid_t
+summarizer_supervisor_start (SummarizerSupervisorState *state)
+{
+	// nonzero, so caller doesn't think it's the supervisor
+	return (pid_t) 1;
+}
+
+static void
+summarizer_supervisor_end (SummarizerSupervisorState *state)
+{
+	return;
+}
+
+#else
+static void
+summarizer_supervisor_wait (SummarizerSupervisorState *state)
+{
+	sleep (TIMEOUT_CRASH_REPORTER_FATAL);
+
+	// If we haven't been SIGKILL'ed yet, we signal our parent
+	// and then exit
+#ifdef HAVE_KILL
+	MOSTLY_ASYNC_SAFE_PRINTF("Crash Reporter has timed out, sending SIGSEGV\n");
+	kill (state->pid, SIGSEGV);
+#else
+	g_error ("kill () is not supported by this platform");
+#endif
+
+	exit (1);
+}
+
+static pid_t
+summarizer_supervisor_start (SummarizerSupervisorState *state)
+{
+	memset (state, 0, sizeof (*state));
+	pid_t pid;
+
+	state->pid = getpid();
+
+	/*
+	* glibc fork acquires some locks, so if the crash happened inside malloc/free,
+	* it will deadlock. Call the syscall directly instead.
+	*/
+#if defined(HOST_ANDROID)
+	/* SYS_fork is defined to be __NR_fork which is not defined in some ndk versions */
+	// We disable this when we set HAVE_MONO_SUMMARIZER_SUPERVISOR above
+	g_assert_not_reached ();
+#elif !defined(HOST_DARWIN) && defined(SYS_fork)
+	pid = (pid_t) syscall (SYS_fork);
+#elif HAVE_FORK
+	pid = (pid_t) fork ();
+#else
+	g_assert_not_reached ();
+#endif
+
+	if (pid != 0)
+		state->supervisor_pid = pid;
+
+	return pid;
+}
+
+static void
+summarizer_supervisor_end (SummarizerSupervisorState *state)
+{
+#ifdef HAVE_KILL
+	kill (state->supervisor_pid, SIGKILL);
+#endif
+
+#if defined (HAVE_WAITPID)
+	// Accessed on same thread that sets it.
+	int status;
+	waitpid (state->supervisor_pid, &status, 0);
+#endif
+}
+#endif
 
 static gboolean
 summarizer_state_init (SummarizerGlobalState *state, MonoNativeThreadId current, int *my_index)
@@ -6197,7 +6295,7 @@ summarizer_post_dump (SummarizerGlobalState *state, MonoThreadSummary *this_thre
 static void
 summary_timedwait (SummarizerGlobalState *state, int timeout_seconds)
 {
-	gint64 milliseconds_in_second = 1000;
+	const gint64 milliseconds_in_second = 1000;
 	gint64 timeout_total = milliseconds_in_second * timeout_seconds;
 
 	gint64 end = mono_msec_ticks () + timeout_total;
@@ -6361,7 +6459,13 @@ mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gb
 			if (!already_async)
 				mono_thread_info_set_is_async_context (TRUE);
 
-			success = mono_threads_summarize_execute (ctx, out, hashes, silent, mem, provided_size);
+			SummarizerSupervisorState synch;
+			if (summarizer_supervisor_start (&synch)) {
+				success = mono_threads_summarize_execute (ctx, out, hashes, silent, mem, provided_size);
+				summarizer_supervisor_end (&synch);
+			} else {
+				summarizer_supervisor_wait (&synch);
+			}
 
 			if (!already_async)
 				mono_thread_info_set_is_async_context (FALSE);

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -1014,10 +1014,11 @@ dump_native_stacktrace (const char *signal, void *ctx)
 
 			if (!leave) {
 				mono_sigctx_to_monoctx (ctx, &mctx);
-				// Do before forking
-				if (!mono_threads_summarize (&mctx, &output, &hashes, FALSE, TRUE, NULL, 0))
-					g_assert_not_reached ();
+				// Returns success, so leave if !success
+				leave = !mono_threads_summarize (&mctx, &output, &hashes, FALSE, TRUE, NULL, 0);
+			}
 
+			if (!leave) {
 				// Wait for the other threads to clean up and exit their handlers
 				// We can't lock / wait indefinitely, in case one of these threads got stuck somehow
 				// while dumping. 
@@ -1062,12 +1063,11 @@ dump_native_stacktrace (const char *signal, void *ctx)
 			if (pid == 0) {
 				if (!ctx) {
 					mono_runtime_printf_err ("\nMust always pass non-null context when using merp.\n");
-					exit (1);
+				} else if (output) {
+					mono_merp_invoke (crashed_pid, signal, output, &hashes);
+				} else {
+					mono_runtime_printf_err ("\nMerp dump step not run, no dump created.\n");
 				}
-
-				mono_merp_invoke (crashed_pid, signal, output, &hashes);
-
-				exit (1);
 			}
 		}
 #endif


### PR DESCRIPTION
Going to put this through some tests offline with sleeps introduced to make sure the mechanism works. 

This PR creates a thread that will watch the crash reporter and send a fatal signal if it does not complete within a fixed timeout period. This fatal signal is interpreted as a nested fault by the crash reporter machinery, and it completes the (now non-failing) early exit and continues to dump.

Backport of #11636.

/cc @alexanderkyte 