### PR TITLE
[2019-02] [arm] align stack pointer in throw trampoline

### DIFF
--- a/mono/mini/exceptions-arm.c
+++ b/mono/mini/exceptions-arm.c
@@ -252,6 +252,7 @@ get_throw_trampoline (int size, gboolean corlib, gboolean rethrow, gboolean llvm
 	int param_size = 8;
 	if (!resume_unwind && !corlib)
 		param_size += 4; // Extra arg
+	param_size = ALIGN_TO (param_size, MONO_ARCH_FRAME_ALIGNMENT);
 	ARM_SUB_REG_IMM8 (code, ARMREG_SP, ARMREG_SP, param_size);
 	cfa_offset += param_size;
 	mono_add_unwind_op_def_cfa_offset (unwind_ops, code, start, cfa_offset);


### PR DESCRIPTION
This is a regression introduced by e46fa20466010a18b9b9a8130f6d8c62899780b3

Fixes https://github.com/mono/mono/issues/13672

Backport of #14078.

/cc @lambdageek @lewurm