### PR TITLE
Custom modifier equivalence, duplication, appending and inflation

### DIFF
--- a/mono/dis/get.c
+++ b/mono/dis/get.c
@@ -438,10 +438,13 @@ get_custom_mod (MonoImage *m, const char *ptr, char **return_value)
 		ptr++;
 		ptr = get_encoded_typedef_or_ref (m, ptr, &s);
 
+		/* cmods are encoded in reverse order from how we want to print them.
+		 * "int32 modopt (Foo) modopt (Bar)" is encoded as "cmod_opt [typedef_or_ref "Bar"] cmod_opt [typedef_or_ref "Foo"] I4"
+		 */
 		if (*return_value == NULL)
 			*return_value = g_strconcat (" ", mod, " (", s, ")", NULL);
 		else
-			*return_value = g_strconcat (*return_value, " ", mod, " (", s, ")", NULL);
+			*return_value = g_strconcat (mod, " (", s, ") ", *return_value, NULL);
 		g_free (s);
 	}
 	return ptr;

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -854,6 +854,8 @@ inflate_generic_custom_modifiers (MonoImage *image, const MonoType *type, MonoGe
 	int count = mono_type_custom_modifier_count (type);
 	gboolean changed = FALSE;
 
+	/* Try not to blow up the stack. See comment on MONO_MAX_EXPECTED_CMODS. */
+	g_assert (count < MONO_MAX_EXPECTED_CMODS);
 	size_t aggregate_size = mono_sizeof_aggregate_modifiers (count);
 	MonoAggregateModContainer *candidate_mods = g_alloca (aggregate_size);
 	memset (candidate_mods, 0, aggregate_size);

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -72,6 +72,9 @@ static gboolean mono_class_is_subclass_of_internal (MonoClass *klass, MonoClass 
 GENERATE_GET_CLASS_WITH_CACHE (valuetype, "System", "ValueType")
 GENERATE_TRY_GET_CLASS_WITH_CACHE (handleref, "System.Runtime.InteropServices", "HandleRef")
 
+// define to print types whenever custom modifiers are appended during inflation
+#undef DEBUG_INFLATE_CMODS
+
 static
 MonoImage *
 mono_method_get_image (MonoMethod *method)
@@ -633,17 +636,39 @@ can_inflate_gparam_with (MonoGenericParam *gparam, MonoType *type)
 }
 
 static MonoType*
+inflate_generic_custom_modifiers (MonoImage *image, const MonoType *type, MonoGenericContext *context, MonoError *error);
+
+static MonoType*
 inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *context, MonoError *error)
 {
+	gboolean changed = FALSE;
 	error_init (error);
+
+	/* C++/CLI (and some Roslyn tests) constructs method signatures like:
+	 *     void .CL1`1.Test(!0 modopt(System.Nullable`1<!0>))
+	 * where !0 has a custom modifier which itself mentions the type variable.
+	 * So we need to potentially inflate the modifiers.
+	 */
+	if (type->has_cmods) {
+		MonoType *new_type = inflate_generic_custom_modifiers (image, type, context, error);
+		return_val_if_nok (error, NULL);
+		if (new_type != NULL) {
+			type = new_type;
+			changed = TRUE;
+		}
+	}
 
 	switch (type->type) {
 	case MONO_TYPE_MVAR: {
 		MonoType *nt;
 		int num = mono_type_get_generic_param_num (type);
 		MonoGenericInst *inst = context->method_inst;
-		if (!inst)
-			return NULL;
+		if (!inst) {
+			if (!changed)
+				return NULL;
+			else
+				return type;
+		}
 		MonoGenericParam *gparam = type->data.generic_param;
 		if (num >= inst->type_argc) {
 			const char *pname = mono_generic_param_name (gparam);
@@ -672,8 +697,12 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 		MonoType *nt;
 		int num = mono_type_get_generic_param_num (type);
 		MonoGenericInst *inst = context->class_inst;
-		if (!inst)
-			return NULL;
+		if (!inst) {
+			if (!changed)
+				return NULL;
+			else
+				return type;
+		}
 		MonoGenericParam *gparam = type->data.generic_param;
 		if (num >= inst->type_argc) {
 			const char *pname = mono_generic_param_name (gparam);
@@ -688,16 +717,38 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 			return NULL;			
 		}
 
+#ifdef DEBUG_INFLATE_CMODS
+		gboolean append_cmods;
+		append_cmods = FALSE;
+		if (type->has_cmods && inst->type_argv[num]->has_cmods) {
+			char *tname = mono_type_full_name (type);
+			char *vname = mono_type_full_name (inst->type_argv[num]);
+			printf ("\n\n\tsubstitution for '%s' with '%s' yields...\n", tname, vname);
+			g_free (tname);
+			g_free (vname);
+			append_cmods = TRUE;
+		}
+#endif
+
 		nt = mono_metadata_type_dup_with_cmods (image, inst->type_argv [num], type);
-		nt->byref = type->byref;
+		nt->byref = type->byref || inst->type_argv[num]->byref;
 		nt->attrs = type->attrs;
+#ifdef DEBUG_INFLATE_CMODS
+		if (append_cmods) {
+			char *ntname = mono_type_full_name (nt);
+			printf ("\tyields '%s'\n\n\n", ntname);
+			g_free (ntname);
+		}
+#endif
 		return nt;
 	}
 	case MONO_TYPE_SZARRAY: {
 		MonoClass *eclass = type->data.klass;
 		MonoType *nt, *inflated = inflate_generic_type (NULL, m_class_get_byval_arg (eclass), context, error);
-		if (!inflated || !mono_error_ok (error))
+		if ((!inflated && !changed) || !mono_error_ok (error))
 			return NULL;
+		if (!inflated)
+			return type;
 		nt = mono_metadata_type_dup (image, type);
 		nt->data.klass = mono_class_from_mono_type_internal (inflated);
 		mono_metadata_free_type (inflated);
@@ -706,8 +757,10 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 	case MONO_TYPE_ARRAY: {
 		MonoClass *eclass = type->data.array->eklass;
 		MonoType *nt, *inflated = inflate_generic_type (NULL, m_class_get_byval_arg (eclass), context, error);
-		if (!inflated || !mono_error_ok (error))
+		if ((!inflated && !changed) || !mono_error_ok (error))
 			return NULL;
+		if (!inflated)
+			return type;
 		nt = mono_metadata_type_dup (image, type);
 		nt->data.array->eklass = mono_class_from_mono_type_internal (inflated);
 		mono_metadata_free_type (inflated);
@@ -717,8 +770,12 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 		MonoGenericClass *gclass = type->data.generic_class;
 		MonoGenericInst *inst;
 		MonoType *nt;
-		if (!gclass->context.class_inst->is_open)
-			return NULL;
+		if (!gclass->context.class_inst->is_open) {
+			if (!changed)
+				return NULL;
+			else
+				return type;
+		}
 
 		inst = mono_metadata_inflate_generic_inst (gclass->context.class_inst, context, error);
 		return_val_if_nok (error, NULL);
@@ -726,8 +783,12 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 		if (inst != gclass->context.class_inst)
 			gclass = mono_metadata_lookup_generic_class (gclass->container_class, inst, gclass->is_dynamic);
 
-		if (gclass == type->data.generic_class)
-			return NULL;
+		if (gclass == type->data.generic_class) {
+			if (!changed)
+				return NULL;
+			else
+				return type;
+		}
 
 		nt = mono_metadata_type_dup (image, type);
 		nt->data.generic_class = gclass;
@@ -741,15 +802,23 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 		MonoGenericClass *gclass = NULL;
 		MonoType *nt;
 
-		if (!container)
-			return NULL;
+		if (!container) {
+			if (!changed)
+				return NULL;
+			else
+				return type;
+		}
 
 		/* We can't use context->class_inst directly, since it can have more elements */
 		inst = mono_metadata_inflate_generic_inst (container->context.class_inst, context, error);
 		return_val_if_nok (error, NULL);
 
-		if (inst == container->context.class_inst)
-			return NULL;
+		if (inst == container->context.class_inst) {
+			if (!changed)
+				return NULL;
+			else
+				return type;
+		}
 
 		gclass = mono_metadata_lookup_generic_class (klass, inst, image_is_dynamic (m_class_get_image (klass)));
 
@@ -760,16 +829,55 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 	}
 	case MONO_TYPE_PTR: {
 		MonoType *nt, *inflated = inflate_generic_type (image, type->data.type, context, error);
-		if (!inflated || !mono_error_ok (error))
+		if ((!inflated && !changed) || !mono_error_ok (error))
 			return NULL;
+		if (!inflated && changed)
+			return type;
 		nt = mono_metadata_type_dup (image, type);
 		nt->data.type = inflated;
 		return nt;
 	}
 	default:
-		return NULL;
+		if (!changed)
+			return NULL;
+		else
+			return type;
 	}
 	return NULL;
+}
+
+static MonoType*
+inflate_generic_custom_modifiers (MonoImage *image, const MonoType *type, MonoGenericContext *context, MonoError *error)
+{
+	g_assert (type->has_cmods);
+	int count = mono_type_custom_modifier_count (type);
+	gboolean changed = FALSE;
+	MonoType *new_type = g_alloca (mono_sizeof_type_with_mods (count, TRUE));
+	memcpy (new_type, type, MONO_SIZEOF_TYPE);
+	mono_type_with_mods_init (new_type, count, TRUE);
+	MonoAggregateModContainer *new_mods = mono_type_get_amods (new_type);
+
+	for (int i = 0; i < count; ++i) {
+		gboolean required;
+		MonoType *cmod_old = mono_type_get_custom_modifier (type, i, &required, error);
+		return_val_if_nok (error, NULL);
+		MonoType *cmod_new = inflate_generic_type (NULL, cmod_old, context, error); /* FIXME leaks */
+		return_val_if_nok (error, NULL);
+		if (cmod_new)
+			changed = TRUE;
+		new_mods->modifiers [i].required = required;
+		new_mods->modifiers [i].type = cmod_new ? cmod_new : cmod_old;
+	}
+#ifdef DEBUG_INFLATE_CMODS
+	if (changed) {
+		char *full_name = mono_type_full_name ((MonoType*)type);
+		printf ("\n\n\tcustom modifier on '%s' affected by subsititution\n\n\n", full_name);
+		g_free (full_name);
+	}
+#endif
+	if (!changed)
+		return NULL;
+	return mono_metadata_type_dup (image, new_type);
 }
 
 MonoGenericContext *

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -111,19 +111,19 @@ find_system_class (const char *name)
 }
 
 static void
-mono_custom_modifiers_get_desc (GString *res, const MonoCustomModContainer *cmods, gboolean include_namespace)
+mono_custom_modifiers_get_desc (GString *res, const MonoType *type, gboolean include_namespace)
 {
 	ERROR_DECL (error);
-	MonoImage *image = cmods->image;
-	for (int i = 0; i < cmods->count; ++i) {
-		const MonoCustomMod *cmod = &cmods->modifiers [i];
-		if (cmod->required)
+	int count = mono_type_custom_modifier_count (type);
+	for (int i = 0; i < count; ++i) {
+		gboolean required;
+		MonoType *cmod_type = mono_type_get_custom_modifier (type, i, &required, error);
+		mono_error_assert_ok (error);
+		if (required)
 			g_string_append (res, " modreq(");
 		else
 			g_string_append (res, " modopt(");
-		MonoClass *cmod_class = mono_class_get_checked (image, cmod->token, error);
-		mono_error_assert_ok (error);
-		mono_type_get_desc (res, &cmod_class->_byval_arg, include_namespace);
+		mono_type_get_desc (res, cmod_type, include_namespace);
 		g_string_append (res, ")");
 	}
 }
@@ -233,10 +233,7 @@ mono_type_get_desc (GString *res, MonoType *type, gboolean include_namespace)
 		break;
 	}
 	if (type->has_cmods) {
-		if (!mono_type_is_aggregate_mods (type))
-			mono_custom_modifiers_get_desc (res, mono_type_get_cmods (type), include_namespace);
-		else
-			g_string_append (res, "<<aggregate???>>");
+		mono_custom_modifiers_get_desc (res, type, include_namespace);
 	}
 	if (type->byref)
 		g_string_append_c (res, '&');

--- a/mono/metadata/debug-helpers.c
+++ b/mono/metadata/debug-helpers.c
@@ -232,8 +232,12 @@ mono_type_get_desc (GString *res, MonoType *type, gboolean include_namespace)
 	default:
 		break;
 	}
