### PR TITLE
[sdks,mac] Remove dependency on MXE in favor of MinGW

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -640,6 +640,13 @@ if test x$have_zlib = xyes; then
    ])
 fi
 
+AC_ARG_WITH(static-zlib, [  --with-static-zlib=PATH    use the specified static zlib instead of -lz],[STATIC_ZLIB_PATH=$with_static_zlib],[STATIC_ZLIB_PATH=])
+if test "x$STATIC_ZLIB_PATH" != "x"; then
+	have_static_zlib=yes
+	AC_SUBST(STATIC_ZLIB_PATH)
+fi
+
+AM_CONDITIONAL(HAVE_STATIC_ZLIB, test x$have_static_zlib = xyes)
 AM_CONDITIONAL(HAVE_ZLIB, test x$have_zlib = xyes)
 AC_DEFINE(HAVE_ZLIB,1,[Have system zlib])
 

--- a/llvm/Makefile.am
+++ b/llvm/Makefile.am
@@ -9,10 +9,14 @@ else
 llvm_config=llvm-config
 endif
 
+if HAVE_STATIC_ZLIB
+llvm_extra_libs = $(STATIC_ZLIB_PATH)
+else
 if HAVE_ZLIB
 llvm_extra_libs=-lz
 else
 llvm_extra_libs=
+endif
 endif
 
 if INTERNAL_LLVM

--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -158,8 +158,12 @@ libmonoruntime_config_la_CPPFLAGS = $(AM_CPPFLAGS) -DMONO_BINDIR=\"$(bindir)/\" 
 #
 libmonoruntime_support_la_SOURCES = $(support_sources)
 libmonoruntime_support_la_CFLAGS = $(filter-out @CXX_REMOVE_CFLAGS@, @CFLAGS@)
+if HAVE_STATIC_ZLIB
+libmonoruntime_support_la_LDFLAGS = $(STATIC_ZLIB_PATH)
+else
 if HAVE_ZLIB
 libmonoruntime_support_la_LDFLAGS = -lz
+endif
 endif
 
 #

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -15,6 +15,13 @@
  */
 
 #include <config.h>
+
+#if defined(TARGET_WIN32) || defined(HOST_WIN32)
+/* Needed for _ecvt_s */
+#define MINGW_HAS_SECURE_API 1
+#include <stdio.h>
+#endif
+
 #include <glib.h>
 #include <stdarg.h>
 #include <string.h>
@@ -31,6 +38,7 @@
 #if defined (HAVE_WCHAR_H)
 #include <wchar.h>
 #endif
+
 #include "mono/metadata/icall-internals.h"
 #include "mono/utils/mono-membar.h"
 #include <mono/metadata/object.h>

--- a/mono/profiler/Makefile.am
+++ b/mono/profiler/Makefile.am
@@ -97,11 +97,15 @@ endif
 endif
 endif
 
+if HAVE_STATIC_ZLIB
+zlib_dep = $(STATIC_ZLIB_PATH)
+else
 if HAVE_ZLIB
 # The log profiler uses zlib for output compression when available.
 zlib_dep = -lz
 else
 zlib_dep =
+endif
 endif
 
 # We build a separate, static version of each profiler for use on targets

