### PR TITLE
[debugger] Fix test StepOutAsync

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -239,7 +239,7 @@ public sealed class DebuggerTaskScheduler : TaskScheduler, IDisposable
 				}
 			});
 			//the new task will be executed by a foreground thread ensuring that it will be executed ultil the end.
-			t.IsBackground = true;
+			t.IsBackground = false;
 			t.Start();
 			return t;
 

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -404,11 +404,7 @@ public class Tests : TestsBase, ITest2
 			return 0;
 		}
 		if (args.Length > 0 && args [0] == "step-out-void-async") {
-			DebuggerTaskScheduler dts = new DebuggerTaskScheduler(2);
-			var wait =  new ManualResetEvent (false);
-			step_out_void_async (wait);
-			wait.WaitOne ();//Don't exist until step_out_void_async is executed...
-			dts.Dispose();
+			run_step_out_void_async();
 			return 0;
 		}
 		assembly_load ();
@@ -1843,6 +1839,15 @@ public class Tests : TestsBase, ITest2
 	public static void Bug59649 ()
 	{
 		UninitializedClass.Call();//Breakpoint here and step in
+	}
+	
+	public static void run_step_out_void_async()
+	{
+		DebuggerTaskScheduler dts = new DebuggerTaskScheduler(2);
+		var wait =  new ManualResetEvent (false);
+		step_out_void_async (wait);
+		wait.WaitOne ();//Don't exist until step_out_void_async is executed...
+		dts.Dispose();
 	}
 
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Sockets;
+using System.Collections.Concurrent;
 #if !MOBILE
 using MonoTests.Helpers;
 #endif
@@ -221,6 +222,65 @@ class TestIfaces : ITest
 	}
 }
 
+public sealed class DebuggerTaskScheduler : TaskScheduler, IDisposable
+{
+	private readonly BlockingCollection<Task> _tasks = new BlockingCollection<Task>();
+	private readonly List<Thread> _threads;
+	private readonly Thread mainThread = null;
+	public DebuggerTaskScheduler(int countThreads)
+	{
+		_threads = Enumerable.Range(0, countThreads).Select(i =>
+		{
+			Thread t = new Thread(() =>
+			{
+				foreach (var task in _tasks.GetConsumingEnumerable())
+				{
+					TryExecuteTask(task);
+				}
+			});
+			//the new task will be executed by a foreground thread ensuring that it will be executed ultil the end.
+			t.IsBackground = true;
+			t.Start();
+			return t;
+
+		}).ToList();
+	}
+
+	/// <inheritdoc />
+	protected override void QueueTask(Task task)
+	{
+		_tasks.Add(task);
+	}
+
+	/// <inheritdoc />
+	public override int MaximumConcurrencyLevel
+	{
+		get
+		{
+			return _threads.Count;
+		}
+	}
+
+	/// <inheritdoc />
+	public void Dispose()
+	{	
+		// Indicate that no new tasks will be coming in
+		_tasks.CompleteAdding();
+	}
+
+	/// <inheritdoc />
+	protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
+	{
+		return false;
+	}
+
+	/// <inheritdoc />
+	protected override IEnumerable<Task> GetScheduledTasks()
+	{
+		return _tasks;
+	}
+}
+
 class TestIfaces<T> : ITest<T>
 {
 	void ITest<T>.Foo () {
@@ -344,9 +404,11 @@ public class Tests : TestsBase, ITest2
 			return 0;
 		}
 		if (args.Length > 0 && args [0] == "step-out-void-async") {
-			var wait = new ManualResetEvent (false);
+			DebuggerTaskScheduler dts = new DebuggerTaskScheduler(2);
+			var wait =  new ManualResetEvent (false);
 			step_out_void_async (wait);
 			wait.WaitOne ();//Don't exist until step_out_void_async is executed...
+			dts.Dispose();
 			return 0;
 		}
 		assembly_load ();

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -4457,11 +4457,11 @@ public class DebuggerTests
 		e = run_until ("threadpool_bp");
 		var req = create_step (e);
 		e = step_out (); // leave threadpool_bp
+		
 		e = step_out (); // leave threadpool_io
 	}
 
 	[Test]
