### PR TITLE
[2019-04] [corlib] Fix a few NSLogWriter issues.

### DIFF
--- a/mcs/class/corlib/System/Console.iOS.cs
+++ b/mcs/class/corlib/System/Console.iOS.cs
@@ -46,7 +46,11 @@ namespace System {
 			
 			public override void Flush ()
 			{
-				string s = sb.ToString ();
+				string s;
+				lock (sb) {
+					s = sb.ToString ();
+					sb.Length = 0;
+				}
 				try {
 					xamarin_log (s);
 				}
@@ -56,14 +60,14 @@ namespace System {
 						direct_write_to_stdout (Environment.NewLine);
 					} catch (Exception){}
 				}
-				sb.Length = 0;
 			}
 			
 			// minimum to override - see http://msdn.microsoft.com/en-us/library/system.io.textwriter.aspx
 			public override void Write (char value)
 			{
 				try {
-					sb.Append (value);
+					lock (sb)
+						sb.Append (value);
 				}
 				catch (Exception) {
 				}
@@ -73,9 +77,11 @@ namespace System {
 			public override void Write (string value)
 			{
 				try {
-					sb.Append (value);
-					if (value != null && value.Length >= CoreNewLine.Length && EndsWithNewLine (value))
-						Flush ();
+					lock (sb) {
+						sb.Append (value);
+						if (value != null && value.Length >= CoreNewLine.Length && EndsWithNewLine (value))
+							Flush ();
+					}
 				}
 				catch (Exception) {
 				}
@@ -84,9 +90,11 @@ namespace System {
 			/* Called from TextWriter:WriteLine(string) */
 			public override void Write(char[] buffer, int index, int count) {
 				try {
-					sb.Append (buffer);
-					if (buffer != null && buffer.Length >= CoreNewLine.Length && EndsWithNewLine (buffer))
-						Flush ();
+					lock (sb) {
+						sb.Append (buffer);
+						if (buffer != null && buffer.Length >= CoreNewLine.Length && EndsWithNewLine (buffer))
+							Flush ();
+					}
 				}
 				catch (Exception) {
 				}

--- a/mcs/class/corlib/System/Console.iOS.cs
+++ b/mcs/class/corlib/System/Console.iOS.cs
@@ -91,7 +91,7 @@ namespace System {
 			public override void Write(char[] buffer, int index, int count) {
 				try {
 					lock (sb) {
-						sb.Append (buffer);
+						sb.Append (buffer, index, count);
 						if (EndsWithNewLine (sb))
 							Flush ();
 					}

--- a/mcs/class/corlib/System/Console.iOS.cs
+++ b/mcs/class/corlib/System/Console.iOS.cs
@@ -79,7 +79,7 @@ namespace System {
 				try {
 					lock (sb) {
 						sb.Append (value);
-						if (value != null && value.Length >= CoreNewLine.Length && EndsWithNewLine (value))
+						if (EndsWithNewLine (sb))
 							Flush ();
 					}
 				}
@@ -92,7 +92,7 @@ namespace System {
 				try {
 					lock (sb) {
 						sb.Append (buffer);
-						if (buffer != null && buffer.Length >= CoreNewLine.Length && EndsWithNewLine (buffer))
+						if (EndsWithNewLine (sb))
 							Flush ();
 					}
 				}
@@ -100,18 +100,11 @@ namespace System {
 				}
 			}
 			
-			bool EndsWithNewLine (string value)
+			bool EndsWithNewLine (StringBuilder value)
 			{
-				for (int i = 0, v = value.Length - CoreNewLine.Length; i < CoreNewLine.Length; ++i, ++v) {
-					if (value [v] != CoreNewLine [i])
-						return false;
-				}
-				
-				return true;
-			}
+				if (value.Length < CoreNewLine.Length)
+					return false;
 
-			bool EndsWithNewLine (char[] value)
-			{
 				for (int i = 0, v = value.Length - CoreNewLine.Length; i < CoreNewLine.Length; ++i, ++v) {
 					if (value [v] != CoreNewLine [i])
 						return false;


### PR DESCRIPTION
* Make NSLogWriter thread-safe.
* Simplify newline checking in NSLogWriter.
* Fix NSLogWriter.Write to take into account the index and count parameters.

Backport of #13799.

/cc @lewurm @rolfbjarne