### PR TITLE
[arm64] set MONO_ARCH_HAVE_UNWIND_BACKTRACE for watch4

### DIFF
--- a/mono/mini/mini-arm64.h
+++ b/mono/mini/mini-arm64.h
@@ -182,7 +182,7 @@ typedef struct {
 
 #endif
 
-#if defined(TARGET_IOS)
+#if defined(TARGET_IOS) || defined(TARGET_WATCHOS)
 #define MONO_ARCH_HAVE_UNWIND_BACKTRACE 1
 #endif
 


### PR DESCRIPTION
Fixes a couple of mscorlib test failures, failing with
> Stack walks are not supported on this platform
