### PR TITLE
Make sure mini_method_is_default_method is in loaded LLVM

### DIFF
--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2705,7 +2705,7 @@ gboolean mini_is_gsharedvt_variable_klass (MonoClass *klass) MONO_LLVM_INTERNAL;
 gboolean mini_is_gsharedvt_sharable_method (MonoMethod *method);
 gboolean mini_is_gsharedvt_variable_signature (MonoMethodSignature *sig);
 gboolean mini_is_gsharedvt_sharable_inst (MonoGenericInst *inst);
-gboolean mini_method_is_default_method (MonoMethod *m);
+gboolean mini_method_is_default_method (MonoMethod *m) MONO_LLVM_INTERNAL;
 gboolean mini_method_needs_mrgctx (MonoMethod *m);
 gpointer mini_method_get_rgctx (MonoMethod *m);
 void mini_init_gsctx (MonoDomain *domain, MonoMemPool *mp, MonoGenericContext *context, MonoGenericSharingContext *gsctx);


### PR DESCRIPTION
mono: symbol lookup error: /usr/lib/libmono-llvm.so: undefined symbol: mini_method_is_default_method