### PR TITLE
Fix pipes not being enabled in all relevant versions of the build profile

### DIFF
--- a/mcs/class/System.Core/linux_build_System.Core.dll.sources
+++ b/mcs/class/System.Core/linux_build_System.Core.dll.sources
@@ -1,0 +1,1 @@
+#include unix_net_4_x_System.Core.dll.sources

--- a/mcs/class/System.Core/macos_build_System.Core.dll.sources
+++ b/mcs/class/System.Core/macos_build_System.Core.dll.sources
@@ -1,0 +1,1 @@
+#include unix_net_4_x_System.Core.dll.sources


### PR DESCRIPTION
I missed this in my compiler server PRs. Without it, the compiler server won't be able to open pipes. (It already works in every other profile).