### PR TITLE
[runtime] Avoid depending on the layout of the ParameterInfo class in the runtime, netcore has a version with a different layout.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # There is no ordering of corlib versions, no old or new,
 # the runtime expects an exact match.
 #
-MONO_CORLIB_VERSION=26CB76A6-673F-4126-99F0-E98277541B92
+MONO_CORLIB_VERSION=1A1222D8-4B4D-4EB4-B4FC-8227F50AB114
 
 #
 # Put a quoted #define in config.h.

--- a/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
+++ b/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
@@ -565,6 +565,8 @@
 		<type fullname="System.Reflection.RuntimeParameterInfo" preserve="fields" >
 			<!-- reflection.c mono_object_new_checked in event_object_construct -->
 			<method signature="System.Void .ctor()" />
+			<!-- reflection.c add_parameter_object_to_array -->
+			<method signature="System.Void .ctor(System.String,System.Type,int,int,System.Object,System.Reflection.MemberInfo,System.Runtime.InteropServices)" />
 		</type>
 
 		<!-- object.c: mono_field_get_value_object and mono_runtime_invoke_array -->

--- a/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
+++ b/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
@@ -562,11 +562,11 @@
 		</type>
 		<type fullname="System.Reflection.ParameterInfo" preserve="fields" />
 		<!-- reflection.c: ves_icall_get_parameter_info -->
-		<type fullname="System.Reflection.RuntimeParameterInfo" preserve="fields" >
+		<type fullname="System.Reflection.RuntimeParameterInfo" >
 			<!-- reflection.c mono_object_new_checked in event_object_construct -->
 			<method signature="System.Void .ctor()" />
 			<!-- reflection.c add_parameter_object_to_array -->
-			<method signature="System.Void .ctor(System.String,System.Type,int,int,System.Object,System.Reflection.MemberInfo,System.Runtime.InteropServices)" />
+			<method signature="System.Void .ctor(System.String,System.Type,System.Int32,System.Int32,System.Object,System.Reflection.MemberInfo,System.Runtime.InteropServices.MarshalAsAttribute)" />
 		</type>
 
 		<!-- object.c: mono_field_get_value_object and mono_runtime_invoke_array -->

--- a/mcs/class/corlib/Mono.Interop/ComInteropProxy.cs
+++ b/mcs/class/corlib/Mono.Interop/ComInteropProxy.cs
@@ -128,9 +128,6 @@ namespace Mono.Interop
 
 		public override IMessage Invoke (IMessage msg)
 		{
-			Console.WriteLine ("Invoke");
-            Console.WriteLine (System.Environment.StackTrace);
-
 			throw new Exception ("The method or operation is not implemented.");
 		}
 

--- a/mcs/class/corlib/System.Reflection/RuntimeParameterInfo.cs
+++ b/mcs/class/corlib/System.Reflection/RuntimeParameterInfo.cs
@@ -44,9 +44,19 @@ namespace System.Reflection
 	[Serializable]
 	[ClassInterfaceAttribute (ClassInterfaceType.None)]
 #endif
