### PR TITLE
[wasm] Fix crash with delegates.

### DIFF
--- a/sdks/wasm/binding_support.js
+++ b/sdks/wasm/binding_support.js
@@ -606,9 +606,16 @@ var BindingSupportLib = {
 					this.corlib = this.assembly_load ("mscorlib");
 				if (!this.delegate_class)
 					this.delegate_class = this.find_class (this.corlib, "System", "Delegate");
+				if (!this.delegate_class)
+				{
+					throw new Error("System.Delegate class can not be resolved.");
+				}
 				this.delegate_dynamic_invoke = this.find_method (this.delegate_class, "DynamicInvoke", -1);
 			}
 			var mono_args = this.js_array_to_mono_array (js_args);
+			if (!this.delegate_dynamic_invoke)
+				throw new Error("System.Delegate.DynamicInvoke method can not be resolved.");
+
 			return this.call_method (this.delegate_dynamic_invoke, this.extract_mono_obj (delegate_obj), "m", [ mono_args ]);
 		},
 		

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/LinkDescriptor/WebAssembly.Bindings.xml
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/LinkDescriptor/WebAssembly.Bindings.xml
@@ -4,4 +4,14 @@
   Preserve the entire assembly
   -->
   <assembly fullname="WebAssembly.Bindings" preserve="all"/>
+
+  <!--
+  Preserve System.Delegate.DynamicInvoke which is called from javascript
+  -->
+  <assembly fullname="mscorlib">
+    <type fullname="System.Delegate">
+      <method signature="System.Object DynamicInvoke(System.Object[])" />
+    </type>
+  </assembly>   
+    
 </linker>


### PR DESCRIPTION
Internally the javascript bridge support uses `System.Delegate` and `System.Delegate.DynamicInvoke` to support delegate callbacks.  The linker, when executed over the assemblies, does not know about this code coverage and will strip out `System.Delegate.DynamicInvoke`.

To fix this:

- Add reference to `System.Delegate.DynamicInvoke` to the `WebAssembly.Bindings` linker xml file so the linker knows not to strip the code.
- Add detailed error messages in case something else goes wrong so the crash is not so cryptic.
