### PR TITLE
[netcore] Fix `make dist` following https://github.com/mono/mono/pull/14167

### DIFF
--- a/mcs/class/System.Private.CoreLib/Makefile
+++ b/mcs/class/System.Private.CoreLib/Makefile
@@ -14,10 +14,9 @@ all-local: $(ROSLYN_PROPS_FILE)
 $(ROSLYN_PROPS_FILE):
 	make -C ../../../netcore update-roslyn
 
-dist-recursive:
-	$(mkdir_p) $(distdir)
-	cp -a Makefile.am $(distdir)
-	cp -a Makefile.in $(distdir)
+dist-local:
+	mkdir -p $(distdir)
+	cp -a Makefile $(distdir)
 	cp -a *.csproj $(distdir)
-	for i in $(dirs); do $(mkdir_p) $(distdir)/$$i; done
+	for i in $(dirs); do mkdir -p $(distdir)/$$i; done
 	for i in $(files); do cp -a $$i $(distdir)/$$i; done

--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -192,3 +192,5 @@ run-%: check-env
 build-base: $(addprefix build-, $(TEST_SUITES))
 
 check: $(addprefix run-, $(TEST_SUITES))
+
+distdir:


### PR DESCRIPTION
```
17:34:54 make[2]: Entering directory '/mnt/jenkins/workspace/build-source-tarball-mono/netcore'
17:34:54 
make[2]: *** No rule to make target 'distdir'.  Stop.
```