### PR TITLE
Batch of runtime warning fixes on Darwin

### DIFF
--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -786,6 +786,7 @@ HANDLES(MARSHAL_47, "GetObjectForCCW", ves_icall_System_Runtime_InteropServices_
 HANDLES(MARSHAL_54, "GetRawIUnknownForComObjectNoAddRef", ves_icall_System_Runtime_InteropServices_Marshal_GetRawIUnknownForComObjectNoAddRef, gpointer, 1, (MonoObject))
 HANDLES(MARSHAL_48, "IsComObject", ves_icall_System_Runtime_InteropServices_Marshal_IsComObject, MonoBoolean, 1, (MonoObject))
 #endif
+HANDLES(MARSHAL_48a, "IsPinnableType", ves_icall_System_Runtime_InteropServices_Marshal_IsPinnableType, MonoBoolean, 1, (MonoReflectionType))
 HANDLES(MARSHAL_12, "OffsetOf", ves_icall_System_Runtime_InteropServices_Marshal_OffsetOf, int, 2, (MonoReflectionType, MonoString))
 HANDLES(MARSHAL_13, "Prelink", ves_icall_System_Runtime_InteropServices_Marshal_Prelink, void, 1, (MonoReflectionMethod))
 HANDLES(MARSHAL_14, "PrelinkAll", ves_icall_System_Runtime_InteropServices_Marshal_PrelinkAll, void, 1, (MonoReflectionType))

--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -6543,7 +6543,6 @@ emit_vtfixup_ftnptr_ilgen (MonoMethodBuilder *mb, MonoMethod *method, int param_
 static void
 emit_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoJitICallInfo *callinfo, MonoMethodSignature *csig2, gboolean check_exceptions)
 {
-	gconstpointer const func = callinfo->func;
 	MonoMethodSignature *const sig = callinfo->sig;
 
 	if (sig->hasthis)

--- a/mono/metadata/method-builder-ilgen.c
+++ b/mono/metadata/method-builder-ilgen.c
@@ -546,8 +546,6 @@ mono_mb_emit_native_call (MonoMethodBuilder *mb, MonoMethodSignature *sig, gpoin
 void
 mono_mb_emit_icall_id (MonoMethodBuilder *mb, MonoJitICallId jit_icall_id)
 {
-	MonoJitICallInfo const * const jit_icall_info = mono_find_jit_icall_info (jit_icall_id);
-
 	mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
 	mono_mb_emit_byte (mb, CEE_MONO_ICALL);
 	mono_mb_emit_i4 (mb, jit_icall_id);

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -7196,10 +7196,10 @@ get_plt_entry_debug_sym (MonoAotCompile *acfg, MonoJumpInfo *ji, GHashTable *cac
 		break;
 	}
 	case MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR:
-		debug_sym = g_strdup_printf ("%s_jit_icall_native_trampoline_func_%d", prefix, ji->data.index);
+		debug_sym = g_strdup_printf ("%s_jit_icall_native_trampoline_func_%li", prefix, ji->data.index);
 		break;
 	case MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR:
-		debug_sym = g_strdup_printf ("%s_jit_icall_native_specific_trampoline_lazy_fetch_%u", prefix, ji->data.uindex);
+		debug_sym = g_strdup_printf ("%s_jit_icall_native_specific_trampoline_lazy_fetch_%lu", prefix, ji->data.uindex);
 		break;
 	case MONO_PATCH_INFO_JIT_ICALL_ADDR:
 		debug_sym = g_strdup_printf ("%s_jit_icall_native_%s", prefix, mono_find_jit_icall_info (ji->data.jit_icall_id)->name);

--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -1049,8 +1049,7 @@ mono_arch_get_native_to_interp_trampoline (MonoTrampInfo **info)
 	guint8 *start = NULL, *code;
 	MonoJumpInfo *ji = NULL;
 	GSList *unwind_ops = NULL;
-	int buf_len, i, frame_size, cfa_offset, ctx_offset;
-	int framesize;
+	int buf_len, i, framesize, cfa_offset, ctx_offset;
 
 	buf_len = 512;
 	start = code = (guint8 *) mono_global_codeman_reserve (buf_len + MONO_MAX_TRAMPOLINE_UNWINDINFO_SIZE);

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -262,7 +262,7 @@ mono_state_alloc_mem (MonoStateMem *mem, long tag, size_t size)
 	memset (mem, 0, sizeof (*mem));
 	mem->tag = tag;
 	mem->size = size;
-	mem->handle = NULL;
+	mem->handle = 0;
 
 	if (!g_hasenv ("MONO_CRASH_NOFILE"))
 		mem->handle = g_open (name, O_RDWR | O_CREAT | O_EXCL, S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH);


### PR DESCRIPTION
Warnings resolved, in no particular order:

```
mono-state.c:265:14: warning: incompatible pointer to integer conversion assigning to 'gint' (aka 'int') from 'void *' [-Wint-conversion]
        mem->handle = NULL;

marshal.c:5550:1: warning: no previous prototype for function 'ves_icall_System_Runtime_InteropServices_Marshal_IsPinnableType' [-Wmissing-prototypes]
ves_icall_System_Runtime_InteropServices_Marshal_IsPinnableType (MonoReflectionTypeHandle type_h, MonoError *error)

method-builder-ilgen.c:549:33: warning: unused variable 'jit_icall_info' [-Wunused-variable]
        MonoJitICallInfo const * const jit_icall_info = mono_find_jit_icall_info (jit_icall_id);

marshal-ilgen.c:6546:22: warning: unused variable 'func' [-Wunused-variable]
        gconstpointer const func = callinfo->func;

aot-compiler.c:7199:82: warning: format specifies type 'int' but the argument has type 'gssize' (aka 'long') [-Wformat]
                debug_sym = g_strdup_printf ("%s_jit_icall_native_trampoline_func_%d", prefix, ji->data.index);

aot-compiler.c:7202:97: warning: format specifies type 'unsigned int' but the argument has type 'gsize' (aka 'unsigned long') [-Wformat]
                debug_sym = g_strdup_printf ("%s_jit_icall_native_specific_trampoline_lazy_fetch_%u", prefix, ji->data.uindex);

tramp-amd64.c:1052:18: warning: unused variable 'frame_size' [-Wunused-variable]
        int buf_len, i, frame_size, cfa_offset, ctx_offset;
```
