### PR TITLE
Fix data race in System.Web.Caching by using appropriate lock level

### DIFF
--- a/mcs/class/System.Web/System.Web.Caching/Cache.cs
+++ b/mcs/class/System.Web/System.Web.Caching/Cache.cs
@@ -609,7 +609,7 @@ namespace System.Web.Caching
 		internal DateTime GetKeyLastChange (string key)
 		{
 			try {
-				cacheLock.EnterReadLock ();
+				cacheLock.EnterWriteLock ();
 				CacheItem it = cache [key];
 
 				if (it == null)
@@ -618,7 +618,7 @@ namespace System.Web.Caching
 				return it.LastChange;
 			} finally {
 				// See comment at the top of the file, above cacheLock declaration
-				cacheLock.ExitReadLock ();
+				cacheLock.ExitWriteLock ();
 			}
 		}
 

--- a/mcs/class/System.Web/System.Web.Caching/CacheItemLRU.cs
+++ b/mcs/class/System.Web/System.Web.Caching/CacheItemLRU.cs
@@ -151,6 +151,8 @@ namespace System.Web.Caching
 		}
 		
 		public CacheItem this [string key] {
+			// Must ALWAYS be called with the owner's write lock held
+			// (Since every retrieval from LRU cache modifies shared LRU list)
 			get {
 				if (key == null)
 					return null;
@@ -171,6 +173,7 @@ namespace System.Web.Caching
 				return null;
 			}
 
+			// Must ALWAYS be called with the owner's write lock held
 			set {
 				LinkedListNode<CacheItem> node;
 	


### PR DESCRIPTION
System.Web.Caching.CacheItemLRU.this[string].get modifies LRU list so it
must be called under write lock. Cache.GetKeyLastChange violates this
constraint by acquiring only a read lock.

Fixes #12218



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
