### PR TITLE
[cil-strip] Fix reading of undefined NativeType values in old Cecil

### DIFF
--- a/mcs/tools/cil-strip/Mono.Cecil.Signatures/SignatureReader.cs
+++ b/mcs/tools/cil-strip/Mono.Cecil.Signatures/SignatureReader.cs
@@ -926,8 +926,8 @@ namespace Mono.Cecil.Signatures {
 
 		MarshalSig ReadMarshalSig (byte [] data)
 		{
-			int start;
-			MarshalSig ms = new MarshalSig ((NativeType) Utilities.ReadCompressedInteger (data, 0, out start));
+			MarshalSig ms = new MarshalSig ((NativeType) data[0]);
+			int start = 1;
 			switch (ms.NativeInstrinsic) {
 			case NativeType.ARRAY:
 				MarshalSig.Array ar = new MarshalSig.Array ();


### PR DESCRIPTION
cil-strip crashed when processing this method: https://github.com/mono/corefx/blob/f54e64b341a7b114c3502e197b46670cacb28639/src/Microsoft.CSharp/tests/DefaultParameterTests.cs#L88

It uses `MarshalAs((UnmanagedType)2000)`, i.e. an undefined value for the native type. The old Cecil embedded in cil-strip tried to read more than one byte which blows up in this case.

Upstream Cecil just reads a single byte:
https://github.com/jbevain/cecil/blob/1b79b96d29f1e8e9ba832191b1b42ea9cb750d20/Mono.Cecil/AssemblyReader.cs#L3700-L3703

Fixes https://github.com/mono/mono/issues/13639
