### PR TITLE
[netcore] Add System.Runtime.Loader.Tests

### DIFF
--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -50,12 +50,14 @@ check-env:
 
 TEST_SUITES = \
 	System.Runtime.Tests \
+	System.Runtime.Loader.Tests \
 	System.Runtime.CompilerServices.Unsafe.Tests \
 	System.Collections.Tests
 
 # The binary directory under $(COREFIX_BINDIR)
 System.Runtime.CompilerServices.Unsafe.Tests_PROFILE = netstandard-Debug
 System.Runtime.Tests_PROFILE = netcoreapp-Unix-Debug
+System.Runtime.Loader.Tests_PROFILE = netcoreapp-Unix-Debug
 System.Runtime.Tests_XUNIT_ARGS = @../excludes-System.Runtime.Tests.rsp
 System.Collections.Tests_PROFILE = netcoreapp-Debug
 
@@ -66,6 +68,7 @@ build-%: check-env
 	ln -sf $(CURDIR)/$(SHAREDRUNTIME)/System.Globalization.Native.dylib tests/$*
 	sed -e 's/9.9.9/$(VERSION)/g' < tests/$*/RemoteExecutorConsoleApp.runtimeconfig.json > 2 && mv 2 tests/$*/RemoteExecutorConsoleApp.runtimeconfig.json
 	cd tests/$* && dotnet build
+	cp $(COREFX_BINDIR)/System.Runtime.Loader.Test.Assembly/netcoreapp-Debug/System.Runtime.Loader.Test.Assembly.dll tests/$*/bin/Debug/netcoreapp3.0/System.Runtime.Loader.Test.Assembly.dll
 
 run-%: check-env
 	cd tests/$* && MONO_PATH=bin/Debug/netcoreapp3.0 MONO_ENV_OPTIONS="--debug --explicit-null-checks" COMPlus_DebugWriteToStdErr=1 ../../dotnet bin/Debug/netcoreapp3.0/$*-runner.dll


### PR DESCRIPTION
Current results:
RUN: 21
FAILURES: 15
SKIPPED: 0

Commands to run:
```
make build-System.Runtime.Loader.Tests
make run-System.Runtime.Loader.Tests
```

Output:
```
cd tests/System.Runtime.Loader.Tests && MONO_PATH=bin/Debug/netcoreapp3.0 MONO_ENV_OPTIONS="--debug --explicit-null-checks" COMPlus_DebugWriteToStdErr=1 ../../dotnet bin/Debug/netcoreapp3.0/System.Runtime.Loader.Tests-runner.dll
System.Runtime.Loader.Tests.AssemblyLoadContextTest.GetAssemblyNameTest_ValidAssembly ...
FAILED: System.IO.FileNotFoundException: 
File name: '/prj/mono/mono-netcore/netcore/tests/System.Runtime.Loader.Tests/System.Runtime.Loader.Tests.dll'
   at System.Reflection.AssemblyName.GetAssemblyName(String assemblyFile)
   at System.Runtime.Loader.AssemblyLoadContext.GetAssemblyName(String assemblyPath)
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.GetAssemblyNameTest_ValidAssembly() in /prj/corefx-egor/src/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs:line 26
   at RunTests.Run() in /prj/mono/mono-netcore/netcore/tests/System.Runtime.Loader.Tests/runner.cs:line 17
System.Runtime.Loader.Tests.AssemblyLoadContextTest.GetAssemblyNameTest_AssemblyNotFound ...
System.Runtime.Loader.Tests.AssemblyLoadContextTest.GetAssemblyNameTest_NullParameter ...
System.Runtime.Loader.Tests.AssemblyLoadContextTest.LoadAssemblyByPath_ValidUserAssembly ...
System.Runtime.Loader.Tests.AssemblyLoadContextTest.LoadAssemblyByStream_ValidUserAssembly ...
System.Runtime.Loader.Tests.AssemblyLoadContextTest.LoadFromAssemblyName_AssemblyNotFound ...
System.Runtime.Loader.Tests.AssemblyLoadContextTest.LoadFromAssemblyName_ValidTrustedPlatformAssembly ...
FAILED: System.NotImplementedException: The method or operation is not implemented.
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.LoadFromAssemblyName_ValidTrustedPlatformAssembly() in /prj/corefx-egor/src/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs:line 98
   at RunTests.Run() in /prj/mono/mono-netcore/netcore/tests/System.Runtime.Loader.Tests/runner.cs:line 119
System.Runtime.Loader.Tests.AssemblyLoadContextTest.GetLoadContextTest_ValidUserAssembly ...
FAILED: System.NotImplementedException: The method or operation is not implemented.
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.GetLoadContextTest_ValidUserAssembly() in /prj/corefx-egor/src/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs:line 111
   at RunTests.Run() in /prj/mono/mono-netcore/netcore/tests/System.Runtime.Loader.Tests/runner.cs:line 136
System.Runtime.Loader.Tests.AssemblyLoadContextTest.GetLoadContextTest_ValidTrustedPlatformAssembly ...
FAILED: System.NotImplementedException: The method or operation is not implemented.
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.GetLoadContextTest_ValidTrustedPlatformAssembly() in /prj/corefx-egor/src/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs:line 120
   at RunTests.Run() in /prj/mono/mono-netcore/netcore/tests/System.Runtime.Loader.Tests/runner.cs:line 153
System.Runtime.Loader.Tests.AssemblyLoadContextTest.GetLoadContextTest_SystemPrivateCorelibAssembly ...
FAILED: System.NotImplementedException: The method or operation is not implemented.
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.GetLoadContextTest_SystemPrivateCorelibAssembly() in /prj/corefx-egor/src/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs:line 131
   at RunTests.Run() in /prj/mono/mono-netcore/netcore/tests/System.Runtime.Loader.Tests/runner.cs:line 170
System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unload_CollectibleWithNoAssemblyLoaded ...
FAILED: Xunit.Sdk.EqualException: Assert.Equal() Failure
Expected: 1
Actual:   0
   at Xunit.Assert.Equal[Int32](Int32 expected, Int32 actual, IEqualityComparer`1 comparer)
   at Xunit.Assert.Equal[Int32](Int32 expected, Int32 actual)
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.CollectibleChecker.GcAndCheck(Int32 overrideExpect) in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 480
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unload_CollectibleWithNoAssemblyLoaded() in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 39
   at RunTests.Run() in /prj/mono/mono-netcore/netcore/tests/System.Runtime.Loader.Tests/runner.cs:line 187
