### PR TITLE
[2018-08] Bump corert

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -49,6 +49,7 @@
 [submodule "external/corert"]
 	path = external/corert
 	url = git://github.com/mono/corert.git
+	branch = mono-2018-08
 [submodule "external/xunit-binaries"]
 	path = external/xunit-binaries
 	url = git://github.com/mono/xunit-binaries.git


### PR DESCRIPTION
Commit list for mono/corert:

* mono/corert@e229c9448 [Number] make double 0.0 cmp more portable (#30)

Diff: https://github.com/mono/corert/compare/6c9c4d9cffe2031acb788718646fbc013632c9ea...e229c9448cb262ceb230dfab64a8237140c1dc2d