### PR TITLE
[runtime] Refactor pinvoke probing, part 2

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7809,16 +7809,10 @@ ves_icall_System_TypedReference_InternalMakeTypedReference (MonoTypedRef *res, M
 static void
 prelink_method (MonoMethod *method, MonoError *error)
 {
-	const char *exc_class, *exc_arg;
-
 	error_init (error);
 	if (!(method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL))
 		return;
-	mono_lookup_pinvoke_call_internal (method, &exc_class, &exc_arg);
-	if (exc_class) {
-		mono_error_set_generic_error (error, "System", exc_class, "%s", exc_arg);
-		return;
-	}
+	mono_lookup_pinvoke_call_internal (method, error);
 	/* create the wrapper, too? */
 }
 

--- a/mono/metadata/loader-internals.h
+++ b/mono/metadata/loader-internals.h
@@ -7,8 +7,9 @@
 
 #include <glib.h>
 #include <mono/metadata/object-forward.h>
+#include <mono/utils/mono-error.h>
 
 gpointer
-mono_lookup_pinvoke_call_internal (MonoMethod *method, const char **exc_class, const char **exc_arg);
+mono_lookup_pinvoke_call_internal (MonoMethod *method, MonoError *error);
 
 #endif

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -6499,6 +6499,12 @@ mb_emit_exception_ilgen (MonoMethodBuilder *mb, const char *exc_nspace, const ch
 }
 
 static void
+mb_emit_exception_for_error_ilgen (MonoMethodBuilder *mb, const MonoError *error)
+{
+	mono_mb_emit_exception_for_error (mb, (MonoError*)error);
+}
+
+static void
 emit_vtfixup_ftnptr_ilgen (MonoMethodBuilder *mb, MonoMethod *method, int param_count, guint16 type)
 {
 	for (int i = 0; i < param_count; i++)
@@ -6572,6 +6578,7 @@ mono_marshal_ilgen_init (void)
 	cb.mb_skip_visibility = mb_skip_visibility_ilgen;
 	cb.mb_set_dynamic = mb_set_dynamic_ilgen;
 	cb.mb_emit_exception = mb_emit_exception_ilgen;
+	cb.mb_emit_exception_for_error = mb_emit_exception_for_error_ilgen;
 	cb.mb_emit_byte = mb_emit_byte_ilgen;
 	mono_install_marshal_callbacks (&cb);
 }

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -100,6 +100,28 @@ emit_struct_conv (MonoMethodBuilder *mb, MonoClass *klass, gboolean to_object);
 static void
 emit_struct_conv_full (MonoMethodBuilder *mb, MonoClass *klass, gboolean to_object, int offset_of_first_child_field, MonoMarshalNative string_encoding);
 
+/**
+ * mono_mb_strdup:
+ * \param mb the MethodBuilder
+ * \param s a string
+ *
+ * Creates a copy of the string \p s that can be referenced from the IL of \c mb.
+ *
+ * \returns a pointer to the new string which is owned by the method builder
+ */
+char*
+mono_mb_strdup (MonoMethodBuilder *mb, const char *s)
+{
+	char *res;
+	if (!mb->dynamic)
+		res = mono_image_strdup (get_method_image (mb->method), s);
+	else
+		res = g_strdup (s);
+	return res;
+}
+
+
+
 /*
  * mono_mb_emit_exception_marshal_directive:
  *
@@ -108,14 +130,8 @@ emit_struct_conv_full (MonoMethodBuilder *mb, MonoClass *klass, gboolean to_obje
 static void
 mono_mb_emit_exception_marshal_directive (MonoMethodBuilder *mb, char *msg)
 {
-	char *s;
-
-	if (!mb->dynamic) {
-		s = mono_image_strdup (get_method_image (mb->method), msg);
-		g_free (msg);
-	} else {
-		s = g_strdup (msg);
-	}
+	char *s = mono_mb_strdup (mb, msg);
+	g_free (msg);
 	mono_mb_emit_exception_full (mb, "System.Runtime.InteropServices", "MarshalDirectiveException", s);
 }
 

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -2128,6 +2128,11 @@ mb_emit_exception_noilgen (MonoMethodBuilder *mb, const char *exc_nspace, const 
 }
 
 static void
+mb_emit_exception_for_error_noilgen (MonoMethodBuilder *mb, const MonoError *error)
+{
+}
+
+static void
 emit_delegate_invoke_internal_noilgen (MonoMethodBuilder *mb, MonoMethodSignature *sig, MonoMethodSignature *invoke_sig, gboolean static_method_with_first_arg_bound, gboolean callvirt, gboolean closed_over_null, MonoMethod *method, MonoMethod *target_method, MonoClass *target_class, MonoGenericContext *ctx, MonoGenericContainer *container)
 {
 }
@@ -6236,6 +6241,7 @@ install_noilgen (void)
 	cb.mb_skip_visibility = mb_skip_visibility_noilgen;
 	cb.mb_set_dynamic = mb_set_dynamic_noilgen;
 	cb.mb_emit_exception = mb_emit_exception_noilgen;
+	cb.mb_emit_exception_for_error = mb_emit_exception_for_error_noilgen;
 	cb.mb_emit_byte = mb_emit_byte_noilgen;
 	mono_install_marshal_callbacks (&cb);
 }

--- a/mono/metadata/marshal.h
+++ b/mono/metadata/marshal.h
@@ -267,7 +267,7 @@ typedef enum {
 } MonoStelemrefKind;
 
 
-#define MONO_MARSHAL_CALLBACKS_VERSION 2
+#define MONO_MARSHAL_CALLBACKS_VERSION 3
 
 typedef struct {
 	int version;
@@ -311,6 +311,7 @@ typedef struct {
 	void (*mb_skip_visibility) (MonoMethodBuilder *mb);
 	void (*mb_set_dynamic) (MonoMethodBuilder *mb);
 	void (*mb_emit_exception) (MonoMethodBuilder *mb, const char *exc_nspace, const char *exc_name, const char *msg);
+	void (*mb_emit_exception_for_error) (MonoMethodBuilder *mb, const MonoError *emitted_error);
 	void (*mb_emit_byte) (MonoMethodBuilder *mb, guint8 op);
 } MonoMarshalCallbacks;
 

--- a/mono/metadata/method-builder-ilgen.c
+++ b/mono/metadata/method-builder-ilgen.c
@@ -591,7 +591,9 @@ mono_mb_emit_exception_for_error (MonoMethodBuilder *mb, MonoError *error)
 	 * the behaviour should conform with mono_error_prepare_exception().
 	 */
 	g_assert (mono_error_get_error_code (error) == MONO_ERROR_GENERIC && "Unsupported error code.");
-	mono_mb_emit_exception_full (mb, "System", mono_error_get_exception_name (error), mono_error_get_message (error));
+	/* Have to copy the message because it will be referenced from JITed code while the MonoError may be freed. */
+	char *msg = mono_mb_strdup (mb, mono_error_get_message (error));
+	mono_mb_emit_exception_full (mb, "System", mono_error_get_exception_name (error), msg);
 }
 
 /**

--- a/mono/metadata/method-builder-ilgen.h
+++ b/mono/metadata/method-builder-ilgen.h
@@ -140,4 +140,7 @@ mono_mb_set_clauses (MonoMethodBuilder *mb, int num_clauses, MonoExceptionClause
 void
 mono_mb_set_param_names (MonoMethodBuilder *mb, const char **param_names);
 
+char*
+mono_mb_strdup (MonoMethodBuilder *mb, const char *s);
+
 #endif

--- a/mono/metadata/method-builder.h
+++ b/mono/metadata/method-builder.h
@@ -45,6 +45,9 @@ mono_mb_create_method (MonoMethodBuilder *mb, MonoMethodSignature *signature, in
 guint32
 mono_mb_add_data (MonoMethodBuilder *mb, gpointer data);
 
+char*
+mono_mb_strdup (MonoMethodBuilder *mb, const char *s);
+
 void
 mono_install_method_builder_callbacks (MonoMethodBuilderCallbacks *cb);
 

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -496,6 +496,10 @@ get_virtual_method (InterpMethod *imethod, MonoObject *obj)
 		mono_error_cleanup (error); /* FIXME: don't swallow the error */
 	}
 
+	if (virtual_method->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL) {
+		virtual_method = mono_marshal_get_native_wrapper (virtual_method, TRUE, FALSE);
+	}
+
 	if (virtual_method->iflags & METHOD_IMPL_ATTRIBUTE_SYNCHRONIZED) {
 		virtual_method = mono_marshal_get_synchronized_wrapper (virtual_method);
 	}


### PR DESCRIPTION
1. Use `MonoError` to signal pinvoke probing failures. This is a bit complicated because:
   a. the old API uses another error mechanism
   b. the marshalling code needs to emit IL that will raise an exception given a `MonoError`.
2. Refactor the pinvoke library path transformation code a bit.  It still needs work, but at least it's now hopefully a little clearer that it's just doing some name mangling every time through the loop.

3. There's a `ENABLE_NETCORE` leak that I didn't fix - see the comment in the code.  Ultimately, I think I'll need to make dllmap lookups return copies of results by default, or else copy them at the use site, and then free at the use site.