### PR TITLE
[2018-10] [runtime] Use temp folders for merp tests

### DIFF
--- a/mono/tests/merp-crash-test.cs
+++ b/mono/tests/merp-crash-test.cs
@@ -127,7 +127,7 @@ class C
 		}
 	}
 
-	static string configDir = "./";
+	static string configDir = "./merp-crash-test/";
 
 	public static void 
 	CrashWithMerp (int testNum)
@@ -161,7 +161,7 @@ class C
 	}
 
 	public static void 
-	TestValidateAndCleanup (string configDir, bool silent)
+	TestValidate (string configDir, bool silent)
 	{
 		DumpLogCheck ();
 
@@ -181,7 +181,7 @@ class C
 				Console.WriteLine ("Xml file {0}", text);
 			File.Delete (xmlFilePath);
 		} else {
-			Console.WriteLine ("Xml file missing");
+			Console.WriteLine ("Xml file {0} missing", xmlFilePath);
 		}
 
 		if (paramsFileExists) {
@@ -190,7 +190,7 @@ class C
 				Console.WriteLine ("Params file {0}", text);
 			File.Delete (paramsFilePath);
 		} else {
-			Console.WriteLine ("Params file missing");
+			Console.WriteLine ("Params file {0} missing", paramsFilePath);
 		}
 
 		if (crashFileExists) {
@@ -211,7 +211,7 @@ class C
 			File.Delete (crashFilePath);
 			// Assert it has the required merp fields
 		} else {
-			Console.WriteLine ("Crash file missing");
+			Console.WriteLine ("Crash file {0} missing", crashFilePath);
 		}
 
 		if (!xmlFileExists)
@@ -227,24 +227,7 @@ class C
 	public static void
 	Cleanup (string configDir)
 	{
-		var xmlFilePath = String.Format("{0}CustomLogsMetadata.xml", configDir);
-		var paramsFilePath = String.Format("{0}MERP.uploadparams.txt", configDir);
-		var crashFilePath = String.Format("{0}lastcrashlog.txt", configDir);
-
-		// Fixme: Maybe parse these json files rather than
-		// just checking they exist
-		var xmlFileExists = File.Exists (xmlFilePath);
-		var paramsFileExists = File.Exists (paramsFilePath);
-		var crashFileExists = File.Exists (crashFilePath);
-
-		if (xmlFileExists)
-			File.Delete (xmlFilePath);
-
-		if (paramsFileExists)
-			File.Delete (paramsFilePath);
-
-		if (crashFileExists)
-			File.Delete (crashFilePath);
+		Directory.Delete (configDir, true);
 	}
 
 	static void DumpLogSet ()
@@ -287,13 +270,26 @@ class C
 		pi.Arguments = String.Format ("{0} {1}", asm, testNum);;
 		pi.Environment ["MONO_PATH"] = env;
 
-		if (!silent)
+		if (!silent) {
+			Console.WriteLine ("Running {0}", CrasherClass.Crashers [testNum].Item1);
 			Console.WriteLine ("MONO_PATH={0} {1} {2} {3}", env, runtime, asm, testNum);
+		}
 
-		var process = Diag.Process.Start (pi);
-		process.WaitForExit ();
+		if (Directory.Exists (configDir)) {
+			Console.WriteLine ("Cleaning up left over configDir {0}", configDir);
+			Cleanup (configDir);
+		}
 
-		TestValidateAndCleanup (configDir, silent);
+		Directory.CreateDirectory (configDir);
+
+		try {
+			var process = Diag.Process.Start (pi);
+			process.WaitForExit ();
+
+			TestValidate (configDir, silent);
+		} finally {
+			Cleanup (configDir);
+		}
 	}
 
 	public static void Main (string [] args)
@@ -350,7 +346,6 @@ class C
 					SpawnCrashingRuntime (processExe, CrasherClass.StresserIndex, true);
 				} catch (Exception e) {
 					Console.WriteLine ("Stress test caught failure. Shutting down after {1} iterations.\n {0} \n\n", e.InnerException, iter);
-					Cleanup (configDir);
 					throw;
 				}
 			}

--- a/mono/tests/merp-json-valid.cs
+++ b/mono/tests/merp-json-valid.cs
@@ -19,7 +19,7 @@ class C
 	}
 
 	public static void 
-	JsonValidateMerp ()
+	JsonValidateMerp (string configDir)
 	{
 		var monoType = Type.GetType ("Mono.Runtime", false);
 		var m = monoType.GetMethod("EnableMicrosoftTelemetry", BindingFlags.NonPublic | BindingFlags.Static);
@@ -32,7 +32,6 @@ class C
 		var appVersion = "123456";
 		var eventType = "AppleAppCrash";
 		var appPath = "/where/mono/lives";
-		var configDir = "./";
 
 		var m_params = new object[] { appBundleId, appSignature, appVersion, merpGUIPath, eventType, appPath, configDir };
 
@@ -63,8 +62,6 @@ class C
 		var paramsFilePath = String.Format("{0}MERP.uploadparams.txt", configDir);
 		var crashFilePath = String.Format("{0}lastcrashlog.txt", configDir);
 
-		// Fixme: Maybe parse these json files rather than
-		// just checking they exist
 		var xmlFileExists = File.Exists (xmlFilePath);
 		var paramsFileExists = File.Exists (paramsFilePath);
 		var crashFileExists = File.Exists (crashFilePath);
@@ -81,7 +78,7 @@ class C
 
 		if (crashFileExists) {
 			var crashFile = File.ReadAllText (crashFilePath);
-			//File.Delete (crashFilePath);
+			File.Delete (crashFilePath);
 
 			var checker = new JavaScriptSerializer ();
 
@@ -103,6 +100,13 @@ class C
 	public static void Main ()
 	{
 		JsonValidateState ();
-		JsonValidateMerp ();
+
+		var configDir = "./merp-json-valid/";
+		Directory.CreateDirectory (configDir);
+		try {
+			JsonValidateMerp (configDir);
+		} finally {
+			Directory.Delete (configDir, true);
+		}
 	}
 }


### PR DESCRIPTION
The 2018-10 lane seemed to be failing some tests because the merp-json-valid.exe test left behind the crash log file. I fixed that in this PR, but also move the tests into their separate folders so they can run at the same time safely.

Backport of #12830.

/cc @alexanderkyte