### PR TITLE
[Debugger] Fix crash when there is a generic struct with a field that is an enumerator.

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -87,77 +87,30 @@ public class Tests2 {
 	}
 }
 
-public class TestEnumeratorInsideClass<TKey, TValue>
+public struct TestEnumeratorInsideGenericStruct<TKey, TValue>
 {
-	HashBucket myBucket;
-	internal void Add(TKey key, TValue value)
+	private KeyValuePair<TKey, TValue> _bucket;
+	private Position _currentPosition;
+	internal TestEnumeratorInsideGenericStruct(KeyValuePair<TKey, TValue> bucket)
 	{
-		myBucket._firstValue = new KeyValuePair<TKey, TValue>(key, value);
+		_bucket = bucket;
+		_currentPosition = Position.BeforeFirst;
 	}
-	internal struct HashBucket : IEnumerable<KeyValuePair<TKey, TValue>>
+
+	public KeyValuePair<TKey, TValue> Current
 	{
-		public KeyValuePair<TKey, TValue> _firstValue;
-		public Enumerator GetEnumerator()
+		get
 		{
-			return new Enumerator(this);
+			if (_currentPosition == Position.BeforeFirst)
+				return _bucket;
+			return _bucket;
 		}
-		IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
-		{
-			return this.GetEnumerator();
-		}
-		IEnumerator IEnumerable.GetEnumerator()
-		{
-			return this.GetEnumerator();
-		}
-		internal struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>
-		{
-			private readonly HashBucket _bucket;
-			private Position _currentPosition;
-			internal Enumerator(HashBucket bucket)
-			{
-				_bucket = bucket;
-				_currentPosition = Position.BeforeFirst;
-			}
-
-			public KeyValuePair<TKey, TValue> Current
-			{
-				get
-				{
-					return _bucket._firstValue;
-				}
-			}
-
-			object IEnumerator.Current
-			{
-				get
-				{
-					return _bucket._firstValue;
-				}
-			}
-
-			public void Dispose()
-			{
-				throw new NotImplementedException();
-			}
-
-			public bool MoveNext()
-			{
-				throw new NotImplementedException();
-			}
-
-			public void Reset()
-			{
-				throw new NotImplementedException();
-			}
-
-			private enum Position
-			{
-				BeforeFirst
-			}
-		}
+	}
+	private enum Position
+	{
+		BeforeFirst
 	}
 }
-
 
 public struct AStruct : ITest2 {
 	public int i;
@@ -521,7 +474,7 @@ public class Tests : TestsBase, ITest2
 		new Tests ().evaluate_method ();
 		Bug59649 ();
 		elapsed_time();
-		inspect_field_content();
+		inspect_enumerator_in_generic_struct();
 		return 3;
 	}
 
@@ -735,9 +688,8 @@ public class Tests : TestsBase, ITest2
 	}
 	
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]
-	public static void inspect_field_content() {
-		TestEnumeratorInsideClass<String, String> files = new TestEnumeratorInsideClass<String, String>();
-		files.Add("0", "f1");
+	public static void inspect_enumerator_in_generic_struct() {
+		TestEnumeratorInsideGenericStruct<String, String> generic_struct = new TestEnumeratorInsideGenericStruct<String, String>(new KeyValuePair<string, string>("0", "f1"));
 	}
 
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -4585,29 +4585,22 @@ public class DebuggerTests
 	}
 
 	[Test]
