### PR TITLE
Skip TypedReferenceTest fixture for WASM as it causes a runtime abort

### DIFF
--- a/mcs/class/corlib/Test/System/TypedReferenceTest.cs
+++ b/mcs/class/corlib/Test/System/TypedReferenceTest.cs
@@ -34,6 +34,7 @@ namespace MonoTests.System
 {
 #if !MONODROID // Type load segfaults the runtime on ARM64 (https://gist.github.com/grendello/334d06c45376602a9afc)
 	[TestFixture]
+	[Category("NotWasm")]
 	public class TypedReferenceTest
 	{
 		struct TestFields

--- a/mcs/class/corlib/Test/System/TypedReferenceTest.cs
+++ b/mcs/class/corlib/Test/System/TypedReferenceTest.cs
@@ -34,6 +34,7 @@ namespace MonoTests.System
 {
 #if !MONODROID // Type load segfaults the runtime on ARM64 (https://gist.github.com/grendello/334d06c45376602a9afc)
 	[TestFixture]
+	// Currently causes the WASM runtime to abort
 	[Category("NotWasm")]
 	public class TypedReferenceTest
 	{


### PR DESCRIPTION
The sdks/wasm run-all-corlib target currently aborts in the TypedReferenceTest fixture. Skip it in that case by adding it to the NotWasm category.