### PR TITLE
[interp] Fix resuming into interp frame during EH

### DIFF
--- a/mono/mini/ee.h
+++ b/mono/mini/ee.h
@@ -15,7 +15,7 @@
 #ifndef __MONO_EE_H__
 #define __MONO_EE_H__
 
-#define MONO_EE_API_VERSION 0x6
+#define MONO_EE_API_VERSION 0x7
 
 typedef struct _MonoInterpStackIter MonoInterpStackIter;
 
@@ -34,8 +34,8 @@ struct _MonoEECallbacks {
 	void (*delegate_ctor) (MonoObjectHandle this_obj, MonoObjectHandle target, gpointer addr, MonoError *error);
 	gpointer (*get_remoting_invoke) (gpointer imethod, MonoError *error);
 	void (*set_resume_state) (MonoJitTlsData *jit_tls, MonoException *ex, MonoJitExceptionInfo *ei, MonoInterpFrameHandle interp_frame, gpointer handler_ip);
-	gboolean (*run_finally) (StackFrameInfo *frame, int clause_index, gpointer handler_ip);
-	gboolean (*run_filter) (StackFrameInfo *frame, MonoException *ex, int clause_index, gpointer handler_ip);
+	gboolean (*run_finally) (StackFrameInfo *frame, int clause_index, gpointer handler_ip, gpointer handler_ip_end);
+	gboolean (*run_filter) (StackFrameInfo *frame, MonoException *ex, int clause_index, gpointer handler_ip, gpointer handler_ip_end);
 	void (*frame_iter_init) (MonoInterpStackIter *iter, gpointer interp_exit_data);
 	gboolean (*frame_iter_next) (MonoInterpStackIter *iter, StackFrameInfo *frame);
 	MonoJitInfo* (*find_jit_info) (MonoDomain *domain, MonoMethod *method);

--- a/mono/mini/interp-stubs.c
+++ b/mono/mini/interp-stubs.c
@@ -81,13 +81,13 @@ stub_set_resume_state (MonoJitTlsData *jit_tls, MonoException *ex, MonoJitExcept
 }
 
 static gboolean
-stub_run_finally (StackFrameInfo *frame, int clause_index, gpointer handler_ip)
+stub_run_finally (StackFrameInfo *frame, int clause_index, gpointer handler_ip, gpointer handler_ip_end)
 {
 	g_assert_not_reached ();
 }
 
 static gboolean
-stub_run_filter (StackFrameInfo *frame, MonoException *ex, int clause_index, gpointer handler_ip)
+stub_run_filter (StackFrameInfo *frame, MonoException *ex, int clause_index, gpointer handler_ip, gpointer handler_ip_end)
 {
 	g_assert_not_reached ();
 	return FALSE;

--- a/mono/mini/interp/interp-internals.h
+++ b/mono/mini/interp/interp-internals.h
@@ -147,7 +147,7 @@ typedef struct {
 	/* Frame to resume execution at */
 	InterpFrame *handler_frame;
 	/* IP to resume execution at */
-	gpointer handler_ip;
+	guint16 *handler_ip;
 	/* Clause that we are resuming to */
 	MonoJitExceptionInfo *handler_ei;
 } ThreadContext;

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -79,6 +79,17 @@
 #pragma warning(disable:4102) // label' : unreferenced label
 #endif
 
+/* Arguments that are passed when invoking only a finally/filter clause from the frame */
+typedef struct {
+	/* Where we start the frame execution from */
+	guint16 *start_with_ip;
+	/* When exiting this clause we also exit the frame */
+	int exit_clause;
+	/* Exception that we are filtering */
+	MonoException *filter_exception;
+	InterpFrame *base_frame;
+} FrameClauseArgs;
+
 static inline void
 init_frame (InterpFrame *frame, InterpFrame *parent_frame, InterpMethod *rmethod, stackval *method_args, stackval *method_retval)
 {
@@ -96,7 +107,7 @@ init_frame (InterpFrame *frame, InterpFrame *parent_frame, InterpMethod *rmethod
 	init_frame ((frame), (parent_frame), _rmethod, (method_args), (method_retval)); \
 	} while (0)
 
-#define interp_exec_method(frame, context) interp_exec_method_full ((frame), (context), NULL, NULL, -1, NULL)
+#define interp_exec_method(frame, context) interp_exec_method_full ((frame), (context), NULL)
 
 /*
  * List of classes whose methods will be executed by transitioning to JITted code.
@@ -112,7 +123,7 @@ static gboolean interp_init_done = FALSE;
 
 static char* dump_frame (InterpFrame *inv);
 static MonoArray *get_trace_ips (MonoDomain *domain, InterpFrame *top);
-static void interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *start_with_ip, MonoException *filter_exception, int exit_at_finally, InterpFrame *base_frame);
+static void interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClauseArgs *clause_args);
 static InterpMethod* lookup_method_pointer (gpointer addr);
 
 typedef void (*ICallMethod) (InterpFrame *frame);
@@ -2606,7 +2617,7 @@ static int opcode_counts[512];
  * If BASE_FRAME is not NULL, copy arguments/locals from BASE_FRAME.
  */
 static void 
-interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *start_with_ip, MonoException *filter_exception, int exit_at_finally, InterpFrame *base_frame)
+interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClauseArgs *clause_args)
 {
 	InterpFrame child_frame;
 	GSList *finally_ips = NULL;
@@ -2653,16 +2664,16 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 		EXCEPTION_CHECKPOINT;
 	}
 
-	if (!start_with_ip) {
+	if (!clause_args) {
 		frame->args = g_newa (char, rtm->alloca_size);
 		memset (frame->args, 0, rtm->alloca_size);
 
 		ip = rtm->code;
 	} else {
-		ip = start_with_ip;
-		if (base_frame) {
+		ip = clause_args->start_with_ip;
+		if (clause_args->base_frame) {
 			frame->args = g_newa (char, rtm->alloca_size);
-			memcpy (frame->args, base_frame->args, rtm->alloca_size);
+			memcpy (frame->args, clause_args->base_frame->args, rtm->alloca_size);
 		}
 	}
 	sp = frame->stack = (stackval *) ((char *) frame->args + rtm->args_size);
@@ -2674,8 +2685,8 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 	frame->locals = locals;
 	child_frame.parent = frame;
 
-	if (filter_exception) {
-		sp->data.p = filter_exception;
+	if (clause_args && clause_args->filter_exception) {
+		sp->data.p = clause_args->filter_exception;
 		sp++;
 	}
 
@@ -5181,7 +5192,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 			int clause_index = *ip;
 			gboolean pending_abort = mono_threads_end_abort_protected_block ();
 
-			if (clause_index == exit_at_finally)
+			if (clause_args && clause_index == clause_args->exit_clause)
 				goto exit_frame;
 			while (sp > frame->stack) {
 				--sp;
@@ -5845,8 +5856,8 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 
 exit_frame:
 
-	if (base_frame)
-		memcpy (base_frame->args, frame->args, rtm->alloca_size);
+	if (clause_args && clause_args->base_frame)
+		memcpy (clause_args->base_frame->args, frame->args, rtm->alloca_size);
 
 	if (!frame->ex && MONO_PROFILER_ENABLED (method_leave) &&
 	    frame->imethod->prof_flags & MONO_PROFILER_CALL_INSTRUMENTATION_LEAVE) {
@@ -5941,9 +5952,13 @@ interp_run_finally (StackFrameInfo *frame, int clause_index, gpointer handler_ip
 	InterpFrame *iframe = (InterpFrame*)frame->interp_frame;
 	ThreadContext *context = get_context ();
 	const unsigned short *old_ip = iframe->ip;
+	FrameClauseArgs clause_args;
 
+	memset (&clause_args, 0, sizeof (FrameClauseArgs));
+	clause_args.start_with_ip = (guint16*) handler_ip;
+	clause_args.exit_clause = clause_index;
 
-	interp_exec_method_full (iframe, context, (guint16*)handler_ip, NULL, clause_index, NULL);
+	interp_exec_method_full (iframe, context, &clause_args);
 	if (context->has_resume_state) {
 		return TRUE;
 	} else {
@@ -5965,6 +5980,7 @@ interp_run_filter (StackFrameInfo *frame, MonoException *ex, int clause_index, g
 	ThreadContext *context = get_context ();
 	InterpFrame child_frame;
 	stackval retval;
+	FrameClauseArgs clause_args;
 
 	/*
 	 * Have to run the clause in a new frame which is a copy of IFRAME, since
@@ -5975,7 +5991,12 @@ interp_run_filter (StackFrameInfo *frame, MonoException *ex, int clause_index, g
 	child_frame.retval = &retval;
 	child_frame.parent = iframe;
 
-	interp_exec_method_full (&child_frame, context, (guint16*)handler_ip, ex, clause_index, iframe);
+	memset (&clause_args, 0, sizeof (FrameClauseArgs));
+	clause_args.start_with_ip = (guint16*) handler_ip;
+	clause_args.filter_exception = ex;
+	clause_args.base_frame = iframe;
+
+	interp_exec_method_full (&child_frame, context, &clause_args);
 	/* ENDFILTER stores the result into child_frame->retval */
 	return child_frame.retval->data.i ? TRUE : FALSE;
 }

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -228,6 +228,21 @@ set_resume_state (ThreadContext *context, InterpFrame *frame)
 		goto main_loop;													\
 	} while (0)
 
+/*
+ * If this bit is set, it means the call has thrown the exception, and we
+ * reached this point because the EH code in mono_handle_exception ()
+ * unwound all the JITted frames below us. mono_interp_set_resume_state ()
+ * has set the fields in context to indicate where we have to resume execution.
+ */
+#define CHECK_RESUME_STATE(context) do { \
+		if ((context)->has_resume_state) { \
+			if (frame == (context)->handler_frame) \
+				SET_RESUME_STATE (context); \
+			else \
+				goto exit_frame; \
+		} \
+	} while (0);
+
 static void
 set_context (ThreadContext *context)
 {
@@ -767,10 +782,7 @@ fill_in_trace (MonoException *exception, InterpFrame *frame)
 #define THROW_EX_GENERAL(exception,ex_ip, rethrow)		\
 	do {							\
 		interp_throw (context, (exception), (frame), (ex_ip), (rethrow)); \
-		if (frame == context->handler_frame) \
-			SET_RESUME_STATE (context); \
-		else \
-			goto exit_frame; \
+		CHECK_RESUME_STATE(context); \
 	} while (0)
 
 #define THROW_EX(exception,ex_ip) THROW_EX_GENERAL ((exception), (ex_ip), FALSE)
@@ -2875,12 +2887,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 
 			interp_exec_method (&child_frame, context);
 
-			if (context->has_resume_state) {
-				if (frame == context->handler_frame)
-					SET_RESUME_STATE (context);
-				else
-					goto exit_frame;
-			}
+			CHECK_RESUME_STATE (context);
 
 			CHECK_CHILD_EX (child_frame, ip - 2);
 
@@ -2901,12 +2908,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 
 			sp = do_icall (frame, csignature, opcode, sp, target_ip);
 			EXCEPTION_CHECKPOINT;
-			if (context->has_resume_state) {
-				if (frame == context->handler_frame)
-					SET_RESUME_STATE (context);
-				else
-					goto exit_frame;
-			}
+			CHECK_RESUME_STATE (context);
 			ip += 3;
 			MINT_IN_BREAK;
 		}
@@ -2955,12 +2957,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 				ves_pinvoke_method (&child_frame, csignature, (MonoFuncV) code, FALSE, context);
 			}
 
-			if (context->has_resume_state) {
-				if (frame == context->handler_frame)
-					SET_RESUME_STATE (context);
-				else
-					goto exit_frame;
-			}
+			CHECK_RESUME_STATE (context);
 
 			CHECK_CHILD_EX (child_frame, ip - 2);
 
@@ -3013,12 +3010,8 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 
 			interp_exec_method (&child_frame, context);
 
-			if (context->has_resume_state) {
-				if (frame == context->handler_frame)
-					SET_RESUME_STATE (context);
-				else
-					goto exit_frame;
-			}
+			CHECK_RESUME_STATE (context);
+
 			CHECK_CHILD_EX (child_frame, ip - 2);
 
 			if (!is_void) {
@@ -3039,18 +3032,8 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 				THROW_EX (ex, ip);
 			}
 
-			if (context->has_resume_state) {
-				/*
-				 * If this bit is set, it means the call has thrown the exception, and we
-				 * reached this point because the EH code in mono_handle_exception ()
-				 * unwound all the JITted frames below us. mono_interp_set_resume_state ()
-				 * has set the fields in context to indicate where we have to resume execution.
-				 */
-				if (frame == context->handler_frame)
-					SET_RESUME_STATE (context);
-				else
-					goto exit_frame;
-			}
+			CHECK_RESUME_STATE (context);
+
 			if (rmethod->rtype->type != MONO_TYPE_VOID)
 				sp++;
 
@@ -4057,12 +4040,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 
 			interp_exec_method (&child_frame, context);
 
-			if (context->has_resume_state) {
-				if (frame == context->handler_frame)
-					SET_RESUME_STATE (context);
-				else
-					goto exit_frame;
-			}
+			CHECK_RESUME_STATE (context);
 			CHECK_CHILD_EX (child_frame, ip);
 			if (vt)
 				*sp = valuetype_this;
@@ -4139,12 +4117,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 
 			interp_exec_method (&child_frame, context);
 
-			if (context->has_resume_state) {
-				if (frame == context->handler_frame)
-					SET_RESUME_STATE (context);
-				else
-					goto exit_frame;
-			}
+			CHECK_RESUME_STATE (context);
 
 			CHECK_CHILD_EX (child_frame, ip - 2);
 			/*
@@ -5289,12 +5262,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 			frame->ip = ip;
 			sp = do_icall (frame, NULL, *ip, sp, rtm->data_items [*(guint16 *)(ip + 1)]);
 			EXCEPTION_CHECKPOINT;
-			if (context->has_resume_state) {
-				if (frame == context->handler_frame)
-					SET_RESUME_STATE (context);
-				else
-					goto exit_frame;
-			}
+			CHECK_RESUME_STATE (context);
 			ip += 2;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_MONO_LDPTR) 
@@ -5363,12 +5331,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 				 */
 				do_debugger_tramp (ss_tramp, frame);
 
-				if (context->has_resume_state) {
-					if (frame == context->handler_frame)
-						SET_RESUME_STATE (context);
-					else
-						goto exit_frame;
-				}
+				CHECK_RESUME_STATE (context);
 			}
 			++ip;
 			MINT_IN_BREAK;
@@ -5390,12 +5353,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, guint16 *st
 			/* Use the same trampoline as the JIT */
 			do_debugger_tramp (bp_tramp, frame);
 
-			if (context->has_resume_state) {
-				if (frame == context->handler_frame)
-					SET_RESUME_STATE (context);
-				else
-					goto exit_frame;
-			}
+			CHECK_RESUME_STATE (context);
 
 			++ip;
 			MINT_IN_BREAK;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2287,7 +2287,8 @@ handle_exception_first_pass (MonoContext *ctx, MonoObject *obj, gint32 *out_filt
 					}
 
 					if (ji->is_interp) {
-						filtered = mini_get_interp_callbacks ()->run_filter (&frame, (MonoException*)ex_obj, i, ei->data.filter);
+						/* The filter ends where the exception handler starts */
+						filtered = mini_get_interp_callbacks ()->run_filter (&frame, (MonoException*)ex_obj, i, ei->data.filter, ei->handler_start);
 					} else {
 						filtered = call_filter (ctx, ei->data.filter);
 					}
@@ -2829,7 +2830,7 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 					} else {
 						mini_set_abort_threshold (&frame);
 						if (in_interp) {
-							gboolean has_ex = mini_get_interp_callbacks ()->run_finally (&frame, i, ei->handler_start);
+							gboolean has_ex = mini_get_interp_callbacks ()->run_finally (&frame, i, ei->handler_start, ei->data.handler_end);
 							if (has_ex)
 								return 0;
 						} else {

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -320,6 +320,7 @@ TESTS_CS_SRC=		\
 	merp-json-valid.cs		\
 	exception19.cs		\
 	exception20.cs		\
+	exception21.cs		\
 	typeload-unaligned.cs	\
 	struct.cs		\
 	valuetype-gettype.cs	\

--- a/mono/tests/exception21.cs
+++ b/mono/tests/exception21.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading;
+
+public class Program {
+
+	public static void Main (string[] args) {
+		int caughts = 0;
+		int finallys = 0;
+		try {
+			try {
+				throw new Exception ();
+			} finally {
+				finallys++;
+				throw new Exception ();
+			}
+		} catch (Exception) {
+			caughts++;
+			Console.WriteLine ("Caught");
+		}
+		if (caughts != 1)
+			Environment.Exit (1);
+		if (finallys != 1)
+			Environment.Exit (2);
+		Console.WriteLine ("Exit");
+	}
+}


### PR DESCRIPTION
During EH, we can have the same frame twice on the stack, the original one and when invoking clauses in the same frame from EH. When having a resume state, we need to check if we should catch it in the current frame, or the original.

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
