### PR TITLE
[2018-12] [interp] Add method to seq_points table after we finish registering it

### DIFF
--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -5601,9 +5601,6 @@ mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, Mon
 
 	return_if_nok (error);
 
-	// FIXME: Add a different callback ?
-	MONO_PROFILER_RAISE (jit_done, (method, imethod->jinfo));
-
 	/* Copy changes back */
 	imethod = real_imethod;
 	mono_os_mutex_lock (&calc_section);
@@ -5622,5 +5619,8 @@ mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, Mon
 	if (!g_hash_table_lookup (domain_jit_info (domain)->seq_points, imethod->method))
 		g_hash_table_insert (domain_jit_info (domain)->seq_points, imethod->method, imethod->jinfo->seq_points);
 	mono_domain_unlock (domain);
+
+	// FIXME: Add a different callback ?
+	MONO_PROFILER_RAISE (jit_done, (method, imethod->jinfo));
 }
 

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -2173,10 +2173,6 @@ save_seq_points (TransformData *td, MonoJitInfo *jinfo)
 
 	g_byte_array_free (array, TRUE);
 
-	mono_domain_lock (domain);
-	g_hash_table_insert (domain_jit_info (domain)->seq_points, rtm->method, info);
-	mono_domain_unlock (domain);
-
 	jinfo->seq_points = info;
 }
 
@@ -5618,7 +5614,13 @@ mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, Mon
 		mono_memory_barrier ();
 		imethod->transformed = TRUE;
 		mono_atomic_fetch_add_i32 (&mono_jit_stats.methods_with_interp, 1);
+
 	}
 	mono_os_mutex_unlock (&calc_section);
+
+	mono_domain_lock (domain);
+	if (!g_hash_table_lookup (domain_jit_info (domain)->seq_points, imethod->method))
+		g_hash_table_insert (domain_jit_info (domain)->seq_points, imethod->method, imethod->jinfo->seq_points);
+	mono_domain_unlock (domain);
 }
 


### PR DESCRIPTION
When adding a breakpoint (mono_de_set_breakpoint) we search in this table for seq_point information for the method. If we find the information we expect that the method is already compiled and has the metadata initialized when actually adding the breakpoint (set_bp_in_method). We were crashing if the jinfo field of the interp method was not yet initialized.

Fixes https://github.com/xamarin/xamarin-macios/issues/5381


Backport of #12902.

/cc @luhenry @BrzVlad