### PR TITLE
ld -Bsymbolic so dynamic linker does not get between mono and itself.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4940,14 +4940,15 @@ AC_SEARCH_LIBS(dlopen, dl)
 old_ldflags="${LDFLAGS}"
 # GNU specific option, this confuses IBM ld, but do offer alternatives when possible
 if test $lt_cv_prog_gnu_ld = yes; then
-	LDFLAGS="${LDFLAGS} -Wl,-export-dynamic"
+	LDFLAGS="${LDFLAGS} -Wl,-export-dynamic,-Bsymbolic"
 else
 	case $host in
 	*-*-aix*|*-*-os400*)
+		LDFLAGS="${LDFLAGS} -bsymbolic"
 		;;
 	*)
 		dnl Try to use export-dynamic anyways
-		LDFLAGS="${LDFLAGS} -Wl,-export-dynamic"
+		LDFLAGS="${LDFLAGS} -Wl,-export-dynamic,-Bsymbolic"
 		;;
 	esac
 fi


### PR DESCRIPTION
With this change, within libmonosgen.so, calls from
‘mono_x’ to ‘mono_y’ are made directly instead of going through ‘mono_y@plt’.

This is the same as the mono executable already and the same as Windows.
Mac/iOS might also already be this way?
This definitely changes Linux.

No other shared object, nor the executable can therefore replace ‘mono_y’. Does anyone do that?

It is then much more understood where locks are, making coop and crash reporting more correct and reliable.