### PR TITLE
[corefx] Use fallbacks when link() fails

### DIFF
--- a/mcs/class/corlib/Test/System.IO/FileTest.cs
+++ b/mcs/class/corlib/Test/System.IO/FileTest.cs
@@ -923,7 +923,7 @@ namespace MonoTests.System.IO
 			}
 			
 			Assert.IsTrue (File.Exists (bar), "#1");
-			File.Move (bar, baz);
+			Assert.DoesNotThrow (() => File.Move (bar, baz), "#5");
 			Assert.IsFalse (File.Exists (bar), "#2");
 			Assert.IsTrue (File.Exists (baz), "#3");
 
@@ -939,7 +939,7 @@ namespace MonoTests.System.IO
 			Directory.CreateDirectory (dir);
 			Directory.CreateDirectory (dir2);
 			File.Create (dir_foo).Close ();
-			File.Move (dir_foo, dir2_foo);
+			Assert.DoesNotThrow (() => File.Move (dir_foo, dir2_foo), "#6");
 			Assert.IsTrue (File.Exists (dir2_foo), "#4");
 			
 			Directory.Delete (dir, true);


### PR DESCRIPTION
System.IO.Filesystem's MoveFile() and ReplaceFile() use link/unlink under some conditions to avoid a copy. This fixes two problems with that:

* MoveFile()'s fall-back does not recognize Android's error as non-critical, and bails out on the fall-back with an exception. From logs we know that 'strerror_r(android_error)' is 'Permission denied' so the missing error should be EACCES (we already check for EPERM)
* While MoveFile() was using a fall-back, ReplaceFile() wasn't.

Also improve a relevant test for more useful fault output.
