### PR TITLE
Add a few `RuntimeFeature.IsDynamicCodeSupported` conditionals.

### DIFF
--- a/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
+++ b/mcs/class/corlib/LinkerDescriptor/mscorlib.xml
@@ -7,7 +7,7 @@
 			<!-- appdomain.c: mono_domain_try_type_resolve -->
 			<method name="DoTypeResolve" />
 			<!-- appdomain.c: mono_domain_try_type_builder_resolve -->
-			<method name="DoTypeBuilderResolve" />
+			<method name="DoTypeBuilderResolve" feature="sre" />
 			<!-- appdomain.c: mono_try_assembly_resolve -->
 			<method name="DoAssemblyResolve" />
 			<!-- appdomain.c: mono_domain_fire_assembly_load -->

--- a/mcs/class/corlib/System.Reflection/RuntimeMethodInfo.cs
+++ b/mcs/class/corlib/System.Reflection/RuntimeMethodInfo.cs
@@ -711,12 +711,11 @@ namespace System.Reflection {
 			}
 
 			if (hasUserType) {
-#if FULL_AOT_RUNTIME
-				throw new NotSupportedException ("User types are not supported under full aot");
-#else
+#if !FULL_AOT_RUNTIME
 				if (RuntimeFeature.IsDynamicCodeSupported)
 					return new MethodOnTypeBuilderInst (this, methodInstantiation);
 #endif
+				throw new NotSupportedException ("User types are not supported under full aot");
 			}
 
 			MethodInfo ret = MakeGenericMethod_impl (methodInstantiation);

--- a/mcs/class/corlib/System.Reflection/RuntimeMethodInfo.cs
+++ b/mcs/class/corlib/System.Reflection/RuntimeMethodInfo.cs
@@ -714,7 +714,8 @@ namespace System.Reflection {
 #if FULL_AOT_RUNTIME
 				throw new NotSupportedException ("User types are not supported under full aot");
 #else
-				return new MethodOnTypeBuilderInst (this, methodInstantiation);
+				if (RuntimeFeature.IsDynamicCodeSupported)
+					return new MethodOnTypeBuilderInst (this, methodInstantiation);
 #endif
 			}
 

--- a/mcs/class/corlib/System/MonoCustomAttrs.cs
+++ b/mcs/class/corlib/System/MonoCustomAttrs.cs
@@ -54,7 +54,7 @@ namespace System
 		{
 			Type type = obj as Type;
 #if !FULL_AOT_RUNTIME
-			if ((type is RuntimeType) || (type is TypeBuilder))
+			if ((type is RuntimeType) || (RuntimeFeature.IsDynamicCodeSupported && type is TypeBuilder))
 #else
 			if (type is RuntimeType)
 #endif

--- a/mcs/class/corlib/Test/System.Reflection/FieldInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection/FieldInfoTest.cs
@@ -1372,6 +1372,7 @@ namespace MonoTests.System.Reflection
 		}
 
 		[Test]
+		[Category ("Remoting")]
 		public void GetValueContextBoundObject ()
 		{
 			var instance = new CBOTest ();
@@ -1394,6 +1395,7 @@ namespace MonoTests.System.Reflection
 		}
 
 		[Test]
+		[Category ("Remoting")]
 		public void SetValueContextBoundObject ()
 		{
 			var instance = new CBOTest ();

--- a/mcs/class/corlib/Test/System.Resources/ResourceManagerTest.cs
+++ b/mcs/class/corlib/Test/System.Resources/ResourceManagerTest.cs
@@ -791,6 +791,7 @@ namespace MonoTests.System.Resources
 		}
 
 		[Test]
+		[Category ("Globalization")]
 		[Category ("StackWalks")]
 		[Category ("NotWasm")]
 		public void TestSatellites ()

--- a/mcs/class/corlib/corefx/RuntimeFeature.cs
+++ b/mcs/class/corlib/corefx/RuntimeFeature.cs
@@ -1,0 +1,9 @@
+namespace System.Runtime.CompilerServices
+{
+	partial class RuntimeFeature
+	{
+		// https://github.com/dotnet/coreclr/blob/397aaccb5104844998c3bcf6e9245cc81127e1e2/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.CoreCLR.cs#L9-L10
+		public static bool IsDynamicCodeSupported => true;
+		public static bool IsDynamicCodeCompiled => true;
+	}
+}

--- a/mcs/class/corlib/corlib.csproj
+++ b/mcs/class/corlib/corlib.csproj
@@ -2044,6 +2044,7 @@
     <Compile Include="corefx\MethodInfo.cs" />
     <Compile Include="corefx\MonoLinqHelper.cs" />
     <Compile Include="corefx\RandomNumberGenerator.cs" />
+    <Compile Include="corefx\RuntimeFeature.cs" />
     <Compile Include="corefx\RuntimeImports.cs" />
     <Compile Include="corefx\SR.cs" />
     <Compile Include="corefx\SR.missing.cs" />

--- a/mcs/class/corlib/corlib.dll.sources
+++ b/mcs/class/corlib/corlib.dll.sources
@@ -1619,6 +1619,7 @@ corefx/GlobalizationMode.cs
 corefx/Interop.GetRandomBytes.Mono.cs
 corefx/MethodInfo.cs
 corefx/RandomNumberGenerator.cs
+corefx/RuntimeFeature.cs
 corefx/RuntimeImports.cs
 corefx/TimeSpanParse.cs
 

--- a/mcs/class/referencesource/mscorlib/system/activator.cs
+++ b/mcs/class/referencesource/mscorlib/system/activator.cs
@@ -74,7 +74,7 @@ namespace System {
                 throw new ArgumentNullException("type");
             Contract.EndContractBlock();
 #if !FULL_AOT_RUNTIME
-            if (type is System.Reflection.Emit.TypeBuilder)
+            if (RuntimeFeature.IsDynamicCodeSupported && type is System.Reflection.Emit.TypeBuilder)
                 throw new NotSupportedException(Environment.GetResourceString("NotSupported_CreateInstanceWithTypeBuilder"));
 #endif
             // If they didn't specify a lookup, then we will provide the default lookup.

--- a/mcs/class/referencesource/mscorlib/system/rttype.cs
+++ b/mcs/class/referencesource/mscorlib/system/rttype.cs
@@ -3782,7 +3782,7 @@ namespace System
             }
 #if !FULL_AOT_RUNTIME
             // Special case for TypeBuilder to be backward-compatible.
-            if (c is System.Reflection.Emit.TypeBuilder)
+            if (RuntimeFeature.IsDynamicCodeSupported && c is System.Reflection.Emit.TypeBuilder)
             {
                 // If c is a subclass of this class, then c can be cast to this type.
                 if (c.IsSubclassOf(this))
@@ -4303,7 +4303,11 @@ namespace System
 #if NETCORE
                     throw new NotImplementedException ();
 #else
+#pragma warning disable 162
+                    if (!RuntimeFeature.IsDynamicCodeSupported)
+                        throw new PlatformNotSupportedException();
                     return System.Reflection.Emit.TypeBuilderInstantiation.MakeGenericType(this, instantiation);
+#pragma warning restore 162
 #endif
                 }
 


### PR DESCRIPTION
Move the `RuntimeFeature.IsDynamicCodeSupported` and `IsDynamicCodeCompiled` conditionals over here from the corefx module and add them in a few places where `TypeBuilder` is used.