### PR TITLE
Work towards removing JIT icall hashing.

### DIFF
--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -390,6 +390,8 @@ common_sources = \
 	w32handle.c	\
 	w32error.h	\
 	reflection.c	\
+	register-icall-def.c \
+	register-icall-def.h \
 	dynamic-image.c	\
 	sre.c	\
 	sre-encode.c	\

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -41,6 +41,7 @@
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/unlocked.h>
 #include <mono/metadata/icall-decl.h>
+#include "register-icall-def.h"
 
 #if HAVE_BOEHM_GC
 

--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -583,6 +583,7 @@ typedef struct {
 	MonoMethodSignature *sig;
 	const char *c_symbol;
 	MonoMethod *wrapper_method;
+	gboolean inited;
 } MonoJitICallInfo;
 
 void
@@ -1067,25 +1068,25 @@ MONO_API gboolean
 mono_metadata_load_generic_param_constraints_checked (MonoImage *image, guint32 token,
 					      MonoGenericContainer *container, MonoError *error);
 
-MonoJitICallInfo *
-mono_register_jit_icall (gconstpointer func, const char *name, MonoMethodSignature *sig, gboolean is_save);
+void
+mono_register_jit_icall_info (MonoJitICallInfo *info, gconstpointer func, const char *name, MonoMethodSignature *sig, gboolean is_save);
 
-MonoJitICallInfo *
-mono_register_jit_icall_full (gconstpointer func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper, const char *c_symbol);
+void
+mono_register_jit_icall_info_full (MonoJitICallInfo *info, gconstpointer func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper, const char *c_symbol);
 
 #ifdef __cplusplus
 template <typename T>
-inline MonoJitICallInfo *
-mono_register_jit_icall (T func, const char *name, MonoMethodSignature *sig, gboolean is_save)
+inline void
+mono_register_jit_icall_info (MonoJitICallInfo *info, T func, const char *name, MonoMethodSignature *sig, gboolean is_save)
 {
-	return mono_register_jit_icall ((gconstpointer)func, name, sig, is_save);
+	mono_register_jit_icall_info (info, (gconstpointer)func, name, sig, is_save);
 }
 
 template <typename T>
-inline MonoJitICallInfo *
-mono_register_jit_icall_full (T func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper, const char *c_symbol)
+inline void
+mono_register_jit_icall_info_full (MonoJitICallInfo *info, T func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper, const char *c_symbol)
 {
-	return mono_register_jit_icall_full ((gconstpointer)func, name, sig, no_wrapper, c_symbol);
+	mono_register_jit_icall_info_full (info, (gconstpointer)func, name, sig, no_wrapper, c_symbol);
 }
 #endif // __cplusplus
 
@@ -1098,8 +1099,48 @@ mono_find_jit_icall_by_name (const char *name) MONO_LLVM_INTERNAL;
 MonoJitICallInfo *
 mono_find_jit_icall_by_addr (gconstpointer addr) MONO_LLVM_INTERNAL;
 
