### PR TITLE
[llvm] Propagate nonnull attribute through LLVM IR

### DIFF
--- a/mcs/tools/linker/monolinker.csproj
+++ b/mcs/tools/linker/monolinker.csproj
@@ -61,6 +61,7 @@
     <Compile Include="..\..\..\external\linker\src\linker\Linker.Steps\OutputStep.cs" />
     <Compile Include="..\..\..\external\linker\src\linker\Linker.Steps\PreserveCalendarsStep.cs" />
     <Compile Include="..\..\..\external\linker\src\linker\Linker.Steps\PreserveDependencyLookupStep.cs" />
+    <Compile Include="..\..\..\external\linker\src\linker\Linker.Steps\ReflectionBlockedStep.cs" />
     <Compile Include="..\..\..\external\linker\src\linker\Linker.Steps\RegenerateGuidStep.cs" />
     <Compile Include="..\..\..\external\linker\src\linker\Linker.Steps\RemoveFeaturesStep.cs" />
     <Compile Include="..\..\..\external\linker\src\linker\Linker.Steps\RemoveSecurityStep.cs" />

--- a/mcs/tools/linker/monolinker.exe.sources
+++ b/mcs/tools/linker/monolinker.exe.sources
@@ -49,3 +49,5 @@
 ../../../external/linker/src/linker/Linker.Steps/PreserveCalendarsStep.cs
 ../../../external/linker/src/linker/Linker.Steps/CodeRewriterStep.cs
 ../../../external/linker/src/linker/Linker.Steps/RemoveFeaturesStep.cs
+../../../external/linker/src/linker/Linker.Steps/ReflectionBlockedStep.cs
+

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -4354,7 +4354,7 @@ add_gc_wrappers (MonoAotCompile *acfg)
 }
 
 static gboolean
