### PR TITLE
[Wasm] debug context

### DIFF
--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/DebugStore.cs
@@ -302,7 +302,7 @@ namespace WsProxy {
 
 				this.image = ModuleDefinition.ReadModule (new MemoryStream (assembly), rp);
 			} catch (BadImageFormatException ex) {
-				Console.WriteLine ("Failed to read assembly as portable PDB");
+				Console.WriteLine ($"Failed to read assembly as portable PDB: {ex.Message}");
 			}
 
 			if (this.image == null) {
@@ -606,8 +606,11 @@ namespace WsProxy {
 
 		public SourceLocation FindBestBreakpoint (BreakPointRequest req)
 		{
-			var asm = this.assemblies.FirstOrDefault (a => a.Name.Equals (req.Assembly, StringComparison.OrdinalIgnoreCase));
-			var src = asm.Sources.FirstOrDefault (s => s.DebuggerFileName.Equals (req.File, StringComparison.OrdinalIgnoreCase));
+			var asm = assemblies.FirstOrDefault (a => a.Name.Equals (req.Assembly, StringComparison.OrdinalIgnoreCase));
+			var src = asm?.Sources?.FirstOrDefault (s => s.DebuggerFileName.Equals (req.File, StringComparison.OrdinalIgnoreCase));
+
+			if (src == null)
+				return null;
 
 			foreach (var m in src.Methods) {
 				foreach (var sp in m.methodDef.DebugInformation.SequencePoints) {

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -330,7 +330,7 @@ namespace WsProxy {
 						this.current_callstack = frames;
 
 					}
-				} else if (!function_name.StartsWith ("wasm-function", StringComparison.InvariantCulture)
+				} else if (!(function_name.StartsWith ("wasm-function", StringComparison.InvariantCulture)
 					|| url.StartsWith ("wasm://wasm/", StringComparison.InvariantCulture))) {
 					callFrames.Add (frame);
 				}
@@ -490,6 +490,10 @@ namespace WsProxy {
 			// results in a "Memory access out of bounds", causing 'values' to be null,
 			// so skip returning variable values in that case.
 			for (int i = 0; values != null && i < vars.Length; ++i) {
+				var value = values [i] ["value"];
+				if (((string)value ["description"]) == null)
+					value ["description"] = value ["value"]?.ToString();
+
 				var_list.Add (JObject.FromObject (new {
 					name = vars [i].Name,
 					value = values [i] ["value"]


### PR DESCRIPTION
Add missing callFrameId to the call stack and fill in any missing descriptions to make VSCode happy.