### PR TITLE
Remapping should affect GAC search paths considered by the loader

### DIFF
--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -4385,10 +4385,15 @@ mono_assembly_load_full_gac_base_default (MonoAssemblyName *aname,
 					  MonoImageOpenStatus *status)
 {
 	MonoAssembly *result;
+	MonoAssemblyName maped_aname;
 	char *fullpath, *filename;
 	int ext_index;
 	const char *ext;
 	int len;
+
+	/* If we remap e.g. 4.1.3.0 to 4.0.0.0, look in the 4.0.0.0
+	 * GAC directory, not 4.1.3.0 */
+	aname = mono_assembly_remap_version (aname, &maped_aname);
 
 	/* Currently we retrieve the loaded corlib for reflection 
 	 * only requests, like a common reflection only assembly 


### PR DESCRIPTION
Closes: #14366

Fixes Mac package failures during IronRuby compilation

```
Mono: The request to load the assembly System.Numerics.Vectors v4.1.3.0 was remapped to v4.0.0.0
Mono: Assembly Loader probing location: '/tmp/monoprefix/lib/mono/gac/System.Numerics.Vectors/4.1.3.0__b03f5f7f11d50a3a/System.Numerics.Vectors.dll'.
Mono: Assembly Loader probing location: '/tmp/monoprefix/lib/mono/msbuild/Current/bin/Roslyn/System.Numerics.Vectors.dll'.
Mono: Assembly Loader probing location: '/tmp/monoprefix/lib/System.Numerics.Vectors.dll'.
Mono: Assembly Loader probing location: '/tmp/monoprefix/lib/mono/4.5//Facades/System.Numerics.Vectors.dll'.
Mono: Assembly Loader probing location: '/tmp/monoprefix/lib/mono/gac/System.Numerics.Vectors/4.1.3.0__b03f5f7f11d50a3a/System.Numerics.Vectors.exe'.
Mono: Assembly Loader probing location: '/tmp/monoprefix/lib/mono/msbuild/Current/bin/Roslyn/System.Numerics.Vectors.exe'.
Mono: Assembly Loader probing location: '/tmp/monoprefix/lib/System.Numerics.Vectors.exe'.
Mono: Assembly Loader probing location: '/tmp/monoprefix/lib/mono/4.5//Facades/System.Numerics.Vectors.exe'.
Mono: The following assembly referenced from /tmp/monoprefix/lib/mono/4.5/System.Memory.dll could not be loaded:
     Assembly:   System.Numerics.Vectors    (assemblyref_index=1)
     Version:    4.1.3.0
     Public Key: b03f5f7f11d50a3a
The assembly was not found in the Global Assembly Cache, a path listed in the MONO_PATH environment variable, or in the location of the executing assembly (/tmp/monoprefix/lib/mono/msbuild/Current/bin/Roslyn/).
```

becomes

```
Mono: The request to load the assembly System.Numerics.Vectors v4.1.3.0 was remapped to v4.0.0.0
Mono: Assembly Loader probing location: '/tmp/monoprefix/lib/mono/gac/System.Numerics.Vectors/4.0.0.0__b03f5f7f11d50a3a/System.Numerics.Vectors.dll'.
Mono: Image addref System.Numerics.Vectors[0x7f53ec06b490] (asmctx DEFAULT) -> /tmp/monoprefix/lib/mono/gac/System.Numerics.Vectors/4.0.0.0__b03f5f7f11d50a3a/System.Numerics.Vectors.dll[0x7f53ec072710]: 2
```