### PR TITLE
[wasm] Add puppeteer to the browser tests node packages.

### DIFF
--- a/sdks/wasm/tests/browser/.gitignore
+++ b/sdks/wasm/tests/browser/.gitignore
@@ -1,3 +1,4 @@
 .stamp-browser-test-suite
 publish
 package-lock.json
+test-results.xml

--- a/sdks/wasm/tests/browser/karma.conf.js
+++ b/sdks/wasm/tests/browser/karma.conf.js
@@ -1,3 +1,6 @@
+const puppeteer = require('puppeteer');
+process.env.CHROME_BIN = puppeteer.executablePath();
+
 module.exports = function(config) {
     config.set({
 
@@ -14,7 +17,17 @@ module.exports = function(config) {
             {pattern: './publish/**/*.txt', included: false, served: true, type: 'text'},
         ],
         //load karma-mocha-reporter and karma-html
-        reporters: ['mocha','karmaHTML'], //, 'progress'],
+        reporters: ['mocha','karmaHTML', 'dots', 'junit'], //, 'progress'],
+        // the default configuration
+        junitReporter: {
+            outputDir: '', // results will be saved as $outputDir/$browserName.xml
+            outputFile: 'test-results.xml', // if included, results will be saved as $outputDir/$browserName/$outputFile
+            suite: '', // suite will become the package name attribute in xml testsuite element
+            useBrowserName: false, // add browser name to report and classes names
+            nameFormatter: undefined, // function (browser, result) to customize the name attribute in xml testcase element
+            classNameFormatter: undefined, // function (browser, result) to customize the classname attribute in xml testcase element
+            properties: {} // key value pair of properties to add to the <properties> section of the report
+        },
         //load karma-jasmine-dom and karma-jasmine
         frameworks: ['jasmine-dom','jasmine','mocha', 'chai'],
         //load karma-chrome-launcher

--- a/sdks/wasm/tests/browser/package.json
+++ b/sdks/wasm/tests/browser/package.json
@@ -10,16 +10,18 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "jasmine-core": "^3.3.0",
     "chai": "^4.2.0",
+    "jasmine-core": "^3.3.0",
     "karma": "^3.1.3",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-html": "^1.0.5",
-    "karma-mocha": "^1.3.0",
-    "mocha": "^5.2.0",
     "karma-jasmine": "^2.0.1",
     "karma-jasmine-dom": "^1.0.1",
-    "karma-mocha-reporter": "^2.2.5"
+    "karma-junit-reporter": "^1.2.0",
+    "karma-mocha": "^1.3.0",
+    "karma-mocha-reporter": "^2.2.5",
+    "mocha": "^5.2.0",
+    "puppeteer": "^1.11.0"
   }
 }


### PR DESCRIPTION
- This will download the most recent version of headless to use.
- Add junit-reporter to output a tests output file to be used for jenkins CI in the future.