System.Runtime.Loader.Tests.AssemblyLoadContextTest.Finalizer_CollectibleWithNoAssemblyLoaded ...
System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unload_CollectibleWithOneAssemblyLoaded ...
FAILED: Xunit.Sdk.EqualException: Assert.Equal() Failure
Expected: 1
Actual:   0
   at Xunit.Assert.Equal[Int32](Int32 expected, Int32 actual, IEqualityComparer`1 comparer)
   at Xunit.Assert.Equal[Int32](Int32 expected, Int32 actual)
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.CollectibleChecker.GcAndCheck(Int32 overrideExpect) in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 480
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.TestBase.CheckContextUnloaded() in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 103
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unload_CollectibleWithOneAssemblyLoaded() in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 121
   at RunTests.Run() in /prj/mono/mono-netcore/netcore/tests/System.Runtime.Loader.Tests/runner.cs:line 221
System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unload_CollectibleWithOneAssemblyLoadedWithStatic ...
FAILED: Xunit.Sdk.EqualException: Assert.Equal() Failure
Expected: 1
Actual:   0
   at Xunit.Assert.Equal[Int32](Int32 expected, Int32 actual, IEqualityComparer`1 comparer)
   at Xunit.Assert.Equal[Int32](Int32 expected, Int32 actual)
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.CollectibleChecker.GcAndCheck(Int32 overrideExpect) in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 480
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.TestBase.CheckContextUnloaded() in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 103
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unload_CollectibleWithOneAssemblyLoadedWithStatic() in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 147
   at RunTests.Run() in /prj/mono/mono-netcore/netcore/tests/System.Runtime.Loader.Tests/runner.cs:line 238
System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unload_CollectibleWithOneAssemblyLoadedWithWeakReferenceToType ...
FAILED: Xunit.Sdk.EqualException: Assert.Equal() Failure
Expected: 1
Actual:   0
   at Xunit.Assert.Equal[Int32](Int32 expected, Int32 actual, IEqualityComparer`1 comparer)
   at Xunit.Assert.Equal[Int32](Int32 expected, Int32 actual)
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.CollectibleChecker.GcAndCheck(Int32 overrideExpect) in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 480
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.TestBase.CheckContextUnloaded() in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 103
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unload_CollectibleWithOneAssemblyLoadedWithWeakReferenceToType() in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 178
   at RunTests.Run() in /prj/mono/mono-netcore/netcore/tests/System.Runtime.Loader.Tests/runner.cs:line 255
System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unload_CollectibleWithOneAssemblyLoadedWithWeakReferenceToInstance ...
FAILED: Xunit.Sdk.EqualException: Assert.Equal() Failure
Expected: 1
Actual:   0
   at Xunit.Assert.Equal[Int32](Int32 expected, Int32 actual, IEqualityComparer`1 comparer)
   at Xunit.Assert.Equal[Int32](Int32 expected, Int32 actual)
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.CollectibleChecker.GcAndCheck(Int32 overrideExpect) in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 480
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.TestBase.CheckContextUnloaded() in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 103
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unload_CollectibleWithOneAssemblyLoadedWithWeakReferenceToInstance() in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 211
   at RunTests.Run() in /prj/mono/mono-netcore/netcore/tests/System.Runtime.Loader.Tests/runner.cs:line 272
