### PR TITLE
[wip] Reduce heap allocations and hash lookups in JIT icall implementation.

### DIFF
--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -386,6 +386,8 @@ common_sources = \
 	w32handle.c	\
 	w32error.h	\
 	reflection.c	\
+	register-icall-def.c \
+	register-icall-def.h \
 	dynamic-image.c	\
 	sre.c	\
 	sre-encode.c	\

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -41,6 +41,7 @@
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/unlocked.h>
 #include <mono/metadata/icall-decl.h>
+#include "register-icall-def.h"
 
 #if HAVE_BOEHM_GC
 

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -577,12 +577,15 @@ typedef struct MonoCachedClassInfo {
 
 typedef struct {
 	const char *name;
+	// FIXME try making these regular gpointer
 	gconstpointer func;
 	gconstpointer wrapper;
 	gconstpointer trampoline;
 	MonoMethodSignature *sig;
 	const char *c_symbol;
 	MonoMethod *wrapper_method;
+	MonoMethod *interp_lmf_wrapper;
+	gboolean inited;
 } MonoJitICallInfo;
 
 void
@@ -1068,38 +1071,77 @@ mono_metadata_load_generic_param_constraints_checked (MonoImage *image, guint32 
 					      MonoGenericContainer *container, MonoError *error);
 
 MonoJitICallInfo *
-mono_register_jit_icall (gconstpointer func, const char *name, MonoMethodSignature *sig, gboolean is_save);
+mono_register_jit_icall_info (MonoJitICallInfo *info, gconstpointer func, const char *name, MonoMethodSignature *sig, gboolean is_save);
 
 MonoJitICallInfo *
-mono_register_jit_icall_full (gconstpointer func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper, const char *c_symbol);
+mono_register_jit_icall_info_full (MonoJitICallInfo *info, gconstpointer func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper, const char *c_symbol);
 
 #ifdef __cplusplus
 template <typename T>
 inline MonoJitICallInfo *
-mono_register_jit_icall (T func, const char *name, MonoMethodSignature *sig, gboolean is_save)
+mono_register_jit_icall_info (MonoJitICallInfo *info, T func, const char *name, MonoMethodSignature *sig, gboolean is_save)
 {
-	return mono_register_jit_icall ((gconstpointer)func, name, sig, is_save);
+	return mono_register_jit_icall_info (info, (gconstpointer)func, name, sig, is_save);
 }
 
 template <typename T>
 inline MonoJitICallInfo *
-mono_register_jit_icall_full (T func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper, const char *c_symbol)
+mono_register_jit_icall_info_full (MonoJitICallInfo *info, T func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper, const char *c_symbol)
 {
-	return mono_register_jit_icall_full ((gconstpointer)func, name, sig, no_wrapper, c_symbol);
+	return mono_register_jit_icall_info_full (info, (gconstpointer)func, name, sig, no_wrapper, c_symbol);
 }
 #endif // __cplusplus
 
 void
 mono_register_jit_icall_wrapper (MonoJitICallInfo *info, gconstpointer wrapper);
 
+// Provide info-less signatures that provide info via token pasting.
+// The wrappers are for mono_ functions in class-internals.h and
+// for various similar non-mono_ functions in other files.
+//
+// Name parametere reduces diff, feeds, assert, and name parameter can be removed later.
+#define register_icall_with_wrapper(func, name, sig) do { 	\
+	g_assert (!strcmp (#func, name)); 							\
+	register_icall_info_with_wrapper ((&mono_jit_icall_info.func), (func), (#func), (sig)); \
+} while (0)
+
+// Name parametere reduces diff, feeds, assert, and name parameter can be removed later.
+#define register_icall(func, name, sig, no_wrapper) do {	\
+	g_assert (!strcmp (#func, name)); 							\
+	register_icall_info ((&mono_jit_icall_info. func), (func), (#func), (sig), (no_wrapper)); \
+} while (0)
+
+// Name parametere reduces diff, feeds, assert, and name parameter can be removed later.
+#define register_icall_no_wrapper(func, name, sig) do { \
+	g_assert (!strcmp (#func, name)); 							\
+	register_icall_info_no_wrapper ((&mono_jit_icall_info. func), (func), (#func), (sig)); \
+} while (0)
+
+// Some register_jit_icall_not_full pass NULL as last parameter, some pass name.
+// name parameter is just to reduce diff. It must match #func.
+#define mono_register_jit_icall(func, name, sig, avoid_wrapper) do { \
+	g_assert (!strcmp (#func, name)); 							\
+	mono_register_jit_icall_info ((&mono_jit_icall_info. func), (func), (#func), (sig), (avoid_wrapper)); \
+} while (0)
+
+// name parameter is just to reduce diff. It must match #func.
+#define mono_register_jit_icall_full(func, name, sig, avoid_wrapper, c_symbol) do { \
+	g_assert (!strcmp (#func, name)); 							\
+	mono_register_jit_icall_info_full ((&mono_jit_icall_info. func), (func), (#func), (sig), (avoid_wrapper), (c_symbol)); \
+} while (0)
+
+/*
+ * Register an icall where FUNC is dynamically generated or otherwise not
+ * possible to link to it using NAME during AOT.
+ */
+#define register_dyn_icall(expr, name, sig, no_wrapper) \
+	(register_dyn_icall_info ((&mono_jit_icall_info. name), (expr), #name, (sig), (no_wrapper)))
+
 MonoJitICallInfo *
 mono_find_jit_icall_by_name (const char *name) MONO_LLVM_INTERNAL;
 
 MonoJitICallInfo *
 mono_find_jit_icall_by_addr (gconstpointer addr) MONO_LLVM_INTERNAL;
-
-GHashTable*
-mono_get_jit_icall_info (void);
 
 const char*
 mono_lookup_jit_icall_symbol (const char *name);

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -49,6 +49,7 @@
 #endif
 #include "icall-decl.h"
 #include "icall-signatures.h"
+#include "register-icall-def.h"
 
 static void
 mono_System_ComObject_ReleaseInterfaces (MonoComObjectHandle obj);
@@ -87,13 +88,18 @@ Code shared between the DISABLE_COM and !DISABLE_COM
 #ifdef __cplusplus
 template <typename T>
 static void
-register_icall (       T func, const char *name, MonoMethodSignature *sig, gboolean save)
+register_icall_info (MonoJitICallInfo *info,        T func, const char *name, MonoMethodSignature *sig, gboolean save)
 #else
 static void
-register_icall (gpointer func, const char *name, MonoMethodSignature *sig, gboolean save)
+register_icall_info (MonoJitICallInfo *info, gpointer func, const char *name, MonoMethodSignature *sig, gboolean save)
 #endif
 {
-	mono_register_jit_icall_full (func, name, sig, save, name);
+	// FIXME Some versions of register_icall_info pass NULL for last parameter, some pass name.
+	// marshal.c: name
+	// remoting.c: NULL (via mono_register_jit_icall_info)
+	// cominterop.c: name
+	// mini-runtime.c: name
+	mono_register_jit_icall_info_full (info, func, name, sig, save, name);
 }
 
 mono_bstr

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -8862,6 +8862,7 @@ mono_create_icall_signatures (void)
 	}
 }
 
+// FIXME Remove this function.
 MonoJitICallInfo *
 mono_find_jit_icall_by_name (const char *name)
 {
@@ -8874,6 +8875,7 @@ mono_find_jit_icall_by_name (const char *name)
 	return info;
 }
 
+// FIXME Remove this function.
 MonoJitICallInfo *
 mono_find_jit_icall_by_addr (gconstpointer addr)
 {
@@ -8885,18 +8887,6 @@ mono_find_jit_icall_by_addr (gconstpointer addr)
 	mono_icall_unlock ();
 
 	return info;
-}
-
-/*
- * mono_get_jit_icall_info:
- *
- *   Return the hashtable mapping JIT icall names to MonoJitICallInfo structures. The
- * caller should access it while holding the icall lock.
- */
-GHashTable*
-mono_get_jit_icall_info (void)
-{
-	return jit_icall_hash_name;
 }
 
 /*
@@ -8927,39 +8917,42 @@ mono_register_jit_icall_wrapper (MonoJitICallInfo *info, gconstpointer wrapper)
 }
 
 MonoJitICallInfo *
-mono_register_jit_icall_full (gconstpointer func, const char *name, MonoMethodSignature *sig, gboolean avoid_wrapper, const char *c_symbol)
+mono_register_jit_icall_info_full (MonoJitICallInfo *info, gconstpointer func,
+	const char *name, MonoMethodSignature *sig, gboolean avoid_wrapper, const char *c_symbol)
 {
-	MonoJitICallInfo *info;
-
+	g_assert (info);
 	g_assert (func);
 	g_assert (name);
 
 	mono_icall_lock ();
 
 	if (!jit_icall_hash_name) {
-		jit_icall_hash_name = g_hash_table_new_full (g_str_hash, g_str_equal, NULL, g_free);
+		jit_icall_hash_name = g_hash_table_new_full (g_str_hash, g_str_equal, NULL, NULL);
 		jit_icall_hash_addr = g_hash_table_new (NULL, NULL);
 	}
 
-	if ((info = (MonoJitICallInfo *)g_hash_table_lookup (jit_icall_hash_name, name))) {
-		g_warning ("jit icall already defined \"%s\" \"%s\" %p %p\n", name, info->name, func, info->func);
-		g_assert_not_reached ();
+	MonoJitICallInfo *existing_info = (MonoJitICallInfo *)g_hash_table_lookup (jit_icall_hash_name, name);
+
+	g_assertf (!existing_info, "jit icall name already defined \"%s\" \"%s\" %p %p\n",
+		name, existing_info->name, func, existing_info->func);
+
+	if ((existing_info = (MonoJitICallInfo *)g_hash_table_lookup (jit_icall_hash_addr, (gpointer)func))) {
+		g_error("jit icall func already defined \"%s\" \"%s\" %p %p\n",
+			name, existing_info->name, func, existing_info->func);
 	}
 
-	info = g_new0 (MonoJitICallInfo, 1);
-	
+	g_assertf (!info->inited, "%s", name);
+	info->inited = TRUE;
 	info->name = name;
 	info->func = func;
 	info->sig = sig;
 	info->c_symbol = c_symbol;
 
-	if (avoid_wrapper) {
-		info->wrapper = func;
-	} else {
-		info->wrapper = NULL;
-	}
+	// Fill in wrapper ahead of time, to just be func, to avoid
+	// later initializing it to anything else. So therefore, no wrapper.
+	info->wrapper = avoid_wrapper ? func : NULL;
 
-	g_hash_table_insert (jit_icall_hash_name, (gpointer)info->name, info);
+	g_hash_table_insert (jit_icall_hash_name, (gpointer)name, info);
 	g_hash_table_insert (jit_icall_hash_addr, (gpointer)func, info);
 
 	mono_icall_unlock ();
@@ -8967,9 +8960,10 @@ mono_register_jit_icall_full (gconstpointer func, const char *name, MonoMethodSi
 }
 
 MonoJitICallInfo *
-mono_register_jit_icall (gconstpointer func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper)
+mono_register_jit_icall_info (MonoJitICallInfo *info, gconstpointer func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper)
 {
-	return mono_register_jit_icall_full (func, name, sig, no_wrapper, NULL);
+	// FIXME Sometimes register_not_full has NULL last parameter, sometimes it repeats name.
+	return mono_register_jit_icall_info_full (info, func, name, sig, no_wrapper, NULL);
 }
 
 int

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -2148,6 +2148,9 @@ mono_get_method_constrained_checked (MonoImage *image, guint32 token, MonoClass 
 void
 mono_free_method  (MonoMethod *method)
 {
+	if (!method)
+		return;
+
 	MONO_PROFILER_RAISE (method_free, (method));
 	
 	/* FIXME: This hack will go away when the profiler will support freeing methods */

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -49,6 +49,7 @@
 #include <string.h>
 #include <errno.h>
 #include "icall-decl.h"
+#include "register-icall-def.h"
 
 #define OPDEF(a,b,c,d,e,f,g,h,i,j) \
 	a = i,
@@ -575,7 +576,7 @@ emit_ptr_to_object_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv 
 	}
 }
 
-static gpointer
+static MonoJitICallInfo*
 conv_to_icall (MonoMarshalConv conv, int *ind_store_type)
 {
 	// FIXME This or its caller might be a good place to inline some
@@ -589,77 +590,77 @@ conv_to_icall (MonoMarshalConv conv, int *ind_store_type)
 	*ind_store_type = CEE_STIND_I;
 	switch (conv) {
 	case MONO_MARSHAL_CONV_STR_LPWSTR:
-		return (gpointer)mono_marshal_string_to_utf16;
+		return &mono_jit_icall_info.mono_marshal_string_to_utf16;
 	case MONO_MARSHAL_CONV_LPWSTR_STR:
 		*ind_store_type = CEE_STIND_REF;
-		return (gpointer)ves_icall_mono_string_from_utf16;
+		return &mono_jit_icall_info.ves_icall_mono_string_from_utf16;
 	case MONO_MARSHAL_CONV_LPTSTR_STR:
 		*ind_store_type = CEE_STIND_REF;
-		return (gpointer)ves_icall_string_new_wrapper;
+		return &mono_jit_icall_info.ves_icall_string_new_wrapper;
 	case MONO_MARSHAL_CONV_UTF8STR_STR:
 	case MONO_MARSHAL_CONV_LPSTR_STR:
 		*ind_store_type = CEE_STIND_REF;
-		return (gpointer)ves_icall_string_new_wrapper;
+		return &mono_jit_icall_info.ves_icall_string_new_wrapper;
 	case MONO_MARSHAL_CONV_STR_LPTSTR:
 #ifdef TARGET_WIN32
-		return (gpointer)mono_marshal_string_to_utf16;
+		return &mono_jit_icall_info.mono_marshal_string_to_utf16;
 #else
-		return (gpointer)mono_string_to_utf8str;
+		return &mono_jit_icall_info.mono_string_to_utf8str;
 #endif
 		// In Mono historically LPSTR was treated as a UTF8STR
 	case MONO_MARSHAL_CONV_STR_UTF8STR:
 	case MONO_MARSHAL_CONV_STR_LPSTR:
-		return (gpointer)mono_string_to_utf8str;
+		return &mono_jit_icall_info.mono_string_to_utf8str;
 	case MONO_MARSHAL_CONV_STR_BSTR:
-		return (gpointer)mono_string_to_bstr;
+		return &mono_jit_icall_info.mono_string_to_bstr;
 	case MONO_MARSHAL_CONV_BSTR_STR:
 		*ind_store_type = CEE_STIND_REF;
-		return (gpointer)mono_string_from_bstr_icall;
+		return &mono_jit_icall_info.mono_string_from_bstr_icall;
 	case MONO_MARSHAL_CONV_STR_TBSTR:
 	case MONO_MARSHAL_CONV_STR_ANSIBSTR:
-		return (gpointer)mono_string_to_ansibstr;
+		return &mono_jit_icall_info.mono_string_to_ansibstr;
 	case MONO_MARSHAL_CONV_SB_UTF8STR:
 	case MONO_MARSHAL_CONV_SB_LPSTR:
-		return (gpointer)mono_string_builder_to_utf8;
+		return &mono_jit_icall_info.mono_string_builder_to_utf8;
 	case MONO_MARSHAL_CONV_SB_LPTSTR:
 #ifdef TARGET_WIN32
-		return (gpointer)mono_string_builder_to_utf16;
+		return &mono_jit_icall_info.mono_string_builder_to_utf16;
 #else
-		return (gpointer)mono_string_builder_to_utf8;
+		return &mono_jit_icall_info.mono_string_builder_to_utf8;
 #endif
 	case MONO_MARSHAL_CONV_SB_LPWSTR:
-		return (gpointer)mono_string_builder_to_utf16;
+		return &mono_jit_icall_info.mono_string_builder_to_utf16;
 	case MONO_MARSHAL_CONV_ARRAY_SAVEARRAY:
-		return (gpointer)mono_array_to_savearray;
+		return &mono_jit_icall_info.mono_array_to_savearray;
 	case MONO_MARSHAL_CONV_ARRAY_LPARRAY:
-		return (gpointer)mono_array_to_lparray;
+		return &mono_jit_icall_info.mono_array_to_lparray;
 	case MONO_MARSHAL_FREE_LPARRAY:
-		return (gpointer)mono_free_lparray;
+		return &mono_jit_icall_info.mono_free_lparray;
 	case MONO_MARSHAL_CONV_DEL_FTN:
-		return (gpointer)mono_delegate_to_ftnptr;
+		return &mono_jit_icall_info.mono_delegate_to_ftnptr;
 	case MONO_MARSHAL_CONV_FTN_DEL:
 		*ind_store_type = CEE_STIND_REF;
-		return (gpointer)mono_ftnptr_to_delegate;
+		return &mono_jit_icall_info.mono_ftnptr_to_delegate;
 	case MONO_MARSHAL_CONV_UTF8STR_SB:
 	case MONO_MARSHAL_CONV_LPSTR_SB:
 		*ind_store_type = CEE_STIND_REF;
-		return (gpointer)mono_string_utf8_to_builder;
+		return &mono_jit_icall_info.mono_string_utf8_to_builder;
 	case MONO_MARSHAL_CONV_LPTSTR_SB:
 		*ind_store_type = CEE_STIND_REF;
 #ifdef TARGET_WIN32
-		return (gpointer)mono_string_utf16_to_builder;
+		return &mono_jit_icall_info.mono_string_utf16_to_builder;
 #else
-		return (gpointer)mono_string_utf8_to_builder;
+		return &mono_jit_icall_info.mono_string_utf8_to_builder;
 #endif
 	case MONO_MARSHAL_CONV_LPWSTR_SB:
 		*ind_store_type = CEE_STIND_REF;
-		return (gpointer)mono_string_utf16_to_builder;
+		return &mono_jit_icall_info.mono_string_utf16_to_builder;
 	case MONO_MARSHAL_FREE_ARRAY:
-		return (gpointer)mono_marshal_free_array;
+		return &mono_jit_icall_info.mono_marshal_free_array;
 	case MONO_MARSHAL_CONV_STR_BYVALSTR:
-		return (gpointer)mono_string_to_byvalstr;
+		return &mono_jit_icall_info.mono_string_to_byvalstr;
 	case MONO_MARSHAL_CONV_STR_BYVALWSTR:
-		return (gpointer)mono_string_to_byvalwstr;
+		return &mono_jit_icall_info.mono_string_to_byvalwstr;
 	default:
 		g_assert_not_reached ();
 	}
@@ -708,7 +709,7 @@ emit_object_to_ptr_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv 
 		mono_mb_emit_ldloc (mb, 1);
 		mono_mb_emit_ldloc (mb, 0);
 		mono_mb_emit_byte (mb, CEE_LDIND_REF);
-		mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
+		mono_mb_emit_icall_info (mb, conv_to_icall (conv, &stind_op));
 		mono_mb_emit_byte (mb, stind_op);
 		break;
 	}
@@ -718,7 +719,7 @@ emit_object_to_ptr_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv 
 		mono_mb_emit_ldloc (mb, 1);
 		mono_mb_emit_ldloc (mb, 0);
 		mono_mb_emit_byte (mb, CEE_LDIND_REF);
-		mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
+		mono_mb_emit_icall_info (mb, conv_to_icall (conv, &stind_op));
 		mono_mb_emit_byte (mb, stind_op);
 		break;
 	case MONO_MARSHAL_CONV_STR_BYVALSTR: 
@@ -729,7 +730,7 @@ emit_object_to_ptr_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv 
 		mono_mb_emit_ldloc (mb, 0);	
 		mono_mb_emit_byte (mb, CEE_LDIND_REF); /* src String */
 		mono_mb_emit_icon (mb, mspec->data.array_data.num_elem);
-		mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+		mono_mb_emit_icall_info (mb, conv_to_icall (conv, NULL));
 		break;
 	}
 	case MONO_MARSHAL_CONV_ARRAY_BYVALARRAY: {
@@ -1185,7 +1186,7 @@ emit_struct_free (MonoMethodBuilder *mb, MonoClass *klass, int struct_var)
 }
 
 static void
-emit_thread_interrupt_checkpoint_call (MonoMethodBuilder *mb, gpointer checkpoint_func)
+emit_thread_interrupt_checkpoint_call (MonoMethodBuilder *mb, MonoJitICallInfo *checkpoint_icall_info)
 {
 	int pos_noabort, pos_noex;
 
@@ -1197,7 +1198,7 @@ emit_thread_interrupt_checkpoint_call (MonoMethodBuilder *mb, gpointer checkpoin
 	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
 	mono_mb_emit_byte (mb, CEE_MONO_NOT_TAKEN);
 
-	mono_mb_emit_icall (mb, checkpoint_func);
+	mono_mb_emit_icall_info (mb, checkpoint_icall_info);
 	/* Throw the exception returned by the checkpoint function, if any */
 	mono_mb_emit_byte (mb, CEE_DUP);
 	pos_noex = mono_mb_emit_branch (mb, CEE_BRFALSE);
@@ -1219,16 +1220,17 @@ emit_thread_interrupt_checkpoint_call (MonoMethodBuilder *mb, gpointer checkpoin
 static void
 emit_thread_interrupt_checkpoint (MonoMethodBuilder *mb)
 {
+	// FIXME Put a boolean in MonoMethodBuilder instead.
 	if (strstr (mb->name, "mono_thread_interruption_checkpoint"))
 		return;
 	
-	emit_thread_interrupt_checkpoint_call (mb, (gpointer)mono_thread_interruption_checkpoint);
+	emit_thread_interrupt_checkpoint_call (mb, &mono_jit_icall_info.mono_thread_interruption_checkpoint);
 }
 
 static void
 emit_thread_force_interrupt_checkpoint (MonoMethodBuilder *mb)
 {
-	emit_thread_interrupt_checkpoint_call (mb, (gpointer)mono_thread_force_interruption_checkpoint_noraise);
+	emit_thread_interrupt_checkpoint_call (mb, &mono_jit_icall_info.mono_thread_force_interruption_checkpoint_noraise);
 }
 
 void
@@ -2268,7 +2270,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			mono_mb_emit_ldarg (mb, argnum);
 			if (t->byref)
 				mono_mb_emit_byte (mb, CEE_LDIND_I);
-			mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_ARRAY_LPARRAY, NULL));
+			mono_mb_emit_icall_info (mb, conv_to_icall (MONO_MARSHAL_CONV_ARRAY_LPARRAY, NULL));
 			mono_mb_emit_stloc (mb, conv_arg);
 		} else {
 			guint32 label1, label2, label3;
@@ -2350,7 +2352,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 				mono_mb_emit_ldloc (mb, src_var);
 				mono_mb_emit_ldloc (mb, index_var);
 				mono_mb_emit_byte (mb, CEE_LDELEM_REF);
-				mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
+				mono_mb_emit_icall_info (mb, conv_to_icall (conv, &stind_op));
 				mono_mb_emit_byte (mb, stind_op);
 			} else {
 				/* set the src_ptr */
@@ -2472,7 +2474,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 				mono_mb_emit_ldloc (mb, src_ptr);
 				mono_mb_emit_byte (mb, CEE_LDIND_I);
 
-				mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+				mono_mb_emit_icall_info (mb, conv_to_icall (conv, NULL));
 
 				if (need_free) {
 					/* src */
@@ -2533,7 +2535,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			if (t->byref)
 				mono_mb_emit_byte (mb, CEE_LDIND_REF);
 			mono_mb_emit_ldloc (mb, conv_arg);
-			mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_FREE_LPARRAY, NULL));
+			mono_mb_emit_icall_info (mb, conv_to_icall (MONO_MARSHAL_FREE_LPARRAY, NULL));
 		}
 
 		break;
@@ -2707,7 +2709,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			mono_mb_emit_ldloc (mb, src_ptr);
 			mono_mb_emit_byte (mb, CEE_LDIND_I);
 
-			mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+			mono_mb_emit_icall_info (mb, conv_to_icall (conv, NULL));
 			mono_mb_emit_byte (mb, CEE_STELEM_REF);
 		}
 		else {
@@ -2825,7 +2827,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 			mono_mb_emit_byte (mb, CEE_LDELEM_REF);
 
-			mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
+			mono_mb_emit_icall_info (mb, conv_to_icall (conv, &stind_op));
 			mono_mb_emit_byte (mb, stind_op);
 		}
 		else {
@@ -2920,7 +2922,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 			mono_mb_emit_byte (mb, CEE_LDELEM_REF);
 
-			mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
+			mono_mb_emit_icall_info (mb, conv_to_icall (conv, &stind_op));
 			mono_mb_emit_byte (mb, stind_op);
 		}
 		else {
@@ -4949,7 +4951,7 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			char *msg = g_strdup_printf ("string marshalling conversion %d not implemented", encoding);
 			mono_mb_emit_exception_marshal_directive (mb, msg);
 		} else {
-			mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+			mono_mb_emit_icall_info (mb, conv_to_icall (conv, NULL));
 
 			mono_mb_emit_stloc (mb, conv_arg);
 		}
@@ -4991,7 +4993,7 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			int stind_op;
 			mono_mb_emit_ldarg (mb, argnum);
 			mono_mb_emit_ldloc (mb, conv_arg);
-			mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
+			mono_mb_emit_icall_info (mb, conv_to_icall (conv, &stind_op));
 			mono_mb_emit_byte (mb, stind_op);
 			need_free = TRUE;
 		}
@@ -5023,7 +5025,7 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		}
 
 		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+		mono_mb_emit_icall_info (mb, conv_to_icall (conv, NULL));
 		mono_mb_emit_stloc (mb, 3);
 
 		/* free the string */
@@ -5054,7 +5056,7 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		mono_mb_emit_ldarg (mb, argnum);
 		if (t->byref)
 			mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+		mono_mb_emit_icall_info (mb, conv_to_icall (conv, NULL));
 		mono_mb_emit_stloc (mb, conv_arg);
 		break;
 
@@ -5064,18 +5066,18 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 				int stind_op;
 				mono_mb_emit_ldarg (mb, argnum);
 				mono_mb_emit_ldloc (mb, conv_arg);
-				mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
+				mono_mb_emit_icall_info (mb, conv_to_icall (conv, &stind_op));
 				mono_mb_emit_byte (mb, stind_op);
 			}
 		}
 		break;
 
 	case MARSHAL_ACTION_MANAGED_CONV_RESULT:
-		if (conv_to_icall (conv, NULL) == mono_marshal_string_to_utf16)
+		if (conv_to_icall (conv, NULL) == &mono_jit_icall_info.mono_marshal_string_to_utf16)
 			/* We need to make a copy so the caller is able to free it */
 			mono_mb_emit_icall (mb, mono_marshal_string_to_utf16_copy);
 		else
-			mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+			mono_mb_emit_icall_info (mb, conv_to_icall (conv, NULL));
 		mono_mb_emit_stloc (mb, 3);
 		break;
 
@@ -5084,7 +5086,6 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	}
 	return conv_arg;
 }
-
 
 static int
 emit_marshal_safehandle_ilgen (EmitMarshalContext *m, int argnum, MonoType *t, 
@@ -5342,7 +5343,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 				mono_mb_emit_stloc (mb, conv_arg);
 			} else {
 				mono_mb_emit_ldarg (mb, argnum);
-				mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_DEL_FTN, NULL));
+				mono_mb_emit_icall_info (mb, conv_to_icall (MONO_MARSHAL_CONV_DEL_FTN, NULL));
 				mono_mb_emit_stloc (mb, conv_arg);
 			}
 		} else if (klass == mono_class_try_get_stringbuilder_class ()) {
@@ -5372,7 +5373,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			if (t->byref)
 				mono_mb_emit_byte (mb, CEE_LDIND_I);
 
-			mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+			mono_mb_emit_icall_info (mb, conv_to_icall (conv, NULL));
 			mono_mb_emit_stloc (mb, conv_arg);
 		} else if (m_class_is_blittable (klass)) {
 			mono_mb_emit_byte (mb, CEE_LDNULL);
@@ -5477,7 +5478,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 				mono_mb_emit_ldarg (mb, argnum);
 				mono_mb_emit_ldloc (mb, conv_arg);
 
-				mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+				mono_mb_emit_icall_info (mb, conv_to_icall (conv, NULL));
 			}
 
 			if (need_free) {
@@ -5493,7 +5494,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 				mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
 				mono_mb_emit_op (mb, CEE_MONO_CLASSCONST, klass);
 				mono_mb_emit_ldloc (mb, conv_arg);
-				mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_FTN_DEL, NULL));
+				mono_mb_emit_icall_info (mb, conv_to_icall (MONO_MARSHAL_CONV_FTN_DEL, NULL));
 				mono_mb_emit_byte (mb, CEE_STIND_REF);
 			}
 			break;
