### PR TITLE
[2019-04] Revert "[System] Add FSEvent FileSystemWatcher to monotouch BCL profile"

### DIFF
--- a/mcs/class/System/System.csproj
+++ b/mcs/class/System/System.csproj
@@ -3616,21 +3616,13 @@
     </When>
     <When Condition="'$(Platform)' == 'monotouch_watch'">
       <ItemGroup>
-        <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\OSX\Interop.CoreFoundation.cs" />
-        <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\OSX\Interop.EventStream.cs" />
-        <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\OSX\Interop.Libraries.cs" />
-        <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\OSX\Interop.RunLoop.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\Interop.Errors.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\Interop.IOErrors.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\Interop.Libraries.cs" />
-        <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.RealPath.cs" />
-        <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Sync.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\Microsoft\Win32\SafeHandles\GssSafeHandles.cs" />
-        <Compile Include="..\..\..\external\corefx\src\Common\src\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs" />
-        <Compile Include="..\..\..\external\corefx\src\Common\src\Microsoft\Win32\SafeHandles\SafeEventStreamHandle.OSX.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\System\Net\ContextAwareResult.Unix.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\System\Net\ContextFlagsAdapterPal.Unix.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\System\Net\Security\CertificateHelper.Unix.cs" />
@@ -3639,7 +3631,7 @@
         <Compile Include="..\..\..\external\corefx\src\Common\src\System\Net\Security\Unix\SafeDeleteNegoContext.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\System\Net\Security\Unix\SafeFreeCredentials.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\System\Net\Security\Unix\SafeFreeNegoCredentials.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.IO.FileSystem.Watcher\src\System\IO\FileSystemWatcher.OSX.cs" />
+        <Compile Include="..\..\..\external\corefx\src\System.IO.FileSystem.Watcher\src\System\IO\FileSystemWatcher.UnknownUnix.cs" />
         <Compile Include="..\Mono.Security\Mono.Security.Cryptography\PKCS8.cs" />
         <Compile Include="..\Mono.Security\Mono.Security.X509.Extensions\AuthorityKeyIdentifierExtension.cs" />
         <Compile Include="..\Mono.Security\Mono.Security.X509.Extensions\BasicConstraintsExtension.cs" />
@@ -3723,21 +3715,13 @@
     </When>
     <When Condition="'$(Platform)' == 'monotouch_tv'">
       <ItemGroup>
-        <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\OSX\Interop.CoreFoundation.cs" />
-        <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\OSX\Interop.EventStream.cs" />
-        <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\OSX\Interop.Libraries.cs" />
-        <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\OSX\Interop.RunLoop.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\Interop.Errors.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\Interop.IOErrors.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\Interop.Libraries.cs" />
-        <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.RealPath.cs" />
-        <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Sync.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\Microsoft\Win32\SafeHandles\GssSafeHandles.cs" />
-        <Compile Include="..\..\..\external\corefx\src\Common\src\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs" />
-        <Compile Include="..\..\..\external\corefx\src\Common\src\Microsoft\Win32\SafeHandles\SafeEventStreamHandle.OSX.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\System\Net\ContextAwareResult.Unix.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\System\Net\ContextAwareResult.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\System\Net\ContextFlagsAdapterPal.Unix.cs" />
@@ -3750,7 +3734,7 @@
         <Compile Include="..\..\..\external\corefx\src\Common\src\System\Net\Security\Unix\SafeFreeCredentials.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\System\Net\Security\Unix\SafeFreeNegoCredentials.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\System\Net\TlsStream.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.IO.FileSystem.Watcher\src\System\IO\FileSystemWatcher.OSX.cs" />
+        <Compile Include="..\..\..\external\corefx\src\System.IO.FileSystem.Watcher\src\System\IO\FileSystemWatcher.UnknownUnix.cs" />
         <Compile Include="..\..\..\external\corefx\src\System.Net.HttpListener\src\System\Net\WebSockets\HttpListenerWebSocketContext.cs" />
         <Compile Include="..\..\..\external\corefx\src\System.Net.Requests\src\System\Net\CommandStream.cs" />
         <Compile Include="..\..\..\external\corefx\src\System.Net.Requests\src\System\Net\FtpControlStream.cs" />
@@ -3865,21 +3849,13 @@
     </When>
     <When Condition="'$(Platform)' == 'monotouch'">
       <ItemGroup>
-        <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\OSX\Interop.CoreFoundation.cs" />
-        <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\OSX\Interop.EventStream.cs" />
-        <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\OSX\Interop.Libraries.cs" />
-        <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\OSX\Interop.RunLoop.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\Interop.Errors.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\Interop.IOErrors.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\Interop.Libraries.cs" />
-        <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.RealPath.cs" />
-        <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Native\Interop.Sync.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\Microsoft\Win32\SafeHandles\GssSafeHandles.cs" />
-        <Compile Include="..\..\..\external\corefx\src\Common\src\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs" />
-        <Compile Include="..\..\..\external\corefx\src\Common\src\Microsoft\Win32\SafeHandles\SafeEventStreamHandle.OSX.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\System\Net\ContextAwareResult.Unix.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\System\Net\ContextAwareResult.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\System\Net\ContextFlagsAdapterPal.Unix.cs" />
@@ -3892,7 +3868,7 @@
         <Compile Include="..\..\..\external\corefx\src\Common\src\System\Net\Security\Unix\SafeFreeCredentials.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\System\Net\Security\Unix\SafeFreeNegoCredentials.cs" />
         <Compile Include="..\..\..\external\corefx\src\Common\src\System\Net\TlsStream.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.IO.FileSystem.Watcher\src\System\IO\FileSystemWatcher.OSX.cs" />
