### PR TITLE
[System.Data] Remove unnecessary file from xunit tests

### DIFF
--- a/mcs/class/System.Data/System.Data_xtest.dll.sources
+++ b/mcs/class/System.Data/System.Data_xtest.dll.sources
@@ -119,7 +119,6 @@
 ../../../external/corefx/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/SSPI/SecResult.cs
 ../../../external/corefx/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/SSPI/SecurityHandle.cs
 ../../../external/corefx/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/SSPI/SecurityInteger.cs
-../../../external/corefx/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/SSPI/SecurityWrapper.cs
 ../../../external/corefx/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/SSPI/SSPIContext.Unix.cs
 ../../../external/corefx/src/System.Data.SqlClient/tests/Tools/TDS/TDS.EndPoint/SSPI/SSPIResponse.cs
 


### PR DESCRIPTION
It contained DllImports to some Windows APIs which causes issues on xamarin-macios which expects all pinvokes to exist.

Turns out we don't even need that file.
