### PR TITLE
Add temporary workaround for internal StreamContent constructor.

### DIFF
--- a/mcs/class/System.Net.Http/StreamContent.Mono.cs
+++ b/mcs/class/System.Net.Http/StreamContent.Mono.cs
@@ -1,0 +1,19 @@
+using System.IO;
+using System.Threading;
+
+namespace System.Net.Http
+{
+	partial class StreamContent
+	{
+		//
+		// Workarounds for poor .NET API
+		// Instead of having SerializeToStreamAsync with CancellationToken as public API. Only LoadIntoBufferAsync
+		// called internally from the send worker can be cancelled and user cannot see/do it
+		//
+		[Obsolete ("FIXME: Please talk to Martin about this; see https://github.com/mono/mono/issues/12996.")]
+		internal StreamContent (Stream content, CancellationToken cancellationToken)
+			: this (content)
+		{
+		}
+	}
+}

--- a/mcs/class/System.Net.Http/System.Net.Http.csproj
+++ b/mcs/class/System.Net.Http/System.Net.Http.csproj
@@ -604,6 +604,7 @@
             <Compile Include="HttpClientHandler.cs" />
             <Compile Include="IMonoHttpClientHandler.cs" />
             <Compile Include="MonoWebRequestHandler.cs" />
+            <Compile Include="StreamContent.Mono.cs" />
             <Compile Include="corefx\NetEventSource.Http.cs" />
             <Compile Include="corefx\SocketsHttpHandler.Mono.cs" />
           </ItemGroup>
@@ -718,6 +719,7 @@
             <Compile Include="HttpClientHandler.cs" />
             <Compile Include="IMonoHttpClientHandler.cs" />
             <Compile Include="MonoWebRequestHandler.cs" />
+            <Compile Include="StreamContent.Mono.cs" />
             <Compile Include="corefx\NetEventSource.Http.cs" />
             <Compile Include="corefx\SocketsHttpHandler.Mono.cs" />
           </ItemGroup>
@@ -832,6 +834,7 @@
             <Compile Include="HttpClientHandler.cs" />
             <Compile Include="IMonoHttpClientHandler.cs" />
             <Compile Include="MonoWebRequestHandler.cs" />
+            <Compile Include="StreamContent.Mono.cs" />
             <Compile Include="corefx\NetEventSource.Http.cs" />
             <Compile Include="corefx\SocketsHttpHandler.Mono.cs" />
           </ItemGroup>

--- a/mcs/class/System.Net.Http/unix_net_4_x_System.Net.Http.dll.sources
+++ b/mcs/class/System.Net.Http/unix_net_4_x_System.Net.Http.dll.sources
@@ -5,6 +5,7 @@ HttpClientHandler.cs
 HttpClientHandler.SocketsHandler.cs
 IMonoHttpClientHandler.cs
 MonoWebRequestHandler.cs
+StreamContent.Mono.cs
 
 ../corlib/System.Diagnostics/Debug.cs
 


### PR DESCRIPTION
This is a temporary workaround and not a final solution.  Please read my detailed comment in https://github.com/mono/mono/issues/12996#issuecomment-464142887 for details.