### PR TITLE
[bcl] Fix compiling nunitlite when PARENT_PROFILE is defined

### DIFF
--- a/mcs/build/tests.make
+++ b/mcs/build/tests.make
@@ -62,7 +62,7 @@ xunit_class_deps :=
 xunit_libs_ref = $(patsubst %,-r:$(topdir)/../external/xunit-binaries/%.dll,$(xunit_core))
 xunit_libs_ref += $(patsubst %,-r:$(topdir)/class/lib/$(PROFILE)/Facades/%.dll,$(xunit_deps))
 
-xunit_libs_dep = $(xunit_class_deps:%=$(topdir)/class/lib/$(PROFILE)/$(PARENT_PROFILE)%.dll)
+xunit_libs_dep = $(xunit_class_deps:%=$(topdir)/class/lib/$(PROFILE)/%.dll)
 xunit_libs_ref += $(xunit_libs_dep:%=-r:%)
 
 TEST_LIB_REFS_ALL = $(TEST_LIB_REFS) $(DEFAULT_REFERENCES)
@@ -80,7 +80,7 @@ endif
 
 XTEST_LIB_MCS_FLAGS = $(patsubst %,-r:$(topdir)/class/lib/$(PROFILE)/%.dll,$(XTEST_LIB_REFS) $(DEFAULT_REFERENCES))
 
-test_nunit_dep = $(test_nunit_lib:%=$(topdir)/class/lib/$(PROFILE)/$(PARENT_PROFILE)%)
+test_nunit_dep = $(test_nunit_lib:%=$(topdir)/class/lib/$(PROFILE)/%)
 test_nunit_ref = $(test_nunit_dep:%=-r:%)
 tests_CLEAN_FILES += TestResult*.xml
 
@@ -132,9 +132,7 @@ $(test_nunit_dep): $(topdir)/build/deps/nunit-$(PROFILE).stamp
 	@if test -f $@; then :; else rm -f $<; $(MAKE) $<; fi
 
 $(topdir)/build/deps/nunit-$(PROFILE).stamp:
-ifndef PARENT_PROFILE
 	cd ${topdir}/tools/nunit-lite && $(MAKE)
-endif
 	echo "stamp" >$@
 
 tests_CLEAN_FILES += $(topdir)/build/deps/nunit-$(PROFILE).stamp

--- a/mcs/class/Microsoft.Build.Tasks/Makefile
+++ b/mcs/class/Microsoft.Build.Tasks/Makefile
@@ -41,7 +41,7 @@ endif
 EXTRA_DISTFILES = $(filter-out Test/resources/test.dll, $(TEST_RESOURCE_FILES))
 
 Test/resources/test.dll: Test/resources/test.cs
-	$(CSCOMPILE) -r:$(topdir)/class/lib/$(PROFILE)/mscorlib.dll -target:library /out:$@ $<
+	$(CSCOMPILE) -r:$(topdir)/class/lib/$(PROFILE)/$(PARENT_PROFILE)mscorlib.dll -target:library /out:$@ $<
 
 clean-test-resources:
 	rm -f Test/resources/test.dll

--- a/mcs/tools/nunit-lite/NUnitLite/Makefile
+++ b/mcs/tools/nunit-lite/NUnitLite/Makefile
@@ -6,9 +6,10 @@ LIBRARY = nunitlite.dll
 KEYFILE = ../../../class/mono.snk
 
 LOCAL_MCS_FLAGS= /target:library /define:"__MOBILE__;TRACE;DEBUG;NET_4_0;CLR_4_0,NUNITLITE" /warn:4 /delaysign
-LIB_REFS = System System.Xml System.Core
+LIB_REFS = $(PARENT_PROFILE)System $(PARENT_PROFILE)System.Xml $(PARENT_PROFILE)System.Core
 
 NO_TEST = yes
+NO_INSTALL = yes
 
 include ../../../build/library.make
 

--- a/mcs/tools/nunit-lite/nunit-lite-console/Makefile
+++ b/mcs/tools/nunit-lite/nunit-lite-console/Makefile
@@ -6,5 +6,7 @@ PROGRAM = nunit-lite-console.exe
 LIB_REFS = nunitlite
 LOCAL_MCS_FLAGS =
 
+NO_INSTALL = yes
+
 include ../../../build/executable.make
 

--- a/scripts/ci/run-test-default.sh
+++ b/scripts/ci/run-test-default.sh
@@ -11,7 +11,7 @@ if [[ ${CI_TAGS} == *'win-'* ]] || [[ ${CI_TAGS} == *'ppc64'* ]]
 then ${TESTCMD} --label=aot-test --skip;
 else ${TESTCMD} --label=aot-test --timeout=30m make -w -C mono/tests -j ${CI_CPU_COUNT} -k test-aot
 fi
-${TESTCMD} --label=compile-bcl-tests --timeout=40m make -i -w -C runtime -j ${CI_CPU_COUNT} test xunit-test
+${TESTCMD} --label=compile-bcl-tests --timeout=40m make -w -C runtime -j ${CI_CPU_COUNT} test xunit-test
 ${TESTCMD} --label=compile-runtime-tests --timeout=40m make -w -C mono/tests -j ${CI_CPU_COUNT} test
 ${TESTCMD} --label=runtime --timeout=160m make -w -C mono/tests -k test-wrench V=1
 ${TESTCMD} --label=runtime-unit-tests --timeout=5m make -w -C mono/unit-tests -k check

--- a/scripts/ci/run-test-helix.sh
+++ b/scripts/ci/run-test-helix.sh
@@ -4,10 +4,7 @@ source ${MONO_REPO_ROOT}/scripts/ci/util.sh
 
 helix_send_build_start_event "build/tests/$MONO_HELIX_TYPE/"
 ${TESTCMD} --label=compile-runtime-tests --timeout=20m --fatal make -w -C mono -j ${CI_CPU_COUNT} test
-${TESTCMD} --label=compile-bcl-tests --timeout=40m --fatal make -i -w -C runtime -j ${CI_CPU_COUNT} test xunit-test
-# TODO: remove the explicit xbuild tests compile step once the nunitlite dependency bug is fixed
-${TESTCMD} --label=compile-xbuild_12 --timeout=5m --fatal make -w -C mcs/class -j ${CI_CPU_COUNT} test PROFILE=xbuild_12
-${TESTCMD} --label=compile-xbuild_14 --timeout=5m --fatal make -w -C mcs/class -j ${CI_CPU_COUNT} test PROFILE=xbuild_14
+${TESTCMD} --label=compile-bcl-tests --timeout=40m --fatal make -w -C runtime -j ${CI_CPU_COUNT} test xunit-test
 ${TESTCMD} --label=create-test-payload --timeout=5m --fatal make -w test-bundle TEST_BUNDLE_PATH="$MONO_REPO_ROOT/mono-test-bundle"
 helix_send_build_done_event "build/tests/$MONO_HELIX_TYPE/" 0
 


### PR DESCRIPTION
In this case we relied on nunitlite to be compiled when the parent profile is compiled. That doesn't work however if we compile the child profile first (e.g. during a parallel make) since it'll
complain about missing nunitlite.dll.

We now compile nunitlite in the child profiles too even though we don't use it.
This is an alternative solution to what I tried in https://github.com/mono/mono/pull/5357 since I couldn't get it to work and this should be the easier fix.

It allows us to finally remove the `-i` (ignore errors) from the CI scripts and catch test assembly breakages in mobile profiles which we ignored before.

