### PR TITLE
[netcore] Fix couple of custom attribute tests

### DIFF
--- a/mcs/class/System.Private.CoreLib/System/Attribute.cs
+++ b/mcs/class/System.Private.CoreLib/System/Attribute.cs
@@ -6,6 +6,11 @@ namespace System
 	{
 		static Attribute GetAttr (ICustomAttributeProvider element, Type attributeType, bool inherit)
 		{
+            if (attributeType == null)
+                throw new ArgumentNullException (nameof (attributeType));
+            if (!attributeType.IsSubclassOf (typeof (Attribute)) && attributeType != typeof (Attribute))
+                throw new ArgumentException (SR.Argument_MustHaveAttributeBaseClass + " " + attributeType.FullName);
+
 			var attrs = MonoCustomAttrs.GetCustomAttributes (element, attributeType, inherit);
 			if (attrs == null || attrs.Length == 0)
 				return null;

--- a/mcs/class/System.Private.CoreLib/System/Attribute.cs
+++ b/mcs/class/System.Private.CoreLib/System/Attribute.cs
@@ -39,7 +39,17 @@ namespace System
         public static Attribute[] GetCustomAttributes (ParameterInfo element, bool inherit) => (Attribute[])MonoCustomAttrs.GetCustomAttributes (element, inherit);
         public static Attribute[] GetCustomAttributes (ParameterInfo element, Type attributeType) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, true);
         public static Attribute[] GetCustomAttributes (ParameterInfo element, Type attributeType, bool inherit) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, inherit);
-        internal static Attribute[] GetCustomAttributes (ICustomAttributeProvider element, Type attributeType, bool inherit) => (Attribute[])MonoCustomAttrs.GetCustomAttributes (element, attributeType, inherit);
+
+        internal static Attribute[] GetCustomAttributes (ICustomAttributeProvider element, Type attributeType, bool inherit)
+        {
+            if (attributeType == null)
+                throw new ArgumentNullException (nameof (attributeType));
+            if (!attributeType.IsSubclassOf (typeof (Attribute)) && attributeType != typeof (Attribute))
+                throw new ArgumentException (SR.Argument_MustHaveAttributeBaseClass + " " + attributeType.FullName);
+
+            return (Attribute[])MonoCustomAttrs.GetCustomAttributes (element, attributeType, inherit);
+        }
+
         public static bool IsDefined (Assembly element, Type attributeType) => IsDefined ((ICustomAttributeProvider)element, attributeType, true);
         public static bool IsDefined (Assembly element, Type attributeType, bool inherit) => IsDefined ((ICustomAttributeProvider)element, attributeType, inherit);
         public static bool IsDefined (MemberInfo element, Type attributeType) => IsDefined ((ICustomAttributeProvider)element, attributeType, true);

