### PR TITLE
Fix generating `.dSYM` for GTK assemblies

### DIFF
--- a/packaging/MacSDK/profile.py
+++ b/packaging/MacSDK/profile.py
@@ -99,7 +99,7 @@ class MonoReleaseProfile(DarwinProfile):
         self.env.set('PANGO_SYSCONFDIR', '%{staged_prefix}/etc')
         self.env.set('PANGO_LIBDIR', '%{staged_prefix}/lib')
         # self.env.set ('MONO_PATH', '%{staged_prefix}/lib/mono/4.0')
-        self.debug_info = ['gtk+', 'cairo', 'glib',
+        self.debug_info = ['gtk', 'cairo', 'glib',
                            'pango', 'mono', 'llvm', 'libgdiplus']
         self.cache_host = None
 


### PR DESCRIPTION
Problem is that https://github.com/mono/bockbuild/blob/14535c270ea9f8d536efe6852700d8d1cb657c1f/packages/gtk%2B.py#L4 passes `gtk` for repository name to `GitHubPackage` which then uses this as package name. So when it's decided if `-g` should be added at https://github.com/mono/bockbuild/blob/5c2378112dc681cea0aa5c2447661fb13adbc46b/bockbuild/darwinprofile.py#L158-L159 it's false hence GTK assemblies don't get debug symbols.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
