### PR TITLE
Fix interpreter mini regression test on Windows x64.

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -1322,8 +1322,7 @@ get_interp_to_native_trampoline (void)
 		} else {
 			MonoTrampInfo *info;
 			trampoline = (MonoPIFunc) mono_arch_get_interp_to_native_trampoline (&info);
-			// TODO:
-			// mono_tramp_info_register (info, NULL);
+			mono_tramp_info_register (info, NULL);
 		}
 		mono_memory_barrier ();
 	}
@@ -1375,6 +1374,9 @@ ves_pinvoke_method (InterpFrame *frame, MonoMethodSignature *sig, MonoFuncV addr
 #ifdef MONO_ARCH_HAVE_INTERP_PINVOKE_TRAMP
 	if (!frame->ex)
 		mono_arch_get_native_call_context_ret (&ccontext, frame, sig);
+
+	if (ccontext.stack != NULL)
+		g_free (ccontext.stack);
 #else
 	if (!frame->ex && !MONO_TYPE_ISSTRUCT (sig->ret))
 		stackval_from_data (sig->ret, frame->retval, (char*)&frame->retval->data.p, sig->pinvoke);


### PR DESCRIPTION
First set of fixes to get the following tests working under interpreter on Windows x64:

* mono/mini richeck
* mono/mini mixedcheck
* mono/mini fullaotmixedcheck
* mono/tests winx64structs.exe

Fixes are primarily related to Windows x64 ABI support in interpreter. Fixes also makes sure our interpreter trampolines get unwind info making it possible to debug through the trampolines on Windows x64.

Several fixes related to value types was needed, also fixed support for return value types not fitting into registers, current implementation didn't return passed in value type address in return register as mandated by both System V and Win x64 ABI's.

Identified and fixed memory leak on every pinvoke from interpreter that needs stack. Since Windows x64 ABI always use 32 bytes of stack allocated by caller, the memory leak was hit on every pinvoke call.
