### PR TITLE
Register two separate functions for mono_fconv_u4 and mono_fconv_u8

### DIFF
--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -963,6 +963,17 @@ mono_fconv_u8 (double v)
 }
 
 guint64
+mono_fconv_u8_2 (double v)
+{
+	// Separate from mono_fconv_u8 to avoid duplicate JIT icall.
+	//
+	// When there are duplicates, there is single instancing
+	// against function address that breaks stuff. For example,
+	// wrappers are only produced for one of them, breaking FullAOT.
+	return mono_fconv_u8 (v);
+}
+
+guint64
 mono_rconv_u8 (float v)
 {
 	return (guint64)v;
@@ -983,6 +994,17 @@ mono_fconv_u4 (double v)
 	if (mono_isinf (v) || mono_isnan (v))
 		return 0;
 	return (guint32)v;
+}
+
+guint32
+mono_fconv_u4_2 (double v)
+{
+	// Separate from mono_fconv_u4 to avoid duplicate JIT icall.
+	//
+	// When there are duplicates, there is single instancing
+	// against function address that breaks stuff. For example,
+	// wrappers are only produced for one of them, breaking FullAOT.
+	return mono_fconv_u4 (v);
 }
 
 gint64

--- a/mono/mini/jit-icalls.h
+++ b/mono/mini/jit-icalls.h
@@ -70,12 +70,14 @@ G_EXTERN_C gpointer mono_ldtoken_wrapper (MonoImage *image, int token, MonoGener
 G_EXTERN_C gpointer mono_ldtoken_wrapper_generic_shared (MonoImage *image, int token, MonoMethod *method);
 
 G_EXTERN_C guint64 mono_fconv_u8 (double v);
+G_EXTERN_C guint64 mono_fconv_u8_2 (double v);
 
 G_EXTERN_C guint64 mono_rconv_u8 (float v);
 
 G_EXTERN_C gint64 mono_fconv_i8 (double v);
 
 G_EXTERN_C guint32 mono_fconv_u4 (double v);
+G_EXTERN_C guint32 mono_fconv_u4_2 (double v);
 
 G_EXTERN_C gint64 mono_fconv_ovf_i8 (double v);
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4706,9 +4706,9 @@ register_icalls (void)
 	register_opcode_emulation (OP_FDIV, "__emul_fdiv", "double double double", mono_fdiv, "mono_fdiv", FALSE);
 #endif
 
-	register_opcode_emulation (OP_FCONV_TO_U8, "__emul_fconv_to_u8", "ulong double", mono_fconv_u8, "mono_fconv_u8", FALSE);
+	register_opcode_emulation (OP_FCONV_TO_U8, "__emul_fconv_to_u8", "ulong double", mono_fconv_u8_2, "mono_fconv_u8_2", FALSE);
 	register_opcode_emulation (OP_RCONV_TO_U8, "__emul_rconv_to_u8", "ulong float", mono_rconv_u8, "mono_rconv_u8", FALSE);
-	register_opcode_emulation (OP_FCONV_TO_U4, "__emul_fconv_to_u4", "uint32 double", mono_fconv_u4, "mono_fconv_u4", FALSE);
+	register_opcode_emulation (OP_FCONV_TO_U4, "__emul_fconv_to_u4", "uint32 double", mono_fconv_u4_2, "mono_fconv_u4_2", FALSE);
 	register_opcode_emulation (OP_FCONV_TO_OVF_I8, "__emul_fconv_to_ovf_i8", "long double", mono_fconv_ovf_i8, "mono_fconv_ovf_i8", FALSE);
 	register_opcode_emulation (OP_FCONV_TO_OVF_U8, "__emul_fconv_to_ovf_u8", "ulong double", mono_fconv_ovf_u8, "mono_fconv_ovf_u8", FALSE);
 	register_opcode_emulation (OP_RCONV_TO_OVF_I8, "__emul_rconv_to_ovf_i8", "long float", mono_rconv_ovf_i8, "mono_rconv_ovf_i8", FALSE);


### PR DESCRIPTION
instead of each function twice.

Elsewhere there is single instancing based on function address
and registering the same function twice breaks things.

What breaks is that due to the single instancing, based on address, the second name is skipped, whatever happens to be second in hash order. Sometimes that is ok, sometimes not.