@@ -5576,7 +5577,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
 			mono_mb_emit_op (mb, CEE_MONO_CLASSCONST, klass);
 			mono_mb_emit_ldloc (mb, 0);
-			mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_FTN_DEL, NULL));
+			mono_mb_emit_icall_info (mb, conv_to_icall (MONO_MARSHAL_CONV_FTN_DEL, NULL));
 			mono_mb_emit_stloc (mb, 3);
 		} else if (klass == mono_class_try_get_stringbuilder_class ()) {
 			// FIXME:
@@ -5630,7 +5631,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			mono_mb_emit_ldarg (mb, argnum);
 			if (t->byref)
 				mono_mb_emit_byte (mb, CEE_LDIND_I);
-			mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_FTN_DEL, NULL));
+			mono_mb_emit_icall_info (mb, conv_to_icall (MONO_MARSHAL_CONV_FTN_DEL, NULL));
 			mono_mb_emit_stloc (mb, conv_arg);
 			break;
 		}
@@ -5707,7 +5708,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 				int stind_op;
 				mono_mb_emit_ldarg (mb, argnum);
 				mono_mb_emit_ldloc (mb, conv_arg);
-				mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_DEL_FTN, &stind_op));
+				mono_mb_emit_icall_info (mb, conv_to_icall (MONO_MARSHAL_CONV_DEL_FTN, &stind_op));
 				mono_mb_emit_byte (mb, stind_op);
 				break;
 			}
@@ -5767,7 +5768,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 	case MARSHAL_ACTION_MANAGED_CONV_RESULT:
 		if (m_class_is_delegate (klass)) {
-			mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_DEL_FTN, NULL));
+			mono_mb_emit_icall_info (mb, conv_to_icall (MONO_MARSHAL_CONV_DEL_FTN, NULL));
 			mono_mb_emit_stloc (mb, 3);
 			break;
 		}

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -62,6 +62,8 @@
 #include <errno.h>
 #include "icall-decl.h"
 #include "icall-signatures.h"
+#include "register-icall-def.h"
+#include "class-internals.h"
 
 static void
 mono_string_utf16len_to_builder (MonoStringBuilderHandle sb, const gunichar2 *text, gsize len, MonoError *error);
@@ -120,37 +122,44 @@ get_method_image (MonoMethod *method)
 #ifdef __cplusplus
 template <typename T>
 static void
-register_dyn_icall (T func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper)
+register_dyn_icall_info (MonoJitICallInfo *info, T func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper)
 #else
 static void
-register_dyn_icall (gpointer func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper)
+register_dyn_icall_info (MonoJitICallInfo *info, gpointer func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper)
 #endif
 {
-	mono_register_jit_icall_full (func, name, sig, no_wrapper, NULL);
+	// FIXME There are near duplicates of this function, in marshal.c and mini-runtime.c.
+	mono_register_jit_icall_info_full (info, func, name, sig, no_wrapper, NULL);
 }
 
 #ifdef __cplusplus
 template <typename T>
 static void
-register_icall (T func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper)
+register_icall_info (MonoJitICallInfo *info, T func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper)
 #else
 static void
-register_icall (gpointer func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper)
+register_icall_info (MonoJitICallInfo *info, gpointer func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper)
 #endif
 {
-	mono_register_jit_icall_full (func, name, sig, no_wrapper, name);
+	// FIXME Some versions of register_icall_info pass NULL for last parameter, some pass name.
+	// marshal.c: name
+	// remoting.c: NULL (via mono_register_jit_icall_info)
+	// cominterop.c: name
+	// mini-runtime.c: name
+	mono_register_jit_icall_info_full (info, func, name, sig, no_wrapper, name);
 }
 
 #ifdef __cplusplus
 template <typename T>
 static void
-register_icall_no_wrapper (T func, const char *name, MonoMethodSignature *sig)
+register_icall_info_no_wrapper (MonoJitICallInfo *info, T func, const char *name, MonoMethodSignature *sig)
 #else
 static void
-register_icall_no_wrapper (gpointer func, const char *name, MonoMethodSignature *sig)
+register_icall_info_no_wrapper (MonoJitICallInfo *info, gpointer func, const char *name, MonoMethodSignature *sig)
 #endif
 {
-	mono_register_jit_icall_full (func, name, sig, TRUE, name);
+	// FIXME There are near duplicates of this function in mini-runtime.c and marshal.c.
+	mono_register_jit_icall_info_full (info, func, name, sig, TRUE, name);
 }
 
 MonoMethodSignature*
@@ -265,12 +274,12 @@ mono_marshal_init (void)
 		register_icall (mono_marshal_free_array, "mono_marshal_free_array", mono_icall_sig_void_ptr_int32, FALSE);
 		register_icall (mono_string_to_byvalstr, "mono_string_to_byvalstr", mono_icall_sig_void_ptr_ptr_int32, FALSE);
 		register_icall (mono_string_to_byvalwstr, "mono_string_to_byvalwstr", mono_icall_sig_void_ptr_ptr_int32, FALSE);
-		register_dyn_icall (g_free, "g_free", mono_icall_sig_void_ptr, FALSE);
+		register_dyn_icall (g_free, g_free, mono_icall_sig_void_ptr, FALSE);
 		register_icall_no_wrapper (mono_object_isinst_icall, "mono_object_isinst_icall", mono_icall_sig_object_object_ptr);
 		register_icall (mono_struct_delete_old, "mono_struct_delete_old", mono_icall_sig_void_ptr_ptr, FALSE);
 		register_icall (mono_delegate_begin_invoke, "mono_delegate_begin_invoke", mono_icall_sig_object_object_ptr, FALSE);
 		register_icall (mono_delegate_end_invoke, "mono_delegate_end_invoke", mono_icall_sig_object_object_ptr, FALSE);
-		register_dyn_icall (mono_gc_wbarrier_generic_nostore_internal, "wb_generic_internal", mono_icall_sig_void_ptr, FALSE);
+		register_dyn_icall (mono_gc_wbarrier_generic_nostore_internal, mono_gc_wbarrier_generic_nostore_internal, mono_icall_sig_void_ptr, FALSE);
 		register_icall (mono_gchandle_get_target_internal, "mono_gchandle_get_target_internal", mono_icall_sig_object_int32, TRUE);
 		register_icall (mono_marshal_isinst_with_cache, "mono_marshal_isinst_with_cache", mono_icall_sig_object_object_ptr_ptr, FALSE);
 		register_icall (mono_threads_enter_gc_safe_region_unbalanced, "mono_threads_enter_gc_safe_region_unbalanced", mono_icall_sig_ptr_ptr, TRUE);
@@ -2918,8 +2927,8 @@ emit_return_noilgen (MonoMethodBuilder *mb)
 
 /**
  * mono_marshal_get_icall_wrapper:
- * Generates IL code for the icall wrapper. The generated method
- * calls the unmanaged code in \p func.
+ * Generates IL code for the JIT icall wrapper. The generated method
+ * calls the unmanaged code in \p callinfo->func.
  */
 MonoMethod *
 mono_marshal_get_icall_wrapper (MonoJitICallInfo *callinfo, gboolean check_exceptions)
@@ -2957,8 +2966,9 @@ mono_marshal_get_icall_wrapper (MonoJitICallInfo *callinfo, gboolean check_excep
 		csig->call_convention = 0;
 
 	info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_ICALL_WRAPPER);
-	info->d.icall.func = (gpointer)func;
+	info->d.icall_info = callinfo;
 	res = mono_mb_create_and_cache_full (cache, (gpointer) func, mb, csig, csig->param_count + 16, info, NULL);
+
 	mono_mb_free (mb);
 	g_free (name);
 

--- a/mono/metadata/marshal.h
+++ b/mono/metadata/marshal.h
@@ -174,10 +174,6 @@ typedef struct {
 } GenericArrayHelperWrapperInfo;
 
 typedef struct {
-	gpointer func;
-} ICallWrapperInfo;
-
-typedef struct {
 	MonoMethod *method;
 } ArrayAccessorWrapperInfo;
 
@@ -251,7 +247,7 @@ typedef struct {
 		/* GENERIC_ARRAY_HELPER */
 		GenericArrayHelperWrapperInfo generic_array_helper;
 		/* ICALL_WRAPPER */
-		ICallWrapperInfo icall;
+		MonoJitICallInfo *icall_info;
 		/* ARRAY_ACCESSOR */
 		ArrayAccessorWrapperInfo array_accessor;
 		/* PROXY_ISINST etc. */

--- a/mono/metadata/method-builder-ilgen.c
+++ b/mono/metadata/method-builder-ilgen.c
@@ -544,10 +544,10 @@ mono_mb_emit_native_call (MonoMethodBuilder *mb, MonoMethodSignature *sig, gpoin
 }
 
 void
-mono_mb_emit_icall (MonoMethodBuilder *mb, gpointer func)
+mono_mb_emit_icall_info (MonoMethodBuilder *mb, MonoJitICallInfo *jit_icall_info)
 {
 	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-	mono_mb_emit_op (mb, CEE_MONO_ICALL, func);
+	mono_mb_emit_op (mb, CEE_MONO_ICALL, jit_icall_info);
 }
 
 void

--- a/mono/metadata/method-builder-ilgen.h
+++ b/mono/metadata/method-builder-ilgen.h
@@ -57,16 +57,9 @@ void
 mono_mb_emit_managed_call (MonoMethodBuilder *mb, MonoMethod *method, MonoMethodSignature *opt_sig);
 
 void
-mono_mb_emit_icall (MonoMethodBuilder *mb, gpointer func);
+mono_mb_emit_icall_info (MonoMethodBuilder *mb, MonoJitICallInfo *jit_icall_info);
 
-#ifdef __cplusplus
-template <typename T>
-inline void
-mono_mb_emit_icall (MonoMethodBuilder *mb, T func)
-{
-	mono_mb_emit_icall (mb, (gpointer)func);
-}
-#endif // __cplusplus
+#define mono_mb_emit_icall(mb, name) (mono_mb_emit_icall_info ((mb), &mono_jit_icall_info.name))
 
 int
 mono_mb_add_local (MonoMethodBuilder *mb, MonoType *type);

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -58,6 +58,8 @@
 #include "monitor.h"
 #include "icall-decl.h"
 #include "icall-signatures.h"
+#include "register-icall-def.h"
+#include "class-internals.h"
 
 // If no symbols in an object file in a static library are referenced, its exports will not be exported.
 // There are a few workarounds:

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -3167,7 +3167,7 @@ mono_class_from_mono_type_handle (MonoReflectionTypeHandle reftype)
 	return mono_class_from_mono_type_internal (MONO_HANDLE_RAW (reftype)->type);
 }
 
