### PR TITLE
[runtime] Add some llvm-cbe automation

### DIFF
--- a/llvm/build.mk
+++ b/llvm/build.mk
@@ -27,7 +27,7 @@ $(LLVM_BUILD)/$(if $(NINJA),build.ninja,Makefile): $(abs_top_srcdir)/external/ll
 		-DLLVM_INCLUDE_TESTS=Off \
 		-DLLVM_BUILD_EXAMPLES=Off \
 		-DLLVM_INCLUDE_EXAMPLES=Off \
-		-DLLVM_TOOLS_TO_BUILD="opt;llc;llvm-config;llvm-dis" \
+		-DLLVM_TOOLS_TO_BUILD="opt;llc;llvm-config;llvm-dis;llvm-cbe" \
 		-DLLVM_TARGETS_TO_BUILD="X86;ARM;AArch64" \
 		$(EXTRA_LLVM_ARGS)	\
 		-DLLVM_ENABLE_ASSERTIONS=$(if $(INTERNAL_LLVM_ASSERTS),On,Off) \


### PR DESCRIPTION
Automates the steps named in https://github.com/mono/mono/issues/11940

Note that the emitted C currently has some issues compiling due to linking to some minor runtime code from Julia. I need to bring that over, or make it get those primitives from us. That'll probably happen in the `mono/llvm` repo. 