### PR TITLE
[2019-02] [aot] interp flag on AOT images only on mscorlib required

### DIFF
--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -1871,7 +1871,8 @@ check_usable (MonoAssembly *assembly, MonoAotFileInfo *info, guint8 *blob, char 
 		msg = g_strdup_printf ("compiled with --aot=full");
 		usable = FALSE;
 	}
-	if (mono_use_interpreter && !interp) {
+	if (mono_use_interpreter && !interp && !strcmp (assembly->aname.name, "mscorlib")) {
+		/* mscorlib contains necessary interpreter trampolines */
 		msg = g_strdup_printf ("not compiled with --aot=interp");
 		usable = FALSE;
 	}


### PR DESCRIPTION
/cc @spouliot. This fixes `--interpreter=-all` on Xamarin.iOS.

Backport of #12838.

/cc @lewurm 