### PR TITLE
Fix leak if mono_set_config_dir is called multiple times.

### DIFF
--- a/mono/metadata/mono-config.c
+++ b/mono/metadata/mono-config.c
@@ -719,6 +719,8 @@ mono_set_config_dir (const char *dir)
 	if (env_mono_cfg_dir == NULL && dir != NULL)
 		env_mono_cfg_dir = g_strdup (dir);
 
+	if (mono_cfg_dir)
+		g_free (mono_cfg_dir);
 	mono_cfg_dir = env_mono_cfg_dir;
 }
 


### PR DESCRIPTION
Fix leak if mono_set_config_dir is called multiple times by freeing the
previously stored value.




<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->