### PR TITLE
[2019-04] [llvmonly] make local copy of trace_ips pointer from exception object

### DIFF
--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -3851,16 +3851,18 @@ mono_llvm_load_exception (void)
 
 	MonoException *mono_ex = (MonoException*)mono_gchandle_get_target_internal (jit_tls->thrown_exc);
 
-	if (mono_ex->trace_ips) {
+	MonoArray *ta = mono_ex->trace_ips;
+
+	if (ta) {
 		GList *trace_ips = NULL;
 		gpointer ip = MONO_RETURN_ADDRESS ();
 
-		size_t upper = mono_array_length_internal (mono_ex->trace_ips);
+		size_t upper = mono_array_length_internal (ta);
 
 		for (int i = 0; i < upper; i += TRACE_IP_ENTRY_SIZE) {
-			gpointer curr_ip = mono_array_get_internal (mono_ex->trace_ips, gpointer, i);
+			gpointer curr_ip = mono_array_get_internal (ta, gpointer, i);
 			for (int j = 0; j < TRACE_IP_ENTRY_SIZE; ++j) {
-				gpointer p = mono_array_get_internal (mono_ex->trace_ips, gpointer, i + j);
+				gpointer p = mono_array_get_internal (ta, gpointer, i + j);
 				trace_ips = g_list_append (trace_ips, p);
 			}
 			if (ip == curr_ip)


### PR DESCRIPTION
Fixes a race in llvmonly (watchOS):
```
Process 397 stopped
* thread %10, name = 'tid_8e2f', stop reason = EXC_BAD_ACCESS (code=1, address=0x28)
    frame %0: 0x0177f690 mscorlibtests`mono_llvm_load_exception at mini-exceptions.c:3886:23
   3883                 size_t upper = mono_array_length_internal (mono_ex->trace_ips);
   3884
   3885                 for (int i = 0; i < upper; i += TRACE_IP_ENTRY_SIZE) {
-> 3886                         gpointer curr_ip = mono_array_get_internal (mono_ex->trace_ips, gpointer, i);
   3887                         for (int j = 0; j < TRACE_IP_ENTRY_SIZE; ++j) {
   3888                                 gpointer p = mono_array_get_internal (mono_ex->trace_ips, gpointer, i + j);
   3889                                 trace_ips = g_list_append (trace_ips, p);
Target 0: (mscorlibtests) stopped.

(lldb) mbt
* thread %10
  * frame %0: 0x0177f690 mscorlibtests`mono_llvm_load_exception at mini-exceptions.c:3886:23
    frame %1: 0x00e23b7a mscorlibtests`mscorlibtests1_MonoTests_System_LazyTest__c__DisplayClass16_0__ConcurrentInitializationb__1 + 254
    frame %2: 0x0087af98 mscorlibtests`mscorlib_wrapper_delegate_invoke__Module_invoke_void + 610
    frame %3: 0x00368856 mscorlibtests`mscorlib_System_Threading_ThreadHelper_ThreadStart_Context_object + 448
  [...]
(lldb) p/x mono_ex
(MonoException *) $2 = 0x01d9e968
(lldb) p/x mono_ex->trace_ips
(MonoArray *) $3 = 0x00000000
(lldb) thread list
Process 397 stopped
  thread %1: tid = 0x38772, 0x018156aa mscorlibtests`jit_info_table_copy_and_split_chunk(table=0x17635a00, chunk=0x17b767f0) at jit-info.c:483:28, name = 'tid_303', queue = 'com.apple.main-thread'
  thread %3: tid = 0x387ad, 0x1c4f9764 libsystem_kernel.dylib`__psynch_cvwait + 24, name = 'SGen worker'
  thread %4: tid = 0x387b0, 0x1c4f1224 libsystem_kernel.dylib`semaphore_wait_trap + 8, name = 'Finalizer'
  thread %5: tid = 0x387b5, 0x1c4fa6cc libsystem_kernel.dylib`__workq_kernreturn + 8
  thread %6: tid = 0x387b6, 0x1c4f11d4 libsystem_kernel.dylib`mach_msg_trap + 20, name = 'com.apple.uikit.eventfetch-thread'
* thread %10: tid = 0x389a6, 0x0177f690 mscorlibtests`mono_llvm_load_exception at mini-exceptions.c:3886:23, name = 'tid_8e2f', stop reason = EXC_BAD_ACCESS (code=1, address=0x28)
  thread %11: tid = 0x38985, 0x1c4f9764 libsystem_kernel.dylib`__psynch_cvwait + 24, name = 'tid_8113'
  thread %12: tid = 0x38986, 0x1c4f123c libsystem_kernel.dylib`semaphore_timedwait_trap + 8, name = 'Thread Pool Worker'
  thread %13: tid = 0x38987, 0x1c4f123c libsystem_kernel.dylib`semaphore_timedwait_trap + 8, name = 'Thread Pool Worker'
  thread %14: tid = 0x389a3, 0x1c4f123c libsystem_kernel.dylib`semaphore_timedwait_trap + 8, name = 'Thread Pool Worker'
  thread %15: tid = 0x389a4, 0x1c4f123c libsystem_kernel.dylib`semaphore_timedwait_trap + 8, name = 'Thread Pool Worker'
  thread %16: tid = 0x389a5, 0x1c4f123c libsystem_kernel.dylib`semaphore_timedwait_trap + 8, name = 'Thread Pool Worker'
(lldb) thread select 1
* thread %1, name = 'tid_303', queue = 'com.apple.main-thread'
    frame %0: 0x018156aa mscorlibtests`jit_info_table_copy_and_split_chunk(table=0x17635a00, chunk=0x17b767f0) at jit-info.c:483:28
   480                          jit_info_table_split_chunk (chunk, &new_table->chunks [j], &new_table->chunks [j + 1]);
   481                          j += 2;
   482                  } else {
-> 483                          new_table->chunks [j] = table->chunks [i];
   484                          ++new_table->chunks [j]->refcount;
   485                          ++j;
   486                  }
(lldb) mbt
* thread %1
  * frame %0: 0x018156aa mscorlibtests`jit_info_table_copy_and_split_chunk(table=0x17635a00, chunk=0x17b767f0) at jit-info.c:483:28
    frame %1: 0x01815304 mscorlibtests`jit_info_table_chunk_overflow(table=0x17635a00, chunk=0x17b767f0) at jit-info.c:579:10
    frame %2: 0x018146ee mscorlibtests`jit_info_table_add(domain=0x16624cc0, table_ptr=0x16624d9c, ji=0x176f4428) at jit-info.c:614:33
    frame %3: 0x01814662 mscorlibtests`mono_jit_info_table_add(domain=0x16624cc0, ji=0x176f4428) at jit-info.c:674:2
    frame %4: 0x0175f5da mscorlibtests`mono_aot_find_jit_info(domain=0x16624cc0, image=0x16c07200, addr=0x00271ff1) at aot-runtime.c:3710:3
    frame %5: 0x0181443e mscorlibtests`mono_jit_info_table_find_internal(domain=0x16624cc0, addr=0x00271ff1, try_aot=1, allow_trampolines=0) at jit-info.c:306:9
    frame %6: 0x018145e0 mscorlibtests`mono_jit_info_table_find(domain=0x16624cc0, addr=0x00271ff1) at jit-info.c:335:9
    frame %7: 0x01780212 mscorlibtests`build_stack_trace(frame_ctx=0x01c2fb18, state=0x01c2ffb8) at mini-exceptions.c:392:31
    frame %8: 0x1c598aa2 libunwind.dylib`_Unwind_Backtrace + 232
    frame %9: 0x0177f4fc mscorlibtests`throw_exception(ex=0x01d9e968, rethrow=0) at mini-exceptions.c:3800:3
    frame %10: 0x0177f3c8 mscorlibtests`mono_llvm_throw_exception(ex=0x01d9e968) at mini-exceptions.c:3823:2
    frame %11: 0x00439ed0 mscorlibtests`mscorlib_System_Runtime_ExceptionServices_ExceptionDispatchInfo_Throw + 116
    frame %12: 0x00271ff0 mscorlibtests`mscorlib_System_LazyHelper_ThrowException + 98
    frame %13: 0x002730c2 mscorlibtests`mscorlib_System_Lazy_1_T_REF_CreateValue + 194
    frame %14: 0x00273390 mscorlibtests`mscorlib_System_Lazy_1_T_REF_get_Value + 128
    frame %15: 0x0027307a mscorlibtests`mscorlib_System_Lazy_1_T_REF_CreateValue + 122
    frame %16: 0x00273390 mscorlibtests`mscorlib_System_Lazy_1_T_REF_get_Value + 128
    frame %17: 0x00e22eb0 mscorlibtests`mscorlibtests1_MonoTests_System_LazyTest_ConcurrentInitialization + 1422
    frame %18: 0x008948e2 mscorlibtests`aot_wrapper_gsharedvt_out_sig_pinvoke_void_this_ + 28
    frame %19: 0x008664a2 mscorlibtests`mscorlib_wrapper_runtime_invoke_object_runtime_invoke_sig_void_intptr_intptr_object_intptr_intptr_intptr + 312
```


Contributes to #13006

Backport of #14400.

/cc @lewurm 