### PR TITLE
Protecting boxing a null value

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection/MethodInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/MethodInfoTest.cs
@@ -658,6 +658,15 @@ namespace MonoTests.System.Reflection
 			Assert.AreEqual (10, pi2.GetGetMethod ().Invoke (10, null));
 		}
 
+		[Test]
+		public void NullableTestsStatic ()
+		{
+			Nullable<Double> val = new Nullable<Double>(new Double());
+			MethodInfo mi = typeof (Nullable<Double>).GetMethod ("op_Implicit");
+            object obj = val;
+            mi.Invoke(null, new[] { obj });
+		}
+
 		public static void foo_generic<T> ()
 		{
 		}

--- a/mcs/class/corlib/Test/System.Reflection/MethodInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/MethodInfoTest.cs
@@ -663,8 +663,8 @@ namespace MonoTests.System.Reflection
 		{
 			Nullable<Double> val = new Nullable<Double>(new Double());
 			MethodInfo mi = typeof (Nullable<Double>).GetMethod ("op_Implicit");
-            object obj = val;
-            mi.Invoke(null, new[] { obj });
+			object obj = val;
+			mi.Invoke(null, new[] { obj });
 		}
 
 		public static void foo_generic<T> ()

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -6941,7 +6941,6 @@ mono_value_box_handle (MonoDomain *domain, MonoClass *klass, gpointer value, Mon
 	if (mono_class_is_nullable (klass))
 		return mono_nullable_box_handle (value, klass, error);
 
-	
 	vtable = mono_class_vtable_checked (domain, klass, error);
 	return_val_if_nok (error, NULL_HANDLE);
 
@@ -6951,7 +6950,6 @@ mono_value_box_handle (MonoDomain *domain, MonoClass *klass, gpointer value, Mon
 	return_val_if_nok (error, NULL_HANDLE);
 
 	size -= MONO_ABI_SIZEOF (MonoObject);
-	
 	if (mono_gc_is_moving ()) {
 		g_assert (size == mono_class_value_size (klass, NULL));
 		MONO_ENTER_NO_SAFEPOINTS;
@@ -6983,7 +6981,6 @@ mono_value_box_handle (MonoDomain *domain, MonoClass *klass, gpointer value, Mon
 #endif
 		MONO_EXIT_NO_SAFEPOINTS;
 	}
-
 	if (m_class_has_finalize (klass))
 		mono_object_register_finalizer_handle (res_handle);
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -6946,37 +6946,38 @@ mono_value_box_handle (MonoDomain *domain, MonoClass *klass, gpointer value, Mon
 	return_val_if_nok (error, NULL_HANDLE);
 
 	size -= MONO_ABI_SIZEOF (MonoObject);
-
-	if (mono_gc_is_moving ()) {
-		g_assert (size == mono_class_value_size (klass, NULL));
-		MONO_ENTER_NO_SAFEPOINTS;
-		gpointer data = mono_handle_get_data_unsafe (res_handle);
-		mono_gc_wbarrier_value_copy_internal (data, value, 1, klass);
-		MONO_EXIT_NO_SAFEPOINTS;
-	} else {
-		MONO_ENTER_NO_SAFEPOINTS;
-		gpointer data = mono_handle_get_data_unsafe (res_handle);
-#if NO_UNALIGNED_ACCESS
-		mono_gc_memmove_atomic (data, value, size);
-#else
-		switch (size) {
-		case 1:
-			*(guint8*)data = *(guint8 *) value;
-			break;
-		case 2:
-			*(guint16 *)(data) = *(guint16 *) value;
-			break;
-		case 4:
-			*(guint32 *)(data) = *(guint32 *) value;
-			break;
-		case 8:
-			*(guint64 *)(data) = *(guint64 *) value;
-			break;
-		default:
+	if (value != NULL) { 
+		if (mono_gc_is_moving ()) {
+			g_assert (size == mono_class_value_size (klass, NULL));
+			MONO_ENTER_NO_SAFEPOINTS;
+			gpointer data = mono_handle_get_data_unsafe (res_handle);
+			mono_gc_wbarrier_value_copy_internal (data, value, 1, klass);
+			MONO_EXIT_NO_SAFEPOINTS;
+		} else {
+			MONO_ENTER_NO_SAFEPOINTS;
+			gpointer data = mono_handle_get_data_unsafe (res_handle);
+	#if NO_UNALIGNED_ACCESS
 			mono_gc_memmove_atomic (data, value, size);
+	#else
+			switch (size) {
+			case 1:
+				*(guint8*)data = *(guint8 *) value;
+				break;
+			case 2:
+				*(guint16 *)(data) = *(guint16 *) value;
+				break;
+			case 4:
+				*(guint32 *)(data) = *(guint32 *) value;
+				break;
+			case 8:
+				*(guint64 *)(data) = *(guint64 *) value;
+				break;
+			default:
+				mono_gc_memmove_atomic (data, value, size);
+			}
+	#endif
+			MONO_EXIT_NO_SAFEPOINTS;
 		}
-#endif
-		MONO_EXIT_NO_SAFEPOINTS;
 	}
 	if (m_class_has_finalize (klass))
 		mono_object_register_finalizer_handle (res_handle);

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -6937,6 +6937,10 @@ mono_value_box_handle (MonoDomain *domain, MonoClass *klass, gpointer value, Mon
 	if (mono_class_is_nullable (klass))
 		return mono_nullable_box_handle (value, klass, error);
 
+	if (!value) {
+		return NULL_HANDLE;
+	}
+	
 	vtable = mono_class_vtable_checked (domain, klass, error);
 	return_val_if_nok (error, NULL_HANDLE);
 
@@ -6946,39 +6950,39 @@ mono_value_box_handle (MonoDomain *domain, MonoClass *klass, gpointer value, Mon
 	return_val_if_nok (error, NULL_HANDLE);
 
 	size -= MONO_ABI_SIZEOF (MonoObject);
-	if (value != NULL) { 
-		if (mono_gc_is_moving ()) {
-			g_assert (size == mono_class_value_size (klass, NULL));
-			MONO_ENTER_NO_SAFEPOINTS;
-			gpointer data = mono_handle_get_data_unsafe (res_handle);
-			mono_gc_wbarrier_value_copy_internal (data, value, 1, klass);
-			MONO_EXIT_NO_SAFEPOINTS;
-		} else {
-			MONO_ENTER_NO_SAFEPOINTS;
-			gpointer data = mono_handle_get_data_unsafe (res_handle);
-	#if NO_UNALIGNED_ACCESS
+	
+	if (mono_gc_is_moving ()) {
+		g_assert (size == mono_class_value_size (klass, NULL));
+		MONO_ENTER_NO_SAFEPOINTS;
+		gpointer data = mono_handle_get_data_unsafe (res_handle);
+		mono_gc_wbarrier_value_copy_internal (data, value, 1, klass);
+		MONO_EXIT_NO_SAFEPOINTS;
+	} else {
+		MONO_ENTER_NO_SAFEPOINTS;
+		gpointer data = mono_handle_get_data_unsafe (res_handle);
+#if NO_UNALIGNED_ACCESS
+		mono_gc_memmove_atomic (data, value, size);
+#else
+		switch (size) {
+		case 1:
+			*(guint8*)data = *(guint8 *) value;
+			break;
+		case 2:
+			*(guint16 *)(data) = *(guint16 *) value;
+			break;
+		case 4:
+			*(guint32 *)(data) = *(guint32 *) value;
+			break;
+		case 8:
+			*(guint64 *)(data) = *(guint64 *) value;
+			break;
+		default:
 			mono_gc_memmove_atomic (data, value, size);
-	#else
-			switch (size) {
-			case 1:
-				*(guint8*)data = *(guint8 *) value;
-				break;
-			case 2:
-				*(guint16 *)(data) = *(guint16 *) value;
-				break;
-			case 4:
-				*(guint32 *)(data) = *(guint32 *) value;
-				break;
-			case 8:
-				*(guint64 *)(data) = *(guint64 *) value;
-				break;
-			default:
-				mono_gc_memmove_atomic (data, value, size);
-			}
-	#endif
-			MONO_EXIT_NO_SAFEPOINTS;
 		}
+#endif
+		MONO_EXIT_NO_SAFEPOINTS;
 	}
+
 	if (m_class_has_finalize (klass))
 		mono_object_register_finalizer_handle (res_handle);
 


### PR DESCRIPTION
Trying to box a null value crashes inside mono_gc_wbarrier_value_copy_internal. As described by the customer using version 5.18.0.240 the crash doesn't happen.

As I could debug using this version doesn't crash only because is ignoring the SIGSEGV, when I attach to LLDB I can see the same crash in both versions.
I protected to only add data to res_handle if there is a valid value.
Fixes #13969

