### PR TITLE
[Fix] GetActiveTcpConnections now returns correct state in unix

### DIFF
--- a/mcs/class/System/System.Net.NetworkInformation/UnixIPGlobalProperties.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/UnixIPGlobalProperties.cs
@@ -280,6 +280,38 @@ namespace System.Net.NetworkInformation {
 			}
 		}
 
+		static TcpState UnixTcpStateToTcpState (int unixState)
+		{
+			//The values of these states in Linux are listed here:
+			//https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/net/tcp_states.h?id=HEAD
+			switch (unixState) {
+			case 1:
+				return TcpState.Established;
+			case 2:
+				return TcpState.SynSent;
+			case 3:
+				return TcpState.SynReceived;
+			case 4:
+				return TcpState.FinWait1;
+			case 5:
+				return TcpState.FinWait2;
+			case 6:
+				return TcpState.TimeWait;
+			case 7:
+				return TcpState.Closed;
+			case 8:
+				return TcpState.CloseWait;
+			case 9:
+				return TcpState.LastAck;
+			case 10:
+				return TcpState.Listen;
+			case 11:
+				return TcpState.Closing;
+			default:
+				return TcpState.Unknown;
+			}
+		}
+
 		public override TcpConnectionInformation [] GetActiveTcpConnections ()
 		{
 			List<string []> list = new List<string []> ();
@@ -291,7 +323,7 @@ namespace System.Net.NetworkInformation {
 				// sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
 				IPEndPoint local = ToEndpoint (list [i] [1]);
 				IPEndPoint remote = ToEndpoint (list [i] [2]);
-				TcpState state = (TcpState) int.Parse (list [i] [3], NumberStyles.HexNumber);
+				TcpState state = UnixTcpStateToTcpState (int.Parse (list [i] [3], NumberStyles.HexNumber));
 				ret [i] = new SystemTcpConnectionInformation (local, remote, state);
 			}
 			return ret;


### PR DESCRIPTION
The values of the enum for the TcpState are different in Unix systems
than in .NET, so a function was added to convert between the two.

Fixes #6477



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
