### PR TITLE
[2018-10][sdks,mac] Remove dependency on MXE in favor of MinGW

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -556,6 +556,13 @@ if test x$have_zlib = xyes; then
    ])
 fi
 
+AC_ARG_WITH(static-zlib, [  --with-static-zlib=PATH    use the specified static zlib instead of -lz],[STATIC_ZLIB_PATH=$with_static_zlib],[STATIC_ZLIB_PATH=])
+if test "x$STATIC_ZLIB_PATH" != "x"; then
+	have_static_zlib=yes
+	AC_SUBST(STATIC_ZLIB_PATH)
+fi
+
+AM_CONDITIONAL(HAVE_STATIC_ZLIB, test x$have_static_zlib = xyes)
 AM_CONDITIONAL(HAVE_ZLIB, test x$have_zlib = xyes)
 AC_DEFINE(HAVE_ZLIB,1,[Have system zlib])
 

--- a/llvm/Makefile.am
+++ b/llvm/Makefile.am
@@ -9,10 +9,14 @@ else
 llvm_config=llvm-config
 endif
 
+if HAVE_STATIC_ZLIB
+llvm_extra_libs = $(STATIC_ZLIB_PATH)
+else
 if HAVE_ZLIB
 llvm_extra_libs=-lz
 else
 llvm_extra_libs=
+endif
 endif
 
 if INTERNAL_LLVM

--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -158,8 +158,12 @@ libmonoruntime_config_la_CPPFLAGS = $(AM_CPPFLAGS) -DMONO_BINDIR=\"$(bindir)/\" 
 #
 libmonoruntime_support_la_SOURCES = $(support_sources)
 libmonoruntime_support_la_CFLAGS = $(filter-out @CXX_REMOVE_CFLAGS@, @CFLAGS@)
+if HAVE_STATIC_ZLIB
+libmonoruntime_support_la_LDFLAGS = $(STATIC_ZLIB_PATH)
+else
 if HAVE_ZLIB
 libmonoruntime_support_la_LDFLAGS = -lz
+endif
 endif
 
 #

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -15,6 +15,13 @@
  */
 
 #include <config.h>
+
+#if defined(TARGET_WIN32) || defined(HOST_WIN32)
+/* Needed for _ecvt_s */
+#define MINGW_HAS_SECURE_API 1
+#include <stdio.h>
+#endif
+
 #include <glib.h>
 #include <stdarg.h>
 #include <string.h>
@@ -31,6 +38,7 @@
 #if defined (HAVE_WCHAR_H)
 #include <wchar.h>
 #endif
+
 #include "mono/metadata/icall-internals.h"
 #include "mono/utils/mono-membar.h"
 #include <mono/metadata/object.h>

--- a/mono/profiler/Makefile.am
+++ b/mono/profiler/Makefile.am
@@ -99,11 +99,15 @@ endif
 endif
 endif
 
+if HAVE_STATIC_ZLIB
+zlib_dep = $(STATIC_ZLIB_PATH)
+else
 if HAVE_ZLIB
 # The log profiler uses zlib for output compression when available.
 zlib_dep = -lz
 else
 zlib_dep =
+endif
 endif
 
 # We build a separate, static version of each profiler for use on targets

