### PR TITLE
Add hybrid/cooperate suspend runtime support on Windows.

### DIFF
--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -615,9 +615,7 @@ ves_icall_System_GC_WaitForPendingFinalizers (void)
 	ResetEvent (pending_done_event);
 	mono_gc_finalize_notify ();
 	/* g_print ("Waiting for pending finalizers....\n"); */
-	MONO_ENTER_GC_SAFE;
-	mono_win32_wait_for_single_object_ex (pending_done_event, INFINITE, TRUE);
-	MONO_EXIT_GC_SAFE;
+	mono_coop_win32_wait_for_single_object_ex (pending_done_event, INFINITE, TRUE);
 	/* g_print ("Done pending....\n"); */
 #else
 	gboolean alerted = FALSE;

--- a/mono/metadata/monitor.c
+++ b/mono/metadata/monitor.c
@@ -1382,13 +1382,7 @@ ves_icall_System_Threading_Monitor_Monitor_wait (MonoObject *obj, guint32 ms)
 	 * is private to this thread.  Therefore even if the event was
 	 * signalled before we wait, we still succeed.
 	 */
-#ifdef HOST_WIN32
-	MONO_ENTER_GC_SAFE;
-	ret = mono_w32handle_convert_wait_ret (mono_win32_wait_for_single_object_ex (event, ms, TRUE), 1);
-	MONO_EXIT_GC_SAFE;
-#else
 	ret = mono_w32handle_wait_one (event, ms, TRUE);
-#endif /* HOST_WIN32 */
 
 	/* Reset the thread state fairly early, so we don't have to worry
 	 * about the monitor error checking
@@ -1411,13 +1405,7 @@ ves_icall_System_Threading_Monitor_Monitor_wait (MonoObject *obj, guint32 ms)
 		/* Poll the event again, just in case it was signalled
 		 * while we were trying to regain the monitor lock
 		 */
-#ifdef HOST_WIN32
-		MONO_ENTER_GC_SAFE;
-		ret = mono_w32handle_convert_wait_ret (mono_win32_wait_for_single_object_ex (event, 0, FALSE), 1);
-		MONO_EXIT_GC_SAFE;
-#else
 		ret = mono_w32handle_wait_one (event, 0, FALSE);
-#endif /* HOST_WIN32 */
 	}
 
 	/* Pulse will have popped our event from the queue if it signalled

--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -498,13 +498,7 @@ mono_threadpool_end_invoke (MonoAsyncResult *ares, MonoArray **out_args, MonoObj
 			MONO_OBJECT_SETREF_INTERNAL (ares, handle, (MonoObject*) wait_handle);
 		}
 		mono_monitor_exit_internal ((MonoObject*) ares);
-#ifdef HOST_WIN32
-		MONO_ENTER_GC_SAFE;
-		mono_win32_wait_for_single_object_ex (wait_event, INFINITE, TRUE);
-		MONO_EXIT_GC_SAFE;
-#else
 		mono_w32handle_wait_one (wait_event, MONO_INFINITE_WAIT, TRUE);
-#endif
 	}
 
 	ac = (MonoAsyncCall*) ares->object_data;

--- a/mono/metadata/w32file-win32-uwp.c
+++ b/mono/metadata/w32file-win32-uwp.c
@@ -20,7 +20,7 @@ mono_w32file_move (const gunichar2 *path, const gunichar2 *dest, gint32 *error)
 	gboolean result = FALSE;
 	MONO_ENTER_GC_SAFE;
 
-	result = MoveFileEx (path, dest, MOVEFILE_COPY_ALLOWED);
+	result = MoveFileExW (path, dest, MOVEFILE_COPY_ALLOWED);
 	if (result == FALSE) {
 		*error=GetLastError ();
 	}

--- a/mono/metadata/w32handle.c
+++ b/mono/metadata/w32handle.c
@@ -813,6 +813,13 @@ own_if_owned (MonoW32Handle *handle_data, gboolean *abandoned)
 	return TRUE;
 }
 
+#ifdef HOST_WIN32
+MonoW32HandleWaitRet
+mono_w32handle_wait_one (gpointer handle, guint32 timeout, gboolean alertable)
+{
+	return mono_w32handle_convert_wait_ret (mono_coop_win32_wait_for_single_object_ex (handle, timeout, alertable), 1);
+}
+#else
 MonoW32HandleWaitRet
 mono_w32handle_wait_one (gpointer handle, guint32 timeout, gboolean alertable)
 {
@@ -903,6 +910,7 @@ done:
 
 	return ret;
 }
+#endif /* HOST_WIN32 */
 
 static MonoW32Handle*
 mono_w32handle_has_duplicates (MonoW32Handle *handles [ ], gsize nhandles)
@@ -965,6 +973,16 @@ mono_w32handle_check_duplicates (MonoW32Handle *handles [ ], gsize nhandles, gbo
 	mono_w32handle_clear_duplicates (handles, nhandles);
 }
 
