### PR TITLE
Bump msbuild to track mono-2018-08

### DIFF
--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = '8b3a694c2c419582108588a7bd1133630a1b8077')
+			revision = '4c8adc5130321db5508bdfcb2f7719801725c30c')
 
 	def build (self):
 		self.sh ('./eng/cibuild_bootstrapped_msbuild.sh --host_type mono --configuration Release --skip_tests')


### PR DESCRIPTION
.. to pick up update for the NuGetSdkResolver.
https://github.com/mono/msbuild/pull/92