### PR TITLE
Quash warning icall.c:4408:12: warning: using the result of an assign…

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -4405,7 +4405,7 @@ handle_parent:
 
 		g_hash_table_insert (events, event, event);
 	}
-	if (klass = m_class_get_parent (klass))
+	if ((klass = m_class_get_parent (klass)))
 		goto handle_parent;
 
 	g_hash_table_destroy (events);


### PR DESCRIPTION
…ment as a condition without parentheses [-Wparentheses]

        if (klass = m_class_get_parent (klass))
            ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
icall.c:4408:12: note: place parentheses around the assignment to silence this warning
        if (klass = m_class_get_parent (klass))
                  ^
            (                                 )
icall.c:4408:12: note: use '==' to turn this assignment into an equality comparison
        if (klass = m_class_get_parent (klass))