+#ifdef HOST_WIN32
+MonoW32HandleWaitRet
+mono_w32handle_wait_multiple (gpointer *handles, gsize nhandles, gboolean waitall, guint32 timeout, gboolean alertable, MonoError *error)
+{
+	DWORD const wait_result = (nhandles != 1)
+		? mono_coop_win32_wait_for_multiple_objects_ex (nhandles, handles, waitall, timeout, alertable, error)
+		: mono_coop_win32_wait_for_single_object_ex (handles [0], timeout, alertable);
+	return mono_w32handle_convert_wait_ret (wait_result, nhandles);
+}
+#else
 MonoW32HandleWaitRet
 mono_w32handle_wait_multiple (gpointer *handles, gsize nhandles, gboolean waitall, guint32 timeout, gboolean alertable, MonoError *error)
 {
@@ -1159,7 +1177,15 @@ done:
 
 	return ret;
 }
+#endif /* HOST_WIN32 */
 
+#ifdef HOST_WIN32
+MonoW32HandleWaitRet
+mono_w32handle_signal_and_wait (gpointer signal_handle, gpointer wait_handle, guint32 timeout, gboolean alertable)
+{
+	return mono_w32handle_convert_wait_ret (mono_coop_win32_signal_object_and_wait (signal_handle, wait_handle, timeout, alertable), 1);
+}
+#else
 MonoW32HandleWaitRet
 mono_w32handle_signal_and_wait (gpointer signal_handle, gpointer wait_handle, guint32 timeout, gboolean alertable)
 {
@@ -1263,3 +1289,4 @@ done:
 
 	return ret;
 }
+#endif /* HOST_WIN32 */

--- a/mono/utils/mono-os-wait-win32-uwp.c
+++ b/mono/utils/mono-os-wait-win32-uwp.c
@@ -21,6 +21,15 @@ mono_win32_msg_wait_for_multiple_objects_ex (DWORD count, CONST HANDLE *handles,
 	return WAIT_FAILED;
 }
 
+DWORD
+mono_coop_win32_msg_wait_for_multiple_objects_ex (DWORD count, CONST HANDLE *handles, DWORD timeout, DWORD wakeMask, DWORD flags)
+{
+	g_unsupported_api ("MsgWaitForMultipleObjectsEx");
+	SetLastError (ERROR_NOT_SUPPORTED);
+
+	return WAIT_FAILED;
+}
+
 #else /* G_HAVE_API_SUPPORT(HAVE_UWP_WINAPI_SUPPORT) */
 
 MONO_EMPTY_SOURCE_FILE (mono_os_wait_win32_uwp);

--- a/mono/utils/mono-os-wait-win32.c
+++ b/mono/utils/mono-os-wait-win32.c
@@ -14,20 +14,136 @@
 #include "mono-logger-internals.h"
 #include "mono-error-internals.h"
 #include <mono/metadata/w32subset.h>
+#include <mono/utils/checked-build.h>
 
