### PR TITLE
Pass X509Certificate2 to the certificate validator.

### DIFF
--- a/mcs/class/Mono.Btls.Interface/Mono.Btls.Interface/BtlsProvider.cs
+++ b/mcs/class/Mono.Btls.Interface/Mono.Btls.Interface/BtlsProvider.cs
@@ -55,12 +55,12 @@ namespace Mono.Btls.Interface
 
 		public static X509Certificate2 CreateCertificate2 (byte[] data, BtlsX509Format format, bool disallowFallback = false)
 		{
-			return MonoBtlsProvider.CreateCertificate2 (data, (MonoBtlsX509Format)format);
+			return MonoBtlsProvider.CreateCertificate (data, (MonoBtlsX509Format)format);
 		}
 
 		public static X509Certificate2 CreateCertificate2 (byte[] data, string password, bool disallowFallback = false)
 		{
-			return MonoBtlsProvider.CreateCertificate2 (data, password);
+			return MonoBtlsProvider.CreateCertificate (data, password);
 		}
 
 		public static BtlsX509Chain CreateNativeChain ()

--- a/mcs/class/System/Mono.AppleTls/AppleTlsContext.cs
+++ b/mcs/class/System/Mono.AppleTls/AppleTlsContext.cs
@@ -50,7 +50,7 @@ namespace Mono.AppleTls
 		SafeSecIdentityHandle serverIdentity;
 		SafeSecIdentityHandle clientIdentity;
 
-		X509Certificate remoteCertificate;
+		X509Certificate2 remoteCertificate;
 		X509Certificate localClientCertificate;
 		MonoTlsConnectionInfo connectionInfo;
 		bool isAuthenticated;
@@ -247,7 +247,7 @@ namespace Mono.AppleTls
 
 			bool ok;
 			SecTrust trust = null;
-			X509CertificateCollection certificates = null;
+			X509Certificate2Collection certificates = null;
 
 			try {
 				trust = GetPeerTrust (!IsServer);
@@ -261,11 +261,11 @@ namespace Mono.AppleTls
 					if (trust.Count > 1)
 						Debug ("WARNING: Got multiple certificates in SecTrust!");
 
-					certificates = new X509CertificateCollection ();
+					certificates = new X509Certificate2Collection ();
 					for (int i = 0; i < trust.Count; i++)
 						certificates.Add (trust.GetCertificate (i));
 
-					remoteCertificate = new X509Certificate (certificates [0]);
+					remoteCertificate = new X509Certificate2 (certificates [0]);
 					Debug ("Got peer trust: {0}", remoteCertificate);
 				}
 
@@ -395,7 +395,7 @@ namespace Mono.AppleTls
 			get { return localClientCertificate; }
 		}
 
