### PR TITLE
[sqllite] Throw ArgumentException during empty text command initialization for reader

### DIFF
--- a/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/SQLiteCommand.cs
+++ b/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/SQLiteCommand.cs
@@ -503,6 +503,9 @@ namespace Mono.Data.Sqlite
       if (_cnn.State != ConnectionState.Open)
         throw new InvalidOperationException("Database is not open");
 
+      if (string.IsNullOrWhiteSpace (CommandText))
+        throw new ArgumentException ("Empty SQL statement");
+
       // If the version of the connection has changed, clear out any previous commands before starting
       if (_cnn._version != _version)
       {

--- a/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/SQLiteDataReader.cs
+++ b/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/SQLiteDataReader.cs
@@ -994,6 +994,8 @@ namespace Mono.Data.Sqlite
     public override bool Read()
     {
       CheckClosed();
+      if (_activeStatement == null)
+        throw new ArgumentException ("Empty SQL statement");
 
       if (_readingState == -1) // First step was already done at the NextResult() level, so don't step again, just return true.
       {

--- a/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/SQLiteDataReader.cs
+++ b/mcs/class/Mono.Data.Sqlite/Mono.Data.Sqlite_2.0/SQLiteDataReader.cs
@@ -994,8 +994,6 @@ namespace Mono.Data.Sqlite
     public override bool Read()
     {
       CheckClosed();
-      if (_activeStatement == null)
-        throw new ArgumentException ("Empty SQL statement");
 
       if (_readingState == -1) // First step was already done at the NextResult() level, so don't step again, just return true.
       {

--- a/mcs/class/Mono.Data.Sqlite/Test/SqliteDataReaderTest.cs
+++ b/mcs/class/Mono.Data.Sqlite/Test/SqliteDataReaderTest.cs
@@ -41,45 +41,65 @@ using MonoTests.Helpers;
 
 namespace MonoTests.Mono.Data.Sqlite
 {
-        [TestFixture]
-        public class SqliteDataReaderTest
-        {
-                readonly static string _uri = TestResourceHelper.GetFullPathOfResource("Test/test.db");
-                readonly static string _connectionString = "URI=file://" + _uri + ", version=3";
-                SqliteConnection _conn = new SqliteConnection ();
+	[TestFixture]
+	public class SqliteDataReaderTest
+	{
+		readonly static string _uri = TestResourceHelper.GetFullPathOfResource("Test/test.db");
+		readonly static string _connectionString = "URI=file://" + _uri + ", version=3";
+		SqliteConnection _conn = new SqliteConnection ();
 
-                [TestFixtureSetUp]
-                public void FixtureSetUp ()
-                {
-                        if (! File.Exists (_uri) || new FileInfo (_uri).Length == 0) {
-                                // ignore all tests
-                                Assert.Ignore ("#000 ignoring all fixtures. No database present");
-                        }
-                }
-                
-                
-                [Test]
-                [Category ("NotWorking")]
-                public void GetSchemaTableTest ()
-                {
-                        _conn.ConnectionString = _connectionString;
-                        SqliteDataReader reader = null;
-                        using (_conn) {
-                                _conn.Open ();
-                                SqliteCommand cmd = (SqliteCommand) _conn.CreateCommand ();
-                                cmd.CommandText = "select * from test";
-                                reader = cmd.ExecuteReader ();
-                                try {
-                                        DataTable dt = reader.GetSchemaTable ();
-                                        Assert.IsNotNull (dt, "#GS1 should return valid table");
-                                        Assert.IsTrue (dt.Rows.Count > 0, "#GS2 should return with rows ;-)");
-                                } finally {
-                                        if (reader != null && !reader.IsClosed)
-                                                reader.Close ();
-                                        _conn.Close ();
-                                }
-                        }
-                }
+		[TestFixtureSetUp]
+		public void FixtureSetUp ()
+		{
+			if (! File.Exists (_uri) || new FileInfo (_uri).Length == 0) {
+				// ignore all tests
+				Assert.Ignore ("#000 ignoring all fixtures. No database present");
+			}
+		}
+
+		[Test]
+		public void EmptyStatementThrowsAgrumentException ()
+		{
+			_conn.ConnectionString = _connectionString;
+			SqliteDataReader reader = null;
+			using (_conn) {
+				_conn.Open ();
+				SqliteCommand cmd = (SqliteCommand) _conn.CreateCommand ();
+				cmd.CommandText = string.Empty;
+				reader = cmd.ExecuteReader ();
+				try {
+					reader.Read ();
+					Assert.Fail ();
+				} catch (ArgumentException ex){
+					// expected this one
+				} catch (Exception ex) {
+					Assert.Fail ();
+				}
+			}
+		}
+		
+		[Test]
+		[Category ("NotWorking")]
+		public void GetSchemaTableTest ()
+		{
+			_conn.ConnectionString = _connectionString;
+			SqliteDataReader reader = null;
+			using (_conn) {
+				_conn.Open ();
+				SqliteCommand cmd = (SqliteCommand) _conn.CreateCommand ();
+				cmd.CommandText = "select * from test";
+				reader = cmd.ExecuteReader ();
+				try {
+					DataTable dt = reader.GetSchemaTable ();
+					Assert.IsNotNull (dt, "#GS1 should return valid table");
+					Assert.IsTrue (dt.Rows.Count > 0, "#GS2 should return with rows ;-)");
+				} finally {
+					if (reader != null && !reader.IsClosed)
+						reader.Close ();
+					_conn.Close ();
+				}
+			}
+		}
 
 		[Test]
 		public void TypeOfNullInResultTest ()
@@ -301,5 +321,5 @@ namespace MonoTests.Mono.Data.Sqlite
 				}
 			}
 		}
-        }
+	}
 }

--- a/mcs/class/Mono.Data.Sqlite/Test/SqliteDataReaderTest.cs
+++ b/mcs/class/Mono.Data.Sqlite/Test/SqliteDataReaderTest.cs
@@ -66,9 +66,8 @@ namespace MonoTests.Mono.Data.Sqlite
 				_conn.Open ();
 				SqliteCommand cmd = (SqliteCommand) _conn.CreateCommand ();
 				cmd.CommandText = string.Empty;
-				reader = cmd.ExecuteReader ();
 				try {
-					reader.Read ();
+					reader = cmd.ExecuteReader ();
 					Assert.Fail ();
 				} catch (ArgumentException ex){
 					// expected this one
@@ -77,7 +76,47 @@ namespace MonoTests.Mono.Data.Sqlite
 				}
 			}
 		}
