### PR TITLE
[2019-02] [2018-10] [Android] Fix runtime loading of DSOs for 64-bit processes

### DIFF
--- a/mono/metadata/loader.c
+++ b/mono/metadata/loader.c
@@ -1382,8 +1382,20 @@ mono_lookup_pinvoke_call (MonoMethod *method, const char **exc_class, const char
 
 							base = g_path_get_dirname (resolvedname);
 							newbase = g_path_get_dirname(base);
-							mdirname = g_strdup_printf ("%s/lib", newbase);
 
+							// On Android the executable for the application is going to be /system/bin/app_process{32,64} depending on
+							// the application's architecture. However, libraries for the different architectures live in different
+							// subdirectories of `/system`: `lib` for 32-bit apps and `lib64` for 64-bit ones. Thus appending `/lib` below
+							// will fail to load the DSO for a 64-bit app, even if it exists there, because it will have a different
+							// architecture. This is the cause of https://github.com/xamarin/xamarin-android/issues/2780 and the ifdef
+							// below is the fix.
+							mdirname = g_strdup_printf (
+#if defined(TARGET_ANDROID) && (defined(TARGET_ARM64) || defined(TARGET_AMD64))
+									"%s/lib64",
+#else
+									"%s/lib",
+#endif
+									newbase);
 							g_free (resolvedname);
 							g_free (base);
 							g_free (newbase);


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/issues/2780

On Android the executable for the application is going to be
`/system/bin/app_process{32,64}` depending on the application's architecture.
However, libraries for the different architectures live in different
subdirectories of `/system`: `lib` for 32-bit apps and `lib64` for 64-bit ones.
Thus appending `/lib` below will fail to load the DSO for a 64-bit app, even if
it exists there, because it will have a different architecture. The quickest fix
is to use `lib64` explicitly for 64-bit Android apps.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->


Backport of #13281.

/cc @lambdageek @grendello