### PR TITLE
[WIP] Change config paths to ~/.config/mono

### DIFF
--- a/man/certmgr.1
+++ b/man/certmgr.1
@@ -106,10 +106,10 @@ Display help about this tool.
 The only safe way to interact with certificate stores is to use the certmgr
 tool. The current releases of Mono keeps all the user certificate stores in 
 separates directories under
-.I ~/.config/.mono/certs/
+.I ~/.config/mono/certs/
 .TP
 For example the trusted root certificates for a user would be kept under
-.I ~/.config/.mono/certs/Trust/
+.I ~/.config/mono/certs/Trust/
 .TP
 Certificates files are kept in DER (binary) format (extension .cer).
 .TP
@@ -122,7 +122,7 @@ The filenames either start with
 The rest of the filename is the base64-encoded value (tbp or ski).
 .TP
 Private key data is stored under
-.I ~/.config/.mono/keypairs/
+.I ~/.config/mono/keypairs/
 
 .SH EXAMPLES
 .TP

--- a/man/gacutil.1
+++ b/man/gacutil.1
@@ -109,7 +109,7 @@ On Unix assemblies are loaded from the installation lib directory.  If you set
 Windows, the assemblies are loaded from the directory where mono and
 mint live.
 .PP
-/etc/mono/config, ~/.mono/config
+/etc/mono/config, ~/.config/mono/config
 .PP
 Mono runtime configuration file.  See the mono-config(5) manual page
 for more information.

--- a/man/httpcfg.1
+++ b/man/httpcfg.1
@@ -56,7 +56,7 @@ see the following web page:
 .PP
 http://www.mono-project.com/docs/web/using-clientcertificates-with-xsp/
 .SH FILES
-The certificates are stored in the ~/.mono/httplistener directory
+The certificates are stored in the ~/.config/mono/httplistener directory
 .SH AUTHOR
 .B httpcfg
 was written by Gonzalo Paniagua.

--- a/man/mkbundle.1
+++ b/man/mkbundle.1
@@ -53,7 +53,7 @@ flag.  For example, the following disables inlining, by passing the
 
 .PP
 The simple version allows for cross-compiling, this requires a Mono
-runtime to be installed in the ~/.mono/targets/TARGET/mono to be
+runtime to be installed in the ~/.config/mono/targets/TARGET/mono to be
 available.   You can use the "--local-targets" to list all available
 targets, and the "--cross" argument to specify the target, like this:
 .nf
@@ -106,7 +106,7 @@ MacOS:
 .fi
 .PP
 Downloaded targets are stored
-.B ~/.mono/targets
+.B ~/.config/mono/targets
 directory.
 .SH OPTIONS
 .TP 
@@ -123,7 +123,7 @@ When passed, DIR will be set for the MONO_CFG_DIR environment variable
 .I "--cross target"
 Use this to request mkbundle generate a cross-compiled binary.  It
 Creates a bundle for the specified target platform.  The target must
-be a directory in ~/.mono/targets/ that contains an SDK installation
+be a directory in ~/.config/mono/targets/ that contains an SDK installation
 as produced by the mono-package-runtime tool.  You can get a list of
 the precompiled versions of the runtime using --list-targets and you
 can fetch a specific target using the --fetch-target command line
@@ -461,7 +461,7 @@ set this variable to "console".
 This program will load referenced assemblies from the Mono assembly
 cache. 
 .PP
-Targets are loaded from ~/.mono/targets/TARGETNAME/mono
+Targets are loaded from ~/.config/mono/targets/TARGETNAME/mono
 .SH BUGS
 .SH MAILING LISTS
 Visit http://lists.ximian.com/mailman/listinfo/mono-devel-list for details.

--- a/man/mono-config.5
+++ b/man/mono-config.5
@@ -10,12 +10,12 @@
 mono-config \- Mono runtime file format configuration
 .SH DESCRIPTION
 The Mono runtime will load configuration data from the
-installation prefix /etc/mono/config file, the ~/.mono/config or from
+installation prefix /etc/mono/config file, the ~/.config/mono/config or from
 the file pointed by the MONO_CONFIG environment variable.
 .PP
 For each assembly loaded a config file with the name:
 /path/to/the/assembly.exe.config is loaded as well as the
