### PR TITLE
Remove string parsing, hashing, locking, and dynamic allocations from JIT icall signatures.

### DIFF
--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -273,6 +273,7 @@ common_sources = \
 	icall-decl.h		\
 	icall-def.h		\
 	icall-internals.h \
+	icall-signatures.h \
 	icall-table.h	\
 	image.c			\
 	image-internals.h	\

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1054,9 +1054,6 @@ MONO_API gboolean
 mono_metadata_load_generic_param_constraints_checked (MonoImage *image, guint32 token,
 					      MonoGenericContainer *container, MonoError *error);
 
-MonoMethodSignature*
-mono_create_icall_signature (const char *sigstr);
-
 MonoJitICallInfo *
 mono_register_jit_icall (gconstpointer func, const char *name, MonoMethodSignature *sig, gboolean is_save);
 

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -48,6 +48,7 @@
 #include "mono/metadata/cominterop-win32-internals.h"
 #endif
 #include "icall-decl.h"
+#include "icall-signatures.h"
 
 typedef guint32 gchandle_t; // FIXME use this more
 
@@ -91,11 +92,9 @@ static void
 register_icall (       T func, const char *name, const char *sigstr, gboolean save)
 #else
 static void
-register_icall (gpointer func, const char *name, const char *sigstr, gboolean save)
+register_icall (gpointer func, const char *name, MonoMethodSignature *sig, gboolean save)
 #endif
 {
-	MonoMethodSignature *sig = mono_create_icall_signature (sigstr);
-
 	mono_register_jit_icall_full (func, name, sig, save, name);
 }
 
@@ -660,23 +659,23 @@ mono_cominterop_init (void)
 		com_provider = MONO_COM_MS;
 	g_free (com_provider_env);
 
-	register_icall (cominterop_get_method_interface, "cominterop_get_method_interface", "ptr ptr", FALSE);
-	register_icall (cominterop_get_function_pointer, "cominterop_get_function_pointer", "ptr ptr int32", FALSE);
-	register_icall (cominterop_object_is_rcw, "cominterop_object_is_rcw", "int32 object", FALSE);
-	register_icall (cominterop_get_ccw, "cominterop_get_ccw", "ptr object ptr", FALSE);
-	register_icall (cominterop_get_ccw_object, "cominterop_get_ccw_object", "object ptr int32", FALSE);
-	register_icall (cominterop_get_interface, "cominterop_get_interface", "ptr object ptr", FALSE);
+	register_icall (cominterop_get_method_interface, "cominterop_get_method_interface", mono_icall_sig_ptr_ptr, FALSE);
+	register_icall (cominterop_get_function_pointer, "cominterop_get_function_pointer", mono_icall_sig_ptr_ptr_int32, FALSE);
+	register_icall (cominterop_object_is_rcw, "cominterop_object_is_rcw", mono_icall_sig_int32_object, FALSE);
+	register_icall (cominterop_get_ccw, "cominterop_get_ccw", mono_icall_sig_ptr_object_ptr, FALSE);
+	register_icall (cominterop_get_ccw_object, "cominterop_get_ccw_object", mono_icall_sig_object_ptr_int32, FALSE);
+	register_icall (cominterop_get_interface, "cominterop_get_interface", mono_icall_sig_ptr_object_ptr, FALSE);
 
-	register_icall (cominterop_type_from_handle, "cominterop_type_from_handle", "object ptr", FALSE);
+	register_icall (cominterop_type_from_handle, "cominterop_type_from_handle", mono_icall_sig_object_ptr, FALSE);
 
 	/* SAFEARRAY marshalling */
-	register_icall (mono_marshal_safearray_begin, "mono_marshal_safearray_begin", "int32 ptr ptr ptr ptr ptr int32", FALSE);
-	register_icall (mono_marshal_safearray_get_value, "mono_marshal_safearray_get_value", "ptr ptr ptr", FALSE);
-	register_icall (mono_marshal_safearray_next, "mono_marshal_safearray_next", "int32 ptr ptr", FALSE);
-	register_icall (mono_marshal_safearray_end, "mono_marshal_safearray_end", "void ptr ptr", FALSE);
-	register_icall (mono_marshal_safearray_create, "mono_marshal_safearray_create", "int32 object ptr ptr ptr", FALSE);
-	register_icall (mono_marshal_safearray_set_value, "mono_marshal_safearray_set_value", "void ptr ptr ptr", FALSE);
-	register_icall (mono_marshal_safearray_free_indices, "mono_marshal_safearray_free_indices", "void ptr", FALSE);
+	register_icall (mono_marshal_safearray_begin, "mono_marshal_safearray_begin", mono_icall_sig_int32_ptr_ptr_ptr_ptr_ptr_int32, FALSE);
+	register_icall (mono_marshal_safearray_get_value, "mono_marshal_safearray_get_value", mono_icall_sig_ptr_ptr_ptr, FALSE);
+	register_icall (mono_marshal_safearray_next, "mono_marshal_safearray_next", mono_icall_sig_int32_ptr_ptr, FALSE);
+	register_icall (mono_marshal_safearray_end, "mono_marshal_safearray_end", mono_icall_sig_void_ptr_ptr, FALSE);
+	register_icall (mono_marshal_safearray_create, "mono_marshal_safearray_create", mono_icall_sig_int32_object_ptr_ptr_ptr, FALSE);
+	register_icall (mono_marshal_safearray_set_value, "mono_marshal_safearray_set_value", mono_icall_sig_void_ptr_ptr_ptr, FALSE);
+	register_icall (mono_marshal_safearray_free_indices, "mono_marshal_safearray_free_indices", mono_icall_sig_void_ptr, FALSE);
 #endif // DISABLE_COM
 	/*FIXME
 
@@ -688,9 +687,9 @@ mono_cominterop_init (void)
 	The proper fix would be to emit warning, remove them from marshal.c when DISABLE_COM is used and
 	emit an exception in the generated IL.
 	*/
-	register_icall (mono_string_to_bstr, "mono_string_to_bstr", "ptr obj", FALSE);
-	register_icall (mono_string_from_bstr_icall, "mono_string_from_bstr_icall", "obj ptr", FALSE);
-	register_icall (mono_free_bstr, "mono_free_bstr", "void ptr", FALSE);
+	register_icall (mono_string_to_bstr, "mono_string_to_bstr", mono_icall_sig_ptr_obj, FALSE);
+	register_icall (mono_string_from_bstr_icall, "mono_string_from_bstr_icall", mono_icall_sig_obj_ptr, FALSE);
+	register_icall (mono_free_bstr, "mono_free_bstr", mono_icall_sig_void_ptr, FALSE);
 }
 
 #ifndef DISABLE_COM

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -89,7 +89,7 @@ Code shared between the DISABLE_COM and !DISABLE_COM
 #ifdef __cplusplus
 template <typename T>
 static void
-register_icall (       T func, const char *name, const char *sigstr, gboolean save)
+register_icall (       T func, const char *name, MonoMethodSignature *sig, gboolean save)
 #else
 static void
 register_icall (gpointer func, const char *name, MonoMethodSignature *sig, gboolean save)

--- a/mono/metadata/icall-signatures.h
+++ b/mono/metadata/icall-signatures.h
@@ -1,0 +1,158 @@
+/**
+ * \file
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ *
+ * Previously JIT icall signatures were presented as strings,
+ * subject to parsing and hashing and allocations and locking.
+ * Here they are statically allocated and almost statically initialized.
+ * There is no parsing, locking, or hashing.
+ */
+#ifndef __MONO_METADATA_ICALL_SIGNATURES_H__
+#define __MONO_METADATA_ICALL_SIGNATURES_H__
+
+// FIXME Some of these are only needed under ifdef.
+// FIXME Some of these are redundant like obj vs. object, int vs. int32.
+//
+// count and types, where first type is return type
+// and the rest are the parameter types.
+//
+// There are tradeoffs either way as to if return
+// type is part of the parameter list.
+//
+#define ICALL_SIGS				\
+ICALL_SIG (1, (object))				\
+ICALL_SIG (1, (ptr))				\
+ICALL_SIG (1, (void))				\
+ICALL_SIG (2, (double, double))			\
+ICALL_SIG (2, (double, int32))			\
+ICALL_SIG (2, (double, long))			\
+ICALL_SIG (2, (double, ptr))			\
+ICALL_SIG (2, (float, long))			\
+ICALL_SIG (2, (int, obj))			\
+ICALL_SIG (2, (int16, double))			\
+ICALL_SIG (2, (int32, double))			\
+ICALL_SIG (2, (int32, obj))			\
+ICALL_SIG (2, (int32, object))			\
+ICALL_SIG (2, (int8, double))			\
+ICALL_SIG (2, (long, double))			\
+ICALL_SIG (2, (long, float))			\
+ICALL_SIG (2, (obj, ptr))			\
+ICALL_SIG (2, (object, int))			\
+ICALL_SIG (2, (object, int32))			\
+ICALL_SIG (2, (object, object))			\
+ICALL_SIG (2, (object, ptr))			\
+ICALL_SIG (2, (ptr, int))			\
+ICALL_SIG (2, (ptr, obj))			\
+ICALL_SIG (2, (ptr, object))			\
+ICALL_SIG (2, (ptr, ptr))			\
+ICALL_SIG (2, (uint16, double))			\
+ICALL_SIG (2, (uint32, double))			\
+ICALL_SIG (2, (uint8, double))			\
+ICALL_SIG (2, (ulong, double))			\
+ICALL_SIG (2, (ulong, float))			\
+ICALL_SIG (2, (void, int))			\
+ICALL_SIG (2, (void, int32))			\
+ICALL_SIG (2, (void, object))			\
+ICALL_SIG (2, (void, ptr))			\
+ICALL_SIG (3, (bool, ptr, ptrref))		\
+ICALL_SIG (3, (double, double, double))		\
+ICALL_SIG (3, (float, float, float))		\
+ICALL_SIG (3, (int, obj, ptr))			\
+ICALL_SIG (3, (int32, int32, int32))		\
+ICALL_SIG (3, (int32, int32, ptr))		\
+ICALL_SIG (3, (int32, int32, ptrref))		\
+ICALL_SIG (3, (int32, ptr, ptr))		\
+ICALL_SIG (3, (int32, ptr, ptrref))		\
+ICALL_SIG (3, (long, long, int32))		\
+ICALL_SIG (3, (long, long, long))		\
+ICALL_SIG (3, (obj, ptr, int))			\
+ICALL_SIG (3, (object, int, object))		\
+ICALL_SIG (3, (object, object, ptr))		\
+ICALL_SIG (3, (object, ptr, int))		\
+ICALL_SIG (3, (object, ptr, int32))		\
+ICALL_SIG (3, (object, ptr, ptr))		\
+ICALL_SIG (3, (ptr, int32, ptrref))		\
+ICALL_SIG (3, (ptr, object, ptr))		\
+ICALL_SIG (3, (ptr, ptr, int))			\
+ICALL_SIG (3, (ptr, ptr, int32))		\
+ICALL_SIG (3, (ptr, ptr, ptr))			\
+ICALL_SIG (3, (ptr, ptr, ptrref))		\
+ICALL_SIG (3, (ptr, uint32, ptrref))		\
+ICALL_SIG (3, (uint32, double, double))		\
+ICALL_SIG (3, (uint32, ptr, int32))		\
+ICALL_SIG (3, (void, double, ptr))		\
+ICALL_SIG (3, (void, int32, ptrref))		\
+ICALL_SIG (3, (void, obj, ptr))			\
+ICALL_SIG (3, (void, object, object))		\
+ICALL_SIG (3, (void, object, ptr))		\
+ICALL_SIG (3, (void, ptr, int))			\
+ICALL_SIG (3, (void, ptr, int32))		\
+ICALL_SIG (3, (void, ptr, object))		\
+ICALL_SIG (3, (void, ptr, ptr))			\
+ICALL_SIG (3, (void, ptr, ptrref))		\
+ICALL_SIG (3, (void, uint32, ptrref))		\
+ICALL_SIG (4, (bool, ptr, int32, ptrref))	\
+ICALL_SIG (4, (int32, int32, ptr, ptrref))	\
+ICALL_SIG (4, (int32, ptr, int32, ptr))		\
+ICALL_SIG (4, (int32, ptr, int32, ptrref))	\
+ICALL_SIG (4, (object, int, object, object))	\
+ICALL_SIG (4, (object, object, ptr, ptr))	\
+ICALL_SIG (4, (object, ptr, int, int))		\
+ICALL_SIG (4, (object, ptr, int, int32))	\
+ICALL_SIG (4, (object, ptr, ptr, int32))	\
+ICALL_SIG (4, (ptr, object, int32, int32))	\
+ICALL_SIG (4, (ptr, object, ptr, ptr))		\
+ICALL_SIG (4, (ptr, ptr, int, ptr))		\
+ICALL_SIG (4, (ptr, ptr, int32, ptrref))	\
+ICALL_SIG (4, (ptr, ptr, ptr, ptr))		\
+ICALL_SIG (4, (ptr, ptr, ptr, ptrref))		\
+ICALL_SIG (4, (ptr, ptr, uint32, ptrref))	\
+ICALL_SIG (4, (void, object, object, ptr))	\
+ICALL_SIG (4, (void, object, ptr, int32))	\
+ICALL_SIG (4, (void, ptr, int, object))		\
+ICALL_SIG (4, (void, ptr, int, ptr))		\
+ICALL_SIG (4, (void, ptr, object, int32))	\
+ICALL_SIG (4, (void, ptr, ptr, int))		\
+ICALL_SIG (4, (void, ptr, ptr, int32))		\
+ICALL_SIG (4, (void, ptr, ptr, ptr))		\
+ICALL_SIG (4, (void, ptr, ptr, ptrref))	\
+ICALL_SIG (5, (int32, object, ptr, ptr, ptr)) 	\
+ICALL_SIG (5, (object, object, ptr, ptr, ptr))	\
+ICALL_SIG (5, (object, ptr, int, int, int))	\
+ICALL_SIG (5, (ptr, object, int, ptr, ptr))	\
+ICALL_SIG (5, (ptr, ptr, int32, ptr, ptrref))	\
+ICALL_SIG (5, (ptr, ptr, ptr, int32, ptrref))	\
+ICALL_SIG (5, (ptr, ptr, ptr, ptr, ptrref))	\
+ICALL_SIG (5, (ptr, ptr, ptr, ptrref, ptrref))	\
+ICALL_SIG (5, (void, object, ptr, int32, int32)) 	\
+ICALL_SIG (5, (void, object, ptr, ptr, ptr))		\
+ICALL_SIG (5, (void, ptr, int, int, object))		\
+ICALL_SIG (6, (int, int, int, ptr, ptr, ptr))		\
+ICALL_SIG (6, (int, ptr, int, int, ptr, object))	\
+ICALL_SIG (6, (object, ptr, int, int, int, int))	\
+ICALL_SIG (6, (object, ptr, ptr, ptr, ptr, ptr))	\
+ICALL_SIG (6, (ptr, ptr, int32, ptr, ptr, ptrref))	\
+ICALL_SIG (6, (void, ptr, ptr, int32, ptr, ptrref))	\
+ICALL_SIG (7, (int32, ptr, ptr, ptr, ptr, ptr, int32))	\
+ICALL_SIG (8, (void, ptr, ptr, int32, ptr, ptrref, ptr, ptrref)) 	\
+
+#define ICALL_SIG_NAME_1(a) 		 	 mono_icall_sig_ ## a
+#define ICALL_SIG_NAME_2(a, b) 		 	 mono_icall_sig_ ## a ## _ ## b
+#define ICALL_SIG_NAME_3(a, b, c) 	 	 mono_icall_sig_ ## a ## _ ## b ## _ ## c
+#define ICALL_SIG_NAME_4(a, b, c, d) 	 	 mono_icall_sig_ ## a ## _ ## b ## _ ## c ## _ ## d
+#define ICALL_SIG_NAME_5(a, b, c, d, e)    	 mono_icall_sig_ ## a ## _ ## b ## _ ## c ## _ ## d ## _ ## e
+#define ICALL_SIG_NAME_6(a, b, c, d, e, f) 	 mono_icall_sig_ ## a ## _ ## b ## _ ## c ## _ ## d ## _ ## e ## _ ## f
+#define ICALL_SIG_NAME_7(a, b, c, d, e, f, g)	 mono_icall_sig_ ## a ## _ ## b ## _ ## c ## _ ## d ## _ ## e ## _ ## f ## _ ## g
+#define ICALL_SIG_NAME_8(a, b, c, d, e, f, g, h) mono_icall_sig_ ## a ## _ ## b ## _ ## c ## _ ## d ## _ ## e ## _ ## f ## _ ## g ## _ ## h
+
+#define ICALL_SIG_NAME(n, types) ICALL_SIG_NAME_ ## n types
+#define ICALL_SIG(n, types) extern MonoMethodSignature * const ICALL_SIG_NAME (n, types);
+
+ICALL_SIGS
+
+#undef ICALL_SIG
+
+void
+mono_create_icall_signatures (void);
+
+#endif // __MONO_METADATA_ICALL_SIGNATURES_H__

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -109,6 +109,7 @@
 #endif
 #include "icall-decl.h"
 #include "mono/utils/mono-threads-coop.h"
