### PR TITLE
[wasm][sdk] Add command line quoting and escaping to WasmLinkAssembli…

### DIFF
--- a/sdks/wasm/sdk/Mono.WebAssembly.Build/Glob.cs
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Build/Glob.cs
@@ -1,0 +1,300 @@
+﻿//
+// Author:
+//   Aaron Bockover <abock@xamarin.com>
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Collections.Generic;
+
+// Reuse of code from https://github.com/Microsoft/workbooks/blob/master/Agents/Xamarin.Interactive/ProcessControl/Glob.cs 
+namespace Xamarin.ProcessControl
+{
+    static class Glob
+    {
+        static string[] ParseParts(string path, out string rootComponent)
+        {
+            rootComponent = null;
+
+            if (path == null)
+                return null;
+
+            rootComponent = Path.GetPathRoot(path);
+            if (String.IsNullOrEmpty(rootComponent))
+                rootComponent = null;
+
+            return path
+                .Split(new[] { Path.DirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries)
+                .Where(part => !String.IsNullOrEmpty(part) && part != ".")
+                .ToArray();
+        }
+
+        public static Regex GetRegex(string pattern)
+        {
+            return GlobEnumerator.GetRegex(pattern);
+        }
+
+        /// <summary>
+        /// Perform a glob expansion on <paramref name="pattern"/> with shell style
+        /// behavior, using the current working directory as a base path. If the
+        /// pattern cannot be expanded, the pattern itself will be yielded.
+        /// </summary>
+        public static IEnumerable<string> ShellExpand(string pattern)
+        {
+            var any = false;
+
+            foreach (var expansion in Expand(pattern))
+            {
+                any = true;
+                yield return expansion;
+            }
+
+            if (!any)
+                yield return pattern;
+        }
+
+        /// <summary>
+        /// Expand the specified <paramref name="pattern"/> against the current working
+        /// directory. If the pattern cannot be expanded, nothing will be yielded.
+        /// </summary>
+        public static IEnumerable<string> Expand(string pattern)
+        {
+            return Expand(".", pattern);
+        }
+
+        /// <summary>
+        /// Expand the specified <paramref name="pattern"/> against the
+        /// <paramref name="basePath"/>. If the pattern cannot be expanded,
+        /// nothing will be yielded.</summary>
+        public static IEnumerable<string> Expand(string basePath, string pattern)
+        {
+            if (basePath == null)
+                throw new ArgumentNullException(nameof(basePath));
+
+            if (pattern == null)
+                throw new ArgumentNullException(nameof(pattern));
+
+            var parts = ParseParts(pattern, out string rootComponent);
+
+            return PatternEnumerator.Create(parts).Enumerate(basePath);
+        }
+
+        abstract class PatternEnumerator
+        {
+            public static PatternEnumerator Create(string[] patternParts)
+            {
+                if (patternParts == null)
+                    return new TerminalEnumerator();
+
+                if (patternParts.Length == 0)
+                    throw new ArgumentException("must have at least one element", nameof(patternParts));
+
+                if (patternParts[0] == null)
+                    throw new ArgumentException("must not have null elements", nameof(patternParts));
+
+                var root = patternParts[0];
+                string[] childParts = null;
+
+                if (patternParts.Length > 1)
+                {
+                    childParts = new string[patternParts.Length - 1];
+                    Array.Copy(patternParts, 1, childParts, 0, childParts.Length);
+                }
+
+                if (root == "**")
+                    return new RecursiveDirectoryEnumerator(childParts);
+                else if (root.Contains("**"))
+                    throw new ArgumentException("invalid pattern: '**' can only be an " +
+                        $"entire path component ({root}", nameof(patternParts));
+                else if (GlobEnumerator.CanHandleWildcards(root))
+                    return new GlobEnumerator(root, childParts);
+                else
+                    return new VerbatimEnumerator(root, childParts);
+            }
+
+            protected PatternEnumerator Successor { get; private set; }
+
+            protected PatternEnumerator() { }
+
+            protected PatternEnumerator(string[] childParts)
+            {
+                Successor = Create(childParts);
+            }
+
+            public abstract IEnumerable<string> Enumerate(string basePath);
+        }
+
+        class TerminalEnumerator : PatternEnumerator
+        {
+            internal TerminalEnumerator()
+            {
+            }
+
+            public override IEnumerable<string> Enumerate(string basePath)
+            {
+                yield return basePath;
+            }
+        }
+
+        class VerbatimEnumerator : PatternEnumerator
+        {
+            readonly string name;
+
+            internal VerbatimEnumerator(string name, string[] childParts) : base(childParts)
+            {
+                this.name = name;
+            }
+
+            public override IEnumerable<string> Enumerate(string basePath)
+            {
+                if (Directory.Exists(basePath))
+                {
+                    var path = Path.Combine(basePath, name);
+                    if (Directory.Exists(path) || File.Exists(path))
+                    {
+                        foreach (var expanded in Successor.Enumerate(path))
+                            yield return expanded;
+                    }
+                }
+            }
+        }
+
+        class RecursiveDirectoryEnumerator : PatternEnumerator
+        {
+            internal RecursiveDirectoryEnumerator(string[] childParts) : base(childParts)
+            {
+            }
+
+            static IEnumerable<string> EnumerateDirectories(string basePath)
+            {
+                yield return basePath;
+                foreach (var directory in Directory.EnumerateDirectories(basePath, "*", SearchOption.AllDirectories))
+                    yield return directory;
+            }
+
+            public override IEnumerable<string> Enumerate(string basePath)
+            {
+                if (Directory.Exists(basePath))
+                {
+                    var yielded = new HashSet<string>();
+                    foreach (var directory in EnumerateDirectories(basePath))
+                    {
+                        foreach (var path in Successor.Enumerate(directory))
+                        {
+                            if (!yielded.Contains(path))
+                            {
+                                yield return path;
+                                yielded.Add(path);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        class GlobEnumerator : PatternEnumerator
+        {
+            internal static bool CanHandleWildcards(string pattern)
+            {
+                return pattern.Any(c => c == '*' || c == '?' || c == '[' || c == '{');
+            }
+
+            public static Regex GetRegex(string pattern)
+            {
+                return new Regex(TranslatePattern(pattern), RegexOptions.Multiline);
+            }
+
+            static string TranslatePattern(string pattern)
+            {
+                var builder = new StringBuilder(pattern.Length * 2);
+
+                var i = 0;
+                var n = pattern.Length;
+                var braceDepth = 0;
+
+                while (i < n)
+                {
+                    var c = pattern[i];
+                    i++;
+
+                    if (c == '*')
+                        builder.Append(".*");
+                    else if (c == '?')
+                        builder.Append('.');
+                    else if (c == '[')
+                    {
+                        var j = i;
+
+                        if (j < n && pattern[j] == '!')
+                            j++;
+                        if (j < n && pattern[j] == ']')
+                            j++;
+                        while (j < n && pattern[j] != ']')
+                            j++;
+
+                        if (j >= n)
+                            builder.Append("\\[");
+                        else
+                        {
+                            var subpattern = pattern.Substring(i, j - i).Replace("\\", "\\\\");
+                            i = j + 1;
+                            if (subpattern[0] == '!')
+                                subpattern = '^' + subpattern.Substring(1);
+                            else if (subpattern[0] == '^')
+                                subpattern = "\\" + subpattern;
+                            builder.Append('[');
+                            builder.Append(subpattern);
+                            builder.Append(']');
+                        }
+                    }
+                    else if (c == '{')
+                    {
+                        braceDepth++;
+                        builder.Append('(');
+                    }
+                    else if (c == '}')
+                    {
+                        braceDepth--;
+                        builder.Append(')');
+                    }
+                    else if (c == ',' && braceDepth > 0)
+                        builder.Append('|');
+                    else
+                        builder.Append(Regex.Escape(c.ToString()));
+                }
+
+                builder.Append('$');
+
+                return builder.ToString();
+            }
+
+            readonly Regex pattern;
+
+            internal GlobEnumerator(string pattern, string[] childParts) : base(childParts)
+            {
+                this.pattern = GetRegex(pattern);
+            }
+
+            public override IEnumerable<string> Enumerate(string basePath)
+            {
+                if (Directory.Exists(basePath))
+                {
+                    foreach (var path in Directory.EnumerateFileSystemEntries(basePath))
+                    {
+                        var name = Path.GetFileName(path);
+                        if (pattern.IsMatch(name))
+                        {
+                            foreach (var expanded in Successor.Enumerate(path))
+                                yield return expanded;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/sdks/wasm/sdk/Mono.WebAssembly.Build/ProcessArguments.cs
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Build/ProcessArguments.cs
@@ -1,0 +1,210 @@
+﻿//
+// Author:
+//   Aaron Bockover <abock@xamarin.com>
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+
+// Reuse of code from https://github.com/Microsoft/workbooks/blob/master/Agents/Xamarin.Interactive/ProcessControl/ProcessArguments.cs 
+namespace Xamarin.ProcessControl
+{
+    /// <summary>
+    /// An immutable list of process arguments. Arguments will be quoted if escaping is necessary.
+    /// </summary>
+    sealed class ProcessArguments : IReadOnlyList<string>
+    {
+        public static ProcessArguments Parse(string commandLine, bool expandGlobs = true)
+        {
+            var args = Empty;
+            var builder = new StringBuilder();
+            var quote = Char.MinValue;
+
+            Action<char, string> appendArg = (q, a) => {
+                if (q == Char.MinValue && String.IsNullOrWhiteSpace(a))
+                    return;
+
+                if (!expandGlobs || q == '\'')
+                {
+                    args = args.Add(a);
+                    return;
+                }
+
+                foreach (var glob in Glob.ShellExpand(a))
+                    args = args.Add(glob);
+            };
+
+            for (int i = 0; i < commandLine.Length; i++)
+            {
+                var c = commandLine[i];
+                var n = Char.MinValue;
+                if (i < commandLine.Length - 1)
+                    n = commandLine[i + 1];
+
+                if (Char.IsWhiteSpace(c) && quote == Char.MinValue)
+                {
+                    appendArg(quote, builder.ToString());
+                    builder.Length = 0;
+                }
+                else if (quote == Char.MinValue && (c == '\'' || c == '"'))
+                {
+                    quote = c;
+                }
+                else if (c == '\\' && n == quote)
+                {
+                    builder.Append(n);
+                    i++;
+                }
+                else if (quote != Char.MinValue && c == quote)
+                {
+                    quote = Char.MinValue;
+                }
+                else
+                {
+                    builder.Append(c);
+                }
+            }
+
+            if (builder.Length > 0)
+                appendArg(quote, builder.ToString());
+
+            return args;
+        }
+
+        public static string Quote(string argument)
+        {
+            if (argument == null)
+                throw new ArgumentNullException(nameof(argument));
+
+            StringBuilder builder = null;
+
+            for (int i = 0; i < argument.Length; i++)
+            {
+                var c = argument[i];
+                if (Char.IsWhiteSpace(c) || c == '\b' || c == '"' || c == '\\')
+                {
+                    if (builder == null)
+                    {
+                        builder = new StringBuilder(argument.Length + 8);
+                        builder.Append('"');
+                        builder.Append(argument.Substring(0, i));
+                    }
+
+                    if (c == '"' || c == '\\')
+                        builder.Append('\\');
+                }
+
+                if (builder != null)
+                    builder.Append(c);
+            }
+
+            if (builder == null)
+                return argument;
+
+            builder.Append('"');
+            return builder.ToString();
+        }
+
+        public static ProcessArguments Create(params string[] arguments)
+            => Create((IEnumerable<string>)arguments);
+
+        public static ProcessArguments Create(IEnumerable<string> arguments)
+        {
+            var processArguments = Empty;
+            if (arguments != null)
+                processArguments = processArguments.AddRange(arguments);
+            return processArguments;
+        }
+
+        public static ProcessArguments FromCommandAndArguments(string command, IEnumerable<string> arguments)
+        {
+            if (command == null)
+                throw new ArgumentNullException(nameof(command));
+
+            var processArguments = Empty.Add(command);
+
+            if (arguments != null)
+                processArguments = processArguments.AddRange(arguments);
+
+            return processArguments;
+        }
+
+        public static readonly ProcessArguments Empty = new ProcessArguments(ImmutableList<string>.Empty);
+
+        readonly ImmutableList<string> arguments;
+
+        ProcessArguments(ImmutableList<string> arguments)
+            => this.arguments = arguments;
+
+        public int Count => arguments.Count;
+
+        public string this[int index] => arguments[index];
+
+        public ProcessArguments Add(string argument)
+        {
+            if (argument == null)
+                throw new ArgumentNullException(nameof(argument));
+
+            return new ProcessArguments(
+                (arguments ?? ImmutableList<string>.Empty).Add(argument));
+        }
+
+        public ProcessArguments AddRange(params string[] arguments)
+            => AddRange((IEnumerable<string>)arguments);
+
+        public ProcessArguments AddRange(IEnumerable<string> arguments)
+        {
+            if (arguments == null)
+                throw new ArgumentNullException(nameof(arguments));
+
+            if (!arguments.Any())
+                return this;
+
+            return new ProcessArguments(
+                (this.arguments ?? ImmutableList<string>.Empty).AddRange(arguments));
+        }
+
+        public ProcessArguments Insert(int index, string argument)
+        {
+            if (argument == null)
+                throw new ArgumentNullException(nameof(argument));
+
+            return new ProcessArguments(
+                (arguments ?? ImmutableList<string>.Empty).Insert(
+                    index,
+                    argument));
+        }
+
+        public ProcessArguments InsertRange(int index, params string[] arguments)
+            => InsertRange(index, (IEnumerable<string>)arguments);
+
+        public ProcessArguments InsertRange(int index, IEnumerable<string> arguments)
+        {
+            if (arguments == null)
+                throw new ArgumentNullException(nameof(arguments));
+
+            if (!arguments.Any())
+                return this;
+
+            return new ProcessArguments(
+                (this.arguments ?? ImmutableList<string>.Empty).InsertRange(
+                    index,
+                    arguments));
+        }
+
+        public override string ToString()
+            => string.Join(" ", this.Select(Quote));
+
+        public IEnumerator<string> GetEnumerator()
+            => arguments.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => GetEnumerator();
+    }
+}

--- a/sdks/wasm/sdk/Mono.WebAssembly.Build/WasmLinkAssemblies.cs
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Build/WasmLinkAssemblies.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using Xamarin.ProcessControl;
 
 namespace Mono.WebAssembly.Build
 {
@@ -93,11 +94,10 @@ namespace Mono.WebAssembly.Build
 
 		protected override string GenerateCommandLineCommands ()
 		{
-			var sb = new StringBuilder ();
-			sb.Append (" --verbose");
+			ProcessArguments arguments = ProcessArguments.Create ("--verbose");
 
 			// add exclude features
-			sb.Append (" --exclude-feature remoting --exclude-feature com --exclude-feature etw");
+			arguments = arguments.AddRange ("--exclude-feature", "remoting", "--exclude-feature", "com", "--exclude-feature", "etw");
 
 			string coremode, usermode;
 
@@ -116,24 +116,30 @@ namespace Mono.WebAssembly.Build
 				break;
 			}
 
-			sb.AppendFormat ($" -c {coremode} -u {usermode}");
+			arguments = arguments.AddRange ("-c", coremode, "-u", usermode);
 
 			//the linker doesn't consider these core by default
-			sb.AppendFormat ($" -p {coremode} WebAssembly.Bindings -p {coremode} WebAssembly.Net.Http -p {coremode} WebAssembly.Net.WebSockets");
+			arguments = arguments.AddRange ("-p", coremode, "WebAssembly.Bindings");
+			arguments = arguments.AddRange ("-p", coremode, "WebAssembly.Net.Http");
+			arguments = arguments.AddRange ("-p", coremode, "WebAssembly.Net.WebSockets");
 
 			if (!string.IsNullOrEmpty (LinkSkip)) {
 				var skips = LinkSkip.Split (new[] { ';', ',', ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
 				foreach (var s in skips) {
-					sb.AppendFormat ($" -p \"{s}\" copy");
+					arguments = arguments.AddRange ("-p", s, "copy");
 				}
 			}
 
-			sb.AppendFormat ($" -out \"{OutputDir.Replace ("\\", "\\\\")}\"");
-			sb.AppendFormat ($" -d \"{FrameworkDir.Replace ("\\", "\\\\")}\"");
-			sb.AppendFormat ($" -d \"{Path.Combine (FrameworkDir, "Facades").Replace ("\\", "\\\\")}\"");
-			sb.AppendFormat ($" -b {Debug} -v {Debug}");
+			arguments = arguments.AddRange ("-out", OutputDir);
 
-			sb.AppendFormat ($" -a \"{RootAssembly[0].GetMetadata("FullPath").Replace ("\\", "\\\\")}\"");
+			arguments = arguments.AddRange ("-d", FrameworkDir);
+
+			arguments = arguments.AddRange ("-d", Path.Combine(FrameworkDir, "Facades"));
+
+			arguments = arguments.AddRange ("-b", Debug.ToString());
+			arguments = arguments.AddRange ("-v", Debug.ToString());
+
+			arguments = arguments.AddRange ("-a", RootAssembly[0].GetMetadata ("FullPath"));
 
 			//we'll normally have to check most of the because the SDK references most framework asm by default
 			//so let's enumerate upfront
@@ -148,23 +154,22 @@ namespace Mono.WebAssembly.Build
 			//add references for non-framework assemblies
 			if (Assemblies != null) {
 				foreach (var asm in Assemblies) {
-
 					var p = asm.GetMetadata ("FullPath");
-					if (frameworkAssemblies.Contains(Path.GetFileNameWithoutExtension(p))) {
+					if (frameworkAssemblies.Contains (Path.GetFileNameWithoutExtension (p))) {
 						continue;
 					}
-
-					sb.AppendFormat ($" -r \"{p.Replace ("\\", "\\\\")}\"");
+					arguments = arguments.AddRange ("-r", p);
 				}
 			}
 
 			if (string.IsNullOrEmpty (I18n)) {
-				sb.Append (" -l none");
+				arguments = arguments.AddRange ("-l", "none");
 			} else {
 				var vals = I18n.Split (new[] { ',', ';', ' ', '\r', '\n', '\t' });
-				sb.AppendFormat ($" -l {string.Join (",", vals)}");
+				arguments = arguments.AddRange ("-l", string.Join (",", vals));
 			}
-			return sb.ToString ();
+
+			return arguments.ToString ();
 		}
 	}
 

--- a/sdks/wasm/sdk/Mono.WebAssembly.Build/WasmLinkAssemblies.cs
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Build/WasmLinkAssemblies.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using Xamarin.ProcessControl;
 
 namespace Mono.WebAssembly.Build
 {
@@ -93,79 +94,94 @@ namespace Mono.WebAssembly.Build
 
 		protected override string GenerateCommandLineCommands ()
 		{
-			var sb = new StringBuilder ();
-			sb.Append (" --verbose");
+            ProcessArguments arguments = ProcessArguments.Create("--verbose");
 
-			// add exclude features
-			sb.Append (" --exclude-feature remoting --exclude-feature com --exclude-feature etw");
+            // add exclude features
+            arguments = arguments.AddRange("--exclude-feature", "remoting", "--exclude-feature", "com", "--exclude-feature", "etw");
 
-			string coremode, usermode;
+            string coremode, usermode;
 
-			switch ((WasmLinkMode)Enum.Parse (typeof (WasmLinkMode), LinkMode)) {
-			case WasmLinkMode.SdkOnly:
-				coremode = "link";
-				usermode = "copy";
-				break;
-			case WasmLinkMode.Full:
-				coremode = "link";
-				usermode = "link";
-				break;
-			default:
-				coremode = "copyused";
-				usermode = "copy";
-				break;
-			}
+            switch ((WasmLinkMode)Enum.Parse(typeof(WasmLinkMode), LinkMode))
+            {
+                case WasmLinkMode.SdkOnly:
+                    coremode = "link";
+                    usermode = "copy";
+                    break;
+                case WasmLinkMode.Full:
+                    coremode = "link";
+                    usermode = "link";
+                    break;
+                default:
+                    coremode = "copyused";
+                    usermode = "copy";
+                    break;
+            }
 
-			sb.AppendFormat ($" -c {coremode} -u {usermode}");
+            arguments = arguments.AddRange("-c", coremode, "-u", usermode);
 
-			//the linker doesn't consider these core by default
-			sb.AppendFormat ($" -p {coremode} WebAssembly.Bindings -p {coremode} WebAssembly.Net.Http -p {coremode} WebAssembly.Net.WebSockets");
+            //the linker doesn't consider these core by default
+            arguments = arguments.AddRange("-p", coremode, "WebAssembly.Bindings");
+            arguments = arguments.AddRange("-p", coremode, "WebAssembly.Net.Http");
+            arguments = arguments.AddRange("-p", coremode, "WebAssembly.Net.WebSockets");
 
-			if (!string.IsNullOrEmpty (LinkSkip)) {
-				var skips = LinkSkip.Split (new[] { ';', ',', ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-				foreach (var s in skips) {
-					sb.AppendFormat ($" -p \"{s}\" copy");
-				}
-			}
+            if (!string.IsNullOrEmpty(LinkSkip))
+            {
+                var skips = LinkSkip.Split(new[] { ';', ',', ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+                foreach (var s in skips)
+                {
+                    arguments = arguments.AddRange("-p", s, "copy");
+                }
+            }
 
-			sb.AppendFormat ($" -out \"{OutputDir.Replace ("\\", "\\\\")}\"");
-			sb.AppendFormat ($" -d \"{FrameworkDir.Replace ("\\", "\\\\")}\"");
-			sb.AppendFormat ($" -d \"{Path.Combine (FrameworkDir, "Facades").Replace ("\\", "\\\\")}\"");
-			sb.AppendFormat ($" -b {Debug} -v {Debug}");
+            arguments = arguments.AddRange("-out", OutputDir);
 
-			sb.AppendFormat ($" -a \"{RootAssembly[0].GetMetadata("FullPath").Replace ("\\", "\\\\")}\"");
+            arguments = arguments.AddRange("-d", FrameworkDir);
 
-			//we'll normally have to check most of the because the SDK references most framework asm by default
-			//so let's enumerate upfront
-			var frameworkAssemblies = new HashSet<string> (StringComparer.OrdinalIgnoreCase);
-			foreach (var f in Directory.EnumerateFiles (FrameworkDir)) {
-				frameworkAssemblies.Add (Path.GetFileNameWithoutExtension (f));
-			}
-			foreach (var f in Directory.EnumerateFiles (Path.Combine (FrameworkDir, "Facades"))) {
-				frameworkAssemblies.Add (Path.GetFileNameWithoutExtension (f));
-			}
+            arguments = arguments.AddRange("-d", Path.Combine(FrameworkDir, "Facades"));
 
-			//add references for non-framework assemblies
-			if (Assemblies != null) {
-				foreach (var asm in Assemblies) {
+            arguments = arguments.AddRange("-b", Debug.ToString());
+            arguments = arguments.AddRange("-v", Debug.ToString());
 
-					var p = asm.GetMetadata ("FullPath");
-					if (frameworkAssemblies.Contains(Path.GetFileNameWithoutExtension(p))) {
-						continue;
-					}
+            arguments = arguments.AddRange("-a", RootAssembly[0].GetMetadata("FullPath"));
 
-					sb.AppendFormat ($" -r \"{p.Replace ("\\", "\\\\")}\"");
-				}
-			}
+            //we'll normally have to check most of the because the SDK references most framework asm by default
+            //so let's enumerate upfront
+            var frameworkAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var f in Directory.EnumerateFiles(FrameworkDir))
+            {
+                frameworkAssemblies.Add(Path.GetFileNameWithoutExtension(f));
+            }
+            foreach (var f in Directory.EnumerateFiles(Path.Combine(FrameworkDir, "Facades")))
+            {
+                frameworkAssemblies.Add(Path.GetFileNameWithoutExtension(f));
+            }
 
-			if (string.IsNullOrEmpty (I18n)) {
-				sb.Append (" -l none");
-			} else {
-				var vals = I18n.Split (new[] { ',', ';', ' ', '\r', '\n', '\t' });
-				sb.AppendFormat ($" -l {string.Join (",", vals)}");
-			}
-			return sb.ToString ();
-		}
+            //add references for non-framework assemblies
+            if (Assemblies != null)
+            {
+                foreach (var asm in Assemblies)
+                {
+                    var p = asm.GetMetadata("FullPath");
+                    if (frameworkAssemblies.Contains(Path.GetFileNameWithoutExtension(p)))
+                    {
+                        continue;
+                    }
+                    arguments = arguments.AddRange("-r", p);
+                }
+            }
+
+            if (string.IsNullOrEmpty(I18n))
+            {
+                arguments = arguments.AddRange("-l", "none");
+            }
+            else
+            {
+                var vals = I18n.Split(new[] { ',', ';', ' ', '\r', '\n', '\t' });
+                arguments = arguments.AddRange("-l", string.Join(",", vals));
+            }
+
+            return arguments.ToString();
+        }
 	}
 
 	public enum WasmLinkMode


### PR DESCRIPTION
…es ToolTask.

- This resolves a few issues when executing `monolinker.exe` from windows build.
  - `monolinker.exe` executed on windows requires the windows path to be quoted or exception was thrown.
  - `monolinker.exe` executed on windows throws `Legacy path not supported` exception if the the path separator `\` is not escaped `\\`.  Example: `C:\path\to\assembly` needs to be passed as `C:\\path\\to\\assembly` 

The two new modules `Glob.cs` and `ProcessArguments.cs` were added as a general approach of escaping to replace the simplified escaping of the path separators using `.Replace ("\\", "\\\\")}\"")`.  The routines will also add quoting of the parameters instead of relying on the quoting within the module itself. 

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
