### PR TITLE
[2018-10] [System]: Fix race condition in `SystemDependencyProvider.Initialize()`.  #12538.

### DIFF
--- a/mcs/class/System/Mono/SystemDependencyProvider.cs
+++ b/mcs/class/System/Mono/SystemDependencyProvider.cs
@@ -34,6 +34,7 @@ namespace Mono
 	class SystemDependencyProvider : ISystemDependencyProvider
 	{
 		static SystemDependencyProvider instance;
+		static object syncRoot = new object ();
 
 		public static SystemDependencyProvider Instance {
 			get {
@@ -44,8 +45,12 @@ namespace Mono
 
 		internal static void Initialize ()
 		{
-			if (instance == null)
-				Interlocked.CompareExchange (ref instance, new SystemDependencyProvider (), null);
+			lock (syncRoot) {
+				if (instance != null)
+					return;
+
+				instance = new SystemDependencyProvider ();
+			}
 		}
 
 		ISystemCertificateProvider ISystemDependencyProvider.CertificateProvider => CertificateProvider;


### PR DESCRIPTION
Fix race condition in `SystemDependencyProvider.Initialize()`.

Fixes #12538.

Backport of #12541.

/cc @baulig 