### PR TITLE
[wasm] Add support to find the wasm framework libraries.

### DIFF
--- a/sdks/wasm/packager.cs
+++ b/sdks/wasm/packager.cs
@@ -151,6 +151,7 @@ class Driver {
 		root_search_paths.ForEach(resolver.AddSearchDirectory);
 		resolver.AddSearchDirectory(bcl_facades_prefix);
 		resolver.AddSearchDirectory(bcl_prefix);
+		resolver.AddSearchDirectory(framework_prefix);		
 		rp.AssemblyResolver = resolver;
 
 		rp.InMemory = true;


### PR DESCRIPTION
Fixes issue: https://github.com/mono/mono/issues/11856