### PR TITLE
[2019-04] Usually do not create a handle in mono_runtime_invoke_handle.

### DIFF
--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -1497,7 +1497,7 @@ mono_domain_fire_assembly_load (MonoAssembly *assembly, gpointer user_data)
 
 	void *params [1];
 	params [0] = MONO_HANDLE_RAW (reflection_assembly);
-	mono_runtime_invoke_handle (assembly_load_method, appdomain, params, error);
+	mono_runtime_invoke_handle_void (assembly_load_method, appdomain, params, error);
 leave:
 	mono_error_cleanup (error);
 	HANDLE_FUNCTION_RETURN ();

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -856,7 +856,7 @@ create_custom_attr (MonoImage *image, MonoMethod *method, const guchar *data, gu
 		attr = mono_object_new_handle (mono_domain_get (), method->klass, error);
 		goto_if_nok (error, fail);
 
-		mono_runtime_invoke_handle (method, attr, NULL, error);
+		mono_runtime_invoke_handle_void (method, attr, NULL, error);
 		goto_if_nok (error, fail);
 
 		goto exit;
@@ -1456,7 +1456,7 @@ create_custom_attr_data (MonoImage *image, MonoCustomAttrEntry *cattr, MonoError
 	params [2] = &cattr->data;
 	params [3] = &cattr->data_size;
 
-	mono_runtime_invoke_handle (ctor, attr, params, error);
+	mono_runtime_invoke_handle_void (ctor, attr, params, error);
 	goto fail;
 result_null:
 	attr = MONO_HANDLE_CAST (MonoObject, mono_new_null ());

--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -202,7 +202,7 @@ create_exception_two_strings (MonoClass *klass, MonoStringHandle a1, MonoStringH
 
 	gpointer args [ ] = { MONO_HANDLE_RAW (a1), MONO_HANDLE_RAW (a2) };
 
-	mono_runtime_invoke_handle (method, o, args, error);
+	mono_runtime_invoke_handle_void (method, o, args, error);
 	if (!is_ok (error))
 		o = mono_new_null ();
 
@@ -856,7 +856,7 @@ mono_get_exception_type_initialization_handle (const gchar *type_name, MonoExcep
 	MonoObjectHandle exc = mono_object_new_handle (domain, klass, error);
 	mono_error_assert_ok (error);
 
-	mono_runtime_invoke_handle (method, exc, args, error);
+	mono_runtime_invoke_handle_void (method, exc, args, error);
 	goto_if_nok (error, return_null);
 	goto exit;
 return_null:
@@ -1100,7 +1100,7 @@ mono_get_exception_runtime_wrapped_handle (MonoObjectHandle wrapped_exception, M
 
 	gpointer args [ ] = { MONO_HANDLE_RAW (wrapped_exception) };
 
-	mono_runtime_invoke_handle (method, o, args, error);
+	mono_runtime_invoke_handle_void (method, o, args, error);
 	goto_if_nok (error, return_null);
 	goto exit;
 return_null:

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -5173,7 +5173,7 @@ ves_icall_System_Runtime_InteropServices_Marshal_StructureToPtr (MonoObjectHandl
 
 	gpointer pa [ ] = { MONO_HANDLE_RAW (obj), &dst, &delete_old };
 
-	mono_runtime_invoke_handle (method, NULL_HANDLE, pa, error);
+	mono_runtime_invoke_handle_void (method, NULL_HANDLE, pa, error);
 }
 
 static void
@@ -5956,7 +5956,7 @@ mono_marshal_asany_impl (MonoObjectHandle o, MonoMarshalNative string_encoding, 
 			MonoBoolean delete_old = FALSE;
 			gpointer pa [ ] = { MONO_HANDLE_RAW (o), &res, &delete_old };
 
-			mono_runtime_invoke_handle (method, NULL_HANDLE, pa, error);
+			mono_runtime_invoke_handle_void (method, NULL_HANDLE, pa, error);
 			return_val_if_nok (error, NULL);
 		}
 

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -140,7 +140,7 @@ mono_runtime_object_init_handle (MonoObjectHandle this_obj, MonoError *error)
 		mono_runtime_invoke_checked (method, raw, NULL, error);
 		mono_gchandle_free_internal (gchandle);
 	} else {
-		mono_runtime_invoke_handle (method, this_obj, NULL, error);
+		mono_runtime_invoke_handle_void (method, this_obj, NULL, error);
 	}
 
 	return is_ok (error);
@@ -4828,7 +4828,7 @@ create_unhandled_exception_eventargs (MonoObjectHandle exc, MonoError *error)
 	obj = mono_object_new_handle (mono_domain_get (), klass, error);
 	goto_if_nok (error, return_null);
 
-	mono_runtime_invoke_handle (method, obj, args, error);
+	mono_runtime_invoke_handle_void (method, obj, args, error);
 	goto_if_nok (error, return_null);
 	return obj;
 

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -1042,7 +1042,7 @@ add_parameter_object_to_array (MonoDomain *domain, MonoMethod *method, MonoObjec
 	args [5] = MONO_HANDLE_RAW (member);
 	args [6] = MONO_HANDLE_RAW (mobj);
 
-	mono_runtime_invoke_handle (ctor, MONO_HANDLE_CAST (MonoObject, param), args, error);
+	mono_runtime_invoke_handle_void (ctor, MONO_HANDLE_CAST (MonoObject, param), args, error);
 	goto_if_nok (error, leave);
 
 	MONO_HANDLE_ARRAY_SETREF (dest, idx, param);
@@ -1350,7 +1350,7 @@ method_body_object_construct (MonoDomain *domain, MonoClass *unused_class, MonoM
 	params [3] = &init_locals_param;
 	params [4] = &sig_token_param;
 	params [5] = &max_stack_param;
-	mono_runtime_invoke_handle (ctor, MONO_HANDLE_CAST (MonoObject, ret), params, error);
+	mono_runtime_invoke_handle_void (ctor, MONO_HANDLE_CAST (MonoObject, ret), params, error);
 	mono_error_assert_ok (error);
 
 	return ret;


### PR DESCRIPTION
Use mono_runtime_invoke_handle_void instead.


Backport of #14404.

/cc @lewurm @jaykrell