### PR TITLE
[Tailcall] [arm] [jit] Optimize more and fix moving tailcall parameters.

### DIFF
--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -5038,38 +5038,48 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			 */
 
 			if (call->unaligned_stack_usage) {
-				int i, prev_sp_offset = 0;
+				int prev_sp_offset = cfg->stack_usage;
 				int saved_ip_offset_sp = 0;
 				int saved_ip_offset_fp = 0;
-
-				if (tailcall_membase || tailcall_reg) {
-					ARM_PUSH (code, 1 << ARMREG_IP);
-					saved_ip_offset_sp = 4;
-				}
+				int frame_reg = cfg->frame_reg;
 
 				/* Compute size of saved registers restored below */
 				if (iphone_abi)
-					prev_sp_offset = 2 * 4;
+					prev_sp_offset += 2 * 4;
 				else
-					prev_sp_offset = 1 * 4;
-				for (i = 0; i < 16; ++i) {
+					prev_sp_offset += 1 * 4;
+				for (int i = 0; i < 16; ++i) {
 					if (cfg->used_int_regs & (1 << i))
 						prev_sp_offset += 4;
 				}
 
-				code = emit_big_add (code, ARMREG_IP, cfg->frame_reg, cfg->stack_usage + prev_sp_offset);
-				if (cfg->frame_reg == ARMREG_SP)
-					saved_ip_offset_fp = saved_ip_offset_sp;
+				// Is locals + parameters encodable as immediate?
+				// If not, use temporary IP to get past locals.
+				// parameters alone must be encodable, per mono_arch_tailcall_supported,
+				// and 4K is very large for that.
+				const gboolean far = (prev_sp_offset + call->unaligned_stack_usage >= 4096);
+				if (far) {
+					if (tailcall_membase || tailcall_reg) {
+						ARM_PUSH (code, 1 << ARMREG_IP);
+						saved_ip_offset_sp = 4;
+					}
+
+					code = emit_big_add (code, ARMREG_IP, frame_reg, prev_sp_offset);
+					if (frame_reg == ARMREG_SP)
+						saved_ip_offset_fp = saved_ip_offset_sp;
+					frame_reg = ARMREG_IP;
+					prev_sp_offset = 0;
+				}
 
 				/* Copy arguments on the stack to our argument area */
 				// FIXME a fixed size memcpy is desirable here,
 				// at least for larger values of stack_usage.
-				for (i = 0; i < call->unaligned_stack_usage; i += sizeof (target_mgreg_t)) {
+				for (int i = 0; i < call->unaligned_stack_usage; i += sizeof (target_mgreg_t)) {
 					ARM_LDR_IMM (code, ARMREG_LR, ARMREG_SP, i + saved_ip_offset_sp);
-					ARM_STR_IMM (code, ARMREG_LR, ARMREG_IP, i + saved_ip_offset_fp);
+					ARM_STR_IMM (code, ARMREG_LR, frame_reg, i + saved_ip_offset_fp + prev_sp_offset);
 				}
 
-				if (saved_ip_offset_sp)
+				if (saved_ip_offset_sp) // far implied
 					ARM_POP (code, 1 << ARMREG_IP);
 			}
 

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -1624,10 +1624,10 @@ get_call_info (MonoMemPool *mp, MonoMethodSignature *sig)
 		add_general (&gr, &stack_size, &cinfo->sig_cookie, TRUE);
 	}
 
+	// Alignment causes tailcall to copy extra data unnecessarily.
 	DEBUG (g_print ("      stack size: %d (%d)\n", (stack_size + 15) & ~15, stack_size));
-	stack_size = ALIGN_TO (stack_size, MONO_ARCH_FRAME_ALIGNMENT);
-
-	cinfo->stack_usage = stack_size;
+	cinfo->unaligned_stack_usage = stack_size;
+	cinfo->stack_usage = ALIGN_TO (stack_size, MONO_ARCH_FRAME_ALIGNMENT);
 	return cinfo;
 }
 
