### PR TITLE
[sdks] Use 7z format for the android/ios/mac archives

### DIFF
--- a/scripts/ci/pipeline/sdks-archive.groovy
+++ b/scripts/ci/pipeline/sdks-archive.groovy
@@ -110,8 +110,8 @@ def archive (product, configuration, platform, chrootname = "", chrootadditional
                             throw new Exception("Unknown platform \"${platform}\"")
                         }
                     }
-                    // move Archive to the workspace root
-                    packageFileName = findFiles (glob: "${product}-${configuration}-${platform}-${commitHash}.zip")[0].name
+                    // find Archive in the workspace root
+                    packageFileName = findFiles (glob: "${product}-${configuration}-${platform}-${commitHash}.*")[0].name
                 }
                 stage('Upload Archive to Azure') {
                     azureUpload(storageCredentialId: "fbd29020e8166fbede5518e038544343",

--- a/sdks/builds/Makefile
+++ b/sdks/builds/Makefile
@@ -100,29 +100,34 @@ endif
 ##
 # Parameters:
 #  $(1): target (android, ios, mac, wasm)
+#  $(2): compression format (7z, zip)
 define ArchiveTemplate
 _$(1)_HASH = $$(shell git -C $$(TOP) rev-parse HEAD)
-_$(1)_PACKAGE = $(1)-$$(CONFIGURATION)-$$(UNAME)-$$(_$(1)_HASH).zip
+_$(1)_PACKAGE = $(1)-$$(CONFIGURATION)-$$(UNAME)-$$(_$(1)_HASH).$(2)
+
+ifeq ($(2),7z)
+_$(1)_COMPRESSION_ARGS = -t7z -mx=9
+endif
 
 .PHONY: archive-$(1)
 archive-$(1):
-	cd $$(TOP)/sdks/out && 7z a $$(TOP)/$$(_$(1)_PACKAGE) $$(sort $$($(1)_ARCHIVE))
+	cd $$(TOP)/sdks/out && 7z a $$(_$(1)_COMPRESSION_ARGS) $$(TOP)/$$(_$(1)_PACKAGE) $$(sort $$($(1)_ARCHIVE))
 endef
 
 ifndef DISABLE_ANDROID
-$(eval $(call ArchiveTemplate,android))
+$(eval $(call ArchiveTemplate,android,7z))
 endif
 
 ifndef DISABLE_IOS
-$(eval $(call ArchiveTemplate,ios))
+$(eval $(call ArchiveTemplate,ios,7z))
 endif
 
 ifndef DISABLE_MAC
-$(eval $(call ArchiveTemplate,mac))
+$(eval $(call ArchiveTemplate,mac,7z))
 endif
 
 ifndef DISABLE_WASM
-$(eval $(call ArchiveTemplate,wasm))
+$(eval $(call ArchiveTemplate,wasm,zip))
 endif
 
 ## Targets


### PR DESCRIPTION
It has way better compression performance.
Kept WebAssembly on .zip for now since external users took dependencies on it [1].

Fixes https://github.com/mono/mono/issues/14215

[1] https://github.com/nventive/Uno.Wasm.Bootstrap/blob/e2bf8946e162642ca1bdf4f003f8de4a94954f73/Readme.md#updating-the-mono-sdk-build



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
