### PR TITLE
Revert "[android] add hardware specific workaround for Nexus9 in armv7 mode"

### DIFF
--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -407,17 +407,7 @@ info_has_identity (MonoRgctxInfoType info_type)
 /*
  * LOCKING: loader lock
  */
-#if defined(HOST_ANDROID) && defined(TARGET_ARM)
-/* work around for HW bug on Nexus9 when running on armv7 */
-#ifdef __clang__
-static __attribute__ ((optnone)) void
-#else
-/* gcc */
-static __attribute__ ((optimize("O0"))) void
-#endif
-#else
 static void
-#endif
 rgctx_template_set_slot (MonoImage *image, MonoRuntimeGenericContextTemplate *template_, int type_argc,
 	int slot, gpointer data, MonoRgctxInfoType info_type)
 {


### PR DESCRIPTION
This reverts commit ee90fc601e762dc31eeb90fc61b6305246ad5275 (also see https://github.com/mono/mono/pull/4878 ).

The device was released November 2014.  I think it's fair to assume it isn't widely used anymore.