### PR TITLE
[Mono.Debugger.Soft] Disable Attach() test that fails or hangs

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -4655,6 +4655,7 @@ public class DebuggerTests
 	}
 
 	[Test]
+	[Category("NotWorking")] // fails or hangs
 	public void Attach () {
 		vm.Exit (0);
 


### PR DESCRIPTION
It was recently reenabled in https://github.com/mono/mono/pull/9091 but it fails/hangs frequently, e.g.:
- https://jenkins.mono-project.com/job/test-mono-pull-request-amd64-osx/19575/testReport/junit/(root)/DebuggerTests/Attach/
- https://jenkins.mono-project.com/job/test-mono-pull-request-interpreter/15082/testReport/(root)/DebuggerTests/Attach/

/cc @luhenry @mfilippov 