### PR TITLE
[spinlock] reduce interations in BCL test and extract it into a stress test

### DIFF
--- a/mcs/class/corlib/Test/System.Threading/SpinLockTests.cs
+++ b/mcs/class/corlib/Test/System.Threading/SpinLockTests.cs
@@ -135,7 +135,7 @@ namespace MonoTests.System.Threading
 				}, 4);
 
 				Assert.IsFalse (fail);
-			}, 200);
+			}, 5);
 		}
 
 		[Test]

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -167,7 +167,10 @@ check-coreclr:
 	$(MAKE) -C $(mono_build_root)/acceptance-tests check-coreclr
 
 check-stress:
-	$(MAKE) test-stress-sgen
+	ok=; \
+	$(MAKE) test-stress-sgen || ok=false; \
+	$(MAKE) stresstest || ok=false; \
+	$$ok
 
 # for backwards compatibility on Wrench
 test-wrench: check-parallel
@@ -259,6 +262,7 @@ TESTS_STRESS_SRC=	\
 	gc-graystack-stress.cs		\
 	exit-stress.cs		\
 	process-stress.cs	\
+	spinlock-stress.cs 	\
 	assembly-load-stress.cs
 
 # Disabled until ?mcs is fixed

--- a/mono/tests/spinlock-stress.cs
+++ b/mono/tests/spinlock-stress.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Threading;
+
+internal class SpinLockWrapper
+{
+	public SpinLock Lock = new SpinLock (false);
+}
+
+public class Tests
+{
+	public static void Main (string[] args)
+	{
+		int iterations = 200;
+		if (args.Length > 0)
+			iterations = Int32.Parse (args [0]);
+
+		ParallelTestHelper.Repeat (delegate {
+			int currentCount = 0;
+			bool fail = false;
+			SpinLockWrapper wrapper = new SpinLockWrapper ();
+
+			ParallelTestHelper.ParallelStressTest (wrapper, delegate {
+				bool taken = false;
+				wrapper.Lock.Enter (ref taken);
+				int current = currentCount++;
+				if (current != 0)
+					fail = true;
+
+				SpinWait sw = new SpinWait ();
+				for (int i = 0; i < 200; i++)
+					sw.SpinOnce ();
+				currentCount -= 1;
+
+				wrapper.Lock.Exit ();
+			}, 4);
+
+			if (fail)
+				Environment.Exit (1);
+		}, iterations);
+		Environment.Exit (0);
+	}
+}
+
+static class ParallelTestHelper
+{
+	public static void Repeat (Action action, int numRun)
+	{
+		for (int i = 0; i < numRun; i++) {
+			//Console.WriteLine ("Run " + i.ToString ());
+			action ();
+		}
+	}
+
+	public static void ParallelStressTest<TSource>(TSource obj, Action<TSource> action, int numThread)
+	{
+		Thread[] threads = new Thread[numThread];
+		for (int i = 0; i < numThread; i++) {
+			threads[i] = new Thread(new ThreadStart(delegate { action(obj); }));
+			threads[i].Start();
+		}
+
+		// Wait for the completion
+		for (int i = 0; i < numThread; i++)
+			threads[i].Join();
+	}
+}

--- a/mono/tests/stress-runner.pl
+++ b/mono/tests/stress-runner.pl
@@ -86,6 +86,12 @@ my %tests = (
 		'arg-knob' => 0, # loops
 		'ratio' => 20,
 	},
+	'spinlock-stress' => {
+		'program' => 'spinlock-stress.exe',
+		'args' => [20],
+		'arg-knob' => 0,
+		'ratio' => 4,
+	},
 	'abort-stress-1' => {
 		'program' => 'abort-stress-1.exe',
 		# loops,


### PR DESCRIPTION
Reduces execution time from about two minutes down to five seconds for SpinLockTests.

Contributes to https://github.com/mono/mono/issues/12363 (this PR doesn't fix it).