-DWORD
-mono_win32_sleep_ex (DWORD timeout, BOOL alertable)
+/* Empty handler only used to detect interrupt state of current thread. */
+/* Needed in order to correctly avoid entering wait methods under */
+/* cooperative suspend of a thread. Under preemptive suspend a thread gets */
+/* a queued APC as part of an alertable suspend request. The APC will break any wait's */
+/* done by any of below methods. In hybrid suspend, if a thread gets into a GC safe area */
+/* thread will be preemptive suspend as above and an APC will be queued, breaking any wait. */
+/* If the thread is not within a GC safe area, a cooperative suspend will be used, but that */
+/* won't queue an APC to the thread, so in cases where we enter a GC safe area and a wait */
+/* using below functions, that wait won't be alerted. This could be solved using */
+/* interrupt handlers. Problem with interrupt handlers on Windows together with APC is race */
+/* between thread executing interrupt handler and current thread. We will need the thread */
+/* alive when posting the APC, but since there is no synchronization between waiting thread */
+/* and thread running interrupt handler, waiting thread could already be terminated when executing */
+/* interrupt handler. There are ways to mitigate this, but using below schema is more lightweight and */
+/* solves the same problem + gives some additional benefits on preemptive suspend. Wait methods */
+/* will register a empty interrupt handler. This is needed in order to correctly get current alertable */
+/* state of the thread when register/unregister handler. If thread is already interrupted, we can */
+/* ignore call to wait method and return alertable error code. This solves the cooperative suspend */
+/* scenario since we evaluate the current interrupt state inside GC safe block. If not yet interrupted, */
+/* cooperative suspend will detect that thread is inside a GC safe block so it will interrupt kernel */
+/* as part of suspend request (similar to preemptive suspend) queuing APC, breaking any waits. */
+static void
+win32_wait_interrupt_handler (gpointer ignored)
+{
+}
+
+/* Evaluate if we have a pending interrupt on current thread before */
+/* entering wait. If thread has been cooperative suspended, it won't */
+/* always queue an APC (only when already in a GC safe block), but since */
+/* we should be inside a GC safe block at this point, checking current */
+/* thread's interrupt state will tell us if we have a pending interrupt. */
+/* If not, we will get an APC queued to break any waits if interrupted */
+/* after this check (both in cooperative and preemptive suspend modes). */
+#define WIN32_CHECK_INTERRUPT(info, alertable) \
+	do { \
+		MONO_REQ_GC_SAFE_MODE; \
+		if (alertable && info && mono_thread_info_is_interrupt_state (info)) { \
+			SetLastError (WAIT_IO_COMPLETION); \
+			return WAIT_IO_COMPLETION; \
+		} \
+	} while (0)
+
+#define WIN32_ENTER_ALERTABLE_WAIT(info) \
+	do { \
+		if (info) { \
+			gboolean alerted = FALSE; \
+			mono_thread_info_install_interrupt (win32_wait_interrupt_handler, NULL, &alerted); \
+			if (alerted) { \
+				SetLastError (WAIT_IO_COMPLETION); \
+				return WAIT_IO_COMPLETION; \
+			} \
+			mono_win32_enter_alertable_wait (info); \
+		} \
+	} while (0)
+
+#define WIN32_LEAVE_ALERTABLE_WAIT(info) \
+	do { \
+		if (info) { \
+			gboolean alerted = FALSE; \
+			mono_win32_leave_alertable_wait (info); \
+			mono_thread_info_uninstall_interrupt (&alerted); \
+		} \
+	} while (0)
+
+static DWORD
+win32_sleep_ex_interrupt_checked (MonoThreadInfo *info, DWORD timeout, BOOL alertable)
+{
+	WIN32_CHECK_INTERRUPT (info, alertable);
+	return SleepEx (timeout, alertable);
+}
+
+static DWORD
+win32_sleep_ex (DWORD timeout, BOOL alertable, BOOL cooperative)
 {
 	DWORD result = WAIT_FAILED;
 	MonoThreadInfo * const info = alertable ? mono_thread_info_current_unchecked () : NULL;
 
-	if (info)
-		mono_win32_enter_alertable_wait (info);
+	WIN32_ENTER_ALERTABLE_WAIT (info);
 
-	result = SleepEx (timeout, alertable);
+	if (cooperative) {
+		MONO_ENTER_GC_SAFE;
+		result = win32_sleep_ex_interrupt_checked (info, timeout, alertable);
+		MONO_EXIT_GC_SAFE;
+	} else {
+		result = win32_sleep_ex_interrupt_checked (info, timeout, alertable);
+	}
 
-	if (info)
-		mono_win32_leave_alertable_wait (info);
+	WIN32_LEAVE_ALERTABLE_WAIT (info);
+
+	return result;
+}
+
+DWORD
+mono_win32_sleep_ex (DWORD timeout, BOOL alertable)
+{
+	return win32_sleep_ex (timeout, alertable, FALSE);
+}
+
+DWORD
+mono_coop_win32_sleep_ex (DWORD timeout, BOOL alertable)
+{
+	return win32_sleep_ex (timeout, alertable, TRUE);
+}
+
+static DWORD
+win32_wait_for_single_object_ex_interrupt_checked (MonoThreadInfo *info, HANDLE handle, DWORD timeout, BOOL alertable)
+{
+	WIN32_CHECK_INTERRUPT (info, alertable);
+	return WaitForSingleObjectEx (handle, timeout, alertable);
+}
+
+static DWORD
+win32_wait_for_single_object_ex (HANDLE handle, DWORD timeout, BOOL alertable, BOOL cooperative)
+{
+	DWORD result = WAIT_FAILED;
+	MonoThreadInfo * const info = alertable ? mono_thread_info_current_unchecked () : NULL;
+
+	WIN32_ENTER_ALERTABLE_WAIT (info);
+
+	if (cooperative) {
+		MONO_ENTER_GC_SAFE;
+		result = win32_wait_for_single_object_ex_interrupt_checked (info, handle, timeout, alertable);
+		MONO_EXIT_GC_SAFE;
+	} else {
+		result = win32_wait_for_single_object_ex_interrupt_checked (info, handle, timeout, alertable);
+	}
+
+	WIN32_LEAVE_ALERTABLE_WAIT (info);
 
 	return result;
 }
@@ -35,32 +151,39 @@ mono_win32_sleep_ex (DWORD timeout, BOOL alertable)
 DWORD
 mono_win32_wait_for_single_object_ex (HANDLE handle, DWORD timeout, BOOL alertable)
 {
-	DWORD result = WAIT_FAILED;
-	MonoThreadInfo * const info = alertable ? mono_thread_info_current_unchecked () : NULL;
-
-	if (info)
-		mono_win32_enter_alertable_wait (info);
-
-	result = WaitForSingleObjectEx (handle, timeout, alertable);
-
-	if (info)
-		mono_win32_leave_alertable_wait (info);
-
-	return result;
+	return win32_wait_for_single_object_ex (handle, timeout, alertable, FALSE);
 }
 
 DWORD
