### PR TITLE
[arm] one more attempt to fix slotsize issue on llvmonly

### DIFF
--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -2371,14 +2371,7 @@ mono_arch_get_llvm_call_info (MonoCompile *cfg, MonoMethodSignature *sig)
 			break;
 		case RegTypeStructByVal: {
 			lainfo->storage = LLVMArgAsIArgs;
-			int slotsize;
-#ifdef TARGET_WATCHOS
-			/* slotsize=4 works for armv7k, however arm64_32 allows passing
-			 * structs with sizes up to 8 bytes in a single register. */
-			slotsize = arm64_32_abi ? 8 : 4;
-#else
-			slotsize = eabi_supported && ainfo->align == 8 ? 8 : 4;
-#endif
+			int slotsize = eabi_supported && ainfo->align == 8 ? 8 : 4;
 			lainfo->nslots = ALIGN_TO (ainfo->struct_size, slotsize) / slotsize;
 			lainfo->esize = slotsize;
 			break;

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -88,8 +88,6 @@ static gboolean thumb2_supported = FALSE;
  */
 static gboolean eabi_supported = FALSE;
 
-static gboolean arm64_32_abi = FALSE;
-
 /* 
  * Whenever to use the iphone ABI extensions:
  * http://developer.apple.com/library/ios/documentation/Xcode/Conceptual/iPhoneOSABIReference/index.html
@@ -7461,9 +7459,6 @@ mono_arch_set_target (char *mtriple)
 	}
 	if (strstr (mtriple, "gnueabi"))
 		eabi_supported = TRUE;
-
-	if (strstr (mtriple, "arm64_32"))
-		arm64_32_abi = TRUE;
 }
 
 gboolean


### PR DESCRIPTION
Regression of https://github.com/mono/mono/pull/12992 & https://github.com/mono/mono/pull/14362

In the end, the actual fix boils down to:
```patch
--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -2374,7 +2374,7 @@ mono_arch_get_llvm_call_info (MonoCompile *cfg, MonoMethodSignature *sig)
                                lainfo->nslots = ALIGN_TO (ainfo->struct_size, 8) / 8;
                                lainfo->esize = 8;
                        } else {
-                               lainfo->nslots = ainfo->struct_size / sizeof (target_mgreg_t);
+                               lainfo->nslots = ALIGN_TO (ainfo->struct_size, sizeof (target_mgreg_t)) / sizeof (target_mgreg_t);
                                lainfo->esize = 4;
                        }
                        break;
```

Tested on `xamarin-macios/arm64_32-v3` branch:
* mscorlib
* mini
* dont link
* monotouch tests
* and a modified version of https://github.com/mono/mono/issues/8486#issuecomment-414365860 (added larger structs too)

with each device, Watch Series 3 (`armv7k`) and Watch Series 4 (`arm64_32`).

I hope that is the last iteration on this.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
