### PR TITLE
Do not allocate handles in ReleaseMutex.

### DIFF
--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -437,9 +437,6 @@ gboolean
 mono_thread_internal_is_current (MonoInternalThread *internal);
 
 gboolean
-mono_thread_internal_is_current_handle (MonoInternalThreadHandle internal);
-
-gboolean
 mono_threads_is_current_thread_in_protected_block (void);
 
 gboolean

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -6177,12 +6177,6 @@ mono_thread_internal_is_current (MonoInternalThread *internal)
 	return mono_native_thread_id_equals (mono_native_thread_id_get (), MONO_UINT_TO_NATIVE_THREAD_ID (internal->tid));
 }
 
-gboolean
-mono_thread_internal_is_current_handle (MonoInternalThreadHandle internal)
-{
-	return mono_thread_internal_is_current (MONO_HANDLE_RAW (internal));
-}
-
 void
 mono_set_thread_dump_dir (gchar* dir) {
 	thread_dump_dir = dir;

--- a/mono/metadata/w32mutex-unix.c
+++ b/mono/metadata/w32mutex-unix.c
@@ -37,27 +37,31 @@ static gpointer
 mono_w32mutex_open (const char* utf8_name, gint32 rights G_GNUC_UNUSED, gint32 *win32error);
 
 static void
-thread_own_mutex (MonoInternalThreadHandle internal, gpointer handle, MonoW32Handle *handle_data)
+thread_own_mutex (MonoInternalThread *internal, gpointer handle, MonoW32Handle *handle_data)
+// Thread and InternalThread are pinned/mature.
+// Take advantage of that and do not use handles here.
 {
 	/* if we are not on the current thread, there is a
 	 * race condition when allocating internal->owned_mutexes */
-	g_assert (mono_thread_internal_is_current_handle (internal));
+	g_assert (mono_thread_internal_is_current (internal));
 
-	if (!MONO_HANDLE_GETVAL (internal, owned_mutexes))
-		MONO_HANDLE_SETVAL(internal, owned_mutexes, GPtrArray*, g_ptr_array_new ());
+	if (!internal->owned_mutexes)
+		internal->owned_mutexes = g_ptr_array_new ();
 
-	g_ptr_array_add (MONO_HANDLE_GETVAL (internal, owned_mutexes), mono_w32handle_duplicate (handle_data));
+	g_ptr_array_add (internal->owned_mutexes, mono_w32handle_duplicate (handle_data));
 }
 
 static void
-thread_disown_mutex (MonoInternalThreadHandle internal, gpointer handle)
+thread_disown_mutex (MonoInternalThread *internal, gpointer handle)
+// Thread and InternalThread are pinned/mature.
+// Take advantage of that and do not use handles here.
 {
 	gboolean removed;
 
-	g_assert (mono_thread_internal_is_current_handle (internal));
+	g_assert (mono_thread_internal_is_current (internal));
 
-	g_assert (MONO_HANDLE_GETVAL (internal, owned_mutexes));
-	removed = g_ptr_array_remove (MONO_HANDLE_GETVAL (internal, owned_mutexes), handle);
+	g_assert (internal->owned_mutexes);
+	removed = g_ptr_array_remove (internal->owned_mutexes, handle);
 	g_assert (removed);
 
 	mono_w32handle_close (handle);
@@ -66,8 +70,6 @@ thread_disown_mutex (MonoInternalThreadHandle internal, gpointer handle)
 static gint32
 mutex_handle_signal (MonoW32Handle *handle_data)
 {
-	HANDLE_FUNCTION_ENTER ();
-
 	MonoW32HandleMutex *mutex_handle;
 	pthread_t tid;
 
@@ -90,7 +92,7 @@ mutex_handle_signal (MonoW32Handle *handle_data)
 		mutex_handle->recursion--;
 
 		if (mutex_handle->recursion == 0) {
-			thread_disown_mutex (mono_thread_internal_current_handle (), handle_data);
+			thread_disown_mutex (mono_thread_internal_current (), handle_data);
 
 			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_MUTEX, "%s: unlocking %s handle %p, tid: %p recusion : %d",
 				__func__, mono_w32handle_get_typename (handle_data->type), handle_data, (gpointer) mutex_handle->tid, mutex_handle->recursion);
@@ -99,15 +101,12 @@ mutex_handle_signal (MonoW32Handle *handle_data)
 			mono_w32handle_set_signal_state (handle_data, TRUE, FALSE);
 		}
 	}
-	HANDLE_FUNCTION_RETURN ();
 	return MONO_W32HANDLE_WAIT_RET_SUCCESS_0;
 }
 
 static gboolean
 mutex_handle_own (MonoW32Handle *handle_data, gboolean *abandoned)
 {
-	HANDLE_FUNCTION_ENTER ();
-
 	MonoW32HandleMutex *mutex_handle;
 
 	*abandoned = FALSE;
@@ -124,7 +123,7 @@ mutex_handle_own (MonoW32Handle *handle_data, gboolean *abandoned)
 		mutex_handle->tid = pthread_self ();
 		mutex_handle->recursion = 1;
 
-		thread_own_mutex (mono_thread_internal_current_handle (), handle_data, handle_data);
+		thread_own_mutex (mono_thread_internal_current (), handle_data, handle_data);
 	}
 
 	if (mutex_handle->abandoned) {
@@ -133,8 +132,7 @@ mutex_handle_own (MonoW32Handle *handle_data, gboolean *abandoned)
 	}
 
 	mono_w32handle_set_signal_state (handle_data, FALSE, FALSE);
-
-	HANDLE_FUNCTION_RETURN_VAL (TRUE);
+	return TRUE;
 }
 
 static gboolean
