### PR TITLE
[2019-02] [debugger] Reverting part of https://github.com/mono/mono/pull/12114 

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -489,9 +489,26 @@ public class Tests : TestsBase, ITest2
 		elapsed_time();
 		field_with_unsafe_cast_value();
 		inspect_enumerator_in_generic_struct();
+		if_property_stepping();
 		return 3;
 	}
 
+	private class TestClass {
+		private string oneLineProperty = "";
+		public string OneLineProperty
+		{
+			get { return oneLineProperty; }/*3722cad3-7da1-4c86-a398-bb2cf6cc65a9*/
+			set { oneLineProperty = value; }
+		}
+	}
+
+	public static void if_property_stepping() {
+		var test = new TestClass();
+		if (test.OneLineProperty == "someInvalidValue6049e709-7271-41a1-bc0a-f1f1b80d4125")
+			return;
+		Console.Write("");
+	}
+	
 	public static void local_reflect () {
 		//Breakpoint line below, and reflect someField via ObjectMirror;
 		LocalReflectClass.RunMe ();

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -495,9 +495,8 @@ public class Tests : TestsBase, ITest2
 
 	private class TestClass {
 		private string oneLineProperty = "";
-		public string OneLineProperty
-		{
-			get { return oneLineProperty; }/*3722cad3-7da1-4c86-a398-bb2cf6cc65a9*/
+		public string OneLineProperty {
+			get { return oneLineProperty; }
 			set { oneLineProperty = value; }
 		}
 	}

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -4844,7 +4844,7 @@ public class DebuggerTests
 		e = step_into ();
 		e = step_into ();
 		e = step_into ();
-		assert_location(e, "op_Equality");
+		Assert.IsTrue ((e as StepEvent).Method.Name == "op_Equality" || (e as StepEvent).Method.Name == "if_property_stepping");
 	}
 } // class DebuggerTests
 } // namespace

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -4829,8 +4829,7 @@ public class DebuggerTests
 
 	}
 	[Test]
-	public void IfPropertyStepping ()
-	{
+	public void IfPropertyStepping () {
 		Event e = run_until ("if_property_stepping");
 		var req = create_step (e);
 		req.Enable ();

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -4828,5 +4828,24 @@ public class DebuggerTests
 		AssertValue ("abc", variable);
 
 	}
+	[Test]
+	public void IfPropertyStepping ()
+	{
+		Event e = run_until ("if_property_stepping");
+		var req = create_step (e);
+		req.Enable ();
+		e = step_once ();
+		e = step_over ();
+		e = step_into ();
+		e = step_into ();
+		e = step_into ();
+		e = step_into ();
+		e = step_into ();
+		e = step_into ();
+		e = step_into ();
+		e = step_into ();
+		e = step_into ();
+		assert_location(e, "op_Equality");
+	}
 } // class DebuggerTests
 } // namespace

--- a/mono/mini/debugger-engine.c
+++ b/mono/mini/debugger-engine.c
@@ -954,7 +954,7 @@ mono_de_ss_update (SingleStepReq *req, MonoJitInfo *ji, SeqPoint *sp, void *tls,
 		}
 	}
 
-	if (req->depth == STEP_DEPTH_INTO && req->size == STEP_SIZE_MIN && (sp->flags & MONO_SEQ_POINT_FLAG_NONEMPTY_STACK) && !(sp->flags & MONO_SEQ_POINT_FLAG_NESTED_CALL) && req->start_method) {
+	if (req->depth == STEP_DEPTH_INTO && req->size == STEP_SIZE_MIN && (sp->flags & MONO_SEQ_POINT_FLAG_NONEMPTY_STACK) && req->start_method) {
 		int nframes;
 		rt_callbacks.ss_calculate_framecount (tls, ctx, FALSE, NULL, &nframes);
 		if (req->start_method == method && req->nframes && nframes == req->nframes) { //Check also frame count(could be recursion)


### PR DESCRIPTION
Reverting part of this commit https://github.com/mono/mono/pull/12114, removing this part the test ShouldCorrectlyStepOverOnExitFromArgsAfterStepInMethodParameter continues working and solve the regressions of 12881.

Inserted a new test that reproduces the regression.
Fixes #12881

Backport of #12950.

/cc @thaystg 