### PR TITLE
[wasm] Fix Uint8ClampedArray.From(byte[]) invalid cast

### DIFF
--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -172,7 +172,8 @@ build-test-suite: bin/test-suite/mono.js
 $(BROWSER_TEST)/.stamp-browser-test-suite: $(DRIVER_CONF)/.stamp-build packager.exe $(WASM_FRAMEWORK)/.stamp-framework $(BROWSER_TEST_SOURCES)
 	$(CSC) $(CSC_FLAGS) /target:library -out:$(BROWSER_TEST)/HttpTestSuite.dll $(BCL_DEPS) $(WASM_FRAMEWORK_DEPS) $(BROWSER_TEST)/HttpTestSuite.cs 
 	$(CSC) $(CSC_FLAGS) /target:library -out:$(BROWSER_TEST)/WebSocketTestSuite.dll $(BCL_DEPS) $(WASM_FRAMEWORK_DEPS) $(BROWSER_TEST)/WebSocketTestSuite.cs 
-	mono --debug packager.exe -out=$(BROWSER_TEST)/publish --copy=IfNewer --template=$(BROWSER_TEST)/runtime.js $(BROWSER_TEST_ASSETS) $(BROWSER_TEST)/HttpTestSuite.dll $(BROWSER_TEST)/WebSocketTestSuite.dll
+	$(CSC) $(CSC_FLAGS) /target:library -out:$(BROWSER_TEST)/BindingsTestSuite.dll $(BCL_DEPS) $(WASM_FRAMEWORK_DEPS) /r:$(WASM_BCL_DIR)/Facades/System.Memory.dll $(BROWSER_TEST)/BindingsTestSuite.cs 
+	mono --debug packager.exe -out=$(BROWSER_TEST)/publish --copy=IfNewer --template=$(BROWSER_TEST)/runtime.js $(BROWSER_TEST_ASSETS) $(BROWSER_TEST)/HttpTestSuite.dll $(BROWSER_TEST)/WebSocketTestSuite.dll $(BROWSER_TEST)/BindingsTestSuite.dll
 	(cd $(BROWSER_TEST) && npm install)
 	touch $@
 

