### PR TITLE
[2019-02] [sre] Handle null values in MarshalAsAttribute CustomAttributeBuilder

### DIFF
--- a/mcs/class/corlib/System.Reflection.Emit/CustomAttributeBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/CustomAttributeBuilder.cs
@@ -303,11 +303,24 @@ namespace System.Reflection.Emit {
 			return System.Text.Encoding.UTF8.GetString(data, pos, len);
 		}
 
+		internal static string decode_string (byte [] data, int pos, out int rpos)
+		{
+			if (data [pos] == 0xff) {
+				rpos = pos + 1;
+				return null;
+			} else {
+				int len = decode_len (data, pos, out pos);
+				string s = string_from_bytes (data, pos, len);
+				pos += len;
+				rpos = pos;
+				return s;
+			}
+		}
+
 		internal string string_arg ()
 		{
 			int pos = 2;
-			int len = decode_len (data, pos, out pos);
-			return string_from_bytes (data, pos, len);
+			return decode_string (data, pos, out pos);
 		}			
 
 		internal static UnmanagedMarshal get_umarshal (CustomAttributeBuilder customBuilder, bool is_field) {
@@ -335,18 +348,14 @@ namespace System.Reflection.Emit {
 				int paramType; // What is this ?
 				
 				/* Skip field/property signature */
-				pos ++;
+				int fieldPropSig = (int)data [pos ++];
 				/* Read type */
 				paramType = ((int)data [pos++]);
 				if (paramType == 0x55) {
 					/* enums, the value is preceeded by the type */
-					int len2 = decode_len (data, pos, out pos);
-					string_from_bytes (data, pos, len2);
-					pos += len2;
+					decode_string (data, pos, out pos);
 				}
-				int len = decode_len (data, pos, out pos);
-				string named_name = string_from_bytes (data, pos, len);
-				pos += len;
+				string named_name = decode_string (data, pos, out pos);
 
 				switch (named_name) {
 				case "ArraySubType":
@@ -375,9 +384,7 @@ namespace System.Reflection.Emit {
 					pos += 4;
 					break;
 				case "SafeArrayUserDefinedSubType":
-					len = decode_len (data, pos, out pos);
-					string_from_bytes (data, pos, len);
-					pos += len;
+					decode_string (data, pos, out pos);
 					break;
 				case "SizeParamIndex":
 					value = (int)data [pos++];
@@ -386,20 +393,15 @@ namespace System.Reflection.Emit {
 					hasSize = true;
 					break;
 				case "MarshalType":
-					len = decode_len (data, pos, out pos);
-					marshalTypeName = string_from_bytes (data, pos, len);
-					pos += len;
+					marshalTypeName = decode_string (data, pos, out pos);
 					break;
 				case "MarshalTypeRef":
-					len = decode_len (data, pos, out pos);
-					marshalTypeName = string_from_bytes (data, pos, len);
-					marshalTypeRef = Type.GetType (marshalTypeName);
-					pos += len;
+					marshalTypeName = decode_string (data, pos, out pos);
+					if (marshalTypeName != null)
+						marshalTypeRef = Type.GetType (marshalTypeName);
 					break;
 				case "MarshalCookie":
-					len = decode_len (data, pos, out pos);
-					marshalCookie = string_from_bytes (data, pos, len);
-					pos += len;
+					marshalCookie = decode_string (data, pos, out pos);
 					break;
 				default:
 					throw new Exception ("Unknown MarshalAsAttribute field: " + named_name);


### PR DESCRIPTION
Normally strings are encoded as length-then-utf8 in ECMA-335.  But a null
String is encoded as just the byte 0xFF.

When we make a CustomAttributeBuilder for a MarshalAsAttribute and attach it to
some parameter we first encode the CAB as a byte blob and then decode it in
CAB.get_umarshal into a UnmanagedMarshal attribute.  But the decoding didn't
account for the possibility of null strings.

Fixes https://github.com/mono/mono/issues/12747


Backport of #12872.

/cc @lambdageek 