### PR TITLE
Add tests to ensure `make install` prefix is functional

### DIFF
--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -54,7 +54,7 @@ if [[ ${CI_TAGS} == *'osx-i386'* ]]; then EXTRA_CFLAGS="$EXTRA_CFLAGS -m32 -arch
 if [[ ${CI_TAGS} == *'osx-amd64'* ]]; then EXTRA_CFLAGS="$EXTRA_CFLAGS -m64 -arch x86_64 -mmacosx-version-min=10.9"; EXTRA_LDFLAGS="$EXTRA_LDFLAGS -m64 -arch x86_64" EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-libgdiplus=/Library/Frameworks/Mono.framework/Versions/Current/lib/libgdiplus.dylib"; fi
 if [[ ${CI_TAGS} == *'win-i386'* ]]; then PLATFORM=Win32; EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --host=i686-w64-mingw32 --enable-btls"; export MONO_EXECUTABLE="${MONO_REPO_ROOT}/msvc/build/sgen/Win32/bin/Release/mono-sgen.exe"; fi
 if [[ ${CI_TAGS} == *'win-amd64'* ]]; then PLATFORM=x64; EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --host=x86_64-w64-mingw32 --disable-boehm --enable-btls"; export MONO_EXECUTABLE="${MONO_REPO_ROOT}/msvc/build/sgen/x64/bin/Release/mono-sgen.exe"; fi
-if [[ ${CI_TAGS} == *'prefix-tests'* ]]; then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --enable-loadedllvm --prefix=${MONO_REPO_ROOT}/tmp/monoprefix"; fi
+if [[ ${CI_TAGS} == *'make-install'* ]]; then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --enable-loadedllvm --prefix=${MONO_REPO_ROOT}/tmp/monoprefix"; fi
 
 if   [[ ${CI_TAGS} == *'coop-suspend'* ]];   then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --disable-hybrid-suspend --enable-cooperative-suspend";
 elif [[ ${CI_TAGS} == *'hybrid-suspend'* ]]; then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --enable-hybrid-suspend";
@@ -357,7 +357,7 @@ elif [[ ${CI_TAGS} == *'interpreter'* ]];              then ${MONO_REPO_ROOT}/sc
 elif [[ ${CI_TAGS} == *'mcs-compiler'* ]];             then ${MONO_REPO_ROOT}/scripts/ci/run-test-mcs.sh;
 elif [[ ${CI_TAGS} == *'mac-sdk'* ]];                  then ${MONO_REPO_ROOT}/scripts/ci/run-test-mac-sdk.sh;
 elif [[ ${CI_TAGS} == *'helix-tests'* ]];              then ${MONO_REPO_ROOT}/scripts/ci/run-test-helix.sh;
-elif [[ ${CI_TAGS} == *'prefix-tests'* ]];             then ${MONO_REPO_ROOT}/scripts/ci/run-test-make-install.sh;
+elif [[ ${CI_TAGS} == *'make-install'* ]];             then ${MONO_REPO_ROOT}/scripts/ci/run-test-make-install.sh;
 elif [[ ${CI_TAGS} == *'no-tests'* ]];                 then echo "Skipping tests.";
 else make check-ci;
 fi

--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -54,6 +54,7 @@ if [[ ${CI_TAGS} == *'osx-i386'* ]]; then EXTRA_CFLAGS="$EXTRA_CFLAGS -m32 -arch
 if [[ ${CI_TAGS} == *'osx-amd64'* ]]; then EXTRA_CFLAGS="$EXTRA_CFLAGS -m64 -arch x86_64 -mmacosx-version-min=10.9"; EXTRA_LDFLAGS="$EXTRA_LDFLAGS -m64 -arch x86_64" EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --with-libgdiplus=/Library/Frameworks/Mono.framework/Versions/Current/lib/libgdiplus.dylib"; fi
 if [[ ${CI_TAGS} == *'win-i386'* ]]; then PLATFORM=Win32; EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --host=i686-w64-mingw32 --enable-btls"; export MONO_EXECUTABLE="${MONO_REPO_ROOT}/msvc/build/sgen/Win32/bin/Release/mono-sgen.exe"; fi
 if [[ ${CI_TAGS} == *'win-amd64'* ]]; then PLATFORM=x64; EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --host=x86_64-w64-mingw32 --disable-boehm --enable-btls"; export MONO_EXECUTABLE="${MONO_REPO_ROOT}/msvc/build/sgen/x64/bin/Release/mono-sgen.exe"; fi
