### PR TITLE
[configure] Add failsafe for missing submodules

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,9 +25,8 @@ DIST_SUBDIRS = $(build_with_msvc) m4 mk po $(libgc_dir) llvm mono ikvm-native su
 
 all: update_submodules
 
-SUBMODULE_ERROR='Could not recursively update all git submodules. You may experience compilation problems if some submodules are out of date'
 update_submodules:
-	@$(srcdir)/scripts/update_submodules.sh
+	@cd $(srcdir) && scripts/update_submodules.sh
 
 .PHONY: update_submodules
 

--- a/scripts/update_submodules.sh
+++ b/scripts/update_submodules.sh
@@ -9,6 +9,6 @@ if test -e .git; then \
 fi
 
 if ! test -e external/corefx/README.md; then
-	echo "Couldn't find the required submodules. This usually happens when using an archive from GitHub instead of https://download.mono-project.com/sources/mono/, or something went wrong while updating submodules."
+	echo "Error: Couldn't find the required submodules. This usually happens when using an archive from GitHub instead of https://download.mono-project.com/sources/mono/, or something went wrong while updating submodules."
 	exit 1
 fi

--- a/scripts/update_submodules.sh
+++ b/scripts/update_submodules.sh
@@ -8,3 +8,7 @@ if test -e .git; then \
 	|| (echo 'Git submodules could not be updated. Compilation will fail') \
 fi
 
+if ! test -e external/corefx/README.md; then
+	echo "Couldn't find the required submodules. This usually happens when using an archive from GitHub instead of https://download.mono-project.com/sources/mono/, or something went wrong while updating submodules."
+	exit 1
+fi


### PR DESCRIPTION
GitHub provides a way to download a .zip/.tar.gz of the repository content in their UI, however the archive doesn't contain git submodules.

The mono build then fails with confusing "missing file" errors.

Since GitHub doesn't let us disable the archive download we should at least add some logic to detect this broken case and bail out.
