### PR TITLE
[2019-02] [ios] pass --enable-monotouch to cross compilers so icall defintions are visible to it

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7361,31 +7361,51 @@ G_EXTERN_C gint32   WriteZStream (gpointer stream, gpointer buffer, gint32 lengt
 gpointer
 ves_icall_System_IO_Compression_DeflateStreamNative_CreateZStream (gint32 compress, MonoBoolean gzip, gpointer feeder, gpointer data)
 {
+#ifdef MONO_CROSS_COMPILE
+	return NULL;
+#else
 	return CreateZStream (compress, gzip, feeder, data);
+#endif
 }
 
 gint32
 ves_icall_System_IO_Compression_DeflateStreamNative_CloseZStream (gpointer stream)
 {
+#ifdef MONO_CROSS_COMPILE
+	return 0;
+#else
 	return CloseZStream (stream);
+#endif
 }
 
 gint32
 ves_icall_System_IO_Compression_DeflateStreamNative_Flush (gpointer stream)
 {
+#ifdef MONO_CROSS_COMPILE
+	return 0;
+#else
 	return Flush (stream);
+#endif
 }
 
 gint32
 ves_icall_System_IO_Compression_DeflateStreamNative_ReadZStream (gpointer stream, gpointer buffer, gint32 length)
 {
+#ifdef MONO_CROSS_COMPILE
+	return 0;
+#else
 	return ReadZStream (stream, buffer, length);
+#endif
 }
 
 gint32
 ves_icall_System_IO_Compression_DeflateStreamNative_WriteZStream (gpointer stream, gpointer buffer, gint32 length)
 {
+#ifdef MONO_CROSS_COMPILE
+	return 0;
+#else
 	return WriteZStream (stream, buffer, length);
+#endif
 }
 
 #endif

--- a/sdks/builds/ios.mk
+++ b/sdks/builds/ios.mk
@@ -337,6 +337,7 @@ _ios-$(1)_CONFIGURE_FLAGS= \
 	--enable-dtrace=no \
 	--enable-icall-symbol-map \
 	--enable-minimal=com,remoting \
+	--enable-monotouch \
 	--disable-crash-reporting
 
 $$(eval $$(call CrossRuntimeTemplate,ios,$(1),$(2)-apple-darwin10,$(3)-darwin,$(4),$(5),$(6)))


### PR DESCRIPTION
This fixes a regression introduced by https://github.com/mono/mono/commit/5187b0bdaaff56936d697b0753dad51e7498991d

The AOT compiler wasn't aware of the icalls since they are guarded by `ENABLE_MONOTOUCH`. Passing `--enable-monotouch` to configure of the AOT compiler enables that define, so it can properly resolve those icalls. However, to avoid `zlib` dependency for the cross compilers, we stub
them out.

Needs backport up to 2018-10.

Backport of #12834.

/cc @akoeplinger @lewurm