### PR TITLE
[wasm] [packager] Run mono-cil-strip from wasm-tools

### DIFF
--- a/mcs/tools/Makefile
+++ b/mcs/tools/Makefile
@@ -63,7 +63,7 @@ monotouch_tools_PARALLEL_SUBDIRS = corcompare mono-api-html
 net_4_x_SUBDIRS =
 net_4_x_PARALLEL_SUBDIRS = $(net_4_5_dirs)
 wasm_tools_SUBDIRS =
-wasm_tools_PARALLEL_SUBDIRS = linker wasm-tuner
+wasm_tools_PARALLEL_SUBDIRS = linker wasm-tuner cil-strip
 
 DIST_SUBDIRS = $(net_4_5_dirs) cil-stringreplacer commoncryptogenerator resx2sr gensources upload-to-sentry mono-helix-client
 

--- a/mcs/tools/cil-strip/mono-cil-strip.csproj
+++ b/mcs/tools/cil-strip/mono-cil-strip.csproj
@@ -33,6 +33,11 @@
     <IntermediateOutputPath>./../../class/obj/$(AssemblyName)-monodroid_tools</IntermediateOutputPath>
     <DefineConstants>NET_4_6;MONO;MONODROID_TOOLS;WIN_PLATFORM</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Platform)' == 'wasm_tools' ">
+    <OutputPath>./../../class/lib/wasm_tools</OutputPath>
+    <IntermediateOutputPath>./../../class/obj/$(AssemblyName)-wasm_tools</IntermediateOutputPath>
+    <DefineConstants>NET_4_6;MONO;WASM_TOOLS</DefineConstants>
+  </PropertyGroup>
   <!-- @ALL_PROFILE_PROPERTIES@ -->
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>

--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -125,6 +125,9 @@ bcl:
 tuner:
 	$(MAKE) -C ../../mcs/tools/wasm-tuner PROFILE=wasm_tools
 
+cil-strip:
+	$(MAKE) -C ../../mcs/tools/cil-strip  PROFILE=wasm_tools
+
 mono: runtime cross bcl
 
 BCL_DEPS=/r:$(WASM_BCL_DIR)/mscorlib.dll /r:$(WASM_BCL_DIR)/System.Core.dll /r:$(WASM_BCL_DIR)/System.dll /r:$(WASM_BCL_DIR)/System.Net.Http.dll /r:$(WASM_BCL_DIR)/Facades/netstandard.dll 

--- a/sdks/wasm/packager.cs
+++ b/sdks/wasm/packager.cs
@@ -708,7 +708,7 @@ class Driver {
 		ninja.WriteLine ("rule gen-icall-table");
 		ninja.WriteLine ("  command = mono $tools_dir/wasm-tuner.exe --gen-icall-table $runtime_table $in > $out");
 		ninja.WriteLine ("rule ilstrip");
-		ninja.WriteLine ("  command = cp $in $out; mono-cil-strip $out");
+		ninja.WriteLine ("  command = cp $in $out; $tools_dir/mono-cil-strip $out");
 		ninja.WriteLine ("  description = [IL-STRIP]");
 
 		// Targets

--- a/sdks/wasm/packager.cs
+++ b/sdks/wasm/packager.cs
@@ -708,7 +708,7 @@ class Driver {
 		ninja.WriteLine ("rule gen-icall-table");
 		ninja.WriteLine ("  command = mono $tools_dir/wasm-tuner.exe --gen-icall-table $runtime_table $in > $out");
 		ninja.WriteLine ("rule ilstrip");
-		ninja.WriteLine ("  command = cp $in $out; $tools_dir/mono-cil-strip $out");
+		ninja.WriteLine ("  command = cp $in $out; mono $tools_dir/mono-cil-strip.exe $out");
 		ninja.WriteLine ("  description = [IL-STRIP]");
 
 		// Targets


### PR DESCRIPTION
- Build, package and deliver `mono-cil-strip` in the mono `wasm_tools` to be used without relying on it being installed on the host system.
- Use the `mono-cil-strip` from the `wasm_tools` directory same as `monolinker.exe` and `wasm-tuner`.