### PR TITLE
[2019-02] [AOT] remove confusing llcopts flag

### DIFF
--- a/man/mono.1
+++ b/man/mono.1
@@ -228,12 +228,6 @@ obtained by calling the bundled
 .I llc
 program that comes with Mono.
 .TP
-.I llcopts=[options]
-Use this option to add more flags to the built-in set of flags passed to the
-LLVM system compiler. If not provided, it will fallback to
-.I -mcpu=generic
-on x86 systems.
-.TP
 .I llvm-outfile=[filename]
 Gives the path for the temporary LLVM bitcode file created during AOT.
 .I dedup


### PR DESCRIPTION
Introduced by
https://github.com/mono/mono/commit/2eeaf888c1d0a681c8705bd609f76196d8fb82ed



Backport of #13877.

/cc @lewurm 