### PR TITLE
[netcore] Propagate System.Globalization.Invariant from runtimeconfig.json

### DIFF
--- a/mono/mini/main-core.c
+++ b/mono/mini/main-core.c
@@ -168,6 +168,9 @@ parse_properties (int propertyCount, const char** propertyKeys, const char** pro
 			parse_trusted_platform_assemblies (propertyValues[i]);
 		} else if (!strcmp (propertyKeys[i], "NATIVE_DLL_SEARCH_DIRECTORIES")) {
 			parse_native_dll_search_directories (propertyValues[i]);
+		} else if (!strcmp (propertyKeys[i], "System.Globalization.Invariant")) {
+			// TODO: Ideally we should propagate this through AppContext options
+			setenv ("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", propertyValues[i], TRUE);
 		} else {
 #if 0
 			// can't use mono logger, it's not initialized yet.


### PR DESCRIPTION
Propagate System.Globalization.Invariant from runtimeconfig.json to GlobalizationMode. It's temporary hack to make all Invariant.Tests pass. CoreCLR also uses special `CLRConfig` class and icall to access this property because it needs it very early, so this may end up quite ok way to accomplish the same.