### PR TITLE
[wasm] fix insufficient csc arguments in sample README

### DIFF
--- a/sdks/wasm/docs/getting-started/sample.md
+++ b/sdks/wasm/docs/getting-started/sample.md
@@ -36,7 +36,7 @@ The WebAssembly SDK includes the sample code that we can use.
 1.  Compile sample
 
     ```
-    csc /target:library -out:sample.dll /r:$WASM_SDK/wasm-bcl/wasm/System.Net.Http.dll /r:$WASM_SDK/framework/WebAssembly.Bindings.dll /r:$WASM_SDK/framework/WebAssembly.Net.Http.dll dependency.cs sample.cs
+    csc /target:library -out:sample.dll /noconfig /nostdlib /r:$WASM_SDK/wasm-bcl/wasm/mscorlib.dll /r:$WASM_SDK/wasm-bcl/wasm/System.dll /r:$WASM_SDK/wasm-bcl/wasm/System.Core.dll /r:$WASM_SDK/wasm-bcl/wasm/Facades/netstandard.dll /r:$WASM_SDK/wasm-bcl/wasm/System.Net.Http.dll /r:$WASM_SDK/framework/WebAssembly.Bindings.dll /r:$WASM_SDK/framework/WebAssembly.Net.Http.dll dependency.cs sample.cs
     ```
 
 1. Package and publish sample 


### PR DESCRIPTION
There would be newer build instruction with msbuild sdks but so far fix current readme.