### PR TITLE
Increase main thread stack size on Windows.

### DIFF
--- a/msvc/mono.vcxproj
+++ b/msvc/mono.vcxproj
@@ -107,6 +107,7 @@
       <SubSystem>Console</SubSystem>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
+      <StackReserveSize>0x800000</StackReserveSize>
     </Link>
     <ProjectReference>
       <LinkLibraryDependencies>false</LinkLibraryDependencies>
@@ -141,6 +142,7 @@ xcopy "$(SolutionDir)setup-vs-msvcbuild-env.bat" "$(OutDir)" /q /y &gt;nul 2&gt;
       <SubSystem>Console</SubSystem>
       <ShowProgress>
       </ShowProgress>
+      <StackReserveSize>0x800000</StackReserveSize>
     </Link>
     <PostBuildEvent>
       <Command>xcopy "$(SolutionDir)mono-sgen-msvc.sh" "$(OutDir)" /q /y &gt;nul 2&gt;&amp;1
@@ -168,6 +170,7 @@ xcopy "$(SolutionDir)setup-vs-msvcbuild-env.bat" "$(OutDir)" /q /y &gt;nul 2&gt;
       <SubSystem>Console</SubSystem>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
+      <StackReserveSize>0x180000</StackReserveSize>
     </Link>
     <PostBuildEvent>
       <Command>xcopy "$(SolutionDir)mono-sgen-msvc.sh" "$(OutDir)" /q /y &gt;nul 2&gt;&amp;1
@@ -196,6 +199,7 @@ xcopy "$(SolutionDir)setup-vs-msvcbuild-env.bat" "$(OutDir)" /q /y &gt;nul 2&gt;
     <Link>
       <AdditionalDependencies>$(MONO_LIBMONO_LIB);%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
+      <StackReserveSize>0x180000</StackReserveSize>
     </Link>
     <PostBuildEvent>
       <Command>xcopy "$(SolutionDir)mono-sgen-msvc.sh" "$(OutDir)" /q /y &gt;nul 2&gt;&amp;1


### PR DESCRIPTION
On Windows default thread stack size has been 1MB for a long time (both 32/64-bit). When starting to use interpreter some of the tests include deep recursions that will hit stackoverflow on Windows(ackermann.exe as one example). This commit adjust the default reserved stack size to 8MB for debug builds and 1.5MB for release builds (same as coreclr), for main thread only. All other threads will still default to 1MB stack size (both debug/release).