### PR TITLE
[Wasm] debug local source

### DIFF
--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -712,10 +712,11 @@ namespace WsProxy {
 			var src_file = store.GetFileById (id);
 
 			var res = new StringWriter ();
-			res.WriteLine ($"//{src_file.SourceUri}");
+			res.WriteLine ($"//{id}");
 
 			try {
-				if (src_file.SourceUri.IsFile && File.Exists(src_file.SourceUri.LocalPath)) {
+				var uri = new Uri (src_file.Url);
+				if (uri.IsFile && File.Exists(uri.LocalPath)) {
 					using (var f = new StreamReader (File.Open (src_file.SourceUri.LocalPath, FileMode.Open))) {
 						await res.WriteAsync (await f.ReadToEndAsync ());
 					}

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -712,7 +712,7 @@ namespace WsProxy {
 			var src_file = store.GetFileById (id);
 
 			var res = new StringWriter ();
-			res.WriteLine ($"//{id}");
+			//res.WriteLine ($"//{id}");
 
 			try {
 				var uri = new Uri (src_file.Url);

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -157,7 +157,7 @@ namespace WsProxy {
 
 			case "Debugger.setBreakpointByUrl": {
 					Info ($"BP req {args}");
-					var bp_req = BreakPointRequest.Parse (args);
+					var bp_req = BreakPointRequest.Parse (args, store);
 					if (bp_req != null) {
 						await SetBreakPoint (id, bp_req, token);
 						return true;
@@ -712,7 +712,7 @@ namespace WsProxy {
 			var src_file = store.GetFileById (id);
 
 			var res = new StringWriter ();
-			res.WriteLine ($"//dotnet:{id}");
+			res.WriteLine ($"//{src_file.SourceUri}");
 
 			try {
 				if (src_file.SourceUri.IsFile && File.Exists(src_file.SourceUri.LocalPath)) {


### PR DESCRIPTION
If we can locate the source locally use direct file: references because some of the Visual Studio tooling works much better in this case.