### PR TITLE
[2019-02] [arm64] encode offset within stack slot for r4 in gsharedvt descriptor

### DIFF
--- a/mono/mini/mini-arm64-gsharedvt.c
+++ b/mono/mini/mini-arm64-gsharedvt.c
@@ -281,7 +281,7 @@ mono_arch_get_gsharedvt_call_info (gpointer addr, MonoMethodSignature *normal_si
 			src [0] |= (arg_size << 22);
 			/* Encode the offset inside the stack slot */
 			src [0] |= ((ainfo->offset % 8) << 26);
-			if (ainfo2->storage == ArgOnStack)
+			if (ainfo2->storage == ArgOnStack || ainfo2->storage == ArgOnStackR4)
 				dst [0] |= ((ainfo2->offset % 8) << 26);
 		} else if (ainfo2->storage == ArgOnStack && ainfo2->slot_size != 8) {
 			/* The caller passes in an address, need to store it into a stack slot */


### PR DESCRIPTION
Follow up fix for https://github.com/mono/mono/pull/11741

Fixes https://github.com/mono/mono/issues/12831


Backport of #12867.

/cc @lewurm 