### PR TITLE
[2018-12] Add back missing stack frames to mono MERP reports

### DIFF
--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -549,10 +549,10 @@ mono_native_state_add_frames (MonoStateWriter *writer, int num_frames, MonoFrame
 	// the add_frame method
 
 	mono_native_state_add_frame (writer, &frames [0]);
-	//  for (int i = 1; i < num_frames; ++i) {
-	//  	mono_state_writer_printf(writer, ",\n");
-	//  	mono_native_state_add_frame (writer, &frames [i]);
-	//  }
+	  for (int i = 1; i < num_frames; ++i) {
+	  	mono_state_writer_printf(writer, ",\n");
+	  	mono_native_state_add_frame (writer, &frames [i]);
+	  }
 	mono_state_writer_printf(writer, "\n");
 
 	mono_state_writer_indent (writer);


### PR DESCRIPTION
Changeset https://github.com/mono/mono/commit/e1461ebc855977667f71d1804fd96eed2a155aff
introduced a regression where only the topmost frame of managed crashes are reported.

This change adds back the missing stack frames.

Please note this directly impacts Visual Studio for Mac crash reporting.

Backport of #12737.

/cc @luhenry @leculver