### PR TITLE
[2018-08] [Unsafe] Sanatize the computed offset

### DIFF
--- a/mcs/class/corlib/System.Runtime.CompilerServices/Unsafe.il
+++ b/mcs/class/corlib/System.Runtime.CompilerServices/Unsafe.il
@@ -239,8 +239,8 @@
         ldarg.0
         ldarg.1
         sizeof !!T
-        conv.i
         mul
+        conv.i
         add
         ret
   }
@@ -252,8 +252,8 @@
         ldarg.0
         ldarg.1
         sizeof !!T
-        conv.i
         mul
+        conv.i
         add
         ret
   }
@@ -266,6 +266,7 @@
         ldarg.1
         sizeof !!T
         mul
+        conv.i
         add
         ret
   }


### PR DESCRIPTION
We do 64bit operations, but operate on 32bit values. We need to sanitize those values.

Consider:
```
(lldb) x/8i 0x40011357
    0x40011357: 0f 84 c7 00 00 00  je     0x40011424
    0x4001135d: 49 8d 7c 24 14     leaq   0x14(%r12), %rdi
->  0x40011362: 49 8b c6           movq   %r14, %rax
    0x40011365: 48 d1 e0           shlq   %rax
    0x40011368: 48 03 f8           addq   %rax, %rdi
    0x4001136b: 0f b7 74 24 20     movzwl 0x20(%rsp), %esi
    0x40011370: 49 8b d7           movq   %r15, %rdx
    0x40011373: e8 bc 00 00 00     callq  0x40011434
(lldb) register read r14 rax rdi
     r14 = 0x0000000100000000
     rax = 0x0000000000000010
     rdi = 0x00007ffff7f48144
(lldb) si
(lldb) si
(lldb) si
(lldb) register read r14 rax rdi
     r14 = 0x0000000100000000
     rax = 0x0000000200000000
     rdi = 0x00008001f7f48144
```
In this snippet `r14` has some garbage in the 32bit upper half, which unfortunately is taken into account for the multiplication (`shl`) and addition in order to compute the address (`rdi`).

Several factors why we didn't see it earlier:
1. It doesn't trigger on AOT, because when compiling mscorlib.dll, `Unsafe.dll` isn't available to the AOT compiler and thus inlining won't happen. We use AOT where possible in our CI. When doing a call the upper halfs are properly cleared.
2. It doesn't trigger on macOS due to different memory organization.  We don't end up with gargabe in the registers.
3. Recently we added intrinsics for Unsafe.* https://github.com/mono/mono/pull/12605/files#diff-89fe30e1e87c5db21be052ddb0c8e28dR329 It masks this specific problem. Funnily enough, the assumed IL for the `Add ()` intrinsics didn't match what we had before. Now it does :-)

Fixes https://github.com/mono/mono/issues/13452 and https://github.com/mono/mono/issues/13597


Backport of #13609.

/cc @marek-safar @lewurm