### PR TITLE
[2019-04] [gsharedvt] Fix sizeof opcode

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -10955,7 +10955,7 @@ mono_ldptr:
 				CHECK_TYPELOAD (klass);
 
 				if (mini_is_gsharedvt_klass (klass)) {
-					MonoInst *ins = mini_emit_get_gsharedvt_info_klass (cfg, klass, MONO_RGCTX_INFO_CLASS_SIZEOF);
+					ins = mini_emit_get_gsharedvt_info_klass (cfg, klass, MONO_RGCTX_INFO_CLASS_SIZEOF);
 					ins->type = STACK_I4;
 				} else {
 					val = mono_type_size (m_class_get_byval_arg (klass), &ialign);


### PR DESCRIPTION
We were setting the stack type by using another global local named ins.

This lead to missing methods in the aot image due to invalid IL. Fixes https://github.com/mono/mono/issues/13479.

Backport of #13817.

/cc @lewurm @BrzVlad