### PR TITLE
Throw InvalidOperationException if inner handler is not assigned in DelegatingHandler

### DIFF
--- a/mcs/class/System.Net.Http/System.Net.Http/DelegatingHandler.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/DelegatingHandler.cs
@@ -73,6 +73,9 @@ namespace System.Net.Http
 
 		protected internal override Task<HttpResponseMessage> SendAsync (HttpRequestMessage request, CancellationToken cancellationToken)
 		{
+			if (InnerHandler == null) {
+				throw new InvalidOperationException (SR.net_http_handler_not_assigned);
+			}
 			return InnerHandler.SendAsync (request, cancellationToken);
 		}
 	}


### PR DESCRIPTION
Mono uses DelegatingHandler class legacy implementation on Windows. The PR aligns its behavior with corefx implementation used on macOS/Unix.

Fixes https://github.com/mono/mono/issues/8142