### PR TITLE
Take text alignment for LinkLabels into account 

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/LinkLabel.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/LinkLabel.cs
@@ -668,71 +668,71 @@ namespace System.Windows.Forms
 										 PaddingClientRectangle,
 										 string_format);
 
-            // Get offset for different text alignments
-            float align_offset_x = 0F;
-            float align_offset_y = 0F;
-            
-            if (TextAlign != ContentAlignment.TopLeft) {
-                Region all_regions = new Region (new Rectangle ());
+			// Get offset for different text alignments
+			float align_offset_x = 0F;
+			float align_offset_y = 0F;
 
-                foreach (Region region in regions) {
-                    all_regions.Union (region);
-                }
+			if (TextAlign != ContentAlignment.TopLeft) {
+				Region all_regions = new Region (new Rectangle ());
 
-                Graphics graphics = CreateGraphics ();
+				foreach (Region region in regions) {
+					all_regions.Union (region);
+				}
 
-                if (TextAlign == ContentAlignment.TopCenter) {
-                    float text_width = all_regions.GetBounds(graphics).Width;
+				Graphics graphics = CreateGraphics ();
 
-                    align_offset_x = (ClientRectangle.Width / 2 - text_width  / 2);
-                }
-                if (TextAlign == ContentAlignment.TopRight) {
-                    float text_width = all_regions.GetBounds(graphics).Width;
+				if (TextAlign == ContentAlignment.TopCenter) {
+					float text_width = all_regions.GetBounds(graphics).Width;
 
-                    align_offset_x = (ClientRectangle.Width - text_width);
-                }
-                if (TextAlign == ContentAlignment.MiddleLeft) {
-                    float text_height = all_regions.GetBounds(graphics).Height;
+					align_offset_x = (ClientRectangle.Width / 2 - text_width  / 2);
+				}
+				if (TextAlign == ContentAlignment.TopRight) {
+					float text_width = all_regions.GetBounds(graphics).Width;
 
-                    align_offset_y = (ClientRectangle.Height / 2 - text_height / 2);
-                }
-                if (TextAlign == ContentAlignment.MiddleCenter) {
-                    float text_width  = all_regions.GetBounds(graphics).Width;
-                    float text_height = all_regions.GetBounds(graphics).Height;
+					align_offset_x = (ClientRectangle.Width - text_width);
+				}
+				if (TextAlign == ContentAlignment.MiddleLeft) {
+					float text_height = all_regions.GetBounds(graphics).Height;
 
-                    align_offset_x = (ClientRectangle.Width  / 2 - text_width  / 2);
-                    align_offset_y = (ClientRectangle.Height / 2 - text_height / 2);
-                }
-                if (TextAlign == ContentAlignment.MiddleRight) {
-                    float text_width  = all_regions.GetBounds(graphics).Width;
-                    float text_height = all_regions.GetBounds(graphics).Height;
+					align_offset_y = (ClientRectangle.Height / 2 - text_height / 2);
+				}
+				if (TextAlign == ContentAlignment.MiddleCenter) {
+					float text_width  = all_regions.GetBounds(graphics).Width;
+					float text_height = all_regions.GetBounds(graphics).Height;
 
-                    align_offset_x = (ClientRectangle.Width      - text_width);
-                    align_offset_y = (ClientRectangle.Height / 2 - text_height / 2);
-                }
-                if (TextAlign == ContentAlignment.BottomLeft) {
-                    float text_height = all_regions.GetBounds(graphics).Height;
+					align_offset_x = (ClientRectangle.Width  / 2 - text_width  / 2);
+					align_offset_y = (ClientRectangle.Height / 2 - text_height / 2);
+				}
+				if (TextAlign == ContentAlignment.MiddleRight) {
+					float text_width  = all_regions.GetBounds(graphics).Width;
+					float text_height = all_regions.GetBounds(graphics).Height;
 
-                    align_offset_y = (ClientRectangle.Height - text_height);
-                }
-                if (TextAlign == ContentAlignment.BottomCenter) {
-                    float text_width  = all_regions.GetBounds(graphics).Width;
-                    float text_height = all_regions.GetBounds(graphics).Height;
+					align_offset_x = (ClientRectangle.Width      - text_width);
+					align_offset_y = (ClientRectangle.Height / 2 - text_height / 2);
+				}
+				if (TextAlign == ContentAlignment.BottomLeft) {
+					float text_height = all_regions.GetBounds(graphics).Height;
 
-                    align_offset_x = (ClientRectangle.Width / 2 - text_width / 2);
-                    align_offset_y = (ClientRectangle.Height    - text_height);
-                }
-                if (TextAlign == ContentAlignment.BottomRight) {
-                    float text_width  = all_regions.GetBounds(graphics).Width;
-                    float text_height = all_regions.GetBounds(graphics).Height;
+					align_offset_y = (ClientRectangle.Height - text_height);
+				}
+				if (TextAlign == ContentAlignment.BottomCenter) {
+					float text_width  = all_regions.GetBounds(graphics).Width;
+					float text_height = all_regions.GetBounds(graphics).Height;
 
-                    align_offset_x = (ClientRectangle.Width  - text_width);
-                    align_offset_y = (ClientRectangle.Height - text_height);
-                }
-            }
+					align_offset_x = (ClientRectangle.Width / 2 - text_width / 2);
+					align_offset_y = (ClientRectangle.Height    - text_height);
+				}
+				if (TextAlign == ContentAlignment.BottomRight) {
+					float text_width  = all_regions.GetBounds(graphics).Width;
+					float text_height = all_regions.GetBounds(graphics).Height;
+
+					align_offset_x = (ClientRectangle.Width  - text_width);
+					align_offset_y = (ClientRectangle.Height - text_height);
+				}
+			}
 
 
-            for (int i = 0; i < pieces.Length; i ++) {
+			for (int i = 0; i < pieces.Length; i ++) {
 				pieces[i].region = regions[i];
 				pieces[i].region.Translate (Padding.Left + align_offset_x, Padding.Top + align_offset_y);
 			}


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
## Problem
`LinkLabels` ignore the text alignment for rendering the "hitbox" and the text color (= the `LinkArea`), and the focus rectangle. Also every text behind the end of this LinkArea/focus rectangle region is not painted at all.
This becomes visible if `AutoSize = false` and the `Size` is bigger than the text would need,
and if the text alignment is anything different than `TopLeft`.

## Cause
I think this is because the `piece.regions` are only translated regarding the padding, but neglecting the text alignment.

## Solution
Calculate the offset due to alignment and add it to the translation in `LinkLabel.CreateLinkPieces ()`

Fixes #12402 

## One more problem:
~Right now, a very tiny bit at the end of the label is still cut off (see my zipped and attached comparison pictures). Maybe `GetBounds ()` returns a value little bit smaller than it should be.
Can someone help?~

Also, maybe I took the wrong approach to this issue, but I don't know the inner mechanisms of mono.
So feel free to either advise me to change something, or change it yourself(s) :)