### PR TITLE
[runtime] Fix jemalloc support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5833,7 +5833,7 @@ AC_CONFIG_COMMANDS([nolock-libtool], [sed -e 's/lock_old_archive_extraction=yes/
 AC_CONFIG_COMMANDS([clean-llvm], [rm -f llvm/llvm_config.mk])
 
 # Anything involving -Werror must be done late because autoconf depends on compiling with warnings to be success.
-if test x"$GCC" = xyes; then
+if test x"$GCC" = xyes && "x$with_jemalloc" != "xyes"; then
 
 	# incompatible-pointer-types requires gcc circa 5.x
 

--- a/mono/utils/jemalloc/Makefile.am
+++ b/mono/utils/jemalloc/Makefile.am
@@ -42,7 +42,7 @@ jemalloc:
 # Disable zone allocator, otherwise malloc uses jemalloc for things it's not set for
 # We call autoconf ourselves so we can call configure and not autogen. Autogen script is broken, minor bash issues around quote escaping
 jemalloc/lib/libjemalloc.a: jemalloc Makefile
-	cd jemalloc && autoconf && ./configure --with-jemalloc-prefix=mono_je --prefix=`pwd` $(ASSERT_OPT) $(JEMALLOC_AUTOCONF_FLAGS) --disable-zone-allocator EXTRA_CFLAGS="-I $(top_srcdir) $(GLIB_CFLAGS) $(CFLAGS) $(PLATFORM_CFLAGS) $(ARCH_CFLAGS) $(SHARED_CFLAGS) " CC="$(CC)" CXX="$(CXX)" CPPFLAGS="$(CPPFLAGS) $(JEMALLOC_CPPFLAGS) " CXXFLAGS="$(CXXFLAGS)" LDFLAGS="$(LDFLAGS)"
+	cd jemalloc && autoconf && ./configure --with-jemalloc-prefix=mono_je --prefix=`pwd` --enable-debug $(JEMALLOC_AUTOCONF_FLAGS) --disable-zone-allocator EXTRA_CFLAGS="-I $(top_srcdir) $(GLIB_CFLAGS) $(CFLAGS) $(PLATFORM_CFLAGS) $(ARCH_CFLAGS) $(SHARED_CFLAGS) -Wno-error" CC="$(CC)" CXX="$(CXX)" CPPFLAGS="$(CPPFLAGS) $(JEMALLOC_CPPFLAGS) " CXXFLAGS="$(CXXFLAGS)" LDFLAGS="$(LDFLAGS)"
 
 	cd jemalloc && $(MAKE) build_lib_static 
 


### PR DESCRIPTION
In the process of diagnosing 

https://github.com/mono/mono/pull/12125
and
https://github.com/mono/mono/pull/12387

I needed jemalloc to be fixed because instruments was too heavyweight and I needed the memory assertions (--enable-fill).

This fixes the build with --enable-jemalloc. 