### PR TITLE
[coop] Add high level suspend policy accessors

### DIFF
--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1651,7 +1651,7 @@ mono_get_version_info (void)
 #endif
 #endif
 
-	g_string_append_printf (output, "\tSuspend:       %s\n", mono_threads_suspend_policy_name ());
+	g_string_append_printf (output, "\tSuspend:       %s\n", mono_threads_suspend_policy_name (mono_threads_suspend_policy ()));
 
 	return g_string_free (output, FALSE);
 }

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -646,7 +646,7 @@ mono_native_state_add_version (MonoStateWriter *writer)
 #endif
 #endif
 
-	const char *susp_policy = mono_threads_suspend_policy_name ();
+	const char *susp_policy = mono_threads_suspend_policy_name (mono_threads_suspend_policy ());
 	assert_has_space (writer);
 	mono_state_writer_indent (writer);
 	mono_state_writer_object_key (writer, "suspend");

--- a/mono/utils/mono-threads-coop.h
+++ b/mono/utils/mono-threads-coop.h
@@ -28,8 +28,40 @@ extern volatile size_t mono_polling_required;
 void
 mono_threads_state_poll (void);
 
+// 0 also used internally for uninitialized
+typedef enum {
+	MONO_THREADS_SUSPEND_FULL_PREEMPTIVE = 1,
+	MONO_THREADS_SUSPEND_FULL_COOP       = 2,
+	MONO_THREADS_SUSPEND_HYBRID          = 3,
+} MonoThreadsSuspendPolicy;
+
+static inline gboolean
+mono_threads_suspend_policy_are_safepoints_enabled (MonoThreadsSuspendPolicy p)
+{
+	switch (p) {
+	case MONO_THREADS_SUSPEND_FULL_COOP:
+	case MONO_THREADS_SUSPEND_HYBRID:
+		return TRUE;
+	default:
+		return FALSE;
+	}
+}
+
+static inline gboolean
+mono_threads_suspend_policy_is_multiphase_stw_enabled (MonoThreadsSuspendPolicy p)
+{
+	/* So far, hybrid suspend is the only one using a multi-phase STW */
+	return p == MONO_THREADS_SUSPEND_HYBRID;
+}
+
+gboolean
+mono_threads_suspend_policy_is_blocking_transition_enabled (MonoThreadsSuspendPolicy p);
+
+MonoThreadsSuspendPolicy
+mono_threads_suspend_policy (void);
+
 const char*
-mono_threads_suspend_policy_name (void);
+mono_threads_suspend_policy_name (MonoThreadsSuspendPolicy p);
 
 gboolean
 mono_threads_is_blocking_transition_enabled (void);
@@ -43,14 +75,13 @@ mono_threads_is_hybrid_suspension_enabled (void);
 static inline gboolean
 mono_threads_are_safepoints_enabled (void)
 {
-	return mono_threads_is_cooperative_suspension_enabled () || mono_threads_is_hybrid_suspension_enabled ();
+	return mono_threads_suspend_policy_are_safepoints_enabled (mono_threads_suspend_policy ());
 }
 
 static inline gboolean
 mono_threads_is_multiphase_stw_enabled (void)
 {
-	/* So far, hybrid suspend is the only one using a multi-phase STW */
-	return mono_threads_is_hybrid_suspension_enabled ();
+	return mono_threads_suspend_policy_is_multiphase_stw_enabled (mono_threads_suspend_policy ());
 }
 
 static inline void
@@ -60,16 +91,8 @@ mono_threads_safepoint (void)
 		mono_threads_state_poll ();
 }
 
-// 0 also used internally for uninitialized
-typedef enum {
-	MONO_THREADS_SUSPEND_FULL_PREEMPTIVE = 1,
-	MONO_THREADS_SUSPEND_FULL_COOP       = 2,
-	MONO_THREADS_SUSPEND_HYBRID          = 3,
-} MonoThreadsSuspendPolicy;
-
 /* Don't use this. */
 void mono_threads_suspend_override_policy (MonoThreadsSuspendPolicy new_policy);
-
 
 /*
  * The following are used when detaching a thread. We need to pass the MonoThreadInfo*


### PR DESCRIPTION
- mono_threads_suspend_policy_name
- mono_threads_suspend_policy_are_safepoints_enabled
- mono_threads_suspend_policy_is_multiphase_stw_enabled
- mono_threads_suspend_policy_is_blocking_transition_enabled

The normal accessors (mono_threads_are_safepoints_enabled, etc) just apply the
policy acessors to the current policy
