### PR TITLE
[2018-08] [runtime] Add opt-out for AOT file probing with MONO_AOT_MODE_NONE

### DIFF
--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -2039,6 +2039,9 @@ load_aot_module (MonoAssembly *assembly, gpointer user_data)
 	if (mono_compile_aot)
 		return;
 
+	if (mono_aot_mode == MONO_AOT_MODE_NONE)
+		return;
+
 	if (assembly->image->aot_module)
 		/* 
 		 * Already loaded. This can happen because the assembly loading code might invoke

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -2660,6 +2660,7 @@ mono_runtime_set_execution_mode (MonoEEMode mode)
 		break;
 
 	case MONO_AOT_MODE_NORMAL:
+	case MONO_AOT_MODE_NONE:
 		break;
 
 	default:

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -2675,11 +2675,13 @@ void
 mono_jit_set_aot_mode (MonoAotMode mode)
 {
 	/* we don't want to set mono_aot_mode twice */
-	g_assert (mono_aot_mode == MONO_AOT_MODE_NONE);
+	static gboolean inited;
+
+	g_assert (!inited);
 	mono_aot_mode = mode;
+	inited = TRUE;
 	
 	mono_runtime_set_execution_mode ((MonoEEMode)mode);
-
 }
 
 mono_bool

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -105,7 +105,8 @@ gboolean mono_compile_aot = FALSE;
 gboolean mono_aot_only = FALSE;
 /* Same as mono_aot_only, but only LLVM compiled code is used, no trampolines */
 gboolean mono_llvm_only = FALSE;
-MonoAotMode mono_aot_mode = MONO_AOT_MODE_NONE;
+/* By default, don't require AOT but attempt to probe */
+MonoAotMode mono_aot_mode = MONO_AOT_MODE_NORMAL;
 MonoEEFeatures mono_ee_features;
 
 const char *mono_build_date;


### PR DESCRIPTION
Fixes reported startup time issues with probing filesystem for native AOT code files on Android.

Backport of #12053.

/cc @alexanderkyte 