### PR TITLE
[netcore] Improve xunit console runner

### DIFF
--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -81,13 +81,13 @@ check: $(addprefix run-, $(TEST_SUITES))
 clean:
 	rm -rf sdk shared host dotnet tests LICENSE.txt ThirdPartyNotices.txt $(NETCORESDK_FILE)
 
-xtest-%: check-env
+xtest-%: prepare check-env
 	ln -sf $(CURDIR)/$(SHAREDRUNTIME)/System.Globalization.Native.dylib \
 		$(COREFX_BINDIR)/testhost/netcoreapp-OSX-Debug-x64/shared/Microsoft.NETCore.App/9.9.9/
 	COMPlus_DebugWriteToStdErr=1 ./dotnet --fx-version "$(VERSION)" \
 		$(COREFX_BINDIR)/testhost/netcoreapp-OSX-Debug-x64/shared/Microsoft.NETCore.App/9.9.9/xunit.console.dll \
 		$(COREFX_BINDIR)/$*/$($*_PROFILE)/$*.dll -notrait category=outerloop -notrait category=nonosxtests -notrait category=failing \
-		-notrait category=nonnetcoreapptests -noappdomain -noshadow -parallel all -nunit TestResult-netcore-xunit.xml \
+		-notrait category=nonnetcoreapptests -noappdomain -noshadow -parallel all -nunit TestResult-$*-netcore-xunit.xml \
 		$(shell grep -v '^#\|^$$' excludes-$*.rsp)
 
 xtest-all: $(addprefix xtest-, $(TEST_SUITES))

--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -81,10 +81,13 @@ check: $(addprefix run-, $(TEST_SUITES))
 clean:
 	rm -rf sdk shared host dotnet tests LICENSE.txt ThirdPartyNotices.txt $(NETCORESDK_FILE)
 
-run-xunit: check-env
+xtest-%: check-env
 	ln -sf $(CURDIR)/$(SHAREDRUNTIME)/System.Globalization.Native.dylib \
 		$(COREFX_BINDIR)/testhost/netcoreapp-OSX-Debug-x64/shared/Microsoft.NETCore.App/9.9.9/
 	COMPlus_DebugWriteToStdErr=1 ./dotnet --fx-version "$(VERSION)" \
 		$(COREFX_BINDIR)/testhost/netcoreapp-OSX-Debug-x64/shared/Microsoft.NETCore.App/9.9.9/xunit.console.dll \
-		$(TEST_ASSEMBLY) -notrait category=nonosxtests -notrait category=failing -notrait category=Outerloop -notrait category=nonnetcoreapptests \
-		-noappdomain -noshadow -parallel all -nunit TestResult-netcore-xunit.xml < excludes-System.Runtime.Tests.rsp
+		$(COREFX_BINDIR)/$*/$($*_PROFILE)/$*.dll -notrait category=outerloop -notrait category=nonosxtests -notrait category=failing \
+		-notrait category=nonnetcoreapptests -noappdomain -noshadow -parallel all -nunit TestResult-netcore-xunit.xml \
+		$(shell grep -v '^#\|^$$' excludes-$*.rsp)
+
+xtest-all: $(addprefix xtest-, $(TEST_SUITES))

--- a/netcore/excludes-System.Runtime.Tests.rsp
+++ b/netcore/excludes-System.Runtime.Tests.rsp
@@ -96,3 +96,8 @@
 # GCHandle.ctor is not implemented
 -nomethod System.Tests.UriCreateStringTests.Path_Query_Fragment
 -nomethod System.Tests.UriCreateStringTests.OriginalString_AbsoluteUri_ToString
+
+-noclass System.Tests.TypeTestsExtended
+-noclass System.Tests.ArgIteratorTests
+-nomethod System.Tests.ActivatorTests.CreateInstance_InvalidType_ThrowsNotSupportedException
+-nomethod System.Tests.ArrayTests.CreateInstance_NotSupportedType_ThrowsNotSupportedException


### PR DESCRIPTION
Now it correctly loads *.rsp files (list of tests to ignore).
Also, had to disable a few tests due to runtime crashes.
Renamed from `run-xunit` because there is already `run-%`.

1) **System.Collections.Tests**
```
make xtest-System.Collections.Tests COREFX_ROOT=/prj/corefx-egor

total="30406" failures="8" skipped="78"
```

2) **System.Runtime.Tests**
```
make xtest-System.Runtime.Tests COREFX_ROOT=/prj/corefx-egor

total="30706" failures="772" skipped="9"
```
_(most of the failures are RemoteTestExecutor related)_

3) **System.Reflection.Emit.Lightweight.Tests**
```
make xtest-System.Reflection.Emit.Lightweight.Tests COREFX_ROOT=/prj/corefx-egor

total="74" failures="22" skipped="0"
```
4) **System.Reflection.Emit.Tests**
```
make xtest-System.Reflection.Emit.Tests COREFX_ROOT=/prj/corefx-egor

total="995" failures="28" skipped="0"
```

