### PR TITLE
threads: set mutex PRIO_INHERIT in attribute

### DIFF
--- a/mono/utils/mono-os-mutex.h
+++ b/mono/utils/mono-os-mutex.h
@@ -49,17 +49,7 @@ typedef pthread_mutex_t mono_mutex_t;
 typedef pthread_cond_t mono_cond_t;
 
 static inline void
-mono_os_mutex_init (mono_mutex_t *mutex)
-{
-	int res;
-
-	res = pthread_mutex_init (mutex, NULL);
-	if (G_UNLIKELY (res != 0))
-		g_error ("%s: pthread_mutex_init failed with \"%s\" (%d)", __func__, g_strerror (res), res);
-}
-
-static inline void
-mono_os_mutex_init_recursive (mono_mutex_t *mutex)
+mono_os_mutex_init_type (mono_mutex_t *mutex, int type)
 {
 	int res;
 	pthread_mutexattr_t attr;
@@ -68,9 +58,13 @@ mono_os_mutex_init_recursive (mono_mutex_t *mutex)
 	if (G_UNLIKELY (res != 0))
 		g_error ("%s: pthread_mutexattr_init failed with \"%s\" (%d)", __func__, g_strerror (res), res);
 
-	res = pthread_mutexattr_settype (&attr, PTHREAD_MUTEX_RECURSIVE);
+	res = pthread_mutexattr_settype (&attr, type);
 	if (G_UNLIKELY (res != 0))
 		g_error ("%s: pthread_mutexattr_settype failed with \"%s\" (%d)", __func__, g_strerror (res), res);
+
+	res = pthread_mutexattr_setprotocol (&attr, PTHREAD_PRIO_INHERIT);
+	if (G_UNLIKELY (res != 0))
+		g_error ("%s: pthread_mutexattr_setprotocol failed with \"%s\" (%d)", __func__, g_strerror (res), res);
 
 	res = pthread_mutex_init (mutex, &attr);
 	if (G_UNLIKELY (res != 0))
@@ -79,6 +73,18 @@ mono_os_mutex_init_recursive (mono_mutex_t *mutex)
 	res = pthread_mutexattr_destroy (&attr);
 	if (G_UNLIKELY (res != 0))
 		g_error ("%s: pthread_mutexattr_destroy failed with \"%s\" (%d)", __func__, g_strerror (res), res);
+}
+
+static inline void
+mono_os_mutex_init (mono_mutex_t *mutex)
+{
+	mono_os_mutex_init_type(mutex, PTHREAD_MUTEX_DEFAULT);
+}
+
+static inline void
+mono_os_mutex_init_recursive (mono_mutex_t *mutex)
+{
+	mono_os_mutex_init_type(mutex, PTHREAD_MUTEX_RECURSIVE);
 }
 
 static inline void

--- a/mono/utils/mono-os-mutex.h
+++ b/mono/utils/mono-os-mutex.h
@@ -62,9 +62,12 @@ mono_os_mutex_init_type (mono_mutex_t *mutex, int type)
 	if (G_UNLIKELY (res != 0))
 		g_error ("%s: pthread_mutexattr_settype failed with \"%s\" (%d)", __func__, g_strerror (res), res);
 
+#ifdef PTHREAD_PRIO_INHERIT
+	/* use PTHREAD_PRIO_INHERIT if possible */
 	res = pthread_mutexattr_setprotocol (&attr, PTHREAD_PRIO_INHERIT);
 	if (G_UNLIKELY (res != 0))
 		g_error ("%s: pthread_mutexattr_setprotocol failed with \"%s\" (%d)", __func__, g_strerror (res), res);
+#endif
 
 	res = pthread_mutex_init (mutex, &attr);
 	if (G_UNLIKELY (res != 0))


### PR DESCRIPTION
When running multiple threads on a linux-rt kernel, with different priorities, the lack of priority-inheritance
makes the kernel make wrong scheduling choices.
This commit changes the system-wide mutex initializers.
This change protects our system against unexpected latencies in higher priority threads.

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
