### PR TITLE
[2019-06] Fix build on macOS 10.15 Catalina + xcode 11

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6112,6 +6112,10 @@ elif test x$target_osx = xyes; then
 	MONO_NATIVE_PLATFORM=macos
 	MONO_NATIVE_PLATFORM_TYPE="MONO_NATIVE_PLATFORM_TYPE_MACOS"
 
+	if test x$enable_gss = xyes; then
+		MONO_NATIVE_LDFLAGS="$MONO_NATIVE_LDFLAGS -framework GSS"
+	fi
+
 	AC_MONO_APPLE_AVAILABLE(mono_native_compat, [whether we need the compatibility layer],
 		[!(MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12)])
 

--- a/configure.ac
+++ b/configure.ac
@@ -399,7 +399,7 @@ case "$host" in
 		parallel_mark="Disabled_Currently_Hangs_On_MacOSX"
 		host_darwin=yes
 		target_mach=yes
-		CPPFLAGS="$CPPFLAGS -D_THREAD_SAFE -DGC_MACOSX_THREADS -DUSE_MMAP -DUSE_MUNMAP -DOBJC_OLD_DISPATCH_PROTOTYPES=1"
+		CPPFLAGS="$CPPFLAGS -D_THREAD_SAFE -DGC_MACOSX_THREADS -DUSE_MMAP -DUSE_MUNMAP"
 		libmono_cflags="-D_THREAD_SAFE"
 		need_link_unlink=yes
 		AC_DEFINE(PTHREAD_POINTER_ID)

--- a/configure.ac
+++ b/configure.ac
@@ -399,7 +399,7 @@ case "$host" in
 		parallel_mark="Disabled_Currently_Hangs_On_MacOSX"
 		host_darwin=yes
 		target_mach=yes
-		CPPFLAGS="$CPPFLAGS -D_THREAD_SAFE -DGC_MACOSX_THREADS -DUSE_MMAP -DUSE_MUNMAP"
+		CPPFLAGS="$CPPFLAGS -D_THREAD_SAFE -DGC_MACOSX_THREADS -DUSE_MMAP -DUSE_MUNMAP -DOBJC_OLD_DISPATCH_PROTOTYPES=1"
 		libmono_cflags="-D_THREAD_SAFE"
 		need_link_unlink=yes
 		AC_DEFINE(PTHREAD_POINTER_ID)

--- a/mono/utils/mono-md5.c
+++ b/mono/utils/mono-md5.c
@@ -30,6 +30,12 @@
 
 #if HAVE_COMMONCRYPTO_COMMONDIGEST_H
 
+// CC_MD5_* API is deprecated on macOS 10.15
+#if defined(__APPLE__) && defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 /**
  * mono_md5_init:
  */
@@ -56,6 +62,10 @@ mono_md5_final (MonoMD5Context *ctx, guchar digest[16])
 {
 	CC_MD5_Final (digest, ctx);
 }
+
+#if defined(__APPLE__) && defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 #else
 

--- a/mono/utils/mono-threads-mach-helper.c
+++ b/mono/utils/mono-threads-mach-helper.c
@@ -9,6 +9,9 @@
  */
 
 #if defined(__MACH__)
+
+#define OBJC_OLD_DISPATCH_PROTOTYPES 1  // TODO remove once https://github.com/mono/mono/issues/14792 is fixed
+
 #include "config.h"
 #include <glib.h>
 #include <stdio.h>


### PR DESCRIPTION
1) CC_MD5_Init, CC_MD5_Update and CC_MD5_Final are deprecated.
```c
mono-md5.c:45:2: error: 'CC_MD5_Init' is deprecated: first deprecated in macOS 10.15 - This function is
      cryptographically broken and should not be used in security contexts. Clients should migrate to SHA256
      (or stronger). [-Werror,-Wdeprecated-declarations]
        CC_MD5_Init (ctx);
        ^
```

2) 
```
mono-threads-mach-helper.c:95:17: error: too many arguments to function call, expected 0, have 2
                objc_msgSend (value, release);
                ~~~~~~~~~~~~  ^~~~~~~~~~~~~~
```
XCode has a special switch `Enable Strict Checking of objc_msgSend Calls` which is now `true` by default? anyway it's fixed by `-DOBJC_OLD_DISPATCH_PROTOTYPES=1` flag

3) Fixes https://github.com/mono/mono/issues/14793
No idea how it worked on pre 10.15 without `-framework GSS` 🤔 

Backport of #14820.

/cc @akoeplinger @EgorBo