### PR TITLE
[2019-02] Fix arm32 tailcall_reg/tailcall_membase.

### DIFF
--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -5027,18 +5027,42 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 
 			code = realloc_code (cfg, max_len);
 
+			// For reg and membase, get destination in IP.
+
+			if (tailcall_reg) {
+				g_assert (ins->sreg1 > -1);
+				if (ins->sreg1 != ARMREG_IP)
+					ARM_MOV_REG_REG (code, ARMREG_IP, ins->sreg1);
+			} else if (tailcall_membase) {
+				g_assert (ins->sreg1 > -1);
+				if (!arm_is_imm12 (ins->inst_offset)) {
+					g_assert (ins->sreg1 != ARMREG_IP); // temp in emit_big_add
+					code = emit_big_add (code, ARMREG_IP, ins->sreg1, ins->inst_offset);
+					ARM_LDR_IMM (code, ARMREG_IP, ARMREG_IP, 0);
+				} else {
+					ARM_LDR_IMM (code, ARMREG_IP, ins->sreg1, ins->inst_offset);
+				}
+			}
+
 			/*
 			 * The stack looks like the following:
 			 * <caller argument area>
 			 * <saved regs etc>
 			 * <rest of frame>
 			 * <callee argument area>
+			 * <optionally saved IP> (about to be)
 			 * Need to copy the arguments from the callee argument area to
 			 * the caller argument area, and pop the frame.
 			 */
 			if (call->stack_usage) {
 				int i, prev_sp_offset = 0;
-				
+				int saved_ip_offset = 0;
+
+				if (tailcall_membase || tailcall_reg) {
+					ARM_PUSH (code, 1 << ARMREG_IP);
+					saved_ip_offset = 4;
+				}
+
 				/* Compute size of saved registers restored below */
 				if (iphone_abi)
 					prev_sp_offset = 2 * 4;
@@ -5055,27 +5079,12 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				// FIXME a fixed size memcpy is desirable here,
 				// at least for larger values of stack_usage.
 				for (i = 0; i < call->stack_usage; i += sizeof (target_mgreg_t)) {
-					ARM_LDR_IMM (code, ARMREG_LR, ARMREG_SP, i);
-					ARM_STR_IMM (code, ARMREG_LR, ARMREG_IP, i);
+					ARM_LDR_IMM (code, ARMREG_LR, ARMREG_SP, i + saved_ip_offset);
+					ARM_STR_IMM (code, ARMREG_LR, ARMREG_IP, i + saved_ip_offset);
 				}
 
-			}
-
-			// For reg and membase, get destination in IP.
-
-			if (tailcall_reg) {
-				g_assert (ins->sreg1 > -1);
-				if (ins->sreg1 != ARMREG_IP)
-					ARM_MOV_REG_REG (code, ARMREG_IP, ins->sreg1);
-			} else if (tailcall_membase) {
-				g_assert (ins->sreg1 > -1);
-				if (!arm_is_imm12 (ins->inst_offset)) {
-					g_assert (ins->sreg1 != ARMREG_IP); // temp in emit_big_add
-					code = emit_big_add (code, ARMREG_IP, ins->sreg1, ins->inst_offset);
-					ARM_LDR_IMM (code, ARMREG_IP, ARMREG_IP, 0);
-				} else {
-					ARM_LDR_IMM (code, ARMREG_IP, ins->sreg1, ins->inst_offset);
-				}
+				if (saved_ip_offset)
+					ARM_POP (code, 1 << ARMREG_IP);
 			}
 
 			/*

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -5056,12 +5056,27 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			 */
 			if (call->stack_usage) {
 				int i, prev_sp_offset = 0;
-				int saved_ip_offset = 0;
 
-				if (tailcall_membase || tailcall_reg) {
+				// When we get here, the parameters to the tailcall are already formed,
+				// in registers and at the bottom of the grow-down stack.
+				//
+				// Our goal is generally preserve parameters, and trim the stack,
+				// and, before trimming stack, move parameters from the bottom of the
+				// frame to the bottom of the trimmed frame.
+
+				// For the case of large frames, and presently therefore always,
+				// IP is used as an adjusted frame_reg.
+				// Be conservative and save IP around the movement
+				// of parameters from the bottom of frame to top of the frame.
+				const gboolean save_ip = tailcall_membase || tailcall_reg;
+				if (save_ip)
 					ARM_PUSH (code, 1 << ARMREG_IP);
-					saved_ip_offset = 4;
-				}
+
+				// When moving stacked parameters from the bottom
+				// of the frame (sp) to the top of the frame (ip),
+				// account, 0 or 4, for the conditional save of IP.
+				const int offset_sp = save_ip ? 4 : 0;
+				const int offset_ip = (save_ip && (cfg->frame_reg == ARMREG_SP)) ? 4 : 0;
 
 				/* Compute size of saved registers restored below */
 				if (iphone_abi)
@@ -5073,17 +5088,23 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 						prev_sp_offset += 4;
 				}
 
+				// Point IP at the start of where the parameters will go after trimming stack.
+				// After locals and saved registers.
 				code = emit_big_add (code, ARMREG_IP, cfg->frame_reg, cfg->stack_usage + prev_sp_offset);
 
 				/* Copy arguments on the stack to our argument area */
 				// FIXME a fixed size memcpy is desirable here,
 				// at least for larger values of stack_usage.
+				//
+				// FIXME For most functions, with frames < 4K, we can use frame_reg directly here instead of IP.
+				// See https://github.com/mono/mono/pull/12079
+				// See https://github.com/mono/mono/pull/12079/commits/93e7007a9567b78fa8152ce404b372b26e735516
 				for (i = 0; i < call->stack_usage; i += sizeof (target_mgreg_t)) {
-					ARM_LDR_IMM (code, ARMREG_LR, ARMREG_SP, i + saved_ip_offset);
-					ARM_STR_IMM (code, ARMREG_LR, ARMREG_IP, i + saved_ip_offset);
+					ARM_LDR_IMM (code, ARMREG_LR, ARMREG_SP, i + offset_sp);
+					ARM_STR_IMM (code, ARMREG_LR, ARMREG_IP, i + offset_ip);
 				}
 
-				if (saved_ip_offset)
+				if (save_ip)
 					ARM_POP (code, 1 << ARMREG_IP);
 			}
 


### PR DESCRIPTION
Revert 257efc6374cbffb95d83dc9257b432d6ae3d80f6
and provide something much closer to what it was based on.

There have been many variations of this.

My original slightly bigger fix that adds a small optimization:
https://github.com/mono/mono/pull/12070

My original bigger fix with even more optimization:
https://github.com/mono/mono/pull/12079 

The broken fix that was merged:
https://github.com/mono/mono/pull/12701

A current bigger fix:
https://github.com/mono/mono/pull/14178 

This PR is a revert of #12701 and then closely resembles #12070, but the small optimization is removed, and the semantically same thing is stated with an attempt at increased clarity and more const and slightly less change.

This should help or fix https://github.com/mono/mono/issues/14103.

The basic problem with #12701 is it moved computation of the target, in IP (intra procedural scratch), relative to the movement of the parameters. This is quite risky because the computation of the target could depend on the parameters being in their "normal" location (esp. for tailcall_membase, the register could point to the frame; for tailcall_reg it seems safe). The code was previously structured conservatively to avoid breaking such a dependency.

The basic problem prior to #12701 was assumption that the frame register is the stack pointer, which is usually but not always true. So the change is to compute 0 or 4, two values, one for SP one for frame register, when moving the parameters.


Backport of #14187.

/cc @directhex @jaykrell