-// This is called by calls, it will return NULL and set pending exception (in wrapper) on failure.
+// This is called by icalls, it will return NULL and set pending exception (in wrapper) on failure.
 MonoReflectionTypeHandle
 mono_type_from_handle_impl (MonoType *handle, MonoError *error)
 {

--- a/mono/metadata/register-icall-def.c
+++ b/mono/metadata/register-icall-def.c
@@ -9,4 +9,4 @@
 #include "mono/metadata/exception-internals.h"
 #include "register-icall-def.h"
 
-MonoJitICallInfos mono_jit_icall_info;
+MonoJitICallInfos mono_jit_icall_info = { 0 };

--- a/mono/metadata/register-icall-def.c
+++ b/mono/metadata/register-icall-def.c
@@ -1,0 +1,12 @@
+/**
+ * \file
+ * Copyright 2018 Microsoft
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+#include <config.h>
+#include <glib.h>
+#include "mono/metadata/exception-internals.h"
+#include "register-icall-def.h"
+
+MonoJitICallInfos mono_jit_icall_info;

--- a/mono/metadata/register-icall-def.h
+++ b/mono/metadata/register-icall-def.h
@@ -1,0 +1,328 @@
+/**
+ * \file
+ * Copyright 2018 Microsoft
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+#ifndef __MONO_METADATA_REGISTER_ICALL_DEF_H__
+#define __MONO_METADATA_REGISTER_ICALL_DEF_H__
+
+// Changes to this file affect AOT file format.
+#define MONO_REGISTER_JIT_ICALLS \
+MONO_REGISTER_JIT_ICALL (mono_jit_icall_zero_is_reserved) \
+	\
+MONO_REGISTER_JIT_ICALL (__emul_fadd) \
+MONO_REGISTER_JIT_ICALL (__emul_fcmp_ceq) \
+MONO_REGISTER_JIT_ICALL (__emul_fcmp_cgt) \
+MONO_REGISTER_JIT_ICALL (__emul_fcmp_cgt_un) \
+MONO_REGISTER_JIT_ICALL (__emul_fcmp_clt) \
+MONO_REGISTER_JIT_ICALL (__emul_fcmp_clt_un) \
+MONO_REGISTER_JIT_ICALL (__emul_fcmp_eq) \
+MONO_REGISTER_JIT_ICALL (__emul_fcmp_ge) \
+MONO_REGISTER_JIT_ICALL (__emul_fcmp_ge_un) \
+MONO_REGISTER_JIT_ICALL (__emul_fcmp_gt) \
+MONO_REGISTER_JIT_ICALL (__emul_fcmp_gt_un) \
+MONO_REGISTER_JIT_ICALL (__emul_fcmp_le) \
+MONO_REGISTER_JIT_ICALL (__emul_fcmp_le_un) \
+MONO_REGISTER_JIT_ICALL (__emul_fcmp_lt) \
+MONO_REGISTER_JIT_ICALL (__emul_fcmp_lt_un) \
+MONO_REGISTER_JIT_ICALL (__emul_fcmp_ne_un) \
+MONO_REGISTER_JIT_ICALL (__emul_fconv_to_i) \
+MONO_REGISTER_JIT_ICALL (__emul_fconv_to_i1) \
+MONO_REGISTER_JIT_ICALL (__emul_fconv_to_i2) \
+MONO_REGISTER_JIT_ICALL (__emul_fconv_to_i4) \
+MONO_REGISTER_JIT_ICALL (__emul_fconv_to_i8) \
+MONO_REGISTER_JIT_ICALL (__emul_fconv_to_ovf_i8) \
+MONO_REGISTER_JIT_ICALL (__emul_fconv_to_ovf_u8) \
+MONO_REGISTER_JIT_ICALL (__emul_fconv_to_r4) \
+MONO_REGISTER_JIT_ICALL (__emul_fconv_to_u) \
+MONO_REGISTER_JIT_ICALL (__emul_fconv_to_u1) \
+MONO_REGISTER_JIT_ICALL (__emul_fconv_to_u2) \
+MONO_REGISTER_JIT_ICALL (__emul_fconv_to_u4) \
+MONO_REGISTER_JIT_ICALL (__emul_fconv_to_u8) \
+MONO_REGISTER_JIT_ICALL (__emul_fdiv) \
+MONO_REGISTER_JIT_ICALL (__emul_fmul) \
+MONO_REGISTER_JIT_ICALL (__emul_fneg) \
+MONO_REGISTER_JIT_ICALL (__emul_frem) \
+MONO_REGISTER_JIT_ICALL (__emul_fsub) \
+MONO_REGISTER_JIT_ICALL (__emul_iconv_to_r_un) \
+MONO_REGISTER_JIT_ICALL (__emul_iconv_to_r4) \
+MONO_REGISTER_JIT_ICALL (__emul_iconv_to_r8) \
+MONO_REGISTER_JIT_ICALL (__emul_lconv_to_r4) \
+MONO_REGISTER_JIT_ICALL (__emul_lconv_to_r8) \
+MONO_REGISTER_JIT_ICALL (__emul_lconv_to_r8_un) \
+MONO_REGISTER_JIT_ICALL (__emul_ldiv) \
+MONO_REGISTER_JIT_ICALL (__emul_ldiv_un) \
+MONO_REGISTER_JIT_ICALL (__emul_lmul) \
+MONO_REGISTER_JIT_ICALL (__emul_lmul_ovf) \
+MONO_REGISTER_JIT_ICALL (__emul_lmul_ovf_un) \
+MONO_REGISTER_JIT_ICALL (__emul_lrem) \
+MONO_REGISTER_JIT_ICALL (__emul_lrem_un) \
+MONO_REGISTER_JIT_ICALL (__emul_lshl) \
+MONO_REGISTER_JIT_ICALL (__emul_lshr) \
+MONO_REGISTER_JIT_ICALL (__emul_lshr_un) \
+MONO_REGISTER_JIT_ICALL (__emul_op_idiv) \
+MONO_REGISTER_JIT_ICALL (__emul_op_idiv_un) \
+MONO_REGISTER_JIT_ICALL (__emul_op_imul) \
+MONO_REGISTER_JIT_ICALL (__emul_op_imul_ovf) \
+MONO_REGISTER_JIT_ICALL (__emul_op_imul_ovf_un) \
+MONO_REGISTER_JIT_ICALL (__emul_op_irem) \
+MONO_REGISTER_JIT_ICALL (__emul_op_irem_un) \
+MONO_REGISTER_JIT_ICALL (__emul_rconv_to_i8) \
+MONO_REGISTER_JIT_ICALL (__emul_rconv_to_ovf_i8) \
+MONO_REGISTER_JIT_ICALL (__emul_rconv_to_ovf_u8) \
+MONO_REGISTER_JIT_ICALL (__emul_rconv_to_u8) \
+MONO_REGISTER_JIT_ICALL (__emul_rrem) \
+	\
+MONO_REGISTER_JIT_ICALL (cominterop_get_ccw) \
+MONO_REGISTER_JIT_ICALL (cominterop_get_ccw_object) \
+MONO_REGISTER_JIT_ICALL (cominterop_get_function_pointer) \
+MONO_REGISTER_JIT_ICALL (cominterop_get_interface) \
+MONO_REGISTER_JIT_ICALL (cominterop_get_method_interface) \
+MONO_REGISTER_JIT_ICALL (cominterop_object_is_rcw) \
+MONO_REGISTER_JIT_ICALL (cominterop_type_from_handle) \
+	\
+MONO_REGISTER_JIT_ICALL (g_free) \
+	\
+MONO_REGISTER_JIT_ICALL (init_method) \
+MONO_REGISTER_JIT_ICALL (init_method_gshared_mrgctx) \
+MONO_REGISTER_JIT_ICALL (init_method_gshared_this) \
+MONO_REGISTER_JIT_ICALL (init_method_gshared_vtable) \
+	\
+MONO_REGISTER_JIT_ICALL (mini_llvm_init_gshared_method_mrgctx) \
+MONO_REGISTER_JIT_ICALL (mini_llvm_init_gshared_method_this) \
+MONO_REGISTER_JIT_ICALL (mini_llvm_init_gshared_method_vtable) \
+MONO_REGISTER_JIT_ICALL (mini_llvm_init_method) \
+MONO_REGISTER_JIT_ICALL (mini_llvmonly_init_delegate) \
+MONO_REGISTER_JIT_ICALL (mini_llvmonly_init_delegate_virtual) \
+MONO_REGISTER_JIT_ICALL (mini_llvmonly_init_vtable_slot) \
+MONO_REGISTER_JIT_ICALL (mini_llvmonly_resolve_generic_virtual_call) \
+MONO_REGISTER_JIT_ICALL (mini_llvmonly_resolve_generic_virtual_iface_call) \
+MONO_REGISTER_JIT_ICALL (mini_llvmonly_resolve_iface_call_gsharedvt) \
+MONO_REGISTER_JIT_ICALL (mini_llvmonly_resolve_vcall_gsharedvt) \
+MONO_REGISTER_JIT_ICALL (mini_llvmonly_throw_nullref_exception) \
+	\
+MONO_REGISTER_JIT_ICALL (mono_amd64_throw_exception) \
+MONO_REGISTER_JIT_ICALL (mono_aot_init_gshared_method_mrgctx) \
+MONO_REGISTER_JIT_ICALL (mono_aot_init_gshared_method_this) \
+MONO_REGISTER_JIT_ICALL (mono_aot_init_gshared_method_vtable) \
+MONO_REGISTER_JIT_ICALL (mono_aot_init_llvm_method) \
+MONO_REGISTER_JIT_ICALL (mono_arch_rethrow_exception) \
+MONO_REGISTER_JIT_ICALL (mono_arch_throw_corlib_exception) \
+MONO_REGISTER_JIT_ICALL (mono_arch_throw_exception) \
+MONO_REGISTER_JIT_ICALL (mono_arm_throw_exception) \
+MONO_REGISTER_JIT_ICALL (mono_arm_throw_exception_by_token) \
+MONO_REGISTER_JIT_ICALL (mono_arm_unaligned_stack) \
+MONO_REGISTER_JIT_ICALL (mono_array_new_1) \
+MONO_REGISTER_JIT_ICALL (mono_array_new_2) \
+MONO_REGISTER_JIT_ICALL (mono_array_new_3) \
+MONO_REGISTER_JIT_ICALL (mono_array_new_4) \
+MONO_REGISTER_JIT_ICALL (mono_array_new_n_icall) \
+MONO_REGISTER_JIT_ICALL (mono_array_to_byte_byvalarray) \
+MONO_REGISTER_JIT_ICALL (mono_array_to_lparray) \
+MONO_REGISTER_JIT_ICALL (mono_array_to_savearray) \
+MONO_REGISTER_JIT_ICALL (mono_break) \
+MONO_REGISTER_JIT_ICALL (mono_byvalarray_to_byte_array) \
+MONO_REGISTER_JIT_ICALL (mono_chkstk_win64) \
+MONO_REGISTER_JIT_ICALL (mono_ckfinite) \
+MONO_REGISTER_JIT_ICALL (mono_class_interface_match) \
+MONO_REGISTER_JIT_ICALL (mono_class_static_field_address) \
+MONO_REGISTER_JIT_ICALL (mono_compile_method_icall) \
+MONO_REGISTER_JIT_ICALL (mono_context_get_icall) \
+MONO_REGISTER_JIT_ICALL (mono_context_set_icall) \
+MONO_REGISTER_JIT_ICALL (mono_create_corlib_exception_0) \
+MONO_REGISTER_JIT_ICALL (mono_create_corlib_exception_1) \
+MONO_REGISTER_JIT_ICALL (mono_create_corlib_exception_2) \
+MONO_REGISTER_JIT_ICALL (mono_debug_personality) \
+MONO_REGISTER_JIT_ICALL (mono_debugger_agent_user_break) \
+MONO_REGISTER_JIT_ICALL (mono_delegate_begin_invoke) \
+MONO_REGISTER_JIT_ICALL (mono_delegate_end_invoke) \
+MONO_REGISTER_JIT_ICALL (mono_delegate_to_ftnptr) \
+MONO_REGISTER_JIT_ICALL (mono_domain_get) \
+MONO_REGISTER_JIT_ICALL (mono_dummy_jit_icall) \
+MONO_REGISTER_JIT_ICALL (mono_fill_class_rgctx) \
+MONO_REGISTER_JIT_ICALL (mono_fill_method_rgctx) \
+MONO_REGISTER_JIT_ICALL (mono_fload_r4) \
+MONO_REGISTER_JIT_ICALL (mono_fload_r4_arg) \
+MONO_REGISTER_JIT_ICALL (mono_free_bstr) \
+MONO_REGISTER_JIT_ICALL (mono_free_lparray) \
+MONO_REGISTER_JIT_ICALL (mono_fstore_r4) \
+MONO_REGISTER_JIT_ICALL (mono_ftnptr_to_delegate) \
+MONO_REGISTER_JIT_ICALL (mono_gc_alloc_obj) \
+MONO_REGISTER_JIT_ICALL (mono_gc_alloc_string) \
+MONO_REGISTER_JIT_ICALL (mono_gc_alloc_vector) \
+MONO_REGISTER_JIT_ICALL (mono_gc_wbarrier_generic_nostore_internal) \
+MONO_REGISTER_JIT_ICALL (mono_gc_wbarrier_range_copy) \
+MONO_REGISTER_JIT_ICALL (mono_gchandle_get_target_internal) \
+MONO_REGISTER_JIT_ICALL (mono_generic_class_init) \
+MONO_REGISTER_JIT_ICALL (mono_get_assembly_object) \
+MONO_REGISTER_JIT_ICALL (mono_get_lmf_addr) \
+MONO_REGISTER_JIT_ICALL (mono_get_method_object) \
+MONO_REGISTER_JIT_ICALL (mono_get_native_calli_wrapper) \
+MONO_REGISTER_JIT_ICALL (mono_get_special_static_data) \
+MONO_REGISTER_JIT_ICALL (mono_gsharedvt_constrained_call) \
+MONO_REGISTER_JIT_ICALL (mono_gsharedvt_value_copy) \
+MONO_REGISTER_JIT_ICALL (mono_helper_compile_generic_method) \
+MONO_REGISTER_JIT_ICALL (mono_helper_ldstr) \
+MONO_REGISTER_JIT_ICALL (mono_helper_ldstr_mscorlib) \
+MONO_REGISTER_JIT_ICALL (mono_helper_newobj_mscorlib) \
+MONO_REGISTER_JIT_ICALL (mono_helper_stelem_ref_check) \
+MONO_REGISTER_JIT_ICALL (mono_init_vtable_slot) \
+MONO_REGISTER_JIT_ICALL (mono_interp_entry_from_trampoline) \
+MONO_REGISTER_JIT_ICALL (mono_interp_to_native_trampoline) \
+MONO_REGISTER_JIT_ICALL (mono_isfinite_double) \
+MONO_REGISTER_JIT_ICALL (mono_jit_set_domain) \
+MONO_REGISTER_JIT_ICALL (mono_ldftn) \
+MONO_REGISTER_JIT_ICALL (mono_ldtoken_wrapper) \
+MONO_REGISTER_JIT_ICALL (mono_ldtoken_wrapper_generic_shared) \
+MONO_REGISTER_JIT_ICALL (mono_ldvirtfn) \
+MONO_REGISTER_JIT_ICALL (mono_ldvirtfn_gshared) \
+MONO_REGISTER_JIT_ICALL (mono_llvm_clear_exception) \
+MONO_REGISTER_JIT_ICALL (mono_llvm_load_exception) \
+MONO_REGISTER_JIT_ICALL (mono_llvm_match_exception) \
+MONO_REGISTER_JIT_ICALL (mono_llvm_resume_exception) \
+MONO_REGISTER_JIT_ICALL (mono_llvm_resume_unwind_trampoline) \
+MONO_REGISTER_JIT_ICALL (mono_llvm_rethrow_exception) \
+MONO_REGISTER_JIT_ICALL (mono_llvm_rethrow_exception_trampoline) \
+MONO_REGISTER_JIT_ICALL (mono_llvm_set_unhandled_exception_handler) \
+MONO_REGISTER_JIT_ICALL (mono_llvm_throw_corlib_exception) \
+MONO_REGISTER_JIT_ICALL (mono_llvm_throw_corlib_exception_abs_trampoline) \
+MONO_REGISTER_JIT_ICALL (mono_llvm_throw_corlib_exception_trampoline) \
+MONO_REGISTER_JIT_ICALL (mono_llvm_throw_exception) \
+MONO_REGISTER_JIT_ICALL (mono_llvm_throw_exception_trampoline) \
+MONO_REGISTER_JIT_ICALL (mono_llvmonly_init_delegate) \
+MONO_REGISTER_JIT_ICALL (mono_llvmonly_init_delegate_virtual) \
+MONO_REGISTER_JIT_ICALL (mono_marshal_asany) \
+MONO_REGISTER_JIT_ICALL (mono_marshal_check_domain_image) \
+MONO_REGISTER_JIT_ICALL (mono_marshal_free) \
+MONO_REGISTER_JIT_ICALL (mono_marshal_free_array) \
+MONO_REGISTER_JIT_ICALL (mono_marshal_free_asany) \
+MONO_REGISTER_JIT_ICALL (mono_marshal_get_type_object) \
+MONO_REGISTER_JIT_ICALL (mono_marshal_isinst_with_cache) \
+MONO_REGISTER_JIT_ICALL (mono_marshal_safearray_begin) \
+MONO_REGISTER_JIT_ICALL (mono_marshal_safearray_create) \
+MONO_REGISTER_JIT_ICALL (mono_marshal_safearray_end) \
+MONO_REGISTER_JIT_ICALL (mono_marshal_safearray_free_indices) \
+MONO_REGISTER_JIT_ICALL (mono_marshal_safearray_get_value) \
+MONO_REGISTER_JIT_ICALL (mono_marshal_safearray_next) \
+MONO_REGISTER_JIT_ICALL (mono_marshal_safearray_set_value) \
+MONO_REGISTER_JIT_ICALL (mono_marshal_set_domain_by_id) \
+MONO_REGISTER_JIT_ICALL (mono_marshal_set_last_error) \
+MONO_REGISTER_JIT_ICALL (mono_marshal_set_last_error_windows) \
+MONO_REGISTER_JIT_ICALL (mono_marshal_string_to_utf16) \
+MONO_REGISTER_JIT_ICALL (mono_marshal_string_to_utf16_copy) \
+MONO_REGISTER_JIT_ICALL (mono_marshal_xdomain_copy_out_value) \
+MONO_REGISTER_JIT_ICALL (mono_monitor_enter_fast) \
+MONO_REGISTER_JIT_ICALL (mono_monitor_enter_internal) \
+MONO_REGISTER_JIT_ICALL (mono_monitor_enter_v4_fast) \
+MONO_REGISTER_JIT_ICALL (mono_monitor_enter_v4_internal) \
+MONO_REGISTER_JIT_ICALL (mono_object_castclass_unbox) \
+MONO_REGISTER_JIT_ICALL (mono_object_castclass_with_cache) \
+MONO_REGISTER_JIT_ICALL (mono_object_isinst_icall) \
+MONO_REGISTER_JIT_ICALL (mono_object_isinst_with_cache) \
+MONO_REGISTER_JIT_ICALL (mono_profiler_raise_exception_clause) \
+MONO_REGISTER_JIT_ICALL (mono_profiler_raise_gc_allocation) \
+MONO_REGISTER_JIT_ICALL (mono_profiler_raise_method_enter) \
+MONO_REGISTER_JIT_ICALL (mono_profiler_raise_method_leave) \
+MONO_REGISTER_JIT_ICALL (mono_profiler_raise_method_tail_call) \
+MONO_REGISTER_JIT_ICALL (mono_remoting_update_exception) \
+MONO_REGISTER_JIT_ICALL (mono_remoting_wrapper) \
+MONO_REGISTER_JIT_ICALL (mono_resolve_generic_virtual_call) \
+MONO_REGISTER_JIT_ICALL (mono_resolve_generic_virtual_iface_call) \
+MONO_REGISTER_JIT_ICALL (mono_resolve_iface_call_gsharedvt) \
+MONO_REGISTER_JIT_ICALL (mono_resolve_vcall_gsharedvt) \
+MONO_REGISTER_JIT_ICALL (mono_resume_unwind) \
+MONO_REGISTER_JIT_ICALL (mono_string_builder_to_utf16) \
+MONO_REGISTER_JIT_ICALL (mono_string_builder_to_utf8) \
+MONO_REGISTER_JIT_ICALL (mono_string_from_bstr_icall) \
+MONO_REGISTER_JIT_ICALL (mono_string_from_byvalstr) \
+MONO_REGISTER_JIT_ICALL (mono_string_from_byvalwstr) \
+MONO_REGISTER_JIT_ICALL (mono_string_new_len_wrapper) \
+MONO_REGISTER_JIT_ICALL (mono_string_new_wrapper_internal) \
+MONO_REGISTER_JIT_ICALL (mono_string_to_ansibstr) \
+MONO_REGISTER_JIT_ICALL (mono_string_to_bstr) \
+MONO_REGISTER_JIT_ICALL (mono_string_to_byvalstr) \
+MONO_REGISTER_JIT_ICALL (mono_string_to_byvalwstr) \
+MONO_REGISTER_JIT_ICALL (mono_string_to_utf16_internal) \
+MONO_REGISTER_JIT_ICALL (mono_string_to_utf8str) \
+MONO_REGISTER_JIT_ICALL (mono_string_utf16_to_builder) \
+MONO_REGISTER_JIT_ICALL (mono_string_utf16_to_builder2) \
+MONO_REGISTER_JIT_ICALL (mono_string_utf8_to_builder) \
+MONO_REGISTER_JIT_ICALL (mono_string_utf8_to_builder2) \
+MONO_REGISTER_JIT_ICALL (mono_struct_delete_old) \
+MONO_REGISTER_JIT_ICALL (mono_thread_force_interruption_checkpoint_noraise) \
+MONO_REGISTER_JIT_ICALL (mono_thread_get_undeniable_exception) \
+MONO_REGISTER_JIT_ICALL (mono_thread_interruption_checkpoint) \
+MONO_REGISTER_JIT_ICALL (mono_threads_attach_coop) \
+MONO_REGISTER_JIT_ICALL (mono_threads_detach_coop) \
+MONO_REGISTER_JIT_ICALL (mono_threads_enter_gc_safe_region_unbalanced) \
+MONO_REGISTER_JIT_ICALL (mono_threads_enter_gc_unsafe_region_unbalanced) \
+MONO_REGISTER_JIT_ICALL (mono_threads_exit_gc_safe_region_unbalanced) \
+MONO_REGISTER_JIT_ICALL (mono_threads_exit_gc_unsafe_region_unbalanced) \
+MONO_REGISTER_JIT_ICALL (mono_threads_state_poll) \
+MONO_REGISTER_JIT_ICALL (mono_throw_method_access) \
+MONO_REGISTER_JIT_ICALL (mono_tls_get_domain) \
+MONO_REGISTER_JIT_ICALL (mono_tls_get_jit_tls) \
+MONO_REGISTER_JIT_ICALL (mono_tls_get_lmf_addr) \
+MONO_REGISTER_JIT_ICALL (mono_tls_get_sgen_thread_info) \
+MONO_REGISTER_JIT_ICALL (mono_tls_get_thread) \
+MONO_REGISTER_JIT_ICALL (mono_tls_set_domain) \
+MONO_REGISTER_JIT_ICALL (mono_tls_set_jit_tls) \
+MONO_REGISTER_JIT_ICALL (mono_tls_set_lmf_addr) \
+MONO_REGISTER_JIT_ICALL (mono_tls_set_sgen_thread_info) \
+MONO_REGISTER_JIT_ICALL (mono_tls_set_thread) \
+MONO_REGISTER_JIT_ICALL (mono_trace_enter_method) \
+MONO_REGISTER_JIT_ICALL (mono_trace_leave_method) \
+MONO_REGISTER_JIT_ICALL (mono_upgrade_remote_class_wrapper) \
+MONO_REGISTER_JIT_ICALL (mono_value_copy_internal) \
+	\
+MONO_REGISTER_JIT_ICALL (personality) \
+	\
+MONO_REGISTER_JIT_ICALL (pthread_getspecific) \
+	\
+MONO_REGISTER_JIT_ICALL (type_from_handle) \
+	\
+MONO_REGISTER_JIT_ICALL (ves_icall_array_new) \
+MONO_REGISTER_JIT_ICALL (ves_icall_array_new_specific) \
+MONO_REGISTER_JIT_ICALL (ves_icall_marshal_alloc) \
+MONO_REGISTER_JIT_ICALL (ves_icall_mono_delegate_ctor) \
+MONO_REGISTER_JIT_ICALL (ves_icall_mono_delegate_ctor_interp) \
+MONO_REGISTER_JIT_ICALL (ves_icall_mono_ldstr) \
+MONO_REGISTER_JIT_ICALL (ves_icall_mono_marshal_xdomain_copy_value) \
+MONO_REGISTER_JIT_ICALL (ves_icall_mono_string_from_utf16) \
+MONO_REGISTER_JIT_ICALL (ves_icall_mono_string_to_utf8) \
+MONO_REGISTER_JIT_ICALL (ves_icall_object_new) \
+MONO_REGISTER_JIT_ICALL (ves_icall_object_new_specific) \
+MONO_REGISTER_JIT_ICALL (ves_icall_runtime_class_init) \
+MONO_REGISTER_JIT_ICALL (ves_icall_string_alloc) \
+MONO_REGISTER_JIT_ICALL (ves_icall_string_new_wrapper) \
+MONO_REGISTER_JIT_ICALL (ves_icall_thread_finish_async_abort) \
+	\
+MONO_REGISTER_JIT_ICALL (count) \
+
+// This enum is not actually used, except for count.
+// Instead mono_jit_icall_info_index should
+// generate the values from pointers for AOT and ilgen.
+// They could be used for const static special case arrays,
+// to shrink a pointer from 8 bytes + reloc to 4 (or 2) bytes.
+typedef enum MonoJitICallId {
+#define MONO_REGISTER_JIT_ICALL(x) MONO_JIT_ICALL_ ## x,
+MONO_REGISTER_JIT_ICALLS
+	mono_jit_icall_count = MONO_JIT_ICALL_count,
+#undef MONO_REGISTER_JIT_ICALL
+} MonoJitICallId;
+
+typedef union MonoJitICallInfos {
+	struct {
+#define MONO_REGISTER_JIT_ICALL(x) MonoJitICallInfo x;
+MONO_REGISTER_JIT_ICALLS
+#undef MONO_REGISTER_JIT_ICALL
+	};
+	MonoJitICallInfo array [mono_jit_icall_count];
+} MonoJitICallInfos;
+
+extern MonoJitICallInfos mono_jit_icall_info;
+
+#define mono_jit_icall_info_index(x) ((x) - mono_jit_icall_info.array)
+
+#endif // __MONO_METADATA_REGISTER_ICALL_DEF_H__

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -26,6 +26,7 @@
 #include "mono/metadata/assembly.h"
 #include "icall-decl.h"
 #include "icall-signatures.h"
+#include "register-icall-def.h"
 
 typedef enum {
 	MONO_MARSHAL_NONE,			/* No marshalling needed */
@@ -107,13 +108,18 @@ mono_compile_method_icall (MonoMethod *method);
 #ifdef __cplusplus
 template <typename T>
 static void
-register_icall (T func, const char *name, MonoMethodSignature *sig, gboolean save)
+register_icall_info (MonoJitICallInfo *info, T func, const char *name, MonoMethodSignature *sig, gboolean save)
 #else
 static void
-register_icall (gpointer func, const char *name, MonoMethodSignature *sig, gboolean save)
+register_icall_info (MonoJitICallInfo *info, gpointer func, const char *name, MonoMethodSignature *sig, gboolean save)
 #endif
 {
-	mono_register_jit_icall (func, name, sig, save);
+	// FIXME Some versions of register_icall_info pass NULL for last parameter, some pass name.
+	// marshal.c: name
+	// remoting.c: NULL (via mono_register_jit_icall_info)
+	// cominterop.c: name
+	// mini-runtime.c: name
+	mono_register_jit_icall_info (info, func, name, sig, save);
 }
 
 static inline void

--- a/mono/metadata/sgen-mono-ilgen.c
+++ b/mono/metadata/sgen-mono-ilgen.c
@@ -34,6 +34,7 @@
 #include "utils/mono-threads.h"
 #include "metadata/w32handle.h"
 #include "icall-decl.h"
+#include "register-icall-def.h"
 
 #define OPDEF(a,b,c,d,e,f,g,h,i,j) \
 	a = i,

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -37,6 +37,8 @@
 #include "utils/mono-threads.h"
 #include "metadata/w32handle.h"
 #include "icall-signatures.h"
+#include "class-internals.h"
+#include "register-icall-def.h"
 
 #ifdef HEAVY_STATISTICS
 static guint64 stat_wbarrier_set_arrayref = 0;

--- a/mono/mini/aot-runtime.h
+++ b/mono/mini/aot-runtime.h
@@ -11,7 +11,7 @@
 #include "mini.h"
 
 /* Version number of the AOT file format */
-#define MONO_AOT_FILE_VERSION 157
+#define MONO_AOT_FILE_VERSION 158
 
 #define MONO_AOT_TRAMP_PAGE_SIZE 16384
 

--- a/mono/mini/calls.c
+++ b/mono/mini/calls.c
@@ -645,6 +645,8 @@ mini_emit_abs_call (MonoCompile *cfg, MonoJumpInfoType patch_type, gconstpointer
 	MonoJumpInfo *ji = mono_patch_info_new (cfg->mempool, 0, patch_type, data);
 	MonoInst *ins;
 
+	g_assert (patch_type != MONO_PATCH_INFO_JIT_ICALL);
+
 	/* 
 	 * We pass ji as the call address, the PATCH_INFO_ABS resolving code will
 	 * handle it.

--- a/mono/mini/dwarfwriter.c
+++ b/mono/mini/dwarfwriter.c
@@ -1400,8 +1400,7 @@ disasm_ins (MonoMethod *method, const guchar *ip, const guint8 **endip)
 			MonoJitICallInfo *info;
 
 			token = read32 (ip + 2);
-			data = mono_method_get_wrapper_data (method, token);
-			info = mono_find_jit_icall_by_addr (data);
+			info = (MonoJitICallInfo*)mono_method_get_wrapper_data (method, token);
 			g_assert (info);
 
 			dis = g_strdup_printf ("IL_%04x: mono_icall <%s>", (int)(ip - header->code), info->name);

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -45,6 +45,7 @@
 #include "mini-runtime.h"
 #include "aot-runtime.h"
 #include "tasklets.h"
+#include "mono/metadata/register-icall-def.h"
 
 #ifdef TARGET_WIN32
 static void (*restore_stack) (void);
@@ -920,20 +921,35 @@ mono_arch_handle_altstack_exception (void *sigctx, MONO_SIG_HANDLER_INFO_TYPE *s
 
 #ifndef DISABLE_JIT
 GSList*
-mono_amd64_get_exception_trampolines (gboolean aot)
+mono_amd64_get_exception_trampolines (gboolean aot, gboolean reg)
 {
 	MonoTrampInfo *info;
 	GSList *tramps = NULL;
 
 	/* LLVM needs different throw trampolines */
 	get_throw_trampoline (&info, FALSE, TRUE, FALSE, FALSE, "llvm_throw_corlib_exception_trampoline", aot, FALSE);
-	tramps = g_slist_prepend (tramps, info);
+	if (reg) {
+		mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_throw_corlib_exception_trampoline, info->code, g_strdup (info->name), NULL, TRUE);
+		mono_tramp_info_register (info, NULL);
+	} else {
+		tramps = g_slist_prepend (tramps, info);
+	}
 
 	get_throw_trampoline (&info, FALSE, TRUE, TRUE, FALSE, "llvm_throw_corlib_exception_abs_trampoline", aot, FALSE);
-	tramps = g_slist_prepend (tramps, info);
+	if (reg) {
+		mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_throw_corlib_exception_abs_trampoline, info->code, g_strdup (info->name), NULL, TRUE);
+		mono_tramp_info_register (info, NULL);
+	} else {
+		tramps = g_slist_prepend (tramps, info);
+	}
 
 	get_throw_trampoline (&info, FALSE, TRUE, TRUE, TRUE, "llvm_resume_unwind_trampoline", aot, FALSE);
