### PR TITLE
Consider unknown GB18030 characters as invalid to enforce use of replacement character instead of throwing SystemException.

### DIFF
--- a/mcs/class/I18N/CJK/GB18030Source.cs
+++ b/mcs/class/I18N/CJK/GB18030Source.cs
@@ -187,8 +187,10 @@ namespace I18N.CJK
 					startIgnore = m.GEnd + 1;
 				}
 			}
-//			return ToUcsRaw ((int) (linear - gbxBase));
-			throw new SystemException (String.Format ("GB18030 INTERNAL ERROR (should not happen): GBX {0:x02} {1:x02} {2:x02} {3:x02}", b1, b2, b3, b4));
+
+			// All 4 bytes look valid but we didn't find any appropriate range.
+			// So just return negative result for it.
+			return -4;
 		}
 
 		public static long FromUCSSurrogate (int cp)

--- a/mcs/class/I18N/CJK/GB18030Source.cs
+++ b/mcs/class/I18N/CJK/GB18030Source.cs
@@ -214,7 +214,9 @@ namespace I18N.CJK
 					startIgnore = m.UEnd + 1;
 				}
 			}
-			throw new SystemException (String.Format ("GB18030 INTERNAL ERROR (should not happen): UCS {0:x06}", cp));
+
+			// Consider it as invalid character
+			return -1;
 		}
 
 		static long FromGBXRaw (

--- a/mcs/class/I18N/CJK/Test/I18N.CJK.Test.cs
+++ b/mcs/class/I18N/CJK/Test/I18N.CJK.Test.cs
@@ -597,5 +597,13 @@ namespace MonoTests.I18N.CJK
 		}
 
 		#endregion
+
+		[Test]
+		public void Bug13144 ()
+		{
+			var encoding = Encoding.GetEncoding ("GB18030");
+			var str = encoding.GetString (new byte[] { 0x84, 0x32, 0x81, 0x30 });
+			Assert.AreEqual ("?", str);
+		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/13144