### PR TITLE
[netcore] Improve netcore/build.sh script

### DIFF
--- a/mcs/class/System.Private.CoreLib/System/Environment.cs
+++ b/mcs/class/System.Private.CoreLib/System/Environment.cs
@@ -41,6 +41,11 @@ namespace System
 			get;
 		}
 
+		public extern static long TickCount64 {
+			[MethodImplAttribute (MethodImplOptions.InternalCall)]
+			get;
+		}
+
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		public extern static void Exit (int exitCode);
 

--- a/mono/metadata/icall-decl.h
+++ b/mono/metadata/icall-decl.h
@@ -159,6 +159,9 @@ ICALL_EXPORT gint ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_GetOf
 ICALL_EXPORT gint32 ves_icall_System_Buffer_ByteLengthInternal (MonoArray*);
 ICALL_EXPORT gint32 ves_icall_System_Environment_get_ProcessorCount (void);
 ICALL_EXPORT gint32 ves_icall_System_Environment_get_TickCount (void);
+#if ENABLE_NETCORE
+ICALL_EXPORT gint64 ves_icall_System_Environment_get_TickCount64 (void);
+#endif
 ICALL_EXPORT gint32 ves_icall_System_ValueType_InternalGetHashCode (MonoObject*, MonoArray**);
 ICALL_EXPORT gint64 ves_icall_System_DateTime_GetSystemTimeAsFileTime (void);
 ICALL_EXPORT gint64 ves_icall_System_Diagnostics_Stopwatch_GetTimestamp (void);

--- a/mono/metadata/icall-def-netcore.h
+++ b/mono/metadata/icall-def-netcore.h
@@ -87,6 +87,7 @@ HANDLES(ENV_11, "get_MachineName", ves_icall_System_Environment_get_MachineName,
 NOHANDLES(ICALL(ENV_13, "get_Platform", ves_icall_System_Environment_get_Platform))
 NOHANDLES(ICALL(ENV_14, "get_ProcessorCount", ves_icall_System_Environment_get_ProcessorCount))
 NOHANDLES(ICALL(ENV_15, "get_TickCount", ves_icall_System_Environment_get_TickCount))
+NOHANDLES(ICALL(ENV_15a, "get_TickCount64", ves_icall_System_Environment_get_TickCount64))
 HANDLES(ENV_16, "get_UserName", ves_icall_System_Environment_get_UserName, MonoString, 0, ())
 HANDLES(ENV_17, "internalGetEnvironmentVariable_native", ves_icall_System_Environment_GetEnvironmentVariable_native, MonoString, 1, (const_char_ptr))
 NOHANDLES(ICALL(ENV_20, "set_ExitCode", mono_environment_exitcode_set))

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7589,6 +7589,14 @@ ves_icall_System_Environment_get_TickCount (void)
 	return (gint32) (mono_msec_boottime () & 0xffffffff);
 }
 
