### PR TITLE
Fix incorrect use of FreeHGlobal on Marshal UTF8 string test.

### DIFF
--- a/mcs/class/corlib/Test/System.Runtime.InteropServices/MarshalTest.cs
+++ b/mcs/class/corlib/Test/System.Runtime.InteropServices/MarshalTest.cs
@@ -197,7 +197,7 @@ namespace MonoTests.System.Runtime.InteropServices
 				if (srcString.Contains("\0"))
 					continue;
 
-				IntPtr ptrString = Marshal.StringToAllocatedMemoryUTF8(srcString);
+				IntPtr ptrString = Marshal.StringToCoTaskMemUTF8(srcString);
 				string retString = Marshal.PtrToStringUTF8(ptrString);
 
 				Assert.AreEqual (srcString, retString, "#" + i);
@@ -206,7 +206,7 @@ namespace MonoTests.System.Runtime.InteropServices
 					string retString2 = Marshal.PtrToStringUTF8(ptrString, srcString.Length - 1);
 					Assert.AreEqual (srcString.Substring(0, srcString.Length - 1), retString2, "#s" + i);
 				}
-				Marshal.FreeHGlobal(ptrString);
+				Marshal.ZeroFreeCoTaskMemUTF8 (ptrString);
 			}			
 		}
 		


### PR DESCRIPTION
Make sure the correct free method is called for strings allocated by StringToAllocatedMemoryUTF8 or StringToCoTaskMemUTF8, ZeroFreeCoTaskMemUTF8. Using incorrect free method will lead to heap corruption on platforms where CoTaskMem is backed by a different heap compared to HGlobal.

StringToAllocatedMemoryUTF8 has been renamed in corefx to StringToCoTaskMemUTF8, so switch to that method for allocation call.