-~/.mono/assemblies/ASSEMBLY/ASSEMBLY.EXT.config file. 
+~/.config/mono/assemblies/ASSEMBLY/ASSEMBLY.EXT.config file. 
 .PP
 This file controls the behavior of the runtime.
 .PP

--- a/man/mono-configuration-crypto.1
+++ b/man/mono-configuration-crypto.1
@@ -18,11 +18,11 @@ Show verbose information (including exception stacktraces)
 .TP
 .B   -m, --machine, --global
 Use machine (global) store for all the key actions. Note that on Unix machines global store is located in
-\fI/usr/share/.mono\fR and modifying it requires root user permissions.
+\fI/usr/share/mono\fR and modifying it requires root user permissions.
 
 .TP
 .B   -u, --user, --local
-Use local (user) store for all the key actions. User key store is located in the \fI$HOME/.config/.mono\fR
+Use local (user) store for all the key actions. User key store is located in the \fI$HOME/.config/mono\fR
 directory. This is the default location used by mono-configuration-crypto.
 
 .TP

--- a/man/mono.1
+++ b/man/mono.1
@@ -414,7 +414,7 @@ Currently the only option supported by this command line argument is
 .TP
 \fB--config filename\fR
 Load the specified configuration file instead of the default one(s).
-The default files are /etc/mono/config and ~/.mono/config or the file
+The default files are /etc/mono/config and ~/.config/mono/config or the file
 specified in the MONO_CONFIG environment variable, if set.  See the
 mono-config(5) man page for details on the format of this file.
 .TP
@@ -1539,7 +1539,7 @@ Provides a prefix the runtime uses to look for Global Assembly Caches.
 Directories are separated by the platform path separator (colons on
 unix). MONO_GAC_PREFIX should point to the top directory of a prefixed
 install. Or to the directory provided in the gacutil /gacdir command. Example:
-.B /home/username/.mono:/usr/local/mono/
+.B /home/username/.config/mono:/usr/local/mono/
 .TP
 \fBMONO_IOMAP\fR
 Enables some filename rewriting support to assist badly-written
@@ -1998,30 +1998,30 @@ On Unix assemblies are loaded from the installation lib directory.  If you set
 Windows, the assemblies are loaded from the directory where mono and
 mint live.
 .TP
-.B ~/.mono/aot-cache
+.B ~/.config/mono/aot-cache
 .Sp
 The directory for the ahead-of-time compiler demand creation
 assemblies are located. 
 .TP
-.B /etc/mono/config, ~/.mono/config
+.B /etc/mono/config, ~/.config/mono/config
 .Sp
 Mono runtime configuration file.  See the mono-config(5) manual page
 for more information.
 .TP
-.B ~/.config/.mono/certs, /usr/share/.mono/certs
+.B ~/.config/mono/certs, /usr/share/mono/certs
 .Sp
 Contains Mono certificate stores for users / machine. See the certmgr(1) 
 manual page for more information on managing certificate stores and
 the mozroots(1) page for information on how to import the Mozilla root
 certificates into the Mono certificate store. 
 .TP
-.B ~/.mono/assemblies/ASSEMBLY/ASSEMBLY.config
+.B ~/.config/mono/assemblies/ASSEMBLY/ASSEMBLY.config
 .Sp
 Files in this directory allow a user to customize the configuration
 for a given system assembly, the format is the one described in the
 mono-config(5) page. 
 .TP
-.B ~/.config/.mono/keypairs, /usr/share/.mono/keypairs
+.B ~/.config/mono/keypairs, /usr/share/mono/keypairs
 .Sp
 Contains Mono cryptographic keypairs for users / machine. They can be 
 accessed by using a CspParameters object with DSACryptoServiceProvider

--- a/man/mozroots.1
+++ b/man/mozroots.1
@@ -162,7 +162,7 @@ required if no changes are made to your trust store.
 .fi
 .SH FILES
 .PP
-~/.config/.mono/certs, /usr/share/.mono/certs
+~/.config/mono/certs, /usr/share/mono/certs
 .PP
 Contains Mono certificate stores for users / machine. See the certmgr(1) 
 manual page for more information on managing certificate stores.

--- a/mcs/build/tests.make
+++ b/mcs/build/tests.make
@@ -162,7 +162,7 @@ endif
 
 ifdef ALWAYS_AOT_TESTS
 test-local-aot-compile: $(topdir)/build/deps/nunit-$(PROFILE).stamp $(test_assemblies)
