### PR TITLE
[runtime] Fix jit-info.c memory consistency

### DIFF
--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -62,7 +62,7 @@ typedef struct _MonoJitInfoTableChunk MonoJitInfoTableChunk;
 
 struct _MonoJitInfoTableChunk
 {
-	int		       refcount;
+	volatile gint32       refcount;
 	volatile gint32           num_elements;
 	volatile gint8        *last_code_end;
 	MonoJitInfo *next_tombstone;

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -63,7 +63,7 @@ typedef struct _MonoJitInfoTableChunk MonoJitInfoTableChunk;
 struct _MonoJitInfoTableChunk
 {
 	int		       refcount;
-	volatile int           num_elements;
+	volatile gint32           num_elements;
 	volatile gint8        *last_code_end;
 	MonoJitInfo *next_tombstone;
 	MonoJitInfo * volatile data [MONO_JIT_INFO_TABLE_CHUNK_SIZE];

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -1196,8 +1196,20 @@ mono_domain_free (MonoDomain *domain, gboolean force)
 	if (domain->aot_modules)
 		mono_jit_info_table_free (domain->aot_modules);
 	g_assert (domain->num_jit_info_table_duplicates == 0);
-	mono_jit_info_table_free (domain->jit_info_table);
-	domain->jit_info_table = NULL;
+
+	while (TRUE) {
+		gpointer table = mono_atomic_load_ptr ((volatile gpointer *) &domain->jit_info_table);
+
+		if (!table)
+			break;
+
+		gpointer old_table = mono_atomic_cas_ptr ((volatile gpointer *) &domain->jit_info_table, NULL, table);
+		if (table != old_table)
+			continue;
+
+		mono_jit_info_table_free ((MonoJitInfoTable *) table);
+	}
+
 	g_assert (!domain->jit_info_free_queue);
 
 	/* collect statistics */

--- a/mono/metadata/jit-info.c
+++ b/mono/metadata/jit-info.c
@@ -146,10 +146,16 @@ jit_info_table_free_duplicate (MonoJitInfoTable *table)
 	jit_info_table_free (table, TRUE);
 }
 
+static void
+jit_info_table_free_non_duplicate (MonoJitInfoTable *table)
+{
+	jit_info_table_free (table, FALSE);
+}
+
 void
 mono_jit_info_table_free (MonoJitInfoTable *table)
 {
-	jit_info_table_free (table, FALSE);
+	mono_thread_hazardous_try_free (table, (MonoHazardousFreeFunc)jit_info_table_free_non_duplicate);
 }
 
 /* The jit_info_table is sorted in ascending order by the end


### PR DESCRIPTION
In the process of getting the tests added in https://github.com/mono/mono/pull/12125 green, I ran into a lot of data races and use-after-frees in jit-info.c . 

This PR has extracted them, so they can be considered separately. 

