### PR TITLE
[wasm][debugger] Add array inspection to the debugger.

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -1910,7 +1910,7 @@ static MonoGHashTable *suspended_objs;
 static void
 objrefs_init (void)
 {
-	objrefs = g_hash_table_new_full (NULL, NULL, NULL, free_objref);
+	objrefs = g_hash_table_new_full (NULL, NULL, NULL, mono_debugger_free_objref);
 	obj_to_objref = g_hash_table_new (NULL, NULL);
 	suspended_objs = mono_g_hash_table_new_type ((GHashFunc)mono_object_hash_internal, NULL, MONO_HASH_KEY_GC, MONO_ROOT_SOURCE_DEBUGGER, NULL, "Debugger Suspended Object Table");
 }

--- a/mono/mini/debugger-engine.c
+++ b/mono/mini/debugger-engine.c
@@ -1555,7 +1555,7 @@ mono_de_cleanup (void)
 }
 
 void
-free_objref (gpointer value)
+mono_debugger_free_objref (gpointer value)
 {
 	ObjRef *o = (ObjRef *)value;
 

--- a/mono/mini/debugger-engine.c
+++ b/mono/mini/debugger-engine.c
@@ -1554,4 +1554,13 @@ mono_de_cleanup (void)
 	domains_cleanup ();
 }
 
+void
+free_objref (gpointer value)
+{
+	ObjRef *o = (ObjRef *)value;
+
+	mono_gchandle_free_internal (o->handle);
+
+	g_free (o);
+}
 #endif

--- a/mono/mini/debugger-engine.h
+++ b/mono/mini/debugger-engine.h
@@ -207,7 +207,7 @@ typedef struct {
 } ObjRef;
 
 
-void free_objref (gpointer value);
+void mono_debugger_free_objref (gpointer value);
 
 typedef int DbgEngineErrorCode;
 #define DE_ERR_NONE 0

--- a/mono/mini/debugger-engine.h
+++ b/mono/mini/debugger-engine.h
@@ -207,15 +207,7 @@ typedef struct {
 } ObjRef;
 
 
-static void
-free_objref (gpointer value)
-{
-	ObjRef *o = (ObjRef *)value;
-
-	mono_gchandle_free_internal (o->handle);
-
-	g_free (o);
-}
+void free_objref (gpointer value);
 
 typedef int DbgEngineErrorCode;
 #define DE_ERR_NONE 0

--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -31,6 +31,7 @@ EMSCRIPTEN_KEEPALIVE void mono_wasm_get_var_info (int scope, int pos);
 EMSCRIPTEN_KEEPALIVE void mono_wasm_clear_all_breakpoints (void);
 EMSCRIPTEN_KEEPALIVE void mono_wasm_setup_single_step (int kind);
 EMSCRIPTEN_KEEPALIVE void mono_wasm_get_object_properties (int object_id);
+EMSCRIPTEN_KEEPALIVE void mono_wasm_get_array_values (int object_id);
 
 //JS functions imported that we use
 extern void mono_wasm_add_frame (int il_offset, int method_token, const char *assembly_name);
@@ -42,7 +43,9 @@ extern void mono_wasm_add_float_var (float);
 extern void mono_wasm_add_double_var (double);
 extern void mono_wasm_add_string_var (const char*);
 extern void mono_wasm_add_obj_var (const char*, guint64);
+extern void mono_wasm_add_array_var (const char*, guint64);
 extern void mono_wasm_add_properties_var (const char*);
+extern void mono_wasm_add_array_item (int);
 
 G_END_DECLS
 
@@ -516,6 +519,19 @@ mono_wasm_current_bp_id (void)
 	return evt->id;
 }
 
+static int get_object_id(MonoObject *obj) 
+{
+	ObjRef *ref = (ObjRef *)g_hash_table_lookup (obj_to_objref, GINT_TO_POINTER (~((gsize)obj)));
+	if (ref)
+		return ref->id;
+	ref = g_new0 (ObjRef, 1);
+	ref->id = mono_atomic_inc_i32 (&objref_id);
+	ref->handle = mono_gchandle_new_weakref_internal (obj, FALSE);
+	g_hash_table_insert (objrefs, GINT_TO_POINTER (ref->id), ref);
+	g_hash_table_insert (obj_to_objref, GINT_TO_POINTER (~((gsize)obj)), ref);
+	return ref->id;
+}
+
 static gboolean
 list_frames (MonoStackFrameInfo *info, MonoContext *ctx, gpointer data)
 {
@@ -611,6 +627,8 @@ static gboolean decode_value(MonoType * type, gpointer addr)
 			g_free (str);
 			break;
 		}
+		case MONO_TYPE_SZARRAY:
+		case MONO_TYPE_ARRAY:
 		case MONO_TYPE_OBJECT:
 		case MONO_TYPE_CLASS: {
 			MonoObject *obj = *(MonoObject**)addr;
@@ -624,12 +642,10 @@ static gboolean decode_value(MonoType * type, gpointer addr)
 					g_string_append_c (class_name, '.');
 				}
 				g_string_append (class_name, obj->vtable->klass->name);
