### PR TITLE
Cleanup mono_marshal_get_icall_wrapper.

### DIFF
--- a/mono/metadata/marshal.h
+++ b/mono/metadata/marshal.h
@@ -430,7 +430,7 @@ gpointer
 mono_marshal_get_vtfixup_ftnptr (MonoImage *image, guint32 token, guint16 type);
 
 MonoMethod *
-mono_marshal_get_icall_wrapper (MonoMethodSignature *sig, const char *name, gconstpointer func, gboolean check_exceptions);
+mono_marshal_get_icall_wrapper (MonoJitICallInfo *callinfo, gboolean check_exceptions);
 
 MonoMethod *
 mono_marshal_get_aot_init_wrapper (MonoAotInitSubtype subtype) MONO_LLVM_INTERNAL;

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -4158,17 +4158,11 @@ add_jit_icall_wrapper (gpointer key, gpointer value, gpointer user_data)
 {
 	MonoAotCompile *acfg = (MonoAotCompile *)user_data;
 	MonoJitICallInfo *callinfo = (MonoJitICallInfo *)value;
-	MonoMethod *wrapper;
-	char *name;
 
 	if (!callinfo->sig)
 		return;
 
-	name = g_strdup_printf ("__icall_wrapper_%s", callinfo->name);
-	wrapper = mono_marshal_get_icall_wrapper (callinfo->sig, name, callinfo->func, TRUE);
-	g_free (name);
-
-	add_method (acfg, wrapper);
+	add_method (acfg, mono_marshal_get_icall_wrapper (callinfo, TRUE));
 }
 
 static void

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -5683,9 +5683,7 @@ mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, Mon
 				if (*name == '.' && (strcmp (name, ".ctor") == 0)) {
 					MonoJitICallInfo *mi = mono_find_jit_icall_by_name ("ves_icall_mono_delegate_ctor_interp");
 					g_assert (mi);
-					char *wrapper_name = g_strdup_printf ("__icall_wrapper_%s", mi->name);
-					nm = mono_marshal_get_icall_wrapper (mi->sig, wrapper_name, mi->func, TRUE);
-					g_free (wrapper_name);
+					nm = mono_marshal_get_icall_wrapper (mi, TRUE);
 				} else if (*name == 'I' && (strcmp (name, "Invoke") == 0)) {
 					/*
 					 * Usually handled during transformation of the caller, but

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -2175,9 +2175,7 @@ mono_emit_jit_icall_by_info (MonoCompile *cfg, int il_offset, MonoJitICallInfo *
 		int costs;
 
 		if (!info->wrapper_method) {
-			name = g_strdup_printf ("__icall_wrapper_%s", info->name);
-			info->wrapper_method = mono_marshal_get_icall_wrapper (info->sig, name, info->func, TRUE);
-			g_free (name);
+			info->wrapper_method = mono_marshal_get_icall_wrapper (info, TRUE);
 			mono_memory_barrier ();
 		}
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -614,19 +614,13 @@ mono_debug_count (void)
 MonoMethod*
 mono_icall_get_wrapper_method (MonoJitICallInfo* callinfo)
 {
-	MonoMethod *wrapper;
 	gboolean check_exc = TRUE;
-	char *name;
 
 	if (!strcmp (callinfo->name, "mono_thread_interruption_checkpoint"))
 		/* This icall is used to check for exceptions, so don't check in the wrapper */
 		check_exc = FALSE;
 
-	name = g_strdup_printf ("__icall_wrapper_%s", callinfo->name);
-	wrapper = mono_marshal_get_icall_wrapper (callinfo->sig, name, callinfo->func, check_exc);
-	g_free (name);
-
-	return wrapper;
+	return mono_marshal_get_icall_wrapper (callinfo, check_exc);
 }
 
 gconstpointer


### PR DESCRIPTION
Every caller was consistently forming the same name based on callinfo->name
and passing callinfo->func and callinfo->sig.
Pass callinfo instead and do the common work in mono_marshal_get_icall_wrapper.

This has the following side effects:
 Do not form and free name when there is cache hit. This seems like a nice optimization.
 Allow name to be null when there is cache hit. This is unintended. We could assert
 if it is a problem.