### PR TITLE
Couple of fixes to LLVM AOT compiler on Windows x64.

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -9509,6 +9509,11 @@ emit_llvm_file (MonoAotCompile *acfg)
 	if (acfg->aot_opts.mtriple)
 		g_string_append_printf (acfg->llc_args, " -mtriple=%s", acfg->aot_opts.mtriple);
 
+#if defined(TARGET_X86_64_WIN32_MSVC) && LLVM_API_VERSION >= 600
+	if (!acfg->aot_opts.mtriple)
+		g_string_append_printf (acfg->llc_args, " -mtriple=%s", "x86_64-pc-windows-msvc");
+#endif
+
 	g_string_append (acfg->llc_args, " -disable-gnu-eh-frame -enable-mono-eh-frame");
 
 	g_string_append_printf (acfg->llc_args, " -mono-eh-frame-symbol=%s%s", acfg->user_symbol_prefix, acfg->llvm_eh_frame_symbol);
@@ -9522,8 +9527,7 @@ emit_llvm_file (MonoAotCompile *acfg)
 	g_string_append_printf (acfg->llc_args, " -no-x86-call-frame-opt");
 #endif
 
-#if ( defined(TARGET_MACH) && defined(TARGET_ARM) ) || defined(TARGET_ORBIS)
-	/* ios requires PIC code now */
+#if ( defined(TARGET_MACH) && defined(TARGET_ARM) ) || defined(TARGET_ORBIS) || defined(TARGET_X86_64_WIN32_MSVC)
 	g_string_append_printf (acfg->llc_args, " -relocation-model=pic");
 #else
 	if (llvm_acfg->aot_opts.static_link)
