### PR TITLE
[jit/cprop] insert dummy insn if first insn of basic block got replaced

### DIFF
--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -1986,6 +1986,13 @@ mono_local_emulate_ops (MonoCompile *cfg)
 					first_bb->in_count = first_bb->out_count = 0;
 					cfg->cbb = first_bb;
 
+					if (!saved_prev) {
+						/* first instruction of basic block got replaced, so create
+						 * dummy inst that points to start of basic block */
+						MONO_INST_NEW (cfg, saved_prev, OP_NOP);
+						saved_prev = bb->code;
+					}
+
 					/* ins is hanging, continue scanning the emitted code */
 					ins = saved_prev;
 				} else {

--- a/mono/mini/local-propagation.c
+++ b/mono/mini/local-propagation.c
@@ -780,6 +780,12 @@ mono_local_cprop (MonoCompile *cfg)
 				bb_opt->in_count = bb_opt->out_count = 0;
 				cfg->cbb = bb_opt;
 
+				if (!saved_prev) {
+					/* first instruction of basic block got replaced, so create
+					 * dummy inst that points to start of basic block */
+					MONO_INST_NEW (cfg, saved_prev, OP_NOP);
+					saved_prev = bb->code;
+				}
 				/* ins is hanging, continue scanning the emitted code */
 				ins = saved_prev;
 				continue;

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1009,7 +1009,8 @@ TESTS_IL_SRC=			\
 	ldfldvt.il \
 	newobj-abstract.il \
 	invalid-isbyreflike.il \
-	gh-13056_mono_local_cprop_av.il
+	gh-13056_mono_local_cprop_av.il \
+	gh-13057_mono_local_emulate_ops_av.il
 
 # This test crashes the runtime, even with recent fixes.
 #	incorrect-ldvirtftn-read-behind-for-dup.il

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1008,7 +1008,8 @@ TESTS_IL_SRC=			\
 	tailcall-valuetype-parameter.il \
 	ldfldvt.il \
 	newobj-abstract.il \
-	invalid-isbyreflike.il
+	invalid-isbyreflike.il \
+	gh-13056_mono_local_cprop_av.il
 
 # This test crashes the runtime, even with recent fixes.
 #	incorrect-ldvirtftn-read-behind-for-dup.il

--- a/mono/tests/gh-13056_mono_local_cprop_av.il
+++ b/mono/tests/gh-13056_mono_local_cprop_av.il
@@ -1,0 +1,15 @@
+.assembly mono_local_cprop_av {}
+.assembly extern mscorlib{auto}
+.class mono_local_cprop_av {
+.method static int32 Main() {
+ .entrypoint
+ .maxstack	12
+
+    ldc.i8 4
+    ldc.i8 2
+   cgt
+   ldc.i4 2
+  div
+ ret
+}
+}

--- a/mono/tests/gh-13057_mono_local_emulate_ops_av.il
+++ b/mono/tests/gh-13057_mono_local_emulate_ops_av.il
@@ -1,0 +1,20 @@
+.assembly mono_local_emulate_ops_av{}
+.assembly extern mscorlib{auto}
+.class mono_local_emulate_ops_av{
+.method static int32 Main() {
+.entrypoint
+.maxstack       32
+
+    ldc.r8 42.58279566
+
+Start_Orphan:
+    ldc.i8 33
+    ldc.i8 32
+   cgt
+  pop
+End_Orphan:
+
+   conv.ovf.i4
+  ret
+ }
+}

--- a/mono/tests/gh-13057_mono_local_emulate_ops_av.il
+++ b/mono/tests/gh-13057_mono_local_emulate_ops_av.il
@@ -15,6 +15,9 @@ Start_Orphan:
 End_Orphan:
 
    conv.ovf.i4
+   ldc.i4 42
+   sub
+   /* should be return code 0 */
   ret
  }
 }


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/13056 & https://github.com/mono/mono/issues/13057