### PR TITLE
[2018-10] [debugger][backport] Fix test ShouldCorrectlyStepOverOnExitFromArgsAfterStepInMethodParameter (#12114)

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -466,6 +466,8 @@ public class Tests : TestsBase, ITest2
 		ss_fp_clobber ();
 		ss_no_frames ();
 		ss_await ();
+		ss_nested_with_three_args_wrapper();
+		ss_nested_twice_with_two_args_wrapper();
 	}
 
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]
@@ -578,12 +580,43 @@ public class Tests : TestsBase, ITest2
 	}
 
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	public static void ss_nested_with_three_args_wrapper () {
+		ss_nested_with_three_args(ss_nested_arg1 (), ss_nested_arg2 (), ss_nested_arg3 ());
+	}
+
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	public static void ss_nested_twice_with_two_args_wrapper () {
+		ss_nested_with_two_args(ss_nested_arg1 (), ss_nested_with_two_args(ss_nested_arg2 (), ss_nested_arg3 ()));
+  	}
+  
+	
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
 	public static int ss_nested_with_two_args (int a1, int a2) {
 		return a1 + a2;
 	}
 
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	public static int ss_nested_with_three_args (int a1, int a2, int a3) {
+		return a1 + a2 + a3;
+	}
+
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
 	public static int ss_nested_arg () {
+		return 0;
+	}
+
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	public static int ss_nested_arg1 () {
+		return 0;
+	}
+
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	public static int ss_nested_arg2 () {
+		return 0;
+	}
+	
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	public static int ss_nested_arg3 () {
 		return 0;
 	}
 

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -4444,7 +4444,83 @@ public class DebuggerTests
 	}
 
 	[Test]
