### PR TITLE
[sdks] Include 'etc/mono/config'

### DIFF
--- a/sdks/builds/runtime.mk
+++ b/sdks/builds/runtime.mk
@@ -87,6 +87,9 @@ setup-custom-$(1)-$(2):
 package-$(1)-$(2):
 	$$(MAKE) -C $$(TOP)/sdks/builds/$(1)-$(2)-$$(CONFIGURATION)/mono install
 	$$(MAKE) -C $$(TOP)/sdks/builds/$(1)-$(2)-$$(CONFIGURATION)/support install
+	mkdir -p $$(TOP)/sdks/out/$(1)-$(2)-$$(CONFIGURATION)/etc/mono
+	cp $$(TOP)/sdks/builds/$(1)-$(2)-$$(CONFIGURATION)/data/config $$(TOP)/sdks/out/$(1)-$(2)-$$(CONFIGURATION)/etc/mono
+
 
 .PHONY: clean-$(1)-$(2)
 clean-$(1)-$(2):


### PR DESCRIPTION
Still not 100% this will be the final approach - while getting the config file from the archive takes care of the proper name of `libmono-native` as well as the libary suffix, this also uses `$mono_libdir` which I am not sure I can make work on the Xamarin Android side.