--- a/scripts/ci/pipeline/sdks-archive.groovy
+++ b/scripts/ci/pipeline/sdks-archive.groovy
@@ -79,9 +79,9 @@ def archive (product, configuration, platform, chrootname = "", chrootadditional
                     // build the Archive
                     timeout (time: 300, unit: 'MINUTES') {
                         if (platform == "Darwin") {
-                            def brewpackages = "autoconf automake ccache cmake coreutils gdk-pixbuf gettext glib gnu-sed gnu-tar intltool ios-deploy jpeg libffi libidn2 libpng libtiff libtool libunistring ninja openssl p7zip pcre pkg-config scons wget xz mingw-w64 make"
+                            def brewpackages = "autoconf automake ccache cmake coreutils gdk-pixbuf gettext glib gnu-sed gnu-tar intltool ios-deploy jpeg libffi libidn2 libpng libtiff libtool libunistring ninja openssl p7zip pcre pkg-config scons wget xz mingw-w64 make xamarin/xamarin-android-windeps/mingw-zlib"
+                            sh "brew tap xamarin/xamarin-android-windeps"
                             sh "brew install ${brewpackages} || brew upgrade ${brewpackages}"
-
                             sh "CI_TAGS=sdks-${product},no-tests,${configuration} scripts/ci/run-jenkins.sh"
                         } else if (platform == "Linux") {
                             chroot chrootName: chrootname,

--- a/sdks/android/Makefile
+++ b/sdks/android/Makefile
@@ -9,9 +9,6 @@ SDK_DIR = $(ANDROID_TOOLCHAIN_DIR)/sdk
 NDK_DIR = $(ANDROID_TOOLCHAIN_DIR)/ndk
 
 ADB       = $(SDK_DIR)/platform-tools/adb
-ANDROID   = $(SDK_DIR)/tools/android
-ANT       = ant
-NDK_BUILD = $(NDK_DIR)/ndk-build
 
 PACKAGE   = org.mono.android.AndroidTestRunner
 RUNNER    = org.mono.android.AndroidRunner

--- a/sdks/builds/Makefile
+++ b/sdks/builds/Makefile
@@ -1,16 +1,26 @@
 TOP=$(realpath $(CURDIR)/../..)
 -include $(TOP)/sdks/Make.config
 
+all: package
+
 MAKEFLAGS += --no-builtin-rules
 
 CONFIGURATION?=release
 
 RELEASE=$(if $(filter $(CONFIGURATION),release),1)
 
+lowercase=$(shell echo "$(1)" | tr '[:upper:]' '[:lower:]')
+
 CCACHE:=$(if $(DISABLE_CCACHE),,$(shell which ccache))
 NINJA:=$(shell which ninja)
 
 UNAME=$(shell uname)
+
+ifneq ($(UNAME),Darwin)
+ifneq ($(UNAME),Linux)
+$(error "Unsupported UNAME=$(UNAME)")
+endif
+endif
 
 ifneq ($(UNAME),Darwin)
 # iOS requires Xcode to be available, and Xcode is only available on macOS
@@ -40,19 +50,100 @@ configure-mono: $(TOP)/configure
 $(TOP)/configure: $(TOP)/configure.ac $(TOP)/autogen.sh
 	cd $(TOP) && PATH=$(EXTRA_PATH):$$PATH NOCONFIGURE=1 ./autogen.sh
 
-TARGETS=
+## Archive targets
 
 ifndef DISABLE_ANDROID
-android_TARGETS=
+android_ARCHIVE=
 endif
 
 ifndef DISABLE_IOS
-ios_TARGETS=
+ios_ARCHIVE=
 endif
 
 ifndef DISABLE_WASM
-wasm_TARGETS=
+wasm_ARCHIVE=
 endif
+
+##
+# Parameters:
+#  $(1): target (android, ios, wasm)
+define ArchiveTemplate
+_$(1)_HASH = $$(shell git -C $$(TOP) rev-parse HEAD)
+_$(1)_PACKAGE = $(1)-$$(CONFIGURATION)-$$(UNAME)-$$(_$(1)_HASH).zip
+
+.PHONY: archive-$(1)
+archive-$(1):
+	cd $$(TOP)/sdks/out && 7z a $$(TOP)/$$(_$(1)_PACKAGE) $$(sort $$($(1)_ARCHIVE))
+endef
+
+ifndef DISABLE_ANDROID
+$(eval $(call ArchiveTemplate,android))
+endif
+
+ifndef DISABLE_IOS
+$(eval $(call ArchiveTemplate,ios))
+endif
+
+ifndef DISABLE_WASM
+$(eval $(call ArchiveTemplate,wasm))
+endif
+
+## Targets
+
+.PHONY: build-custom-%
+build-custom-%:
+	$(MAKE) -C $*
+
+.PHONY: setup-custom-%
+setup-custom-%:
+	mkdir -p $(TOP)/sdks/out/$*
+
+##
+# Parameters:
+# $(1): product
+# $(2): target
+define TargetTemplate
+
+.PHONY: toolchain-$(1)-$(2)
+toolchain-$(1)-$(2): .stamp-$(1)-$(2)-toolchain
+
+.PHONY: toolchain
+toolchain: toolchain-$(1)-$(2)
+
+.stamp-$(1)-$(2)-configure: .stamp-$(1)-$(2)-toolchain
+
+.PHONY: configure-$(1)-$(2)
+configure-$(1)-$(2): .stamp-$(1)-$(2)-configure
+
+.PHONY: configure
+configure: configure-$(1)-$(2)
+
+.PHONY: build-$(1)-$(2)
+build-$(1)-$(2): .stamp-$(1)-$(2)-configure
+	$$(MAKE) build-custom-$(1)-$(2)
+
+.PHONY: build
+build: build-$(1)-$(2)
+
+.PHONY: setup-$(1)-$(2)
+setup-$(1)-$(2):
+	$$(MAKE) setup-custom-$(1)-$(2)
+
+.PHONY: package-$(1)-$(2)
+package-$(1)-$(2): setup-$(1)-$(2) build-$(1)-$(2)
+
+.PHONY: package
+package: package-$(1)-$(2)
+
+.PHONY: clean-$(1)-$(2)
+clean-$(1)-$(2):
+
+.PHONY: clean
+clean: clean-$(1)-$(2)
+
+endef
+
+## Products
 
 include runtime.mk
 include bcl.mk
@@ -86,78 +177,3 @@ endif
 ifndef DISABLE_WASM
 include wasm.mk
 endif
-
-## Archive targets
-
-##
-# Parameters:
-#  $(1): target (android, ios, wasm)
-define ArchiveTemplate
-_$(1)_HASH = $$(shell git -C $$(TOP) rev-parse HEAD)
-_$(1)_PACKAGE = $(1)-$$(CONFIGURATION)-$$(UNAME)-$$(_$(1)_HASH).zip
-
-.PHONY: archive-$(1)
-archive-$(1): $$(foreach target,$$(filter $(1)-%,$$(patsubst %-$$(CONFIGURATION),%,$$($(1)_TARGETS))),package-$$(target))
-	cd $$(TOP)/sdks/out && 7z a $$(TOP)/$$(_$(1)_PACKAGE) $$(sort $$(foreach target,$$($(1)_TARGETS),$$(or $$(wildcard $$(target)-$$(CONFIGURATION)),$$(target))))
-endef
-
-ifndef DISABLE_ANDROID
-$(eval $(call ArchiveTemplate,android))
-endif
-
-ifndef DISABLE_IOS
-$(eval $(call ArchiveTemplate,ios))
-endif
-
-ifndef DISABLE_WASM
-$(eval $(call ArchiveTemplate,wasm))
-endif
-
-## Generic targets
-.PHONY: $(foreach target,$(TARGETS),toolchain-$(target))
-$(foreach target,$(TARGETS),toolchain-$(target)): toolchain-%: .stamp-%-toolchain
-
-$(foreach target,$(TARGETS),.stamp-$(target)-configure): .stamp-%-configure: .stamp-%-toolchain
-
-.PHONY: $(foreach target,$(TARGETS),configure-$(target))
-$(foreach target,$(TARGETS),configure-$(target)): configure-%: .stamp-%-configure
-
-.PHONY: build-custom-%
-build-custom-%:
-	$(MAKE) -C $*
-
-.PHONY: $(foreach target,$(TARGETS),build-$(target))
-$(foreach target,$(TARGETS),build-$(target)): build-%: .stamp-%-configure
-	$(MAKE) build-custom-$*
-
-.PHONY: setup-custom-%
-setup-custom-%:
-	mkdir -p $(TOP)/sdks/out/$*
-
-.PHONY: $(foreach target,$(TARGETS),setup-$(target))
-$(foreach target,$(TARGETS),setup-$(target)): setup-%:
-	$(MAKE) setup-custom-$*
-
-.PHONY: $(foreach target,$(TARGETS),package-$(target))
-$(foreach target,$(TARGETS),package-$(target)): package-%: setup-% build-%
-
-.PHONY: $(foreach target,$(TARGETS),clean-$(target))
-$(foreach target,$(TARGETS),clean-$(target)): clean-%:
-
-## Global targets
-.PHONY: toolchain
-toolchain: $(foreach target,$(TARGETS),toolchain-$(target))
-
-.PHONY: configure
-configure: $(foreach target,$(TARGETS),configure-$(target))
-
-.PHONY: build
-build: $(foreach target,$(TARGETS),build-$(target))
-
-.PHONY: package
-package: $(foreach target,$(TARGETS),package-$(target))
-
-.PHONY: clean
-clean: $(foreach target,$(TARGETS),clean-$(target))
-
-all: package

--- a/sdks/builds/android.mk
+++ b/sdks/builds/android.mk
@@ -245,25 +245,25 @@ define AndroidHostMxeTemplate
 
 _android-$(1)_PATH=$$(MXE_PREFIX)/bin
 
-_android-$(1)_AR=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-ar
-_android-$(1)_AS=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-as
-_android-$(1)_CC=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-gcc
-_android-$(1)_CXX=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-g++
-_android-$(1)_DLLTOOL=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-dlltool
-_android-$(1)_LD=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-ld
-_android-$(1)_OBJDUMP=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-objdump
-_android-$(1)_RANLIB=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-ranlib
-_android-$(1)_STRIP=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-strip
+_android-$(1)_AR=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-ar
+_android-$(1)_AS=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-as
+_android-$(1)_CC=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-gcc
+_android-$(1)_CXX=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-g++
+_android-$(1)_DLLTOOL=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-dlltool
+_android-$(1)_LD=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-ld
+_android-$(1)_OBJDUMP=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-objdump
+_android-$(1)_RANLIB=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-ranlib
+_android-$(1)_STRIP=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-strip
 
 _android-$(1)_AC_VARS= \
 	ac_cv_header_zlib_h=no \
 	ac_cv_search_dlopen=no
 
 _android-$(1)_CFLAGS= \
-	-DXAMARIN_PRODUCT_VERSION=0
+	-DXAMARIN_PRODUCT_VERSION=0 -I$$(MXE_PREFIX)/opt/mingw-zlib/usr/$(2)-w64-mingw32/include
 
 _android-$(1)_CXXFLAGS= \
-	-DXAMARIN_PRODUCT_VERSION=0
+	-DXAMARIN_PRODUCT_VERSION=0 -I$$(MXE_PREFIX)/opt/mingw-zlib/usr/$(2)-w64-mingw32/include
 
 _android-$(1)_CONFIGURE_FLAGS= \
 	--disable-boehm \
@@ -275,14 +275,19 @@ _android-$(1)_CONFIGURE_FLAGS= \
 	--with-monodroid \
 	--disable-crash-reporting
 
+ifeq ($(UNAME),Darwin)
+_android-$(1)_LDFLAGS= \
+	$$(MXE_PREFIX)/opt/mingw-zlib/usr/$(2)-w64-mingw32/lib/libz.a
+endif
+
 .stamp-android-$(1)-toolchain:
 	touch $$@
 
 .stamp-android-$(1)-$$(CONFIGURATION)-configure: | $(if $(IGNORE_PROVISION_MXE),,provision-mxe)
 
-$$(eval $$(call RuntimeTemplate,android-$(1),$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)))
-
 android_TARGETS += android-$(1)-$$(CONFIGURATION)
+
+$$(eval $$(call RuntimeTemplate,android,$(1),$(2)-w64-mingw32))
 
 endef
 
@@ -353,32 +358,30 @@ _android-$(1)_OFFSETS_DUMPER_ARGS=--gen-android --android-ndk="$$(ANDROID_TOOLCH
 
 _android-$(1)_PATH=$$(MXE_PREFIX)/bin
 
-_android-$(1)_AR=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-ar
-_android-$(1)_AS=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-as
-_android-$(1)_CC=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-gcc
-_android-$(1)_CXX=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-g++
-_android-$(1)_DLLTOOL=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-dlltool
-_android-$(1)_LD=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-ld
-_android-$(1)_OBJDUMP=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-objdump
-_android-$(1)_RANLIB=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-ranlib
-_android-$(1)_STRIP=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static)-strip
+_android-$(1)_AR=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-ar
+_android-$(1)_AS=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-as
+_android-$(1)_CC=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-gcc
+_android-$(1)_CXX=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-g++
+_android-$(1)_DLLTOOL=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-dlltool
+_android-$(1)_LD=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-ld
+_android-$(1)_OBJDUMP=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-objdump
+_android-$(1)_RANLIB=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-ranlib
+_android-$(1)_STRIP=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-strip
 
 _android-$(1)_CFLAGS= \
 	$$(if $$(RELEASE),,-DDEBUG_CROSS) \
-	-static \
 	-static-libgcc \
-	-DXAMARIN_PRODUCT_VERSION=0
+	-DXAMARIN_PRODUCT_VERSION=0 \
+	-I$$(MXE_PREFIX)/opt/mingw-zlib/usr/$(2)-w64-mingw32/include
 
 _android-$(1)_CXXFLAGS= \
 	$$(if $$(RELEASE),,-DDEBUG_CROSS) \
-	-static \
 	-static-libgcc \
-	-DXAMARIN_PRODUCT_VERSION=0
+	-DXAMARIN_PRODUCT_VERSION=0 \
+	-I$$(MXE_PREFIX)/opt/mingw-zlib/usr/$(2)-w64-mingw32/include
 
 _android-$(1)_LDFLAGS= \
-	-static \
-	-static-libgcc \
-	-static-libstdc++
+	-static-libgcc
 
 _android-$(1)_CONFIGURE_FLAGS= \
 	--disable-boehm \
@@ -388,11 +391,16 @@ _android-$(1)_CONFIGURE_FLAGS= \
 	--enable-maintainer-mode \
 	--with-tls=pthread
 
+ifeq ($(UNAME),Darwin)
+_android-$(1)_CONFIGURE_FLAGS += \
+	--with-static-zlib=$$(MXE_PREFIX)/opt/mingw-zlib/usr/$(2)-w64-mingw32/lib/libz.a
+endif
+
 .stamp-android-$(1)-$$(CONFIGURATION)-configure: | $(if $(IGNORE_PROVISION_MXE),,provision-mxe)
 
-$$(eval $$(call CrossRuntimeTemplate,android-$(1),$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static),$(3)-linux-android,$(4),$(5),$(6)))
-
 android_TARGETS += android-$(1)-$$(CONFIGURATION) $(5)
