### PR TITLE
[sdks] Add net_4_x profile to android-bcl

### DIFF
--- a/sdks/builds/android.mk
+++ b/sdks/builds/android.mk
@@ -401,5 +401,5 @@ $(eval $(call AndroidCrossMXETemplate,cross-arm64-win,x86_64,aarch64-v8a,android
 $(eval $(call AndroidCrossMXETemplate,cross-x86-win,i686,i686,android-x86,llvm-llvmwin32,i686-none-linux-android))
 $(eval $(call AndroidCrossMXETemplate,cross-x86_64-win,x86_64,x86_64,android-x86_64,llvm-llvmwin64,x86_64-none-linux-android))
 
-$(eval $(call BclTemplate,android-bcl,monodroid monodroid_tools,monodroid))
+$(eval $(call BclTemplate,android-bcl,monodroid monodroid_tools net_4_x,monodroid))
 android_TARGETS += android-bcl


### PR DESCRIPTION
XA needs net_4_x BCL to run jnimarshalmethod-gen.exe tool on
Windows.

Context: https://github.com/xamarin/xamarin-android/pull/2454
