### PR TITLE
[2018-08] Bump to latest SQLite for Mac bundle

### DIFF
--- a/packaging/MacSDK/sqlite.py
+++ b/packaging/MacSDK/sqlite.py
@@ -1,3 +1,3 @@
 Package('sqlite-autoconf', '3260000', sources=[
     'https://www.sqlite.org/2018/%{name}-%{version}.tar.gz'
-])
+],configure_flags=['--disable-editline'])

--- a/packaging/MacSDK/sqlite.py
+++ b/packaging/MacSDK/sqlite.py
@@ -1,3 +1,3 @@
-Package('sqlite-autoconf', '3090200', sources=[
-    'https://www.sqlite.org/2015/%{name}-%{version}.tar.gz'
+Package('sqlite-autoconf', '3260000', sources=[
+    'https://www.sqlite.org/2018/%{name}-%{version}.tar.gz'
 ])


### PR DESCRIPTION
Bump Mac bundle from SQLite 3.9.2 to 3.26.0

Backport of #12118.

/cc @akoeplinger @directhex