### PR TITLE
[llvm] fix field init for platforms where unbox_trampolines tables are not used

### DIFF
--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -9401,7 +9401,7 @@ emit_aot_file_info (MonoLLVMModule *module)
 		fields [tindex ++] = AddJitGlobal (module, eltype, "method_addresses");
 	else
 		fields [tindex ++] = LLVMConstNull (eltype);
-	if (module->llvm_only) {
+	if (module->llvm_only && module->unbox_tramp_indexes) {
 		fields [tindex ++] = module->unbox_tramp_indexes;
 		fields [tindex ++] = module->unbox_trampolines;
 	} else {


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/13522