### PR TITLE
Small steps toward JIT icall hash reduction/elimination.

### DIFF
--- a/mono/mini/exceptions-arm.c
+++ b/mono/mini/exceptions-arm.c
@@ -385,28 +385,42 @@ mono_arch_get_throw_corlib_exception (MonoTrampInfo **info, gboolean aot)
 }	
 
 GSList*
-mono_arm_get_exception_trampolines (gboolean aot)
+mono_arm_get_exception_trampoline (gboolean corlib, gboolean rethrow, gboolean llvm, gboolean resume_unwind,
+				   const char *tramp_name, gboolean aot, gboolean reg, GSList *tramps)
 {
 	MonoTrampInfo *info;
+
+	(void)get_throw_trampoline (168, corlib, rethrow, llvm, resume_unwind, tramp_name, &info, aot, FALSE);
+
+	// Register the trampolines or build up a list.
+	if (reg) {
+		mono_register_jit_icall (info->code, tramp_name, NULL, TRUE);
+		mono_tramp_info_register (info, NULL);
+		return NULL;
+	}
+	return g_slist_prepend (tramps, info);
+}
+
+// Not taking a string directly here will be useful in removing JIT icall hashing.
+#define mono_arm_get_exception_trampoline(corlib, rethrow, llvm, resume_unwind, tramp_name, aot, reg, tramps) \
+	(mono_arm_get_exception_trampoline ((corlib), (rethrow), (llvm), (resume_unwind), #tramp_name, (aot), (reg), (tramps)))
+
+GSList*
+mono_arm_get_exception_trampolines (gboolean aot, gboolean reg)
+{
 	GSList *tramps = NULL;
 
 	/* LLVM uses the normal trampolines, but with a different name */
-	get_throw_trampoline (168, TRUE, FALSE, FALSE, FALSE, "llvm_throw_corlib_exception_trampoline", &info, aot, FALSE);
-	tramps = g_slist_prepend (tramps, info);
-	
-	get_throw_trampoline (168, TRUE, FALSE, TRUE, FALSE, "llvm_throw_corlib_exception_abs_trampoline", &info, aot, FALSE);
-	tramps = g_slist_prepend (tramps, info);
-
-	get_throw_trampoline (168, FALSE, FALSE, FALSE, TRUE, "llvm_resume_unwind_trampoline", &info, aot, FALSE);
-	tramps = g_slist_prepend (tramps, info);
-
-	return tramps;
+	//                                          corlib rethrow  llvm  resume_unwind
+	tramps = mono_arm_get_exception_trampoline (  TRUE, FALSE, FALSE,        FALSE, llvm_throw_corlib_exception_trampoline,     aot, reg, tramps);
+	tramps = mono_arm_get_exception_trampoline (  TRUE, FALSE,  TRUE,        FALSE, llvm_throw_corlib_exception_abs_trampoline, aot, reg, tramps);
+	return   mono_arm_get_exception_trampoline ( FALSE, FALSE, FALSE,         TRUE, llvm_resume_unwind_trampoline,              aot, reg, tramps);
 }
 
 #else
 
 GSList*
-mono_arm_get_exception_trampolines (gboolean aot)
+mono_arm_get_exception_trampolines (gboolean aot, gboolean reg)
 {
 	g_assert_not_reached ();
 	return NULL;
@@ -418,7 +432,6 @@ void
 mono_arch_exceptions_init (void)
 {
 	gpointer tramp;
-	GSList *tramps, *l;
 	
 	if (mono_aot_only) {
 		tramp = mono_aot_get_trampoline ("llvm_throw_corlib_exception_trampoline");
@@ -427,16 +440,9 @@ mono_arch_exceptions_init (void)
 		mono_register_jit_icall (tramp, "llvm_throw_corlib_exception_abs_trampoline", NULL, TRUE);
 		tramp = mono_aot_get_trampoline ("llvm_resume_unwind_trampoline");
 		mono_register_jit_icall (tramp, "llvm_resume_unwind_trampoline", NULL, TRUE);
-	} else {
-		tramps = mono_arm_get_exception_trampolines (FALSE);
-		for (l = tramps; l; l = l->next) {
-			MonoTrampInfo *info = (MonoTrampInfo*)l->data;
-
-			mono_register_jit_icall (info->code, g_strdup (info->name), NULL, TRUE);
-			mono_tramp_info_register (info, NULL);
-		}
-		g_slist_free (tramps);
+		return;
 	}
+	(void)mono_arm_get_exception_trampolines (FALSE, TRUE);
 }
 
 /* 

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -8331,7 +8331,7 @@ mono_arch_emit_load_aotconst (guint8 *start, guint8 *code, MonoJumpInfo **ji, Mo
 GSList *
 mono_arch_get_trampolines (gboolean aot)
 {
-	return mono_amd64_get_exception_trampolines (aot);
+	return mono_amd64_get_exception_trampolines (aot, FALSE);
 }
 
 /* Soft Debug support */

--- a/mono/mini/mini-amd64.h
+++ b/mono/mini/mini-amd64.h
@@ -516,7 +516,7 @@ gpointer
 mono_amd64_start_gsharedvt_call (GSharedVtCallInfo *info, gpointer *caller, gpointer *callee, gpointer mrgctx_reg);
 
 GSList*
-mono_amd64_get_exception_trampolines (gboolean aot);
+mono_amd64_get_exception_trampolines (gboolean aot, gboolean reg);
 
 int
 mono_amd64_get_tls_gs_offset (void) MONO_LLVM_INTERNAL;

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -7200,7 +7200,7 @@ mono_arch_context_set_int_reg (MonoContext *ctx, int reg, host_mgreg_t val)
 GSList *
 mono_arch_get_trampolines (gboolean aot)
 {
-	return mono_arm_get_exception_trampolines (aot);
+	return mono_arm_get_exception_trampolines (aot, FALSE);
 }
 
 #if defined(MONO_ARCH_SOFT_DEBUG_SUPPORTED)

--- a/mono/mini/mini-arm.h
+++ b/mono/mini/mini-arm.h
@@ -415,7 +415,7 @@ int
 mono_arm_i8_align (void);
 
 GSList*
-mono_arm_get_exception_trampolines (gboolean aot);
+mono_arm_get_exception_trampolines (gboolean aot, gboolean reg);
 
 guint8*
 mono_arm_get_thumb_plt_entry (guint8 *code);

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -5393,7 +5393,7 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTC
 GSList *
 mono_arch_get_trampolines (gboolean aot)
 {
-	return mono_arm_get_exception_trampolines (aot);
+	return mono_arm_get_exception_trampolines (aot, FALSE);
 }
 
 #else /* DISABLE_JIT */

--- a/mono/mini/mini-arm64.h
+++ b/mono/mini/mini-arm64.h
@@ -277,7 +277,7 @@ void mono_arm_throw_exception (gpointer arg, host_mgreg_t pc, host_mgreg_t *int_
 
 void mono_arm_gsharedvt_init (void);
 
-GSList* mono_arm_get_exception_trampolines (gboolean aot);
+GSList* mono_arm_get_exception_trampolines (gboolean aot, gboolean reg);
 
 void mono_arm_resume_unwind (gpointer arg, host_mgreg_t pc, host_mgreg_t *int_regs, gdouble *fp_regs, gboolean corlib, gboolean rethrow);
 


### PR DESCRIPTION
This is related to https://github.com/mono/mono/pull/14047.

In particular it is useful to have mono_register_jit_icall
nearer the creation of trampolines, so we can specify the related data or enum.

Alternate would be to grow MonoTrampInfo to pass the data through.
 Which I hadn't thought of before and would be a way to
 wastefully decrease the diff.

This restructuring also lets us avoid memory allocation/free
of the trampoline list -- register inline with creation instead
of returning the list and then registering and freeing.

And while we are here, save some string allocs/copies.