--- a/mcs/class/System.Private.CoreLib/System/Attribute.cs
+++ b/mcs/class/System.Private.CoreLib/System/Attribute.cs
@@ -6,10 +6,10 @@ namespace System
 	{
 		static Attribute GetAttr (ICustomAttributeProvider element, Type attributeType, bool inherit)
 		{
-            if (attributeType == null)
-                throw new ArgumentNullException (nameof (attributeType));
-            if (!attributeType.IsSubclassOf (typeof (Attribute)) && attributeType != typeof (Attribute))
-                throw new ArgumentException (SR.Argument_MustHaveAttributeBaseClass + " " + attributeType.FullName);
+			if (attributeType == null)
+				throw new ArgumentNullException (nameof (attributeType));
+			if (!attributeType.IsSubclassOf (typeof (Attribute)) && attributeType != typeof (Attribute))
+				throw new ArgumentException (SR.Argument_MustHaveAttributeBaseClass + " " + attributeType.FullName);
 
 			var attrs = MonoCustomAttrs.GetCustomAttributes (element, attributeType, inherit);
 			if (attrs == null || attrs.Length == 0)
@@ -19,59 +19,59 @@ namespace System
 			return (Attribute)(attrs [0]);
 		}
 
-        public static Attribute GetCustomAttribute (Assembly element, Type attributeType) => GetAttr (element, attributeType, true);
-        public static Attribute GetCustomAttribute(Assembly element, Type attributeType, bool inherit) => GetAttr (element, attributeType, inherit);
-        public static Attribute GetCustomAttribute(MemberInfo element, Type attributeType) => GetAttr (element, attributeType, true);
-        public static Attribute GetCustomAttribute(MemberInfo element, Type attributeType, bool inherit) => GetAttr (element, attributeType, inherit);
-        public static Attribute GetCustomAttribute(Module element, Type attributeType) => GetAttr (element, attributeType, true);
-        public static Attribute GetCustomAttribute(Module element, Type attributeType, bool inherit) => GetAttr (element, attributeType, inherit);
-        public static Attribute GetCustomAttribute(ParameterInfo element, Type attributeType) => GetAttr (element, attributeType, true);
-        public static Attribute GetCustomAttribute(ParameterInfo element, Type attributeType, bool inherit) => GetAttr (element, attributeType, inherit);
+		public static Attribute GetCustomAttribute (Assembly element, Type attributeType) => GetAttr (element, attributeType, true);
+		public static Attribute GetCustomAttribute(Assembly element, Type attributeType, bool inherit) => GetAttr (element, attributeType, inherit);
+		public static Attribute GetCustomAttribute(MemberInfo element, Type attributeType) => GetAttr (element, attributeType, true);
+		public static Attribute GetCustomAttribute(MemberInfo element, Type attributeType, bool inherit) => GetAttr (element, attributeType, inherit);
+		public static Attribute GetCustomAttribute(Module element, Type attributeType) => GetAttr (element, attributeType, true);
+		public static Attribute GetCustomAttribute(Module element, Type attributeType, bool inherit) => GetAttr (element, attributeType, inherit);
+		public static Attribute GetCustomAttribute(ParameterInfo element, Type attributeType) => GetAttr (element, attributeType, true);
+		public static Attribute GetCustomAttribute(ParameterInfo element, Type attributeType, bool inherit) => GetAttr (element, attributeType, inherit);
 
-        public static Attribute[] GetCustomAttributes (Assembly element) => (Attribute[])MonoCustomAttrs.GetCustomAttributes (element, true);
-        public static Attribute[] GetCustomAttributes (Assembly element, bool inherit) => (Attribute[])MonoCustomAttrs.GetCustomAttributes (element, inherit);
-        public static Attribute[] GetCustomAttributes (Assembly element, Type attributeType) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, true);
-        public static Attribute[] GetCustomAttributes (Assembly element, Type attributeType, bool inherit) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, inherit);
-        public static Attribute[] GetCustomAttributes (MemberInfo element) => (Attribute[])MonoCustomAttrs.GetCustomAttributes (element, true);
-        public static Attribute[] GetCustomAttributes (MemberInfo element, bool inherit) => (Attribute[])MonoCustomAttrs.GetCustomAttributes (element, inherit);
-        public static Attribute[] GetCustomAttributes (MemberInfo element, Type attributeType) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, true);
-        public static Attribute[] GetCustomAttributes (MemberInfo element, Type attributeType, bool inherit) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, inherit);
-        public static Attribute[] GetCustomAttributes (Module element) => (Attribute[])MonoCustomAttrs.GetCustomAttributes (element, true);
-        public static Attribute[] GetCustomAttributes (Module element, bool inherit) => (Attribute[])MonoCustomAttrs.GetCustomAttributes (element, inherit);
-        public static Attribute[] GetCustomAttributes (Module element, Type attributeType) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, true);
-        public static Attribute[] GetCustomAttributes (Module element, Type attributeType, bool inherit) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, inherit);
-        public static Attribute[] GetCustomAttributes (ParameterInfo element) => (Attribute[])MonoCustomAttrs.GetCustomAttributes (element, true);
-        public static Attribute[] GetCustomAttributes (ParameterInfo element, bool inherit) => (Attribute[])MonoCustomAttrs.GetCustomAttributes (element, inherit);
-        public static Attribute[] GetCustomAttributes (ParameterInfo element, Type attributeType) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, true);
-        public static Attribute[] GetCustomAttributes (ParameterInfo element, Type attributeType, bool inherit) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, inherit);
+		public static Attribute[] GetCustomAttributes (Assembly element) => (Attribute[])MonoCustomAttrs.GetCustomAttributes (element, true);
+		public static Attribute[] GetCustomAttributes (Assembly element, bool inherit) => (Attribute[])MonoCustomAttrs.GetCustomAttributes (element, inherit);
+		public static Attribute[] GetCustomAttributes (Assembly element, Type attributeType) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, true);
+		public static Attribute[] GetCustomAttributes (Assembly element, Type attributeType, bool inherit) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, inherit);
+		public static Attribute[] GetCustomAttributes (MemberInfo element) => (Attribute[])MonoCustomAttrs.GetCustomAttributes (element, true);
+		public static Attribute[] GetCustomAttributes (MemberInfo element, bool inherit) => (Attribute[])MonoCustomAttrs.GetCustomAttributes (element, inherit);
+		public static Attribute[] GetCustomAttributes (MemberInfo element, Type attributeType) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, true);
+		public static Attribute[] GetCustomAttributes (MemberInfo element, Type attributeType, bool inherit) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, inherit);
+		public static Attribute[] GetCustomAttributes (Module element) => (Attribute[])MonoCustomAttrs.GetCustomAttributes (element, true);
+		public static Attribute[] GetCustomAttributes (Module element, bool inherit) => (Attribute[])MonoCustomAttrs.GetCustomAttributes (element, inherit);
+		public static Attribute[] GetCustomAttributes (Module element, Type attributeType) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, true);
+		public static Attribute[] GetCustomAttributes (Module element, Type attributeType, bool inherit) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, inherit);
+		public static Attribute[] GetCustomAttributes (ParameterInfo element) => (Attribute[])MonoCustomAttrs.GetCustomAttributes (element, true);
+		public static Attribute[] GetCustomAttributes (ParameterInfo element, bool inherit) => (Attribute[])MonoCustomAttrs.GetCustomAttributes (element, inherit);
+		public static Attribute[] GetCustomAttributes (ParameterInfo element, Type attributeType) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, true);
+		public static Attribute[] GetCustomAttributes (ParameterInfo element, Type attributeType, bool inherit) => (Attribute[])GetCustomAttributes ((ICustomAttributeProvider)element, attributeType, inherit);
 