-	public void InspectFieldContent() {
+	public void InspectEnumeratorInGenericStruct() {
 		//files.myBucket.GetEnumerator().get_Current().Key watching this generates an exception in Debugger
-		Event e = run_until("inspect_field_content");
+		Event e = run_until("inspect_enumerator_in_generic_struct");
 		var req = create_step(e);
 		req.Enable();
 		e = step_once();
 		e = step_over();
-		e = step_over();
 		StackFrame frame = e.Thread.GetFrames () [0];
-		var ginst = frame.Method.GetLocal ("files");
+		var ginst = frame.Method.GetLocal ("generic_struct");
 		Value variable = frame.GetValue (ginst);
-		ObjectMirror thisObj = (ObjectMirror)variable;
+		StructMirror thisObj = (StructMirror)variable;
 		TypeMirror thisType = thisObj.Type;
-		variable = thisObj.GetValue (thisType.GetField ("myBucket"));
-		StructMirror thisSObj = (StructMirror)variable;
-		thisType = thisSObj.Type;
-		variable = thisSObj.InvokeMethod(e.Thread, thisType.GetMethod("GetEnumerator"), null);
-		thisSObj = (StructMirror)variable;
-		thisType = thisSObj.Type;
-		variable = thisSObj.InvokeMethod(e.Thread, thisType.GetMethod("get_Current"), null);
-		thisSObj = (StructMirror)variable;
-		thisType = thisSObj.Type;
-		AssertValue ("f1", thisSObj["value"]);
+		variable = thisObj.InvokeMethod(e.Thread, thisType.GetMethod("get_Current"), null);
+		thisObj = (StructMirror)variable;
+		thisType = thisObj.Type;
+		AssertValue ("f1", thisObj["value"]);
 	}
 
 	[Test]

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -4585,6 +4585,32 @@ public class DebuggerTests
 	}
 
 	[Test]
+	public void InspectFieldContent() {
+		//files.myBucket.GetEnumerator().get_Current().Key watching this generates an exception in Debugger
+		Event e = run_until("inspect_field_content");
+		var req = create_step(e);
+		req.Enable();
+		e = step_once();
+		e = step_over();
+		e = step_over();
+		StackFrame frame = e.Thread.GetFrames () [0];
+		var ginst = frame.Method.GetLocal ("files");
+		Value variable = frame.GetValue (ginst);
+		ObjectMirror thisObj = (ObjectMirror)variable;
+		TypeMirror thisType = thisObj.Type;
+		variable = thisObj.GetValue (thisType.GetField ("myBucket"));
+		StructMirror thisSObj = (StructMirror)variable;
+		thisType = thisSObj.Type;
+		variable = thisSObj.InvokeMethod(e.Thread, thisType.GetMethod("GetEnumerator"), null);
+		thisSObj = (StructMirror)variable;
+		thisType = thisSObj.Type;
+		variable = thisSObj.InvokeMethod(e.Thread, thisType.GetMethod("get_Current"), null);
+		thisSObj = (StructMirror)variable;
+		thisType = thisSObj.Type;
+		AssertValue ("f1", thisSObj["value"]);
+	}
+
+	[Test]
 	public void CheckElapsedTime() {
 		Event e = run_until ("elapsed_time");
 

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -5601,7 +5601,7 @@ decode_value_internal (MonoType *t, int type, MonoDomain *domain, guint8 *addr, 
 			err = decode_vtype (t, domain, addr, buf, &buf, limit);
 			if (err != ERR_NONE)
 				return err;
-		} else  {
+		} else {
 			NOT_IMPLEMENTED;
 		}
 		break;

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -5595,7 +5595,13 @@ decode_value_internal (MonoType *t, int type, MonoDomain *domain, guint8 *addr, 
 				g_free (name);
 				return ERR_INVALID_ARGUMENT;
 			}
-		} else {
+		} else if ((t->type == MONO_TYPE_GENERICINST) && 
+					mono_metadata_generic_class_is_valuetype (t->data.generic_class) &&
+					m_class_is_enumtype (t->data.generic_class->container_class)){
+			err = decode_vtype (t, domain, addr, buf, &buf, limit);
+			if (err != ERR_NONE)
+				return err;
+		} else  {
 			NOT_IMPLEMENTED;
 		}
 		break;
@@ -6039,7 +6045,6 @@ do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, guint8 
 
 		mono_runtime_try_invoke (invoke->method, NULL, invoke->args, &exc, error);
 		mono_error_assert_ok (error);
-
 		g_assert_not_reached ();
 	}
 


### PR DESCRIPTION
Debugger crashes when there is a generic struct with a field that is an enumerator
Example: files.get_Current().Key
A unit test that reproduces this crash was added too.
Fixes #10735