### PR TITLE
[crash] Move /proc/self/maps crash collection to created JSON blob

### DIFF
--- a/mono/eglib/eglib-remap.h
+++ b/mono/eglib/eglib-remap.h
@@ -133,6 +133,7 @@
 #define g_pattern_match_string monoeg_g_pattern_match_string
 #define g_pattern_spec_free monoeg_g_pattern_spec_free
 #define g_pattern_spec_new monoeg_g_pattern_spec_new
+#define g_async_safe_fgets monoeg_g_async_safe_fgets
 #define g_async_safe_fprintf monoeg_g_async_safe_fprintf
 #define g_async_safe_vfprintf monoeg_g_async_safe_vfprintf
 #define g_async_safe_printf monoeg_g_async_safe_printf

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -1146,7 +1146,7 @@ gchar *g_mkdtemp (gchar *tmpl);
 static inline int
 g_async_safe_fgets (char *str, int num, int handle, gboolean *newline)
 {
-	memset (str, '\0', sizeof(char) * num);
+	memset (str, 0, num);
 	// Make sure we always have null-termination
 	int without_padding = num - 1;
 	int i=0;

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -1157,9 +1157,13 @@ g_async_safe_fgets (char *str, int num, int handle, gboolean *newline)
 			str [i] = '\0';
 			*newline = TRUE;
 		}
+		
+		if (!isprint (str [i]))
+			str [i] = '\0';
 
 		if (str [i] == '\0')
 			break;
