### PR TITLE
[aot] use g_malloc () instead of malloc ()

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -6159,7 +6159,7 @@ get_debug_sym (MonoMethod *method, const char *prefix, GHashTable *cache)
 #endif
 
 	len = strlen (name1);
-	name2 = (char *)malloc (strlen (prefix) + len + 16);
+	name2 = (char *) g_malloc (strlen (prefix) + len + 16);
 	memcpy (name2, prefix, strlen (prefix));
 	j = strlen (prefix);
 	for (i = 0; i < len; ++i) {


### PR DESCRIPTION
Unbreaks jemalloc support as it hooks into `g_malloc ()` instead of replacing `malloc ()`.

```
%4  0x000055ee6af0d27b in sigabrt_signal_handler (_dummy=6, _info=0x7ffc7b0c4ff0, context=0x7ffc7b0c4ec0) at mini-posix.c:232
%5  <signal handler called>
%6  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
%7  0x00007f4ae0d73801 in __GI_abort () at abort.c:79
%8  0x000055ee6b2ab6ed in rtree_child_leaf_tryread (elm=0x55ee6b75b028 <je_extents_rtree+704104>, dependent=true) at src/rtree.c:205
%9  0x000055ee6b2ab95f in je_rtree_leaf_elm_lookup_hard (tsdn=0x7f4ae1f05738, rtree=0x55ee6b6af1c0 <je_extents_rtree>, rtree_ctx=0x7f4ae1f05758, key=94482510772944, dependent=true, init_missing=false) at src/rtree.c:292
%10 0x000055ee6b242f70 in rtree_leaf_elm_lookup (tsdn=0x7f4ae1f05738, rtree=0x55ee6b6af1c0 <je_extents_rtree>, rtree_ctx=0x7f4ae1f05758, key=94482510772944, dependent=true, init_missing=false) at include/jemalloc/internal/rtree.h:369
%11 0x000055ee6b242fb5 in rtree_read (tsdn=0x7f4ae1f05738, rtree=0x55ee6b6af1c0 <je_extents_rtree>, rtree_ctx=0x7f4ae1f05758, key=94482510772944, dependent=true) at include/jemalloc/internal/rtree.h:394
%12 0x000055ee6b2431ee in rtree_szind_slab_read (tsdn=0x7f4ae1f05738, rtree=0x55ee6b6af1c0 <je_extents_rtree>, rtree_ctx=0x7f4ae1f05758, key=94482510772944, dependent=true, r_szind=0x7ffc7b0c6000, r_slab=0x7ffc7b0c6004) at include/jemalloc/internal/rtree.h:446
%13 0x000055ee6b24d468 in ifree (tsd=0x7f4ae1f05738, ptr=0x55ee6c7dfad0, tcache=0x7f4ae1f058f0, slow_path=true) at src/jemalloc.c:2126
%14 0x000055ee6b24de06 in mono_jefree (ptr=0x55ee6c7dfad0) at src/jemalloc.c:2290
%15 0x000055ee6b2c6c68 in monoeg_g_free (ptr=0x55ee6c7dfad0) at gmem.c:83
%16 0x000055ee6adefafa in emit_method_code (acfg=0x7f4ae0986000, cfg=0x7f4ae0ad4e00) at aot-compiler.c:6243
%17 0x000055ee6adf9534 in emit_code (acfg=0x7f4ae0986000) at aot-compiler.c:9704
%18 0x000055ee6ae04a9d in emit_aot_image (acfg=0x7f4ae0986000) at aot-compiler.c:13535
%19 0x000055ee6ae03b7c in mono_compile_assembly (ass=0x7f4ae09a9300, opts=374434303, aot_options=0x7f4ae093c000 "bind-to-runtime-version,outfile=./../../class/lib/build-linux//Microsoft.CodeAnalysis.CSharp.dll.so", global_aot_state=0x7ffc7b0c6438) at aot-compiler.c:13357

```