-	tramps = g_slist_prepend (tramps, info);
+	if (reg) {
+		mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_resume_unwind_trampoline, info->code, g_strdup (info->name), NULL, TRUE);
+		mono_tramp_info_register (info, NULL);
+	} else {
+		tramps = g_slist_prepend (tramps, info);
+	}
 
 	return tramps;
 }
@@ -941,7 +957,7 @@ mono_amd64_get_exception_trampolines (gboolean aot)
 #else
 
 GSList*
-mono_amd64_get_exception_trampolines (gboolean aot)
+mono_amd64_get_exception_trampolines (gboolean aot, gboolean reg)
 {
 	g_assert_not_reached ();
 	return NULL;
@@ -952,26 +968,28 @@ mono_amd64_get_exception_trampolines (gboolean aot)
 void
 mono_arch_exceptions_init (void)
 {
-	GSList *tramps, *l;
-	gpointer tramp;
-
 	if (mono_ee_features.use_aot_trampolines) {
-		tramp = mono_aot_get_trampoline ("llvm_throw_corlib_exception_trampoline");
-		mono_register_jit_icall (tramp, "llvm_throw_corlib_exception_trampoline", NULL, TRUE);
-		tramp = mono_aot_get_trampoline ("llvm_throw_corlib_exception_abs_trampoline");
-		mono_register_jit_icall (tramp, "llvm_throw_corlib_exception_abs_trampoline", NULL, TRUE);
-		tramp = mono_aot_get_trampoline ("llvm_resume_unwind_trampoline");
-		mono_register_jit_icall (tramp, "llvm_resume_unwind_trampoline", NULL, TRUE);
+
+		typedef struct MonoArchExceptionsInit {
+			const char *name;
+			MonoJitICallInfo *icall_info;
+		} MonoArchExceptionsInit;
+
+		const static MonoArchExceptionsInit inits [ ] = {
+			{ "llvm_throw_corlib_exception_trampoline", &mono_jit_icall_info.mono_llvm_throw_corlib_exception_trampoline },
+			{ "llvm_throw_corlib_exception_abs_trampoline", &mono_jit_icall_info.mono_llvm_throw_corlib_exception_abs_trampoline },
+			{ "llvm_resume_unwind_trampoline", &mono_jit_icall_info.mono_llvm_resume_unwind_trampoline },
+		};
+
+		for (guint i = 0; i < G_N_ELEMENTS (inits); ++i) {
+			const MonoArchExceptionsInit *init = &inits [i];
+			gpointer tramp = mono_aot_get_trampoline (init->name);
+			mono_register_jit_icall_info (init->icall_info, tramp, init->name, NULL, TRUE);
+		}
+
 	} else if (!mono_llvm_only) {
 		/* Call this to avoid initialization races */
-		tramps = mono_amd64_get_exception_trampolines (FALSE);
-		for (l = tramps; l; l = l->next) {
-			MonoTrampInfo *info = (MonoTrampInfo *)l->data;
-
-			mono_register_jit_icall (info->code, g_strdup (info->name), NULL, TRUE);
-			mono_tramp_info_register (info, NULL);
-		}
-		g_slist_free (tramps);
+		mono_amd64_get_exception_trampolines (FALSE, TRUE);
 	}
 }
 

--- a/mono/mini/exceptions-arm.c
+++ b/mono/mini/exceptions-arm.c
@@ -40,6 +40,7 @@
 #include "aot-runtime.h"
 #include "mono/utils/mono-sigcontext.h"
 #include "mono/utils/mono-compiler.h"
+#include "mono/metadata/register-icall-def.h"
 
 #ifndef DISABLE_JIT
 
@@ -384,20 +385,35 @@ mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 }	
 
 GSList*
-mono_arm_get_exception_trampolines (gboolean aot)
+mono_arm_get_exception_trampolines (gboolean aot, gboolean reg)
 {
 	MonoTrampInfo *info;
 	GSList *tramps = NULL;
 
 	/* LLVM uses the normal trampolines, but with a different name */
 	get_throw_trampoline (168, TRUE, FALSE, FALSE, FALSE, "llvm_throw_corlib_exception_trampoline", &info, aot, FALSE);
-	tramps = g_slist_prepend (tramps, info);
+	if (reg) {
+		mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_throw_corlib_exception_trampoline, info->code, g_strdup (info->name), NULL, TRUE);
+		mono_tramp_info_register (info, NULL);
+	} else {
+		tramps = g_slist_prepend (tramps, info);
+	}
 	
 	get_throw_trampoline (168, TRUE, FALSE, TRUE, FALSE, "llvm_throw_corlib_exception_abs_trampoline", &info, aot, FALSE);
-	tramps = g_slist_prepend (tramps, info);
+	if (reg) {
+		mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_throw_corlib_exception_abs_trampoline, info->code, g_strdup (info->name), NULL, TRUE);
+		mono_tramp_info_register (info, NULL);
+	} else {
+		tramps = g_slist_prepend (tramps, info);
+	}
 
 	get_throw_trampoline (168, FALSE, FALSE, FALSE, TRUE, "llvm_resume_unwind_trampoline", &info, aot, FALSE);
-	tramps = g_slist_prepend (tramps, info);
+	if (reg) {
+		mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_resume_unwind_trampoline, info->code, g_strdup (info->name), NULL, TRUE);
+		mono_tramp_info_register (info, NULL);
+	} else {
+		tramps = g_slist_prepend (tramps, info);
+	}
 
 	return tramps;
 }
@@ -405,7 +421,7 @@ mono_arm_get_exception_trampolines (gboolean aot)
 #else
 
 GSList*
-mono_arm_get_exception_trampolines (gboolean aot)
+mono_arm_get_exception_trampolines (gboolean aot, gboolean reg)
 {
 	g_assert_not_reached ();
 	return NULL;
@@ -416,25 +432,26 @@ mono_arm_get_exception_trampolines (gboolean aot)
 void
 mono_arch_exceptions_init (void)
 {
-	gpointer tramp;
-	GSList *tramps, *l;
-	
 	if (mono_aot_only) {
-		tramp = mono_aot_get_trampoline ("llvm_throw_corlib_exception_trampoline");
-		mono_register_jit_icall (tramp, "llvm_throw_corlib_exception_trampoline", NULL, TRUE);
-		tramp = mono_aot_get_trampoline ("llvm_throw_corlib_exception_abs_trampoline");
-		mono_register_jit_icall (tramp, "llvm_throw_corlib_exception_abs_trampoline", NULL, TRUE);
-		tramp = mono_aot_get_trampoline ("llvm_resume_unwind_trampoline");
-		mono_register_jit_icall (tramp, "llvm_resume_unwind_trampoline", NULL, TRUE);
-	} else {
-		tramps = mono_arm_get_exception_trampolines (FALSE);
-		for (l = tramps; l; l = l->next) {
-			MonoTrampInfo *info = (MonoTrampInfo*)l->data;
 
-			mono_register_jit_icall (info->code, g_strdup (info->name), NULL, TRUE);
-			mono_tramp_info_register (info, NULL);
+		typedef struct MonoArchExceptionsInit {
+			const char *name;
+			MonoJitICallInfo *icall_info;
+		} MonoArchExceptionsInit;
+
+		const static MonoArchExceptionsInit inits [ ] = {
+			{ "llvm_throw_corlib_exception_trampoline", &mono_jit_icall_info.mono_llvm_throw_corlib_exception_trampoline },
+			{ "llvm_throw_corlib_exception_abs_trampoline", &mono_jit_icall_info.mono_llvm_throw_corlib_exception_abs_trampoline },
+			{ "llvm_resume_unwind_trampoline", &mono_jit_icall_info.mono_llvm_resume_unwind_trampoline },
+		};
+
+		for (guint i = 0; i < G_N_ELEMENTS (inits); ++i) {
+			const MonoArchExceptionsInit *init = &inits [i];
+			gpointer tramp = mono_aot_get_trampoline (init->name);
+			mono_register_jit_icall_info (init->icall_info, tramp, init->name, NULL, TRUE);
 		}
-		g_slist_free (tramps);
+	} else {
+		mono_arm_get_exception_trampolines (FALSE, TRUE);
 	}
 }
 

--- a/mono/mini/exceptions-arm64.c
+++ b/mono/mini/exceptions-arm64.c
@@ -20,6 +20,7 @@
 
 #include <mono/arch/arm64/arm64-codegen.h>
 #include <mono/metadata/abi-details.h>
+#include "mono/metadata/register-icall-def.h"
 
 #ifndef DISABLE_JIT
 
@@ -287,20 +288,35 @@ mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 }
 
 GSList*
-mono_arm_get_exception_trampolines (gboolean aot)
+mono_arm_get_exception_trampolines (gboolean aot, gboolean reg)
 {
 	MonoTrampInfo *info;
 	GSList *tramps = NULL;
 
 	/* LLVM uses the normal trampolines, but with a different name */
 	get_throw_trampoline (256, TRUE, FALSE, FALSE, FALSE, "llvm_throw_corlib_exception_trampoline", &info, aot, FALSE);
-	tramps = g_slist_prepend (tramps, info);
+	if (reg) {
+		mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_throw_corlib_exception_trampoline, info->code, g_strdup (info->name), NULL, TRUE);
+		mono_tramp_info_register (info, NULL);
+	} else {
+		tramps = g_slist_prepend (tramps, info);
+	}
 	
 	get_throw_trampoline (256, TRUE, FALSE, TRUE, FALSE, "llvm_throw_corlib_exception_abs_trampoline", &info, aot, FALSE);
-	tramps = g_slist_prepend (tramps, info);
+	if (reg) {
+		mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_throw_corlib_exception_abs_trampoline, info->code, g_strdup (info->name), NULL, TRUE);
+		mono_tramp_info_register (info, NULL);
+	} else {
+		tramps = g_slist_prepend (tramps, info);
+	}
 
 	get_throw_trampoline (256, FALSE, FALSE, FALSE, TRUE, "llvm_resume_unwind_trampoline", &info, aot, FALSE);
-	tramps = g_slist_prepend (tramps, info);
+	if (reg) {
+		mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_resume_unwind_trampoline, info->code, g_strdup (info->name), NULL, TRUE);
+		mono_tramp_info_register (info, NULL);
+	} else {
+		tramps = g_slist_prepend (tramps, info);
+	}
 
 	return tramps;
 }
@@ -308,7 +324,7 @@ mono_arm_get_exception_trampolines (gboolean aot)
 #else
 
 GSList*
