### PR TITLE
Fix leak in mono_parse_options

### DIFF
--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -2996,14 +2996,14 @@ merge_parsed_options (GPtrArray *parsed_options, int *ref_argc, char **ref_argv 
 static char *
 mono_parse_options (const char *options, int *ref_argc, char **ref_argv [], gboolean prepend)
 {
+	if (options == NULL)
+		return NULL;
+
 	GPtrArray *array = g_ptr_array_new ();
 	GString *buffer = g_string_new ("");
 	const char *p;
 	gboolean in_quotes = FALSE;
 	char quote_char = '\0';
-
-	if (options == NULL)
-		return NULL;
 
 	for (p = options; *p; p++){
 		switch (*p){


### PR DESCRIPTION
When MONO_ENV_OPTIONS is null, we would leak the array and buffer



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
