### PR TITLE
[netcore] Fix Math.ILogB corner cases

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2840,6 +2840,40 @@ if test x$host_win32 = xno; then
 	dnl *********************************
 	AC_SEARCH_LIBS(sqrtf, m)
 
+	AC_MSG_CHECKING(for compatible FP_ILOGB0)
+	AC_TRY_RUN([
+#include <math.h>
+#include <stdlib.h>
+int main(void) {
+  if (FP_ILOGB0 != -2147483648) {
+    exit(1);
+  }
+  exit(0);
+}
+	], [
+				AC_MSG_RESULT(yes)
+				AC_DEFINE(HAVE_COMPATIBLE_ILOGB0, 1, [Have a portable FP_ILOGB0])
+	], [
+				AC_MSG_RESULT(no)
+	])
+
+	AC_MSG_CHECKING(for compatible FP_ILOGBNAN)
+	AC_TRY_RUN([
+#include <math.h>
+#include <stdlib.h>
+int main(void) {
+  if (FP_ILOGBNAN != 2147483647) {
+    exit(1);
+  }
+  exit(0);
+}
+	], [
+				AC_MSG_RESULT(yes)
+				AC_DEFINE(HAVE_COMPATIBLE_ILOGBNAN, 1, [Have a portable FP_ILOGBNAN])
+	], [
+				AC_MSG_RESULT(no)
+	])
+
 	dnl ****************************************************************
 	dnl *** Checks for working poll() (macosx defines it but doesn't ***
 	dnl *** have it in the library (duh))                            ***

--- a/configure.ac
+++ b/configure.ac
@@ -2840,40 +2840,6 @@ if test x$host_win32 = xno; then
 	dnl *********************************
 	AC_SEARCH_LIBS(sqrtf, m)
 
-	AC_MSG_CHECKING(for compatible FP_ILOGB0)
-	AC_TRY_RUN([
-#include <math.h>
-#include <stdlib.h>
-int main(void) {
-  if (FP_ILOGB0 != -2147483648) {
-    exit(1);
-  }
-  exit(0);
-}
-	], [
-		AC_MSG_RESULT(yes)
-		AC_DEFINE(HAVE_COMPATIBLE_ILOGB0, 1, [Have a portable FP_ILOGB0])
-	], [
-		AC_MSG_RESULT(no)
-	])
-
-	AC_MSG_CHECKING(for compatible FP_ILOGBNAN)
-	AC_TRY_RUN([
-#include <math.h>
-#include <stdlib.h>
-int main(void) {
-  if (FP_ILOGBNAN != 2147483647) {
-    exit(1);
-  }
-  exit(0);
-}
-	], [
-		AC_MSG_RESULT(yes)
-		AC_DEFINE(HAVE_COMPATIBLE_ILOGBNAN, 1, [Have a portable FP_ILOGBNAN])
-	], [
-		AC_MSG_RESULT(no)
-	])
-
 	dnl ****************************************************************
 	dnl *** Checks for working poll() (macosx defines it but doesn't ***
 	dnl *** have it in the library (duh))                            ***

--- a/configure.ac
+++ b/configure.ac
@@ -2851,10 +2851,10 @@ int main(void) {
   exit(0);
 }
 	], [
-				AC_MSG_RESULT(yes)
-				AC_DEFINE(HAVE_COMPATIBLE_ILOGB0, 1, [Have a portable FP_ILOGB0])
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_COMPATIBLE_ILOGB0, 1, [Have a portable FP_ILOGB0])
 	], [
-				AC_MSG_RESULT(no)
+		AC_MSG_RESULT(no)
 	])
 
 	AC_MSG_CHECKING(for compatible FP_ILOGBNAN)
@@ -2868,10 +2868,10 @@ int main(void) {
   exit(0);
 }
 	], [
-				AC_MSG_RESULT(yes)
-				AC_DEFINE(HAVE_COMPATIBLE_ILOGBNAN, 1, [Have a portable FP_ILOGBNAN])
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_COMPATIBLE_ILOGBNAN, 1, [Have a portable FP_ILOGBNAN])
 	], [
-				AC_MSG_RESULT(no)
+		AC_MSG_RESULT(no)
 	])
 
 	dnl ****************************************************************

