### PR TITLE
[netcore] Disable runtime cleanup on netcore, coreclr does not cleanup either. Also disable aborting background threads, its no longer needed.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1207,6 +1207,7 @@ elif test x$with_runtime_preset = xnetcore; then
    mono_feature_disable_remoting='yes'
    mono_feature_disable_reflection_emit_save='yes'
    mono_feature_disable_appdomains='yes'
+   mono_feature_disable_cleanup='yes'
    disable_mono_native=yes
 elif test x$with_runtime_preset = xnet_4_x; then
    with_profile4_x_default=yes

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -3722,6 +3722,11 @@ mono_thread_manage (void)
 		mono_thread_execute_interruption_void ();
 	}
 
+#ifndef ENABLE_NETCORE
+	/*
+	 * Under netcore, we don't abort any threads, just exit.
+	 * This is not a problem since we don't do runtime cleanup either.
+	 */
 	/* 
 	 * Remove everything but the finalizer thread and self.
 	 * Also abort all the background threads
@@ -3742,6 +3747,7 @@ mono_thread_manage (void)
 			wait_for_tids (wait, MONO_INFINITE_WAIT, FALSE);
 		}
 	} while (wait->num > 0);
+#endif
 	
 	/* 
 	 * give the subthreads a chance to really quit (this is mainly needed

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4400,9 +4400,7 @@ mini_init (const char *filename, const char *runtime_version)
 
 #define JIT_RUNTIME_WORKS
 #ifdef JIT_RUNTIME_WORKS
-#ifndef DISABLE_CLEANUP
 	mono_install_runtime_cleanup ((MonoDomainFunc)mini_cleanup);
-#endif
 	mono_runtime_init_checked (domain, (MonoThreadStartCB)mono_thread_start_cb, mono_thread_attach_cb, error);
 	mono_error_assert_ok (error);
 	mono_thread_attach (domain);
@@ -4767,6 +4765,12 @@ print_jit_stats (void)
 	}
 }
 
+#ifdef DISABLE_CLEANUP
+void
+mini_cleanup (MonoDomain *domain)
+{
+}
+#else
 void
 mini_cleanup (MonoDomain *domain)
 {
@@ -4856,6 +4860,7 @@ mini_cleanup (MonoDomain *domain)
 	mono_w32handle_cleanup ();
 #endif
 }
+#endif
 
 void
 mono_set_defaults (int verbose_level, guint32 opts)


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->