### PR TITLE
[2019-04] [System.Core] Ensure monotouch[_runtime] API are identical

### DIFF
--- a/mcs/class/System.Core/System.Core.csproj
+++ b/mcs/class/System.Core/System.Core.csproj
@@ -1196,6 +1196,8 @@
         <Compile Include="System.IO.Pipes\NamedPipeServerStream.NotSupported.cs" />
         <Compile Include="System.IO.Pipes\PipeStream.NotSupported.cs" />
         <Compile Include="System.IO.Pipes\SafePipeHandle.NotSupported.cs" />
+        <Compile Include="System.Linq.Expressions\LambdaExpression.NotSupported.cs" />
+        <Compile Include="System.Runtime.CompilerServices\RuntimeOps.NotSupported.cs" />
       </ItemGroup>
     </When>
     <When Condition="'$(Platform)' == 'monotouch_tv'">
@@ -1253,6 +1255,8 @@
         <Compile Include="System.IO.Pipes\NamedPipeServerStream.NotSupported.cs" />
         <Compile Include="System.IO.Pipes\PipeStream.NotSupported.cs" />
         <Compile Include="System.IO.Pipes\SafePipeHandle.NotSupported.cs" />
+        <Compile Include="System.Linq.Expressions\LambdaExpression.NotSupported.cs" />
+        <Compile Include="System.Runtime.CompilerServices\RuntimeOps.NotSupported.cs" />
       </ItemGroup>
     </When>
     <When Condition="'$(Platform)' == 'monotouch'">
@@ -1310,6 +1314,8 @@
         <Compile Include="System.IO.Pipes\NamedPipeServerStream.NotSupported.cs" />
         <Compile Include="System.IO.Pipes\PipeStream.NotSupported.cs" />
         <Compile Include="System.IO.Pipes\SafePipeHandle.NotSupported.cs" />
+        <Compile Include="System.Linq.Expressions\LambdaExpression.NotSupported.cs" />
+        <Compile Include="System.Runtime.CompilerServices\RuntimeOps.NotSupported.cs" />
       </ItemGroup>
     </When>
     <When Condition="'$(Platform)' == 'monodroid'">

--- a/mcs/class/System.Core/System.Linq.Expressions/LambdaExpression.NotSupported.cs
+++ b/mcs/class/System.Core/System.Linq.Expressions/LambdaExpression.NotSupported.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+
+namespace System.Linq.Expressions {
+
+	public partial class LambdaExpression {
+		
+		public void CompileToMethod (MethodBuilder method) => throw new PlatformNotSupportedException ();
+
+		public void CompileToMethod (MethodBuilder method, DebugInfoGenerator debugInfoGenerator) => throw new PlatformNotSupportedException ();
+	}
+}

--- a/mcs/class/System.Core/System.Runtime.CompilerServices/RuntimeOps.NotSupported.cs
+++ b/mcs/class/System.Core/System.Runtime.CompilerServices/RuntimeOps.NotSupported.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Reflection.Emit;
+using System.Linq.Expressions;
+
+namespace System.Runtime.CompilerServices {
+
+	public partial class RuntimeOps {
+		
+		[Obsolete ("do not use this method")]
+		public static IRuntimeVariables MergeRuntimeVariables (IRuntimeVariables first, IRuntimeVariables second, int[] indexes) => throw new PlatformNotSupportedException ();
+
+		[Obsolete ("do not use this method")]
+		public static Expression Quote (Expression expression, object hoistedLocals, object[] locals) => throw new PlatformNotSupportedException ();
+	}
+}

--- a/mcs/class/System.Core/monotouch_System.Core.dll.sources
+++ b/mcs/class/System.Core/monotouch_System.Core.dll.sources
@@ -1,3 +1,4 @@
 #include common_System.Core.dll.sources
 #include interpreter_System.Core.dll.sources
 #include pipes_pns.sources
+#include sre_pns.sources

--- a/mcs/class/System.Core/sre_pns.sources
+++ b/mcs/class/System.Core/sre_pns.sources
@@ -1,0 +1,2 @@
+System.Linq.Expressions/LambdaExpression.NotSupported.cs
+System.Runtime.CompilerServices/RuntimeOps.NotSupported.cs


### PR DESCRIPTION
Ensure the API surface for `System.Core.dll` is identical between the
`monotouch` and `monotouch_runtime` (used for REPL and the interpreter).

This ensure code compiled against one will be fine when building against
the other (e.g. avoiding linker errors).

Removed methods:

```csharp
public void CompileToMethod (System.Reflection.Emit.MethodBuilder method);
public void CompileToMethod (System.Reflection.Emit.MethodBuilder method, System.Runtime.CompilerServices.DebugInfoGenerator debugInfoGenerator);
```

Removed methods:

```csharp
[Obsolete ("do not use this method")]
public static IRuntimeVariables MergeRuntimeVariables (IRuntimeVariables first, IRuntimeVariables second, int[] indexes);

[Obsolete ("do not use this method")]
public static System.Linq.Expressions.Expression Quote (System.Linq.Expressions.Expression expression, object hoistedLocals, object[] locals);
```

Backport of #14606.

/cc @akoeplinger @spouliot