-        internal static Attribute[] GetCustomAttributes (ICustomAttributeProvider element, Type attributeType, bool inherit)
-        {
-            if (attributeType == null)
-                throw new ArgumentNullException (nameof (attributeType));
-            if (!attributeType.IsSubclassOf (typeof (Attribute)) && attributeType != typeof (Attribute))
-                throw new ArgumentException (SR.Argument_MustHaveAttributeBaseClass + " " + attributeType.FullName);
+		internal static Attribute[] GetCustomAttributes (ICustomAttributeProvider element, Type attributeType, bool inherit)
+		{
+			if (attributeType == null)
+				throw new ArgumentNullException (nameof (attributeType));
+			if (!attributeType.IsSubclassOf (typeof (Attribute)) && attributeType != typeof (Attribute))
+				throw new ArgumentException (SR.Argument_MustHaveAttributeBaseClass + " " + attributeType.FullName);
 
-            return (Attribute[])MonoCustomAttrs.GetCustomAttributes (element, attributeType, inherit);
-        }
+			return (Attribute[])MonoCustomAttrs.GetCustomAttributes (element, attributeType, inherit);
+		}
 
-        public static bool IsDefined (Assembly element, Type attributeType) => IsDefined ((ICustomAttributeProvider)element, attributeType, true);
-        public static bool IsDefined (Assembly element, Type attributeType, bool inherit) => IsDefined ((ICustomAttributeProvider)element, attributeType, inherit);
-        public static bool IsDefined (MemberInfo element, Type attributeType) => IsDefined ((ICustomAttributeProvider)element, attributeType, true);
-        public static bool IsDefined (MemberInfo element, Type attributeType, bool inherit) => IsDefined ((ICustomAttributeProvider)element, attributeType, inherit);
-        public static bool IsDefined (Module element, Type attributeType) => IsDefined ((ICustomAttributeProvider)element, attributeType, true);
-        public static bool IsDefined (Module element, Type attributeType, bool inherit) => IsDefined ((ICustomAttributeProvider)element, attributeType, inherit);
-        public static bool IsDefined (ParameterInfo element, Type attributeType) => IsDefined ((ICustomAttributeProvider)element, attributeType, true);
-        public static bool IsDefined (ParameterInfo element, Type attributeType, bool inherit) => IsDefined ((ICustomAttributeProvider)element, attributeType, inherit);
+		public static bool IsDefined (Assembly element, Type attributeType) => IsDefined ((ICustomAttributeProvider)element, attributeType, true);
+		public static bool IsDefined (Assembly element, Type attributeType, bool inherit) => IsDefined ((ICustomAttributeProvider)element, attributeType, inherit);
+		public static bool IsDefined (MemberInfo element, Type attributeType) => IsDefined ((ICustomAttributeProvider)element, attributeType, true);
+		public static bool IsDefined (MemberInfo element, Type attributeType, bool inherit) => IsDefined ((ICustomAttributeProvider)element, attributeType, inherit);
+		public static bool IsDefined (Module element, Type attributeType) => IsDefined ((ICustomAttributeProvider)element, attributeType, true);
+		public static bool IsDefined (Module element, Type attributeType, bool inherit) => IsDefined ((ICustomAttributeProvider)element, attributeType, inherit);
+		public static bool IsDefined (ParameterInfo element, Type attributeType) => IsDefined ((ICustomAttributeProvider)element, attributeType, true);
+		public static bool IsDefined (ParameterInfo element, Type attributeType, bool inherit) => IsDefined ((ICustomAttributeProvider)element, attributeType, inherit);
 
