### PR TITLE
Fix handle leak in cominterop

### DIFF
--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -625,7 +625,6 @@ cominterop_get_interface (MonoComObject *obj_raw, MonoClass *ic)
 	gpointer const itf = cominterop_get_interface_checked (obj, ic, error);
 	g_assert (!!itf == is_ok (error)); // two equal success indicators
 	mono_error_set_pending_exception (error);
-	return itf;
 	HANDLE_FUNCTION_RETURN_VAL (itf);
 }
 


### PR DESCRIPTION
The function `cominterop_get_interface` in `mono/metadata/cominterop.c` had a number of changes made to it in 18b6846a3a2218525b7335a1f0515de93a1e44ca.

One of these seems to have missed a `return itf;` statement preceding `HANDLE_FUNCTION_RETURN_VAL`. Since `HANDLE_FUNCTION_RETURN_VAL` is meant to clean up the handle created in this function, this'd lead to a leaking handle.

This mainly hurt when running COM interface routines from finalizers, since the finalizer thread would end up owning a GC handle, and then hitting an assertion expecting the handle stack to be empty, but would be practically unnoticeable otherwise.