### PR TITLE
Remove obsolete AOT relocations for code clarity, assuming no need to support old AOT images.

### DIFF
--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -5387,10 +5387,6 @@ load_function_full (MonoAotModule *amodule, const char *name, MonoTrampInfo **ou
 					target = (gpointer)mono_thread_force_interruption_checkpoint_noraise;
 				} else if (!strcmp (ji->data.name, "mono_exception_from_token")) {
 					target = (gpointer)mono_exception_from_token;
-				} else if (!strcmp (ji->data.name, "mono_throw_exception")) {
-					target = (gpointer)mono_get_throw_exception ();
-				} else if (!strcmp (ji->data.name, "mono_rethrow_preserve_exception")) {
-					target = (gpointer)mono_get_rethrow_preserve_exception ();
 				} else if (!strcmp (ji->data.name, "debugger_agent_single_step_from_context")) {
 					target = (gpointer)mini_get_dbg_callbacks ()->single_step_from_context;
 				} else if (!strcmp (ji->data.name, "debugger_agent_breakpoint_from_context")) {

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2492,7 +2492,6 @@ gpointer mono_get_rethrow_exception             (void);
 gpointer mono_get_rethrow_preserve_exception             (void);
 gpointer mono_get_call_filter                   (void);
 gpointer mono_get_restore_context               (void);
-gpointer mono_get_throw_exception_by_name       (void);
 gpointer mono_get_throw_corlib_exception        (void);
 gpointer mono_get_throw_exception_addr          (void);
 gpointer mono_get_rethrow_preserve_exception_addr          (void);


### PR DESCRIPTION
It does not matter perf-wise, but makes the code clearer.
i.e. if attempting to replace strings with enums.