### PR TITLE
Fixing crash where a generic enum is passed into get_shared_type. 

### DIFF
--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -3856,6 +3856,8 @@ get_shared_type (MonoType *t, MonoType *type)
 	ttype = type->type;
 	if (type->type == MONO_TYPE_VALUETYPE) {
 		ttype = mono_class_enum_basetype_internal (type->data.klass)->type;
+	} else if (type->type == MONO_TYPE_GENERICINST && m_class_is_enumtype(type->data.generic_class->container_class)) {
+		ttype = mono_class_enum_basetype_internal (mono_class_from_mono_type_internal (type))->type;
 	} else if (MONO_TYPE_IS_REFERENCE (type)) {
 		ttype = MONO_TYPE_OBJECT;
 	} else if (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR) {

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -702,7 +702,8 @@ TESTS_CS_SRC=		\
 	generic-unmanaged-constraint.cs \
 	bug-10834.cs \
 	bug-10837.cs	\
-	bug-gh-9507.cs
+	bug-gh-9507.cs	\
+	async-generic-enum.cs
 
 # some tests fail to compile on mcs
 if CSC_IS_ROSLYN

--- a/mono/tests/async-generic-enum.cs
+++ b/mono/tests/async-generic-enum.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading.Tasks;
+
+
+public enum someEnum2 {
+    aaa,
+    bbb
+}
+class Tests {
+    private static GenericEnumTest<someEnum2> test1 = new GenericEnumTest<someEnum2>();
+    public static async Task<int> Main(string[] args)
+    {
+        int retVal = await test1.ThrowExceptionWithGeneric(someEnum2.aaa);
+        return retVal;
+    }
+}
+
+public class GenericEnumTest<T> where T : struct {
+    public enum anEnum {
+        val1,
+        val2
+    }
+
+    public async Task<int> ThrowExceptionWithGeneric(T val) {
+        try {
+            await ThrowExceptionTaskReturn(val);
+        } catch (Exception e) {
+            Console.WriteLine(e);
+        }
+        return 0;
+    }
+
+    public async Task<anEnum> ThrowExceptionTaskReturn(T val) {
+        for (int i = 0; i < 3; i++) {
+            Console.WriteLine("[ASY] " + (3 - i) + " " + System.Threading.Thread.CurrentThread.ManagedThreadId);
+            await Task.Delay(TimeSpan.FromSeconds(1));
+        }
+
+        var nulla = default(string[]);
+        // Causes exception to fire, walking the stack trace causes nullpointer exception bug
+        var vala = nulla[0];
+
+        return anEnum.val1;
+    }
+}


### PR DESCRIPTION
Also added an automated test to catch this scenario.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
