### PR TITLE
[wasm] Fix build targets errors

### DIFF
--- a/sdks/wasm/sdk/Mono.WebAssembly.Build/Mono.WebAssembly.Build.targets
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Build/Mono.WebAssembly.Build.targets
@@ -1,6 +1,6 @@
 <Project>
-	<UsingTask AssemblyFile="$(MSBuildThisFileDirectory)Mono.WebAssembly.Build.dll" TaskName="WasmLinkAssemblies" />
-	<UsingTask AssemblyFile="$(MSBuildThisFileDirectory)Mono.WebAssembly.Build.dll" TaskName="WasmCreateRuntimeJs" />
+	<UsingTask AssemblyFile="$(MSBuildThisFileDirectory)netstandard2.0/Mono.WebAssembly.Build.dll" TaskName="WasmLinkAssemblies" />
+	<UsingTask AssemblyFile="$(MSBuildThisFileDirectory)netstandard2.0/Mono.WebAssembly.Build.dll" TaskName="WasmCreateRuntimeJs" />
 
 	<PropertyGroup>
 		<EnableDefaultWebContentItems Condition="'$(EnableDefaultWebContentItems)' == ''">True</EnableDefaultWebContentItems>


### PR DESCRIPTION
- The "WasmLinkAssemblies" task could not be loaded from the assembly
