### PR TITLE
[netcore] hand-craft a dist-recursive rule for System.Private.CoreLib

### DIFF
--- a/mcs/class/System.Private.CoreLib/Makefile.am
+++ b/mcs/class/System.Private.CoreLib/Makefile.am
@@ -2,10 +2,16 @@ thisdir = class/System.Private.CoreLib
 SUBDIRS =
 #include ../../build/rules.make
 
+dirs := $(dir $(wildcard */*))
+files := $(wildcard */*.cs)
+
 all-local:
 	dotnet build @CORETARGETS@ -p:BuildArch=@COREARCH@ -p:OutputPath=bin/@COREARCH@ -p:FeaturePortableTimer=true System.Private.CoreLib.csproj
 
-dist-recursive: dist-local
-
-dist-local:
-	@:
+dist-recursive:
+	$(mkdir_p) $(distdir)
+	cp -a Makefile.am $(distdir)
+	cp -a Makefile.in $(distdir)
+	cp -a *.csproj $(distdir)
+	for i in $(dirs); do $(mkdir_p) $(distdir)/$$i; done
+	for i in $(files); do cp -a $$i $(distdir)/$$i; done


### PR DESCRIPTION
`make dist` stopped erroring in #13961 but didn't actually work, because the relevant Makefile.am was not distributed, causing configure to fail (because the Makefile.am was cited as an input, unconditionally).

We can't rely on the dist-recusrive from library.make or build.make because this lib is in a weirdo format which doesn't comply with the requirements of those helpers, so craft a simple handwritten replacement for our special case