-        internal static bool IsDefined (ICustomAttributeProvider element, Type attributeType, bool inherit)
-        {
-            if (attributeType == null)
-                throw new ArgumentNullException (nameof (attributeType));
-            if (!attributeType.IsSubclassOf (typeof (Attribute)) && attributeType != typeof (Attribute))
-                throw new ArgumentException (SR.Argument_MustHaveAttributeBaseClass + " " + attributeType.FullName);
+		internal static bool IsDefined (ICustomAttributeProvider element, Type attributeType, bool inherit)
+		{
+			if (attributeType == null)
+				throw new ArgumentNullException (nameof (attributeType));
+			if (!attributeType.IsSubclassOf (typeof (Attribute)) && attributeType != typeof (Attribute))
+				throw new ArgumentException (SR.Argument_MustHaveAttributeBaseClass + " " + attributeType.FullName);
 
-            return MonoCustomAttrs.IsDefined (element, attributeType, inherit);
-        }
-    }
+			return MonoCustomAttrs.IsDefined (element, attributeType, inherit);
+		}
+	}
 }

--- a/mcs/class/corlib/System/MonoCustomAttrs.cs
+++ b/mcs/class/corlib/System/MonoCustomAttrs.cs
@@ -149,13 +149,7 @@ namespace System
 			if (obj == null)
 				throw new ArgumentNullException ("obj");
 			if (attributeType == null)
-				throw new ArgumentNullException ("attributeType");
-			
-#if NETCORE
-			if (!attributeType.IsSubclassOf(typeof(Attribute)) &&
-			    attributeType != typeof(Attribute))
-				throw new ArgumentException(SR.Argument_MustHaveAttributeBaseClass);
-#endif
+				throw new ArgumentNullException ("attributeType");	
 
 			if (attributeType == typeof (MonoCustomAttrs))
 				attributeType = null;


### PR DESCRIPTION
This is fix for regressions from #14056 (System.ComponentModel.Composition.Tests) and #14050 (System.Runtime.Tests).

Essentially the issue is that `Attribute` methods (`GetCustomAttribute`, `GetCustomAttributes`, `IsDefined`) have to check if the `attributeType` is subclass of `Attribute` or `Attribute` itself. On the other hand other custom attribute methods should not check that because someone can ask for all custom attributes implementing some interface as the component model code does. All of these calls end up calling `MonoCustomAttrs` so the `attributeType` parameter checks have to be in `Attribute` class.

This highlights the need to get some CI working ASAP since we keep breaking it (myself included). I'm keeping this as draft until I run the full test suite on my machine to check for any regressions.