### PR TITLE
[2018-12] [runtime] Don\u0027t try (slow) dlopen on android if it doesn\u0027t exist

### DIFF
--- a/mono/utils/mono-dl-posix.c
+++ b/mono/utils/mono-dl-posix.c
@@ -65,6 +65,8 @@ mono_dl_open_file (const char *file, int flags)
 	/* Bionic doesn't support NULL filenames */
 	if (!file)
 		return NULL;
+	if (!g_file_test (file, G_FILE_TEST_EXISTS))
+		return NULL;
 #endif
 #if defined(_AIX)
 	/*


### PR DESCRIPTION
On android, the dlopen call will take around 1ms per AOT module we try to load. By not using dlopen with the existence check, we rely on a much slower dlopen check that happens later. I think they support dlopen of non-resolved names. 

This might break a few things if we don't use the full path to dlopen. If it does, we should probably add existence checks at the caller, but this will be an optimization that works everywhere.  

@jonpryor @grendello 

Backport of #12074.

/cc @alexanderkyte 