### PR TITLE
[runtime] Add MONO_LLVM_INTERNAL to *get_aot_init_wrapper* marshal funcs

### DIFF
--- a/mono/metadata/marshal.h
+++ b/mono/metadata/marshal.h
@@ -433,10 +433,10 @@ MonoMethod *
 mono_marshal_get_icall_wrapper (MonoMethodSignature *sig, const char *name, gconstpointer func, gboolean check_exceptions);
 
 MonoMethod *
-mono_marshal_get_aot_init_wrapper (MonoAotInitSubtype subtype);
+mono_marshal_get_aot_init_wrapper (MonoAotInitSubtype subtype) MONO_LLVM_INTERNAL;
 
 const char *
-mono_marshal_get_aot_init_wrapper_name (MonoAotInitSubtype subtype);
+mono_marshal_get_aot_init_wrapper_name (MonoAotInitSubtype subtype) MONO_LLVM_INTERNAL;
 
 MonoMethod *
 mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, gboolean aot);


### PR DESCRIPTION
This should fix the error seen when using the loaded-llvm configuration. 

```
root@breakfast:/# mono --aot=llvm /tmp/hello.exe 
Mono Ahead of Time compiler - compiling assembly /tmp/hello.exe
AOTID CA786163-28F4-6B55-13D1-2E3569054BE8
mono: symbol lookup error: /usr/lib/libmono-llvm.so: undefined symbol: mono_marshal_get_aot_init_wrapper_name
```