### PR TITLE
[2019-02] [SWF] Fix Stackoverflow SplitContainer`s SplitterDistance set in SplitterMoved

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/SplitContainer.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/SplitContainer.cs
@@ -395,7 +395,7 @@ namespace System.Windows.Forms
 				if (value < panel1_min_size)
 					value = panel1_min_size;
 
-				bool updated = true;
+				bool updated;
 				if (orientation == Orientation.Vertical) {
 					if (this.Width - (this.SplitterWidth + value) < panel2_min_size)
 						value = this.Width - (this.SplitterWidth + panel2_min_size);

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/SplitContainer.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/SplitContainer.cs
@@ -395,7 +395,7 @@ namespace System.Windows.Forms
 				if (value < panel1_min_size)
 					value = panel1_min_size;
 
-				bool updated;
+				bool updated = false;
 				if (orientation == Orientation.Vertical) {
 					if (this.Width - (this.SplitterWidth + value) < panel2_min_size)
 						value = this.Width - (this.SplitterWidth + panel2_min_size);


### PR DESCRIPTION
Fixes #13434

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->


Backport of #13451.

/cc @marek-safar @sancheolz