### PR TITLE
Add log profiler support to Mono MSVC build.

### DIFF
--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -4,6 +4,7 @@
  * Authors:
  *   Paolo Molaro (lupus@ximian.com)
  *   Alex Rønne Petersen (alexrp@xamarin.com)
+ *   Johan Lorensson (lateralusx.github@gmail.com)
  *
  * Copyright 2010 Novell, Inc (http://www.novell.com)
  * Copyright 2011 Xamarin Inc (http://www.xamarin.com)
@@ -60,13 +61,26 @@
 #if defined(__APPLE__)
 #include <mach/mach_time.h>
 #endif
+#ifndef HOST_WIN32
 #include <netinet/in.h>
+#endif
 #ifdef HAVE_SYS_MMAN_H
 #include <sys/mman.h>
 #endif
+#ifndef HOST_WIN32
 #include <sys/socket.h>
+#endif
 #if defined (HAVE_SYS_ZLIB)
 #include <zlib.h>
+#endif
+
+#ifdef HOST_WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#endif
+
+#ifndef HOST_WIN32
+#define HAVE_COMMAND_PIPES 1
 #endif
 
 // Statistics for internal profiler data structures.
@@ -298,7 +312,12 @@ struct _MonoProfiler {
 	int pipe_output;
 	int command_port;
 	int server_socket;
+
+#ifdef HAVE_COMMAND_PIPES
 	int pipes [2];
+#else
+	int pipe_command;
+#endif
 
 	MonoLinkedListSet profiler_thread_list;
 	volatile gint32 buffer_lock_state;
@@ -2863,12 +2882,62 @@ cleanup_reusable_samples (void)
 }
 
 static void
+close_socket_fd (int fd)
+{
+#ifdef HOST_WIN32
+	closesocket (fd);
+#else
+	close (fd);
+#endif
+}
+
+static void
 signal_helper_thread (char c)
 {
+#ifdef HAVE_COMMAND_PIPES
 	if (write (log_profiler.pipes [1], &c, 1) != 1) {
 		mono_profiler_printf_err ("Could not write to log profiler pipe: %s", g_strerror (errno));
 		exit (1);
 	}
+#else
+	/*
+	* On Windows we can't use pipes together with sockets in select. Instead of
+	* re-writing the whole logic, the Windows implementation will replace use of command pipe
+	* with simple command buffer and a dummy connect to localhost, making sure
+	* helper thread will pick up command and process is. Since the dummy connection will
+	* be closed right away by client, it will be discarded by helper thread.
+	*/
+	mono_atomic_store_i32(&log_profiler.pipe_command, c);
+
+	SOCKET client_socket;
+	client_socket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+	if (client_socket != INVALID_SOCKET) {
+		struct sockaddr_in client_addr;
+		client_addr.sin_family = AF_INET;
+		client_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+		client_addr.sin_port = htons(log_profiler.command_port);
+
+		gulong non_blocking = 1;
+		ioctlsocket (client_socket, FIONBIO, &non_blocking);
+		if (connect (client_socket, (SOCKADDR *)&client_addr, sizeof (client_addr)) == SOCKET_ERROR) {
+			if (WSAGetLastError () == WSAEWOULDBLOCK) {
+				fd_set wfds;
+				int max_fd = -1;
+
+				FD_ZERO (&wfds);
+				FD_SET (client_socket, &wfds);
+
+				/*
+				* Include timeout to prevent hanging on connect call.
+				*/
+				struct timeval tv = { .tv_sec = 1, .tv_usec = 0 };
+				select (client_socket + 1, NULL, &wfds, NULL, &tv);
+			}
+		}
+
+		close_socket_fd (client_socket);
+	}
+#endif
 }
 
 static void
@@ -2994,6 +3063,14 @@ log_shutdown (MonoProfiler *prof)
 	mono_coop_mutex_destroy (&log_profiler.api_mutex);
 
 	g_free (prof->args);
+
+#ifdef HOST_WIN32
+	/*
+	* We depend on socket support in this profiler provider we need to
+	* make sure we keep a reference on WSA for the lifetime of this provider.
+	*/
+	WSACleanup ();
+#endif
 }
 
 static char*
@@ -3152,7 +3229,10 @@ helper_thread (void *arg)
 		FD_ZERO (&rfds);
 
 		add_to_fd_set (&rfds, log_profiler.server_socket, &max_fd);
+
+#ifdef HAVE_COMMAND_PIPES
 		add_to_fd_set (&rfds, log_profiler.pipes [0], &max_fd);
+#endif
 
 		for (gint i = 0; i < command_sockets->len; i++)
 			add_to_fd_set (&rfds, g_array_index (command_sockets, int, i), &max_fd);
@@ -3178,14 +3258,24 @@ helper_thread (void *arg)
 		buffer_unlock_excl ();
 
 		// Did we get a shutdown or detach signal?
+#ifdef HAVE_COMMAND_PIPES
 		if (FD_ISSET (log_profiler.pipes [0], &rfds)) {
 			char c;
-
 			read (log_profiler.pipes [0], &c, 1);
-
 			if (c == 1)
 				break;
 		}
+#else
+		int value = mono_atomic_load_i32(&log_profiler.pipe_command);
+		if (value != 0) {
+			while (mono_atomic_cas_i32 (&log_profiler.pipe_command, 0, value) != value)
+				value = mono_atomic_load_i32(&log_profiler.pipe_command);
+
+			char c = (char)value;
+			if (c == 1)
+				break;
+		}
+#endif
 
 		for (gint i = 0; i < command_sockets->len; i++) {
 			int fd = g_array_index (command_sockets, int, i);
@@ -3194,15 +3284,18 @@ helper_thread (void *arg)
 				continue;
 
 			char buf [64];
+#ifdef HOST_WIN32
+			int len = recv (fd, buf, sizeof (buf) - 1, 0);
+#else
 			int len = read (fd, buf, sizeof (buf) - 1);
-
+#endif
 			if (len == -1)
 				continue;
 
 			if (!len) {
 				// The other end disconnected.
 				g_array_remove_index (command_sockets, i);
-				close (fd);
+				close_socket_fd (fd);
 
 				continue;
 			}
@@ -3218,7 +3311,7 @@ helper_thread (void *arg)
 
 			if (fd != -1) {
 				if (fd >= FD_SETSIZE)
-					close (fd);
+					close_socket_fd (fd);
 				else
 					g_array_append_val (command_sockets, fd);
 			}
@@ -3228,7 +3321,7 @@ helper_thread (void *arg)
 	}
 
 	for (gint i = 0; i < command_sockets->len; i++)
-		close (g_array_index (command_sockets, int, i));
+		close_socket_fd (g_array_index (command_sockets, int, i));
 
 	g_array_free (command_sockets, TRUE);
 
@@ -3240,10 +3333,12 @@ helper_thread (void *arg)
 static void
 start_helper_thread (void)
 {
+#ifdef HAVE_COMMAND_PIPES
 	if (pipe (log_profiler.pipes) == -1) {
 		mono_profiler_printf_err ("Could not create log profiler pipe: %s", g_strerror (errno));
 		exit (1);
 	}
+#endif
 
 	log_profiler.server_socket = socket (PF_INET, SOCK_STREAM, 0);
 
@@ -3261,13 +3356,13 @@ start_helper_thread (void)
 
 	if (bind (log_profiler.server_socket, (struct sockaddr *) &server_address, sizeof (server_address)) == -1) {
 		mono_profiler_printf_err ("Could not bind log profiler server socket on port %d: %s", log_profiler.command_port, g_strerror (errno));
-		close (log_profiler.server_socket);
+		close_socket_fd (log_profiler.server_socket);
 		exit (1);
 	}
 
 	if (listen (log_profiler.server_socket, 1) == -1) {
 		mono_profiler_printf_err ("Could not listen on log profiler server socket: %s", g_strerror (errno));
-		close (log_profiler.server_socket);
+		close_socket_fd (log_profiler.server_socket);
 		exit (1);
 	}
 
@@ -3275,7 +3370,7 @@ start_helper_thread (void)
 
 	if (getsockname (log_profiler.server_socket, (struct sockaddr *) &server_address, &slen)) {
 		mono_profiler_printf_err ("Could not retrieve assigned port for log profiler server socket: %s", g_strerror (errno));
-		close (log_profiler.server_socket);
+		close_socket_fd (log_profiler.server_socket);
 		exit (1);
 	}
 
@@ -3283,7 +3378,7 @@ start_helper_thread (void)
 
 	if (!mono_native_thread_create (&log_profiler.helper_thread, helper_thread, NULL)) {
 		mono_profiler_printf_err ("Could not start log profiler helper thread");
-		close (log_profiler.server_socket);
+		close_socket_fd (log_profiler.server_socket);
 		exit (1);
 	}
 }
@@ -3889,6 +3984,20 @@ proflog_icall_SetJitEvents (MonoBoolean value)
 static void
 runtime_initialized (MonoProfiler *profiler)
 {
+#ifdef HOST_WIN32
+	/*
+	* We depend on socket support in this profiler provider we need to
+	* make sure we keep a reference on WSA for the lifetime of this provider.
+	*/
+	WSADATA wsadata;
+	int err;
+
+	err = WSAStartup (2 /* 2.0 */, &wsadata);
+	if (err) {
+		mono_profiler_printf_err ("Couldn't initialise networking.");
+		exit (1);
+	}
+#endif
 	mono_atomic_store_i32 (&log_profiler.runtime_inited, 1);
 
 	register_counter ("Sample events allocated", &sample_allocations_ctr);

--- a/mono/utils/Makefile.am
+++ b/mono/utils/Makefile.am
@@ -42,7 +42,8 @@ endif
 if HOST_WIN32
 win32_sources = \
 	os-event-win32.c \
-	mono-os-wait-win32.c
+	mono-os-wait-win32.c \
+	mono-os-semaphore-win32.c
 
 platform_sources = $(win32_sources)
 else

--- a/mono/utils/mono-os-semaphore-win32.c
+++ b/mono/utils/mono-os-semaphore-win32.c
@@ -1,0 +1,37 @@
+/**
+ * \file
+ * MonoOSSemaphore on Win32
+ *
+ * Author:
+ *	Ludovic Henry (luhenry@microsoft.com)
+ *
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+#include "mono-os-semaphore.h"
+
+MonoSemTimedwaitRet
+mono_os_sem_timedwait (MonoSemType *sem, guint32 timeout_ms, MonoSemFlags flags)
+{
+	BOOL res;
+
+retry:
+	res = mono_win32_wait_for_single_object_ex (*sem, timeout_ms, flags & MONO_SEM_FLAGS_ALERTABLE);
+	if (G_UNLIKELY (res != WAIT_OBJECT_0 && res != WAIT_IO_COMPLETION && res != WAIT_TIMEOUT))
+		g_error ("%s: mono_win32_wait_for_single_object_ex failed with error %d", __func__, GetLastError ());
+
+	if (res == WAIT_IO_COMPLETION && !(flags & MONO_SEM_FLAGS_ALERTABLE))
+		goto retry;
+
+	switch (res) {
+	case WAIT_OBJECT_0:
+		return MONO_SEM_TIMEDWAIT_RET_SUCCESS;
+	case WAIT_IO_COMPLETION:
+		return MONO_SEM_TIMEDWAIT_RET_ALERTED;
+	case WAIT_TIMEOUT:
+		return MONO_SEM_TIMEDWAIT_RET_TIMEDOUT;
+	default:
+		g_assert_not_reached ();
+	}
+}
+

--- a/mono/utils/mono-os-semaphore.h
+++ b/mono/utils/mono-os-semaphore.h
@@ -280,6 +280,8 @@ mono_os_sem_post (MonoSemType *sem)
 
 #else
 
+#include <mono/utils/mono-compiler.h>
+
 typedef HANDLE MonoSemType;
 
 static inline void
@@ -305,30 +307,8 @@ mono_os_sem_destroy (MonoSemType *sem)
 		g_error ("%s: CloseHandle failed with error %d", __func__, GetLastError ());
 }
 
-static inline MonoSemTimedwaitRet
-mono_os_sem_timedwait (MonoSemType *sem, guint32 timeout_ms, MonoSemFlags flags)
-{
-	BOOL res;
-
-retry:
-	res = mono_win32_wait_for_single_object_ex (*sem, timeout_ms, flags & MONO_SEM_FLAGS_ALERTABLE);
-	if (G_UNLIKELY (res != WAIT_OBJECT_0 && res != WAIT_IO_COMPLETION && res != WAIT_TIMEOUT))
-		g_error ("%s: mono_win32_wait_for_single_object_ex failed with error %d", __func__, GetLastError ());
-
-	if (res == WAIT_IO_COMPLETION && !(flags & MONO_SEM_FLAGS_ALERTABLE))
-		goto retry;
-
-	switch (res) {
-	case WAIT_OBJECT_0:
-		return MONO_SEM_TIMEDWAIT_RET_SUCCESS;
-	case WAIT_IO_COMPLETION:
-		return MONO_SEM_TIMEDWAIT_RET_ALERTED;
-	case WAIT_TIMEOUT:
-		return MONO_SEM_TIMEDWAIT_RET_TIMEDOUT;
-	default:
-		g_assert_not_reached ();
-	}
-}
+MONO_PROFILER_API MonoSemTimedwaitRet
+mono_os_sem_timedwait (MonoSemType *sem, guint32 timeout_ms, MonoSemFlags flags);
 
 static inline int
 mono_os_sem_wait (MonoSemType *sem, MonoSemFlags flags)

--- a/msvc/libmonoutils-win32.targets
+++ b/msvc/libmonoutils-win32.targets
@@ -3,5 +3,6 @@
   <ItemGroup Label="win32_sources">
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\os-event-win32.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-os-wait-win32.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-os-semaphore-win32.c" />
   </ItemGroup>
 </Project>

--- a/msvc/libmonoutils-win32.targets.filters
+++ b/msvc/libmonoutils-win32.targets.filters
@@ -7,6 +7,9 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-os-wait-win32.c">
       <Filter>Source Files$(MonoUtilsFilterSubFolder)\win32</Filter>
     </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-os-semaphore-win32.c">
+      <Filter>Source Files$(MonoUtilsFilterSubFolder)\win32</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Source Files$(MonoUtilsFilterSubFolder)\win32">

--- a/msvc/mono-profiler-log.vcxproj
+++ b/msvc/mono-profiler-log.vcxproj
@@ -1,0 +1,174 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{8C02A728-7A50-43CE-B507-BDFC05B7EA94}</ProjectGuid>
+    <RootNamespace>mono-profiler-log</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="mono.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="mono.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="mono.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="mono.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">mono-profiler-log</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">mono-profiler-log</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">mono-profiler-log</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">mono-profiler-log</TargetName>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(MONO_BUILD_DIR_PREFIX)$(Platform)\bin\$(Configuration)\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(MONO_BUILD_DIR_PREFIX)$(Platform)\bin\$(Configuration)\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(MONO_BUILD_DIR_PREFIX)$(Platform)\bin\$(Configuration)\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(MONO_BUILD_DIR_PREFIX)$(Platform)\bin\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(MONO_BUILD_DIR_PREFIX)$(Platform)\obj\$(ProjectName)$(MONO_TARGET_SUFFIX)\$(Configuration)\</IntDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(MONO_BUILD_DIR_PREFIX)$(Platform)\obj\$(ProjectName)$(MONO_TARGET_SUFFIX)\$(Configuration)\</IntDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(MONO_BUILD_DIR_PREFIX)$(Platform)\obj\$(ProjectName)$(MONO_TARGET_SUFFIX)\$(Configuration)\</IntDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(MONO_BUILD_DIR_PREFIX)$(Platform)\obj\$(ProjectName)$(MONO_TARGET_SUFFIX)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;MONO_DLL_EXPORT;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(GLIB_CFLAGS_INCLUDE);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <StringPooling>true</StringPooling>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>$(MONO_LIBMONO_LIB);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;MONO_DLL_EXPORT;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <WarningLevel>Level3</WarningLevel>
+      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(GLIB_CFLAGS_INCLUDE);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <StringPooling>true</StringPooling>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>$(MONO_LIBMONO_LIB);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(GLIB_CFLAGS_INCLUDE);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;MONO_DLL_EXPORT;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <WarningLevel>Level3</WarningLevel>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>$(MONO_LIBMONO_LIB);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(MONO_DIR);$(MONO_INCLUDE_DIR);$(GLIB_CFLAGS_INCLUDE);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;MONO_DLL_EXPORT;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <WarningLevel>Level3</WarningLevel>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>$(MONO_LIBMONO_LIB);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\mono\profiler\log-args.c" />
+    <ClCompile Include="..\mono\profiler\log.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="eglib.vcxproj">
+      <Project>{158073ed-99ae-4196-9edc-ddb2344f8466}</Project>
+    </ProjectReference>
+    <ProjectReference Include="libmono-dynamic.vcxproj">
+      <Project>{675f4175-ffb1-480d-ad36-f397578844d4}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\mono\profiler\log.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/msvc/mono-profiler-log.vcxproj.filters
+++ b/msvc/mono-profiler-log.vcxproj.filters
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{BD730379-6140-4E93-8B3B-9DD624E75542}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{118A98DC-B9FE-4B14-B20E-0DFBFBE084BA}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{84C17491-B180-444E-BFF3-1846DE426B13}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\mono\profiler\log.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mono\profiler\log-args.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\mono\profiler\log.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/msvc/mono.sln
+++ b/msvc/mono.sln
@@ -208,6 +208,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "build-external-llvm", "buil
 		{92AE7622-5F58-4234-9A26-9EC71876B3F4} = {92AE7622-5F58-4234-9A26-9EC71876B3F4}
 	EndProjectSection
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mono-profiler-log", "mono-profiler-log.vcxproj", "{8C02A728-7A50-43CE-B507-BDFC05B7EA94}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
@@ -432,6 +434,14 @@ Global
 		{C3D4C623-55F8-4653-980D-61AA629B4E1D}.Release|Win32.Build.0 = Release|Win32
 		{C3D4C623-55F8-4653-980D-61AA629B4E1D}.Release|x64.ActiveCfg = Release|x64
 		{C3D4C623-55F8-4653-980D-61AA629B4E1D}.Release|x64.Build.0 = Release|x64
+		{8C02A728-7A50-43CE-B507-BDFC05B7EA94}.Debug|Win32.ActiveCfg = Debug|Win32
+		{8C02A728-7A50-43CE-B507-BDFC05B7EA94}.Debug|Win32.Build.0 = Debug|Win32
+		{8C02A728-7A50-43CE-B507-BDFC05B7EA94}.Debug|x64.ActiveCfg = Debug|x64
+		{8C02A728-7A50-43CE-B507-BDFC05B7EA94}.Debug|x64.Build.0 = Debug|x64
+		{8C02A728-7A50-43CE-B507-BDFC05B7EA94}.Release|Win32.ActiveCfg = Release|Win32
+		{8C02A728-7A50-43CE-B507-BDFC05B7EA94}.Release|Win32.Build.0 = Release|Win32
+		{8C02A728-7A50-43CE-B507-BDFC05B7EA94}.Release|x64.ActiveCfg = Release|x64
+		{8C02A728-7A50-43CE-B507-BDFC05B7EA94}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -471,11 +481,12 @@ Global
 		{675F4175-FFB1-480D-AD36-F397578844D4} = {DE3617B4-17A8-4E5F-A00F-BA43D956881F}
 		{E41DDF41-0916-454B-A7C2-6E410E45CAFD} = {7AF3635B-001C-42BF-94B9-C036CFDCA71D}
 		{C3D4C623-55F8-4653-980D-61AA629B4E1D} = {7AF3635B-001C-42BF-94B9-C036CFDCA71D}
+		{8C02A728-7A50-43CE-B507-BDFC05B7EA94} = {4CFD7702-60B2-4E82-BFAD-FCBB53EB4DA2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		AMDCaPersistentConfig = Debug|Win32
-		AMDCaPersistentStartup = mono
 		AMDCaProjectFile = C:\Users\Owner\Development\monogit\mono\msvc\CodeAnalyst\mono.caw
+		AMDCaPersistentStartup = mono
+		AMDCaPersistentConfig = Debug|Win32
 	EndGlobalSection
 	GlobalSection(DPCodeReviewSolutionGUID) = preSolution
 		DPCodeReviewSolutionGUID = {00000000-0000-0000-0000-000000000000}


### PR DESCRIPTION
Several fixes to the log profiler in order to work on Windows.

* Add new dynamic library project to build log profiler on Windows MSVC.
* Fix dependecy between log profiler and Mono.
* Rewrite command pipe logic on Windows since it's not supported to select
  on both sockets and pipes.
* Several additional socket fixes needed for log profiler to work on Windows.

NOTE, this makes sure we have a log profiler that can be started/stopped and at least generate some basic output. Still needs more testing on Windows since there might be other parts of the profiler not working as expected (since it has not been run for quite some time).
