### PR TITLE
[2019-02] [mono-dl] Don't do thread state transitions in mono_dl_fallback_register

### DIFF
--- a/mono/utils/mono-dl.c
+++ b/mono/utils/mono-dl.c
@@ -356,7 +356,6 @@ MonoDlFallbackHandler *
 mono_dl_fallback_register (MonoDlFallbackLoad load_func, MonoDlFallbackSymbol symbol_func, MonoDlFallbackClose close_func, void *user_data)
 {
 	MonoDlFallbackHandler *handler = NULL;
-	MONO_ENTER_GC_UNSAFE;
 	if (load_func == NULL || symbol_func == NULL)
 		goto leave;
 
@@ -369,7 +368,6 @@ mono_dl_fallback_register (MonoDlFallbackLoad load_func, MonoDlFallbackSymbol sy
 	fallback_handlers = g_slist_prepend (fallback_handlers, handler);
 	
 leave:
-	MONO_EXIT_GC_UNSAFE;
 	return handler;
 }
 


### PR DESCRIPTION
1. it doesn't touch the managed runtime

2. it may be called (arguably it ought to be called only) before the runtime is
initialized (and in particular before the current thread is attached).



Backport of #13866.

/cc @lambdageek 