### PR TITLE
[runtime] cleanup around native crash info

### DIFF
--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -1182,6 +1182,12 @@ mono_init_native_crash_info (void)
 	lldb_path = g_find_program_in_path ("lldb");
 }
 
+void
+mono_cleanup_native_crash_info (void)
+{
+	g_free (gdb_path);
+	g_free (lldb_path);
+}
 
 static gboolean
 native_stack_with_gdb (pid_t crashed_pid, const char **argv, int commands, char* commands_filename)

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4828,6 +4828,8 @@ mini_cleanup (MonoDomain *domain)
 
 	mono_generic_sharing_cleanup ();
 
+	mono_cleanup_native_crash_info ();
+
 	mono_cleanup ();
 
 	mono_trace_cleanup ();

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -516,6 +516,9 @@ void
 mono_init_native_crash_info (void);
 
 void
+mono_cleanup_native_crash_info (void);
+
+void
 mono_dump_native_crash_info (const char *signal, void *ctx, MONO_SIG_HANDLER_INFO_TYPE *info);
 
 void

--- a/mono/mini/mini-wasm.c
+++ b/mono/mini/mini-wasm.c
@@ -528,6 +528,12 @@ mono_init_native_crash_info (void)
 	return;
 }
 
+void
+mono_init_native_crash_info (void)
+{
+	return;
+}
+
 gboolean
 mono_thread_state_init_from_handle (MonoThreadUnwindState *tctx, MonoThreadInfo *info, void *sigctx)
 {

--- a/mono/mini/mini-wasm.c
+++ b/mono/mini/mini-wasm.c
@@ -529,7 +529,7 @@ mono_init_native_crash_info (void)
 }
 
 void
-mono_init_native_crash_info (void)
+mono_cleanup_native_crash_info (void)
 {
 	return;
 }

--- a/mono/mini/mini-windows.c
+++ b/mono/mini/mini-windows.c
@@ -251,6 +251,12 @@ mono_init_native_crash_info (void)
 	return;
 }
 
+void
+mono_cleanup_native_crash_info (void)
+{
+	return;
+}
+
 #if G_HAVE_API_SUPPORT (HAVE_CLASSIC_WINAPI_SUPPORT | HAVE_UWP_WINAPI_SUPPORT)
 /* mono_chain_signal:
  *


### PR DESCRIPTION
Contributes to https://github.com/mono/mono/issues/12404
