### PR TITLE
[image] Create MonoImageStorage to own the image raw data

### DIFF
--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -2902,7 +2902,7 @@ mono_assembly_request_load_from (MonoImage *image, const char *fname,
 	mono_assemblies_unlock ();
 
 #ifdef HOST_WIN32
-	if (image->is_module_handle)
+	if (m_image_is_module_handle (image))
 		mono_image_fixup_vtable (image);
 #endif
 

--- a/mono/metadata/coree.c
+++ b/mono/metadata/coree.c
@@ -103,7 +103,7 @@ BOOL STDMETHODCALLTYPE _CorDllMain(HINSTANCE hInst, DWORD dwReason, LPVOID lpRes
 
 			image = mono_image_open (file_name, NULL);
 			if (image) {
-				image->has_entry_point = TRUE;
+				image->storage->has_entry_point = TRUE;
 				mono_close_exe_image ();
 				/* Decrement reference count to zero. (Image will not be closed.) */
 				mono_image_close (image);
@@ -954,8 +954,8 @@ mono_load_coree (const char* exe_file_name)
 void
 mono_fixup_exe_image (MonoImage* image)
 {
-	if (!init_from_coree && image && image->is_module_handle)
-		MonoFixupExe ((HMODULE) image->raw_data);
+	if (!init_from_coree && image && m_image_is_module_handle (image))
+		MonoFixupExe ((HMODULE) m_image_get_raw_data (image));
 }
 
 #endif /* HOST_WIN32 */

--- a/mono/metadata/debug-mono-ppdb.c
+++ b/mono/metadata/debug-mono-ppdb.c
@@ -80,10 +80,10 @@ get_pe_debug_guid (MonoImage *image, guint8 *out_guid, gint32 *out_age, gint32 *
 		return FALSE;
 
 	int offset = mono_cli_rva_image_map (image, debug_dir_entry->rva);
-	debug_dir = (ImageDebugDirectory*)(image->raw_data + offset);
+	debug_dir = (ImageDebugDirectory*)(m_image_get_raw_data (image) + offset);
 	if (debug_dir->type == 2 && debug_dir->major_version == 0x100 && debug_dir->minor_version == 0x504d) {
 		/* This is a 'CODEVIEW' debug directory */
-		CodeviewDebugDirectory *dir = (CodeviewDebugDirectory*)(image->raw_data + debug_dir->pointer);
+		CodeviewDebugDirectory *dir = (CodeviewDebugDirectory*)(m_image_get_raw_data (image) + debug_dir->pointer);
 
 		if (dir->signature == 0x53445352) {
 			memcpy (out_guid, dir->guid, 16);

--- a/mono/metadata/icall-windows.c
+++ b/mono/metadata/icall-windows.c
@@ -38,8 +38,8 @@ mono_icall_get_file_path_prefix (const gchar *path)
 gpointer
 mono_icall_module_get_hinstance (MonoImage *image)
 {
-	if (image && image->is_module_handle)
-		return image->raw_data;
+	if (image && m_image_is_module_handle (image))
+		return m_image_get_raw_data (image);
 
 	return (gpointer) (-1);
 }

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -1942,7 +1942,7 @@ mono_get_method_from_token (MonoImage *image, guint32 token, MonoClass *klass,
 
 #ifdef TARGET_WIN32
 		/* IJW is P/Invoke with a predefined function pointer. */
-		if (image->is_module_handle && (cols [1] & METHOD_IMPL_ATTRIBUTE_NATIVE)) {
+		if (m_image_is_module_handle (image) && (cols [1] & METHOD_IMPL_ATTRIBUTE_NATIVE)) {
 			piinfo->addr = mono_image_rva_map (image, cols [0]);
 			g_assert (piinfo->addr);
 		}

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -19,6 +19,7 @@
 #include "mono/utils/mono-value-hash.h"
 #include <mono/utils/mono-error.h>
 #include "mono/utils/mono-conc-hashtable.h"
+#include "mono/utils/refcount.h"
 
 struct _MonoType {
 	union {
@@ -306,16 +307,24 @@ typedef struct {
 	gboolean (*load_tables) (MonoImage*);
 } MonoImageLoader;
 
-struct _MonoImage {
-	/*
-	 * This count is incremented during these situations:
-	 *   - An assembly references this MonoImage though its 'image' field
-	 *   - This MonoImage is present in the 'files' field of an image
-	 *   - This MonoImage is present in the 'modules' field of an image
-	 *   - A thread is holding a temporary reference to this MonoImage between
-	 *     calls to mono_image_open and mono_image_close ()
-	 */
-	int   ref_count;
+/* Represents the physical bytes (usually on disk, but could be in memory) for
+ * an image.
+ *
+ * The MonoImageStorage owns the raw data for an image and is responsible for
+ * cleanup.
+ *
+ * May be shared by multiple MonoImage objects if they opened the same
+ * underlying file or byte blob in memory.
+ *
+ * There is an abstract string key (usually a file path, but could be formed in
+ * other ways) that is used to share MonoImageStorage objects among images.
+ *
+ */
+typedef struct {
+	MonoRefCount ref;
+
+	/* key used for lookups.  owned by this image storage. */
+	char *key;
 
 	/* If the raw data was allocated from a source such as mmap, the allocator may store resource tracking information here. */
 	void *raw_data_handle;
@@ -332,6 +341,20 @@ struct _MonoImage {
 	/* Module entry point is _CorDllMain. */
 	guint8 has_entry_point : 1;
 #endif
+} MonoImageStorage;
+
+struct _MonoImage {
+	/*
+	 * This count is incremented during these situations:
+	 *   - An assembly references this MonoImage though its 'image' field
+	 *   - This MonoImage is present in the 'files' field of an image
+	 *   - This MonoImage is present in the 'modules' field of an image
+	 *   - A thread is holding a temporary reference to this MonoImage between
+	 *     calls to mono_image_open and mono_image_close ()
+	 */
+	int   ref_count;
+
+	MonoImageStorage *storage;
 
 	/* Whenever this is a dynamically emitted module */
 	guint8 dynamic : 1;
@@ -1121,5 +1144,44 @@ MonoAssemblyContextKind
 mono_asmctx_get_kind (const MonoAssemblyContext *ctx);
 
 #define MONO_CLASS_IS_INTERFACE_INTERNAL(c) ((mono_class_get_flags (c) & TYPE_ATTRIBUTE_INTERFACE) || mono_type_is_generic_parameter (m_class_get_byval_arg (c)))
+
+static inline char*
+m_image_get_raw_data (MonoImage *image)
+{
+	return image->storage ? image->storage->raw_data : NULL;
+}
+
+static inline guint32
+m_image_get_raw_data_len (MonoImage *image)
+{
+	return image->storage ? image->storage->raw_data_len : 0;
+}
+
+static inline gboolean
+m_image_is_raw_data_allocated (MonoImage *image)
+{
+	return image->storage ? image->storage->raw_data_allocated : FALSE;
+}
+
+static inline gboolean
+m_image_is_fileio_used (MonoImage *image)
+{
+	return image->storage ? image->storage->fileio_used : FALSE;
+}
+
+#ifdef HOST_WIN32
+static inline gboolean
+m_image_is_module_handle (MonoImage *image)
+{
+	return image->storage ? image->storage->is_module_handle : FALSE;
+}
+
+static inline gboolean
+m_image_has_entry_point (MonoImage *image)
+{
+	return image->storage ? image->storage->has_entry_point : FALSE;
+}
+
+#endif
 
 #endif /* __MONO_METADATA_INTERNALS_H__ */

--- a/mono/metadata/metadata-verify.c
+++ b/mono/metadata/metadata-verify.c
@@ -951,11 +951,11 @@ get_metadata_stream (VerifyContext *ctx, MonoStreamHeader *header)
 static gboolean
 is_valid_string_full_with_image (MonoImage *image, guint32 offset, gboolean allow_empty)
 {
-	guint32 heap_offset = (char*)image->heap_strings.data - image->raw_data;
+	guint32 heap_offset = (char*)image->heap_strings.data - m_image_get_raw_data (image);
 	guint32 heap_size = image->heap_strings.size;
 
 	glong length;
-	const char *data = image->raw_data + heap_offset;
+	const char *data = m_image_get_raw_data (image) + heap_offset;
 
 	if (offset >= heap_size)
 		return FALSE;
@@ -3944,8 +3944,8 @@ init_verify_context (VerifyContext *ctx, MonoImage *image)
 	ctx->report_error = TRUE;
 	ctx->report_warning = FALSE; //export this setting in the API
 	ctx->valid = 1;
-	ctx->size = image->raw_data_len;
-	ctx->data = image->raw_data;
+	ctx->size = m_image_get_raw_data_len (image);
+	ctx->data = m_image_get_raw_data (image);
 }
 
 static gboolean

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -1260,7 +1260,7 @@ method_body_object_construct (MonoDomain *domain, MonoClass *unused_class, MonoM
 	if ((method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL) ||
 		(method->flags & METHOD_ATTRIBUTE_ABSTRACT) ||
 	    (method->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL) ||
-	    (image->raw_data && image->raw_data [1] != 'Z') ||
+	    (!image_is_dynamic (image) && m_image_get_raw_data (image) && m_image_get_raw_data (image) [1] != 'Z') ||
 	    (method->iflags & METHOD_IMPL_ATTRIBUTE_RUNTIME))
 		return MONO_HANDLE_CAST (MonoReflectionMethodBody, NULL_HANDLE);
 

--- a/mono/metadata/w32process.c
+++ b/mono/metadata/w32process.c
@@ -461,7 +461,7 @@ get_domain_assemblies (MonoDomain *domain)
 	mono_domain_assemblies_lock (domain);
 	for (tmp = domain->domain_assemblies; tmp; tmp = tmp->next) {
 		MonoAssembly *ass = (MonoAssembly *)tmp->data;
-		if (ass->image->fileio_used)
+		if (m_image_is_fileio_used (ass->image))
 			continue;
 		g_ptr_array_add (assemblies, ass);
 	}
@@ -547,8 +547,8 @@ process_get_module (MonoAssembly *assembly, MonoClass *proc_class, MonoError *er
 	goto_if_nok (error, return_null);
 	process_set_field_object (item, "version_info", filever);
 
-	process_set_field_intptr (item, "baseaddr", assembly->image->raw_data);
-	process_set_field_int (item, "memory_size", assembly->image->raw_data_len);
+	process_set_field_intptr (item, "baseaddr", m_image_get_raw_data (assembly->image));
+	process_set_field_int (item, "memory_size", m_image_get_raw_data_len (assembly->image));
 	process_set_field_string_char (item, "filename", filename, error);
 	goto_if_nok (error, return_null);
 	process_set_field_string_char (item, "modulename", modulename, error);

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -7348,7 +7348,7 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
         if (ass->dynamic) {
             return ERR_NOT_IMPLEMENTED;
         }
-        buffer_add_byte_array (buf, (guint8*)image->raw_data, image->raw_data_len);
+        buffer_add_byte_array (buf, (guint8*)m_image_get_raw_data (image), m_image_get_raw_data_len (image));
         break;
     }
     case CMD_ASSEMBLY_GET_IS_DYNAMIC: {
@@ -7364,7 +7364,7 @@ assembly_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
         MonoPPDBFile* ppdb = handle->ppdb;
         if (ppdb) {
             image = mono_ppdb_get_image (ppdb);
-            buffer_add_byte_array (buf, (guint8*)image->raw_data, image->raw_data_len);
+            buffer_add_byte_array (buf, (guint8*)m_image_get_raw_data (image), m_image_get_raw_data_len (image));
         } else {
             buffer_add_byte_array (buf, NULL, 0);
         }

--- a/tools/pedump/pedump.c
+++ b/tools/pedump/pedump.c
@@ -319,7 +319,7 @@ dump_metadata (MonoImage *meta)
 			mono_meta_table_name (table),
 			meta->tables [table].rows,
 			meta->tables [table].row_size,
-			(unsigned int)(meta->tables [table].base - meta->raw_data)
+			(unsigned int)(meta->tables [table].base - m_image_get_raw_data (meta))
 			);
 	}
 }


### PR DESCRIPTION
Create a new data structure: MonoImageStorage.

It is an object that will have the responsibility for the raw data of a
MonoImage.  It has a string key and a refcount that is used to share a
MonoImageStorage between multiple MonoImage objects.

The reason we need this is because the current MonoAssembly/MonoImage design is
broken for multiple domains and (more evidently) it will be broken when we add
AssemblyLoadContext support.  The issue is that a MonoImage may be shared
between multiple domains (or ALCs), but it has a 'references' field which
points to a single other MonoAssembly.

This is a problem because the references of an image may be resolved
differently in different domains (or ALCs).

The eventual solution will be to stop sharing MonoImages based on path name (or
in the case of in-memory images based on a name made up from the address of the
byte blob).

However we still don't want to open the same data more than once (if we're on a
config where we don't have mmap, we malloc some memory and dump the data in
there - we don't want to do that multiple times for the same file).

So the solution is to create this MonoImageStorage object and make it possible
to share it based on path name, but don't give it any responsibilities except
for owning the memory.  It doesn't know anything about metadata or assemblies
or any of that stuff - it just owns a chunk of memory and knows when and how to
free it.

This commit just adds the MonoImageStorage object and wires it up in MonoImage
loading.  There should be no observable behavioral changes from this commit.

This is the first step of #13891