### PR TITLE
[2019-04] [debugger] Deadlock while debugging a process

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -2773,6 +2773,8 @@ try_process_suspend (void *the_tls, MonoContext *ctx)
 		/* Fastpath during invokes, see in process_suspend () */
 		if (suspend_count - tls->resume_count == 0)
 			return FALSE;
+		if (tls->invoke)
+			return FALSE;
 		process_suspend (tls, ctx);
 		return TRUE;
 	}


### PR DESCRIPTION
A deadlock happens when during a process_suspend there is a pending invoke and then when it's calling the invoke there is another call to process_suspend in the same thread.



Backport of #14368.

/cc @lewurm @thaystg