-GHashTable*
-mono_get_jit_icall_info (void);
+// Provide info-less signatures that provide info via token pasting.
+//
+// Name parametere reduces diff, feeds assert, and can be removed later.
+#define register_icall_with_wrapper(func, name, sig) do { 	\
+	g_assert (!strcmp (#func, name)); 							\
+	register_icall_info_with_wrapper ((&mono_jit_icall_info.func), (func), (#func), (sig)); \
+} while (0)
+
+// Name parametere reduces diff, feeds assert, and can be removed later.
+#define register_icall(func, name, sig, no_wrapper) do {	\
+	g_assert (!strcmp (#func, name)); 							\
+	register_icall_info ((&mono_jit_icall_info.func), (func), (#func), (sig), (no_wrapper)); \
+} while (0)
+
+// Name parametere reduces diff, feeds assert, and can be removed later.
+#define register_icall_no_wrapper(func, name, sig) do { \
+	g_assert (!strcmp (#func, name)); 							\
+	register_icall_info_no_wrapper ((&mono_jit_icall_info.func), (func), (#func), (sig)); \
+} while (0)
+
+// Some register_jit_icall_not_full pass NULL as last parameter, some pass name.
+// Name parametere reduces diff, feeds assert, and can be removed later.
+#define mono_register_jit_icall(func, name, sig, avoid_wrapper) do { \
+	g_assert (!strcmp (#func, name)); 							\
+	mono_register_jit_icall_info ((&mono_jit_icall_info.func), (func), (#func), (sig), (avoid_wrapper)); \
+} while (0)
+
+// Name parametere reduces diff, feeds assert, and can be removed later.
+#define mono_register_jit_icall_full(func, name, sig, avoid_wrapper, c_symbol) do { \
+	g_assert (!strcmp (#func, name)); 							\
+	mono_register_jit_icall_info_full ((&mono_jit_icall_info.func), (func), (#func), (sig), (avoid_wrapper), (c_symbol)); \
+} while (0)
+
+/*
+ * Register an icall where FUNC is dynamically generated or otherwise not
+ * possible to link to it using NAME during AOT.
+ */
+#define register_dyn_icall(expr, name, sig, no_wrapper) \
+	(mono_register_jit_icall_info_full ((&mono_jit_icall_info.name), (expr), #name, (sig), (no_wrapper), NULL))
+
+MonoJitICallInfo *
+mono_find_jit_icall_by_addr (gconstpointer addr) MONO_LLVM_INTERNAL;
 
 const char*
 mono_lookup_jit_icall_symbol (const char *name);

--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -49,6 +49,7 @@
 #endif
 #include "icall-decl.h"
 #include "icall-signatures.h"
+#include "register-icall-def.h"
 
 static void
 mono_System_ComObject_ReleaseInterfaces (MonoComObjectHandle obj);
@@ -87,13 +88,18 @@ Code shared between the DISABLE_COM and !DISABLE_COM
 #ifdef __cplusplus
 template <typename T>
 static void
-register_icall (       T func, const char *name, MonoMethodSignature *sig, gboolean save)
+register_icall_info (MonoJitICallInfo *info,        T func, const char *name, MonoMethodSignature *sig, gboolean save)
 #else
 static void
-register_icall (gpointer func, const char *name, MonoMethodSignature *sig, gboolean save)
+register_icall_info (MonoJitICallInfo *info, gpointer func, const char *name, MonoMethodSignature *sig, gboolean save)
 #endif
 {
-	mono_register_jit_icall_full (func, name, sig, save, name);
+	// FIXME Some versions of register_icall_info pass NULL for last parameter, some pass name.
+	// marshal.c: name
+	// remoting.c: NULL (via mono_register_jit_icall_info)
+	// cominterop.c: name
+	// mini-runtime.c: name
+	mono_register_jit_icall_info_full (info, func, name, sig, save, name);
 }
 
 mono_bstr

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -119,6 +119,7 @@
 #include "icall-decl.h"
 #include "mono/utils/mono-threads-coop.h"
 #include "mono/metadata/icall-signatures.h"
+#include "register-icall-def.h"
 
 //#define MONO_DEBUG_ICALLARRAY
 

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -9082,19 +9082,25 @@ mono_register_jit_icall_wrapper (MonoJitICallInfo *info, gconstpointer wrapper)
 	mono_icall_unlock ();
 }
 
+void
+mono_no_trampolines (void)
+{
+	g_assert_not_reached ();
+}
+
 static
 void
 assert_equivalent_jit_icall_info (const char *which, const MonoJitICallInfo *info, gconstpointer func,
 	const char *name, MonoMethodSignature *sig, gboolean avoid_wrapper, const char *c_symbol)
 {
-	g_assertf (!strcmp(info->name, name),
+	g_assertf (func == (gpointer)mono_no_trampolines || !strcmp(info->name, name),
 		"jit icall name already %s %s %s %p %p\n",
 		which, name, info->name, func, info->func);
 
 	const char * const c_symbol1 = info->c_symbol ? info->c_symbol : "null1";
 	const char * const c_symbol2 =       c_symbol ?       c_symbol : "null2";
 
-	g_assertf (!strcmp(c_symbol1, c_symbol2),
+	g_assertf (func == (gpointer)mono_no_trampolines || !strcmp(c_symbol1, c_symbol2),
 		"jit icall c_symbol already %s %s %s %s\n",
 		which, name, c_symbol1, c_symbol2);
 
@@ -9136,7 +9142,7 @@ mono_register_jit_icall_info_full (MonoJitICallInfo *info, gconstpointer func,
 		if (!existing_info)
 			continue;
 
-		g_assertf (info == existing_info,
+		g_assertf (info == existing_info || func == (gpointer)mono_no_trampolines,
 			"jit icall info already hashed name:%s existing_name:%s func:%p existing_func:%p i:%d index:%d existing_index:%d\n",
 			name, existing_info->name, func, existing_info->func, i, mono_jit_icall_info_index (info),
 			mono_jit_icall_info_index (existing_info));

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -9135,10 +9135,12 @@ mono_register_jit_icall_info_full (MonoJitICallInfo *info, gconstpointer func,
 		if (!existing_info)
 			continue;
 
-		g_assertf (info == existing_info, "jit icall info already hashed %s %s\n",
-			name, existing_info->name);
+		g_assertf (info == existing_info,
+			"jit icall info already hashed name:%s existing_name:%s func:%p existing_func:%p i:%d index:%d existing_index:%d\n",
+			name, existing_info->name, func, existing_info->func, i, mono_jit_icall_info_index (info),
+			mono_jit_icall_info_index (existing_info));
 
-		assert_equivalent_jit_icall_info ("hashed", existing_info, func, name, sig, avoid_wrapper, c_symbol);
+		assert_equivalent_jit_icall_info (i ? "hashed1" : "hashed0", existing_info, func, name, sig, avoid_wrapper, c_symbol);
 	}
 
 	if (info->inited)

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -2182,6 +2182,9 @@ mono_get_method_constrained_checked (MonoImage *image, guint32 token, MonoClass 
 void
 mono_free_method  (MonoMethod *method)
 {
+	if (!method)
+		return;
+
 	MONO_PROFILER_RAISE (method_free, (method));
 	
 	/* FIXME: This hack will go away when the profiler will support freeing methods */

--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -2182,9 +2182,6 @@ mono_get_method_constrained_checked (MonoImage *image, guint32 token, MonoClass 
 void
 mono_free_method  (MonoMethod *method)
 {
-	if (!method)
-		return;
-
 	MONO_PROFILER_RAISE (method_free, (method));
 	
 	/* FIXME: This hack will go away when the profiler will support freeing methods */

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -49,6 +49,7 @@
 #include <string.h>
 #include <errno.h>
 #include "icall-decl.h"
+#include "register-icall-def.h"
 
 #define OPDEF(a,b,c,d,e,f,g,h,i,j) \
 	a = i,
@@ -575,7 +576,7 @@ emit_ptr_to_object_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv 
 	}
 }
 
-static gpointer
+static MonoJitICallInfo*
 conv_to_icall (MonoMarshalConv conv, int *ind_store_type)
 {
 	// FIXME This or its caller might be a good place to inline some
@@ -589,77 +590,77 @@ conv_to_icall (MonoMarshalConv conv, int *ind_store_type)
 	*ind_store_type = CEE_STIND_I;
 	switch (conv) {
 	case MONO_MARSHAL_CONV_STR_LPWSTR:
-		return (gpointer)mono_marshal_string_to_utf16;
+		return &mono_jit_icall_info.mono_marshal_string_to_utf16;
 	case MONO_MARSHAL_CONV_LPWSTR_STR:
 		*ind_store_type = CEE_STIND_REF;
-		return (gpointer)ves_icall_mono_string_from_utf16;
+		return &mono_jit_icall_info.ves_icall_mono_string_from_utf16;
 	case MONO_MARSHAL_CONV_LPTSTR_STR:
 		*ind_store_type = CEE_STIND_REF;
-		return (gpointer)ves_icall_string_new_wrapper;
+		return &mono_jit_icall_info.ves_icall_string_new_wrapper;
 	case MONO_MARSHAL_CONV_UTF8STR_STR:
 	case MONO_MARSHAL_CONV_LPSTR_STR:
 		*ind_store_type = CEE_STIND_REF;
-		return (gpointer)ves_icall_string_new_wrapper;
+		return &mono_jit_icall_info.ves_icall_string_new_wrapper;
 	case MONO_MARSHAL_CONV_STR_LPTSTR:
 #ifdef TARGET_WIN32
-		return (gpointer)mono_marshal_string_to_utf16;
+		return &mono_jit_icall_info.mono_marshal_string_to_utf16;
 #else
-		return (gpointer)mono_string_to_utf8str;
+		return &mono_jit_icall_info.mono_string_to_utf8str;
 #endif
 		// In Mono historically LPSTR was treated as a UTF8STR
 	case MONO_MARSHAL_CONV_STR_UTF8STR:
 	case MONO_MARSHAL_CONV_STR_LPSTR:
-		return (gpointer)mono_string_to_utf8str;
+		return &mono_jit_icall_info.mono_string_to_utf8str;
 	case MONO_MARSHAL_CONV_STR_BSTR:
-		return (gpointer)mono_string_to_bstr;
+		return &mono_jit_icall_info.mono_string_to_bstr;
 	case MONO_MARSHAL_CONV_BSTR_STR:
 		*ind_store_type = CEE_STIND_REF;
-		return (gpointer)mono_string_from_bstr_icall;
+		return &mono_jit_icall_info.mono_string_from_bstr_icall;
 	case MONO_MARSHAL_CONV_STR_TBSTR:
 	case MONO_MARSHAL_CONV_STR_ANSIBSTR:
-		return (gpointer)mono_string_to_ansibstr;
+		return &mono_jit_icall_info.mono_string_to_ansibstr;
 	case MONO_MARSHAL_CONV_SB_UTF8STR:
 	case MONO_MARSHAL_CONV_SB_LPSTR:
-		return (gpointer)mono_string_builder_to_utf8;
+		return &mono_jit_icall_info.mono_string_builder_to_utf8;
 	case MONO_MARSHAL_CONV_SB_LPTSTR:
 #ifdef TARGET_WIN32
-		return (gpointer)mono_string_builder_to_utf16;
+		return &mono_jit_icall_info.mono_string_builder_to_utf16;
 #else
-		return (gpointer)mono_string_builder_to_utf8;
+		return &mono_jit_icall_info.mono_string_builder_to_utf8;
 #endif
 	case MONO_MARSHAL_CONV_SB_LPWSTR:
-		return (gpointer)mono_string_builder_to_utf16;
+		return &mono_jit_icall_info.mono_string_builder_to_utf16;
 	case MONO_MARSHAL_CONV_ARRAY_SAVEARRAY:
-		return (gpointer)mono_array_to_savearray;
+		return &mono_jit_icall_info.mono_array_to_savearray;
 	case MONO_MARSHAL_CONV_ARRAY_LPARRAY:
-		return (gpointer)mono_array_to_lparray;
+		return &mono_jit_icall_info.mono_array_to_lparray;
 	case MONO_MARSHAL_FREE_LPARRAY:
-		return (gpointer)mono_free_lparray;
+		return &mono_jit_icall_info.mono_free_lparray;
 	case MONO_MARSHAL_CONV_DEL_FTN:
-		return (gpointer)mono_delegate_to_ftnptr;
+		return &mono_jit_icall_info.mono_delegate_to_ftnptr;
 	case MONO_MARSHAL_CONV_FTN_DEL:
 		*ind_store_type = CEE_STIND_REF;
-		return (gpointer)mono_ftnptr_to_delegate;
+		return &mono_jit_icall_info.mono_ftnptr_to_delegate;
 	case MONO_MARSHAL_CONV_UTF8STR_SB:
 	case MONO_MARSHAL_CONV_LPSTR_SB:
 		*ind_store_type = CEE_STIND_REF;
-		return (gpointer)mono_string_utf8_to_builder;
+		return &mono_jit_icall_info.mono_string_utf8_to_builder;
 	case MONO_MARSHAL_CONV_LPTSTR_SB:
 		*ind_store_type = CEE_STIND_REF;
 #ifdef TARGET_WIN32
-		return (gpointer)mono_string_utf16_to_builder;
+		return &mono_jit_icall_info.mono_string_utf16_to_builder;
 #else
-		return (gpointer)mono_string_utf8_to_builder;
+		return &mono_jit_icall_info.mono_string_utf8_to_builder;
 #endif
 	case MONO_MARSHAL_CONV_LPWSTR_SB:
 		*ind_store_type = CEE_STIND_REF;
-		return (gpointer)mono_string_utf16_to_builder;
+		return &mono_jit_icall_info.mono_string_utf16_to_builder;
 	case MONO_MARSHAL_FREE_ARRAY:
-		return (gpointer)mono_marshal_free_array;
+		return &mono_jit_icall_info.mono_marshal_free_array;
 	case MONO_MARSHAL_CONV_STR_BYVALSTR:
-		return (gpointer)mono_string_to_byvalstr;
+		return &mono_jit_icall_info.mono_string_to_byvalstr;
 	case MONO_MARSHAL_CONV_STR_BYVALWSTR:
-		return (gpointer)mono_string_to_byvalwstr;
+		return &mono_jit_icall_info.mono_string_to_byvalwstr;
 	default:
 		g_assert_not_reached ();
 	}
@@ -708,7 +709,7 @@ emit_object_to_ptr_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv 
 		mono_mb_emit_ldloc (mb, 1);
 		mono_mb_emit_ldloc (mb, 0);
 		mono_mb_emit_byte (mb, CEE_LDIND_REF);
-		mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
+		mono_mb_emit_icall_info (mb, conv_to_icall (conv, &stind_op));
 		mono_mb_emit_byte (mb, stind_op);
 		break;
 	}
@@ -718,7 +719,7 @@ emit_object_to_ptr_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv 
 		mono_mb_emit_ldloc (mb, 1);
 		mono_mb_emit_ldloc (mb, 0);
 		mono_mb_emit_byte (mb, CEE_LDIND_REF);
-		mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
+		mono_mb_emit_icall_info (mb, conv_to_icall (conv, &stind_op));
 		mono_mb_emit_byte (mb, stind_op);
 		break;
 	case MONO_MARSHAL_CONV_STR_BYVALSTR: 
@@ -729,7 +730,7 @@ emit_object_to_ptr_conv (MonoMethodBuilder *mb, MonoType *type, MonoMarshalConv 
 		mono_mb_emit_ldloc (mb, 0);	
 		mono_mb_emit_byte (mb, CEE_LDIND_REF); /* src String */
 		mono_mb_emit_icon (mb, mspec->data.array_data.num_elem);
-		mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+		mono_mb_emit_icall_info (mb, conv_to_icall (conv, NULL));
 		break;
 	}
 	case MONO_MARSHAL_CONV_ARRAY_BYVALARRAY: {
@@ -1185,7 +1186,7 @@ emit_struct_free (MonoMethodBuilder *mb, MonoClass *klass, int struct_var)
 }
 
 static void
-emit_thread_interrupt_checkpoint_call (MonoMethodBuilder *mb, gpointer checkpoint_func)
+emit_thread_interrupt_checkpoint_call (MonoMethodBuilder *mb, MonoJitICallInfo *checkpoint_icall_info)
 {
 	int pos_noabort, pos_noex;
 
@@ -1197,7 +1198,7 @@ emit_thread_interrupt_checkpoint_call (MonoMethodBuilder *mb, gpointer checkpoin
 	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
 	mono_mb_emit_byte (mb, CEE_MONO_NOT_TAKEN);
 
-	mono_mb_emit_icall (mb, checkpoint_func);
+	mono_mb_emit_icall_info (mb, checkpoint_icall_info);
 	/* Throw the exception returned by the checkpoint function, if any */
 	mono_mb_emit_byte (mb, CEE_DUP);
 	pos_noex = mono_mb_emit_branch (mb, CEE_BRFALSE);
@@ -1219,16 +1220,17 @@ emit_thread_interrupt_checkpoint_call (MonoMethodBuilder *mb, gpointer checkpoin
 static void
 emit_thread_interrupt_checkpoint (MonoMethodBuilder *mb)
 {
+	// FIXME Put a boolean in MonoMethodBuilder instead.
 	if (strstr (mb->name, "mono_thread_interruption_checkpoint"))
 		return;
 	
-	emit_thread_interrupt_checkpoint_call (mb, (gpointer)mono_thread_interruption_checkpoint);
+	emit_thread_interrupt_checkpoint_call (mb, &mono_jit_icall_info.mono_thread_interruption_checkpoint);
 }
 
 static void
 emit_thread_force_interrupt_checkpoint (MonoMethodBuilder *mb)
 {
-	emit_thread_interrupt_checkpoint_call (mb, (gpointer)mono_thread_force_interruption_checkpoint_noraise);
+	emit_thread_interrupt_checkpoint_call (mb, &mono_jit_icall_info.mono_thread_force_interruption_checkpoint_noraise);
 }
 
 void
@@ -2269,7 +2271,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			mono_mb_emit_ldarg (mb, argnum);
 			if (t->byref)
 				mono_mb_emit_byte (mb, CEE_LDIND_I);
-			mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_ARRAY_LPARRAY, NULL));
+			mono_mb_emit_icall_info (mb, conv_to_icall (MONO_MARSHAL_CONV_ARRAY_LPARRAY, NULL));
 			mono_mb_emit_stloc (mb, conv_arg);
 		} else {
 			guint32 label1, label2, label3;
@@ -2351,7 +2353,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 				mono_mb_emit_ldloc (mb, src_var);
 				mono_mb_emit_ldloc (mb, index_var);
 				mono_mb_emit_byte (mb, CEE_LDELEM_REF);
-				mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
+				mono_mb_emit_icall_info (mb, conv_to_icall (conv, &stind_op));
 				mono_mb_emit_byte (mb, stind_op);
 			} else {
 				/* set the src_ptr */
@@ -2473,7 +2475,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 				mono_mb_emit_ldloc (mb, src_ptr);
 				mono_mb_emit_byte (mb, CEE_LDIND_I);
 
-				mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+				mono_mb_emit_icall_info (mb, conv_to_icall (conv, NULL));
 
 				if (need_free) {
 					/* src */
@@ -2534,7 +2536,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			if (t->byref)
 				mono_mb_emit_byte (mb, CEE_LDIND_REF);
 			mono_mb_emit_ldloc (mb, conv_arg);
-			mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_FREE_LPARRAY, NULL));
+			mono_mb_emit_icall_info (mb, conv_to_icall (MONO_MARSHAL_FREE_LPARRAY, NULL));
 		}
 
 		break;
@@ -2708,7 +2710,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			mono_mb_emit_ldloc (mb, src_ptr);
 			mono_mb_emit_byte (mb, CEE_LDIND_I);
 
-			mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+			mono_mb_emit_icall_info (mb, conv_to_icall (conv, NULL));
 			mono_mb_emit_byte (mb, CEE_STELEM_REF);
 		}
 		else {
@@ -2826,7 +2828,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 			mono_mb_emit_byte (mb, CEE_LDELEM_REF);
 
-			mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
+			mono_mb_emit_icall_info (mb, conv_to_icall (conv, &stind_op));
 			mono_mb_emit_byte (mb, stind_op);
 		}
 		else {
@@ -2921,7 +2923,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 			mono_mb_emit_byte (mb, CEE_LDELEM_REF);
 
-			mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
+			mono_mb_emit_icall_info (mb, conv_to_icall (conv, &stind_op));
 			mono_mb_emit_byte (mb, stind_op);
 		}
 		else {
@@ -4950,7 +4952,7 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			char *msg = g_strdup_printf ("string marshalling conversion %d not implemented", encoding);
 			mono_mb_emit_exception_marshal_directive (mb, msg);
 		} else {
-			mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+			mono_mb_emit_icall_info (mb, conv_to_icall (conv, NULL));
 
 			mono_mb_emit_stloc (mb, conv_arg);
 		}
@@ -4992,7 +4994,7 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			int stind_op;
 			mono_mb_emit_ldarg (mb, argnum);
 			mono_mb_emit_ldloc (mb, conv_arg);
-			mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
+			mono_mb_emit_icall_info (mb, conv_to_icall (conv, &stind_op));
 			mono_mb_emit_byte (mb, stind_op);
 			need_free = TRUE;
 		}
@@ -5024,7 +5026,7 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		}
 
 		mono_mb_emit_ldloc (mb, 0);
-		mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+		mono_mb_emit_icall_info (mb, conv_to_icall (conv, NULL));
 		mono_mb_emit_stloc (mb, 3);
 
 		/* free the string */
@@ -5055,7 +5057,7 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		mono_mb_emit_ldarg (mb, argnum);
 		if (t->byref)
 			mono_mb_emit_byte (mb, CEE_LDIND_I);
-		mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+		mono_mb_emit_icall_info (mb, conv_to_icall (conv, NULL));
 		mono_mb_emit_stloc (mb, conv_arg);
 		break;
 
@@ -5065,18 +5067,18 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 				int stind_op;
 				mono_mb_emit_ldarg (mb, argnum);
 				mono_mb_emit_ldloc (mb, conv_arg);
-				mono_mb_emit_icall (mb, conv_to_icall (conv, &stind_op));
+				mono_mb_emit_icall_info (mb, conv_to_icall (conv, &stind_op));
 				mono_mb_emit_byte (mb, stind_op);
 			}
 		}
 		break;
 
 	case MARSHAL_ACTION_MANAGED_CONV_RESULT:
-		if (conv_to_icall (conv, NULL) == mono_marshal_string_to_utf16)
+		if (conv_to_icall (conv, NULL) == &mono_jit_icall_info.mono_marshal_string_to_utf16)
 			/* We need to make a copy so the caller is able to free it */
 			mono_mb_emit_icall (mb, mono_marshal_string_to_utf16_copy);
 		else
-			mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+			mono_mb_emit_icall_info (mb, conv_to_icall (conv, NULL));
 		mono_mb_emit_stloc (mb, 3);
 		break;
 
@@ -5343,7 +5345,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 				mono_mb_emit_stloc (mb, conv_arg);
 			} else {
 				mono_mb_emit_ldarg (mb, argnum);
-				mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_DEL_FTN, NULL));
+				mono_mb_emit_icall_info (mb, conv_to_icall (MONO_MARSHAL_CONV_DEL_FTN, NULL));
 				mono_mb_emit_stloc (mb, conv_arg);
 			}
 		} else if (klass == mono_class_try_get_stringbuilder_class ()) {
@@ -5373,7 +5375,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			if (t->byref)
 				mono_mb_emit_byte (mb, CEE_LDIND_I);
 
-			mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+			mono_mb_emit_icall_info (mb, conv_to_icall (conv, NULL));
 			mono_mb_emit_stloc (mb, conv_arg);
 		} else if (m_class_is_blittable (klass)) {
 			mono_mb_emit_byte (mb, CEE_LDNULL);
@@ -5478,7 +5480,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 				mono_mb_emit_ldarg (mb, argnum);
 				mono_mb_emit_ldloc (mb, conv_arg);
 
-				mono_mb_emit_icall (mb, conv_to_icall (conv, NULL));
+				mono_mb_emit_icall_info (mb, conv_to_icall (conv, NULL));
 			}
 
 			if (need_free) {
@@ -5494,7 +5496,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 				mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
 				mono_mb_emit_op (mb, CEE_MONO_CLASSCONST, klass);
 				mono_mb_emit_ldloc (mb, conv_arg);
-				mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_FTN_DEL, NULL));
+				mono_mb_emit_icall_info (mb, conv_to_icall (MONO_MARSHAL_CONV_FTN_DEL, NULL));
 				mono_mb_emit_byte (mb, CEE_STIND_REF);
 			}
 			break;
@@ -5577,7 +5579,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
 			mono_mb_emit_op (mb, CEE_MONO_CLASSCONST, klass);
 			mono_mb_emit_ldloc (mb, 0);
-			mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_FTN_DEL, NULL));
+			mono_mb_emit_icall_info (mb, conv_to_icall (MONO_MARSHAL_CONV_FTN_DEL, NULL));
 			mono_mb_emit_stloc (mb, 3);
 		} else if (klass == mono_class_try_get_stringbuilder_class ()) {
 			// FIXME:
@@ -5631,7 +5633,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			mono_mb_emit_ldarg (mb, argnum);
 			if (t->byref)
 				mono_mb_emit_byte (mb, CEE_LDIND_I);
-			mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_FTN_DEL, NULL));
+			mono_mb_emit_icall_info (mb, conv_to_icall (MONO_MARSHAL_CONV_FTN_DEL, NULL));
 			mono_mb_emit_stloc (mb, conv_arg);
 			break;
 		}
@@ -5708,7 +5710,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 				int stind_op;
 				mono_mb_emit_ldarg (mb, argnum);
 				mono_mb_emit_ldloc (mb, conv_arg);
-				mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_DEL_FTN, &stind_op));
+				mono_mb_emit_icall_info (mb, conv_to_icall (MONO_MARSHAL_CONV_DEL_FTN, &stind_op));
 				mono_mb_emit_byte (mb, stind_op);
 				break;
 			}
@@ -5768,7 +5770,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 	case MARSHAL_ACTION_MANAGED_CONV_RESULT:
 		if (m_class_is_delegate (klass)) {
-			mono_mb_emit_icall (mb, conv_to_icall (MONO_MARSHAL_CONV_DEL_FTN, NULL));
+			mono_mb_emit_icall_info (mb, conv_to_icall (MONO_MARSHAL_CONV_DEL_FTN, NULL));
 			mono_mb_emit_stloc (mb, 3);
 			break;
 		}

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -62,6 +62,8 @@
 #include <errno.h>
 #include "icall-decl.h"
 #include "icall-signatures.h"
+#include "register-icall-def.h"
+#include "class-internals.h"
 
 static void
 mono_string_utf16len_to_builder (MonoStringBuilderHandle sb, const gunichar2 *text, gsize len, MonoError *error);
@@ -120,37 +122,31 @@ get_method_image (MonoMethod *method)
 #ifdef __cplusplus
 template <typename T>
 static void
-register_dyn_icall (T func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper)
+register_icall_info (MonoJitICallInfo *info, T func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper)
 #else
 static void
-register_dyn_icall (gpointer func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper)
+register_icall_info (MonoJitICallInfo *info, gpointer func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper)
 #endif
 {
-	mono_register_jit_icall_full (func, name, sig, no_wrapper, NULL);
+	// FIXME Some versions of register_icall_info pass NULL for last parameter, some pass name.
+	// marshal.c: name
+	// remoting.c: NULL (via mono_register_jit_icall_info)
+	// cominterop.c: name
+	// mini-runtime.c: name
+	mono_register_jit_icall_info_full (info, func, name, sig, no_wrapper, name);
 }
 
 #ifdef __cplusplus
 template <typename T>
 static void
-register_icall (T func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper)
+register_icall_info_no_wrapper (MonoJitICallInfo *info, T func, const char *name, MonoMethodSignature *sig)
 #else
 static void
-register_icall (gpointer func, const char *name, MonoMethodSignature *sig, gboolean no_wrapper)
+register_icall_info_no_wrapper (MonoJitICallInfo *info, gpointer func, const char *name, MonoMethodSignature *sig)
 #endif
 {
-	mono_register_jit_icall_full (func, name, sig, no_wrapper, name);
-}
-
-#ifdef __cplusplus
-template <typename T>
-static void
-register_icall_no_wrapper (T func, const char *name, MonoMethodSignature *sig)
-#else
-static void
-register_icall_no_wrapper (gpointer func, const char *name, MonoMethodSignature *sig)
-#endif
-{
-	mono_register_jit_icall_full (func, name, sig, TRUE, name);
+	// FIXME There are near duplicates of this function in mini-runtime.c and marshal.c.
+	mono_register_jit_icall_info_full (info, func, name, sig, TRUE, name);
 }
 
 MonoMethodSignature*
@@ -266,7 +262,7 @@ mono_marshal_init (void)
 		register_icall (mono_string_to_byvalstr, "mono_string_to_byvalstr", mono_icall_sig_void_ptr_ptr_int32, FALSE);
 		register_icall (mono_string_to_byvalwstr, "mono_string_to_byvalwstr", mono_icall_sig_void_ptr_ptr_int32, FALSE);
 		// Because #define g_free monoeg_g_free.
-		register_icall (g_free, "monoeg_g_free", mono_icall_sig_void_ptr, FALSE);
+		register_icall_info (&mono_jit_icall_info.g_free, g_free, "monoeg_g_free", mono_icall_sig_void_ptr, FALSE);
 		register_icall_no_wrapper (mono_object_isinst_icall, "mono_object_isinst_icall", mono_icall_sig_object_object_ptr);
 		register_icall (mono_struct_delete_old, "mono_struct_delete_old", mono_icall_sig_void_ptr_ptr, FALSE);
 		register_icall (mono_delegate_begin_invoke, "mono_delegate_begin_invoke", mono_icall_sig_object_object_ptr, FALSE);
@@ -2919,8 +2915,8 @@ emit_return_noilgen (MonoMethodBuilder *mb)
 
 /**
  * mono_marshal_get_icall_wrapper:
- * Generates IL code for the icall wrapper. The generated method
- * calls the unmanaged code in \p func.
+ * Generates IL code for the JIT icall wrapper. The generated method
+ * calls the unmanaged code in \p callinfo->func.
  */
 MonoMethod *
 mono_marshal_get_icall_wrapper (MonoJitICallInfo *callinfo, gboolean check_exceptions)

--- a/mono/metadata/method-builder-ilgen.c
+++ b/mono/metadata/method-builder-ilgen.c
@@ -18,6 +18,7 @@
 #include <string.h>
 #include <errno.h>
 #include "class-init.h"
+#include "register-icall-def.h"
 
 #define OPDEF(a,b,c,d,e,f,g,h,i,j) \
 	a = i,
@@ -544,10 +545,14 @@ mono_mb_emit_native_call (MonoMethodBuilder *mb, MonoMethodSignature *sig, gpoin
 }
 
 void
-mono_mb_emit_icall (MonoMethodBuilder *mb, gpointer func)
+mono_mb_emit_icall_info (MonoMethodBuilder *mb, MonoJitICallInfo *jit_icall_info)
 {
+	g_assert (jit_icall_info);
+	g_assertf (jit_icall_info->name, "%d", (int)mono_jit_icall_info_index (jit_icall_info));
+	g_assertf (jit_icall_info->func, "%d", (int)mono_jit_icall_info_index (jit_icall_info));
+
 	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-	mono_mb_emit_op (mb, CEE_MONO_ICALL, func);
+	mono_mb_emit_op (mb, CEE_MONO_ICALL, (gpointer)jit_icall_info->func);
 }
 
 void

--- a/mono/metadata/method-builder-ilgen.h
+++ b/mono/metadata/method-builder-ilgen.h
@@ -57,16 +57,9 @@ void
 mono_mb_emit_managed_call (MonoMethodBuilder *mb, MonoMethod *method, MonoMethodSignature *opt_sig);
 
 void
-mono_mb_emit_icall (MonoMethodBuilder *mb, gpointer func);
+mono_mb_emit_icall_info (MonoMethodBuilder *mb, MonoJitICallInfo *jit_icall_info);
 
-#ifdef __cplusplus
-template <typename T>
-inline void
-mono_mb_emit_icall (MonoMethodBuilder *mb, T func)
-{
-	mono_mb_emit_icall (mb, (gpointer)func);
-}
-#endif // __cplusplus
+#define mono_mb_emit_icall(mb, name) (mono_mb_emit_icall_info ((mb), &mono_jit_icall_info.name))
 
 int
 mono_mb_add_local (MonoMethodBuilder *mb, MonoType *type);

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -58,6 +58,8 @@
 #include "monitor.h"
 #include "icall-decl.h"
 #include "icall-signatures.h"
+#include "register-icall-def.h"
+#include "class-internals.h"
 
 // If no symbols in an object file in a static library are referenced, its exports will not be exported.
 // There are a few workarounds:

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -3163,7 +3163,7 @@ mono_class_from_mono_type_handle (MonoReflectionTypeHandle reftype)
 	return mono_class_from_mono_type_internal (MONO_HANDLE_RAW (reftype)->type);
 }
 
-// This is called by calls, it will return NULL and set pending exception (in wrapper) on failure.
+// This is called by icalls, it will return NULL and set pending exception (in wrapper) on failure.
 MonoReflectionTypeHandle
 mono_type_from_handle_impl (MonoType *handle, MonoError *error)
 {

--- a/mono/metadata/register-icall-def.c
+++ b/mono/metadata/register-icall-def.c
@@ -1,0 +1,15 @@
+/**
+ * \file
+ * Copyright 2019 Microsoft
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+#include <config.h>
+#include <glib.h>
+#include "mono/metadata/exception-internals.h"
+#include "register-icall-def.h"
+
+// FIXME move to jit-icalls.c
+MonoJitICallInfos mono_jit_icall_info = { 0 };
+
+

--- a/mono/metadata/register-icall-def.h
+++ b/mono/metadata/register-icall-def.h
@@ -14,11 +14,10 @@
 #ifndef __MONO_METADATA_REGISTER_JIT_ICALL_DEF_H__
 #define __MONO_METADATA_REGISTER_JIT_ICALL_DEF_H__
 
-// Changes to this file affect AOT file format.
 #define MONO_JIT_ICALLS \
 	\
-MONO_JIT_ICALL (mono_jit_icall_zero_is_reserved)	\
-/* generic_trampoline_* must be first, after zero */	\
+MONO_JIT_ICALL (ZeroIsReserved)	\
+	\
 /* These must be ordered like MonoTrampolineType. */	\
 MONO_JIT_ICALL (generic_trampoline_jit)	\
 MONO_JIT_ICALL (generic_trampoline_jump)	\

--- a/mono/metadata/register-icall-def.h
+++ b/mono/metadata/register-icall-def.h
@@ -1,0 +1,357 @@
+/**
+ * \file
+ * Copyright 2018 Microsoft
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+// FIXME This belong here:
+// #include "mono/mini/jit-icalls.h"
+// but that requires some factoring.
+//
+// This file is is misnamed.
+// It is not "register" or "def".
+
+#ifndef __MONO_METADATA_REGISTER_JIT_ICALL_DEF_H__
+#define __MONO_METADATA_REGISTER_JIT_ICALL_DEF_H__
+
+// Changes to this file affect AOT file format.
+#define MONO_JIT_ICALLS \
+	\
+MONO_JIT_ICALL (mono_jit_icall_zero_is_reserved)	\
+/* generic_trampoline_* must be first, after zero */	\
+/* These must be ordered like MonoTrampolineType. */	\
+MONO_JIT_ICALL (generic_trampoline_jit)	\
+MONO_JIT_ICALL (generic_trampoline_jump)	\
+MONO_JIT_ICALL (generic_trampoline_rgctx_lazy_fetch)	\
+MONO_JIT_ICALL (generic_trampoline_aot)	\
+MONO_JIT_ICALL (generic_trampoline_aot_plt)	\
+MONO_JIT_ICALL (generic_trampoline_delegate)	\
+MONO_JIT_ICALL (generic_trampoline_generic_virtual_remoting)	\
+MONO_JIT_ICALL (generic_trampoline_vcall)	\
+	\
+/* These must be ordered like MonoTlsKey. */ \
+MONO_JIT_ICALL (mono_tls_get_thread) \
+MONO_JIT_ICALL (mono_tls_get_jit_tls) \
+MONO_JIT_ICALL (mono_tls_get_domain) \
+MONO_JIT_ICALL (mono_tls_get_sgen_thread_info) \
+MONO_JIT_ICALL (mono_tls_get_lmf_addr) \
+	\
+MONO_JIT_ICALL (__emul_fadd)	\
+MONO_JIT_ICALL (__emul_fcmp_ceq)	\
+MONO_JIT_ICALL (__emul_fcmp_cgt)	\
+MONO_JIT_ICALL (__emul_fcmp_cgt_un)	\
+MONO_JIT_ICALL (__emul_fcmp_clt)	\
+MONO_JIT_ICALL (__emul_fcmp_clt_un)	\
+MONO_JIT_ICALL (__emul_fcmp_eq)	\
+MONO_JIT_ICALL (__emul_fcmp_ge)	\
+MONO_JIT_ICALL (__emul_fcmp_ge_un)	\
+MONO_JIT_ICALL (__emul_fcmp_gt)	\
+MONO_JIT_ICALL (__emul_fcmp_gt_un)	\
+MONO_JIT_ICALL (__emul_fcmp_le)	\
+MONO_JIT_ICALL (__emul_fcmp_le_un)	\
+MONO_JIT_ICALL (__emul_fcmp_lt)	\
+MONO_JIT_ICALL (__emul_fcmp_lt_un)	\
+MONO_JIT_ICALL (__emul_fcmp_ne_un)	\
+MONO_JIT_ICALL (__emul_fconv_to_i)	\
+MONO_JIT_ICALL (__emul_fconv_to_i1)	\
+MONO_JIT_ICALL (__emul_fconv_to_i2)	\
+MONO_JIT_ICALL (__emul_fconv_to_i4)	\
+MONO_JIT_ICALL (__emul_fconv_to_i8)	\
+MONO_JIT_ICALL (__emul_fconv_to_ovf_i8)	\
+MONO_JIT_ICALL (__emul_fconv_to_ovf_u8)	\
+MONO_JIT_ICALL (__emul_fconv_to_r4)	\
+MONO_JIT_ICALL (__emul_fconv_to_u)	\
+MONO_JIT_ICALL (__emul_fconv_to_u1)	\
+MONO_JIT_ICALL (__emul_fconv_to_u2)	\
+MONO_JIT_ICALL (__emul_fconv_to_u4)	\
+MONO_JIT_ICALL (__emul_fconv_to_u8)	\
+MONO_JIT_ICALL (__emul_fdiv)	\
+MONO_JIT_ICALL (__emul_fmul)	\
+MONO_JIT_ICALL (__emul_fneg)	\
+MONO_JIT_ICALL (__emul_frem)	\
+MONO_JIT_ICALL (__emul_fsub)	\
+MONO_JIT_ICALL (__emul_iconv_to_r_un) \
+MONO_JIT_ICALL (__emul_iconv_to_r4) \
+MONO_JIT_ICALL (__emul_iconv_to_r8) \
+MONO_JIT_ICALL (__emul_lconv_to_r4) \
+MONO_JIT_ICALL (__emul_lconv_to_r8) \
+MONO_JIT_ICALL (__emul_lconv_to_r8_un) \
+MONO_JIT_ICALL (__emul_ldiv) \
+MONO_JIT_ICALL (__emul_ldiv_un) \
+MONO_JIT_ICALL (__emul_lmul) \
+MONO_JIT_ICALL (__emul_lmul_ovf) \
+MONO_JIT_ICALL (__emul_lmul_ovf_un) \
+MONO_JIT_ICALL (__emul_lrem) \
+MONO_JIT_ICALL (__emul_lrem_un) \
+MONO_JIT_ICALL (__emul_lshl) \
+MONO_JIT_ICALL (__emul_lshr) \
+MONO_JIT_ICALL (__emul_lshr_un) \
+MONO_JIT_ICALL (__emul_op_idiv) \
+MONO_JIT_ICALL (__emul_op_idiv_un) \
+MONO_JIT_ICALL (__emul_op_imul) \
+MONO_JIT_ICALL (__emul_op_imul_ovf) \
+MONO_JIT_ICALL (__emul_op_imul_ovf_un) \
+MONO_JIT_ICALL (__emul_op_irem) \
+MONO_JIT_ICALL (__emul_op_irem_un) \
+MONO_JIT_ICALL (__emul_rconv_to_i8) \
+MONO_JIT_ICALL (__emul_rconv_to_ovf_i8) \
+MONO_JIT_ICALL (__emul_rconv_to_ovf_u8) \
+MONO_JIT_ICALL (__emul_rconv_to_u8) \
+MONO_JIT_ICALL (__emul_rrem) \
+MONO_JIT_ICALL (cominterop_get_ccw) \
+MONO_JIT_ICALL (cominterop_get_ccw_object) \
+MONO_JIT_ICALL (cominterop_get_function_pointer) \
+MONO_JIT_ICALL (cominterop_get_interface) \
+MONO_JIT_ICALL (cominterop_get_method_interface) \
+MONO_JIT_ICALL (cominterop_object_is_rcw) \
+MONO_JIT_ICALL (cominterop_type_from_handle) \
+MONO_JIT_ICALL (g_free) \
+MONO_JIT_ICALL (interp_to_native_trampoline)	\
+MONO_JIT_ICALL (mini_llvm_init_gshared_method_mrgctx) \
+MONO_JIT_ICALL (mini_llvm_init_gshared_method_this) \
+MONO_JIT_ICALL (mini_llvm_init_gshared_method_vtable) \
+MONO_JIT_ICALL (mini_llvm_init_method) \
+MONO_JIT_ICALL (mini_llvmonly_init_delegate) \
+MONO_JIT_ICALL (mini_llvmonly_init_delegate_virtual) \
+MONO_JIT_ICALL (mini_llvmonly_init_vtable_slot) \
+MONO_JIT_ICALL (mini_llvmonly_resolve_generic_virtual_call) \
+MONO_JIT_ICALL (mini_llvmonly_resolve_generic_virtual_iface_call) \
+MONO_JIT_ICALL (mini_llvmonly_resolve_iface_call_gsharedvt) \
+MONO_JIT_ICALL (mini_llvmonly_resolve_vcall_gsharedvt) \
+MONO_JIT_ICALL (mini_llvmonly_throw_nullref_exception) \
+MONO_JIT_ICALL (mono_amd64_resume_unwind)	\
+MONO_JIT_ICALL (mono_amd64_start_gsharedvt_call)	\
+MONO_JIT_ICALL (mono_amd64_throw_corlib_exception)	\
+MONO_JIT_ICALL (mono_amd64_throw_exception)	\
+MONO_JIT_ICALL (mono_arch_rethrow_exception) \
+MONO_JIT_ICALL (mono_arch_throw_corlib_exception) \
+MONO_JIT_ICALL (mono_arch_throw_exception) \
+MONO_JIT_ICALL (mono_arm_resume_unwind)	\
+MONO_JIT_ICALL (mono_arm_start_gsharedvt_call)	\
+MONO_JIT_ICALL (mono_arm_throw_exception)	\
+MONO_JIT_ICALL (mono_arm_throw_exception_by_token)	\
+MONO_JIT_ICALL (mono_arm_unaligned_stack)	\
+MONO_JIT_ICALL (mono_array_new_1) \
+MONO_JIT_ICALL (mono_array_new_2) \
+MONO_JIT_ICALL (mono_array_new_3) \
+MONO_JIT_ICALL (mono_array_new_4) \
+MONO_JIT_ICALL (mono_array_new_n_icall) \
+MONO_JIT_ICALL (mono_array_to_byte_byvalarray) \
+MONO_JIT_ICALL (mono_array_to_lparray) \
+MONO_JIT_ICALL (mono_array_to_savearray) \
+MONO_JIT_ICALL (mono_break) \
+MONO_JIT_ICALL (mono_byvalarray_to_byte_array) \
+MONO_JIT_ICALL (mono_chkstk_win64) \
+MONO_JIT_ICALL (mono_ckfinite) \
+MONO_JIT_ICALL (mono_class_interface_match) \
+MONO_JIT_ICALL (mono_class_static_field_address) \
+MONO_JIT_ICALL (mono_compile_method_icall) \
+MONO_JIT_ICALL (mono_context_get_icall) \
+MONO_JIT_ICALL (mono_context_set_icall) \
+MONO_JIT_ICALL (mono_create_corlib_exception_0) \
+MONO_JIT_ICALL (mono_create_corlib_exception_1) \
+MONO_JIT_ICALL (mono_create_corlib_exception_2) \
+MONO_JIT_ICALL (mono_debug_personality) \
+MONO_JIT_ICALL (mono_debugger_agent_breakpoint_from_context) \
+MONO_JIT_ICALL (mono_debugger_agent_single_step_from_context) \
+MONO_JIT_ICALL (mono_debugger_agent_user_break) \
+MONO_JIT_ICALL (mono_delegate_begin_invoke) \
+MONO_JIT_ICALL (mono_delegate_end_invoke) \
+MONO_JIT_ICALL (mono_delegate_to_ftnptr) \
+MONO_JIT_ICALL (mono_domain_get) \
+MONO_JIT_ICALL (mono_dummy_jit_icall) \
+MONO_JIT_ICALL (mono_exception_from_token) \
+MONO_JIT_ICALL (mono_fill_class_rgctx) \
+MONO_JIT_ICALL (mono_fill_method_rgctx) \
+MONO_JIT_ICALL (mono_fload_r4) \
+MONO_JIT_ICALL (mono_fload_r4_arg) \
+MONO_JIT_ICALL (mono_free_bstr) \
+MONO_JIT_ICALL (mono_free_lparray) \
+MONO_JIT_ICALL (mono_fstore_r4) \
+MONO_JIT_ICALL (mono_ftnptr_to_delegate) \
+MONO_JIT_ICALL (mono_gc_alloc_obj) \
+MONO_JIT_ICALL (mono_gc_alloc_string) \
+MONO_JIT_ICALL (mono_gc_alloc_vector) \
+MONO_JIT_ICALL (mono_gc_wbarrier_generic_nostore_internal) \
+MONO_JIT_ICALL (mono_gc_wbarrier_range_copy) \
+MONO_JIT_ICALL (mono_gchandle_get_target_internal) \
+MONO_JIT_ICALL (mono_generic_class_init) \
+MONO_JIT_ICALL (mono_get_assembly_object) \
+MONO_JIT_ICALL (mono_get_lmf_addr) \
+MONO_JIT_ICALL (mono_get_method_object) \
+MONO_JIT_ICALL (mono_get_native_calli_wrapper) \
+MONO_JIT_ICALL (mono_get_special_static_data) \
+MONO_JIT_ICALL (mono_gsharedvt_constrained_call) \
+MONO_JIT_ICALL (mono_gsharedvt_value_copy) \
+MONO_JIT_ICALL (mono_helper_compile_generic_method) \
+MONO_JIT_ICALL (mono_helper_ldstr) \
+MONO_JIT_ICALL (mono_helper_ldstr_mscorlib) \
+MONO_JIT_ICALL (mono_helper_newobj_mscorlib) \
+MONO_JIT_ICALL (mono_helper_stelem_ref_check) \
+MONO_JIT_ICALL (mono_init_vtable_slot) \
+MONO_JIT_ICALL (mono_interp_entry_from_trampoline) \
+MONO_JIT_ICALL (mono_interp_to_native_trampoline) \
+MONO_JIT_ICALL (mono_isfinite_double) \
+MONO_JIT_ICALL (mono_jit_set_domain) \
+MONO_JIT_ICALL (mono_ldftn) \
+MONO_JIT_ICALL (mono_ldtoken_wrapper) \
+MONO_JIT_ICALL (mono_ldtoken_wrapper_generic_shared) \
+MONO_JIT_ICALL (mono_ldvirtfn) \
+MONO_JIT_ICALL (mono_ldvirtfn_gshared) \
+MONO_JIT_ICALL (mono_llvm_clear_exception) \
+MONO_JIT_ICALL (mono_llvm_load_exception) \
+MONO_JIT_ICALL (mono_llvm_match_exception) \
+MONO_JIT_ICALL (mono_llvm_resume_exception) \
+MONO_JIT_ICALL (mono_llvm_resume_unwind_trampoline) \
+MONO_JIT_ICALL (mono_llvm_rethrow_exception) \
+MONO_JIT_ICALL (mono_llvm_rethrow_exception_trampoline) \
+MONO_JIT_ICALL (mono_llvm_set_unhandled_exception_handler) \
+MONO_JIT_ICALL (mono_llvm_throw_corlib_exception) \
+MONO_JIT_ICALL (mono_llvm_throw_corlib_exception_abs_trampoline) \
+MONO_JIT_ICALL (mono_llvm_throw_corlib_exception_trampoline) \
+MONO_JIT_ICALL (mono_llvm_throw_exception) \
+MONO_JIT_ICALL (mono_llvm_throw_exception_trampoline) \
+MONO_JIT_ICALL (mono_llvmonly_init_delegate) \
+MONO_JIT_ICALL (mono_llvmonly_init_delegate_virtual) \
+MONO_JIT_ICALL (mono_marshal_asany) \
+MONO_JIT_ICALL (mono_marshal_check_domain_image) \
+MONO_JIT_ICALL (mono_marshal_free) \
+MONO_JIT_ICALL (mono_marshal_free_array) \
+MONO_JIT_ICALL (mono_marshal_free_asany) \
+MONO_JIT_ICALL (mono_marshal_get_type_object) \
+MONO_JIT_ICALL (mono_marshal_isinst_with_cache) \
+MONO_JIT_ICALL (mono_marshal_safearray_begin) \
+MONO_JIT_ICALL (mono_marshal_safearray_create) \
+MONO_JIT_ICALL (mono_marshal_safearray_end) \
+MONO_JIT_ICALL (mono_marshal_safearray_free_indices) \
+MONO_JIT_ICALL (mono_marshal_safearray_get_value) \
+MONO_JIT_ICALL (mono_marshal_safearray_next) \
+MONO_JIT_ICALL (mono_marshal_safearray_set_value) \
+MONO_JIT_ICALL (mono_marshal_set_domain_by_id) \
+MONO_JIT_ICALL (mono_marshal_set_last_error) \
+MONO_JIT_ICALL (mono_marshal_set_last_error_windows) \
+MONO_JIT_ICALL (mono_marshal_string_to_utf16) \
+MONO_JIT_ICALL (mono_marshal_string_to_utf16_copy) \
+MONO_JIT_ICALL (mono_marshal_xdomain_copy_out_value) \
+MONO_JIT_ICALL (mono_monitor_enter_fast) \
+MONO_JIT_ICALL (mono_monitor_enter_internal) \
+MONO_JIT_ICALL (mono_monitor_enter_v4_fast) \
+MONO_JIT_ICALL (mono_monitor_enter_v4_internal) \
+MONO_JIT_ICALL (mono_object_castclass_unbox) \
+MONO_JIT_ICALL (mono_object_castclass_with_cache) \
+MONO_JIT_ICALL (mono_object_isinst_icall) \
+MONO_JIT_ICALL (mono_object_isinst_with_cache) \
+MONO_JIT_ICALL (mono_ppc_throw_exception)	\
+MONO_JIT_ICALL (mono_profiler_raise_exception_clause) \
+MONO_JIT_ICALL (mono_profiler_raise_gc_allocation) \
+MONO_JIT_ICALL (mono_profiler_raise_method_enter) \
+MONO_JIT_ICALL (mono_profiler_raise_method_leave) \
+MONO_JIT_ICALL (mono_profiler_raise_method_tail_call) \
+MONO_JIT_ICALL (mono_remoting_update_exception) \
+MONO_JIT_ICALL (mono_remoting_wrapper) \
+MONO_JIT_ICALL (mono_resolve_generic_virtual_call) \
+MONO_JIT_ICALL (mono_resolve_generic_virtual_iface_call) \
+MONO_JIT_ICALL (mono_resolve_iface_call_gsharedvt) \
+MONO_JIT_ICALL (mono_resolve_vcall_gsharedvt) \
+MONO_JIT_ICALL (mono_resume_unwind) \
+MONO_JIT_ICALL (mono_rethrow_preserve_exception) \
+MONO_JIT_ICALL (mono_string_builder_to_utf16) \
+MONO_JIT_ICALL (mono_string_builder_to_utf8) \
+MONO_JIT_ICALL (mono_string_from_bstr_icall) \
+MONO_JIT_ICALL (mono_string_from_byvalstr) \
+MONO_JIT_ICALL (mono_string_from_byvalwstr) \
+MONO_JIT_ICALL (mono_string_new_len_wrapper) \
+MONO_JIT_ICALL (mono_string_new_wrapper_internal) \
+MONO_JIT_ICALL (mono_string_to_ansibstr) \
+MONO_JIT_ICALL (mono_string_to_bstr) \
+MONO_JIT_ICALL (mono_string_to_byvalstr) \
+MONO_JIT_ICALL (mono_string_to_byvalwstr) \
+MONO_JIT_ICALL (mono_string_to_utf16_internal) \
+MONO_JIT_ICALL (mono_string_to_utf8str) \
+MONO_JIT_ICALL (mono_string_utf16_to_builder) \
+MONO_JIT_ICALL (mono_string_utf16_to_builder2) \
+MONO_JIT_ICALL (mono_string_utf8_to_builder) \
+MONO_JIT_ICALL (mono_string_utf8_to_builder2) \
+MONO_JIT_ICALL (mono_struct_delete_old) \
+MONO_JIT_ICALL (mono_thread_force_interruption_checkpoint_noraise) \
+MONO_JIT_ICALL (mono_thread_get_undeniable_exception) \
+MONO_JIT_ICALL (mono_thread_interruption_checkpoint) \
+MONO_JIT_ICALL (mono_threads_attach_coop) \
+MONO_JIT_ICALL (mono_threads_detach_coop) \
+MONO_JIT_ICALL (mono_threads_enter_gc_safe_region_unbalanced) \
+MONO_JIT_ICALL (mono_threads_enter_gc_unsafe_region_unbalanced) \
+MONO_JIT_ICALL (mono_threads_exit_gc_safe_region_unbalanced) \
+MONO_JIT_ICALL (mono_threads_exit_gc_unsafe_region_unbalanced) \
+MONO_JIT_ICALL (mono_threads_state_poll) \
+MONO_JIT_ICALL (mono_throw_exception) \
+MONO_JIT_ICALL (mono_throw_method_access) \
+MONO_JIT_ICALL (mono_tls_set_domain) \
+MONO_JIT_ICALL (mono_tls_set_jit_tls) \
+MONO_JIT_ICALL (mono_tls_set_lmf_addr) \
+MONO_JIT_ICALL (mono_tls_set_sgen_thread_info) \
+MONO_JIT_ICALL (mono_tls_set_thread) \
+MONO_JIT_ICALL (mono_trace_enter_method) \
+MONO_JIT_ICALL (mono_trace_leave_method) \
+MONO_JIT_ICALL (mono_upgrade_remote_class_wrapper) \
+MONO_JIT_ICALL (mono_value_copy_internal) \
+MONO_JIT_ICALL (mono_x86_start_gsharedvt_call)	\
+MONO_JIT_ICALL (mono_x86_throw_corlib_exception)	\
+MONO_JIT_ICALL (mono_x86_throw_exception)	\
+MONO_JIT_ICALL (native_to_interp_trampoline)	\
+MONO_JIT_ICALL (personality) \
+MONO_JIT_ICALL (pthread_getspecific) \
+MONO_JIT_ICALL (rgctx_fetch_trampoline_general)	\
+MONO_JIT_ICALL (sdb_breakpoint_trampoline)	\
+MONO_JIT_ICALL (sdb_single_step_trampoline)	\
+MONO_JIT_ICALL (type_from_handle) \
+MONO_JIT_ICALL (ves_icall_array_new) \
+MONO_JIT_ICALL (ves_icall_array_new_specific) \
+MONO_JIT_ICALL (ves_icall_marshal_alloc) \
+MONO_JIT_ICALL (ves_icall_mono_delegate_ctor) \
+MONO_JIT_ICALL (ves_icall_mono_delegate_ctor_interp) \
+MONO_JIT_ICALL (ves_icall_mono_ldstr) \
+MONO_JIT_ICALL (ves_icall_mono_marshal_xdomain_copy_value) \
+MONO_JIT_ICALL (ves_icall_mono_string_from_utf16) \
+MONO_JIT_ICALL (ves_icall_mono_string_to_utf8) \
+MONO_JIT_ICALL (ves_icall_object_new) \
+MONO_JIT_ICALL (ves_icall_object_new_specific) \
+MONO_JIT_ICALL (ves_icall_runtime_class_init) \
+MONO_JIT_ICALL (ves_icall_string_alloc) \
+MONO_JIT_ICALL (ves_icall_string_new_wrapper) \
+MONO_JIT_ICALL (ves_icall_thread_finish_async_abort) \
+	\
+MONO_JIT_ICALL (count) \
+
+typedef enum MonoJitICallId {
+#define MONO_JIT_ICALL(x) MONO_JIT_ICALL_ ## x,
+MONO_JIT_ICALLS
+#undef MONO_JIT_ICALL
+} MonoJitICallId;
+
+typedef union MonoJitICallInfos {
+	struct {
+#define MONO_JIT_ICALL(x) MonoJitICallInfo x;
+MONO_JIT_ICALLS
+#undef MONO_JIT_ICALL
+	};
+	MonoJitICallInfo array [MONO_JIT_ICALL_count];
+} MonoJitICallInfos;
+
+extern MonoJitICallInfos mono_jit_icall_info;
+
+#define mono_jit_icall_info_index(x) ((x) - mono_jit_icall_info.array)
+
+static inline MonoJitICallInfo*
+mono_check_jit_icall_info (gconstpointer jit_icall_info)
+{
+	// All pointers to MonoJitICallInfo must be within mono_jit_icall_info.
+	// This will enable converting to and from a small integer or enum.
+	g_assert ((char*)jit_icall_info >= (char*)&mono_jit_icall_info && (char*)jit_icall_info < (char*)(&mono_jit_icall_info + 1));
+
+	// Allow encoding in 16 bits, and maybe 9 (but not 8). FIXME static_assert.
+	g_assert (MONO_JIT_ICALL_count < 0x200);
+
+	return (MonoJitICallInfo*)jit_icall_info;
+}
+
+#endif // __MONO_METADATA_JIT_ICALL_DEF_H__

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -26,6 +26,7 @@
 #include "mono/metadata/assembly.h"
 #include "icall-decl.h"
 #include "icall-signatures.h"
+#include "register-icall-def.h"
 
 typedef enum {
 	MONO_MARSHAL_NONE,			/* No marshalling needed */
@@ -107,13 +108,18 @@ mono_compile_method_icall (MonoMethod *method);
 #ifdef __cplusplus
 template <typename T>
 static void
-register_icall (T func, const char *name, MonoMethodSignature *sig, gboolean save)
+register_icall_info (MonoJitICallInfo *info, T func, const char *name, MonoMethodSignature *sig, gboolean save)
 #else
 static void
-register_icall (gpointer func, const char *name, MonoMethodSignature *sig, gboolean save)
+register_icall_info (MonoJitICallInfo *info, gpointer func, const char *name, MonoMethodSignature *sig, gboolean save)
 #endif
 {
-	mono_register_jit_icall (func, name, sig, save);
+	// FIXME Some versions of register_icall_info pass NULL for last parameter, some pass name.
+	// marshal.c: name
+	// remoting.c: NULL (via mono_register_jit_icall_info)
+	// cominterop.c: name
+	// mini-runtime.c: name
+	mono_register_jit_icall_info (info, func, name, sig, save);
 }
 
 static inline void

--- a/mono/metadata/sgen-mono-ilgen.c
+++ b/mono/metadata/sgen-mono-ilgen.c
@@ -34,6 +34,7 @@
 #include "utils/mono-threads.h"
 #include "metadata/w32handle.h"
 #include "icall-decl.h"
+#include "register-icall-def.h"
 
 #define OPDEF(a,b,c,d,e,f,g,h,i,j) \
 	a = i,

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -37,6 +37,8 @@
 #include "utils/mono-threads.h"
 #include "metadata/w32handle.h"
 #include "icall-signatures.h"
+#include "class-internals.h"
+#include "register-icall-def.h"
 
 #ifdef HEAVY_STATISTICS
 static guint64 stat_wbarrier_set_arrayref = 0;

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -68,6 +68,7 @@
 #include "mini-gc.h"
 #include "mini-llvm.h"
 #include "mini-runtime.h"
+#include "mono/metadata/register-icall-def.h"
 
 static MonoMethod*
 try_get_method_nofail (MonoClass *klass, const char *method_name, int param_count, int flags)
@@ -4169,12 +4170,9 @@ add_extra_method (MonoAotCompile *acfg, MonoMethod *method)
 }
 
 static void
-add_jit_icall_wrapper (gpointer key, gpointer value, gpointer user_data)
+add_jit_icall_wrapper (MonoAotCompile *acfg, MonoJitICallInfo *callinfo)
 {
-	MonoAotCompile *acfg = (MonoAotCompile *)user_data;
-	MonoJitICallInfo *callinfo = (MonoJitICallInfo *)value;
-
-	if (!callinfo->sig)
+	if (!callinfo->inited || !callinfo->sig)
 		return;
 
 	add_method (acfg, mono_marshal_get_icall_wrapper (callinfo, TRUE));
@@ -4531,8 +4529,9 @@ add_wrappers (MonoAotCompile *acfg)
 		add_method (acfg, mono_marshal_get_isinst_with_cache ());
 
 		/* JIT icall wrappers */
-		/* FIXME: locking - this is "safe" as full-AOT threads don't mutate the icall hash*/
-		g_hash_table_foreach (mono_get_jit_icall_info (), add_jit_icall_wrapper, acfg);
+		/* FIXME: locking - this is "safe" as full-AOT threads don't mutate the icall data */
+		for (int i = 0; i < MONO_JIT_ICALL_count; ++i)
+			add_jit_icall_wrapper (acfg, &mono_jit_icall_info.array [i]);
 	}
 
 	/* 
@@ -5949,7 +5948,7 @@ get_file_index (MonoAotCompile *acfg, const char *source_file)
  *   Emit the native code in CODE, handling relocations along the way. If GOT_ONLY
  * is true, calls are made through the GOT too. This is used for emitting trampolines
  * in full-aot mode, since calls made from trampolines couldn't go through the PLT,
- * since trampolines are needed to make PTL work.
+ * since trampolines are needed to make PLT work.
  */
 static void
 emit_and_reloc_code (MonoAotCompile *acfg, MonoMethod *method, guint8 *code, guint32 code_len, MonoJumpInfo *relocs, gboolean got_only, MonoDebugMethodJitInfo *debug_info)
@@ -7144,11 +7143,9 @@ get_plt_entry_debug_sym (MonoAotCompile *acfg, MonoJumpInfo *ji, GHashTable *cac
 		break;
 	}
 	case MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR:
-		// FIXME Check with https://github.com/mono/mono/pull/13792
 		debug_sym = g_strdup_printf ("%s_jit_icall_native_trampoline_func_%d", prefix, ji->data.index);
 		break;
 	case MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR:
-		// FIXME Check with https://github.com/mono/mono/pull/13792
 		debug_sym = g_strdup_printf ("%s_jit_icall_native_specific_trampoline_lazy_fetch_%u", prefix, ji->data.uindex);
 		break;
 	case MONO_PATCH_INFO_JIT_ICALL_ADDR:
@@ -13506,7 +13503,8 @@ mono_compile_assembly (MonoAssembly *ass, guint32 opts, const char *aot_options,
 		if (strcmp (acfg->image->assembly->aname.name, "mscorlib") == 0) {
 			add_gc_wrappers (acfg);
 
-			g_hash_table_foreach (mono_get_jit_icall_info (), add_jit_icall_wrapper, acfg);
+			for (int i = 0; i < MONO_JIT_ICALL_count; ++i)
+				add_jit_icall_wrapper (acfg, &mono_jit_icall_info.array [i]);
 		}
 	}
 

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -5314,7 +5314,7 @@ load_function_full (MonoAotModule *amodule, const char *name, MonoTrampInfo **ou
 
 	/* Load the code */
 
-	symbol = g_strdup_printf ("%s", name);
+	symbol = g_strdup (name);
 	find_amodule_symbol (amodule, symbol, (gpointer *)&code);
 	g_free (symbol);
 	if (!code)
@@ -5477,7 +5477,7 @@ mono_aot_get_trampoline_full (const char *name, MonoTrampInfo **out_tinfo)
 }
 
 gpointer
-(mono_aot_get_trampoline) (const char *name)
+mono_aot_get_trampoline (const char *name)
 {
 	MonoTrampInfo *out_tinfo;
 	gpointer code;

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -5453,11 +5453,8 @@ get_mscorlib_aot_module (void)
 	return amodule;
 }
 
-static void
-no_trampolines (void)
-{
-	g_assert_not_reached ();
-}
+void
+mono_no_trampolines (void);
 
 /*
  * Return the trampoline identified by NAME from the mscorlib AOT file.
@@ -5470,7 +5467,7 @@ mono_aot_get_trampoline_full (const char *name, MonoTrampInfo **out_tinfo)
 
 	if (mono_llvm_only) {
 		*out_tinfo = NULL;
-		return (gpointer)no_trampolines;
+		return (gpointer)mono_no_trampolines;
 	}
 
 	return mono_create_ftnptr_malloc ((guint8 *)load_function_full (amodule, name, out_tinfo));

--- a/mono/mini/aot-runtime.h
+++ b/mono/mini/aot-runtime.h
@@ -11,7 +11,7 @@
 #include "mini.h"
 
 /* Version number of the AOT file format */
-#define MONO_AOT_FILE_VERSION 159
+#define MONO_AOT_FILE_VERSION 160
 
 #define MONO_AOT_TRAMP_PAGE_SIZE 16384
 

--- a/mono/mini/aot-runtime.h
+++ b/mono/mini/aot-runtime.h
@@ -11,7 +11,7 @@
 #include "mini.h"
 
 /* Version number of the AOT file format */
-#define MONO_AOT_FILE_VERSION 160
+#define MONO_AOT_FILE_VERSION 159
 
 #define MONO_AOT_TRAMP_PAGE_SIZE 16384
 

--- a/mono/mini/calls.c
+++ b/mono/mini/calls.c
@@ -17,6 +17,7 @@
 #include <mono/metadata/class-abi-details.h>
 #include <mono/utils/mono-utils-debug.h>
 #include "mono/metadata/icall-signatures.h"
+#include "mono/metadata/register-icall-def.h"
 
 static const gboolean debug_tailcall_break_compile = FALSE; // break in method_to_ir
 static const gboolean debug_tailcall_break_run = FALSE;     // insert breakpoint in generated code
@@ -633,11 +634,11 @@ mono_emit_native_call (MonoCompile *cfg, gconstpointer func, MonoMethodSignature
 }
 
 MonoInst*
-mono_emit_jit_icall (MonoCompile *cfg, gconstpointer func, MonoInst **args)
+mono_emit_jit_icall_info (MonoCompile *cfg, MonoJitICallInfo *info, MonoInst **args)
 {
-	MonoJitICallInfo *info = mono_find_jit_icall_by_addr (func);
-
 	g_assert (info);
+	g_assertf (info->name, "%d", (int)mono_jit_icall_info_index (info));
+	g_assertf (info->func, "%d", (int)mono_jit_icall_info_index (info));
 
 	return mono_emit_native_call (cfg, mono_icall_get_wrapper (info), info->sig, args);
 }

--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -20,6 +20,7 @@
 #include <mono/utils/mono-compiler.h>
 #define MONO_MATH_DECLARE_ALL 1
 #include <mono/utils/mono-math.h>
+#include "mono/metadata/register-icall-def.h"
 
 #ifndef DISABLE_JIT
 

--- a/mono/mini/dwarfwriter.c
+++ b/mono/mini/dwarfwriter.c
@@ -31,6 +31,7 @@
 #endif
 
 #include <mono/utils/freebsd-dwarf.h>
+#include "mono/metadata/register-icall-def.h"
 
 #define DW_AT_MIPS_linkage_name 0x2007
 #define DW_LNE_set_prologue_end 0x0a

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -45,6 +45,7 @@
 #include "mini-runtime.h"
 #include "aot-runtime.h"
 #include "tasklets.h"
+#include "mono/metadata/register-icall-def.h"
 
 #ifdef TARGET_WIN32
 static void (*restore_stack) (void);
@@ -920,20 +921,35 @@ mono_arch_handle_altstack_exception (void *sigctx, MONO_SIG_HANDLER_INFO_TYPE *s
 
 #ifndef DISABLE_JIT
 GSList*
-mono_amd64_get_exception_trampolines (gboolean aot)
+mono_amd64_get_exception_trampolines (gboolean aot, gboolean reg)
 {
 	MonoTrampInfo *info;
 	GSList *tramps = NULL;
 
 	/* LLVM needs different throw trampolines */
 	get_throw_trampoline (&info, FALSE, TRUE, FALSE, FALSE, "llvm_throw_corlib_exception_trampoline", aot, FALSE);
-	tramps = g_slist_prepend (tramps, info);
+	if (reg) {
+		mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_throw_corlib_exception_trampoline, info->code, g_strdup (info->name), NULL, TRUE);
+		mono_tramp_info_register (info, NULL);
+	} else {
+		tramps = g_slist_prepend (tramps, info);
+	}
 
 	get_throw_trampoline (&info, FALSE, TRUE, TRUE, FALSE, "llvm_throw_corlib_exception_abs_trampoline", aot, FALSE);
-	tramps = g_slist_prepend (tramps, info);
+	if (reg) {
+		mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_throw_corlib_exception_abs_trampoline, info->code, g_strdup (info->name), NULL, TRUE);
+		mono_tramp_info_register (info, NULL);
+	} else {
+		tramps = g_slist_prepend (tramps, info);
+	}
 
 	get_throw_trampoline (&info, FALSE, TRUE, TRUE, TRUE, "llvm_resume_unwind_trampoline", aot, FALSE);
-	tramps = g_slist_prepend (tramps, info);
+	if (reg) {
+		mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_resume_unwind_trampoline, info->code, g_strdup (info->name), NULL, TRUE);
+		mono_tramp_info_register (info, NULL);
+	} else {
+		tramps = g_slist_prepend (tramps, info);
+	}
 
 	return tramps;
 }
@@ -941,7 +957,7 @@ mono_amd64_get_exception_trampolines (gboolean aot)
 #else
 
 GSList*
-mono_amd64_get_exception_trampolines (gboolean aot)
+mono_amd64_get_exception_trampolines (gboolean aot, gboolean reg)
 {
 	g_assert_not_reached ();
 	return NULL;
@@ -952,26 +968,28 @@ mono_amd64_get_exception_trampolines (gboolean aot)
 void
 mono_arch_exceptions_init (void)
 {
-	GSList *tramps, *l;
-	gpointer tramp;
-
 	if (mono_ee_features.use_aot_trampolines) {
-		tramp = mono_aot_get_trampoline ("llvm_throw_corlib_exception_trampoline");
-		mono_register_jit_icall (tramp, "llvm_throw_corlib_exception_trampoline", NULL, TRUE);
-		tramp = mono_aot_get_trampoline ("llvm_throw_corlib_exception_abs_trampoline");
-		mono_register_jit_icall (tramp, "llvm_throw_corlib_exception_abs_trampoline", NULL, TRUE);
-		tramp = mono_aot_get_trampoline ("llvm_resume_unwind_trampoline");
-		mono_register_jit_icall (tramp, "llvm_resume_unwind_trampoline", NULL, TRUE);
+
+		typedef struct MonoArchExceptionsInit {
+			const char *name;
+			MonoJitICallInfo *jit_icall_info;
+		} MonoArchExceptionsInit;
+
+		const static MonoArchExceptionsInit inits [ ] = {
+			{ "llvm_throw_corlib_exception_trampoline", &mono_jit_icall_info.mono_llvm_throw_corlib_exception_trampoline },
+			{ "llvm_throw_corlib_exception_abs_trampoline", &mono_jit_icall_info.mono_llvm_throw_corlib_exception_abs_trampoline },
+			{ "llvm_resume_unwind_trampoline", &mono_jit_icall_info.mono_llvm_resume_unwind_trampoline },
+		};
+
+		for (guint i = 0; i < G_N_ELEMENTS (inits); ++i) {
+			const MonoArchExceptionsInit *init = &inits [i];
+			gpointer tramp = mono_aot_get_trampoline (init->name);
+			mono_register_jit_icall_info (init->jit_icall_info, tramp, init->name, NULL, TRUE);
+		}
+
 	} else if (!mono_llvm_only) {
 		/* Call this to avoid initialization races */
-		tramps = mono_amd64_get_exception_trampolines (FALSE);
-		for (l = tramps; l; l = l->next) {
-			MonoTrampInfo *info = (MonoTrampInfo *)l->data;
-
-			mono_register_jit_icall (info->code, g_strdup (info->name), NULL, TRUE);
-			mono_tramp_info_register (info, NULL);
-		}
-		g_slist_free (tramps);
+		mono_amd64_get_exception_trampolines (FALSE, TRUE);
 	}
 }
 

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -536,7 +536,7 @@ get_throw_trampoline (MonoTrampInfo **info, gboolean rethrow, gboolean corlib, g
 		if (resume_unwind)
 			icall_name = "mono_amd64_resume_unwind";
 		else if (corlib)
-			icall_name = "mono_amd64_throw_corlib_exception";
+			icall_name = llvm_abs ? "mono_amd64_throw_corlib_exception_abs" : "mono_amd64_throw_corlib_exception";
 		else
 			icall_name = "mono_amd64_throw_exception";
 		ji = mono_patch_info_list_prepend (ji, code - start, MONO_PATCH_INFO_JIT_ICALL_ADDR, icall_name);
@@ -925,27 +925,28 @@ mono_amd64_get_exception_trampolines (gboolean aot, gboolean reg)
 {
 	MonoTrampInfo *info;
 	GSList *tramps = NULL;
+	const char *name;
 
 	/* LLVM needs different throw trampolines */
-	get_throw_trampoline (&info, FALSE, TRUE, FALSE, FALSE, "llvm_throw_corlib_exception_trampoline", aot, FALSE);
+	get_throw_trampoline (&info, FALSE, TRUE, FALSE, FALSE, name = "llvm_throw_corlib_exception_trampoline", aot, FALSE);
 	if (reg) {
-		mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_throw_corlib_exception_trampoline, info->code, g_strdup (info->name), NULL, TRUE);
+		mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_throw_corlib_exception_trampoline, info->code, name, NULL, TRUE);
 		mono_tramp_info_register (info, NULL);
 	} else {
 		tramps = g_slist_prepend (tramps, info);
 	}
 
-	get_throw_trampoline (&info, FALSE, TRUE, TRUE, FALSE, "llvm_throw_corlib_exception_abs_trampoline", aot, FALSE);
+	get_throw_trampoline (&info, FALSE, TRUE, TRUE, FALSE, name = "llvm_throw_corlib_exception_abs_trampoline", aot, FALSE);
 	if (reg) {
-		mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_throw_corlib_exception_abs_trampoline, info->code, g_strdup (info->name), NULL, TRUE);
+		mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_throw_corlib_exception_abs_trampoline, info->code, name, NULL, TRUE);
 		mono_tramp_info_register (info, NULL);
 	} else {
 		tramps = g_slist_prepend (tramps, info);
 	}
 
