### PR TITLE
Remove constant parameter to mono_tls_get_tls_setter and mono_tls_get_tls_getter.

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -5662,7 +5662,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			goto exit_frame;
 		MINT_IN_CASE(MINT_MONO_TLS) {
 			MonoTlsKey key = (MonoTlsKey)*(gint32 *)(ip + 1);
-			sp->data.p = ((gpointer (*)(void)) mono_tls_get_tls_getter (key, FALSE)) ();
+			sp->data.p = mono_tls_get_tls_getter (key) (); // get function pointer and call it
 			sp++;
 			ip += 3;
 			MINT_IN_BREAK;

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -1710,7 +1710,7 @@ mono_create_tls_get (MonoCompile *cfg, MonoTlsKey key)
 		EMIT_NEW_AOTCONST (cfg, addr, MONO_PATCH_INFO_GET_TLS_TRAMP, GUINT_TO_POINTER(key));
 		return mini_emit_calli (cfg, mono_icall_sig_ptr, NULL, addr, NULL, NULL);
 	} else {
-		gpointer getter = mono_tls_get_tls_getter (key, FALSE);
+		gpointer getter = (gpointer)mono_tls_get_tls_getter (key);
 		return mono_emit_jit_icall (cfg, getter, NULL);
 	}
 }

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -1672,10 +1672,10 @@ mono_resolve_patch_target (MonoMethod *method, MonoDomain *domain, guint8 *code,
 		target = mini_get_gsharedvt_wrapper (TRUE, NULL, patch_info->data.sig, NULL, -1, FALSE);
 		break;
 	case MONO_PATCH_INFO_GET_TLS_TRAMP:
-		target = mono_tls_get_tls_getter ((MonoTlsKey)patch_info->data.index, FALSE);
+		target = (gpointer)mono_tls_get_tls_getter ((MonoTlsKey)patch_info->data.index);
 		break;
 	case MONO_PATCH_INFO_SET_TLS_TRAMP:
-		target = mono_tls_get_tls_setter ((MonoTlsKey)patch_info->data.index, FALSE);
+		target = (gpointer)mono_tls_get_tls_setter ((MonoTlsKey)patch_info->data.index);
 		break;
 	case MONO_PATCH_INFO_PROFILER_ALLOCATION_COUNT: {
 		target = (gpointer) &mono_profiler_state.gc_allocation_count;

--- a/mono/utils/mono-tls.c
+++ b/mono/utils/mono-tls.c
@@ -276,40 +276,40 @@ mono_tls_get_tls_offset (MonoTlsKey key)
  * Returns the getter (gpointer (*)(void)) for the mono tls key.
  * Managed code will always get the value by calling this getter.
  */
-gpointer
-mono_tls_get_tls_getter (MonoTlsKey key, gboolean name)
+MonoTlsGetter
+mono_tls_get_tls_getter (MonoTlsKey key)
 {
 	switch (key) {
 	case TLS_KEY_THREAD:
-		return name ? (gpointer)"mono_tls_get_thread" : (gpointer)mono_tls_get_thread;
+		return (MonoTlsGetter)mono_tls_get_thread;
 	case TLS_KEY_JIT_TLS:
-		return name ? (gpointer)"mono_tls_get_jit_tls" : (gpointer)mono_tls_get_jit_tls;
+		return (MonoTlsGetter)mono_tls_get_jit_tls;
 	case TLS_KEY_DOMAIN:
-		return name ? (gpointer)"mono_tls_get_domain" : (gpointer)mono_tls_get_domain;
+		return (MonoTlsGetter)mono_tls_get_domain;
 	case TLS_KEY_SGEN_THREAD_INFO:
-		return name ? (gpointer)"mono_tls_get_sgen_thread_info" : (gpointer)mono_tls_get_sgen_thread_info;
+		return (MonoTlsGetter)mono_tls_get_sgen_thread_info;
 	case TLS_KEY_LMF_ADDR:
-		return name ? (gpointer)"mono_tls_get_lmf_addr" : (gpointer)mono_tls_get_lmf_addr;
+		return (MonoTlsGetter)mono_tls_get_lmf_addr;
 	}
 	g_assert_not_reached ();
 	return NULL;
 }
 
 /* Returns the setter (void (*)(gpointer)) for the mono tls key */
-gpointer
-mono_tls_get_tls_setter (MonoTlsKey key, gboolean name)
+MonoTlsSetter
+mono_tls_get_tls_setter (MonoTlsKey key)
 {
 	switch (key) {
 	case TLS_KEY_THREAD:
-		return name ? (gpointer)"mono_tls_set_thread" : (gpointer)mono_tls_set_thread;
+		return (MonoTlsSetter)mono_tls_set_thread;
 	case TLS_KEY_JIT_TLS:
-		return name ? (gpointer)"mono_tls_set_jit_tls" : (gpointer)mono_tls_set_jit_tls;
+		return (MonoTlsSetter)mono_tls_set_jit_tls;
 	case TLS_KEY_DOMAIN:
-		return name ? (gpointer)"mono_tls_set_domain" : (gpointer)mono_tls_set_domain;
+		return (MonoTlsSetter)mono_tls_set_domain;
 	case TLS_KEY_SGEN_THREAD_INFO:
-		return name ? (gpointer)"mono_tls_set_sgen_thread_info" : (gpointer)mono_tls_set_sgen_thread_info;
+		return (MonoTlsSetter)mono_tls_set_sgen_thread_info;
 	case TLS_KEY_LMF_ADDR:
-		return name ? (gpointer)"mono_tls_set_lmf_addr" : (gpointer)mono_tls_set_lmf_addr;
+		return (MonoTlsSetter)mono_tls_set_lmf_addr;
 	}
 	g_assert_not_reached ();
 	return NULL;

--- a/mono/utils/mono-tls.h
+++ b/mono/utils/mono-tls.h
@@ -83,8 +83,12 @@ void mono_tls_init_gc_keys (void);
 void mono_tls_init_runtime_keys (void);
 void mono_tls_free_keys (void);
 gint32 mono_tls_get_tls_offset (MonoTlsKey key);
-gpointer mono_tls_get_tls_getter (MonoTlsKey key, gboolean name);
-gpointer mono_tls_get_tls_setter (MonoTlsKey key, gboolean name);
+
+typedef gpointer (*MonoTlsGetter)(void);
+typedef void (*MonoTlsSetter)(gpointer);
+
+MonoTlsGetter mono_tls_get_tls_getter (MonoTlsKey key);
+MonoTlsSetter mono_tls_get_tls_setter (MonoTlsKey key);
 
 G_EXTERN_C MonoInternalThread *mono_tls_get_thread (void);
 G_EXTERN_C MonoJitTlsData     *mono_tls_get_jit_tls (void);


### PR DESCRIPTION
It doesn't matter, but for code clarity.
Also strengthen the types of both of these, though rarely enough to avoid casts.
