### PR TITLE
Make the DnsTest more resilient to multi-IP DNS results

### DIFF
--- a/mcs/class/System/Test/System.Net/DnsTest.cs
+++ b/mcs/class/System/Test/System.Net/DnsTest.cs
@@ -75,8 +75,7 @@ namespace MonoTests.System.Net
 			IAsyncResult async = Dns.BeginResolve (site1Dot, null, null);
 			IPHostEntry entry = Dns.EndResolve (async);
 			SubTestValidIPHostEntry (entry);
-			var ip = GetIPv4Address (entry);
-			Assert.AreEqual (site1Dot, ip.ToString ());
+			CheckIPv4Address (entry, IPAddress.Parse (site1Dot));
 		}
 
 		[Test]
@@ -239,12 +238,10 @@ namespace MonoTests.System.Net
 			}
 		}
 
-		static IPAddress GetIPv4Address (IPHostEntry h)
+		static void CheckIPv4Address (IPHostEntry h, IPAddress a)
 		{
-			var al = h.AddressList.FirstOrDefault (x => x.AddressFamily == AddressFamily.InterNetwork);
-			if (al == null)
-				Assert.Ignore ("Could not resolve an IPv4 address as required by this test case, e.g. running on an IPv6 only network");
-			return al;
+			var al = h.AddressList.Contains (a);
+			Assert.True (al, "Failed to resolve host name " + h.HostName + " to expected IP address " + a.ToString());
 		}
 
 		void SubTestGetHostByName (string siteName, string siteDot)
@@ -252,8 +249,7 @@ namespace MonoTests.System.Net
 			IPHostEntry h = Dns.GetHostByName (siteName);
 			SubTestValidIPHostEntry (h);
 			Assert.AreEqual (siteName, h.HostName, "siteName");
-			var ip = GetIPv4Address (h);
-			Assert.AreEqual (siteDot, ip.ToString (), "siteDot");
+			CheckIPv4Address (h, IPAddress.Parse (siteDot));
 		}
 
 		[Test]
@@ -330,8 +326,7 @@ namespace MonoTests.System.Net
 			IPAddress addr = new IPAddress (IPAddress.NetworkToHostOrder ((int) site1IP));
 			IPHostEntry h = Dns.GetHostByAddress (addr);
 			SubTestValidIPHostEntry (h);
-			var ip = GetIPv4Address (h);
-			Assert.AreEqual (addr.ToString (), ip.ToString ());
+			CheckIPv4Address (h, addr);
 		}
 
 		[Test]
@@ -340,8 +335,7 @@ namespace MonoTests.System.Net
 			IPAddress addr = new IPAddress (IPAddress.NetworkToHostOrder ((int) site2IP));
 			IPHostEntry h = Dns.GetHostByAddress (addr);
 			SubTestValidIPHostEntry (h);
-			var ip = GetIPv4Address (h);
-			Assert.AreEqual (addr.ToString (), ip.ToString ());
+			CheckIPv4Address (h, addr);
 		}
 
 		[Test]


### PR DESCRIPTION
Sometimes Google DNS is/was returning "dns.google" for reverse query of 8.8.8.8 and 8.8.4.4 instead of the expected "google-public-dns-a.google.com" and "google-public-dns-b.google.com". Since "dns.google" resolves to both 8.8.8.8 and 8.8.4.4 in random order the round-trip tests for IP -> hostname -> IP were failing when they got the other IP. This changes the logic in the hostname -> IP check to check whether the expected IP is any one of the returned ones (ie. non necessarily the first one). 

/cc @akoeplinger @kg 