### PR TITLE
Fix mono conc hashtable lookup endless loop

### DIFF
--- a/mono/metadata/mono-conc-hash.c
+++ b/mono/metadata/mono-conc-hash.c
@@ -166,7 +166,7 @@ rehash_table (MonoConcGHashTable *hash_table, int multiplier)
 	hash_table->table = new_table;
 	hash_table->overflow_count = (int)(new_table->table_size * LOAD_FACTOR);
 	hash_table->element_count -= hash_table->tombstone_count;
-  hash_table->tombstone_count = 0;
+	hash_table->tombstone_count = 0;
 	conc_table_lf_free (old_table);	
 }
 

--- a/mono/metadata/mono-conc-hash.c
+++ b/mono/metadata/mono-conc-hash.c
@@ -165,6 +165,8 @@ rehash_table (MonoConcGHashTable *hash_table, int multiplier)
 	mono_memory_barrier ();
 	hash_table->table = new_table;
 	hash_table->overflow_count = (int)(new_table->table_size * LOAD_FACTOR);
+	hash_table->element_count -= hash_table->tombstone_count;
+  hash_table->tombstone_count = 0;
 	conc_table_lf_free (old_table);	
 }
 

--- a/mono/utils/mono-conc-hashtable.c
+++ b/mono/utils/mono-conc-hashtable.c
@@ -129,6 +129,8 @@ rehash_table (MonoConcurrentHashTable *hash_table, int multiplier)
 	mono_memory_barrier ();
 	hash_table->table = new_table;
 	hash_table->overflow_count = (int)(new_table->table_size * LOAD_FACTOR);
+	hash_table->element_count -= hash_table->tombstone_count;
+	hash_table->tombstone_count = 0;
 	conc_table_lf_free (old_table);
 }
 
@@ -141,7 +143,7 @@ check_table_size (MonoConcurrentHashTable *hash_table)
 			rehash_table (hash_table, 1);
 		else
 			rehash_table (hash_table, 2);
-  }
+	}
 }
 
 
@@ -351,14 +353,11 @@ mono_conc_hashtable_insert (MonoConcurrentHashTable *hash_table, gpointer key, g
 				kvs [i].value = value;
 				/* The write to values must happen after the write to keys */
 				mono_memory_barrier ();
-				
 				if (kvs [i].key == TOMBSTONE)
 					--hash_table->tombstone_count;
 				else
 					++hash_table->element_count;	
-				
 				kvs [i].key = key;
-				
 				return NULL;
 			}
 			if (key == kvs [i].key) {
@@ -374,14 +373,11 @@ mono_conc_hashtable_insert (MonoConcurrentHashTable *hash_table, gpointer key, g
 				kvs [i].value = value;
 				/* The write to values must happen after the write to keys */
 				mono_memory_barrier ();
-				
 				if (kvs [i].key == TOMBSTONE)
 					--hash_table->tombstone_count;
 				else
 					++hash_table->element_count;
-				
 				kvs [i].key = key;
-				
 				return NULL;
 			}
 			if (equal (key, kvs [i].key)) {

--- a/mono/utils/mono-conc-hashtable.c
+++ b/mono/utils/mono-conc-hashtable.c
@@ -141,7 +141,15 @@ check_table_size (MonoConcurrentHashTable *hash_table)
 			rehash_table (hash_table, 1);
 		else
 			rehash_table (hash_table, 2);
-	}
+	
+
+    // now we have to reset the tombstone and element counters to the actual values
+    // because if we don't we will be doomed to finally fill up the entire hashmap 
+    // and the next failing lookup will toast our cpu in an endless cycle
+
+    hash_table->element_count -= hash_table->tombstone_count;
+    hash_table->tombstone_count = 0;
+  }
 }
 
 

--- a/mono/utils/mono-conc-hashtable.c
+++ b/mono/utils/mono-conc-hashtable.c
@@ -141,14 +141,6 @@ check_table_size (MonoConcurrentHashTable *hash_table)
 			rehash_table (hash_table, 1);
 		else
 			rehash_table (hash_table, 2);
-	
-
-    // now we have to reset the tombstone and element counters to the actual values
-    // because if we don't we will be doomed to finally fill up the entire hashmap 
-    // and the next failing lookup will toast our cpu in an endless cycle
-
-    hash_table->element_count -= hash_table->tombstone_count;
-    hash_table->tombstone_count = 0;
   }
 }
 

--- a/mono/utils/mono-conc-hashtable.c
+++ b/mono/utils/mono-conc-hashtable.c
@@ -351,12 +351,14 @@ mono_conc_hashtable_insert (MonoConcurrentHashTable *hash_table, gpointer key, g
 				kvs [i].value = value;
 				/* The write to values must happen after the write to keys */
 				mono_memory_barrier ();
-				kvs [i].key = key;
+				
 				if (kvs [i].key == TOMBSTONE)
 					--hash_table->tombstone_count;
 				else
 					++hash_table->element_count;	
-					
+				
+				kvs [i].key = key;
+				
 				return NULL;
 			}
 			if (key == kvs [i].key) {
@@ -372,11 +374,14 @@ mono_conc_hashtable_insert (MonoConcurrentHashTable *hash_table, gpointer key, g
 				kvs [i].value = value;
 				/* The write to values must happen after the write to keys */
 				mono_memory_barrier ();
-				kvs [i].key = key;
+				
 				if (kvs [i].key == TOMBSTONE)
 					--hash_table->tombstone_count;
 				else
 					++hash_table->element_count;
+				
+				kvs [i].key = key;
+				
 				return NULL;
 			}
 			if (equal (key, kvs [i].key)) {


### PR DESCRIPTION

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->

The tombstone scrubbing fix applied in the past did not work in every case.

Since the key assignment to an element added via mono_conc_hashmap_insert() happens before the tombstone check, the tombstone count remains the same even if a tombstone was replaced. 

In this case the table size check can decide to rehash to the same table size because assuming free spots will become available from not copying over the tombstones. But if all tombstones have been replaced with new elements the fill rate of the hashmap will effectively stay the same, and in the long run rehashing with the same hashmapsize finally leads to a completely filled hashmap.

In the case of a completely filled hashmap looking up an element, not contained in the hashmap, will result in an endless loop because the termination condition for lookups is finding a null key.

We continuously run into this issue with our server application.

Please include this fix into the main repository


Backport of #12382.

/cc @lewurm @hecklatcipsoft