### PR TITLE
[2018-10] Bump corert

### DIFF
--- a/bcl.sln
+++ b/bcl.sln
@@ -3366,8 +3366,10 @@ Global
 		{817CE046-07E8-409D-84BF-A6EA4F2879DE}.Release|wasm.ActiveCfg = Release|net_4_x
 		{817CE046-07E8-409D-84BF-A6EA4F2879DE}.Debug|winaot.ActiveCfg = Debug|net_4_x
 		{817CE046-07E8-409D-84BF-A6EA4F2879DE}.Release|winaot.ActiveCfg = Release|net_4_x
-		{817CE046-07E8-409D-84BF-A6EA4F2879DE}.Debug|xammac.ActiveCfg = Debug|net_4_x
-		{817CE046-07E8-409D-84BF-A6EA4F2879DE}.Release|xammac.ActiveCfg = Release|net_4_x
+		{817CE046-07E8-409D-84BF-A6EA4F2879DE}.Debug|xammac.ActiveCfg = Debug|xammac
+		{817CE046-07E8-409D-84BF-A6EA4F2879DE}.Debug|xammac.Build.0 = Debug|xammac
+		{817CE046-07E8-409D-84BF-A6EA4F2879DE}.Release|xammac.ActiveCfg = Release|xammac
+		{817CE046-07E8-409D-84BF-A6EA4F2879DE}.Release|xammac.Build.0 = Release|xammac
 		{8787A3B7-8A19-4586-8DCF-6F5914FD48D5}.Debug|net_4_x.ActiveCfg = Debug|net_4_x
 		{8787A3B7-8A19-4586-8DCF-6F5914FD48D5}.Debug|net_4_x.Build.0 = Debug|net_4_x
 		{8787A3B7-8A19-4586-8DCF-6F5914FD48D5}.Release|net_4_x.ActiveCfg = Release|net_4_x

--- a/mcs/class/Mono.CSharp/Mono.CSharp.csproj
+++ b/mcs/class/Mono.CSharp/Mono.CSharp.csproj
@@ -75,6 +75,11 @@
     <IntermediateOutputPath>./../../class/obj/$(AssemblyName)-testing_aot_full</IntermediateOutputPath>
     <DefineConstants>NET_1_1;NET_2_0;NET_2_1;NET_3_5;NET_4_0;NET_4_5;MONO;MOBILE;MOBILE_LEGACY;FULL_AOT_DESKTOP;FULL_AOT_RUNTIME;DISABLE_REMOTING;DISABLE_COM;IOS_REFLECTION;MONO_FEATURE_THREAD_ABORT;MONO_FEATURE_PROCESS_START</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Platform)' == 'xammac' ">
+    <OutputPath>./../../class/lib/xammac</OutputPath>
+    <IntermediateOutputPath>./../../class/obj/$(AssemblyName)-xammac</IntermediateOutputPath>
+    <DefineConstants>NET_1_1;NET_2_0;NET_2_1;NET_3_5;NET_4_0;NET_4_5;MONO;MOBILE;MOBILE_DYNAMIC;XAMMAC;FEATURE_INTERCEPTABLE_THREADPOOL_CALLBACK;XAMARIN_MODERN;MONO_FEATURE_THREAD_ABORT;MONO_FEATURE_PROCESS_START</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Platform)' == 'xammac_net_4_5' ">
     <OutputPath>./../../class/lib/xammac_net_4_5</OutputPath>
     <IntermediateOutputPath>./../../class/obj/$(AssemblyName)-xammac_net_4_5</IntermediateOutputPath>
@@ -122,6 +127,9 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(Platform)' == 'testing_aot_full' ">
     <Compile Include="testing_aot_full-parser.cs" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(Platform)' == 'xammac' ">
+    <Compile Include="xammac-parser.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(Platform)' == 'xammac_net_4_5' ">
     <Compile Include="xammac_net_4_5-parser.cs" />


### PR DESCRIPTION
Commit list for mono/corert:

* mono/corert@1b7d4a1e4 [Number] make double 0.0 cmp more portable (#30)
* mono/corert@c4ae51646 Update ISOWeek.cs
* mono/corert@7e8bf2382 fix ISOWeek for mcs
* mono/corert@0e5f123f6 [corlib] Import System.IO.Stream/BufferedStream from CoreFX (#26)

Diff: https://github.com/mono/corert/compare/b6a822b7424dab39eee81f0c08160f996c9e9e27...1b7d4a1e4bd79305905338827cc41eb8303364f0

