### PR TITLE
Fixes https://github.com/mono/mono/issues/12461.

### DIFF
--- a/mcs/class/System.ComponentModel.Composition.4.5/src/ComponentModel/System/ComponentModel/Composition/ReflectionModel/ReflectionModelServices.cs
+++ b/mcs/class/System.ComponentModel.Composition.4.5/src/ComponentModel/System/ComponentModel/Composition/ReflectionModel/ReflectionModelServices.cs
@@ -110,14 +110,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         {
             Requires.NotNull(importDefinition, "importDefinition");
 
-            ReflectionImportDefinition reflectionImportDefinition = importDefinition as ReflectionImportDefinition;
-            if (reflectionImportDefinition == null)
-            {
-                throw new ArgumentException(
-                    string.Format(CultureInfo.CurrentCulture, Strings.ReflectionModel_InvalidImportDefinition, importDefinition.GetType()),
-                    "importDefinition");
-            }
-
             return (importDefinition is IPartCreatorImportDefinition);
         }
 


### PR DESCRIPTION
After .NET 4.5 .NET Framework has changed the System.ComponentModel.Composition ReflectionModelServices.IsExportFactoryImportDefinition to not throw.

Updating this to match the .NET Framework behavior.

Fixes #12461
