### PR TITLE
[2018-08][debugger][backport] Fix crash when there is a generic struct with a field that is an enumerator

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -85,6 +85,31 @@ public class Tests2 {
 	}
 }
 
+public struct TestEnumeratorInsideGenericStruct<TKey, TValue>
+{
+	private KeyValuePair<TKey, TValue> _bucket;
+	private Position _currentPosition;
+	internal TestEnumeratorInsideGenericStruct(KeyValuePair<TKey, TValue> bucket)
+	{
+		_bucket = bucket;
+		_currentPosition = Position.BeforeFirst;
+	}
+
+	public KeyValuePair<TKey, TValue> Current
+	{
+		get
+		{
+			if (_currentPosition == Position.BeforeFirst)
+				return _bucket;
+			return _bucket;
+		}
+	}
+	private enum Position
+	{
+		BeforeFirst
+	}
+}
+
 public struct AStruct : ITest2 {
 	public int i;
 	public string s;
@@ -384,6 +409,7 @@ public class Tests : TestsBase, ITest2
 			new Tests ().invoke_abort ();
 		new Tests ().evaluate_method ();
 		Bug59649 ();
+		inspect_enumerator_in_generic_struct();
 		return 3;
 	}
 
@@ -577,6 +603,32 @@ public class Tests : TestsBase, ITest2
 	}
 
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+<<<<<<< HEAD
+=======
+	public static void ss_nested_with_three_args_wrapper () {
+		ss_nested_with_three_args(ss_nested_arg1 (), ss_nested_arg2 (), ss_nested_arg3 ());
+	}
+
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	public static void ss_nested_twice_with_two_args_wrapper () {
+		ss_nested_with_two_args(ss_nested_arg1 (), ss_nested_with_two_args(ss_nested_arg2 (), ss_nested_arg3 ()));
+	}
+  
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	public static void elapsed_time () {
+		Thread.Sleep(200);
+		Thread.Sleep(00);
+		Thread.Sleep(100);
+		Thread.Sleep(300);
+	}
+	
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	public static void inspect_enumerator_in_generic_struct() {
+		TestEnumeratorInsideGenericStruct<String, String> generic_struct = new TestEnumeratorInsideGenericStruct<String, String>(new KeyValuePair<string, string>("0", "f1"));
+	}
+
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+>>>>>>> 141bec26a55... [Debugger] Fix crash when there is a generic struct with a field that is an enumerator. (#12368)
 	public static int ss_nested_with_two_args (int a1, int a2) {
 		return a1 + a2;
 	}

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -603,32 +603,11 @@ public class Tests : TestsBase, ITest2
 	}
 
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]
-<<<<<<< HEAD
-=======
-	public static void ss_nested_with_three_args_wrapper () {
-		ss_nested_with_three_args(ss_nested_arg1 (), ss_nested_arg2 (), ss_nested_arg3 ());
-	}
-
-	[MethodImplAttribute (MethodImplOptions.NoInlining)]
-	public static void ss_nested_twice_with_two_args_wrapper () {
-		ss_nested_with_two_args(ss_nested_arg1 (), ss_nested_with_two_args(ss_nested_arg2 (), ss_nested_arg3 ()));
-	}
-  
-	[MethodImplAttribute (MethodImplOptions.NoInlining)]
-	public static void elapsed_time () {
-		Thread.Sleep(200);
-		Thread.Sleep(00);
-		Thread.Sleep(100);
-		Thread.Sleep(300);
-	}
-	
-	[MethodImplAttribute (MethodImplOptions.NoInlining)]
 	public static void inspect_enumerator_in_generic_struct() {
 		TestEnumeratorInsideGenericStruct<String, String> generic_struct = new TestEnumeratorInsideGenericStruct<String, String>(new KeyValuePair<string, string>("0", "f1"));
 	}
 
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]
->>>>>>> 141bec26a55... [Debugger] Fix crash when there is a generic struct with a field that is an enumerator. (#12368)
 	public static int ss_nested_with_two_args (int a1, int a2) {
 		return a1 + a2;
 	}

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -4462,6 +4462,25 @@ public class DebuggerTests
 	}
 
 	[Test]
+	public void InspectEnumeratorInGenericStruct() {
+		//files.myBucket.GetEnumerator().get_Current().Key watching this generates an exception in Debugger
+		Event e = run_until("inspect_enumerator_in_generic_struct");
+		var req = create_step(e);
+		req.Enable();
+		e = step_once();
+		e = step_over();
+		StackFrame frame = e.Thread.GetFrames () [0];
+		var ginst = frame.Method.GetLocal ("generic_struct");
+		Value variable = frame.GetValue (ginst);
+		StructMirror thisObj = (StructMirror)variable;
+		TypeMirror thisType = thisObj.Type;
+		variable = thisObj.InvokeMethod(e.Thread, thisType.GetMethod("get_Current"), null);
+		thisObj = (StructMirror)variable;
+		thisType = thisObj.Type;
+		AssertValue ("f1", thisObj["value"]);
+	}
+
+	[Test]
 	// Uses a fixed port
 	[Category("NotWorking")]
 	public void Attach () {

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -5957,6 +5957,7 @@ do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, guint8 
 
 		mono_runtime_try_invoke (invoke->method, NULL, invoke->args, &exc, error);
 		mono_error_assert_ok (error);
+
 		g_assert_not_reached ();
 	}
 

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -5510,6 +5510,12 @@ decode_value_internal (MonoType *t, int type, MonoDomain *domain, guint8 *addr, 
 				g_free (name);
 				return ERR_INVALID_ARGUMENT;
 			}
+		} else if ((t->type == MONO_TYPE_GENERICINST) && 
+					mono_metadata_generic_class_is_valuetype (t->data.generic_class) &&
+					m_class_is_enumtype (t->data.generic_class->container_class)){
+			err = decode_vtype (t, domain, addr, buf, &buf, limit);
+			if (err != ERR_NONE)
+				return err;
 		} else {
 			NOT_IMPLEMENTED;
 		}
@@ -5951,7 +5957,6 @@ do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, guint8 
 
 		mono_runtime_try_invoke (invoke->method, NULL, invoke->args, &exc, error);
 		mono_error_assert_ok (error);
-
 		g_assert_not_reached ();
 	}
 


### PR DESCRIPTION
Debugger crashes when there is a generic struct with a field that is an enumerator
Example: files.get_Current().Key
A unit test that reproduces this crash was added too.
Fixes #10735

Backport https://github.com/mono/mono/pull/12368