### PR TITLE
[threading] Try to fix the os-event-unix.c:82 assert(event) failure

### DIFF
--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -946,6 +946,15 @@ finalizer_thread (gpointer unused)
 	mono_coop_cond_signal (&exited_cond);
 	mono_finalizer_unlock ();
 
+	/* HACK - by the time we're finished, the root domain was already
+	 * destroyed, so the reference queue that cleans up
+	 * MonoInternalThread:synch_cs was already cleared since the
+	 * finalizer's MonoInternalThread is in the root domain.
+	 *
+	 * (MonoInternalThread:synch_cs is accessed by mono_thread_detach_internal)
+	 */
+	mono_thread_internal_current ()->synch_cs = NULL;
+
 	return 0;
 }
 

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -510,7 +510,7 @@ struct _MonoInternalThread {
 	gpointer unused3;
 	gunichar2  *name;
 	guint32	    name_len;
-	guint32	    state;
+	guint32	    state;      /* must be accessed while synch_cs is locked */
 	MonoException *abort_exc;
 	int abort_state_handle;
 	guint64 tid;	/* This is accessed as a gsize in the code (so it can hold a 64bit pointer on systems that need it), but needs to reserve 64 bits of space on all machines as it corresponds to a field in managed code */


### PR DESCRIPTION
This is an attempt to fix #11956, but it contains a **gross hack** and I would like some **help**.

## The good bit ##

Partly revert a29ad08 (#9914)

The problem is a race between `mono_thread_detach_internal` and
`mono_thread_suspend_all_other_threads`:

In `mono_thread_suspend_all_other_threads`, we use `LOCK_THREAD (thread)` (which
locks `MonoInternalThread:synch_cs`) and then test and update the `thread->state` and also
call `mono_os_reset_event (thread->suspended)` while holding the lock.

In `mono_thread_detach_interna`l, we do not lock the thread, and then CAS the
`thread->state` and then continue and set `thread->suspended = NULL`.

As a result we have a concurrency bug: in `suspend_all_other_threads` it's
possible to see both the old (non-Stopped) value of `thread->state` and the
new (`NULL`) value of `thread->suspended`.  Hence the crashes seen in
#11956

This PR switches back to using `LOCK_THREAD` in `mono_thread_detach_internal` when
manipulating the thread state.

As a result, `mono_thread_suspend_all_other_thread`s will see a consistent
`thread->state` and `thread->suspended`: when it takes the lock, if the thread is
not stopped, the suspended event is not NULL, or else it will see the thread is
Stopped and we will skip trying to suspend it.

## The hacky bit ## 

Set the finalizer's `MonoInternalThread:synch_cs` to NULL when finished.

This is a hack to work around the way that synch_cs is managed.

We use a reference queue to ensure that the `MonoInternalThread:synch_cs` mutex
is destroyed when the thread is detached, but it does not set the `MonoInternalThread:synch_cs`
to NULL (since it just has a pointer to the mutex, not the address of the field).

The problem is that reference queues are force-cleared when a domain is
destroyed, and `MonoInternalThread` for the finalizer thread is associated with
the root domain.  The root domain is finalized before the finalizer thread is
detached.

Consequently, when `mono_thread_detach_internal` is called for the finalizer
thread, it will try to lock a destroyed mutex, which leads to a crash.