### PR TITLE
[interp] Don't check for exception in native wrappers

### DIFF
--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -6331,9 +6331,6 @@ emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 
 	(void) mono_lookup_internal_call_full (method, FALSE, &uses_handles, &foreign_icall);
 
-	/* If it uses handles and MonoError, it had better check exceptions */
-	g_assert (!uses_handles || check_exceptions);
-
 	if (G_UNLIKELY (foreign_icall)) {
 		/* FIXME: we only want the transitions for hybrid suspend.  Q: What to do about AOT? */
 		need_gc_safe = gc_safe_transition_builder_init (&gc_safe_transition_builder, mb, FALSE);

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -495,7 +495,7 @@ get_virtual_method (InterpMethod *imethod, MonoObject *obj)
 	}
 
 	if (virtual_method->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL) {
-		virtual_method = mono_marshal_get_native_wrapper (virtual_method, TRUE, FALSE);
+		virtual_method = mono_marshal_get_native_wrapper (virtual_method, FALSE, FALSE);
 	}
 
 	if (virtual_method->iflags & METHOD_IMPL_ATTRIBUTE_SYNCHRONIZED) {

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1304,7 +1304,7 @@ interp_transform_internal_calls (MonoMethod *method, MonoMethod *target_method, 
 			target_method = mono_marshal_get_synchronized_wrapper (target_method);
 
 		if (target_method->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL && !is_virtual && !mono_class_is_marshalbyref (target_method->klass) && m_class_get_rank (target_method->klass) == 0)
-			target_method = mono_marshal_get_native_wrapper (target_method, TRUE, FALSE);
+			target_method = mono_marshal_get_native_wrapper (target_method, FALSE, FALSE);
 	}
 	return target_method;
 }
@@ -5854,7 +5854,7 @@ mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, Mon
 
 		/* assumes all internal calls with an array this are built in... */
 		if (method->iflags & METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL && (! mono_method_signature_internal (method)->hasthis || m_class_get_rank (method->klass) == 0)) {
-			nm = mono_marshal_get_native_wrapper (method, TRUE, FALSE);
+			nm = mono_marshal_get_native_wrapper (method, FALSE, FALSE);
 			signature = mono_method_signature_internal (nm);
 		} else {
 			const char *name = method->name;


### PR DESCRIPTION
We already do it when we get back to the interpreter.