### PR TITLE
[netcore] Reenable some methods on RuntimeType

### DIFF
--- a/mcs/class/corlib/ReferenceSources/RuntimeType.cs
+++ b/mcs/class/corlib/ReferenceSources/RuntimeType.cs
@@ -95,19 +95,18 @@ namespace System
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		extern ConstructorInfo GetCorrespondingInflatedConstructor (ConstructorInfo generic);
 
-#if !NETCORE
 		internal override MethodInfo GetMethod (MethodInfo fromNoninstanciated)
-                {
+		{
 			if (fromNoninstanciated == null)
 				throw new ArgumentNullException ("fromNoninstanciated");
-                        return GetCorrespondingInflatedMethod (fromNoninstanciated);
-                }
+			return GetCorrespondingInflatedMethod (fromNoninstanciated);
+		}
 
 		internal override ConstructorInfo GetConstructor (ConstructorInfo fromNoninstanciated)
 		{
 			if (fromNoninstanciated == null)
 				throw new ArgumentNullException ("fromNoninstanciated");
-                        return GetCorrespondingInflatedConstructor (fromNoninstanciated);
+			return GetCorrespondingInflatedConstructor (fromNoninstanciated);
 		}
 
 		internal override FieldInfo GetField (FieldInfo fromNoninstanciated)
@@ -117,7 +116,6 @@ namespace System
 			flags |= fromNoninstanciated.IsPublic ? BindingFlags.Public : BindingFlags.NonPublic;
 			return GetField (fromNoninstanciated.Name, flags);
 		}
-#endif
 
 		string GetDefaultMemberName ()
 		{


### PR DESCRIPTION
Fixes remaining failures on System.Xml.XmlSerializer.Tests.