### PR TITLE
MONO_PATCH_INFO_JIT_ICALL cleanup

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -3878,8 +3878,6 @@ static inline gboolean
 is_plt_patch (MonoJumpInfo *patch_info)
 {
 	switch (patch_info->type) {
-	case MONO_PATCH_INFO_JIT_ICALL: //temporary
-		g_assert (!15);
 	case MONO_PATCH_INFO_METHOD:
 	case MONO_PATCH_INFO_JIT_ICALL_ID:
 	case MONO_PATCH_INFO_JIT_ICALL_ADDR:
@@ -6170,18 +6168,9 @@ emit_and_reloc_code (MonoAotCompile *acfg, MonoMethod *method, guint8 *code, gui
 						g_assert (strlen (sym) < 1000);
 						direct_call_target = g_strdup_printf ("%s%s", acfg->user_symbol_prefix, sym);
 					}
-				} else if (patch_info->type == MONO_PATCH_INFO_JIT_ICALL //temporary
-						|| patch_info->type == MONO_PATCH_INFO_JIT_ICALL_ID) {
-					MonoJitICallInfo *info;
-					const char *sym;
-					if (patch_info->type == MONO_PATCH_INFO_JIT_ICALL) { //temporary
-						g_assert (!1);
-						info = mono_find_jit_icall_by_name (patch_info->data.name);
-						sym = mono_lookup_jit_icall_symbol (patch_info->data.name);
-					} else {
-						info = mono_find_jit_icall_info (patch_info->data.jit_icall_id);
-						sym = info->c_symbol;
-					}
+				} else if (patch_info->type == MONO_PATCH_INFO_JIT_ICALL_ID) {
+					MonoJitICallInfo * const info = mono_find_jit_icall_info (patch_info->data.jit_icall_id);
+					const char * const sym = info->c_symbol;
 					if (!got_only && sym && acfg->aot_opts.direct_icalls && info->func == info->wrapper) {
 						/* Call to a jit icall without a wrapper */
 						direct_call = TRUE;
@@ -6511,8 +6500,6 @@ encode_patch (MonoAotCompile *acfg, MonoJumpInfo *patch_info, guint8 *buf, guint
 	case MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR:
 		encode_value (patch_info->data.uindex, p, &p);
 		break;
-	case MONO_PATCH_INFO_JIT_ICALL: //temporary
-		g_assert (!2);
 	case MONO_PATCH_INFO_LDSTR_LIT:
 	case MONO_PATCH_INFO_JIT_ICALL_ADDR:
 	case MONO_PATCH_INFO_JIT_ICALL_ADDR_NOCALL: {
@@ -7208,10 +7195,6 @@ get_plt_entry_debug_sym (MonoAotCompile *acfg, MonoJumpInfo *ji, GHashTable *cac
 		break;
 	case MONO_PATCH_INFO_JIT_ICALL_ID:
 		debug_sym = g_strdup_printf ("%s_jit_icall_%s", prefix, mono_find_jit_icall_info (ji->data.jit_icall_id)->name);
-		break;
-	case MONO_PATCH_INFO_JIT_ICALL: //temporary
-		g_assert (!3);
-		debug_sym = g_strdup_printf ("%s_jit_icall_%s", prefix, ji->data.name);
 		break;
 	case MONO_PATCH_INFO_RGCTX_FETCH:
 		debug_sym = g_strdup_printf ("%s_rgctx_fetch_%d", prefix, acfg->label_generator ++);
@@ -9539,18 +9522,9 @@ mono_aot_get_direct_call_symbol (MonoJumpInfoType type, gconstpointer data)
 				sym = lookup_icall_symbol_name_aot (method);
 			else if (llvm_acfg->aot_opts.direct_pinvoke)
 				sym = get_pinvoke_import (llvm_acfg, method);
-		} else if (type == MONO_PATCH_INFO_JIT_ICALL || //temporary
-				type == MONO_PATCH_INFO_JIT_ICALL_ID) {
-			MonoJitICallInfo *info;
-			const char *name;
-			if (type == MONO_PATCH_INFO_JIT_ICALL) {//temporary
-				g_assert (!4);
-				info = mono_find_jit_icall_by_name ((const char*)data);
-				name = mono_lookup_jit_icall_symbol ((const char*)data);
-			} else {
-				info = mono_find_jit_icall_info ((MonoJitICallId)(gsize)data);
-				name = info->c_symbol;
-			}
+		} else if (type == MONO_PATCH_INFO_JIT_ICALL_ID) {
+			MonoJitICallInfo const * const info = mono_find_jit_icall_info ((MonoJitICallId)(gsize)data);
+			char const * const name = info->c_symbol;
 			if (name && info->func == info->wrapper)
 				sym = name;
 		}

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -3773,8 +3773,6 @@ decode_patch (MonoAotModule *aot_module, MonoMemPool *mp, MonoJumpInfo *ji, guin
 		}
 		break;
 	}
-	case MONO_PATCH_INFO_JIT_ICALL://temporary
-		g_assert (!5);
 	case MONO_PATCH_INFO_LDSTR_LIT:
 	case MONO_PATCH_INFO_JIT_ICALL_ADDR:
 	case MONO_PATCH_INFO_JIT_ICALL_ADDR_NOCALL:
@@ -5123,16 +5121,13 @@ mono_aot_plt_resolve (gpointer aot_module, guint32 plt_info_offset, guint8 *code
 		}
 	}
 
-	g_assert (ji.type != MONO_PATCH_INFO_JIT_ICALL); //temporary
-
 	/*
 	 * The trampoline expects us to return a function descriptor on platforms which use
 	 * it, but resolve_patch_target returns a direct function pointer for some type of
 	 * patches, so have to translate between the two.
 	 * FIXME: Clean this up, but how ?
 	 */
-	if (ji.type == MONO_PATCH_INFO_ABS || ji.type == MONO_PATCH_INFO_JIT_ICALL_ID ||
-		ji.type == MONO_PATCH_INFO_JIT_ICALL //temporary
+	if (ji.type == MONO_PATCH_INFO_ABS || ji.type == MONO_PATCH_INFO_JIT_ICALL_ID
 		|| ji.type == MONO_PATCH_INFO_ICALL_ADDR
 		|| ji.type == MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR || ji.type == MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR
 		|| ji.type == MONO_PATCH_INFO_JIT_ICALL_ADDR || ji.type == MONO_PATCH_INFO_RGCTX_FETCH) {
@@ -5140,7 +5135,6 @@ mono_aot_plt_resolve (gpointer aot_module, guint32 plt_info_offset, guint8 *code
 #ifdef PPC_USES_FUNCTION_DESCRIPTOR
 		/* Our function descriptors have a 0 environment, gcc created ones don't */
 		if (ji.type != MONO_PATCH_INFO_JIT_ICALL_ID &&
-				ji.type != MONO_PATCH_INFO_JIT_ICALL //temporary
 				&& ji.type != MONO_PATCH_INFO_JIT_ICALL_ADDR && ji.type != MONO_PATCH_INFO_ICALL_ADDR
 				&& ji.type != MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR && ji.type != MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR)
 			g_assert (((gpointer*)target) [2] == 0);

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -3021,7 +3021,6 @@ emit_call_body (MonoCompile *cfg, guint8 *code, MonoJumpInfoType patch_type, gco
 	gboolean no_patch = FALSE;
 
 	g_assert (patch_type == MONO_PATCH_INFO_METHOD ||	// data is MonoMethod*; MONO_PATCH_INFO_METHOD_JUMP is already reasonable
-		  //patch_type == MONO_PATCH_INFO_JIT_ICALL ||	// data is function name //temporary
 		  patch_type == MONO_PATCH_INFO_JIT_ICALL_ID ||	// data is function id
 		  patch_type == MONO_PATCH_INFO_ABS);		// data is code pointer, hashed to MonoJumpInfo* with additional patch type/data
 
@@ -3050,22 +3049,15 @@ emit_call_body (MonoCompile *cfg, guint8 *code, MonoJumpInfoType patch_type, gco
 					near_call = FALSE;
 			}
 
-			if (patch_type == MONO_PATCH_INFO_JIT_ICALL || patch_type == MONO_PATCH_INFO_JIT_ICALL_ID) {
+			if (patch_type == MONO_PATCH_INFO_JIT_ICALL_ID) {
 				/* 
 				 * The call might go directly to a native function without
 				 * the wrapper.
 				 */
-				MonoJitICallInfo *mi;
-				if (patch_type == MONO_PATCH_INFO_JIT_ICALL) { //temporary
-					g_assert (!6);
-					mi = mono_find_jit_icall_by_name ((const char *)data);
-				} else
-					mi = mono_find_jit_icall_info ((MonoJitICallId)(gsize)data);
-				if (mi) {
-					gconstpointer target = mono_icall_get_wrapper (mi);
-					if ((((guint64)target) >> 32) != 0)
-						near_call = FALSE;
-				}
+				MonoJitICallInfo * const mi = mono_find_jit_icall_info ((MonoJitICallId)(gsize)data);
+				gconstpointer target = mono_icall_get_wrapper (mi);
+				if ((((guint64)target) >> 32) != 0)
+					near_call = FALSE;
 			}
 		}
 		else {
@@ -6852,10 +6844,6 @@ mono_arch_patch_code_new (MonoCompile *cfg, MonoDomain *domain, guint8 *code, Mo
 		if (!amd64_is_imm32 (disp)) {
 			printf ("TYPE: %d\n", ji->type);
 			switch (ji->type) {
-			case MONO_PATCH_INFO_JIT_ICALL: //temporary
-				g_assert (!7);
-				printf ("V: %s\n", ji->data.name);
-				break;
 			case MONO_PATCH_INFO_JIT_ICALL_ID:
 				printf ("V: %s\n", mono_find_jit_icall_info (ji->data.jit_icall_id)->name);
 				break;

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -4680,8 +4680,6 @@ mono_arch_patch_code_new (MonoCompile *cfg, MonoDomain *domain, guint8 *code, Mo
 		/* everything is dealt with at epilog output time */
 		break;
 #ifdef PPC_USES_FUNCTION_DESCRIPTOR
-	case MONO_PATCH_INFO_JIT_ICALL: //temporary
-		g_assert (!21);
 	case MONO_PATCH_INFO_JIT_ICALL_ID:
 	case MONO_PATCH_INFO_ABS:
 	case MONO_PATCH_INFO_RGCTX_FETCH:

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -1070,10 +1070,6 @@ mono_print_ji (const MonoJumpInfo *ji)
 		g_free (s);
 		break;
 	}
-	case MONO_PATCH_INFO_JIT_ICALL: //temporary
-		g_assert (!22);
-		printf ("[JIT_ICALL %s]", ji->data.name);
-		break;
 	case MONO_PATCH_INFO_JIT_ICALL_ID:
 		printf ("[JIT_ICALL %s]", mono_find_jit_icall_info (ji->data.jit_icall_id)->name);
 		break;
@@ -1200,8 +1196,6 @@ mono_patch_info_hash (gconstpointer data)
 	case MONO_PATCH_INFO_OBJC_SELECTOR_REF: // Hash on the selector name
 	case MONO_PATCH_INFO_LDSTR_LIT:
 		return g_str_hash (ji->data.name);
-	case MONO_PATCH_INFO_JIT_ICALL: //temporary
-		g_assert (!23);
 	case MONO_PATCH_INFO_JIT_ICALL_ADDR:
 	case MONO_PATCH_INFO_JIT_ICALL_ADDR_NOCALL:
 		return hash | g_str_hash (ji->data.name);
@@ -1251,16 +1245,6 @@ mono_patch_info_hash (gconstpointer data)
 	case MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR:
 		return hash | ji->data.uindex;
 	case MONO_PATCH_INFO_JIT_ICALL_ID:
-#if 0 // Temporarily MONO_PATCH_INFO_JIT_ICALL and MONO_PATCH_INFO_JIT_ICALL_ID can be mixed.
-      // This lets us partially convert without failing due to duplicate PLT entries?
-      // Or so I thought. In the face of errors, conversion completed.
-		{
-			MonoJumpInfo ji2;
-			ji2.type = MONO_PATCH_INFO_JIT_ICALL;
-			ji2.data.name = mono_find_jit_icall_info (ji->data.jit_icall_id)->name;
-			return mono_patch_info_hash (&ji2);
-		}
-#endif
 	case MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR:
 	case MONO_PATCH_INFO_CASTCLASS_CACHE:
 		return hash | ji->data.index;
@@ -1301,18 +1285,8 @@ mono_patch_info_equal (gconstpointer ka, gconstpointer kb)
 	MonoJumpInfoType const ji1_type = ji1->type;
 	MonoJumpInfoType const ji2_type = ji2->type;
 
-	if (ji1_type != ji2_type) {
-#if 0 // Temporarily MONO_PATCH_INFO_JIT_ICALL and MONO_PATCH_INFO_JIT_ICALL_ID can be mixed.
-      // This lets us partially convert without failing due to duplicate PLT entries?
-      // Or so I thought. In the face of errors, conversion completed.
-		if (ji1_type == MONO_PATCH_INFO_JIT_ICALL_ID && ji2_type == MONO_PATCH_INFO_JIT_ICALL)
-			return mono_patch_info_equal (ji2, ji1);
-
-		if (ji1_type == MONO_PATCH_INFO_JIT_ICALL && ji2_type == MONO_PATCH_INFO_JIT_ICALL_ID)
-			return g_str_equal (ji1->data.name, mono_get_jit_icall_info (ji2->data.jit_icall_id)->name);
-#endif
+	if (ji1_type != ji2_type)
 		return 0;
-	}
 
 	switch (ji1_type) {
 	case MONO_PATCH_INFO_RVA:
@@ -1325,8 +1299,6 @@ mono_patch_info_equal (gconstpointer ka, gconstpointer kb)
 		       ji1->data.token->has_context == ji2->data.token->has_context &&
 		       ji1->data.token->context.class_inst == ji2->data.token->context.class_inst &&
 		       ji1->data.token->context.method_inst == ji2->data.token->context.method_inst;
-	case MONO_PATCH_INFO_JIT_ICALL: //temporary
-		g_assert (!11);
 	case MONO_PATCH_INFO_OBJC_SELECTOR_REF:
 	case MONO_PATCH_INFO_LDSTR_LIT:
 	case MONO_PATCH_INFO_JIT_ICALL_ADDR:
@@ -1396,17 +1368,9 @@ mono_resolve_patch_target (MonoMethod *method, MonoDomain *domain, guint8 *code,
 	case MONO_PATCH_INFO_METHOD_REL:
 		target = code + patch_info->data.offset;
 		break;
-	case MONO_PATCH_INFO_JIT_ICALL: //temporary
-		g_assert (!12);
 	case MONO_PATCH_INFO_JIT_ICALL_ID: {
-		MonoJitICallInfo *mi;
-		if (patch_info->type == MONO_PATCH_INFO_JIT_ICALL) { //temporary
-			mi = mono_find_jit_icall_by_name (patch_info->data.name);
-			g_assertf (mi, "unknown MONO_PATCH_INFO_JIT_ICALL %s", patch_info->data.name);
-		}
-		else
-			mi = mono_find_jit_icall_info (patch_info->data.jit_icall_id);
-		g_assertf (mi, "unknown MONO_PATCH_INFO_JIT_ICALL_ID %s", patch_info->data.name);
+		MonoJitICallInfo * const mi = mono_find_jit_icall_info (patch_info->data.jit_icall_id);
+		g_assertf (mi, "unknown MONO_PATCH_INFO_JIT_ICALL_ID %d", (int)patch_info->data.jit_icall_id);
 		target = mono_icall_get_wrapper (mi);
 		break;
 	}

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -5338,8 +5338,6 @@ mono_arch_patch_code (MonoCompile *cfg, MonoMethod *method, MonoDomain *domain,
 			case MONO_PATCH_INFO_EXC:
 				s390_patch_addr (ip, (guint64) target);
 				continue;
-			case MONO_PATCH_INFO_JIT_ICALL: //temporary
-				g_assert (!13);
 			case MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR:
 			case MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR:
 			case MONO_PATCH_INFO_METHOD:

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -4897,8 +4897,6 @@ mono_arch_patch_code_new (MonoCompile *cfg, MonoDomain *domain, guint8 *code, Mo
 	case MONO_PATCH_INFO_IP:
 		*((gconstpointer *)(ip)) = target;
 		break;
-	case MONO_PATCH_INFO_JIT_ICALL: //temporary
-		g_assert (!14);
 	case MONO_PATCH_INFO_ABS:
 	case MONO_PATCH_INFO_METHOD:
 	case MONO_PATCH_INFO_METHOD_JUMP:

--- a/mono/mini/patch-info.h
+++ b/mono/mini/patch-info.h
@@ -5,26 +5,8 @@ PATCH_INFO(METHOD, "method")
 PATCH_INFO(METHOD_JUMP, "method_jump")
 PATCH_INFO(METHOD_REL, "method_rel")
 PATCH_INFO(METHODCONST, "methodconst")
-/* Either the address of a C function implementing a JIT icall, or a wrapper around it */
-// MONO_PATCH_INFO_JIT_ICALL is obsolete but is deliberately kept for reasons:
-//  - It is easier to search the tree for MONO_PATCH_INFO_JIT_ICALL and verify
-//    all instances are converted to allow MONO_PATCH_INFO_JIT_ICALL_ID and that
-//    they all fail an assert, than it is to visit all converted MONO_PATCH_INFO_JIT_ICALL
-//    and verify they are converted, Basically, you want instantiations of
-//    MONO_PATCH_INFO_JIT_ICALL to drain away, and only leave support/detection for it.
-//  - While this PR currently converts all MONO_PATCH_INFO_JIT_ICALL instantiations,
-//    having them both temporarily allows splitting this PR up into smaller chunks.
-//    Arguably the support should have gone in ahead of any uses.
-//  - Changing the name, instead of giving it new semantics, allows for cross-branch
-//    porting of changes with arguably ease. It is not intended to port MONO_PATCH_INFO_JIT_ICALL_ID,
-//    cross branch, but one cannot rule out nearby lines being ported.
-//    Actually changing MONO_PATCH_INFO_JIT_ICALL to MONO_PATCH_INFO_JIT_ICALL_ID encourages
-//    merge conflicts and extra attention, instead of accidentally porting a change
-//    that uses the wrong type along with MONO_PATCH_INFO_JIT_ICALL.
-//  - As the tree stabilizes near MONO_PATCH_INFO_JIT_ICALL[_ID], i.e. once it has
-//    has released once or twice, MONO_PATCH_INFO_JIT_ICALL can be later cleaned up.
-//
-PATCH_INFO(JIT_ICALL, "jit_icall") // obsolete, temporary
+// Either the address of a C function implementing a JIT icall, or a wrapper around it
+PATCH_INFO(JIT_ICALL_ID, "jit_icall_id") // replaced MONO_PATCH_INFO_JIT_ICALL, using enum instead of string
 PATCH_INFO(SWITCH, "switch")
 PATCH_INFO(EXC, "exc")
 PATCH_INFO(EXC_NAME, "exc_name")
@@ -91,5 +73,3 @@ PATCH_INFO(METHOD_FTNDESC, "method_ftndesc")
 
 PATCH_INFO(TRAMPOLINE_FUNC_ADDR, "trampoline_func_addr")
 PATCH_INFO(SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR, "specific_trampoline_lazy_fetch_addr")
-// Either the address of a C function implementing a JIT icall, or a wrapper around it
-PATCH_INFO(JIT_ICALL_ID, "jit_icall_id") // replaced jit_icall, using enum instead of string


### PR DESCRIPTION
The most important point of the "temporary" aspect, esp. given
the complete conversion, is renaming MONO_PATCH_INFO_JIT_ICALL to MONO_PATCH_INFO_JIT_ICALL_ID.
Any accidental or merged MONO_PATCH_INFO_JIT_ICALL will fail to compile.