+        <Compile Include="..\..\..\external\corefx\src\System.IO.FileSystem.Watcher\src\System\IO\FileSystemWatcher.UnknownUnix.cs" />
         <Compile Include="..\..\..\external\corefx\src\System.Net.HttpListener\src\System\Net\WebSockets\HttpListenerWebSocketContext.cs" />
         <Compile Include="..\..\..\external\corefx\src\System.Net.Requests\src\System\Net\CommandStream.cs" />
         <Compile Include="..\..\..\external\corefx\src\System.Net.Requests\src\System\Net\FtpControlStream.cs" />

--- a/mcs/class/System/mono_fsw.sources
+++ b/mcs/class/System/mono_fsw.sources
@@ -1,9 +1,0 @@
-System.IO/DefaultWatcher.cs
-System.IO/FAMWatcher.cs
-System.IO/NullFileWatcher.cs
-System.IO/FileAction.cs
-System.IO/FileSystemWatcher.cs
-System.IO/IFileWatcher.cs
-System.IO/KeventWatcher.cs
-System.IO/SearchPattern.cs
-System.IO/CoreFXFileSystemWatcherProxy.cs

--- a/mcs/class/System/monotouch_System.dll.exclude.sources
+++ b/mcs/class/System/monotouch_System.dll.exclude.sources
@@ -1,4 +1,2 @@
-#include mono_fsw.sources
-../../../external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.UnknownUnix.cs
 corefx/Unix/Interop.cs
 corefx/Unix/Interop.Read.cs

--- a/mcs/class/System/monotouch_System.dll.sources
+++ b/mcs/class/System/monotouch_System.dll.sources
@@ -4,13 +4,3 @@
 
 Mono.AppleTls/MonoCertificatePal.Mobile.cs
 Mono.AppleTls/SafeHandles.cs
-
-../../../external/corefx/src/Common/src/Interop/OSX/Interop.Libraries.cs
-../../../external/corefx/src/Common/src/Interop/OSX/Interop.EventStream.cs
-../../../external/corefx/src/Common/src/Interop/OSX/Interop.RunLoop.cs
-../../../external/corefx/src/Common/src/Interop/OSX/Interop.CoreFoundation.cs
-../../../external/corefx/src/Common/src/Interop/Unix/System.Native/Interop.Sync.cs
-../../../external/corefx/src/Common/src/Interop/Unix/System.Native/Interop.RealPath.cs
-../../../external/corefx/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
-../../../external/corefx/src/Common/src/Microsoft/Win32/SafeHandles/SafeCreateHandle.OSX.cs
-../../../external/corefx/src/Common/src/Microsoft/Win32/SafeHandles/SafeEventStreamHandle.OSX.cs

--- a/mcs/class/System/monotouch_runtime_System.dll.exclude.sources
+++ b/mcs/class/System/monotouch_runtime_System.dll.exclude.sources
@@ -1,1 +1,0 @@
-#include monotouch_System.dll.exclude.sources

--- a/mcs/class/System/monotouch_tv_runtime_System.dll.exclude.sources
+++ b/mcs/class/System/monotouch_tv_runtime_System.dll.exclude.sources
@@ -1,1 +1,0 @@
-#include monotouch_System.dll.exclude.sources

--- a/mcs/class/System/net_4_x_System.dll.sources
+++ b/mcs/class/System/net_4_x_System.dll.sources
@@ -1,6 +1,5 @@
 #include common.sources
 #include common_networking.sources
-#include mono_fsw.sources
 
 Microsoft.CSharp/CSharpCodeGenerator.cs
 Microsoft.VisualBasic/VBCodeGenerator.cs
@@ -133,6 +132,17 @@ System.Diagnostics/PerformanceCounterPermissionEntry.cs
 System.Diagnostics/PerformanceCounterType.cs
 System.Diagnostics/TraceSourceInfo.cs
 System.Diagnostics/Win32EventLog.cs
+
+System.IO/DefaultWatcher.cs
+System.IO/FAMWatcher.cs
+System.IO/NullFileWatcher.cs
+System.IO/FileAction.cs
+System.IO/FileSystemWatcher.cs
+System.IO/IFileWatcher.cs
+System.IO/KeventWatcher.cs
+System.IO/SearchPattern.cs
+
+System.IO/CoreFXFileSystemWatcherProxy.cs
 
 System.IO.Ports/Handshake.cs
 System.IO.Ports/ISerialStream.cs


### PR DESCRIPTION
This reverts commit 46fc5352f3dfe0027e684a0f61e71130fccd559f.

While iOS FileSystemWatcher works, we now find that it is used unofficially-available  symbols and cannot publish apps using those.

Fixes https://github.com/mono/mono/issues/14290

Backport of #14316.
