### PR TITLE
Fix re-entrant structured exception handling

### DIFF
--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -56,7 +56,7 @@ LPTOP_LEVEL_EXCEPTION_FILTER mono_old_win_toplevel_exception_filter;
 void *mono_win_vectored_exception_handle;
 
 #define W32_SEH_HANDLE_EX(_ex) \
-	if (_ex##_handler) _ex##_handler(0, ep, ctx)
+	if (_ex##_handler) _ex##_handler(er->ExceptionCode, &info, ctx)
 
 static LONG CALLBACK seh_unhandled_exception_filter(EXCEPTION_POINTERS* ep)
 {
@@ -135,12 +135,12 @@ static LONG CALLBACK seh_vectored_exception_handler(EXCEPTION_POINTERS* ep)
 	LONG res;
 	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
 	MonoDomain* domain = mono_domain_get ();
+	MonoWindowsSigHandlerInfo info = { TRUE, ep };
 
 	/* If the thread is not managed by the runtime return early */
 	if (!jit_tls)
 		return EXCEPTION_CONTINUE_SEARCH;
 
-	jit_tls->mono_win_chained_exception_needs_run = FALSE;
 	res = EXCEPTION_CONTINUE_EXECUTION;
 
 	er = ep->ExceptionRecord;
@@ -157,7 +157,7 @@ static LONG CALLBACK seh_vectored_exception_handler(EXCEPTION_POINTERS* ep)
 				ctx->Rip = (guint64)restore_stack;
 			}
 		} else {
-			jit_tls->mono_win_chained_exception_needs_run = TRUE;
+			info.handled = FALSE;
 		}
 		break;
 	case EXCEPTION_ACCESS_VIOLATION:
@@ -175,11 +175,11 @@ static LONG CALLBACK seh_vectored_exception_handler(EXCEPTION_POINTERS* ep)
 		W32_SEH_HANDLE_EX(fpe);
 		break;
 	default:
-		jit_tls->mono_win_chained_exception_needs_run = TRUE;
+		info.handled = FALSE;
 		break;
 	}
 
