### PR TITLE
[netcore] Runtime nupkg fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -159,12 +159,15 @@ case "$host" in
 		fi
 		HOST_CC="gcc"
 		RID="win-x86"
+		CORETARGETS="/p:TargetsWindows=true"
+		COREARCH="x86"
 		# Boehm not supported on 64-bit Windows.
 		case "$host" in
 		x86_64-*-* | amd64-*-*)
 			support_boehm=no
 			with_gc=sgen
 			RID="win-x64"
+			COREARCH="x64"
 			;;
 		esac
 
@@ -306,6 +309,7 @@ case "$host" in
 		libmono_cflags="-D_REENTRANT"
 		libdl="-ldl"
 		libgc_threads=pthreads
+		CORETARGETS="/p:TargetsUnix=true"
 		use_sigposix=yes
 		if test "x$cross_compiling" != "xno"; then
                 	# to bypass the underscore linker check, not
@@ -329,9 +333,11 @@ case "$host" in
 			;;
 		x86-*)
 			RID="linux-x86"
+			COREARCH="x86"
 			;;
 		x86_64-*)
 			RID="linux-x64"
+			COREARCH="x64"
 			;;
 		arm-*)
 			# deal with this in the FPU detection section, since
@@ -342,6 +348,7 @@ case "$host" in
 			support_boehm=no
 			with_gc=sgen
 			RID="linux-arm64"
+			COREARCH="arm64"
 			;;
 		powerpc*-*-linux*)
 			# https://bugzilla.novell.com/show_bug.cgi?id=504411
@@ -394,6 +401,7 @@ case "$host" in
 		need_link_unlink=yes
 		AC_DEFINE(PTHREAD_POINTER_ID)
 		AC_DEFINE(USE_MACH_SEMA, 1, [...])
+		CORETARGETS="/p:TargetsUnix=true /p:TargetsOSX=true"
 		libdl=
 		libgc_threads=pthreads
 		has_dtrace=yes
@@ -416,10 +424,12 @@ case "$host" in
 				CFLAGS_FOR_LIBGC="$CFLAGS_FOR_LIBGC $BROKEN_DARWIN_FLAGS"
 				with_sgen_default_concurrent=yes
 				RID="osx-x86"
+				COREARCH="x86"
 				;;
 			x*64-*-darwin*)
 				with_sgen_default_concurrent=yes
 				RID="osx-x64"
+				COREARCH="x64"
 				;;
 			arm*-darwin*)
 				platform_ios=yes
@@ -479,6 +489,7 @@ case "$host" in
 		dnl ppc Linux is the same? test further
 		disable_munmap=yes
 		RID="aix-ppc64"
+		CORETARGETS="/p:TargetsUnix=true"
 		;;
 	*)
 		AC_MSG_WARN([*** Please add $host to configure.ac checks!])
@@ -5233,13 +5244,17 @@ if test ${TARGET} = ARM; then
 
 	if test x$host_linux = xyes; then
 		RID="linux-arm"
+		COREARCH="arm"
 		if test x$fpu = xNONE; then
 			RID="linux-armel"
+			COREARCH="armel"
 		fi
 	fi
 fi
 
 AC_SUBST(RID)
+AC_SUBST(COREARCH)
+AC_SUBST(CORETARGETS)
 
 if test ${TARGET} = RISCV32 -o ${TARGET} = RISCV64; then
 	AC_ARG_WITH([riscv-fpabi], [  --with-riscv-fpabi=auto,double,soft   Select RISC-V floating point ABI (auto)], [fpabi=$withval], [fpabi=double])
@@ -6396,6 +6411,7 @@ acceptance-tests/Makefile
 llvm/Makefile
 scripts/mono-find-provides
 scripts/mono-find-requires
+mcs/class/System.Private.CoreLib/Makefile
 mk/Makefile
 mono/Makefile
 mono/btls/Makefile

--- a/mcs/class/System.Private.CoreLib/.gitignore
+++ b/mcs/class/System.Private.CoreLib/.gitignore
@@ -1,0 +1,1 @@
+Makefile

