### PR TITLE
Revert "[2019-02] Do not use MAP_JIT by default"

### DIFF
--- a/man/mono.1
+++ b/man/mono.1
@@ -628,10 +628,6 @@ running a 1.1 program on a 2.0 version:
 Configures the virtual machine to be better suited for server
 operations (currently, allows a heavier threadpool initialization).
 .TP
-\fB--use-map-jit\fR
-Instructs Mono to generate code using MAP_JIT on MacOS.  Necessary for
-bundled applications.
-.TP
 \fB--verify-all\fR 
 Verifies mscorlib and assemblies in the global
 assembly cache for valid IL, and all user code for IL

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -2388,8 +2388,6 @@ mono_main (int argc, char* argv[])
 			mono_parse_response_options (response_options, &argc, &argv, FALSE);
 			g_free (response_content);
 		} else if (argv [i][0] == '-' && argv [i][1] == '-' && mini_parse_debug_option (argv [i] + 2)) {
-		} else if (strcmp (argv [i], "--use-map-jit") == 0){
-			mono_setmmapjit (TRUE);
 		} else {
 			fprintf (stderr, "Unknown command line option: '%s'\n", argv [i]);
 			return 1;

--- a/mono/utils/mono-mmap.c
+++ b/mono/utils/mono-mmap.c
@@ -227,22 +227,6 @@ get_darwin_version (void)
 }
 #endif
 
-static int use_mmap_jit;
-
-/**
- * mono_setmmapjit:
- * \param flag indicating whether to enable or disable the use of MAP_JIT in mmap
- *
- * Call this method to enable or disable the use of MAP_JIT to create the pages
- * for the JIT to use.   This is only needed for scenarios where Mono is bundled
- * as an App in MacOS
- */
-void
-mono_setmmapjit (int flag)
-{
-	use_mmap_jit = flag;
-}
-
 /**
  * mono_valloc:
  * \param addr memory address
@@ -278,7 +262,7 @@ mono_valloc (void *addr, size_t length, int flags, MonoMemAccountType type)
 #endif
 
 #if defined(__APPLE__) && defined(MAP_JIT)
-	if ((flags & MONO_MMAP_JIT) && use_mmap_jit) {
+	if (flags & MONO_MMAP_JIT) {
 		if (get_darwin_version () >= DARWIN_VERSION_MOJAVE) {
 			mflags |= MAP_JIT;
 		}

--- a/mono/utils/mono-mmap.h
+++ b/mono/utils/mono-mmap.h
@@ -53,7 +53,6 @@ MONO_API guint64      mono_file_map_size  (MonoFileMap *fmap);
 MONO_API int          mono_file_map_fd    (MonoFileMap *fmap);
 MONO_API int          mono_file_map_close (MonoFileMap *fmap);
 
-MONO_API void  mono_setmmapjit (int flag);
 MONO_API int   mono_pagesize   (void);
 MONO_API int   mono_valloc_granule (void);
 MONO_API void* mono_valloc     (void *addr, size_t length, int flags, MonoMemAccountType type);


### PR DESCRIPTION
Reverts mono/mono#13637, it breaks the build