### PR TITLE
[2018-08] [bcl] Fix possible deadlock race in CSharpCodeGenerator

### DIFF
--- a/mcs/class/System/Microsoft.CSharp/CSharpCodeGenerator.cs
+++ b/mcs/class/System/Microsoft.CSharp/CSharpCodeGenerator.cs
@@ -67,7 +67,8 @@ namespace Microsoft.CSharp
 
 			mcs.StartInfo.Arguments += BuildArgs (options, fileNames, _provOptions);
 
-			var mcsOutMutex = new Mutex ();
+			var stderr_completed = new ManualResetEvent (false);
+			var stdout_completed = new ManualResetEvent (false);
 /*		       
 			string monoPath = Environment.GetEnvironmentVariable ("MONO_PATH");
 			if (monoPath != null)
@@ -93,15 +94,19 @@ namespace Microsoft.CSharp
 
 			mcs.StartInfo.CreateNoWindow=true;
 			mcs.StartInfo.UseShellExecute=false;
+			mcs.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
 			mcs.StartInfo.RedirectStandardOutput=true;
 			mcs.StartInfo.RedirectStandardError=true;
 			mcs.ErrorDataReceived += new DataReceivedEventHandler ((sender, args) => {
-				if (args.Data != null) {
-					mcsOutMutex.WaitOne ();
+				if (args.Data != null)
 					results.Output.Add (args.Data);
-					mcsOutMutex.ReleaseMutex ();
-				}
+				else
+					stderr_completed.Set ();
 			});
+			mcs.OutputDataReceived += new DataReceivedEventHandler ((sender, args) => {
+					if (args.Data == null)
+						stdout_completed.Set ();
+				});
 
 			// Use same text decoder as mcs and not user set values in Console
 			mcs.StartInfo.StandardOutputEncoding =
@@ -125,8 +130,8 @@ namespace Microsoft.CSharp
 				
 				results.NativeCompilerReturnValue = mcs.ExitCode;
 			} finally {
-				mcs.CancelErrorRead ();
-				mcs.CancelOutputRead ();
+				stderr_completed.WaitOne (TimeSpan.FromSeconds (30));
+				stdout_completed.WaitOne (TimeSpan.FromSeconds (30));
 				mcs.Close();
 			}
 


### PR DESCRIPTION
`CSharpCodeGenerator` runs a compiler while redirecting its standard error and
standard output streams for further reporting. However, in doing that it fails
to read the standard output data completely and also fails to properly wait for
the standard error output to complete. Depending on environment it may lead to
the process using `CSharpCodeGenerator` hanging while the process has already
exited but there still is data to be read from standard output and standard
error.

This commit changes the code to an implementation of reading standard error and output
that makes sure all the data is read before the process is closed.

The hope is that it may fix some of the timeouts/hangs we see on the
Xamarin.Android build bots as a portion of them hangs in test that use the
code generator.


Backport of #12685.

/cc @akoeplinger @grendello