### PR TITLE
Runtime nupkg generation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -158,12 +158,13 @@ case "$host" in
 			fi
 		fi
 		HOST_CC="gcc"
-
+		RID="win-x86"
 		# Boehm not supported on 64-bit Windows.
 		case "$host" in
 		x86_64-*-* | amd64-*-*)
 			support_boehm=no
 			with_gc=sgen
+			RID="win-x64"
 			;;
 		esac
 
@@ -317,9 +318,30 @@ case "$host" in
 			;;
 		esac
 		case "$host" in
+		ppc64-*)
+			RID="linux-ppc64"
+			;;
+		ppc64le-*)
+			RID="linux-ppc64el"
+			;;
+		mipsel-*)
+			RID="linux-mipsel"
+			;;
+		x86-*)
+			RID="linux-x86"
+			;;
+		x86_64-*)
+			RID="linux-x64"
+			;;
+		arm-*)
+			# deal with this in the FPU detection section, since
+			# we cannot determine FPU from triplet and don't want
+			# to duplicate the logic
+			;;
 		aarch64-*)
 			support_boehm=no
 			with_gc=sgen
+			RID="linux-arm64"
 			;;
 		powerpc*-*-linux*)
 			# https://bugzilla.novell.com/show_bug.cgi?id=504411
@@ -393,9 +415,11 @@ case "$host" in
 				CPPFLAGS_FOR_LIBGC="$CPPFLAGS_FOR_LIBGC $BROKEN_DARWIN_CPPFLAGS"
 				CFLAGS_FOR_LIBGC="$CFLAGS_FOR_LIBGC $BROKEN_DARWIN_FLAGS"
 				with_sgen_default_concurrent=yes
+				RID="osx-x86"
 				;;
 			x*64-*-darwin*)
 				with_sgen_default_concurrent=yes
+				RID="osx-x64"
 				;;
 			arm*-darwin*)
 				platform_ios=yes
@@ -454,6 +478,7 @@ case "$host" in
 		with_tls=pthread
 		dnl ppc Linux is the same? test further
 		disable_munmap=yes
+		RID="aix-ppc64"
 		;;
 	*)
 		AC_MSG_WARN([*** Please add $host to configure.ac checks!])
@@ -5198,7 +5223,16 @@ if test ${TARGET} = ARM; then
 		AC_DEFINE(HAVE_ARMV7, 1, [ARM v7])
 		CPPFLAGS_FOR_LIBGC="$CPPFLAGS_FOR_LIBGC -DHAVE_ARMV7=1"
 	fi
+
+	if test x$host_linux = xyes; then
+		RID="linux-arm"
+		if test x$fpu = xNONE; then
+			RID="linux-armel"
+		fi
+	fi
 fi
+
+AC_SUBST(RID)
 
 if test ${TARGET} = RISCV32 -o ${TARGET} = RISCV64; then
 	AC_ARG_WITH([riscv-fpabi], [  --with-riscv-fpabi=auto,double,soft   Select RISC-V floating point ABI (auto)], [fpabi=$withval], [fpabi=double])

--- a/configure.ac
+++ b/configure.ac
@@ -6392,6 +6392,7 @@ mono/profiler/Makefile
 mono/eglib/Makefile
 mono/eglib/eglib-config.h
 mono/eglib/test/Makefile
+netcore/Makefile
 m4/Makefile
 ikvm-native/Makefile
 scripts/Makefile

--- a/netcore/Makefile.am
+++ b/netcore/Makefile.am
@@ -32,7 +32,7 @@ link-mono:
 prepare: $(NETCORESDK_FILE) link-mono
 
 nupkg:
-	nuget pack runtime.nuspec -properties VERSION=@VERSION@\;RID=osx-x64\;PLATFORM_AOT_SUFFIX=@PLATFORM_AOT_SUFFIX@
+	nuget pack runtime.nuspec -properties VERSION=@VERSION@\;RID=@RID@\;PLATFORM_AOT_SUFFIX=@PLATFORM_AOT_SUFFIX@
 
 COREFX_BINDIR=$(COREFX_ROOT)/artifacts/bin
 

--- a/netcore/Makefile.am
+++ b/netcore/Makefile.am
@@ -31,6 +31,9 @@ link-mono:
 
 prepare: $(NETCORESDK_FILE) link-mono
 
+nupkg:
+	nuget pack runtime.nuspec -properties VERSION=@VERSION@\;RID=osx-x64\;PLATFORM_AOT_SUFFIX=@PLATFORM_AOT_SUFFIX@
+
 COREFX_BINDIR=$(COREFX_ROOT)/artifacts/bin
 
 check-env:

--- a/netcore/runtime.nuspec
+++ b/netcore/runtime.nuspec
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>runtime.$RID$.Microsoft.NETCore.Runtime.Mono</id>
+        <version>$VERSION$</version>
+        <description>Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+The Mono runtime, and the base library, called mscorlib. It includes the garbage collector, JIT compiler, base .NET data types and many low-level classes.</description>
+        <authors>Microsoft</authors>
+        <projectUrl>https://www.mono-project.com/</projectUrl>
+    </metadata>
+    <files>
+        <file src="..\mcs\class\System.Private.CoreLib\bin\x64\System.Private.CoreLib.dll" target="runtimes\$RID$\native" />
+        <file src="..\mono\mini\.libs\libmonosgen-2.0.$PLATFORM_AOT_SUFFIX$" target="runtimes\$RID$\native" />
+    </files>
+</package>


### PR DESCRIPTION
I changed the thing, so we can generate mono.nupkg runtime packages in the format consumed in core-setup. This isn't as immediately usable as the current makefile's "just squash Mono into a .zip", until some changes are made on the Core end (e.g. supporting `libmonosgen-2.0` in lieu of `libcoreclr`), but it's a starting point.