### PR TITLE
[netcore] add some intrinsics for interpreter

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -3005,6 +3005,11 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 			ip += 4;
 			++sp;
 			MINT_IN_BREAK;
+		MINT_IN_CASE(MINT_LDC_I8_S)
+			sp->data.l = *(const short *)(ip + 1);
+			ip += 2;
+			++sp;
+			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_LDC_R4) {
 			guint32 val;
 			++ip;

--- a/mono/mini/interp/mintops.def
+++ b/mono/mini/interp/mintops.def
@@ -37,6 +37,7 @@ OPDEF(MINT_LDC_I4_8, "ldc.i4.8", 1, MintOpNoArgs)
 OPDEF(MINT_LDC_I4_S, "ldc.i4.s", 2, MintOpShortInt)
 OPDEF(MINT_LDC_I4, "ldc.i4", 3, MintOpInt)
 OPDEF(MINT_LDC_I8, "ldc.i8", 5, MintOpLongInt)
+OPDEF(MINT_LDC_I8_S, "ldc.i8.s", 2, MintOpShortInt)
 
 OPDEF(MINT_LDC_R4, "ldc.r4", 3, MintOpFloat)
 OPDEF(MINT_LDC_R8, "ldc.r8", 5, MintOpDouble)

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1469,11 +1469,8 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 			return TRUE;
 		}
 	} else if (in_corlib && !strcmp (klass_name_space, "System.Threading") && !strcmp (klass_name, "Interlocked")) {
-		if (!strcmp (tm, "MemoryBarrier") && csignature->param_count == 0) {
-			interp_add_ins (td, MINT_MONO_MEMORY_BARRIER);
-			td->ip += 5;
-			return TRUE;
-		}
+		if (!strcmp (tm, "MemoryBarrier") && csignature->param_count == 0)
+			*op = MINT_MONO_MEMORY_BARRIER;
 	}
 
 	return FALSE;

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1349,7 +1349,12 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 			*op = MINT_INTRINS_UNSAFE_BYTE_OFFSET;
 		else if (!strcmp (tm, "As") || !strcmp (tm, "AsRef"))
 			*op = MINT_NOP;
