### PR TITLE
[sdks] Statically link LLVM and Android MXE cross builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1618,6 +1618,13 @@ if test x$USE_NLS = xprofile_default; then
 	AC_MSG_RESULT([$USE_NLS])
 fi
 
+AC_ARG_ENABLE(static-gcc-libs, [  --enable-static-gcc-libs      Statically link GCC support libs (for MinGW32)])
+if test "x$enable_static_gcc_libs" = "xyes"; then
+	# llvm/build.mk doesn't use automake, so make a regular make variable for it.
+	AC_SUBST(STATIC_GCC_LIBS,1)
+fi
+AM_CONDITIONAL(ENABLE_STATIC_GCC_LIBS, test "x$enable_static_gcc_libs" = "xyes")
+
 AC_ARG_ENABLE(minimal, [  --enable-minimal=LIST      drop support for LIST subsystems.
      LIST is a comma-separated list from: aot, profiler, decimal, pinvoke, debug, appdomains, verifier, 
      reflection_emit, reflection_emit_save, large_code, logging, com, ssa, generics, attach, jit, interpreter, simd, soft_debug, perfcounters, normalization, desktop_loader, shared_perfcounters, remoting,

--- a/llvm/build.mk
+++ b/llvm/build.mk
@@ -12,7 +12,8 @@ LLVM_DOWNLOAD_LOCATION = "http://xamjenkinsartifact.blob.core.windows.net/build-
 CMAKE := $(or $(CMAKE),$(shell which cmake))
 NINJA := $(shell which ninja)
 
-EXTRA_LLVM_ARGS = $(if $(filter $(LLVM_TARGET),wasm32), -DLLVM_BUILD_32_BITS=On -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="WebAssembly",)
+EXTRA_LLVM_ARGS = $(if $(filter $(LLVM_TARGET),wasm32), -DLLVM_BUILD_32_BITS=On -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="WebAssembly",) \
+	$(if $(STATIC_GCC_LIBS),-DCMAKE_EXE_LINKER_FLAGS="-static")
 
 # -DLLVM_ENABLE_LIBXML2=Off is needed because xml2 is not used and it breaks 32-bit builds on 64-bit Linux hosts
 $(LLVM_BUILD)/$(if $(NINJA),build.ninja,Makefile): $(abs_top_srcdir)/external/llvm/CMakeLists.txt

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -262,8 +262,12 @@ mono_sgen_LDADD = \
 	-lm			\
 	$(MONO_DTRACE_OBJECT)
 
-mono_sgen_LDFLAGS = $(static_flags) $(monobinldflags) $(monobin_platform_ldflags) 
 
+mono_sgen_LDFLAGS = $(static_flags) $(monobinldflags) $(monobin_platform_ldflags)
+
+if ENABLE_STATIC_GCC_LIBS
+mono_sgen_LDFLAGS += -all-static
+endif
 
 if BITCODE
 libmonoldflags += -no-undefined

--- a/sdks/builds/android.mk
+++ b/sdks/builds/android.mk
@@ -283,6 +283,7 @@ _android-$(1)_CONFIGURE_FLAGS= \
 	--disable-llvm \
 	--disable-mcs-build \
 	--disable-nls \
+	--enable-static-gcc-libs \
 	--enable-maintainer-mode \
 	--enable-monodroid \
 	--with-monodroid \
@@ -406,23 +407,22 @@ _android-$(1)_STRIP=$$(MXE_PREFIX)/bin/$(2)-w64-mingw32-strip
 
 _android-$(1)_CFLAGS= \
 	$$(if $$(RELEASE),,-DDEBUG_CROSS) \
-	-static-libgcc \
 	-DXAMARIN_PRODUCT_VERSION=0 \
 	-I$$(MXE_PREFIX)/opt/mingw-zlib/usr/$(2)-w64-mingw32/include
 
 _android-$(1)_CXXFLAGS= \
 	$$(if $$(RELEASE),,-DDEBUG_CROSS) \
-	-static-libgcc \
 	-DXAMARIN_PRODUCT_VERSION=0 \
 	-I$$(MXE_PREFIX)/opt/mingw-zlib/usr/$(2)-w64-mingw32/include
 
-_android-$(1)_LDFLAGS= \
-	-static-libgcc
+_android-$(1)_LDFLAGS=
+
 
 _android-$(1)_CONFIGURE_FLAGS= \
 	--disable-boehm \
 	--disable-mcs-build \
 	--disable-nls \
+	--enable-static-gcc-libs \
 	--enable-maintainer-mode \
 	--with-tls=pthread
 

--- a/sdks/builds/llvm.mk
+++ b/sdks/builds/llvm.mk
@@ -163,7 +163,9 @@ define LLVMMxeTemplate
 # -DCROSS_TOOLCHAIN_FLAGS_NATIVE is needed to compile the native tools (tlbgen) using the host compilers
 # -DLLVM_ENABLE_THREADS=0 is needed because mxe doesn't define std::mutex etc.
 # -DLLVM_BUILD_EXECUTION_ENGINE=Off is needed because it depends on threads
+# -DCMAKE_EXE_LINKER_FLAGS=-static is needed so that we don't dynamically link with any of the mingw gcc support libs.
 _llvm-$(1)_CMAKE_ARGS = \
+	-DCMAKE_EXE_LINKER_FLAGS=\"-static\" \
 	-DCROSS_TOOLCHAIN_FLAGS_NATIVE=-DCMAKE_TOOLCHAIN_FILE=$$(TOP)/external/llvm/cmake/modules/NATIVE.cmake \
 	-DCMAKE_TOOLCHAIN_FILE=$$(TOP)/external/llvm/cmake/modules/$(3).cmake \
 	-DLLVM_ENABLE_THREADS=Off \


### PR DESCRIPTION
We used to use the static MXE toolchain, but after switching to Homebrew we have to ask for static linking explicitly.