### PR TITLE
[2018-10] Fix transition offset logic

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -834,10 +834,12 @@ namespace System
 
 			if (tzRule != null && tz.IsInDST (tzRule, dateTime)) {
 				// Replicate what .NET does when given a time which falls into the hour which is lost when
-				// DST starts. isDST should always be true but the offset should be BaseUtcOffset without the
+				// DST starts. isDST should be false and the offset should be BaseUtcOffset without the
 				// DST delta while in that hour.
-				isDST = true;
+				if (forOffset)
+					isDST = true;
 				if (tz.IsInDST (tzRule, dstUtcDateTime)) {
+					isDST = true;
 					return tz.BaseUtcOffset + tzRule.DaylightDelta;
 				} else {
 					return tz.BaseUtcOffset;

--- a/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
@@ -436,17 +436,17 @@ namespace MonoTests.System
 				try {
 
 					var date = new DateTime (2014, 3, 30 , 3, 0, 0);
-					Assert.IsTrue (tzi.IsDaylightSavingTime (date));
+					Assert.IsFalse (tzi.IsDaylightSavingTime (date));
 					Assert.AreEqual (new TimeSpan (2, 0, 0), tzi.GetUtcOffset (date));
 					Assert.IsTrue (tzi.IsDaylightSavingTime (new DateTimeOffset (date, tzi.GetUtcOffset (date))));
 
 					date = new DateTime (2014, 3, 30 , 3, 1, 0);
-					Assert.IsTrue (tzi.IsDaylightSavingTime (date));
+					Assert.IsFalse (tzi.IsDaylightSavingTime (date));
 					Assert.AreEqual (new TimeSpan (2, 0, 0), tzi.GetUtcOffset (date));
 					Assert.IsTrue (tzi.IsDaylightSavingTime (new DateTimeOffset (date, tzi.GetUtcOffset (date))));
 
 					date = new DateTime (2014, 3, 30 , 3, 59, 0);
-					Assert.IsTrue (tzi.IsDaylightSavingTime (date));
+					Assert.IsFalse (tzi.IsDaylightSavingTime (date));
 					Assert.AreEqual (new TimeSpan (2, 0, 0), tzi.GetUtcOffset (date));
 					Assert.IsTrue (tzi.IsDaylightSavingTime (new DateTimeOffset (date, tzi.GetUtcOffset (date))));
 

--- a/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
@@ -55,6 +55,8 @@ namespace MonoTests.System
 					return "GTB Standard Time";
 				case "US/Eastern":
 					return "Eastern Standard Time";
+				case "US/Central":
+					return "Central Standard Time";
 				case "US/Pacific":
 					return "Pacific Standard Time";
 				case "Australia/Sydney":
@@ -385,23 +387,28 @@ namespace MonoTests.System
 			[Test]
 			public void TestAthensDST_InDSTDelta ()
 			{
-				// In .NET GetUtcOffset() returns the BaseUtcOffset for times within the hour
-				// lost when DST starts but IsDaylightSavingTime() returns true.
-
+				// In .NET/.Net Core GetUtcOffset() returns the BaseUtcOffset for times within the hour
+				// lost when DST starts and IsDaylightSavingTime() returns false for datetime and true for datetimeoffset
+				
 				TimeZoneInfo tzi = TimeZoneInfo.FindSystemTimeZoneById (MapTimeZoneId ("Europe/Athens"));
 
-				var date = new DateTime (2014, 3, 30 , 3, 0, 0);
-				Assert.IsTrue (tzi.IsDaylightSavingTime (date));
+				var date = new DateTime (2014, 3, 30 , 2, 0, 0);
+				Assert.IsFalse (tzi.IsDaylightSavingTime (date));
+				Assert.AreEqual (new TimeSpan (2, 0, 0), tzi.GetUtcOffset (date));
+				Assert.IsFalse (tzi.IsDaylightSavingTime (new DateTimeOffset (date, tzi.GetUtcOffset (date))));
+
+				date = new DateTime (2014, 3, 30 , 3, 0, 0);
+				Assert.IsFalse (tzi.IsDaylightSavingTime (date));
 				Assert.AreEqual (new TimeSpan (2, 0, 0), tzi.GetUtcOffset (date));
 				Assert.IsTrue (tzi.IsDaylightSavingTime (new DateTimeOffset (date, tzi.GetUtcOffset (date))));
 
 				date = new DateTime (2014, 3, 30 , 3, 1, 0);
-				Assert.IsTrue (tzi.IsDaylightSavingTime (date));
+				Assert.IsFalse (tzi.IsDaylightSavingTime (date));
 				Assert.AreEqual (new TimeSpan (2, 0, 0), tzi.GetUtcOffset (date));
 				Assert.IsTrue (tzi.IsDaylightSavingTime (new DateTimeOffset (date, tzi.GetUtcOffset (date))));
 
 				date = new DateTime (2014, 3, 30 , 3, 59, 0);
-				Assert.IsTrue (tzi.IsDaylightSavingTime (date));
+				Assert.IsFalse (tzi.IsDaylightSavingTime (date));
 				Assert.AreEqual (new TimeSpan (2, 0, 0), tzi.GetUtcOffset (date));
 				Assert.IsTrue (tzi.IsDaylightSavingTime (new DateTimeOffset (date, tzi.GetUtcOffset (date))));
 
@@ -466,6 +473,31 @@ namespace MonoTests.System
 				offset = tzi.GetUtcOffset (date);
 				dateOffset = new DateTimeOffset (date, offset);
 				Assert.IsTrue (tzi.IsDaylightSavingTime (dateOffset));
+			}
+
+			// https://github.com/mono/mono/issues/9664
+			[Test]
+			public void Bug_9664 ()
+			{
+				TimeZoneInfo tzi = TimeZoneInfo.FindSystemTimeZoneById (MapTimeZoneId ("US/Central"));
+				var date = new DateTime (2019, 3, 9, 21, 0, 0);
+				Assert.IsFalse (tzi.IsDaylightSavingTime (date));
+				Assert.AreEqual (new TimeSpan (-6, 0, 0), tzi.GetUtcOffset (date));
+
+				tzi = TimeZoneInfo.FindSystemTimeZoneById (MapTimeZoneId ("US/Central"));
+				date = new DateTime (2019, 3, 10, 2, 0, 0);
+				Assert.IsFalse (tzi.IsDaylightSavingTime (date));
+				Assert.AreEqual (new TimeSpan (-6, 0, 0), tzi.GetUtcOffset (date));
+
+				tzi = TimeZoneInfo.FindSystemTimeZoneById (MapTimeZoneId ("US/Central"));
+				date = new DateTime (2019, 3, 10, 2, 30, 0);
+				Assert.IsFalse (tzi.IsDaylightSavingTime (date));
+				Assert.AreEqual (new TimeSpan (-6, 0, 0), tzi.GetUtcOffset (date));
+
+				tzi = TimeZoneInfo.FindSystemTimeZoneById (MapTimeZoneId ("US/Central"));
+				date = new DateTime (2019, 3, 10, 3, 0, 0);
+				Assert.IsTrue (tzi.IsDaylightSavingTime (date));
+				Assert.AreEqual (new TimeSpan (-5, 0, 0), tzi.GetUtcOffset (date));
 			}
 		}
 		


### PR DESCRIPTION
I'm not sure about the correctness of this workaround but it works on macOS for the repro from https://github.com/mono/mono/issues/9664#issuecomment-472260968

Transition bounds used by time zone info represent some local date-time but actually they are of Unspecified date-time kind. 
When we try to get transition offset we compare some current date-time converted to UTC with appropriate transition bounds.
The fix is to use UTC for both current date-time and transition bounds during comparing.

Fixes https://github.com/mono/mono/issues/9664

Backport of #13553.

/cc @marek-safar @MaximLipnin