-		public override X509Certificate RemoteCertificate {
+		public override X509Certificate2 RemoteCertificate {
 			get { return remoteCertificate; }
 		}
 

--- a/mcs/class/System/Mono.AppleTls/Trust.cs
+++ b/mcs/class/System/Mono.AppleTls/Trust.cs
@@ -115,7 +115,7 @@ namespace Mono.AppleTls {
 		[DllImport (AppleTlsContext.SecurityLibrary)]
 		extern static IntPtr /* SecCertificateRef */ SecTrustGetCertificateAtIndex (IntPtr /* SecTrustRef */ trust, IntPtr /* CFIndex */ ix);
 
-		internal X509Certificate GetCertificate (int index)
+		internal X509Certificate2 GetCertificate (int index)
 		{
 			if (handle == IntPtr.Zero)
 				throw new ObjectDisposedException ("SecTrust");
@@ -124,7 +124,7 @@ namespace Mono.AppleTls {
 
 			var ptr = SecTrustGetCertificateAtIndex (handle, (IntPtr)index);
 			var impl = new X509CertificateImplApple (ptr, false);
-			return new X509Certificate (impl);
+			return new X509Certificate2 (impl);
 		}
 
 		[DllImport (AppleTlsContext.SecurityLibrary)]

--- a/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsContext.cs
@@ -49,7 +49,7 @@ namespace Mono.Btls
 {
 	class MonoBtlsContext : MNS.MobileTlsContext, IMonoBtlsBioMono
 	{
-		X509Certificate remoteCertificate;
+		X509Certificate2 remoteCertificate;
 		X509Certificate clientCertificate;
 		X509CertificateImplBtls nativeServerCertificate;
 		X509CertificateImplBtls nativeClientCertificate;
@@ -463,7 +463,7 @@ namespace Mono.Btls
 		internal override X509Certificate LocalClientCertificate {
 			get { return clientCertificate; }
 		}
-		public override X509Certificate RemoteCertificate {
+		public override X509Certificate2 RemoteCertificate {
 			get { return remoteCertificate; }
 		}
 		public override TlsProtocols NegotiatedProtocol {

--- a/mcs/class/System/Mono.Btls/MonoBtlsProvider.cs
+++ b/mcs/class/System/Mono.Btls/MonoBtlsProvider.cs
@@ -430,31 +430,24 @@ namespace Mono.Btls
 #endif
 		}
 
-		public static X509Certificate CreateCertificate (byte[] data, MonoBtlsX509Format format)
-		{
-			using (var impl = new X509CertificateImplBtls (data, format)) {
-				return new X509Certificate (impl);
-			}
-		}
-
-		public static X509Certificate2 CreateCertificate2 (byte[] data, MonoBtlsX509Format format)
+		public static X509Certificate2 CreateCertificate (byte[] data, MonoBtlsX509Format format)
 		{
 			using (var impl = new X509CertificateImplBtls (data, format)) {
 				return new X509Certificate2 (impl);
 			}
 		}
 
-		public static X509Certificate2 CreateCertificate2 (byte[] data, string password, bool disallowFallback = false)
+		public static X509Certificate2 CreateCertificate (byte[] data, string password, bool disallowFallback = false)
 		{
 			using (var handle = new SafePasswordHandle (password))
 			using (var impl = new X509CertificateImplBtls (data, handle, X509KeyStorageFlags.DefaultKeySet))
 				return new X509Certificate2 (impl);
 		}
 
-		public static X509Certificate CreateCertificate (MonoBtlsX509 x509)
+		public static X509Certificate2 CreateCertificate (MonoBtlsX509 x509)
 		{
 			using (var impl = new X509CertificateImplBtls (x509))
-				return new X509Certificate (impl);
+				return new X509Certificate2 (impl);
 		}
 
 		public static X509Chain CreateChain ()

--- a/mcs/class/System/Mono.Net.Security/MobileTlsContext.cs
+++ b/mcs/class/System/Mono.Net.Security/MobileTlsContext.cs
@@ -156,7 +156,7 @@ namespace Mono.Net.Security
 			get;
 		}
 
-		public abstract X509Certificate RemoteCertificate {
+		public abstract X509Certificate2 RemoteCertificate {
 			get;
 		}
 
@@ -174,13 +174,13 @@ namespace Mono.Net.Security
 
 		public abstract bool PendingRenegotiation ();
 
-		protected bool ValidateCertificate (X509Certificate leaf, X509Chain chain)
+		protected bool ValidateCertificate (X509Certificate2 leaf, X509Chain chain)
 		{
 			var result = certificateValidator.ValidateCertificate (TargetHost, IsServer, leaf, chain);
 			return result != null && result.Trusted && !result.UserDenied;
 		}
 
-		protected bool ValidateCertificate (X509CertificateCollection certificates)
+		protected bool ValidateCertificate (X509Certificate2Collection certificates)
 		{
 			var result = certificateValidator.ValidateCertificate (TargetHost, IsServer, certificates);
 			return result != null && result.Trusted && !result.UserDenied;

--- a/mcs/class/System/Mono/SystemCertificateProvider.cs
+++ b/mcs/class/System/Mono/SystemCertificateProvider.cs
@@ -159,16 +159,15 @@ namespace Mono
 			if (cert.Impl == null)
 				return null;
 
-			X509Certificate2Impl impl = null;
+			var impl = cert.Impl as X509Certificate2Impl;
+			if (impl != null)
+				return (X509Certificate2Impl)impl.Clone ();
+
 			if ((importFlags & CertificateImportFlags.DisableNativeBackend) == 0) {
 				impl = X509Pal.Import (cert);
 				if (impl != null)
 					return impl;
 			}
-
-			impl = cert.Impl as X509Certificate2Impl;
-			if (impl != null)
-				return (X509Certificate2Impl)impl.Clone ();
 
 			if ((importFlags & CertificateImportFlags.DisableAutomaticFallback) != 0)
 				return null;


### PR DESCRIPTION
This makes us consistent with corefx; see also https://github.com/dotnet/corefx/pull/35306.

Using `X509Certificate` has become a problem because the `HttpClientHandler.ServerCertificateCustomValidationCallback` callback takes an `X509Certificate2` argument.