### PR TITLE
[2018-12] [aot] Resolve profile against compiled assembly

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -11982,7 +11982,7 @@ resolve_class (ClassProfileData *cdata)
  * Resolve the profile data to the corresponding loaded classes/methods etc. if possible.
  */
 static void
-resolve_profile_data (MonoAotCompile *acfg, ProfileData *data)
+resolve_profile_data (MonoAotCompile *acfg, ProfileData *data, MonoAssembly* current)
 {
 	GHashTableIter iter;
 	gpointer key, value;
@@ -11996,6 +11996,11 @@ resolve_profile_data (MonoAotCompile *acfg, ProfileData *data)
 	g_hash_table_iter_init (&iter, data->images);
 	while (g_hash_table_iter_next (&iter, &key, &value)) {
 		ImageProfileData *idata = (ImageProfileData*)value;
+
+		if (!strcmp (current->aname.name, idata->name)) {
+			idata->image = current->image;
+			break;
+		}
 
 		for (i = 0; i < assemblies->len; ++i) {
 			MonoAssembly *ass = (MonoAssembly*)g_ptr_array_index (assemblies, i);
@@ -13110,7 +13115,7 @@ mono_compile_assembly (MonoAssembly *ass, guint32 opts, const char *aot_options,
 		GList *l;
 
 		for (l = acfg->profile_data; l; l = l->next)
-			resolve_profile_data (acfg, (ProfileData*)l->data);
+			resolve_profile_data (acfg, (ProfileData*)l->data, ass);
 		for (l = acfg->profile_data; l; l = l->next)
 			add_profile_instances (acfg, (ProfileData*)l->data);
 	}


### PR DESCRIPTION
When trying to use AOT profile in XA for assembly AOT compilation, the
methods from the profile were not compiled.

Context: https://github.com/xamarin/xamarin-android/issues/2504

The problem was, the profile data were not resolved, as there was no
assembly loaded in the domain.

With this fix, the compiled assembly is used to resolve the profile as
well.


Backport of #13148.

/cc @lewurm @radekdoulik