-	PATH="$(TEST_RUNTIME_WRAPPERS_PATH):$(PATH)" MONO_REGISTRY_PATH="$(HOME)/.mono/registry" MONO_TESTS_IN_PROGRESS="yes" $(TEST_RUNTIME) $(TEST_RUNTIME_FLAGS) $(AOT_BUILD_FLAGS) $(test_assemblies)
+	PATH="$(TEST_RUNTIME_WRAPPERS_PATH):$(PATH)" MONO_REGISTRY_PATH="$(HOME)/.config/mono/registry" MONO_TESTS_IN_PROGRESS="yes" $(TEST_RUNTIME) $(TEST_RUNTIME_FLAGS) $(AOT_BUILD_FLAGS) $(test_assemblies)
 
 else
 test-local-aot-compile: $(topdir)/build/deps/nunit-$(PROFILE).stamp $(test_assemblies)
@@ -236,7 +236,7 @@ endif
 ## FIXME: i18n problem in the 'sed' command below
 run-test-lib: test-local test-local-aot-compile copy-nunitlite-appconfig
 	ok=:; \
-	PATH="$(TEST_RUNTIME_WRAPPERS_PATH):$(PATH)" MONO_REGISTRY_PATH="$(HOME)/.mono/registry" MONO_TESTS_IN_PROGRESS="yes" DBG_RUNTIME_ARGS="$(TEST_RUNTIME_FLAGS)" $(TEST_HARNESS_EXEC) $(test_assemblies) $(NOSHADOW_FLAG) $(TEST_HARNESS_FLAGS) $(LOCAL_TEST_HARNESS_FLAGS) $(TEST_HARNESS_EXCLUDES) $(LABELS_ARG) -format:nunit2 -result:TestResult-$(PROFILE).xml $(FIXTURE_ARG) $(TESTNAME_ARG)|| ok=false; \
+	PATH="$(TEST_RUNTIME_WRAPPERS_PATH):$(PATH)" MONO_REGISTRY_PATH="$(HOME)/.config/mono/registry" MONO_TESTS_IN_PROGRESS="yes" DBG_RUNTIME_ARGS="$(TEST_RUNTIME_FLAGS)" $(TEST_HARNESS_EXEC) $(test_assemblies) $(NOSHADOW_FLAG) $(TEST_HARNESS_FLAGS) $(LOCAL_TEST_HARNESS_FLAGS) $(TEST_HARNESS_EXCLUDES) $(LABELS_ARG) -format:nunit2 -result:TestResult-$(PROFILE).xml $(FIXTURE_ARG) $(TESTNAME_ARG)|| ok=false; \
 	if [ ! -f "TestResult-$(PROFILE).xml" ]; then echo "<?xml version='1.0' encoding='utf-8'?><test-results failures='1' total='1' not-run='0' name='bcl-tests' date='$$(date +%F)' time='$$(date +%T)'><test-suite name='$(strip $(test_assemblies))' success='False' time='0'><results><test-case name='$(notdir $(strip $(test_assemblies))).crash' executed='True' success='False' time='0'><failure><message>The test runner didn't produce a test result XML, probably due to a crash of the runtime. Check the log for more details.</message><stack-trace></stack-trace></failure></test-case></results></test-suite></test-results>" > TestResult-$(PROFILE).xml; fi; \
 	$$ok
 

--- a/mcs/class/System.Data.Linq/build/Makefile
+++ b/mcs/class/System.Data.Linq/build/Makefile
@@ -32,13 +32,13 @@ $(sqlite_tests): $(sqlite_tests_dep)
 test-sqlite: $(sqlite_tests)
 
 RUN_TEST_COMMAND = \
-	MONO_REGISTRY_PATH="$(HOME)/.mono/registry" $(TEST_RUNTIME) $(TEST_RUNTIME_FLAGS) $(TEST_HARNESS) $(1) $(TEST_HARNESS_FLAGS) $(LOCAL_TEST_HARNESS_FLAGS) $(TEST_HARNESS_EXCLUDES) $(TEST_HARNESS_OUTPUT) -labels -format:nunit2 -result=TestResult-$(1:.dll=)-$(PROFILE).xml $(FIXTURE_ARG) $(TESTNAME_ARG) ;
+	MONO_REGISTRY_PATH="$(HOME)/.config/mono/registry" $(TEST_RUNTIME) $(TEST_RUNTIME_FLAGS) $(TEST_HARNESS) $(1) $(TEST_HARNESS_FLAGS) $(LOCAL_TEST_HARNESS_FLAGS) $(TEST_HARNESS_EXCLUDES) $(TEST_HARNESS_OUTPUT) -labels -format:nunit2 -result=TestResult-$(1:.dll=)-$(PROFILE).xml $(FIXTURE_ARG) $(TESTNAME_ARG) ;
 
 run-test-sqlite:
 	$(call RUN_TEST_COMMAND,$(sqlite_tests))
 
 foo:
