### PR TITLE
[2018-10] Fix InvalidCastException when building ASP MVC 5 project with RazorGenerator

### DIFF
--- a/mcs/class/System.Web/System.Web.Configuration_2.0/WebConfigurationHost.cs
+++ b/mcs/class/System.Web/System.Web.Configuration_2.0/WebConfigurationHost.cs
@@ -272,7 +272,8 @@ namespace System.Web.Configuration
 		{
 			string path = NormalizeVirtualPath (virtualPath);
 			
-			foreach (VirtualDirectoryMapping mapping in map.VirtualDirectories) {
+			for (int j = 0; j < map.VirtualDirectories.Count; j++) {
+				VirtualDirectoryMapping mapping = map.VirtualDirectories.Get(j);
 				if (path.StartsWith (mapping.VirtualDirectory)) {
 					int i = mapping.VirtualDirectory.Length;
 					if (path.Length == i) {


### PR DESCRIPTION
`WebConfigurationFileMap.VirtualDirectories` is of `VirtualDirectoryMappingCollection` type and inherits from `NameObjectCollectionBase`. 
Its default enumerator returns `string` keys but the logic in `WebConfigurationHost.MapPathFromMapper` method expects  `VirtualDirectoryMapping` values.

This is a minimal repro:
```
using System.Web.Configuration;

class Program
{

    static void Main()
    {
        WebConfigurationFileMap map = new WebConfigurationFileMap();
        map.VirtualDirectories.Add("/some", new VirtualDirectoryMapping("/some", true));

        // This crashes with InvalidCastException
        //foreach (VirtualDirectoryMapping m in map.VirtualDirectories)
        //{
        //    var a = m.VirtualDirectory;
        //}

        // This works
        for (int i = 0; i < map.VirtualDirectories.Count; i++)
        {
            var a = map.VirtualDirectories.Get(i).VirtualDirectory;
        }
    }
}
```
So I used `for` loop to access collection item values.
As a test I've built sample project from related issue and run it on xsp4 server.

Fixes https://github.com/mono/mono/issues/12955


Backport of #13063.

/cc @marek-safar @MaximLipnin