### PR TITLE
[2018-12] [2018-10] Extend mono-native minimum version magic to CPPFLAGS/CXXFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5855,8 +5855,12 @@ if test x$target_osx = xyes; then
 		mono_native_compat=yes
 		mono_native_text="Mac OSX (compat+unified)"
 		MONO_NATIVE_COMPAT_CFLAGS="$CFLAGS $mono_native_compat_version"
+		MONO_NATIVE_COMPAT_CPPFLAGS="$CPPFLAGS $mono_native_compat_version"
+		MONO_NATIVE_COMPAT_CXXFLAGS="$CXXFLAGS $mono_native_compat_version"
 		MONO_NATIVE_COMPAT_LDFLAGS="$LDFLAGS $mono_native_compat_version"
 		MONO_NATIVE_UNIFIED_CFLAGS="$MONO_NATIVE_CFLAGS -mmacosx-version-min=10.12"
+		MONO_NATIVE_UNIFIED_CPPFLAGS="$MONO_NATIVE_CPPFLAGS -mmacosx-version-min=10.12"
+		MONO_NATIVE_UNIFIED_CXXFLAGS="$MONO_NATIVE_CXXFLAGS -mmacosx-version-min=10.12"
 		MONO_NATIVE_UNIFIED_LDFLAGS="$MONO_NATIVE_LDFLAGS -mmacosx-version-min=10.12"
 	else
 		mono_native_compat=no
@@ -5940,8 +5944,12 @@ elif test x$mono_native_platform_ios = xyes; then
 	if test x$mono_native_compat = xyes; then
 		mono_native_text="$mono_native_text (compat+unified)"
 		MONO_NATIVE_COMPAT_CFLAGS="$CFLAGS $mono_native_compat_version"
-		MONO_NATIVE_COMPAT_LDFLAGS="$LDFLAGS $mono_native_compat_version"
+		MONO_NATIVE_COMPAT_CPPFLAGS="$CPPFLAGS $mono_native_compat_version"
+		MONO_NATIVE_COMPAT_CXXFLAGS="$CXXFLAGS $mono_native_compat_version"
+		MONO_NATIVE_COMPAT_LDFLAGS="$LDFLAGS $mono_native_ldflags $mono_native_compat_version"
 		MONO_NATIVE_UNIFIED_CFLAGS="$MONO_NATIVE_CFLAGS -m$mono_native_ios_target-version-min=$mono_native_unified_version"
+		MONO_NATIVE_UNIFIED_CPPFLAGS="$MONO_NATIVE_CPPFLAGS -m$mono_native_ios_target-version-min=$mono_native_unified_version"
+		MONO_NATIVE_UNIFIED_CXXFLAGS="$MONO_NATIVE_CXXFLAGS -m$mono_native_ios_target-version-min=$mono_native_unified_version"
 		MONO_NATIVE_UNIFIED_LDFLAGS="$MONO_NATIVE_LDFLAGS -m$mono_native_ios_target-version-min=$mono_native_unified_version"
 	fi
 
@@ -5996,7 +6004,11 @@ AC_SUBST(MONO_NATIVE_PLATFORM)
 AC_SUBST(MONO_NATIVE_CC)
 AC_SUBST(MONO_NATIVE_CXX)
 AC_SUBST(MONO_NATIVE_CPPFLAGS)
+AC_SUBST(MONO_NATIVE_COMPAT_CPPFLAGS)
+AC_SUBST(MONO_NATIVE_UNIFIED_CPPFLAGS)
 AC_SUBST(MONO_NATIVE_CXXFLAGS)
+AC_SUBST(MONO_NATIVE_COMPAT_CXXFLAGS)
+AC_SUBST(MONO_NATIVE_UNIFIED_CXXFLAGS)
 AC_SUBST(MONO_NATIVE_CFLAGS)
 AC_SUBST(MONO_NATIVE_COMPAT_CFLAGS)
 AC_SUBST(MONO_NATIVE_UNIFIED_CFLAGS)

