### PR TITLE
configure: check for c++ availability

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -573,6 +573,10 @@ dnl We should use AM_PROG_AS, but it's not available on automake/aclocal 1.4
 AC_SUBST(CCAS)
 AC_SUBST(CCASFLAGS)
 
+if test "x$CXX" = "xno"; then
+	AC_MSG_ERROR([No c++ compiler found. You need to install a c++ compiler])
+fi
+
 # AC_PROG_CXX helpfully sets CXX to g++ even if no c++ compiler is found so check
 # GXX instead. See http://lists.gnu.org/archive/html/bug-autoconf/2002-04/msg00056.html
 if test "x$CXX" = "xg++"; then


### PR DESCRIPTION
Since commit d8af775, c++ compiler is required to compile.
This patch checks if the c++ compiler is available as soon as possible
and returns an error in case it is not found.

Fixes: https://github.com/mono/mono/issues/14195

Signed-off-by: Angelo Compagnucci <angelo@amarulasolutions.com>



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
