### PR TITLE
Change array construction with rank>4 to use not use varargs -- localalloc.

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -8709,8 +8709,8 @@ mono_register_jit_icall_full (gconstpointer func, const char *name, MonoMethodSi
 		jit_icall_hash_addr = g_hash_table_new (NULL, NULL);
 	}
 
-	if (g_hash_table_lookup (jit_icall_hash_name, name)) {
-		g_warning ("jit icall already defined \"%s\"\n", name);
+	if ((info = (MonoJitICallInfo *)g_hash_table_lookup (jit_icall_hash_name, name))) {
+		g_warning ("jit icall already defined \"%s\" \"%s\" %p %p\n", name, info->name, func, info->func);
 		g_assert_not_reached ();
 	}
 

--- a/mono/mini/aot-runtime.h
+++ b/mono/mini/aot-runtime.h
@@ -11,7 +11,7 @@
 #include "mini.h"
 
 /* Version number of the AOT file format */
-#define MONO_AOT_FILE_VERSION 150
+#define MONO_AOT_FILE_VERSION 151
 
 #define MONO_AOT_TRAMP_PAGE_SIZE 16384
 

--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -690,51 +690,38 @@ mono_fload_r4_arg (double val)
 #endif
 
 MonoArray *
-mono_array_new_va (MonoMethod *cm, ...)
+mono_array_new_n_icall (MonoMethod *cm, gint32 pcount, intptr_t *params)
 {
 	ERROR_DECL (error);
-	MonoArray *arr;
-	MonoDomain *domain = mono_domain_get ();
-	va_list ap;
-	uintptr_t *lengths;
-	intptr_t *lower_bounds;
-	int pcount;
-	int rank;
-	int i, d;
+	g_assert (cm);
+	g_assert (pcount);
+	g_assert (params);
+	intptr_t *lower_bounds = NULL;
 
-	pcount = mono_method_signature_internal (cm)->param_count;
-	rank = m_class_get_rank (cm->klass);
+	const int pcount_sig = mono_method_signature_internal (cm)->param_count;
+	const int rank = m_class_get_rank (cm->klass);
+	g_assert (pcount == pcount_sig);
+	g_assert (rank == pcount || rank * 2 == pcount);
 
-	va_start (ap, cm);
-	
-	lengths = g_newa (uintptr_t, pcount);
-	for (i = 0; i < pcount; ++i)
-		lengths [i] = d = va_arg(ap, int);
+	uintptr_t *lengths = (uintptr_t*)params;
 
 	if (rank == pcount) {
 		/* Only lengths provided. */
 		if (m_class_get_byval_arg (cm->klass)->type == MONO_TYPE_ARRAY) {
 			lower_bounds = g_newa (intptr_t, rank);
 			memset (lower_bounds, 0, sizeof (intptr_t) * rank);
-		} else {
-			lower_bounds = NULL;
 		}
 	} else {
 		g_assert (pcount == (rank * 2));
 		/* lower bounds are first. */
-		lower_bounds = (intptr_t*)lengths;
+		lower_bounds = params;
 		lengths += rank;
 	}
-	va_end(ap);
 
-	arr = mono_array_new_full_checked (domain, cm->klass, lengths, lower_bounds, error);
+	MonoArray *arr = mono_array_new_full_checked (mono_domain_get (),
+		cm->klass, lengths, lower_bounds, error);
 
-	if (!mono_error_ok (error)) {
-		mono_error_set_pending_exception (error);
-		return NULL;
-	}
-
-	return arr;
+	return mono_error_set_pending_exception (error) ? NULL : arr;
 }
 
 /* Specialized version of mono_array_new_va () which avoids varargs */

--- a/mono/mini/jit-icalls.h
+++ b/mono/mini/jit-icalls.h
@@ -53,7 +53,8 @@ G_EXTERN_C guint64 mono_lshr_un (guint64 a, gint32 shamt);
 
 G_EXTERN_C gint64 mono_lshr (gint64 a, gint32 shamt);
 
-G_EXTERN_C MonoArray *mono_array_new_va (MonoMethod *cm, ...);
+// For param_count > 4.
+G_EXTERN_C MonoArray *mono_array_new_n_icall (MonoMethod *cm, gint32 param_count, intptr_t *params);
 
 G_EXTERN_C MonoArray *mono_array_new_1 (MonoMethod *cm, guint32 length);
 

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -8588,8 +8588,8 @@ calli_end:
 					EMIT_NEW_UNALU (cfg, ins, OP_MOVE, alloc_preg (cfg), dreg);
 					ins->type = STACK_PTR;
 					sp [2] = ins;
-					// FIXME Adjust sp by n - 3?
-					function = mono_array_new_n_icall;
+					// FIXME Adjust sp by n - 3? Attempts failed.
+					function = (gpointer)mono_array_new_n_icall;
 					break;
 				}
 				alloc = mono_emit_jit_icall (cfg, function, sp);

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -3589,24 +3589,6 @@ handle_delegate_ctor (MonoCompile *cfg, MonoClass *klass, MonoInst *target, Mono
 	return obj;
 }
 
