### PR TITLE
[netcore] Implement missing bits in ThreadPool

### DIFF
--- a/mcs/class/System.Private.CoreLib/System.Threading/ThreadPool.cs
+++ b/mcs/class/System.Private.CoreLib/System.Threading/ThreadPool.cs
@@ -4,7 +4,6 @@ namespace System.Threading
 {
 	partial class ThreadPool
 	{
-		[System.Security.SecurityCritical]
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		private static extern void InitializeVMTp(ref bool enableWorkerTracking);
 
@@ -17,11 +16,10 @@ namespace System.Threading
 			}
 		}
 
-		[System.Security.SecurityCritical]
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		internal static extern bool RequestWorkerThread();
 
-		internal static bool KeepDispatching(int startTickCount) => true; // just like in ThreadPool.Portable.cs
+		internal static bool KeepDispatching(int startTickCount) => true;
 
 		internal static void NotifyWorkItemProgress ()
 		{
@@ -29,7 +27,6 @@ namespace System.Threading
 			NotifyWorkItemProgressNative();
 		}
 
-		[System.Security.SecurityCritical]
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		internal static extern void NotifyWorkItemProgressNative();
 
@@ -52,31 +49,24 @@ namespace System.Threading
 			return waiter;
 		}
 
-		[System.Security.SecurityCritical]
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		internal static extern void ReportThreadStatus(bool isWorking);
 
-		[System.Security.SecurityCritical]
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		internal static extern bool NotifyWorkItemComplete();
 
-		[System.Security.SecurityCritical]
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		private static extern bool SetMinThreadsNative(int workerThreads, int completionPortThreads);
 
-		[System.Security.SecurityCritical]
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		private static extern bool SetMaxThreadsNative(int workerThreads, int completionPortThreads);
 
-		[System.Security.SecurityCritical]
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		private static extern void GetMinThreadsNative(out int workerThreads, out int completionPortThreads);
 
-		[System.Security.SecurityCritical]
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		private static extern void GetMaxThreadsNative(out int workerThreads, out int completionPortThreads);
 
-		[System.Security.SecurityCritical]
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		private static extern void GetAvailableThreadsNative(out int workerThreads, out int completionPortThreads);
 
@@ -85,7 +75,6 @@ namespace System.Threading
 			return SetMaxThreadsNative(workerThreads, completionPortThreads);
 		}
 
-		[System.Security.SecuritySafeCritical]  // auto-generated
 		public static void GetMaxThreads(out int workerThreads, out int completionPortThreads)
 		{
 			GetMaxThreadsNative(out workerThreads, out completionPortThreads);
@@ -96,13 +85,11 @@ namespace System.Threading
 			return SetMinThreadsNative(workerThreads, completionPortThreads);
 		}
 
-		[System.Security.SecuritySafeCritical]  // auto-generated
 		public static void GetMinThreads(out int workerThreads, out int completionPortThreads)
 		{
 			GetMinThreadsNative(out workerThreads, out completionPortThreads);
 		}
 
