### PR TITLE
Bump msbuild to track mono-2018-10

### DIFF
--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = '804bde742bdf9d65c7ceb672a3d5400c0c22e628')
+			revision = 'dcd570aa770ae831d9d5b3cd1310e91de369497d')
 
 	def build (self):
 		self.sh ('./build.sh -hostType mono -configuration Release -skipTests')


### PR DESCRIPTION
. to pick up an update for the NuGetSdkResolver.