-static MonoInst*
-handle_array_new (MonoCompile *cfg, int rank, MonoInst **sp, guchar *ip)
-{
-	MonoJitICallInfo *info;
-
-	/* Need to register the icall so it gets an icall wrapper */
-	info = mono_get_array_new_va_icall (rank);
-
-	cfg->flags |= MONO_CFG_HAS_VARARGS;
-
-	/* mono_array_new_va () needs a vararg calling convention */
-	cfg->exception_message = g_strdup ("array-new");
-	cfg->disable_llvm = TRUE;
-
-	/* FIXME: This uses info->sig, but it should use the signature of the wrapper */
-	return mono_emit_native_call (cfg, mono_icall_get_wrapper (info), info->sig, sp);
-}
-
 /*
  * handle_constrained_gsharedvt_call:
  *
@@ -5928,6 +5910,8 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 		   guint inline_offset, gboolean is_virtual_call)
 {
 	ERROR_DECL (error);
+	// Buffer to hold parameters to mono_new_array, instead of varargs.
+	MonoInst *array_new_localalloc_ins = NULL;
 	MonoInst *ins, **sp, **stack_start;
 	MonoBasicBlock *tblock = NULL;
 	MonoBasicBlock *init_localsbb = NULL, *init_localsbb2 = NULL;
@@ -8573,18 +8557,42 @@ calli_end:
 			if (mini_class_is_system_array (cmethod->klass)) {
 				*sp = emit_get_rgctx_method (cfg, context_used,
 											 cmethod, MONO_RGCTX_INFO_METHOD);
-
-				/* Avoid varargs in the common case */
-				if (fsig->param_count == 1)
-					alloc = mono_emit_jit_icall (cfg, mono_array_new_1, sp);
-				else if (fsig->param_count == 2)
-					alloc = mono_emit_jit_icall (cfg, mono_array_new_2, sp);
-				else if (fsig->param_count == 3)
-					alloc = mono_emit_jit_icall (cfg, mono_array_new_3, sp);
-				else if (fsig->param_count == 4)
-					alloc = mono_emit_jit_icall (cfg, mono_array_new_4, sp);
-				else
-					alloc = handle_array_new (cfg, fsig->param_count, sp, ip);
+				/* Optimize the common cases */
+				gpointer function = NULL;
+				int n = fsig->param_count;
+				switch (n) {
+				case 1: function = (gpointer)mono_array_new_1;
+					break;
+				case 2: function = (gpointer)mono_array_new_2;
+					break;
+				case 3: function = (gpointer)mono_array_new_3;
+					break;
+				case 4: function = (gpointer)mono_array_new_4;
+					break;
+				default:
+					// FIXME Maximum value of param_count? Realistically 64. Fits in imm?
+					if  (!array_new_localalloc_ins) {
+						MONO_INST_NEW (cfg, array_new_localalloc_ins, OP_LOCALLOC_IMM);
+						array_new_localalloc_ins->dreg = alloc_preg (cfg);
+						cfg->flags |= MONO_CFG_HAS_ALLOCA;
+						MONO_ADD_INS (init_localsbb, array_new_localalloc_ins);
+					}
+					array_new_localalloc_ins->inst_imm = MAX (array_new_localalloc_ins->inst_imm, n * sizeof (target_mgreg_t));
+					int dreg = array_new_localalloc_ins->dreg;
+					for (int i = 0; i < n; ++i) {
+						NEW_STORE_MEMBASE (cfg, ins, OP_STORE_MEMBASE_REG, dreg, i * sizeof (target_mgreg_t), sp [i + 1]->dreg);
+						MONO_ADD_INS (cfg->cbb, ins);
+					}
+					EMIT_NEW_ICONST (cfg, ins, n);
+					sp [1] = ins;
+					EMIT_NEW_UNALU (cfg, ins, OP_MOVE, alloc_preg (cfg), dreg);
+					ins->type = STACK_PTR;
+					sp [2] = ins;
+					// FIXME Adjust sp by n - 3?
+					function = mono_array_new_n_icall;
+					break;
+				}
+				alloc = mono_emit_jit_icall (cfg, function, sp);
 			} else if (cmethod->string_ctor) {
 				g_assert (!context_used);
 				g_assert (!vtable_arg);
@@ -12496,7 +12504,6 @@ mono_spill_global_vars (MonoCompile *cfg, gboolean *need_local_opts)
 	g_free (live_range_start_bb);
 	g_free (live_range_end_bb);
 }
