### PR TITLE
[2019-02][mscorlib] Ensure monotouch[_runtime] API are identical

### DIFF
--- a/mcs/class/corlib/System.Reflection.Emit/AssemblyBuilder.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/AssemblyBuilder.pns.cs
@@ -27,11 +27,103 @@
 //
 
 #if !MONO_FEATURE_SRE
+using System.Globalization;
+using System.IO;
 
 namespace System.Reflection.Emit
 {
 	public class AssemblyBuilder : Assembly
 	{
+		private AssemblyBuilder () {}
+
+		public override string CodeBase {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		public override MethodInfo EntryPoint {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		public override string EscapedCodeBase {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		public override System.Security.Policy.Evidence Evidence {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		public override string FullName {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		public override bool GlobalAssemblyCache {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		public override string ImageRuntimeVersion {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		public override bool IsDynamic {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		public override string Location {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		public override Module ManifestModule {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		public override bool ReflectionOnly {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		public void AddResourceFile (string name, string fileName) => throw new PlatformNotSupportedException ();
+
+		public void AddResourceFile (string name, string fileName, ResourceAttributes attribute) => throw new PlatformNotSupportedException ();
+
+		public ModuleBuilder DefineDynamicModule (string name, bool emitSymbolInfo) => throw new PlatformNotSupportedException ();
+
+		public ModuleBuilder DefineDynamicModule (string name, string fileName) => throw new PlatformNotSupportedException ();
+
+		public ModuleBuilder DefineDynamicModule (string name, string fileName, bool emitSymbolInfo) => throw new PlatformNotSupportedException ();
+
+		public System.Resources.IResourceWriter DefineResource (string name, string description, string fileName) => throw new PlatformNotSupportedException ();
+
+		public System.Resources.IResourceWriter DefineResource (string name, string description, string fileName, ResourceAttributes attribute) => throw new PlatformNotSupportedException ();
+
+		public void DefineUnmanagedResource (byte[] resource) => throw new PlatformNotSupportedException ();
+
+		public void DefineUnmanagedResource (string resourceFileName) => throw new PlatformNotSupportedException ();
+
+		public void DefineVersionInfoResource () => throw new PlatformNotSupportedException ();
+
+		public void DefineVersionInfoResource (string product, string productVersion, string company, string copyright, string trademark) => throw new PlatformNotSupportedException ();
+
 		public static AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access)
 		{
 			throw new PlatformNotSupportedException ();
@@ -47,10 +139,54 @@ namespace System.Reflection.Emit
 			throw new PlatformNotSupportedException ();
 		}
 
+		public override bool Equals (object obj) => throw new PlatformNotSupportedException ();
+
+		public override object[] GetCustomAttributes (bool inherit) => throw new PlatformNotSupportedException ();
+
+		public override object[] GetCustomAttributes (System.Type attributeType, bool inherit) => throw new PlatformNotSupportedException ();
+
 		public ModuleBuilder GetDynamicModule (string name)
 		{
 			throw new PlatformNotSupportedException ();
 		}
+
+		public override Type[] GetExportedTypes () => throw new PlatformNotSupportedException ();
+
+		public override FileStream GetFile (string name) => throw new PlatformNotSupportedException ();
+
+		public override FileStream[] GetFiles (bool getResourceModules) => throw new PlatformNotSupportedException ();
+
+		public override int GetHashCode () => throw new PlatformNotSupportedException ();
+
+		public override Module[] GetLoadedModules (bool getResourceModules) => throw new PlatformNotSupportedException ();
+
+		public override ManifestResourceInfo GetManifestResourceInfo (string resourceName) => throw new PlatformNotSupportedException ();
+
+		public override string[] GetManifestResourceNames () => throw new PlatformNotSupportedException ();
+
+		public override Stream GetManifestResourceStream (string name) => throw new PlatformNotSupportedException ();
+
+		public override Stream GetManifestResourceStream (Type type, string name) => throw new PlatformNotSupportedException ();
+
+		public override Module GetModule (string name) => throw new PlatformNotSupportedException ();
+
+		public override Module[] GetModules (bool getResourceModules) => throw new PlatformNotSupportedException ();
+
+		public override AssemblyName GetName (bool copiedName) => throw new PlatformNotSupportedException ();
+
+		public override AssemblyName[] GetReferencedAssemblies () => throw new PlatformNotSupportedException ();
+
+		public override Assembly GetSatelliteAssembly (CultureInfo culture) => throw new PlatformNotSupportedException ();
+
+		public override Assembly GetSatelliteAssembly (CultureInfo culture, Version version) => throw new PlatformNotSupportedException ();
+
+		public override Type GetType (string name, bool throwOnError, bool ignoreCase) => throw new PlatformNotSupportedException ();
+
+		public override bool IsDefined (Type attributeType, bool inherit) => throw new PlatformNotSupportedException ();
+
+		public void Save (string assemblyFileName) => throw new PlatformNotSupportedException ();
+
+		public void Save (string assemblyFileName, PortableExecutableKinds portableExecutableKind, ImageFileMachine imageFileMachine) => throw new PlatformNotSupportedException ();
 
 		public void SetCustomAttribute (CustomAttributeBuilder customBuilder)
 		{
@@ -63,6 +199,11 @@ namespace System.Reflection.Emit
 			throw new PlatformNotSupportedException ();
 		}
 
+		public void SetEntryPoint (MethodInfo entryMethod) => throw new PlatformNotSupportedException ();
+
+		public void SetEntryPoint (MethodInfo entryMethod, PEFileKinds fileKind) => throw new PlatformNotSupportedException ();
+
+		public override string ToString () => throw new PlatformNotSupportedException ();
 	}
 }
 

--- a/mcs/class/corlib/System.Reflection.Emit/ConstructorBuilder.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ConstructorBuilder.pns.cs
@@ -26,15 +26,27 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
 #if !MONO_FEATURE_SRE
 
 namespace System.Reflection.Emit
 {
-	public abstract class ConstructorBuilder : ConstructorInfo
+	public class ConstructorBuilder : ConstructorInfo
 	{
+		internal ConstructorBuilder () {}
+
 		public bool InitLocals { get; set; }
 
 		public override MethodAttributes Attributes { 
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		public override CallingConventions CallingConvention {
 			get {
 				throw new PlatformNotSupportedException ();
 			}
@@ -46,7 +58,20 @@ namespace System.Reflection.Emit
 			}
 		}
 
+		public override Module Module {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
 		public override string Name {
+			get {
+				throw new PlatformNotSupportedException ();
+			}
+		}
+
+		[Obsolete]
+		public Type ReturnType {
 			get {
 				throw new PlatformNotSupportedException ();
 			}
@@ -86,6 +111,25 @@ namespace System.Reflection.Emit
 		{
 			throw new PlatformNotSupportedException ();
 		}
+
+		public string Signature => throw new PlatformNotSupportedException ();
+		public Module GetModule () => throw new PlatformNotSupportedException ();
+		public MethodToken GetToken () => throw new PlatformNotSupportedException ();
+		public void SetMethodBody (byte[] il, int maxStack, byte[] localSignature,
+			IEnumerable<ExceptionHandler> exceptionHandlers, IEnumerable<int> tokenFixups) => 
+				throw new PlatformNotSupportedException ();
+
+		public void AddDeclarativeSecurity (System.Security.Permissions.SecurityAction action, System.Security.PermissionSet pset) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.MethodImplAttributes GetMethodImplementationFlags() { throw new PlatformNotSupportedException (); }
+		public override System.RuntimeMethodHandle MethodHandle { get { throw new PlatformNotSupportedException (); } }
+		public override object Invoke(System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object[] parameters, System.Globalization.CultureInfo culture) { throw new PlatformNotSupportedException (); }
+		public override bool IsDefined(System.Type attributeType, bool inherit) { throw new PlatformNotSupportedException (); }
+		public override object[] GetCustomAttributes(bool inherit) { throw new PlatformNotSupportedException (); }
+		public override object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw new PlatformNotSupportedException (); }
+		public override System.Type ReflectedType { get { throw new PlatformNotSupportedException (); } }
+		public override object Invoke(object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object[] parameters, System.Globalization.CultureInfo culture) { throw new PlatformNotSupportedException (); }
+		public void SetSymCustomAttribute (string name, byte[] data) { throw new PlatformNotSupportedException (); }
+		public override string ToString () { throw new PlatformNotSupportedException (); }
 	}
 }
 

--- a/mcs/class/corlib/System.Reflection.Emit/DynamicMethod.notsupported.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/DynamicMethod.notsupported.cs
@@ -94,10 +94,10 @@ namespace System.Reflection.Emit
 
 		public bool InitLocals { get; set; }
 
-		public override MethodImplAttributes MethodImplementationFlags {
+		public override Module Module {
 			get {
 				throw new PlatformNotSupportedException ();
-			}				
+			}
 		}
 
 		public override string Name {
@@ -137,6 +137,9 @@ namespace System.Reflection.Emit
 		public override Type ReflectedType { get { throw new PlatformNotSupportedException (); } }
 		public override ICustomAttributeProvider ReturnTypeCustomAttributes { get { throw new PlatformNotSupportedException (); } }
 
+		public override sealed Delegate CreateDelegate (Type delegateType) { throw new PlatformNotSupportedException (); }
+		public override sealed Delegate CreateDelegate (Type delegateType, object target) { throw new PlatformNotSupportedException (); }
+
 		public override object[] GetCustomAttributes (bool inherit) { throw new PlatformNotSupportedException (); }
 		public override object[] GetCustomAttributes (Type attributeType, bool inherit) { throw new PlatformNotSupportedException (); }
 		public override MethodImplAttributes GetMethodImplementationFlags () { throw new PlatformNotSupportedException (); }
@@ -145,6 +148,11 @@ namespace System.Reflection.Emit
 		public override object Invoke (object obj, BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture) { throw new PlatformNotSupportedException (); }
 
 		public override bool IsDefined (Type attributeType, bool inherit) { throw new PlatformNotSupportedException (); }
+
+		public ParameterBuilder DefineParameter (int position, ParameterAttributes attributes, string parameterName) => throw new PlatformNotSupportedException ();
+		public DynamicILInfo GetDynamicILInfo () => throw new PlatformNotSupportedException ();
+
+		public override string ToString () => throw new PlatformNotSupportedException ();
 	}
 }
 

--- a/mcs/class/corlib/System.Reflection.Emit/EnumBuilder.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/EnumBuilder.pns.cs
@@ -30,87 +30,67 @@
 
 namespace System.Reflection.Emit
 {
-	public abstract class EnumBuilder : TypeInfo
+	public sealed partial class EnumBuilder : System.Reflection.TypeInfo
 	{
-		public FieldBuilder UnderlyingField {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override Assembly Assembly {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override string AssemblyQualifiedName {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override Type BaseType {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override string FullName {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override Guid GUID {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override Module Module {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override string Name {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-		
-		public override string Namespace {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public TypeInfo CreateTypeInfo ()
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public FieldBuilder DefineLiteral (string literalName, object literalValue)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public override System.Type GetElementType ()
-		{
-			throw new PlatformNotSupportedException ();
-		}		
-
-		public void SetCustomAttribute (CustomAttributeBuilder customBuilder)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetCustomAttribute (ConstructorInfo con, byte[] binaryAttribute)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-		
+		internal EnumBuilder() { throw new PlatformNotSupportedException (); } 
+		public override System.Reflection.Assembly Assembly { get { throw new PlatformNotSupportedException (); } }
+		public override string AssemblyQualifiedName { get { throw new PlatformNotSupportedException (); } }
+		public override System.Type BaseType { get { throw new PlatformNotSupportedException (); } }
+		public override System.Type DeclaringType { get { throw new PlatformNotSupportedException (); } }
+		public override string FullName { get { throw new PlatformNotSupportedException (); } }
+		public override System.Guid GUID { get { throw new PlatformNotSupportedException (); } }
+		public override bool IsConstructedGenericType { get { throw new PlatformNotSupportedException (); } }
+		public override bool IsTypeDefinition { get { throw new PlatformNotSupportedException (); } }
+		public override System.Reflection.Module Module { get { throw new PlatformNotSupportedException (); } }
+		public override string Name { get { throw new PlatformNotSupportedException (); } }
+		public override string Namespace { get { throw new PlatformNotSupportedException (); } }
+		public override System.Type ReflectedType { get { throw new PlatformNotSupportedException (); } }
+		public override System.RuntimeTypeHandle TypeHandle { get { throw new PlatformNotSupportedException (); } }
+		public System.Reflection.Emit.TypeToken TypeToken { get { throw new PlatformNotSupportedException (); } }
+		public System.Reflection.Emit.FieldBuilder UnderlyingField { get { throw new PlatformNotSupportedException (); } }
+		public override System.Type UnderlyingSystemType { get { throw new PlatformNotSupportedException (); } }
+		public System.Type CreateType() { throw new PlatformNotSupportedException (); }
+		public System.Reflection.TypeInfo CreateTypeInfo() { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.FieldBuilder DefineLiteral(string literalName, object literalValue) { throw new PlatformNotSupportedException (); }
+		protected override System.Reflection.TypeAttributes GetAttributeFlagsImpl() { throw new PlatformNotSupportedException (); }
+		protected override System.Reflection.ConstructorInfo GetConstructorImpl(System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.ConstructorInfo[] GetConstructors(System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override object[] GetCustomAttributes(bool inherit) { throw new PlatformNotSupportedException (); }
+		public override object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw new PlatformNotSupportedException (); }
+		public override System.Type GetElementType() { throw new PlatformNotSupportedException (); }
+		public override System.Type GetEnumUnderlyingType() { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.EventInfo GetEvent(string name, System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.EventInfo[] GetEvents() { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.EventInfo[] GetEvents(System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.FieldInfo GetField(string name, System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.FieldInfo[] GetFields(System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override System.Type GetInterface(string name, bool ignoreCase) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.InterfaceMapping GetInterfaceMap(System.Type interfaceType) { throw new PlatformNotSupportedException (); }
+		public override System.Type[] GetInterfaces() { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.MemberInfo[] GetMember(string name, System.Reflection.MemberTypes type, System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.MemberInfo[] GetMembers(System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		protected override System.Reflection.MethodInfo GetMethodImpl(string name, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.MethodInfo[] GetMethods(System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override System.Type GetNestedType(string name, System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override System.Type[] GetNestedTypes(System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.PropertyInfo[] GetProperties(System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		protected override System.Reflection.PropertyInfo GetPropertyImpl(string name, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Type returnType, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw new PlatformNotSupportedException (); }
+		protected override bool HasElementTypeImpl() { throw new PlatformNotSupportedException (); }
+		public override object InvokeMember(string name, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object target, object[] args, System.Reflection.ParameterModifier[] modifiers, System.Globalization.CultureInfo culture, string[] namedParameters) { throw new PlatformNotSupportedException (); }
+		protected override bool IsArrayImpl() { throw new PlatformNotSupportedException (); }
+		public override bool IsAssignableFrom (System.Reflection.TypeInfo typeInfo) { throw new PlatformNotSupportedException (); }
+		protected override bool IsByRefImpl() { throw new PlatformNotSupportedException (); }
+		protected override bool IsCOMObjectImpl() { throw new PlatformNotSupportedException (); }
+		public override bool IsDefined(System.Type attributeType, bool inherit) { throw new PlatformNotSupportedException (); }
+		protected override bool IsPointerImpl() { throw new PlatformNotSupportedException (); }
+		protected override bool IsPrimitiveImpl() { throw new PlatformNotSupportedException (); }
+		protected override bool IsValueTypeImpl() { throw new PlatformNotSupportedException (); }
+		public override System.Type MakeArrayType() { throw new PlatformNotSupportedException (); }
+		public override System.Type MakeArrayType(int rank) { throw new PlatformNotSupportedException (); }
+		public override System.Type MakeByRefType() { throw new PlatformNotSupportedException (); }
+		public override System.Type MakePointerType() { throw new PlatformNotSupportedException (); }
+		public void SetCustomAttribute(System.Reflection.ConstructorInfo con, byte[] binaryAttribute) { throw new PlatformNotSupportedException (); } 
+		public void SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder customBuilder) { throw new PlatformNotSupportedException (); } 
 	}
 }
 

--- a/mcs/class/corlib/System.Reflection.Emit/EventBuilder.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/EventBuilder.pns.cs
@@ -32,6 +32,8 @@ namespace System.Reflection.Emit
 {
 	public class EventBuilder
 	{		
+		private EventBuilder () {}
+
 		public void AddOtherMethod (MethodBuilder mdBuilder)
 		{
 			throw new PlatformNotSupportedException ();
@@ -61,6 +63,8 @@ namespace System.Reflection.Emit
 		{
 			throw new PlatformNotSupportedException ();
 		}
+
+		public EventToken GetEventToken () => throw new PlatformNotSupportedException ();
 	}
 }
 

--- a/mcs/class/corlib/System.Reflection.Emit/FieldBuilder.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/FieldBuilder.pns.cs
@@ -30,56 +30,29 @@
 
 namespace System.Reflection.Emit
 {
-	public abstract class FieldBuilder : FieldInfo
+	public sealed partial class FieldBuilder : System.Reflection.FieldInfo
 	{
-		public override FieldAttributes Attributes {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override Type DeclaringType {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override Type FieldType {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override string Name {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override object GetValue (object obj)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetConstant (object defaultValue)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetCustomAttribute (CustomAttributeBuilder customBuilder)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetCustomAttribute (ConstructorInfo con, byte[] binaryAttribute)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetOffset (int iOffset)
-		{
-			throw new PlatformNotSupportedException ();
-		}		
+		internal FieldBuilder() { throw new PlatformNotSupportedException (); } 
+		public override System.Reflection.FieldAttributes Attributes { get { throw null; } }
+		public override System.Type DeclaringType { get { throw null; } }
+		public override System.RuntimeFieldHandle FieldHandle { get { throw null; } }
+		public override System.Type FieldType { get { throw null; } }
+		public override string Name { get { throw null; } }
+		public override System.Type ReflectedType { get { throw null; } }
+		public override object[] GetCustomAttributes(bool inherit) { throw null; }
+		public override object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw null; }
+		public System.Reflection.Emit.FieldToken GetToken() { throw null; }
+		public override object GetValue(object obj) { throw null; }
+		public override bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
+		public override int MetadataToken { get { throw new PlatformNotSupportedException (); } }
+		public override Module Module { get { throw new PlatformNotSupportedException (); } }
+		public void SetConstant(object defaultValue) { throw new PlatformNotSupportedException (); } 
+		public void SetCustomAttribute(System.Reflection.ConstructorInfo con, byte[] binaryAttribute) { throw new PlatformNotSupportedException (); } 
+		public void SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder customBuilder) { throw new PlatformNotSupportedException (); } 
+		[Obsolete ("An alternate API is available: Emit the MarshalAs custom attribute instead.")]
+		public void SetMarshal (UnmanagedMarshal unmanagedMarshal) { throw new PlatformNotSupportedException (); }
+		public void SetOffset(int iOffset) { throw new PlatformNotSupportedException (); } 
+		public override void SetValue(object obj, object val, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Globalization.CultureInfo culture) { throw new PlatformNotSupportedException (); } 
 	}
 }
 

--- a/mcs/class/corlib/System.Reflection.Emit/GenericTypeParameterBuilder.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/GenericTypeParameterBuilder.pns.cs
@@ -30,85 +30,79 @@
 
 namespace System.Reflection.Emit
 {
-	public abstract class GenericTypeParameterBuilder : TypeInfo
+	public sealed partial class GenericTypeParameterBuilder : System.Reflection.TypeInfo
 	{
-		public override Assembly Assembly {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override string AssemblyQualifiedName {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override Type BaseType {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override string FullName {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override Guid GUID {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override Module Module {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override string Name {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override string Namespace {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override Type GetElementType ()
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetBaseTypeConstraint (Type baseTypeConstraint)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetCustomAttribute (CustomAttributeBuilder customBuilder)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetCustomAttribute (ConstructorInfo con, byte[] binaryAttribute)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetGenericParameterAttributes (GenericParameterAttributes genericParameterAttributes)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetInterfaceConstraints (Type[] interfaceConstraints)
-		{
-			throw new PlatformNotSupportedException ();
-		}	
+		internal GenericTypeParameterBuilder() { throw new PlatformNotSupportedException (); } 
+		public override System.Reflection.Assembly Assembly { get { throw new PlatformNotSupportedException (); } }
+		public override string AssemblyQualifiedName { get { throw new PlatformNotSupportedException (); } }
+		public override System.Type BaseType { get { throw new PlatformNotSupportedException (); } }
+		public override bool ContainsGenericParameters { get { throw new PlatformNotSupportedException (); } }
+		public override System.Reflection.MethodBase DeclaringMethod { get { throw new PlatformNotSupportedException (); } }
+		public override System.Type DeclaringType { get { throw new PlatformNotSupportedException (); } }
+		public override string FullName { get { throw new PlatformNotSupportedException (); } }
+		public override System.Reflection.GenericParameterAttributes GenericParameterAttributes { get { throw new PlatformNotSupportedException (); } }
+		public override int GenericParameterPosition { get { throw new PlatformNotSupportedException (); } }
+		public override System.Guid GUID { get { throw new PlatformNotSupportedException (); } }
+		public override bool IsGenericParameter { get { throw new PlatformNotSupportedException (); } }
+		public override bool IsGenericType { get { throw new PlatformNotSupportedException (); } }
+		public override bool IsGenericTypeDefinition { get { throw new PlatformNotSupportedException (); } }
+		public override System.Reflection.Module Module { get { throw new PlatformNotSupportedException (); } }
+		public override string Name { get { throw new PlatformNotSupportedException (); } }
+		public override string Namespace { get { throw new PlatformNotSupportedException (); } }
+		public override System.Type ReflectedType { get { throw new PlatformNotSupportedException (); } }
+		public override System.RuntimeTypeHandle TypeHandle { get { throw new PlatformNotSupportedException (); } }
+		public override System.Type UnderlyingSystemType { get { throw new PlatformNotSupportedException (); } }
+		public override bool Equals(object o) { throw new PlatformNotSupportedException (); }
+		protected override System.Reflection.TypeAttributes GetAttributeFlagsImpl() { throw new PlatformNotSupportedException (); }
+		protected override System.Reflection.ConstructorInfo GetConstructorImpl(System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.ConstructorInfo[] GetConstructors(System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override object[] GetCustomAttributes(bool inherit) { throw new PlatformNotSupportedException (); }
+		public override object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw new PlatformNotSupportedException (); }
+		public override System.Type GetElementType() { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.EventInfo GetEvent(string name, System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.EventInfo[] GetEvents() { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.EventInfo[] GetEvents(System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.FieldInfo GetField(string name, System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.FieldInfo[] GetFields(System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override System.Type[] GetGenericArguments() { throw new PlatformNotSupportedException (); }
+		public override System.Type[] GetGenericParameterConstraints () { throw new PlatformNotSupportedException (); }
+		public override System.Type GetGenericTypeDefinition() { throw new PlatformNotSupportedException (); }
+		public override int GetHashCode() { throw new PlatformNotSupportedException (); }
+		public override System.Type GetInterface(string name, bool ignoreCase) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.InterfaceMapping GetInterfaceMap(System.Type interfaceType) { throw new PlatformNotSupportedException (); }
+		public override System.Type[] GetInterfaces() { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.MemberInfo[] GetMember(string name, System.Reflection.MemberTypes type, System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.MemberInfo[] GetMembers(System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		protected override System.Reflection.MethodInfo GetMethodImpl(string name, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.MethodInfo[] GetMethods(System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override System.Type GetNestedType(string name, System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override System.Type[] GetNestedTypes(System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.PropertyInfo[] GetProperties(System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		protected override System.Reflection.PropertyInfo GetPropertyImpl(string name, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Type returnType, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw new PlatformNotSupportedException (); }
+		protected override bool HasElementTypeImpl() { throw new PlatformNotSupportedException (); }
+		public override object InvokeMember(string name, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object target, object[] args, System.Reflection.ParameterModifier[] modifiers, System.Globalization.CultureInfo culture, string[] namedParameters) { throw new PlatformNotSupportedException (); }
+		protected override bool IsArrayImpl() { throw new PlatformNotSupportedException (); }
+		public override bool IsAssignableFrom(System.Type c) { throw new PlatformNotSupportedException (); }
+		public override bool IsAssignableFrom (TypeInfo typeInfo) { throw new PlatformNotSupportedException (); }
+		protected override bool IsByRefImpl() { throw new PlatformNotSupportedException (); }
+		protected override bool IsCOMObjectImpl() { throw new PlatformNotSupportedException (); }
+		public override bool IsDefined(System.Type attributeType, bool inherit) { throw new PlatformNotSupportedException (); }
+		public override bool IsInstanceOfType (object o) { throw new PlatformNotSupportedException (); }
+		protected override bool IsPointerImpl() { throw new PlatformNotSupportedException (); }
+		protected override bool IsPrimitiveImpl() { throw new PlatformNotSupportedException (); }
+		public override bool IsSubclassOf(System.Type c) { throw new PlatformNotSupportedException (); }
+		protected override bool IsValueTypeImpl() { throw new PlatformNotSupportedException (); }
+		public override System.Type MakeArrayType() { throw new PlatformNotSupportedException (); }
+		public override System.Type MakeArrayType(int rank) { throw new PlatformNotSupportedException (); }
+		public override System.Type MakeByRefType() { throw new PlatformNotSupportedException (); }
+		public override System.Type MakeGenericType(params System.Type[] typeArguments) { throw new PlatformNotSupportedException (); }
+		public override System.Type MakePointerType() { throw new PlatformNotSupportedException (); }
+		public void SetBaseTypeConstraint(System.Type baseTypeConstraint) { throw new PlatformNotSupportedException (); } 
+		public void SetCustomAttribute(System.Reflection.ConstructorInfo con, byte[] binaryAttribute) { throw new PlatformNotSupportedException (); } 
+		public void SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder customBuilder) { throw new PlatformNotSupportedException (); } 
+		public void SetGenericParameterAttributes(System.Reflection.GenericParameterAttributes genericParameterAttributes) { throw new PlatformNotSupportedException (); } 
+		public void SetInterfaceConstraints(params System.Type[] interfaceConstraints) { throw new PlatformNotSupportedException (); } 
+		public override string ToString() { throw new PlatformNotSupportedException (); }
 	}
 }
 

--- a/mcs/class/corlib/System.Reflection.Emit/ILGenerator.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ILGenerator.pns.cs
@@ -28,6 +28,8 @@
 
 #if !MONO_FEATURE_SRE
 
+using System.Runtime.InteropServices;
+
 namespace System.Reflection.Emit
 {
 	public class ILGenerator
@@ -36,7 +38,7 @@ namespace System.Reflection.Emit
 		{
 		}
 
-		public int ILOffset {
+		public virtual int ILOffset {
 			get	{
 				throw new PlatformNotSupportedException ();
 			}
@@ -183,6 +185,8 @@ namespace System.Reflection.Emit
 			throw new PlatformNotSupportedException ();
 		}
 
+		public virtual void EmitCalli (OpCode opcode, CallingConvention unmanagedCallConv, Type returnType, Type[] parameterTypes) => throw new PlatformNotSupportedException ();
+
 		public virtual void EmitWriteLine (LocalBuilder localBuilder)
 		{
 			throw new PlatformNotSupportedException ();
@@ -209,6 +213,11 @@ namespace System.Reflection.Emit
 		}
 
 		public virtual void MarkLabel (Label loc)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+		public virtual void MarkSequencePoint (System.Diagnostics.SymbolStore.ISymbolDocumentWriter document, int startLine, int startColumn, int endLine, int endColumn)
 		{
 			throw new PlatformNotSupportedException ();
 		}

--- a/mcs/class/corlib/System.Reflection.Emit/MethodBuilder.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/MethodBuilder.pns.cs
@@ -28,84 +28,62 @@
 
 #if !MONO_FEATURE_SRE
 
+
+using System;
+using System.Collections.Generic;
+
 namespace System.Reflection.Emit
 {
-	public abstract class MethodBuilder : MethodInfo
+	public sealed partial class MethodBuilder : System.Reflection.MethodInfo
 	{
-		public bool InitLocals { get; set; }
+		internal MethodBuilder() { throw new PlatformNotSupportedException (); } 
+		public override System.Reflection.MethodAttributes Attributes { get { throw new PlatformNotSupportedException (); } }
+		public override System.Reflection.CallingConventions CallingConvention { get { throw new PlatformNotSupportedException (); } }
+		public override bool ContainsGenericParameters { get { throw new PlatformNotSupportedException (); } }
+		public override System.Type DeclaringType { get { throw new PlatformNotSupportedException (); } }
+		public bool InitLocals { get { throw new PlatformNotSupportedException (); } set { throw new PlatformNotSupportedException (); }  }
+		public override bool IsGenericMethod { get { throw new PlatformNotSupportedException (); } }
+		public override bool IsGenericMethodDefinition { get { throw new PlatformNotSupportedException (); } }
+		public override System.RuntimeMethodHandle MethodHandle { get { throw new PlatformNotSupportedException (); } }
+		public override System.Reflection.Module Module { get { throw new PlatformNotSupportedException (); } }
+		public override string Name { get { throw new PlatformNotSupportedException (); } }
+		public override System.Type ReflectedType { get { throw new PlatformNotSupportedException (); } }
+		public override System.Reflection.ParameterInfo ReturnParameter { get { throw new PlatformNotSupportedException (); } }
+		public override System.Type ReturnType { get { throw new PlatformNotSupportedException (); } }
+		public override System.Reflection.ICustomAttributeProvider ReturnTypeCustomAttributes { get { throw new PlatformNotSupportedException (); } }
+		public string Signature { get { throw new PlatformNotSupportedException (); } }
 
-		public override MethodAttributes Attributes {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override Type DeclaringType {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override string Name {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public GenericTypeParameterBuilder[] DefineGenericParameters (string[] names)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public ParameterBuilder DefineParameter (int position, ParameterAttributes attributes, string strParamName)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public ILGenerator GetILGenerator ()
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public ILGenerator GetILGenerator (int size)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public override System.Reflection.ParameterInfo[] GetParameters ()
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetCustomAttribute (CustomAttributeBuilder customBuilder)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetCustomAttribute (ConstructorInfo con, byte[] binaryAttribute)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetImplementationFlags (MethodImplAttributes attributes)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetParameters (Type[] parameterTypes)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetReturnType (Type returnType)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetSignature (Type returnType, Type[] returnTypeRequiredCustomModifiers, Type[] returnTypeOptionalCustomModifiers, Type[] parameterTypes, Type[][] parameterTypeRequiredCustomModifiers, Type[][] parameterTypeOptionalCustomModifiers)
-		{
-			throw new PlatformNotSupportedException ();
-		}
+		public void AddDeclarativeSecurity (System.Security.Permissions.SecurityAction action, System.Security.PermissionSet pset) { throw new PlatformNotSupportedException (); } 
+		public void CreateMethodBody(byte[] il, int count) { throw new PlatformNotSupportedException (); } 
+		public System.Reflection.Emit.GenericTypeParameterBuilder[] DefineGenericParameters(params string[] names) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.ParameterBuilder DefineParameter(int position, System.Reflection.ParameterAttributes attributes, string strParamName) { throw new PlatformNotSupportedException (); }
+		public override bool Equals(object obj) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.MethodInfo GetBaseDefinition() { throw new PlatformNotSupportedException (); }
+		public override object[] GetCustomAttributes(bool inherit) { throw new PlatformNotSupportedException (); }
+		public override object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw new PlatformNotSupportedException (); }
+		public override System.Type[] GetGenericArguments() { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.MethodInfo GetGenericMethodDefinition() { throw new PlatformNotSupportedException (); }
+		public override int GetHashCode() { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.ILGenerator GetILGenerator() { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.ILGenerator GetILGenerator(int size) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.MethodImplAttributes GetMethodImplementationFlags() { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Module GetModule() { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.ParameterInfo[] GetParameters() { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.MethodToken GetToken() { throw new PlatformNotSupportedException (); }
+		public override object Invoke(object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object[] parameters, System.Globalization.CultureInfo culture) { throw new PlatformNotSupportedException (); }
+		public override bool IsDefined(System.Type attributeType, bool inherit) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.MethodInfo MakeGenericMethod(params System.Type[] typeArguments) { throw new PlatformNotSupportedException (); }
+		public void SetCustomAttribute(System.Reflection.ConstructorInfo con, byte[] binaryAttribute) { throw new PlatformNotSupportedException (); } 
+		public void SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder customBuilder) { throw new PlatformNotSupportedException (); } 
+		public void SetImplementationFlags(System.Reflection.MethodImplAttributes attributes) { throw new PlatformNotSupportedException (); } 
+		[Obsolete ("An alternate API is available: Emit the MarshalAs custom attribute instead.")]
+		public void SetMarshal (UnmanagedMarshal unmanagedMarshal) { throw new PlatformNotSupportedException (); }
+		public void SetMethodBody(byte[] il, int maxStack, byte[] localSignature, System.Collections.Generic.IEnumerable<System.Reflection.Emit.ExceptionHandler> exceptionHandlers, System.Collections.Generic.IEnumerable<int> tokenFixups) { throw new PlatformNotSupportedException (); } 
+		public void SetParameters(params System.Type[] parameterTypes) { throw new PlatformNotSupportedException (); } 
+		public void SetReturnType(System.Type returnType) { throw new PlatformNotSupportedException (); } 
+		public void SetSignature(System.Type returnType, System.Type[] returnTypeRequiredCustomModifiers, System.Type[] returnTypeOptionalCustomModifiers, System.Type[] parameterTypes, System.Type[][] parameterTypeRequiredCustomModifiers, System.Type[][] parameterTypeOptionalCustomModifiers) { throw new PlatformNotSupportedException (); } 
+		public void SetSymCustomAttribute (string name, byte[] data) { throw new PlatformNotSupportedException (); }
+		public override string ToString() { throw new PlatformNotSupportedException (); }
 	}
 }
 

--- a/mcs/class/corlib/System.Reflection.Emit/MethodRental.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/MethodRental.pns.cs
@@ -1,0 +1,25 @@
+#if !MONO_FEATURE_SRE
+using System.Runtime.InteropServices;
+
+namespace System.Reflection.Emit {
+
+	public partial class MethodRental : _MethodRental {
+
+		private MethodRental () {}
+
+		public const int JitImmediate = 1;
+		public const int JitOnDemand = 0;
+
+		public static void SwapMethodBody (Type cls, int methodtoken, IntPtr rgIL, int methodSize, int flags) => throw new PlatformNotSupportedException ();
+
+		void _MethodRental.GetIDsOfNames ([In] ref Guid riid, IntPtr rgszNames, uint cNames, uint lcid, IntPtr rgDispId) => throw new PlatformNotSupportedException ();
+
+		void _MethodRental.GetTypeInfo (uint iTInfo, uint lcid, IntPtr ppTInfo) => throw new PlatformNotSupportedException ();
+
+		void _MethodRental.GetTypeInfoCount (out uint pcTInfo) => throw new PlatformNotSupportedException ();
+
+		void _MethodRental.Invoke (uint dispIdMember, [In] ref Guid riid, uint lcid, short wFlags, IntPtr pDispParams, IntPtr pVarResult, IntPtr pExcepInfo, IntPtr puArgErr) => throw new PlatformNotSupportedException ();
+	}
+}
+
+#endif

--- a/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ModuleBuilder.pns.cs
@@ -30,93 +30,186 @@
 
 namespace System.Reflection.Emit
 {
-	public abstract class ModuleBuilder : Module
-	{
-		public void CreateGlobalFunctions ()
-		{
-			throw new PlatformNotSupportedException ();
-		}
+    public partial class ModuleBuilder : System.Reflection.Module
+    {
+        internal ModuleBuilder() => throw new PlatformNotSupportedException();
+        public override System.Reflection.Assembly Assembly { get { throw new PlatformNotSupportedException(); } }
+        public override string FullyQualifiedName { get { throw new PlatformNotSupportedException(); } }
+        public override int MetadataToken { get { throw new PlatformNotSupportedException(); } }
+        public override System.Guid ModuleVersionId { get { throw new PlatformNotSupportedException(); } }
+        public override string Name { get { throw new PlatformNotSupportedException(); } }
+        public override string ScopeName { get { throw new PlatformNotSupportedException(); } }
+        public void CreateGlobalFunctions() => throw new PlatformNotSupportedException();
+        public System.Diagnostics.SymbolStore.ISymbolDocumentWriter DefineDocument (string url, System.Guid language, System.Guid languageVendor, System.Guid documentType) => throw new PlatformNotSupportedException ();
+        public System.Reflection.Emit.EnumBuilder DefineEnum(string name, System.Reflection.TypeAttributes visibility, System.Type underlyingType) { throw new PlatformNotSupportedException(); }
+        public System.Reflection.Emit.MethodBuilder DefineGlobalMethod(string name, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes) { throw new PlatformNotSupportedException(); }
+        public System.Reflection.Emit.MethodBuilder DefineGlobalMethod(string name, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] requiredReturnTypeCustomModifiers, System.Type[] optionalReturnTypeCustomModifiers, System.Type[] parameterTypes, System.Type[][] requiredParameterTypeCustomModifiers, System.Type[][] optionalParameterTypeCustomModifiers) { throw new PlatformNotSupportedException(); }
+        public System.Reflection.Emit.MethodBuilder DefineGlobalMethod(string name, System.Reflection.MethodAttributes attributes, System.Type returnType, System.Type[] parameterTypes) { throw new PlatformNotSupportedException(); }
+        public System.Reflection.Emit.FieldBuilder DefineInitializedData(string name, byte[] data, System.Reflection.FieldAttributes attributes) { throw new PlatformNotSupportedException(); }
+        public void DefineManifestResource (string name, System.IO.Stream stream, System.Reflection.ResourceAttributes attribute) => throw new PlatformNotSupportedException ();
+        public System.Reflection.Emit.MethodBuilder DefinePInvokeMethod(string name, string dllName, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes, System.Runtime.InteropServices.CallingConvention nativeCallConv, System.Runtime.InteropServices.CharSet nativeCharSet) { throw new PlatformNotSupportedException(); }
+        public System.Reflection.Emit.MethodBuilder DefinePInvokeMethod(string name, string dllName, string entryName, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes, System.Runtime.InteropServices.CallingConvention nativeCallConv, System.Runtime.InteropServices.CharSet nativeCharSet) { throw new PlatformNotSupportedException(); }
+        public System.Resources.IResourceWriter DefineResource (string name, string description) => throw new PlatformNotSupportedException ();
+        public System.Resources.IResourceWriter DefineResource (string name, string description, System.Reflection.ResourceAttributes attribute) => throw new PlatformNotSupportedException ();
+        public void DefineUnmanagedResource (byte[] resource) => throw new PlatformNotSupportedException ();
+        public void DefineUnmanagedResource (string resourceFileName) => throw new PlatformNotSupportedException ();
+        public System.Reflection.Emit.TypeBuilder DefineType(string name) { throw new PlatformNotSupportedException(); }
+        public System.Reflection.Emit.TypeBuilder DefineType(string name, System.Reflection.TypeAttributes attr) { throw new PlatformNotSupportedException(); }
+        public System.Reflection.Emit.TypeBuilder DefineType(string name, System.Reflection.TypeAttributes attr, System.Type parent) { throw new PlatformNotSupportedException(); }
+        public System.Reflection.Emit.TypeBuilder DefineType(string name, System.Reflection.TypeAttributes attr, System.Type parent, int typesize) { throw new PlatformNotSupportedException(); }
+        public System.Reflection.Emit.TypeBuilder DefineType(string name, System.Reflection.TypeAttributes attr, System.Type parent, System.Reflection.Emit.PackingSize packsize) { throw new PlatformNotSupportedException(); }
+        public System.Reflection.Emit.TypeBuilder DefineType(string name, System.Reflection.TypeAttributes attr, System.Type parent, System.Reflection.Emit.PackingSize packingSize, int typesize) { throw new PlatformNotSupportedException(); }
+        public System.Reflection.Emit.TypeBuilder DefineType(string name, System.Reflection.TypeAttributes attr, System.Type parent, System.Type[] interfaces) { throw new PlatformNotSupportedException(); }
+        public System.Reflection.Emit.FieldBuilder DefineUninitializedData(string name, int size, System.Reflection.FieldAttributes attributes) { throw new PlatformNotSupportedException(); }
+        public override bool Equals(object obj) { throw new PlatformNotSupportedException(); }
+        public System.Reflection.MethodInfo GetArrayMethod(System.Type arrayClass, string methodName, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes) { throw new PlatformNotSupportedException(); }
+        public System.Reflection.Emit.MethodToken GetArrayMethodToken(System.Type arrayClass, string methodName, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes) { throw new PlatformNotSupportedException(); }
+        public System.Reflection.Emit.MethodToken GetConstructorToken(System.Reflection.ConstructorInfo con) { throw new PlatformNotSupportedException(); }
+        public System.Reflection.Emit.MethodToken GetConstructorToken(System.Reflection.ConstructorInfo constructor, System.Collections.Generic.IEnumerable<System.Type> optionalParameterTypes) { throw new PlatformNotSupportedException(); }
+        public override object[] GetCustomAttributes (bool inherit) { throw new PlatformNotSupportedException(); }
+        public override object[] GetCustomAttributes (System.Type attributeType, bool inherit) { throw new PlatformNotSupportedException(); }
+        public override System.Reflection.FieldInfo GetField (string name, System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException(); }
+        public override System.Reflection.FieldInfo[] GetFields (System.Reflection.BindingFlags bindingFlags) { throw new PlatformNotSupportedException(); }
+        public System.Reflection.Emit.FieldToken GetFieldToken(System.Reflection.FieldInfo field) { throw new PlatformNotSupportedException(); }
+        public override int GetHashCode() { throw new PlatformNotSupportedException(); }
+        protected override System.Reflection.MethodInfo GetMethodImpl (string name, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw new PlatformNotSupportedException(); }
+        public override System.Reflection.MethodInfo[] GetMethods (System.Reflection.BindingFlags bindingFlags) { throw new PlatformNotSupportedException(); }
+        public System.Reflection.Emit.MethodToken GetMethodToken(System.Reflection.MethodInfo method) { throw new PlatformNotSupportedException(); }
+        public System.Reflection.Emit.MethodToken GetMethodToken(System.Reflection.MethodInfo method, System.Collections.Generic.IEnumerable<System.Type> optionalParameterTypes) { throw new PlatformNotSupportedException(); }
+        public System.Reflection.Emit.SignatureToken GetSignatureToken(byte[] sigBytes, int sigLength) { throw new PlatformNotSupportedException(); }
+        public System.Reflection.Emit.SignatureToken GetSignatureToken(System.Reflection.Emit.SignatureHelper sigHelper) { throw new PlatformNotSupportedException(); }
+        public System.Reflection.Emit.StringToken GetStringConstant(string str) { throw new PlatformNotSupportedException(); }
+        public System.Diagnostics.SymbolStore.ISymbolWriter GetSymWriter () => throw new PlatformNotSupportedException ();
+        public override System.Type GetType (string className) { throw new PlatformNotSupportedException(); }
+        public override System.Type GetType (string className, bool ignoreCase) { throw new PlatformNotSupportedException(); }
+        public override System.Type GetType (string className, bool throwOnError, bool ignoreCase) { throw new PlatformNotSupportedException(); }
+        public override System.Type[] GetTypes () { throw new PlatformNotSupportedException(); }
+        public System.Reflection.Emit.TypeToken GetTypeToken(string name) { throw new PlatformNotSupportedException(); }
+        public System.Reflection.Emit.TypeToken GetTypeToken(System.Type type) { throw new PlatformNotSupportedException(); }
+        public override bool IsDefined (System.Type attributeType, bool inherit) { throw new PlatformNotSupportedException(); }
+        public override bool IsResource () { throw new PlatformNotSupportedException(); }
+        public bool IsTransient() { throw new PlatformNotSupportedException(); }
+        public override System.Reflection.FieldInfo ResolveField (int metadataToken, System.Type[] genericTypeArguments, System.Type[] genericMethodArguments) { throw new PlatformNotSupportedException(); }
+        public override System.Reflection.MemberInfo ResolveMember (int metadataToken, System.Type[] genericTypeArguments, System.Type[] genericMethodArguments) { throw new PlatformNotSupportedException(); }
+        public override System.Reflection.MethodBase ResolveMethod (int metadataToken, System.Type[] genericTypeArguments, System.Type[] genericMethodArguments) { throw new PlatformNotSupportedException(); }
+        public override byte[] ResolveSignature (int metadataToken) { throw new PlatformNotSupportedException(); }
+        public override string ResolveString (int metadataToken) { throw new PlatformNotSupportedException(); }
+        public override System.Type ResolveType (int metadataToken, System.Type[] genericTypeArguments, System.Type[] genericMethodArguments) { throw new PlatformNotSupportedException(); }
+        public void SetCustomAttribute(System.Reflection.ConstructorInfo con, byte[] binaryAttribute) => throw new PlatformNotSupportedException();
+        public void SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder customBuilder) => throw new PlatformNotSupportedException();
+        public void SetSymCustomAttribute (string name, byte[] data) => throw new PlatformNotSupportedException ();
+        public void SetUserEntryPoint(System.Reflection.MethodInfo entryPoint) => throw new PlatformNotSupportedException();
+    }
 
-		public EnumBuilder DefineEnum (string name, TypeAttributes visibility, Type underlyingType)
-		{
-			throw new PlatformNotSupportedException ();
-		}
+    public readonly partial struct MethodToken : System.IEquatable<MethodToken>
+    {
+        public static readonly System.Reflection.Emit.MethodToken Empty;
+        public int Token { get { throw new PlatformNotSupportedException(); } }
+        public override bool Equals(object obj) { throw new PlatformNotSupportedException(); }
+        public bool Equals(System.Reflection.Emit.MethodToken obj) { throw new PlatformNotSupportedException(); }
+        public override int GetHashCode() { throw new PlatformNotSupportedException(); }
+        public static bool operator ==(System.Reflection.Emit.MethodToken a, System.Reflection.Emit.MethodToken b) { throw new PlatformNotSupportedException(); }
+        public static bool operator !=(System.Reflection.Emit.MethodToken a, System.Reflection.Emit.MethodToken b) { throw new PlatformNotSupportedException(); }
+    }
 
-		public MethodBuilder DefineGlobalMethod (string name, MethodAttributes attributes, Type returnType, Type[] parameterTypes)
-		{
-			throw new PlatformNotSupportedException ();
-		}
+    public readonly partial struct SignatureToken : System.IEquatable<SignatureToken>
+    {
+        public static readonly System.Reflection.Emit.SignatureToken Empty;
+        public int Token { get { throw new PlatformNotSupportedException(); } }
+        public override bool Equals(object obj) { throw new PlatformNotSupportedException(); }
+        public bool Equals(System.Reflection.Emit.SignatureToken obj) { throw new PlatformNotSupportedException(); }
+        public override int GetHashCode() { throw new PlatformNotSupportedException(); }
+        public static bool operator ==(System.Reflection.Emit.SignatureToken a, System.Reflection.Emit.SignatureToken b) { throw new PlatformNotSupportedException(); }
+        public static bool operator !=(System.Reflection.Emit.SignatureToken a, System.Reflection.Emit.SignatureToken b) { throw new PlatformNotSupportedException(); }
+    }
 
-		public MethodBuilder DefineGlobalMethod (string name, MethodAttributes attributes, CallingConventions callingConvention, Type returnType, Type[] parameterTypes)
-		{
-			throw new PlatformNotSupportedException ();
-		}
+    public readonly partial struct FieldToken : System.IEquatable<FieldToken>
+    {
+        public static readonly System.Reflection.Emit.FieldToken Empty;
+        public int Token { get { throw new PlatformNotSupportedException(); } }
+        public override bool Equals(object obj) { throw new PlatformNotSupportedException(); }
+        public bool Equals(System.Reflection.Emit.FieldToken obj) { throw new PlatformNotSupportedException(); }
+        public override int GetHashCode() { throw new PlatformNotSupportedException(); }
+        public static bool operator ==(System.Reflection.Emit.FieldToken a, System.Reflection.Emit.FieldToken b) { throw new PlatformNotSupportedException(); }
+        public static bool operator !=(System.Reflection.Emit.FieldToken a, System.Reflection.Emit.FieldToken b) { throw new PlatformNotSupportedException(); }
+    }
 
-		public MethodBuilder DefineGlobalMethod (string name, MethodAttributes attributes, CallingConventions callingConvention, Type returnType, Type[] requiredReturnTypeCustomModifiers, Type[] optionalReturnTypeCustomModifiers, Type[] parameterTypes, Type[][] requiredParameterTypeCustomModifiers, Type[][] optionalParameterTypeCustomModifiers)
-		{
-			throw new PlatformNotSupportedException ();
-		}
+    public readonly partial struct StringToken : System.IEquatable<StringToken>
+    {
+        public int Token { get { throw new PlatformNotSupportedException(); } }
+        public override bool Equals(object obj) { throw new PlatformNotSupportedException(); }
+        public bool Equals(System.Reflection.Emit.StringToken obj) { throw new PlatformNotSupportedException(); }
+        public override int GetHashCode() { throw new PlatformNotSupportedException(); }
+        public static bool operator ==(System.Reflection.Emit.StringToken a, System.Reflection.Emit.StringToken b) { throw new PlatformNotSupportedException(); }
+        public static bool operator !=(System.Reflection.Emit.StringToken a, System.Reflection.Emit.StringToken b) { throw new PlatformNotSupportedException(); }
+    }
 
-		public FieldBuilder DefineInitializedData (string name, byte[] data, FieldAttributes attributes)
-		{
-			throw new PlatformNotSupportedException ();
-		}
+    public readonly partial struct TypeToken : System.IEquatable<TypeToken>
+    {
+        public static readonly System.Reflection.Emit.TypeToken Empty;
+        public int Token { get { throw new PlatformNotSupportedException(); } }
+        public override bool Equals(object obj) { throw new PlatformNotSupportedException(); }
+        public bool Equals(System.Reflection.Emit.TypeToken obj) { throw new PlatformNotSupportedException(); }
+        public override int GetHashCode() { throw new PlatformNotSupportedException(); }
+        public static bool operator ==(System.Reflection.Emit.TypeToken a, System.Reflection.Emit.TypeToken b) { throw new PlatformNotSupportedException(); }
+        public static bool operator !=(System.Reflection.Emit.TypeToken a, System.Reflection.Emit.TypeToken b) { throw new PlatformNotSupportedException(); }
+    }
 
-		public TypeBuilder DefineType (string name)
-		{
-			throw new PlatformNotSupportedException ();
-		}
+    public partial class DynamicILInfo
+    {
+        internal DynamicILInfo() => throw new PlatformNotSupportedException();
+        public System.Reflection.Emit.DynamicMethod DynamicMethod { get { throw new PlatformNotSupportedException(); } }
+        public int GetTokenFor(byte[] signature) { throw new PlatformNotSupportedException(); }
+        public int GetTokenFor(System.Reflection.Emit.DynamicMethod method) { throw new PlatformNotSupportedException(); }
+        public int GetTokenFor(System.RuntimeFieldHandle field) { throw new PlatformNotSupportedException(); }
+        public int GetTokenFor(System.RuntimeFieldHandle field, System.RuntimeTypeHandle contextType) { throw new PlatformNotSupportedException(); }
+        public int GetTokenFor(System.RuntimeMethodHandle method) { throw new PlatformNotSupportedException(); }
+        public int GetTokenFor(System.RuntimeMethodHandle method, System.RuntimeTypeHandle contextType) { throw new PlatformNotSupportedException(); }
+        public int GetTokenFor(System.RuntimeTypeHandle type) { throw new PlatformNotSupportedException(); }
+        public int GetTokenFor(string literal) { throw new PlatformNotSupportedException(); }
+        [System.CLSCompliantAttribute(false)]
+        public unsafe void SetCode(byte* code, int codeSize, int maxStackSize) => throw new PlatformNotSupportedException();
+        public void SetCode(byte[] code, int maxStackSize) => throw new PlatformNotSupportedException();
+        [System.CLSCompliantAttribute(false)]
+        public unsafe void SetExceptions(byte* exceptions, int exceptionsSize) => throw new PlatformNotSupportedException();
+        public void SetExceptions(byte[] exceptions) => throw new PlatformNotSupportedException();
+        [System.CLSCompliantAttribute(false)]
+        public unsafe void SetLocalSignature(byte* localSignature, int signatureSize) => throw new PlatformNotSupportedException();
+        public void SetLocalSignature(byte[] localSignature) => throw new PlatformNotSupportedException();
+    }
 
-		public TypeBuilder DefineType (string name, TypeAttributes attr)
-		{
-			throw new PlatformNotSupportedException ();
-		}
+    public readonly partial struct EventToken : System.IEquatable<EventToken>
+    {
+        public static readonly System.Reflection.Emit.EventToken Empty;
+        public int Token { get { throw new PlatformNotSupportedException(); } }
+        public override bool Equals(object obj) { throw new PlatformNotSupportedException(); }
+        public bool Equals(System.Reflection.Emit.EventToken obj) { throw new PlatformNotSupportedException(); }
+        public override int GetHashCode() { throw new PlatformNotSupportedException(); }
+        public static bool operator ==(System.Reflection.Emit.EventToken a, System.Reflection.Emit.EventToken b) { throw new PlatformNotSupportedException(); }
+        public static bool operator !=(System.Reflection.Emit.EventToken a, System.Reflection.Emit.EventToken b) { throw new PlatformNotSupportedException(); }
+    }
 
-		public TypeBuilder DefineType (string name, TypeAttributes attr, Type parent)
-		{
-			throw new PlatformNotSupportedException ();
-		}
+    public readonly partial struct ParameterToken : System.IEquatable<ParameterToken>
+    {
+        public static readonly System.Reflection.Emit.ParameterToken Empty;
+        public int Token { get { throw new PlatformNotSupportedException(); } }
+        public override bool Equals(object obj) { throw new PlatformNotSupportedException(); }
+        public bool Equals(System.Reflection.Emit.ParameterToken obj) { throw new PlatformNotSupportedException(); }
+        public override int GetHashCode() { throw new PlatformNotSupportedException(); }
+        public static bool operator ==(System.Reflection.Emit.ParameterToken a, System.Reflection.Emit.ParameterToken b) { throw new PlatformNotSupportedException(); }
+        public static bool operator !=(System.Reflection.Emit.ParameterToken a, System.Reflection.Emit.ParameterToken b) { throw new PlatformNotSupportedException(); }
+    }
 
-		public TypeBuilder DefineType (string name, TypeAttributes attr, Type parent, int typesize)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public TypeBuilder DefineType (string name, TypeAttributes attr, Type parent, PackingSize packsize)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public TypeBuilder DefineType (string name, TypeAttributes attr, Type parent, Type[] interfaces)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public TypeBuilder DefineType (string name, TypeAttributes attr, Type parent, PackingSize packingSize, int typesize)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public FieldBuilder DefineUninitializedData (string name, int size, FieldAttributes attributes)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public MethodInfo GetArrayMethod (Type arrayClass, string methodName, CallingConventions callingConvention, Type returnType, Type[] parameterTypes)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetCustomAttribute (CustomAttributeBuilder customBuilder)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetCustomAttribute (ConstructorInfo con, byte[] binaryAttribute)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-	}
+    public readonly partial struct PropertyToken : System.IEquatable<PropertyToken>
+    {
+        public static readonly System.Reflection.Emit.PropertyToken Empty;
+        public int Token { get { throw new PlatformNotSupportedException(); } }
+        public override bool Equals(object obj) { throw new PlatformNotSupportedException(); }
+        public bool Equals(System.Reflection.Emit.PropertyToken obj) { throw new PlatformNotSupportedException(); }
+        public override int GetHashCode() { throw new PlatformNotSupportedException(); }
+        public static bool operator ==(System.Reflection.Emit.PropertyToken a, System.Reflection.Emit.PropertyToken b) { throw new PlatformNotSupportedException(); }
+        public static bool operator !=(System.Reflection.Emit.PropertyToken a, System.Reflection.Emit.PropertyToken b) { throw new PlatformNotSupportedException(); }
+    }
 }
 
 #endif

--- a/mcs/class/corlib/System.Reflection.Emit/ParameterBuilder.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/ParameterBuilder.pns.cs
@@ -36,7 +36,7 @@ namespace System.Reflection.Emit
 		{
 		}
 
-		public int Attributes {
+		public virtual int Attributes {
 			get {
 				throw new PlatformNotSupportedException ();
 			}
@@ -60,13 +60,13 @@ namespace System.Reflection.Emit
 			}
 		}
 
-		public string Name {
+		public virtual string Name {
 			get {
 				throw new PlatformNotSupportedException ();
 			}
 		}
 
-		public int Position {
+		public virtual int Position {
 			get {
 				throw new PlatformNotSupportedException ();
 			}
@@ -86,6 +86,11 @@ namespace System.Reflection.Emit
 		{
 			throw new PlatformNotSupportedException ();
 		}
+
+		[Obsolete ("An alternate API is available: Emit the MarshalAs custom attribute instead.")]
+		public virtual void SetMarshal (UnmanagedMarshal unmanagedMarshal) => throw new PlatformNotSupportedException ();
+
+		public virtual ParameterToken GetToken() => throw new PlatformNotSupportedException ();
 	}
 }
 

--- a/mcs/class/corlib/System.Reflection.Emit/PropertyBuilder.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/PropertyBuilder.pns.cs
@@ -30,78 +30,35 @@
 
 namespace System.Reflection.Emit
 {
-	public abstract class PropertyBuilder : PropertyInfo
+	public sealed partial class PropertyBuilder : System.Reflection.PropertyInfo
 	{
-		public override PropertyAttributes Attributes {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override bool CanRead {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override bool CanWrite {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override Type DeclaringType {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override string Name {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-		
-		public override Type PropertyType {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public void AddOtherMethod (MethodBuilder mdBuilder)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetConstant (object defaultValue)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetCustomAttribute (CustomAttributeBuilder customBuilder)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetCustomAttribute (ConstructorInfo con, byte[] binaryAttribute)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetGetMethod (MethodBuilder mdBuilder)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetSetMethod (MethodBuilder mdBuilder)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public override ParameterInfo[] GetIndexParameters ()
-		{
-			throw new PlatformNotSupportedException ();
-		}
+        internal PropertyBuilder() { throw new PlatformNotSupportedException (); } 
+        public override System.Reflection.PropertyAttributes Attributes { get { throw new PlatformNotSupportedException (); } }
+        public override bool CanRead { get { throw new PlatformNotSupportedException (); } }
+        public override bool CanWrite { get { throw new PlatformNotSupportedException (); } }
+        public override System.Type DeclaringType { get { throw new PlatformNotSupportedException (); } }
+        public override System.Reflection.Module Module { get { throw new PlatformNotSupportedException (); } }
+        public override string Name { get { throw new PlatformNotSupportedException (); } }
+        public System.Reflection.Emit.PropertyToken PropertyToken { get { throw new PlatformNotSupportedException (); } }
+        public override System.Type PropertyType { get { throw new PlatformNotSupportedException (); } }
+        public override System.Type ReflectedType { get { throw new PlatformNotSupportedException (); } }
+        public void AddOtherMethod(System.Reflection.Emit.MethodBuilder mdBuilder) { throw new PlatformNotSupportedException (); } 
+        public override System.Reflection.MethodInfo[] GetAccessors(bool nonPublic) { throw new PlatformNotSupportedException (); }
+        public override object[] GetCustomAttributes(bool inherit) { throw new PlatformNotSupportedException (); }
+        public override object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw new PlatformNotSupportedException (); }
+        public override System.Reflection.MethodInfo GetGetMethod(bool nonPublic) { throw new PlatformNotSupportedException (); }
+        public override System.Reflection.ParameterInfo[] GetIndexParameters() { throw new PlatformNotSupportedException (); }
+        public override System.Reflection.MethodInfo GetSetMethod(bool nonPublic) { throw new PlatformNotSupportedException (); }
+        public override object GetValue(object obj, object[] index) { throw new PlatformNotSupportedException (); }
+        public override object GetValue(object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object[] index, System.Globalization.CultureInfo culture) { throw new PlatformNotSupportedException (); }
+        public override bool IsDefined(System.Type attributeType, bool inherit) { throw new PlatformNotSupportedException (); }
+        public void SetConstant(object defaultValue) { throw new PlatformNotSupportedException (); } 
+        public void SetCustomAttribute(System.Reflection.ConstructorInfo con, byte[] binaryAttribute) { throw new PlatformNotSupportedException (); } 
+        public void SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder customBuilder) { throw new PlatformNotSupportedException (); } 
+        public void SetGetMethod(System.Reflection.Emit.MethodBuilder mdBuilder) { throw new PlatformNotSupportedException (); } 
+        public void SetSetMethod(System.Reflection.Emit.MethodBuilder mdBuilder) { throw new PlatformNotSupportedException (); } 
+        public override void SetValue(object obj, object value, object[] index) { throw new PlatformNotSupportedException (); } 
+        public override void SetValue(object obj, object value, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object[] index, System.Globalization.CultureInfo culture) { throw new PlatformNotSupportedException (); } 
 	}
 }
 

--- a/mcs/class/corlib/System.Reflection.Emit/SignatureHelper.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/SignatureHelper.pns.cs
@@ -28,9 +28,11 @@
 
 #if !MONO_FEATURE_SRE
 
+using System.Runtime.InteropServices;
+
 namespace System.Reflection.Emit
 {
-	public class SignatureHelper
+	public class SignatureHelper : _SignatureHelper
 	{
 		SignatureHelper ()
 		{			
@@ -110,6 +112,24 @@ namespace System.Reflection.Emit
 		{
 			throw new PlatformNotSupportedException ();
 		}
+
+		public static SignatureHelper GetMethodSigHelper (Module mod, CallingConvention unmanagedCallConv, Type returnType) => 
+			throw new PlatformNotSupportedException ();
+
+		public static SignatureHelper GetMethodSigHelper (CallingConvention unmanagedCallingConvention, Type returnType) =>
+			throw new PlatformNotSupportedException ();
+
+		public override bool Equals (object obj) => throw new PlatformNotSupportedException ();
+		public override int GetHashCode () => throw new PlatformNotSupportedException ();
+		public override string ToString () => throw new PlatformNotSupportedException ();
+
+		void _SignatureHelper.GetIDsOfNames ([In] ref Guid riid, IntPtr rgszNames, uint cNames, uint lcid, IntPtr rgDispId) => throw new PlatformNotSupportedException ();
+
+		void _SignatureHelper.GetTypeInfo (uint iTInfo, uint lcid, IntPtr ppTInfo) => throw new PlatformNotSupportedException ();
+
+		void _SignatureHelper.GetTypeInfoCount (out uint pcTInfo) => throw new PlatformNotSupportedException ();
+
+		void _SignatureHelper.Invoke (uint dispIdMember, [In] ref Guid riid, uint lcid, short wFlags, IntPtr pDispParams, IntPtr pVarResult, IntPtr pExcepInfo, IntPtr puArgErr) => throw new PlatformNotSupportedException ();
 	}
 }
 

--- a/mcs/class/corlib/System.Reflection.Emit/TypeBuilder.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/TypeBuilder.pns.cs
@@ -28,256 +28,122 @@
 
 #if !MONO_FEATURE_SRE
 
+using System.Runtime.InteropServices;
+
 namespace System.Reflection.Emit
 {
-	public abstract class TypeBuilder : TypeInfo
+	public sealed partial class TypeBuilder : System.Reflection.TypeInfo
 	{
+		internal TypeBuilder() { throw new PlatformNotSupportedException (); } 
 		public const int UnspecifiedTypeSize = 0;
+		public override System.Reflection.Assembly Assembly { get { throw new PlatformNotSupportedException (); } }
+		public override string AssemblyQualifiedName { get { throw new PlatformNotSupportedException (); } }
+		public override System.Type BaseType { get { throw new PlatformNotSupportedException (); } }
+		public override bool ContainsGenericParameters { get { throw new PlatformNotSupportedException (); } }
+		public override System.Reflection.MethodBase DeclaringMethod { get { throw new PlatformNotSupportedException (); } }
+		public override System.Type DeclaringType { get { throw new PlatformNotSupportedException (); } }
+		public override string FullName { get { throw new PlatformNotSupportedException (); } }
+		public override System.Reflection.GenericParameterAttributes GenericParameterAttributes { get { throw new PlatformNotSupportedException (); } }
+		public override int GenericParameterPosition { get { throw new PlatformNotSupportedException (); } }
+		public override System.Guid GUID { get { throw new PlatformNotSupportedException (); } }
+		public override bool IsConstructedGenericType { get { throw new PlatformNotSupportedException (); } }
+		public override bool IsGenericParameter { get { throw new PlatformNotSupportedException (); } }
+		public override bool IsGenericType { get { throw new PlatformNotSupportedException (); } }
+		public override bool IsGenericTypeDefinition { get { throw new PlatformNotSupportedException (); } }
+		public override bool IsTypeDefinition { get { throw new PlatformNotSupportedException (); } }
+		public override System.Reflection.Module Module { get { throw new PlatformNotSupportedException (); } }
+		public override string Name { get { throw new PlatformNotSupportedException (); } }
+		public override string Namespace { get { throw new PlatformNotSupportedException (); } }
+		public System.Reflection.Emit.PackingSize PackingSize { get { throw new PlatformNotSupportedException (); } }
+		public override System.Type ReflectedType { get { throw new PlatformNotSupportedException (); } }
+		public int Size { get { throw new PlatformNotSupportedException (); } }
+		public override System.RuntimeTypeHandle TypeHandle { get { throw new PlatformNotSupportedException (); } }
+		public System.Reflection.Emit.TypeToken TypeToken { get { throw new PlatformNotSupportedException (); } }
+		public override System.Type UnderlyingSystemType { get { throw new PlatformNotSupportedException (); } }
 
-		public PackingSize PackingSize {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public int Size {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override Assembly Assembly {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override string AssemblyQualifiedName {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override Type BaseType {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override string FullName {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override Guid GUID {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override Module Module {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override string Name {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public override string Namespace {
-			get {
-				throw new PlatformNotSupportedException ();
-			}
-		}
-
-		public void AddInterfaceImplementation (Type interfaceType)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public TypeInfo CreateTypeInfo ()
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public ConstructorBuilder DefineConstructor (MethodAttributes attributes, CallingConventions callingConvention, Type[] parameterTypes)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public ConstructorBuilder DefineConstructor (MethodAttributes attributes, CallingConventions callingConvention, Type[] parameterTypes, Type[][] requiredCustomModifiers, Type[][] optionalCustomModifiers)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public ConstructorBuilder DefineDefaultConstructor (MethodAttributes attributes)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public EventBuilder DefineEvent (string name, EventAttributes attributes, Type eventtype)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public FieldBuilder DefineField (string fieldName, Type type, FieldAttributes attributes)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public FieldBuilder DefineField (string fieldName, Type type, Type[] requiredCustomModifiers, Type[] optionalCustomModifiers, FieldAttributes attributes)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public GenericTypeParameterBuilder[] DefineGenericParameters (string[] names)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public FieldBuilder DefineInitializedData (string name, byte[] data, FieldAttributes attributes)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public MethodBuilder DefineMethod (string name, MethodAttributes attributes)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public MethodBuilder DefineMethod (string name, MethodAttributes attributes, CallingConventions callingConvention)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public MethodBuilder DefineMethod (string name, MethodAttributes attributes, Type returnType, Type[] parameterTypes)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public MethodBuilder DefineMethod (string name, MethodAttributes attributes, CallingConventions callingConvention, Type returnType, Type[] parameterTypes)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public MethodBuilder DefineMethod (string name, MethodAttributes attributes, CallingConventions callingConvention, Type returnType, Type[] returnTypeRequiredCustomModifiers, Type[] returnTypeOptionalCustomModifiers, Type[] parameterTypes, Type[][] parameterTypeRequiredCustomModifiers, Type[][] parameterTypeOptionalCustomModifiers)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void DefineMethodOverride (MethodInfo methodInfoBody, MethodInfo methodInfoDeclaration)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public TypeBuilder DefineNestedType (string name)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public TypeBuilder DefineNestedType (string name, TypeAttributes attr)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public TypeBuilder DefineNestedType (string name, TypeAttributes attr, Type parent)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public TypeBuilder DefineNestedType (string name, TypeAttributes attr, Type parent, int typeSize)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public TypeBuilder DefineNestedType (string name, TypeAttributes attr, Type parent, PackingSize packSize)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public TypeBuilder DefineNestedType (string name, TypeAttributes attr, Type parent, Type[] interfaces)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public TypeBuilder DefineNestedType (string name, TypeAttributes attr, Type parent, PackingSize packSize, int typeSize)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public PropertyBuilder DefineProperty (string name, PropertyAttributes attributes, Type returnType, Type[] parameterTypes)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public PropertyBuilder DefineProperty (string name, PropertyAttributes attributes, CallingConventions callingConvention, Type returnType, Type[] parameterTypes)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public PropertyBuilder DefineProperty (string name, PropertyAttributes attributes, Type returnType, Type[] returnTypeRequiredCustomModifiers, Type[] returnTypeOptionalCustomModifiers, Type[] parameterTypes, Type[][] parameterTypeRequiredCustomModifiers, Type[][] parameterTypeOptionalCustomModifiers)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public PropertyBuilder DefineProperty (string name, PropertyAttributes attributes, CallingConventions callingConvention, Type returnType, Type[] returnTypeRequiredCustomModifiers, Type[] returnTypeOptionalCustomModifiers, Type[] parameterTypes, Type[][] parameterTypeRequiredCustomModifiers, Type[][] parameterTypeOptionalCustomModifiers)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public ConstructorBuilder DefineTypeInitializer ()
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public FieldBuilder DefineUninitializedData (string name, int size, FieldAttributes attributes)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public static ConstructorInfo GetConstructor (Type type, ConstructorInfo constructor)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public static FieldInfo GetField (Type type, FieldInfo field)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public static MethodInfo GetMethod (Type type, MethodInfo method)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public bool IsCreated ()
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetCustomAttribute (CustomAttributeBuilder customBuilder)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetCustomAttribute (ConstructorInfo con, byte[] binaryAttribute)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public void SetParent (Type parent)
-		{
-			throw new PlatformNotSupportedException ();
-		}
-
-		public override Type GetElementType ()
-		{
-			throw new PlatformNotSupportedException ();
-		}
+		public void AddDeclarativeSecurity (System.Security.Permissions.SecurityAction action, System.Security.PermissionSet pset) { throw new PlatformNotSupportedException (); }
+		public void AddInterfaceImplementation(System.Type interfaceType) { throw new PlatformNotSupportedException (); } 
+		public System.Type CreateType() { throw new PlatformNotSupportedException (); }
+		public System.Reflection.TypeInfo CreateTypeInfo() { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.ConstructorBuilder DefineConstructor(System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type[] parameterTypes) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.ConstructorBuilder DefineConstructor(System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type[] parameterTypes, System.Type[][] requiredCustomModifiers, System.Type[][] optionalCustomModifiers) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.ConstructorBuilder DefineDefaultConstructor(System.Reflection.MethodAttributes attributes) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.EventBuilder DefineEvent(string name, System.Reflection.EventAttributes attributes, System.Type eventtype) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.FieldBuilder DefineField(string fieldName, System.Type type, System.Reflection.FieldAttributes attributes) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.FieldBuilder DefineField(string fieldName, System.Type type, System.Type[] requiredCustomModifiers, System.Type[] optionalCustomModifiers, System.Reflection.FieldAttributes attributes) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.GenericTypeParameterBuilder[] DefineGenericParameters(params string[] names) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.FieldBuilder DefineInitializedData(string name, byte[] data, System.Reflection.FieldAttributes attributes) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.MethodBuilder DefineMethod(string name, System.Reflection.MethodAttributes attributes) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.MethodBuilder DefineMethod(string name, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.MethodBuilder DefineMethod(string name, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.MethodBuilder DefineMethod(string name, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] returnTypeRequiredCustomModifiers, System.Type[] returnTypeOptionalCustomModifiers, System.Type[] parameterTypes, System.Type[][] parameterTypeRequiredCustomModifiers, System.Type[][] parameterTypeOptionalCustomModifiers) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.MethodBuilder DefineMethod(string name, System.Reflection.MethodAttributes attributes, System.Type returnType, System.Type[] parameterTypes) { throw new PlatformNotSupportedException (); }
+		public void DefineMethodOverride(System.Reflection.MethodInfo methodInfoBody, System.Reflection.MethodInfo methodInfoDeclaration) { throw new PlatformNotSupportedException (); } 
+		public System.Reflection.Emit.TypeBuilder DefineNestedType(string name) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.TypeBuilder DefineNestedType(string name, System.Reflection.TypeAttributes attr) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.TypeBuilder DefineNestedType(string name, System.Reflection.TypeAttributes attr, System.Type parent) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.TypeBuilder DefineNestedType(string name, System.Reflection.TypeAttributes attr, System.Type parent, int typeSize) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.TypeBuilder DefineNestedType(string name, System.Reflection.TypeAttributes attr, System.Type parent, System.Reflection.Emit.PackingSize packSize) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.TypeBuilder DefineNestedType(string name, System.Reflection.TypeAttributes attr, System.Type parent, System.Reflection.Emit.PackingSize packSize, int typeSize) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.TypeBuilder DefineNestedType(string name, System.Reflection.TypeAttributes attr, System.Type parent, System.Type[] interfaces) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.MethodBuilder DefinePInvokeMethod(string name, string dllName, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes, System.Runtime.InteropServices.CallingConvention nativeCallConv, System.Runtime.InteropServices.CharSet nativeCharSet) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.MethodBuilder DefinePInvokeMethod(string name, string dllName, string entryName, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes, System.Runtime.InteropServices.CallingConvention nativeCallConv, System.Runtime.InteropServices.CharSet nativeCharSet) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.MethodBuilder DefinePInvokeMethod(string name, string dllName, string entryName, System.Reflection.MethodAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] returnTypeRequiredCustomModifiers, System.Type[] returnTypeOptionalCustomModifiers, System.Type[] parameterTypes, System.Type[][] parameterTypeRequiredCustomModifiers, System.Type[][] parameterTypeOptionalCustomModifiers, System.Runtime.InteropServices.CallingConvention nativeCallConv, System.Runtime.InteropServices.CharSet nativeCharSet) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.PropertyBuilder DefineProperty(string name, System.Reflection.PropertyAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] parameterTypes) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.PropertyBuilder DefineProperty(string name, System.Reflection.PropertyAttributes attributes, System.Reflection.CallingConventions callingConvention, System.Type returnType, System.Type[] returnTypeRequiredCustomModifiers, System.Type[] returnTypeOptionalCustomModifiers, System.Type[] parameterTypes, System.Type[][] parameterTypeRequiredCustomModifiers, System.Type[][] parameterTypeOptionalCustomModifiers) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.PropertyBuilder DefineProperty(string name, System.Reflection.PropertyAttributes attributes, System.Type returnType, System.Type[] parameterTypes) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.PropertyBuilder DefineProperty(string name, System.Reflection.PropertyAttributes attributes, System.Type returnType, System.Type[] returnTypeRequiredCustomModifiers, System.Type[] returnTypeOptionalCustomModifiers, System.Type[] parameterTypes, System.Type[][] parameterTypeRequiredCustomModifiers, System.Type[][] parameterTypeOptionalCustomModifiers) { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.ConstructorBuilder DefineTypeInitializer() { throw new PlatformNotSupportedException (); }
+		public System.Reflection.Emit.FieldBuilder DefineUninitializedData(string name, int size, System.Reflection.FieldAttributes attributes) { throw new PlatformNotSupportedException (); }
+		protected override System.Reflection.TypeAttributes GetAttributeFlagsImpl() { throw new PlatformNotSupportedException (); }
+		public static System.Reflection.ConstructorInfo GetConstructor(System.Type type, System.Reflection.ConstructorInfo constructor) { throw new PlatformNotSupportedException (); }
+		protected override System.Reflection.ConstructorInfo GetConstructorImpl(System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.ConstructorInfo[] GetConstructors(System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override object[] GetCustomAttributes(bool inherit) { throw new PlatformNotSupportedException (); }
+		public override object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw new PlatformNotSupportedException (); }
+		public override System.Type GetElementType() { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.EventInfo GetEvent(string name, System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.EventInfo[] GetEvents() { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.EventInfo[] GetEvents(System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.FieldInfo GetField(string name, System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public static System.Reflection.FieldInfo GetField(System.Type type, System.Reflection.FieldInfo field) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.FieldInfo[] GetFields(System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override System.Type[] GetGenericArguments() { throw new PlatformNotSupportedException (); }
+		public override System.Type GetGenericTypeDefinition() { throw new PlatformNotSupportedException (); }
+		public override System.Type GetInterface(string name, bool ignoreCase) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.InterfaceMapping GetInterfaceMap(System.Type interfaceType) { throw new PlatformNotSupportedException (); }
+		public override System.Type[] GetInterfaces() { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.MemberInfo[] GetMember(string name, System.Reflection.MemberTypes type, System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.MemberInfo[] GetMembers(System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public static System.Reflection.MethodInfo GetMethod(System.Type type, System.Reflection.MethodInfo method) { throw new PlatformNotSupportedException (); }
+		protected override System.Reflection.MethodInfo GetMethodImpl(string name, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Reflection.CallingConventions callConvention, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.MethodInfo[] GetMethods(System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override System.Type GetNestedType(string name, System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override System.Type[] GetNestedTypes(System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		public override System.Reflection.PropertyInfo[] GetProperties(System.Reflection.BindingFlags bindingAttr) { throw new PlatformNotSupportedException (); }
+		protected override System.Reflection.PropertyInfo GetPropertyImpl(string name, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Type returnType, System.Type[] types, System.Reflection.ParameterModifier[] modifiers) { throw new PlatformNotSupportedException (); }
+		protected override bool HasElementTypeImpl() { throw new PlatformNotSupportedException (); }
+		public override object InvokeMember(string name, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, object target, object[] args, System.Reflection.ParameterModifier[] modifiers, System.Globalization.CultureInfo culture, string[] namedParameters) { throw new PlatformNotSupportedException (); }
+		protected override bool IsArrayImpl() { throw new PlatformNotSupportedException (); }
+		public override bool IsAssignableFrom (System.Type c) { throw new PlatformNotSupportedException (); }
+		public override bool IsAssignableFrom (TypeInfo typeInfo) { throw new PlatformNotSupportedException (); }
+		protected override bool IsByRefImpl() { throw new PlatformNotSupportedException (); }
+		protected override bool IsCOMObjectImpl() { throw new PlatformNotSupportedException (); }
+		public bool IsCreated() { throw new PlatformNotSupportedException (); }
+		public override bool IsDefined(System.Type attributeType, bool inherit) { throw new PlatformNotSupportedException (); }
+		protected override bool IsPointerImpl() { throw new PlatformNotSupportedException (); }
+		protected override bool IsPrimitiveImpl() { throw new PlatformNotSupportedException (); }
+		public override bool IsSubclassOf(System.Type c) { throw new PlatformNotSupportedException (); }
+		protected override bool IsValueTypeImpl () { throw new PlatformNotSupportedException (); }
+		public override System.Type MakeArrayType() { throw new PlatformNotSupportedException (); }
+		public override System.Type MakeArrayType(int rank) { throw new PlatformNotSupportedException (); }
+		public override System.Type MakeByRefType() { throw new PlatformNotSupportedException (); }
+		public override System.Type MakeGenericType(params System.Type[] typeArguments) { throw new PlatformNotSupportedException (); }
+		public override System.Type MakePointerType() { throw new PlatformNotSupportedException (); }
+		public void SetCustomAttribute(System.Reflection.ConstructorInfo con, byte[] binaryAttribute) { throw new PlatformNotSupportedException (); } 
+		public void SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder customBuilder) { throw new PlatformNotSupportedException (); } 
+		public void SetParent(System.Type parent) { throw new PlatformNotSupportedException (); } 
+		public override string ToString() { throw new PlatformNotSupportedException (); }
 	}
 }
 

--- a/mcs/class/corlib/System.Reflection.Emit/UnmanagedMarshal.pns.cs
+++ b/mcs/class/corlib/System.Reflection.Emit/UnmanagedMarshal.pns.cs
@@ -1,0 +1,26 @@
+#if !MONO_FEATURE_SRE
+using System.Runtime.InteropServices;
+
+namespace System.Reflection.Emit {
+
+	[Obsolete ("An alternate API is available: Emit the MarshalAs custom attribute instead.")]
+	[ComVisible (true)]
+	[Serializable]
+	[StructLayout (LayoutKind.Sequential)]
+	public sealed class UnmanagedMarshal {
+
+		private UnmanagedMarshal () {}
+
+		public UnmanagedType BaseType { get { throw new PlatformNotSupportedException (); } }
+		public int ElementCount { get { throw new PlatformNotSupportedException (); } }
+		public UnmanagedType GetUnmanagedType { get { throw new PlatformNotSupportedException (); } }
+		public System.Guid IIDGuid { get { throw new PlatformNotSupportedException (); } }
+
+		public static UnmanagedMarshal DefineByValArray (int elemCount) => throw new PlatformNotSupportedException ();
+		public static UnmanagedMarshal DefineByValTStr (int elemCount) => throw new PlatformNotSupportedException ();
+		public static UnmanagedMarshal DefineLPArray (UnmanagedType elemType) => throw new PlatformNotSupportedException ();
+		public static UnmanagedMarshal DefineUnmanagedMarshal (UnmanagedType unmanagedType) => throw new PlatformNotSupportedException ();
+	}
+}
+
+#endif

--- a/mcs/class/corlib/System.Runtime.InteropServices/ITypeLibConverter.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/ITypeLibConverter.cs
@@ -30,7 +30,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection;
 using System.Reflection.Emit;
 

--- a/mcs/class/corlib/System.Runtime.InteropServices/ITypeLibExporterNameProvider.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/ITypeLibExporterNameProvider.cs
@@ -30,7 +30,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 namespace System.Runtime.InteropServices {
 
 	[ComVisible (true)]

--- a/mcs/class/corlib/System.Runtime.InteropServices/ITypeLibExporterNotifySink.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/ITypeLibExporterNotifySink.cs
@@ -30,7 +30,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/ITypeLibImporterNotifySink.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/ITypeLibImporterNotifySink.cs
@@ -30,7 +30,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/Marshal.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/Marshal.cs
@@ -391,7 +391,7 @@ namespace System.Runtime.InteropServices
 			FreeHGlobal (s);
 		}
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 		public static Guid GenerateGuidForType (Type type)
 		{
 			return type.GUID;
@@ -438,7 +438,7 @@ namespace System.Runtime.InteropServices
 				return GetCCW (o, T);
 		}
 #endif
-#endif // !FULL_AOT_RUNTIME
+#endif // !FULL_AOT_RUNTIME && !MONOTOUCH
 
 		public static IntPtr GetComInterfaceForObject (object o, Type T)
 		{
@@ -463,7 +463,7 @@ namespace System.Runtime.InteropServices
 			return GetComInterfaceForObject ((object)o, typeof (T));
 		}
 
-#if !FULL_AOT_RUNTIME && !NETCORE
+#if !FULL_AOT_RUNTIME && !NETCORE && !MONOTOUCH
 
 		public static IntPtr GetComInterfaceForObjectInContext (object o, Type t)
 		{
@@ -545,7 +545,7 @@ namespace System.Runtime.InteropServices
 #endif
 		}
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		private extern static IntPtr GetIDispatchForObjectInternal (object o);
 
@@ -595,7 +595,7 @@ namespace System.Runtime.InteropServices
 
 		public static IntPtr GetIUnknownForObject (object o)
 		{
-#if FULL_AOT_RUNTIME
+#if FULL_AOT_RUNTIME || MONOTOUCH
 			throw new PlatformNotSupportedException ();
 #else
 			IntPtr pUnk = GetIUnknownForObjectInternal (o);
@@ -700,7 +700,7 @@ namespace System.Runtime.InteropServices
 #endif
 		}
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 
 #if !NETCORE
 
@@ -1123,7 +1123,7 @@ namespace System.Runtime.InteropServices
 #endif
 		}
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 		[Obsolete]
 
 		public static void ReleaseThreadCache()

--- a/mcs/class/corlib/System.Runtime.InteropServices/TypeLibConverter.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/TypeLibConverter.cs
@@ -28,7 +28,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System;
 using System.Reflection;
 using System.Reflection.Emit;

--- a/mcs/class/corlib/System.Runtime.InteropServices/TypeLibExporterFlags.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/TypeLibExporterFlags.cs
@@ -30,7 +30,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 namespace System.Runtime.InteropServices
 {
 	[ComVisible(true)]

--- a/mcs/class/corlib/System.Runtime.InteropServices/TypeLibImporterFlags.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/TypeLibImporterFlags.cs
@@ -28,7 +28,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System;
 
 namespace System.Runtime.InteropServices

--- a/mcs/class/corlib/System.Runtime.InteropServices/UCOMITypeComp.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/UCOMITypeComp.cs
@@ -28,7 +28,7 @@
 //
 // (C) 2002 Ximian, Inc.
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 namespace System.Runtime.InteropServices
 {
 	[Obsolete]

--- a/mcs/class/corlib/System.Runtime.InteropServices/UCOMITypeLib.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/UCOMITypeLib.cs
@@ -28,7 +28,7 @@
 //
 // (C) 2002 Ximian, Inc.
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 namespace System.Runtime.InteropServices
 {
 	[Obsolete]

--- a/mcs/class/corlib/System.Runtime.InteropServices/_AssemblyBuilder.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_AssemblyBuilder.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/_ConstructorBuilder.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_ConstructorBuilder.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/_CustomAttributeBuilder.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_CustomAttributeBuilder.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/_EnumBuilder.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_EnumBuilder.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/_EventBuilder.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_EventBuilder.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/_FieldBuilder.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_FieldBuilder.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/_ILGenerator.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_ILGenerator.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/_LocalBuilder.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_LocalBuilder.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/_MethodBuilder.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_MethodBuilder.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/_ModuleBuilder.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_ModuleBuilder.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/_ParameterBuilder.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_ParameterBuilder.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/_PropertyBuilder.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_PropertyBuilder.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System.Runtime.InteropServices/_TypeBuilder.cs
+++ b/mcs/class/corlib/System.Runtime.InteropServices/_TypeBuilder.cs
@@ -27,7 +27,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
 using System.Reflection.Emit;
 
 namespace System.Runtime.InteropServices {

--- a/mcs/class/corlib/System/AppDomain.pns.cs
+++ b/mcs/class/corlib/System/AppDomain.pns.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Security;
+using System.Security.Policy;
+
+#if !MONO_FEATURE_SRE
+
+namespace System {
+
+	public partial class AppDomain {
+
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access, IEnumerable<CustomAttributeBuilder> assemblyAttributes)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+
+		[Obsolete ("Declarative security for assembly level is no longer enforced")]
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access, Evidence evidence)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access, string dir)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access, IEnumerable<CustomAttributeBuilder> assemblyAttributes, SecurityContextSource securityContextSource)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+		[Obsolete ("Declarative security for assembly level is no longer enforced")]
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access, string dir, Evidence evidence)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+		[Obsolete ("Declarative security for assembly level is no longer enforced")]
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access, PermissionSet requiredPermissions, PermissionSet optionalPermissions, PermissionSet refusedPermissions)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access, string dir, bool isSynchronized, IEnumerable<CustomAttributeBuilder> assemblyAttributes)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+		[Obsolete ("Declarative security for assembly level is no longer enforced")]
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access, Evidence evidence, PermissionSet requiredPermissions, PermissionSet optionalPermissions, PermissionSet refusedPermissions)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+		[Obsolete ("Declarative security for assembly level is no longer enforced")]
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access, string dir, PermissionSet requiredPermissions, PermissionSet optionalPermissions, PermissionSet refusedPermissions)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+		[Obsolete ("Declarative security for assembly level is no longer enforced")]
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access, string dir, Evidence evidence, PermissionSet requiredPermissions, PermissionSet optionalPermissions, PermissionSet refusedPermissions)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+		[Obsolete ("Declarative security for assembly level is no longer enforced")]
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access, string dir, Evidence evidence, PermissionSet requiredPermissions, PermissionSet optionalPermissions, PermissionSet refusedPermissions, bool isSynchronized)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+
+		[Obsolete ("Declarative security for assembly level is no longer enforced")]
+		public AssemblyBuilder DefineDynamicAssembly (AssemblyName name, AssemblyBuilderAccess access, string dir, Evidence evidence, PermissionSet requiredPermissions, PermissionSet optionalPermissions, PermissionSet refusedPermissions, bool isSynchronized, IEnumerable<CustomAttributeBuilder> assemblyAttributes)
+		{
+			throw new PlatformNotSupportedException ();
+		}
+	}
+}
+
+#endif

--- a/mcs/class/corlib/corlib.csproj
+++ b/mcs/class/corlib/corlib.csproj
@@ -1441,6 +1441,7 @@
     <Compile Include="System.Reflection.Emit\MethodBuilder.pns.cs" />
     <Compile Include="System.Reflection.Emit\MethodOnTypeBuilderInst.cs" />
     <Compile Include="System.Reflection.Emit\MethodRental.cs" />
+    <Compile Include="System.Reflection.Emit\MethodRental.pns.cs" />
     <Compile Include="System.Reflection.Emit\MethodToken.cs" />
     <Compile Include="System.Reflection.Emit\ModuleBuilder.cs" />
     <Compile Include="System.Reflection.Emit\ModuleBuilder.pns.cs" />
@@ -1465,6 +1466,7 @@
     <Compile Include="System.Reflection.Emit\TypeBuilderInstantiation.cs" />
     <Compile Include="System.Reflection.Emit\TypeToken.cs" />
     <Compile Include="System.Reflection.Emit\UnmanagedMarshal.cs" />
+    <Compile Include="System.Reflection.Emit\UnmanagedMarshal.pns.cs" />
     <Compile Include="System.Reflection.Metadata\AssemblyExtensions.cs" />
     <Compile Include="System.Reflection\Assembly.cs" />
     <Compile Include="System.Reflection\AssemblyName.cs" />
@@ -1965,6 +1967,7 @@
     <Compile Include="System\ActivationContext.cs" />
     <Compile Include="System\AndroidPlatform.cs" />
     <Compile Include="System\AppDomain.cs" />
+    <Compile Include="System\AppDomain.pns.cs" />
     <Compile Include="System\AppDomainInitializer.cs" />
     <Compile Include="System\AppDomainManager.cs" />
     <Compile Include="System\AppDomainSetup.cs" />

--- a/mcs/class/corlib/corlib.dll.sources
+++ b/mcs/class/corlib/corlib.dll.sources
@@ -73,6 +73,7 @@ Mono.Xml/SecurityParser.cs
 System/ActivationContext.cs
 System/AndroidPlatform.cs
 System/AppDomain.cs
+System/AppDomain.pns.cs
 System/AppDomainInitializer.cs
 System/AppDomainManager.cs
 System/AppDomainSetup.cs
@@ -285,6 +286,7 @@ System.Reflection.Emit/MethodBuilder.cs
 System.Reflection.Emit/MethodOnTypeBuilderInst.cs
 System.Reflection.Emit/MethodToken.cs
 System.Reflection.Emit/MethodRental.cs
+System.Reflection.Emit/MethodRental.pns.cs
 System.Reflection.Emit/ModuleBuilder.cs
 System.Reflection.Emit/MonoArrayMethod.cs
 System.Reflection.Emit/OpCodeNames.cs
@@ -307,6 +309,7 @@ System.Reflection.Emit/TypeBuilder.cs
 System.Reflection.Emit/TypeBuilderInstantiation.cs
 System.Reflection.Emit/TypeToken.cs
 System.Reflection.Emit/UnmanagedMarshal.cs
+System.Reflection.Emit/UnmanagedMarshal.pns.cs
 System.Reflection.Emit/AssemblyBuilder.pns.cs
 System.Reflection.Emit/ConstructorBuilder.pns.cs
 System.Reflection.Emit/CustomAttributeBuilder.pns.cs

--- a/mcs/class/referencesource/mscorlib/system/iappdomain.cs
+++ b/mcs/class/referencesource/mscorlib/system/iappdomain.cs
@@ -29,9 +29,7 @@ namespace System {
     using System.Threading;
     using System.Runtime.InteropServices;
     using System.Runtime.Remoting;
-#if !FULL_AOT_RUNTIME
     using System.Reflection.Emit;
-#endif
     using CultureInfo = System.Globalization.CultureInfo;
     using System.IO;
     using System.Runtime.Versioning;
@@ -88,7 +86,7 @@ namespace System {
 
         [method:System.Security.SecurityCritical]
         event UnhandledExceptionEventHandler UnhandledException;
-#if !FULL_AOT_RUNTIME
+
         AssemblyBuilder DefineDynamicAssembly(AssemblyName            name,
                                               AssemblyBuilderAccess   access);
 
@@ -141,7 +139,7 @@ namespace System {
                                               PermissionSet           optionalPermissions,
                                               PermissionSet           refusedPermissions,
                                               bool                    isSynchronized);
-#endif
+
         ObjectHandle CreateInstance(String assemblyName,
                                     String typeName);
 

--- a/mcs/class/referencesource/mscorlib/system/runtime/interopservices/dispatchwrapper.cs
+++ b/mcs/class/referencesource/mscorlib/system/runtime/interopservices/dispatchwrapper.cs
@@ -31,7 +31,7 @@ namespace System.Runtime.InteropServices {
         {
             if (obj != null)
             {
-#if FULL_AOT_RUNTIME
+#if FULL_AOT_RUNTIME || MONOTOUCH
                 throw new PlatformNotSupportedException ();
 #else
                 // Make sure this guy has an IDispatch

--- a/mcs/class/referencesource/mscorlib/system/runtime/interopservices/ucomitypeinfo.cs
+++ b/mcs/class/referencesource/mscorlib/system/runtime/interopservices/ucomitypeinfo.cs
@@ -304,7 +304,7 @@ namespace System.Runtime.InteropServices
         VARFLAG_FIMMEDIATEBIND    =0x1000
     }
 
-#if !FULL_AOT_RUNTIME
+#if !FULL_AOT_RUNTIME && !MONOTOUCH
     [Obsolete("Use System.Runtime.InteropServices.ComTypes.ITypeInfo instead. http://go.microsoft.com/fwlink/?linkid=14202", false)]
     [Guid("00020401-0000-0000-C000-000000000046")]
     [InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown)]


### PR DESCRIPTION
Backport of #14665 to 2019-02

/cc @spouliot 