### PR TITLE
[2019-02] [profiler] Add duration=NUM parameter to AOT profiler (#13688)

### DIFF
--- a/man/mono-profilers.1
+++ b/man/mono-profilers.1
@@ -335,6 +335,9 @@ format.
 .SS Options
 The AOT profiler supports the following options:
 .TP
+\fBduration\fR=\fInum\fR
+Profile only NUM seconds of runtime and then write the data.
+.TP
 \fBhelp\fR
 Print usage instructions.
 .TP

--- a/mono/profiler/aot.c
+++ b/mono/profiler/aot.c
@@ -57,12 +57,12 @@ prof_shutdown (MonoProfiler *prof);
 static void
 usage (void)
 {
-	mono_profiler_printf ("AOT profiler.\n");
+	mono_profiler_printf ("AOT profiler.");
 	mono_profiler_printf ("Usage: mono --profile=aot[:OPTION1[,OPTION2...]] program.exe\n");
-	mono_profiler_printf ("Options:\n");
-	mono_profiler_printf ("\thelp                 show this usage info\n");
-	mono_profiler_printf ("\toutput=FILENAME      write the data to file FILENAME\n");
-	mono_profiler_printf ("\tverbose              print diagnostic info\n");
+	mono_profiler_printf ("Options:");
+	mono_profiler_printf ("\thelp                 show this usage info");
+	mono_profiler_printf ("\toutput=FILENAME      write the data to file FILENAME");
+	mono_profiler_printf ("\tverbose              print diagnostic info");
 
 	exit (0);
 }
@@ -395,7 +395,7 @@ add_method (MonoProfiler *prof, MonoMethod *m)
 	g_free (s);
 
 	if (prof->verbose)
-		mono_profiler_printf ("%s %d\n", mono_method_full_name (m, 1), id);
+		mono_profiler_printf ("%s %d", mono_method_full_name (m, 1), id);
 }
 
 /* called at the end of the program */


### PR DESCRIPTION
Backport of https://github.com/mono/mono/pull/13688 & https://github.com/mono/mono/pull/13060



[profiler] Add duration=NUM parameter to AOT profiler (#13688)

* [profiler] Add duration=NUM parameter to AOT profiler

It instructs the AOT profiler to write the data after NUM seconds
measured from runtime initialization.

* [profilers] Added aot:duration=NUM parameter description

 [profiler] Do not print that many new lines (#13060)

The `mono_profiler_printf` already adds `\n` char, so we don't need to
add them in most cases.

Before the fix the output of aot profiler with verbose enabled looked
like:

    02-19 10:50:02.877 22795 22815 I mono-prof: System.OutOfMemoryException:.ctor (string) 2
    02-19 10:50:02.877 22795 22815 I mono-prof:
    02-19 10:50:02.877 22795 22815 I mono-prof: System.SystemException:.ctor (string) 4
    02-19 10:50:02.877 22795 22815 I mono-prof:
    02-19 10:50:02.877 22795 22815 I mono-prof: System.Exception:.ctor (string) 6
    02-19 10:50:02.877 22795 22815 I mono-prof:
    02-19 10:50:02.877 22795 22815 I mono-prof: System.Exception:.cctor () 7
    02-19 10:50:02.877 22795 22815 I mono-prof:
    ...

The `usage ()`'s output should now look similar to other profilers
usage output.