### PR TITLE
[mono] Don't try "open" handlers on iOS/Android in ves_icall_System_Diagnostics_Process_ShellExecuteEx_internal

### DIFF
--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -2022,6 +2022,12 @@ ves_icall_System_Diagnostics_Process_ShellExecuteEx_internal (MonoW32ProcessStar
 		goto done;
 
 	if (!ret) {
+
+#if defined(TARGET_IOS) || defined(TARGET_ANDROID)
+		// don't try the "open" handlers on iOS/Android, they don't exist there anyway
+		goto done;
+#endif
+
 		static char *handler;
 		static gunichar2 *handler_utf16;
 


### PR DESCRIPTION
When you use `Process.Start()` with `UseShellExecute=true` (which is the default on Mono/.NET Framework, but false on .NET Core) then we'd still try to first start the file directly, before falling back to trying the "open" handlers like xdg-open to launch the file.

Presumably we do this so that on mobile you can still start a process without needing to explicitly set `UseShellExecute=false`.

However we don't need to try the fallback on iOS/Android since the "open" handlers won't work there anyway.

This recently showed up on the Xamarin.iOS Mono 2019-02 integration where we started running the `System.Diagnostics.ProcessTest` suite and the `Start1_FileName_NotFound()` would fail at `#C6` because the native error code wasn't 2 (file not found) but 13 (invalid data). This is because it tried
to use `/usr/bin/open` which doesn't work of course so it got to the `mono_w32error_set_last (ERROR_INVALID_DATA)` on L2088.
