### PR TITLE
[2019-02] Make test runner able to deal with whitespace patterns other than newline

### DIFF
--- a/mono/tests/test-runner.cs
+++ b/mono/tests/test-runner.cs
@@ -205,8 +205,12 @@ public class TestRunner
 
 		if (!String.IsNullOrEmpty (inputFile)) {
 			foreach (string l in File.ReadAllLines (inputFile)) {
-				for (int r = 0; r < repeat; ++r)
-					tests.Add (l);
+				foreach (string m in l.Split (' ')) {
+					if (!String.IsNullOrEmpty (m)) {
+						for (int r = 0; r < repeat; ++r)
+							tests.Add (m);
+					}
+				}
 			}
 		} else {
 			// The remaining arguments are the tests


### PR DESCRIPTION
Helix wasn't running our runtime tests as expected, because the test runner expected newline-separated tests to run, and we were generating space-separated.

Following "be liberal in what you accept" philosophy, and to prevent this issue in the future, just deal with "whitespace separated" rather than "this specific whitespace and no other"

Backport of #13587.

/cc @akoeplinger @directhex