### PR TITLE
Dispose tooltips

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridView.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridView.cs
@@ -3404,6 +3404,12 @@ namespace System.Windows.Forms {
 				foreach (DataGridViewRow row in Rows)
 					row.Dispose();
 				Rows.Clear();
+
+				if (tooltip_timer != null)
+					tooltip_timer.Dispose();
+
+				if (tooltip_window != null)
+					tooltip_window.Dispose();
 			}
 			editingControl = null;
 

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ListView.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ListView.cs
@@ -3369,6 +3369,9 @@ namespace System.Windows.Forms
 				if (!virtual_mode) // In virtual mode we don't save the items
 					foreach (ListViewItem item in items)
 						item.Owner = null;
+
+				if (item_tooltip != null)
+					item_tooltip.Dispose();
 			}
 			
 			base.Dispose (disposing);

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/StatusBar.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/StatusBar.cs
@@ -220,6 +220,18 @@ namespace System.Windows.Forms {
 		}
 
 		protected override void Dispose (bool disposing) {
+			if (!IsDisposed)
+			{
+				if (disposing)
+				{
+					if (tooltip_timer != null)
+						tooltip_timer.Dispose();
+
+					if (tooltip_window != null)
+						tooltip_window.Dispose();
+				}
+			}
+
 			base.Dispose (disposing);
 		}
 

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/TabControl.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/TabControl.cs
@@ -675,7 +675,12 @@ namespace System.Windows.Forms {
 
 		protected override void Dispose (bool disposing)
 		{
-			CloseToolTip ();
+			if (tooltip_timer != null)
+				tooltip_timer.Dispose();
+
+			if (tooltip != null)
+				tooltip.Dispose();
+
 			base.Dispose (disposing);
 		}
 

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolBar.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolBar.cs
@@ -503,7 +503,15 @@ namespace System.Windows.Forms
 		protected override void Dispose (bool disposing)
 		{
 			if (disposing)
+			{
 				ImageList = null;
+
+				if (tipdown_timer != null)
+					tipdown_timer.Dispose();
+
+				if (tip_window != null)
+					tip_window.Dispose();
+			}
 
 			base.Dispose (disposing);
 		}

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStrip.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStrip.cs
@@ -744,10 +744,7 @@ namespace System.Windows.Forms
 					ToolStripManager.RemoveToolStrip (this);
 
 					if (tooltip_timer != null)
-					{
-						tooltip_timer.Stop();
 						tooltip_timer.Dispose();
-					}
 
 					if (tooltip_window != null)
 						tooltip_window.Dispose();

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStrip.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStrip.cs
@@ -733,7 +733,6 @@ namespace System.Windows.Forms
 					// Event Handler must be stopped before disposing Items.
 					Events.Dispose();
 
-					CloseToolTip (null);
 					// ToolStripItem.Dispose modifes the collection,
 					// so we iterate it in reverse order
 					for (int i = Items.Count - 1; i >= 0; i--)
@@ -743,6 +742,15 @@ namespace System.Windows.Forms
 						this.overflow_button.drop_down.Dispose ();
 
 					ToolStripManager.RemoveToolStrip (this);
+
+					if (tooltip_timer != null)
+					{
+						tooltip_timer.Stop();
+						tooltip_timer.Dispose();
+					}
+
+					if (tooltip_window != null)
+						tooltip_window.Dispose();
 				}
 				base.Dispose (disposing);
 			}
@@ -1538,8 +1546,10 @@ namespace System.Windows.Forms
 	
 		private void CloseToolTip (ToolStripItem item)
 		{
-			ToolTipTimer.Stop ();
-			ToolTipWindow.Hide (this);
+			if (tooltip_timer != null)
+				tooltip_timer.Stop ();
+			if (tooltip_window != null)
+				tooltip_window.Hide (this);
 			tooltip_currently_showing = null;
 			tooltip_state = ToolTip.TipState.Down;
 		}

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStripTextBox.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStripTextBox.cs
@@ -583,6 +583,20 @@ namespace System.Windows.Forms
 
 				ToolTipTimer.Stop ();
 			}
+
+			protected override void Dispose(bool disposing)
+			{
+				if (disposing)
+				{
+					if (tooltip_timer != null)
+						tooltip_timer.Dispose();
+
+					if (tooltip_window != null)
+						tooltip_window.Dispose();
+				}
+
+				base.Dispose(disposing);
+			}
 			#endregion
 		}
 	}

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/TreeView.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/TreeView.cs
@@ -822,7 +822,12 @@ namespace System.Windows.Forms {
 
 		protected override void Dispose (bool disposing) {
 			if (disposing)
+			{
 				image_list = null;
+
+				if (tooltip_window != null)
+					tooltip_window.Dispose();
+			}
 
 			base.Dispose (disposing);
 		}


### PR DESCRIPTION
I noticed that some controls do not dispose tooltips and timers. Depending on the underlying implementation these may use native resources. Therefore I'd suggest to dispose these with the parent control to not rely on the garbage collector to eventually release the resources.

Additionally, in the case of `ToolStrip.cs` `CloseToolTip` would first create the objects before turning them off.
