### PR TITLE
[2018-10] System.Windows.Forms: Fix incorrect layout for table layout nested in flow layout

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms.Layout/TableLayout.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms.Layout/TableLayout.cs
@@ -483,7 +483,7 @@ namespace System.Windows.Forms.Layout
 			CalculateColumnWidths (settings, actual_positions, max_colspan, settings.ColumnStyles, auto_size, column_widths, false);
 
 			// Calculate available width
-			int available_width = size.Width - (border_width * (columns + 1));
+			int available_width = size.Width < Int16.MaxValue ? size.Width - (border_width * (columns + 1)) : 0;
 			foreach (int width in column_widths)
 				available_width -= width;
 
@@ -516,7 +516,7 @@ namespace System.Windows.Forms.Layout
 			CalculateRowHeights (settings, actual_positions, max_rowspan, settings.RowStyles, auto_size, column_widths, row_heights);
 
 			// Calculate available height
-			int available_height = size.Height - (border_width * (rows + 1));
+			int available_height = size.Height < Int16.MaxValue ? size.Height - (border_width * (rows + 1)) : 0;
 			foreach (int height in row_heights)
 				available_height -= height;
 


### PR DESCRIPTION
Fixes issue #8922. The flow layout code specifies `int.MaxValue` as width in `GetPreferredSize` call, which the table layout didn't handle properly and tried to use all the available space.

Relevant WinForms open source code that implements the same behavior:

https://github.com/dotnet/winforms/blob/e5606060fa95bdb40af9ddeceb7bea81535de291/src/System.Windows.Forms/src/System/Windows/Forms/Layout/FlowLayout.cs#L183-L188

https://github.com/dotnet/winforms/blob/e5606060fa95bdb40af9ddeceb7bea81535de291/src/System.Windows.Forms/src/System/Windows/Forms/Layout/TableLayout.cs#L700-L702


Backport of #12161.

/cc @marek-safar @filipnavara