--- a/sdks/wasm/binding_support.js
+++ b/sdks/wasm/binding_support.js
@@ -431,6 +431,9 @@ var BindingSupportLib = {
 				case 14:
 					newTypedArray = new Float64Array(end - begin);
 					break;
+				case 15:  // This is a special case because the typed array is also byte[]
+					newTypedArray = new Uint8ClampedArray(end - begin);
+					break;
 			}
 
 			this.typedarray_copy_from(newTypedArray, pinned_array, begin, end, bytes_per_element);

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Core/TypedArray.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Core/TypedArray.cs
@@ -24,6 +24,31 @@ namespace WebAssembly.Core {
 		internal TypedArray (IntPtr js_handle) : base (js_handle)
 		{ }
 
+		public TypedArrayTypeCode GetTypedArrayType()
+		{
+			switch (this) {
+			case Int8Array _:
+				return TypedArrayTypeCode.Int8Array;
+			case Uint8Array _:
+				return TypedArrayTypeCode.Uint8Array;
+			case Uint8ClampedArray _:
+				return TypedArrayTypeCode.Uint8ClampedArray;
+			case Int16Array _:
+				return TypedArrayTypeCode.Int16Array;
+			case Uint16Array _:
+				return TypedArrayTypeCode.Uint16Array;
+			case Int32Array _:
+				return TypedArrayTypeCode.Int32Array;
+			case Uint32Array _:
+				return TypedArrayTypeCode.Uint32Array;
+			case Float32Array _:
+				return TypedArrayTypeCode.Float32Array;
+			case Float64Array _:
+				return TypedArrayTypeCode.Float64Array;
+			default:
+				throw new ArrayTypeMismatchException ("TypedArray is not of correct type.");
+			}
+		}
 
 		public int BytesPerElement => (int)GetObjectProperty ("BYTES_PER_ELEMENT");
 		public string Name => (string)GetObjectProperty ("name");
@@ -106,13 +131,14 @@ namespace WebAssembly.Core {
 			// source has to be instantiated.
 			ValidateFromSource (span);
 
-			int type = (int)Type.GetTypeCode (typeof (U));
-			if (type == 6 && typeof(T) == typeof(Uint8ClampedArray))
-				type = 15;  // Special case for clamped array
+			TypedArrayTypeCode type = (TypedArrayTypeCode)Type.GetTypeCode (typeof (U));
+			// Special case for Uint8ClampedArray, a clamped array which represents an array of 8-bit unsigned integers clamped to 0-255;
+			if (type == TypedArrayTypeCode.Uint8Array && typeof(T) == typeof(Uint8ClampedArray))
+				type = TypedArrayTypeCode.Uint8ClampedArray;  // This is only passed to the JavaScript side so it knows it will be a Uint8ClampedArray
 
 			var bytes = MemoryMarshal.AsBytes (span);
 			fixed (byte* ptr = bytes) {
-				var res = Runtime.TypedArrayFrom ((int)ptr, 0, span.Length, Marshal.SizeOf<U> (), type, out int exception);
+				var res = Runtime.TypedArrayFrom ((int)ptr, 0, span.Length, Marshal.SizeOf<U> (), (int)type, out int exception);
 				if (exception != 0)
 					throw new JSException ((string)res);
 				return (T)res;

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Core/TypedArray.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Core/TypedArray.cs
@@ -107,6 +107,8 @@ namespace WebAssembly.Core {
 			ValidateFromSource (span);
 
 			int type = (int)Type.GetTypeCode (typeof (U));
+			if (type == 6 && typeof(T) == typeof(Uint8ClampedArray))
+				type = 15;  // Special case for clamped array
 
 			var bytes = MemoryMarshal.AsBytes (span);
 			fixed (byte* ptr = bytes) {

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Core/TypedArrayTypeCode.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Core/TypedArrayTypeCode.cs
@@ -1,0 +1,14 @@
+﻿using System;
+namespace WebAssembly.Core {
+	public enum TypedArrayTypeCode {
+		Int8Array = 5,
+		Uint8Array = 6,
+		Int16Array = 7,
+		Uint16Array = 8,
+		Int32Array = 9,
+		Uint32Array = 10,
+		Float32Array = 13,
+		Float64Array = 14,
+		Uint8ClampedArray = 0xF,
+	}
+}

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Interfaces.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Interfaces.cs
@@ -21,6 +21,7 @@ namespace WebAssembly.Core {
 
 		void Set (ITypedArray typedArray);
 		void Set (ITypedArray typedArray, int offset);
+		TypedArrayTypeCode GetTypedArrayType ();
 	}
 
 	public interface ITypedArray<T, U> where U : struct {

--- a/sdks/wasm/tests/browser/BindingsTestSuite.cs
+++ b/sdks/wasm/tests/browser/BindingsTestSuite.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using WebAssembly;
+using WebAssembly.Core;
+
+namespace TestSuite
+{
+    public class Program
+    {
+        private static Uint8ClampedArray Uint8ClampedArrayFrom ()
+        {
+            var clamped = new byte[50];
+            return Uint8ClampedArray.From(clamped);
+        }
+
+        private static Uint8Array Uint8ArrayFrom ()
+        {
+            var array = new byte[50];
+            return Uint8Array.From(array);
+        }
+        private static Uint16Array Uint16ArrayFrom ()
+        {
+            var array = new ushort[50];
+            return Uint16Array.From(array);
+        }
+        private static Uint32Array Uint32ArrayFrom ()
+        {
+            var array = new uint[50];
+            return Uint32Array.From(array);
+        }
+        private static Int8Array Int8ArrayFrom ()
+        {
+            var array = new sbyte[50];
+            return Int8Array.From(array);
+        }
+        private static Int16Array Int16ArrayFrom ()
+        {
+            var array = new short[50];
+            return Int16Array.From(array);
+        }
+        private static Int32Array Int32ArrayFrom ()
+        {
+            var array = new int[50];
+            return Int32Array.From(array);
+        }
+        private static Float32Array Float32ArrayFrom ()
+        {
+            var array = new float[50];
+            return Float32Array.From(array);
+        }
+        private static Float64Array Float64ArrayFrom ()
+        {
+            var array = new double[50];
+            return Float64Array.From(array);
+        }
+    }
+}

--- a/sdks/wasm/tests/browser/BindingsTestSuite.cs
+++ b/sdks/wasm/tests/browser/BindingsTestSuite.cs
@@ -54,5 +54,9 @@ namespace TestSuite
             var array = new double[50];
             return Float64Array.From(array);
         }
+        private static TypedArrayTypeCode TypedArrayType (ITypedArray arr)
+        {
+            return arr.GetTypedArrayType();
+        }
     }
 }

--- a/sdks/wasm/tests/browser/http-spec.js
+++ b/sdks/wasm/tests/browser/http-spec.js
@@ -547,5 +547,88 @@ describe("The WebAssembly Browser Test Suite",function(){
       var arr = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:Float64ArrayFrom", []);
       assert.equal(arr.length, 50, "result does not match length of 50.");
       assert.equal(Object.prototype.toString.call(arr), "[object Float64Array]", "TypedArray is not of type Float64Array" )
+    }, DEFAULT_TIMEOUT);  
+    
+    it('BindingTestSuite: Should return Int8Array type.', () => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+
+      var type = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:TypedArrayType", [new Int8Array()]);
+      assert.equal(type, "Int8Array", "result does not match Int8Array.");
+
     }, DEFAULT_TIMEOUT);    
+    
+    it('BindingTestSuite: Should return Uint8Array type.', () => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+
+      var type = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:TypedArrayType", [new Uint8Array()]);
+      assert.equal(type, "Uint8Array", "result does not match Uint8Array.");
+
+    }, DEFAULT_TIMEOUT);    
+    
+    it('BindingTestSuite: Should return Uint8ClampedArray type.', () => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+
+      var type = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:TypedArrayType", [new Uint8ClampedArray()]);
+      assert.equal(type, "Uint8ClampedArray", "result does not match Uint8ClampedArray.");
+
+    }, DEFAULT_TIMEOUT);    
+    
+    it('BindingTestSuite: Should return Int16Array type.', () => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+
+      var type = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:TypedArrayType", [new Int16Array()]);
+      assert.equal(type, "Int16Array", "result does not match Int16Array.");
+
+    }, DEFAULT_TIMEOUT);    
+    
+    it('BindingTestSuite: Should return Uint16Array type.', () => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+
+      var type = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:TypedArrayType", [new Uint16Array()]);
+      assert.equal(type, "Uint16Array", "result does not match Uint16Array.");
+
+    }, DEFAULT_TIMEOUT);    
+    
+    it('BindingTestSuite: Should return Int32Array type.', () => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+
+      var type = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:TypedArrayType", [new Int32Array()]);
+      assert.equal(type, "Int32Array", "result does not match Int32Array.");
+
+    }, DEFAULT_TIMEOUT);    
+    
+    it('BindingTestSuite: Should return Uint32Array type.', () => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+
+      var type = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:TypedArrayType", [new Uint32Array()]);
+      assert.equal(type, "Uint32Array", "result does not match Uint32Array.");
+
+    }, DEFAULT_TIMEOUT);    
+    
+    it('BindingTestSuite: Should return Float32Array type.', () => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+
+      var type = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:TypedArrayType", [new Float32Array()]);
+      assert.equal(type, "Float32Array", "result does not match Float32Array.");
+
+    }, DEFAULT_TIMEOUT);    
+    
+    it('BindingTestSuite: Should return Float64Array type.', () => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+
+      var type = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:TypedArrayType", [new Float64Array()]);
+      assert.equal(type, "Float64Array", "result does not match Float64Array.");
+
+    }, DEFAULT_TIMEOUT);    
+
+    
   });

