### PR TITLE
[wasm] Add --link-descriptor arg to packager

### DIFF
--- a/sdks/wasm/packager.cs
+++ b/sdks/wasm/packager.cs
@@ -360,6 +360,7 @@ class Driver {
 		var ee_mode = ExecMode.Interp;
 		var linkModeParm = "all";
 		var linkMode = LinkMode.All;
+		var linkDescriptor = "";
 		string coremode, usermode;
 		var linker_verbose = false;
 
@@ -391,6 +392,7 @@ class Driver {
 				{ "copy=", s => copyTypeParm = s },
 				{ "aot-assemblies=", s => aot_assemblies = s },
 				{ "link-mode=", s => linkModeParm = s },
+				{ "link-descriptor=", s => linkDescriptor = s },
 				{ "pinvoke-libs=", s => pinvoke_libs = s },
 				{ "help", s => print_usage = true },
 					};
@@ -876,9 +878,17 @@ class Driver {
 			}
 
 			string linker_args = "";
-			foreach (var assembly in root_assemblies) {
-				string filename = Path.GetFileName (assembly);
-				linker_args += $"-a linker-in/{filename} ";
+			if (!string.IsNullOrEmpty (linkDescriptor)) {
+				linker_args += $"-x {linkDescriptor} ";
+				foreach (var assembly in root_assemblies) {
+					string filename = Path.GetFileName (assembly);
+					linker_args += $"-p {usermode} {filename} -r linker-in/{filename} ";
+				}
+			} else {
+				foreach (var assembly in root_assemblies) {
+					string filename = Path.GetFileName (assembly);
+					linker_args += $"-a linker-in/{filename} ";
+				}
 			}
 
 			// the linker does not consider these core by default


### PR DESCRIPTION
Allow a --link-descriptor arg to supply a linker.xml configuration file
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
