### PR TITLE
If a ClientIdentity has no ClientProxy then return null from the accessor instead of throwing

### DIFF
--- a/mcs/class/corlib/System.Runtime.Remoting/Identity.cs
+++ b/mcs/class/corlib/System.Runtime.Remoting/Identity.cs
@@ -157,7 +157,7 @@ namespace System.Runtime.Remoting
 
 		public MarshalByRefObject ClientProxy
 		{
-			get	{ return (MarshalByRefObject) _proxyReference.Target; }
+			get	{ return (MarshalByRefObject) _proxyReference?.Target; }
 			set { _proxyReference = new WeakReference (value); }
 		}
 


### PR DESCRIPTION
Experimental partial fix for issue #13113. From looking at the code that uses this API, I don't think it's expected for it to throw in this scenario, and it's easy to end up with an instance that doesn't have a WR at all. The code using it seems to handle scenarios where the ClientProxy is null so I think this may be the correct way for the code to work.