### PR TITLE
[netcore] Allow all primitive types to be passed to Buffer.BlockCopy

### DIFF
--- a/mcs/class/System.Private.CoreLib/System/Buffer.cs
+++ b/mcs/class/System.Private.CoreLib/System/Buffer.cs
@@ -25,17 +25,17 @@ namespace System
 				throw new ArgumentOutOfRangeException (nameof (dstOffset), SR.ArgumentOutOfRange_MustBeNonNegInt32);
 			if (count < 0)
 				throw new ArgumentOutOfRangeException (nameof (count), SR.ArgumentOutOfRange_MustBeNonNegInt32);
-			if (!IsPrimitiveTypeArray(src))
+			if (!IsPrimitiveTypeArray (src))
 				throw new ArgumentException (SR.Arg_MustBePrimArray, nameof (src));
-			if (!IsPrimitiveTypeArray(dest))
+			if (!IsPrimitiveTypeArray (dest))
 				throw new ArgumentException (SR.Arg_MustBePrimArray, nameof (dest));
 
 			var uCount = (nuint) count;
 			var uSrcOffset = (nuint) srcOffset;
 			var uDstOffset = (nuint) dstOffset;
 
-			var uSrcLen = (nuint) ByteLength(src);
-			var uDstLen = (nuint) ByteLength(dest);
+			var uSrcLen = (nuint) ByteLength (src);
+			var uDstLen = (nuint) ByteLength (dest);
 
 			if (uSrcLen < uSrcOffset + uCount)
 				throw new ArgumentException (SR.Argument_InvalidOffLen, "");

--- a/mcs/class/System.Private.CoreLib/System/Buffer.cs
+++ b/mcs/class/System.Private.CoreLib/System/Buffer.cs
@@ -25,9 +25,9 @@ namespace System
 				throw new ArgumentOutOfRangeException (nameof (dstOffset), SR.ArgumentOutOfRange_MustBeNonNegInt32);
 			if (count < 0)
 				throw new ArgumentOutOfRangeException (nameof (count), SR.ArgumentOutOfRange_MustBeNonNegInt32);
-			if (!(src is byte[]))
+			if (!IsPrimitiveTypeArray(src))
 				throw new ArgumentException (SR.Arg_MustBePrimArray, nameof (src));
-			if (!(dest is byte[]))
+			if (!IsPrimitiveTypeArray(dest))
 				throw new ArgumentException (SR.Arg_MustBePrimArray, nameof (dest));
 
 			var uCount = (nuint) count;

--- a/mcs/class/System.Private.CoreLib/System/Buffer.cs
+++ b/mcs/class/System.Private.CoreLib/System/Buffer.cs
@@ -34,8 +34,8 @@ namespace System
 			var uSrcOffset = (nuint) srcOffset;
 			var uDstOffset = (nuint) dstOffset;
 
-			var uSrcLen = (nuint) src.Length;
-			var uDstLen = (nuint) dest.Length;
+			var uSrcLen = (nuint) ByteLength(src);
+			var uDstLen = (nuint) ByteLength(dest);
 
 			if (uSrcLen < uSrcOffset + uCount)
 				throw new ArgumentException (SR.Argument_InvalidOffLen, "");


### PR DESCRIPTION
It fixes ~226 tests added in https://github.com/mono/mono/pull/13543