### PR TITLE
Update documentation for --with-large-heap

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,9 @@ faster under the Xen virtualization system.
 
 * `--with-large-heap=yes,no` - Enable support for GC heaps larger than 3GB.
 
+  * This only applies only to the Boehm garbage collector, the SGen garbage
+collector does not use this configuration option.
+
   * This defaults to `no`.
 
 * `--enable-small-config=yes,no` - Enable some tweaks to reduce memory usage


### PR DESCRIPTION
This flag only applies to the Boehm GC, but it's not obvious until you dig down into the source code. I thought that an edit like this to the readme would help prevent future confusion for others, given that SGen the default.