### PR TITLE
[DIM] Do not order implemented interfaces

### DIFF
--- a/mcs/class/PEAPI/Metadata.cs
+++ b/mcs/class/PEAPI/Metadata.cs
@@ -5562,7 +5562,6 @@ namespace PEAPI {
 				  }*/
 			}
 			SortTable(metaDataTables[(int)MDTable.GenericParamConstraint]);
-			//SortTable(metaDataTables[(int)MDTable.InterfaceImpl]);
 			SortTable(metaDataTables[(int)MDTable.CustomAttribute]);
 
 		}

--- a/mcs/class/PEAPI/Metadata.cs
+++ b/mcs/class/PEAPI/Metadata.cs
@@ -1168,8 +1168,7 @@ namespace PEAPI {
 
 		internal override uint SortKey ()
 		{
-			return (theClass.Row << MetaData.CIxShiftMap[(uint)CIx.TypeDefOrRef])
-				| theClass.GetCodedIx (CIx.TypeDefOrRef);
+			throw new Exception ("Should not be used.");
 		}
 
 	}
@@ -5563,7 +5562,7 @@ namespace PEAPI {
 				  }*/
 			}
 			SortTable(metaDataTables[(int)MDTable.GenericParamConstraint]);
-			SortTable(metaDataTables[(int)MDTable.InterfaceImpl]);
+			//SortTable(metaDataTables[(int)MDTable.InterfaceImpl]);
 			SortTable(metaDataTables[(int)MDTable.CustomAttribute]);
 
 		}