-		[System.Security.SecuritySafeCritical]  // auto-generated
 		public static void GetAvailableThreads(out int workerThreads, out int completionPortThreads)
 		{
 			GetAvailableThreadsNative(out workerThreads, out completionPortThreads);

--- a/mcs/class/System.Private.CoreLib/System.Threading/ThreadPool.cs
+++ b/mcs/class/System.Private.CoreLib/System.Threading/ThreadPool.cs
@@ -1,47 +1,138 @@
+using System.Runtime.CompilerServices;
+
 namespace System.Threading
 {
 	partial class ThreadPool
 	{
+		[System.Security.SecurityCritical]
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
+		private static extern void InitializeVMTp(ref bool enableWorkerTracking);
+
 		static void EnsureInitialized ()
 		{
+			if (!ThreadPoolGlobals.threadPoolInitialized)
+			{
+				ThreadPool.InitializeVMTp(ref ThreadPoolGlobals.enableWorkerTracking);
+				ThreadPoolGlobals.threadPoolInitialized = true;
+			}
 		}
 
-		internal static bool RequestWorkerThread ()
-		{
-			throw new NotImplementedException ();
-		}
+		[System.Security.SecurityCritical]
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
+		internal static extern bool RequestWorkerThread();
 
-		internal static bool KeepDispatching(int startTickCount)
-		{
-			throw new NotImplementedException ();
-		}
+		internal static bool KeepDispatching(int startTickCount) => true; // just like in ThreadPool.Portable.cs
 
 		internal static void NotifyWorkItemProgress ()
 		{
+			EnsureInitialized ();
+			NotifyWorkItemProgressNative();
 		}
+
+		[System.Security.SecurityCritical]
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
+		internal static extern void NotifyWorkItemProgressNative();
 
 		static RegisteredWaitHandle RegisterWaitForSingleObject(WaitHandle waitObject, WaitOrTimerCallback callBack, object state,
-			 uint millisecondsTimeOutInterval, bool executeOnlyOnce, bool compressStack)
+			uint millisecondsTimeOutInterval, bool executeOnlyOnce, bool compressStack)
 		{
-			throw new NotImplementedException ();
+			if (waitObject == null)
+				throw new ArgumentNullException ("waitObject");
+			if (callBack == null)
+				throw new ArgumentNullException ("callBack");
+			if (millisecondsTimeOutInterval != Timeout.UnsignedInfinite && millisecondsTimeOutInterval > Int32.MaxValue)
+				throw new NotSupportedException ("Timeout is too big. Maximum is Int32.MaxValue");
+
+			RegisteredWaitHandle waiter = new RegisteredWaitHandle (waitObject, callBack, state, new TimeSpan (0, 0, 0, 0, (int) millisecondsTimeOutInterval), executeOnlyOnce);
+			if (compressStack)
+				QueueUserWorkItem (new WaitCallback (waiter.Wait), null);
+			else
+				UnsafeQueueUserWorkItem (new WaitCallback (waiter.Wait), null);
+
+			return waiter;
 		}
 
-		internal static void ReportThreadStatus (bool isWorking)
+		[System.Security.SecurityCritical]
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
+		internal static extern void ReportThreadStatus(bool isWorking);
+
+		[System.Security.SecurityCritical]
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
+		internal static extern bool NotifyWorkItemComplete();
+
+		[System.Security.SecurityCritical]
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
+		private static extern bool SetMinThreadsNative(int workerThreads, int completionPortThreads);
+
+		[System.Security.SecurityCritical]
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
+		private static extern bool SetMaxThreadsNative(int workerThreads, int completionPortThreads);
+
+		[System.Security.SecurityCritical]
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
+		private static extern void GetMinThreadsNative(out int workerThreads, out int completionPortThreads);
+
+		[System.Security.SecurityCritical]
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
+		private static extern void GetMaxThreadsNative(out int workerThreads, out int completionPortThreads);
+
+		[System.Security.SecurityCritical]
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
+		private static extern void GetAvailableThreadsNative(out int workerThreads, out int completionPortThreads);
+
+		public static bool SetMaxThreads(int workerThreads, int completionPortThreads)
 		{
+			return SetMaxThreadsNative(workerThreads, completionPortThreads);
 		}
 
-		internal static bool NotifyWorkItemComplete ()
+		[System.Security.SecuritySafeCritical]  // auto-generated
+		public static void GetMaxThreads(out int workerThreads, out int completionPortThreads)
 		{
-			throw new NotImplementedException ();
+			GetMaxThreadsNative(out workerThreads, out completionPortThreads);
 		}
 
-		public static bool BindHandle (System.IntPtr osHandle) { throw null; }
-		public static bool BindHandle (System.Runtime.InteropServices.SafeHandle osHandle) { throw null; }
-		public static void GetAvailableThreads (out int workerThreads, out int completionPortThreads) { throw null; }
-		public static void GetMaxThreads (out int workerThreads, out int completionPortThreads) { throw null; }
-		public static void GetMinThreads (out int workerThreads, out int completionPortThreads) { throw null; }
-		public static bool SetMaxThreads(int workerThreads, int completionPortThreads) { throw null; }
-		public static bool SetMinThreads(int workerThreads, int completionPortThreads) { throw null; }
-		public static unsafe bool UnsafeQueueNativeOverlapped(System.Threading.NativeOverlapped* overlapped) { throw null; }
+		public static bool SetMinThreads(int workerThreads, int completionPortThreads)
+		{
+			return SetMinThreadsNative(workerThreads, completionPortThreads);
+		}
+
+		[System.Security.SecuritySafeCritical]  // auto-generated
+		public static void GetMinThreads(out int workerThreads, out int completionPortThreads)
+		{
+			GetMinThreadsNative(out workerThreads, out completionPortThreads);
+		}
+
+		[System.Security.SecuritySafeCritical]  // auto-generated
+		public static void GetAvailableThreads(out int workerThreads, out int completionPortThreads)
+		{
+			GetAvailableThreadsNative(out workerThreads, out completionPortThreads);
+		}
+
+		public static bool BindHandle (System.IntPtr osHandle) => throw new NotImplementedException();
+		public static bool BindHandle (System.Runtime.InteropServices.SafeHandle osHandle)  => throw new NotImplementedException();
+		public static unsafe bool UnsafeQueueNativeOverlapped(System.Threading.NativeOverlapped* overlapped)  => throw new NotImplementedException();
+	}
+
+	internal static class _ThreadPoolWaitCallback
+	{
+		// This feature is used by Xamarin.iOS to use an NSAutoreleasePool
+		// for every task done by the threadpool.
+		static Func<Func<bool>, bool> dispatcher;
+
+		internal static void SetDispatcher (Func<Func<bool>, bool> value)
+		{
+			dispatcher = value;
+		}
+
+		[System.Security.SecurityCritical]
+		static internal bool PerformWaitCallback()
+		{
+			// store locally first to ensure another thread doesn't clear the field between checking for null and using it.
+			var dispatcher = _ThreadPoolWaitCallback.dispatcher;
+			if (dispatcher != null)
+				return dispatcher (ThreadPoolWorkQueue.Dispatch);
+
+			return ThreadPoolWorkQueue.Dispatch();
+		}
 	}
 }

