### PR TITLE
[llvm] Implement direct cross-amodule calls

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -13380,7 +13380,7 @@ mono_setup_direct_external_call_state (MonoAotCompile *acfg, MonoAotState **glob
 	gpointer value;
 	g_hash_table_iter_init (&iter, (*astate)->exported_method_failures);
 	while (g_hash_table_iter_next (&iter, &key, &value))
-		g_hash_table_insert (acfg->imported_method_failures, g_strdup (key), value);
+		g_hash_table_insert (acfg->imported_method_failures, g_strdup ((char *) key), value);
 
 	// Clear out exports table for a fresh iteration
 	GHashTable *old = (*astate)->exported_method_failures;
@@ -13546,7 +13546,7 @@ mono_compile_assemblies (MonoDomain *domain, char **argv, int argc, guint32 opts
 			continue;
 		}
 
-		int res = mono_compile_assembly (assem, opts, aot_options, (gpointer) &aot_state);
+		int res = mono_compile_assembly (assem, opts, aot_options, (gpointer **) &aot_state);
 
 		if (!aot_opts.disable_direct_external_calls)
 			mono_write_callee_failures (aot_state->exported_method_failures, assem->image);
@@ -13569,7 +13569,7 @@ mono_compile_assemblies (MonoDomain *domain, char **argv, int argc, guint32 opts
 	while (g_hash_table_iter_next (&iter, (gpointer *) &assem, NULL)) {
 		g_assert (!aot_state->collecting_callee_failures);
 
-		int res = mono_compile_assembly (assem, opts, aot_options, (gpointer) &aot_state);
+		int res = mono_compile_assembly (assem, opts, aot_options, (gpointer **) &aot_state);
 
 		if (!aot_opts.disable_direct_external_calls)
 			mono_write_callee_failures (aot_state->exported_method_failures, assem->image);

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -13570,6 +13570,10 @@ mono_compile_assemblies (MonoDomain *domain, char **argv, int argc, guint32 opts
 		g_assert (!aot_state->collecting_callee_failures);
 
 		int res = mono_compile_assembly (assem, opts, aot_options, (gpointer) &aot_state);
+
+		if (!aot_opts.disable_direct_external_calls)
+			mono_write_callee_failures (aot_state->exported_method_failures, assem->image);
+
 		if (res != 0) {
 			fprintf (stderr, "Deferred AOT of image %s failed.\n", assem->image->name);
 			exit (1);

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -13214,7 +13214,8 @@ mono_read_string_set (char *filename, GHashTable *out_table, gpointer sentinel, 
 	}
 
 cleanup:
-	fclose (cache);
+	if (cache)
+		fclose (cache);
 	return success;
 
 fail:

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -8193,6 +8193,11 @@ mono_aot_parse_options (const char *aot_options, MonoAotOptions *opts)
 		opts->nunbox_arbitrary_trampolines = 0;
 	}
 
+#ifndef MONO_DYNAMIC_AOT_DIRECT_CALLS
+	if (!opts->static_link)
+		opts->disable_direct_external_calls = TRUE;
+#endif
+
 	g_ptr_array_free (args, /*free_seg=*/TRUE);
 }
 
@@ -12072,6 +12077,7 @@ compile_asm (MonoAotCompile *acfg)
 #elif defined(TARGET_AMD64) && defined(TARGET_MACH)
 #define LD_NAME "clang"
 #define LD_OPTIONS "-undefined dynamic_lookup --shared"
+#define MONO_DYNAMIC_AOT_DIRECT_CALLS TRUE
 #elif defined(TARGET_WIN32_MSVC)
 #define LD_NAME "link.exe"
 #define LD_OPTIONS "/DLL /MACHINE:X64 /NOLOGO /INCREMENTAL:NO"
@@ -12081,7 +12087,8 @@ compile_asm (MonoAotCompile *acfg)
 #define LD_OPTIONS "-shared"
 #elif defined(TARGET_X86) && defined(TARGET_MACH)
 #define LD_NAME "clang"
-#define LD_OPTIONS "-m32 -dynamiclib"
+#define LD_OPTIONS "-undefined dynamic_lookup -m32 -dynamiclib"
+#define MONO_DYNAMIC_AOT_DIRECT_CALLS TRUE
 #elif defined(TARGET_X86) && !defined(TARGET_MACH)
 #define LD_OPTIONS "-m elf_i386"
 #elif defined(TARGET_ARM) && !defined(TARGET_ANDROID)

--- a/mono/mini/aot-compiler.h
+++ b/mono/mini/aot-compiler.h
@@ -8,6 +8,7 @@
 #include "mini.h"
 
 int mono_compile_assembly (MonoAssembly *ass, guint32 opts, const char *aot_options, gpointer **aot_state);
+int mono_compile_assemblies (MonoDomain *domain, char **argv, int argc, guint32 opts, const char *aot_options);
 int mono_compile_deferred_assemblies (guint32 opts, const char *aot_options, gpointer **aot_state);
 void* mono_aot_readonly_field_override (MonoClassField *field);
 gboolean mono_aot_direct_icalls_enabled_for_method (MonoCompile *cfg, MonoMethod *method);
@@ -16,6 +17,9 @@ gboolean mono_aot_is_shared_got_offset (int offset) MONO_LLVM_INTERNAL;
 guint32  mono_aot_get_got_offset            (MonoJumpInfo *ji) MONO_LLVM_INTERNAL;
 char*    mono_aot_get_method_name           (MonoCompile *cfg) MONO_LLVM_INTERNAL;
 char*    mono_aot_get_mangled_method_name   (MonoMethod *method) MONO_LLVM_INTERNAL;
+gboolean mono_aot_can_directly_call         (MonoMethod *method) MONO_LLVM_INTERNAL;
+void     mono_aot_register_llvm_failure     (MonoMethod *method) MONO_LLVM_INTERNAL;
+gboolean mono_aot_has_external_symbol       (MonoMethod *method) MONO_LLVM_INTERNAL;
 gboolean mono_aot_is_direct_callable        (MonoJumpInfo *patch_info) MONO_LLVM_INTERNAL;
 void     mono_aot_mark_unused_llvm_plt_entry(MonoJumpInfo *patch_info) MONO_LLVM_INTERNAL;
 char*    mono_aot_get_plt_symbol            (MonoJumpInfoType type, gconstpointer data) MONO_LLVM_INTERNAL;

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -1346,40 +1346,7 @@ static void main_thread_handler (gpointer user_data)
 	MonoAssembly *assembly;
 
 	if (mono_compile_aot) {
-		int i, res;
-		gpointer *aot_state = NULL;
-
-		/* Treat the other arguments as assemblies to compile too */
-		for (i = 0; i < main_args->argc; ++i) {
-			assembly = mono_domain_assembly_open (main_args->domain, main_args->argv [i]);
-			if (!assembly) {
-				fprintf (stderr, "Can not open image %s\n", main_args->argv [i]);
-				exit (1);
-			}
-			/* Check that the assembly loaded matches the filename */
-			{
-				MonoImageOpenStatus status;
-				MonoImage *img;
-
-				img = mono_image_open (main_args->argv [i], &status);
-				if (img && strcmp (img->name, assembly->image->name)) {
-					fprintf (stderr, "Error: Loaded assembly '%s' doesn't match original file name '%s'. Set MONO_PATH to the assembly's location.\n", assembly->image->name, img->name);
-					exit (1);
-				}
-			}
-			res = mono_compile_assembly (assembly, main_args->opts, main_args->aot_options, &aot_state);
-			if (res != 0) {
-				fprintf (stderr, "AOT of image %s failed.\n", main_args->argv [i]);
-				exit (1);
-			}
-		}
-		if (aot_state) {
-			res = mono_compile_deferred_assemblies (main_args->opts, main_args->aot_options, &aot_state);
-			if (res != 0) {
-				fprintf (stderr, "AOT of mode-specific deferred assemblies failed.\n");
-				exit (1);
-			}
-		}
+		mono_compile_assemblies (main_args->domain, main_args->argv, main_args->argc, main_args->opts, main_args->aot_options);
 	} else {
 		assembly = mono_domain_assembly_open (main_args->domain, main_args->file);
 		if (!assembly){

--- a/mono/mini/mini-llvm-cpp.cpp
+++ b/mono/mini/mini-llvm-cpp.cpp
@@ -462,6 +462,18 @@ mono_llvm_add_func_attr (LLVMValueRef func, AttrKind kind)
 #endif
 }
 
+LLVMTypeRef
+mono_llvm_get_function_type (LLVMValueRef func)
+{
+	return wrap (unwrap<Function>(func)->getFunctionType ());
+}
+
+LLVMTypeRef
+mono_llvm_get_ptr_dst_type (LLVMTypeRef ptr)
+{
+	return wrap (unwrap<PointerType>(ptr)->getElementType ());
+}
+
 void
 mono_llvm_add_param_attr (LLVMValueRef param, AttrKind kind)
 {

--- a/mono/mini/mini-llvm-cpp.h
+++ b/mono/mini/mini-llvm-cpp.h
@@ -130,6 +130,12 @@ mono_llvm_set_call_noalias_ret (LLVMValueRef wrapped_calli);
 void
 mono_llvm_add_func_attr (LLVMValueRef func, AttrKind kind);
 
+LLVMTypeRef
+mono_llvm_get_function_type (LLVMValueRef func);
+
+LLVMTypeRef
+mono_llvm_get_ptr_dst_type (LLVMTypeRef ptr);
+
 void
 mono_llvm_add_param_attr (LLVMValueRef param, AttrKind kind);
 

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -7498,12 +7498,6 @@ is_externally_callable (EmitContext *ctx, MonoMethod *method)
 	return FALSE;
 }
 
-void
-mono_llvm_register_failure (MonoCompile *cfg)
-{
-	mono_aot_register_llvm_failure (cfg->method);
-}
-
 /*
  * mono_llvm_emit_method:
  *

--- a/mono/mini/mini-llvm.h
+++ b/mono/mini/mini-llvm.h
@@ -33,6 +33,7 @@ MONO_API void mono_personality              (void);
 int      mono_llvm_load                     (const char* bpath);
 void     mono_llvm_create_vars (MonoCompile *cfg) MONO_LLVM_INTERNAL;
 void     mono_llvm_fixup_aot_module         (void) MONO_LLVM_INTERNAL;
+void     mono_llvm_register_failure         (MonoCompile *cfg) MONO_LLVM_INTERNAL;
 
 gboolean mini_llvm_init                     (void);
 

--- a/mono/mini/mini-llvm.h
+++ b/mono/mini/mini-llvm.h
@@ -33,7 +33,6 @@ MONO_API void mono_personality              (void);
 int      mono_llvm_load                     (const char* bpath);
 void     mono_llvm_create_vars (MonoCompile *cfg) MONO_LLVM_INTERNAL;
 void     mono_llvm_fixup_aot_module         (void) MONO_LLVM_INTERNAL;
-void     mono_llvm_register_failure         (MonoCompile *cfg) MONO_LLVM_INTERNAL;
 
 gboolean mini_llvm_init                     (void);
 

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -3286,6 +3286,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 					cfg->disable_aot = TRUE;
 					return cfg;
 				}
+				mono_llvm_register_failure (cfg);
 				mono_destroy_compile (cfg);
 				try_llvm = FALSE;
 				goto restart_compile;
@@ -3460,6 +3461,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 					MONO_PROBE_METHOD_COMPILE_END (method, FALSE);
 				return cfg;
 			}
+			mono_llvm_register_failure (cfg);
 			mono_destroy_compile (cfg);
 			try_generic_shared = FALSE;
 			goto restart_compile;

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -80,6 +80,7 @@
 #include "mini-llvm.h"
 #include "lldb.h"
 #include "aot-runtime.h"
+#include "aot-compiler.h"
 #include "mini-runtime.h"
 
 MonoCallSpec *mono_jit_trace_calls;
@@ -3286,7 +3287,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 					cfg->disable_aot = TRUE;
 					return cfg;
 				}
-				mono_llvm_register_failure (cfg);
+				mono_aot_register_llvm_failure (cfg->method);
 				mono_destroy_compile (cfg);
 				try_llvm = FALSE;
 				goto restart_compile;
@@ -3461,7 +3462,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFl
 					MONO_PROBE_METHOD_COMPILE_END (method, FALSE);
 				return cfg;
 			}
-			mono_llvm_register_failure (cfg);
+			mono_aot_register_llvm_failure (cfg->method);
 			mono_destroy_compile (cfg);
 			try_generic_shared = FALSE;
 			goto restart_compile;


### PR DESCRIPTION
After much debugging, I've got an initial prototype for direct cross-aot-module calls. 

## Big Picture
Right now, every AOT'ed method call from one assembly to another goes through a layer of indirection.

This indirection leads to a number of performance issues. The need to lazily initialize references is a drain on latency and startup time, and repeated indirection calls introduces a need to keep many, many function addresses kept in L1/L2 cache in order to not continually stall on the access to the function pointer.

This PR tries to introduce direct calls. Doing so is very simple, we only need to change the linkage of a symbol. The hard parts come from figuring out which methods cannot be called directly, and failing gracefully.

## Linking Options
Since we're emitting direct OS-visible calls between AOT modules, we have some flexibility with how the OS links them together. We will want to use this flexibility in some places. 

On the desktop (dynamic linking) AOT scenario, I am using clang's ability to resolve undefined references at runtime. The external symbol name referenced by the native binary made by the AOT compile will be undefined. When we call it, the OS will look for the actual symbol and will patch it into process such that the symbol references it. I'm sure that this could be faster, but it seems pretty quick.

In the static scenario, all of these direct calls can simply be linked away into references to the actual function address.

## Tech Debt
Right now we're not using this infrastructure as much as can be used.

This disables a lot of possible calls for the reason that they are `beforefieldinit`. When allowed to directly call, there's a ton of crashes due to what seems like clearly calling the wrong callee or passing the wrong args. 

There's good statistic tracking to watch and fix these in later PRs though.

## Stats 
The following table is emitted with `--aot=stats` :

```

Call indirection stats:
    Direct Calls Made: 4
    Indirection Cause: Wrappers Count: 317
    Indirection Cause: Static Ctor Count: 149
    Indirection Cause: BeginInvoke Count: 2
    Indirection Cause: Duplicated Count: 6871
    Indirection Cause: BeforeFieldInit Count: 12734
    Indirection Cause: PrivateImpl Count: 2

```

## Caching

The idea behind the caching is to amortize the compilation. We have inescapable wasted work if we want to preserve parallel AOTing of all assemblies in the assembly reference graph.

It's important to be able to shadow-compile (see if we'd fail to compile by doing IR transformation steps without emitting code) an assembly to be able to see what we fail to compile. Otherwise, we force churn on the embedder that is everything from AOT dependency ordering to concurrency-vs-wasted-work tradeoffs. These are easier to handle on our end, from within the runtime. AOT interface churn can be very painful, as it involves having to set up dependencies between the emitted AOT files that mirror the dependencies between the source Assemblies. 

We therefore shadow-compile Assemblies when they're referenced *and* when they're normally compiled. 

This means that if System's nunit test assembly has a reference to mscorlib.dll, and mscorlib.dll has been AOT'ed before System, we will use the cached failure file. 

It also means that if two test assemblies reference the same mscorlib.dll, the AOT of both of them won't have to duplicate the step of checking which compilation failures will happen in mscorlib.dll

The caching amortizes the shadow compilation, providing theoretic running-time bounds that are much better than the combinatorial explosion of every AOT step having to re-AOT every method in every assembly that is referenced.

## Testing

Build any AOT profile with LLVM and you should see this enabled. CI here will test this. This is disabled on Linux in the non static linking scenario, but Wasm will enable it and OSX will run with it by default (using the clang runtime dynamic loading mechanism).

The idea is to have it enabled by default on the desktop, static scenarios, wasm, etc. This is tested by the BCL tests, and minor mistakes lead to easy-to-spot failures (missing symbol lookups or calling the wrong callee and crashing after stack corruption).

