### PR TITLE
[netcore] Download test assets from the dotnet-core blob feed.

### DIFF
--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -94,3 +94,15 @@ xtest-%: prepare check-env
 		$(shell grep -v '^#\|^$$' excludes-$*.rsp) $(FIXTURE)
 
 xtest-all: $(addprefix xtest-, $(TEST_SUITES))
+
+FEED_BASE_URL = https://dotnetfeed.blob.core.windows.net/dotnet-core
+TEST_ASSETS_URL = https://dotnetfeed.blob.core.windows.net/dotnet-core/corefx-tests/4.6.0-preview4.19156.10/OSX.x64/netcoreapp/corefx-test-assets.xml
+
+corefx-test-assets.xml:
+	wget $(TEST_ASSETS_URL)
+
+dl-test-assets: corefx-test-assets.xml .stamp-dl-test-assets
+
+.stamp-dl-test-assets:
+	python dl-test-assets.py corefx-test-assets.xml $(FEED_BASE_URL) assets
+	touch $@

--- a/netcore/dl-test-assets.py
+++ b/netcore/dl-test-assets.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+import sys
+import subprocess
+import xml.etree.ElementTree as ET
+
+if len(sys.argv) < 4:
+    print("Usage: dl-test-assets.py <path to assets.xml> <base url> <output dir>")
+    sys.exit(1)
+
+infile_name = sys.argv [1]
+base_url = sys.argv [2]
+outdir = sys.argv [3];
+tree = ET.parse(infile_name)
+root = tree.getroot()
+
+for elem in root:
+    if elem.tag != "Blob":
+        continue
+    print elem.attrib ["Id"]
+    res = subprocess.call (["wget", "-N", "-P", outdir, base_url + "/" + elem.attrib ["Id"]])
+    if res != 0:
+        print ("Download failed.")
+        sys.exit (1)
+


### PR DESCRIPTION
Use them in gen-xunit-runner. Note that COREFX_ROOT is still required since the test assemblies reference assemblies from
the corefx sdk dir.