-mono_arm_get_exception_trampolines (gboolean aot)
+mono_arm_get_exception_trampolines (gboolean aot, gboolean reg)
 {
 	g_assert_not_reached ();
 	return NULL;
@@ -319,25 +335,25 @@ mono_arm_get_exception_trampolines (gboolean aot)
 void
 mono_arch_exceptions_init (void)
 {
-	gpointer tramp;
-	GSList *tramps, *l;
-
 	if (mono_aot_only) {
-		tramp = mono_aot_get_trampoline ("llvm_throw_corlib_exception_trampoline");
-		mono_register_jit_icall (tramp, "llvm_throw_corlib_exception_trampoline", NULL, TRUE);
-		tramp = mono_aot_get_trampoline ("llvm_throw_corlib_exception_abs_trampoline");
-		mono_register_jit_icall (tramp, "llvm_throw_corlib_exception_abs_trampoline", NULL, TRUE);
-		tramp = mono_aot_get_trampoline ("llvm_resume_unwind_trampoline");
-		mono_register_jit_icall (tramp, "llvm_resume_unwind_trampoline", NULL, TRUE);
-	} else {
-		tramps = mono_arm_get_exception_trampolines (FALSE);
-		for (l = tramps; l; l = l->next) {
-			MonoTrampInfo *info = (MonoTrampInfo*)l->data;
+		typedef struct MonoArchExceptionsInit {
+			const char *name;
+			MonoJitICallInfo *icall_info;
+		} MonoArchExceptionsInit;
 
-			mono_register_jit_icall (info->code, g_strdup (info->name), NULL, TRUE);
-			mono_tramp_info_register (info, NULL);
+		const static MonoArchExceptionsInit inits [ ] = {
+			{ "llvm_throw_corlib_exception_trampoline", &mono_jit_icall_info.mono_llvm_throw_corlib_exception_trampoline },
+			{ "llvm_throw_corlib_exception_abs_trampoline", &mono_jit_icall_info.mono_llvm_throw_corlib_exception_abs_trampoline },
+			{ "llvm_resume_unwind_trampoline", &mono_jit_icall_info.mono_llvm_resume_unwind_trampoline },
+		};
+
+		for (guint i = 0; i < G_N_ELEMENTS (inits); ++i) {
+			const MonoArchExceptionsInit *init = &inits [i];
+			gpointer tramp = mono_aot_get_trampoline (init->name);
+			mono_register_jit_icall_info (init->icall_info, tramp, init->name, NULL, TRUE);
 		}
-		g_slist_free (tramps);
+	} else {
+		mono_arm_get_exception_trampolines (FALSE, TRUE);
 	}
 }
 

--- a/mono/mini/exceptions-mips.c
+++ b/mono/mini/exceptions-mips.c
@@ -30,6 +30,7 @@
 #include "mini-mips.h"
 #include "mini-runtime.h"
 #include "aot-runtime.h"
+#include "mono/metadata/register-icall-def.h"
 
 #define GENERIC_EXCEPTION_SIZE 256
 

--- a/mono/mini/exceptions-ppc.c
+++ b/mono/mini/exceptions-ppc.c
@@ -32,6 +32,7 @@
 #include "mini-ppc.h"
 #include "mini-runtime.h"
 #include "aot-runtime.h"
+#include "mono/metadata/register-icall-def.h"
 
 /*
 

--- a/mono/mini/exceptions-s390x.c
+++ b/mono/mini/exceptions-s390x.c
@@ -63,6 +63,7 @@
 #include "support-s390x.h"
 #include "mini-runtime.h"
 #include "aot-runtime.h"
+#include "mono/metadata/register-icall-def.h"
 
 /*========================= End of Includes ========================*/
 

--- a/mono/mini/exceptions-sparc.c
+++ b/mono/mini/exceptions-sparc.c
@@ -27,6 +27,7 @@
 
 #include "mini.h"
 #include "mini-sparc.h"
+#include "mono/metadata/register-icall-def.h"
 
 #ifndef REG_SP
 #define REG_SP REG_O6

--- a/mono/mini/exceptions-x86.c
+++ b/mono/mini/exceptions-x86.c
@@ -33,6 +33,7 @@
 #include "mini-runtime.h"
 #include "tasklets.h"
 #include "aot-runtime.h"
+#include "mono/metadata/register-icall-def.h"
 
 static gpointer signal_exception_trampoline;
 
@@ -768,23 +769,23 @@ mono_arch_exceptions_init (void)
 
 	/* LLVM needs different throw trampolines */
 	tramp = get_throw_trampoline ("llvm_throw_exception_trampoline", FALSE, TRUE, FALSE, FALSE, FALSE, &tinfo, FALSE,  FALSE);
-	mono_register_jit_icall (tramp, "llvm_throw_exception_trampoline", NULL, TRUE);
+	mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_throw_exception_trampoline, tramp, "llvm_throw_exception_trampoline", NULL, TRUE);
 	mono_tramp_info_register (tinfo, NULL);
 
 	tramp = get_throw_trampoline ("llvm_rethrow_exception_trampoline", TRUE, TRUE, FALSE, FALSE, FALSE, &tinfo, FALSE, FALSE);
-	mono_register_jit_icall (tramp, "llvm_rethrow_exception_trampoline", NULL, TRUE);
+	mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_rethrow_exception_trampoline, tramp, "llvm_rethrow_exception_trampoline", NULL, TRUE);
 	mono_tramp_info_register (tinfo, NULL);
 
 	tramp = get_throw_trampoline ("llvm_throw_corlib_exception_trampoline", FALSE, TRUE, TRUE, FALSE, FALSE, &tinfo, FALSE, FALSE);
-	mono_register_jit_icall (tramp, "llvm_throw_corlib_exception_trampoline", NULL, TRUE);
+	mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_throw_corlib_exception_trampoline, tramp, "llvm_throw_corlib_exception_trampoline", NULL, TRUE);
 	mono_tramp_info_register (tinfo, NULL);
 
 	tramp = get_throw_trampoline ("llvm_throw_corlib_exception_abs_trampoline", FALSE, TRUE, TRUE, TRUE, FALSE, &tinfo, FALSE, FALSE);
-	mono_register_jit_icall (tramp, "llvm_throw_corlib_exception_abs_trampoline", NULL, TRUE);
+	mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_throw_corlib_exception_abs_trampoline, tramp, "llvm_throw_corlib_exception_abs_trampoline", NULL, TRUE);
 	mono_tramp_info_register (tinfo, NULL);
 
 	tramp = get_throw_trampoline ("llvm_resume_unwind_trampoline", FALSE, FALSE, FALSE, FALSE, TRUE, &tinfo, FALSE, FALSE);
-	mono_register_jit_icall (tramp, "llvm_resume_unwind_trampoline", NULL, TRUE);
+	mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_resume_unwind_trampoline, tramp, "llvm_resume_unwind_trampoline", NULL, TRUE);
 	mono_tramp_info_register (tinfo, NULL);
 
 	signal_exception_trampoline = mono_x86_get_signal_exception_trampoline (&tinfo, FALSE);

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -77,6 +77,7 @@
 #include <mono/mini/mini-arm.h>
 #endif
 #include <mono/metadata/icall-decl.h>
+#include "mono/metadata/register-icall-def.h"
 
 #ifdef _MSC_VER
 #pragma warning(disable:4102) // label' : unreferenced label
@@ -1371,7 +1372,7 @@ ves_pinvoke_method (InterpFrame *frame, MonoMethodSignature *sig, MonoFuncV addr
 	if (!entry_func) {
 #ifdef MONO_ARCH_HAS_NO_PROPER_MONOCTX
 		ERROR_DECL (error);
-		entry_func = (MonoPIFunc) mono_jit_compile_method_jit_only (mini_get_interp_lmf_wrapper ("mono_interp_to_native_trampoline", (gpointer) mono_interp_to_native_trampoline), error);
+		entry_func = (MonoPIFunc) mono_jit_compile_method_jit_only (mini_get_interp_lmf_wrapper (&mono_jit_icall_info.mono_interp_to_native_trampoline), error);
 		mono_error_assert_ok (error);
 #else
 		entry_func = get_interp_to_native_trampoline ();
@@ -2828,7 +2829,7 @@ interp_create_method_pointer (MonoMethod *method, gboolean compile, MonoError *e
 	else {
 		static gpointer cached_func = NULL;
 		if (!cached_func) {
-			cached_func = mono_jit_compile_method_jit_only (mini_get_interp_lmf_wrapper ("mono_interp_entry_from_trampoline", (gpointer) mono_interp_entry_from_trampoline), error);
+			cached_func = mono_jit_compile_method_jit_only (mini_get_interp_lmf_wrapper (&mono_jit_icall_info.mono_interp_entry_from_trampoline), error);
 			mono_memory_barrier ();
 		}
 		entry_func = cached_func;

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -22,9 +22,9 @@
 #include <mono/metadata/abi-details.h>
 #include <mono/metadata/reflection-internals.h>
 #include <mono/utils/unlocked.h>
-
 #include <mono/mini/mini.h>
 #include <mono/mini/mini-runtime.h>
+#include <mono/metadata/register-icall-def.h>
 
 #include "mintops.h"
 #include "interp-internals.h"
@@ -825,7 +825,7 @@ static int mono_class_get_magic_index (MonoClass *k)
 static void
 interp_generate_mae_throw (TransformData *td, MonoMethod *method, MonoMethod *target_method)
 {
-	MonoJitICallInfo *info = mono_find_jit_icall_by_name ("mono_throw_method_access");
+	MonoJitICallInfo *info = &mono_jit_icall_info.mono_throw_method_access;
 
 	/* Inject code throwing MethodAccessException */
 	interp_add_ins (td, MINT_MONO_LDPTR);
@@ -4834,14 +4834,14 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 				}
 				case CEE_MONO_ICALL: {
 					guint32 token;
-					gpointer func;
 					MonoJitICallInfo *info;
 					int icall_op;
 
+					// FIXME enum instead of pointer would be good here
+
 					token = read32 (td->ip + 1);
 					td->ip += 5;
-					func = mono_method_get_wrapper_data (method, token);
-					info = mono_find_jit_icall_by_addr (func);
+					info = (MonoJitICallInfo*)mono_method_get_wrapper_data (method, token);
 					g_assert (info);
 
 					CHECK_STACK (td, info->sig->param_count);
@@ -4864,7 +4864,8 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 						g_assert (icall_op != -1);
 
 						interp_add_ins (td, icall_op);
-						td->last_ins->data [0] = get_data_item_index (td, func);
+						// FIXME try making info have gpointer instead of gconstpointer
+						td->last_ins->data [0] = get_data_item_index (td, (gpointer)info->func);
 					}
 					td->sp -= info->sig->param_count;
 
@@ -5681,7 +5682,7 @@ mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, Mon
 			const char *name = method->name;
 			if (m_class_get_parent (method->klass) == mono_defaults.multicastdelegate_class) {
 				if (*name == '.' && (strcmp (name, ".ctor") == 0)) {
-					MonoJitICallInfo *mi = mono_find_jit_icall_by_name ("ves_icall_mono_delegate_ctor_interp");
+					MonoJitICallInfo *mi = &mono_jit_icall_info.ves_icall_mono_delegate_ctor_interp;
 					g_assert (mi);
 					nm = mono_marshal_get_icall_wrapper (mi, TRUE);
 				} else if (*name == 'I' && (strcmp (name, "Invoke") == 0)) {

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -2171,7 +2171,6 @@ mono_emit_jit_icall_by_info (MonoCompile *cfg, int il_offset, MonoJitICallInfo *
 	 * threads when debugging.
 	 */
 	if (direct_icalls_enabled (cfg)) {
-		char *name;
 		int costs;
 
 		if (!info->wrapper_method) {
@@ -10094,12 +10093,8 @@ field_access_end:
 
 		case MONO_CEE_MONO_ICALL: {
 			g_assert (method->wrapper_type != MONO_WRAPPER_NONE);
-			gpointer func;
-			MonoJitICallInfo *info;
-
-			func = mono_method_get_wrapper_data (method, token);
-			info = mono_find_jit_icall_by_addr (func);
-			if (!info)
+			MonoJitICallInfo *info = (MonoJitICallInfo*)mono_method_get_wrapper_data (method, token);
+			if (!info || !info->func)
 				g_error ("Could not find icall address in wrapper %s", mono_method_full_name (method, 1));
 			g_assert (info);
 

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -516,7 +516,7 @@ gpointer
 mono_amd64_start_gsharedvt_call (GSharedVtCallInfo *info, gpointer *caller, gpointer *callee, gpointer mrgctx_reg);
 
 GSList*
-mono_amd64_get_exception_trampolines (gboolean aot);
+mono_amd64_get_exception_trampolines (gboolean aot, gboolean reg);
 
 int
 mono_amd64_get_tls_gs_offset (void) MONO_LLVM_INTERNAL;

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -34,6 +34,7 @@
 #include "mini-runtime.h"
 #include "aot-runtime.h"
 #include "mono/arch/arm/arm-vfp-codegen.h"
+#include "mono/metadata/register-icall-def.h"
 
 /* Sanity check: This makes no sense */
 #if defined(ARM_FPU_NONE) && (defined(ARM_FPU_VFP) || defined(ARM_FPU_VFP_HARD))
@@ -427,8 +428,8 @@ emit_save_lmf (MonoCompile *cfg, guint8 *code, gint32 lmf_offset)
 	if (mono_arch_have_fast_tls () && mono_tls_get_tls_offset (TLS_KEY_LMF_ADDR) != -1) {
 		code = emit_tls_get (code, ARMREG_R0, mono_tls_get_tls_offset (TLS_KEY_LMF_ADDR));
 	} else {
-		mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL,
-							 (gpointer)"mono_tls_get_lmf_addr");
+		mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL_INFO,
+							 &mono_jit_icall_info.mono_tls_get_lmf_addr);
 		code = emit_call_seq (cfg, code);
 	}
 	/* we build the MonoLMF structure on the stack - see mini-arm.h */
@@ -4260,8 +4261,8 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 	cpos = bb->max_offset;
 
     if (mono_break_at_bb_method && mono_method_desc_full_match (mono_break_at_bb_method, cfg->method) && bb->block_num == mono_break_at_bb_bb_num) {
-		mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL, 
-							 (gpointer)"mono_break");
+		mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL_INFO,
+							 &mono_jit_icall_info.mono_break);
 		code = emit_call_seq (cfg, code);
 	}
 
@@ -4586,8 +4587,8 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			//*(int*)code = 0xef9f0001;
 			//code += 4;
 			//ARM_DBRK (code);
-			mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL, 
-								 (gpointer)"mono_break");
+			mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL_INFO,
+								 &mono_jit_icall_info.mono_break);
 			code = emit_call_seq (cfg, code);
 			break;
 		case OP_RELAXED_NOP:
@@ -5198,8 +5199,8 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			/* Uninitialized case */
 			g_assert (ins->sreg1 == ARMREG_R0);
 
-			mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL,
-								 (gpointer)"mono_generic_class_init");
+			mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL_INFO,
+								 &mono_jit_icall_info.mono_generic_class_init);
 			code = emit_call_seq (cfg, code);
 
 			/* Initialized case */
@@ -5306,16 +5307,16 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_THROW: {
 			if (ins->sreg1 != ARMREG_R0)
 				ARM_MOV_REG_REG (code, ARMREG_R0, ins->sreg1);
-			mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL, 
-					     (gpointer)"mono_arch_throw_exception");
+			mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL_INFO,
+					     &mono_jit_icall_info.mono_arch_throw_exception);
 			code = emit_call_seq (cfg, code);
 			break;
 		}
 		case OP_RETHROW: {
 			if (ins->sreg1 != ARMREG_R0)
 				ARM_MOV_REG_REG (code, ARMREG_R0, ins->sreg1);
-			mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL, 
-					     (gpointer)"mono_arch_rethrow_exception");
+			mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL_INFO,
+					     &mono_jit_icall_info.mono_arch_rethrow_exception);
 			code = emit_call_seq (cfg, code);
 			break;
 		}
@@ -6018,7 +6019,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			ARM_CMP_REG_IMM (code, ARMREG_IP, 0, 0);
 			buf [0] = code;
 			ARM_B_COND (code, ARMCOND_EQ, 0);
-			mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL, "mono_threads_state_poll");
+			mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL_INFO, &mono_jit_icall_info.mono_threads_state_poll);
 			code = emit_call_seq (cfg, code);
 			arm_patch (buf [0], code);
 			break;
@@ -6287,7 +6288,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 			ARM_MOV_REG_IMM8 (code, ARMREG_R0, 0);
 		else
 			code = mono_arm_emit_load_imm (code, ARMREG_R0, (guint32)cfg->method);
-		mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL, "mono_arm_unaligned_stack");
+		mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL_INFO, &mono_jit_icall_info.mono_arm_unaligned_stack);
 		code = emit_call_seq (cfg, code);
 		arm_patch (buf [0], code);
 	}
@@ -6811,8 +6812,8 @@ mono_arch_emit_exceptions (MonoCompile *cfg)
 
 			ARM_MOV_REG_REG (code, ARMREG_R1, ARMREG_LR);
 			ARM_LDR_IMM (code, ARMREG_R0, ARMREG_PC, 0);
-			patch_info->type = MONO_PATCH_INFO_JIT_ICALL;
-			patch_info->data.name = "mono_arch_throw_corlib_exception";
+			patch_info->type = MONO_PATCH_INFO_JIT_ICALL_INFO;
+			patch_info->data.icall_info = &mono_jit_icall_info.mono_arch_throw_corlib_exception;
 			patch_info->ip.i = code - cfg->native_code;
 			ARM_BL (code, 0);
 			cfg->thunk_area += THUNK_SIZE;
@@ -7172,7 +7173,7 @@ mono_arch_context_set_int_reg (MonoContext *ctx, int reg, host_mgreg_t val)
 GSList *
 mono_arch_get_trampolines (gboolean aot)
 {
-	return mono_arm_get_exception_trampolines (aot);
+	return mono_arm_get_exception_trampolines (aot, FALSE);
 }
 
 #if defined(MONO_ARCH_SOFT_DEBUG_SUPPORTED)

--- a/mono/mini/mini-arm.h
+++ b/mono/mini/mini-arm.h
@@ -415,7 +415,7 @@ int
 mono_arm_i8_align (void);
 
 GSList*
-mono_arm_get_exception_trampolines (gboolean aot);
+mono_arm_get_exception_trampolines (gboolean aot, gboolean reg);
 
 guint8*
 mono_arm_get_thumb_plt_entry (guint8 *code);

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -28,6 +28,7 @@
 #include <mono/metadata/abi-details.h>
 
 #include "interp/interp.h"
+#include "mono/metadata/register-icall-def.h"
 
 /*
  * Documentation:
@@ -3262,7 +3263,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			 * So instead of emitting a trap, we emit a call a C function and place a 
 			 * breakpoint there.
 			 */
-			code = emit_call (cfg, code, MONO_PATCH_INFO_JIT_ICALL, (gpointer)"mono_break");
+			code = emit_call (cfg, code, MONO_PATCH_INFO_JIT_ICALL_INFO, &mono_jit_icall_info.mono_break);
 			break;
 		case OP_LOCALLOC: {
 			guint8 *buf [16];
@@ -4544,8 +4545,8 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 
 			/* Slowpath */
 			g_assert (sreg1 == ARMREG_R0);
-			code = emit_call (cfg, code, MONO_PATCH_INFO_JIT_ICALL,
-							  (gpointer)"mono_generic_class_init");
+			code = emit_call (cfg, code, MONO_PATCH_INFO_JIT_ICALL_INFO,
+							  &mono_jit_icall_info.mono_generic_class_init);
 
 			mono_arm_patch (jump, code, MONO_R_ARM64_CBZ);
 			break;
@@ -4600,14 +4601,14 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_THROW:
 			if (sreg1 != ARMREG_R0)
 				arm_movx (code, ARMREG_R0, sreg1);
-			code = emit_call (cfg, code, MONO_PATCH_INFO_JIT_ICALL, 
-							  (gpointer)"mono_arch_throw_exception");
+			code = emit_call (cfg, code, MONO_PATCH_INFO_JIT_ICALL_INFO,
+							  &mono_jit_icall_info.mono_arch_throw_exception);
 			break;
 		case OP_RETHROW:
 			if (sreg1 != ARMREG_R0)
 				arm_movx (code, ARMREG_R0, sreg1);
-			code = emit_call (cfg, code, MONO_PATCH_INFO_JIT_ICALL, 
-							  (gpointer)"mono_arch_rethrow_exception");
+			code = emit_call (cfg, code, MONO_PATCH_INFO_JIT_ICALL_INFO,
+							  &mono_jit_icall_info.mono_arch_rethrow_exception);
 			break;
 		case OP_CALL_HANDLER:
 			mono_add_patch_info_rel (cfg, offset, MONO_PATCH_INFO_BB, ins->inst_target_bb, MONO_R_ARM64_BL);
@@ -4669,7 +4670,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			/* Call it if it is non-null */
 			buf [0] = code;
 			arm_cbzx (code, ARMREG_IP1, 0);
-			code = emit_call (cfg, code, MONO_PATCH_INFO_JIT_ICALL, "mono_threads_state_poll");
+			code = emit_call (cfg, code, MONO_PATCH_INFO_JIT_ICALL_INFO, &mono_jit_icall_info.mono_threads_state_poll);
 			mono_arm_patch (buf [0], code, MONO_R_ARM64_CBZ);
 			break;
 		}
@@ -5244,8 +5245,8 @@ mono_arch_emit_exceptions (MonoCompile *cfg)
 		arm_movx (code, ARMREG_R1, ARMREG_IP1);
 		/* Branch to the corlib exception throwing trampoline */
 		ji->ip.i = code - cfg->native_code;
-		ji->type = MONO_PATCH_INFO_JIT_ICALL;
-		ji->data.name = "mono_arch_throw_corlib_exception";
+		ji->type = MONO_PATCH_INFO_JIT_ICALL_INFO;
+		ji->data.icall_info = &mono_jit_icall_info.mono_arch_throw_corlib_exception;
 		ji->relocation = MONO_R_ARM64_BL;
 		arm_bl (code, 0);
 		cfg->thunk_area += THUNK_SIZE;
