### PR TITLE
[llvm] Remove unused default_mono_llvm_unhandled_exception.

### DIFF
--- a/mono/mini/mini-llvm-cpp.h
+++ b/mono/mini/mini-llvm-cpp.h
@@ -141,9 +141,6 @@ G_EXTERN_C _Unwind_Reason_Code mono_debug_personality (int a, _Unwind_Action b,
 	uint64_t c, struct _Unwind_Exception *d, struct _Unwind_Context *e);
 #endif
 
-void
-default_mono_llvm_unhandled_exception (void);
-
 void*
 mono_llvm_create_di_builder (LLVMModuleRef module);
 

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -9938,17 +9938,6 @@ emit_default_dbg_loc (EmitContext *ctx, LLVMBuilderRef builder)
 #endif
 }
 
-void
-default_mono_llvm_unhandled_exception (void)
-{
-	MonoJitTlsData *jit_tls = mono_get_jit_tls ();
-	MonoObject *target = mono_gchandle_get_target_internal (jit_tls->thrown_exc);
-
-	mono_unhandled_exception_internal (target);
-	mono_invoke_unhandled_exception_hook (target);
-	g_assert_not_reached ();
-}
-
 /*
   DESIGN:
   - Emit LLVM IR from the mono IR using the LLVM C API.
@@ -10066,11 +10055,6 @@ mono_llvm_free_domain_info (MonoDomain *domain)
 
 void
 mono_llvm_init (void)
-{
-}
-
-void
-default_mono_llvm_unhandled_exception (void)
 {
 }
 


### PR DESCRIPTION
It references mono_gchandle_get_target_internal which is not marked MONO_LLVM_INTERNAL
so attempts to run it will fail.

This is caught by linking wit -z now (https://github.com/mono/mono/pull/14562).

Alternative to https://github.com/mono/mono/pull/14567.
