### PR TITLE
[2019-02][monodroid] Remove File.Copy xUnit tests

### DIFF
--- a/mcs/class/corlib/monodroid_corlib_xtest.dll.exclude.sources
+++ b/mcs/class/corlib/monodroid_corlib_xtest.dll.exclude.sources
@@ -1,0 +1,1 @@
+../../../external/corefx/src/System.IO.FileSystem/tests/File/Copy.cs


### PR DESCRIPTION
a) CopyFileWithData_MemberData() is crashing the Xamarin .Android test runner

b) Some other failures that may be real issues (but also these are new tests on a new platform so not necessarily a regression)
