### PR TITLE
[2019-02] [llvm] Fix the computation of size of gshared instances in emit_args_to_vtype ().

### DIFF
--- a/mono/mini/generics.cs
+++ b/mono/mini/generics.cs
@@ -1448,6 +1448,20 @@ class Tests
 		var res = builder.Caller (ref awaiter);
 		return res == typeof (bool) ? 0 : 1;
 	}
+
+	struct OneThing<T1> {
+		public T1 Item1;
+	}
+
+	[MethodImpl (MethodImplOptions.NoInlining)]
+	static T FromResult<T> (T result) {
+		return result;
+	}
+
+	public static int test_42_llvm_gsharedvt_small_vtype_in_regs () {
+		var t = FromResult<OneThing<int>>(new OneThing<int> {Item1 = 42});
+		return t.Item1;
+	}
 }
 
 #if !__MOBILE__

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -2341,12 +2341,14 @@ static void
 emit_args_to_vtype (EmitContext *ctx, LLVMBuilderRef builder, MonoType *t, LLVMValueRef address, LLVMArgInfo *ainfo, LLVMValueRef *args)
 {
 	int j, size, nslots;
+	MonoClass *klass;
 
-	size = mono_class_value_size (mono_class_from_mono_type_internal (t), NULL);
+	t = mini_get_underlying_type (t);
+	klass = mono_class_from_mono_type_internal (t);
+	size = mono_class_value_size (klass, NULL);
 
-	if (MONO_CLASS_IS_SIMD (ctx->cfg, mono_class_from_mono_type_internal (t))) {
+	if (MONO_CLASS_IS_SIMD (ctx->cfg, klass))
 		address = LLVMBuildBitCast (ctx->builder, address, LLVMPointerType (LLVMInt8Type (), 0), "");
-	}
 
 	if (ainfo->storage == LLVMArgAsFpArgs)
 		nslots = ainfo->nslots;
@@ -2367,7 +2369,7 @@ emit_args_to_vtype (EmitContext *ctx, LLVMBuilderRef builder, MonoType *t, LLVMV
 		switch (ainfo->pair_storage [j]) {
 		case LLVMArgInIReg: {
 			part_type = LLVMIntType (part_size * 8);
-			if (MONO_CLASS_IS_SIMD (ctx->cfg, mono_class_from_mono_type_internal (t))) {
+			if (MONO_CLASS_IS_SIMD (ctx->cfg, klass)) {
 				index [0] = LLVMConstInt (LLVMInt32Type (), j * TARGET_SIZEOF_VOID_P, FALSE);
 				addr = LLVMBuildGEP (builder, address, index, 1, "");
 			} else {

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -622,7 +622,7 @@ typedef struct {
 	LLVMArgStorage storage;
 
 	/*
-	 * Only if storage == ArgValuetypeInReg/LLVMArgAsFpArgs.
+	 * Only if storage == ArgVtypeInReg/LLVMArgAsFpArgs.
 	 * This contains how the parts of the vtype are passed.
 	 */
 	LLVMArgStorage pair_storage [8];


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/13610.

Backport of #13659.

/cc @lambdageek @vargaz