### PR TITLE
Fix build warning, local variable hides global.

### DIFF
--- a/mono/metadata/mono-config.c
+++ b/mono/metadata/mono-config.c
@@ -642,14 +642,14 @@ mono_config_for_assembly_internal (MonoImage *assembly)
 	g_free (cfg_name);
 
 	cfg_name = g_strdup_printf ("%s.config", mono_image_get_name (assembly));
-	const char *mono_cfg_dir = mono_get_config_dir ();
-	if (!mono_cfg_dir) {
+	const char *cfg_dir = mono_get_config_dir ();
+	if (!cfg_dir) {
 		g_free (cfg_name);
 		return;
 	}
 
 	for (i = 0; (aname = get_assembly_filename (assembly, i)) != NULL; ++i) {
-		cfg = g_build_filename (mono_cfg_dir, "mono", "assemblies", aname, cfg_name, NULL);
+		cfg = g_build_filename (cfg_dir, "mono", "assemblies", aname, cfg_name, NULL);
 		got_it += mono_config_parse_file_with_context (&state, cfg);
 		g_free (cfg);
 
@@ -692,9 +692,9 @@ mono_config_parse (const char *filename) {
 		return;
 	}
 
-	const char *mono_cfg_dir = mono_get_config_dir ();
-	if (mono_cfg_dir) {
-		mono_cfg = g_build_filename (mono_cfg_dir, "mono", "config", NULL);
+	const char *cfg_dir = mono_get_config_dir ();
+	if (cfg_dir) {
+		mono_cfg = g_build_filename (cfg_dir, "mono", "config", NULL);
 		mono_config_parse_file (mono_cfg);
 		g_free (mono_cfg);
 	}


### PR DESCRIPTION
On Windows MSVC build this cause:

warning C4459: declaration of 'mono_cfg_dir' hides global declaration
