### PR TITLE
[signcode.exe] Allow use of new hash algorithm

### DIFF
--- a/man/signcode.1
+++ b/man/signcode.1
@@ -27,7 +27,7 @@ The Private Key File (pvk) that contains the private key used to digitally
 sign the PE executable. This private key must match the public key inside the
 publisher X.509 certificate.
 .TP
-.I "-a sha1 | md5"
+.I "-a sha1 | md5 | sha2 | sha256 | sha384 | sha512"
 The hash algorithm used in the digital signature of the PE executable. The 
 default algorithm is SHA1.
 .TP

--- a/mcs/class/Mono.Security/Mono.Security.Authenticode/AuthenticodeFormatter.cs
+++ b/mcs/class/Mono.Security/Mono.Security.Authenticode/AuthenticodeFormatter.cs
@@ -88,7 +88,13 @@ namespace Mono.Security.Authenticode {
 				switch (h) {
 					case "MD5":
 					case "SHA1":
+					case "SHA256":
+					case "SHA384":
+					case "SHA512":
 						hash = h;
+						break;
+					case "SHA2":
+						hash = "SHA256";
 						break;
 					default:
 						throw new ArgumentException ("Invalid Authenticode hash algorithm");

--- a/mcs/tools/security/signcode.cs
+++ b/mcs/tools/security/signcode.cs
@@ -33,12 +33,12 @@ namespace Mono.Tools {
 		static private void Help () 
 		{
 			Console.WriteLine ("Usage: signcode [options] filename{0}", Environment.NewLine);
-			Console.WriteLine ("\t-spc spc\tSoftware Publisher Certificate file");
-			Console.WriteLine ("\t-v pvk\t\tPrivate Key file");
-			Console.WriteLine ("\t-a sha1 | md5\tHash Algorithm (default: SHA1)");
-			Console.WriteLine ("\t-$ indivisual | commercial\tSignature type");
-			Console.WriteLine ("\t-n description\tDescription for the signed file");
-			Console.WriteLine ("\t-i url\tURL for the signed file");
+			Console.WriteLine ("\t-spc spc\t\t\t\t\tSoftware Publisher Certificate file");
+			Console.WriteLine ("\t-v pvk\t\t\t\t\t\tPrivate Key file");
+			Console.WriteLine ("\t-a sha1 | md5 | sha2[56] | sha384 | sha512\tHash Algorithm (default: SHA1)");
+			Console.WriteLine ("\t-$ individual | commercial\t\tSignature type");
+			Console.WriteLine ("\t-n description\t\t\t\t\tDescription for the signed file");
+			Console.WriteLine ("\t-i url\t\t\t\t\t\tURL for the signed file");
 			Console.WriteLine ("Timestamp options");
 			Console.WriteLine ("\t-t url\tTimestamp service http URL");
 			Console.WriteLine ("\t-tr #\tNumber of retries for timestamp");


### PR DESCRIPTION
Enable SHA256, SHA384 and SHA512 hash algorithms to be used for
Authenticode signatures. This enables producing digital signatures that
are trustworthy using the `mono` tooling.

Fixes #7517



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
