### PR TITLE
Increase spin-count on test to not end up in frequent sleeps on multicore machines.

### DIFF
--- a/mcs/class/corlib/Test/System.Threading/ManualResetEventSlimTests.cs
+++ b/mcs/class/corlib/Test/System.Threading/ManualResetEventSlimTests.cs
@@ -234,11 +234,11 @@ namespace MonoTests.System.Threading
 				int count = 2;
 				SpinWait wait = new SpinWait ();
 
-				ThreadPool.QueueUserWorkItem (_ => { while (count > 1) wait.SpinOnce (); mre.Set (); Interlocked.Decrement (ref count); });
+				ThreadPool.QueueUserWorkItem (_ => { while (count > 1) wait.SpinOnce (100); mre.Set (); Interlocked.Decrement (ref count); });
 				ThreadPool.QueueUserWorkItem (_ => { mre.Reset (); Interlocked.Decrement (ref count); });
 
 				while (count > 0)
-					wait.SpinOnce ();
+					wait.SpinOnce (100);
 				Assert.AreEqual (mre.IsSet, mre.WaitHandle.WaitOne (0));
 			}
 		}


### PR DESCRIPTION
When running this test, ManualResetSlimTest on Windows on a machine with free cores during the test run, the SpinOnce's default value will be to low forcing the thread into frequent sleep(1) scenario, causing long execution times. This PR set count to 100 for the test (default 20) before SpinOnces will hit sleep(1. This will run the test much quicker on machines with idle cores.