### PR TITLE
[2019-02] [corlib] Do not clone SynchronizationContext in ExecutionContext.Capture

### DIFF
--- a/mcs/class/corlib/Test/System.Threading/CancellationTokenSourceTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/CancellationTokenSourceTest.cs
@@ -505,12 +505,16 @@ namespace MonoTests.System.Threading
 			var tcs = new TaskCompletionSource<bool> ();
 			ct.Token.Register (() => tcs.TrySetCanceled ());
 
+			bool taskIsCancelled = false;
 			Action awaitAction = async () => {
 					try { await tcs.Task; }
-					catch (OperationCanceledException) { }
+					catch (OperationCanceledException) { 
+						taskIsCancelled = true;
+					}
 				};
 			awaitAction ();
 			ct.Cancel (); // should not trigger SynchronizationContext.Post
+			Assert.IsTrue (taskIsCancelled);
 			SynchronizationContext.SetSynchronizationContext (mainContext);
 		}
 

--- a/mcs/class/corlib/Test/System.Threading/CancellationTokenSourceTest.cs
+++ b/mcs/class/corlib/Test/System.Threading/CancellationTokenSourceTest.cs
@@ -494,6 +494,31 @@ namespace MonoTests.System.Threading
 				c1.Dispose ();
 			}
 		}
+
+		[Test] // https://github.com/mono/mono/issues/12421
+		public void EnsurePostIsNotCalled ()
+		{
+			SynchronizationContext mainContext = SynchronizationContext.Current;
+			var asc = new AssertSyncContext ();
+			SynchronizationContext.SetSynchronizationContext (asc);
+			var ct = new CancellationTokenSource ();
+			var tcs = new TaskCompletionSource<bool> ();
+			ct.Token.Register (() => tcs.TrySetCanceled ());
+
+			Action awaitAction = async () => {
+					try { await tcs.Task; }
+					catch (OperationCanceledException) { }
+				};
+			awaitAction ();
+			ct.Cancel (); // should not trigger SynchronizationContext.Post
+			SynchronizationContext.SetSynchronizationContext (mainContext);
+		}
+
+		class AssertSyncContext : SynchronizationContext
+		{
+			public override void Post (SendOrPostCallback d, object state) =>
+				throw new InvalidOperationException ("SynchronizationContext.Post was not expected.");
+		}
 	}
 }
 

--- a/mcs/class/corlib/corlib.csproj
+++ b/mcs/class/corlib/corlib.csproj
@@ -930,6 +930,7 @@
     <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\shared\System\Runtime\CompilerServices\TaskAwaiter.cs" />
     <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\shared\System\Runtime\ConstrainedExecution\CriticalFinalizerObject.cs" />
     <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\shared\System\Runtime\InteropServices\SafeBuffer.cs" />
+    <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\shared\System\Threading\CancellationToken.cs" />
     <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\shared\System\Threading\ManualResetEventSlim.cs" />
     <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\shared\System\Threading\NativeOverlapped.cs" />
     <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\shared\System\Threading\SpinWait.cs" />
@@ -951,6 +952,7 @@
     <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\src\System\Reflection\MissingMetadataException.cs" />
     <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\src\System\Runtime\CompilerServices\ReflectionBlockedAttribute.cs" />
     <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\src\System\Threading\CancellationTokenRegistration.cs" />
+    <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\src\System\Threading\CancellationTokenSource.cs" />
     <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\src\System\Threading\LockHolder.cs" />
     <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\src\System\Threading\Tasks\DebuggerSupport.Dummy.cs" />
     <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\src\System\Threading\Tasks\DebuggerSupport.cs" />
@@ -1254,8 +1256,6 @@
     <Compile Include="..\referencesource\mscorlib\system\security\util\tokenizer.cs" />
     <Compile Include="..\referencesource\mscorlib\system\sharedstatics.cs" />
     <Compile Include="..\referencesource\mscorlib\system\text\encoding.cs" />
-    <Compile Include="..\referencesource\mscorlib\system\threading\CancellationToken.cs" />
-    <Compile Include="..\referencesource\mscorlib\system\threading\CancellationTokenSource.cs" />
     <Compile Include="..\referencesource\mscorlib\system\threading\SemaphoreSlim.cs" />
     <Compile Include="..\referencesource\mscorlib\system\threading\SpinLock.cs" />
     <Compile Include="..\referencesource\mscorlib\system\threading\Tasks\AsyncCausalityTracer.cs" />

--- a/mcs/class/corlib/corlib.dll.sources
+++ b/mcs/class/corlib/corlib.dll.sources
@@ -1544,8 +1544,8 @@ corefx/BinaryEnums.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/Threading/ApartmentState.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/Threading/AsyncLocal.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/Threading/AutoResetEvent.cs
-../referencesource/mscorlib/system/threading/CancellationToken.cs
-../referencesource/mscorlib/system/threading/CancellationTokenSource.cs
+../../../external/corert/src/System.Private.CoreLib/shared/System/Threading/CancellationToken.cs
+../../../external/corert/src/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
 ../../../external/corefx/src/System.Threading/src/System/Threading/CountdownEvent.cs
 ../../../external/corefx/src/Common/src/CoreLib/System/Threading/EventResetMode.cs
 ../referencesource/mscorlib/system/threading/eventwaithandle.cs

--- a/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs
+++ b/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs
@@ -1248,7 +1248,7 @@ namespace System.Threading
             {
                 // capture the sync context
                 if (0 == (options & CaptureOptions.IgnoreSyncCtx))
-                    syncCtxNew = (ecCurrent.SynchronizationContext == null) ? null : ecCurrent.SynchronizationContext.CreateCopy();
+                    syncCtxNew = ecCurrent.SynchronizationContext;
 
 #if FEATURE_REMOTING
                 // copy over the Logical Call Context

--- a/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs
+++ b/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs
@@ -1248,7 +1248,11 @@ namespace System.Threading
             {
                 // capture the sync context
                 if (0 == (options & CaptureOptions.IgnoreSyncCtx))
+#if MONO
                     syncCtxNew = ecCurrent.SynchronizationContext;
+#else
+                    syncCtxNew = (ecCurrent.SynchronizationContext == null) ? null : ecCurrent.SynchronizationContext.CreateCopy();
+#endif
 
 #if FEATURE_REMOTING
                 // copy over the Logical Call Context


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/12421
When we switched to CoreFX/CoreRT sources (mostly CoreRT) for System.Threading we had to keep old reference-source based `ExecutionContext`, `CancellationToken` and `CancellationTokenSource`.  In the bug above the redundant `SynchronizationContext.Post` was triggered here:
https://github.com/mono/corert/blob/1b7d4a1e4bd79305905338827cc41eb8303364f0/src/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs#L404

it was expected to be "myCustomSyncContext == myCustomSyncContext" but instead it was "myCustomSyncContext == empty SynchronizationContext instance".
That empty instance was allocated in `CreateCopy` which I am trying to delete in this PR.
That `.CreateCopy()` always creates `SynchronizationContext` instance (see [here](https://github.com/mono/mono/blob/master/mcs/class/referencesource/mscorlib/system/threading/synchronizationcontext.cs#L363-L368), but it's expected) so `==` is `false` in our case => it goes to the "Post" path instead of "Execute synchronously". 
PS: .NET Core sources do not call `CreateCopy anywhere.

Backport of #12774.

/cc @marek-safar @EgorBo