### PR TITLE
[netcore] Avoid needing any submodules to build `--with-core=only`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,11 +19,17 @@ build_with_msvc =
 build_without_msvc = msvc
 endif
 
+if ENABLE_NETCORE
+update_submodules = 
+else
+update_submodules = update_submodules
+endif
+
 SUBDIRS = $(build_with_msvc) mk po $(libgc_dir) llvm mono $(ikvm_native_dir) support data runtime scripts man samples $(tools_dir) $(build_without_msvc) $(docs_dir) acceptance-tests
 # Keep in sync with SUBDIRS
 DIST_SUBDIRS = $(build_with_msvc) m4 mk po $(libgc_dir) llvm mono ikvm-native support data runtime scripts man samples tools $(build_without_msvc) docs acceptance-tests netcore
 
-all: update_submodules
+all: $(update_submodules)
 
 update_submodules:
 	@cd $(srcdir) && scripts/update_submodules.sh

--- a/configure.ac
+++ b/configure.ac
@@ -6410,7 +6410,9 @@ AC_SUBST(CPPFLAGS)
 AC_SUBST(LDFLAGS)
 
 # Update all submodules recursively to ensure everything is checked out
-(cd $srcdir && scripts/update_submodules.sh)
+if test "x$with_core" != "xonly"; then
+	(cd $srcdir && scripts/update_submodules.sh)
+fi
 
 AC_OUTPUT([
 Makefile

--- a/mcs/class/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/mcs/class/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -277,9 +277,9 @@
       <Compile Include="..\referencesource\mscorlib\system\rttype.cs" />
   </ItemGroup>
   <ItemGroup>
-      <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\src\System\Reflection\CustomAttributeNamedArgument.cs" />
-      <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\src\System\Reflection\CustomAttributeTypedArgument.cs" />
-      <Compile Include="..\..\..\external\corert\src\System.Private.CoreLib\src\System\Reflection\MissingMetadataException.cs" />
+      <Compile Include="System.Reflection\CustomAttributeNamedArgument.cs" />
+      <Compile Include="System.Reflection\CustomAttributeTypedArgument.cs" />
+      <Compile Include="System.Reflection\MissingMetadataException.cs" />
       <Compile Include="..\corlib\corert\RuntimeAugments.cs" />
   </ItemGroup>
 

--- a/mcs/class/System.Private.CoreLib/System.Reflection/CustomAttributeNamedArgument.cs
+++ b/mcs/class/System.Private.CoreLib/System.Reflection/CustomAttributeNamedArgument.cs
@@ -1,0 +1,125 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using Internal.Runtime.Augments;
+
+namespace System.Reflection
+{
+    public struct CustomAttributeNamedArgument
+    {
+        // This constructor is the one used by .Net Native as the current metadata format only contains the name and the "isField" value,
+        // not the actual member. To keep .Net Native running as before, we'll use the name and isField as the principal data and 
+        // construct the MemberInfo on demand.
+        internal CustomAttributeNamedArgument(Type attributeType, string memberName, bool isField, CustomAttributeTypedArgument typedValue)
+        {
+            IsField = isField;
+            MemberName = memberName;
+            TypedValue = typedValue;
+            _attributeType = attributeType;
+            _lazyMemberInfo = null;
+        }
+
+        public CustomAttributeNamedArgument(MemberInfo memberInfo, object value)
+        {
+            if (memberInfo == null)
+                throw new ArgumentNullException(nameof(memberInfo));
+
+            Type type = null;
+            FieldInfo field = memberInfo as FieldInfo;
+            PropertyInfo property = memberInfo as PropertyInfo;
+
+            if (field != null)
+                type = field.FieldType;
+            else if (property != null)
+                type = property.PropertyType;
+            else
+                throw new ArgumentException(SR.Argument_InvalidMemberForNamedArgument);
+
+            _lazyMemberInfo = memberInfo;
+            _attributeType = memberInfo.DeclaringType;
+#if MONO
+            // Mono runtime "create_cattr_named_arg" method passes value wrapped into CustomAttributeTypedArgument object
+            // but CoreFX expects just value. 
+            if (value is CustomAttributeTypedArgument typedArument)
+                TypedValue = typedArument;    
+            else
+#endif
+            TypedValue = new CustomAttributeTypedArgument(type, value);
+            IsField = field != null;
+            MemberName = memberInfo.Name;
+        }
+
+        public CustomAttributeNamedArgument(MemberInfo memberInfo, CustomAttributeTypedArgument typedArgument)
+        {
+            if (memberInfo == null)
+                throw new ArgumentNullException(nameof(memberInfo));
+
+            _lazyMemberInfo = memberInfo;
+            _attributeType = memberInfo.DeclaringType;
+            TypedValue = typedArgument;
+            IsField = memberInfo is FieldInfo;  // For compat with the desktop, there is no validation that a non-field member is a PropertyInfo.
+            MemberName = memberInfo.Name;
+        }
+
+        public CustomAttributeTypedArgument TypedValue { get; }
+        public bool IsField { get; }
+        public string MemberName { get; }
+
+        public MemberInfo MemberInfo
+        {
+            get
+            {
+                MemberInfo memberInfo = _lazyMemberInfo;
+                if (memberInfo == null)
+                {
+                    if (IsField)
+                        memberInfo = _attributeType.GetField(MemberName, BindingFlags.Public | BindingFlags.Instance);
+                    else
+                        memberInfo = _attributeType.GetProperty(MemberName, BindingFlags.Public | BindingFlags.Instance);
+
+                    if (memberInfo == null)
+                        throw RuntimeAugments.Callbacks.CreateMissingMetadataException(_attributeType);
+                    _lazyMemberInfo = memberInfo;
+                }
+                return memberInfo;
+            }
+        }
+
+        public override bool Equals(object obj) => obj == (object)this;
+        public override int GetHashCode() => base.GetHashCode();
+        public static bool operator ==(CustomAttributeNamedArgument left, CustomAttributeNamedArgument right) => left.Equals(right);
+        public static bool operator !=(CustomAttributeNamedArgument left, CustomAttributeNamedArgument right) => !(left.Equals(right));
+
+        public override string ToString()
+        {
+            if (_attributeType == null)
+                return base.ToString(); // Someone called ToString() on default(CustomAttributeNamedArgument)
+
+            try
+            {
+                bool typed;
+                if (_lazyMemberInfo == null)
+                {
+                    // If we haven't resolved the memberName into a MemberInfo yet, don't do so just for ToString()'s sake (it can trigger a MissingMetadataException.)
+                    // Just use the fully type-qualified format by fiat.
+                    typed = true;
+                }
+                else
+                {
+                    Type argumentType = IsField ? ((FieldInfo)_lazyMemberInfo).FieldType : ((PropertyInfo)_lazyMemberInfo).PropertyType;
+                    typed = argumentType != typeof(object);
+                }
+                return string.Format(CultureInfo.CurrentCulture, "{0} = {1}", MemberName, TypedValue.ToString(typed));
+            }
+            catch (MissingMetadataException)
+            {
+                return base.ToString(); // Failsafe. Code inside "try" should still strive to avoid trigging a MissingMetadataException as caught exceptions are annoying when debugging.
+            }
+        }
+
+        private readonly Type _attributeType;
+        private volatile MemberInfo _lazyMemberInfo;
+    }
+}

--- a/mcs/class/System.Private.CoreLib/System.Reflection/CustomAttributeTypedArgument.cs
+++ b/mcs/class/System.Private.CoreLib/System.Reflection/CustomAttributeTypedArgument.cs
@@ -1,0 +1,105 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Collections.Generic;
+
+namespace System.Reflection
+{
+    public struct CustomAttributeTypedArgument
+    {
+        public CustomAttributeTypedArgument(object value)
+        {
+            // value cannot be null.
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+
+            Value = CanonicalizeValue(value);
+            ArgumentType = value.GetType();
+        }
+
+        public CustomAttributeTypedArgument(Type argumentType, object value)
+        {
+            // value can be null.
+            if (argumentType == null)
+                throw new ArgumentNullException(nameof(argumentType));
+
+            Value = (value == null) ? null : CanonicalizeValue(value);
+            ArgumentType = argumentType;
+#if MONO
+            if (value is Array a) {
+                Type etype = a.GetType().GetElementType();
+                CustomAttributeTypedArgument[] new_value = new CustomAttributeTypedArgument[a.GetLength(0)];
+                for (int i = 0; i < new_value.Length; ++i) {
+                    var val = a.GetValue (i);
+                    var elemType = etype == typeof (System.Object) && val != null ? val.GetType () : etype;
+                    new_value[i] = new CustomAttributeTypedArgument (elemType, val);
+                }
+                Value = new System.Collections.ObjectModel.ReadOnlyCollection <CustomAttributeTypedArgument>(new_value);
+            }
+#endif
+        }
+
+        public Type ArgumentType { get; }
+        public object Value { get; }
+
+        public override bool Equals(object obj) => obj == (object)this;
+        public override int GetHashCode() => base.GetHashCode();
+        public static bool operator ==(CustomAttributeTypedArgument left, CustomAttributeTypedArgument right) => left.Equals(right);
+        public static bool operator !=(CustomAttributeTypedArgument left, CustomAttributeTypedArgument right) => !(left.Equals(right));
+
+        public override string ToString() => ToString(typed: false);
+
+        internal string ToString(bool typed)
+        {
+            if (ArgumentType == null)
+                return base.ToString(); // Someone called ToString() on "default(CustomAttributeTypedArgument)"
+
+            try
+            {
+                if (ArgumentType.IsEnum)
+                    return string.Format(CultureInfo.CurrentCulture, typed ? "{0}" : "({1}){0}", Value, ArgumentType.FullNameOrDefault);
+
+                else if (Value == null)
+                    return string.Format(CultureInfo.CurrentCulture, typed ? "null" : "({0})null", ArgumentType.NameOrDefault);
+
+                else if (ArgumentType == typeof(string))
+                    return string.Format(CultureInfo.CurrentCulture, "\"{0}\"", Value);
+
+                else if (ArgumentType == typeof(char))
+                    return string.Format(CultureInfo.CurrentCulture, "'{0}'", Value);
+
+                else if (ArgumentType == typeof(Type))
+                    return string.Format(CultureInfo.CurrentCulture, "typeof({0})", ((Type)Value).FullNameOrDefault);
+
+                else if (ArgumentType.IsArray)
+                {
+                    string result = null;
+                    IList<CustomAttributeTypedArgument> array = Value as IList<CustomAttributeTypedArgument>;
+
+                    Type elementType = ArgumentType.GetElementType();
+                    result = string.Format(CultureInfo.CurrentCulture, @"new {0}[{1}] {{ ", elementType.IsEnum ? elementType.FullNameOrDefault : elementType.NameOrDefault, array.Count);
+
+                    for (int i = 0; i < array.Count; i++)
+                        result += string.Format(CultureInfo.CurrentCulture, i == 0 ? "{0}" : ", {0}", array[i].ToString(elementType != typeof(object)));
+
+                    return result += " }";
+                }
+
+                return string.Format(CultureInfo.CurrentCulture, typed ? "{0}" : "({1}){0}", Value, ArgumentType.NameOrDefault);
+            }
+            catch (MissingMetadataException)
+            {
+                return base.ToString(); // Failsafe. Code inside "try" should still strive to avoid trigging a MissingMetadataException as caught exceptions are annoying when debugging.
+            }
+        }
+
+        private static object CanonicalizeValue(object value)
+        {
+            if (value.GetType().IsEnum)
+                return ((Enum)value).GetValue();
+            return value;
+        }
+    }
+}

--- a/mcs/class/System.Private.CoreLib/System.Reflection/MissingMetadataException.cs
+++ b/mcs/class/System.Private.CoreLib/System.Reflection/MissingMetadataException.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace System.Reflection
+{
+    public sealed class MissingMetadataException : TypeAccessException
+    {
+        public MissingMetadataException()
+        {
+        }
+
+        public MissingMetadataException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/mono/Makefile.am
+++ b/mono/Makefile.am
@@ -12,6 +12,10 @@ if MONO_NATIVE
 native_dirs = native
 endif
 
+if ENABLE_NETCORE
+btls_dirs = 
+endif
+
 if CROSS_COMPILING
 SUBDIRS = $(btls_dirs) eglib arch utils cil $(sgen_dirs) metadata mini dis profiler $(native_dirs)
 else


### PR DESCRIPTION
This change:

* avoids updating submodules during autogen, if `--with-core=only`
* avoids updating submodules during make, if `--with-core=only`
* Bundles in 3 small files from corert with System.Private.CoreLib, to avoid the need for the corert submodule

This enables us to build on the internal project without needing to mirror or mangle submodules at all, which is proving difficult (and it should also speed builds up)