### PR TITLE
Fix issue where togglerefs might be incorrectly pinned by GC.

### DIFF
--- a/mono/metadata/sgen-stw.c
+++ b/mono/metadata/sgen-stw.c
@@ -112,10 +112,10 @@ sgen_client_stop_world (int generation, gboolean serial_collection)
 
 	MONO_PROFILER_RAISE (gc_event, (MONO_GC_EVENT_PRE_STOP_WORLD_LOCKED, generation, serial_collection));
 
+	update_current_thread_stack (&generation);
+
 	/* We start to scan after locks are taking, this ensures we won't be interrupted. */
 	sgen_process_togglerefs ();
-
-	update_current_thread_stack (&generation);
 
 	sgen_global_stop_count++;
 	SGEN_LOG (3, "stopping world n %d from %p %p", sgen_global_stop_count, mono_thread_info_current (), (gpointer) (gsize) mono_native_thread_id_get ());


### PR DESCRIPTION
Due to current call order in sgen_client_stop_world to first process togglerefs and then take current threads stack could cause a problem where toogleref object references might be left in registers after running sgen_process_togglerefs and then those object reference would be put into current thread context, incorrectly pinning the object pointed to by a toggleref, preventing it from properly being handled by GC.

The problem was observed on Windows (in debug build) running sgen-toggleref.exe runtime test since
the compile of sgen_process_togglerefs used a register holding the current toogleref's object reference when walking the list of togglerefs. That register was then not re-used until the current threads stack was taken, causing incorrect pinning of the last toogleref object in the list. This problem could in theory happen on any platform depending on native compiler and optimization.

Fix takes current threads context before walking the togglerefs to make sure we are not getting managed references into registers as part of managing the toggleref list in sgen_process_togglerefs.
