### PR TITLE
[profiler] Add duration=NUM parameter to AOT profiler

### DIFF
--- a/man/mono-profilers.1
+++ b/man/mono-profilers.1
@@ -335,6 +335,9 @@ format.
 .SS Options
 The AOT profiler supports the following options:
 .TP
+\fBduration\fR=\fInum\fR
+Profile only NUM seconds of runtime and then write the data.
+.TP
 \fBhelp\fR
 Print usage instructions.
 .TP


### PR DESCRIPTION
It instructs the AOT profiler to write the data after NUM seconds
measured from runtime initialization.

Fixes: https://github.com/xamarin/xamarin-android/issues/2813