### PR TITLE
[Wasm] Expand support for dynamic linking

### DIFF
--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -106,7 +106,7 @@ release-dynamic/:
 
 MONO_LIBS = $(TOP)/sdks/out/wasm-runtime-release/lib/{libmono-ee-interp.a,libmono-native.a,libmono-icall-table.a,libmonosgen-2.0.a,libmono-ilgen.a}
 
-EMCC_FLAGS=-s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s BINARYEN=1 -s "BINARYEN_TRAP_MODE='clamp'" -s ALIASING_FUNCTION_POINTERS=0 -s NO_EXIT_RUNTIME=1 -s "EXTRA_EXPORTED_RUNTIME_METHODS=['ccall', 'FS_createPath', 'FS_createDataFile', 'cwrap', 'setValue', 'getValue', 'UTF8ToString']" -s EMULATED_FUNCTION_POINTERS=1
+EMCC_FLAGS=-s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s BINARYEN=1 -s "BINARYEN_TRAP_MODE='clamp'" -s ALIASING_FUNCTION_POINTERS=0 -s NO_EXIT_RUNTIME=1 -s "EXTRA_EXPORTED_RUNTIME_METHODS=['ccall', 'FS_createPath', 'FS_createDataFile', 'cwrap', 'setValue', 'getValue', 'UTF8ToString', 'addFunction']" -s EMULATED_FUNCTION_POINTERS=1
 
 debug/.stamp-build: driver.o corebindings.o library_mono.js binding_support.js dotnet_support.js $(TOP)/sdks/out/wasm-runtime-release/lib/libmonosgen-2.0.a | debug/
 	$(EMCC) $(EMCC_FLAGS) -g4 -Os -s ASSERTIONS=1 --js-library library_mono.js --js-library binding_support.js --js-library dotnet_support.js driver.o corebindings.o $(MONO_LIBS) -o debug/mono.js

--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -118,7 +118,7 @@ release/.stamp-build: driver.o corebindings.o library_mono.js binding_support.js
 
 # Notice that release-dynamic/.stamp-build depends on release/.stamp-build. This is the case as emcc is believed to not work well with parallel builds.
 release-dynamic/.stamp-build: driver-dynamic.o corebindings.o library_mono.js binding_support.js dotnet_support.js $(TOP)/sdks/out/wasm-runtime-release/lib/libmonosgen-2.0.a release/.stamp-build | release-dynamic/
-	$(EMCC) $(EMCC_FLAGS) -s MAIN_MODULE=1 -s EXPORT_ALL=1 -Oz --llvm-opts 2 --llvm-lto 1 --js-library library_mono.js --js-library binding_support.js --js-library dotnet_support.js driver-dynamic.o corebindings.o $(MONO_LIBS) -o release-dynamic/mono.js -s "EXPORTED_FUNCTIONS=['_putchar']"
+	EMCC_FORCE_STDLIBS=libcxx,libcxxabi $(EMCC) $(EMCC_FLAGS) -s MAIN_MODULE=1 -s EXPORT_ALL=1 -Oz --llvm-opts 2 --llvm-lto 1 --js-library library_mono.js --js-library binding_support.js --js-library dotnet_support.js driver-dynamic.o corebindings.o $(MONO_LIBS) -o release-dynamic/mono.js -s "EXPORTED_FUNCTIONS=['_putchar']"
 	touch $@
 
 build-native: debug/.stamp-build release/.stamp-build release-dynamic/.stamp-build

--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -17,6 +17,7 @@ CSC_LOCATION?=$(STANDALONE_CSC_LOCATION)
 
 EMSCRIPTEN_SDKDIR=$(TOP)/sdks/builds/toolchains/emsdk
 EMCC=source $(TOP)/sdks/builds/toolchains/emsdk/emsdk_env.sh && emcc
+EMCC_DYNAMIC=source $(TOP)/sdks/builds/toolchains/emsdk/emsdk_env.sh && EMCC_FORCE_STDLIBS=1 emcc
 WASM_BCL_DIR=$(TOP)/sdks/out/wasm-bcl/wasm
 WASM_RUNTIME_DIR=$(TOP)/sdks/out/wasm-runtime-release
 MINI_PATH=$(TOP)/mono/mini
@@ -118,7 +119,7 @@ release/.stamp-build: driver.o corebindings.o library_mono.js binding_support.js
 
 # Notice that release-dynamic/.stamp-build depends on release/.stamp-build. This is the case as emcc is believed to not work well with parallel builds.
 release-dynamic/.stamp-build: driver-dynamic.o corebindings.o library_mono.js binding_support.js dotnet_support.js $(TOP)/sdks/out/wasm-runtime-release/lib/libmonosgen-2.0.a release/.stamp-build | release-dynamic/
