### PR TITLE
Fix a few deficiencies in mono_path_filename_in_basedir. Still with testability but will remove if not desired.

### DIFF
--- a/mono/unit-tests/Makefile.am
+++ b/mono/unit-tests/Makefile.am
@@ -101,10 +101,17 @@ test_mono_string_CFLAGS = $(test-cflags) -DMAIN=test_mono_string_main
 test_mono_string_LDADD = $(test_ldadd) $(mini_libs) $(sgen_libs) libtestlib_la-test-mono-string.lo
 test_mono_string_LDFLAGS = $(test_ldflags)
 
+test_path_SOURCES = test-path.c
+test_path_CFLAGS = $(test-cflags)
+test_path_LDADD = $(test_ldadd) $(mini_libs) $(sgen_libs)
+test_path_LDFLAGS = $(test_ldflags)
+
 check_PROGRAMS = test-sgen-qsort test-memfuncs test-mono-linked-list-set test-conc-hashtable test-mono-handle	\
+		 test-path \
 		 test-mono-callspec test-mono-string
 
 TESTS = test-sgen-qsort test-memfuncs test-mono-linked-list-set test-conc-hashtable test-mono-handle \
+	test-path \
 	test-mono-callspec test-mono-string
 
 AM_TESTS_ENVIRONMENT = export MONO_PATH=$(mcs_topdir)/class/lib/build;

--- a/mono/unit-tests/test-path.c
+++ b/mono/unit-tests/test-path.c
@@ -1,0 +1,79 @@
+/*
+ * test-path.c
+ */
+
+#include "config.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include "glib.h"
+
+gboolean mono_host_win32;
+#undef HOST_WIN32
+#define HOST_WIN32 mono_host_win32
+#include "utils/mono-path.c"
+
+static char*
+make_path (const char *a, int itrail, int slash, int upcase, int win32)
+{
+	mono_host_win32 = !!win32;
+	char trail [3] = {'/', '/'};
+	trail [itrail] = 0;
+	char *b = g_strdup_printf ("%s%s", a, trail);
+	if (win32) {
+		if (slash)
+			g_strdelimit (b, '/', '\\');
+		if (upcase)
+			g_strdelimit (b, 'f', 'F');
+	}
+	return b;
+}
+
+int
+main (void)
+{
+	static const char * const bases [2] = {"/", "/foo"};
+	static const char * const files [3] = {"/foo", "/foo/bar", "/foob"};
+
+	static const gboolean result [2][3] = {
+		{ TRUE, FALSE, TRUE },
+		{ FALSE, TRUE, FALSE }
+	};
+
+	int i = 0;
+	gboolean const verbose = !!getenv("V");
+
+	for (int win32 = 0; win32 <= 1; ++win32) {
+		for (int upcase_file = 0; upcase_file <= 1; ++upcase_file) {
+			for (int upcase_base = 0; upcase_base <= 1; ++upcase_base) {
+				for (int itrail_base = 0; itrail_base <= 2; ++itrail_base) {
+					for (int itrail_file = 0; itrail_file <= 2; ++itrail_file) {
+						for (int ibase = 1; ibase < G_N_ELEMENTS (bases); ++ibase) {
+							for (int ifile = 0; ifile < G_N_ELEMENTS (files); ++ifile) {
+								for (int islash_base = 0; islash_base <= 1; ++islash_base) {
+									for (int islash_file = 0; islash_file <= 1; ++islash_file) {
+										char *base = make_path (bases [ibase], itrail_base, islash_base, upcase_base, win32);
+										char *file = make_path (files [ifile], itrail_file, islash_file, upcase_file, win32);
+										verbose && printf ("mono_path_filename_in_basedir (%s, %s)\n", file, base);
+										gboolean r = mono_path_filename_in_basedir (file, base);
+										verbose && printf ("mono_path_filename_in_basedir (%s, %s, win32:%d):%d\n", file, base, win32, r);
+										g_assertf (result [ibase][ifile] == r,
+											"mono_path_filename_in_basedir (%s, %s, win32:%d):%d\n", file, base, win32, r);
+										if (strcmp (base, file) == 0)
+											g_assertf (!r,
+												"mono_path_filename_in_basedir (%s, %s, win32:%d):%d\n", file, base, win32, r);
+										g_free (base);
+										g_free (file);
+										++i;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	printf ("%d tests\n", i);
+
+	return 0;
+}


### PR DESCRIPTION
The main one is that strstr is too loose.
Add tests.
Make it case insensitive on Win32 and allow some denormal input.
Make the Win32 variant testable on Unix (and vice versa).

Add more data to asserts.

Account for test reality -- filename is not absolute.

Use HOST_WIN32 per https://github.com/mono/mono/pull/9930#pullrequestreview-144919252.
Comment was unclear, and regular ifdef will not meet the goals of the test.

Basedir might also not be a full path.

Regarding `#ifdef` vs. `if`:

Please consider that this is not a hack.

It is a legitimate technique to form a more testable but not less efficient codebase.

In general `#ifdef` should be weeded out like this.

This is also for example, how you could form a native JIT/runtime with the same efficiency as today, but also a cross-compiler that targets multiple/all targets in one configuration -- by moving `#ifdef` to be `if` against what is either a just as optimizable constant, or a global variable (or thread local, or function call) that varies.

This enables testing, at least unit testing, Windows-specific code paths without using Windows or an alternate build system.

It provides an excellent balance between testability, testability of each configuration on all configurations, and does not compromise at all the runtime performance.

`#ifdef` on the other hand is very rigid. Tests are strongly tied to configuration and there is no ability to exercise code unless configuration matches exactly.

I do not want to be so quick to sacrifice testability when it is so easy to achieve without sacrificing runtime performance.

If testability is really not desired then I will remove it.
