### PR TITLE
[2019-02] Ensure that the module cctor is run before the entry point is executed

### DIFF
--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1865,6 +1865,9 @@ MonoVTable *
 mono_class_try_get_vtable (MonoDomain *domain, MonoClass *klass);
 
 gboolean
+mono_runtime_run_module_cctor (MonoImage *image, MonoDomain *domain, MonoError *error);
+
+gboolean
 mono_runtime_class_init_full (MonoVTable *vtable, MonoError *error);
 
 void

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1006,7 +1006,8 @@ TESTS_IL_SRC=			\
 	tailcall-valuetype-parameter.il \
 	ldfldvt.il \
 	newobj-abstract.il \
-	invalid-isbyreflike.il
+	invalid-isbyreflike.il \
+	module-cctor-entrypoint.il
 
 # This test crashes the runtime, even with recent fixes.
 #	incorrect-ldvirtftn-read-behind-for-dup.il

--- a/mono/tests/module-cctor-entrypoint.il
+++ b/mono/tests/module-cctor-entrypoint.il
@@ -1,0 +1,30 @@
+// See https://blogs.msdn.microsoft.com/junfeng/2005/11/19/module-initializer-a-k-a-module-constructor/
+// for more information about module initializers
+
+.assembly TestDll { }
+.assembly extern mscorlib { }
+
+.method assembly specialname rtspecialname static 
+        void  .cctor() cil managed
+{
+	// If this method executes, we've succeeded
+        ldc.i4 0
+        call void [mscorlib]System.Environment::Exit(int32)
+	ret
+}
+
+.namespace NS
+{
+	.class public TestClass extends [mscorlib]System.Object
+	{
+		.method public static void  Main() cil managed
+		{
+		  .entrypoint
+		  // This should never run due to the module constructor
+		  // exiting
+		  ldc.i4 1
+		  call void [mscorlib]System.Environment::Exit(int32)
+		  ret
+		}
+	}
+}


### PR DESCRIPTION
Backport #13242 to `2019-02`


---

* Ensure that the module cctor is run before the entry point is executed

We need to ensure that any module cctor for the 'main' image
is run *before* we invoke the entry point

This is required in order for tools like Costura
(https://github.com/Fody/Costura) to work properly. These tools inject
a module initializer which sets up event handlers (e.g. AssemblyResolve),
which allows the main method to run properly

For more information about module constructors,
see https://blogs.msdn.microsoft.com/junfeng/2005/11/19/module-initializer-a-k-a-module-constructor/

* Fix module-cctor-entrypoint.il



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
