### PR TITLE
Fix missing llc options for Windows x64 full AOT + LLVM mini regression tests.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1360,7 +1360,8 @@ elif test x$with_runtime_preset = xwinaot_llvm; then
    mono_feature_disable_reflection_emit='yes'
    mono_feature_disable_appdomains='yes'
 
-   AOT_BUILD_FLAGS="--runtime=mobile -O=gsharedvt --llvm --aot=full,llcopts=-mattr=sse4.1,$INVARIANT_AOT_OPTIONS"
+   INVARIANT_AOT_OPTIONS="llcopts=-mattr=sse4.1,$INVARIANT_AOT_OPTIONS"
+   AOT_BUILD_FLAGS="--runtime=mobile -O=gsharedvt --llvm --aot=full,$INVARIANT_AOT_OPTIONS"
    AOT_RUN_FLAGS="--runtime=mobile --full-aot"
    AOT_MODE="full"
 elif test x$with_runtime_preset = xorbis; then


### PR DESCRIPTION
Turns out that https://github.com/mono/mono/pull/13444 didn't solve the issue fully since mini regression tests are not using the AOT_BUILD_FLAGS variable set in configure script. The mini regression tests do however use the values in the INVARIANT_AOT_OPTION, so adding the llcopt into that will make sure the flag ends up in mini regression tests as well as other CI test suites.