### PR TITLE
More PPC/AIX regression fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6165,7 +6165,15 @@ elif case $host_os in aix*|os400*) true;; *) false;; esac; then
 	MONO_NATIVE_CPPFLAGS=$CPPFLAGS
 	MONO_NATIVE_CXXFLAGS=$CXXFLAGS
 	MONO_NATIVE_CFLAGS=$CFLAGS
-	MONO_NATIVE_LDFLAGS=$LDFLAGS
+	dnl flock in AIX exists in libbsd (not the same as freedesktop.org
+	dnl libbsd) which Mono.Native needs.
+	dnl Because of the way that the library is built by default, unresolved
+	dnl references are kept and resolved at runtime. Often, the dependency
+	dnl chain means libbsd is loaded anyways, but not necessarily. It's
+	dnl better to explicitly link it, even though it has it shadows libc's
+	dnl ioctl with its own. (As for the other unresolved imports, those
+	dnl should be provided by the Mono runtime loaded.)
+	MONO_NATIVE_LDFLAGS="$LDFLAGS -lbsd"
 
 	mono_native=yes
 	mono_native_compat=no

--- a/mono/mini/basic-math.cs
+++ b/mono/mini/basic-math.cs
@@ -176,6 +176,9 @@ class Tests
 			return 5;
 		if (Math.Min ((long)-100, (long)-101) != -101)
 			return 6;
+		// this will trip if Min is accidentally using unsigned/logical comparison
+		if (Math.Min((long)-100000000000L, (long)0L) != (long)-100000000000L)
+			return 7;
 		return 0;
 	}
 
@@ -192,6 +195,9 @@ class Tests
 			return 5;
 		if (Math.Max ((long)-100, (long)-101) != -100)
 			return 6;
+		// this will trip if Max is accidentally using unsigned/logical comparison
+		if (Math.Max((long)-100000000000L, (long)0L) != (long)0L)
+			return 7;
 		return 0;
 	}
 

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -4279,7 +4279,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			ppc_iselgt (code, ins->dreg, ins->sreg1, ins->sreg2);
 			break;
 		CASE_PPC64 (OP_LMIN)
-			ppc_cmpl (code, 0, 1, ins->sreg1, ins->sreg2);
+			ppc_cmp (code, 0, 1, ins->sreg1, ins->sreg2);
 			ppc_isellt (code, ins->dreg, ins->sreg1, ins->sreg2);
 			break;
 		CASE_PPC64 (OP_LMIN_UN)
@@ -5732,14 +5732,17 @@ mono_arch_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMetho
 		opcode = 0;
 		if ((cpu_hw_caps & PPC_ISA_2X) && (fsig->param_count == 1) && (fsig->params [0]->type == MONO_TYPE_R8)) {
 			/*
-			 * XXX: sysmath.c and frin imply round is a little bit
-			 * more complicated than expected? but amd64 does this?
+			 * XXX: sysmath.c and the POWER ISA documentation for
+			 * frin[.] imply rounding is a little more complicated
+			 * than expected; the semantics are slightly different,
+			 * so just "frin." isn't a drop-in replacement. Floor,
+			 * Truncate, and Ceiling seem to work normally though.
 			 * (also, no float versions of these ops, but frsp
 			 * could be preprended?)
 			 */
-			if (!strcmp (cmethod->name, "Round"))
-				opcode = OP_ROUND;
-			else if (!strcmp (cmethod->name, "Floor"))
+			//if (!strcmp (cmethod->name, "Round"))
+			//	opcode = OP_ROUND;
+			if (!strcmp (cmethod->name, "Floor"))
 				opcode = OP_PPC_FLOOR;
 			else if (!strcmp (cmethod->name, "Ceiling"))
 				opcode = OP_PPC_CEIL;


### PR DESCRIPTION
* fix a typo in the JIT optimization where signed longs were being compared unsigned, and add a mini rcheck test for it

* don't use `frin.` for rounding; the semantics are different enough from `Math.Round` where it might not be actually safe, some tests tripped out. Ceil/Floor/Trunc seem safe, however.

* link libbsd into Mono.Native (not the fd.o one) for flock; the runtime's dep chain on AIX loaded libbsd it seemed, but not on i