### PR TITLE
[netcore] Implement missing Math and MathF methods

### DIFF
--- a/mcs/class/System.Private.CoreLib/System/Math.cs
+++ b/mcs/class/System.Private.CoreLib/System/Math.cs
@@ -1,10 +1,20 @@
+using System.Runtime.CompilerServices;
+
 namespace System
 {
 	partial class Math
 	{
-		public static double FusedMultiplyAdd(double x, double y, double z) { throw null; }
-		public static int ILogB(double x) { throw null; }
-		public static double Log2(double x) { throw null; }
-		public static double ScaleB(double x, int n) { throw null; }
+		// [Intrinsic] TODO: implement FMA intrinsic
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		public static extern double FusedMultiplyAdd (double x, double y, double z);
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		public static extern int ILogB (double x);
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		public static extern double Log2 (double x);
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		public static extern double ScaleB (double x, int n);
 	}
 }

--- a/mcs/class/System.Private.CoreLib/System/MathF.cs
+++ b/mcs/class/System.Private.CoreLib/System/MathF.cs
@@ -1,10 +1,20 @@
+using System.Runtime.CompilerServices;
+
 namespace System
 {
 	partial class MathF
 	{
-		public static float FusedMultiplyAdd(float x, float y, float z) { throw null; }
-		public static int ILogB(float x) { throw null; }
-		public static float Log2(float x) { throw null; }
-		public static float ScaleB(float x, int n) { throw null; }
+		// [Intrinsic] TODO: implement intrinsic (FMA)
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		public static extern float FusedMultiplyAdd (float x, float y, float z);
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		public static extern int ILogB (float x);
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		public static extern float Log2 (float x);
+
+		[MethodImpl (MethodImplOptions.InternalCall)]
+		public static extern float ScaleB (float x, int n);
 	}
 }

--- a/mono/metadata/icall-decl.h
+++ b/mono/metadata/icall-decl.h
@@ -145,6 +145,16 @@ ICALL_EXPORT float ves_icall_System_MathF_Sqrt (float);
 ICALL_EXPORT float ves_icall_System_MathF_Tan (float);
 ICALL_EXPORT float ves_icall_System_MathF_Tanh (float);
 ICALL_EXPORT float ves_icall_System_Math_Abs_single (float);
+#if ENABLE_NETCORE
+ICALL_EXPORT gint32 ves_icall_System_Math_ILogB (double);
+ICALL_EXPORT double ves_icall_System_Math_Log2 (double);
+ICALL_EXPORT double ves_icall_System_Math_ScaleB (double, gint32);
+ICALL_EXPORT double ves_icall_System_Math_FusedMultiplyAdd (double, double, double);
+ICALL_EXPORT gint32 ves_icall_System_MathF_ILogB (float);
+ICALL_EXPORT float ves_icall_System_MathF_Log2 (float);
+ICALL_EXPORT float ves_icall_System_MathF_ScaleB (float, gint32);
+ICALL_EXPORT float ves_icall_System_MathF_FusedMultiplyAdd (float, float, float);
+#endif
 ICALL_EXPORT gint ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_GetOffsetToStringData (void);
 ICALL_EXPORT gint32 ves_icall_System_Buffer_ByteLengthInternal (MonoArray*);
 ICALL_EXPORT gint32 ves_icall_System_Environment_get_ProcessorCount (void);

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -488,11 +488,21 @@ NOHANDLES(ICALL(MATH_6, "Cosh", ves_icall_System_Math_Cosh))
 NOHANDLES(ICALL(MATH_7, "Exp", ves_icall_System_Math_Exp))
 NOHANDLES(ICALL(MATH_7a, "FMod", ves_icall_System_Math_FMod))
 NOHANDLES(ICALL(MATH_8, "Floor", ves_icall_System_Math_Floor))
+#if ENABLE_NETCORE
+NOHANDLES(ICALL(MATH_22, "FusedMultiplyAdd", ves_icall_System_Math_FusedMultiplyAdd))
+NOHANDLES(ICALL(MATH_23, "ILogB", ves_icall_System_Math_ILogB))
+#endif
 NOHANDLES(ICALL(MATH_9, "Log", ves_icall_System_Math_Log))
 NOHANDLES(ICALL(MATH_10, "Log10", ves_icall_System_Math_Log10))
+#if ENABLE_NETCORE
+NOHANDLES(ICALL(MATH_24, "Log2", ves_icall_System_Math_Log2))
+#endif
 NOHANDLES(ICALL(MATH_10a, "ModF", ves_icall_System_Math_ModF))
 NOHANDLES(ICALL(MATH_11, "Pow", ves_icall_System_Math_Pow))
 NOHANDLES(ICALL(MATH_12, "Round", ves_icall_System_Math_Round))
+#if ENABLE_NETCORE
+NOHANDLES(ICALL(MATH_25, "ScaleB", ves_icall_System_Math_ScaleB))
+#endif
 NOHANDLES(ICALL(MATH_14, "Sin", ves_icall_System_Math_Sin))
 NOHANDLES(ICALL(MATH_15, "Sinh", ves_icall_System_Math_Sinh))
 NOHANDLES(ICALL(MATH_16, "Sqrt", ves_icall_System_Math_Sqrt))
