### PR TITLE
[2018-10] [interp] Fix ldelema

### DIFF
--- a/mono/mini/arrays.cs
+++ b/mono/mini/arrays.cs
@@ -806,6 +806,28 @@ class Tests
 			arr [i] = 1;
 		return llvm_ldlen_licm (arr);
 	}
+
+	private unsafe static void WritePtr (FooStruct *val, out FooStruct* ptr)
+	{
+		ptr = val;
+	}
+
+	public unsafe static int test_0_ldelema_ptr () {
+		int i;
+		int len = 10;
+		FooStruct*[] ptr_array = new FooStruct* [len];
+		FooStruct str = new FooStruct (3);
+
+		for (i = 0; i < len; i++)
+			WritePtr (&str, out ptr_array [i]);
+
+		for (i = 0; i < len; i++) {
+			if (ptr_array [i]->i != 3)
+				return i;
+		}
+
+                return 0;
+	}
 }
 
 

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -942,7 +942,7 @@ ves_array_element_address (InterpFrame *frame, MonoClass *required_type, MonoArr
 	if (frame->ex)
 		return NULL;
 
-	if (needs_typecheck && !mono_class_is_assignable_from_internal (m_class_get_element_class (mono_object_class ((MonoObject *) ao)), m_class_get_element_class (required_type))) {
+	if (needs_typecheck && !mono_class_is_assignable_from_internal (m_class_get_element_class (mono_object_class ((MonoObject *) ao)), required_type)) {
 		frame->ex = mono_get_exception_array_type_mismatch ();
 		FILL_IN_TRACE (frame->ex, frame);
 		return NULL;

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1623,7 +1623,7 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 #endif
 		}
 		if (op == MINT_LDELEMA || op == MINT_LDELEMA_TC) {
-			ADD_CODE (td, get_data_item_index (td, target_method->klass));
+			ADD_CODE (td, get_data_item_index (td, m_class_get_element_class (target_method->klass)));
 			ADD_CODE (td, 1 + m_class_get_rank (target_method->klass));
 		}
 


### PR DESCRIPTION
The ldelema IL instruction provided the element class while the Address intrinsic provided the array class.

Fixes https://github.com/xamarin/xamarin-macios/issues/5363

Backport of #12903.

/cc @lewurm @BrzVlad