### PR TITLE
[2018-10] Fix IndexOutOfRangeException in MethodInfo.ReturnParameter.IsDefined(type)

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection/ParameterInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/ParameterInfoTest.cs
@@ -526,5 +526,14 @@ namespace MonoTests.System.Reflection
 			Assert.AreEqual (new DateTime (1), type.GetMethod ("M4").GetParameters () [0].RawDefaultValue);
 			Assert.AreEqual (null, type.GetMethod ("M5").GetParameters () [0].RawDefaultValue);
 		}		
+
+		[Test]
+		public void ReturnParameter_IsDefined_False ()
+		{
+			Type type = typeof (object);
+			MethodInfo method = type.GetMethod ("ToString");
+			ParameterInfo paramInfo = method.ReturnParameter;
+			Assert.IsFalse (paramInfo.IsDefined (typeof (Attribute)));
+		}
 	}
 }

--- a/mcs/class/referencesource/mscorlib/system/attribute.cs
+++ b/mcs/class/referencesource/mscorlib/system/attribute.cs
@@ -106,7 +106,10 @@ namespace System {
             var method = ((MethodInfo) member).GetBaseMethod ();
 
             while (true) {
-                var param = method.GetParametersInternal () [parameter.Position];
+                var parameters = method.GetParametersInternal ();
+                if (parameters?.Length == 0 || parameter.Position < 0)
+                    return false;
+                var param = parameters [parameter.Position];
                 if (param.IsDefined (attributeType, false))
                     return true;
 


### PR DESCRIPTION
Fixes #12069

Backport of #12090.