-		else if (!strcmp (tm, "SizeOf")) {
+		else if (!strcmp (tm, "AsPointer")) {
+			/* NOP */
+			SET_SIMPLE_TYPE (td->sp - 1, STACK_TYPE_MP);
+			td->ip += 5;
+			return TRUE;
+		} else if (!strcmp (tm, "SizeOf")) {
 			MonoGenericContext *ctx = mono_method_get_context (target_method);
 			g_assert (ctx);
 			g_assert (ctx->method_inst);

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1356,6 +1356,18 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 			SET_SIMPLE_TYPE (td->sp - 1, STACK_TYPE_MP);
 			td->ip += 5;
 			return TRUE;
+		} else if (!strcmp (tm, "IsAddressLessThan")) {
+			MonoGenericContext *ctx = mono_method_get_context (target_method);
+			g_assert (ctx);
+			g_assert (ctx->method_inst);
+			g_assert (ctx->method_inst->type_argc == 1);
+
+			MonoClass *k = mono_defaults.boolean_class;
+			interp_add_ins (td, MINT_CLT_UN_P);
+			td->sp -= 1;
+			SET_TYPE (td->sp - 1, stack_type [mint_type (m_class_get_byval_arg (k))], k);
+			td->ip += 5;
+			return TRUE;
 		} else if (!strcmp (tm, "SizeOf")) {
 			MonoGenericContext *ctx = mono_method_get_context (target_method);
 			g_assert (ctx);

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1264,6 +1264,7 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 				*op = MINT_BREAK;
 		}
 	} else if (in_corlib && !strcmp (klass_name_space, "System") && !strcmp (klass_name, "ByReference`1")) {
+		g_assert (!strcmp (tm, "get_Value"));
 		*op = MINT_INTRINS_BYREFERENCE_GET_VALUE;
 	} else if (in_corlib && !strcmp (klass_name_space, "System") && !strcmp (klass_name, "Math") && csignature->param_count == 1 && csignature->params [0]->type == MONO_TYPE_R8) {
 		if (tm [0] == 'A') {

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1413,6 +1413,7 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 		else if (!strcmp (tm, "GetType"))
 			*op = MINT_INTRINS_GET_TYPE;
 #endif
+#ifdef ENABLE_NETCORE
 		else if (!strcmp (tm, "GetRawData")) {
 			gint64 val = MONO_ABI_SIZEOF (MonoObject);
 			interp_add_ins (td, MINT_LDC_I8);
@@ -1424,6 +1425,7 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 			td->ip += 5;
 			return TRUE;
 		}
+#endif
 	} else if (in_corlib && target_method->klass == mono_defaults.enum_class && !strcmp (tm, "HasFlag")) {
 		gboolean intrinsify = FALSE;
 		MonoClass *base_klass = NULL;
@@ -1469,8 +1471,10 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 			return TRUE;
 		}
 	} else if (in_corlib && !strcmp (klass_name_space, "System.Threading") && !strcmp (klass_name, "Interlocked")) {
+#if ENABLE_NETCORE
 		if (!strcmp (tm, "MemoryBarrier") && csignature->param_count == 0)
 			*op = MINT_MONO_MEMORY_BARRIER;
+#endif
 	}
 
 	return FALSE;

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -200,6 +200,7 @@ static int stack_type [] = {
 #define MINT_CLT_FP MINT_CLT_R8
 #define MINT_CLE_FP MINT_CLE_R8
 
+#define MINT_CONV_OVF_U4_P MINT_CONV_OVF_U4_I8
 #else
 
 #define MINT_NEG_P MINT_NEG_I4
@@ -245,6 +246,7 @@ static int stack_type [] = {
 #define MINT_CLT_FP MINT_CLT_R4
 #define MINT_CLE_FP MINT_CLE_R4
 
+#define MINT_CONV_OVF_U4_P MINT_CONV_OVF_U4_I4
 #endif
 
 typedef struct {
@@ -5030,6 +5032,9 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 				break;
 			case STACK_TYPE_I8:
 				interp_add_ins (td, MINT_CONV_OVF_U4_I8);
+				break;
+			case STACK_TYPE_MP:
+				interp_add_ins (td, MINT_CONV_OVF_U4_P);
 				break;
 			default:
 				g_assert_not_reached ();

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1437,6 +1437,12 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 			td->ip += 5;
 			return TRUE;
 		}
+	} else if (in_corlib && !strcmp (klass_name_space, "System.Threading") && !strcmp (klass_name, "Interlocked")) {
+		if (!strcmp (tm, "MemoryBarrier") && csignature->param_count == 0) {
+			interp_add_ins (td, MINT_MONO_MEMORY_BARRIER);
+			td->ip += 5;
+			return TRUE;
+		}
 	}
 
 	return FALSE;

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1415,9 +1415,12 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 #endif
 #ifdef ENABLE_NETCORE
 		else if (!strcmp (tm, "GetRawData")) {
-			gint64 val = MONO_ABI_SIZEOF (MonoObject);
-			interp_add_ins (td, MINT_LDC_I8);
-			WRITE64_INS (td->last_ins, 0, &val);
+#if SIZEOF_VOID_P == 8
+			interp_add_ins (td, MINT_LDC_I8_S);
+#else
+			interp_add_ins (td, MINT_LDC_I4_S);
+#endif
+			td->last_ins->data [0] = (gint16) MONO_ABI_SIZEOF (MonoObject);
 
 			interp_add_ins (td, MINT_ADD_P);
 			SET_SIMPLE_TYPE (td->sp - 1, STACK_TYPE_MP);


### PR DESCRIPTION
```console
$ MONO_ENV_OPTIONS='--interp' make -C netcore xtest-System.Runtime.Tests
Microsoft.DotNet.XUnitConsoleRunner v2.5.0 (64-bit .NET Core 3.0.0-preview5-27620-01)
  Discovering: System.Runtime.Tests (method display = ClassAndMethod, method display options = None)
  Discovered:  System.Runtime.Tests (found 5266 of 5402 test cases)
  Starting:    System.Runtime.Tests (parallel test collections = on, max threads = 16)
[...]
  Finished:    System.Runtime.Tests
=== TEST EXECUTION SUMMARY ===
   System.Runtime.Tests  Total: 32485, Errors: 0, Failed: 23, Skipped: 2, Time: 126.432s
```
See failures here: https://gist.github.com/lewurm/c8372b0c7ba6a78cf8b7b7b8c7090820