### PR TITLE
Add UTC timezone in WinRT GetSystemTimeZones fallback implementation.

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.WinRT.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.WinRT.cs
@@ -338,8 +338,17 @@ namespace System
 				// EnumDynamicTimeZoneInformation() might not be available.
 			}
 
-			if (result.Count == 0)
+			if (result.Count == 0) {
 				result.Add (Local);
+				result.Add (Utc);
+			}
+
+			result.Sort ((x, y) =>
+			{
+				int comparison = x.BaseUtcOffset.CompareTo(y.BaseUtcOffset);
+				return comparison == 0 ? string.CompareOrdinal(x.DisplayName, y.DisplayName) : comparison;
+			});
+
 			return result;
 		}
 	}


### PR DESCRIPTION
Needed by tests when hitting fallback solution in TimeZoneInfo.WinRT.cs. Fix also sort the TimeZones similar to how its done in .NET Framework/Core.
