### PR TITLE
[2019-02] [metadata] use handle stack in mono_runtime_object_init_handle

### DIFF
--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -126,6 +126,7 @@ mono_runtime_object_init_handle (MonoObjectHandle this_obj, MonoError *error)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
+	HANDLE_FUNCTION_ENTER ();
 	error_init (error);
 
 	MonoClass * const klass = MONO_HANDLE_GETVAL (this_obj, vtable)->klass;
@@ -142,7 +143,7 @@ mono_runtime_object_init_handle (MonoObjectHandle this_obj, MonoError *error)
 		mono_runtime_invoke_handle_void (method, this_obj, NULL, error);
 	}
 
-	return is_ok (error);
+	HANDLE_FUNCTION_RETURN_VAL (is_ok (error));
 }
 
 /**


### PR DESCRIPTION
Fixes this crash on watchOS with llvmonly:
https://gist.github.com/lewurm/921b77a238c6fd60757a5ee9f54279d1

The hint here was that the crash happened in `mono_handle_stack_scan ()` and inspecting the handle stack there. After enabling `MONO_HANDLE_TRACK_OWNER` and `MONO_HANDLE_TRACK_SP` in `handle.h`, I got this:
https://gist.github.com/lewurm/71f936a126879ef2b96d00399e6b2bd9


@lambdageek suggested this fix after showing this trace to him. As far as I understand we do _not_ know the root cause yet. The handle leak happens in this trace:
https://gist.github.com/lewurm/b76fbc391f22d897bfd532ac1b67e2aa
`mono_runtime_object_init_checked ()` already should take care of the handle stack 😕


Contributes to #13006

Backport of #14399.

/cc @akoeplinger @lewurm