### PR TITLE
[System.IO.Compression] Make Brotli throw PlatformNotSupportedException on mobile

### DIFF
--- a/mcs/class/System.IO.Compression/System.IO.Compression.csproj
+++ b/mcs/class/System.IO.Compression/System.IO.Compression.csproj
@@ -152,6 +152,7 @@
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="TypeForwarders.cs" />
     <Compile Include="corefx\Crc32Helper.cs" />
+    <Compile Include="corefx\Interop.Libraries.cs" />
     <Compile Include="corefx\SR.cs" />
     <Compile Include="corefx\ZipArchiveEntry.Mono.cs" />
     <ProjectReference Include="$(SolutionDir)\msvc\scripts\genconsts.csproj">
@@ -165,39 +166,6 @@
   <!--End of common files-->
   <!--Per-profile files-->
   <Choose>
-    <When Condition="'$(Platform)' == 'xammac'">
-      <ItemGroup>
-        <Compile Include="..\..\..\external\corefx\src\System.IO.Compression.Brotli\src\Interop\Interop.Brotli.Decoder.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.IO.Compression.Brotli\src\Interop\Interop.Brotli.Encoder.cs" />
-        <Compile Include="corefx\Interop.Libraries.cs" />
-      </ItemGroup>
-    </When>
-    <When Condition="'$(Platform)' == 'winaot'">
-      <ItemGroup>
-        <Compile Include="corefx\BrotliStubs.cs" />
-      </ItemGroup>
-    </When>
-    <When Condition="'$(Platform)' == 'wasm'">
-      <ItemGroup>
-        <Compile Include="..\..\..\external\corefx\src\System.IO.Compression.Brotli\src\Interop\Interop.Brotli.Decoder.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.IO.Compression.Brotli\src\Interop\Interop.Brotli.Encoder.cs" />
-        <Compile Include="corefx\Interop.Libraries.cs" />
-      </ItemGroup>
-    </When>
-    <When Condition="'$(Platform)' == 'unreal'">
-      <ItemGroup>
-        <Compile Include="..\..\..\external\corefx\src\System.IO.Compression.Brotli\src\Interop\Interop.Brotli.Decoder.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.IO.Compression.Brotli\src\Interop\Interop.Brotli.Encoder.cs" />
-        <Compile Include="corefx\Interop.Libraries.cs" />
-      </ItemGroup>
-    </When>
-    <When Condition="'$(Platform)' == 'orbis'">
-      <ItemGroup>
-        <Compile Include="..\..\..\external\corefx\src\System.IO.Compression.Brotli\src\Interop\Interop.Brotli.Decoder.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.IO.Compression.Brotli\src\Interop\Interop.Brotli.Encoder.cs" />
-        <Compile Include="corefx\Interop.Libraries.cs" />
-      </ItemGroup>
-    </When>
     <When Condition="'$(Platform)' == 'net_4_x'">
       <!--Per-host-platform files-->
       <Choose>
@@ -210,54 +178,28 @@
           <ItemGroup>
             <Compile Include="..\..\..\external\corefx\src\System.IO.Compression.Brotli\src\Interop\Interop.Brotli.Decoder.cs" />
             <Compile Include="..\..\..\external\corefx\src\System.IO.Compression.Brotli\src\Interop\Interop.Brotli.Encoder.cs" />
-            <Compile Include="corefx\Interop.Libraries.cs" />
           </ItemGroup>
         </When>
         <When Condition="'$(HostPlatform)' == 'macos'">
           <ItemGroup>
             <Compile Include="..\..\..\external\corefx\src\System.IO.Compression.Brotli\src\Interop\Interop.Brotli.Decoder.cs" />
             <Compile Include="..\..\..\external\corefx\src\System.IO.Compression.Brotli\src\Interop\Interop.Brotli.Encoder.cs" />
-            <Compile Include="corefx\Interop.Libraries.cs" />
           </ItemGroup>
         </When>
         <When Condition="'$(HostPlatform)' == 'linux'">
           <ItemGroup>
             <Compile Include="..\..\..\external\corefx\src\System.IO.Compression.Brotli\src\Interop\Interop.Brotli.Decoder.cs" />
             <Compile Include="..\..\..\external\corefx\src\System.IO.Compression.Brotli\src\Interop\Interop.Brotli.Encoder.cs" />
-            <Compile Include="corefx\Interop.Libraries.cs" />
           </ItemGroup>
         </When>
       </Choose>
       <!--End of per-host-platform files-->
     </When>
-    <When Condition="'$(Platform)' == 'monotouch_watch'">
+    <Otherwise>
       <ItemGroup>