--- a/mcs/class/referencesource/mscorlib/system/threading/threadpool.cs
+++ b/mcs/class/referencesource/mscorlib/system/threading/threadpool.cs
@@ -1986,8 +1986,7 @@ namespace System.Threading
         [System.Security.SecuritySafeCritical]
         internal static void NotifyWorkItemProgress()
         {
-            if (!ThreadPoolGlobals.vmTpInitialized)
-                ThreadPool.InitializeVMTp(ref ThreadPoolGlobals.enableWorkerTracking);
+            EnsureVMInitialized();
             NotifyWorkItemProgressNative();
         }
 

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -786,7 +786,6 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	mono_defaults.generic_ienumerator_class = mono_class_load_from_name (
 	        mono_defaults.corlib, "System.Collections.Generic", "IEnumerator`1");
 
-#ifndef ENABLE_NETCORE
 	ERROR_DECL (error);
 
 	MonoClass *threadpool_wait_callback_class = mono_class_load_from_name (
@@ -795,7 +794,6 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	mono_defaults.threadpool_perform_wait_callback_method = mono_class_get_method_from_name_checked (
 		threadpool_wait_callback_class, "PerformWaitCallback", 0, 0, error);
 	mono_error_assert_ok (error);
-#endif
 
 	domain->friendly_name = g_path_get_basename (filename);
 


### PR DESCRIPTION
Now I am able to run xunit tests directly.
I mostly copied missing bits from old threadpool.
(In theory we need to use ThreadPool.Portable.cs, am I right?)

Managed to run 29808 xunit tests directly without the gen-xunit-proj in System.Runtime.Tests,
it crashes on `PointerFieldGetValue` which I guess should be skipped on mono (see https://github.com/mono/corefx/blob/master/src/System.Runtime/tests/System/Reflection/PointerTests.cs#L128)

I think we need to upstream all mono-runtime specific [Skip]s from mono/corefx to dotnet/corefx