+
+$$(eval $$(call CrossRuntimeTemplate,android,$(1),$(2)-w64-mingw32,$(3)-linux-android,$(4),$(5),$(6)))
 
 endef
 

--- a/sdks/builds/android.mk
+++ b/sdks/builds/android.mk
@@ -7,87 +7,40 @@ ANDROID_SDK_PREFIX?=$(ANDROID_TOOLCHAIN_DIR)/sdk
 ANDROID_TOOLCHAIN_PREFIX?=$(ANDROID_TOOLCHAIN_DIR)/toolchains
 ANDROID_NEW_NDK=$(shell if test `grep 'Pkg\.Revision' $(ANDROID_TOOLCHAIN_DIR)/ndk/source.properties | cut -d '=' -f 2 | tr -d ' ' | cut -d '.' -f 1` -ge 18; then echo yes; else echo no; fi)
 
-$(ANDROID_TOOLCHAIN_CACHE_DIR) $(ANDROID_TOOLCHAIN_DIR):
-	mkdir -p $@
-
 ##
 # Parameters:
 #  $(1): target
 #  $(2): dir
-#  $(3): category
-#  $(4): url prefix
+#  $(3): subdir (optional)
+#  $(4): stamp (optional, default to $(1))
 define AndroidProvisioningTemplate
 
-$$(ANDROID_TOOLCHAIN_CACHE_DIR)/$(1).zip: | $$(ANDROID_TOOLCHAIN_CACHE_DIR)
-	wget --no-verbose -O $$@ $(4)$(1).zip
+$$(ANDROID_TOOLCHAIN_CACHE_DIR)/$(1).zip:
+	mkdir -p $$(dir $$@)
+	wget --no-verbose -O $$@ $$(ANDROID_URI)$(1).zip
 
-$$(ANDROID_TOOLCHAIN_DIR)/$(3)$$(if $(2),/$(2))/.stamp-$(1): $$(ANDROID_TOOLCHAIN_CACHE_DIR)/$(1).zip | $$(ANDROID_TOOLCHAIN_DIR)
-	rm -rf $$(ANDROID_TOOLCHAIN_DIR)/$(3)$$(if $(2),/$(2))
-	./unzip-android-archive.sh "$$<" "$$(ANDROID_TOOLCHAIN_DIR)/$(3)$$(if $(2),/$(2))"
+$$(ANDROID_TOOLCHAIN_DIR)/$(2)/.stamp-$$(or $(4),$(1)): $$(ANDROID_TOOLCHAIN_CACHE_DIR)/$(1).zip
+	mkdir -p $$(dir $$@)
+	rm -rf $$(ANDROID_TOOLCHAIN_DIR)/$(2)$$(if $(3),/$(3))
+	./unzip-android-archive.sh "$$<" "$$(ANDROID_TOOLCHAIN_DIR)/$(2)$$(if $(3),/$(3))"
 	touch $$@
 
-.PHONY: provision-android-$(3)-$(1)
-provision-android-$(3)-$(1): $$(ANDROID_TOOLCHAIN_DIR)/$(3)$$(if $(2),/$(2))/.stamp-$(1)
-
 .PHONY: provision-android
-provision-android: provision-android-$(3)-$(1)
+provision-android: $$(ANDROID_TOOLCHAIN_DIR)/$(2)/.stamp-$$(or $(4),$(1))
 
 endef
 
-AndroidNDKProvisioningTemplate=$(call AndroidProvisioningTemplate,$(1),,ndk,$(ANDROID_URI))
-
 ifeq ($(UNAME),Darwin)
-$(eval $(call AndroidNDKProvisioningTemplate,android-ndk-$(ANDROID_NDK_VERSION)-darwin-x86_64))
+$(eval $(call AndroidProvisioningTemplate,android-ndk-$(ANDROID_NDK_VERSION)-darwin-x86_64,ndk,,ndk))
+$(eval $(call AndroidProvisioningTemplate,platform-tools_r$(ANDROID_PLATFORM_TOOLS_VERSION)-darwin,sdk,platform-tools))
+$(eval $(call AndroidProvisioningTemplate,sdk-tools-darwin-4333796,sdk,tools))
 else
 ifeq ($(UNAME),Linux)
-$(eval $(call AndroidNDKProvisioningTemplate,android-ndk-$(ANDROID_NDK_VERSION)-linux-x86_64))
-else
-$(error "Unknown UNAME=$(UNAME)")
+$(eval $(call AndroidProvisioningTemplate,android-ndk-$(ANDROID_NDK_VERSION)-linux-x86_64,ndk,,ndk))
+$(eval $(call AndroidProvisioningTemplate,platform-tools_r$(ANDROID_PLATFORM_TOOLS_VERSION)-linux,sdk,platform-tools))
+$(eval $(call AndroidProvisioningTemplate,sdk-tools-linux-4333796,sdk,tools))
 endif
 endif
-
-AndroidSDKProvisioningTemplate=$(call AndroidProvisioningTemplate,$(1),$(2),sdk,$(ANDROID_URI)$(3))
-
-ifeq ($(UNAME),Darwin)
-$(eval $(call AndroidSDKProvisioningTemplate,build-tools_r$(ANDROID_BUILD_TOOLS_VERSION)-macosx,build-tools/$(or $(ANDROID_BUILD_TOOLS_DIR),$(ANDROID_BUILD_TOOLS_VERSION))))
-$(eval $(call AndroidSDKProvisioningTemplate,platform-tools_r$(ANDROID_PLATFORM_TOOLS_VERSION)-darwin,platform-tools))
-$(eval $(call AndroidSDKProvisioningTemplate,sdk-tools-darwin-4333796,tools))
-$(eval $(call AndroidSDKProvisioningTemplate,emulator-darwin-4266726,emulator))
-$(eval $(call AndroidSDKProvisioningTemplate,cmake-3.6.4111459-darwin-x86_64,cmake/3.6.4111459))
-else
-ifeq ($(UNAME),Linux)
-$(eval $(call AndroidSDKProvisioningTemplate,build-tools_r$(ANDROID_BUILD_TOOLS_VERSION)-linux,build-tools/$(or $(ANDROID_BUILD_TOOLS_DIR),$(ANDROID_BUILD_TOOLS_VERSION))))
-$(eval $(call AndroidSDKProvisioningTemplate,platform-tools_r$(ANDROID_PLATFORM_TOOLS_VERSION)-linux,platform-tools))
-$(eval $(call AndroidSDKProvisioningTemplate,sdk-tools-linux-4333796,tools))
-$(eval $(call AndroidSDKProvisioningTemplate,emulator-linux-4266726,emulator))
-$(eval $(call AndroidSDKProvisioningTemplate,cmake-3.6.4111459-linux-x86_64,cmake/3.6.4111459))
-else
-$(error "Unknown UNAME=$(UNAME)")
-endif
-endif
-
-$(eval $(call AndroidSDKProvisioningTemplate,android-2.3.3_r02-linux,platforms/android-10))
-$(eval $(call AndroidSDKProvisioningTemplate,android-15_r03,platforms/android-15))
-$(eval $(call AndroidSDKProvisioningTemplate,android-16_r04,platforms/android-16))
-$(eval $(call AndroidSDKProvisioningTemplate,android-17_r02,platforms/android-17))
-$(eval $(call AndroidSDKProvisioningTemplate,android-18_r02,platforms/android-18))
-$(eval $(call AndroidSDKProvisioningTemplate,android-19_r03,platforms/android-19))
-$(eval $(call AndroidSDKProvisioningTemplate,android-20_r02,platforms/android-20))
-$(eval $(call AndroidSDKProvisioningTemplate,android-21_r02,platforms/android-21))
-$(eval $(call AndroidSDKProvisioningTemplate,android-22_r02,platforms/android-22))
-$(eval $(call AndroidSDKProvisioningTemplate,platform-23_r03,platforms/android-23))
-$(eval $(call AndroidSDKProvisioningTemplate,platform-24_r02,platforms/android-24))
-$(eval $(call AndroidSDKProvisioningTemplate,platform-25_r03,platforms/android-25))
-$(eval $(call AndroidSDKProvisioningTemplate,platform-26_r02,platforms/android-26))
-$(eval $(call AndroidSDKProvisioningTemplate,platform-27_r03,platforms/android-27))
-$(eval $(call AndroidSDKProvisioningTemplate,platform-28_r04,platforms/android-28))
-$(eval $(call AndroidSDKProvisioningTemplate,docs-24_r01,docs))
-$(eval $(call AndroidSDKProvisioningTemplate,android_m2repository_r16,extras/android/m2repository))
-$(eval $(call AndroidSDKProvisioningTemplate,x86-21_r05,system-images/android-21/default/x86,sys-img/android/))
-
-AndroidAntProvisioningTemplate=$(call AndroidProvisioningTemplate,$(1),,ant,$(ANT_URI))
-
-$(eval $(call AndroidAntProvisioningTemplate,apache-ant-1.9.9-bin))
 
 ##
 # Parameters:
