### PR TITLE
[2019-02] [runtime] Make cross-appdomain wrappers throw NIE for methods with ref struct args

### DIFF
--- a/mcs/class/corlib/ReferenceSources/MethodBase.cs
+++ b/mcs/class/corlib/ReferenceSources/MethodBase.cs
@@ -8,6 +8,7 @@ using System.Text;
 
 namespace System.Reflection
 {
+	[Serializable]
 	partial class MethodBase
 	{
 		//

--- a/mcs/class/corlib/corefx/MethodInfo.cs
+++ b/mcs/class/corlib/corefx/MethodInfo.cs
@@ -1,4 +1,5 @@
 namespace System.Reflection {
+    [Serializable]
     partial class MethodInfo {
         internal virtual int GenericParameterCount => GetGenericArguments ().Length;
     }

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -1009,6 +1009,7 @@ mono_marshal_get_xappdomain_invoke (MonoMethod *method, MonoError *error)
 
 	marshal_types = g_newa (int, sig->param_count);
 	complex_count = complex_out_count = 0;
+	gboolean has_byreflike = FALSE;
 	for (i = 0; i < sig->param_count; i++) {
 		MonoType *ptype = sig->params[i];
 		int mt = mono_get_xdomain_marshal_type (ptype);
@@ -1023,6 +1024,10 @@ mono_marshal_get_xappdomain_invoke (MonoMethod *method, MonoError *error)
 			if (ptype->byref) complex_out_count++;
 		}
 		marshal_types [i] = mt;
+		/* Can't make a xdomain wrapper for a method with an IsByRefLike result */
+		if (!ptype->byref && m_class_is_byreflike (mono_class_from_mono_type_internal (ptype))) {
+			has_byreflike = TRUE;
+		}
 	}
 
 	if (sig->ret->type != MONO_TYPE_VOID) {
@@ -1031,9 +1036,25 @@ mono_marshal_get_xappdomain_invoke (MonoMethod *method, MonoError *error)
 		copy_return = ret_marshal_type != MONO_MARSHAL_SERIALIZE;
 	}
 	
+	/* Can't make a xdomain wrapper for a method with an IsByRefLike result */
+	if (!sig->ret->byref && m_class_is_byreflike (mono_class_from_mono_type_internal (sig->ret))) {
+		has_byreflike = TRUE;
+	}
+
 	/* Locals */
 
 #ifndef DISABLE_JIT
+	if (has_byreflike) {
+		/* Make a wrapper that throws a NotImplementedException if it's ever called */
+		mono_mb_emit_exception (mb, "NotImplementedException", "Cross AppDomain calls with IsByRefLike parameter or return types are not implemented");
+		info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_NONE);
+		info->d.remoting.method = method;
+		res = mono_remoting_mb_create_and_cache (method, mb, sig, sig->param_count + 16, info);
+		mono_mb_free (mb);
+		return res;
+	}
+
+
 	MonoType *object_type = mono_get_object_type ();
 	MonoType *byte_array_type = m_class_get_byval_arg (byte_array_class);
 	MonoType *int32_type = mono_get_int32_type ();


### PR DESCRIPTION
If we have a ref struct and a method that takes it as an argument:

```
[Serializable]
public ref struct R {
  public int i;
}

public interface I {
  public void M1 (R r, SomeClass o);
}

public class M : MarshalByRefObject, I {
  public void M1 (R r, SomeClass o) { ... }
}
```

If we create an instance of M in another domain and try to call it:
```
  I obj = (I)otherDomain.CreateInstanceAndUnwrap (typeof(M).Assembly.FullName,
  nameof(M));
  R r;
  r.i = 42;
  SomeClass o = ...;
  obj.M1 (r, o);
```

Mono will need to create a wrapper that can invoke M.M1 in the other domain. The way the wrapper works in `mono_marshal_get_xappdomain_invoke` is by creating an array of all the arguments that need to be serialized (see `mono_get_xdomain_marshal_type`) and then serializing the whole array (by calling out to `System.Runtime.Remoting.RemotingServices.SerializeCallData`). In the example it would make a two element array and try to serialize `r` and `o` into it. For valuetypes it normally does this by boxing the argument. However since `R` is a ref-struct, boxing it is not allowed.

This works on .NET Framework.

However for Mono we would need to serilize `R` without boxing it, which seems challenging with our current setup.

So for now we generate a wrapper that just throws a NotImplementedException if it is ever called.

This fixes #14809 (in that marshalling a TextWriter across domains works again) but in an unsatisfactory way (because you can't call any of the `ReadOnlySpan<char>` overloads on the transparent proxy object).

---

Also mark `MethodInfo` and `MethodBase` with `[Serializable]` again so that unit testing with [NUnit.ApplicationDomain](https://www.nuget.org/packages/NUnit.ApplicationDomain/) works again (they need to serialize method info for stack traces, I think)

Backport of #14863.

/cc @lambdageek 