### PR TITLE
[2019-04] [merp] Restore non-assertion behavior in debugger-engine.c

### DIFF
--- a/mono/mini/debugger-engine.c
+++ b/mono/mini/debugger-engine.c
@@ -337,7 +337,9 @@ mono_de_add_pending_breakpoints (MonoMethod *method, MonoJitInfo *ji)
 				}
 			}
 
-			g_assert (seq_points);
+			if (!seq_points)
+				/* Could be AOT code, or above "search_all_backends" call could have failed */
+				continue;
 
 			insert_breakpoint (seq_points, domain, ji, bp, NULL);
 		}


### PR DESCRIPTION
In my batch of changes here: https://github.com/mono/mono/commit/c3fe80a0c43be780e35f3a4091d3dc1023b35a00#diff-dca5f20c7ac28a5a4487805c49836fdbL340

I changed

```
			if (!seq_points)
				/* Could be AOT code */
				continue;
```

into

```
			seq_points = (MonoSeqPointInfo *) ji->seq_points;

			if (!seq_points) {
				MonoMethod *jmethod = jinfo_get_method (ji);
				if (jmethod->is_inflated) {
					MonoJitInfo *seq_ji;
					MonoMethod *declaring = mono_method_get_declaring_generic_method (jmethod);
					mono_jit_search_all_backends_for_jit_info (domain, declaring, &seq_ji);
					seq_points = (MonoSeqPointInfo *) seq_ji->seq_points;
				}
			}
```

which doesn't account for the case when it can't find the seq_points. When seq_points is NULL at the end of that block, we don't `continue;` as we did before. Instead we assert, and crash the runtime.

This PR undoes this change, making us continue if `!seq_points`.

Backport of #13865.

/cc @lambdageek @alexanderkyte