-mono_win32_wait_for_multiple_objects_ex (DWORD count, CONST HANDLE *handles, BOOL waitAll, DWORD timeout, BOOL alertable, MonoError *error)
+mono_coop_win32_wait_for_single_object_ex (HANDLE handle, DWORD timeout, BOOL alertable)
 {
+	return win32_wait_for_single_object_ex (handle, timeout, alertable, TRUE);
+}
+
+static DWORD
+win32_wait_for_multiple_objects_ex_interrupt_checked (MonoThreadInfo *info, DWORD count, CONST HANDLE *handles, BOOL waitAll, DWORD timeout, BOOL alertable)
+{
+	WIN32_CHECK_INTERRUPT (info, alertable);
+	return WaitForMultipleObjectsEx (count, handles, waitAll, timeout, alertable);
+}
+
+static DWORD
+win32_wait_for_multiple_objects_ex (DWORD count, CONST HANDLE *handles, BOOL waitAll, DWORD timeout, BOOL alertable, MonoError *error, BOOL cooperative)
+{
+	DWORD result = WAIT_FAILED;
 	MonoThreadInfo * const info = alertable ? mono_thread_info_current_unchecked () : NULL;
 
-	if (info)
-		mono_win32_enter_alertable_wait (info);
+	WIN32_ENTER_ALERTABLE_WAIT (info);
 
-	DWORD const result = WaitForMultipleObjectsEx (count, handles, waitAll, timeout, alertable);
+	if (cooperative) {
+		MONO_ENTER_GC_SAFE;
+		result = win32_wait_for_multiple_objects_ex_interrupt_checked (info, count, handles, waitAll, timeout, alertable);
+		MONO_EXIT_GC_SAFE;
+	} else {
+		result = win32_wait_for_multiple_objects_ex_interrupt_checked (info, count, handles, waitAll, timeout, alertable);
+	}
 
-	if (info)
-		mono_win32_leave_alertable_wait (info);
+	WIN32_LEAVE_ALERTABLE_WAIT (info);
 
 	// This is not perfect, but it is the best you can do in usermode and matches CoreCLR.
 	// i.e. handle-based instead of object-based.
@@ -86,59 +209,141 @@ mono_win32_wait_for_multiple_objects_ex (DWORD count, CONST HANDLE *handles, BOO
 	return result;
 }
 
-#if HAVE_API_SUPPORT_WIN32_SIGNAL_OBJECT_AND_WAIT
 DWORD
-mono_win32_signal_object_and_wait (HANDLE toSignal, HANDLE toWait, DWORD timeout, BOOL alertable)
+mono_win32_wait_for_multiple_objects_ex (DWORD count, CONST HANDLE *handles, BOOL waitAll, DWORD timeout, BOOL alertable, MonoError *error)
+{
+	return win32_wait_for_multiple_objects_ex (count, handles, waitAll, timeout, alertable, error, FALSE);
+}
+
+DWORD
+mono_coop_win32_wait_for_multiple_objects_ex (DWORD count, CONST HANDLE *handles, BOOL waitAll, DWORD timeout, BOOL alertable, MonoError *error)
+{
+	return win32_wait_for_multiple_objects_ex (count, handles, waitAll, timeout, alertable, error, TRUE);
+}
+
+#if HAVE_API_SUPPORT_WIN32_SIGNAL_OBJECT_AND_WAIT
+
+static DWORD
+win32_signal_object_and_wait_interrupt_checked (MonoThreadInfo *info, HANDLE toSignal, HANDLE toWait, DWORD timeout, BOOL alertable)
+{
+	WIN32_CHECK_INTERRUPT (info, alertable);
+	return SignalObjectAndWait (toSignal, toWait, timeout, alertable);
+}
+
+static DWORD
+win32_signal_object_and_wait (HANDLE toSignal, HANDLE toWait, DWORD timeout, BOOL alertable, BOOL cooperative)
 {
 	DWORD result = WAIT_FAILED;
 	MonoThreadInfo * const info = alertable ? mono_thread_info_current_unchecked () : NULL;
 
-	if (info)
-		mono_win32_enter_alertable_wait (info);
+	WIN32_ENTER_ALERTABLE_WAIT (info);
 
-	result = SignalObjectAndWait (toSignal, toWait, timeout, alertable);
+	if (cooperative) {
+		MONO_ENTER_GC_SAFE;
+		result = win32_signal_object_and_wait_interrupt_checked (info, toSignal, toWait, timeout, alertable);
+		MONO_EXIT_GC_SAFE;
+	} else {
+		result = win32_signal_object_and_wait_interrupt_checked (info, toSignal, toWait, timeout, alertable);
+	}
 
-	if (info)
-		mono_win32_leave_alertable_wait (info);
+	WIN32_LEAVE_ALERTABLE_WAIT (info);
 
 	return result;
+}
+
+DWORD
+mono_win32_signal_object_and_wait (HANDLE toSignal, HANDLE toWait, DWORD timeout, BOOL alertable)
+{
+	return win32_signal_object_and_wait (toSignal, toWait, timeout, alertable, FALSE);
+}
+
+DWORD
+mono_coop_win32_signal_object_and_wait (HANDLE toSignal, HANDLE toWait, DWORD timeout, BOOL alertable)
+{
+	return win32_signal_object_and_wait (toSignal, toWait, timeout, alertable, TRUE);
 }
 
 #endif /* HAVE_API_SUPPORT_WIN32_SIGNAL_OBJECT_AND_WAIT */
 
 #if HAVE_API_SUPPORT_WIN32_MSG_WAIT_FOR_MULTIPLE_OBJECTS
-DWORD
-mono_win32_msg_wait_for_multiple_objects_ex (DWORD count, CONST HANDLE *handles, DWORD timeout, DWORD wakeMask, DWORD flags)
+static DWORD
+win32_msg_wait_for_multiple_objects_ex_interrupt_checked (MonoThreadInfo *info, DWORD count, CONST HANDLE *handles, DWORD timeout, DWORD wakeMask, DWORD flags, BOOL alertable)
+{
+	WIN32_CHECK_INTERRUPT (info, alertable);
+	return MsgWaitForMultipleObjectsEx (count, handles, timeout, wakeMask, flags);
+}
+
+static DWORD
+win32_msg_wait_for_multiple_objects_ex (DWORD count, CONST HANDLE *handles, DWORD timeout, DWORD wakeMask, DWORD flags, BOOL cooperative)
 {
 	DWORD result = WAIT_FAILED;
 	BOOL alertable = flags & MWMO_ALERTABLE;
 	MonoThreadInfo * const info = alertable ? mono_thread_info_current_unchecked () : NULL;
 
-	if (info)
-		mono_win32_enter_alertable_wait (info);
+	WIN32_ENTER_ALERTABLE_WAIT (info);
 
-	result = MsgWaitForMultipleObjectsEx (count, handles, timeout, wakeMask, flags);
+	if (cooperative) {
+		MONO_ENTER_GC_SAFE;
+		result = win32_msg_wait_for_multiple_objects_ex_interrupt_checked (info, count, handles, timeout, wakeMask, flags, alertable);
+		MONO_EXIT_GC_SAFE;
+	} else {
+		result = win32_msg_wait_for_multiple_objects_ex_interrupt_checked (info, count, handles, timeout, wakeMask, flags, alertable);
+	}
 
-	if (info)
-		mono_win32_leave_alertable_wait (info);
+	WIN32_LEAVE_ALERTABLE_WAIT (info);
 
 	return result;
 }
-#endif /* HAVE_API_SUPPORT_WIN32_MSG_WAIT_FOR_MULTIPLE_OBJECTS */
 
 DWORD
-mono_win32_wsa_wait_for_multiple_events (DWORD count, const WSAEVENT FAR *handles, BOOL waitAll, DWORD timeout, BOOL alertable)
+mono_win32_msg_wait_for_multiple_objects_ex (DWORD count, CONST HANDLE *handles, DWORD timeout, DWORD wakeMask, DWORD flags)
+{
+	return win32_msg_wait_for_multiple_objects_ex (count, handles, timeout, wakeMask, flags, FALSE);
+}
+
+DWORD
+mono_coop_win32_msg_wait_for_multiple_objects_ex (DWORD count, CONST HANDLE *handles, DWORD timeout, DWORD wakeMask, DWORD flags)
+{
+	return win32_msg_wait_for_multiple_objects_ex (count, handles, timeout, wakeMask, flags, TRUE);
+}
+#endif /* HAVE_API_SUPPORT_WIN32_MSG_WAIT_FOR_MULTIPLE_OBJECTS */
+
+static DWORD
+win32_wsa_wait_for_multiple_events_interrupt_checked (MonoThreadInfo *info, DWORD count, const WSAEVENT FAR *handles, BOOL waitAll, DWORD timeout, BOOL alertable)
+{
+	WIN32_CHECK_INTERRUPT (info, alertable);
+	return WSAWaitForMultipleEvents (count, handles, waitAll, timeout, alertable);
+}
+
+static DWORD
+win32_wsa_wait_for_multiple_events (DWORD count, const WSAEVENT FAR *handles, BOOL waitAll, DWORD timeout, BOOL alertable, BOOL cooperative)
 {
 	DWORD result = WAIT_FAILED;
 	MonoThreadInfo * const info = alertable ? mono_thread_info_current_unchecked () : NULL;
 
-	if (info)
-		mono_win32_enter_alertable_wait (info);
+	WIN32_ENTER_ALERTABLE_WAIT (info);
 
-	result = WSAWaitForMultipleEvents (count, handles, waitAll, timeout, alertable);
+	if (cooperative) {
+		MONO_ENTER_GC_SAFE;
+		result = win32_wsa_wait_for_multiple_events_interrupt_checked (info, count, handles, waitAll, timeout, alertable);
+		MONO_EXIT_GC_SAFE;
+	} else {
+		result = win32_wsa_wait_for_multiple_events_interrupt_checked (info, count, handles, waitAll, timeout, alertable);
+	}
 
-	if (info)
-		mono_win32_leave_alertable_wait (info);
+	WIN32_LEAVE_ALERTABLE_WAIT (info);
 
 	return result;
+}
+
+DWORD
+mono_win32_wsa_wait_for_multiple_events (DWORD count, const WSAEVENT FAR *handles, BOOL waitAll, DWORD timeout, BOOL alertable)
+{
+	return win32_wsa_wait_for_multiple_events (count, handles, waitAll, timeout, alertable, FALSE);
+}
+
+DWORD
+mono_coop_win32_wsa_wait_for_multiple_events (DWORD count, const WSAEVENT FAR *handles, BOOL waitAll, DWORD timeout, BOOL alertable)
+{
+	return win32_wsa_wait_for_multiple_events (count, handles, waitAll, timeout, alertable, TRUE);
 }

--- a/mono/utils/mono-os-wait.h
+++ b/mono/utils/mono-os-wait.h
@@ -16,19 +16,37 @@ DWORD
 mono_win32_sleep_ex (DWORD timeout, BOOL alertable);
 
 DWORD
+mono_coop_win32_sleep_ex (DWORD timeout, BOOL alertable);
+
+DWORD
 mono_win32_wait_for_single_object_ex (HANDLE handle, DWORD timeout, BOOL alertable);
+
+DWORD
+mono_coop_win32_wait_for_single_object_ex (HANDLE handle, DWORD timeout, BOOL alertable);
 
 DWORD
 mono_win32_wait_for_multiple_objects_ex (DWORD count, CONST HANDLE *handles, BOOL waitAll, DWORD timeout, BOOL alertable, MonoError *error);
 
 DWORD
+mono_coop_win32_wait_for_multiple_objects_ex (DWORD count, CONST HANDLE *handles, BOOL waitAll, DWORD timeout, BOOL alertable, MonoError *error);
+
+DWORD
 mono_win32_signal_object_and_wait (HANDLE toSignal, HANDLE toWait, DWORD timeout, BOOL alertable);
+
+DWORD
+mono_coop_win32_signal_object_and_wait (HANDLE toSignal, HANDLE toWait, DWORD timeout, BOOL alertable);
 
 DWORD
 mono_win32_msg_wait_for_multiple_objects_ex (DWORD count, CONST HANDLE *handles, DWORD timeout, DWORD wakeMask, DWORD flags);
 
 DWORD
+mono_coop_win32_msg_wait_for_multiple_objects_ex (DWORD count, CONST HANDLE *handles, DWORD timeout, DWORD wakeMask, DWORD flags);
+
+DWORD
 mono_win32_wsa_wait_for_multiple_events (DWORD count, const WSAEVENT FAR *handles, BOOL waitAll, DWORD timeout, BOOL alertable);
+
+DWORD
+mono_coop_win32_wsa_wait_for_multiple_events (DWORD count, const WSAEVENT FAR *handles, BOOL waitAll, DWORD timeout, BOOL alertable);
 
 #endif
 

--- a/mono/utils/mono-threads-coop.c
+++ b/mono/utils/mono-threads-coop.c
@@ -35,8 +35,9 @@
 #endif
 
 #ifdef _MSC_VER
-// TODO: Find MSVC replacement for __builtin_unwind_init
-#define SAVE_REGS_ON_STACK g_assert_not_reached ();
+// __builtin_unwind_init not available under MSVC but equivalent implementation is done using
+// copy_stack_data_internal_win32_wrapper.
+#define SAVE_REGS_ON_STACK do {} while (0)
 #elif defined (HOST_WASM)
 //TODO: figure out wasm stack scanning
 #define SAVE_REGS_ON_STACK do {} while (0)
@@ -167,7 +168,7 @@ return_stack_ptr (gpointer *i)
 }
 
 static void