-        <Compile Include="..\..\..\external\corefx\src\System.IO.Compression.Brotli\src\Interop\Interop.Brotli.Decoder.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.IO.Compression.Brotli\src\Interop\Interop.Brotli.Encoder.cs" />
-        <Compile Include="corefx\Interop.Libraries.cs" />
+        <Compile Include="corefx\BrotliStubs.cs" />
       </ItemGroup>
-    </When>
-    <When Condition="'$(Platform)' == 'monotouch_tv'">
-      <ItemGroup>
-        <Compile Include="..\..\..\external\corefx\src\System.IO.Compression.Brotli\src\Interop\Interop.Brotli.Decoder.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.IO.Compression.Brotli\src\Interop\Interop.Brotli.Encoder.cs" />
-        <Compile Include="corefx\Interop.Libraries.cs" />
-      </ItemGroup>
-    </When>
-    <When Condition="'$(Platform)' == 'monotouch'">
-      <ItemGroup>
-        <Compile Include="..\..\..\external\corefx\src\System.IO.Compression.Brotli\src\Interop\Interop.Brotli.Decoder.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.IO.Compression.Brotli\src\Interop\Interop.Brotli.Encoder.cs" />
-        <Compile Include="corefx\Interop.Libraries.cs" />
-      </ItemGroup>
-    </When>
-    <When Condition="'$(Platform)' == 'monodroid'">
-      <ItemGroup>
-        <Compile Include="..\..\..\external\corefx\src\System.IO.Compression.Brotli\src\Interop\Interop.Brotli.Decoder.cs" />
-        <Compile Include="..\..\..\external\corefx\src\System.IO.Compression.Brotli\src\Interop\Interop.Brotli.Encoder.cs" />
-        <Compile Include="corefx\Interop.Libraries.cs" />
-      </ItemGroup>
-    </When>
+    </Otherwise>
   </Choose>
   <!--End of per-profile files-->
   <!-- @ALL_SOURCES@ -->

