### PR TITLE
[2019-04] [mscorlib] Ensure monotouch[_runtime] API are identical

### DIFF
--- a/mcs/class/corlib/System.Reflection.Emit/AssemblyBuilder.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/AssemblyBuilder.pns.cs
@@ -27,11 +27,103 @@
 //
 
 #if !MONO_FEATURE_SRE
+using System.Globalization;
+using System.IO;
 
 namespace System.Reflection.Emit
 {
 	public class AssemblyBuilder : Assembly
 	{
+		private AssemblyBuilder () {}
+
+		public override string CodeBase {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		public override MethodInfo EntryPoint {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		public override string EscapedCodeBase {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		public override System.Security.Policy.Evidence Evidence {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		public override string FullName {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		public override bool GlobalAssemblyCache {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		public override string ImageRuntimeVersion {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		public override bool IsDynamic {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		public override string Location {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		public override Module ManifestModule {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		public override bool ReflectionOnly {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		public void AddResourceFile (string name, string fileName) => throw new PlatformNotSupportedException ();
+
+		public void AddResourceFile (string name, string fileName, ResourceAttributes attribute) => throw new PlatformNotSupportedException ();
+
+		public ModuleBuilder DefineDynamicModule (string name, bool emitSymbolInfo) => throw new PlatformNotSupportedException ();
+
+		public ModuleBuilder DefineDynamicModule (string name, string fileName) => throw new PlatformNotSupportedException ();
+
+		public ModuleBuilder DefineDynamicModule (string name, string fileName, bool emitSymbolInfo) => throw new PlatformNotSupportedException ();
+
+		public System.Resources.IResourceWriter DefineResource (string name, string description, string fileName) => throw new PlatformNotSupportedException ();
+
+		public System.Resources.IResourceWriter DefineResource (string name, string description, string fileName, ResourceAttributes attribute) => throw new PlatformNotSupportedException ();
+
+		public void DefineUnmanagedResource (byte[] resource) => throw new PlatformNotSupportedException ();
+
+		public void DefineUnmanagedResource (string resourceFileName) => throw new PlatformNotSupportedException ();
+
+		public void DefineVersionInfoResource () => throw new PlatformNotSupportedException ();
+
+		public void DefineVersionInfoResource (string product, string productVersion, string company, string copyright, string trademark) => throw new PlatformNotSupportedException ();
+
 		public static AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access)
 		{
 			throw new PlatformNotSupportedException ();
@@ -47,10 +139,54 @@ namespace System.Reflection.Emit
 			throw new PlatformNotSupportedException ();
 		}
 
+		public override bool Equals (object obj) => throw new PlatformNotSupportedException ();
+
+		public override object[] GetCustomAttributes (bool inherit) => throw new PlatformNotSupportedException ();
+
+		public override object[] GetCustomAttributes (System.Type attributeType, bool inherit) => throw new PlatformNotSupportedException ();
+
 		public ModuleBuilder GetDynamicModule (string name)
 		{
 			throw new PlatformNotSupportedException ();
 		}
+
+		public override Type[] GetExportedTypes () => throw new PlatformNotSupportedException ();
+
+		public override FileStream GetFile (string name) => throw new PlatformNotSupportedException ();
+
+		public override FileStream[] GetFiles (bool getResourceModules) => throw new PlatformNotSupportedException ();
+
+		public override int GetHashCode () => throw new PlatformNotSupportedException ();
+
+		public override Module[] GetLoadedModules (bool getResourceModules) => throw new PlatformNotSupportedException ();
+
+		public override ManifestResourceInfo GetManifestResourceInfo (string resourceName) => throw new PlatformNotSupportedException ();
+
+		public override string[] GetManifestResourceNames () => throw new PlatformNotSupportedException ();
+
+		public override Stream GetManifestResourceStream (string name) => throw new PlatformNotSupportedException ();
+
+		public override Stream GetManifestResourceStream (Type type, string name) => throw new PlatformNotSupportedException ();
+
+		public override Module GetModule (string name) => throw new PlatformNotSupportedException ();
+
+		public override Module[] GetModules (bool getResourceModules) => throw new PlatformNotSupportedException ();
+
+		public override AssemblyName GetName (bool copiedName) => throw new PlatformNotSupportedException ();
+
+		public override AssemblyName[] GetReferencedAssemblies () => throw new PlatformNotSupportedException ();
+
+		public override Assembly GetSatelliteAssembly (CultureInfo culture) => throw new PlatformNotSupportedException ();
+
+		public override Assembly GetSatelliteAssembly (CultureInfo culture, Version version) => throw new PlatformNotSupportedException ();
+
+		public override Type GetType (string name, bool throwOnError, bool ignoreCase) => throw new PlatformNotSupportedException ();
+
+		public override bool IsDefined (Type attributeType, bool inherit) => throw new PlatformNotSupportedException ();
+
+		public void Save (string assemblyFileName) => throw new PlatformNotSupportedException ();
+
+		public void Save (string assemblyFileName, PortableExecutableKinds portableExecutableKind, ImageFileMachine imageFileMachine) => throw new PlatformNotSupportedException ();
 
 		public void SetCustomAttribute (CustomAttributeBuilder customBuilder)
 		{
@@ -64,6 +200,10 @@ namespace System.Reflection.Emit
 		}
 
 		public void SetEntryPoint (MethodInfo entryMethod) => throw new PlatformNotSupportedException ();
+
+		public void SetEntryPoint (MethodInfo entryMethod, PEFileKinds fileKind) => throw new PlatformNotSupportedException ();
+
+		public override string ToString () => throw new PlatformNotSupportedException ();
 	}
 }
 

--- a/mcs/class/corlib/System.Reflection.Emit/ConstructorBuilder.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ConstructorBuilder.pns.cs
@@ -36,9 +36,17 @@ namespace System.Reflection.Emit
 {
 	public class ConstructorBuilder : ConstructorInfo
 	{
+		internal ConstructorBuilder () {}
+
 		public bool InitLocals { get; set; }
 
 		public override MethodAttributes Attributes { 
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		public override CallingConventions CallingConvention {
 			get {
 				throw new PlatformNotSupportedException ();
 			}
@@ -50,7 +58,20 @@ namespace System.Reflection.Emit
 			}
 		}
 
+		public override Module Module {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
 		public override string Name {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		[Obsolete]
+		public Type ReturnType {
 			get {
 				throw new PlatformNotSupportedException ();
 			}
@@ -98,6 +119,7 @@ namespace System.Reflection.Emit
 			IEnumerable<ExceptionHandler> exceptionHandlers, IEnumerable<int> tokenFixups) => 
 				throw new PlatformNotSupportedException ();
 
+		public void AddDeclarativeSecurity (System.Security.Permissions.SecurityAction action, System.Security.PermissionSet pset) { throw new PlatformNotSupportedException (); }
 		public override System.Reflection.MethodImplAttributes GetMethodImplementationFlags() { throw new PlatformNotSupportedException (); }
 		public override System.RuntimeMethodHandle MethodHandle { get { throw new PlatformNotSupportedException (); } }
 		public override object Invoke(System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object[] parameters, System.Globalization.CultureInfo culture) { throw new PlatformNotSupportedException (); }
@@ -106,6 +128,8 @@ namespace System.Reflection.Emit
 		public override object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw new PlatformNotSupportedException (); }
 		public override System.Type ReflectedType { get { throw new PlatformNotSupportedException (); } }
 		public override object Invoke(object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object[] parameters, System.Globalization.CultureInfo culture) { throw new PlatformNotSupportedException (); }
+		public void SetSymCustomAttribute (string name, byte[] data) { throw new PlatformNotSupportedException (); }
+		public override string ToString () { throw new PlatformNotSupportedException (); }
 	}
 }
 

--- a/mcs/class/corlib/System.Reflection.Emit/DynamicMethod.notsupported.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/DynamicMethod.notsupported.cs
@@ -94,10 +94,10 @@ namespace System.Reflection.Emit
 
 		public bool InitLocals { get; set; }
 
-		public override MethodImplAttributes MethodImplementationFlags {
+		public override Module Module {
 			get {
 				throw new PlatformNotSupportedException ();
-			}				
+			}
 		}
 
 		public override string Name {
@@ -137,6 +137,9 @@ namespace System.Reflection.Emit
 		public override Type ReflectedType { get { throw new PlatformNotSupportedException (); } }
 		public override ICustomAttributeProvider ReturnTypeCustomAttributes { get { throw new PlatformNotSupportedException (); } }
 
+		public override sealed Delegate CreateDelegate (Type delegateType) { throw new PlatformNotSupportedException (); }
+		public override sealed Delegate CreateDelegate (Type delegateType, object target) { throw new PlatformNotSupportedException (); }
+
 		public override object[] GetCustomAttributes (bool inherit) { throw new PlatformNotSupportedException (); }
 		public override object[] GetCustomAttributes (Type attributeType, bool inherit) { throw new PlatformNotSupportedException (); }
 		public override MethodImplAttributes GetMethodImplementationFlags () { throw new PlatformNotSupportedException (); }
@@ -148,6 +151,8 @@ namespace System.Reflection.Emit
 
 		public ParameterBuilder DefineParameter (int position, ParameterAttributes attributes, string parameterName) => throw new PlatformNotSupportedException ();
 		public DynamicILInfo GetDynamicILInfo () => throw new PlatformNotSupportedException ();
+
+		public override string ToString () => throw new PlatformNotSupportedException ();
 	}
 }
 

--- a/mcs/class/corlib/System.Reflection.Emit/EnumBuilder.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/EnumBuilder.pns.cs
@@ -39,11 +39,8 @@ namespace System.Reflection.Emit
 		public override System.Type DeclaringType { get { throw new PlatformNotSupportedException (); } }
 		public override string FullName { get { throw new PlatformNotSupportedException (); } }
 		public override System.Guid GUID { get { throw new PlatformNotSupportedException (); } }
-		public override bool IsByRefLike { get { throw new PlatformNotSupportedException (); } }
 		public override bool IsConstructedGenericType { get { throw new PlatformNotSupportedException (); } }
-		public override bool IsSZArray { get { throw new PlatformNotSupportedException (); } }
 		public override bool IsTypeDefinition { get { throw new PlatformNotSupportedException (); } }
-		public override bool IsVariableBoundArray { get { throw new PlatformNotSupportedException (); } }
 		public override System.Reflection.Module Module { get { throw new PlatformNotSupportedException (); } }
 		public override string Name { get { throw new PlatformNotSupportedException (); } }
 		public override string Namespace { get { throw new PlatformNotSupportedException (); } }
@@ -81,6 +78,7 @@ namespace System.Reflection.Emit
 		protected override bool HasElementTypeImpl() { throw new PlatformNotSupportedException (); }
 		public override object InvokeMember(string name, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object target, object[] args, System.Reflection.ParameterModifier[] modifiers, System.Globalization.CultureInfo culture, string[] namedParameters) { throw new PlatformNotSupportedException (); }
 		protected override bool IsArrayImpl() { throw new PlatformNotSupportedException (); }
+		public override bool IsAssignableFrom (System.Reflection.TypeInfo typeInfo) { throw new PlatformNotSupportedException (); }
 		protected override bool IsByRefImpl() { throw new PlatformNotSupportedException (); }
 		protected override bool IsCOMObjectImpl() { throw new PlatformNotSupportedException (); }
 		public override bool IsDefined(System.Type attributeType, bool inherit) { throw new PlatformNotSupportedException (); }

--- a/mcs/class/corlib/System.Reflection.Emit/EventBuilder.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/EventBuilder.pns.cs
@@ -32,6 +32,8 @@ namespace System.Reflection.Emit
 {
 	public class EventBuilder
 	{		
+		private EventBuilder () {}
+
 		public void AddOtherMethod (MethodBuilder mdBuilder)
 		{
 			throw new PlatformNotSupportedException ();

--- a/mcs/class/corlib/System.Reflection.Emit/FieldBuilder.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/FieldBuilder.pns.cs
@@ -44,9 +44,13 @@ namespace System.Reflection.Emit
 		public System.Reflection.Emit.FieldToken GetToken() { throw null; }
 		public override object GetValue(object obj) { throw null; }
 		public override bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
+		public override int MetadataToken { get { throw new PlatformNotSupportedException (); } }
+		public override Module Module { get { throw new PlatformNotSupportedException (); } }
 		public void SetConstant(object defaultValue) { throw new PlatformNotSupportedException (); } 
 		public void SetCustomAttribute(System.Reflection.ConstructorInfo con, byte[] binaryAttribute) { throw new PlatformNotSupportedException (); } 
 		public void SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder customBuilder) { throw new PlatformNotSupportedException (); } 
+		[Obsolete ("An alternate API is available: Emit the MarshalAs custom attribute instead.")]
+		public void SetMarshal (UnmanagedMarshal unmanagedMarshal) { throw new PlatformNotSupportedException (); }
 		public void SetOffset(int iOffset) { throw new PlatformNotSupportedException (); } 
 		public override void SetValue(object obj, object val, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Globalization.CultureInfo culture) { throw new PlatformNotSupportedException (); } 
 	}

--- a/mcs/class/corlib/System.Reflection.Emit/GenericTypeParameterBuilder.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/GenericTypeParameterBuilder.pns.cs
@@ -43,14 +43,9 @@ namespace System.Reflection.Emit
 		public override System.Reflection.GenericParameterAttributes GenericParameterAttributes { get { throw new PlatformNotSupportedException (); } }
 		public override int GenericParameterPosition { get { throw new PlatformNotSupportedException (); } }
 		public override System.Guid GUID { get { throw new PlatformNotSupportedException (); } }
-		public override bool IsByRefLike { get { throw new PlatformNotSupportedException (); } }
-		public override bool IsConstructedGenericType { get { throw new PlatformNotSupportedException (); } }
 		public override bool IsGenericParameter { get { throw new PlatformNotSupportedException (); } }
 		public override bool IsGenericType { get { throw new PlatformNotSupportedException (); } }
 		public override bool IsGenericTypeDefinition { get { throw new PlatformNotSupportedException (); } }
-		public override bool IsSZArray { get { throw new PlatformNotSupportedException (); } }
-		public override bool IsTypeDefinition { get { throw new PlatformNotSupportedException (); } }
-		public override bool IsVariableBoundArray { get { throw new PlatformNotSupportedException (); } }
 		public override System.Reflection.Module Module { get { throw new PlatformNotSupportedException (); } }
 		public override string Name { get { throw new PlatformNotSupportedException (); } }
 		public override string Namespace { get { throw new PlatformNotSupportedException (); } }
@@ -70,6 +65,7 @@ namespace System.Reflection.Emit
 		public override System.Reflection.FieldInfo GetField(string name, System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
 		public override System.Reflection.FieldInfo[] GetFields(System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
 		public override System.Type[] GetGenericArguments() { throw new PlatformNotSupportedException (); }
+		public override System.Type[] GetGenericParameterConstraints () { throw new PlatformNotSupportedException (); }
 		public override System.Type GetGenericTypeDefinition() { throw new PlatformNotSupportedException (); }
 		public override int GetHashCode() { throw new PlatformNotSupportedException (); }
 		public override System.Type GetInterface(string name, bool ignoreCase) { throw new PlatformNotSupportedException (); }
@@ -87,9 +83,11 @@ namespace System.Reflection.Emit
 		public override object InvokeMember(string name, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object target, object[] args, System.Reflection.ParameterModifier[] modifiers, System.Globalization.CultureInfo culture, string[] namedParameters) { throw new PlatformNotSupportedException (); }
 		protected override bool IsArrayImpl() { throw new PlatformNotSupportedException (); }
 		public override bool IsAssignableFrom(System.Type c) { throw new PlatformNotSupportedException (); }
+		public override bool IsAssignableFrom (TypeInfo typeInfo) { throw new PlatformNotSupportedException (); }
 		protected override bool IsByRefImpl() { throw new PlatformNotSupportedException (); }
 		protected override bool IsCOMObjectImpl() { throw new PlatformNotSupportedException (); }
 		public override bool IsDefined(System.Type attributeType, bool inherit) { throw new PlatformNotSupportedException (); }
+		public override bool IsInstanceOfType (object o) { throw new PlatformNotSupportedException (); }
 		protected override bool IsPointerImpl() { throw new PlatformNotSupportedException (); }
 		protected override bool IsPrimitiveImpl() { throw new PlatformNotSupportedException (); }
 		public override bool IsSubclassOf(System.Type c) { throw new PlatformNotSupportedException (); }

--- a/mcs/class/corlib/System.Reflection.Emit/ILGenerator.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ILGenerator.pns.cs
@@ -38,7 +38,7 @@ namespace System.Reflection.Emit
 		{
 		}
 
-		public int ILOffset {
+		public virtual int ILOffset {
 			get	{
 				throw new PlatformNotSupportedException ();
 			}
@@ -213,6 +213,11 @@ namespace System.Reflection.Emit
 		}
 
 		public virtual void MarkLabel (Label loc)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+		public virtual void MarkSequencePoint (System.Diagnostics.SymbolStore.ISymbolDocumentWriter document, int startLine, int startColumn, int endLine, int endColumn)
 		{
 			throw new PlatformNotSupportedException ();
 		}

--- a/mcs/class/corlib/System.Reflection.Emit/MethodBuilder.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/MethodBuilder.pns.cs
@@ -41,7 +41,6 @@ namespace System.Reflection.Emit
 		public override bool ContainsGenericParameters { get { throw new PlatformNotSupportedException (); } }
 		public override System.Type DeclaringType { get { throw new PlatformNotSupportedException (); } }
 		public bool InitLocals { get { throw new PlatformNotSupportedException (); } set { throw new PlatformNotSupportedException (); }  }
-		public override bool IsConstructedGenericMethod { get { throw new PlatformNotSupportedException (); } }
 		public override bool IsGenericMethod { get { throw new PlatformNotSupportedException (); } }
 		public override bool IsGenericMethodDefinition { get { throw new PlatformNotSupportedException (); } }
 		public override System.RuntimeMethodHandle MethodHandle { get { throw new PlatformNotSupportedException (); } }
@@ -52,6 +51,8 @@ namespace System.Reflection.Emit
 		public override System.Type ReturnType { get { throw new PlatformNotSupportedException (); } }
 		public override System.Reflection.ICustomAttributeProvider ReturnTypeCustomAttributes { get { throw new PlatformNotSupportedException (); } }
 		public string Signature { get { throw new PlatformNotSupportedException (); } }
+
+		public void AddDeclarativeSecurity (System.Security.Permissions.SecurityAction action, System.Security.PermissionSet pset) { throw new PlatformNotSupportedException (); } 
 		public void CreateMethodBody(byte[] il, int count) { throw new PlatformNotSupportedException (); } 
 		public System.Reflection.Emit.GenericTypeParameterBuilder[] DefineGenericParameters(params string[] names) { throw new PlatformNotSupportedException (); }
 		public System.Reflection.Emit.ParameterBuilder DefineParameter(int position, System.Reflection.ParameterAttributes attributes, string strParamName) { throw new PlatformNotSupportedException (); }
@@ -74,10 +75,13 @@ namespace System.Reflection.Emit
 		public void SetCustomAttribute(System.Reflection.ConstructorInfo con, byte[] binaryAttribute) { throw new PlatformNotSupportedException (); } 
 		public void SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder customBuilder) { throw new PlatformNotSupportedException (); } 
 		public void SetImplementationFlags(System.Reflection.MethodImplAttributes attributes) { throw new PlatformNotSupportedException (); } 
+		[Obsolete ("An alternate API is available: Emit the MarshalAs custom attribute instead.")]
+		public void SetMarshal (UnmanagedMarshal unmanagedMarshal) { throw new PlatformNotSupportedException (); }
 		public void SetMethodBody(byte[] il, int maxStack, byte[] localSignature, System.Collections.Generic.IEnumerable<System.Reflection.Emit.ExceptionHandler> exceptionHandlers, System.Collections.Generic.IEnumerable<int> tokenFixups) { throw new PlatformNotSupportedException (); } 
 		public void SetParameters(params System.Type[] parameterTypes) { throw new PlatformNotSupportedException (); } 
 		public void SetReturnType(System.Type returnType) { throw new PlatformNotSupportedException (); } 
 		public void SetSignature(System.Type returnType, System.Type[] returnTypeRequiredCustomModifiers, System.Type[] returnTypeOptionalCustomModifiers, System.Type[] parameterTypes, System.Type[][] parameterTypeRequiredCustomModifiers, System.Type[][] parameterTypeOptionalCustomModifiers) { throw new PlatformNotSupportedException (); } 
+		public void SetSymCustomAttribute (string name, byte[] data) { throw new PlatformNotSupportedException (); }
 		public override string ToString() { throw new PlatformNotSupportedException (); }
 	}
 }

--- a/mcs/class/corlib/System.Reflection.Emit/MethodRental.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/MethodRental.pns.cs
@@ -1,0 +1,25 @@
+#if !MONO_FEATURE_SRE
+using System.Runtime.InteropServices;
+
+namespace System.Reflection.Emit {
+
+	public partial class MethodRental : _MethodRental {
+
+		private MethodRental () {}
+
+		public const int JitImmediate = 1;
+		public const int JitOnDemand = 0;
+
+		public static void SwapMethodBody (Type cls, int methodtoken, IntPtr rgIL, int methodSize, int flags) => throw new PlatformNotSupportedException ();
+
+		void _MethodRental.GetIDsOfNames ([In] ref Guid riid, IntPtr rgszNames, uint cNames, uint lcid, IntPtr rgDispId) => throw new PlatformNotSupportedException ();
+
+		void _MethodRental.GetTypeInfo (uint iTInfo, uint lcid, IntPtr ppTInfo) => throw new PlatformNotSupportedException ();
+
+		void _MethodRental.GetTypeInfoCount (out uint pcTInfo) => throw new PlatformNotSupportedException ();
+
+		void _MethodRental.Invoke (uint dispIdMember, [In] ref Guid riid, uint lcid, short wFlags, IntPtr pDispParams, IntPtr pVarResult, IntPtr pExcepInfo, IntPtr puArgErr) => throw new PlatformNotSupportedException ();
+	}
+}
+
+#endif

--- a/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.pns.cs
@@ -35,15 +35,24 @@ namespace System.Reflection.Emit
         internal ModuleBuilder() => throw new PlatformNotSupportedException();
         public override System.Reflection.Assembly Assembly { get { throw new PlatformNotSupportedException(); } }
         public override string FullyQualifiedName { get { throw new PlatformNotSupportedException(); } }
+        public override int MetadataToken { get { throw new PlatformNotSupportedException(); } }
+        public override System.Guid ModuleVersionId { get { throw new PlatformNotSupportedException(); } }
         public override string Name { get { throw new PlatformNotSupportedException(); } }
+        public override string ScopeName { get { throw new PlatformNotSupportedException(); } }
         public void CreateGlobalFunctions() => throw new PlatformNotSupportedException();
+        public System.Diagnostics.SymbolStore.ISymbolDocumentWriter DefineDocument (string url, System.Guid language, System.Guid languageVendor, System.Guid documentType) => throw new PlatformNotSupportedException ();
         public System.Reflection.Emit.EnumBuilder DefineEnum(string name, System.Reflection.TypeAttributes visibility, System.Type underlyingType) { throw new PlatformNotSupportedException(); }
         public System.Reflection.Emit.MethodBuilder DefineGlobalMethod(string name, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes) { throw new PlatformNotSupportedException(); }
         public System.Reflection.Emit.MethodBuilder DefineGlobalMethod(string name, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] requiredReturnTypeCustomModifiers, System.Type[] optionalReturnTypeCustomModifiers, System.Type[] parameterTypes, System.Type[][] requiredParameterTypeCustomModifiers, System.Type[][] optionalParameterTypeCustomModifiers) { throw new PlatformNotSupportedException(); }
         public System.Reflection.Emit.MethodBuilder DefineGlobalMethod(string name, System.Reflection.MethodAttributes attributes, System.Type returnType, System.Type[] parameterTypes) { throw new PlatformNotSupportedException(); }
         public System.Reflection.Emit.FieldBuilder DefineInitializedData(string name, byte[] data, System.Reflection.FieldAttributes attributes) { throw new PlatformNotSupportedException(); }
+        public void DefineManifestResource (string name, System.IO.Stream stream, System.Reflection.ResourceAttributes attribute) => throw new PlatformNotSupportedException ();
         public System.Reflection.Emit.MethodBuilder DefinePInvokeMethod(string name, string dllName, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes, System.Runtime.InteropServices.CallingConvention nativeCallConv, System.Runtime.InteropServices.CharSet nativeCharSet) { throw new PlatformNotSupportedException(); }
         public System.Reflection.Emit.MethodBuilder DefinePInvokeMethod(string name, string dllName, string entryName, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes, System.Runtime.InteropServices.CallingConvention nativeCallConv, System.Runtime.InteropServices.CharSet nativeCharSet) { throw new PlatformNotSupportedException(); }
+        public System.Resources.IResourceWriter DefineResource (string name, string description) => throw new PlatformNotSupportedException ();
+        public System.Resources.IResourceWriter DefineResource (string name, string description, System.Reflection.ResourceAttributes attribute) => throw new PlatformNotSupportedException ();
+        public void DefineUnmanagedResource (byte[] resource) => throw new PlatformNotSupportedException ();
+        public void DefineUnmanagedResource (string resourceFileName) => throw new PlatformNotSupportedException ();
         public System.Reflection.Emit.TypeBuilder DefineType(string name) { throw new PlatformNotSupportedException(); }
         public System.Reflection.Emit.TypeBuilder DefineType(string name, System.Reflection.TypeAttributes attr) { throw new PlatformNotSupportedException(); }
         public System.Reflection.Emit.TypeBuilder DefineType(string name, System.Reflection.TypeAttributes attr, System.Type parent) { throw new PlatformNotSupportedException(); }
@@ -57,18 +66,38 @@ namespace System.Reflection.Emit
         public System.Reflection.Emit.MethodToken GetArrayMethodToken(System.Type arrayClass, string methodName, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes) { throw new PlatformNotSupportedException(); }
         public System.Reflection.Emit.MethodToken GetConstructorToken(System.Reflection.ConstructorInfo con) { throw new PlatformNotSupportedException(); }
         public System.Reflection.Emit.MethodToken GetConstructorToken(System.Reflection.ConstructorInfo constructor, System.Collections.Generic.IEnumerable<System.Type> optionalParameterTypes) { throw new PlatformNotSupportedException(); }
+        public override object[] GetCustomAttributes (bool inherit) { throw new PlatformNotSupportedException(); }
+        public override object[] GetCustomAttributes (System.Type attributeType, bool inherit) { throw new PlatformNotSupportedException(); }
+        public override System.Reflection.FieldInfo GetField (string name, System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException(); }
+        public override System.Reflection.FieldInfo[] GetFields (System.Reflection.BindingFlags bindingFlags) { throw new PlatformNotSupportedException(); }
         public System.Reflection.Emit.FieldToken GetFieldToken(System.Reflection.FieldInfo field) { throw new PlatformNotSupportedException(); }
         public override int GetHashCode() { throw new PlatformNotSupportedException(); }
+        protected override System.Reflection.MethodInfo GetMethodImpl (string name, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw new PlatformNotSupportedException(); }
+        public override System.Reflection.MethodInfo[] GetMethods (System.Reflection.BindingFlags bindingFlags) { throw new PlatformNotSupportedException(); }
         public System.Reflection.Emit.MethodToken GetMethodToken(System.Reflection.MethodInfo method) { throw new PlatformNotSupportedException(); }
         public System.Reflection.Emit.MethodToken GetMethodToken(System.Reflection.MethodInfo method, System.Collections.Generic.IEnumerable<System.Type> optionalParameterTypes) { throw new PlatformNotSupportedException(); }
         public System.Reflection.Emit.SignatureToken GetSignatureToken(byte[] sigBytes, int sigLength) { throw new PlatformNotSupportedException(); }
         public System.Reflection.Emit.SignatureToken GetSignatureToken(System.Reflection.Emit.SignatureHelper sigHelper) { throw new PlatformNotSupportedException(); }
         public System.Reflection.Emit.StringToken GetStringConstant(string str) { throw new PlatformNotSupportedException(); }
+        public System.Diagnostics.SymbolStore.ISymbolWriter GetSymWriter () => throw new PlatformNotSupportedException ();
+        public override System.Type GetType (string className) { throw new PlatformNotSupportedException(); }
+        public override System.Type GetType (string className, bool ignoreCase) { throw new PlatformNotSupportedException(); }
+        public override System.Type GetType (string className, bool throwOnError, bool ignoreCase) { throw new PlatformNotSupportedException(); }
+        public override System.Type[] GetTypes () { throw new PlatformNotSupportedException(); }
         public System.Reflection.Emit.TypeToken GetTypeToken(string name) { throw new PlatformNotSupportedException(); }
         public System.Reflection.Emit.TypeToken GetTypeToken(System.Type type) { throw new PlatformNotSupportedException(); }
+        public override bool IsDefined (System.Type attributeType, bool inherit) { throw new PlatformNotSupportedException(); }
+        public override bool IsResource () { throw new PlatformNotSupportedException(); }
         public bool IsTransient() { throw new PlatformNotSupportedException(); }
+        public override System.Reflection.FieldInfo ResolveField (int metadataToken, System.Type[] genericTypeArguments, System.Type[] genericMethodArguments) { throw new PlatformNotSupportedException(); }
+        public override System.Reflection.MemberInfo ResolveMember (int metadataToken, System.Type[] genericTypeArguments, System.Type[] genericMethodArguments) { throw new PlatformNotSupportedException(); }
+        public override System.Reflection.MethodBase ResolveMethod (int metadataToken, System.Type[] genericTypeArguments, System.Type[] genericMethodArguments) { throw new PlatformNotSupportedException(); }
+        public override byte[] ResolveSignature (int metadataToken) { throw new PlatformNotSupportedException(); }
+        public override string ResolveString (int metadataToken) { throw new PlatformNotSupportedException(); }
+        public override System.Type ResolveType (int metadataToken, System.Type[] genericTypeArguments, System.Type[] genericMethodArguments) { throw new PlatformNotSupportedException(); }
         public void SetCustomAttribute(System.Reflection.ConstructorInfo con, byte[] binaryAttribute) => throw new PlatformNotSupportedException();
         public void SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder customBuilder) => throw new PlatformNotSupportedException();
+        public void SetSymCustomAttribute (string name, byte[] data) => throw new PlatformNotSupportedException ();
         public void SetUserEntryPoint(System.Reflection.MethodInfo entryPoint) => throw new PlatformNotSupportedException();
     }
 

--- a/mcs/class/corlib/System.Reflection.Emit/ParameterBuilder.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ParameterBuilder.pns.cs
@@ -36,7 +36,7 @@ namespace System.Reflection.Emit
 		{
 		}
 
-		public int Attributes {
+		public virtual int Attributes {
 			get {
 				throw new PlatformNotSupportedException ();
 			}
@@ -60,13 +60,13 @@ namespace System.Reflection.Emit
 			}
 		}
 
-		public string Name {
+		public virtual string Name {
 			get {
 				throw new PlatformNotSupportedException ();
 			}
 		}
 
-		public int Position {
+		public virtual int Position {
 			get {
 				throw new PlatformNotSupportedException ();
 			}
@@ -86,6 +86,9 @@ namespace System.Reflection.Emit
 		{
 			throw new PlatformNotSupportedException ();
 		}
+
+		[Obsolete ("An alternate API is available: Emit the MarshalAs custom attribute instead.")]
+		public virtual void SetMarshal (UnmanagedMarshal unmanagedMarshal) => throw new PlatformNotSupportedException ();
 
 		public virtual ParameterToken GetToken() => throw new PlatformNotSupportedException ();
 	}

--- a/mcs/class/corlib/System.Reflection.Emit/SignatureHelper.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/SignatureHelper.pns.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 
 namespace System.Reflection.Emit
 {
-	public class SignatureHelper
+	public class SignatureHelper : _SignatureHelper
 	{
 		SignatureHelper ()
 		{			
@@ -118,6 +118,18 @@ namespace System.Reflection.Emit
 
 		public static SignatureHelper GetMethodSigHelper (CallingConvention unmanagedCallingConvention, Type returnType) =>
 			throw new PlatformNotSupportedException ();
+
+		public override bool Equals (object obj) => throw new PlatformNotSupportedException ();
+		public override int GetHashCode () => throw new PlatformNotSupportedException ();
+		public override string ToString () => throw new PlatformNotSupportedException ();
+
+		void _SignatureHelper.GetIDsOfNames ([In] ref Guid riid, IntPtr rgszNames, uint cNames, uint lcid, IntPtr rgDispId) => throw new PlatformNotSupportedException ();
+
+		void _SignatureHelper.GetTypeInfo (uint iTInfo, uint lcid, IntPtr ppTInfo) => throw new PlatformNotSupportedException ();
+
+		void _SignatureHelper.GetTypeInfoCount (out uint pcTInfo) => throw new PlatformNotSupportedException ();
+
+		void _SignatureHelper.Invoke (uint dispIdMember, [In] ref Guid riid, uint lcid, short wFlags, IntPtr pDispParams, IntPtr pVarResult, IntPtr pExcepInfo, IntPtr puArgErr) => throw new PlatformNotSupportedException ();
 	}
 }
 

--- a/mcs/class/corlib/System.Reflection.Emit/TypeBuilder.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/TypeBuilder.pns.cs
@@ -39,23 +39,18 @@ namespace System.Reflection.Emit
 		public override System.Reflection.Assembly Assembly { get { throw new PlatformNotSupportedException (); } }
 		public override string AssemblyQualifiedName { get { throw new PlatformNotSupportedException (); } }
 		public override System.Type BaseType { get { throw new PlatformNotSupportedException (); } }
+		public override bool ContainsGenericParameters { get { throw new PlatformNotSupportedException (); } }
 		public override System.Reflection.MethodBase DeclaringMethod { get { throw new PlatformNotSupportedException (); } }
 		public override System.Type DeclaringType { get { throw new PlatformNotSupportedException (); } }
 		public override string FullName { get { throw new PlatformNotSupportedException (); } }
 		public override System.Reflection.GenericParameterAttributes GenericParameterAttributes { get { throw new PlatformNotSupportedException (); } }
 		public override int GenericParameterPosition { get { throw new PlatformNotSupportedException (); } }
 		public override System.Guid GUID { get { throw new PlatformNotSupportedException (); } }
-		public override bool IsByRefLike { get { throw new PlatformNotSupportedException (); } }
 		public override bool IsConstructedGenericType { get { throw new PlatformNotSupportedException (); } }
 		public override bool IsGenericParameter { get { throw new PlatformNotSupportedException (); } }
 		public override bool IsGenericType { get { throw new PlatformNotSupportedException (); } }
 		public override bool IsGenericTypeDefinition { get { throw new PlatformNotSupportedException (); } }
-		public override bool IsSecurityCritical { get { throw new PlatformNotSupportedException (); } }
-		public override bool IsSecuritySafeCritical { get { throw new PlatformNotSupportedException (); } }
-		public override bool IsSecurityTransparent { get { throw new PlatformNotSupportedException (); } }
-		public override bool IsSZArray { get { throw new PlatformNotSupportedException (); } }
 		public override bool IsTypeDefinition { get { throw new PlatformNotSupportedException (); } }
-		public override bool IsVariableBoundArray { get { throw new PlatformNotSupportedException (); } }
 		public override System.Reflection.Module Module { get { throw new PlatformNotSupportedException (); } }
 		public override string Name { get { throw new PlatformNotSupportedException (); } }
 		public override string Namespace { get { throw new PlatformNotSupportedException (); } }
@@ -65,6 +60,8 @@ namespace System.Reflection.Emit
 		public override System.RuntimeTypeHandle TypeHandle { get { throw new PlatformNotSupportedException (); } }
 		public System.Reflection.Emit.TypeToken TypeToken { get { throw new PlatformNotSupportedException (); } }
 		public override System.Type UnderlyingSystemType { get { throw new PlatformNotSupportedException (); } }
+
+		public void AddDeclarativeSecurity (System.Security.Permissions.SecurityAction action, System.Security.PermissionSet pset) { throw new PlatformNotSupportedException (); }
 		public void AddInterfaceImplementation(System.Type interfaceType) { throw new PlatformNotSupportedException (); } 
 		public System.Type CreateType() { throw new PlatformNotSupportedException (); }
 		public System.Reflection.TypeInfo CreateTypeInfo() { throw new PlatformNotSupportedException (); }
@@ -128,7 +125,8 @@ namespace System.Reflection.Emit
 		protected override bool HasElementTypeImpl() { throw new PlatformNotSupportedException (); }
 		public override object InvokeMember(string name, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object target, object[] args, System.Reflection.ParameterModifier[] modifiers, System.Globalization.CultureInfo culture, string[] namedParameters) { throw new PlatformNotSupportedException (); }
 		protected override bool IsArrayImpl() { throw new PlatformNotSupportedException (); }
-		public override bool IsAssignableFrom(System.Type c) { throw new PlatformNotSupportedException (); }
+		public override bool IsAssignableFrom (System.Type c) { throw new PlatformNotSupportedException (); }
+		public override bool IsAssignableFrom (TypeInfo typeInfo) { throw new PlatformNotSupportedException (); }
 		protected override bool IsByRefImpl() { throw new PlatformNotSupportedException (); }
 		protected override bool IsCOMObjectImpl() { throw new PlatformNotSupportedException (); }
 		public bool IsCreated() { throw new PlatformNotSupportedException (); }
@@ -136,6 +134,7 @@ namespace System.Reflection.Emit
 		protected override bool IsPointerImpl() { throw new PlatformNotSupportedException (); }
 		protected override bool IsPrimitiveImpl() { throw new PlatformNotSupportedException (); }
 		public override bool IsSubclassOf(System.Type c) { throw new PlatformNotSupportedException (); }
+		protected override bool IsValueTypeImpl () { throw new PlatformNotSupportedException (); }
 		public override System.Type MakeArrayType() { throw new PlatformNotSupportedException (); }
 		public override System.Type MakeArrayType(int rank) { throw new PlatformNotSupportedException (); }
 		public override System.Type MakeByRefType() { throw new PlatformNotSupportedException (); }

--- a/mcs/class/corlib/System.Reflection.Emit/UnmanagedMarshal.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/UnmanagedMarshal.pns.cs
@@ -1,0 +1,26 @@
+#if !MONO_FEATURE_SRE
+using System.Runtime.InteropServices;
+
+namespace System.Reflection.Emit {
+
+	[Obsolete ("An alternate API is available: Emit the MarshalAs custom attribute instead.")]
+	[ComVisible (true)]
+	[Serializable]
+	[StructLayout (LayoutKind.Sequential)]
+	public sealed class UnmanagedMarshal {
+
+		private UnmanagedMarshal () {}
+
+		public UnmanagedType BaseType { get { throw new PlatformNotSupportedException (); } }
+		public int ElementCount { get { throw new PlatformNotSupportedException (); } }
+		public UnmanagedType GetUnmanagedType { get { throw new PlatformNotSupportedException (); } }
+		public System.Guid IIDGuid { get { throw new PlatformNotSupportedException (); } }
+
+		public static UnmanagedMarshal DefineByValArray (int elemCount) => throw new PlatformNotSupportedException ();
+		public static UnmanagedMarshal DefineByValTStr (int elemCount) => throw new PlatformNotSupportedException ();
+		public static UnmanagedMarshal DefineLPArray (UnmanagedType elemType) => throw new PlatformNotSupportedException ();
+		public static UnmanagedMarshal DefineUnmanagedMarshal (UnmanagedType unmanagedType) => throw new PlatformNotSupportedException ();
+	}
+}
+
+#endif

--- a/mcs/class/corlib/System.Runtime.InteropServices/ITypeLibConverter.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/ITypeLibConverter.cs
@@ -30,7 +30,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection;
 using System.Reflection.Emit;
 

--- a/mcs/class/corlib/System.Runtime.InteropServices/ITypeLibExporterNameProvider.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/ITypeLibExporterNameProvider.cs
@@ -30,7 +30,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 namespace System.Runtime.InteropServices {
 
 	[ComVisible (true)]

--- a/mcs/class/corlib/System.Runtime.InteropServices/ITypeLibExporterNotifySink.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/ITypeLibExporterNotifySink.cs
@@ -30,7 +30,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/ITypeLibImporterNotifySink.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/ITypeLibImporterNotifySink.cs
@@ -30,7 +30,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/Marshal.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/Marshal.cs
@@ -391,7 +391,7 @@ namespace System.Runtime.InteropServices
 			FreeHGlobal (s);
 		}
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 		public static Guid GenerateGuidForType (Type type)
 		{
 			return type.GUID;
@@ -438,7 +438,7 @@ namespace System.Runtime.InteropServices
 				return GetCCW (o, T);
 		}
 #endif
-#endif // !FULL_AOT_RUNTIME
+#endif // !FULL_AOT_RUNTIME && !MONOTOUCH
 
 		public static IntPtr GetComInterfaceForObject (object o, Type T)
 		{
@@ -463,7 +463,7 @@ namespace System.Runtime.InteropServices
 			return GetComInterfaceForObject ((object)o, typeof (T));
 		}
 
-#if !FULL_AOT_RUNTIME && !NETCORE
+#if !FULL_AOT_RUNTIME && !NETCORE && !MONOTOUCH
 
 		public static IntPtr GetComInterfaceForObjectInContext (object o, Type t)
 		{
@@ -518,7 +518,7 @@ namespace System.Runtime.InteropServices
 
 			return (IntPtr)(-1);
 		}
-#else
+#elif !MONOTOUCH
 		public static IntPtr GetHINSTANCE (Module m) => throw new PlatformNotSupportedException();
 		public static IntPtr GetIDispatchForObject (object o) => throw new PlatformNotSupportedException();
 		public static object GetTypedObjectForIUnknown (IntPtr pUnk, Type t) => throw new PlatformNotSupportedException();
@@ -556,7 +556,7 @@ namespace System.Runtime.InteropServices
 #endif
 		}
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		private extern static IntPtr GetIDispatchForObjectInternal (object o);
 
@@ -606,7 +606,7 @@ namespace System.Runtime.InteropServices
 
 		public static IntPtr GetIUnknownForObject (object o)
 		{
-#if FULL_AOT_RUNTIME
+#if FULL_AOT_RUNTIME || MONOTOUCH
 			throw new PlatformNotSupportedException ();
 #else
 			IntPtr pUnk = GetIUnknownForObjectInternal (o);
@@ -711,7 +711,7 @@ namespace System.Runtime.InteropServices
 #endif
 		}
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 
 #if !NETCORE
 
@@ -1134,7 +1134,7 @@ namespace System.Runtime.InteropServices
 #endif
 		}
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 		[Obsolete]
 
 		public static void ReleaseThreadCache()

--- a/mcs/class/corlib/System.Runtime.InteropServices/TypeLibConverter.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/TypeLibConverter.cs
@@ -28,7 +28,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System;
 using System.Reflection;
 using System.Reflection.Emit;

--- a/mcs/class/corlib/System.Runtime.InteropServices/TypeLibExporterFlags.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/TypeLibExporterFlags.cs
@@ -30,7 +30,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 namespace System.Runtime.InteropServices
 {
 	[ComVisible(true)]

--- a/mcs/class/corlib/System.Runtime.InteropServices/TypeLibImporterFlags.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/TypeLibImporterFlags.cs
@@ -28,7 +28,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System;
 
 namespace System.Runtime.InteropServices

--- a/mcs/class/corlib/System.Runtime.InteropServices/UCOMITypeComp.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/UCOMITypeComp.cs
@@ -28,7 +28,7 @@
 //
 // (C) 2002 Ximian, Inc.
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 namespace System.Runtime.InteropServices
 {
 	[Obsolete]

--- a/mcs/class/corlib/System.Runtime.InteropServices/UCOMITypeLib.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/UCOMITypeLib.cs
@@ -28,7 +28,7 @@
 //
 // (C) 2002 Ximian, Inc.
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 namespace System.Runtime.InteropServices
 {
 	[Obsolete]

--- a/mcs/class/corlib/System.Runtime.InteropServices/_AssemblyBuilder.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_AssemblyBuilder.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/_ConstructorBuilder.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_ConstructorBuilder.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/_CustomAttributeBuilder.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_CustomAttributeBuilder.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/_EnumBuilder.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_EnumBuilder.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/_EventBuilder.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_EventBuilder.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/_FieldBuilder.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_FieldBuilder.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/_ILGenerator.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_ILGenerator.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/_LocalBuilder.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_LocalBuilder.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/_MethodBuilder.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_MethodBuilder.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/_ModuleBuilder.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_ModuleBuilder.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/_ParameterBuilder.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_ParameterBuilder.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/_PropertyBuilder.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_PropertyBuilder.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/_TypeBuilder.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_TypeBuilder.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System/AppDomain.pns.cs
+++ b/mcs/class/corlib/System/AppDomain.pns.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Security;
+using System.Security.Policy;
+
+#if !MONO_FEATURE_SRE
+
+namespace System {
+
+	public partial class AppDomain {
+
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access, IEnumerable<CustomAttributeBuilder> assemblyAttributes)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+
+		[Obsolete ("Declarative security for assembly level is no longer enforced")]
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access, Evidence evidence)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access, string dir)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access, IEnumerable<CustomAttributeBuilder> assemblyAttributes, SecurityContextSource securityContextSource)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+		[Obsolete ("Declarative security for assembly level is no longer enforced")]
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access, string dir, Evidence evidence)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+		[Obsolete ("Declarative security for assembly level is no longer enforced")]
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access, PermissionSet requiredPermissions, PermissionSet optionalPermissions, PermissionSet refusedPermissions)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access, string dir, bool isSynchronized, IEnumerable<CustomAttributeBuilder> assemblyAttributes)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+		[Obsolete ("Declarative security for assembly level is no longer enforced")]
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access, Evidence evidence, PermissionSet requiredPermissions, PermissionSet optionalPermissions, PermissionSet refusedPermissions)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+		[Obsolete ("Declarative security for assembly level is no longer enforced")]
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access, string dir, PermissionSet requiredPermissions, PermissionSet optionalPermissions, PermissionSet refusedPermissions)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+		[Obsolete ("Declarative security for assembly level is no longer enforced")]
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access, string dir, Evidence evidence, PermissionSet requiredPermissions, PermissionSet optionalPermissions, PermissionSet refusedPermissions)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+		[Obsolete ("Declarative security for assembly level is no longer enforced")]
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access, string dir, Evidence evidence, PermissionSet requiredPermissions, PermissionSet optionalPermissions, PermissionSet refusedPermissions, bool isSynchronized)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+		[Obsolete ("Declarative security for assembly level is no longer enforced")]
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access, string dir, Evidence evidence, PermissionSet requiredPermissions, PermissionSet optionalPermissions, PermissionSet refusedPermissions, bool isSynchronized, IEnumerable<CustomAttributeBuilder> assemblyAttributes)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+	}
+}
+
+#endif

