### PR TITLE
[runtime] Avoid putting non-virtual and non-static DIM methods into vtables, roslyn generates these for private property accessors.

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -1548,7 +1548,7 @@ build_imt_slots (MonoClass *klass, MonoVTable *vt, MonoDomain *domain, gpointer*
 				continue;
 			}
 
-			if (!(method->flags & METHOD_ATTRIBUTE_STATIC)) {
+			if (method->flags & METHOD_ATTRIBUTE_VIRTUAL) {
 				add_imt_builder_entry (imt_builder, method, &imt_collisions_bitmap, vt_slot, slot_num);
 				vt_slot ++;
 			}


### PR DESCRIPTION
Fixes part of https://github.com/mono/mono/issues/13374.