--- a/mono/native/Makefile.am
+++ b/mono/native/Makefile.am
@@ -11,11 +11,6 @@ CPP = $(MONO_NATIVE_CC) -E
 CXX = $(MONO_NATIVE_CXX)
 CXXCPP = $(MONO_NATIVE_CXX) -E
 CC_FOR_BUILD = $(MONO_NATIVE_CC)
-CPPFLAGS = $(MONO_NATIVE_CPPFLAGS)
-CXXFLAGS = $(MONO_NATIVE_CXXFLAGS)
-LDFLAGS = $(MONO_NATIVE_LDFLAGS)
-
-AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/mono $(LIBGC_CPPFLAGS) $(GLIB_CFLAGS) $(SHARED_CFLAGS)
 
 common_sources = \
 	pal_config.h \
@@ -92,14 +87,22 @@ endif
 endif
 endif
 
+common_cppflags = -I$(top_srcdir) -I$(top_srcdir)/mono
+
 common_cflags = \
 	-I$(abs_top_srcdir)/external/corefx/src/Native/Unix/Common \
 	-I$(abs_top_srcdir)/external/corefx/src/Native/Unix/System.Native \
+	$(GLIB_CFLAGS) \
+	$(SHARED_CFLAGS) \
 	-Wno-typedef-redefinition
 
 libmono_native_la_SOURCES = $(common_sources) $(platform_sources) platform-type.c
 
 libmono_native_la_CFLAGS = $(MONO_NATIVE_CFLAGS) $(common_cflags)
+
+libmono_native_la_CPPFLAGS = $(MONO_NATIVE_CPPFLAGS) $(common_cppflags)
+
+libmono_native_la_CXXFLAGS = $(MONO_NATIVE_CXXFLAGS)
 
 libmono_native_la_LDFLAGS = $(MONO_NATIVE_LDFLAGS)
 
@@ -109,6 +112,10 @@ libmono_native_compat_la_SOURCES = $(common_sources) $(platform_sources) platfor
 
 libmono_native_compat_la_CFLAGS = $(MONO_NATIVE_COMPAT_CFLAGS) $(common_cflags)
 
+libmono_native_compat_la_CPPFLAGS = $(MONO_NATIVE_COMPAT_CPPFLAGS) $(common_cppflags)
+
+libmono_native_compat_la_CXXFLAGS = $(MONO_NATIVE_COMPAT_CXXFLAGS)
+
 libmono_native_compat_la_LDFLAGS = $(MONO_NATIVE_COMPAT_LDFLAGS)
 
 libmono_native_compat_la_LIBADD = $(MONO_NATIVE_LIBADD)
@@ -116,6 +123,10 @@ libmono_native_compat_la_LIBADD = $(MONO_NATIVE_LIBADD)
 libmono_native_unified_la_SOURCES = $(common_sources) $(platform_sources) platform-type-unified.c
 
 libmono_native_unified_la_CFLAGS = $(MONO_NATIVE_UNIFIED_CFLAGS) $(common_cflags)
+
+libmono_native_unified_la_CPPFLAGS = $(MONO_NATIVE_UNIFIED_CPPFLAGS) $(common_cppflags)
+
+libmono_native_unified_la_CXXFLAGS = $(MONO_NATIVE_UNIFIED_CXXFLAGS)
 
 libmono_native_unified_la_LDFLAGS = $(MONO_NATIVE_UNIFIED_LDFLAGS)
 


### PR DESCRIPTION
We were only doing the `-mmacosx-min-version` replacement magic on CFLAGS and LDFLAGS for mono-native-compat and -unified, but we need to do the same for CPPFLAGS/CXXFLAGS too.

Fixes an issue where the libraries were targeting the wrong minimum OSX version when built from xamarin-macios since they pass the minimum version in CPPFLAGS instead of CFLAGS for OSX.


Backport of #12801.

/cc @akoeplinger 