### PR TITLE
[crash] Move dump_memory_around_ip after the native crash

### DIFF
--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -1154,9 +1154,9 @@ mono_dump_native_crash_info (const char *signal, void *ctx, MONO_SIG_HANDLER_INF
 {
 	print_process_map ();
 
-	dump_memory_around_ip (ctx);
-
 	dump_native_stacktrace (signal, ctx);
+
+	dump_memory_around_ip (ctx);
 }
 
 void


### PR DESCRIPTION
If someone jumps to a bogus address for some reason, the dump_memory_around_ip function will double-fault. On OSX, a double fault is often a hang. 

Moving this after the mission-critical reporting is helpful here. 