-copy_stack_data (MonoThreadInfo *info, MonoStackData *stackdata_begin)
+copy_stack_data_internal (MonoThreadInfo *info, MonoStackData *stackdata_begin, gconstpointer wrapper_data1, gconstpointer wrapper_data2)
 {
 	MonoThreadUnwindState *state;
 	int stackdata_size;
@@ -196,6 +197,57 @@ copy_stack_data (MonoThreadInfo *info, MonoStackData *stackdata_begin)
 
 	state->gc_stackdata_size = stackdata_size;
 }
+
+#ifdef _MSC_VER
+typedef void (*CopyStackDataFunc)(MonoThreadInfo *, MonoStackData *, gconstpointer, gconstpointer);
+
+#ifdef TARGET_AMD64
+// Implementation of __builtin_unwind_init under MSVC, dumping nonvolatile registers into MonoBuiltinUnwindInfo.
+typedef struct {
+	__m128d fregs [10];
+	host_mgreg_t gregs [8];
+} MonoBuiltinUnwindInfo;
+
+// Defined in win64.asm
+G_EXTERN_C void
+copy_stack_data_internal_win32_wrapper (MonoThreadInfo *, MonoStackData *, MonoBuiltinUnwindInfo *, CopyStackDataFunc);
+#else
+// Implementation of __builtin_unwind_init under MSVC, dumping nonvolatile registers into MonoBuiltinUnwindInfo.
+typedef struct {
+	host_mgreg_t gregs [4];
+} MonoBuiltinUnwindInfo;
+
+// Implementation of __builtin_unwind_init under MSVC, dumping nonvolatile registers into MonoBuiltinUnwindInfo *.
+__declspec(naked) void __cdecl
+copy_stack_data_internal_win32_wrapper (MonoThreadInfo *info, MonoStackData *stackdata_begin, MonoBuiltinUnwindInfo *unwind_info_data, CopyStackDataFunc func)
+{
+	__asm {
+		mov edx, dword ptr [esp + 0Ch]
+		mov dword ptr [edx + 00h], ebx
+		mov dword ptr [edx + 04h], esi
+		mov dword ptr [edx + 08h], edi
+		mov dword ptr [edx + 0Ch], ebp
+
+		// tailcall, all parameters passed through to CopyStackDataFunc.
+		mov edx, dword ptr [esp + 10h]
+		jmp edx
+	};
+}
+#endif
+
+static void
+copy_stack_data (MonoThreadInfo *info, MonoStackData *stackdata_begin)
+{
+	MonoBuiltinUnwindInfo unwind_info_data;
+	copy_stack_data_internal_win32_wrapper (info, stackdata_begin, &unwind_info_data, copy_stack_data_internal);
+}
+#else
+static void
+copy_stack_data (MonoThreadInfo *info, MonoStackData *stackdata_begin)
+{
+	copy_stack_data_internal (info, stackdata_begin, NULL, NULL);
+}
+#endif
 
 static gpointer
 mono_threads_enter_gc_safe_region_unbalanced_with_info (MonoThreadInfo *info, MonoStackData *stackdata);
