### PR TITLE
[loaded LLVM] Add several missing MONO_LLVM_INTERNAL

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1462,7 +1462,7 @@ gboolean
 mono_class_init_checked (MonoClass *klass, MonoError *error);
 
 MonoType*
-mono_class_enum_basetype_internal (MonoClass *klass);
+mono_class_enum_basetype_internal (MonoClass *klass) MONO_LLVM_INTERNAL;
 
 // Enum and static storage for JIT icalls.
 #include "jit-icall-reg.h"

--- a/mono/metadata/debug-internals.h
+++ b/mono/metadata/debug-internals.h
@@ -73,7 +73,9 @@ void            mono_debugger_lock                          (void);
 void            mono_debugger_unlock                        (void);
 
 void
-mono_debug_get_seq_points (MonoDebugMethodInfo *minfo, char **source_file, GPtrArray **source_file_list, int **source_files, MonoSymSeqPoint **seq_points, int *n_seq_points);
+mono_debug_get_seq_points (MonoDebugMethodInfo *minfo, char **source_file,
+			   GPtrArray **source_file_list, int **source_files,
+			   MonoSymSeqPoint **seq_points, int *n_seq_points) MONO_LLVM_INTERNAL;
 
 MONO_API void
 mono_debug_free_locals (MonoDebugLocalsInfo *info);

--- a/mono/metadata/mono-debug.h
+++ b/mono/metadata/mono-debug.h
@@ -10,7 +10,6 @@
 #include <mono/utils/mono-publib.h>
 #include <mono/metadata/image.h>
 #include <mono/metadata/appdomain.h>
-#include <mono/utils/mono-compiler.h>
 
 MONO_BEGIN_DECLS
 

--- a/mono/metadata/mono-debug.h
+++ b/mono/metadata/mono-debug.h
@@ -10,6 +10,7 @@
 #include <mono/utils/mono-publib.h>
 #include <mono/metadata/image.h>
 #include <mono/metadata/appdomain.h>
+#include <mono/utils/mono-compiler.h>
 
 MONO_BEGIN_DECLS
 

--- a/mono/metadata/mono-debug.h
+++ b/mono/metadata/mono-debug.h
@@ -196,7 +196,7 @@ MonoDebugMethodAsyncInfo*
 mono_debug_lookup_method_async_debug_info (MonoMethod *method);
 
 MonoDebugSourceLocation *
