### PR TITLE
[coop] Drop support for MONO_ENABLE_BLOCKING_TRANSITION env var

### DIFF
--- a/mono/utils/mono-threads-coop.c
+++ b/mono/utils/mono-threads-coop.c
@@ -639,17 +639,8 @@ mono_threads_suspend_policy_name (MonoThreadsSuspendPolicy policy)
 	}
 }
 
-static gboolean
-blocking_transition_getenv_compat (void)
-{
-	static int inenv = -1;
-	if (G_UNLIKELY (inenv == -1))
-		inenv = g_hasenv ("MONO_ENABLE_BLOCKING_TRANSITION");
-	return inenv;
-}
-
-static gboolean
-blocking_transition_from_policy (MonoThreadsSuspendPolicy p)
+gboolean
+mono_threads_suspend_policy_is_blocking_transition_enabled (MonoThreadsSuspendPolicy p)
 {
 	switch (p) {
 	case MONO_THREADS_SUSPEND_FULL_COOP:
@@ -663,13 +654,6 @@ blocking_transition_from_policy (MonoThreadsSuspendPolicy p)
 }
 
 gboolean
-mono_threads_suspend_policy_is_blocking_transition_enabled (MonoThreadsSuspendPolicy p)
-{
-	return blocking_transition_getenv_compat () ||
-		blocking_transition_from_policy (p);
-}
-
-gboolean
 mono_threads_is_cooperative_suspension_enabled (void)
 {
 	return (mono_threads_suspend_policy () == MONO_THREADS_SUSPEND_FULL_COOP);
@@ -678,11 +662,7 @@ mono_threads_is_cooperative_suspension_enabled (void)
 gboolean
 mono_threads_is_blocking_transition_enabled (void)
 {
-	static int enabled = -1;
-	if (G_UNLIKELY (enabled == -1)) {
-		enabled = mono_threads_suspend_policy_is_blocking_transition_enabled (mono_threads_suspend_policy ());
-	}
-	return enabled == 1;
+	return mono_threads_suspend_policy_is_blocking_transition_enabled (mono_threads_suspend_policy ());
 }
 
 gboolean

--- a/mono/utils/mono-threads-coop.c
+++ b/mono/utils/mono-threads-coop.c
@@ -640,29 +640,9 @@ mono_threads_suspend_policy_name (MonoThreadsSuspendPolicy policy)
 }
 
 gboolean
-mono_threads_suspend_policy_is_blocking_transition_enabled (MonoThreadsSuspendPolicy p)
-{
-	switch (p) {
-	case MONO_THREADS_SUSPEND_FULL_COOP:
-	case MONO_THREADS_SUSPEND_HYBRID:
-		return TRUE;
-	case MONO_THREADS_SUSPEND_FULL_PREEMPTIVE:
-		return FALSE;
-	default:
-		g_assert_not_reached ();
-	}
-}
-
-gboolean
 mono_threads_is_cooperative_suspension_enabled (void)
 {
 	return (mono_threads_suspend_policy () == MONO_THREADS_SUSPEND_FULL_COOP);
-}
-
-gboolean
-mono_threads_is_blocking_transition_enabled (void)
-{
-	return mono_threads_suspend_policy_is_blocking_transition_enabled (mono_threads_suspend_policy ());
 }
 
 gboolean

--- a/mono/utils/mono-threads-coop.h
+++ b/mono/utils/mono-threads-coop.h
@@ -34,6 +34,20 @@ typedef enum {
 } MonoThreadsSuspendPolicy;
 
 static inline gboolean
+mono_threads_suspend_policy_is_blocking_transition_enabled (MonoThreadsSuspendPolicy p)
+{
+	switch (p) {
+	case MONO_THREADS_SUSPEND_FULL_COOP:
+	case MONO_THREADS_SUSPEND_HYBRID:
+		return TRUE;
+	case MONO_THREADS_SUSPEND_FULL_PREEMPTIVE:
+		return FALSE;
+	default:
+		g_assert_not_reached ();
+	}
+}
+
+static inline gboolean
 mono_threads_suspend_policy_are_safepoints_enabled (MonoThreadsSuspendPolicy p)
 {
 	switch (p) {
@@ -61,8 +75,11 @@ mono_threads_suspend_policy (void);
 const char*
 mono_threads_suspend_policy_name (MonoThreadsSuspendPolicy p);
 
-gboolean
-mono_threads_is_blocking_transition_enabled (void);
+static inline gboolean
+mono_threads_is_blocking_transition_enabled (void)
+{
+	return mono_threads_suspend_policy_is_blocking_transition_enabled (mono_threads_suspend_policy ());
+}
 
 gboolean
 mono_threads_is_cooperative_suspension_enabled (void);


### PR DESCRIPTION
It was never documented and it is not as useful now with a matured hybrid
suspend.

If `MONO_ENABLE_BLOCKING_TRANSITION` is set, and mono is otherwise configured to use
preemptive suspend, the thread state machinery would perform RUNNING->BLOCKING
transitions (ie: `MONO_ENTER_GC_SAFE` and friends would be more than no-ops), but
still preemptively suspend every thread.  This was useful for testing the
thread transitions separately from the coop suspend details.