### PR TITLE
[netcore] Do not inline if [DynamicSecurityMethod] exists

### DIFF
--- a/mcs/class/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/mcs/class/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -229,7 +229,6 @@
       <Compile Include="..\corlib\Mono\RuntimeHandles.cs" />
       <Compile Include="..\corlib\Mono\SafeStringMarshal.cs" />
       <Compile Include="..\corlib\Mono\SafeGPtrArrayHandle.cs" />
-      <Compile Include="..\corlib\Mono.Security\Uri.cs" />
 
       <Compile Include="..\corlib\System\ArgIterator.cs" />
       <Compile Include="..\corlib\System\EmptyArray.cs" />

--- a/mcs/class/System.Private.CoreLib/System.Reflection/AssemblyName.cs
+++ b/mcs/class/System.Private.CoreLib/System.Reflection/AssemblyName.cs
@@ -34,8 +34,11 @@ namespace System.Reflection
 
 		unsafe byte [] ComputePublicKeyToken ()
 		{
+			if (_publicKey == null || _publicKey.Length == 0)
+				return Array.Empty<byte>();
+				
 			var token = new byte [8];
-			fixed (byte* pkt = _publicKeyToken)
+			fixed (byte* pkt = token)
 			fixed (byte *pk = _publicKey)
 				get_public_token (pkt, pk, _publicKey.Length);
 			return token;

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -3760,7 +3760,7 @@ mono_method_check_inlining (MonoCompile *cfg, MonoMethod *method)
 	    header.has_clauses)
 		return FALSE;
 
-	if (cfg->method->flags & METHOD_ATTRIBUTE_REQSECOBJ)
+	if (method->flags & METHOD_ATTRIBUTE_REQSECOBJ)
 		/* Used to mark methods containing StackCrawlMark locals */
 		return FALSE;
 


### PR DESCRIPTION
I think it's just a typo made in https://github.com/mono/mono/pull/13906

I tried to run System.Runtime.Tests on top of the fresh master and I got:
```
Method 'void Xunit.DiaSession:.cctor ()' which contains a StackCrawlMark local variable must be decorated with [System.Security.DynamicSecurityMethod].
```
so I suspect one of the `Type.GetType` was inlined despite the `[DynamicSecurityMethod]` attribute.

However after this fix I am getting:
```
System.InvalidOperationException: Could not find/load any of the following assemblies: xunit.execution.dotnet.dll
```

**UPD**: Applying @filipnavara's fix for the `InvalidOperationException` (missing null-check in CompurePublickKey).

cc: @filipnavara 