### PR TITLE
[runtime] Add backwards-compatible signature for reflection-only telemetry icall

### DIFF
--- a/mcs/class/corlib/Mono/Runtime.cs
+++ b/mcs/class/corlib/Mono/Runtime.cs
@@ -147,6 +147,11 @@ namespace Mono {
 			SendMicrosoftTelemetry (payload_str, portable_hash, unportable_hash);
 		}
 
+		static void EnableMicrosoftTelemetry (string appBundleID_str, string appSignature_str, string appVersion_str, string merpGUIPath_str, string eventType_str, string appPath_str)
+		{
+			EnableMicrosoftTelemetry (appBundleID_str, appSignature_str, appVersion_str, merpGUIPath_str, eventType_str, appPath_str, null)
+		}
+
 		// All must be set except for configDir_str
 		static void EnableMicrosoftTelemetry (string appBundleID_str, string appSignature_str, string appVersion_str, string merpGUIPath_str, string eventType_str, string appPath_str, string configDir_str)
 		{

--- a/mcs/class/corlib/Mono/Runtime.cs
+++ b/mcs/class/corlib/Mono/Runtime.cs
@@ -149,7 +149,7 @@ namespace Mono {
 
 		static void EnableMicrosoftTelemetry (string appBundleID_str, string appSignature_str, string appVersion_str, string merpGUIPath_str, string eventType_str, string appPath_str)
 		{
-			EnableMicrosoftTelemetry (appBundleID_str, appSignature_str, appVersion_str, merpGUIPath_str, eventType_str, appPath_str, null)
+			EnableMicrosoftTelemetry (appBundleID_str, appSignature_str, appVersion_str, merpGUIPath_str, eventType_str, appPath_str, null);
 		}
 
 		// All must be set except for configDir_str


### PR DESCRIPTION
This was requested so that icall signatures don't change. 

VS4M wants to be able to support multiple monos at once. 