--- a/mcs/class/corlib/corlib.csproj
+++ b/mcs/class/corlib/corlib.csproj
@@ -1446,6 +1446,7 @@
     <Compile Include="System.Reflection.Emit\MethodBuilder.pns.cs" />
     <Compile Include="System.Reflection.Emit\MethodOnTypeBuilderInst.cs" />
     <Compile Include="System.Reflection.Emit\MethodRental.cs" />
+    <Compile Include="System.Reflection.Emit\MethodRental.pns.cs" />
     <Compile Include="System.Reflection.Emit\MethodToken.cs" />
     <Compile Include="System.Reflection.Emit\ModuleBuilder.cs" />
     <Compile Include="System.Reflection.Emit\ModuleBuilder.pns.cs" />
@@ -1470,6 +1471,7 @@
     <Compile Include="System.Reflection.Emit\TypeBuilderInstantiation.cs" />
     <Compile Include="System.Reflection.Emit\TypeToken.cs" />
     <Compile Include="System.Reflection.Emit\UnmanagedMarshal.cs" />
+    <Compile Include="System.Reflection.Emit\UnmanagedMarshal.pns.cs" />
     <Compile Include="System.Reflection.Metadata\AssemblyExtensions.cs" />
     <Compile Include="System.Reflection\Assembly.cs" />
     <Compile Include="System.Reflection\AssemblyName.cs" />
