### PR TITLE
Plug leak of ppdb_filename

### DIFF
--- a/mono/metadata/debug-mono-ppdb.c
+++ b/mono/metadata/debug-mono-ppdb.c
@@ -154,8 +154,7 @@ mono_ppdb_load_file (MonoImage *image, const guint8 *raw_contents, int size)
 		}
 
 		ppdb_image = mono_image_open_metadata_only (ppdb_filename, &status);
-		if (!ppdb_image)
-			g_free (ppdb_filename);
+		g_free (ppdb_filename);
 	}
 	if (!ppdb_image)
 		return NULL;


### PR DESCRIPTION
mono_image_open_metadata_only and its callees all dupe the filename string, so free the string after mono_image_open_metadata_only is done with it:

```
      1 (128 bytes) ROOT LEAK: 0x7fb07f086c80 [128]  length: 105  "/Users/therzok/Work/md/md-addins/external-addins/MonoDevelop.MonoDroid/build/Xamarin.Installer.Common.pdb"
```



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
