### PR TITLE
Split `AppDomain.DoTypeResolve(object)` into two stongly-typed methods.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,7 +59,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # This line is parsed by tools besides autoconf, such as msvc/mono.winconfig.targets.
 # It should remain in the format they expect.
 #
-MONO_CORLIB_VERSION=4A9CEBCF-2544-4CB4-9F84-07A10C16BEEB
+MONO_CORLIB_VERSION=92351299-EECB-4E61-A590-39382BA4F7A0
 
 #
 # Put a quoted #define in config.h.

--- a/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
+++ b/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
@@ -6,6 +6,8 @@
 		<type fullname="System.AppDomain" preserve="fields">
 			<!-- appdomain.c: mono_domain_try_type_resolve -->
 			<method name="DoTypeResolve" />
+			<!-- appdomain.c: mono_domain_try_type_builder_resolve -->
+			<method name="DoTypeBuilderResolve" />
 			<!-- appdomain.c: mono_try_assembly_resolve -->
 			<method name="DoAssemblyResolve" />
 			<!-- appdomain.c: mono_domain_fire_assembly_load -->

--- a/mcs/class/corlib/System.Reflection.Emit/TypeBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/TypeBuilder.cs
@@ -791,7 +791,7 @@ namespace System.Reflection.Emit
 					if (!fb.IsStatic && (ft is TypeBuilder) && ft.IsValueType && (ft != this) && is_nested_in (ft)) {
 						TypeBuilder tb = (TypeBuilder)ft;
 						if (!tb.is_created) {
-							AppDomain.CurrentDomain.DoTypeResolve (tb);
+							AppDomain.CurrentDomain.DoTypeBuilderResolve (tb);
 							if (!tb.is_created) {
 								// FIXME: We should throw an exception here,
 								// but mcs expects that the type is created

--- a/mcs/class/corlib/System.Reflection.Emit/TypeBuilderInstantiation.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/TypeBuilderInstantiation.cs
@@ -83,12 +83,12 @@ namespace System.Reflection.Emit
 		// Called from the runtime to return the corresponding finished Type object
 		internal override Type RuntimeResolve ()
 		{
-			if (generic_type is TypeBuilder && !(generic_type as TypeBuilder).IsCreated ())
-				AppDomain.CurrentDomain.DoTypeResolve (generic_type);
+			if (generic_type is TypeBuilder type_builder && !type_builder.IsCreated ())
+				AppDomain.CurrentDomain.DoTypeBuilderResolve (type_builder);
 			for (int i = 0; i < type_arguments.Length; ++i) {
 				var t = type_arguments [i];
-				if (t is TypeBuilder && !(t as TypeBuilder).IsCreated ())
-					AppDomain.CurrentDomain.DoTypeResolve (t);
+				if (t is TypeBuilder tb && !tb.IsCreated ())
+					AppDomain.CurrentDomain.DoTypeBuilderResolve (tb);
 			}
 			return InternalResolve ();
 		}

--- a/mcs/class/corlib/System/AppDomain.cs
+++ b/mcs/class/corlib/System/AppDomain.cs
@@ -1338,19 +1338,20 @@ namespace System {
 			}
 		}
 
-		internal Assembly DoTypeResolve (Object name_or_tb)
+#if MONO_FEATURE_SRE
+		internal Assembly DoTypeBuilderResolve (TypeBuilder tb)
 		{
 			if (TypeResolve == null)
 				return null;
 
-			string name;
-
-#if MONO_FEATURE_SRE
-			if (name_or_tb is TypeBuilder)
-				name = ((TypeBuilder) name_or_tb).FullName;
-			else
+			return DoTypeResolve (tb.FullName);
+		}
 #endif
-				name = (string) name_or_tb;
+
+		internal Assembly DoTypeResolve (string name)
+		{
+			if (TypeResolve == null)
+				return null;
 
 			/* Prevent infinite recursion */
 			var ht = type_resolve_in_progress;

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -857,6 +857,29 @@ mono_class_get_appdomain_do_type_resolve_method (MonoError *error)
 }
 
 /**
+ * mono_class_get_appdomain_do_type_builder_resolve_method:
+ *
+ * This routine returns System.AppDomain.DoTypeBuilderResolve.
+ */
+static MonoMethod *
+mono_class_get_appdomain_do_type_builder_resolve_method (MonoError *error)
+{
+	static MonoMethod *method; // cache
+
+	if (method)
+		return method;
+
+	// not cached yet, fill cache under caller's lock
+
+	method = mono_class_get_method_from_name_checked (mono_class_get_appdomain_class (), "DoTypeBuilderResolve", -1, 0, error);
+
+	if (method == NULL)
+		g_warning ("%s method AppDomain.DoTypeBuilderResolve not found. %s\n", __func__, mono_error_get_message (error));
+
+	return method;
+}
+
+/**
  * mono_domain_try_type_resolve_name:
  * \param domain application domain in which to resolve the type
  * \param name the name of the type to resolve.
@@ -902,7 +925,7 @@ exit:
  * \param domain application domain in which to resolve the type
  * \param typebuilder A \c System.Reflection.Emit.TypeBuilder; typebuilder.FullName is the name of the type to resolve.
  *
- * This routine invokes the internal \c System.AppDomain.DoTypeResolve and returns
+ * This routine invokes the internal \c System.AppDomain.DoTypeBuilderResolve and returns
  * the assembly that matches typebuilder.FullName.
  *
  * \returns A \c MonoReflectionAssembly or NULL_HANDLE if not found
@@ -918,7 +941,7 @@ mono_domain_try_type_resolve_typebuilder (MonoDomain *domain, MonoReflectionType
 
 	error_init (error);
 
-	MonoMethod * const method = mono_class_get_appdomain_do_type_resolve_method (error);
+	MonoMethod * const method = mono_class_get_appdomain_do_type_builder_resolve_method (error);
 	goto_if_nok (error, return_null);
 
 	MonoAppDomainHandle appdomain;


### PR DESCRIPTION
* Instead of having one `AppDomain.DoTypeResolve(object)` that checks at runtime whether the argument is a `string` or a `TypeBuilder`, use two strongly-typed methods `DoTypeResolve(string)` and `DoTypeBuilderResolve(TypeBuilder)`.

* Add both to the `corlib/LinkerDescriptor/mscorlib.xml`.

* Adjust the code in `appdomain.c` accordingly.

* Bump corlib version.

This is part of a larger on-going project to improve the linker logic.

The rationale behind this is that the new `AppDomain.DoTypeResolve(string)` that is being called from `mono_domain_try_type_resolve_name()` should not reference `TypeBuilder`, to allow the linker to remove some of the `System.Reflection.Emit` types.