### PR TITLE
[2019-04] [runtime] Use MAP_JIT automatically when running under a hardened runtime on osx.

### DIFF
--- a/mono/utils/mono-mmap.c
+++ b/mono/utils/mono-mmap.c
@@ -280,18 +280,18 @@ mono_valloc (void *addr, size_t length, int flags, MonoMemAccountType type)
 #if defined(__APPLE__) && defined(MAP_JIT)
 	if (get_darwin_version () >= DARWIN_VERSION_MOJAVE) {
 		/* Check for hardened runtime */
-		static gboolean is_hardened_runtime, checked;
+		static int is_hardened_runtime;
 
-		if (!checked && !use_mmap_jit) {
+		if (is_hardened_runtime == 0 && !use_mmap_jit) {
 			ptr = mmap (NULL, getpagesize (), PROT_WRITE|PROT_EXEC, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
-			if (ptr == MAP_FAILED)
-				is_hardened_runtime = TRUE;
-			else
+			if (ptr == MAP_FAILED) {
+				is_hardened_runtime = 1;
+			} else {
+				is_hardened_runtime = 2;
 				munmap (ptr, getpagesize ());
-			mono_memory_barrier ();
-			checked = TRUE;
+			}
 		}
-		if ((flags & MONO_MMAP_JIT) && (use_mmap_jit || is_hardened_runtime))
+		if ((flags & MONO_MMAP_JIT) && (use_mmap_jit || is_hardened_runtime == 1))
 			mflags |= MAP_JIT;
 	}
 #endif


### PR DESCRIPTION
This is to address https://github.com/mono/mono/pull/13446#issuecomment-489749599

Backport of #14395.

/cc @lewurm @vargaz