### PR TITLE
Remove unused ves_icall_System_Globalization_RegionInfo_construct_internal_region_from_lcid.

### DIFF
--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -363,8 +363,7 @@ HANDLES(CULINF_7, "get_current_locale_name", ves_icall_System_Globalization_Cult
 ICALL(CULINF_9, "internal_get_cultures", ves_icall_System_Globalization_CultureInfo_internal_get_cultures)
 //ICALL(CULINF_10, "internal_is_lcid_neutral", ves_icall_System_Globalization_CultureInfo_internal_is_lcid_neutral)
 
-ICALL_TYPE(REGINF, "System.Globalization.RegionInfo", REGINF_1)
-ICALL(REGINF_1, "construct_internal_region_from_lcid", ves_icall_System_Globalization_RegionInfo_construct_internal_region_from_lcid)
+ICALL_TYPE(REGINF, "System.Globalization.RegionInfo", REGINF_2)
 ICALL(REGINF_2, "construct_internal_region_from_name", ves_icall_System_Globalization_RegionInfo_construct_internal_region_from_name)
 
 #if defined(ENABLE_MONODROID) || defined(ENABLE_MONOTOUCH)

--- a/mono/metadata/locales.c
+++ b/mono/metadata/locales.c
@@ -55,8 +55,6 @@ static gint32 string_invariant_indexof_char (MonoString *source, gint32 sindex,
 
 static const CultureInfoEntry* culture_info_entry_from_lcid (int lcid);
 
-static const RegionInfoEntry* region_info_entry_from_lcid (int lcid);
-
 /* Lazy class loading functions */
 static GENERATE_GET_CLASS_WITH_CACHE (culture_info, "System.Globalization", "CultureInfo")
 
@@ -429,22 +427,6 @@ culture_info_entry_from_lcid (int lcid)
 	return ci;
 }
 
-static const RegionInfoEntry*
-region_info_entry_from_lcid (int lcid)
-{
-	const RegionInfoEntry *entry;
-	const CultureInfoEntry *ne;
-
-	ne = (const CultureInfoEntry *)mono_binary_search (&lcid, culture_entries, NUM_CULTURE_ENTRIES, sizeof (CultureInfoEntry), culture_lcid_locator);
-
-	if (ne == NULL)
-		return FALSE;
-
-	entry = &region_entries [ne->region_entry_index];
-
-	return entry;
-}
-
 #if defined (__APPLE__)
 static gchar*
 get_darwin_locale (void)
@@ -663,21 +645,6 @@ ves_icall_System_Globalization_CultureInfo_construct_internal_locale_from_specif
 	return ret;
 }
 */
-MonoBoolean
-ves_icall_System_Globalization_RegionInfo_construct_internal_region_from_lcid (MonoRegionInfo *this_obj,
-		gint lcid)
-{
-	ERROR_DECL (error);
-	const RegionInfoEntry *ri;
-	
-	ri = region_info_entry_from_lcid (lcid);
-	if(ri == NULL)
-		return FALSE;
-
-	MonoBoolean result = construct_region (this_obj, ri, error);
-	mono_error_set_pending_exception (error);
-	return result;
-}
 
 MonoBoolean
 ves_icall_System_Globalization_RegionInfo_construct_internal_region_from_name (MonoRegionInfo *this_obj,

--- a/mono/metadata/locales.h
+++ b/mono/metadata/locales.h
@@ -63,10 +63,6 @@ void ves_icall_System_Globalization_CompareInfo_free_internal_collator (MonoComp
 
 ICALL_EXPORT
 MonoBoolean
-ves_icall_System_Globalization_RegionInfo_construct_internal_region_from_lcid (MonoRegionInfo *this_obj, gint lcid);
-
-ICALL_EXPORT
-MonoBoolean
 ves_icall_System_Globalization_RegionInfo_construct_internal_region_from_name (MonoRegionInfo *this_obj,
  MonoString *name);
 


### PR DESCRIPTION
See 0204abe80374a7f021d91a7c226ef07587195c8a from 2009.
