### PR TITLE
Propagate type load errors out of IsAssignableFrom instead of erroneously returning false

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -3543,13 +3543,20 @@ mono_class_is_assignable_from_checked (MonoClass *klass, MonoClass *oklass, gboo
 	if (!m_class_is_inited (oklass))
 		mono_class_init_internal (oklass);
 
-	if (mono_class_has_failure (klass) || mono_class_has_failure  (oklass)) {
+	if (mono_class_has_failure (klass)) {
+		mono_error_set_for_class_failure (error, klass);
+		*result = FALSE;
+		return;
+	}
+
+	if (mono_class_has_failure (oklass)) {
+		mono_error_set_for_class_failure (error, oklass);
 		*result = FALSE;
 		return;
 	}
 
 	MonoType *klass_byval_arg = m_class_get_byval_arg (klass);
-	MonoType  *oklass_byval_arg = m_class_get_byval_arg (oklass);
+	MonoType *oklass_byval_arg = m_class_get_byval_arg (oklass);
 
 	if (mono_type_is_generic_argument (klass_byval_arg)) {
 		if (!mono_type_is_generic_argument (oklass_byval_arg)) {

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -1752,7 +1752,10 @@ ves_icall_RuntimeTypeHandle_type_is_assignable_from (MonoReflectionTypeHandle re
 			 return m_class_is_valuetype (klass) == m_class_is_valuetype (klassc);
 		}
 	}
-	return mono_class_is_assignable_from_internal (klass, klassc);
+
+	gboolean result;
+	mono_class_is_assignable_from_checked (klass, klassc, &result, error);
+	return (guint32)result;
 }
 
 MonoBoolean


### PR DESCRIPTION
This change makes the underlying cause of #13113 discoverable - a type load error was occurring and instead of surfacing the error we were returning false from IsAssignableFrom, causing mysterious failures in other code.