### PR TITLE
[jit] Also allow System.Runtime.CompilerServices.Unsafe intrinsics from the System.Runtime.CompilerServices assembly, not just corlib.

### DIFF
--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -1657,9 +1657,9 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 			   !strcmp (cmethod_klass_name_space, "Internal.Runtime.CompilerServices") &&
 			   !strcmp (cmethod_klass_name, "Unsafe")) {
 		return emit_unsafe_intrinsics (cfg, cmethod, fsig, args);
-	} else if (in_corlib &&
-			   !strcmp (cmethod_klass_name_space, "System.Runtime.CompilerServices") &&
-			   !strcmp (cmethod_klass_name, "Unsafe")) {
+	} else if (!strcmp (cmethod_klass_name_space, "System.Runtime.CompilerServices") &&
+			   !strcmp (cmethod_klass_name, "Unsafe") &&
+			   (in_corlib || !strcmp (cmethod_klass_image->assembly->aname.name, "System.Runtime.CompilerServices.Unsafe"))) {
 		return emit_unsafe_intrinsics (cfg, cmethod, fsig, args);
 	} else if (in_corlib &&
 			   !strcmp (cmethod_klass_name_space, "System.Runtime.CompilerServices") &&

--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -323,7 +323,7 @@ emit_unsafe_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignatu
 
 		dreg = alloc_ireg (cfg);
 		EMIT_NEW_BIALU (cfg, ins, OP_COMPARE, -1, args [0]->dreg, args [1]->dreg);
-		EMIT_NEW_UNALU (cfg, ins, OP_PCLT, dreg, -1);
+		EMIT_NEW_UNALU (cfg, ins, OP_PCLT_UN, dreg, -1);
 		return ins;
 	} else if (!strcmp (cmethod->name, "IsAddressGreaterThan")) {
 		g_assert (ctx);
@@ -333,7 +333,7 @@ emit_unsafe_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignatu
 
 		dreg = alloc_ireg (cfg);
 		EMIT_NEW_BIALU (cfg, ins, OP_COMPARE, -1, args [0]->dreg, args [1]->dreg);
-		EMIT_NEW_UNALU (cfg, ins, OP_PCGT, dreg, -1);
+		EMIT_NEW_UNALU (cfg, ins, OP_PCGT_UN, dreg, -1);
 		return ins;
 	} else if (!strcmp (cmethod->name, "Add")) {
 		g_assert (ctx);

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1715,6 +1715,8 @@ enum {
 #define OP_PCEQ OP_LCEQ
 #define OP_PCLT OP_LCLT
 #define OP_PCGT OP_LCGT
+#define OP_PCLT_UN OP_LCLT_UN
+#define OP_PCGT_UN OP_LCGT_UN
 #define OP_PBNE_UN OP_LBNE_UN
 #define OP_PBGE_UN OP_LBGE_UN
 #define OP_PBLT_UN OP_LBLT_UN
@@ -1743,6 +1745,8 @@ enum {
 #define OP_PCEQ OP_ICEQ
 #define OP_PCLT OP_ICLT
 #define OP_PCGT OP_ICGT
+#define OP_PCLT_UN OP_ICLT_UN
+#define OP_PCGT_UN OP_ICGT_UN
 #define OP_PBNE_UN OP_IBNE_UN
 #define OP_PBGE_UN OP_IBGE_UN
 #define OP_PBLT_UN OP_IBLT_UN


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->