### PR TITLE
Fix handling invalid Windows proxy config

### DIFF
--- a/mcs/class/System/ReferenceSources/AutoWebProxyScriptEngine.cs
+++ b/mcs/class/System/ReferenceSources/AutoWebProxyScriptEngine.cs
@@ -122,6 +122,11 @@ namespace System.Net
 				ArrayList al = new ArrayList ();
 				
 				string strProxyServer = (string)Microsoft.Win32.Registry.GetValue ("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings", "ProxyServer", null);
+				
+				if(strProxyServer == null) {
+					return null;
+				}
+
 				string strProxyOverrride = (string)Microsoft.Win32.Registry.GetValue ("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings", "ProxyOverride", null);
 				
 				if (strProxyServer.Contains ("=")) {


### PR DESCRIPTION
This fixes `NullReferenceException` that was thrown if:
- `HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\ProxyEnable` was set to true (1)
- but `HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\ProxyServer` was set to null

Fixes #10030 

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
