### PR TITLE
[netcore] Marshal.IsPinnable

### DIFF
--- a/mcs/class/System.Private.CoreLib/System.IO/Stream.cs
+++ b/mcs/class/System.Private.CoreLib/System.IO/Stream.cs
@@ -2,14 +2,8 @@ namespace System.IO
 {
 	partial class Stream
 	{
-		private bool HasOverriddenBeginEndRead ()
-		{
-			throw new NotImplementedException ();
-		}
+		bool HasOverriddenBeginEndRead () => true;
 
-		private bool HasOverriddenBeginEndWrite ()
-		{
-			throw new NotImplementedException ();
-		}
+		bool HasOverriddenBeginEndWrite () => true;
 	}
 }

--- a/mcs/class/System.Private.CoreLib/System.Runtime.InteropServices/Marshal.cs
+++ b/mcs/class/System.Private.CoreLib/System.Runtime.InteropServices/Marshal.cs
@@ -49,7 +49,7 @@ namespace System.Runtime.InteropServices
 
 		internal static bool IsPinnable (object obj)
 		{
-			return (obj == null) || RuntimeTypeHandle.HasReferences (obj.GetType () as RuntimeType));
+			return (obj == null) || RuntimeTypeHandle.HasReferences (obj.GetType () as RuntimeType);
 		}
 
 		// TODO: Should be called from Windows only code

--- a/mcs/class/System.Private.CoreLib/System.Runtime.InteropServices/Marshal.cs
+++ b/mcs/class/System.Private.CoreLib/System.Runtime.InteropServices/Marshal.cs
@@ -49,7 +49,7 @@ namespace System.Runtime.InteropServices
 
 		internal static bool IsPinnable (object obj)
 		{
-			return (obj == null) || RuntimeTypeHandle.HasReferences (obj.GetType () as RuntimeType);
+			return obj == null || RuntimeTypeHandle.HasReferences (obj.GetType () as RuntimeType);
 		}
 
 		// TODO: Should be called from Windows only code

--- a/mcs/class/System.Private.CoreLib/System.Runtime.InteropServices/Marshal.cs
+++ b/mcs/class/System.Private.CoreLib/System.Runtime.InteropServices/Marshal.cs
@@ -49,7 +49,7 @@ namespace System.Runtime.InteropServices
 
 		internal static bool IsPinnable (object obj)
 		{
-			return (o == null) || RuntimeTypeHandle.HasReferences (obj.GetType () as RuntimeType));
+			return (obj == null) || RuntimeTypeHandle.HasReferences (obj.GetType () as RuntimeType));
 		}
 
 		// TODO: Should be called from Windows only code

--- a/mcs/class/System.Private.CoreLib/System.Runtime.InteropServices/Marshal.cs
+++ b/mcs/class/System.Private.CoreLib/System.Runtime.InteropServices/Marshal.cs
@@ -49,7 +49,7 @@ namespace System.Runtime.InteropServices
 
 		internal static bool IsPinnable (object obj)
 		{
-			throw new NotImplementedException ();
+			return (o == null) || RuntimeTypeHandle.HasReferences (obj.GetType () as RuntimeType));
 		}
 
 		// TODO: Should be called from Windows only code


### PR DESCRIPTION
Needed for MSBuild.
Stream changes were copied from [CoreRT](https://github.com/dotnet/corert/blob/master/src/System.Private.CoreLib/src/System/IO/Stream.CoreRT.cs).
IsPinnable - perhaps it should be an icall/intrinsics for better perf?
[CoreCLR impl for IsPinnable (InternalCall)](https://github.com/dotnet/coreclr/blob/1f3f474a13bdde1c5fecdf8cd9ce525dbe5df000/src/vm/marshalnative.cpp#L257)
[CoreRT impl for IsPinnable](https://github.com/dotnet/corert/blob/master/src/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs#L114) (and [MightBeBlittable](https://github.com/dotnet/corert/blob/master/src/System.Private.CoreLib/src/System/Runtime/InteropServices/InteropExtensions.cs#L60)) 