### PR TITLE
[bcl] Fixed leaking of innerStream inside WebResponseStream.

### DIFF
--- a/mcs/class/System/System.Net/WebResponseStream.cs
+++ b/mcs/class/System/System.Net/WebResponseStream.cs
@@ -370,6 +370,7 @@ namespace System.Net
 				}
 
 				var buffer = await ReadAllAsyncInner (cancellationToken).ConfigureAwait (false);
+				innerStream?.Close ();
 				var bos = new BufferOffsetSize (buffer, 0, buffer.Length, false);
 				innerStream = new BufferedReadStream (Operation, null, bos);
 
@@ -395,6 +396,7 @@ namespace System.Net
 		protected override void Close_internal (ref bool disposed)
 		{
 			WebConnection.Debug ($"{ME} CLOSE: disposed={disposed} closed={closed} nextReadCalled={nextReadCalled}");
+			innerStream?.Close ();
 			if (!closed && !nextReadCalled) {
 				nextReadCalled = true;
 				WebConnection.Debug ($"{ME} CLOSE #1: read_eof={read_eof} bufferedEntireContent={bufferedEntireContent}");


### PR DESCRIPTION
The innerStream property of WebResponseStream is never properly closed. Normally this would not be a major issue, since the garbage collector will clean this up. However, some innerStreams handle native resources, in particular DeflateStream. Since DeflateStream tells the GC to never clean itself up, DeflateStream will be kept alive (and in turn a lot of other things as well). See the linked issue (#11928) for more details.

I have done my best to understand the code, but still kinda confused about what `nextReadCalled` is supposed to signify. However, from my testing it seems that those two lines stop the leak and do not cause any further issues down the line.

I also didn't find out whether `variable?.Function ()` was discourage or not. Let me know, if I should change that.

This fixes #11928