### PR TITLE
Don't apply MONO_ATTR_FORMAT_PRINTF to mono_error_set_argument

### DIFF
--- a/mono/utils/mono-error-internals.h
+++ b/mono/utils/mono-error-internals.h
@@ -164,7 +164,7 @@ void
 mono_error_set_argument_format (MonoError *error, const char *argument, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(3,4);
 
 void
-mono_error_set_argument (MonoError *error, const char *argument, const char *msg, ...) MONO_ATTR_FORMAT_PRINTF(3,4);
+mono_error_set_argument (MonoError *error, const char *argument, const char *msg);
 
 void
 mono_error_set_argument_null (MonoError *oerror, const char *argument, const char *msg_format, ...) MONO_ATTR_FORMAT_PRINTF(3,4);

--- a/mono/utils/mono-error.c
+++ b/mono/utils/mono-error.c
@@ -543,7 +543,7 @@ mono_error_set_argument_format (MonoError *oerror, const char *argument, const c
 }
 
 void
-mono_error_set_argument (MonoError *oerror, const char *argument, const char *msg, ...)
+mono_error_set_argument (MonoError *oerror, const char *argument, const char *msg)
 {
 	MonoErrorInternal *error = (MonoErrorInternal*)oerror;
 	mono_error_prepare (error);


### PR DESCRIPTION
The constructor for mono_error_set_argument lacks a `const char *msg_format` so clearly we shouldn't be applying formatting from an entirely unrelated parameter.

This was flagged by `-Werror=format-security`