### PR TITLE
[corlib] Avoid recursive extracting redundant frames from captured traces in StackTrace.GetFrames

### DIFF
--- a/mcs/class/corlib/System.Diagnostics/StackTrace.cs
+++ b/mcs/class/corlib/System.Diagnostics/StackTrace.cs
@@ -188,8 +188,10 @@ namespace System.Diagnostics {
 				return frames;
 
 			var accum = new List<StackFrame> ();
-			foreach (var t in captured_traces)
-				accum.AddRange(t.GetFrames ());
+			foreach (var t in captured_traces) {
+				for (int i = 0; i < t.FrameCount; i++)
+					accum.Add (t.GetFrame (i));
+			}
 
 			accum.AddRange (frames);
 			return accum.ToArray ();

--- a/mcs/class/corlib/Test/System.Diagnostics/StackFrameTest.cs
+++ b/mcs/class/corlib/Test/System.Diagnostics/StackFrameTest.cs
@@ -12,6 +12,7 @@ using System.Diagnostics;
 using System.Reflection;
 using NUnit.Framework;
 using System.Runtime.ExceptionServices;
+using System.Threading.Tasks;
 
 namespace MonoTests.System.Diagnostics
 {
@@ -183,7 +184,7 @@ namespace MonoTests.System.Diagnostics
 							 frame1.GetFileLineNumber (),
 							 "Line number (1)");
 
-			Assert.AreEqual (137,
+			Assert.AreEqual (138,
 							 frame2.GetFileLineNumber (),
 							 "Line number (2)");
 
@@ -325,7 +326,7 @@ namespace MonoTests.System.Diagnostics
 							 frame1.GetFileLineNumber (),
 							 "Line number (1)");
 
-			Assert.AreEqual (275,
+			Assert.AreEqual (276,
 							 frame2.GetFileLineNumber (),
 							 "Line number (2)");
 		}
@@ -380,6 +381,47 @@ namespace MonoTests.System.Diagnostics
 					Assert.AreEqual ("GetFramesAndNestedExc", frames [2].GetMethod ().Name);
 				}
 			}
+		}
+
+		[Test]
+		// https://github.com/mono/mono/issues/12688
+		public void GetFrames_AsynsCalls ()
+		{
+			StartAsyncCalls ().Wait ();
+		}
+
+		private async Task StartAsyncCalls ()
+		{
+			try
+			{
+				await AsyncMethod1 ();
+			}
+			catch (Exception exception)
+			{
+				var stackTrace = new StackTrace (exception, true);
+				Assert.AreEqual (25, stackTrace.GetFrames ().Length);
+			}
+		}
+
+		private async Task<int> AsyncMethod1 ()
+		{
+			return await AsyncMethod2 ();
+		}
+
+		private async Task<int> AsyncMethod2 ()
+		{
+			return await AsyncMethod3 ();
+		}
+
+		private async Task<int> AsyncMethod3 ()
+		{
+			return await AsyncMethod4 ();
+		}
+
+		private async Task<int> AsyncMethod4 ()
+		{
+			await Task.Delay (10);
+			throw new Exception ("Test exception thrown!");
 		}
 
 		/// <summary>


### PR DESCRIPTION
StackTrace.GetFrames can return additional frames recursively extracting them from captured traces.
It results in too many redundant frames for async methods. 
To limit a number of the additional frames I removed recursive calls and used frames from the first level of captured traces only.
For the sample from https://github.com/mono/mono/issues/12688 it becomes `25` instead of 56.
It kind of correlates with NetFX/NetCore number (`17`): in this case Mono gives two more frames for `Throw ` and `ValidateEnd` methods.

![image](https://user-images.githubusercontent.com/3258267/52134991-e0606480-2655-11e9-8e43-306cd193f1f1.png)

`Stack.FrameCount()` and `Stack.GetFrames().Length` still show different numbers.