### PR TITLE
no-op change to get install log for #10919 baseline

### DIFF
--- a/packaging/MacSDK/fsharp.py
+++ b/packaging/MacSDK/fsharp.py
@@ -26,3 +26,4 @@ class FsharpPackage(GitHubTarballPackage):
         Package.make(self)
 
 FsharpPackage()
+


### PR DESCRIPTION
To help understand the problems with updating F# in #10919 we need a baseline log of the package build