### PR TITLE
[2018-10] Add TypeConverter fallback to DefaultValueAttribute

### DIFF
--- a/mcs/class/System/Test/System.ComponentModel/DefaultValueAttributeTest.cs
+++ b/mcs/class/System/Test/System.ComponentModel/DefaultValueAttributeTest.cs
@@ -26,6 +26,9 @@
 
 using System;
 using System.ComponentModel;
+#if !FULL_AOT_RUNTIME
+using System.Drawing;
+#endif
 using NUnit.Framework;
 
 namespace MonoTests.System.ComponentModel {
@@ -58,5 +61,21 @@ namespace MonoTests.System.ComponentModel {
 
 			Assert.AreEqual (1, dvat.GetHashCode (), "GetHashCode");
 		}
+
+#if !FULL_AOT_RUNTIME
+		[DefaultValue (typeof (Color), "Black")]
+		public Color Bar { get; set; }
+
+		// https://github.com/mono/mono/issues/12362
+		[Test]
+		public void Bug_12362 ()
+		{
+			var prop = typeof (DefaultValueAttributeTest).GetProperty ("Bar");
+			var attr = (DefaultValueAttribute)prop.GetCustomAttributes (true) [0];
+			var value = attr.Value;
+			Assert.IsNotNull (value);
+			Assert.AreEqual (typeof (Color), value.GetType ());
+		}
+#endif
 	}
 }

--- a/mcs/class/referencesource/System/compmod/system/componentmodel/TypeDescriptor.cs
+++ b/mcs/class/referencesource/System/compmod/system/componentmodel/TypeDescriptor.cs
@@ -1557,6 +1557,14 @@ namespace System.ComponentModel
             return converter;
         }
 
+#if MONO // from https://github.com/dotnet/corefx/pull/31739
+        // This is called by System.ComponentModel.DefaultValueAttribute via reflection.
+        private static object ConvertFromInvariantString(Type type, string stringValue)
+        {
+            return GetConverter(type).ConvertFromInvariantString(stringValue);
+        }
+#endif
+
         /// <devdoc>
         ///     Gets the default event for the specified type of component.
         /// </devdoc>


### PR DESCRIPTION
Backport of https://github.com/mono/mono/pull/12412 to 2018-10 branch.

Requires https://github.com/mono/corefx/pull/239

Fixes https://github.com/mono/mono/issues/12362