### PR TITLE
[interp] disable inlining for built-in types

### DIFF
--- a/mono/mini/builtin-types.cs
+++ b/mono/mini/builtin-types.cs
@@ -351,6 +351,11 @@ public class BuiltinTests {
 		return a == b;
 	}
 
+	static bool decimal_cmp_can_inline (decimal a, decimal b)
+	{
+		return a == b;
+	}
+
 	static int test_0_nint_implicit_decimal ()
 	{
 		nint a = new nint (10);
@@ -854,6 +859,9 @@ public class BuiltinTests {
 
 		if ((int) x.GetA () != 20)
 			return 6;
+
+		if (!decimal_cmp_can_inline ((int) x.GetA (), 20))
+			return 66;
 
 		if ((float) SomeNativeStructWithNuint.b != 21f)
 			return 7;

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1623,6 +1623,11 @@ interp_method_check_inlining (TransformData *td, MonoMethod *method)
 	if (method->wrapper_type != MONO_WRAPPER_NONE)
 		return FALSE;
 
+	/* Our usage of `emit_store_value_as_local ()` for nint, nuint and nfloat
+	 * is kinda hacky, and doesn't work with the inliner */
+	if (mono_class_get_magic_index (method->klass) >= 0)
+		return FALSE;
+
 	return TRUE;
 }
 


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/14246