### PR TITLE
Fix MSBuild/FSharp patch, which was missed in backport

### DIFF
--- a/packaging/MacSDK/patches/fsharp-msbuild-16-0.patch
+++ b/packaging/MacSDK/patches/fsharp-msbuild-16-0.patch
@@ -1,7 +1,7 @@
-diff --git a/mono/config.make.in b/mono/config.make.in
+diff --git a/mono/config.make b/mono/config.make
 index 3106ab99f..8af247ffd 100644
---- a/mono/config.make.in
-+++ b/mono/config.make.in
+--- a/mono/config.make
++++ b/mono/config.make
 @@ -148,6 +148,7 @@ install-sdk-lib:
  	    echo " --> $(DESTDIR)$(monodir)/xbuild/Microsoft/VisualStudio/v12.0/FSharp/"; \
  	    echo " --> $(DESTDIR)$(monodir)/xbuild/Microsoft/VisualStudio/v14.0/FSharp/"; \
@@ -45,6 +45,13 @@ index 3106ab99f..8af247ffd 100644
  	    $(INSTALL_LIB) $(outdir)Microsoft.FSharp.NetSdk.targets $(DESTDIR)$(monodir)/xbuild/Microsoft/VisualStudio/v14.0/FSharp/; \
  	    $(INSTALL_LIB) $(outdir)Microsoft.FSharp.NetSdk.targets $(DESTDIR)$(monodir)/xbuild/Microsoft/VisualStudio/v15.0/FSharp/; \
 +	    $(INSTALL_LIB) $(outdir)Microsoft.FSharp.NetSdk.targets $(DESTDIR)$(monodir)/xbuild/Microsoft/VisualStudio/v16.0/FSharp/; \
+ 	    \
+ 	    $(INSTALL_LIB) $(outdir)Microsoft.FSharp.Overrides.NetSdk.targets $(DESTDIR)$(monodir)/xbuild/Microsoft/VisualStudio/v/FSharp/; \
+ 	    $(INSTALL_LIB) $(outdir)Microsoft.FSharp.Overrides.NetSdk.targets $(DESTDIR)$(monodir)/xbuild/Microsoft/VisualStudio/v11.0/FSharp/; \
+ 	    $(INSTALL_LIB) $(outdir)Microsoft.FSharp.Overrides.NetSdk.targets $(DESTDIR)$(monodir)/xbuild/Microsoft/VisualStudio/v12.0/FSharp/; \
+ 	    $(INSTALL_LIB) $(outdir)Microsoft.FSharp.Overrides.NetSdk.targets $(DESTDIR)$(monodir)/xbuild/Microsoft/VisualStudio/v14.0/FSharp/; \
+ 	    $(INSTALL_LIB) $(outdir)Microsoft.FSharp.Overrides.NetSdk.targets $(DESTDIR)$(monodir)/xbuild/Microsoft/VisualStudio/v15.0/FSharp/; \
++	    $(INSTALL_LIB) $(outdir)Microsoft.FSharp.Overrides.NetSdk.targets $(DESTDIR)$(monodir)/xbuild/Microsoft/VisualStudio/v16.0/FSharp/; \
  	fi
  	@if test x-$(outsuffix) = x-net40; then \
  	    if test -e $(outdir)$(NAME).dll; then \


### PR DESCRIPTION
Fixes:

```
23:55:47  can't find file to patch at input line 5
23:55:47  Perhaps you used the wrong -p or --strip option?
23:55:47  The text leading up to this was:
23:55:47  --------------------------
23:55:47  |diff --git a/mono/config.make.in b/mono/config.make.in
23:55:47  |index 3106ab99f..8af247ffd 100644
23:55:47  |--- a/mono/config.make.in
23:55:47  |+++ b/mono/config.make.in
23:55:47  --------------------------
23:55:47  File to patch: 
23:55:47  Skip this patch? [y] 
23:55:47  Skipping patch.
23:55:47  4 out of 4 hunks ignored
```

e.g. https://jenkins.mono-project.com/job/build-package-osx-mono/job/2019-02/173/console