### PR TITLE
[netcore] Add a python script to download the prebuilt corefx test assemblies.

### DIFF
--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -77,3 +77,8 @@ check: $(addprefix run-, $(TEST_SUITES))
 clean:
 	rm -rf sdk shared host dotnet tests LICENSE.txt ThirdPartyNotices.txt $(NETCORESDK_FILE)
 
+testlist:
+	wget -O $@ $(TESTLIST_URL)
+
+download-test-zips: testlist
+	python dlzips.py testlist zips

--- a/netcore/dlzips.py
+++ b/netcore/dlzips.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+import sys
+import json
+import subprocess
+
+if len(sys.argv) < 3:
+    print("Usage: dlzips.py testlist outdir")
+    sys.exit(1)
+
+infilename = sys.argv [1]
+outdir = sys.argv [2]
+testlist = json.load (open (infilename))
+for item in testlist:
+    print (item ['PayloadUri'])
+    res = subprocess.call (["wget", "-P", outdir, str (item ['PayloadUri'])])
+    if res != 0:
+        print("Download failed.")
+        sys.exit (1)
+
+
+
+


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->