-				ObjRef *ref = g_new0 (ObjRef, 1); //ok
-				ref->id = mono_atomic_inc_i32 (&objref_id); //ok
-				ref->handle = mono_gchandle_new_weakref_internal (obj, FALSE); //ok
-				g_hash_table_insert (objrefs, GINT_TO_POINTER (ref->id), ref);
-				mono_wasm_add_obj_var (class_name->str, ref->id);
-				g_hash_table_insert (obj_to_objref, GINT_TO_POINTER (~((gsize)obj)), ref);
+				if (m_class_get_byval_arg (obj->vtable->klass)->type == MONO_TYPE_SZARRAY || m_class_get_byval_arg (obj->vtable->klass)->type == MONO_TYPE_ARRAY)
+					mono_wasm_add_array_var (class_name->str, get_object_id(obj));
+				else
+					mono_wasm_add_obj_var (class_name->str, get_object_id(obj));
 				g_string_free(class_name, FALSE);
 				break;
 			}
@@ -679,6 +695,30 @@ describe_object_properties (guint64 objectId)
 	while ((p = mono_class_get_properties (obj->vtable->klass, &iter))) {
 		mono_wasm_add_properties_var(p->name);
 	}*/
+	return TRUE;
+}
+
+
+static gboolean 
+describe_array_values (guint64 objectId)
+{
+	int esize;
+	gpointer elem;
+	ObjRef *ref = (ObjRef *)g_hash_table_lookup (objrefs, GINT_TO_POINTER (objectId));
+	if (!ref) {
+		return FALSE;
+	}
+	MonoArray *arr = (MonoArray *)mono_gchandle_get_target_internal (ref->handle);
+	MonoObject *obj = &arr->obj;
+	if (!obj) {
+		return FALSE;
+	}
+	esize = mono_array_element_size (obj->vtable->klass);
+	for (int i = 0; i < arr->max_length; i++) {
+		mono_wasm_add_array_item(i);
+		elem = (gpointer*)((char*)arr->vector + (i * esize));
+		decode_value(m_class_get_byval_arg (m_class_get_element_class (arr->obj.vtable->klass)), elem);
+	}
 	return TRUE;
 }
 
@@ -749,6 +789,14 @@ mono_wasm_get_object_properties (int object_id)
 	DEBUG_PRINTF (2, "getting properties of object %d\n", object_id);
 
 	describe_object_properties(object_id);
+}
+
+EMSCRIPTEN_KEEPALIVE void
+mono_wasm_get_array_values (int object_id)
+{
+	DEBUG_PRINTF (2, "getting array values %d\n", object_id);
+
+	describe_array_values(object_id);
 }
 
 // Functions required by debugger-state-machine.

--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -331,7 +331,7 @@ mono_wasm_debugger_init (void)
 	mono_profiler_set_domain_loaded_callback (prof, appdomain_load);
 
 	obj_to_objref = g_hash_table_new (NULL, NULL);
-	objrefs = g_hash_table_new_full (NULL, NULL, NULL, free_objref);
+	objrefs = g_hash_table_new_full (NULL, NULL, NULL, mono_debugger_free_objref);
 }
 
 MONO_API void

--- a/sdks/wasm/library_mono.js
+++ b/sdks/wasm/library_mono.js
@@ -51,13 +51,27 @@ var MonoSupportLib = {
 			return res;
 		},
 
-		mono_wasm_get_object_properties: function(scope) {
+		mono_wasm_get_object_properties: function(objId) {
 			if (!this.mono_wasm_get_object_properties_info)
 				this.mono_wasm_get_object_properties_info = Module.cwrap ("mono_wasm_get_object_properties", 'void', [ 'number' ]);
 
 			this.var_info = [];
-			console.log (">> mono_wasm_get_object_properties " + scope);
-			this.mono_wasm_get_object_properties_info (scope);
+			console.log (">> mono_wasm_get_object_properties " + objId);
+			this.mono_wasm_get_object_properties_info (objId);
+
+			var res = this.var_info;
+			this.var_info = []
+
+			return res;
+		},
+
+		mono_wasm_get_array_values: function(objId) {
+			if (!this.mono_wasm_get_array_values_info)
+				this.mono_wasm_get_array_values_info = Module.cwrap ("mono_wasm_get_array_values", 'void', [ 'number' ]);
+
+			this.var_info = [];
+			console.log (">> mono_wasm_get_array_values " + objId);
+			this.mono_wasm_get_array_values_info (objId);
 
 			var res = this.var_info;
 			this.var_info = []
@@ -244,7 +258,12 @@ var MonoSupportLib = {
 			name: Module.UTF8ToString (name),
 		});
 	},
-
+	mono_wasm_add_array_item: function(position) {
+		MONO.var_info.push({
+			name: "[" + position + "]",
+		});
+	},
+	
 	mono_wasm_add_string_var: function(var_value) {
 		if (var_value == 0) {
 			MONO.var_info.push({
@@ -279,6 +298,27 @@ var MonoSupportLib = {
 					className: Module.UTF8ToString (className),
 					description: Module.UTF8ToString (className),
 					objectId: "dotnet:object:"+ objectId,
+				}
+			});
+		}
+	},
+	mono_wasm_add_array_var: function(className, objectId) {
+		if (objectId == 0) {
+			MONO.var_info.push({
+				value: {
+					type: "array",
+					className: Module.UTF8ToString (className),
+					description: Module.UTF8ToString (className),
+					subtype: "null"
+				}
+			});
+		} else {
+			MONO.var_info.push({
+				value: {
+					type: "array",
+					className: Module.UTF8ToString (className),
+					description: Module.UTF8ToString (className),
+					objectId: "dotnet:array:"+ objectId,
 				}
 			});
 		}


### PR DESCRIPTION
Add array inspection to the debugger for sized and unsized array, the example is below:
![image](https://user-images.githubusercontent.com/4503299/52145736-03d0e280-2649-11e9-8277-50f0b78c345a.png)
