### PR TITLE
Fix NRE when combobox was disposed and Text set

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ComboBox.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ComboBox.cs
@@ -767,7 +767,8 @@ namespace System.Windows.Forms
 
 				// set directly the passed value
 				if (dropdown_style != ComboBoxStyle.DropDownList)
-					textbox_ctrl.Text = value;
+					if (textbox_ctrl != null)
+						textbox_ctrl.Text = value;
 			}
 		}
 
@@ -1878,6 +1879,8 @@ namespace System.Windows.Forms
 
 		internal void SetControlText (string s, bool suppressTextChanged, bool supressAutoScroll)
 		{
+			if (textbox_ctrl == null)
+				return;
 			if (suppressTextChanged)
 				process_textchanged_event = false;
 			if (supressAutoScroll)

--- a/mcs/class/System.Windows.Forms/Test/System.Windows.Forms/ComboBoxTest.cs
+++ b/mcs/class/System.Windows.Forms/Test/System.Windows.Forms/ComboBoxTest.cs
@@ -1504,33 +1504,19 @@ namespace MonoTests.System.Windows.Forms
         [Test]
         public void SetTextAfterDisposeTest()
         {
-            try
-            {
-                var comboBox = new ComboBox();
-                comboBox.Dispose();
-                comboBox.Text = "1";
-            }
-            catch (Exception ex)
-            {
-                Assert.Fail("#B1");
-            }
+            var comboBox = new ComboBox();
+            comboBox.Dispose();
+            comboBox.Text = "1";
         }
 
         [Test]
         public void SetNullTextDropDownTest()
         {
-            try
-            {
-                var comboBox = new ComboBox();
-                comboBox.DropDownStyle = ComboBoxStyle.DropDown;
-                comboBox.SelectedIndex = -1;
-                comboBox.Dispose();
-                comboBox.Text = null;
-            }
-            catch (Exception ex)
-            {
-                Assert.Fail("#C1");
-            }
+            var comboBox = new ComboBox();
+            comboBox.DropDownStyle = ComboBoxStyle.DropDown;
+            comboBox.SelectedIndex = -1;
+            comboBox.Dispose();
+            comboBox.Text = null;
         }
     }
 

--- a/mcs/class/System.Windows.Forms/Test/System.Windows.Forms/ComboBoxTest.cs
+++ b/mcs/class/System.Windows.Forms/Test/System.Windows.Forms/ComboBoxTest.cs
@@ -1500,7 +1500,39 @@ namespace MonoTests.System.Windows.Forms
 			cmb.Items.Add (new ComboVal ("A"));
 			cmb.Sorted = true;
 		}
-	}
+
+        [Test]
+        public void SetTextAfterDisposeTest()
+        {
+            try
+            {
+                var comboBox = new ComboBox();
+                comboBox.Dispose();
+                comboBox.Text = "1";
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("#B1");
+            }
+        }
+
+        [Test]
+        public void SetNullTextDropDownTest()
+        {
+            try
+            {
+                var comboBox = new ComboBox();
+                comboBox.DropDownStyle = ComboBoxStyle.DropDown;
+                comboBox.SelectedIndex = -1;
+                comboBox.Dispose();
+                comboBox.Text = null;
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("#C1");
+            }
+        }
+    }
 
 	[TestFixture]
 	public class ComboBoxObjectCollectionTest : TestHelper


### PR DESCRIPTION
If combobox already was disposed and we setting Text field there will be NullReferenceException. On .net winforms there no excetions.