### PR TITLE
[2018-10] [bitcode] round up value type size for slot calculation

### DIFF
--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -2368,17 +2368,22 @@ mono_arch_get_llvm_call_info (MonoCompile *cfg, MonoMethodSignature *sig)
 		case RegTypeFP:
 			lainfo->storage = LLVMArgNormal;
 			break;
-		case RegTypeStructByVal:
+		case RegTypeStructByVal: {
 			lainfo->storage = LLVMArgAsIArgs;
-			if (eabi_supported && ainfo->align == 8) {
-				/* LLVM models this by passing an int64 array */
-				lainfo->nslots = ALIGN_TO (ainfo->struct_size, 8) / 8;
-				lainfo->esize = 8;
-			} else {
-				lainfo->nslots = ainfo->struct_size / sizeof (target_mgreg_t);
-				lainfo->esize = 4;
-			}
+			int slotsize;
+#ifdef TARGET_WATCHOS
+			/* slotsize=4 would work for armv7k, however arm64_32 allows
+			 * passing structs with sizes up to 8 bytes in a single register.
+			 * On armv7k slotsize=8 boils down to the same generated native
+			 * code by LLVM, so it's okay. */
+			slotsize = 8;
+#else
+			slotsize = eabi_supported && ainfo->align == 8 ? 8 : 4;
+#endif
+			lainfo->nslots = ALIGN_TO (ainfo->struct_size, slotsize) / slotsize;
+			lainfo->esize = slotsize;
 			break;
+		}
 		case RegTypeStructByAddr:
 		case RegTypeStructByAddrOnStack:
 			lainfo->storage = LLVMArgVtypeByRef;


### PR DESCRIPTION
consider

```csharp
struct S3
{
    public ushort X;
    public ushort Y;
    public ushort Z;
}
```
this would be 3 * 2 = 6 bytes. Structs, however, are passed around as i32
arrays in LLVM IR between functions. Those, if such a struct is passed, are
split to `int32`s depending on the struct's size. The previous calulation was
wrongly reserving one such i32 slot instead of two for `S3` above.

Additionally increase slot size to i64 so that it aligns with a
slightly different ABI on arm64_32.


Fixes https://github.com/mono/mono/issues/8486

@rolfbjarne I've tested it on a arm64_32 device, please confirm that this fixes the issue on your armv7k device as well

Backport of #12992.

/cc @lewurm 