### PR TITLE
Revert roslyn bump to fix msbuild and some other scenarios

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5821,8 +5821,7 @@ fi
 AC_SUBST(mono_runtime)
 AC_SUBST(mono_runtime_wrapper)
 
-CSC_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.1.0/csc.exe
-VBCS_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/3.1.0/VBCSCompiler.exe
+CSC_LOCATION=`cd $srcdir && pwd`/external/roslyn-binaries/Microsoft.Net.Compilers/Microsoft.Net.Compilers.2.8.2/tools/csc.exe
 
 if test $csc_compiler = mcs; then
   CSC=$mcs_topdir/class/lib/build/mcs.exe
@@ -5838,7 +5837,6 @@ if test x$host_win32 = xyes; then
     mono_cfg_dir=`cygpath -w -a $mono_cfg_root`\\etc
     CSC=`cygpath -m -a $CSC`
     CSC_LOCATION=`cygpath -m -a $CSC_LOCATION`
-    VBCS_LOCATION=`cygpath -m -a $VBCS_LOCATION`
   else
     mono_cfg_dir=`echo $mono_cfg_root | tr '/' '\\'`\\etc
   fi
@@ -6576,7 +6574,7 @@ fi
 
     echo "STANDALONE_CSC_LOCATION=$CSC_LOCATION" >> $srcdir/$mcsdir/build/config.make
     echo "SERVER_CSC_LOCATION?=$CSC_LOCATION" >> $srcdir/$mcsdir/build/config.make
-    echo "VBCS_LOCATION?=$VBCS_LOCATION" >> $srcdir/$mcsdir/build/config.make
+    echo "VBCS_LOCATION?=" >> $srcdir/$mcsdir/build/config.make
 
     if test $csc_compiler = mcs; then
       echo "MCS_MODE = 1" >> $srcdir/$mcsdir/build/config.make

--- a/mcs/packages/Makefile
+++ b/mcs/packages/Makefile
@@ -19,9 +19,7 @@ ROSLYN_FILES_FOR_MONO = \
 	$(ROSLYN_CSC_DIR)/Microsoft.CodeAnalysis.dll		\
 	$(ROSLYN_CSC_DIR)/Microsoft.CodeAnalysis.Scripting.dll \
 	$(ROSLYN_CSC_DIR)/System.Collections.Immutable.dll	\
-	$(ROSLYN_CSC_DIR)/System.Numerics.Vectors.dll		\
 	$(ROSLYN_CSC_DIR)/System.Reflection.Metadata.dll	\
-	$(ROSLYN_CSC_DIR)/System.Runtime.CompilerServices.Unsafe.dll	\
 	$(ROSLYN_CSC_DIR)/System.Threading.Tasks.Extensions.dll	\
 	$(ROSLYN_CSC_DIR)/System.Memory.dll	\
 	$(ROSLYN_CSC_DIR)/VBCSCompiler.exe			\

--- a/mcs/packages/Makefile
+++ b/mcs/packages/Makefile
@@ -20,8 +20,6 @@ ROSLYN_FILES_FOR_MONO = \
 	$(ROSLYN_CSC_DIR)/Microsoft.CodeAnalysis.Scripting.dll \
 	$(ROSLYN_CSC_DIR)/System.Collections.Immutable.dll	\
 	$(ROSLYN_CSC_DIR)/System.Reflection.Metadata.dll	\
-	$(ROSLYN_CSC_DIR)/System.Threading.Tasks.Extensions.dll	\
-	$(ROSLYN_CSC_DIR)/System.Memory.dll	\
 	$(ROSLYN_CSC_DIR)/VBCSCompiler.exe			\
 	$(ROSLYN_CSC_DIR)/VBCSCompiler.exe.config
 
@@ -31,6 +29,8 @@ ROSLYN_FILES_TO_COPY_FOR_MSBUILD = \
 	$(ROSLYN_CSC_DIR)/Microsoft.Managed.Core.targets	 \
 	$(ROSLYN_CSC_DIR)/Microsoft.VisualBasic.Core.targets
 
+ROSLYN_DIM_FILES = $(topdir)/../external/roslyn-binaries/Prototypes/DefaultInterfaceImplementation/*
+
 DISTFILES = $(ROSLYN_FILES_FOR_MONO) $(ROSLYN_FILES_TO_COPY_FOR_MSBUILD) csi-test.csx
 
 ifeq ($(PROFILE), $(DEFAULT_PROFILE))
@@ -38,13 +38,17 @@ ifeq ($(PROFILE), $(DEFAULT_PROFILE))
 TARGET_DIR = $(DESTDIR)$(mono_libdir)/mono/$(FRAMEWORK_VERSION)
 MSBUILD_ROSLYN_DIR = $(DESTDIR)$(mono_libdir)/mono/msbuild/Current/bin/Roslyn
 
-install-local:
+install-local: install-prototypes
 	$(MKINSTALLDIRS) $(TARGET_DIR)
 	$(INSTALL_LIB) $(ROSLYN_FILES_FOR_MONO) $(TARGET_DIR)
 	$(MKINSTALLDIRS) $(MSBUILD_ROSLYN_DIR)
 	$(INSTALL_LIB) $(ROSLYN_FILES_TO_COPY_FOR_MSBUILD) $(MSBUILD_ROSLYN_DIR)
 
 	(cd $(MSBUILD_ROSLYN_DIR); for asm in $(ROSLYN_FILES_FOR_MONO); do ln -fs ../../../../$(FRAMEWORK_VERSION)/$$(basename $$asm) . ; done)
+
+install-prototypes:
+	$(MKINSTALLDIRS) $(TARGET_DIR)/dim
+	$(INSTALL_LIB) $(ROSLYN_DIM_FILES) $(TARGET_DIR)/dim
 
 run-test-local: test-csi
 


### PR DESCRIPTION
MSBuild and/or csc have broken in some configurations and scenarios as a result of the roslyn bump, so this PR backs it out entirely, returning us to the version of Roslyn we were previously using. DIM remains a current-ish version of Roslyn as before.