### PR TITLE
Rearrange the TcpStatus enum to match Linux

### DIFF
--- a/mcs/class/referencesource/System/net/System/Net/NetworkInformation/TcpState.cs
+++ b/mcs/class/referencesource/System/net/System/Net/NetworkInformation/TcpState.cs
@@ -7,17 +7,17 @@ namespace System.Net.NetworkInformation
     public enum TcpState
     {
         Unknown,
-        Closed,
-        Listen,
+        Established,
         SynSent,
         SynReceived,
-        Established,
         FinWait1,
         FinWait2,
-        CloseWait,
-        Closing,
-        LastAck,
         TimeWait,
+        Closed,
+        CloseWait,
+        LastAck,
+        Listen,
+        Closing,
         DeleteTcb
     }
  }


### PR DESCRIPTION
The enum in Linux can be seen here: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/net/tcp_states.h?id=HEAD
Fixes #6477




<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
