### PR TITLE
Workaround endianness issue by using pointer-sized values in union

### DIFF
--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -316,6 +316,10 @@ struct MonoJumpInfo {
 	} ip;
 
 	MonoJumpInfoType type;
+	/*
+	 * This array should consist of all-pointer sized elements, or
+	 * mixing fields on BE can result in invalid values.
+	 */
 	union {
 		gconstpointer   target;
 #if TARGET_SIZEOF_VOID_P == 8
@@ -333,7 +337,7 @@ struct MonoJumpInfo {
 		MonoImage      *image;
 		MonoVTable     *vtable;
 		const char     *name;
-		MonoJitICallId jit_icall_id; // Or just use index?
+		gsize jit_icall_id; // Or just use index?
 		MonoJumpInfoToken  *token;
 		MonoJumpInfoBBTable *table;
 		MonoJumpInfoRgctxEntry *rgctx_entry;


### PR DESCRIPTION
Technically not the full workaround, but fixes the issue with JIT
patches. The proper fix would be auditing accesses and not mixing
up usage of 32-bit and 64-bit field members.

Tested on AIX/ppc64be. Fixes #14622.