@@ -1968,6 +1970,7 @@
     <Compile Include="System.Threading\WaitHandle.cs" />
     <Compile Include="System\ActivationContext.cs" />
     <Compile Include="System\AppDomain.cs" />
+    <Compile Include="System\AppDomain.pns.cs" />
     <Compile Include="System\AppDomainInitializer.cs" />
     <Compile Include="System\AppDomainManager.cs" />
     <Compile Include="System\AppDomainSetup.cs" />

--- a/mcs/class/corlib/corlib.dll.sources
+++ b/mcs/class/corlib/corlib.dll.sources
@@ -73,6 +73,7 @@ Mono.Xml/SecurityParser.cs
 System/ActivationContext.cs
 System/AndroidPlatform.cs
 System/AppDomain.cs
+System/AppDomain.pns.cs
 System/AppDomainInitializer.cs
 System/AppDomainManager.cs
 System/AppDomainSetup.cs
@@ -286,6 +287,7 @@ System.Reflection.Emit/MethodBuilder.cs
 System.Reflection.Emit/MethodOnTypeBuilderInst.cs
 System.Reflection.Emit/MethodToken.cs
 System.Reflection.Emit/MethodRental.cs
+System.Reflection.Emit/MethodRental.pns.cs
 System.Reflection.Emit/ModuleBuilder.cs
 System.Reflection.Emit/MonoArrayMethod.cs
 System.Reflection.Emit/OpCodeNames.cs
