### PR TITLE
[netcore] Fix two System.Tests.PseudoCustomAttributeTests tests

### DIFF
--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -2877,14 +2877,16 @@ mono_reflection_marshal_as_attribute_from_marshal_spec (MonoDomain *domain, Mono
 	switch (utype) {
 	case MONO_NATIVE_LPARRAY:
 		MONO_HANDLE_SETVAL (minfo, array_subtype, guint32, spec->data.array_data.elem_type);
-		MONO_HANDLE_SETVAL (minfo, size_const, gint32, spec->data.array_data.num_elem);
+		if (spec->data.array_data.num_elem != -1)
+			MONO_HANDLE_SETVAL (minfo, size_const, gint32, spec->data.array_data.num_elem);
 		if (spec->data.array_data.param_num != -1)
 			MONO_HANDLE_SETVAL (minfo, size_param_index, gint16, spec->data.array_data.param_num);
 		break;
 
 	case MONO_NATIVE_BYVALTSTR:
 	case MONO_NATIVE_BYVALARRAY:
-		MONO_HANDLE_SETVAL (minfo, size_const, gint32, spec->data.array_data.num_elem);
+		if (spec->data.array_data.num_elem != -1)
+			MONO_HANDLE_SETVAL (minfo, size_const, gint32, spec->data.array_data.num_elem);
 		break;
 
 	case MONO_NATIVE_CUSTOM:

--- a/mono/metadata/w32handle.c
+++ b/mono/metadata/w32handle.c
@@ -1208,13 +1208,11 @@ mono_w32handle_signal_and_wait (gpointer signal_handle, gpointer wait_handle, gu
 
 	mono_w32handle_unlock (signal_handle_data);
 
-#if ENABLE_NETCORE
 	if (signal_ret == MONO_W32HANDLE_WAIT_RET_TOO_MANY_POSTS ||
 		signal_ret == MONO_W32HANDLE_WAIT_RET_NOT_OWNED_BY_CALLER) {
 		ret = (MonoW32HandleWaitRet) signal_ret;
 		goto done;
 	}
-#endif
 
 	if (mono_w32handle_test_capabilities (wait_handle_data, MONO_W32HANDLE_CAP_OWN)) {
 		if (own_if_owned (wait_handle_data, &abandoned)) {

--- a/mono/metadata/w32handle.c
+++ b/mono/metadata/w32handle.c
@@ -1208,11 +1208,13 @@ mono_w32handle_signal_and_wait (gpointer signal_handle, gpointer wait_handle, gu
 
 	mono_w32handle_unlock (signal_handle_data);
 
+#if ENABLE_NETCORE
 	if (signal_ret == MONO_W32HANDLE_WAIT_RET_TOO_MANY_POSTS ||
 		signal_ret == MONO_W32HANDLE_WAIT_RET_NOT_OWNED_BY_CALLER) {
 		ret = (MonoW32HandleWaitRet) signal_ret;
 		goto done;
 	}
+#endif
 
 	if (mono_w32handle_test_capabilities (wait_handle_data, MONO_W32HANDLE_CAP_OWN)) {
 		if (own_if_owned (wait_handle_data, &abandoned)) {


### PR DESCRIPTION
Now all custom attribute related tests pass in System.Runtime.Tests.
Also this PR fixes broken acceptance tests for regular mono introduced in https://github.com/mono/mono/pull/13809