### PR TITLE
Make mono_fmod extern "C and not static, to simplify later

### DIFF
--- a/mono/mini/jit-icalls.c
+++ b/mono/mini/jit-icalls.c
@@ -1017,6 +1017,15 @@ mono_lconv_to_r8_un (guint64 a)
 }
 #endif
 
+#ifdef MONO_ARCH_EMULATE_FREM
+// Wrapper to avoid taking address of overloaded function.
+double
+mono_fmod (double a, double b)
+{
+	return fmod (a, b);
+}
+#endif
+
 gpointer
 mono_helper_compile_generic_method (MonoObject *obj, MonoMethod *method, gpointer *this_arg)
 {

--- a/mono/mini/jit-icalls.h
+++ b/mono/mini/jit-icalls.h
@@ -170,8 +170,7 @@ G_EXTERN_C void     mono_fstore_r4 (double val, float *ptr);
 
 G_EXTERN_C guint32  mono_fload_r4_arg (double val);
 
-G_EXTERN_C
-mono_fmod (double a, double b);
+G_EXTERN_C double mono_fmod (double a, double b);
 
 G_EXTERN_C void     mono_break (void);
 

--- a/mono/mini/jit-icalls.h
+++ b/mono/mini/jit-icalls.h
@@ -170,6 +170,9 @@ G_EXTERN_C void     mono_fstore_r4 (double val, float *ptr);
 
 G_EXTERN_C guint32  mono_fload_r4_arg (double val);
 
+G_EXTERN_C
+mono_fmod (double a, double b);
+
 G_EXTERN_C void     mono_break (void);
 
 G_EXTERN_C MonoException *mono_create_corlib_exception_0 (guint32 token);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4387,15 +4387,6 @@ mini_init (const char *filename, const char *runtime_version)
 	return domain;
 }
 
-#ifdef MONO_ARCH_EMULATE_FREM
-// Wrapper to avoid taking address of overloaded function.
-double
-mono_fmod (double a, double b)
-{
-	return fmod (a, b);
-}
-#endif
-
 static void
 register_icalls (void)
 {

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4389,7 +4389,7 @@ mini_init (const char *filename, const char *runtime_version)
 
 #ifdef MONO_ARCH_EMULATE_FREM
 // Wrapper to avoid taking address of overloaded function.
-static double
+double
 mono_fmod (double a, double b)
 {
 	return fmod (a, b);
@@ -4524,7 +4524,7 @@ register_icalls (void)
 	register_opcode_emulation (OP_LCONV_TO_R_UN, __emul_lconv_to_r8_un, mono_icall_sig_double_long, mono_lconv_to_r8_un, "mono_lconv_to_r8_un", FALSE);
 #endif
 #ifdef MONO_ARCH_EMULATE_FREM
-	register_opcode_emulation (OP_FREM, __emul_frem, mono_icall_sig_double_double_double, mono_fmod, "fmod", FALSE);
+	register_opcode_emulation (OP_FREM, __emul_frem, mono_icall_sig_double_double_double, mono_fmod, "mono_fmod", FALSE);
 	register_opcode_emulation (OP_RREM, __emul_rrem, mono_icall_sig_float_float_float, fmodf, "fmodf", FALSE);
 #endif
 


### PR DESCRIPTION
removal of JIT icall hashing. Making it more consistent with other icalls.
Costing maybe one instruction in some slow paths.
