### PR TITLE
[WinForms] Fix displayed image in TreeNode when ImageIndex set to -1

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/TreeNode.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/TreeNode.cs
@@ -1071,7 +1071,7 @@ namespace System.Windows.Forms
 						return TreeView.ImageList.Images.IndexOfKey (selected_image_key);
 					if (!string.IsNullOrEmpty (TreeView.SelectedImageKey))
 						return TreeView.ImageList.Images.IndexOfKey (TreeView.SelectedImageKey);
-					if (TreeView.SelectedImageIndex >= 0)
+					if (selected_image_index == -1 && TreeView.SelectedImageIndex >= 0)
 						return TreeView.SelectedImageIndex;
 				} else {
 					if (image_index >= 0)
@@ -1080,12 +1080,9 @@ namespace System.Windows.Forms
 						return TreeView.ImageList.Images.IndexOfKey (image_key);
 					if (!string.IsNullOrEmpty (TreeView.ImageKey))
 						return TreeView.ImageList.Images.IndexOfKey (TreeView.ImageKey);
-					if (TreeView.ImageIndex >= 0)
+					if (image_index == -1 && TreeView.ImageIndex >= 0)
 						return TreeView.ImageIndex;
 				}
-
-				if (TreeView.ImageList.Images.Count > 0)
-					return 0;
 					
 				return -1;
 			}


### PR DESCRIPTION
When ImageIndex in TreeNode set to -2 must not displayed any image



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