-contains_cannot_specialize_attribute (MonoCustomAttrInfo *cattr)
+contains_disable_reflection_attribute (MonoCustomAttrInfo *cattr)
 {
 	for (int i = 0; i < cattr->num_attrs; ++i) {
 		MonoCustomAttrEntry *attr = &cattr->attrs [i];
@@ -4400,7 +4400,7 @@ mono_aot_can_specialize (MonoMethod *method)
 	if (!is_ok (cattr_error)) {
 		mono_error_cleanup (cattr_error);
 		goto cleanup_false;
-	} else if (cattr && contains_cannot_specialize_attribute (cattr)) {
+	} else if (cattr && contains_disable_reflection_attribute (cattr)) {
 		goto cleanup_true;
 	}
 
@@ -4409,7 +4409,7 @@ mono_aot_can_specialize (MonoMethod *method)
 	if (!is_ok (cattr_error)) {
 		mono_error_cleanup (cattr_error);
 		goto cleanup_false;
-	} else if (cattr && contains_cannot_specialize_attribute (cattr)) {
+	} else if (cattr && contains_disable_reflection_attribute (cattr)) {
 		goto cleanup_true;
 	} else {
 		goto cleanup_false;

--- a/mono/mini/aot-compiler.h
+++ b/mono/mini/aot-compiler.h
@@ -22,6 +22,7 @@ char*    mono_aot_get_plt_symbol            (MonoJumpInfoType type, gconstpointe
 char*    mono_aot_get_direct_call_symbol    (MonoJumpInfoType type, gconstpointer data) MONO_LLVM_INTERNAL;
 int      mono_aot_get_method_index          (MonoMethod *method) MONO_LLVM_INTERNAL;
 MonoJumpInfo* mono_aot_patch_info_dup       (MonoJumpInfo* ji) MONO_LLVM_INTERNAL;
+gboolean mono_aot_can_specialize (MonoMethod *method) MONO_LLVM_INTERNAL;
 
 #endif
 

--- a/mono/mini/mini-llvm-cpp.cpp
+++ b/mono/mini/mini-llvm-cpp.cpp
@@ -265,6 +265,19 @@ mono_llvm_set_func_nonnull_arg (LLVMValueRef func, int argNo)
 	unwrap<Function>(func)->addParamAttr (argNo, Attribute::NonNull);
 }
 
+LLVMValueRef *
+mono_llvm_call_args (LLVMValueRef calli)
+{
+	CallInst *call = unwrap<CallInst> (calli);
+	unsigned int numOperands = call->getNumArgOperands ();
+
+	LLVMValueRef *ret = g_malloc (sizeof (LLVMValueRef) * numOperands);
+	for (int i=0; i < numOperands; i++)
+		ret [i] = wrap (call->getArgOperand (i));
+
+	return ret;
+}
+
 void
 mono_llvm_set_call_notailcall (LLVMValueRef func)
 {

--- a/mono/mini/mini-llvm-cpp.cpp
+++ b/mono/mini/mini-llvm-cpp.cpp
@@ -254,6 +254,12 @@ mono_llvm_set_call_nonnull_arg (LLVMValueRef calli, int argNo)
 }
 
 void
+mono_llvm_set_call_nonnull_ret (LLVMValueRef calli)
+{
+	unwrap<CallInst>(calli)->addAttribute (AttributeList::ReturnIndex, Attribute::NonNull);
+}
+
+void
 mono_llvm_set_func_nonnull_arg (LLVMValueRef func, int argNo)
 {
 	unwrap<Function>(func)->addParamAttr (argNo, Attribute::NonNull);

--- a/mono/mini/mini-llvm-cpp.cpp
+++ b/mono/mini/mini-llvm-cpp.cpp
@@ -248,45 +248,56 @@ mono_llvm_set_preserveall_cc (LLVMValueRef func)
 void
 mono_llvm_set_call_preserveall_cc (LLVMValueRef wrapped_calli)
 {
+#if LLVM_API_VERSION > 100
 	Instruction *calli = unwrap<Instruction> (wrapped_calli);
 
 	if (isa<CallInst> (calli))
 		dyn_cast<CallInst>(calli)->setCallingConv (CallingConv::PreserveAll);
 	else
 		dyn_cast<InvokeInst>(calli)->setCallingConv (CallingConv::PreserveAll);
+#else
+	unwrap<CallInst>(wrapped_calli)->setCallingConv (CallingConv::PreserveAll);
+#endif
 }
 
 void
 mono_llvm_set_call_nonnull_arg (LLVMValueRef wrapped_calli, int argNo)
 {
+#if LLVM_API_VERSION > 100
 	Instruction *calli = unwrap<Instruction> (wrapped_calli);
 
 	if (isa<CallInst> (calli))
 		dyn_cast<CallInst>(calli)->addParamAttr (argNo, Attribute::NonNull);
 	else
 		dyn_cast<InvokeInst>(calli)->addParamAttr (argNo, Attribute::NonNull);
+#endif
 }
 
 void
 mono_llvm_set_call_nonnull_ret (LLVMValueRef wrapped_calli)
 {
+#if LLVM_API_VERSION > 100
 	Instruction *calli = unwrap<Instruction> (wrapped_calli);
 
 	if (isa<CallInst> (calli))
 		dyn_cast<CallInst>(calli)->addAttribute (AttributeList::ReturnIndex, Attribute::NonNull);
 	else
 		dyn_cast<InvokeInst>(calli)->addAttribute (AttributeList::ReturnIndex, Attribute::NonNull);
+#endif
 }
 
 void
 mono_llvm_set_func_nonnull_arg (LLVMValueRef func, int argNo)
 {
+#if LLVM_API_VERSION > 100
 	unwrap<Function>(func)->addParamAttr (argNo, Attribute::NonNull);
+#endif
 }
 
 gboolean
 mono_llvm_is_nonnull (LLVMValueRef wrapped)
 {
+#if LLVM_API_VERSION > 100
 	// Argument to function
 	Value *val = unwrap (wrapped);
 
@@ -313,6 +324,7 @@ mono_llvm_is_nonnull (LLVMValueRef wrapped)
 		}
 	}
 
+#endif
 	return FALSE;
 }
 

--- a/mono/mini/mini-llvm-cpp.cpp
+++ b/mono/mini/mini-llvm-cpp.cpp
@@ -309,12 +309,26 @@ mono_llvm_is_nonnull (LLVMValueRef wrapped)
 
 			return FALSE;
 		} else {
-			mono_llvm_dump_value(wrapped);
-			g_assert_not_reached ();
+			return FALSE;
 		}
 	}
 
 	return FALSE;
