### PR TITLE
[2019-04] Plug leak of CustomAttribute initializer name

### DIFF
--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -980,15 +980,17 @@ create_custom_attr (MonoImage *image, MonoMethod *method, const guchar *data, gu
 			mono_property_set_value_handle (prop, attr, pparams, error);
 			goto_if_nok (error, fail);
 		}
+		
+		g_free (name);
 	}
 
 	goto exit;
 fail:
+	g_free (name);
 	attr = mono_new_null ();
 exit:
 	if (field && !type_is_reference (field->type))
 		g_free (val);
-	g_free (name);
 	if (prop_type && !type_is_reference (prop_type))
 		g_free (pparams [0]);
 	if (params) {

--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -982,11 +982,13 @@ create_custom_attr (MonoImage *image, MonoMethod *method, const guchar *data, gu
 		}
 		
 		g_free (name);
+		name = NULL;
 	}
 
 	goto exit;
 fail:
 	g_free (name);
+	name = NULL;
 	attr = mono_new_null ();
 exit:
 	if (field && !type_is_reference (field->type))


### PR DESCRIPTION
All the CustomAttribute initializer names (fields, property) except the last were leaked. Ensure all names are freed.

Fixes #14543



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->


Backport of #14544.

/cc @marek-safar @Therzok