### PR TITLE
Remove ves_icall_System_Globalization_CompareInfo_internal_index_char.

### DIFF
--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -349,7 +349,6 @@ ICALL(CALDATA_1, "fill_calendar_data", ves_icall_System_Globalization_CalendarDa
 ICALL_TYPE(COMPINF, "System.Globalization.CompareInfo", COMPINF_1)
 ICALL(COMPINF_1, "assign_sortkey(object,string,System.Globalization.CompareOptions)", ves_icall_System_Globalization_CompareInfo_assign_sortkey)
 ICALL(COMPINF_4, "internal_compare(string,int,int,string,int,int,System.Globalization.CompareOptions)", ves_icall_System_Globalization_CompareInfo_internal_compare)
-ICALL(COMPINF_5, "internal_index(string,int,int,char,System.Globalization.CompareOptions,bool)", ves_icall_System_Globalization_CompareInfo_internal_index_char)
 ICALL(COMPINF_6, "internal_index(string,int,int,string,System.Globalization.CompareOptions,bool)", ves_icall_System_Globalization_CompareInfo_internal_index)
 
 ICALL_TYPE(CULDATA, "System.Globalization.CultureData", CULDATA_1)

--- a/mono/metadata/locales.c
+++ b/mono/metadata/locales.c
@@ -49,9 +49,6 @@ static gint32 string_invariant_compare (MonoString *str1, gint32 off1,
 static gint32 string_invariant_indexof (MonoString *source, gint32 sindex,
 					gint32 count, MonoString *value,
 					MonoBoolean first);
-static gint32 string_invariant_indexof_char (MonoString *source, gint32 sindex,
-					     gint32 count, gunichar2 value,
-					     MonoBoolean first);
 
 static const CultureInfoEntry* culture_info_entry_from_lcid (int lcid);
 
@@ -801,12 +798,6 @@ int ves_icall_System_Globalization_CompareInfo_internal_index (MonoCompareInfo *
 	return(string_invariant_indexof (source, sindex, count, value, first));
 }
 
-int ves_icall_System_Globalization_CompareInfo_internal_index_char (MonoCompareInfo *this_obj, MonoString *source, gint32 sindex, gint32 count, gunichar2 value, gint32 options, MonoBoolean first)
-{
-	return(string_invariant_indexof_char (source, sindex, count, value,
-					      first));
-}
-
 int
 ves_icall_System_Threading_Thread_current_lcid (void)
 {
@@ -939,32 +930,6 @@ static gint32 string_invariant_indexof (MonoString *source, gint32 sindex,
 			}
 		}
 		
-		return(-1);
-	}
-}
-
-static gint32 string_invariant_indexof_char (MonoString *source, gint32 sindex,
-					     gint32 count, gunichar2 value,
-					     MonoBoolean first)
-{
-	gint32 pos;
-	gunichar2 *src;
-
-	src = mono_string_chars_internal (source);
-	if(first) {
-		for (pos = sindex; pos != count + sindex; pos++) {
-			if (src [pos] == value) {
-				return(pos);
-			}
-		}
-
-		return(-1);
-	} else {
-		for (pos = sindex; pos > sindex - count; pos--) {
-			if (src [pos] == value)
-				return(pos);
-		}
-
 		return(-1);
 	}
 }

--- a/mono/metadata/locales.h
+++ b/mono/metadata/locales.h
@@ -77,9 +77,6 @@ ICALL_EXPORT
 int ves_icall_System_Globalization_CompareInfo_internal_index (MonoCompareInfo *this_obj, MonoString *source, gint32 sindex, gint32 count, MonoString *value, gint32 options, MonoBoolean first);
 
 ICALL_EXPORT
-int ves_icall_System_Globalization_CompareInfo_internal_index_char (MonoCompareInfo *this_obj, MonoString *source, gint32 sindex, gint32 count, gunichar2 value, gint32 options, MonoBoolean first);
-
-ICALL_EXPORT
 int
 ves_icall_System_Threading_Thread_current_lcid (void);
 


### PR DESCRIPTION
Unused since Feb 2018 d63e8b6f5ae04bdbf7b68f6f884d797df0d220ec.