### PR TITLE
[2018-12] Preserve old EnableMicrosoftTelemetry signature on backport

### DIFF
--- a/mcs/class/corlib/Mono/Runtime.cs
+++ b/mcs/class/corlib/Mono/Runtime.cs
@@ -148,7 +148,7 @@ namespace Mono {
 		}
 
 		// All must be set except for configDir_str
-		static void EnableMicrosoftTelemetry (string appBundleID_str, string appSignature_str, string appVersion_str, string merpGUIPath_str, string eventType_str, string appPath_str, string configDir_str)
+		static void EnableMicrosoftTelemetryNext (string appBundleID_str, string appSignature_str, string appVersion_str, string merpGUIPath_str, string eventType_str, string appPath_str, string configDir_str)
 		{
 			if (RuntimeInformation.IsOSPlatform (OSPlatform.OSX)) {
 				using (var appBundleID_chars = RuntimeMarshal.MarshalString (appBundleID_str))
@@ -164,6 +164,11 @@ namespace Mono {
 			} else {
 				throw new PlatformNotSupportedException("Merp support is currently only supported on OSX.");
 			}
+		}
+
+		static void EnableMicrosoftTelemetry (string appBundleID_str, string appSignature_str, string appVersion_str, string merpGUIPath_str, string eventType_str, string appPath_str)
+		{
+			EnableMicrosoftTelemetryNext (appBundleID_str, appSignature_str, appVersion_str, merpGUIPath_str, eventType_str, appPath_str, null);
 		}
 #endif
 

--- a/mono/tests/merp-json-valid.cs
+++ b/mono/tests/merp-json-valid.cs
@@ -22,7 +22,7 @@ class C
 	JsonValidateMerp ()
 	{
 		var monoType = Type.GetType ("Mono.Runtime", false);
-		var m = monoType.GetMethod("EnableMicrosoftTelemetry", BindingFlags.NonPublic | BindingFlags.Static);
+		var m = monoType.GetMethod("EnableMicrosoftTelemetryNext", BindingFlags.NonPublic | BindingFlags.Static);
 
 		// This leads to open -a /bin/cat, which errors out, but errors
 		// in invoking merp are only logged errors, not fatal assertions.


### PR DESCRIPTION
Needed to avoid changing the signature of this function within a mono release