### PR TITLE
[netcore] Add a metapackage for all supported runtimes

### DIFF
--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -107,6 +107,7 @@ prepare: $(ASPNETCORESDK_FILE) $(NETCORESDK_FILE) update-corefx update-roslyn li
 
 nupkg:
 	dotnet pack roslyn-restore.csproj -p:NuspecFile=runtime.nuspec -p:NuspecProperties=\"RID=$(RID)\;VERSION=$(VERSION)$(VERSTUB)\;PLATFORM_AOT_SUFFIX=$(PLATFORM_AOT_SUFFIX)\;COREARCH=$(COREARCH)\;PLATFORM_AOT_PREFIX=$(PLATFORM_AOT_PREFIX)\" --output ../artifacts/ --no-build
+	dotnet pack roslyn-restore.csproj -p:NuspecFile=metapackage.nuspec -p:NuspecProperties=\"RID=$(RID)\;VERSION=$(VERSION)$(VERSTUB)\;PLATFORM_AOT_SUFFIX=$(PLATFORM_AOT_SUFFIX)\;COREARCH=$(COREARCH)\;PLATFORM_AOT_PREFIX=$(PLATFORM_AOT_PREFIX)\" --output ../artifacts/ --no-build
 
 clean:
 	rm -rf sdk shared host dotnet tests obj corefx roslyn LICENSE.txt ThirdPartyNotices.txt $(NETCORESDK_FILE) $(ASPNETCORESDK_FILE)

--- a/netcore/metapackage.nuspec
+++ b/netcore/metapackage.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>Microsoft.NETCore.Runtime.Mono</id>
+        <version>$VERSION$</version>
+        <description>Internal implementation package not meant for direct consumption.  Please do not reference directly. 
+The Mono runtime, and the base library, called mscorlib. It includes the garbage collector, JIT compiler, base .NET data types and many low-level classes.</description>
+        <authors>Microsoft</authors>
+        <projectUrl>https://www.mono-project.com/</projectUrl>
+        <dependencies>
+            <dependency id="runtime.win-x64.Microsoft.NETCore.Runtime.Mono" version="$VERSION$" />
+            <dependency id="runtime.osx-x64.Microsoft.NETCore.Runtime.Mono" version="$VERSION$" />
+            <dependency id="runtime.linux-x64.Microsoft.NETCore.Runtime.Mono" version="$VERSION$" />
+        </dependencies>
+    </metadata>
+    <files>
+    </files>
+</package>


### PR DESCRIPTION
Works in local testing.

