### PR TITLE
[wasm][debugger] Bug on attributes with value type string and content NULL

### DIFF
--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -618,9 +618,9 @@ static gboolean describe_value(MonoType * type, gpointer addr)
 			break;
 		case MONO_TYPE_STRING: {
 			MonoString *str_obj = *(MonoString **)addr;
-			if (!str_obj)
+			if (!str_obj) {
 				mono_wasm_add_string_var (NULL);
-			else {
+			} else {
 				char *str = mono_string_to_utf8_checked_internal (str_obj, error);
 				mono_error_assert_ok (error); /* FIXME report error */
 				mono_wasm_add_string_var (str);

--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -620,11 +620,12 @@ static gboolean describe_value(MonoType * type, gpointer addr)
 			MonoString *str_obj = *(MonoString **)addr;
 			if (!str_obj)
 				mono_wasm_add_string_var (NULL);
-			char *str = mono_string_to_utf8_checked_internal (str_obj, error);
-			mono_error_assert_ok (error); /* FIXME report error */
-
-			mono_wasm_add_string_var (str);
-			g_free (str);
+			else {
+				char *str = mono_string_to_utf8_checked_internal (str_obj, error);
+				mono_error_assert_ok (error); /* FIXME report error */
+				mono_wasm_add_string_var (str);
+				g_free (str);
+			}
 			break;
 		}
 		case MONO_TYPE_GENERICINST:


### PR DESCRIPTION
An attribute with a content that was a string null was creating two items in result json and it was throwing an exception in client side because it is expected a name and a value and not a name and two values.

