### PR TITLE
[llvm] do not emit safe points for simple methods

### DIFF
--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -7602,7 +7602,7 @@ emit_method_inner (EmitContext *ctx)
 		}
 	}
 
-	if (!cfg->llvm_only && cfg->compile_aot && mono_threads_are_safepoints_enabled ())
+	if (!cfg->llvm_only && cfg->compile_aot && mono_threads_are_safepoints_enabled () && requires_safepoint)
 		LLVMSetGC (method, "mono");
 	LLVMSetLinkage (method, LLVMPrivateLinkage);
 

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -7595,10 +7595,11 @@ emit_method_inner (EmitContext *ctx)
 	 *  (2) and no loops
 	 * we can skip the GC safepoint on method entry. */
 	gboolean requires_safepoint = cfg->has_calls;
-
-	for (bb = cfg->bb_entry->next_bb; bb; bb = bb->next_bb) {
-		if (bb->loop_body_start || (bb->flags & BB_EXCEPTION_HANDLER)) {
-			requires_safepoint = TRUE;
+	if (!requires_safepoint) {
+		for (bb = cfg->bb_entry->next_bb; bb; bb = bb->next_bb) {
+			if (bb->loop_body_start || (bb->flags & BB_EXCEPTION_HANDLER)) {
+				requires_safepoint = TRUE;
+			}
 		}
 	}
 

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -7589,6 +7589,19 @@ emit_method_inner (EmitContext *ctx)
 
 	if (!cfg->llvm_only)
 		LLVMSetFunctionCallConv (method, LLVMMono1CallConv);
+
+	/* if the method doesn't contain
+	 *  (1) a call (so it's a leaf method)
+	 *  (2) and no loops
+	 * we can skip the GC safepoint on method entry. */
+	gboolean requires_safepoint = cfg->has_calls;
+
+	for (bb = cfg->bb_entry->next_bb; bb; bb = bb->next_bb) {
+		if (bb->loop_body_start || (bb->flags & BB_EXCEPTION_HANDLER)) {
+			requires_safepoint = TRUE;
+		}
+	}
+
 	if (!cfg->llvm_only && cfg->compile_aot && mono_threads_are_safepoints_enabled ())
 		LLVMSetGC (method, "mono");
 	LLVMSetLinkage (method, LLVMPrivateLinkage);


### PR DESCRIPTION
When we switched to `-place-safepoints` we lost this small but nice optimization introduced in #11554

e.g. C#:
```csharp
static unsafe void Test (byte* a)
{
    a[0] = 42;
}
```
Before:
```llvm
; Function Attrs: norecurse nounwind uwtable
define hidden monocc void @P_Test_byte_(i64* nocapture %arg_a) #5 gc "mono" {
BB0:
  %0 = bitcast i64* %arg_a to i8*
  store i8 42, i8* %0, align 1
  %1 = load i64*, i64** getelementptr inbounds (%MONO_GOT_p.exe, %MONO_GOT_p.exe* @mono_aot_p_llvm_got, i64 0, i32 7), align 8
  %2 = load i64, i64* %1, align 4
  %3 = icmp eq i64 %2, 0
  br i1 %3, label %gc.safepoint_poll.exit, label %gc.safepoint_poll.poll.i

gc.safepoint_poll.poll.i:                         ; preds = %BB0
  %4 = load void ()*, void ()** getelementptr inbounds (%MONO_GOT_p.exe, %MONO_GOT_p.exe* @mono_aot_p_llvm_got, i64 0, i32 25), align 8
  call void %4() #6
  br label %gc.safepoint_poll.exit

gc.safepoint_poll.exit:                           ; preds = %BB0, %gc.safepoint_poll.poll.i
  ret void
}
```

After:
```llvm
define hidden monocc void @P_Test_byte_(i64* nocapture %arg_a) #5 {
BB0:
  %0 = bitcast i64* %arg_a to i8*
  store i8 42, i8* %0, align 1
  ret void
}
```
_Ideally: (pass pointer directly byte*=i8* and without bitcast)_
```llvm
define hidden monocc void @_Z4TestPh(i8* nocapture %arg_a) #5 {
BB0:
  store i8 42, i8* %arg_a, align 1
  ret void
}
```


Contributes to #13844
