### PR TITLE
[2019-02] TextInfo.ChangeCase should not use CultureInfo.CurrentCulture

### DIFF
--- a/mcs/class/corlib/ReferenceSources/TextInfo.cs
+++ b/mcs/class/corlib/ReferenceSources/TextInfo.cs
@@ -252,20 +252,18 @@ namespace System.Globalization
 			if (source.IsEmpty)
 				return;
 
-			var ti = CultureInfo.CurrentCulture.TextInfo;
-
 			fixed (char* pSource = &MemoryMarshal.GetReference (source))
 			fixed (char* pResult = &MemoryMarshal.GetReference (destination)) {
 				int length = 0;
 				char* a = pSource, b = pResult;
 				if (toUpper) {
 					while (length < source.Length) {
-						*b++ = ti.ToUpper (*a++);
+						*b++ = this.ToUpper (*a++);
 						length++;
 					}
 				} else {
 					while (length < source.Length) {
-						*b++ = ti.ToLower (*a++);
+						*b++ = this.ToLower (*a++);
 						length++;
 					}
 				}

--- a/mcs/class/corlib/Test/System.Globalization/CultureInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Globalization/CultureInfoTest.cs
@@ -784,7 +784,7 @@ namespace MonoTests.System.Globalization
 			var dst = new Span<char> (new char [testStr.Length]);
 			CultureInfo savedCulture = CultureInfo.CurrentCulture;
 			CultureInfo.CurrentCulture = new InterceptingLocale ();
-			testStr.AsSpan().ToUpperInvariant(dst); // should not throw InvalidOperationException ("Shouldn't be called.")
+			testStr.AsSpan ().ToUpperInvariant (dst); // should not throw InvalidOperationException ("Shouldn't be called.")
 			CultureInfo.CurrentCulture = savedCulture;
 			Assert.AreEqual ("TEST", dst.ToString ());
 		}

--- a/mcs/class/corlib/Test/System.Globalization/CultureInfoTest.cs
+++ b/mcs/class/corlib/Test/System.Globalization/CultureInfoTest.cs
@@ -776,5 +776,23 @@ namespace MonoTests.System.Globalization
 
 			Assert.IsTrue (f ().Wait (5 * 1000), "#1");
 		}
+
+		[Test]
+		public void SpanToUpperInvariantDoesntUseCurrentCulture ()
+		{
+			string testStr = "test";
+			var dst = new Span<char> (new char [testStr.Length]);
+			CultureInfo savedCulture = CultureInfo.CurrentCulture;
+			CultureInfo.CurrentCulture = new InterceptingLocale ();
+			testStr.AsSpan().ToUpperInvariant(dst); // should not throw InvalidOperationException ("Shouldn't be called.")
+			CultureInfo.CurrentCulture = savedCulture;
+			Assert.AreEqual ("TEST", dst.ToString ());
+		}
+
+		private class InterceptingLocale : CultureInfo
+		{
+			public InterceptingLocale () : base (string.Empty) { }
+			public override TextInfo TextInfo => throw new InvalidOperationException ("Shouldn't be called.");
+		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/14102

Backport of #14105.

/cc @marek-safar @EgorBo