### PR TITLE
[Debugger] Redirecting the StandardOutput and StandardError

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -80,7 +80,8 @@ public class DebuggerTests
 
 	Diag.ProcessStartInfo CreateStartInfo (string[] args) {
 		var pi = new Diag.ProcessStartInfo ();
-
+		pi.RedirectStandardOutput = true;
+		pi.RedirectStandardError = true;
 		if (runtime != null) {
 			pi.FileName = runtime;
 		} else {


### PR DESCRIPTION
When going to https://jenkins.mono-project.com/job/test-mono-pull-request-arm64/8921/testReport/junit/(root)/DebuggerTests/StackTraceInNative/ for example, we have no idea why the underlying process has exited. To figure it out, we need to go to https://jenkins.mono-project.com/job/test-mono-pull-request-arm64/8921/parsed_console/log_content.html#WARNING1 and scroll back up to where the test was executed to find out the debuggee process crashed with an assertion.

This was fixed by redirecting the StandardOutput and StandardError of the debuggee process in the Mono.Debugger.Soft test suite.


Fixes #7741