### PR TITLE
Fix DNS Name Resolution Failure on OpenBSD (GitHub issue #8168)

### DIFF
--- a/mcs/class/System/System.Net.NetworkInformation/UnixNetworkInterfaceFactory.cs
+++ b/mcs/class/System/System.Net.NetworkInformation/UnixNetworkInterfaceFactory.cs
@@ -43,7 +43,7 @@ namespace System.Net.NetworkInformation {
 			if (runningOnUnix) {
 				// XXX: OpenBSD and NetBSD too? It seems other platforms map closer to the Mac OS version than Linux,
 				// even if not exactly; it seems Linux and/or glibc are the different ones.
-				if (Platform.IsMacOS || Platform.IsFreeBSD)
+				if (Platform.IsMacOS || Platform.IsFreeBSD || Platform.IsOpenBSD)
 					return new MacOsNetworkInterfaceAPI ();
 
 				// XXX: IBM i would be better with its own API targetting Qp2getifaddrs

--- a/mcs/class/System/System/Platform.cs
+++ b/mcs/class/System/System/Platform.cs
@@ -50,6 +50,7 @@ namespace System {
 
 #else
 		static bool isFreeBSD;
+		static bool isOpenBSD;
 
 		[DllImport ("libc")]
 		static extern int uname (IntPtr buf);
@@ -76,6 +77,9 @@ namespace System {
 				case "OS400":
 					isIBMi = true;
 					break;
+				case "OpenBSD":
+					isOpenBSD = true;
+					break;
 				}
 			}
 			Marshal.FreeHGlobal (buf);
@@ -96,6 +100,14 @@ namespace System {
 				if (!checkedOS)
 					CheckOS();
 				return isFreeBSD;
+			}
+		}
+
+		public static bool IsOpenBSD {
+			get {
+				if (!checkedOS)
+					CheckOS();
+				return isOpenBSD;
 			}
 		}
 


### PR DESCRIPTION

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
This adds OpenBSD to the platforms to use MacOsNetworkInterfaceAPI, fixes #8168, should apply similarly to DragonFly BSD. Tested with mono-5.14.0.177 from ports on OpenBSD with OpenRA and SMAPI for StardewValley that both do DNS lookup and exhibited NameResolutionFailure that is resolved with this diff.