### PR TITLE
Allow urls with a blob scheme to pass validation in WASM

### DIFF
--- a/mcs/class/System.Net.Http/System.Net.Http/HttpRequestMessage.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpRequestMessage.cs
@@ -101,6 +101,11 @@ namespace System.Net.Http
 			if (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)
 				return true;
 
+#if WASM
+			if (uri.Scheme == "blob")
+				return true;
+#endif
+
 			// Mono URI handling which does not distinguish between file and url absolute paths without scheme
 			if (uri.Scheme == Uri.UriSchemeFile && uri.OriginalString.StartsWith ("/", StringComparison.Ordinal))
 				return true;

--- a/sdks/wasm/tests/browser/HttpTestSuite.cs
+++ b/sdks/wasm/tests/browser/HttpTestSuite.cs
@@ -31,13 +31,9 @@ namespace TestSuite
                 return httpClient.BaseAddress.ToString();
         }
 
-        private static async Task<object> RequestStream(bool streamingEnabled = true)
+        private static async Task<object> RequestStream(bool streamingEnabled, string url)
         {
             var requestTcs = new TaskCompletionSource<object>();
-
-            string ApiFile = "base/publish/NowIsTheTime.txt";
-            //string ApiFile = "SampleJPGImage_30mbmb.jpg";
-
             cts = new CancellationTokenSource();
 
             try
@@ -47,7 +43,7 @@ namespace TestSuite
                     Console.WriteLine($"streaming supported: { WasmHttpMessageHandler.StreamingSupported}");
                     WasmHttpMessageHandler.StreamingEnabled = streamingEnabled;
                     Console.WriteLine($"streaming enabled: {WasmHttpMessageHandler.StreamingEnabled}");                
-                    using (var rspMsg = await httpClient.GetAsync(ApiFile, cts.Token))
+                    using (var rspMsg = await httpClient.GetAsync(url, cts.Token))
                     {
                         requestTcs.SetResult((int)rspMsg.Content?.ReadAsStreamAsync().Result.Length);
                     }
@@ -55,19 +51,15 @@ namespace TestSuite
             }
             catch (Exception exc2)
             {
-                requestTcs.SetException(new Exception("bad"));
+                requestTcs.SetException(exc2);
             }
 
             return requestTcs.Task;
         }
 
-        private static async Task<object> RequestByteArray(bool streamingEnabled = true)
+        private static async Task<object> RequestByteArray(bool streamingEnabled, string url)
         {
             var requestTcs = new TaskCompletionSource<object>();
-
-            string ApiFile = "base/publish/NowIsTheTime.txt";
-            //string ApiFile = "SampleJPGImage_30mbmb.jpg";
-
             cts = new CancellationTokenSource();
 
             try
@@ -77,8 +69,9 @@ namespace TestSuite
                     Console.WriteLine($"streaming supported: { WasmHttpMessageHandler.StreamingSupported}");
                     WasmHttpMessageHandler.StreamingEnabled = streamingEnabled;
                     Console.WriteLine($"streaming enabled: {WasmHttpMessageHandler.StreamingEnabled}");
-
-                    using (var rspMsg = await httpClient.GetAsync(ApiFile, cts.Token))
+                    Console.WriteLine($"url: {url}");
+                    
+                    using (var rspMsg = await httpClient.GetAsync(url, cts.Token))
                     {
                         requestTcs.SetResult(rspMsg.Content?.ReadAsByteArrayAsync().Result.Length);
                     }
@@ -86,7 +79,7 @@ namespace TestSuite
             }
             catch (Exception exc2)
             {
-                requestTcs.SetException(new Exception("bad"));
+                requestTcs.SetException(exc2);
             }
             return requestTcs.Task;
         }

