### PR TITLE
Windows support to abort blocking system calls.

### DIFF
--- a/mono/metadata/w32file-win32.c
+++ b/mono/metadata/w32file-win32.c
@@ -87,11 +87,16 @@ gboolean
 mono_w32file_read(gpointer handle, gpointer buffer, guint32 numbytes, guint32 *bytesread, gint32 *win32error)
 {
 	gboolean res;
+	MonoThreadInfo *info = mono_thread_info_current ();
+
+	mono_win32_enter_blocking_io_call (info, (HANDLE)handle);
 	MONO_ENTER_GC_SAFE;
-	res = ReadFile (handle, buffer, numbytes, (PDWORD)bytesread, NULL);
+	res = ReadFile ((HANDLE)handle, buffer, numbytes, (PDWORD)bytesread, NULL);
 	if (!res)
 		*win32error = GetLastError ();
 	MONO_EXIT_GC_SAFE;
+	mono_win32_leave_blocking_io_call (info, (HANDLE)handle);
+
 	return res;
 }
 
@@ -99,11 +104,16 @@ gboolean
 mono_w32file_write (gpointer handle, gconstpointer buffer, guint32 numbytes, guint32 *byteswritten, gint32 *win32error)
 {
 	gboolean res;
+	MonoThreadInfo *info = mono_thread_info_current ();
+
+	mono_win32_enter_blocking_io_call (info, (HANDLE)handle);
 	MONO_ENTER_GC_SAFE;
-	res = WriteFile (handle, buffer, numbytes, (PDWORD)byteswritten, NULL);
+	res = WriteFile ((HANDLE)handle, buffer, numbytes, (PDWORD)byteswritten, NULL);
 	if (!res)
 		*win32error = GetLastError ();
 	MONO_EXIT_GC_SAFE;
+	mono_win32_leave_blocking_io_call (info, (HANDLE)handle);
+
 	return res;
 }
 

--- a/mono/metadata/w32socket-win32.c
+++ b/mono/metadata/w32socket-win32.c
@@ -38,281 +38,145 @@ mono_w32socket_cleanup (void)
 {
 }
 
