### PR TITLE
[class-init] Take loader lock around mono_class_setup_interface_id_internal

### DIFF
--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -4393,7 +4393,9 @@ mono_class_init_internal (MonoClass *klass)
 		if (mono_class_set_type_load_failure_causedby_class (klass, gklass, "Generic Type Definition failed to init"))
 			goto leave;
 
+		mono_loader_lock ();
 		mono_class_setup_interface_id_internal (klass);
+		mono_loader_unlock ();
 	}
 
 	if (klass->parent && !klass->parent->inited)


### PR DESCRIPTION


Writing to MonoClass:interface_id must be done with the loader lock held.

Fixes assertion:
```
* Assertion at class-init.c:1830, condition `i == 0 || interfaces_full [i]->interface_id >= interfaces_full [i - 1]->interface_id' not met
```

