### PR TITLE
Cleaning exceptions during static constructor loading

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -471,10 +471,13 @@ mono_runtime_class_init_full (MonoVTable *vtable, MonoError *error)
 		return TRUE;
 	}
 	if (vtable->init_failed) {
-		mono_type_initialization_unlock ();
-
 		/* The type initialization already failed once, rethrow the same exception */
-		mono_error_set_exception_instance (error, get_type_init_exception_for_vtable (vtable));
+		MonoException *exp = get_type_init_exception_for_vtable (vtable);
+		/* Reset the stack_trace and trace_ips because the exception is reused */
+		exp->stack_trace = NULL;
+		exp->trace_ips = NULL;
+		mono_type_initialization_unlock ();
+		mono_error_set_exception_instance (error, exp);
 		return FALSE;
 	}
 	lock = (TypeInitializationLock *)g_hash_table_lookup (type_initialization_hash, vtable);

--- a/mono/tests/exception.cs
+++ b/mono/tests/exception.cs
@@ -1,9 +1,42 @@
 using System;
+using System.Reflection;
+public static class Test
+{
+	static Test ()
+	{
+		throw new ApplicationException ();
+	}
 
+	public static void Foo ()
+	{
+		
+	}
+}
 public class Ex {
 
 	int p;
-	
+	public static int test2 () {
+		var m = typeof (Test).GetMethod ("Foo");
+		int lenStackTrace = 0;
+		try
+		{
+			m.Invoke (null, null);
+		}
+		catch (Exception e)
+		{
+			lenStackTrace = e.ToString().Length;
+		}
+		try
+		{
+			m.Invoke (null, null);
+		}
+		catch (Exception e)
+		{	
+			if (lenStackTrace == e.ToString().Length)
+				return 0;
+		}
+		return 1;
+	}
 	public static int test1 () {
                 Ex x = null;
 		
@@ -42,7 +75,8 @@ public class Ex {
 			return 2;
 		if (test1() != 0)
 			return 3;
-		
+		if (test2() != 0)
+			return 4;
 		return 0;
 	}
 }


### PR DESCRIPTION
Reset the stack_trace and trace_ips because the type initialization exception is reused.
Fixes #13714