### PR TITLE
Remove exclusions stemming from resolved type check bug

### DIFF
--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -542,11 +542,6 @@
 ##  System.Runtime.Tests
 ####################################################################
 
-# https://github.com/mono/mono/issues/14555 Array of pointers is not array of objects
--nomethod System.Tests.ArrayTests.LastIndexOf_ArrayOfPointers_ThrowsNotSupportedException
--nomethod System.Tests.ArrayTests.Reverse_ArrayOfPointers_ThrowsNotSupportedException
--nomethod System.Tests.ArrayTests.IndexOf_ArrayOfPointers_ThrowsNotSupportedException
-
 # https://github.com/mono/mono/issues/14291 incorrect line numbers
 -nomethod System.Tests.ExceptionTests.ThrowStatementDoesNotResetExceptionStackLineSameMethod
 -nomethod System.Tests.ExceptionTests.ThrowStatementDoesNotResetExceptionStackLineOtherMethod


### PR DESCRIPTION
These tests were disabled because of #14555 which was fixed in a5a26a2f92d00ab174d794f077007faaab5d3843, but the tests were not reenabled as pointed out [here](https://github.com/mono/mono/issues/14555#issuecomment-499652206). That was an oversight and this corrects it.