### PR TITLE
[debug-helpers] Include custom modifiers in mono_type_get_desc

### DIFF
--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -2858,7 +2858,7 @@ print_vtable_layout_result (MonoClass *klass, MonoMethod **vtable, int cur_slot)
 		cm = vtable [i];
 		if (cm) {
 			printf ("  slot assigned: %03d, slot index: %03d %s\n", i, cm->slot,
-				mono_method_full_name (cm, TRUE));
+				mono_method_get_full_name (cm));
 		} else {
 			printf ("  slot assigned: %03d, <null>\n", i);
 		}

--- a/mono/mini/mini-codegen.c
+++ b/mono/mini/mini-codegen.c
@@ -615,7 +615,7 @@ mono_print_ins_index_strbuf (int i, MonoInst *ins)
 		}
 
 		if (call->method) {
-			char *full_name = mono_method_full_name (call->method, TRUE);
+			char *full_name = mono_method_get_full_name (call->method);
 			g_string_append_printf (sbuf, " [%s]", full_name);
 			g_free (full_name);
 		} else if (call->fptr_is_patch) {


### PR DESCRIPTION
Include custom modifiers in the output of `mono_type_get_desc()` - useful when printing the vtable layout for debugging.