--- a/sdks/wasm/tests/browser/http-spec.js
+++ b/sdks/wasm/tests/browser/http-spec.js
@@ -457,7 +457,95 @@ describe("The WebAssembly Browser Test Suite",function(){
         (error) => done.fail(error)
 
       );
-      
-    }, DEFAULT_WS_TIMEOUT);    
+    }, DEFAULT_WS_TIMEOUT);  
 
+    it('BindingTestSuite: Should return new Uint8ClampedArray from a c# byte array.', () => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+
+
+      var clamped = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:Uint8ClampedArrayFrom", []);
+      assert.equal(clamped.length, 50, "result does not match length of 50.");
+      assert.equal(Object.prototype.toString.call(clamped), "[object Uint8ClampedArray]", "TypedArray is not of type Float64Array" )
+
+    }, DEFAULT_TIMEOUT);  
+
+    it('BindingTestSuite: Should return new Uint8Array from a c# byte array.', () => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+
+      var arr = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:Uint8ArrayFrom", []);
+      assert.equal(arr.length, 50, "result does not match length of 50.");
+      assert.equal(Object.prototype.toString.call(arr), "[object Uint8Array]", "TypedArray is not of type Float64Array" )
+
+    }, DEFAULT_TIMEOUT);    
+
+    it('BindingTestSuite: Should return new Uint16Array from a c# ushort array.', () => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+
+      var arr = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:Uint16ArrayFrom", []);
+      assert.equal(arr.length, 50, "result does not match length of 50.");
+      assert.equal(Object.prototype.toString.call(arr), "[object Uint16Array]", "TypedArray is not of type Float64Array" )
+
+    }, DEFAULT_TIMEOUT);    
+
+    it('BindingTestSuite: Should return new Uint32Array from a c# uint array.', () => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+
+      var arr = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:Uint32ArrayFrom", []);
+      assert.equal(arr.length, 50, "result does not match length of 50.");
+      assert.equal(Object.prototype.toString.call(arr), "[object Uint32Array]", "TypedArray is not of type Float64Array" )
+
+    }, DEFAULT_TIMEOUT);    
+
+    it('BindingTestSuite: Should return new Int8Array from a c# sbyte array.', () => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+
+      var arr = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:Int8ArrayFrom", []);
+      assert.equal(arr.length, 50, "result does not match length of 50.");
+      assert.equal(Object.prototype.toString.call(arr), "[object Int8Array]", "TypedArray is not of type Float64Array" )
+
+    }, DEFAULT_TIMEOUT);    
+
+    it('BindingTestSuite: Should return new Int16Array from a c# short array.', () => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+
+      var arr = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:Int16ArrayFrom", []);
+      assert.equal(arr.length, 50, "result does not match length of 50.");
+      assert.equal(Object.prototype.toString.call(arr), "[object Int16Array]", "TypedArray is not of type Float64Array" )
+
+    }, DEFAULT_TIMEOUT);    
+
+    it('BindingTestSuite: Should return new Int32Array from a c# int array.', () => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+
+      var arr = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:Int32ArrayFrom", []);
+      assert.equal(arr.length, 50, "result does not match length of 50.");
+      assert.equal(Object.prototype.toString.call(arr), "[object Int32Array]", "TypedArray is not of type Float64Array" )
+
+    }, DEFAULT_TIMEOUT);    
+
+    it('BindingTestSuite: Should return new Float32Array from a c# float array.', () => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+
+      var arr = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:Float32ArrayFrom", []);
+      assert.equal(arr.length, 50, "result does not match length of 50.");
+      assert.equal(Object.prototype.toString.call(arr), "[object Float32Array]", "TypedArray is not of type Float64Array" )
+
+    }, DEFAULT_TIMEOUT);    
+
+    it('BindingTestSuite: Should return new Float64Array from a c# double array.', () => {
+      //karmaHTML.httpspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.httpspec.document;
+
+      var arr = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:Float64ArrayFrom", []);
+      assert.equal(arr.length, 50, "result does not match length of 50.");
+      assert.equal(Object.prototype.toString.call(arr), "[object Float64Array]", "TypedArray is not of type Float64Array" )
+    }, DEFAULT_TIMEOUT);    
   });