-	get_throw_trampoline (&info, FALSE, TRUE, TRUE, TRUE, "llvm_resume_unwind_trampoline", aot, FALSE);
+	get_throw_trampoline (&info, FALSE, TRUE, TRUE, TRUE, name = "llvm_resume_unwind_trampoline", aot, FALSE);
 	if (reg) {
-		mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_resume_unwind_trampoline, info->code, g_strdup (info->name), NULL, TRUE);
+		mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_resume_unwind_trampoline, info->code, name, NULL, TRUE);
 		mono_tramp_info_register (info, NULL);
 	} else {
 		tramps = g_slist_prepend (tramps, info);

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -536,7 +536,7 @@ get_throw_trampoline (MonoTrampInfo **info, gboolean rethrow, gboolean corlib, g
 		if (resume_unwind)
 			icall_name = "mono_amd64_resume_unwind";
 		else if (corlib)
-			icall_name = llvm_abs ? "mono_amd64_throw_corlib_exception_abs" : "mono_amd64_throw_corlib_exception";
+			icall_name = "mono_amd64_throw_corlib_exception";
 		else
 			icall_name = "mono_amd64_throw_exception";
 		ji = mono_patch_info_list_prepend (ji, code - start, MONO_PATCH_INFO_JIT_ICALL_ADDR, icall_name);

--- a/mono/mini/exceptions-arm.c
+++ b/mono/mini/exceptions-arm.c
@@ -40,6 +40,7 @@
 #include "aot-runtime.h"
 #include "mono/utils/mono-sigcontext.h"
 #include "mono/utils/mono-compiler.h"
+#include "mono/metadata/register-icall-def.h"
 
 #ifndef DISABLE_JIT
 
@@ -385,20 +386,35 @@ mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 }	
 
 GSList*
-mono_arm_get_exception_trampolines (gboolean aot)
+mono_arm_get_exception_trampolines (gboolean aot, gboolean reg)
 {
 	MonoTrampInfo *info;
 	GSList *tramps = NULL;
 
 	/* LLVM uses the normal trampolines, but with a different name */
 	get_throw_trampoline (168, TRUE, FALSE, FALSE, FALSE, "llvm_throw_corlib_exception_trampoline", &info, aot, FALSE);
-	tramps = g_slist_prepend (tramps, info);
+	if (reg) {
+		mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_throw_corlib_exception_trampoline, info->code, g_strdup (info->name), NULL, TRUE);
+		mono_tramp_info_register (info, NULL);
+	} else {
+		tramps = g_slist_prepend (tramps, info);
+	}
 	
 	get_throw_trampoline (168, TRUE, FALSE, TRUE, FALSE, "llvm_throw_corlib_exception_abs_trampoline", &info, aot, FALSE);
-	tramps = g_slist_prepend (tramps, info);
+	if (reg) {
+		mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_throw_corlib_exception_abs_trampoline, info->code, g_strdup (info->name), NULL, TRUE);
+		mono_tramp_info_register (info, NULL);
+	} else {
+		tramps = g_slist_prepend (tramps, info);
+	}
 
 	get_throw_trampoline (168, FALSE, FALSE, FALSE, TRUE, "llvm_resume_unwind_trampoline", &info, aot, FALSE);
