### PR TITLE
[Coop] Convert System.Globalization.CompareInfo.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # There is no ordering of corlib versions, no old or new,
 # the runtime expects an exact match.
 #
-MONO_CORLIB_VERSION=01E717C3-C157-44C0-89D9-32818E9C551B
+MONO_CORLIB_VERSION=26622411-EB89-4555-AA99-51C982BC19EF
 
 #
 # Put a quoted #define in config.h.

--- a/mcs/class/corlib/ReferenceSources/CompareInfo.cs
+++ b/mcs/class/corlib/ReferenceSources/CompareInfo.cs
@@ -88,7 +88,7 @@ namespace System.Globalization
 			
 			return UseManagedCollation ?
 				internal_index_managed (s1, sindex, count, s2, opt, first) :
-				internal_index (s1, sindex, count, s2, opt, first);
+				internal_index (s1, sindex, count, s2, first);
 		}
 
 		int internal_compare_switch (string str1, int offset1, int length1, string str2, int offset2, int length2, CompareOptions options)
@@ -121,21 +121,29 @@ namespace System.Globalization
 		}
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
-		private extern int internal_compare (string str1, int offset1,
-							 int length1, string str2,
-							 int offset2, int length2,
-							 CompareOptions options);
+		private static unsafe extern int internal_compare_icall (char* str1, int length1,
+			char* str2, int length2, CompareOptions options);
+
+		private static unsafe int internal_compare (string str1, int offset1,
+			int length1, string str2, int offset2, int length2, CompareOptions options)
+		{
+			fixed (char* fixed_str1 = str1,
+				     fixed_str2 = str2)
+				return internal_compare_icall (fixed_str1 + offset1, length1,
+					fixed_str2 + offset2, length2, options);
+		}
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
-		private extern int internal_index (string source, int sindex,
-						   int count, char value,
-						   CompareOptions options,
-						   bool first);
+		private static unsafe extern int internal_index_icall (char *source, int sindex,
+			int count, char *value, int value_length, bool first);
 
-		[MethodImplAttribute (MethodImplOptions.InternalCall)]
-		private extern int internal_index (string source, int sindex,
-						   int count, string value,
-						   CompareOptions options,
-						   bool first);
+		private static unsafe int internal_index (string source, int sindex,
+			int count, string value, bool first)
+		{
+			fixed (char* fixed_source = source,
+				     fixed_value = value)
+				return internal_index_icall (fixed_source, sindex, count,
+					fixed_value, value?.Length ?? 0, first);
+		}
 	}
 }

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -347,8 +347,8 @@ ICALL_TYPE(CALDATA, "System.Globalization.CalendarData", CALDATA_1)
 ICALL(CALDATA_1, "fill_calendar_data", ves_icall_System_Globalization_CalendarData_fill_calendar_data)
 
 ICALL_TYPE(COMPINF, "System.Globalization.CompareInfo", COMPINF_4)
-ICALL(COMPINF_4, "internal_compare(string,int,int,string,int,int,System.Globalization.CompareOptions)", ves_icall_System_Globalization_CompareInfo_internal_compare)
-ICALL(COMPINF_6, "internal_index(string,int,int,string,System.Globalization.CompareOptions,bool)", ves_icall_System_Globalization_CompareInfo_internal_index)
+NOHANDLES(ICALL(COMPINF_4, "internal_compare_icall", ves_icall_System_Globalization_CompareInfo_internal_compare))
+NOHANDLES(ICALL(COMPINF_6, "internal_index_icall", ves_icall_System_Globalization_CompareInfo_internal_index))
 
 ICALL_TYPE(CULDATA, "System.Globalization.CultureData", CULDATA_1)
 ICALL(CULDATA_1, "fill_culture_data", ves_icall_System_Globalization_CultureData_fill_culture_data)

--- a/mono/metadata/locales.h
+++ b/mono/metadata/locales.h
@@ -55,8 +55,9 @@ MonoArray *ves_icall_System_Globalization_CultureInfo_internal_get_cultures (Mon
 ICALL_EXPORT
 void ves_icall_System_Globalization_CompareInfo_construct_compareinfo (MonoCompareInfo *comp, MonoString *locale);
 
-ICALL_EXPORT
-int ves_icall_System_Globalization_CompareInfo_internal_compare (MonoCompareInfo *this_obj, MonoString *str1, gint32 off1, gint32 len1, MonoString *str2, gint32 off2, gint32 len2, gint32 options);
+ICALL_EXPORT int
+ves_icall_System_Globalization_CompareInfo_internal_compare (const gunichar2 *str1, gint32 len1,
+	const gunichar2 *str2, gint32 len2, gint32 options);
 
 ICALL_EXPORT
 void ves_icall_System_Globalization_CompareInfo_free_internal_collator (MonoCompareInfo *this_obj);
@@ -66,8 +67,9 @@ MonoBoolean
 ves_icall_System_Globalization_RegionInfo_construct_internal_region_from_name (MonoRegionInfo *this_obj,
  MonoString *name);
 
-ICALL_EXPORT
-int ves_icall_System_Globalization_CompareInfo_internal_index (MonoCompareInfo *this_obj, MonoString *source, gint32 sindex, gint32 count, MonoString *value, gint32 options, MonoBoolean first);
+ICALL_EXPORT int
+ves_icall_System_Globalization_CompareInfo_internal_index (const gunichar2 *source, gint32 sindex,
+	gint32 count, const gunichar2 *value, int value_length, MonoBoolean first);
 
 ICALL_EXPORT
 int


### PR DESCRIPTION
This is a subset of https://github.com/mono/mono/pull/12023, maybe easier to review
in smaller pieces.

Alternatives:
 1. Move more to managed.
 2. Remove the feature.
