### PR TITLE
Initial support for Fuchsia

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -402,7 +402,7 @@ case "$host" in
 		;;
 	*-*-fuchsia*)
 		AC_DEFINE(DISABLE_PORTABILITY,1,[Disable the io-portability layer])
-		AC_DEFINE(TARGET_FUCHSIA,1,[Targeting the Fuchsia platform])
+		AC_DEFINE(HOST_FUCHSIA,1,[Targeting the Fuchsia platform])
 		fuchsia=true
 		with_tls=pthread
 		with_sigaltstack=yes
@@ -4409,7 +4409,7 @@ if test "x$host" != "x$target"; then
 	x86_64-google-fuchsia)
 		TARGET=AMD64
 		target_win32=nop
-		AC_DEFINE(TARGET_FUCHSIA,1,[Targeting the Fuchsia platform])
+		AC_DEFINE(HOST_FUCHSIA,1,[Targeting the Fuchsia platform])
 		;;
 	*)
 		AC_MSG_ERROR([Cross compiling is not supported for target $target])

--- a/configure.ac
+++ b/configure.ac
@@ -400,6 +400,18 @@ case "$host" in
 		use_sigposix=yes
 		with_sigaltstack=no
 		;;
+	*-*-fuchsia*)
+		AC_DEFINE(DISABLE_PORTABILITY,1,[Disable the io-portability layer])
+		AC_DEFINE(TARGET_FUCHSIA,1,[Targeting the Fuchsia platform])
+		fuchsia=true
+		with_tls=pthread
+		with_sigaltstack=yes
+		with_static_mono=no
+		support_boehm=no
+		with_gc=sgen
+		mono_cv_uscore=yes
+		mono_cv_clang=no
+		;;
 	*-*-aix*|*-*-os400*)
 		dnl Set up a 64-bit build
 		CPPFLAGS="$CPPFLAGS -maix64 -DGC_AIX_THREADS -D_ALL_SOURCE -D_THREAD_SAFE -D_LARGE_FILES -D_REENTRANT"
@@ -4393,6 +4405,11 @@ if test "x$host" != "x$target"; then
 		arch_target=riscv64
 		target_mach=no
 		with_tls=pthread
+		;;
+	x86_64-google-fuchsia)
+		TARGET=AMD64
+		target_win32=nop
+		AC_DEFINE(TARGET_FUCHSIA,1,[Targeting the Fuchsia platform])
 		;;
 	*)
 		AC_MSG_ERROR([Cross compiling is not supported for target $target])

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -73,7 +73,7 @@ extern gboolean
 mono_native_thread_join_handle (HANDLE thread_handle, gboolean close_handle);
 #endif
 
-#if defined(TARGET_FUCHSIA)
+#if defined(HOST_FUCHSIA)
 #include <zircon/syscalls.h>
 #endif
 
@@ -717,7 +717,7 @@ mono_thread_internal_set_priority (MonoInternalThread *internal, MonoThreadPrior
 	MONO_EXIT_GC_SAFE;
 	if (!res)
 		g_error ("%s: SetThreadPriority failed, error %d", __func__, last_error);
-#elif defined(TARGET_FUCHSIA)
+#elif defined(HOST_FUCHSIA)
 	int z_priority;
 	
 	if (priority == MONO_THREAD_PRIORITY_LOWEST)
@@ -737,7 +737,7 @@ mono_thread_internal_set_priority (MonoInternalThread *internal, MonoThreadPrior
 	// When this API becomes available on an arbitrary thread, we can use it,
 	// not available on current Zircon
 	//
-#else /* !HOST_WIN32 and not TARGET_FUCHSIA */
+#else /* !HOST_WIN32 and not HOST_FUCHSIA */
 	pthread_t tid;
 	int policy;
 	struct sched_param param;

--- a/mono/utils/mono-threads-posix.c
+++ b/mono/utils/mono-threads-posix.c
@@ -15,6 +15,10 @@
 #define _DARWIN_C_SOURCE 1
 #endif
 
+#if defined (TARGET_FUCHSIA)
+
+#endif
+
 #if defined (__HAIKU__)
 #include <os/kernel/OS.h>
 #endif
@@ -131,6 +135,15 @@ mono_threads_platform_exit (gsize exit_code)
 	pthread_exit ((gpointer) exit_code);
 }
 
+#if TARGET_FUCHSIA
+int
+mono_thread_info_get_system_max_stack_size (void)
+{
+	/* For now, we do not enforce any limits */
+	return INT_MAX;
+}
+
+#else
 int
 mono_thread_info_get_system_max_stack_size (void)
 {
@@ -144,6 +157,7 @@ mono_thread_info_get_system_max_stack_size (void)
 		return INT_MAX;
 	return (int)lim.rlim_max;
 }
+#endif
 
 int
 mono_threads_pthread_kill (MonoThreadInfo *info, int signum)

--- a/mono/utils/mono-threads-posix.c
+++ b/mono/utils/mono-threads-posix.c
@@ -15,8 +15,8 @@
 #define _DARWIN_C_SOURCE 1
 #endif
 
-#if defined (TARGET_FUCHSIA)
-
+#if defined (HOST_FUCHSIA)
+#include <zircon/syscalls.h>
 #endif
 
 #if defined (__HAIKU__)
@@ -135,7 +135,7 @@ mono_threads_platform_exit (gsize exit_code)
 	pthread_exit ((gpointer) exit_code);
 }
 
-#if TARGET_FUCHSIA
+#if HOST_FUCHSIA
 int
 mono_thread_info_get_system_max_stack_size (void)
 {


### PR DESCRIPTION
Compile like this:

if you have Zircon installed, with the prebuilts on "../zircon", use this to compile:
```
CC="`pwd`/../zircon/prebuilt/downloads/clang/bin/clang-9 -nostdlib -O2 -g -fdebug-prefix-map=/cvs/fuchsia/zircon=. -finline -fno-common -ffunction-sections -fdata-sections -no-canonical-prefixes -march=x86-64 -mcx16 --target=x86_64-fuchsia -fPIC -D_ALL_SOURCE=1 -DENABLE_DRIVER_TRACING=1 -fasynchronous-unwind-tables -fno-omit-frame-pointer  -std=c11 -I`pwd`/../zircon/build-x64-clang/sysroot/include/ -I`pwd`/../zircon/system/public" LDFLAGS="-L`pwd`/../zircon/build-x64-clang/sysroot/lib/ -L`pwd`/../zircon/build-x64-clang/sysroot/debug" ./configure --host=x86_64-google-fuchsia
```