### PR TITLE
[monodroid] Exclude System.IO.Tests.File_Copy_str_str CoreFX testsuite

### DIFF
--- a/mcs/class/corlib/monodroid_corlib_xtest.dll.exclude.sources
+++ b/mcs/class/corlib/monodroid_corlib_xtest.dll.exclude.sources
@@ -1,0 +1,2 @@
+../../../external/corefx/src/System.IO.FileSystem/tests/File/Copy.cs
+../../../external/corefx/src/System.IO.FileSystem/tests/FileInfo/CopyTo.cs


### PR DESCRIPTION
The test case CopyFileWithData_MemberData with input of size 1024 * 1024 * 10
causes the Xamarin.Android.Bcl_Tests to crash for some reason.  Temporarily
exclude this entire set of tests from running.

Also disable System.IO.Tests.FileInfo_CopyTo_str because it derives from the
above test class.