+#include "mono/metadata/icall-signatures.h"
 
 //#define MONO_DEBUG_ICALLARRAY
 
@@ -8523,111 +8524,105 @@ mono_lookup_icall_symbol (MonoMethod *m)
 	return icall_table.lookup_icall_symbol (func);
 }
 
-static MonoType*
-type_from_typename (char *type_name)
-{
-	MonoClass *klass = NULL;	/* assignment to shut GCC warning up */
-
-	if (!strcmp (type_name, "int"))
-		klass = mono_defaults.int_class;
-	else if (!strcmp (type_name, "ptr&"))
-		return mono_class_get_byref_type (mono_defaults.int_class);
-	else if (!strcmp (type_name, "ptr"))
-		klass = mono_defaults.int_class;
-	else if (!strcmp (type_name, "void"))
-		klass = mono_defaults.void_class;
-	else if (!strcmp (type_name, "int32"))
-		klass = mono_defaults.int32_class;
-	else if (!strcmp (type_name, "uint32"))
-		klass = mono_defaults.uint32_class;
-	else if (!strcmp (type_name, "int8"))
-		klass = mono_defaults.sbyte_class;
-	else if (!strcmp (type_name, "uint8"))
-		klass = mono_defaults.byte_class;
-	else if (!strcmp (type_name, "int16"))
-		klass = mono_defaults.int16_class;
-	else if (!strcmp (type_name, "uint16"))
-		klass = mono_defaults.uint16_class;
-	else if (!strcmp (type_name, "long"))
-		klass = mono_defaults.int64_class;
-	else if (!strcmp (type_name, "ulong"))
-		klass = mono_defaults.uint64_class;
-	else if (!strcmp (type_name, "float"))
-		klass = mono_defaults.single_class;
-	else if (!strcmp (type_name, "double"))
-		klass = mono_defaults.double_class;
-	else if (!strcmp (type_name, "object"))
-		klass = mono_defaults.object_class;
-	else if (!strcmp (type_name, "obj"))
-		klass = mono_defaults.object_class;
-	else if (!strcmp (type_name, "string"))
-		klass = mono_defaults.string_class;
-	else if (!strcmp (type_name, "bool"))
-		klass = mono_defaults.boolean_class;
-	else if (!strcmp (type_name, "boolean"))
-		klass = mono_defaults.boolean_class;
-	else {
-		g_error ("%s", type_name);
-		g_assert_not_reached ();
-	}
-	return m_class_get_byval_arg (klass);
-}
-
-/**
- * LOCKING: Take the corlib image lock.
- */
-MonoMethodSignature*
-mono_create_icall_signature (const char *sigstr)
-{
-	gchar **parts;
-	int i, len;
-	gchar **tmp;
-	MonoMethodSignature *res, *res2;
-	MonoImage *corlib = mono_defaults.corlib;
-
-	mono_image_lock (corlib);
-	res = (MonoMethodSignature *)g_hash_table_lookup (corlib->helper_signatures, sigstr);
-	mono_image_unlock (corlib);
-
-	if (res)
-		return res;
-
-	parts = g_strsplit (sigstr, " ", 256);
-
-	tmp = parts;
-	len = 0;
-	while (*tmp) {
-		len ++;
-		tmp ++;
-	}
-
-	res = mono_metadata_signature_alloc (corlib, len - 1);
-	res->pinvoke = 1;
-
 #if defined(TARGET_WIN32) && defined(TARGET_X86)
-	/* 
-	 * Under windows, the default pinvoke calling convention is STDCALL but
-	 * we need CDECL.
-	 */
-	res->call_convention = MONO_CALL_C;
+/*
+ * Under windows, the default pinvoke calling convention is STDCALL but
+ * we need CDECL.
+ */
+#define MONO_ICALL_SIGNATURE_CALL_CONVENTION MONO_CALL_C
+#else
+#define MONO_ICALL_SIGNATURE_CALL_CONVENTION 0
 #endif
 
-	res->ret = type_from_typename (parts [0]);
-	for (i = 1; i < len; ++i) {
-		res->params [i - 1] = type_from_typename (parts [i]);
+static char mono_create_icall_signatures_ptrref;
+
+#define ICALL_SIG_TYPE_int 	(MonoType*)&mono_defaults.int_class
+#define ICALL_SIG_TYPE_ptr 	(MonoType*)&mono_defaults.int_class // ?
+#define ICALL_SIG_TYPE_ptrref 	(MonoType*)&mono_create_icall_signatures_ptrref
+#define ICALL_SIG_TYPE_void 	(MonoType*)&mono_defaults.void_class
+#define ICALL_SIG_TYPE_int32 	(MonoType*)&mono_defaults.int32_class
+#define ICALL_SIG_TYPE_uint32 	(MonoType*)&mono_defaults.uint32_class
+#define ICALL_SIG_TYPE_int8 	(MonoType*)&mono_defaults.sbyte_class
+#define ICALL_SIG_TYPE_uint8 	(MonoType*)&mono_defaults.byte_class
+#define ICALL_SIG_TYPE_int16 	(MonoType*)&mono_defaults.int16_class
+#define ICALL_SIG_TYPE_uint16 	(MonoType*)&mono_defaults.uint16_class
+#define ICALL_SIG_TYPE_long 	(MonoType*)&mono_defaults.int64_class
+#define ICALL_SIG_TYPE_ulong 	(MonoType*)&mono_defaults.uint64_class
+#define ICALL_SIG_TYPE_float 	(MonoType*)&mono_defaults.single_class
+#define ICALL_SIG_TYPE_double 	(MonoType*)&mono_defaults.double_class
+#define ICALL_SIG_TYPE_object 	(MonoType*)&mono_defaults.object_class
+#define ICALL_SIG_TYPE_obj 	(MonoType*)&mono_defaults.object_class
+#define ICALL_SIG_TYPE_string 	(MonoType*)&mono_defaults.string_class
+#define ICALL_SIG_TYPE_bool 	(MonoType*)&mono_defaults.boolean_class
+#define ICALL_SIG_TYPE_boolean 	(MonoType*)&mono_defaults.boolean_class
+
+// The initializer has a different type than the result and
+// is stored in the same place. Return type is with parameters.
+#define ICALL_SIG_TYPES_1(a) 		  	ICALL_SIG_TYPE_ ## a,
+#define ICALL_SIG_TYPES_2(a, b) 	  	ICALL_SIG_TYPES_1 (a            ) ICALL_SIG_TYPES_1 (b)
+#define ICALL_SIG_TYPES_3(a, b, c) 	  	ICALL_SIG_TYPES_2 (a, b         ) ICALL_SIG_TYPES_1 (c)
+#define ICALL_SIG_TYPES_4(a, b, c, d) 	  	ICALL_SIG_TYPES_3 (a, b, c      ) ICALL_SIG_TYPES_1 (d)
+#define ICALL_SIG_TYPES_5(a, b, c, d, e)	ICALL_SIG_TYPES_4 (a, b, c, d   ) ICALL_SIG_TYPES_1 (e)
+#define ICALL_SIG_TYPES_6(a, b, c, d, e, f)	ICALL_SIG_TYPES_5 (a, b, c, d, e) ICALL_SIG_TYPES_1 (f)
+#define ICALL_SIG_TYPES_7(a, b, c, d, e, f, g)	ICALL_SIG_TYPES_6 (a, b, c, d, e, f) ICALL_SIG_TYPES_1 (g)
+#define ICALL_SIG_TYPES_8(a, b, c, d, e, f, g, h) ICALL_SIG_TYPES_7 (a, b, c, d, e, f, g) ICALL_SIG_TYPES_1 (h)
+
+#define ICALL_SIG_TYPES(n, types) ICALL_SIG_TYPES_ ## n types
+
+static struct {
+#define ICALL_SIG(n, xtypes) 			\
+	struct {				\
+		MonoMethodSignature sig;	\
+		gpointer     types [n];		\
+	} ICALL_SIG_NAME (n, xtypes);
+ICALL_SIGS
+	MonoMethodSignature end;
+} mono_icall_signatures = {
+#undef ICALL_SIG
+#define ICALL_SIG(n, types) { { \
+	0,			/* ret */ \
+	n,			/* param_count */ \
+	-1,			/* sentinelpos */ \
+	0,			/* generic_param_count */ \
+	MONO_ICALL_SIGNATURE_CALL_CONVENTION, \
+	0,			/* hasthis */ \
+	0, 			/* explicit_this */ \
+	1, 			/* pinvoke */ \
+	0, 			/* is_inflated */ \
+	0,			/* has_type_parameters */ \
+}, { ICALL_SIG_TYPES (n, types) } }, /* params and ret */
+ICALL_SIGS
+};
+
+#undef ICALL_SIG
+#define ICALL_SIG(n, types) MonoMethodSignature * const ICALL_SIG_NAME (n, types) = &mono_icall_signatures.ICALL_SIG_NAME (n, types).sig;
+ICALL_SIGS
+#undef ICALL_SIG
+
+void
+mono_create_icall_signatures (void)
+{
+	// Fixup the mostly statically initialized icall signatures.
+	//   x = m_class_get_byval_arg (x)
+	//   Shift params [0] to ret and params [i + 1] to params [i].
+	//   ptrref is special
+
+	MonoType* ptrref = mono_class_get_byref_type (mono_defaults.int_class); // int?
+	int ptrref_hits = 0;
+	MonoMethodSignature *sig = (MonoMethodSignature*)&mono_icall_signatures;
+	int n;
+	while ((n = sig->param_count)) {
+		--sig->param_count; // remove ret (leave terminal element unchanged)
+		MonoClass ***types = (MonoClass***)(sig + 1);
+		for (int i = 0; i < n; ++i) {
+			MonoClass** klass = types [i];
+			*(i ? &sig->params [i - 1] : &sig->ret) =
+				(klass == (gpointer)&mono_create_icall_signatures_ptrref)
+				? (++ptrref_hits, ptrref) : m_class_get_byval_arg (*klass);
+		}
+		sig = (MonoMethodSignature*)(types + n);
 	}
-
-	g_strfreev (parts);
-
-	mono_image_lock (corlib);
-	res2 = (MonoMethodSignature *)g_hash_table_lookup (corlib->helper_signatures, sigstr);
-	if (res2)
-		res = res2; /*Value is allocated in the image pool*/
-	else
-		g_hash_table_insert (corlib->helper_signatures, (gpointer)sigstr, res);
-	mono_image_unlock (corlib);
-
-	return res;
+	g_assert (ptrref_hits);
 }
 
 MonoJitICallInfo *

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -806,7 +806,6 @@ mono_image_init (MonoImage *image)
 
 	image->typespec_cache = mono_conc_hashtable_new (NULL, NULL);
 	image->memberref_signatures = g_hash_table_new (NULL, NULL);
-	image->helper_signatures = g_hash_table_new (g_str_hash, g_str_equal);
 	image->method_signatures = g_hash_table_new (NULL, NULL);
 
 	image->property_hash = mono_property_hash_new ();
@@ -2174,7 +2173,6 @@ mono_image_close_except_pools (MonoImage *image)
 
 	/* The ownership of signatures is not well defined */
 	g_hash_table_destroy (image->memberref_signatures);
-	g_hash_table_destroy (image->helper_signatures);
 	g_hash_table_destroy (image->method_signatures);
 
 	if (image->rgctx_template_hash)

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -60,6 +60,7 @@
 #include <string.h>
 #include <errno.h>
 #include "icall-decl.h"
+#include "icall-signatures.h"
 
 static void
 mono_string_utf16len_to_builder (MonoStringBuilderHandle sb, const gunichar2 *text, gsize len, MonoError *error);
@@ -121,11 +122,9 @@ static void
 register_dyn_icall (T func, const char *name, const char *sigstr, gboolean no_wrapper)
 #else
 static void
-register_dyn_icall (gpointer func, const char *name, const char *sigstr, gboolean no_wrapper)
+register_dyn_icall (gpointer func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper)
 #endif
 {
-	MonoMethodSignature *sig = mono_create_icall_signature (sigstr);
-
 	mono_register_jit_icall_full (func, name, sig, no_wrapper, NULL);
 }
 
@@ -135,11 +134,9 @@ static void
 register_icall (T func, const char *name, const char *sigstr, gboolean no_wrapper)
 #else
 static void
-register_icall (gpointer func, const char *name, const char *sigstr, gboolean no_wrapper)
+register_icall (gpointer func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper)
 #endif
 {
-	MonoMethodSignature *sig = mono_create_icall_signature (sigstr);
-
 	mono_register_jit_icall_full (func, name, sig, no_wrapper, name);
 }
 
@@ -149,11 +146,9 @@ static void
 register_icall_no_wrapper (T func, const char *name, const char *sigstr)
 #else
 static void
-register_icall_no_wrapper (gpointer func, const char *name, const char *sigstr)
+register_icall_no_wrapper (gpointer func, const char *name, MonoMethodSignature *sig)
 #endif
 {
-	MonoMethodSignature *sig = mono_create_icall_signature (sigstr);
-
 	mono_register_jit_icall_full (func, name, sig, TRUE, name);
 }
 
@@ -235,55 +230,55 @@ mono_marshal_init (void)
 		mono_coop_mutex_init_recursive (&marshal_mutex);
 		marshal_mutex_initialized = TRUE;
 
