### PR TITLE
[cxx] Set CXXLD and CCLD in configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6168,6 +6168,41 @@ AC_SUBST(MONO_NATIVE_PLATFORM_TYPE)
 AC_SUBST(MONO_NATIVE_PLATFORM_TYPE_COMPAT)
 AC_SUBST(MONO_NATIVE_PLATFORM_TYPE_UNIFIED)
 
+### C++ Linker selection
+#
+# We have to lie to autotools, sometimes.
+#
+# If we're building with llvm compiled into Mono, set MONO_CXXLD to CXX,
+# otherwise to CC.  We want C linking even if we're compiling with C++ enabled
+# because we do not want to link inthe C++ runtime library (-lstdc++ or -lc++),
+# except if we're linking with LLVM which relies on it.
+#
+# Explanation of the hack:
+#
+# According to
+# https://www.gnu.org/software/automake/manual/html_node/How-the-Linker-is-Chosen.html,
+# automake chooses the linker that it used to compile a target based on the
+# _SOURCES for that target.  If the target is comprised of only C code, it
+# chooses the C linker (on Linux and OSX this is just gcc or clang called with
+# linker arguments and a -o).  If the target _SOURCES include at least one C++ file, 
+# then automake chooses the C++ linker (usually g++ or clang++ called with linker arguments and -o).
+#
+# The problem for Mono is that we don't want the C++ runtime library (libstdc++
+# or libc++) linked in - even when Mono is written in C++, we take care not to
+# require the runtime library.  As a result, we don't want g++ or clang++ to do
+# the linking.  On the other hand if LLVM is enabled, then we _must_ use the
+# C++ linker - LLVM doesn't have the same restrictions.
+#
+# So the trick is we set MONO_CXXLD here to $CXX or $CC and in
+#  mono/mini/Makefile.am.in we have CCLD=$MONO_CXXLD and CXXLD=$MONO_CXXLD which bypasses
+#  automake's autodetection and lets us use the linker that we want.
+#
+if test "x$enable_llvm_runtime" = "xyes"; then
+	AC_SUBST(MONO_CXXLD, [$CXX])
+else
+	AC_SUBST(MONO_CXXLD, [$CC])
+fi
+
 # Update all submodules recursively to ensure everything is checked out
 (cd $srcdir && scripts/update_submodules.sh)
 

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -1,5 +1,10 @@
 include $(top_srcdir)/mk/common.mk
 
+## Set the C++ linker based on configure settings, see comment in configure.ac
+## about why we need to do this.
+CXXLD=$(MONO_CXXLD)
+CCLD=$(MONO_CXXLD)
+
 count=100000
 mtest=for_loop
 monodir=$(top_builddir)
@@ -261,29 +266,6 @@ mono_sgen_LDADD = \
 mono_sgen_LDFLAGS = $(static_flags) $(monobinldflags) $(monobin_platform_ldflags) 
 
 
-if STATIC_MONO
-# Force the C++ linker if we linked mono against libmono.a and if we know that
-# libmono.a has C++ code in it.
-#
-# The conditional logic here has to match exactly what we do for deciding
-# whether to add libmini-cxx.la into libmini.la.  If we do, then force the use
-# of the C++ linker here.
-#
-# Have to use the nodist_EXTRA_..._SOURCES hack because if we set
-#  ..._LINK=$(CXXLINK) directly, it will not use the ..._LDFLAGS and other
-#  linker flags and so we would end up with linker errors because we wouldn't pick up
-#  monobin_platform_ldflags, for example.
-if ENABLE_LLVM
-nodist_EXTRA_mono_boehm_SOURCES = dummy.cpp
-nodist_EXTRA_mono_sgen_SOURCES = dummy.cpp
-else
-if ENABLE_LLVM_RUNTIME
-nodist_EXTRA_mono_boehm_SOURCES = dummy.cpp
-nodist_EXTRA_mono_sgen_SOURCES = dummy.cpp
-endif
-endif
-endif
-
 if BITCODE
 libmonoldflags += -no-undefined
 endif
@@ -314,12 +296,10 @@ if SUPPORT_BOEHM
 monow_LDADD = $(mono_boehm_LDADD)
 monow_LDFLAGS = $(mono_boehm_LDFLAGS) -mwindows
 monow_SOURCES = $(mono_boehm_SOURCES)
-nodist_EXTRA_monow_SOURCES = $(nodist_EXTRA_mono_boehm_SOURCES)
 else
 monow_LDADD = $(mono_sgen_LDADD)
 monow_LDFLAGS = $(mono_sgen_LDFLAGS) -mwindows
 monow_SOURCES = $(mono_sgen_SOURCES)
-nodist_EXTRA_monow_SOURCES = $(nodist_EXTRA_mono_sgen_SOURCES)
 endif
 endif
 