-	[StructLayout (LayoutKind.Sequential)]
 	class RuntimeParameterInfo : ParameterInfo {		
 		internal MarshalAsAttribute marshalAs;
+
+		// Called by the runtime
+		internal RuntimeParameterInfo (string name, Type type, int position, int attrs, object defaultValue, MemberInfo member, MarshalAsAttribute marshalAs) {
+			NameImpl = name;
+			ClassImpl = type;
+			PositionImpl = position;
+			AttrsImpl = (ParameterAttributes)attrs;
+			DefaultValueImpl = defaultValue;
+			MemberImpl = member;
+			this.marshalAs = marshalAs;
+		}
 
 		internal static void FormatParameters (StringBuilder sb, ParameterInfo[] p, CallingConventions callingConvention, bool serialization)
 		{
@@ -304,7 +314,7 @@ namespace System.Reflection
 		}
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
-		internal extern Type[] GetTypeModifiers (bool optional);		
+		internal static extern Type[] GetTypeModifiers (Type type, MemberInfo member, int position, bool optional);
 
 		internal static ParameterInfo New (ParameterInfo pinfo, Type type, MemberInfo member, int position)
 		{
@@ -321,6 +331,6 @@ namespace System.Reflection
 			return new RuntimeParameterInfo (type, member, marshalAs);
 		}
 
-		private Type[] GetCustomModifiers (bool optional) => GetTypeModifiers (optional) ?? Type.EmptyTypes;
+		private Type[] GetCustomModifiers (bool optional) => GetTypeModifiers (ParameterType, Member, Position, optional) ?? Type.EmptyTypes;
 	}
 }

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -2098,11 +2098,15 @@ mono_reflection_get_custom_attrs_info_checked (MonoObjectHandle obj, MonoError *
 		goto_if_nok (error, leave);
 	} else if (strcmp ("ParameterInfo", klass_name) == 0 || strcmp ("RuntimeParameterInfo", klass_name) == 0) {
 		MonoReflectionParameterHandle param = MONO_HANDLE_CAST (MonoReflectionParameter, obj);
-		MonoObjectHandle member_impl = MONO_HANDLE_NEW_GET (MonoObject, param, MemberImpl);
+
+		MonoObjectHandle member_impl = MONO_HANDLE_NEW (MonoObject, NULL);
+		int position;
+		mono_reflection_get_param_info_member_and_pos (param, member_impl, &position);
+
 		MonoClass *member_class = mono_handle_class (member_impl);
 		if (mono_class_is_reflection_method_or_constructor (member_class)) {
 			MonoReflectionMethodHandle rmethod = MONO_HANDLE_CAST (MonoReflectionMethod, member_impl);
-			cinfo = mono_custom_attrs_from_param_checked (MONO_HANDLE_GETVAL (rmethod, method), MONO_HANDLE_GETVAL (param, PositionImpl) + 1, error);
+			cinfo = mono_custom_attrs_from_param_checked (MONO_HANDLE_GETVAL (rmethod, method), position + 1, error);
 			goto_if_nok (error, leave);
 		} else if (mono_is_sr_mono_property (member_class)) {
 			MonoReflectionPropertyHandle prop = MONO_HANDLE_CAST (MonoReflectionProperty, member_impl);
@@ -2112,7 +2116,7 @@ mono_reflection_get_custom_attrs_info_checked (MonoObjectHandle obj, MonoError *
 				method = property->set;
 			g_assert (method);
 
-			cinfo = mono_custom_attrs_from_param_checked (method, MONO_HANDLE_GETVAL (param, PositionImpl) + 1, error);
+			cinfo = mono_custom_attrs_from_param_checked (method, position + 1, error);
 			goto_if_nok (error, leave);
 		} 
 #ifndef DISABLE_REFLECTION_EMIT

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -723,7 +723,7 @@ HANDLES(MODULE_13, "get_MetadataToken", ves_icall_reflection_get_token, guint32,
 
 ICALL_TYPE(PARAMI, "System.Reflection.RuntimeParameterInfo", MPARAMI_1)
 HANDLES_REUSE_WRAPPER(MPARAMI_1, "GetMetadataToken", ves_icall_reflection_get_token)
-HANDLES(MPARAMI_2, "GetTypeModifiers", ves_icall_RuntimeParameterInfo_GetTypeModifiers, MonoArray, 2, (MonoReflectionParameter, MonoBoolean))
+HANDLES(MPARAMI_2, "GetTypeModifiers", ves_icall_RuntimeParameterInfo_GetTypeModifiers, MonoArray, 4, (MonoReflectionType, MonoObject, int, MonoBoolean))
 
 ICALL_TYPE(MPROP, "System.Reflection.RuntimePropertyInfo", MPROP_1)
 HANDLES(MPROP_1, "GetTypeModifiers", ves_icall_RuntimePropertyInfo_GetTypeModifiers, MonoArray, 2, (MonoReflectionProperty, MonoBoolean))

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7941,18 +7941,13 @@ fail:
 }
 
 MonoArrayHandle
-ves_icall_RuntimeParameterInfo_GetTypeModifiers (MonoReflectionParameterHandle param, MonoBoolean optional, MonoError *error)
+ves_icall_RuntimeParameterInfo_GetTypeModifiers (MonoReflectionTypeHandle rt, MonoObjectHandle member, int pos, MonoBoolean optional, MonoError *error)
 {
 	error_init (error);
-	MonoReflectionTypeHandle rt = MONO_HANDLE_NEW (MonoReflectionType, NULL);
-	MONO_HANDLE_GET (rt, param, ClassImpl);
 	MonoType *type = MONO_HANDLE_GETVAL (rt, type);
-	MonoObjectHandle member = MONO_HANDLE_NEW (MonoObject, NULL);
-	MONO_HANDLE_GET (member, param, MemberImpl);
 	MonoClass *member_class = mono_handle_class (member);
 	MonoMethod *method = NULL;
 	MonoImage *image;
-	int pos;
 	MonoMethodSignature *sig;
 
 	if (mono_class_is_reflection_method_or_constructor (member_class)) {
@@ -7970,7 +7965,6 @@ ves_icall_RuntimeParameterInfo_GetTypeModifiers (MonoReflectionParameterHandle p
 	}
 
 	image = m_class_get_image (method->klass);
-	pos = MONO_HANDLE_GETVAL (param, PositionImpl);
 	sig = mono_method_signature_internal (method);
 	if (pos == -1)
 		type = sig->ret;

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -985,13 +985,6 @@ TYPED_HANDLE_DECL (MonoReflectionMonoEvent);
 
 typedef struct {
 	MonoObject object;
-	guint32 AttrsImpl;	
-	MonoReflectionType *ClassImpl;
-	MonoObject *DefaultValueImpl;
-	MonoObject *MemberImpl;
-	MonoString *NameImpl;
-	gint32 PositionImpl;
-	MonoObject *MarshalAsImpl;
 } MonoReflectionParameter;
 
 /* Safely access System.Reflection.ParameterInfo from native code */

--- a/mono/metadata/reflection-internals.h
+++ b/mono/metadata/reflection-internals.h
@@ -136,4 +136,7 @@ mono_runtime_get_caller_no_system_or_reflection (void);
 MonoAssembly*
 mono_runtime_get_caller_from_stack_mark (MonoStackCrawlMark *stack_mark);
 
+void
+mono_reflection_get_param_info_member_and_pos (MonoReflectionParameterHandle p, MonoObjectHandle member_impl, int *out_position);
+
 #endif /* __MONO_METADATA_REFLECTION_INTERNALS_H__ */

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -949,32 +949,33 @@ add_parameter_object_to_array (MonoDomain *domain, MonoMethod *method, MonoObjec
 	MonoReflectionParameterHandle param = MONO_HANDLE_CAST (MonoReflectionParameter, mono_object_new_handle (domain, mono_class_get_mono_parameter_info_class (), error));
 	goto_if_nok (error, leave);
 
+	static MonoMethod *ctor;
+	if (!ctor) {
+		MonoMethod *m = mono_class_get_method_from_name_checked (mono_class_get_mono_parameter_info_class (), ".ctor", 7, 0, error);
+		g_assert (m);
+		mono_memory_barrier ();
+		ctor = m;
+	}
+
+	void *args [16];
+
 	MonoReflectionTypeHandle rt;
 	rt = mono_type_get_object_handle (domain, sig_param, error);
 	goto_if_nok (error, leave);
-
-	MONO_HANDLE_SET (param, ClassImpl, rt);
-
-	MONO_HANDLE_SET (param, MemberImpl, member);
 
 	MonoStringHandle name_str;
 	name_str = mono_string_new_handle (domain, name, error);
 	goto_if_nok (error, leave);
 
-	MONO_HANDLE_SET (param, NameImpl, name_str);
-
-	MONO_HANDLE_SETVAL (param, PositionImpl, gint32, idx);
-
-	MONO_HANDLE_SETVAL (param, AttrsImpl, guint32, sig_param->attrs);
+	MonoObjectHandle def_value;
 
 	if (!(sig_param->attrs & PARAM_ATTRIBUTE_HAS_DEFAULT)) {
 		if (sig_param->attrs & PARAM_ATTRIBUTE_OPTIONAL)
-			MONO_HANDLE_SET (param, DefaultValueImpl, get_reflection_missing (domain, missing));
+			def_value = get_reflection_missing (domain, missing);
 		else
-			MONO_HANDLE_SET (param, DefaultValueImpl, get_dbnull (domain, dbnull, error));
+			def_value = get_dbnull (domain, dbnull, error);
 		goto_if_nok (error, leave);
 	} else {
-
 		MonoType blob_type;
 
 		blob_type.type = (MonoTypeEnum)blob_type_enum;
@@ -989,25 +990,37 @@ add_parameter_object_to_array (MonoDomain *domain, MonoMethod *method, MonoObjec
 		} else
 			blob_type.data.klass = mono_class_from_mono_type_internal (&blob_type);
 
-		MonoObjectHandle default_val_obj = MONO_HANDLE_NEW (MonoObject, mono_get_object_from_blob (domain, &blob_type, blob, error)); /* FIXME make mono_get_object_from_blob return a handle */
+		def_value = MONO_HANDLE_NEW (MonoObject, mono_get_object_from_blob (domain, &blob_type, blob, error)); /* FIXME make mono_get_object_from_blob return a handle */
 		goto_if_nok (error, leave);
-		MONO_HANDLE_SET (param, DefaultValueImpl, default_val_obj);
 
 		/* Type in the Constant table is MONO_TYPE_CLASS for nulls */
-		if (blob_type_enum != MONO_TYPE_CLASS && MONO_HANDLE_IS_NULL(default_val_obj)) {
+		if (blob_type_enum != MONO_TYPE_CLASS && MONO_HANDLE_IS_NULL(def_value)) {
 			if (sig_param->attrs & PARAM_ATTRIBUTE_OPTIONAL)
-				MONO_HANDLE_SET (param, DefaultValueImpl, get_reflection_missing (domain, missing));
+				def_value = get_reflection_missing (domain, missing);
 			else
-				MONO_HANDLE_SET (param, DefaultValueImpl, get_dbnull (domain, dbnull, error));
+				def_value = get_dbnull (domain, dbnull, error);
 			goto_if_nok (error, leave);
 		}
 	}
 
+	MonoReflectionMarshalAsAttributeHandle mobj = MONO_HANDLE_NEW (MonoReflectionMarshalAsAttribute, NULL);
 	if (mspec) {
-		MonoReflectionMarshalAsAttributeHandle mobj = mono_reflection_marshal_as_attribute_from_marshal_spec (domain, method->klass, mspec, error);
+		mobj = mono_reflection_marshal_as_attribute_from_marshal_spec (domain, method->klass, mspec, error);
 		goto_if_nok (error, leave);
-		MONO_HANDLE_SET (param, MarshalAsImpl, mobj);
 	}
+
+	/* internal RuntimeParameterInfo (string name, Type type, int position, int attrs, object defaultValue, MemberInfo member, MarshalAsAttribute marshalAs) */
+	args [0] = MONO_HANDLE_RAW (name_str);
+	args [1] = MONO_HANDLE_RAW (rt);
+	args [2] = &idx;
+	int attrs = sig_param->attrs;
+	args [3] = &attrs;
+	args [4] = MONO_HANDLE_RAW (def_value);
+	args [5] = MONO_HANDLE_RAW (member);
+	args [6] = MONO_HANDLE_RAW (mobj);
+
+	mono_runtime_invoke_handle (ctor, MONO_HANDLE_CAST (MonoObject, param), args, error);
+	goto_if_nok (error, leave);
 
 	MONO_HANDLE_ARRAY_SETREF (dest, idx, param);
 
@@ -2331,6 +2344,37 @@ mono_reflection_get_token (MonoObject *obj_raw)
 }
 
 /**
+ * mono_reflection_get_param_info_member_and_pos:
+ *
+ *   Return the MemberImpl and PositionImpl fields of P.
+ */
+void
+mono_reflection_get_param_info_member_and_pos (MonoReflectionParameterHandle p, MonoObjectHandle member_impl, int *out_position)
+{
+	MonoClass *klass = mono_class_get_mono_parameter_info_class ();
+
+	/* These two fields are part of ParameterInfo instead of RuntimeParameterInfo, and they cannot be moved */
+
+	static MonoClassField *member_field;
+	if (!member_field) {
+		MonoClassField *f = mono_class_get_field_from_name_full (klass, "MemberImpl", NULL);
+		g_assert (f);
+		member_field = f;
+	}
+	MonoObject *member;
+	mono_field_get_value_internal (MONO_HANDLE_RAW (MONO_HANDLE_CAST (MonoObject, p)), member_field, &member);
+	MONO_HANDLE_ASSIGN_RAW (member_impl, member);
+
+	static MonoClassField *pos_field;
+	if (!pos_field) {
+		MonoClassField *f = mono_class_get_field_from_name_full (klass, "PositionImpl", NULL);
+		g_assert (f);
+		pos_field = f;
+	}
+	mono_field_get_value_internal (MONO_HANDLE_RAW (MONO_HANDLE_CAST (MonoObject, p)), pos_field, out_position);
+}
+
+/**
  * mono_reflection_get_token_checked:
  * \param obj the object
  * \param error set on error
@@ -2394,13 +2438,16 @@ mono_reflection_get_token_checked (MonoObjectHandle obj, MonoError *error)
 		token = mono_class_get_event_token (MONO_HANDLE_GETVAL (p, event));
 	} else if (strcmp (klass_name, "ParameterInfo") == 0 || strcmp (klass_name, "RuntimeParameterInfo") == 0) {
 		MonoReflectionParameterHandle p = MONO_HANDLE_CAST (MonoReflectionParameter, obj);
+
 		MonoObjectHandle member_impl = MONO_HANDLE_NEW (MonoObject, NULL);
-		MONO_HANDLE_GET (member_impl, p, MemberImpl);
+		int position;
+		mono_reflection_get_param_info_member_and_pos (p, member_impl, &position);
+
 		MonoClass *member_class = mono_handle_class (member_impl);
 		g_assert (mono_class_is_reflection_method_or_constructor (member_class));
 		MonoMethod *method = MONO_HANDLE_GETVAL (MONO_HANDLE_CAST (MonoReflectionMethod, member_impl), method);
 
-		token = mono_method_get_param_token (method, MONO_HANDLE_GETVAL (p, PositionImpl));
+		token = mono_method_get_param_token (method, position);
 	} else if (strcmp (klass_name, "RuntimeModule") == 0 || strcmp (klass_name, "ModuleBuilder") == 0) {
 		MonoReflectionModuleHandle m = MONO_HANDLE_CAST (MonoReflectionModule, obj);
 

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -1003,7 +1003,8 @@ add_parameter_object_to_array (MonoDomain *domain, MonoMethod *method, MonoObjec
 		}
 	}
 
-	MonoReflectionMarshalAsAttributeHandle mobj = MONO_HANDLE_NEW (MonoReflectionMarshalAsAttribute, NULL);
+	MonoReflectionMarshalAsAttributeHandle mobj;
+	mobj = MONO_HANDLE_NEW (MonoReflectionMarshalAsAttribute, NULL);
 	if (mspec) {
 		mobj = mono_reflection_marshal_as_attribute_from_marshal_spec (domain, method->klass, mspec, error);
 		goto_if_nok (error, leave);

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -1014,7 +1014,8 @@ add_parameter_object_to_array (MonoDomain *domain, MonoMethod *method, MonoObjec
 	args [0] = MONO_HANDLE_RAW (name_str);
 	args [1] = MONO_HANDLE_RAW (rt);
 	args [2] = &idx;
-	int attrs = sig_param->attrs;
+	int attrs;
+	attrs = sig_param->attrs;
 	args [3] = &attrs;
 	args [4] = MONO_HANDLE_RAW (def_value);
 	args [5] = MONO_HANDLE_RAW (member);


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->