### PR TITLE
[metadata] Create strongly typed versions of mono_assembly_request_prepare - Coverity #1443346

### DIFF
--- a/mono/dis/main.c
+++ b/mono/dis/main.c
@@ -1634,7 +1634,7 @@ disassemble_file (const char *file)
 		/* FIXME: is this call necessary? */
 		/* FIXME: if it's necessary, can it be refonly instead? */
 		MonoAssemblyLoadRequest req;
-		mono_assembly_request_prepare (&req, sizeof (req), MONO_ASMCTX_DEFAULT);
+		mono_assembly_request_prepare_load (&req, MONO_ASMCTX_DEFAULT);
 		mono_assembly_request_load_from (img, file, &req, &status);
 	}
 
@@ -1925,7 +1925,7 @@ monodis_preload (MonoAssemblyName *aname,
 
 	if (assemblies_path && assemblies_path [0] != NULL) {
 		MonoAssemblyOpenRequest req;
-		mono_assembly_request_prepare (&req.request, sizeof (req), refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT);
+		mono_assembly_request_prepare_open (&req, refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT);
 
 		result = real_load (assemblies_path, aname->culture, aname->name, &req);
 	}

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2258,7 +2258,7 @@ mono_domain_assembly_preload (MonoAssemblyName *aname,
 	}
 #endif
 	MonoAssemblyOpenRequest req;
-	mono_assembly_request_prepare (&req.request, sizeof (req), refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT);
+	mono_assembly_request_prepare_open (&req, refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT);
 	req.request.predicate = predicate;
 	req.request.predicate_ud = predicate_ud;
 
@@ -2306,7 +2306,7 @@ mono_assembly_load_from_assemblies_path (gchar **assemblies_path, MonoAssemblyNa
 	}
 #endif
 	MonoAssemblyOpenRequest req;
-	mono_assembly_request_prepare (&req.request, sizeof (req), asmctx);
+	mono_assembly_request_prepare_open (&req, asmctx);
 	req.request.predicate = predicate;
 	req.request.predicate_ud = predicate_ud;
 	MonoAssembly *result = NULL;
@@ -2367,7 +2367,7 @@ ves_icall_System_Reflection_Assembly_InternalLoad (MonoStringHandle name_handle,
 	char *name;
 
 	asmctx = MONO_ASMCTX_DEFAULT;
-	mono_assembly_request_prepare (&req.request, sizeof (req), asmctx);
+	mono_assembly_request_prepare_byname (&req, asmctx);
 	req.basedir = NULL;
 	req.no_postload_search = TRUE;
 
@@ -2419,7 +2419,7 @@ ves_icall_System_Reflection_Assembly_LoadFrom (MonoStringHandle fname, MonoBoole
 
 	MonoAssembly *ass;
 	MonoAssemblyOpenRequest req;
-	mono_assembly_request_prepare (&req.request, sizeof (req), refOnly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_LOADFROM);
+	mono_assembly_request_prepare_open (&req, refOnly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_LOADFROM);
 	req.requesting_assembly = requesting_assembly;
 	ass = mono_assembly_request_open (filename, &req, &status);
 	
@@ -2462,7 +2462,7 @@ ves_icall_System_Reflection_Assembly_LoadFile_internal (MonoStringHandle fname, 
 	executing_assembly = mono_runtime_get_caller_from_stack_mark (stack_mark);
 	MonoAssembly *ass;
 	MonoAssemblyOpenRequest req;
-	mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_INDIVIDUAL);
+	mono_assembly_request_prepare_open (&req, MONO_ASMCTX_INDIVIDUAL);
 	req.requesting_assembly = executing_assembly;
 	ass = mono_assembly_request_open (filename, &req, &status);
 	if (!ass) {
@@ -2532,7 +2532,7 @@ ves_icall_System_AppDomain_LoadAssemblyRaw (MonoAppDomainHandle ad,
 	}
 
 	MonoAssemblyLoadRequest req;
-	mono_assembly_request_prepare (&req, sizeof (req), refonly? MONO_ASMCTX_REFONLY : MONO_ASMCTX_INDIVIDUAL);
+	mono_assembly_request_prepare_load (&req, refonly? MONO_ASMCTX_REFONLY : MONO_ASMCTX_INDIVIDUAL);
 	ass = mono_assembly_request_load_from (image, "", &req, &status);
 
 	if (!ass) {
@@ -2600,7 +2600,7 @@ ves_icall_System_AppDomain_LoadAssembly (MonoAppDomainHandle ad, MonoStringHandl
 
 
 	MonoAssemblyByNameRequest req;
-	mono_assembly_request_prepare (&req.request, sizeof (req), asmctx);
+	mono_assembly_request_prepare_byname (&req, asmctx);
 	req.basedir = basedir;
 	req.no_postload_search = TRUE;
 	ass = mono_assembly_request_byname (&aname, &req, &status);

--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -79,9 +79,14 @@ typedef struct MonoAssemblyByNameRequest {
 	/* FIXME: predicate unused? */
 } MonoAssemblyByNameRequest;
 
-void                   mono_assembly_request_prepare (MonoAssemblyLoadRequest *req,
-						      size_t req_size,
-						      MonoAssemblyContextKind asmctx);
+void                   mono_assembly_request_prepare_load (MonoAssemblyLoadRequest *req,
+							   MonoAssemblyContextKind asmctx);
+
+void                   mono_assembly_request_prepare_open (MonoAssemblyOpenRequest *req,
+							   MonoAssemblyContextKind asmctx);
+
+void                   mono_assembly_request_prepare_byname (MonoAssemblyByNameRequest *req,
+							     MonoAssemblyContextKind asmctx);
 
 MonoAssembly*          mono_assembly_request_open (const char *filename,
 						     const MonoAssemblyOpenRequest *req,

--- a/mono/metadata/attach.c
+++ b/mono/metadata/attach.c
@@ -277,7 +277,7 @@ mono_attach_load_agent (MonoDomain *domain, char *agent, char *args, MonoObject 
 	MonoImageOpenStatus open_status;
 
 	MonoAssemblyOpenRequest req;
-	mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT);
+	mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT);
 	agent_assembly = mono_assembly_request_open (agent, &req, &open_status);
 	if (!agent_assembly) {
 		fprintf (stderr, "Cannot open agent assembly '%s': %s.\n", agent, mono_image_strerror (open_status));

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -1040,7 +1040,7 @@ mono_domain_assembly_open_internal (MonoDomain *domain, const char *name)
 	mono_domain_assemblies_unlock (domain);
 
 	MonoAssemblyOpenRequest req;
-	mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT);
+	mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT);
 	if (domain != mono_domain_get ()) {
 		current = mono_domain_get ();
 

--- a/mono/metadata/mono-security.c
+++ b/mono/metadata/mono-security.c
@@ -617,7 +617,7 @@ mono_invoke_protected_memory_method (MonoArrayHandle data, MonoObjectHandle scop
 			system_security_assembly = mono_image_loaded_internal ("System.Security", FALSE);
 			if (!system_security_assembly) {
 				MonoAssemblyOpenRequest req;
-				mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT);
+				mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT);
 				MonoAssembly *sa = mono_assembly_request_open ("System.Security.dll", &req, NULL);
 				g_assert (sa);
 				system_security_assembly = mono_assembly_get_image_internal (sa);

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -717,7 +717,7 @@ get_socket_assembly (void)
 		socket_assembly = mono_image_loaded_internal ("System", FALSE);
 		if (!socket_assembly) {
 			MonoAssemblyOpenRequest req;
-			mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT);
+			mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT);
 			MonoAssembly *sa = mono_assembly_request_open ("System.dll", &req, NULL);
 		
 			if (!sa) {
@@ -1844,7 +1844,7 @@ ves_icall_System_Net_Sockets_Socket_GetSocketOption_obj_internal (gsize sock, gi
 			mono_posix_image = mono_image_loaded_internal ("Mono.Posix", FALSE);
 			if (!mono_posix_image) {
 				MonoAssemblyOpenRequest req;
-				mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT);
+				mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT);
 				MonoAssembly *sa = mono_assembly_request_open ("Mono.Posix.dll", &req, NULL);
 				if (!sa) {
 					*werror = WSAENOPROTOOPT;

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -2093,7 +2093,7 @@ if (container_assm_name && !container_amodule) {
 	MonoImageOpenStatus status = MONO_IMAGE_OK;
 	MonoAssemblyOpenRequest req;
 	gchar *dll = g_strdup_printf (		"%s.dll", local_ref);
-	mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT);
+	mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT);
 	MonoAssembly *assm = mono_assembly_request_open (dll, &req, &status);
 	if (!assm) {
 		gchar *exe = g_strdup_printf ("%s.exe", local_ref);

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -664,7 +664,7 @@ mini_regression_list (int verbose, int count, char *images [])
 	total_run =  total = 0;
 	for (i = 0; i < count; ++i) {
 		MonoAssemblyOpenRequest req;
-		mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT);
+		mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT);
 		ass = mono_assembly_request_open (images [i], &req, NULL);
 		if (!ass) {
 			g_warning ("failed to load assembly: %s", images [i]);
@@ -791,7 +791,7 @@ mono_interp_regression_list (int verbose, int count, char *images [])
 	total_run = total = 0;
 	for (i = 0; i < count; ++i) {
 		MonoAssemblyOpenRequest req;
-		mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT);
+		mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT);
 		MonoAssembly *ass = mono_assembly_request_open (images [i], &req, NULL);
 		if (!ass) {
 			g_warning ("failed to load assembly: %s", images [i]);
@@ -1422,7 +1422,7 @@ load_agent (MonoDomain *domain, char *desc)
 	}
 
 	MonoAssemblyOpenRequest req;
-	mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT);
+	mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT);
 	agent_assembly = mono_assembly_request_open (agent, &req, &open_status);
 	if (!agent_assembly) {
 		fprintf (stderr, "Cannot open agent assembly '%s': %s.\n", agent, mono_image_strerror (open_status));
@@ -2574,7 +2574,7 @@ mono_main (int argc, char* argv[])
 	}
 
 	MonoAssemblyOpenRequest open_req;
-	mono_assembly_request_prepare (&open_req.request, sizeof (open_req), MONO_ASMCTX_DEFAULT);
+	mono_assembly_request_prepare_open (&open_req, MONO_ASMCTX_DEFAULT);
 	assembly = mono_assembly_request_open (aname, &open_req, &open_status);
 	if (!assembly) {
 		fprintf (stderr, "Cannot open assembly '%s': %s.\n", aname, mono_image_strerror (open_status));


### PR DESCRIPTION
Addresses the family of issues similar to Coverity #1443346.

This came up as part of the Coverity review, and Coverity notices that this is
writting beyond the end of the structure.  While this is correct, this requires
that the idiom be properly followed - that is, that the structure being passed
is of the given size.

Replaced instead with a method that eliminates the room for error with methods
that will initialize the whole structure, and the actual size computation is
done inside the method with the proper type sizes.

While I used methods, I feel that this should use macros.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
