### PR TITLE
[2019-04] [corlib] Implement AssemblyBuilder.get_ReflectionOnly()

### DIFF
--- a/mcs/class/corlib/System.Reflection.Emit/AssemblyBuilder.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/AssemblyBuilder.cs
@@ -402,9 +402,10 @@ namespace System.Reflection.Emit
 			}
 		}
 
-		[MonoTODO]
 		public override bool ReflectionOnly {
-			get { return base.ReflectionOnly; }
+			get {
+				return access == (uint)AssemblyBuilderAccess.ReflectionOnly;
+			}
 		}
 
 		public void AddResourceFile (string name, string fileName)

--- a/mcs/class/corlib/Test/System.Reflection.Emit/AssemblyBuilderTest.cs
+++ b/mcs/class/corlib/Test/System.Reflection.Emit/AssemblyBuilderTest.cs
@@ -1906,6 +1906,17 @@ public class AssemblyBuilderTest
 			});
 	}
 
+	[Test]
+	public void GetReflectionOnly ()
+	{
+		// Regression test for 13028.
+		// Asserts ReflectionOnly is actually implemented.
+		AssemblyBuilder ab1 = genAssembly ();
+		AssemblyBuilder ab2 = genAssembly (AssemblyBuilderAccess.ReflectionOnly);
+		Assert.IsFalse (ab1.ReflectionOnly, "#1");
+		Assert.IsTrue (ab2.ReflectionOnly, "#2");
+	}
+
 
 }
 }


### PR DESCRIPTION
Fixes #13028

Backport of #14406.

/cc @lambdageek @CoffeeFlux