### PR TITLE
[netcore] Set of workarounds for ArrayTests

### DIFF
--- a/mcs/class/System.Private.CoreLib/System.Collections.Generic/ArraySortHelper.cs
+++ b/mcs/class/System.Private.CoreLib/System.Collections.Generic/ArraySortHelper.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace System.Collections.Generic
 {
 	partial class ArraySortHelper<T>

--- a/mcs/class/System.Private.CoreLib/System.Collections.Generic/ArraySortHelper.cs
+++ b/mcs/class/System.Private.CoreLib/System.Collections.Generic/ArraySortHelper.cs
@@ -1,4 +1,4 @@
-#nullable enable
+
 
 namespace System.Collections.Generic
 {

--- a/mcs/class/System.Private.CoreLib/System.Collections.Generic/ArraySortHelper.cs
+++ b/mcs/class/System.Private.CoreLib/System.Collections.Generic/ArraySortHelper.cs
@@ -1,4 +1,4 @@
-
+#nullable enable
 
 namespace System.Collections.Generic
 {

--- a/mcs/class/System.Private.CoreLib/System.Collections.Generic/Comparer.cs
+++ b/mcs/class/System.Private.CoreLib/System.Collections.Generic/Comparer.cs
@@ -1,5 +1,7 @@
 using System.Runtime.CompilerServices;
 
+#nullable enable
+
 namespace System.Collections.Generic
 {
 	partial class Comparer<T>

--- a/mcs/class/System.Private.CoreLib/System.Collections.Generic/Comparer.cs
+++ b/mcs/class/System.Private.CoreLib/System.Collections.Generic/Comparer.cs
@@ -1,6 +1,6 @@
-using System.Runtime.CompilerServices;
-
 #nullable enable
+
+using System.Runtime.CompilerServices;
 
 namespace System.Collections.Generic
 {

--- a/mcs/class/System.Private.CoreLib/System.Collections.Generic/EqualityComparer.cs
+++ b/mcs/class/System.Private.CoreLib/System.Collections.Generic/EqualityComparer.cs
@@ -1,5 +1,7 @@
 using System.Runtime.CompilerServices;
 
+#nullable enable
+
 namespace System.Collections.Generic
 {
 	partial class EqualityComparer<T>

--- a/mcs/class/System.Private.CoreLib/System.Collections.Generic/EqualityComparer.cs
+++ b/mcs/class/System.Private.CoreLib/System.Collections.Generic/EqualityComparer.cs
@@ -1,6 +1,6 @@
-using System.Runtime.CompilerServices;
-
 #nullable enable
+
+using System.Runtime.CompilerServices;
 
 namespace System.Collections.Generic
 {

--- a/mcs/class/System.Private.CoreLib/System/Array.cs
+++ b/mcs/class/System.Private.CoreLib/System/Array.cs
@@ -149,7 +149,7 @@ namespace System
 				for (int i = 0; i < length; i++) {
 					Object srcval = sourceArray.GetValueImpl (source_pos + i);
 
-					if (srcval == null && dst_type_vt)
+					if (dst_type_vt && (srcval == null || (src_type == typeof (object) && srcval.GetType () != dst_type)))
 						throw new InvalidCastException ();
 
 					try {

--- a/mcs/class/System.Private.CoreLib/System/Array.cs
+++ b/mcs/class/System.Private.CoreLib/System/Array.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Reflection;
 
 namespace System
 {
@@ -129,7 +128,7 @@ namespace System
 
 			Type src_type = sourceArray.GetType ().GetElementType ();
 			Type dst_type = destinationArray.GetType ().GetElementType ();
-			var dst_type_vt = dst_type.IsValueType;
+			var dst_type_vt = dst_type.IsValueType && Nullable.GetUnderlyingType(dst_type) == null;
 
 			if (src_type.IsEnum)
 				src_type = Enum.GetUnderlyingType (src_type);

--- a/mcs/class/System.Private.CoreLib/System/Array.cs
+++ b/mcs/class/System.Private.CoreLib/System/Array.cs
@@ -197,6 +197,12 @@ namespace System
 				} else if (source.IsPointer && target.IsPointer) {
 					return true;
 				} else if (source.IsPrimitive && target.IsPrimitive) {
+					
+					// DefaultBinder.CanChangePrimitive for some reason doesn't allow UInt16 (0-65535) to Char (0-65535) conversion
+					// but does support Char to UInt16.
+					if (source == typeof (ushort) && target == typeof (char))
+						return true;
+					
 					// Allow primitive type widening
 					return DefaultBinder.CanChangePrimitive (source, target);
 				} else if (!source.IsValueType && !source.IsPointer) {

--- a/mcs/class/System.Private.CoreLib/System/Array.cs
+++ b/mcs/class/System.Private.CoreLib/System/Array.cs
@@ -273,6 +273,8 @@ namespace System
 				throw new NotSupportedException ("Array type can not be void");
 			if (elementType.ContainsGenericParameters)
 				throw new NotSupportedException ("Array type can not be an open generic type");
+			if (elementType.IsByRef)
+				throw new NotSupportedException (SR.NotSupported_Type);
 			
 			return CreateInstanceImpl (elementType, lengths, bounds);
 		}
@@ -293,6 +295,8 @@ namespace System
 				throw new NotSupportedException ("Array type can not be void");
 			if (elementType.ContainsGenericParameters)
 				throw new NotSupportedException ("Array type can not be an open generic type");
+			if (elementType.IsByRef)
+				throw new NotSupportedException (SR.NotSupported_Type);
 
 			if (lengths.Length < 1)
 				throw new ArgumentException ("Arrays must contain >= 1 elements.");

--- a/mcs/class/System.Private.CoreLib/System/Array.cs
+++ b/mcs/class/System.Private.CoreLib/System/Array.cs
@@ -197,8 +197,7 @@ namespace System
 					return true;
 				} else if (source.IsPrimitive && target.IsPrimitive) {
 					
-					// DefaultBinder.CanChangePrimitive for some reason doesn't allow UInt16 (0-65535) to Char (0-65535) conversion
-					// but does support Char to UInt16.
+					// Special case: normally C# doesn't allow implicit ushort->char cast).
 					if (source == typeof (ushort) && target == typeof (char))
 						return true;
 					

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -154,7 +154,7 @@ icallarray_print (const char *format, ...)
 static GENERATE_GET_CLASS_WITH_CACHE (module, "System.Reflection", "Module")
 
 static void
-array_set_value_impl (MonoArrayHandle arr, MonoObjectHandle value, guint32 pos, MonoError *error, gboolean strict);
+array_set_value_impl (MonoArrayHandle arr, MonoObjectHandle value, guint32 pos, gboolean strict, MonoError *error);
 
 static MonoArrayHandle
 type_array_from_modifiers (MonoImage *image, MonoType *type, int optional, MonoError *error);
@@ -252,7 +252,7 @@ ves_icall_System_Array_GetValue (MonoArrayHandle arr, MonoArrayHandle indices, M
 void
 ves_icall_System_Array_SetValueImpl (MonoArrayHandle arr, MonoObjectHandle value, guint32 pos, MonoError *error)
 {
-	array_set_value_impl (arr, value, pos, error, FALSE);
+	array_set_value_impl (arr, value, pos, FALSE, error);
 }
 
 static inline void
@@ -263,7 +263,7 @@ set_invalid_cast (MonoError *error, MonoClass *src_class, MonoClass *dst_class)
 }
 
 static void
-array_set_value_impl (MonoArrayHandle arr_handle, MonoObjectHandle value_handle, guint32 pos, MonoError *error, gboolean strict)
+array_set_value_impl (MonoArrayHandle arr_handle, MonoObjectHandle value_handle, guint32 pos, gboolean strict, MonoError *error)
 {
 	MonoClass *ac, *vc, *ec;
 	gint32 esize, vsize;
@@ -667,7 +667,7 @@ ves_icall_System_Array_SetValue (MonoArrayHandle arr, MonoObjectHandle value,
 			return;
 		}
 
-		array_set_value_impl (arr, value, idx, error, TRUE);
+		array_set_value_impl (arr, value, idx, TRUE, error);
 		return;
 	}
 	
@@ -691,7 +691,7 @@ ves_icall_System_Array_SetValue (MonoArrayHandle arr, MonoObjectHandle value,
 		pos = pos * dim.length + idx - dim.lower_bound;
 	}
 
-	array_set_value_impl (arr, value, pos, error, TRUE);
+	array_set_value_impl (arr, value, pos, TRUE, error);
 }
 
 MonoArrayHandle

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -273,6 +273,8 @@ array_set_value_impl (MonoArrayHandle arr_handle, MonoObjectHandle value_handle,
 	gint64 i64 = 0;
 	gdouble r64 = 0;
 	gboolean castOk = FALSE;
+	gboolean et_isenum = FALSE;
+	gboolean vt_isenum = FALSE;
 
 	error_init (error);
 
@@ -411,12 +413,14 @@ array_set_value_impl (MonoArrayHandle arr_handle, MonoObjectHandle value_handle,
 
 	vsize = mono_class_value_size (vc, NULL);
 
-	gboolean et_isenum = et == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_class_get_byval_arg (ec)->data.klass);
-	gboolean vt_isenum = vt == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_class_get_byval_arg (vc)->data.klass);
+	et_isenum = et == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_class_get_byval_arg (ec)->data.klass);
+	vt_isenum = vt == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_class_get_byval_arg (vc)->data.klass);
 
 #if ENABLE_NETCORE
-	if (strict && et_isenum && !vt_isenum)
+	if (strict && et_isenum && !vt_isenum) {
 		INVALID_CAST;
+		goto leave;
+	}
 #endif
 
 	if (et_isenum)

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -154,7 +154,7 @@ icallarray_print (const char *format, ...)
 static GENERATE_GET_CLASS_WITH_CACHE (module, "System.Reflection", "Module")
 
 static void
-array_set_value_impl (MonoArrayHandle arr, MonoObjectHandle value, guint32 pos, MonoError *error);
+array_set_value_impl (MonoArrayHandle arr, MonoObjectHandle value, guint32 pos, MonoError *error, gboolean strict);
 
 static MonoArrayHandle
 type_array_from_modifiers (MonoImage *image, MonoType *type, int optional, MonoError *error);
@@ -252,7 +252,7 @@ ves_icall_System_Array_GetValue (MonoArrayHandle arr, MonoArrayHandle indices, M
 void
 ves_icall_System_Array_SetValueImpl (MonoArrayHandle arr, MonoObjectHandle value, guint32 pos, MonoError *error)
 {
-	array_set_value_impl (arr, value, pos, error);
+	array_set_value_impl (arr, value, pos, error, FALSE);
 }
 
 static inline void
@@ -263,7 +263,7 @@ set_invalid_cast (MonoError *error, MonoClass *src_class, MonoClass *dst_class)
 }
 
 static void
-array_set_value_impl (MonoArrayHandle arr_handle, MonoObjectHandle value_handle, guint32 pos, MonoError *error)
+array_set_value_impl (MonoArrayHandle arr_handle, MonoObjectHandle value_handle, guint32 pos, MonoError *error, gboolean strict)
 {
 	MonoClass *ac, *vc, *ec;
 	gint32 esize, vsize;
@@ -312,18 +312,20 @@ array_set_value_impl (MonoArrayHandle arr_handle, MonoObjectHandle value_handle,
 
 #ifdef ENABLE_NETCORE
 #define WIDENING_MSG NULL
+#define WIDENING_ARG NULL
 #else
 #define WIDENING_MSG "not a widening conversion"
+#define WIDENING_ARG "value"
 #endif
 
 #define NO_WIDENING_CONVERSION G_STMT_START{				\
-		mono_error_set_argument (error, "value", WIDENING_MSG); \
+		mono_error_set_argument (error, WIDENING_ARG, WIDENING_MSG); \
 		break;							\
 	}G_STMT_END
 
 #define CHECK_WIDENING_CONVERSION(extra) G_STMT_START{			\
 		if (esize < vsize + (extra)) {				\
-			mono_error_set_argument (error, "value", WIDENING_MSG); \
+			mono_error_set_argument (error, WIDENING_ARG, WIDENING_MSG); \
 			break;						\
 		}							\
 	}G_STMT_END
@@ -409,10 +411,18 @@ array_set_value_impl (MonoArrayHandle arr_handle, MonoObjectHandle value_handle,
 
 	vsize = mono_class_value_size (vc, NULL);
 
-	if (et == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_class_get_byval_arg (ec)->data.klass))
+	gboolean et_isenum = et == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_class_get_byval_arg (ec)->data.klass);
+	gboolean vt_isenum = vt == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_class_get_byval_arg (vc)->data.klass);
+
+#if ENABLE_NETCORE
+	if (strict && et_isenum && !vt_isenum)
+		INVALID_CAST;
+#endif
+
+	if (et_isenum)
 		et = mono_class_enum_basetype_internal (m_class_get_byval_arg (ec)->data.klass)->type;
 
-	if (vt == MONO_TYPE_VALUETYPE && m_class_is_enumtype (m_class_get_byval_arg (vc)->data.klass))
+	if (vt_isenum)
 		vt = mono_class_enum_basetype_internal (m_class_get_byval_arg (vc)->data.klass)->type;
 
 #define ASSIGN_UNSIGNED(etype) G_STMT_START{\
@@ -657,7 +667,7 @@ ves_icall_System_Array_SetValue (MonoArrayHandle arr, MonoObjectHandle value,
 			return;
 		}
 
-		array_set_value_impl (arr, value, idx, error);
+		array_set_value_impl (arr, value, idx, error, TRUE);
 		return;
 	}
 	
@@ -681,7 +691,7 @@ ves_icall_System_Array_SetValue (MonoArrayHandle arr, MonoObjectHandle value,
 		pos = pos * dim.length + idx - dim.lower_bound;
 	}
 
-	array_set_value_impl (arr, value, pos, error);
+	array_set_value_impl (arr, value, pos, error, TRUE);
 }
 
 MonoArrayHandle

--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -72,9 +72,9 @@ corefx/.stamp-dl-corefx-tests-$(NETCORETESTS_VERSION):
 	python dl-test-assets.py corefx-test-assets.xml $(FEED_BASE_URL) corefx/tests
 	touch $@
 
-run-sample:
+run-sample: prepare
 	dotnet build sample/HelloWorld
-	COMPlus_DebugWriteToStdErr=1 ./dotnet --fx-version "$(NETCOREAPP_VERSION)" sample/HelloWorld/bin/Debug/netcoreapp3.0/HelloWorld.dll
+	MONO_ENV_OPTIONS="--debug" COMPlus_DebugWriteToStdErr=1 ./dotnet --fx-version "$(NETCOREAPP_VERSION)" sample/HelloWorld/bin/Debug/netcoreapp3.0/HelloWorld.dll
 
 run-aspnet-sample: prepare
 	rm -rf sample/AspNetCore/{bin,obj}
@@ -89,7 +89,7 @@ SHAREDRUNTIME := shared/Microsoft.NETCore.App/$(NETCOREAPP_VERSION)
 bcl:
 	$(MAKE) -C ../mcs/build/ common/Consts.cs
 	$(MAKE) -C ../mcs/class/System.Private.CoreLib
-	cp ../mcs/class/System.Private.CoreLib/bin/$(COREARCH)/System.Private.CoreLib.dll $(SHAREDRUNTIME)
+	cp ../mcs/class/System.Private.CoreLib/bin/$(COREARCH)/System.Private.CoreLib.{dll,pdb} $(SHAREDRUNTIME)
 
 runtime:
 	$(MAKE) -C ../mono

--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -5,7 +5,7 @@ include ../mcs/build/config.make
 #
 
 # Extracted MicrosoftPrivateCoreFxNETCoreAppVersion from https://github.com/dotnet/coreclr/blob/master/eng/Versions.props#L12
-NETCORETESTS_VERSION := 4.6.0-preview6.19229.1
+NETCORETESTS_VERSION := 4.6.0-preview6.19257.4
 
 # Extracted MicrosoftNETCoreAppVersion from https://github.com/dotnet/coreclr/blob/master/eng/Versions.props#L14
 NETCOREAPP_VERSION := 3.0.0-preview5-27620-01

--- a/netcore/excludes-System.Runtime.Tests.rsp
+++ b/netcore/excludes-System.Runtime.Tests.rsp
@@ -42,7 +42,6 @@
 
 # Implement more checks in Array.Copy
 -nomethod System.Tests.ArrayTests.SetValue_Casting_Invalid
--nomethod System.Tests.ArrayTests.Copy_SZArray
 -nomethod System.Tests.ArrayTests.CreateInstance_NotSupportedType_ThrowsNotSupportedException
 -nomethod System.Tests.ActivatorTests.CreateInstance_PrimitiveWidening_ThrowsInvalidCastException
 

--- a/netcore/excludes-System.Runtime.Tests.rsp
+++ b/netcore/excludes-System.Runtime.Tests.rsp
@@ -41,7 +41,6 @@
 -nomethod System.Tests.Types.VoidTests.IsByRef_Get_ReturnsExpected
 
 # Implement more checks in Array.Copy
--nomethod System.Tests.ArrayTests.SetValue_Casting_Invalid
 -nomethod System.Tests.ArrayTests.CreateInstance_NotSupportedType_ThrowsNotSupportedException
 -nomethod System.Tests.ActivatorTests.CreateInstance_PrimitiveWidening_ThrowsInvalidCastException
 

--- a/netcore/excludes-System.Runtime.Tests.rsp
+++ b/netcore/excludes-System.Runtime.Tests.rsp
@@ -41,7 +41,6 @@
 -nomethod System.Tests.Types.VoidTests.IsByRef_Get_ReturnsExpected
 
 # Implement more checks in Array.Copy
--nomethod System.Tests.ArrayTests.CreateInstance_NotSupportedType_ThrowsNotSupportedException
 -nomethod System.Tests.ActivatorTests.CreateInstance_PrimitiveWidening_ThrowsInvalidCastException
 
 # Boxed pointers are not supported? https://github.com/mono/mono/blob/ced517784b2a07fb851e2227dac04e0df2262d57/mcs/class/corlib/ReferenceSources/RuntimeType.cs#L229

--- a/netcore/excludes-System.Runtime.Tests.rsp
+++ b/netcore/excludes-System.Runtime.Tests.rsp
@@ -40,22 +40,11 @@
 # while the test passes, xunit fails in the end if it's enabled
 -nomethod System.Tests.Types.VoidTests.IsByRef_Get_ReturnsExpected
 
-# Implement more checks in Array.Copy
--nomethod System.Tests.ActivatorTests.CreateInstance_PrimitiveWidening_ThrowsInvalidCastException
-
 # Boxed pointers are not supported? https://github.com/mono/mono/blob/ced517784b2a07fb851e2227dac04e0df2262d57/mcs/class/corlib/ReferenceSources/RuntimeType.cs#L229
 -nomethod System.Reflection.Tests.InvokeRefReturnNetcoreTests.TestByRefLikeRefReturn
 
 # `private new T Foo` doesn't hide members from Type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
 -nomethod System.Reflection.Tests.TypeTests_HiddenTestingOrder.HideDetectionHappensBeforeBindingFlagChecks
-
-# remove once CoreFX gets https://github.com/dotnet/coreclr/pull/24279
--nomethod System.Tests.TimeSpanTests.FromMilliseconds
--nomethod System.Tests.TimeSpanTests.FromMilliseconds_Invalid
--nomethod System.Tests.TimeSpanTests.Multiplication
--nomethod System.Tests.TimeSpanTests.NamedMultiplication
--nomethod System.Tests.TimeSpanTests.Division
--nomethod System.Tests.TimeSpanTests.NamedDivision
 
 # TODO: ignore in CoreFX for mono runtime:
 -nomethod System.Reflection.Tests.PointerTests.*


### PR DESCRIPTION
This PR enables >200 tests in System.Runtime.Tests.
 1.
```csharp
public enum SByteEnum : sbyte
{
    MinusTwo = -2,
    Zero = 0,
    Five = 5
}

SByteEnum[] arr = new SByteEnum[3];
arr.SetValue((sbyte) 1, 0);  // Expected: InvalidCast!
arr.CopyTo(new sbyte[3], 0); // Expected: success
```
Mono used to allow both (looks more logical).

2.
```csharp
Array sourceArray = new object[] { null };
Array destinationArray = new int?[] { 0 };
Array.Copy(sourceArray, 0, destinationArray, 0, 1);
```
Mono used to throw Exception here (that's why I added `Nullable.GetUnderlyingType`).

3.
In .NET Core it's allowed to copy array of `ushort` to `char` (`DefaultBinder.CanChangePrimitive` returns false for such conversion, but returns true for `char` to `ushort`).


4. if `#nullable enable` is defined in one of the `partial` file - it should be defined everywhere else (didn't compile without it with some weird error).

```
=== TEST EXECUTION SUMMARY ===
   System.Runtime.Tests  Total: 32502, Errors: 0, Failed: 0, Skipped: 2, Time: 25.303s
```