### PR TITLE
[profiler] Do not print that many new lines

### DIFF
--- a/mono/profiler/aot.c
+++ b/mono/profiler/aot.c
@@ -57,12 +57,12 @@ prof_shutdown (MonoProfiler *prof);
 static void
 usage (void)
 {
-	mono_profiler_printf ("AOT profiler.\n");
+	mono_profiler_printf ("AOT profiler.");
 	mono_profiler_printf ("Usage: mono --profile=aot[:OPTION1[,OPTION2...]] program.exe\n");
-	mono_profiler_printf ("Options:\n");
-	mono_profiler_printf ("\thelp                 show this usage info\n");
-	mono_profiler_printf ("\toutput=FILENAME      write the data to file FILENAME\n");
-	mono_profiler_printf ("\tverbose              print diagnostic info\n");
+	mono_profiler_printf ("Options:");
+	mono_profiler_printf ("\thelp                 show this usage info");
+	mono_profiler_printf ("\toutput=FILENAME      write the data to file FILENAME");
+	mono_profiler_printf ("\tverbose              print diagnostic info");
 
 	exit (0);
 }
@@ -395,7 +395,7 @@ add_method (MonoProfiler *prof, MonoMethod *m)
 	g_free (s);
 
 	if (prof->verbose)
-		mono_profiler_printf ("%s %d\n", mono_method_full_name (m, 1), id);
+		mono_profiler_printf ("%s %d", mono_method_full_name (m, 1), id);
 }
 
 /* called at the end of the program */


### PR DESCRIPTION
The `mono_profiler_printf` already adds `\n` char, so we don't need to
add them in most cases.

Before the fix the output of aot profiler with verbose enabled looked
like:

    02-19 10:50:02.877 22795 22815 I mono-prof: System.OutOfMemoryException:.ctor (string) 2
    02-19 10:50:02.877 22795 22815 I mono-prof:
    02-19 10:50:02.877 22795 22815 I mono-prof: System.SystemException:.ctor (string) 4
    02-19 10:50:02.877 22795 22815 I mono-prof:
    02-19 10:50:02.877 22795 22815 I mono-prof: System.Exception:.ctor (string) 6
    02-19 10:50:02.877 22795 22815 I mono-prof:
    02-19 10:50:02.877 22795 22815 I mono-prof: System.Exception:.cctor () 7
    02-19 10:50:02.877 22795 22815 I mono-prof:
    ...

The `usage ()` output should now look similar to other profilers
usage output.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
