### PR TITLE
[2018-10] [SslStream]: Flatten exceptions in sync `SslStream` APIs.

### DIFF
--- a/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
+++ b/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
@@ -178,7 +178,11 @@ namespace Mono.Net.Security
 			};
 
 			var task = ProcessAuthentication (true, options, CancellationToken.None);
-			task.Wait ();
+			try {
+				task.Wait ();
+			} catch (Exception ex) {
+				throw HttpWebRequest.FlattenException (ex);
+			}
 		}
 
 		public IAsyncResult BeginAuthenticateAsClient (string targetHost, AsyncCallback asyncCallback, object asyncState)
@@ -231,7 +235,11 @@ namespace Mono.Net.Security
 			};
 
 			var task = ProcessAuthentication (true, options, CancellationToken.None);
-			task.Wait ();
+			try {
+				task.Wait ();
+			} catch (Exception ex) {
+				throw HttpWebRequest.FlattenException (ex);
+			}
 		}
 
 		public IAsyncResult BeginAuthenticateAsServer (X509Certificate serverCertificate, AsyncCallback asyncCallback, object asyncState)


### PR DESCRIPTION
The sync APIs `SslStream.AuthenticateAsClient()` and `AuthenticateAsServer()` should not throw `AggregateException`.

Fixes #9418.

Backport of #12553.

/cc @baulig 