### PR TITLE
[netcore] Fix System.Tests.PseudoCustomAttributeTests.* tests

### DIFF
--- a/mcs/class/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/mcs/class/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -190,6 +190,7 @@
       <Compile Include="System.Runtime.InteropServices\GCHandle.cs" />
       <Compile Include="System.Runtime.InteropServices\InteropExtensions.cs" />
       <Compile Include="System.Runtime.InteropServices\Marshal.cs" />
+      <Compile Include="System.Runtime.InteropServices\MarshalAsAttribute.cs" />
       <Compile Include="System.Runtime.InteropServices\NativeLibrary.cs" />
       <Compile Include="System.Runtime.Loader\AssemblyLoadContext.cs" />
       <Compile Include="System.Runtime.Loader\AssemblyDependencyResolver.cs" />

--- a/mcs/class/System.Private.CoreLib/System.Runtime.InteropServices/MarshalAsAttribute.cs
+++ b/mcs/class/System.Private.CoreLib/System.Runtime.InteropServices/MarshalAsAttribute.cs
@@ -5,7 +5,7 @@
 namespace System.Runtime.InteropServices
 {
     [StructLayout(LayoutKind.Sequential)]
-    public sealed partial class MarshalAsAttribute : Attribute
+    partial class MarshalAsAttribute
     {
     }
 }

--- a/mcs/class/System.Private.CoreLib/System.Runtime.InteropServices/MarshalAsAttribute.cs
+++ b/mcs/class/System.Private.CoreLib/System.Runtime.InteropServices/MarshalAsAttribute.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Runtime.InteropServices
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public sealed partial class MarshalAsAttribute : Attribute
+    {
+    }
+}

