### PR TITLE
Fix a few deficiencies in mono_path_filename_in_basedir. Mainly strstr.

### DIFF
--- a/mono/unit-tests/Makefile.am
+++ b/mono/unit-tests/Makefile.am
@@ -101,10 +101,17 @@ test_mono_string_CFLAGS = $(test-cflags) -DMAIN=test_mono_string_main
 test_mono_string_LDADD = $(test_ldadd) $(mini_libs) $(sgen_libs) libtestlib_la-test-mono-string.lo
 test_mono_string_LDFLAGS = $(test_ldflags)
 
+test_path_SOURCES = test-path.c
+test_path_CFLAGS = $(test-cflags)
+test_path_LDADD = $(test_ldadd) $(mini_libs) $(sgen_libs)
+test_path_LDFLAGS = $(test_ldflags)
+
 check_PROGRAMS = test-sgen-qsort test-memfuncs test-mono-linked-list-set test-conc-hashtable test-mono-handle	\
+		 test-path \
 		 test-mono-callspec test-mono-string
 
 TESTS = test-sgen-qsort test-memfuncs test-mono-linked-list-set test-conc-hashtable test-mono-handle \
+	test-path \
 	test-mono-callspec test-mono-string
 
 AM_TESTS_ENVIRONMENT = export MONO_PATH=$(mcs_topdir)/class/lib/build;

