### PR TITLE
[mini] remove public symbol helper_sig_llvmonly_imt_trampoline

### DIFF
--- a/mono/mini/calls.c
+++ b/mono/mini/calls.c
@@ -656,6 +656,7 @@ mini_emit_abs_call (MonoCompile *cfg, MonoJumpInfoType patch_type, gconstpointer
 MonoInst*
 mini_emit_llvmonly_virtual_call (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsig, int context_used, MonoInst **sp)
 {
+	static MonoMethodSignature *helper_sig_llvmonly_imt_trampoline = NULL;
 	MonoInst *icall_args [16];
 	MonoInst *call_target, *ins, *vtable_ins;
 	int arg_reg, this_reg, vtable_reg;
@@ -685,6 +686,11 @@ mini_emit_llvmonly_virtual_call (MonoCompile *cfg, MonoMethod *cmethod, MonoMeth
 
 	if (is_iface && mono_class_has_variant_generic_params (cmethod->klass))
 		variant_iface = TRUE;
+
+	if (!helper_sig_llvmonly_imt_trampoline) {
+		helper_sig_llvmonly_imt_trampoline = mono_create_icall_signature ("ptr ptr ptr");
+		mono_memory_barrier ();
+	}
 
 	if (!fsig->generic_param_count && !is_iface && !is_gsharedvt) {
 		/*

--- a/mono/mini/calls.c
+++ b/mono/mini/calls.c
@@ -688,8 +688,9 @@ mini_emit_llvmonly_virtual_call (MonoCompile *cfg, MonoMethod *cmethod, MonoMeth
 		variant_iface = TRUE;
 
 	if (!helper_sig_llvmonly_imt_trampoline) {
-		helper_sig_llvmonly_imt_trampoline = mono_create_icall_signature ("ptr ptr ptr");
+		MonoMethodSignature *tmp = mono_create_icall_signature ("ptr ptr ptr");
 		mono_memory_barrier ();
+		helper_sig_llvmonly_imt_trampoline = tmp;
 	}
 
 	if (!fsig->generic_param_count && !is_iface && !is_gsharedvt) {

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -182,7 +182,6 @@ static MonoMethodSignature *helper_sig_rgctx_lazy_fetch_trampoline;
 static MonoMethodSignature *helper_sig_jit_thread_attach;
 static MonoMethodSignature *helper_sig_get_tls_tramp;
 static MonoMethodSignature *helper_sig_set_tls_tramp;
-MonoMethodSignature *helper_sig_llvmonly_imt_trampoline;
 
 /* type loading helpers */
 static GENERATE_TRY_GET_CLASS_WITH_CACHE (debuggable_attribute, "System.Diagnostics", "DebuggableAttribute")
@@ -393,7 +392,6 @@ mono_create_helper_signatures (void)
 {
 	helper_sig_domain_get = mono_create_icall_signature ("ptr");
 	helper_sig_rgctx_lazy_fetch_trampoline = mono_create_icall_signature ("ptr ptr");
-	helper_sig_llvmonly_imt_trampoline = mono_create_icall_signature ("ptr ptr ptr");
 	helper_sig_jit_thread_attach = mono_create_icall_signature ("ptr ptr");
 	helper_sig_get_tls_tramp = mono_create_icall_signature ("ptr");
 	helper_sig_set_tls_tramp = mono_create_icall_signature ("void ptr");

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -356,7 +356,6 @@ extern gboolean mono_do_x86_stack_align;
 extern gboolean	mono_using_xdebug;
 extern int mini_verbose;
 extern int valgrind_register;
-extern MonoMethodSignature *helper_sig_llvmonly_imt_trampoline;
 
 #define INS_INFO(opcode) (&mini_ins_info [((opcode) - OP_START - 1) * 4])
 


### PR DESCRIPTION
Fixes Xamarin.Tests.Misc.PublicSymbols test with 2019-02 integration: https://jenkins.mono-project.com/job/xamarin-macios-pr-builder/9524/Test_20Report/


