### PR TITLE
[metadata] Don't free_aggregate_modifiers in mono_metadata_free_type

### DIFF
--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -4053,9 +4053,6 @@ do_mono_metadata_parse_type (MonoType *type, MonoImage *m, MonoGenericContainer 
 void
 mono_metadata_free_type (MonoType *type)
 {
-	if (type->has_cmods && mono_type_is_aggregate_mods (type))
-		free_aggregate_modifiers (mono_type_get_amods (type));
-	
 	if (type >= builtin_types && type < builtin_types + NBUILTIN_TYPES ())
 		return;
 	


### PR DESCRIPTION
The aggregate modifiers container is owned by a `MonoImageSet`.  The aggregate modifiers may be shared by more than one `MonoType` that happen to need the same modifiers. (Similar to how generic instantiations are shared)

When the image set is cleaned up the aggregate modifier cleanup will free the types in the aggregate modifiers container (the call to `free_aggregate_modifiers` in `mono_metadata_clean_for_image`).

With this extra call to `free_aggregate_modifiers` in `mono_metadata_free_type` may cause the same memory to be freed twice.

Fixes https://github.com/mono/mono/issues/13775



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
