### PR TITLE
Bump roslyn binaries to 3.1.0 and add VBCSCompiler.exe to the set of paths auto-detected by configure.ac

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -68,6 +68,3 @@
 [submodule "external/illinker-test-assets"]
 	path = external/illinker-test-assets
 	url = git://github.com/mono/illinker-test-assets.git
-[submodule "external/roslyn-binaries-new"]
-	path = external/roslyn-binaries-new
-	url = https://github.com/kg/roslyn-binaries.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -68,3 +68,6 @@
 [submodule "external/illinker-test-assets"]
 	path = external/illinker-test-assets
 	url = git://github.com/mono/illinker-test-assets.git
+[submodule "external/roslyn-binaries-new"]
+	path = external/roslyn-binaries-new
+	url = https://github.com/kg/roslyn-binaries.git

--- a/configure.ac
+++ b/configure.ac
@@ -5763,8 +5763,8 @@ fi
 AC_SUBST(mono_runtime)
 AC_SUBST(mono_runtime_wrapper)
 
-CSC_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries-new/Microsoft.Net.Compilers/3.1.0.1916208/csc.exe
-VBCS_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries-new/Microsoft.Net.Compilers/3.1.0.1916208/VBCSCompiler.exe
+CSC_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.1.0/csc.exe
+VBCS_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.1.0/VBCSCompiler.exe
 
 if test $csc_compiler = mcs; then
   CSC=$mcs_topdir/class/lib/build/mcs.exe

--- a/configure.ac
+++ b/configure.ac
@@ -5763,8 +5763,8 @@ fi
 AC_SUBST(mono_runtime)
 AC_SUBST(mono_runtime_wrapper)
 
-CSC_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries-new/csc.exe
-VBCS_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries-new/VBCSCompiler.exe
+CSC_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries-new/Microsoft.Net.Compilers/3.1.0.1916208/csc.exe
+VBCS_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries-new/Microsoft.Net.Compilers/3.1.0.1916208/VBCSCompiler.exe
 
 if test $csc_compiler = mcs; then
   CSC=$mcs_topdir/class/lib/build/mcs.exe

--- a/configure.ac
+++ b/configure.ac
@@ -5763,7 +5763,8 @@ fi
 AC_SUBST(mono_runtime)
 AC_SUBST(mono_runtime_wrapper)
 
-CSC_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/Microsoft.Net.Compilers.2.8.2/tools/csc.exe
+CSC_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries-new/csc.exe
+VBCS_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries-new/VBCSCompiler.exe
 
 if test $csc_compiler = mcs; then
   CSC=$mcs_topdir/class/lib/build/mcs.exe
@@ -5779,6 +5780,7 @@ if test x$host_win32 = xyes; then
     mono_cfg_dir=`cygpath -w -a $mono_cfg_root`\\etc
     CSC=`cygpath -m -a $CSC`
     CSC_LOCATION=`cygpath -m -a $CSC_LOCATION`
+    VBCS_LOCATION=`cygpath -m -a $VBCS_LOCATION`
   else
     mono_cfg_dir=`echo $mono_cfg_root | tr '/' '\\'`\\etc
   fi
@@ -6516,7 +6518,7 @@ fi
 
     echo "STANDALONE_CSC_LOCATION=$CSC_LOCATION" >> $srcdir/$mcsdir/build/config.make
     echo "SERVER_CSC_LOCATION?=$CSC_LOCATION" >> $srcdir/$mcsdir/build/config.make
-    echo "VBCS_LOCATION?=" >> $srcdir/$mcsdir/build/config.make
+    echo "VBCS_LOCATION?=$VBCS_LOCATION" >> $srcdir/$mcsdir/build/config.make
 
     if test $csc_compiler = mcs; then
       echo "MCS_MODE = 1" >> $srcdir/$mcsdir/build/config.make

--- a/mcs/packages/csi-test.csx
+++ b/mcs/packages/csi-test.csx
@@ -1,2 +1,1 @@
-#r "../../external/binary-reference-assemblies/v4.7.2/Facades/netstandard.dll"
 Console.WriteLine ("hello world: " + DateTime.Now)

--- a/mcs/packages/csi-test.csx
+++ b/mcs/packages/csi-test.csx
@@ -1,1 +1,2 @@
+#r "../../external/binary-reference-assemblies/v4.7.2/Facades/netstandard.dll"
 Console.WriteLine ("hello world: " + DateTime.Now)


### PR DESCRIPTION
This PR tests bumping our default roslyn to a recent version.