### PR TITLE
"Ice Blue": Adding some "Connection Info" properties to SslStream.

### DIFF
--- a/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
+++ b/mcs/class/System/Mono.Net.Security/MobileAuthenticatedStream.cs
@@ -1102,29 +1102,64 @@ namespace Mono.Net.Security
 			}
 		}
 
-#region Need to Implement
 		public int CipherStrength {
 			get {
-				throw new NotImplementedException ();
+				CheckThrow (true);
+				var info = GetConnectionInfo ();
+				if (info == null)
+					return 0;
+				switch (info.CipherAlgorithmType) {
+				case MSI.CipherAlgorithmType.None:
+				case MSI.CipherAlgorithmType.Aes128:
+				case MSI.CipherAlgorithmType.AesGcm128:
+					return 128;
+				case MSI.CipherAlgorithmType.Aes256:
+				case MSI.CipherAlgorithmType.AesGcm256:
+					return 256;
+				default:
+					throw new ArgumentOutOfRangeException (nameof (info.CipherAlgorithmType));
+				}
 			}
 		}
+
 		public int HashStrength {
 			get {
-				throw new NotImplementedException ();
+				CheckThrow (true);
+				var info = GetConnectionInfo ();
+				if (info == null)
+					return 0;
+				switch (info.HashAlgorithmType) {
+				case MSI.HashAlgorithmType.Md5:
+				case MSI.HashAlgorithmType.Md5Sha1:
+					return 128;
+				case MSI.HashAlgorithmType.Sha1:
+					return 160;
+				case MSI.HashAlgorithmType.Sha224:
+					return 224;
+				case MSI.HashAlgorithmType.Sha256:
+					return 256;
+				case MSI.HashAlgorithmType.Sha384:
+					return 384;
+				case MSI.HashAlgorithmType.Sha512:
+					return 512;
+				default:
+					throw new ArgumentOutOfRangeException (nameof (info.HashAlgorithmType));
+				}
 			}
 		}
+
 		public int KeyExchangeStrength {
 			get {
-				throw new NotImplementedException ();
+				// FIXME: CoreFX returns 0 on non-Windows platforms.
+				return 0;
 			}
 		}
+
 		public bool CheckCertRevocationStatus {
 			get {
 				throw new NotImplementedException ();
 			}
 		}
-
-#endregion
 	}
 }
 #endif


### PR DESCRIPTION
Provide a Mono-specific version of CoreFx's `SslConnectionInfo` and use it to implement some "Connection Info" properties in `SslStream`: `CipherStrength`, `HashStrength` and `KeyExchangeStrength`.

Fixes #12552.