### PR TITLE
[ILAsm] Remove 'virtual' attribute that is being added to sealed default interface methods

### DIFF
--- a/mcs/ilasm/codegen/TypeDef.cs
+++ b/mcs/ilasm/codegen/TypeDef.cs
@@ -207,11 +207,6 @@ namespace Mono.ILASM {
 
                 public void AddMethodDef (MethodDef methoddef)
                 {
-                        if (IsInterface && !methoddef.IsStatic && !methoddef.IsVirtual) {
-                                Report.Warning (methoddef.StartLocation, "Non-virtual instance method in interface, set to such");
-                                methoddef.Attributes |= PEAPI.MethAttr.Virtual;
-                        }
-
                         if (method_table [methoddef.Signature] != null)
                                 Report.Error (methoddef.StartLocation, "Duplicate method declaration: " + methoddef.Signature);
 


### PR DESCRIPTION
When it is a sealed method in Interface it's not Static nor Virtual and shouldn't add virtual.

Fixes #13508

