### PR TITLE
[netcore] fix typo

### DIFF
--- a/netcore/gen-xunit-runner/Program.cs
+++ b/netcore/gen-xunit-runner/Program.cs
@@ -226,7 +226,7 @@ unchecked {
 		}
 
 		if (val != null && expectedType != null && val.GetType () != expectedType && !expectedType.IsGenericParameter)
-			result = CastExpression (IdentifierName (GetTypeName (val.GetType ())), ParenthesizedExpression (result));
+			result = CastExpression (IdentifierName (GetTypeName (expectedType)), ParenthesizedExpression (result));
 		return result;
 	}
 


### PR DESCRIPTION
I could not run tests because of it (I guess the typo was made when gen-xunit-runner was rewritten to use Roslyn instead of CodeDom).