### PR TITLE
[mini] Propagate valuetype constraint from one mvar to another for gsharing

### DIFF
--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -3908,14 +3908,18 @@ get_shared_type (MonoType *t, MonoType *type)
 	} else if (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR) {
 		if (type->data.generic_param->gshared_constraint)
 			return mini_get_shared_gparam (t, type->data.generic_param->gshared_constraint);
-		ttype = MONO_TYPE_OBJECT;
+		MonoGenericParamInfo *info = mono_generic_param_info (type->data.generic_param);
+		if (info && (info->flags & GENERIC_PARAMETER_ATTRIBUTE_VALUE_TYPE_CONSTRAINT))
+			ttype = MONO_TYPE_VALUETYPE;
+		else
+			ttype = MONO_TYPE_OBJECT;
 	}
 
 	{
 		MonoType t2;
 		MonoClass *klass;
 
-		memset (&t2, 0, sizeof (t2));
+		memset (&t2, 0, MONO_SIZEOF_TYPE);
 		t2.type = ttype;
 		klass = mono_class_from_mono_type_internal (&t2);
 


### PR DESCRIPTION
Maybe this helps with #13607.

In daf92b9e62a847d521ae314c320d3502fefe217e we added a restriction to how to inflate one type var with another one, but here in gsharing we treat an type var constraint as if it was an `object` constraint.

This PR is for 2019-02.  I need to make another one for `master` that also adds a test.