### PR TITLE
[netcore] Fix TrySetApartmentStateUnchecked return value

### DIFF
--- a/mcs/class/System.Private.CoreLib/System.Threading/Thread.cs
+++ b/mcs/class/System.Private.CoreLib/System.Threading/Thread.cs
@@ -255,7 +255,7 @@ namespace System.Threading
 			return YieldInternal ();
 		}
 
-		public bool TrySetApartmentStateUnchecked (ApartmentState state) => false;
+		public bool TrySetApartmentStateUnchecked (ApartmentState state) => state == ApartmentState.Unknown;
 
 		ThreadState ValidateThreadState ()
 		{


### PR DESCRIPTION
Fixes remaining failure in System.Threading.Thread.Tests.
