### PR TITLE
[runtime] Gracefully skip AOTing problematic assemblies

### DIFF
--- a/mono/metadata/image-internals.h
+++ b/mono/metadata/image-internals.h
@@ -26,4 +26,7 @@ mono_image_open_a_lot (const char *fname, MonoImageOpenStatus *status, gboolean 
 gboolean
 mono_is_problematic_image (MonoImage *image);
 
+gboolean
+mono_is_problematic_file (const char *fname);
+
 #endif /* __MONO_METADATA_IMAGE_INTERNALS_H__ */


### PR DESCRIPTION
If we cause the AOT step to return a nonzero exit code, it makes failing to compile the "problematic" assemblies pretty disruptive. It means that suddenly the build systems need to filter all of these assemblies to use Mono.

If the "problematic" assembly can just be skipped, we should be able to just turn the AOT step into a "no-op".

This PR does that.

Fixes issue described here: https://github.com/mono/mono/issues/13941