--- a/mcs/class/System.Private.CoreLib/System.Runtime.InteropServices/MarshalAsAttribute.cs
+++ b/mcs/class/System.Private.CoreLib/System.Runtime.InteropServices/MarshalAsAttribute.cs
@@ -4,7 +4,7 @@
 
 namespace System.Runtime.InteropServices
 {
-    [StructLayout(LayoutKind.Sequential)]
+    [StructLayout (LayoutKind.Sequential)]
     partial class MarshalAsAttribute
     {
     }

--- a/mcs/class/System.Private.CoreLib/System/Attribute.cs
+++ b/mcs/class/System.Private.CoreLib/System/Attribute.cs
@@ -6,6 +6,14 @@ namespace System
 	{
 		static Attribute GetAttr (ICustomAttributeProvider element, Type attributeType, bool inherit)
 		{
+			if (attributeType == null)
+				throw new ArgumentNullException (nameof (attributeType));
+			
+			if (!attributeType.IsSubclassOf (typeof (Attribute)) &&
+			    attributeType != typeof (Attribute) &&
+			    attributeType != typeof (MonoCustomAttrs))
+				throw new ArgumentException (SR.Argument_MustHaveAttributeBaseClass);
+			
 			var attrs = MonoCustomAttrs.GetCustomAttributes (element, attributeType, inherit);
 			if (attrs == null || attrs.Length == 0)
 				return null;

--- a/mcs/class/corlib/System/MonoCustomAttrs.cs
+++ b/mcs/class/corlib/System/MonoCustomAttrs.cs
@@ -150,10 +150,6 @@ namespace System
 				throw new ArgumentNullException (nameof (obj));
 			if (attributeType == null)
 				throw new ArgumentNullException (nameof (attributeType));
-			
-#if NETCORE
-			
-#endif
 
 			if (attributeType == typeof (MonoCustomAttrs) || 
 				attributeType == typeof (Attribute))

--- a/mcs/class/corlib/System/MonoCustomAttrs.cs
+++ b/mcs/class/corlib/System/MonoCustomAttrs.cs
@@ -152,10 +152,7 @@ namespace System
 				throw new ArgumentNullException (nameof (attributeType));
 			
 #if NETCORE
-			if (!attributeType.IsSubclassOf (typeof (Attribute)) &&
-				attributeType != typeof (Attribute) &&
-				attributeType != typeof (MonoCustomAttrs))
-				throw new ArgumentException (SR.Argument_MustHaveAttributeBaseClass);
+			
 #endif
 
 			if (attributeType == typeof (MonoCustomAttrs) || 

--- a/mcs/class/corlib/System/MonoCustomAttrs.cs
+++ b/mcs/class/corlib/System/MonoCustomAttrs.cs
@@ -147,17 +147,19 @@ namespace System
 		internal static object[] GetCustomAttributes (ICustomAttributeProvider obj, Type attributeType, bool inherit)
 		{
 			if (obj == null)
-				throw new ArgumentNullException ("obj");
+				throw new ArgumentNullException (nameof (obj));
 			if (attributeType == null)
-				throw new ArgumentNullException ("attributeType");
+				throw new ArgumentNullException (nameof (attributeType));
 			
 #if NETCORE
-			if (!attributeType.IsSubclassOf(typeof(Attribute)) &&
-			    attributeType != typeof(Attribute))
-				throw new ArgumentException(SR.Argument_MustHaveAttributeBaseClass);
+			if (!attributeType.IsSubclassOf (typeof (Attribute)) &&
+				attributeType != typeof (Attribute) &&
+				attributeType != typeof (MonoCustomAttrs))
+				throw new ArgumentException (SR.Argument_MustHaveAttributeBaseClass);
 #endif
 
-			if (attributeType == typeof (MonoCustomAttrs))
+			if (attributeType == typeof (MonoCustomAttrs) || 
+				attributeType == typeof (Attribute))
 				attributeType = null;
 			
 			object[] r;

--- a/mcs/class/corlib/System/MonoCustomAttrs.cs
+++ b/mcs/class/corlib/System/MonoCustomAttrs.cs
@@ -151,8 +151,11 @@ namespace System
 			if (attributeType == null)
 				throw new ArgumentNullException (nameof (attributeType));
 
-			if (attributeType == typeof (MonoCustomAttrs) || 
-				attributeType == typeof (Attribute))
+			if (attributeType == typeof (MonoCustomAttrs)
+#if NETCORE
+				|| attributeType == typeof (Attribute)
+#endif
+			   	)
 				attributeType = null;
 			
 			object[] r;

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -1509,6 +1509,21 @@ typedef struct {
 
 TYPED_HANDLE_DECL (MonoReflectionCustomAttr);
 
+#if ENABLE_NETCORE
+typedef struct {
+	MonoObject object;
+	guint32 utype;
+	gint32 safe_array_subtype;
+	MonoReflectionType *marshal_safe_array_user_defined_subtype;
+	gint32 IidParameterIndex;
+	guint32 array_subtype;
+	gint16 size_param_index;
+	gint32 size_const;
+	MonoString *marshal_type;
+	MonoReflectionType *marshal_type_ref;
+	MonoString *marshal_cookie;
+} MonoReflectionMarshalAsAttribute;
+#else
 typedef struct {
 	MonoObject object;
 	MonoString *marshal_cookie;
@@ -1522,6 +1537,7 @@ typedef struct {
 	gint32 IidParameterIndex;
 	gint16 size_param_index;
 } MonoReflectionMarshalAsAttribute;
+#endif
 
 /* Safely access System.Runtime.InteropServices.MarshalAsAttribute */
 TYPED_HANDLE_DECL (MonoReflectionMarshalAsAttribute);

--- a/netcore/Makefile.am
+++ b/netcore/Makefile.am
@@ -107,6 +107,11 @@ xtestall: update-corefx-tests $(foreach workingtest, $(foreach test, $(wildcard 
 xtestpass: update-corefx-tests $(foreach workingtest, $(foreach test, $(wildcard corefx/tests/extracted/*), \
 		$(filter $(PASSING_COREFX_TESTS), $(notdir $(test)))), $(addprefix xtest-, $(workingtest)))
 
+build-local-corefx-test-%: check-env
+	cd $(COREFX_ROOT)/src/$*/tests && dotnet build -o "$(CURDIR)/corefx/tests/extracted/tmp"
+	cp $(CURDIR)/corefx/tests/extracted/tmp/$*.Tests.{dll,pdb} $(CURDIR)/corefx/tests/extracted/$*.Tests/
+	rm -rf $(CURDIR)/corefx/tests/extracted/tmp
+
 #
 # console test runner (obsolete)
 #


### PR DESCRIPTION
~@filipnavara noticed my previous [PR](https://github.com/mono/mono/pull/14056#issuecomment-483387022) broke `System.ComponentModel.Composition.Tests`.
Those were expecting to find custom attributes by an interface those attributes implement.~

This PR also fixes 7 test cases in `System.Tests.PseudoCustomAttributeTests.*`

Now results are:
```
System.Runtime.Tests  Total: 32363, Errors: 0, Failed: 38, Skipped: 0, Time: 28.718s
```
```
System.ComponentModel.Composition.Tests  Total: 1428, Errors: 0, Failed: 2, Skipped: 0, Time: 1.181s
```

`build-local-corefx-test-%` is a command to build corefx tests locally and put them to corefx/tests/extracted/$*.
