### PR TITLE
[2018-12] [wasm][tests]Disable test GetFrames_AsynsCalls for wasm only.

### DIFF
--- a/mcs/class/corlib/Test/System.Diagnostics/StackFrameTest.cs
+++ b/mcs/class/corlib/Test/System.Diagnostics/StackFrameTest.cs
@@ -380,6 +380,7 @@ namespace MonoTests.System.Diagnostics
 
 		[Test]
 		// https://github.com/mono/mono/issues/12688
+		[Category("NotWasm")]
 		public void GetFrames_AsynsCalls ()
 		{
 			StartAsyncCalls ().Wait ();


### PR DESCRIPTION
Disable test GetFrames_AsynsCalls for wasm only.


Backport of #12768.

/cc @marek-safar @thaystg