### PR TITLE
[wasm] Build target fixes

### DIFF
--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -268,13 +268,15 @@ clean:
 	$(RM) -r binding-tests.dll
 	$(RM) -r sdk/**/bin
 	$(RM) -r sdk/**/obj
+	$(RM) -r sdk/**/**/bin
+	$(RM) -r sdk/**/**/obj
 	$(RM) -r sdk/packages
 	$(RM) -r $(WASM_FRAMEWORK)/.stamp-framework
+	$(RM) -r $(WASM_FRAMEWORK)/netstandard2.0
 	$(RM) $(WASM_FRAMEWORK)/WebAssembly.Bindings.dll
 	$(RM) $(WASM_FRAMEWORK)/WebAssembly.Bindings.pdb
 	$(RM) $(WASM_FRAMEWORK)/WebAssembly.Net.Http.dll
 	$(RM) $(WASM_FRAMEWORK)/WebAssembly.Net.Http.pdb
-
 
 package: build build-dbg-proxy
 	rm -rf tmp
@@ -329,3 +331,7 @@ canary:
 	/Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary --remote-debugging-port=9222
 
 check-aot: do-aot-sample
+
+build-sdk: $(WASM_FRAMEWORK)/.stamp-framework
+	msbuild /r sdk/Mono.WebAssembly.Sdk
+	msbuild /r sdk

--- a/sdks/wasm/framework/.gitignore
+++ b/sdks/wasm/framework/.gitignore
@@ -1,2 +1,4 @@
 *.xml
 *.json
+!src/WebAssembly.Bindings/LinkDescriptor/*
+!src/WebAssembly.Net.Http/LinkDescriptor/*

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/LinkDescriptor/WebAssembly.Bindings.xml
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/LinkDescriptor/WebAssembly.Bindings.xml
@@ -1,0 +1,7 @@
+<linker>
+  
+  <!--
+  Preserve the entire assembly
+  -->
+  <assembly fullname="WebAssembly.Bindings, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" preserve="all"/>
+</linker>

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/LinkDescriptor/WebAssembly.Bindings.xml
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/LinkDescriptor/WebAssembly.Bindings.xml
@@ -3,5 +3,5 @@
   <!--
   Preserve the entire assembly
   -->
-  <assembly fullname="WebAssembly.Bindings, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" preserve="all"/>
+  <assembly fullname="WebAssembly.Bindings" preserve="all"/>
 </linker>

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/WebAssembly.Bindings.csproj
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/WebAssembly.Bindings.csproj
@@ -15,4 +15,12 @@
     <OutputPath>..\..\</OutputPath>
     <DocumentationFile>..\..\netstandard2.0\WebAssembly.Bindings.xml</DocumentationFile>
   </PropertyGroup>
+  <ItemGroup>
+    <None Remove="LinkDescriptor\WebAssembly.Bindings.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="LinkDescriptor\WebAssembly.Bindings.xml">
+      <LogicalName>WebAssembly.Bindings.xml</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/sdks/wasm/framework/src/WebAssembly.Net.Http/LinkDescriptor/WebAssembly.Net.Http.xml
+++ b/sdks/wasm/framework/src/WebAssembly.Net.Http/LinkDescriptor/WebAssembly.Net.Http.xml
@@ -1,0 +1,7 @@
+<linker>
+  
+  <!--
+  Preserve the entire assembly
+  -->
+  <assembly fullname="WebAssembly.Net.Http" preserve="all"/>
+</linker>

--- a/sdks/wasm/framework/src/WebAssembly.Net.Http/WebAssembly.Net.Http.csproj
+++ b/sdks/wasm/framework/src/WebAssembly.Net.Http/WebAssembly.Net.Http.csproj
@@ -18,4 +18,13 @@
   <ItemGroup>
     <ProjectReference Include="..\WebAssembly.Bindings\WebAssembly.Bindings.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <None Remove="LinkDescriptor\WebAssembly.Net.Http.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="LinkDescriptor\WebAssembly.Net.Http.xml">
+      <LogicalName>WebAssembly.Net.Http.xml</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
 </Project>

--- a/sdks/wasm/sdk/Mono.WebAssembly.Build/WasmLinkAssemblies.cs
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Build/WasmLinkAssemblies.cs
@@ -117,6 +117,9 @@ namespace Mono.WebAssembly.Build
 
 			sb.AppendFormat (" -c {0} -u {1}", coremode, usermode);
 
+			//the linker doesn't consider these core by default
+			sb.AppendFormat (" -p {0} netstandard -p {0} WebAssembly.Bindings -p {0} WebAssembly.Net.Http", coremode);
+
 			if (!string.IsNullOrEmpty (LinkSkip)) {
 				var skips = LinkSkip.Split (new[] { ';', ',', ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
 				foreach (var s in skips) {

--- a/sdks/wasm/sdk/WebAssembly.Net.Http.Framework/WebAssembly.Net.Http.csproj
+++ b/sdks/wasm/sdk/WebAssembly.Net.Http.Framework/WebAssembly.Net.Http.csproj
@@ -10,4 +10,7 @@
     <None Include="..\..\..\wasm\framework\WebAssembly.Net.Http.dll" PackagePath="lib\netstandard2.0\%(Filename)%(Extension)" Pack="True" />
     <None Include="..\..\..\wasm\framework\WebAssembly.Net.Http.pdb" PackagePath="lib\netstandard2.0\%(Filename)%(Extension)" Pack="True" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\WebAssembly.Bindings.Framework\WebAssembly.Bindings.csproj" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
- Add linker xml descriptor to WebAssembly.Bindings and WebAssembly.Net.Http
   - The XML linker descriptor will keep the full assembly for these assemblies during link.

- Fix Link Assemblies command line.
   - Miscellaneous fixes for how the assemblies are linked whether they are framework or facades.
   - Add the Facades directory to the resolve paths.