### PR TITLE
[2018-08] [tests] Remove an invalid assertion on System.IO.DriveInfo

### DIFF
--- a/mcs/class/corlib/Test/System.IO/DriveInfoTest.cs
+++ b/mcs/class/corlib/Test/System.IO/DriveInfoTest.cs
@@ -86,7 +86,6 @@ namespace MonoTests.System.IO
 			}
 
 			if (d.DriveType == DriveType.Fixed) { // just consider fixed drives for now
-				Assert.True (d.IsReady);
 				AssertHelper.GreaterOrEqual (d.AvailableFreeSpace, 0);
 				AssertHelper.GreaterOrEqual (d.TotalFreeSpace, 0);
 				AssertHelper.GreaterOrEqual (d.TotalSize, 0);


### PR DESCRIPTION
All fixed drives are not guaranteed to be ready

Fixes https://github.com/mono/mono/issues/11960

Backport of #12296.

/cc @alexischr 