### PR TITLE
Fix interpreter failure in install_eh_callback.exe under Windows x64 MSVC.

### DIFF
--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -155,6 +155,9 @@ typedef struct {
 	int kind;
 	MonoContext ctx; /* valid if kind == DEBUGGER_INVOKE || kind == INTERP_EXIT_WITH_CTX */
 	gpointer interp_exit_data; /* valid if kind == INTERP_EXIT || kind == INTERP_EXIT_WITH_CTX */
+#if defined (_MSC_VER)
+	gboolean interp_exit_label_set;
+#endif
 } MonoLMFExt;
 
 typedef void (*MonoFtnPtrEHCallback) (guint32 gchandle);

--- a/mono/utils/win64.asm
+++ b/mono/utils/win64.asm
@@ -18,7 +18,6 @@ mono_context_get_current PROC
 	mov [rcx + 08h], rcx
 	mov [rcx + 10h], rdx
 	mov [rcx + 18h], rbx
-	mov [rcx + 20h], rsp
 	mov [rcx + 28h], rbp
 	mov [rcx + 30h], rsi
 	mov [rcx + 38h], rdi
@@ -31,9 +30,12 @@ mono_context_get_current PROC
 	mov [rcx + 70h], r14
 	mov [rcx + 78h], r15
 
-	lea rax, __mono_current_ip
-__mono_current_ip:
+	lea rax, [rsp+8]
+	mov [rcx + 20h], rax
+
+	mov rax, qword ptr [rsp]
 	mov [rcx + 80h], rax
+
 	ret
 
 mono_context_get_current endP


### PR DESCRIPTION
INTERP_PUSH_LMF_WITH_CTX_BODY is not fully supported under Windows MSVC since that compiler doesn't support taking address from a label, needed by current implementation to correctly resume after unwinding exceptions happening in native frames as tested by install_eh_callback.exe.

This fix add support to restore to a known location and use a flag indicating if we have been resumed to the location or just passing by for the first time. If we resume it will transfer control to specified label. This will mimic the behavior of taking the address of a label and use that address as the resume point.

I also considered switching to setjmp/longjmp but that would have had a bigger impact on all platforms and needed changes into the resume context machinery as well.

While doing the implementation I also found an interesting issue with MONO_CONTEXT_GET_CURRENT under Windows x64. On most other platforms it is implemented as inline assembler, but on MSVC x64 inline assembler is not supported so it is implemented as a function. Problem with that is how IP
was resolved, since it won't be resolved to the last instruction in the expanded macro, but to the IP within the mono_context_get_current. This has not had any visible effects in the past since it will just do the ret and get back to the call site, but when this was used in INTERP_PUSH_LMF_WITH_CTX_BODY
it caused some issues. This was fixed to make sure rsp and rip reflect location in caller frame and not within mono_context_get_current, similar to how it works on all platforms with inline assembler support.
