### PR TITLE
[runtime] Refactor pinvoke probing

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -87,6 +87,7 @@
 #include <mono/metadata/w32semaphore.h>
 #include <mono/metadata/w32event.h>
 #include <mono/metadata/abi-details.h>
+#include <mono/metadata/loader-internals.h>
 #include <mono/utils/monobitset.h>
 #include <mono/utils/mono-time.h>
 #include <mono/utils/mono-proclib.h>
@@ -7793,7 +7794,7 @@ prelink_method (MonoMethod *method, MonoError *error)
 	error_init (error);
 	if (!(method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL))
 		return;
-	mono_lookup_pinvoke_call (method, &exc_class, &exc_arg);
+	mono_lookup_pinvoke_call_internal (method, &exc_class, &exc_arg);
 	if (exc_class) {
 		mono_error_set_generic_error (error, "System", exc_class, "%s", exc_arg);
 		return;

--- a/mono/metadata/loader-internals.h
+++ b/mono/metadata/loader-internals.h
@@ -5,4 +5,10 @@
 #ifndef _MONO_METADATA_LOADER_INTERNALS_H_
 #define _MONO_METADATA_LOADER_INTERNALS_H_
 
+#include <glib.h>
+#include <mono/metadata/object-forward.h>
+
+gpointer
+mono_lookup_pinvoke_call_internal (MonoMethod *method, const char **exc_class, const char **exc_arg);
+
 #endif

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -32,6 +32,7 @@
 #include <mono/metadata/tabledefs.h>
 #include <mono/metadata/metadata-internals.h>
 #include <mono/metadata/loader.h>
+#include <mono/metadata/loader-internals.h>
 #include <mono/metadata/class-init.h>
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/debug-helpers.h>
@@ -1191,6 +1192,17 @@ is_absolute_path (const char *path)
  */
 gpointer
 mono_lookup_pinvoke_call (MonoMethod *method, const char **exc_class, const char **exc_arg)
+{
+	gpointer result;
+	MONO_ENTER_GC_UNSAFE;
+	result = mono_lookup_pinvoke_call_internal (method, exc_class, exc_arg);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
+}
+
+
+gpointer
+mono_lookup_pinvoke_call_internal (MonoMethod *method, const char **exc_class, const char **exc_arg)
 {
 	MonoImage *image = m_class_get_image (method->klass);
 	MonoMethodPInvoke *piinfo = (MonoMethodPInvoke *)method;

--- a/mono/metadata/loader.h
+++ b/mono/metadata/loader.h
@@ -71,7 +71,7 @@ mono_lookup_icall_symbol (MonoMethod *m);
 MONO_API void
 mono_dllmap_insert (MonoImage *assembly, const char *dll, const char *func, const char *tdll, const char *tfunc);
 
-MONO_API void*
+MONO_API MONO_RT_EXTERNAL_ONLY void*
 mono_lookup_pinvoke_call (MonoMethod *method, const char **exc_class, const char **exc_arg);
 
 MONO_API void

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -50,6 +50,7 @@
 #include "mono/metadata/custom-attrs-internals.h"
 #include "mono/metadata/abi-details.h"
 #include "mono/metadata/custom-attrs-internals.h"
+#include "mono/metadata/loader-internals.h"
 #include "mono/utils/mono-counters.h"
 #include "mono/utils/mono-tls.h"
 #include "mono/utils/mono-memory-model.h"
@@ -347,7 +348,7 @@ mono_delegate_to_ftnptr_impl (MonoDelegateHandle delegate, MonoError *error)
 		const char *exc_class, *exc_arg;
 		gpointer ftnptr;
 
-		ftnptr = mono_lookup_pinvoke_call (method, &exc_class, &exc_arg);
+		ftnptr = mono_lookup_pinvoke_call_internal (method, &exc_class, &exc_arg);
 		if (!ftnptr) {
 			g_assert (exc_class);
 			mono_error_set_generic_error (error, "System", exc_class, "%s", exc_arg);
@@ -3344,7 +3345,7 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 			if (method->iflags & METHOD_IMPL_ATTRIBUTE_NATIVE)
 				exc_arg = "Method contains unsupported native code";
 			else if (!aot)
-				mono_lookup_pinvoke_call (method, &exc_class, &exc_arg);
+				mono_lookup_pinvoke_call_internal (method, &exc_class, &exc_arg);
 		} else {
 			if (!aot || (method->klass == mono_defaults.string_class))
 				piinfo->addr = mono_lookup_internal_call (method);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -52,6 +52,7 @@
 #include <mono/metadata/reflection-internals.h>
 #include <mono/metadata/monitor.h>
 #include <mono/metadata/icall-internals.h>
+#include <mono/metadata/loader-internals.h>
 #define MONO_MATH_DECLARE_ALL 1
 #include <mono/utils/mono-math.h>
 #include <mono/utils/mono-compiler.h>
@@ -1615,7 +1616,7 @@ mono_resolve_patch_target (MonoMethod *method, MonoDomain *domain, guint8 *code,
 			const char *exc_arg;
 
 			if (run_cctors) {
-				target = mono_lookup_pinvoke_call (patch_info->data.method, &exc_class, &exc_arg);
+				target = mono_lookup_pinvoke_call_internal (patch_info->data.method, &exc_class, &exc_arg);
 				if (!target) {
 					if (mono_aot_only) {
 						mono_error_set_exception_instance (error, mono_exception_from_name_msg (mono_defaults.corlib, "System", exc_class, exc_arg));
@@ -2213,7 +2214,7 @@ compile_special (MonoMethod *method, MonoDomain *target_domain, MonoError *error
 				g_warning ("Method '%s' in assembly '%s' contains native code that cannot be executed by Mono on this platform. The assembly was probably created using C++/CLI.\n", mono_method_full_name (method, TRUE), m_class_get_image (method->klass)->name);
 #endif
 			else
-				mono_lookup_pinvoke_call (method, NULL, NULL);
+				mono_lookup_pinvoke_call_internal (method, NULL, NULL);
 		}
 		nm = mono_marshal_get_native_wrapper (method, TRUE, mono_aot_only);
 		gpointer compiled_method = mono_jit_compile_method_jit_only (nm, error);


### PR DESCRIPTION
Split up `mono_lookup_pinvoke_call` into several smaller static functions.  There is still more that should be done (the `for`-loop and `switch` for filename probing should also factor into smaller functions) but this is a first step.

There should be no functional change.

Also mark `mono_lookup_pinvoke_call` as external-only and switch the runtime to using `mono_lookup_pinvoke_call_internal`.  (This will make it easier to switch to a `MonoError` for errors, instead of returning a pair of strings).
