### PR TITLE
[netcore] Simple xunit runner

### DIFF
--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -77,3 +77,7 @@ check: $(addprefix run-, $(TEST_SUITES))
 clean:
 	rm -rf sdk shared host dotnet tests LICENSE.txt ThirdPartyNotices.txt $(NETCORESDK_FILE)
 
+
+TEST_ASSEMBLY=tests/System.Runtime.Tests/bin/Debug/netcoreapp3.0/System.Runtime.Tests.dll
+run-simple-xunit-runner:
+	dotnet build simple-xunit-runner && COMPlus_DebugWriteToStdErr=1 ./dotnet --fx-version "$(VERSION)" simple-xunit-runner/bin/Debug/netcoreapp3.0/SimpleXunitRunner.dll $(TEST_ASSEMBLY)

--- a/netcore/simple-xunit-runner/Program.cs
+++ b/netcore/simple-xunit-runner/Program.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using Xunit.Runners;
+
+namespace Xunit
+{
+    public class SimpleXunitRunner
+    {
+        const bool runInParallel = false; // works, but output is a bit messy
+        
+        static string[] igoredTests =
+            {
+                // works as "TestDisplayName contains X"
+                "IndexOfSequenceMultipleMatch_Char",
+                "Test_ToLower_Culture",
+                "Exception_TargetSite_Aot"
+            };
+        
+        public static void Main(string[] args)
+        {
+            if (args?.Length != 1)
+            {
+                Console.WriteLine("\nInvalid arguments.\n\tUsage: assembly-path\n");
+                return;
+            }
+
+            string asmPath = args[0];
+            Environment.CurrentDirectory = Path.GetDirectoryName(asmPath);
+            asmPath = Path.GetFileName(asmPath);
+
+            if (File.Exists("Microsoft.DotNet.XUnitExtensions.dll")) 
+                Assembly.LoadFrom("Microsoft.DotNet.XUnitExtensions.dll");
+            
+            if (File.Exists("CoreFx.Private.TestUtilities.dll")) 
+                Assembly.LoadFrom("CoreFx.Private.TestUtilities.dll");
+
+            Assembly.LoadFrom(asmPath);
+            
+            var mre = new ManualResetEvent(false);
+            int testsCount = 0;
+            using (var runner = AssemblyRunner.WithoutAppDomain(asmPath))
+            {
+                runner.OnTestFailed += i => Console.WriteLine($"FAILED: {i.MethodName}. ExceptionMessage: {i.ExceptionMessage} {i.ExceptionStackTrace}");
+                //runner.OnTestOutput += i => Console.WriteLine(i.TestDisplayName + " output: " + i.Output);
+                runner.OnErrorMessage += i => Console.WriteLine("OnErrorMessage: " + i.ExceptionMessage);
+                runner.OnTestSkipped += i => Console.WriteLine($"SKIPPED: {i.TestDisplayName}");
+                runner.OnDiscoveryComplete += i => Console.WriteLine($"TestCasesDiscovered={i.TestCasesDiscovered}, TestCasesToRun={i.TestCasesToRun}");
+                runner.OnTestPassed += i => Console.WriteLine($"PASSED: {i.TestCollectionDisplayName}");
+                runner.TestCaseFilter += t => !igoredTests.Any(i => t.DisplayName.Contains(i));
+                runner.OnDiagnosticMessage += i => Console.WriteLine("OnDiagnosticMessage: " + i.Message);
+                runner.OnTestFinished += i => Console.WriteLine($"{i.TestDisplayName} finished");
+                runner.OnTestStarting += i =>  Console.WriteLine($"{i.TestDisplayName} started... (#{testsCount++})");
+
+                runner.OnExecutionComplete += i =>
+                    {
+                        Console.WriteLine($"Done:\n\n\tTotalTests={i.TotalTests}, TestsFailed={i.TestsFailed}, TestsSkipped={i.TestsSkipped}, ExecutionTime={i.ExecutionTime}\n");
+                        mre.Set();
+                    };
+
+                runner.Start(parallel: runInParallel, diagnosticMessages: false, internalDiagnosticMessages: false);
+                mre.WaitOne();
+            }
+            Console.ReadKey();
+        }
+    }
+}

--- a/netcore/simple-xunit-runner/Program.cs
+++ b/netcore/simple-xunit-runner/Program.cs
@@ -16,7 +16,8 @@ namespace Xunit
                 // works as "TestDisplayName contains X"
                 "IndexOfSequenceMultipleMatch_Char",
                 "Test_ToLower_Culture",
-                "Exception_TargetSite_Aot"
+                "Exception_TargetSite_Aot",
+                "PointerTests"
             };
         
         public static void Main(string[] args)

--- a/netcore/simple-xunit-runner/SimpleXunitRunner.csproj
+++ b/netcore/simple-xunit-runner/SimpleXunitRunner.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.utility" Version="2.4.1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
I am just sharing the way I use to run the xunit tests using the actual xunit libs.

Usage:
```
make run-simple-xunit-runner TEST_ASSEMBLY=path-to-assembly-with-tests.dll
```
the `path-to-assembly-with-tests.dll` must also contain `Microsoft.DotNet.XUnitExtensions.dll` and `CoreFx.Private.TestUtilities.dll`


**System.Runtime.Tests:**
```
TotalTests=29906, TestsFailed=2107, TestsSkipped=56, ExecutionTime=61.109s
```
**System.Collection.Tests:**
```
TotalTests=53532, TestsFailed=269, TestsSkipped=39, ExecutionTime=72.493
```
