### PR TITLE
Disable Mono.CSharp on Windows x64 full AOT test.

### DIFF
--- a/scripts/ci/run-test-winaot.sh
+++ b/scripts/ci/run-test-winaot.sh
@@ -25,7 +25,6 @@ else
     ${TESTCMD} --label=System.ServiceModel --timeout=15m make -w -C mcs/class/System.ServiceModel run-test
     ${TESTCMD} --label=System.ServiceModel.Web --timeout=5m make -w -C mcs/class/System.ServiceModel.Web run-test
     ${TESTCMD} --label=System.ComponentModel.DataAnnotations --timeout=5m make -w -C mcs/class/System.ComponentModel.DataAnnotations run-test
-    ${TESTCMD} --label=Mono.CSharp --timeout=5m make -w -C mcs/class/Mono.CSharp run-test
     ${TESTCMD} --label=System.Numerics --timeout=5m make -w -C mcs/class/System.Numerics run-test
     ${TESTCMD} --label=System.Net.Http --timeout=5m make -w -C mcs/class/System.Net.Http run-test
     ${TESTCMD} --label=System.Json --timeout=5m make -w -C mcs/class/System.Json run-test


### PR DESCRIPTION
Not part (and should not be) part of the winaot profile and therefore not testable (even though they pass when manually AOT:ing the assembly).
