### PR TITLE
[aot] Cosmetical follow-up for https://github.com/mono/mono/pull/14043

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -9887,7 +9887,7 @@ emit_code (MonoAotCompile *acfg)
 			index = get_method_index (acfg, method);
 			sprintf (symbol, "ut_%d", index);
 
-			arch_emit_direct_call (acfg, symbol, FALSE, acfg->thumb_mixed && cfg->compile_llvm, NULL, &call_size);
+			arch_emit_label_address (acfg, symbol, FALSE, acfg->thumb_mixed && cfg->compile_llvm, NULL, &call_size);
 #endif
 		}
 	}


### PR DESCRIPTION
https://github.com/mono/mono/pull/14043

If we ever should use FullAOT on a non-Darwin/arm32 target then this is needed.
