### PR TITLE
Mono.CSharp is not included in winaot build causing test failure in full AOT.

### DIFF
--- a/mcs/class/Makefile
+++ b/mcs/class/Makefile
@@ -156,7 +156,8 @@ monotouch_tv_runtime_dirs := \
 winaot_dirs_parallel := \
 	$(mobile_common_dirs_parallel)	\
 	System.Drawing \
-	Mono.Simd
+	Mono.Simd \
+	Mono.CSharp
 
 unreal_dirs_parallel := \
 	$(mobile_common_dirs_parallel)	\


### PR DESCRIPTION
Since it is not included it won't be full AOT:ed as part of build and failing Mono.CSharp tests at a later point in time, since that won't do full AOT of assembly.
