### PR TITLE
[interp] add missing enum check on constrained callvirt

### DIFF
--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1896,7 +1896,7 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 				 * but that type doesn't override the method we're
 				 * calling, so we need to box `this'.
 				 */
-				if ((td->sp - csignature->param_count - 1)->type == STACK_TYPE_MP) {
+				if (target_method->klass == mono_defaults.enum_class && (td->sp - csignature->param_count - 1)->type == STACK_TYPE_MP) {
 					/* managed pointer on the stack, we need to deref that puppy */
 					/* Always load the entire stackval, to handle also the case where the enum has long storage */
 					interp_add_ins (td, MINT_LDIND_I8);


### PR DESCRIPTION
This detail got lost when the code was duplicated here: https://github.com/mono/mono/pull/13154/files#diff-f115ce23fba6528256a47e2b7e8b0a19R1611

Fixes `mono/tests/dim-constrainedcall.il` on the interpreter. This PR will enable it: https://github.com/mono/mono/pull/14166

/cc @thaystg @kg 