### PR TITLE
[2018-08] [runtime] Fix building older runtimes with newer system Mono

### DIFF
--- a/mcs/tools/cil-stringreplacer/Makefile
+++ b/mcs/tools/cil-stringreplacer/Makefile
@@ -5,6 +5,14 @@ include ../../build/rules.make
 PROGRAM = cil-stringreplacer.exe
 NO_INSTALL = yes
 
+$(topdir)/class/lib/$(PROFILE_DIRECTORY)/tmp/Mono.Cecil.dll: $(topdir)/class/lib/$(PROFILE_DIRECTORY)/Mono.Cecil.dll $(topdir)/class/lib/$(PROFILE_DIRECTORY)/tmp/.stamp
+	cp $< $@
+
+$(topdir)/class/lib/$(PROFILE_DIRECTORY)/tmp/Mono.Cecil.Mdb.dll: $(topdir)/class/lib/$(PROFILE_DIRECTORY)/Mono.Cecil.Mdb.dll $(topdir)/class/lib/$(PROFILE_DIRECTORY)/tmp/.stamp
+	cp $< $@
+
+LIB_REFS = System
+
 API = $(filter basic build, $(PROFILE))
 ifdef API
 # It can be run using system .net during boostrap
@@ -12,12 +20,24 @@ TARGET_NET_REFERENCE = v4.6
 # Trick to make it work during boostrap where it has to run with system
 # assemblies not the ones in lib/basic folder
 PROGRAM_USE_INTERMEDIATE_FILE = 1
-endif
 
-LIB_REFS = System Mono.Cecil
+$(topdir)/class/lib/$(PROFILE_DIRECTORY)/tmp/cil-stringreplacer.exe: $(topdir)/class/lib/$(PROFILE_DIRECTORY)/tmp/Mono.Cecil.dll
+
+LIB_REFS += tmp/Mono.Cecil
+
+ifdef MCS_MODE
+$(topdir)/class/lib/$(PROFILE_DIRECTORY)/tmp/cil-stringreplacer.exe: $(topdir)/class/lib/$(PROFILE_DIRECTORY)/tmp/Mono.Cecil.Mdb.dll
+
+LIB_REFS += tmp/Mono.Cecil.Mdb
+endif # MCS_MODE
+
+else # Not basic/build
+LIB_REFS += Mono.Cecil
 
 ifdef MCS_MODE
 LIB_REFS += Mono.Cecil.Mdb
-endif
+endif # MCS_MODE
+
+endif # Not basic/build
 
 include ../../build/executable.make


### PR DESCRIPTION
What was happening was that this was building with a Mono.Cecil from
the build profile, but was trying to load the system Mono.Cecil.

Those versions mismatch when building 2018-08 with a nightly mono that is 5.23.0.

Rather than messing with the MONO_PATH and risking shadowing something
important there, I chose to copy the Mono.Cecil files into this
"lib/build/tmp" directory that we are using for the emitted executable.
It is loaded by the system Mono as the correct Mono.Cecil to use, as assemblies in the same folder have precedence.

This fixes the build.



Backport of #12573.

/cc @alexanderkyte 