### PR TITLE
Fixed casing

### DIFF
--- a/sdks/wasm/binding_support.js
+++ b/sdks/wasm/binding_support.js
@@ -417,7 +417,7 @@ var BindingSupportLib = {
 					newTypedArray = new Int16Array(end - begin);
 					break;
 				case 8: 
-					newTypedArray = new UInt16Array(end - begin);
+					newTypedArray = new Uint16Array(end - begin);
 					break;
 				case 9: 
 					newTypedArray = new Int32Array(end - begin);


### PR DESCRIPTION
Hi guys,

Yesterday I updated the WASM SDK and noticed an error while using Uint16Array: there's a misspeling in the binding_support.js file.

I've modified it on final mono.js one and works as expected.

Thanks for your work,

PS: We're using above here: https://github.com/MarcosCobena/WebGL.NET

—Marcos