### PR TITLE
Add MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR and MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR.

### DIFF
--- a/mcs/build/tests.make
+++ b/mcs/build/tests.make
@@ -131,7 +131,8 @@ ifndef NO_TEST
 $(test_nunit_dep): $(topdir)/build/deps/nunit-$(PROFILE).stamp
 	@if test -f $@; then :; else rm -f $<; $(MAKE) $<; fi
 
-$(topdir)/build/deps/nunit-$(PROFILE).stamp:
+# aot-runtime.h due to MONO_AOT_FILE_VERSION.
+$(topdir)/build/deps/nunit-$(PROFILE).stamp: $(topdir)/../mono/mini/aot-runtime.h
 	cd ${topdir}/tools/nunit-lite && $(MAKE)
 	echo "stamp" >$@
 

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -3870,7 +3870,10 @@ is_plt_patch (MonoJumpInfo *patch_info)
 	case MONO_PATCH_INFO_JIT_ICALL_ADDR:
 	case MONO_PATCH_INFO_ICALL_ADDR_CALL:
 	case MONO_PATCH_INFO_RGCTX_FETCH:
+	case MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR:
+	case MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR:
 		return TRUE;
+	case MONO_PATCH_INFO_JIT_ICALL_ADDR_NOCALL:
 	default:
 		return FALSE;
 	}
@@ -6006,6 +6009,12 @@ emit_and_reloc_code (MonoAotCompile *acfg, MonoMethod *method, guint8 *code, gui
 						g_assert (strlen (sym) < 1000);
 						direct_call_target = g_strdup_printf ("%s%s", acfg->user_symbol_prefix, sym);
 					}
