### PR TITLE
[2019-02] Remove TypedReference.MakeTypedReference readonly restriction

### DIFF
--- a/mcs/class/referencesource/mscorlib/system/typedreference.cs
+++ b/mcs/class/referencesource/mscorlib/system/typedreference.cs
@@ -56,7 +56,7 @@ namespace System {
                 if (field == null)
                     throw new ArgumentException(Environment.GetResourceString("Argument_MustBeRuntimeFieldInfo"));
 
-                if (field.IsInitOnly || field.IsStatic)
+                if (field.IsStatic)
                     throw new ArgumentException(Environment.GetResourceString("Argument_TypedReferenceInvalidField"));
                 
                 if (targetType != field.GetDeclaringTypeInternal() && !targetType.IsSubclassOf(field.GetDeclaringTypeInternal()))


### PR DESCRIPTION
Fixes #13162

Backport of #13991.

/cc @marek-safar