### PR TITLE
mono_remoting_marshal_init in mono_marshal_get_proxy_cancast to register icalls.

### DIFF
--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -1902,6 +1902,9 @@ mono_marshal_get_proxy_cancast (MonoClass *klass)
 	mb->method->save_lmf = 1;
 
 #ifndef DISABLE_JIT
+
+	mono_remoting_marshal_init (); // register icalls
+
 	/* get the real proxy from the transparent proxy*/
 	mono_mb_emit_ldarg (mb, 0);
 	mono_mb_emit_ldflda (mb, MONO_STRUCT_OFFSET (MonoTransparentProxy, rp));


### PR DESCRIPTION
Alternative to https://github.com/mono/mono/pull/14076.

Alternatively move the registration to mono_remoting_init.

This should fix a problem I see in other work, and *seems* like an existing race condition.

In particular, you can emit a function pointer, and then:

```
		case MONO_CEE_MONO_ICALL: {
			g_assert (method->wrapper_type != MONO_WRAPPER_NONE);
			gpointer func;
			MonoJitICallInfo *info;

			func = mono_method_get_wrapper_data (method, token);
			info = mono_find_jit_icall_by_addr (func);
			if (!info)
				g_error ("Could not find icall address in wrapper %s", mono_method_full_name (method, 1));
			g_assert (info);
```

though I don't know why with my changes this always hits, and previously never.
Anyway, it seems like this is the original intent.

Moving the initializer earlier would make it easier to maintain correctly.