### PR TITLE
Remove linq usage from WasmHttpMessageHandler

### DIFF
--- a/sdks/wasm/framework/src/WebAssembly.Net.WebSockets/ClientWebSocket.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Net.WebSockets/ClientWebSocket.cs
@@ -3,8 +3,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
 using System.Net.WebSockets;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;


### PR DESCRIPTION
Remove linq usage from WasmHttpMessageHandler
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
