### PR TITLE
Fix light on light ListViewGroup headers on dark theme

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/ThemeWin32Classic.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/ThemeWin32Classic.cs
@@ -3176,7 +3176,7 @@ namespace System.Windows.Forms
 			}
 
 			sformat.LineAlignment = StringAlignment.Near;
-			dc.DrawString (group.Header, font, SystemBrushes.ControlText, text_bounds, sformat);
+			dc.DrawString (group.Header, font, SystemBrushes.Highlight, text_bounds, sformat);
 			dc.DrawLine (pen, header_bounds.Left, header_bounds.Top + text_height, header_bounds.Left + ListViewGroupLineWidth, 
 					header_bounds.Top + text_height);
 


### PR DESCRIPTION
## Problem

If you use a ListViewGroup with a dark theme, the text is light on light:

![image](https://user-images.githubusercontent.com/1559108/57118340-32358b00-6d28-11e9-9d8f-0e0c4ae32921.png)

## Cause

It's using `SystemBrushes.ControlText`, which is not guaranteed to contrast with the background, which is `SystemColor.Window` and contrasts with `WindowText`.

## Changes

On Windows these are drawn in a nice shade of blue:

![image](https://user-images.githubusercontent.com/1559108/57118359-614bfc80-6d28-11e9-8d57-2892653a31f4.png)

So now mono will use `SystemBrushes.Highlight` to mimic that nice blue:

![image](https://user-images.githubusercontent.com/1559108/57118366-7032af00-6d28-11e9-9c43-bd61c2950ee6.png)

I think `Highlight` will contrast well with `Window`, and also look better in a dark theme.

(I was not able to get my locally compiled mono to obey a dark theme, but I'm 100% sure that's not caused by this change. If there are any known quirks related to that, I'd love some tips on how to fix it.)