--- a/mcs/class/System.Private.CoreLib/Makefile
+++ b/mcs/class/System.Private.CoreLib/Makefile
@@ -1,9 +1,0 @@
-thisdir = class/System.Private.CoreLib
-SUBDIRS =
-include ../../build/rules.make
-
-all-local:
-	dotnet build -p:TargetsUnix=true -p:TargetsOSX=true -p:BuildArch=x64 -p:OutputPath=bin/x64 -p:FeaturePortableTimer=true System.Private.CoreLib.csproj
-
-dist-local:
-	@:

--- a/mcs/class/System.Private.CoreLib/Makefile.am
+++ b/mcs/class/System.Private.CoreLib/Makefile.am
@@ -1,6 +1,6 @@
 thisdir = class/System.Private.CoreLib
 SUBDIRS =
-include ../../build/rules.make
+#include ../../build/rules.make
 
 all-local:
 	dotnet build @CORETARGETS@ -p:BuildArch=@COREARCH@ -p:OutputPath=bin/@COREARCH@ -p:FeaturePortableTimer=true System.Private.CoreLib.csproj

--- a/mcs/class/System.Private.CoreLib/Makefile.am
+++ b/mcs/class/System.Private.CoreLib/Makefile.am
@@ -1,0 +1,9 @@
+thisdir = class/System.Private.CoreLib
+SUBDIRS =
+include ../../build/rules.make
+
+all-local:
+	dotnet build @CORETARGETS@ -p:BuildArch=@COREARCH@ -p:OutputPath=bin/@COREARCH@ -p:FeaturePortableTimer=true System.Private.CoreLib.csproj
+
+dist-local:
+	@:

--- a/netcore/Makefile.am
+++ b/netcore/Makefile.am
@@ -44,7 +44,7 @@ SHAREDRUNTIME := shared/Microsoft.NETCore.App/$(NETCOREAPP_VERSION)
 bcl:
 	$(MAKE) -C ../mcs/build/ common/Consts.cs
 	$(MAKE) -C ../mcs/class/System.Private.CoreLib
-	cp ../mcs/class/System.Private.CoreLib/bin/x64/System.Private.CoreLib.dll $(SHAREDRUNTIME)
+	cp ../mcs/class/System.Private.CoreLib/bin/@COREARCH@/System.Private.CoreLib.dll $(SHAREDRUNTIME)
 
 runtime:
 	$(MAKE) -C ../mono
@@ -52,12 +52,12 @@ runtime:
 
 link-mono:
 	cp ../mono/mini/.libs/libmonosgen-2.0@PLATFORM_AOT_SUFFIX@ $(SHAREDRUNTIME)/libcoreclr@PLATFORM_AOT_SUFFIX@
-	cp ../mcs/class/System.Private.CoreLib/bin/x64/System.Private.CoreLib.{dll,pdb} $(SHAREDRUNTIME)
+	cp ../mcs/class/System.Private.CoreLib/bin/@COREARCH@/System.Private.CoreLib.{dll,pdb} $(SHAREDRUNTIME)
 
 prepare: $(NETCORESDK_FILE) update-corefx link-mono
 
 nupkg:
-	nuget pack runtime.nuspec -properties VERSION=@VERSION@\;RID=@RID@\;PLATFORM_AOT_SUFFIX=@PLATFORM_AOT_SUFFIX@
+	nuget pack runtime.nuspec -properties VERSION=@VERSION@\;RID=@RID@\;PLATFORM_AOT_SUFFIX=@PLATFORM_AOT_SUFFIX@\;COREARCH=@COREARCH@
 
 COREFX_BINDIR=$(COREFX_ROOT)/artifacts/bin
 

--- a/netcore/Makefile.am
+++ b/netcore/Makefile.am
@@ -42,6 +42,7 @@ run-sample:
 SHAREDRUNTIME := shared/Microsoft.NETCore.App/$(NETCOREAPP_VERSION)
 
 bcl:
+	$(MAKE) -C ../mcs/build/ common/Consts.cs
 	$(MAKE) -C ../mcs/class/System.Private.CoreLib
 	cp ../mcs/class/System.Private.CoreLib/bin/x64/System.Private.CoreLib.dll $(SHAREDRUNTIME)
 