+
 		i++;
 	}
 

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -1147,12 +1147,11 @@ static inline int
 g_async_safe_fgets (char *str, int num, int handle, gboolean *newline)
 {
 	memset (str, 0, num);
-	// Make sure we always have null-termination
+	// Make sure we don't overwrite the last index so that we are
+	// guaranteed to be NULL-terminated
 	int without_padding = num - 1;
 	int i=0;
-	char scratch [2];
-	while (i < without_padding && g_read (handle, scratch, sizeof(char))) {
-		str [i] = scratch [0];
+	while (i < without_padding && g_read (handle, &str [i], sizeof(char))) {
 		if (str [i] == '\n') {
 			str [i] = '\0';
 			*newline = TRUE;

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -908,7 +908,7 @@ dump_memory_around_ip (MonoContext *mctx)
 static void
 print_process_map (void)
 {
-#ifdef __linux__
+#if defined(__linux__) && !defined(HOST_ANDROID)
 	FILE *fp = fopen ("/proc/self/maps", "r");
 	char line [256];
 

--- a/mono/mini/mini-posix.c
+++ b/mono/mini/mini-posix.c
@@ -906,37 +906,6 @@ dump_memory_around_ip (MonoContext *mctx)
 }
 
 static void
-print_process_map (void)
-{
-#if defined(__linux__) && !defined(HOST_ANDROID)
-	FILE *fp = fopen ("/proc/self/maps", "r");
-	char line [256];
-
-	if (fp == NULL) {
-		mono_runtime_printf_err ("no /proc/self/maps, not on linux?\n");
-		return;
-	}
-
-	mono_runtime_printf_err ("/proc/self/maps:");
-	const int max_lines = 25;
-	int i = 0;
-
-	while (fgets (line, sizeof (line), fp) && i++ < max_lines) {
-		// strip newline
-		size_t len = strlen (line);
-		if (len > 0 && line [len - 1] == '\n')
-			line [len - 1] = '\0';
-
-		mono_runtime_printf_err ("%s", line);
-	}
-
-	fclose (fp);
-#else
-	/* do nothing */
-#endif
-}
-
-static void
 assert_printer_callback (void)
 {
 	mono_dump_native_crash_info ("SIGABRT", NULL, NULL);
@@ -1153,8 +1122,6 @@ dump_native_stacktrace (const char *signal, MonoContext *mctx)
 void
 mono_dump_native_crash_info (const char *signal, MonoContext *mctx, MONO_SIG_HANDLER_INFO_TYPE *info)
 {
-	print_process_map ();
-
 	dump_native_stacktrace (signal, mctx);
 
 	dump_memory_around_ip (mctx);

--- a/mono/utils/mono-linked-list-set.h
+++ b/mono/utils/mono-linked-list-set.h
@@ -102,8 +102,8 @@ mono_lls_filter_accept_all (gpointer elem, gpointer dummy)
 		MonoLinkedListSet *list__ = (list); \
 		MonoThreadHazardPointers *hp__ = mono_hazard_pointer_get (); \
 		gboolean progress__ = FALSE; \
-		uintptr_t hkey__; \
-		gboolean restart__; \
+		uintptr_t hkey__ = 0; \
+		gboolean restart__ = FALSE; \
 		do { \
 			restart__ = FALSE; \
 			MonoLinkedListSetNode **prev__ = &list__->head; \

--- a/mono/utils/mono-merp.c
+++ b/mono/utils/mono-merp.c
@@ -372,7 +372,7 @@ mono_merp_write_fingerprint_payload (const char *non_param_data, const MERPStruc
 
 	g_async_safe_fprintf(handle, "{\n");
 	g_async_safe_fprintf(handle, "\t\"payload\" : \n");
-	g_write (handle, non_param_data, (guint32)strlen (non_param_data));	\
+	g_write (handle, non_param_data, (guint32)strlen (non_param_data));
 	g_async_safe_fprintf(handle, ",\n");
 
 	g_async_safe_fprintf(handle, "\t\"parameters\" : \n{\n");

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -952,12 +952,17 @@ mono_native_state_add_process_map (MonoStateWriter *writer)
 		mono_state_writer_printf (writer, "\t\"");
 
 		while (TRUE) {
-			char line [25];
+			char line [10];
 			gboolean newline = FALSE;
 			int charsCopied = g_async_safe_fgets (line, sizeof (line), handle, &newline);
 
 			if (charsCopied == 0)
 				break;
+
+			for (int i=0; i < charsCopied; i++)
+				g_assert (isprint (line [i]));
+
+			g_assert (line [charsCopied] == '\0');
 
 			mono_state_writer_printf (writer, "%s", line);
 

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -933,15 +933,6 @@ static void
 mono_native_state_add_process_map (MonoStateWriter *writer)
 {
 #if defined(__linux__) && !defined(HOST_ANDROID)
-	static gint32 handle_in_use;
-	gint32 old = mono_atomic_cas_i32 (&handle_in_use, TRUE /* set */, FALSE /* compare */);
-	if (old != FALSE) {
-		g_async_safe_printf ("Warning: Couldn't open /proc/self/maps for concurrent reads, crash report will lack it.\n");
-		return;
-	}
-
-	mono_memory_barrier ();
-
 	int handle = g_open ("/proc/self/maps", O_RDONLY, S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH);
 	if (handle == -1) {
 		g_async_safe_printf ("Couldn't find /proc/self/maps on Linux system. Continuing.");
@@ -990,9 +981,6 @@ mono_native_state_add_process_map (MonoStateWriter *writer)
 	mono_state_writer_printf(writer, "],\n");
 
 	close (handle);
-
-	mono_atomic_store_i32 (&handle_in_use, FALSE);
-	mono_memory_barrier ();
 #endif
 }
 

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -927,6 +927,58 @@ mono_native_state_add_memory (MonoStateWriter *writer)
 	mono_state_writer_printf(writer, "},\n");
 }
 
+#define MONO_CRASH_REPORTING_MAPPING_LINE_LIMIT 30
+
+static void
+mono_native_state_add_process_map (MonoStateWriter *writer)
+{
+#if defined(__linux__) && !defined(HOST_ANDROID)
+	int handle = g_open ("/proc/self/maps", O_RDONLY, S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH);
+	if (handle == -1) {
+		g_async_safe_printf ("Couldn't find /proc/self/maps on Linux system. Continuing.");
+		return;
+	}
+
+	assert_has_space (writer);
+	mono_state_writer_indent (writer);
+	mono_state_writer_object_key (writer, "process_map");
+	mono_state_writer_printf(writer, "[\n");
+
+	int mapping = 0;
+	while (mapping < MONO_CRASH_REPORTING_MAPPING_LINE_LIMIT) {
+		if (mapping > 0)
+			mono_state_writer_printf (writer, "\",\n");
+
+		mono_state_writer_printf (writer, "\t\"");
+
+		while (TRUE) {
+			char line [25];
+			gboolean newline = FALSE;
+			int charsCopied = g_async_safe_fgets (line, sizeof (line), handle, &newline);
+
+			if (charsCopied == 0)
+				break;
+
+			mono_state_writer_printf (writer, "%s", line);
+
+			if (newline)
+				break;
+		}
+
+		mapping++;
+	}
+
+	if (mapping > 0)
+		mono_state_writer_printf (writer, "\"");
+
+	mono_state_writer_indent (writer);
+	writer->indent--;
+	mono_state_writer_printf(writer, "],\n");
+
+	close (handle);
+#endif
+}
+
 static void
 mono_native_state_add_prologue (MonoStateWriter *writer)
 {
@@ -960,6 +1012,10 @@ mono_native_state_add_prologue (MonoStateWriter *writer)
 
 		mono_state_writer_printf(writer, "\"%.*s\",\n", (int)length, assertion_msg);
 	}
+
+#ifndef MONO_PRIVATE_CRASHES
+	mono_native_state_add_process_map (writer);
+#endif
 
 	// Start threads array
 	assert_has_space (writer);


### PR DESCRIPTION
Previously, we would simply print the mapping to stdout. 

Since the pointers that are embedded into crash reports will point into these native modules, providing the mapping to module names helps someone debugging using the JSON to track down where a pointer came from.

Example report: https://gist.github.com/alexanderkyte/578b4e2f82a0e71a169c37d8bc18a305

Because of the fact that this is sending file paths from the end-user's machine, I have disabled it when we have crash privacy enabled. 