### PR TITLE
[2019-02] [corlib] Fix GetFrames_AsyncCalls test not to block

### DIFF
--- a/mcs/class/corlib/Test/System.Diagnostics/StackFrameTest.cs
+++ b/mcs/class/corlib/Test/System.Diagnostics/StackFrameTest.cs
@@ -385,10 +385,9 @@ namespace MonoTests.System.Diagnostics
 
 		[Test]
 		// https://github.com/mono/mono/issues/12688
-		[Category("NotWasm")]
-		public void GetFrames_AsynsCalls ()
+		public async Task GetFrames_AsyncCalls ()
 		{
-			StartAsyncCalls ().Wait ();
+			await StartAsyncCalls ();
 		}
 
 		private async Task StartAsyncCalls ()


### PR DESCRIPTION


Backport of #12781.

/cc @marek-safar 