--- a/netcore/Makefile.am
+++ b/netcore/Makefile.am
@@ -8,7 +8,7 @@ NETCORETESTS_VERSION := 4.6.0-preview5.19205.9
 # Extracted MicrosoftNETCoreAppVersion from https://github.com/dotnet/coreclr/blob/master/eng/Versions.props#L13
 NETCOREAPP_VERSION := 3.0.0-preview5-27606-02
 
-NETCORESDK_FILE := dotnet-runtime-$(NETCOREAPP_VERSION)-osx-x64.tar.gz
+NETCORESDK_FILE := dotnet-runtime-$(NETCOREAPP_VERSION)-@RID@.tar.gz
 URL := https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$(NETCOREAPP_VERSION)/$(NETCORESDK_FILE)
 FEED_BASE_URL := https://dotnetfeed.blob.core.windows.net/dotnet-core
 TEST_ASSETS_URL = $(FEED_BASE_URL)/corefx-tests/$(NETCORETESTS_VERSION)/OSX.x64/netcoreapp/corefx-test-assets.xml
@@ -47,10 +47,10 @@ bcl:
 
 runtime:
 	$(MAKE) -C ../mono
-	cp ../mono/mini/.libs/libmonosgen-2.0.dylib $(SHAREDRUNTIME)/libcoreclr.dylib
+	cp ../mono/mini/.libs/libmonosgen-2.0@PLATFORM_AOT_SUFFIX@ $(SHAREDRUNTIME)/libcoreclr@PLATFORM_AOT_SUFFIX@
 
 link-mono:
-	cp ../mono/mini/.libs/libmonosgen-2.0.dylib $(SHAREDRUNTIME)/libcoreclr.dylib
+	cp ../mono/mini/.libs/libmonosgen-2.0@PLATFORM_AOT_SUFFIX@ $(SHAREDRUNTIME)/libcoreclr@PLATFORM_AOT_SUFFIX@
 	cp ../mcs/class/System.Private.CoreLib/bin/x64/System.Private.CoreLib.{dll,pdb} $(SHAREDRUNTIME)
 
 prepare: $(NETCORESDK_FILE) update-corefx link-mono

--- a/netcore/runtime.nuspec
+++ b/netcore/runtime.nuspec
@@ -10,6 +10,6 @@ The Mono runtime, and the base library, called mscorlib. It includes the garbage
     </metadata>
     <files>
         <file src="..\mcs\class\System.Private.CoreLib\bin\x64\System.Private.CoreLib.dll" target="runtimes\$RID$\native" />
-        <file src="..\mono\mini\.libs\libmonosgen-2.0.$PLATFORM_AOT_SUFFIX$" target="runtimes\$RID$\native" />
+        <file src="..\mono\mini\.libs\libmonosgen-2.0$PLATFORM_AOT_SUFFIX$" target="runtimes\$RID$\native" />
     </files>
 </package>

--- a/netcore/runtime.nuspec
+++ b/netcore/runtime.nuspec
@@ -9,7 +9,7 @@ The Mono runtime, and the base library, called mscorlib. It includes the garbage
         <projectUrl>https://www.mono-project.com/</projectUrl>
     </metadata>
     <files>
-        <file src="..\mcs\class\System.Private.CoreLib\bin\x64\System.Private.CoreLib.dll" target="runtimes\$RID$\native" />
+        <file src="..\mcs\class\System.Private.CoreLib\bin\$COREARCH$\System.Private.CoreLib.dll" target="runtimes\$RID$\native" />
         <file src="..\mono\mini\.libs\libmonosgen-2.0$PLATFORM_AOT_SUFFIX$" target="runtimes\$RID$\native" />
     </files>
 </package>


### PR DESCRIPTION
I know everyone hated the move to Autotools, but there was method to my madness.

We can now build `--with-core=only` on Linux or Mac with the same makefile, and have a functional `make nupkg` rule which attempts to produce a .nupkg of the runtime in the format consumed by core-setup. We should at least have something we can throw at CI to get binaries produced, and talk to the Core team about consuming them.