@@ -5393,7 +5394,7 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTC
 GSList *
 mono_arch_get_trampolines (gboolean aot)
 {
-	return mono_arm_get_exception_trampolines (aot);
+	return mono_arm_get_exception_trampolines (aot, FALSE);
 }
 
 #else /* DISABLE_JIT */

--- a/mono/mini/mini-arm64.h
+++ b/mono/mini/mini-arm64.h
@@ -277,7 +277,7 @@ void mono_arm_throw_exception (gpointer arg, host_mgreg_t pc, host_mgreg_t *int_
 
 void mono_arm_gsharedvt_init (void);
 
-GSList* mono_arm_get_exception_trampolines (gboolean aot);
+GSList* mono_arm_get_exception_trampolines (gboolean aot, gboolean reg);
 
 void mono_arm_resume_unwind (gpointer arg, host_mgreg_t pc, host_mgreg_t *int_regs, gdouble *fp_regs, gboolean corlib, gboolean rethrow);
 

--- a/mono/mini/mini-mips.c
+++ b/mono/mini/mini-mips.c
@@ -30,6 +30,7 @@
 #include "ir-emit.h"
 #include "aot-runtime.h"
 #include "mini-runtime.h"
+#include "mono/metadata/register-icall-def.h"
 
 #define SAVE_FP_REGS		0
 
@@ -3438,8 +3439,8 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			 * So instead of emitting a trap, we emit a call a C function and place a 
 			 * breakpoint there.
 			 */
-			mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL, 
-								 (gpointer)"mono_break");
+			mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL_INFO,
+								 &mono_jit_icall_info.mono_break);
 			mips_load (code, mips_t9, 0x1f1f1f1f);
 			mips_jalr (code, mips_t9, mips_ra);
 			mips_nop (code);

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -39,6 +39,7 @@
 #ifdef _AIX
 #include <sys/systemcfg.h>
 #endif
+#include "mono/metadata/register-icall-def.h"
 
 static GENERATE_TRY_GET_CLASS_WITH_CACHE (math, "System", "Math")
 static GENERATE_TRY_GET_CLASS_WITH_CACHE (mathf, "System", "MathF")
@@ -3336,8 +3337,8 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			 */
 			//ppc_break (code);
 			ppc_mr (code, ppc_r3, ins->sreg1);
