### PR TITLE
Reduce malloc in JIT icall registration.

### DIFF
--- a/mono/metadata/cominterop.c
+++ b/mono/metadata/cominterop.c
@@ -85,8 +85,14 @@ mono_IUnknown_Release (MonoIUnknown *pUnk)
 Code shared between the DISABLE_COM and !DISABLE_COM
 */
 
+// func is an identifier, that names a function, and is also in jit-icall-reg.h,
+// and therefore a field in mono_jit_icall_info and can be token pasted into an enum value.
+//
+// The name of func must be linkable for AOT, for example g_free does not work (monoeg_g_free instead),
+// nor does the C++ overload fmod (mono_fmod instead). These functions therefore
+// must be extern "C".
 #define register_icall(func, sig, save) \
-	(mono_register_jit_icall_full ((func), (#func), (sig), (save), (#func)))
+	(mono_register_jit_icall_info (&mono_jit_icall_info.func, func, #func, (sig), (save), #func))
 
 mono_bstr
 mono_string_to_bstr_impl (MonoStringHandle s, MonoError *error)

--- a/mono/metadata/icall-table.c
+++ b/mono/metadata/icall-table.c
@@ -38,9 +38,6 @@
 #include "handle-decl.h"
 #include "icall-decl.h"
 
-// Not yet used.
-MonoJitICallInfos mono_jit_icall_info = { 0 };
-
 // These definitions are used for multiple includes of icall-def.h and eventually undefined.
 #define NOHANDLES(inner) inner
 #define HANDLES(id, name, func, ...)	ICALL (id, name, func ## _raw)

--- a/mono/metadata/jit-icall-reg.h
+++ b/mono/metadata/jit-icall-reg.h
@@ -175,7 +175,6 @@ MONO_JIT_ICALL (mono_gc_wbarrier_range_copy) \
 MONO_JIT_ICALL (mono_gchandle_get_target_internal) \
 MONO_JIT_ICALL (mono_generic_class_init) \
 MONO_JIT_ICALL (mono_get_assembly_object) \
-MONO_JIT_ICALL (mono_get_lmf_addr) \
 MONO_JIT_ICALL (mono_get_method_object) \
 MONO_JIT_ICALL (mono_get_native_calli_wrapper) \
 MONO_JIT_ICALL (mono_get_special_static_data) \
@@ -338,6 +337,12 @@ MONO_JIT_ICALLS
 extern MonoJitICallInfos mono_jit_icall_info;
 
 #define mono_jit_icall_info_index(x) ((x) - mono_jit_icall_info.array)
+
+static inline gboolean // temporary, lone caller will go away
+mono_is_jit_icall_info (gconstpointer jit_icall_info)
+{
+	return (char*)jit_icall_info >= (char*)&mono_jit_icall_info && (char*)jit_icall_info < (char*)(&mono_jit_icall_info + 1);
+}
 
 static inline MonoJitICallInfo*
 mono_check_jit_icall_info (gconstpointer jit_icall_info)

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -117,8 +117,14 @@ get_method_image (MonoMethod *method)
 	return m_class_get_image (method->klass);
 }
 
+// func is an identifier, that names a function, and is also in jit-icall-reg.h,
+// and therefore a field in mono_jit_icall_info and can be token pasted into an enum value.
+//
+// The name of func must be linkable for AOT, for example g_free does not work (monoeg_g_free instead),
+// nor does the C++ overload fmod (mono_fmod instead). These functions therefore
+// must be extern "C".
 #define register_icall(func, sig, no_wrapper) \
-	(mono_register_jit_icall_full ((func), (#func), (sig), (no_wrapper), (#func)))
+	(mono_register_jit_icall_info (&mono_jit_icall_info.func, func, #func, (sig), (no_wrapper), #func))
 
 MonoMethodSignature*
 mono_signature_no_pinvoke (MonoMethod *method)

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -104,9 +104,16 @@ static MonoMethod *method_set_call_context, *method_needs_context_sink, *method_
 static gpointer
 mono_compile_method_icall (MonoMethod *method);
 
-// This is not the same as other register_icall.
+// func is an identifier, that names a function, and is also in jit-icall-reg.h,
+// and therefore a field in mono_jit_icall_info and can be token pasted into an enum value.
+//
+// The name of func must be linkable for AOT, for example g_free does not work (monoeg_g_free instead),
+// nor does the C++ overload fmod (mono_fmod instead). These functions therefore
+// must be extern "C".
+//
+// This is not the same as other register_icall (last parameter NULL vs. #func)
 #define register_icall(func, sig, save) \
-	(mono_register_jit_icall ((func), (#func), (sig), (save)))
+	(mono_register_jit_icall_info (&mono_jit_icall_info.func, func, #func, (sig), (save), NULL))
 
 static inline void
 remoting_lock (void)

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -5443,11 +5443,8 @@ get_mscorlib_aot_module (void)
 	return amodule;
 }
 
-static void
-no_trampolines (void)
-{
-	g_assert_not_reached ();
-}
+void
+mono_no_trampolines (void);
 
 /*
  * Return the trampoline identified by NAME from the mscorlib AOT file.
@@ -5460,14 +5457,14 @@ mono_aot_get_trampoline_full (const char *name, MonoTrampInfo **out_tinfo)
 
 	if (mono_llvm_only) {
 		*out_tinfo = NULL;
-		return (gpointer)no_trampolines;
+		return (gpointer)mono_no_trampolines;
 	}
 
 	return mono_create_ftnptr_malloc ((guint8 *)load_function_full (amodule, name, out_tinfo));
 }
 
 gpointer
-(mono_aot_get_trampoline) (const char *name)
+mono_aot_get_trampoline (const char *name)
 {
 	MonoTrampInfo *out_tinfo;
 	gpointer code;

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -1678,14 +1678,13 @@ mono_find_jit_opcode_emulation (int opcode)
 }
 
 void
-mini_register_opcode_emulation (int opcode, const char *name, MonoMethodSignature *sig, gpointer func, const char *symbol, gboolean no_wrapper)
+mini_register_opcode_emulation (int opcode, MonoJitICallInfo *info, const char *name, MonoMethodSignature *sig, gpointer func, const char *symbol, gboolean no_wrapper)
 {
-	MonoJitICallInfo *info;
-
+	g_assert (info);
 	g_assert (!sig->hasthis);
 	g_assert (sig->param_count < 3);
 
-	info = mono_register_jit_icall_full (func, name, sig, no_wrapper, symbol);
+	mono_register_jit_icall_info (info, func, name, sig, no_wrapper, symbol);
 
 	if (emul_opcode_num >= emul_opcode_alloced) {
 		int incr = emul_opcode_alloced? emul_opcode_alloced/2: 16;

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2104,14 +2104,14 @@ void      mono_add_ins_to_end               (MonoBasicBlock *bb, MonoInst *inst)
 
 void      mono_replace_ins                  (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins, MonoInst **prev, MonoBasicBlock *first_bb, MonoBasicBlock *last_bb);
 
-void              mini_register_opcode_emulation (int opcode, const char *name, MonoMethodSignature *sig, gpointer func, const char *symbol, gboolean no_throw);
+void      mini_register_opcode_emulation (int opcode, MonoJitICallInfo *jit_icall_info, const char *name, MonoMethodSignature *sig, gpointer func, const char *symbol, gboolean no_throw);
 
 #ifdef __cplusplus
 template <typename T>
 inline void
-mini_register_opcode_emulation (int opcode, const char *name, MonoMethodSignature *sig, T func, const char *symbol, gboolean no_throw)
+mini_register_opcode_emulation (int opcode, MonoJitICallInfo *jit_icall_info, const char *name, MonoMethodSignature *sig, T func, const char *symbol, gboolean no_throw)
 {
-	mini_register_opcode_emulation (opcode, name, sig, (gpointer)func, symbol, no_throw);
+	mini_register_opcode_emulation (opcode, jit_icall_info, name, sig, (gpointer)func, symbol, no_throw);
 }
 #endif // __cplusplus
 


### PR DESCRIPTION
There is a little more to do (in a later PR).

Need to decide here, pointer or enum. Either work.
Very minor difference either way.

Make duplicate registration checking stricter.