--- a/sdks/wasm/tests/browser/http-spec.js
+++ b/sdks/wasm/tests/browser/http-spec.js
@@ -466,7 +466,7 @@ describe("The WebAssembly Browser Test Suite",function(){
 
       var clamped = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:Uint8ClampedArrayFrom", []);
       assert.equal(clamped.length, 50, "result does not match length of 50.");
-      assert.equal(Object.prototype.toString.call(clamped), "[object Uint8ClampedArray]", "TypedArray is not of type Float64Array" )
+      assert.equal(Object.prototype.toString.call(clamped), "[object Uint8ClampedArray]", "TypedArray is not of type Uint8ClampedArray" )
 
     }, DEFAULT_TIMEOUT);  
 
@@ -476,7 +476,7 @@ describe("The WebAssembly Browser Test Suite",function(){
 
       var arr = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:Uint8ArrayFrom", []);
       assert.equal(arr.length, 50, "result does not match length of 50.");
-      assert.equal(Object.prototype.toString.call(arr), "[object Uint8Array]", "TypedArray is not of type Float64Array" )
+      assert.equal(Object.prototype.toString.call(arr), "[object Uint8Array]", "TypedArray is not of type Uint8Array" )
 
     }, DEFAULT_TIMEOUT);    
 
@@ -486,7 +486,7 @@ describe("The WebAssembly Browser Test Suite",function(){
 
       var arr = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:Uint16ArrayFrom", []);
       assert.equal(arr.length, 50, "result does not match length of 50.");
-      assert.equal(Object.prototype.toString.call(arr), "[object Uint16Array]", "TypedArray is not of type Float64Array" )
+      assert.equal(Object.prototype.toString.call(arr), "[object Uint16Array]", "TypedArray is not of type Uint16Array" )
 
     }, DEFAULT_TIMEOUT);    
 
