### PR TITLE
Add support for Windows x64 winaot, winaot_llvm builds/tests on CI.

### DIFF
--- a/bcl.sln
+++ b/bcl.sln
@@ -3480,8 +3480,10 @@ Global
 		{045A3571-9B4B-4318-BD72-22C6CCD094F1}.Release|unreal.ActiveCfg = Release|net_4_x
 		{045A3571-9B4B-4318-BD72-22C6CCD094F1}.Debug|wasm.ActiveCfg = Debug|net_4_x
 		{045A3571-9B4B-4318-BD72-22C6CCD094F1}.Release|wasm.ActiveCfg = Release|net_4_x
-		{045A3571-9B4B-4318-BD72-22C6CCD094F1}.Debug|winaot.ActiveCfg = Debug|net_4_x
-		{045A3571-9B4B-4318-BD72-22C6CCD094F1}.Release|winaot.ActiveCfg = Release|net_4_x
+		{045A3571-9B4B-4318-BD72-22C6CCD094F1}.Debug|winaot.ActiveCfg = Debug|winaot
+		{045A3571-9B4B-4318-BD72-22C6CCD094F1}.Debug|winaot.Build.0 = Debug|winaot
+		{045A3571-9B4B-4318-BD72-22C6CCD094F1}.Release|winaot.ActiveCfg = Release|winaot
+		{045A3571-9B4B-4318-BD72-22C6CCD094F1}.Release|winaot.Build.0 = Release|winaot
 		{045A3571-9B4B-4318-BD72-22C6CCD094F1}.Debug|xammac.ActiveCfg = Debug|net_4_x
 		{045A3571-9B4B-4318-BD72-22C6CCD094F1}.Release|xammac.ActiveCfg = Release|net_4_x
 		{1B87A378-65E8-4899-9C9A-C940429D643C}.Debug|net_4_x.ActiveCfg = Debug|net_4_x

