### PR TITLE
[netcore] Small runtime changes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -760,6 +760,9 @@ AC_ARG_WITH(jumptables, [  --with-jumptables=yes,no      enable/disable support 
 AC_ARG_WITH(core,       [  --with-core=only       controls whether to build Mono as a .NET Core runtime (defaults to no)],[],[with_core=no])
 if test x$with_core = xonly; then
     AC_DEFINE(ENABLE_NETCORE,1,[Enables the support for .NET Core Features in the MonoVM])
+    mono_feature_disable_remoting='yes'
+    mono_feature_disable_reflection_emit_save='yes'
+    mono_feature_disable_appdomains='yes'
 fi
 AM_CONDITIONAL(ENABLE_NETCORE, test x$with_core = xonly)
 

--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -622,7 +622,11 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 	/* reserve space to store vector pointer in arrays */
 	if (mono_is_corlib_image (image) && !strcmp (nspace, "System") && !strcmp (name, "Array")) {
 		klass->instance_size += 2 * TARGET_SIZEOF_VOID_P;
+#ifndef ENABLE_NETCORE
 		g_assert (mono_class_get_field_count (klass) == 0);
+#else
+		/* TODO: check that array has 0 non-const fields */
+#endif
 	}
 
 	if (klass->enumtype) {

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -4898,9 +4898,13 @@ mono_unhandled_exception_checked (MonoObjectHandle exc, MonoError *error)
 	 * a thread started in unmanaged world.
 	 * https://msdn.microsoft.com/en-us/library/system.appdomainunloadedexception(v=vs.110).aspx#Anchor_6
 	 */
-	if (klass == mono_defaults.threadabortexception_class ||
+	gboolean no_event = (klass == mono_defaults.threadabortexception_class);
+#ifndef ENABLE_NETCORE
+	no_event = no_event ||
 			(klass == mono_class_get_appdomain_unloaded_exception_class () &&
-			mono_thread_info_current ()->runtime_thread))
+			mono_thread_info_current ()->runtime_thread);
+#endif
+	if (no_event)
 		return;
 
 	field = mono_class_get_field_from_name_full (mono_defaults.appdomain_class, "UnhandledException", NULL);


### PR DESCRIPTION
1. For `--with-core=only`, disable AppDomains, SRE.Save and Remoting.
2. System.Private.CoreLib System.Array type has some constant fields - don't assert in the runtime that there are 0 fields - when initializing the array type.
3. Don't treat `AppDomainUnloadedException` specially in exception handling.  (And in particular, don't try to load AppDomainUnloadedException - it's not in System.Private.CoreLib.dll, it's in netstandard.dll, so it won't work).