### PR TITLE
[w32mutex] use handle stack in ReleaseMutex

### DIFF
--- a/mono/metadata/w32mutex-unix.c
+++ b/mono/metadata/w32mutex-unix.c
@@ -385,14 +385,16 @@ ves_icall_System_Threading_Mutex_ReleaseMutex_internal (gpointer handle)
 	if (!mono_w32handle_lookup_and_ref (handle, &handle_data)) {
 		g_warning ("%s: unkown handle %p", __func__, handle);
 		mono_w32error_set_last (ERROR_INVALID_HANDLE);
-		return FALSE;
+		ret = FALSE;
+		goto exit;
 	}
 
 	if (handle_data->type != MONO_W32TYPE_MUTEX && handle_data->type != MONO_W32TYPE_NAMEDMUTEX) {
 		g_warning ("%s: unknown mutex handle %p", __func__, handle);
 		mono_w32error_set_last (ERROR_INVALID_HANDLE);
 		mono_w32handle_unref (handle_data);
-		return FALSE;
+		ret = FALSE;
+		goto exit;
 	}
 
 	mutex_handle = (MonoW32HandleMutex*) handle_data->specific;
@@ -432,6 +434,7 @@ ves_icall_System_Threading_Mutex_ReleaseMutex_internal (gpointer handle)
 	mono_w32handle_unlock (handle_data);
 	mono_w32handle_unref (handle_data);
 
+exit:
 	HANDLE_FUNCTION_RETURN_VAL (ret);
 }
 

--- a/mono/metadata/w32mutex-unix.c
+++ b/mono/metadata/w32mutex-unix.c
@@ -380,6 +380,8 @@ ves_icall_System_Threading_Mutex_ReleaseMutex_internal (gpointer handle)
 	pthread_t tid;
 	gboolean ret;
 
+	HANDLE_FUNCTION_ENTER ();
+
 	if (!mono_w32handle_lookup_and_ref (handle, &handle_data)) {
 		g_warning ("%s: unkown handle %p", __func__, handle);
 		mono_w32error_set_last (ERROR_INVALID_HANDLE);
@@ -430,7 +432,7 @@ ves_icall_System_Threading_Mutex_ReleaseMutex_internal (gpointer handle)
 	mono_w32handle_unlock (handle_data);
 	mono_w32handle_unref (handle_data);
 
-	return ret;
+	HANDLE_FUNCTION_RETURN_VAL (ret);
 }
 
 gpointer


### PR DESCRIPTION
Fixes this on watchOS with llvmonly:
```
MutexTest
warning: Handle 0x1624bc0c (object = 0x2ce4120) (allocated from "../../../../../mono/metadata/threads.c:2022") is leaking.

* thread %1
  * frame %0: 0x0183a3e0 mscorlibtests`mono_pmip(ip=0x01a2e191) at mini-runtime.c:243
    frame %1: 0x0189f3a6 mscorlibtests`mono_handle_new(obj=0x01e505f8, info=0x1624e600, owner="../../../../../mono/metadata/gc.c:1337") at handle.c:186:2
    frame %2: 0x0189e398 mscorlibtests`mono_gc_alloc_handle_string(vtable=0x16a52760, size=50, len=18) at gc.c:1337:9
    frame %3: 0x018fa91e mscorlibtests`mono_string_new_size_handle(domain=0x15e14e60, len=18, error=0x01ce4180) at object.c:6658:6
    frame %4: 0x018f304c mscorlibtests`mono_string_new_size_checked(domain=0x15e14e60, length=18, error=0x01ce4180) at object.c:6670:2
    frame %5: 0x018fa6d6 mscorlibtests`mono_string_new_utf16_checked(domain=0x15e14e60, text=0x02c5980d, len=18, error=0x01ce4180) at object.c:6551:6
    frame %6: 0x018fa726 mscorlibtests`mono_string_new_utf16_handle(domain=0x15e14e60, text=0x02c5980d, len=18, error=0x01ce4180) at object.c:6569:9
    frame %7: 0x018f651e mscorlibtests`mono_ldstr_metadata_sig(domain=0x15e14e60, sig="M", error=0x01ce4180) at object.c:7525:23
    frame %8: 0x018fc0f0 mscorlibtests`mono_ldstr_checked(domain=0x15e14e60, image=0x16a4c400, idx=70660, error=0x01ce4180) at object.c:7477:8
    frame %9: 0x018224ce mscorlibtests`mono_helper_ldstr_mscorlib(idx=70660) at jit-icalls.c:1172:23
    frame %10: 0x00925efe mscorlibtests`aot_wrapper_icall_mono_helper_ldstr_mscorlib + 68
    frame %11: 0x0042a60e mscorlibtests`mscorlib_System_Threading_Mutex_ReleaseMutex + 194
    frame %12: 0x01232f36 mscorlibtests`mscorlibtests1_MonoTests_System_Threading_MutexTest_DoubleRelease + 394
    frame %13: 0x009456ca mscorlibtests`aot_wrapper_gsharedvt_out_sig_pinvoke_void_this_ + 28
    frame %14: 0x0091728a mscorlibtests`mscorlib_wrapper_runtime_invoke_object_runtime_invoke_sig_void_intptr_intptr_object_intptr_intptr_intptr + 312
    frame %15: 0x018438ca mscorlibtests`mono_llvmonly_runtime_invoke(method=0x1632ecd8, info=0x17b94ec0, obj=0x01e4fe70, params=0x00000000, exc=0x01ce4550, error=0x01ce48a4) at mini-runtime.c:3000:2
```
Contributes to https://github.com/mono/mono/issues/13006