### PR TITLE
Better probing logic on Windows when Unicode Win32 symbols are used.

### DIFF
--- a/winconfig.h
+++ b/winconfig.h
@@ -240,8 +240,10 @@
 
 #ifdef _WIN64
 #define TARGET_AMD64 1
+#define HOST_AMD64 1
 #else
 #define TARGET_X86 1
+#define HOST_X86 1
 #endif
 
 /* byte order of target */


### PR DESCRIPTION
Several of the corefx interop sources uses the Unicode names of Win32 symbols. Our current probing implementation on Windows will test the given name last when nomangle is not provided (default). On Windows that will be a large number of probes due to old stdcall name mangling rules. Fix makes sure we first test the symbol against its charset and the given symbol, before trying the stdcall name mangling rules. Will reduce the probing a lot on Windows for corefx Win32 interop classes.
