### PR TITLE
[2019-02] [corlib] Fix GetFrames_AsyncCalls test not to block

### DIFF
--- a/mcs/class/corlib/Test/System.Diagnostics/StackFrameTest.cs
+++ b/mcs/class/corlib/Test/System.Diagnostics/StackFrameTest.cs
@@ -384,6 +384,8 @@ namespace MonoTests.System.Diagnostics
 		}
 
 		[Test]
+		[Category("NotWasm")]
+		[Category("MobileNotWorking")]
 		// https://github.com/mono/mono/issues/12688
 		public async Task GetFrames_AsyncCalls ()
 		{


### PR DESCRIPTION


Backport of #12790.

/cc @marek-safar 