### PR TITLE
Incorrect call to MONO_HANDLE_SETRAW causes random crash in sgen.

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -798,7 +798,7 @@ mono_string_utf16_to_builder_copy (MonoStringBuilderHandle sb, const gunichar2 *
 	gchandle_t gchandle = 0;
 	memcpy (MONO_ARRAY_HANDLE_PIN (chunkChars, gunichar2, 0, &gchandle), text, sizeof (gunichar2) * string_len);
 	mono_gchandle_free_internal (gchandle);
-	MONO_HANDLE_SETRAW (sb, chunkLength, string_len);
+	MONO_HANDLE_SETVAL (sb, chunkLength, int, string_len);
 }
 
 MonoStringBuilderHandle


### PR DESCRIPTION
mono_string_utf16_to_builder_copy incorrectly uses MONO_HANDLE_SETRAW to update the chunkLength field with a string length. Since MONO_HANDLE_SETRAW assumes the argument is a MonoObject reference this could lead to a dereference and since the value is a string length, that dereference will lead to a crash.

The problem happens in mono_gc_wbarrier_set_arrayref_internal where vtable is retrieved from value. The crash happens randomly since it is depending on the object being moved out of the nursery + sgen_binary_protocol_wbarrier not being eliminated.

Fix is to use MONO_HANDLE_SETVAL since the value is not a reference so no need to trigger a write barrier.
