### PR TITLE
[Debugger] Checking server version before call elapsed_time

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -2119,7 +2119,7 @@ namespace Mono.Debugger.Soft
 		}
 
 		internal long Thread_GetElapsedTime (long id) {
-			if (connection.Version.AtLeast (2, 50)) {
+			if (connection.Version.AtLeast (2, 50))
 				return SendReceive (CommandSet.THREAD, (int)CmdThread.GET_ELAPSED_TIME, new PacketWriter ().WriteId (id)).ReadLong ();
 			return -1;
 		}

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -427,7 +427,7 @@ namespace Mono.Debugger.Soft
 		 * with newer runtimes, and vice versa.
 		 */
 		internal const int MAJOR_VERSION = 2;
-		internal const int MINOR_VERSION = 49;
+		internal const int MINOR_VERSION = 50;
 
 		enum WPSuspendPolicy {
 			NONE = 0,
@@ -2119,7 +2119,9 @@ namespace Mono.Debugger.Soft
 		}
 
 		internal long Thread_GetElapsedTime (long id) {
-			return SendReceive (CommandSet.THREAD, (int)CmdThread.GET_ELAPSED_TIME, new PacketWriter ().WriteId (id)).ReadLong ();
+			if (connection.Version.AtLeast (2, 50)) {
+				return SendReceive (CommandSet.THREAD, (int)CmdThread.GET_ELAPSED_TIME, new PacketWriter ().WriteId (id)).ReadLong ();
+			return -1;
 		}
 
 		internal void Thread_GetFrameInfo (long id, int start_frame, int length, Action<FrameInfo[]> resultCallaback) {

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -2119,7 +2119,7 @@ namespace Mono.Debugger.Soft
 		}
 
 		internal long Thread_GetElapsedTime (long id) {
-			if (connection.Version.AtLeast (2, 50))
+			if (Version.AtLeast (2, 50))
 				return SendReceive (CommandSet.THREAD, (int)CmdThread.GET_ELAPSED_TIME, new PacketWriter ().WriteId (id)).ReadLong ();
 			return -1;
 		}

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -274,7 +274,7 @@ typedef struct {
 #define HEADER_LENGTH 11
 
 #define MAJOR_VERSION 2
-#define MINOR_VERSION 49
+#define MINOR_VERSION 50
 
 typedef enum {
 	CMD_SET_VM = 1,


### PR DESCRIPTION
The version of the server and client should be bumped to call the elapsed_time.
https://github.com/mono/mono/pull/12217