+if [[ ${CI_TAGS} == *'prefix-tests'* ]]; then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --enable-loadedllvm --prefix=${MONO_REPO_ROOT}/tmp/monoprefix"; fi
 
 if   [[ ${CI_TAGS} == *'coop-suspend'* ]];   then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --disable-hybrid-suspend --enable-cooperative-suspend";
 elif [[ ${CI_TAGS} == *'hybrid-suspend'* ]]; then EXTRA_CONF_FLAGS="${EXTRA_CONF_FLAGS} --enable-hybrid-suspend";
@@ -356,6 +357,7 @@ elif [[ ${CI_TAGS} == *'interpreter'* ]];              then ${MONO_REPO_ROOT}/sc
 elif [[ ${CI_TAGS} == *'mcs-compiler'* ]];             then ${MONO_REPO_ROOT}/scripts/ci/run-test-mcs.sh;
 elif [[ ${CI_TAGS} == *'mac-sdk'* ]];                  then ${MONO_REPO_ROOT}/scripts/ci/run-test-mac-sdk.sh;
 elif [[ ${CI_TAGS} == *'helix-tests'* ]];              then ${MONO_REPO_ROOT}/scripts/ci/run-test-helix.sh;
+elif [[ ${CI_TAGS} == *'prefix-tests'* ]];             then ${MONO_REPO_ROOT}/scripts/ci/run-test-make-install.sh;
 elif [[ ${CI_TAGS} == *'no-tests'* ]];                 then echo "Skipping tests.";
 else make check-ci;
 fi

--- a/scripts/ci/run-test-make-install.sh
+++ b/scripts/ci/run-test-make-install.sh
@@ -1,13 +1,15 @@
 #!/bin/bash -e
 
 ${TESTCMD} --label=make-install --timeout=30m make -w install
-mkdir -p ${MONO_REPO_ROOT}/tmp/
-echo "class H{static void Main(){System.Console.WriteLine(\"ok\");}}" > ${MONO_REPO_ROOT}/tmp/hello.cs
-export LD_LIBRARY_PATH=${MONO_REPO_ROOT}/tmp/monoprefix/lib:${LD_LIBRARY_PATH}
-${TESTCMD} --label=check-prefix-mcs --timeout=1m ${MONO_REPO_ROOT}/tmp/monoprefix/bin/mcs /out:${MONO_REPO_ROOT}/tmp/hello.exe ${MONO_REPO_ROOT}/tmp/hello.cs 
-${TESTCMD} --label=check-prefix-roslyn --timeout=1m ${MONO_REPO_ROOT}/tmp/monoprefix/bin/csc /out:${MONO_REPO_ROOT}/tmp/hello.exe ${MONO_REPO_ROOT}/tmp/hello.cs
-${TESTCMD} --label=check-prefix-aot --timeout=1m ${MONO_REPO_ROOT}/tmp/monoprefix/bin/mono --aot ${MONO_REPO_ROOT}/tmp/hello.exe
-${TESTCMD} --label=check-prefix-llvmaot --timeout=1m ${MONO_REPO_ROOT}/tmp/monoprefix/bin/mono --aot=llvm,llvm-path=/usr/lib/mono/llvm/bin ${MONO_REPO_ROOT}/tmp/hello.exe
-${TESTCMD} --label=check-prefix-llvmjit --timeout=1m ${MONO_REPO_ROOT}/tmp/monoprefix/bin/mono --llvm ${MONO_REPO_ROOT}/tmp/hello.exe
+echo "class H { static void Main () { System.Console.WriteLine (\"Hello World: \" + System.DateTime.Now); } }" > ${MONO_REPO_ROOT}/tmp/hello.cs
 
