### PR TITLE
[msbuild] Install msbuild bits in to `Current/` instead of `15.0/`

### DIFF
--- a/mcs/packages/Makefile
+++ b/mcs/packages/Makefile
@@ -36,7 +36,7 @@ DISTFILES = $(ROSLYN_FILES_FOR_MONO) $(ROSLYN_FILES_TO_COPY_FOR_MSBUILD) csi-tes
 ifeq ($(PROFILE), $(DEFAULT_PROFILE))
 
 TARGET_DIR = $(DESTDIR)$(mono_libdir)/mono/$(FRAMEWORK_VERSION)
-MSBUILD_ROSLYN_DIR = $(DESTDIR)$(mono_libdir)/mono/msbuild/15.0/bin/Roslyn
+MSBUILD_ROSLYN_DIR = $(DESTDIR)$(mono_libdir)/mono/msbuild/Current/bin/Roslyn
 
 install-local: install-prototypes
 	$(MKINSTALLDIRS) $(TARGET_DIR)
@@ -45,6 +45,7 @@ install-local: install-prototypes
 	$(INSTALL_LIB) $(ROSLYN_FILES_TO_COPY_FOR_MSBUILD) $(MSBUILD_ROSLYN_DIR)
 
 	(cd $(MSBUILD_ROSLYN_DIR); for asm in $(ROSLYN_FILES_FOR_MONO); do ln -fs ../../../../$(FRAMEWORK_VERSION)/$$(basename $$asm) . ; done)
+	(cd $(DESTDIR)$(mono_libdir)/mono/msbuild; ln -s Current 15.0)
 
 install-prototypes:
 	$(MKINSTALLDIRS) $(TARGET_DIR)/dim

--- a/mcs/tools/xbuild/Makefile
+++ b/mcs/tools/xbuild/Makefile
@@ -25,7 +25,7 @@ PCL5_FX_DIR=$(mono_libdir)/mono/xbuild-frameworks/.NETPortable/v5.0
 VS_TARGETS_DIR = $(mono_libdir)/mono/xbuild/Microsoft/VisualStudio
 PORTABLE_TARGETS_DIR = $(mono_libdir)/mono/xbuild/Microsoft/Portable
 NUGET_BUILDTASKS_TARGETS_DIR = $(mono_libdir)/mono/xbuild/Microsoft/NuGet
-MSBUILD_EXTENSIONS_15_DIR=$(mono_libdir)/mono/xbuild/15.0
+MSBUILD_EXTENSIONS_CURRENT_DIR=$(mono_libdir)/mono/xbuild/Current
 
 ifeq (14.0, $(XBUILD_VERSION))
 install-extras: install-versioned-files install-global-files
@@ -106,12 +106,12 @@ NUGET_BUILDTASKS_REPO_DIR=$(topdir)/../external/nuget-buildtasks
 
 install-nuget-targets:
 	$(MKINSTALLDIRS) $(DESTDIR)$(NUGET_BUILDTASKS_TARGETS_DIR)
-	$(MKINSTALLDIRS) $(DESTDIR)$(MSBUILD_EXTENSIONS_15_DIR)/Imports/Microsoft.Common.props/ImportBefore
-	$(MKINSTALLDIRS) $(DESTDIR)$(MSBUILD_EXTENSIONS_15_DIR)/Microsoft.Common.targets/ImportAfter
+	$(MKINSTALLDIRS) $(DESTDIR)$(MSBUILD_EXTENSIONS_CURRENT_DIR)/Imports/Microsoft.Common.props/ImportBefore
+	$(MKINSTALLDIRS) $(DESTDIR)$(MSBUILD_EXTENSIONS_CURRENT_DIR)/Microsoft.Common.targets/ImportAfter
 	$(INSTALL_DATA) $(NUGET_BUILDTASKS_REPO_DIR)/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets $(DESTDIR)$(NUGET_BUILDTASKS_TARGETS_DIR)
 	$(INSTALL_DATA) $(NUGET_BUILDTASKS_REPO_DIR)/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.props $(DESTDIR)$(NUGET_BUILDTASKS_TARGETS_DIR)
-	$(INSTALL_DATA) $(NUGET_BUILDTASKS_REPO_DIR)/src/Microsoft.NuGet.Build.Tasks/ImportBeforeAfter/Microsoft.NuGet.ImportBefore.props $(DESTDIR)$(MSBUILD_EXTENSIONS_15_DIR)/Imports/Microsoft.Common.props/ImportBefore
-	$(INSTALL_DATA) $(NUGET_BUILDTASKS_REPO_DIR)/src/Microsoft.NuGet.Build.Tasks/ImportBeforeAfter/Microsoft.NuGet.ImportAfter.targets $(DESTDIR)$(MSBUILD_EXTENSIONS_15_DIR)/Microsoft.Common.targets/ImportAfter
+	$(INSTALL_DATA) $(NUGET_BUILDTASKS_REPO_DIR)/src/Microsoft.NuGet.Build.Tasks/ImportBeforeAfter/Microsoft.NuGet.ImportBefore.props $(DESTDIR)$(MSBUILD_EXTENSIONS_CURRENT_DIR)/Imports/Microsoft.Common.props/ImportBefore
+	$(INSTALL_DATA) $(NUGET_BUILDTASKS_REPO_DIR)/src/Microsoft.NuGet.Build.Tasks/ImportBeforeAfter/Microsoft.NuGet.ImportAfter.targets $(DESTDIR)$(MSBUILD_EXTENSIONS_CURRENT_DIR)/Microsoft.Common.targets/ImportAfter
 
 install-nuget-imports:
 ifeq (14.0, $(XBUILD_VERSION))
@@ -134,6 +134,7 @@ install-pcl5-framework:
 
 install-msbuild-specific-files:
 	$(MKINSTALLDIRS) $(DESTDIR)$(mono_libdir)/mono/xbuild
+	(cd $(DESTDIR)$(mono_libdir)/mono/xbuild; ln -s Current 15.0)
 	$(INSTALL_DATA) $(DENIED_ASSEMBLY_LIST_SRC) $(DESTDIR)$(mono_libdir)/mono/xbuild
 
 EXTRA_DISTFILES = \


### PR DESCRIPTION
- This is to prepare for the update to msbuild which expects
	`lib/mono/xbuild/Current` and
	`lib/mono/msbuild/Current`.

Except for Roslyn, which still installs and expects to be in
`lib/mono/msbuild/15.0/bin/Roslyn`.

Because of that and to not break compat with other tools (like nuget)
we add symlinks for 15.0 .



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
