### PR TITLE
[crash] Remove missing LLVM_API_SUPPORT symbol usage

### DIFF
--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -618,20 +618,9 @@ mono_native_state_add_version (MonoStateWriter *writer)
 	mono_state_writer_indent (writer);
 	mono_state_writer_object_key (writer, "interpreter");
 #ifndef DISABLE_INTERPRETER
-	mono_state_writer_printf(writer, "\"enabled\",\n");
+	mono_state_writer_printf(writer, "\"enabled\"\n");
 #else
-	mono_state_writer_printf(writer, "\"disabled\",\n");
-#endif
-
-	assert_has_space (writer);
-	mono_state_writer_indent (writer);
-	mono_state_writer_object_key (writer, "llvm_support");
-#ifdef MONO_ARCH_LLVM_SUPPORTED
-#ifdef ENABLE_LLVM
-	mono_state_writer_printf (writer, "\"%d\"\n", LLVM_API_VERSION);
-#else
-	mono_state_writer_printf (writer, "\"disabled\"\n");
-#endif
+	mono_state_writer_printf(writer, "\"disabled\"\n");
 #endif
 
 	assert_has_space (writer);


### PR DESCRIPTION
According to @akoeplinger we are seeing a failure on CI:

```
mono-state.c:631:48: error: use of undeclared identifier 'LLVM_API_VERSION'
20:28:52         mono_state_writer_printf (writer, "\"%d\"\n", LLVM_API_VERSION);
```

I've removed that here. 

Note that this is the last item in the JSON list, so we have to preserve the lack of a trailing comma. That's why Github renders this diff like so.