### PR TITLE
[2019-04] [arm] amend stack pointer properly in exception trampoline

### DIFF
--- a/mono/mini/exceptions-arm.c
+++ b/mono/mini/exceptions-arm.c
@@ -252,7 +252,8 @@ get_throw_trampoline (int size, gboolean corlib, gboolean rethrow, gboolean llvm
 	int param_size = 8;
 	if (!resume_unwind && !corlib)
 		param_size += 4; // Extra arg
-	param_size = ALIGN_TO (param_size, MONO_ARCH_FRAME_ALIGNMENT);
+	/* SP isn't 16byte aligned at this point which matters for some targets */
+	param_size = ALIGN_TO (cfa_offset + param_size, MONO_ARCH_FRAME_ALIGNMENT) - cfa_offset;
 	ARM_SUB_REG_IMM8 (code, ARMREG_SP, ARMREG_SP, param_size);
 	cfa_offset += param_size;
 	mono_add_unwind_op_def_cfa_offset (unwind_ops, code, start, cfa_offset);


### PR DESCRIPTION
The previous attempt ( https://github.com/mono/mono/pull/14078 ) only fixed it for ABIs where the stack pointer alignment is 8 bytes. ABIs, such as watchOS, require 16 byte alignment.

Fixes https://github.com/mono/mono/issues/14223

Backport of #14310.

/cc @lewurm 