### PR TITLE
Fix MonoSortKey native/managed layout mismatch.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # There is no ordering of corlib versions, no old or new,
 # the runtime expects an exact match.
 #
-MONO_CORLIB_VERSION=0C41185A-B349-47B0-B592-2409FE8B0134
+MONO_CORLIB_VERSION=296F7A7D-5541-4D55-878B-3C273B46D3E6
 
 #
 # Put a quoted #define in config.h.

--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # There is no ordering of corlib versions, no old or new,
 # the runtime expects an exact match.
 #
-MONO_CORLIB_VERSION=10A00432-75BD-4DC1-9CE7-5DB228795B29
+MONO_CORLIB_VERSION=01E717C3-C157-44C0-89D9-32818E9C551B
 
 #
 # Put a quoted #define in config.h.

--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # There is no ordering of corlib versions, no old or new,
 # the runtime expects an exact match.
 #
-MONO_CORLIB_VERSION=296F7A7D-5541-4D55-878B-3C273B46D3E6
+MONO_CORLIB_VERSION=10A00432-75BD-4DC1-9CE7-5DB228795B29
 
 #
 # Put a quoted #define in config.h.

--- a/mcs/class/corlib/Mono.Globalization.Unicode/SortKey.cs
+++ b/mcs/class/corlib/Mono.Globalization.Unicode/SortKey.cs
@@ -77,6 +77,11 @@ namespace System.Globalization
 			this.lcid = lcid;
 			this.source = source;
 			this.options = opt;
+			var source_length = source.Length;
+			var k = new byte [source_length];
+			for (int i = 0; i < source_length; ++i)
+				k [i] = (byte)source [i];
+			this.key = k;
 		}
 
 		internal SortKey (int lcid, string source, byte [] buffer, CompareOptions opt,

--- a/mcs/class/corlib/ReferenceSources/CompareInfo.cs
+++ b/mcs/class/corlib/ReferenceSources/CompareInfo.cs
@@ -83,7 +83,7 @@ namespace System.Globalization
 			 * SortKey constructor, as we need access to
 			 * this instance's collator.
 			 */
-			assign_sortkey (key, source, options);
+			key.key = assign_sortkey (source);
 			
 			return(key);        	
 		}
@@ -129,8 +129,7 @@ namespace System.Globalization
 		}
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
-		private extern void assign_sortkey (object key, string source,
-							CompareOptions options);		
+		private static extern byte[] assign_sortkey (string source);
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		private extern int internal_compare (string str1, int offset1,

--- a/mcs/class/corlib/ReferenceSources/CompareInfo.cs
+++ b/mcs/class/corlib/ReferenceSources/CompareInfo.cs
@@ -77,15 +77,7 @@ namespace System.Globalization
 		{
 			if (UseManagedCollation)
 				return GetCollator ().GetSortKey (source, options);
-			SortKey key=new SortKey (culture, source, options);
-
-			/* Need to do the icall here instead of in the
-			 * SortKey constructor, as we need access to
-			 * this instance's collator.
-			 */
-			key.key = assign_sortkey (source);
-			
-			return(key);        	
+			return new SortKey (culture, source, options);
 		}
 
 		int internal_index_switch (string s1, int sindex, int count, string s2, CompareOptions opt, bool first)
@@ -127,9 +119,6 @@ namespace System.Globalization
 				GetCollator ().IndexOf (s1, s2, sindex, count, opt) :
 				GetCollator ().LastIndexOf (s1, s2, sindex, count, opt);
 		}
-
-		[MethodImplAttribute (MethodImplOptions.InternalCall)]
-		private static extern byte[] assign_sortkey (string source);
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		private extern int internal_compare (string str1, int offset1,

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -346,8 +346,7 @@ HANDLES(GC_8, "register_ephemeron_array", ves_icall_System_GC_register_ephemeron
 ICALL_TYPE(CALDATA, "System.Globalization.CalendarData", CALDATA_1)
 ICALL(CALDATA_1, "fill_calendar_data", ves_icall_System_Globalization_CalendarData_fill_calendar_data)
 
-ICALL_TYPE(COMPINF, "System.Globalization.CompareInfo", COMPINF_1)
-ICALL(COMPINF_1, "assign_sortkey(object,string,System.Globalization.CompareOptions)", ves_icall_System_Globalization_CompareInfo_assign_sortkey)
+ICALL_TYPE(COMPINF, "System.Globalization.CompareInfo", COMPINF_4)
 ICALL(COMPINF_4, "internal_compare(string,int,int,string,int,int,System.Globalization.CompareOptions)", ves_icall_System_Globalization_CompareInfo_internal_compare)
 ICALL(COMPINF_6, "internal_index(string,int,int,string,System.Globalization.CompareOptions,bool)", ves_icall_System_Globalization_CompareInfo_internal_index)
 

--- a/mono/metadata/locales.c
+++ b/mono/metadata/locales.c
@@ -740,7 +740,8 @@ int ves_icall_System_Globalization_CompareInfo_internal_compare (MonoCompareInfo
 					 options));
 }
 
