### PR TITLE
[2019-04] [interp] fix op_explicit for cast from nfloat to nint and vice versa

### DIFF
--- a/mono/mini/builtin-types.cs
+++ b/mono/mini/builtin-types.cs
@@ -1357,6 +1357,33 @@ public class BuiltinTests {
 		return 0;
 	}
 
+	static int test_0_much_casting ()
+	{
+		var notOof = (int)(float)1;
+		if (notOof != 1)
+			return 1;
+
+		var notOof2 = (nint)(float)(nfloat)1;
+		if (notOof2 != 1)
+			return 2;
+
+		var notOof3 = (nint)(int)(nfloat)1;
+		if (notOof3 != 1)
+			return 3;
+
+		var oof = (nint)(nfloat)1;
+		var oof2 = (int) oof - 1;
+		if (oof2 != 0)
+			return 4;
+
+		var noof = (nfloat)(nint)1;
+		var noof2 = (float) noof - 1;
+		if (noof2 > 0.1)
+			return 5;
+
+		return 0;
+	}
+
 #if !__MOBILE__
 	public static int Main (String[] args) {
 		return TestDriver.RunTests (typeof (BuiltinTests), args);

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -998,6 +998,7 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoMeth
 		} else if (!strcmp ("op_Implicit", tm ) || !strcmp ("op_Explicit", tm)) {
 			MonoType *src = csignature->params [0];
 			MonoType *dst = csignature->ret;
+			MonoClass *src_klass = mono_class_from_mono_type_internal (src);
 			int src_size = mini_magic_type_size (NULL, src);
 			int dst_size = mini_magic_type_size (NULL, dst);
 
@@ -1008,6 +1009,8 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoMeth
 				if (!mini_magic_is_int_type (src) || !mini_magic_is_int_type (dst)) {
 					if (mini_magic_is_int_type (src))
 						store_value_as_local = TRUE;
+					else if (mono_class_is_magic_float (src_klass))
+						store_value_as_local = TRUE;
 					else
 						return FALSE;
 				}
@@ -1015,6 +1018,8 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoMeth
 			case 2:
 				if (!mini_magic_is_float_type (src) || !mini_magic_is_float_type (dst)) {
 					if (mini_magic_is_float_type (src))
+						store_value_as_local = TRUE;
+					else if (mono_class_is_magic_int (src_klass))
 						store_value_as_local = TRUE;
 					else
 						return FALSE;


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-macios/issues/5809

/cc @spouliot 

Backport of #14201.

/cc @lewurm 