### PR TITLE
[sdb] Add property AssemblyMirror.HasDebugInfo

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/AssemblyMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/AssemblyMirror.cs
@@ -21,6 +21,7 @@ namespace Mono.Debugger.Soft
 		byte[] metadata_blob;
 		bool? isDynamic;
 		byte[] pdb_blob;
+		bool? has_debug_info;
 		Dictionary<string, long> typeCacheIgnoreCase = new Dictionary<string, long> (StringComparer.InvariantCultureIgnoreCase);
 		Dictionary<string, long> typeCache = new Dictionary<string, long> ();
 		Dictionary<uint, long> tokenTypeCache = new Dictionary<uint, long> ();
@@ -222,5 +223,17 @@ namespace Mono.Debugger.Soft
 			}
 			return vm.GetMethod (methodId);
 		}
-    }
+
+		public bool HasDebugInfo {
+			get {
+				if (has_debug_info.HasValue)
+					return has_debug_info.Value;
+
+				vm.CheckProtocolVersion (2, 51);
+
+				has_debug_info = vm.conn.Assembly_HasDebugInfo (id);
+				return has_debug_info.Value;
+			}
+		}
+	}
 }

--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs
@@ -427,7 +427,7 @@ namespace Mono.Debugger.Soft
 		 * with newer runtimes, and vice versa.
 		 */
 		internal const int MAJOR_VERSION = 2;
-		internal const int MINOR_VERSION = 50;
+		internal const int MINOR_VERSION = 51;
 
 		enum WPSuspendPolicy {
 			NONE = 0,
@@ -548,7 +548,8 @@ namespace Mono.Debugger.Soft
 			GET_IS_DYNAMIC = 9,
 			GET_PDB_BLOB = 10,
 			GET_TYPE_FROM_TOKEN = 11,
-			GET_METHOD_FROM_TOKEN = 12
+			GET_METHOD_FROM_TOKEN = 12,
+			HAS_DEBUG_INFO = 13,
 		}
 
 		enum CmdModule {
@@ -2224,6 +2225,10 @@ namespace Mono.Debugger.Soft
 
 		internal long Assembly_GetMethod (long id, uint token) {
 			return SendReceive (CommandSet.ASSEMBLY, (int)CmdAssembly.GET_METHOD_FROM_TOKEN, new PacketWriter ().WriteId (id).WriteInt ((int)token)).ReadId ();
+		}
+
+		internal bool Assembly_HasDebugInfo (long id) {
+			return SendReceive (CommandSet.ASSEMBLY, (int)CmdAssembly.HAS_DEBUG_INFO, new PacketWriter ().WriteId (id)).ReadBool ();
 		}
 
 		/*

--- a/mono/metadata/mono-debug.c
+++ b/mono/metadata/mono-debug.c
@@ -378,7 +378,7 @@ lookup_image_func (gpointer key, gpointer value, gpointer user_data)
 	if (data->found)
 		return;
 
-	if (handle->image == data->image && handle->symfile)
+	if (handle->image == data->image && (handle->symfile || handle->ppdb))
 		data->found = TRUE;
 }
 

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -274,7 +274,7 @@ typedef struct {
 #define HEADER_LENGTH 11
 
 #define MAJOR_VERSION 2
-#define MINOR_VERSION 50
+#define MINOR_VERSION 51
 
 typedef enum {
 	CMD_SET_VM = 1,
@@ -408,7 +408,8 @@ typedef enum {
 	CMD_ASSEMBLY_GET_IS_DYNAMIC = 9,
 	CMD_ASSEMBLY_GET_PDB_BLOB = 10,
 	CMD_ASSEMBLY_GET_TYPE_FROM_TOKEN = 11,
-	CMD_ASSEMBLY_GET_METHOD_FROM_TOKEN = 12
+	CMD_ASSEMBLY_GET_METHOD_FROM_TOKEN = 12,
+	CMD_ASSEMBLY_HAS_DEBUG_INFO = 13
 } CmdAssembly;
 
 typedef enum {
@@ -7401,6 +7402,10 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
         mono_error_cleanup (error);
         break;
     }
+	case CMD_ASSEMBLY_HAS_DEBUG_INFO: {
+		buffer_add_byte (buf, !ass->dynamic && mono_debug_image_has_debug_info (ass->image));
+		break;
+	}
 	default:
 		return ERR_NOT_IMPLEMENTED;
 	}
@@ -9355,7 +9360,8 @@ static const char* assembly_cmds_str[] = {
 	"GET_OBJECT",
 	"GET_TYPE",
 	"GET_NAME",
-	"GET_DOMAIN"
+	"GET_DOMAIN",
+	"HAS_DEBUG_INFO"
 };
 
 static const char* module_cmds_str[] = {


### PR DESCRIPTION
This PR adds a new property to AssemblyMirror. This will allow us to optimize the treatment of assemblies with and without debug information in our debugger client.