### PR TITLE
[2018-10] [System]: Correctly dispose inner stream in `WebResponseStream`.  #11928.

### DIFF
--- a/mcs/class/System/System.Net/WebResponseStream.cs
+++ b/mcs/class/System/System.Net/WebResponseStream.cs
@@ -400,6 +400,8 @@ namespace System.Net
 				WebConnection.Debug ($"{ME} CLOSE #1: read_eof={read_eof} bufferedEntireContent={bufferedEntireContent}");
 				if (read_eof || bufferedEntireContent) {
 					disposed = true;
+					innerStream?.Dispose ();
+					innerStream = null;
 					Operation.Finish (true);
 				} else {
 					// If we have not read all the contents


### PR DESCRIPTION
Fixes #11928.

Backport of #12459.

/cc @marek-safar @baulig