### PR TITLE
Merge icall_hash and icall_hash_foreign into one.

### DIFF
--- a/mono/metadata/icall-internals.h
+++ b/mono/metadata/icall-internals.h
@@ -62,9 +62,8 @@ guint32
 mono_icall_drive_info_get_drive_type (MonoString *root_path_name);
 #endif  /* !G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT) */
 
-void*
+gconstpointer
 mono_lookup_internal_call_full (MonoMethod *method, gboolean warn_on_missing, mono_bool *uses_handles, mono_bool *foreign);
-
 
 MONO_PAL_API void
 mono_add_internal_call_with_flags (const char *name, const void* method, gboolean cooperative);
@@ -74,6 +73,16 @@ mono_add_internal_call_internal (const char *name, gconstpointer method);
 
 MonoAssembly*
 mono_runtime_get_caller_from_stack_mark (MonoStackCrawlMark *stack_mark);
+
+typedef enum {
+	MONO_ICALL_FLAGS_NONE = 0,
+	MONO_ICALL_FLAGS_FOREIGN = 1 << 1,
+	MONO_ICALL_FLAGS_USES_HANDLES = 1 << 2,
+	MONO_ICALL_FLAGS_COOPERATIVE = 1 << 3
+} MonoInternalCallFlags;
+
+gconstpointer
+mono_lookup_internal_call_full_with_flags (MonoMethod *method, gboolean warn_on_missing, guint32 *flags);
 
 #ifdef __cplusplus
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -2161,7 +2161,6 @@ compile_special (MonoMethod *method, MonoDomain *target_domain, MonoError *error
 
 	if ((method->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL) ||
 	    (method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL)) {
-		MonoMethod *nm;
 		MonoMethodPInvoke* piinfo = (MonoMethodPInvoke *) method;
 
 		if (!piinfo->addr) {
@@ -2179,9 +2178,11 @@ compile_special (MonoMethod *method, MonoDomain *target_domain, MonoError *error
 				mono_error_cleanup (ignored_error);
 			}
 		}
-		nm = mono_marshal_get_native_wrapper (method, TRUE, mono_aot_only);
+
+		MonoMethod *nm = mono_marshal_get_native_wrapper (method, TRUE, mono_aot_only);
 		gpointer compiled_method = mono_jit_compile_method_jit_only (nm, error);
 		return_val_if_nok (error, NULL);
+
 		code = mono_get_addr_from_ftnptr (compiled_method);
 		jinfo = mono_jit_info_table_find (target_domain, code);
 		if (!jinfo)

--- a/sdks/wasm/driver.c
+++ b/sdks/wasm/driver.c
@@ -38,7 +38,7 @@ void mono_free (void*);
 
 typedef struct {
 	int version;
-	void* (*lookup) (MonoMethod *method, char *classname, char *methodname, char *sigstart, uint8_t *uses_handles);
+	void* (*lookup) (MonoMethod *method, char *classname, char *methodname, char *sigstart, int32_t *uses_handles);
 	const char* (*lookup_icall_symbol) (void* func);
 } MonoIcallTableCallbacks;
 
@@ -196,7 +196,7 @@ compare_int (const void *k1, const void *k2)
 }
 
 static void*
-icall_table_lookup (MonoMethod *method, char *classname, char *methodname, char *sigstart, uint8_t *uses_handles)
+icall_table_lookup (MonoMethod *method, char *classname, char *methodname, char *sigstart, int32_t *uses_handles)
 {
 	uint32_t token = mono_method_get_token (method);
 	assert (token);


### PR DESCRIPTION
icalls registered with mono_add_internal_call, mono_add_internal_call_with_flags or mono_add_internal_call_internal ended up in two different hash tables depending if they were "foreign" or not. This caused double lookups in mono_lookup_internal_call_full. There are also use cases where it could be interesting to keep additional flags related to the icall, that could be used by codegen for various optimization.

This PR merge the two hash tables into one and add a flag describing icall details. The flag could later be extended with additional behaviors going forward if needed.
