### PR TITLE
[interp] Fix GetFunctionPointer

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -5873,6 +5873,14 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			++sp;
 			MINT_IN_BREAK;
 		}
+		MINT_IN_CASE(MINT_LDFTN_DYNAMIC) {
+			ERROR_DECL (error);
+			InterpMethod *m = mono_interp_get_imethod (mono_domain_get (), (MonoMethod*) sp [-1].data.p, error);
+			mono_error_assert_ok (error);
+			sp [-1].data.p = m;
+			ip++;
+			MINT_IN_BREAK;
+		}
 
 #define LDARG(datamem, argtype) \
 	sp->data.datamem = (argtype) frame->stack_args [*(guint16 *)(ip + 1)].data.datamem; \

--- a/mono/mini/interp/mintops.def
+++ b/mono/mini/interp/mintops.def
@@ -342,6 +342,7 @@ OPDEF(MINT_BOX_VT, "box.vt", 3, MintOpTwoShorts)
 OPDEF(MINT_UNBOX, "unbox", 2, MintOpClassToken) 
 OPDEF(MINT_LDTOKEN, "ldtoken", 2, MintOpClassToken) /* not really */
 OPDEF(MINT_LDFTN, "ldftn", 2, MintOpMethodToken) 
+OPDEF(MINT_LDFTN_DYNAMIC, "ldftn.dynamic", 1, MintOpMethodToken)
 OPDEF(MINT_LDVIRTFTN, "ldvirtftn", 2, MintOpMethodToken) 
 OPDEF(MINT_CPOBJ, "cpobj", 2, MintOpClassToken)
 OPDEF(MINT_CPOBJ_VT, "cpobj.vt", 2, MintOpClassToken)

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1219,6 +1219,9 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoMeth
 			return TRUE;
 		}
 #endif
+	} else if (in_corlib && !strcmp (klass_name_space, "System") && !strcmp (klass_name, "RuntimeMethodHandle") && !strcmp (tm, "GetFunctionPointer") && csignature->param_count == 1) {
+		// We must intrinsify this method on interp so we don't return a pointer to native code entering interpreter
+		*op = MINT_LDFTN_DYNAMIC;
 	}
 
 	return FALSE;


### PR DESCRIPTION
This method returns a function pointer that can be called with a calli instruction. On interpreter we use a pointer to InterpMethod while on jit we use the native code address. Normally, GetFunctionPointer should return the InterpMethod pointer if called from interp or the native code address if called from jit. Since we don't have any information about the execution engine of the caller, we solve this by intrinsifying all these calls, that happen in the interpreter.

Passing such function pointers between jitted and interp code is probably still unreliable.

Fixes https://github.com/mono/mono/issues/13654