### PR TITLE
[ci] Prefer gmake over make for SDKs build

### DIFF
--- a/mcs/build/library.make
+++ b/mcs/build/library.make
@@ -387,5 +387,5 @@ ifneq ($(RESX_STRINGS),)
 endif
 
 update-corefx-sr: $(RESX_RESOURCE_STRING) $(XTEST_RESX_RESOURCE_STRING)
-	make SR_OUTPUT=corefx/SR.cs RESX_STRINGS="$(RESX_RESOURCE_STRING)" RESX_EXTRA_ARGUMENTS="$(RESX_EXTRA_ARGUMENTS)" update-corefx-sr-generic \
-	&& make SR_OUTPUT=corefx/SR.tests.cs RESX_STRINGS=$(XTEST_RESX_RESOURCE_STRING) update-corefx-sr-generic
+	$(MAKE) SR_OUTPUT=corefx/SR.cs RESX_STRINGS="$(RESX_RESOURCE_STRING)" RESX_EXTRA_ARGUMENTS="$(RESX_EXTRA_ARGUMENTS)" update-corefx-sr-generic \
+	&& $(MAKE) SR_OUTPUT=corefx/SR.tests.cs RESX_STRINGS=$(XTEST_RESX_RESOURCE_STRING) update-corefx-sr-generic

