### PR TITLE
[aot] cleanup MonoError in add_extra_method_with_depth

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -4123,9 +4123,11 @@ add_extra_method_with_depth (MonoAotCompile *acfg, MonoMethod *method, int depth
 
 	if (mono_method_is_generic_sharable_full (method, TRUE, TRUE, FALSE)) {
 		method = mini_get_shared_method_full (method, SHARE_MODE_NONE, error);
-		if (!is_ok (error))
+		if (!is_ok (error)) {
 			/* vtype constraint */
+			mono_error_cleanup (error);
 			return;
+		}
 	} else if ((acfg->opts & MONO_OPT_GSHAREDVT) && prefer_gsharedvt_method (acfg, method) && mono_method_is_generic_sharable_full (method, FALSE, FALSE, TRUE)) {
 		/* Use the gsharedvt version */
 		method = mini_get_shared_method_full (method, SHARE_MODE_GSHAREDVT, error);


### PR DESCRIPTION
I missed something in the code review for #13581.  Need to cleanup MonoError if it's not ok.