### PR TITLE
[2019-02] [jit] Treat ternary operations as non-constant during constant evaluation and propagation

### DIFF
--- a/mono/mini/basic.cs
+++ b/mono/mini/basic.cs
@@ -1428,12 +1428,4 @@ class Tests
 
 		return k == -32768 ? 0 : 1;
 	}
-
-	static int variable_with_constant_address;
-
-	public static int test_cfold_with_non_constant_ternary_op () {
-		variable_with_constant_address = 0;
-		var old = System.Threading.Interlocked.CompareExchange(ref variable_with_constant_address, 1, 0);
-		return old == 0 && variable_with_constant_address == 1 ? 0 : 1;
-	}
 }

--- a/mono/mini/basic.cs
+++ b/mono/mini/basic.cs
@@ -1428,4 +1428,12 @@ class Tests
 
 		return k == -32768 ? 0 : 1;
 	}
+
+	static int variable_with_constant_address;
+
+	public static int test_cfold_with_non_constant_ternary_op () {
+		variable_with_constant_address = 0;
+		var old = System.Threading.Interlocked.CompareExchange(ref variable_with_constant_address, 1, 0);
+		return old == 0 && variable_with_constant_address == 1 ? 0 : 1;
+	}
 }

--- a/mono/mini/objects.cs
+++ b/mono/mini/objects.cs
@@ -2001,6 +2001,13 @@ ncells ) {
 		return gh_11378_inner_3 (new Vec3(0, 2, -20));
 	}
 
+	static int variable_with_constant_address;
+
+	public static int test_0_cfold_with_non_constant_ternary_op () {
+		variable_with_constant_address = 0;
+		var old = System.Threading.Interlocked.CompareExchange(ref variable_with_constant_address, 1, 0);
+		return old == 0 && variable_with_constant_address == 1 ? 0 : 1;
+	}
 }
 
 #if __MOBILE__

--- a/mono/mini/ssa.c
+++ b/mono/mini/ssa.c
@@ -826,6 +826,10 @@ evaluate_ins (MonoCompile *cfg, MonoInst *ins, MonoInst **res, MonoInst **carray
 		return 2;
 
 	num_sregs = mono_inst_get_src_registers (ins, sregs);
+
+	if (num_sregs > 2)
+		return 2;
+
 	for (i = 0; i < MONO_MAX_SRC_REGS; ++i)
 		args [i] = NULL;
 	for (i = 0; i < num_sregs; ++i) {


### PR DESCRIPTION
Fixes #13873

Backport of #14782.

/cc @marek-safar @imhameed