### PR TITLE
Add conditionals allowing some calenders to be disabled.

### DIFF
--- a/mcs/class/System.Data/Test/System.Data.SqlTypes/SqlStringTest.cs
+++ b/mcs/class/System.Data/Test/System.Data.SqlTypes/SqlStringTest.cs
@@ -599,6 +599,7 @@ namespace MonoTests.System.Data.SqlTypes
 		}
 
 		[Test]
+		[Category ("Calendars")]
 		public void SqlDateTimeToSqlString()
 		{
 			SqlDateTime TestTime = new SqlDateTime(2002, 10, 22, 9, 52, 30);

--- a/mcs/class/System/Test/System.ComponentModel/DateTimeConverterTests.cs
+++ b/mcs/class/System/Test/System.ComponentModel/DateTimeConverterTests.cs
@@ -12,10 +12,10 @@ using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
 using System.Globalization;
 
-using NUnit.Framework;
-
 namespace MonoTests.System.ComponentModel
 {
+	using NUnit.Framework;
+
 	[TestFixture]
 	public class DateTimeConverterTests
 	{
@@ -146,7 +146,8 @@ namespace MonoTests.System.ComponentModel
 		}
 
 		[Test]
-		[SetCulture("en-GB")]
+		[SetCulture ("en-GB")]
+		[Category ("Calendars")]
 		public void ConvertToString ()
 		{
 			CultureInfo culture = new MyCultureInfo ();

--- a/mcs/class/corlib/System.Globalization/CultureInfo.cs
+++ b/mcs/class/corlib/System.Globalization/CultureInfo.cs
@@ -555,7 +555,11 @@ namespace System.Globalization
 				if (!constructed) Construct ();
 				CheckNeutral ();
 
-				var temp = new DateTimeFormatInfo (m_cultureData, Calendar);
+				DateTimeFormatInfo temp;
+				if (GlobalizationMode.Invariant)
+					temp = new DateTimeFormatInfo();
+				else
+					temp = new DateTimeFormatInfo(m_cultureData, Calendar);
 				temp._isReadOnly = m_isReadOnly;
 				System.Threading.Thread.MemoryBarrier();
 				dateTimeInfo = temp;

--- a/mcs/class/corlib/Test/System.Globalization/CalendarTest.cs
+++ b/mcs/class/corlib/Test/System.Globalization/CalendarTest.cs
@@ -123,6 +123,7 @@ sealed class Date {
 } // class Date
 
 [TestFixture]
+[Category ("Calendars")]
 public class CalendarTest {
 	private Calendar[] acal;
 	private GregorianCalendar gcal;

--- a/mcs/class/corlib/Test/System.Globalization/DateTimeFormatInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Globalization/DateTimeFormatInfoTest.cs
@@ -92,6 +92,7 @@ namespace MonoTests.System.Globalization
 		}
 
 		[Test]
+		[Category ("Calendars")]
 		public void TestSpecificCultureFormats_es_ES ()
 		{
 			CultureInfo ci = new CultureInfo ("es-ES");
@@ -119,6 +120,7 @@ namespace MonoTests.System.Globalization
 		}
 
 		[Test]
+		[Category ("Calendars")]
 		public void MonthGenitiveNames ()
 		{
 			var dfi = new CultureInfo ("cs-CZ").DateTimeFormat;
@@ -127,6 +129,7 @@ namespace MonoTests.System.Globalization
 		}
 
 		[Test]
+		[Category ("Calendars")]
 		public void QuoteInValue ()
 		{
 			var culture = new CultureInfo("mt-MT");
@@ -144,6 +147,7 @@ namespace MonoTests.System.Globalization
 		}
 
 		[Test]
+		[Category ("Calendars")]
 		public void TestFirstYearOfJapaneseEra ()
 		{
 			DateTimeFormatInfo jpnFormat = new CultureInfo ("ja-JP").DateTimeFormat;

--- a/mcs/class/corlib/Test/System.Globalization/EastAsianLunisolarCalendarTest.cs
+++ b/mcs/class/corlib/Test/System.Globalization/EastAsianLunisolarCalendarTest.cs
@@ -37,6 +37,7 @@ using System.IO;
 namespace MonoTests.System.Globalization
 {
 	[TestFixture]
+	[Category ("Calendars")]
 	public class EastAsianLunisolarCalendarTest
 	{
 		static ChineseLunisolarCalendar cn = new ChineseLunisolarCalendar ();

--- a/mcs/class/corlib/Test/System/DateTimeOffsetTest.cs
+++ b/mcs/class/corlib/Test/System/DateTimeOffsetTest.cs
@@ -110,6 +110,7 @@ namespace MonoTests.System {
 		}
 
 		[Test]
+		[Category ("Calendars")]
 		public void ParameterlessToString ()
 		{
 			DateTimeOffset dt = new DateTimeOffset (2007, 12, 18, 12, 16, 30, new TimeSpan (1, 0, 0));
@@ -121,6 +122,7 @@ namespace MonoTests.System {
 		}
 
 		[Test]
+		[Category ("Calendars")]
 		public void ToStringWithCultureInfo ()
 		{
 			DateTimeOffset dto = new DateTimeOffset(2007, 5, 1, 9, 0, 0, TimeSpan.Zero);
@@ -146,6 +148,7 @@ namespace MonoTests.System {
 		}
 
 		[Test]
+		[Category ("Calendars")]
 		public void ToStringWithFormat ()
 		{
 			DateTimeOffset dto = new DateTimeOffset (2007, 10, 31, 21, 0, 0, new TimeSpan(-8, 0, 0));
@@ -173,8 +176,10 @@ namespace MonoTests.System {
 			DateTimeOffset dto = new DateTimeOffset (2007, 11, 1, 9, 0, 0, new TimeSpan(-7, 0, 0));
 			const string format = "dddd, MMM dd yyyy HH:mm:ss zzz";
 			Assert.AreEqual ("Thursday, Nov 01 2007 09:00:00 -07:00", dto.ToString (format, CultureInfo.InvariantCulture), "ts2");
-			Assert.AreEqual ("jeudi, nov. 01 2007 09:00:00 -07:00", dto.ToString (format, new CultureInfo ("fr-FR")), "ts3");
-			Assert.AreEqual ("jueves, nov. 01 2007 09:00:00 -07:00", dto.ToString (format, new CultureInfo ("es-ES")), "ts4");
+			if (!GlobalizationMode.Invariant) {
+				Assert.AreEqual ("jeudi, nov. 01 2007 09:00:00 -07:00", dto.ToString (format, new CultureInfo ("fr-FR")), "ts3");
+				Assert.AreEqual ("jueves, nov. 01 2007 09:00:00 -07:00", dto.ToString (format, new CultureInfo ("es-ES")), "ts4");
+			}
 		}
 
 		[Test]
@@ -251,6 +256,7 @@ namespace MonoTests.System {
 		// see bug 589227
 		//
 		[Test]
+		[Category ("Calendars")]
 		public void ParseExactWithKFormat ()
 		{
 			DateTimeOffset o = DateTimeOffset.ParseExact ("Wed Mar 17 22:25:08 +0000 2010", "ddd MMM d H:m:ss K yyyy", CultureInfo.InvariantCulture);

--- a/mcs/class/corlib/Test/System/DateTimeTest.cs
+++ b/mcs/class/corlib/Test/System/DateTimeTest.cs
@@ -364,6 +364,7 @@ namespace MonoTests.System
 		}
 
 		[Test]
+		[Category ("Calendars")]
 		public void TestToStringGenitive ()
 		{
 			DateTime dt = new DateTime (2010, 1, 2, 3, 4, 5);
@@ -1134,6 +1135,7 @@ namespace MonoTests.System
 		}
 
 		[Test]
+		[Category ("Calendars")]
 		public void TestParseWithDifferentMonthDayPatterns ()
 		{
 			CultureInfo cultureInfo = new CultureInfo("en-US");
@@ -1175,16 +1177,19 @@ namespace MonoTests.System
 		{
 			string s = "Wednesday, 09 June 2004";
 			DateTime.ParseExact (s, "dddd, dd MMMM yyyy", CultureInfo.InvariantCulture);
-			try {
-				DateTime.ParseExact (s, "dddd, dd MMMM yyyy", new CultureInfo ("ja-JP"));
-				Assert.Fail ("ja-JP culture does not support format \"dddd, dd MMMM yyyy\"");
-			} catch (FormatException) {
+			if (!GlobalizationMode.Invariant) {
+				try {
+					DateTime.ParseExact (s, "dddd, dd MMMM yyyy", new CultureInfo ("ja-JP"));
+					Assert.Fail ("ja-JP culture does not support format \"dddd, dd MMMM yyyy\"");
+				} catch (FormatException) {
+				}
 			}
 
 			// Ok, now we can assume ParseExact() works expectedly.
 
 			DateTime.Parse (s, CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces);
-			DateTime.Parse (s, new CultureInfo ("ja-JP"), DateTimeStyles.AllowWhiteSpaces);
+			if (!GlobalizationMode.Invariant)
+				DateTime.Parse (s, new CultureInfo ("ja-JP"), DateTimeStyles.AllowWhiteSpaces);
 			//DateTime.Parse (s, null); currently am not sure if it works for _every_ culture.
 		}
 
@@ -1242,6 +1247,7 @@ namespace MonoTests.System
 		}
 
 		[Test] // bug #72788
+		[Category ("Calendars")]
 		public void Parse_Bug72788 ()
 		{
 			DateTime dt = DateTime.Parse ("21/02/05", new CultureInfo ("fr-FR"));
@@ -1276,6 +1282,7 @@ namespace MonoTests.System
 		}
 
 		[Test]
+		[Category ("Calendars")]
 		public void Parse_Bug53023b ()
 		{
 			foreach (CultureInfo ci in CultureInfo.GetCultures (CultureTypes.SpecificCultures)) {
@@ -1297,6 +1304,7 @@ namespace MonoTests.System
 		}
 
 		[Test]
+		[Category ("Calendars")]
 		public void Parse_SameTimeAndDateSeparator ()
 		{
 			var fiFI = (CultureInfo) CultureInfo.GetCultureInfo("fi-FI").Clone();
@@ -1341,6 +1349,7 @@ namespace MonoTests.System
 		}
 
 		[Test]
+		[Category ("Calendars")]
 		public void ParseCOMDependentFormat ()
 		{
 			// Japanese format.
@@ -1359,6 +1368,7 @@ namespace MonoTests.System
 		}
 
 		[Test]
+		[Category ("Calendars")]
 		[ExpectedException(typeof (FormatException))]
 		public void ParseFormatException1 ()
 		{
@@ -1399,6 +1409,7 @@ namespace MonoTests.System
 		}
 
 		[Test]
+		[Category ("Calendars")]
 		public void ParseUtcNonUtc ()
 		{
 			Thread.CurrentThread.CurrentCulture = new CultureInfo ("es-ES");
@@ -1463,6 +1474,7 @@ namespace MonoTests.System
 		}
 
 		[Test]
+		[Category ("Calendars")]
 		public void TimeZoneAdjustment ()
 		{
 			CultureInfo ci = Thread.CurrentThread.CurrentCulture;
@@ -1851,6 +1863,7 @@ namespace MonoTests.System
 		}
 
 		[Test]
+		[Category ("Calendars")]
 		public void ParseExact_Bug80094 ()
 		{
 			// we can safely change the curernt culture, as the original value will
@@ -2584,6 +2597,7 @@ namespace MonoTests.System
 		}
 		
 		[Test]
+		[Category ("Calendars")]
 		public void GenitiveMonth ()
 		{
 			var ci = new CultureInfo ("ru-RU");
@@ -2592,6 +2606,7 @@ namespace MonoTests.System
 		}
 
 		[Test]
+		[Category ("Calendars")]
 		public void Parse_ThaiCalendar ()
 		{
 			var culture = CultureInfo.GetCultureInfo ("th-TH");
@@ -2670,6 +2685,7 @@ namespace MonoTests.System
 		}
 
 		[Test] // https://github.com/mono/mono/issues/11317
+		[Category ("Calendars")]
 		public void DateTimeKoCulture ()
 		{
 			foreach (var culture in new [] { new CultureInfo ("ko"), new CultureInfo ("ko-KR") })

--- a/mcs/class/corlib/Test/System/TimeSpanTest.cs
+++ b/mcs/class/corlib/Test/System/TimeSpanTest.cs
@@ -657,18 +657,20 @@ public class TimeSpanTest {
 		ParseHelper ("10:11:12:13", false, false, "10.11:12:13"); // Days using : instead of . as separator
 		ParseHelper ("10.11", true, false, "dontcare"); // days+hours is invalid
 
-		// Force the use of french culture -which is using a non common NumberDecimalSeparator-
-		// as current culture, to show that the Parse method is *actually* being culture sensitive
-		// *and* also keeping the compatibility with '.'
-		CultureInfo french_culture = CultureInfo.GetCultureInfo ("fr-FR");
-		CultureInfo prev_culture = CultureInfo.CurrentCulture;
-		try {
-			Thread.CurrentThread.CurrentCulture = french_culture;
-			ParseHelper ("10:10:10,006", false, false, "10:10:10.0060000");
-			ParseHelper ("10:10:10.006", false, false, "10:10:10.0060000");
-		} finally {
-			// restore culture
-			Thread.CurrentThread.CurrentCulture = prev_culture;
+		if (!GlobalizationMode.Invariant) {
+			// Force the use of french culture -which is using a non common NumberDecimalSeparator-
+			// as current culture, to show that the Parse method is *actually* being culture sensitive
+			// *and* also keeping the compatibility with '.'
+			CultureInfo french_culture = CultureInfo.GetCultureInfo ("fr-FR");
+			CultureInfo prev_culture = CultureInfo.CurrentCulture;
+			try {
+				Thread.CurrentThread.CurrentCulture = french_culture;
+				ParseHelper ("10:10:10,006", false, false, "10:10:10.0060000");
+				ParseHelper ("10:10:10.006", false, false, "10:10:10.0060000");
+			} finally {
+				// restore culture
+				Thread.CurrentThread.CurrentCulture = prev_culture;
+			}
 		}
 
 		ParseHelper ("00:00:00", false, false, "00:00:00");
@@ -812,18 +814,20 @@ public class TimeSpanTest {
 		Assert.AreEqual (true, TimeSpan.TryParse ("-10675199.02:48:05.4775808", out result), "MinValue#1");
 		Assert.AreEqual (TimeSpan.MinValue, result, "MinValue#2");
 
-		// Force the use of french culture -which is using a non common NumberDecimalSeparator-
-		// as current culture, to show that the Parse method is *actually* being culture sensitive
-		CultureInfo french_culture = CultureInfo.GetCultureInfo ("fr-FR");
-		CultureInfo prev_culture = CultureInfo.CurrentCulture;
-		result = new TimeSpan (0, 10, 10, 10, 6);
-		try {
-			Thread.CurrentThread.CurrentCulture = french_culture;
-			Assert.AreEqual (true, TimeSpan.TryParse ("10:10:10,006", out result), "#CultureSensitive1");
-			Assert.AreEqual ("10:10:10.0060000", result.ToString (), "#CultureSensitive2");
-		} finally {
-			// restore culture
-			Thread.CurrentThread.CurrentCulture = prev_culture;
+		if (!GlobalizationMode.Invariant) {
+			// Force the use of french culture -which is using a non common NumberDecimalSeparator-
+			// as current culture, to show that the Parse method is *actually* being culture sensitive
+			CultureInfo french_culture = CultureInfo.GetCultureInfo ("fr-FR");
+			CultureInfo prev_culture = CultureInfo.CurrentCulture;
+			result = new TimeSpan (0, 10, 10, 10, 6);
+			try {
+				Thread.CurrentThread.CurrentCulture = french_culture;
+				Assert.AreEqual (true, TimeSpan.TryParse ("10:10:10,006", out result), "#CultureSensitive1");
+				Assert.AreEqual ("10:10:10.0060000", result.ToString (), "#CultureSensitive2");
+			} finally {
+				// restore culture
+				Thread.CurrentThread.CurrentCulture = prev_culture;
+			}
 		}
 	}
 
@@ -842,10 +846,12 @@ public class TimeSpanTest {
 	{ 
 		TimeSpan result;
 
-		// We use fr-FR culture since its NumericDecimalSeparator is not the same used by
-		// most cultures - including the invariant one.
-		CultureInfo french_culture = CultureInfo.GetCultureInfo ("fr-FR");
-		Assert.AreEqual (true, TimeSpan.TryParse ("11:50:50,006", french_culture, out result), "#A1");
+		if (!GlobalizationMode.Invariant) {
+			// We use fr-FR culture since its NumericDecimalSeparator is not the same used by
+			// most cultures - including the invariant one.
+			CultureInfo french_culture = CultureInfo.GetCultureInfo ("fr-FR");
+			Assert.AreEqual (true, TimeSpan.TryParse ("11:50:50,006", french_culture, out result), "#A1");
+		}
 
 		// LAMESPEC - msdn states that an instance of DateTimeFormatInfo is retrieved to
 		// obtain culture sensitive information, but at least in the betas that's false
@@ -858,9 +864,6 @@ public class TimeSpanTest {
 	[Test]
 	public void ParseExact ()
 	{
-		CultureInfo french_culture = CultureInfo.GetCultureInfo ("fr-FR");
-		CultureInfo us_culture = CultureInfo.GetCultureInfo ("en-US");
-
 		// At this point we are only missing the style bites and then we are
 		// pretty much done with the standard formats.
 
@@ -876,16 +879,21 @@ public class TimeSpanTest {
 		ParseExactHelper ("11:12:13", g_format, false, false, "11:12:13");
 		ParseExactHelper ("-11:12:13", g_format, false, false, "-11:12:13");
 		ParseExactHelper ("10.11:12:13", g_format, true, false, "dontcare"); // this should work as well
-		ParseExactHelper ("10.11:12:13", g_format, true, false, "dontcare", us_culture);
 		ParseExactHelper ("10.11:12:13", g_format, true, false, "dontcare", CultureInfo.InvariantCulture);
 		ParseExactHelper ("10:11:12:66", g_format, true, false, "dontcare");
 		ParseExactHelper ("10:11:12:13", g_format, false, false, "10.11:12:13");
 		ParseExactHelper ("11:12:13.6", g_format, false, false, "11:12:13.6000000", CultureInfo.InvariantCulture);
-		ParseExactHelper ("11:12:13,6", g_format, false, false, "11:12:13.6000000", french_culture);
-		ParseExactHelper ("10:11:12:13.6", g_format, false, false, "10.11:12:13.6000000", us_culture);
-		ParseExactHelper (" 10:11:12:13.6 ", g_format, false, false, "10.11:12:13.6000000", us_culture);
 		ParseExactHelper ("10:11", g_format, false, false, "10:11:00", null, TimeSpanStyles.None);
 		ParseExactHelper ("10:11", g_format, false, false, "10:11:00", null, TimeSpanStyles.AssumeNegative); // no effect
+
+		if (!GlobalizationMode.Invariant) {
+			CultureInfo french_culture = CultureInfo.GetCultureInfo ("fr-FR");
+			CultureInfo us_culture = CultureInfo.GetCultureInfo ("en-US");
+			ParseExactHelper ("10.11:12:13", g_format, true, false, "dontcare", us_culture);
+			ParseExactHelper ("11:12:13,6", g_format, false, false, "11:12:13.6000000", french_culture);
+			ParseExactHelper ("10:11:12:13.6", g_format, false, false, "10.11:12:13.6000000", us_culture);
+			ParseExactHelper (" 10:11:12:13.6 ", g_format, false, false, "10.11:12:13.6000000", us_culture);
+		}
 
 		// 
 		// G format
@@ -895,15 +903,20 @@ public class TimeSpanTest {
 		ParseExactHelper ("9:10:12.6", G_format, true, false, "dontcare");
 		ParseExactHelper ("3.9:10:12", G_format, true, false, "dontcare");
 		ParseExactHelper ("3.9:10:12.153", G_format, true, false, "dontcare"); // this should be valid...
-		ParseExactHelper ("3:9:10:12.153", G_format, false, false, "3.09:10:12.1530000", us_culture);
-		ParseExactHelper ("0:9:10:12.153", G_format, false, false, "09:10:12.1530000", us_culture);
-		ParseExactHelper ("03:09:10:12.153", G_format, false, false, "3.09:10:12.1530000", us_culture);
-		ParseExactHelper ("003:009:0010:0012.00153", G_format, false, false, "3.09:10:12.0015300", us_culture);
 		ParseExactHelper ("3:9:10:66.153", G_format, true, false, "dontcare"); // seconds out of range
-		ParseExactHelper ("3:9:10:12.153", G_format, true, false, "dontcare", french_culture); // fr-FR uses ',' as decimal separator
-		ParseExactHelper ("3:9:10:12,153", G_format, false, false, "3.09:10:12.1530000", french_culture);
-		ParseExactHelper ("  3:9:10:12.153  ", G_format, false, false, "3.09:10:12.1530000", us_culture);
-		ParseExactHelper ("3:9:10:13.153", G_format, false, false, "3.09:10:13.1530000", us_culture, TimeSpanStyles.AssumeNegative);
+
+		if (!GlobalizationMode.Invariant) {
+			CultureInfo french_culture = CultureInfo.GetCultureInfo ("fr-FR");
+			CultureInfo us_culture = CultureInfo.GetCultureInfo ("en-US");
+			ParseExactHelper ("3:9:10:12.153", G_format, false, false, "3.09:10:12.1530000", us_culture);
+			ParseExactHelper ("0:9:10:12.153", G_format, false, false, "09:10:12.1530000", us_culture);
+			ParseExactHelper ("03:09:10:12.153", G_format, false, false, "3.09:10:12.1530000", us_culture);
+			ParseExactHelper ("003:009:0010:0012.00153", G_format, false, false, "3.09:10:12.0015300", us_culture);
+			ParseExactHelper ("3:9:10:12.153", G_format, true, false, "dontcare", french_culture); // fr-FR uses ',' as decimal separator
+			ParseExactHelper ("3:9:10:12,153", G_format, false, false, "3.09:10:12.1530000", french_culture);
+			ParseExactHelper ("  3:9:10:12.153  ", G_format, false, false, "3.09:10:12.1530000", us_culture);
+			ParseExactHelper ("3:9:10:13.153", G_format, false, false, "3.09:10:13.1530000", us_culture, TimeSpanStyles.AssumeNegative);
+		}
 
 		// c format
 		string [] c_format = new string [] { "c" };
@@ -915,7 +928,6 @@ public class TimeSpanTest {
 		ParseExactHelper ("10:11:12:13", c_format, true, false, "dontcare"); // this is normally accepted in the Parse method
 		ParseExactHelper ("10.11:12:13.6", c_format, false, false, "10.11:12:13.6000000");
 		ParseExactHelper ("10:11:12,6", c_format, true, false, "dontcare");
-		ParseExactHelper ("10:11:12,6", c_format, true, false, "dontcare", french_culture);
 		ParseExactHelper ("  10:11:12.6  ", c_format, false, false, "10:11:12.6000000");
 		ParseExactHelper ("10:12", c_format, false, false, "10:12:00", null, TimeSpanStyles.AssumeNegative);
 		ParseExactHelper ("10:123456789999", c_format, true, false, "dontcare");
@@ -923,6 +935,11 @@ public class TimeSpanTest {
 		ParseExactHelper ("10:12", new string [0], true, false, "dontcare");
 		ParseExactHelper ("10:12", new string [] { String.Empty }, true, false, "dontcare");
 		ParseExactHelper ("10:12", new string [] { null }, true, false, "dontcare");
+
+		if (!GlobalizationMode.Invariant) {
+			CultureInfo french_culture = CultureInfo.GetCultureInfo ("fr-FR");
+			ParseExactHelper ("10:11:12,6", c_format, true, false, "dontcare", french_culture);
+		}
 	}
 
 	[Test]
@@ -1072,6 +1089,7 @@ public class TimeSpanTest {
 
 	// 'Ported' the ParseExact test to use TryParseExact instead.
 	[Test]
+	[Category ("Calendars")]
 	public void TryParseExact ()
 	{
 		CultureInfo french_culture = CultureInfo.GetCultureInfo ("fr-FR");
@@ -1185,21 +1203,23 @@ public class TimeSpanTest {
 		Assert.AreEqual ("1.02:03:04.0060000", ts.ToString (null), "#A3");
 		Assert.AreEqual ("1.02:03:04.0060000", ts.ToString (String.Empty), "#A4");
 
-		//
-		// IFormatProvider ones - use a culture changing numeric format.
-		// Also, we use fr-FR as culture, since it uses some elements different to invariant culture
-		//
-		CultureInfo culture = CultureInfo.GetCultureInfo ("fr-FR");
+		if (!GlobalizationMode.Invariant) {
+			//
+			// IFormatProvider ones - use a culture changing numeric format.
+			// Also, we use fr-FR as culture, since it uses some elements different to invariant culture
+			//
+			CultureInfo culture = CultureInfo.GetCultureInfo ("fr-FR");
 
-		Assert.AreEqual ("1:2:03:04,006", ts.ToString ("g", culture), "#B1");
-		Assert.AreEqual ("1:02:03:04,0060000", ts.ToString ("G", culture), "#B2");
-		Assert.AreEqual ("1.02:03:04.0060000", ts.ToString ("c", culture), "#B3"); // 'c' format ignores CultureInfo
-		Assert.AreEqual ("1.02:03:04.0060000", ts.ToString ("t", culture), "#B4"); // 't' and 'T' are the same as 'c'
-		Assert.AreEqual("1.02:03:04.0060000", ts.ToString("T", culture), "#B5");
+			Assert.AreEqual ("1:2:03:04,006", ts.ToString ("g", culture), "#B1");
+			Assert.AreEqual ("1:02:03:04,0060000", ts.ToString ("G", culture), "#B2");
+			Assert.AreEqual ("1.02:03:04.0060000", ts.ToString ("c", culture), "#B3"); // 'c' format ignores CultureInfo
+			Assert.AreEqual ("1.02:03:04.0060000", ts.ToString ("t", culture), "#B4"); // 't' and 'T' are the same as 'c'
+			Assert.AreEqual("1.02:03:04.0060000", ts.ToString("T", culture), "#B5");
 
-		ts = new TimeSpan (4, 5, 6);
-		Assert.AreEqual ("4:05:06", ts.ToString ("g", culture), "#C1");
-		Assert.AreEqual ("0:04:05:06,0000000", ts.ToString ("G", culture), "#C2");
+			ts = new TimeSpan (4, 5, 6);
+			Assert.AreEqual ("4:05:06", ts.ToString ("g", culture), "#C1");
+			Assert.AreEqual ("0:04:05:06,0000000", ts.ToString ("G", culture), "#C2");
+		}
 	}
 
 	[Test]

--- a/mcs/class/corlib/corlib_test.dll.sources
+++ b/mcs/class/corlib/corlib_test.dll.sources
@@ -1,3 +1,5 @@
+../../../../external/corert/src/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.cs
+../corefx/GlobalizationMode.cs
 Microsoft.Win32/RegistryKeyTest.cs
 Mono/DataConvertTest.cs
 ../Mono/DataConverter.cs

--- a/mcs/class/corlib/corlib_xtest.dll.sources
+++ b/mcs/class/corlib/corlib_xtest.dll.sources
@@ -1,3 +1,6 @@
+../../../external/corert/src/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.cs
+corefx/GlobalizationMode.cs
+
 ../../../external/corefx/src/CoreFx.Private.TestUtilities/src/System/AssertExtensions.cs
 ../../../external/corefx/src/Common/tests/System/MockType.cs
 

--- a/mcs/class/referencesource/mscorlib/system/globalization/calendardata.cs
+++ b/mcs/class/referencesource/mscorlib/system/globalization/calendardata.cs
@@ -184,7 +184,7 @@ namespace System.Globalization
             InitializeAbbreviatedEraNames(localeName, calendarId);
 
             // Abbreviated English Era Names are only used for the Japanese calendar.
-            if (calendarId == (int)CalendarId.JAPAN)
+            if (!GlobalizationMode.Invariant && calendarId == (int)CalendarId.JAPAN)
             {
                 this.saAbbrevEnglishEraNames = JapaneseCalendar.EnglishEraNames();
             }
@@ -268,6 +268,10 @@ namespace System.Globalization
                     
                 case CalendarId.JAPAN:
                 case CalendarId.JAPANESELUNISOLAR:
+                    if (GlobalizationMode.Invariant)
+                    {
+                        throw new PlatformNotSupportedException();
+                    }
                     this.saEraNames = JapaneseCalendar.EraNames();
                     break;
 
@@ -306,7 +310,11 @@ namespace System.Globalization
                     break;                    
                 case CalendarId.JAPAN:
                 case CalendarId.JAPANESELUNISOLAR:
-                    this.saAbbrevEraNames = JapaneseCalendar.AbbrevEraNames();
+                    if (GlobalizationMode.Invariant)
+                    {
+                        throw new PlatformNotSupportedException();
+                    }
+                    this.saAbbrevEraNames = this.saEraNames;
                     break;
                 case CalendarId.HIJRI:
                 case CalendarId.UMALQURA:


### PR DESCRIPTION
Add `GlobalizationMode.Invariant` conditionals to some calendar code.

This allows the Japanese, Taiwan and Hebrew calendars to be disabled.