@@ -417,7 +415,7 @@ ves_icall_System_Threading_Mutex_ReleaseMutex_internal (gpointer handle)
 		mutex_handle->recursion--;
 
 		if (mutex_handle->recursion == 0) {
-			thread_disown_mutex (mono_thread_internal_current_handle (), handle);
+			thread_disown_mutex (mono_thread_internal_current (), handle);
 
 			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_MUTEX, "%s: unlocking %s handle %p, tid: %p recusion : %d",
 				__func__, mono_w32handle_get_typename (handle_data->type), handle, (gpointer) mutex_handle->tid, mutex_handle->recursion);
@@ -476,24 +474,22 @@ mono_w32mutex_open (const char* utf8_name, gint32 rights G_GNUC_UNUSED, gint32 *
 }
 
 void
-mono_w32mutex_abandon (MonoInternalThread *internal_raw)
+mono_w32mutex_abandon (MonoInternalThread *internal)
+// Thread and InternalThread are pinned/mature.
+// Take advantage of that and do not use handles here.
 {
-	HANDLE_FUNCTION_ENTER ()
+	g_assert (mono_thread_internal_is_current (internal));
 
-	MONO_HANDLE_DCL (MonoInternalThread, internal);
+	if (!internal->owned_mutexes)
+		return;
 
-	g_assert (mono_thread_internal_is_current_handle (internal));
-
-	if (!MONO_HANDLE_GETVAL (internal, owned_mutexes))
-		goto exit;
-
-	while (MONO_HANDLE_GETVAL (internal, owned_mutexes)->len) {
+	while (internal->owned_mutexes->len) {
 		MonoW32Handle *handle_data;
 		MonoW32HandleMutex *mutex_handle;
 		MonoNativeThreadId tid;
 		gpointer handle;
 
-		handle = g_ptr_array_index (MONO_HANDLE_GETVAL (internal, owned_mutexes), 0);
+		handle = g_ptr_array_index (internal->owned_mutexes, 0);
 
 		if (!mono_w32handle_lookup_and_ref (handle, &handle_data))
 			g_error ("%s: unkown handle %p", __func__, handle);
@@ -506,7 +502,7 @@ mono_w32mutex_abandon (MonoInternalThread *internal_raw)
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_MUTEX, "%s: abandoning %s handle %p",
 			__func__, mono_w32handle_get_typename (handle_data->type), handle);
 
-		tid = MONO_UINT_TO_NATIVE_THREAD_ID (MONO_HANDLE_GETVAL (internal, tid));
+		tid = MONO_UINT_TO_NATIVE_THREAD_ID (internal->tid);
 
 		if (!pthread_equal (mutex_handle->tid, tid))
 			g_error ("%s: trying to release mutex %p acquired by thread %p from thread %p",
@@ -529,11 +525,8 @@ mono_w32mutex_abandon (MonoInternalThread *internal_raw)
 		mono_w32handle_unref (handle_data);
 	}
 
-	g_ptr_array_free (MONO_HANDLE_GETVAL (internal, owned_mutexes), TRUE);
-	MONO_HANDLE_SETVAL(internal, owned_mutexes, GPtrArray*, NULL);
-
-exit:
-	HANDLE_FUNCTION_RETURN ();
+	g_ptr_array_free (internal->owned_mutexes, TRUE);
+	internal->owned_mutexes = NULL;
 }
 
 MonoW32HandleNamespace*

--- a/mono/metadata/w32mutex-unix.c
+++ b/mono/metadata/w32mutex-unix.c
@@ -38,9 +38,10 @@ mono_w32mutex_open (const char* utf8_name, gint32 rights G_GNUC_UNUSED, gint32 *
 
 static void
 thread_own_mutex (MonoInternalThread *internal, gpointer handle, MonoW32Handle *handle_data)
-// Thread and InternalThread are pinned/mature.
-// Take advantage of that and do not use handles here.
 {
+	// Thread and InternalThread are pinned/mature.
+	// Take advantage of that and do not use handles here.
+
 	/* if we are not on the current thread, there is a
 	 * race condition when allocating internal->owned_mutexes */
 	g_assert (mono_thread_internal_is_current (internal));
@@ -53,9 +54,9 @@ thread_own_mutex (MonoInternalThread *internal, gpointer handle, MonoW32Handle *
 
 static void
 thread_disown_mutex (MonoInternalThread *internal, gpointer handle)
-// Thread and InternalThread are pinned/mature.
-// Take advantage of that and do not use handles here.
 {
+	// Thread and InternalThread are pinned/mature.
+	// Take advantage of that and do not use handles here.
 	gboolean removed;
 
 	g_assert (mono_thread_internal_is_current (internal));
@@ -475,9 +476,9 @@ mono_w32mutex_open (const char* utf8_name, gint32 rights G_GNUC_UNUSED, gint32 *
 
 void
 mono_w32mutex_abandon (MonoInternalThread *internal)
-// Thread and InternalThread are pinned/mature.
-// Take advantage of that and do not use handles here.
 {
+	// Thread and InternalThread are pinned/mature.
+	// Take advantage of that and do not use handles here.
 	g_assert (mono_thread_internal_is_current (internal));
 
 	if (!internal->owned_mutexes)


### PR DESCRIPTION
Take advantage of thread/internal_thread maturity/pinning.

There are arguments for and against this.

It is arguably better to use handles everywhere.
But it is dubious to require an allocation to release a lock.
Releasing a lock should be infallible.
And surviving low memory shouldn't be a lost cause, imho..

This diff could also be viewed as an opportunistic cycle/size optimization
and be placed under ifdef -- ifdef THREAD_ALWAYS_PINNED orsuch.

This is an alternative to https://github.com/mono/mono/pull/14397.

Contributes to https://github.com/mono/mono/issues/13006