### PR TITLE
[mkbundle] Fix mapping length

### DIFF
--- a/mono/utils/mono-mmap-windows.c
+++ b/mono/utils/mono-mmap-windows.c
@@ -158,7 +158,13 @@ mono_file_map_error (size_t length, int flags, int fd, guint64 offset, void **re
 	const char *failed_function = NULL;
 
 	// The size of the mapping is the maximum file offset to map.
+	//
 	// It is not, as you might expect, the maximum view size to be mapped from it.
+	//
+	// If it were the maximum view size, the size parameter would have just
+	// been one DWORD in 32bit Windows, expanded to SIZE_T in 64bit Windows.
+	// It is 64bits even on 32bit Windows to allow large files.
+	//
 	// See https://docs.microsoft.com/en-us/windows/desktop/Memory/creating-a-file-mapping-object.
 	const guint64 mapping_length = offset + length;
 

--- a/mono/utils/mono-mmap-windows.c
+++ b/mono/utils/mono-mmap-windows.c
@@ -143,6 +143,16 @@ mono_file_map_error (size_t length, int flags, int fd, guint64 offset, void **re
 	HANDLE mapping = NULL;
 	int const prot = mono_mmap_win_prot_from_flags (flags);
 	/* translate the flags */
+	/*if (flags & MONO_MMAP_PRIVATE)
+		mflags |= MAP_PRIVATE;
+	if (flags & MONO_MMAP_SHARED)
+		mflags |= MAP_SHARED;
+	if (flags & MONO_MMAP_ANON)
+		mflags |= MAP_ANONYMOUS;
+	if (flags & MONO_MMAP_FIXED)
+		mflags |= MAP_FIXED;
+	if (flags & MONO_MMAP_32BIT)
+		mflags |= MAP_32BIT;*/
 	int const mflags = (flags & MONO_MMAP_WRITE) ? FILE_MAP_COPY : FILE_MAP_READ;
 	HANDLE const file = (HANDLE)_get_osfhandle (fd);
 	const char *failed_function = NULL;

--- a/mono/utils/mono-mmap-windows.c
+++ b/mono/utils/mono-mmap-windows.c
@@ -158,6 +158,7 @@ mono_file_map_error (size_t length, int flags, int fd, guint64 offset, void **re
 	const char *failed_function = NULL;
 
 	// The size of the mapping is the maximum file offset to map.
+	// It is not, as you might expect, the maximum view size to be mapped from it.
 	// See https://docs.microsoft.com/en-us/windows/desktop/Memory/creating-a-file-mapping-object.
 	const guint64 mapping_length = offset + length;
 

--- a/mono/utils/mono-mmap-windows.c
+++ b/mono/utils/mono-mmap-windows.c
@@ -142,6 +142,7 @@ mono_file_map_error (size_t length, int flags, int fd, guint64 offset, void **re
 	void *ptr = NULL;
 	HANDLE mapping = NULL;
 	int const prot = mono_mmap_win_prot_from_flags (flags);
+	/* translate the flags */
 	int const mflags = (flags & MONO_MMAP_WRITE) ? FILE_MAP_COPY : FILE_MAP_READ;
 	HANDLE const file = (HANDLE)_get_osfhandle (fd);
 	const char *failed_function = NULL;


### PR DESCRIPTION
When I tried it, I got a different error.

The size of the mapping is the maximum file offset to map.
See https://docs.microsoft.com/en-us/windows/desktop/Memory/creating-a-file-mapping-object.

If in the debugger you simulate this fix, it gets further.

Here is a small program to exercise and see the behavior:

```
// include <windows.h>
// include <stdio.h>
// include <stdlib.h>
//
// int main()
// {
//  // Create a 128K file.
//
//  HANDLE file = CreateFile("1", GENERIC_READ | GENERIC_WRITE, 0, 0, CREATE_ALWAYS, 0, 0);
//  printf("createfile %p %d\n", file, GetLastError());
//
//  HANDLE map = CreateFileMapping(file, 0, PAGE_READWRITE, 0, 1 << 17, 0);
//  printf("createmap %p %d\n", map, GetLastError());
//
//  CloseHandle(map);
//  CloseHandle(file);
//  system("dir");
//
//  // Attempt to map the second 64K of the 128K file, with a 64K mapping.
//
//  file = CreateFile("1", GENERIC_READ | GENERIC_WRITE, 0, 0, OPEN_EXISTING, 0, 0);
//  printf("createfile %p %d\n", file, GetLastError());
//
//  map = CreateFileMapping(file, 0, PAGE_READWRITE, 0, 1 << 16, 0);
//  printf("createmap %p %d\n", map, GetLastError());
//
//   // This fails.
//
//  PVOID view = MapViewOfFile(map, FILE_MAP_WRITE, 0, 1 << 16, 1 << 16);
//  printf("view %p %d\n", view, GetLastError());
//
//  CloseHandle(map);
//
//  // Use a 128K mapping instead. It works.
//
//  map = CreateFileMapping(file, 0, PAGE_READWRITE, 0, 1 << 17, 0);
//  printf("createmap %p %d\n", map, GetLastError());
//
//  view = MapViewOfFile(map, FILE_MAP_WRITE, 0, 1 << 16, 1 << 16);
//  printf("view %p %d\n", view, GetLastError());
// }
```

Here is debugging mono and simulating the fix in the debugger (I did not build or test
the fix):

```

\bin\amd64\cdb C:\Users\jaykrell\Downloads\output\output.exe

0:000> bm kernel*!*createfilemap*
0:000> g

Breakpoint 2 hit
KERNELBASE!CreateFileMappingW:
00007ffd`0a449de0 4883ec48        sub     rsp,48h
0:000> dv
                  hFile = 0x00000000`00000200
lpFileMappingAttributes = 0x00000000`00000000
              flProtect = 2
      dwMaximumSizeHigh = 0
       dwMaximumSizeLow = 0x477000
                 lpName = 0x00000000`00000000 ""

0:000> bm kern*!*mapviewoffile*
0:000> g
Breakpoint 38 hit
KERNEL32!MapViewOfFileStub:
00007ffd`0b09bfa0 48ff2591c10500  jmp     qword ptr [KERNEL32!_imp_MapViewOfFile (00007ffd`0b0f8138)] ds:00007ffd`0b0f8138={KERNELBASE!MapViewOfFile (00007ffd`0a465ad0)}
0:000> dv
  hFileMappingObject = 0x00000000`00000204
     dwDesiredAccess = 4
    dwFileOffsetHigh = 0
     dwFileOffsetLow = 0x30000
dwNumberOfBytesToMap = 0x477000
0:000> gu
0:000> r rax
rax=0000000000000000
0:000> !gle
LastErrorValue: (Win32) 0x5 (5) - Access is denied.
LastStatusValue: (NTSTATUS) 0xc000001f - {Invalid Mapping}  An attempt was made to create a view for a section which is bigger than the section.

0:000> .restart
0:000> bm kernel*!*createfilemap*
0:000> g
0:000> dv
                  hFile = 0x00000000`00000220
lpFileMappingAttributes = 0x00000000`00000000
              flProtect = 2
      dwMaximumSizeHigh = 0
       dwMaximumSizeLow = 0x477000
                 lpName = 0x00000000`00000000 ""
0:000> ?? dwMaximumSizeLow += 0x30000
unsigned long 0x4a7000
0:000> bc *
0:000> g
Corlib not in sync with this runtime: The runtime did not find the mscorlib.dll it expected. Expected interface version CA4932AE-2294-4ECD-B863-BF98FDD84F33 but found 0CC970F6-6F25-4218-9427-3E4C3DC8DE33. Check that your runtime and class libraries are matching.
Loaded from: mscorlib.dll
Download a newer corlib or a newer runtime at http://www.mono-project.com/download.

```

Furthermore, it can be reasoned, that if this was the maximum view size,
it would be one DWORD parameter originally, later redefined as SIZE_T.
There'd be no need for 64bits of size on a 32bit system.

Fixes https://github.com/mono/mono/issues/11643