### PR TITLE
[interp] set correct stack type on op_Implicit/op_Explicit intrinsics for native types

### DIFF
--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -1133,7 +1133,6 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 				return FALSE;
 			}
 
-#if SIZEOF_VOID_P == 4
 			if (src_size > dst_size) { // 8 -> 4
 				switch (type_index) {
 				case 0: case 1:
@@ -1144,9 +1143,7 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 					break;
 				}
 			}
-#endif
 
-#if SIZEOF_VOID_P == 8
 			if (src_size < dst_size) { // 4 -> 8
 				switch (type_index) {
 				case 0:
@@ -1160,9 +1157,8 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 					break;
 				}
 			}
-#endif
 
-			SET_TYPE (td->sp - 1, stack_type [mt], magic_class);
+			SET_TYPE (td->sp - 1, stack_type [mint_type (dst)], mono_class_from_mono_type_internal (dst));
 			td->ip += 5;
 			return TRUE;
 		} else if (!strcmp ("op_Increment", tm)) {


### PR DESCRIPTION
Needs some additional conversions which happen to be included by accident previously.

This fixes those warnings on amd64:
```
Test run:
image=/Users/lewurm/work/mono-dim-call/mono/mini/builtin-types.exe
BuiltinTests.test_0_nuint_fieldload: Store local stack type mismatch 0 1
BuiltinTests.test_0_much_casting: Store local stack type mismatch 0 1
Results: total tests: 84, all pass
Elapsed time: 0.026546 secs (0.026546, 0.000000)
```

and those warnings on armv7:
```
Test run: image=/mono/mono/mini/builtin-types.exe
BuiltinTests.test_0_nint_inc: 0011 arith type mismatch add.i4 0 1
BuiltinTests.test_0_nint_dec: 0011 arith type mismatch sub.i4 0 1
BuiltinTests.test_0_nint_implicit_decimal: 0034 arith type mismatch
add.i4 0 1
BuiltinTests.test_0_nuint_inc: 0011 arith type mismatch add.i4 0 1
BuiltinTests.test_0_nuint_dec: 0011 arith type mismatch sub.i4 0 1
BuiltinTests.test_0_nuint_implicit_decimal: 0034 arith type mismatch
add.i4 0 1
Results: total tests: 84, all pass
Elapsed time: 0.039214 secs (0.039214, 0.000000)
```


