### PR TITLE
Enable the compiler server by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6542,11 +6542,11 @@ AC_ARG_WITH(compiler-server, [  --with-compiler-server=yes,no,default      Enabl
    elif test x$withval = xno; then
        enable_compiler_server=no;
    elif test x$withval = xdefault; then
-       enable_compiler_server=no;
+       enable_compiler_server=yes;
    else
        AC_MSG_ERROR([You must supply one of "yes", "no" or "default" to the --with-compiler-server option])
    fi
-],[enable_compiler_server=no])
+],[enable_compiler_server=yes])
 
 if test x$enable_compiler_server = xyes; then
    if test x$csc_compiler = xmcs; then


### PR DESCRIPTION
Now that 2019-06 has branched, enable the compiler server by default