### PR TITLE
Change in process_complete_path exposed uninitialized variable error.

### DIFF
--- a/mono/metadata/w32process-win32.c
+++ b/mono/metadata/w32process-win32.c
@@ -239,6 +239,7 @@ process_complete_path (const gunichar2 *appname, gchar **completed)
 	}
 
 	*completed = process_quote_path (found);
+	result = TRUE;
 exit:
 	g_free (found);
 	g_free (utf8appmemory);


### PR DESCRIPTION
https://github.com/mono/mono/commit/5d088cf0de7f3e50e3547dba361af4401e938dd4 exposed a problem with an uninitialized variable, only exposed on some build configurations, 32-bit Windows release builds.
