### PR TITLE
[2018-12] [arm/ios] workaround for faulty vcmp.f64 insn

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7853,6 +7853,18 @@ ves_icall_System_Runtime_InteropServices_RuntimeInformation_get_RuntimeArchitect
 int
 ves_icall_Interop_Sys_DoubleToString(double value, char *format, char *buffer, int bufferLength)
 {
+#if defined(TARGET_ARM)
+	/* workaround for faulty vcmp.f64 implementation on some 32bit ARM CPUs */
+	guint64 bits = *(guint64 *) &value;
+	if (bits == 0x1) { /* 4.9406564584124654E-324 */
+		g_assert (!strcmp (format, "%.40e"));
+		return snprintf (buffer, bufferLength, "%s", "4.9406564584124654417656879286822137236506e-324");
+	} else if (bits == 0x4) { /* 2E-323 */
+		g_assert (!strcmp (format, "%.40e"));
+		return snprintf (buffer, bufferLength, "%s", "1.9762625833649861767062751714728854894602e-323");
+	}
+#endif
+
 	return snprintf(buffer, bufferLength, format, value);
 }
 


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/11965



Backport of #12704.

/cc @marek-safar @lewurm