### PR TITLE
[do not merge] Add some (inefficient) asserts to confirm my understan…

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -8881,6 +8881,9 @@ mono_find_jit_icall_by_name (const char *name)
 	mono_icall_lock ();
 	info = (MonoJitICallInfo *)g_hash_table_lookup (jit_icall_hash_name, name);
 	mono_icall_unlock ();
+
+	g_assertf (!strstr (name, "trampoline_"), "%s", name);
+
 	return info;
 }
 
@@ -8893,6 +8896,8 @@ mono_find_jit_icall_by_addr (gconstpointer addr)
 	mono_icall_lock ();
 	info = (MonoJitICallInfo *)g_hash_table_lookup (jit_icall_hash_addr, (gpointer)addr);
 	mono_icall_unlock ();
+
+	g_assertf (!info || !strstr (info->name, "trampoline_"), "%s", info->name);
 
 	return info;
 }
@@ -8925,6 +8930,9 @@ mono_lookup_jit_icall_symbol (const char *name)
 	if (info)
 		res = info->c_symbol;
 	mono_icall_unlock ();
+
+	g_assertf (!strstr (name, "trampoline_"), "%s", name);
+
 	return res;
 }
 
@@ -8934,12 +8942,16 @@ mono_register_jit_icall_wrapper (MonoJitICallInfo *info, gconstpointer wrapper)
 	mono_icall_lock ();
 	g_hash_table_insert (jit_icall_hash_addr, (gpointer)wrapper, info);
 	mono_icall_unlock ();
+
+	g_assertf (!strstr(info->name, "trampoline_"), "%s", info->name);
 }
 
 MonoJitICallInfo *
 mono_register_jit_icall_full (gconstpointer func, const char *name, MonoMethodSignature *sig, gboolean avoid_wrapper, const char *c_symbol)
 {
 	MonoJitICallInfo *info;
+
+	g_assertf (!strstr(name, "trampoline_"), "%s", name);
 
 	g_assert (func);
 	g_assert (name);

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -8931,7 +8931,7 @@ mono_lookup_jit_icall_symbol (const char *name)
 		res = info->c_symbol;
 	mono_icall_unlock ();
 
-	g_assertf (!strstr (name, "trampoline_"), "%s", name);
+	g_assertf (!info || !strstr (name, "trampoline_"), "%s", name);
 
 	return res;
 }


### PR DESCRIPTION
…ding of the system to validate a change.

In particular:

```
Searching for '%u", slot'...
C:\s\mono2\mono\mini\tramp-amd64.c(718):  code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, g_strdup_printf ("specific_trampoline_lazy_fetch_%u", slot));
C:\s\mono2\mono\mini\tramp-arm.c(699):  ji = mono_patch_info_list_prepend (ji, code - buf, MONO_PATCH_INFO_JIT_ICALL_ADDR, g_strdup_printf ("specific_trampoline_lazy_fetch_%u", slot));
C:\s\mono2\mono\mini\tramp-arm64.c(474):  code = mono_arm_emit_aotconst (&ji, code, buf, ARMREG_IP0, MONO_PATCH_INFO_JIT_ICALL_ADDR, g_strdup_printf ("specific_trampoline_lazy_fetch_%u", slot));
C:\s\mono2\mono\mini\tramp-mips.c(429):  ji = mono_patch_info_list_prepend (ji, code - buf, MONO_PATCH_INFO_JIT_ICALL_ADDR, g_strdup_printf ("specific_trampoline_lazy_fetch_%u", slot));
C:\s\mono2\mono\mini\tramp-ppc.c(641):  code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, g_strdup_printf ("specific_trampoline_lazy_fetch_%u", slot));
C:\s\mono2\mono\mini\tramp-x86.c(493):  code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, g_strdup_printf ("specific_trampoline_lazy_fetch_%u", slot));


Searching for 'trampoline_func_'...
C:\s\mono2\mono\mini\aot-runtime.c(5382):				} else if (strstr (ji->data.name, "trampoline_func_") == ji->data.name) {
C:\s\mono2\mono\mini\aot-runtime.c(5383):					MonoTrampolineType tramp_type2 = (MonoTrampolineType)atoi (ji->data.name + strlen ("trampoline_func_"));
C:\s\mono2\mono\mini\tramp-amd64.c(467):		char *icall_name = g_strdup_printf ("trampoline_func_%d", tramp_type);
C:\s\mono2\mono\mini\tramp-arm.c(294):		char *icall_name = g_strdup_printf ("trampoline_func_%d", tramp_type);
C:\s\mono2\mono\mini\tramp-arm64.c(232):		char *icall_name = g_strdup_printf ("trampoline_func_%d", tramp_type);
C:\s\mono2\mono\mini\tramp-ppc.c(361):		code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, g_strdup_printf ("trampoline_func_%d", tramp_type));
C:\s\mono2\mono\mini\tramp-x86.c(287):		char *icall_name = g_strdup_printf ("trampoline_func_%d", tramp_type);


```


Do not really participate in this part of the runtime.
They can/should be made separate patch inf.