@@ -282,8 +334,10 @@ mono_threads_exit_gc_safe_region_internal (gpointer cookie, MonoStackData *stack
 		return;
 
 #ifdef ENABLE_CHECKED_BUILD_GC
+	W32_DEFINE_LAST_ERROR_RESTORE_POINT;
 	if (mono_check_mode_enabled (MONO_CHECK_MODE_GC))
 		coop_tls_pop (cookie);
+	W32_RESTORE_LAST_ERROR_FROM_RESTORE_POINT;
 #endif
 
 	mono_threads_exit_gc_safe_region_unbalanced_internal (cookie, stackdata);
@@ -304,6 +358,11 @@ mono_threads_exit_gc_safe_region_unbalanced_internal (gpointer cookie, MonoStack
 
 	if (!mono_threads_is_blocking_transition_enabled ())
 		return;
+
+	/* Common to use enter/exit gc safe around OS API's affecting last error. */
+	/* This method can call OS API's that will reset last error on some platforms. */
+	/* To reduce errors, we need to restore last error before exit gc safe. */
+	W32_DEFINE_LAST_ERROR_RESTORE_POINT;
 
 	info = (MonoThreadInfo *)cookie;
 
@@ -335,6 +394,8 @@ mono_threads_exit_gc_safe_region_unbalanced_internal (gpointer cookie, MonoStack
 		info->async_target = NULL;
 		info->user_data = NULL;
 	}
+
+	W32_RESTORE_LAST_ERROR_FROM_RESTORE_POINT;
 }
 
 void

--- a/mono/utils/mono-threads-posix.c
+++ b/mono/utils/mono-threads-posix.c
@@ -127,7 +127,7 @@ mono_threads_platform_init (void)
 }
 
 gboolean
