### PR TITLE
Fix build warning for orig_method

### DIFF
--- a/mono/mini/mini-trampolines.c
+++ b/mono/mini/mini-trampolines.c
@@ -431,7 +431,9 @@ common_call_trampoline (host_mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVTa
 	gpointer *orig_vtable_slot, *vtable_slot_to_patch = NULL;
 	MonoJitInfo *ji = NULL;
 	MonoDomain *domain = mono_domain_get ();
+#if LLVM_API_VERSION > 100
 	MonoMethod *orig_method = m;
+#endif
 
 	error_init (error);
 


### PR DESCRIPTION
Variable is only used here: https://github.com/mono/mono/blob/82a993124888d470d1057eae9546e5be76524dad/mono/mini/mini-trampolines.c#L743