@@ -496,7 +496,7 @@ describe("The WebAssembly Browser Test Suite",function(){
 
       var arr = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:Uint32ArrayFrom", []);
       assert.equal(arr.length, 50, "result does not match length of 50.");
-      assert.equal(Object.prototype.toString.call(arr), "[object Uint32Array]", "TypedArray is not of type Float64Array" )
+      assert.equal(Object.prototype.toString.call(arr), "[object Uint32Array]", "TypedArray is not of type Uint32Array" )
 
     }, DEFAULT_TIMEOUT);    
 
@@ -506,7 +506,7 @@ describe("The WebAssembly Browser Test Suite",function(){
 
       var arr = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:Int8ArrayFrom", []);
       assert.equal(arr.length, 50, "result does not match length of 50.");
-      assert.equal(Object.prototype.toString.call(arr), "[object Int8Array]", "TypedArray is not of type Float64Array" )
+      assert.equal(Object.prototype.toString.call(arr), "[object Int8Array]", "TypedArray is not of type Int8Array" )
 
     }, DEFAULT_TIMEOUT);    
 
@@ -516,7 +516,7 @@ describe("The WebAssembly Browser Test Suite",function(){
 
       var arr = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:Int16ArrayFrom", []);
       assert.equal(arr.length, 50, "result does not match length of 50.");
-      assert.equal(Object.prototype.toString.call(arr), "[object Int16Array]", "TypedArray is not of type Float64Array" )
+      assert.equal(Object.prototype.toString.call(arr), "[object Int16Array]", "TypedArray is not of type Int16Array" )
 
     }, DEFAULT_TIMEOUT);    
 
@@ -526,7 +526,7 @@ describe("The WebAssembly Browser Test Suite",function(){
 
       var arr = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:Int32ArrayFrom", []);
       assert.equal(arr.length, 50, "result does not match length of 50.");
-      assert.equal(Object.prototype.toString.call(arr), "[object Int32Array]", "TypedArray is not of type Float64Array" )
+      assert.equal(Object.prototype.toString.call(arr), "[object Int32Array]", "TypedArray is not of type Int32Array" )
 
     }, DEFAULT_TIMEOUT);    
 
@@ -536,7 +536,7 @@ describe("The WebAssembly Browser Test Suite",function(){
 
       var arr = _document.Module.BINDING.call_static_method("[BindingsTestSuite]TestSuite.Program:Float32ArrayFrom", []);
       assert.equal(arr.length, 50, "result does not match length of 50.");
-      assert.equal(Object.prototype.toString.call(arr), "[object Float32Array]", "TypedArray is not of type Float64Array" )
+      assert.equal(Object.prototype.toString.call(arr), "[object Float32Array]", "TypedArray is not of type Float32Array" )
 
     }, DEFAULT_TIMEOUT);    
 


### PR DESCRIPTION
Fixes issue https://github.com/mono/mono/issues/13787

- Add new BindingsTestSuite.cs program to the Tests that will test for these cases so regressions do not slip in.
- Add TypedArrayTypeCode enum