### PR TITLE
[Debugger] Crash test

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -2458,6 +2458,10 @@ public class DebuggerTests
 	[Test]
 	[Category("NotOnWindows")]
 	public void Crash () {
+		bool deleteCrash = true;
+		string [] crashFileEntries = Directory.GetFiles (".", "mono_crash*.json");
+		if (crashFileEntries.Length != 0)
+			deleteCrash = false;
 		bool success = false;
 		for (int i = 0 ; i < 10; i++) {
 			try {
@@ -2492,6 +2496,12 @@ public class DebuggerTests
 			//try again because of unreliability of the crash reporter.
 			TearDown();
 			SetUp();
+		}
+		if (deleteCrash) {
+			crashFileEntries = Directory.GetFiles (".", "mono_crash*.json");
+			foreach (string f in crashFileEntries) {
+        		File.Delete(f);
+    		}
 		}
 		if (!success)
 			Assert.Fail ("Didn't get crash event");

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -2457,34 +2457,43 @@ public class DebuggerTests
 
 	[Test]
 	[Category("NotOnWindows")]
-	[Ignore("https://github.com/mono/mono/issues/11385")]
 	public void Crash () {
 		bool success = false;
-
-		try {
-			vm.Detach ();
-			Start (new string [] { dtest_app_path, "crash-vm" });
-			Event e = run_until ("crash");
-			while (!success) {
-				vm.Resume ();
-				e = GetNextEvent ();
-				var crash = e as CrashEvent;
-				if (crash == null)
-					continue;
-
-				success = true;
-				Assert.AreNotEqual (0, crash.Dump.Length);
-
-				break;
-			}
-		} finally {
+		for (int i = 0 ; i < 10; i++) {
 			try {
 				vm.Detach ();
-			} finally {
-				vm = null;
-			}
-		}
+				Start (new string [] { dtest_app_path, "crash-vm" });
+				Event e = run_until ("crash");
+				while (!success) {
+					vm.Resume ();
+					e = GetNextEvent ();
+					var crash = e as CrashEvent;
+					if (crash == null)
+						continue;
 
+					success = true;
+					Assert.AreNotEqual (0, crash.Dump.Length);
+
+					break;
+				}
+			} catch (VMDisconnectedException vmDisconnect) { //expected behavior because of unreliability of the crash reporter.
+						success = false;
+			} finally {
+				try {
+					vm.Detach ();
+				} catch (VMDisconnectedException vmDisconnect) { //expected behavior because of unreliability of the crash reporter.
+						success = false;
+				} finally {
+					vm = null;
+				}
+			}
+			if (success) 
+				break;
+			System.Console.WriteLine("tentando");
+			//try again because of unreliability of the crash reporter.
+			TearDown();
+			SetUp();
+		}
 		if (!success)
 			Assert.Fail ("Didn't get crash event");
 	}

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -2489,7 +2489,6 @@ public class DebuggerTests
 			}
 			if (success) 
 				break;
-			System.Console.WriteLine("tentando");
 			//try again because of unreliability of the crash reporter.
 			TearDown();
 			SetUp();


### PR DESCRIPTION
Changing the test behavior as discussed with Ludovic, because we already have knowledge about the unreliability of the crash reporter and the test is not about it.
So if in 10 times at least one of them works for now it's good.
Fixes #11385