### PR TITLE
[System.IO.Compression]: Correctly handle exceptions in inner stream.  #12205.

### DIFF
--- a/mcs/class/System/System.IO.Compression/DeflateStream.cs
+++ b/mcs/class/System/System.IO.Compression/DeflateStream.cs
@@ -456,7 +456,6 @@ namespace System.IO.Compression
 			return self.UnmanagedWrite (buffer, length);
 		}
 
-		static int martinTest;
 
 		int UnmanagedWrite (IntPtr buffer, int length)
 		{

--- a/mcs/class/System/System.IO.Compression/DeflateStream.cs
+++ b/mcs/class/System/System.IO.Compression/DeflateStream.cs
@@ -349,6 +349,7 @@ namespace System.IO.Compression
 		GCHandle data;
 		bool disposed;
 		byte [] io_buffer;
+		Exception last_error;
 
 		private DeflateStreamNative ()
 		{
@@ -430,7 +431,15 @@ namespace System.IO.Compression
 				io_buffer = new byte [BufferSize];
 
 			int count = Math.Min (length, io_buffer.Length);
-			int n = base_stream.Read (io_buffer, 0, count);
+			int n;
+
+			try {
+				n = base_stream.Read (io_buffer, 0, count);
+			} catch (Exception ex) {
+				last_error = ex;
+				return -12;
+			}
+
 			if (n > 0)
 				Marshal.Copy (io_buffer, 0, buffer, n);
 
@@ -447,6 +456,8 @@ namespace System.IO.Compression
 			return self.UnmanagedWrite (buffer, length);
 		}
 
+		static int martinTest;
+
 		int UnmanagedWrite (IntPtr buffer, int length)
 		{
 			int total = 0;
@@ -456,7 +467,12 @@ namespace System.IO.Compression
 
 				int count = Math.Min (length, io_buffer.Length);
 				Marshal.Copy (buffer, io_buffer, 0, count);
-				base_stream.Write (io_buffer, 0, count);
+				try {
+					base_stream.Write (io_buffer, 0, count);
+				} catch (Exception ex) {
+					last_error = ex;
+					return -12;
+				}
 				unsafe {
 					buffer = new IntPtr ((byte *) buffer.ToPointer () + count);
 				}
@@ -466,10 +482,14 @@ namespace System.IO.Compression
 			return total;
 		}
 
-		static void CheckResult (int result, string where)
+		void CheckResult (int result, string where)
 		{
 			if (result >= 0)
 				return;
+
+			var throw_me = Interlocked.Exchange (ref last_error, null);
+			if (throw_me != null)
+				throw throw_me;
 
 			string error;
 			switch (result) {
@@ -625,7 +645,11 @@ namespace System.IO.Compression
 
 			override protected bool ReleaseHandle()
 			{
-				DeflateStreamNative.CloseZStream(handle);
+				try {
+					DeflateStreamNative.CloseZStream(handle);
+				} catch {
+					;
+				}
 				return true;
 			}
 		}

--- a/support/zlib-helper.c
+++ b/support/zlib-helper.c
@@ -29,6 +29,7 @@
 #define BUFFER_SIZE 4096
 #define ARGUMENT_ERROR -10
 #define IO_ERROR -11
+#define MONO_EXCEPTION -12
 
 #define z_malloc(size)          ((gpointer) malloc(size))
 #define z_malloc0(size)         ((gpointer) calloc(1,size))
@@ -121,6 +122,10 @@ CloseZStream (ZStream *zstream)
 			do {
 				status = deflate (zstream->stream, Z_FINISH);
 				flush_status = flush_internal (zstream, TRUE);
+				if (flush_status == MONO_EXCEPTION) {
+					status = flush_status;
+					break;
+				}
 			} while (status == Z_OK); /* We want Z_STREAM_END or error here here */
 			if (status == Z_STREAM_END)
 				status = flush_status;
@@ -147,6 +152,8 @@ write_to_managed (ZStream *stream)
 		n = stream->func (stream->buffer, BUFFER_SIZE - zs->avail_out, stream->gchandle);
 		zs->next_out = stream->buffer;
 		zs->avail_out = BUFFER_SIZE;
+		if (n == MONO_EXCEPTION)
+			return n;
 		if (n < 0)
 			return IO_ERROR;
 	}


### PR DESCRIPTION
DeflateStream now correctly handles exceptions thrown by it's inner stream and
rethrows them after returning from native code.

Fixes #12205.