-	MONO_REGISTRY_PATH="$(HOME)/.mono/registry" $(TEST_RUNTIME) $(TEST_RUNTIME_FLAGS) $(TEST_HARNESS) $(sqlite_tests) -noshadow $(TEST_HARNESS_FLAGS) $(LOCAL_TEST_HARNESS_FLAGS) $(TEST_HARNESS_EXCLUDES) $(TEST_HARNESS_OUTPUT) -xml=TestResult-$(PROFILE).xml $(FIXTURE_ARG) $(TESTNAME_ARG)|| ok=false; \
+	MONO_REGISTRY_PATH="$(HOME)/.config/mono/registry" $(TEST_RUNTIME) $(TEST_RUNTIME_FLAGS) $(TEST_HARNESS) $(sqlite_tests) -noshadow $(TEST_HARNESS_FLAGS) $(LOCAL_TEST_HARNESS_FLAGS) $(TEST_HARNESS_EXCLUDES) $(TEST_HARNESS_OUTPUT) -xml=TestResult-$(PROFILE).xml $(FIXTURE_ARG) $(TESTNAME_ARG)|| ok=false; \
 	$(TEST_HARNESS_POSTPROC) ; $$ok
 
 all-local: $(sqlite_tests)

--- a/mcs/class/corlib/Microsoft.Win32/UnixRegistryApi.cs
+++ b/mcs/class/corlib/Microsoft.Win32/UnixRegistryApi.cs
@@ -805,8 +805,8 @@ namespace Microsoft.Win32 {
 		private static string UserStore {
 			get {
 				if (user_store == null)
-					user_store = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal),
-					".mono/registry");
+					user_store = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.ApplicationData),
+					"mono/registry");
 
 				return user_store;
 			}

--- a/mcs/tools/mkbundle/Makefile
+++ b/mcs/tools/mkbundle/Makefile
@@ -25,8 +25,8 @@ test-simple: simple.exe
 	mono --debug $(the_lib) --sdk `dirname \`which mono\``/.. simple.exe -o foo && ./foo
 	-rm DEMO.zip
 	$(topdir)/../scripts/mono-package-runtime `dirname \`which mono\``/.. DEMO
-	mkdir -p ~/.mono/targets/DEMO
-	unzip -d ~/.mono/targets/DEMO DEMO.zip
+	mkdir -p ~/.config/mono/targets/DEMO
+	unzip -d ~/.config/mono/targets/DEMO DEMO.zip
 	mono --debug $(the_lib) --cross DEMO simple.exe -o foo | grep "Assembly.*mscorlib.dll"
 	./foo
 

--- a/mcs/tools/mkbundle/mkbundle.cs
+++ b/mcs/tools/mkbundle/mkbundle.cs
@@ -573,7 +573,7 @@ class MakeBundle {
                 }
 	}
 
