### PR TITLE
Fix error in SIMD test on Windows x64 LLVM due to changed llc defaults.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1360,7 +1360,7 @@ elif test x$with_runtime_preset = xwinaot_llvm; then
    mono_feature_disable_reflection_emit='yes'
    mono_feature_disable_appdomains='yes'
 
-   AOT_BUILD_FLAGS="--runtime=mobile -O=gsharedvt --llvm --aot=full,$INVARIANT_AOT_OPTIONS"
+   AOT_BUILD_FLAGS="--runtime=mobile -O=gsharedvt --llvm --aot=full,llcopts=-mattr=sse4.1,$INVARIANT_AOT_OPTIONS"
    AOT_RUN_FLAGS="--runtime=mobile --full-aot"
    AOT_MODE="full"
 elif test x$with_runtime_preset = xorbis; then


### PR DESCRIPTION
Regression in SIMD test on Windows x64 LLVM after https://github.com/mono/mono/commit/2eeaf888c1d0a681c8705bd609f76196d8fb82ed