### PR TITLE
[2019-02] [amd64] use 32bit variant of lea_membase for 32bit operations

### DIFF
--- a/mono/arch/amd64/amd64-codegen.h
+++ b/mono/arch/amd64/amd64-codegen.h
@@ -450,15 +450,18 @@ typedef union {
 	} while (0)
 
 
-#define amd64_lea_membase_body(inst,reg,basereg,disp)	\
+#define amd64_lea_membase_body(inst,reg,basereg,disp,width)	\
 	do {	\
-		amd64_emit_rex(inst, 8, (reg), 0, (basereg)); \
+		amd64_emit_rex(inst, width, (reg), 0, (basereg)); \
 		*(inst)++ = (unsigned char)0x8d;	\
 		amd64_membase_emit ((inst), (reg), (basereg), (disp));	\
 	} while (0)
 
+#define amd64_lea4_membase(inst,reg,basereg,disp) \
+	amd64_lea_membase_body((inst), (reg), (basereg), (disp), 4)
+
 #define amd64_lea_membase(inst,reg,basereg,disp) \
-	amd64_lea_membase_body((inst), (reg), (basereg), (disp))
+	amd64_lea_membase_body((inst), (reg), (basereg), (disp), 8)
 
 /* Instruction are implicitly 64-bits so don't generate REX for just the size. */
 #define amd64_push_reg(inst,reg)	\

--- a/mono/mini/cpu-amd64.md
+++ b/mono/mini/cpu-amd64.md
@@ -336,6 +336,7 @@ x86_push_membase: src1:b len:8
 x86_push_obj: src1:b len:40
 x86_lea: dest:i src1:i src2:i len:8
 x86_lea_membase: dest:i src1:i len:11
+amd64_lea_membase: dest:i src1:i len:11
 x86_xchg: src1:i src2:i clob:x len:2
 x86_fpop: src1:f len:3
 x86_seteq_membase: src1:b len:9

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -2460,7 +2460,7 @@ mono_arch_emit_outarg_vt (MonoCompile *cfg, MonoInst *ins, MonoInst *src)
 		mini_emit_memcpy (cfg, load->dreg, 0, src->dreg, 0, size, TARGET_SIZEOF_VOID_P);
 
 		if (ainfo->pair_storage [0] == ArgInIReg) {
-			MONO_INST_NEW (cfg, arg, OP_X86_LEA_MEMBASE);
+			MONO_INST_NEW (cfg, arg, OP_AMD64_LEA_MEMBASE);
 			arg->dreg = mono_alloc_ireg (cfg);
 			arg->sreg1 = load->dreg;
 			arg->inst_imm = 0;
@@ -3201,7 +3201,7 @@ mono_arch_peephole_pass_1 (MonoCompile *cfg, MonoBasicBlock *bb)
 				 * sreg1==dreg restriction. inst_imm > 0 is needed since LEA sign-extends 
 				 * its operand to 64 bit.
 				 */
-				ins->opcode = OP_X86_LEA_MEMBASE;
+				ins->opcode = ins->opcode == OP_IADD_IMM ? OP_X86_LEA_MEMBASE : OP_AMD64_LEA_MEMBASE;
 				ins->inst_basereg = ins->sreg1;
 			}
 			break;
@@ -5072,6 +5072,9 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			amd64_lea_memindex (code, ins->dreg, ins->sreg1, ins->inst_imm, ins->sreg2, ins->backend.shift_amount);
 			break;
 		case OP_X86_LEA_MEMBASE:
+			amd64_lea4_membase (code, ins->dreg, ins->sreg1, ins->inst_imm);
+			break;
+		case OP_AMD64_LEA_MEMBASE:
 			amd64_lea_membase (code, ins->dreg, ins->sreg1, ins->inst_imm);
 			break;
 		case OP_X86_XCHG:

--- a/mono/mini/mini-ops.h
+++ b/mono/mini/mini-ops.h
@@ -1190,6 +1190,7 @@ MINI_OP(OP_AMD64_AND_MEMBASE_IMM,        "amd64_and_membase_imm", NONE, IREG, NO
 MINI_OP(OP_AMD64_OR_MEMBASE_IMM,         "amd64_or_membase_imm", NONE, IREG, NONE)
 MINI_OP(OP_AMD64_XOR_MEMBASE_IMM,        "amd64_xor_membase_imm", NONE, IREG, NONE)
 MINI_OP(OP_AMD64_MUL_MEMBASE_IMM,        "amd64_mul_membase_imm", NONE, IREG, NONE)
+MINI_OP(OP_AMD64_LEA_MEMBASE,            "amd64_lea_membase", IREG, IREG, NONE)
 
 MINI_OP(OP_AMD64_ADD_REG_MEMBASE,        "amd64_add_reg_membase", IREG, IREG, IREG)
 MINI_OP(OP_AMD64_SUB_REG_MEMBASE,        "amd64_sub_reg_membase", IREG, IREG, IREG)


### PR DESCRIPTION
Consider
```
 xor %r15, %r15       // %r15 = 0x0
 dec %r15d            // %r15 = 0xffff_ffff
 lea 0x1(%r15), %rdx  // %rdx = 0x1_0000_0000 but should be 0x0
```

instead `lea 0x1(%r15), %edx` should be generated.


Fixes #13452
Fixes #13597

Backport of #13642.

/cc @lewurm 