+}
+
+GSList *
+mono_llvm_calls_using (LLVMValueRef wrapped_local)
+{
+	GSList *usages = NULL;
+	Value *local = unwrap (wrapped_local);
+
+	for (User *U : local->users ()) {
+		if (isa<CallInst> (U) || isa<InvokeInst> (U)) {
+			usages = g_slist_prepend (usages, wrap (U));
+		}
+	}
+
+	return usages;
 }
 
 LLVMValueRef *

--- a/mono/mini/mini-llvm-cpp.cpp
+++ b/mono/mini/mini-llvm-cpp.cpp
@@ -248,6 +248,12 @@ mono_llvm_set_call_preserveall_cc (LLVMValueRef func)
 }
 
 void
+mono_llvm_set_call_nonnull_arg (LLVMValueRef calli, int argNo)
+{
+	unwrap<CallInst>(calli)->addParamAttr (argNo, Attribute::NonNull);
+}
+
+void
 mono_llvm_set_call_notailcall (LLVMValueRef func)
 {
 #if LLVM_API_VERSION > 100

--- a/mono/mini/mini-llvm-cpp.cpp
+++ b/mono/mini/mini-llvm-cpp.cpp
@@ -254,6 +254,12 @@ mono_llvm_set_call_nonnull_arg (LLVMValueRef calli, int argNo)
 }
 
 void
