### PR TITLE
[2019-02] [arm64] set MONO_ARCH_HAVE_UNWIND_BACKTRACE for watch4

### DIFF
--- a/mono/mini/mini-arm64.h
+++ b/mono/mini/mini-arm64.h
@@ -183,7 +183,7 @@ typedef struct {
 
 #endif
 
-#if defined(TARGET_IOS)
+#if defined(TARGET_IOS) || defined(TARGET_WATCHOS)
 #define MONO_ARCH_HAVE_UNWIND_BACKTRACE 1
 #endif
 


### PR DESCRIPTION
Fixes a couple of mscorlib test failures, failing with
> Stack walks are not supported on this platform


Backport of #14440.

/cc @lewurm 