### PR TITLE
Add explicit no-op to RISC-V FPU detection, to fix old Autoconf (RHEL 6)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5056,6 +5056,7 @@ if test ${TARGET} = RISCV32 -o ${TARGET} = RISCV64; then
 			#error "double"
 			#endif
 		], [
+			fpabi=auto
 		], [
 			fpabi=double
 		])
@@ -5067,6 +5068,7 @@ if test ${TARGET} = RISCV32 -o ${TARGET} = RISCV64; then
 			#error "single"
 			#endif
 		], [
+			fpabi=auto
 		], [
 			fpabi=single
 		])
@@ -5078,6 +5080,7 @@ if test ${TARGET} = RISCV32 -o ${TARGET} = RISCV64; then
 			#error "soft"
 			#endif
 		], [
+			fpabi=auto
 		], [
 			fpabi=soft
 		])


### PR DESCRIPTION
Apparently, on old versions of Autoconf, a AC_TRY_COMPILE block with an empty action-if-true block, like:
```
        if test x$fpabi = xauto; then
                AC_TRY_COMPILE([], [
                        #ifdef __riscv_float_abi_double
                        #error "double"
                        #endif
                ], [
                ], [
                        fpabi=double
                ])
        fi
```
emits invalid shell code, like:
```
  (exit $ac_status); } && {
         test -z "$ac_c_werror_flag" ||
         test ! -s conftest.err
       } && test -s conftest.$ac_objext; then

else
```

`else` immediately after `then` is not valid.

This construct is fine on newer versions, where `then :` is used, which does not count as invalid.

Even though we're not building for CentOS 6 RISC-V, the invalid shell causes the configure script to fail entirely, e.g. https://jenkins.mono-project.com/view/Releases/job/ng-release-generate-rpm-packages/963/execution/node/142/log/

Add a useless action-if-true which won't affect the program flow, but means we aren't emitting `then else` on old Autoconf.