### PR TITLE
Remove MONO_PATCH_INFO_METHOD_REL.

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -6468,9 +6468,6 @@ encode_patch (MonoAotCompile *acfg, MonoJumpInfo *patch_info, guint8 *buf, guint
 	case MONO_PATCH_INFO_GC_NURSERY_START:
 	case MONO_PATCH_INFO_GC_NURSERY_BITS:
 		break;
-	case MONO_PATCH_INFO_METHOD_REL:
-		encode_value ((gint)patch_info->data.offset, p, &p);
-		break;
 	case MONO_PATCH_INFO_SWITCH: {
 		gpointer *table = (gpointer *)patch_info->data.table->table;
 		int k;

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -3889,9 +3889,6 @@ decode_patch (MonoAotModule *aot_module, MonoMemPool *mp, MonoJumpInfo *ji, guin
 			goto cleanup;
 		ji->data.name = m_class_get_name (ji->data.klass);
 		break;
-	case MONO_PATCH_INFO_METHOD_REL:
-		ji->data.offset = decode_value (p, &p);
-		break;
 	case MONO_PATCH_INFO_INTERRUPTION_REQUEST_FLAG:
 	case MONO_PATCH_INFO_GC_CARD_TABLE_ADDR:
 	case MONO_PATCH_INFO_GC_NURSERY_START:

--- a/mono/mini/aot-runtime.h
+++ b/mono/mini/aot-runtime.h
@@ -11,7 +11,7 @@
 #include "mini.h"
 
 /* Version number of the AOT file format */
-#define MONO_AOT_FILE_VERSION 160
+#define MONO_AOT_FILE_VERSION 161
 
 #define MONO_AOT_TRAMP_PAGE_SIZE 16384
 

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -6107,10 +6107,6 @@ mono_arch_patch_code_new (MonoCompile *cfg, MonoDomain *domain, guint8 *code, Mo
 		g_assert_not_reached ();
 		patch_lis_ori (ip, ip);
 		break;
-	case MONO_PATCH_INFO_METHOD_REL:
-		g_assert_not_reached ();
-		*((gpointer *)(ip)) = target;
-		break;
 	case MONO_PATCH_INFO_METHODCONST:
 	case MONO_PATCH_INFO_CLASS:
 	case MONO_PATCH_INFO_IMAGE:

--- a/mono/mini/mini-mips.c
+++ b/mono/mini/mini-mips.c
@@ -5233,30 +5233,7 @@ mono_arch_emit_exceptions (MonoCompile *cfg)
 	for (patch_info = cfg->patch_info; patch_info; patch_info = patch_info->next) {
 		switch (patch_info->type) {
 		case MONO_PATCH_INFO_EXC: {
-#if 0
-			//unsigned char *ip = patch_info->ip.i + cfg->native_code;
-
-			i = exception_id_by_name (patch_info->data.target);
-			g_assert (i >= 0 && i < MONO_EXC_INTRINS_NUM);
-			if (!exc_throw_pos [i]) {
-				guint32 addr;
-
-				exc_throw_pos [i] = code;
-				//g_print ("exc: writing stub at %p\n", code);
-				mips_load_const (code, mips_a0, patch_info->data.target);
-				addr = (guint32) mono_arch_get_throw_exception_by_name ();
-				mips_load_const (code, mips_t9, addr);
-				mips_jr (code, mips_t9);
-				mips_nop (code);
-			}
-			//g_print ("exc: patch %p to %p\n", ip, exc_throw_pos[i]);
-
-			/* Turn into a Relative patch, pointing at code stub */
-			patch_info->type = MONO_PATCH_INFO_METHOD_REL;
-			patch_info->data.offset = exc_throw_pos[i] - cfg->native_code;
-#else
 			g_assert_not_reached();
-#endif
 			break;
 		}
 		default:

--- a/mono/mini/mini-ppc.c
+++ b/mono/mini/mini-ppc.c
@@ -4636,10 +4636,6 @@ mono_arch_patch_code_new (MonoCompile *cfg, MonoDomain *domain, guint8 *code, Mo
 	case MONO_PATCH_INFO_IP:
 		patch_load_sequence (ip, ip);
 		break;
-	case MONO_PATCH_INFO_METHOD_REL:
-		g_assert_not_reached ();
-		*((gpointer *)(ip)) = code + ji->data.offset;
-		break;
 	case MONO_PATCH_INFO_SWITCH: {
 		gpointer *table = (gpointer *)ji->data.table->table;
 		int i;

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -1365,9 +1365,6 @@ mono_resolve_patch_target (MonoMethod *method, MonoDomain *domain, guint8 *code,
 	case MONO_PATCH_INFO_IP:
 		target = ip;
 		break;
-	case MONO_PATCH_INFO_METHOD_REL:
-		target = code + patch_info->data.offset;
-		break;
 	case MONO_PATCH_INFO_JIT_ICALL_ID: {
 		MonoJitICallInfo * const mi = mono_find_jit_icall_info (patch_info->data.jit_icall_id);
 		g_assertf (mi, "unknown MONO_PATCH_INFO_JIT_ICALL_ID %d", (int)patch_info->data.jit_icall_id);

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -318,11 +318,6 @@ struct MonoJumpInfo {
 	MonoJumpInfoType type;
 	union {
 		gconstpointer   target;
-#if TARGET_SIZEOF_VOID_P == 8
-		gint64          offset;
-#else
-		int             offset;
-#endif
 		int index;
 		guint uindex;
 		MonoBasicBlock *bb;

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -5367,7 +5367,6 @@ mono_arch_patch_code (MonoCompile *cfg, MonoMethod *method, MonoDomain *domain,
 				continue;
 			case MONO_PATCH_INFO_R4:
 			case MONO_PATCH_INFO_R8:
-			case MONO_PATCH_INFO_METHOD_REL:
 				g_assert_not_reached ();
 				continue;
 			default:

--- a/mono/mini/patch-info.h
+++ b/mono/mini/patch-info.h
@@ -3,7 +3,6 @@ PATCH_INFO(ABS, "abs")
 PATCH_INFO(LABEL, "label")
 PATCH_INFO(METHOD, "method")
 PATCH_INFO(METHOD_JUMP, "method_jump")
-PATCH_INFO(METHOD_REL, "method_rel")
 PATCH_INFO(METHODCONST, "methodconst")
 // Either the address of a C function implementing a JIT icall, or a wrapper around it
 PATCH_INFO(JIT_ICALL_ID, "jit_icall_id") // replaced MONO_PATCH_INFO_JIT_ICALL, using enum instead of string


### PR DESCRIPTION
It is not used, and it had a larger than pointer field
where a pointer was required, at least for 32bit hosted cross builds.

By "unused", I'm assuming nobody does math on these enums to forms ones, that I don't see via textual search.