-	EMCC_FORCE_STDLIBS=libcxx,libcxxabi $(EMCC) $(EMCC_FLAGS) -s MAIN_MODULE=1 -s EXPORT_ALL=1 -Oz --llvm-opts 2 --llvm-lto 1 --js-library library_mono.js --js-library binding_support.js --js-library dotnet_support.js driver-dynamic.o corebindings.o $(MONO_LIBS) -o release-dynamic/mono.js -s "EXPORTED_FUNCTIONS=['_putchar']"
+	$(EMCC_DYNAMIC) $(EMCC_FLAGS) -s MAIN_MODULE=1 -s EXPORT_ALL=1 -s RESERVED_FUNCTION_POINTERS=64 -Oz --llvm-opts 2 --llvm-lto 1 --js-library library_mono.js --js-library binding_support.js --js-library dotnet_support.js driver-dynamic.o corebindings.o $(MONO_LIBS) -o release-dynamic/mono.js -s "EXPORTED_FUNCTIONS=['_putchar']"
 	touch $@
 
 build-native: debug/.stamp-build release/.stamp-build release-dynamic/.stamp-build

--- a/sdks/wasm/bindings-test.cs
+++ b/sdks/wasm/bindings-test.cs
@@ -51,6 +51,12 @@ public class TestClass {
 		intptr_val = i;
 	}
 
