### PR TITLE
[Registry] Prevent crash due to background thread facing problems in the file system

### DIFF
--- a/mcs/class/corlib/Microsoft.Win32/UnixRegistryApi.cs
+++ b/mcs/class/corlib/Microsoft.Win32/UnixRegistryApi.cs
@@ -690,7 +690,12 @@ namespace Microsoft.Win32 {
 
 		public void DirtyTimeout (object state)
 		{
-			Flush ();
+			try {
+				Flush ();
+			} catch {
+				// This was identified as a crasher under some scenarios
+				// Internal MS issue: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/787119
+			}
 		}
 
 		public void Flush ()


### PR DESCRIPTION
This should fix the crash spotted by MonoDevelop/Visual Studio for Mac that happens when a plugin uses the Win32 Registry. 

Fixes #12863
