### PR TITLE
[wasm][sdk] Fixes to the sdk packages

### DIFF
--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -400,6 +400,7 @@ clean-sdk:
 	$(RM) -r sdk/**/obj
 	$(RM) -r sdk/**/**/bin
 	$(RM) -r sdk/**/**/obj
+	$(RM) -r sdk/packages
 
 build-sdk: $(WASM_FRAMEWORK)/.stamp-framework
 	dotnet build sdk/Mono.WebAssembly.Sdk

--- a/sdks/wasm/sdk/Mono.WebAssembly.Build/Mono.WebAssembly.Build.csproj
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Build/Mono.WebAssembly.Build.csproj
@@ -13,8 +13,8 @@
   <ItemGroup>
     <None Include="..\..\..\out\wasm-bcl\wasm_tools\monolinker.exe" Link="monolinker.exe" CopyToOutputDirectory="Always" Pack="true" PackagePath="$(BuildOutputTargetFolder)\tools" />
     <None Include="..\..\..\out\wasm-bcl\wasm_tools\Mono.Cecil.dll" Link="Mono.Cecil.dll" CopyToOutputDirectory="Always" Pack="true" PackagePath="$(BuildOutputTargetFolder)\tools" />
-    <None Update="Mono.WebAssembly.Build.targets" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath="$(BuildOutputTargetFolder)netstandard2.0" />
-    <None Update="Mono.WebAssembly.Build.props" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath="$(BuildOutputTargetFolder)" />
+    <None Update="Mono.WebAssembly.Build.targets" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath="$(BuildOutputTargetFolder)\netstandard2.0" />
+    <None Update="Mono.WebAssembly.Build.props" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath="$(BuildOutputTargetFolder)\netstandard2.0" />
     <None Update="RuntimeJs.tt" Generator="TextTemplatingFilePreprocessor" LastGenOutput="RuntimeJs.cs" />
     <Compile Update="RuntimeJs.cs" DependentUpon="RuntimeJs.tt" />
   </ItemGroup>

--- a/sdks/wasm/sdk/Mono.WebAssembly.Build/WasmLinkAssemblies.cs
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Build/WasmLinkAssemblies.cs
@@ -82,8 +82,7 @@ namespace Mono.WebAssembly.Build
 				return false;
 			}
 
-			WasmLinkMode linkme;
-			if (!Enum.TryParse<WasmLinkMode>(LinkMode, out linkme)) {
+			if (!Enum.TryParse<WasmLinkMode> (LinkMode, out var linkme)) {
 				Log.LogError ("LinkMode is invalid.");
 				return false;
 			}
@@ -95,7 +94,6 @@ namespace Mono.WebAssembly.Build
 		protected override string GenerateCommandLineCommands ()
 		{
 			var sb = new StringBuilder ();
-
 			sb.Append (" --verbose");
 
 			// add exclude features
@@ -118,24 +116,24 @@ namespace Mono.WebAssembly.Build
 				break;
 			}
 
-			sb.AppendFormat (" -c {0} -u {1}", coremode, usermode);
+			sb.AppendFormat ($" -c {coremode} -u {usermode}");
 
 			//the linker doesn't consider these core by default
-			sb.AppendFormat (" -p {0} WebAssembly.Bindings -p {0} WebAssembly.Net.Http -p {0} WebAssembly.Net.WebSockets", coremode);
+			sb.AppendFormat ($" -p {coremode} WebAssembly.Bindings -p {coremode} WebAssembly.Net.Http -p {coremode} WebAssembly.Net.WebSockets");
 
 			if (!string.IsNullOrEmpty (LinkSkip)) {
 				var skips = LinkSkip.Split (new[] { ';', ',', ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
 				foreach (var s in skips) {
-					sb.AppendFormat (" -p \"{0}\" copy", s);
+					sb.AppendFormat ($" -p \"{s}\" copy");
 				}
 			}
 
-			sb.AppendFormat (" -out \"{0}\"", OutputDir);
-			sb.AppendFormat (" -d \"{0}\"", FrameworkDir);
-			sb.AppendFormat (" -d \"{0}\"", Path.Combine(FrameworkDir, "Facades"));
-			sb.AppendFormat (" -b {0} -v {0}", Debug);
+			sb.AppendFormat ($" -out \"{OutputDir.Replace ("\\", "\\\\")}\"");
+			sb.AppendFormat ($" -d \"{FrameworkDir.Replace ("\\", "\\\\")}\"");
+			sb.AppendFormat ($" -d \"{Path.Combine (FrameworkDir, "Facades").Replace ("\\", "\\\\")}\"");
+			sb.AppendFormat ($" -b {Debug} -v {Debug}");
 
-			sb.AppendFormat (" -a \"{0}\"", RootAssembly[0].GetMetadata("FullPath"));
+			sb.AppendFormat ($" -a \"{RootAssembly[0].GetMetadata("FullPath").Replace ("\\", "\\\\")}\"");
 
 			//we'll normally have to check most of the because the SDK references most framework asm by default
 			//so let's enumerate upfront
@@ -156,7 +154,7 @@ namespace Mono.WebAssembly.Build
 						continue;
 					}
 
-					sb.AppendFormat (" -r \"{0}\"", p);
+					sb.AppendFormat ($" -r \"{p.Replace ("\\", "\\\\")}\"");
 				}
 			}
 
