### PR TITLE
[runtime] Remove dead code

### DIFF
--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1625,38 +1625,7 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 			ADD_CODE (td, MINT_LDIND_I);
 			ADD_CODE (td, csignature->param_count);
 		} else {
-			if (m_class_is_valuetype (target_method->klass)) {
-				/* Own method */
-			} else {
-				/* Interface method */
-				int ioffset, slot;
-
-				mono_class_setup_vtable (constrained_class);
-				ioffset = mono_class_interface_offset (constrained_class, target_method->klass);
-				if (ioffset == -1)
-					g_error ("type load error: constrained_class");
-				slot = mono_method_get_vtable_slot (target_method);
-				if (slot == -1)
-					g_error ("type load error: target_method->klass");
-				target_method = m_class_get_vtable (constrained_class) [ioffset + slot];
-
-				if (target_method->klass == mono_defaults.enum_class) {
-					if ((td->sp - csignature->param_count - 1)->type == STACK_TYPE_MP) {
-						/* managed pointer on the stack, we need to deref that puppy */
-						ADD_CODE (td, MINT_LDIND_I);
-						ADD_CODE (td, csignature->param_count);
-					}
-					if (mint_type (m_class_get_byval_arg (constrained_class)) == MINT_TYPE_VT) {
-						ADD_CODE (td, MINT_BOX_VT);
-						ADD_CODE (td, get_data_item_index (td, constrained_class));
-						ADD_CODE (td, csignature->param_count | ((td->sp - 1 - csignature->param_count)->type != STACK_TYPE_MP ? 0 : BOX_NOT_CLEAR_VT_SP));
-					} else {
-						ADD_CODE (td, MINT_BOX);
-						ADD_CODE (td, get_data_item_index (td, constrained_class));
-						ADD_CODE (td, csignature->param_count);
-					}
-				}
-			}
+			g_assert (m_class_is_valuetype (target_method->klass));
 			is_virtual = FALSE;
 		}
 	}

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -5708,31 +5708,7 @@ handle_constrained_call (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignat
 		ins->type = STACK_OBJ;
 		sp [0] = ins;
 	} else {
-		if (m_class_is_valuetype (cmethod->klass)) {
-			/* Own method */
-		} else {
-			/* Interface method */
-			int ioffset, slot;
-
-			mono_class_setup_vtable (constrained_class);
-			CHECK_TYPELOAD (constrained_class);
-			ioffset = mono_class_interface_offset (constrained_class, cmethod->klass);
-			if (ioffset == -1)
-				TYPE_LOAD_ERROR (constrained_class);
-			slot = mono_method_get_vtable_slot (cmethod);
-			if (slot == -1)
-				TYPE_LOAD_ERROR (cmethod->klass);
-			cmethod = m_class_get_vtable (constrained_class) [ioffset + slot];
-			*ref_cmethod = cmethod;
-
-			if (cmethod->klass == mono_defaults.enum_class) {
-				/* Enum implements some interfaces, so treat this as the first case */
-				EMIT_NEW_LOAD_MEMBASE_TYPE (cfg, ins, m_class_get_byval_arg (constrained_class), sp [0]->dreg, 0);
-				ins->klass = constrained_class;
-				sp [0] = mini_emit_box (cfg, ins, constrained_class, mono_class_check_context_used (constrained_class));
-				CHECK_CFG_EXCEPTION;
-			}
-		}
+		g_assert (m_class_is_valuetype (cmethod->klass));
 		*ref_virtual = FALSE;
 	}
 


### PR DESCRIPTION
Interface method calls on constrained types are resolved in get_method_constrained now (apparently since https://github.com/mono/mono/commit/3259e04ace67552fc8d63a8f1ddbb830e526f05f)