### PR TITLE
[threads] Use refcounts for coordinating finalization and detaching

### DIFF
--- a/mcs/class/corlib/System.Threading/Thread.cs
+++ b/mcs/class/corlib/System.Threading/Thread.cs
@@ -71,7 +71,7 @@ namespace System.Threading {
 		internal int _serialized_principal_version;
 		private IntPtr appdomain_refs;
 		private int interruption_requested;
-		private IntPtr synch_cs;
+		private IntPtr longlived;
 		internal bool threadpool_thread;
 		private bool thread_interrupt_requested;
 		/* These are used from managed code */

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -510,7 +510,7 @@ struct _MonoInternalThread {
 	gpointer unused3;
 	gunichar2  *name;
 	guint32	    name_len;
-	guint32	    state;
+	guint32	    state;      /* must be accessed while longlived->synch_cs is locked */
 	MonoException *abort_exc;
 	int abort_state_handle;
 	guint64 tid;	/* This is accessed as a gsize in the code (so it can hold a 64bit pointer on systems that need it), but needs to reserve 64 bits of space on all machines as it corresponds to a field in managed code */
@@ -524,7 +524,10 @@ struct _MonoInternalThread {
 	gpointer appdomain_refs;
 	/* This is modified using atomic ops, so keep it a gint32 */
 	gint32 __interruption_requested;
-	MonoCoopMutex *synch_cs;
+	/* data that must live as long as this managed object is not finalized
+	 * or as long as the underlying thread is attached, whichever is
+	 * longer */
+	MonoLongLivedThreadData *longlived;
 	MonoBoolean threadpool_thread;
 	MonoBoolean thread_interrupt_requested;
 	int stack_size;

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -106,6 +106,20 @@ mono_thread_create_internal_handle (MonoDomain *domain, T func, gpointer arg, Mo
 }
 #endif
 
+/* Data owned by a MonoInternalThread that must live until both the finalizer
+ * for MonoInternalThread has run, and the underlying machine thread has
+ * detached.
+ *
+ * Normally a thread is first detached and then the InternalThread object is
+ * finalized and collected.  However during shutdown, when the root domain is
+ * finalized, all the InternalThread objects are finalized first and the
+ * machine threads are detached later.
+ */
+typedef struct {
+  MonoRefCount ref;
+  MonoCoopMutex *synch_cs;
+} MonoLongLivedThreadData;
+
 void mono_threads_install_cleanup (MonoThreadCleanupFunc func);
 
 ICALL_EXPORT


### PR DESCRIPTION
Reverts a29ad08d005671163e0c4b1f4d7c92a3d9e8df71 (#9914)

The basic problem we want to solve is the following:
  1. All access to `InternalThread:state` must be protected by the
     `InternalThread:synch_cs` mutex
  2. We must destroy the mutex when we are done with the thread.
  3. We don't know which happens later - detaching the machine thread or
     finalizing its `InternalThread` managed object.

The solution is to replace `InternalThread:synch_c`s by `InternalThread:longlived`
which is a refcounted struct that holds the `synch_cs`.  The refcount starts out
at 2 when the thread is attached to the runtime and when we create the managed
`InternalThread` object that represents it.
Both detaching and finalizing the managed object will decrement the refounct,
and whichever one happens last will be responsible for destroying the mutex.

This addresses https://github.com/mono/mono/issues/11956 which was a race
condition due to the previous attempt to fix this lifetime problem.  The
previous attempt incorrectly used CAS in `mono_thread_detach_internal` while
continuing to use locking of `synch_cs` elsewhere. In particular
`mono_thread_suspend_all_other_threads` could race with
`mono_thread_detach_internal`: it expects to take the thread lock and test
`thread->state` and use the `thread->suspended event`, while detaching deletes
`thread->suspended` without taking a lock.

As a result we had a concurrency bug: in suspend_all_other_threads it's
possible to see both the old (non-Stopped) value of `thread->state` and the
new (NULL) value of `thread->suspended`.  Which leads to crashes.

---

Background - why we don't know if detaching or finalization happens first.

1. `InternalThread` normally outlives the machine thread. This can happen because
when one thread starts another it can hold a reference to the fresh thread's
`Thread` object which holds a reference to the `InternalThread`. So after the
machine thread is done, the older thread can query the state of the younger
`Thread` object. This is the normal situation.

2. During shutdown we can have the opposite situation: the` InternalThread`
objects are finalized first (this happens during root domain finalization), but
the machine threads are still running, and they may still return to
`start_wrapper_internal` and call `detach_internal`. So in this case we have an
`InternalThread` whose finalizer ran first and detach will run second.
