### PR TITLE
[2019-06]  [llvm] emit call to mini_llvmonly_throw_nullref_exception without exceptions in mind

### DIFF
--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -7595,7 +7595,7 @@ mono_llvm_emit_method (MonoCompile *cfg)
 
 				LLVMTypeRef sig = LLVMFunctionType0 (LLVMVoidType (), FALSE);
 				LLVMValueRef callee = get_callee (ctx, sig, MONO_PATCH_INFO_JIT_ICALL_ADDR, GUINT_TO_POINTER (MONO_JIT_ICALL_mini_llvmonly_throw_nullref_exception));
-				emit_call (ctx, cfg->bb_entry, &builder, callee, NULL, 0);
+				LLVMBuildCall (builder, callee, NULL, 0, "");
 				LLVMBuildUnreachable (builder);
 			} else {
 				LLVMDeleteFunction (ctx->lmethod);


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/14243




Backport of #14840.

/cc @lewurm 