### PR TITLE
[wasm] Add exclude features option when linking through the sdk.

### DIFF
--- a/sdks/wasm/sdk/Mono.WebAssembly.Build/WasmLinkAssemblies.cs
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Build/WasmLinkAssemblies.cs
@@ -98,6 +98,9 @@ namespace Mono.WebAssembly.Build
 
 			sb.Append (" --verbose");
 
+			// add exclude features
+			sb.Append (" --exclude-feature remoting --exclude-feature com --exclude-feature etw");
+
 			string coremode, usermode;
 
 			switch ((WasmLinkMode)Enum.Parse (typeof (WasmLinkMode), LinkMode)) {


### PR DESCRIPTION
Add the following exclude features when linking through the sdk.
   - `--exclude-feature remoting --exclude-feature com --exclude-feature etw`
