### PR TITLE
[runtime] Autoconf check for pthread_mutexattr_setprotocol

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2646,6 +2646,8 @@ if test x$host_win32 = xno; then
 	AC_CHECK_FUNCS(pthread_attr_setstacksize)
 	AC_CHECK_FUNCS(pthread_attr_getstack pthread_attr_getstacksize)
 	AC_CHECK_FUNCS(pthread_get_stacksize_np pthread_get_stackaddr_np)
+	dnl check that pthread_mutexattr_setprotocol is declared
+	AC_CHECK_DECLS([pthread_mutexattr_setprotocol], [], [], [[#include <pthread.h>]])
 	AC_CHECK_FUNCS(mincore mlock munlock)
 
 	dnl ***********************************

--- a/mono/utils/mono-os-mutex.h
+++ b/mono/utils/mono-os-mutex.h
@@ -57,7 +57,7 @@ mono_os_mutex_init_type (mono_mutex_t *mutex, int type)
 	if (G_UNLIKELY (res != 0))
 		g_error ("%s: pthread_mutexattr_settype failed with \"%s\" (%d)", __func__, g_strerror (res), res);
 
-#ifdef PTHREAD_PRIO_INHERIT
+#if defined (PTHREAD_PRIO_INHERIT) && HAVE_DECL_PTHREAD_MUTEXATTR_SETPROTOCOL
 	/* use PTHREAD_PRIO_INHERIT if possible */
 	res = pthread_mutexattr_setprotocol (&attr, PTHREAD_PRIO_INHERIT);
 	if (G_UNLIKELY (res != 0 && res != ENOTSUP))


### PR DESCRIPTION
Android doesn't always declare that function.

Alternative to #14798
