### PR TITLE
[llvmonly] Add gsharedvt in wrappers to calls which could go to the interpreter.

### DIFF
--- a/mono/mini/calls.c
+++ b/mono/mini/calls.c
@@ -467,6 +467,9 @@ mini_emit_method_call_full (MonoCompile *cfg, MonoMethod *method, MonoMethodSign
 	if (cfg->llvm_only && cfg->interp && !virtual_ && !tailcall && can_enter_interp (cfg, method, FALSE)) {
 		MonoInst *ftndesc = mini_emit_get_rgctx_method (cfg, -1, method, MONO_RGCTX_INFO_METHOD_FTNDESC);
 
+		/* Need wrappers for this signature to be able to enter interpreter */
+		cfg->interp_in_signatures = g_slist_prepend_mempool (cfg->mempool, cfg->interp_in_signatures, sig);
+
 		/* This call might need to enter the interpreter so make it indirect */
 		return mini_emit_llvmonly_calli (cfg, sig, args, ftndesc);
 	}

--- a/mono/tests/llvmonly-mixed/interponly.cs
+++ b/mono/tests/llvmonly-mixed/interponly.cs
@@ -62,6 +62,11 @@ public class InterpOnly : InterpOnlyIFace
 	public static Func<int, int> create_del () {
 		return InterpOnly.entry_1;
 	}
+
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	public static int entry_sig (byte b1, byte b2, byte b3, byte b4, byte b5, byte b6) {
+		return b1 + b2 + b3 + b4 + b5 + b6;
+	}
 }
 
 public struct InterpOnlyStruct : InterpOnlyIFace

--- a/mono/tests/llvmonly-mixed/tests.cs
+++ b/mono/tests/llvmonly-mixed/tests.cs
@@ -88,4 +88,8 @@ public class BitcodeMixedTests
 		}
 		return 2;
 	}
+
+	public static int test_21_entry_sig () {
+		return InterpOnly.entry_sig ((byte)1, (byte)2, (byte)3, (byte)4, (byte)5, (byte)6);
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/13463.




<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->