### PR TITLE
Fix two leaks in error paths.

### DIFF
--- a/mono/metadata/mono-perfcounters.c
+++ b/mono/metadata/mono-perfcounters.c
@@ -1602,9 +1602,9 @@ mono_perfcounter_category_names (void)
 	perfctr_lock ();
 	custom_categories = get_custom_categories ();
 	res = mono_array_new_checked (domain, mono_get_string_class (), NUM_CATEGORIES + g_slist_length (custom_categories), error);
-	if (mono_error_set_pending_exception (error)) {
-		perfctr_unlock ();
-		return NULL;
+	if (!is_ok (error)) {
+		res = NULL;
+		goto leave;
 	}
 
 	for (i = 0; i < NUM_CATEGORIES; ++i) {

--- a/mono/metadata/w32process.c
+++ b/mono/metadata/w32process.c
@@ -523,7 +523,7 @@ process_get_module (MonoAssembly *assembly, MonoClass *proc_class, MonoError *er
 {
 	MonoObject *item, *filever;
 	MonoDomain *domain;
-	gchar *filename;
+	char *filename = NULL;
 	const gchar *modulename;
 
 	error_init (error);
@@ -534,27 +534,30 @@ process_get_module (MonoAssembly *assembly, MonoClass *proc_class, MonoError *er
 
 	/* Build a System.Diagnostics.ProcessModule with the data. */
 	item = mono_object_new_checked (domain, proc_class, error);
-	return_val_if_nok (error, NULL);
+	goto_if_nok (error, return_null);
 
 	filever = mono_object_new_checked (domain, get_file_version_info_class (), error);
-	return_val_if_nok (error, NULL);
+	goto_if_nok (error, return_null);
 
 	filename = g_strdup_printf ("[In Memory] %s", modulename);
 
 	process_get_assembly_fileversion (filever, assembly);
 	process_set_field_string_char (filever, "filename", filename, error);
-	return_val_if_nok (error, NULL);
+	goto_if_nok (error, return_null);
 	process_set_field_object (item, "version_info", filever);
 
 	process_set_field_intptr (item, "baseaddr", assembly->image->raw_data);
 	process_set_field_int (item, "memory_size", assembly->image->raw_data_len);
 	process_set_field_string_char (item, "filename", filename, error);
-	return_val_if_nok (error, NULL);
+	goto_if_nok (error, return_null);
 	process_set_field_string_char (item, "modulename", modulename, error);
-	return_val_if_nok (error, NULL);
+	goto_if_nok (error, return_null);
 
+	goto exit;
+return_null:
+	item = NULL;
+exit:
 	g_free (filename);
-
 	return item;
 }
 


### PR DESCRIPTION
These are the kinds of things a bare minimum of C++ -- destructors -- will make trivial to get correct with smaller/cleaner code.

A strict C convention would help too -- only ever a single point of function exit, at least for functions that "allocate any resources" (or more generally have "invariants to restore" -- like a function that increments some counter upon entry and decrements upon exit).

"Things you find if you read the code while converting to Coop."