--- a/mcs/class/System.IO.Compression/System.IO.Compression.dll.sources
+++ b/mcs/class/System.IO.Compression/System.IO.Compression.dll.sources
@@ -41,6 +41,6 @@ corefx/SR.cs
 ../../../external/corefx/src/System.IO.Compression.Brotli/src/System/IO/Compression/dec/*.cs
 ../../../external/corefx/src/System.IO.Compression.Brotli/src/System/IO/Compression/enc/*.cs
 ../../../external/corefx/src/System.IO.Compression.Brotli/src/System/IO/Compression/*.cs
-../../../external/corefx/src/System.IO.Compression.Brotli/src/Interop/*.cs
 ../../../external/corefx/src/Common/src/Microsoft/Win32/SafeHandles/SafeBrotliHandle.cs
 corefx/Interop.Libraries.cs
+corefx/BrotliStubs.cs

--- a/mcs/class/System.IO.Compression/System.IO.Compression_xtest.dll.sources
+++ b/mcs/class/System.IO.Compression/System.IO.Compression_xtest.dll.sources
@@ -1,5 +1,4 @@
 ../../../external/corefx/src/CoreFx.Private.TestUtilities/src/System/AssertExtensions.cs
-../../../external/corefx/src/System.IO.Compression.Brotli/tests/BrotliEncoderTests.cs
 ../../../external/corefx/src/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
 ../../../external/corefx/src/Common/tests/System/IO/Compression/CompressionStreamTestBase.cs
 ../../../external/corefx/src/Common/tests/System/IO/Compression/LocalMemoryStream.cs

--- a/mcs/class/System.IO.Compression/linux_net_4_x_System.IO.Compression.dll.exclude.sources
+++ b/mcs/class/System.IO.Compression/linux_net_4_x_System.IO.Compression.dll.exclude.sources
@@ -1,0 +1,1 @@
+corefx/BrotliStubs.cs

--- a/mcs/class/System.IO.Compression/linux_net_4_x_System.IO.Compression.dll.sources
+++ b/mcs/class/System.IO.Compression/linux_net_4_x_System.IO.Compression.dll.sources
@@ -1,0 +1,2 @@
+#include System.IO.Compression.dll.sources
+../../../external/corefx/src/System.IO.Compression.Brotli/src/Interop/*.cs

--- a/mcs/class/System.IO.Compression/linux_net_4_x_System.IO.Compression_xtest.dll.sources
+++ b/mcs/class/System.IO.Compression/linux_net_4_x_System.IO.Compression_xtest.dll.sources
@@ -1,1 +1,2 @@
+#include System.IO.Compression_xtest.dll.sources
 ../../../external/corefx/src/System.IO.Compression.Brotli/tests/BrotliEncoderTests.cs

--- a/mcs/class/System.IO.Compression/macos_net_4_x_System.IO.Compression.dll.exclude.sources
+++ b/mcs/class/System.IO.Compression/macos_net_4_x_System.IO.Compression.dll.exclude.sources
@@ -1,0 +1,1 @@
+corefx/BrotliStubs.cs

--- a/mcs/class/System.IO.Compression/macos_net_4_x_System.IO.Compression.dll.sources
+++ b/mcs/class/System.IO.Compression/macos_net_4_x_System.IO.Compression.dll.sources
@@ -1,0 +1,2 @@
+#include System.IO.Compression.dll.sources
+../../../external/corefx/src/System.IO.Compression.Brotli/src/Interop/*.cs

--- a/mcs/class/System.IO.Compression/macos_net_4_x_System.IO.Compression_xtest.dll.sources
+++ b/mcs/class/System.IO.Compression/macos_net_4_x_System.IO.Compression_xtest.dll.sources
@@ -1,0 +1,2 @@
+#include System.IO.Compression_xtest.dll.sources
+../../../external/corefx/src/System.IO.Compression.Brotli/tests/BrotliEncoderTests.cs

--- a/mcs/class/System.IO.Compression/unix_net_4_x_System.IO.Compression.dll.exclude.sources
+++ b/mcs/class/System.IO.Compression/unix_net_4_x_System.IO.Compression.dll.exclude.sources
@@ -1,0 +1,1 @@
+corefx/BrotliStubs.cs

--- a/mcs/class/System.IO.Compression/unix_net_4_x_System.IO.Compression.dll.sources
+++ b/mcs/class/System.IO.Compression/unix_net_4_x_System.IO.Compression.dll.sources
@@ -1,0 +1,2 @@
+#include System.IO.Compression.dll.sources
+../../../external/corefx/src/System.IO.Compression.Brotli/src/Interop/*.cs

--- a/mcs/class/System.IO.Compression/unix_net_4_x_System.IO.Compression_xtest.dll.sources
+++ b/mcs/class/System.IO.Compression/unix_net_4_x_System.IO.Compression_xtest.dll.sources
@@ -1,0 +1,2 @@
+#include System.IO.Compression_xtest.dll.sources
+../../../external/corefx/src/System.IO.Compression.Brotli/tests/BrotliEncoderTests.cs

--- a/mcs/class/System.IO.Compression/win32_net_4_x_System.IO.Compression.dll.exclude.sources
+++ b/mcs/class/System.IO.Compression/win32_net_4_x_System.IO.Compression.dll.exclude.sources
@@ -1,3 +1,0 @@
-corefx/Interop.Libraries.cs
-../../../external/corefx/src/System.IO.Compression.Brotli/src/Interop/Interop.Brotli.Decoder.cs
-../../../external/corefx/src/System.IO.Compression.Brotli/src/Interop/Interop.Brotli.Encoder.cs

--- a/mcs/class/System.IO.Compression/win32_net_4_x_System.IO.Compression.dll.sources
+++ b/mcs/class/System.IO.Compression/win32_net_4_x_System.IO.Compression.dll.sources
@@ -1,5 +1,0 @@
-#include System.IO.Compression.dll.sources
-corefx/BrotliStubs.cs
-
-# for clrcompression.dll (instead of BrotliStubs for Windows)
-#../../../external/corefx/src/Common/src/Interop/Windows/Interop.Libraries.cs

--- a/mcs/class/System.IO.Compression/winaot_System.IO.Compression.dll.exclude.sources
+++ b/mcs/class/System.IO.Compression/winaot_System.IO.Compression.dll.exclude.sources
@@ -1,3 +1,0 @@
-corefx/Interop.Libraries.cs
-../../../external/corefx/src/System.IO.Compression.Brotli/src/Interop/Interop.Brotli.Decoder.cs
-../../../external/corefx/src/System.IO.Compression.Brotli/src/Interop/Interop.Brotli.Encoder.cs

--- a/mcs/class/System.IO.Compression/winaot_System.IO.Compression.dll.sources
+++ b/mcs/class/System.IO.Compression/winaot_System.IO.Compression.dll.sources
@@ -1,1 +1,0 @@
-#include win32_net_4_x_System.IO.Compression.dll.sources

--- a/mono/native/Makefile.am
+++ b/mono/native/Makefile.am
@@ -29,29 +29,7 @@ common_sources = \
 	../../external/corefx/src/Native/Unix/System.Native/pal_uid.c \
 	../../external/corefx/src/Native/Unix/System.Native/pal_uid.h \
 	../../external/corefx/src/Native/Unix/System.Native/pal_time.c \
-	../../external/corefx/src/Native/Unix/System.Native/pal_time.h \
-	../../external/corefx/src/Native/AnyOS/brotli/enc/dictionary_hash.c \
-	../../external/corefx/src/Native/AnyOS/brotli/enc/backward_references_hq.c \
-	../../external/corefx/src/Native/AnyOS/brotli/enc/histogram.c \
-	../../external/corefx/src/Native/AnyOS/brotli/enc/memory.c \
-	../../external/corefx/src/Native/AnyOS/brotli/enc/entropy_encode.c \
-	../../external/corefx/src/Native/AnyOS/brotli/enc/compress_fragment_two_pass.c \
-	../../external/corefx/src/Native/AnyOS/brotli/enc/block_splitter.c \
-	../../external/corefx/src/Native/AnyOS/brotli/enc/encode.c \
-	../../external/corefx/src/Native/AnyOS/brotli/enc/cluster.c \
-	../../external/corefx/src/Native/AnyOS/brotli/enc/backward_references.c \
-	../../external/corefx/src/Native/AnyOS/brotli/enc/utf8_util.c \
-	../../external/corefx/src/Native/AnyOS/brotli/enc/compress_fragment.c \
-	../../external/corefx/src/Native/AnyOS/brotli/enc/brotli_bit_stream.c \
-	../../external/corefx/src/Native/AnyOS/brotli/enc/bit_cost.c \
-	../../external/corefx/src/Native/AnyOS/brotli/enc/static_dict.c \
-	../../external/corefx/src/Native/AnyOS/brotli/enc/literal_cost.c \
-	../../external/corefx/src/Native/AnyOS/brotli/enc/metablock.c \
-	../../external/corefx/src/Native/AnyOS/brotli/dec/state.c \
-	../../external/corefx/src/Native/AnyOS/brotli/dec/decode.c \
-	../../external/corefx/src/Native/AnyOS/brotli/dec/huffman.c \
-	../../external/corefx/src/Native/AnyOS/brotli/dec/bit_reader.c \
-	../../external/corefx/src/Native/AnyOS/brotli/common/dictionary.c
+	../../external/corefx/src/Native/Unix/System.Native/pal_time.h
 
 macos_sources = $(unix_sources)
 
@@ -98,7 +76,29 @@ unix_sources = \
 	../../external/corefx/src/Native/Unix/System.Native/pal_tcpstate.c \
 	../../external/corefx/src/Native/Unix/System.Native/pal_tcpstate.h \
 	../../external/corefx/src/Native/Unix/System.Native/pal_random.c \
-	../../external/corefx/src/Native/Unix/System.Native/pal_random.h
+	../../external/corefx/src/Native/Unix/System.Native/pal_random.h \
+	../../external/corefx/src/Native/AnyOS/brotli/enc/dictionary_hash.c \
+	../../external/corefx/src/Native/AnyOS/brotli/enc/backward_references_hq.c \
+	../../external/corefx/src/Native/AnyOS/brotli/enc/histogram.c \
+	../../external/corefx/src/Native/AnyOS/brotli/enc/memory.c \
+	../../external/corefx/src/Native/AnyOS/brotli/enc/entropy_encode.c \
+	../../external/corefx/src/Native/AnyOS/brotli/enc/compress_fragment_two_pass.c \
+	../../external/corefx/src/Native/AnyOS/brotli/enc/block_splitter.c \
+	../../external/corefx/src/Native/AnyOS/brotli/enc/encode.c \
+	../../external/corefx/src/Native/AnyOS/brotli/enc/cluster.c \
+	../../external/corefx/src/Native/AnyOS/brotli/enc/backward_references.c \
+	../../external/corefx/src/Native/AnyOS/brotli/enc/utf8_util.c \
+	../../external/corefx/src/Native/AnyOS/brotli/enc/compress_fragment.c \
+	../../external/corefx/src/Native/AnyOS/brotli/enc/brotli_bit_stream.c \
+	../../external/corefx/src/Native/AnyOS/brotli/enc/bit_cost.c \
+	../../external/corefx/src/Native/AnyOS/brotli/enc/static_dict.c \
+	../../external/corefx/src/Native/AnyOS/brotli/enc/literal_cost.c \
+	../../external/corefx/src/Native/AnyOS/brotli/enc/metablock.c \
+	../../external/corefx/src/Native/AnyOS/brotli/dec/state.c \
+	../../external/corefx/src/Native/AnyOS/brotli/dec/decode.c \
+	../../external/corefx/src/Native/AnyOS/brotli/dec/huffman.c \
+	../../external/corefx/src/Native/AnyOS/brotli/dec/bit_reader.c \
+	../../external/corefx/src/Native/AnyOS/brotli/common/dictionary.c
 
 gss_sources = \
 	../../external/corefx/src/Native/Unix/System.Net.Security.Native/pal_gssapi.c \


### PR DESCRIPTION
The native Brotli decoder/encoder code in libmono-native is about 2MB per architecture, we don't want to pay this size penalty for now.
