### PR TITLE
[2018-12] [corlib] Disable four tests in TypeTest

### DIFF
--- a/mcs/class/corlib/Test/System/TypeTest.cs
+++ b/mcs/class/corlib/Test/System/TypeTest.cs
@@ -3295,6 +3295,7 @@ namespace MonoTests.System
 			Assert.AreEqual ("System.Int32", t.FullName);
 		}
 
+/*
 		[Test]
 #if MONOTOUCH || FULL_AOT_RUNTIME
 		[ExpectedException (typeof (NotSupportedException))]
@@ -3353,6 +3354,7 @@ namespace MonoTests.System
 			var g0 = t.GetGenericArguments () [0];
 			Assert.AreSame (g0, ut, "#1");
 		}
+*/
 
 		[Test]
 		public void MakeGenericType_WrongNumOfArguments ()


### PR DESCRIPTION
TypeTest.MakeGenericType_BadUserType
TypeTest.MakeGenericType_NestedUserDefinedType
TypeTest.MakeGenericType_UserDefinedType
TypeTest.TestMakeGenericType_UserDefinedType_DotNet20SP1

These tests pass when run with the interpreter on xamarin-macios.
They were disabled on master with https://github.com/mono/mono/commit/dc9bc9e0e6462739872117afc59e46fbc780d981



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->


Backport of #12868.

/cc @akoeplinger 