-mono_threads_platform_in_critical_region (MonoNativeThreadId tid)
+mono_threads_platform_in_critical_region (THREAD_INFO_TYPE *info)
 {
 	return FALSE;
 }

--- a/mono/utils/mono-threads-wasm.c
+++ b/mono/utils/mono-threads-wasm.c
@@ -153,7 +153,7 @@ mono_threads_platform_exit (gsize exit_code)
 }
 
 gboolean
-mono_threads_platform_in_critical_region (MonoNativeThreadId tid)
+mono_threads_platform_in_critical_region (THREAD_INFO_TYPE *info)
 {
 	return FALSE;
 }

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -1828,6 +1828,11 @@ mono_thread_info_uninstall_interrupt (gboolean *interrupted)
 	MonoThreadInfo *info;
 	MonoThreadInfoInterruptToken *previous_token;
 
+	/* Common to uninstall interrupt handler around OS API's affecting last error. */
+	/* This method could call OS API's on some platforms that will reset last error so make sure to restore */
+	/* last error before exit. */
+	W32_DEFINE_LAST_ERROR_RESTORE_POINT;
+
 	g_assert (interrupted);
 	*interrupted = FALSE;
 
@@ -1848,6 +1853,8 @@ mono_thread_info_uninstall_interrupt (gboolean *interrupted)
 
 	THREADS_INTERRUPT_DEBUG ("interrupt uninstall  tid %p previous_token %p interrupted %s\n",
 		mono_thread_info_get_tid (info), previous_token, *interrupted ? "TRUE" : "FALSE");
+
+	W32_RESTORE_LAST_ERROR_FROM_RESTORE_POINT;
 }
 
 static MonoThreadInfoInterruptToken*

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -1167,7 +1167,7 @@ is_thread_in_critical_region (MonoThreadInfo *info)
 	gpointer stack_start;
 	MonoThreadUnwindState *state;
 
