### PR TITLE
[windows]Fix and cleanup configure.ac parsing for MONO_CORLIB_VERSION and AC_INIT.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,9 +46,11 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # perl -pi.bak -e "s/^MONO_CORLIB_VERSION=\S+/MONO_CORLIB_VERSION=`uuidgen`/" configure.ac
 #
 # There is no ordering of corlib versions, no old or new,
-# the runtime expects an exact match.
+# the runtime requires an exact match.
 #
-MONO_CORLIB_VERSION=4A9CEBCF-2544-4CB4-9F84-07A10C16BEEB
+# This is an arbitrary string, not necessarily a guid. It ends at whitespace or end of line.
+#
+MONO_CORLIB_VERSION=march232019
 
 #
 # Put a quoted #define in config.h.

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,7 @@
 # Process this file with autoconf to produce a configure script.
 #AC_PREREQ([2.62])
 
+# This line is parsed by mono.winconfig.targets.
 AC_INIT(mono, [6.1.0],
         [https://github.com/mono/mono/issues/new])
 
@@ -49,6 +50,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # the runtime requires an exact match.
 #
 # This is an arbitrary string, not necessarily a guid. It ends at whitespace or end of line.
+# This line is parsed by mono.winconfig.targets.
 #
 MONO_CORLIB_VERSION=march232019
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,10 @@
 # Process this file with autoconf to produce a configure script.
 #AC_PREREQ([2.62])
 
-# This line is parsed by mono.winconfig.targets.
+# This line is parsed by tools besides autoconf, such as msvc/mono.winconfig.targets.
+# It should remain in the format they expect.
+# msvc/mono.winconfig.targets: ^AC_INIT\s*\(\s*mono,\s*\[?\s*([^\],\s]+)
+#
 AC_INIT(mono, [6.1.0],
         [https://github.com/mono/mono/issues/new])
 
@@ -41,18 +44,24 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # of classes the runtime knows about, changing icall signature or
 # semantics etc), change this variable.
 #
-# This must be unique relative to corlib interface/semantics.
+# This must be unique relative to corlib interface and semantics.
+#
+# If you change corlib such that a runtime change is required, or
+# vice versa, change this string. Examples include removing icalls,
+# adding icalls, changing icall signatures, and changing type layouts
+# that both sides know.
+#
+# It is an arbitrary string and should be parsed as such.
+# A guid works and is encouraged.
 #
 # Generate it with uuidgen. For example:
 # perl -pi.bak -e "s/^MONO_CORLIB_VERSION=\S+/MONO_CORLIB_VERSION=`uuidgen`/" configure.ac
 #
-# There is no ordering of corlib versions, no old or new,
-# the runtime requires an exact match.
+# This line is parsed by tools besides autoconf, such as msvc/mono.winconfig.targets.
+# It should remain in the format they expect.
+# msvc/mono.winconfig.targets: ^MONO_CORLIB_VERSION\s*=\s*(\S+)
 #
-# This is an arbitrary string, not necessarily a guid. It ends at whitespace or end of line.
-# This line is parsed by mono.winconfig.targets.
-#
-MONO_CORLIB_VERSION=march232019
+MONO_CORLIB_VERSION=4A9CEBCF-2544-4CB4-9F84-07A10C16BEEB
 
 #
 # Put a quoted #define in config.h.

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,6 @@
 
 # This line is parsed by tools besides autoconf, such as msvc/mono.winconfig.targets.
 # It should remain in the format they expect.
-# msvc/mono.winconfig.targets: ^AC_INIT\s*\(\s*mono,\s*\[?\s*([^\],\s]+)
 #
 AC_INIT(mono, [6.1.0],
         [https://github.com/mono/mono/issues/new])
@@ -59,7 +58,6 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 #
 # This line is parsed by tools besides autoconf, such as msvc/mono.winconfig.targets.
 # It should remain in the format they expect.
-# msvc/mono.winconfig.targets: ^MONO_CORLIB_VERSION\s*=\s*(\S+)
 #
 MONO_CORLIB_VERSION=4A9CEBCF-2544-4CB4-9F84-07A10C16BEEB
 

--- a/msvc/mono.winconfig.targets
+++ b/msvc/mono.winconfig.targets
@@ -29,7 +29,8 @@
                       if (File.Exists (configureACFile))
                       {
                           var monoVersionRegEx = new Regex (@"(.*AC_INIT\(mono, \[)(\d+\.\d+\.\d+)");
-                          var monoCorlibVersionRegEx = new Regex (@"(MONO_CORLIB_VERSION=)([A-F0-9]{8}(?:-[A-F0-9]{4}){3}-[A-F0-9]{12})");
+                          // MONO_CORLIB_VERSION is an arbitrary string
+                          var monoCorlibVersionRegEx = new Regex (@"^MONO_CORLIB_VERSION\s*=\s*(\S+)");
                           using (StreamReader reader = new StreamReader (configureACFile))
                           {
                               string line;
@@ -43,9 +44,9 @@
                                   }
 
                                   var monoCorlibVersionMatch = monoCorlibVersionRegEx.Match (line);
-                                  if (monoCorlibVersionMatch != null && monoCorlibVersionMatch.Success && monoCorlibVersionMatch.Groups.Count == 3)
+                                  if (monoCorlibVersionMatch != null && monoCorlibVersionMatch.Success)
                                   {
-                                      monoCorlibVersion = monoCorlibVersionMatch.Groups[2].Value;
+                                      monoCorlibVersion = monoCorlibVersionMatch.Groups[0].Value;
                                       continue;
                                   }
                               }
@@ -259,6 +260,18 @@
                     string monoVersion = null;
                     string monoCorlibVersion = null;
                     GetVersionsFromConfigureAC (configureACFile, out monoVersion, out monoCorlibVersion);
+
+                    if (monoVersion == null)
+                    {
+                        Log.LogError("failed to parse version from AC_INIT in {0}", configureACFile);
+                        return false;
+                    }
+
+                    if (monoCorlibVersion == null)
+                    {
+                        Log.LogError("failed to parse MONO_CORLIB_VERSION from {0}", configureACFile);
+                        return false;
+                    }
 
                     var disableDefines = GetDisabledConfigFeatures (cygConfigFile);
                     var enableDefines = (EnableDefines != null) ? EnableDefines.Split (';') : null;

--- a/msvc/mono.winconfig.targets
+++ b/msvc/mono.winconfig.targets
@@ -296,7 +296,7 @@
 
                     CreateVersionFile (versionFile);
 
-                    Log.LogMessage (MessageImportance.High, "Successfully setup Mono configuration headers {0} {1} from {2}.", configFile, versionFile, winConfigFile);
+                    Log.LogMessage (MessageImportance.High, "Successfully setup Mono configuration headers {0} and {1} from {2}.", configFile, versionFile, winConfigFile);
 
                     return true;
                   }

--- a/msvc/mono.winconfig.targets
+++ b/msvc/mono.winconfig.targets
@@ -22,14 +22,15 @@
 
                 public class _WinConfigSetup : Task
                 {
-                  void GetVersionsFromConfigureAC (string configureACFile, out string monoVersion, out string monoCorlibVersion)
+                  bool GetVersionsFromConfigureAC (string configureACFile, out string monoVersion, out string monoCorlibVersion)
                   {
+                      bool result = true;
                       monoVersion = null;
                       monoCorlibVersion = null;
                       if (File.Exists (configureACFile))
                       {
-                          var monoVersionRegEx = new Regex (@"(.*AC_INIT\(mono, \[)(\d+\.\d+\.\d+)");
-                          // MONO_CORLIB_VERSION is an arbitrary string
+                          // These are both fairly arbitrary strings.
+                          var monoVersionRegEx = new Regex (@"^AC_INIT\s*\(\s*mono,\s*\[?\s*([^\],\s]+)");
                           var monoCorlibVersionRegEx = new Regex (@"^MONO_CORLIB_VERSION\s*=\s*(\S+)");
                           using (StreamReader reader = new StreamReader (configureACFile))
                           {
@@ -37,21 +38,35 @@
                               while ((line = reader.ReadLine ()) != null && (monoVersion == null || monoCorlibVersion == null))
                               {
                                   var monoVersionMatch = monoVersionRegEx.Match (line);
-                                  if (monoVersionMatch != null && monoVersionMatch.Success && monoVersionMatch.Groups.Count == 3)
+                                  if (monoVersionMatch.Success)
                                   {
-                                      monoVersion = monoVersionMatch.Groups[2].Value;
+                                      if (monoVersion != null)
+                                      {
+                                          Log.LogError("duplicate MONO_INIT in {0}", configureACFile);
+                                          result = false;
+                                      }
+                                      monoVersion = monoVersionMatch.Groups[1].Value;
+                                      Log.LogMessage ("{0}:AC_INIT:MONO_VERSION=\"{1}\"", configureACFile, monoVersion);
                                       continue;
                                   }
 
                                   var monoCorlibVersionMatch = monoCorlibVersionRegEx.Match (line);
-                                  if (monoCorlibVersionMatch != null && monoCorlibVersionMatch.Success)
+                                  if (monoCorlibVersionMatch.Success)
                                   {
-                                      monoCorlibVersion = monoCorlibVersionMatch.Groups[0].Value;
+                                      if (monoCorlibVersion != null)
+                                      {
+                                          // This is misleading. The loop stops when both found, so duplicates usually not noticed.
+                                          Log.LogError("duplicate MONO_CORLIB_VERSION in {0}", configureACFile);
+                                          result = false;
+                                      }
+                                      monoCorlibVersion = monoCorlibVersionMatch.Groups[1].Value;
+                                      Log.LogMessage ("{0}:MONO_CORLIB_VERSION=\"{1}\"", configureACFile, monoCorlibVersion);
                                       continue;
                                   }
                               }
                           }
                       }
+                      return result;
                   }
 
                   string [] GetDisabledConfigFeatures (string path)
@@ -259,7 +274,8 @@
 
                     string monoVersion = null;
                     string monoCorlibVersion = null;
-                    GetVersionsFromConfigureAC (configureACFile, out monoVersion, out monoCorlibVersion);
+                    if (!GetVersionsFromConfigureAC (configureACFile, out monoVersion, out monoCorlibVersion))
+                        return false;
 
                     if (monoVersion == null)
                     {
@@ -280,7 +296,7 @@
 
                     CreateVersionFile (versionFile);
 
-                    Log.LogMessage (MessageImportance.High, "Successfully setup Mono configuration headers.");
+                    Log.LogMessage (MessageImportance.High, "Successfully setup Mono configuration headers {0} {1} from {2}.", configFile, versionFile, winConfigFile);
 
                     return true;
                   }


### PR DESCRIPTION
Not just a guid or an uppercase guid.
