### PR TITLE
[2018-10] Use LoadFrom instead LoadFile for load logger type.

### DIFF
--- a/mcs/tools/xbuild/LoggerInfo.cs
+++ b/mcs/tools/xbuild/LoggerInfo.cs
@@ -78,7 +78,7 @@ namespace Mono.XBuild.CommandLine
 			if (HasAssemblyInfo (assemblyName))
 				loggerAssembly = Assembly.Load (assemblyName);
 			else if (File.Exists (assemblyName))
-				loggerAssembly = Assembly.LoadFile (assemblyName);
+				loggerAssembly = Assembly.LoadFrom (assemblyName);
 
 			if (loggerAssembly == null)
 				return null;


### PR DESCRIPTION
LoadFile lost assembly load-context. If the logger assembly has any dependencies placed in same folder logger can't load it. Main.cs using LoadFrom to load assembly but assembly already loaded in the cache after GetLoggerTypeName.
It is a regression in previous version mono(I'm not sure about certain version) didn't use cache in this case. We have some customer reports from Linux distro without msbuild(like Arch). They have a problem after  mono upgrade.

Backport of #12372.

/cc @EgorBo @mfilippov