### PR TITLE
 Fixes #issue-14234

### DIFF
--- a/mcs/class/System.Web/System.Web.Security/SqliteMembershipProvider.cs
+++ b/mcs/class/System.Web/System.Web.Security/SqliteMembershipProvider.cs
@@ -139,7 +139,7 @@ namespace System.Web.Security
 			}
 
 			// Get encryption and decryption key information from the configuration.
-			m_MachineKey = (MachineKeySection)WebConfigurationManager.GetSection("system.web/machineKey", null);
+			m_MachineKey = (MachineKeySection)WebConfigurationManager.GetSection("system.web/machineKey");
 
 			if (!m_PasswordFormat.Equals(MembershipPasswordFormat.Clear))
 			{


### PR DESCRIPTION

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
Dear team Mono,

Please find below the fix of issue #14234 .  On the stage of the initialization of the SqliteMembershipProvider the existed code always produced an error "Failed to map path '/'" in case if the ASP.NET application is placed not at the root path. Detailed step by step description of the problem is provided in the issue description.

The bug was that was implemented the call of the function with wrong parameters list. So the fix was in changing the function call. The same function call is also used in SqlMembershipProvider.cs.

Thanks for your job.

Regards,
Alex