### PR TITLE
[llvm] Give LLVM noalias info about alloc functions

### DIFF
--- a/mono/mini/mini-llvm-cpp.cpp
+++ b/mono/mini/mini-llvm-cpp.cpp
@@ -255,6 +255,19 @@ mono_llvm_set_call_notailcall (LLVMValueRef func)
 #endif
 }
 
+void
+mono_llvm_set_call_noalias_ret (LLVMValueRef wrapped_calli)
+{
+#if LLVM_API_VERSION > 100
+	Instruction *calli = unwrap<Instruction> (wrapped_calli);
+
+	if (isa<CallInst> (calli))
+		dyn_cast<CallInst>(calli)->addAttribute (AttributeList::ReturnIndex, Attribute::NoAlias);
+	else
+		dyn_cast<InvokeInst>(calli)->addAttribute (AttributeList::ReturnIndex, Attribute::NoAlias);
+#endif
+}
+
 #if LLVM_API_VERSION > 500
 static Attribute::AttrKind
 convert_attr (AttrKind kind)

--- a/mono/mini/mini-llvm-cpp.h
+++ b/mono/mini/mini-llvm-cpp.h
@@ -107,6 +107,9 @@ void
 mono_llvm_set_call_notailcall (LLVMValueRef call);
 
 void
+mono_llvm_set_call_noalias_ret (LLVMValueRef wrapped_calli);
+
+void
 mono_llvm_add_func_attr (LLVMValueRef func, AttrKind kind);
 
 void

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -3973,6 +3973,11 @@ process_call (EmitContext *ctx, MonoBasicBlock *bb, LLVMBuilderRef *builder_ref,
 	if (ins->opcode != OP_TAILCALL && ins->opcode != OP_TAILCALL_MEMBASE && LLVMGetInstructionOpcode (lcall) == LLVMCall)
 		mono_llvm_set_call_notailcall (lcall);
 
+	// As per the LLVM docs, a function has a noalias return value if and only if
+	// it is an allocation function. This is an allocation function.
+	if (call->method && call->method->wrapper_type == MONO_WRAPPER_ALLOC)
+		mono_llvm_set_call_noalias_ret (lcall);
+
 	/*
 	 * Modify cconv and parameter attributes to pass rgctx/imt correctly.
 	 */


### PR DESCRIPTION
From: https://llvm.org/docs/LangRef.html

```
Furthermore, the semantics of the noalias attribute on return values are stronger than the semantics of the attribute when used on function arguments. On function return values, the noalias attribute indicates that the function acts like a system memory allocation function, returning a pointer to allocated storage disjoint from the storage for any other object accessible to the caller.
```

Think this probably helps LLVM reorder the method calls, telling it that allocating won't return a pointer to something else on the stack.