-	[Category("NotWorking")] // flaky, see https://github.com/mono/mono/issues/6997
 	public void StepOutAsync () {
 		vm.Detach ();
 		Start (new string [] { dtest_app_path, "step-out-void-async" });
@@ -4475,8 +4475,8 @@ public class DebuggerTests
 		vm.Resume ();
 		var e3 = GetNextEvent ();
 		//after step-out from async void, execution should continue
-		//and runtime should exit
-		Assert.IsTrue (e3 is VMDeathEvent, e3.GetType().FullName);
+		//and runtime should Step
+		Assert.IsTrue (e3 is StepEvent, e3.GetType().FullName);
 		vm = null;
 	}
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -1278,6 +1278,7 @@ create_thread (MonoThread *thread, MonoInternalThread *internal, MonoObject *sta
 	mono_threads_lock ();
 	if (shutting_down && !(flags & MONO_THREAD_CREATE_FLAGS_FORCE_CREATE)) {
 		mono_threads_unlock ();
+		mono_error_set_execution_engine (error, "Couldn't create thread. Runtime is shutting down.");
 		return FALSE;
 	}
 	if (threads_starting_up == NULL) {

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -684,7 +684,7 @@ static void ids_cleanup (void);
 
 static void suspend_init (void);
 
-static void start_debugger_thread (void);
+static void start_debugger_thread (MonoError *error);
 static void stop_debugger_thread (void);
 
 static void finish_agent_init (gboolean on_startup);
@@ -1064,7 +1064,9 @@ finish_agent_init (gboolean on_startup)
 	if (!on_startup) {
 		/* Do some which is usually done after sending the VMStart () event */
 		vm_start_event_sent = TRUE;
-		start_debugger_thread ();
+		ERROR_DECL (error);
+		start_debugger_thread (error);
+		mono_error_assert_ok (error);
 	}
 }
 
@@ -1613,15 +1615,14 @@ stop_debugger_thread (void)
 }
 
 static void
-start_debugger_thread (void)
+start_debugger_thread (MonoError *error)
 {
-	ERROR_DECL (error);
 	MonoInternalThread *thread;
 
 	thread = mono_thread_create_internal (mono_get_root_domain (), (gpointer)debugger_thread, NULL, MONO_THREAD_CREATE_FLAGS_DEBUGGER, error);
-	mono_error_assert_ok (error);
-	if (!mono_runtime_is_shutting_down () )
-		debugger_thread_handle = mono_threads_open_thread_handle (thread->handle);
+	return_if_nok (error);
+	
+	debugger_thread_handle = mono_threads_open_thread_handle (thread->handle);
 	g_assert (debugger_thread_handle);
 	
 }
@@ -3804,8 +3805,11 @@ process_event (EventKind event, gpointer arg, gint32 il_offset, MonoContext *ctx
 
 	if (event == EVENT_KIND_VM_START) {
 		suspend_policy = agent_config.suspend ? SUSPEND_POLICY_ALL : SUSPEND_POLICY_NONE;
-		if (!agent_config.defer)
-			start_debugger_thread ();
+		if (!agent_config.defer) {
+			ERROR_DECL (error);
+			start_debugger_thread (error);
+			mono_error_assert_ok (error);
+		}
 	}
    
 	if (event == EVENT_KIND_VM_DEATH) {
@@ -3890,8 +3894,11 @@ static void
 runtime_initialized (MonoProfiler *prof)
 {
 	process_profiler_event (EVENT_KIND_VM_START, mono_thread_current ());
-	if (agent_config.defer)
-		start_debugger_thread ();
+	if (agent_config.defer) {
+		ERROR_DECL (error);
+		start_debugger_thread (error);
+		mono_error_assert_ok (error);
+	}
 }
 
 static void
@@ -9721,7 +9728,9 @@ debugger_thread (void *arg)
 	
 	if (!attach_failed && command_set == CMD_SET_VM && command == CMD_VM_DISPOSE && !(vm_death_event_sent || mono_runtime_is_shutting_down ())) {
 		DEBUG_PRINTF (2, "[dbg] Detached - restarting clean debugger thread.\n");
-		start_debugger_thread ();
+		ERROR_DECL (error);
+		start_debugger_thread (error);
+		mono_error_cleanup (error);
 	}
 
 	return 0;

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -1620,9 +1620,10 @@ start_debugger_thread (void)
 
 	thread = mono_thread_create_internal (mono_get_root_domain (), (gpointer)debugger_thread, NULL, MONO_THREAD_CREATE_FLAGS_DEBUGGER, error);
 	mono_error_assert_ok (error);
-
-	debugger_thread_handle = mono_threads_open_thread_handle (thread->handle);
+	if (!mono_runtime_is_shutting_down () )
+		debugger_thread_handle = mono_threads_open_thread_handle (thread->handle);
 	g_assert (debugger_thread_handle);
+	
 }
 
 /*


### PR DESCRIPTION
The problem with this flaky issue was the timing of processing of the async tasks, as it was executed in background threads it was not possible to reach the end of execution because all the foreground threads exit earlier.

The solution creates a TaskScheduler that ensure that the thread that will execute the task will be a foreground thread and then the test always works.

Fixes https://github.com/mono/mono/issues/6997
