### PR TITLE
[2018-10][runtime] Switch to GC Unsafe in a few more external API functions

### DIFF
--- a/mono/metadata/coree.c
+++ b/mono/metadata/coree.c
@@ -20,6 +20,7 @@
 #include "cil-coff.h"
 #include "metadata-internals.h"
 #include "image.h"
+#include "image-internals.h"
 #include "assembly-internals.h"
 #include "domain-internals.h"
 #include "appdomain.h"
@@ -129,7 +130,7 @@ BOOL STDMETHODCALLTYPE _CorDllMain(HINSTANCE hInst, DWORD dwReason, LPVOID lpRes
 			/* The process is terminating. */
 			return TRUE;
 		file_name = mono_get_module_file_name (hInst);
-		image = mono_image_loaded (file_name);
+		image = mono_image_loaded_internal (file_name, FALSE);
 		if (image)
 			mono_image_close (image);
 

--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -660,7 +660,11 @@ mono_get_exception_argument_internal (const char *type, const char *arg, const c
 MonoException*
 mono_get_exception_argument_null (const char *arg)
 {
-	return mono_get_exception_argument_internal ("ArgumentNullException", arg, NULL);
+	MonoException *ex;
+	MONO_ENTER_GC_UNSAFE;
+	ex = mono_get_exception_argument_internal ("ArgumentNullException", arg, NULL);
+	MONO_EXIT_GC_UNSAFE;
+	return ex;
 }
 
 /**

--- a/mono/metadata/exception.h
+++ b/mono/metadata/exception.h
@@ -100,7 +100,7 @@ mono_get_exception_not_implemented     (const char *msg);
 MONO_API MonoException *
 mono_get_exception_not_supported       (const char *msg);
 
-MONO_API MonoException*
+MONO_API MONO_RT_EXTERNAL_ONLY MonoException*
 mono_get_exception_argument_null       (const char *arg);
 
 MONO_API MonoException *

--- a/mono/metadata/image-internals.h
+++ b/mono/metadata/image-internals.h
@@ -8,6 +8,9 @@
 
 #include <mono/metadata/image.h>
 
+MonoImage*
+mono_image_loaded_internal (const char *name, mono_bool refonly);
+
 MonoImage *
 mono_find_image_owner (void *ptr);
 

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1480,6 +1480,26 @@ do_mono_image_open (const char *fname, MonoImageOpenStatus *status,
 MonoImage *
 mono_image_loaded_full (const char *name, gboolean refonly)
 {
+	MonoImage *result;
+	MONO_ENTER_GC_UNSAFE;
+	result = mono_image_loaded_internal (name, refonly);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
+}
+
+/**
+ * mono_image_loaded_internal:
+ * \param name path or assembly name of the image to load
+ * \param refonly Check with respect to reflection-only loads?
+ *
+ * This routine verifies that the given image is loaded.
+ * It checks either reflection-only loads only, or normal loads only, as specified by parameter.
+ *
+ * \returns the loaded \c MonoImage, or NULL on failure.
+ */
+MonoImage *
+mono_image_loaded_internal (const char *name, gboolean refonly)
+{
 	MonoImage *res;
 
 	mono_images_lock ();
@@ -1500,7 +1520,11 @@ mono_image_loaded_full (const char *name, gboolean refonly)
 MonoImage *
 mono_image_loaded (const char *name)
 {
-	return mono_image_loaded_full (name, FALSE);
+	MonoImage *result;
+	MONO_ENTER_GC_UNSAFE;
+	result = mono_image_loaded_internal (name, FALSE);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
 }
 
 typedef struct {

--- a/mono/metadata/image.h
+++ b/mono/metadata/image.h
@@ -42,8 +42,10 @@ MONO_API MONO_RT_EXTERNAL_ONLY
 MonoImage    *mono_image_open_from_data_with_name (char *data, uint32_t data_len, mono_bool need_copy,
                                                    MonoImageOpenStatus *status, mono_bool refonly, const char *name);
 MONO_API void          mono_image_fixup_vtable (MonoImage *image);
-MONO_API MonoImage    *mono_image_loaded   (const char *name);
-MONO_API MonoImage    *mono_image_loaded_full   (const char *name, mono_bool refonly);
+MONO_API MONO_RT_EXTERNAL_ONLY
+MonoImage             *mono_image_loaded   (const char *name);
+MONO_API MONO_RT_EXTERNAL_ONLY
+MonoImage             *mono_image_loaded_full   (const char *name, mono_bool refonly);
 MONO_API MonoImage    *mono_image_loaded_by_guid (const char *guid);
 MONO_API MonoImage    *mono_image_loaded_by_guid_full (const char *guid, mono_bool refonly);
 MONO_API void          mono_image_init     (MonoImage *image);

--- a/mono/metadata/mono-security.c
+++ b/mono/metadata/mono-security.c
@@ -15,6 +15,7 @@
 #include <mono/metadata/appdomain.h>
 #include <mono/metadata/image.h>
 #include <mono/metadata/exception.h>
+#include <mono/metadata/image-internals.h>
 #include <mono/metadata/object-internals.h>
 #include <mono/metadata/metadata-internals.h>
 #include <mono/metadata/security.h>
@@ -620,7 +621,7 @@ void mono_invoke_protected_memory_method (MonoArray *data, MonoObject *scope, gb
 	error_init (error);
 	
 	if (system_security_assembly == NULL) {
-		system_security_assembly = mono_image_loaded ("System.Security");
+		system_security_assembly = mono_image_loaded_internal ("System.Security", FALSE);
 		if (!system_security_assembly) {
 			MonoAssembly *sa = mono_assembly_open_predicate ("System.Security.dll", MONO_ASMCTX_DEFAULT, NULL, NULL, NULL, NULL);
 			if (!sa)

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -3871,16 +3871,17 @@ mono_property_set_value_handle (MonoProperty *prop, MonoObjectHandle obj, void *
 MonoObject*
 mono_property_get_value (MonoProperty *prop, void *obj, void **params, MonoObject **exc)
 {
-	MONO_REQ_GC_UNSAFE_MODE;
+	MonoObject *val;
+	MONO_ENTER_GC_UNSAFE;
 
 	ERROR_DECL (error);
-	MonoObject *val = do_runtime_invoke (prop->get, obj, params, exc, error);
+	val = do_runtime_invoke (prop->get, obj, params, exc, error);
 	if (exc && *exc == NULL && !mono_error_ok (error)) {
 		*exc = (MonoObject*) mono_error_convert_to_exception (error);
 	} else {
 		mono_error_cleanup (error); /* FIXME don't raise here */
 	}
-
+	MONO_EXIT_GC_UNSAFE;
 	return val;
 }
 

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -58,6 +58,7 @@
 /* FIXME change this code to not mess so much with the internals */
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/domain-internals.h>
+#include <mono/metadata/image-internals.h>
 #include <mono/utils/mono-threads.h>
 #include <mono/utils/mono-memory-model.h>
 #include <mono/utils/networking.h>
@@ -709,7 +710,7 @@ get_socket_assembly (void)
 	if (domain->socket_assembly == NULL) {
 		MonoImage *socket_assembly;
 
-		socket_assembly = mono_image_loaded ("System");
+		socket_assembly = mono_image_loaded_internal ("System", FALSE);
 		if (!socket_assembly) {
 			MonoAssembly *sa = mono_assembly_open_predicate ("System.dll", MONO_ASMCTX_DEFAULT, NULL, NULL, NULL, NULL);
 		
@@ -1834,7 +1835,7 @@ ves_icall_System_Net_Sockets_Socket_GetSocketOption_obj_internal (gsize sock, gi
 		static MonoImage *mono_posix_image = NULL;
 		
 		if (mono_posix_image == NULL) {
-			mono_posix_image = mono_image_loaded ("Mono.Posix");
+			mono_posix_image = mono_image_loaded_internal ("Mono.Posix", FALSE);
 			if (!mono_posix_image) {
 				MonoAssembly *sa = mono_assembly_open_predicate ("Mono.Posix.dll", MONO_ASMCTX_DEFAULT, NULL, NULL, NULL, NULL);
 				if (!sa) {


### PR DESCRIPTION
Addresses #12724 

Note this is against 2018-10.  Forward ports to 2018-12 and master after this one.
