### PR TITLE
[runtime] Remove duplicate merp invoke line

### DIFF
--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -1031,7 +1031,6 @@ dump_native_stacktrace (const char *signal, void *ctx)
 				if (!ctx) {
 					mono_runtime_printf_err ("\nMust always pass non-null context when using merp.\n");
 				} else if (output) {
-					mono_merp_invoke (crashed_pid, signal, output, &hashes);
 					gboolean merp_upload_success = mono_merp_invoke (crashed_pid, signal, output, &hashes);
 
 					g_assert (merp_upload_success);


### PR DESCRIPTION
Looks like this broke when it got squashed down, or we overlooked it. We've got two calls where we expected one.