+				} else if (patch_info->type == MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR) {
+					// There is a name for these, but in their previous MONO_PATCH_INFO_JIT_ICALL_ADDR form,
+					// they were never in the hashtable, so do nothing.
+				} else if (patch_info->type == MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR) {
+					// There is a name for these, but in their previous MONO_PATCH_INFO_JIT_ICALL_ADDR form,
+					// they were never in the hashtable, so do nothing.
 				} else if (patch_info->type == MONO_PATCH_INFO_JIT_ICALL) {
 					MonoJitICallInfo *info = mono_find_jit_icall_by_name (patch_info->data.name);
 					const char *sym = mono_lookup_jit_icall_symbol (patch_info->data.name);
@@ -6332,7 +6341,10 @@ encode_patch (MonoAotCompile *acfg, MonoJumpInfo *patch_info, guint8 *buf, guint
 	case MONO_PATCH_INFO_AOT_JIT_INFO:
 	case MONO_PATCH_INFO_GET_TLS_TRAMP:
 	case MONO_PATCH_INFO_SET_TLS_TRAMP:
+	case MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR:
 		encode_value (patch_info->data.index, p, &p);
+	case MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR:
+		encode_value (patch_info->data.uindex, p, &p);
 		break;
 	case MONO_PATCH_INFO_JIT_ICALL:
 	case MONO_PATCH_INFO_JIT_ICALL_ADDR:
@@ -7041,6 +7053,14 @@ get_plt_entry_debug_sym (MonoAotCompile *acfg, MonoJumpInfo *ji, GHashTable *cac
 		g_free (s);
 		break;
 	}
+	case MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR:
+		// FIXME Check with https://github.com/mono/mono/pull/13792
+		debug_sym = g_strdup_printf ("%s_jit_icall_native_trampoline_func_%d", prefix, ji->data.index);
+		break;
+	case MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR:
+		// FIXME Check with https://github.com/mono/mono/pull/13792
+		debug_sym = g_strdup_printf ("%s_jit_icall_native_specific_trampoline_lazy_fetch_%u", prefix, ji->data.uindex);
+		break;
 	case MONO_PATCH_INFO_JIT_ICALL_ADDR:
 		debug_sym = g_strdup_printf ("%s_jit_icall_native_%s", prefix, ji->data.name);
 		break;
@@ -9343,6 +9363,14 @@ mono_aot_get_direct_call_symbol (MonoJumpInfoType type, gconstpointer data)
 		if (type == MONO_PATCH_INFO_JIT_ICALL_ADDR) {
 			/* Call to a C function implementing a jit icall */
 			sym = mono_lookup_jit_icall_symbol ((const char *)data);
+		} else if (type == MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR) {
+			// There is a name for these, but in their previous MONO_PATCH_INFO_JIT_ICALL_ADDR form,
+			// they were never in the hashtable, so do nothing.
+			// See https://github.com/mono/mono/pull/13792
+		} else if (type == MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR) {
+			// There is a name for these, but in their previous MONO_PATCH_INFO_JIT_ICALL_ADDR form,
+			// they were never in the hashtable, so do nothing.
+			// See https://github.com/mono/mono/pull/13792
 		} else if (type == MONO_PATCH_INFO_ICALL_ADDR_CALL) {
 			MonoMethod *method = (MonoMethod *)data;
 			if (!(method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL))
@@ -9378,6 +9406,14 @@ mono_aot_get_plt_symbol (MonoJumpInfoType type, gconstpointer data)
 		if (type == MONO_PATCH_INFO_JIT_ICALL_ADDR) {
 			/* Call to a C function implementing a jit icall */
 			sym = mono_lookup_jit_icall_symbol ((const char *)data);
+		} else if (type == MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR) {
+			// There is a name for these, but in their previous MONO_PATCH_INFO_JIT_ICALL_ADDR form,
+			// they were never in the hashtable, so do nothing.
+			// See https://github.com/mono/mono/pull/13792
+		} else if (type == MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR) {
+			// There is a name for these, but in their previous MONO_PATCH_INFO_JIT_ICALL_ADDR form,
+			// they were never in the hashtable, so do nothing.
+			// See https://github.com/mono/mono/pull/13792
 		} else if (type == MONO_PATCH_INFO_ICALL_ADDR_CALL) {
 			MonoMethod *method = (MonoMethod *)data;
 			if (!(method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL))

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -6009,12 +6009,6 @@ emit_and_reloc_code (MonoAotCompile *acfg, MonoMethod *method, guint8 *code, gui
 						g_assert (strlen (sym) < 1000);
 						direct_call_target = g_strdup_printf ("%s%s", acfg->user_symbol_prefix, sym);
 					}
-				} else if (patch_info->type == MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR) {
-					// There is a name for these, but in their previous MONO_PATCH_INFO_JIT_ICALL_ADDR form,
-					// they were never in the hashtable, so do nothing.
-				} else if (patch_info->type == MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR) {
-					// There is a name for these, but in their previous MONO_PATCH_INFO_JIT_ICALL_ADDR form,
-					// they were never in the hashtable, so do nothing.
 				} else if (patch_info->type == MONO_PATCH_INFO_JIT_ICALL) {
 					MonoJitICallInfo *info = mono_find_jit_icall_by_name (patch_info->data.name);
 					const char *sym = mono_lookup_jit_icall_symbol (patch_info->data.name);
@@ -9363,14 +9357,6 @@ mono_aot_get_direct_call_symbol (MonoJumpInfoType type, gconstpointer data)
 		if (type == MONO_PATCH_INFO_JIT_ICALL_ADDR) {
 			/* Call to a C function implementing a jit icall */
 			sym = mono_lookup_jit_icall_symbol ((const char *)data);
-		} else if (type == MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR) {
-			// There is a name for these, but in their previous MONO_PATCH_INFO_JIT_ICALL_ADDR form,
-			// they were never in the hashtable, so do nothing.
-			// See https://github.com/mono/mono/pull/13792
-		} else if (type == MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR) {
-			// There is a name for these, but in their previous MONO_PATCH_INFO_JIT_ICALL_ADDR form,
-			// they were never in the hashtable, so do nothing.
-			// See https://github.com/mono/mono/pull/13792
 		} else if (type == MONO_PATCH_INFO_ICALL_ADDR_CALL) {
 			MonoMethod *method = (MonoMethod *)data;
 			if (!(method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL))
@@ -9406,14 +9392,6 @@ mono_aot_get_plt_symbol (MonoJumpInfoType type, gconstpointer data)
 		if (type == MONO_PATCH_INFO_JIT_ICALL_ADDR) {
 			/* Call to a C function implementing a jit icall */
 			sym = mono_lookup_jit_icall_symbol ((const char *)data);
-		} else if (type == MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR) {
-			// There is a name for these, but in their previous MONO_PATCH_INFO_JIT_ICALL_ADDR form,
-			// they were never in the hashtable, so do nothing.
-			// See https://github.com/mono/mono/pull/13792
-		} else if (type == MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR) {
-			// There is a name for these, but in their previous MONO_PATCH_INFO_JIT_ICALL_ADDR form,
-			// they were never in the hashtable, so do nothing.
-			// See https://github.com/mono/mono/pull/13792
 		} else if (type == MONO_PATCH_INFO_ICALL_ADDR_CALL) {
 			MonoMethod *method = (MonoMethod *)data;
 			if (!(method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL))

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -6337,6 +6337,7 @@ encode_patch (MonoAotCompile *acfg, MonoJumpInfo *patch_info, guint8 *buf, guint
 	case MONO_PATCH_INFO_SET_TLS_TRAMP:
 	case MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR:
 		encode_value (patch_info->data.index, p, &p);
+		break;
 	case MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR:
 		encode_value (patch_info->data.uindex, p, &p);
 		break;

--- a/mono/mini/aot-runtime.h
+++ b/mono/mini/aot-runtime.h
@@ -11,7 +11,7 @@
 #include "mini.h"
 
 /* Version number of the AOT file format */
-#define MONO_AOT_FILE_VERSION 157
+#define MONO_AOT_FILE_VERSION 158
 
 #define MONO_AOT_TRAMP_PAGE_SIZE 16384
 

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -6913,7 +6913,9 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 					ins = (MonoInst*)mini_emit_abs_call (cfg, MONO_PATCH_INFO_ICALL_ADDR_CALL, info_data, fsig, sp);
 					NULLIFY_INS (addr);
 					goto calli_end;
-				} else if (info_type == MONO_PATCH_INFO_JIT_ICALL_ADDR) {
+				} else if (info_type == MONO_PATCH_INFO_JIT_ICALL_ADDR
+						|| info_type == MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR
+						|| info_type == MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR) {
 					tailcall = FALSE;
 					ins = (MonoInst*)mini_emit_abs_call (cfg, info_type, info_data, fsig, sp);
 					NULLIFY_INS (addr);

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -4689,6 +4689,8 @@ mono_arch_patch_code_new (MonoCompile *cfg, MonoDomain *domain, guint8 *code, Mo
 	case MONO_PATCH_INFO_ABS:
 	case MONO_PATCH_INFO_RGCTX_FETCH:
 	case MONO_PATCH_INFO_JIT_ICALL_ADDR:
+	case MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR:
+	case MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR:
 		is_fd = TRUE;
 		/* fall through */
 #endif

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -1255,6 +1255,9 @@ mono_patch_info_hash (gconstpointer data)
 	case MONO_PATCH_INFO_PROFILER_ALLOCATION_COUNT:
 	case MONO_PATCH_INFO_PROFILER_CLAUSE_COUNT:
 		return (ji->type << 8);
+	case MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR:
+		return (ji->type << 8) | (ji->data.uindex);
+	case MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR:
 	case MONO_PATCH_INFO_CASTCLASS_CACHE:
 		return (ji->type << 8) | (ji->data.index);
 	case MONO_PATCH_INFO_SWITCH:
@@ -1334,6 +1337,9 @@ mono_patch_info_equal (gconstpointer ka, gconstpointer kb)
 		return ji1->data.gsharedvt_method->method == ji2->data.gsharedvt_method->method;
 	case MONO_PATCH_INFO_DELEGATE_TRAMPOLINE:
 		return ji1->data.del_tramp->klass == ji2->data.del_tramp->klass && ji1->data.del_tramp->method == ji2->data.del_tramp->method && ji1->data.del_tramp->is_virtual == ji2->data.del_tramp->is_virtual;
+	case MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR:
+		return ji1->data.uindex == ji2->data.uindex;
+	case MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR:
 	case MONO_PATCH_INFO_CASTCLASS_CACHE:
 		return ji1->data.index == ji2->data.index;
 	case MONO_PATCH_INFO_VIRT_METHOD:

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -324,6 +324,7 @@ struct MonoJumpInfo {
 		int             offset;
 #endif
 		int index;
+		guint uindex;
 		MonoBasicBlock *bb;
 		MonoInst       *inst;
 		MonoMethod     *method;

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -5345,6 +5345,8 @@ mono_arch_patch_code (MonoCompile *cfg, MonoMethod *method, MonoDomain *domain,
 			case MONO_PATCH_INFO_EXC:
 				s390_patch_addr (ip, (guint64) target);
 				continue;
+			case MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR:
+			case MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR:
 			case MONO_PATCH_INFO_METHOD:
 			case MONO_PATCH_INFO_JIT_ICALL:
 			case MONO_PATCH_INFO_JIT_ICALL_ADDR:

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -1732,7 +1732,9 @@ x86_align_and_patch (MonoCompile *cfg, guint8 *code, guint32 patch_type, gconstp
 
 	if (cfg->abs_patches) {
 		jinfo = (MonoJumpInfo*)g_hash_table_lookup (cfg->abs_patches, data);
-		if (jinfo && jinfo->type == MONO_PATCH_INFO_JIT_ICALL_ADDR)
+		if (jinfo && (jinfo->type == MONO_PATCH_INFO_JIT_ICALL_ADDR
+				|| jinfo->type == MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR
+				|| jinfo->type == MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR))
 			needs_paddings = FALSE;
 	}
 
@@ -4903,6 +4905,8 @@ mono_arch_patch_code_new (MonoCompile *cfg, MonoDomain *domain, guint8 *code, Mo
 	case MONO_PATCH_INFO_LABEL:
 	case MONO_PATCH_INFO_RGCTX_FETCH:
 	case MONO_PATCH_INFO_JIT_ICALL_ADDR:
+	case MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR:
+	case MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR:
 		x86_patch (ip, (unsigned char*)target);
 		break;
 	case MONO_PATCH_INFO_NONE:

--- a/mono/mini/patch-info.h
+++ b/mono/mini/patch-info.h
@@ -70,3 +70,16 @@ PATCH_INFO(PROFILER_CLAUSE_COUNT, "profiler_clause_count")
  * function.
  */
 PATCH_INFO(METHOD_FTNDESC, "method_ftndesc")
+
+
+// Formerly MONO_PATCH_INFO_JIT_ICALL_ADDR + sprintf ("trampoline_func_%d", tramp_type)
+// Now an enum. This is faster, fixes leaks, and is a step toward eliminating
+// JIT icall hash tables.
+// Shorter name?
+PATCH_INFO(TRAMPOLINE_FUNC_ADDR, "trampoline_func_addr")
+
+// Formerly MONO_PATCH_INFO_JIT_ICALL_ADDR + sprintf ("specific_trampoline_lazy_fetch_%u", slot)
+// Now an enum. This is faster, fixes leaks, and is a step toward eliminating
+// JIT icall hash tables.
+// Shorter name?
+PATCH_INFO(SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR, "specific_trampoline_lazy_fetch_addr")

--- a/mono/mini/patch-info.h
+++ b/mono/mini/patch-info.h
@@ -71,15 +71,5 @@ PATCH_INFO(PROFILER_CLAUSE_COUNT, "profiler_clause_count")
  */
 PATCH_INFO(METHOD_FTNDESC, "method_ftndesc")
 
-
-// Formerly MONO_PATCH_INFO_JIT_ICALL_ADDR + sprintf ("trampoline_func_%d", tramp_type)
-// Now an enum. This is faster, fixes leaks, and is a step toward eliminating
-// JIT icall hash tables.
-// Shorter name?
 PATCH_INFO(TRAMPOLINE_FUNC_ADDR, "trampoline_func_addr")
-
-// Formerly MONO_PATCH_INFO_JIT_ICALL_ADDR + sprintf ("specific_trampoline_lazy_fetch_%u", slot)
-// Now an enum. This is faster, fixes leaks, and is a step toward eliminating
-// JIT icall hash tables.
-// Shorter name?
 PATCH_INFO(SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR, "specific_trampoline_lazy_fetch_addr")

--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -464,8 +464,7 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 	amd64_mov_reg_membase (code, AMD64_ARG_REG4, AMD64_RBP, tramp_offset, sizeof (target_mgreg_t));
 
 	if (aot) {
-		char *icall_name = g_strdup_printf ("trampoline_func_%d", tramp_type);
-		code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, icall_name);
+		code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR, GINT_TO_POINTER (tramp_type));
 	} else {
 		tramp = (guint8*)mono_get_trampoline_func (tramp_type);
 		amd64_mov_reg_imm (code, AMD64_R11, tramp);
@@ -715,7 +714,7 @@ mono_arch_create_rgctx_lazy_fetch_trampoline (guint32 slot, MonoTrampInfo **info
 	}
 
 	if (aot) {
-		code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, g_strdup_printf ("specific_trampoline_lazy_fetch_%u", slot));
+		code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR, GUINT_TO_POINTER (slot));
 		amd64_jump_reg (code, AMD64_R11);
 	} else {
 		tramp = (guint8 *)mono_arch_create_specific_trampoline (GUINT_TO_POINTER (slot), MONO_TRAMPOLINE_RGCTX_LAZY_FETCH, mono_get_root_domain (), NULL);

--- a/mono/mini/tramp-arm.c
+++ b/mono/mini/tramp-arm.c
@@ -291,8 +291,7 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 	ARM_MOV_REG_REG (code, ARMREG_R2, ARMREG_V2);
 
 	if (aot) {
-		char *icall_name = g_strdup_printf ("trampoline_func_%d", tramp_type);
-		ji = mono_patch_info_list_prepend (ji, code - buf, MONO_PATCH_INFO_JIT_ICALL_ADDR, icall_name);
+		ji = mono_patch_info_list_prepend (ji, code - buf, MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR, GINT_TO_POINTER (tramp_type));
 		ARM_LDR_IMM (code, ARMREG_IP, ARMREG_PC, 0);
 		ARM_B (code, 0);
 		*(gpointer*)code = NULL;
@@ -696,7 +695,7 @@ mono_arch_create_rgctx_lazy_fetch_trampoline (guint32 slot, MonoTrampInfo **info
 	/* The vtable/mrgctx is still in R0 */
 
 	if (aot) {
-		ji = mono_patch_info_list_prepend (ji, code - buf, MONO_PATCH_INFO_JIT_ICALL_ADDR, g_strdup_printf ("specific_trampoline_lazy_fetch_%u", slot));
+		ji = mono_patch_info_list_prepend (ji, code - buf, MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR, GUINT_TO_POINTER (slot));
 		ARM_LDR_IMM (code, ARMREG_R1, ARMREG_PC, 0);
 		ARM_B (code, 0);
 		*(gpointer*)code = NULL;

--- a/mono/mini/tramp-arm64.c
+++ b/mono/mini/tramp-arm64.c
@@ -229,8 +229,7 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 	arm_movx (code, ARMREG_R3, ARMREG_RZR);
 
 	if (aot) {
-		char *icall_name = g_strdup_printf ("trampoline_func_%d", tramp_type);
-		code = mono_arm_emit_aotconst (&ji, code, buf, ARMREG_IP0, MONO_PATCH_INFO_JIT_ICALL_ADDR, icall_name);
+		code = mono_arm_emit_aotconst (&ji, code, buf, ARMREG_IP0, MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR, GINT_TO_POINTER (tramp_type));
 	} else {
 		tramp = (guint8*)mono_get_trampoline_func (tramp_type);
 		code = mono_arm_emit_imm64 (code, ARMREG_IP0, (guint64)tramp);
@@ -471,7 +470,7 @@ mono_arch_create_rgctx_lazy_fetch_trampoline (guint32 slot, MonoTrampInfo **info
 	/* Call mono_rgctx_lazy_fetch_trampoline (), passing in the slot as argument */
 	/* The vtable/mrgctx is still in R0 */
 	if (aot) {
-		code = mono_arm_emit_aotconst (&ji, code, buf, ARMREG_IP0, MONO_PATCH_INFO_JIT_ICALL_ADDR, g_strdup_printf ("specific_trampoline_lazy_fetch_%u", slot));
+		code = mono_arm_emit_aotconst (&ji, code, buf, ARMREG_IP0, MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR, GUINT_TO_POINTER (slot));
 	} else {
 		tramp = (guint8*)mono_arch_create_specific_trampoline (GUINT_TO_POINTER (slot), MONO_TRAMPOLINE_RGCTX_LAZY_FETCH, mono_get_root_domain (), &code_len);
 		code = mono_arm_emit_imm64 (code, ARMREG_IP0, (guint64)tramp);

--- a/mono/mini/tramp-mips.c
+++ b/mono/mini/tramp-mips.c
@@ -426,7 +426,7 @@ mono_arch_create_rgctx_lazy_fetch_trampoline (guint32 slot, MonoTrampInfo **info
 	/* The vtable/mrgctx is still in a0 */
 
 	if (aot) {
-		ji = mono_patch_info_list_prepend (ji, code - buf, MONO_PATCH_INFO_JIT_ICALL_ADDR, g_strdup_printf ("specific_trampoline_lazy_fetch_%u", slot));
+		ji = mono_patch_info_list_prepend (ji, code - buf, MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR, GUINT_TO_POINTER (slot));
 		mips_load (code, mips_at, 0);
 		mips_jr (code, mips_at);
 		mips_nop (code);

--- a/mono/mini/tramp-ppc.c
+++ b/mono/mini/tramp-ppc.c
@@ -358,7 +358,7 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 	ppc_ldr (code, ppc_r5, GREGS_OFFSET, ppc_r1);
 
 	if (aot) {
-		code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, g_strdup_printf ("trampoline_func_%d", tramp_type));
+		code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR, GINT_TO_POINTER (tramp_type));
 #ifdef PPC_USES_FUNCTION_DESCRIPTOR
 		ppc_ldptr (code, ppc_r2, sizeof (target_mgreg_t), ppc_r12);
 		ppc_ldptr (code, ppc_r12, 0, ppc_r12);
@@ -638,7 +638,7 @@ mono_arch_create_rgctx_lazy_fetch_trampoline (guint32 slot, MonoTrampInfo **info
 	ppc_mr (code, MONO_ARCH_VTABLE_REG, ppc_r3);
 
 	if (aot) {
-		code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, g_strdup_printf ("specific_trampoline_lazy_fetch_%u", slot));
+		code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR, GUINT_TO_POINTER (slot));
 		/* Branch to the trampoline */
 #ifdef PPC_USES_FUNCTION_DESCRIPTOR
 		ppc_ldptr (code, ppc_r12, 0, ppc_r12);

--- a/mono/mini/tramp-x86.c
+++ b/mono/mini/tramp-x86.c
@@ -284,8 +284,7 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 #endif
 
 	if (aot) {
-		char *icall_name = g_strdup_printf ("trampoline_func_%d", tramp_type);
-		code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, icall_name);
+		code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR, GINT_TO_POINTER (tramp_type));
 		x86_call_reg (code, X86_EAX);
 	} else {
 		tramp = (guint8*)mono_get_trampoline_func (tramp_type);
@@ -490,7 +489,7 @@ mono_arch_create_rgctx_lazy_fetch_trampoline (guint32 slot, MonoTrampInfo **info
 	x86_mov_reg_membase (code, MONO_ARCH_VTABLE_REG, X86_ESP, 4, 4);
 
 	if (aot) {
-		code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, g_strdup_printf ("specific_trampoline_lazy_fetch_%u", slot));
+		code = mono_arch_emit_load_aotconst (buf, code, &ji, MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR, GUINT_TO_POINTER (slot));
 		x86_jump_reg (code, X86_EAX);
 	} else {
 		tramp = (guint8*)mono_arch_create_specific_trampoline (GUINT_TO_POINTER (slot), MONO_TRAMPOLINE_RGCTX_LAZY_FETCH, mono_get_root_domain (), NULL);


### PR DESCRIPTION
Formerly identical fork of https://github.com/mono/mono/pull/13794
 to get a new workspace, to try to resolve AOT version error.
 That didn't work, so an attempt is also present to incrementally build nunit to fix the problem.

The larger goal here is to stop hashing JIT icalls, by string and by code address, as suggested a few months ago. Both the inserts into hashtables and the lookups.

Note this is about JIT icalls.
Not icalls declared in C#.

Reducing the lookups is easy, but complete elimination takes more work,
and I believe is possible and desirable.

JIT icalls are used with:
  `MONO_PATCH_INFO_JIT_ICALL` 
  `MONO_PATCH_INFO_JIT_ICALL_ADDR` 
  `MONO_PATCH_INFO_JIT_ICALL_ADDR_NOCALL` 


There is a fixed set of JIT icalls.
Their strings can be replaced with an enum,
or pointers to fixed data structures, or pointers/offsets
into a fixed data structure.


Except for:
  `MONO_PATCH_INFO_JIT_ICALL_ADDR + sprintf ("trampoline_func_%d", tramp_type)`
  `MONO_PATCH_INFO_JIT_ICALL_ADDR + sprintf ("specific_trampoline_lazy_fetch_%u", slot)`


This change splits those uses into separate patch types, along with
the dynamic integer. Instead of forming the string.


As well, an important theory here is, while these were reusing
some JIT icall infrastructure, they were not using all
of it. These were not actually placed in the hashtables,
and if they were looked up, they were not found.


If that theory is in fact false, then this effort fails.

A separate do-not-merge PR exists to help test that theory (https://github.com/mono/mono/pull/13792
).

It is fairly obvious in the code, in that these JIT icalls
are not passed to any `register` function.

The int vs. uint nuance in this PR not clearly required, but follows
the prior code. They can probably all be int or uint.
As well we might consider guint32 instead of guint, if Mono is ever
to run with a 16bit integer.