### PR TITLE
Check for and diagnose duplicate JIT icall registration.

### DIFF
--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -5443,11 +5443,8 @@ get_mscorlib_aot_module (void)
 	return amodule;
 }
 
-static void
-no_trampolines (void)
-{
-	g_assert_not_reached ();
-}
+void
+mono_no_trampolines (void);
 
 /*
  * Return the trampoline identified by NAME from the mscorlib AOT file.
@@ -5460,7 +5457,7 @@ mono_aot_get_trampoline_full (const char *name, MonoTrampInfo **out_tinfo)
 
 	if (mono_llvm_only) {
 		*out_tinfo = NULL;
-		return (gpointer)no_trampolines;
+		return (gpointer)mono_no_trampolines;
 	}
 
 	return mono_create_ftnptr_malloc ((guint8 *)load_function_full (amodule, name, out_tinfo));

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -435,8 +435,8 @@ MONO_API int       mono_parse_default_optimizations  (const char* p);
 gboolean          mono_running_on_valgrind (void);
 
 MonoLMF * mono_get_lmf                      (void);
-#define mono_get_lmf_addr mono_tls_get_lmf_addr
-MonoLMF** mono_get_lmf_addr                 (void);
+MonoLMF** mono_get_lmf_addr                 (void); // mono_get_lmf_addr and mono_tls_get_lmf_addr are the same
+MonoLMF** mono_tls_get_lmf_addr             (void); // mono_get_lmf_addr and mono_tls_get_lmf_addr are the same
 void      mono_set_lmf                      (MonoLMF *lmf);
 void      mono_push_lmf                     (MonoLMFExt *ext);
 void      mono_pop_lmf                      (MonoLMF *lmf);

--- a/mono/utils/mono-tls.c
+++ b/mono/utils/mono-tls.c
@@ -338,9 +338,19 @@ SgenThreadInfo *mono_tls_get_sgen_thread_info (void)
 	return (SgenThreadInfo*)MONO_TLS_GET_VALUE (mono_tls_sgen_thread_info, mono_tls_key_sgen_thread_info);
 }
 
+// This is duplicated because JIT icall infrastructure checks for duplicates (same function, multiple names).
+#define MONO_GET_LMF_ADDR() ((MonoLMF**)MONO_TLS_GET_VALUE (mono_tls_lmf_addr, mono_tls_key_lmf_addr))
+
 MonoLMF **mono_tls_get_lmf_addr (void)
+// This is duplicated because JIT icall infrastructure checks for duplicates (same function, multiple names).
 {
-	return (MonoLMF**)MONO_TLS_GET_VALUE (mono_tls_lmf_addr, mono_tls_key_lmf_addr);
+	return MONO_GET_LMF_ADDR();
+}
+
+MonoLMF **mono_get_lmf_addr (void)
+// This is duplicated because JIT icall infrastructure checks for duplicates (same function, multiple names).
+{
+	return MONO_GET_LMF_ADDR();
 }
 
 /* Setters for each tls key */


### PR DESCRIPTION
Duplicate name or duplicate function.
Dedup one case (mono_tls_get_lmf_addr, mono_get_lmf_addr) and special case another (mono_no_trampolines).
In the first case we should probably pick just one name for it.

This is part of JIT icall hash elimination.
It is mainly useful while JIT icall hashing is in flux and might later be removed, or reduced.
Hopefully this will devolve to already-initialized check, and hashing goes away.
