### PR TITLE
Propagate error in mono_file_map_error on posix implementation

### DIFF
--- a/mono/utils/mono-mmap.c
+++ b/mono/utils/mono-mmap.c
@@ -364,6 +364,13 @@ mono_vfree (void *addr, size_t length, MonoMemAccountType type)
 void*
 mono_file_map (size_t length, int flags, int fd, guint64 offset, void **ret_handle)
 {
+	return mono_file_map_error (length, flags, fd, offset, ret_handle, NULL, NULL);
+}
+
+void*
+mono_file_map_error (size_t length, int flags, int fd, guint64 offset, void **ret_handle,
+	const char *filepath, char **error_message)
+{
 	void *ptr;
 	int mflags = 0;
 	int prot = prot_from_flags (flags);
@@ -380,23 +387,23 @@ mono_file_map (size_t length, int flags, int fd, guint64 offset, void **ret_hand
 #ifdef HOST_WASM
 	if (length == 0)
 		/* emscripten throws an exception on 0 length */
+		*error_message = g_stdrup_printf ("%s failed file:%s length:0x%zx offset:0x%lluX error:%s\n",
+			__func__, filepath ? filepath : "", length, offset, "mmaps of zero length are not permitted with emscripten");
 		return NULL;
 #endif
 
 	BEGIN_CRITICAL_SECTION;
 	ptr = mmap (0, length, prot, mflags, fd, offset);
 	END_CRITICAL_SECTION;
-	if (ptr == MAP_FAILED)
+	if (ptr == MAP_FAILED) {
+		if (error_message) {
+			*error_message = g_strdup_printf ("%s failed file:%s length:0x%zX offset:0x%lluX error:%s(0x%X)\n",
+				__func__, filepath ? filepath : "", length, offset, g_strerror (errno), errno);
+		}
 		return NULL;
+	}
 	*ret_handle = (void*)length;
 	return ptr;
-}
-
-void*
-mono_file_map_error (size_t length, int flags, int fd, guint64 offset, void **ret_handle,
-	const char *filepath, char **error_message)
-{
-	return mono_file_map (length, flags, fd, offset, ret_handle);
 }
 
 /**


### PR DESCRIPTION
Fixes #14594

This should make the behavior consistent with Windows. The commit adding the emscripten-related length check didn't specify the exact exception, so I just put something that's as descriptive as possible.