### PR TITLE
[netcore] Change loader behaviour to disable assembly remapping…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1228,6 +1228,7 @@ elif test x$with_runtime_preset = xnetcore; then
    mono_feature_disable_reflection_emit_save='yes'
    mono_feature_disable_appdomains='yes'
    mono_feature_disable_cleanup='yes'
+   mono_feature_disable_assembly_remapping='yes'
    disable_mono_native=yes
 elif test x$with_runtime_preset = xnet_4_x; then
    with_profile4_x_default=yes

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -4221,7 +4221,13 @@ mono_assembly_candidate_predicate_sn_same_name (MonoAssembly *candidate, gpointe
 gboolean
 exact_sn_match (MonoAssemblyName *wanted_name, MonoAssemblyName *candidate_name)
 {
+#if ENABLE_NETCORE
+	gboolean result = mono_assembly_names_equal_flags (wanted_name, candidate_name, MONO_ANAME_EQ_IGNORE_VERSION);
+	if (result && assembly_names_compare_versions (wanted_name, candidate_name, -1) > 0)
+		result = false;
+#else
 	gboolean result = mono_assembly_names_equal (wanted_name, candidate_name);
+#endif
 
 	mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Predicate: candidate and wanted names %s\n",
 		    result ? "match, returning TRUE" : "don't match, returning FALSE");


### PR DESCRIPTION
…and allow loading newer assembly versions.

Allows running `./dotnet build sample/HelloWorld`.

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
