### PR TITLE
[netcore] Allow reflection invocation of methods with ByRef return types

### DIFF
--- a/mcs/class/corlib/System.Reflection/RuntimePropertyInfo.cs
+++ b/mcs/class/corlib/System.Reflection/RuntimePropertyInfo.cs
@@ -377,7 +377,7 @@ namespace System.Reflection {
 					MethodInfo method = GetGetMethod (true);
 					if (method == null)
 						throw new ArgumentException ($"Get Method not found for '{Name}'");
-					if (!DeclaringType.IsValueType && !method.ContainsGenericParameters) { //FIXME find a way to build an invoke delegate for value types.
+					if (!DeclaringType.IsValueType && !PropertyType.IsByRef && !method.ContainsGenericParameters) { //FIXME find a way to build an invoke delegate for value types.
 						cached_getter = CreateGetterDelegate (method);
 						// The try-catch preserves the .Invoke () behaviour
 						try {

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -3518,8 +3518,11 @@ ves_icall_InternalInvoke (MonoReflectionMethod *method, MonoObject *this_arg, Mo
 	}
 
 	if (sig->ret->byref) {
-		mono_gc_wbarrier_generic_store_internal (exc, (MonoObject*) mono_exception_from_name_msg (mono_defaults.corlib, "System", "NotSupportedException", "Cannot invoke method returning ByRef type via reflection"));
-		return NULL;
+		MonoType* ret_byval = m_class_get_byval_arg (mono_class_from_mono_type_internal (sig->ret));
+		if (ret_byval->byref) {
+			mono_gc_wbarrier_generic_store_internal (exc, (MonoObject*) mono_exception_from_name_msg (mono_defaults.corlib, "System", "NotSupportedException", "Cannot invoke method returning ByRef to ByRefLike type via reflection"));
+			return NULL;
+		}
 	}
 
 	pcount = params? mono_array_length_internal (params): 0;

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -3518,11 +3518,16 @@ ves_icall_InternalInvoke (MonoReflectionMethod *method, MonoObject *this_arg, Mo
 	}
 
 	if (sig->ret->byref) {
+#if ENABLE_NETCORE
 		MonoType* ret_byval = m_class_get_byval_arg (mono_class_from_mono_type_internal (sig->ret));
 		if (ret_byval->byref) {
 			mono_gc_wbarrier_generic_store_internal (exc, (MonoObject*) mono_exception_from_name_msg (mono_defaults.corlib, "System", "NotSupportedException", "Cannot invoke method returning ByRef to ByRefLike type via reflection"));
 			return NULL;
 		}
+#else
+		mono_gc_wbarrier_generic_store_internal (exc, (MonoObject*) mono_exception_from_name_msg (mono_defaults.corlib, "System", "NotSupportedException", "Cannot invoke method returning ByRef type via reflection"));
+		return NULL;
+#endif
 	}
 
 	pcount = params? mono_array_length_internal (params): 0;

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -1489,6 +1489,7 @@ handle_enum:
 		int ldind_op;
 		MonoType* ret_byval = m_class_get_byval_arg (mono_class_from_mono_type_internal (sig->ret));
 		g_assert (!ret_byval->byref);
+		// TODO: Handle null references
 		ldind_op = mono_type_to_ldind (ret_byval);
 		/* taken from similar code in mini-generic-sharing.c
 		 * we need to use mono_mb_emit_op to add method data when loading


### PR DESCRIPTION
CoreCLR allows reflection on methods with ByRef return types under certain conditions. The PR implementing it is https://github.com/dotnet/coreclr/pull/17639.

Mono already implemented most of it in the marshalling code but artificially blocked it in `ves_icall_InternalInvoke`. I changed the condition for the exception to match the condition in `emit_invoke_call` (marshal-ilgen.c). It's similar to the condition in CoreCLR, but it may not handle byref-like types correctly. It would have to fixed on both places if it turns out to be the case.

The remaining issue is that null references returned in ByRef are not checked and converted to correct exception. It should result in `NullReferenceException` with special message that doesn't get wrapped in `TargetInvocationException`. I put a TODO marker at a place where I think it should be handled, but it's a bit over my head to implement it.

/cc @vargaz 