--- a/mcs/ilasm/codegen/TypeManager.cs
+++ b/mcs/ilasm/codegen/TypeManager.cs
@@ -13,7 +13,7 @@ using System.Collections;
 namespace Mono.ILASM {
 
         public class TypeManager {
-
+                private ArrayList type_list;
                 private Hashtable type_table;
                 private CodeGen code_gen;
 
@@ -29,6 +29,7 @@ namespace Mono.ILASM {
                         }
                         set {
                                 type_table[full_name] = value;
+                                type_list.Add(value);
                         }
                 }
 
@@ -47,8 +48,6 @@ namespace Mono.ILASM {
 
                 public void DefineAll ()
                 {
-                        ArrayList type_list = new ArrayList (type_table.Values);
-                        //type_list.Sort ();
                         foreach (TypeDef typedef in type_list) {
                                 typedef.Define (code_gen);
                         }

--- a/mcs/ilasm/codegen/TypeManager.cs
+++ b/mcs/ilasm/codegen/TypeManager.cs
@@ -48,7 +48,7 @@ namespace Mono.ILASM {
                 public void DefineAll ()
                 {
                         ArrayList type_list = new ArrayList (type_table.Values);
-                        type_list.Sort ();
+                        //type_list.Sort ();
                         foreach (TypeDef typedef in type_list) {
                                 typedef.Define (code_gen);
                         }

--- a/mcs/ilasm/codegen/TypeManager.cs
+++ b/mcs/ilasm/codegen/TypeManager.cs
@@ -21,6 +21,7 @@ namespace Mono.ILASM {
                 {
                         this.code_gen = code_gen;
                         type_table = new Hashtable ();
+                        type_list = new ArrayList ();
                 }
 
                 public TypeDef this[string full_name] {

--- a/mcs/ilasm/parser/ILParser.jay
+++ b/mcs/ilasm/parser/ILParser.jay
@@ -652,7 +652,7 @@ impl_class_refs		: K_IMPLEMENTS generic_class_ref
                           {
                                 ArrayList al = (ArrayList) $1;
 
-                                al.Insert (0, $3);
+                                al.Add ($3);
                                 $$ = al;
                           }
  			;

--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -1612,13 +1612,15 @@ set_interface_and_offset (int num_ifaces, MonoClass **interfaces_full, int *inte
 		return FALSE;
 	}
 	for (i = 0; i < num_ifaces; ++i) {
-		if (interfaces_full [i]) {
+		/*if (interfaces_full [i]) {
 			int end;
-			end = i + 1;
+			
 			while (end < num_ifaces && interfaces_full [end]) end++;
 			memmove (interfaces_full + i + 1, interfaces_full + i, sizeof (MonoClass*) * (end - i));
 			memmove (interface_offsets_full + i + 1, interface_offsets_full + i, sizeof (int) * (end - i));
-		}
+		}*/
+		if (interfaces_full [i])
+			continue;
 		interfaces_full [i] = ic;
 		interface_offsets_full [i] = offset;
 		break;

--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -1614,8 +1614,6 @@ set_interface_and_offset (int num_ifaces, MonoClass **interfaces_full, int *inte
 	for (i = 0; i < num_ifaces; ++i) {
 		if (interfaces_full [i]) {
 			int end;
-			if (interfaces_full [i]->interface_id < ic->interface_id)
-				continue;
 			end = i + 1;
 			while (end < num_ifaces && interfaces_full [end]) end++;
 			memmove (interfaces_full + i + 1, interfaces_full + i, sizeof (MonoClass*) * (end - i));

--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -1579,41 +1579,17 @@ count_virtual_methods (MonoClass *klass)
 	return vcount;
 }
 
-static int
-find_interface (int num_ifaces, MonoClass **interfaces_full, MonoClass *ic)
-{
-	int m, l = 0;
-	if (!num_ifaces)
-		return -1;
-	while (1) {
-		if (l > num_ifaces)
-			return -1;
-		m = (l + num_ifaces) / 2;
-		if (interfaces_full [m] == ic)
-			return m;
-		if (l == num_ifaces)
-			return -1;
-		if (!interfaces_full [m] || interfaces_full [m]->interface_id > ic->interface_id) {
-			num_ifaces = m - 1;
-		} else {
-			l =  m + 1;
-		}
-	}
-}
-
 static mono_bool
 set_interface_and_offset (int num_ifaces, MonoClass **interfaces_full, int *interface_offsets_full, MonoClass *ic, int offset, mono_bool force_set)
 {
-	int i = find_interface (num_ifaces, interfaces_full, ic);
-	if (i >= 0) {
-		if (!force_set)
-			return TRUE;
-		interface_offsets_full [i] = offset;
-		return FALSE;
-	}
+	int i;
 	for (i = 0; i < num_ifaces; ++i) {
-		if (interfaces_full [i] && interfaces_full [i]->interface_id == ic->interface_id)
-			return TRUE;
+		if (interfaces_full [i] && interfaces_full [i]->interface_id == ic->interface_id) {
+			if (!force_set)
+				return TRUE;
+			interface_offsets_full [i] = offset;
+			return FALSE;
+		}
 		if (interfaces_full [i])
 			continue;
 		interfaces_full [i] = ic;

--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -1612,13 +1612,8 @@ set_interface_and_offset (int num_ifaces, MonoClass **interfaces_full, int *inte
 		return FALSE;
 	}
 	for (i = 0; i < num_ifaces; ++i) {
-		/*if (interfaces_full [i]) {
-			int end;
-			
-			while (end < num_ifaces && interfaces_full [end]) end++;
-			memmove (interfaces_full + i + 1, interfaces_full + i, sizeof (MonoClass*) * (end - i));
-			memmove (interface_offsets_full + i + 1, interface_offsets_full + i, sizeof (int) * (end - i));
-		}*/
+		if (interfaces_full [i] && interfaces_full [i]->interface_id == ic->interface_id)
+			return TRUE;
 		if (interfaces_full [i])
 			continue;
 		interfaces_full [i] = ic;

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -1735,18 +1735,15 @@ compare_interface_ids (const void *p_key, const void *p_element)
 int
 mono_class_interface_offset (MonoClass *klass, MonoClass *itf)
 {
+	int i;
 	MonoClass **klass_interfaces_packed = m_class_get_interfaces_packed (klass);
-	MonoClass **result = (MonoClass **)mono_binary_search (
-			itf,
-			klass_interfaces_packed,
-			m_class_get_interface_offsets_count (klass),
-			sizeof (MonoClass *),
-			compare_interface_ids);
-	if (result) {
-		return m_class_get_interface_offsets_packed (klass) [result - klass_interfaces_packed];
-	} else {
-		return -1;
+	for (i = 0 ; i < m_class_get_interface_offsets_count (klass); i++ ){
+		MonoClass *result = klass_interfaces_packed[i];
+		if (m_class_get_interface_id(result) == m_class_get_interface_id(itf)) {
+			return m_class_get_interface_offsets_packed (klass) [i];
+		} 
 	}
+	return -1;
 }
 
 /**

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -1737,7 +1737,7 @@ mono_class_interface_offset (MonoClass *klass, MonoClass *itf)
 {
 	int i;
 	MonoClass **klass_interfaces_packed = m_class_get_interfaces_packed (klass);
-	for (i = 0 ; i < m_class_get_interface_offsets_count (klass); i++ ){
+	for (i = m_class_get_interface_offsets_count (klass) -1 ; i >= 0 ; i-- ){
 		MonoClass *result = klass_interfaces_packed[i];
 		if (m_class_get_interface_id(result) == m_class_get_interface_id(itf)) {
 			return m_class_get_interface_offsets_packed (klass) [i];

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1586,7 +1586,8 @@ PROFILE_DISABLED_TESTS += \
 	unhandled-exception-7.exe \
 	unhandled-exception-test-case.2.exe \
 	unload-appdomain-on-shutdown.exe \
-	xdomain-threads.exe
+	xdomain-threads.exe \
+	twopassvariance.exe
 
 # Tests which load assemblies which are not in the profile
 PROFILE_DISABLED_TESTS += \

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1462,9 +1462,6 @@ PROFILE_DISABLED_TESTS += \
 PROFILE_DISABLED_TESTS += \
 	delegate15.exe
 
-PROFILE_DISABLED_TESTS += \
-	twopassvariance.exe
-
 # https://bugzilla.xamarin.com/show_bug.cgi?id=60973
 PROFILE_DISABLED_TESTS += \
 	weak-fields.exe

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1009,6 +1009,7 @@ TESTS_IL_SRC=			\
 	dim-sealed.il \
 	dim-protected-accessibility1.il \
 	dim-protected-accessibility2.il \
+	twopassvariance.il \
 	tailcall-generic-cast-conservestack-il.il \
 	tailcall-generic-cast-nocrash-il.il \
 	tailcall-member-function-in-valuetype.il \

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1462,6 +1462,9 @@ PROFILE_DISABLED_TESTS += \
 PROFILE_DISABLED_TESTS += \
 	delegate15.exe
 
+PROFILE_DISABLED_TESTS += \
+	twopassvariance.exe
+
 # https://bugzilla.xamarin.com/show_bug.cgi?id=60973
 PROFILE_DISABLED_TESTS += \
 	weak-fields.exe

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1586,8 +1586,7 @@ PROFILE_DISABLED_TESTS += \
 	unhandled-exception-7.exe \
 	unhandled-exception-test-case.2.exe \
 	unload-appdomain-on-shutdown.exe \
-	xdomain-threads.exe \
-	twopassvariance.exe
+	xdomain-threads.exe
 
 # Tests which load assemblies which are not in the profile
 PROFILE_DISABLED_TESTS += \

--- a/mono/tests/twopassvariance.il
+++ b/mono/tests/twopassvariance.il
@@ -347,6 +347,6 @@ Fooer7_IFoo_BaseOK:
 
 Fooer7_IFoo_DerivedOK:
 
-    ldc.i4 100
+    ldc.i4 0
     ret
 }

--- a/mono/tests/twopassvariance.il
+++ b/mono/tests/twopassvariance.il
@@ -134,6 +134,28 @@
     }
 }
 
+.class Fooer8<T>
+    implements class IFoo<class Base>, class IFoo<class Derived>
+{
+    .method public specialname rtspecialname instance void .ctor()
+    {
+        ldarg.0
+        call instance void [mscorlib]System.Object::.ctor()
+        ret
+    }
+}
+
+.class Fooer9<T>
+    implements class IFoo<class Derived>, class IFoo<class Base>
+{
+    .method public specialname rtspecialname instance void .ctor()
+    {
+        ldarg.0
+        call instance void [mscorlib]System.Object::.ctor()
+        ret
+    }
+}
+
 .method static int32 main()
 {
     .entrypoint
@@ -346,7 +368,40 @@ Fooer7_IFoo_BaseOK:
     ret
 
 Fooer7_IFoo_DerivedOK:
+    ldstr      "Fooer7_IFoo_DerivedOK"
+    call       void [mscorlib]System.Console::WriteLine(string)
+    newobj instance void class Fooer8<class Base>::.ctor()
+    castclass class IFoo<class SuperDerived>
+    callvirt instance class [mscorlib]System.Type class IFoo<class SuperDerived>::Gimme()
+    dup
+    callvirt instance string [mscorlib]System.Object::ToString()
+    call void [mscorlib]System.Console::WriteLine(string)
+    ldtoken class IFoo<class Base>
+    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+    ceq
+    brtrue Fooer8_IFoo_SuperDerivedOK
+    ldc.i4.1
+    ret
 
+Fooer8_IFoo_SuperDerivedOK:
+    ldstr      "Fooer8_IFoo_SuperDerivedOK"
+    call       void [mscorlib]System.Console::WriteLine(string)
+    newobj instance void class Fooer9<class Base>::.ctor()
+    castclass class IFoo<class SuperDerived>
+    callvirt instance class [mscorlib]System.Type class IFoo<class SuperDerived>::Gimme()
+    dup
+    callvirt instance string [mscorlib]System.Object::ToString()
+    call void [mscorlib]System.Console::WriteLine(string)
+    ldtoken class IFoo<class Derived>
+    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+    ceq
+    brtrue Fooer9_IFoo_SuperDerivedOK
+    ldc.i4.2
+    ret
+
+Fooer9_IFoo_SuperDerivedOK:
+    ldstr      "Fooer9_IFoo_SuperDerivedOK"
+    call       void [mscorlib]System.Console::WriteLine(string)
     ldc.i4 0
     ret
 }

--- a/mono/tests/twopassvariance.il
+++ b/mono/tests/twopassvariance.il
@@ -153,7 +153,7 @@
 
 Fooer1_IFoo_SuperDerivedOK:
     ldstr      "Fooer1_IFoo_SuperDerivedOK"
-    call       void [System.Console]System.Console::WriteLine(string)
+    call       void [mscorlib]System.Console::WriteLine(string)
     newobj instance void Fooer2::.ctor()
     castclass class IFoo<class SuperDerived>
     callvirt instance class [mscorlib]System.Type class IFoo<class SuperDerived>::Gimme()
@@ -169,7 +169,7 @@ Fooer1_IFoo_SuperDerivedOK:
 
 Fooer2_IFoo_SuperDerivedOK:
     ldstr      "Fooer2_IFoo_SuperDerivedOK"
-    call       void [System.Console]System.Console::WriteLine(string)
+    call       void [mscorlib]System.Console::WriteLine(string)
     newobj instance void Fooer3::.ctor()
     castclass class IFoo<class Base>
     callvirt instance class [mscorlib]System.Type class IFoo<class Base>::Gimme()
@@ -185,7 +185,7 @@ Fooer2_IFoo_SuperDerivedOK:
 
 Fooer3_IFoo_BaseOK:
     ldstr      "Fooer3_IFoo_BaseOK"
-    call       void [System.Console]System.Console::WriteLine(string)
+    call       void [mscorlib]System.Console::WriteLine(string)
 
     newobj instance void Fooer3::.ctor()
     castclass class IFoo<class Derived>
@@ -202,7 +202,7 @@ Fooer3_IFoo_BaseOK:
 
 Fooer3_IFoo_DerivedOK:
     ldstr      "Fooer3_IFoo_DerivedOK"
-    call       void [System.Console]System.Console::WriteLine(string)
+    call       void [mscorlib]System.Console::WriteLine(string)
     newobj instance void Fooer3::.ctor()
     castclass class IFoo<class SuperDerived>
     callvirt instance class [mscorlib]System.Type class IFoo<class SuperDerived>::Gimme()
@@ -218,7 +218,7 @@ Fooer3_IFoo_DerivedOK:
 
 Fooer3_IFoo_SuperDerivedOK:
     ldstr      "Fooer3_IFoo_SuperDerivedOK"
-    call       void [System.Console]System.Console::WriteLine(string)
+    call       void [mscorlib]System.Console::WriteLine(string)
     newobj instance void Fooer4::.ctor()
     castclass class IFoo<class Base>
     callvirt instance class [mscorlib]System.Type class IFoo<class Base>::Gimme()
@@ -234,7 +234,7 @@ Fooer3_IFoo_SuperDerivedOK:
 
 Fooer4_IFoo_BaseOK:
     ldstr      "Fooer4_IFoo_BaseOK"
-    call       void [System.Console]System.Console::WriteLine(string)
+    call       void [mscorlib]System.Console::WriteLine(string)
     newobj instance void Fooer4::.ctor()
     castclass class IFoo<class Derived>
     callvirt instance class [mscorlib]System.Type class IFoo<class Derived>::Gimme()
@@ -250,7 +250,7 @@ Fooer4_IFoo_BaseOK:
 
 Fooer4_IFoo_DerivedOK:
     ldstr      "Fooer4_IFoo_DerivedOK"
-    call       void [System.Console]System.Console::WriteLine(string)
+    call       void [mscorlib]System.Console::WriteLine(string)
 
     newobj instance void Fooer4::.ctor()
     castclass class IFoo<class SuperDerived>
@@ -267,7 +267,7 @@ Fooer4_IFoo_DerivedOK:
 
 Fooer4_IFoo_SuperDerivedOK:
     ldstr      "Fooer4_IFoo_SuperDerivedOK"
-    call       void [System.Console]System.Console::WriteLine(string)
+    call       void [mscorlib]System.Console::WriteLine(string)
     newobj instance void Fooer5::.ctor()
     castclass class IFoo<class SuperDerived>
     callvirt instance class [mscorlib]System.Type class IFoo<class SuperDerived>::Gimme()
@@ -283,7 +283,7 @@ Fooer4_IFoo_SuperDerivedOK:
 
 Fooer5_IFoo_SuperDerivedOK:
     ldstr      "Fooer5_IFoo_SuperDerivedOK"
-    call       void [System.Console]System.Console::WriteLine(string)
+    call       void [mscorlib]System.Console::WriteLine(string)
     newobj instance void Fooer6::.ctor()
     castclass class IFoo<class Base>
     callvirt instance class [mscorlib]System.Type class IFoo<class Base>::Gimme()
@@ -299,7 +299,7 @@ Fooer5_IFoo_SuperDerivedOK:
 
 Fooer6_IFoo_BaseOK:
     ldstr      "Fooer6_IFoo_BaseOK"
-    call       void [System.Console]System.Console::WriteLine(string)
+    call       void [mscorlib]System.Console::WriteLine(string)
     newobj instance void Fooer6::.ctor()
     castclass class IFoo<class Derived>
     callvirt instance class [mscorlib]System.Type class IFoo<class Derived>::Gimme()
@@ -315,7 +315,7 @@ Fooer6_IFoo_BaseOK:
 
 Fooer6_IFoo_DerivedOK:
     ldstr      "Fooer6_IFoo_DerivedOK"
-    call       void [System.Console]System.Console::WriteLine(string)
+    call       void [mscorlib]System.Console::WriteLine(string)
     newobj instance void Fooer7::.ctor()
     castclass class IFoo<class Base>
     callvirt instance class [mscorlib]System.Type class IFoo<class Base>::Gimme()
@@ -331,7 +331,7 @@ Fooer6_IFoo_DerivedOK:
 
 Fooer7_IFoo_BaseOK:
     ldstr      "Fooer7_IFoo_BaseOK"
-    call       void [System.Console]System.Console::WriteLine(string)
+    call       void [mscorlib]System.Console::WriteLine(string)
     newobj instance void Fooer7::.ctor()
     castclass class IFoo<class Derived>
     callvirt instance class [mscorlib]System.Type class IFoo<class Derived>::Gimme()

--- a/mono/tests/twopassvariance.il
+++ b/mono/tests/twopassvariance.il
@@ -1,0 +1,352 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib { }
+
+.assembly twopassvariance { }
+
+.class Base { }
+
+.class Derived extends Base { }
+
+.class SuperDerived extends Derived { }
+
+.class MegaSuperDerived extends SuperDerived { }
+
+.class interface IFoo<-T>
+{
+    .method public newslot virtual instance class [mscorlib]System.Type Gimme()
+    {
+        ldtoken class IFoo<!0>
+        call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+        ret
+    }
+}
+
+.class interface IBar<T> implements class IFoo<!T>
+{
+    .method public virtual final instance class [mscorlib]System.Type Gimme()
+    {
+        .override method instance class [mscorlib]System.Type class IFoo<!T>::Gimme()
+        ldtoken class IBar<!0>
+        call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+        ret
+    }
+}
+
+.class interface IBaz<T> implements class IFoo<!T>
+{
+    .method public virtual final instance class [mscorlib]System.Type Gimme()
+    {
+        .override method instance class [mscorlib]System.Type class IFoo<!T>::Gimme()
+        ldtoken class IBar<!0>
+        call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+        ret
+    }
+}
+
+.class interface IQux implements class IFoo<class Base>, class IFoo<class Derived>
+{
+    .method public virtual final instance class [mscorlib]System.Type Gimme()
+    {
+        .override method instance class [mscorlib]System.Type class IFoo<class Base>::Gimme()
+        ldtoken IQux
+        call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+        ret
+    }
+}
+
+.class Fooer1
+    implements class IFoo<class Base>, class IFoo<class Derived>
+{
+    .method public specialname rtspecialname instance void .ctor()
+    {
+        ldarg.0
+        call instance void [mscorlib]System.Object::.ctor()
+        ret
+    }
+}
+
+.class Fooer2
+    implements class IFoo<class Derived>, class IFoo<class Base>
+{
+    .method public specialname rtspecialname instance void .ctor()
+    {
+        ldarg.0
+        call instance void [mscorlib]System.Object::.ctor()
+        ret
+    }
+}
+
+.class Fooer3
+    implements class IBaz<class Base>, class IBar<class Derived>, class IFoo<object>
+{
+    .method public specialname rtspecialname instance void .ctor()
+    {
+        ldarg.0
+        call instance void [mscorlib]System.Object::.ctor()
+        ret
+    }
+}
+
+.class Fooer4
+    implements IQux, class IBar<class Derived>
+{
+    .method public specialname rtspecialname instance void .ctor()
+    {
+        ldarg.0
+        call instance void [mscorlib]System.Object::.ctor()
+        ret
+    }
+}
+
+.class Fooer5
+    implements class IBar<class Derived>, IQux
+{
+    .method public specialname rtspecialname instance void .ctor()
+    {
+        ldarg.0
+        call instance void [mscorlib]System.Object::.ctor()
+        ret
+    }
+}
+
+.class Fooer6
+    implements class IFoo<class Base>, class IBar<class Base>
+{
+    .method public specialname rtspecialname instance void .ctor()
+    {
+        ldarg.0
+        call instance void [mscorlib]System.Object::.ctor()
+        ret
+    }
+}
+
+.class Fooer7
+    implements class IBar<class Base>, class IFoo<class Base>
+{
+    .method public specialname rtspecialname instance void .ctor()
+    {
+        ldarg.0
+        call instance void [mscorlib]System.Object::.ctor()
+        ret
+    }
+}
+
+.method static int32 main()
+{
+    .entrypoint
+
+    newobj instance void Fooer1::.ctor()
+    castclass class IFoo<class SuperDerived>
+    callvirt instance class [mscorlib]System.Type class IFoo<class SuperDerived>::Gimme()
+    dup
+    callvirt instance string [mscorlib]System.Object::ToString()
+    call void [mscorlib]System.Console::WriteLine(string)
+    ldtoken class IFoo<class Base>
+    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+    ceq
+    brtrue Fooer1_IFoo_SuperDerivedOK
+    ldc.i4.1
+    ret
+
+Fooer1_IFoo_SuperDerivedOK:
+    ldstr      "Fooer1_IFoo_SuperDerivedOK"
+    call       void [System.Console]System.Console::WriteLine(string)
+    newobj instance void Fooer2::.ctor()
+    castclass class IFoo<class SuperDerived>
+    callvirt instance class [mscorlib]System.Type class IFoo<class SuperDerived>::Gimme()
+    dup
+    callvirt instance string [mscorlib]System.Object::ToString()
+    call void [mscorlib]System.Console::WriteLine(string)
+    ldtoken class IFoo<class Derived>
+    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+    ceq
+    brtrue Fooer2_IFoo_SuperDerivedOK
+    ldc.i4.2
+    ret
+
+Fooer2_IFoo_SuperDerivedOK:
+    ldstr      "Fooer2_IFoo_SuperDerivedOK"
+    call       void [System.Console]System.Console::WriteLine(string)
+    newobj instance void Fooer3::.ctor()
+    castclass class IFoo<class Base>
+    callvirt instance class [mscorlib]System.Type class IFoo<class Base>::Gimme()
+    dup
+    callvirt instance string [mscorlib]System.Object::ToString()
+    call void [mscorlib]System.Console::WriteLine(string)
+    ldtoken class IBar<class Base>
+    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+    ceq
+    brtrue Fooer3_IFoo_BaseOK
+    ldc.i4.3
+    ret
+
+Fooer3_IFoo_BaseOK:
+    ldstr      "Fooer3_IFoo_BaseOK"
+    call       void [System.Console]System.Console::WriteLine(string)
+
+    newobj instance void Fooer3::.ctor()
+    castclass class IFoo<class Derived>
+    callvirt instance class [mscorlib]System.Type class IFoo<class Derived>::Gimme()
+    dup
+    callvirt instance string [mscorlib]System.Object::ToString()
+    call void [mscorlib]System.Console::WriteLine(string)
+    ldtoken class IBar<class Derived>
+    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+    ceq
+    brtrue Fooer3_IFoo_DerivedOK
+    ldc.i4.4
+    ret
+
+Fooer3_IFoo_DerivedOK:
+    ldstr      "Fooer3_IFoo_DerivedOK"
+    call       void [System.Console]System.Console::WriteLine(string)
+    newobj instance void Fooer3::.ctor()
+    castclass class IFoo<class SuperDerived>
+    callvirt instance class [mscorlib]System.Type class IFoo<class SuperDerived>::Gimme()
+    dup
+    callvirt instance string [mscorlib]System.Object::ToString()
+    call void [mscorlib]System.Console::WriteLine(string)
+    ldtoken class IBar<class Base>
+    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+    ceq
+    brtrue Fooer3_IFoo_SuperDerivedOK
+    ldc.i4.5
+    ret
+
+Fooer3_IFoo_SuperDerivedOK:
+    ldstr      "Fooer3_IFoo_SuperDerivedOK"
+    call       void [System.Console]System.Console::WriteLine(string)
+    newobj instance void Fooer4::.ctor()
+    castclass class IFoo<class Base>
+    callvirt instance class [mscorlib]System.Type class IFoo<class Base>::Gimme()
+    dup
+    callvirt instance string [mscorlib]System.Object::ToString()
+    call void [mscorlib]System.Console::WriteLine(string)
+    ldtoken IQux
+    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+    ceq
+    brtrue Fooer4_IFoo_BaseOK
+    ldc.i4.6
+    ret
+
+Fooer4_IFoo_BaseOK:
+    ldstr      "Fooer4_IFoo_BaseOK"
+    call       void [System.Console]System.Console::WriteLine(string)
+    newobj instance void Fooer4::.ctor()
+    castclass class IFoo<class Derived>
+    callvirt instance class [mscorlib]System.Type class IFoo<class Derived>::Gimme()
+    dup
+    callvirt instance string [mscorlib]System.Object::ToString()
+    call void [mscorlib]System.Console::WriteLine(string)
+    ldtoken class IBar<class Derived>
+    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+    ceq
+    brtrue Fooer4_IFoo_DerivedOK
+    ldc.i4.7
+    ret
+
+Fooer4_IFoo_DerivedOK:
+    ldstr      "Fooer4_IFoo_DerivedOK"
+    call       void [System.Console]System.Console::WriteLine(string)
+
+    newobj instance void Fooer4::.ctor()
+    castclass class IFoo<class SuperDerived>
+    callvirt instance class [mscorlib]System.Type class IFoo<class SuperDerived>::Gimme()
+    dup
+    callvirt instance string [mscorlib]System.Object::ToString()
+    call void [mscorlib]System.Console::WriteLine(string)
+    ldtoken IQux
+    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+    ceq
+    brtrue Fooer4_IFoo_SuperDerivedOK
+    ldc.i4.8
+    ret
+
+Fooer4_IFoo_SuperDerivedOK:
+    ldstr      "Fooer4_IFoo_SuperDerivedOK"
+    call       void [System.Console]System.Console::WriteLine(string)
+    newobj instance void Fooer5::.ctor()
+    castclass class IFoo<class SuperDerived>
+    callvirt instance class [mscorlib]System.Type class IFoo<class SuperDerived>::Gimme()
+    dup
+    callvirt instance string [mscorlib]System.Object::ToString()
+    call void [mscorlib]System.Console::WriteLine(string)
+    ldtoken class IBar<class Derived>
+    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+    ceq
+    brtrue Fooer5_IFoo_SuperDerivedOK
+    ldc.i4 9
+    ret
+
+Fooer5_IFoo_SuperDerivedOK:
+    ldstr      "Fooer5_IFoo_SuperDerivedOK"
+    call       void [System.Console]System.Console::WriteLine(string)
+    newobj instance void Fooer6::.ctor()
+    castclass class IFoo<class Base>
+    callvirt instance class [mscorlib]System.Type class IFoo<class Base>::Gimme()
+    dup
+    callvirt instance string [mscorlib]System.Object::ToString()
+    call void [mscorlib]System.Console::WriteLine(string)
+    ldtoken class IBar<class Base>
+    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+    ceq
+    brtrue Fooer6_IFoo_BaseOK
+    ldc.i4 10
+    ret
+
+Fooer6_IFoo_BaseOK:
+    ldstr      "Fooer6_IFoo_BaseOK"
+    call       void [System.Console]System.Console::WriteLine(string)
+    newobj instance void Fooer6::.ctor()
+    castclass class IFoo<class Derived>
+    callvirt instance class [mscorlib]System.Type class IFoo<class Derived>::Gimme()
+    dup
+    callvirt instance string [mscorlib]System.Object::ToString()
+    call void [mscorlib]System.Console::WriteLine(string)
+    ldtoken class IBar<class Base>
+    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+    ceq
+    brtrue Fooer6_IFoo_DerivedOK
+    ldc.i4 11
+    ret
+
+Fooer6_IFoo_DerivedOK:
+    ldstr      "Fooer6_IFoo_DerivedOK"
+    call       void [System.Console]System.Console::WriteLine(string)
+    newobj instance void Fooer7::.ctor()
+    castclass class IFoo<class Base>
+    callvirt instance class [mscorlib]System.Type class IFoo<class Base>::Gimme()
+    dup
+    callvirt instance string [mscorlib]System.Object::ToString()
+    call void [mscorlib]System.Console::WriteLine(string)
+    ldtoken class IBar<class Base>
+    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+    ceq
+    brtrue Fooer7_IFoo_BaseOK
+    ldc.i4 12
+    ret
+
+Fooer7_IFoo_BaseOK:
+    ldstr      "Fooer7_IFoo_BaseOK"
+    call       void [System.Console]System.Console::WriteLine(string)
+    newobj instance void Fooer7::.ctor()
+    castclass class IFoo<class Derived>
+    callvirt instance class [mscorlib]System.Type class IFoo<class Derived>::Gimme()
+    dup
+    callvirt instance string [mscorlib]System.Object::ToString()
+    call void [mscorlib]System.Console::WriteLine(string)
+    ldtoken class IBar<class Base>
+    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+    ceq
+    brtrue Fooer7_IFoo_DerivedOK
+    ldc.i4 13
+    ret
+
+Fooer7_IFoo_DerivedOK:
+
+    ldc.i4 100
+    ret
+}


### PR DESCRIPTION
This test https://github.com/dotnet/coreclr/blob/1649da12db73c8c07513c9168cb30ec70c310063/tests/src/Regressions/coreclr/20452/twopassvariance.il

On mono we were ordering the list of implemented interfaces and shouldn't do this as it's described on ECMA-335 Section II.12.2.1 and II.12.2.2.
The ordering was removed on ilasm and some changes were needed on metadata either because it's not ordered anymore.

There were two bugs, one on ilasm and other on class initialization on mono.

### ILAsm ###

If we get the .exe generated by .net Framework it doesn't execute on mono without modifications because we ordered the implemented interfaces list by id. And doing that the order defined on source code is ignored.

If we get the .exe generated by Mono it doesn't execute on .net Framework because on IlAsm we order the list and loose the order defined on source code.

The interfaces on metadata before these changes on IlAsm were like this:
```
1: Fooer1 implements class IFoo<class Derived>
2: Fooer1 implements class IFoo<class Base>
3: Fooer2 implements class IFoo<class Base>
4: Fooer2 implements class IFoo<class Derived>
5: Fooer3 implements class IFoo<object>
6: Fooer3 implements class IBar<class Derived>
7: Fooer3 implements class IBaz<class Base>
8: IBar implements class IFoo<!0>
9: IBaz implements class IFoo<!0>
10: Fooer4 implements IQux
11: Fooer4 implements class IBar<class Derived>
12: IQux implements class IFoo<class Base>
13: IQux implements class IFoo<class Derived>
14: Fooer5 implements IQux
15: Fooer5 implements class IBar<class Derived>
16: Fooer6 implements class IBar<class Base>
17: Fooer6 implements class IFoo<class Base>
18: Fooer7 implements class IFoo<class Base>
19: Fooer7 implements class IBar<class Base>
```

And After the changes they follow the definition order which is the same order of IlAsm for .net framework and .net core.
```
1: IBar implements class IFoo<!0>
2: IBaz implements class IFoo<!0>
3: IQux implements class IFoo<class Base>
4: IQux implements class IFoo<class Derived>
5: Fooer1 implements class IFoo<class Base>
6: Fooer1 implements class IFoo<class Derived>
7: Fooer2 implements class IFoo<class Derived>
8: Fooer2 implements class IFoo<class Base>
9: Fooer3 implements class IBaz<class Base>
10: Fooer3 implements class IBar<class Derived>
11: Fooer3 implements class IFoo<object>
12: Fooer4 implements IQux
13: Fooer4 implements class IBar<class Derived>
14: Fooer5 implements class IBar<class Derived>
15: Fooer5 implements IQux
16: Fooer6 implements class IFoo<class Base>
17: Fooer6 implements class IBar<class Base>
18: Fooer7 implements class IBar<class Base>
19: Fooer7 implements class IFoo<class Base>
```

### Mono vtable layout ###

Internally when Mono computes the interface table for each class, it would previously sort the interfaces by `MonoClass:interface_id` which is a unique id assigned (roughly) in load order.  This was incorrect because the order of the interfaces determines the final vtable for the class.  This PR changes the interface table computation so that the interfaces of a single class are ordered in declaration order, following ECMA. 

One consequence is that we can no longer use binary search with the interface id as the key to find out if a class implements an interface.  We have to do a linear scan. On the other hand, we expect that the number of interfaces implemented by a single class is small in practice.

This is how the Vtable for Fooer1 and Fooer2 looks like after the changes:
```
*** Vtable for class 'Fooer1' at "FINALLY" (size 6)
[O][000][INDEX 000] object:ToString () [0x7fd78681db20]
[O][001][INDEX 001] object:GetHashCode () [0x7fd78681daf8]
[O][002][INDEX 002] object:Finalize () [0x7fd78681dad0]
[O][003][INDEX 003] object:Equals (object) [0x7fd78681daa8]
[I][004][INDEX 000] IFoo:Gimme () [0x7fd786503800]
[I][005][INDEX 000] IFoo:Gimme () [0x7fd7865038c0]
Packed interface table for class Fooer1 has size 2
[000][UUID 078][SLOT 004][SIZE 001] interface IFoo[Base]
[001][UUID 079][SLOT 005][SIZE 001] interface IFoo[Derived]
```
and
```
*** Vtable for class 'Fooer2' at "FINALLY" (size 6)
[O][000][INDEX 000] object:ToString () [0x7fd78681db20]
[O][001][INDEX 001] object:GetHashCode () [0x7fd78681daf8]
[O][002][INDEX 002] object:Finalize () [0x7fd78681dad0]
[O][003][INDEX 003] object:Equals (object) [0x7fd78681daa8]
[I][004][INDEX 000] IFoo:Gimme () [0x7fd7865038c0]
[I][005][INDEX 000] IFoo:Gimme () [0x7fd786503800]
Packed interface table for class Fooer2 has size 2
[000][UUID 079][SLOT 004][SIZE 001] interface IFoo[Derived]
[001][UUID 078][SLOT 005][SIZE 001] interface IFoo[Base]
```

This is how the VTable for Fooer1 and Fooer2 looks like before the changes, as you can see Packed interface table are the same in Fooer1 and Fooer2, so the behavior of both classes was the same:

```
Vtable for class 'Fooer1' at "FINALLY" (size 6)
[O][000][INDEX 000] object:ToString () [0x7fcf3801d920]
[O][001][INDEX 001] object:GetHashCode () [0x7fcf3801d8f8]
[O][002][INDEX 002] object:Finalize () [0x7fcf3801d8d0]
[O][003][INDEX 003] object:Equals (object) [0x7fcf3801d8a8]
[I][004][INDEX 000] IFoo:Gimme () [0x7fcf37c29880]
[I][005][INDEX 000] IFoo:Gimme () [0x7fcf37c29940]
Packed interface table for class Fooer1 has size 2
[000][UUID 076][SLOT 004][SIZE 001] interface IFoo[Base]
[001][UUID 077][SLOT 005][SIZE 001] interface IFoo[Derived]
```

```
Vtable for class 'Fooer2' at "FINALLY" (size 6)
[O][000][INDEX 000] object:ToString () [0x7fcf3801d920]
[O][001][INDEX 001] object:GetHashCode () [0x7fcf3801d8f8]
[O][002][INDEX 002] object:Finalize () [0x7fcf3801d8d0]
[O][003][INDEX 003] object:Equals (object) [0x7fcf3801d8a8]
[I][004][INDEX 000] IFoo:Gimme () [0x7fcf37c29940]
[I][005][INDEX 000] IFoo:Gimme () [0x7fcf37c29880]
Packed interface table for class Fooer2 has size 2
[000][UUID 076][SLOT 005][SIZE 001] interface IFoo[Base]
[001][UUID 077][SLOT 004][SIZE 001] interface IFoo[Derived]
```