@@ -412,12 +392,10 @@ if ENABLE_LLVM
 if LOADED_LLVM
 llvm_sources = \
 	mini-llvm-loaded.c
-llvm_cxx_sources =
 else
 llvm_sources = \
 	mini-llvm.c		\
-	mini-llvm-loaded.c
-llvm_cxx_sources = \
+	mini-llvm-loaded.c \
 	mini-llvm-cpp.cpp \
 	llvm-jit.cpp
 endif
@@ -739,28 +717,8 @@ endif
 # This library is shared between mono and mono-sgen, since the code in mini/ doesn't contain
 # compile time dependencies on boehm/sgen.
 #
-libmini_la_SOURCES = $(common_sources) $(llvm_sources) $(arch_sources) $(os_sources) $(netcore_sources)
+libmini_la_SOURCES = $(common_sources) $(llvm_sources) $(llvm_runtime_sources) $(arch_sources) $(os_sources) $(netcore_sources)
 libmini_la_CFLAGS = $(AM_CFLAGS) @CXX_ADD_CFLAGS@
-if ENABLE_LLVM
-libmini_la_LIBADD = libmini-cxx.la
-noinst_LTLIBRARIES += libmini-cxx.la
-else
-if ENABLE_LLVM_RUNTIME
-libmini_la_LIBADD = libmini-cxx.la
-noinst_LTLIBRARIES += libmini-cxx.la
-endif
-endif
-
-# Split out the C++ sources so that if they're not used, libmini will be linked
-# with the C linker.  The issue is that the automatic linker selection (See
-# https://www.gnu.org/software/automake/manual/html_node/How-the-Linker-is-Chosen.html)
-# looks at all the _SOURCES for a target, even those that are only
-# conditionally added, even if the condition is false.  So because we sometimes
-# build mini-llvm-cpp.cpp we always get the c++ linker.  But that's not what we
-# want.
-libmini_cxx_la_SOURCES = $(llvm_cxx_sources) $(llvm_runtime_sources)
-libmini_cxx_la_CFLAGS = $(AM_CFLAGS) @CXX_ADD_CFLAGS@
-
 
 libmonoboehm_2_0_la_SOURCES =
 libmonoboehm_2_0_la_CFLAGS = $(mono_boehm_CFLAGS) @CXX_ADD_CFLAGS@

--- a/mono/mini/llvm-jit.cpp
+++ b/mono/mini/llvm-jit.cpp
@@ -42,9 +42,7 @@
 
 #include <cstdlib>
 
-extern "C" {
 #include <mono/utils/mono-dl.h>
-}
 
 using namespace llvm;
 using namespace llvm::orc;

--- a/mono/utils/mono-dl.c
+++ b/mono/utils/mono-dl.c
@@ -10,6 +10,7 @@
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
 #include "config.h"
+#include "mono/utils/mono-compiler.h"
 #include "mono/utils/mono-dl.h"
 #include "mono/utils/mono-embed.h"
 #include "mono/utils/mono-path.h"

--- a/mono/utils/mono-dl.h
+++ b/mono/utils/mono-dl.h
@@ -30,7 +30,9 @@ typedef struct {
 
 
 MONO_API MonoDl*     mono_dl_open       (const char *name, int flags, char **error_msg) MONO_LLVM_INTERNAL;
+MONO_EXTERN_C
 char*       mono_dl_symbol     (MonoDl *module, const char *name, void **symbol) MONO_LLVM_INTERNAL;
+MONO_EXTERN_C
 void        mono_dl_close      (MonoDl *module) MONO_LLVM_INTERNAL;
 
 char*       mono_dl_build_path (const char *directory, const char *name, void **iter);


### PR DESCRIPTION
Essentialy bypass automake's automatic linker selection based on _SOURCES file
extensions.

The issue:
  1. Right now we need to use the C linker unless we're linking with LLVM which
     needs C++.
  2. Later when we start using C++ in Mono we will still want the C linker,
     because we will use a subset of C++ that doesn't depend on the C++ runtime
     library (because we don't want to break embedders that don't expect us to
     use C++).

So in either case which linker we use is a decision that we want to make
independent of what the file extensions look like.

So we set MONO_CXXLD in configure.  If LLVM is enabled, we use $CXX, otherwise
$CC.

Then in mono/mini/Makefile.am.in we set CCLD and CXXLD to MONO_CXXLD.  So
whatever automake decides we're going to use the linker that we want.

This partly reverts 988f4a2 which tried
another approach (which turned out not to work).

This should also address #12060

Closes #12435

---

Also fix a linking issue between llvm-jit.cpp and `mono_dl_symbol` and `mono_dl_close` when both `--enable-llvm` and `--enable-cxx` were used - in that case `llvm-jit.cpp` wanted C symbols but mono-dl was producing C++ symbols.  Now `mono_dl_symbol` and `mono_dl_close` are always C symbols.