-${MONO_REPO_ROOT}/scripts/ci/run-upload-sentry.sh
+MONO_PREFIX=${MONO_REPO_ROOT}/tmp/monoprefix
+export DYLD_FALLBACK_LIBRARY_PATH=$MONO_PREFIX/lib:$DYLD_LIBRARY_FALLBACK_PATH
+export LD_LIBRARY_PATH=$MONO_PREFIX/lib:$LD_LIBRARY_PATH
+export PATH=$MONO_PREFIX/bin:$PATH
+
+${TESTCMD} --label=check-prefix-mcs --timeout=1m mcs /out:${MONO_REPO_ROOT}/tmp/hello.exe ${MONO_REPO_ROOT}/tmp/hello.cs 
+${TESTCMD} --label=check-prefix-roslyn --timeout=1m csc /out:${MONO_REPO_ROOT}/tmp/hello.exe ${MONO_REPO_ROOT}/tmp/hello.cs
+${TESTCMD} --label=check-prefix-aot --timeout=1m mono --aot ${MONO_REPO_ROOT}/tmp/hello.exe
+${TESTCMD} --label=check-prefix-llvmaot --timeout=1m mono --aot=llvm,llvm-path=/usr/lib/mono/llvm/bin ${MONO_REPO_ROOT}/tmp/hello.exe
+${TESTCMD} --label=check-prefix-llvmjit --timeout=1m mono --llvm ${MONO_REPO_ROOT}/tmp/hello.exe

--- a/scripts/ci/run-test-make-install.sh
+++ b/scripts/ci/run-test-make-install.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+${TESTCMD} --label=make-install --timeout=30m make -w install
+mkdir -p ${MONO_REPO_ROOT}/tmp/
+echo "class H{static void Main(){System.Console.WriteLine(\"ok\");}}" > ${MONO_REPO_ROOT}/tmp/hello.cs
+export LD_LIBRARY_PATH=${MONO_REPO_ROOT}/tmp/monoprefix/lib:${LD_LIBRARY_PATH}
+${TESTCMD} --label=check-prefix-mcs --timeout=1m ${MONO_REPO_ROOT}/tmp/monoprefix/bin/mcs /out:${MONO_REPO_ROOT}/tmp/hello.exe ${MONO_REPO_ROOT}/tmp/hello.cs 
+${TESTCMD} --label=check-prefix-roslyn --timeout=1m ${MONO_REPO_ROOT}/tmp/monoprefix/bin/csc /out:${MONO_REPO_ROOT}/tmp/hello.exe ${MONO_REPO_ROOT}/tmp/hello.cs
+${TESTCMD} --label=check-prefix-aot --timeout=1m ${MONO_REPO_ROOT}/tmp/monoprefix/bin/mono --aot ${MONO_REPO_ROOT}/tmp/hello.exe
+${TESTCMD} --label=check-prefix-llvmaot --timeout=1m ${MONO_REPO_ROOT}/tmp/monoprefix/bin/mono --aot=llvm,llvm-path=/usr/lib/mono/llvm/bin ${MONO_REPO_ROOT}/tmp/hello.exe
+${TESTCMD} --label=check-prefix-llvmjit --timeout=1m ${MONO_REPO_ROOT}/tmp/monoprefix/bin/mono --llvm ${MONO_REPO_ROOT}/tmp/hello.exe
+
+${MONO_REPO_ROOT}/scripts/ci/run-upload-sentry.sh


### PR DESCRIPTION
Adds 5 quick checks, on prefix-tests tag:
* Build a basic file with mcs
* Build a basic file with Roslyn
* AOT an assembly
* LLVM AOT an assembly
* LLVM JIT an assembly

This uses loadedllvm, since that's what we ship on Linux.

This should let us spot regressions affecting installed prefixes sooner