-	tramps = g_slist_prepend (tramps, info);
+	if (reg) {
+		mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_resume_unwind_trampoline, info->code, g_strdup (info->name), NULL, TRUE);
+		mono_tramp_info_register (info, NULL);
+	} else {
+		tramps = g_slist_prepend (tramps, info);
+	}
 
 	return tramps;
 }
@@ -406,7 +422,7 @@ mono_arm_get_exception_trampolines (gboolean aot)
 #else
 
 GSList*
-mono_arm_get_exception_trampolines (gboolean aot)
+mono_arm_get_exception_trampolines (gboolean aot, gboolean reg)
 {
 	g_assert_not_reached ();
 	return NULL;
@@ -417,25 +433,26 @@ mono_arm_get_exception_trampolines (gboolean aot)
 void
 mono_arch_exceptions_init (void)
 {
-	gpointer tramp;
-	GSList *tramps, *l;
-	
 	if (mono_aot_only) {
-		tramp = mono_aot_get_trampoline ("llvm_throw_corlib_exception_trampoline");
-		mono_register_jit_icall (tramp, "llvm_throw_corlib_exception_trampoline", NULL, TRUE);
-		tramp = mono_aot_get_trampoline ("llvm_throw_corlib_exception_abs_trampoline");
-		mono_register_jit_icall (tramp, "llvm_throw_corlib_exception_abs_trampoline", NULL, TRUE);
-		tramp = mono_aot_get_trampoline ("llvm_resume_unwind_trampoline");
-		mono_register_jit_icall (tramp, "llvm_resume_unwind_trampoline", NULL, TRUE);
-	} else {
-		tramps = mono_arm_get_exception_trampolines (FALSE);
-		for (l = tramps; l; l = l->next) {
-			MonoTrampInfo *info = (MonoTrampInfo*)l->data;
 
-			mono_register_jit_icall (info->code, g_strdup (info->name), NULL, TRUE);
-			mono_tramp_info_register (info, NULL);
+		typedef struct MonoArchExceptionsInit {
+			const char *name;
+			MonoJitICallInfo *jit_icall_info;
+		} MonoArchExceptionsInit;
+
+		const static MonoArchExceptionsInit inits [ ] = {
+			{ "llvm_throw_corlib_exception_trampoline", &mono_jit_icall_info.mono_llvm_throw_corlib_exception_trampoline },
+			{ "llvm_throw_corlib_exception_abs_trampoline", &mono_jit_icall_info.mono_llvm_throw_corlib_exception_abs_trampoline },
+			{ "llvm_resume_unwind_trampoline", &mono_jit_icall_info.mono_llvm_resume_unwind_trampoline },
+		};
+
+		for (guint i = 0; i < G_N_ELEMENTS (inits); ++i) {
+			const MonoArchExceptionsInit *init = &inits [i];
+			gpointer tramp = mono_aot_get_trampoline (init->name);
+			mono_register_jit_icall_info (init->jit_icall_info, tramp, init->name, NULL, TRUE);
 		}
-		g_slist_free (tramps);
+	} else {
+		mono_arm_get_exception_trampolines (FALSE, TRUE);
 	}
 }
 

--- a/mono/mini/exceptions-arm64.c
+++ b/mono/mini/exceptions-arm64.c
@@ -20,6 +20,7 @@
 
 #include <mono/arch/arm64/arm64-codegen.h>
 #include <mono/metadata/abi-details.h>
+#include "mono/metadata/register-icall-def.h"
 
 #ifndef DISABLE_JIT
 
@@ -287,20 +288,35 @@ mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 }
 
 GSList*
-mono_arm_get_exception_trampolines (gboolean aot)
+mono_arm_get_exception_trampolines (gboolean aot, gboolean reg)
 {
 	MonoTrampInfo *info;
 	GSList *tramps = NULL;
 
 	/* LLVM uses the normal trampolines, but with a different name */
 	get_throw_trampoline (256, TRUE, FALSE, FALSE, FALSE, "llvm_throw_corlib_exception_trampoline", &info, aot, FALSE);
-	tramps = g_slist_prepend (tramps, info);
+	if (reg) {
+		mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_throw_corlib_exception_trampoline, info->code, g_strdup (info->name), NULL, TRUE);
+		mono_tramp_info_register (info, NULL);
+	} else {
+		tramps = g_slist_prepend (tramps, info);
+	}
 	
 	get_throw_trampoline (256, TRUE, FALSE, TRUE, FALSE, "llvm_throw_corlib_exception_abs_trampoline", &info, aot, FALSE);
-	tramps = g_slist_prepend (tramps, info);
+	if (reg) {
+		mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_throw_corlib_exception_abs_trampoline, info->code, g_strdup (info->name), NULL, TRUE);
+		mono_tramp_info_register (info, NULL);
+	} else {
+		tramps = g_slist_prepend (tramps, info);
+	}
 
 	get_throw_trampoline (256, FALSE, FALSE, FALSE, TRUE, "llvm_resume_unwind_trampoline", &info, aot, FALSE);