--- a/mcs/build/tests.make
+++ b/mcs/build/tests.make
@@ -210,7 +210,7 @@ MKBUNDLE_EXE = $(topdir)/class/lib/$(PROFILE)/mkbundle.exe
 TEST_ASSEMBLIES:=$(sort $(patsubst .//%,%,$(filter-out %.exe.static %.dll.dll %.exe.dll %bare% %plaincore% %secxml% %Facades% %ilasm%,$(filter %.dll,$(wildcard $(topdir)/class/lib/$(PROFILE)/tests/*)))))
 
 $(MKBUNDLE_EXE): $(topdir)/tools/mkbundle/mkbundle.cs
-	make -C $(topdir)/tools/mkbundle
+	$(MAKE) -C $(topdir)/tools/mkbundle
 
 mkbundle-all-tests:
 	$(Q_AOT) $(MAKE) -C $(topdir)/class do-test

--- a/mcs/class/corlib/Mono.Globalization.Unicode/Makefile
+++ b/mcs/class/corlib/Mono.Globalization.Unicode/Makefile
@@ -34,7 +34,7 @@ norm-test : $(NORM_TEST_TABLE) $(NORM_TEST).cs
 	$(RUNTIME) $(NORM_TEST).exe
 
 distclean :
-	make clean
+	$(MAKE) clean
 	rm $(UCA_TABLE) $(NORM_TABLE) $(CB_CLASS_TABLE) $(CP932_TABLE) $(DERIV_CORE_PROP_TABLE) $(SCRIPTS_TABLE) $(NORM_TEST_TABLE)
 
 clean : clean-collation clean-normalization clean-mscompat clean-normtest

--- a/mono/eglib/test/Makefile.am
+++ b/mono/eglib/test/Makefile.am
@@ -43,7 +43,7 @@ assertf_LDADD = ../libeglib.la $(LTLIBICONV)
 
 # Something amiss with subdirs ordering?
 ../libeglib.la: ../goutput.c # etc
-	make  -C .. $(@F)
+	$(MAKE)  -C .. $(@F)
 
 run-eglib: all
 	srcdir=`readlink -f $(srcdir)` ./test-eglib

--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -17,6 +17,7 @@ helix_set_env_vars
 helix_send_build_start_event "build/source/$MONO_HELIX_TYPE/"
 
 make_timeout=300m
+gnumake=$(which gmake || which gnumake || which make)
 
 if [[ ${CI_TAGS} == *'clang-sanitizer'* ]]; then
 	export CC="clang"
@@ -127,9 +128,9 @@ then
 fi
 
 if [[ ${CI_TAGS} == *'sdks-llvm'* ]]; then
-	${TESTCMD} --label=archive --timeout=120m --fatal make -j ${CI_CPU_COUNT} --output-sync=recurse --trace -C sdks/builds archive-llvm-llvm{,win}{32,64} NINJA=
+	${TESTCMD} --label=archive --timeout=120m --fatal $gnumake -j ${CI_CPU_COUNT} --output-sync=recurse --trace -C sdks/builds archive-llvm-llvm{,win}{32,64} NINJA=
 	if [[ ${CI_TAGS} == *'osx-amd64'* ]]; then
-		${TESTCMD} --label=archive-llvm36 --timeout=60m --fatal make -j ${CI_CPU_COUNT} --output-sync=recurse --trace -C sdks/builds archive-llvm36-llvm32 NINJA=
+		${TESTCMD} --label=archive-llvm36 --timeout=60m --fatal $gnumake -j ${CI_CPU_COUNT} --output-sync=recurse --trace -C sdks/builds archive-llvm36-llvm32 NINJA=
 	fi
 	exit 0
 fi
@@ -152,27 +153,27 @@ if [[ ${CI_TAGS} == *'sdks-ios'* ]];
 
 	   export device_test_suites="Mono.Runtime.Tests System.Core"
 
-	   ${TESTCMD} --label=configure --timeout=180m --fatal make -j ${CI_CPU_COUNT} --output-sync=recurse --trace -C sdks/builds configure-ios NINJA=
-	   ${TESTCMD} --label=build     --timeout=180m --fatal make -j ${CI_CPU_COUNT} --output-sync=recurse --trace -C sdks/builds build-ios     NINJA=
-	   ${TESTCMD} --label=archive   --timeout=180m --fatal make -j ${CI_CPU_COUNT} --output-sync=recurse --trace -C sdks/builds archive-ios   NINJA=
+	   ${TESTCMD} --label=configure --timeout=180m --fatal $gnumake -j ${CI_CPU_COUNT} --output-sync=recurse --trace -C sdks/builds configure-ios NINJA=
+	   ${TESTCMD} --label=build     --timeout=180m --fatal $gnumake -j ${CI_CPU_COUNT} --output-sync=recurse --trace -C sdks/builds build-ios     NINJA=
+	   ${TESTCMD} --label=archive   --timeout=180m --fatal $gnumake -j ${CI_CPU_COUNT} --output-sync=recurse --trace -C sdks/builds archive-ios   NINJA=
 
         if [[ ${CI_TAGS} != *'no-tests'* ]]; then
-            ${TESTCMD} --label=run-sim --timeout=20m make -C sdks/ios run-ios-sim-all
-            ${TESTCMD} --label=build-ios-dev --timeout=60m make -C sdks/ios build-ios-dev-all
+            ${TESTCMD} --label=run-sim --timeout=20m $gnumake -C sdks/ios run-ios-sim-all
+            ${TESTCMD} --label=build-ios-dev --timeout=60m $gnumake -C sdks/ios build-ios-dev-all
             if [[ ${CI_TAGS} == *'run-device-tests'* ]]; then
-                for suite in ${device_test_suites}; do ${TESTCMD} --label=run-ios-dev-${suite} --timeout=10m make -C sdks/ios run-ios-dev-${suite}; done
+                for suite in ${device_test_suites}; do ${TESTCMD} --label=run-ios-dev-${suite} --timeout=10m $gnumake -C sdks/ios run-ios-dev-${suite}; done
             fi
-            ${TESTCMD} --label=build-ios-dev-llvm --timeout=60m make -C sdks/ios build-ios-dev-llvm-all
+            ${TESTCMD} --label=build-ios-dev-llvm --timeout=60m $gnumake -C sdks/ios build-ios-dev-llvm-all
             if [[ ${CI_TAGS} == *'run-device-tests'* ]]; then
-                for suite in ${device_test_suites}; do ${TESTCMD} --label=run-ios-dev-llvm-${suite} --timeout=10m make -C sdks/ios run-ios-dev-${suite}; done
+                for suite in ${device_test_suites}; do ${TESTCMD} --label=run-ios-dev-llvm-${suite} --timeout=10m $gnumake -C sdks/ios run-ios-dev-${suite}; done
             fi
-            ${TESTCMD} --label=build-ios-dev-interp-only --timeout=60m make -C sdks/ios build-ios-dev-interp-only-all
+            ${TESTCMD} --label=build-ios-dev-interp-only --timeout=60m $gnumake -C sdks/ios build-ios-dev-interp-only-all
             if [[ ${CI_TAGS} == *'run-device-tests'* ]]; then
-                for suite in ${device_test_suites}; do ${TESTCMD} --label=run-ios-dev-interp-only-${suite} --timeout=10m make -C sdks/ios run-ios-dev-${suite}; done
+                for suite in ${device_test_suites}; do ${TESTCMD} --label=run-ios-dev-interp-only-${suite} --timeout=10m $gnumake -C sdks/ios run-ios-dev-${suite}; done
             fi
-            ${TESTCMD} --label=build-ios-dev-interp-mixed --timeout=60m make -C sdks/ios build-ios-dev-interp-mixed-all
+            ${TESTCMD} --label=build-ios-dev-interp-mixed --timeout=60m $gnumake -C sdks/ios build-ios-dev-interp-mixed-all
             if [[ ${CI_TAGS} == *'run-device-tests'* ]]; then
-                for suite in ${device_test_suites}; do ${TESTCMD} --label=run-ios-dev-interp-mixed-${suite} --timeout=10m make -C sdks/ios run-ios-dev-${suite}; done
+                for suite in ${device_test_suites}; do ${TESTCMD} --label=run-ios-dev-interp-mixed-${suite} --timeout=10m $gnumake -C sdks/ios run-ios-dev-${suite}; done
             fi
         fi
 	   exit 0
@@ -194,33 +195,33 @@ if [[ ${CI_TAGS} == *'sdks-android'* ]];
 
         # For some very strange reasons, `make -C sdks/android accept-android-license` get stuck when invoked through ${TESTCMD}
         # but doesn't get stuck when called via the shell, so let's just call it here now.
-        ${TESTCMD} --label=provision-android --timeout=120m --fatal make -j ${CI_CPU_COUNT} -C sdks/builds provision-android && make -C sdks/android accept-android-license
-        ${TESTCMD} --label=provision-mxe --timeout=240m --fatal make -j ${CI_CPU_COUNT} -C sdks/builds provision-mxe
+        ${TESTCMD} --label=provision-android --timeout=120m --fatal $gnumake -j ${CI_CPU_COUNT} -C sdks/builds provision-android && $gnumake -C sdks/android accept-android-license
+        ${TESTCMD} --label=provision-mxe --timeout=240m --fatal $gnumake -j ${CI_CPU_COUNT} -C sdks/builds provision-mxe
 
-        ${TESTCMD} --label=configure --timeout=180m --fatal make -j ${CI_CPU_COUNT} --output-sync=recurse --trace -C sdks/builds configure-android NINJA= IGNORE_PROVISION_ANDROID=1 IGNORE_PROVISION_MXE=1
-        ${TESTCMD} --label=build     --timeout=180m --fatal make -j ${CI_CPU_COUNT} --output-sync=recurse --trace -C sdks/builds build-android     NINJA= IGNORE_PROVISION_ANDROID=1 IGNORE_PROVISION_MXE=1
-        ${TESTCMD} --label=archive   --timeout=180m --fatal make -j ${CI_CPU_COUNT} --output-sync=recurse --trace -C sdks/builds archive-android   NINJA= IGNORE_PROVISION_ANDROID=1 IGNORE_PROVISION_MXE=1
+        ${TESTCMD} --label=configure --timeout=180m --fatal $gnumake -j ${CI_CPU_COUNT} --output-sync=recurse --trace -C sdks/builds configure-android NINJA= IGNORE_PROVISION_ANDROID=1 IGNORE_PROVISION_MXE=1
+        ${TESTCMD} --label=build     --timeout=180m --fatal $gnumake -j ${CI_CPU_COUNT} --output-sync=recurse --trace -C sdks/builds build-android     NINJA= IGNORE_PROVISION_ANDROID=1 IGNORE_PROVISION_MXE=1
+        ${TESTCMD} --label=archive   --timeout=180m --fatal $gnumake -j ${CI_CPU_COUNT} --output-sync=recurse --trace -C sdks/builds archive-android   NINJA= IGNORE_PROVISION_ANDROID=1 IGNORE_PROVISION_MXE=1
 
         if [[ ${CI_TAGS} != *'no-tests'* ]]; then
-            ${TESTCMD} --label=mini --timeout=60m make -C sdks/android check-mini
-            ${TESTCMD} --label=corlib --timeout=60m make -C sdks/android check-corlib
-            ${TESTCMD} --label=System --timeout=60m make -C sdks/android check-System
-            ${TESTCMD} --label=System.Core --timeout=60m make -C sdks/android check-System.Core
-            ${TESTCMD} --label=System.Data --timeout=60m make -C sdks/android check-System.Data
-            ${TESTCMD} --label=System.IO.Compression.FileSystem --timeout=60m make -C sdks/android check-System.IO.Compression.FileSystem
-            ${TESTCMD} --label=System.IO.Compression --timeout=60m make -C sdks/android check-System.IO.Compression
-            ${TESTCMD} --label=System.Json --timeout=60m make -C sdks/android check-System.Json
-            ${TESTCMD} --label=System.Net.Http --timeout=60m make -C sdks/android check-System.Net.Http
-            ${TESTCMD} --label=System.Numerics --timeout=60m make -C sdks/android check-System.Numerics
-            ${TESTCMD} --label=System.Runtime.Serialization --timeout=60m make -C sdks/android check-System.Runtime.Serialization
-            ${TESTCMD} --label=System.ServiceModel.Web --timeout=60m make -C sdks/android check-System.ServiceModel.Web
-            ${TESTCMD} --label=System.Transactions --timeout=60m make -C sdks/android check-System.Transactions
-            ${TESTCMD} --label=System.Xml --timeout=60m make -C sdks/android check-System.Xml
-            ${TESTCMD} --label=System.Xml.Linq --timeout=60m make -C sdks/android check-System.Xml.Linq
-            ${TESTCMD} --label=Mono.CSharp --timeout=60m make -C sdks/android check-Mono.CSharp
-            ${TESTCMD} --label=Mono.Data.Sqlite --timeout=60m make -C sdks/android check-Mono.Data.Sqlite
-            ${TESTCMD} --label=Mono.Data.Tds --timeout=60m make -C sdks/android check-Mono.Data.Tds
-            ${TESTCMD} --label=Mono.Security --timeout=60m make -C sdks/android check-Mono.Security
+            ${TESTCMD} --label=mini --timeout=60m $gnumake -C sdks/android check-mini
+            ${TESTCMD} --label=corlib --timeout=60m $gnumake -C sdks/android check-corlib
+            ${TESTCMD} --label=System --timeout=60m $gnumake -C sdks/android check-System
+            ${TESTCMD} --label=System.Core --timeout=60m $gnumake -C sdks/android check-System.Core
+            ${TESTCMD} --label=System.Data --timeout=60m $gnumake -C sdks/android check-System.Data
+            ${TESTCMD} --label=System.IO.Compression.FileSystem --timeout=60m $gnumake -C sdks/android check-System.IO.Compression.FileSystem
+            ${TESTCMD} --label=System.IO.Compression --timeout=60m $gnumake -C sdks/android check-System.IO.Compression
+            ${TESTCMD} --label=System.Json --timeout=60m $gnumake -C sdks/android check-System.Json
+            ${TESTCMD} --label=System.Net.Http --timeout=60m $gnumake -C sdks/android check-System.Net.Http
+            ${TESTCMD} --label=System.Numerics --timeout=60m $gnumake -C sdks/android check-System.Numerics
+            ${TESTCMD} --label=System.Runtime.Serialization --timeout=60m $gnumake -C sdks/android check-System.Runtime.Serialization
+            ${TESTCMD} --label=System.ServiceModel.Web --timeout=60m $gnumake -C sdks/android check-System.ServiceModel.Web
+            ${TESTCMD} --label=System.Transactions --timeout=60m $gnumake -C sdks/android check-System.Transactions
+            ${TESTCMD} --label=System.Xml --timeout=60m $gnumake -C sdks/android check-System.Xml
+            ${TESTCMD} --label=System.Xml.Linq --timeout=60m $gnumake -C sdks/android check-System.Xml.Linq
+            ${TESTCMD} --label=Mono.CSharp --timeout=60m $gnumake -C sdks/android check-Mono.CSharp
+            ${TESTCMD} --label=Mono.Data.Sqlite --timeout=60m $gnumake -C sdks/android check-Mono.Data.Sqlite
+            ${TESTCMD} --label=Mono.Data.Tds --timeout=60m $gnumake -C sdks/android check-Mono.Data.Tds
+            ${TESTCMD} --label=Mono.Security --timeout=60m $gnumake -C sdks/android check-Mono.Security
         fi
         exit 0
 fi
@@ -241,32 +242,32 @@ if [[ ${CI_TAGS} == *'webassembly'* ]] || [[ ${CI_TAGS} == *'wasm'* ]];
 	   export aot_test_suites="System.Core"
 	   export mixed_test_suites="System.Core"
 
-	   ${TESTCMD} --label=provision --timeout=20m --fatal make --output-sync=recurse --trace -C sdks/builds provision-wasm
+	   ${TESTCMD} --label=provision --timeout=20m --fatal $gnumake --output-sync=recurse --trace -C sdks/builds provision-wasm
 
-	   ${TESTCMD} --label=configure --timeout=180m --fatal make -j ${CI_CPU_COUNT} --output-sync=recurse --trace -C sdks/builds configure-wasm NINJA=
-	   ${TESTCMD} --label=build     --timeout=180m --fatal make -j ${CI_CPU_COUNT} --output-sync=recurse --trace -C sdks/builds build-wasm     NINJA=
-	   ${TESTCMD} --label=archive   --timeout=180m --fatal make -j ${CI_CPU_COUNT} --output-sync=recurse --trace -C sdks/builds archive-wasm   NINJA=
+	   ${TESTCMD} --label=configure --timeout=180m --fatal $gnumake -j ${CI_CPU_COUNT} --output-sync=recurse --trace -C sdks/builds configure-wasm NINJA=
+	   ${TESTCMD} --label=build     --timeout=180m --fatal $gnumake -j ${CI_CPU_COUNT} --output-sync=recurse --trace -C sdks/builds build-wasm     NINJA=
+	   ${TESTCMD} --label=archive   --timeout=180m --fatal $gnumake -j ${CI_CPU_COUNT} --output-sync=recurse --trace -C sdks/builds archive-wasm   NINJA=
 
         if [[ ${CI_TAGS} != *'no-tests'* ]]; then
-            ${TESTCMD} --label=wasm-build --timeout=60m --fatal make -j ${CI_CPU_COUNT} -C sdks/wasm build
-            ${TESTCMD} --label=ch-mini-test --timeout=60m make -C sdks/wasm run-ch-mini
-            ${TESTCMD} --label=v8-mini-test --timeout=60m make -C sdks/wasm run-v8-mini
-            ${TESTCMD} --label=sm-mini-test --timeout=60m make -C sdks/wasm run-sm-mini
-            ${TESTCMD} --label=jsc-mini-test --timeout=60m make -C sdks/wasm run-jsc-mini
+            ${TESTCMD} --label=wasm-build --timeout=60m --fatal $gnumake -j ${CI_CPU_COUNT} -C sdks/wasm build
+            ${TESTCMD} --label=ch-mini-test --timeout=60m $gnumake -C sdks/wasm run-ch-mini
+            ${TESTCMD} --label=v8-mini-test --timeout=60m $gnumake -C sdks/wasm run-v8-mini
+            ${TESTCMD} --label=sm-mini-test --timeout=60m $gnumake -C sdks/wasm run-sm-mini
+            ${TESTCMD} --label=jsc-mini-test --timeout=60m $gnumake -C sdks/wasm run-jsc-mini
             #The following tests are not passing yet, so enabling them would make us perma-red
-            #${TESTCMD} --label=mini-corlib --timeout=60m make -C sdks/wasm run-all-corlib
-            #${TESTCMD} --label=mini-system --timeout=60m make -C sdks/wasm run-all-system
-            ${TESTCMD} --label=ch-system-core --timeout=60m make -C sdks/wasm run-ch-system-core
-            ${TESTCMD} --label=v8-system-core --timeout=60m make -C sdks/wasm run-v8-system-core
-            ${TESTCMD} --label=sm-system-core --timeout=60m make -C sdks/wasm run-sm-system-core
-            ${TESTCMD} --label=jsc-system-core --timeout=60m make -C sdks/wasm run-jsc-system-core
-            ${TESTCMD} --label=v8-corlib --timeout=60m make -C sdks/wasm run-v8-corlib
-            ${TESTCMD} --label=aot-mini --timeout=60m make -j ${CI_CPU_COUNT} -C sdks/wasm run-aot-mini
-            ${TESTCMD} --label=build-aot-all --timeout=60m make -j ${CI_CPU_COUNT} -C sdks/wasm build-aot-all
-            for suite in ${aot_test_suites}; do ${TESTCMD} --label=run-aot-${suite} --timeout=10m make -C sdks/wasm run-aot-${suite}; done
-            for suite in ${mixed_test_suites}; do ${TESTCMD} --label=run-aot-mixed-${suite} --timeout=10m make -C sdks/wasm run-aot-mixed-${suite}; done
-            #${TESTCMD} --label=check-aot --timeout=60m make -C sdks/wasm check-aot
-            ${TESTCMD} --label=package --timeout=60m make -C sdks/wasm package
+            #${TESTCMD} --label=mini-corlib --timeout=60m $gnu$gnumake -C sdks/wasm run-all-corlib
+            #${TESTCMD} --label=mini-system --timeout=60m $gnu$gnumake -C sdks/wasm run-all-system
+            ${TESTCMD} --label=ch-system-core --timeout=60m $gnumake -C sdks/wasm run-ch-system-core
+            ${TESTCMD} --label=v8-system-core --timeout=60m $gnumake -C sdks/wasm run-v8-system-core
+            ${TESTCMD} --label=sm-system-core --timeout=60m $gnumake -C sdks/wasm run-sm-system-core
+            ${TESTCMD} --label=jsc-system-core --timeout=60m $gnumake -C sdks/wasm run-jsc-system-core
+            ${TESTCMD} --label=v8-corlib --timeout=60m $gnumake -C sdks/wasm run-v8-corlib
+            ${TESTCMD} --label=aot-mini --timeout=60m $gnumake -j ${CI_CPU_COUNT} -C sdks/wasm run-aot-mini
+            ${TESTCMD} --label=build-aot-all --timeout=60m $gnumake -j ${CI_CPU_COUNT} -C sdks/wasm build-aot-all
+            for suite in ${aot_test_suites}; do ${TESTCMD} --label=run-aot-${suite} --timeout=10m $gnumake -C sdks/wasm run-aot-${suite}; done
+            for suite in ${mixed_test_suites}; do ${TESTCMD} --label=run-aot-mixed-${suite} --timeout=10m $gnumake -C sdks/wasm run-aot-mixed-${suite}; done
+            #${TESTCMD} --label=check-aot --timeout=60m $gnumake -C sdks/wasm check-aot
+            ${TESTCMD} --label=package --timeout=60m $gnumake -C sdks/wasm package
         fi
 	   exit 0
 fi

--- a/sdks/ios/Makefile
+++ b/sdks/ios/Makefile
@@ -55,10 +55,10 @@ test-runner.exe: test-runner/runner.cs
 	csc /out:$@ -r:$(BCL_DIR)/nunitlite.dll -r:$(BCL_DIR)/Mono.Security.dll test-runner/runner.cs
 
 runtime/runtime:
-	make -C runtime
+	$(MAKE) -C runtime
 
 runtime/libmonoios.a:
-	make -C runtime
+	$(MAKE) -C runtime
 
 # Build % from assemblies %_ASSEMBLIES
 # The end result is in bin/ios-sim/test-%.app
@@ -134,26 +134,26 @@ clean:
 	$(RM) -rf bin obj *.exe *.log aot-cache
 
 run-ios-sim-all:
-	for suite in $(TEST_SUITES); do make build-ios-sim-$$suite || exit 1; make run-ios-sim-$$suite || exit 1; done
+	for suite in $(TEST_SUITES); do $(MAKE) build-ios-sim-$$suite || exit 1; $(MAKE) run-ios-sim-$$suite || exit 1; done
 
 build-ios-dev-all:
 	rm -rf aot-cache
-	for suite in $(TEST_SUITES); do make clean-ios-dev-$$suite; make build-ios-dev-$$suite ENABLE_AOT_CACHE=1 || exit 1; done
+	for suite in $(TEST_SUITES); do $(MAKE) clean-ios-dev-$$suite; $(MAKE) build-ios-dev-$$suite ENABLE_AOT_CACHE=1 || exit 1; done
 
 build-ios-dev-llvm-all:
 	rm -rf aot-cache
-	for suite in $(TEST_SUITES); do echo "*** $$suite ***"; make clean-ios-dev-$$suite; make build-ios-dev-$$suite LLVM=1 ENABLE_AOT_CACHE=1 || exit 1; done
+	for suite in $(TEST_SUITES); do echo "*** $$suite ***"; $(MAKE) clean-ios-dev-$$suite; $(MAKE) build-ios-dev-$$suite LLVM=1 ENABLE_AOT_CACHE=1 || exit 1; done
 
 build-ios-dev-interp-only-all:
 	rm -rf aot-cache
-	for suite in $(TEST_SUITES); do echo "*** $$suite ***"; make clean-ios-dev-$$suite; make build-ios-dev-$$suite INTERP_ONLY=1 ENABLE_AOT_CACHE=1 || exit 1; done
+	for suite in $(TEST_SUITES); do echo "*** $$suite ***"; $(MAKE) clean-ios-dev-$$suite; $(MAKE) build-ios-dev-$$suite INTERP_ONLY=1 ENABLE_AOT_CACHE=1 || exit 1; done
 
 build-ios-dev-interp-mixed-all:
 	rm -rf aot-cache
-	for suite in $(TEST_SUITES); do echo "*** $$suite ***"; make clean-ios-dev-$$suite; make build-ios-dev-$$suite INTERP_MIXED=1 ENABLE_AOT_CACHE=1 || exit 1; done
+	for suite in $(TEST_SUITES); do echo "*** $$suite ***"; $(MAKE) clean-ios-dev-$$suite; $(MAKE) build-ios-dev-$$suite INTERP_MIXED=1 ENABLE_AOT_CACHE=1 || exit 1; done
 
 run-ios-dev-all:
-	for suite in $(TEST_SUITES); do make run-ios-dev-$$suite || exit 1; done
+	for suite in $(TEST_SUITES); do $(MAKE) run-ios-dev-$$suite || exit 1; done
 
 # Developer targets, ignore
 # 'launch' doesn't propagate the error code

--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -238,7 +238,7 @@ build-aot-all: build
 	$(MAKE) $(patsubst %,build-aot-%,$(AOT_TEST_SUITES))
 
 run-aot-all: build-aot-all
-	for suite in System.Core; do make run-aot-$$suite || exit 1; done
+	for suite in System.Core; do $(MAKE) run-aot-$$suite || exit 1; done
 
 build-debug-sample: .stamp-build-debug-sample
 
@@ -268,10 +268,10 @@ run-sm-%: toolchain build-test-suite
 
 # Leaving JSC for now cuz it aborts when it encounters wasm
 run-all-%:
-	make -C . run-ch-$*
-	make -C . run-v8-$*
-	make -C . run-sm-$*
-	make -C . run-jsc-$*
+	$(MAKE) -C . run-ch-$*
+	$(MAKE) -C . run-v8-$*
+	$(MAKE) -C . run-sm-$*
+	$(MAKE) -C . run-jsc-$*
 
 run-browser-tests: $(BROWSER_TEST)/.stamp-browser-test-suite
 	(cd $(BROWSER_TEST) && npm test)


### PR DESCRIPTION
Apple's `make` doesn't support the `--output-sync` option and Homebrew's `make` is installed as `gmake`.

Also fixed a few places in the repo where we directly invoked make instead of $(MAKE).