--- a/scripts/ci/pipeline/sdks-archive.groovy
+++ b/scripts/ci/pipeline/sdks-archive.groovy
@@ -88,9 +88,9 @@ def archive (product, configuration, platform, chrootname = "", chrootadditional
                     // build the Archive
                     timeout (time: 300, unit: 'MINUTES') {
                         if (platform == "Darwin") {
-                            def brewpackages = "autoconf automake ccache cmake coreutils gdk-pixbuf gettext glib gnu-sed gnu-tar intltool ios-deploy jpeg libffi libidn2 libpng libtiff libtool libunistring ninja openssl p7zip pcre pkg-config scons wget xz mingw-w64 make"
+                            def brewpackages = "autoconf automake ccache cmake coreutils gdk-pixbuf gettext glib gnu-sed gnu-tar intltool ios-deploy jpeg libffi libidn2 libpng libtiff libtool libunistring ninja openssl p7zip pcre pkg-config scons wget xz mingw-w64 make xamarin/xamarin-android-windeps/mingw-zlib"
+                            sh "brew tap xamarin/xamarin-android-windeps"
                             sh "brew install ${brewpackages} || brew upgrade ${brewpackages}"
-
                             sh "CI_TAGS=sdks-${product},no-tests,${configuration} scripts/ci/run-jenkins.sh"
                         } else if (platform == "Linux") {
                             chroot chrootName: chrootname,

--- a/sdks/builds/android.mk
+++ b/sdks/builds/android.mk
@@ -195,25 +195,25 @@ define AndroidHostMxeTemplate
 
 _android-$(1)_PATH=$$(MXE_PREFIX)/bin
 
-_android-$(1)_AR=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-ar
-_android-$(1)_AS=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-as
-_android-$(1)_CC=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-gcc
-_android-$(1)_CXX=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-g++
-_android-$(1)_DLLTOOL=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-dlltool
-_android-$(1)_LD=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-ld
-_android-$(1)_OBJDUMP=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-objdump
-_android-$(1)_RANLIB=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-ranlib
-_android-$(1)_STRIP=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-strip
+_android-$(1)_AR=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-ar
+_android-$(1)_AS=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-as
+_android-$(1)_CC=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-gcc
+_android-$(1)_CXX=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-g++
+_android-$(1)_DLLTOOL=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-dlltool
+_android-$(1)_LD=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-ld
+_android-$(1)_OBJDUMP=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-objdump
+_android-$(1)_RANLIB=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-ranlib
+_android-$(1)_STRIP=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-strip
 
 _android-$(1)_AC_VARS= \
 	ac_cv_header_zlib_h=no \
 	ac_cv_search_dlopen=no
 
 _android-$(1)_CFLAGS= \
-	-DXAMARIN_PRODUCT_VERSION=0
+	-DXAMARIN_PRODUCT_VERSION=0 -I$$(MXE_PREFIX)/opt/mingw-zlib/usr/$(2)-w64-mingw32/include
 
 _android-$(1)_CXXFLAGS= \
-	-DXAMARIN_PRODUCT_VERSION=0
+	-DXAMARIN_PRODUCT_VERSION=0 -I$$(MXE_PREFIX)/opt/mingw-zlib/usr/$(2)-w64-mingw32/include
 
 _android-$(1)_CONFIGURE_FLAGS= \
 	--disable-boehm \
@@ -225,12 +225,17 @@ _android-$(1)_CONFIGURE_FLAGS= \
 	--with-monodroid \
 	--disable-crash-reporting
 
+ifeq ($(UNAME),Darwin)
+_android-$(1)_LDFLAGS= \
+	$$(MXE_PREFIX)/opt/mingw-zlib/usr/$(2)-w64-mingw32/lib/libz.a
+endif
+
 .stamp-android-$(1)-toolchain:
 	touch $$@
 
 .stamp-android-$(1)-$$(CONFIGURATION)-configure: | $(if $(IGNORE_PROVISION_MXE),,provision-mxe)
 
-$$(eval $$(call RuntimeTemplate,android,$(1),$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)))
+$$(eval $$(call RuntimeTemplate,android,$(1),$(2)-w64-mingw32))
 
 endef
 
@@ -298,32 +303,30 @@ _android-$(1)_OFFSETS_DUMPER_ARGS=--gen-android --android-ndk="$$(ANDROID_TOOLCH
 
 _android-$(1)_PATH=$$(MXE_PREFIX)/bin
 
-_android-$(1)_AR=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-ar
-_android-$(1)_AS=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-as
-_android-$(1)_CC=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-gcc
-_android-$(1)_CXX=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-g++
-_android-$(1)_DLLTOOL=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-dlltool
-_android-$(1)_LD=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-ld
-_android-$(1)_OBJDUMP=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-objdump
-_android-$(1)_RANLIB=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-ranlib
-_android-$(1)_STRIP=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-strip
+_android-$(1)_AR=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-ar
+_android-$(1)_AS=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-as
+_android-$(1)_CC=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-gcc
+_android-$(1)_CXX=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-g++
+_android-$(1)_DLLTOOL=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-dlltool
+_android-$(1)_LD=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-ld
+_android-$(1)_OBJDUMP=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-objdump
+_android-$(1)_RANLIB=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-ranlib
+_android-$(1)_STRIP=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-strip
 
 _android-$(1)_CFLAGS= \
 	$$(if $$(RELEASE),,-DDEBUG_CROSS) \
-	-static \
 	-static-libgcc \
-	-DXAMARIN_PRODUCT_VERSION=0
+	-DXAMARIN_PRODUCT_VERSION=0 \
+	-I$$(MXE_PREFIX)/opt/mingw-zlib/usr/$(2)-w64-mingw32/include
 
 _android-$(1)_CXXFLAGS= \
 	$$(if $$(RELEASE),,-DDEBUG_CROSS) \
-	-static \
 	-static-libgcc \
-	-DXAMARIN_PRODUCT_VERSION=0
+	-DXAMARIN_PRODUCT_VERSION=0 \
+	-I$$(MXE_PREFIX)/opt/mingw-zlib/usr/$(2)-w64-mingw32/include
 
 _android-$(1)_LDFLAGS= \
-	-static \
-	-static-libgcc \
-	-static-libstdc++
+	-static-libgcc
 
 _android-$(1)_CONFIGURE_FLAGS= \
 	--disable-boehm \
@@ -332,9 +335,14 @@ _android-$(1)_CONFIGURE_FLAGS= \
 	--enable-maintainer-mode \
 	--with-tls=pthread
 
+ifeq ($(UNAME),Darwin)
+_android-$(1)_CONFIGURE_FLAGS += \
+	--with-static-zlib=$$(MXE_PREFIX)/opt/mingw-zlib/usr/$(2)-w64-mingw32/lib/libz.a
+endif
+
 .stamp-android-$(1)-$$(CONFIGURATION)-configure: | $(if $(IGNORE_PROVISION_MXE),,provision-mxe)
 
-$$(eval $$(call CrossRuntimeTemplate,android,$(1),$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static),$(3)-linux-android,$(4),$(5),$(6)))
+$$(eval $$(call CrossRuntimeTemplate,android,$(1),$(2)-w64-mingw32,$(3)-linux-android,$(4),$(5),$(6)))
 
 endef
 

--- a/sdks/builds/llvm.mk
+++ b/sdks/builds/llvm.mk
@@ -148,8 +148,13 @@ _llvm-$(1)_CMAKE_ARGS = \
 	-DLLVM_BUILD_EXECUTION_ENGINE=Off \
 	$$(llvm-$(1)_CMAKE_ARGS)
 
+ifeq ($(UNAME),Darwin)
+_llvm-$(1)_CMAKE_ARGS += \
+	-DZLIB_ROOT=$$(MXE_PREFIX)/opt/mingw-zlib/usr/$(2)-w64-mingw32 -DZLIB_LIBRARY=$$(MXE_PREFIX)/opt/mingw-zlib/usr/$(2)-w64-mingw32/lib/libz.a -DZLIB_INCLUDE_DIR=$$(MXE_PREFIX)/opt/mingw-zlib/usr/$(2)-w64-mingw32/include
+endif
+
 $$(TOP)/external/llvm/cmake/modules/$(3).cmake: $(3).cmake.in
-	sed -e 's,@MXE_PATH@,$$(MXE_PREFIX),' -e 's,@MXE_SUFFIX@,$$(if $$(filter $(UNAME),Darwin),.static),' < $$< > $$@
+	sed -e 's,@MXE_PATH@,$$(MXE_PREFIX),' < $$< > $$@
 
 .PHONY: setup-llvm-$(1)
 setup-llvm-$(1):

--- a/sdks/builds/mxe-Win32.cmake.in
+++ b/sdks/builds/mxe-Win32.cmake.in
@@ -5,9 +5,9 @@ set(CMAKE_SYSTEM_NAME Windows)
 set(CMAKE_FIND_ROOT_PATH @MXE_PATH@)
 
 # which compilers to use for C and C++
-set(CMAKE_C_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/i686-w64-mingw32@MXE_SUFFIX@-gcc)
-set(CMAKE_CXX_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/i686-w64-mingw32@MXE_SUFFIX@-g++)
-set(CMAKE_RC_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/i686-w64-mingw32@MXE_SUFFIX@-windres)
+set(CMAKE_C_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/i686-w64-mingw32-gcc)
+set(CMAKE_CXX_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/i686-w64-mingw32-g++)
+set(CMAKE_RC_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/i686-w64-mingw32-windres)
 
 # adjust the default behaviour of the FIND_XXX() commands:
 # search headers and libraries in the target environment, search

--- a/sdks/builds/mxe-Win64.cmake.in
+++ b/sdks/builds/mxe-Win64.cmake.in
@@ -5,9 +5,9 @@ set(CMAKE_SYSTEM_NAME Windows)
 set(CMAKE_FIND_ROOT_PATH @MXE_PATH@)
 
 # which compilers to use for C and C++
-set(CMAKE_C_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/x86_64-w64-mingw32@MXE_SUFFIX@-gcc)
-set(CMAKE_CXX_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/x86_64-w64-mingw32@MXE_SUFFIX@-g++)
-set(CMAKE_RC_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/x86_64-w64-mingw32@MXE_SUFFIX@-windres)
+set(CMAKE_C_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/x86_64-w64-mingw32-gcc)
+set(CMAKE_CXX_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/x86_64-w64-mingw32-g++)
+set(CMAKE_RC_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/x86_64-w64-mingw32-windres)
 
 # adjust the default behaviour of the FIND_XXX() commands:
 # search headers and libraries in the target environment, search

--- a/sdks/builds/mxe.mk
+++ b/sdks/builds/mxe.mk
@@ -13,23 +13,12 @@ MXE_PREFIX=/usr
 provision-mxe:
 	@echo $(LINUX_FLAVOR) Linux does not require mxe provisioning. mingw from packages is used instead
 else
-MXE_SRC?=$(TOP)/sdks/builds/toolchains/mxe
-MXE_PREFIX_DIR?=$(HOME)/android-toolchain
-
-# This is not overridable
-MXE_PREFIX:=$(MXE_PREFIX_DIR)/mxe-$(shell echo $(MXE_HASH) | head -c 7)
-
-$(MXE_PREFIX)/.stamp:
-	rm -rf $(MXE_PREFIX) $(MXE_SRC)
-	git clone -b xamarin https://github.com/xamarin/mxe.git $(MXE_SRC) \
-		&& git -C $(MXE_SRC) checkout $(MXE_HASH)
-	$(MAKE) -C $(MXE_SRC) gcc cmake zlib pthreads dlfcn-win32 mman-win32 \
-		PREFIX="$(MXE_PREFIX)" MXE_TARGETS="i686-w64-mingw32.static x86_64-w64-mingw32.static" \
-			OS_SHORT_NAME="disable-native-plugins" PATH="$$PATH:$(MXE_PREFIX)/bin:$(dir $(shell brew list gettext | grep bin/autopoint$))"
-	touch $@
+MXE_PREFIX:=$(shell brew --prefix)
 
 .PHONY: provision-mxe
-provision-mxe: $(MXE_PREFIX)/.stamp
+provision-mxe:
+	brew tap xamarin/xamarin-android-windeps
+	brew install mingw-w64 xamarin/xamarin-android-windeps/mingw-zlib
 endif
 
 .PHONY: provision

--- a/support/Makefile.am
+++ b/support/Makefile.am
@@ -99,12 +99,17 @@ ZLIB_SOURCES = \
 	zlib.h  	\
 	zutil.h
 
+if HAVE_STATIC_ZLIB
+Z_SOURCE = zlib-helper.c
+Z_LIBS = $(STATIC_ZLIB_PATH)
+else
 if HAVE_ZLIB
 Z_SOURCE = zlib-helper.c
 Z_LIBS= -lz
 else
 Z_SOURCE = zlib-helper.c $(ZLIB_SOURCES)
 Z_LIBS=
+endif
 endif
 
 libMonoPosixHelper_la_SOURCES =			\


### PR DESCRIPTION
It turns out that homebrew now has a package for the MinGW gcc-based windows
cross compiler which is awesome as it allows us to skip building MXE and use the
latest version of the GCC suite pre-packaged for Mac. This commit removes almost
all traces of MXE (except for `mxe.mk` itself, because I don't know if any bot
or external tool, whatever, use targets in it) and adds the following brew
packages to SDK bot provisioning as well as to the `provision-mxe` target of
Mono SDKs:

  * mingw-w64
  * xamarin/xamarin-android-windeps/mingw-zlib

The latter package builds a Windows version of zlib using MinGW and it comes
from Xamarin's own homebrew tap at https://github.com/xamarin/homebrew-xamarin-android-windeps/blob/f4cc90845ff1953800d8d71035566a12d9b7aa24/mingw-zlib.rb

A few things need to be solved before this PR builds successfully:

- [x]  zlib must be built for Windows before LLVM build is attempted
   * Installed by `homebrew` from our own tap
- [x] something must be done about [32-bit builds](https://gist.github.com/grendello/f488ecd69475286154e18838c0441e8a) on Mojave (I have Mojave and I can't complete the build atm)
   * Solved by installing Apple command line tools for Xcode 9.4.1 and macOS 10.13
