### PR TITLE
Try to extract valid drive name from DriveInfo ctor string argument

### DIFF
--- a/mcs/class/corlib/System.IO/DriveInfo.cs
+++ b/mcs/class/corlib/System.IO/DriveInfo.cs
@@ -55,11 +55,11 @@ namespace System.IO {
 			}
 
 			DriveInfo [] drives = GetDrives ();
+			Array.Sort (drives, (DriveInfo di1, DriveInfo di2) => String.Compare (di2.path, di1.path, true));
 			foreach (DriveInfo d in drives){
-				if (d.path == driveName){
+				if (driveName.StartsWith (d.path, StringComparison.OrdinalIgnoreCase)){
 					this.path = d.path;
 					this.drive_format = d.drive_format;
-					this.path = d.path;
 					return;
 				}
 			}

--- a/mcs/class/corlib/System.IO/DriveInfo.cs
+++ b/mcs/class/corlib/System.IO/DriveInfo.cs
@@ -56,14 +56,16 @@ namespace System.IO {
 
 			DriveInfo [] drives = GetDrives ();
 			Array.Sort (drives, (DriveInfo di1, DriveInfo di2) => String.Compare (di2.path, di1.path, true));
+			var sb = new StringBuilder($"driveName: {driveName}; available drives: ");
 			foreach (DriveInfo d in drives){
+				sb.Append($"{d.path}, ");
 				if (driveName.StartsWith (d.path, StringComparison.OrdinalIgnoreCase)){
 					this.path = d.path;
 					this.drive_format = d.drive_format;
 					return;
 				}
 			}
-			throw new ArgumentException ("The drive name does not exist", "driveName");
+			throw new ArgumentException ($"The drive name does not exist; {sb.ToString()}", "driveName");
 		}
 		
 		static void GetDiskFreeSpace (string path, out ulong availableFreeSpace, out ulong totalSize, out ulong totalFreeSpace)

--- a/mcs/class/corlib/System.IO/DriveInfo.cs
+++ b/mcs/class/corlib/System.IO/DriveInfo.cs
@@ -56,16 +56,14 @@ namespace System.IO {
 
 			DriveInfo [] drives = GetDrives ();
 			Array.Sort (drives, (DriveInfo di1, DriveInfo di2) => String.Compare (di2.path, di1.path, true));
-			var sb = new StringBuilder($"driveName: {driveName}; available drives: ");
 			foreach (DriveInfo d in drives){
-				sb.Append($"{d.path}, ");
 				if (driveName.StartsWith (d.path, StringComparison.OrdinalIgnoreCase)){
 					this.path = d.path;
 					this.drive_format = d.drive_format;
 					return;
 				}
 			}
-			throw new ArgumentException ($"The drive name does not exist; {sb.ToString()}", "driveName");
+			throw new ArgumentException ("The drive name does not exist", "driveName");
 		}
 		
 		static void GetDiskFreeSpace (string path, out ulong availableFreeSpace, out ulong totalSize, out ulong totalFreeSpace)

--- a/mcs/class/corlib/Test/System.IO/DriveInfoTest.cs
+++ b/mcs/class/corlib/Test/System.IO/DriveInfoTest.cs
@@ -54,7 +54,18 @@ namespace MonoTests.System.IO
 		[Test]
 		public void ConstructorThrowsOnNonExistingDrive ()
 		{
-			Assert.Throws<ArgumentException> (() => new DriveInfo ("/monodriveinfotest"));
+			Assert.Throws<ArgumentException> (() => new DriveInfo ("monodriveinfotest"));
+		}
+
+		[Test]
+		public void ConstructorGetsValidDriveFromNonDriveString ()
+		{
+			var tempPath = Path.GetTempPath ();
+			var drive = new DriveInfo (tempPath);
+			ValidateDriveInfo (drive);
+
+			drive = new DriveInfo (tempPath.ToUpper());
+			ValidateDriveInfo (drive);
 		}
 
 		[Test]

--- a/mcs/class/corlib/Test/System.IO/DriveInfoTest.cs
+++ b/mcs/class/corlib/Test/System.IO/DriveInfoTest.cs
@@ -58,8 +58,12 @@ namespace MonoTests.System.IO
 		}
 
 		[Test]
+		[Category ("NotWasm")] // it doesn't know about 'memfs' drive format
 		public void ConstructorGetsValidDriveFromNonDriveString ()
 		{
+			if (Environment.OSVersion.Platform != PlatformID.Win32NT && Environment.OSVersion.Platform != PlatformID.MacOSX)
+				Assert.Ignore ("Some Linux-hosted CI builders don't have '/' mounted, just testing Windows and MacOS for now.");			
+			
 			var tempPath = Path.GetTempPath ();
 			var drive = new DriveInfo (tempPath);
 			ValidateDriveInfo (drive);


### PR DESCRIPTION
It's possible to pass any string as an argument to DriveInfo ctor (e.g.  `new DriveInfo(Path.GetTempPath())`). Mono throws ArgumentException if there is no exactly the same drive name in the list of available drives.

I tried to handle this case by extracting any valid drive name from the array of available drives sorted by path in descending order.

Fixes https://github.com/mono/mono/issues/12157