### PR TITLE
[sdks] Make sure GCC runtime libs are installed for MinGW targets

### DIFF
--- a/sdks/builds/android.mk
+++ b/sdks/builds/android.mk
@@ -121,8 +121,9 @@ _android-$(1)_CONFIGURE_FLAGS= \
 	python "$$(ANDROID_TOOLCHAIN_DIR)/ndk/build/tools/make_standalone_toolchain.py" --verbose --force --api=$$(ANDROID_SDK_VERSION_$(1)) --arch=$(2) --install-dir=$$(ANDROID_TOOLCHAIN_PREFIX)/$(1)-clang
 	touch $$@
 
-$$(eval $$(call RuntimeTemplate,android,$(1),$(4)))
+package-local-android-$(1):
 
+$$(eval $$(call RuntimeTemplate,android,$(1),$(4)))
 endef
 
 ## android-armeabi-v7a
@@ -181,6 +182,8 @@ _android-$(1)_CONFIGURE_FLAGS= \
 .stamp-android-$(1)-toolchain:
 	touch $$@
 
+package-local-android-$(1):
+
 $$(eval $$(call RuntimeTemplate,android,$(1)))
 
 endef
@@ -235,6 +238,14 @@ endif
 
 .stamp-android-$(1)-$$(CONFIGURATION)-configure: | $(if $(IGNORE_PROVISION_MXE),,provision-mxe)
 
+ifeq ($(2),x86_64)
+package-local-android-$(1):
+	mkdir -p $$(TOP)/sdks/out/android-$(1)-$$(CONFIGURATION)/bin
+	cp $(shell x86_64-w64-mingw32-gcc -print-file-name=libgcc_s_seh-1.dll) $$(TOP)/sdks/out/android-$(1)-$$(CONFIGURATION)/bin
+else
+package-local-android-$(1):
+endif
+
 $$(eval $$(call RuntimeTemplate,android,$(1),$(2)-w64-mingw32))
 
 endef
@@ -281,6 +292,8 @@ _android-$(1)_CONFIGURE_FLAGS= \
 	--with-tls=pthread
 
 $$(eval $$(call CrossRuntimeTemplate,android,$(1),$$(if $$(filter $$(UNAME),Darwin),$(2)-apple-darwin10,$$(if $$(filter $$(UNAME),Linux),$(2)-linux-gnu)),$(3)-linux-android,$(4),$(5),$(6)))
+
+package-local-android-$(1):
 
 endef
 
@@ -342,7 +355,11 @@ endif
 
 .stamp-android-$(1)-$$(CONFIGURATION)-configure: | $(if $(IGNORE_PROVISION_MXE),,provision-mxe)
 
+package-local-android-$(1):
+
+
 $$(eval $$(call CrossRuntimeTemplate,android,$(1),$(2)-w64-mingw32,$(3)-linux-android,$(4),$(5),$(6)))
+
 
 endef
 

--- a/sdks/builds/ios.mk
+++ b/sdks/builds/ios.mk
@@ -104,6 +104,8 @@ _ios-$(1)_CONFIGURE_FLAGS = \
 .stamp-ios-$(1)-toolchain:
 	touch $$@
 
+package-local-ios-$(1):
+
 $$(eval $$(call RuntimeTemplate,ios,$(1),$(2)))
 
 
@@ -236,7 +238,10 @@ _ios-$(1)_CONFIGURE_FLAGS= \
 .stamp-ios-$(1)-toolchain:
 	touch $$@
 
+package-local-ios-$(1):
+
 $$(eval $$(call RuntimeTemplate,ios,$(1),$(2)))
+
 
 endef
 
@@ -338,7 +343,10 @@ _ios-$(1)_CONFIGURE_FLAGS= \
 	--enable-monotouch \
 	--disable-crash-reporting
 
+package-local-ios-$(1):
+
 $$(eval $$(call CrossRuntimeTemplate,ios,$(1),$(2)-apple-darwin10,$(3),$(4),$(5),$(6)))
+
 
 endef
 

--- a/sdks/builds/mac.mk
+++ b/sdks/builds/mac.mk
@@ -43,7 +43,10 @@ _mac-$(1)_CONFIGURE_FLAGS= \
 .stamp-mac-$(1)-toolchain:
 	touch $$@
 
+package-local-mac-$(1):
+
 $$(eval $$(call RuntimeTemplate,mac,$(1),$(2)-apple-darwin10))
+
 
 endef
 

--- a/sdks/builds/runtime.mk
+++ b/sdks/builds/runtime.mk
@@ -84,7 +84,10 @@ setup-custom-$(1)-$(2):
 	mkdir -p $$(TOP)/sdks/out/$(1)-$(2)-$$(CONFIGURATION)
 
 .PHONY: package-$(1)-$(2)
-package-$(1)-$(2):
+package-$(1)-$(2): do-package-$(1)-$(2) package-local-$(1)-$(2)
+
+.PHONY: do-package-$(1)-$(2)
+do-package-$(1)-$(2):
 	$$(MAKE) -C $$(TOP)/sdks/builds/$(1)-$(2)-$$(CONFIGURATION)/mono install
 	$$(MAKE) -C $$(TOP)/sdks/builds/$(1)-$(2)-$$(CONFIGURATION)/support install
 


### PR DESCRIPTION
When building with MinGW, the mono runtime DLL (`libmonosgen-2.0.dll`) is built
and linked with both `-shared` (provided by libtool) as well as
`-static-libgcc` (provided by Mono's `configure.ac`) however it doesn't have the
desired effect of linking static versions of all the GCC runtime libraries. The
reason is hidden in the MinGW's gcc spec files which, seeing `-shared` first on
the command line, prefer to link the library with `-lgcc -lgcc_s` which gives us
static `libgcc` but dynamic SEH (structured exception handling) library -
`libgcc_s_seh-1.dll`.
The easiest fix, implemented by this commit, is to simply package the runtime
library with Mono. This is done only for the mingw targets.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