@@ -13315,7 +13319,13 @@ mono_compile_assembly (MonoAssembly *ass, guint32 opts, const char *aot_options,
 #ifdef ENABLE_LLVM
 	if (acfg->llvm) {
 		llvm_acfg = acfg;
-		LLVMModuleFlags flags = LLVM_MODULE_FLAG_DWARF;
+		LLVMModuleFlags flags = 0;
+#ifdef EMIT_DWARF_INFO
+		flags = LLVM_MODULE_FLAG_DWARF;
+#endif
+#ifdef EMIT_WIN32_CODEVIEW_INFO
+		flags = LLVM_MODULE_FLAG_CODEVIEW;
+#endif
 		if (acfg->aot_opts.static_link)
 			flags = (LLVMModuleFlags)(flags | LLVM_MODULE_FLAG_STATIC);
 		if (acfg->aot_opts.llvm_only)

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -39,6 +39,14 @@
 
 #ifndef DISABLE_JIT
 
+#if defined(TARGET_AMD64) && defined(TARGET_WIN32) && defined(HOST_WIN32) && defined(_MSC_VER)
+#define TARGET_X86_64_WIN32_MSVC
+#endif
+
+#if defined(TARGET_X86_64_WIN32_MSVC)
+#define TARGET_WIN32_MSVC
+#endif
+
 #if  defined(__MINGW32__) || defined(_MSC_VER)
 
 #include <stddef.h>
@@ -8999,6 +9007,7 @@ mono_llvm_create_aot_module (MonoAssembly *assembly, const char *global_prefix, 
 {
 	MonoLLVMModule *module = &aot_module;
 	gboolean emit_dwarf = (flags & LLVM_MODULE_FLAG_DWARF) ? 1 : 0;
+	gboolean emit_codeview = (flags & LLVM_MODULE_FLAG_CODEVIEW) ? 1 : 0;
 	gboolean static_link = (flags & LLVM_MODULE_FLAG_STATIC) ? 1 : 0;
 	gboolean llvm_only = (flags & LLVM_MODULE_FLAG_LLVM_ONLY) ? 1 : 0;
 	gboolean interp = (flags & LLVM_MODULE_FLAG_INTERP) ? 1 : 0;
@@ -9060,43 +9069,44 @@ mono_llvm_create_aot_module (MonoAssembly *assembly, const char *global_prefix, 
 	}
 #endif
 
-#if defined(TARGET_AMD64) && defined(TARGET_WIN32) && defined(HOST_WIN32) && defined(_MSC_VER)
-	const char linker_options[] = "Linker Options";
-	const char *default_static_lib_names[] = { "/DEFAULTLIB:libcmt",
-												"/DEFAULTLIB:libucrt.lib",
-												"/DEFAULTLIB:libvcruntime.lib" };
-	const char *default_dynamic_lib_names[] = { "/DEFAULTLIB:msvcrt",
-												"/DEFAULTLIB:ucrt.lib",
-												"/DEFAULTLIB:vcruntime.lib" };
+#ifdef TARGET_WIN32_MSVC
+	if (emit_codeview) {
+		LLVMValueRef codeview_option_args[3];
 
-	LLVMValueRef linker_option_args[3];
-	LLVMValueRef default_lib_args[G_N_ELEMENTS (default_static_lib_names)];
-	LLVMValueRef default_lib_nodes[G_N_ELEMENTS(default_dynamic_lib_names)];
+		codeview_option_args[0] = LLVMConstInt (LLVMInt32Type (), 2, FALSE);
+		codeview_option_args[1] = LLVMMDString ("CodeView", 8);
+		codeview_option_args[2] = LLVMConstInt (LLVMInt32Type (), 1, FALSE);
 
-	g_assert (G_N_ELEMENTS (default_static_lib_names) == G_N_ELEMENTS (default_dynamic_lib_names));
-
-	const char *default_lib_name = NULL;
-	for (int i = 0; i < G_N_ELEMENTS (default_static_lib_names); ++i) {
-		const char *default_lib_name = NULL;
-
-		if (static_link)
-			default_lib_name = default_static_lib_names[i];
-		else
-			default_lib_name = default_dynamic_lib_names[i];
-
-		default_lib_args[i] = LLVMMDString (default_lib_name, strlen (default_lib_name));
-		default_lib_nodes[i] = LLVMMDNode (default_lib_args + i, 1);
+		LLVMAddNamedMetadataOperand (module->lmodule, "llvm.module.flags", LLVMMDNode (codeview_option_args, G_N_ELEMENTS (codeview_option_args)));
 	}
 
-#if LLVM_API_VERSION < 600
-	linker_option_args[0] = LLVMConstInt (LLVMInt32Type (), 1, FALSE);
-	linker_option_args[1] = LLVMMDString (linker_options, G_N_ELEMENTS (linker_options) - 1);
-	linker_option_args[2] = LLVMMDNode (default_lib_nodes, G_N_ELEMENTS (default_lib_nodes));
+	if (!static_link) {
+		const char linker_options[] = "Linker Options";
+		const char *default_dynamic_lib_names[] = {	"/DEFAULTLIB:msvcrt",
+								"/DEFAULTLIB:ucrt.lib",
+								"/DEFAULTLIB:vcruntime.lib" };
 
-	LLVMAddNamedMetadataOperand (module->lmodule, "llvm.module.flags", LLVMMDNode (linker_option_args, G_N_ELEMENTS (linker_option_args)));
+		LLVMValueRef linker_option_args[3];
+		LLVMValueRef default_lib_args[G_N_ELEMENTS (default_dynamic_lib_names)];
+		LLVMValueRef default_lib_nodes[G_N_ELEMENTS(default_dynamic_lib_names)];
+
+		const char *default_lib_name = NULL;
+		for (int i = 0; i < G_N_ELEMENTS (default_dynamic_lib_names); ++i) {
+			const char *default_lib_name = default_dynamic_lib_names[i];
+			default_lib_args[i] = LLVMMDString (default_lib_name, strlen (default_lib_name));
+			default_lib_nodes[i] = LLVMMDNode (default_lib_args + i, 1);
+		}
+
+#if LLVM_API_VERSION < 600
+		linker_option_args[0] = LLVMConstInt (LLVMInt32Type (), 1, FALSE);
+		linker_option_args[1] = LLVMMDString (linker_options, G_N_ELEMENTS (linker_options) - 1);
+		linker_option_args[2] = LLVMMDNode (default_lib_nodes, G_N_ELEMENTS (default_lib_nodes));
+
+		LLVMAddNamedMetadataOperand (module->lmodule, "llvm.module.flags", LLVMMDNode (linker_option_args, G_N_ELEMENTS (linker_option_args)));
 #else
-	LLVMAddNamedMetadataOperand (module->lmodule, "llvm.linker.options", LLVMMDNode (default_lib_args, G_N_ELEMENTS (default_lib_args)));
+		LLVMAddNamedMetadataOperand (module->lmodule, "llvm.linker.options", LLVMMDNode (default_lib_args, G_N_ELEMENTS (default_lib_args)));
 #endif
+	}
 #endif
 
 	/* Add GOT */

--- a/mono/mini/mini-llvm.h
+++ b/mono/mini/mini-llvm.h
@@ -14,7 +14,8 @@ typedef enum {
 	LLVM_MODULE_FLAG_STATIC = (1 << 0),
 	LLVM_MODULE_FLAG_LLVM_ONLY = (1 << 1),
 	LLVM_MODULE_FLAG_DWARF = (1 << 2),
-	LLVM_MODULE_FLAG_INTERP = (1 << 3)
+	LLVM_MODULE_FLAG_CODEVIEW = (1 << 3),
+	LLVM_MODULE_FLAG_INTERP = (1 << 4)
 } LLVMModuleFlags;
 
 /* KEEP THIS IN SYNCH WITH mini-llvm-loaded.c */


### PR DESCRIPTION
- Enable MSVC objects on LLVM >= 6.00

- Always used PIC relocation-model on Windows x64 due to LLVM problem with
static triggering incorrect ADDR32 relocation entries in 64-bit objects.

- Add CodeView symbol format instead of DWARF for Windows x64.

- Fix LLVM outfile when doing static link to not end up in temp directory.

- Only add /DEFAULTLIB when using MSVC and not doing static compile. For static compile the needed libraries must be added when objects get's linked and since the needed libraries are c-runtime libraries, should be transparent for most applications consuming the object files.
