### PR TITLE
[runtime] Guard usage of unix functions that aren't posix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2022,6 +2022,9 @@ if test x$host_win32 = xno; then
 		AC_CHECK_FUNCS(getpwuid_r)
 	fi
 
+	AC_CHECK_FUNCS(readlink)
+	AC_CHECK_FUNCS(chmod)
+
 	AC_FUNC_STRERROR_R()
 
 	dnl ****************************************************************
@@ -2519,7 +2522,6 @@ if test x$host_win32 = xno; then
 	AC_CHECK_FUNCS(pthread_mutex_timedlock)
 	AC_CHECK_FUNCS(pthread_getattr_np pthread_attr_get_np pthread_getname_np pthread_setname_np pthread_cond_timedwait_relative_np)
 	AC_CHECK_FUNCS(pthread_kill)
-	AC_CHECK_FUNCS(readlink)
 	AC_MSG_CHECKING(for PTHREAD_MUTEX_RECURSIVE)
 	AC_TRY_COMPILE([ #include <pthread.h>], [
 		pthread_mutexattr_t attr;

--- a/configure.ac
+++ b/configure.ac
@@ -476,6 +476,11 @@ fi
 
 AC_SUBST(PLATFORM_AOT_SUFFIX)
 
+if test -z "$HOST_WASM_TRUE"; then :
+AC_DEFINE(HAVE_UTIME)
+AC_DEFINE(HAVE_UTIMES)
+fi
+
 ## PLATFORM_AOT_SUFFIX not so simple for windows :-)
 
 AC_CHECK_TOOL(CC, gcc, gcc)

--- a/configure.ac
+++ b/configure.ac
@@ -1492,7 +1492,7 @@ fi
 AC_ARG_ENABLE(minimal, [  --enable-minimal=LIST      drop support for LIST subsystems.
      LIST is a comma-separated list from: aot, profiler, decimal, pinvoke, debug, appdomains, verifier, 
      reflection_emit, reflection_emit_save, large_code, logging, com, ssa, generics, attach, jit, interpreter, simd, soft_debug, perfcounters, normalization, desktop_loader, shared_perfcounters, remoting,
-	 security, lldb, mdb, assert_messages, cleanup, sgen_marksweep_conc, sgen_split_nursery, sgen_gc_bridge, sgen_debug_helpers.],
+	 security, lldb, mdb, assert_messages, cleanup, sgen_marksweep_conc, sgen_split_nursery, sgen_gc_bridge, sgen_debug_helpers, sockets.],
 [
 	for feature in `echo "$enable_minimal" | sed -e "s/,/ /g"`; do
 		eval "mono_feature_disable_$feature='yes'"
@@ -1692,6 +1692,11 @@ fi
 if test "x$mono_feature_disable_sgen_debug_helpers" = "xyes"; then
 	AC_DEFINE(DISABLE_SGEN_DEBUG_HELPERS, 1, [Disable debug helpers in SGEN.])
 	AC_MSG_NOTICE([Disabled debug helpers in SGEN.])
+fi
+
+if test "x$mono_feature_disable_sockets" = "xyes"; then
+	AC_DEFINE(DISABLE_SOCKETS, 1, [Disable sockets])
+	AC_MSG_NOTICE([Disabled sockets])
 fi
 
 AC_ARG_ENABLE(executables, [  --disable-executables disable the build of the runtime executables], enable_executables=$enableval, enable_executables=yes)

--- a/configure.ac
+++ b/configure.ac
@@ -2039,6 +2039,7 @@ if test x$host_win32 = xno; then
 	AC_CHECK_FUNCS(utime utimes)
 
 	AC_CHECK_FUNCS(openlog closelog)
+	AC_CHECK_FUNCS(atexit)
 
 	AC_FUNC_STRERROR_R()
 

--- a/configure.ac
+++ b/configure.ac
@@ -2030,6 +2030,8 @@ if test x$host_win32 = xno; then
 	AC_CHECK_FUNCS(ftruncate)
 	AC_CHECK_FUNCS(msync)
 
+	AC_CHECK_FUNCS(gethostname)
+
 	AC_FUNC_STRERROR_R()
 
 	dnl ****************************************************************

--- a/configure.ac
+++ b/configure.ac
@@ -2027,6 +2027,9 @@ if test x$host_win32 = xno; then
 	AC_CHECK_FUNCS(lstat)
 	AC_CHECK_FUNCS(getdtablesize)
 
+	AC_CHECK_FUNCS(ftruncate)
+	AC_CHECK_FUNCS(msync)
+
 	AC_FUNC_STRERROR_R()
 
 	dnl ****************************************************************

--- a/configure.ac
+++ b/configure.ac
@@ -2038,6 +2038,8 @@ if test x$host_win32 = xno; then
 	AC_CHECK_FUNCS(gethostname)
 	AC_CHECK_FUNCS(utime utimes)
 
+	AC_CHECK_FUNCS(openlog closelog)
+
 	AC_FUNC_STRERROR_R()
 
 	dnl ****************************************************************

--- a/configure.ac
+++ b/configure.ac
@@ -2519,6 +2519,7 @@ if test x$host_win32 = xno; then
 	AC_CHECK_FUNCS(pthread_mutex_timedlock)
 	AC_CHECK_FUNCS(pthread_getattr_np pthread_attr_get_np pthread_getname_np pthread_setname_np pthread_cond_timedwait_relative_np)
 	AC_CHECK_FUNCS(pthread_kill)
+	AC_CHECK_FUNCS(readlink)
 	AC_MSG_CHECKING(for PTHREAD_MUTEX_RECURSIVE)
 	AC_TRY_COMPILE([ #include <pthread.h>], [
 		pthread_mutexattr_t attr;

--- a/configure.ac
+++ b/configure.ac
@@ -2024,6 +2024,7 @@ if test x$host_win32 = xno; then
 
 	AC_CHECK_FUNCS(readlink)
 	AC_CHECK_FUNCS(chmod)
+	AC_CHECK_FUNCS(lstat)
 
 	AC_FUNC_STRERROR_R()
 

--- a/configure.ac
+++ b/configure.ac
@@ -2035,7 +2035,7 @@ if test x$host_win32 = xno; then
 	AC_CHECK_FUNCS(ftruncate)
 	AC_CHECK_FUNCS(msync)
 
-	AC_CHECK_FUNCS(gethostname)
+	AC_CHECK_FUNCS(gethostname getpeername)
 	AC_CHECK_FUNCS(utime utimes)
 
 	AC_CHECK_FUNCS(openlog closelog)

--- a/configure.ac
+++ b/configure.ac
@@ -2025,6 +2025,7 @@ if test x$host_win32 = xno; then
 	AC_CHECK_FUNCS(readlink)
 	AC_CHECK_FUNCS(chmod)
 	AC_CHECK_FUNCS(lstat)
+	AC_CHECK_FUNCS(getdtablesize)
 
 	AC_FUNC_STRERROR_R()
 

--- a/configure.ac
+++ b/configure.ac
@@ -2031,6 +2031,7 @@ if test x$host_win32 = xno; then
 	AC_CHECK_FUNCS(msync)
 
 	AC_CHECK_FUNCS(gethostname)
+	AC_CHECK_FUNCS(utime utimes)
 
 	AC_FUNC_STRERROR_R()
 

--- a/mono/eglib/gfile-unix.c
+++ b/mono/eglib/gfile-unix.c
@@ -58,11 +58,13 @@ g_file_test (const gchar *filename, GFileTest test)
 		if (access (filename, X_OK) == 0)
 			return TRUE;
 	}
+#ifdef HAVE_LSTAT
 	if ((test & G_FILE_TEST_IS_SYMLINK) != 0) {
 		have_stat = (lstat (filename, &st) == 0);
 		if (have_stat && S_ISLNK (st.st_mode))
 			return TRUE;
 	}
+#endif
 
 	if ((test & G_FILE_TEST_IS_REGULAR) != 0) {
 		if (!have_stat)

--- a/mono/eglib/gspawn.c
+++ b/mono/eglib/gspawn.c
@@ -226,7 +226,7 @@ write_all (int fd, const void *vbuf, size_t n)
 	return nwritten;
 }
 
-#ifndef G_OS_WIN32
+#if !defined(G_OS_WIN32) && defined(HAVE_GETDTABLESIZE)
 int
 eg_getdtablesize (void)
 {

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -997,8 +997,12 @@ mono_set_rootdir (void)
 	int  s;
 	char *str;
 
+#if defined(HAVE_READLINK)
 	/* Linux style */
 	s = readlink ("/proc/self/exe", buf, sizeof (buf)-1);
+#else
+	s = -1;
+#endif
 
 	if (s != -1){
 		buf [s] = 0;
@@ -1008,7 +1012,13 @@ mono_set_rootdir (void)
 
 	/* Solaris 10 style */
 	str = g_strdup_printf ("/proc/%d/path/a.out", getpid ());
+
+#if defined(HAVE_READLINK)
 	s = readlink (str, buf, sizeof (buf)-1);
+#else
+	s = -1;
+#endif
+
 	g_free (str);
 	if (s != -1){
 		buf [s] = 0;

--- a/mono/metadata/file-mmap-posix.c
+++ b/mono/metadata/file-mmap-posix.c
@@ -286,7 +286,9 @@ open_file_map (const char *c_path, int input_fd, int mode, gint64 *capacity, int
 	}
 
 	if (result != 0 || *capacity > buf.st_size) {
+#ifdef HAVE_FTRUNCATE
 		int unused G_GNUC_UNUSED = ftruncate (fd, (off_t)*capacity);
+#endif
 	}
 
 	handle = g_new0 (MmapHandle, 1);
@@ -358,7 +360,9 @@ open_memory_map (const char *c_mapName, int mode, gint64 *capacity, int access, 
 		}
 
 		unlink (file_name);
+#ifdef HAVE_FTRUNCATE
 		unused = ftruncate (fd, (off_t)*capacity);
+#endif
 
 		handle = g_new0 (MmapHandle, 1);
 		handle->ref_count = 1;
@@ -489,8 +493,10 @@ mono_mmap_flush (void *mmap_handle, MonoError *error)
 {
 	MmapInstance *h = (MmapInstance *)mmap_handle;
 
+#ifdef HAVE_MSYNC
 	if (h)
 		msync (h->address, h->length, MS_SYNC);
+#endif
 }
 
 int

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -6765,6 +6765,7 @@ mono_icall_get_machine_name (MonoError *error)
 	n = 512;
 	buf = (char*)g_malloc (n + 1);
 
+#if defined(HAVE_GETHOSTNAME)
 	if (gethostname (buf, n) == 0){
 		buf [n] = 0;
 		// try truncating the string at the first dot
@@ -6776,7 +6777,9 @@ mono_icall_get_machine_name (MonoError *error)
 		}
 		result = mono_string_new_handle (mono_domain_get (), buf, error);
 	} else
+#endif
 		result = MONO_HANDLE_CAST (MonoString, NULL_HANDLE);
+
 	g_free (buf);
 	
 	return result;

--- a/mono/metadata/mono-security.c
+++ b/mono/metadata/mono-security.c
@@ -518,7 +518,11 @@ Protect (const gunichar2 *path, gint32 file_mode, gint32 add_dir_mode)
 			int mode = file_mode;
 			if (st.st_mode & S_IFDIR)
 				mode |= add_dir_mode;
+#ifdef HAVE_CHMOD
 			result = (chmod (utf8_name, mode) == 0);
+#else
+			result = -1;
+#endif
 		}
 		g_free (utf8_name);
 	}

--- a/mono/metadata/mono-security.c
+++ b/mono/metadata/mono-security.c
@@ -66,9 +66,13 @@
  */
 static size_t mono_sysconf (int name)
 {
+#ifdef HAVE_SYSCONF
 	size_t size = (size_t) sysconf (name);
 	/* default value */
 	return (size == -1) ? MONO_SYSCONF_DEFAULT_SIZE : size;
+#else
+	return MONO_SYSCONF_DEFAULT_SIZE;
+#endif
 }
 
 static gchar*

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -341,7 +341,11 @@ _wapi_chmod (const gchar *pathname, mode_t mode)
 	gint ret;
 
 	MONO_ENTER_GC_SAFE;
+#if defined(HAVE_CHMOD)
 	ret = chmod (pathname, mode);
+#else
+	ret = -1;
+#endif
 	MONO_EXIT_GC_SAFE;
 	if (ret == -1 && (errno == ENOENT || errno == ENOTDIR) && IS_PORTABILITY_SET) {
 		gint saved_errno = errno;
@@ -352,9 +356,13 @@ _wapi_chmod (const gchar *pathname, mode_t mode)
 			return -1;
 		}
 
+#if defined(HAVE_CHMOD)
 		MONO_ENTER_GC_SAFE;
 		ret = chmod (located_filename, mode);
 		MONO_EXIT_GC_SAFE;
+#else
+		ret = -1;
+#endif
 		g_free (located_filename);
 	}
 
@@ -3669,9 +3677,13 @@ mono_w32file_set_attributes (const gunichar2 *name, guint32 attrs)
 		if ((buf.st_mode & S_IROTH) != 0)
 			exec_mask |= S_IXOTH;
 
+#if defined(HAVE_CHMOD)
 		MONO_ENTER_GC_SAFE;
 		result = chmod (utf8_name, buf.st_mode | exec_mask);
 		MONO_EXIT_GC_SAFE;
+#else
+		result = -1;
+#endif
 	}
 	/* Don't bother to reset executable (might need to change this
 	 * policy)

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -519,6 +519,7 @@ _wapi_lstat (const gchar *path, struct stat *buf)
 {
 	gint ret;
 
+#ifdef HAVE_LSTAT
 	MONO_ENTER_GC_SAFE;
 	ret = lstat (path, buf);
 	MONO_EXIT_GC_SAFE;
@@ -534,6 +535,9 @@ _wapi_lstat (const gchar *path, struct stat *buf)
 		ret = lstat (located_filename, buf);
 		g_free (located_filename);
 	}
+#else
+	ret = -1;
+#endif
 
 	return ret;
 }

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -23,7 +23,9 @@
 #endif
 #include <sys/types.h>
 #include <stdio.h>
+#ifdef HAVE_UTIME_H
 #include <utime.h>
+#endif
 #ifdef __linux__
 #include <sys/ioctl.h>
 #include <linux/fs.h>
@@ -373,8 +375,9 @@ _wapi_chmod (const gchar *pathname, mode_t mode)
 static gint
 _wapi_utime (const gchar *filename, const struct utimbuf *buf)
 {
-	gint ret;
+	gint ret = -1;
 
+#ifdef HAVE_UTIME
 	MONO_ENTER_GC_SAFE;
 	ret = utime (filename, buf);
 	MONO_EXIT_GC_SAFE;
@@ -392,6 +395,7 @@ _wapi_utime (const gchar *filename, const struct utimbuf *buf)
 		MONO_EXIT_GC_SAFE;
 		g_free (located_filename);
 	}
+#endif
 
 	return ret;
 }
@@ -400,8 +404,9 @@ _wapi_utime (const gchar *filename, const struct utimbuf *buf)
 static gint
 _wapi_utimes (const gchar *filename, const struct timeval times[2])
 {
-	gint ret;
+	gint ret = -1;
 
+#ifdef HAVE_UTIMES
 	MONO_ENTER_GC_SAFE;
 	ret = utimes (filename, times);
 	MONO_EXIT_GC_SAFE;
@@ -419,6 +424,7 @@ _wapi_utimes (const gchar *filename, const struct timeval times[2])
 		MONO_EXIT_GC_SAFE;
 		g_free (located_filename);
 	}
+#endif
 
 	return ret;
 }

--- a/mono/metadata/w32process-unix-default.c
+++ b/mono/metadata/w32process-unix-default.c
@@ -77,9 +77,11 @@ mono_w32process_get_name (pid_t pid)
 #else
 	memset (buf, '\0', sizeof(buf));
 	filename = g_strdup_printf ("/proc/%d/exe", pid);
+#if defined(HAVE_READLINK)
 	if (readlink (filename, buf, 255) > 0) {
 		ret = g_strdup (buf);
 	}
+#endif
 	g_free (filename);
 
 	if (ret != NULL) {

--- a/mono/metadata/w32process-unix-default.c
+++ b/mono/metadata/w32process-unix-default.c
@@ -322,8 +322,11 @@ mono_w32process_get_modules (pid_t pid)
 		if (!g_ascii_isspace (*p)) {
 			continue;
 		}
-
+#if defined(MAJOR_IN_MKDEV) || defined(MAJOR_IN_SYSMACROS)
 		device = makedev ((int)maj_dev, (int)min_dev);
+#else
+		device = 0;
+#endif
 		if ((device == 0) && (inode == 0)) {
 			continue;
 		}

--- a/mono/metadata/w32socket-unix.c
+++ b/mono/metadata/w32socket-unix.c
@@ -22,7 +22,9 @@
 #ifdef HAVE_NETDB_H
 #include <netdb.h>
 #endif
+#ifdef HAVE_NETINET_TCP_H
 #include <arpa/inet.h>
+#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/mono/metadata/w32socket-unix.c
+++ b/mono/metadata/w32socket-unix.c
@@ -803,9 +803,13 @@ mono_w32socket_getpeername (SOCKET sock, struct sockaddr *name, socklen_t *namel
 		return SOCKET_ERROR;
 	}
 
+#ifdef HAVE_GETPEERNAME
 	MONO_ENTER_GC_SAFE;
 	ret = getpeername (((MonoFDHandle*) sockethandle)->fd, name, namelen);
 	MONO_EXIT_GC_SAFE;
+#else
+	ret = -1;
+#endif
 	if (ret == -1) {
 		gint errnum = errno;
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_SOCKET, "%s: getpeername error: %s", __func__, g_strerror (errno));

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -37,7 +37,9 @@
 #ifdef HAVE_NETDB_H
 #include <netdb.h>
 #endif
+#ifdef HAVE_NETINET_TCP_H
 #include <arpa/inet.h>
+#endif
 #endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>

--- a/mono/mini/main.c
+++ b/mono/mini/main.c
@@ -159,7 +159,9 @@ bundle_save_library_initialize (void)
 	g_free (path);
 	if (bundled_dylibrary_directory == NULL)
 		return;
+#ifdef HAVE_ATEXIT
 	atexit (delete_bundled_libraries);
+#endif
 }
 
 static void

--- a/mono/utils/dlmalloc.c
+++ b/mono/utils/dlmalloc.c
@@ -1188,7 +1188,7 @@ int mspace_mallopt(int, int);
 #include <string.h>      /* for memset etc */
 #endif  /* LACKS_STRING_H */
 #if USE_BUILTIN_FFS
-#ifndef LACKS_STRINGS_H
+#if !defined(LACKS_STRINGS_H) && defined(HAVE_STRINGS_H)
 #include <strings.h>     /* for ffs */
 #endif /* LACKS_STRINGS_H */
 #endif /* USE_BUILTIN_FFS */

--- a/mono/utils/mono-dl-posix.c
+++ b/mono/utils/mono-dl-posix.c
@@ -47,7 +47,11 @@ mono_dl_get_so_suffixes (void)
 int
 mono_dl_get_executable_path (char *buf, int buflen)
 {
+#if defined(HAVE_READLINK)
 	return readlink ("/proc/self/exe", buf, buflen - 1);
+#else
+	return -1;
+#endif
 }
 
 const char*

--- a/mono/utils/mono-log-posix.c
+++ b/mono/utils/mono-log-posix.c
@@ -64,7 +64,9 @@ mapSyslogLevel(GLogLevelFlags level)
 void
 mono_log_open_syslog(const char *ident, void *userData)
 {
+#ifdef HAVE_OPENLOG
 	openlog("mono", LOG_PID, LOG_USER);
+#endif
 	logUserData = userData;
 }
 
@@ -92,6 +94,8 @@ mono_log_write_syslog(const char *domain, GLogLevelFlags level, mono_bool hdr, c
 void
 mono_log_close_syslog()
 {
+#ifdef HAVE_CLOSELOG
 	closelog();
+#endif
 }
 #endif

--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -964,7 +964,7 @@ mono_cpu_get_data (int cpu_id, MonoCpuData data, MonoProcessError *error)
 int
 mono_atexit (void (*func)(void))
 {
-#ifdef HOST_ANDROID
+#if defined(HOST_ANDROID) || !defined(HAVE_ATEXIT)
 	/* Some versions of android libc doesn't define atexit () */
 	return 0;
 #else

--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -29,7 +29,9 @@
 #ifdef HAVE_SYS_ERRNO_H
 #include <sys/errno.h>
 #endif
+#ifdef HAVE_SYS_PARAM_H
 #include <sys/param.h>
+#endif
 #include <errno.h>
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>

--- a/mono/utils/mono-threads-posix.c
+++ b/mono/utils/mono-threads-posix.c
@@ -39,7 +39,9 @@ extern int tkill (pid_t tid, int signal);
 
 #include <pthread.h>
 
+#ifdef HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>
+#endif
 
 gboolean
 mono_thread_platform_create_thread (MonoThreadStart thread_fn, gpointer thread_data, gsize* const stack_size, MonoNativeThreadId *tid)


### PR DESCRIPTION
Some of these functions aren't available on POSIX-compliant platforms that are not linux or OSX. This some checks for these functions. 

It also makes it easier to use DISABLE_SOCKETS, by adding an enable-minimal option for it. 