--- a/mono/metadata/sysmath.c
+++ b/mono/metadata/sysmath.c
@@ -205,17 +205,11 @@ gint32
 ves_icall_System_Math_ILogB (gdouble x)
 {
 	int ret;
-#if !HAVE_COMPATIBLE_ILOGB0
-	if (x == 0.0)
+	if (FP_ILOGB0 != -2147483648 && x == 0.0)
 		ret = -2147483648;
-	else 
-#endif
-
-#if !HAVE_COMPATIBLE_ILOGBNAN
-	if (isnan(x))
+	else if (FP_ILOGBNAN != 2147483647 && isnan(x))
 		ret = 2147483647;
 	else
-#endif
 		ret = ilogb(x);
 	return ret;
 }
@@ -382,17 +376,11 @@ gint32
 ves_icall_System_MathF_ILogB (float x)
 {
 	int ret;
-#if !HAVE_COMPATIBLE_ILOGB0
-	if (x == 0.0f)
+	if (FP_ILOGB0 != -2147483648 && x == 0.0)
 		ret = -2147483648;
-	else 
-#endif
-
-#if !HAVE_COMPATIBLE_ILOGBNAN
-	if (isnan(x))
+	else if (FP_ILOGBNAN != 2147483647 && isnan(x))
 		ret = 2147483647;
 	else
-#endif
 		ret = ilogbf(x);
 	return ret;
 }

--- a/mono/metadata/sysmath.c
+++ b/mono/metadata/sysmath.c
@@ -204,7 +204,20 @@ ves_icall_System_Math_Ceiling (gdouble v)
 gint32
 ves_icall_System_Math_ILogB (gdouble x)
 {
-	return ilogb (x);
+	int ret;
+#if !HAVE_COMPATIBLE_ILOGB0
+	if (x == 0.0)
+		ret = -2147483648;
+	else 
+#endif
+
+#if !HAVE_COMPATIBLE_ILOGBNAN
+	if (isnan(x))
+		ret = 2147483647;
+	else
+#endif
+		ret = ilogb(x);
+	return ret;
 }
 
 gdouble
@@ -368,7 +381,20 @@ ves_icall_System_MathF_ModF (float x, float *d)
 gint32
 ves_icall_System_MathF_ILogB (float x)
 {
-	return ilogbf (x);
+	int ret;
+#if !HAVE_COMPATIBLE_ILOGB0
+	if (x == 0.0f)
+		ret = -2147483648;
+	else 
+#endif
+
+#if !HAVE_COMPATIBLE_ILOGBNAN
+	if (isnan(x))
+		ret = 2147483647;
+	else
+#endif
+		ret = ilogbf(x);
+	return ret;
 }
 
 float

--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -156,7 +156,6 @@ EXCLUDED_COREFX_TESTS_NOT_PASSING = \
 	System.Reflection.MetadataLoadContext.Tests \
 	System.Reflection.TypeExtensions.CoreCLR.Tests \
 	System.Reflection.TypeExtensions.Tests \
-	System.Runtime.Extensions.Tests \
 	System.Runtime.InteropServices.Tests \
 	System.Runtime.Loader.DefaultContext.Tests \
 	System.Runtime.Loader.RefEmitLoadContext.Tests \

--- a/netcore/excludes-System.Runtime.Extensions.Tests.rsp
+++ b/netcore/excludes-System.Runtime.Extensions.Tests.rsp
@@ -3,8 +3,8 @@
 -nomethod System.Tests.EnvironmentTests.FailFast_ExceptionStackTrace_ArgumentException
 -nomethod System.Tests.EnvironmentTests.FailFast_ExceptionStackTrace_StackOverflowException
 
