### PR TITLE
[2019-04] [aot] Avoid passing -march=arm to llc when using thumb, it forces arm32 code generation.

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -1110,7 +1110,8 @@ arch_init (MonoAotCompile *acfg)
 	if (acfg->aot_opts.mtriple && strstr (acfg->aot_opts.mtriple, "darwin")) {
 		g_string_append (acfg->llc_args, "-mattr=+v6");
 	} else {
-		g_string_append (acfg->llc_args, " -march=arm");
+		if (!(acfg->aot_opts.mtriple && strstr (acfg->aot_opts.mtriple, "thumb")))
+			g_string_append (acfg->llc_args, " -march=arm");
 
 		if (acfg->aot_opts.mtriple && strstr (acfg->aot_opts.mtriple, "ios"))
 			g_string_append (acfg->llc_args, " -mattr=+v7");


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/14247.




<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->

Backport of #14288.

/cc @marek-safar @vargaz