### PR TITLE
Don't install jay as part of make install.

### DIFF
--- a/mcs/jay/Makefile
+++ b/mcs/jay/Makefile
@@ -3,6 +3,7 @@ SUBDIRS :=
 include ../build/rules.make
 
 LOCAL_CFLAGS = -DSKEL_DIRECTORY=\""$(prefix)/share/jay"\"
+NO_INSTALL = yes
 
 sources = closure.c error.c lalr.c lr0.c main.c mkpar.c output.c reader.c \
           symtab.c verbose.c warshall.c
@@ -14,11 +15,11 @@ DISTFILES = $(datafiles) $(sources) jay.1 $(wildcard *.h) jay.vcxproj
 
 all-local: jay
 
-install-local: jay
+install-local:
 uninstall-local:
 
 ifndef NO_INSTALL
-install-local:
+install-local: jay
 	$(MKINSTALLDIRS) $(DESTDIR)$(prefix)/bin
 	$(MKINSTALLDIRS) $(DESTDIR)$(prefix)/share/jay
 	$(MKINSTALLDIRS) $(DESTDIR)$(prefix)/share/man/man1


### PR DESCRIPTION
Jay should not be part of the package and cause issues on Windows 32-bit cygwin build since it's not using makefile generated by autotools. When make install is run it will build jay one more time, but picking up
cygwin default gcc compiler instead of the one used in configure step, mingw. That cause link errors since the object files are not rebuild, only relinked with different linker, causing errors.