-	tramps = g_slist_prepend (tramps, info);
+	if (reg) {
+		mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_resume_unwind_trampoline, info->code, g_strdup (info->name), NULL, TRUE);
+		mono_tramp_info_register (info, NULL);
+	} else {
+		tramps = g_slist_prepend (tramps, info);
+	}
 
 	return tramps;
 }
@@ -308,7 +324,7 @@ mono_arm_get_exception_trampolines (gboolean aot)
 #else
 
 GSList*
-mono_arm_get_exception_trampolines (gboolean aot)
+mono_arm_get_exception_trampolines (gboolean aot, gboolean reg)
 {
 	g_assert_not_reached ();
 	return NULL;
@@ -319,25 +335,25 @@ mono_arm_get_exception_trampolines (gboolean aot)
 void
 mono_arch_exceptions_init (void)
 {
-	gpointer tramp;
-	GSList *tramps, *l;
-
 	if (mono_aot_only) {
-		tramp = mono_aot_get_trampoline ("llvm_throw_corlib_exception_trampoline");
-		mono_register_jit_icall (tramp, "llvm_throw_corlib_exception_trampoline", NULL, TRUE);
-		tramp = mono_aot_get_trampoline ("llvm_throw_corlib_exception_abs_trampoline");
-		mono_register_jit_icall (tramp, "llvm_throw_corlib_exception_abs_trampoline", NULL, TRUE);
-		tramp = mono_aot_get_trampoline ("llvm_resume_unwind_trampoline");
-		mono_register_jit_icall (tramp, "llvm_resume_unwind_trampoline", NULL, TRUE);
-	} else {
-		tramps = mono_arm_get_exception_trampolines (FALSE);
-		for (l = tramps; l; l = l->next) {
-			MonoTrampInfo *info = (MonoTrampInfo*)l->data;
+		typedef struct MonoArchExceptionsInit {
+			const char *name;
+			MonoJitICallInfo *jit_icall_info;
+		} MonoArchExceptionsInit;
 
-			mono_register_jit_icall (info->code, g_strdup (info->name), NULL, TRUE);
-			mono_tramp_info_register (info, NULL);
+		const static MonoArchExceptionsInit inits [ ] = {
+			{ "llvm_throw_corlib_exception_trampoline", &mono_jit_icall_info.mono_llvm_throw_corlib_exception_trampoline },
+			{ "llvm_throw_corlib_exception_abs_trampoline", &mono_jit_icall_info.mono_llvm_throw_corlib_exception_abs_trampoline },
+			{ "llvm_resume_unwind_trampoline", &mono_jit_icall_info.mono_llvm_resume_unwind_trampoline },
+		};
+
+		for (guint i = 0; i < G_N_ELEMENTS (inits); ++i) {
+			const MonoArchExceptionsInit *init = &inits [i];
+			gpointer tramp = mono_aot_get_trampoline (init->name);
+			mono_register_jit_icall_info (init->jit_icall_info, tramp, init->name, NULL, TRUE);
 		}
-		g_slist_free (tramps);
+	} else {
+		mono_arm_get_exception_trampolines (FALSE, TRUE);
 	}
 }
 

--- a/mono/mini/exceptions-mips.c
+++ b/mono/mini/exceptions-mips.c
@@ -30,6 +30,7 @@
 #include "mini-mips.h"
 #include "mini-runtime.h"
 #include "aot-runtime.h"
+#include "mono/metadata/register-icall-def.h"
 
 #define GENERIC_EXCEPTION_SIZE 256
 

--- a/mono/mini/exceptions-ppc.c
+++ b/mono/mini/exceptions-ppc.c
@@ -32,6 +32,7 @@
 #include "mini-ppc.h"
 #include "mini-runtime.h"
 #include "aot-runtime.h"
+#include "mono/metadata/register-icall-def.h"
 
 /*
 

--- a/mono/mini/exceptions-s390x.c
+++ b/mono/mini/exceptions-s390x.c
@@ -63,6 +63,7 @@
 #include "support-s390x.h"
 #include "mini-runtime.h"
 #include "aot-runtime.h"
+#include "mono/metadata/register-icall-def.h"
 
 /*========================= End of Includes ========================*/
 

--- a/mono/mini/exceptions-sparc.c
+++ b/mono/mini/exceptions-sparc.c
@@ -27,6 +27,7 @@
 
 #include "mini.h"
 #include "mini-sparc.h"
+#include "mono/metadata/register-icall-def.h"
 
 #ifndef REG_SP
 #define REG_SP REG_O6

--- a/mono/mini/exceptions-x86.c
+++ b/mono/mini/exceptions-x86.c
@@ -33,6 +33,7 @@
 #include "mini-runtime.h"
 #include "tasklets.h"
 #include "aot-runtime.h"
+#include "mono/metadata/register-icall-def.h"
 
 static gpointer signal_exception_trampoline;
 
@@ -768,23 +769,23 @@ mono_arch_exceptions_init (void)
 
 	/* LLVM needs different throw trampolines */
 	tramp = get_throw_trampoline ("llvm_throw_exception_trampoline", FALSE, TRUE, FALSE, FALSE, FALSE, &tinfo, FALSE,  FALSE);
-	mono_register_jit_icall (tramp, "llvm_throw_exception_trampoline", NULL, TRUE);
+	mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_throw_exception_trampoline, tramp, "llvm_throw_exception_trampoline", NULL, TRUE);
 	mono_tramp_info_register (tinfo, NULL);
 
 	tramp = get_throw_trampoline ("llvm_rethrow_exception_trampoline", TRUE, TRUE, FALSE, FALSE, FALSE, &tinfo, FALSE, FALSE);
-	mono_register_jit_icall (tramp, "llvm_rethrow_exception_trampoline", NULL, TRUE);
+	mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_rethrow_exception_trampoline, tramp, "llvm_rethrow_exception_trampoline", NULL, TRUE);
 	mono_tramp_info_register (tinfo, NULL);
 
 	tramp = get_throw_trampoline ("llvm_throw_corlib_exception_trampoline", FALSE, TRUE, TRUE, FALSE, FALSE, &tinfo, FALSE, FALSE);
