### PR TITLE
[crash] Test and fix stability of native crash pipeline(s)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -544,6 +544,8 @@ AC_PROG_LD_GNU
 
 AC_CHECK_HEADERS(sys/filio.h sys/sockio.h netdb.h utime.h sys/utime.h semaphore.h sys/un.h linux/rtc.h sys/syscall.h sys/mkdev.h sys/uio.h sys/param.h sys/sysctl.h libproc.h sys/prctl.h copyfile.h)
 AC_CHECK_HEADERS(sys/param.h sys/socket.h sys/ipc.h sys/utsname.h alloca.h ucontext.h pwd.h sys/select.h netinet/tcp.h netinet/in.h unistd.h sys/types.h link.h asm/sigcontext.h sys/inotify.h arpa/inet.h complex.h unwind.h)
+AC_CHECK_HEADER(unistd.h, [HAVE_UNISTD_H=1], [HAVE_UNISTD_H=0])
+AC_SUBST(HAVE_UNISTD_H)
 AC_CHECK_HEADERS([linux/netlink.h linux/rtnetlink.h],
                   [], [], [#include <stddef.h>
 		  #include <sys/socket.h>

--- a/configure.ac
+++ b/configure.ac
@@ -4744,8 +4744,6 @@ elif test x$target_ios = xno; then
 AC_CHECK_FUNCS(strndup getpwuid_r)
 fi
 
-AM_CONDITIONAL(NEED_VASPRINTF, test x$ac_cv_func_vasprintf = xno || test x$with_overridable_allocators = xyes)
-
 AC_SEARCH_LIBS(sqrtf, m)
 
 # nanosleep may not be part of libc, also search it in other libraries
@@ -5331,7 +5329,7 @@ dnl **********************
 dnl *** checked builds ***
 dnl **********************
 
-AC_ARG_ENABLE(checked_build, [  --enable-checked-build=LIST      To enable checked build (expensive asserts), configure with a comma-separated LIST of checked build modules and then include that same list in the environment variable MONO_CHECK_MODE at runtime. Recognized checked build modules: all, gc, metadata, thread, private_types],[
+AC_ARG_ENABLE(checked_build, [  --enable-checked-build=LIST      To enable checked build (expensive asserts), configure with a comma-separated LIST of checked build modules and then include that same list in the environment variable MONO_CHECK_MODE at runtime. Recognized checked build modules: all, gc, metadata, thread, private_types, crash_reporting],[
 
 	if test x$enable_checked_build != x ; then
 		AC_DEFINE(ENABLE_CHECKED_BUILD,1,[Enable checked build])
@@ -5345,6 +5343,7 @@ AC_ARG_ENABLE(checked_build, [  --enable-checked-build=LIST      To enable check
 		eval "mono_checked_build_test_enable_metadata='yes'"
 		eval "mono_checked_build_test_enable_thread='yes'"
 		eval "mono_checked_build_test_enable_private_types='yes'"
+		eval "mono_checked_build_test_enable_crash_reporting='yes'"
 	fi
 
 	if test "x$mono_checked_build_test_enable_gc" = "xyes"; then
@@ -5362,9 +5361,19 @@ AC_ARG_ENABLE(checked_build, [  --enable-checked-build=LIST      To enable check
 	if test "x$mono_checked_build_test_enable_private_types" = "xyes"; then
 		AC_DEFINE(ENABLE_CHECKED_BUILD_PRIVATE_TYPES, 1, [Enable private types checked build])
 	fi
+
+	if test "x$mono_checked_build_test_enable_crash_reporting" = "xyes"; then
+		# Required
+		with_overridable_allocators=yes
+		AC_DEFINE(ENABLE_OVERRIDABLE_ALLOCATORS,1,[Overridable allocator support enabled])
+
+		AC_DEFINE(ENABLE_CHECKED_BUILD_CRASH_REPORTING, 1, [Enable private types checked build])
+	fi
 ], [])
 
 dnl End of checked builds
+
+AM_CONDITIONAL(NEED_VASPRINTF, test x$ac_cv_func_vasprintf = xno || test x$with_overridable_allocators = xyes)
 
 AC_CHECK_HEADER([malloc.h], 
 		[AC_DEFINE([HAVE_USR_INCLUDE_MALLOC_H], [1], 

--- a/mcs/class/corlib/Mono/Runtime.cs
+++ b/mcs/class/corlib/Mono/Runtime.cs
@@ -204,14 +204,30 @@ namespace Mono {
 			}
 		}
 
+		enum CrashReportLogLevel : int {
+			MonoSummaryNone = 0,
+			MonoSummarySetup,
+			MonoSummarySuspendHandshake,
+			MonoSummaryUnmanagedStacks,
+			MonoSummaryManagedStacks,
+			MonoSummaryStateWriter,
+			MonoSummaryStateWriterDone,
+			MonoSummaryMerpWriter,
+			MonoSummaryMerpInvoke,
+			MonoSummaryCleanup,
+			MonoSummaryDone,
+
+			MonoSummaryDoubleFault
+		}
+
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		static extern int CheckCrashReportLog_internal (IntPtr directory, bool clear);
 
-		static int CheckCrashReportLog (string directory_str, bool clear)
+		static CrashReportLogLevel CheckCrashReportLog (string directory_str, bool clear)
 		{
 			using (var directory_chars = RuntimeMarshal.MarshalString (directory_str))
 			{
-				return CheckCrashReportLog_internal (directory_chars.Value, clear);
+				return (CrashReportLogLevel) CheckCrashReportLog_internal (directory_chars.Value, clear);
 			}
 		}
 

--- a/mcs/class/corlib/Test/System/ExceptionTest.cs
+++ b/mcs/class/corlib/Test/System/ExceptionTest.cs
@@ -528,7 +528,7 @@ namespace MonoTests.System
 			var monoType = Type.GetType ("Mono.Runtime", false);
 			var convert = monoType.GetMethod("CheckCrashReportLog", BindingFlags.NonPublic | BindingFlags.Static);
 			var result = (int) convert.Invoke(null, new object[] { "./", true });
-			var monoSummaryDone = 8;
+			var monoSummaryDone = 10;
 			Assert.AreEqual (monoSummaryDone, result, "#DLC1");
 		}
 

--- a/mcs/class/corlib/Test/System/ExceptionTest.cs
+++ b/mcs/class/corlib/Test/System/ExceptionTest.cs
@@ -527,9 +527,10 @@ namespace MonoTests.System
 		{
 			var monoType = Type.GetType ("Mono.Runtime", false);
 			var convert = monoType.GetMethod("CheckCrashReportLog", BindingFlags.NonPublic | BindingFlags.Static);
-			var result = (int) convert.Invoke(null, new object[] { "./", true });
-			var monoSummaryDone = 10;
-			Assert.AreEqual (monoSummaryDone, result, "#DLC1");
+			var result = convert.Invoke(null, new object[] { "./", true });
+			var enumType = monoType.Assembly.GetType("Mono.Runtime+CrashReportLogLevel");
+			var doneEnum = Enum.Parse(enumType, "MonoSummaryDone");
+			Assert.AreEqual (doneEnum, result, "#DLC1");
 		}
 
 		[Test]

--- a/mono/eglib/eglib-config.h.in
+++ b/mono/eglib/eglib-config.h.in
@@ -19,6 +19,10 @@
 #define G_HAVE_ALLOCA_H
 #endif
 
+#if @HAVE_UNISTD_H@ == 1
+#define G_HAVE_UNISTD_H
+#endif
+
 typedef @GSIZE@ gsize;
 typedef @GSSIZE@ gssize;
 

--- a/mono/eglib/eglib-remap.h
+++ b/mono/eglib/eglib-remap.h
@@ -269,6 +269,8 @@
 #define g_utf8_to_ucs4_fast monoeg_g_utf8_to_ucs4_fast
 #define g_vasprintf monoeg_g_vasprintf
 #define g_win32_getlocale monoeg_g_win32_getlocale
+#define g_assertion_disable_global monoeg_assertion_disable_global
+#define g_assert_abort monoeg_assert_abort
 #define g_assertion_message monoeg_assertion_message
 #define g_get_assertion_message monoeg_get_assertion_message
 #define g_malloc monoeg_malloc

--- a/mono/eglib/eglib-remap.h
+++ b/mono/eglib/eglib-remap.h
@@ -120,6 +120,7 @@
 #define g_markup_parse_context_parse monoeg_g_markup_parse_context_parse
 #define g_memdup monoeg_g_memdup
 #define g_mem_set_vtable monoeg_g_mem_set_vtable
+#define g_mem_get_vtable monoeg_g_mem_get_vtable
 #define g_mkdtemp monoeg_g_mkdtemp
 #define g_module_build_path monoeg_g_module_build_path
 #define g_module_close monoeg_g_module_close

--- a/mono/eglib/eglib-remap.h
+++ b/mono/eglib/eglib-remap.h
@@ -134,7 +134,9 @@
 #define g_pattern_spec_free monoeg_g_pattern_spec_free
 #define g_pattern_spec_new monoeg_g_pattern_spec_new
 #define g_async_safe_fprintf monoeg_g_async_safe_fprintf
+#define g_async_safe_vfprintf monoeg_g_async_safe_vfprintf
 #define g_async_safe_printf monoeg_g_async_safe_printf
+#define g_async_safe_vprintf monoeg_g_async_safe_vprintf
 #define g_print monoeg_g_print
 #define g_printf monoeg_g_printf
 #define g_printerr monoeg_g_printerr

--- a/mono/eglib/eglib-remap.h
+++ b/mono/eglib/eglib-remap.h
@@ -133,6 +133,8 @@
 #define g_pattern_match_string monoeg_g_pattern_match_string
 #define g_pattern_spec_free monoeg_g_pattern_spec_free
 #define g_pattern_spec_new monoeg_g_pattern_spec_new
+#define g_async_safe_fprintf monoeg_g_async_safe_fprintf
+#define g_async_safe_printf monoeg_g_async_safe_printf
 #define g_print monoeg_g_print
 #define g_printf monoeg_g_printf
 #define g_printerr monoeg_g_printerr

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -763,7 +763,10 @@ const char *   g_get_assertion_message (void);
 
 typedef void (*GLogFunc) (const gchar *log_domain, GLogLevelFlags log_level, const gchar *message, gpointer user_data);
 typedef void (*GPrintFunc) (const gchar *string);
+typedef void (*GAbortFunc) (void);
 
+void       g_assertion_disable_global   (GAbortFunc func);
+void       g_assert_abort               (void);
 void       g_log_default_handler     (const gchar *log_domain, GLogLevelFlags log_level, const gchar *message, gpointer unused_data);
 GLogFunc   g_log_set_default_handler (GLogFunc log_func, gpointer user_data);
 GPrintFunc g_set_print_handler       (GPrintFunc func);

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -304,6 +304,7 @@ typedef struct {
 } GMemVTable;
 
 void g_mem_set_vtable (GMemVTable* vtable);
+void g_mem_get_vtable (GMemVTable* vtable);
 
 struct _GMemChunk {
 	guint alloc_size;

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -382,6 +382,8 @@ gint         g_printf          (gchar const *format, ...) G_ATTR_FORMAT_PRINTF(1
 gint         g_fprintf         (FILE *file, gchar const *format, ...) G_ATTR_FORMAT_PRINTF(2, 3);
 gint         g_sprintf         (gchar *string, gchar const *format, ...) G_ATTR_FORMAT_PRINTF(2, 3);
 gint         g_snprintf        (gchar *string, gulong n, gchar const *format, ...) G_ATTR_FORMAT_PRINTF(3, 4);
+inline gint  g_async_safe_printf (gchar const *format, ...) G_ATTR_FORMAT_PRINTF(1, 2);
+inline gint  g_async_safe_fprintf (int handle, gchar const *format, ...) G_ATTR_FORMAT_PRINTF(2, 3);
 gint         g_vasprintf       (gchar **ret, const gchar *fmt, va_list ap);
 #define g_vprintf vprintf
 #define g_vfprintf vfprintf

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -54,6 +54,10 @@
 #include <malloc.h>
 #endif
 
+#ifdef G_HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
 #ifndef offsetof
 #   define offsetof(s_name,n_name) (size_t)(char *)&(((s_name*)0)->m_name)
 #endif
@@ -382,8 +386,6 @@ gint         g_printf          (gchar const *format, ...) G_ATTR_FORMAT_PRINTF(1
 gint         g_fprintf         (FILE *file, gchar const *format, ...) G_ATTR_FORMAT_PRINTF(2, 3);
 gint         g_sprintf         (gchar *string, gchar const *format, ...) G_ATTR_FORMAT_PRINTF(2, 3);
 gint         g_snprintf        (gchar *string, gulong n, gchar const *format, ...) G_ATTR_FORMAT_PRINTF(3, 4);
-inline gint  g_async_safe_printf (gchar const *format, ...) G_ATTR_FORMAT_PRINTF(1, 2);
-inline gint  g_async_safe_fprintf (int handle, gchar const *format, ...) G_ATTR_FORMAT_PRINTF(2, 3);
 gint         g_vasprintf       (gchar **ret, const gchar *fmt, va_list ap);
 #define g_vprintf vprintf
 #define g_vfprintf vfprintf
@@ -1124,6 +1126,49 @@ gboolean   g_file_test (const gchar *filename, GFileTest test);
 #define g_ascii_isalnum isalnum
 
 gchar *g_mkdtemp (gchar *tmpl);
+
+
+/*
+ * Low-level write-based printing functions
+ */
+static inline gint
+g_async_safe_vfprintf (int handle, gchar const *format, va_list args)
+{
+	char print_buff [1024];
+	print_buff [0] = '\0';
+	g_vsnprintf (print_buff, sizeof(print_buff), format, args);
+	int ret = g_write (handle, print_buff, (guint32) strlen (print_buff));
+
+	return ret;
+}
+
+static inline gint
+g_async_safe_fprintf (int handle, gchar const *format, ...)
+{
+	va_list args;
+	va_start (args, format);
+	int ret = g_async_safe_vfprintf (handle, format, args);
+	va_end (args);
+	return ret;
+}
+
+static inline gint
+g_async_safe_vprintf (gchar const *format, va_list args)
+{
+	return g_async_safe_vfprintf (1, format, args);
+}
+
+static inline gint
+g_async_safe_printf (gchar const *format, ...)
+{
+	va_list args;
+	va_start (args, format);
+	int ret = g_async_safe_vfprintf (1, format, args);
+	va_end (args);
+
+	return ret;
+}
+
 
 /*
  * Pattern matching

--- a/mono/eglib/gmem.c
+++ b/mono/eglib/gmem.c
@@ -48,11 +48,23 @@ g_mem_set_vtable (GMemVTable* vtable)
 	sGMemVTable.free = vtable->free ? vtable->free : free;
 }
 
+void
+g_mem_get_vtable (GMemVTable* vtable)
+{
+	*vtable = sGMemVTable;
+}
+
 #define G_FREE_INTERNAL sGMemVTable.free
 #define G_REALLOC_INTERNAL sGMemVTable.realloc
 #define G_CALLOC_INTERNAL sGMemVTable.calloc
 #define G_MALLOC_INTERNAL sGMemVTable.malloc
 #else
+
+void
+g_mem_get_vtable (GMemVTable* vtable)
+{
+	memset (vtable, 0, sizeof (*vtable));
+}
 
 void
 g_mem_set_vtable (GMemVTable* vtable)

--- a/mono/eglib/goutput.c
+++ b/mono/eglib/goutput.c
@@ -40,6 +40,23 @@ static GPrintFunc stdout_handler, stderr_handler;
 static void default_stdout_handler (const gchar *string);
 static void default_stderr_handler (const gchar *string);
 
+static GAbortFunc internal_abort_func;
+
+void
+g_assertion_disable_global (GAbortFunc abort_func)
+{
+	internal_abort_func = abort_func;
+}
+
+void
+g_assert_abort (void)
+{
+	if (internal_abort_func)
+		internal_abort_func ();
+	else
+		abort ();
+}
+
 void
 g_printv (const gchar *format, va_list args)
 {
@@ -122,8 +139,11 @@ g_logv_nofree (const gchar *log_domain, GLogLevelFlags log_level, const gchar *f
 {
 	char *msg;
 
-	if (g_vasprintf (&msg, format, args) < 0)
+	if (internal_abort_func) {
+		msg = NULL;
+	} else if (g_vasprintf (&msg, format, args) < 0) {
 		return NULL;
+	}
 
 	g_logstr (log_domain, log_level, msg);
 	return msg;
@@ -236,7 +256,7 @@ g_log_default_handler (const gchar *log_domain, GLogLevelFlags log_level, const 
 {
 	android_log (to_android_priority (log_level), log_domain, message);
 	if (log_level & fatal)
-		abort ();
+		g_assert_abort ();
 }
 
 static void
@@ -277,7 +297,7 @@ g_log_default_handler (const gchar *log_domain, GLogLevelFlags log_level, const 
 {
 	asl_log (NULL, NULL, to_asl_priority (log_level), "%s", message);
 	if (log_level & fatal)
-		abort ();
+		g_assert_abort ();
 }
 
 static void
@@ -307,7 +327,7 @@ g_log_default_handler (const gchar *log_domain, GLogLevelFlags log_level, const 
 	if (log_level & fatal) {
 		fflush (stdout);
 		fflush (stderr);
-		abort ();
+		g_assert_abort ();
 	}
 }
 

--- a/mono/eglib/goutput.c
+++ b/mono/eglib/goutput.c
@@ -31,10 +31,6 @@
 #include <stdlib.h>
 #include <glib.h>
 
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
-
 /* The current fatal levels, error is always fatal */
 static GLogLevelFlags fatal = G_LOG_LEVEL_ERROR;
 static GLogFunc default_log_func;
@@ -59,44 +55,6 @@ g_assert_abort (void)
 		internal_abort_func ();
 	else
 		abort ();
-}
-
-static int
-async_safe_vfprintf (int handle, gchar const *format, va_list args)
-{
-	char __buff [256];
-	__buff [0] = '\0';
-	g_vsnprintf (__buff, sizeof(__buff), format, args);
-	int ret = g_write (handle, __buff, (guint32) strlen (__buff));
-
-	return ret;
-}
-
-inline int
-g_async_safe_fprintf (int handle, gchar const *format, ...)
-{
-	va_list args;
-	va_start (args, format);
-	int ret = async_safe_vfprintf (handle, format, args);
-	va_end (args);
-	return ret;
-}
-
-static int
-async_safe_vprintf (gchar const *format, va_list args)
-{
-	return async_safe_vfprintf (1, format, args);
-}
-
-inline int
-g_async_safe_printf (gchar const *format, ...)
-{
-	va_list args;
-	va_start (args, format);
-	int ret = async_safe_vfprintf (1, format, args);
-	va_end (args);
-
-	return ret;
 }
 
 void
@@ -182,7 +140,7 @@ g_logv_nofree (const gchar *log_domain, GLogLevelFlags log_level, const gchar *f
 	char *msg;
 
 	if (internal_abort_func) {
-		async_safe_vprintf (format, args);
+		g_async_safe_vprintf (format, args);
 		return NULL;
 	} else if (g_vasprintf (&msg, format, args) < 0) {
 		return NULL;

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -35,6 +35,7 @@
 #include <mono/utils/mono-mmap.h>
 #include <mono/utils/mono-io-portability.h>
 #include <mono/utils/atomic.h>
+#include <mono/utils/mono-proclib.h>
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/assembly.h>
 #include <mono/metadata/object-internals.h>
@@ -1067,7 +1068,7 @@ mono_image_load_time_date_stamp (MonoImage *image)
 		return;
 
 	gunichar2 *uni_name = g_utf8_to_utf16 (image->name, -1, NULL, NULL, NULL);
-	mono_w32process_time_date_stamp (uni_name, &image->time_date_stamp);
+	mono_pe_file_time_date_stamp (uni_name, &image->time_date_stamp);
 	g_free (uni_name);
 #endif
 }

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -276,6 +276,7 @@ struct _MonoImage {
 
 	/* The module name reported in the file for this image (could be NULL for a malformed file) */
 	const char *module_name;
+	guint32 time_date_stamp;
 
 	char *version;
 	gint16 md_version_major, md_version_minor;

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -729,6 +729,7 @@ typedef struct {
 	gpointer (*create_ftnptr) (MonoDomain *domain, gpointer addr);
 	gpointer (*get_addr_from_ftnptr) (gpointer descr);
 	char*    (*get_runtime_build_info) (void);
+	const char*    (*get_runtime_build_version) (void);
 	gpointer (*get_vtable_trampoline) (MonoVTable *vtable, int slot_index);
 	gpointer (*get_imt_trampoline) (MonoVTable *vtable, int imt_slot_index);
 	gboolean (*imt_entry_inited) (MonoVTable *vtable, int imt_slot_index);

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -514,7 +514,6 @@ typedef struct {
 
 	char name [MONO_MAX_THREAD_NAME_LEN];
 
-	intptr_t managed_thread_ptr;
 	intptr_t info_addr;
 	intptr_t native_thread_id;
 

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -480,7 +480,9 @@ typedef struct {
 		// symbolicated string on release builds
 		const char *name;
 #endif
-
+		const char *filename;
+		guint32 image_size;
+		guint32 time_date_stamp;
 	} managed_data;
 	struct {
 		intptr_t ip;

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -6124,10 +6124,6 @@ mono_threads_summarize_native_self (MonoThreadSummary *out, MonoContext *ctx)
 
 	mono_native_thread_get_name (current, out->name, MONO_MAX_SUMMARY_NAME_LEN);
 
-	// FIXME: Figure out how to store and look these up?
-	/*MonoDomain *domain = thread->obj.vtable->domain;*/
-	/*out->managed_thread_ptr = (intptr_t) get_current_thread_ptr_for_domain (domain, thread);*/
-	/*out->info_addr = (intptr_t) thread->thread_info;*/
 	return TRUE;
 }
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -2762,7 +2762,7 @@ static gboolean
 mono_thread_resume (MonoInternalThread *thread)
 {
 	if ((thread->state & ThreadState_SuspendRequested) != 0) {
-		// MOSTLY_ASYNC_SAFE_PRINTF ("RESUME (1) thread %p\n", thread_get_tid (thread));
+		// g_async_safe_printf ("RESUME (1) thread %p\n", thread_get_tid (thread));
 		thread->state &= ~ThreadState_SuspendRequested;
 		MONO_ENTER_GC_SAFE;
 		mono_os_event_set (thread->suspended);
@@ -2775,11 +2775,11 @@ mono_thread_resume (MonoInternalThread *thread)
 		(thread->state & ThreadState_Aborted) != 0 || 
 		(thread->state & ThreadState_Stopped) != 0)
 	{
-		// MOSTLY_ASYNC_SAFE_PRINTF ("RESUME (2) thread %p\n", thread_get_tid (thread));
+		// g_async_safe_printf ("RESUME (2) thread %p\n", thread_get_tid (thread));
 		return FALSE;
 	}
 
-	// MOSTLY_ASYNC_SAFE_PRINTF ("RESUME (3) thread %p\n", thread_get_tid (thread));
+	// g_async_safe_printf ("RESUME (3) thread %p\n", thread_get_tid (thread));
 
 	MONO_ENTER_GC_SAFE;
 	mono_os_event_set (thread->suspended);
@@ -5501,7 +5501,7 @@ async_suspend_internal (MonoInternalThread *thread, gboolean interrupt)
 
 	g_assert (thread != mono_thread_internal_current ());
 
-	// MOSTLY_ASYNC_SAFE_PRINTF ("ASYNC SUSPEND thread %p\n", thread_get_tid (thread));
+	// g_async_safe_printf ("ASYNC SUSPEND thread %p\n", thread_get_tid (thread));
 
 	thread->self_suspended = FALSE;
 
@@ -5526,7 +5526,7 @@ self_suspend_internal (void)
 
 	thread = mono_thread_internal_current ();
 
-	// MOSTLY_ASYNC_SAFE_PRINTF ("SELF SUSPEND thread %p\n", thread_get_tid (thread));
+	// g_async_safe_printf ("SELF SUSPEND thread %p\n", thread_get_tid (thread));
 
 	thread->self_suspended = TRUE;
 
@@ -6200,7 +6200,7 @@ summarizer_supervisor_wait (SummarizerSupervisorState *state)
 	// If we haven't been SIGKILL'ed yet, we signal our parent
 	// and then exit
 #ifdef HAVE_KILL
-	MOSTLY_ASYNC_SAFE_PRINTF("Crash Reporter has timed out, sending SIGSEGV\n");
+	g_async_safe_printf("Crash Reporter has timed out, sending SIGSEGV\n");
 	kill (state->pid, SIGSEGV);
 #else
 	g_error ("kill () is not supported by this platform");
@@ -6291,7 +6291,7 @@ summarizer_signal_other_threads (SummarizerGlobalState *state, MonoNativeThreadI
 		pthread_kill (state->thread_array [i], SIGTERM);
 
 		if (!state->silent)
-			MOSTLY_ASYNC_SAFE_PRINTF("Pkilling 0x%zx from 0x%zx\n", MONO_NATIVE_THREAD_ID_TO_UINT (state->thread_array [i]), MONO_NATIVE_THREAD_ID_TO_UINT (current));
+			g_async_safe_printf("Pkilling 0x%zx from 0x%zx\n", MONO_NATIVE_THREAD_ID_TO_UINT (state->thread_array [i]), MONO_NATIVE_THREAD_ID_TO_UINT (current));
 	#else
 		g_error ("pthread_kill () is not supported by this platform");
 	#endif
@@ -6307,10 +6307,10 @@ summarizer_post_dump (SummarizerGlobalState *state, MonoThreadSummary *this_thre
 	gpointer old = mono_atomic_cas_ptr ((volatile gpointer *)&state->all_threads [current_idx], this_thread, NULL);
 
 	if (old == GINT_TO_POINTER (-1)) {
-		MOSTLY_ASYNC_SAFE_PRINTF ("Trying to register response after dumping period ended");
+		g_async_safe_printf ("Trying to register response after dumping period ended");
 		return FALSE;
 	} else if (old != NULL) {
-		MOSTLY_ASYNC_SAFE_PRINTF ("Thread dump raced for thread slot.");
+		g_async_safe_printf ("Thread dump raced for thread slot.");
 		return FALSE;
 	} 
 
@@ -6456,21 +6456,21 @@ mono_threads_summarize_execute (MonoContext *ctx, gchar **out, MonoStackHash *ha
 		// Store a reference to our stack memory into global state
 		gboolean success = summarizer_post_dump (&state, this_thread, current_idx);
 		if (!success && !state.silent)
-			MOSTLY_ASYNC_SAFE_PRINTF("Thread 0x%zx reported itself.\n", MONO_NATIVE_THREAD_ID_TO_UINT (current));
+			g_async_safe_printf("Thread 0x%zx reported itself.\n", MONO_NATIVE_THREAD_ID_TO_UINT (current));
 	} else if (!state.silent) {
-		MOSTLY_ASYNC_SAFE_PRINTF("Thread 0x%zx couldn't report itself.\n", MONO_NATIVE_THREAD_ID_TO_UINT (current));
+		g_async_safe_printf("Thread 0x%zx couldn't report itself.\n", MONO_NATIVE_THREAD_ID_TO_UINT (current));
 	}
 
 	// From summarizer, wait and dump.
 	if (this_thread_controls) {
 		if (!state.silent)
-			MOSTLY_ASYNC_SAFE_PRINTF("Entering thread summarizer pause from 0x%zx\n", MONO_NATIVE_THREAD_ID_TO_UINT (current));
+			g_async_safe_printf("Entering thread summarizer pause from 0x%zx\n", MONO_NATIVE_THREAD_ID_TO_UINT (current));
 
 		// Wait up to 2 seconds for all of the other threads to catch up
 		summary_timedwait (&state, 2);
 
 		if (!state.silent)
-			MOSTLY_ASYNC_SAFE_PRINTF("Finished thread summarizer pause from 0x%zx.\n", MONO_NATIVE_THREAD_ID_TO_UINT (current));
+			g_async_safe_printf("Finished thread summarizer pause from 0x%zx.\n", MONO_NATIVE_THREAD_ID_TO_UINT (current));
 
 		// Dump and cleanup all the stack memory
 		summarizer_state_term (&state, out, working_mem, provided_size, this_thread);
@@ -6542,12 +6542,12 @@ mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gb
 			break;
 		} else if (signal_handler_controller) {
 			// We're done. We can't do anything.
-			MOSTLY_ASYNC_SAFE_PRINTF ("Attempted to dump for critical failure when already in dump. Error reporting crashed?");
+			g_async_safe_printf ("Attempted to dump for critical failure when already in dump. Error reporting crashed?");
 			mono_summarize_double_fault_log ();
 			break;
 		} else {
 			if (!silent)
-				MOSTLY_ASYNC_SAFE_PRINTF ("Waiting for in-flight dump to complete.");
+				g_async_safe_printf ("Waiting for in-flight dump to complete.");
 			sleep (2);
 		}
 	}

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -6389,20 +6389,23 @@ summarizer_state_term (SummarizerGlobalState *state, gchar **out, gchar *mem, si
 		mono_get_eh_callbacks ()->mono_summarize_managed_stack (threads [i]);
 	}
 
+	MonoStateWriter writer;
+	memset (&writer, 0, sizeof (writer));
+
 	mono_summarize_timeline_phase_log (MonoSummaryStateWriter);
-	mono_summarize_native_state_begin (mem, provided_size);
+	mono_summarize_native_state_begin (&writer, mem, provided_size);
 	for (int i=0; i < state->nthreads; i++) {
 		MonoThreadSummary *thread = threads [i];
 		if (!thread)
 			continue;
 
-		mono_summarize_native_state_add_thread (thread, thread->ctx, thread == controlling);
+		mono_summarize_native_state_add_thread (&writer, thread, thread->ctx, thread == controlling);
 		// Set non-shared state to notify the waiting thread to clean up
 		// without having to keep our shared state alive
 		mono_atomic_store_i32 (&thread->done, 0x1);
 		mono_os_sem_post (&thread->done_wait);
 	}
-	*out = mono_summarize_native_state_end ();
+	*out = mono_summarize_native_state_end (&writer);
 	mono_summarize_timeline_phase_log (MonoSummaryStateWriterDone);
 
 	mono_os_sem_destroy (&state->update);

--- a/mono/metadata/w32process-internals.h
+++ b/mono/metadata/w32process-internals.h
@@ -55,9 +55,6 @@ gboolean
 mono_w32process_module_get_information (gpointer process, gpointer module, MODULEINFO *modinfo, guint32 size);
 
 gboolean
-mono_w32process_time_date_stamp (gunichar2 *filename, guint32 *out);
-
-gboolean
 mono_w32process_get_fileversion_info (gunichar2 *filename, gpointer *data);
 
 gboolean

--- a/mono/metadata/w32process-internals.h
+++ b/mono/metadata/w32process-internals.h
@@ -55,6 +55,9 @@ gboolean
 mono_w32process_module_get_information (gpointer process, gpointer module, MODULEINFO *modinfo, guint32 size);
 
 gboolean
+mono_w32process_time_date_stamp (gunichar2 *filename, guint32 *out);
+
+gboolean
 mono_w32process_get_fileversion_info (gunichar2 *filename, gpointer *data);
 
 gboolean

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -253,245 +253,6 @@ typedef struct {
 #define VS_FFI_STRUCVERSION	0x00010000
 #endif
 
-#define IMAGE_NUMBEROF_DIRECTORY_ENTRIES 16
-
-#define IMAGE_DIRECTORY_ENTRY_EXPORT	0
-#define IMAGE_DIRECTORY_ENTRY_IMPORT	1
-#define IMAGE_DIRECTORY_ENTRY_RESOURCE	2
-
-#define IMAGE_SIZEOF_SHORT_NAME	8
-
-#if G_BYTE_ORDER != G_LITTLE_ENDIAN
-#define IMAGE_DOS_SIGNATURE	0x4d5a
-#define IMAGE_NT_SIGNATURE	0x50450000
-#define IMAGE_NT_OPTIONAL_HDR32_MAGIC	0xb10
-#define IMAGE_NT_OPTIONAL_HDR64_MAGIC	0xb20
-#else
-#define IMAGE_DOS_SIGNATURE	0x5a4d
-#define IMAGE_NT_SIGNATURE	0x00004550
-#define IMAGE_NT_OPTIONAL_HDR32_MAGIC	0x10b
-#define IMAGE_NT_OPTIONAL_HDR64_MAGIC	0x20b
-#endif
-
-typedef struct {
-	guint16 e_magic;
-	guint16 e_cblp;
-	guint16 e_cp;
-	guint16 e_crlc;
-	guint16 e_cparhdr;
-	guint16 e_minalloc;
-	guint16 e_maxalloc;
-	guint16 e_ss;
-	guint16 e_sp;
-	guint16 e_csum;
-	guint16 e_ip;
-	guint16 e_cs;
-	guint16 e_lfarlc;
-	guint16 e_ovno;
-	guint16 e_res[4];
-	guint16 e_oemid;
-	guint16 e_oeminfo;
-	guint16 e_res2[10];
-	guint32 e_lfanew;
-} IMAGE_DOS_HEADER;
-
-typedef struct {
-	guint16 Machine;
-	guint16 NumberOfSections;
-	guint32 TimeDateStamp;
-	guint32 PointerToSymbolTable;
-	guint32 NumberOfSymbols;
-	guint16 SizeOfOptionalHeader;
-	guint16 Characteristics;
-} IMAGE_FILE_HEADER;
-
-typedef struct {
-	guint32 VirtualAddress;
-	guint32 Size;
-} IMAGE_DATA_DIRECTORY;
-
-typedef struct {
-	guint16 Magic;
-	guint8 MajorLinkerVersion;
-	guint8 MinorLinkerVersion;
-	guint32 SizeOfCode;
-	guint32 SizeOfInitializedData;
-	guint32 SizeOfUninitializedData;
-	guint32 AddressOfEntryPoint;
-	guint32 BaseOfCode;
-	guint32 BaseOfData;
-	guint32 ImageBase;
-	guint32 SectionAlignment;
-	guint32 FileAlignment;
-	guint16 MajorOperatingSystemVersion;
-	guint16 MinorOperatingSystemVersion;
-	guint16 MajorImageVersion;
-	guint16 MinorImageVersion;
-	guint16 MajorSubsystemVersion;
-	guint16 MinorSubsystemVersion;
-	guint32 Win32VersionValue;
-	guint32 SizeOfImage;
-	guint32 SizeOfHeaders;
-	guint32 CheckSum;
-	guint16 Subsystem;
-	guint16 DllCharacteristics;
-	guint32 SizeOfStackReserve;
-	guint32 SizeOfStackCommit;
-	guint32 SizeOfHeapReserve;
-	guint32 SizeOfHeapCommit;
-	guint32 LoaderFlags;
-	guint32 NumberOfRvaAndSizes;
-	IMAGE_DATA_DIRECTORY DataDirectory[IMAGE_NUMBEROF_DIRECTORY_ENTRIES];
-} IMAGE_OPTIONAL_HEADER32;
-
-typedef struct {
-	guint16 Magic;
-	guint8 MajorLinkerVersion;
-	guint8 MinorLinkerVersion;
-	guint32 SizeOfCode;
-	guint32 SizeOfInitializedData;
-	guint32 SizeOfUninitializedData;
-	guint32 AddressOfEntryPoint;
-	guint32 BaseOfCode;
-	guint64 ImageBase;
-	guint32 SectionAlignment;
-	guint32 FileAlignment;
-	guint16 MajorOperatingSystemVersion;
-	guint16 MinorOperatingSystemVersion;
-	guint16 MajorImageVersion;
-	guint16 MinorImageVersion;
-	guint16 MajorSubsystemVersion;
-	guint16 MinorSubsystemVersion;
-	guint32 Win32VersionValue;
-	guint32 SizeOfImage;
-	guint32 SizeOfHeaders;
-	guint32 CheckSum;
-	guint16 Subsystem;
-	guint16 DllCharacteristics;
-	guint64 SizeOfStackReserve;
-	guint64 SizeOfStackCommit;
-	guint64 SizeOfHeapReserve;
-	guint64 SizeOfHeapCommit;
-	guint32 LoaderFlags;
-	guint32 NumberOfRvaAndSizes;
-	IMAGE_DATA_DIRECTORY DataDirectory[IMAGE_NUMBEROF_DIRECTORY_ENTRIES];
-} IMAGE_OPTIONAL_HEADER64;
-
-#if SIZEOF_VOID_P == 8
-typedef IMAGE_OPTIONAL_HEADER64 IMAGE_OPTIONAL_HEADER;
-#else
-typedef IMAGE_OPTIONAL_HEADER32 IMAGE_OPTIONAL_HEADER;
-#endif
-
-typedef struct {
-	guint32 Signature;
-	IMAGE_FILE_HEADER FileHeader;
-	IMAGE_OPTIONAL_HEADER32 OptionalHeader;
-} IMAGE_NT_HEADERS32;
-
-typedef struct {
-	guint32 Signature;
-	IMAGE_FILE_HEADER FileHeader;
-	IMAGE_OPTIONAL_HEADER64 OptionalHeader;
-} IMAGE_NT_HEADERS64;
-
-#if SIZEOF_VOID_P == 8
-typedef IMAGE_NT_HEADERS64 IMAGE_NT_HEADERS;
-#else
-typedef IMAGE_NT_HEADERS32 IMAGE_NT_HEADERS;
-#endif
-
-typedef struct {
-	guint8 Name[IMAGE_SIZEOF_SHORT_NAME];
-	union {
-		guint32 PhysicalAddress;
-		guint32 VirtualSize;
-	} Misc;
-	guint32 VirtualAddress;
-	guint32 SizeOfRawData;
-	guint32 PointerToRawData;
-	guint32 PointerToRelocations;
-	guint32 PointerToLinenumbers;
-	guint16 NumberOfRelocations;
-	guint16 NumberOfLinenumbers;
-	guint32 Characteristics;
-} IMAGE_SECTION_HEADER;
-
-#define IMAGE_FIRST_SECTION32(header) ((IMAGE_SECTION_HEADER *)((gsize)(header) + G_STRUCT_OFFSET (IMAGE_NT_HEADERS32, OptionalHeader) + GUINT16_FROM_LE (((IMAGE_NT_HEADERS32 *)(header))->FileHeader.SizeOfOptionalHeader)))
-
-#define RT_CURSOR	0x01
-#define RT_BITMAP	0x02
-#define RT_ICON		0x03
-#define RT_MENU		0x04
-#define RT_DIALOG	0x05
-#define RT_STRING	0x06
-#define RT_FONTDIR	0x07
-#define RT_FONT		0x08
-#define RT_ACCELERATOR	0x09
-#define RT_RCDATA	0x0a
-#define RT_MESSAGETABLE	0x0b
-#define RT_GROUP_CURSOR	0x0c
-#define RT_GROUP_ICON	0x0e
-#define RT_VERSION	0x10
-#define RT_DLGINCLUDE	0x11
-#define RT_PLUGPLAY	0x13
-#define RT_VXD		0x14
-#define RT_ANICURSOR	0x15
-#define RT_ANIICON	0x16
-#define RT_HTML		0x17
-#define RT_MANIFEST	0x18
-
-typedef struct {
-	guint32 Characteristics;
-	guint32 TimeDateStamp;
-	guint16 MajorVersion;
-	guint16 MinorVersion;
-	guint16 NumberOfNamedEntries;
-	guint16 NumberOfIdEntries;
-} IMAGE_RESOURCE_DIRECTORY;
-
-typedef struct {
-	union {
-		struct {
-#if G_BYTE_ORDER == G_BIG_ENDIAN
-			guint32 NameIsString:1;
-			guint32 NameOffset:31;
-#else
-			guint32 NameOffset:31;
-			guint32 NameIsString:1;
-#endif
-		};
-		guint32 Name;
-#if G_BYTE_ORDER == G_BIG_ENDIAN
-		struct {
-			guint16 __wapi_big_endian_padding;
-			guint16 Id;
-		};
-#else
-		guint16 Id;
-#endif
-	};
-	union {
-		guint32 OffsetToData;
-		struct {
-#if G_BYTE_ORDER == G_BIG_ENDIAN
-			guint32 DataIsDirectory:1;
-			guint32 OffsetToDirectory:31;
-#else
-			guint32 OffsetToDirectory:31;
-			guint32 DataIsDirectory:1;
-#endif
-		};
-	};
-} IMAGE_RESOURCE_DIRECTORY_ENTRY;
-
-typedef struct {
-	guint32 OffsetToData;
-	guint32 Size;
-	guint32 CodePage;
-	guint32 Reserved;
-} IMAGE_RESOURCE_DATA_ENTRY;
-
 #define VOS_UNKNOWN		0x00000000
 #define VOS_DOS			0x00010000
 #define VOS_OS216		0x00020000
@@ -3140,91 +2901,6 @@ find_pe_file_resources (gpointer file_map, guint32 map_size, guint32 res_id, gui
 	}
 }
 
-static gpointer
-map_pe_file (gunichar2 *filename, gint32 *map_size, void **handle)
-{
-	gchar *filename_ext = NULL;
-	gchar *located_filename = NULL;
-	int fd = -1;
-	struct stat statbuf;
-	gpointer file_map = NULL;
-
-	/* According to the MSDN docs, a search path is applied to
-	 * filename.  FIXME: implement this, for now just pass it
-	 * straight to open
-	 */
-
-	filename_ext = mono_unicode_to_external (filename);
-	if (filename_ext == NULL) {
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: unicode conversion returned NULL", __func__);
-
-		mono_w32error_set_last (ERROR_INVALID_NAME);
-		goto exit;
-	}
-
-	fd = open (filename_ext, O_RDONLY, 0);
-	if (fd == -1 && (errno == ENOENT || errno == ENOTDIR) && IS_PORTABILITY_SET) {
-		gint saved_errno = errno;
-
-		located_filename = mono_portability_find_file (filename_ext, TRUE);
-		if (!located_filename) {
-			errno = saved_errno;
-
-			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: Error opening file %s (1): %s", __func__, filename_ext, strerror (errno));
-			goto error;
-		}
-
-		fd = open (located_filename, O_RDONLY, 0);
-		if (fd == -1) {
-			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: Error opening file %s (2): %s", __func__, filename_ext, strerror (errno));
-			goto error;
-		}
-	}
-	else if (fd == -1) {
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: Error opening file %s (3): %s", __func__, filename_ext, strerror (errno));
-		goto error;
-	}
-
-	if (fstat (fd, &statbuf) == -1) {
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: Error stat()ing file %s: %s", __func__, filename_ext, strerror (errno));
-		goto error;
-	}
-	*map_size = statbuf.st_size;
-
-	/* Check basic file size */
-	if (statbuf.st_size < sizeof(IMAGE_DOS_HEADER)) {
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: File %s is too small: %lld", __func__, filename_ext, (long long) statbuf.st_size);
-
-		mono_w32error_set_last (ERROR_BAD_LENGTH);
-		goto exit;
-	}
-
-	file_map = mono_file_map (statbuf.st_size, MONO_MMAP_READ | MONO_MMAP_PRIVATE, fd, 0, handle);
-	if (file_map == NULL) {
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: Error mmap()int file %s: %s", __func__, filename_ext, strerror (errno));
-		goto error;
-	}
-exit:
-	if (fd != -1)
-		close (fd);
-	g_free (located_filename);
-	g_free (filename_ext);
-	return file_map;
-error:
-	mono_w32error_set_last (mono_w32error_unix_to_win32 (errno));
-	goto exit;
-}
-
-static void
-unmap_pe_file (gpointer file_map, void *handle)
-{
-	gint res;
-
-	res = mono_file_unmap (file_map, handle);
-	if (G_UNLIKELY (res != 0))
-		g_error ("%s: mono_file_unmap failed, error: \"%s\" (%d)", __func__, g_strerror (errno), errno);
-}
-
 static guint32
 unicode_chars (const gunichar2 *str)
 {
@@ -3645,38 +3321,6 @@ big_up (gconstpointer datablock, guint32 size)
 #endif
 
 gboolean
-mono_w32process_time_date_stamp (gunichar2 *filename, guint32 *out)
-{
-	void *map_handle;
-	gint32 map_size;
-	gpointer file_map = map_pe_file (filename, &map_size, &map_handle);
-	if (!file_map)
-		return FALSE;
-
-	/* Figure this out when we support 64bit PE files */
-	if (1) {
-		IMAGE_DOS_HEADER *dos_header = (IMAGE_DOS_HEADER *)file_map;
-		if (dos_header->e_magic != IMAGE_DOS_SIGNATURE) {
-			unmap_pe_file (file_map, map_handle);
-			return FALSE;
-		}
-
-		IMAGE_NT_HEADERS32 *nt_headers = (IMAGE_NT_HEADERS32 *)((guint8 *)file_map + GUINT32_FROM_LE (dos_header->e_lfanew));
-		if (nt_headers->Signature != IMAGE_NT_SIGNATURE) {
-			unmap_pe_file (file_map, map_handle);
-			return FALSE;
-		}
-
-		*out = nt_headers->FileHeader.TimeDateStamp;
-	} else {
-		g_assert_not_reached ();
-	}
-
-	unmap_pe_file (file_map, map_handle);
-	return TRUE;
-}
-
-gboolean
 mono_w32process_get_fileversion_info (gunichar2 *filename, gpointer *data)
 {
 	gpointer file_map;
@@ -3688,13 +3332,13 @@ mono_w32process_get_fileversion_info (gunichar2 *filename, gpointer *data)
 	g_assert (data);
 	*data = NULL;
 
-	file_map = map_pe_file (filename, &map_size, &map_handle);
+	file_map = mono_pe_file_map (filename, &map_size, &map_handle);
 	if (!file_map)
 		return FALSE;
 
 	versioninfo = find_pe_file_resources (file_map, map_size, RT_VERSION, 0, &datasize);
 	if (!versioninfo) {
-		unmap_pe_file (file_map, map_handle);
+		mono_pe_file_unmap (file_map, map_handle);
 		return FALSE;
 	}
 
@@ -3708,7 +3352,7 @@ mono_w32process_get_fileversion_info (gunichar2 *filename, gpointer *data)
 	big_up (*data, datasize);
 #endif
 
-	unmap_pe_file (file_map, map_handle);
+	mono_pe_file_unmap (file_map, map_handle);
 
 	return TRUE;
 }

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -3645,6 +3645,38 @@ big_up (gconstpointer datablock, guint32 size)
 #endif
 
 gboolean
+mono_w32process_time_date_stamp (gunichar2 *filename, guint32 *out)
+{
+	void *map_handle;
+	gint32 map_size;
+	gpointer file_map = map_pe_file (filename, &map_size, &map_handle);
+	if (!file_map)
+		return FALSE;
+
+	/* Figure this out when we support 64bit PE files */
+	if (1) {
+		IMAGE_DOS_HEADER *dos_header = (IMAGE_DOS_HEADER *)file_map;
+		if (dos_header->e_magic != IMAGE_DOS_SIGNATURE) {
+			unmap_pe_file (file_map, map_handle);
+			return FALSE;
+		}
+
+		IMAGE_NT_HEADERS32 *nt_headers = (IMAGE_NT_HEADERS32 *)((guint8 *)file_map + GUINT32_FROM_LE (dos_header->e_lfanew));
+		if (nt_headers->Signature != IMAGE_NT_SIGNATURE) {
+			unmap_pe_file (file_map, map_handle);
+			return FALSE;
+		}
+
+		*out = nt_headers->FileHeader.TimeDateStamp;
+	} else {
+		g_assert_not_reached ();
+	}
+
+	unmap_pe_file (file_map, map_handle);
+	return TRUE;
+}
+
+gboolean
 mono_w32process_get_fileversion_info (gunichar2 *filename, gpointer *data)
 {
 	gpointer file_map;

--- a/mono/mini/debugger-state-machine.h
+++ b/mono/mini/debugger-state-machine.h
@@ -58,7 +58,7 @@ mono_debugger_log_suspend (DebuggerTlsData *tls);
 #if 0
 #define DEBUGGER_STATE_MACHINE_DEBUG(level, ...)
 #else
-#define DEBUGGER_STATE_MACHINE_DEBUG(level, ...) MOSTLY_ASYNC_SAFE_PRINTF(__VA_ARGS__)
+#define DEBUGGER_STATE_MACHINE_DEBUG(level, ...) g_async_safe_printf(__VA_ARGS__)
 #endif
 
 void

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -651,10 +651,13 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 		for (i = 0; i < AMD64_NREG; ++i)
 			regs [i] = new_ctx->gregs [i];
 
-		mono_unwind_frame (unwind_info, unwind_info_len, (guint8 *)ji->code_start,
+		gboolean success = mono_unwind_frame (unwind_info, unwind_info_len, (guint8 *)ji->code_start,
 						   (guint8*)ji->code_start + ji->code_size,
 						   (guint8 *)ip, epilog ? &epilog : NULL, regs, MONO_MAX_IREGS + 1,
 						   save_locations, MONO_MAX_IREGS, &cfa);
+
+		if (!success)
+			return FALSE;
 
 		for (i = 0; i < AMD64_NREG; ++i)
 			new_ctx->gregs [i] = regs [i];

--- a/mono/mini/exceptions-arm.c
+++ b/mono/mini/exceptions-arm.c
@@ -484,10 +484,13 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 			regs [MONO_MAX_IREGS + i] = *(guint64*)&(new_ctx->fregs [8 + i]);
 #endif
 
-		mono_unwind_frame (unwind_info, unwind_info_len, (guint8*)ji->code_start,
+		gboolean success = mono_unwind_frame (unwind_info, unwind_info_len, (guint8*)ji->code_start,
 						   (guint8*)ji->code_start + ji->code_size,
 						   (guint8*)ip, NULL, regs, MONO_MAX_IREGS + 8,
 						   save_locations, MONO_MAX_IREGS, &cfa);
+
+		if (!success)
+			return FALSE;
 
 		for (i = 0; i < 16; ++i)
 			new_ctx->regs [i] = regs [i];

--- a/mono/mini/exceptions-arm64.c
+++ b/mono/mini/exceptions-arm64.c
@@ -447,10 +447,13 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 		for (int i = 0; i < 8; i++)
 			(regs + MONO_MAX_IREGS) [i] = *((host_mgreg_t*)&new_ctx->fregs [8 + i]);
 
-		mono_unwind_frame (unwind_info, unwind_info_len, (guint8*)ji->code_start,
+		gboolean success = mono_unwind_frame (unwind_info, unwind_info_len, (guint8*)ji->code_start,
 						   (guint8*)ji->code_start + ji->code_size,
 						   (guint8*)ip, NULL, regs, MONO_MAX_IREGS + 8,
 						   save_locations, MONO_MAX_IREGS, (guint8**)&cfa);
+
+		if (!success)
+			return FALSE;
 
 		memcpy (&new_ctx->regs, regs, sizeof (host_mgreg_t) * 32);
 		for (int i = 0; i < 8; i++)

--- a/mono/mini/exceptions-mips.c
+++ b/mono/mini/exceptions-mips.c
@@ -448,10 +448,13 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 		for (i = 0; i < MONO_MAX_IREGS; ++i)
 			regs [i] = new_ctx->sc_regs [i];
 
-		mono_unwind_frame (unwind_info, unwind_info_len, ji->code_start, 
+		gboolean success = mono_unwind_frame (unwind_info, unwind_info_len, ji->code_start, 
 						   (guint8*)ji->code_start + ji->code_size,
 						   ip, NULL, regs, MONO_MAX_IREGS,
 						   save_locations, MONO_MAX_IREGS, &cfa);
+
+		if (!success)
+			return FALSE;
 
 		for (i = 0; i < MONO_MAX_IREGS; ++i)
 			new_ctx->sc_regs [i] = regs [i];

--- a/mono/mini/exceptions-ppc.c
+++ b/mono/mini/exceptions-ppc.c
@@ -581,10 +581,13 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 			for (i = MONO_PPC_FIRST_SAVED_GREG; i < MONO_MAX_IREGS; ++i)
 				regs [i] = ctx->regs [i];
 
-			mono_unwind_frame (unwind_info, unwind_info_len, ji->code_start, 
+			gboolean success = mono_unwind_frame (unwind_info, unwind_info_len, ji->code_start, 
 							   (guint8*)ji->code_start + ji->code_size,
 							   ip, NULL, regs, ppc_lr + 1,
 							   save_locations, MONO_MAX_IREGS, &cfa);
+
+			if (!success)
+				return FALSE;
 
 			/* we substract 4, so that the IP points into the call instruction */
 			MONO_CONTEXT_SET_IP (new_ctx, regs [ppc_lr] - 4);

--- a/mono/mini/exceptions-s390x.c
+++ b/mono/mini/exceptions-s390x.c
@@ -515,10 +515,14 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 		address = (char *)ip - (char *)ji->code_start;
 
 		memcpy(&regs, &ctx->uc_mcontext.gregs, sizeof(regs));
-		mono_unwind_frame (unwind_info, unwind_info_len, ji->code_start,
+		gboolean success = mono_unwind_frame (unwind_info, unwind_info_len, ji->code_start,
 						   (guint8 *) ji->code_start + ji->code_size,
 						   ip, NULL, regs, 16, save_locations,
 						   MONO_MAX_IREGS, &cfa);
+
+		if (!success)
+			return FALSE;
+
 		memcpy (&new_ctx->uc_mcontext.gregs, &regs, sizeof(regs));
 		MONO_CONTEXT_SET_IP(new_ctx, regs[14] - 2);
 		MONO_CONTEXT_SET_BP(new_ctx, cfa);

--- a/mono/mini/exceptions-x86.c
+++ b/mono/mini/exceptions-x86.c
@@ -833,10 +833,13 @@ mono_arch_unwind_frame (MonoDomain *domain, MonoJitTlsData *jit_tls,
 		regs [X86_EDI] = new_ctx->edi;
 		regs [X86_NREG] = new_ctx->eip;
 
-		mono_unwind_frame ((guint8*)unwind_info, unwind_info_len, (guint8*)ji->code_start,
+		gboolean success = mono_unwind_frame ((guint8*)unwind_info, unwind_info_len, (guint8*)ji->code_start,
 						   (guint8*)ji->code_start + ji->code_size,
 						   (guint8*)ip, NULL, regs, MONO_MAX_IREGS + 1,
 						   save_locations, MONO_MAX_IREGS, &cfa);
+
+		if (!success)
+			return FALSE;
 
 		new_ctx->eax = regs [X86_EAX];
 		new_ctx->ebx = regs [X86_EBX];

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1199,6 +1199,8 @@ mono_walk_stack_full (MonoJitStackWalk func, MonoContext *start_ctx, MonoDomain 
 	gboolean async = mono_thread_info_is_async_context ();
 	Unwinder unwinder;
 
+	memset (&frame, 0, sizeof (StackFrameInfo));
+
 #ifndef TARGET_WASM
 	if (mono_llvm_only) {
 		GSList *l, *ips;
@@ -1634,6 +1636,7 @@ mono_summarize_managed_stack (MonoThreadSummary *out)
 
 	if (data.error != NULL)
 		out->error_msg = data.error;
+	out->is_managed = (out->num_managed_frames != 0);
 }
 
 // Always runs on the dumped thread
@@ -1665,6 +1668,7 @@ mono_summarize_unmanaged_stack (MonoThreadSummary *out)
 	out->lmf = mono_get_lmf ();
 
 	MonoThreadInfo *thread = mono_thread_info_current_unchecked ();
+	out->info_addr = (intptr_t) thread;
 	out->jit_tls = thread->jit_data;
 	out->domain = mono_domain_get ();
 

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -3233,13 +3233,19 @@ mono_handle_native_crash (const char *signal, void *ctx, MONO_SIG_HANDLER_INFO_T
 	/* prevent infinite loops in crash handling */
 	handle_crash_loop = TRUE;
 
+	//  FIXME:
+	// Not thread safe.
+	// Crashes very, very often
 	/* !jit_tls means the thread was not registered with the runtime */
-	if (jit_tls && mono_thread_internal_current ()) {
-		mono_runtime_printf_err ("Stacktrace:\n");
 
-		/* FIXME: Is MONO_UNWIND_LOOKUP_IL_OFFSET correct here? */
-		mono_walk_stack (print_stack_frame_to_stderr, MONO_UNWIND_LOOKUP_IL_OFFSET, NULL);
-	}
+	// This is not signal safe
+	//
+	// if (jit_tls && mono_thread_internal_current ()) {
+	// 	mono_runtime_printf_err ("Stacktrace:\n");
+
+	// 	/* FIXME: Is MONO_UNWIND_LOOKUP_IL_OFFSET correct here? */
+	// 	mono_walk_stack (print_stack_frame_to_stderr, MONO_UNWIND_LOOKUP_IL_OFFSET, NULL);
+	// }
 
 	mono_dump_native_crash_info (signal, ctx, info);
 

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -3182,9 +3182,9 @@ print_stack_frame_signal_safe (StackFrameInfo *frame, MonoContext *ctx, gpointer
 
 	if (method) {
 		const char *name_space = m_class_get_name_space (method->klass);
-		MOSTLY_ASYNC_SAFE_PRINTF("\t  at %s%s%s:%s <0x%05x>\n", name_space, (name_space [0] != '\0' ? "." : ""), m_class_get_name (method->klass), method->name, frame->native_offset);
+		g_async_safe_printf("\t  at %s%s%s:%s <0x%05x>\n", name_space, (name_space [0] != '\0' ? "." : ""), m_class_get_name (method->klass), method->name, frame->native_offset);
 	} else {
-		MOSTLY_ASYNC_SAFE_PRINTF("\t  at <unknown> <0x%05x>\n", frame->native_offset);
+		g_async_safe_printf("\t  at <unknown> <0x%05x>\n", frame->native_offset);
 	}
 
 	return FALSE;
@@ -3227,7 +3227,7 @@ mono_handle_native_crash (const char *signal, void *ctx, MONO_SIG_HANDLER_INFO_T
 		return;
 
 	if (mini_get_debug_options ()->suspend_on_native_crash) {
-		MOSTLY_ASYNC_SAFE_PRINTF ("Received %s, suspending...\n", signal);
+		g_async_safe_printf ("Received %s, suspending...\n", signal);
 		while (1) {
 			// Sleep for 1 second.
 			g_usleep (1000 * 1000);
@@ -3243,27 +3243,27 @@ mono_handle_native_crash (const char *signal, void *ctx, MONO_SIG_HANDLER_INFO_T
 	 * with ones which have a greater chance of working.
 	 */
 
-	MOSTLY_ASYNC_SAFE_PRINTF("\n=================================================================\n");
-	MOSTLY_ASYNC_SAFE_PRINTF("\tNative Crash Reporting\n");
-	MOSTLY_ASYNC_SAFE_PRINTF("=================================================================\n");
-	MOSTLY_ASYNC_SAFE_PRINTF("Got a %s while executing native code. This usually indicates\n", signal);
-	MOSTLY_ASYNC_SAFE_PRINTF("a fatal error in the mono runtime or one of the native libraries \n");
-	MOSTLY_ASYNC_SAFE_PRINTF("used by your application.\n");
-	MOSTLY_ASYNC_SAFE_PRINTF("=================================================================\n");
+	g_async_safe_printf("\n=================================================================\n");
+	g_async_safe_printf("\tNative Crash Reporting\n");
+	g_async_safe_printf("=================================================================\n");
+	g_async_safe_printf("Got a %s while executing native code. This usually indicates\n", signal);
+	g_async_safe_printf("a fatal error in the mono runtime or one of the native libraries \n");
+	g_async_safe_printf("used by your application.\n");
+	g_async_safe_printf("=================================================================\n");
 	mono_dump_native_crash_info (signal, ctx, info);
 
 	/* !jit_tls means the thread was not registered with the runtime */
 	// This must be below the native crash dump, because we can't safely
 	// do runtime state probing after we have walked the managed stack here.
 	if (jit_tls && mono_thread_internal_current () && ctx) {
-		MOSTLY_ASYNC_SAFE_PRINTF ("\n=================================================================\n");
-		MOSTLY_ASYNC_SAFE_PRINTF ("\tManaged Stacktrace:\n");
-		MOSTLY_ASYNC_SAFE_PRINTF ("=================================================================\n");
+		g_async_safe_printf ("\n=================================================================\n");
+		g_async_safe_printf ("\tManaged Stacktrace:\n");
+		g_async_safe_printf ("=================================================================\n");
 
 		MonoContext mctx;
 		mono_sigctx_to_monoctx (ctx, &mctx);
 		mono_walk_stack_full (print_stack_frame_signal_safe, &mctx, mono_domain_get (), jit_tls, mono_get_lmf (), MONO_UNWIND_LOOKUP_IL_OFFSET, NULL, TRUE);
-		MOSTLY_ASYNC_SAFE_PRINTF ("=================================================================\n");
+		g_async_safe_printf ("=================================================================\n");
 	}
 
 #ifdef MONO_ARCH_USE_SIGACTION

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1525,6 +1525,14 @@ summarize_frame_internal (MonoMethod *method, gpointer ip, size_t native_offset,
 		dest->managed_data.native_offset = native_offset;
 		dest->managed_data.token = method->token;
 		dest->managed_data.il_offset = il_offset;
+
+		dest->managed_data.filename = image->module_name;
+
+		MonoDotNetHeader *header = &image->image_info->cli_header;
+		dest->managed_data.image_size = header->pe.pe_code_size;
+
+		dest->managed_data.time_date_stamp = image->time_date_stamp;
+
 	} else {
 		dest->managed_data.token = -1;
 	}

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -3052,6 +3052,9 @@ mono_free_altstack (MonoJitTlsData *tls)
 gboolean
 mono_handle_soft_stack_ovf (MonoJitTlsData *jit_tls, MonoJitInfo *ji, void *ctx, MONO_SIG_HANDLER_INFO_TYPE *siginfo, guint8* fault_addr)
 {
+	if (!jit_tls)
+		return FALSE;
+
 	if (mono_llvm_only)
 		return FALSE;
 

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -940,7 +940,6 @@ dump_native_stacktrace (const char *signal, void *ctx)
 	for (i = 0; i < size; ++i) {
 		mono_runtime_printf_err ("\t%s", names [i]);
 	}
-	g_free (names);
 
 	/* Try to get more meaningful information using gdb */
 	// FIXME: Remove locking and reenable. Can race with itself

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -1108,7 +1108,7 @@ dump_native_stacktrace (const char *signal, void *ctx)
 			g_async_safe_printf("\tExternal Debugger Dump:\n");
 			g_async_safe_printf ("=================================================================\n");
 			mono_gdb_render_native_backtraces (crashed_pid);
-			exit (1);
+			_exit (1);
 		}
 
 		waitpid (pid, &status, 0);
@@ -1118,7 +1118,7 @@ dump_native_stacktrace (const char *signal, void *ctx)
 #ifndef DISABLE_CRASH_REPORTING
 			mono_state_free_mem (&merp_mem);
 #endif
-			exit (-1);
+			_exit (-1);
 		}
 
 #ifndef DISABLE_CRASH_REPORTING

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -91,6 +91,14 @@
 #include <mono/utils/mono-threads-debug.h>
 #endif
 
+#include <fcntl.h>
+#ifndef HOST_WIN32
+#include <dlfcn.h>
+#endif
+#if HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
+
 #if defined(HOST_WATCHOS)
 
 void
@@ -878,21 +886,23 @@ mono_runtime_setup_stat_profiler (void)
 static void
 dump_memory_around_ip (void *ctx)
 {
-#if 0
 #ifdef MONO_ARCH_HAVE_SIGCTX_TO_MONOCTX
 	if (!ctx)
 		return;
+
+	MOSTLY_ASYNC_SAFE_PRINTF ("\n=================================================================\n");
+	MOSTLY_ASYNC_SAFE_PRINTF ("\tBasic Fault Adddress Reporting\n");
+	MOSTLY_ASYNC_SAFE_PRINTF ("=================================================================\n");
 
 	MonoContext mctx;
 	mono_sigctx_to_monoctx (ctx, &mctx);
 	gpointer native_ip = MONO_CONTEXT_GET_IP (&mctx);
 	if (native_ip) {
-		mono_runtime_printf_err ("Memory around native instruction pointer (%p):", native_ip);
+		MOSTLY_ASYNC_SAFE_PRINTF ("Memory around native instruction pointer (%p):", native_ip);
 		mono_dump_mem (((guint8 *) native_ip) - 0x10, 0x40);
 	} else {
-		mono_runtime_printf_err ("instruction pointer is NULL, skip dumping");
+		MOSTLY_ASYNC_SAFE_PRINTF ("instruction pointer is NULL, skip dumping");
 	}
-#endif
 #endif
 }
 
@@ -942,41 +952,46 @@ dump_native_stacktrace (const char *signal, void *ctx)
 	mono_memory_write_barrier ();
 
 	if (!double_faulted) {
-		mono_runtime_printf_err ("Dumping, not in media res %d\n", double_faulted);
 		g_assertion_disable_global (assert_printer_callback);
 	} else {
-		mono_runtime_printf_err ("\nAn error has occured in the native fault reporting. Some diagnostic information will be unavailable.\n");
+		MOSTLY_ASYNC_SAFE_PRINTF ("\nAn error has occured in the native fault reporting. Some diagnostic information will be unavailable.\n");
+
+
+#if 1
+	pid_t crashed_pid = getpid ();
+	// Break here
+	MOSTLY_ASYNC_SAFE_PRINTF ("Attach to PID %d. Supervisor thread will signal us shortly.\n", crashed_pid);
+	while (TRUE) {
+		// Sleep for 1 second.
+		g_usleep (1000 * 1000);
+	}
+#endif
 
 		// In case still enabled
 		mono_summarize_toggle_assertions (FALSE);
 	}
 
 #ifdef HAVE_BACKTRACE_SYMBOLS
+
 	void *array [256];
-	char **names;
-	int i, size;
+	int size = backtrace (array, 256);
 
-#if 0
-	// Crashes a lot in backtrace_symbols
-	// FIXME: make this work using dladdr
+	MOSTLY_ASYNC_SAFE_PRINTF ("\n=================================================================\n");
+	MOSTLY_ASYNC_SAFE_PRINTF ("\tNative stacktrace:\n");
+	MOSTLY_ASYNC_SAFE_PRINTF ("=================================================================\n");
+	if (size == 0)
+		MOSTLY_ASYNC_SAFE_PRINTF ("\t (No frames) \n\n");
 
-	mono_runtime_printf_err ("\nNative stacktrace:\n");
-
-	size = backtrace (array, 256);
-	names = backtrace_symbols (array, size);
-	for (i = 0; i < size; ++i) {
-		mono_runtime_printf_err ("\t%s", names [i]);
+	for (int i = 0; i < size; ++i) {
+		gpointer ip = array [i];
+		Dl_info info;
+		gboolean success = dladdr ((void*) ip, &info);
+		if (!success) {
+			MOSTLY_ASYNC_SAFE_PRINTF ("\t%p - Unknown\n", ip);
+		} else {
+			MOSTLY_ASYNC_SAFE_PRINTF ("\t%p - %s : %s\n", ip, info.dli_fname, info.dli_sname);
+		}
 	}
-#endif
-
-	/* Try to get more meaningful information using gdb */
-	// FIXME: Remove locking and reenable. Can race with itself
-	// due to signals being handled on other threads.
-	//
-	// char *debugger_log = mono_debugger_state_str ();
-	// if (debugger_log) {
-	// 	fprintf (stderr, "\n\tDebugger session state:\n%s\n", debugger_log);
-	// }
 
 #if !defined(HOST_WIN32) && defined(HAVE_SYS_SYSCALL_H) && (defined(SYS_fork) || HAVE_FORK)
 	if (!mini_get_debug_options ()->no_gdb_backtrace) {
@@ -987,10 +1002,10 @@ dump_native_stacktrace (const char *signal, void *ctx)
 		gchar *output = NULL;
 		MonoStackHash hashes;
 
+#ifndef DISABLE_CRASH_REPORTING
 		MonoStateMem merp_mem;
 		memset (&merp_mem, 0, sizeof (merp_mem));
 
-#ifndef DISABLE_CRASH_REPORTING
 		if (!double_faulted) {
 			gboolean leave = FALSE;
 			gboolean dump_for_merp = FALSE;
@@ -1013,6 +1028,10 @@ dump_native_stacktrace (const char *signal, void *ctx)
 				passed_ctx = &mctx;
 			}
 
+			MOSTLY_ASYNC_SAFE_PRINTF ("\n=================================================================\n");
+			MOSTLY_ASYNC_SAFE_PRINTF ("\tTelemetry Dumper:\n");
+			MOSTLY_ASYNC_SAFE_PRINTF ("=================================================================\n");
+
 			if (!leave) {
 				mono_summarize_timeline_start ();
 				mono_summarize_toggle_assertions (TRUE);
@@ -1029,7 +1048,7 @@ dump_native_stacktrace (const char *signal, void *ctx)
 				// Wait for the other threads to clean up and exit their handlers
 				// We can't lock / wait indefinitely, in case one of these threads got stuck somehow
 				// while dumping. 
-				mono_runtime_printf_err ("\nWaiting for dumping threads to resume\n");
+				MOSTLY_ASYNC_SAFE_PRINTF ("\nWaiting for dumping threads to resume\n");
 				sleep (1);
 			}
 
@@ -1073,20 +1092,19 @@ dump_native_stacktrace (const char *signal, void *ctx)
 		if (!double_faulted && mono_merp_enabled ()) {
 			if (pid == 0) {
 				if (output) {
-					mono_runtime_printf_err ("\nBefore merp upload\n");
 					gboolean merp_upload_success = mono_merp_invoke (crashed_pid, signal, output, &hashes);
 
-					if (!merp_upload_success)
-						mono_runtime_printf_err ("\nThe MERP upload step has failed.\n");
-					else {
+					if (!merp_upload_success) {
+						MOSTLY_ASYNC_SAFE_PRINTF("\nThe MERP upload step has failed.\n");
+					} else {
 						// Remove
-						mono_runtime_printf_err ("\nThe MERP upload step has succeeded.\n");
+						MOSTLY_ASYNC_SAFE_PRINTF("\nThe MERP upload step has succeeded.\n");
 						mono_summarize_timeline_phase_log (MonoSummaryDone);
 					}
 
 					mono_summarize_toggle_assertions (FALSE);
 				} else {
-					mono_runtime_printf_err ("\nMerp dump step not run, no dump created.\n");
+					MOSTLY_ASYNC_SAFE_PRINTF("\nMerp dump step not run, no dump created.\n");
 				}
 			}
 		}
@@ -1095,7 +1113,9 @@ dump_native_stacktrace (const char *signal, void *ctx)
 		if (pid == 0) {
 			dup2 (STDERR_FILENO, STDOUT_FILENO);
 
-			mono_runtime_printf_err ("\nDebug info from gdb:\n");
+			MOSTLY_ASYNC_SAFE_PRINTF ("\n=================================================================\n");
+			MOSTLY_ASYNC_SAFE_PRINTF("\tExternal Debugger Dump:\n");
+			MOSTLY_ASYNC_SAFE_PRINTF ("=================================================================\n");
 			mono_gdb_render_native_backtraces (crashed_pid);
 			exit (1);
 		}
@@ -1103,11 +1123,14 @@ dump_native_stacktrace (const char *signal, void *ctx)
 		waitpid (pid, &status, 0);
 
 		if (double_faulted) {
-			mono_runtime_printf_err ("\nExiting early due to double fault.\n");
+			MOSTLY_ASYNC_SAFE_PRINTF("\nExiting early due to double fault.\n");
+#ifndef DISABLE_CRASH_REPORTING
 			mono_state_free_mem (&merp_mem);
+#endif
 			exit (-1);
 		}
 
+#ifndef DISABLE_CRASH_REPORTING
 		if (output) {
 			// We've already done our gdb dump and our telemetry steps. Before exiting,
 			// see if we can notify any attached debugger instances.
@@ -1115,9 +1138,10 @@ dump_native_stacktrace (const char *signal, void *ctx)
 			// At this point we are accepting that the below step might end in a crash
 			mini_get_dbg_callbacks ()->send_crash (output, &hashes, 0 /* wait # seconds */);
 		}
-
 		output = NULL;
 		mono_state_free_mem (&merp_mem);
+#endif
+
 	}
 #endif
 #else
@@ -1128,7 +1152,7 @@ dump_native_stacktrace (const char *signal, void *ctx)
 	* set this on start-up as DUMPABLE has security implications. */
 	prctl (PR_SET_DUMPABLE, 1);
 
-	mono_runtime_printf_err ("\nNo native Android stacktrace (see debuggerd output).\n");
+	MOSTLY_ASYNC_SAFE_PRINTF("\nNo native Android stacktrace (see debuggerd output).\n");
 #endif
 #endif
 }
@@ -1159,7 +1183,7 @@ mono_post_native_crash_handler (const char *signal, void *ctx, MONO_SIG_HANDLER_
 
 
 static gboolean
-native_stack_with_gdb (pid_t crashed_pid, const char **argv, FILE *commands, char* commands_filename)
+native_stack_with_gdb (pid_t crashed_pid, const char **argv, int commands, char* commands_filename)
 {
 	gchar *gdb;
 
@@ -1173,15 +1197,15 @@ native_stack_with_gdb (pid_t crashed_pid, const char **argv, FILE *commands, cha
 	argv [3] = commands_filename;
 	argv [4] = "-nx";
 
-	fprintf (commands, "attach %ld\n", (long) crashed_pid);
-	fprintf (commands, "info threads\n");
-	fprintf (commands, "thread apply all bt\n");
+	MOSTLY_ASYNC_SAFE_FPRINTF (commands, "attach %ld\n", (long) crashed_pid);
+	MOSTLY_ASYNC_SAFE_FPRINTF (commands, "info threads\n");
+	MOSTLY_ASYNC_SAFE_FPRINTF (commands, "thread apply all bt\n");
 	if (mini_get_debug_options ()->verbose_gdb) {
 		for (int i = 0; i < 32; ++i) {
-			fprintf (commands, "info registers\n");
-			fprintf (commands, "info frame\n");
-			fprintf (commands, "info locals\n");
-			fprintf (commands, "up\n");
+			MOSTLY_ASYNC_SAFE_FPRINTF (commands, "info registers\n");
+			MOSTLY_ASYNC_SAFE_FPRINTF (commands, "info frame\n");
+			MOSTLY_ASYNC_SAFE_FPRINTF (commands, "info locals\n");
+			MOSTLY_ASYNC_SAFE_FPRINTF (commands, "up\n");
 		}
 	}
 
@@ -1190,7 +1214,7 @@ native_stack_with_gdb (pid_t crashed_pid, const char **argv, FILE *commands, cha
 
 
 static gboolean
-native_stack_with_lldb (pid_t crashed_pid, const char **argv, FILE *commands, char* commands_filename)
+native_stack_with_lldb (pid_t crashed_pid, const char **argv, int commands, char* commands_filename)
 {
 	gchar *lldb;
 
@@ -1204,19 +1228,19 @@ native_stack_with_lldb (pid_t crashed_pid, const char **argv, FILE *commands, ch
 	argv [3] = commands_filename;
 	argv [4] = "--no-lldbinit";
 
-	fprintf (commands, "process attach --pid %ld\n", (long) crashed_pid);
-	fprintf (commands, "thread list\n");
-	fprintf (commands, "thread backtrace all\n");
+	MOSTLY_ASYNC_SAFE_FPRINTF (commands, "process attach --pid %ld\n", (long) crashed_pid);
+	MOSTLY_ASYNC_SAFE_FPRINTF (commands, "thread list\n");
+	MOSTLY_ASYNC_SAFE_FPRINTF (commands, "thread backtrace all\n");
 	if (mini_get_debug_options ()->verbose_gdb) {
 		for (int i = 0; i < 32; ++i) {
-			fprintf (commands, "reg read\n");
-			fprintf (commands, "frame info\n");
-			fprintf (commands, "frame variable\n");
-			fprintf (commands, "up\n");
+			MOSTLY_ASYNC_SAFE_FPRINTF (commands, "reg read\n");
+			MOSTLY_ASYNC_SAFE_FPRINTF (commands, "frame info\n");
+			MOSTLY_ASYNC_SAFE_FPRINTF (commands, "frame variable\n");
+			MOSTLY_ASYNC_SAFE_FPRINTF (commands, "up\n");
 		}
 	}
-	fprintf (commands, "detach\n");
-	fprintf (commands, "quit\n");
+	MOSTLY_ASYNC_SAFE_FPRINTF (commands, "detach\n");
+	MOSTLY_ASYNC_SAFE_FPRINTF (commands, "quit\n");
 
 	return TRUE;
 }
@@ -1226,46 +1250,45 @@ mono_gdb_render_native_backtraces (pid_t crashed_pid)
 {
 #ifdef HAVE_EXECV
 	const char *argv [10];
-	FILE *commands;
-	char commands_filename [] = "/tmp/mono-gdb-commands.XXXXXX";
+	memset (argv, 0, sizeof (char*) * 10);
 
-	if (mkstemp (commands_filename) == -1)
-		return;
+	char commands_filename [100]; 
+	commands_filename [0] = '\0';
+	g_snprintf (commands_filename, sizeof (commands_filename), "/tmp/mono-gdb-commands.%d", crashed_pid);
 
-	commands = fopen (commands_filename, "w");
-	if (!commands) {
-		unlink (commands_filename);
+	// Create this file, overwriting if it already exists
+	int commands_handle = g_open (commands_filename, O_TRUNC | O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH);
+	if (commands_handle == -1) {
+		MOSTLY_ASYNC_SAFE_PRINTF ("Could not make debugger temp file %s\n", commands_filename);
 		return;
 	}
 
-	memset (argv, 0, sizeof (char*) * 10);
-
 #if defined(HOST_DARWIN)
-	if (native_stack_with_lldb (crashed_pid, argv, commands, commands_filename))
+	if (native_stack_with_lldb (crashed_pid, argv, commands_handle, commands_filename))
 		goto exec;
 #endif
 
-	if (native_stack_with_gdb (crashed_pid, argv, commands, commands_filename))
+	if (native_stack_with_gdb (crashed_pid, argv, commands_handle, commands_filename))
 		goto exec;
 
 #if !defined(HOST_DARWIN)
-	if (native_stack_with_lldb (crashed_pid, argv, commands, commands_filename))
+	if (native_stack_with_lldb (crashed_pid, argv, commands_handle, commands_filename))
 		goto exec;
 #endif
 
-	fprintf (stderr, "mono_gdb_render_native_backtraces not supported on this platform, unable to find gdb or lldb\n");
+	MOSTLY_ASYNC_SAFE_PRINTF ("mono_gdb_render_native_backtraces not supported on this platform, unable to find gdb or lldb\n");
 
-	fclose (commands);
+	close (commands_handle);
 	unlink (commands_filename);
 	return;
 
 exec:
-	fclose (commands);
+	close (commands_handle);
 	execv (argv [0], (char**)argv);
 
 	_exit (-1);
 #else
-	fprintf (stderr, "mono_gdb_render_native_backtraces not supported on this platform\n");
+	MOSTLY_ASYNC_SAFE_PRINTF ("mono_gdb_render_native_backtraces not supported on this platform\n");
 #endif // HAVE_EXECV
 }
 

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -956,19 +956,10 @@ dump_native_stacktrace (const char *signal, void *ctx)
 	} else {
 		MOSTLY_ASYNC_SAFE_PRINTF ("\nAn error has occured in the native fault reporting. Some diagnostic information will be unavailable.\n");
 
-
-#if 1
-	pid_t crashed_pid = getpid ();
-	// Break here
-	MOSTLY_ASYNC_SAFE_PRINTF ("Attach to PID %d. Supervisor thread will signal us shortly.\n", crashed_pid);
-	while (TRUE) {
-		// Sleep for 1 second.
-		g_usleep (1000 * 1000);
-	}
-#endif
-
+#ifndef DISABLE_CRASH_REPORTING
 		// In case still enabled
 		mono_summarize_toggle_assertions (FALSE);
+#endif
 	}
 
 #ifdef HAVE_BACKTRACE_SYMBOLS
@@ -1181,17 +1172,24 @@ mono_post_native_crash_handler (const char *signal, void *ctx, MONO_SIG_HANDLER_
 }
 #endif /* !MONO_CROSS_COMPILE */
 
+static gchar *gdb_path;
+static gchar *lldb_path;
+
+void
+mono_init_native_crash_info (void)
+{
+	gdb_path = g_find_program_in_path ("gdb");
+	lldb_path = g_find_program_in_path ("lldb");
+}
+
 
 static gboolean
 native_stack_with_gdb (pid_t crashed_pid, const char **argv, int commands, char* commands_filename)
 {
-	gchar *gdb;
-
-	gdb = g_find_program_in_path ("gdb");
-	if (!gdb)
+	if (!gdb_path)
 		return FALSE;
 
-	argv [0] = gdb;
+	argv [0] = gdb_path;
 	argv [1] = "-batch";
 	argv [2] = "-x";
 	argv [3] = commands_filename;
@@ -1216,13 +1214,10 @@ native_stack_with_gdb (pid_t crashed_pid, const char **argv, int commands, char*
 static gboolean
 native_stack_with_lldb (pid_t crashed_pid, const char **argv, int commands, char* commands_filename)
 {
-	gchar *lldb;
-
-	lldb = g_find_program_in_path ("lldb");
-	if (!lldb)
+	if (!lldb_path)
 		return FALSE;
 
-	argv [0] = lldb;
+	argv [0] = lldb_path;
 	argv [1] = "--batch";
 	argv [2] = "--source";
 	argv [3] = commands_filename;

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -878,6 +878,7 @@ mono_runtime_setup_stat_profiler (void)
 static void
 dump_memory_around_ip (void *ctx)
 {
+#if 0
 #ifdef MONO_ARCH_HAVE_SIGCTX_TO_MONOCTX
 	if (!ctx)
 		return;
@@ -891,6 +892,7 @@ dump_memory_around_ip (void *ctx)
 	} else {
 		mono_runtime_printf_err ("instruction pointer is NULL, skip dumping");
 	}
+#endif
 #endif
 }
 
@@ -926,12 +928,37 @@ print_process_map (void)
 }
 
 static void
+assert_printer_callback (void)
+{
+	mono_dump_native_crash_info ("SIGABRT", NULL, NULL);
+}
+
+static void
 dump_native_stacktrace (const char *signal, void *ctx)
 {
+	mono_memory_barrier ();
+	static gint32 middle_of_crash = 0x0;
+	gint32 double_faulted = mono_atomic_cas_i32 ((gint32 *)&middle_of_crash, 0x1, 0x0);
+	mono_memory_write_barrier ();
+
+	if (!double_faulted) {
+		mono_runtime_printf_err ("Dumping, not in media res %d\n", double_faulted);
+		g_assertion_disable_global (assert_printer_callback);
+	} else {
+		mono_runtime_printf_err ("\nAn error has occured in the native fault reporting. Some diagnostic information will be unavailable.\n");
+
+		// In case still enabled
+		mono_summarize_toggle_assertions (FALSE);
+	}
+
 #ifdef HAVE_BACKTRACE_SYMBOLS
 	void *array [256];
 	char **names;
 	int i, size;
+
+#if 0
+	// Crashes a lot in backtrace_symbols
+	// FIXME: make this work using dladdr
 
 	mono_runtime_printf_err ("\nNative stacktrace:\n");
 
@@ -940,6 +967,7 @@ dump_native_stacktrace (const char *signal, void *ctx)
 	for (i = 0; i < size; ++i) {
 		mono_runtime_printf_err ("\t%s", names [i]);
 	}
+#endif
 
 	/* Try to get more meaningful information using gdb */
 	// FIXME: Remove locking and reenable. Can race with itself
@@ -960,47 +988,51 @@ dump_native_stacktrace (const char *signal, void *ctx)
 		MonoStackHash hashes;
 
 #ifndef DISABLE_CRASH_REPORTING
-		gboolean leave = FALSE;
-		gboolean dump_for_merp = FALSE;
+		if (!double_faulted) {
+			gboolean leave = FALSE;
+			gboolean dump_for_merp = FALSE;
 #if defined(TARGET_OSX)
-		dump_for_merp = mono_merp_enabled ();
+			dump_for_merp = mono_merp_enabled ();
 #endif
 
-		if (!dump_for_merp) {
+			if (!dump_for_merp) {
 #ifdef DISABLE_STRUCTURED_CRASH
-			leave = TRUE;
+				leave = TRUE;
 #else
-			mini_register_sigterm_handler ();
+				mini_register_sigterm_handler ();
 #endif
-		}
+			}
 
-		MonoContext mctx;
-		MonoContext *passed_ctx = NULL;
-		if (!leave && ctx) {
-			mono_sigctx_to_monoctx (ctx, &mctx);
-			passed_ctx = &mctx;
-		}
+			MonoContext mctx;
+			MonoContext *passed_ctx = NULL;
+			if (!leave && ctx) {
+				mono_sigctx_to_monoctx (ctx, &mctx);
+				passed_ctx = &mctx;
+			}
 
-		if (!leave) {
-			mono_summarize_timeline_start ();
-			// Returns success, so leave if !success
-			leave = !mono_threads_summarize (passed_ctx, &output, &hashes, FALSE, TRUE, NULL, 0);
-		}
+			if (!leave) {
+				mono_summarize_timeline_start ();
+				mono_summarize_toggle_assertions (TRUE);
+				// Returns success, so leave if !success
+				leave = !mono_threads_summarize (passed_ctx, &output, &hashes, FALSE, TRUE, NULL, 0);
+			}
 
-		if (!leave) {
-			// Wait for the other threads to clean up and exit their handlers
-			// We can't lock / wait indefinitely, in case one of these threads got stuck somehow
-			// while dumping. 
-			mono_runtime_printf_err ("\nWaiting for dumping threads to resume\n");
-			sleep (1);
-		}
+			if (!leave) {
+				// Wait for the other threads to clean up and exit their handlers
+				// We can't lock / wait indefinitely, in case one of these threads got stuck somehow
+				// while dumping. 
+				mono_runtime_printf_err ("\nWaiting for dumping threads to resume\n");
+				sleep (1);
+			}
 
-		// We want our crash, and don't have telemetry
-		// So we dump to disk
-		if (!leave && !dump_for_merp) {
-			mono_summarize_timeline_phase_log (MonoSummaryCleanup);
-			mono_crash_dump (output, &hashes);
-			mono_summarize_timeline_phase_log (MonoSummaryDone);
+			// We want our crash, and don't have telemetry
+			// So we dump to disk
+			if (!leave && !dump_for_merp) {
+				mono_summarize_timeline_phase_log (MonoSummaryCleanup);
+				mono_crash_dump (output, &hashes);
+				mono_summarize_timeline_phase_log (MonoSummaryDone);
+				mono_summarize_toggle_assertions (FALSE);
+			}
 		}
 #endif // DISABLE_CRASH_REPORTING
 
@@ -1030,13 +1062,21 @@ dump_native_stacktrace (const char *signal, void *ctx)
 #endif
 
 #if defined(TARGET_OSX) && !defined(DISABLE_CRASH_REPORTING)
-		if (mono_merp_enabled ()) {
+		if (!double_faulted && mono_merp_enabled ()) {
 			if (pid == 0) {
 				if (output) {
+					mono_runtime_printf_err ("\nBefore merp upload\n");
 					gboolean merp_upload_success = mono_merp_invoke (crashed_pid, signal, output, &hashes);
 
-					g_assert (merp_upload_success);
-					mono_summarize_timeline_phase_log (MonoSummaryDone);
+					if (!merp_upload_success)
+						mono_runtime_printf_err ("\nThe MERP upload step has failed.\n");
+					else {
+						// Remove
+						mono_runtime_printf_err ("\nThe MERP upload step has succeeded.\n");
+						mono_summarize_timeline_phase_log (MonoSummaryDone);
+					}
+
+					mono_summarize_toggle_assertions (FALSE);
 				} else {
 					mono_runtime_printf_err ("\nMerp dump step not run, no dump created.\n");
 				}
@@ -1054,11 +1094,16 @@ dump_native_stacktrace (const char *signal, void *ctx)
 
 		waitpid (pid, &status, 0);
 
-		// We've already done our gdb dump and our telemetry steps. Before exiting,
-		// see if we can notify any attached debugger instances.
-		//
-		// At this point we are accepting that the below step might end in a crash
-		mini_get_dbg_callbacks ()->send_crash (output, &hashes, 0 /* wait # seconds */);
+		if (double_faulted)
+			exit (-1);
+
+		if (output) {
+			// We've already done our gdb dump and our telemetry steps. Before exiting,
+			// see if we can notify any attached debugger instances.
+			//
+			// At this point we are accepting that the below step might end in a crash
+			mini_get_dbg_callbacks ()->send_crash (output, &hashes, 0 /* wait # seconds */);
+		}
 	}
 #endif
 #else

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -1195,15 +1195,15 @@ native_stack_with_gdb (pid_t crashed_pid, const char **argv, int commands, char*
 	argv [3] = commands_filename;
 	argv [4] = "-nx";
 
-	MOSTLY_ASYNC_SAFE_FPRINTF (commands, "attach %ld\n", (long) crashed_pid);
-	MOSTLY_ASYNC_SAFE_FPRINTF (commands, "info threads\n");
-	MOSTLY_ASYNC_SAFE_FPRINTF (commands, "thread apply all bt\n");
+	g_async_safe_fprintf (commands, "attach %ld\n", (long) crashed_pid);
+	g_async_safe_fprintf (commands, "info threads\n");
+	g_async_safe_fprintf (commands, "thread apply all bt\n");
 	if (mini_get_debug_options ()->verbose_gdb) {
 		for (int i = 0; i < 32; ++i) {
-			MOSTLY_ASYNC_SAFE_FPRINTF (commands, "info registers\n");
-			MOSTLY_ASYNC_SAFE_FPRINTF (commands, "info frame\n");
-			MOSTLY_ASYNC_SAFE_FPRINTF (commands, "info locals\n");
-			MOSTLY_ASYNC_SAFE_FPRINTF (commands, "up\n");
+			g_async_safe_fprintf (commands, "info registers\n");
+			g_async_safe_fprintf (commands, "info frame\n");
+			g_async_safe_fprintf (commands, "info locals\n");
+			g_async_safe_fprintf (commands, "up\n");
 		}
 	}
 
@@ -1223,19 +1223,19 @@ native_stack_with_lldb (pid_t crashed_pid, const char **argv, int commands, char
 	argv [3] = commands_filename;
 	argv [4] = "--no-lldbinit";
 
-	MOSTLY_ASYNC_SAFE_FPRINTF (commands, "process attach --pid %ld\n", (long) crashed_pid);
-	MOSTLY_ASYNC_SAFE_FPRINTF (commands, "thread list\n");
-	MOSTLY_ASYNC_SAFE_FPRINTF (commands, "thread backtrace all\n");
+	g_async_safe_fprintf (commands, "process attach --pid %ld\n", (long) crashed_pid);
+	g_async_safe_fprintf (commands, "thread list\n");
+	g_async_safe_fprintf (commands, "thread backtrace all\n");
 	if (mini_get_debug_options ()->verbose_gdb) {
 		for (int i = 0; i < 32; ++i) {
-			MOSTLY_ASYNC_SAFE_FPRINTF (commands, "reg read\n");
-			MOSTLY_ASYNC_SAFE_FPRINTF (commands, "frame info\n");
-			MOSTLY_ASYNC_SAFE_FPRINTF (commands, "frame variable\n");
-			MOSTLY_ASYNC_SAFE_FPRINTF (commands, "up\n");
+			g_async_safe_fprintf (commands, "reg read\n");
+			g_async_safe_fprintf (commands, "frame info\n");
+			g_async_safe_fprintf (commands, "frame variable\n");
+			g_async_safe_fprintf (commands, "up\n");
 		}
 	}
-	MOSTLY_ASYNC_SAFE_FPRINTF (commands, "detach\n");
-	MOSTLY_ASYNC_SAFE_FPRINTF (commands, "quit\n");
+	g_async_safe_fprintf (commands, "detach\n");
+	g_async_safe_fprintf (commands, "quit\n");
 
 	return TRUE;
 }

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3312,7 +3312,8 @@ MONO_SIG_HANDLER_FUNC_DEBUG (static, mono_sigsegv_signal_handler_debug)
 MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
 #endif
 {
-	MonoJitInfo *ji;
+	MonoJitInfo *ji = NULL;
+	MonoDomain *domain = mono_domain_get ();
 	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
 	gpointer fault_addr = NULL;
 #ifdef HAVE_SIG_INFO
@@ -3353,7 +3354,8 @@ MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
 	}
 #endif
 
-	ji = mono_jit_info_table_find_internal (mono_domain_get (), mono_arch_ip_from_context (ctx), TRUE, TRUE);
+	if (domain)
+		ji = mono_jit_info_table_find_internal (domain, mono_arch_ip_from_context (ctx), TRUE, TRUE);
 
 #ifdef MONO_ARCH_SIGSEGV_ON_ALTSTACK
 	if (mono_handle_soft_stack_ovf (jit_tls, ji, ctx, info, (guint8*)info->si_addr))
@@ -3371,7 +3373,7 @@ MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
 	}
 #endif
 
-	if (jit_tls->stack_size &&
+	if (jit_tls && jit_tls->stack_size &&
 		ABS ((guint8*)fault_addr - ((guint8*)jit_tls->end_of_stack - jit_tls->stack_size)) < 8192 * sizeof (gpointer)) {
 		/*
 		 * The hard-guard page has been hit: there is not much we can do anymore

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4103,6 +4103,9 @@ mono_interp_to_native_trampoline (gpointer addr, gpointer ccontext)
 	mini_get_interp_callbacks ()->to_native_trampoline (addr, ccontext);
 }
 
+static const char*
+mono_get_runtime_build_version (void);
+
 MonoDomain *
 mini_init (const char *filename, const char *runtime_version)
 {
@@ -4168,6 +4171,7 @@ mini_init (const char *filename, const char *runtime_version)
 	callbacks.create_ftnptr = mini_create_ftnptr;
 	callbacks.get_addr_from_ftnptr = mini_get_addr_from_ftnptr;
 	callbacks.get_runtime_build_info = mono_get_runtime_build_info;
+	callbacks.get_runtime_build_version = mono_get_runtime_build_version;
 	callbacks.set_cast_details = mono_set_cast_details;
 	callbacks.debug_log = mini_get_dbg_callbacks ()->debug_log;
 	callbacks.debug_log_is_enabled = mini_get_dbg_callbacks ()->debug_log_is_enabled;
@@ -4860,6 +4864,12 @@ void
 mono_set_verbose_level (guint32 level)
 {
 	mini_verbose = level;
+}
+
+static const char*
+mono_get_runtime_build_version (void)
+{
+	return FULL_VERSION;
 }
 
 /**

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4289,6 +4289,8 @@ mini_init (const char *filename, const char *runtime_version)
 
 	mono_thread_info_signals_init ();
 
+	mono_init_native_crash_info ();
+
 #ifndef MONO_CROSS_COMPILE
 	mono_runtime_install_handlers ();
 #endif

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -513,6 +513,9 @@ void
 mono_cross_helpers_run (void);
 
 void
+mono_init_native_crash_info (void);
+
+void
 mono_dump_native_crash_info (const char *signal, void *ctx, MONO_SIG_HANDLER_INFO_TYPE *info);
 
 void

--- a/mono/mini/mini-unwind.h
+++ b/mono/mini/mini-unwind.h
@@ -177,7 +177,7 @@ mono_unwind_ops_encode_full (GSList *unwind_ops, guint32 *out_len, gboolean enab
 guint8*
 mono_unwind_ops_encode (GSList *unwind_ops, guint32 *out_len);
 
-void
+gboolean
 mono_unwind_frame (guint8 *unwind_info, guint32 unwind_info_len, 
 				   guint8 *start_ip, guint8 *end_ip, guint8 *ip, guint8 **mark_locations,
 				   mono_unwind_reg_t *regs, int nregs,

--- a/mono/mini/mini-wasm.c
+++ b/mono/mini/mini-wasm.c
@@ -522,6 +522,12 @@ mono_runtime_cleanup_handlers (void)
 {
 }
 
+void
+mono_init_native_crash_info (void)
+{
+	return;
+}
+
 gboolean
 mono_thread_state_init_from_handle (MonoThreadUnwindState *tctx, MonoThreadInfo *info, void *sigctx)
 {

--- a/mono/mini/mini-windows.c
+++ b/mono/mini/mini-windows.c
@@ -245,6 +245,12 @@ mono_runtime_cleanup_handlers (void)
 #endif
 }
 
+void
+mono_init_native_crash_info (void)
+{
+	return;
+}
+
 #if G_HAVE_API_SUPPORT (HAVE_CLASSIC_WINAPI_SUPPORT | HAVE_UWP_WINAPI_SUPPORT)
 /* mono_chain_signal:
  *

--- a/mono/mini/unwind.c
+++ b/mono/mini/unwind.c
@@ -536,8 +536,10 @@ typedef struct {
  * N was saved, or NULL, if it was not saved by this frame.
  * MARK_LOCATIONS should contain the locations marked by mono_emit_unwind_op_mark_loc (), if any.
  * This function is signal safe.
+ *
+ * It returns FALSE on failure
  */
-void
+gboolean
 mono_unwind_frame (guint8 *unwind_info, guint32 unwind_info_len, 
 				   guint8 *start_ip, guint8 *end_ip, guint8 *ip, guint8 **mark_locations,
 				   mono_unwind_reg_t *regs, int nregs,
@@ -595,7 +597,10 @@ mono_unwind_frame (guint8 *unwind_info, guint32 unwind_info_len,
 				reg = decode_uleb128 (p, &p);
 				hwreg = mono_dwarf_reg_to_hw_reg (reg);
 				offset = decode_sleb128 (p, &p);
-				g_assert (reg < NUM_DWARF_REGS);
+				if (reg >= NUM_DWARF_REGS) {
+					mono_runtime_printf_err ("Unwind failure. Assertion at %s %d\n.", __FILE__, __LINE__);
+					return FALSE;
+				}
 				reg_saved [hwreg] = TRUE;
 				locations [hwreg].loc_type = LOC_OFFSET;
 				locations [hwreg].offset = offset * DWARF_DATA_ALIGN;
@@ -604,7 +609,10 @@ mono_unwind_frame (guint8 *unwind_info, guint32 unwind_info_len,
 				reg = decode_uleb128 (p, &p);
 				hwreg = mono_dwarf_reg_to_hw_reg (reg);
 				offset = decode_uleb128 (p, &p);
-				g_assert (reg < NUM_DWARF_REGS);
+				if (reg >= NUM_DWARF_REGS) {
+					mono_runtime_printf_err ("Unwind failure. Assertion at %s %d\n.", __FILE__, __LINE__);
+					return FALSE;
+				}
 				reg_saved [hwreg] = TRUE;
 				locations [hwreg].loc_type = LOC_OFFSET;
 				locations [hwreg].offset = offset * DWARF_DATA_ALIGN;
@@ -626,7 +634,10 @@ mono_unwind_frame (guint8 *unwind_info, guint32 unwind_info_len,
 				p += 4;
 				break;
 			case DW_CFA_remember_state:
-				g_assert (state_stack_pos == 0);
+				if (state_stack_pos != 0) {
+					mono_runtime_printf_err ("Unwind failure. Assertion at %s %d\n.", __FILE__, __LINE__);
+					return FALSE;
+				}
 				memcpy (&state_stack [0].locations, &locations, sizeof (locations));
 				memcpy (&state_stack [0].reg_saved, &reg_saved, sizeof (reg_saved));
 				state_stack [0].cfa_reg = cfa_reg;
@@ -634,7 +645,10 @@ mono_unwind_frame (guint8 *unwind_info, guint32 unwind_info_len,
 				state_stack_pos ++;
 				break;
 			case DW_CFA_restore_state:
-				g_assert (state_stack_pos == 1);
+				if (state_stack_pos != 1) {
+					mono_runtime_printf_err ("Unwind failure. Assertion at %s %d\n.", __FILE__, __LINE__);
+					return FALSE;
+				}
 				state_stack_pos --;
 				memcpy (&locations, &state_stack [0].locations, sizeof (locations));
 				memcpy (&reg_saved, &state_stack [0].reg_saved, sizeof (reg_saved));
@@ -642,16 +656,21 @@ mono_unwind_frame (guint8 *unwind_info, guint32 unwind_info_len,
 				cfa_offset = state_stack [0].cfa_offset;
 				break;
 			case DW_CFA_mono_advance_loc:
-				g_assert (mark_locations [0]);
+				if (!mark_locations [0]) {
+					mono_runtime_printf_err ("Unwind failure. Assertion at %s %d\n.", __FILE__, __LINE__);
+					return FALSE;
+				}
 				pos = mark_locations [0] - start_ip;
 				break;
 			default:
-				g_assert_not_reached ();
+				mono_runtime_printf_err ("Unwind failure. Illegal value for switch statement, assertion at %s %d\n.", __FILE__, __LINE__);
+				return FALSE;
 			}
 			break;
 		}
 		default:
-			g_assert_not_reached ();
+			mono_runtime_printf_err ("Unwind failure. Illegal value for switch statement, assertion at %s %d\n.", __FILE__, __LINE__);
+			return FALSE;
 		}
 	}
 
@@ -661,13 +680,16 @@ mono_unwind_frame (guint8 *unwind_info, guint32 unwind_info_len,
 	if (cfa_reg == -1) {
 		mono_runtime_printf_err ("Unset cfa_reg in method %s. Memory around ip (%p):", mono_get_method_from_ip (ip), ip);
 		mono_dump_mem (ip - 0x10, 0x40);
-		g_assert_not_reached ();
+		return FALSE;
 	}
 	cfa_val = (guint8*)regs [mono_dwarf_reg_to_hw_reg (cfa_reg)] + cfa_offset;
 	for (hwreg = 0; hwreg < NUM_HW_REGS; ++hwreg) {
 		if (reg_saved [hwreg] && locations [hwreg].loc_type == LOC_OFFSET) {
 			int dwarfreg = mono_hw_reg_to_dwarf_reg (hwreg);
-			g_assert (hwreg < nregs);
+			if (hwreg >= nregs) {
+				mono_runtime_printf_err ("Unwind failure. Assertion at %s %d\n.", __FILE__, __LINE__);
+				return FALSE;
+			}
 			if (IS_DOUBLE_REG (dwarfreg))
 				regs [hwreg] = *(guint64*)(cfa_val + locations [hwreg].offset);
 			else
@@ -678,6 +700,9 @@ mono_unwind_frame (guint8 *unwind_info, guint32 unwind_info_len,
 	}
 
 	*out_cfa = cfa_val;
+
+	// Success
+	return TRUE;
 }
 
 void

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -318,6 +318,7 @@ TESTS_CS_SRC=		\
 	exception18.cs		\
 	exception-invokes.cs		\
 	merp-json-valid.cs		\
+	merp-crash-test.cs		\
 	exception19.cs		\
 	exception20.cs		\
 	exception21.cs		\
@@ -1079,7 +1080,7 @@ if HOST_DARWIN
 # see https://github.com/mono/mono/issues/10845
 PLATFORM_DISABLED_TESTS += monitor-wait-abort.exe
 else
-PLATFORM_DISABLED_TESTS += merp-json-valid.exe
+PLATFORM_DISABLED_TESTS += merp-json-valid.exe merp-crash-test.exe
 endif
 
 if AMD64
@@ -2064,6 +2065,9 @@ reference-loader.exe: reference-loader.cs TestingReferenceAssembly.dll TestingRe
 	$(MCS) -r:$(CLASS)/System.dll -r:TestDriver.dll -r:TestingReferenceAssembly.dll -r:TestingReferenceReferenceAssembly.dll $(TEST_DRIVER_HARD_KILL_FEATURE) -out:$@ $(srcdir)/reference-loader.cs
 
 merp-json-valid.exe: merp-json-valid.cs
+	$(MCS) -r:$(CLASS)/System.Web.Extensions.dll -r:$(CLASS)/System.dll -r:$(CLASS)/System.Xml.dll -r:$(CLASS)/System.Core.dll -out:$@ $<
+
+merp-crash-test.exe: merp-crash-test.cs
 	$(MCS) -r:$(CLASS)/System.Web.Extensions.dll -r:$(CLASS)/System.dll -r:$(CLASS)/System.Xml.dll -r:$(CLASS)/System.Core.dll -out:$@ $<
 
 TestingReferenceAssembly.dll: TestingReferenceAssembly.cs

--- a/mono/tests/merp-crash-test.cs
+++ b/mono/tests/merp-crash-test.cs
@@ -1,0 +1,358 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Reflection;
+using System.Web.Script.Serialization;
+using Diag = System.Diagnostics;
+using System.Runtime.InteropServices;
+
+class C
+{
+	class CrasherClass
+	{
+		public static List<Tuple<String, Action>> Crashers;
+		public static int StresserIndex;
+
+		static CrasherClass ()
+		{
+			Crashers = new List<Tuple<String, Action>> ();
+
+			// Basic functionality
+			Crashers.Add(new Tuple<String, Action> ("MerpCrashManaged", MerpCrashManaged));
+			//  Run this test for stress tests
+			//
+			//  I've ran a burn-in with all of them of
+			//  1,000 - 10,000 runs already.
+			//
+			//  Feel free to change by moving this line.
+			StresserIndex = Crashers.Count - 1;
+
+			Crashers.Add(new Tuple<String, Action> ("MerpCrashMalloc", MerpCrashMalloc));
+
+			Crashers.Add(new Tuple<String, Action> ("MerpCrashNullFp", MerpCrashNullFp));
+			Crashers.Add(new Tuple<String, Action> ("MerpCrashExceptionHook", MerpCrashUnhandledExceptionHook));
+
+			// Specific Edge Cases
+			Crashers.Add(new Tuple<String, Action> ("MerpCrashDladdr", MerpCrashDladdr));
+			Crashers.Add(new Tuple<String, Action> ("MerpCrashSnprintf", MerpCrashSnprintf));
+			Crashers.Add(new Tuple<String, Action> ("MerpCrashDomainUnload", MerpCrashDomainUnload));
+			Crashers.Add(new Tuple<String, Action> ("MerpCrashUnbalancedGCSafe", MerpCrashUnbalancedGCSafe));
+		}
+
+		public static void 
+		MerpCrashManaged ()
+		{
+			unsafe { Console.WriteLine("{0}", *(int*) -1); }
+		}
+
+		[DllImport("libtest")]
+		public static extern void mono_test_MerpCrashSnprintf ();
+
+		// This test tries to test the writer's reentrancy
+		public static void 
+		MerpCrashSnprintf ()
+		{
+			mono_test_MerpCrashSnprintf ();
+		}
+
+		[DllImport("libtest")]
+		public static extern void mono_test_MerpCrashDladdr ();
+
+		public static void 
+		MerpCrashDladdr ()
+		{
+			mono_test_MerpCrashDladdr ();
+		}
+
+		[DllImport("libtest")]
+		public static extern void mono_test_MerpCrashMalloc ();
+
+		public static void 
+		MerpCrashMalloc ()
+		{
+			mono_test_MerpCrashMalloc ();
+		}
+
+		[DllImport("libtest")]
+		public static extern void mono_test_MerpCrashLoaderLock ();
+
+		public static void 
+		MerpCrashLoaderLock ()
+		{
+			mono_test_MerpCrashLoaderLock ();
+		}
+
+		[DllImport("libtest")]
+		public static extern void mono_test_MerpCrashDomainUnload ();
+
+		public static void 
+		MerpCrashDomainUnload ()
+		{
+			mono_test_MerpCrashDomainUnload ();
+		}
+
+		[DllImport("libtest")]
+		public static extern void mono_test_MerpCrashUnbalancedGCSafe ();
+
+		public static void 
+		MerpCrashUnbalancedGCSafe ()
+		{
+			mono_test_MerpCrashUnbalancedGCSafe ();
+		}
+
+		[DllImport("libtest")]
+		public static extern void mono_test_MerpCrashNullFp ();
+
+		public static void 
+		MerpCrashNullFp ()
+		{
+			mono_test_MerpCrashNullFp ();
+		}
+
+		[DllImport("libtest")]
+		public static extern void mono_test_MerpCrashUnhandledExceptionHook ();
+
+		public static void 
+		MerpCrashUnhandledExceptionHook ()
+		{
+			AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(HandleException);
+			throw new Exception ("This is Unhandled");
+		}
+
+		public static void HandleException (object sender, UnhandledExceptionEventArgs e)
+		{
+			Console.WriteLine ("And now to crash inside the hook");
+			mono_test_MerpCrashUnhandledExceptionHook ();
+		}
+	}
+
+	static string configDir = "./";
+
+	public static void 
+	CrashWithMerp (int testNum)
+	{
+		SetupCrash (configDir);
+		CrasherClass.Crashers [Convert.ToInt32 (testNum)].Item2 ();
+	}
+
+	public static string env = Environment.GetEnvironmentVariable ("MONO_PATH");
+	public static string this_assembly_path = Path.GetDirectoryName (Assembly.GetExecutingAssembly ().Location);
+
+	public static void 
+	SetupCrash (string configDir)
+	{
+		var monoType = Type.GetType ("Mono.Runtime", false);
+		var m = monoType.GetMethod("EnableMicrosoftTelemetry", BindingFlags.NonPublic | BindingFlags.Static);
+
+		// This leads to open -a /bin/cat, which errors out, but errors
+		// in invoking merp are only logged errors, not fatal assertions.
+		var merpGUIPath = "/bin/cat";
+		var appBundleId = "com.xam.Minimal";
+		var appSignature = "Test.Xam.Minimal";
+		var appVersion = "123456";
+		var eventType = "AppleAppCrash";
+		var appPath = "/where/mono/lives";
+		var m_params = new object[] { appBundleId, appSignature, appVersion, merpGUIPath, eventType, appPath, configDir };
+
+		m.Invoke(null, m_params);	
+
+		DumpLogSet ();
+	}
+
+	public static void 
+	TestValidateAndCleanup (string configDir, bool silent)
+	{
+		DumpLogCheck ();
+
+		var xmlFilePath = String.Format("{0}CustomLogsMetadata.xml", configDir);
+		var paramsFilePath = String.Format("{0}MERP.uploadparams.txt", configDir);
+		var crashFilePath = String.Format("{0}lastcrashlog.txt", configDir);
+
+		// Fixme: Maybe parse these json files rather than
+		// just checking they exist
+		var xmlFileExists = File.Exists (xmlFilePath);
+		var paramsFileExists = File.Exists (paramsFilePath);
+		var crashFileExists = File.Exists (crashFilePath);
+
+		if (xmlFileExists) {
+			var text = File.ReadAllText (xmlFilePath);
+			if (!silent)
+				Console.WriteLine ("Xml file {0}", text);
+			File.Delete (xmlFilePath);
+		}
+
+		if (paramsFileExists) {
+			var text = File.ReadAllText (paramsFilePath);
+			if (!silent)
+				Console.WriteLine ("Params file {0}", text);
+			File.Delete (paramsFilePath);
+		}
+
+		if (crashFileExists) {
+			var crashFile = File.ReadAllText (crashFilePath);
+			File.Delete (crashFilePath);
+
+			var checker = new JavaScriptSerializer ();
+
+			// Throws if invalid json
+			if (!silent)
+				Console.WriteLine("Validating: {0}",  crashFile);
+			try {
+				var obj = checker.DeserializeObject (crashFile);
+			} catch (Exception e) {
+				throw new Exception (String.Format ("Invalid json: {0}", crashFile));
+			}
+
+			File.Delete (crashFilePath);
+			// Assert it has the required merp fields
+		}
+
+		if (!xmlFileExists)
+			throw new Exception (String.Format ("Did not produce {0}", xmlFilePath));
+
+		if (!paramsFileExists)
+			throw new Exception (String.Format ("Did not produce {0}", paramsFilePath));
+
+		if (!crashFileExists)
+			throw new Exception (String.Format ("Did not produce {0}", crashFilePath));
+	}
+
+	public static void
+	Cleanup (string configDir)
+	{
+		var xmlFilePath = String.Format("{0}CustomLogsMetadata.xml", configDir);
+		var paramsFilePath = String.Format("{0}MERP.uploadparams.txt", configDir);
+		var crashFilePath = String.Format("{0}lastcrashlog.txt", configDir);
+
+		// Fixme: Maybe parse these json files rather than
+		// just checking they exist
+		var xmlFileExists = File.Exists (xmlFilePath);
+		var paramsFileExists = File.Exists (paramsFilePath);
+		var crashFileExists = File.Exists (crashFilePath);
+
+		if (xmlFileExists)
+			File.Delete (xmlFilePath);
+
+		if (paramsFileExists)
+			File.Delete (paramsFilePath);
+
+		if (crashFileExists)
+			File.Delete (crashFilePath);
+	}
+
+	static void DumpLogSet ()
+	{
+		var monoType = Type.GetType ("Mono.Runtime", false);
+		var convert = monoType.GetMethod("EnableCrashReportLog", BindingFlags.NonPublic | BindingFlags.Static);
+		convert.Invoke(null, new object[] { "./" });
+	}
+
+	static void DumpLogUnset ()
+	{
+		var monoType = Type.GetType ("Mono.Runtime", false);
+		var convert = monoType.GetMethod("EnableCrashReportLog", BindingFlags.NonPublic | BindingFlags.Static);
+		convert.Invoke(null, new object[] { null });
+	}
+
+	static void DumpLogCheck ()
+	{
+		var monoType = Type.GetType ("Mono.Runtime", false);
+		var convert = monoType.GetMethod("CheckCrashReportLog", BindingFlags.NonPublic | BindingFlags.Static);
+		var result = (int) convert.Invoke(null, new object[] { "./", true });
+		// Value of enum
+		string [] levels = new string [] { "None", "Setup", "SuspendHandshake", "UnmanagedStacks", "ManagedStacks", "StateWriter", "StateWriterDone", "MerpWriter", "MerpInvoke", "Cleanup", "Done", "DoubleFault" };
+
+		if ("MerpInvoke" == levels [result]) {
+			Console.WriteLine ("Merp invoke command failed, expected failure?");
+		} else if ("Done" != levels [result]) {
+			throw new Exception (String.Format ("Crash level not done, failed in stage: {0}", levels [result]));
+		}
+	}
+
+
+	public static void 
+	SpawnCrashingRuntime (string runtime, int testNum, bool silent)
+	{
+		var asm = "merp-crash-test.exe";
+		var pi = new Diag.ProcessStartInfo ();
+		pi.UseShellExecute = false;
+		pi.FileName = runtime;
+		pi.Arguments = String.Format ("{0} {1}", asm, testNum);;
+		pi.Environment ["MONO_PATH"] = env;
+
+		if (!silent)
+			Console.WriteLine ("MONO_PATH={0} {1} {2} {3}", env, runtime, asm, testNum);
+
+		var process = Diag.Process.Start (pi);
+		process.WaitForExit ();
+
+		TestValidateAndCleanup (configDir, silent);
+	}
+
+	public static void Main (string [] args)
+	{
+		if (args.Length == 0) {
+			string processExe = Diag.Process.GetCurrentProcess ().MainModule.FileName;
+			if (processExe == null)
+				throw new ArgumentException ("Couldn't get name of running file");
+			else if (string.IsNullOrEmpty (processExe))
+				throw new ArgumentException ("Couldn't find mono runtime.");
+			else if (!Path.GetFileName (processExe).StartsWith ("mono"))
+				throw new ArgumentException (String.Format("Running native app {0}  isn't 'mono'"));
+
+			var failures = new Exception [CrasherClass.Crashers.Count];
+			int failure_count = 0;
+			for (int i=0; i < CrasherClass.Crashers.Count; i++) {
+				try {
+					SpawnCrashingRuntime (processExe, i, false);
+				} catch (Exception e) {
+					failures [i] = e;
+					if (e.InnerException != null)
+						failures [i] = e.InnerException;
+					failure_count++;
+				}
+			}
+
+			Console.WriteLine ("\n\n##################");
+			Console.WriteLine ("Merp Test Results:");
+			Console.WriteLine ("##################\n\n");
+
+			if (failure_count > 0) {
+				for (int i=0; i < CrasherClass.Crashers.Count; i++) {
+					if (failures [i] != null) {
+						Console.WriteLine ("Crash reporter failed test {0}", CrasherClass.Crashers [i].Item1);
+						Console.WriteLine ("Cause: {0}\n{1}\n", failures [i].Message, failures [i].StackTrace);
+					}
+				}
+			}
+
+			if (failure_count > 0)
+				return;
+
+			Console.WriteLine ("\n\n##################");
+			Console.WriteLine ("Merp Stress Test:");
+			Console.WriteLine ("##################\n\n");
+
+			Console.WriteLine ("Starting crash stress test\n");
+			int iter = 0;
+			for (iter=0; iter < 20; iter++) {
+				Console.WriteLine ("\n#############################################");
+				Console.WriteLine ("\tMerp Stress Test Iteration {0}", iter);
+				Console.WriteLine ("#############################################\n");
+				try {
+					SpawnCrashingRuntime (processExe, CrasherClass.StresserIndex, true);
+				} catch (Exception e) {
+					Console.WriteLine ("Stress test caught failure. Shutting down after {1} iterations.\n {0} \n\n", e.InnerException, iter);
+					Cleanup (configDir);
+					throw;
+				}
+			}
+			Console.WriteLine ("Ending crash stress test. No failures caught.\n");
+
+			return;
+		} else {
+			CrashWithMerp (Convert.ToInt32 (args [0]));
+		}
+	}
+}

--- a/mono/utils/mono-log-android.c
+++ b/mono/utils/mono-log-android.c
@@ -73,7 +73,7 @@ mono_log_write_logcat (const char *log_domain, GLogLevelFlags level, mono_bool h
 
 	__android_log_write (apriority, log_domain, message);
 	if (apriority == ANDROID_LOG_FATAL)
-		abort ();
+		g_assert_abort ();
 }
 
 /**

--- a/mono/utils/mono-log-common.c
+++ b/mono/utils/mono-log-common.c
@@ -133,7 +133,7 @@ mono_log_write_logfile (const char *log_domain, GLogLevelFlags level, mono_bool 
 	fflush(logFile);
 
 	if (level & G_LOG_LEVEL_ERROR)
-		abort();
+		g_assert_abort ();
 }
 
 /**

--- a/mono/utils/mono-log-darwin.c
+++ b/mono/utils/mono-log-darwin.c
@@ -100,7 +100,7 @@ mono_log_write_asl (const char *log_domain, GLogLevelFlags level, mono_bool hdr,
 		message);
 
 	if (level & G_LOG_LEVEL_ERROR)
-		abort();
+		g_assert_abort ();
 }
 
 void

--- a/mono/utils/mono-log-posix.c
+++ b/mono/utils/mono-log-posix.c
@@ -82,7 +82,7 @@ mono_log_write_syslog(const char *domain, GLogLevelFlags level, mono_bool hdr, c
 	syslog (mapSyslogLevel(level), "%s", message);
 
 	if (level & G_LOG_LEVEL_ERROR)
-		abort();
+		g_assert_abort ();
 }
 
 /**

--- a/mono/utils/mono-log-windows.c
+++ b/mono/utils/mono-log-windows.c
@@ -104,7 +104,7 @@ mono_log_write_syslog(const char *domain, GLogLevelFlags level, mono_bool hdr, c
 	fflush(logFile);
 
 	if (level & G_LOG_LEVEL_ERROR)
-		abort();
+		g_assert_abort ();
 }
 
 /**

--- a/mono/utils/mono-logger.c
+++ b/mono/utils/mono-logger.c
@@ -9,6 +9,8 @@
 
 #include "mono-compiler.h"
 #include "mono-logger-internals.h"
+#include <mono/utils/mono-threads-debug.h>
+
 
 typedef struct {
 	GLogLevelFlags	level;
@@ -545,24 +547,26 @@ mono_dump_mem (gpointer d, int len)
 	guint8 *data = (guint8 *) d;
 
 	for (int off = 0; off < len; off += 0x10) {
-		char *line = g_strdup_printf ("%p  ", data + off);
+		MOSTLY_ASYNC_SAFE_PRINTF("%p  ", data + off);
 
 		for (int i = 0; i < 0x10; i++) {
-			if ((i + off) >= len)
-				line = g_strdup_printf ("%s   ", line);
-			else
-				line = g_strdup_printf ("%s%02x ", line, data [off + i]);
+			if ((i + off) >= len) {
+				MOSTLY_ASYNC_SAFE_PRINTF("%s", "   ");
+			} else {
+				MOSTLY_ASYNC_SAFE_PRINTF("%02x ", data [off + i]);
+			}
 		}
 
-		line = g_strdup_printf ("%s ", line);
+		MOSTLY_ASYNC_SAFE_PRINTF(" ");
 
 		for (int i = 0; i < 0x10; i++) {
-			if ((i + off) >= len)
-				line = g_strdup_printf ("%s ", line);
-			else
-				line = g_strdup_printf ("%s%c", line, conv_ascii_char (data [off + i]));
+			if ((i + off) >= len) {
+				MOSTLY_ASYNC_SAFE_PRINTF("%s", " ");
+			} else {
+				MOSTLY_ASYNC_SAFE_PRINTF("%c", conv_ascii_char (data [off + i]));
+			}
 		}
 
-		mono_runtime_printf_err ("%s", line);
+		MOSTLY_ASYNC_SAFE_PRINTF ("\n");
 	}
 }

--- a/mono/utils/mono-logger.c
+++ b/mono/utils/mono-logger.c
@@ -547,26 +547,26 @@ mono_dump_mem (gpointer d, int len)
 	guint8 *data = (guint8 *) d;
 
 	for (int off = 0; off < len; off += 0x10) {
-		MOSTLY_ASYNC_SAFE_PRINTF("%p  ", data + off);
+		g_async_safe_printf("%p  ", data + off);
 
 		for (int i = 0; i < 0x10; i++) {
 			if ((i + off) >= len) {
-				MOSTLY_ASYNC_SAFE_PRINTF("%s", "   ");
+				g_async_safe_printf("%s", "   ");
 			} else {
-				MOSTLY_ASYNC_SAFE_PRINTF("%02x ", data [off + i]);
+				g_async_safe_printf("%02x ", data [off + i]);
 			}
 		}
 
-		MOSTLY_ASYNC_SAFE_PRINTF(" ");
+		g_async_safe_printf(" ");
 
 		for (int i = 0; i < 0x10; i++) {
 			if ((i + off) >= len) {
-				MOSTLY_ASYNC_SAFE_PRINTF("%s", " ");
+				g_async_safe_printf("%s", " ");
 			} else {
-				MOSTLY_ASYNC_SAFE_PRINTF("%c", conv_ascii_char (data [off + i]));
+				g_async_safe_printf("%c", conv_ascii_char (data [off + i]));
 			}
 		}
 
-		MOSTLY_ASYNC_SAFE_PRINTF ("\n");
+		g_async_safe_printf ("\n");
 	}
 }

--- a/mono/utils/mono-merp.c
+++ b/mono/utils/mono-merp.c
@@ -45,12 +45,19 @@ static const char *
 os_version_string (void)
 {
 #ifdef HAVE_SYS_UTSNAME_H
-	struct utsname name;
+	static struct utsname name;
+	static const char *version_string;
 
-	memset (&name, 0, sizeof (name)); // WSL does not always nul terminate.
+	if (!version_string) {
+		memset (&name, 0, sizeof (name)); // WSL does not always nul terminate.
 
-	if (uname (&name) >= 0)
-		return g_strdup_printf ("%s", name.release);
+		if (uname (&name) >= 0)
+			version_string = name.release;
+	}
+	if (!version_string)
+		version_string = "";
+
+	return version_string;
 #endif
 	return "";
 }

--- a/mono/utils/mono-merp.c
+++ b/mono/utils/mono-merp.c
@@ -481,22 +481,25 @@ mono_merp_invoke (const intptr_t crashed_pid, const char *signal, const char *no
 
 	mono_summarize_timeline_phase_log (MonoSummaryMerpWriter);
 
-	mono_init_merp (crashed_pid, signal, hashes, &merp);
-	if (!mono_merp_write_params (&merp))
+	mono_init_merp (crashed_pid, signal, hashes, merp);
+
+	if (!mono_merp_write_params (merp))
 		return FALSE;
 
-	if (!mono_merp_write_fingerprint_payload (non_param_data, &merp))
+	if (!mono_merp_write_fingerprint_payload (non_param_data, merp))
 		return FALSE;
 
-	if (!mono_write_wer_template (&merp))
+	if (!mono_write_wer_template (merp))
 		return FALSE;
 
 	// Start program
 	mono_summarize_timeline_phase_log (MonoSummaryMerpInvoke);
-	gboolean success = mono_merp_send (&merp);
+	gboolean success = mono_merp_send (merp);
 
 	if (success)
 		mono_summarize_timeline_phase_log (MonoSummaryCleanup);
+
+	mono_state_free_mem (&mem);
 
 	return success;
 }

--- a/mono/utils/mono-merp.c
+++ b/mono/utils/mono-merp.c
@@ -324,6 +324,7 @@ get_apple_model (char *buffer, size_t max_length)
 static void
 mono_init_merp (const intptr_t crashed_pid, const char *signal, MonoStackHash *hashes, MERPStruct *merp)
 {
+	mono_memory_barrier ();
 	g_assert (mono_merp_enabled ());
 
 	merp->merpFilePath = config.merpFilePath;
@@ -516,6 +517,8 @@ mono_merp_add_annotation (const char *key, const char *value)
 void
 mono_merp_disable (void)
 {
+	mono_memory_barrier ();
+
 	if (!config.enable_merp)
 		return;
 
@@ -528,11 +531,15 @@ mono_merp_disable (void)
 	g_free ((char*)config.moduleVersion);
 	g_slist_free (config.annotations);
 	memset (&config, 0, sizeof (config));
+
+	mono_memory_barrier ();
 }
 
 void
 mono_merp_enable (const char *appBundleID, const char *appSignature, const char *appVersion, const char *merpGUIPath, const char *eventType, const char *appPath, const char *configDir)
 {
+	mono_memory_barrier ();
+
 	g_assert (!config.enable_merp);
 
 	char *prefix = NULL;
@@ -560,6 +567,8 @@ mono_merp_enable (const char *appBundleID, const char *appSignature, const char 
 	config.log = g_getenv ("MONO_MERP_VERBOSE") != NULL;
 
 	config.enable_merp = TRUE;
+
+	mono_memory_barrier ();
 }
 
 gboolean

--- a/mono/utils/mono-merp.c
+++ b/mono/utils/mono-merp.c
@@ -470,8 +470,14 @@ mono_write_wer_template (MERPStruct *merp)
 gboolean
 mono_merp_invoke (const intptr_t crashed_pid, const char *signal, const char *non_param_data, MonoStackHash *hashes)
 {
-	MERPStruct merp;
-	memset (&merp, 0, sizeof (merp));
+	MonoStateMem mem;
+	int merp_tmp_file_tag = 2;
+	gboolean alloc_success = mono_state_alloc_mem (&mem, merp_tmp_file_tag, sizeof (MERPStruct));
+	if (!alloc_success)
+		return FALSE;
+
+	MERPStruct *merp = (MERPStruct *) mem.mem;
+	memset (merp, 0, sizeof (*merp));
 
 	mono_summarize_timeline_phase_log (MonoSummaryMerpWriter);
 

--- a/mono/utils/mono-merp.c
+++ b/mono/utils/mono-merp.c
@@ -240,25 +240,25 @@ mono_merp_write_params (MERPStruct *merp)
 	int handle = g_open (merp->merpFilePath, O_TRUNC | O_WRONLY | O_CREAT, merp_file_permissions);
 	g_assertf (handle != -1, "Could not open MERP file at %s", merp->merpFilePath);
 
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "ApplicationBundleId: %s\n", merp->bundleIDArg);
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "ApplicationVersion: %s\n", merp->versionArg);
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "ApplicationBitness: %s\n", get_merp_bitness (merp->archArg));
+	g_async_safe_fprintf(handle, "ApplicationBundleId: %s\n", merp->bundleIDArg);
+	g_async_safe_fprintf(handle, "ApplicationVersion: %s\n", merp->versionArg);
+	g_async_safe_fprintf(handle, "ApplicationBitness: %s\n", get_merp_bitness (merp->archArg));
 
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "ApplicationName: %s\n", merp->serviceNameArg);
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "ApplicationPath: %s\n", merp->servicePathArg);
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "BlameModuleName: %s\n", merp->moduleName);
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "BlameModuleVersion: %s\n", merp->moduleVersion);
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "BlameModuleOffset: 0x%llx\n", (unsigned long long)merp->moduleOffset);
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "ExceptionType: %s\n", get_merp_exctype (merp->exceptionArg));
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "StackChecksum: 0x%llx\n", merp->hashes.offset_free_hash);
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "StackHash: 0x%llx\n", merp->hashes.offset_rich_hash);
+	g_async_safe_fprintf(handle, "ApplicationName: %s\n", merp->serviceNameArg);
+	g_async_safe_fprintf(handle, "ApplicationPath: %s\n", merp->servicePathArg);
+	g_async_safe_fprintf(handle, "BlameModuleName: %s\n", merp->moduleName);
+	g_async_safe_fprintf(handle, "BlameModuleVersion: %s\n", merp->moduleVersion);
+	g_async_safe_fprintf(handle, "BlameModuleOffset: 0x%llx\n", (unsigned long long)merp->moduleOffset);
+	g_async_safe_fprintf(handle, "ExceptionType: %s\n", get_merp_exctype (merp->exceptionArg));
+	g_async_safe_fprintf(handle, "StackChecksum: 0x%llx\n", merp->hashes.offset_free_hash);
+	g_async_safe_fprintf(handle, "StackHash: 0x%llx\n", merp->hashes.offset_rich_hash);
 
 	// Provided by icall
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "OSVersion: %s\n", merp->osVersion);
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "LanguageID: 0x%x\n", merp->uiLidArg);
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "SystemManufacturer: %s\n", merp->systemManufacturer);
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "SystemModel: %s\n", merp->systemModel);
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "EventType: %s\n", merp->eventType);
+	g_async_safe_fprintf(handle, "OSVersion: %s\n", merp->osVersion);
+	g_async_safe_fprintf(handle, "LanguageID: 0x%x\n", merp->uiLidArg);
+	g_async_safe_fprintf(handle, "SystemManufacturer: %s\n", merp->systemManufacturer);
+	g_async_safe_fprintf(handle, "SystemModel: %s\n", merp->systemModel);
+	g_async_safe_fprintf(handle, "EventType: %s\n", merp->eventType);
 
 	close (handle);
 	return TRUE;
@@ -370,41 +370,41 @@ mono_merp_write_fingerprint_payload (const char *non_param_data, const MERPStruc
 	int handle = g_open (merp->crashLogPath, O_TRUNC | O_WRONLY | O_CREAT, merp_file_permissions);
 	g_assertf (handle != -1, "Could not open crash log file at %s", merp->crashLogPath);
 
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "{\n");
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "\t\"payload\" : \n");
+	g_async_safe_fprintf(handle, "{\n");
+	g_async_safe_fprintf(handle, "\t\"payload\" : \n");
 	g_write (handle, non_param_data, (guint32)strlen (non_param_data));	\
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, ",\n");
+	g_async_safe_fprintf(handle, ",\n");
 
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "\t\"parameters\" : \n{\n");
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "\t\t\"ApplicationBundleId\" : \"%s\",\n", merp->bundleIDArg);
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "\t\t\"ApplicationVersion\" : \"%s\",\n", merp->versionArg);
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "\t\t\"ApplicationBitness\" : \"%s\",\n", get_merp_bitness (merp->archArg));
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "\t\t\"ApplicationName\" : \"%s\",\n", merp->serviceNameArg);
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "\t\t\"BlameModuleName\" : \"%s\",\n", merp->moduleName);
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "\t\t\"BlameModuleVersion\" : \"%s\",\n", merp->moduleVersion);
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "\t\t\"BlameModuleOffset\" : \"0x%lx\",\n", merp->moduleOffset);
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "\t\t\"ExceptionType\" : \"%s\",\n", get_merp_exctype (merp->exceptionArg));
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "\t\t\"StackChecksum\" : \"0x%llx\",\n", merp->hashes.offset_free_hash);
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "\t\t\"StackHash\" : \"0x%llx\",\n", merp->hashes.offset_rich_hash);
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "\t\t\"Extra\" : \n\t\t{\n");
+	g_async_safe_fprintf(handle, "\t\"parameters\" : \n{\n");
+	g_async_safe_fprintf(handle, "\t\t\"ApplicationBundleId\" : \"%s\",\n", merp->bundleIDArg);
+	g_async_safe_fprintf(handle, "\t\t\"ApplicationVersion\" : \"%s\",\n", merp->versionArg);
+	g_async_safe_fprintf(handle, "\t\t\"ApplicationBitness\" : \"%s\",\n", get_merp_bitness (merp->archArg));
+	g_async_safe_fprintf(handle, "\t\t\"ApplicationName\" : \"%s\",\n", merp->serviceNameArg);
+	g_async_safe_fprintf(handle, "\t\t\"BlameModuleName\" : \"%s\",\n", merp->moduleName);
+	g_async_safe_fprintf(handle, "\t\t\"BlameModuleVersion\" : \"%s\",\n", merp->moduleVersion);
+	g_async_safe_fprintf(handle, "\t\t\"BlameModuleOffset\" : \"0x%lx\",\n", merp->moduleOffset);
+	g_async_safe_fprintf(handle, "\t\t\"ExceptionType\" : \"%s\",\n", get_merp_exctype (merp->exceptionArg));
+	g_async_safe_fprintf(handle, "\t\t\"StackChecksum\" : \"0x%llx\",\n", merp->hashes.offset_free_hash);
+	g_async_safe_fprintf(handle, "\t\t\"StackHash\" : \"0x%llx\",\n", merp->hashes.offset_rich_hash);
+	g_async_safe_fprintf(handle, "\t\t\"Extra\" : \n\t\t{\n");
 
 	for (GSList *cursor = merp->annotations; cursor; cursor = cursor->next) {
 		MonoMerpAnnotationEntry *iter = (MonoMerpAnnotationEntry *) cursor->data;
-		MOSTLY_ASYNC_SAFE_FPRINTF(handle, "\t\t\t\"%s\" : \"%s\"\n", iter->key, iter->value);
+		g_async_safe_fprintf(handle, "\t\t\t\"%s\" : \"%s\"\n", iter->key, iter->value);
 	}
 
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "\t\t},\n");
+	g_async_safe_fprintf(handle, "\t\t},\n");
 
 	// Provided by icall
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "\t\t\"OSVersion\" : \"%s\",\n", merp->osVersion);
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "\t\t\"LanguageID\" : \"0x%x\",\n", merp->uiLidArg);
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "\t\t\"SystemManufacturer\" : \"%s\",\n", merp->systemManufacturer);
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "\t\t\"SystemModel\" : \"%s\",\n", merp->systemModel);
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "\t\t\"EventType\" : \"%s\"\n", merp->eventType);
+	g_async_safe_fprintf(handle, "\t\t\"OSVersion\" : \"%s\",\n", merp->osVersion);
+	g_async_safe_fprintf(handle, "\t\t\"LanguageID\" : \"0x%x\",\n", merp->uiLidArg);
+	g_async_safe_fprintf(handle, "\t\t\"SystemManufacturer\" : \"%s\",\n", merp->systemManufacturer);
+	g_async_safe_fprintf(handle, "\t\t\"SystemModel\" : \"%s\",\n", merp->systemModel);
+	g_async_safe_fprintf(handle, "\t\t\"EventType\" : \"%s\"\n", merp->eventType);
 
 	// End of parameters 
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "\t}\n");
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "}\n");
+	g_async_safe_fprintf(handle, "\t}\n");
+	g_async_safe_fprintf(handle, "}\n");
 
 	// End of object
 	close (handle);
@@ -424,43 +424,43 @@ mono_write_wer_template (MERPStruct *merp)
 	g_assertf (handle != -1, "Could not open WER XML file at %s", merp->werXmlPath);
 
 	// Provided by icall
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "<WERReportMetadata>\n");
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "<ProblemSignatures>\n");
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "<EventType>%s</EventType>\n", merp->eventType);
+	g_async_safe_fprintf(handle, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+	g_async_safe_fprintf(handle, "<WERReportMetadata>\n");
+	g_async_safe_fprintf(handle, "<ProblemSignatures>\n");
+	g_async_safe_fprintf(handle, "<EventType>%s</EventType>\n", merp->eventType);
 
 	int i=0;
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "<Parameter%d>%s</Parameter%d>\n", i, merp->bundleIDArg, i);
+	g_async_safe_fprintf(handle, "<Parameter%d>%s</Parameter%d>\n", i, merp->bundleIDArg, i);
 	i++;
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "<Parameter%d>%s</Parameter%d>\n", i, merp->versionArg, i);
+	g_async_safe_fprintf(handle, "<Parameter%d>%s</Parameter%d>\n", i, merp->versionArg, i);
 	i++;
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "<Parameter%d>%s</Parameter%d>\n", i, get_merp_bitness (merp->archArg), i);
+	g_async_safe_fprintf(handle, "<Parameter%d>%s</Parameter%d>\n", i, get_merp_bitness (merp->archArg), i);
 	i++;
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "<Parameter%d>%s</Parameter%d>\n", i, merp->serviceNameArg, i);
+	g_async_safe_fprintf(handle, "<Parameter%d>%s</Parameter%d>\n", i, merp->serviceNameArg, i);
 	i++;
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "<Parameter%d>%s</Parameter%d>\n", i, merp->moduleName, i);
+	g_async_safe_fprintf(handle, "<Parameter%d>%s</Parameter%d>\n", i, merp->moduleName, i);
 	i++;
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "<Parameter%d>%s</Parameter%d>\n", i, merp->moduleVersion, i);
+	g_async_safe_fprintf(handle, "<Parameter%d>%s</Parameter%d>\n", i, merp->moduleVersion, i);
 	i++;
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "<Parameter%d>0x%zx</Parameter%d>\n", i, merp->moduleOffset, i);
+	g_async_safe_fprintf(handle, "<Parameter%d>0x%zx</Parameter%d>\n", i, merp->moduleOffset, i);
 	i++;
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "<Parameter%d>%s</Parameter%d>\n", i, get_merp_exctype (merp->exceptionArg), i);
+	g_async_safe_fprintf(handle, "<Parameter%d>%s</Parameter%d>\n", i, get_merp_exctype (merp->exceptionArg), i);
 	i++;
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "<Parameter%d>0x%llx</Parameter%d>\n", i, merp->hashes.offset_free_hash, i);
+	g_async_safe_fprintf(handle, "<Parameter%d>0x%llx</Parameter%d>\n", i, merp->hashes.offset_free_hash, i);
 	i++;
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "<Parameter%d>0x%llx</Parameter%d>\n", i, merp->hashes.offset_rich_hash, i);
+	g_async_safe_fprintf(handle, "<Parameter%d>0x%llx</Parameter%d>\n", i, merp->hashes.offset_rich_hash, i);
 	i++;
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "<Parameter%d>%s</Parameter%d>\n", i, merp->osVersion, i);
+	g_async_safe_fprintf(handle, "<Parameter%d>%s</Parameter%d>\n", i, merp->osVersion, i);
 	i++;
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "<Parameter%d>0x%x</Parameter%d>\n", i, merp->uiLidArg, i);
+	g_async_safe_fprintf(handle, "<Parameter%d>0x%x</Parameter%d>\n", i, merp->uiLidArg, i);
 	i++;
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "<Parameter%d>%s</Parameter%d>\n", i, merp->systemManufacturer, i);
+	g_async_safe_fprintf(handle, "<Parameter%d>%s</Parameter%d>\n", i, merp->systemManufacturer, i);
 	i++;
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "<Parameter%d>%s</Parameter%d>\n", i, merp->systemModel, i);
+	g_async_safe_fprintf(handle, "<Parameter%d>%s</Parameter%d>\n", i, merp->systemModel, i);
 	i++;
 
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "</ProblemSignatures>\n");
-	MOSTLY_ASYNC_SAFE_FPRINTF(handle, "</WERReportMetadata>\n");
+	g_async_safe_fprintf(handle, "</ProblemSignatures>\n");
+	g_async_safe_fprintf(handle, "</WERReportMetadata>\n");
 
 	close (handle);
 

--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -20,6 +20,10 @@
 #include <sched.h>
 #endif
 
+#include <utils/mono-mmap.h>
+#include <utils/strenc.h>
+#include <utils/mono-io-portability.h>
+
 #if defined(_POSIX_VERSION)
 #ifdef HAVE_SYS_ERRNO_H
 #include <sys/errno.h>
@@ -966,6 +970,124 @@ mono_atexit (void (*func)(void))
 	return atexit (func);
 #endif
 }
+
+#ifndef HOST_WIN32
+
+gboolean
+mono_pe_file_time_date_stamp (gunichar2 *filename, guint32 *out)
+{
+	void *map_handle;
+	gint32 map_size;
+	gpointer file_map = mono_pe_file_map (filename, &map_size, &map_handle);
+	if (!file_map)
+		return FALSE;
+
+	/* Figure this out when we support 64bit PE files */
+	if (1) {
+		IMAGE_DOS_HEADER *dos_header = (IMAGE_DOS_HEADER *)file_map;
+		if (dos_header->e_magic != IMAGE_DOS_SIGNATURE) {
+			mono_pe_file_unmap (file_map, map_handle);
+			return FALSE;
+		}
+
+		IMAGE_NT_HEADERS32 *nt_headers = (IMAGE_NT_HEADERS32 *)((guint8 *)file_map + GUINT32_FROM_LE (dos_header->e_lfanew));
+		if (nt_headers->Signature != IMAGE_NT_SIGNATURE) {
+			mono_pe_file_unmap (file_map, map_handle);
+			return FALSE;
+		}
+
+		*out = nt_headers->FileHeader.TimeDateStamp;
+	} else {
+		g_assert_not_reached ();
+	}
+
+	mono_pe_file_unmap (file_map, map_handle);
+	return TRUE;
+}
+
+gpointer
+mono_pe_file_map (gunichar2 *filename, gint32 *map_size, void **handle)
+{
+	gchar *filename_ext = NULL;
+	gchar *located_filename = NULL;
+	int fd = -1;
+	struct stat statbuf;
+	gpointer file_map = NULL;
+
+	/* According to the MSDN docs, a search path is applied to
+	 * filename.  FIXME: implement this, for now just pass it
+	 * straight to open
+	 */
+
+	filename_ext = mono_unicode_to_external (filename);
+	if (filename_ext == NULL) {
+		g_async_safe_printf ("%s: unicode conversion returned NULL", __func__);
+
+		goto exit;
+	}
+
+	fd = open (filename_ext, O_RDONLY, 0);
+	if (fd == -1 && (errno == ENOENT || errno == ENOTDIR) && IS_PORTABILITY_SET) {
+		gint saved_errno = errno;
+
+		located_filename = mono_portability_find_file (filename_ext, TRUE);
+		if (!located_filename) {
+			errno = saved_errno;
+
+			g_async_safe_printf ("%s: Error opening file %s (3): %s", __func__, filename_ext, strerror (errno));
+			goto error;
+		}
+
+		fd = open (located_filename, O_RDONLY, 0);
+		if (fd == -1) {
+			g_async_safe_printf ("%s: Error opening file %s (3): %s", __func__, filename_ext, strerror (errno));
+			goto error;
+		}
+	}
+	else if (fd == -1) {
+		g_async_safe_printf ("%s: Error opening file %s (3): %s", __func__, filename_ext, strerror (errno));
+		goto error;
+	}
+
+	if (fstat (fd, &statbuf) == -1) {
+		g_async_safe_printf ("%s: Error stat()ing file %s: %s", __func__, filename_ext, strerror (errno));
+		goto error;
+	}
+	*map_size = statbuf.st_size;
+
+	/* Check basic file size */
+	if (statbuf.st_size < sizeof(IMAGE_DOS_HEADER)) {
+		g_async_safe_printf ("%s: File %s is too small: %lld", __func__, filename_ext, (long long) statbuf.st_size);
+
+		goto exit;
+	}
+
+	file_map = mono_file_map (statbuf.st_size, MONO_MMAP_READ | MONO_MMAP_PRIVATE, fd, 0, handle);
+	if (file_map == NULL) {
+		g_async_safe_printf ("%s: Error mmap()int file %s: %s", __func__, filename_ext, strerror (errno));
+		goto error;
+	}
+exit:
+	if (fd != -1)
+		close (fd);
+	g_free (located_filename);
+	g_free (filename_ext);
+	return file_map;
+error:
+	goto exit;
+}
+
+void
+mono_pe_file_unmap (gpointer file_map, void *handle)
+{
+	gint res;
+
+	res = mono_file_unmap (file_map, handle);
+	if (G_UNLIKELY (res != 0))
+		g_error ("%s: mono_file_unmap failed, error: \"%s\" (%d)", __func__, g_strerror (errno), errno);
+}
+
+#endif /* HOST_WIN32 */
 
 /*
  * This function returns the cpu usage in percentage,

--- a/mono/utils/mono-proclib.h
+++ b/mono/utils/mono-proclib.h
@@ -78,5 +78,261 @@ gint32    mono_cpu_usage (MonoCpuUsageState *prev);
 
 int       mono_atexit (void (*func)(void));
 
+#ifndef HOST_WIN32
+
+#include <sys/stat.h>
+#include <unistd.h>
+
+#define IMAGE_NUMBEROF_DIRECTORY_ENTRIES 16
+
+#define IMAGE_DIRECTORY_ENTRY_EXPORT	0
+#define IMAGE_DIRECTORY_ENTRY_IMPORT	1
+#define IMAGE_DIRECTORY_ENTRY_RESOURCE	2
+
+#define IMAGE_SIZEOF_SHORT_NAME	8
+
+#if G_BYTE_ORDER != G_LITTLE_ENDIAN
+#define IMAGE_DOS_SIGNATURE	0x4d5a
+#define IMAGE_NT_SIGNATURE	0x50450000
+#define IMAGE_NT_OPTIONAL_HDR32_MAGIC	0xb10
+#define IMAGE_NT_OPTIONAL_HDR64_MAGIC	0xb20
+#else
+#define IMAGE_DOS_SIGNATURE	0x5a4d
+#define IMAGE_NT_SIGNATURE	0x00004550
+#define IMAGE_NT_OPTIONAL_HDR32_MAGIC	0x10b
+#define IMAGE_NT_OPTIONAL_HDR64_MAGIC	0x20b
+#endif
+
+typedef struct {
+	guint16 e_magic;
+	guint16 e_cblp;
+	guint16 e_cp;
+	guint16 e_crlc;
+	guint16 e_cparhdr;
+	guint16 e_minalloc;
+	guint16 e_maxalloc;
+	guint16 e_ss;
+	guint16 e_sp;
+	guint16 e_csum;
+	guint16 e_ip;
+	guint16 e_cs;
+	guint16 e_lfarlc;
+	guint16 e_ovno;
+	guint16 e_res[4];
+	guint16 e_oemid;
+	guint16 e_oeminfo;
+	guint16 e_res2[10];
+	guint32 e_lfanew;
+} IMAGE_DOS_HEADER;
+
+typedef struct {
+	guint16 Machine;
+	guint16 NumberOfSections;
+	guint32 TimeDateStamp;
+	guint32 PointerToSymbolTable;
+	guint32 NumberOfSymbols;
+	guint16 SizeOfOptionalHeader;
+	guint16 Characteristics;
+} IMAGE_FILE_HEADER;
+
+typedef struct {
+	guint32 VirtualAddress;
+	guint32 Size;
+} IMAGE_DATA_DIRECTORY;
+
+typedef struct {
+	guint16 Magic;
+	guint8 MajorLinkerVersion;
+	guint8 MinorLinkerVersion;
+	guint32 SizeOfCode;
+	guint32 SizeOfInitializedData;
+	guint32 SizeOfUninitializedData;
+	guint32 AddressOfEntryPoint;
+	guint32 BaseOfCode;
+	guint32 BaseOfData;
+	guint32 ImageBase;
+	guint32 SectionAlignment;
+	guint32 FileAlignment;
+	guint16 MajorOperatingSystemVersion;
+	guint16 MinorOperatingSystemVersion;
+	guint16 MajorImageVersion;
+	guint16 MinorImageVersion;
+	guint16 MajorSubsystemVersion;
+	guint16 MinorSubsystemVersion;
+	guint32 Win32VersionValue;
+	guint32 SizeOfImage;
+	guint32 SizeOfHeaders;
+	guint32 CheckSum;
+	guint16 Subsystem;
+	guint16 DllCharacteristics;
+	guint32 SizeOfStackReserve;
+	guint32 SizeOfStackCommit;
+	guint32 SizeOfHeapReserve;
+	guint32 SizeOfHeapCommit;
+	guint32 LoaderFlags;
+	guint32 NumberOfRvaAndSizes;
+	IMAGE_DATA_DIRECTORY DataDirectory[IMAGE_NUMBEROF_DIRECTORY_ENTRIES];
+} IMAGE_OPTIONAL_HEADER32;
+
+typedef struct {
+	guint16 Magic;
+	guint8 MajorLinkerVersion;
+	guint8 MinorLinkerVersion;
+	guint32 SizeOfCode;
+	guint32 SizeOfInitializedData;
+	guint32 SizeOfUninitializedData;
+	guint32 AddressOfEntryPoint;
+	guint32 BaseOfCode;
+	guint64 ImageBase;
+	guint32 SectionAlignment;
+	guint32 FileAlignment;
+	guint16 MajorOperatingSystemVersion;
+	guint16 MinorOperatingSystemVersion;
+	guint16 MajorImageVersion;
+	guint16 MinorImageVersion;
+	guint16 MajorSubsystemVersion;
+	guint16 MinorSubsystemVersion;
+	guint32 Win32VersionValue;
+	guint32 SizeOfImage;
+	guint32 SizeOfHeaders;
+	guint32 CheckSum;
+	guint16 Subsystem;
+	guint16 DllCharacteristics;
+	guint64 SizeOfStackReserve;
+	guint64 SizeOfStackCommit;
+	guint64 SizeOfHeapReserve;
+	guint64 SizeOfHeapCommit;
+	guint32 LoaderFlags;
+	guint32 NumberOfRvaAndSizes;
+	IMAGE_DATA_DIRECTORY DataDirectory[IMAGE_NUMBEROF_DIRECTORY_ENTRIES];
+} IMAGE_OPTIONAL_HEADER64;
+
+#if SIZEOF_VOID_P == 8
+typedef IMAGE_OPTIONAL_HEADER64 IMAGE_OPTIONAL_HEADER;
+#else
+typedef IMAGE_OPTIONAL_HEADER32 IMAGE_OPTIONAL_HEADER;
+#endif
+
+typedef struct {
+	guint32 Signature;
+	IMAGE_FILE_HEADER FileHeader;
+	IMAGE_OPTIONAL_HEADER32 OptionalHeader;
+} IMAGE_NT_HEADERS32;
+
+typedef struct {
+	guint32 Signature;
+	IMAGE_FILE_HEADER FileHeader;
+	IMAGE_OPTIONAL_HEADER64 OptionalHeader;
+} IMAGE_NT_HEADERS64;
+
+#if SIZEOF_VOID_P == 8
+typedef IMAGE_NT_HEADERS64 IMAGE_NT_HEADERS;
+#else
+typedef IMAGE_NT_HEADERS32 IMAGE_NT_HEADERS;
+#endif
+
+typedef struct {
+	guint8 Name[IMAGE_SIZEOF_SHORT_NAME];
+	union {
+		guint32 PhysicalAddress;
+		guint32 VirtualSize;
+	} Misc;
+	guint32 VirtualAddress;
+	guint32 SizeOfRawData;
+	guint32 PointerToRawData;
+	guint32 PointerToRelocations;
+	guint32 PointerToLinenumbers;
+	guint16 NumberOfRelocations;
+	guint16 NumberOfLinenumbers;
+	guint32 Characteristics;
+} IMAGE_SECTION_HEADER;
+
+#define IMAGE_FIRST_SECTION32(header) ((IMAGE_SECTION_HEADER *)((gsize)(header) + G_STRUCT_OFFSET (IMAGE_NT_HEADERS32, OptionalHeader) + GUINT16_FROM_LE (((IMAGE_NT_HEADERS32 *)(header))->FileHeader.SizeOfOptionalHeader)))
+
+#define RT_CURSOR	0x01
+#define RT_BITMAP	0x02
+#define RT_ICON		0x03
+#define RT_MENU		0x04
+#define RT_DIALOG	0x05
+#define RT_STRING	0x06
+#define RT_FONTDIR	0x07
+#define RT_FONT		0x08
+#define RT_ACCELERATOR	0x09
+#define RT_RCDATA	0x0a
+#define RT_MESSAGETABLE	0x0b
+#define RT_GROUP_CURSOR	0x0c
+#define RT_GROUP_ICON	0x0e
+#define RT_VERSION	0x10
+#define RT_DLGINCLUDE	0x11
+#define RT_PLUGPLAY	0x13
+#define RT_VXD		0x14
+#define RT_ANICURSOR	0x15
+#define RT_ANIICON	0x16
+#define RT_HTML		0x17
+#define RT_MANIFEST	0x18
+
+typedef struct {
+	guint32 Characteristics;
+	guint32 TimeDateStamp;
+	guint16 MajorVersion;
+	guint16 MinorVersion;
+	guint16 NumberOfNamedEntries;
+	guint16 NumberOfIdEntries;
+} IMAGE_RESOURCE_DIRECTORY;
+
+typedef struct {
+	union {
+		struct {
+#if G_BYTE_ORDER == G_BIG_ENDIAN
+			guint32 NameIsString:1;
+			guint32 NameOffset:31;
+#else
+			guint32 NameOffset:31;
+			guint32 NameIsString:1;
+#endif
+		};
+		guint32 Name;
+#if G_BYTE_ORDER == G_BIG_ENDIAN
+		struct {
+			guint16 __wapi_big_endian_padding;
+			guint16 Id;
+		};
+#else
+		guint16 Id;
+#endif
+	};
+	union {
+		guint32 OffsetToData;
+		struct {
+#if G_BYTE_ORDER == G_BIG_ENDIAN
+			guint32 DataIsDirectory:1;
+			guint32 OffsetToDirectory:31;
+#else
+			guint32 OffsetToDirectory:31;
+			guint32 DataIsDirectory:1;
+#endif
+		};
+	};
+} IMAGE_RESOURCE_DIRECTORY_ENTRY;
+
+typedef struct {
+	guint32 OffsetToData;
+	guint32 Size;
+	guint32 CodePage;
+	guint32 Reserved;
+} IMAGE_RESOURCE_DATA_ENTRY;
+
+
+
+gboolean
+mono_pe_file_time_date_stamp (gunichar2 *filename, guint32 *out);
+
+gpointer
+mono_pe_file_map (gunichar2 *filename, gint32 *map_size, void **handle);
+
+void
+mono_pe_file_unmap (gpointer file_map, void *handle);
+#endif /* HOST_WIN32 */
+
 #endif /* __MONO_PROC_LIB_H__ */
 

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -542,8 +542,6 @@ mono_native_state_add_ee_info  (MonoStateWriter *writer)
 #define MONO_ARCHITECTURE MONO_ARCH_ARCHITECTURE
 #endif
 
-static char *mono_runtime_build_info;
-
 static void
 mono_native_state_add_version (MonoStateWriter *writer)
 {
@@ -556,9 +554,7 @@ mono_native_state_add_version (MonoStateWriter *writer)
 	assert_has_space (writer);
 	mono_state_writer_indent (writer);
 	mono_state_writer_object_key (writer, "version");
-	if (!mono_runtime_build_info)
-		mono_runtime_build_info = mono_get_runtime_callbacks ()->get_runtime_build_info ();
-	mono_state_writer_printf(writer, "\"%s\",\n", mono_runtime_build_info);
+	mono_state_writer_printf(writer, "\"(%s) (%s)\",\n", VERSION, mono_get_runtime_callbacks ()->get_runtime_build_version ());
 
 	assert_has_space (writer);
 	mono_state_writer_indent (writer);

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -174,12 +174,18 @@ mono_summarize_timeline_phase_log (MonoSummaryStage next)
 			out_level = MonoSummarySuspendHandshake;
 			break;
 		case MonoSummarySuspendHandshake:
-			out_level = MonoSummaryDumpTraversal;
+			out_level = MonoSummaryUnmanagedStacks;
 			break;
-		case MonoSummaryDumpTraversal:
+		case MonoSummaryUnmanagedStacks:
+			out_level = MonoSummaryManagedStacks;
+			break;
+		case MonoSummaryManagedStacks:
 			out_level = MonoSummaryStateWriter;
 			break;
 		case MonoSummaryStateWriter:
+			out_level = MonoSummaryStateWriterDone;
+			break;
+		case MonoSummaryStateWriterDone:
 #ifdef TARGET_OSX
 			if (mono_merp_enabled ()) {
 				out_level = MonoSummaryMerpWriter;
@@ -253,7 +259,8 @@ mono_summarize_timeline_read_level (const char *directory, gboolean clear)
 	gboolean has_level_merp_invoke = timeline_has_level (directory, out_file, sizeof(out_file), clear, MonoSummaryMerpInvoke);
 	gboolean has_level_merp_writer = timeline_has_level (directory, out_file, sizeof(out_file), clear, MonoSummaryMerpWriter);
 	gboolean has_level_state_writer = timeline_has_level (directory, out_file, sizeof(out_file), clear, MonoSummaryStateWriter);
-	gboolean has_level_dump_traversal = timeline_has_level (directory, out_file, sizeof(out_file), clear, MonoSummaryDumpTraversal);
+	gboolean has_level_managed_stacks = timeline_has_level (directory, out_file, sizeof(out_file), clear, MonoSummaryManagedStacks);
+	gboolean has_level_unmanaged_stacks = timeline_has_level (directory, out_file, sizeof(out_file), clear, MonoSummaryUnmanagedStacks);
 	gboolean has_level_suspend_handshake = timeline_has_level (directory, out_file, sizeof(out_file), clear, MonoSummarySuspendHandshake);
 	gboolean has_level_setup = timeline_has_level (directory, out_file, sizeof(out_file), clear, MonoSummarySetup);
 
@@ -267,8 +274,10 @@ mono_summarize_timeline_read_level (const char *directory, gboolean clear)
 		return MonoSummaryMerpWriter;
 	else if (has_level_state_writer)
 		return MonoSummaryStateWriter;
-	else if (has_level_dump_traversal)
-		return MonoSummaryDumpTraversal;
+	else if (has_level_managed_stacks)
+		return MonoSummaryManagedStacks;
+	else if (has_level_unmanaged_stacks)
+		return MonoSummaryUnmanagedStacks;
 	else if (has_level_suspend_handshake)
 		return MonoSummarySuspendHandshake;
 	else if (has_level_setup)

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -48,12 +48,12 @@ extern GCStats mono_gc_stats;
 static void
 assert_not_reached_mem (const char *msg)
 {
-	MOSTLY_ASYNC_SAFE_PRINTF ("%s\n", msg);
+	g_async_safe_printf ("%s\n", msg);
 
 #if 0
 	pid_t crashed_pid = getpid ();
 	// Break here
-	MOSTLY_ASYNC_SAFE_PRINTF ("Attach to PID %d. Supervisor thread will signal us shortly.\n", crashed_pid);
+	g_async_safe_printf ("Attach to PID %d. Supervisor thread will signal us shortly.\n", crashed_pid);
 	while (TRUE) {
 		// Sleep for 1 second.
 		g_usleep (1000 * 1000);
@@ -210,10 +210,10 @@ mono_summarize_timeline_phase_log (MonoSummaryStage next)
 			break;
 
 		case MonoSummaryDone:
-			MOSTLY_ASYNC_SAFE_PRINTF ("Trying to log crash reporter timeline, already at done %d\n", log.level);
+			g_async_safe_printf ("Trying to log crash reporter timeline, already at done %d\n", log.level);
 			return;
 		default:
-			MOSTLY_ASYNC_SAFE_PRINTF ("Trying to log crash reporter timeline, illegal state %d\n", log.level);
+			g_async_safe_printf ("Trying to log crash reporter timeline, illegal state %d\n", log.level);
 			return;
 	}
 
@@ -289,7 +289,7 @@ mono_state_free_mem (MonoStateMem *mem)
 	if (mem->handle)
 		close (mem->handle);
 	else
-		MOSTLY_ASYNC_SAFE_PRINTF ("NULL handle mono-state mem on freeing\n");
+		g_async_safe_printf ("NULL handle mono-state mem on freeing\n");
 
 	char name [100];
 	mem_file_name (mem->tag, name, sizeof (name));

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -585,11 +585,6 @@ mono_native_state_add_thread (MonoStateWriter *writer, MonoThreadSummary *thread
 
 	assert_has_space (writer);
 	mono_state_writer_indent (writer);
-	mono_state_writer_object_key (writer, "managed_thread_ptr");
-	mono_state_writer_printf(writer, "\"0x%" PRIx64 "\",\n", (guint64) thread->managed_thread_ptr);
-
-	assert_has_space (writer);
-	mono_state_writer_indent (writer);
 	mono_state_writer_object_key (writer, "native_thread_id");
 	mono_state_writer_printf(writer, "\"0x%" PRIx64 "\",\n", (guint64) thread->native_thread_id);
 

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -475,6 +475,21 @@ mono_native_state_add_frame (MonoStateWriter *writer, MonoFrameSummary *frame)
 
 		assert_has_space (writer);
 		mono_state_writer_indent (writer);
+		mono_state_writer_object_key (writer, "filename");
+		mono_state_writer_printf(writer, "\"%s\",\n", frame->managed_data.filename);
+
+		assert_has_space (writer);
+		mono_state_writer_indent (writer);
+		mono_state_writer_object_key (writer, "sizeofimage");
+		mono_state_writer_printf(writer, "\"0x%x\",\n", frame->managed_data.image_size);
+
+		assert_has_space (writer);
+		mono_state_writer_indent (writer);
+		mono_state_writer_object_key (writer, "timestamp");
+		mono_state_writer_printf(writer, "\"0x%x\",\n", frame->managed_data.time_date_stamp);
+
+		assert_has_space (writer);
+		mono_state_writer_indent (writer);
 		mono_state_writer_object_key (writer, "il_offset");
 		mono_state_writer_printf(writer, "\"0x%05x\"\n", frame->managed_data.il_offset);
 

--- a/mono/utils/mono-state.h
+++ b/mono/utils/mono-state.h
@@ -24,14 +24,16 @@ typedef enum {
 	MonoSummaryNone = 0,
 	MonoSummarySetup = 1,
 	MonoSummarySuspendHandshake = 2,
-	MonoSummaryDumpTraversal = 3,
-	MonoSummaryStateWriter = 4,
-	MonoSummaryMerpWriter = 5,
-	MonoSummaryMerpInvoke = 6,
-	MonoSummaryCleanup = 7,
-	MonoSummaryDone = 8,
+	MonoSummaryUnmanagedStacks = 3,
+	MonoSummaryManagedStacks = 4,
+	MonoSummaryStateWriter = 5,
+	MonoSummaryStateWriterDone = 6,
+	MonoSummaryMerpWriter = 7,
+	MonoSummaryMerpInvoke = 8,
+	MonoSummaryCleanup = 9,
+	MonoSummaryDone = 10,
 
-	MonoSummaryDoubleFault = 9
+	MonoSummaryDoubleFault = 11, 
 } MonoSummaryStage;
 
 typedef struct {

--- a/mono/utils/mono-state.h
+++ b/mono/utils/mono-state.h
@@ -21,19 +21,19 @@
 #define MONO_NATIVE_STATE_PROTOCOL_VERSION "0.0.2"
 
 typedef enum {
-	MonoSummaryNone = 0,
-	MonoSummarySetup = 1,
-	MonoSummarySuspendHandshake = 2,
-	MonoSummaryUnmanagedStacks = 3,
-	MonoSummaryManagedStacks = 4,
-	MonoSummaryStateWriter = 5,
-	MonoSummaryStateWriterDone = 6,
-	MonoSummaryMerpWriter = 7,
-	MonoSummaryMerpInvoke = 8,
-	MonoSummaryCleanup = 9,
-	MonoSummaryDone = 10,
+	MonoSummaryNone,
+	MonoSummarySetup,
+	MonoSummarySuspendHandshake,
+	MonoSummaryUnmanagedStacks,
+	MonoSummaryManagedStacks,
+	MonoSummaryStateWriter,
+	MonoSummaryStateWriterDone,
+	MonoSummaryMerpWriter,
+	MonoSummaryMerpInvoke,
+	MonoSummaryCleanup,
+	MonoSummaryDone,
 
-	MonoSummaryDoubleFault = 11, 
+	MonoSummaryDoubleFault
 } MonoSummaryStage;
 
 typedef struct {

--- a/mono/utils/mono-state.h
+++ b/mono/utils/mono-state.h
@@ -57,6 +57,11 @@ mono_summarize_double_fault_log (void);
 MonoSummaryStage
 mono_summarize_timeline_read_level (const char *directory, gboolean clear);
 
+// Enable checked-build assertions on summary workflow
+// Turns all potential hangs into instant faults
+void
+mono_summarize_toggle_assertions (gboolean enable);
+
 // Json State Writer
 
 /*

--- a/mono/utils/mono-state.h
+++ b/mono/utils/mono-state.h
@@ -43,6 +43,17 @@ typedef struct {
 	int indent;
 } MonoStateWriter;
 
+typedef struct {
+	gpointer *mem;
+	size_t size;
+
+	// File Information
+	int handle;
+	long tag;
+} MonoStateMem;
+
+MONO_BEGIN_DECLS
+
 // Logging
 gboolean
 mono_summarize_set_timeline_dir (const char *directory);
@@ -100,6 +111,14 @@ mono_native_state_add_thread (MonoStateWriter *writer, MonoThreadSummary *thread
 void
 mono_crash_dump (const char *jsonFile, MonoStackHash *hashes);
 
-#endif // DISABLE_CRASH_REPORTING
+// Signal-safe file allocators
 
+gboolean
+mono_state_alloc_mem (MonoStateMem *mem, long tag, size_t size);
+
+void
+mono_state_free_mem (MonoStateMem *mem);
+
+MONO_END_DECLS
+#endif // DISABLE_CRASH_REPORTING
 #endif // MONO_UTILS_NATIVE_STATE

--- a/mono/utils/mono-state.h
+++ b/mono/utils/mono-state.h
@@ -82,13 +82,13 @@ mono_summarize_toggle_assertions (gboolean enable);
  */
 
 void
-mono_summarize_native_state_begin (char *mem, int size);
+mono_summarize_native_state_begin (MonoStateWriter *writer, gchar *mem, int size);
 
 char *
-mono_summarize_native_state_end (void);
+mono_summarize_native_state_end (MonoStateWriter *writer);
 
 void
-mono_summarize_native_state_add_thread (MonoThreadSummary *thread, MonoContext *ctx, gboolean crashing_thread);
+mono_summarize_native_state_add_thread (MonoStateWriter *writer, MonoThreadSummary *thread, MonoContext *ctx, gboolean crashing_thread);
 
 /*
  * These use memory from the caller

--- a/mono/utils/mono-state.h
+++ b/mono/utils/mono-state.h
@@ -45,11 +45,11 @@ typedef struct {
 
 typedef struct {
 	gpointer *mem;
-	size_t size;
+	gsize size;
 
 	// File Information
-	int handle;
-	long tag;
+	gint handle;
+	gint64 tag;
 } MonoStateMem;
 
 MONO_BEGIN_DECLS

--- a/mono/utils/mono-threads-debug.h
+++ b/mono/utils/mono-threads-debug.h
@@ -7,7 +7,7 @@
 
 /* Logging - enable them below if you need specific logging for the category you need */
 #define MOSTLY_ASYNC_SAFE_FPRINTF(handle, ...) do { \
-	char __buff[1024];	\
+	char __buff [128];	\
 	__buff [0] = '\0';	\
 	g_snprintf (__buff, sizeof(__buff), __VA_ARGS__);	\
 	g_write (handle, __buff, (guint32)strlen (__buff));	\

--- a/mono/utils/mono-threads-debug.h
+++ b/mono/utils/mono-threads-debug.h
@@ -5,6 +5,9 @@
 #ifndef __MONO_UTILS_MONO_THREADS_DEBUG_H__
 #define __MONO_UTILS_MONO_THREADS_DEBUG_H__
 
+#include <config.h>
+#include <glib.h>
+
 /* Logging - enable them below if you need specific logging for the category you need */
 #define MOSTLY_ASYNC_SAFE_FPRINTF(handle, ...) do { \
 	g_async_safe_fprintf (handle, __VA_ARGS__); \

--- a/mono/utils/mono-threads-debug.h
+++ b/mono/utils/mono-threads-debug.h
@@ -7,10 +7,7 @@
 
 /* Logging - enable them below if you need specific logging for the category you need */
 #define MOSTLY_ASYNC_SAFE_FPRINTF(handle, ...) do { \
-	char __buff [128];	\
-	__buff [0] = '\0';	\
-	g_snprintf (__buff, sizeof(__buff), __VA_ARGS__);	\
-	g_write (handle, __buff, (guint32)strlen (__buff));	\
+	g_async_safe_fprintf (handle, __VA_ARGS__); \
 } while (0)
 
 #define MOSTLY_ASYNC_SAFE_PRINTF(...) MOSTLY_ASYNC_SAFE_FPRINTF(1, __VA_ARGS__);

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -270,26 +270,26 @@ dump_threads (void)
 {
 	MonoThreadInfo *cur = mono_thread_info_current ();
 
-	MOSTLY_ASYNC_SAFE_PRINTF ("STATE CUE CARD: (? means a positive number, usually 1 or 2, * means any number)\n");
-	MOSTLY_ASYNC_SAFE_PRINTF ("\t0x0\t- starting (GOOD, unless the thread is running managed code)\n");
-	MOSTLY_ASYNC_SAFE_PRINTF ("\t0x1\t- detached (GOOD, unless the thread is running managed code)\n");
-	MOSTLY_ASYNC_SAFE_PRINTF ("\t0x2\t- running (BAD, unless it's the gc thread)\n");
-	MOSTLY_ASYNC_SAFE_PRINTF ("\t0x?03\t- async suspended (GOOD)\n");
-	MOSTLY_ASYNC_SAFE_PRINTF ("\t0x?04\t- self suspended (GOOD)\n");
-	MOSTLY_ASYNC_SAFE_PRINTF ("\t0x?05\t- async suspend requested (BAD)\n");
-	MOSTLY_ASYNC_SAFE_PRINTF ("\t0x6\t- blocking (BAD, unless there's no suspend initiator)\n");
-	MOSTLY_ASYNC_SAFE_PRINTF ("\t0x?07\t- blocking async suspended (GOOD)\n");
-	MOSTLY_ASYNC_SAFE_PRINTF ("\t0x?08\t- blocking self suspended (GOOD)\n");
-	MOSTLY_ASYNC_SAFE_PRINTF ("\t0x?09\t- blocking suspend requested (BAD in coop; GOOD in hybrid)\n");
+	g_async_safe_printf ("STATE CUE CARD: (? means a positive number, usually 1 or 2, * means any number)\n");
+	g_async_safe_printf ("\t0x0\t- starting (GOOD, unless the thread is running managed code)\n");
+	g_async_safe_printf ("\t0x1\t- detached (GOOD, unless the thread is running managed code)\n");
+	g_async_safe_printf ("\t0x2\t- running (BAD, unless it's the gc thread)\n");
+	g_async_safe_printf ("\t0x?03\t- async suspended (GOOD)\n");
+	g_async_safe_printf ("\t0x?04\t- self suspended (GOOD)\n");
+	g_async_safe_printf ("\t0x?05\t- async suspend requested (BAD)\n");
+	g_async_safe_printf ("\t0x6\t- blocking (BAD, unless there's no suspend initiator)\n");
+	g_async_safe_printf ("\t0x?07\t- blocking async suspended (GOOD)\n");
+	g_async_safe_printf ("\t0x?08\t- blocking self suspended (GOOD)\n");
+	g_async_safe_printf ("\t0x?09\t- blocking suspend requested (BAD in coop; GOOD in hybrid)\n");
 
 	FOREACH_THREAD_SAFE_ALL (info) {
 #ifdef TARGET_MACH
 		char thread_name [256] = { 0 };
 		pthread_getname_np (mono_thread_info_get_tid (info), thread_name, 255);
 
-		MOSTLY_ASYNC_SAFE_PRINTF ("--thread %p id %p [%p] (%s) state %x  %s\n", info, (void *) mono_thread_info_get_tid (info), (void*)(size_t)info->native_handle, thread_name, info->thread_state, info == cur ? "GC INITIATOR" : "" );
+		g_async_safe_printf ("--thread %p id %p [%p] (%s) state %x  %s\n", info, (void *) mono_thread_info_get_tid (info), (void*)(size_t)info->native_handle, thread_name, info->thread_state, info == cur ? "GC INITIATOR" : "" );
 #else
-		MOSTLY_ASYNC_SAFE_PRINTF ("--thread %p id %p [%p] state %x  %s\n", info, (void *) mono_thread_info_get_tid (info), (void*)(size_t)info->native_handle, info->thread_state, info == cur ? "GC INITIATOR" : "" );
+		g_async_safe_printf ("--thread %p id %p [%p] state %x  %s\n", info, (void *) mono_thread_info_get_tid (info), (void*)(size_t)info->native_handle, info->thread_state, info == cur ? "GC INITIATOR" : "" );
 #endif
 	} FOREACH_THREAD_SAFE_END
 }
@@ -314,7 +314,7 @@ mono_threads_wait_pending_operations (void)
 
 			dump_threads ();
 
-			MOSTLY_ASYNC_SAFE_PRINTF ("WAITING for %d threads, got %d suspended\n", (int)pending_suspends, i);
+			g_async_safe_printf ("WAITING for %d threads, got %d suspended\n", (int)pending_suspends, i);
 			g_error ("suspend_thread suspend took %d ms, which is more than the allowed %d ms", (int)mono_stopwatch_elapsed_ms (&suspension_time), sleepAbortDuration);
 		}
 		mono_stopwatch_stop (&suspension_time);


### PR DESCRIPTION
The added test caught a lot of failures. It failed most of the time it was run before (90% of executions resulting in crashes in seq-point or jit info tables or in gdb dumper).

After these changes, I was able to run the suite 10k times on OSX and 10k times on Linux without seeing a failure. 

This brings some crash format changes too:

https://gist.github.com/alexanderkyte/72c12f0450513f079189e3e6561db502

I think this is a good idea. If we've got so many crash-time state reporters, having visual demarcation between them makes it easier to say "we crashed in the middle of doing X".

Please don't squash these changes, as they're rather varied, and would not offer a single semantic unit to be rebased around and reverted. 