### PR TITLE
Remove libgcc_s_seh-1.dll dependency when targeting Win32 with gcc.

### DIFF
--- a/mono/sgen/sgen-marksweep.c
+++ b/mono/sgen/sgen-marksweep.c
@@ -1544,7 +1544,9 @@ bitcount (mword d)
 {
 	int count = 0;
 
-#ifdef __GNUC__
+#if defined (__GNUC__) && !defined (HOST_WIN32)
+// The builtins do work on Win32, but can cause a not worthwhile runtime dependency.
+// See https://github.com/mono/mono/pull/14248.
 	if (sizeof (mword) == 8)
 		count += __builtin_popcountll (d);
 	else

--- a/mono/utils/monobitset.c
+++ b/mono/utils/monobitset.c
@@ -201,14 +201,17 @@ mono_bitset_size (const MonoBitSet *set) {
  * \returns number of bits that are set.
  */
 guint32
-mono_bitset_count (const MonoBitSet *set) {
+mono_bitset_count (const MonoBitSet *set)
+{
 	guint32 i, count;
 	gsize d;
 
 	count = 0;
 	for (i = 0; i < set->size / BITS_PER_CHUNK; ++i) {
 		d = set->data [i];
-#ifdef __GNUC__
+#if defined (__GNUC__) && !defined (HOST_WIN32)
+// The builtins do work on Win32, but can cause a not worthwhile runtime dependency.
+// See https://github.com/mono/mono/pull/14248.
 		if (sizeof (gsize) == sizeof (unsigned int))
 			count += __builtin_popcount (d);
 		else


### PR DESCRIPTION
Don't use popcount intrinsic.
Alternative but not exactly contradictory to https://github.com/mono/mono/pull/14248.

Note that this is a single inlinable instruction on x86,
if you assume at least SSE4 from circa 2007, which I am avoiding here.