-	mono_register_jit_icall (tramp, "llvm_throw_corlib_exception_trampoline", NULL, TRUE);
+	mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_throw_corlib_exception_trampoline, tramp, "llvm_throw_corlib_exception_trampoline", NULL, TRUE);
 	mono_tramp_info_register (tinfo, NULL);
 
 	tramp = get_throw_trampoline ("llvm_throw_corlib_exception_abs_trampoline", FALSE, TRUE, TRUE, TRUE, FALSE, &tinfo, FALSE, FALSE);
-	mono_register_jit_icall (tramp, "llvm_throw_corlib_exception_abs_trampoline", NULL, TRUE);
+	mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_throw_corlib_exception_abs_trampoline, tramp, "llvm_throw_corlib_exception_abs_trampoline", NULL, TRUE);
 	mono_tramp_info_register (tinfo, NULL);
 
 	tramp = get_throw_trampoline ("llvm_resume_unwind_trampoline", FALSE, FALSE, FALSE, FALSE, TRUE, &tinfo, FALSE, FALSE);
-	mono_register_jit_icall (tramp, "llvm_resume_unwind_trampoline", NULL, TRUE);
+	mono_register_jit_icall_info (&mono_jit_icall_info.mono_llvm_resume_unwind_trampoline, tramp, "llvm_resume_unwind_trampoline", NULL, TRUE);
 	mono_tramp_info_register (tinfo, NULL);
 
 	signal_exception_trampoline = mono_x86_get_signal_exception_trampoline (&tinfo, FALSE);

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -77,6 +77,7 @@
 #include <mono/mini/mini-arm.h>
 #endif
 #include <mono/metadata/icall-decl.h>
+#include "mono/metadata/register-icall-def.h"
 
 #ifdef _MSC_VER
 #pragma warning(disable:4102) // label' : unreferenced label

--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -18,6 +18,7 @@
 #include <mono/metadata/gc-internals.h>
 #include <mono/metadata/monitor.h>
 #include <mono/utils/mono-memory-model.h>
+#include "mono/metadata/register-icall-def.h"
 
 static GENERATE_GET_CLASS_WITH_CACHE (runtime_helpers, "System.Runtime.CompilerServices", "RuntimeHelpers")
 static GENERATE_TRY_GET_CLASS_WITH_CACHE (math, "System", "Math")
@@ -762,10 +763,19 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 
 			NEW_BBLOCK (cfg, end_bb);
 
-			ins = mono_emit_jit_icall (cfg, is_v4 ? (gpointer)mono_monitor_enter_v4_fast : (gpointer)mono_monitor_enter_fast, args);
+			if (is_v4)
+				ins = mono_emit_jit_icall (cfg, mono_monitor_enter_v4_fast, args);
+			else
+				ins = mono_emit_jit_icall (cfg, mono_monitor_enter_fast, args);
+
 			MONO_EMIT_NEW_BIALU_IMM (cfg, OP_ICOMPARE_IMM, -1, ins->dreg, 0);
 			MONO_EMIT_NEW_BRANCH_BLOCK (cfg, OP_IBNE_UN, end_bb);
-			ins = mono_emit_jit_icall (cfg, is_v4 ? (gpointer)mono_monitor_enter_v4_internal : (gpointer)mono_monitor_enter_internal, args);
+
+			if (is_v4)
+				ins = mono_emit_jit_icall (cfg, mono_monitor_enter_v4_internal, args);
+			else
+				ins = mono_emit_jit_icall (cfg, mono_monitor_enter_internal, args);
+
 			MONO_START_BB (cfg, end_bb);
 			return ins;
 		}