@@ -164,9 +162,8 @@ namespace Mono.WebAssembly.Build
 				sb.Append (" -l none");
 			} else {
 				var vals = I18n.Split (new[] { ',', ';', ' ', '\r', '\n', '\t' });
-				sb.AppendFormat (" -l {0}", string.Join(",", vals));
+				sb.AppendFormat ($" -l {string.Join (",", vals)}");
 			}
-
 			return sb.ToString ();
 		}
 	}

--- a/sdks/wasm/sdk/Mono.WebAssembly.Framework/Mono.WebAssembly.Framework.csproj
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Framework/Mono.WebAssembly.Framework.csproj
@@ -11,6 +11,6 @@
     <Content Include="..\..\..\out\wasm-bcl\wasm\*.pdb" PackagePath="wasm-assemblies\%(Filename)%(Extension)" Link="runtime-assemblies\%(Filename)%(Extension)" />
     <Content Include="..\..\..\out\wasm-bcl\wasm\Facades\*.dll" PackagePath="wasm-assemblies\Facades\%(Filename)%(Extension)" Link="runtime-assemblies\Facades\%(Filename)%(Extension)" />
     <Content Include="..\..\..\out\wasm-bcl\wasm\Facades\*.pdb" PackagePath="wasm-assemblies\Facades\%(Filename)%(Extension)" Link="runtime-assemblies\Facades\%(Filename)%(Extension)" />
-    <None Update="build\netstandard2.0\Mono.WebAssembly.Framework.props" Pack="True" />
+    <None Update="build\netstandard2.0\Mono.WebAssembly.Framework.props" PackagePath="build\netstandard2.0\Mono.WebAssembly.Framework.props" Pack="True" />
   </ItemGroup>
 </Project>

--- a/sdks/wasm/sdk/Mono.WebAssembly.Framework/Mono.WebAssembly.Framework.csproj
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Framework/Mono.WebAssembly.Framework.csproj
@@ -7,10 +7,10 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="..\..\..\out\bcl\wasm\*.dll" PackagePath="wasm-assemblies\%(Filename)%(Extension)" Link="runtime-assemblies\%(Filename)%(Extension)" />
-    <Content Include="..\..\..\out\bcl\wasm\*.pdb" PackagePath="wasm-assemblies\%(Filename)%(Extension)" Link="runtime-assemblies\%(Filename)%(Extension)" />
-    <Content Include="..\..\..\out\bcl\wasm\Facades\*.dll" PackagePath="wasm-assemblies\Facades\%(Filename)%(Extension)" Link="runtime-assemblies\Facades\%(Filename)%(Extension)" />
-    <Content Include="..\..\..\out\bcl\wasm\Facades\*.pdb" PackagePath="wasm-assemblies\Facades\%(Filename)%(Extension)" Link="runtime-assemblies\Facades\%(Filename)%(Extension)" />
+    <Content Include="..\..\..\out\wasm-bcl\wasm\*.dll" PackagePath="wasm-assemblies\%(Filename)%(Extension)" Link="runtime-assemblies\%(Filename)%(Extension)" />
+    <Content Include="..\..\..\out\wasm-bcl\wasm\*.pdb" PackagePath="wasm-assemblies\%(Filename)%(Extension)" Link="runtime-assemblies\%(Filename)%(Extension)" />
+    <Content Include="..\..\..\out\wasm-bcl\wasm\Facades\*.dll" PackagePath="wasm-assemblies\Facades\%(Filename)%(Extension)" Link="runtime-assemblies\Facades\%(Filename)%(Extension)" />
+    <Content Include="..\..\..\out\wasm-bcl\wasm\Facades\*.pdb" PackagePath="wasm-assemblies\Facades\%(Filename)%(Extension)" Link="runtime-assemblies\Facades\%(Filename)%(Extension)" />
     <None Update="build\netstandard2.0\Mono.WebAssembly.Framework.props" Pack="True" />
   </ItemGroup>
 </Project>

