### PR TITLE
[2019-04] [aot] partial revert of #14043

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -6044,7 +6044,7 @@ emit_and_reloc_code (MonoAotCompile *acfg, MonoMethod *method, guint8 *code, gui
 				if (direct_call) {
 					int call_size;
 
-					arch_emit_label_address (acfg, direct_call_target, external_call, FALSE, patch_info, &call_size);
+					arch_emit_direct_call (acfg, direct_call_target, external_call, FALSE, patch_info, &call_size);
 					i += call_size - INST_LEN;
 				} else {
 					int code_size;


### PR DESCRIPTION
We need to emit a real call here. On arm/android we would emit this now:
```asm
ldr pc, =label
.ltorg         # place address of `label` here.
```
which is a jump to `label`, not a call.

We need a different solution to make larger assemblies work, but for now
I revert it so the `2019-02` intergration is unblocked.

Partial revert of #14043


Backport of #14135.

/cc @lewurm 