```
directhex@breakfast:~/Projects/mono/artifacts$ nuget sources add -name moo -source .
Package source with Name: moo added successfully.
directhex@breakfast:~/Projects/mono/artifacts$ nuget install Microsoft.NETCore.Runtime.Mono
Feeds used:
  https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
  https://api.nuget.org/v3/index.json
  /home/directhex/Projects/mono/.

Installing package 'Microsoft.NETCore.Runtime.Mono' to '/home/directhex/Projects/mono/artifacts'.
  GET https://api.nuget.org/v3/registration3-gz-semver2/microsoft.netcore.runtime.mono/index.json
  NotFound https://api.nuget.org/v3/registration3-gz-semver2/microsoft.netcore.runtime.mono/index.json 330ms
  GET https://dotnetfeed.blob.core.windows.net/dotnet-core/registration/microsoft.netcore.runtime.mono/index.json
  NotFound https://dotnetfeed.blob.core.windows.net/dotnet-core/registration/microsoft.netcore.runtime.mono/index.json 362ms


Attempting to gather dependency information for package 'Microsoft.NETCore.Runtime.Mono.6.3.0.774' with respect to project '/home/directhex/Projects/mono/artifacts', targeting 'Any,Version=v0.0'
Gathering dependency information took 809.11 ms
Attempting to resolve dependencies for package 'Microsoft.NETCore.Runtime.Mono.6.3.0.774' with DependencyBehavior 'Lowest'
Resolving dependency information took 0 ms
Resolving actions to install package 'Microsoft.NETCore.Runtime.Mono.6.3.0.774'
Resolved actions to install package 'Microsoft.NETCore.Runtime.Mono.6.3.0.774'
Retrieving package 'Microsoft.NETCore.Runtime.Mono 6.3.0.774' from 'moo'.
Retrieving package 'runtime.linux-x64.Microsoft.NETCore.Runtime.Mono 6.3.0.774' from 'dotnet-core'.
Retrieving package 'runtime.osx-x64.Microsoft.NETCore.Runtime.Mono 6.3.0.774' from 'dotnet-core'.
Retrieving package 'runtime.win-x64.Microsoft.NETCore.Runtime.Mono 6.3.0.774' from 'dotnet-core'.
  GET https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/runtime.linux-x64.microsoft.netcore.runtime.mono/6.3.0.774/runtime.linux-x64.microsoft.netcore.runtime.mono.6.3.0.774.nupkg
  OK https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/runtime.linux-x64.microsoft.netcore.runtime.mono/6.3.0.774/runtime.linux-x64.microsoft.netcore.runtime.mono.6.3.0.774.nupkg 162ms
Installing runtime.linux-x64.Microsoft.NETCore.Runtime.Mono 6.3.0.774.
  GET https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/runtime.win-x64.microsoft.netcore.runtime.mono/6.3.0.774/runtime.win-x64.microsoft.netcore.runtime.mono.6.3.0.774.nupkg
Adding package 'runtime.linux-x64.Microsoft.NETCore.Runtime.Mono.6.3.0.774' to folder '/home/directhex/Projects/mono/artifacts'
Added package 'runtime.linux-x64.Microsoft.NETCore.Runtime.Mono.6.3.0.774' to folder '/home/directhex/Projects/mono/artifacts'
Successfully installed 'runtime.linux-x64.Microsoft.NETCore.Runtime.Mono 6.3.0.774' to /home/directhex/Projects/mono/artifacts
  OK https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/runtime.win-x64.microsoft.netcore.runtime.mono/6.3.0.774/runtime.win-x64.microsoft.netcore.runtime.mono.6.3.0.774.nupkg 175ms
Installing runtime.win-x64.Microsoft.NETCore.Runtime.Mono 6.3.0.774.
  GET https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/runtime.osx-x64.microsoft.netcore.runtime.mono/6.3.0.774/runtime.osx-x64.microsoft.netcore.runtime.mono.6.3.0.774.nupkg
  OK https://dotnetfeed.blob.core.windows.net/dotnet-core/flatcontainer/runtime.osx-x64.microsoft.netcore.runtime.mono/6.3.0.774/runtime.osx-x64.microsoft.netcore.runtime.mono.6.3.0.774.nupkg 153ms
Installing runtime.osx-x64.Microsoft.NETCore.Runtime.Mono 6.3.0.774.
Adding package 'runtime.osx-x64.Microsoft.NETCore.Runtime.Mono.6.3.0.774' to folder '/home/directhex/Projects/mono/artifacts'
Added package 'runtime.osx-x64.Microsoft.NETCore.Runtime.Mono.6.3.0.774' to folder '/home/directhex/Projects/mono/artifacts'
Successfully installed 'runtime.osx-x64.Microsoft.NETCore.Runtime.Mono 6.3.0.774' to /home/directhex/Projects/mono/artifacts
Adding package 'runtime.win-x64.Microsoft.NETCore.Runtime.Mono.6.3.0.774' to folder '/home/directhex/Projects/mono/artifacts'
Added package 'runtime.win-x64.Microsoft.NETCore.Runtime.Mono.6.3.0.774' to folder '/home/directhex/Projects/mono/artifacts'
Successfully installed 'runtime.win-x64.Microsoft.NETCore.Runtime.Mono 6.3.0.774' to /home/directhex/Projects/mono/artifacts
Adding package 'Microsoft.NETCore.Runtime.Mono.6.3.0.774' to folder '/home/directhex/Projects/mono/artifacts'
Added package 'Microsoft.NETCore.Runtime.Mono.6.3.0.774' to folder '/home/directhex/Projects/mono/artifacts'
Successfully installed 'Microsoft.NETCore.Runtime.Mono 6.3.0.774' to /home/directhex/Projects/mono/artifacts
Executing nuget actions took 3.91 sec

```