System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unload_CollectibleWithOneAssemblyLoadedWithStrongReferenceToType ...
FAILED: Xunit.Sdk.EqualException: Assert.Equal() Failure
Expected: 1
Actual:   0
   at Xunit.Assert.Equal[Int32](Int32 expected, Int32 actual, IEqualityComparer`1 comparer)
   at Xunit.Assert.Equal[Int32](Int32 expected, Int32 actual)
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.CollectibleChecker.GcAndCheck(Int32 overrideExpect) in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 480
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.TestBase.CheckContextUnloaded() in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 103
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unload_CollectibleWithOneAssemblyLoadedWithStrongReferenceToType() in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 268
   at RunTests.Run() in /prj/mono/mono-netcore/netcore/tests/System.Runtime.Loader.Tests/runner.cs:line 289
System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unload_CollectibleWithOneAssemblyLoadedWithStrongReferenceToInstance ...
FAILED: Xunit.Sdk.EqualException: Assert.Equal() Failure
Expected: 1
Actual:   0
   at Xunit.Assert.Equal[Int32](Int32 expected, Int32 actual, IEqualityComparer`1 comparer)
   at Xunit.Assert.Equal[Int32](Int32 expected, Int32 actual)
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.CollectibleChecker.GcAndCheck(Int32 overrideExpect) in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 480
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.TestBase.CheckContextUnloaded() in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 103
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unload_CollectibleWithOneAssemblyLoadedWithStrongReferenceToInstance() in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 328
   at RunTests.Run() in /prj/mono/mono-netcore/netcore/tests/System.Runtime.Loader.Tests/runner.cs:line 306
System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unload_CollectibleWithTwoAssemblies ...
FAILED: System.IO.FileNotFoundException: 
File name: 'System.Runtime.Loader.Test.Assembly2'
   at System.Reflection.Assembly.Load(AssemblyName assemblyRef, StackCrawlMark& stackMark, IntPtr ptrLoadContextBinder)
   at System.Runtime.Loader.AssemblyLoadContext.LoadFromAssemblyName(AssemblyName assemblyName)
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.CollectibleWithTwoAssembliesTest.Execute() in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 340
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unload_CollectibleWithTwoAssemblies() in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 353
   at RunTests.Run() in /prj/mono/mono-netcore/netcore/tests/System.Runtime.Loader.Tests/runner.cs:line 323
System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unload_TwoCollectibleWithOneAssemblyAndOneInstanceReferencingAnother ...
FAILED: Xunit.Sdk.EqualException: Assert.Equal() Failure
Expected: 1
Actual:   0
   at Xunit.Assert.Equal[Int32](Int32 expected, Int32 actual, IEqualityComparer`1 comparer)
   at Xunit.Assert.Equal[Int32](Int32 expected, Int32 actual)
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.CollectibleChecker.GcAndCheck(Int32 overrideExpect) in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 480
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.TwoCollectibleWithOneAssemblyAndOneInstanceReferencingAnotherTest.CheckContextUnloaded2() in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 401
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unload_TwoCollectibleWithOneAssemblyAndOneInstanceReferencingAnother() in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 425
   at RunTests.Run() in /prj/mono/mono-netcore/netcore/tests/System.Runtime.Loader.Tests/runner.cs:line 340
System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unsupported_FixedAddressValueType ...
FAILED: System.IO.FileNotFoundException: 
File name: 'System.Runtime.Loader.Test.AssemblyNotSupported'
   at System.Reflection.Assembly.Load(AssemblyName assemblyRef, StackCrawlMark& stackMark, IntPtr ptrLoadContextBinder)
   at System.Runtime.Loader.AssemblyLoadContext.LoadFromAssemblyName(AssemblyName assemblyName)
   at System.Runtime.Loader.Tests.AssemblyLoadContextTest.Unsupported_FixedAddressValueType() in /prj/corefx-egor/src/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs:line 436
   at RunTests.Run() in /prj/mono/mono-netcore/netcore/tests/System.Runtime.Loader.Tests/runner.cs:line 357
RUN: 21
FAILURES: 15
SKIPPED: 0

```