### PR TITLE
Adjust genconst to changes in winsetup.bat.

### DIFF
--- a/msvc/scripts/genconsts.cs
+++ b/msvc/scripts/genconsts.cs
@@ -50,7 +50,17 @@ public static class Program {
                 Console.Write (output);
                 return winsetupProcess.ExitCode;
             } else {
-                var m = Regex.Match (output, "MONO_VERSION=([0-9.]+)");
+                var configDirectory = Path.Combine (executableDirectory, "..", "..");
+                var configPath = Path.Combine (configDirectory, "config.h");
+
+                if (!File.Exists (configPath)) {
+                    Console.Error.WriteLine ($"File not found: {configPath}");
+                    return 1;
+                }
+
+                var configData = File.ReadAllText (configPath);
+
+                var m = Regex.Match (configData, @"#define.*VERSION.*""([0-9.]+)""");
                 if (!m.Success)
                     return 1;
                 monoVersion = m.Groups[1].Value;
@@ -61,7 +71,7 @@ public static class Program {
                     monoVersion += ".0";
 
                 Console.WriteLine ($"MONO_VERSION={monoVersion}");
-                m = Regex.Match (output, "MONO_CORLIB_VERSION=([^\\s]+)");
+                m = Regex.Match (configData, @"#define.*MONO_CORLIB_VERSION.*""([^\\s]+)""");
                 if (!m.Success)
                     return 1;
                 monoCorlibVersion = m.Groups[1].Value;

--- a/msvc/winsetup.bat
+++ b/msvc/winsetup.bat
@@ -1,6 +1,111 @@
 @echo off
 setlocal
 
-call "msbuild.exe" /t:RunWinConfigSetup mono.winconfig.targets
+set BUILD_RESULT=1
 
-exit /b 0
+:: Make sure we can restore current working directory after setting up environment.
+:: Some of the VS scripts can change the current working directory.
+set CALLER_WD=%CD%
+
+:: Visual Studio 2015 == 14.0
+if "%VisualStudioVersion%" == "14.0" (
+    goto SETUP_VS_2015
+)
+
+:: Visual Studio 2017 == 15.0
+if "%VisualStudioVersion%" == "15.0" (
+    goto SETUP_VS_2017
+)
+
+:SETUP_VS_2015
+
+:SETUP_VS_2015_BUILD_TOOLS
+
+:: Try to locate VS2015 build tools installation.
+set VS_2015_BUILD_TOOLS_CMD=%ProgramFiles(x86)%\Microsoft Visual C++ Build Tools\vcbuildtools_msbuild.bat
+
+:: Setup VS2015 VC development environment using build tools installation.
+call :setup_build_env "%VS_2015_BUILD_TOOLS_CMD%" "%CALLER_WD%" && (
+    goto ON_BUILD
+)
+
+:SETUP_VS_2015_VC
+
+:: Try to locate installed VS2015 VC environment.
+set VS_2015_DEV_CMD=%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\Common7\Tools\VsMSBuildCmd.bat
+
+:: Setup VS2015 VC development environment using VS installation.
+call :setup_build_env "%VS_2015_DEV_CMD%" "%CALLER_WD%" && (
+    goto ON_BUILD
+)
+
+:SETUP_VS_2017
+
+:SETUP_VS_2017_BUILD_TOOLS
+
+:: Try to locate VS2017 build tools installation.
+set VS_2017_BUILD_TOOLS_CMD=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\Common7\Tools\VsMSBuildCmd.bat
+
+:: Setup VS2017 VC development environment using build tools installation.
+call :setup_build_env "%VS_2017_BUILD_TOOLS_CMD%" "%CALLER_WD%" && (
+    goto ON_BUILD
+)
+
+:SETUP_VS_2017_VC
+
+:: VS2017 includes vswhere.exe that can be used to locate current VS2017 installation.
+set VSWHERE_TOOLS_BIN=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe
+set VS_2017_DEV_CMD=
+
+:: Try to locate installed VS2017 VC environment.
+if exist "%VSWHERE_TOOLS_BIN%" (
+    for /f "tokens=*" %%a in ('"%VSWHERE_TOOLS_BIN%" -latest -property installationPath') do (
+        set VS_2017_DEV_CMD=%%a\Common7\Tools\VsMSBuildCmd.bat
+    )
+)
+
+:: Setup VS2017 VC development environment using VS installation.
+call :setup_build_env "%VS_2017_DEV_CMD%" "%CALLER_WD%" && (
+    goto ON_BUILD
+)
+
+:ON_ENV_ERROR
+
+echo Warning, failed to setup build environment needed by msbuild.exe.
+echo Incomplete build environment can cause build error's due to missing compiler, linker and platform libraries.
+
+:ON_BUILD
+
+call "msbuild.exe" /t:RunWinConfigSetup mono.winconfig.targets && (
+    set BUILD_RESULT=0
+) || (
+    set BUILD_RESULT=1
+    if not %ERRORLEVEL% == 0 (
+        set BUILD_RESULT=%ERRORLEVEL%
+    )
+)
+
+exit /b %BUILD_RESULT%
+
+:setup_build_env
+
+:: Check if VS build environment script exists.
+if not exist "%~1" (
+    goto setup_build_env_error
+)
+
+:: Run VS build environment script.
+call "%~1" > NUL
+
+:: Restore callers working directory in case it has been changed by VS scripts.
+cd /d "%~2"
+
+goto setup_build_env_exit
+
+:setup_build_env_error
+exit /b 1
+
+:setup_build_env_exit
+goto :EOF
+
+@echo on


### PR DESCRIPTION
When logic moved from winsetup.bat into an msbuild task that changed the console output of winsetup.bat causing problems for genconst to find MONO_VERSION and MONO_CORLIB_VERSION. There was also a potential problem where winsetup.bat couldn't find msbuild.exe if not included in PATH.

This fix makes sure winsetup.bat detect and setup a full msbuild environment before running msbuild.exe. It also change genconsts to look at the generated config.h for the correct values of MONO_VERSION and MONO_CORLIB_VERSION that will be used by the runtime builds.

Should fix https://github.com/mono/mono/issues/13533.
