### PR TITLE
Fix build warning in mono-error.h.

### DIFF
--- a/mono/utils/mono-error.h
+++ b/mono/utils/mono-error.h
@@ -49,6 +49,11 @@ enum {
 	MONO_ERROR_CLEANUP_CALLED_SENTINEL = 0xffff
 };
 
+#ifdef _MSC_VER
+__pragma(warning (push))
+__pragma(warning (disable:4201))
+#endif
+
 /*Keep in sync with MonoErrorInternal*/
 typedef union _MonoError {
 	// Merge two uint16 into one uint32 so it can be initialized
@@ -60,6 +65,10 @@ typedef union _MonoError {
 		void *hidden_1 [12]; /*DON'T TOUCH */
 	};
 } MonoError;
+
+#ifdef _MSC_VER
+__pragma(warning (pop))
+#endif
 
 /* Mempool-allocated MonoError.*/
 typedef struct _MonoErrorBoxed MonoErrorBoxed;


### PR DESCRIPTION
Warning (at least on Windows) due to unamed struct:

C4201, nonstandard extension used : nameless struct/union

Since the header can be consumed by embedders this warning should be disabled.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