-	if (jit_tls->mono_win_chained_exception_needs_run) {
+	if (!info.handled) {
 		/* Don't copy context back if we chained exception
 		* as the handler may have modfied the EXCEPTION_POINTERS
 		* directly. We don't pass sigcontext to chained handlers.

--- a/mono/mini/exceptions-x86.c
+++ b/mono/mini/exceptions-x86.c
@@ -55,7 +55,7 @@ extern int (*gUnhandledExceptionHandler)(EXCEPTION_POINTERS*);
 #endif
 
 #define W32_SEH_HANDLE_EX(_ex) \
-	if (_ex##_handler) _ex##_handler(0, ep, ctx)
+	if (_ex##_handler) _ex##_handler(er->ExceptionCode, &info, ctx)
 
 LONG CALLBACK seh_unhandled_exception_filter(EXCEPTION_POINTERS* ep)
 {
@@ -198,12 +198,12 @@ LONG CALLBACK seh_vectored_exception_handler(EXCEPTION_POINTERS* ep)
 	CONTEXT* ctx;
 	LONG res;
 	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
+	MonoWindowsSigHandlerInfo info = { TRUE, ep };
 
 	/* If the thread is not managed by the runtime return early */
 	if (!jit_tls)
 		return EXCEPTION_CONTINUE_SEARCH;
 
-	jit_tls->mono_win_chained_exception_needs_run = FALSE;
 	res = EXCEPTION_CONTINUE_EXECUTION;
 
 	er = ep->ExceptionRecord;
@@ -228,11 +228,11 @@ LONG CALLBACK seh_vectored_exception_handler(EXCEPTION_POINTERS* ep)
 		W32_SEH_HANDLE_EX(fpe);
 		break;
 	default:
-		jit_tls->mono_win_chained_exception_needs_run = TRUE;
+		info.handled = FALSE;
 		break;
 	}
 
-	if (jit_tls->mono_win_chained_exception_needs_run) {
+	if (!info.handled) {
 		/* Don't copy context back if we chained exception
 		* as the handler may have modfied the EXCEPTION_POINTERS
 		* directly. We don't pass sigcontext to chained handlers.

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -32,7 +32,7 @@ struct sigcontext {
 };
 #endif
 
-typedef void (* MonoW32ExceptionHandler) (int _dummy, EXCEPTION_POINTERS *info, void *context);
+typedef void MONO_SIG_HANDLER_SIGNATURE ((*MonoW32ExceptionHandler));
 void win32_seh_init(void);
 void win32_seh_cleanup(void);
 void win32_seh_set_handler(int type, MonoW32ExceptionHandler handler);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3603,7 +3603,7 @@ MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
 MONO_SIG_HANDLER_FUNC (, mono_sigsegv_signal_handler)
 {
 #ifdef HOST_WIN32
-	gpointer const debug_fault_addr = (gpointer)_info->ExceptionRecord->ExceptionInformation [1];
+	gpointer const debug_fault_addr = (gpointer)MONO_SIG_HANDLER_GET_INFO () ->ep->ExceptionRecord->ExceptionInformation [1];
 #elif defined (HAVE_SIG_INFO)
 	gpointer const debug_fault_addr = MONO_SIG_HANDLER_GET_INFO ()->si_addr;
 #else

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -109,11 +109,6 @@ struct MonoJitTlsData {
 	gboolean orig_ex_ctx_set;
 
 	/* 
-	 * Stores if we need to run a chained exception in Windows.
-	 */
-	gboolean mono_win_chained_exception_needs_run;
-
-	/* 
 	 * The current exception in flight
 	 */
 	guint32 thrown_exc;

--- a/mono/mini/mini-windows.c
+++ b/mono/mini/mini-windows.c
@@ -255,8 +255,8 @@ mono_runtime_cleanup_handlers (void)
 gboolean
 MONO_SIG_HANDLER_SIGNATURE (mono_chain_signal)
 {
-	MonoJitTlsData *jit_tls = mono_tls_get_jit_tls ();
-	jit_tls->mono_win_chained_exception_needs_run = TRUE;
+	/* Set to FALSE to indicate that vectored exception handling should continue to look for handler */
+	MONO_SIG_HANDLER_GET_INFO ()->handled = FALSE;
 	return TRUE;
 }
 

--- a/mono/mini/mini-x86.h
+++ b/mono/mini/mini-x86.h
@@ -16,7 +16,7 @@
 #include <signal.h>
 #endif
 
-typedef void (* MonoW32ExceptionHandler) (int _dummy, EXCEPTION_POINTERS *info, void *context);
+typedef void MONO_SIG_HANDLER_SIGNATURE ((*MonoW32ExceptionHandler));
 
 void win32_seh_init(void);
 void win32_seh_cleanup(void);

--- a/mono/utils/mono-signal-handler.h
+++ b/mono/utils/mono-signal-handler.h
@@ -78,7 +78,14 @@
  */
 
 #ifdef HOST_WIN32
-#define MONO_SIG_HANDLER_INFO_TYPE EXCEPTION_POINTERS
+#define MONO_SIG_HANDLER_INFO_TYPE MonoWindowsSigHandlerInfo
+typedef struct {
+	/* Set to FALSE to indicate chained signal handler needs run.
+	 * With vectored exceptions Windows does that for us by returning
+	 * EXCEPTION_CONTINUE_SEARCH from handler */
+	gboolean handled;
+	EXCEPTION_POINTERS* ep;
+} MonoWindowsSigHandlerInfo;
 /* seh_vectored_exception_handler () passes in a CONTEXT* */
 #else
 /* sigaction */


### PR DESCRIPTION
Store handled status in local that is passed into
handler rather than a single thread local value
which can be overwritten in case of re-entrance.

I encountered this in following scenario:
```
try {
    // cause null reference exception
} finally {
   // cause a structure exception that mono does not handle, for example call OutputDebugString
}
```

The above caused a problem as:
1. Mono is in the middle of processing an exception it will handle, so previous thread local variable `mono_win_chained_exception_needs_run` is `FALSE`
2. Finally clauses are called during structured exception handling
3. Benign structured exception is triggered in finally clause (pinvoke `OutputDebugString` without debugger attached). This causes an exception mono doesn't want to handle but other handler will.
4. In previous logic, the thread local `mono_win_chained_exception_needs_run` is now set to `TRUE`
5. Return from other structured exception handler
6. Return from mono structured exception handling of null reference.
7. In previous logic, `mono_win_chained_exception_needs_run` is now `TRUE` and `EXCEPTION_CONTINUE_SEARCH` is returned indicating mono did *not* handle the null reference exception leading to a crash.

Question: Is it okay to reuse the `_dummy` signal number parameter on windows for this purpose? Or should we introduce another parameter?


Modified PR of https://github.com/Unity-Technologies/mono/pull/1119/files
