### PR TITLE
[interp] Add support for break on method entry

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3008,6 +3008,10 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			++ip;
 			do_debugger_tramp (mini_get_dbg_callbacks ()->user_break, frame);
 			MINT_IN_BREAK;
+		MINT_IN_CASE(MINT_BREAKPOINT)
+			++ip;
+			mono_break ();
+			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_LDNULL) 
 			sp->data.p = NULL;
 			++ip;

--- a/mono/mini/interp/mintops.def
+++ b/mono/mini/interp/mintops.def
@@ -11,6 +11,7 @@
 OPDEF(MINT_NOP, "nop", 1, MintOpNoArgs)
 OPDEF(MINT_NIY, "niy", 1, MintOpNoArgs)
 OPDEF(MINT_BREAK, "break", 1, MintOpNoArgs)
+OPDEF(MINT_BREAKPOINT, "breakpoint", 1, MintOpNoArgs)
 OPDEF(MINT_LDNULL, "ldnull", 1, MintOpNoArgs)
 OPDEF(MINT_DUP, "dup", 1, MintOpNoArgs)
 OPDEF(MINT_DUP_VT, "dup.vt", 3, MintOpInt)

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -2496,6 +2496,9 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 		emit_seq_point (td, METHOD_ENTRY_IL_OFFSET, cbb, FALSE);
 	}
 
+	if (mono_debugger_method_has_breakpoint (method))
+		ADD_CODE(td, MINT_BREAKPOINT);
+
 	if (method == td->method) {
 		if (td->verbose_level) {
 			char *tmp = mono_disasm_code (NULL, method, td->ip, end);


### PR DESCRIPTION
When using --break. We need to have a breakpoint set from debugger in mono_break.