### PR TITLE
[wasm] Revert Update to emscripten 1.38.30 

### DIFF
--- a/sdks/builds/wasm.mk
+++ b/sdks/builds/wasm.mk
@@ -1,7 +1,7 @@
 #emcc has lots of bash'isms
 SHELL:=/bin/bash
 
-EMSCRIPTEN_VERSION=1.38.30
+EMSCRIPTEN_VERSION=1.38.29
 EMSCRIPTEN_SDK_DIR=$(TOP)/sdks/builds/toolchains/emsdk
 
 $(TOP)/sdks/builds/toolchains/emsdk:


### PR DESCRIPTION
This reverts the update for PR: https://github.com/mono/mono/pull/13759

- 1.38.30 is still not available for mac.
- Works on Build CI.
