### PR TITLE
[2019-06] [llvm] turn filter-exception assert into compilation failure

### DIFF
--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -2111,7 +2111,10 @@ emit_call (EmitContext *ctx, MonoBasicBlock *bb, LLVMBuilderRef *builder_ref, LL
 		clause = get_most_deep_clause (cfg, ctx, bb);
 
 		if (clause) {
-			g_assert (clause->flags == MONO_EXCEPTION_CLAUSE_NONE || clause->flags == MONO_EXCEPTION_CLAUSE_FINALLY || clause->flags == MONO_EXCEPTION_CLAUSE_FAULT);
+			if (clause->flags != MONO_EXCEPTION_CLAUSE_FINALLY && clause->flags != MONO_EXCEPTION_CLAUSE_FAULT && clause->flags != MONO_EXCEPTION_CLAUSE_NONE) {
+				set_failure (ctx, "non-finally/catch/fault clause.");
+				return NULL;
+			}
 
 			/*
 			 * Have to use an invoke instead of a call, branching to the


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/14243




Backport of #14840.

/cc @akoeplinger @lewurm