### PR TITLE
[2018-12] [corlib] Fix GetFrames_AsyncCalls test not to block

### DIFF
--- a/mcs/class/corlib/Test/System.Diagnostics/StackFrameTest.cs
+++ b/mcs/class/corlib/Test/System.Diagnostics/StackFrameTest.cs
@@ -379,10 +379,11 @@ namespace MonoTests.System.Diagnostics
 		}
 
 		[Test]
+		[Category("NotWasm")]
 		// https://github.com/mono/mono/issues/12688
-		public void GetFrames_AsynsCalls ()
+		public async Task GetFrames_AsyncCalls ()
 		{
-			StartAsyncCalls ().Wait ();
+			await StartAsyncCalls ();
 		}
 
 		private async Task StartAsyncCalls ()


### PR DESCRIPTION


Backport of #12790.

/cc @marek-safar 