### PR TITLE
[2018-10 Android,AOT] Support dumping AOT offsets with Android NDK r17+ (#12454)

### DIFF
--- a/tools/offsets-tool/MonoAotOffsetsDumper.cs
+++ b/tools/offsets-tool/MonoAotOffsetsDumper.cs
@@ -632,9 +632,46 @@ namespace CppSharp
 
             const int androidNdkApiLevel = 21;
 
+            string arch = GetArchFromTriple(target.Triple);
             var toolchainPath = Path.Combine(AndroidNdkPath, "platforms",
-                "android-" + androidNdkApiLevel, "arch-" + GetArchFromTriple(target.Triple),
+                "android-" + androidNdkApiLevel, "arch-" + arch,
                 "usr", "include");
+
+            if (!Directory.Exists (toolchainPath)) {
+                // Android NDK r17 and newer no longer have per-platform include directories, they instead use a
+                // unified set of headers
+                toolchainPath = Path.Combine (AndroidNdkPath, "sysroot", "usr", "include");
+
+                // The unified headers require that the target API level is defined as a macro - that's how they
+                // differentiate between native APIs available for the given API level
+                parserOptions.AddDefines ($"__ANDROID_API__={androidNdkApiLevel}");
+
+                // And they also need to point to the per-arch `asm` directory
+                string asmTriple;
+                switch (arch) {
+                        case "arm64":
+                                asmTriple = "aarch64-linux-android";
+                                break;
+
+                        case "arm":
+                                asmTriple = "arm-linux-androideabi";
+                                break;
+
+                        case "x86":
+                                asmTriple = "i686-linux-android";
+                                break;
+
+                        case "x86_64":
+                                asmTriple = "x86_64-linux-android";
+                                break;
+
+                        default:
+                                throw new Exception ($"Unsupported architecture {arch}");
+                }
+
+                parserOptions.AddSystemIncludeDirs (Path.Combine (toolchainPath, asmTriple));
+            }
+
             parserOptions.AddSystemIncludeDirs(toolchainPath);
 
             parserOptions.NoBuiltinIncludes = true;


### PR DESCRIPTION
Backport of: https://github.com/mono/mono/commit/eebe4b52857140ba9dea872c6249960273d222f2 from https://github.com/mono/mono/pull/12454

The latest Android NDK releases no longer ship with per-platform C headers.
Instead they ship with a set of unified headers and require the presence of the
`__ANDROID_API__` macro in order to select the target platform.
The AOT offset dumper doesn't support this new layout and this commit changes
that by adding support for the unified headers (without removing support for the
older NDKs) thus fixing the following error when trying to dump the offsets with
newer NDK:

    Processing triple: aarch64-v8a-linux-android
    Error parsing '[...]/mono/mono/metadata/metadata-cross-helpers.c'
    [...]/mono/mono/metadata/metadata-cross-helpers.c(5,10): fatal: 'stdio.h' file not found
    Error parsing '[...]/mono/mono/mini/mini-cross-helpers.c'
    [...]/mono/mono/mini/mini-cross-helpers.c(7,10): fatal: 'stdio.h' file not found

