### PR TITLE
[sdks] Explicitly set version of the mac/ios/watchos/tvos platform SDKs

### DIFF
--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -132,9 +132,14 @@ fi
 
 if [[ ${CI_TAGS} == *'sdks-ios'* ]];
    then
-	   # configuration on our bots: https://github.com/mono/mono/pull/11691#issuecomment-439178459
-	   export XCODE_DIR=/Applications/Xcode101.app/Contents/Developer
-	   export XCODE32_DIR=/Applications/Xcode94.app/Contents/Developer
+        # configuration on our bots: https://github.com/mono/mono/pull/11691#issuecomment-439178459
+        export XCODE_DIR=/Applications/Xcode101.app/Contents/Developer
+        export XCODE32_DIR=/Applications/Xcode94.app/Contents/Developer
+        export MACOS_VERSION=10.14
+        export IOS_VERSION=12.1
+        export TVOS_VERSION=12.1
+        export WATCHOS_VERSION=5.1
+        export WATCHOS5_VERSION=5.1
 
         # make sure we embed the correct path into the PDBs
         export MONOTOUCH_MCS_FLAGS=-pathmap:${MONO_REPO_ROOT}/=/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/src/Xamarin.iOS/
@@ -182,6 +187,7 @@ then
     # configuration on our bots: https://github.com/mono/mono/pull/11691#issuecomment-439178459
     export XCODE_DIR=/Applications/Xcode101.app/Contents/Developer
     export XCODE32_DIR=/Applications/Xcode94.app/Contents/Developer
+    export MACOS_VERSION=10.14
 
     # make sure we embed the correct path into the PDBs
     export XAMMAC_MCS_FLAGS=-pathmap:${MONO_REPO_ROOT}/=/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/src/Xamarin.Mac/

--- a/sdks/builds/ios.mk
+++ b/sdks/builds/ios.mk
@@ -274,7 +274,7 @@ endef
 
 ios_sim_sysroot = -isysroot $(XCODE_DIR)/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator$(IOS_VERSION).sdk 
 tvos_sim_sysroot = -isysroot $(XCODE_DIR)/Platforms/AppleTVSimulator.platform/Developer/SDKs/AppleTVSimulator$(TVOS_VERSION).sdk
-watchos_sim_sysroot = -isysroot $(XCODE_DIR)/Platforms/WatchSimulator.platform/Developer/SDKs/WatchSimulator$(WATCH_VERSION).sdk
+watchos_sim_sysroot = -isysroot $(XCODE_DIR)/Platforms/WatchSimulator.platform/Developer/SDKs/WatchSimulator$(WATCHOS_VERSION).sdk
 
 ios-sim32_SYSROOT = $(ios_sim_sysroot) -mios-simulator-version-min=$(IOS_VERSION_MIN)
 ios-sim64_SYSROOT = $(ios_sim_sysroot) -mios-simulator-version-min=$(IOS_VERSION_MIN)
@@ -343,11 +343,11 @@ _ios-$(1)_AC_VARS= \
 	ac_cv_func_shm_open_working_with_mmap=no
 
 _ios-$(1)_CFLAGS= \
-	-isysroot $(7)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$$(MACOS_VERSION).sdk -mmacosx-version-min=$$(MACOS_VERSION_MIN) \
+	$$(ios-$(1)_SYSROOT) \
 	-Qunused-arguments
 
 _ios-$(1)_CXXFLAGS= \
-	-isysroot $(7)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$$(MACOS_VERSION).sdk -mmacosx-version-min=$$(MACOS_VERSION_MIN) \
+	$$(ios-$(1)_SYSROOT) \
 	-Qunused-arguments \
 	-stdlib=libc++
 