+	public static IntPtr mkintptr_val;
+	public static IntPtr InvokeMkIntPtr() {
+		intptr_val = (IntPtr)42;
+		return intptr_val;
+	}
+
 	public static object obj1;
 	public static object InvokeObj1(object obj)
 	{
@@ -652,12 +658,28 @@ public class BindingTests {
 	public static void BindIntPtrStaticMethod () {
 		TestClass.intptr_val = IntPtr.Zero;
 		Runtime.InvokeJS (@"
-			var invoke_int = Module.mono_bind_static_method (""[binding_tests]TestClass:InvokeIntPtr"");
-			invoke_int (42);
+			var invoke_int_ptr = Module.mono_bind_static_method (""[binding_tests]TestClass:InvokeIntPtr"");
+			invoke_int_ptr (42);
 		");
 
 		Assert.AreEqual (42, TestClass.intptr_val);
 	}
+
+
+	[Test]
+	public static void MarshalIntPtrToJS () {
+		TestClass.mkstr = TestClass.string_res = null;
+		Runtime.InvokeJS (@"
+			var invoke_mk_int = Module.mono_bind_static_method (""[binding_tests]TestClass:InvokeMkIntPtr"");
+			var r = invoke_mk_int ();
+
+			if (r != 42) throw `Invalid int_ptr value`;
+		");
+		Assert.IsNotNull (TestClass.mkstr);
+
+		Assert.AreEqual (TestClass.mkstr, TestClass.string_res);
+	}
+
 
 	[Test]
 	public static void InvokeStaticMethod () {

--- a/sdks/wasm/bindings-test.cs
+++ b/sdks/wasm/bindings-test.cs
@@ -41,12 +41,19 @@ public class TestClass {
 		return mkstr;
 	}
 
-	public static int int_val;
-	public static void InvokeInt (int i) {
-		int_val = i;
-	}
+    public static int int_val;
+    public static void InvokeInt(int i)
+    {
+        int_val = i;
+    }
 
-	public static object obj1;
+    public static IntPtr intptr_val;
+    public static void InvokeIntPtr(IntPtr i)
+    {
+        intptr_val = i;
+    }
+
+    public static object obj1;
 	public static object InvokeObj1(object obj)
 	{
 		obj1 = obj;
@@ -632,18 +639,31 @@ public class BindingTests {
 		// Assert.AreEqual (99, TestClass.int_val);
 	}
 
-	[Test]
-	public static void BindStaticMethod () {
-		TestClass.int_val = 0;
-		Runtime.InvokeJS (@"
+    [Test]
+    public static void BindStaticMethod()
+    {
+        TestClass.int_val = 0;
+        Runtime.InvokeJS(@"
 			var invoke_int = Module.mono_bind_static_method (""[binding_tests]TestClass:InvokeInt"");
 			invoke_int (200);
 		");
 
-		Assert.AreEqual (200, TestClass.int_val);
-	}
+        Assert.AreEqual(200, TestClass.int_val);
+    }
 
-	[Test]
+    [Test]
+    public static void BindIntPtrStaticMethod()
+    {
+        TestClass.intptr_val = IntPtr.Zero;
+        Runtime.InvokeJS(@"
+			var invoke_int = Module.mono_bind_static_method (""[binding_tests]TestClass:InvokeIntPtr"");
+			invoke_int (42);
+		");
+
+        Assert.AreEqual(42, TestClass.intptr_val);
+    }
+
+    [Test]
 	public static void InvokeStaticMethod () {
 		TestClass.int_val = 0;
 		Runtime.InvokeJS (@"

--- a/sdks/wasm/bindings-test.cs
+++ b/sdks/wasm/bindings-test.cs
@@ -41,19 +41,17 @@ public class TestClass {
 		return mkstr;
 	}
 
-    public static int int_val;
-    public static void InvokeInt(int i)
-    {
-        int_val = i;
-    }
+	public static int int_val;
+	public static void InvokeInt (int i) {
+		int_val = i;
+	}
 
-    public static IntPtr intptr_val;
-    public static void InvokeIntPtr(IntPtr i)
-    {
-        intptr_val = i;
-    }
+	public static IntPtr intptr_val;
+	public static void InvokeIntPtr(IntPtr i) {
+		intptr_val = i;
+	}
 
-    public static object obj1;
+	public static object obj1;
 	public static object InvokeObj1(object obj)
 	{
 		obj1 = obj;
@@ -639,31 +637,29 @@ public class BindingTests {
 		// Assert.AreEqual (99, TestClass.int_val);
 	}
 
-    [Test]
-    public static void BindStaticMethod()
-    {
-        TestClass.int_val = 0;
-        Runtime.InvokeJS(@"
+	[Test]
+	public static void BindStaticMethod () {
+		TestClass.int_val = 0;
+		Runtime.InvokeJS (@"
 			var invoke_int = Module.mono_bind_static_method (""[binding_tests]TestClass:InvokeInt"");
 			invoke_int (200);
 		");
 
-        Assert.AreEqual(200, TestClass.int_val);
-    }
+		Assert.AreEqual (200, TestClass.int_val);
+	}
 
-    [Test]
-    public static void BindIntPtrStaticMethod()
-    {
-        TestClass.intptr_val = IntPtr.Zero;
-        Runtime.InvokeJS(@"
+	[Test]
+	public static void BindIntPtrStaticMethod () {
+		TestClass.intptr_val = IntPtr.Zero;
+		Runtime.InvokeJS (@"
 			var invoke_int = Module.mono_bind_static_method (""[binding_tests]TestClass:InvokeIntPtr"");
 			invoke_int (42);
 		");
 
-        Assert.AreEqual(42, TestClass.intptr_val);
-    }
+		Assert.AreEqual (42, TestClass.intptr_val);
+	}
 
-    [Test]
+	[Test]
 	public static void InvokeStaticMethod () {
 		TestClass.int_val = 0;
 		Runtime.InvokeJS (@"

--- a/sdks/wasm/driver.c
+++ b/sdks/wasm/driver.c
@@ -488,6 +488,7 @@ mono_wasm_get_obj_type (MonoObject *obj)
 	case MONO_TYPE_U4:
 	case MONO_TYPE_I8:
 	case MONO_TYPE_U8:
+	case MONO_TYPE_I:	// IntPtr
 		return MARSHAL_TYPE_INT;
 	case MONO_TYPE_R4:
 	case MONO_TYPE_R8:
@@ -552,6 +553,7 @@ mono_unbox_int (MonoObject *obj)
 	case MONO_TYPE_U2:
 		return *(unsigned short*)ptr;
 	case MONO_TYPE_I4:
+	case MONO_TYPE_I:
 		return *(int*)ptr;
 	case MONO_TYPE_U4:
 		return *(unsigned int*)ptr;

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Runtime.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Runtime.cs
@@ -351,8 +351,8 @@ namespace WebAssembly {
 					} else {
  						if (t.IsValueType)
  							throw new Exception("Can't handle VT arguments");
+						res += "o";
 					}
-					res += "o";
 					break;
 				}
 			}

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Runtime.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Runtime.cs
@@ -346,8 +346,12 @@ namespace WebAssembly {
 					res += "s";
 					break;
 				default:
-					if (t.IsValueType)
-						throw new Exception ("Can't handle VT arguments");
+					if (t == typeof(IntPtr)) { 
+ 						res += "i";
+					} else {
+ 						if (t.IsValueType)
+ 							throw new Exception("Can't handle VT arguments");
+					}
 					res += "o";
 					break;
 				}


### PR DESCRIPTION
These changes update the `release-dynamic` configuration of the wasm runtime:

- Enhance the support for dynamically linked libraries, by including all available emscripten libraries. This makes the runtime a bit larger and enables support for C++ libraries.
- Add support for `IntPtr` in JavaScript bindings.
- Enable `addFunction` support to allow for wasm originating callbacks.