### PR TITLE
[2019-02] Increase gsharedvt trampolines by 10% from 4000 to 4400.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1190,7 +1190,8 @@ with_bitcode_default=no
 enable_cooperative_suspend_default=no
 enable_hybrid_suspend_default=no
 
-INVARIANT_AOT_OPTIONS=nimt-trampolines=2000,ntrampolines=10000,nrgctx-fetch-trampolines=256,ngsharedvt-trampolines=4000,nftnptr-arg-trampolines=4000
+# For the sake of clearer error messages, these numbers should all be different from each other.
+INVARIANT_AOT_OPTIONS=nimt-trampolines=2000,ntrampolines=10000,nrgctx-fetch-trampolines=256,ngsharedvt-trampolines=4400,nftnptr-arg-trampolines=4000
 
 AOT_BUILD_ATTRS=$INVARIANT_AOT_OPTIONS
 


### PR DESCRIPTION
There are many minor arguments here.

Where this matters most -- iOS -- the pool is already dynamic.

Other platforms could use a dynamic pool or JIT (despite FullAOT).
Using JIT would defeat the test coverage.

Mitigates https://github.com/mono/mono/issues/13888.
If this feels too tenative, go bigger.


Backport of #13988.

/cc @lambdageek @jaykrell