### PR TITLE
[wasm] Update to emscripten 1.38.30 

### DIFF
--- a/sdks/builds/wasm.mk
+++ b/sdks/builds/wasm.mk
@@ -1,7 +1,7 @@
 #emcc has lots of bash'isms
 SHELL:=/bin/bash
 
-EMSCRIPTEN_VERSION=1.38.29
+EMSCRIPTEN_VERSION=1.38.30
 EMSCRIPTEN_SDK_DIR=$(TOP)/sdks/builds/toolchains/emsdk
 
 $(TOP)/sdks/builds/toolchains/emsdk:


### PR DESCRIPTION
Updating to recent sdk 1.38.30.

There seems to be a problem with the 1.38.30 release right now for OSX.

Issue: https://github.com/WebAssembly/binaryen/issues/1975