-# Mono expands generic Types in stacktraces unlike the .NET Core (sounds more like a feature)
--method System.Tests.EnvironmentStackTrace.StackTraceTest
+# Mono expands generic Types in stacktraces unlike the .NET Core (sounds more like a feature: https://gist.github.com/EgorBo/3abb37d2ff4fc904bc7472c62498f933)
+-nomethod System.Tests.EnvironmentStackTrace.StackTraceTest
 
 # AppContext.FirstChanceException event is never fired
 -nomethod System.Tests.AppDomainTests.FirstChanceException_Called

--- a/netcore/excludes-System.Runtime.Extensions.Tests.rsp
+++ b/netcore/excludes-System.Runtime.Extensions.Tests.rsp
@@ -6,15 +6,15 @@
 # Mono expands generic Types in stacktraces unlike the .NET Core (sounds more like a feature: https://gist.github.com/EgorBo/3abb37d2ff4fc904bc7472c62498f933)
 -nomethod System.Tests.EnvironmentStackTrace.StackTraceTest
 
-# AppContext.FirstChanceException event is never fired
--nomethod System.Tests.AppDomainTests.FirstChanceException_Called
-
 # AssemblyLoadContext.InternalLoad is not implemented
 -nomethod System.Tests.AppDomainTests.LoadBytes
 
-# TODO: investigate
+# These events are not wired up in mono
 -nomethod System.Tests.AppDomainTests.TypeResolve
 -nomethod System.Tests.AppDomainTests.GetAssemblies
 -nomethod System.Tests.AppDomainTests.ResourceResolve
 -nomethod System.Tests.AppDomainTests.AssemblyLoad
--nomethod System.Runtime.Tests.ProfileOptimizationTest.ProfileOptimization_CheckFileExists
+-nomethod System.Tests.AppDomainTests.FirstChanceException_Called
+
+# AssemblyLoadContext.SetProfileOptimizationRoot is no-op (not implemented)
+-method System.Runtime.Tests.ProfileOptimizationTest.ProfileOptimization_CheckFileExists

--- a/netcore/excludes-System.Runtime.Extensions.Tests.rsp
+++ b/netcore/excludes-System.Runtime.Extensions.Tests.rsp
@@ -1,0 +1,20 @@
+# Environment.FailFast is not implemented
+-nomethod System.Tests.EnvironmentTests.FailFast_ExceptionStackTrace_InnerException
+-nomethod System.Tests.EnvironmentTests.FailFast_ExceptionStackTrace_ArgumentException
+-nomethod System.Tests.EnvironmentTests.FailFast_ExceptionStackTrace_StackOverflowException
+
+# Mono expands generic Types in stacktraces unlike the .NET Core (sounds more like a feature)
+-method System.Tests.EnvironmentStackTrace.StackTraceTest
+
+# AppContext.FirstChanceException event is never fired
+-nomethod System.Tests.AppDomainTests.FirstChanceException_Called
+
+# AssemblyLoadContext.InternalLoad is not implemented
+-nomethod System.Tests.AppDomainTests.LoadBytes
+
+# TODO: investigate
+-nomethod System.Tests.AppDomainTests.TypeResolve
+-nomethod System.Tests.AppDomainTests.GetAssemblies
+-nomethod System.Tests.AppDomainTests.ResourceResolve
+-nomethod System.Tests.AppDomainTests.AssemblyLoad
+-nomethod System.Runtime.Tests.ProfileOptimizationTest.ProfileOptimization_CheckFileExists


### PR DESCRIPTION
This PR fixes 5 tests in `System.Runtime.Extensions.Tests` (MathTests)
It's basically a copy-paste from CoreCLR:
1) https://github.com/dotnet/coreclr/blob/bd7f8e7435b8cba0cca3a198f15fdc2e4764c2fc/src/pal/src/configure.cmake#L869-L892
2) https://github.com/dotnet/coreclr/blob/master/src/pal/src/cruntime/math.cpp#L876-L894


```
System.Runtime.Extensions.Tests  Total: 6466, Errors: 0, Failed: 11, Skipped: 2
```