### PR TITLE
[2018-10] [corlib] Fix GetFrames_AsyncCalls test not to block

### DIFF
--- a/mcs/class/corlib/Test/System.Diagnostics/StackFrameTest.cs
+++ b/mcs/class/corlib/Test/System.Diagnostics/StackFrameTest.cs
@@ -379,10 +379,12 @@ namespace MonoTests.System.Diagnostics
 		}
 
 		[Test]
+		[Category("NotWasm")]
+		[Category("MobileNotWorking")]
 		// https://github.com/mono/mono/issues/12688
-		public void GetFrames_AsynsCalls ()
+		public async Task GetFrames_AsyncCalls ()
 		{
-			StartAsyncCalls ().Wait ();
+			await StartAsyncCalls ();
 		}
 
 		private async Task StartAsyncCalls ()


### PR DESCRIPTION


Backport of #12790.

/cc @marek-safar 