### PR TITLE
[2018-12] Fix IndexOutOfRangeException in MethodInfo.ReturnParameter.IsDefined(type)

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection/ParameterInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/ParameterInfoTest.cs
@@ -562,6 +562,15 @@ namespace MonoTests.System.Reflection
 			var optionalCustomModifiers = parameter.GetOptionalCustomModifiers ();
 			Assert.AreEqual (new[] { typeof (C), typeof (C), typeof (D), typeof (C) }, optionalCustomModifiers);
 		}
-#endif		
+#endif
+
+		[Test]
+		public void ReturnParameter_IsDefined_False ()
+		{
+			Type type = typeof (object);
+			MethodInfo method = type.GetMethod ("ToString");
+			ParameterInfo paramInfo = method.ReturnParameter;
+			Assert.IsFalse (paramInfo.IsDefined (typeof (Attribute)));
+		}
 	}
 }

--- a/mcs/class/referencesource/mscorlib/system/attribute.cs
+++ b/mcs/class/referencesource/mscorlib/system/attribute.cs
@@ -106,7 +106,10 @@ namespace System {
             var method = ((MonoMethod)(MethodInfo) member).GetBaseMethod ();
 
             while (true) {
-                var param = method.GetParametersInternal () [parameter.Position];
+                var parameters = method.GetParametersInternal ();
+                if (parameters?.Length == 0 || parameter.Position < 0)
+                    return false;
+                var param = parameters [parameter.Position];
                 if (param.IsDefined (attributeType, false))
                     return true;
 


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/12069


Backport of #12090.

/cc @marek-safar @MaximLipnin