### PR TITLE
[2018-10] Protecting boxing a null value

### DIFF
--- a/mcs/class/corlib/Test/System.Reflection/MethodInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/MethodInfoTest.cs
@@ -658,6 +658,15 @@ namespace MonoTests.System.Reflection
 			Assert.AreEqual (10, pi2.GetGetMethod ().Invoke (10, null));
 		}
 
+		[Test]
+		public void NullableTestsStatic ()
+		{
+			Nullable<Double> val = new Nullable<Double>(new Double());
+			MethodInfo mi = typeof (Nullable<Double>).GetMethod ("op_Implicit");
+			object obj = val;
+			mi.Invoke(null, new[] { obj });
+		}
+
 		public static void foo_generic<T> ()
 		{
 		}


### PR DESCRIPTION
When a static method is called the obj is not used, so it can be null and it doesn't need to be boxed.

Adding an assert in the method to prevent other crash in this method if a NULL is received.
Fixes #13969

Backport of #14018.

/cc @lambdageek @thaystg