-void ves_icall_System_Globalization_CompareInfo_assign_sortkey (MonoCompareInfo *this_obj, MonoSortKey *key, MonoString *source, gint32 options)
+MonoArray*
+ves_icall_System_Globalization_CompareInfo_assign_sortkey (MonoString *source)
 {
 	ERROR_DECL (error);
 	MonoArray *arr;
@@ -751,13 +752,13 @@ void ves_icall_System_Globalization_CompareInfo_assign_sortkey (MonoCompareInfo 
 	arr=mono_array_new_checked (mono_domain_get (), mono_get_byte_class (),
 				    keylen, error);
 	if (mono_error_set_pending_exception (error))
-		return;
+		return NULL;
 
 	for(i=0; i<keylen; i++) {
 		mono_array_set_internal (arr, guint8, i, mono_string_chars_internal (source)[i]);
 	}
-	
-	MONO_OBJECT_SETREF_INTERNAL (key, key, arr);
+
+	return arr;
 }
 
 int ves_icall_System_Globalization_CompareInfo_internal_index (MonoCompareInfo *this_obj, MonoString *source, gint32 sindex, gint32 count, MonoString *value, gint32 options, MonoBoolean first)

--- a/mono/metadata/locales.c
+++ b/mono/metadata/locales.c
@@ -740,27 +740,6 @@ int ves_icall_System_Globalization_CompareInfo_internal_compare (MonoCompareInfo
 					 options));
 }
 
-MonoArray*
-ves_icall_System_Globalization_CompareInfo_assign_sortkey (MonoString *source)
-{
-	ERROR_DECL (error);
-	MonoArray *arr;
-	gint32 keylen, i;
-
-	keylen=mono_string_length_internal (source);
-	
-	arr=mono_array_new_checked (mono_domain_get (), mono_get_byte_class (),
-				    keylen, error);
-	if (mono_error_set_pending_exception (error))
-		return NULL;
-
-	for(i=0; i<keylen; i++) {
-		mono_array_set_internal (arr, guint8, i, mono_string_chars_internal (source)[i]);
-	}
-
-	return arr;
-}
-
 int ves_icall_System_Globalization_CompareInfo_internal_index (MonoCompareInfo *this_obj, MonoString *source, gint32 sindex, gint32 count, MonoString *value, gint32 options, MonoBoolean first)
 {
 	return(string_invariant_indexof (source, sindex, count, value, first));

--- a/mono/metadata/locales.h
+++ b/mono/metadata/locales.h
@@ -67,7 +67,8 @@ ves_icall_System_Globalization_RegionInfo_construct_internal_region_from_name (M
  MonoString *name);
 
 ICALL_EXPORT
-void ves_icall_System_Globalization_CompareInfo_assign_sortkey (MonoCompareInfo *this_obj, MonoSortKey *key, MonoString *source, gint32 options);
+MonoArray*
+ves_icall_System_Globalization_CompareInfo_assign_sortkey (MonoString *source);
 
 ICALL_EXPORT
 int ves_icall_System_Globalization_CompareInfo_internal_index (MonoCompareInfo *this_obj, MonoString *source, gint32 sindex, gint32 count, MonoString *value, gint32 options, MonoBoolean first);

--- a/mono/metadata/locales.h
+++ b/mono/metadata/locales.h
@@ -67,10 +67,6 @@ ves_icall_System_Globalization_RegionInfo_construct_internal_region_from_name (M
  MonoString *name);
 
 ICALL_EXPORT
-MonoArray*
-ves_icall_System_Globalization_CompareInfo_assign_sortkey (MonoString *source);
-
-ICALL_EXPORT
 int ves_icall_System_Globalization_CompareInfo_internal_index (MonoCompareInfo *this_obj, MonoString *source, gint32 sindex, gint32 count, MonoString *value, gint32 options, MonoBoolean first);
 
 ICALL_EXPORT

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -698,14 +698,6 @@ typedef struct {
 } MonoRegionInfo;
 
 typedef struct {
-	MonoObject obj;
-	MonoString *str;
-	MonoArray *key;
-	gint32 options;
-	gint32 lcid;
-} MonoSortKey;
-
-typedef struct {
 	MonoObject object;
 	guint32 intType;
 } MonoInterfaceTypeAttribute;

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -700,8 +700,8 @@ typedef struct {
 typedef struct {
 	MonoObject obj;
 	MonoString *str;
-	gint32 options;
 	MonoArray *key;
+	gint32 options;
 	gint32 lcid;
 } MonoSortKey;
 


### PR DESCRIPTION
MonoSortKey native:
https://github.com/mono/mono/blob/f019810b12ba130b7fed1cd41bb2eaed04ececef/mono/metadata/object-internals.h#L700

SortKey managed:
https://github.com/mono/mono/blob/f019810b12ba130b7fed1cd41bb2eaed04ececef/mcs/class/corlib/Mono.Globalization.Unicode/SortKey.cs#L69

do not agree.

Memory is corrupted and crash if you set $MONO_DISABLE_MANAGED_COLLATION=yes documented here:
https://github.com/mono/mono/blob/f019810b12ba130b7fed1cd41bb2eaed04ececef/man/mono.1#L1161

Fix is to remove the native code and replace by trivial managed.

Found testing coop-conversion of System.Globalization. https://github.com/mono/mono/pull/12023