-	if (type->has_cmods)
-		mono_custom_modifiers_get_desc (res, mono_type_get_cmods (type), include_namespace);
+	if (type->has_cmods) {
+		if (!mono_type_is_aggregate_mods (type))
+			mono_custom_modifiers_get_desc (res, mono_type_get_cmods (type), include_namespace);
+		else
+			g_string_append (res, "<<aggregate???>>");
+	}
 	if (type->byref)
 		g_string_append_c (res, '&');
 }

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -8004,12 +8004,11 @@ ves_icall_System_NumberFormatter_GetFormatterTables (guint64 const **mantissas,
 }
 
 static gboolean
-add_modifier_to_array (MonoDomain *domain, MonoImage *image, MonoCustomMod *modifier, MonoArrayHandle dest, int dest_idx, MonoError *error)
+add_modifier_to_array (MonoDomain *domain, MonoType *type, MonoArrayHandle dest, int dest_idx, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
 	error_init (error);
-	MonoClass *klass = mono_class_get_checked (image, modifier->token, error);
-	goto_if_nok (error, leave);
+	MonoClass *klass = mono_class_from_mono_type_internal (type);
 
 	MonoReflectionTypeHandle rt;
 	rt = mono_type_get_object_handle (domain, m_class_get_byval_arg (klass), error);
@@ -8030,13 +8029,16 @@ type_array_from_modifiers (MonoImage *image, MonoType *type, int optional, MonoE
 	int i, count = 0;
 	MonoDomain *domain = mono_domain_get ();
 
-	MonoCustomModContainer *cmods = mono_type_get_cmods (type);
-	if (!cmods)
+	int cmod_count = mono_type_custom_modifier_count (type);
+	if (cmod_count == 0)
 		goto fail;
 
 	error_init (error);
-	for (i = 0; i < cmods->count; ++i) {
-		if ((optional && !cmods->modifiers [i].required) || (!optional && cmods->modifiers [i].required))
+	for (i = 0; i < cmod_count; ++i) {
+		gboolean required;
+		(void) mono_type_get_custom_modifier (type, i, &required, error);
+		goto_if_nok (error, fail);
+		if ((optional && !required) || (!optional && required))
 			count++;
 	}
 	if (!count)
@@ -8046,9 +8048,12 @@ type_array_from_modifiers (MonoImage *image, MonoType *type, int optional, MonoE
 	res = mono_array_new_handle (domain, mono_defaults.systemtype_class, count, error);
 	goto_if_nok (error, fail);
 	count = 0;
-	for (i = cmods->count - 1; i >= 0; --i) {
-		if ((optional && !cmods->modifiers [i].required) || (!optional && cmods->modifiers [i].required)) {
-			if (!add_modifier_to_array (domain, image, &cmods->modifiers [i], res, count , error))
+	for (i = cmod_count - 1; i >= 0; --i) {
+		gboolean required;
+		MonoType *cmod_type = mono_type_get_custom_modifier (type, i, &required, error);
+		goto_if_nok (error, fail);
+		if ((optional && !required) || (!optional && required)) {
+			if (!add_modifier_to_array (domain, cmod_type, res, count, error))
 				goto fail;
 			count++;
 		}

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -8048,7 +8048,7 @@ type_array_from_modifiers (MonoImage *image, MonoType *type, int optional, MonoE
 	res = mono_array_new_handle (domain, mono_defaults.systemtype_class, count, error);
 	goto_if_nok (error, fail);
 	count = 0;
-	for (i = cmod_count - 1; i >= 0; --i) {
+	for (i = 0; i < cmod_count; ++i) {
 		gboolean required;
 		MonoType *cmod_type = mono_type_get_custom_modifier (type, i, &required, error);
 		goto_if_nok (error, fail);

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -61,6 +61,14 @@ typedef struct {
 	MonoSingleCustomMod modifiers[1]; /* Actual length is count */
 } MonoAggregateModContainer;
 
+/* ECMA says upto 64 custom modifiers.  It's possible we could see more at
+ * runtime due to modifiers being appended together when we inflate type.  In
+ * that case we should revisit the places where this define is used to make
+ * sure that we don't blow up the stack (or switch to heap allocation for
+ * temporaries).
+ */
+#define MONO_MAX_EXPECTED_CMODS 64
+
 typedef struct {
 	MonoType unmodified;
 	gboolean is_aggregate;

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -37,12 +37,78 @@ struct _MonoType {
 };
 
 typedef struct {
+	unsigned int required : 1;
+	MonoType *type;
+} MonoSingleCustomMod;
+
+/* Aggregate custom modifiers can happen if a generic VAR or MVAR is inflated,
+ * and both the VAR and the type that will be used to inflated it have custom
+ * modifiers, but they come from different images.  (e.g. inflating 'class G<T>
+ * {void Test (T modopt(IsConst) t);}' with 'int32 modopt(IsLong)' where G is
+ * in image1 and the int32 is in image2.)
+ *
+ * Moreover, we can't just store an image and a type token per modifier, because
+ * Roslyn and C++/CLI sometimes create modifiers that mention generic parameters that must be inflated, like:
+ *     void .CL1`1.Test(!0 modopt(System.Nullable`1<!0>))
+ * So we have to store a resolved MonoType*.
+ *
+ * FIXME: types with aggregate custom modifiers really ought to be allocated in
+ * the mempool of a MonoImageSet to ensure that don't have danging image
+ * pointers.
+ */
+typedef struct {
+	uint8_t count;
+	MonoSingleCustomMod modifiers[1]; /* Actual length is count */
+} MonoAggregateModContainer;
+
+typedef struct {
 	MonoType unmodified;
-	MonoCustomModContainer cmods;
+	gboolean is_aggregate;
+	union {
+		MonoCustomModContainer cmods;
+		MonoAggregateModContainer amods;
+	} mods;
 } MonoTypeWithModifiers;
+
+gboolean
+mono_type_is_aggregate_mods (const MonoType *t);
+
+static inline void
+mono_type_with_mods_init (MonoType *dest, uint8_t num_mods, gboolean is_aggregate)
+{
+	if (num_mods == 0) {
+		dest->has_cmods = 0;
+		return;
+	}
+	dest->has_cmods = 1;
+	MonoTypeWithModifiers *dest_full = (MonoTypeWithModifiers *)dest;
+	dest_full->is_aggregate = !!is_aggregate;
+	if (is_aggregate)
+		dest_full->mods.amods.count = num_mods;
+	else
+		dest_full->mods.cmods.count = num_mods;
+}
 
 MonoCustomModContainer *
 mono_type_get_cmods (const MonoType *t);
+
+MonoAggregateModContainer *
+mono_type_get_amods (const MonoType *t);
+
+static inline uint8_t
+mono_type_custom_modifier_count (const MonoType *t)
+{
+	if (!t->has_cmods)
+		return 0;
+	MonoTypeWithModifiers *full = (MonoTypeWithModifiers *)t;
+	if (full->is_aggregate)
+		return full->mods.amods.count;
+	else
+		return full->mods.cmods.count;
+}
+
+MonoType *
+mono_type_get_custom_modifier (const MonoType *ty, uint8_t idx, gboolean *required, MonoError *error);
 
 // Note: sizeof (MonoType) is dangerous. It can copy the num_mods
 // field without copying the variably sized array. This leads to
@@ -54,7 +120,7 @@ mono_type_get_cmods (const MonoType *t);
 #define MONO_SIZEOF_TYPE sizeof (MonoType)
 
 size_t 
-mono_sizeof_type_with_mods (uint8_t num_mods);
+mono_sizeof_type_with_mods (uint8_t num_mods, gboolean aggregate);
 
 size_t 
 mono_sizeof_type (const MonoType *ty);

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -5934,6 +5934,14 @@ do_metadata_type_dup_append_cmods (MonoImage *image, const MonoType *o, const Mo
 		memcpy (r, o, mono_sizeof_type_with_mods (0, FALSE));
 		deep_type_dup_fixup (image, r, o);
 
+		/* Try not to blow up the stack. See comment on
+		 * MONO_MAX_EXPECTED_CMODS.  Since here we're appending all the
+		 * mods together, it's possible we'll end up with more than the
+		 * maximum allowed.  If that ever happens in practice, we
+		 * should redefine the bound and possibly make this function
+		 * fail dynamically instead of asserting.
+		 */
+		g_assert (total_cmods < MONO_MAX_EXPECTED_CMODS);
 		size_t r_container_size = mono_sizeof_aggregate_modifiers (total_cmods);
 		MonoAggregateModContainer *r_container_candidate = g_alloca (r_container_size);
 		memset (r_container_candidate, 0, r_container_size);

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -1837,7 +1837,7 @@ mono_metadata_parse_type_internal (MonoImage *m, MonoGenericContainer *container
 			return NULL;
 		}
 
-		size_t size = mono_sizeof_type_with_mods (count);
+		size_t size = mono_sizeof_type_with_mods (count, FALSE);
 		type = transient ? (MonoType *)g_malloc0 (size) : (MonoType *)mono_image_alloc0 (m, size);
 		type->has_cmods = TRUE;
 
@@ -5493,6 +5493,36 @@ mono_metadata_fnptr_equal (MonoMethodSignature *s1, MonoMethodSignature *s2, gbo
 	}
 }
 
+static gboolean
+mono_metadata_custom_modifiers_equal (MonoType *t1, MonoType *t2, gboolean signature_only)
+{
+	// ECMA 335, 7.1.1:
+	// The CLI itself shall treat required and optional modifiers in the same manner.
+	// Two signatures that differ only by the addition of a custom modifier
+	// (required or optional) shall not be considered to match.
+	int count = mono_type_custom_modifier_count (t1);
+	if (count != mono_type_custom_modifier_count (t2))
+		return FALSE;
+
+	for (int i=0; i < count; i++) {
+		// FIXME: propagate error to caller
+		ERROR_DECL (error);
+		gboolean cm1_required, cm2_required;
+
+		MonoType *cm1_type = mono_type_get_custom_modifier (t1, i, &cm1_required, error);
+		mono_error_assert_ok (error);
+		MonoType *cm2_type = mono_type_get_custom_modifier (t2, i, &cm2_required, error);
+		mono_error_assert_ok (error);
+
+		if (cm1_required != cm2_required)
+			return FALSE;
+
+		if (!do_mono_metadata_type_equal (cm1_type, cm2_type, signature_only))
+			return FALSE;
+	}
+	return TRUE;
+}
+
 /*
  * mono_metadata_type_equal:
  * @t1: a type
@@ -5510,41 +5540,10 @@ do_mono_metadata_type_equal (MonoType *t1, MonoType *t2, gboolean signature_only
 
 	gboolean cmod_reject = FALSE;
 
-	gboolean is_pointer = (t1->type == MONO_TYPE_PTR);
-
 	if (t1->has_cmods != t2->has_cmods)
 		cmod_reject = TRUE;
 	else if (t1->has_cmods && t2->has_cmods) {
-		MonoCustomModContainer *cm1 = mono_type_get_cmods (t1);
-		MonoCustomModContainer *cm2 = mono_type_get_cmods (t2);
-
-		g_assert (cm1);
-		g_assert (cm2);
-
-		// ECMA 335, 7.1.1:
-		// The CLI itself shall treat required and optional modifiers in the same manner.
-		// Two signatures that differ only by the addition of a custom modifier 
-		// (required or optional) shall not be considered to match.
-		if (cm1->count != cm2->count) {
-			cmod_reject = TRUE;
-		} else for (int i=0; i < cm1->count; i++) {
-			if (cm1->modifiers[i].required != cm2->modifiers[i].required) {
-				cmod_reject = TRUE;
-				break;
-			}
-
-			// FIXME: propagate error to caller
-			ERROR_DECL (error);
-			MonoClass *c1 = mono_class_get_checked (cm1->image, cm1->modifiers [i].token, error);
-			mono_error_assert_ok (error);
-			MonoClass *c2 = mono_class_get_checked (cm2->image, cm2->modifiers [i].token, error);
-			mono_error_assert_ok (error);
-
-			if (c1 != c2) {
-				cmod_reject = TRUE;
-				break;
-			}
-		}
+		cmod_reject = !mono_metadata_custom_modifiers_equal (t1, t2, signature_only);
 	}
 
 	gboolean result = FALSE;
@@ -5604,10 +5603,7 @@ do_mono_metadata_type_equal (MonoType *t1, MonoType *t2, gboolean signature_only
 		return FALSE;
 	}
 
-	if (cmod_reject && is_pointer)
-		return FALSE;
-
-	return result;
+	return result && !cmod_reject;
 }
 
 /**
@@ -5681,6 +5677,30 @@ mono_metadata_signature_equal (MonoMethodSignature *sig1, MonoMethodSignature *s
 	return TRUE;
 }
 
+MonoType *
+mono_type_get_custom_modifier (const MonoType *ty, uint8_t idx, gboolean *required, MonoError *error)
+{
+	g_assert (ty->has_cmods);
+	if (mono_type_is_aggregate_mods (ty)) {
+		MonoAggregateModContainer *amods = mono_type_get_amods (ty);
+		g_assert (idx < amods->count);
+		MonoSingleCustomMod *cmod = &amods->modifiers [idx];
+		if (required)
+			*required = !!cmod->required;
+		return cmod->type;
+	} else {
+		MonoCustomModContainer *cmods = mono_type_get_cmods (ty);
+		g_assert (idx < cmods->count);
+		MonoCustomMod *cmod = &cmods->modifiers [idx];
+		if (required)
+			*required = !!cmod->required;
+		MonoImage *image = cmods->image;
+		uint32_t token = cmod->token;
+		return mono_type_get_checked (image, token, NULL, error);
+	}
+}
+
+
 /**
  * mono_metadata_type_dup:
  * \param image image to alloc memory from
@@ -5693,25 +5713,151 @@ mono_metadata_type_dup (MonoImage *image, const MonoType *o)
 	return mono_metadata_type_dup_with_cmods (image, o, o);
 }
 
+static void
+deep_type_dup_fixup (MonoImage *image, MonoType *r, const MonoType *o);
+
+static uint8_t
+custom_modifier_copy (MonoAggregateModContainer *dest, uint8_t dest_offset, const MonoType *source)
+{
+	if (mono_type_is_aggregate_mods (source)) {
+		MonoAggregateModContainer *src_cmods = mono_type_get_amods (source);
+		memcpy (&dest->modifiers [dest_offset], &src_cmods->modifiers[0], src_cmods->count * sizeof (MonoSingleCustomMod));
+		dest_offset += src_cmods->count;
+	} else {
+		MonoCustomModContainer *src_cmods = mono_type_get_cmods (source);
+		for (int i = 0; i < src_cmods->count; i++) {
+			ERROR_DECL (error); // XXX FIXME: AK - propagate the error to the caller.
+			MonoSingleCustomMod *cmod = &dest->modifiers [dest_offset++];
+			cmod->type = mono_type_get_checked (src_cmods->image, src_cmods->modifiers [i].token, NULL, error);
+			mono_error_assert_ok (error);
+			cmod->required = src_cmods->modifiers [i].required;
+		}
+	}
+	return dest_offset;
+}
+
+/* makes a dup of 'o' but also appends the custom modifiers from 'cmods_source' */
+static MonoType *
+do_metadata_type_dup_append_cmods (MonoImage *image, const MonoType *o, const MonoType *cmods_source)
+{
+	g_assert (o != cmods_source);
+	g_assert (o->has_cmods);
+	g_assert (cmods_source->has_cmods);
+	if (!mono_type_is_aggregate_mods (o) &&
+	    !mono_type_is_aggregate_mods (cmods_source) &&
+	    mono_type_get_cmods (o)->image == mono_type_get_cmods (cmods_source)->image) {
+		/* the uniform case: all the cmods are from the same image. */
+		MonoCustomModContainer *o_cmods = mono_type_get_cmods (o);
+		MonoCustomModContainer *extra_cmods = mono_type_get_cmods (cmods_source);
+		uint8_t total_cmods = o_cmods->count + extra_cmods->count;
+		gboolean aggregate = FALSE;
+		size_t sizeof_dup = mono_sizeof_type_with_mods (total_cmods, aggregate);
+		MonoType *r = image ? (MonoType *)mono_image_alloc0 (image, sizeof_dup) : (MonoType *)g_malloc0 (sizeof_dup);
+
+		mono_type_with_mods_init (r, total_cmods, aggregate);
+
+		/* copy the original type o, not including its modifiers */
+		memcpy (r, o, mono_sizeof_type_with_mods (0, FALSE));
+		deep_type_dup_fixup (image, r, o);
+
+		/* The modifier order matters to Roslyn, they expect the extra cmods to come first:
+		 *
+		 * Suppose we substitute 'int32 modopt(IsLong)' for 'T' in 'void Test
+		 * (T modopt(IsConst) t)'.  Roslyn expects the result to be 'void Test
+		 * (int32 modopt(IsConst) modopt(IsLong) t)'.
+		 *
+		 * (Here 'o' is 'int32 modopt(IsLong)' and cmods_source is 'T modopt(IsConst)')
+		 */
+		/* append the modifiers from cmods_source and o */
+		MonoCustomModContainer *r_container = mono_type_get_cmods (r);
+		uint8_t dest_offset = 0;
+		r_container->image = extra_cmods->image;
+
+		memcpy (&r_container->modifiers [dest_offset], &extra_cmods->modifiers [0], extra_cmods->count * sizeof (MonoCustomMod));
+		dest_offset += extra_cmods->count;
+		memcpy (&r_container->modifiers [dest_offset], &o_cmods->modifiers [0], o_cmods->count * sizeof (MonoCustomMod));
+
+		return r;
+	} else {
+		/* The aggregate case: either o_cmods or extra_cmods has aggregate cmods, or they're both simple but from different images. */
+		uint8_t total_cmods = 0;
+		total_cmods += mono_type_custom_modifier_count (cmods_source);
+		total_cmods += mono_type_custom_modifier_count (o);
+		    
+		gboolean aggregate = TRUE;
+		size_t sizeof_dup = mono_sizeof_type_with_mods (total_cmods, aggregate);
+
+		/* FIXME: if image, and the images of the custom modifiers from
+		 * o and cmods_source are all different, we need an image
+		 * set... */
+		MonoType *r = image ? (MonoType *)mono_image_alloc0 (image, sizeof_dup) : (MonoType*)g_malloc0 (sizeof_dup);
+
+		mono_type_with_mods_init (r, total_cmods, aggregate);
+
+		memcpy (r, o, mono_sizeof_type_with_mods (0, FALSE));
+		deep_type_dup_fixup (image, r, o);
+
+		MonoAggregateModContainer *r_container = mono_type_get_amods (r);
+		uint8_t dest_offset = 0;
+
+		dest_offset = custom_modifier_copy (r_container, dest_offset, cmods_source);
+		dest_offset = custom_modifier_copy (r_container, dest_offset, o);
+		g_assert (dest_offset == total_cmods);
+
+		return r;
+	}
+}
+
+static void
+deep_type_dup_amods_fixup (MonoImage *image, MonoType *r)
+{
+	// replace each custom modifier in r by a dup.
+	MonoAggregateModContainer *r_container = mono_type_get_amods (r);
+	for (int i = 0; i < r_container->count; ++i)
+		r_container->modifiers [i].type = mono_metadata_type_dup (image, r_container->modifiers [i].type);
+}
+
 /**
  * Works the same way as mono_metadata_type_dup but pick cmods from @cmods_source
  */
 MonoType *
 mono_metadata_type_dup_with_cmods (MonoImage *image, const MonoType *o, const MonoType *cmods_source)
 {
-	MonoType *r = NULL;
-	size_t sizeof_o = mono_sizeof_type (cmods_source);
-
-	r = image ? (MonoType *)mono_image_alloc0 (image, sizeof_o) : (MonoType *)g_malloc (sizeof_o);
-
-	if (cmods_source->has_cmods) {
-		g_assert (!image || image == mono_type_get_cmods (cmods_source)->image);
-		memcpy (r, cmods_source, sizeof_o);
+	if (o->has_cmods && o != cmods_source && cmods_source->has_cmods) {
+		return do_metadata_type_dup_append_cmods (image, o, cmods_source);
 	}
 
-	memcpy (r, o, sizeof (MonoType));
-	r->has_cmods = cmods_source->has_cmods;
+	MonoType *r = NULL;
 
+	/* if we get here, either o and cmods_source alias, or else exactly one of them has cmods. */
+
+	uint8_t num_mods = MAX (mono_type_custom_modifier_count (o), mono_type_custom_modifier_count (cmods_source));
+	gboolean aggregate = mono_type_is_aggregate_mods (o) || mono_type_is_aggregate_mods (cmods_source);
+	size_t sizeof_r = mono_sizeof_type_with_mods (num_mods, aggregate);
+
+	r = image ? (MonoType *)mono_image_alloc0 (image, sizeof_r) : (MonoType *)g_malloc0 (sizeof_r);
+
+	if (cmods_source->has_cmods) {
+		/* FIXME: if it's aggregate what do we assert here? */
+		g_assert (!image || (!aggregate && image == mono_type_get_cmods (cmods_source)->image));
+		memcpy (r, cmods_source, mono_sizeof_type (cmods_source));
+	}
+
+	memcpy (r, o, mono_sizeof_type (o));
+
+	/* reset custom mod count and aggregateness to be correct. */
+	mono_type_with_mods_init (r, num_mods, aggregate);
+
+	deep_type_dup_fixup (image, r, o);
+	if (aggregate)
+		deep_type_dup_amods_fixup (image, r);
+	return r;
+}
+
+
+static void
+deep_type_dup_fixup (MonoImage *image, MonoType *r, const MonoType *o)
+{
 	if (o->type == MONO_TYPE_PTR) {
 		r->data.type = mono_metadata_type_dup (image, o->data.type);
 	} else if (o->type == MONO_TYPE_ARRAY) {
@@ -5720,7 +5866,6 @@ mono_metadata_type_dup_with_cmods (MonoImage *image, const MonoType *o, const Mo
 		/*FIXME the dup'ed signature is leaked mono_metadata_free_type*/
 		r->data.method = mono_metadata_signature_deep_dup (image, o->data.method);
 	}
-	return r;
 }
 
 /**
@@ -7268,6 +7413,17 @@ mono_loader_get_strict_strong_names (void)
 }
 
 
+gboolean
+mono_type_is_aggregate_mods (const MonoType *t)
+{
+	if (!t->has_cmods)
+		return FALSE;
+
+	MonoTypeWithModifiers *full = (MonoTypeWithModifiers *)t;
+
+	return full->is_aggregate;
+}
+
 MonoCustomModContainer *
 mono_type_get_cmods (const MonoType *t)
 {
@@ -7276,29 +7432,52 @@ mono_type_get_cmods (const MonoType *t)
 
 	MonoTypeWithModifiers *full = (MonoTypeWithModifiers *)t;
 
-	return &full->cmods;
+	g_assert (!full->is_aggregate);
+	return &full->mods.cmods;
+}
+
+MonoAggregateModContainer *
+mono_type_get_amods (const MonoType *t)
+{
+	if (!t->has_cmods)
+		return NULL;
+
+	MonoTypeWithModifiers *full = (MonoTypeWithModifiers *)t;
+
+	g_assert (full->is_aggregate);
+	return &full->mods.amods;
 }
 
 size_t 
-mono_sizeof_type_with_mods (uint8_t num_mods)
+mono_sizeof_type_with_mods (uint8_t num_mods, gboolean is_aggregate)
 {
-	size_t accum = 0;
-	accum += sizeof (MonoType);
 	if (num_mods == 0)
-		return accum;
+		return sizeof (MonoType);
+	size_t accum = 0;
+	accum += offsetof (MonoTypeWithModifiers, mods);
 
-	accum += offsetof (struct _MonoCustomModContainer, modifiers);
-	accum += sizeof (MonoCustomMod) * num_mods;
+	if (!is_aggregate) {
+		accum += offsetof (struct _MonoCustomModContainer, modifiers);
+		accum += sizeof (MonoCustomMod) * num_mods;
+	} else {
+		accum += offsetof (MonoAggregateModContainer, modifiers);
+		accum += sizeof (MonoSingleCustomMod) * num_mods;
+	}
 	return accum;
 }
 
 size_t 
 mono_sizeof_type (const MonoType *ty)
 {
-	MonoCustomModContainer *cmods = mono_type_get_cmods (ty);
-	if (cmods)
-		return mono_sizeof_type_with_mods (cmods->count);
-	else
+	if (ty->has_cmods) {
+		if (!mono_type_is_aggregate_mods (ty)) {
+			MonoCustomModContainer *cmods = mono_type_get_cmods (ty);
+			return mono_sizeof_type_with_mods (cmods->count, FALSE);
+		} else {
+			MonoAggregateModContainer *amods = mono_type_get_amods (ty);
+			return mono_sizeof_type_with_mods (amods->count, TRUE);
+		}
+	} else
 		return sizeof (MonoType);
 }
 

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -465,6 +465,16 @@ mono_type_get_object_checked (MonoDomain *domain, MonoType *type, MonoError *err
 	 */
 	type = m_class_get_byval_arg (klass)->byref == type->byref ? m_class_get_byval_arg (klass) : m_class_get_this_arg (klass);
 
+	/* We don't want to return types with custom modifiers to the managed
+	 * world since they're hard to distinguish from plain types using the
+	 * reflection APIs, but they are not ReferenceEqual to the unadorned
+	 * types.
+	 *
+	 * If we ever see cmods here, it's a bug: MonoClass:byval_arg and
+	 * MonoClass:this_arg shouldn't have cmods by construction.
+	 */
+	g_assert (!type->has_cmods);
+
 	/* void is very common */
 #ifdef ENABLE_NETCORE
 	if (!type->byref && type->type == MONO_TYPE_VOID && domain->typeof_void)

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -1503,37 +1503,44 @@ add_custom_modifiers_to_type (MonoType *without_mods, MonoArrayHandle req_array,
 	if (!MONO_HANDLE_IS_NULL (opt_array))
 		num_opt_mods = mono_array_handle_length (opt_array);
 
-	if (!(num_opt_mods || num_req_mods))
+	const int total_mods = num_req_mods + num_opt_mods;
+	if (total_mods == 0)
 		return without_mods;
 
 	MonoTypeWithModifiers *result;
-	result = mono_image_g_malloc0 (image, mono_sizeof_type_with_mods (num_req_mods + num_opt_mods, FALSE));
+	result = mono_image_g_malloc0 (image, mono_sizeof_type_with_mods (total_mods, FALSE));
 	memcpy (result, without_mods, MONO_SIZEOF_TYPE);
 	result->unmodified.has_cmods = 1;
 	MonoCustomModContainer *cmods = mono_type_get_cmods ((MonoType *)result);
 	g_assert (cmods);
-	cmods->count = num_req_mods + num_opt_mods;
+	cmods->count = total_mods;
 	cmods->image = image;
 
 	g_assert (image_is_dynamic (image));
 	MonoDynamicImage *allocator = (MonoDynamicImage *) image;
 
-	int modifier_index = 0;
+	g_assert (total_mods > 0);
+	/* store cmods in reverse order from how the API supplies them.
+	(Assemblies store modifiers in reverse order of IL syntax - and SRE
+	follows the same order as IL syntax). */
+	int modifier_index = total_mods - 1;
 
 	MonoObjectHandle mod_handle = MONO_HANDLE_NEW (MonoObject, NULL);
 	for (int i=0; i < num_req_mods; i++) {
 		cmods->modifiers [modifier_index].required = TRUE;
 		MONO_HANDLE_ARRAY_GETREF (mod_handle, req_array, i);
 		cmods->modifiers [modifier_index].token = mono_image_create_token (allocator, mod_handle, FALSE, TRUE, error);
-		modifier_index++;
+		modifier_index--;
 	}
 
 	for (int i=0; i < num_opt_mods; i++) {
 		cmods->modifiers [modifier_index].required = FALSE;
 		MONO_HANDLE_ARRAY_GETREF (mod_handle, opt_array, i);
 		cmods->modifiers [modifier_index].token = mono_image_create_token (allocator, mod_handle, FALSE, TRUE, error);
-		modifier_index++;
+		modifier_index--;
 	}
+
+	g_assert (modifier_index == -1);
 
 	HANDLE_FUNCTION_RETURN_VAL ((MonoType *) result);
 }

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -1507,7 +1507,7 @@ add_custom_modifiers_to_type (MonoType *without_mods, MonoArrayHandle req_array,
 		return without_mods;
 
 	MonoTypeWithModifiers *result;
-	result = mono_image_g_malloc0 (image, mono_sizeof_type_with_mods (num_req_mods + num_opt_mods));
+	result = mono_image_g_malloc0 (image, mono_sizeof_type_with_mods (num_req_mods + num_opt_mods, FALSE));
 	memcpy (result, without_mods, MONO_SIZEOF_TYPE);
 	result->unmodified.has_cmods = 1;
 	MonoCustomModContainer *cmods = mono_type_get_cmods ((MonoType *)result);

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -3388,18 +3388,19 @@ encode_type (MonoAotCompile *acfg, MonoType *t, guint8 *buf, guint8 **endbuf)
 	guint8 *p = buf;
 
 	if (t->has_cmods) {
-		/* TODO: encode mono_type_get_amods, too. */
-		MonoCustomModContainer *cm = mono_type_get_cmods (t);
+		int count = mono_type_custom_modifier_count (t);
 
 		*p = MONO_TYPE_CMOD_REQD;
 		++p;
 
-		encode_value (cm->count, p, &p);
-		int iindex = get_image_index (acfg, cm->image);
-		encode_value (iindex, p, &p);
-		for (int i = 0; i < cm->count; ++i) {
-			encode_value (cm->modifiers [i].required, p, &p);
-			encode_value (cm->modifiers [i].token, p, &p);
+		encode_value (count, p, &p);
+		for (int i = 0; i < count; ++i) {
+			ERROR_DECL (error);
+			gboolean required;
+			MonoType *cmod_type = mono_type_get_custom_modifier (t, i, &required, error);
+			mono_error_assert_ok (error);
+			encode_value (required, p, &p);
+			encode_type (acfg, cmod_type, p, &p);
 		}
 	}
 

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -3388,6 +3388,7 @@ encode_type (MonoAotCompile *acfg, MonoType *t, guint8 *buf, guint8 **endbuf)
 	guint8 *p = buf;
 
 	if (t->has_cmods) {
+		/* TODO: encode mono_type_get_amods, too. */
 		MonoCustomModContainer *cm = mono_type_get_cmods (t);
 
 		*p = MONO_TYPE_CMOD_REQD;

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -671,6 +671,8 @@ decode_type (MonoAotModule *module, guint8 *buf, guint8 **endbuf, MonoError *err
 		t = (MonoType*)g_malloc0 (mono_sizeof_type_with_mods (count, TRUE));
 		mono_type_with_mods_init (t, count, TRUE);
 
+		/* Try not to blow up the stack. See comment on MONO_MAX_EXPECTED_CMODS */
+		g_assert (count < MONO_MAX_EXPECTED_CMODS);
 		MonoAggregateModContainer *cm = g_alloca (mono_sizeof_aggregate_modifiers (count));
 		cm->count = count;
 		for (int i = 0; i < count; ++i) {

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -667,7 +667,8 @@ decode_type (MonoAotModule *module, guint8 *buf, guint8 **endbuf, MonoError *err
 
 		int count = decode_value (p, &p);
 
-		t = (MonoType*)g_malloc0 (mono_sizeof_type_with_mods (count));
+		/* TODO: possibility that encode_type will encode aggregate mods */
+		t = (MonoType*)g_malloc0 (mono_sizeof_type_with_mods (count, FALSE));
 		t->has_cmods = TRUE;
 
 		MonoCustomModContainer *cm = mono_type_get_cmods (t);

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -667,24 +667,24 @@ decode_type (MonoAotModule *module, guint8 *buf, guint8 **endbuf, MonoError *err
 
 		int count = decode_value (p, &p);
 
-		/* TODO: possibility that encode_type will encode aggregate mods */
-		t = (MonoType*)g_malloc0 (mono_sizeof_type_with_mods (count, FALSE));
-		t->has_cmods = TRUE;
+		/* TODO: encode aggregate cmods differently than simple cmods and make it possible to use the more compact encoding here. */
+		t = (MonoType*)g_malloc0 (mono_sizeof_type_with_mods (count, TRUE));
+		mono_type_with_mods_init (t, count, TRUE);
 
-		MonoCustomModContainer *cm = mono_type_get_cmods (t);
-		int iindex = decode_value (p, &p);
-		cm->image = load_image (module, iindex, error);
-		if (!cm->image) {
-			g_free (t);
-			return NULL;
-		}
+		MonoAggregateModContainer *cm = g_alloca (mono_sizeof_aggregate_modifiers (count));
 		cm->count = count;
-		for (int i = 0; i < cm->count; ++i) {
-			cm->modifiers [i].required = decode_value (p, &p);
-			cm->modifiers [i].token = decode_value (p, &p);
+		for (int i = 0; i < count; ++i) {
+			MonoSingleCustomMod *cmod = &cm->modifiers [i];
+			cmod->required = decode_value (p, &p);
+			cmod->type = decode_type (module, p, &p, error);
+			goto_if_nok (error, fail);
 		}
+
+		mono_type_set_amods (t, mono_metadata_get_canonical_aggregate_modifiers (cm));
+		for (int i = 0; i < count; ++i)
+			mono_metadata_free_type (cm->modifiers [i].type);
 	} else {
-		t = (MonoType *) g_malloc0 (sizeof (MonoType));
+		t = (MonoType *) g_malloc0 (MONO_SIZEOF_TYPE);
 	}
 
 	while (TRUE) {

--- a/mono/mini/aot-runtime.h
+++ b/mono/mini/aot-runtime.h
@@ -11,7 +11,7 @@
 #include "mini.h"
 
 /* Version number of the AOT file format */
-#define MONO_AOT_FILE_VERSION 156
+#define MONO_AOT_FILE_VERSION 157
 
 #define MONO_AOT_TRAMP_PAGE_SIZE 16384
 

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1011,6 +1011,7 @@ TESTS_IL_SRC=			\
 	ldfldvt.il \
 	newobj-abstract.il \
 	invalid-isbyreflike.il \
+	custom-modifiers-append.1.il \
 	gh-13056_mono_local_cprop_av.il \
 	gh-13057_mono_local_emulate_ops_av.il \
 	module-cctor-entrypoint.il

--- a/mono/tests/custom-modifiers-append.1.il
+++ b/mono/tests/custom-modifiers-append.1.il
@@ -1,0 +1,148 @@
+// Test runtime custom modifier behavior.
+//
+// Roslyn expects custom modifiers to append together when a generic type is
+// instantiated.
+//
+// For example, if a method has the signature
+//       .method public hidebysig virtual instance void Method (!0 modopt(Foo))
+// and the type is instantiated with int32 modopt (Bar)
+// the result should be a method with a signature
+//       .method public hidebysig virtual instance void Method (int32 modopt(Foo) modopt(Bar))
+
+.assembly extern mscorlib { }
+.assembly 'custom-modifiers-append.1' { }
+
+.class public Foo
+{
+    .method public hidebysig specialname rtspecialname instance void .ctor()
+    {
+	ldarg.0
+	call instance void object::.ctor()
+	ret
+    }
+}
+
+.class public Bar
+{
+    .method public hidebysig specialname rtspecialname instance void .ctor()
+    {
+	ldarg.0
+	call instance void object::.ctor()
+	ret
+    }
+}
+
+
+.class public BaseClass`1<T1> extends [mscorlib]System.Object
+{
+    .method public hidebysig specialname rtspecialname instance void .ctor()
+    {
+	ldarg.0
+	call instance void object::.ctor()
+	ret
+    }
+
+    .method public newslot virtual instance int32 TestMethod(!T1 modopt(Foo))
+    {
+	ldstr "In BaseClass::TestMethod (T1 modopt(Foo))"
+	call void class [mscorlib]System.Console::WriteLine(string)
+	ldc.i4.1
+	ret
+    }
+
+    .method public newslot virtual instance int32 TestMethod(!T1)
+    {
+	ldstr "In BaseClass::TestMethod (T1)"
+	call void class [mscorlib]System.Console::WriteLine(string)
+	ldc.i4.2
+	ret
+    }
+}
+
+.class public MidClass extends class BaseClass`1<int32 modopt(Bar)>
+{
+    .method public hidebysig specialname rtspecialname instance void .ctor()
+    {
+	ldarg.0
+	call instance void class BaseClass`1<int32 modopt(Bar)>::.ctor()
+	ret
+    }
+
+    .method public hidebysig virtual instance int32 TestMethod(int32 modopt(Bar))
+    {
+	ldstr "In MidClass::TestMethod (int32 modopt(Bar))"
+	call void class [mscorlib]System.Console::WriteLine(string)
+	ldc.i4.s 21
+	ret
+    }
+}
+
+.class public LeafClass extends class MidClass
+{
+    .method public hidebysig specialname rtspecialname instance void .ctor()
+    {
+	ldarg.0
+	call instance void class MidClass::.ctor()
+	ret
+    }
+
+    .method public hidebysig virtual instance int32 TestMethod(int32 modopt(Bar) modopt(Foo))
+    {
+	ldstr "In LeafClass::TestMethod (int32 modopt(Bar) modopt(Foo))"
+	call void class [mscorlib]System.Console::WriteLine(string)
+	ldc.i4 32
+	ret
+    }
+}
+
+.class public MainClass
+{
+    .method public static hidebysig int32 Main()
+    {
+	.entrypoint
+	.locals init (class BaseClass`1<int32> c)
+	ldstr "HelloWorld"
+	call void class [mscorlib]System.Console::WriteLine(string)
+	newobj instance void class MidClass::.ctor()
+	stloc.0
+	ldloc.0
+	ldc.i4.0
+	// expect the call to BaseClass::TestMethod (T1 modopt(Foo))
+	callvirt instance int32 class BaseClass`1<int32>::TestMethod(!0 modopt(Foo))
+	ldc.i4.1
+	bne.un bad1
+	br after1
+    bad1:
+	ldc.i4.1
+	ret
+    after1:
+	newobj instance void class MidClass::.ctor()
+	stloc.0
+	ldloc.0
+	ldc.i4.0
+	// expect the call to MidClass::TestMethod (int32 modopt(Bar))
+	callvirt instance int32 class BaseClass`1<int32>::TestMethod(!0)
+	ldc.i4.s 21
+	bne.un bad2
+	br after2
+    bad2:
+	ldc.i4.2
+	ret
+    after2:
+	newobj instance void class LeafClass::.ctor()
+	stloc.0
+	ldloc.0
+	ldc.i4.0
+	// expect the call to LeafClass::TestMethod (int32 modopt(Bar) modopt(Foo))
+	callvirt instance int32 class BaseClass`1<int32>::TestMethod(!0 modopt(Foo))
+	ldc.i4.s 32
+	bne.un bad3
+	br after3
+    bad3:
+	ldc.i4.2
+	ret
+    after3:
+	ldc.i4.0
+	ret
+    }
+}

--- a/mono/tests/custom-modifiers-lib.il
+++ b/mono/tests/custom-modifiers-lib.il
@@ -20,6 +20,7 @@ extends [mscorlib]System.Object
 {
 	.field public int32 modreq([mscorlib]System.Runtime.CompilerServices.IsBoxed) field_1
 	.field public int32 modopt([mscorlib]System.Runtime.CompilerServices.IsVolatile) field_2
+	.field public int32 modopt([mscorlib]System.Runtime.CompilerServices.IsLong) modopt([mscorlib]System.Runtime.CompilerServices.IsConst) field_3
 } // end of class CustomModifiers
 
 

--- a/mono/tests/custom-modifiers.2.cs
+++ b/mono/tests/custom-modifiers.2.cs
@@ -30,6 +30,16 @@ public class Tests {
 		if (arr [0] != typeof (System.Runtime.CompilerServices.IsVolatile))
 			return 6;
 		
+
+		/* Check that if there's more than one modifier, we get them in the expected order. */
+		arr = typeof (CustomModifiers).GetField ("field_3").GetOptionalCustomModifiers ();
+		if (arr.Length != 2)
+			return 7;
+		if (arr [0] != typeof (System.Runtime.CompilerServices.IsLong))
+			return 8;
+		if (arr [1] != typeof (System.Runtime.CompilerServices.IsConst))
+			return 9;
+
 		return 0;
 	}
 }


### PR DESCRIPTION
This all stems from ECMA 335, 7.1.1:

> The CLI itself shall treat required and optional modifiers in the same
> manner. Two signatures that differ only by the addition of a custom
> modifier (required or optional) shall not be considered to match. Custom
> modifiers have no other effect on the operation of the VES.

This rule means that when comparing signatures, we have to treat two types that
differ only in their custom modifiers as distinct. In particular, we have to do
this when comparing signatures in order to fill in the vtable for a class.  And
moreover, we have to concatenate custom modifiers when doing generic
instantiation.  If a method in a generic type has signature `T modopt(IsConst)
Method()` and we instantiate T with `int32 modopt(IsLong)`, we are expected to
produce the signature `int32 modopt(IsConst) modopt(IsLong) Method()` (with the
custom modifiers on `int32` in that order).

So this PR implements the following operations:
1. custom modifier appending during `mono_metadata_type_dup_with_cmods`
2. custom modifier-respecting comparison in `do_mono_metadata_type_equal`

To do this, we actually have to introduce a second representation of custom
modifiers: in the normal representation, all the cmod type specs come from a
single image.  Whereas now, due to inflation of signatures, we can have a mix
of modifiers from different images.  So in the MonoAggregateModContainer
representation, we pair each typespec token with the image in which it is to be
resolved.

We keep the old representation (a single image to resolve the entire set of
typespec tokens) because it's natural when you're just reading from a single
image.  Also this representation is part of the embedding API.

---

### But that's not all ###


It is possible for generic parameters of a generic class to appear in the
_custom modifiers_ of a type in a method signature.  For example:
```
    T modopt(Nullable`1<T>) Method ()
```

In this case, when we inflate this signature, we need to inflate not only the
return type, but also the modifiers on a return type.

That means our old aggregate representation (where each modifier is a pair of a
MonoImage and a typespec token) is inadequate: we can inflate a signature and
get a custom modifier that doesn't appear as a typespec in any table of any
existing image.

This is the same situation as generic instances: as a program runs, it creates
generic instances that are not part of the source code.  So we solve it the
same way as with generic instances.

Our new `MonoAggregateModContainer` representation is a pointer into memory owned
by a MonoImageSet that contains an entire MonoType for each custom modifier.

The invariant is that the aggregate modifier container is allocated from a
mempool of a `MonoImageSet` that includes the images of all the modifiers.

In general, when inflating, we first create a provisional candidate
MonoAggregateModContainer on the stack and then look it up the image set that
should own it and then look for a "canonical" mod container in the
`MonoImageSet:aggergate_modifiers_cache`

---

Also had to bump the AOT image format, which now always reads back in using the aggregate representation.

---

This should address #10564, #10565, #12422, #10945 (again), #6936, and the parts of #11350 that **don't** deal with arrays.

---

TODO:

- [x] Add some representative test cases to this PR.
- [ ] Modify our acceptance tests to run the various disabled Roslyn tests.