### PR TITLE
Cater for later glibc use of ucontext

### DIFF
--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -866,7 +866,11 @@ typedef struct {
 
 #define MONO_ARCH_HAS_MONO_CONTEXT 1
 
+#if __GLIBC_PREREQ(2, 27)
+typedef ucontext_t MonoContext;
+#else
 typedef struct ucontext MonoContext;
+#endif
 
 #define MONO_CONTEXT_SET_IP(ctx,ip) 					\
 	do {								\

--- a/mono/utils/mono-context.h
+++ b/mono/utils/mono-context.h
@@ -866,6 +866,8 @@ typedef struct {
 
 #define MONO_ARCH_HAS_MONO_CONTEXT 1
 
+#include <sys/ucontext.h>
+
 #if __GLIBC_PREREQ(2, 27)
 typedef ucontext_t MonoContext;
 #else


### PR DESCRIPTION
Later levels of glibc redefine struct ucontext to typedef struct ucontext_t. This PR will check the level of glibc and define MonoContext appropriately.