### PR TITLE
Update output from console-output test.

### DIFF
--- a/mono/tests/console-output.cs
+++ b/mono/tests/console-output.cs
@@ -5,7 +5,7 @@ class Driver
 {
 	public static void Main ()
 	{
-		Console.Out.WriteLine ("Out");
-		Console.Error.WriteLine ("Error");
+		Console.Out.WriteLine ("Testing Console.Out");
+		Console.Error.WriteLine ("Testing Console.Error");
 	}
 }

--- a/mono/tests/console-output.exe.stderr.expected
+++ b/mono/tests/console-output.exe.stderr.expected
@@ -1,1 +1,1 @@
-Error
+Testing Console.Error

--- a/mono/tests/console-output.exe.stdout.expected
+++ b/mono/tests/console-output.exe.stdout.expected
@@ -1,1 +1,1 @@
-Out
+Testing Console.Out


### PR DESCRIPTION
Current output from console-output test is just Error and Out (indicating the different console output streams). When seen in log files the error output string can be misleading. Fix makes it clearer that the output is originating from a test and not an “error”.
