### PR TITLE
TransactionScope now actually uses IsolationLevel that was specified …

### DIFF
--- a/mcs/class/System.Transactions/System.Transactions/CommittableTransaction.cs
+++ b/mcs/class/System.Transactions/System.Transactions/CommittableTransaction.cs
@@ -31,12 +31,14 @@ namespace System.Transactions
 		}
 
 		public CommittableTransaction (TimeSpan timeout)
+			: base (IsolationLevel.Serializable)
 		{
 			options = new TransactionOptions ();
 			options.Timeout = timeout;
 		}
 
 		public CommittableTransaction (TransactionOptions options)
+			: base (options.IsolationLevel)
 		{
 			this.options = options;
 		}

--- a/mcs/class/System.Transactions/System.Transactions/DependentTransaction.cs
+++ b/mcs/class/System.Transactions/System.Transactions/DependentTransaction.cs
@@ -21,6 +21,7 @@ namespace System.Transactions
 
 		internal DependentTransaction (Transaction parent,
 			DependentCloneOption option)
+			: base(parent.IsolationLevel)
 		{
 //			this.parent = parent;
 //			this.option = option;

--- a/mcs/class/System.Transactions/System.Transactions/SubordinateTransaction.cs
+++ b/mcs/class/System.Transactions/System.Transactions/SubordinateTransaction.cs
@@ -16,6 +16,7 @@ namespace System.Transactions
 	{
 		public SubordinateTransaction (IsolationLevel isoLevel,
 			ISimpleTransactionSuperior superior)
+			: base (isoLevel)
 		{
 			throw new NotImplementedException ();
 		}

--- a/mcs/class/System.Transactions/System.Transactions/Transaction.cs
+++ b/mcs/class/System.Transactions/System.Transactions/Transaction.cs
@@ -69,10 +69,10 @@ namespace System.Transactions
 
 		internal IPromotableSinglePhaseNotification Pspe { get { return pspe; } }
 
-		internal Transaction ()
+		internal Transaction (IsolationLevel isolationLevel)
 		{
 			info = new TransactionInformation ();
-			level = IsolationLevel.Serializable;
+			level = isolationLevel;
 		}
 
 		internal Transaction (Transaction other)

--- a/mcs/class/System.Transactions/System.Transactions/TransactionScope.cs
+++ b/mcs/class/System.Transactions/System.Transactions/TransactionScope.cs
@@ -138,14 +138,14 @@ namespace System.Transactions
 
 			oldTransaction = Transaction.CurrentInternal;
 
-			Transaction.CurrentInternal = transaction = InitTransaction (tx, scopeOption);
+			Transaction.CurrentInternal = transaction = InitTransaction (tx, scopeOption, options);
 			if (transaction != null)
 				transaction.InitScope (this);
 			if (parentScope != null)
 				parentScope.nested ++;
 		}
 
-		Transaction InitTransaction (Transaction tx, TransactionScopeOption scopeOption)
+		Transaction InitTransaction (Transaction tx, TransactionScopeOption scopeOption, TransactionOptions options)
 		{
 			if (tx != null)
 				return tx;
@@ -159,7 +159,7 @@ namespace System.Transactions
 			if (scopeOption == TransactionScopeOption.Required) {
 				if (Transaction.CurrentInternal == null) {
 					isRoot = true;
-					return new Transaction ();
+					return new Transaction (options.IsolationLevel);
 				}
 
 				parentScope = Transaction.CurrentInternal.Scope;
@@ -170,8 +170,8 @@ namespace System.Transactions
 			if (Transaction.CurrentInternal != null)
 				parentScope = Transaction.CurrentInternal.Scope;
 			isRoot = true;
-			return new Transaction ();
-		}
+			return new Transaction (options.IsolationLevel);
+        }
 
 		public void Complete ()
 		{

--- a/mcs/class/System.Transactions/Test/TransactionScopeTest.cs
+++ b/mcs/class/System.Transactions/Test/TransactionScopeTest.cs
@@ -1094,6 +1094,26 @@ namespace MonoTests.System.Transactions
 		}
 
 		#endregion
+
+		[Test]
+		public void DefaultIsolationLevel()
+		{
+			using (TransactionScope transactionScope = new TransactionScope(TransactionScopeOption.Required))
+			{
+				Assert.AreEqual(IsolationLevel.Serializable, Transaction.Current.IsolationLevel);
+			}
+		}
+		
+		[Test]
+		public void ExplicitIsolationLevel()
+		{
+			TransactionOptions transactionOptions = new TransactionOptions();
+			transactionOptions.IsolationLevel = IsolationLevel.ReadCommitted;
+			using (TransactionScope transactionScope = new TransactionScope(TransactionScopeOption.Required, transactionOptions))
+			{
+				Assert.AreEqual(IsolationLevel.ReadCommitted, Transaction.Current.IsolationLevel);
+			}
+		}
 	}
 
 }


### PR DESCRIPTION
…in TransactionOptions

Previously, using TransactionScope would always produce transactions
that use serializable isolation level even when user specified another
level (like ReadCommited).

fixes #13945



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
