### PR TITLE
[interp] Fix resuming into interp when finally throws exception

### DIFF
--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -2831,8 +2831,16 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 						mini_set_abort_threshold (&frame);
 						if (in_interp) {
 							gboolean has_ex = mini_get_interp_callbacks ()->run_finally (&frame, i, ei->handler_start, ei->data.handler_end);
-							if (has_ex)
+							if (has_ex) {
+								/*
+								 * If run_finally didn't resume to a context, it means that the handler frame
+								 * is linked to the frame calling finally through interpreter frames. This
+								 * means that we will reach the handler frame by resuming the current context.
+								 */
+								if (MONO_CONTEXT_GET_IP (ctx) != 0)
+									mono_arch_undo_ip_adjustment (ctx);
 								return 0;
+							}
 						} else {
 							call_filter (ctx, ei->handler_start);
 						}

--- a/mono/mini/mixed.cs
+++ b/mono/mini/mixed.cs
@@ -283,4 +283,24 @@ class Tests
 			return 5;
 		return 0;
 	}
+
+	// Finally exception will be thrown from this stack : interp -> jit -> eh -> interp
+	// Test that we propagate the finally exception over the jitted frames
+	public static int test_0_finex () {
+		bool called_finally = false;
+		try {
+			try {
+				JitClass.throw_ex ();
+				return 3;
+			} finally {
+				called_finally = true;
+				throw new Exception ("E2");
+			}
+		} catch (Exception) {
+			if (!called_finally)
+				return 1;
+			return 0;
+		}
+		return 2;
+        }
 }

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1576,7 +1576,6 @@ PROFILE_DISABLED_TESTS += \
 	bug-80307.exe
 
 PROFILE_DISABLED_TESTS += \
-	bug-70561.exe \
 	transparentproxy.exe
 endif
 


### PR DESCRIPTION
We might need to adjust the ip in the same fashion when normally resuming to catch handler.

In the example from the testcase, we have these transitions : ... -> interp_frame -> jit -> eh1 -> interp_frame -> eh2. When eh1 unwinds to call the finally clause from interp_frame it also pops all other lmf entries until there. This means that eh2 thinks it was called directly from the interp_frame (as it would happen with the jit), but in this case there are still the jit frames in the middle. Eh2 doesn't know how to resume over the jit frames, it will just set the resume state to the interp_frame and eh1 will do the resuming over the jitted frames, after run_finally returns gracefully. If the exception were to be handled by frames parent to interp_frame and there are also pushed contexts on the lmf stack, then eh2 could both unwind and resume directly there, skipping eh1 and the jitted frames altogether.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
