### PR TITLE
Fixes #12479 - Fixed issue where time lookups on a symlink (GetLastWrite, Creation, …

### DIFF
--- a/mcs/class/corlib/Test/System.IO/FileTest.cs
+++ b/mcs/class/corlib/Test/System.IO/FileTest.cs
@@ -2779,6 +2779,62 @@ namespace MonoTests.System.IO
 		public static extern int symlink (string oldpath, string newpath);
 
 		[Test]
+		[Category ("NotWasm")]
+		public void SymLinkStats() {
+			if (!RunningOnUnix)
+				Assert.Ignore ("Symlink are hard on windows");
+
+			var name1 = Path.GetRandomFileName ();
+			var name2 = Path.GetRandomFileName ();
+
+			var path1 = Path.Combine (Path.GetTempPath (), name1);
+			var path2 = Path.Combine (Path.GetTempPath (), name2);
+
+			File.Delete (path1);
+			File.Delete (path2);
+
+			try {			
+				using (var f = File.Create(path1)) {
+					Assert.IsNotNull (f, "Path1 must be created for symlink stats");
+				}
+
+				if (symlink (path1, path2) != 0)
+					Assert.Fail ("symlink #1 failed with errno={0}", Marshal.GetLastWin32Error ());
+				
+				Assert.IsTrue (File.Exists (path1), "File.Exists must return true for path1 symlink stats");
+				Assert.IsTrue (File.Exists (path2), "File.Exists must return true for path2 symlink stats");
+
+				try {					
+					File.SetLastWriteTime (path1, DateTime.Now.AddMinutes(-5));
+					File.SetCreationTime (path1, DateTime.Now.AddMinutes(-5));
+					File.SetLastAccessTime (path1, DateTime.Now.AddMinutes(-5));
+
+					Assert.AreNotEqual (File.GetLastWriteTime(path1), File.GetLastWriteTime (path2), "Path1 and Path2 should not have the same last write times");
+					Assert.AreNotEqual (File.GetCreationTime(path1), File.GetCreationTime (path2), "Path1 and Path2 should not have the same creation times");
+					Assert.AreNotEqual (File.GetLastAccessTime(path1), File.GetLastAccessTime (path2), "Path1 and Path2 should not have the same last access times");
+				}
+				catch(IOException e) {
+					Assert.Fail ("Symlink stats should allow setting/getting time on file");
+				}
+
+				File.Delete (path2);
+				Assert.IsTrue (File.Exists(path1), "Original file must still exist for symlink stats");
+				Assert.IsFalse (File.Exists(path2), "File.Delete must delete symlink only for symlink stats");
+
+				File.Delete (path1); 
+				Assert.IsFalse (File.Exists (path1), "File.Delete must delete symlink stats");
+
+			} finally {
+				try {
+					File.Delete (path1);
+					File.Delete (path2);
+				} catch (IOException) {
+					//Don't double fault any exception from the tests.
+				}
+			}
+		}
+
+		[Test]
 #if MONOTOUCH_TV
 		[Ignore ("See bug #59239")]
 #endif

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -3537,6 +3537,7 @@ mono_w32file_get_attributes_ex (const gunichar2 *name, MonoIOStat *stat)
 	gchar *utf8_name;
 
 	struct stat buf, linkbuf;
