### PR TITLE
Add a few properties to AppDomainSetup 

### DIFF
--- a/mcs/class/System/ReferenceSources/DynamicRoleClaimProvider.cs
+++ b/mcs/class/System/ReferenceSources/DynamicRoleClaimProvider.cs
@@ -1,0 +1,21 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+//------------------------------------------------------------------------------
+ 
+using System.Collections.Generic;
+using System.ComponentModel;
+ 
+namespace System.Security.Claims
+{
+    public static class DynamicRoleClaimProvider
+    {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use ClaimsAuthenticationManager to add claims to a ClaimsIdentity", true)]
+        public static void AddDynamicRoleClaims(ClaimsIdentity claimsIdentity, IEnumerable<Claim> claims)
+        {
+            claimsIdentity.ExternalClaims.Add(claims);
+        }
+    }
+}

--- a/mcs/class/System/System.csproj
+++ b/mcs/class/System/System.csproj
@@ -1878,6 +1878,7 @@
             <Compile Include="Mono.Net.Security\SystemCertificateValidator.cs" />
             <Compile Include="ReferenceSources\BinaryCompatibility.cs" />
             <Compile Include="ReferenceSources\ConfigurationManagerInternalFactory.cs" />
+            <Compile Include="ReferenceSources\DynamicRoleClaimProvider.cs" />
             <Compile Include="System.CodeDom.Compiler\CodeDomConfigurationHandler.cs" />
             <Compile Include="System.CodeDom.Compiler\Compiler.cs" />
             <Compile Include="System.CodeDom.Compiler\CompilerCollection.cs" />
@@ -2347,6 +2348,7 @@
             <Compile Include="Mono.Net.Security\SystemCertificateValidator.cs" />
             <Compile Include="ReferenceSources\BinaryCompatibility.cs" />
             <Compile Include="ReferenceSources\ConfigurationManagerInternalFactory.cs" />
+            <Compile Include="ReferenceSources\DynamicRoleClaimProvider.cs" />
             <Compile Include="System.CodeDom.Compiler\CodeDomConfigurationHandler.cs" />
             <Compile Include="System.CodeDom.Compiler\Compiler.cs" />
             <Compile Include="System.CodeDom.Compiler\CompilerCollection.cs" />
@@ -2855,6 +2857,7 @@
             <Compile Include="Mono.Net.Security\SystemCertificateValidator.cs" />
             <Compile Include="ReferenceSources\BinaryCompatibility.cs" />
             <Compile Include="ReferenceSources\ConfigurationManagerInternalFactory.cs" />
+            <Compile Include="ReferenceSources\DynamicRoleClaimProvider.cs" />
             <Compile Include="System.CodeDom.Compiler\CodeDomConfigurationHandler.cs" />
             <Compile Include="System.CodeDom.Compiler\Compiler.cs" />
             <Compile Include="System.CodeDom.Compiler\CompilerCollection.cs" />
@@ -3351,6 +3354,7 @@
             <Compile Include="Mono.Net.Security\SystemCertificateValidator.cs" />
             <Compile Include="ReferenceSources\BinaryCompatibility.cs" />
             <Compile Include="ReferenceSources\ConfigurationManagerInternalFactory.cs" />
+            <Compile Include="ReferenceSources\DynamicRoleClaimProvider.cs" />
             <Compile Include="System.CodeDom.Compiler\CodeDomConfigurationHandler.cs" />
             <Compile Include="System.CodeDom.Compiler\Compiler.cs" />
             <Compile Include="System.CodeDom.Compiler\CompilerCollection.cs" />

--- a/mcs/class/System/net_4_x_System.dll.sources
+++ b/mcs/class/System/net_4_x_System.dll.sources
@@ -200,6 +200,8 @@ System.Net.Mail/SmtpPermissionAttribute.cs
 
 System.Runtime.InteropServices/StandardOleMarshalObject.cs
 
+ReferenceSources/DynamicRoleClaimProvider.cs
+
 System.Security.Permissions/PermissionHelper.cs
 System.Security.Permissions/ResourcePermissionBase.cs
 System.Security.Permissions/ResourcePermissionBaseEntry.cs

--- a/mcs/class/corlib/System/AppDomainSetup.cs
+++ b/mcs/class/corlib/System/AppDomainSetup.cs
@@ -91,6 +91,10 @@ namespace System
 
 		byte [] serialized_non_primitives;
 
+		string manager_assembly;
+		string manager_type;
+		string [] partial_visible_assemblies;
+
 		public AppDomainSetup ()
 		{
 		}
@@ -118,6 +122,9 @@ namespace System
 			domain_initializer_args = setup.domain_initializer_args;
 			disallow_appbase_probe = setup.disallow_appbase_probe;
 			configuration_bytes = setup.configuration_bytes;
+			manager_assembly = setup.manager_assembly;
+			manager_type = setup.manager_type;
+			partial_visible_assemblies = setup.partial_visible_assemblies;
 		}
 
 		public AppDomainSetup (ActivationArguments activationArguments)
@@ -254,6 +261,31 @@ namespace System
 #else
 				loader_optimization = value;
 #endif
+			}
+		}
+
+		// AppDomainManagerAssembly, ManagerType, and PartialTrustVisibleAssemblies 
+		// don't really do anything within Mono, but will help with refsrc compat. 
+		public string AppDomainManagerAssembly {
+			get { return manager_assembly; }
+			set { manager_assembly = value; }
+		}
+
+		public string AppDomainManagerType {
+			get { return manager_type; }
+			set { manager_type = value; }
+		}
+
+		public string [] PartialTrustVisibleAssemblies {
+			get { return partial_visible_assemblies; }
+			set {
+				if (value != null) {
+					partial_visible_assemblies = (string [])value.Clone();
+					Array.Sort<string> (partial_visible_assemblies, StringComparer.OrdinalIgnoreCase);
+				}
+				else {
+					partial_visible_assemblies = null;
+				}
 			}
 		}
 


### PR DESCRIPTION
This relates to https://github.com/mono/mono/pull/12619

* DynamicRoleClaimProvider to help with legacy role management in web forms
* Added AppDomainManagerAssembly, AppDomainManagerType, and PartialTrustVisibleAssemblies
  properties to AppDomainSetup. They don't do anything, but having  them there
  helps lessen the amount of change in refsrc System.Web.

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
