### PR TITLE
configure.ac: bail out if C++ is not found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -573,12 +573,11 @@ dnl We should use AM_PROG_AS, but it's not available on automake/aclocal 1.4
 AC_SUBST(CCAS)
 AC_SUBST(CCASFLAGS)
 
-# AC_PROG_CXX helpfully sets CXX to g++ even if no c++ compiler is found so check
+# With old versions of autoconf, AC_PROG_CXX helpfully sets CXX to g++ even if no c++ compiler is found so check
 # GXX instead. See http://lists.gnu.org/archive/html/bug-autoconf/2002-04/msg00056.html
-if test "x$CXX" = "xg++"; then
+# With new versions of autoconf, AC_PROG_CXX sets CXX to no if no C++ compiler is found so check also this value
+if test "x$CXX" = "xg++" -o "x$CXX" = "xno"; then
 	if test "x$GXX" != "xyes"; then
-		# automake/libtool is so broken, it requires g++ even if the c++ sources
-		# are inside automake conditionals
 		AC_MSG_ERROR([You need to install g++])
 	fi
 fi


### PR DESCRIPTION
Since version 5.16.0.179 and d8af775, mono requires the availability of
a working C++ compiler to get the exact type of size_t.

So bail out if CXX is set to no by AC_PROG_CXX and remove comment about
automake/libtool being broken as mono is now really requiring C++

Fix #14195

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
