### PR TITLE
Bump msbuild to track xplat-master

### DIFF
--- a/packaging/MacSDK/msbuild.py
+++ b/packaging/MacSDK/msbuild.py
@@ -3,7 +3,7 @@ import fileinput
 class MSBuild (GitHubPackage):
 	def __init__ (self):
 		GitHubPackage.__init__ (self, 'mono', 'msbuild', '15',  # note: fix scripts/ci/run-test-mac-sdk.sh when bumping the version number
-			revision = '4e8391a0f34d2aad63dd2cb941caa153f2a3d0fb')
+			revision = '8f608e49833cc1e2f6c9c070dacbd8fdcb41a20e')
 
 	def build (self):
 		self.sh ('./eng/cibuild_bootstrapped_msbuild.sh --host_type mono --configuration Release --skip_tests')


### PR DESCRIPTION
Picks up changes in msbuild after:
	[mono] Update SDKs to track cli branch `release/2.1.8xx`

(https://github.com/mono/msbuild/pull/110)