+#if ENABLE_NETCORE
+gint64
+ves_icall_System_Environment_get_TickCount64 (void)
+{
+	return mono_msec_boottime ();
+}
+#endif
+
 gint32
 ves_icall_System_Runtime_Versioning_VersioningHelper_GetRuntimeId (MonoError *error)
 {

--- a/netcore/.gitignore
+++ b/netcore/.gitignore
@@ -13,3 +13,4 @@ packs/
 /obj
 corefx-test-assets.xml
 Makefile
+.configured

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -589,6 +589,9 @@
 # WeakReference.get_TrackResurrection is not implemented
 -nomethod System.Tests.WeakReferenceTests.NonGeneric
 
+# Could not load type 'System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]' from assembly 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
+-nomethod System.Tests.ActivatorTests.TestingCreateInstanceObjectHandleFullSignature
+
 # Disabled in coreclr too: https://github.com/dotnet/coreclr/blob/master/tests/CoreFX/CoreFX.issues.rsp#L68-L71
 -nomethod System.Tests.StringTests.CasingNegativeTest
 -nomethod System.Tests.StringTests.ToLowerNullCulture

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -589,6 +589,12 @@
 # WeakReference.get_TrackResurrection is not implemented
 -nomethod System.Tests.WeakReferenceTests.NonGeneric
 
+# Disabled in coreclr too: https://github.com/dotnet/coreclr/blob/master/tests/CoreFX/CoreFX.issues.rsp#L68-L71
+-nomethod System.Tests.StringTests.CasingNegativeTest
+-nomethod System.Tests.StringTests.ToLowerNullCulture
+-nomethod System.Tests.StringTests.CompareNegativeTest
+-nomethod System.Tests.StringTests.ToUpperNullCulture
+
 ####################################################################
 ##  System.Text.Json.Tests
 ####################################################################

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -919,3 +919,22 @@
 
 -nomethod System.Xml.Tests.CTransformResolverTest.TC_AbsolutePath_Transform
 -nomethod System.Xml.Tests.CXmlResolverTest.TC_AbsolutePath_Transform
+
+####################################################################
+##  System.Globalization.Tests
+####################################################################
+
+-nomethod System.Globalization.Tests.RegionInfoPropertyTests.EnglishName
+
+####################################################################
+##  System.IO.FileSystem.Watcher.Tests
+####################################################################
+
+-nomethod System.IO.Tests.File_Move_Tests.File_Move_From_Unwatched_To_Watched
+
+####################################################################
+##  System.IO.MemoryMappedFiles.Tests
+####################################################################
+
+-nomethod System.IO.MemoryMappedFiles.Tests.MemoryMappedViewStreamTests.ValidAccessLevelCombinations
+-nomethod System.IO.MemoryMappedFiles.Tests.MemoryMappedViewAccessorTests.ValidAccessLevelCombinations

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -950,12 +950,15 @@
 # hangs:
 -nomethod System.Net.Tests.HttpWebRequestTest.HttpWebRequest_SetHostHeader_ContainsPortNumber
 
-
+####################################################################
 ##  System.Security.Cryptography.X509Certificates.Tests
+####################################################################
+
 -nomethod System.Security.Cryptography.X509Certificates.Tests.DynamicChainTests.TestInvalidAia
 
+####################################################################
 ##  System.Runtime.Serialization.Json.Tests
+####################################################################
+
 -nomethod DataContractJsonSerializerTests.DCJS_VerifyDateTimeForDateTimeFormat
 -nomethod DataContractJsonSerializerTests.DCJS_VerifyDateTimeForFormatStringDCJsonSerSettings
-
-##  System.Runtime.Serialization.Json.ReflectionOnly.Tests

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -577,23 +577,17 @@
 # throws ArgumentException
 -nomethod System.Reflection.Tests.PointerTests.PointerPropertyGetValue
 
-# TODO: ignore in CoreFX for mono runtime:
--nomethod System.Tests.StringTests.NormalizationTest
--nomethod System.Tests.GCTests.KeepAlive
--nomethod System.Tests.GCTests.LargeObjectHeapCompactionModeRoundTrips
--nomethod System.Tests.GCTests.GetGCMemoryInfo
--nomethod System.Tests.GCTests.Collect_CallsFinalizer
+# GC.GetTotalAllocatedBytes is not implemented
+-nomethod System.Tests.GCTests.GetTotalAllocatedBytes
+
+# GC.GetAllocatedBytesForCurrentThread is not implemented
 -nomethod System.Tests.GCTests.GetAllocatedBytesForCurrentThread
--nomethod System.Tests.GCTests.GetTotalMemoryTest_ForceCollection
--nomethod System.Tests.GCTests.LatencyRoundtrips    
--nomethod System.Tests.GCTests.KeepAlive_Null
--nomethod System.Runtime.CompilerServices.Tests.ConditionalWeakTableTests.GetOrCreateValue
--nomethod System.Runtime.CompilerServices.Tests.ConditionalWeakTableTests.Add
--nomethod System.Runtime.CompilerServices.Tests.ConditionalWeakTableTests.GetValue
--nomethod System.Tests.ActivatorTests.TestingCreateInstanceObjectHandleFullSignature
--nomethod System.Tests.EnumTests.Parse
--nomethod System.Tests.EnumTests.Parse_NetCoreApp11
--nomethod System.Tests.ArgIteratorTests.ArgIterator_Throws_PlatformNotSupportedException
+
+# GCSettings.LatencyMode is not implemented
+-nomethod System.Tests.GCTests.LatencyRoundtrips
+
+# WeakReference.get_TrackResurrection is not implemented
+-nomethod System.Tests.WeakReferenceTests.NonGeneric
 
 ####################################################################
 ##  System.Text.Json.Tests

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -645,6 +645,7 @@
 ##  System.ComponentModel.Composition.Tests
 ####################################################################
 
+-nomethod System.ComponentModel.Composition.MetadataTests.TestOptionalMetadataValueTypeMismatch
 -nomethod System.ComponentModel.Composition.CompositionServicesTests.GetDefaultContractNameTest
 -nomethod System.ComponentModel.Composition.MetadataViewProviderTests.GetMetadataView_InterfaceWithIndexer_ShouldThrowNotSupportedException
 -nomethod Tests.Integration.ExportFactoryTests.ExportFactoryStandardImports_ShouldWorkProperly
@@ -798,6 +799,9 @@
 -nomethod System.Tests.EnvironmentTests.FailFast_ExceptionStackTrace_ArgumentException
 -nomethod System.Tests.EnvironmentTests.FailFast_ExceptionStackTrace_StackOverflowException
 
+# GC.GetGCMemoryInfo is not implemented
+-nomethod System.Tests.AppDomainTests.MonitoringIsEnabled
+
 # Mono expands generic Types in stacktraces unlike the .NET Core (sounds more like a feature: https://gist.github.com/EgorBo/3abb37d2ff4fc904bc7472c62498f933)
 -nomethod System.Tests.EnvironmentStackTrace.StackTraceTest
 
@@ -938,3 +942,20 @@
 
 -nomethod System.IO.MemoryMappedFiles.Tests.MemoryMappedViewStreamTests.ValidAccessLevelCombinations
 -nomethod System.IO.MemoryMappedFiles.Tests.MemoryMappedViewAccessorTests.ValidAccessLevelCombinations
+
+####################################################################
+##  System.Net.Requests.Tests
+####################################################################
+
+# hangs:
+-nomethod System.Net.Tests.HttpWebRequestTest.HttpWebRequest_SetHostHeader_ContainsPortNumber
+
+
+##  System.Security.Cryptography.X509Certificates.Tests
+-nomethod System.Security.Cryptography.X509Certificates.Tests.DynamicChainTests.TestInvalidAia
+
+##  System.Runtime.Serialization.Json.Tests
+-nomethod DataContractJsonSerializerTests.DCJS_VerifyDateTimeForDateTimeFormat
+-nomethod DataContractJsonSerializerTests.DCJS_VerifyDateTimeForFormatStringDCJsonSerSettings
+
+##  System.Runtime.Serialization.Json.ReflectionOnly.Tests

--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -117,7 +117,7 @@ nupkg:
 	$(DOTNET) pack roslyn-restore.csproj -p:NuspecFile=metapackage.nuspec -p:NuspecProperties=\"RID=$(RID)\;VERSION=$(VERSION)$(VERSTUB)\;PLATFORM_AOT_SUFFIX=$(PLATFORM_AOT_SUFFIX)\;COREARCH=$(COREARCH)\;PLATFORM_AOT_PREFIX=$(PLATFORM_AOT_PREFIX)\" --output ../artifacts/ --no-build
 
 clean:
-	rm -rf ../.dotnet sdk shared host dotnet tests obj corefx roslyn LICENSE.txt ThirdPartyNotices.txt $(NETCORESDK_FILE) $(ASPNETCORESDK_FILE)
+	rm -rf .configured ../.dotnet sdk shared host dotnet tests obj corefx roslyn LICENSE.txt ThirdPartyNotices.txt $(NETCORESDK_FILE) $(ASPNETCORESDK_FILE)
 
 #
 # Running tests:
@@ -145,8 +145,11 @@ xtest-%: prepare update-corefx-tests
 # these tests won't be included in `xtestall`
 EXCLUDED_COREFX_TESTS =
 
-xtestall: update-corefx-tests $(foreach workingtest, $(foreach test, $(wildcard corefx/tests/extracted/*), \
+xtestall-noload: $(foreach workingtest, $(foreach test, $(wildcard corefx/tests/extracted/*), \
 		$(filter-out $(EXCLUDED_COREFX_TESTS), $(notdir $(test)))), $(addprefix xtest-, $(workingtest)))
+
+xtestall: update-corefx-tests
+	$(MAKE) xtestall-noload
 
 # build a test assembly in COREFX_ROOT and copy it to corefx/tests/extracted
 # e.g. `make build-local-corefx-test-System.Runtime COREFX_ROOT=/prj/corefx-master`

--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -95,13 +95,15 @@ run-aspnet-sample: prepare
 # COREHOST_TRACE=1 
 SHAREDRUNTIME := shared/Microsoft.NETCore.App/$(NETCOREAPP_VERSION)
 
-# CORLIB_BUILD_FLAGS="-c Debug" to compile System.Private.CoreLib.dll in debug mode
 bcl: update-roslyn
 	$(MAKE) -C ../mcs/build/ common/Consts.cs
 	$(DOTNET) build $(CORETARGETS) $(CORLIB_BUILD_FLAGS) -p:BuildArch=$(COREARCH) \
 	-p:OutputPath=bin/$(COREARCH) \
 	-p:RoslynPropsFile="../../../netcore/roslyn/packages/microsoft.net.compilers.toolset/$(ROSLYN_VERSION)/build/Microsoft.Net.Compilers.Toolset.props" \
 	../mcs/class/System.Private.CoreLib/System.Private.CoreLib.csproj
+
+debug-bcl:
+	$(MAKE) bcl CORLIB_BUILD_FLAGS="-c Debug"
 
 runtime:
 	$(MAKE) -C ../mono
@@ -127,7 +129,6 @@ clean:
 #
 
 # e.g. `make xtest-System.Collections.Tests`
-# '-parallel none -verbose' and MONO_ENV_OPTIONS="--debug" for debug
 xtest-%: prepare update-corefx-tests
 	echo -n "***************** $* *********************"
 	cp corefx/restore/corefx-restore.deps.json corefx/tests/extracted/$*/xunit.console.deps.json
@@ -141,6 +142,9 @@ xtest-%: prepare update-corefx-tests
 		-html ../../TestResult-$*.html -nunit ../../TestResult-$*-netcore-xunit.xml \
 		$(XUNIT_FLAGS) @../../../../CoreFX.issues.rsp \
 		$(FIXTURE) || true
+
+debug-xtest-%:
+	MONO_ENV_OPTIONS="--debug" $(MAKE) xtest-$*
 
 # these tests won't be included in `xtestall`
 EXCLUDED_COREFX_TESTS =

--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -4,11 +4,11 @@ include ../mcs/build/config.make
 # NETCORETESTS_VERSION and NETCOREAPP_VERSION must be updated in sync, we are using coreclr repo for that but that's fine for now
 #
 
-# Extracted MicrosoftPrivateCoreFxNETCoreAppVersion from https://github.com/dotnet/coreclr/blob/master/eng/Versions.props#L18
-NETCORETESTS_VERSION := 4.6.0-preview6.19273.8
+# Extracted MicrosoftPrivateCoreFxNETCoreAppVersion from https://github.com/dotnet/coreclr/blob/master/eng/Versions.props#L21
+NETCORETESTS_VERSION := 4.6.0-preview7.19305.1
 
-# Extracted MicrosoftNETCoreAppVersion from https://github.com/dotnet/coreclr/blob/master/eng/Versions.props#L22
-NETCOREAPP_VERSION := 3.0.0-preview6-27727-02
+# Extracted MicrosoftNETCoreAppVersion from https://github.com/dotnet/coreclr/blob/master/eng/Versions.props#L25
+NETCOREAPP_VERSION := 3.0.0-preview7-27804-03
 
 # Extracted from https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/master/latest.version
 ASPNETCOREAPP_VERSION := 3.0.0-preview-18614-0151

--- a/netcore/corefx-restore.csproj
+++ b/netcore/corefx-restore.csproj
@@ -7,6 +7,7 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="1.0.5" />
     <PackageReference Include="Microsoft.Private.CoreFx.NETCoreApp" Version="$(MicrosoftPrivateCoreFxNETCoreAppVersion)" />
     <PackageReference Include="Microsoft.Private.CoreFx.OOB" Version="$(MicrosoftPrivateCoreFxNETCoreAppVersion)" />
   </ItemGroup>

--- a/netcore/sample/AspNetCore/Startup.cs
+++ b/netcore/sample/AspNetCore/Startup.cs
@@ -32,9 +32,8 @@ namespace AspNetCore
             {
                 endpoints.MapGet("/", async context =>
                 {
-                    string corlib = typeof(object).Assembly.FullName;
-                    bool isMono = corlib.Contains("0.0.0.0");
-                    await context.Response.WriteAsync("Hello World " + (isMono ? "from mono!\n" : "\n") + corlib);
+                    bool isMono = typeof(object).Assembly.GetType("Mono.RuntimeStructs") != null;
+                    await context.Response.WriteAsync("Hello World " + (isMono ? "from mono!\n" : "from CoreCLR"));
                 });
             });
         }


### PR DESCRIPTION
Improve `netcore/build.sh` script:
1) Run `.autogen.sh` only once (creates `.configured` file as a sign - let me know if you don't like this file name)
2) Added `--rebuild` flag to run `.autogen.sh` despite the `.configured` file
3) Added `--skipnative` and `--skipmscorlib` for consistency with coreclr's build.sh
4) `xtestall` rule didn't run tests if it needed to download them first (so you had to run it twice)

Also, bump corefx and coreclr versions (to preview7) and ignore new failures in xtestall.