@@ -308,6 +310,7 @@ System.Reflection.Emit/TypeBuilder.cs
 System.Reflection.Emit/TypeBuilderInstantiation.cs
 System.Reflection.Emit/TypeToken.cs
 System.Reflection.Emit/UnmanagedMarshal.cs
+System.Reflection.Emit/UnmanagedMarshal.pns.cs
 System.Reflection.Emit/AssemblyBuilder.pns.cs
 System.Reflection.Emit/ConstructorBuilder.pns.cs
 System.Reflection.Emit/CustomAttributeBuilder.pns.cs

--- a/mcs/class/referencesource/mscorlib/system/iappdomain.cs
+++ b/mcs/class/referencesource/mscorlib/system/iappdomain.cs
@@ -29,9 +29,7 @@ namespace System {
     using System.Threading;
     using System.Runtime.InteropServices;
     using System.Runtime.Remoting;
-#if !FULL_AOT_RUNTIME
     using System.Reflection.Emit;
-#endif
     using CultureInfo = System.Globalization.CultureInfo;
     using System.IO;
     using System.Runtime.Versioning;
@@ -88,7 +86,7 @@ namespace System {
 
         [method:System.Security.SecurityCritical]
         event UnhandledExceptionEventHandler UnhandledException;
-#if !FULL_AOT_RUNTIME
+
         AssemblyBuilder DefineDynamicAssembly(AssemblyName            name,
                                               AssemblyBuilderAccess   access);
 
@@ -141,7 +139,7 @@ namespace System {
                                               PermissionSet           optionalPermissions,
                                               PermissionSet           refusedPermissions,
                                               bool                    isSynchronized);
-#endif
+
         ObjectHandle CreateInstance(String assemblyName,
                                     String typeName);
 

--- a/mcs/class/referencesource/mscorlib/system/runtime/interopservices/dispatchwrapper.cs
+++ b/mcs/class/referencesource/mscorlib/system/runtime/interopservices/dispatchwrapper.cs
@@ -31,7 +31,7 @@ namespace System.Runtime.InteropServices {
         {
             if (obj != null)
             {
-#if FULL_AOT_RUNTIME
+#if FULL_AOT_RUNTIME || MONOTOUCH
                 throw new PlatformNotSupportedException ();
 #else
                 // Make sure this guy has an IDispatch

--- a/mcs/class/referencesource/mscorlib/system/runtime/interopservices/ucomitypeinfo.cs
+++ b/mcs/class/referencesource/mscorlib/system/runtime/interopservices/ucomitypeinfo.cs
@@ -304,7 +304,7 @@ namespace System.Runtime.InteropServices
         VARFLAG_FIMMEDIATEBIND    =0x1000
     }
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
     [Obsolete("Use System.Runtime.InteropServices.ComTypes.ITypeInfo instead. http://go.microsoft.com/fwlink/?linkid=14202", false)]
     [Guid("00020401-0000-0000-C000-000000000046")]
     [InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown)]


### PR DESCRIPTION
Ensure the API surface for `mscorlib.Core.dll` is identical between the
`monotouch` and `monotouch_runtime` (used for REPL and the interpreter).

This ensure code compiled against one will be fine when building against
the other (e.g. avoiding linker errors).

In practice this means:

1. Expose the API needed for `System.Reflection.Emit` in XI

	- throwing `PlatformNotSupportedException` **by default**; or
	- calling the mono runtime when the interpreter is enabled;

2. Do not expose additional, not supported, API (e.g. COM related)

	- `monotouch_runtime` configuration was built without `FULL_AOT_RUNTIME`
	  and that brings some other stuff that is not AOT related

Follow up to #14606

Existing diff

Removed methods:

```csharp
public Reflection.Emit.AssemblyBuilder DefineDynamicAssembly (Reflection.AssemblyName name, Reflection.Emit.AssemblyBuilderAccess access);
public Reflection.Emit.AssemblyBuilder DefineDynamicAssembly (Reflection.AssemblyName name, Reflection.Emit.AssemblyBuilderAccess access, System.Collections.Generic.IEnumerable<Reflection.Emit.CustomAttributeBuilder> assemblyAttributes);

[Obsolete ("Declarative security for assembly level is no longer enforced")]
public Reflection.Emit.AssemblyBuilder DefineDynamicAssembly (Reflection.AssemblyName name, Reflection.Emit.AssemblyBuilderAccess access, Security.Policy.Evidence evidence);
public Reflection.Emit.AssemblyBuilder DefineDynamicAssembly (Reflection.AssemblyName name, Reflection.Emit.AssemblyBuilderAccess access, string dir);
public Reflection.Emit.AssemblyBuilder DefineDynamicAssembly (Reflection.AssemblyName name, Reflection.Emit.AssemblyBuilderAccess access, System.Collections.Generic.IEnumerable<Reflection.Emit.CustomAttributeBuilder> assemblyAttributes, Security.SecurityContextSource securityContextSource);

[Obsolete ("Declarative security for assembly level is no longer enforced")]
public Reflection.Emit.AssemblyBuilder DefineDynamicAssembly (Reflection.AssemblyName name, Reflection.Emit.AssemblyBuilderAccess access, string dir, Security.Policy.Evidence evidence);

[Obsolete ("Declarative security for assembly level is no longer enforced")]
public Reflection.Emit.AssemblyBuilder DefineDynamicAssembly (Reflection.AssemblyName name, Reflection.Emit.AssemblyBuilderAccess access, Security.PermissionSet requiredPermissions, Security.PermissionSet optionalPermissions, Security.PermissionSet refusedPermissions);
public Reflection.Emit.AssemblyBuilder DefineDynamicAssembly (Reflection.AssemblyName name, Reflection.Emit.AssemblyBuilderAccess access, string dir, bool isSynchronized, System.Collections.Generic.IEnumerable<Reflection.Emit.CustomAttributeBuilder> assemblyAttributes);

[Obsolete ("Declarative security for assembly level is no longer enforced")]
public Reflection.Emit.AssemblyBuilder DefineDynamicAssembly (Reflection.AssemblyName name, Reflection.Emit.AssemblyBuilderAccess access, Security.Policy.Evidence evidence, Security.PermissionSet requiredPermissions, Security.PermissionSet optionalPermissions, Security.PermissionSet refusedPermissions);

[Obsolete ("Declarative security for assembly level is no longer enforced")]
public Reflection.Emit.AssemblyBuilder DefineDynamicAssembly (Reflection.AssemblyName name, Reflection.Emit.AssemblyBuilderAccess access, string dir, Security.PermissionSet requiredPermissions, Security.PermissionSet optionalPermissions, Security.PermissionSet refusedPermissions);

[Obsolete ("Declarative security for assembly level is no longer enforced")]
public Reflection.Emit.AssemblyBuilder DefineDynamicAssembly (Reflection.AssemblyName name, Reflection.Emit.AssemblyBuilderAccess access, string dir, Security.Policy.Evidence evidence, Security.PermissionSet requiredPermissions, Security.PermissionSet optionalPermissions, Security.PermissionSet refusedPermissions);

[Obsolete ("Declarative security for assembly level is no longer enforced")]
public Reflection.Emit.AssemblyBuilder DefineDynamicAssembly (Reflection.AssemblyName name, Reflection.Emit.AssemblyBuilderAccess access, string dir, Security.Policy.Evidence evidence, Security.PermissionSet requiredPermissions, Security.PermissionSet optionalPermissions, Security.PermissionSet refusedPermissions, bool isSynchronized);

[Obsolete ("Declarative security for assembly level is no longer enforced")]
public Reflection.Emit.AssemblyBuilder DefineDynamicAssembly (Reflection.AssemblyName name, Reflection.Emit.AssemblyBuilderAccess access, string dir, Security.Policy.Evidence evidence, Security.PermissionSet requiredPermissions, Security.PermissionSet optionalPermissions, Security.PermissionSet refusedPermissions, bool isSynchronized, System.Collections.Generic.IEnumerable<Reflection.Emit.CustomAttributeBuilder> assemblyAttributes);
```

Removed methods:

```csharp
public virtual Reflection.Emit.AssemblyBuilder DefineDynamicAssembly (Reflection.AssemblyName name, Reflection.Emit.AssemblyBuilderAccess access);
public virtual Reflection.Emit.AssemblyBuilder DefineDynamicAssembly (Reflection.AssemblyName name, Reflection.Emit.AssemblyBuilderAccess access, Security.Policy.Evidence evidence);
public virtual Reflection.Emit.AssemblyBuilder DefineDynamicAssembly (Reflection.AssemblyName name, Reflection.Emit.AssemblyBuilderAccess access, string dir);
public virtual Reflection.Emit.AssemblyBuilder DefineDynamicAssembly (Reflection.AssemblyName name, Reflection.Emit.AssemblyBuilderAccess access, string dir, Security.Policy.Evidence evidence);
public virtual Reflection.Emit.AssemblyBuilder DefineDynamicAssembly (Reflection.AssemblyName name, Reflection.Emit.AssemblyBuilderAccess access, Security.PermissionSet requiredPermissions, Security.PermissionSet optionalPermissions, Security.PermissionSet refusedPermissions);
public virtual Reflection.Emit.AssemblyBuilder DefineDynamicAssembly (Reflection.AssemblyName name, Reflection.Emit.AssemblyBuilderAccess access, Security.Policy.Evidence evidence, Security.PermissionSet requiredPermissions, Security.PermissionSet optionalPermissions, Security.PermissionSet refusedPermissions);
public virtual Reflection.Emit.AssemblyBuilder DefineDynamicAssembly (Reflection.AssemblyName name, Reflection.Emit.AssemblyBuilderAccess access, string dir, Security.PermissionSet requiredPermissions, Security.PermissionSet optionalPermissions, Security.PermissionSet refusedPermissions);
public virtual Reflection.Emit.AssemblyBuilder DefineDynamicAssembly (Reflection.AssemblyName name, Reflection.Emit.AssemblyBuilderAccess access, string dir, Security.Policy.Evidence evidence, Security.PermissionSet requiredPermissions, Security.PermissionSet optionalPermissions, Security.PermissionSet refusedPermissions);
public virtual Reflection.Emit.AssemblyBuilder DefineDynamicAssembly (Reflection.AssemblyName name, Reflection.Emit.AssemblyBuilderAccess access, string dir, Security.Policy.Evidence evidence, Security.PermissionSet requiredPermissions, Security.PermissionSet optionalPermissions, Security.PermissionSet refusedPermissions, bool isSynchronized);
```

Added constructor:

```csharp
public AssemblyBuilder ();
```

Removed properties:

```csharp
public override string CodeBase { get; }
public override System.Reflection.MethodInfo EntryPoint { get; }
public override string EscapedCodeBase { get; }
public override System.Security.Policy.Evidence Evidence { get; }
public override string FullName { get; }
public override bool GlobalAssemblyCache { get; }
public override string ImageRuntimeVersion { get; }
public override bool IsDynamic { get; }
public override string Location { get; }
public override System.Reflection.Module ManifestModule { get; }
public override bool ReflectionOnly { get; }
```

Removed methods:

```csharp
public void AddResourceFile (string name, string fileName);
public void AddResourceFile (string name, string fileName, System.Reflection.ResourceAttributes attribute);
public ModuleBuilder DefineDynamicModule (string name, bool emitSymbolInfo);
public ModuleBuilder DefineDynamicModule (string name, string fileName);
public ModuleBuilder DefineDynamicModule (string name, string fileName, bool emitSymbolInfo);
public System.Resources.IResourceWriter DefineResource (string name, string description, string fileName);
public System.Resources.IResourceWriter DefineResource (string name, string description, string fileName, System.Reflection.ResourceAttributes attribute);
public void DefineUnmanagedResource (byte[] resource);
public void DefineUnmanagedResource (string resourceFileName);
public void DefineVersionInfoResource ();
public void DefineVersionInfoResource (string product, string productVersion, string company, string copyright, string trademark);
public override bool Equals (object obj);
public override object[] GetCustomAttributes (bool inherit);
public override object[] GetCustomAttributes (System.Type attributeType, bool inherit);
public override System.Type[] GetExportedTypes ();
public override System.IO.FileStream GetFile (string name);
public override System.IO.FileStream[] GetFiles (bool getResourceModules);
public override int GetHashCode ();
public override System.Reflection.Module[] GetLoadedModules (bool getResourceModules);
public override System.Reflection.ManifestResourceInfo GetManifestResourceInfo (string resourceName);
public override string[] GetManifestResourceNames ();
public override System.IO.Stream GetManifestResourceStream (string name);
public override System.IO.Stream GetManifestResourceStream (System.Type type, string name);
public override System.Reflection.Module GetModule (string name);
public override System.Reflection.Module[] GetModules (bool getResourceModules);
public override System.Reflection.AssemblyName GetName (bool copiedName);
public override System.Reflection.AssemblyName[] GetReferencedAssemblies ();
public override System.Reflection.Assembly GetSatelliteAssembly (System.Globalization.CultureInfo culture);
public override System.Reflection.Assembly GetSatelliteAssembly (System.Globalization.CultureInfo culture, System.Version version);
public override System.Type GetType (string name, bool throwOnError, bool ignoreCase);
public override bool IsDefined (System.Type attributeType, bool inherit);
public void Save (string assemblyFileName);
public void Save (string assemblyFileName, System.Reflection.PortableExecutableKinds portableExecutableKind, System.Reflection.ImageFileMachine imageFileMachine);
public void SetEntryPoint (System.Reflection.MethodInfo entryMethod, PEFileKinds fileKind);
public override string ToString ();
```

Added constructor:

```csharp
public ConstructorBuilder ();
```

Removed properties:

```csharp
public override System.Reflection.CallingConventions CallingConvention { get; }
public override System.Reflection.Module Module { get; }

[Obsolete]
public System.Type ReturnType { get; }
```

Removed methods:

```csharp
public void AddDeclarativeSecurity (System.Security.Permissions.SecurityAction action, System.Security.PermissionSet pset);
public void SetSymCustomAttribute (string name, byte[] data);
public override string ToString ();
```

Removed property:

```csharp
public override System.Reflection.Module Module { get; }
```

Added property:

```csharp
public override System.Reflection.MethodImplAttributes MethodImplementationFlags { get; }
```

Removed methods:

```csharp
public override System.Delegate CreateDelegate (System.Type delegateType);
public override System.Delegate CreateDelegate (System.Type delegateType, object target);
public override string ToString ();
```

Added properties:

```csharp
public override bool IsByRefLike { get; }
public override bool IsSZArray { get; }
public override bool IsVariableBoundArray { get; }
```

Removed method:

```csharp
public override bool IsAssignableFrom (System.Reflection.TypeInfo typeInfo);
```

Added constructor:

```csharp
public EventBuilder ();
```

Removed properties:

```csharp
public override int MetadataToken { get; }
public override System.Reflection.Module Module { get; }
```

Removed method:

```csharp
[Obsolete ("An alternate API is available: Emit the MarshalAs custom attribute instead.")]
public void SetMarshal (UnmanagedMarshal unmanagedMarshal);
```

Added properties:

```csharp
public override bool IsByRefLike { get; }
public override bool IsConstructedGenericType { get; }
public override bool IsSZArray { get; }
public override bool IsTypeDefinition { get; }
public override bool IsVariableBoundArray { get; }
```

Removed methods:

```csharp
public override System.Type[] GetGenericParameterConstraints ();
public override bool IsAssignableFrom (System.Reflection.TypeInfo typeInfo);
public override bool IsInstanceOfType (object o);
```

Modified properties:

```diff
-public virtual int ILOffset { get; }
+public int ILOffset { get; }
```

Removed method:

```csharp
public virtual void MarkSequencePoint (System.Diagnostics.SymbolStore.ISymbolDocumentWriter document, int startLine, int startColumn, int endLine, int endColumn);
```

Added property:

```csharp
public override bool IsConstructedGenericMethod { get; }
```

Removed methods:

```csharp
public void AddDeclarativeSecurity (System.Security.Permissions.SecurityAction action, System.Security.PermissionSet pset);

[Obsolete ("An alternate API is available: Emit the MarshalAs custom attribute instead.")]
public void SetMarshal (UnmanagedMarshal unmanagedMarshal);
public void SetSymCustomAttribute (string name, byte[] data);
```

Removed properties:

```csharp
public override int MetadataToken { get; }
public override System.Guid ModuleVersionId { get; }
public override string ScopeName { get; }
```

Removed methods:

```csharp
public System.Diagnostics.SymbolStore.ISymbolDocumentWriter DefineDocument (string url, System.Guid language, System.Guid languageVendor, System.Guid documentType);
public void DefineManifestResource (string name, System.IO.Stream stream, System.Reflection.ResourceAttributes attribute);
public System.Resources.IResourceWriter DefineResource (string name, string description);
public System.Resources.IResourceWriter DefineResource (string name, string description, System.Reflection.ResourceAttributes attribute);
public void DefineUnmanagedResource (byte[] resource);
public void DefineUnmanagedResource (string resourceFileName);
public override object[] GetCustomAttributes (bool inherit);
public override object[] GetCustomAttributes (System.Type attributeType, bool inherit);
public override System.Reflection.FieldInfo GetField (string name, System.Reflection.BindingFlags bindingAttr);
public override System.Reflection.FieldInfo[] GetFields (System.Reflection.BindingFlags bindingFlags);
protected override System.Reflection.MethodInfo GetMethodImpl (string name, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers);
public override System.Reflection.MethodInfo[] GetMethods (System.Reflection.BindingFlags bindingFlags);
public System.Diagnostics.SymbolStore.ISymbolWriter GetSymWriter ();
public override System.Type GetType (string className);
public override System.Type GetType (string className, bool ignoreCase);
public override System.Type GetType (string className, bool throwOnError, bool ignoreCase);
public override System.Type[] GetTypes ();
public override bool IsDefined (System.Type attributeType, bool inherit);
public override bool IsResource ();
public override System.Reflection.FieldInfo ResolveField (int metadataToken, System.Type[] genericTypeArguments, System.Type[] genericMethodArguments);
public override System.Reflection.MemberInfo ResolveMember (int metadataToken, System.Type[] genericTypeArguments, System.Type[] genericMethodArguments);
public override System.Reflection.MethodBase ResolveMethod (int metadataToken, System.Type[] genericTypeArguments, System.Type[] genericMethodArguments);
public override byte[] ResolveSignature (int metadataToken);
public override string ResolveString (int metadataToken);
public override System.Type ResolveType (int metadataToken, System.Type[] genericTypeArguments, System.Type[] genericMethodArguments);
public void SetSymCustomAttribute (string name, byte[] data);
```

Modified properties:

```diff
-public virtual int Attributes { get; }
+public int Attributes { get; }
-public virtual string Name { get; }
+public string Name { get; }
-public virtual int Position { get; }
+public int Position { get; }
```

Removed method:

```csharp
[Obsolete ("An alternate API is available: Emit the MarshalAs custom attribute instead.")]
public virtual void SetMarshal (UnmanagedMarshal unmanagedMarshal);
```

Removed interface:

```csharp
System.Runtime.InteropServices._SignatureHelper
```

Removed methods:

```csharp
public override bool Equals (object obj);
public override int GetHashCode ();
public override string ToString ();
```

Removed property:

```csharp
public override bool ContainsGenericParameters { get; }
```

Added properties:

```csharp
public override bool IsByRefLike { get; }
public override bool IsSZArray { get; }
public override bool IsSecurityCritical { get; }
public override bool IsSecuritySafeCritical { get; }
public override bool IsSecurityTransparent { get; }
public override bool IsVariableBoundArray { get; }
```

Removed methods:

```csharp
public void AddDeclarativeSecurity (System.Security.Permissions.SecurityAction action, System.Security.PermissionSet pset);
public override bool IsAssignableFrom (System.Reflection.TypeInfo typeInfo);
protected override bool IsValueTypeImpl ();
```

Removed methods:

```csharp
public static object GetActiveObject (string progID);
public static IntPtr GetComInterfaceForObjectInContext (object o, System.Type t);
public static int GetComSlotForMethodInfo (System.Reflection.MemberInfo m);
public static int GetEndComSlot (System.Type t);
public static IntPtr GetExceptionPointers ();
public static IntPtr GetIDispatchForObjectInContext (object o);
public static IntPtr GetITypeInfoForType (System.Type t);
public static IntPtr GetIUnknownForObjectInContext (object o);

[Obsolete ("This method has been deprecated")]
public static IntPtr GetManagedThunkForUnmanagedMethodPtr (IntPtr pfnMethodToWrap, IntPtr pbSignature, int cbSignature);
public static System.Reflection.MemberInfo GetMethodInfoForComSlot (System.Type t, int slot, ref ComMemberType memberType);

[Obsolete ("This method has been deprecated")]
public static System.Threading.Thread GetThreadFromFiberCookie (int cookie);
public static System.Type GetTypeForITypeInfo (IntPtr piTypeInfo);

[Obsolete]
public static string GetTypeInfoName (UCOMITypeInfo pTI);
public static System.Guid GetTypeLibGuid (ComTypes.ITypeLib typelib);

[Obsolete]
public static System.Guid GetTypeLibGuid (UCOMITypeLib pTLB);
public static System.Guid GetTypeLibGuidForAssembly (System.Reflection.Assembly asm);
public static int GetTypeLibLcid (ComTypes.ITypeLib typelib);

[Obsolete]
public static int GetTypeLibLcid (UCOMITypeLib pTLB);
public static string GetTypeLibName (ComTypes.ITypeLib typelib);

[Obsolete]
public static string GetTypeLibName (UCOMITypeLib pTLB);
public static void GetTypeLibVersionForAssembly (System.Reflection.Assembly inputAssembly, out int majorVersion, out int minorVersion);

[Obsolete ("This method has been deprecated")]
public static IntPtr GetUnmanagedThunkForManagedMethodPtr (IntPtr pfnMethodToWrap, IntPtr pbSignature, int cbSignature);
public static bool IsTypeVisibleFromCom (System.Type t);
public static int NumParamBytes (System.Reflection.MethodInfo m);

[Obsolete]
public static void ReleaseThreadCache ();
```

Backport of #14665.

/cc @akoeplinger @spouliot