### PR TITLE
[2018-10][configure.ac] Fix configure checks for Mono.Native

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3041,10 +3041,14 @@ if test x$host_win32 = xno; then
 	AC_CHECK_FUNC(ioctl,             [AC_DEFINE(HAVE_IOCTL, 1, [ioctl])])
 	AC_CHECK_FUNC(sched_getaffinity, [AC_DEFINE(HAVE_SCHED_GETAFFINITY, 1, [sched_getaffinity])])
 	AC_CHECK_FUNC(sched_setaffinity, [AC_DEFINE(HAVE_SCHED_SETAFFINITY, 1, [sched_setaffinity])])
+
+	if test "x$platform_android" != "xyes"; then
+		AC_CHECK_FUNC(arc4random_buf,    [AC_DEFINE(HAVE_ARC4RANDOM_BUF, 1, [arc4random_buf])])
+	fi
+
 	AC_CHECK_DECL(TIOCGWINSZ,        [AC_DEFINE(HAVE_TIOCGWINSZ, 1, [TIOCGWINSZ])], [], [[#include <sys/ioctl.h>]])
 	AC_CHECK_FUNC(tcgetattr,         [AC_DEFINE(HAVE_TCGETATTR, 1, [tcgetattr])])
 	AC_CHECK_FUNC(tcsetattr,         [AC_DEFINE(HAVE_TCSETATTR, 1, [tcsetattr])])
-	AC_CHECK_FUNC(arc4random,        [AC_DEFINE(HAVE_ARC4RANDOM, 1, [arc4random])])
 	AC_CHECK_DECL(ECHO,              [AC_DEFINE(HAVE_ECHO, 1, [ECHO])], [], [[#include <termios.h>]])
 	AC_CHECK_DECL(ICANON,            [AC_DEFINE(HAVE_ICANON, 1, [ICANON])], [], [[#include <termios.h>]])
 	AC_CHECK_DECL(TCSANOW,           [AC_DEFINE(HAVE_TCSANOW, 1, [TCSANOW])], [], [[#include <termios.h>]])
@@ -3081,7 +3085,7 @@ if test x$host_win32 = xno; then
 	fi
 
 	AC_MSG_CHECKING(for readdir_r)
-	AC_TRY_COMPILE([
+	AC_TRY_LINK([
 		#include <dirent.h>
 	], [
 		DIR* dir;
@@ -3096,7 +3100,7 @@ if test x$host_win32 = xno; then
 	])
 
 	AC_MSG_CHECKING(for kevent with void *data)
-	AC_TRY_COMPILE([
+	AC_TRY_LINK([
 		#include <sys/types.h>
 		#include <sys/event.h>
 	], [
@@ -3114,9 +3118,17 @@ if test x$host_win32 = xno; then
 	AC_CHECK_MEMBER(struct fd_set.__fds_bits, [AC_DEFINE(HAVE_PRIVATE_FDS_BITS, 1, [struct fd_set.__fds_bits])], [], [[#include <sys/select.h>]])
 
 	AC_MSG_CHECKING(for sendfile with 4 arguments)
-	AC_TRY_COMPILE([
+	AC_TRY_LINK([
 		#include <sys/sendfile.h>
 	], [
+		#if defined(TARGET_ANDROID)
+		#if !defined(__ANDROID_API__)
+		#error No definition for __ANDROID_API__ even though we're targeting TARGET_ANDROID
+		#elif __ANDROID_API__ < 21
+		#error sendfile is not supported on this Android API level
+		#endif
+		#endif
+
 		int result = sendfile(0, 0, 0, 0);
 	],[
 		AC_MSG_RESULT(yes)
@@ -3146,10 +3158,10 @@ if test x$host_win32 = xno; then
 	AC_CHECK_FUNC(kqueue,        [AC_DEFINE(HAVE_KQUEUE, 1, [kqueue])])
 
 	ORIG_CFLAGS="$CFLAGS"
-	CFLAGS="-Werror -Wsign-conversion"
+	CFLAGS="$CFLAGS -Werror=sign-conversion"
 
 	AC_MSG_CHECKING(for getnameinfo with signed flags)
-	AC_TRY_COMPILE([
+	AC_TRY_LINK([
 		#include <sys/types.h>
 		#include <netdb.h>
 	], [
@@ -3177,10 +3189,10 @@ if test x$host_win32 = xno; then
 	fi
 
 	ORIG_CFLAGS="$CFLAGS"
-	CFLAGS="-Werror -Wsign-conversion"
+	CFLAGS="$CFLAGS -Werror=sign-conversion"
 
 	AC_MSG_CHECKING(for bind with unsigned addrlen)
-	AC_TRY_COMPILE([
+	AC_TRY_LINK([
 		#include <sys/socket.h>
 	], [
 		int fd;
@@ -3195,7 +3207,7 @@ if test x$host_win32 = xno; then
 	])
 
 	AC_MSG_CHECKING(for struct ipv6_mreq with unsigned ipv6mr_interface)
-	AC_TRY_COMPILE([
+	AC_TRY_LINK([
 		#include <netinet/in.h>
 		#include <netinet/tcp.h>
 	], [
@@ -3210,7 +3222,7 @@ if test x$host_win32 = xno; then
 	])
 
 	AC_MSG_CHECKING(for inotify_rm_watch with unsigned wd)
-	AC_TRY_COMPILE([
+	AC_TRY_LINK([
 		#include <sys/inotify.h>
 	], [
 		intptr_t fd;
@@ -3262,7 +3274,7 @@ if test x$host_win32 = xno; then
 	fi
 
 	AC_MSG_CHECKING(for getpriority with int who)
-	AC_TRY_COMPILE([
+	AC_TRY_LINK([
 		#include <sys/resource.h>
 	], [
 		int which;
@@ -3276,7 +3288,7 @@ if test x$host_win32 = xno; then
 	])
 
 	AC_MSG_CHECKING(for kevent with int parameters)
-	AC_TRY_COMPILE([
+	AC_TRY_LINK([
 		#include <sys/types.h>
 		#include <sys/event.h>
 	], [
@@ -3294,34 +3306,15 @@ if test x$host_win32 = xno; then
 		AC_MSG_RESULT(no)
 	])
 
-	ORIG_CFLAGS="$CFLAGS"
-	CFLAGS="-Werror -Wimplicit-function-declaration"
+	AC_CHECK_FUNCS(mkstemps)
+	# AC_CHECK_FUNCS(mkstemp) # already done above
 
-	AC_MSG_CHECKING(for mkstemps)
-	AC_TRY_COMPILE([
-		#include <stdlib.h>
-		#include <unistd.h>
-		#include <string.h>
-	], [
-		char *template;
-		int suffixlen;
-		int result = mkstemps(template, suffixlen);
-	],[
-		AC_MSG_RESULT(yes)
-		AC_DEFINE(HAVE_MKSTEMPS, 1, [mkstemps])
-		have_mkstemps=yes
-	], [
-		AC_MSG_RESULT(no)
-	])
-
-	CFLAGS="$ORIG_CFLAGS"
-
-	if test "x$have_mkstemps" != "xyes" -a "x$ac_cv_func_mkstemp" != "xyes"; then
+	if test "x$ac_cv_func_mkstemps" != "xyes" -a "x$ac_cv_func_mkstemp" != "xyes"; then
 		AC_MSG_ERROR([Cannot find mkstemps or mkstemp on this platform])
 	fi
 
 	AC_MSG_CHECKING(for tcp/var.h)
-	AC_TRY_COMPILE([
+	AC_TRY_LINK([
 		#include <sys/types.h>
 		#include <sys/socketvar.h>
 		#include <netinet/ip.h>
@@ -3338,7 +3331,7 @@ if test x$host_win32 = xno; then
 	AC_CHECK_HEADERS([sys/cdefs.h])
 
 	AC_MSG_CHECKING(for TCPSTATE enum in netinet/tcp.h)
-	AC_TRY_COMPILE([
+	AC_TRY_LINK([
 		#ifdef HAVE_SYS_CDEFS_H
 		#include <sys/cdefs.h>
 		#endif
@@ -3375,10 +3368,10 @@ if test x$host_win32 = xno; then
 	AC_CHECK_FUNC(uname,         [AC_DEFINE(HAVE_UNAME, 1, [uname])])
 
 	ORIG_CFLAGS="$CFLAGS"
-	CFLAGS="-Werror -Weverything"
+	CFLAGS="$CFLAGS -Werror=shorten-64-to-32"
 
 	AC_MSG_CHECKING(for getdomainname with size_t namelen)
-	AC_TRY_COMPILE([
+	AC_TRY_LINK([
 		#include <unistd.h>
 	], [
 		size_t namelen = 20;
@@ -3406,7 +3399,7 @@ if test x$host_win32 = xno; then
 	AC_CHECK_HEADERS([crt_externs.h])
 
 	AC_MSG_CHECKING(for _NSGetEnviron)
-	AC_TRY_COMPILE([
+	AC_TRY_LINK([
 		#include <crt_externs.h>
 	], [
 		char **result = *(_NSGetEnviron());
@@ -3418,6 +3411,7 @@ if test x$host_win32 = xno; then
 	])
 
 	AC_CHECK_DECL(IN_EXCL_UNLINK, [AC_DEFINE(HAVE_IN_EXCL_UNLINK, 1, [IN_EXCL_UNLINK])], [], [[#include <sys/inotify.h>]])
+	AC_CHECK_DECL(TCP_KEEPALIVE, [AC_DEFINE(HAVE_TCP_H_TCP_KEEPALIVE, 1, [TCP_KEEPALIVE])], [], [[#include <netinet/tcp.h>]])
 
 else
 	dnl *********************************
@@ -4536,7 +4530,6 @@ i*86-*-darwin*)
 esac
 
 AC_SUBST(ORDER)
-AC_SUBST(CFLAGS)
 AC_SUBST(PATHSEP)
 AC_SUBST(SEARCHSEP)
 AC_SUBST(OS)
@@ -5121,14 +5114,6 @@ AC_CHECK_HEADER([malloc.h],
 		[AC_DEFINE([HAVE_USR_INCLUDE_MALLOC_H], [1], 
 			[Define to 1 if you have /usr/include/malloc.h.])],,)
 
-if test x"$GCC" = xyes; then
-   	# Implicit function declarations are not 64 bit safe
-	# Do this late, since this causes lots of configure tests to fail
-	CFLAGS="$CFLAGS -Werror-implicit-function-declaration"
-	# jay has a lot of implicit declarations
-	JAY_CFLAGS="-Wno-implicit-function-declaration"
-fi
-
 # When --disable-shared is used, libtool transforms libmono-2.0.la into libmono-2.0.so
 # instead of libmono-static.a
 if test "x$enable_shared" = "xno" -a "x$enable_executables" = "xyes"; then
@@ -5326,9 +5311,6 @@ AC_SUBST(GTKX11)
 AC_SUBST(XINERAMA)
 AC_DEFINE_UNQUOTED(MONO_ARCHITECTURE,"$arch_target",[The architecture this is running on])
 AC_SUBST(arch_target)
-AC_SUBST(CFLAGS)
-AC_SUBST(CPPFLAGS)
-AC_SUBST(LDFLAGS)
 
 #This must always be defined when building the runtime
 AC_DEFINE(MONO_INSIDE_RUNTIME,1, [Disable banned functions from being used by the runtime])
@@ -5527,24 +5509,6 @@ AC_CONFIG_COMMANDS([runtime/etc/mono/4.5/web.config],
 AC_CONFIG_COMMANDS([quiet-libtool], [sed -e 's/echo "copying selected/# "copying selected/g' < libtool > libtool.tmp && mv libtool.tmp libtool && chmod a+x libtool; sed -e 's/$ECHO "copying selected/# "copying selected/g' < libtool > libtool.tmp && mv libtool.tmp libtool && chmod a+x libtool])
 AC_CONFIG_COMMANDS([nolock-libtool], [sed -e 's/lock_old_archive_extraction=yes/lock_old_archive_extraction=no/g' < libtool > libtool.tmp && mv libtool.tmp libtool && chmod a+x libtool])
 AC_CONFIG_COMMANDS([clean-llvm], [rm -f llvm/llvm_config.mk])
-
-# Anything involving -Werror must be done late because autoconf depends on compiling with warnings to be success.
-if test x"$GCC" = xyes; then
-
-	# incompatible-pointer-types requires gcc circa 5.x
-
-	ORIG_CFLAGS=$CFLAGS
-	CFLAGS="$CFLAGS -Wincompatible-pointer-types -Werror"
-	AC_MSG_CHECKING(for -Wincompatible-pointer-types option to gcc)
-	AC_TRY_COMPILE([],[
-	], [
-		AC_MSG_RESULT(yes)
-		CFLAGS="$ORIG_CFLAGS -Werror=incompatible-pointer-types"
-	], [
-		AC_MSG_RESULT(no)
-		CFLAGS=$ORIG_CFLAGS
-	])
-fi
 
 #
 # Mono.Native Support
@@ -5778,6 +5742,42 @@ MONO_NATIVE_PLATFORM_TYPE_UNIFIED="$MONO_NATIVE_PLATFORM_TYPE | MONO_NATIVE_PLAT
 AC_SUBST(MONO_NATIVE_PLATFORM_TYPE)
 AC_SUBST(MONO_NATIVE_PLATFORM_TYPE_COMPAT)
 AC_SUBST(MONO_NATIVE_PLATFORM_TYPE_UNIFIED)
+
+### Set -Werror options
+#
+# Anything involving -Werror must be done late because autoconf depends on compiling with warnings to be success.
+#
+if test x"$GCC" = xyes; then
+
+	if test "x$with_jemalloc" != "xyes"; then
+
+		# incompatible-pointer-types requires gcc circa 5.x
+
+		ORIG_CFLAGS=$CFLAGS
+		CFLAGS="$CFLAGS -Wincompatible-pointer-types -Werror"
+		AC_MSG_CHECKING(for -Wincompatible-pointer-types option to gcc)
+		AC_TRY_COMPILE([],[
+		], [
+			AC_MSG_RESULT(yes)
+			CFLAGS="$ORIG_CFLAGS -Werror=incompatible-pointer-types"
+		], [
+			AC_MSG_RESULT(no)
+			CFLAGS=$ORIG_CFLAGS
+		])
+
+		CFLAGS="$CFLAGS -Werror=return-type"
+	fi
+
+	# Implicit function declarations are not 64 bit safe
+	# Do this late, since this causes lots of configure tests to fail
+	CFLAGS="$CFLAGS -Werror-implicit-function-declaration"
+	# jay has a lot of implicit declarations
+	JAY_CFLAGS="-Wno-implicit-function-declaration"
+fi
+
+AC_SUBST(CFLAGS)
+AC_SUBST(CPPFLAGS)
+AC_SUBST(LDFLAGS)
 
 # Update all submodules recursively to ensure everything is checked out
 (cd $srcdir && scripts/update_submodules.sh)

--- a/configure.ac
+++ b/configure.ac
@@ -2461,6 +2461,7 @@ if test x$host_win32 = xno; then
 			#error "__thread does not currently work with clang on Mac OS X"
 			#endif
 			
+			#include <unistd.h>
 			#include <pthread.h>
 			__thread int i;
 			static int res1, res2;
@@ -2749,6 +2750,9 @@ if test x$host_win32 = xno; then
 		#include <stdio.h>
 		#include <sys/types.h>
 		#include <sys/socket.h>
+		#ifdef HAVE_NET_IF_H
+		#include <net/if.h>
+		#endif
 		#include <ifaddrs.h>
 	], [
 		getifaddrs(NULL);
@@ -3137,6 +3141,9 @@ if test x$host_win32 = xno; then
 		AC_MSG_RESULT(no)
 	])
 
+	ORIG_CFLAGS="$CFLAGS"
+	CFLAGS="$CFLAGS -Werror-implicit-function-declaration"
+
 	AC_MSG_CHECKING(for sendfile with 6 arguments)
 	AC_TRY_LINK([
 		#include <stdlib.h>
@@ -3151,6 +3158,8 @@ if test x$host_win32 = xno; then
 	], [
 		AC_MSG_RESULT(no)
 	])
+
+	CFLAGS="$ORIG_CFLAGS"
 
 	AC_CHECK_FUNC(fcopyfile,     [AC_DEFINE(HAVE_FCOPYFILE, 1, [fcopyfile])])
 	AC_CHECK_FUNC(epoll_create1, [AC_DEFINE(HAVE_EPOLL, 1, [epoll_create1])])
@@ -3364,7 +3373,7 @@ if test x$host_win32 = xno; then
 	AC_CHECK_HEADERS([linux/rtnetlink.h])
 
 	AC_CHECK_FUNC(getpeereid,    [AC_DEFINE(HAVE_GETPEEREID, 1, [getpeereid])])
-	AC_CHECK_FUNC(getdomainname, [AC_DEFINE(HAVE_GETDOMAINNAME, 1, [getdomainname])])
+	#AC_CHECK_FUNC(getdomainname, [AC_DEFINE(HAVE_GETDOMAINNAME, 1, [getdomainname])]) # already done above
 	AC_CHECK_FUNC(uname,         [AC_DEFINE(HAVE_UNAME, 1, [uname])])
 
 	ORIG_CFLAGS="$CFLAGS"

--- a/mono/native/pal_config.h
+++ b/mono/native/pal_config.h
@@ -6,10 +6,3 @@
 #undef HAVE_CLOCK_MONOTONIC
 #undef HAVE_CLOCK_MONOTONIC_COARSE
 #endif
-
-#ifdef TARGET_ANDROID
-/* arc4random_buf() is not available even when configure seems to find it */
-#undef HAVE_ARC4RANDOM_BUF
-/* sendfile() is not available for what seems like x86+older API levels */
-#undef HAVE_SENDFILE_4
-#endif

--- a/tools/sgen/sgen-grep-binprot.c
+++ b/tools/sgen/sgen-grep-binprot.c
@@ -180,7 +180,9 @@ is_always_match (int type)
 
 #include <mono/sgen/sgen-protocol-def.h>
 
-	default: assert (0);
+	default:
+		assert (0);
+		return FALSE;
 	}
 }
 
@@ -502,7 +504,9 @@ match_index (mword ptr, int type, void *data)
 
 #include <mono/sgen/sgen-protocol-def.h>
 
-	default: assert (0);
+	default:
+		assert (0);
+		return 0;
 	}
 }
 
@@ -565,7 +569,9 @@ is_vtable_match (mword ptr, int type, void *data)
 
 #include <mono/sgen/sgen-protocol-def.h>
 
-	default: assert (0);
+	default:
+		assert (0);
+		return FALSE;
 	}
 }
 


### PR DESCRIPTION
When the configure checks were ported from configure.cmake in corefx a couple of mistakes happened:

- Using AC_TRY_COMPILE instead of AC_TRY_LINK:
  CMake's check_c_source_compiles() function compiles *and* links while
  AC_TRY_COMPILE only does the former. This hides potential linking issues
  which should fail the configure check.
- Using CFLAGS="-Werror -W....":
  This works in CMake but autoconf always appends the previously defined
  CFLAGS and since we set e.g. `-Wno-undefined` some configure checks
  would fail due to an unrelated warning being treated as an error.
  We need to only promot specific warnings to errors instead.

While looking at this I also found that we were setting CFLAGS after we already AC_SUBST() it, we need to do this very close to the end of configure.ac. Moved some code into that last block.

Finally, Android has special cases for sendfile and arc4random_buf where they're defined in the header but aren't actually there for certain API profiles. For now we disable arc4random_buf on Android and add a special check for sendfile.
