### PR TITLE
[netcore] Add exceptions for tests that depend on CoreCLR behavior

### DIFF
--- a/netcore/excludes-System.IO.Tests.rsp
+++ b/netcore/excludes-System.IO.Tests.rsp
@@ -1,0 +1,2 @@
+# Mono allows large arrays (int.MaxValue elements)
+-nomethod System.IO.Tests.MemoryStream_ConstructorTests.MemoryStream_Ctor_InvalidCapacities

--- a/netcore/excludes-System.Text.Json.Tests.rsp
+++ b/netcore/excludes-System.Text.Json.Tests.rsp
@@ -1,0 +1,4 @@
+# JsonSerializer.Parse<Enum>(...) generates invalid IL through DynamicMethod
+# Mono throws "System.MemberAccessException: Cannot create an abstract class: System.Enum" from System.Reflection.Emit.DynamicMethod.CreateDelegate
+# CoreCLR creates the delegate, but fails to execute it with "System.InvalidOperationException: Instances of abstract classes cannot be created."
+-nomethod System.Text.Json.Serialization.Tests.ValueTests.ValueFail

--- a/netcore/excludes-System.Threading.ThreadPool.Tests.rsp
+++ b/netcore/excludes-System.Threading.ThreadPool.Tests.rsp
@@ -1,0 +1,4 @@
+# Tests for ThreadPool.SetMaxThreads(-1, -1) == true, which only happens to work on CoreCLR because
+# the managed SetMaxThreadsNative prototype uses "int"s while the unmanaged code uses "DWORD"s and
+# thus it interprets it as large positive numbers.
+-nomethod System.Threading.ThreadPools.Tests.ThreadPoolTests.SetMinMaxThreadsTest


### PR DESCRIPTION
Please review them carefully. Some of them may be worth fixing.