### PR TITLE
[2018-08] [Network] Fix CVE 2018-8292 on Mac OS X.

### DIFF
--- a/mcs/class/System.Net.Http/CFNetworkHandler.cs
+++ b/mcs/class/System.Net.Http/CFNetworkHandler.cs
@@ -269,7 +269,7 @@ namespace System.Net.Http
  					bucket.StreamCanBeDisposed = true;
 					// remove headers in a redirect for Authentication.
 					request.Headers.Authorization = null;
- 					var redirectResponse = await SendAsync (redirectRequest, cancellationToken, false).ConfigureAwait (false);
+ 					var redirectResponse = await SendAsync (request, cancellationToken, false).ConfigureAwait (false);
  					return redirectResponse;
  				}
  				return initialRequest;

--- a/mcs/class/System.Net.Http/CFNetworkHandler.cs
+++ b/mcs/class/System.Net.Http/CFNetworkHandler.cs
@@ -267,7 +267,7 @@ namespace System.Net.Http
  				var status = initialRequest.StatusCode;
  				if (IsRedirect (status) && allowAutoRedirect) {
  					bucket.StreamCanBeDisposed = true;
-					// remove headers in a redirec for Authentication.
+					// remove headers in a redirect for Authentication.
 					request.Headers.Authorization = null;
  					var redirectResponse = await SendAsync (redirectRequest, cancellationToken, false).ConfigureAwait (false);
  					return redirectResponse;

--- a/mcs/class/System.Net.Http/CFNetworkHandler.cs
+++ b/mcs/class/System.Net.Http/CFNetworkHandler.cs
@@ -269,13 +269,11 @@ namespace System.Net.Http
  					bucket.StreamCanBeDisposed = true;
 					// remove headers in a redirect for Authentication.
 					request.Headers.Authorization = null;
- 					var redirectResponse = await SendAsync (request, cancellationToken, false).ConfigureAwait (false);
- 					return redirectResponse;
+ 					return await SendAsync (request, cancellationToken, false).ConfigureAwait (false);
  				}
  				return initialRequest;
- 			} else {
- 				return await response.Task;
- 			}
+ 			} 
+			return await response.Task;
 		}
 
 		// Decide if we redirect or not, similar to what is done in the managed handler


### PR DESCRIPTION
This commit ensures that CVE 2018-8292 is fixed by not setting
auto-redirect in the first request done by CFNetwork. CFNetwork has the
same bug, but we can work around it by performing the first request,
checking the response and, if it is a rediret, follow it without the
Authorization headers.


PS: This fix should be ported to 2018-08, 2018-10 and 2018-12.

Backport of #12047.

/cc @mandel-macaque 