--- a/configure.ac
+++ b/configure.ac
@@ -1106,7 +1106,7 @@ AC_ARG_WITH(unreal,              [  --with-unreal=yes,no                If you w
 AC_ARG_WITH(wasm,                [  --with-wasm=yes,no                  If you want to build the WebAssembly (defaults to no)], [], [with_wasm=default])
 
 
-AC_ARG_WITH(runtime-preset, [  --with-runtime-preset=net_4_x,all,aot,aot_llvm,hybridaot,hybridaot_llvm,fullaot,fullaot_llvm,bitcode,unreal,fullaotinterp,fullaotinterp_llvm  Which default profile to build (defaults to net_4_x)],  [], [with_runtime_preset=net_4_x])
+AC_ARG_WITH(runtime-preset, [  --with-runtime-preset=net_4_x,all,aot,aot_llvm,hybridaot,hybridaot_llvm,fullaot,fullaot_llvm,winaot,winaot_llvm,bitcode,unreal,fullaotinterp,fullaotinterp_llvm  Which default profile to build (defaults to net_4_x)],  [], [with_runtime_preset=net_4_x])
 AC_ARG_WITH(spectre-mitigation,             [  --with-spectre-mitigation=yes,no   If you want to build the runtime with compiler flags that enable Spectre mitigation (defaults to no)], [], [with_spectre_mitigation=default])
 AC_ARG_WITH(spectre-indirect-branch-choice,   [  --with-spectre-indirect-branch-choice=keep,thunk,inline,extern   Convert indirect branches to the specified kind of thunk (defaults to inline)], [], [with_spectre_indirect_branch_choice=inline])
 AC_ARG_WITH(spectre-function-return-choice, [  --with-spectre-function-return-choice=keep,thunk,inline,extern   Convert function return instructions to the specified kind of thunk (defaults to inline)], [], [with_spectre_function_return_choice=inline])
@@ -1310,9 +1310,23 @@ elif test x$with_runtime_preset = xwinaot; then
    mono_feature_disable_reflection_emit='yes'
    mono_feature_disable_appdomains='yes'
 
-   AOT_BUILD_FLAGS="--runtime=mobile --aot=full,$INVARIANT_AOT_OPTIONS"
+   AOT_BUILD_FLAGS="--runtime=mobile -O=gsharedvt --aot=full,$INVARIANT_AOT_OPTIONS"
    AOT_RUN_FLAGS="--runtime=mobile --full-aot"
-   AOT_MODE="llvmonly"
+   AOT_MODE="full"
+elif test x$with_runtime_preset = xwinaot_llvm; then
+   DISABLE_MCS_DOCS_default=yes
+   with_winaot_default=yes
+   TEST_PROFILE=winaot
+
+   mono_feature_disable_com='yes'
+   mono_feature_disable_remoting='yes'
+   mono_feature_disable_reflection_emit_save='yes'
+   mono_feature_disable_reflection_emit='yes'
+   mono_feature_disable_appdomains='yes'
+
+   AOT_BUILD_FLAGS="--runtime=mobile -O=gsharedvt --llvm --aot=full,$INVARIANT_AOT_OPTIONS"
+   AOT_RUN_FLAGS="--runtime=mobile --full-aot"
+   AOT_MODE="full"
 elif test x$with_runtime_preset = xorbis; then
    DISABLE_MCS_DOCS_default=yes
    with_orbis_default=yes
@@ -5661,19 +5675,23 @@ if test "x$enable_msvc" = "xyes"; then
 		mono_msvc_build_lib_dir='$(mono_msvc_build_dir)'/Win32/lib/Release
 		mono_msvc_build_bin_dir='$(mono_msvc_build_dir)'/Win32/bin/Release
 		mono_runtime=msvc/build/sgen/Win32/bin/Release/mono-sgen.exe
+		mono_runtime_wrapper=$mono_runtime
 	else
 		mono_msvc_build_lib_dir='$(mono_msvc_build_dir)'/x64/lib/Release
 		mono_msvc_build_bin_dir='$(mono_msvc_build_dir)'/x64/bin/Release
 		mono_runtime=msvc/build/sgen/x64/bin/Release/mono-sgen.exe
+		mono_runtime_wrapper=msvc/build/sgen/x64/bin/Release/mono-sgen-msvc.sh
 	fi
 	AC_SUBST(mono_msvc_build_dir)
 	AC_SUBST(mono_msvc_build_lib_dir)
 	AC_SUBST(mono_msvc_build_bin_dir)
 else
 	mono_runtime=mono/mini/mono
+	mono_runtime_wrapper=$mono_runtime
 fi
 
 AC_SUBST(mono_runtime)
+AC_SUBST(mono_runtime_wrapper)
 
 CSC_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/Microsoft.Net.Compilers.2.8.2/tools/csc.exe
 

--- a/mcs/class/Makefile
+++ b/mcs/class/Makefile
@@ -154,7 +154,8 @@ monotouch_tv_runtime_dirs := \
 
 winaot_dirs_parallel := \
 	$(mobile_common_dirs_parallel)	\
-	System.Drawing
+	System.Drawing \
+	Mono.Simd
 
 unreal_dirs_parallel := \
 	$(mobile_common_dirs_parallel)	\

--- a/mcs/class/Mono.Simd/Mono.Simd.csproj
+++ b/mcs/class/Mono.Simd/Mono.Simd.csproj
@@ -61,6 +61,11 @@
     <IntermediateOutputPath>./../../class/obj/$(AssemblyName)-testing_aot_full</IntermediateOutputPath>
     <DefineConstants>NET_1_1;NET_2_0;NET_2_1;NET_3_5;NET_4_0;NET_4_5;MONO;MOBILE;MOBILE_LEGACY;FULL_AOT_DESKTOP;FULL_AOT_RUNTIME;DISABLE_REMOTING;DISABLE_COM</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Platform)' == 'winaot' ">
+    <OutputPath>./../../class/lib/winaot</OutputPath>
+    <IntermediateOutputPath>./../../class/obj/$(AssemblyName)-winaot</IntermediateOutputPath>
+    <DefineConstants>NET_1_1;NET_2_0;NET_2_1;NET_3_5;NET_4_0;NET_4_5;MONO;MOBILE;MOBILE_LEGACY;FULL_AOT_DESKTOP;FULL_AOT_RUNTIME;DISABLE_REMOTING;DISABLE_COM;WIN_PLATFORM</DefineConstants>
+  </PropertyGroup>
   <!-- @ALL_PROFILE_PROPERTIES@ -->
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -67,7 +67,7 @@ TOOLS_RUNTIME = MONO_PATH=$(mcs_topdir)/class/lib/build $(top_builddir)/runtime/
 INTERP_RUNTIME = $(MINI_RUNTIME) --interpreter
 RUNTIME_AOTCHECK = MONO_PATH="$(CLASS)$(PLATFORM_PATH_SEPARATOR)." $(RUNTIME_EXECUTABLE)
 
-MCS = CSC_SDK_PATH_DISABLED= $(TOOLS_RUNTIME) $(CSC) -langversion:7.2 -unsafe -nowarn:0162 -nologo -noconfig -r:$(CLASS)/mscorlib.dll -r:$(CLASS)/System.dll -r:$(CLASS)/System.Core.dll
+MCS = CSC_SDK_PATH_DISABLED= $(TOOLS_RUNTIME) $(CSC) -langversion:7.2 -nostdlib -unsafe -nowarn:0162 -nologo -noconfig -r:$(CLASS)/mscorlib.dll -r:$(CLASS)/System.dll -r:$(CLASS)/System.Core.dll
 ILASM = $(TOOLS_RUNTIME) $(mcs_topdir)/class/lib/build/ilasm.exe
 
 AM_CFLAGS = \
@@ -964,16 +964,16 @@ FULLAOT_LIBS = $(filter-out $(FULLAOT_LIBS_DISABLED),$(FULLAOT_LIBS_UNIVERSAL))
 
 FULLAOT_TMP_DIR=$(top_builddir)/mono/mini/fullaot-tmp
 
-FULLAOT_AOT_ARGS=$(if $(HYBRID),hybrid,full,interp)
+FULLAOT_AOT_ARGS=$(if $(HYBRID),hybrid,full,interp),$(MONO_FULLAOT_ADDITIONAL_ARGS)$(INVARIANT_AOT_OPTIONS)
 FULLAOT_ARGS=$(if $(HYBRID),--hybrid-aot,--full-aot)
 
 # This currently only works on amd64/arm
 fullaotcheck: $(mono) $(fullaot_regtests) $(fullaot_testing_deps)
 	rm -rf $(FULLAOT_TMP_DIR)
 	mkdir $(FULLAOT_TMP_DIR)
-	$(MAKE) fullaot-libs AOT_FLAGS="$(FULLAOT_AOT_ARGS),$(MONO_FULLAOT_ADDITIONAL_ARGS)$(INVARIANT_AOT_OPTIONS)" GSHAREDVT=$(GSHAREDVT)
-	cp $(regtests) $(fullaot_regtests) $(fullaot_testing_deps) $(FULLAOT_TMP_DIR)/
-	MONO_PATH=$(FULLAOT_TMP_DIR) $(top_builddir)/runtime/mono-wrapper $(MOBILE_RUNTIME_ARG) $(LLVM_AOT_RUNTIME_OPTS) $(GSHAREDVT_RUNTIME_OPTS) --aot="$(FULLAOT_AOT_ARGS),$(MONO_FULLAOT_ADDITIONAL_ARGS)$(INVARIANT_AOT_OPTIONS)" $(FULLAOT_TMP_DIR)/{$(fullaot_testing_deps_commas),*.exe} || exit 1
+	$(MAKE) fullaot-libs AOT_FLAGS="$(FULLAOT_AOT_ARGS)"
+	cp $(fullaot_regtests) $(fullaot_testing_deps) $(FULLAOT_TMP_DIR)/
+	MONO_PATH=$(FULLAOT_TMP_DIR) $(top_builddir)/runtime/mono-wrapper $(MOBILE_RUNTIME_ARG) $(LLVM_AOT_RUNTIME_OPTS) $(GSHAREDVT_RUNTIME_OPTS) --aot="$(FULLAOT_AOT_ARGS)" $(FULLAOT_TMP_DIR)/{$(fullaot_testing_deps_commas),*.exe} || exit 1
 	ln -s $(if $(MONO_EXECUTABLE),$(MONO_EXECUTABLE),$$PWD/mono) $(FULLAOT_TMP_DIR)/
 	for i in $(fullaot_regtests); do echo $$i; MONO_PATH=$(FULLAOT_TMP_DIR) $(top_builddir)/runtime/mono-wrapper $(MOBILE_RUNTIME_ARG) $(FULLAOT_ARGS) $(FULLAOT_TMP_DIR)/$$i --exclude '!FULLAOT' $(ARCH_FULLAOT_EXCLUDE) || exit 1; done
 	if test x$(MIXED) == x1; then failed=0;i=0; while test $$i -lt 900; do i=`expr $$i + 1`; bash -c "echo -n '.'"; MONO_PATH=$(FULLAOT_TMP_DIR) MONO_DEBUG=aot-skip=$$i ./mono --full-aot-interp $(FULLAOT_TMP_DIR)/basic.exe > $(FULLAOT_TMP_DIR)/mixed.log || failed=1; if test $$failed -eq 1; then echo "Failed at $$i"; exit $$failed; fi; done; fi
@@ -984,11 +984,11 @@ fullaot-libs: $(patsubst %,fullaot-tmp/%.dylib,$(FULLAOT_LIBS))
 fullaot-tmp/%.dylib: $(CLASS)/%
 	cp $(CLASS)/$* fullaot-tmp/
 	mkdir fullaot-tmp/$*-tmp
-	MONO_PATH="fullaot-tmp/$(PLATFORM_PATH_SEPARATOR)$(CLASS)" $(top_builddir)/runtime/mono-wrapper $(MOBILE_RUNTIME_ARG) $(if $(GSHAREDVT),-O=gsharedvt) --aot=$(AOT_FLAGS),temp-path=fullaot-tmp/$*-tmp fullaot-tmp/$*
+	MONO_PATH="fullaot-tmp/$(PLATFORM_PATH_SEPARATOR)$(CLASS)" $(top_builddir)/runtime/mono-wrapper $(MOBILE_RUNTIME_ARG) $(LLVM_AOT_RUNTIME_OPTS) $(GSHAREDVT_RUNTIME_OPTS) --aot=$(AOT_FLAGS),temp-path=fullaot-tmp/$*-tmp fullaot-tmp/$*
 	rm -rf fullaot-tmp/$*-tmp
 
 llvmfullaotcheck:
-	$(MAKE) fullaotcheck LLVM=1
+	$(MAKE) fullaotcheck LLVM=1 GSHAREDVT=1
 
 llvmonly_regtests = $(fullaot_regtests) gshared.exe
 

--- a/msvc/mono-sgen-msvc.bat
+++ b/msvc/mono-sgen-msvc.bat
@@ -1,0 +1,229 @@
+:: Set up VS MSVC environment when running MSVC build mono-sgen.exe with all supplied arguments.
+:: Simplify the setup of VS and MSVC toolchain, when running Mono AOT compiler
+:: since it need to locate correct compiler and OS libraries as well as clang.exe and link.exe
+:: from VS setup for the corresponding architecture.
+
+@echo off
+
+setlocal
+
+set EXECUTE_RESULT=1
+
+:: Make sure we can restore current working directory after setting up environment.
+:: Some of the VS scripts can change the current working directory.
+set CALLER_WD=%CD%
+
+:: Get path for current running script.
+set RUN_MONO_SGEN_MSVC_SCRIPT_PATH=%~dp0
+
+:: If we are running from none Windows shell we will need to restore a clean PATH
+:: before setting up VS MSVC build environment. If not there is a risk we will pick up
+:: for example cygwin binaries when running toolchain commands not explicitly setup by VS MSVC build environment.
+set HKCU_ENV_PATH=
+set HKLM_ENV_PATH=
+if "%SHELL%" == "/bin/bash" (
+    for /f "tokens=2,*" %%a in ('%WINDIR%\System32\reg.exe query "HKCU\Environment" /v "Path" ^| %WINDIR%\System32\find.exe /i "REG_"') do (
+        SET HKCU_ENV_PATH=%%b
+    )
+    for /f "tokens=2,*" %%a in ('%WINDIR%\System32\reg.exe query "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v "Path" ^| %WINDIR%\System32\find.exe /i "REG_"') do (
+        SET HKLM_ENV_PATH=%%b
+    )
+)
+
+:: Restore default path, if we are running from none Windows shell.
+if "%SHELL%" == "/bin/bash" (
+    call :restore_default_path "%HKCU_ENV_PATH%" "%HKLM_ENV_PATH%"
+)
+
+:: NOTE, MSVC build mono-sgen.exe AOT compiler currently support 64-bit AMD codegen. Below will only setup
+:: amd64 versions of VS MSVC build environment and corresponding ClangC2 compiler.
+
+set VS_2015_TOOLCHAIN_ARCH=amd64
+set VS_2015_VCVARS_ARCH=%VS_2015_TOOLCHAIN_ARCH%\vcvars64.bat
+set VS_2015_CLANGC2_ARCH=%VS_2015_TOOLCHAIN_ARCH%
+set VS_2017_VCVARS_ARCH=vcvars64.bat
+set VS_2017_CLANGC2_ARCH=HostX64
+
+:: 32-bit AOT toolchains for MSVC build mono-sgen.exe is currently not supported.
+:: set VS_2015_TOOLCHAIN_ARCH=x86
+:: set VS_2015_VCVARS_ARCH=vcvars32.bat
+:: set VS_2015_CLANGC2_ARCH=%VS_2015_TOOLCHAIN_ARCH%
+:: set VS_2017_VCVARS_ARCH=vcvars32.bat
+:: set VS_2017_CLANGC2_ARCH=HostX86
+
+set MONO_AS_AOT_COMPILER=0
+set VS_CLANGC2_TOOLS_BIN_PATH=
+
+:: Optimization, check if we need to setup full build environment, only needed when running mono-sgen.exe as AOT compiler.
+echo.%* | findstr /c:"--aot=" > nul && (
+    set MONO_AS_AOT_COMPILER=1
+)
+
+if %MONO_AS_AOT_COMPILER% == 1 (
+    goto SETUP_VS_ENV
+)
+
+:: mono-sgen.exe not invoked as a AOT compiler, no need to setup full build environment.
+goto ON_EXECUTE
+
+:: Try setting up VS MSVC build environment.
+:SETUP_VS_ENV
+
+:: Optimization, check if we have something that looks like a MSVC build environment already available.
+if /i not "%VCINSTALLDIR%" == "" (
+    if /i not "%INCLUDE%" == "" (
+        if /i not "%LIB%" == "" (
+            goto ON_EXECUTE
+        )
+    )
+)
+
+:: Visual Studio 2015 == 14.0
+if "%VisualStudioVersion%" == "14.0" (
+    goto SETUP_VS_2015
+)
+
+:: Visual Studio 2017 == 15.0
+if "%VisualStudioVersion%" == "15.0" (
+    goto SETUP_VS_2017
+)
+
+:SETUP_VS_2015
+
+set VS_2015_VCINSTALL_DIR=%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\
+
+:: Try to locate installed VS2015 Clang/C2.
+SET VS_2015_CLANGC2_TOOLS_BIN_PATH=%VS_2015_VCINSTALL_DIR%ClangC2\bin\%VS_2015_CLANGC2_ARCH%\
+SET VS_2015_CLANGC2_TOOLS_BIN=%VS_2015_CLANGC2_TOOLS_BIN_PATH%clang.exe
+
+if not exist "%VS_2015_CLANGC2_TOOLS_BIN%" (
+    goto SETUP_VS_2017
+)
+
+:SETUP_VS_2015_BUILD_TOOLS
+
+:: Try to locate VS2015 build tools installation.
+set VS_2015_BUILD_TOOLS_INSTALL_DIR=%ProgramFiles(x86)%\Microsoft Visual C++ Build Tools\
+set VS_2015_BUILD_TOOLS_CMD=%VS_2015_BUILD_TOOLS_INSTALL_DIR%vcbuildtools.bat
+
+:: Setup VS2015 VC development environment using build tools installation.
+call :setup_build_env "%VS_2015_BUILD_TOOLS_CMD%" "%VS_2015_TOOLCHAIN_ARCH%" "%CALLER_WD%" && (
+    set "VS_CLANGC2_TOOLS_BIN_PATH=%VS_2015_CLANGC2_TOOLS_BIN_PATH%"
+    goto ON_EXECUTE
+)
+
+:SETUP_VS_2015_VC
+
+:: Try to locate installed VS2015 VC environment.
+set VS_2015_DEV_CMD=%VS_2015_VCINSTALL_DIR%bin\%VS_2015_VCVARS_ARCH%
+
+call :setup_build_env "%VS_2015_DEV_CMD%" "" "%CALLER_WD%" && (
+    set "VS_CLANGC2_TOOLS_BIN_PATH=%VS_2015_CLANGC2_TOOLS_BIN_PATH%"
+    goto ON_EXECUTE
+)
+
+:SETUP_VS_2017
+
+:: VS2017 includes vswhere.exe that can be used to locate current VS2017 installation.
+set VSWHERE_TOOLS_BIN=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe
+set VS_2017_VCINSTALL_DIR=
+
+:: Try to locate installed VS2017 VC environment.
+if exist "%VSWHERE_TOOLS_BIN%" (
+    for /f "tokens=*" %%a in ('"%VSWHERE_TOOLS_BIN%" -latest -property installationPath') do (
+        set VS_2017_VCINSTALL_DIR=%%a\VC\
+    )
+)
+
+:: Try to locate installed VS2017 Clang/C2.
+SET VS_2017_CLANGC2_VERSION_FILE=%VS_2017_VCINSTALL_DIR%Auxiliary/Build/Microsoft.ClangC2Version.default.txt
+if not exist "%VS_2017_CLANGC2_VERSION_FILE%" (
+	goto ON_ENV_ERROR
+)
+
+set /p VS_2017_CLANGC2_VERSION=<"%VS_2017_CLANGC2_VERSION_FILE%"
+set VS_2017_CLANGC2_TOOLS_BIN_PATH=%VS_2017_VCINSTALL_DIR%Tools\ClangC2\%VS_2017_CLANGC2_VERSION%\bin\%VS_2017_CLANGC2_ARCH%\
+set VS_2017_CLANGC2_TOOLS_BIN=%VS_2017_CLANGC2_TOOLS_BIN_PATH%clang.exe
+if not exist "%VS_2017_CLANGC2_TOOLS_BIN%" (
+	goto ON_ENV_ERROR
+)
+
+:SETUP_VS_2017_BUILD_TOOLS
+
+:: Try to locate VS2017 build tools installation.
+set VS_2017_BUILD_TOOLS_INSTALL_DIR=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\
+set VS_2017_BUILD_TOOLS_CMD=%VS_2017_BUILD_TOOLS_INSTALL_DIR%VC\Auxiliary\Build\%VS_2017_VCVARS_ARCH%
+
+:: Setup VS2017 VC development environment using build tools installation.
+call :setup_build_env "%VS_2017_BUILD_TOOLS_CMD%" "" "%CALLER_WD%" && (
+    set "VS_CLANGC2_TOOLS_BIN_PATH=%VS_2017_CLANGC2_TOOLS_BIN_PATH%"
+    goto ON_EXECUTE
+)
+
+:SETUP_VS_2017_VC
+
+:: Try to locate installed VS2017 VC environment.
+set VS_2017_DEV_CMD=%VS_2017_VCINSTALL_DIR%Auxiliary\Build\%VS_2017_VCVARS_ARCH%
+
+:: Setup VS2017 VC development environment using VS installation.
+call :setup_build_env "%VS_2017_DEV_CMD%" "" "%CALLER_WD%" && (
+    set "VS_CLANGC2_TOOLS_BIN_PATH=%VS_2017_CLANGC2_TOOLS_BIN_PATH%"
+    goto ON_EXECUTE
+)
+
+:ON_ENV_ERROR
+
+echo Warning, failed to setup build environment needed by MSVC build mono-sgen.exe running as an AOT compiler.
+echo Incomplete build environment can cause AOT compiler build due to missing compiler, linker and platform libraries.
+
+:ON_EXECUTE
+
+:: Add mono.sgen.exe (needed for optional LLVM tooling) and ClangC2 folders to PATH
+set "PATH=%RUN_MONO_SGEN_MSVC_SCRIPT_PATH%;%VS_CLANGC2_TOOLS_BIN_PATH%;%PATH%"
+
+call "%RUN_MONO_SGEN_MSVC_SCRIPT_PATH%mono-sgen.exe" %* && (
+    set EXCEUTE_RESULT=0
+) || (
+    set EXCEUTE_RESULT=1
+    if not %ERRORLEVEL% == 0 (
+        set EXCEUTE_RESULT=%ERRORLEVEL%
+    )
+)
+
+exit /b %EXCEUTE_RESULT%
+
+:setup_build_env
+
+:: Check if VS build environment script exists.
+if not exist "%~1" (
+    goto setup_build_env_error
+)
+
+:: Run VS build environment script.
+call "%~1" %~2 > NUL
+
+:: Restore callers working directory in case it has been changed by VS scripts.
+cd /d "%~3"
+
+goto setup_build_env_exit
+
+:setup_build_env_error
+exit /b 1
+
+:setup_build_env_exit
+goto :EOF
+
+:restore_default_path
+
+:: Restore default PATH.
+if not "%~2" == "" (
+    if not "%~1" == "" (
+        set "PATH=%~2;%~1"
+    ) else (
+        set "PATH=%~2"
+    )
+)
+
+goto :EOF
+
+@echo on

--- a/msvc/mono-sgen-msvc.sh
+++ b/msvc/mono-sgen-msvc.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Wrapper that can be used as MONO_EXECUTABLE_WRAPPER in mono-wrapper when running MSVC build
+# mono-sgen.exe. Simplify the setup of VS and MSVC toolchain, primarly when running MSVC build
+# mono-sgen.exe as AOT compiler, since it needs to locate libraries as well as ClangC2 and linker
+# from VS MSVC for corresponding architecture.
+
+# NOTE, MSVC build mono-sgen.exe AOT compiler currently support 64-bit AMD codegen. mono-sgen-msvc.bat will ony setup
+# amd64 versions of VS MSVC build environment and corresponding ClangC2 compiler.
+
+# Optimization, only run full build environment when running mono-sgen.exe as AOT compiler.
+# If not, just run mono-sgen.exe with supplied arguments.
+
+MONO_SGEN_MSVC_SCRIPT_PATH=$(cd "$(dirname "$0")"; pwd)
+
+if [[ "$@" != *"--aot="* ]]; then
+    "$MONO_SGEN_MSVC_SCRIPT_PATH/mono-sgen.exe" "$@"
+else
+    MONO_SGEN_MSVC_SCRIPT_PATH=$(cygpath -w "$MONO_SGEN_MSVC_SCRIPT_PATH/mono-sgen-msvc.bat")
+    "$WINDIR/System32/cmd.exe" /c "$MONO_SGEN_MSVC_SCRIPT_PATH" "$@"
+fi

--- a/msvc/mono.vcxproj
+++ b/msvc/mono.vcxproj
@@ -111,6 +111,10 @@
     <ProjectReference>
       <LinkLibraryDependencies>false</LinkLibraryDependencies>
     </ProjectReference>
+    <PostBuildEvent>
+      <Command>xcopy "$(SolutionDir)mono-sgen-msvc.sh" "$(OutDir)" /q /y &gt;nul 2&gt;&amp;1
+xcopy "$(SolutionDir)mono-sgen-msvc.bat" "$(OutDir)" /q /y &gt;nul 2&gt;&amp;1</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Midl>
@@ -135,6 +139,10 @@
       <ShowProgress>
       </ShowProgress>
     </Link>
+    <PostBuildEvent>
+      <Command>xcopy "$(SolutionDir)mono-sgen-msvc.sh" "$(OutDir)" /q /y &gt;nul 2&gt;&amp;1
+xcopy "$(SolutionDir)mono-sgen-msvc.bat" "$(OutDir)" /q /y &gt;nul 2&gt;&amp;1</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -155,6 +163,10 @@
       <DataExecutionPrevention>
       </DataExecutionPrevention>
     </Link>
+    <PostBuildEvent>
+      <Command>xcopy "$(SolutionDir)mono-sgen-msvc.sh" "$(OutDir)" /q /y &gt;nul 2&gt;&amp;1
+xcopy "$(SolutionDir)mono-sgen-msvc.bat" "$(OutDir)" /q /y &gt;nul 2&gt;&amp;1</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Midl>
@@ -176,6 +188,10 @@
       <AdditionalDependencies>$(MONO_LIBMONO_LIB);%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
     </Link>
+    <PostBuildEvent>
+      <Command>xcopy "$(SolutionDir)mono-sgen-msvc.sh" "$(OutDir)" /q /y &gt;nul 2&gt;&amp;1
+xcopy "$(SolutionDir)mono-sgen-msvc.bat" "$(OutDir)" /q /y &gt;nul 2&gt;&amp;1</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(MONO_COMPILE_AS_CPP)'=='true'">
     <ClCompile>

--- a/msvc/run-msbuild.bat
+++ b/msvc/run-msbuild.bat
@@ -1,17 +1,96 @@
 :: Set up build environment and run execute msbuild with all supplied arguments.
+
+:: Arguments:
+:: -------------------------------------------------------
+:: %1 Visual Studio target, build|clean, default build
+:: %2 Host CPU architecture, x86_64|i686, default x86_64
+:: %3 Visual Studio configuration, debug|release, default release
+:: %4 Additional arguments passed to msbuild, needs to be quoted if multiple.
+:: -------------------------------------------------------
+
 @echo off
+
 setlocal
 
 set BUILD_RESULT=1
 
-set VS_2015_DEV_CMD=%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\Common7\Tools\VsMSBuildCmd.bat
-set VS_2015_BUILD_TOOLS_CMD=%ProgramFiles(x86)%\Microsoft Visual C++ Build Tools\vcbuildtools_msbuild.bat
-set VSWHERE_TOOLS_BIN=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe
-set VS_2017_DEV_CMD=
-set VS_2017_BUILD_TOOLS_CMD=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\Common7\Tools\VsMSBuildCmd.bat
-set VS_PLATFORM_TOOLSET=/p:PlatformToolset=v140
+:: Make sure we can restore current working directory after setting up environment.
+:: Some of the VS scripts can change the current working directory.
+set CALLER_WD=%CD%
+
+:: Get path for current running script.
+set RUN_MSBUILD_SCRIPT_PATH=%~dp0
+
+:: If we are running from none Windows shell we will need to restore a clean PATH
+:: before setting up VS MSVC build environment. If not there is a risk we will pick up
+:: for example cygwin binaries when running toolchain commands not explicitly setup by VS MSVC build environment.
+set HKCU_ENV_PATH=
+set HKLM_ENV_PATH=
+if "%SHELL%" == "/bin/bash" (
+    for /f "tokens=2,*" %%a in ('%WINDIR%\System32\reg.exe query "HKCU\Environment" /v "Path" ^| %WINDIR%\System32\find.exe /i "REG_"') do (
+        SET HKCU_ENV_PATH=%%b
+    )
+    for /f "tokens=2,*" %%a in ('%WINDIR%\System32\reg.exe query "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v "Path" ^| %WINDIR%\System32\find.exe /i "REG_"') do (
+        SET HKLM_ENV_PATH=%%b
+    )
+)
+
+:: Restore default path, if we are running from none Windows shell.
+if "%SHELL%" == "/bin/bash" (
+    call :restore_default_path "%HKCU_ENV_PATH%" "%HKLM_ENV_PATH%"
+)
+
+:: There is still a scenario where the default path can include cygwin\bin folder. If that's the case
+:: there is still a big risk that build tools will be incorrectly resolved towards cygwin bin folder.
+:: Make sure to adjust path and drop all cygwin paths.
+set NEW_PATH=
+call where /Q "cygpath.exe" && (
+    echo Warning, PATH includes cygwin bin folders. This can cause build errors due to incorrectly
+    echo located build tools. Build script will drop all cygwin folders from used PATH.
+    for %%a in ("%PATH:;=";"%") do (
+        if not exist "%%~a\cygpath.exe" (
+            call :add_to_new_path "%%~a"
+        )
+    )
+)
+
+if not "%NEW_PATH%" == "" (
+    set "PATH=%NEW_PATH%"
+)
+
+:: Configure all known build arguments.
+set VS_BUILD_ARGS=""
+set VS_TARGET=build
+if /i "%~1" == "clean" (
+    set VS_TARGET="clean"
+)
+shift
+
+set VS_PLATFORM=x64
+if /i "%~1" == "i686" (
+    set VS_PLATFORM="Win32"
+)
+if /i "%~1" == "win32" (
+    set VS_PLATFORM="Win32"
+)
+shift
+
+set VS_CONFIGURATION=Release
+if /i "%~1" == "debug" (
+    set VS_CONFIGURATION="Debug"
+)
+shift
+
+set "VS_ADDITIONAL_ARGUMENTS=/p:PlatformToolset=v140 /p:MONO_TARGET_GC=sgen"
+if /i not "%~1" == "" (
+    set VS_ADDITIONAL_ARGUMENTS=%~1
+)
 
 :: Visual Studio 2015 == 14.0
+if "%VisualStudioVersion%" == "14.0" (
+    goto SETUP_VS_2015
+)
+
 :: Visual Studio 2017 == 15.0
 if "%VisualStudioVersion%" == "15.0" (
     goto SETUP_VS_2017
@@ -19,46 +98,117 @@ if "%VisualStudioVersion%" == "15.0" (
 
 :SETUP_VS_2015
 
-if exist "%VS_2015_DEV_CMD%" (
-    echo Setting up VS2015 build environment.
-    call "%VS_2015_DEV_CMD%" && (
-        goto ON_BUILD
-    )
+:SETUP_VS_2015_BUILD_TOOLS
+
+:: Try to locate VS2015 build tools installation.
+set VS_2015_BUILD_TOOLS_CMD=%ProgramFiles(x86)%\Microsoft Visual C++ Build Tools\vcbuildtools_msbuild.bat
+
+:: Setup VS2015 VC development environment using build tools installation.
+call :setup_build_env "%VS_2015_BUILD_TOOLS_CMD%" "%CALLER_WD%" && (
+    goto ON_BUILD
 )
 
-if exist "%VS_2015_BUILD_TOOLS_CMD%" (
-    echo Setting up VS2015 build environment.
-    call "%VS_2015_BUILD_TOOLS_CMD%" && (
-        goto ON_BUILD
-    )
+:SETUP_VS_2015_VC
+
+:: Try to locate installed VS2015 VC environment.
+set VS_2015_DEV_CMD=%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\Common7\Tools\VsMSBuildCmd.bat
+
+:: Setup VS2015 VC development environment using VS installation.
+call :setup_build_env "%VS_2015_DEV_CMD%" "%CALLER_WD%" && (
+    goto ON_BUILD
 )
 
 :SETUP_VS_2017
 
+:SETUP_VS_2017_BUILD_TOOLS
+
+:: Try to locate VS2017 build tools installation.
+set VS_2017_BUILD_TOOLS_CMD=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\Common7\Tools\VsMSBuildCmd.bat
+
+:: Setup VS2017 VC development environment using build tools installation.
+call :setup_build_env "%VS_2017_BUILD_TOOLS_CMD%" "%CALLER_WD%" && (
+    goto ON_BUILD
+)
+
+:SETUP_VS_2017_VC
+
+:: VS2017 includes vswhere.exe that can be used to locate current VS2017 installation.
+set VSWHERE_TOOLS_BIN=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe
+set VS_2017_DEV_CMD=
+
+:: Try to locate installed VS2017 VC environment.
 if exist "%VSWHERE_TOOLS_BIN%" (
     for /f "tokens=*" %%a in ('"%VSWHERE_TOOLS_BIN%" -latest -property installationPath') do (
         set VS_2017_DEV_CMD=%%a\Common7\Tools\VsMSBuildCmd.bat
     )
 )
 
-if exist "%VS_2017_DEV_CMD%" (
-    echo Setting up VS2017 build environment.
-    call "%VS_2017_DEV_CMD%"
-    set VS_PLATFORM_TOOLSET=/p:PlatformToolset=v141
+:: Setup VS2017 VC development environment using VS installation.
+call :setup_build_env "%VS_2017_DEV_CMD%" "%CALLER_WD%" && (
+    goto ON_BUILD
 )
 
-if exist "%VS_2017_BUILD_TOOLS_CMD%" (
-    echo Setting up VS2017 build environment.
-    call "%VS_2017_BUILD_TOOLS_CMD%"
-    set VS_PLATFORM_TOOLSET=/p:PlatformToolset=v141
-)
+:ON_ENV_ERROR
+
+echo Warning, failed to setup build environment needed by msbuild.exe.
+echo Incomplete build environment can cause build error's due to missing compiler, linker and platform libraries.
 
 :ON_BUILD
 
-call msbuild.exe %VS_PLATFORM_TOOLSET% %* "%~dp0mono.sln" && (
+set VS_BUILD_ARGS=/p:Configuration=%VS_CONFIGURATION% /p:Platform=%VS_PLATFORM% %VS_ADDITIONAL_ARGUMENTS% /t:%VS_TARGET%
+call msbuild.exe %VS_BUILD_ARGS% "%RUN_MSBUILD_SCRIPT_PATH%mono.sln" && (
     set BUILD_RESULT=0
+) || (
+    set BUILD_RESULT=1
+    if not %ERRORLEVEL% == 0 (
+        set BUILD_RESULT=%ERRORLEVEL%
+    )
 )
 
 exit /b %BUILD_RESULT%
+
+:setup_build_env
+
+:: Check if VS build environment script exists.
+if not exist "%~1" (
+    goto setup_build_env_error
+)
+
+:: Run VS build environment script.
+call "%~1" > NUL
+
+:: Restore callers working directory in case it has been changed by VS scripts.
+cd /d "%~2"
+
+goto setup_build_env_exit
+
+:setup_build_env_error
+exit /b 1
+
+:setup_build_env_exit
+goto :EOF
+
+:restore_default_path
+
+:: Restore default PATH.
+if not "%~2" == "" (
+    if not "%~1" == "" (
+        set "PATH=%~2;%~1"
+    ) else (
+        set "PATH=%~2"
+    )
+)
+
+goto :EOF
+
+:add_to_new_path
+
+if "%NEW_PATH%" == "" (
+    set "NEW_PATH=%~1"
+) else (
+    SET "NEW_PATH=%NEW_PATH%;%~1"
+)
+
+goto :EOF
 
 @echo on

--- a/msvc/run-msbuild.sh
+++ b/msvc/run-msbuild.sh
@@ -4,29 +4,11 @@
 #-------------------------------------------------------
 # $1 Visual Studio target, build|clean, default build
 # $2 Host CPU architecture, x86_64|i686, default x86_64
+# $3 Visual Studio configuration, debug|release, default release
+# $4 Additional arguments passed to msbuild, needs to be quoted if multiple.
 #-------------------------------------------------------
 
-VS_TARGET="build"
-VS_PLATFORM="x64"
+RUN_MSBUILD_SCRIPT_PATH=$(cd "$(dirname "$0")"; pwd)
+RUN_MSBUILD_SCRIPT_PATH=$(cygpath -w "$RUN_MSBUILD_SCRIPT_PATH/run-msbuild.bat")
 
-if [[ $1 = "clean" ]]; then
-    VS_TARGET="clean"
-fi
-
-if [[ $2 = "i686" ]]; then
-    VS_PLATFORM="Win32"
-fi
-
-VS_BUILD_ARGS="run-msbuild.bat"
-VS_BUILD_ARGS+=" /p:Configuration=Release"
-VS_BUILD_ARGS+=" /p:Platform=$VS_PLATFORM"
-VS_BUILD_ARGS+=" /p:MONO_TARGET_GC=sgen"
-VS_BUILD_ARGS+=" /t:Build"
-
-if [[ -z "$ORIGINAL_PATH" ]]; then
-    echo "Warning, run-msbuild.sh executed without ORIGINAL_PATH environment variable set. \
-    Windows environment can not be properly restored before running command."
-fi
-
-export PATH=$ORIGINAL_PATH
-$WINDIR/System32/cmd.exe /c "$VS_BUILD_ARGS"
+"$WINDIR/System32/cmd.exe" /c "$RUN_MSBUILD_SCRIPT_PATH" "$@"

--- a/runtime/mono-wrapper.in
+++ b/runtime/mono-wrapper.in
@@ -2,6 +2,10 @@
 r='@mono_build_root@'
 MONO_CFG_DIR='@mono_cfg_dir@'
 PATH="$r/runtime/_tmpinst/bin:$PATH"
+if [ -z "$MONO_EXECUTABLE_WRAPPER" ]
+then
+    MONO_EXECUTABLE_WRAPPER=${MONO_EXECUTABLE:-"$r/@mono_runtime_wrapper@"}
+fi
 MONO_EXECUTABLE=${MONO_EXECUTABLE:-"$r/@mono_runtime@"}
 export MONO_CFG_DIR PATH
-exec "$r/libtool" --mode=execute "${MONO_EXECUTABLE}" --config "@mono_cfg_dir@/mono/config" "$@"
+exec "$r/libtool" --mode=execute "${MONO_EXECUTABLE_WRAPPER}" --config "@mono_cfg_dir@/mono/config" "$@"

--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -67,6 +67,7 @@ if [[ ${CI_TAGS} == *'disable-mcs-build'* ]]; then EXTRA_CONF_FLAGS="${EXTRA_CON
 
 if   [[ ${CI_TAGS} == *'fullaot_llvm'* ]];       then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --enable-llvm=yes --with-runtime-preset=fullaot_llvm ";
 elif [[ ${CI_TAGS} == *'hybridaot_llvm'* ]];     then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --enable-llvm=yes --with-runtime-preset=hybridaot_llvm";
+elif [[ ${CI_TAGS} == *'winaot_llvm'* ]];        then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --enable-llvm=yes --with-runtime-preset=winaot_llvm";
 elif [[ ${CI_TAGS} == *'aot_llvm'* ]];           then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --enable-llvm=yes --with-runtime-preset=aot_llvm ";
 elif [[ ${CI_TAGS} == *'jit_llvm'* ]];           then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --enable-llvm=yes"; export MONO_ENV_OPTIONS="$MONO_ENV_OPTIONS --llvm";
 elif [[ ${CI_TAGS} == *'fullaotinterp_llvm'* ]]; then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --enable-llvm=yes --with-runtime-preset=fullaotinterp_llvm";
@@ -245,19 +246,24 @@ fi
 if [[ ${CI_TAGS} == *'win-i386'* ]];
     then
 	# only build boehm on w32 (only windows platform supporting boehm).
-    ${TESTCMD} --label=make-msvc --timeout=60m --fatal /cygdrive/c/Program\ Files\ \(x86\)/MSBuild/14.0/Bin/MSBuild.exe /p:PlatformToolset=v140 /p:Platform=${PLATFORM} /p:Configuration=Release ${MSBUILD_CXX} /p:MONO_TARGET_GC=boehm msvc/mono.sln
+    ${TESTCMD} --label=make-msvc --timeout=60m --fatal ./msvc/run-msbuild.sh "build" "${PLATFORM}" "release" "/p:PlatformToolset=v140 /p:MONO_TARGET_GC=boehm ${MSBUILD_CXX}"
 fi
 if [[ ${CI_TAGS} == *'win-'* ]];
     then
-    ${TESTCMD} --label=make-msvc-sgen --timeout=60m --fatal /cygdrive/c/Program\ Files\ \(x86\)/MSBuild/14.0/Bin/MSBuild.exe /p:PlatformToolset=v140 /p:Platform=${PLATFORM} /p:Configuration=Release ${MSBUILD_CXX} /p:MONO_TARGET_GC=sgen msvc/mono.sln
+    ${TESTCMD} --label=make-msvc-sgen --timeout=60m --fatal ./msvc/run-msbuild.sh "build" "${PLATFORM}" "release" "/p:PlatformToolset=v140 /p:MONO_TARGET_GC=sgen ${MSBUILD_CXX}"
 fi
 
 if [[ ${CI_TAGS} == *'winaot'* ]];
     then
-    # The AOT compiler on Windows requires Visual Studio's clang.exe and link.exe in $PATH
-    # and we must make sure Visual Studio's link.exe comes before Cygwin's link.exe
-    VC_ROOT="/cygdrive/c/Program Files (x86)/Microsoft Visual Studio 14.0/VC"
-    export PATH="$VC_ROOT/ClangC2/bin/amd64:$VC_ROOT/bin/amd64":$PATH
+
+    if [[ ${PLATFORM} == x64 ]];
+        then
+        # The AOT compiler on Windows requires Visual Studio's clang.exe and link.exe.
+        # Depending on codegen (JIT/LLVM) it might also need platform specific libraries.
+        # Use a wrapper script that will make sure to setup full VS MSVC environment if
+        # needed when running mono-sgen.exe as AOT compiler.
+        export MONO_EXECUTABLE_WRAPPER="${MONO_REPO_ROOT}/msvc/build/sgen/x64/bin/Release/mono-sgen-msvc.sh"
+    fi
 fi
 
 if [[ ${CI_TAGS} == *'monolite'* ]]; then make get-monolite-latest; fi

--- a/scripts/ci/run-test-winaot.sh
+++ b/scripts/ci/run-test-winaot.sh
@@ -1,37 +1,36 @@
 #!/bin/bash -e
 
-if test -n "${MONO_LLVMONLY}";
-then
-${TESTCMD} --label=mini --timeout=25m make -j ${CI_CPU_COUNT} -w -C mono/mini -k llvmonlycheck
+if [[ ${CI_TAGS} == *'winaot_llvm'* ]]; then
+    ${TESTCMD} --label=mini --timeout=25m make -j ${CI_CPU_COUNT} -w -C mono/mini -k llvmfullaotcheck
 else
-${TESTCMD} --label=mini --timeout=25m make -j ${CI_CPU_COUNT} -w -C mono/mini -k fullaotcheck
+    ${TESTCMD} --label=mini --timeout=25m make -j ${CI_CPU_COUNT} -w -C mono/mini -k fullaotcheck
 fi
 
-${TESTCMD} --label=runtime --timeout=160m make -w -C mono/tests -k test-wrench V=1
-${TESTCMD} --label=corlib --timeout=30m make -w -C mcs/class/corlib run-test
-${TESTCMD} --label=verify --timeout=15m make -w -C runtime mcs-compileall
-${TESTCMD} --label=profiler --timeout=30m make -w -C mono/profiler -k check
-${TESTCMD} --label=System --timeout=10m make -w -C mcs/class/System run-test
-${TESTCMD} --label=System.XML --timeout=5m make -w -C mcs/class/System.XML run-test
-${TESTCMD} --label=Mono.Security --timeout=5m make -w -C mcs/class/Mono.Security run-test
-${TESTCMD} --label=System.Data --timeout=5m make -w -C mcs/class/System.Data run-test
-${TESTCMD} --label=System.Web.Services --timeout=5m make -w -C mcs/class/System.Web.Services run-test
-${TESTCMD} --label=I18N.CJK --timeout=5m make -w -C mcs/class/I18N/CJK run-test
-${TESTCMD} --label=I18N.West --timeout=5m make -w -C mcs/class/I18N/West run-test
-${TESTCMD} --label=I18N.MidEast --timeout=5m make -w -C mcs/class/I18N/MidEast run-test
-${TESTCMD} --label=I18N.Rare --timeout=5m make -w -C mcs/class/I18N/Rare run-test
-${TESTCMD} --label=I18N.Other --timeout=5m make -w -C mcs/class/I18N/Other run-test
-${TESTCMD} --label=System.Transactions --timeout=5m make -w -C mcs/class/System.Transactions run-test
-${TESTCMD} --label=System.Core --timeout=15m make -w -C mcs/class/System.Core run-test
-${TESTCMD} --label=System.Xml.Linq --timeout=5m make -w -C mcs/class/System.Xml.Linq run-test
-${TESTCMD} --label=System.Runtime.Serialization --timeout=5m make -w -C mcs/class/System.Runtime.Serialization run-test
-${TESTCMD} --label=System.ServiceModel --timeout=15m make -w -C mcs/class/System.ServiceModel run-test
-${TESTCMD} --label=System.ServiceModel.Web --timeout=5m make -w -C mcs/class/System.ServiceModel.Web run-test
-${TESTCMD} --label=System.ComponentModel.DataAnnotations --timeout=5m make -w -C mcs/class/System.ComponentModel.DataAnnotations run-test
-${TESTCMD} --label=Mono.CSharp --timeout=5m make -w -C mcs/class/Mono.CSharp run-test
-${TESTCMD} --label=System.Numerics --timeout=5m make -w -C mcs/class/System.Numerics run-test
-${TESTCMD} --label=System.Net.Http --timeout=5m make -w -C mcs/class/System.Net.Http run-test
-${TESTCMD} --label=System.Json --timeout=5m make -w -C mcs/class/System.Json run-test
+# ${TESTCMD} --label=runtime --timeout=160m make -w -C mono/tests -k test-wrench V=1
+# ${TESTCMD} --label=corlib --timeout=30m make -w -C mcs/class/corlib run-test
+# ${TESTCMD} --label=verify --timeout=15m make -w -C runtime mcs-compileall
+# ${TESTCMD} --label=profiler --timeout=30m make -w -C mono/profiler -k check
+# ${TESTCMD} --label=System --timeout=10m make -w -C mcs/class/System run-test
+# ${TESTCMD} --label=System.XML --timeout=5m make -w -C mcs/class/System.XML run-test
+# ${TESTCMD} --label=Mono.Security --timeout=5m make -w -C mcs/class/Mono.Security run-test
+# ${TESTCMD} --label=System.Data --timeout=5m make -w -C mcs/class/System.Data run-test
+# ${TESTCMD} --label=System.Web.Services --timeout=5m make -w -C mcs/class/System.Web.Services run-test
+# ${TESTCMD} --label=I18N.CJK --timeout=5m make -w -C mcs/class/I18N/CJK run-test
+# ${TESTCMD} --label=I18N.West --timeout=5m make -w -C mcs/class/I18N/West run-test
+# ${TESTCMD} --label=I18N.MidEast --timeout=5m make -w -C mcs/class/I18N/MidEast run-test
+# ${TESTCMD} --label=I18N.Rare --timeout=5m make -w -C mcs/class/I18N/Rare run-test
+# ${TESTCMD} --label=I18N.Other --timeout=5m make -w -C mcs/class/I18N/Other run-test
+# ${TESTCMD} --label=System.Transactions --timeout=5m make -w -C mcs/class/System.Transactions run-test
+# ${TESTCMD} --label=System.Core --timeout=15m make -w -C mcs/class/System.Core run-test
+# ${TESTCMD} --label=System.Xml.Linq --timeout=5m make -w -C mcs/class/System.Xml.Linq run-test
+# ${TESTCMD} --label=System.Runtime.Serialization --timeout=5m make -w -C mcs/class/System.Runtime.Serialization run-test
+# ${TESTCMD} --label=System.ServiceModel --timeout=15m make -w -C mcs/class/System.ServiceModel run-test
+# ${TESTCMD} --label=System.ServiceModel.Web --timeout=5m make -w -C mcs/class/System.ServiceModel.Web run-test
+# ${TESTCMD} --label=System.ComponentModel.DataAnnotations --timeout=5m make -w -C mcs/class/System.ComponentModel.DataAnnotations run-test
+# ${TESTCMD} --label=Mono.CSharp --timeout=5m make -w -C mcs/class/Mono.CSharp run-test
+# ${TESTCMD} --label=System.Numerics --timeout=5m make -w -C mcs/class/System.Numerics run-test
+# ${TESTCMD} --label=System.Net.Http --timeout=5m make -w -C mcs/class/System.Net.Http run-test
+# ${TESTCMD} --label=System.Json --timeout=5m make -w -C mcs/class/System.Json run-test
 
 rm -fr /tmp/jenkins-temp-aspnet*
 


### PR DESCRIPTION
Add support for building Windows x64 fullaot version of winaot profile that can be run on CI. Initial changes also add execution of mini regression tests on CI. More tests will be added going forward and when having full pass rate.

Add support for building Windows x64 fullaot+llvm version of winaot profile that can be run on CI. Initial changes also add execution of mini regression tests on CI. More tests will be added going forward and when having full pass rate.

In order to get deterministic build results and working build on CI, we need to setup a correct build environment for the MSVC builds. Since MSVC build is currently run from cygwin, there are environment problems, both general but also in our CI environment, since we add cygwin bin folder to system path
(needed by Jenkins plugin). When running more complex cmake builds like BTLS and LLVM, this will cause problems picking up incorrect tools, failing builds on CI.

Another problem is the AOT compilation using MSVC toolchain. In the past CI used some "hard coded paths" to make sure clang.exe and link.exe was found. This is not optimal and won't work when including LLVM as part of full AOT since link.exe will need access to more of the full build environment setup by VS development environments (like platform libraries).

In order to get a better build environment on CI this commit includes and enhance a couple of build scripts used to run msbuild.exe and mono-sgen.exe (as AOT compiler) in a VS development environment, isolate that build process from cygwin environment.

The build scripts will locate installed VS tooling, VS2015 build tools or VS dev env, VS2017 build tools or VS dev env and use corresponding development environment scripts as part of running msbuild.exe and mono-sgen.exe in AOT mode.

In order to make sure mono-sgen.exe as AOT compiler is run through these scripts an additional environment variable MONO_EXECUTABLE_WRAPPER is introduced and used in mono-wrapper when set. Without this indirection there will be problems on CI tests since the environment is using MONO_EXECUTABLE and pass that into for example test driver that run child processes of mono-sgen.exe, meaning that we can't use scripts for MONO_EXECUTABLE, but splitting the MONO_EXECUTABLE to represent mono runtime and have a MONO_EXECUTABLE_WRAPPER that could be a launch script solves this issue.

This commit also includes several smaller fixes made to the generic fullaot build infrastructure.