### PR TITLE
[netcore] Keep the xunit parallelization setting at default value

### DIFF
--- a/netcore/Makefile.am
+++ b/netcore/Makefile.am
@@ -68,7 +68,7 @@ xtest-%: prepare check-env dl-test-assets
 	cd assets/extracted/$* && \
 	COMPlus_DebugWriteToStdErr=1 $(CURDIR)/./dotnet --fx-version "$(NETCOREAPP_VERSION)" xunit.console.dll $*.dll \
 		-notrait category=outerloop -notrait category=nonosxtests -notrait category=failing \
-		-notrait category=nonnetcoreapptests -noappdomain -noshadow \
+		-notrait category=nonnetcoreapptests \
 		-html ../../../TestResult-$*.html -nunit ../../TestResult-$*-netcore-xunit.xml \
 		$(shell if [ -a $(CURDIR)/excludes-$*.rsp ]; then grep -v '^#\|^$$' $(CURDIR)/excludes-$*.rsp; fi;) \
 		$(FIXTURE) || true

--- a/netcore/Makefile.am
+++ b/netcore/Makefile.am
@@ -68,7 +68,7 @@ xtest-%: prepare check-env dl-test-assets
 	cd assets/extracted/$* && \
 	COMPlus_DebugWriteToStdErr=1 $(CURDIR)/./dotnet --fx-version "$(NETCOREAPP_VERSION)" xunit.console.dll $*.dll \
 		-notrait category=outerloop -notrait category=nonosxtests -notrait category=failing \
-		-notrait category=nonnetcoreapptests -noappdomain -noshadow -parallel all \
+		-notrait category=nonnetcoreapptests -noappdomain -noshadow \
 		-html ../../../TestResult-$*.html -nunit ../../TestResult-$*-netcore-xunit.xml \
 		$(shell if [ -a $(CURDIR)/excludes-$*.rsp ]; then grep -v '^#\|^$$' $(CURDIR)/excludes-$*.rsp; fi;) \
 		$(FIXTURE) || true


### PR DESCRIPTION
Keep the xunit parallelization setting at default value to allow `Xunit.CollectionBehavior(DisableTestParallelization = true)` override to work. Fixes all failures in System.Xml.RW.XmlWriterApi.Tests.