### PR TITLE
Fix build errors for net_4_x bcl.sln build.

### DIFF
--- a/mcs/ilasm/ilasm.csproj
+++ b/mcs/ilasm/ilasm.csproj
@@ -13,6 +13,7 @@
     <HostPlatform Condition=" '$(HostPlatform)' == '' and '$(OS)' == 'Unix'">linux</HostPlatform>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <NoStdLib>False</NoStdLib>
+    <NoStdLib Condition=" '$(Platform)' == 'net_4_x' ">True</NoStdLib>
     <NoConfig>True</NoConfig>
     <AssemblyName>ilasm</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
@@ -157,6 +158,7 @@
   <!-- @ALL_SOURCES@ -->
   <!-- @COMMON_PROJECT_REFERENCES@ -->
   <ItemGroup Condition=" '$(Platform)' == 'net_4_x' ">
+    <ProjectReference Include="../class/corlib/corlib.csproj" />
     <ProjectReference Include="../class/PEAPI/PEAPI.csproj" />
     <ProjectReference Include="../class/System/System.csproj" />
     <ProjectReference Include="../class/Mono.Security/Mono.Security.csproj" />

--- a/mcs/mcs/mcs.csproj
+++ b/mcs/mcs/mcs.csproj
@@ -13,6 +13,7 @@
     <HostPlatform Condition=" '$(HostPlatform)' == '' and '$(OS)' == 'Unix'">linux</HostPlatform>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <NoStdLib>False</NoStdLib>
+    <NoStdLib Condition=" '$(Platform)' == 'net_4_x' ">True</NoStdLib>
     <NoConfig>True</NoConfig>
     <AssemblyName>mcs</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
@@ -213,6 +214,7 @@
   <!-- @ALL_SOURCES@ -->
   <!-- @COMMON_PROJECT_REFERENCES@ -->
   <ItemGroup Condition=" '$(Platform)' == 'net_4_x' ">
+    <ProjectReference Include="../class/corlib/corlib.csproj" />
     <ProjectReference Include="../class/System.Core/System.Core.csproj" />
     <ProjectReference Include="../class/System.XML/System.Xml.csproj" />
     <ProjectReference Include="../class/System/System.csproj" />

--- a/mcs/tools/al/al.csproj
+++ b/mcs/tools/al/al.csproj
@@ -13,6 +13,7 @@
     <HostPlatform Condition=" '$(HostPlatform)' == '' and '$(OS)' == 'Unix'">linux</HostPlatform>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <NoStdLib>False</NoStdLib>
+    <NoStdLib Condition=" '$(Platform)' == 'net_4_x' ">True</NoStdLib>
     <NoConfig>True</NoConfig>
     <AssemblyName>al</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
@@ -149,6 +150,7 @@
   <!-- @ALL_SOURCES@ -->
   <!-- @COMMON_PROJECT_REFERENCES@ -->
   <ItemGroup Condition=" '$(Platform)' == 'net_4_x' ">
+    <ProjectReference Include="../../class/corlib/corlib.csproj" />
     <ProjectReference Include="../../class/System/System.csproj" />
     <ProjectReference Include="../../class/System.Core/System.Core.csproj" />
     <ProjectReference Include="../../class/Mono.Security/Mono.Security.csproj" />

--- a/mcs/tools/gacutil/gacutil.csproj
+++ b/mcs/tools/gacutil/gacutil.csproj
@@ -13,6 +13,7 @@
     <HostPlatform Condition=" '$(HostPlatform)' == '' and '$(OS)' == 'Unix'">linux</HostPlatform>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <NoStdLib>False</NoStdLib>
+    <NoStdLib Condition=" '$(Platform)' == 'net_4_x' ">True</NoStdLib>
     <NoConfig>True</NoConfig>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>gacutil</AssemblyName>
@@ -140,6 +141,7 @@
   <!-- @ALL_SOURCES@ -->
   <!-- @COMMON_PROJECT_REFERENCES@ -->
   <ItemGroup Condition=" '$(Platform)' == 'net_4_x' ">
