### PR TITLE
[loaded LLVM] mono_gchandle_get_target_internal needs MONO_LLVM_INTERNAL.

### DIFF
--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -2334,7 +2334,7 @@ uint32_t
 mono_gchandle_new_weakref_internal (MonoObject *obj, mono_bool track_resurrection);
 
 MonoObject*
-mono_gchandle_get_target_internal (uint32_t gchandle);
+mono_gchandle_get_target_internal (uint32_t gchandle) MONO_LLVM_INTERNAL;
 
 void mono_gchandle_free_internal (uint32_t gchandle);
 


### PR DESCRIPTION
Found by ld -z now
 https://github.com/mono/mono/pull/14562
 https://jenkins.mono-project.com/job/test-mono-pull-request-amd64-prefix/1398/parsed_console/log.html

 instruction pointer is NULL, skip dumping/mnt/jenkins/workspace/test-mono-pull-request-amd64-prefix/scripts/ci/babysitter: Test suite terminated with code -6, and suite cannot report test case data. Halting.
 *** start: check-prefix-llvmjit
 llvm load failed: /mnt/jenkins/workspace/test-mono-pull-request-amd64-prefix/tmp/monoprefix/lib/libmono-llvm.so: undefined symbol: mono_gchandle_get_target_internal

Mono Warning: llvm support could not be loaded.

There could be more of these, I don't know if it finds them all at once or just one at a time.
