### PR TITLE
[wasm][ci] Re-enable chakra tests

### DIFF
--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -215,8 +215,7 @@ if [[ ${CI_TAGS} == *'webassembly'* ]] || [[ ${CI_TAGS} == *'wasm'* ]];
 
         if [[ ${CI_TAGS} != *'no-tests'* ]]; then
             ${TESTCMD} --label=wasm-build --timeout=60m --fatal make -j ${CI_CPU_COUNT} -C sdks/wasm build
-	    # Chakra install fails: https://github.com/mono/mono/issues/12331
-            #${TESTCMD} --label=ch-mini-test --timeout=60m make -C sdks/wasm run-ch-mini
+            ${TESTCMD} --label=ch-mini-test --timeout=60m make -C sdks/wasm run-ch-mini
             ${TESTCMD} --label=v8-mini-test --timeout=60m make -C sdks/wasm run-v8-mini
             ${TESTCMD} --label=sm-mini-test --timeout=60m make -C sdks/wasm run-sm-mini
             ${TESTCMD} --label=jsc-mini-test --timeout=60m make -C sdks/wasm run-jsc-mini

--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -222,8 +222,7 @@ if [[ ${CI_TAGS} == *'webassembly'* ]] || [[ ${CI_TAGS} == *'wasm'* ]];
             #The following tests are not passing yet, so enabling them would make us perma-red
             #${TESTCMD} --label=mini-corlib --timeout=60m make -C sdks/wasm run-all-corlib
             #${TESTCMD} --label=mini-system --timeout=60m make -C sdks/wasm run-all-system
-            # Chakra install fails: https://github.com/mono/mono/issues/12331
-            #${TESTCMD} --label=ch-system-core --timeout=60m make -C sdks/wasm run-ch-system-core
+            ${TESTCMD} --label=ch-system-core --timeout=60m make -C sdks/wasm run-ch-system-core
             ${TESTCMD} --label=v8-system-core --timeout=60m make -C sdks/wasm run-v8-system-core
             ${TESTCMD} --label=sm-system-core --timeout=60m make -C sdks/wasm run-sm-system-core
             ${TESTCMD} --label=jsc-system-core --timeout=60m make -C sdks/wasm run-jsc-system-core

--- a/sdks/wasm/package.json
+++ b/sdks/wasm/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "jsvu": "1.3.1"
+    "jsvu": "1.3.2"
   }
 }

--- a/sdks/wasm/package.json
+++ b/sdks/wasm/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "jsvu": "1.3.2"
+    "jsvu": "1.3.3"
   }
 }


### PR DESCRIPTION
Re-enables the chakra tests now that the upstream jsvu issue was fixed.

Fixes https://github.com/mono/mono/issues/12331

