### PR TITLE
[2018-10] Revert "[mini] Inline Selector.GetHandle for tvOS and watchOS assemblies as well. (#13246)"

### DIFF
--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -1173,8 +1173,6 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 				!strcmp (cmethod_klass_name_space, "XamCore.ObjCRuntime") &&
 				!strcmp (cmethod_klass_name, "Selector")) ||
 			   ((!strcmp (cmethod_klass_image->assembly->aname.name, "Xamarin.iOS") ||
-				 !strcmp (cmethod_klass_image->assembly->aname.name, "Xamarin.WatchOS") ||
-				 !strcmp (cmethod_klass_image->assembly->aname.name, "Xamarin.TVOS") ||
 				 !strcmp (cmethod_klass_image->assembly->aname.name, "Xamarin.Mac")) &&
 				!strcmp (cmethod_klass_name_space, "ObjCRuntime") &&
 				!strcmp (cmethod_klass_name, "Selector"))


### PR DESCRIPTION
This reverts commit c99fe4b4628817d9872172ff8e4b73b4f69bcf9e.

It doesn't work when LLVM is enabled for tvOS: https://github.com/xamarin/xamarin-macios/pull/5742#issuecomment-471007078, it causes multiple compilation errors like this:

    Process exited with code 1, command:
    /Applications/Xcode101.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang  -isysroot /Applications/Xcode101.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.1.sdk -Qunused-arguments -mtvos-version-min=12.1 -fembed-bitcode-marker -arch arm64 -c -o /private/var/folders/nh/n1y9qj2n40d7wpmx1mg9blg80000gn/T/mtouch.cache/arpl1vgs.js6/arm64/Xamarin.TVOS.dll-llvm.o -x assembler /private/var/folders/nh/n1y9qj2n40d7wpmx1mg9blg80000gn/T/mtouch.cache/arpl1vgs.js6/arm64/Xamarin.TVOS.dll-llvm.s
    /private/var/folders/nh/n1y9qj2n40d7wpmx1mg9blg80000gn/T/mtouch.cache/arpl1vgs.js6/arm64/Xamarin.TVOS.dll-llvm.s:4665:14: error: invalid variant 'OBJC_SELECTOR_REFERENCES_.2@PAGE'
            adrp    x8, l_@OBJC_SELECTOR_REFERENCES_.2@PAGE
                           ^
    /private/var/folders/nh/n1y9qj2n40d7wpmx1mg9blg80000gn/T/mtouch.cache/arpl1vgs.js6/arm64/Xamarin.TVOS.dll-llvm.s:4673:18: error: invalid variant 'OBJC_SELECTOR_REFERENCES_.2@PAGEOFF'
            ldr     x1, [x8, l_@OBJC_SELECTOR_REFERENCES_.2@PAGEOFF]




<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->

Backport of #13418.

/cc @lambdageek @rolfbjarne