### PR TITLE
Fix LLVM build break on Windows MSVC.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6656,7 +6656,7 @@ fi
       echo "AOT_RUN_FLAGS=$AOT_RUN_FLAGS" >> $srcdir/$mcsdir/build/config.make
       echo "AOT_BUILD_ATTRS=$AOT_BUILD_ATTRS" >> $srcdir/$mcsdir/build/config.make
 
-      if test "x$internal_llvm" != "xno"; then
+      if test "x$internal_llvm" != "xno" && test "x$enable_llvm_msvc_only" = "xno"; then
         echo "AOT_BUILD_FLAGS=$AOT_BUILD_FLAGS,$MONO_LLVM_PATH_OPTION" >> $srcdir/$mcsdir/build/config.make
       else
         echo "AOT_BUILD_FLAGS=$AOT_BUILD_FLAGS" >> $srcdir/$mcsdir/build/config.make


### PR DESCRIPTION
https://github.com/mono/mono/pull/14607 broke LLVM build on Windows MSVC. This is just a quick fix falling back to old behavior on Windows MSVC. Since all LLVM tools will be available in the same folder as mono runtime binary there is no specific need to point out other build folders hosting LLVM tooling.