@@ -167,9 +120,7 @@ _android-$(1)_CONFIGURE_FLAGS= \
 	python "$$(ANDROID_TOOLCHAIN_DIR)/ndk/build/tools/make_standalone_toolchain.py" --verbose --force --api=$$(ANDROID_SDK_VERSION_$(1)) --arch=$(2) --install-dir=$$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang
 	touch $$@
 
-$$(eval $$(call RuntimeTemplate,android-$(1),$(4)))
-
-android_TARGETS += android-$(1)-$$(CONFIGURATION)
+$$(eval $$(call RuntimeTemplate,android,$(1),$(4)))
 
 endef
 
@@ -229,9 +180,7 @@ _android-$(1)_CONFIGURE_FLAGS= \
 .stamp-android-$(1)-toolchain:
 	touch $$@
 
-$$(eval $$(call RuntimeTemplate,android-$(1)))
-
-android_TARGETS += android-$(1)-$$(CONFIGURATION)
+$$(eval $$(call RuntimeTemplate,android,$(1)))
 
 endef
 
@@ -285,8 +234,6 @@ endif
 
 .stamp-android-$(1)-$$(CONFIGURATION)-configure: | $(if $(IGNORE_PROVISION_MXE),,provision-mxe)
 
-android_TARGETS += android-$(1)-$$(CONFIGURATION)
-
 $$(eval $$(call RuntimeTemplate,android,$(1),$(2)-w64-mingw32))
 
 endef
@@ -333,16 +280,14 @@ _android-$(1)_CONFIGURE_FLAGS= \
 	--enable-maintainer-mode \
 	--with-tls=pthread
 
-$$(eval $$(call CrossRuntimeTemplate,android-$(1),$$(if $$(filter $$(UNAME),Darwin),$(2)-apple-darwin10,$$(if $$(filter $$(UNAME),Linux),$(2)-linux-gnu,$$(error "Unknown UNAME='$$(UNAME)'"))),$(3)-linux-android,$(4),$(5),$(6)))
-
-android_TARGETS += android-$(1)-$$(CONFIGURATION) $(5)
+$$(eval $$(call CrossRuntimeTemplate,android,$(1),$$(if $$(filter $$(UNAME),Darwin),$(2)-apple-darwin10,$$(if $$(filter $$(UNAME),Linux),$(2)-linux-gnu)),$(3)-linux-android,$(4),$(5),$(6)))
 
 endef
 
-$(eval $(call AndroidCrossTemplate,cross-arm,i686,armv7,android-armeabi-v7a,llvm-llvm32,armv7-none-linux-androideabi))
-$(eval $(call AndroidCrossTemplate,cross-arm64,x86_64,aarch64-v8a,android-arm64-v8a,llvm-llvm64,aarch64-v8a-linux-android))
-$(eval $(call AndroidCrossTemplate,cross-x86,i686,i686,android-x86,llvm-llvm32,i686-none-linux-android))
-$(eval $(call AndroidCrossTemplate,cross-x86_64,x86_64,x86_64,android-x86_64,llvm-llvm64,x86_64-none-linux-android))
+$(eval $(call AndroidCrossTemplate,cross-arm,i686,armv7,armeabi-v7a,llvm-llvm32,armv7-none-linux-androideabi))
+$(eval $(call AndroidCrossTemplate,cross-arm64,x86_64,aarch64-v8a,arm64-v8a,llvm-llvm64,aarch64-v8a-linux-android))
+$(eval $(call AndroidCrossTemplate,cross-x86,i686,i686,x86,llvm-llvm32,i686-none-linux-android))
+$(eval $(call AndroidCrossTemplate,cross-x86_64,x86_64,x86_64,x86_64,llvm-llvm64,x86_64-none-linux-android))
 
 ##
 # Parameters
@@ -396,18 +341,13 @@ _android-$(1)_CONFIGURE_FLAGS += \
 	--with-static-zlib=$$(MXE_PREFIX)/opt/mingw-zlib/usr/$(2)-w64-mingw32/lib/libz.a
 endif
 
-.stamp-android-$(1)-$$(CONFIGURATION)-configure: | $(if $(IGNORE_PROVISION_MXE),,provision-mxe)
-
-android_TARGETS += android-$(1)-$$(CONFIGURATION) $(5)
-
 $$(eval $$(call CrossRuntimeTemplate,android,$(1),$(2)-w64-mingw32,$(3)-linux-android,$(4),$(5),$(6)))
 
 endef
 
-$(eval $(call AndroidCrossMXETemplate,cross-arm-win,i686,armv7,android-armeabi-v7a,llvm-llvmwin32,armv7-none-linux-androideabi))
-$(eval $(call AndroidCrossMXETemplate,cross-arm64-win,x86_64,aarch64-v8a,android-arm64-v8a,llvm-llvmwin64,aarch64-v8a-linux-android))
-$(eval $(call AndroidCrossMXETemplate,cross-x86-win,i686,i686,android-x86,llvm-llvmwin32,i686-none-linux-android))
-$(eval $(call AndroidCrossMXETemplate,cross-x86_64-win,x86_64,x86_64,android-x86_64,llvm-llvmwin64,x86_64-none-linux-android))
+$(eval $(call AndroidCrossMXETemplate,cross-arm-win,i686,armv7,armeabi-v7a,llvm-llvmwin32,armv7-none-linux-androideabi))
+$(eval $(call AndroidCrossMXETemplate,cross-arm64-win,x86_64,aarch64-v8a,arm64-v8a,llvm-llvmwin64,aarch64-v8a-linux-android))
+$(eval $(call AndroidCrossMXETemplate,cross-x86-win,i686,i686,x86,llvm-llvmwin32,i686-none-linux-android))
+$(eval $(call AndroidCrossMXETemplate,cross-x86_64-win,x86_64,x86_64,x86_64,llvm-llvmwin64,x86_64-none-linux-android))
 
-$(eval $(call BclTemplate,android-bcl,monodroid monodroid_tools,monodroid))
-android_TARGETS += android-bcl
+$(eval $(call BclTemplate,android,monodroid monodroid_tools,monodroid))

--- a/sdks/builds/bcl.mk
+++ b/sdks/builds/bcl.mk
@@ -21,38 +21,43 @@ clean-bcl:
 
 ##
 # Parameters
-#  $(1): target
+#  $(1): product
 #  $(2): build profiles
 #  $(3): test profiles
 define BclTemplate
 
-.stamp-$(1)-toolchain:
+.stamp-$(1)-bcl-toolchain:
 	touch $$@
 
-.stamp-$(1)-configure: .stamp-bcl-configure
+.stamp-$(1)-bcl-configure: .stamp-bcl-configure
 	touch $$@
 
-.PHONY: setup-custom-$(1)
-setup-custom-$(1):
-	mkdir -p $$(TOP)/sdks/out/$(1) $$(foreach profile,$(2),$$(TOP)/sdks/out/$(1)/$$(profile))
+.PHONY: setup-custom-$(1)-bcl
+setup-custom-$(1)-bcl:
+	mkdir -p $$(TOP)/sdks/out/$(1)-bcl $$(foreach profile,$(2),$$(TOP)/sdks/out/$(1)-bcl/$$(profile))
 
-.PHONY: build-$(1)
-build-$(1): build-bcl
+.PHONY: build-$(1)-bcl
+build-$(1)-bcl: build-bcl
 
-.PHONY: build-custom-$(1)
-build-custom-$(1):
+.PHONY: build-custom-$(1)-bcl
+build-custom-$(1)-bcl:
 	$$(MAKE) -C bcl -C runtime all-mcs build_profiles="$(2)"
 	$$(if $(3),$$(MAKE) -C bcl -C runtime test xunit-test test_profiles="$(3)")
 
