### PR TITLE
[2019-04] Mutex memory leak on sgen GC (nursery, major).

### DIFF
--- a/mono/sgen/sgen-gray.c
+++ b/mono/sgen/sgen-gray.c
@@ -418,6 +418,8 @@ sgen_gray_object_queue_dispose (SgenGrayQueue *queue)
 	SGEN_ASSERT (0, !last_gray_queue_free_list, "Are we disposing two gray queues after another?");
 	last_gray_queue_free_list = queue->free_list;
 
+	mono_os_mutex_destroy (&queue->steal_mutex);
+
 	/* just to make sure */
 	memset (queue, 0, sizeof (SgenGrayQueue));
 }


### PR DESCRIPTION
During GC we allocate a gray queue protected by a mutex, sgen_gray_object_queue_init. This mutex is never destroyed when clearing up the object containing it, sgen_gray_object_queue_dispose, so it will leak. Overtime this could cause OOM on some systems depending on how memory related to system primitives are handled and partitioned.


Backport of #14375.

/cc @BrzVlad @lateralusX