-
 
 /**
  * FIXME:

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -3082,9 +3082,8 @@ emit_call_body (MonoCompile *cfg, guint8 *code, MonoJumpInfoType patch_type, gco
 							near_call = TRUE;
 					}
 					else {
-						/* See the comment in mono_codegen () */
-						if ((info->name [0] != 'v') || (strstr (info->name, "ves_array_new_va_") == NULL && strstr (info->name, "ves_array_element_address_") == NULL))
-							near_call = TRUE;
+						/* ?See the comment in mono_codegen ()? */
+						near_call = TRUE;
 					}
 				}
 				else if ((((guint64)data) >> 32) == 0) {

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -380,12 +380,6 @@ typedef struct {
 
 #endif
 
-/*
- * Some icalls might need to be called using a different
- * calling convention. None currently do.
- */
-#define MONO_ARCH_VARARG_ICALLS 1
-
 #if !defined( HOST_WIN32 ) && !defined(__HAIKU__) && defined (HAVE_SIGACTION)
 
 #define MONO_ARCH_USE_SIGACTION 1

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -381,8 +381,8 @@ typedef struct {
 #endif
 
 /*
- * some icalls like mono_array_new_va needs to be called using a different 
- * calling convention.
+ * Some icalls might need to be called using a different
+ * calling convention. None currently do.
  */
 #define MONO_ARCH_VARARG_ICALLS 1
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4824,6 +4824,7 @@ register_icalls (void)
 	register_icall (mono_array_new_2, "mono_array_new_2", "object ptr int int", FALSE);
 	register_icall (mono_array_new_3, "mono_array_new_3", "object ptr int int int", FALSE);
 	register_icall (mono_array_new_4, "mono_array_new_4", "object ptr int int int int", FALSE);
+	register_icall (mono_array_new_n_icall, "mono_array_new_n_icall", "object ptr int ptr", FALSE);
 	register_icall (mono_get_native_calli_wrapper, "mono_get_native_calli_wrapper", "ptr ptr ptr ptr", FALSE);
 	register_icall (mono_resume_unwind, "mono_resume_unwind", "void ptr", TRUE);
 	register_icall (mono_gsharedvt_constrained_call, "mono_gsharedvt_constrained_call", "object ptr ptr ptr ptr ptr", FALSE);

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -538,12 +538,6 @@ void MONO_SIG_HANDLER_SIGNATURE (mono_sigsegv_signal_handler);
 void MONO_SIG_HANDLER_SIGNATURE (mono_sigint_signal_handler) ;
 gboolean MONO_SIG_HANDLER_SIGNATURE (mono_chain_signal);
 
-#ifdef MONO_ARCH_VARARG_ICALLS
-#define ARCH_VARARG_ICALLS 1
-#else
-#define ARCH_VARARG_ICALLS 0
-#endif
-
 #if defined (HOST_WASM)
 
 #define MONO_RETURN_ADDRESS_N(N) NULL

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2072,9 +2072,6 @@ gboolean  mini_should_insert_breakpoint (MonoMethod *method);
 int mono_target_pagesize (void);
 
 gboolean  mini_class_is_system_array (MonoClass *klass);
-MonoMethodSignature *mono_get_element_address_signature (int arity);
-MonoJitICallInfo    *mono_get_element_address_icall (int rank);
-MonoJitICallInfo    *mono_get_array_new_va_icall (int rank);
 
 void      mono_linterval_add_range          (MonoCompile *cfg, MonoLiveInterval *interval, int from, int to);
 void      mono_linterval_print              (MonoLiveInterval *interval);

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -268,6 +268,7 @@ TESTS_CS_SRC=		\
 	create-instance.cs	\
 	bug-2907.cs		\
 	$(ARRAY_COOP_CS)	\
+	array-12193.cs		\
 	array-init.cs		\
 	arraylist.cs		\
 	assembly-load-remap.cs	\

--- a/mono/tests/array-12193.cs
+++ b/mono/tests/array-12193.cs
@@ -1,0 +1,59 @@
+// Test for creating multi-dimensional arrays.
+// See https://github.com/mono/mono/issues/12193.
+
+using System;
+
+class T
+{
+	// These are separate functions so that they are
+	// JITed in a different context.
+
+	static System.Array f0 () { return new int[] {1,2}; }
+	static System.Array f1 () { return new int[,] {{2,3}}; }
+	static System.Array f2 () { return new int[,,] {{{3}}}; }
+	static System.Array f3 () { return new int[,,,] {{{{4}}}}; }
+	static System.Array f4 () { return new int[,,,,] {{{{{5}}}}}; }
+	static System.Array f5 () { return new int[,,,,,] {{{{{{6}}}}}}; }
+	static System.Array f6 () { return new int[,,,,,] {{{{{{6,7}}}}}}; }
+	static System.Array f7 () { return new int[,,,,,] {{{{{{6},{7}}}}}}; }
+	static System.Array f8 () { return new int[,,,,,] {{{{{{6},{8},{9}}}}}}; }
+	static System.Array f9 () { return new int[,,,,,] {{{{{{6},{8},{9}},{{1},{2},{3}}}}}}; }
+	static System.Array f10() { return new int[,,,,,] {{{{{{6,7,8},{9,10,11},{1,2,3},{5,6,7}}}}}}; }
+	static System.Array f11() {
+		// Should only have one or two alloca or sub rsp (locals and localalloc are not combined, alas).
+		var a = new int[,,,,,] {{{{{{6,7,8},{9,10,11},{1,2,3},{5,6,7}}}}}};
+		var b = new int[,,,,,] {{{{{{0x60,0x70,0x80},{0x90,0x100,0x110},{0x10,0x20,0x30},{0x50,0x60,0x70}}}}}};
+		var c = new int[,,,,,] {{{{{{0x600,0x700,0x800},{0x900,0x1000,0x1100},{0x100,0x200,0x300},{0x500,0x600,0x700}}}}}};
+		return a == b ? null : c;
+	}
+
+	static System.Array f12() {
+		// Should only have one or two alloca or sub rsp (locals and localalloc are not combined, alas).
+		// Should use more stack than f11.
+		var a = new int[,,,,,,,,,,,,,,,,,,] {{{{{{{{{{{{{{{{{{{ 1 }}}}}}}}}}}}}}}}}}};
+		var b = new int[,,,,,,,,,,,,,,,,,,] {{{{{{{{{{{{{{{{{{{ 2 }}}}}}}}}}}}}}}}}}};
+		var c = new int[,,,,,,,,,,,,,,,,,,] {{{{{{{{{{{{{{{{{{{ 3 }}}}}}}}}}}}}}}}}}};
+		a = new int[,,,,,,,,,,,,,,,,,,] {{{{{{{{{{{{{{{{{{{ 4 }}}}}}}}}}}}}}}}}}};
+		b = new int[,,,,,,,,,,,,,,,,,,] {{{{{{{{{{{{{{{{{{{ 5 }}}}}}}}}}}}}}}}}}};
+		c = new int[,,,,,,,,,,,,,,,,,,] {{{{{{{{{{{{{{{{{{{ 6 }}}}}}}}}}}}}}}}}}};
+		return a == b ? null : c;
+	}
+
+	static int Main ()
+	{
+		return (f0 ().Rank
+		 + f1 ().Rank
+		 + f2 ().Rank
+		 + f3 ().Rank
+		 + f4 ().Rank
+		 + f5 ().Rank
+		 + f6 ().Rank
+		 + f7 ().Rank
+		 + f8 ().Rank
+		 + f9 ().Rank
+		 + f10 ().Rank
+		 + f11 ().Rank
+		 + f12 ().Rank) == 76 ? 0 : 1;
+		// Matches desktop. FIXME: Verify more.
+	}
+}

--- a/mono/tests/array-12193.cs
+++ b/mono/tests/array-12193.cs
@@ -1,5 +1,7 @@
 // Test for creating multi-dimensional arrays.
 // See https://github.com/mono/mono/issues/12193.
+// See mono_array_new_n_icall.
+// FIXME Coverage of the doubled parameter count, with lower_bounds.
 
 using System;
 


### PR DESCRIPTION
This fixes https://github.com/mono/mono/issues/12193.

This is alternative to https://github.com/mono/mono/pull/12200.
They are both pretty good approaches.
12200 uncovered a hash order dependency which should be fixed either way.