### PR TITLE
[2019-02] [interp] compute size of generic valuetype correctly

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -2569,7 +2569,7 @@ interp_entry_general (gpointer this_arg, gpointer res, gpointer *args, gpointer 
 // inline so we can alloc on stack
 #define alloc_storage_for_stackval(s, t, p) do {							\
 		if ((t)->type == MONO_TYPE_GENERICINST && !MONO_TYPE_IS_REFERENCE (t)) {		\
-			(s)->data.vt = alloca (mono_class_value_size ((t)->data.generic_class->container_class, NULL));	\
+			(s)->data.vt = alloca (mono_class_value_size (mono_class_from_mono_type_internal (t), NULL));	\
 		} else if ((t)->type == MONO_TYPE_VALUETYPE) {						\
 			if (p)										\
 				(s)->data.vt = alloca (mono_class_native_size ((t)->data.klass, NULL));	\

--- a/mono/mini/mixed.cs
+++ b/mono/mini/mixed.cs
@@ -75,6 +75,12 @@ class InterpClass
 	}
 
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	public static int entry_deep_generic_vt (int i, decimal? b) {
+		return i;
+	}
+
+
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
 	public static StackTrace get_stacktrace_interp () {
 		var o = new object ();
 		return new StackTrace (true);
@@ -134,6 +140,9 @@ class JitClass
 		var ptr2 = InterpClass.entry_intptr_intptr (ptr);
 		if (ptr != ptr2)
 			return 10;
+		var edgvt_ret = InterpClass.entry_deep_generic_vt (1337, 2m);
+		if (edgvt_ret != 1337)
+			return 11;
 		return 0;
 	}
 


### PR DESCRIPTION
Otherwise we smash the stack.


Contributes to https://github.com/xamarin/xamarin-macios/issues/5622

Backport of #13216.

/cc @lewurm 