### PR TITLE
[2018-12] [corlib] Avoid recursive extracting redundant frames from captured traces in StackTrace.GetFrames

### DIFF
--- a/mcs/class/corlib/System.Diagnostics/StackTrace.cs
+++ b/mcs/class/corlib/System.Diagnostics/StackTrace.cs
@@ -185,8 +185,10 @@ namespace System.Diagnostics {
 				return frames;
 
 			var accum = new List<StackFrame> ();
-			foreach (var t in captured_traces)
-				accum.AddRange(t.GetFrames ());
+			foreach (var t in captured_traces) {
+				for (int i = 0; i < t.FrameCount; i++)
+					accum.Add (t.GetFrame (i));
+			}
 
 			accum.AddRange (frames);
 			return accum.ToArray ();

--- a/mcs/class/corlib/Test/System.Diagnostics/StackFrameTest.cs
+++ b/mcs/class/corlib/Test/System.Diagnostics/StackFrameTest.cs
@@ -12,6 +12,7 @@ using System.Diagnostics;
 using System.Reflection;
 using NUnit.Framework;
 using System.Runtime.ExceptionServices;
+using System.Threading.Tasks;
 
 namespace MonoTests.System.Diagnostics
 {
@@ -181,7 +182,7 @@ namespace MonoTests.System.Diagnostics
 							 frame1.GetFileLineNumber (),
 							 "Line number (1)");
 
-			Assert.AreEqual (135,
+			Assert.AreEqual (136,
 							 frame2.GetFileLineNumber (),
 							 "Line number (2)");
 
@@ -321,7 +322,7 @@ namespace MonoTests.System.Diagnostics
 							 frame1.GetFileLineNumber (),
 							 "Line number (1)");
 
-			Assert.AreEqual (271,
+			Assert.AreEqual (272,
 							 frame2.GetFileLineNumber (),
 							 "Line number (2)");
 		}
@@ -375,6 +376,47 @@ namespace MonoTests.System.Diagnostics
 					Assert.AreEqual ("GetFramesAndNestedExc", frames [2].GetMethod ().Name);
 				}
 			}
+		}
+
+		[Test]
+		// https://github.com/mono/mono/issues/12688
+		public void GetFrames_AsynsCalls ()
+		{
+			StartAsyncCalls ().Wait ();
+		}
+
+		private async Task StartAsyncCalls ()
+		{
+			try
+			{
+				await AsyncMethod1 ();
+			}
+			catch (Exception exception)
+			{
+				var stackTrace = new StackTrace (exception, true);
+				Assert.AreEqual (25, stackTrace.GetFrames ().Length);
+			}
+		}
+
+		private async Task<int> AsyncMethod1 ()
+		{
+			return await AsyncMethod2 ();
+		}
+
+		private async Task<int> AsyncMethod2 ()
+		{
+			return await AsyncMethod3 ();
+		}
+
+		private async Task<int> AsyncMethod3 ()
+		{
+			return await AsyncMethod4 ();
+		}
+
+		private async Task<int> AsyncMethod4 ()
+		{
+			await Task.Delay (10);
+			throw new Exception ("Test exception thrown!");
 		}
 
 		/// <summary>


### PR DESCRIPTION
Backport of https://github.com/mono/mono/pull/12729 to 2018-12 branch.

Related issue: https://github.com/mono/mono/issues/12688