+mono_llvm_set_func_nonnull_arg (LLVMValueRef func, int argNo)
+{
+	unwrap<Function>(func)->addParamAttr (argNo, Attribute::NonNull);
+}
+
+void
 mono_llvm_set_call_notailcall (LLVMValueRef func)
 {
 #if LLVM_API_VERSION > 100

--- a/mono/mini/mini-llvm-cpp.cpp
+++ b/mono/mini/mini-llvm-cpp.cpp
@@ -322,9 +322,9 @@ mono_llvm_calls_using (LLVMValueRef wrapped_local)
 	GSList *usages = NULL;
 	Value *local = unwrap (wrapped_local);
 
-	for (User *U : local->users ()) {
-		if (isa<CallInst> (U) || isa<InvokeInst> (U)) {
-			usages = g_slist_prepend (usages, wrap (U));
+	for (User *user : local->users ()) {
+		if (isa<CallInst> (user) || isa<InvokeInst> (user)) {
+			usages = g_slist_prepend (usages, wrap (user));
 		}
 	}
 

--- a/mono/mini/mini-llvm-cpp.h
+++ b/mono/mini/mini-llvm-cpp.h
@@ -112,6 +112,9 @@ mono_llvm_set_call_nonnull_ret (LLVMValueRef calli);
 void
 mono_llvm_set_func_nonnull_arg (LLVMValueRef func, int argNo);
 
+GSList *
+mono_llvm_calls_using (LLVMValueRef wrapped_local);
+
 LLVMValueRef *
 mono_llvm_call_args (LLVMValueRef calli);
 

--- a/mono/mini/mini-llvm-cpp.h
+++ b/mono/mini/mini-llvm-cpp.h
@@ -107,6 +107,9 @@ void
 mono_llvm_set_call_nonnull_arg (LLVMValueRef calli, int argNo);
 
 void
+mono_llvm_set_func_nonnull_arg (LLVMValueRef func, int argNo);
+
+void
 mono_llvm_set_call_notailcall (LLVMValueRef call);
 
 void

--- a/mono/mini/mini-llvm-cpp.h
+++ b/mono/mini/mini-llvm-cpp.h
@@ -107,6 +107,9 @@ void
 mono_llvm_set_call_nonnull_arg (LLVMValueRef calli, int argNo);
 
 void
+mono_llvm_set_call_nonnull_ret (LLVMValueRef calli);
+
+void
 mono_llvm_set_func_nonnull_arg (LLVMValueRef func, int argNo);
 
 void

--- a/mono/mini/mini-llvm-cpp.h
+++ b/mono/mini/mini-llvm-cpp.h
@@ -115,6 +115,9 @@ mono_llvm_set_func_nonnull_arg (LLVMValueRef func, int argNo);
 LLVMValueRef *
 mono_llvm_call_args (LLVMValueRef calli);
 
+gboolean
+mono_llvm_is_nonnull (LLVMValueRef val);
+
 void
 mono_llvm_set_call_notailcall (LLVMValueRef call);
 

--- a/mono/mini/mini-llvm-cpp.h
+++ b/mono/mini/mini-llvm-cpp.h
@@ -112,6 +112,9 @@ mono_llvm_set_call_nonnull_ret (LLVMValueRef calli);
 void
 mono_llvm_set_func_nonnull_arg (LLVMValueRef func, int argNo);
 
+LLVMValueRef *
+mono_llvm_call_args (LLVMValueRef calli);
+
 void
 mono_llvm_set_call_notailcall (LLVMValueRef call);
 

--- a/mono/mini/mini-llvm-cpp.h
+++ b/mono/mini/mini-llvm-cpp.h
@@ -104,6 +104,9 @@ void
 mono_llvm_set_call_preserveall_cc (LLVMValueRef call);
 
 void
+mono_llvm_set_call_nonnull_arg (LLVMValueRef calli, int argNo);
+
+void
 mono_llvm_set_call_notailcall (LLVMValueRef call);
 
 void

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -65,6 +65,9 @@ typedef struct {
 	GHashTable *plt_entries;
 	GHashTable *plt_entries_ji;
 	GHashTable *method_to_lmethod;
+	GHashTable *lmethod_to_method;
+	GHashTable *method_to_call_info;
+	GHashTable *lvalue_to_lcalls;
 	GHashTable *direct_callables;
 	GHashTable *module_nonnull;
 	char **bb_names;
@@ -8161,6 +8164,9 @@ after_codegen:
 
 	if (ctx->module->method_to_lmethod)
 		g_hash_table_insert (ctx->module->method_to_lmethod, cfg->method, ctx->lmethod);
+	if (ctx->module->lmethod_to_method)
+		g_hash_table_insert (ctx->module->lmethod_to_method, ctx->lmethod, cfg->method);
+
 	if (ctx->module->idx_to_lmethod)
 		g_hash_table_insert (ctx->module->idx_to_lmethod, GINT_TO_POINTER (cfg->method_index), ctx->lmethod);
 
@@ -9012,8 +9018,11 @@ mono_llvm_create_aot_module (MonoAssembly *assembly, const char *global_prefix, 
 	module->plt_entries_ji = g_hash_table_new (NULL, NULL);
 	module->direct_callables = g_hash_table_new (g_str_hash, g_str_equal);
 	module->module_nonnull = g_hash_table_new (NULL, NULL);
-	module->method_to_lmethod = g_hash_table_new (NULL, NULL);
 	module->idx_to_lmethod = g_hash_table_new (NULL, NULL);
+	module->method_to_lmethod = g_hash_table_new (NULL, NULL);
+	module->lmethod_to_method = g_hash_table_new (NULL, NULL);
+	module->method_to_call_info = g_hash_table_new (NULL, NULL);
+	module->lvalue_to_lcalls = g_hash_table_new (NULL, NULL);
 	module->idx_to_unbox_tramp = g_hash_table_new (NULL, NULL);
 	module->callsite_list = g_ptr_array_new ();
 }

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -4115,7 +4115,7 @@ process_call (EmitContext *ctx, MonoBasicBlock *bb, LLVMBuilderRef *builder_ref,
 
 	// If we just allocated an object, it's not null.
 	if (call->method && call->method->wrapper_type == MONO_WRAPPER_ALLOC) {
-			mono_llvm_set_call_nonnull_ret (lcall);
+		mono_llvm_set_call_nonnull_ret (lcall);
 	}
 
 	if (ins->opcode != OP_TAILCALL && ins->opcode != OP_TAILCALL_MEMBASE && LLVMGetInstructionOpcode (lcall) == LLVMCall)

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -5903,10 +5903,10 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 			if (!cfg->llvm_only || mono_aot_is_shared_got_offset (got_offset)) {
 				/* Can't use this in llvmonly mode since the got slots are initialized by the methods themselves */
 				set_invariant_load_flag (values [ins->dreg]);
-
-				if (ji->type == MONO_PATCH_INFO_LDSTR)
-					set_nonnull_load_flag (values [ins->dreg]);
 			}
+
+			if (ji->type == MONO_PATCH_INFO_LDSTR)
+				set_nonnull_load_flag (values [ins->dreg]);
 			break;
 		}
 		case OP_NOT_REACHED:

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -9496,12 +9496,18 @@ mono_llvm_propagate_nonnull_final (GHashTable *all_specializable, MonoLLVMModule
 			// If this wasn't a direct call for which mono_aot_can_specialize is true, 
 			// this lookup won't find a MonoMethod. 
 			MonoMethod *callee_method = (MonoMethod *) g_hash_table_lookup (all_specializable, callee_lmethod);
+			if (!callee_method)
+				continue;
 
 			// Decrement number of nullable refs at that func's arg offset
 			GArray *call_site_union = (GArray *) g_hash_table_lookup (module->method_to_call_info, callee_method);
-			int max_params = LLVMCountParams (callee_lmethod);
+
+			// It has module-local callers and is specializable, should have seen this call site
+			// and inited this
+			g_assert (call_site_union);
 
 			// The function *definition* parameter arity should always be consistent
+			int max_params = LLVMCountParams (callee_lmethod);
 			if (call_site_union->len != max_params) {
 				mono_llvm_dump_value (callee_lmethod);
 				g_assert_not_reached ();

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -9395,6 +9395,7 @@ typedef struct {
 static void
 mono_llvm_nonnull_state_update (EmitContext *ctx, LLVMValueRef lcall, MonoMethod *call_method, LLVMValueRef *args, int num_params)
 {
+#if LLVM_API_VERSION > 100
 	if (!ctx->module->llvm_disable_self_init && mono_aot_can_specialize (call_method)) {
 		int num_passed = LLVMGetNumArgOperands (lcall);
 		g_assert (num_params <= num_passed);
@@ -9421,11 +9422,13 @@ mono_llvm_nonnull_state_update (EmitContext *ctx, LLVMValueRef lcall, MonoMethod
 
 		g_hash_table_insert (ctx->module->method_to_call_info, call_method, call_site_union);
 	}
+#endif
 }
 
 static void
 mono_llvm_propagate_nonnull_final (GHashTable *all_specializable, MonoLLVMModule *module)
 {
+#if LLVM_API_VERSION > 100
 	// When we first traverse the mini IL, we mark the things that are
 	// nonnull (the roots). Then, for all of the methods that can be specialized, we
 	// see if their call sites have nonnull attributes. 
@@ -9542,7 +9545,7 @@ mono_llvm_propagate_nonnull_final (GHashTable *all_specializable, MonoLLVMModule
 
 		g_free (current);
 	}
-
+#endif
 }
 
 /*

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -9462,7 +9462,7 @@ mono_llvm_propagate_nonnull_func (GHashTable *all_directly_called, MonoLLVMModul
 
 			g_hash_table_insert (module->method_to_call_info, callee_method, call_site_union);
 		}
-		g_free (calls);
+		g_slist_free (calls);
 
 		g_free (current);
 	}

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -9450,11 +9450,13 @@ mono_llvm_propagate_nonnull_func (MonoLLVMModule *module, LLVMValueRef root_lmet
 			LLVMValueRef lcall = (LLVMValueRef) cursor->data;
 			LLVMValueRef callee_lmethod = LLVMGetCalledValue (lcall);
 
-			// Decrement number of nullable refs at that func's arg offset
+			// If this wasn't a direct call, this lookup won't find a MonoMethod. By limiting ourselves to
+			// direct calls, we entire that the arity of the call site and the arity of the function are identical
 			MonoMethod *callee_method = (MonoMethod *) g_hash_table_lookup (module->lmethod_to_method, callee_lmethod);
 			if (!mono_aot_can_specialize (callee_method))
 				continue;
 
+			// Decrement number of nullable refs at that func's arg offset
 			GArray *call_site_union = (GArray *) g_hash_table_lookup (module->method_to_call_info, callee_method);
 			int max_params = LLVMCountParams (callee_lmethod);
 			if (call_site_union->len != max_params) {

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -2055,6 +2055,19 @@ set_metadata_flag (LLVMValueRef v, const char *flag_name)
 }
 
 static void
+set_nonnull_load_flag (LLVMValueRef v)
+{
+	LLVMValueRef md_arg;
+	int md_kind;
+	const char *flag_name;
+
+	flag_name = "nonnull";
+	md_kind = LLVMGetMDKindID (flag_name, strlen (flag_name));
+	md_arg = LLVMMDString ("<index>", strlen ("<index>"));
+	LLVMSetMetadata (v, md_kind, LLVMMDNode (&md_arg, 1));
+}
+
+static void
 set_invariant_load_flag (LLVMValueRef v)
 {
 	LLVMValueRef md_arg;
@@ -5876,8 +5889,12 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 			values [ins->dreg] = LLVMBuildLoad (builder, got_entry_addr, name);
 			g_free (name);
 			/* Can't use this in llvmonly mode since the got slots are initialized by the methods themselves */
-			if (!cfg->llvm_only || mono_aot_is_shared_got_offset (got_offset))
+			if (!cfg->llvm_only || mono_aot_is_shared_got_offset (got_offset)) {
+				/* Can't use this in llvmonly mode since the got slots are initialized by the methods themselves */
 				set_invariant_load_flag (values [ins->dreg]);
+
+				set_nonnull_load_flag (values [ins->dreg]);
+			}
 			break;
 		}
 		case OP_NOT_REACHED:

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -4098,6 +4098,12 @@ process_call (EmitContext *ctx, MonoBasicBlock *bb, LLVMBuilderRef *builder_ref,
 			mono_llvm_set_call_nonnull_arg (lcall, i);
 	}
 
+	// If we just allocated an object, it's not null.
+	if (call->method && call->method->wrapper_type == MONO_WRAPPER_ALLOC) {
+			mono_llvm_set_call_nonnull_ret (lcall);
+			g_hash_table_insert (ctx->module->module_nonnull, lcall, lcall);
+	}
+
 	if (ins->opcode != OP_TAILCALL && ins->opcode != OP_TAILCALL_MEMBASE && LLVMGetInstructionOpcode (lcall) == LLVMCall)
 		mono_llvm_set_call_notailcall (lcall);
 

--- a/sdks/wasm/packager.cs
+++ b/sdks/wasm/packager.cs
@@ -702,7 +702,7 @@ class Driver {
 		ninja.WriteLine ($"  command = bash -c '$emcc $emcc_flags -o $out --js-library $tool_prefix/library_mono.js --js-library $tool_prefix/dotnet_support.js {wasm_core_support_library} $in'");
 		ninja.WriteLine ("  description = [EMCC-LINK] $in -> $out");
 		ninja.WriteLine ("rule linker");
-		ninja.WriteLine ("  command = mono $tools_dir/monolinker.exe -out $builddir/linker-out -l none --exclude-feature com --exclude-feature remoting --exclude-feature etw $linker_args || exit 1; for f in $out; do if test ! -f $$f; then echo > empty.cs; csc /nologo /out:$$f /target:library empty.cs; fi; done");
+		ninja.WriteLine ("  command = mono $tools_dir/monolinker.exe -out $builddir/linker-out -l none --explicit-reflection --exclude-feature com --exclude-feature remoting --exclude-feature etw $linker_args || exit 1; for f in $out; do if test ! -f $$f; then echo > empty.cs; csc /nologo /out:$$f /target:library empty.cs; fi; done");
 		ninja.WriteLine ("  description = [IL-LINK]");
 		ninja.WriteLine ("rule aot-dummy");
 		ninja.WriteLine ("  command = echo > aot-dummy.cs; csc /out:$out /target:library aot-dummy.cs");

--- a/sdks/wasm/packager.cs
+++ b/sdks/wasm/packager.cs
@@ -702,7 +702,7 @@ class Driver {
 		ninja.WriteLine ($"  command = bash -c '$emcc $emcc_flags -o $out --js-library $tool_prefix/library_mono.js --js-library $tool_prefix/dotnet_support.js {wasm_core_support_library} $in'");
 		ninja.WriteLine ("  description = [EMCC-LINK] $in -> $out");
 		ninja.WriteLine ("rule linker");
-		ninja.WriteLine ("  command = mono $tools_dir/monolinker.exe -out $builddir/linker-out -l none --explicit-reflection --exclude-feature com --exclude-feature remoting --exclude-feature etw $linker_args || exit 1; for f in $out; do if test ! -f $$f; then echo > empty.cs; csc /nologo /out:$$f /target:library empty.cs; fi; done");
+		ninja.WriteLine ("  command = mono $tools_dir/monolinker.exe -out $builddir/linker-out -l none --explicit-reflection --disable-opt unreachablebodies --exclude-feature com --exclude-feature remoting --exclude-feature etw $linker_args || exit 1; for f in $out; do if test ! -f $$f; then echo > empty.cs; csc /nologo /out:$$f /target:library empty.cs; fi; done");
 		ninja.WriteLine ("  description = [IL-LINK]");
 		ninja.WriteLine ("rule aot-dummy");
 		ninja.WriteLine ("  command = echo > aot-dummy.cs; csc /out:$out /target:library aot-dummy.cs");


### PR DESCRIPTION
## Summary

This change allows LLVM to identify unnecessary null checks. We mark GOT accesses (including those made by LDSTR) and new object calls as nonnull.

Since LLVM won't propagate this, we propagate from definition to usage, across casts, and from usage to definition (conditionally).

This enables it to remove a significant portion of some benchmarks. 

In real-world code, we can expect to see this remove the unnecessary null checks made by private methods. 

## Example

### C#:

Note that the constant strings are trivially non-null. This PR spots and propagates that. 

```

   static void ThrowIfNull(string s)
    {
        if (s == null)
            ThrowArgumentNullException();
    }

    static void ThrowArgumentNullException()
    {
        throw new ArgumentNullException();
    }

    [MethodImpl(MethodImplOptions.NoInlining)]
    static int Bench(string a, string b, string c, string d)
    {
        ThrowIfNull(a);
        ThrowIfNull(b);
        ThrowIfNull(c);
        ThrowIfNull(d);

        return a.Length + b.Length + c.Length + d.Length;
    }

    [Benchmark(Description = nameof(NoThrowInline))]
    public int Test() => Bench("a", "bc", "def", "ghij");

```

### Before:

```

define hidden monocc i32 @NoThrowInline_MainClass_Bench_string_string_string_string(i64*  %arg_a, i64* %arg_b, i64* %arg_c, i64*  %arg_d) #6 gc "mono" {
BB0:
  br label %INIT_BB1

INIT_BB1:                                         ; preds = %BB0
  br label %INITED_BB2

INITED_BB2:                                       ; preds = %INIT_BB1
  br label %BB3

BB3:                                              ; preds = %INITED_BB2
  br label %BB2

BB2:                                              ; preds = %BB3
  notail call monocc void @NoThrowInline_MainClass_ThrowIfNull_string(i64* %arg_a)
  notail call monocc void @NoThrowInline_MainClass_ThrowIfNull_string(i64* %arg_b)
  notail call monocc void @NoThrowInline_MainClass_ThrowIfNull_string(i64* %arg_c)
  notail call monocc void @NoThrowInline_MainClass_ThrowIfNull_string(i64* %arg_d)
  %0 = bitcast i64* %arg_a to i32*
  %1 = getelementptr i32, i32* %0, i32 4
  %t50 = load volatile i32, i32* %1
  %2 = bitcast i64* %arg_b to i32*
  %3 = getelementptr i32, i32* %2, i32 4
  %t52 = load volatile i32, i32* %3
  %t53 = add i32 %t50, %t52
  %4 = bitcast i64* %arg_c to i32*
  %5 = getelementptr i32, i32* %4, i32 4
  %t55 = load volatile i32, i32* %5
  %t56 = add i32 %t53, %t55
  %6 = bitcast i64* %arg_d to i32*
  %7 = getelementptr i32, i32* %6, i32 4
  %t58 = load volatile i32, i32* %7
  %t60 = add i32 %t56, %t58
  br label %BB1

BB1:                                              ; preds = %BB2
  ret i32 %t60
}

```

### After:

Note: safepoint in below code is added by backend, not part of this change

```

define hidden monocc i32 @NoThrowInline_MainClass_Bench_string_string_string_string(i64* nonnull %arg_a, i64* nonnull %arg_b, i64* nonnull %arg_c, i64* nonnull %arg_d) #6 gc "mono" {
BB0:
  %0 = getelementptr i64, i64* %arg_a, i64 2
  %1 = bitcast i64* %0 to i32*
  %t50 = load volatile i32, i32* %1, align 4
  %2 = getelementptr i64, i64* %arg_b, i64 2
  %3 = bitcast i64* %2 to i32*
  %t52 = load volatile i32, i32* %3, align 4
  %t53 = add i32 %t52, %t50
  %4 = getelementptr i64, i64* %arg_c, i64 2
  %5 = bitcast i64* %4 to i32*
  %t55 = load volatile i32, i32* %5, align 4
  %t56 = add i32 %t53, %t55
  %6 = getelementptr i64, i64* %arg_d, i64 2
  %7 = bitcast i64* %6 to i32*
  %t58 = load volatile i32, i32* %7, align 4
  %t60 = add i32 %t56, %t58
  %8 = load i64*, i64** getelementptr inbounds ([37 x i64*], [37 x i64*]* @mono_aot_NoThrowInline_llvm_got, i64 0, i64 7), align 8
  %9 = load i64, i64* %8, align 4
  %10 = icmp eq i64 %9, 0
  br i1 %10, label %gc.safepoint_poll.exit, label %gc.safepoint_poll.poll.i

gc.safepoint_poll.poll.i:                         ; preds = %BB0
  %11 = load void ()*, void ()** bitcast (i64** getelementptr inbounds ([37 x i64*], [37 x i64*]* @mono_aot_NoThrowInline_llvm_got, i64 0, i64 25) to void ()**), align 8
  call void %11() #8
  br label %gc.safepoint_poll.exit

gc.safepoint_poll.exit:                           ; preds = %BB0, %gc.safepoint_poll.poll.i
  ret i32 %t60
}

```

## Dependencies 

This depends on https://github.com/mono/linker/pull/528.

## TODO:

1. Add usage to Wasm so tested 
2. Add unit tests
3. Benchmark change with https://github.com/mono/mono/issues/13104 