### PR TITLE
Fix build on Alpine Linux

### DIFF
--- a/mono/utils/mono-os-mutex.h
+++ b/mono/utils/mono-os-mutex.h
@@ -60,7 +60,7 @@ mono_os_mutex_init_type (mono_mutex_t *mutex, int type)
 #ifdef PTHREAD_PRIO_INHERIT
 	/* use PTHREAD_PRIO_INHERIT if possible */
 	res = pthread_mutexattr_setprotocol (&attr, PTHREAD_PRIO_INHERIT);
-	if (G_UNLIKELY (res != 0))
+	if (G_UNLIKELY (res != 0 && res != ENOTSUP))
 		g_error ("%s: pthread_mutexattr_setprotocol failed with \"%s\" (%d)", __func__, g_strerror (res), res);
 #endif
 

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -35,9 +35,9 @@ extern GCStats mono_gc_stats;
 #include <mach/task_info.h>
 #endif
 
-#include <sys/param.h>
+#ifdef HAVE_SYS_SYSCTL_H
 #include <sys/sysctl.h>
-#include <fcntl.h>
+#endif
 
 #ifdef HAVE_SYS_MMAN_H
 #include <sys/mman.h>


### PR DESCRIPTION
- sys/sysctl.h isn't available on Alpine and not needed by the code,
  guard it using HAVE_SYS_SYSCTL_H like elsewhere (param.h/fcntl.h are already included further above). Added by https://github.com/mono/mono/pull/11855

- pthread_mutexattr_setprotocol doesn't support PTHREAD_PRIO_INHERIT,
  check return value. Added by https://github.com/mono/mono/pull/13333
