### PR TITLE
[wasm] Define wasm_strdup when setting options

### DIFF
--- a/sdks/wasm/library_mono.js
+++ b/sdks/wasm/library_mono.js
@@ -119,6 +119,7 @@ var MonoSupportLib = {
 			if (!this.wasm_parse_runtime_options)
 				this.wasm_parse_runtime_options = Module.cwrap ('mono_wasm_parse_runtime_options', 'void', ['number', 'number']);
 			var argv = Module._malloc (options.length * 4);
+			var wasm_strdup = Module.cwrap ('mono_wasm_strdup', 'number', ['string']);
 			aindex = 0;
 			for (var i = 0; i < options.length; ++i) {
 				Module.setValue (argv + (aindex * 4), wasm_strdup (options [i]), "i32");


### PR DESCRIPTION
fix mono_wasm_set_runtime_options so that it can be used outside of the test app
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
