### PR TITLE
updated 4 overloads of Math.Sign for better performance

### DIFF
--- a/mcs/class/referencesource/mscorlib/system/math.cs
+++ b/mcs/class/referencesource/mscorlib/system/math.cs
@@ -759,12 +759,7 @@ namespace System {
         [CLSCompliant(false)]
         public static int Sign(sbyte value)
         {
-            if (value < 0)
-                return -1;
-            else if (value > 0)
-                return 1;
-            else
-                return 0;
+            return unchecked (value >> 7 | (int) ((uint) -value >> 7));
         }
 
 
@@ -772,34 +767,19 @@ namespace System {
         // is negative, 0, or positive.  Throws for floating point NaN's.
         public static int Sign(short value)
         {
-            if (value < 0)
-                return -1;
-            else if (value > 0)
-                return 1;
-            else
-                return 0;
+            return unchecked (value >> 15 | (int) ((uint) -value >> 15));
         }
 
         // Sign function for VB.  Returns -1, 0, or 1 if the sign of the number
         // is negative, 0, or positive.  Throws for floating point NaN's.
         public static int Sign(int value)
         {
-            if (value < 0)
-                return -1;
-            else if (value > 0)
-                return 1;
-            else
-                return 0;
+            return unchecked (value >> 31 | (int) ((uint) -value >> 31));
         }
 
         public static int Sign(long value)
         {
-            if (value < 0)
-                return -1;
-            else if (value > 0)
-                return 1;
-            else
-                return 0;
+            return unchecked (value >> 63 | (int) ((uint) -value >> 63));
         }
         
         public static int Sign (float value) 


### PR DESCRIPTION
Hey, I updated the implementation of 4 overloads of Math.Sign

Instead of the `if`s, it performs several bitwise operations on the original number to calculate the sign, 
like the dotnet core implementation [here](https://github.com/dotnet/corefx/blob/master/src/Common/src/CoreLib/System/Math.cs#L956)

### Few Notes
- The implementation was taken from the [corefx repo](https://github.com/dotnet/corefx)
- At first I wasn't sure why the expression was wrapped with `unchecked` (because it's the default) but after some reading I believe it's for the case that the function will be called inside a `checked` block.
  (in case of any confusion)
