### PR TITLE
[netcore] Fix few Array tests

### DIFF
--- a/mcs/class/System.Private.CoreLib/System/Array.cs
+++ b/mcs/class/System.Private.CoreLib/System/Array.cs
@@ -303,7 +303,7 @@ namespace System
 				if (lengths [j] < 0)
 					throw new ArgumentOutOfRangeException ($"lengths[{j}]", "Each value has to be >= 0.");
 				if ((long)lowerBounds [j] + (long)lengths [j] > (long)Int32.MaxValue)
-					throw new ArgumentOutOfRangeException ("lengths", "Length + bound must not exceed Int32.MaxValue.");
+					throw new ArgumentOutOfRangeException (null, "Length + bound must not exceed Int32.MaxValue.");
 			}
 
 			if (lengths.Length > 255)

--- a/mcs/class/System.Private.CoreLib/System/Buffer.cs
+++ b/mcs/class/System.Private.CoreLib/System/Buffer.cs
@@ -17,7 +17,7 @@ namespace System
 			if (src == null)
 				throw new ArgumentNullException (nameof (src));
 			if (dest == null)
-				throw new ArgumentNullException (nameof (dest));
+				throw new ArgumentNullException ("dst");
 
 			if (srcOffset < 0)
 				throw new ArgumentOutOfRangeException (nameof (srcOffset), SR.ArgumentOutOfRange_MustBeNonNegInt32);

