### PR TITLE
Rename cabs/cimag/creal to mono_cabs/mono_cimag/mono_creal without macros.

### DIFF
--- a/mono/metadata/threadpool-worker-default.c
+++ b/mono/metadata/threadpool-worker-default.c
@@ -974,10 +974,10 @@ hill_climbing_update (gint16 current_thread_count, guint32 sample_duration, gint
 			 * throughput). Our "error" estimate (the amount of noise that might be present in the
 			 * frequency band we're really interested in) is the average of the adjacent bands. */
 			throughput_wave_component = mono_double_complex_scalar_div (hill_climbing_get_wave_component (hc->samples, sample_count, hc->wave_period), average_throughput);
-			throughput_error_estimate = cabs (mono_double_complex_scalar_div (hill_climbing_get_wave_component (hc->samples, sample_count, adjacent_period_1), average_throughput));
+			throughput_error_estimate = mono_cabs (mono_double_complex_scalar_div (hill_climbing_get_wave_component (hc->samples, sample_count, adjacent_period_1), average_throughput));
 
 			if (adjacent_period_2 <= sample_count) {
-				throughput_error_estimate = MAX (throughput_error_estimate, cabs (mono_double_complex_scalar_div (hill_climbing_get_wave_component (
+				throughput_error_estimate = MAX (throughput_error_estimate, mono_cabs (mono_double_complex_scalar_div (hill_climbing_get_wave_component (
 					hc->samples, sample_count, adjacent_period_2), average_throughput)));
 			}
 
@@ -994,7 +994,7 @@ hill_climbing_update (gint16 current_thread_count, guint32 sample_duration, gint
 					+ ((1.0 + hc->throughput_error_smoothing_factor) * hc->average_throughput_noise);
 			}
 
-			if (cabs (thread_wave_component) > 0) {
+			if (mono_cabs (thread_wave_component) > 0) {
 				/* Adjust the throughput wave so it's centered around the target wave,
 				 * and then calculate the adjusted throughput/thread ratio. */
 				ratio = mono_double_complex_div (mono_double_complex_sub (throughput_wave_component, mono_double_complex_scalar_mul(thread_wave_component, hc->target_throughput_ratio)), thread_wave_component);
@@ -1006,7 +1006,7 @@ hill_climbing_update (gint16 current_thread_count, guint32 sample_duration, gint
 
 			noise_for_confidence = MAX (hc->average_throughput_noise, throughput_error_estimate);
 			if (noise_for_confidence > 0) {
-				confidence = cabs (thread_wave_component) / noise_for_confidence / hc->target_signal_to_noise_ratio;
+				confidence = mono_cabs (thread_wave_component) / noise_for_confidence / hc->target_signal_to_noise_ratio;
 			} else {
 				/* there is no noise! */
 				confidence = 1.0;
@@ -1020,7 +1020,7 @@ hill_climbing_update (gint16 current_thread_count, guint32 sample_duration, gint
 	 * backward (because this indicates that our changes are having the opposite of the intended effect).
 	 * If they're 90 degrees out of phase, we won't move at all, because we can't tell wether we're
 	 * having a negative or positive effect on throughput. */
-	move = creal (ratio);
+	move = mono_creal (ratio);
 	move = CLAMP (move, -1.0, 1.0);
 
 	/* Apply our confidence multiplier. */
@@ -1058,8 +1058,8 @@ hill_climbing_update (gint16 current_thread_count, guint32 sample_duration, gint
 	if (new_thread_count != current_thread_count)
 		hill_climbing_change_thread_count (new_thread_count, transition);
 
-	if (creal (ratio) < 0.0 && new_thread_count == worker.limit_worker_min)
-		*adjustment_interval = (gint)(0.5 + hc->current_sample_interval * (10.0 * MAX (-1.0 * creal (ratio), 1.0)));
+	if (mono_creal (ratio) < 0.0 && new_thread_count == worker.limit_worker_min)
+		*adjustment_interval = (gint)(0.5 + hc->current_sample_interval * (10.0 * MAX (-1.0 * mono_creal (ratio), 1.0)));
 	else
 		*adjustment_interval = hc->current_sample_interval;
 

--- a/mono/utils/mono-complex.h
+++ b/mono/utils/mono-complex.h
@@ -14,29 +14,13 @@
 #define _USE_MATH_DEFINES // needed by MSVC to define math constants
 #include <math.h>
 
-#undef cabs
-#undef cimag
-#undef creal
-#define cabs mono_cabs
-#define cimag mono_cimag
-#define creal mono_creal
-
 typedef struct double_complex {
 	double real;
 	double imag;
 } double_complex;
 
-static inline double
-creal (double_complex c)
-{
-	return c.real;
-}
-
-static inline double
-cimag (double_complex c)
-{
-	return c.imag;
-}
+#define mono_creal(c) ((c).real)
+#define mono_cimag(c) ((c).imag)
 
 static inline
 double_complex mono_double_complex_make(gdouble re, gdouble im)
@@ -48,30 +32,30 @@ double_complex mono_double_complex_make(gdouble re, gdouble im)
 static inline
 double_complex mono_double_complex_scalar_div(double_complex c, gdouble s)
 {
-	return mono_double_complex_make(creal(c) / s, cimag(c) / s);
+	return mono_double_complex_make (mono_creal (c) / s, mono_cimag (c) / s);
 }
 
 static inline
 double_complex mono_double_complex_scalar_mul(double_complex c, gdouble s)
 {
-	return mono_double_complex_make(creal(c) * s, cimag(c) * s);
+	return mono_double_complex_make (mono_creal (c) * s, mono_cimag (c) * s);
 }
 
 static inline
 double_complex mono_double_complex_div(double_complex left, double_complex right)
 {
-	double denom = creal(right) * creal(right) + cimag(right) * cimag(right);
+	double denom = mono_creal (right) * mono_creal (right) + mono_cimag (right) * mono_cimag (right);
 
 	return mono_double_complex_make(
-		(creal(left) * creal(right) + cimag(left) * cimag(right)) / denom,
-		(-creal(left) * cimag(right) + cimag(left) * creal(right)) / denom);
+		(mono_creal (left) * mono_creal (right) + mono_cimag (left) * mono_cimag (right)) / denom,
+		(-mono_creal (left) * mono_cimag (right) + mono_cimag (left) * mono_creal (right)) / denom);
 }
 
 static inline
 double_complex mono_double_complex_sub(double_complex left, double_complex right)
 {
-	return mono_double_complex_make(creal(left) - creal(right), cimag(left)
-		- cimag(right));
+	return mono_double_complex_make (mono_creal (left) - mono_creal (right), mono_cimag (left)
+		- mono_cimag (right));
 }
 
 #include "../../support/libm/complex.c"

--- a/support/libm/complex.c
+++ b/support/libm/complex.c
@@ -50,11 +50,11 @@
 
 static inline
 double
-cabs(double_complex z)
+mono_cabs (double_complex z)
 {
 #ifdef _MSC_VER // older versions deprecate hypot
-	return _hypot (creal (z), cimag (z));
+	return _hypot (mono_creal (z), mono_cimag (z));
 #else
-	return hypot(creal(z), cimag(z));
+	return hypot (mono_creal (z), mono_cimag (z));
 #endif
 }


### PR DESCRIPTION
Also make cimag/creal macros for guaranteed inlining -- instead of passing structs by value.
And add spaces before parens to follow coding convention (which is designed
to ease low tech searches for entire words).

This was agreed to when the code was first ported to C++ but got dropped.
The compromise though was to put the defines relatively late to limit their impact.