--- a/sdks/wasm/tests/browser/http-spec.js
+++ b/sdks/wasm/tests/browser/http-spec.js
@@ -59,7 +59,7 @@ describe("The WebAssembly Browser Test Suite",function(){
       //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
       var _document = karmaHTML.httpspec.document;
       
-      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestStream", [true]).then(
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestStream", [true, "base/publish/NowIsTheTime.txt"]).then(
         (result) => 
         {
             //console.log("we are here: " + result);
@@ -74,13 +74,82 @@ describe("The WebAssembly Browser Test Suite",function(){
 
       );
       
-    }, DEFAULT_TIMEOUT);    
+    }, DEFAULT_TIMEOUT);
+
+    it('RequestStream: blob should return size of Stream with streaming', (done) => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+      var blob = new Blob([JSON.stringify({hello: "world"}, null, 2)], {type : 'application/json'});
+      var blobUrl = URL.createObjectURL(blob);
+      
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestStream", [true, blobUrl]).then(
+        (result) => 
+        {
+            //console.log("we are here: " + result);
+            try {
+              assert.equal(result, 22, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+      
+      URL.revokeObjectURL(blobUrl);
+    }, DEFAULT_TIMEOUT);
 
     it('RequestByteArray: should return size of ByteArrray with streaming', (done) => {
       //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
       var _document = karmaHTML.httpspec.document;
       
-      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestByteArray", [true]).then(
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestByteArray", [true, "base/publish/NowIsTheTime.txt"]).then(
+        (result) => 
+        {
+            //console.log("we are here: " + result);
+            try {
+              assert.equal(result, 500000, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+      
+    }, DEFAULT_TIMEOUT);
+
+    it('RequestByteArray: blob should return size of ByteArrray with streaming', (done) => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+      var blob = new Blob([JSON.stringify({hello: "world"}, null, 2)], {type : 'application/json'});
+      var blobUrl = URL.createObjectURL(blob);
+
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestByteArray", [true, blobUrl]).then(
+        (result) => 
+        {
+            //console.log("we are here: " + result);
+            try {
+              assert.equal(result, 22, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+      
+      URL.revokeObjectURL(blobUrl);
+    }, DEFAULT_TIMEOUT);
+
+    it('RequestStream: should return size of Stream without streaming', (done) => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+      
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestStream", [false, "base/publish/NowIsTheTime.txt"]).then(
         (result) => 
         {
             //console.log("we are here: " + result);
@@ -97,17 +166,18 @@ describe("The WebAssembly Browser Test Suite",function(){
       
     }, DEFAULT_TIMEOUT);    
 
-
-    it('RequestStream: should return size of Stream without streaming', (done) => {
+    it('RequestStream: blob should return size of Stream without streaming', (done) => {
       //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
       var _document = karmaHTML.httpspec.document;
-      
-      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestStream", [false]).then(
+      var blob = new Blob([JSON.stringify({hello: "world"}, null, 2)], {type : 'application/json'});
+      var blobUrl = URL.createObjectURL(blob);
+
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestStream", [false, blobUrl]).then(
         (result) => 
         {
             //console.log("we are here: " + result);
             try {
-              assert.equal(result, 500000, "result doesn't match length");
+              assert.equal(result, 22, "result doesn't match length");
               done()
             } catch (e) {
               done.fail(e);
@@ -117,13 +187,14 @@ describe("The WebAssembly Browser Test Suite",function(){
 
       );
       
+      URL.revokeObjectURL(blobUrl);
     }, DEFAULT_TIMEOUT);    
 
     it('RequestByteArray: should return size of ByteArrray without streaming', (done) => {
       //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
       var _document = karmaHTML.httpspec.document;
       
-      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestByteArray", [false]).then(
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestByteArray", [false, "base/publish/NowIsTheTime.txt"]).then(
         (result) => 
         {
             //console.log("we are here: " + result);
@@ -138,8 +209,32 @@ describe("The WebAssembly Browser Test Suite",function(){
 
       );
       
-    }, DEFAULT_TIMEOUT);    
-    
+    }, DEFAULT_TIMEOUT);
+
+    it('RequestByteArray: blob should return size of ByteArrray without streaming', (done) => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+      var blob = new Blob([JSON.stringify({hello: "world"}, null, 2)], {type : 'application/json'});
+      var blobUrl = URL.createObjectURL(blob);
+
+      _document.Module.BINDING.call_static_method("[HttpTestSuite]TestSuite.Program:RequestByteArray", [false, blobUrl]).then(
+        (result) => 
+        {
+            //console.log("we are here: " + result);
+            try {
+              assert.equal(result, 22, "result doesn't match length");
+              done()
+            } catch (e) {
+              done.fail(e);
+            }
+        },
+        (error) => done.fail(error)
+
+      );
+      
+      URL.revokeObjectURL(blobUrl);
+    }, DEFAULT_TIMEOUT);
+
     it('GetStreamAsync_ReadZeroBytes_Success: should return 0', (done) => {
       //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
       var _document = karmaHTML.httpspec.document;


### PR DESCRIPTION
Relax HttpMessageRequest url scheme validation for wasm so that urls with a blob scheme make it to the host backend. Fixes #11681

note: the browser tests fail when running chrome 71 in headless mode, they work in chrome 70 and 72