--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -689,7 +689,10 @@ mono_exception_new_argument_internal (const char *type, const char *arg, const c
 	MonoStringHandle arg_str = arg ? mono_string_new_handle (mono_domain_get (), arg, error) : NULL_HANDLE_STRING;
 	MonoStringHandle msg_str = msg ? mono_string_new_handle (mono_domain_get (), msg, error) : NULL_HANDLE_STRING;
 
-	return mono_exception_from_name_two_strings_checked (mono_get_corlib (), "System", type, msg_str, arg_str, error);
+	if (!strcmp (type, "ArgumentException"))
+		return mono_exception_from_name_two_strings_checked (mono_get_corlib (), "System", type, msg_str, arg_str, error);
+	else
+		return mono_exception_from_name_two_strings_checked (mono_get_corlib (), "System", type, arg_str, msg_str, error);
 #else
 	MonoExceptionHandle ex = mono_exception_new_by_name_msg (mono_get_corlib (), "System", type, msg, error);
 
@@ -711,7 +714,7 @@ mono_exception_new_argument (const char *arg, const char *msg, MonoError *error)
 MonoExceptionHandle
 mono_exception_new_argument_null (const char *arg, MonoError *error)
 {
-	return mono_exception_new_argument_internal ("ArgumentNullException", NULL, arg, error);
+	return mono_exception_new_argument_internal ("ArgumentNullException", arg, NULL, error);
 }
 
 MonoExceptionHandle

--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -711,7 +711,7 @@ mono_exception_new_argument (const char *arg, const char *msg, MonoError *error)
 MonoExceptionHandle
 mono_exception_new_argument_null (const char *arg, MonoError *error)
 {
-	return mono_exception_new_argument_internal ("ArgumentNullException", arg, NULL, error);
+	return mono_exception_new_argument_internal ("ArgumentNullException", NULL, arg, error);
 }
 
 MonoExceptionHandle

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -331,12 +331,6 @@ array_set_value_impl (MonoArrayHandle arr_handle, MonoObjectHandle value_handle,
 	MonoTypeEnum vt;
 	vt = m_class_get_byval_arg (vc)->type;
 
-#ifdef ENABLE_NETCORE
-	if (m_class_is_enumtype (ec) && m_class_is_primitive (vc))
-		/* Can't convert a primitive to an enum */
-		INVALID_CAST;
-#endif
-
 	/* Check element (destination) type. */
 	switch (et) {
 	case MONO_TYPE_STRING:

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -634,7 +634,11 @@ ves_icall_System_Array_SetValue (MonoArrayHandle arr, MonoObjectHandle value,
 
 	g_assert (m_class_get_rank (ic) == 1);
 	if (mono_handle_array_has_bounds (idxs) || MONO_HANDLE_GETVAL (idxs, max_length) != m_class_get_rank (ac)) {
+#ifdef ENABLE_NETCORE
+		mono_error_set_argument (error, NULL, "");
+#else
 		mono_error_set_argument (error, "idxs", "");
+#endif
 		return;
 	}
 

--- a/netcore/excludes-System.Runtime.Tests.rsp
+++ b/netcore/excludes-System.Runtime.Tests.rsp
@@ -36,14 +36,6 @@
 -nomethod System.Tests.UriMethodTests.EscapeUriString_Invalid
 -nomethod System.Tests.UriMethodTests.GetComponents_Invalid
 
-# Remote test runner can't load System.Globalization.Native
--nomethod System.Text.Tests.StringBuilderTests.Test_Insert_Float
--nomethod System.Text.Tests.StringBuilderTests.Test_Insert_Double
--nomethod System.Text.Tests.StringBuilderTests.Test_Insert_Decimal
--nomethod System.Text.Tests.StringBuilderTests.Test_Append_Float
--nomethod System.Text.Tests.StringBuilderTests.Test_Append_Double
--nomethod System.Text.Tests.StringBuilderTests.Test_Append_Decimal
-
 # Works, but leads to a SIGSEGV under lldb even with explicit-null-checks
 -nomethod *Append_CharPointer_Null_ThrowsNullReferenceException
 

--- a/netcore/excludes-System.Runtime.Tests.rsp
+++ b/netcore/excludes-System.Runtime.Tests.rsp
@@ -3,11 +3,6 @@
 -nomethod *LastIndexOf_ArrayOfPointers_ThrowsNotSupportedException
 -nomethod *Reverse_ArrayOfPointers_ThrowsNotSupportedException
 # No SRE yet
--nomethod *CreateInstance_TypeNotRuntimeType_ThrowsArgumentException
--nomethod *CreateInstance_NotRuntimeType_ThrowsArgumentException
--nomethod *CreateInstance_NonPublicValueTypeWithPrivateDefaultConstructor_Success
--nomethod *CreateInstance_TypeBuilder_ThrowsNotSupportedException
--nomethod *CreateInstance_PublicOnlyValueTypeWithPrivateDefaultConstructor_ThrowsMissingMethodException
 -nomethod System.Tests.EnumTests.GetName_MultipleMatches
 -nomethod System.Tests.EnumTests.GetName_Invalid
 -nomethod System.Tests.EnumTests.GetName_NonIntegralTypes
@@ -70,10 +65,6 @@
 -nomethod System.Tests.GCTests.KeepAlive_Null
 -nomethod System.Tests.LazyTests.Value_Invalid
 -nomethod System.Tests.LazyTests.Value_ThrownException_DoesntCreateValue
-
-# GCHandle.ctor is not implemented
--nomethod System.Tests.UriCreateStringTests.Path_Query_Fragment
--nomethod System.Tests.UriCreateStringTests.OriginalString_AbsoluteUri_ToString
 
 -noclass System.Tests.TypeTestsExtended
 -noclass System.Tests.ArgIteratorTests

--- a/netcore/excludes-System.Runtime.Tests.rsp
+++ b/netcore/excludes-System.Runtime.Tests.rsp
@@ -66,7 +66,6 @@
 -nomethod *StaticThrow_UpdatesStackTraceAppropriately
 -nomethod System.Reflection.Tests.InvokeRefReturnNetcoreTests.TestRefReturnNullable
 -nomethod System.Runtime.Serialization.Tests.SerializationExceptionTests.Ctor_SerializationInfo_StreamingContext
--nomethod System.Tests.BufferTests.BlockCopy_Invalid
 -nomethod System.Tests.GCTests.ReRegisterForFinalize
 -nomethod System.Tests.WeakReferenceTests.NonGeneric
 

--- a/netcore/excludes-System.Runtime.Tests.rsp
+++ b/netcore/excludes-System.Runtime.Tests.rsp
@@ -28,13 +28,6 @@
 -nomethod System.Tests.GCTests.LargeObjectHeapCompactionModeRoundTrips
 -nomethod System.Tests.GCTests.GetAllocatedBytesForCurrentThread
 -nomethod System.Tests.GCTests.LatencyRoundtrips
-# InternalGetSatelliteAssembly
--nomethod System.Tests.UriCreateStringTests.Create_String_InvalidUriKind_ThrowsArgumentException
--nomethod System.Tests.UriMethodTests.MakeRelative_Invalid
--nomethod System.Tests.UriMethodTests.IsWellFormedUriString
--nomethod System.Tests.UriMethodTests.EscapeDataString_Invalid
--nomethod System.Tests.UriMethodTests.EscapeUriString_Invalid
--nomethod System.Tests.UriMethodTests.GetComponents_Invalid
 
 # Works, but leads to a SIGSEGV under lldb even with explicit-null-checks
 -nomethod *Append_CharPointer_Null_ThrowsNullReferenceException
@@ -55,7 +48,6 @@
 -nomethod System.Tests.ActivatorTests.CreateInstance_DesignatedOptionalParameters_ThrowsMissingMemberException
 -nomethod System.Reflection.Tests.InvokeRefReturnNetcoreTests.TestByRefLikeRefReturn
 -nomethod System.Tests.StringTests.NormalizationTest
--nomethod System.Tests.StringTests.IndexOf_HungarianDoubleCompression_HungarianCulture
 -nomethod *HideDetectionHappensBeforeBindingFlagChecks
 -nomethod *TestRefReturnNullableNoValue
 -nomethod *TestRefReturnOfPointer


### PR DESCRIPTION
Fixes 7 System.Tests.ArrayTests

ArrayTests still has a lot of failing tests for `ArrayTypeMismatchException` (tests expect it when we throw nothing and vice versa).

Mostly these two:
```
System.Tests.ArrayTests.ConstrainedCopy_UnreliableConversion_ThrowsArrayTypeMismatchException
System.Tests.ArrayTests.Copy_SourceAndDestinationNeverConvertible_ThrowsArrayTypeMismatchException
```