### PR TITLE
[System] Clear MONO_CFG_DIR before starting mcs in CodeDOM CSharpCodeGenerator

### DIFF
--- a/mcs/class/System/Microsoft.CSharp/CSharpCodeGenerator.cs
+++ b/mcs/class/System/Microsoft.CSharp/CSharpCodeGenerator.cs
@@ -89,8 +89,11 @@ namespace Microsoft.CSharp
 			/*
 			 * reset MONO_GC_PARAMS - we are invoking compiler possibly with another GC that
 			 * may not handle some of the options causing compilation failure
+			 *
+			 * reset MONO_CFG_DIR - we don't want to propagate the current config to another mono
 			 */
-			mcs.StartInfo.EnvironmentVariables ["MONO_GC_PARAMS"] = String.Empty;
+			mcs.StartInfo.EnvironmentVariables.Remove ("MONO_GC_PARAMS");
+			mcs.StartInfo.EnvironmentVariables.Remove ("MONO_CFG_DIR");
 
 			mcs.StartInfo.CreateNoWindow=true;
 			mcs.StartInfo.UseShellExecute=false;

--- a/mcs/class/System/Microsoft.CSharp/CSharpCodeGenerator.cs
+++ b/mcs/class/System/Microsoft.CSharp/CSharpCodeGenerator.cs
@@ -89,11 +89,16 @@ namespace Microsoft.CSharp
 			/*
 			 * reset MONO_GC_PARAMS - we are invoking compiler possibly with another GC that
 			 * may not handle some of the options causing compilation failure
-			 *
-			 * reset MONO_CFG_DIR - we don't want to propagate the current config to another mono
 			 */
 			mcs.StartInfo.EnvironmentVariables.Remove ("MONO_GC_PARAMS");
+
+#if XAMMAC_4_5
+			/*/
+			 * reset MONO_CFG_DIR - we don't want to propagate the current config to another mono
+			 * since it's specific to the XM application and won't work on system mono.
+			 */
 			mcs.StartInfo.EnvironmentVariables.Remove ("MONO_CFG_DIR");
+#endif
 
 			mcs.StartInfo.CreateNoWindow=true;
 			mcs.StartInfo.UseShellExecute=false;


### PR DESCRIPTION
This showed up in the xamarin-macios 2019-02 integration.
When you used Xslt with a custom C# script in a Xamarin.Mac Full application we'd try to launch mcs via CodeDOM to compile the script.

This started failing in 2019-02 because System.Native (mono-native) wasn't found and we now need it for basic File IO, the reason is that XM sets MONO_CFG_DIR to point to the Contents/MonoBundle in the app bundle where it packages the global config file with dllmaps.

However the started Mono wasn't able to find mono-native since the config there uses a different name for the file.

To prevent that we now clear MONO_CFG_DIR so it uses the default value for the mono process we're starting (note that setting it to String.Empty doesn't work)
