### PR TITLE
[fsharp] Fix a type inference error introduced by recent changes

### DIFF
--- a/packaging/MacSDK/fsharp.py
+++ b/packaging/MacSDK/fsharp.py
@@ -12,7 +12,8 @@ class FsharpPackage(GitHubTarballPackage):
                              'patches/fsharp-string-switchName.patch',
                              'patches/fsharp-path-overloads.patch',
                              'patches/fsharp-debug-pinvoke-fix.patch',
-                             'patches/fsharp-IsPathRooted-type-inference.patch'])
+                             'patches/fsharp-IsPathRooted-type-inference.patch',
+                             'patches/fsharp-GetFileNameWithoutExtension-type-inference.patch'])
 
     def prep(self):
         Package.prep(self)

--- a/packaging/MacSDK/patches/fsharp-GetFileNameWithoutExtension-type-inference.patch
+++ b/packaging/MacSDK/patches/fsharp-GetFileNameWithoutExtension-type-inference.patch
@@ -1,0 +1,13 @@
+diff --git a/src/scripts/fssrgen.fsx b/src/scripts/fssrgen.fsx
+index 0bee9b79e..e6ceda11e 100644
+--- a/src/scripts/fssrgen.fsx
++++ b/src/scripts/fssrgen.fsx
+@@ -329,7 +329,7 @@ let StringBoilerPlate filename =
+     // END BOILERPLATE        
+ "            
+ 
+-let RunMain(filename, outFilename, outXmlFilenameOpt, projectNameOpt) =
++let RunMain(filename:string, outFilename, outXmlFilenameOpt, projectNameOpt) =
+     try
+         let justfilename = System.IO.Path.GetFileNameWithoutExtension(filename)
+         if justfilename |> Seq.exists (fun c -> not(System.Char.IsLetterOrDigit(c))) then


### PR DESCRIPTION
```
@/external/bockbuild/builds/fsharp-fsharp-6624925/src/scripts/fssrgen.fsx(334,28): error FS0041: A unique overload for method 'GetFileNameWithoutExtension' could not be determined based on type information prior to this program point.
A type annotation may be needed. Candidates: System.IO.Path.GetFileNameWithoutExtension(path: System.ReadOnlySpan<char>) : System.ReadOnlySpan<char>, System.IO.Path.GetFileNameWithoutExtension(path: string) : string
[@/external/bockbuild/builds/fsharp-fsharp-6624925/src/fsharp/FSharp.Build-proto/FSharp.Build-proto.fsproj]
```



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
