### PR TITLE
Remove redundant check of llvm_acfg->aot_opts.direct_icalls.

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -9355,7 +9355,7 @@ mono_aot_get_direct_call_symbol (MonoJumpInfoType type, gconstpointer data)
 		} else if (type == MONO_PATCH_INFO_JIT_ICALL) {
 			MonoJitICallInfo *info = mono_find_jit_icall_by_name ((const char*)data);
 			const char *name = mono_lookup_jit_icall_symbol ((const char*)data);
-			if (name && llvm_acfg->aot_opts.direct_icalls && info->func == info->wrapper)
+			if (name && info->func == info->wrapper)
 				sym = name;
 		}
 		if (sym)


### PR DESCRIPTION
It is checked just a few lines earlier.