### PR TITLE
[mini] re-enable LLVM for Linux JIT

### DIFF
--- a/mono/mini/llvm-jit.h
+++ b/mono/mini/llvm-jit.h
@@ -21,9 +21,9 @@
 #endif
 
 /* These can't go into mini-<ARCH>.h since thats not included into llvm-jit.cpp */
-#if defined(TARGET_AMD64) && defined(TARGET_OSX)
+#if defined(TARGET_AMD64) && (defined(TARGET_OSX)||defined(__linux__))
 #define MONO_ARCH_LLVM_JIT_SUPPORTED 1
-#elif defined(TARGET_X86) && defined(TARGET_OSX)
+#elif defined(TARGET_X86) && (defined(TARGET_OSX)||defined(__linux__))
 #define MONO_ARCH_LLVM_JIT_SUPPORTED 1
 #endif
 


### PR DESCRIPTION
This re-enables the Linux JIT as suggested in https://github.com/mono/mono/issues/12030