-		register_icall (mono_marshal_string_to_utf16, "mono_marshal_string_to_utf16", "ptr obj", FALSE);
-		register_icall (mono_marshal_string_to_utf16_copy, "mono_marshal_string_to_utf16_copy", "ptr obj", FALSE);
-		register_icall (mono_string_to_utf16_internal, "mono_string_to_utf16_internal", "ptr obj", FALSE);
-		register_icall (ves_icall_mono_string_from_utf16, "ves_icall_mono_string_from_utf16", "obj ptr", FALSE);
-		register_icall (mono_string_from_byvalstr, "mono_string_from_byvalstr", "obj ptr int", FALSE);
-		register_icall (mono_string_from_byvalwstr, "mono_string_from_byvalwstr", "obj ptr int", FALSE);
-		register_icall (mono_string_new_wrapper_internal, "mono_string_new_wrapper_internal", "obj ptr", FALSE);
-		register_icall (ves_icall_string_new_wrapper, "ves_icall_string_new_wrapper", "obj ptr", FALSE);
-		register_icall (mono_string_new_len_wrapper, "mono_string_new_len_wrapper", "obj ptr int", FALSE);
-		register_icall (ves_icall_mono_string_to_utf8, "ves_icall_mono_string_to_utf8", "ptr obj", FALSE);
-		register_icall (mono_string_to_utf8str, "mono_string_to_utf8str", "ptr obj", FALSE);
-		register_icall (mono_string_to_ansibstr, "mono_string_to_ansibstr", "ptr object", FALSE);
-		register_icall (mono_string_builder_to_utf8, "mono_string_builder_to_utf8", "ptr object", FALSE);
-		register_icall (mono_string_builder_to_utf16, "mono_string_builder_to_utf16", "ptr object", FALSE);
-		register_icall (mono_array_to_savearray, "mono_array_to_savearray", "ptr object", FALSE);
-		register_icall (mono_array_to_lparray, "mono_array_to_lparray", "ptr object", FALSE);
-		register_icall (mono_free_lparray, "mono_free_lparray", "void object ptr", FALSE);
-		register_icall (mono_byvalarray_to_byte_array, "mono_byvalarray_to_byte_array", "void object ptr int32", FALSE);
-		register_icall (mono_array_to_byte_byvalarray, "mono_array_to_byte_byvalarray", "void ptr object int32", FALSE);
-		register_icall (mono_delegate_to_ftnptr, "mono_delegate_to_ftnptr", "ptr object", FALSE);
-		register_icall (mono_ftnptr_to_delegate, "mono_ftnptr_to_delegate", "object ptr ptr", FALSE);
-		register_icall (mono_marshal_asany, "mono_marshal_asany", "ptr object int32 int32", FALSE);
-		register_icall (mono_marshal_free_asany, "mono_marshal_free_asany", "void object ptr int32 int32", FALSE);
-		register_icall (ves_icall_marshal_alloc, "ves_icall_marshal_alloc", "ptr ptr", FALSE);
-		register_icall (mono_marshal_free, "mono_marshal_free", "void ptr", FALSE);
-		register_icall (mono_marshal_set_last_error, "mono_marshal_set_last_error", "void", TRUE);
-		register_icall (mono_marshal_set_last_error_windows, "mono_marshal_set_last_error_windows", "void int32", TRUE);
-		register_icall (mono_string_utf8_to_builder, "mono_string_utf8_to_builder", "void ptr ptr", FALSE);
-		register_icall (mono_string_utf8_to_builder2, "mono_string_utf8_to_builder2", "object ptr", FALSE);
-		register_icall (mono_string_utf16_to_builder, "mono_string_utf16_to_builder", "void ptr ptr", FALSE);
-		register_icall (mono_string_utf16_to_builder2, "mono_string_utf16_to_builder2", "object ptr", FALSE);
-		register_icall (mono_marshal_free_array, "mono_marshal_free_array", "void ptr int32", FALSE);
-		register_icall (mono_string_to_byvalstr, "mono_string_to_byvalstr", "void ptr ptr int32", FALSE);
-		register_icall (mono_string_to_byvalwstr, "mono_string_to_byvalwstr", "void ptr ptr int32", FALSE);
-		register_dyn_icall (g_free, "g_free", "void ptr", FALSE);
-		register_icall_no_wrapper (mono_object_isinst_icall, "mono_object_isinst_icall", "object object ptr");
-		register_icall (mono_struct_delete_old, "mono_struct_delete_old", "void ptr ptr", FALSE);
-		register_icall (mono_delegate_begin_invoke, "mono_delegate_begin_invoke", "object object ptr", FALSE);
-		register_icall (mono_delegate_end_invoke, "mono_delegate_end_invoke", "object object ptr", FALSE);
-		register_dyn_icall (mono_gc_wbarrier_generic_nostore_internal, "wb_generic_internal", "void ptr", FALSE);
-		register_icall (mono_gchandle_get_target_internal, "mono_gchandle_get_target_internal", "object int32", TRUE);
-		register_icall (mono_marshal_isinst_with_cache, "mono_marshal_isinst_with_cache", "object object ptr ptr", FALSE);
-		register_icall (mono_threads_enter_gc_safe_region_unbalanced, "mono_threads_enter_gc_safe_region_unbalanced", "ptr ptr", TRUE);
-		register_icall (mono_threads_exit_gc_safe_region_unbalanced, "mono_threads_exit_gc_safe_region_unbalanced", "void ptr ptr", TRUE);
-		register_icall (mono_threads_enter_gc_unsafe_region_unbalanced, "mono_threads_enter_gc_unsafe_region_unbalanced", "ptr ptr", TRUE);
-		register_icall (mono_threads_exit_gc_unsafe_region_unbalanced, "mono_threads_exit_gc_unsafe_region_unbalanced", "void ptr ptr", TRUE);
-		register_icall (mono_threads_attach_coop, "mono_threads_attach_coop", "ptr ptr ptr", TRUE);
-		register_icall (mono_threads_detach_coop, "mono_threads_detach_coop", "void ptr ptr", TRUE);
-		register_icall (mono_marshal_get_type_object, "mono_marshal_get_type_object", "object ptr", TRUE);
+		register_icall (mono_marshal_string_to_utf16, "mono_marshal_string_to_utf16", mono_icall_sig_ptr_obj, FALSE);
+		register_icall (mono_marshal_string_to_utf16_copy, "mono_marshal_string_to_utf16_copy", mono_icall_sig_ptr_obj, FALSE);
+		register_icall (mono_string_to_utf16_internal, "mono_string_to_utf16_internal", mono_icall_sig_ptr_obj, FALSE);
+		register_icall (ves_icall_mono_string_from_utf16, "ves_icall_mono_string_from_utf16", mono_icall_sig_obj_ptr, FALSE);
+		register_icall (mono_string_from_byvalstr, "mono_string_from_byvalstr", mono_icall_sig_obj_ptr_int, FALSE);
+		register_icall (mono_string_from_byvalwstr, "mono_string_from_byvalwstr", mono_icall_sig_obj_ptr_int, FALSE);
+		register_icall (mono_string_new_wrapper_internal, "mono_string_new_wrapper_internal", mono_icall_sig_obj_ptr, FALSE);
+		register_icall (ves_icall_string_new_wrapper, "ves_icall_string_new_wrapper", mono_icall_sig_obj_ptr, FALSE);
+		register_icall (mono_string_new_len_wrapper, "mono_string_new_len_wrapper", mono_icall_sig_obj_ptr_int, FALSE);
+		register_icall (ves_icall_mono_string_to_utf8, "ves_icall_mono_string_to_utf8", mono_icall_sig_ptr_obj, FALSE);
+		register_icall (mono_string_to_utf8str, "mono_string_to_utf8str", mono_icall_sig_ptr_obj, FALSE);
+		register_icall (mono_string_to_ansibstr, "mono_string_to_ansibstr", mono_icall_sig_ptr_object, FALSE);
+		register_icall (mono_string_builder_to_utf8, "mono_string_builder_to_utf8", mono_icall_sig_ptr_object, FALSE);
+		register_icall (mono_string_builder_to_utf16, "mono_string_builder_to_utf16", mono_icall_sig_ptr_object, FALSE);
+		register_icall (mono_array_to_savearray, "mono_array_to_savearray", mono_icall_sig_ptr_object, FALSE);
+		register_icall (mono_array_to_lparray, "mono_array_to_lparray", mono_icall_sig_ptr_object, FALSE);
+		register_icall (mono_free_lparray, "mono_free_lparray", mono_icall_sig_void_object_ptr, FALSE);
+		register_icall (mono_byvalarray_to_byte_array, "mono_byvalarray_to_byte_array", mono_icall_sig_void_object_ptr_int32, FALSE);
+		register_icall (mono_array_to_byte_byvalarray, "mono_array_to_byte_byvalarray", mono_icall_sig_void_ptr_object_int32, FALSE);
+		register_icall (mono_delegate_to_ftnptr, "mono_delegate_to_ftnptr", mono_icall_sig_ptr_object, FALSE);
+		register_icall (mono_ftnptr_to_delegate, "mono_ftnptr_to_delegate", mono_icall_sig_object_ptr_ptr, FALSE);
+		register_icall (mono_marshal_asany, "mono_marshal_asany", mono_icall_sig_ptr_object_int32_int32, FALSE);
+		register_icall (mono_marshal_free_asany, "mono_marshal_free_asany", mono_icall_sig_void_object_ptr_int32_int32, FALSE);
+		register_icall (ves_icall_marshal_alloc, "ves_icall_marshal_alloc", mono_icall_sig_ptr_ptr, FALSE);
+		register_icall (mono_marshal_free, "mono_marshal_free", mono_icall_sig_void_ptr, FALSE);
+		register_icall (mono_marshal_set_last_error, "mono_marshal_set_last_error", mono_icall_sig_void, TRUE);
+		register_icall (mono_marshal_set_last_error_windows, "mono_marshal_set_last_error_windows", mono_icall_sig_void_int32, TRUE);
+		register_icall (mono_string_utf8_to_builder, "mono_string_utf8_to_builder", mono_icall_sig_void_ptr_ptr, FALSE);
+		register_icall (mono_string_utf8_to_builder2, "mono_string_utf8_to_builder2", mono_icall_sig_object_ptr, FALSE);
+		register_icall (mono_string_utf16_to_builder, "mono_string_utf16_to_builder", mono_icall_sig_void_ptr_ptr, FALSE);
+		register_icall (mono_string_utf16_to_builder2, "mono_string_utf16_to_builder2", mono_icall_sig_object_ptr, FALSE);
+		register_icall (mono_marshal_free_array, "mono_marshal_free_array", mono_icall_sig_void_ptr_int32, FALSE);
+		register_icall (mono_string_to_byvalstr, "mono_string_to_byvalstr", mono_icall_sig_void_ptr_ptr_int32, FALSE);
+		register_icall (mono_string_to_byvalwstr, "mono_string_to_byvalwstr", mono_icall_sig_void_ptr_ptr_int32, FALSE);
+		register_dyn_icall (g_free, "g_free", mono_icall_sig_void_ptr, FALSE);
+		register_icall_no_wrapper (mono_object_isinst_icall, "mono_object_isinst_icall", mono_icall_sig_object_object_ptr);
+		register_icall (mono_struct_delete_old, "mono_struct_delete_old", mono_icall_sig_void_ptr_ptr, FALSE);
+		register_icall (mono_delegate_begin_invoke, "mono_delegate_begin_invoke", mono_icall_sig_object_object_ptr, FALSE);
+		register_icall (mono_delegate_end_invoke, "mono_delegate_end_invoke", mono_icall_sig_object_object_ptr, FALSE);
+		register_dyn_icall (mono_gc_wbarrier_generic_nostore_internal, "wb_generic_internal", mono_icall_sig_void_ptr, FALSE);
+		register_icall (mono_gchandle_get_target_internal, "mono_gchandle_get_target_internal", mono_icall_sig_object_int32, TRUE);
+		register_icall (mono_marshal_isinst_with_cache, "mono_marshal_isinst_with_cache", mono_icall_sig_object_object_ptr_ptr, FALSE);
+		register_icall (mono_threads_enter_gc_safe_region_unbalanced, "mono_threads_enter_gc_safe_region_unbalanced", mono_icall_sig_ptr_ptr, TRUE);
+		register_icall (mono_threads_exit_gc_safe_region_unbalanced, "mono_threads_exit_gc_safe_region_unbalanced", mono_icall_sig_void_ptr_ptr, TRUE);
+		register_icall (mono_threads_enter_gc_unsafe_region_unbalanced, "mono_threads_enter_gc_unsafe_region_unbalanced", mono_icall_sig_ptr_ptr, TRUE);
+		register_icall (mono_threads_exit_gc_unsafe_region_unbalanced, "mono_threads_exit_gc_unsafe_region_unbalanced", mono_icall_sig_void_ptr_ptr, TRUE);
+		register_icall (mono_threads_attach_coop, "mono_threads_attach_coop", mono_icall_sig_ptr_ptr_ptr, TRUE);
+		register_icall (mono_threads_detach_coop, "mono_threads_detach_coop", mono_icall_sig_void_ptr_ptr, TRUE);
+		register_icall (mono_marshal_get_type_object, "mono_marshal_get_type_object", mono_icall_sig_object_ptr, TRUE);
 
 		mono_cominterop_init ();
 		mono_remoting_init ();
@@ -4149,7 +4144,7 @@ mono_marshal_get_ptr_to_struct (MonoClass *klass)
 		/* Create the signature corresponding to
 		 	  static void PtrToStructure (IntPtr ptr, object structure);
 		   defined in class/corlib/System.Runtime.InteropServices/Marshal.cs */
-		sig = mono_create_icall_signature ("void ptr object");
+		sig = mono_icall_sig_void_ptr_object;
 		sig = mono_metadata_signature_dup_full (mono_defaults.corlib, sig);
 		sig->pinvoke = 0;
 		mono_memory_barrier ();

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -119,7 +119,7 @@ get_method_image (MonoMethod *method)
 #ifdef __cplusplus
 template <typename T>
 static void
-register_dyn_icall (T func, const char *name, const char *sigstr, gboolean no_wrapper)
+register_dyn_icall (T func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper)
 #else
 static void
 register_dyn_icall (gpointer func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper)
