### PR TITLE
[runtime] Fix building older runtimes with newer system Mono

### DIFF
--- a/mcs/tools/cil-stringreplacer/Makefile
+++ b/mcs/tools/cil-stringreplacer/Makefile
@@ -8,10 +8,28 @@ NO_INSTALL = yes
 TARGET_NET_REFERENCE = $(BOOTSTRAP_BIN_PROFILE)
 PROGRAM_USE_INTERMEDIATE_FILE = 1
 
+ifneq ($(PROFILE_RUNTIME),$(EXTERNAL_RUNTIME))
+
 LIB_REFS = System Mono.Cecil
 
 ifdef MCS_MODE
 LIB_REFS += Mono.Cecil.Mdb
-endif
+endif # MCS_MODE
+
+else
+
+$(topdir)/class/lib/$(PROFILE_DIRECTORY)/tmp/Mono.Cecil: $(topdir)/class/lib/$(PROFILE_DIRECTORY)/Mono.Cecil
+	cp $@ $<
+
+$(topdir)/class/lib/$(PROFILE_DIRECTORY)/tmp/Mono.Cecil.Mdb: $(topdir)/class/lib/$(PROFILE_DIRECTORY)/Mono.Cecil.Mdb
+	cp $@ $<
+
+LIB_REFS = System tmp/Mono.Cecil
+
+ifdef MCS_MODE
+LIB_REFS += tmp/Mono.Cecil.Mdb
+endif # MCS_MODE
+
+endif # Not external mono
 
 include ../../build/executable.make


### PR DESCRIPTION
What was happening was that this was building with a Mono.Cecil from
the build profile, but was trying to load the system Mono.Cecil.

Those versions mismatch when building 2018-08 with a nightly mono that is 5.23.0.

Rather than messing with the MONO_PATH and risking shadowing something
important there, I chose to copy the Mono.Cecil files into this
"lib/build/tmp" directory that we are using for the emitted executable.
It is loaded by the system Mono as the correct Mono.Cecil to use, as assemblies in the same folder have precedence.

This fixes the build.

