### PR TITLE
[2019-02] [2018-08][merp] Fix anon allocation, use MAP_PRIVATE

### DIFF
--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -260,7 +260,7 @@ mono_state_alloc_mem (MonoStateMem *mem, long tag, size_t size)
 
 	mem->handle = g_open (name, O_RDWR | O_CREAT | O_EXCL, S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH);
 	if (mem->handle < 1) {
-		mem->mem = (gpointer *) mmap (0, mem->size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS, -1, 0);
+		mem->mem = (gpointer *) mmap (0, mem->size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 	} else {
 		lseek (mem->handle, mem->size, SEEK_SET);
 		g_write (mem->handle, "", 1);


### PR DESCRIPTION
The crash this fixes should have been fixed in https://github.com/mono/mono/pull/13503. When I tested it locally on Linux it was working. 

When I did a prolonged test by triggering a package build and testing with VS4M, it didn't work. Perhaps I failed to correctly inject the open() failure that VS4M encounters. 

This is a hotfix of a previous patch. 

Confirmed to be working. The VS4M MERP dialog box popped up with this JSON:

https://gist.github.com/alexanderkyte/89da7afb6019572ea4fe026ea715b05a

Backport of #13538.

/cc @alexanderkyte 