### PR TITLE
[ssa] avoid code motion to try-blocks

### DIFF
--- a/mono/mini/ssa.c
+++ b/mono/mini/ssa.c
@@ -1501,6 +1501,14 @@ mono_ssa_loop_invariant_code_motion (MonoCompile *cfg)
 					ins->sreg1 = sreg;
 				}
 
+				/* if any successor block of the immediate post dominator is an
+				 * exception handler, it's not safe to do the code motion */
+				skip = FALSE;
+				for (int j = 0; j < idom->out_count && !skip; j++)
+					skip |= !!(idom->out_bb [j]->flags & BB_EXCEPTION_HANDLER);
+				if (skip)
+					continue;
+
 				if (cfg->verbose_level > 1) {
 					printf ("licm in BB%d on ", bb->block_num);
 					mono_print_ins (ins);


### PR DESCRIPTION
Consider
```
BB4:  // successor BB5, BB9
[...]
br [B9]

BB5: // catch handler block for BB4
[...]
br BB9

BB9:
aotconst R90
gc_safe_point R90
[...]
```

Previously, our invariant code motion pass would move `aotconst R90` to the end of BB4. Unfortunately, BB4 contains instructions that can cause an exception and thus control flow is broken and continues to BB5. `aotconst R90` wouldn't be loaded correctly in this scenario.

When lowered to LLVM IR this is more obvious, and the verification pass of LLVM catches this.

Fixes https://github.com/mono/mono/issues/13460
