### PR TITLE
[aot] force v7 on arm when using LLVM on iOS

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -1112,6 +1112,10 @@ arch_init (MonoAotCompile *acfg)
 		g_string_append (acfg->llc_args, "-mattr=+v6");
 	} else {
 		g_string_append (acfg->llc_args, " -march=arm");
+
+		if (acfg->aot_opts.mtriple && strstr (acfg->aot_opts.mtriple, "ios"))
+			g_string_append (acfg->llc_args, " -mattr=+v7");
+
 #if defined(ARM_FPU_VFP_HARD)
 		g_string_append (acfg->llc_args, " -mattr=+vfp2,-neon,+d16 -float-abi=hard");
 		g_string_append (acfg->as_args, " -mfpu=vfp3");


### PR DESCRIPTION
In https://github.com/mono/mono/pull/11172 we added passing `-march=arm` to `llc`, so that newer LLVM would generate code correctly for the target arch. Unfortunately this seems to break older LLVM, that is still used for 32bit code on Xamarin.iOS. For iOS we need to force it to armv7, otherwise it will try to substitute certain locking primitives with builtins that aren't available as hardware instructions on armv5.


Before this change:

```console
$ nm ./obj/iPhone/Release/mtouch-cache/armv7/mscorlib.dll-llvm.o | grep sync_
         U ___sync_fetch_and_add_4
         U ___sync_lock_test_and_set_4
         U ___sync_synchronize
         U ___sync_val_compare_and_swap_4
00079e1c T _mscorlib_System_Runtime_CompilerServices_AsyncMethodBuilderCore_ThrowAsync_System_Exception_System_Threading_SynchronizationContext
00057f80 T _mscorlib_System_Threading_SemaphoreSlim_WaitAsync_int_System_Threading_CancellationToken
00058430 T _mscorlib_System_Threading_SemaphoreSlim_WaitUntilCountOrTimeoutAsync_System_Threading_SemaphoreSlim_TaskNode_int_System_Threading_CancellationToken
         U _p_1214_plt_mscorlib_System_Threading_SemaphoreSlim_WaitAsync_int_System_Threading_CancellationToken_llvm
         U _p_1217_plt_mscorlib_System_Threading_SemaphoreSlim_WaitUntilCountOrTimeoutAsync_System_Threading_SemaphoreSlim_TaskNode_int_System_Threading_CancellationToken_llvm
         U _p_1735_plt_mscorlib_System_Runtime_CompilerServices_AsyncMethodBuilderCore_ThrowAsync_System_Exception_System_Threading_SynchronizationContext_llvm
         U _p_1976_plt_mscorlib_System_Threading_SemaphoreSlim_WaitAsync_llvm
         U _p_37_plt_mscorlib__jit_icall_ves_icall_thread_finish_async_abort_llvm

```

After this change:

```console
$ nm ./obj/iPhone/Release/mtouch-cache/armv7/mscorlib.dll-llvm.o | grep sync_
0007008c T _mscorlib_System_Runtime_CompilerServices_AsyncMethodBuilderCore_ThrowAsync_System_Exception_System_Threading_SynchronizationContext
00050654 T _mscorlib_System_Threading_SemaphoreSlim_WaitAsync_int_System_Threading_CancellationToken
00050ab4 T _mscorlib_System_Threading_SemaphoreSlim_WaitUntilCountOrTimeoutAsync_System_Threading_SemaphoreSlim_TaskNode_int_System_Threading_CancellationToken
         U _p_1214_plt_mscorlib_System_Threading_SemaphoreSlim_WaitAsync_int_System_Threading_CancellationToken_llvm
         U _p_1217_plt_mscorlib_System_Threading_SemaphoreSlim_WaitUntilCountOrTimeoutAsync_System_Threading_SemaphoreSlim_TaskNode_int_System_Threading_CancellationToken_llvm
         U _p_1735_plt_mscorlib_System_Runtime_CompilerServices_AsyncMethodBuilderCore_ThrowAsync_System_Exception_System_Threading_SynchronizationContext_llvm
         U _p_1976_plt_mscorlib_System_Threading_SemaphoreSlim_WaitAsync_llvm
         U _p_37_plt_mscorlib__jit_icall_ves_icall_thread_finish_async_abort_llvm
```

Fixes https://github.com/mono/mono/issues/13478

