### PR TITLE
[2019-02] [SWF] Method OnClosed should pass FormClosedEventArgs type, instead of EventArgs

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/Form.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/Form.cs
@@ -157,8 +157,9 @@ namespace System.Windows.Forms {
 		// Convenience method for fire BOTH OnClosed and OnFormClosed events
 		private void FireClosedEvents (CloseReason reason)
 		{
-			this.OnClosed (EventArgs.Empty);
-			this.OnFormClosed (new FormClosedEventArgs (reason));
+			FormClosedEventArgs fc = new FormClosedEventArgs(reason);
+			this.OnClosed (fc);
+			this.OnFormClosed (fc);
 		}
 
 		[EditorBrowsable (EditorBrowsableState.Advanced)]

--- a/mcs/class/System.Windows.Forms/Test/System.Windows.Forms/MdiFormTest.cs
+++ b/mcs/class/System.Windows.Forms/Test/System.Windows.Forms/MdiFormTest.cs
@@ -260,6 +260,7 @@ namespace MonoTests.System.Windows.Forms
 
 				void ChildForm_Closed (object sender, EventArgs e)
 				{
+					Assert.IsNotNull ((FormClosedEventArgs)e, "FormClosedEventArgs");
 					Assert.IsNotNull (MdiParent, "ChildForm_Closed");
 				}
 			


### PR DESCRIPTION
Fixes #13282



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->


Backport of #13283.

/cc @marek-safar @sancheolz