+    <ProjectReference Include="../../class/corlib/corlib.csproj" />
     <ProjectReference Include="../../class/System/System.csproj" />
     <ProjectReference Include="../../class/Mono.Security/Mono.Security.csproj" />
     <ProjectReference Include="../../class/System.Security/System.Security.csproj" />

--- a/mcs/tools/ikdasm/ikdasm.csproj
+++ b/mcs/tools/ikdasm/ikdasm.csproj
@@ -13,6 +13,7 @@
     <HostPlatform Condition=" '$(HostPlatform)' == '' and '$(OS)' == 'Unix'">linux</HostPlatform>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <NoStdLib>False</NoStdLib>
+    <NoStdLib Condition=" '$(Platform)' == 'net_4_x' ">True</NoStdLib>
     <NoConfig>True</NoConfig>
     <AssemblyName>ikdasm</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
@@ -148,6 +149,7 @@
   <!-- @ALL_SOURCES@ -->
   <!-- @COMMON_PROJECT_REFERENCES@ -->
   <ItemGroup Condition=" '$(Platform)' == 'net_4_x' ">
+    <ProjectReference Include="../../class/corlib/corlib.csproj" />
     <ProjectReference Include="../../class/System/System.csproj" />
     <ProjectReference Include="../../class/System.Core/System.Core.csproj" />
     <ProjectReference Include="../../class/System.Security/System.Security.csproj" />

--- a/mcs/tools/linker/monolinker.csproj
+++ b/mcs/tools/linker/monolinker.csproj
@@ -12,7 +12,7 @@
     <HostPlatform Condition=" '$(HostPlatform)' == '' and '$(OS)' == 'Unix' and $([System.IO.File]::Exists('/usr/lib/libc.dylib'))">macos</HostPlatform>
     <HostPlatform Condition=" '$(HostPlatform)' == '' and '$(OS)' == 'Unix'">linux</HostPlatform>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
-    <NoStdLib>False</NoStdLib>
+    <NoStdLib>True</NoStdLib>
     <NoConfig>True</NoConfig>
     <AssemblyName>monolinker</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
@@ -100,6 +100,7 @@
   <!--End of common files-->
   <!-- @ALL_SOURCES@ -->
   <ItemGroup>
+    <ProjectReference Include="../../class/corlib/corlib.csproj" />
     <ProjectReference Include="../../class/System/System.csproj" />
     <ProjectReference Include="../../class/System.Core/System.Core.csproj" />
     <ProjectReference Include="../../class/System.XML/System.Xml.csproj" />

--- a/mcs/tools/mdoc/mdoc.csproj
+++ b/mcs/tools/mdoc/mdoc.csproj
@@ -12,7 +12,7 @@
     <HostPlatform Condition=" '$(HostPlatform)' == '' and '$(OS)' == 'Unix' and $([System.IO.File]::Exists('/usr/lib/libc.dylib'))">macos</HostPlatform>
     <HostPlatform Condition=" '$(HostPlatform)' == '' and '$(OS)' == 'Unix'">linux</HostPlatform>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
-    <NoStdLib>False</NoStdLib>
+    <NoStdLib>True</NoStdLib>
     <NoConfig>True</NoConfig>
     <AssemblyName>mdoc</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
@@ -86,6 +86,7 @@
   <!--End of common files-->
   <!-- @ALL_SOURCES@ -->
   <ItemGroup>
+    <ProjectReference Include="../../class/corlib/corlib.csproj" />
     <ProjectReference Include="../../class/monodoc/monodoc.csproj" />
     <ProjectReference Include="../../class/System/System.csproj" />
     <ProjectReference Include="../../class/System.XML/System.Xml.csproj" />

--- a/mcs/tools/mkbundle/mkbundle.csproj
+++ b/mcs/tools/mkbundle/mkbundle.csproj
@@ -12,7 +12,7 @@
     <HostPlatform Condition=" '$(HostPlatform)' == '' and '$(OS)' == 'Unix' and $([System.IO.File]::Exists('/usr/lib/libc.dylib'))">macos</HostPlatform>
     <HostPlatform Condition=" '$(HostPlatform)' == '' and '$(OS)' == 'Unix'">linux</HostPlatform>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