@@ -1375,7 +1385,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 			(strcmp (cmethod_klass_name, "Debugger") == 0)) {
 		if (!strcmp (cmethod->name, "Break") && fsig->param_count == 0) {
 			if (mini_should_insert_breakpoint (cfg->method)) {
-				ins = mono_emit_jit_icall (cfg, mini_get_dbg_callbacks ()->user_break, NULL);
+				ins = mono_emit_jit_icall (cfg, mono_debugger_agent_user_break, NULL);
 			} else {
 				MONO_INST_NEW (cfg, ins, OP_NOP);
 				MONO_ADD_INS (cfg->cbb, ins);

--- a/mono/mini/memory-access.c
+++ b/mono/mini/memory-access.c
@@ -15,6 +15,7 @@
 #include "mini.h"
 #include "ir-emit.h"
 #include "jit-icalls.h"
+#include "mono/metadata/register-icall-def.h"
 
 #define MAX_INLINE_COPIES 10
 #define MAX_INLINE_COPY_SIZE 10000
@@ -424,7 +425,7 @@ mini_emit_memory_copy_internal (MonoCompile *cfg, MonoInst *dest, MonoInst *src,
 				size &= ~(TARGET_SIZEOF_VOID_P - 1);
 
 				EMIT_NEW_ICONST (cfg, iargs [2], size);
-				mono_emit_jit_icall (cfg, mono_gc_get_range_copy_func (), iargs);
+				mono_emit_jit_icall (cfg, mono_gc_wbarrier_range_copy, iargs);
 			}
 			return;
 		}

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -85,6 +85,7 @@
 #include "mini-llvm.h"
 #include "mini-runtime.h"
 #include "llvmonly-runtime.h"
+#include "mono/metadata/register-icall-def.h"
 
 #define BRANCH_COST 10
 #define CALL_COST 10
@@ -1710,8 +1711,10 @@ mono_create_tls_get (MonoCompile *cfg, MonoTlsKey key)
 		EMIT_NEW_AOTCONST (cfg, addr, MONO_PATCH_INFO_GET_TLS_TRAMP, GUINT_TO_POINTER(key));
 		return mini_emit_calli (cfg, mono_icall_sig_ptr, NULL, addr, NULL, NULL);
 	} else {
-		gpointer getter = (gpointer)mono_tls_get_tls_getter (key);
-		return mono_emit_jit_icall (cfg, getter, NULL);
+		g_assert (TLS_KEY_THREAD == 0); // static_assert
+		MonoJitICallInfo *jit_icall_info = &mono_jit_icall_info.array [MONO_JIT_ICALL_mono_tls_get_thread + key];
+		jit_icall_info->func = (gpointer)mono_tls_get_tls_getter (key);
+		return mono_emit_jit_icall_info (cfg, jit_icall_info, NULL);
 	}
 }
 
