### PR TITLE
[coop] Always emit safepoints and blocking transitions, except on WASM

### DIFF
--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -1706,17 +1706,18 @@ typedef struct EmitGCSafeTransitionBuilder {
 static gboolean
 gc_safe_transition_builder_init (GCSafeTransitionBuilder *builder, MonoMethodBuilder *mb, gboolean func_param)
 {
-	if (mono_threads_is_blocking_transition_enabled ()) {
-		builder->mb = mb;
-		builder->func_param = func_param;
-		builder->coop_gc_stack_dummy = -1;
-		builder->coop_gc_var = -1;
+	builder->mb = mb;
+	builder->func_param = func_param;
+	builder->coop_gc_stack_dummy = -1;
+	builder->coop_gc_var = -1;
 #ifndef DISABLE_COM
-		builder->coop_cominterop_fnptr = -1;
+	builder->coop_cominterop_fnptr = -1;
 #endif
-		return TRUE;
-	} else
-		return FALSE;
+#if defined (TARGET_WASM)
+	return FALSE;
+#else
+	return TRUE;
+#endif
 }
 
 /**
@@ -1912,12 +1913,8 @@ emit_native_wrapper_ilgen (MonoImage *image, MonoMethodBuilder *mb, MonoMethodSi
 		mono_mb_emit_calli (mb, csig);
 	} else if (MONO_CLASS_IS_IMPORT (mb->method->klass)) {
 #ifndef DISABLE_COM
-		if (!mono_threads_is_blocking_transition_enabled ()) {
-			mono_mb_emit_cominterop_call (mb, csig, &piinfo->method);
-		} else {
-			mono_mb_emit_ldloc (mb, gc_safe_transition_builder.coop_cominterop_fnptr);
-			mono_mb_emit_cominterop_call_function_pointer (mb, csig);
-		}
+		mono_mb_emit_ldloc (mb, gc_safe_transition_builder.coop_cominterop_fnptr);
+		mono_mb_emit_cominterop_call_function_pointer (mb, csig);
 #else
 		g_assert_not_reached ();
 #endif
@@ -4164,6 +4161,11 @@ emit_thunk_invoke_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 	int pos_leave, coop_gc_var = 0, coop_gc_stack_dummy = 0;
 	MonoExceptionClause *clause;
 	MonoType *object_type = mono_get_object_type ();
+#if defined (TARGET_WASM)
+	const gboolean do_blocking_transition = FALSE;
+#else
+	const gboolean do_blocking_transition = TRUE;
+#endif
 
 	/* local 0 (temp for exception object) */
 	mono_mb_add_local (mb, object_type);
@@ -4172,7 +4174,7 @@ emit_thunk_invoke_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 	if (!MONO_TYPE_IS_VOID (sig->ret))
 		mono_mb_add_local (mb, sig->ret);
 
-	if (mono_threads_is_blocking_transition_enabled ()) {
+	if (do_blocking_transition) {
 		/* local 4, dummy local used to get a stack address for suspend funcs */
 		coop_gc_stack_dummy = mono_mb_add_local (mb, mono_get_int_type ());
 		/* local 5, the local to be used when calling the suspend funcs */
@@ -4184,7 +4186,7 @@ emit_thunk_invoke_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 	mono_mb_emit_byte (mb, CEE_LDNULL);
 	mono_mb_emit_byte (mb, CEE_STIND_REF);
 
-	if (mono_threads_is_blocking_transition_enabled ()) {
+	if (do_blocking_transition) {
 		mono_mb_emit_ldloc_addr (mb, coop_gc_stack_dummy);
 		mono_mb_emit_icall (mb, mono_threads_enter_gc_unsafe_region_unbalanced);
 		mono_mb_emit_stloc (mb, coop_gc_var);
@@ -4259,7 +4261,7 @@ emit_thunk_invoke_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 			mono_mb_emit_op (mb, CEE_BOX, mono_class_from_mono_type_internal (sig->ret));
 	}
 
-	if (mono_threads_is_blocking_transition_enabled ()) {
+	if (do_blocking_transition) {
 		mono_mb_emit_ldloc (mb, coop_gc_var);
 		mono_mb_emit_ldloc_addr (mb, coop_gc_stack_dummy);
 		mono_mb_emit_icall (mb, mono_threads_exit_gc_unsafe_region_unbalanced);
@@ -6306,7 +6308,7 @@ emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 		/* FIXME: we only want the transitions for hybrid suspend.  Q: What to do about AOT? */
 		need_gc_safe = gc_safe_transition_builder_init (&gc_safe_transition_builder, mb, FALSE);
 
-		if (G_UNLIKELY (need_gc_safe))
+		if (need_gc_safe)
 			gc_safe_transition_builder_add_locals (&gc_safe_transition_builder);
 	}
 
@@ -6439,7 +6441,7 @@ emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 			mono_mb_emit_ldarg (mb, i);
 	}
 
-	if (G_UNLIKELY (need_gc_safe))
+	if (need_gc_safe)
 		gc_safe_transition_builder_emit_enter (&gc_safe_transition_builder, &piinfo->method, aot);
 
 	if (aot) {
@@ -6451,7 +6453,7 @@ emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 		mono_mb_emit_native_call (mb, call_sig, piinfo->addr);
 	}
 
-	if (G_UNLIKELY (need_gc_safe))
+	if (need_gc_safe)
 		gc_safe_transition_builder_emit_exit (&gc_safe_transition_builder);
 
 	// Copy back ObjOut and ObjInOut from locals through parameters.
@@ -6469,7 +6471,7 @@ emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 	}
 	g_free (handles_locals);
 
-	if (G_UNLIKELY (need_gc_safe))
+	if (need_gc_safe)
 		gc_safe_transition_builder_cleanup (&gc_safe_transition_builder);
 
 	if (check_exceptions)

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -13001,7 +13001,7 @@ mono_compile_assembly (MonoAssembly *ass, guint32 opts, const char *aot_options,
 		acfg->is_full_aot = TRUE;
 	}
 
-	if (mono_threads_are_safepoints_enabled ())
+	if (mini_safepoints_enabled ())
 		acfg->flags = (MonoAotFileFlags)(acfg->flags | MONO_AOT_FILE_FLAG_SAFEPOINTS);
 
 	// The methods in dedup-emit amodules must be available on runtime startup

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -6759,8 +6759,6 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_GC_SAFE_POINT: {
 			guint8 *br [1];
 
-			g_assert (mono_threads_are_safepoints_enabled ());
-
 			amd64_test_membase_imm_size (code, ins->sreg1, 0, 1, 4);
 			br[0] = code; x86_branch8 (code, X86_CC_EQ, 0, FALSE);
 			code = emit_call (cfg, code, MONO_PATCH_INFO_JIT_ICALL, "mono_threads_state_poll", FALSE);

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -6004,8 +6004,6 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_GC_SAFE_POINT: {
 			guint8 *buf [1];
 
-			g_assert (mono_threads_are_safepoints_enabled ());
-
 			ARM_LDR_IMM (code, ARMREG_IP, ins->sreg1, 0);
 			ARM_CMP_REG_IMM (code, ARMREG_IP, 0, 0);
 			buf [0] = code;

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -4665,8 +4665,6 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_GC_SAFE_POINT: {
 			guint8 *buf [1];
 
-			g_assert (mono_threads_are_safepoints_enabled ());
-
 			arm_ldrx (code, ARMREG_IP1, ins->sreg1, 0);
 			/* Call it if it is non-null */
 			buf [0] = code;

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4665,8 +4665,7 @@ register_icalls (void)
 	register_icall (mono_thread_interruption_checkpoint, "mono_thread_interruption_checkpoint", "object", FALSE);
 	register_icall (mono_thread_force_interruption_checkpoint_noraise, "mono_thread_force_interruption_checkpoint_noraise", "object", FALSE);
 
-	if (mono_threads_are_safepoints_enabled ())
-		register_icall (mono_threads_state_poll, "mono_threads_state_poll", "void", FALSE);
+	register_icall (mono_threads_state_poll, "mono_threads_state_poll", "void", FALSE);
 
 #ifndef MONO_ARCH_NO_EMULATE_LONG_MUL_OPTS
 	register_opcode_emulation (OP_LMUL, "__emul_lmul", "long long long", mono_llmult, "mono_llmult", FALSE);

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -4642,8 +4642,6 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_GC_SAFE_POINT: {
 			short *br;
 
-			g_assert (mono_threads_are_safepoints_enabled ());
-
 			s390_ltg (code, s390_r0, 0, ins->sreg1, 0);	
 			s390_jz  (code, 0); CODEPTR(code, br);
 			mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_ABS,

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -4833,8 +4833,6 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_GC_SAFE_POINT: {
 			guint8 *br [1];
 
-			g_assert (mono_threads_are_safepoints_enabled ());
-
 			x86_test_membase_imm (code, ins->sreg1, 0, 1);
 			br[0] = code; x86_branch8 (code, X86_CC_EQ, 0, FALSE);
 			code = emit_call (cfg, code, MONO_PATCH_INFO_JIT_ICALL, "mono_threads_state_poll");

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -2851,7 +2851,7 @@ mono_create_gc_safepoint (MonoCompile *cfg, MonoBasicBlock *bblock)
 	if (cfg->verbose_level > 1)
 		printf ("ADDING SAFE POINT TO BB %d\n", bblock->block_num);
 
-	g_assert (mono_threads_are_safepoints_enabled ());
+	g_assert (mini_safepoints_enabled ());
 	NEW_AOTCONST (cfg, poll_addr, MONO_PATCH_INFO_GC_SAFE_POINT_FLAG, (gpointer)&mono_polling_required);
 
 	MONO_INST_NEW (cfg, ins, OP_GC_SAFE_POINT);
@@ -2897,12 +2897,11 @@ mono_insert_safepoints (MonoCompile *cfg)
 {
 	MonoBasicBlock *bb;
 
-	if (!mono_threads_are_safepoints_enabled ())
+	if (!mini_safepoints_enabled ())
 		return;
 
 	if (cfg->method->wrapper_type == MONO_WRAPPER_MANAGED_TO_NATIVE) {
 		WrapperInfo *info = mono_marshal_get_wrapper_info (cfg->method);
-		g_assert (mono_threads_are_safepoints_enabled ());
 		gpointer poll_func = (gpointer)&mono_threads_state_poll;
 
 		if (info && info->subtype == WRAPPER_SUBTYPE_ICALL_WRAPPER && info->d.icall.func == poll_func) {
@@ -3211,7 +3210,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 		cfg->gen_sdb_seq_points = FALSE;
 	}
 	/* coop requires loop detection to happen */
-	if (mono_threads_are_safepoints_enabled ())
+	if (mini_safepoints_enabled ())
 		cfg->opt |= MONO_OPT_LOOP;
 	if (cfg->backend->explicit_null_checks) {
 		/* some platforms have null pages, so we can't SIGSEGV */

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2791,4 +2791,14 @@ MonoType*   mini_native_type_replace_type (MonoType *type) MONO_LLVM_INTERNAL;
 MonoMethod*
 mini_method_to_shared (MonoMethod *method); // null if not shared
 
+static inline gboolean
+mini_safepoints_enabled (void)
+{
+#if defined (TARGET_WASM)
+	return FALSE;
+#else
+	return TRUE;
+#endif
+}
+
 #endif /* __MONO_MINI_H__ */


### PR DESCRIPTION
Always emit safepoints and blocking transitions on all targets except WASM.

Addresses #11765.

---

This is an alternative to #11833 which was over-engineered.  The rationale is that we should always emit the machinery at compile time and just ignore it at runtime if the host suspend policy says so.
