### PR TITLE
[2019-02] [loader] Fix off by 1 (netstandard is a framework facade)

### DIFF
--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -1055,7 +1055,7 @@ mono_assemblies_init (void)
 	assembly_remapping_table = g_hash_table_new (g_str_hash, g_str_equal);
 
 	int i;
-	for (i = 0; i < G_N_ELEMENTS (framework_assemblies) - 1; ++i)
+	for (i = 0; i < G_N_ELEMENTS (framework_assemblies); ++i)
 		g_hash_table_insert (assembly_remapping_table, (void*)framework_assemblies [i].assembly_name, (void*)&framework_assemblies [i]);
 
 #endif


### PR DESCRIPTION
Before 5e0d39a8a1268773656348a012a237164985dc5f, there used to be a handwritten binary search that traveersed `framework_assemblies` to determine if a given assembly was a framework assembly or not.  The binary search used `last = G_N_ELEMENTS (framework_assemblies) - 1` as the initial condition, but it used an inclusive `first <= last` as the loop count.

After we switched to a hashtable, we used the same final value initialize `assembly_remapping_table`.

We didn't notice because `mscorlib` used to be the last assembly in the table and `mscorlib` already has a ton of special handling in the loader.  But `netstandard` is not special.  So we added it to the table, but it still doesn't get special handling.

This should fix instances where code references netstandard 2.0.0.0, but we give it netstandard 2.1.0.0

https://github.com/mono/mono/blob/f8094319132d2d40f37e8cac6058e783b5648260/mono/metadata/assembly.c#L345


Backport of #13111.

/cc @marek-safar @lambdageek