### PR TITLE
For the files that are always C++, for LLVM support, instead of compi…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1041,38 +1041,51 @@ fi
 
 AC_SUBST(CXXFLAGS_COMMON)
 
+AM_CONDITIONAL(CXX, [test "x$enable_cxx" = "xyes"])
+
+# "always" as in, this variable is always defined, independently
+# of configure -enable-cxx
+#
+# This used to suppress libc++ despite the presence of .cpp files
+# in LLVM support, even when overall compiling mono as C.
+#
+# It is needed when mono is C++ also, thus the "always".
+
+# -std=gnu99 -xc++ is not allowed and errors.
+ALWAYS_CXX_REMOVE_CFLAGS="-std=gnu99"
+
+# These give warnings and should be removed. They are C-only.
+# i.e. C++ never allows these, they are always errors and their warningness is not controllable.
+ALWAYS_CXX_REMOVE_CFLAGS="$ALWAYS_CXX_REMOVE_CFLAGS -Wmissing-prototypes -Wstrict-prototypes -Wnested-externs"
+
+# Likewise with CentOS 6 gcc 4.4.
+ALWAYS_CXX_REMOVE_CFLAGS="$ALWAYS_CXX_REMOVE_CFLAGS -Werror-implicit-function-declaration"
+
+# The C-only-ness of -Wno-format-zero-length varies with gcc version.
+# It is C-only prior to 4.7. Using it with C++ prior to 4.7
+# generates a warning every time we run gcc which is very unsightly.
+# The warning is for e.g. sprintf(foo, "") which can just be
+# foo[0] = 0 but Mono's use is more elaborate, not as easy to "fix",
+# and completely legal and valid.
+# We have to switch to C++ and not just use -xc++ because of -std=gnu99 (error when combined with -xc++).
+# Alternatively, just run $CXX -xc++ -c /dev/null.
+AC_LANG_PUSH(C++)
+ORIG_CXXFLAGS=$CXXFLAGS
+CXXFLAGS="$CXXFLAGS -Werror -Wno-format-zero-length -xc++ "
+AC_MSG_CHECKING(or C-only-ness of -Wno-format-zero-length)
+AC_TRY_COMPILE([ ], [ ], [ AC_MSG_RESULT(yes) ],
+			 [ AC_MSG_RESULT(no)
+			   ALWAYS_CXX_REMOVE_CFLAGS="$ALWAYS_CXX_REMOVE_CFLAGS -Wno-format-zero-length" ])
+CXXFLAGS=$ORIG_CXXFLAGS
+AC_LANG_POP(C++)
+
 if test "x$enable_cxx" = "xyes"; then
-
+	CXX_REMOVE_CFLAGS="$ALWAYS_CXX_REMOVE_CFLAGS"
 	CXX_ADD_CFLAGS=" -xc++ $CXXFLAGS_COMMON "
-
-	# -std=gnu99 -xc++ is not allowed and errors.
-	CXX_REMOVE_CFLAGS=-std=gnu99
-	# These give warnings and should be removed. They are C-only.
-	# i.e. C++ never allows these, they are always errors and their warningness is not controllable.
-	CXX_REMOVE_CFLAGS="$CXX_REMOVE_CFLAGS -Wmissing-prototypes -Wstrict-prototypes -Wnested-externs"
-	# Likewise with CentOS 6 gcc 4.4.
-	CXX_REMOVE_CFLAGS="$CXX_REMOVE_CFLAGS -Werror-implicit-function-declaration"
-
-	# The C-only-ness of -Wno-format-zero-length varies with gcc version.
-	# It is C-only prior to 4.7. Using it with C++ prior to 4.7
-	# generates a warning every time we run gcc which is very unsightly.
-	# The warning is for e.g. sprintf(foo, "") which can just be
-	# foo[0] = 0 but Mono's use is more elaborate, not as easy to "fix",
-	# and completely legal and valid.
-	# We have to switch to C++ and not just use -xc++ because of -std=gnu99 (error when combined with -xc++).
-	# Alternatively, just run $CXX -xc++ -c /dev/null.
-	AC_LANG_PUSH(C++)
-	ORIG_CXXFLAGS=$CXXFLAGS
-	CXXFLAGS="$CXXFLAGS -Werror -Wno-format-zero-length -xc++ "
-	AC_MSG_CHECKING(or C-only-ness of -Wno-format-zero-length)
-	AC_TRY_COMPILE([ ], [ ], [ AC_MSG_RESULT(yes) ],
-				 [ AC_MSG_RESULT(no)
-				   CXX_REMOVE_CFLAGS="$CXX_REMOVE_CFLAGS -Wno-format-zero-length" ])
-	CXXFLAGS=$ORIG_CXXFLAGS
-	AC_LANG_POP(C++)
 fi
 AC_SUBST(CXX_ADD_CFLAGS)
 AC_SUBST(CXX_REMOVE_CFLAGS)
+AC_SUBST(ALWAYS_CXX_REMOVE_CFLAGS)
 
 #
 # Set the build profiles and options before things which use them

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -77,6 +77,10 @@ AM_CFLAGS = \
 	$(JEMALLOC_CFLAGS)	\
 	$(PLATFORM_CFLAGS) $(ARCH_CFLAGS) $(SHARED_CFLAGS)
 
+if !CXX
+AM_CFLAGS += @ALWAYS_CXX_REMOVE_CFLAGS@
+endif
+
 AM_CXXFLAGS = $(LLVM_CXXFLAGS) $(GLIB_CFLAGS)
 
 if HOST_WIN32
