### PR TITLE
[windows] Link libgcc statically on Windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -171,7 +171,7 @@ case "$host" in
 		# Windows 7 or later is required
 		WIN32_CPPFLAGS="-DWINVER=0x0601 -D_WIN32_WINNT=0x0601 -D_WIN32_IE=0x0501 -D_UNICODE -DUNICODE -DWIN32_THREADS -DFD_SETSIZE=1024"
 		CPPFLAGS="$CPPFLAGS $WIN32_CPPFLAGS"
-		WIN32_LDFLAGS="-lbcrypt -lmswsock -lws2_32 -lole32 -loleaut32 -lpsapi -lversion -ladvapi32 -lwinmm -lkernel32 -liphlpapi"
+		WIN32_LDFLAGS="-lbcrypt -lmswsock -lws2_32 -lole32 -loleaut32 -lpsapi -lversion -ladvapi32 -lwinmm -lkernel32 -liphlpapi -static-libgcc"
 		LDFLAGS="$LDFLAGS $WIN32_LDFLAGS"
 		libmono_cflags="-mms-bitfields -mwindows"
 		libmono_ldflags="-mms-bitfields -mwindows"


### PR DESCRIPTION
Mono currently uses `__builtin_popcount[ll]` functions. On older processor architectures the popcount operations are implemented using software fallback in libgcc library. On MinGW this happens to pull in dependency on two dynamic libraries (libgcc_s_seh-1.dll and transitively libwinpthread-1.dll). These two libraries are together ~130 Kb of code that is pulled in because of ~12 bytes of one function. Linking statically to libgcc reduces the overhead to 4Kb in debug build (page size aligned) and simplifies the deployment because the resulting binary has no external dependencies.