-			mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL, 
-					     (gpointer)"mono_break");
+			mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL_INFO,
+					     &mono_jit_icall_info.mono_break);
 			if ((FORCE_INDIR_CALL || cfg->method->dynamic) && !cfg->compile_aot) {
 				ppc_load_func (code, PPC_CALL_REG, 0);
 				ppc_mtlr (code, PPC_CALL_REG);
@@ -3916,8 +3917,8 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_THROW: {
 			//ppc_break (code);
 			ppc_mr (code, ppc_r3, ins->sreg1);
-			mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL, 
-					     (gpointer)"mono_arch_throw_exception");
+			mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL_INFO,
+					     &mono_jit_icall_info.mono_arch_throw_exception);
 			if ((FORCE_INDIR_CALL || cfg->method->dynamic) && !cfg->compile_aot) {
 				ppc_load_func (code, PPC_CALL_REG, 0);
 				ppc_mtlr (code, PPC_CALL_REG);
@@ -3930,8 +3931,8 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_RETHROW: {
 			//ppc_break (code);
 			ppc_mr (code, ppc_r3, ins->sreg1);
-			mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL, 
-					     (gpointer)"mono_arch_rethrow_exception");
+			mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL_INFO,
+					     &mono_jit_icall_info.mono_arch_rethrow_exception);
 			if ((FORCE_INDIR_CALL || cfg->method->dynamic) && !cfg->compile_aot) {
 				ppc_load_func (code, PPC_CALL_REG, 0);
 				ppc_mtlr (code, PPC_CALL_REG);
@@ -4686,6 +4687,8 @@ mono_arch_patch_code_new (MonoCompile *cfg, MonoDomain *domain, guint8 *code, Mo
 		break;
 #ifdef PPC_USES_FUNCTION_DESCRIPTOR
 	case MONO_PATCH_INFO_JIT_ICALL:
+		g_assert (!"MONO_PATCH_INFO_JIT_ICALL");
+	case MONO_PATCH_INFO_JIT_ICALL_INFO:
 	case MONO_PATCH_INFO_ABS:
 	case MONO_PATCH_INFO_RGCTX_FETCH:
 	case MONO_PATCH_INFO_JIT_ICALL_ADDR:
@@ -5165,8 +5168,8 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 			/* Compute the got address which is needed by the PLT entry */
 			code = mono_arch_emit_load_got_addr (cfg->native_code, code, cfg, NULL);
 		}
-		mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL, 
-			     (gpointer)"mono_tls_get_lmf_addr");
+		mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL_INFO,
+			     &mono_jit_icall_info.mono_tls_get_lmf_addr);
 		if ((FORCE_INDIR_CALL || cfg->method->dynamic) && !cfg->compile_aot) {
 			ppc_load_func (code, PPC_CALL_REG, 0);
 			ppc_mtlr (code, PPC_CALL_REG);
@@ -5441,8 +5444,8 @@ mono_arch_emit_exceptions (MonoCompile *cfg)
 			ppc_load (code, ppc_r3, m_class_get_type_token (exc_class));
 			/* we got here from a conditional call, so the calling ip is set in lr */
 			ppc_mflr (code, ppc_r4);
-			patch_info->type = MONO_PATCH_INFO_JIT_ICALL;
-			patch_info->data.name = "mono_arch_throw_corlib_exception";
+			patch_info->type = MONO_PATCH_INFO_JIT_ICALL_INFO;
+			patch_info->data.icall_info = &mono_jit_icall_info.mono_arch_throw_corlib_exception;
 			patch_info->ip.i = code - cfg->native_code;
 			if (FORCE_INDIR_CALL || cfg->method->dynamic) {
 				ppc_load_func (code, PPC_CALL_REG, 0);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -100,6 +100,8 @@
 #endif
 #endif
 #include "mono/metadata/icall-signatures.h"
+#include "mono/metadata/register-icall-def.h"
+#include "mono/metadata/class-internals.h"
 
 static guint32 default_opt = 0;
 static gboolean default_opt_set = FALSE;
@@ -616,6 +618,10 @@ mono_icall_get_wrapper_method (MonoJitICallInfo* callinfo)
 {
 	gboolean check_exc = TRUE;
 
+	// FIXME Remove strcmp.
+	g_assert ((callinfo == &mono_jit_icall_info.mono_thread_interruption_checkpoint)
+		== !strcmp (callinfo->name, "mono_thread_interruption_checkpoint"));
+
 	if (!strcmp (callinfo->name, "mono_thread_interruption_checkpoint"))
 		/* This icall is used to check for exceptions, so don't check in the wrapper */
 		check_exc = FALSE;
@@ -629,7 +635,6 @@ mono_icall_get_wrapper_full (MonoJitICallInfo* callinfo, gboolean do_compile)
 	ERROR_DECL (error);
 	MonoMethod *wrapper;
 	gconstpointer trampoline;
-	MonoDomain *domain = mono_get_root_domain ();
 
 	if (callinfo->wrapper)
 		return callinfo->wrapper;
@@ -643,6 +648,7 @@ mono_icall_get_wrapper_full (MonoJitICallInfo* callinfo, gboolean do_compile)
 		trampoline = mono_compile_method_checked (wrapper, error);
 		mono_error_assert_ok (error);
 	} else {
+		MonoDomain *domain = mono_get_root_domain ();
 		trampoline = mono_create_jit_trampoline (domain, wrapper, error);
 		mono_error_assert_ok (error);
 		trampoline = mono_create_ftnptr (domain, (gpointer)trampoline);
@@ -679,21 +685,33 @@ mono_dynamic_code_hash_lookup (MonoDomain *domain, MonoMethod *method)
 #ifdef __cplusplus
 template <typename T>
 static void
-register_opcode_emulation (int opcode, const char *name, MonoMethodSignature *sig, T func, const char *symbol, gboolean no_wrapper)
+register_opcode_emulation_info (int opcode, MonoJitICallInfo *info, const char *name, MonoMethodSignature *sig, T func, const char *symbol, gboolean no_wrapper)
 #else
 static void
-register_opcode_emulation (int opcode, const char *name, MonoMethodSignature *sig, gpointer func, const char *symbol, gboolean no_wrapper)
+register_opcode_emulation_info (int opcode, MonoJitICallInfo *info, const char *name, MonoMethodSignature *sig, gpointer func, const char *symbol, gboolean no_wrapper)
 #endif
 {
 #ifndef DISABLE_JIT
-	mini_register_opcode_emulation (opcode, name, sig, func, symbol, no_wrapper);
+	mini_register_opcode_emulation_info (opcode, info, name, sig, func, symbol, no_wrapper);
 #else
+	// FIXME ifdef in mini_register_opcode_emulation and just call it.
+
 	g_assert (!sig->hasthis);
 	g_assert (sig->param_count < 3);
 
-	mono_register_jit_icall_full (func, name, sig, no_wrapper, symbol);
+	mono_register_jit_icall_info_full (info, (gpointer)func, name, sig, no_wrapper, symbol);
 #endif
 }
+
+// The opcode emulation icall_info does not need to be public, so instantiate
+// it here instead of in register-icall-def.h. A scope is not placed
+// here, to more likely catch duplicates.
+#define register_opcode_emulation(opcode, name, sig, func, no_wrapper) 	\
+	register_opcode_emulation_full ((opcode), name, (sig), (func), (#func), (no_wrapper))
+
+// Provide a different function for AOT to skip a layer.
+#define register_opcode_emulation_full(opcode, name, sig, func, symbol, no_wrapper) 	\
+	register_opcode_emulation_info ((opcode), (&mono_jit_icall_info.name), (#name), (sig), (gpointer)(func), (symbol), (no_wrapper)) \
 
 /*
  * For JIT icalls implemented in C.
@@ -704,37 +722,42 @@ register_opcode_emulation (int opcode, const char *name, MonoMethodSignature *si
 #ifdef __cplusplus
 template <typename T>
 static void
-register_icall (T func, const char *name, MonoMethodSignature *sig, gboolean avoid_wrapper)
+register_icall_info (MonoJitICallInfo *info, T func, const char *name, MonoMethodSignature *sig, gboolean avoid_wrapper)
 #else
 static void
-register_icall (gpointer func, const char *name, MonoMethodSignature *sig, gboolean avoid_wrapper)
+register_icall_info (MonoJitICallInfo *info, gconstpointer func, const char *name, MonoMethodSignature *sig, gboolean avoid_wrapper)
 #endif
 {
-	mono_register_jit_icall_full (func, name, sig, avoid_wrapper, name);
+	// FIXME Some versions of register_icall_info pass NULL for last parameter, some pass name.
+	// marshal.c: name
+	// remoting.c: NULL (via mono_register_jit_icall_info)
+	// cominterop.c: name
+	// mini-runtime.c: name
+	mono_register_jit_icall_info_full (info, func, name, sig, avoid_wrapper, name);
 }
 
 #ifdef __cplusplus
 template <typename T>
 static void
-register_icall_no_wrapper (T func, const char *name,  MonoMethodSignature *sig)
+register_icall_info_no_wrapper (MonoJitICallInfo *info, T func, const char *name, MonoMethodSignature *sig)
 #else
 static void
-register_icall_no_wrapper (gpointer func, const char *name,  MonoMethodSignature *sig)
+register_icall_info_no_wrapper (MonoJitICallInfo *info, gpointer func, const char *name, MonoMethodSignature *sig)
 #endif
 {
-	mono_register_jit_icall_full (func, name, sig, TRUE, name);
+	mono_register_jit_icall_info_full (info, func, name, sig, TRUE, name);
 }
 
 #ifdef __cplusplus
 template <typename T>
 static void
-register_icall_with_wrapper (T func, const char *name, MonoMethodSignature *sig)
+register_icall_info_with_wrapper (MonoJitICallInfo *info, T func, const char *name, MonoMethodSignature *sig)
 #else
 static void
-register_icall_with_wrapper (gpointer func, const char *name, MonoMethodSignature *sig)
+register_icall_info_with_wrapper (MonoJitICallInfo *info, gpointer func, const char *name, MonoMethodSignature *sig)
 #endif
 {
-	mono_register_jit_icall_full (func, name, sig, FALSE, name);
+	mono_register_jit_icall_info_full (info, func, name, sig, FALSE, name);
 }
 
 /*
@@ -744,13 +767,13 @@ register_icall_with_wrapper (gpointer func, const char *name, MonoMethodSignatur
 #ifdef __cplusplus
 template <typename T>
 static void
-register_dyn_icall (T func, const char *name, MonoMethodSignature *sig, gboolean save)
+register_dyn_icall_info (MonoJitICallInfo *info, T func, const char *name, MonoMethodSignature *sig, gboolean save)
 #else
 static void
-register_dyn_icall (gpointer func, const char *name, MonoMethodSignature *sig, gboolean save)
+register_dyn_icall_info (MonoJitICallInfo *info, gpointer func, const char *name, MonoMethodSignature *sig, gboolean save)
 #endif
 {
-	mono_register_jit_icall (func, name, sig, save);
+	mono_register_jit_icall_info (info, func, name, sig, save);
 }
 
 MonoLMF *
@@ -1088,10 +1111,13 @@ mono_print_ji (const MonoJumpInfo *ji)
 		g_free (s);
 		break;
 	}
-	case MONO_PATCH_INFO_JIT_ICALL: {
+	case MONO_PATCH_INFO_JIT_ICALL:
+		g_assert (!"MONO_PATCH_INFO_JIT_ICALL");
 		printf ("[JIT_ICALL %s]", ji->data.name);
 		break;
-	}
+	case MONO_PATCH_INFO_JIT_ICALL_INFO:
+		printf ("[JIT_ICALL_INFO %s]", ji->data.icall_info->name);
+		break;
 	case MONO_PATCH_INFO_CLASS:
 	case MONO_PATCH_INFO_VTABLE: {
 		char *name = mono_class_full_name (ji->data.klass);
@@ -1211,7 +1237,10 @@ mono_patch_info_hash (gconstpointer data)
 	case MONO_PATCH_INFO_TYPE_FROM_HANDLE:
 		return (ji->type << 8) | ji->data.token->token | (ji->data.token->has_context ? (gsize)ji->data.token->context.class_inst : 0);
 	case MONO_PATCH_INFO_JIT_ICALL:
+		g_assert (!"MONO_PATCH_INFO_JIT_ICALL");
 		return (ji->type << 8) | g_str_hash (ji->data.name);
+	case MONO_PATCH_INFO_JIT_ICALL_INFO:
+		return (ji->type << 8) | g_str_hash (ji->data.icall_info->name);
 	case MONO_PATCH_INFO_VTABLE:
 	case MONO_PATCH_INFO_CLASS:
 	case MONO_PATCH_INFO_IID:
@@ -1316,7 +1345,10 @@ mono_patch_info_equal (gconstpointer ka, gconstpointer kb)
 			return 0;
 		break;
 	case MONO_PATCH_INFO_JIT_ICALL:
+		g_assert (!"MONO_PATCH_INFO_JIT_ICALL");
 		return g_str_equal (ji1->data.name, ji2->data.name);
+	case MONO_PATCH_INFO_JIT_ICALL_INFO:
+		return ji1->data.icall_info == ji2->data.icall_info;
 	case MONO_PATCH_INFO_RGCTX_FETCH:
 	case MONO_PATCH_INFO_RGCTX_SLOT_INDEX: {
 		MonoJumpInfoRgctxEntry *e1 = ji1->data.rgctx_entry;
@@ -1385,9 +1417,20 @@ mono_resolve_patch_target (MonoMethod *method, MonoDomain *domain, guint8 *code,
 	case MONO_PATCH_INFO_METHOD_REL:
 		target = code + patch_info->data.offset;
 		break;
-	case MONO_PATCH_INFO_JIT_ICALL: {
-		MonoJitICallInfo *mi = mono_find_jit_icall_by_name (patch_info->data.name);
-		g_assertf (mi, "unknown MONO_PATCH_INFO_JIT_ICALL %s", patch_info->data.name);
+	case MONO_PATCH_INFO_JIT_ICALL:
+	case MONO_PATCH_INFO_JIT_ICALL_INFO: {
+		MonoJitICallInfo *mi = NULL;
+		switch (patch_info->type) {
+		case MONO_PATCH_INFO_JIT_ICALL:
+			g_assert (!"MONO_PATCH_INFO_JIT_ICALL");
+			//mi = mono_find_jit_icall_by_name (patch_info->data.name);
+			g_assertf (mi, "unknown MONO_PATCH_INFO_JIT_ICALL %s", patch_info->data.name);
+			break;
+		case MONO_PATCH_INFO_JIT_ICALL_INFO:
+			mi = patch_info->data.icall_info;
+			g_assert (mi && "unknown MONO_PATCH_INFO_JIT_ICALL_INFO");
+			break;
+		}
 		target = mono_icall_get_wrapper (mi);
 		break;
 	}
@@ -2190,7 +2233,7 @@ compile_special (MonoMethod *method, MonoDomain *target_domain, MonoError *error
 
 		if (m_class_get_parent (method->klass) == mono_defaults.multicastdelegate_class) {
 			if (*name == '.' && (strcmp (name, ".ctor") == 0)) {
-				MonoJitICallInfo *mi = mono_find_jit_icall_by_name ("ves_icall_mono_delegate_ctor");
+				MonoJitICallInfo *mi = &mono_jit_icall_info.ves_icall_mono_delegate_ctor;
 				g_assert (mi);
 				/*
 				 * We need to make sure this wrapper
@@ -2309,7 +2352,7 @@ mono_jit_compile_method_with_opt (MonoMethod *method, guint32 opt, gboolean jit_
 	if (method->wrapper_type == MONO_WRAPPER_MANAGED_TO_NATIVE)
 		winfo = mono_marshal_get_wrapper_info (method);
 	if (winfo && winfo->subtype == WRAPPER_SUBTYPE_ICALL_WRAPPER) {
-		callinfo = mono_find_jit_icall_by_addr (winfo->d.icall.func);
+		callinfo = winfo->d.icall_info;
 		g_assert (callinfo);
 
 		/* Must be domain neutral since there is only one copy */
@@ -4444,9 +4487,9 @@ register_icalls (void)
 #endif
 
 	if (!mono_llvm_only) {
-		register_dyn_icall (mono_get_throw_exception (), "mono_arch_throw_exception", mono_icall_sig_void_object, TRUE);
-		register_dyn_icall (mono_get_rethrow_exception (), "mono_arch_rethrow_exception", mono_icall_sig_void_object, TRUE);
-		register_dyn_icall (mono_get_throw_corlib_exception (), "mono_arch_throw_corlib_exception", mono_icall_sig_void_ptr, TRUE);
+		register_dyn_icall (mono_get_throw_exception (), mono_arch_throw_exception, mono_icall_sig_void_object, TRUE);
+		register_dyn_icall (mono_get_rethrow_exception (), mono_arch_rethrow_exception, mono_icall_sig_void_object, TRUE);
+		register_dyn_icall (mono_get_throw_corlib_exception (), mono_arch_throw_corlib_exception, mono_icall_sig_void_ptr, TRUE);
 	}
 	register_icall (mono_thread_get_undeniable_exception, "mono_thread_get_undeniable_exception", mono_icall_sig_object, FALSE);
 	register_icall (ves_icall_thread_finish_async_abort, "ves_icall_thread_finish_async_abort", mono_icall_sig_void, FALSE);
@@ -4456,109 +4499,109 @@ register_icalls (void)
 	register_icall (mono_threads_state_poll, "mono_threads_state_poll", mono_icall_sig_void, FALSE);
 
 #ifndef MONO_ARCH_NO_EMULATE_LONG_MUL_OPTS
-	register_opcode_emulation (OP_LMUL, "__emul_lmul", mono_icall_sig_long_long_long, mono_llmult, "mono_llmult", FALSE);
-	register_opcode_emulation (OP_LDIV, "__emul_ldiv", mono_icall_sig_long_long_long, mono_lldiv, "mono_lldiv", FALSE);
-	register_opcode_emulation (OP_LDIV_UN, "__emul_ldiv_un", mono_icall_sig_long_long_long, mono_lldiv_un, "mono_lldiv_un", FALSE);
-	register_opcode_emulation (OP_LREM, "__emul_lrem", mono_icall_sig_long_long_long, mono_llrem, "mono_llrem", FALSE);
-	register_opcode_emulation (OP_LREM_UN, "__emul_lrem_un", mono_icall_sig_long_long_long, mono_llrem_un, "mono_llrem_un", FALSE);
+	register_opcode_emulation (OP_LMUL, __emul_lmul, mono_icall_sig_long_long_long, mono_llmult, FALSE);
+	register_opcode_emulation (OP_LDIV, __emul_ldiv, mono_icall_sig_long_long_long, mono_lldiv, FALSE);
+	register_opcode_emulation (OP_LDIV_UN, __emul_ldiv_un, mono_icall_sig_long_long_long, mono_lldiv_un, FALSE);
+	register_opcode_emulation (OP_LREM, __emul_lrem, mono_icall_sig_long_long_long, mono_llrem, FALSE);
+	register_opcode_emulation (OP_LREM_UN, __emul_lrem_un, mono_icall_sig_long_long_long, mono_llrem_un, FALSE);
 #endif
 #if !defined(MONO_ARCH_NO_EMULATE_LONG_MUL_OPTS) || defined(MONO_ARCH_EMULATE_LONG_MUL_OVF_OPTS)
-	register_opcode_emulation (OP_LMUL_OVF_UN, "__emul_lmul_ovf_un", mono_icall_sig_long_long_long, mono_llmult_ovf_un, "mono_llmult_ovf_un", FALSE);
-	register_opcode_emulation (OP_LMUL_OVF, "__emul_lmul_ovf", mono_icall_sig_long_long_long, mono_llmult_ovf, "mono_llmult_ovf", FALSE);
+	register_opcode_emulation (OP_LMUL_OVF_UN, __emul_lmul_ovf_un, mono_icall_sig_long_long_long, mono_llmult_ovf_un, FALSE);
+	register_opcode_emulation (OP_LMUL_OVF, __emul_lmul_ovf, mono_icall_sig_long_long_long, mono_llmult_ovf, FALSE);
 #endif
 
 #ifndef MONO_ARCH_NO_EMULATE_LONG_SHIFT_OPS
-	register_opcode_emulation (OP_LSHL, "__emul_lshl", mono_icall_sig_long_long_int32, mono_lshl, "mono_lshl", TRUE);
-	register_opcode_emulation (OP_LSHR, "__emul_lshr", mono_icall_sig_long_long_int32, mono_lshr, "mono_lshr", TRUE);
-	register_opcode_emulation (OP_LSHR_UN, "__emul_lshr_un", mono_icall_sig_long_long_int32, mono_lshr_un, "mono_lshr_un", TRUE);
+	register_opcode_emulation (OP_LSHL, __emul_lshl, mono_icall_sig_long_long_int32, mono_lshl, TRUE);
+	register_opcode_emulation (OP_LSHR, __emul_lshr, mono_icall_sig_long_long_int32, mono_lshr, TRUE);
+	register_opcode_emulation (OP_LSHR_UN, __emul_lshr_un, mono_icall_sig_long_long_int32, mono_lshr_un, TRUE);
 #endif
 
 #if defined(MONO_ARCH_EMULATE_MUL_DIV) || defined(MONO_ARCH_EMULATE_DIV)
-	register_opcode_emulation (OP_IDIV, "__emul_op_idiv", mono_icall_sig_int32_int32_int32, mono_idiv, "mono_idiv", FALSE);
-	register_opcode_emulation (OP_IDIV_UN, "__emul_op_idiv_un", mono_icall_sig_int32_int32_int32, mono_idiv_un, "mono_idiv_un", FALSE);
-	register_opcode_emulation (OP_IREM, "__emul_op_irem", mono_icall_sig_int32_int32_int32, mono_irem, "mono_irem", FALSE);
-	register_opcode_emulation (OP_IREM_UN, "__emul_op_irem_un", mono_icall_sig_int32_int32_int32, mono_irem_un, "mono_irem_un", FALSE);
+	register_opcode_emulation (OP_IDIV, __emul_op_idiv, mono_icall_sig_int32_int32_int32, mono_idiv, FALSE);
+	register_opcode_emulation (OP_IDIV_UN, __emul_op_idiv_un, mono_icall_sig_int32_int32_int32, mono_idiv_un, FALSE);
+	register_opcode_emulation (OP_IREM, __emul_op_irem, mono_icall_sig_int32_int32_int32, mono_irem, FALSE);
+	register_opcode_emulation (OP_IREM_UN, __emul_op_irem_un, mono_icall_sig_int32_int32_int32, mono_irem_un, FALSE);
 #endif
 
 #ifdef MONO_ARCH_EMULATE_MUL_DIV
-	register_opcode_emulation (OP_IMUL, "__emul_op_imul", mono_icall_sig_int32_int32_int32, mono_imul, "mono_imul", TRUE);
+	register_opcode_emulation (OP_IMUL, __emul_op_imul, mono_icall_sig_int32_int32_int32, mono_imul, TRUE);
 #endif
 
 #if defined(MONO_ARCH_EMULATE_MUL_DIV) || defined(MONO_ARCH_EMULATE_MUL_OVF)
-	register_opcode_emulation (OP_IMUL_OVF, "__emul_op_imul_ovf", mono_icall_sig_int32_int32_int32, mono_imul_ovf, "mono_imul_ovf", FALSE);
-	register_opcode_emulation (OP_IMUL_OVF_UN, "__emul_op_imul_ovf_un", mono_icall_sig_int32_int32_int32, mono_imul_ovf_un, "mono_imul_ovf_un", FALSE);
+	register_opcode_emulation (OP_IMUL_OVF, __emul_op_imul_ovf, mono_icall_sig_int32_int32_int32, mono_imul_ovf, FALSE);
+	register_opcode_emulation (OP_IMUL_OVF_UN, __emul_op_imul_ovf_un, mono_icall_sig_int32_int32_int32, mono_imul_ovf_un, FALSE);
 #endif
 
 #if defined(MONO_ARCH_EMULATE_MUL_DIV) || defined(MONO_ARCH_SOFT_FLOAT_FALLBACK)
-	register_opcode_emulation (OP_FDIV, "__emul_fdiv", mono_icall_sig_double_double_double, mono_fdiv, "mono_fdiv", FALSE);
+	register_opcode_emulation (OP_FDIV, __emul_fdiv, mono_icall_sig_double_double_double, mono_fdiv, FALSE);
 #endif
 
-	register_opcode_emulation (OP_FCONV_TO_U8, "__emul_fconv_to_u8", mono_icall_sig_ulong_double, mono_fconv_u8_2, "mono_fconv_u8_2", FALSE);
-	register_opcode_emulation (OP_RCONV_TO_U8, "__emul_rconv_to_u8", mono_icall_sig_ulong_float, mono_rconv_u8, "mono_rconv_u8", FALSE);
-	register_opcode_emulation (OP_FCONV_TO_U4, "__emul_fconv_to_u4", mono_icall_sig_uint32_double, mono_fconv_u4_2, "mono_fconv_u4_2", FALSE);
-	register_opcode_emulation (OP_FCONV_TO_OVF_I8, "__emul_fconv_to_ovf_i8", mono_icall_sig_long_double, mono_fconv_ovf_i8, "mono_fconv_ovf_i8", FALSE);
-	register_opcode_emulation (OP_FCONV_TO_OVF_U8, "__emul_fconv_to_ovf_u8", mono_icall_sig_ulong_double, mono_fconv_ovf_u8, "mono_fconv_ovf_u8", FALSE);
-	register_opcode_emulation (OP_RCONV_TO_OVF_I8, "__emul_rconv_to_ovf_i8", mono_icall_sig_long_float, mono_rconv_ovf_i8, "mono_rconv_ovf_i8", FALSE);
-	register_opcode_emulation (OP_RCONV_TO_OVF_U8, "__emul_rconv_to_ovf_u8", mono_icall_sig_ulong_float, mono_rconv_ovf_u8, "mono_rconv_ovf_u8", FALSE);
+	register_opcode_emulation (OP_FCONV_TO_U8, __emul_fconv_to_u8, mono_icall_sig_ulong_double, mono_fconv_u8_2,FALSE);
+	register_opcode_emulation (OP_RCONV_TO_U8, __emul_rconv_to_u8, mono_icall_sig_ulong_float, mono_rconv_u8, FALSE);
+	register_opcode_emulation (OP_FCONV_TO_U4, __emul_fconv_to_u4, mono_icall_sig_uint32_double, mono_fconv_u4_2, FALSE);
+	register_opcode_emulation (OP_FCONV_TO_OVF_I8, __emul_fconv_to_ovf_i8, mono_icall_sig_long_double, mono_fconv_ovf_i8, FALSE);
+	register_opcode_emulation (OP_FCONV_TO_OVF_U8, __emul_fconv_to_ovf_u8, mono_icall_sig_ulong_double, mono_fconv_ovf_u8, FALSE);
+	register_opcode_emulation (OP_RCONV_TO_OVF_I8, __emul_rconv_to_ovf_i8, mono_icall_sig_long_float, mono_rconv_ovf_i8, FALSE);
+	register_opcode_emulation (OP_RCONV_TO_OVF_U8, __emul_rconv_to_ovf_u8, mono_icall_sig_ulong_float, mono_rconv_ovf_u8, FALSE);
 
 
 #ifdef MONO_ARCH_EMULATE_FCONV_TO_I8
-	register_opcode_emulation (OP_FCONV_TO_I8, "__emul_fconv_to_i8", mono_icall_sig_long_double, mono_fconv_i8, "mono_fconv_i8", FALSE);
-	register_opcode_emulation (OP_RCONV_TO_I8, "__emul_rconv_to_i8", mono_icall_sig_long_float, mono_rconv_i8, "mono_rconv_i8", FALSE);
+	register_opcode_emulation (OP_FCONV_TO_I8, __emul_fconv_to_i8, mono_icall_sig_long_double, mono_fconv_i8, FALSE);
+	register_opcode_emulation (OP_RCONV_TO_I8, __emul_rconv_to_i8, mono_icall_sig_long_float, mono_rconv_i8, FALSE);
 #endif
 
 #ifdef MONO_ARCH_EMULATE_CONV_R8_UN
-	register_opcode_emulation (OP_ICONV_TO_R_UN, "__emul_iconv_to_r_un", mono_icall_sig_double_int32, mono_conv_to_r8_un, "mono_conv_to_r8_un", FALSE);
+	register_opcode_emulation (OP_ICONV_TO_R_UN, __emul_iconv_to_r_un, mono_icall_sig_double_int32, mono_conv_to_r8_un, FALSE);
 #endif
 #ifdef MONO_ARCH_EMULATE_LCONV_TO_R8
-	register_opcode_emulation (OP_LCONV_TO_R8, "__emul_lconv_to_r8", mono_icall_sig_double_long, mono_lconv_to_r8, "mono_lconv_to_r8", FALSE);
+	register_opcode_emulation (OP_LCONV_TO_R8, __emul_lconv_to_r8, mono_icall_sig_double_long, mono_lconv_to_r8, FALSE);
 #endif
 #ifdef MONO_ARCH_EMULATE_LCONV_TO_R4
-	register_opcode_emulation (OP_LCONV_TO_R4, "__emul_lconv_to_r4", mono_icall_sig_float_long, mono_lconv_to_r4, "mono_lconv_to_r4", FALSE);
+	register_opcode_emulation (OP_LCONV_TO_R4, __emul_lconv_to_r4, mono_icall_sig_float_long, mono_lconv_to_r4, FALSE);
 #endif
 #ifdef MONO_ARCH_EMULATE_LCONV_TO_R8_UN
-	register_opcode_emulation (OP_LCONV_TO_R_UN, "__emul_lconv_to_r8_un", mono_icall_sig_double_long, mono_lconv_to_r8_un, "mono_lconv_to_r8_un", FALSE);
+	register_opcode_emulation (OP_LCONV_TO_R_UN, __emul_lconv_to_r8_un, mono_icall_sig_double_long, mono_lconv_to_r8_un, FALSE);
 #endif
 #ifdef MONO_ARCH_EMULATE_FREM
-	register_opcode_emulation (OP_FREM, "__emul_frem", mono_icall_sig_double_double_double, mono_fmod, "fmod", FALSE);
-	register_opcode_emulation (OP_RREM, "__emul_rrem", mono_icall_sig_float_float_float, fmodf, "fmodf", FALSE);
+	register_opcode_emulation (OP_FREM, __emul_frem, mono_icall_sig_double_double_double, mono_fmod, FALSE);
+	register_opcode_emulation (OP_RREM, __emul_rrem, mono_icall_sig_float_float_float, fmodf, FALSE);
 #endif
 
 #ifdef MONO_ARCH_SOFT_FLOAT_FALLBACK
 	if (mono_arch_is_soft_float ()) {
-		register_opcode_emulation (OP_FSUB, "__emul_fsub", mono_icall_sig_double_double_double, mono_fsub, "mono_fsub", FALSE);
-		register_opcode_emulation (OP_FADD, "__emul_fadd", mono_icall_sig_double_double_double, mono_fadd, "mono_fadd", FALSE);
-		register_opcode_emulation (OP_FMUL, "__emul_fmul", mono_icall_sig_double_double_double, mono_fmul, "mono_fmul", FALSE);
-		register_opcode_emulation (OP_FNEG, "__emul_fneg", mono_icall_sig_double_double, mono_fneg, "mono_fneg", FALSE);
-		register_opcode_emulation (OP_ICONV_TO_R8, "__emul_iconv_to_r8", mono_icall_sig_double_int32, mono_conv_to_r8, "mono_conv_to_r8", FALSE);
-		register_opcode_emulation (OP_ICONV_TO_R4, "__emul_iconv_to_r4", mono_icall_sig_double_int32, mono_conv_to_r4, "mono_conv_to_r4", FALSE);
-		register_opcode_emulation (OP_FCONV_TO_R4, "__emul_fconv_to_r4", mono_icall_sig_double_double, mono_fconv_r4, "mono_fconv_r4", FALSE);
-		register_opcode_emulation (OP_FCONV_TO_I1, "__emul_fconv_to_i1", mono_icall_sig_int8_double, mono_fconv_i1, "mono_fconv_i1", FALSE);
-		register_opcode_emulation (OP_FCONV_TO_I2, "__emul_fconv_to_i2", mono_icall_sig_int16_double, mono_fconv_i2, "mono_fconv_i2", FALSE);
-		register_opcode_emulation (OP_FCONV_TO_I4, "__emul_fconv_to_i4", mono_icall_sig_int32_double, mono_fconv_i4, "mono_fconv_i4", FALSE);
-		register_opcode_emulation (OP_FCONV_TO_U1, "__emul_fconv_to_u1", mono_icall_sig_uint8_double, mono_fconv_u1, "mono_fconv_u1", FALSE);
-		register_opcode_emulation (OP_FCONV_TO_U2, "__emul_fconv_to_u2", mono_icall_sig_uint16_double, mono_fconv_u2, "mono_fconv_u2", FALSE);
+		register_opcode_emulation (OP_FSUB, __emul_fsub, mono_icall_sig_double_double_double, mono_fsub, FALSE);
+		register_opcode_emulation (OP_FADD, __emul_fadd, mono_icall_sig_double_double_double, mono_fadd, FALSE);
+		register_opcode_emulation (OP_FMUL, __emul_fmul, mono_icall_sig_double_double_double, mono_fmul, FALSE);
+		register_opcode_emulation (OP_FNEG, __emul_fneg, mono_icall_sig_double_double, mono_fneg, FALSE);
+		register_opcode_emulation (OP_ICONV_TO_R8, __emul_iconv_to_r8, mono_icall_sig_double_int32, mono_conv_to_r8, FALSE);
+		register_opcode_emulation (OP_ICONV_TO_R4, __emul_iconv_to_r4, mono_icall_sig_double_int32, mono_conv_to_r4, FALSE);
+		register_opcode_emulation (OP_FCONV_TO_R4, __emul_fconv_to_r4, mono_icall_sig_double_double, mono_fconv_r4, FALSE);
+		register_opcode_emulation (OP_FCONV_TO_I1, __emul_fconv_to_i1, mono_icall_sig_int8_double, mono_fconv_i1, FALSE);
+		register_opcode_emulation (OP_FCONV_TO_I2, __emul_fconv_to_i2, mono_icall_sig_int16_double, mono_fconv_i2, FALSE);
+		register_opcode_emulation (OP_FCONV_TO_I4, __emul_fconv_to_i4, mono_icall_sig_int32_double, mono_fconv_i4, FALSE);
+		register_opcode_emulation (OP_FCONV_TO_U1, __emul_fconv_to_u1, mono_icall_sig_uint8_double, mono_fconv_u1, FALSE);
+		register_opcode_emulation (OP_FCONV_TO_U2, __emul_fconv_to_u2, mono_icall_sig_uint16_double, mono_fconv_u2, FALSE);
 
 #if TARGET_SIZEOF_VOID_P == 4
-		register_opcode_emulation (OP_FCONV_TO_I, "__emul_fconv_to_i", mono_icall_sig_int32_double, mono_fconv_i4, "mono_fconv_i4", FALSE);
+		register_opcode_emulation (OP_FCONV_TO_I, __emul_fconv_to_i, mono_icall_sig_int32_double, mono_fconv_i4, FALSE);
 #endif
 
-		register_opcode_emulation (OP_FBEQ, "__emul_fcmp_eq", mono_icall_sig_uint32_double_double, mono_fcmp_eq, "mono_fcmp_eq", FALSE);
-		register_opcode_emulation (OP_FBLT, "__emul_fcmp_lt", mono_icall_sig_uint32_double_double, mono_fcmp_lt, "mono_fcmp_lt", FALSE);
-		register_opcode_emulation (OP_FBGT, "__emul_fcmp_gt", mono_icall_sig_uint32_double_double, mono_fcmp_gt, "mono_fcmp_gt", FALSE);
-		register_opcode_emulation (OP_FBLE, "__emul_fcmp_le", mono_icall_sig_uint32_double_double, mono_fcmp_le, "mono_fcmp_le", FALSE);
-		register_opcode_emulation (OP_FBGE, "__emul_fcmp_ge", mono_icall_sig_uint32_double_double, mono_fcmp_ge, "mono_fcmp_ge", FALSE);
-		register_opcode_emulation (OP_FBNE_UN, "__emul_fcmp_ne_un", mono_icall_sig_uint32_double_double, mono_fcmp_ne_un, "mono_fcmp_ne_un", FALSE);
-		register_opcode_emulation (OP_FBLT_UN, "__emul_fcmp_lt_un", mono_icall_sig_uint32_double_double, mono_fcmp_lt_un, "mono_fcmp_lt_un", FALSE);
-		register_opcode_emulation (OP_FBGT_UN, "__emul_fcmp_gt_un", mono_icall_sig_uint32_double_double, mono_fcmp_gt_un, "mono_fcmp_gt_un", FALSE);
-		register_opcode_emulation (OP_FBLE_UN, "__emul_fcmp_le_un", mono_icall_sig_uint32_double_double, mono_fcmp_le_un, "mono_fcmp_le_un", FALSE);
-		register_opcode_emulation (OP_FBGE_UN, "__emul_fcmp_ge_un", mono_icall_sig_uint32_double_double, mono_fcmp_ge_un, "mono_fcmp_ge_un", FALSE);
+		register_opcode_emulation (OP_FBEQ, __emul_fcmp_eq, mono_icall_sig_uint32_double_double, mono_fcmp_eq, FALSE);
+		register_opcode_emulation (OP_FBLT, __emul_fcmp_lt, mono_icall_sig_uint32_double_double, mono_fcmp_lt, FALSE);
+		register_opcode_emulation (OP_FBGT, __emul_fcmp_gt, mono_icall_sig_uint32_double_double, mono_fcmp_gt, FALSE);
+		register_opcode_emulation (OP_FBLE, __emul_fcmp_le, mono_icall_sig_uint32_double_double, mono_fcmp_le, FALSE);
+		register_opcode_emulation (OP_FBGE, __emul_fcmp_ge, mono_icall_sig_uint32_double_double, mono_fcmp_ge, FALSE);
+		register_opcode_emulation (OP_FBNE_UN, __emul_fcmp_ne_un, mono_icall_sig_uint32_double_double, mono_fcmp_ne_un, FALSE);
+		register_opcode_emulation (OP_FBLT_UN, __emul_fcmp_lt_un, mono_icall_sig_uint32_double_double, mono_fcmp_lt_un, FALSE);
+		register_opcode_emulation (OP_FBGT_UN, __emul_fcmp_gt_un, mono_icall_sig_uint32_double_double, mono_fcmp_gt_un, FALSE);
+		register_opcode_emulation (OP_FBLE_UN, __emul_fcmp_le_un, mono_icall_sig_uint32_double_double, mono_fcmp_le_un, FALSE);
+		register_opcode_emulation (OP_FBGE_UN, __emul_fcmp_ge_un, mono_icall_sig_uint32_double_double, mono_fcmp_ge_un, FALSE);
 
-		register_opcode_emulation (OP_FCEQ, "__emul_fcmp_ceq", mono_icall_sig_uint32_double_double, mono_fceq, "mono_fceq", FALSE);
-		register_opcode_emulation (OP_FCGT, "__emul_fcmp_cgt", mono_icall_sig_uint32_double_double, mono_fcgt, "mono_fcgt", FALSE);
-		register_opcode_emulation (OP_FCGT_UN, "__emul_fcmp_cgt_un", mono_icall_sig_uint32_double_double, mono_fcgt_un, "mono_fcgt_un", FALSE);
-		register_opcode_emulation (OP_FCLT, "__emul_fcmp_clt", mono_icall_sig_uint32_double_double, mono_fclt, "mono_fclt", FALSE);
-		register_opcode_emulation (OP_FCLT_UN, "__emul_fcmp_clt_un", mono_icall_sig_uint32_double_double, mono_fclt_un, "mono_fclt_un", FALSE);
+		register_opcode_emulation (OP_FCEQ, __emul_fcmp_ceq, mono_icall_sig_uint32_double_double, mono_fceq, FALSE);
+		register_opcode_emulation (OP_FCGT, __emul_fcmp_cgt, mono_icall_sig_uint32_double_double, mono_fcgt, FALSE);
+		register_opcode_emulation (OP_FCGT_UN, __emul_fcmp_cgt_un, mono_icall_sig_uint32_double_double, mono_fcgt_un, FALSE);
+		register_opcode_emulation (OP_FCLT, __emul_fcmp_clt, mono_icall_sig_uint32_double_double, mono_fclt, FALSE);
+		register_opcode_emulation (OP_FCLT_UN, __emul_fcmp_clt_un, mono_icall_sig_uint32_double_double, mono_fclt_un, FALSE);
 
 		register_icall (mono_fload_r4, "mono_fload_r4", mono_icall_sig_double_ptr, FALSE);
 		register_icall (mono_fstore_r4, "mono_fstore_r4", mono_icall_sig_void_double_ptr, FALSE);
@@ -4572,10 +4615,11 @@ register_icalls (void)
 	register_icall (mono_class_interface_match, "mono_class_interface_match", mono_icall_sig_uint32_ptr_int32, TRUE);
 #endif
 
+	// FIXME Elsewhere these are registered with no_wrapper = FALSE
 #if SIZEOF_REGISTER == 4
-	register_opcode_emulation (OP_FCONV_TO_U, "__emul_fconv_to_u", mono_icall_sig_uint32_double, mono_fconv_u4, "mono_fconv_u4", TRUE);
+	register_opcode_emulation (OP_FCONV_TO_U, __emul_fconv_to_u, mono_icall_sig_uint32_double, mono_fconv_u4, TRUE);
 #else
-	register_opcode_emulation (OP_FCONV_TO_U, "__emul_fconv_to_u", mono_icall_sig_ulong_double, mono_fconv_u8, "mono_fconv_u8", TRUE);
+	register_opcode_emulation (OP_FCONV_TO_U, __emul_fconv_to_u, mono_icall_sig_ulong_double, mono_fconv_u8, TRUE);
 #endif
 
 	/* other jit icalls */
@@ -4618,7 +4662,8 @@ register_icalls (void)
 	register_icall (mono_gsharedvt_value_copy, "mono_gsharedvt_value_copy", mono_icall_sig_void_ptr_ptr_ptr, TRUE);
 
 	//WARNING We do runtime selection here but the string *MUST* be to a fallback function that has same signature and behavior
-	register_icall_no_wrapper (mono_gc_get_range_copy_func (), "mono_gc_wbarrier_range_copy", mono_icall_sig_void_ptr_ptr_int);
+	const MonoRangeCopyFunction mono_gc_wbarrier_range_copy = mono_gc_get_range_copy_func ();
+	register_icall_no_wrapper (mono_gc_wbarrier_range_copy, "mono_gc_wbarrier_range_copy", mono_icall_sig_void_ptr_ptr_int);
 
 	register_icall (mono_object_castclass_with_cache, "mono_object_castclass_with_cache", mono_icall_sig_object_object_ptr_ptr, FALSE);
 	register_icall (mono_object_isinst_with_cache, "mono_object_isinst_with_cache", mono_icall_sig_object_object_ptr_ptr, FALSE);
@@ -4626,7 +4671,7 @@ register_icalls (void)
 	register_icall (mono_fill_class_rgctx, "mono_fill_class_rgctx", mono_icall_sig_ptr_ptr_int, FALSE);
 	register_icall (mono_fill_method_rgctx, "mono_fill_method_rgctx", mono_icall_sig_ptr_ptr_int, FALSE);
 
-	register_dyn_icall (mini_get_dbg_callbacks ()->user_break, "mono_debugger_agent_user_break", mono_icall_sig_void, FALSE);
+	register_dyn_icall (mini_get_dbg_callbacks ()->user_break, mono_debugger_agent_user_break, mono_icall_sig_void, FALSE);
 
 	register_icall (mini_llvm_init_method, "mini_llvm_init_method", mono_icall_sig_void_ptr_int, TRUE);
 	register_icall (mini_llvm_init_gshared_method_this, "mini_llvm_init_gshared_method_this", mono_icall_sig_void_ptr_int_object, TRUE);

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -342,6 +342,7 @@ struct MonoJumpInfo {
 		MonoDelegateClassMethodPair *del_tramp;
 		/* MONO_PATCH_INFO_VIRT_METHOD */
 		MonoJumpInfoVirtMethod *virt_method;
+		MonoJitICallInfo *icall_info;
 	} data;
 };
 
@@ -434,8 +435,8 @@ MONO_API int       mono_parse_default_optimizations  (const char* p);
 gboolean          mono_running_on_valgrind (void);
 
 MonoLMF * mono_get_lmf                      (void);
-#define mono_get_lmf_addr mono_tls_get_lmf_addr
-MonoLMF** mono_get_lmf_addr                 (void);
+MonoLMF** mono_get_lmf_addr                 (void); // mono_get_lmf_addr and mono_tls_get_lmf_addr are the same thing
+MonoLMF** mono_tls_get_lmf_addr				(void); // mono_get_lmf_addr and mono_tls_get_lmf_addr are the same thing
 void      mono_set_lmf                      (MonoLMF *lmf);
 void      mono_push_lmf                     (MonoLMFExt *ext);
 void      mono_pop_lmf                      (MonoLMF *lmf);

--- a/mono/mini/mini-sparc.c
+++ b/mono/mini/mini-sparc.c
@@ -37,6 +37,7 @@
 #include "cpu-sparc.h"
 #include "jit-icalls.h"
 #include "ir-emit.h"
+#include "mono/metadata/register-icall-def.h"
 
 /*
  * Sparc V9 means two things:
@@ -3059,14 +3060,14 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		}
 		case OP_THROW:
 			sparc_mov_reg_reg (code, ins->sreg1, sparc_o0);
-			mono_add_patch_info (cfg, (guint8*)code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL, 
-					     (gpointer)"mono_arch_throw_exception");
+			mono_add_patch_info (cfg, (guint8*)code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL_INFO,
+					     &mono_jit_icall_info.mono_arch_throw_exception);
 			EMIT_CALL ();
 			break;
 		case OP_RETHROW:
 			sparc_mov_reg_reg (code, ins->sreg1, sparc_o0);
-			mono_add_patch_info (cfg, (guint8*)code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL, 
-					     (gpointer)"mono_arch_rethrow_exception");
+			mono_add_patch_info (cfg, (guint8*)code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL_INFO,
+					     &mono_jit_icall_info.mono_arch_rethrow_exception;
 			EMIT_CALL ();
 			break;
 		case OP_START_HANDLER: {
@@ -4067,8 +4068,8 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 		sparc_set (code, cfg->method, sparc_o7);
 		sparc_sti_imm (code, sparc_o7, sparc_fp, lmf_offset + G_STRUCT_OFFSET (MonoLMF, method));
 
-		mono_add_patch_info (cfg, (guint8*)code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL, 
-							 (gpointer)"mono_arch_get_lmf_addr");		
+		mono_add_patch_info (cfg, (guint8*)code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL_INFO,
+							 &mono_jit_icall_info.mono_arch_get_lmf_addr;		
 		EMIT_CALL ();
 
 		code = (guint32*)mono_sparc_emit_save_lmf (code, lmf_offset);
@@ -4248,8 +4249,8 @@ mono_arch_emit_exceptions (MonoCompile *cfg)
 					nthrows ++;
 				}
 
-				patch_info->data.name = "mono_arch_throw_corlib_exception";
-				patch_info->type = MONO_PATCH_INFO_JIT_ICALL;
+				patch_info->data.name = &mono_jit_icall_info.mono_arch_throw_corlib_exception;
+				patch_info->type = MONO_PATCH_INFO_JIT_ICALL_INFO;
 				patch_info->ip.i = (guint8*)code - cfg->native_code;
 
 				EMIT_CALL ();

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -40,6 +40,7 @@
 #include "mini-gc.h"
 #include "aot-runtime.h"
 #include "mini-runtime.h"
+#include "mono/metadata/register-icall-def.h"
 
 #ifndef TARGET_WIN32
 #ifdef MONO_XEN_OPT
@@ -3161,8 +3162,8 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_THROW: {
 			x86_alu_reg_imm (code, X86_SUB, X86_ESP, MONO_ARCH_FRAME_ALIGNMENT - 4);
 			x86_push_reg (code, ins->sreg1);
-			code = emit_call (cfg, code, MONO_PATCH_INFO_JIT_ICALL, 
-							  (gpointer)"mono_arch_throw_exception");
+			code = emit_call (cfg, code, MONO_PATCH_INFO_JIT_ICALL_INFO,
+							  &mono_jit_icall_info.mono_arch_throw_exception);
 			ins->flags |= MONO_INST_GC_CALLSITE;
 			ins->backend.pc_offset = code - cfg->native_code;
 			break;
@@ -3170,8 +3171,8 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_RETHROW: {
 			x86_alu_reg_imm (code, X86_SUB, X86_ESP, MONO_ARCH_FRAME_ALIGNMENT - 4);
 			x86_push_reg (code, ins->sreg1);
-			code = emit_call (cfg, code, MONO_PATCH_INFO_JIT_ICALL, 
-							  (gpointer)"mono_arch_rethrow_exception");
+			code = emit_call (cfg, code, MONO_PATCH_INFO_JIT_ICALL_INFO,
+							  &mono_jit_icall_info.mono_arch_rethrow_exception);
 			ins->flags |= MONO_INST_GC_CALLSITE;
 			ins->backend.pc_offset = code - cfg->native_code;
 			break;
@@ -4835,7 +4836,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 
 			x86_test_membase_imm (code, ins->sreg1, 0, 1);
 			br[0] = code; x86_branch8 (code, X86_CC_EQ, 0, FALSE);
-			code = emit_call (cfg, code, MONO_PATCH_INFO_JIT_ICALL, "mono_threads_state_poll");
+			code = emit_call (cfg, code, MONO_PATCH_INFO_JIT_ICALL_INFO, &mono_jit_icall_info.mono_threads_state_poll);
 			x86_patch (br [0], code);
 
 			break;
@@ -4895,10 +4896,12 @@ mono_arch_patch_code_new (MonoCompile *cfg, MonoDomain *domain, guint8 *code, Mo
 	case MONO_PATCH_INFO_IP:
 		*((gconstpointer *)(ip)) = target;
 		break;
+	case MONO_PATCH_INFO_JIT_ICALL:
+		g_assert (!"MONO_PATCH_INFO_JIT_ICALL");
 	case MONO_PATCH_INFO_ABS:
 	case MONO_PATCH_INFO_METHOD:
 	case MONO_PATCH_INFO_METHOD_JUMP:
-	case MONO_PATCH_INFO_JIT_ICALL:
+	case MONO_PATCH_INFO_JIT_ICALL_INFO:
 	case MONO_PATCH_INFO_BB:
 	case MONO_PATCH_INFO_LABEL:
 	case MONO_PATCH_INFO_RGCTX_FETCH:
@@ -5336,8 +5339,8 @@ mono_arch_emit_exceptions (MonoCompile *cfg)
 				}
 
 				x86_push_imm (code, m_class_get_type_token (exc_class) - MONO_TOKEN_TYPE_DEF);
-				patch_info->data.name = "mono_arch_throw_corlib_exception";
-				patch_info->type = MONO_PATCH_INFO_JIT_ICALL;
+				patch_info->data.icall_info = &mono_jit_icall_info.mono_arch_throw_corlib_exception;
+				patch_info->type = MONO_PATCH_INFO_JIT_ICALL_INFO;
 				patch_info->ip.i = code - cfg->native_code;
 				x86_call_code (code, 0);
 				x86_push_imm (buf, (code - cfg->native_code) - throw_ip);

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -81,6 +81,7 @@
 #include "lldb.h"
 #include "aot-runtime.h"
 #include "mini-runtime.h"
+#include "mono/metadata/register-icall-def.h"
 
 MonoCallSpec *mono_jit_trace_calls;
 MonoMethodDesc *mono_inject_async_exc_method;
@@ -1666,15 +1667,14 @@ mono_find_jit_opcode_emulation (int opcode)
 }
 
 void
-mini_register_opcode_emulation (int opcode, const char *name, MonoMethodSignature *sig, gpointer func, const char *symbol, gboolean no_wrapper)
+mini_register_opcode_emulation_info (int opcode, MonoJitICallInfo *info, const char *name, MonoMethodSignature *sig, gpointer func, const char *symbol, gboolean no_wrapper)
 {
-	MonoJitICallInfo *info;
-
 	g_assert (!sig->hasthis);
 	g_assert (sig->param_count < 3);
 
-	info = mono_register_jit_icall_full (func, name, sig, no_wrapper, symbol);
+	info = mono_register_jit_icall_info_full (info, func, name, sig, no_wrapper, symbol);
 
+//FIXME #ifndef DISABLE_JIT
 	if (emul_opcode_num >= emul_opcode_alloced) {
 		int incr = emul_opcode_alloced? emul_opcode_alloced/2: 16;
 		emul_opcode_alloced += incr;
@@ -1685,6 +1685,7 @@ mini_register_opcode_emulation (int opcode, const char *name, MonoMethodSignatur
 	emul_opcode_opcodes [emul_opcode_num] = opcode;
 	emul_opcode_num++;
 	emul_opcode_hit_cache [opcode >> (EMUL_HIT_SHIFT + 3)] |= (1 << (opcode & EMUL_HIT_MASK));
+//FIXME #endif
 }
 
 static void
@@ -2079,8 +2080,8 @@ mono_postprocess_patches (MonoCompile *cfg)
 			 * absolute address.
 			 */
 			if (info) {
-				patch_info->type = MONO_PATCH_INFO_JIT_ICALL;
-				patch_info->data.name = info->name;
+				patch_info->type = MONO_PATCH_INFO_JIT_ICALL_INFO;
+				patch_info->data.icall_info = info;
 			}
 
 			if (patch_info->type == MONO_PATCH_INFO_ABS) {
@@ -2859,9 +2860,9 @@ insert_safepoints (MonoCompile *cfg)
 		WrapperInfo *info = mono_marshal_get_wrapper_info (cfg->method);
 		/* These wrappers are called from the wrapper for the polling function, leading to potential stack overflow */
 		if (info && info->subtype == WRAPPER_SUBTYPE_ICALL_WRAPPER &&
-				(info->d.icall.func == mono_threads_state_poll ||
-				 info->d.icall.func == mono_thread_interruption_checkpoint ||
-				 info->d.icall.func == mono_threads_exit_gc_safe_region_unbalanced)) {
+				(info->d.icall_info == &mono_jit_icall_info.mono_threads_state_poll ||
+				 info->d.icall_info == &mono_jit_icall_info.mono_thread_interruption_checkpoint ||
+				 info->d.icall_info == &mono_jit_icall_info.mono_threads_exit_gc_safe_region_unbalanced)) {
 			if (cfg->verbose_level > 1)
 				printf ("SKIPPING SAFEPOINTS for the polling function icall\n");
 			return;

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2102,14 +2102,14 @@ void      mono_add_ins_to_end               (MonoBasicBlock *bb, MonoInst *inst)
 
 void      mono_replace_ins                  (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins, MonoInst **prev, MonoBasicBlock *first_bb, MonoBasicBlock *last_bb);
 
-void              mini_register_opcode_emulation (int opcode, const char *name, MonoMethodSignature *sig, gpointer func, const char *symbol, gboolean no_throw);
+void     mini_register_opcode_emulation_info (int opcode, MonoJitICallInfo *jit_icall_info, const char* name, MonoMethodSignature *sig, gpointer func, const char *symbol, gboolean no_throw);
 
 #ifdef __cplusplus
 template <typename T>
 inline void
-mini_register_opcode_emulation (int opcode, const char *name, MonoMethodSignature *sig, T func, const char *symbol, gboolean no_throw)
+mini_register_opcode_emulation_info (int opcode, MonoJitICallInfo *jit_icall_info, const char* name, MonoMethodSignature *sig, T func, gboolean no_throw)
 {
-	mini_register_opcode_emulation (opcode, name, sig, (gpointer)func, symbol, no_throw);
+	mini_register_opcode_emulation_info (opcode, jit_icall_info, name, sig, (gpointer)func, no_throw);
 }
 #endif // __cplusplus
 
@@ -2720,7 +2720,7 @@ gboolean mini_gsharedvt_runtime_invoke_supported (MonoMethodSignature *sig);
 G_EXTERN_C void mono_interp_entry_from_trampoline (gpointer ccontext, gpointer imethod);
 G_EXTERN_C void mono_interp_to_native_trampoline (gpointer addr, gpointer ccontext);
 MonoMethod* mini_get_interp_in_wrapper (MonoMethodSignature *sig);
-MonoMethod* mini_get_interp_lmf_wrapper (const char *name, gpointer target);
+MonoMethod* mini_get_interp_lmf_wrapper (MonoJitICallInfo *jit_icall_info);
 char* mono_get_method_from_ip (void *ip);
 
 /* SIMD support */

--- a/mono/mini/patch-info.h
+++ b/mono/mini/patch-info.h
@@ -6,7 +6,9 @@ PATCH_INFO(METHOD_JUMP, "method_jump")
 PATCH_INFO(METHOD_REL, "method_rel")
 PATCH_INFO(METHODCONST, "methodconst")
 /* Either the address of a C function implementing a JIT icall, or a wrapper around it */
+// jit_icall is no longer used and has been replaced by jit_icall_info.
 PATCH_INFO(JIT_ICALL, "jit_icall")
+PATCH_INFO(JIT_ICALL_INFO, "jit_icall_info")
 PATCH_INFO(SWITCH, "switch")
 PATCH_INFO(EXC, "exc")
 PATCH_INFO(EXC_NAME, "exc_name")

--- a/mono/utils/mono-tls.c
+++ b/mono/utils/mono-tls.c
@@ -338,9 +338,16 @@ SgenThreadInfo *mono_tls_get_sgen_thread_info (void)
 	return (SgenThreadInfo*)MONO_TLS_GET_VALUE (mono_tls_sgen_thread_info, mono_tls_key_sgen_thread_info);
 }
 
+#define MONO_GET_LMF_ADDR() ((MonoLMF**)MONO_TLS_GET_VALUE (mono_tls_lmf_addr, mono_tls_key_lmf_addr))
+
 MonoLMF **mono_tls_get_lmf_addr (void)
 {
-	return (MonoLMF**)MONO_TLS_GET_VALUE (mono_tls_lmf_addr, mono_tls_key_lmf_addr);
+	return MONO_GET_LMF_ADDR();
+}
+
+MonoLMF **mono_get_lmf_addr (void)
+{
+	return MONO_GET_LMF_ADDR();
 }
 
 /* Setters for each tls key */

--- a/msvc/libmonoruntime-common.targets
+++ b/msvc/libmonoruntime-common.targets
@@ -106,6 +106,8 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\opcodes.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\property-bag.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\property-bag.c" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\register-icall-def.h" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\register-icall-def.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32socket.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32socket.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32socket-internals.h" />

--- a/msvc/libmonoruntime-common.targets.filters
+++ b/msvc/libmonoruntime-common.targets.filters
@@ -301,6 +301,12 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\property-bag.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common</Filter>
     </ClCompile>
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\register-icall-def.h">
+      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common</Filter>
+    </ClInclude>
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\register-icall-def.c">
+      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common</Filter>
+    </ClCompile>
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32socket.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common</Filter>
     </ClCompile>


### PR DESCRIPTION
[Do not merge][work in progress]

Per https://github.com/mono/mono/pull/11941#issuecomment-449157323.
The hash inserts remain, since some hash lookups remain but it is a good start.

Replace MONO_PATCH_INFO_JIT_ICALL with MONO_PATCH_INFO_JIT_ICALL_INFO.
MONO_PATCH_INFO_JIT_ICALL remains only in asserts and can be later removed.
There remain other string-based icall patch enums, this is only one
of two or a few.

It might help to replace or augment the pointers with an enum, particularly for ilgen and aot, as those still use the hashes. It'd be almost as good as pointer, and in some places better -- ilgen and esp. aot.

I had almost finished the enum approach, but got hung up on ICALL_ADDR and ICALL_ADDR_NOCALL, which are not handled here anyway. That is, the more common ICALL should probably change to enum, leave ICALL_ADDR[_NOCALL] as strings, at least in ilgen/aot, maybe they can be enum in some places. Their problem is at some dynamic strings are formed like for vtable slots and other cases.

This was originally written a few months ago (at the time of the PR comment).