-static gboolean set_blocking (SOCKET sock, gboolean block)
-{
-	u_long non_block = block ? 0 : 1;
-	return ioctlsocket (sock, FIONBIO, &non_block) != SOCKET_ERROR;
-}
-
-static DWORD get_socket_timeout (SOCKET sock, int optname)
-{
-	DWORD timeout = 0;
-	int optlen = sizeof (DWORD);
-	if (getsockopt (sock, SOL_SOCKET, optname, (char *)&timeout, &optlen) == SOCKET_ERROR) {
-		WSASetLastError (0);
-		return WSA_INFINITE;
-	}
-	if (timeout == 0)
-		timeout = WSA_INFINITE; // 0 means infinite
-	return timeout;
-}
-
-/*
-* Performs an alertable wait for the specified event (FD_ACCEPT_BIT,
-* FD_CONNECT_BIT, FD_READ_BIT, FD_WRITE_BIT) on the specified socket.
-* Returns TRUE if the event is fired without errors. Calls WSASetLastError()
-* with WSAEINTR and returns FALSE if the thread is alerted. If the event is
-* fired but with an error WSASetLastError() is called to set the error and the
-* function returns FALSE.
-*/
-static gboolean alertable_socket_wait (SOCKET sock, int event_bit)
-{
-	static char const * const EVENT_NAMES[] = { "FD_READ", "FD_WRITE", NULL /*FD_OOB*/, "FD_ACCEPT", "FD_CONNECT", "FD_CLOSE" };
-	gboolean success = FALSE;
-	int error = -1;
-	DWORD timeout = WSA_INFINITE;
-	if (event_bit == FD_READ_BIT || event_bit == FD_WRITE_BIT) {
-		timeout = get_socket_timeout (sock, event_bit == FD_READ_BIT ? SO_RCVTIMEO : SO_SNDTIMEO);
-	}
-	WSASetLastError (0);
-	WSAEVENT event = WSACreateEvent ();
-	if (event != WSA_INVALID_EVENT) {
-		if (WSAEventSelect (sock, event, (1 << event_bit) | FD_CLOSE) != SOCKET_ERROR) {
-			LOGDEBUG (g_message ("%06d - Calling mono_win32_wsa_wait_for_multiple_events () on socket %d", GetCurrentThreadId (), sock));
-			DWORD ret = mono_win32_wsa_wait_for_multiple_events (1, &event, TRUE, timeout, TRUE);
-			if (ret == WSA_WAIT_IO_COMPLETION) {
-				LOGDEBUG (g_message ("%06d - mono_win32_wsa_wait_for_multiple_events () returned WSA_WAIT_IO_COMPLETION for socket %d", GetCurrentThreadId (), sock));
-				error = WSAEINTR;
-			} else if (ret == WSA_WAIT_TIMEOUT) {
-				error = WSAETIMEDOUT;
-			} else {
-				g_assert (ret == WSA_WAIT_EVENT_0);
-				WSANETWORKEVENTS ne = { 0 };
-				if (WSAEnumNetworkEvents (sock, event, &ne) != SOCKET_ERROR) {
-					if (ne.lNetworkEvents & (1 << event_bit) && ne.iErrorCode[event_bit]) {
-						LOGDEBUG (g_message ("%06d - %s error %d on socket %d", GetCurrentThreadId (), EVENT_NAMES[event_bit], ne.iErrorCode[event_bit], sock));
-						error = ne.iErrorCode[event_bit];
-					} else if (ne.lNetworkEvents & FD_CLOSE_BIT && ne.iErrorCode[FD_CLOSE_BIT]) {
-						LOGDEBUG (g_message ("%06d - FD_CLOSE error %d on socket %d", GetCurrentThreadId (), ne.iErrorCode[FD_CLOSE_BIT], sock));
-						error = ne.iErrorCode[FD_CLOSE_BIT];
-					} else {
-						LOGDEBUG (g_message ("%06d - WSAEnumNetworkEvents () finished successfully on socket %d", GetCurrentThreadId (), sock));
-						success = TRUE;
-						error = 0;
-					}
-				}
-			}
-			WSAEventSelect (sock, NULL, 0);
-		}
-		WSACloseEvent (event);
-	}
-	if (error != -1) {
-		WSASetLastError (error);
-	}
-	return success;
-}
-
-#define ALERTABLE_SOCKET_CALL(event_bit, blocking, repeat, ret, op, sock, ...) \
-	LOGDEBUG (g_message ("%06d - Performing %s " #op " () on socket %d", GetCurrentThreadId (), blocking ? "blocking" : "non-blocking", sock)); \
-	if (blocking) { \
-		if (set_blocking(sock, FALSE)) { \
-			while (-1 == (int) (ret = op (sock, __VA_ARGS__))) { \
-				int _error = WSAGetLastError ();\
-				if (_error != WSAEWOULDBLOCK && _error != WSA_IO_PENDING) \
-					break; \
-				if (!alertable_socket_wait (sock, event_bit) || !repeat) \
-					break; \
-			} \
-			int _saved_error = WSAGetLastError (); \
-			set_blocking (sock, TRUE); \
-			WSASetLastError (_saved_error); \
-		} \
-	} else { \
-		ret = op (sock, __VA_ARGS__); \
-	} \
-	int _saved_error = WSAGetLastError (); \
-	LOGDEBUG (g_message ("%06d - Finished %s " #op " () on socket %d (ret = %d, WSAGetLastError() = %d)", GetCurrentThreadId (), \
-		blocking ? "blocking" : "non-blocking", sock, ret, _saved_error)); \
-	WSASetLastError (_saved_error);
+#define INTERRUPTABLE_SOCKET_CALL(blocking, ret, op, sock, ...) \
+	MonoThreadInfo *info = mono_thread_info_current (); \
+	if (blocking) \
+		mono_win32_enter_blocking_io_call (info, (HANDLE)sock); \
+	MONO_ENTER_GC_SAFE; \
+	ret = op (sock, __VA_ARGS__); \
+	MONO_EXIT_GC_SAFE; \
+	if (blocking) \
+		mono_win32_leave_blocking_io_call (info, (HANDLE)sock);
 
 SOCKET mono_w32socket_accept (SOCKET s, struct sockaddr *addr, socklen_t *addrlen, gboolean blocking)
 {
-	MonoInternalThread *curthread = mono_thread_internal_current ();
-	SOCKET newsock = INVALID_SOCKET;
-	MONO_ENTER_GC_SAFE;
-	ALERTABLE_SOCKET_CALL (FD_ACCEPT_BIT, blocking, TRUE, newsock, accept, s, addr, addrlen);
-	MONO_EXIT_GC_SAFE;
-	return newsock;
+	SOCKET ret = INVALID_SOCKET;
+	INTERRUPTABLE_SOCKET_CALL (blocking, ret, accept, s, addr, addrlen);
+	return ret;
 }
 
 int mono_w32socket_connect (SOCKET s, const struct sockaddr *name, int namelen, gboolean blocking)
 {
 	int ret = SOCKET_ERROR;
-	MONO_ENTER_GC_SAFE;
-	ALERTABLE_SOCKET_CALL (FD_CONNECT_BIT, blocking, FALSE, ret, connect, s, name, namelen);
-	ret = WSAGetLastError () != 0 ? SOCKET_ERROR : 0;
-	MONO_EXIT_GC_SAFE;
+	INTERRUPTABLE_SOCKET_CALL (blocking, ret, connect, s, name, namelen);
 	return ret;
 }
 
 int mono_w32socket_recv (SOCKET s, char *buf, int len, int flags, gboolean blocking)
 {
-	MonoInternalThread *curthread = mono_thread_internal_current ();
 	int ret = SOCKET_ERROR;
-	MONO_ENTER_GC_SAFE;
-	ALERTABLE_SOCKET_CALL (FD_READ_BIT, blocking, TRUE, ret, recv, s, buf, len, flags);
-	MONO_EXIT_GC_SAFE;
+	INTERRUPTABLE_SOCKET_CALL (blocking, ret, recv, s, buf, len, flags);
 	return ret;
 }
 
 int mono_w32socket_recvfrom (SOCKET s, char *buf, int len, int flags, struct sockaddr *from, socklen_t *fromlen, gboolean blocking)
 {
 	int ret = SOCKET_ERROR;
-	MONO_ENTER_GC_SAFE;
-	ALERTABLE_SOCKET_CALL (FD_READ_BIT, blocking, TRUE, ret, recvfrom, s, buf, len, flags, from, fromlen);
-	MONO_EXIT_GC_SAFE;
+	INTERRUPTABLE_SOCKET_CALL (blocking, ret, recvfrom, s, buf, len, flags, from, fromlen);
 	return ret;
 }
 
 int mono_w32socket_recvbuffers (SOCKET s, WSABUF *lpBuffers, guint32 dwBufferCount, guint32 *lpNumberOfBytesRecvd, guint32 *lpFlags, gpointer lpOverlapped, gpointer lpCompletionRoutine, gboolean blocking)
 {
 	int ret = SOCKET_ERROR;
-	MONO_ENTER_GC_SAFE;
-	ALERTABLE_SOCKET_CALL (FD_READ_BIT, blocking, TRUE, ret, WSARecv, s, lpBuffers, dwBufferCount, (PDWORD)lpNumberOfBytesRecvd, (PDWORD)lpFlags, (LPWSAOVERLAPPED)lpOverlapped, (LPWSAOVERLAPPED_COMPLETION_ROUTINE)lpCompletionRoutine);
-	MONO_EXIT_GC_SAFE;
+	INTERRUPTABLE_SOCKET_CALL (blocking, ret, WSARecv, s, lpBuffers, dwBufferCount, (LPDWORD)lpNumberOfBytesRecvd, (LPDWORD)lpFlags, (LPWSAOVERLAPPED)lpOverlapped, (LPWSAOVERLAPPED_COMPLETION_ROUTINE)lpCompletionRoutine);
 	return ret;
 }
 
 int mono_w32socket_send (SOCKET s, void *buf, int len, int flags, gboolean blocking)
 {
 	int ret = SOCKET_ERROR;
-	MONO_ENTER_GC_SAFE;
-	ALERTABLE_SOCKET_CALL (FD_WRITE_BIT, blocking, TRUE, ret, send, s, (char*)buf, len, flags);
-	MONO_EXIT_GC_SAFE;
+	INTERRUPTABLE_SOCKET_CALL (blocking, ret, send, s, (const char *)buf, len, flags);
 	return ret;
 }
 
 int mono_w32socket_sendto (SOCKET s, const char *buf, int len, int flags, const struct sockaddr *to, int tolen, gboolean blocking)
 {
 	int ret = SOCKET_ERROR;
-	MONO_ENTER_GC_SAFE;
-	ALERTABLE_SOCKET_CALL (FD_WRITE_BIT, blocking, TRUE, ret, sendto, s, buf, len, flags, to, tolen);
-	MONO_EXIT_GC_SAFE;
+	INTERRUPTABLE_SOCKET_CALL (blocking, ret, sendto, s, buf, len, flags, to, tolen);
 	return ret;
 }
 
 int mono_w32socket_sendbuffers (SOCKET s, WSABUF *lpBuffers, guint32 dwBufferCount, guint32 *lpNumberOfBytesRecvd, guint32 lpFlags, gpointer lpOverlapped, gpointer lpCompletionRoutine, gboolean blocking)
 {
 	int ret = SOCKET_ERROR;
-	MONO_ENTER_GC_SAFE;
-	ALERTABLE_SOCKET_CALL (FD_WRITE_BIT, blocking, TRUE, ret, WSASend, s, lpBuffers, dwBufferCount, (PDWORD)lpNumberOfBytesRecvd, lpFlags, (LPWSAOVERLAPPED)lpOverlapped, (LPWSAOVERLAPPED_COMPLETION_ROUTINE)lpCompletionRoutine);
-	MONO_EXIT_GC_SAFE;
+	INTERRUPTABLE_SOCKET_CALL (blocking, ret, WSASend, s, lpBuffers, dwBufferCount, (LPDWORD)lpNumberOfBytesRecvd, lpFlags, (LPWSAOVERLAPPED)lpOverlapped, (LPWSAOVERLAPPED_COMPLETION_ROUTINE)lpCompletionRoutine);
 	return ret;
 }
 
 #if G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT | HAVE_UWP_WINAPI_SUPPORT)
-BOOL mono_w32socket_transmit_file (SOCKET hSocket, gpointer hFile, TRANSMIT_FILE_BUFFERS *lpTransmitBuffers, guint32 dwReserved, gboolean blocking)
+static gint
+internal_w32socket_transmit_file (SOCKET sock, gpointer file, TRANSMIT_FILE_BUFFERS *lpTransmitBuffers, guint32 dwReserved, gboolean blocking)
 {
-	LOGDEBUG (g_message ("%06d - Performing %s TransmitFile () on socket %d", GetCurrentThreadId (), blocking ? "blocking" : "non-blocking", hSocket));
+	gint ret = ERROR_NOT_SUPPORTED;
+	LPFN_TRANSMITFILE transmit_file;
+	GUID transmit_file_guid = WSAID_TRANSMITFILE;
+	DWORD output_bytes;
 
-	int error = 0, ret;
+	if (!WSAIoctl (sock, SIO_GET_EXTENSION_FUNCTION_POINTER, &transmit_file_guid, sizeof (GUID), &transmit_file, sizeof (LPFN_TRANSMITFILE), &output_bytes, NULL, NULL)) {
+		MonoThreadInfo *info = mono_thread_info_current ();
 
-	MONO_ENTER_GC_SAFE;
+		if (blocking)
+			mono_win32_enter_blocking_io_call (info, (HANDLE)sock);
 
-	if (blocking) {
-		OVERLAPPED overlapped = { 0 };
-		overlapped.hEvent = WSACreateEvent ();
-		if (overlapped.hEvent == WSA_INVALID_EVENT) {
-			ret = FALSE;
-			goto done;
-		}
-		if (!TransmitFile (hSocket, hFile, 0, 0, &overlapped, lpTransmitBuffers, dwReserved)) {
-			error = WSAGetLastError ();
-			if (error == WSA_IO_PENDING) {
-				error = 0;
-				// NOTE: .NET's Socket.SendFile() doesn't honor the Socket's SendTimeout so we shouldn't either
-				DWORD ret = mono_win32_wait_for_single_object_ex (overlapped.hEvent, INFINITE, TRUE);
-				if (ret == WAIT_IO_COMPLETION) {
-					LOGDEBUG (g_message ("%06d - mono_win32_wait_for_single_object_ex () returned WSA_WAIT_IO_COMPLETION for socket %d", GetCurrentThreadId (), hSocket));
-					error = WSAEINTR;
-				} else if (ret == WAIT_TIMEOUT) {
-					error = WSAETIMEDOUT;
-				} else if (ret != WAIT_OBJECT_0) {
-					error = GetLastError ();
-				}
-			}
-		}
-		WSACloseEvent (overlapped.hEvent);
-	} else {
-		if (!TransmitFile (hSocket, hFile, 0, 0, NULL, lpTransmitBuffers, dwReserved)) {
-			error = WSAGetLastError ();
-		}
+		MONO_ENTER_GC_SAFE;
+		if (transmit_file (sock, file, 0, 0, NULL, lpTransmitBuffers, dwReserved))
+			ret = 0;
+		MONO_EXIT_GC_SAFE;
+
+		if (blocking)
+			mono_win32_leave_blocking_io_call (info, (HANDLE)sock);
 	}
 
-	LOGDEBUG (g_message ("%06d - Finished %s TransmitFile () on socket %d (ret = %d, WSAGetLastError() = %d)", GetCurrentThreadId (), \
-		blocking ? "blocking" : "non-blocking", hSocket, error == 0, error));
-	WSASetLastError (error);
+	if (ret != 0)
+		ret = WSAGetLastError ();
 
-	ret = error == 0;
-
-done:
-	MONO_EXIT_GC_SAFE;
 	return ret;
 }
-#endif /* #if G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT | HAVE_UWP_WINAPI_SUPPORT) */
 
-#if G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT | HAVE_UWP_WINAPI_SUPPORT)
+static gint
+internal_w32socket_disconnect (SOCKET sock, gboolean reuse, gboolean blocking)
+{
+	gint ret = ERROR_NOT_SUPPORTED;
+	LPFN_DISCONNECTEX disconnect;
+	GUID disconnect_guid = WSAID_DISCONNECTEX;
+	DWORD output_bytes;
+
+	if (!WSAIoctl (sock, SIO_GET_EXTENSION_FUNCTION_POINTER, &disconnect_guid, sizeof (GUID), &disconnect, sizeof (LPFN_DISCONNECTEX), &output_bytes, NULL, NULL)) {
+		MonoThreadInfo *info = mono_thread_info_current ();
+
+		if (blocking)
+			mono_win32_enter_blocking_io_call (info, (HANDLE)sock);
+
+		MONO_ENTER_GC_SAFE;
+		if (disconnect (sock, NULL, reuse ? TF_REUSE_SOCKET : 0, 0))
+			ret = 0;
+		MONO_EXIT_GC_SAFE;
+
+		if (blocking)
+			mono_win32_leave_blocking_io_call (info, (HANDLE)sock);
+	}
+
+	if (ret != 0)
+		ret = WSAGetLastError ();
+
+	return ret;
+}
+
+BOOL mono_w32socket_transmit_file (SOCKET hSocket, gpointer hFile, TRANSMIT_FILE_BUFFERS *lpTransmitBuffers, guint32 dwReserved, gboolean blocking)
+{
+	return internal_w32socket_transmit_file (hSocket, hFile, lpTransmitBuffers, dwReserved, blocking) == 0 ? TRUE : FALSE;
+}
+
 gint
 mono_w32socket_disconnect (SOCKET sock, gboolean reuse)
 {
-	LPFN_DISCONNECTEX disconnect;
-	LPFN_TRANSMITFILE transmit_file;
-	DWORD output_bytes;
-	gint ret;
+	gint ret = SOCKET_ERROR;
 
-	MONO_ENTER_GC_SAFE;
+	ret = internal_w32socket_disconnect (sock, reuse, TRUE);
+	if (ret == 0)
+		ret = internal_w32socket_transmit_file (sock, NULL, NULL, TF_DISCONNECT | (reuse ? TF_REUSE_SOCKET : 0), TRUE);
 
-	/* Use the SIO_GET_EXTENSION_FUNCTION_POINTER to determine
-	 * the address of the disconnect method without taking
-	 * a hard dependency on a single provider
-	 *
-	 * For an explanation of why this is done, you can read the
-	 * article at http://www.codeproject.com/internet/jbsocketserver3.asp
-	 *
-	 * I _think_ the extension function pointers need to be looked
-	 * up for each socket.
-	 *
-	 * FIXME: check the best way to store pointers to functions in
-	 * managed objects that still works on 64bit platforms. */
-
-	GUID disconnect_guid = WSAID_DISCONNECTEX;
-	GUID transmit_file_guid = WSAID_TRANSMITFILE;
-	ret = WSAIoctl (sock, SIO_GET_EXTENSION_FUNCTION_POINTER, &disconnect_guid, sizeof (GUID), &disconnect, sizeof (LPFN_DISCONNECTEX), &output_bytes, NULL, NULL);
-	if (ret == 0) {
-		if (!disconnect (sock, NULL, reuse ? TF_REUSE_SOCKET : 0, 0)) {
-			ret = WSAGetLastError ();
-			goto done;
-		}
-
-		ret = 0;
-		goto done;
-	}
-
-	ret = WSAIoctl (sock, SIO_GET_EXTENSION_FUNCTION_POINTER, &transmit_file_guid, sizeof (GUID), &transmit_file, sizeof (LPFN_TRANSMITFILE), &output_bytes, NULL, NULL);
-	if (ret == 0) {
-		if (!transmit_file (sock, NULL, 0, 0, NULL, NULL, TF_DISCONNECT | (reuse ? TF_REUSE_SOCKET : 0))) {
-			ret = WSAGetLastError ();
-			goto done;
-		}
-
-		ret = 0;
-		goto done;
-	}
-
-	ret = ERROR_NOT_SUPPORTED;
-
-done:
-	MONO_EXIT_GC_SAFE;
 	return ret;
 }
 #endif /* #if G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT | HAVE_UWP_WINAPI_SUPPORT) */

--- a/mono/utils/mono-os-wait-win32.c
+++ b/mono/utils/mono-os-wait-win32.c
@@ -15,83 +15,6 @@
 #include "mono-error-internals.h"
 #include <mono/metadata/w32subset.h>
 
-enum ThreadWaitInfo {
-	THREAD_WAIT_INFO_CLEARED = 0,
-	THREAD_WAIT_INFO_ALERTABLE_WAIT_SLOT = 1 << 0,
-	THREAD_WAIT_INFO_PENDING_INTERRUPT_APC_SLOT = 1 << 1,
-	THREAD_WAIT_INFO_PENDING_ABORT_APC_SLOT = 1 << 2
-};
-
-static inline void
-request_interrupt (gpointer thread_info, HANDLE native_thread_handle, gint32 pending_apc_slot, PAPCFUNC apc_callback, DWORD tid)
-{
-	/*
-	* On Windows platforms, an async interrupt/abort request queues an APC
-	* that needs to be processed by target thread before it can return from an
-	* alertable OS wait call and complete the mono interrupt/abort request.
-	* Uncontrolled queuing of APC's could flood the APC queue preventing the target thread
-	* to return from its alertable OS wait call, blocking the interrupt/abort requests to complete
-	* This check makes sure that only one APC per type gets queued, preventing potential flooding
-	* of the APC queue. NOTE, this code will execute regardless if targeted thread is currently in
-	* an alertable wait or not. This is done to prevent races between interrupt/abort requests and
-	* alertable wait calls. Threads already in an alertable wait should handle WAIT_IO_COMPLETION
-	* return scenarios and restart the alertable wait operation if needed or take other actions
-	* (like service the interrupt/abort request).
-	*/
-	MonoThreadInfo *info = (MonoThreadInfo *)thread_info;
-	gint32 old_wait_info, new_wait_info;
-
-	do {
-		old_wait_info = mono_atomic_load_i32 (&info->thread_wait_info);
-		if (old_wait_info & pending_apc_slot)
-			return;
-
-		new_wait_info = old_wait_info | pending_apc_slot;
-	} while (mono_atomic_cas_i32 (&info->thread_wait_info, new_wait_info, old_wait_info) != old_wait_info);
-
-	THREADS_INTERRUPT_DEBUG ("%06d - Interrupting/Aborting syscall in thread %06d", GetCurrentThreadId (), tid);
-	QueueUserAPC (apc_callback, native_thread_handle, (ULONG_PTR)NULL);
-}
-
-static void CALLBACK
-interrupt_apc (ULONG_PTR param)
-{
-	THREADS_INTERRUPT_DEBUG ("%06d - interrupt_apc () called", GetCurrentThreadId ());
-}
-
-void
-mono_win32_interrupt_wait (PVOID thread_info, HANDLE native_thread_handle, DWORD tid)
-{
-	request_interrupt (thread_info, native_thread_handle, THREAD_WAIT_INFO_PENDING_INTERRUPT_APC_SLOT, interrupt_apc, tid);
-}
-
-static void CALLBACK
-abort_apc (ULONG_PTR param)
-{
-	THREADS_INTERRUPT_DEBUG ("%06d - abort_apc () called", GetCurrentThreadId ());
-}
-
-void
-mono_win32_abort_wait (PVOID thread_info, HANDLE native_thread_handle, DWORD tid)
-{
-	request_interrupt (thread_info, native_thread_handle, THREAD_WAIT_INFO_PENDING_ABORT_APC_SLOT, abort_apc, tid);
-}
-
-static inline void
-enter_alertable_wait (MonoThreadInfo *info)
-{
-	// Clear any previous flags. Set alertable wait flag.
-	mono_atomic_xchg_i32 (&info->thread_wait_info, THREAD_WAIT_INFO_ALERTABLE_WAIT_SLOT);
-}
-
-static inline void
-leave_alertable_wait (MonoThreadInfo *info)
-{
-	// Clear any previous flags. Thread is exiting alertable wait state, and info around pending interrupt/abort APC's
-	// can now be discarded as well, thread is out of wait operation and can proceed it's execution.
-	mono_atomic_xchg_i32 (&info->thread_wait_info, THREAD_WAIT_INFO_CLEARED);
-}
-
 DWORD
 mono_win32_sleep_ex (DWORD timeout, BOOL alertable)
 {
@@ -99,14 +22,12 @@ mono_win32_sleep_ex (DWORD timeout, BOOL alertable)
 	MonoThreadInfo * const info = alertable ? mono_thread_info_current_unchecked () : NULL;
 
 	if (info)
-		enter_alertable_wait (info);
+		mono_win32_enter_alertable_wait (info);
 
 	result = SleepEx (timeout, alertable);
 
-	// NOTE, leave_alertable_wait should not affect GetLastError but
-	// if changed, GetLastError needs to be preserved and reset before returning.
 	if (info)
-		leave_alertable_wait (info);
+		mono_win32_leave_alertable_wait (info);
 
 	return result;
 }
@@ -118,14 +39,12 @@ mono_win32_wait_for_single_object_ex (HANDLE handle, DWORD timeout, BOOL alertab
 	MonoThreadInfo * const info = alertable ? mono_thread_info_current_unchecked () : NULL;
 
 	if (info)
-		enter_alertable_wait (info);
+		mono_win32_enter_alertable_wait (info);
 
 	result = WaitForSingleObjectEx (handle, timeout, alertable);
 
-	// NOTE, leave_alertable_wait should not affect GetLastError but
-	// if changed, GetLastError needs to be preserved and reset before returning.
 	if (info)
-		leave_alertable_wait (info);
+		mono_win32_leave_alertable_wait (info);
 
 	return result;
 }
@@ -136,14 +55,12 @@ mono_win32_wait_for_multiple_objects_ex (DWORD count, CONST HANDLE *handles, BOO
 	MonoThreadInfo * const info = alertable ? mono_thread_info_current_unchecked () : NULL;
 
 	if (info)
-		enter_alertable_wait (info);
+		mono_win32_enter_alertable_wait (info);
 
 	DWORD const result = WaitForMultipleObjectsEx (count, handles, waitAll, timeout, alertable);
 
-	// NOTE, leave_alertable_wait should not affect GetLastError but
-	// if changed, GetLastError needs to be preserved and reset before returning.
 	if (info)
-		leave_alertable_wait (info);
+		mono_win32_leave_alertable_wait (info);
 
 	// This is not perfect, but it is the best you can do in usermode and matches CoreCLR.
 	// i.e. handle-based instead of object-based.
@@ -177,14 +94,12 @@ mono_win32_signal_object_and_wait (HANDLE toSignal, HANDLE toWait, DWORD timeout
 	MonoThreadInfo * const info = alertable ? mono_thread_info_current_unchecked () : NULL;
 
 	if (info)
-		enter_alertable_wait (info);
+		mono_win32_enter_alertable_wait (info);
 
 	result = SignalObjectAndWait (toSignal, toWait, timeout, alertable);
 
-	// NOTE, leave_alertable_wait should not affect GetLastError but
-	// if changed, GetLastError needs to be preserved and reset before returning.
 	if (info)
-		leave_alertable_wait (info);
+		mono_win32_leave_alertable_wait (info);
 
 	return result;
 }
@@ -200,14 +115,12 @@ mono_win32_msg_wait_for_multiple_objects_ex (DWORD count, CONST HANDLE *handles,
 	MonoThreadInfo * const info = alertable ? mono_thread_info_current_unchecked () : NULL;
 
 	if (info)
-		enter_alertable_wait (info);
+		mono_win32_enter_alertable_wait (info);
 
 	result = MsgWaitForMultipleObjectsEx (count, handles, timeout, wakeMask, flags);
 
-	// NOTE, leave_alertable_wait should not affect GetLastError but
-	// if changed, GetLastError needs to be preserved and reset before returning.
 	if (info)
-		leave_alertable_wait (info);
+		mono_win32_leave_alertable_wait (info);
 
 	return result;
 }
@@ -220,14 +133,12 @@ mono_win32_wsa_wait_for_multiple_events (DWORD count, const WSAEVENT FAR *handle
 	MonoThreadInfo * const info = alertable ? mono_thread_info_current_unchecked () : NULL;
 
 	if (info)
-		enter_alertable_wait (info);
+		mono_win32_enter_alertable_wait (info);
 
 	result = WSAWaitForMultipleEvents (count, handles, waitAll, timeout, alertable);
 
-	// NOTE, leave_alertable_wait should not affect GetLastError but
-	// if changed, GetLastError needs to be preserved and reset before returning.
 	if (info)
-		leave_alertable_wait (info);
+		mono_win32_leave_alertable_wait (info);
 
 	return result;
 }

--- a/mono/utils/mono-os-wait.h
+++ b/mono/utils/mono-os-wait.h
@@ -30,12 +30,6 @@ mono_win32_msg_wait_for_multiple_objects_ex (DWORD count, CONST HANDLE *handles,
 DWORD
 mono_win32_wsa_wait_for_multiple_events (DWORD count, const WSAEVENT FAR *handles, BOOL waitAll, DWORD timeout, BOOL alertable);
 
-void
-mono_win32_interrupt_wait (PVOID thread_info, HANDLE native_thread_handle, DWORD tid);
-
-void
-mono_win32_abort_wait (PVOID thread_info, HANDLE native_thread_handle, DWORD tid);
-
 #endif
 
 #endif /* _MONO_UTILS_OS_WAIT_H_ */

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -463,6 +463,11 @@ register_thread (MonoThreadInfo *info)
 
 	info->profiler_signal_ack = 1;
 
+#ifdef USE_WINDOWS_BACKEND
+	info->win32_apc_info = 0;
+	info->win32_apc_info_io_handle = INVALID_HANDLE_VALUE;
+#endif
+
 	mono_threads_suspend_register (info);
 
 	THREADS_DEBUG ("registering info %p tid %p small id %x\n", info, mono_thread_info_get_tid (info), info->small_id);

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -268,7 +268,8 @@ typedef struct _MonoThreadInfo {
 	gint32 profiler_signal_ack;
 
 #ifdef USE_WINDOWS_BACKEND
-	gint32 thread_wait_info;
+	gint32 win32_apc_info;
+	gpointer win32_apc_info_io_handle;
 #endif
 
 	/*
@@ -792,6 +793,24 @@ void mono_threads_join_unlock (void);
 #ifdef HOST_WASM
 typedef void (*background_job_cb)(void);
 void mono_threads_schedule_background_job (background_job_cb cb);
+#endif
+
+#ifdef USE_WINDOWS_BACKEND
+
+void
+mono_win32_enter_alertable_wait (THREAD_INFO_TYPE *info);
+
+void
+mono_win32_leave_alertable_wait (THREAD_INFO_TYPE *info);
+
+void
+mono_win32_enter_blocking_io_call (THREAD_INFO_TYPE *info, HANDLE io_handle);
+
+void
+mono_win32_leave_blocking_io_call (THREAD_INFO_TYPE *info, HANDLE io_handle);
+
+void
+mono_win32_interrupt_wait (PVOID thread_info, HANDLE native_thread_handle, DWORD tid);
 #endif
 
 #endif /* __MONO_THREADS_H__ */


### PR DESCRIPTION
Windows support to abort blocking system calls has been limited since several of the API's currently used are not using overlapped IO and since system handles are exposed to clients, can't be changed to always work with overlapped IO, even if support could be added in the future, at least for sockets.

In order to add support to abort socket waits,  https://github.com/mono/mono/commit/53af53ae5923ccb205ea8e0ebebdbe0c0ee5de88, did an attempt to implement alertable socket support on Windows, but the implementation was racy and assume that only one thread works against the same socket handle, something that regressed a couple of scenarios, like the one described in https://github.com/mono/mono/issues/12480.

This PR adds optional support to break blocking socket calls using a different approach, leveraging the support we already have in Mono around interrupting/aborting system calls. On Windows this is currently done using APC, but that currently only works for alertable waits and the blocking socket implementation won't return to caller (even if it's using alertable wait behind the scene). Since the abort is currently needed when doing a Thread.Abort the PR includes an additional mechanism where our implementation of blocking system calls registers the current IO handle on current thread MonoThreadInternal structure while doing the blocking call. If that thread gets an abort APC and it's in a blocking IO call region, it will cancel the IO from the queued APC (running on the same thread currently blocking on the call) and that will make sure the thread will break out of any blocking IO call with WSAEINTR or similar error. This builds on the interruptable wait implementation already in place and since the abort logic runs on the same thread as the one register/unregister the IO handle (as part of queued APC) there is no race between the thread requesting an abort and the thread actually running the queued APC.

Since we don't always have full control of the socket/handle used in blocking IO calls, there is a small risk that the socket/handle is not opened to support overlapped IO. If that's the case, the blocking IO call is not doing an alertable wait meaning that it can't run the queued APC so it won't return. This scenario is mitigated by cancel all outstanding sync IO calls on target thread as part of issuing the abort. There is however a small chance that the thread is not yet blocked on sync IO when issuing the cancel request and then it won't be possible to abort the blocking call. NOTE, this is not a problem with blocking calls on socket/handle that uses overlapped IO since the execution of the APC guarantees that the blocking thread has entered an alertable wait as part of waiting for the blocked IO to complete.
