### PR TITLE
[netcore] Improve support for rare enum types

### DIFF
--- a/mcs/class/System.Private.CoreLib/System/Enum.cs
+++ b/mcs/class/System.Private.CoreLib/System/Enum.cs
@@ -41,23 +41,23 @@ namespace System
 			return DefaultEquals (this, obj);
 		}
 
-		[MethodImplAttribute(MethodImplOptions.InternalCall)]
-		private extern bool InternalHasFlag(Enum flags);
+		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		extern bool InternalHasFlag (Enum flags);
 
 		[Intrinsic]
 		public bool HasFlag (Enum flag)
 		{
-			if (flag == null)
+			if (flag is null)
 				throw new ArgumentNullException (nameof(flag));
-			if (!this.GetType().IsEquivalentTo (flag.GetType()))
-				throw new ArgumentException(SR.Format(SR.Argument_EnumTypeDoesNotMatch, flag.GetType(), this.GetType()));
+			if (!this.GetType ().IsEquivalentTo (flag.GetType ()))
+				throw new ArgumentException (SR.Format (SR.Argument_EnumTypeDoesNotMatch, flag.GetType (), this.GetType ()));
 
 			return InternalHasFlag (flag);
 		}
 
 		public static string GetName (Type enumType, object value)
 		{
-			if (enumType == null)
+			if (enumType is null)
 				throw new ArgumentNullException (nameof(enumType));
 
 			return enumType.GetEnumName (value);
@@ -65,7 +65,7 @@ namespace System
 
 		public static string[] GetNames (Type enumType)
 		{
-			if (enumType == null)
+			if (enumType is null)
 				throw new ArgumentNullException (nameof (enumType));
 
 			return enumType.GetEnumNames ();
@@ -73,24 +73,24 @@ namespace System
 
 		public static Type GetUnderlyingType (Type enumType)
 		{
-			if (enumType == null)
-				throw new ArgumentNullException (nameof(enumType));
+			if (enumType is null)
+				throw new ArgumentNullException (nameof (enumType));
 
 			return enumType.GetEnumUnderlyingType ();
 		}
 
-		public static Array GetValues(Type enumType)
+		public static Array GetValues (Type enumType)
 		{
-			if (enumType == null)
-				throw new ArgumentNullException (nameof(enumType));
+			if (enumType is null)
+				throw new ArgumentNullException (nameof (enumType));
 
 			return enumType.GetEnumValues ();
 		}
 
 		public static bool IsDefined (Type enumType, object value)
 		{
-			if (enumType == null)
-				throw new ArgumentNullException (nameof(enumType));
+			if (enumType is null)
+				throw new ArgumentNullException (nameof (enumType));
 
 			return enumType.IsEnumDefined (value);
 		}

--- a/mcs/class/System.Private.CoreLib/System/Enum.cs
+++ b/mcs/class/System.Private.CoreLib/System/Enum.cs
@@ -44,6 +44,7 @@ namespace System
 		[MethodImplAttribute(MethodImplOptions.InternalCall)]
 		private extern bool InternalHasFlag(Enum flags);
 
+		[Intrinsic]
 		public bool HasFlag (Enum flag)
 		{
 			if (flag == null)

--- a/mcs/class/System.Private.CoreLib/System/Enum.cs
+++ b/mcs/class/System.Private.CoreLib/System/Enum.cs
@@ -41,10 +41,17 @@ namespace System
 			return DefaultEquals (this, obj);
 		}
 
-		[Intrinsic]
+		[MethodImplAttribute(MethodImplOptions.InternalCall)]
+		private extern bool InternalHasFlag(Enum flags);
+
 		public bool HasFlag (Enum flag)
 		{
-			throw new NotImplementedException ();
+			if (flag == null)
+				throw new ArgumentNullException (nameof(flag));
+			if (!this.GetType().IsEquivalentTo (flag.GetType()))
+				throw new ArgumentException(SR.Format(SR.Argument_EnumTypeDoesNotMatch, flag.GetType(), this.GetType()));
+
+			return InternalHasFlag (flag);
 		}
 
 		public static string GetName (Type enumType, object value)

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -5994,6 +5994,10 @@ gboolean mono_type_is_valid_enum_basetype (MonoType * type) {
 	case MONO_TYPE_U8:
 	case MONO_TYPE_I:
 	case MONO_TYPE_U:
+#if ENABLE_NETCORE
+	case MONO_TYPE_R8:
+	case MONO_TYPE_R4:
+#endif
 		return TRUE;
 	default:
 		return FALSE;

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -311,8 +311,8 @@ HANDLES(ENUM_2, "InternalBoxEnum", ves_icall_System_Enum_ToObject, MonoObject, 2
 HANDLES(ENUM_3, "InternalCompareTo", ves_icall_System_Enum_compare_value_to, int, 2, (MonoObject, MonoObject))
 HANDLES(ENUM_3a, "InternalGetCorElementType", ves_icall_System_Enum_InternalGetCorElementType, int, 1, (MonoObject))
 HANDLES(ENUM_4, "InternalGetUnderlyingType", ves_icall_System_Enum_get_underlying_type, MonoReflectionType, 1, (MonoReflectionType))
-#if !ENABLE_NETCORE
 HANDLES(ENUM_5, "InternalHasFlag", ves_icall_System_Enum_InternalHasFlag, MonoBoolean, 2, (MonoObject, MonoObject))
+#if !ENABLE_NETCORE
 HANDLES(ENUM_6, "get_hashcode", ves_icall_System_Enum_get_hashcode, int, 1, (MonoObject))
 HANDLES(ENUM_7, "get_value", ves_icall_System_Enum_get_value, MonoObject, 1, (MonoObject))
 #endif


### PR DESCRIPTION
Improve support for rare enum types (IntPtr, UIntPtr, Single, Double, Char, Boolean backing types) and make `Enum.HasFlag` working.

`System.Runtime.Tests  Total: 32076, Errors: 0, Failed: 122, Skipped: 0, Time: 29.682s`

Actual number of fixed tests is quite high because the discovery was broken. Remaining `Enum` related failures:

```
    System.Tests.EnumTests.Parse<TestName_Single>(value: "vaLue2", ignoreCase: True, expected: Value1) [FAIL]
      Assert.Equal() Failure
      Expected: Value1
      Actual:   Value2
      Stack Trace:
        /Users/vsts/agent/2.149.2/work/1/s/src/System.Runtime/tests/System/EnumTests.cs(133,0): at System.Tests.EnumTests.Parse[TestName_Single](String value, Boolean ignoreCase, TestName_Single expected)
        /Users/filipnavara/Documents/mono/mcs/class/corlib/System.Reflection/RuntimeMethodInfo.cs(391,0): at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
    System.Tests.EnumTests.Parse<TestName_Double>(value: "vaLue2", ignoreCase: True, expected: Value1) [FAIL]
      Assert.Equal() Failure
      Expected: Value1
      Actual:   Value2
      Stack Trace:
        /Users/vsts/agent/2.149.2/work/1/s/src/System.Runtime/tests/System/EnumTests.cs(133,0): at System.Tests.EnumTests.Parse[TestName_Double](String value, Boolean ignoreCase, TestName_Double expected)
        /Users/filipnavara/Documents/mono/mcs/class/corlib/System.Reflection/RuntimeMethodInfo.cs(391,0): at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
    System.Tests.EnumTests.Parse_NetCoreApp11<TestName_Single>(value: "vaLue2", ignoreCase: True, expected: Value1) [FAIL]
      Assert.Equal() Failure
      Expected: Value1
      Actual:   Value2
      Stack Trace:
        /Users/vsts/agent/2.149.2/work/1/s/src/System.Runtime/tests/System/EnumTests.netcoreapp.cs(28,0): at System.Tests.EnumTests.Parse_NetCoreApp11[TestName_Single](String value, Boolean ignoreCase, TestName_Single expected)
        /Users/filipnavara/Documents/mono/mcs/class/corlib/System.Reflection/RuntimeMethodInfo.cs(391,0): at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
    System.Tests.EnumTests.Parse_NetCoreApp11<TestName_Double>(value: "vaLue2", ignoreCase: True, expected: Value1) [FAIL]
      Assert.Equal() Failure
      Expected: Value1
      Actual:   Value2
      Stack Trace:
        /Users/vsts/agent/2.149.2/work/1/s/src/System.Runtime/tests/System/EnumTests.netcoreapp.cs(28,0): at System.Tests.EnumTests.Parse_NetCoreApp11[TestName_Double](String value, Boolean ignoreCase, TestName_Double expected)
        /Users/filipnavara/Documents/mono/mcs/class/corlib/System.Reflection/RuntimeMethodInfo.cs(391,0): at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
```