-    <NoStdLib>False</NoStdLib>
+    <NoStdLib>True</NoStdLib>
     <NoConfig>True</NoConfig>
     <AssemblyName>mkbundle</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
@@ -142,6 +142,7 @@
   <!--End of common files-->
   <!-- @ALL_SOURCES@ -->
   <ItemGroup>
+    <ProjectReference Include="../../class/corlib/corlib.csproj" />
     <ProjectReference Include="../../class/System.XML/System.Xml.csproj" />
     <ProjectReference Include="../../class/System/System.csproj" />
     <ProjectReference Include="../../class/System.Core/System.Core.csproj" />

--- a/mcs/tools/mono-symbolicate/mono-symbolicate.csproj
+++ b/mcs/tools/mono-symbolicate/mono-symbolicate.csproj
@@ -12,7 +12,7 @@
     <HostPlatform Condition=" '$(HostPlatform)' == '' and '$(OS)' == 'Unix' and $([System.IO.File]::Exists('/usr/lib/libc.dylib'))">macos</HostPlatform>
     <HostPlatform Condition=" '$(HostPlatform)' == '' and '$(OS)' == 'Unix'">linux</HostPlatform>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
-    <NoStdLib>False</NoStdLib>
+    <NoStdLib>True</NoStdLib>
     <NoConfig>True</NoConfig>
     <AssemblyName>mono-symbolicate</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
@@ -230,6 +230,7 @@
   <!--End of common files-->
   <!-- @ALL_SOURCES@ -->
   <ItemGroup>
+    <ProjectReference Include="../../class/corlib/corlib.csproj" />
     <ProjectReference Include="../../class/System.XML/System.Xml.csproj" />
     <ProjectReference Include="../../class/System.Core/System.Core.csproj" />
     <ProjectReference Include="../../class/System/System.csproj" />

--- a/mcs/tools/monop/monop.csproj
+++ b/mcs/tools/monop/monop.csproj
@@ -13,6 +13,7 @@
     <HostPlatform Condition=" '$(HostPlatform)' == '' and '$(OS)' == 'Unix'">linux</HostPlatform>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <NoStdLib>False</NoStdLib>
+    <NoStdLib Condition=" '$(Platform)' == 'net_4_x' ">True</NoStdLib>
     <NoConfig>True</NoConfig>
     <AssemblyName>monop</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
@@ -145,6 +146,7 @@
   <!-- @ALL_SOURCES@ -->
   <!-- @COMMON_PROJECT_REFERENCES@ -->
   <ItemGroup Condition=" '$(Platform)' == 'net_4_x' ">
+    <ProjectReference Include="../../class/corlib/corlib.csproj" />
     <ProjectReference Include="../../class/System/System.csproj" />
   </ItemGroup>
   <!-- @ALL_REFERENCES@ -->

--- a/mcs/tools/resgen/resgen.csproj
+++ b/mcs/tools/resgen/resgen.csproj
@@ -13,6 +13,7 @@
     <HostPlatform Condition=" '$(HostPlatform)' == '' and '$(OS)' == 'Unix'">linux</HostPlatform>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <NoStdLib>False</NoStdLib>
+    <NoStdLib Condition=" '$(Platform)' == 'net_4_x' ">True</NoStdLib>
     <NoConfig>True</NoConfig>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>resgen</AssemblyName>
@@ -80,6 +81,7 @@
   <!-- @ALL_SOURCES@ -->
   <!-- @COMMON_PROJECT_REFERENCES@ -->
   <ItemGroup Condition=" '$(Platform)' == 'net_4_x' ">
+    <ProjectReference Include="../../class/corlib/corlib.csproj" />
     <ProjectReference Include="../../class/System/System.csproj" />
     <ProjectReference Include="../../class/System.XML/System.Xml.csproj" />
     <ProjectReference Include="../../class/System.Core/System.Core.csproj" />


### PR DESCRIPTION
bcl.sln fails to build 11 tools project due to error around missing type. This is due referencing system mscorlib.dll instead of our own build corlib that doesn't match the system mscorlib.dll causing build errors.

This commit makes sure the tools build --nostdlib and reference our corlib project.
