### PR TITLE
[2019-02] [arm/bitcode] mark valuetype returns as such when dealing with pinvokes

### DIFF
--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -2327,9 +2327,13 @@ mono_arch_get_llvm_call_info (MonoCompile *cfg, MonoMethodSignature *sig)
 	case RegTypeIRegPair:
 		break;
 	case RegTypeStructByAddr:
-		/* Vtype returned using a hidden argument */
-		linfo->ret.storage = LLVMArgVtypeRetAddr;
-		linfo->vret_arg_index = cinfo->vret_arg_index;
+		if (sig->pinvoke) {
+			linfo->ret.storage = LLVMArgVtypeByRef;
+		} else {
+			/* Vtype returned using a hidden argument */
+			linfo->ret.storage = LLVMArgVtypeRetAddr;
+			linfo->vret_arg_index = cinfo->vret_arg_index;
+		}
 		break;
 #if TARGET_WATCHOS
 	case RegTypeStructByVal:


### PR DESCRIPTION
On armv7 our calling convention happens to be the same as the platform
one. However, when using a armv7 cross compiler to generate bitcode that
targets a different platform (e.g. arm64_32) the calling convention can
be different (e.g. on arm64_32, a return buffer must be passed via r8).
Thus, mark it properly for LLVM so it can generate correct code.



Backport of #12894.

/cc @luhenry @lewurm