@@ -162,7 +166,7 @@ lib_LTLIBRARIES += $(interp_libs)
 endif
 
 if SHARED_MONO
-mini_common_lib = libmini.la
+mini_common_lib = libmini.la libmini-cpp.la
 else
 mini_common_lib = 
 endif
@@ -178,9 +182,16 @@ endif
 libmain_a_CFLAGS = $(AM_CFLAGS) @CXX_ADD_CFLAGS@
 
 if LOADED_LLVM
+
+# Compile .cpp files separately, as .c files, that #include .cpp, with -xc++,
+# to prevent automake from using CXX to link.
+noinst_LTLIBRARIES += libmono-llvm-cpp.la
+libmono_llvm_cpp_la_SOURCES = mini-llvm-cpp.c llvm-jit-cpp.c
+libmono_llvm_cpp_la_CFLAGS = $(filter-out @ALWAYS_CXX_REMOVE_CFLAGS@, $(libmono_llvm_la_CFLAGS) $(AM_CXXFLAGS) -xc++)
+
 lib_LTLIBRARIES += libmono-llvm.la
-libmono_llvm_la_SOURCES = mini-llvm.c mini-llvm-cpp.cpp llvm-jit.cpp
-libmono_llvm_la_LIBADD = $(glib_libs) $(LLVM_LIBS) $(LLVM_LDFLAGS)
+libmono_llvm_la_SOURCES = mini-llvm.c
+libmono_llvm_la_LIBADD = $(glib_libs) $(LLVM_LIBS) $(LLVM_LDFLAGS) libmono-llvm-cpp.la
 
 if HOST_DARWIN
 libmono_llvm_la_LDFLAGS=-Wl,-undefined -Wl,suppress -Wl,-flat_namespace 
@@ -389,9 +400,12 @@ llvm_sources = \
 else
 llvm_sources = \
 	mini-llvm.c		\
-	mini-llvm-loaded.c \
-	mini-llvm-cpp.cpp \
-	llvm-jit.cpp
+	mini-llvm-loaded.c
+# Compile .cpp files separately, as .c files, that #include .cpp, with -xc++,
+# to prevent automake from using CXX to link.
+llvm_sources_cpp = \
+	mini-llvm-cpp.c \
+	llvm-jit-cpp.c
 endif
 endif
 
@@ -411,12 +425,12 @@ interp_libs_with_mini = $(interp_libs)
 endif
 
 if ENABLE_LLVM
-llvm_runtime_sources = \
-	llvm-runtime.cpp
+llvm_runtime_sources_cpp = \
+	llvm-runtime-cpp.c
 else
 if ENABLE_LLVM_RUNTIME
-llvm_runtime_sources = \
-	llvm-runtime.cpp
+llvm_runtime_sources_cpp = \
+	llvm-runtime-cpp.c
 endif
 endif
 
@@ -704,8 +718,14 @@ endif
 # This library is shared between mono and mono-sgen, since the code in mini/ doesn't contain
 # compile time dependencies on boehm/sgen.
 #
-libmini_la_SOURCES = $(common_sources) $(llvm_sources) $(llvm_runtime_sources) $(arch_sources) $(os_sources)
+libmini_la_SOURCES = $(common_sources) $(llvm_sources) $(arch_sources) $(os_sources)
 libmini_la_CFLAGS = $(AM_CFLAGS) @CXX_ADD_CFLAGS@
+libmini_la_LIBADD = libmini-cpp.la
+
+# Compile .cpp files separately, as .c files, that #include .cpp, with -xc++,
+# to prevent automake from using CXX to link.
+libmini_cpp_la_SOURCES = empty.c $(llvm_sources_cpp) $(llvm_runtime_sources_cpp)
+libmini_cpp_la_CFLAGS = $(filter-out @ALWAYS_CXX_REMOVE_CFLAGS@, $(libmini_la_CFLAGS) $(AM_CXXFLAGS) -xc++)
 
 libmonoboehm_2_0_la_SOURCES =
 libmonoboehm_2_0_la_CFLAGS = $(mono_boehm_CFLAGS) @CXX_ADD_CFLAGS@
@@ -1053,5 +1073,6 @@ Makefile.am: Makefile.am.in
 
 endif
 
-# Per-library because linking doesn't like -xc++, it treats libraries as C++.
-CFLAGS := $(filter-out @CXX_REMOVE_CFLAGS@, @CFLAGS@)
+# Remove from CFLAGS, the flags that are not allowed with C++.
+# They or C++ flags will then be added back selectively.
+CFLAGS := $(filter-out @ALWAYS_CXX_REMOVE_CFLAGS@, @CFLAGS@)

--- a/mono/mini/llvm-jit-cpp.c
+++ b/mono/mini/llvm-jit-cpp.c
@@ -1,0 +1,1 @@
+#include "llvm-jit.cpp"

--- a/mono/mini/llvm-runtime-cpp.c
+++ b/mono/mini/llvm-runtime-cpp.c
@@ -1,0 +1,1 @@
+#include "llvm-runtime.cpp"

--- a/mono/mini/mini-llvm-cpp.c
+++ b/mono/mini/mini-llvm-cpp.c
@@ -1,0 +1,1 @@
+#include "mini-llvm-cpp.cpp"


### PR DESCRIPTION
…ling foo.cpp,

instead compile foo.c, that includes foo.cpp, with -xc++.

This is to prevent a C++ library dependency -- even when mono is compiled as C, due to the LLVM support -- and fix https://github.com/mono/mono/issues/12060.

There might be another smaller way.
Let me try to understand this:
https://www.gnu.org/software/automake/manual/html_node/How-the-Linker-is-Chosen.html