@@ -2652,6 +2652,7 @@ mono_arch_emit_call (MonoCompile *cfg, MonoCallInst *call)
 
 	call->call_info = cinfo;
 	call->stack_usage = cinfo->stack_usage;
+	call->unaligned_stack_usage = cinfo->unaligned_stack_usage;
 }
 
 static void
@@ -5001,7 +5002,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			gboolean const tailcall_reg = ins->opcode == OP_TAILCALL_REG;
 			MonoCallInst *call = (MonoCallInst*)ins;
 
-			max_len += call->stack_usage / sizeof (target_mgreg_t) * ins_get_size (OP_TAILCALL_PARAMETER);
+			max_len += call->unaligned_stack_usage / sizeof (target_mgreg_t) * ins_get_size (OP_TAILCALL_PARAMETER);
 
 			if (IS_HARD_FLOAT)
 				code = emit_float_args (cfg, call, code, &max_len, &offset);
@@ -5035,13 +5036,15 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			 * Need to copy the arguments from the callee argument area to
 			 * the caller argument area, and pop the frame.
 			 */
-			if (call->stack_usage) {
+
+			if (call->unaligned_stack_usage) {
 				int i, prev_sp_offset = 0;
-				int saved_ip_offset = 0;
+				int saved_ip_offset_sp = 0;
+				int saved_ip_offset_fp = 0;
 
 				if (tailcall_membase || tailcall_reg) {
 					ARM_PUSH (code, 1 << ARMREG_IP);
-					saved_ip_offset = 4;
+					saved_ip_offset_sp = 4;
 				}
 
 				/* Compute size of saved registers restored below */
@@ -5055,16 +5058,18 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				}
 
 				code = emit_big_add (code, ARMREG_IP, cfg->frame_reg, cfg->stack_usage + prev_sp_offset);
+				if (cfg->frame_reg == ARMREG_SP)
+					saved_ip_offset_fp = saved_ip_offset_sp;
 
 				/* Copy arguments on the stack to our argument area */
 				// FIXME a fixed size memcpy is desirable here,
 				// at least for larger values of stack_usage.
-				for (i = 0; i < call->stack_usage; i += sizeof (target_mgreg_t)) {
-					ARM_LDR_IMM (code, ARMREG_LR, ARMREG_SP, i + saved_ip_offset);
-					ARM_STR_IMM (code, ARMREG_LR, ARMREG_IP, i + saved_ip_offset);
+				for (i = 0; i < call->unaligned_stack_usage; i += sizeof (target_mgreg_t)) {
+					ARM_LDR_IMM (code, ARMREG_LR, ARMREG_SP, i + saved_ip_offset_sp);
+					ARM_STR_IMM (code, ARMREG_LR, ARMREG_IP, i + saved_ip_offset_fp);
 				}
 
-				if (saved_ip_offset)
+				if (saved_ip_offset_sp)
 					ARM_POP (code, 1 << ARMREG_IP);
 			}
 

--- a/mono/mini/mini-arm.h
+++ b/mono/mini/mini-arm.h
@@ -215,6 +215,7 @@ typedef struct {
 
 struct CallInfo {
 	int nargs;
+	guint32 unaligned_stack_usage;
 	guint32 stack_usage;
 	/* The index of the vret arg in the argument list for RegTypeStructByAddr */
 	int vret_arg_index;

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -740,6 +740,7 @@ struct MonoCallInst {
 	MonoInst *out_args;
 	MonoInst *vret_var;
 	gconstpointer fptr;
+	guint unaligned_stack_usage;
 	guint stack_usage;
 	guint stack_align_amount;
 	guint is_virtual : 1;


### PR DESCRIPTION
This is based on https://github.com/mono/mono/pull/12070 but with additional optimization.

- Only move unaligned stack usage worth of parameters.
This is a simple optimization. (same as #12070)

- When moving parameters for tailcall, and having pushed ip,
and adjusting the offset to account for that, split the adjustment
between sp and frame pointer, as frame pointer may or may not be sp.
This fixes https://github.com/mono/mono/issues/11489. (same as #12070)

- When moving parameters, if locals + params < 4K, do not use IP=frame_reg+locals, use frame_reg directly. Another optimization beyond #12070.

Here is the incorrect code (with the first optimization applied):

`configure -prefix /i/1`

`MONO_VERBOSE_METHOD=*:CallSite.Target MONO_LOG_LEVEL=debug MONO_LOG_MASK=tailcall /i/1/bin/mono /usr/share/ironpython2.7/ipy.exe ./1.py `

There are many functions with this name.
I believe it is the last one printed, at least when it fails.

```
   0:	e92d49f0 	push	{r4, r5, r6, r7, r8, fp, lr} ; ok, mirrored later
   4:	e24dd05c 	sub	sp, sp, #92	; 0x5c ; ok, mirrored of later
 .
 .
 .

 274:	e595c00c 	ldr	ip, [r5, #12]   ; read function pointer into ip
 278:	e92d1000 	stmfd	sp!, {ip}       ; push ip, so sp needs adjustment by 4 
 27c:	e28bc078 	add	ip, fp, #120	; 92 from above + 7*4 for the pushes/pops
						; for some functions, previous instruction will
						; be add ip, sp, #120, and those already worked

 280:	e59de004 	ldr	lr, [sp, #4]    ; sp adjusted by 4, good
 284:	e58ce004 	str	lr, [ip, #4]    ; fp adjusted by 4 also, incorrect
```
Without the optimization, there was another ldr/str with offset=8, which should be ok,
it is just moving unused/uninitialize space.
```
 288:	e8bd1000 	ldmfd	sp!, {ip}          		; pop ip=function pointer
 28c:	e28bd05c 	add	sp, fp, #92	; 0x5c		; mirrors prolog
 290:	e8bd49f0 	pop	{r4, r5, r6, r7, r8, fp, lr}	; mirrors prolog
 294:	e12fff1c 	bx	ip				; and jump
```

Here is the corrected code:

```
   0:	e92d49f0 	push	{r4, r5, r6, r7, r8, fp, lr} ; same
   4:	e24dd05c 	sub	sp, sp, #92	; 0x5c ; same
 .
 .
 .
 240:	e596c00c 	ldr	ip, [r6, #12]     	; different register allocation, ok
 244:	e92d1000 	stmfd	sp!, {ip}		; same
 248:	e28bc078 	add	ip, fp, #120		; same
 24c:	e59de004 	ldr	lr, [sp, #4]		; same
 250:	e58ce000 	str	lr, [ip]		; <== the fix
 254:	e8bd1000 	ldmfd	sp!, {ip}		; same
 258:	e28bd05c 	add	sp, fp, #92	; 0x5c	; same
 25c:	e8bd49f0 	pop	{r4, r5, r6, r7, r8, fp, lr} ; same
 260:	e12fff1c 	bx	ip			; same
```

and then, upon further optimization, the code is:

```
 238:	e596c00c 	ldr	ip, [r6, #12]
 23c:	e59de000 	ldr	lr, [sp]
 240:	e58be078 	str	lr, [fp, #120]	; 0x78
 244:	e28bd05c 	add	sp, fp, #92	; 0x5c
 248:	e8bd49f0 	pop	{r4, r5, r6, r7, r8, fp, lr}
 24c:	e12fff1c 	bx	ip
```

and really, we could probably just use fp, adjusted, for the temporary.
I was just being very careful/ignorant with regard to register allocation.
i.e. could it have some other local, that is participating in any of this code? I don't think so.

So the code *could* be:
```
 add fp, fp, #92 ; or add fp, sp,#92 if frame_reg==sp
 ldr lr, [sp]
 str lr, [fp,120-92]
 pop
 bx ip
```

Also the `ldr	ip, [r6, #12]` could be moved later, so no need to save/restore ip.
I didn't do that, out of paranoia, that r6 points to a local, within the parameter area, and the parameter movement would clobber it. This seems unlikely but maybe value parameters can be on the stack and have a vtable??