### PR TITLE
Don't hardcode "mscorlib" use MONO_ASSEMLBY_CORLIB_NAME or mono_is_corlib_image

### DIFF
--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -11,6 +11,12 @@
 #include <mono/metadata/assembly.h>
 #include <mono/metadata/metadata-internals.h>
 
+#ifndef ENABLE_NETCORE
+#define MONO_ASSEMBLY_CORLIB_NAME "mscorlib"
+#else
+#define MONO_ASSEMBLY_CORLIB_NAME "System.Private.CoreLib"
+#endif
+
 /* Flag bits for mono_assembly_names_equal_flags (). */
 typedef enum {
 	/* Default comparison: all fields must match */

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1456,7 +1456,7 @@ load_reference_by_aname_refonly_asmctx (MonoAssemblyName *aname, MonoAssembly *a
 	*status = MONO_IMAGE_OK;
 	{
 		/* We use the loaded corlib */
-		if (!strcmp (aname->name, "mscorlib")) {
+		if (!strcmp (aname->name, MONO_ASSEMBLY_CORLIB_NAME)) {
 			MonoAssemblyByNameRequest req;
 			mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT);
 			req.requesting_assembly = assm;
@@ -2800,7 +2800,7 @@ mono_assembly_request_load_from (MonoImage *image, const char *fname,
 
 	mono_assembly_fill_assembly_name (image, &ass->aname);
 
-	if (mono_defaults.corlib && strcmp (ass->aname.name, "mscorlib") == 0) {
+	if (mono_defaults.corlib && strcmp (ass->aname.name, MONO_ASSEMBLY_CORLIB_NAME) == 0) {
 		// MS.NET doesn't support loading other mscorlibs
 		g_free (ass);
 		g_free (base_dir);
@@ -4294,7 +4294,11 @@ mono_assembly_load_full_gac_base_default (MonoAssemblyName *aname,
 	/* Currently we retrieve the loaded corlib for reflection 
 	 * only requests, like a common reflection only assembly 
 	 */
-	if (strcmp (aname->name, "mscorlib") == 0 || strcmp (aname->name, "mscorlib.dll") == 0) {
+	gboolean name_is_corlib = strcmp (aname->name, MONO_ASSEMBLY_CORLIB_NAME) == 0;
+#ifndef NETCORE_LOADER
+	name_is_corlib |= strcmp (aname->name, "mscorlib.dll") == 0;
+#endif
+	if (name_is_corlib) {
 		return mono_assembly_load_corlib (mono_get_runtime_info (), status);
 	}
 

--- a/mono/metadata/security-core-clr.c
+++ b/mono/metadata/security-core-clr.c
@@ -15,6 +15,7 @@
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/security-manager.h>
 #include <mono/metadata/assembly.h>
+#include <mono/metadata/assembly-internals.h>
 #include <mono/metadata/appdomain.h>
 #include <mono/metadata/verify-internals.h>
 #include <mono/metadata/object.h>
@@ -79,10 +80,10 @@ default_platform_check (const char *image_name)
 		return (strcmp (mono_defaults.corlib->name, image_name) == 0);
 	} else {
 		/* this can get called even before we load corlib (e.g. the EXE itself) */
-		const char *corlib = "mscorlib.dll";
+		const char *corlib = MONO_ASSEMBLY_CORLIB_NAME ".dll";
 		int ilen = strlen (image_name);
 		int clen = strlen (corlib);
-		return ((ilen >= clen) && (strcmp ("mscorlib.dll", image_name + ilen - clen) == 0));
+		return ((ilen >= clen) && (strcmp (corlib, image_name + ilen - clen) == 0));
 	}
 }
 

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -4277,7 +4277,7 @@ add_wrappers (MonoAotCompile *acfg)
 		}
  	}
 
-	if (strcmp (acfg->image->assembly->aname.name, "mscorlib") == 0) {
+	if (mono_is_corlib_image (acfg->image->assembly->image)) {
 		int nallocators;
 
 		/* Runtime invoke wrappers */
@@ -7185,7 +7185,7 @@ emit_trampolines (MonoAotCompile *acfg)
 	g_assert (acfg->image->assembly);
 
 	/* Currently, we emit most trampolines into the mscorlib AOT image. */
-	if (strcmp (acfg->image->assembly->aname.name, "mscorlib") == 0) {
+	if (mono_is_corlib_image(acfg->image->assembly->image)) {
 #ifdef MONO_ARCH_HAVE_FULL_AOT_TRAMPOLINES
 		MonoTrampInfo *info;
 

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -1615,7 +1615,7 @@ aot_cache_load_module (MonoAssembly *assembly, char **aot_name)
 		return module;
 	}
 
-	if (!strcmp (assembly->aname.name, "mscorlib") && !mscorlib_aot_loaded)
+	if (mono_is_corlib_image (assembly->image) && !mscorlib_aot_loaded)
 		/*
 		 * Can't AOT this during startup, so we AOT it when called later from
 		 * mono_aot_get_method ().
@@ -2313,7 +2313,7 @@ if (container_assm_name && !container_amodule) {
 	amodule->trampolines [MONO_AOT_TRAMP_FTNPTR_ARG] = (guint8 *)info->ftnptr_arg_trampolines;
 	amodule->trampolines [MONO_AOT_TRAMP_UNBOX_ARBITRARY] = (guint8 *)info->unbox_arbitrary_trampolines;
 
-	if (!strcmp (assembly->aname.name, "mscorlib"))
+	if (mono_is_corlib_image (assembly->image))
 		mscorlib_aot_module = amodule;
 
 	/* Compute method addresses */
@@ -4706,7 +4706,7 @@ mono_aot_get_method (MonoDomain *domain, MonoMethod *method, MonoError *error)
 		/* Non shared AOT code can't be used in other appdomains */
 		return NULL;
 
-	if (enable_aot_cache && !amodule && domain->entry_assembly && m_class_get_image (klass) == mono_defaults.corlib) {
+	if (enable_aot_cache && !amodule && domain->entry_assembly && mono_is_corlib_image (m_class_get_image (klass))) {
 		/* This cannot be AOTed during startup, so do it now */
 		if (!mscorlib_aot_loaded) {
 			mscorlib_aot_loaded = TRUE;
@@ -5782,7 +5782,7 @@ get_numerous_trampoline (MonoAotTrampoline tramp_type, int n_got_slots, MonoAotM
 #endif
 	if (amodule->trampoline_index [tramp_type] == amodule->info.num_trampolines [tramp_type]) {
 		g_error ("Ran out of trampolines of type %d in '%s' (limit %d)%s\n", 
-				 tramp_type, image ? image->name : "mscorlib", amodule->info.num_trampolines [tramp_type], MONOTOUCH_TRAMPOLINES_ERROR);
+				 tramp_type, image ? image->name : MONO_ASSEMBLY_CORLIB_NAME, amodule->info.num_trampolines [tramp_type], MONOTOUCH_TRAMPOLINES_ERROR);
 	}
 	index = amodule->trampoline_index [tramp_type] ++;
 


### PR DESCRIPTION
Use the MONO_ASSEMBLY_CORLIB_NAME define instead of hardcoding "mscorlib" everywhere.  If building for netcore, the define is set to "System.Private.CoreLib" instead.

In some circumstances, a string comparison against `assembly->aname.name` is used to check if something is in corelib.  In cases like that, instead use `mono_is_corlib_image (assembly->image)` instead.  (This introduces a dependency on mono_defaults.corlib being correctly initialized, so it's inappropriate for code that runs very early during startup.  Which I checked as best I could.)

This should fix every use of literal "mscorlib" in the runtime.

This does _not_ fix every use of literal "mscorlib.dll" in the runtime, partly because some of those uses are in the Framework-specific codepaths in the loader and it doesn't necessarily make sense to perturb them.