--- a/mono/unit-tests/test-path.c
+++ b/mono/unit-tests/test-path.c
@@ -1,0 +1,79 @@
+/*
+ * test-path.c
+ */
+
+#include "config.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include "glib.h"
+
+gboolean mono_host_win32;
+#undef HOST_WIN32
+#define HOST_WIN32 mono_host_win32
+#include "utils/mono-path.c"
+
+static char*
+make_path (const char *a, int itrail, int slash, int upcase, int win32)
+{
+	mono_host_win32 = !!win32;
+	char trail [3] = {'/', '/'};
+	trail [itrail] = 0;
+	char *b = g_strdup_printf ("%s%s", a, trail);
+	if (win32) {
+		if (slash)
+			g_strdelimit (b, '/', '\\');
+		if (upcase)
+			g_strdelimit (b, 'f', 'F');
+	}
+	return b;
+}
+
+int
+main (void)
+{
+	static const char * const bases [2] = {"/", "/foo"};
+	static const char * const files [3] = {"/foo", "/foo/bar", "/foob"};
+
+	static const gboolean result [2][3] = {
+		{ TRUE, FALSE, TRUE },
+		{ FALSE, TRUE, FALSE }
+	};
+
+	int i = 0;
+	gboolean const verbose = !!getenv("V");
+
+	for (int win32 = 0; win32 <= 1; ++win32) {
+		for (int upcase_file = 0; upcase_file <= 1; ++upcase_file) {
+			for (int upcase_base = 0; upcase_base <= 1; ++upcase_base) {
+				for (int itrail_base = 0; itrail_base <= 2; ++itrail_base) {
+					for (int itrail_file = 0; itrail_file <= 2; ++itrail_file) {
+						for (int ibase = 1; ibase < G_N_ELEMENTS (bases); ++ibase) {
+							for (int ifile = 0; ifile < G_N_ELEMENTS (files); ++ifile) {
+								for (int islash_base = 0; islash_base <= 1; ++islash_base) {
+									for (int islash_file = 0; islash_file <= 1; ++islash_file) {
+										char *base = make_path (bases [ibase], itrail_base, islash_base, upcase_base, win32);
+										char *file = make_path (files [ifile], itrail_file, islash_file, upcase_file, win32);
+										verbose && printf ("mono_path_filename_in_basedir (%s, %s)\n", file, base);
+										gboolean r = mono_path_filename_in_basedir (file, base);
+										verbose && printf ("mono_path_filename_in_basedir (%s, %s, win32:%d):%d\n", file, base, win32, r);
+										g_assertf (result [ibase][ifile] == r,
+											"mono_path_filename_in_basedir (%s, %s, win32:%d):%d\n", file, base, win32, r);
+										if (strcmp (base, file) == 0)
+											g_assertf (!r,
+												"mono_path_filename_in_basedir (%s, %s, win32:%d):%d\n", file, base, win32, r);
+										g_free (base);
+										g_free (file);
+										++i;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	printf ("%d tests\n", i);
+
+	return 0;
+}

--- a/mono/unit-tests/test-path.c
+++ b/mono/unit-tests/test-path.c
@@ -11,14 +11,17 @@
 static char*
 make_path (const char *a, int itrail, int slash, int upcase)
 {
-	char trail [3] = {'/', '/'};
+	// Append 0, 1, or 2 trailing slashes to a.
+	g_assert (itrail >= 0 && itrail <= 2);
+	char trail [] = "//";
 	trail [itrail] = 0;
 	char *b = g_strdup_printf ("%s%s", a, trail);
+
 #ifdef HOST_WIN32
 	if (slash)
 		g_strdelimit (b, '/', '\\');
 	if (upcase)
-		g_strdelimit (b, 'f', 'F');
+		g_strdelimit (b, 'a', 'A');
 #endif
 	return b;
 }
@@ -26,8 +29,9 @@ make_path (const char *a, int itrail, int slash, int upcase)
 int
 main (void)
 {
-	static const char * const bases [2] = {"/", "/1"};
-	static const char * const files [6] = {"/1", "/1/2", "/1/2/3", "/12", "/2", "/2/2/"};
+	// Use letters not numbers in this data to exercise case insensitivity.
+	static const char * const bases [2] = {"/", "/a"};
+	static const char * const files [6] = {"/a", "/a/b", "/a/b/c", "/ab", "/b", "/b/b/"};
 
 	static const gboolean result [2][6] = {
 		{ TRUE, FALSE, FALSE, TRUE, TRUE, FALSE },
@@ -43,6 +47,7 @@ main (void)
 	const int win32 = 0;
 #endif
 
+	// Iterate a cross product.
 	for (int upcase_file = 0; upcase_file <= win32; ++upcase_file) {
 		for (int upcase_base = 0; upcase_base <= win32; ++upcase_base) {
 			for (int itrail_base = 0; itrail_base <= 2; ++itrail_base) {
@@ -51,6 +56,7 @@ main (void)
 						for (int ifile = 0; ifile < G_N_ELEMENTS (files); ++ifile) {
 							for (int islash_base = 0; islash_base <= win32; ++islash_base) {
 								for (int islash_file = 0; islash_file <= win32; ++islash_file) {
+
 									char *base = make_path (bases [ibase], itrail_base, islash_base, upcase_base);
 									char *file = make_path (files [ifile], itrail_file, islash_file, upcase_file);
 									//verbose && printf ("mono_path_filename_in_basedir (%s, %s)\n", file, base);

--- a/mono/unit-tests/test-path.c
+++ b/mono/unit-tests/test-path.c
@@ -6,25 +6,20 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "glib.h"
-
-gboolean mono_host_win32;
-#undef HOST_WIN32
-#define HOST_WIN32 mono_host_win32
-#include "utils/mono-path.c"
+#include "mono/utils/mono-path.h"
 
 static char*
-make_path (const char *a, int itrail, int slash, int upcase, int win32)
+make_path (const char *a, int itrail, int slash, int upcase)
 {
-	mono_host_win32 = !!win32;
 	char trail [3] = {'/', '/'};
 	trail [itrail] = 0;
 	char *b = g_strdup_printf ("%s%s", a, trail);
-	if (win32) {
-		if (slash)
-			g_strdelimit (b, '/', '\\');
-		if (upcase)
-			g_strdelimit (b, 'f', 'F');
-	}
+#ifdef HOST_WIN32
+	if (slash)
+		g_strdelimit (b, '/', '\\');
+	if (upcase)
+		g_strdelimit (b, 'f', 'F');
+#endif
 	return b;
 }
 
@@ -42,29 +37,33 @@ main (void)
 	int i = 0;
 	gboolean const verbose = !!getenv("V");
 
-	for (int win32 = 0; win32 <= 1; ++win32) {
-		for (int upcase_file = 0; upcase_file <= 1; ++upcase_file) {
-			for (int upcase_base = 0; upcase_base <= 1; ++upcase_base) {
-				for (int itrail_base = 0; itrail_base <= 2; ++itrail_base) {
-					for (int itrail_file = 0; itrail_file <= 2; ++itrail_file) {
-						for (int ibase = 1; ibase < G_N_ELEMENTS (bases); ++ibase) {
-							for (int ifile = 0; ifile < G_N_ELEMENTS (files); ++ifile) {
-								for (int islash_base = 0; islash_base <= 1; ++islash_base) {
-									for (int islash_file = 0; islash_file <= 1; ++islash_file) {
-										char *base = make_path (bases [ibase], itrail_base, islash_base, upcase_base, win32);
-										char *file = make_path (files [ifile], itrail_file, islash_file, upcase_file, win32);
-										verbose && printf ("mono_path_filename_in_basedir (%s, %s)\n", file, base);
-										gboolean r = mono_path_filename_in_basedir (file, base);
-										verbose && printf ("mono_path_filename_in_basedir (%s, %s, win32:%d):%d\n", file, base, win32, r);
-										g_assertf (result [ibase][ifile] == r,
-											"mono_path_filename_in_basedir (%s, %s, win32:%d):%d\n", file, base, win32, r);
-										if (strcmp (base, file) == 0)
-											g_assertf (!r,
-												"mono_path_filename_in_basedir (%s, %s, win32:%d):%d\n", file, base, win32, r);
-										g_free (base);
-										g_free (file);
-										++i;
-									}
+#ifdef HOST_WIN32
+	const int win32 = 1;
+#else
+	const int win32 = 0;
+#endif
+
+	for (int upcase_file = 0; upcase_file <= win32; ++upcase_file) {
+		for (int upcase_base = 0; upcase_base <= win32; ++upcase_base) {
+			for (int itrail_base = 0; itrail_base <= 2; ++itrail_base) {
+				for (int itrail_file = 0; itrail_file <= 2; ++itrail_file) {
+					for (int ibase = 1; ibase < G_N_ELEMENTS (bases); ++ibase) {
+						for (int ifile = 0; ifile < G_N_ELEMENTS (files); ++ifile) {
+							for (int islash_base = 0; islash_base <= win32; ++islash_base) {
+								for (int islash_file = 0; islash_file <= win32; ++islash_file) {
+									char *base = make_path (bases [ibase], itrail_base, islash_base, upcase_base);
+									char *file = make_path (files [ifile], itrail_file, islash_file, upcase_file);
+									verbose && printf ("mono_path_filename_in_basedir (%s, %s)\n", file, base);
+									gboolean r = mono_path_filename_in_basedir (file, base);
+									verbose && printf ("mono_path_filename_in_basedir (%s, %s):%d\n", file, base, r);
+									g_assertf (result [ibase][ifile] == r,
+										"mono_path_filename_in_basedir (%s, %s):%d\n", file, base, r);
+									if (strcmp (base, file) == 0)
+										g_assertf (!r,
+											"mono_path_filename_in_basedir (%s, %s):%d\n", file, base, r);
+									g_free (base);
+									g_free (file);
+									++i;
 								}
 							}
 						}

--- a/mono/unit-tests/test-path.c
+++ b/mono/unit-tests/test-path.c
@@ -26,12 +26,12 @@ make_path (const char *a, int itrail, int slash, int upcase)
 int
 main (void)
 {
-	static const char * const bases [2] = {"/", "/foo"};
-	static const char * const files [3] = {"/foo", "/foo/bar", "/foob"};
+	static const char * const bases [2] = {"/", "/1"};
+	static const char * const files [6] = {"/1", "/1/2", "/1/2/3", "/12", "/2", "/2/2/"};
 
-	static const gboolean result [2][3] = {
-		{ TRUE, FALSE, TRUE },
-		{ FALSE, TRUE, FALSE }
+	static const gboolean result [2][6] = {
+		{ TRUE, FALSE, FALSE, TRUE, TRUE, FALSE },
+		{ FALSE, TRUE, FALSE, FALSE, FALSE, FALSE }
 	};
 
 	int i = 0;
@@ -47,13 +47,13 @@ main (void)
 		for (int upcase_base = 0; upcase_base <= win32; ++upcase_base) {
 			for (int itrail_base = 0; itrail_base <= 2; ++itrail_base) {
 				for (int itrail_file = 0; itrail_file <= 2; ++itrail_file) {
-					for (int ibase = 1; ibase < G_N_ELEMENTS (bases); ++ibase) {
+					for (int ibase = 0; ibase < G_N_ELEMENTS (bases); ++ibase) {
 						for (int ifile = 0; ifile < G_N_ELEMENTS (files); ++ifile) {
 							for (int islash_base = 0; islash_base <= win32; ++islash_base) {
 								for (int islash_file = 0; islash_file <= win32; ++islash_file) {
 									char *base = make_path (bases [ibase], itrail_base, islash_base, upcase_base);
 									char *file = make_path (files [ifile], itrail_file, islash_file, upcase_file);
-									verbose && printf ("mono_path_filename_in_basedir (%s, %s)\n", file, base);
+									//verbose && printf ("mono_path_filename_in_basedir (%s, %s)\n", file, base);
 									gboolean r = mono_path_filename_in_basedir (file, base);
 									verbose && printf ("mono_path_filename_in_basedir (%s, %s):%d\n", file, base, r);
 									g_assertf (result [ibase][ifile] == r,

--- a/mono/unit-tests/test-path.c
+++ b/mono/unit-tests/test-path.c
@@ -6,7 +6,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "glib.h"
-#include "mono/utils/mono-path.h"
+
+#include "mono/utils/mono-path.c"
 
 static char*
 make_path (const char *a, int itrail, int slash, int upcase)

--- a/mono/utils/mono-path.c
+++ b/mono/utils/mono-path.c
@@ -177,14 +177,14 @@ mono_path_resolve_symlinks (const char *path)
 #endif
 }
 
-#ifndef HOST_WIN32
-#define HOST_WIN32 0
-#endif
-
 static gboolean
 mono_path_char_is_separator (char ch)
 {
-	return ch == '/' || (HOST_WIN32 && ch == '\\');
+#ifdef HOST_WIN32
+	return ch == '/' || ch == '\\';
+#else
+	return ch == '/';
+#endif
 }
 
 static gboolean
@@ -206,10 +206,12 @@ mono_path_remove_trailing_path_separators (const char *path,  size_t *length)
 	*length = i;
 }
 
+#ifdef HOST_WIN32
+
 static gboolean
 mono_path_char_is_lowercase (char ch)
 {
-	return HOST_WIN32 && ch >= 'a' && ch <= 'z';
+	return ch >= 'a' && ch <= 'z';
 }
 
 // Version-specific unichar2 upcase tables are stored per-volume at NTFS format-time.
@@ -228,17 +230,20 @@ mono_path_char_equal (char a, char b)
 		|| (mono_path_char_is_separator (a) && mono_path_char_is_separator (b));
 }
 
+#endif
+
 static gboolean
 mono_path_equal (const char *a, const char *b, size_t length)
 {
-	if (HOST_WIN32) {
-		size_t i = 0;
-		for (i = 0; i < length && mono_path_char_equal (a [i], b [i]); ++i) {
-			// nothing
-		}
-		return i == length;
+#ifdef HOST_WIN32
+	size_t i = 0;
+	for (i = 0; i < length && mono_path_char_equal (a [i], b [i]); ++i) {
+		// nothing
 	}
+	return i == length;
+#else
 	return memcmp (a, b, length) == 0;
+#endif
 }
 
 static size_t


### PR DESCRIPTION
The main one is that strstr is too loose. The intent is prefix matching, not searching the entire string.
Add tests.
Make it case insensitive on Win32 and allow some denormal input.
 Despite the prior intent and comments, the input is not normalized/absolute. Assuming so broke tests.
  Note that case sensitivity is a function of file system, not
  operating system, but a lot of code gets it wrong, so here does too.

The Win32 code paths could be tested on Unix and vice versa
w/o compromise. See https://github.com/mono/mono/pull/13707
That is removed here per PR feedback.
