### PR TITLE
Make copy_stack_data support configurable.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1310,6 +1310,7 @@ with_wasm_default=no
 with_bitcode_default=no
 enable_cooperative_suspend_default=no
 enable_hybrid_suspend_default=no
+enable_copy_stack_data_default=yes
 
 # For the sake of clearer error messages, these numbers should all be different from each other.
 INVARIANT_AOT_OPTIONS=nimt-trampolines=2000,ntrampolines=10000,nrgctx-fetch-trampolines=256,ngsharedvt-trampolines=4400,nftnptr-arg-trampolines=4000
@@ -5626,6 +5627,38 @@ fi
 AM_CONDITIONAL([ENABLE_HYBRID_SUSPEND], [test x$enable_hybrid_suspend != xno])
 
 dnl End of thread suspend policy
+
+dnl *******************************
+dnl *** Copy stack data support ***
+dnl *******************************
+
+dnl Disable copy_stack_data on platforms supporting full context and
+dnl having access to full stack of running threads.
+if test x$enable_copy_stack_data_default != xno; then
+	case $HOST in
+	X86 | AMD64)
+		if test x$target_osx = xyes; then
+			dnl Some host/target confusion, there's no host_osx (and
+			dnl host_darwin would be true on iOS not just macOS).
+			enable_copy_stack_data_default=no
+		elif test x$host_linux = xyes -o x$host_win32 = xyes; then
+			enable_copy_stack_data_default=no
+		fi
+		;;
+	esac
+fi
+
+AC_ARG_ENABLE(copy_stack_data, [ --enable-copy-stack-data     Enable copy_stack_data feature for hybrid/cooperative suspend scenarios, (defaults to yes)], [], [enable_copy_stack_data=default])
+
+if test x$enable_copy_stack_data = xdefault; then
+   enable_copy_stack_data=$enable_copy_stack_data_default
+fi
+
+if test x$enable_copy_stack_data != xno ; then
+	AC_DEFINE(ENABLE_COPY_STACK_DATA,1,[Enable copy_stack_data feature for hybrid/cooperative suspend scenarios])
+fi
+
+dnl End of Copy stack data support
 
 dnl ***************************
 dnl *** feature experiments ***


### PR DESCRIPTION
By default when called through macros like MONO_ENTER_GC_UNSAFE code will always dump current registers into stack space on hybrid/coop. The registers will be scanned but only when hitting a GC and when running in GC unsafe, that will only happen when we block in the enter or hit a safe point at a later point in time. There are currently a couple of frequent scenarios where we go into GC safe when thread won't be suspended and in that case the copy of the registers will only reflect the state when
entering GC unsafe.

Commits add option to enable/disable copy_stack_data support in configure step:

--enable-copy-stack-data, --disable-copy-stack-data.

copy_stack_data is enabled by default on all platforms except desktop platforms macos, linux and windows (both 32/64-bit), since these platforms already support full context as well as capabilities to scan the stack of a running thread.