### PR TITLE
[sgen] Don't trigger concurrent collections if we exceed soft heap limit

### DIFF
--- a/mono/sgen/sgen-alloc.c
+++ b/mono/sgen/sgen-alloc.c
@@ -73,8 +73,9 @@ alloc_degraded (GCVTable vtable, size_t size, gboolean for_mature)
 		SGEN_ATOMIC_ADD_P (sgen_degraded_mode, size);
 		sgen_ensure_free_space (size, GENERATION_OLD);
 	} else {
-		if (sgen_need_major_collection (size))
-			sgen_perform_collection (size, GENERATION_OLD, "mature allocation failure", !for_mature, TRUE);
+		gboolean forced;
+		if (sgen_need_major_collection (size, &forced))
+			sgen_perform_collection (size, GENERATION_OLD, "mature allocation failure", !for_mature || forced, TRUE);
 	}
 
 

--- a/mono/sgen/sgen-memory-governor.c
+++ b/mono/sgen/sgen-memory-governor.c
@@ -137,9 +137,11 @@ get_heap_size (void)
 }
 
 gboolean
-sgen_need_major_collection (mword space_needed)
+sgen_need_major_collection (mword space_needed, gboolean *forced)
 {
 	size_t heap_size;
+
+	*forced = FALSE;
 
 	if (sgen_get_concurrent_collection_in_progress ()) {
 		heap_size = get_heap_size ();
@@ -169,6 +171,7 @@ sgen_need_major_collection (mword space_needed)
 
 	heap_size = get_heap_size ();
 
+	*forced = heap_size > soft_heap_limit;
 	return heap_size > major_collection_trigger_size;
 }
 

--- a/mono/sgen/sgen-memory-governor.h
+++ b/mono/sgen/sgen-memory-governor.h
@@ -25,7 +25,7 @@ void sgen_memgov_major_collection_end (gboolean forced, gboolean concurrent, con
 void sgen_memgov_collection_start (int generation);
 void sgen_memgov_collection_end (int generation, gint64 stw);
 
-gboolean sgen_need_major_collection (mword space_needed);
+gboolean sgen_need_major_collection (mword space_needed, gboolean *forced);
 
 
 typedef enum {


### PR DESCRIPTION
Concurrent gc (mark / sweep) allows the heap to grow further, which is not what we want if we already exceeded the limit.