### PR TITLE
Handle MONO_TYPE_TYPEDBYREF return values

### DIFF
--- a/mono/mini/aot-runtime-wasm.c
+++ b/mono/mini/aot-runtime-wasm.c
@@ -35,6 +35,7 @@ handle_enum:
 	case MONO_TYPE_CLASS:
 	case MONO_TYPE_OBJECT:
 	case MONO_TYPE_STRING:
+	case MONO_TYPE_TYPEDBYREF:
 		return 'I';
 	case MONO_TYPE_R4:
 		return 'F';

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -1106,6 +1106,7 @@ static InterpMethodArguments* build_args_from_sig (MonoMethodSignature *sig, Int
 		case MONO_TYPE_U8:
 		case MONO_TYPE_VALUETYPE:
 		case MONO_TYPE_GENERICINST:
+		case MONO_TYPE_TYPEDBYREF:
 			margs->retval = &(frame->retval->data.p);
 			margs->is_float_ret = 0;
 			break;


### PR DESCRIPTION
MonoTests.System.TypedReferenceTest.MakeTypedReference was
aborting in wasm due to missing TypedReference support.
