### PR TITLE
[2018-12] Ensure that the module cctor is run before the entry point is executed

### DIFF
--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1853,6 +1853,9 @@ MonoVTable *
 mono_class_try_get_vtable (MonoDomain *domain, MonoClass *klass);
 
 gboolean
+mono_runtime_run_module_cctor (MonoImage *image, MonoDomain *domain, MonoError *error);
+
+gboolean
 mono_runtime_class_init_full (MonoVTable *vtable, MonoError *error);
 
 void

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -384,6 +384,38 @@ unref_type_lock (TypeInitializationLock *lock)
 }
 
 /**
+ * mono_runtime_run_module_cctor:
+ * \param image the image whose module ctor to run
+ * \param domain the domain to load the module class vtable in
+ * \param error set on error
+ * This routine runs the module ctor for \p image, if it hasn't already run
+ */
+gboolean
+mono_runtime_run_module_cctor (MonoImage *image, MonoDomain *domain, MonoError *error) {
+	MONO_REQ_GC_UNSAFE_MODE;
+
+	if (!image->checked_module_cctor) {
+		mono_image_check_for_module_cctor (image);
+		if (image->has_module_cctor) {
+			MonoClass *module_klass;
+			MonoVTable *module_vtable;
+
+			module_klass = mono_class_get_checked (image, MONO_TOKEN_TYPE_DEF | 1, error);
+			if (!module_klass) {
+				return FALSE;
+			}
+
+			module_vtable = mono_class_vtable_checked (domain, module_klass, error);
+			if (!module_vtable)
+				return FALSE;
+			if (!mono_runtime_class_init_full (module_vtable, error))
+				return FALSE;
+		}
+	}
+	return TRUE;
+}
+
+/**
  * mono_runtime_class_init_full:
  * \param vtable that neeeds to be initialized
  * \param error set on error
@@ -412,23 +444,8 @@ mono_runtime_class_init_full (MonoVTable *vtable, MonoError *error)
 	klass = vtable->klass;
 
 	MonoImage *klass_image = m_class_get_image (klass);
-	if (!klass_image->checked_module_cctor) {
-		mono_image_check_for_module_cctor (klass_image);
-		if (klass_image->has_module_cctor) {
-			MonoClass *module_klass;
-			MonoVTable *module_vtable;
-
-			module_klass = mono_class_get_checked (klass_image, MONO_TOKEN_TYPE_DEF | 1, error);
-			if (!module_klass) {
-				return FALSE;
-			}
-				
-			module_vtable = mono_class_vtable_checked (vtable->domain, module_klass, error);
-			if (!module_vtable)
-				return FALSE;
-			if (!mono_runtime_class_init_full (module_vtable, error))
-				return FALSE;
-		}
+	if (!mono_runtime_run_module_cctor(klass_image, vtable->domain, error)) {
+		return FALSE;
 	}
 	method = mono_class_get_cctor (klass);
 	if (!method) {

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1265,6 +1265,20 @@ mono_jit_exec_internal (MonoDomain *domain, MonoAssembly *assembly, int argc, ch
 	MONO_REQ_GC_UNSAFE_MODE;
 	ERROR_DECL (error);
 	MonoImage *image = mono_assembly_get_image_internal (assembly);
+
+    // We need to ensure that any module cctor for this image
+    // is run *before* we invoke the entry point
+    // For more information, see https://blogs.msdn.microsoft.com/junfeng/2005/11/19/module-initializer-a-k-a-module-constructor/
+    //
+    // This is required in order for tools like Costura
+    // (https://github.com/Fody/Costura) to work properly, as they inject
+    // a module initializer which sets up event handlers (e.g. AssemblyResolve)
+    // that allow the main method to run properly
+    if (!mono_runtime_run_module_cctor(image, domain, error)) {
+        g_print ("Failed to run module constructor due to %s\n", mono_error_get_message (error));
+        return 1;
+    }
+
 	MonoMethod *method;
 	guint32 entry = mono_image_get_entry_point (image);
 

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -995,7 +995,8 @@ TESTS_IL_SRC=			\
 	tailcall-valuetype-parameter.il \
 	ldfldvt.il \
 	newobj-abstract.il \
-	invalid-isbyreflike.il
+	invalid-isbyreflike.il \
+	module-cctor-entrypoint.il
 
 # This test crashes the runtime, even with recent fixes.
 #	incorrect-ldvirtftn-read-behind-for-dup.il

--- a/mono/tests/module-cctor-entrypoint.il
+++ b/mono/tests/module-cctor-entrypoint.il
@@ -1,0 +1,30 @@
+// See https://blogs.msdn.microsoft.com/junfeng/2005/11/19/module-initializer-a-k-a-module-constructor/
+// for more information about module initializers
+
+.assembly TestDll { }
+.assembly extern mscorlib { }
+
+.method assembly specialname rtspecialname static 
+        void  .cctor() cil managed
+{
+	// If this method executes, we've succeeded
+        ldc.i4 0
+        call void [mscorlib]System.Environment::Exit(int32)
+	ret
+}
+
+.namespace NS
+{
+	.class public TestClass extends [mscorlib]System.Object
+	{
+		.method public static void  Main() cil managed
+		{
+		  .entrypoint
+		  // This should never run due to the module constructor
+		  // exiting
+		  ldc.i4 1
+		  call void [mscorlib]System.Environment::Exit(int32)
+		  ret
+		}
+	}
+}


### PR DESCRIPTION
Backport #13242 to `2018-12`

---

* Ensure that the module cctor is run before the entry point is executed

We need to ensure that any module cctor for the 'main' image
is run *before* we invoke the entry point

This is required in order for tools like Costura
(https://github.com/Fody/Costura) to work properly. These tools inject
a module initializer which sets up event handlers (e.g. AssemblyResolve),
which allows the main method to run properly

For more information about module constructors,
see https://blogs.msdn.microsoft.com/junfeng/2005/11/19/module-initializer-a-k-a-module-constructor/

* Fix module-cctor-entrypoint.il



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
