### PR TITLE
[Coop] Convert System.Buffer, with handle frames optimized away.

### DIFF
--- a/mono/metadata/icall-decl.h
+++ b/mono/metadata/icall-decl.h
@@ -60,12 +60,14 @@ typedef enum {
 #define HANDLES(id, name, func, ret, nargs, argtypes) \
 	MONO_HANDLE_DECLARE_RAW (id, name, func, ret, nargs, argtypes); \
 	MONO_HANDLE_DECLARE (id, name, func, ret, nargs, argtypes);
+#define NO_FRAME HANDLES
 #include "icall-def.h"
 #undef ICALL_TYPE
 #undef ICALL
 #undef HANDLES
 #undef HANDLES_REUSE_WRAPPER
 #undef NOHANDLES
+#undef NO_FRAME
 
 // This is sorted.
 // grep ICALL_EXPORT | sort | uniq
@@ -74,7 +76,6 @@ ICALL_EXPORT MonoArray* ves_icall_System_Environment_GetLogicalDrives (void);
 ICALL_EXPORT MonoAssemblyName* ves_icall_System_Reflection_AssemblyName_GetNativeName (MonoAssembly*);
 ICALL_EXPORT MonoBoolean ves_icall_RuntimeTypeHandle_is_subclass_of (MonoType*, MonoType*);
 ICALL_EXPORT MonoBoolean ves_icall_System_Array_FastCopy (MonoArray*, int, MonoArray*, int, int);
-ICALL_EXPORT MonoBoolean ves_icall_System_Buffer_BlockCopyInternal (MonoArray*, gint32, MonoArray*, gint32, gint32);
 ICALL_EXPORT MonoBoolean ves_icall_System_Environment_GetIs64BitOperatingSystem (void);
 ICALL_EXPORT MonoBoolean ves_icall_System_Environment_get_HasShutdownStarted (void);
 ICALL_EXPORT MonoBoolean ves_icall_System_GCHandle_CheckCurrentDomain (guint32 gchandle);
@@ -143,7 +144,6 @@ ICALL_EXPORT float ves_icall_System_MathF_Tan (float);
 ICALL_EXPORT float ves_icall_System_MathF_Tanh (float);
 ICALL_EXPORT float ves_icall_System_Math_Abs_single (float);
 ICALL_EXPORT gint ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_GetOffsetToStringData (void);
-ICALL_EXPORT gint32 ves_icall_System_Buffer_ByteLengthInternal (MonoArray*);
 ICALL_EXPORT gint32 ves_icall_System_Environment_get_ProcessorCount (void);
 ICALL_EXPORT gint32 ves_icall_System_Environment_get_TickCount (void);
 ICALL_EXPORT gint32 ves_icall_System_ValueType_InternalGetHashCode (MonoObject*, MonoArray**);
@@ -151,7 +151,6 @@ ICALL_EXPORT gint64 ves_icall_System_DateTime_GetSystemTimeAsFileTime (void);
 ICALL_EXPORT gint64 ves_icall_System_Diagnostics_Stopwatch_GetTimestamp (void);
 ICALL_EXPORT gint64 ves_icall_System_GC_GetTotalMemory (MonoBoolean forceCollection);
 ICALL_EXPORT gint64 ves_icall_System_Threading_Timer_GetTimeMonotonic (void);
-ICALL_EXPORT gint8 ves_icall_System_Buffer_GetByteInternal (MonoArray*, gint32);
 ICALL_EXPORT gpointer ves_icall_System_GCHandle_GetAddrOfPinnedObject (guint32 handle);
 ICALL_EXPORT int ves_icall_Interop_Sys_DoubleToString (double, char*, char*, int);
 ICALL_EXPORT int ves_icall_System_Environment_get_Platform (void);
@@ -164,7 +163,6 @@ ICALL_EXPORT void ves_icall_Mono_Runtime_RegisterReportingForNativeLib (const ch
 ICALL_EXPORT void ves_icall_System_Array_GetGenericValueImpl (MonoArray*, guint32, gpointer);
 ICALL_EXPORT void ves_icall_System_Array_SetGenericValueImpl (MonoArray*, guint32, gpointer);
 ICALL_EXPORT void ves_icall_System_Buffer_MemcpyInternal (gpointer dest, gconstpointer src, gint32 count);
-ICALL_EXPORT void ves_icall_System_Buffer_SetByteInternal (MonoArray*, gint32, gint8);
 ICALL_EXPORT void ves_icall_System_Environment_Exit (int);
 ICALL_EXPORT void ves_icall_System_GCHandle_FreeHandle (guint32 handle);
 ICALL_EXPORT void ves_icall_System_GC_InternalCollect (int generation);

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -78,6 +78,11 @@
  * HANDLES() additional small wrappers are generated statically by icall-table.h, using the signatures here, producing
  * type-safe handles, i.e. MonoString* => MonoRawHandle* => struct { MonoString** raw }.
  *
+ * NO_FRAME() is like HANDLES() in that parameters are wrapped as handles,
+ * and MonoError is provided, but these functions must not create additional handles.
+ * This saves some overhead that some (many?) functions do not need.
+ * If functions usually create no handles but sometimes do, they can
+ * also create their own frames conditionally.
  */
 
 //
@@ -220,11 +225,11 @@ HANDLES(ARRAY_12, "SetValue",         ves_icall_System_Array_SetValue, void, 3, 
 HANDLES(ARRAY_13, "SetValueImpl",  ves_icall_System_Array_SetValueImpl, void, 3, (MonoArray, MonoObject, guint32))
 
 ICALL_TYPE(BUFFER, "System.Buffer", BUFFER_1)
-ICALL(BUFFER_1, "InternalBlockCopy", ves_icall_System_Buffer_BlockCopyInternal)
+NO_FRAME(BUFFER_1, "InternalBlockCopy", ves_icall_System_Buffer_BlockCopyInternal, MonoBoolean, 5, (MonoArray, gint32, MonoArray, gint32, gint32))
 NOHANDLES(ICALL(BUFFER_5, "InternalMemcpy", ves_icall_System_Buffer_MemcpyInternal))
-ICALL(BUFFER_2, "_ByteLength", ves_icall_System_Buffer_ByteLengthInternal)
-ICALL(BUFFER_3, "_GetByte", ves_icall_System_Buffer_GetByteInternal)
-ICALL(BUFFER_4, "_SetByte", ves_icall_System_Buffer_SetByteInternal)
+NO_FRAME(BUFFER_2, "_ByteLength", ves_icall_System_Buffer_ByteLengthInternal, gint32, 1, (MonoArray))
+NO_FRAME(BUFFER_3, "_GetByte", ves_icall_System_Buffer_GetByteInternal, gint8, 2, (MonoArray, gint32))
+NO_FRAME(BUFFER_4, "_SetByte", ves_icall_System_Buffer_SetByteInternal, void, 3, (MonoArray, gint32, gint8))
 
 ICALL_TYPE(CLRCONFIG, "System.CLRConfig", CLRCONFIG_1)
 HANDLES(CLRCONFIG_1, "CheckThrowUnobservedTaskExceptions", ves_icall_System_CLRConfig_CheckThrowUnobservedTaskExceptions, MonoBoolean, 0, ())

--- a/mono/metadata/icall-table.c
+++ b/mono/metadata/icall-table.c
@@ -41,6 +41,7 @@
 // These definitions are used for multiple includes of icall-def.h and eventually undefined.
 #define NOHANDLES(inner) inner
 #define HANDLES(id, name, func, ...)	ICALL (id, name, func ## _raw)
+#define NO_FRAME 			HANDLES
 #define HANDLES_REUSE_WRAPPER		HANDLES
 
 // Generate Icall_ constants
@@ -169,6 +170,7 @@ static const guchar icall_uses_handles [] = {
 #undef HANDLES
 #undef HANDLES_REUSE_WRAPPER
 #undef NOHANDLES
+#undef NO_FRAME
 
 static int
 compare_method_imap (const void *key, const void *elem)


### PR DESCRIPTION
That is, add a mechanism for icalls that usually do not create handles,
only want input handles.
MonoError is still provided, as that overhead is deemed small, but
we could provide an option to remove that also, i.e. for icalls that never fail.