### PR TITLE
[runtime] Use FastCopy on multidimensional arrays

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -730,8 +730,14 @@ ves_icall_System_Array_FastCopy (MonoArrayHandle source, int source_idx, MonoArr
 	if (src_vtable->rank != dest_vtable->rank)
 		return FALSE;
 
-	if (MONO_HANDLE_GETVAL (source, bounds) || MONO_HANDLE_GETVAL (dest, bounds))
-		return FALSE;
+	MonoArrayBounds *source_bounds = MONO_HANDLE_GETVAL (source, bounds);
+	MonoArrayBounds *dest_bounds = MONO_HANDLE_GETVAL (dest, bounds);
+
+	for (int i = 0; i < src_vtable->rank; i++) {
+		if ((source_bounds && source_bounds [i].lower_bound > 0) ||
+			(dest_bounds && dest_bounds [i].lower_bound > 0))
+			return FALSE;
+	}
 
 	/* there's no integer overflow since mono_array_length_internal returns an unsigned integer */
 	if ((dest_idx + length > mono_array_handle_length (dest)) ||


### PR DESCRIPTION
This fixes 1 of 2 identified issues found in: https://github.com/mono/mono/issues/13133

We need a faster slow path and we need to use the fast path for 2d and 3d arrays. 

This makes us use the fast path on 2d and 3d arrays. Our check for bounds was wrong because we were checking if the array is null. When we have a rank above 1, we will always have at least some bounds struct pointed to by the relevant pointer because we place an array there. Instead, we check that all of the bounds are zero/NULL. 

There's an immediate speed gain on the benchmark.

Using the same number of iterations:

- Before:
![image](https://user-images.githubusercontent.com/700530/53350939-3a1f1c00-38ee-11e9-868e-69afedfb45c2.png)

- After:
![new_bench_array_fastpath_2d](https://user-images.githubusercontent.com/700530/53350955-430fed80-38ee-11e9-928a-f0453d0f4643.jpeg)