-.PHONY: package-$(1)
-package-$(1):
+.PHONY: package-$(1)-bcl
+package-$(1)-bcl:
 	$$(foreach profile,$(2), \
-		cp -R $$(TOP)/mcs/class/lib/$$(profile)/* $$(TOP)/sdks/out/$(1)/$$(profile);)
+		cp -R $$(TOP)/mcs/class/lib/$$(profile)/* $$(TOP)/sdks/out/$(1)-bcl/$$(profile);)
 
-.PHONY: clean-$(1)
-clean-$(1): clean-bcl
-	rm -rf $$(TOP)/sdks/out/$(1) $$(foreach profile,$(2),$$(TOP)/sdks/out/$(1)/$$(profile))
+.PHONY: clean-$(1)-bcl
+clean-$(1)-bcl: clean-bcl
+	rm -rf $$(TOP)/sdks/out/$(1)-bcl $$(foreach profile,$(2),$$(TOP)/sdks/out/$(1)-bcl/$$(profile))
 
-TARGETS += $(1)
+$$(eval $$(call TargetTemplate,$(1),bcl))
+
+.PHONY: archive-$(1)
+archive-$(1): package-$(1)-bcl
+
+$(1)_ARCHIVE += $(1)-bcl
 
 endef

--- a/sdks/builds/desktop.mk
+++ b/sdks/builds/desktop.mk
@@ -23,10 +23,10 @@ _desktop-$(1)_CONFIGURE_FLAGS= \
 	--with-tls=pthread \
 	--without-ikvm-native
 
-$$(eval $$(call RuntimeTemplate,desktop-$(1),$(2)))
+$$(eval $$(call RuntimeTemplate,desktop,$(1),$(2)))
 
 endef
 
 $(eval $(call DesktopTemplate,x86_64,x86_64-apple-darwin17.2.0))
 
-$(eval $(call BclTemplate,desktop-bcl,net_4_x,))
+$(eval $(call BclTemplate,desktop,net_4_x,))

--- a/sdks/builds/ios.mk
+++ b/sdks/builds/ios.mk
@@ -104,9 +104,7 @@ _ios-$(1)_CONFIGURE_FLAGS = \
 .stamp-ios-$(1)-toolchain:
 	touch $$@
 
-$$(eval $$(call RuntimeTemplate,ios-$(1),$(2)))
-
-ios_TARGETS += ios-$(1)-$$(CONFIGURATION)
+$$(eval $$(call RuntimeTemplate,ios,$(1),$(2)))
 
 endef
 
@@ -239,9 +237,7 @@ _ios-$(1)_CONFIGURE_FLAGS= \
 .stamp-ios-$(1)-toolchain:
 	touch $$@
 
-$$(eval $$(call RuntimeTemplate,ios-$(1),$(2)))
-
-ios_TARGETS += ios-$(1)-$$(CONFIGURATION)
+$$(eval $$(call RuntimeTemplate,ios,$(1),$(2)))
 
 endef
 
@@ -343,18 +339,15 @@ _ios-$(1)_CONFIGURE_FLAGS= \
 	--enable-monotouch \
 	--disable-crash-reporting
 
-$$(eval $$(call CrossRuntimeTemplate,ios-$(1),$(2)-apple-darwin10,$(3)-darwin,$(4),$(5),$(6)))
-
-ios_TARGETS += ios-$(1)-$$(CONFIGURATION) $(5)
+$$(eval $$(call CrossRuntimeTemplate,ios,$(1),$(2)-apple-darwin10,$(3),$(4),$(5),$(6)))
 
 endef
 
-$(eval $(call iOSCrossTemplate,cross32,i386,arm,ios-target32,llvm36-llvm32,arm-apple-darwin10,$(XCODE32_DIR)))
-$(eval $(call iOSCrossTemplate,cross64,x86_64,aarch64,ios-target64,llvm-llvm64,aarch64-apple-darwin10,$(XCODE_DIR)))
+$(eval $(call iOSCrossTemplate,cross32,i386,arm,target32,llvm36-llvm32,arm-apple-darwin10))
+$(eval $(call iOSCrossTemplate,cross64,x86_64,aarch64,target64,llvm-llvm64,aarch64-apple-darwin10))
 ios-crosswatch_CONFIGURE_FLAGS=--enable-cooperative-suspend
-$(eval $(call iOSCrossTemplate,crosswatch,i386,armv7k-unknown,ios-targetwatch,llvm36-llvm32,armv7k-apple-darwin,$(XCODE32_DIR)))
+$(eval $(call iOSCrossTemplate,crosswatch,i386,armv7k-unknown,targetwatch,llvm36-llvm32,armv7k-apple-darwin))
 # 64->arm32 cross compiler
-$(eval $(call iOSCrossTemplate,cross32-64,x86_64,arm,ios-target32,llvm-llvm64,arm-apple-darwin10,$(XCODE_DIR)))
+$(eval $(call iOSCrossTemplate,cross32-64,x86_64,arm,target32,llvm-llvm64,arm-apple-darwin10))
 
-$(eval $(call BclTemplate,ios-bcl,monotouch monotouch_runtime monotouch_tv monotouch_tv_runtime monotouch_watch monotouch_watch_runtime,monotouch monotouch_tv monotouch_watch))
-ios_TARGETS += ios-bcl
+$(eval $(call BclTemplate,ios,monotouch monotouch_runtime monotouch_tv monotouch_tv_runtime monotouch_watch monotouch_watch_runtime monotouch_tools,monotouch monotouch_tv monotouch_watch))

--- a/sdks/builds/llvm.mk
+++ b/sdks/builds/llvm.mk
@@ -157,8 +157,13 @@ _llvm-$(1)_CMAKE_ARGS = \
 	-DLLVM_BUILD_EXECUTION_ENGINE=Off \
 	$$(llvm-$(1)_CMAKE_ARGS)
 
-$$(LLVM_SRC)/cmake/modules/$(3).cmake: $(3).cmake.in | $$(LLVM_SRC)
-	sed -e 's,@MXE_PATH@,$$(MXE_PREFIX),' -e 's,@MXE_SUFFIX@,$$(if $$(filter $(UNAME),Darwin),.static),' < $$< > $$@
+ifeq ($(UNAME),Darwin)
+_llvm-$(1)_CMAKE_ARGS += \
+	-DZLIB_ROOT=$$(MXE_PREFIX)/opt/mingw-zlib/usr/$(2)-w64-mingw32 -DZLIB_LIBRARY=$$(MXE_PREFIX)/opt/mingw-zlib/usr/$(2)-w64-mingw32/lib/libz.a -DZLIB_INCLUDE_DIR=$$(MXE_PREFIX)/opt/mingw-zlib/usr/$(2)-w64-mingw32/include
+endif
+
+$$(LLVM_SRC)/llvm/cmake/modules/$(3).cmake: $(3).cmake.in
+	sed -e 's,@MXE_PATH@,$$(MXE_PREFIX),' < $$< > $$@
 
 .PHONY: setup-llvm-$(1)
 setup-llvm-$(1):

--- a/sdks/builds/mxe-Win32.cmake.in
+++ b/sdks/builds/mxe-Win32.cmake.in
@@ -5,9 +5,9 @@ set(CMAKE_SYSTEM_NAME Windows)
 set(CMAKE_FIND_ROOT_PATH @MXE_PATH@)
 
 # which compilers to use for C and C++
-set(CMAKE_C_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/i686-w64-mingw32@MXE_SUFFIX@-gcc)
-set(CMAKE_CXX_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/i686-w64-mingw32@MXE_SUFFIX@-g++)
-set(CMAKE_RC_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/i686-w64-mingw32@MXE_SUFFIX@-windres)
+set(CMAKE_C_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/i686-w64-mingw32-gcc)
+set(CMAKE_CXX_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/i686-w64-mingw32-g++)
+set(CMAKE_RC_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/i686-w64-mingw32-windres)
 
 # adjust the default behaviour of the FIND_XXX() commands:
 # search headers and libraries in the target environment, search

--- a/sdks/builds/mxe-Win64.cmake.in
+++ b/sdks/builds/mxe-Win64.cmake.in
@@ -5,9 +5,9 @@ set(CMAKE_SYSTEM_NAME Windows)
 set(CMAKE_FIND_ROOT_PATH @MXE_PATH@)
 
 # which compilers to use for C and C++
-set(CMAKE_C_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/x86_64-w64-mingw32@MXE_SUFFIX@-gcc)
-set(CMAKE_CXX_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/x86_64-w64-mingw32@MXE_SUFFIX@-g++)
-set(CMAKE_RC_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/x86_64-w64-mingw32@MXE_SUFFIX@-windres)
+set(CMAKE_C_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/x86_64-w64-mingw32-gcc)
+set(CMAKE_CXX_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/x86_64-w64-mingw32-g++)
+set(CMAKE_RC_COMPILER ${CMAKE_FIND_ROOT_PATH}/bin/x86_64-w64-mingw32-windres)
 
 # adjust the default behaviour of the FIND_XXX() commands:
 # search headers and libraries in the target environment, search

--- a/sdks/builds/mxe.mk
+++ b/sdks/builds/mxe.mk
@@ -13,23 +13,12 @@ MXE_PREFIX=/usr
 provision-mxe:
 	@echo $(LINUX_FLAVOR) Linux does not require mxe provisioning. mingw from packages is used instead
 else
-MXE_SRC?=$(TOP)/sdks/builds/toolchains/mxe
-MXE_PREFIX_DIR?=$(HOME)/android-toolchain
-
-# This is not overridable
-MXE_PREFIX:=$(MXE_PREFIX_DIR)/mxe-$(shell echo $(MXE_HASH) | head -c 7)
-
-$(MXE_PREFIX)/.stamp:
-	rm -rf $(MXE_PREFIX) $(MXE_SRC)
-	git clone -b xamarin https://github.com/xamarin/mxe.git $(MXE_SRC) \
-		&& git -C $(MXE_SRC) checkout $(MXE_HASH)
-	$(MAKE) -C $(MXE_SRC) gcc cmake zlib pthreads dlfcn-win32 mman-win32 \
-		PREFIX="$(MXE_PREFIX)" MXE_TARGETS="i686-w64-mingw32.static x86_64-w64-mingw32.static" \
-			OS_SHORT_NAME="disable-native-plugins" PATH="$$PATH:$(MXE_PREFIX)/bin:$(dir $(shell brew list gettext | grep bin/autopoint$))"
-	touch $@
+MXE_PREFIX:=$(shell brew --prefix)
 
 .PHONY: provision-mxe
-provision-mxe: $(MXE_PREFIX)/.stamp
+provision-mxe:
+	brew tap xamarin/xamarin-android-windeps
+	brew install mingw-w64 xamarin/xamarin-android-windeps/mingw-zlib
 endif
 
 .PHONY: provision

--- a/sdks/builds/runtime.mk
+++ b/sdks/builds/runtime.mk
@@ -1,97 +1,101 @@
 
 ##
 # Parameters:
-#  $(1): target
-#  $(2): host triple
+#  $(1): product
+#  $(2): target
+#  $(3): host triple
 #
 # Flags:
-#  _$(1)_AR
-#  _$(1)_AS
-#  _$(1)_CC
-#  _$(1)_CPP
-#  _$(1)_CXX
-#  _$(1)_CXXCPP
-#  _$(1)_DLLTOOL
-#  _$(1)_LD
-#  _$(1)_CMAKE
-#  _$(1)_OBJDUMP
-#  _$(1)_RANLIB
-#  _$(1)_STRIP
-#  _$(1)_CFLAGS
-#  _$(1)_CXXFLAGS
-#  _$(1)_CPPFLAGS
-#  _$(1)_LDFLAGS
-#  _$(1)_AC_VARS
-#  _$(1)_CONFIGURE_FLAGS
-#  _$(1)_PATH
+#  _$(1)-$(2)_AR
+#  _$(1)-$(2)_AS
+#  _$(1)-$(2)_CC
+#  _$(1)-$(2)_CPP
+#  _$(1)-$(2)_CXX
+#  _$(1)-$(2)_CXXCPP
+#  _$(1)-$(2)_DLLTOOL
+#  _$(1)-$(2)_LD
+#  _$(1)-$(2)_OBJDUMP
+#  _$(1)-$(2)_RANLIB
+#  _$(1)-$(2)_STRIP
+#  _$(1)-$(2)_CFLAGS
+#  _$(1)-$(2)_CXXFLAGS
+#  _$(1)-$(2)_CPPFLAGS
+#  _$(1)-$(2)_LDFLAGS
+#  _$(1)-$(2)_AC_VARS
+#  _$(1)-$(2)_CONFIGURE_FLAGS
+#  _$(1)-$(2)_PATH
 define RuntimeTemplate
 
-_runtime_$(1)_BITNESS=$$(if $$(or $$(findstring i686,$(2)),$$(findstring i386,$(2))),-m32,$$(if $$(findstring x86_64,$(2)),-m64))
+_runtime_$(1)-$(2)_BITNESS=$$(if $$(or $$(findstring i686,$(3)),$$(findstring i386,$(3))),-m32,$$(if $$(findstring x86_64,$(3)),-m64))
 
-_runtime_$(1)_CFLAGS=$(if $(RELEASE),-O2 -g,-O0 -ggdb3 -fno-omit-frame-pointer) $$(_$(1)_CFLAGS) $$($(1)_CFLAGS) $$(_runtime_$(1)_BITNESS)
-_runtime_$(1)_CXXFLAGS=$(if $(RELEASE),-O2 -g,-O0 -ggdb3 -fno-omit-frame-pointer) $$(_$(1)_CXXFLAGS) $$($(1)_CXXFLAGS) $$(_runtime_$(1)_BITNESS)
-_runtime_$(1)_CPPFLAGS=$(if $(RELEASE),-O2 -g,-O0 -ggdb3 -fno-omit-frame-pointer) $$(_$(1)_CPPFLAGS) $$($(1)_CPPFLAGS) $$(_runtime_$(1)_BITNESS)
-_runtime_$(1)_CXXCPPFLAGS=$(if $(RELEASE),-O2 -g,-O0 -ggdb3 -fno-omit-frame-pointer) $$(_$(1)_CXXCPPFLAGS) $$($(1)_CXXCPPFLAGS) $$(_runtime_$(1)_BITNESS)
-_runtime_$(1)_LDFLAGS=$$(_$(1)_LDFLAGS) $$($(1)_LDFLAGS)
+_runtime_$(1)-$(2)_CFLAGS=$(if $(RELEASE),-O2 -g,-O0 -ggdb3 -fno-omit-frame-pointer) $$(_$(1)-$(2)_CFLAGS) $$($(1)-$(2)_CFLAGS) $$(_runtime_$(1)-$(2)_BITNESS)
+_runtime_$(1)-$(2)_CXXFLAGS=$(if $(RELEASE),-O2 -g,-O0 -ggdb3 -fno-omit-frame-pointer) $$(_$(1)-$(2)_CXXFLAGS) $$($(1)-$(2)_CXXFLAGS) $$(_runtime_$(1)-$(2)_BITNESS)
+_runtime_$(1)-$(2)_CPPFLAGS=$(if $(RELEASE),-O2 -g,-O0 -ggdb3 -fno-omit-frame-pointer) $$(_$(1)-$(2)_CPPFLAGS) $$($(1)-$(2)_CPPFLAGS) $$(_runtime_$(1)-$(2)_BITNESS)
+_runtime_$(1)-$(2)_CXXCPPFLAGS=$(if $(RELEASE),-O2 -g,-O0 -ggdb3 -fno-omit-frame-pointer) $$(_$(1)-$(2)_CXXCPPFLAGS) $$($(1)-$(2)_CXXCPPFLAGS) $$(_runtime_$(1)-$(2)_BITNESS)
+_runtime_$(1)-$(2)_LDFLAGS=$$(_$(1)-$(2)_LDFLAGS) $$($(1)-$(2)_LDFLAGS)
 
-_runtime_$(1)_AC_VARS=$$(_$(1)_AC_VARS) $$($(1)_AC_VARS)
+_runtime_$(1)-$(2)_AC_VARS=$$(_$(1)-$(2)_AC_VARS) $$($(1)-$(2)_AC_VARS)
 
-_runtime_$(1)_CONFIGURE_ENVIRONMENT = \
-	$(if $$(_$(1)_AR),AR="$$(_$(1)_AR)") \
-	$(if $$(_$(1)_AS),AS="$$(_$(1)_AS)") \
-	$(if $$(_$(1)_CC),CC="$$(_$(1)_CC)") \
-	$(if $$(_$(1)_CPP),CPP="$$(_$(1)_CPP)") \
-	$(if $$(_$(1)_CXX),CXX="$$(_$(1)_CXX)") \
-	$(if $$(_$(1)_CXXCPP),CXXCPP="$$(_$(1)_CXXCPP)") \
-	$(if $$(_$(1)_DLLTOOL),DLLTOOL="$$(_$(1)_DLLTOOL)") \
-	$(if $$(_$(1)_LD),LD="$$(_$(1)_LD)") \
-	$(if $$(_$(1)_OBJDUMP),OBJDUMP="$$(_$(1)_OBJDUMP)") \
-	$(if $$(_$(1)_RANLIB),RANLIB="$$(_$(1)_RANLIB)") \
-	$(if $$(_$(1)_CMAKE),CMAKE="$$(_$(1)_CMAKE)") \
-	$(if $$(_$(1)_STRIP),STRIP="$$(_$(1)_STRIP)") \
-	CFLAGS="$$(_runtime_$(1)_CFLAGS)" \
-	CXXFLAGS="$$(_runtime_$(1)_CXXFLAGS)" \
-	CPPFLAGS="$$(_runtime_$(1)_CPPFLAGS)" \
-	CXXCPPFLAGS="$$(_runtime_$(1)_CXXCPPFLAGS)" \
-	LDFLAGS="$$(_runtime_$(1)_LDFLAGS)" \
-	$$(_$(1)_CONFIGURE_ENVIRONMENT) \
-	$$($(1)_CONFIGURE_ENVIRONMENT)
+_runtime_$(1)-$(2)_CONFIGURE_ENVIRONMENT = \
+	$(if $$(_$(1)-$(2)_AR),AR="$$(_$(1)-$(2)_AR)") \
+	$(if $$(_$(1)-$(2)_AS),AS="$$(_$(1)-$(2)_AS)") \
+	$(if $$(_$(1)-$(2)_CC),CC="$$(_$(1)-$(2)_CC)") \
+	$(if $$(_$(1)-$(2)_CPP),CPP="$$(_$(1)-$(2)_CPP)") \
+	$(if $$(_$(1)-$(2)_CXX),CXX="$$(_$(1)-$(2)_CXX)") \
+	$(if $$(_$(1)-$(2)_CXXCPP),CXXCPP="$$(_$(1)-$(2)_CXXCPP)") \
+	$(if $$(_$(1)-$(2)_DLLTOOL),DLLTOOL="$$(_$(1)-$(2)_DLLTOOL)") \
+	$(if $$(_$(1)-$(2)_LD),LD="$$(_$(1)-$(2)_LD)") \
+	$(if $$(_$(1)-$(2)_OBJDUMP),OBJDUMP="$$(_$(1)-$(2)_OBJDUMP)") \
+	$(if $$(_$(1)-$(2)_RANLIB),RANLIB="$$(_$(1)-$(2)_RANLIB)") \
+	$(if $$(_$(1)-$(2)_STRIP),STRIP="$$(_$(1)-$(2)_STRIP)") \
+	CFLAGS="$$(_runtime_$(1)-$(2)_CFLAGS)" \
+	CXXFLAGS="$$(_runtime_$(1)-$(2)_CXXFLAGS)" \
+	CPPFLAGS="$$(_runtime_$(1)-$(2)_CPPFLAGS)" \
+	CXXCPPFLAGS="$$(_runtime_$(1)-$(2)_CXXCPPFLAGS)" \
+	LDFLAGS="$$(_runtime_$(1)-$(2)_LDFLAGS)" \
+	$$(_$(1)-$(2)_CONFIGURE_ENVIRONMENT) \
+	$$($(1)-$(2)_CONFIGURE_ENVIRONMENT)
 
-_runtime_$(1)_CONFIGURE_FLAGS= \
-	$$(if $(2),--host=$(2)) \
-	--cache-file=$$(TOP)/sdks/builds/$(1)-$$(CONFIGURATION).config.cache \
-	--prefix=$$(TOP)/sdks/out/$(1)-$$(CONFIGURATION) \
+_runtime_$(1)-$(2)_CONFIGURE_FLAGS= \
+	$$(if $(3),--host=$(3)) \
+	--cache-file=$$(TOP)/sdks/builds/$(1)-$(2)-$$(CONFIGURATION).config.cache \
+	--prefix=$$(TOP)/sdks/out/$(1)-$(2)-$$(CONFIGURATION) \
 	$$(if $$(ENABLE_CXX),--enable-cxx) \
-	$$(_cross-runtime_$(1)_CONFIGURE_FLAGS) \
-	$$(_$(1)_CONFIGURE_FLAGS) \
-	$$($(1)_CONFIGURE_FLAGS)
+	$$(_cross-runtime_$(1)-$(2)_CONFIGURE_FLAGS) \
+	$$(_$(1)-$(2)_CONFIGURE_FLAGS) \
+	$$($(1)-$(2)_CONFIGURE_FLAGS)
 
-.stamp-$(1)-$$(CONFIGURATION)-configure: $$(TOP)/configure .stamp-$(1)-toolchain
-	mkdir -p $$(TOP)/sdks/builds/$(1)-$$(CONFIGURATION)
-	$(if $$(_$(1)_PATH),PATH="$$$$PATH:$$(_$(1)_PATH)") ./wrap-configure.sh $$(TOP)/sdks/builds/$(1)-$$(CONFIGURATION) $$(abspath $$<) $$(_runtime_$(1)_AC_VARS) $$(_runtime_$(1)_CONFIGURE_ENVIRONMENT) $$(_runtime_$(1)_CONFIGURE_FLAGS)
+.stamp-$(1)-$(2)-$$(CONFIGURATION)-configure: $$(TOP)/configure .stamp-$(1)-$(2)-toolchain
+	mkdir -p $$(TOP)/sdks/builds/$(1)-$(2)-$$(CONFIGURATION)
+	$(if $$(_$(1)-$(2)_PATH),PATH="$$$$PATH:$$(_$(1)-$(2)_PATH)") ./wrap-configure.sh $$(TOP)/sdks/builds/$(1)-$(2)-$$(CONFIGURATION) $$(abspath $$<) $$(_runtime_$(1)-$(2)_AC_VARS) $$(_runtime_$(1)-$(2)_CONFIGURE_ENVIRONMENT) $$(_runtime_$(1)-$(2)_CONFIGURE_FLAGS)
 	touch $$@
 
-.stamp-$(1)-configure: .stamp-$(1)-$$(CONFIGURATION)-configure
+.stamp-$(1)-$(2)-configure: .stamp-$(1)-$(2)-$$(CONFIGURATION)-configure
 	touch $$@
 
-.PHONY: build-custom-$(1)
-build-custom-$(1):
-	$$(MAKE) -C $(1)-$$(CONFIGURATION)
+.PHONY: build-custom-$(1)-$(2)
+build-custom-$(1)-$(2):
+	$$(MAKE) -C $(1)-$(2)-$$(CONFIGURATION)
 
-.PHONY: setup-custom-$(1)
-setup-custom-$(1):
-	mkdir -p $$(TOP)/sdks/out/$(1)-$$(CONFIGURATION)
+.PHONY: setup-custom-$(1)-$(2)
+setup-custom-$(1)-$(2):
+	mkdir -p $$(TOP)/sdks/out/$(1)-$(2)-$$(CONFIGURATION)
 
-.PHONY: package-$(1)
-package-$(1):
-	$$(MAKE) -C $$(TOP)/sdks/builds/$(1)-$$(CONFIGURATION)/mono install
-	$$(MAKE) -C $$(TOP)/sdks/builds/$(1)-$$(CONFIGURATION)/support install
+.PHONY: package-$(1)-$(2)
+package-$(1)-$(2):
+	$$(MAKE) -C $$(TOP)/sdks/builds/$(1)-$(2)-$$(CONFIGURATION)/mono install
+	$$(MAKE) -C $$(TOP)/sdks/builds/$(1)-$(2)-$$(CONFIGURATION)/support install
 
-.PHONY: clean-$(1)
-clean-$(1):
-	rm -rf .stamp-$(1)-toolchain .stamp-$(1)-$$(CONFIGURATION)-configure $$(TOP)/sdks/builds/toolchains/$(1) $$(TOP)/sdks/builds/$(1)-$$(CONFIGURATION) $$(TOP)/sdks/builds/$(1)-$$(CONFIGURATION).config.cache $$(TOP)/sdks/out/$(1)-$$(CONFIGURATION)
+.PHONY: clean-$(1)-$(2)
+clean-$(1)-$(2):
+	rm -rf .stamp-$(1)-$(2)-toolchain .stamp-$(1)-$(2)-$$(CONFIGURATION)-configure $$(TOP)/sdks/builds/toolchains/$(1)-$(2) $$(TOP)/sdks/builds/$(1)-$(2)-$$(CONFIGURATION) $$(TOP)/sdks/builds/$(1)-$(2)-$$(CONFIGURATION).config.cache $$(TOP)/sdks/out/$(1)-$(2)-$$(CONFIGURATION)
 
-TARGETS += $(1)
+$$(eval $$(call TargetTemplate,$(1),$(2)))
+
+.PHONY: archive-$(1)
+archive-$(1): package-$(1)-$(2)
+
+$(1)_ARCHIVE += $(1)-$(2)-$$(CONFIGURATION)
 
 endef
 
@@ -100,54 +104,60 @@ $(TOP)/tools/offsets-tool/MonoAotOffsetsDumper.exe: $(wildcard $(TOP)/tools/offs
 
 ##
 # Parameters:
-#  $(1): target
-#  $(2): host triple
-#  $(3): target triple
-#  $(4): device target
-#  $(5): llvm
-#  $(6): offsets dumper abi
+#  $(1): product
+#  $(2): target
+#  $(3): host triple
+#  $(4): target triple
+#  $(5): device target
+#  $(6): llvm
+#  $(7): offsets dumper abi
 #
 # Flags:
-#  _$(1)_AR
-#  _$(1)_AS
-#  _$(1)_CC
-#  _$(1)_CPP
-#  _$(1)_CXX
-#  _$(1)_CXXCPP
-#  _$(1)_DLLTOOL
-#  _$(1)_LD
-#  _$(1)_OBJDUMP
-#  _$(1)_RANLIB
-#  _$(1)_STRIP
-#  _$(1)_CFLAGS
-#  _$(1)_CXXFLAGS
-#  _$(1)_CPPFLAGS
-#  _$(1)_LDFLAGS
-#  _$(1)_AC_VARS
-#  _$(1)_CONFIGURE_FLAGS
-#  _$(1)_PATH
-#  _$(1)_OFFSETS_DUMPER_ARGS
+#  _$(1)-$(2)_AR
+#  _$(1)-$(2)_AS
+#  _$(1)-$(2)_CC
+#  _$(1)-$(2)_CPP
+#  _$(1)-$(2)_CXX
+#  _$(1)-$(2)_CXXCPP
+#  _$(1)-$(2)_DLLTOOL
+#  _$(1)-$(2)_LD
+#  _$(1)-$(2)_OBJDUMP
+#  _$(1)-$(2)_RANLIB
+#  _$(1)-$(2)_STRIP
+#  _$(1)-$(2)_CFLAGS
+#  _$(1)-$(2)_CXXFLAGS
+#  _$(1)-$(2)_CPPFLAGS
+#  _$(1)-$(2)_LDFLAGS
+#  _$(1)-$(2)_AC_VARS
+#  _$(1)-$(2)_CONFIGURE_FLAGS
+#  _$(1)-$(2)_PATH
+#  _$(1)-$(2)_OFFSETS_DUMPER_ARGS
 define CrossRuntimeTemplate
 
-_cross-runtime_$(1)_CONFIGURE_FLAGS= \
-	--target=$(3) \
-	--with-cross-offsets=$(3).h \
-	--with-llvm=$$(TOP)/sdks/out/$(5)
+_cross-runtime_$(1)-$(2)_CONFIGURE_FLAGS= \
+	--target=$(4) \
+	--with-cross-offsets=$(4).h \
+	--with-llvm=$$(TOP)/sdks/out/$(6)
 
-.stamp-$(1)-toolchain:
+.stamp-$(1)-$(2)-toolchain:
 	touch $$@
 
-.stamp-$(1)-$$(CONFIGURATION)-configure: | $$(if $$(IGNORE_PROVISION_LLVM),,provision-$(5))
+.stamp-$(1)-$(2)-$$(CONFIGURATION)-configure: | $$(if $$(IGNORE_PROVISION_LLVM),,provision-$(6))
 
-$$(TOP)/sdks/builds/$(1)-$$(CONFIGURATION)/$(3).h: .stamp-$(1)-$$(CONFIGURATION)-configure $$(TOP)/tools/offsets-tool/MonoAotOffsetsDumper.exe | configure-$(4)
-	cd $$(TOP)/sdks/builds/$(1)-$$(CONFIGURATION) && \
+$$(TOP)/sdks/builds/$(1)-$(2)-$$(CONFIGURATION)/$(4).h: .stamp-$(1)-$(2)-$$(CONFIGURATION)-configure $$(TOP)/tools/offsets-tool/MonoAotOffsetsDumper.exe | configure-$(1)-$(5)
+	cd $$(TOP)/sdks/builds/$(1)-$(2)-$$(CONFIGURATION) && \
 		MONO_PATH=$$(TOP)/tools/offsets-tool/CppSharp/$$(if $$(filter $$(UNAME),Darwin),osx_32,$$(if $$(filter $$(UNAME),Linux),linux_64,$$(error "Unknown UNAME='$$(UNAME)'"))) \
 			mono $$(if $$(filter $$(UNAME),Darwin),--arch=32) --debug "$$(TOP)/tools/offsets-tool/MonoAotOffsetsDumper.exe" \
-				--abi $(6) --outfile "$$@" --mono "$$(TOP)" --targetdir "$$(TOP)/sdks/builds/$(4)-$$(CONFIGURATION)" \
-					$$(_$(1)_OFFSETS_DUMPER_ARGS)
+				--abi $(7) --outfile "$$@" --mono "$$(TOP)" --targetdir "$$(TOP)/sdks/builds/$(1)-$(5)-$$(CONFIGURATION)" \
+					$$(_$(1)-$(2)_OFFSETS_DUMPER_ARGS)
 
-build-$(1): $$(TOP)/sdks/builds/$(1)-$$(CONFIGURATION)/$(3).h
+build-$(1)-$(2): $$(TOP)/sdks/builds/$(1)-$(2)-$$(CONFIGURATION)/$(4).h
 
-$$(eval $$(call RuntimeTemplate,$(1),$(2)))
+$$(eval $$(call RuntimeTemplate,$(1),$(2),$(3)))
+
+.PHONY: archive-$(1)
+archive-$(1): provision-$(6)
+
+$(1)_ARCHIVE += $(6)
 
 endef

--- a/sdks/builds/wasm.mk
+++ b/sdks/builds/wasm.mk
@@ -64,9 +64,12 @@ package-wasm-runtime:
 clean-wasm-runtime:
 	rm -rf .stamp-wasm-runtime-toolchain .stamp-wasm-runtime-$(CONFIGURATION)-configure $(TOP)/sdks/builds/wasm-runtime-$(CONFIGURATION) $(TOP)/sdks/builds/wasm-runtime-$(CONFIGURATION).config.cache $(TOP)/sdks/out/wasm-runtime-$(CONFIGURATION)
 
-TARGETS += wasm-runtime
+$(eval $(call TargetTemplate,wasm,runtime))
 
-wasm_TARGETS += wasm-runtime-$(CONFIGURATION)
+.PHONY: archive-wasm
+archive-wasm: package-wasm-runtime
+
+wasm_ARCHIVE += wasm-runtime-$(CONFIGURATION)
 
 ##
 # Parameters
@@ -89,15 +92,14 @@ _wasm-$(1)_CONFIGURE_FLAGS= \
 	--enable-maintainer-mode \
 	--enable-minimal=appdomains,com,remoting
 
-$$(eval $$(call CrossRuntimeTemplate,wasm-$(1),$$(if $$(filter $$(UNAME),Darwin),$(2)-apple-darwin10,$$(if $$(filter $$(UNAME),Linux),$(2)-linux-gnu,$$(error "Unknown UNAME='$$(UNAME)'"))),$(3)-unknown-none,$(4),$(5),$(6)))
-
-wasm_TARGETS += wasm-$(1)-$$(CONFIGURATION) $(5)
+$$(eval $$(call CrossRuntimeTemplate,wasm,$(1),$$(if $$(filter $$(UNAME),Darwin),$(2)-apple-darwin10,$$(if $$(filter $$(UNAME),Linux),$(2)-linux-gnu,$$(error "Unknown UNAME='$$(UNAME)'"))),$(3)-unknown-none,$(4),$(5),$(6)))
 
 endef
 
-ifeq ($(DISABLE_WASM_CROSS),)
-$(eval $(call WasmCrossTemplate,cross,i686,wasm32,wasm-runtime,llvm-llvm32,wasm32-unknown-unknown))
-endif
+# 64 bit cross compiler
+$(eval $(call WasmCrossTemplate,cross,x86_64,wasm32,runtime,llvm-llvm64,wasm32-unknown-unknown))
+# Old 32 bit cross compiler
+$(eval $(call WasmCrossTemplate,cross-32,i686,wasm32,runtime,llvm-llvm32,wasm32-unknown-unknown))
 
 ##
 # Parameters
@@ -151,15 +153,11 @@ _wasm-$(1)_CONFIGURE_FLAGS= \
 
 .stamp-wasm-$(1)-$$(CONFIGURATION)-configure: | $$(if $$(IGNORE_PROVISION_MXE),,provision-mxe)
 
-$$(eval $$(call CrossRuntimeTemplate,wasm-$(1),$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static),$(3)-unknown-none,$(4),$(5),$(6)))
-
-wasm_TARGETS += wasm-$(1)-$$(CONFIGURATION) $(5)
+$$(eval $$(call CrossRuntimeTemplate,wasm,$(1),$(2)-w64-mingw32$$(if $$(filter $(UNAME),Darwin),.static),$(3)-unknown-none,$(4),$(5),$(6)))
 
 endef
 
-ifeq ($(DISABLE_WASM_CROSS),)
-$(eval $(call WasmCrossMXETemplate,cross-win,i686,wasm32,wasm-runtime,llvm-llvmwin32,wasm32-unknown-unknown))
-endif
 
-$(eval $(call BclTemplate,wasm-bcl,wasm,wasm))
-wasm_TARGETS += wasm-bcl
+$(eval $(call WasmCrossMXETemplate,cross-win,i686,wasm32,runtime,llvm-llvmwin32,wasm32-unknown-unknown))
+
+$(eval $(call BclTemplate,wasm,wasm wasm_tools,wasm))

--- a/support/Makefile.am
+++ b/support/Makefile.am
@@ -99,12 +99,17 @@ ZLIB_SOURCES = \
 	zlib.h  	\
 	zutil.h
 
+if HAVE_STATIC_ZLIB
+Z_SOURCE = zlib-helper.c
+Z_LIBS = $(STATIC_ZLIB_PATH)
+else
 if HAVE_ZLIB
 Z_SOURCE = zlib-helper.c
 Z_LIBS= -lz
 else
 Z_SOURCE = zlib-helper.c $(ZLIB_SOURCES)
 Z_LIBS=
+endif
 endif
 
 libMonoPosixHelper_la_SOURCES =			\


### PR DESCRIPTION
It turns out that homebrew now has a package for the MinGW gcc-based windows
cross compiler which is awesome as it allows us to skip building MXE and use the
latest version of the GCC suite pre-packaged for Mac. This commit removes almost
all traces of MXE (except for `mxe.mk` itself, because I don't know if any bot
or external tool, whatever, use targets in it) and adds the following brew
packages to SDK bot provisioning as well as to the `provision-mxe` target of
Mono SDKs:

  * mingw-w64
  * xamarin/xamarin-android-windeps/mingw-zlib

The latter package builds a Windows version of zlib using MinGW and it comes
from Xamarin's own homebrew tap at https://github.com/xamarin/homebrew-xamarin-android-windeps/blob/f4cc90845ff1953800d8d71035566a12d9b7aa24/mingw-zlib.rb

Additionally, this commit adds a new `configure` flag: `--with-static-zlib=PATH`
which allows one to specify the static zlib archive to use when linking Mono.
The static archive supersedes the otherwise indicated or detected zlib. This is
the recommended mode of operation for MinGW builds as it avoids problems with
`zlib.dll` versions on the target machine.



Backport of #12434