+	struct stat *pbuf;
 	gint result;
 	
 	if (name == NULL) {
@@ -3578,26 +3579,33 @@ mono_w32file_get_attributes_ex (const gunichar2 *name, MonoIOStat *stat)
 	stat->attributes = _wapi_stat_to_file_attributes (utf8_name, &buf, &linkbuf);
 	stat->length = (stat->attributes & FILE_ATTRIBUTE_DIRECTORY) ? 0 : buf.st_size;
 
+	if (&linkbuf == NULL) {
+		pbuf = &buf;
+	}
+	else {
+		pbuf = &linkbuf;
+	}
+
 #if HAVE_STRUCT_STAT_ST_ATIMESPEC
-	if (buf.st_mtimespec.tv_sec < buf.st_ctimespec.tv_sec || (buf.st_mtimespec.tv_sec == buf.st_ctimespec.tv_sec && buf.st_mtimespec.tv_nsec < buf.st_ctimespec.tv_nsec))
-		stat->creation_time = buf.st_mtimespec.tv_sec * TICKS_PER_SECOND + (buf.st_mtimespec.tv_nsec / NANOSECONDS_PER_MICROSECOND) * TICKS_PER_MICROSECOND + CONVERT_BASE;
+	if (pbuf->st_mtimespec.tv_sec < pbuf->st_ctimespec.tv_sec || (pbuf->st_mtimespec.tv_sec == pbuf->st_ctimespec.tv_sec && pbuf->st_mtimespec.tv_nsec < pbuf->st_ctimespec.tv_nsec))
+		stat->creation_time = pbuf->st_mtimespec.tv_sec * TICKS_PER_SECOND + (pbuf->st_mtimespec.tv_nsec / NANOSECONDS_PER_MICROSECOND) * TICKS_PER_MICROSECOND + CONVERT_BASE;
 	else
-		stat->creation_time = buf.st_ctimespec.tv_sec * TICKS_PER_SECOND + (buf.st_ctimespec.tv_nsec / NANOSECONDS_PER_MICROSECOND) * TICKS_PER_MICROSECOND + CONVERT_BASE;
+		stat->creation_time = pbuf->st_ctimespec.tv_sec * TICKS_PER_SECOND + (pbuf->st_ctimespec.tv_nsec / NANOSECONDS_PER_MICROSECOND) * TICKS_PER_MICROSECOND + CONVERT_BASE;
 
-	stat->last_access_time = buf.st_atimespec.tv_sec * TICKS_PER_SECOND + (buf.st_atimespec.tv_nsec / NANOSECONDS_PER_MICROSECOND) * TICKS_PER_MICROSECOND + CONVERT_BASE;
-	stat->last_write_time = buf.st_mtimespec.tv_sec * TICKS_PER_SECOND + (buf.st_mtimespec.tv_nsec / NANOSECONDS_PER_MICROSECOND) * TICKS_PER_MICROSECOND + CONVERT_BASE;
+	stat->last_access_time = pbuf->st_atimespec.tv_sec * TICKS_PER_SECOND + (pbuf->st_atimespec.tv_nsec / NANOSECONDS_PER_MICROSECOND) * TICKS_PER_MICROSECOND + CONVERT_BASE;
+	stat->last_write_time = pbuf->st_mtimespec.tv_sec * TICKS_PER_SECOND + (pbuf->st_mtimespec.tv_nsec / NANOSECONDS_PER_MICROSECOND) * TICKS_PER_MICROSECOND + CONVERT_BASE;
 #elif HAVE_STRUCT_STAT_ST_ATIM
-	if (buf.st_mtime < buf.st_ctime || (buf.st_mtime == buf.st_ctime && buf.st_mtim.tv_nsec < buf.st_ctim.tv_nsec))
-		stat->creation_time = buf.st_mtime * TICKS_PER_SECOND + (buf.st_mtim.tv_nsec / NANOSECONDS_PER_MICROSECOND) * TICKS_PER_MICROSECOND + CONVERT_BASE;
+	if (pbuf->st_mtime < pbuf->st_ctime || (pbuf->st_mtime == pbuf->st_ctime && pbuf->st_mtim.tv_nsec < pbuf->st_ctim.tv_nsec))
+		stat->creation_time = pbuf->st_mtime * TICKS_PER_SECOND + (pbuf->st_mtim.tv_nsec / NANOSECONDS_PER_MICROSECOND) * TICKS_PER_MICROSECOND + CONVERT_BASE;
 	else
-		stat->creation_time = buf.st_ctime * TICKS_PER_SECOND + (buf.st_ctim.tv_nsec / NANOSECONDS_PER_MICROSECOND) * TICKS_PER_MICROSECOND + CONVERT_BASE;
+		stat->creation_time = pbuf->st_ctime * TICKS_PER_SECOND + (pbuf->st_ctim.tv_nsec / NANOSECONDS_PER_MICROSECOND) * TICKS_PER_MICROSECOND + CONVERT_BASE;
 
-	stat->last_access_time = buf.st_atime * TICKS_PER_SECOND + (buf.st_atim.tv_nsec / NANOSECONDS_PER_MICROSECOND) * TICKS_PER_MICROSECOND + CONVERT_BASE;
-	stat->last_write_time = buf.st_mtime * TICKS_PER_SECOND + (buf.st_mtim.tv_nsec / NANOSECONDS_PER_MICROSECOND) * TICKS_PER_MICROSECOND + CONVERT_BASE;
+	stat->last_access_time = pbuf->st_atime * TICKS_PER_SECOND + (pbuf->st_atim.tv_nsec / NANOSECONDS_PER_MICROSECOND) * TICKS_PER_MICROSECOND + CONVERT_BASE;
+	stat->last_write_time = pbuf->st_mtime * TICKS_PER_SECOND + (pbuf->st_mtim.tv_nsec / NANOSECONDS_PER_MICROSECOND) * TICKS_PER_MICROSECOND + CONVERT_BASE;
 #else
-	stat->creation_time = (((guint64) (buf.st_mtime < buf.st_ctime ? buf.st_mtime : buf.st_ctime)) * TICKS_PER_SECOND) + CONVERT_BASE;
-	stat->last_access_time = (((guint64) (buf.st_atime)) * TICKS_PER_SECOND) + CONVERT_BASE;
-	stat->last_write_time = (((guint64) (buf.st_mtime)) * TICKS_PER_SECOND) + CONVERT_BASE;
+	stat->creation_time = (((guint64) (pbuf->st_mtime < pbuf->st_ctime ? pbuf->st_mtime : pbuf->st_ctime)) * TICKS_PER_SECOND) + CONVERT_BASE;
+	stat->last_access_time = (((guint64) (pbuf->st_atime)) * TICKS_PER_SECOND) + CONVERT_BASE;
+	stat->last_write_time = (((guint64) (pbuf->st_mtime)) * TICKS_PER_SECOND) + CONVERT_BASE;
 #endif
 
 	g_free (utf8_name);


### PR DESCRIPTION
When given a path to a symlink `GetLastWriteTime` returned the time for the actual file.  This PR resolves that.

Fixes https://github.com/mono/mono/issues/12479