@@ -3149,7 +3152,7 @@ static MonoInst*
 handle_alloc (MonoCompile *cfg, MonoClass *klass, gboolean for_box, int context_used)
 {
 	MonoInst *iargs [2];
-	void *alloc_ftn;
+	MonoJitICallInfo *alloc_ftn;
 
 	if (mono_class_get_flags (klass) & TYPE_ATTRIBUTE_ABSTRACT) {
 		char* full_name = mono_type_get_full_name (klass);
@@ -3176,10 +3179,10 @@ handle_alloc (MonoCompile *cfg, MonoClass *klass, gboolean for_box, int context_
 		if (cfg->opt & MONO_OPT_SHARED) {
 			EMIT_NEW_DOMAINCONST (cfg, iargs [0]);
 			iargs [1] = data;
-			alloc_ftn = (gpointer)ves_icall_object_new;
+			alloc_ftn = &mono_jit_icall_info.ves_icall_object_new;
 		} else {
 			iargs [0] = data;
-			alloc_ftn = (gpointer)ves_icall_object_new_specific;
+			alloc_ftn = &mono_jit_icall_info.ves_icall_object_new_specific;
 		}
 
 		if (managed_alloc && !(cfg->opt & MONO_OPT_SHARED)) {
@@ -3193,19 +3196,19 @@ handle_alloc (MonoCompile *cfg, MonoClass *klass, gboolean for_box, int context_
 			return mono_emit_method_call (cfg, managed_alloc, iargs, NULL);
 		}
 
-		return mono_emit_jit_icall (cfg, alloc_ftn, iargs);
+		return mono_emit_jit_icall_info (cfg, alloc_ftn, iargs);
 	}
 
 	if (cfg->opt & MONO_OPT_SHARED) {
 		EMIT_NEW_DOMAINCONST (cfg, iargs [0]);
 		EMIT_NEW_CLASSCONST (cfg, iargs [1], klass);
 
-		alloc_ftn = (gpointer)ves_icall_object_new;
+		alloc_ftn = &mono_jit_icall_info.ves_icall_object_new;
 	} else if (cfg->compile_aot && cfg->cbb->out_of_line && m_class_get_type_token (klass) && m_class_get_image (klass) == mono_defaults.corlib && !mono_class_is_ginst (klass)) {
 		/* This happens often in argument checking code, eg. throw new FooException... */
 		/* Avoid relocations and save some space by calling a helper function specialized to mscorlib */
 		EMIT_NEW_ICONST (cfg, iargs [0], mono_metadata_token_index (m_class_get_type_token (klass)));
-		alloc_ftn = (gpointer)mono_helper_newobj_mscorlib;
+		alloc_ftn = &mono_jit_icall_info.mono_helper_newobj_mscorlib;
 	} else {
 		MonoVTable *vtable = mono_class_vtable_checked (cfg->domain, klass, &cfg->error);
 
@@ -3225,11 +3228,11 @@ handle_alloc (MonoCompile *cfg, MonoClass *klass, gboolean for_box, int context_
 			EMIT_NEW_ICONST (cfg, iargs [1], size);
 			return mono_emit_method_call (cfg, managed_alloc, iargs, NULL);
 		}
-		alloc_ftn = (gpointer)ves_icall_object_new_specific;
+		alloc_ftn = &mono_jit_icall_info.ves_icall_object_new_specific;
 		EMIT_NEW_VTABLECONST (cfg, iargs [0], vtable);
 	}
 
-	return mono_emit_jit_icall (cfg, alloc_ftn, iargs);
+	return mono_emit_jit_icall_info (cfg, alloc_ftn, iargs);
 }
 	
 /*
@@ -6536,7 +6539,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			break;
 		case MONO_CEE_BREAK:
 			if (mini_should_insert_breakpoint (cfg->method)) {
-				ins = mono_emit_jit_icall (cfg, mini_get_dbg_callbacks ()->user_break, NULL);
+				ins = mono_emit_jit_icall (cfg, mono_debugger_agent_user_break, NULL);
 			} else {
 				MONO_INST_NEW (cfg, ins, OP_NOP);
 			}
@@ -8546,16 +8549,16 @@ calli_end:
 				*sp = emit_get_rgctx_method (cfg, context_used,
 											 cmethod, MONO_RGCTX_INFO_METHOD);
 				/* Optimize the common cases */
-				gpointer function = NULL;
+				MonoJitICallInfo *function = NULL;
 				int n = fsig->param_count;
 				switch (n) {
-				case 1: function = (gpointer)mono_array_new_1;
+				case 1: function = &mono_jit_icall_info.mono_array_new_1;
 					break;
-				case 2: function = (gpointer)mono_array_new_2;
+				case 2: function = &mono_jit_icall_info.mono_array_new_2;
 					break;
-				case 3: function = (gpointer)mono_array_new_3;
+				case 3: function = &mono_jit_icall_info.mono_array_new_3;
 					break;
-				case 4: function = (gpointer)mono_array_new_4;
+				case 4: function = &mono_jit_icall_info.mono_array_new_4;
 					break;
 				default:
 					// FIXME Maximum value of param_count? Realistically 64. Fits in imm?
@@ -8577,10 +8580,10 @@ calli_end:
 					ins->type = STACK_PTR;
 					sp [2] = ins;
 					// FIXME Adjust sp by n - 3? Attempts failed.
-					function = (gpointer)mono_array_new_n_icall;
+					function = &mono_jit_icall_info.mono_array_new_n_icall;
 					break;
 				}
-				alloc = mono_emit_jit_icall (cfg, function, sp);
+				alloc = mono_emit_jit_icall_info (cfg, function, sp);
 			} else if (cmethod->string_ctor) {
 				g_assert (!context_used);
 				g_assert (!vtable_arg);
@@ -10099,14 +10102,12 @@ field_access_end:
 
 			func = mono_method_get_wrapper_data (method, token);
 			info = mono_find_jit_icall_by_addr (func);
-			if (!info)
-				g_error ("Could not find icall address in wrapper %s", mono_method_full_name (method, 1));
-			g_assert (info);
+			g_assertf (info, "Could not find icall address in wrapper %s", mono_method_full_name (method, 1));
 
 			CHECK_STACK (info->sig->param_count);
 			sp -= info->sig->param_count;
 
-			if (!strcmp (info->name, "mono_threads_attach_coop")) {
+			if (info == &mono_jit_icall_info.mono_threads_attach_coop) {
 				MonoInst *addr;
 				MonoBasicBlock *next_bb;
 
@@ -10119,7 +10120,7 @@ field_access_end:
 					EMIT_NEW_AOTCONST (cfg, addr, MONO_PATCH_INFO_JIT_ICALL_ADDR_NOCALL, (char*)info->name);
 					ins = mini_emit_calli (cfg, info->sig, sp, addr, NULL, NULL);
 				} else {
-					ins = mono_emit_jit_icall (cfg, info->func, sp);
+					ins = mono_emit_jit_icall_info (cfg, info, sp);
 				}
 
 				/*
@@ -10129,7 +10130,7 @@ field_access_end:
 				NEW_BBLOCK (cfg, next_bb);
 				MONO_START_BB (cfg, next_bb);
 			} else {
-				ins = mono_emit_jit_icall (cfg, info->func, sp);
+				ins = mono_emit_jit_icall_info (cfg, info, sp);
 			}
 
 			if (!MONO_TYPE_IS_VOID (info->sig->ret))

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -1711,9 +1711,9 @@ mono_create_tls_get (MonoCompile *cfg, MonoTlsKey key)
 		EMIT_NEW_AOTCONST (cfg, addr, MONO_PATCH_INFO_GET_TLS_TRAMP, GUINT_TO_POINTER(key));
 		return mini_emit_calli (cfg, mono_icall_sig_ptr, NULL, addr, NULL, NULL);
 	} else {
-		g_assert (TLS_KEY_THREAD == 0); // static_assert
+		g_assert (TLS_KEY_THREAD == 0); // FIXME static_assert
 		MonoJitICallInfo *jit_icall_info = &mono_jit_icall_info.array [MONO_JIT_ICALL_mono_tls_get_thread + key];
-		jit_icall_info->func = (gpointer)mono_tls_get_tls_getter (key);
+		g_assert (jit_icall_info->func == (gpointer)mono_tls_get_tls_getter (key));
 		return mono_emit_jit_icall_info (cfg, jit_icall_info, NULL);
 	}
 }

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -516,7 +516,7 @@ gpointer
 mono_amd64_start_gsharedvt_call (GSharedVtCallInfo *info, gpointer *caller, gpointer *callee, gpointer mrgctx_reg);
 
 GSList*
-mono_amd64_get_exception_trampolines (gboolean aot);
+mono_amd64_get_exception_trampolines (gboolean aot, gboolean reg);
 
 int
 mono_amd64_get_tls_gs_offset (void) MONO_LLVM_INTERNAL;

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -34,6 +34,7 @@
 #include "mini-runtime.h"
 #include "aot-runtime.h"
 #include "mono/arch/arm/arm-vfp-codegen.h"
+#include "mono/metadata/register-icall-def.h"
 
 /* Sanity check: This makes no sense */
 #if defined(ARM_FPU_NONE) && (defined(ARM_FPU_VFP) || defined(ARM_FPU_VFP_HARD))
@@ -7170,7 +7171,7 @@ mono_arch_context_set_int_reg (MonoContext *ctx, int reg, host_mgreg_t val)
 GSList *
 mono_arch_get_trampolines (gboolean aot)
 {
-	return mono_arm_get_exception_trampolines (aot);
+	return mono_arm_get_exception_trampolines (aot, FALSE);
 }
 
 #if defined(MONO_ARCH_SOFT_DEBUG_SUPPORTED)

--- a/mono/mini/mini-arm.h
+++ b/mono/mini/mini-arm.h
@@ -415,7 +415,7 @@ int
 mono_arm_i8_align (void);
 
 GSList*
-mono_arm_get_exception_trampolines (gboolean aot);
+mono_arm_get_exception_trampolines (gboolean aot, gboolean reg);
 
 guint8*
 mono_arm_get_thumb_plt_entry (guint8 *code);

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -28,6 +28,7 @@
 #include <mono/metadata/abi-details.h>
 
 #include "interp/interp.h"
+#include "mono/metadata/register-icall-def.h"
 
 /*
  * Documentation:
@@ -5393,7 +5394,7 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTC
 GSList *
 mono_arch_get_trampolines (gboolean aot)
 {
-	return mono_arm_get_exception_trampolines (aot);
+	return mono_arm_get_exception_trampolines (aot, FALSE);
 }
 
 #else /* DISABLE_JIT */

--- a/mono/mini/mini-arm64.h
+++ b/mono/mini/mini-arm64.h
@@ -277,7 +277,7 @@ void mono_arm_throw_exception (gpointer arg, host_mgreg_t pc, host_mgreg_t *int_
 
 void mono_arm_gsharedvt_init (void);
 
-GSList* mono_arm_get_exception_trampolines (gboolean aot);
+GSList* mono_arm_get_exception_trampolines (gboolean aot, gboolean reg);
 
 void mono_arm_resume_unwind (gpointer arg, host_mgreg_t pc, host_mgreg_t *int_regs, gdouble *fp_regs, gboolean corlib, gboolean rethrow);
 

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -21,11 +21,11 @@
 #include <mono/utils/mono-counters.h>
 #include <mono/utils/atomic.h>
 #include <mono/utils/unlocked.h>
-
 #include "mini.h"
 #include "aot-runtime.h"
 #include "mini-runtime.h"
 #include "llvmonly-runtime.h"
+#include "mono/metadata/register-icall-def.h"
 
 #define ALLOW_PARTIAL_SHARING TRUE
 //#define ALLOW_PARTIAL_SHARING FALSE

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -36,6 +36,7 @@
 #include "mini-llvm.h"
 #include "mini-runtime.h"
 #include <mono/utils/mono-math.h>
+#include "mono/metadata/register-icall-def.h"
 
 #ifndef DISABLE_JIT
 

--- a/mono/mini/mini-mips.c
+++ b/mono/mini/mini-mips.c
@@ -30,6 +30,7 @@
 #include "ir-emit.h"
 #include "aot-runtime.h"
 #include "mini-runtime.h"
+#include "mono/metadata/register-icall-def.h"
 
 #define SAVE_FP_REGS		0
 

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -39,6 +39,7 @@
 #ifdef _AIX
 #include <sys/systemcfg.h>
 #endif
+#include "mono/metadata/register-icall-def.h"
 
 static GENERATE_TRY_GET_CLASS_WITH_CACHE (math, "System", "Math")
 static GENERATE_TRY_GET_CLASS_WITH_CACHE (mathf, "System", "MathF")

--- a/mono/mini/mini-profiler.c
+++ b/mono/mini/mini-profiler.c
@@ -13,6 +13,7 @@
 #include "ir-emit.h"
 #include "mini.h"
 #include "trace.h"
+#include "mono/metadata/register-icall-def.h"
 
 #ifndef DISABLE_JIT
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -699,11 +699,23 @@ register_opcode_emulation_info (int opcode, MonoJitICallInfo *info, const char *
 #endif
 }
 
+#ifdef MONO_ARCH_EMULATE_FREM
+
 // FIXME symbol can just be #func, except for mono_fmod, unless mono_fmod gains an instruction.
 #define register_opcode_emulation(opcode, name, sig, func, symbol, no_wrapper) 	do { \
 	g_assert (func == mono_fmod || !strcmp (#func, symbol)); \
 	register_opcode_emulation_info ((opcode), (&mono_jit_icall_info.name), (#name), (sig), (gpointer)(func), (symbol), (no_wrapper)); \
 } while(0)
+
+#else
+
+// FIXME symbol can just be #func, except for mono_fmod, unless mono_fmod gains an instruction.
+#define register_opcode_emulation(opcode, name, sig, func, symbol, no_wrapper) 	do { \
+	g_assert (!strcmp (#func, symbol)); \
+	register_opcode_emulation_info ((opcode), (&mono_jit_icall_info.name), (#name), (sig), (gpointer)(func), (symbol), (no_wrapper)); \
+} while(0)
+
+#endif
 
 /*
  * For JIT icalls implemented in C.

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -703,7 +703,7 @@ register_opcode_emulation_info (int opcode, MonoJitICallInfo *info, const char *
 
 // FIXME symbol can just be #func, except for mono_fmod, unless mono_fmod gains an instruction.
 #define register_opcode_emulation(opcode, name, sig, func, symbol, no_wrapper) 	do { \
-	g_assert (func == mono_fmod || !strcmp (#func, symbol)); \
+	g_assert ((gpointer)func == (gpointer)mono_fmod || !strcmp (#func, symbol)); \
 	register_opcode_emulation_info ((opcode), (&mono_jit_icall_info.name), (#name), (sig), (gpointer)(func), (symbol), (no_wrapper)); \
 } while(0)
 

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -700,12 +700,10 @@ register_opcode_emulation_info (int opcode, MonoJitICallInfo *info, const char *
 }
 
 // FIXME symbol can just be #func
-// The opcode emulation jit_icall_info does not need to be public, so instantiate
-// it here instead of in register-icall-def.h. A scope is not placed
-// here, to more likely catch duplicates.
-#define register_opcode_emulation(opcode, name, sig, func, symbol, no_wrapper) 	\
+#define register_opcode_emulation(opcode, name, sig, func, symbol, no_wrapper) 	do { \
 	g_assert (!strcmp (#func, symbol)); \
-	register_opcode_emulation_info ((opcode), (&mono_jit_icall_info.name), (#name), (sig), (gpointer)(func), (symbol), (no_wrapper)) \
+	register_opcode_emulation_info ((opcode), (&mono_jit_icall_info.name), (#name), (sig), (gpointer)(func), (symbol), (no_wrapper)); \
+} while(0)
 
 /*
  * For JIT icalls implemented in C.

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4393,7 +4393,8 @@ mini_init (const char *filename, const char *runtime_version)
 
 #ifdef MONO_ARCH_EMULATE_FREM
 // Wrapper to avoid taking address of overloaded function.
-static double
+G_EXTERN_C
+double
 mono_fmod (double a, double b)
 {
 	return fmod (a, b);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -699,9 +699,9 @@ register_opcode_emulation_info (int opcode, MonoJitICallInfo *info, const char *
 #endif
 }
 
-// FIXME symbol can just be #func
+// FIXME symbol can just be #func, except for mono_fmod, unless mono_fmod gains an instruction.
 #define register_opcode_emulation(opcode, name, sig, func, symbol, no_wrapper) 	do { \
-	g_assert (!strcmp (#func, symbol)); \
+	g_assert (func == mono_fmod || !strcmp (#func, symbol)); \
 	register_opcode_emulation_info ((opcode), (&mono_jit_icall_info.name), (#name), (sig), (gpointer)(func), (symbol), (no_wrapper)); \
 } while(0)
 
@@ -4391,8 +4391,7 @@ mini_init (const char *filename, const char *runtime_version)
 
 #ifdef MONO_ARCH_EMULATE_FREM
 // Wrapper to avoid taking address of overloaded function.
-G_EXTERN_C
-double
+static double
 mono_fmod (double a, double b)
 {
 	return fmod (a, b);

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -435,8 +435,8 @@ MONO_API int       mono_parse_default_optimizations  (const char* p);
 gboolean          mono_running_on_valgrind (void);
 
 MonoLMF * mono_get_lmf                      (void);
-#define mono_get_lmf_addr mono_tls_get_lmf_addr
-MonoLMF** mono_get_lmf_addr                 (void);
+MonoLMF** mono_get_lmf_addr                 (void); // mono_get_lmf_addr and mono_tls_get_lmf_addr are the same thing
+MonoLMF** mono_tls_get_lmf_addr				(void); // mono_get_lmf_addr and mono_tls_get_lmf_addr are the same thing
 void      mono_set_lmf                      (MonoLMF *lmf);
 void      mono_push_lmf                     (MonoLMFExt *ext);
 void      mono_pop_lmf                      (MonoLMF *lmf);

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -341,6 +341,7 @@ if (ins->inst_true_bb->native_offset) { 					\
 #include "mini-gc.h"
 #include "aot-runtime.h"
 #include "mini-runtime.h"
+#include "mono/metadata/register-icall-def.h"
 
 /*========================= End of Includes ========================*/
 

--- a/mono/mini/mini-sparc.c
+++ b/mono/mini/mini-sparc.c
@@ -37,6 +37,7 @@
 #include "cpu-sparc.h"
 #include "jit-icalls.h"
 #include "ir-emit.h"
+#include "mono/metadata/register-icall-def.h"
 
 /*
  * Sparc V9 means two things:

--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -26,6 +26,8 @@
 
 #include "interp/interp.h"
 
+#include "mono/metadata/register-icall-def.h"
+
 /*
  * Address of the trampoline code.  This is used by the debugger to check
  * whether a method is a trampoline.

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -40,6 +40,7 @@
 #include "mini-gc.h"
 #include "aot-runtime.h"
 #include "mini-runtime.h"
+#include "mono/metadata/register-icall-def.h"
 
 #ifndef TARGET_WIN32
 #ifdef MONO_XEN_OPT

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -81,6 +81,7 @@
 #include "lldb.h"
 #include "aot-runtime.h"
 #include "mini-runtime.h"
+#include "mono/metadata/register-icall-def.h"
 
 MonoCallSpec *mono_jit_trace_calls;
 MonoMethodDesc *mono_inject_async_exc_method;
@@ -1678,15 +1679,14 @@ mono_find_jit_opcode_emulation (int opcode)
 }
 
 void
-mini_register_opcode_emulation (int opcode, const char *name, MonoMethodSignature *sig, gpointer func, const char *symbol, gboolean no_wrapper)
+mini_register_opcode_emulation_info (int opcode, MonoJitICallInfo *info, const char *name, MonoMethodSignature *sig, gpointer func, const char *symbol, gboolean no_wrapper)
 {
-	MonoJitICallInfo *info;
-
 	g_assert (!sig->hasthis);
 	g_assert (sig->param_count < 3);
 
-	info = mono_register_jit_icall_full (func, name, sig, no_wrapper, symbol);
+	mono_register_jit_icall_info_full (info, func, name, sig, no_wrapper, symbol);
 
+//FIXME #ifndef DISABLE_JIT
 	if (emul_opcode_num >= emul_opcode_alloced) {
 		int incr = emul_opcode_alloced? emul_opcode_alloced/2: 16;
 		emul_opcode_alloced += incr;
@@ -1697,6 +1697,7 @@ mini_register_opcode_emulation (int opcode, const char *name, MonoMethodSignatur
 	emul_opcode_opcodes [emul_opcode_num] = opcode;
 	emul_opcode_num++;
 	emul_opcode_hit_cache [opcode >> (EMUL_HIT_SHIFT + 3)] |= (1 << (opcode & EMUL_HIT_MASK));
+//FIXME #endif
 }
 
 static void

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2062,16 +2062,8 @@ gboolean mono_compile_is_broken (MonoCompile *cfg, MonoMethod *method, gboolean 
 MonoInst *mono_get_got_var (MonoCompile *cfg);
 void      mono_add_seq_point (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins, int native_offset);
 void      mono_add_var_location (MonoCompile *cfg, MonoInst *var, gboolean is_reg, int reg, int offset, int from, int to);
-MonoInst* mono_emit_jit_icall (MonoCompile *cfg, gconstpointer func, MonoInst **args);
-
-#ifdef __cplusplus
-template <typename T>
-inline MonoInst*
-mono_emit_jit_icall (MonoCompile *cfg, T func, MonoInst **args)
-{
-	return mono_emit_jit_icall (cfg, (gconstpointer)func, args);
-}
-#endif // __cplusplus
+MonoInst* mono_emit_jit_icall_info (MonoCompile *cfg, MonoJitICallInfo *jit_icall_info, MonoInst **args);
+#define mono_emit_jit_icall(cfg, name, args) (mono_emit_jit_icall_info ((cfg), &mono_jit_icall_info.name, (args)))
 
 MonoInst* mono_emit_jit_icall_by_info (MonoCompile *cfg, int il_offset, MonoJitICallInfo *info, MonoInst **args);
 MonoInst* mono_emit_method_call (MonoCompile *cfg, MonoMethod *method, MonoInst **args, MonoInst *this_ins);
@@ -2103,14 +2095,14 @@ void      mono_add_ins_to_end               (MonoBasicBlock *bb, MonoInst *inst)
 
 void      mono_replace_ins                  (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins, MonoInst **prev, MonoBasicBlock *first_bb, MonoBasicBlock *last_bb);
 
-void              mini_register_opcode_emulation (int opcode, const char *name, MonoMethodSignature *sig, gpointer func, const char *symbol, gboolean no_throw);
+void     mini_register_opcode_emulation_info (int opcode, MonoJitICallInfo *jit_icall_info, const char* name, MonoMethodSignature *sig, gpointer func, const char *symbol, gboolean no_throw);
 
 #ifdef __cplusplus
 template <typename T>
 inline void
-mini_register_opcode_emulation (int opcode, const char *name, MonoMethodSignature *sig, T func, const char *symbol, gboolean no_throw)
+mini_register_opcode_emulation_info (int opcode, MonoJitICallInfo *jit_icall_info, const char* name, MonoMethodSignature *sig, T func, gboolean no_throw)
 {
-	mini_register_opcode_emulation (opcode, name, sig, (gpointer)func, symbol, no_throw);
+	mini_register_opcode_emulation_info (opcode, jit_icall_info, name, sig, (gpointer)func, no_throw);
 }
 #endif // __cplusplus
 

--- a/mono/mini/tramp-amd64-gsharedvt.c
+++ b/mono/mini/tramp-amd64-gsharedvt.c
@@ -28,6 +28,7 @@
 #include "mini-amd64.h"
 #include "mini-amd64-gsharedvt.h"
 #include "debugger-agent.h"
+#include "mono/metadata/register-icall-def.h"
 
 #if defined (MONO_ARCH_GSHAREDVT_SUPPORTED)
 

--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -35,6 +35,8 @@
 #include "interp/interp.h"
 #endif
 
+#include "mono/metadata/register-icall-def.h"
+
 #define IS_REX(inst) (((inst) >= 0x40) && ((inst) <= 0x4f))
 
 #ifndef DISABLE_JIT

--- a/mono/mini/tramp-arm-gsharedvt.c
+++ b/mono/mini/tramp-arm-gsharedvt.c
@@ -22,6 +22,7 @@
 #include "mini.h"
 #include "mini-arm.h"
 #include "mini-runtime.h"
+#include "mono/metadata/register-icall-def.h"
 
 #ifdef MONO_ARCH_GSHAREDVT_SUPPORTED
 

--- a/mono/mini/tramp-arm.c
+++ b/mono/mini/tramp-arm.c
@@ -31,6 +31,7 @@
 #ifndef DISABLE_INTERPRETER
 #include "interp/interp.h"
 #endif
+#include "mono/metadata/register-icall-def.h"
 
 void
 mono_arch_patch_callsite (guint8 *method_start, guint8 *code_ptr, guint8 *addr)

--- a/mono/mini/tramp-arm64-gsharedvt.c
+++ b/mono/mini/tramp-arm64-gsharedvt.c
@@ -13,6 +13,7 @@
 #include "mini.h"
 #include "mini-arm64.h"
 #include "mini-arm64-gsharedvt.h"
+#include "mono/metadata/register-icall-def.h"
 
 /*
  * GSHAREDVT

--- a/mono/mini/tramp-arm64.c
+++ b/mono/mini/tramp-arm64.c
@@ -25,7 +25,7 @@
 #ifndef DISABLE_INTERPRETER
 #include "interp/interp.h"
 #endif
-
+#include "mono/metadata/register-icall-def.h"
 
 void
 mono_arch_patch_callsite (guint8 *method_start, guint8 *code_ptr, guint8 *addr)

--- a/mono/mini/tramp-ppc.c
+++ b/mono/mini/tramp-ppc.c
@@ -24,6 +24,7 @@
 #include "mini.h"
 #include "mini-ppc.h"
 #include "mini-runtime.h"
+#include "mono/metadata/register-icall-def.h"
 
 #if 0
 /* Same as mono_create_ftnptr, but doesn't require a domain */

--- a/mono/mini/tramp-x86-gsharedvt.c
+++ b/mono/mini/tramp-x86-gsharedvt.c
@@ -10,6 +10,7 @@
  */
 #include "mini.h"
 #include <mono/metadata/abi-details.h>
+#include "mono/metadata/register-icall-def.h"
 
 #ifdef MONO_ARCH_GSHAREDVT_SUPPORTED
 

--- a/mono/mini/tramp-x86.c
+++ b/mono/mini/tramp-x86.c
@@ -27,6 +27,7 @@
 #include "mini-runtime.h"
 #include "debugger-agent.h"
 #include "jit-icalls.h"
+#include "mono/metadata/register-icall-def.h"
 
 /*
  * mono_arch_get_unbox_trampoline:

--- a/mono/utils/mono-tls.c
+++ b/mono/utils/mono-tls.c
@@ -338,9 +338,18 @@ SgenThreadInfo *mono_tls_get_sgen_thread_info (void)
 	return (SgenThreadInfo*)MONO_TLS_GET_VALUE (mono_tls_sgen_thread_info, mono_tls_key_sgen_thread_info);
 }
 
+#define MONO_GET_LMF_ADDR() ((MonoLMF**)MONO_TLS_GET_VALUE (mono_tls_lmf_addr, mono_tls_key_lmf_addr))
+
 MonoLMF **mono_tls_get_lmf_addr (void)
 {
-	return (MonoLMF**)MONO_TLS_GET_VALUE (mono_tls_lmf_addr, mono_tls_key_lmf_addr);
+	return MONO_GET_LMF_ADDR();
+}
+
+MonoLMF **mono_get_lmf_addr (void)
+// This is duplicated from mono_tls_get_lmf_addr because JIT icall infrastructure checks for
+// duplicates, and both of these names are used.
+{
+	return MONO_GET_LMF_ADDR();
 }
 
 /* Setters for each tls key */

--- a/mono/utils/mono-tls.h
+++ b/mono/utils/mono-tls.h
@@ -18,6 +18,7 @@
 #include <mono/utils/mono-forward-internal.h>
 
 /* TLS entries used by the runtime */
+/* These values are mimiced in mono_create_tls_get and register-icall-def.h */
 typedef enum {
 	/* mono_thread_internal_current () */
 	TLS_KEY_THREAD = 0,

--- a/msvc/libmonoruntime-common.targets
+++ b/msvc/libmonoruntime-common.targets
@@ -106,6 +106,8 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\opcodes.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\property-bag.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\property-bag.c" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\register-icall-def.h" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\register-icall-def.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32socket.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32socket.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\w32socket-internals.h" />

--- a/msvc/libmonoruntime-common.targets.filters
+++ b/msvc/libmonoruntime-common.targets.filters
@@ -301,6 +301,12 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\property-bag.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common</Filter>
     </ClCompile>
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\register-icall-def.h">
+      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common</Filter>
+    </ClInclude>
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\register-icall-def.c">
+      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common</Filter>
+    </ClCompile>
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\w32socket.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common</Filter>
     </ClCompile>


### PR DESCRIPTION
Based on:
 https://github.com/mono/mono/pull/11941#issuecomment-449157323

Hash lookups can often/always be replaced
by directly referencing a struct,
or by indexing into a very dense array.

This PR is a stepping stone. The steps can be made smaller or larger.
There is definitely more to do.