### PR TITLE
[wasm] Add support for pinvokes in user assemblies.

### DIFF
--- a/mcs/tools/wasm-tuner/tuner.cs
+++ b/mcs/tools/wasm-tuner/tuner.cs
@@ -118,19 +118,27 @@ public class WasmTuner
 		}
 	}
 
+	static string MapType (TypeReference t) {
+		if (t.Name == "Void")
+			return "void";
+		else if (t.Name == "Double")
+			return "double";
+		else if (t.Name == "Float")
+			return "float";
+		else
+			return "int";
+	}
+
 	static string GenPinvokeDecl (Pinvoke pinvoke) {
 		var sb = new StringBuilder ();
 		var method = pinvoke.Method;
-		if (method.ReturnType.Name != "Void")
-			sb.Append ("int");
-		else
-			sb.Append ("void");
+		sb.Append (MapType (method.ReturnType));
 		sb.Append ($" {pinvoke.EntryPoint} (");
 		int pindex = 0;
 		foreach (var p in method.Parameters) {
 			if (pindex > 0)
 				sb.Append (",");
-			sb.Append ("int");
+			sb.Append (MapType (method.Parameters [pindex].ParameterType));
 			pindex ++;
 		}
 		sb.Append (");");

--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -124,6 +124,7 @@ bcl:
 
 tuner:
 	$(MAKE) -C ../../mcs/tools/wasm-tuner PROFILE=wasm_tools
+	cp ../../mcs/class/lib/wasm_tools/wasm-tuner.exe* ../out/wasm-bcl/wasm_tools/wasm-tuner.exe*
 
 cil-strip:
 	$(MAKE) -C ../../mcs/tools/cil-strip  PROFILE=wasm_tools
@@ -194,7 +195,7 @@ $(BROWSER_TEST)/.stamp-browser-test-suite: $(DRIVER_CONF)/.stamp-build packager.
 	touch $@
 
 build-aot-sample: packager.exe hello.exe
-	mono --debug packager.exe --emscripten-sdkdir=$(EMSCRIPTEN_SDKDIR) --mono-sdkdir=$(TOP)/sdks/out -appdir=bin/aot-sample --nobinding --builddir=obj/aot-sample --aot --template=runtime-tests.js hello.exe
+	mono --debug packager.exe --emscripten-sdkdir=$(EMSCRIPTEN_SDKDIR) --mono-sdkdir=$(TOP)/sdks/out -appdir=bin/aot-sample --nobinding --builddir=obj/aot-sample --aot --template=runtime-tests.js --pinvoke-libs=libfoo hello.exe
 	ninja -v -C obj/aot-sample
 
 hello.exe: hello.cs

--- a/sdks/wasm/driver.c
+++ b/sdks/wasm/driver.c
@@ -11,7 +11,11 @@
 #include <mono/utils/mono-dl-fallback.h>
 #include <mono/jit/jit.h>
 
+#ifdef GEN_PINVOKE
+#include "pinvoke-table.h"
+#else
 #include "pinvoke-tables-default.h"
+#endif
 
 #ifdef CORE_BINDINGS
 void core_initialize_internals ();

--- a/sdks/wasm/hello.cs
+++ b/sdks/wasm/hello.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 
 public class HelloWorld
 {


### PR DESCRIPTION
The --pinvoke-libs=x argument to packager.exe can be used to generate pinvoke linking tables.
'x' is a list of library names used in DllImport declarations, i.e. --pinvoke-libs=libtest is used
to link with [DllImport ("libtest")].