### PR TITLE
[netcore] Implement missing functions in RegisteredWaitHandle and EventWaitHandle

### DIFF
--- a/mcs/class/System.Private.CoreLib/System.Threading/EventWaitHandle.cs
+++ b/mcs/class/System.Private.CoreLib/System.Threading/EventWaitHandle.cs
@@ -47,7 +47,17 @@ namespace System.Threading
 			throw new PlatformNotSupportedException (SR.PlatformNotSupported_NamedSynchronizationPrimitives);
 		}
 
-		internal static bool Set (SafeWaitHandle waitHandle) => throw new NotImplementedException ();
+		internal static bool Set (SafeWaitHandle waitHandle)
+		{
+			bool release = false;
+			try {
+				waitHandle.DangerousAddRef (ref release);
+				return SetEventInternal (waitHandle.DangerousGetHandle ());
+			} finally {
+				if (release)
+					waitHandle.DangerousRelease ();
+			}
+		}
 
 		SafeWaitHandle ValidateHandle (out bool success)
 		{

--- a/mcs/class/corlib/System.Threading/RegisteredWaitHandle.cs
+++ b/mcs/class/corlib/System.Threading/RegisteredWaitHandle.cs
@@ -111,7 +111,7 @@ namespace System.Threading
 					_callsInProcess--;
 					if (_unregistered && _callsInProcess == 0 && _finalEvent != null)
 #if NETCORE
-						throw new NotImplementedException ();
+						EventWaitHandle.Set (_finalEvent.SafeWaitHandle);
 #else					
 						NativeEventCalls.SetEvent (_finalEvent.SafeWaitHandle);
 #endif


### PR DESCRIPTION
Fixes crash in System.Threading.ThreadPools.Tests and makes it run till the end:

```
xUnit.net Console Runner v2.4.1-pre.build.4059 (64-bit .NET Core 3.0.0-preview4-27514-06)
  Discovering: System.Threading.ThreadPool.Tests (method display = ClassAndMethod, method display options = None)
  Discovered:  System.Threading.ThreadPool.Tests (found 18 test cases)
  Starting:    System.Threading.ThreadPool.Tests (parallel test collections = on, max threads = 4)
    System.Threading.ThreadPools.Tests.ThreadPoolTests.SetMinMaxThreadsTest [FAIL]
      Assert.True() Failure
      Expected: True
      Actual:   False
      Stack Trace:
           at System.Threading.ThreadPools.Tests.ThreadPoolTests.SetMinMaxThreadsTest()
           at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
    System.Threading.ThreadPools.Tests.ThreadPoolTests.SetMinThreadsTo0Test [FAIL]
      Assert.True() Failure
      Expected: True
      Actual:   False
      Stack Trace:
           at System.Threading.ThreadPools.Tests.ThreadPoolTests.SetMinThreadsTo0Test()
           at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
    System.Threading.ThreadPools.Tests.ThreadPoolTests.SetMinMaxThreadsTest_ChangedInDotNetCore [FAIL]
      Assert.True() Failure
      Expected: True
      Actual:   False
      Stack Trace:
           at System.Threading.ThreadPools.Tests.ThreadPoolTests.SetMinMaxThreadsTest_ChangedInDotNetCore()
           at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
  Finished:    System.Threading.ThreadPool.Tests
=== TEST EXECUTION SUMMARY ===
   System.Threading.ThreadPool.Tests  Total: 40, Errors: 0, Failed: 3, Skipped: 0, Time: 1.037s
```