### PR TITLE
[netcore] Add native ARM64 build to `--with-core=only` matrix

### DIFF
--- a/scripts/ci/pipeline-netcore-runtime.yml
+++ b/scripts/ci/pipeline-netcore-runtime.yml
@@ -19,6 +19,13 @@ jobs:
         poolname: Hosted Ubuntu 1604
         manifest: linux-x64
         sed: sed
+      Linux_ARM64:
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          poolname: Xamarin-ARM64
+        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          poolname: Xamarin-ARM64-Private
+        manifest: linux-arm64
+        sed: sed
       Windows_x64:
         poolname: Hosted VS2017
         manifest: win-x64

--- a/scripts/ci/pipeline-netcore-runtime.yml
+++ b/scripts/ci/pipeline-netcore-runtime.yml
@@ -26,6 +26,13 @@ jobs:
           poolname: Xamarin-ARM64-Private
         manifest: linux-arm64
         sed: sed
+      Linux_ARM_Hard_Float:
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          poolname: Xamarin-ARMhf
+        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          poolname: Xamarin-ARMhf-Private
+        manifest: linux-arm
+        sed: sed
       Windows_x64:
         poolname: Hosted VS2017
         manifest: win-x64

--- a/scripts/ci/pipeline-netcore-runtime.yml
+++ b/scripts/ci/pipeline-netcore-runtime.yml
@@ -26,13 +26,6 @@ jobs:
           poolname: Xamarin-ARM64-Private
         manifest: linux-arm64
         sed: sed
-      Linux_ARM_Hard_Float:
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          poolname: Xamarin-ARMhf
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          poolname: Xamarin-ARMhf-Private
-        manifest: linux-arm
-        sed: sed
       Windows_x64:
         poolname: Hosted VS2017
         manifest: win-x64


### PR DESCRIPTION
.NET SDK is installed via a step, instead of via apt, because packages.microsoft.com doesn't support ARM(64)

The other dependencies are installed on the (non-cloud) host system.