### PR TITLE
Make nullable embedding API's public.

### DIFF
--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -855,7 +855,7 @@ mono_class_create_generic_inst (MonoGenericClass *gclass)
 		gclass_recorded_list = g_slist_append (gclass_recorded_list, klass);
 
 	if (mono_class_is_nullable (klass))
-		klass->cast_class = klass->element_class = mono_class_get_nullable_param (klass);
+		klass->cast_class = klass->element_class = mono_class_get_nullable_param_internal (klass);
 
 	MONO_PROFILER_RAISE (class_loading, (klass));
 

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1131,8 +1131,8 @@ MonoMethodSignature *mono_metadata_signature_deep_dup (MonoImage *image, MonoMet
 MONO_API void
 mono_image_init_name_cache (MonoImage *image);
 
-gboolean mono_class_is_nullable (MonoClass *klass);
-MonoClass *mono_class_get_nullable_param (MonoClass *klass);
+MonoClass*
+mono_class_get_nullable_param_internal (MonoClass *klass);
 
 /* object debugging functions, for use inside gdb */
 MONO_API void mono_object_describe        (MonoObject *obj);

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -1908,13 +1908,22 @@ mono_class_is_nullable (MonoClass *klass)
 	return gklass && gklass->container_class == mono_defaults.generic_nullable_class;
 }
 
-
 /** if klass is T? return T */
+MonoClass*
+mono_class_get_nullable_param_internal (MonoClass *klass)
+{
+	g_assert (mono_class_is_nullable (klass));
+	return mono_class_from_mono_type_internal (mono_class_get_generic_class (klass)->context.class_inst->type_argv [0]);
+}
+
 MonoClass*
 mono_class_get_nullable_param (MonoClass *klass)
 {
-       g_assert (mono_class_is_nullable (klass));
-       return mono_class_from_mono_type_internal (mono_class_get_generic_class (klass)->context.class_inst->type_argv [0]);
+	MonoClass *result = NULL;
+	MONO_ENTER_GC_UNSAFE;
+	result = mono_class_get_nullable_param_internal (klass);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
 }
 
 gboolean

--- a/mono/metadata/class.h
+++ b/mono/metadata/class.h
@@ -292,6 +292,12 @@ mono_method_can_access_field (MonoMethod *method, MonoClassField *field);
 MONO_API mono_bool
 mono_method_can_access_method (MonoMethod *method, MonoMethod *called);
 
+MONO_API mono_bool
+mono_class_is_nullable (MonoClass *klass);
+
+MONO_API MONO_RT_EXTERNAL_ONLY MonoClass*
+mono_class_get_nullable_param (MonoClass *klass);
+
 MONO_END_DECLS
 
 #endif /* _MONO_CLI_CLASS_H_ */

--- a/mono/metadata/verify.c
+++ b/mono/metadata/verify.c
@@ -3578,7 +3578,7 @@ do_box_value (VerifyContext *ctx, int klass_token)
 
 	klass = mono_class_from_mono_type_internal (type);
 	if (mono_class_is_nullable (klass))
-		type = m_class_get_byval_arg (mono_class_get_nullable_param (klass));
+		type = m_class_get_byval_arg (mono_class_get_nullable_param_internal (klass));
 	stack_push_val (ctx, TYPE_COMPLEX | BOXED_MASK, type);
 }
 

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -3795,7 +3795,7 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 
 			if (mono_class_is_nullable (klass)) {
 				MonoMethod *target_method;
-				if (m_class_is_enumtype (mono_class_get_nullable_param (klass)))
+				if (m_class_is_enumtype (mono_class_get_nullable_param_internal (klass)))
 					target_method = mono_class_get_method_from_name_checked (klass, "UnboxExact", 1, 0, error);
 				else
 					target_method = mono_class_get_method_from_name_checked (klass, "Unbox", 1, 0, error);
@@ -3832,7 +3832,7 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 				SET_TYPE (td->sp - 1, stack_type [mt], klass);
 			} else if (mono_class_is_nullable (klass)) {
 				MonoMethod *target_method;
-				if (m_class_is_enumtype (mono_class_get_nullable_param (klass)))
+				if (m_class_is_enumtype (mono_class_get_nullable_param_internal (klass)))
 					target_method = mono_class_get_method_from_name_checked (klass, "UnboxExact", 1, 0, error);
 				else
 					target_method = mono_class_get_method_from_name_checked (klass, "Unbox", 1, 0, error);

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -2974,7 +2974,7 @@ handle_unbox_nullable (MonoCompile* cfg, MonoInst* val, MonoClass* klass, int co
 {
 	MonoMethod* method;
 
-	if (m_class_is_enumtype (mono_class_get_nullable_param (klass)))
+	if (m_class_is_enumtype (mono_class_get_nullable_param_internal (klass)))
 		method = get_method_nofail (klass, "UnboxExact", 1, 0);
 	else
 		method = get_method_nofail (klass, "Unbox", 1, 0);


### PR DESCRIPTION
Currently we have two nullable API's that will have value in the public embedding API (already requestsed by users), eliminating the needs to go from native->managed and back to get nullable information about a type.

mono_class_is_nullable
mono_class_get_nullable_param

This PR moves them from class-internals.h into class.h and mark them with MONO_API and when needed include GC UNSAFE/SAFE transition..
