### PR TITLE
[wasm][bindings] Refactor WebAssembly.Core object instantiation.

### DIFF
--- a/sdks/wasm/binding_support.js
+++ b/sdks/wasm/binding_support.js
@@ -7,7 +7,7 @@ var BindingSupportLib = {
 		mono_wasm_ref_counter: 0,
 		mono_wasm_free_list: [],
 		mono_wasm_marshal_enum_as_int: false,
-		mono_wasm_core_map: {},	
+		mono_wasm_core_map: null,	
 		mono_bindings_init: function (binding_asm) {
 			this.BINDING_ASM = binding_asm;
 		},
@@ -96,7 +96,7 @@ var BindingSupportLib = {
 			this.object_to_string = get_method ("ObjectToString");
 
 			this.object_to_enum = get_method ("ObjectToEnum");
-			BINDING.mono_wasm_core_map = new Map();
+			BINDING.mono_wasm_core_map = new WeakMap();
 			this.init = true;
 		},		
 
@@ -739,21 +739,20 @@ var BindingSupportLib = {
 		core_object_type: function(obj) {
 			var coreType = BINDING.mono_wasm_core_map.get(obj.constructor);
 			if (typeof coreType === "undefined") {
-				var switchName = obj.constructor.name;
-				switch (true) {
-					case switchName === "Array":
-					case switchName === "ArrayBuffer":
-					case switchName === "Int8Array":
-					case switchName === "Uint8Array":
-					case switchName === "Uint8ClampedArray":
-					case switchName === "Int16Array":
-					case switchName === "Uint16Array":
-					case switchName === "Int32Array":
-					case switchName === "Uint32Array":
-					case switchName === "Float32Array":
-					case switchName === "Float64Array":
-					case switchName === "Function":
-					case switchName === "SharedArrayBuffer":
+				switch (obj.constructor.name) {
+					case "Array":
+					case "ArrayBuffer":
+					case "Int8Array":
+					case "Uint8Array":
+					case "Uint8ClampedArray":
+					case "Int16Array":
+					case "Uint16Array":
+					case "Int32Array":
+					case "Uint32Array":
+					case "Float32Array":
+					case "Float64Array":
+					case "Function":
+					case "SharedArrayBuffer":
 						coreType = this.wasm_get_core_type(obj);
 						break;
 				}

--- a/sdks/wasm/binding_support.js
+++ b/sdks/wasm/binding_support.js
@@ -7,7 +7,6 @@ var BindingSupportLib = {
 		mono_wasm_ref_counter: 0,
 		mono_wasm_free_list: [],
 		mono_wasm_marshal_enum_as_int: false,
-		mono_wasm_core_map: null,	
 		mono_bindings_init: function (binding_asm) {
 			this.BINDING_ASM = binding_asm;
 		},
@@ -96,7 +95,6 @@ var BindingSupportLib = {
 			this.object_to_string = get_method ("ObjectToString");
 
 			this.object_to_enum = get_method ("ObjectToEnum");
-			BINDING.mono_wasm_core_map = new WeakMap();
 			this.init = true;
 		},		
 
@@ -730,30 +728,89 @@ var BindingSupportLib = {
 		},
 		wasm_get_core_type: function (obj)
 		{
-			var coreType = this.call_method (this.get_core_type, null, "so", [ "WebAssembly.Core."+obj.constructor.name ]);
-			if (typeof coreType !== "undefined") {
-				BINDING.mono_wasm_core_map.set(obj.constructor, coreType);
-			}
-			return coreType;
+			return this.call_method (this.get_core_type, null, "so", [ "WebAssembly.Core."+obj.constructor.name ]);
 		},
-		core_object_type: function(obj) {
-			var coreType = BINDING.mono_wasm_core_map.get(obj.constructor);
+		get_wasm_type: function(obj) {
+			var coreType = obj[Symbol.for("wasm type")];
 			if (typeof coreType === "undefined") {
 				switch (obj.constructor.name) {
 					case "Array":
+						coreType = this.wasm_get_core_type(obj);
+						if (typeof coreType !== "undefined") {
+							Array.prototype[Symbol.for("wasm type")] = coreType
+						}
+						break;
 					case "ArrayBuffer":
+						coreType = this.wasm_get_core_type(obj);
+						if (typeof coreType !== "undefined") {
+							ArrayBuffer.prototype[Symbol.for("wasm type")] = coreType
+						}
+						break;
 					case "Int8Array":
+						coreType = this.wasm_get_core_type(obj);
+						if (typeof coreType !== "undefined") {
+							Int8Array.prototype[Symbol.for("wasm type")] = coreType
+						}
+						break;
 					case "Uint8Array":
+						coreType = this.wasm_get_core_type(obj);
+						if (typeof coreType !== "undefined") {
+							Uint8Array.prototype[Symbol.for("wasm type")] = coreType
+						}
+						break;
 					case "Uint8ClampedArray":
+						coreType = this.wasm_get_core_type(obj);
+						if (typeof coreType !== "undefined") {
+							Uint8ClampedArray.prototype[Symbol.for("wasm type")] = coreType
+						}
+						break;
 					case "Int16Array":
+						coreType = this.wasm_get_core_type(obj);
+						if (typeof coreType !== "undefined") {
+							Int16Array.prototype[Symbol.for("wasm type")] = coreType
+						}
+						break;
 					case "Uint16Array":
+						coreType = this.wasm_get_core_type(obj);
+						if (typeof coreType !== "undefined") {
+							Uint16Array.prototype[Symbol.for("wasm type")] = coreType
+						}
+						break;
 					case "Int32Array":
+						coreType = this.wasm_get_core_type(obj);
+						if (typeof coreType !== "undefined") {
+							Int32Array.prototype[Symbol.for("wasm type")] = coreType
+						}
+						break;
 					case "Uint32Array":
+						coreType = this.wasm_get_core_type(obj);
+						if (typeof coreType !== "undefined") {
+							Uint32Array.prototype[Symbol.for("wasm type")] = coreType
+						}
+						return coreType;
 					case "Float32Array":
+						coreType = this.wasm_get_core_type(obj);
+						if (typeof coreType !== "undefined") {
+							Float32Array.prototype[Symbol.for("wasm type")] = coreType
+						}
+						break;
 					case "Float64Array":
+						coreType = this.wasm_get_core_type(obj);
+						if (typeof coreType !== "undefined") {
+							Float64Array.prototype[Symbol.for("wasm type")] = coreType
+						}
+						break;
 					case "Function":
+						coreType = this.wasm_get_core_type(obj);
+						if (typeof coreType !== "undefined") {
+							Function.prototype[Symbol.for("wasm type")] = coreType
+						}
+						break;
 					case "SharedArrayBuffer":
 						coreType = this.wasm_get_core_type(obj);
+						if (typeof coreType !== "undefined") {
+							SharedArrayBuffer.prototype[Symbol.for("wasm type")] = coreType
+						}
 						break;
 				}
 		  	}
@@ -772,9 +829,9 @@ var BindingSupportLib = {
 					var handle = this.mono_wasm_free_list.length ?
 								this.mono_wasm_free_list.pop() : this.mono_wasm_ref_counter++;
 					obj.__mono_jshandle__ = handle;
-					// Obtain the core object JS -> C# type mapping.
-					var coreObjType = this.core_object_type(obj);
-					gc_handle = obj.__mono_gchandle__ = this.wasm_binding_obj_new(handle + 1, coreObjType);
+					// Obtain the JS -> C# type mapping.
+					var wasm_type = this.get_wasm_type(obj);
+					gc_handle = obj.__mono_gchandle__ = this.wasm_binding_obj_new(handle + 1, wasm_type);
 					this.mono_wasm_object_registry[handle] = obj;
 						
 				}

--- a/sdks/wasm/binding_support.js
+++ b/sdks/wasm/binding_support.js
@@ -756,7 +756,7 @@ var BindingSupportLib = {
 						coreType = this.wasm_get_core_type(obj);
 						break;
 				}
-		  }
+		  	}
 			return coreType;
 		},
 		// Object wrapping helper functions to handle reference handles that will

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Runtime.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Runtime.cs
@@ -63,24 +63,8 @@ namespace WebAssembly {
 		static Dictionary<int, JSObject> bound_objects = new Dictionary<int, JSObject> ();
 		static Dictionary<object, JSObject> raw_to_js = new Dictionary<object, JSObject> ();
 
-		static Dictionary<string, Type> js_clr_mapping = new Dictionary<string, Type> (); 
-
 		static Runtime ()
-		{
-			js_clr_mapping.Add ("[object Array]", typeof (Core.Array));
-			js_clr_mapping.Add ("[object ArrayBuffer]", typeof (Core.ArrayBuffer));
-			js_clr_mapping.Add ("[object Int8Array]", typeof (Core.Int8Array));
-			js_clr_mapping.Add ("[object Uint8Array]", typeof (Core.Uint8Array));
-			js_clr_mapping.Add ("[object Uint8ClampedArray]", typeof (Core.Uint8ClampedArray));
-			js_clr_mapping.Add ("[object Int16Array]", typeof (Core.Int16Array));
-			js_clr_mapping.Add ("[object Uint16Array]", typeof (Core.Uint16Array));
-			js_clr_mapping.Add ("[object Int32Array]", typeof (Core.Int32Array));
-			js_clr_mapping.Add ("[object Uint32Array]", typeof (Core.Uint32Array));
-			js_clr_mapping.Add ("[object Float32Array]", typeof (Core.Float32Array));
-			js_clr_mapping.Add ("[object Float64Array]", typeof (Core.Float64Array));
-			js_clr_mapping.Add ("[object Function]", typeof (Core.Function));
-			js_clr_mapping.Add ("[object SharedArrayBuffer]", typeof (Core.SharedArrayBuffer));
-		}
+		{ }
 
 		/// <summary>
 		/// Creates a new JavaScript object of the specified type
@@ -118,11 +102,10 @@ namespace WebAssembly {
 			return res as JSObject;
 		}
 
-		static int BindJSObject (int js_id, string type)
+		static int BindJSObject (int js_id, Type mappedType)
 		{
-			JSObject obj;
-			if (!bound_objects.TryGetValue (js_id, out obj)) {
-				if (js_clr_mapping.TryGetValue (type, out Type mappedType)) {
+			if (!bound_objects.TryGetValue (js_id, out JSObject obj)) {
+				if (mappedType != null) {
 					return BindJSType (js_id, mappedType);
 				} else {
 					bound_objects [js_id] = obj = new JSObject ((IntPtr)js_id);
@@ -146,11 +129,10 @@ namespace WebAssembly {
 			return (int)(IntPtr)obj.Handle;
 		}
 
-		static int BindJSType (int js_id, Type type)
+		static int BindJSType (int js_id, Type mappedType)
 		{
-			JSObject obj;
-			if (!bound_objects.TryGetValue (js_id, out obj)) {
-				var jsobjectnew = type.GetConstructor (BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.ExactBinding,
+			if (!bound_objects.TryGetValue (js_id, out JSObject obj)) {
+				var jsobjectnew = mappedType.GetConstructor (BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.ExactBinding,
 			    		null, new Type [] { typeof (IntPtr) }, null);
 				bound_objects [js_id] = obj = (JSObject)jsobjectnew.Invoke (new object [] { (IntPtr)js_id });
 			}
@@ -300,6 +282,13 @@ namespace WebAssembly {
 		
 		}
 
+		static object GetCoreType (string coreObj)
+		{
+			Assembly asm = typeof (Runtime).Assembly;
+			Type type = asm.GetType (coreObj);
+			return type;
+
+		}
 
 		[StructLayout (LayoutKind.Explicit)]
 		internal struct IntPtrAndHandle {


### PR DESCRIPTION
Implement suggestion by Katelyn Gadd to use Symbol instead of a Map or WeakMap.

- Attach a special named Symbol for `wasm type` to the prototype property for the Core objects that we have bound.
- The Managed Type is stored in the Symbol property that will be passed to the managed side.
- Move the supported Core object identification into javascript.
- Runtime: the core object type is now passed into the Runtime from javascript binding support instead of being housed in managed code.
- Remove the use of tostring to identify the object type.

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->