### PR TITLE
[configure] Small fix in sigaltstack() checking on cross-compiler case

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2577,7 +2577,8 @@ if test x$host_win32 = xno; then
 	if test "x$with_sigaltstack" != "xyes"; then
 		AC_MSG_RESULT(disabled)
 	elif test "x$cross_compiling" = "xyes"; then
-		AC_MSG_RESULT(cross compiling, assuming yes)
+		AC_MSG_RESULT(cross compiling, assuming no)
+		with_sigaltstack=no
 	else
 		AC_TRY_RUN([
 			#include <stdio.h>


### PR DESCRIPTION
Currently we print out that we are "assuming yes" for the condition but we don't actually follow the "yes" action here: https://github.com/mono/mono/blob/1291c08c1d07b97ed7087d15f4eca2538bd5c24f/configure.ac#L2678-L2679