### PR TITLE
Widen MonoJumpInfo union to pointer-sized so mono_add_patch_info can just use target field blindly.

### DIFF
--- a/mono/metadata/jit-icall-reg.h
+++ b/mono/metadata/jit-icall-reg.h
@@ -339,7 +339,12 @@ MONO_JIT_ICALL (ves_icall_thread_finish_async_abort) \
 	\
 MONO_JIT_ICALL (count) \
 
-typedef enum MonoJitICallId {
+#ifdef __cplusplus
+typedef enum MonoJitICallId : gsize // Widen to gsize for use in MonoJumpInfo union.
+#else
+typedef enum MonoJitICallId
+#endif
+{
 #define MONO_JIT_ICALL(x) MONO_JIT_ICALL_ ## x,
 MONO_JIT_ICALLS
 #undef MONO_JIT_ICALL

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -317,9 +317,11 @@ struct MonoJumpInfo {
 
 	MonoJumpInfoType type;
 	union {
+		// In order to allow blindly using target in mono_add_patch_info,
+		// all fields must be pointer-sized. No ints, no untyped enums.
 		gconstpointer   target;
-		int index;
-		guint uindex;
+		gssize		index;	// only 32 bits used but widened per above
+		gsize		uindex;	// only 32 bits used but widened per above
 		MonoBasicBlock *bb;
 		MonoInst       *inst;
 		MonoMethod     *method;
@@ -328,7 +330,11 @@ struct MonoJumpInfo {
 		MonoImage      *image;
 		MonoVTable     *vtable;
 		const char     *name;
-		MonoJitICallId jit_icall_id; // Or just use index?
+#ifdef __cplusplus // MonoJitICallId has base type of gsize to widen per above.
+		MonoJitICallId jit_icall_id;
+#else
+		gsize jit_icall_id;	// only 9 bits used but widened per above
+#endif
 		MonoJumpInfoToken  *token;
 		MonoJumpInfoBBTable *table;
 		MonoJumpInfoRgctxEntry *rgctx_entry;


### PR DESCRIPTION
Alternative to https://github.com/mono/mono/pull/14641.