### PR TITLE
Add missing refsrc ToolLocationHelper methods 

### DIFF
--- a/mcs/class/Microsoft.Build.Utilities/Microsoft.Build.Utilities/ToolLocationHelper.cs
+++ b/mcs/class/Microsoft.Build.Utilities/Microsoft.Build.Utilities/ToolLocationHelper.cs
@@ -29,6 +29,8 @@ using System;
 using System.IO;
 using System.Xml;
 using System.Linq;
+using System.Collections.Generic;
+using System.Runtime.Versioning;
 
 namespace Microsoft.Build.Utilities
 {
@@ -270,5 +272,26 @@ namespace Microsoft.Build.Utilities
 			return Path.Combine (lib_mono_dir, "xbuild", toolsVersion, "bin");
 		}
 #endif
+
+		// These have no meaning in mono except to exist, so return empty lists for each.
+		public static IList<string> GetPathToReferenceAssemblies(string targetFrameworkIdentifier, string targetFrameworkVersion, string targetFrameworkProfile)
+		{
+			return new List<string>();
+		}
+
+		public static IList<string> GetPathToReferenceAssemblies(FrameworkName frameworkName)
+		{
+			return new List<string>();
+		}
+
+		public static IList<string> GetPathToReferenceAssemblies(string targetFrameworkRootPath, FrameworkName frameworkName)
+		{
+			return new List<string>();
+		}
+
+		public static IList<string> GetSupportedTargetFrameworks()
+		{
+			throw new NotImplementedException();
+		}
 	}
 }


### PR DESCRIPTION
Relates to https://github.com/mono/mono/pull/12619

The methods added will be used by refsrc System.Web.Compliation.AssemblyResolver.  They really don't mean anything in a mono context, so that's why they return empty lists.  

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
