### PR TITLE
[System.Net.Http] Improve HttpClientTest to use the retry http listener

### DIFF
--- a/mcs/class/System.Net.Http/Test/System.Net.Http/HttpClientTest.cs
+++ b/mcs/class/System.Net.Http/Test/System.Net.Http/HttpClientTest.cs
@@ -407,8 +407,8 @@ namespace MonoTests.System.Net.Http
 		public void Send_Complete_Default ()
 		{
 			bool? failed = null;
-			var port = NetworkHelpers.FindFreePort ();
-			var listener = CreateListener (l => {
+			var listener = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int port, "/Send_Complete_Default/");
+			AddListenerContext (listener, l => {
 				try {
 					var request = l.Request;
 	
@@ -433,11 +433,11 @@ namespace MonoTests.System.Net.Http
 				} catch {
 					failed = true;
 				}
-			}, port);
+			});
 
 			try {
 				var client = HttpClientTestHelpers.CreateHttpClient ();
-				var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/");
+				var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/Send_Complete_Default/");
 				var response = client.SendAsync (request, HttpCompletionOption.ResponseHeadersRead).Result;
 
 				Assert.AreEqual ("", response.Content.ReadAsStringAsync ().Result, "#100");
@@ -456,8 +456,8 @@ namespace MonoTests.System.Net.Http
 		{
 			bool? failed = null;
 			
-			var port = NetworkHelpers.FindFreePort ();
-			var listener = CreateListener (l => {
+			var listener = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int port, "/Send_Complete_Version_1_0/");
+			AddListenerContext (listener, l => {
 				try {
 					var request = l.Request;
 	
@@ -483,11 +483,11 @@ namespace MonoTests.System.Net.Http
 				} catch {
 					failed = true;
 				}
-			}, port);
+			});
 
 			try {
 				var client = HttpClientTestHelpers.CreateHttpClient ();
-				var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/");
+				var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/Send_Complete_Version_1_0/");
 				request.Version = HttpVersion.Version10;
 				var response = client.SendAsync (request, HttpCompletionOption.ResponseHeadersRead).Result;
 
@@ -507,8 +507,8 @@ namespace MonoTests.System.Net.Http
 		{
 			bool? failed = null;
 			
-			var port = NetworkHelpers.FindFreePort ();
-			var listener = CreateListener (l => {
+			var listener = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int port, "/Send_Complete_ClientHandlerSettings/");
+			AddListenerContext (listener, l => {
 				var request = l.Request;
 				
 				try {
@@ -537,7 +537,7 @@ namespace MonoTests.System.Net.Http
 				} catch {
 					failed = true;
 				}
-			}, port);
+			});
 
 			try {
 				var chandler = HttpClientTestHelpers.CreateHttpClientHandler ();
@@ -546,14 +546,14 @@ namespace MonoTests.System.Net.Http
 				chandler.MaxAutomaticRedirections = 33;
 				chandler.MaxRequestContentBufferSize = 5555;
 				chandler.PreAuthenticate = true;
-				chandler.CookieContainer.Add (new Uri ($"http://localhost:{port}/"), new Cookie ( "mycookie", "vv"));
+				chandler.CookieContainer.Add (new Uri ($"http://localhost:{port}/Send_Complete_ClientHandlerSettings/"), new Cookie ( "mycookie", "vv"));
 				chandler.UseCookies = true;
 				chandler.UseDefaultCredentials = true;
 				chandler.Proxy = new WebProxy ("ee");
 				chandler.UseProxy = true;
 
 				var client = new HttpClient (chandler);
-				var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/");
+				var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/Send_Complete_ClientHandlerSettings/");
 				request.Version = HttpVersion.Version10;
 				request.Headers.Add ("Keep-Alive", "false");
 				var response = client.SendAsync (request, HttpCompletionOption.ResponseHeadersRead).Result;
@@ -575,8 +575,8 @@ namespace MonoTests.System.Net.Http
 		{
 			bool? failed = null;
 			
-			var port = NetworkHelpers.FindFreePort ();
-			var listener = CreateListener (l => {
+			var listener = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int port, "/Send_Complete_CustomHeaders/");
+			AddListenerContext (listener, l => {
 				var request = l.Request;
 				try {
 					Assert.AreEqual ("vv", request.Headers["aa"], "#1");
@@ -596,12 +596,12 @@ namespace MonoTests.System.Net.Http
 				} catch {
 					failed = true;
 				}
-			}, port);
+			});
 
 			try {
 				var handler = HttpClientTestHelpers.CreateHttpClientHandler ();
 				var client = new HttpClient (handler);
-				var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/");
+				var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/Send_Complete_CustomHeaders/");
 				Assert.IsTrue (request.Headers.TryAddWithoutValidation ("aa", "vv"), "#0");
 				var response = client.SendAsync (request, HttpCompletionOption.ResponseHeadersRead).Result;
 
@@ -647,8 +647,8 @@ namespace MonoTests.System.Net.Http
 		{
 			bool? failed = null;
 
-			var port = NetworkHelpers.FindFreePort ();
-			var listener = CreateListener (l => {
+			var listener = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int port, "/Send_Complete_CustomHeaders_SpecialSeparators/");
+			AddListenerContext (listener, l => {
 				var request = l.Request;
 
 				try {
@@ -657,14 +657,14 @@ namespace MonoTests.System.Net.Http
 				} catch {
 					failed = true;
 				}
-			}, port);
+			});
 
 			try {
 				var client = HttpClientTestHelpers.CreateHttpClient ();
 
 				client.DefaultRequestHeaders.Add("User-Agent", "MLK Android Phone 1.1.9");
 
-				var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/");
+				var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/Send_Complete_CustomHeaders_SpecialSeparators/");
 
 				var response = client.SendAsync (request, HttpCompletionOption.ResponseHeadersRead).Result;
 
@@ -684,8 +684,8 @@ namespace MonoTests.System.Net.Http
 		public void Send_Complete_CustomHeaders_Host ()
 		{
 			Exception error = null;
-			var port = NetworkHelpers.FindFreePort ();
-			var listener = CreateListener (l => {
+			var listener = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int port, "/Send_Complete_CustomHeaders_Host/");
+			AddListenerContext (listener, l => {
 				var request = l.Request;
 
 				try {
@@ -693,14 +693,14 @@ namespace MonoTests.System.Net.Http
 				} catch (Exception ex) {
 					error = ex;
 				}
-			}, port);
+			});
 
 			try {
 				var client = HttpClientTestHelpers.CreateHttpClient ();
 
 				client.DefaultRequestHeaders.Add("Host", "customhost");
 
-				var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/");
+				var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/Send_Complete_CustomHeaders_Host/");
 
 				var response = client.SendAsync (request, HttpCompletionOption.ResponseHeadersRead).Result;
 
@@ -724,16 +724,16 @@ namespace MonoTests.System.Net.Http
 
 			bool? failed = null;
 
-			var port = NetworkHelpers.FindFreePort ();
-			var listener = CreateListener (l => {
+			var listener = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int port, "/Send_Transfer_Encoding_Chunked_Needs_Content/");
+			AddListenerContext (listener, l => {
 				failed = true;
-			}, port);
+			});
 
 			try {
 				try {
 					var client = HttpClientTestHelpers.CreateHttpClient ();
 					client.DefaultRequestHeaders.TransferEncodingChunked = true;
-					client.GetAsync ($"http://localhost:{port}/").Wait ();
+					client.GetAsync ($"http://localhost:{port}/Send_Transfer_Encoding_Chunked_Needs_Content/").Wait ();
 					// fails with
 					// 'Transfer-Encoding: chunked' header can not be used when content object is not specified.
 				} catch (AggregateException e) {
@@ -757,8 +757,8 @@ namespace MonoTests.System.Net.Http
 
 			bool? failed = null;
 
-			var port = NetworkHelpers.FindFreePort ();
-			var listener = CreateListener (l => {
+			var listener = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int port, "/Send_Transfer_Encoding_Chunked/");
+			AddListenerContext (listener, l => {
 				var request = l.Request;
 
 				try {
@@ -770,13 +770,13 @@ namespace MonoTests.System.Net.Http
 					Console.WriteLine (String.Join ("#", l.Request.Headers.AllKeys));
 					failed = true;
 				}
-			}, port);
+			});
 
 			try {
 				var client = HttpClientTestHelpers.CreateHttpClient ();
 				client.DefaultRequestHeaders.TransferEncodingChunked = true;
 
-				client.GetAsync ($"http://localhost:{port}/").Wait ();
+				client.GetAsync ($"http://localhost:{port}/Send_Transfer_Encoding_Chunked/").Wait ();
 
 				Assert.AreEqual (false, failed, "#102");
 			} finally {
@@ -797,16 +797,16 @@ namespace MonoTests.System.Net.Http
 
 			bool? failed = null;
 
-			var port = NetworkHelpers.FindFreePort ();
-			var listener = CreateListener (l => {
+			var listener = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int port, "/Send_Transfer_Encoding_Custom/");
+			AddListenerContext (listener, l => {
 				failed = true;
-			}, port);
+			});
 
 			try {
 				var client = HttpClientTestHelpers.CreateHttpClient ();
 				client.DefaultRequestHeaders.TransferEncoding.Add (new TransferCodingHeaderValue ("chunked2"));
 
-				var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/");
+				var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/Send_Transfer_Encoding_Custom/");
 
 				try {
 					client.SendAsync (request, HttpCompletionOption.ResponseHeadersRead).Wait ();
@@ -827,16 +827,16 @@ namespace MonoTests.System.Net.Http
 #endif
 		public void Send_Complete_Content ()
 		{
-			var port = NetworkHelpers.FindFreePort ();
-			var listener = CreateListener (l => {
+			var listener = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int port, "/Send_Complete_Content/");
+			AddListenerContext (listener, l => {
 				var request = l.Request;
 				l.Response.OutputStream.WriteByte (55);
 				l.Response.OutputStream.WriteByte (75);
-			}, port);
+			});
 
 			try {
 				var client = HttpClientTestHelpers.CreateHttpClient ();
-				var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/");
+				var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/Send_Complete_Content/");
 				Assert.IsTrue (request.Headers.TryAddWithoutValidation ("aa", "vv"), "#0");
 				var response = client.SendAsync (request, HttpCompletionOption.ResponseHeadersRead).Result;
 
@@ -858,17 +858,17 @@ namespace MonoTests.System.Net.Http
 #endif
 		public void Send_Complete_Content_MaxResponseContentBufferSize ()
 		{
-			var port = NetworkHelpers.FindFreePort ();
-			var listener = CreateListener (l => {
+			var listener = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int port, "/Send_Complete_Content_MaxResponseContentBufferSize/");
+			AddListenerContext (listener, l => {
 				var request = l.Request;
 				var b = new byte[4000];
 				l.Response.OutputStream.Write (b, 0, b.Length);
-			}, port);
+			});
 
 			try {
 				var client = HttpClientTestHelpers.CreateHttpClient ();
 				client.MaxResponseContentBufferSize = 1000;
-				var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/");
+				var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/Send_Complete_Content_MaxResponseContentBufferSize/");
 				var response = client.SendAsync (request, HttpCompletionOption.ResponseHeadersRead).Result;
 
 				Assert.AreEqual (4000, response.Content.ReadAsStringAsync ().Result.Length, "#100");
@@ -884,17 +884,17 @@ namespace MonoTests.System.Net.Http
 #endif
 		public void Send_Complete_Content_MaxResponseContentBufferSize_Error ()
 		{
-			var port = NetworkHelpers.FindFreePort ();
-			var listener = CreateListener (l => {
+			var listener = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int port, "/Send_Complete_Content_MaxResponseContentBufferSize_Error/");
+			AddListenerContext (listener, l => {
 				var request = l.Request;
 				var b = new byte[4000];
 				l.Response.OutputStream.Write (b, 0, b.Length);
-			}, port);
+			});
 
 			try {
 				var client = HttpClientTestHelpers.CreateHttpClient ();
 				client.MaxResponseContentBufferSize = 1000;
-				var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/");
+				var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/Send_Complete_Content_MaxResponseContentBufferSize_Error/");
 
 				try {
 					client.SendAsync (request, HttpCompletionOption.ResponseContentRead).Wait (WaitTimeout);
@@ -939,8 +939,8 @@ namespace MonoTests.System.Net.Http
 		{
 			bool? failed = null;
 			var handler = HttpClientTestHelpers.CreateHttpClientHandler ();
-			var port = NetworkHelpers.FindFreePort ();
-			var listener = CreateListener (l => {
+			var listener = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int port, "/Send_Complete_NoContent/");
+			AddListenerContext (listener, l => {
 				try {
 					var request = l.Request;
 
@@ -960,11 +960,11 @@ namespace MonoTests.System.Net.Http
 					
 					failed = true;
 				}
-			}, port);
+			});
 
 			try {
 				var client = new HttpClient (handler);
-				var request = new HttpRequestMessage (method, $"http://localhost:{port}/");
+				var request = new HttpRequestMessage (method, $"http://localhost:{port}/Send_Complete_NoContent/");
 				var response = client.SendAsync (request, HttpCompletionOption.ResponseHeadersRead).Result;
 
 				Assert.AreEqual ("", response.Content.ReadAsStringAsync ().Result, "#100");
@@ -981,15 +981,15 @@ namespace MonoTests.System.Net.Http
 #endif
 		public void Send_Complete_Error ()
 		{
-			var port = NetworkHelpers.FindFreePort ();
-			var listener = CreateListener (l => {
+			var listener = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int port, "/Send_Complete_Error/");
+			AddListenerContext (listener, l => {
 				var response = l.Response;
 				response.StatusCode = 500;
-			}, port);
+			});
 
 			try {
 				var client = HttpClientTestHelpers.CreateHttpClient ();
-				var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/");
+				var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/Send_Complete_Error/");
 				var response = client.SendAsync (request, HttpCompletionOption.ResponseHeadersRead).Result;
 
 				Assert.AreEqual ("", response.Content.ReadAsStringAsync ().Result, "#100");
@@ -1005,15 +1005,15 @@ namespace MonoTests.System.Net.Http
 #endif
 		public void Send_Content_Get ()
 		{
-			var port = NetworkHelpers.FindFreePort ();
-			var listener = CreateListener (l => {
+			var listener = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int port, "/Send_Content_Get/");
+			AddListenerContext (listener, l => {
 				var request = l.Request;
 				l.Response.OutputStream.WriteByte (72);
-			}, port);
+			});
 
 			try {
 				var client = HttpClientTestHelpers.CreateHttpClient ();
-				var r = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/");
+				var r = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/Send_Content_Get/");
 				var response = client.SendAsync (r).Result;
 
 				Assert.AreEqual ("H", response.Content.ReadAsStringAsync ().Result);
@@ -1028,8 +1028,8 @@ namespace MonoTests.System.Net.Http
 #endif
 		public void Send_Content_BomEncoding ()
 		{
-			var port = NetworkHelpers.FindFreePort ();
-			var listener = CreateListener (l => {
+			var listener = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int port, "/Send_Content_BomEncoding/");
+			AddListenerContext (listener, l => {
 				var request = l.Request;
 
 				var str = l.Response.OutputStream;
@@ -1037,11 +1037,11 @@ namespace MonoTests.System.Net.Http
 				str.WriteByte (0xBB);
 				str.WriteByte (0xBF);
 				str.WriteByte (71);
-			}, port);
+			});
 
 			try {
 				var client = HttpClientTestHelpers.CreateHttpClient ();
-				var r = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/");
+				var r = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{port}/Send_Content_BomEncoding/");
 				var response = client.SendAsync (r).Result;
 
 				Assert.AreEqual ("G", response.Content.ReadAsStringAsync ().Result);
@@ -1057,17 +1057,17 @@ namespace MonoTests.System.Net.Http
 		public void Send_Content_Put ()
 		{
 			bool passed = false;
-			var port = NetworkHelpers.FindFreePort ();
-			var listener = CreateListener (l => {
+			var listener = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int port, "/Send_Content_Put/");
+			AddListenerContext (listener, l => {
 				var request = l.Request;
 				passed = 7 == request.ContentLength64;
 				passed &= request.ContentType == "text/plain; charset=utf-8";
 				passed &= request.InputStream.ReadByte () == 'm';
-			}, port);
+			});
 
 			try {
 				var client = HttpClientTestHelpers.CreateHttpClient ();
-				var r = new HttpRequestMessage (HttpMethod.Put, $"http://localhost:{port}/");
+				var r = new HttpRequestMessage (HttpMethod.Put, $"http://localhost:{port}/Send_Content_Put/");
 				r.Content = new StringContent ("my text");
 				var response = client.SendAsync (r).Result;
 
@@ -1087,19 +1087,19 @@ namespace MonoTests.System.Net.Http
 		{
 			bool passed = false;
 			var handler = HttpClientTestHelpers.CreateHttpClientHandler ();
-			var port = NetworkHelpers.FindFreePort ();
-			var listener = CreateListener (l => {
+			var listener = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int port, "/Send_Content_Put_CustomStream/");
+			AddListenerContext (listener, l => {
 				var request = l.Request;
 				if (HttpClientTestHelpers.IsSocketsHandler (handler))
 					passed = -1 == request.ContentLength64;
 				else
 					passed = 44 == request.ContentLength64;
 				passed &= request.ContentType == null;
-			}, port);
+			});
 
 			try {
 				var client = new HttpClient (handler);
-				var r = new HttpRequestMessage (HttpMethod.Put, $"http://localhost:{port}/");
+				var r = new HttpRequestMessage (HttpMethod.Put, $"http://localhost:{port}/Send_Content_Put_CustomStream/");
 				r.Content = new StreamContent (new CustomStream ());
 				var response = client.SendAsync (r).Result;
 
@@ -1195,8 +1195,8 @@ namespace MonoTests.System.Net.Http
 		public void Post_TransferEncodingChunked ()
 		{
 			bool? failed = null;
-			var port = NetworkHelpers.FindFreePort ();
-			var listener = CreateListener (l => {
+			var listener = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int port, "/Post_TransferEncodingChunked/");
+			AddListenerContext (listener, l => {
 				try {
 					var request = l.Request;
 
@@ -1224,7 +1224,7 @@ namespace MonoTests.System.Net.Http
 					failed = true;
 					Console.WriteLine (e);
 				}
-			}, port);
+			});
 
 			try {
 				var client = HttpClientTestHelpers.CreateHttpClient ();
@@ -1233,7 +1233,7 @@ namespace MonoTests.System.Net.Http
 
 				var imageContent = new StreamContent (new MemoryStream ());
 
-				var response = client.PostAsync ($"http://localhost:{port}/", imageContent).Result;
+				var response = client.PostAsync ($"http://localhost:{port}/Post_TransferEncodingChunked/", imageContent).Result;
 
 				Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, "#101");
 				Assert.AreEqual(false, failed, "#102");
@@ -1249,8 +1249,8 @@ namespace MonoTests.System.Net.Http
 		public void Post_StreamCaching ()
 		{
 			bool? failed = null;
-			var port = NetworkHelpers.FindFreePort ();
-			var listener = CreateListener (l => {
+			var listener = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int port, "/Post_StreamCaching/");
+			AddListenerContext (listener, l => {
 				try {
 					var request = l.Request;
 
@@ -1278,14 +1278,14 @@ namespace MonoTests.System.Net.Http
 					failed = true;
 					Console.WriteLine (e);
 				}
-			}, port);
+			});
 
 			try {
 				var client = HttpClientTestHelpers.CreateHttpClient ();
 
 				var imageContent = new StreamContent (new MemoryStream ());
 
-				var response = client.PostAsync ($"http://localhost:{port}/", imageContent).Result;
+				var response = client.PostAsync ($"http://localhost:{port}/Post_StreamCaching/", imageContent).Result;
 
 				Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, "#101");
 				Assert.AreEqual(false, failed, "#102");
@@ -1311,14 +1311,14 @@ namespace MonoTests.System.Net.Http
 				response.OutputStream.WriteByte (0x6f);
 			};
 
-			var port = NetworkHelpers.FindFreePort ();
-			var listener = CreateListener (context, port); // creates a default request handler
+			var listener = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int port, "/GetString_Many/");
+			AddListenerContext (listener, context);  // creates a default request handler
 			AddListenerContext (listener, context);  // add another request handler for the second request
 
 			try {
 				var client = HttpClientTestHelpers.CreateHttpClient ();
-				var t1 = client.GetStringAsync ($"http://localhost:{port}/");
-				var t2 = client.GetStringAsync ($"http://localhost:{port}/");
+				var t1 = client.GetStringAsync ($"http://localhost:{port}/GetString_Many/");
+				var t2 = client.GetStringAsync ($"http://localhost:{port}/GetString_Many/");
 				Assert.IsTrue (Task.WaitAll (new [] { t1, t2 }, WaitTimeout));
 				Assert.AreEqual ("hello", t1.Result, "#1");
 				Assert.AreEqual ("hello", t2.Result, "#2");
@@ -1334,17 +1334,17 @@ namespace MonoTests.System.Net.Http
 #endif
 		public void GetByteArray_ServerError ()
 		{
-			var port = NetworkHelpers.FindFreePort ();
-			var listener = CreateListener (l => {
+			var listener = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int port, "/GetByteArray_ServerError/");
+			AddListenerContext (listener, l => {
 				var response = l.Response;
 				response.StatusCode = 500;
 				l.Response.OutputStream.WriteByte (72);
-			}, port);
+			});
 
 			try {
 				var client = HttpClientTestHelpers.CreateHttpClient ();
 				try {
-					client.GetByteArrayAsync ($"http://localhost:{port}/").Wait (WaitTimeout);
+					client.GetByteArrayAsync ($"http://localhost:{port}/GetByteArray_ServerError/").Wait (WaitTimeout);
 					Assert.Fail ("#1");
 				} catch (AggregateException e) {
 					Assert.IsTrue (e.InnerException is HttpRequestException , "#2");
@@ -1360,14 +1360,14 @@ namespace MonoTests.System.Net.Http
 #endif
 		public void DisallowAutoRedirect ()
 		{
-			var port = NetworkHelpers.FindFreePort ();
-			var listener = CreateListener (l => {
+			var listener = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int port, "/DisallowAutoRedirect/");
+			AddListenerContext (listener, l => {
 				var request = l.Request;
 				var response = l.Response;
 				
 				response.StatusCode = (int)HttpStatusCode.Moved;
 				response.RedirectLocation = "http://xamarin.com/";
-			}, port);
+			});
 
 			try {
 				var chandler = HttpClientTestHelpers.CreateHttpClientHandler ();
@@ -1375,7 +1375,7 @@ namespace MonoTests.System.Net.Http
 				var client = new HttpClient (chandler);
 
 				try {
-					client.GetStringAsync ($"http://localhost:{port}/").Wait (WaitTimeout);
+					client.GetStringAsync ($"http://localhost:{port}/DisallowAutoRedirect/").Wait (WaitTimeout);
 					Assert.Fail ("#1");
 				} catch (AggregateException e) {
 					Assert.IsTrue (e.InnerException is HttpRequestException, "#2");
@@ -1392,18 +1392,18 @@ namespace MonoTests.System.Net.Http
 #endif
 		public void RequestUriAfterRedirect ()
 		{
-			var port = NetworkHelpers.FindFreePort ();
-			var redirectPort = NetworkHelpers.FindFreePort ();
+			var listener = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int port, "/RequestUriAfterRedirect/");
+			var listener2 = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int redirectPort, "/RequestUriAfterRedirect/");
 
-			var listener = CreateListener (l => {
+			AddListenerContext (listener, l => {
 				var request = l.Request;
 				var response = l.Response;
 
 				response.StatusCode = (int)HttpStatusCode.Moved;
-				response.RedirectLocation = $"http://localhost:{redirectPort}/";
-			}, port);
+				response.RedirectLocation = $"http://localhost:{redirectPort}/RequestUriAfterRedirect/";
+			});
 
-			var listener2 = CreateListener (l => {
+			AddListenerContext (listener2, l => {
 				var response = l.Response;
 
 				response.StatusCode = (int)HttpStatusCode.OK;
@@ -1412,17 +1412,17 @@ namespace MonoTests.System.Net.Http
 				response.OutputStream.WriteByte (0x6c);
 				response.OutputStream.WriteByte (0x6c);
 				response.OutputStream.WriteByte (0x6f);
-			}, redirectPort);
+			});
 
 			try {
 				var chandler = HttpClientTestHelpers.CreateHttpClientHandler ();
 				chandler.AllowAutoRedirect = true;
 				var client = new HttpClient (chandler);
 
-				var r = client.GetAsync ($"http://localhost:{port}/");
+				var r = client.GetAsync ($"http://localhost:{port}/RequestUriAfterRedirect/");
 				Assert.IsTrue (r.Wait (WaitTimeout), "#1");
 				var resp = r.Result;
-				Assert.AreEqual ($"http://localhost:{redirectPort}/", resp.RequestMessage.RequestUri.AbsoluteUri, "#2");
+				Assert.AreEqual ($"http://localhost:{redirectPort}/RequestUriAfterRedirect/", resp.RequestMessage.RequestUri.AbsoluteUri, "#2");
 				Assert.AreEqual ("hello", resp.Content.ReadAsStringAsync ().Result, "#3");
 			} finally {
 				listener.Abort ();
@@ -1445,15 +1445,15 @@ namespace MonoTests.System.Net.Http
 			chandler.AllowAutoRedirect = true;
 			var client = new HttpClient (chandler, true);
 
-			var port = NetworkHelpers.FindFreePort ();
-			var listener = CreateListener (l => {
+			var listener = NetworkHelpers.CreateAndStartHttpListener("http://*:", out int port, "/ModifyHandlerAfterFirstRequest/");
+			AddListenerContext (listener, l => {
 				var response = l.Response;
 				response.StatusCode = 200;
 				response.OutputStream.WriteByte (55);
-			}, port);
+			});
 
 			try {
-				client.GetStringAsync ($"http://localhost:{port}/").Wait (WaitTimeout);
+				client.GetStringAsync ($"http://localhost:{port}/ModifyHandlerAfterFirstRequest/").Wait (WaitTimeout);
 				try {
 					chandler.AllowAutoRedirect = false;
 					Assert.Fail ("#1");
@@ -1514,17 +1514,7 @@ namespace MonoTests.System.Net.Http
 		}
 #endif
 
-		HttpListener CreateListener (Action<HttpListenerContext> contextAssert, int port)
-		{
-			var l = new HttpListener ();
-			l.Prefixes.Add (string.Format ("http://*:{0}/", port));
-			l.Start ();
-			AddListenerContext(l, contextAssert);
-
-			return l;
-		}
-
-		HttpListener AddListenerContext (HttpListener l, Action<HttpListenerContext> contextAssert)
+		void AddListenerContext (HttpListener l, Action<HttpListenerContext> contextAssert)
 		{
 			l.BeginGetContext (ar => {
 				var ctx = l.EndGetContext (ar);
@@ -1536,8 +1526,6 @@ namespace MonoTests.System.Net.Http
 					ctx.Response.Close ();
 				}
 			}, null);
-
-			return l;
 		}
 	}
 }


### PR DESCRIPTION
It was missed in https://github.com/mono/mono/pull/11829 so we were still manually creating HttpListeners which are not hardened against "Address already in use".

Should fix/improve https://github.com/xamarin/maccore/issues/1407.
