### PR TITLE
[2018-12] [aot] abort lookup early when a method isn\u0027t available in AOT image

### DIFF
--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -4108,6 +4108,11 @@ load_method (MonoDomain *domain, MonoAotModule *amodule, MonoImage *image, MonoM
 	}
 
 	if (!code) {
+		if (method_index < amodule->info.nmethods)
+			code = (guint8 *)amodule->methods [method_index];
+		else
+			return NULL;
+
 		/* JITted method */
 		if (amodule->methods [method_index] == GINT_TO_POINTER (-1)) {
 			if (mono_trace_is_traced (G_LOG_LEVEL_DEBUG, MONO_TRACE_AOT)) {
@@ -4126,11 +4131,6 @@ load_method (MonoDomain *domain, MonoAotModule *amodule, MonoImage *image, MonoM
 			}
 			return NULL;
 		}
-
-		if (method_index < amodule->info.nmethods)
-			code = (guint8 *)amodule->methods [method_index];
-		else
-			return NULL;
 	}
 
 	info = &amodule->blob [mono_aot_get_offset (amodule->method_info_offsets, method_index)];

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -4126,8 +4126,11 @@ load_method (MonoDomain *domain, MonoAotModule *amodule, MonoImage *image, MonoM
 			}
 			return NULL;
 		}
+
 		if (method_index < amodule->info.nmethods)
 			code = (guint8 *)amodule->methods [method_index];
+		else
+			return NULL;
 	}
 
 	info = &amodule->blob [mono_aot_get_offset (amodule->method_info_offsets, method_index)];


### PR DESCRIPTION
Mixed mode depends on that.  Usually, compile_method of mini takes care
to request only existing methods from the AOT image, but in some cases,
e.g. from a trampoline, AOT runtime is quiered directly.

Contributes to https://github.com/xamarin/xamarin-macios/issues/5618

Backport of #13138.

/cc @lewurm 