### PR TITLE
[2019-02] Xamarin.Android integration fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6104,6 +6104,7 @@ elif test x$host_linux = xyes; then
 	MONO_NATIVE_CXXFLAGS=$CXXFLAGS
 	MONO_NATIVE_CFLAGS=$CFLAGS
 	MONO_NATIVE_LDFLAGS=$LDFLAGS
+	MONO_NATIVE_LIBADD="../mini/$LIBMONO_LA"
 
 	mono_native=yes
 	mono_native_compat=no

--- a/mcs/class/System/corefx/Unix/Interop.cs
+++ b/mcs/class/System/corefx/Unix/Interop.cs
@@ -6,6 +6,6 @@ using System.Runtime.InteropServices;
 
 internal static partial class Interop
 {
-	[DllImport("__Internal")]
+	[DllImport("System.Native")]
 	internal static extern void mono_pal_init ();
 }

--- a/mcs/class/System/monodroid_System_xtest.dll.exclude.sources
+++ b/mcs/class/System/monodroid_System_xtest.dll.exclude.sources
@@ -13,3 +13,8 @@
 ../../../external/corefx/src/System.Net.Security/tests/UnitTests/Fakes/*.cs
 
 ../../../external/corefx/src/System.Text.RegularExpressions/tests/*.cs
+
+System/RemoteExecutorTests.cs
+
+# FileSystemWatcher_Path fails with "System.ArgumentException : The directory name  is invalid"
+../../../external/corefx/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs


### PR DESCRIPTION
…oid build

If this is not done, Android is not able to resolve mono symbols that are used in mono-native (e.g. `mono_add_internal_call_with_flags`), and will refuse to load the library with 'cannot locate symbol' errors


Backport of #12940.

/cc @alexischr 

Backport of #12963.

/cc @alexischr @monojenkins