--- a/sdks/wasm/sdk/Mono.WebAssembly.Runtime.Framework/Mono.WebAssembly.Runtime.csproj
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Runtime.Framework/Mono.WebAssembly.Runtime.csproj
@@ -13,5 +13,6 @@
     <Content Include="..\..\..\wasm\debug\mono.wasm.map" PackagePath="mono-wasm-runtime\debug\%(Filename)%(Extension)" Link="mono-wasm-runtime\debug\mono.wasm.map" />
     <Content Include="..\..\..\wasm\release\mono.js" PackagePath="mono-wasm-runtime\release\%(Filename)%(Extension)" Link="mono-wasm-runtime\release\mono.js" />
     <Content Include="..\..\..\wasm\release\mono.wasm" PackagePath="mono-wasm-runtime\release\%(Filename)%(Extension)" Link="mono-wasm-runtime\release\mono.wasm" />
+    <None Update="build\netstandard2.0\Mono.WebAssembly.Runtime.props" PackagePath="build\netstandard2.0\Mono.WebAssembly.Runtime.props" Pack="True" />
   </ItemGroup>
 </Project>

--- a/sdks/wasm/sdk/Mono.WebAssembly.Sdk/sdk/Sdk.props
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Sdk/sdk/Sdk.props
@@ -1,11 +1,11 @@
 <Project>
   <PropertyGroup>
-    <_MonoWasmBuildPackageVersion>0.1</_MonoWasmBuildPackageVersion>
-    <_MonoWasmFrameworkPackageVersion>0.1</_MonoWasmFrameworkPackageVersion>
-    <_MonoWasmRuntimePackageVersion>0.1</_MonoWasmRuntimePackageVersion>
-    <_MonoWasmBindingsPackageVersion>0.1</_MonoWasmBindingsPackageVersion>
-    <_MonoWasmHttpHandlerPackageVersion>0.1</_MonoWasmHttpHandlerPackageVersion>
-    <_MonoWasmClientWebSocketPackageVersion>0.1</_MonoWasmClientWebSocketPackageVersion>
+    <_MonoWasmBuildPackageVersion>0.1.0</_MonoWasmBuildPackageVersion>
+    <_MonoWasmFrameworkPackageVersion>0.1.0</_MonoWasmFrameworkPackageVersion>
+    <_MonoWasmRuntimePackageVersion>0.1.0</_MonoWasmRuntimePackageVersion>
+    <_MonoWasmBindingsPackageVersion>0.1.0</_MonoWasmBindingsPackageVersion>
+    <_MonoWasmHttpHandlerPackageVersion>0.1.0</_MonoWasmHttpHandlerPackageVersion>
+    <_MonoWasmClientWebSocketPackageVersion>0.1.0</_MonoWasmClientWebSocketPackageVersion>
     <_IsMonoWasmProject>True</_IsMonoWasmProject>
   </PropertyGroup>
 


### PR DESCRIPTION
The PR targets the sdk project build to make sure they run on windows and VS 2019

- Package the wasm bcl and wasm bcl Facades correctly.
- Move the build props and targets file to `netstandard2.0` build directory.
- Place `framework` .props file properly for build
- Place `runtime` .props file properly for build
- Modify the WasmLinkAssemblies Task to escape the windows path separator.  - There are problems executing `mononlinker.exe` on windows if the windows path separators are not escaped. 

**Note:**
* Tested on VS 2019 project on windows.
* VS Mac 2019 has problems executing these project types.  VS Mac 2017 did not have problems.