-	[Category("NotWorking")]
+	public void StepOverOnExitFromArgsAfterStepInMethodParameter2() {
+		Event e = run_until ("ss_nested_with_three_args_wrapper");
+
+		var req = create_step(e);
+		req.Enable();
+
+		e = step_once();
+		assert_location(e, "ss_nested_with_three_args_wrapper");
+
+		e = step_into();
+		assert_location(e, "ss_nested_arg1");
+
+		e = step_over();
+		assert_location(e, "ss_nested_arg1");
+
+		e = step_over();
+		assert_location(e, "ss_nested_arg1");
+
+		e = step_over();
+		assert_location(e, "ss_nested_with_three_args_wrapper");
+
+		e = step_into();
+		assert_location(e, "ss_nested_arg2");
+
+		e = step_over();
+		assert_location(e, "ss_nested_arg2");
+
+		e = step_over();
+		assert_location(e, "ss_nested_arg2");
+
+		e = step_over();
+		assert_location(e, "ss_nested_with_three_args_wrapper");
+
+		e = step_into();
+		assert_location(e, "ss_nested_arg3");
+	}
+
+	
+	[Test]
+	public void StepOverOnExitFromArgsAfterStepInMethodParameter3() {
+		Event e = run_until ("ss_nested_twice_with_two_args_wrapper");
+
+		var req = create_step(e);
+		req.Enable();
+
+		e = step_once();
+		assert_location(e, "ss_nested_twice_with_two_args_wrapper");
+
+		e = step_into();
+		assert_location(e, "ss_nested_arg1");
+
+		e = step_over();
+		assert_location(e, "ss_nested_arg1");
+
+		e = step_over();
+		assert_location(e, "ss_nested_arg1");
+
+		e = step_over();
+		assert_location(e, "ss_nested_twice_with_two_args_wrapper");
+
+		e = step_into();
+		assert_location(e, "ss_nested_arg2");
+
+		e = step_over();
+		assert_location(e, "ss_nested_arg2");
+
+		e = step_over();
+		assert_location(e, "ss_nested_arg2");
+
+		e = step_over();
+		assert_location(e, "ss_nested_twice_with_two_args_wrapper");
+
+		e = step_into();
+		assert_location(e, "ss_nested_arg3");
+	}
+
+	[Test]
 	public void ShouldCorrectlyStepOverOnExitFromArgsAfterStepInMethodParameter() {
 		Event e = run_until ("ss_nested_with_two_args_wrapper");
 

--- a/mono/metadata/seq-points-data.h
+++ b/mono/metadata/seq-points-data.h
@@ -11,6 +11,7 @@
 
 #define MONO_SEQ_POINT_FLAG_NONEMPTY_STACK 1
 #define MONO_SEQ_POINT_FLAG_EXIT_IL 2
+#define MONO_SEQ_POINT_FLAG_NESTED_CALL 4
 
 /* IL offsets used to mark the sequence points belonging to method entry/exit events */
 #define METHOD_ENTRY_IL_OFFSET -1

--- a/mono/mini/debugger-engine.c
+++ b/mono/mini/debugger-engine.c
@@ -931,7 +931,7 @@ mono_de_ss_update (SingleStepReq *req, MonoJitInfo *ji, SeqPoint *sp, void *tls,
 		return FALSE;
 	}
 
-	if (req->depth == STEP_DEPTH_OVER && (sp->flags & MONO_SEQ_POINT_FLAG_NONEMPTY_STACK)) {
+	if (req->depth == STEP_DEPTH_OVER && (sp->flags & MONO_SEQ_POINT_FLAG_NONEMPTY_STACK) && !(sp->flags & MONO_SEQ_POINT_FLAG_NESTED_CALL)) {
 		/*
 		 * These seq points are inserted by the JIT after calls, step over needs to skip them.
 		 */
@@ -954,7 +954,7 @@ mono_de_ss_update (SingleStepReq *req, MonoJitInfo *ji, SeqPoint *sp, void *tls,
 		}
 	}
 
-	if (req->depth == STEP_DEPTH_INTO && req->size == STEP_SIZE_MIN && (sp->flags & MONO_SEQ_POINT_FLAG_NONEMPTY_STACK) && req->start_method) {
+	if (req->depth == STEP_DEPTH_INTO && req->size == STEP_SIZE_MIN && (sp->flags & MONO_SEQ_POINT_FLAG_NONEMPTY_STACK) && !(sp->flags & MONO_SEQ_POINT_FLAG_NESTED_CALL) && req->start_method) {
 		int nframes;
 		rt_callbacks.ss_calculate_framecount (tls, ctx, FALSE, NULL, &nframes);
 		if (req->start_method == method && req->nframes && nframes == req->nframes) { //Check also frame count(could be recursion)
@@ -1227,7 +1227,7 @@ is_last_non_empty (SeqPoint* sp, MonoSeqPointInfo *info)
 	SeqPoint* next = g_new (SeqPoint, sp->next_len);
 	mono_seq_point_init_next (info, *sp, next);
 	for (int i = 0; i < sp->next_len; i++) {
-		if (next [i].flags & MONO_SEQ_POINT_FLAG_NONEMPTY_STACK) {
+		if (next [i].flags & MONO_SEQ_POINT_FLAG_NONEMPTY_STACK && !(next [i].flags & MONO_SEQ_POINT_FLAG_NESTED_CALL)) {
 			if (!is_last_non_empty (&next [i], info)) {
 				g_free (next);
 				return FALSE;

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -795,6 +795,7 @@ enum {
 	MONO_INST_NOTYPECHECK    = 4,
 	MONO_INST_NONEMPTY_STACK = 4, /* in SEQ_POINT */
 	MONO_INST_UNALIGNED  = 8,
+	MONO_INST_NESTED_CALL = 8, /* in SEQ_POINT */
     MONO_INST_CFOLD_TAKEN = 8, /* On branches */
     MONO_INST_CFOLD_NOT_TAKEN = 16, /* On branches */
 	MONO_INST_DEFINITION_HAS_SIDE_EFFECTS = 8,
@@ -1457,6 +1458,7 @@ typedef struct {
 	/* Used to implement dyn_call */
 	MonoInst *dyn_call_var;
 
+	MonoInst *last_seq_point;
 	/*
 	 * List of sequence points represented as IL offset+native offset pairs.
 	 * Allocated using glib.

--- a/mono/mini/seq-points.c
+++ b/mono/mini/seq-points.c
@@ -124,7 +124,8 @@ mono_save_seq_point_info (MonoCompile *cfg, MonoJitInfo *jinfo)
 		sp->native_offset = ins->inst_offset;
 		if (ins->flags & MONO_INST_NONEMPTY_STACK)
 			sp->flags |= MONO_SEQ_POINT_FLAG_NONEMPTY_STACK;
-
+		if (ins->flags & MONO_INST_NESTED_CALL)
+			sp->flags |= MONO_SEQ_POINT_FLAG_NESTED_CALL;
 		/* Used below */
 		ins->backend.size = i;
 	}


### PR DESCRIPTION
Backport of #12114


The problem was in this line:
ss_nested_with_two_args(ss_nested_arg (), ss_nested_arg ());
The first step_into works correctly entering in the ss_nested_arg method, but the second one doesn't work.
The problem was because this flag MONO_SEQ_POINT_FLAG_NONEMPTY_STACK was set, so the debugger don't consider that it was a possible break.
The solution of the issue was create another flag to identify nested calls and ignore the  MONO_SEQ_POINT_FLAG_NONEMPTY_STACK.
2 new tests were added to test other nested calls.



