### PR TITLE
[2019-04] [WinForms] fix EditingCellFormattedValue getter and setter for bool value

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewCheckBoxCell.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewCheckBoxCell.cs
@@ -66,7 +66,7 @@ namespace System.Windows.Forms {
 		public virtual object EditingCellFormattedValue {
 			get { return editingCellFormattedValue; }
 			set {
-				if (FormattedValueType == null || value == null || value.GetType() != FormattedValueType || !(value is Boolean) || !(value is CheckState)) {
+				if (FormattedValueType == null || value == null || !FormattedValueType.IsAssignableFrom(value.GetType())) {
 					throw new ArgumentException("Cannot set this property.");
 				}
 				editingCellFormattedValue = value;

--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewCheckBoxCell.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewCheckBoxCell.cs
@@ -59,7 +59,8 @@ namespace System.Windows.Forms {
 		public DataGridViewCheckBoxCell (bool threeState) : this()
 		{
 			this.threeState = threeState;
-			editingCellFormattedValue = CheckState.Unchecked;
+			if (threeState)
+				editingCellFormattedValue = CheckState.Unchecked;
 		}
 
 		public virtual object EditingCellFormattedValue {
@@ -192,7 +193,11 @@ namespace System.Windows.Forms {
 
 		public virtual void PrepareEditingCellForEdit (bool selectAll)
 		{
-			editingCellFormattedValue = GetCurrentValue ();
+			CheckState cs = GetCurrentValue();
+			if (threeState)
+				editingCellFormattedValue = cs;
+			else
+				editingCellFormattedValue = cs == CheckState.Checked;
 		}
 
 		public override string ToString ()

--- a/mcs/class/System.Windows.Forms/Test/System.Windows.Forms/DataGridViewCheckBoxCellTest.cs
+++ b/mcs/class/System.Windows.Forms/Test/System.Windows.Forms/DataGridViewCheckBoxCellTest.cs
@@ -200,6 +200,36 @@ namespace MonoTests.System.Windows.Forms
 		}
 
 		[Test]
+		public void EditingCellFormattedValue()
+		{
+			var boolCheckBoxCell = new DataGridViewCheckBoxCell();
+			Assert.AreEqual(false, boolCheckBoxCell.EditingCellFormattedValue, "A1");
+			boolCheckBoxCell.EditingCellFormattedValue = true;
+			Assert.AreEqual(true, boolCheckBoxCell.EditingCellFormattedValue, "A2");
+
+			var treeStateCheckBoxCell = new DataGridViewCheckBoxCell(true);
+			Assert.AreEqual(CheckState.Unchecked, treeStateCheckBoxCell.EditingCellFormattedValue, "A3");
+			treeStateCheckBoxCell.EditingCellFormattedValue = CheckState.Checked;
+			Assert.AreEqual(CheckState.Checked, treeStateCheckBoxCell.EditingCellFormattedValue, "A4");
+		}
+
+		[Test]
+		[ExpectedException(typeof(ArgumentException))]
+		public void BoolEditingCellFormattedValueCheckStateSet()
+		{
+			var boolCheckBoxCell = new DataGridViewCheckBoxCell();
+			boolCheckBoxCell.EditingCellFormattedValue = CheckState.Checked;
+		}
+
+		[Test]
+		[ExpectedException(typeof(ArgumentException))]
+		public void TreeStateEditingCellFormattedValueBoolSet()
+		{
+			var treeStateCheckBoxCell = new DataGridViewCheckBoxCell(true);
+			treeStateCheckBoxCell.EditingCellFormattedValue = false;
+		}
+
+		[Test]
 		public void FormattedValueType ()
 		{
 			BaseCell c = new BaseCell ();


### PR DESCRIPTION
If DataGridViewCheckBoxCell not in threeState mode EditingCellFormattedValue must return true or false, instead of value of CheckState type



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->


Backport of #13845.

/cc @marek-safar @sancheolz