### PR TITLE
[Coop] Convert and consolidate {remoting,cominterop}type_from_handle.

### DIFF
--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -631,20 +631,11 @@ cominterop_get_interface (MonoComObject *obj_raw, MonoClass *ic)
 	HANDLE_FUNCTION_RETURN_VAL (itf);
 }
 
+// This is an icall, it will return NULL and set pending exception on failure.
 static MonoReflectionType *
 cominterop_type_from_handle (MonoType *handle)
 {
-	ERROR_DECL (error);
-	MonoReflectionType *ret;
-	MonoDomain *domain = mono_domain_get (); 
-	MonoClass *klass = mono_class_from_mono_type_internal (handle);
-
-	mono_class_init_internal (klass);
-
-	ret = mono_type_get_object_checked (domain, handle, error);
-	mono_error_set_pending_exception (error);
-
-	return ret;
+	return mono_type_from_handle (handle);
 }
 
 #endif // DISABLE_COM

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -631,7 +631,8 @@ cominterop_get_interface (MonoComObject *obj_raw, MonoClass *ic)
 	HANDLE_FUNCTION_RETURN_VAL (itf);
 }
 
-// This is an icall, it will return NULL and set pending exception on failure.
+// This is an icall, it will return NULL and set pending exception (in
+// mono_type_from_handle wrapper) on failure.
 static MonoReflectionType *
 cominterop_type_from_handle (MonoType *handle)
 {

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -1212,11 +1212,12 @@ MONO_HANDLE_REGISTER_ICALL (mono_string_to_bstr, mono_bstr, 1, (MonoString))
 MONO_HANDLE_REGISTER_ICALL (mono_string_to_byvalstr, void, 3, (char_ptr, MonoString, int))
 MONO_HANDLE_REGISTER_ICALL (mono_string_to_byvalwstr, void, 3, (gunichar2_ptr, MonoString, int))
 MONO_HANDLE_REGISTER_ICALL (mono_string_to_utf16_internal, mono_unichar2_ptr, 1, (MonoString))
-MONO_HANDLE_REGISTER_ICALL (mono_string_to_utf32_internal, mono_unichar4_ptr, 1, (MonoString))
+MONO_HANDLE_REGISTER_ICALL (mono_string_to_utf32_internal, mono_unichar4_ptr, 1, (MonoString)) // embedding API
 MONO_HANDLE_REGISTER_ICALL (mono_string_utf16_to_builder, void, 2, (MonoStringBuilder, const_gunichar2_ptr))
 MONO_HANDLE_REGISTER_ICALL (mono_string_utf16_to_builder2, MonoStringBuilder, 1, (const_gunichar2_ptr))
 MONO_HANDLE_REGISTER_ICALL (mono_string_utf8_to_builder, void, 2, (MonoStringBuilder, const_char_ptr))
 MONO_HANDLE_REGISTER_ICALL (mono_string_utf8_to_builder2, MonoStringBuilder, 1, (const_char_ptr))
+MONO_HANDLE_REGISTER_ICALL (mono_type_from_handle, MonoReflectionType, 1, (MonoType_ptr)) // called by icalls
 MONO_HANDLE_REGISTER_ICALL (ves_icall_marshal_alloc, gpointer, 1, (gsize))
 MONO_HANDLE_REGISTER_ICALL (ves_icall_mono_marshal_xdomain_copy_value, MonoObject, 1, (MonoObject))
 MONO_HANDLE_REGISTER_ICALL (ves_icall_mono_string_from_utf16, MonoString, 1, (const_gunichar2_ptr))

--- a/mono/metadata/icall-table.h
+++ b/mono/metadata/icall-table.h
@@ -456,7 +456,7 @@ MONO_HANDLE_DECLARE_RAW (id, name, func, rettype, n, argtypes)			\
 ICALL_EXPORT MONO_HANDLE_TYPE_RAWPOINTER (rettype)				\
 func ( MONO_HANDLE_FOREACH_ARG_RAWPOINTER_ ## n argtypes)
 
-// Implement ves_icall_foo_raw over ves_icall_foo.
+// Implement ves_icall_foo over ves_icall_foo_impl.
 //
 // Raw pointers are converted to/from handles and the rest is passed through.
 // The in/out/inout-ness of parameters must be correct. (unlike MONO_HANDLE_IMPLEMENT)

--- a/mono/metadata/reflection-internals.h
+++ b/mono/metadata/reflection-internals.h
@@ -136,7 +136,4 @@ mono_runtime_get_caller_no_system_or_reflection (void);
 MonoAssembly*
 mono_runtime_get_caller_from_stack_mark (MonoStackCrawlMark *stack_mark);
 
-MonoReflectionType *
-mono_type_from_handle (MonoType *handle);
-
 #endif /* __MONO_METADATA_REFLECTION_INTERNALS_H__ */

--- a/mono/metadata/reflection-internals.h
+++ b/mono/metadata/reflection-internals.h
@@ -136,4 +136,7 @@ mono_runtime_get_caller_no_system_or_reflection (void);
 MonoAssembly*
 mono_runtime_get_caller_from_stack_mark (MonoStackCrawlMark *stack_mark);
 
+MonoReflectionType *
+mono_type_from_handle (MonoType *handle);
+
 #endif /* __MONO_METADATA_REFLECTION_INTERNALS_H__ */

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -3092,19 +3092,10 @@ mono_class_from_mono_type_handle (MonoReflectionTypeHandle reftype)
 	return mono_class_from_mono_type_internal (MONO_HANDLE_RAW (reftype)->type);
 }
 
-// This is an icall, it will return NULL and set pending exception on failure.
-MonoReflectionType*
-mono_type_from_handle (MonoType *handle)
+// This is called by calls, it will return NULL and set pending exception (in wrapper) on failure.
+MonoReflectionTypeHandle
+mono_type_from_handle_impl (MonoType *handle, MonoError *error)
 {
-	ERROR_DECL (error);
-	MonoReflectionType *ret;
-	MonoDomain *domain = mono_domain_get ();
-	MonoClass *klass = mono_class_from_mono_type_internal (handle);
-
-	mono_class_init_internal (klass);
-
-	ret = mono_type_get_object_checked (domain, handle, error);
-	mono_error_set_pending_exception (error);
-
-	return ret;
+	mono_class_init_internal (mono_class_from_mono_type_internal (handle));
+	return mono_type_get_object_handle (mono_domain_get (), handle, error);
 }

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -3091,3 +3091,20 @@ mono_class_from_mono_type_handle (MonoReflectionTypeHandle reftype)
 {
 	return mono_class_from_mono_type_internal (MONO_HANDLE_RAW (reftype)->type);
 }
+
+// This is an icall, it will return NULL and set pending exception on failure.
+MonoReflectionType*
+mono_type_from_handle (MonoType *handle)
+{
+	ERROR_DECL (error);
+	MonoReflectionType *ret;
+	MonoDomain *domain = mono_domain_get ();
+	MonoClass *klass = mono_class_from_mono_type_internal (handle);
+
+	mono_class_init_internal (klass);
+
+	ret = mono_type_get_object_checked (domain, handle, error);
+	mono_error_set_pending_exception (error);
+
+	return ret;
+}

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -247,7 +247,8 @@ mono_remoting_marshal_init (void)
 	module_initialized = TRUE;
 }
 
