### PR TITLE
[crash] Handle OOM/blocked allocation during crash dumper

### DIFF
--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -893,7 +893,7 @@ dump_memory_around_ip (MonoContext *mctx)
 		return;
 
 	g_async_safe_printf ("\n=================================================================\n");
-	g_async_safe_printf ("\tBasic Fault Adddress Reporting\n");
+	g_async_safe_printf ("\tBasic Fault Address Reporting\n");
 	g_async_safe_printf ("=================================================================\n");
 
 	gpointer native_ip = MONO_CONTEXT_GET_IP (mctx);

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -249,7 +249,7 @@ MONO_SIG_HANDLER_FUNC (static, sigterm_signal_handler)
 	// Will return when the dumping is done, so this thread can continue
 	// running. Returns FALSE on unrecoverable error.
 	if (!mono_threads_summarize_execute (&mctx, &output, &hashes, FALSE, NULL, 0))
-		g_assert_not_reached ();
+		g_error ("Crash reporter dumper exited due to fatal error.");
 #endif
 
 	mono_chain_signal (MONO_SIG_HANDLER_PARAMS);


### PR DESCRIPTION
The issues fixed below were identified by https://github.com/mono/mono/issues/14416 .

The typo is a cosmetic fix.

The other change uses g_error and not g_assert_not_reached. g_error goes through the already-modified path that will work correctly during double faults during the crash dumper. Otherwise, the double fault results in a zero/successful status code.

The reproduction for this involves preventing mono from creating any more allocations, using `ulimit`.

