### PR TITLE
Bump macsdk msbuild hash to msbuild that uses new roslyn, matching mono master

### DIFF
--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = '883603959ff53aac1bb6c0d1155a45ff1a3e4d6e')
+			revision = 'fdf0630f6e82e60870cb3a9ec71adb772a436a32')
 
 	def build (self):
 		self.sh ('./eng/cibuild_bootstrapped_msbuild.sh --host_type mono --configuration Release --skip_tests')

--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = 'fdf0630f6e82e60870cb3a9ec71adb772a436a32')
+			revision = '97f3ff32c8766c9ef3823d202e166fe33d5c7883')
 
 	def build (self):
 		self.sh ('./eng/cibuild_bootstrapped_msbuild.sh --host_type mono --configuration Release --skip_tests')


### PR DESCRIPTION
There's a comment in this script that says to 'fix run-test-mac-sdk.sh' but i can't find anything to fix in that script. Is that comment dead?