-	static string targets_dir = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.Personal), ".mono", "targets");
+	static string targets_dir = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.ApplicationData), "mono", "targets");
 	
 	static void CommandLocalTargets ()
 	{

--- a/mono/metadata/mono-config.c
+++ b/mono/metadata/mono-config.c
@@ -701,7 +701,7 @@ mono_config_parse (const char *filename) {
 
 #if !defined(TARGET_WIN32)
 	home = g_get_home_dir ();
-	user_cfg = g_strconcat (home, G_DIR_SEPARATOR_S, ".mono/config", NULL);
+	user_cfg = g_strconcat (home, G_DIR_SEPARATOR_S, ".config/mono/config", NULL);
 	mono_config_parse_file (user_cfg);
 	g_free (user_cfg);
 #endif

--- a/runtime/mono-test.sh
+++ b/runtime/mono-test.sh
@@ -24,8 +24,8 @@ echo "--------------------------------------------------------------------------
 
 case "$(uname)" in
     "Linux")
-        mkdir -p ~/.config/.mono/
-        wget -qO- https://download.mono-project.com/test/new-certs.tgz| tar zx -C ~/.config/.mono/
+        mkdir -p ~/.config/mono/
+        wget -qO- https://download.mono-project.com/test/new-certs.tgz| tar zx -C ~/.config/mono/
         ;;
 esac
 
@@ -85,7 +85,7 @@ if [ "$test_suite" = "--nunit" ]; then
             ;;
     esac
     cp -f "$r/$test_argument_1.nunitlite.config" "$r/net_4_x/nunit-lite-console.exe.config"
-    MONO_REGISTRY_PATH="$HOME/.mono/registry" MONO_TESTS_IN_PROGRESS="yes" $XVFBRUN "${MONO_EXECUTABLE}" --config "$r/_tmpinst/etc/mono/config" --debug "$r/net_4_x/nunit-lite-console.exe" "$r/$test_argument_1" -exclude=NotWorking,CAS,$ADDITIONAL_TEST_EXCLUDES -labels -format:xunit -result:"${xunit_results_path}"
+    MONO_REGISTRY_PATH="$HOME/.config/mono/registry" MONO_TESTS_IN_PROGRESS="yes" $XVFBRUN "${MONO_EXECUTABLE}" --config "$r/_tmpinst/etc/mono/config" --debug "$r/net_4_x/nunit-lite-console.exe" "$r/$test_argument_1" -exclude=NotWorking,CAS,$ADDITIONAL_TEST_EXCLUDES -labels -format:xunit -result:"${xunit_results_path}"
     exit $?
 fi
 

--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -91,8 +91,8 @@ if [ -x "/usr/bin/dpkg-architecture" ];
 	then
 	EXTRA_CONF_FLAGS="$EXTRA_CONF_FLAGS --host=`/usr/bin/dpkg-architecture -qDEB_HOST_GNU_TYPE`"
 	#force build arch = dpkg arch, sometimes misdetected
-	mkdir -p ~/.config/.mono/
-	wget -qO- https://download.mono-project.com/test/new-certs.tgz| tar zx -C ~/.config/.mono/
+	mkdir -p ~/.config/mono/
+	wget -qO- https://download.mono-project.com/test/new-certs.tgz| tar zx -C ~/.config/mono/
 fi
 
 if [[ ${CI_TAGS} == *'cxx'* ]]; then
@@ -106,8 +106,8 @@ fi
 
 if [[ ${CI_TAGS} == *'win-'* ]];
 then
-	mkdir -p ~/.config/.mono/
-	wget -qO- https://download.mono-project.com/test/new-certs.tgz| tar zx -C ~/.config/.mono/
+	mkdir -p ~/.config/mono/
+	wget -qO- https://download.mono-project.com/test/new-certs.tgz| tar zx -C ~/.config/mono/
 fi
 
 if [[ ${CI_TAGS} == *'ccache'* ]];

--- a/scripts/mod.in
+++ b/scripts/mod.in
@@ -14,7 +14,7 @@ MOD="@bindir@/@mono_interp@ $MONO_OPTIONS @mono_instdir@/@framework_version@/@ex
 if `which lynx >/dev/null 2>&1` > /dev/null; then
     $MOD "$1" | lynx -dump -stdin -force_html | ${PAGER:-more}
 else
-    tmp=$HOME/.monodoc-tmp-$$
+    tmp=$HOME/.cache/mono/monodoc-tmp-$$
     $MOD "$1" > $tmp
     links -dump -force-html $tmp | ${PAGER:-more}
     rm $tmp


### PR DESCRIPTION
Previously, a mixture of `~/.mono` and `~/.config/.mono` was used, which is confusing and does not follow the XDG directory standard. Configs should be folders in `~/.config` and not be hidden.

I'm far from a Mono expert. This probably breaks a lot of things as-is, so I've marked it as [WIP], but at least it compiles fine. I mostly did this with `grep` and find/replace. I figured I'd open a pull request rather than an issue, to make an attempt at solving this, but if something is broken here I have no idea how to fix it. Feel free to take these changes and commit them separately if you wish.

See also: [Directory specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html), https://github.com/mono/monodevelop/issues/7037, [this video](https://www.youtube.com/watch?v=AFtfpluqv14), [this article](https://0x46.net/thoughts/2019/02/01/dotfile-madness/).