@@ -374,9 +374,16 @@ $$(eval $$(call CrossRuntimeTemplate,ios,$(1),$(2)-apple-darwin10,$(3),$(4),$(5)
 
 endef
 
+ios-cross32_SYSROOT=-isysroot $(XCODE32_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -mmacosx-version-min=$(MACOS_VERSION_MIN)
+ios-crosswatch_SYSROOT=-isysroot $(XCODE32_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -mmacosx-version-min=$(MACOS_VERSION_MIN)
+ios-cross64_SYSROOT=-isysroot $(XCODE_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_VERSION).sdk -mmacosx-version-min=$(MACOS_VERSION_MIN)
+ios-crosswatch64_32_SYSROOT=-isysroot $(XCODE_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_VERSION).sdk -mmacosx-version-min=$(MACOS_VERSION_MIN)
+ios-cross32-64_SYSROOT=-isysroot $(XCODE_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_VERSION).sdk -mmacosx-version-min=$(MACOS_VERSION_MIN)
+
+ios-crosswatch_CONFIGURE_FLAGS=--enable-cooperative-suspend
+
 $(eval $(call iOSCrossTemplate,cross32,i386,arm-darwin,target32,llvm36-llvm32,arm-apple-darwin10,$(XCODE32_DIR)))
 $(eval $(call iOSCrossTemplate,cross64,x86_64,aarch64-darwin,target64,llvm-llvm64,aarch64-apple-darwin10,$(XCODE_DIR)))
-ios-crosswatch_CONFIGURE_FLAGS=--enable-cooperative-suspend
 $(eval $(call iOSCrossTemplate,crosswatch,i386,armv7k-unknown-darwin,targetwatch,llvm36-llvm32,armv7k-apple-darwin,$(XCODE32_DIR)))
 $(eval $(call iOSCrossTemplate,crosswatch64_32,x86_64,aarch64-apple-darwin10_ilp32,targetwatch64_32,llvm-llvm64,armv7k-apple-darwin_ilp32,$(XCODE_DIR)))
 # 64->arm32 cross compiler

--- a/sdks/builds/mac.mk
+++ b/sdks/builds/mac.mk
@@ -26,11 +26,11 @@ _mac-$(1)_AC_VARS= \
 	ac_cv_func_utimensat=no
 
 _mac-$(1)_CFLAGS= \
-	-isysroot $(3)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$$(MACOS_VERSION).sdk -mmacosx-version-min=$$(MACOS_VERSION_MIN) \
+	$$(mac-$(1)_SYSROOT) \
 	-arch $(2)
 
 _mac-$(1)_CXXFLAGS= \
-	-isysroot $(3)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$$(MACOS_VERSION).sdk -mmacosx-version-min=$$(MACOS_VERSION_MIN) \
+	$$(mac-$(1)_SYSROOT) \
 	-arch $(2)
 
 _mac-$(1)_CPPFLAGS=
@@ -54,6 +54,9 @@ _mac-$(1)_CONFIGURE_FLAGS= \
 $$(eval $$(call RuntimeTemplate,mac,$(1),$(2)-apple-darwin10,yes))
 
 endef
+
+mac-mac32_SYSROOT=-isysroot $(XCODE32_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -mmacosx-version-min=$(MACOS_VERSION_MIN)
+mac-mac64_SYSROOT=-isysroot $(XCODE_DIR)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$(MACOS_VERSION).sdk -mmacosx-version-min=$(MACOS_VERSION_MIN)
 
 $(eval $(call MacTemplate,mac32,i386,$(XCODE32_DIR)))
 $(eval $(call MacTemplate,mac64,x86_64,$(XCODE_DIR)))

--- a/sdks/versions.mk
+++ b/sdks/versions.mk
@@ -29,19 +29,18 @@ XCODE_DIR?=/Applications/Xcode.app/Contents/Developer
 # Xcode version used to compile 32 bit cross compilers
 XCODE32_DIR?=/Applications/Xcode94.app/Contents/Developer
 
-#MACOS_VERSION?=10.13
+# min versions of the targets
 MACOS_VERSION_MIN?=10.9
-
-#IOS_VERSION?=11.1
 IOS_VERSION_MIN?=6.0
-
-#TVOS_VERSION?=11.1
 TVOS_VERSION_MIN?=9.0
-
-#WATCHOS_VERSION?=4.1
 WATCHOS_VERSION_MIN?=2.0
-
-#WATCHOS5_VERSION?=5.1
 WATCHOS5_VERSION_MIN?=5.1
+
+# versions of the platform SDKs, these ship inside of Xcode
+#MACOS_VERSION?=10.13
+#IOS_VERSION?=11.1
+#TVOS_VERSION?=11.1
+#WATCHOS_VERSION?=4.1
+#WATCHOS5_VERSION?=5.1
 
 # WebAssembly


### PR DESCRIPTION
Otherwise the Xcode linker tries to guess the version from the path,
and since we use Xcode101.app it'd use sdk=101 as the version which is wrong.

By explicitly specifying e.g. `$(XCODE_DIR)/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.1.sdk`
as the sysroot it correctly guesses sdk=12.1 instead.

See also https://github.com/xamarin/xamarin-macios/commit/834c0a9fd7062c0c25011721fd7d524b8a60b41e
