### PR TITLE
[bcl] Embed Source Link information

### DIFF
--- a/mcs/build/Makefile
+++ b/mcs/build/Makefile
@@ -19,7 +19,7 @@ common/Consts.cs $(topdir)/class/lib/$(PROFILE_DIRECTORY)/Consts.cs: common/Cons
 	sed -e 's,@''MONO_VERSION@,$(MONO_VERSION),' -e 's,@''MONO_CORLIB_VERSION@,$(MONO_CORLIB_VERSION),' $< > $@
 
 common/sourcelink.json: common/sourcelink.json.in $(wildcard config.make) | $(topdir)/class/lib/$(PROFILE_DIRECTORY)
-	sed -e 's,@mono_topdir@,$(shell cd $(topdir)/.. && pwd),' -e 's,@mono_commit_hash@,$(shell cd $(topdir)/.. && git rev-parse HEAD),' -e 's,@corefx_commit_hash@,$(shell cd $(topdir)/../external/corefx && git rev-parse HEAD),' -e 's,@corert_commit_hash@,$(shell cd $(topdir)/../external/corert && git rev-parse HEAD),' $< > $@
+	sed -e 's,@mono_topdir@,$(shell cd $(topdir)/.. && pwd),' -e 's,@mono_commit_hash@,$(shell cd $(topdir)/.. && git rev-parse HEAD),' -e 's,@corefx_commit_hash@,$(shell cd $(topdir)/../external/corefx && git rev-parse HEAD),' -e 's,@corert_commit_hash@,$(shell cd $(topdir)/../external/corert && git rev-parse HEAD),' -e 's,@cecil_commit_hash@,$(shell cd $(topdir)/../external/cecil && git rev-parse HEAD),' $< > $@
 
 PLATFORMS = macos linux win32 unix
 PROFILES = \

--- a/mcs/build/Makefile
+++ b/mcs/build/Makefile
@@ -2,7 +2,7 @@ thisdir = build
 SUBDIRS = 
 include ../build/rules.make
 
-BUILT_FILES = common/Consts.cs $(topdir)/class/lib/$(PROFILE_DIRECTORY)/Consts.cs
+BUILT_FILES = common/Consts.cs $(topdir)/class/lib/$(PROFILE_DIRECTORY)/Consts.cs common/sourcelink.json
 
 all-local install-local test-local run-test-local csproj-local run-test-ondotnet-local uninstall-local doc-update-local: $(BUILT_FILES)
 	@:
@@ -18,6 +18,9 @@ common/Consts.cs $(topdir)/class/lib/$(PROFILE_DIRECTORY)/Consts.cs: common/Cons
 	test -n '$(MONO_CORLIB_VERSION)'
 	sed -e 's,@''MONO_VERSION@,$(MONO_VERSION),' -e 's,@''MONO_CORLIB_VERSION@,$(MONO_CORLIB_VERSION),' $< > $@
 
+common/sourcelink.json: common/sourcelink.json.in $(wildcard config.make) | $(topdir)/class/lib/$(PROFILE_DIRECTORY)
+	sed -e 's,@mono_topdir@,$(shell cd $(topdir)/.. && pwd),' -e 's,@mono_commit_hash@,$(shell cd $(topdir)/.. && git rev-parse HEAD),' -e 's,@corefx_commit_hash@,$(shell cd $(topdir)/../external/corefx && git rev-parse HEAD),' -e 's,@corert_commit_hash@,$(shell cd $(topdir)/../external/corert && git rev-parse HEAD),' $< > $@
+
 PLATFORMS = macos linux win32 unix
 PROFILES = \
 	build \
@@ -28,6 +31,7 @@ PROFILES = \
 
 COMMON_SRCS = \
 	Consts.cs.in			\
+	common/sourcelink.json.in	\
 	Locale.cs			\
 	MonoTODOAttribute.cs \
 	basic-profile-check.cs		\

--- a/mcs/build/common/.gitignore
+++ b/mcs/build/common/.gitignore
@@ -1,1 +1,2 @@
 /Consts.cs
+/sourcelink.json

--- a/mcs/build/common/sourcelink.json.in
+++ b/mcs/build/common/sourcelink.json.in
@@ -1,0 +1,7 @@
+{
+    "documents": {
+        "@mono_topdir@/external/corefx/*": "https://raw.githubusercontent.com/dotnet/corefx/@corefx_commit_hash@/*",
+        "@mono_topdir@/external/corert/*": "https://raw.githubusercontent.com/dotnet/corert/@corert_commit_hash@/*",
+        "@mono_topdir@/*": "https://raw.githubusercontent.com/mono/mono/@mono_commit_hash@/*"
+    }
+}

--- a/mcs/build/common/sourcelink.json.in
+++ b/mcs/build/common/sourcelink.json.in
@@ -1,7 +1,8 @@
 {
     "documents": {
-        "@mono_topdir@/external/corefx/*": "https://raw.githubusercontent.com/dotnet/corefx/@corefx_commit_hash@/*",
-        "@mono_topdir@/external/corert/*": "https://raw.githubusercontent.com/dotnet/corert/@corert_commit_hash@/*",
+        "@mono_topdir@/external/corefx/*": "https://raw.githubusercontent.com/mono/corefx/@corefx_commit_hash@/*",
+        "@mono_topdir@/external/corert/*": "https://raw.githubusercontent.com/mono/corert/@corert_commit_hash@/*",
+        "@mono_topdir@/external/cecil/*": "https://raw.githubusercontent.com/mono/cecil/@cecil_commit_hash@/*",
         "@mono_topdir@/*": "https://raw.githubusercontent.com/mono/mono/@mono_commit_hash@/*"
     }
 }

--- a/mcs/build/library.make
+++ b/mcs/build/library.make
@@ -72,6 +72,11 @@ endif
 endif
 endif
 
+# add sourcelink information if we're building a portable PDB
+ifneq (, $(findstring debug:portable, $(PROFILE_MCS_FLAGS)))
+LIB_MCS_FLAGS += -sourcelink:$(topdir)/build/common/sourcelink.json
+endif
+
 the_libdir = $(the_libdir_base)$(intermediate)
 
 ifdef LIBRARY_USE_INTERMEDIATE_FILE

--- a/msvc/scripts/genproj.cs
+++ b/msvc/scripts/genproj.cs
@@ -713,6 +713,9 @@ public class MsbuildGenerator {
 
 		case "/features":
 			return true;
+
+		case "/sourcelink":
+			return true;
 		}
 
 		Console.Error.WriteLine ($"// Failing with : {arg}");


### PR DESCRIPTION
Source Link allows IDEs/debuggers to retrieve a source file from a remote location like GitHub when the local file isn't available.

Specification: https://github.com/dotnet/designs/blob/e55c517a1e7f8dc35b092397058029531209d610/accepted/diagnostics/source-link.md

For now we only embed info about mono, cecil, corefx and corert since that covers 99% of what you usually want to debug and doesn't need fancy logic that reads git submodules and figures out their URLs.

Should enable use cases like https://twitter.com/jlaban/status/1084248087802060801 (/cc @jeromelaban)