### PR TITLE
[netcore] Fix Marshal.IsPinnable

### DIFF
--- a/mcs/class/System.Private.CoreLib/System.Runtime.InteropServices/Marshal.cs
+++ b/mcs/class/System.Private.CoreLib/System.Runtime.InteropServices/Marshal.cs
@@ -49,7 +49,10 @@ namespace System.Runtime.InteropServices
 
 		internal static bool IsPinnable (object obj)
 		{
-			return obj == null || RuntimeTypeHandle.HasReferences (obj.GetType () as RuntimeType);
+			if (obj == null)
+				return true;
+			Type type = obj.GetType ();
+			return !type.IsValueType || RuntimeTypeHandle.HasReferences (type as RuntimeType);
 		}
 
 		// TODO: Should be called from Windows only code

--- a/netcore/.gitignore
+++ b/netcore/.gitignore
@@ -1,7 +1,7 @@
 LICENSE.txt
 ThirdPartyNotices.txt
 tests
-shared
+/shared
 sdk
 dotnet*
 netcoreapp2.0/


### PR DESCRIPTION
Fixes 19 failing tests in System.Runtime.Tests
before my fix this IsPinnable returned false for `sbyte[]` 

Inspired by https://github.com/mono/mono/blob/master/mcs/class/corlib/System.Runtime.CompilerServices/RuntimeHelpers.cs#L189

Also, do not add `netcore/System.Private.Corlib/shared` to gitignore, only `netcore/shared`