-mono_debug_method_lookup_location (MonoDebugMethodInfo *minfo, int il_offset);
+mono_debug_method_lookup_location (MonoDebugMethodInfo *minfo, int il_offset) MONO_LLVM_INTERNAL;
 
 /*
  * Line number support.

--- a/mono/metadata/mono-debug.h
+++ b/mono/metadata/mono-debug.h
@@ -196,7 +196,11 @@ MonoDebugMethodAsyncInfo*
 mono_debug_lookup_method_async_debug_info (MonoMethod *method);
 
 MonoDebugSourceLocation *
-mono_debug_method_lookup_location (MonoDebugMethodInfo *minfo, int il_offset) MONO_LLVM_INTERNAL;
+mono_debug_method_lookup_location (MonoDebugMethodInfo *minfo, int il_offset)
+#ifdef MONO_LLVM_INTERNAL
+MONO_LLVM_INTERNAL
+#endif
+;
 
 /*
  * Line number support.

--- a/mono/metadata/mono-debug.h
+++ b/mono/metadata/mono-debug.h
@@ -194,12 +194,10 @@ mono_debug_lookup_locals (MonoMethod *method);
 MonoDebugMethodAsyncInfo*
 mono_debug_lookup_method_async_debug_info (MonoMethod *method);
 
+// The intent here is really MONO_LLVM_INTERNAL but that is not necessarily available.
+MONO_API_NO_EXTERN_C
 MonoDebugSourceLocation *
-mono_debug_method_lookup_location (MonoDebugMethodInfo *minfo, int il_offset)
-#ifdef MONO_LLVM_INTERNAL
-MONO_LLVM_INTERNAL
-#endif
-;
+mono_debug_method_lookup_location (MonoDebugMethodInfo *minfo, int il_offset);
 
 /*
  * Line number support.

--- a/mono/mini/mini-llvm-cpp.h
+++ b/mono/mini/mini-llvm-cpp.h
@@ -141,9 +141,6 @@ G_EXTERN_C _Unwind_Reason_Code mono_debug_personality (int a, _Unwind_Action b,
 	uint64_t c, struct _Unwind_Exception *d, struct _Unwind_Context *e);
 #endif
 
-void
-default_mono_llvm_unhandled_exception (void);
-
 void*
 mono_llvm_create_di_builder (LLVMModuleRef module);
 

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -9938,17 +9938,6 @@ emit_default_dbg_loc (EmitContext *ctx, LLVMBuilderRef builder)
 #endif
 }
 
-void
-default_mono_llvm_unhandled_exception (void)
-{
-	MonoJitTlsData *jit_tls = mono_get_jit_tls ();
-	MonoObject *target = mono_gchandle_get_target_internal (jit_tls->thrown_exc);
-
-	mono_unhandled_exception_internal (target);
-	mono_invoke_unhandled_exception_hook (target);
-	g_assert_not_reached ();
-}
-
 /*
   DESIGN:
   - Emit LLVM IR from the mono IR using the LLVM C API.
@@ -10066,11 +10055,6 @@ mono_llvm_free_domain_info (MonoDomain *domain)
 
 void
 mono_llvm_init (void)
-{
-}
-
-void
-default_mono_llvm_unhandled_exception (void)
 {
 }
 

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2024,7 +2024,7 @@ MonoInst* mono_constant_fold_ins            (MonoCompile *cfg, MonoInst *ins, Mo
 int       mono_eval_cond_branch             (MonoInst *branch);
 int       mono_is_power_of_two              (guint32 val) MONO_LLVM_INTERNAL;
 void      mono_cprop_local                  (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst **acp, int acp_size);
-MonoInst* mono_compile_create_var           (MonoCompile *cfg, MonoType *type, int opcode);
+MonoInst* mono_compile_create_var           (MonoCompile *cfg, MonoType *type, int opcode) MONO_LLVM_INTERNAL;
 MonoInst* mono_compile_create_var_for_vreg  (MonoCompile *cfg, MonoType *type, int opcode, int vreg);
 void      mono_compile_make_var_load        (MonoCompile *cfg, MonoInst *dest, gssize var_index);
 MonoInst* mini_get_int_to_float_spill_area  (MonoCompile *cfg);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2723,7 +2723,7 @@ gboolean mini_is_gsharedvt_signature (MonoMethodSignature *sig);
 gboolean mini_is_gsharedvt_variable_type (MonoType *t) MONO_LLVM_INTERNAL;
 gboolean mini_is_gsharedvt_variable_klass (MonoClass *klass) MONO_LLVM_INTERNAL;
 gboolean mini_is_gsharedvt_sharable_method (MonoMethod *method);
-gboolean mini_is_gsharedvt_variable_signature (MonoMethodSignature *sig);
+gboolean mini_is_gsharedvt_variable_signature (MonoMethodSignature *sig) MONO_LLVM_INTERNAL;
 gboolean mini_is_gsharedvt_sharable_inst (MonoGenericInst *inst);
 gboolean mini_method_is_default_method (MonoMethod *m) MONO_LLVM_INTERNAL;
 gboolean mini_method_needs_mrgctx (MonoMethod *m);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2051,7 +2051,7 @@ void      mono_optimize_branches            (MonoCompile *cfg);
 void      mono_blockset_print               (MonoCompile *cfg, MonoBitSet *set, const char *name, guint idom);
 void      mono_print_ins_index              (int i, MonoInst *ins);
 GString  *mono_print_ins_index_strbuf       (int i, MonoInst *ins);
-void      mono_print_ins                    (MonoInst *ins);
+void      mono_print_ins                    (MonoInst *ins) MONO_LLVM_INTERNAL;
 void      mono_print_bb                     (MonoBasicBlock *bb, const char *msg);
 void      mono_print_code                   (MonoCompile *cfg, const char *msg);
 MONO_LLVM_INTERNAL const char* mono_inst_name                  (int op);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2610,7 +2610,7 @@ gpointer
 mono_method_fill_runtime_generic_context (MonoMethodRuntimeGenericContext *mrgctx, guint32 slot, MonoError *error);
 
 const char*
-mono_rgctx_info_type_to_str (MonoRgctxInfoType type);
+mono_rgctx_info_type_to_str (MonoRgctxInfoType type) MONO_LLVM_INTERNAL;
 
 MonoJumpInfoType
 mini_rgctx_info_type_to_patch_info_type (MonoRgctxInfoType info_type);

--- a/mono/utils/mono-compiler.h
+++ b/mono/utils/mono-compiler.h
@@ -76,6 +76,7 @@ typedef ptrdiff_t ssize_t;
 #define MONO_RESTORE_WARNING
 #endif
 
+// If MONO_LLVM_INTERNAL changes, update mono_debug_method_lookup_location declaration.
 #if !defined(_MSC_VER) && !defined(HOST_SOLARIS) && !defined(_WIN32) && !defined(__CYGWIN__) && !defined(MONOTOUCH) && HAVE_VISIBILITY_HIDDEN
 #if MONO_LLVM_LOADED
 #define MONO_LLVM_INTERNAL MONO_API_NO_EXTERN_C


### PR DESCRIPTION
Remove unused function that would need MONO_LLVM_INTERNAL.
Found by linking with -z now (https://github.com/mono/mono/pull/14562), which we should do, separately.
