### PR TITLE
[netcore] Fix `make dist`

### DIFF
--- a/mcs/class/System.Private.CoreLib/Makefile.am
+++ b/mcs/class/System.Private.CoreLib/Makefile.am
@@ -5,5 +5,7 @@ SUBDIRS =
 all-local:
 	dotnet build @CORETARGETS@ -p:BuildArch=@COREARCH@ -p:OutputPath=bin/@COREARCH@ -p:FeaturePortableTimer=true System.Private.CoreLib.csproj
 
+dist-recursive: dist-local
+
 dist-local:
 	@:


### PR DESCRIPTION
```
make[5]: Entering directory `/mnt/jenkins/workspace/build-source-tarball-mono/mcs/class/System.Private.CoreLib'
make[5]: Leaving directory `/mnt/jenkins/workspace/build-source-tarball-mono/mcs/class/System.Private.CoreLib'

make[5]: *** No rule to make target `dist-recursive'.  Stop.
make[4]: *** [dist-recursive] Error 1
```

dist-recursive is missing because we don't use rules.make because it totally breaks the world when fed through autotools, in the case of this one specific assembly.