### PR TITLE
Don't produce nunit-console scripts in bin/

### DIFF
--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -29,7 +29,6 @@ bin_SCRIPTS = \
 	$(scripts_defaults)	\
 	$(scripts_2_0)		\
 	$(scripts_service)	\
-	$(scripts_nunit)	\
 	$(scripts_rpmhelpers)	\
 	$(MDOC_SUBCOMMANDS)	\
 	$(MDOC_COMPAT)		\
@@ -140,11 +139,10 @@ scripts_defaults = 		\
 	wsdl$(SCRIPT_SUFFIX)
 
 scripts_service = mono-service mono-service2
-scripts_nunit = nunit-console$(SCRIPT_SUFFIX) nunit-console2$(SCRIPT_SUFFIX) nunit-console4$(SCRIPT_SUFFIX)
 scripts_rpmhelpers = mono-find-provides mono-find-requires
 scripts_mono_configuration_crypto = mono-configuration-crypto$(SCRIPT_SUFFIX)
 
-CLEANFILES = $(scripts_mono_configuration_crypto) $(scripts_4_0_umask) $(scripts_2_0) $(scripts_defaults) $(scripts_4_0) mono-service mono-service2 nunit-console nunit-console2 nunit-console4 mono-find-provides mono-find-requires mod $(MDOC_SUBCOMMANDS)
+CLEANFILES = $(scripts_mono_configuration_crypto) $(scripts_4_0_umask) $(scripts_2_0) $(scripts_defaults) $(scripts_4_0) mono-service mono-service2 mono-find-provides mono-find-requires mod $(MDOC_SUBCOMMANDS)
 DISTCLEANFILES = $(pkgconfig_DATA) $(scripts_rpmhelpers)
 
 EXTRA_DIST =			\
@@ -235,18 +233,6 @@ mono-service: mono-service.in Makefile
 
 mono-service2: mono-service.in Makefile
 	$(REWRITE4) -e 's,@''exe_name@,$@,g' $(srcdir)/mono-service.in > $@.tmp
-	mv -f $@.tmp $@
-
-nunit-console$(SCRIPT_SUFFIX): $(SCRIPT_IN) Makefile
-	$(REWRITE4_DEBUG) -e 's,@''exe_name@,nunit-console,g' $(srcdir)/$(SCRIPT_IN) | $(FILTER) > $@.tmp
-	mv -f $@.tmp $@
-
-nunit-console2$(SCRIPT_SUFFIX): $(SCRIPT_IN) Makefile
-	$(REWRITE4_DEBUG) -e 's,@''exe_name@,nunit-console,g' $(srcdir)/$(SCRIPT_IN) | $(FILTER) > $@.tmp
-	mv -f $@.tmp $@
-
-nunit-console4$(SCRIPT_SUFFIX): $(SCRIPT_IN) Makefile
-	$(REWRITE4_DEBUG) -e 's,@''exe_name@,nunit-console,g' $(srcdir)/$(SCRIPT_IN) | $(FILTER) > $@.tmp
 	mv -f $@.tmp $@
 
 xbuild: xbuild.in Makefile


### PR DESCRIPTION
NUnit bundle is gone, these scripts are empty and useless

```
10:27:45  DEBUG: Checking for unpackaged file(s): /usr/lib/rpm/check-files /builddir/build/BUILDROOT/mono-core-6.1.0.462-0.nightly.1.epel6.x86_64
10:27:45  DEBUG: BUILDSTDERR: error: Installed (but unpackaged) file(s) found:
10:27:45  DEBUG: BUILDSTDERR:    /usr/bin/nunit-console
10:27:45  DEBUG: BUILDSTDERR:    /usr/bin/nunit-console2
10:27:45  DEBUG: BUILDSTDERR:    /usr/bin/nunit-console4
10:27:45  DEBUG: RPM build errors:
10:27:45  DEBUG: BUILDSTDERR:     Installed (but unpackaged) file(s) found:
10:27:45  DEBUG: BUILDSTDERR:    /usr/bin/nunit-console
10:27:45  DEBUG: BUILDSTDERR:    /usr/bin/nunit-console2
10:27:45  DEBUG: BUILDSTDERR:    /usr/bin/nunit-console4
```