### PR TITLE
Implement RSACertificateExtensions.CopyWithPrivateKey().  #14152.

### DIFF
--- a/mcs/class/System.Core/System.Security.Cryptography.X509Certificates/RSACertificateExtensions.cs
+++ b/mcs/class/System.Core/System.Security.Cryptography.X509Certificates/RSACertificateExtensions.cs
@@ -30,7 +30,7 @@ namespace System.Security.Cryptography.X509Certificates
 {
 	public static class RSACertificateExtensions
 	{
-		public static RSA GetRSAPrivateKey(this X509Certificate2 certificate)
+		public static RSA GetRSAPrivateKey (this X509Certificate2 certificate)
 		{
 			if (certificate == null)
 				throw new ArgumentNullException (nameof (certificate));
@@ -41,16 +41,21 @@ namespace System.Security.Cryptography.X509Certificates
 			return certificate.Impl.GetRSAPrivateKey ();
 		}
 
-		public static RSA GetRSAPublicKey(this X509Certificate2 certificate)
+		public static RSA GetRSAPublicKey (this X509Certificate2 certificate)
 		{
 			if (certificate == null)
-				throw new ArgumentNullException("certificate");
+				throw new ArgumentNullException (nameof (certificate));
 			return certificate.PublicKey.Key as RSA;
 		}
 		
-		public static X509Certificate2 CopyWithPrivateKey(this X509Certificate2 certificate, RSA privateKey) 
-		{ 
-			throw new PlatformNotSupportedException(); 
+		public static X509Certificate2 CopyWithPrivateKey (this X509Certificate2 certificate, RSA privateKey)
+		{
+			if (certificate == null)
+				throw new ArgumentNullException (nameof (certificate));
+			if (privateKey == null)
+				throw new ArgumentNullException (nameof (privateKey));
+			var impl = certificate.Impl.CopyWithPrivateKey (privateKey);
+			return (X509Certificate2)impl.CreateCertificate ();
 		}
 	}
 }

--- a/mcs/class/System/System.Net/HttpListener.Mono.cs
+++ b/mcs/class/System/System.Net/HttpListener.Mono.cs
@@ -80,8 +80,8 @@ namespace System.Net {
 					if (!File.Exists (pvk_file))
 						return null;
 					var cert = new X509Certificate2 (cert_file);
-					cert.PrivateKey = PrivateKey.CreateFromFile (pvk_file).RSA;
-					certificate = cert;
+					var privateKey = PrivateKey.CreateFromFile (pvk_file).RSA;
+					certificate = new X509Certificate2 ((X509Certificate2Impl)cert.Impl.CopyWithPrivateKey (privateKey));
 					return certificate;
 				} catch {
 					// ignore errors

--- a/mcs/class/System/System.Security.Cryptography.X509Certificates/X509Certificate2Impl.cs
+++ b/mcs/class/System/System.Security.Cryptography.X509Certificates/X509Certificate2Impl.cs
@@ -83,6 +83,18 @@ namespace System.Security.Cryptography.X509Certificates
 
 		public abstract void AppendPrivateKeyInfo (StringBuilder sb);
 
+		public sealed override X509CertificateImpl CopyWithPrivateKey (RSA privateKey)
+		{
+			var impl = (X509Certificate2Impl)Clone ();
+			impl.PrivateKey = privateKey;
+			return impl;
+		}
+
+		public sealed override X509Certificate CreateCertificate ()
+		{
+			return new X509Certificate2 (this);
+		}
+
 		public abstract void Reset ();
 	}
 }

--- a/mcs/class/corlib/System.Security.Cryptography.X509Certificates/X509CertificateImpl.cs
+++ b/mcs/class/corlib/System.Security.Cryptography.X509Certificates/X509CertificateImpl.cs
@@ -123,6 +123,10 @@ namespace System.Security.Cryptography.X509Certificates
 
 		public abstract byte[] Export (X509ContentType contentType, SafePasswordHandle password);
 
+		public abstract X509CertificateImpl CopyWithPrivateKey (RSA privateKey);
+
+		public abstract X509Certificate CreateCertificate ();
+
 		public sealed override bool Equals (object obj)
 		{
 			var other = obj as X509CertificateImpl;

--- a/mcs/tools/security/Makefile
+++ b/mcs/tools/security/Makefile
@@ -4,7 +4,7 @@ DIST_ONLY_SUBDIRS = certview
 include ../../build/rules.make
 
 LOCAL_MCS_FLAGS = 
-LIB_REFS = Mono.Security System
+LIB_REFS = Mono.Security System System.Core
 
 SECURITY_PROGRAMS = secutil.exe cert2spc.exe sn.exe makecert.exe chktrust.exe crlupdate.exe \
 	signcode.exe setreg.exe certmgr.exe caspol.exe permview.exe mozroots.exe cert-sync.exe
@@ -66,4 +66,4 @@ permview.exe: permview.cs
 	$(CSCOMPILE) $^ $(HELPER_SOURCES) -r:$(topdir)/class/lib/$(PROFILE)/mscorlib.dll -r:$(topdir)/class/lib/$(PROFILE)/Mono.Cecil.dll
 
 %.exe: %.cs $(HELPER_SOURCES)
-	$(CSCOMPILE) -r:$(topdir)/class/lib/$(PROFILE)/mscorlib.dll -r:$(topdir)/class/lib/$(PROFILE)/Mono.Security.dll -r:$(topdir)/class/lib/$(PROFILE)/System.dll $^
+	$(CSCOMPILE) -r:$(topdir)/class/lib/$(PROFILE)/mscorlib.dll -r:$(topdir)/class/lib/$(PROFILE)/Mono.Security.dll -r:$(topdir)/class/lib/$(PROFILE)/System.dll -r:$(topdir)/class/lib/$(PROFILE)/System.Core.dll $^

--- a/mcs/tools/security/httpcfg.cs
+++ b/mcs/tools/security/httpcfg.cs
@@ -202,7 +202,8 @@ namespace Mono.Tools {
 		{
 			try {
 				X509Certificate2 x509 = new X509Certificate2 (cert);
-				x509.PrivateKey = PrivateKey.CreateFromFile (pvk).RSA;
+				var privateKey = PrivateKey.CreateFromFile (pvk).RSA;
+				x509 = x509.CopyWithPrivateKey ((RSA)privateKey);
 			} catch (Exception e) {
 				Console.Error.WriteLine ("error loading certificate or private key [{0}]", e.Message);
 				Help (true);


### PR DESCRIPTION
Since `RSACertificateExtensions` lives in `System.Core` and only `mscorlib` internals (but not `System` internals) are visible to it, we need to use a little trick here:

* System.Security.Cryptography.X509Certificates.X509CertificateImpl:
  add new abstract methods CopyWithPrivateKey() and CreateCertificate().

* System.Security.Cryptography.X509Certificates.X509Certificate2Impl:
  sealed implement them here.

The `httpcfg` tool, only checks whether the key is valid, so we don't really need to call `CopyWithPrivateKey()` (which requires us to take a dependency on `System.Core`).

Fixes https://github.com/mono/mono/issues/14152.