### PR TITLE
[2018-10] [Registry] Prevent crash due to background thread facing problems in the file system

### DIFF
--- a/mcs/class/corlib/Microsoft.Win32/UnixRegistryApi.cs
+++ b/mcs/class/corlib/Microsoft.Win32/UnixRegistryApi.cs
@@ -690,7 +690,12 @@ namespace Microsoft.Win32 {
 
 		public void DirtyTimeout (object state)
 		{
-			Flush ();
+			try {
+				Flush ();
+			} catch {
+				// This was identified as a crasher under some scenarios
+				// Internal MS issue: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/787119
+			}
 		}
 
 		public void Flush ()


### PR DESCRIPTION
This should fix the crash spotted by MonoDevelop/Visual Studio for Mac that happens when a plugin uses the Win32 Registry. 



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->


Backport of #12856.

/cc @marek-safar @migueldeicaza