-	if (mono_threads_platform_in_critical_region (mono_thread_info_get_tid (info)))
+	if (mono_threads_platform_in_critical_region (info))
 		return TRUE;
 
 	/* Are we inside a system critical region? */

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -814,6 +814,24 @@ mono_win32_interrupt_wait (PVOID thread_info, HANDLE native_thread_handle, DWORD
 
 void
 mono_win32_abort_blocking_io_call (THREAD_INFO_TYPE *info);
+
+#define W32_DEFINE_LAST_ERROR_RESTORE_POINT \
+	DWORD _last_error_restore_point = GetLastError ();
+
+#define W32_UPDATE_LAST_ERROR_RESTORE_POINT \
+	_last_error_restore_point = GetLastError ();
+
+#define W32_RESTORE_LAST_ERROR_FROM_RESTORE_POINT \
+		/* Only restore if changed to prevent unecessary writes. */ \
+		if (GetLastError () != _last_error_restore_point) \
+			SetLastError (_last_error_restore_point);
+
+#else
+
+#define W32_DEFINE_LAST_ERROR_RESTORE_POINT /* nothing */
+#define W32_UPDATE_LAST_ERROR_RESTORE_POINT /* nothing */
+#define W32_RESTORE_LAST_ERROR_FROM_RESTORE_POINT /* nothing */
+
 #endif
 
 #endif /* __MONO_THREADS_H__ */

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -590,7 +590,7 @@ mono_thread_platform_create_thread (MonoThreadStart thread_fn, gpointer thread_d
 void mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize);
 gboolean mono_threads_platform_is_main_thread (void);
 void mono_threads_platform_init (void);
-gboolean mono_threads_platform_in_critical_region (MonoNativeThreadId tid);
+gboolean mono_threads_platform_in_critical_region (THREAD_INFO_TYPE *info);
 gboolean mono_threads_platform_yield (void);
 void mono_threads_platform_exit (gsize exit_code);
 

--- a/mono/utils/win64.asm
+++ b/mono/utils/win64.asm
@@ -38,6 +38,40 @@ __mono_current_ip:
 
 mono_context_get_current endP
 
+; Implementation of __builtin_unwind_init under MSVC, dumping
+; nonvolatile registers into MonoBuiltinUnwindInfo *.
+
+copy_stack_data_internal_win32_wrapper PROC PUBLIC
+;rcx MonoThreadInfo *
+;rdx MonoStackData *
+;r8 MonoBuiltinUnwindInfo *
+;r9 CopyStackDataFunc
+
+	movaps xmmword ptr [r8 + 00h], xmm6
+	movaps xmmword ptr [r8 + 10h], xmm7
+	movaps xmmword ptr [r8 + 20h], xmm8
+	movaps xmmword ptr [r8 + 30h], xmm9
+	movaps xmmword ptr [r8 + 40h], xmm10
+	movaps xmmword ptr [r8 + 50h], xmm11
+	movaps xmmword ptr [r8 + 60h], xmm12
+	movaps xmmword ptr [r8 + 70h], xmm13
+	movaps xmmword ptr [r8 + 80h], xmm14
+	movaps xmmword ptr [r8 + 90h], xmm15
+
+	mov qword ptr [r8 + 0A0h], rbx
+	mov qword ptr [r8 + 0A8h], rsi
+	mov qword ptr [r8 + 0B0h], rdi
+	mov qword ptr [r8 + 0B8h], r12
+	mov qword ptr [r8 + 0C0h], r13
+	mov qword ptr [r8 + 0C8h], r14
+	mov qword ptr [r8 + 0D0h], r15
+	mov qword ptr [r8 + 0D8h], rbp
+
+	; tailcall, all parameters passed through to CopyStackDataFunc.
+	jmp r9
+
+copy_stack_data_internal_win32_wrapper endP
+
 endif
 
 end

--- a/msvc/mono.winconfig.targets
+++ b/msvc/mono.winconfig.targets
@@ -107,7 +107,9 @@
                   {
                       string [] supportedFeatures = { "ENABLE_ICALL_SYMBOL_MAP",
                                                       "ENABLE_LLVM",
-                                                      "ENABLE_LLVM_RUNTIME" };
+                                                      "ENABLE_LLVM_RUNTIME",
+                                                      "ENABLE_HYBRID_SUSPEND",
+                                                      "ENABLE_COOP_SUSPEND" };
 
                       var enableFeatures = GetConfigFeatures(path, ".*#define.*ENABLE_.*1");
                       if (enableDefines != null)

--- a/winconfig.h
+++ b/winconfig.h
@@ -22,16 +22,24 @@
 /* Disables the IO portability layer */
 #define DISABLE_PORTABILITY 1
 
-/* DISABLE_DEFINES picked up from cygconfig.h, if available */
+/* Start configure DISABLE_DEFINES picked up from cygconfig.h or other external source, if available */
 /* @DISABLE_DEFINES@ */
+/* End configure DISABLE_DEFINES picked up from cygconfig.h or other external source, if available */
 
 /* No DISABLE_DEFINES below this point */
 
 /* Some VES is available at runtime */
 #define ENABLE_ILGEN 1
 
-/* Optional ENABLE_DEFINES */
+/* Start configure ENABLE_DEFINES picked up from cygconfig.h or other external source, if available */
 /* @ENABLE_DEFINES@ */
+/* End configure ENABLE_DEFINES picked up from cygconfig.h or other external source, if available */
+
+#if defined(ENABLE_HYBRID_SUSPEND) || defined(ENABLE_COOP_SUSPEND)
+/* Windows MSVC builds defaults to preemptive suspend. Disable ENABLE_HYBRID_SUSPEND/ENABLE_COOP_SUSPEND defines. */
+#undef ENABLE_HYBRID_SUSPEND
+#undef ENABLE_COOP_SUSPEND
+#endif
 
 /* No ENABLE_DEFINES below this point */
 
@@ -157,8 +165,9 @@
 #define HAVE_WRITE_BARRIERS
 #endif
 
-/* Optional HAVE_DEFINES */
+/* Start configure HAVE_DEFINES picked up from cygconfig.h or other external source, if available */
 /* @HAVE_DEFINES@ */
+/* End configure HAVE_DEFINES picked up from cygconfig.h or other external source, if available */
 
 /* No HAVE_DEFINES below this point */
 


### PR DESCRIPTION
Adding initial support for hybrid and cooperate suspend on Windows 32/64-bit platforms.

Fixes/adjustments needed in several areas:

Implementation/emulation of gcc's __builtin_unwind_init on MSVC needed by copy_stack_data function.

All wait methods have been extended with a cooperative alternative + handling interrupt under hybrid/cooperative suspend.

Methods that handles IO abort interruption on Windows (file, socket) have been updated to handle interrupt under hybrid/cooperative suspend.

Moved Windows implementations into w32handle.c instead of #ifdef on call site.

Reduced number of GC safe transition in a couple of Win32 file IO methods.

Added restore logic to Win32 last error when exiting GC safe mode. This is needed since we have code that depends on GetLastError that could be clobbered if exiting GC safe mode enter a wait. Also added last error restore logic to uninstall interrupt handler since it is commonly used right after exiting GC safe mode.