@@ -131,7 +131,7 @@ register_dyn_icall (gpointer func, const char *name, MonoMethodSignature *sig, g
 #ifdef __cplusplus
 template <typename T>
 static void
-register_icall (T func, const char *name, const char *sigstr, gboolean no_wrapper)
+register_icall (T func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper)
 #else
 static void
 register_icall (gpointer func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper)
@@ -143,7 +143,7 @@ register_icall (gpointer func, const char *name, MonoMethodSignature *sig, gbool
 #ifdef __cplusplus
 template <typename T>
 static void
-register_icall_no_wrapper (T func, const char *name, const char *sigstr)
+register_icall_no_wrapper (T func, const char *name, MonoMethodSignature *sig)
 #else
 static void
 register_icall_no_wrapper (gpointer func, const char *name, MonoMethodSignature *sig)

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -348,7 +348,6 @@ struct _MonoImage {
 	MonoConcurrentHashTable *typespec_cache; /* protected by the image lock */
 	/* indexed by token */
 	GHashTable *memberref_signatures;
-	GHashTable *helper_signatures;
 
 	/* Indexed by blob heap indexes */
 	GHashTable *method_signatures;

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -57,6 +57,7 @@
 #include "external-only.h"
 #include "monitor.h"
 #include "icall-decl.h"
+#include "icall-signatures.h"
 
 // If no symbols in an object file in a static library are referenced, its exports will not be exported.
 // There are a few workarounds:
@@ -278,7 +279,7 @@ mono_type_initialization_init (void)
 	type_initialization_hash = g_hash_table_new (NULL, NULL);
 	blocked_thread_hash = g_hash_table_new (NULL, NULL);
 	mono_coop_mutex_init (&ldstr_section);
-	mono_register_jit_icall (ves_icall_string_alloc, "ves_icall_string_alloc", mono_create_icall_signature ("object int"), FALSE);
+	mono_register_jit_icall (ves_icall_string_alloc, "ves_icall_string_alloc", mono_icall_sig_object_int, FALSE);
 }
 
 void

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -25,6 +25,7 @@
 #include "mono/metadata/reflection-internals.h"
 #include "mono/metadata/assembly.h"
 #include "icall-decl.h"
+#include "icall-signatures.h"
 
 typedef enum {
 	MONO_MARSHAL_NONE,			/* No marshalling needed */
@@ -109,11 +110,9 @@ static void
 register_icall (T func, const char *name, const char *sigstr, gboolean save)
 #else
 static void
-register_icall (gpointer func, const char *name, const char *sigstr, gboolean save)
+register_icall (gpointer func, const char *name, MonoMethodSignature *sig, gboolean save)
 #endif
 {
-	MonoMethodSignature *sig = mono_create_icall_signature (sigstr);
-
 	mono_register_jit_icall (func, name, sig, save);
 }
 
@@ -223,21 +222,21 @@ mono_remoting_marshal_init (void)
 	mono_loader_lock ();
 
 	if (!icalls_registered) {
-		register_icall (type_from_handle, "type_from_handle", "object ptr", FALSE);
-		register_icall (mono_marshal_set_domain_by_id, "mono_marshal_set_domain_by_id", "int32 int32 int32", FALSE);
-		register_icall (mono_marshal_check_domain_image, "mono_marshal_check_domain_image", "int32 int32 ptr", FALSE);
-		register_icall (ves_icall_mono_marshal_xdomain_copy_value, "ves_icall_mono_marshal_xdomain_copy_value", "object object", FALSE);
-		register_icall (mono_marshal_xdomain_copy_out_value, "mono_marshal_xdomain_copy_out_value", "void object object", FALSE);
-		register_icall (mono_remoting_wrapper, "mono_remoting_wrapper", "object ptr ptr", FALSE);
-		register_icall (mono_remoting_update_exception, "mono_remoting_update_exception", "object object", FALSE);
-		register_icall (mono_upgrade_remote_class_wrapper, "mono_upgrade_remote_class_wrapper", "void object object", FALSE);
+		register_icall (type_from_handle, "type_from_handle", mono_icall_sig_object_ptr, FALSE);
+		register_icall (mono_marshal_set_domain_by_id, "mono_marshal_set_domain_by_id", mono_icall_sig_int32_int32_int32, FALSE);
+		register_icall (mono_marshal_check_domain_image, "mono_marshal_check_domain_image", mono_icall_sig_int32_int32_ptr, FALSE);
+		register_icall (ves_icall_mono_marshal_xdomain_copy_value, "ves_icall_mono_marshal_xdomain_copy_value", mono_icall_sig_object_object, FALSE);
+		register_icall (mono_marshal_xdomain_copy_out_value, "mono_marshal_xdomain_copy_out_value", mono_icall_sig_void_object_object, FALSE);
+		register_icall (mono_remoting_wrapper, "mono_remoting_wrapper", mono_icall_sig_object_ptr_ptr, FALSE);
+		register_icall (mono_remoting_update_exception, "mono_remoting_update_exception", mono_icall_sig_object_object, FALSE);
+		register_icall (mono_upgrade_remote_class_wrapper, "mono_upgrade_remote_class_wrapper", mono_icall_sig_void_object_object, FALSE);
 
 #ifndef DISABLE_JIT
-		register_icall (mono_compile_method_icall, "mono_compile_method_icall", "ptr ptr", FALSE);
+		register_icall (mono_compile_method_icall, "mono_compile_method_icall", mono_icall_sig_ptr_ptr, FALSE);
 #endif
 
-		register_icall (mono_context_get_icall, "mono_context_get_icall", "object", FALSE);
-		register_icall (mono_context_set_icall, "mono_context_set_icall", "void object", FALSE);
+		register_icall (mono_context_get_icall, "mono_context_get_icall", mono_icall_sig_object, FALSE);
+		register_icall (mono_context_set_icall, "mono_context_set_icall", mono_icall_sig_void_object, FALSE);
 	}
 
 	icalls_registered = TRUE;

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -107,7 +107,7 @@ mono_compile_method_icall (MonoMethod *method);
 #ifdef __cplusplus
 template <typename T>
 static void
-register_icall (T func, const char *name, const char *sigstr, gboolean save)
+register_icall (T func, const char *name, MonoMethodSignature *sig, gboolean save)
 #else
 static void
 register_icall (gpointer func, const char *name, MonoMethodSignature *sig, gboolean save)

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -36,6 +36,7 @@
 #include "utils/mono-threads-coop.h"
 #include "utils/mono-threads.h"
 #include "metadata/w32handle.h"
+#include "icall-signatures.h"
 
 #ifdef HEAVY_STATISTICS
 static guint64 stat_wbarrier_set_arrayref = 0;
@@ -1006,10 +1007,10 @@ create_allocator (int atype, ManagedAllocatorVariant variant)
 	int num_params, i;
 
 	if (!registered) {
-		mono_register_jit_icall (mono_gc_alloc_obj, "mono_gc_alloc_obj", mono_create_icall_signature ("object ptr int"), FALSE);
-		mono_register_jit_icall (mono_gc_alloc_vector, "mono_gc_alloc_vector", mono_create_icall_signature ("object ptr int int"), FALSE);
-		mono_register_jit_icall (mono_gc_alloc_string, "mono_gc_alloc_string", mono_create_icall_signature ("object ptr int int32"), FALSE);
-		mono_register_jit_icall (mono_profiler_raise_gc_allocation, "mono_profiler_raise_gc_allocation", mono_create_icall_signature ("void object"), FALSE);
+		mono_register_jit_icall (mono_gc_alloc_obj, "mono_gc_alloc_obj", mono_icall_sig_object_ptr_int, FALSE);
+		mono_register_jit_icall (mono_gc_alloc_vector, "mono_gc_alloc_vector", mono_icall_sig_object_ptr_int_int, FALSE);
+		mono_register_jit_icall (mono_gc_alloc_string, "mono_gc_alloc_string", mono_icall_sig_object_ptr_int_int32, FALSE);
+		mono_register_jit_icall (mono_profiler_raise_gc_allocation, "mono_profiler_raise_gc_allocation", mono_icall_sig_void_object, FALSE);
 		registered = TRUE;
 	}
 

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -12817,36 +12817,36 @@ mono_compile_deferred_assemblies (guint32 opts, const char *aot_options, gpointe
 }
 
 #ifndef MONO_ARCH_HAVE_INTERP_ENTRY_TRAMPOLINE
-static const char* interp_in_static_sigs[] = {
-	"bool ptr int32 ptr&",
-	"bool ptr ptr&",
-	"int32 int32 ptr&",
-	"int32 int32 ptr ptr&",
-	"int32 ptr int32 ptr",
-	"int32 ptr int32 ptr&",
-	"int32 ptr ptr&",
-	"object object ptr ptr ptr",
-	"object",
-	"ptr int32 ptr&",
-	"ptr ptr int32 ptr ptr ptr&",
-	"ptr ptr int32 ptr ptr&",
-	"ptr ptr int32 ptr&",
-	"ptr ptr ptr int32 ptr&",
-	"ptr ptr ptr ptr& ptr&",
-	"ptr ptr ptr ptr ptr&",
-	"ptr ptr ptr ptr&",
-	"ptr ptr ptr&",
-	"ptr ptr uint32 ptr&",
-	"ptr uint32 ptr&",
-	"void object ptr ptr ptr",
-	"void ptr ptr int32 ptr ptr& ptr ptr&",
-	"void ptr ptr int32 ptr ptr&",
-	"void ptr ptr ptr&",
-	"void ptr ptr&",
-	"void ptr",
-	"void int32 ptr&",
-	"void uint32 ptr&",
-	"void"
+static MonoMethodSignature * const * const interp_in_static_sigs [] = {
+	&mono_icall_sig_bool_ptr_int32_ptrref,
+	&mono_icall_sig_bool_ptr_ptrref,
+	&mono_icall_sig_int32_int32_ptrref,
+	&mono_icall_sig_int32_int32_ptr_ptrref,
+	&mono_icall_sig_int32_ptr_int32_ptr,
+	&mono_icall_sig_int32_ptr_int32_ptrref,
+	&mono_icall_sig_int32_ptr_ptrref,
+	&mono_icall_sig_object_object_ptr_ptr_ptr,
+	&mono_icall_sig_object,
+	&mono_icall_sig_ptr_int32_ptrref,
+	&mono_icall_sig_ptr_ptr_int32_ptr_ptr_ptrref,
+	&mono_icall_sig_ptr_ptr_int32_ptr_ptrref,
+	&mono_icall_sig_ptr_ptr_int32_ptrref,
+	&mono_icall_sig_ptr_ptr_ptr_int32_ptrref,
+	&mono_icall_sig_ptr_ptr_ptr_ptrref_ptrref,
+	&mono_icall_sig_ptr_ptr_ptr_ptr_ptrref,
+	&mono_icall_sig_ptr_ptr_ptr_ptrref,
+	&mono_icall_sig_ptr_ptr_ptrref,
+	&mono_icall_sig_ptr_ptr_uint32_ptrref,
+	&mono_icall_sig_ptr_uint32_ptrref,
+	&mono_icall_sig_void_object_ptr_ptr_ptr,
+	&mono_icall_sig_void_ptr_ptr_int32_ptr_ptrref_ptr_ptrref,
+	&mono_icall_sig_void_ptr_ptr_int32_ptr_ptrref,
+	&mono_icall_sig_void_ptr_ptr_ptrref,
+	&mono_icall_sig_void_ptr_ptrref,
+	&mono_icall_sig_void_ptr,
+	&mono_icall_sig_void_int32_ptrref,
+	&mono_icall_sig_void_uint32_ptrref,
+	&mono_icall_sig_void
 };
 #endif
 
@@ -13141,8 +13141,8 @@ mono_compile_assembly (MonoAssembly *ass, guint32 opts, const char *aot_options,
 		add_method (acfg, wrapper);
 
 #ifndef MONO_ARCH_HAVE_INTERP_ENTRY_TRAMPOLINE
-		for (int i = 0; i < sizeof (interp_in_static_sigs) / sizeof (const char *); i++) {
-			MonoMethodSignature *sig = mono_create_icall_signature (interp_in_static_sigs [i]);
+		for (int i = 0; i < G_N_ELEMENTS (interp_in_static_sigs); i++) {
+			MonoMethodSignature *sig = *interp_in_static_sigs [i];
 			sig = mono_metadata_signature_dup_full (mono_get_corlib (), sig);
 			sig->pinvoke = FALSE;
 			wrapper = mini_get_interp_in_wrapper (sig);

--- a/mono/mini/calls.c
+++ b/mono/mini/calls.c
@@ -15,6 +15,7 @@
 #include <mono/metadata/abi-details.h>
 #include <mono/metadata/class-abi-details.h>
 #include <mono/utils/mono-utils-debug.h>
+#include "mono/metadata/icall-signatures.h"
 
 static const gboolean debug_tailcall_break_compile = FALSE; // break in method_to_ir
 static const gboolean debug_tailcall_break_run = FALSE;     // insert breakpoint in generated code

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -176,12 +176,8 @@ static MonoInst*
 convert_value (MonoCompile *cfg, MonoType *type, MonoInst *ins);
 
 /* helper methods signatures */
-static MonoMethodSignature *helper_sig_domain_get;
-static MonoMethodSignature *helper_sig_rgctx_lazy_fetch_trampoline;
-static MonoMethodSignature *helper_sig_jit_thread_attach;
-static MonoMethodSignature *helper_sig_get_tls_tramp;
-static MonoMethodSignature *helper_sig_set_tls_tramp;
-MonoMethodSignature *helper_sig_llvmonly_imt_trampoline;
+#define helper_sig_rgctx_lazy_fetch_trampoline mono_icall_sig_ptr_ptr
+#define helper_sig_get_tls_tramp mono_icall_sig_ptr
 
 /* type loading helpers */
 static GENERATE_TRY_GET_CLASS_WITH_CACHE (debuggable_attribute, "System.Diagnostics", "DebuggableAttribute")
@@ -385,17 +381,6 @@ mono_print_bb (MonoBasicBlock *bb, const char *msg)
 
 	for (tree = bb->code; tree; tree = tree->next)
 		mono_print_ins_index (-1, tree);
-}
-
-void
-mono_create_helper_signatures (void)
-{
-	helper_sig_domain_get = mono_create_icall_signature ("ptr");
-	helper_sig_rgctx_lazy_fetch_trampoline = mono_create_icall_signature ("ptr ptr");
-	helper_sig_llvmonly_imt_trampoline = mono_create_icall_signature ("ptr ptr ptr");
-	helper_sig_jit_thread_attach = mono_create_icall_signature ("ptr ptr");
-	helper_sig_get_tls_tramp = mono_create_icall_signature ("ptr");
-	helper_sig_set_tls_tramp = mono_create_icall_signature ("void ptr");
 }
 
 static MONO_NEVER_INLINE gboolean

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -6811,7 +6811,7 @@ void
 mono_arch_register_lowlevel_calls (void)
 {
 	/* The signature doesn't matter */
-	mono_register_jit_icall (mono_amd64_throw_exception, "mono_amd64_throw_exception", mono_create_icall_signature ("void"), TRUE);
+	mono_register_jit_icall (mono_amd64_throw_exception, "mono_amd64_throw_exception", mono_icall_sig_void, TRUE);
 
 #if defined(TARGET_WIN32) || defined(HOST_WIN32)
 #if _MSC_VER

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -6045,9 +6045,9 @@ void
 mono_arch_register_lowlevel_calls (void)
 {
 	/* The signature doesn't matter */
-	mono_register_jit_icall (mono_arm_throw_exception, "mono_arm_throw_exception", mono_create_icall_signature ("void"), TRUE);
-	mono_register_jit_icall (mono_arm_throw_exception_by_token, "mono_arm_throw_exception_by_token", mono_create_icall_signature ("void"), TRUE);
-	mono_register_jit_icall (mono_arm_unaligned_stack, "mono_arm_unaligned_stack", mono_create_icall_signature ("void"), TRUE);
+	mono_register_jit_icall (mono_arm_throw_exception, "mono_arm_throw_exception", mono_icall_sig_void, TRUE);
+	mono_register_jit_icall (mono_arm_throw_exception_by_token, "mono_arm_throw_exception_by_token", mono_icall_sig_void, TRUE);
+	mono_register_jit_icall (mono_arm_unaligned_stack, "mono_arm_unaligned_stack", mono_icall_sig_void, TRUE);
 }
 
 #define patch_lis_ori(ip,val) do {\

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -4539,7 +4539,7 @@ void
 mono_arch_register_lowlevel_calls (void)
 {
 	/* The signature doesn't matter */
-	mono_register_jit_icall (mono_ppc_throw_exception, "mono_ppc_throw_exception", mono_create_icall_signature ("void"), TRUE);
+	mono_register_jit_icall (mono_ppc_throw_exception, "mono_ppc_throw_exception", mono_icall_sig_void, TRUE);
 }
 
 #ifdef __mono_ppc64__

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -681,7 +681,7 @@ mono_dynamic_code_hash_lookup (MonoDomain *domain, MonoMethod *method)
 #ifdef __cplusplus
 template <typename T>
 static void
-register_opcode_emulation (int opcode, const char *name, const char *sigstr, T func, const char *symbol, gboolean no_wrapper)
+register_opcode_emulation (int opcode, const char *name, MonoMethodSignature *sig, T func, const char *symbol, gboolean no_wrapper)
 #else
 static void
 register_opcode_emulation (int opcode, const char *name, MonoMethodSignature *sig, gpointer func, const char *symbol, gboolean no_wrapper)
@@ -4644,7 +4644,7 @@ register_icalls (void)
 	register_opcode_emulation (OP_LREM_UN, "__emul_lrem_un", mono_icall_sig_long_long_long, mono_llrem_un, "mono_llrem_un", FALSE);
 #endif
 #if !defined(MONO_ARCH_NO_EMULATE_LONG_MUL_OPTS) || defined(MONO_ARCH_EMULATE_LONG_MUL_OVF_OPTS)
-	register_opcode_emulation (OP_LMUL_OVF_UN, "__emul_lmul_ovf_un", mono_icall_sig_long_long_long", mono_llmult_ovf_un, "mono_llmult_ovf_un", FALSE);
+	register_opcode_emulation (OP_LMUL_OVF_UN, "__emul_lmul_ovf_un", mono_icall_sig_long_long_long, mono_llmult_ovf_un, "mono_llmult_ovf_un", FALSE);
 	register_opcode_emulation (OP_LMUL_OVF, "__emul_lmul_ovf", mono_icall_sig_long_long_long", mono_llmult_ovf, "mono_llmult_ovf", FALSE);
 #endif
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4711,8 +4711,8 @@ register_icalls (void)
 		register_opcode_emulation (OP_FADD, "__emul_fadd", mono_icall_sig_double_double_double, mono_fadd, "mono_fadd", FALSE);
 		register_opcode_emulation (OP_FMUL, "__emul_fmul", mono_icall_sig_double_double_double, mono_fmul, "mono_fmul", FALSE);
 		register_opcode_emulation (OP_FNEG, "__emul_fneg", mono_icall_sig_double_double, mono_fneg, "mono_fneg", FALSE);
-		register_opcode_emulation (OP_ICONV_TO_R8, "__emul_iconv_to_r8", mono_icall_sig_double_int32", mono_conv_to_r8, "mono_conv_to_r8", FALSE);
-		register_opcode_emulation (OP_ICONV_TO_R4, "__emul_iconv_to_r4", mono_icall_sig_double_int32", mono_conv_to_r4, "mono_conv_to_r4", FALSE);
+		register_opcode_emulation (OP_ICONV_TO_R8, "__emul_iconv_to_r8", mono_icall_sig_double_int32, mono_conv_to_r8, "mono_conv_to_r8", FALSE);
+		register_opcode_emulation (OP_ICONV_TO_R4, "__emul_iconv_to_r4", mono_icall_sig_double_int32, mono_conv_to_r4, "mono_conv_to_r4", FALSE);
 		register_opcode_emulation (OP_FCONV_TO_R4, "__emul_fconv_to_r4", mono_icall_sig_double_double, mono_fconv_r4, "mono_fconv_r4", FALSE);
 		register_opcode_emulation (OP_FCONV_TO_I1, "__emul_fconv_to_i1", mono_icall_sig_int8_double, mono_fconv_i1, "mono_fconv_i1", FALSE);
 		register_opcode_emulation (OP_FCONV_TO_I2, "__emul_fconv_to_i2", mono_icall_sig_int16_double, mono_fconv_i2, "mono_fconv_i2", FALSE);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -684,14 +684,12 @@ static void
 register_opcode_emulation (int opcode, const char *name, const char *sigstr, T func, const char *symbol, gboolean no_wrapper)
 #else
 static void
-register_opcode_emulation (int opcode, const char *name, const char *sigstr, gpointer func, const char *symbol, gboolean no_wrapper)
+register_opcode_emulation (int opcode, const char *name, MonoMethodSignature *sig, gpointer func, const char *symbol, gboolean no_wrapper)
 #endif
 {
 #ifndef DISABLE_JIT
-	mini_register_opcode_emulation (opcode, name, sigstr, func, symbol, no_wrapper);
+	mini_register_opcode_emulation (opcode, name, sig, func, symbol, no_wrapper);
 #else
-	MonoMethodSignature *sig = mono_create_icall_signature (sigstr);
-
 	g_assert (!sig->hasthis);
 	g_assert (sig->param_count < 3);
 
@@ -708,57 +706,36 @@ register_opcode_emulation (int opcode, const char *name, const char *sigstr, gpo
 #ifdef __cplusplus
 template <typename T>
 static void
-register_icall (T func, const char *name, const char *sigstr, gboolean avoid_wrapper)
+register_icall (T func, const char *name, MonoMethodSignature *sig, gboolean avoid_wrapper)
 #else
 static void
-register_icall (gpointer func, const char *name, const char *sigstr, gboolean avoid_wrapper)
+register_icall (gpointer func, const char *name, MonoMethodSignature *sig, gboolean avoid_wrapper)
 #endif
 {
-	MonoMethodSignature *sig;
-
-	if (sigstr)
-		sig = mono_create_icall_signature (sigstr);
-	else
-		sig = NULL;
-
 	mono_register_jit_icall_full (func, name, sig, avoid_wrapper, name);
 }
 
 #ifdef __cplusplus
 template <typename T>
 static void
-register_icall_no_wrapper (T func, const char *name, const char *sigstr)
+register_icall_no_wrapper (T func, const char *name,  MonoMethodSignature *sig)
 #else
 static void
-register_icall_no_wrapper (gpointer func, const char *name, const char *sigstr)
+register_icall_no_wrapper (gpointer func, const char *name,  MonoMethodSignature *sig)
 #endif
 {
-	MonoMethodSignature *sig;
-
-	if (sigstr)
-		sig = mono_create_icall_signature (sigstr);
-	else
-		sig = NULL;
-
 	mono_register_jit_icall_full (func, name, sig, TRUE, name);
 }
 
 #ifdef __cplusplus
 template <typename T>
 static void
-register_icall_with_wrapper (T func, const char *name, const char *sigstr)
+register_icall_with_wrapper (T func, const char *name, MonoMethodSignature *sig)
 #else
 static void
-register_icall_with_wrapper (gpointer func, const char *name, const char *sigstr)
+register_icall_with_wrapper (gpointer func, const char *name, MonoMethodSignature *sig)
 #endif
 {
-	MonoMethodSignature *sig;
-
-	if (sigstr)
-		sig = mono_create_icall_signature (sigstr);
-	else
-		sig = NULL;
-
 	mono_register_jit_icall_full (func, name, sig, FALSE, name);
 }
 
@@ -769,19 +746,12 @@ register_icall_with_wrapper (gpointer func, const char *name, const char *sigstr
 #ifdef __cplusplus
 template <typename T>
 static void
-register_dyn_icall (T func, const char *name, const char *sigstr, gboolean save)
+register_dyn_icall (T func, const char *name, MonoMethodSignature *sig, gboolean save)
 #else
 static void
-register_dyn_icall (gpointer func, const char *name, const char *sigstr, gboolean save)
+register_dyn_icall (gpointer func, const char *name, MonoMethodSignature *sig, gboolean save)
 #endif
 {
-	MonoMethodSignature *sig;
-
-	if (sigstr)
-		sig = mono_create_icall_signature (sigstr);
-	else
-		sig = NULL;
-
 	mono_register_jit_icall (func, name, sig, save);
 }
 
@@ -4545,9 +4515,7 @@ mini_init (const char *filename, const char *runtime_version)
 	/* This should come after mono_init () too */
 	mini_gc_init ();
 
-#ifndef DISABLE_JIT
-	mono_create_helper_signatures ();
-#endif
+	mono_create_icall_signatures ();
 
 	register_jit_stats ();
 
@@ -4632,253 +4600,251 @@ register_icalls (void)
 	 * the wrapper would call the icall which would call the wrapper and
 	 * so on.
 	 */
-	register_icall (mono_profiler_raise_method_enter, "mono_profiler_raise_method_enter", "void ptr ptr", TRUE);
-	register_icall (mono_profiler_raise_method_leave, "mono_profiler_raise_method_leave", "void ptr ptr", TRUE);
-	register_icall (mono_profiler_raise_method_tail_call, "mono_profiler_raise_method_tail_call", "void ptr ptr", TRUE);
-	register_icall (mono_profiler_raise_exception_clause, "mono_profiler_raise_exception_clause", "void ptr int int object", TRUE);
+	register_icall (mono_profiler_raise_method_enter, "mono_profiler_raise_method_enter", mono_icall_sig_void_ptr_ptr, TRUE);
+	register_icall (mono_profiler_raise_method_leave, "mono_profiler_raise_method_leave", mono_icall_sig_void_ptr_ptr, TRUE);
+	register_icall (mono_profiler_raise_method_tail_call, "mono_profiler_raise_method_tail_call", mono_icall_sig_void_ptr_ptr, TRUE);
+	register_icall (mono_profiler_raise_exception_clause, "mono_profiler_raise_exception_clause", mono_icall_sig_void_ptr_int_int_object, TRUE);
 
-	register_icall (mono_trace_enter_method, "mono_trace_enter_method", "void ptr ptr", TRUE);
-	register_icall (mono_trace_leave_method, "mono_trace_leave_method", "void ptr ptr", TRUE);
-	register_icall (mono_get_lmf_addr, "mono_get_lmf_addr", "ptr", TRUE);
-	register_icall (mono_jit_set_domain, "mono_jit_set_domain", "void ptr", TRUE);
-	register_icall (mono_domain_get, "mono_domain_get", "ptr", TRUE);
+	register_icall (mono_trace_enter_method, "mono_trace_enter_method", mono_icall_sig_void_ptr_ptr, TRUE);
+	register_icall (mono_trace_leave_method, "mono_trace_leave_method", mono_icall_sig_void_ptr_ptr, TRUE);
+	register_icall (mono_get_lmf_addr, "mono_get_lmf_addr", mono_icall_sig_ptr, TRUE);
+	register_icall (mono_jit_set_domain, "mono_jit_set_domain", mono_icall_sig_void_ptr, TRUE);
+	register_icall (mono_domain_get, "mono_domain_get", mono_icall_sig_ptr, TRUE);
 
-	register_icall (mono_llvm_throw_exception, "mono_llvm_throw_exception", "void object", TRUE);
-	register_icall (mono_llvm_rethrow_exception, "mono_llvm_rethrow_exception", "void object", TRUE);
-	register_icall (mono_llvm_resume_exception, "mono_llvm_resume_exception", "void", TRUE);
-	register_icall (mono_llvm_match_exception, "mono_llvm_match_exception", "int ptr int int ptr object", TRUE);
+	register_icall (mono_llvm_throw_exception, "mono_llvm_throw_exception", mono_icall_sig_void_object, TRUE);
+	register_icall (mono_llvm_rethrow_exception, "mono_llvm_rethrow_exception", mono_icall_sig_void_object, TRUE);
+	register_icall (mono_llvm_resume_exception, "mono_llvm_resume_exception", mono_icall_sig_void, TRUE);
+	register_icall (mono_llvm_match_exception, "mono_llvm_match_exception", mono_icall_sig_int_ptr_int_int_ptr_object, TRUE);
 	register_icall (mono_llvm_clear_exception, "mono_llvm_clear_exception", NULL, TRUE);
-	register_icall (mono_llvm_load_exception, "mono_llvm_load_exception", "object", TRUE);
-	register_icall (mono_llvm_throw_corlib_exception, "mono_llvm_throw_corlib_exception", "void int", TRUE);
+	register_icall (mono_llvm_load_exception, "mono_llvm_load_exception", mono_icall_sig_object, TRUE);
+	register_icall (mono_llvm_throw_corlib_exception, "mono_llvm_throw_corlib_exception", mono_icall_sig_void_int, TRUE);
 #if defined(ENABLE_LLVM) && !defined(MONO_LLVM_LOADED) && defined(HAVE_UNWIND_H)
 	register_icall (mono_llvm_set_unhandled_exception_handler, "mono_llvm_set_unhandled_exception_handler", NULL, TRUE);
 
 	// FIXME: This is broken
-	register_icall (mono_debug_personality, "mono_debug_personality", "int int int ptr ptr ptr", TRUE);
+	register_icall (mono_debug_personality, "mono_debug_personality", mono_icall_sig_int_int_int_ptr_ptr_ptr, TRUE);
 #endif
 
-	register_dyn_icall (mono_get_throw_exception (), "mono_arch_throw_exception", "void object", TRUE);
-	register_dyn_icall (mono_get_rethrow_exception (), "mono_arch_rethrow_exception", "void object", TRUE);
-	register_dyn_icall (mono_get_throw_corlib_exception (), "mono_arch_throw_corlib_exception", "void ptr", TRUE);
-	register_icall (mono_thread_get_undeniable_exception, "mono_thread_get_undeniable_exception", "object", FALSE);
-	register_icall (ves_icall_thread_finish_async_abort, "ves_icall_thread_finish_async_abort", "void", FALSE);
-	register_icall (mono_thread_interruption_checkpoint, "mono_thread_interruption_checkpoint", "object", FALSE);
-	register_icall (mono_thread_force_interruption_checkpoint_noraise, "mono_thread_force_interruption_checkpoint_noraise", "object", FALSE);
+	register_dyn_icall (mono_get_throw_exception (), "mono_arch_throw_exception", mono_icall_sig_void_object, TRUE);
+	register_dyn_icall (mono_get_rethrow_exception (), "mono_arch_rethrow_exception", mono_icall_sig_void_object, TRUE);
+	register_dyn_icall (mono_get_throw_corlib_exception (), "mono_arch_throw_corlib_exception", mono_icall_sig_void_ptr, TRUE);
+	register_icall (mono_thread_get_undeniable_exception, "mono_thread_get_undeniable_exception", mono_icall_sig_object, FALSE);
+	register_icall (ves_icall_thread_finish_async_abort, "ves_icall_thread_finish_async_abort", mono_icall_sig_void, FALSE);
+	register_icall (mono_thread_interruption_checkpoint, "mono_thread_interruption_checkpoint", mono_icall_sig_object, FALSE);
+	register_icall (mono_thread_force_interruption_checkpoint_noraise, "mono_thread_force_interruption_checkpoint_noraise", mono_icall_sig_object, FALSE);
 
 	if (mono_threads_are_safepoints_enabled ())
-		register_icall (mono_threads_state_poll, "mono_threads_state_poll", "void", FALSE);
+		register_icall (mono_threads_state_poll, "mono_threads_state_poll", mono_icall_sig_void, FALSE);
 
 #ifndef MONO_ARCH_NO_EMULATE_LONG_MUL_OPTS
-	register_opcode_emulation (OP_LMUL, "__emul_lmul", "long long long", mono_llmult, "mono_llmult", FALSE);
-	register_opcode_emulation (OP_LDIV, "__emul_ldiv", "long long long", mono_lldiv, "mono_lldiv", FALSE);
-	register_opcode_emulation (OP_LDIV_UN, "__emul_ldiv_un", "long long long", mono_lldiv_un, "mono_lldiv_un", FALSE);
-	register_opcode_emulation (OP_LREM, "__emul_lrem", "long long long", mono_llrem, "mono_llrem", FALSE);
-	register_opcode_emulation (OP_LREM_UN, "__emul_lrem_un", "long long long", mono_llrem_un, "mono_llrem_un", FALSE);
+	register_opcode_emulation (OP_LMUL, "__emul_lmul", mono_icall_sig_long_long_long, mono_llmult, "mono_llmult", FALSE);
+	register_opcode_emulation (OP_LDIV, "__emul_ldiv", mono_icall_sig_long_long_long, mono_lldiv, "mono_lldiv", FALSE);
+	register_opcode_emulation (OP_LDIV_UN, "__emul_ldiv_un", mono_icall_sig_long_long_long, mono_lldiv_un, "mono_lldiv_un", FALSE);
+	register_opcode_emulation (OP_LREM, "__emul_lrem", mono_icall_sig_long_long_long, mono_llrem, "mono_llrem", FALSE);
+	register_opcode_emulation (OP_LREM_UN, "__emul_lrem_un", mono_icall_sig_long_long_long, mono_llrem_un, "mono_llrem_un", FALSE);
 #endif
 #if !defined(MONO_ARCH_NO_EMULATE_LONG_MUL_OPTS) || defined(MONO_ARCH_EMULATE_LONG_MUL_OVF_OPTS)
-	register_opcode_emulation (OP_LMUL_OVF_UN, "__emul_lmul_ovf_un", "long long long", mono_llmult_ovf_un, "mono_llmult_ovf_un", FALSE);
-	register_opcode_emulation (OP_LMUL_OVF, "__emul_lmul_ovf", "long long long", mono_llmult_ovf, "mono_llmult_ovf", FALSE);
+	register_opcode_emulation (OP_LMUL_OVF_UN, "__emul_lmul_ovf_un", mono_icall_sig_long_long_long", mono_llmult_ovf_un, "mono_llmult_ovf_un", FALSE);
+	register_opcode_emulation (OP_LMUL_OVF, "__emul_lmul_ovf", mono_icall_sig_long_long_long", mono_llmult_ovf, "mono_llmult_ovf", FALSE);
 #endif
 
 #ifndef MONO_ARCH_NO_EMULATE_LONG_SHIFT_OPS
-	register_opcode_emulation (OP_LSHL, "__emul_lshl", "long long int32", mono_lshl, "mono_lshl", TRUE);
-	register_opcode_emulation (OP_LSHR, "__emul_lshr", "long long int32", mono_lshr, "mono_lshr", TRUE);
-	register_opcode_emulation (OP_LSHR_UN, "__emul_lshr_un", "long long int32", mono_lshr_un, "mono_lshr_un", TRUE);
+	register_opcode_emulation (OP_LSHL, "__emul_lshl", mono_icall_sig_long_long_int32, mono_lshl, "mono_lshl", TRUE);
+	register_opcode_emulation (OP_LSHR, "__emul_lshr", mono_icall_sig_long_long_int32, mono_lshr, "mono_lshr", TRUE);
+	register_opcode_emulation (OP_LSHR_UN, "__emul_lshr_un", mono_icall_sig_long_long_int32, mono_lshr_un, "mono_lshr_un", TRUE);
 #endif
 
 #if defined(MONO_ARCH_EMULATE_MUL_DIV) || defined(MONO_ARCH_EMULATE_DIV)
-	register_opcode_emulation (OP_IDIV, "__emul_op_idiv", "int32 int32 int32", mono_idiv, "mono_idiv", FALSE);
-	register_opcode_emulation (OP_IDIV_UN, "__emul_op_idiv_un", "int32 int32 int32", mono_idiv_un, "mono_idiv_un", FALSE);
-	register_opcode_emulation (OP_IREM, "__emul_op_irem", "int32 int32 int32", mono_irem, "mono_irem", FALSE);
-	register_opcode_emulation (OP_IREM_UN, "__emul_op_irem_un", "int32 int32 int32", mono_irem_un, "mono_irem_un", FALSE);
+	register_opcode_emulation (OP_IDIV, "__emul_op_idiv", mono_icall_sig_int32_int32_int32, mono_idiv, "mono_idiv", FALSE);
+	register_opcode_emulation (OP_IDIV_UN, "__emul_op_idiv_un", mono_icall_sig_int32_int32_int32, mono_idiv_un, "mono_idiv_un", FALSE);
+	register_opcode_emulation (OP_IREM, "__emul_op_irem", mono_icall_sig_int32_int32_int32, mono_irem, "mono_irem", FALSE);
+	register_opcode_emulation (OP_IREM_UN, "__emul_op_irem_un", mono_icall_sig_int32_int32_int32, mono_irem_un, "mono_irem_un", FALSE);
 #endif
 
 #ifdef MONO_ARCH_EMULATE_MUL_DIV
-	register_opcode_emulation (OP_IMUL, "__emul_op_imul", "int32 int32 int32", mono_imul, "mono_imul", TRUE);
+	register_opcode_emulation (OP_IMUL, "__emul_op_imul", mono_icall_sig_int32_int32_int32, mono_imul, "mono_imul", TRUE);
 #endif
 
 #if defined(MONO_ARCH_EMULATE_MUL_DIV) || defined(MONO_ARCH_EMULATE_MUL_OVF)
-	register_opcode_emulation (OP_IMUL_OVF, "__emul_op_imul_ovf", "int32 int32 int32", mono_imul_ovf, "mono_imul_ovf", FALSE);
-	register_opcode_emulation (OP_IMUL_OVF_UN, "__emul_op_imul_ovf_un", "int32 int32 int32", mono_imul_ovf_un, "mono_imul_ovf_un", FALSE);
+	register_opcode_emulation (OP_IMUL_OVF, "__emul_op_imul_ovf", mono_icall_sig_int32_int32_int32, mono_imul_ovf, "mono_imul_ovf", FALSE);
+	register_opcode_emulation (OP_IMUL_OVF_UN, "__emul_op_imul_ovf_un", mono_icall_sig_int32_int32_int32, mono_imul_ovf_un, "mono_imul_ovf_un", FALSE);
 #endif
 
 #if defined(MONO_ARCH_EMULATE_MUL_DIV) || defined(MONO_ARCH_SOFT_FLOAT_FALLBACK)
-	register_opcode_emulation (OP_FDIV, "__emul_fdiv", "double double double", mono_fdiv, "mono_fdiv", FALSE);
+	register_opcode_emulation (OP_FDIV, "__emul_fdiv", mono_icall_sig_double_double_double, mono_fdiv, "mono_fdiv", FALSE);
 #endif
 
-	register_opcode_emulation (OP_FCONV_TO_U8, "__emul_fconv_to_u8", "ulong double", mono_fconv_u8, "mono_fconv_u8", FALSE);
-	register_opcode_emulation (OP_RCONV_TO_U8, "__emul_rconv_to_u8", "ulong float", mono_rconv_u8, "mono_rconv_u8", FALSE);
-	register_opcode_emulation (OP_FCONV_TO_U4, "__emul_fconv_to_u4", "uint32 double", mono_fconv_u4, "mono_fconv_u4", FALSE);
-	register_opcode_emulation (OP_FCONV_TO_OVF_I8, "__emul_fconv_to_ovf_i8", "long double", mono_fconv_ovf_i8, "mono_fconv_ovf_i8", FALSE);
-	register_opcode_emulation (OP_FCONV_TO_OVF_U8, "__emul_fconv_to_ovf_u8", "ulong double", mono_fconv_ovf_u8, "mono_fconv_ovf_u8", FALSE);
-	register_opcode_emulation (OP_RCONV_TO_OVF_I8, "__emul_rconv_to_ovf_i8", "long float", mono_rconv_ovf_i8, "mono_rconv_ovf_i8", FALSE);
-	register_opcode_emulation (OP_RCONV_TO_OVF_U8, "__emul_rconv_to_ovf_u8", "ulong float", mono_rconv_ovf_u8, "mono_rconv_ovf_u8", FALSE);
+	register_opcode_emulation (OP_FCONV_TO_U8, "__emul_fconv_to_u8", mono_icall_sig_ulong_double, mono_fconv_u8, "mono_fconv_u8", FALSE);
+	register_opcode_emulation (OP_RCONV_TO_U8, "__emul_rconv_to_u8", mono_icall_sig_ulong_float, mono_rconv_u8, "mono_rconv_u8", FALSE);
+	register_opcode_emulation (OP_FCONV_TO_U4, "__emul_fconv_to_u4", mono_icall_sig_uint32_double, mono_fconv_u4, "mono_fconv_u4", FALSE);
+	register_opcode_emulation (OP_FCONV_TO_OVF_I8, "__emul_fconv_to_ovf_i8", mono_icall_sig_long_double, mono_fconv_ovf_i8, "mono_fconv_ovf_i8", FALSE);
+	register_opcode_emulation (OP_FCONV_TO_OVF_U8, "__emul_fconv_to_ovf_u8", mono_icall_sig_ulong_double, mono_fconv_ovf_u8, "mono_fconv_ovf_u8", FALSE);
+	register_opcode_emulation (OP_RCONV_TO_OVF_I8, "__emul_rconv_to_ovf_i8", mono_icall_sig_long_float, mono_rconv_ovf_i8, "mono_rconv_ovf_i8", FALSE);
+	register_opcode_emulation (OP_RCONV_TO_OVF_U8, "__emul_rconv_to_ovf_u8", mono_icall_sig_ulong_float, mono_rconv_ovf_u8, "mono_rconv_ovf_u8", FALSE);
 
 
 #ifdef MONO_ARCH_EMULATE_FCONV_TO_I8
-	register_opcode_emulation (OP_FCONV_TO_I8, "__emul_fconv_to_i8", "long double", mono_fconv_i8, "mono_fconv_i8", FALSE);
-	register_opcode_emulation (OP_RCONV_TO_I8, "__emul_rconv_to_i8", "long float", mono_rconv_i8, "mono_rconv_i8", FALSE);
+	register_opcode_emulation (OP_FCONV_TO_I8, "__emul_fconv_to_i8", mono_icall_sig_long_double, mono_fconv_i8, "mono_fconv_i8", FALSE);
+	register_opcode_emulation (OP_RCONV_TO_I8, "__emul_rconv_to_i8", mono_icall_sig_long_float, mono_rconv_i8, "mono_rconv_i8", FALSE);
 #endif
 
 #ifdef MONO_ARCH_EMULATE_CONV_R8_UN
-	register_opcode_emulation (OP_ICONV_TO_R_UN, "__emul_iconv_to_r_un", "double int32", mono_conv_to_r8_un, "mono_conv_to_r8_un", FALSE);
+	register_opcode_emulation (OP_ICONV_TO_R_UN, "__emul_iconv_to_r_un", mono_icall_sig_double_int32, mono_conv_to_r8_un, "mono_conv_to_r8_un", FALSE);
 #endif
 #ifdef MONO_ARCH_EMULATE_LCONV_TO_R8
-	register_opcode_emulation (OP_LCONV_TO_R8, "__emul_lconv_to_r8", "double long", mono_lconv_to_r8, "mono_lconv_to_r8", FALSE);
+	register_opcode_emulation (OP_LCONV_TO_R8, "__emul_lconv_to_r8", mono_icall_sig_double_long, mono_lconv_to_r8, "mono_lconv_to_r8", FALSE);
 #endif
 #ifdef MONO_ARCH_EMULATE_LCONV_TO_R4
-	register_opcode_emulation (OP_LCONV_TO_R4, "__emul_lconv_to_r4", "float long", mono_lconv_to_r4, "mono_lconv_to_r4", FALSE);
+	register_opcode_emulation (OP_LCONV_TO_R4, "__emul_lconv_to_r4", mono_icall_sig_float_long, mono_lconv_to_r4, "mono_lconv_to_r4", FALSE);
 #endif
 #ifdef MONO_ARCH_EMULATE_LCONV_TO_R8_UN
-	register_opcode_emulation (OP_LCONV_TO_R_UN, "__emul_lconv_to_r8_un", "double long", mono_lconv_to_r8_un, "mono_lconv_to_r8_un", FALSE);
+	register_opcode_emulation (OP_LCONV_TO_R_UN, "__emul_lconv_to_r8_un", mono_icall_sig_double_long, mono_lconv_to_r8_un, "mono_lconv_to_r8_un", FALSE);
 #endif
 #ifdef MONO_ARCH_EMULATE_FREM
-	register_opcode_emulation (OP_FREM, "__emul_frem", "double double double", mono_fmod, "fmod", FALSE);
-	register_opcode_emulation (OP_RREM, "__emul_rrem", "float float float", fmodf, "fmodf", FALSE);
+	register_opcode_emulation (OP_FREM, "__emul_frem", mono_icall_sig_double_double_double, mono_fmod, "fmod", FALSE);
+	register_opcode_emulation (OP_RREM, "__emul_rrem", mono_icall_sig_float_float_float, fmodf, "fmodf", FALSE);
 #endif
 
 #ifdef MONO_ARCH_SOFT_FLOAT_FALLBACK
 	if (mono_arch_is_soft_float ()) {
-		register_opcode_emulation (OP_FSUB, "__emul_fsub", "double double double", mono_fsub, "mono_fsub", FALSE);
-		register_opcode_emulation (OP_FADD, "__emul_fadd", "double double double", mono_fadd, "mono_fadd", FALSE);
-		register_opcode_emulation (OP_FMUL, "__emul_fmul", "double double double", mono_fmul, "mono_fmul", FALSE);
-		register_opcode_emulation (OP_FNEG, "__emul_fneg", "double double", mono_fneg, "mono_fneg", FALSE);
-		register_opcode_emulation (OP_ICONV_TO_R8, "__emul_iconv_to_r8", "double int32", mono_conv_to_r8, "mono_conv_to_r8", FALSE);
-		register_opcode_emulation (OP_ICONV_TO_R4, "__emul_iconv_to_r4", "double int32", mono_conv_to_r4, "mono_conv_to_r4", FALSE);
-		register_opcode_emulation (OP_FCONV_TO_R4, "__emul_fconv_to_r4", "double double", mono_fconv_r4, "mono_fconv_r4", FALSE);
-		register_opcode_emulation (OP_FCONV_TO_I1, "__emul_fconv_to_i1", "int8 double", mono_fconv_i1, "mono_fconv_i1", FALSE);
-		register_opcode_emulation (OP_FCONV_TO_I2, "__emul_fconv_to_i2", "int16 double", mono_fconv_i2, "mono_fconv_i2", FALSE);
-		register_opcode_emulation (OP_FCONV_TO_I4, "__emul_fconv_to_i4", "int32 double", mono_fconv_i4, "mono_fconv_i4", FALSE);
-		register_opcode_emulation (OP_FCONV_TO_U1, "__emul_fconv_to_u1", "uint8 double", mono_fconv_u1, "mono_fconv_u1", FALSE);
-		register_opcode_emulation (OP_FCONV_TO_U2, "__emul_fconv_to_u2", "uint16 double", mono_fconv_u2, "mono_fconv_u2", FALSE);
+		register_opcode_emulation (OP_FSUB, "__emul_fsub", mono_icall_sig_double_double_double, mono_fsub, "mono_fsub", FALSE);
+		register_opcode_emulation (OP_FADD, "__emul_fadd", mono_icall_sig_double_double_double, mono_fadd, "mono_fadd", FALSE);
+		register_opcode_emulation (OP_FMUL, "__emul_fmul", mono_icall_sig_double_double_double, mono_fmul, "mono_fmul", FALSE);
+		register_opcode_emulation (OP_FNEG, "__emul_fneg", mono_icall_sig_double_double, mono_fneg, "mono_fneg", FALSE);
+		register_opcode_emulation (OP_ICONV_TO_R8, "__emul_iconv_to_r8", mono_icall_sig_double_int32", mono_conv_to_r8, "mono_conv_to_r8", FALSE);
+		register_opcode_emulation (OP_ICONV_TO_R4, "__emul_iconv_to_r4", mono_icall_sig_double_int32", mono_conv_to_r4, "mono_conv_to_r4", FALSE);
+		register_opcode_emulation (OP_FCONV_TO_R4, "__emul_fconv_to_r4", mono_icall_sig_double_double, mono_fconv_r4, "mono_fconv_r4", FALSE);
+		register_opcode_emulation (OP_FCONV_TO_I1, "__emul_fconv_to_i1", mono_icall_sig_int8_double, mono_fconv_i1, "mono_fconv_i1", FALSE);
+		register_opcode_emulation (OP_FCONV_TO_I2, "__emul_fconv_to_i2", mono_icall_sig_int16_double, mono_fconv_i2, "mono_fconv_i2", FALSE);
+		register_opcode_emulation (OP_FCONV_TO_I4, "__emul_fconv_to_i4", mono_icall_sig_int32_double, mono_fconv_i4, "mono_fconv_i4", FALSE);
+		register_opcode_emulation (OP_FCONV_TO_U1, "__emul_fconv_to_u1", mono_icall_sig_uint8_double, mono_fconv_u1, "mono_fconv_u1", FALSE);
+		register_opcode_emulation (OP_FCONV_TO_U2, "__emul_fconv_to_u2", mono_icall_sig_uint16_double, mono_fconv_u2, "mono_fconv_u2", FALSE);
 
 #if TARGET_SIZEOF_VOID_P == 4
-		register_opcode_emulation (OP_FCONV_TO_I, "__emul_fconv_to_i", "int32 double", mono_fconv_i4, "mono_fconv_i4", FALSE);
+		register_opcode_emulation (OP_FCONV_TO_I, "__emul_fconv_to_i", mono_icall_sig_int32_double, mono_fconv_i4, "mono_fconv_i4", FALSE);
 #endif
 
-		register_opcode_emulation (OP_FBEQ, "__emul_fcmp_eq", "uint32 double double", mono_fcmp_eq, "mono_fcmp_eq", FALSE);
-		register_opcode_emulation (OP_FBLT, "__emul_fcmp_lt", "uint32 double double", mono_fcmp_lt, "mono_fcmp_lt", FALSE);
-		register_opcode_emulation (OP_FBGT, "__emul_fcmp_gt", "uint32 double double", mono_fcmp_gt, "mono_fcmp_gt", FALSE);
-		register_opcode_emulation (OP_FBLE, "__emul_fcmp_le", "uint32 double double", mono_fcmp_le, "mono_fcmp_le", FALSE);
-		register_opcode_emulation (OP_FBGE, "__emul_fcmp_ge", "uint32 double double", mono_fcmp_ge, "mono_fcmp_ge", FALSE);
-		register_opcode_emulation (OP_FBNE_UN, "__emul_fcmp_ne_un", "uint32 double double", mono_fcmp_ne_un, "mono_fcmp_ne_un", FALSE);
-		register_opcode_emulation (OP_FBLT_UN, "__emul_fcmp_lt_un", "uint32 double double", mono_fcmp_lt_un, "mono_fcmp_lt_un", FALSE);
-		register_opcode_emulation (OP_FBGT_UN, "__emul_fcmp_gt_un", "uint32 double double", mono_fcmp_gt_un, "mono_fcmp_gt_un", FALSE);
-		register_opcode_emulation (OP_FBLE_UN, "__emul_fcmp_le_un", "uint32 double double", mono_fcmp_le_un, "mono_fcmp_le_un", FALSE);
-		register_opcode_emulation (OP_FBGE_UN, "__emul_fcmp_ge_un", "uint32 double double", mono_fcmp_ge_un, "mono_fcmp_ge_un", FALSE);
+		register_opcode_emulation (OP_FBEQ, "__emul_fcmp_eq", mono_icall_sig_uint32_double_double, mono_fcmp_eq, "mono_fcmp_eq", FALSE);
+		register_opcode_emulation (OP_FBLT, "__emul_fcmp_lt", mono_icall_sig_uint32_double_double, mono_fcmp_lt, "mono_fcmp_lt", FALSE);
+		register_opcode_emulation (OP_FBGT, "__emul_fcmp_gt", mono_icall_sig_uint32_double_double, mono_fcmp_gt, "mono_fcmp_gt", FALSE);
+		register_opcode_emulation (OP_FBLE, "__emul_fcmp_le", mono_icall_sig_uint32_double_double, mono_fcmp_le, "mono_fcmp_le", FALSE);
+		register_opcode_emulation (OP_FBGE, "__emul_fcmp_ge", mono_icall_sig_uint32_double_double, mono_fcmp_ge, "mono_fcmp_ge", FALSE);
+		register_opcode_emulation (OP_FBNE_UN, "__emul_fcmp_ne_un", mono_icall_sig_uint32_double_double, mono_fcmp_ne_un, "mono_fcmp_ne_un", FALSE);
+		register_opcode_emulation (OP_FBLT_UN, "__emul_fcmp_lt_un", mono_icall_sig_uint32_double_double, mono_fcmp_lt_un, "mono_fcmp_lt_un", FALSE);
+		register_opcode_emulation (OP_FBGT_UN, "__emul_fcmp_gt_un", mono_icall_sig_uint32_double_double, mono_fcmp_gt_un, "mono_fcmp_gt_un", FALSE);
+		register_opcode_emulation (OP_FBLE_UN, "__emul_fcmp_le_un", mono_icall_sig_uint32_double_double, mono_fcmp_le_un, "mono_fcmp_le_un", FALSE);
+		register_opcode_emulation (OP_FBGE_UN, "__emul_fcmp_ge_un", mono_icall_sig_uint32_double_double, mono_fcmp_ge_un, "mono_fcmp_ge_un", FALSE);
 
-		register_opcode_emulation (OP_FCEQ, "__emul_fcmp_ceq", "uint32 double double", mono_fceq, "mono_fceq", FALSE);
-		register_opcode_emulation (OP_FCGT, "__emul_fcmp_cgt", "uint32 double double", mono_fcgt, "mono_fcgt", FALSE);
-		register_opcode_emulation (OP_FCGT_UN, "__emul_fcmp_cgt_un", "uint32 double double", mono_fcgt_un, "mono_fcgt_un", FALSE);
-		register_opcode_emulation (OP_FCLT, "__emul_fcmp_clt", "uint32 double double", mono_fclt, "mono_fclt", FALSE);
-		register_opcode_emulation (OP_FCLT_UN, "__emul_fcmp_clt_un", "uint32 double double", mono_fclt_un, "mono_fclt_un", FALSE);
+		register_opcode_emulation (OP_FCEQ, "__emul_fcmp_ceq", mono_icall_sig_uint32_double_double, mono_fceq, "mono_fceq", FALSE);
+		register_opcode_emulation (OP_FCGT, "__emul_fcmp_cgt", mono_icall_sig_uint32_double_double, mono_fcgt, "mono_fcgt", FALSE);
+		register_opcode_emulation (OP_FCGT_UN, "__emul_fcmp_cgt_un", mono_icall_sig_uint32_double_double, mono_fcgt_un, "mono_fcgt_un", FALSE);
+		register_opcode_emulation (OP_FCLT, "__emul_fcmp_clt", mono_icall_sig_uint32_double_double, mono_fclt, "mono_fclt", FALSE);
+		register_opcode_emulation (OP_FCLT_UN, "__emul_fcmp_clt_un", mono_icall_sig_uint32_double_double, mono_fclt_un, "mono_fclt_un", FALSE);
 
-		register_icall (mono_fload_r4, "mono_fload_r4", "double ptr", FALSE);
-		register_icall (mono_fstore_r4, "mono_fstore_r4", "void double ptr", FALSE);
-		register_icall (mono_fload_r4_arg, "mono_fload_r4_arg", "uint32 double", FALSE);
-		register_icall (mono_isfinite_double, "mono_isfinite_double", "int32 double", FALSE);
+		register_icall (mono_fload_r4, "mono_fload_r4", mono_icall_sig_double_ptr, FALSE);
+		register_icall (mono_fstore_r4, "mono_fstore_r4", mono_icall_sig_void_double_ptr, FALSE);
+		register_icall (mono_fload_r4_arg, "mono_fload_r4_arg", mono_icall_sig_uint32_double, FALSE);
+		register_icall (mono_isfinite_double, "mono_isfinite_double", mono_icall_sig_int32_double, FALSE);
 	}
 #endif
-	register_icall (mono_ckfinite, "mono_ckfinite", "double double", FALSE);
+	register_icall (mono_ckfinite, "mono_ckfinite", mono_icall_sig_double_double, FALSE);
 
 #ifdef COMPRESSED_INTERFACE_BITMAP
-	register_icall (mono_class_interface_match, "mono_class_interface_match", "uint32 ptr int32", TRUE);
+	register_icall (mono_class_interface_match, "mono_class_interface_match", mono_icall_sig_uint32_ptr_int32, TRUE);
 #endif
 
 #if SIZEOF_REGISTER == 4
-	register_opcode_emulation (OP_FCONV_TO_U, "__emul_fconv_to_u", "uint32 double", mono_fconv_u4, "mono_fconv_u4", TRUE);
+	register_opcode_emulation (OP_FCONV_TO_U, "__emul_fconv_to_u", mono_icall_sig_uint32_double, mono_fconv_u4, "mono_fconv_u4", TRUE);
 #else
-	register_opcode_emulation (OP_FCONV_TO_U, "__emul_fconv_to_u", "ulong double", mono_fconv_u8, "mono_fconv_u8", TRUE);
+	register_opcode_emulation (OP_FCONV_TO_U, "__emul_fconv_to_u", mono_icall_sig_ulong_double, mono_fconv_u8, "mono_fconv_u8", TRUE);
 #endif
 
 	/* other jit icalls */
-	register_icall (ves_icall_mono_delegate_ctor, "ves_icall_mono_delegate_ctor", "void object object ptr", FALSE);
-	register_icall (ves_icall_mono_delegate_ctor_interp, "ves_icall_mono_delegate_ctor_interp", "void object object ptr", FALSE);
-	register_icall (mono_class_static_field_address , "mono_class_static_field_address",
-				 "ptr ptr ptr", FALSE);
-	register_icall (mono_ldtoken_wrapper, "mono_ldtoken_wrapper", "ptr ptr ptr ptr", FALSE);
-	register_icall (mono_ldtoken_wrapper_generic_shared, "mono_ldtoken_wrapper_generic_shared",
-		"ptr ptr ptr ptr", FALSE);
-	register_icall (mono_get_special_static_data, "mono_get_special_static_data", "ptr int", FALSE);
-	register_icall (ves_icall_mono_ldstr, "ves_icall_mono_ldstr", "object ptr ptr int32", FALSE);
-	register_icall (mono_helper_stelem_ref_check, "mono_helper_stelem_ref_check", "void object object", FALSE);
-	register_icall (ves_icall_object_new, "ves_icall_object_new", "object ptr ptr", FALSE);
-	register_icall (ves_icall_object_new_specific, "ves_icall_object_new_specific", "object ptr", FALSE);
-	register_icall (ves_icall_array_new, "ves_icall_array_new", "object ptr ptr int32", FALSE);
-	register_icall (ves_icall_array_new_specific, "ves_icall_array_new_specific", "object ptr int32", FALSE);
-	register_icall (ves_icall_runtime_class_init, "ves_icall_runtime_class_init", "void ptr", FALSE);
-	register_icall (mono_ldftn, "mono_ldftn", "ptr ptr", FALSE);
-	register_icall (mono_ldvirtfn, "mono_ldvirtfn", "ptr object ptr", FALSE);
-	register_icall (mono_ldvirtfn_gshared, "mono_ldvirtfn_gshared", "ptr object ptr", FALSE);
-	register_icall (mono_helper_compile_generic_method, "mono_helper_compile_generic_method", "ptr object ptr ptr", FALSE);
-	register_icall (mono_helper_ldstr, "mono_helper_ldstr", "object ptr int", FALSE);
-	register_icall (mono_helper_ldstr_mscorlib, "mono_helper_ldstr_mscorlib", "object int", FALSE);
-	register_icall (mono_helper_newobj_mscorlib, "mono_helper_newobj_mscorlib", "object int", FALSE);
-	register_icall (mono_value_copy_internal, "mono_value_copy_internal", "void ptr ptr ptr", FALSE);
-	register_icall (mono_object_castclass_unbox, "mono_object_castclass_unbox", "object object ptr", FALSE);
+	register_icall (ves_icall_mono_delegate_ctor, "ves_icall_mono_delegate_ctor", mono_icall_sig_void_object_object_ptr, FALSE);
+	register_icall (ves_icall_mono_delegate_ctor_interp, "ves_icall_mono_delegate_ctor_interp", mono_icall_sig_void_object_object_ptr, FALSE);
+	register_icall (mono_class_static_field_address , "mono_class_static_field_address", mono_icall_sig_ptr_ptr_ptr, FALSE);
+	register_icall (mono_ldtoken_wrapper, "mono_ldtoken_wrapper", mono_icall_sig_ptr_ptr_ptr_ptr, FALSE);
+	register_icall (mono_ldtoken_wrapper_generic_shared, "mono_ldtoken_wrapper_generic_shared", mono_icall_sig_ptr_ptr_ptr_ptr, FALSE);
+	register_icall (mono_get_special_static_data, "mono_get_special_static_data", mono_icall_sig_ptr_int, FALSE);
+	register_icall (ves_icall_mono_ldstr, "ves_icall_mono_ldstr", mono_icall_sig_object_ptr_ptr_int32, FALSE);
+	register_icall (mono_helper_stelem_ref_check, "mono_helper_stelem_ref_check", mono_icall_sig_void_object_object, FALSE);
+	register_icall (ves_icall_object_new, "ves_icall_object_new", mono_icall_sig_object_ptr_ptr, FALSE);
+	register_icall (ves_icall_object_new_specific, "ves_icall_object_new_specific", mono_icall_sig_object_ptr, FALSE);
+	register_icall (ves_icall_array_new, "ves_icall_array_new", mono_icall_sig_object_ptr_ptr_int32, FALSE);
+	register_icall (ves_icall_array_new_specific, "ves_icall_array_new_specific", mono_icall_sig_object_ptr_int32, FALSE);
+	register_icall (ves_icall_runtime_class_init, "ves_icall_runtime_class_init", mono_icall_sig_void_ptr, FALSE);
+	register_icall (mono_ldftn, "mono_ldftn", mono_icall_sig_ptr_ptr, FALSE);
+	register_icall (mono_ldvirtfn, "mono_ldvirtfn", mono_icall_sig_ptr_object_ptr, FALSE);
+	register_icall (mono_ldvirtfn_gshared, "mono_ldvirtfn_gshared", mono_icall_sig_ptr_object_ptr, FALSE);
+	register_icall (mono_helper_compile_generic_method, "mono_helper_compile_generic_method", mono_icall_sig_ptr_object_ptr_ptr, FALSE);
+	register_icall (mono_helper_ldstr, "mono_helper_ldstr", mono_icall_sig_object_ptr_int, FALSE);
+	register_icall (mono_helper_ldstr_mscorlib, "mono_helper_ldstr_mscorlib", mono_icall_sig_object_int, FALSE);
+	register_icall (mono_helper_newobj_mscorlib, "mono_helper_newobj_mscorlib", mono_icall_sig_object_int, FALSE);
+	register_icall (mono_value_copy_internal, "mono_value_copy_internal", mono_icall_sig_void_ptr_ptr_ptr, FALSE);
+	register_icall (mono_object_castclass_unbox, "mono_object_castclass_unbox", mono_icall_sig_object_object_ptr, FALSE);
 	register_icall (mono_break, "mono_break", NULL, TRUE);
-	register_icall (mono_create_corlib_exception_0, "mono_create_corlib_exception_0", "object int", TRUE);
-	register_icall (mono_create_corlib_exception_1, "mono_create_corlib_exception_1", "object int object", TRUE);
-	register_icall (mono_create_corlib_exception_2, "mono_create_corlib_exception_2", "object int object object", TRUE);
-	register_icall (mono_array_new_1, "mono_array_new_1", "object ptr int", FALSE);
-	register_icall (mono_array_new_2, "mono_array_new_2", "object ptr int int", FALSE);
-	register_icall (mono_array_new_3, "mono_array_new_3", "object ptr int int int", FALSE);
-	register_icall (mono_array_new_4, "mono_array_new_4", "object ptr int int int int", FALSE);
-	register_icall (mono_get_native_calli_wrapper, "mono_get_native_calli_wrapper", "ptr ptr ptr ptr", FALSE);
-	register_icall (mono_resume_unwind, "mono_resume_unwind", "void ptr", TRUE);
-	register_icall (mono_gsharedvt_constrained_call, "mono_gsharedvt_constrained_call", "object ptr ptr ptr ptr ptr", FALSE);
-	register_icall (mono_gsharedvt_value_copy, "mono_gsharedvt_value_copy", "void ptr ptr ptr", TRUE);
+	register_icall (mono_create_corlib_exception_0, "mono_create_corlib_exception_0", mono_icall_sig_object_int, TRUE);
+	register_icall (mono_create_corlib_exception_1, "mono_create_corlib_exception_1", mono_icall_sig_object_int_object, TRUE);
+	register_icall (mono_create_corlib_exception_2, "mono_create_corlib_exception_2", mono_icall_sig_object_int_object_object, TRUE);
+	register_icall (mono_array_new_1, "mono_array_new_1", mono_icall_sig_object_ptr_int, FALSE);
+	register_icall (mono_array_new_2, "mono_array_new_2", mono_icall_sig_object_ptr_int_int, FALSE);
+	register_icall (mono_array_new_3, "mono_array_new_3", mono_icall_sig_object_ptr_int_int_int, FALSE);
+	register_icall (mono_array_new_4, "mono_array_new_4", mono_icall_sig_object_ptr_int_int_int_int, FALSE);
+	register_icall (mono_get_native_calli_wrapper, "mono_get_native_calli_wrapper", mono_icall_sig_ptr_ptr_ptr_ptr, FALSE);
+	register_icall (mono_resume_unwind, "mono_resume_unwind", mono_icall_sig_void_ptr, TRUE);
+	register_icall (mono_gsharedvt_constrained_call, "mono_gsharedvt_constrained_call", mono_icall_sig_object_ptr_ptr_ptr_ptr_ptr, FALSE);
+	register_icall (mono_gsharedvt_value_copy, "mono_gsharedvt_value_copy", mono_icall_sig_void_ptr_ptr_ptr, TRUE);
 
 	//WARNING We do runtime selection here but the string *MUST* be to a fallback function that has same signature and behavior
-	register_icall_no_wrapper (mono_gc_get_range_copy_func (), "mono_gc_wbarrier_range_copy", "void ptr ptr int");
+	register_icall_no_wrapper (mono_gc_get_range_copy_func (), "mono_gc_wbarrier_range_copy", mono_icall_sig_void_ptr_ptr_int);
 
-	register_icall (mono_object_castclass_with_cache, "mono_object_castclass_with_cache", "object object ptr ptr", FALSE);
-	register_icall (mono_object_isinst_with_cache, "mono_object_isinst_with_cache", "object object ptr ptr", FALSE);
-	register_icall (mono_generic_class_init, "mono_generic_class_init", "void ptr", FALSE);
-	register_icall (mono_fill_class_rgctx, "mono_fill_class_rgctx", "ptr ptr int", FALSE);
-	register_icall (mono_fill_method_rgctx, "mono_fill_method_rgctx", "ptr ptr int", FALSE);
+	register_icall (mono_object_castclass_with_cache, "mono_object_castclass_with_cache", mono_icall_sig_object_object_ptr_ptr, FALSE);
+	register_icall (mono_object_isinst_with_cache, "mono_object_isinst_with_cache", mono_icall_sig_object_object_ptr_ptr, FALSE);
+	register_icall (mono_generic_class_init, "mono_generic_class_init", mono_icall_sig_void_ptr, FALSE);
+	register_icall (mono_fill_class_rgctx, "mono_fill_class_rgctx", mono_icall_sig_ptr_ptr_int, FALSE);
+	register_icall (mono_fill_method_rgctx, "mono_fill_method_rgctx", mono_icall_sig_ptr_ptr_int, FALSE);
 
-	register_dyn_icall (mini_get_dbg_callbacks ()->user_break, "mono_debugger_agent_user_break", "void", FALSE);
+	register_dyn_icall (mini_get_dbg_callbacks ()->user_break, "mono_debugger_agent_user_break", mono_icall_sig_void, FALSE);
 
-	register_icall (mono_aot_init_llvm_method, "mono_aot_init_llvm_method", "void ptr int", TRUE);
-	register_icall (mono_aot_init_gshared_method_this, "mono_aot_init_gshared_method_this", "void ptr int object", TRUE);
-	register_icall (mono_aot_init_gshared_method_mrgctx, "mono_aot_init_gshared_method_mrgctx", "void ptr int ptr", TRUE);
-	register_icall (mono_aot_init_gshared_method_vtable, "mono_aot_init_gshared_method_vtable", "void ptr int ptr", TRUE);
+	register_icall (mono_aot_init_llvm_method, "mono_aot_init_llvm_method", mono_icall_sig_void_ptr_int, TRUE);
+	register_icall (mono_aot_init_gshared_method_this, "mono_aot_init_gshared_method_this", mono_icall_sig_void_ptr_int_object, TRUE);
+	register_icall (mono_aot_init_gshared_method_mrgctx, "mono_aot_init_gshared_method_mrgctx", mono_icall_sig_void_ptr_int_ptr, TRUE);
+	register_icall (mono_aot_init_gshared_method_vtable, "mono_aot_init_gshared_method_vtable", mono_icall_sig_void_ptr_int_ptr, TRUE);
 
-	register_icall_no_wrapper (mono_resolve_iface_call_gsharedvt, "mono_resolve_iface_call_gsharedvt", "ptr object int ptr ptr");
-	register_icall_no_wrapper (mono_resolve_vcall_gsharedvt, "mono_resolve_vcall_gsharedvt", "ptr object int ptr ptr");
-	register_icall_no_wrapper (mono_resolve_generic_virtual_call, "mono_resolve_generic_virtual_call", "ptr ptr int ptr");
-	register_icall_no_wrapper (mono_resolve_generic_virtual_iface_call, "mono_resolve_generic_virtual_iface_call", "ptr ptr int ptr");
+	register_icall_no_wrapper (mono_resolve_iface_call_gsharedvt, "mono_resolve_iface_call_gsharedvt", mono_icall_sig_ptr_object_int_ptr_ptr);
+	register_icall_no_wrapper (mono_resolve_vcall_gsharedvt, "mono_resolve_vcall_gsharedvt", mono_icall_sig_ptr_object_int_ptr_ptr);
+	register_icall_no_wrapper (mono_resolve_generic_virtual_call, "mono_resolve_generic_virtual_call", mono_icall_sig_ptr_ptr_int_ptr);
+	register_icall_no_wrapper (mono_resolve_generic_virtual_iface_call, "mono_resolve_generic_virtual_iface_call", mono_icall_sig_ptr_ptr_int_ptr);
 	/* This needs a wrapper so it can have a preserveall cconv */
-	register_icall (mono_init_vtable_slot, "mono_init_vtable_slot", "ptr ptr int", FALSE);
-	register_icall (mono_llvmonly_init_delegate, "mono_llvmonly_init_delegate", "void object", TRUE);
-	register_icall (mono_llvmonly_init_delegate_virtual, "mono_llvmonly_init_delegate_virtual", "void object object ptr", TRUE);
-	register_icall (mono_get_assembly_object, "mono_get_assembly_object", "object ptr", TRUE);
-	register_icall (mono_get_method_object, "mono_get_method_object", "object ptr", TRUE);
-	register_icall (mono_throw_method_access, "mono_throw_method_access", "void ptr ptr", FALSE);
-	register_icall_no_wrapper (mono_dummy_jit_icall, "mono_dummy_jit_icall", "void");
+	register_icall (mono_init_vtable_slot, "mono_init_vtable_slot", mono_icall_sig_ptr_ptr_int, FALSE);
+	register_icall (mono_llvmonly_init_delegate, "mono_llvmonly_init_delegate", mono_icall_sig_void_object, TRUE);
+	register_icall (mono_llvmonly_init_delegate_virtual, "mono_llvmonly_init_delegate_virtual", mono_icall_sig_void_object_object_ptr, TRUE);
+	register_icall (mono_get_assembly_object, "mono_get_assembly_object", mono_icall_sig_object_ptr, TRUE);
+	register_icall (mono_get_method_object, "mono_get_method_object", mono_icall_sig_object_ptr, TRUE);
+	register_icall (mono_throw_method_access, "mono_throw_method_access", mono_icall_sig_void_ptr_ptr, FALSE);
+	register_icall_no_wrapper (mono_dummy_jit_icall, "mono_dummy_jit_icall", mono_icall_sig_void);
 
-	register_icall_with_wrapper (mono_monitor_enter_internal, "mono_monitor_enter_internal", "int32 obj");
-	register_icall_with_wrapper (mono_monitor_enter_v4_internal, "mono_monitor_enter_v4_internal", "void obj ptr");
-	register_icall_no_wrapper (mono_monitor_enter_fast, "mono_monitor_enter_fast", "int obj");
-	register_icall_no_wrapper (mono_monitor_enter_v4_fast, "mono_monitor_enter_v4_fast", "int obj ptr");
+	register_icall_with_wrapper (mono_monitor_enter_internal, "mono_monitor_enter_internal", mono_icall_sig_int32_obj);
+	register_icall_with_wrapper (mono_monitor_enter_v4_internal, "mono_monitor_enter_v4_internal", mono_icall_sig_void_obj_ptr);
+	register_icall_no_wrapper (mono_monitor_enter_fast, "mono_monitor_enter_fast", mono_icall_sig_int_obj);
+	register_icall_no_wrapper (mono_monitor_enter_v4_fast, "mono_monitor_enter_v4_fast", mono_icall_sig_int_obj_ptr);
 
 #ifdef TARGET_IOS
-	register_icall (pthread_getspecific, "pthread_getspecific", "ptr ptr", TRUE);
+	register_icall (pthread_getspecific, "pthread_getspecific", mono_icall_sig_ptr_ptr, TRUE);
 #endif
 	/* Register tls icalls */
-	register_icall_no_wrapper (mono_tls_get_thread, "mono_tls_get_thread", "ptr");
-	register_icall_no_wrapper (mono_tls_get_jit_tls, "mono_tls_get_jit_tls", "ptr");
-	register_icall_no_wrapper (mono_tls_get_domain, "mono_tls_get_domain", "ptr");  
-	register_icall_no_wrapper (mono_tls_get_sgen_thread_info, "mono_tls_get_sgen_thread_info", "ptr");
-	register_icall_no_wrapper (mono_tls_get_lmf_addr, "mono_tls_get_lmf_addr", "ptr");
-	register_icall_no_wrapper (mono_tls_set_thread, "mono_tls_set_thread", "void ptr");
-	register_icall_no_wrapper (mono_tls_set_jit_tls, "mono_tls_set_jit_tls", "void ptr");
-	register_icall_no_wrapper (mono_tls_set_domain, "mono_tls_set_domain", "void ptr");
-	register_icall_no_wrapper (mono_tls_set_sgen_thread_info, "mono_tls_set_sgen_thread_info", "void ptr");
-	register_icall_no_wrapper (mono_tls_set_lmf_addr, "mono_tls_set_lmf_addr", "void ptr");
+	register_icall_no_wrapper (mono_tls_get_thread, "mono_tls_get_thread", mono_icall_sig_ptr);
+	register_icall_no_wrapper (mono_tls_get_jit_tls, "mono_tls_get_jit_tls", mono_icall_sig_ptr);
+	register_icall_no_wrapper (mono_tls_get_domain, "mono_tls_get_domain", mono_icall_sig_ptr);  
+	register_icall_no_wrapper (mono_tls_get_sgen_thread_info, "mono_tls_get_sgen_thread_info", mono_icall_sig_ptr);
+	register_icall_no_wrapper (mono_tls_get_lmf_addr, "mono_tls_get_lmf_addr", mono_icall_sig_ptr);
+	register_icall_no_wrapper (mono_tls_set_thread, "mono_tls_set_thread", mono_icall_sig_void_ptr);
+	register_icall_no_wrapper (mono_tls_set_jit_tls, "mono_tls_set_jit_tls", mono_icall_sig_void_ptr);
+	register_icall_no_wrapper (mono_tls_set_domain, "mono_tls_set_domain", mono_icall_sig_void_ptr);
+	register_icall_no_wrapper (mono_tls_set_sgen_thread_info, "mono_tls_set_sgen_thread_info", mono_icall_sig_void_ptr);
+	register_icall_no_wrapper (mono_tls_set_lmf_addr, "mono_tls_set_lmf_addr", mono_icall_sig_void_ptr);
 
-	register_icall_no_wrapper (mono_interp_entry_from_trampoline, "mono_interp_entry_from_trampoline", "void ptr ptr");
+	register_icall_no_wrapper (mono_interp_entry_from_trampoline, "mono_interp_entry_from_trampoline", mono_icall_sig_void_ptr_ptr);
 
 #ifdef MONO_ARCH_HAS_REGISTER_ICALL
 	mono_arch_register_icall ();

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4645,7 +4645,7 @@ register_icalls (void)
 #endif
 #if !defined(MONO_ARCH_NO_EMULATE_LONG_MUL_OPTS) || defined(MONO_ARCH_EMULATE_LONG_MUL_OVF_OPTS)
 	register_opcode_emulation (OP_LMUL_OVF_UN, "__emul_lmul_ovf_un", mono_icall_sig_long_long_long, mono_llmult_ovf_un, "mono_llmult_ovf_un", FALSE);
-	register_opcode_emulation (OP_LMUL_OVF, "__emul_lmul_ovf", mono_icall_sig_long_long_long", mono_llmult_ovf, "mono_llmult_ovf", FALSE);
+	register_opcode_emulation (OP_LMUL_OVF, "__emul_lmul_ovf", mono_icall_sig_long_long_long, mono_llmult_ovf, "mono_llmult_ovf", FALSE);
 #endif
 
 #ifndef MONO_ARCH_NO_EMULATE_LONG_SHIFT_OPS

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -1710,10 +1710,9 @@ mono_find_jit_opcode_emulation (int opcode)
 }
 
 void
-mini_register_opcode_emulation (int opcode, const char *name, const char *sigstr, gpointer func, const char *symbol, gboolean no_wrapper)
+mini_register_opcode_emulation (int opcode, const char *name, MonoMethodSignature *sig, gpointer func, const char *symbol, gboolean no_wrapper)
 {
 	MonoJitICallInfo *info;
-	MonoMethodSignature *sig = mono_create_icall_signature (sigstr);
 
 	g_assert (!sig->hasthis);
 	g_assert (sig->param_count < 3);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -60,6 +60,7 @@ typedef struct SeqPointInfo SeqPointInfo;
 #include "mono/metadata/security-manager.h"
 #include "mono/metadata/exception.h"
 #include "mono/metadata/callspec.h"
+#include "mono/metadata/icall-signatures.h"
 
 /*
  * The mini code should not have any compile time dependencies on the GC being used, so the same object file from mini/
@@ -356,7 +357,7 @@ extern gboolean mono_do_x86_stack_align;
 extern gboolean	mono_using_xdebug;
 extern int mini_verbose;
 extern int valgrind_register;
-extern MonoMethodSignature *helper_sig_llvmonly_imt_trampoline;
+#define helper_sig_llvmonly_imt_trampoline mono_icall_sig_ptr_ptr_ptr
 
 #define INS_INFO(opcode) (&mini_ins_info [((opcode) - OP_START - 1) * 4])
 
@@ -2066,7 +2067,6 @@ mono_emit_jit_icall (MonoCompile *cfg, T func, MonoInst **args)
 
 MonoInst* mono_emit_jit_icall_by_info (MonoCompile *cfg, int il_offset, MonoJitICallInfo *info, MonoInst **args);
 MonoInst* mono_emit_method_call (MonoCompile *cfg, MonoMethod *method, MonoInst **args, MonoInst *this_ins);
-void      mono_create_helper_signatures (void);
 MonoInst* mono_emit_native_call (MonoCompile *cfg, gconstpointer func, MonoMethodSignature *sig, MonoInst **args);
 gboolean  mini_should_insert_breakpoint (MonoMethod *method);
 int mono_target_pagesize (void);
@@ -2098,14 +2098,14 @@ void      mono_add_ins_to_end               (MonoBasicBlock *bb, MonoInst *inst)
 
 void      mono_replace_ins                  (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins, MonoInst **prev, MonoBasicBlock *first_bb, MonoBasicBlock *last_bb);
 
-void              mini_register_opcode_emulation (int opcode, const char *name, const char *sigstr, gpointer func, const char *symbol, gboolean no_throw);
+void              mini_register_opcode_emulation (int opcode, const char *name, MonoMethodSignature *sig, gpointer func, const char *symbol, gboolean no_throw);
 
 #ifdef __cplusplus
 template <typename T>
 inline void
-mini_register_opcode_emulation (int opcode, const char *name, const char *sigstr, T func, const char *symbol, gboolean no_throw)
+mini_register_opcode_emulation (int opcode, const char *name, MonoMethodSignature *sig, T func, const char *symbol, gboolean no_throw)
 {
-	mini_register_opcode_emulation (opcode, name, sigstr, (gpointer)func, symbol, no_throw);
+	mini_register_opcode_emulation (opcode, name, sig, (gpointer)func, symbol, no_throw);
 }
 #endif // __cplusplus
 

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2092,7 +2092,7 @@ void     mono_save_trampoline_xdebug_info   (MonoTrampInfo *info);
 /* This is an exported function */
 void     mono_xdebug_flush                  (void);
 
-void      mono_register_opcode_emulation    (int opcode, const char* name, const char *sigstr, gpointer func, gboolean no_throw);
+void      mono_register_opcode_emulation    (int opcode, const char* name, MonoMethodSignature *sig, gpointer func, gboolean no_throw);
 void      mono_draw_graph                   (MonoCompile *cfg, MonoGraphOptions draw_options);
 void      mono_add_ins_to_end               (MonoBasicBlock *bb, MonoInst *inst);
 


### PR DESCRIPTION
Make them statically allocated, single-instanced at compile time, and almost statically initialized.