### PR TITLE
[filewatcher] Fall back to default if a new instance cannot be created

### DIFF
--- a/mcs/class/System/Test/System.IO/FileSystemWatcherTest.cs
+++ b/mcs/class/System/Test/System.IO/FileSystemWatcherTest.cs
@@ -95,6 +95,20 @@ namespace MonoTests.System.IO
 				fw.Path = "*";
 			}
 		}
+
+		[Test]
+		[Category ("NotOnMac")] // creates resource exhaustion issues
+		public void LargeNumberOfInstances ()
+		{
+			using (var tmp = new TempDirectory ()) {
+				var watchers = new FileSystemWatcher [256];
+				for (int x = 0; x < watchers.Length; x++)
+				{
+					watchers[x] = new FileSystemWatcher (tmp.Path, "*");
+					watchers[x].EnableRaisingEvents = true;
+				}
+			}
+		}
 	}
 }
 

--- a/mono/metadata/filewatcher.c
+++ b/mono/metadata/filewatcher.c
@@ -56,6 +56,10 @@ ves_icall_System_IO_FAMW_InternalFAMNextEvent (gpointer conn,
 
 static int (*FAMNextEvent) (gpointer, gpointer);
 
+#if defined(HAVE_SYS_INOTIFY_H)
+#include <sys/inotify.h>
+#endif
+
 gint
 ves_icall_System_IO_FSW_SupportsFSW (void)
 {
@@ -65,6 +69,10 @@ ves_icall_System_IO_FSW_SupportsFSW (void)
 	else
 		return 6; /* CoreFX */
 #elif defined(HAVE_SYS_INOTIFY_H)
+	int inotify_instance = inotify_init ();
+	if (inotify_instance == -1)
+		return  0; /* DefaultWatcher */
+	close (inotify_instance);
 	return 6; /* CoreFX */
 #elif HAVE_KQUEUE
 	return 3; /* kqueue */


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/12535