### PR TITLE
[corlib] Fix the linker descriptors for the SRE classes.

### DIFF
--- a/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
+++ b/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
@@ -589,40 +589,22 @@
 			<method signature="System.Void .ctor(System.String)" />
 		</type>
 
-		<type fullname="System.Reflection.Emit.AssemblyBuilder" feature="sre">
-			<method name="AddPermissionRequests" feature="sre" />
-			<method name="AddModule" feature="sre" />
-			<method name="DefineIconResource" feature="sre" />
-			<method name="AddTypeForwarder" feature="sre" />
-			<method name="EmbedResourceFile" feature="sre" />
-		</type>
-		<type fullname="System.Reflection.Emit.ConstructorBuilder" preserve="fields" feature="sre">
-			<method name="RuntimeResolve" feature="sre" />
-		</type>
+		<type fullname="System.Reflection.Emit.AssemblyBuilder" preserve="fields" feature="sre" />
+		<type fullname="System.Reflection.Emit.ConstructorBuilder" preserve="fields" feature="sre"/>
 		<type fullname="System.Reflection.Emit.DynamicMethod" preserve="fields" feature="sre" />
 		<!-- mono_dynamic_image_register_token -->
 		<type fullname="System.Reflection.Emit.EnumBuilder" preserve="fields" feature="sre" />
 		<type fullname="System.Reflection.Emit.EventBuilder" preserve="fields" feature="sre" />
-		<type fullname="System.Reflection.Emit.FieldBuilder" preserve="fields" feature="sre" >
-			<method name="RuntimeResolve" feature="sre" />
-		</type>
-		<type fullname="System.Reflection.Emit.GenericTypeParameterBuilder" feature="sre" >
-			<method name="RuntimeResolve" feature="sre" />
-		</type>
+		<type fullname="System.Reflection.Emit.FieldBuilder" preserve="fields" feature="sre" />
+		<type
+		  fullname="System.Reflection.Emit.GenericTypeParameterBuilder" preserve="fields" feature="sre" />
 		<type fullname="System.Reflection.Emit.ILExceptionBlock" preserve="fields" feature="sre" />
 		<type fullname="System.Reflection.Emit.ILExceptionInfo" preserve="fields" feature="sre" />
-		<type fullname="System.Reflection.Emit.ILGenerator" feature="sre" >
-			<method name="Mono_GetCurrentOffset" feature="sre" />
-		</type>
-		<type fullname="System.Reflection.Emit.LocalBuilder" preserve="fields" feature="sre" >
-			<method name="Mono_GetLocalIndex" feature="sre" />
-		</type>
-		<type fullname="System.Reflection.Emit.MethodBuilder" preserve="fields" feature="sre" >
-			<method name="RuntimeResolve" feature="sre" />
-		</type>
-		<type fullname="System.Reflection.Emit.ModuleBuilder" feature="sre">
+		<type fullname="System.Reflection.Emit.ILGenerator" preserve="fields" feature="sre" />
+		<type fullname="System.Reflection.Emit.LocalBuilder" preserve="fields" feature="sre" />
+		<type fullname="System.Reflection.Emit.MethodBuilder" preserve="fields" feature="sre" />
+		<type fullname="System.Reflection.Emit.ModuleBuilder" preserve="fields" feature="sre">
 			<method name="Mono_GetGuid" feature="sre" />
-			<method name="RuntimeResolve" feature="sre" />
 		</type>
 		<type fullname="System.Reflection.Emit.MonoResource" preserve="fields" feature="sre" />
 		<type fullname="System.Reflection.Emit.MonoWin32Resource" preserve="fields" feature="sre" />
@@ -638,27 +620,12 @@
 			<method name="DefineCustom" feature="sre" />
 			<method name="DefineLPArrayInternal" feature="sre" />
 		</type>
-		<type fullname="System.Reflection.Emit.TypeBuilderInstantiation">
-			<method name="RuntimeResolve" feature="sre" />
-		</type>
-		<type fullname="System.Reflection.Emit.ArrayType" preserve="fields" feature="sre" >
-			<method name="RuntimeResolve" feature="sre" />
-		</type>
-		<type fullname="System.Reflection.Emit.ByRefType" preserve="fields" feature="sre" >
-			<method name="RuntimeResolve" feature="sre" />
-		</type>
-		<type fullname="System.Reflection.Emit.PointerType" preserve="fields" feature="sre" >
-			<method name="RuntimeResolve" feature="sre" />
-		</type>
-		<type fullname="System.Reflection.Emit.FieldOnTypeBuilderInst" preserve="fields" feature="sre" >
-			<method name="RuntimeResolve" feature="sre" />
-		</type>
-		<type fullname="System.Reflection.Emit.MethodOnTypeBuilderInst" preserve="fields" feature="sre" >
-			<method name="RuntimeResolve" feature="sre" />
-		</type>
-		<type fullname="System.Reflection.Emit.ConstructorOnTypeBuilderInst" preserve="fields" feature="sre" >
-			<method name="RuntimeResolve" feature="sre" />
-		</type>
+		<type fullname="System.Reflection.Emit.ArrayType" preserve="fields" feature="sre" />
+		<type fullname="System.Reflection.Emit.ByRefType" preserve="fields" feature="sre" />
+		<type fullname="System.Reflection.Emit.PointerType" preserve="fields" feature="sre" />
+		<type fullname="System.Reflection.Emit.FieldOnTypeBuilderInst" preserve="fields" feature="sre" />
+		<type fullname="System.Reflection.Emit.MethodOnTypeBuilderInst" preserve="fields" feature="sre" />
+		<type fullname="System.Reflection.Emit.ConstructorOnTypeBuilderInst" preserve="fields" feature="sre" />
 
 		<!-- exception.c: mono_get_exception_runtime_wrapped () -->
 		<type fullname="System.Runtime.CompilerServices.RuntimeWrappedException">

--- a/mcs/class/corlib/System.Reflection.Emit/AssemblyBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/AssemblyBuilder.cs
@@ -290,6 +290,7 @@ namespace System.Reflection.Emit
 		/* Keep this in sync with codegen.cs in mcs */
 		private const AssemblyBuilderAccess COMPILER_ACCESS = (AssemblyBuilderAccess) 0x800;
 
+		[PreserveDependency ("RuntimeResolve", "System.Reflection.Emit.ModuleBuilder")]
 		internal AssemblyBuilder (AssemblyName n, string directory, AssemblyBuilderAccess access, bool corlib_internal)
 		{
 			/* This is obsolete now, as mcs doesn't use SRE any more */


### PR DESCRIPTION
Preserve the ModuleBuilder.RuntimeResolve () method using a PreserveDependency attribute.
Remove nonexistent methods.