### PR TITLE
[corlib] Skip FileTest.LastWriteTimeSubMsCopy on older iOS Simulators

### DIFF
--- a/mcs/class/corlib/Test/System.IO/FileTest.cs
+++ b/mcs/class/corlib/Test/System.IO/FileTest.cs
@@ -1317,6 +1317,10 @@ namespace MonoTests.System.IO
 		[Test]
 		public void LastWriteTimeSubMsCopy ()
 		{
+#if MONOTOUCH
+			if (Version.TryParse (Environment.GetEnvironmentVariable ("SIMULATOR_RUNTIME_VERSION"), out Version simulatorVersion) && simulatorVersion.Major < 11 && new DriveInfo("/").DriveFormat == "apfs")
+				Assert.Inconclusive ("This test doesn't work on old iOS Simulator versions running on newer macOS with APFS.");
+#endif
 			string path = tmpFolder + Path.DirectorySeparatorChar + "lastWriteTimeSubMs";
 			if (File.Exists (path))
 				File.Delete (path);


### PR DESCRIPTION
When we switched to using the corefx System.IO.File implementation we also switched to an implementation that uses the `copyfile()` standard library call on macOS/iOS to copy files. This should preserve file metadata such as timestamps.

However there's a small edge case: when using an older version of the iOS Simulator < 11.0 the `copyfile()` call doesn't copy sub-second timestamps, presumably because older iOS ran on HFS which doesn't support that.
When we run this simulator on modern macOS which uses APFS and thus supports sub-second timestamps the origin file used for the test _does_ have sub-second timestamps and the test would fail.

We now skip the test in such environments.

PS: why did this not fail with the old Mono implementation? We used to always call utimes() on the destination file after copying to copy metadata, which in turn would update the file in the simulator host.
It doesn't seem worth it to replicate that behavior for this small edge case.