-/* This is an icall, it will return NULL and set pending exception on failure */
+// This is an icall, it will return NULL and set pending exception (in
+// mono_type_from_handle wrapper) on failure.
 static MonoReflectionType *
 type_from_handle (MonoType *handle)
 {

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -251,17 +251,7 @@ mono_remoting_marshal_init (void)
 static MonoReflectionType *
 type_from_handle (MonoType *handle)
 {
-	ERROR_DECL (error);
-	MonoReflectionType *ret;
-	MonoDomain *domain = mono_domain_get (); 
-	MonoClass *klass = mono_class_from_mono_type_internal (handle);
-
-	mono_class_init_internal (klass);
-
-	ret = mono_type_get_object_checked (domain, handle, error);
-	mono_error_set_pending_exception (error);
-
-	return ret;
+	return mono_type_from_handle (handle);
 }
 
 #ifndef DISABLE_JIT

--- a/mono/metadata/string-icalls.c
+++ b/mono/metadata/string-icalls.c
@@ -24,6 +24,7 @@
 #include <mono/metadata/exception.h>
 #include <mono/metadata/debug-helpers.h>
 #include <mono/metadata/gc-internals.h>
+#include "icall-decl.h"
 
 /* This function is redirected to String.CreateString ()
    by mono_marshal_get_native_wrapper () */


### PR DESCRIPTION
mostly into mono_type_from_handle.
However keep them separate for registration/patching sake, since
will error if register twice, else need to arrange to register once.