### PR TITLE
[merp] Don't leak g_getenv return value

### DIFF
--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -264,7 +264,7 @@ mono_state_alloc_mem (MonoStateMem *mem, long tag, size_t size)
 	mem->size = size;
 	mem->handle = NULL;
 
-	if (!g_getenv ("MONO_CRASH_NOFILE"))
+	if (!g_hasenv ("MONO_CRASH_NOFILE"))
 		mem->handle = g_open (name, O_RDWR | O_CREAT | O_EXCL, S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH);
 
 	if (mem->handle < 1) {
@@ -1044,7 +1044,7 @@ mono_summarize_native_state_add_thread (MonoStateWriter *writer, MonoThreadSumma
 void
 mono_crash_dump (const char *jsonFile, MonoStackHash *hashes)
 {
-	if (g_getenv ("MONO_CRASH_NOFILE"))
+	if (g_hasenv ("MONO_CRASH_NOFILE"))
 		return;
 
 	size_t size = strlen (jsonFile);


### PR DESCRIPTION
Coverity said:
```
     CID 1445100:  Resource leaks  (RESOURCE_LEAK)
     Failing to save or free storage allocated by "monoeg_g_getenv("MONO_CRASH_NOFILE")" leaks it.
```