@@ -514,15 +524,26 @@ NOHANDLES(ICALL(MATHF_11, "Cosh", ves_icall_System_MathF_Cosh))
 NOHANDLES(ICALL(MATHF_12, "Exp", ves_icall_System_MathF_Exp))
 NOHANDLES(ICALL(MATHF_22, "FMod", ves_icall_System_MathF_FMod))
 NOHANDLES(ICALL(MATHF_13, "Floor", ves_icall_System_MathF_Floor))
+#if ENABLE_NETCORE
+NOHANDLES(ICALL(MATHF_24, "FusedMultiplyAdd", ves_icall_System_MathF_FusedMultiplyAdd))
+NOHANDLES(ICALL(MATHF_25, "ILogB", ves_icall_System_MathF_ILogB))
+#endif
 NOHANDLES(ICALL(MATHF_14, "Log", ves_icall_System_MathF_Log))
 NOHANDLES(ICALL(MATHF_15, "Log10", ves_icall_System_MathF_Log10))
+#if ENABLE_NETCORE
+NOHANDLES(ICALL(MATHF_26, "Log2", ves_icall_System_MathF_Log2))
+#endif
 NOHANDLES(ICALL(MATHF_23, "ModF(single,single*)", ves_icall_System_MathF_ModF))
 NOHANDLES(ICALL(MATHF_16, "Pow", ves_icall_System_MathF_Pow))
+#if ENABLE_NETCORE
+NOHANDLES(ICALL(MATHF_27, "ScaleB", ves_icall_System_MathF_ScaleB))
+#endif
 NOHANDLES(ICALL(MATHF_17, "Sin", ves_icall_System_MathF_Sin))
 NOHANDLES(ICALL(MATHF_18, "Sinh", ves_icall_System_MathF_Sinh))
 NOHANDLES(ICALL(MATHF_19, "Sqrt", ves_icall_System_MathF_Sqrt))
 NOHANDLES(ICALL(MATHF_20, "Tan", ves_icall_System_MathF_Tan))
 NOHANDLES(ICALL(MATHF_21, "Tanh", ves_icall_System_MathF_Tanh))
+
 
 ICALL_TYPE(MCATTR, "System.MonoCustomAttrs", MCATTR_1)
 HANDLES(MCATTR_1, "GetCustomAttributesDataInternal", ves_icall_MonoCustomAttrs_GetCustomAttributesDataInternal, MonoArray, 1, (MonoObject))

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -544,7 +544,6 @@ NOHANDLES(ICALL(MATHF_19, "Sqrt", ves_icall_System_MathF_Sqrt))
 NOHANDLES(ICALL(MATHF_20, "Tan", ves_icall_System_MathF_Tan))
 NOHANDLES(ICALL(MATHF_21, "Tanh", ves_icall_System_MathF_Tanh))
 
-
 ICALL_TYPE(MCATTR, "System.MonoCustomAttrs", MCATTR_1)
 HANDLES(MCATTR_1, "GetCustomAttributesDataInternal", ves_icall_MonoCustomAttrs_GetCustomAttributesDataInternal, MonoArray, 1, (MonoObject))
 HANDLES(MCATTR_2, "GetCustomAttributesInternal", ves_icall_MonoCustomAttrs_GetCustomAttributesInternal, MonoArray, 3, (MonoObject, MonoReflectionType, MonoBoolean))

--- a/mono/metadata/sysmath.c
+++ b/mono/metadata/sysmath.c
@@ -200,6 +200,32 @@ ves_icall_System_Math_Ceiling (gdouble v)
 	return ceil (v);
 }
 
+#if ENABLE_NETCORE
+gint32
+ves_icall_System_Math_ILogB (gdouble x)
+{
+	return ilogb (x);
+}
+
+gdouble
+ves_icall_System_Math_Log2 (gdouble x)
+{
+	return log2 (x);
+}
+
+gdouble
+ves_icall_System_Math_ScaleB (gdouble x, gint32 n)
+{
+	return scalbn (x, n);
+}
+
+gdouble
+ves_icall_System_Math_FusedMultiplyAdd (gdouble x, gdouble y, gdouble z)
+{
+	return fma (x, y, z);
+}
+#endif
+
 float
 ves_icall_System_MathF_Acos (float x)
 {
@@ -337,3 +363,29 @@ ves_icall_System_MathF_ModF (float x, float *d)
 {
 	return modff (x, d);
 }
+
+#if ENABLE_NETCORE
+gint32
+ves_icall_System_MathF_ILogB (float x)
+{
+	return ilogbf (x);
+}
+
+float
+ves_icall_System_MathF_Log2 (float x)
+{
+	return log2f (x);
+}
+
+float
+ves_icall_System_MathF_ScaleB (float x, gint32 n)
+{
+	return scalbnf (x, n);
+}
+
+float
+ves_icall_System_MathF_FusedMultiplyAdd (float x, float y, float z)
+{
+	return fmaf (x, y, z);
+}
+#endif


### PR DESCRIPTION
This PR fixes 169 tests in System.Runtime.Extensions.Tests (MathFTests)

.NET Core's JIT is able to replace `FusedMultiplyAdd` with FMA instructions (if CPU supports it)
I guess it should be implemented similar to https://github.com/mono/mono/pull/10039
(btw LLVM is able to insert FMA 🙂 see https://twitter.com/EgorBo/status/1063468884257316865)

