### PR TITLE
[2019-02] [arm] respect potential spilling for overflow flag check

### DIFF
--- a/mono/mini/exceptions.cs
+++ b/mono/mini/exceptions.cs
@@ -1331,6 +1331,48 @@ class Tests
 		return 0;
 	}
 
+	/* Github issue 13284 */
+	public static int test_0_ulong_ovf_spilling () {
+		checked {
+			ulong x = 2UL;
+			ulong y = 1UL;
+			ulong z = 3UL;
+			ulong t = x - y;
+
+			try {
+				var a = x - y >= z;
+				if (a)
+					return 1;
+				// Console.WriteLine ($"u64 ({x} - {y} >= {z}) => {a} [{(a == false ? "OK" : "NG")}]");
+			} catch (OverflowException) {
+				return 2;
+				// Console.WriteLine ($"u64 ({x} - {y} >= {z}) => overflow [NG]");
+			}
+
+			try {
+				var a = t >= z;
+				if (a)
+					return 3;
+				// Console.WriteLine ($"u64 ({t} >= {z}) => {a} [{(a == false ? "OK" : "NG")}]");
+			} catch (OverflowException) {
+				return 4;
+				// Console.WriteLine ($"u64 ({t} >= {z}) => overflow [NG]");
+			}
+
+			try {
+				var a = x - y - z >= 0;
+				if (a)
+					return 5;
+				else
+					return 6;
+				// Console.WriteLine ($"u64 ({x} - {y} - {z} >= 0) => {a} [NG]");
+			} catch (OverflowException) {
+				return 0;
+				// Console.WriteLine ($"u64 ({x} - {y} - {z} >= 0) => overflow [OK]");
+			}
+		}
+	}
+
 	public static int test_0_ulong_cast () {
 		ulong a;
 		bool failed;

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -3496,11 +3496,21 @@ loop_start:
 		case OP_SBB:
 		case OP_ISBB:
 		case OP_SUBCC:
-		case OP_ISUBCC:
-			if (ins->next  && (ins->next->opcode == OP_COND_EXC_C || ins->next->opcode == OP_COND_EXC_IC))
-				/* ARM sets the C flag to 1 if there was _no_ overflow */
-				ins->next->opcode = OP_COND_EXC_NC;
+		case OP_ISUBCC: {
+			int try = 2;
+			MonoInst *current = ins;
+
+			/* may require a look-ahead of a couple instructions due to spilling */
+			while (try-- && current->next) {
+				if (current->next->opcode == OP_COND_EXC_C || current->next->opcode == OP_COND_EXC_IC) {
+					/* ARM sets the C flag to 1 if there was _no_ overflow */
+					current->next->opcode = OP_COND_EXC_NC;
+					break;
+				}
+				current = current->next;
+			}
 			break;
+		}
 		case OP_IDIV_IMM:
 		case OP_IDIV_UN_IMM:
 		case OP_IREM_IMM:


### PR DESCRIPTION
```
  18 int_sbb R77 <- R54 R57
  19 store_membase_reg [arm_fp + 0x24] <- R77
  20 cond_exc_c OverflowException
```
this wasn't properly handled by the arch lowering pass.

Fixes https://github.com/mono/mono/issues/13284


Backport of #13564.

/cc @lewurm 