### PR TITLE
[runtime] Don't define build config dir on android

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5672,6 +5672,11 @@ if test x$host_win32 = xyes; then
 else
   mono_cfg_dir=$mono_cfg_root/etc
 fi
+
+if test "x$platform_android" = "xyes"; then
+  mono_cfg_dir=
+fi
+
 AC_SUBST(mono_cfg_dir)
 
 AC_SUBST(CSC)

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7424,7 +7424,11 @@ ves_icall_System_Configuration_DefaultConfig_get_machine_config_path (MonoError 
 {
 	gchar *path;
 
-	path = g_build_path (G_DIR_SEPARATOR_S, mono_get_config_dir (), "mono", mono_get_runtime_info ()->framework_version, "machine.config", NULL);
+	const char *mono_cfg_dir = mono_get_config_dir ();
+	if (!mono_cfg_dir)
+		return mono_string_new_handle (mono_domain_get (), "", error);
+
+	path = g_build_path (G_DIR_SEPARATOR_S, mono_cfg_dir, "mono", mono_get_runtime_info ()->framework_version, "machine.config", NULL);
 
 	mono_icall_make_platform_path (path);
 
@@ -7519,7 +7523,11 @@ ves_icall_System_Configuration_InternalConfigurationHost_get_bundled_machine_con
 MonoStringHandle
 ves_icall_System_Web_Util_ICalls_get_machine_install_dir (MonoError *error)
 {
-	char *path = g_path_get_dirname (mono_get_config_dir ());
+	const char *mono_cfg_dir = mono_get_config_dir ();
+	if (!mono_cfg_dir)
+		return mono_string_new_handle (mono_domain_get (), "", error);
+
+	char *path = g_path_get_dirname (mono_cfg_dir);
 
 	mono_icall_make_platform_path (path);
 

--- a/mono/metadata/mono-config.c
+++ b/mono/metadata/mono-config.c
@@ -642,9 +642,14 @@ mono_config_for_assembly_internal (MonoImage *assembly)
 	g_free (cfg_name);
 
 	cfg_name = g_strdup_printf ("%s.config", mono_image_get_name (assembly));
+	const char *mono_cfg_dir = mono_get_config_dir ();
+	if (!mono_cfg_dir) {
+		g_free (cfg_name);
+		return;
+	}
 
 	for (i = 0; (aname = get_assembly_filename (assembly, i)) != NULL; ++i) {
-		cfg = g_build_filename (mono_get_config_dir (), "mono", "assemblies", aname, cfg_name, NULL);
+		cfg = g_build_filename (mono_cfg_dir, "mono", "assemblies", aname, cfg_name, NULL);
 		got_it += mono_config_parse_file_with_context (&state, cfg);
 		g_free (cfg);
 
@@ -687,9 +692,12 @@ mono_config_parse (const char *filename) {
 		return;
 	}
 
-	mono_cfg = g_build_filename (mono_get_config_dir (), "mono", "config", NULL);
-	mono_config_parse_file (mono_cfg);
-	g_free (mono_cfg);
+	const char *mono_cfg_dir = mono_get_config_dir ();
+	if (mono_cfg_dir) {
+		mono_cfg = g_build_filename (mono_cfg_dir, "mono", "config", NULL);
+		mono_config_parse_file (mono_cfg);
+		g_free (mono_cfg);
+	}
 
 #if !defined(TARGET_WIN32)
 	home = g_get_home_dir ();


### PR DESCRIPTION
Previously we were defining the build configuration dir on android. This directory exists on the host and not the target. 

It often appears in places like https://github.com/mono/mono/blob/master/mono/metadata/mono-config.c#L647 which causes us to probe files that will never exist.