-		
+
+		[Test]
+		public void NullStatementThrowsAgrumentException ()
+		{
+			_conn.ConnectionString = _connectionString;
+			SqliteDataReader reader = null;
+			using (_conn) {
+				_conn.Open ();
+				SqliteCommand cmd = (SqliteCommand) _conn.CreateCommand ();
+				cmd.CommandText = null;
+				try {
+					reader = cmd.ExecuteReader ();
+					Assert.Fail ();
+				} catch (ArgumentException ex){
+					// expected this one
+				} catch (Exception ex) {
+					Assert.Fail ();
+				}
+			}
+		}
+
+		[Test]
+		public void WhitespaceOnlyStatementThrowsAgrumentException ()
+		{
+			_conn.ConnectionString = _connectionString;
+			SqliteDataReader reader = null;
+			using (_conn) {
+				_conn.Open ();
+				SqliteCommand cmd = (SqliteCommand) _conn.CreateCommand ();
+				cmd.CommandText = "   ";
+				try {
+					reader = cmd.ExecuteReader ();
+					Assert.Fail ();
+				} catch (ArgumentException ex){
+					// expected this one
+				} catch (Exception ex) {
+					Assert.Fail ();
+				}
+			}
+		}
+
 		[Test]
 		[Category ("NotWorking")]
 		public void GetSchemaTableTest ()


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/13547
