### PR TITLE
Remove JIT icall hashing by address.

### DIFF
--- a/mono/metadata/class-internals.h
+++ b/mono/metadata/class-internals.h
@@ -1090,12 +1090,6 @@ mono_register_jit_icall_info (MonoJitICallInfo *info, T func, const char *name, 
 
 #define mono_register_jit_icall(func, sig, no_wrapper) (mono_register_jit_icall_info (&mono_get_jit_icall_info ()->func, func, #func, (sig), (no_wrapper), NULL))
 
-void
-mono_register_jit_icall_wrapper (MonoJitICallInfo *info, gconstpointer wrapper);
-
-MonoJitICallInfo *
-mono_find_jit_icall_by_addr (gconstpointer addr) MONO_LLVM_INTERNAL;
-
 gboolean
 mono_class_set_type_load_failure (MonoClass *klass, const char * fmt, ...) MONO_ATTR_FORMAT_PRINTF(2,3);
 

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -8624,7 +8624,6 @@ ves_icall_System_IO_LogcatTextWriter_Log (const char *appname, gint32 level, con
 static const MonoIcallTableCallbacks *icall_table;
 static mono_mutex_t icall_mutex;
 static GHashTable *icall_hash = NULL;
-static GHashTable *jit_icall_hash_addr = NULL;
 
 typedef struct _MonoIcallHashTableValue {
 	gconstpointer method;
@@ -8664,7 +8663,6 @@ void
 mono_icall_cleanup (void)
 {
 	g_hash_table_destroy (icall_hash);
-	g_hash_table_destroy (jit_icall_hash_addr);
 	mono_os_mutex_destroy (&icall_mutex);
 }
 
@@ -9109,42 +9107,9 @@ mono_create_icall_signatures (void)
 	}
 }
 
-MonoJitICallInfo *
-mono_find_jit_icall_by_addr (gconstpointer addr)
-{
-	MonoJitICallInfo *info;
-	g_assert (jit_icall_hash_addr);
-
-	mono_icall_lock ();
-	info = (MonoJitICallInfo *)g_hash_table_lookup (jit_icall_hash_addr, (gpointer)addr);
-	mono_icall_unlock ();
-
-	return info;
-}
-
-void
-mono_register_jit_icall_wrapper (MonoJitICallInfo *info, gconstpointer wrapper)
-{
-	mono_icall_lock ();
-	g_hash_table_insert (jit_icall_hash_addr, (gpointer)wrapper, info);
-	mono_icall_unlock ();
-}
-
 void
 mono_register_jit_icall_info (MonoJitICallInfo *info, gconstpointer func, const char *name, MonoMethodSignature *sig, gboolean avoid_wrapper, const char *c_symbol)
 {
-	mono_icall_lock ();
-
-	if (!jit_icall_hash_addr) {
-		jit_icall_hash_addr = g_hash_table_new (NULL, NULL);
-	}
-
-	// Duplicate initialization is allowed, assuming it is equivalent.
-
-	g_hash_table_insert (jit_icall_hash_addr, (gpointer)func, info);
-
-	mono_icall_unlock ();
-
 	// Duplicate initialization is allowed and racy, assuming it is equivalent.
 
 	info->name = name;

--- a/mono/metadata/jit-icall-reg.h
+++ b/mono/metadata/jit-icall-reg.h
@@ -389,7 +389,7 @@ mono_find_jit_icall_info (MonoJitICallId id)
 	const guint index = (guint)id;
 
 	g_assert (index < MONO_JIT_ICALL_count);
-	g_static_assert (MONO_JIT_ICALL_count < 0x200); // fits in 9 bits
+	g_static_assert (MONO_JIT_ICALL_count < 0x200); // fits in 9 bits, see MonoCallInst
 
 	return &mono_get_jit_icall_info ()->array [index];
 }

--- a/mono/metadata/jit-icall-reg.h
+++ b/mono/metadata/jit-icall-reg.h
@@ -389,7 +389,7 @@ mono_find_jit_icall_info (MonoJitICallId id)
 	const guint index = (guint)id;
 
 	g_assert (index < MONO_JIT_ICALL_count);
-	g_static_assert (MONO_JIT_ICALL_count < 0x200); // fits in 9 bits, see MonoCallInst
+	g_static_assert (MONO_JIT_ICALL_count < 0x200); // fits in 9 bits
 
 	return &mono_get_jit_icall_info ()->array [index];
 }

--- a/mono/mini/calls.c
+++ b/mono/mini/calls.c
@@ -27,6 +27,8 @@ mono_call_to_patch (MonoCallInst *call)
 	MonoJumpInfoTarget patch;
 	MonoJitICallId jit_icall_id;
 
+	// This is similar to amd64 emit_call.
+
 	if (call->inst.flags & MONO_INST_HAS_METHOD) {
 		patch.type = MONO_PATCH_INFO_METHOD;
 		patch.target = call->method;

--- a/mono/mini/calls.c
+++ b/mono/mini/calls.c
@@ -21,10 +21,10 @@
 static const gboolean debug_tailcall_break_compile = FALSE; // break in method_to_ir
 static const gboolean debug_tailcall_break_run = FALSE;     // insert breakpoint in generated code
 
-MonoJumpInfoPartial
+MonoJumpInfoTarget
 mono_call_to_patch (MonoCallInst *call)
 {
-	MonoJumpInfoPartial patch;
+	MonoJumpInfoTarget patch;
 	MonoJitICallId jit_icall_id;
 
 	if (call->inst.flags & MONO_INST_HAS_METHOD) {
@@ -43,7 +43,7 @@ mono_call_to_patch (MonoCallInst *call)
 void
 mono_call_add_patch_info (MonoCompile *cfg, MonoCallInst *call, int ip)
 {
-	const MonoJumpInfoPartial patch = mono_call_to_patch (call);
+	const MonoJumpInfoTarget patch = mono_call_to_patch (call);
 	mono_add_patch_info (cfg, ip, patch.type, patch.target);
 }
 

--- a/mono/mini/decompose.c
+++ b/mono/mini/decompose.c
@@ -1811,7 +1811,7 @@ mono_decompose_soft_float (MonoCompile *cfg)
 					MONO_INST_NEW (cfg, iargs [1], OP_ARG);
 					iargs [1]->dreg = ins->sreg2;
 
-					call = mono_emit_native_call (cfg, mono_icall_get_wrapper (info), info->sig, iargs);
+					call = mono_emit_jit_icall_id (cfg, mono_jit_icall_info_id (info), iargs);
 
 					MONO_INST_NEW (cfg, cmp, OP_ICOMPARE_IMM);
 					cmp->sreg1 = call->dreg;
@@ -1851,7 +1851,7 @@ mono_decompose_soft_float (MonoCompile *cfg)
 					MONO_INST_NEW (cfg, iargs [1], OP_ARG);
 					iargs [1]->dreg = ins->sreg2;
 
-					call = mono_emit_native_call (cfg, mono_icall_get_wrapper (info), info->sig, iargs);
+					call = mono_emit_jit_icall_id (cfg, mono_jit_icall_info_id (info), iargs);
 
 					MONO_EMIT_NEW_BIALU_IMM (cfg, OP_ICOMPARE_IMM, -1, call->dreg, 1);
 					MONO_EMIT_NEW_UNALU (cfg, OP_ICEQ, ins->dreg, -1);

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -3053,14 +3053,18 @@ emit_call (MonoCompile *cfg, MonoCallInst *call, guint8 *code, MonoJitICallId ji
 	gboolean no_patch = FALSE;
 	MonoJumpInfoTarget patch;
 
+	// FIXME? This is similar to mono_call_to_patch, except it favors MONO_PATCH_INFO_ABS over call->jit_icall_id.
+
 	if (jit_icall_id) {
 		g_assert (!call);
 		patch.type = MONO_PATCH_INFO_JIT_ICALL_ID;
 		patch.target = GUINT_TO_POINTER (jit_icall_id);
+	} else if (call->inst.flags & MONO_INST_HAS_METHOD) {
+		patch.type = MONO_PATCH_INFO_METHOD;
+		patch.target = call->method;
 	} else {
-		g_assert (!call->jit_icall_id);
-		patch = mono_call_to_patch (call);
-		g_assert (patch.type != MONO_PATCH_INFO_JIT_ICALL_ID);
+		patch.type = MONO_PATCH_INFO_ABS;
+		patch.target = call->fptr;
 	}
 
 	/* 

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -3048,13 +3048,20 @@ mono_arch_finish_dyn_call (MonoDynCallInfo *info, guint8 *buf)
 
 #ifndef DISABLE_JIT
 static guint8*
-emit_call (MonoCompile *cfg, MonoCallInst *call, guint8 *code, MonoJumpInfoType patch_type, gconstpointer data)
+emit_call (MonoCompile *cfg, MonoCallInst *call, guint8 *code, MonoJitICallId jit_icall_id)
 {
 	gboolean no_patch = FALSE;
+	MonoJumpInfoTarget patch;
 
-	g_assert (patch_type == MONO_PATCH_INFO_METHOD ||	// data is MonoMethod*; MONO_PATCH_INFO_METHOD_JUMP is also reasonable
-		  patch_type == MONO_PATCH_INFO_JIT_ICALL_ID ||	// data is function id
-		  patch_type == MONO_PATCH_INFO_ABS);		// data is code pointer, hashed to MonoJumpInfo* with additional patch type/data
+	if (jit_icall_id) {
+		g_assert (!call);
+		patch.type = MONO_PATCH_INFO_JIT_ICALL_ID;
+		patch.target = GUINT_TO_POINTER (jit_icall_id);
+	} else {
+		g_assert (!call->jit_icall_id);
+		patch = mono_call_to_patch (call);
+		g_assert (patch.type != MONO_PATCH_INFO_JIT_ICALL_ID);
+	}
 
 	/* 
 	 * FIXME: Add support for thunks
@@ -3068,40 +3075,37 @@ emit_call (MonoCompile *cfg, MonoCallInst *call, guint8 *code, MonoJumpInfoType 
 		 * guaranteed to be at a 32 bit offset.
 		 */
 
-		if (patch_type != MONO_PATCH_INFO_ABS) {
-
-			g_assert (!call);
+		if (patch.type != MONO_PATCH_INFO_ABS) {
 
 			/* The target is in memory allocated using the code manager */
 			near_call = TRUE;
 
-			if ((patch_type == MONO_PATCH_INFO_METHOD) || (patch_type == MONO_PATCH_INFO_METHOD_JUMP)) {
-				if (m_class_get_image (((MonoMethod*)data)->klass)->aot_module)
+			if (patch.type == MONO_PATCH_INFO_METHOD) {
+
+				MonoMethod* const method = call->method;
+
+				if (m_class_get_image (method->klass)->aot_module)
 					/* The callee might be an AOT method */
 					near_call = FALSE;
-				if (((MonoMethod*)data)->dynamic)
+				if (method->dynamic)
 					/* The target is in malloc-ed memory */
 					near_call = FALSE;
-			}
-
-			if (patch_type == MONO_PATCH_INFO_JIT_ICALL_ID) {
+			} else {
 				/* 
 				 * The call might go directly to a native function without
 				 * the wrapper.
 				 */
-				MonoJitICallInfo * const mi = mono_find_jit_icall_info ((MonoJitICallId)(gsize)data);
+				MonoJitICallInfo * const mi = mono_find_jit_icall_info (jit_icall_id);
 				gconstpointer target = mono_icall_get_wrapper (mi);
 				if ((((guint64)target) >> 32) != 0)
 					near_call = FALSE;
 			}
-		}
-		else {
+		} else {
 			MonoJumpInfo *jinfo = NULL;
 
-			g_assert (call && data && call->fptr == data);
-
 			if (cfg->abs_patches)
-				jinfo = (MonoJumpInfo *)g_hash_table_lookup (cfg->abs_patches, data);
+				jinfo = (MonoJumpInfo *)g_hash_table_lookup (cfg->abs_patches, call->fptr);
+
 			if (jinfo) {
 				if (jinfo->type == MONO_PATCH_INFO_JIT_ICALL_ADDR) {
 					MonoJitICallInfo *mi = mono_find_jit_icall_info (jinfo->data.jit_icall_id);
@@ -3116,28 +3120,25 @@ emit_call (MonoCompile *cfg, MonoCallInst *call, guint8 *code, MonoJumpInfoType 
 					near_call = TRUE;
 				}
 			} else {
-				MonoJitICallId jit_icall_id;
-				MonoJitICallInfo const *info = NULL;
+				jit_icall_id = call->jit_icall_id;
 
-				if (call && ((jit_icall_id = call->jit_icall_id))) {
-					info = mono_find_jit_icall_info (jit_icall_id);
+				if (jit_icall_id) {
+					MonoJitICallInfo const *info = mono_find_jit_icall_info (jit_icall_id);
 
 					// Change patch from MONO_PATCH_INFO_ABS to MONO_PATCH_INFO_JIT_ICALL_ID.
-					patch_type = MONO_PATCH_INFO_JIT_ICALL_ID;
-					data = GUINT_TO_POINTER (jit_icall_id);
-				}
-				if (info) {
+					patch.type = MONO_PATCH_INFO_JIT_ICALL_ID;
+					patch.target = GUINT_TO_POINTER (jit_icall_id);
+
 					if (info->func == info->wrapper) {
 						/* No wrapper */
 						if ((((guint64)info->func) >> 32) == 0)
 							near_call = TRUE;
-					}
-					else {
+					} else {
 						/* ?See the comment in mono_codegen ()? */
 						near_call = TRUE;
 					}
 				}
-				else if ((((guint64)data) >> 32) == 0) {
+				else if ((((guint64)patch.target) >> 32) == 0) {
 					near_call = TRUE;
 					no_patch = TRUE;
 				}
@@ -3170,7 +3171,7 @@ emit_call (MonoCompile *cfg, MonoCallInst *call, guint8 *code, MonoJumpInfoType 
 				guint32 pad_size = 4 - ((guint32)(code + 1 - cfg->native_code) % 4);
 				amd64_padding (code, pad_size);
 			}
-			mono_add_patch_info (cfg, code - cfg->native_code, patch_type, data);
+			mono_add_patch_info (cfg, code - cfg->native_code, patch.type, patch.target);
 			amd64_call_code (code, 0);
 		}
 		else {
@@ -3179,7 +3180,7 @@ emit_call (MonoCompile *cfg, MonoCallInst *call, guint8 *code, MonoJumpInfoType 
 				amd64_padding (code, pad_size);
 				g_assert ((guint64)(code + 2 - cfg->native_code) % 8 == 0);
 			}
-			mono_add_patch_info (cfg, code - cfg->native_code, patch_type, data);
+			mono_add_patch_info (cfg, code - cfg->native_code, patch.type, patch.target);
 			amd64_set_reg_template (code, GP_SCRATCH_REG);
 			amd64_call_reg (code, GP_SCRATCH_REG);
 		}
@@ -4929,10 +4930,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			call = (MonoCallInst*)ins;
 
 			code = amd64_handle_varargs_call (cfg, code, call, FALSE);
-			if (ins->flags & MONO_INST_HAS_METHOD)
-				code = emit_call (cfg, NULL, code, MONO_PATCH_INFO_METHOD, call->method);
-			else
-				code = emit_call (cfg, call, code, MONO_PATCH_INFO_ABS, call->fptr);
+			code = emit_call (cfg, call, code, MONO_JIT_ICALL_ZeroIsReserved);
 			ins->flags |= MONO_INST_GC_CALLSITE;
 			ins->backend.pc_offset = code - cfg->native_code;
 			code = emit_move_return_value (cfg, ins, code);
@@ -5092,7 +5090,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			jump = code;
 			amd64_branch8 (code, X86_CC_NZ, -1, 1);
 
-			code = emit_call (cfg, NULL, code, MONO_PATCH_INFO_JIT_ICALL_ID, GUINT_TO_POINTER (MONO_JIT_ICALL_mono_generic_class_init));
+			code = emit_call (cfg, NULL, code, MONO_JIT_ICALL_mono_generic_class_init);
 			ins->flags |= MONO_INST_GC_CALLSITE;
 			ins->backend.pc_offset = code - cfg->native_code;
 
@@ -5152,16 +5150,14 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		}
 		case OP_THROW: {
 			amd64_mov_reg_reg (code, AMD64_ARG_REG1, ins->sreg1, 8);
-			code = emit_call (cfg, NULL, code, MONO_PATCH_INFO_JIT_ICALL_ID,
-					     GUINT_TO_POINTER (MONO_JIT_ICALL_mono_arch_throw_exception));
+			code = emit_call (cfg, NULL, code, MONO_JIT_ICALL_mono_arch_throw_exception);
 			ins->flags |= MONO_INST_GC_CALLSITE;
 			ins->backend.pc_offset = code - cfg->native_code;
 			break;
 		}
 		case OP_RETHROW: {
 			amd64_mov_reg_reg (code, AMD64_ARG_REG1, ins->sreg1, 8);
-			code = emit_call (cfg, NULL, code, MONO_PATCH_INFO_JIT_ICALL_ID,
-					     GUINT_TO_POINTER (MONO_JIT_ICALL_mono_arch_rethrow_exception));
+			code = emit_call (cfg, NULL, code, MONO_JIT_ICALL_mono_arch_rethrow_exception);
 			ins->flags |= MONO_INST_GC_CALLSITE;
 			ins->backend.pc_offset = code - cfg->native_code;
 			break;
@@ -6798,7 +6794,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 
 			amd64_test_membase_imm_size (code, ins->sreg1, 0, 1, 4);
 			br[0] = code; x86_branch8 (code, X86_CC_EQ, 0, FALSE);
-			code = emit_call (cfg, NULL, code, MONO_PATCH_INFO_JIT_ICALL_ID, GUINT_TO_POINTER (MONO_JIT_ICALL_mono_threads_state_poll));
+			code = emit_call (cfg, NULL, code, MONO_JIT_ICALL_mono_threads_state_poll);
 			amd64_patch (br[0], code);
 			break;
 		}
@@ -6927,7 +6923,7 @@ emit_prolog_setup_sp_win64 (MonoCompile *cfg, guint8 *code, int alloc_size, int 
 
 		if (alloc_size >= 0x1000) {
 			amd64_mov_reg_imm (code, AMD64_RAX, alloc_size);
-			code = emit_call (cfg, NULL, code, MONO_PATCH_INFO_JIT_ICALL_ID, GUINT_TO_POINTER (MONO_JIT_ICALL_mono_chkstk_win64));
+			code = emit_call (cfg, NULL, code, MONO_JIT_ICALL_mono_chkstk_win64);
 		}
 
 		amd64_alu_reg_imm (code, X86_SUB, AMD64_RSP, alloc_size);
@@ -7601,7 +7597,7 @@ mono_arch_emit_exceptions (MonoCompile *cfg)
 
 				patch_info->type = MONO_PATCH_INFO_NONE;
 
-				code = emit_call (cfg, NULL, code, MONO_PATCH_INFO_JIT_ICALL_ID, GUINT_TO_POINTER (MONO_JIT_ICALL_mono_arch_throw_corlib_exception));
+				code = emit_call (cfg, NULL, code, MONO_JIT_ICALL_mono_arch_throw_corlib_exception);
 
 				amd64_mov_reg_imm (buf, AMD64_ARG_REG2, (code - cfg->native_code) - throw_ip);
 				while (buf < buf2)

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -4327,7 +4327,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_VCALL2: {
 
 			call = (MonoCallInst*)ins;
-			const MonoJumpInfoPartial patch = mono_call_to_patch (call);
+			const MonoJumpInfoTarget patch = mono_call_to_patch (call);
 			code = emit_call (cfg, code, patch.type, patch.target);
 			code = emit_move_return_value (cfg, code, ins);
 			break;

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -4328,8 +4328,13 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			call = (MonoCallInst*)ins;
 			if (ins->flags & MONO_INST_HAS_METHOD)
 				code = emit_call (cfg, code, MONO_PATCH_INFO_METHOD, call->method);
-			else
-				code = emit_call (cfg, code, MONO_PATCH_INFO_ABS, call->fptr);
+			else {
+				const MonoJitICallId jit_icall_id = call->jit_icall_id;
+				if (jit_icall_id)
+					code = emit_call (cfg, code, MONO_PATCH_INFO_JIT_ICALL_ID, GUINT_TO_POINTER (jit_icall_id));
+				else
+					code = emit_call (cfg, code, MONO_PATCH_INFO_ABS, call->fptr);
+			}
 			code = emit_move_return_value (cfg, code, ins);
 			break;
 		case OP_VOIDCALL_REG:

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -4324,19 +4324,14 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_LCALL:
 		case OP_FCALL:
 		case OP_RCALL:
-		case OP_VCALL2:
+		case OP_VCALL2: {
+
 			call = (MonoCallInst*)ins;
-			if (ins->flags & MONO_INST_HAS_METHOD)
-				code = emit_call (cfg, code, MONO_PATCH_INFO_METHOD, call->method);
-			else {
-				const MonoJitICallId jit_icall_id = call->jit_icall_id;
-				if (jit_icall_id)
-					code = emit_call (cfg, code, MONO_PATCH_INFO_JIT_ICALL_ID, GUINT_TO_POINTER (jit_icall_id));
-				else
-					code = emit_call (cfg, code, MONO_PATCH_INFO_ABS, call->fptr);
-			}
+			const MonoJumpInfoPartial patch = mono_call_to_patch (call);
+			code = emit_call (cfg, code, patch.type, patch.target);
 			code = emit_move_return_value (cfg, code, ins);
 			break;
+		}
 		case OP_VOIDCALL_REG:
 		case OP_CALL_REG:
 		case OP_LCALL_REG:

--- a/mono/mini/mini-codegen.c
+++ b/mono/mini/mini-codegen.c
@@ -604,6 +604,9 @@ mono_print_ins_index_strbuf (int i, MonoInst *ins)
 	case OP_RCALL_MEMBASE: {
 		MonoCallInst *call = (MonoCallInst*)ins;
 		GSList *list;
+		MonoJitICallId jit_icall_id;
+		gconstpointer fptr;
+		MonoMethod *method;
 
 		if (ins->opcode == OP_VCALL || ins->opcode == OP_VCALL_REG || ins->opcode == OP_VCALL_MEMBASE) {
 			/*
@@ -614,8 +617,8 @@ mono_print_ins_index_strbuf (int i, MonoInst *ins)
 				g_string_append_printf (sbuf, " R%d <-", ins->dreg);
 		}
 
-		if (call->method) {
-			char *full_name = mono_method_get_full_name (call->method);
+		if ((method = call->method)) {
+			char *full_name = mono_method_get_full_name (method);
 			g_string_append_printf (sbuf, " [%s]", full_name);
 			g_free (full_name);
 		} else if (call->fptr_is_patch) {
@@ -623,8 +626,12 @@ mono_print_ins_index_strbuf (int i, MonoInst *ins)
 
 			g_string_append_printf (sbuf, " ");
 			mono_print_ji (ji);
-		} else if (call->fptr) {
-			MonoJitICallInfo *info = mono_find_jit_icall_by_addr (call->fptr);
+		} else if ((jit_icall_id = call->jit_icall_id)) {
+			g_string_append_printf (sbuf, " [%s]", mono_find_jit_icall_info (jit_icall_id)->name);
+		} else if ((fptr = call->fptr)) {
+			MonoJitICallInfo *info = mono_find_jit_icall_by_addr (fptr);
+			// FIXME test this
+			g_assertf (!info, "%s", info->name);
 			if (info)
 				g_string_append_printf (sbuf, " [%s]", info->name);
 		}

--- a/mono/mini/mini-codegen.c
+++ b/mono/mini/mini-codegen.c
@@ -605,7 +605,6 @@ mono_print_ins_index_strbuf (int i, MonoInst *ins)
 		MonoCallInst *call = (MonoCallInst*)ins;
 		GSList *list;
 		MonoJitICallId jit_icall_id;
-		gconstpointer fptr;
 		MonoMethod *method;
 
 		if (ins->opcode == OP_VCALL || ins->opcode == OP_VCALL_REG || ins->opcode == OP_VCALL_MEMBASE) {
@@ -628,12 +627,6 @@ mono_print_ins_index_strbuf (int i, MonoInst *ins)
 			mono_print_ji (ji);
 		} else if ((jit_icall_id = call->jit_icall_id)) {
 			g_string_append_printf (sbuf, " [%s]", mono_find_jit_icall_info (jit_icall_id)->name);
-		} else if ((fptr = call->fptr)) {
-			MonoJitICallInfo *info = mono_find_jit_icall_by_addr (fptr);
-			// FIXME test this
-			g_assertf (!info, "%s", info->name);
-			if (info)
-				g_string_append_printf (sbuf, " [%s]", info->name);
 		}
 
 		list = call->out_ireg_args;

--- a/mono/mini/mini-llvm.c
+++ b/mono/mini/mini-llvm.c
@@ -3856,17 +3856,17 @@ process_call (EmitContext *ctx, MonoBasicBlock *bb, LLVMBuilderRef *builder_ref,
 		}
 	} else if (calli) {
 	} else {
-		MonoJitICallInfo *info = mono_find_jit_icall_by_addr (call->fptr);
+		const MonoJitICallId jit_icall_id = call->jit_icall_id;
 
-		if (info) {
+		if (jit_icall_id) {
 			if (cfg->compile_aot) {
-				callee = get_callee (ctx, llvm_sig, MONO_PATCH_INFO_JIT_ICALL_ID, GUINT_TO_POINTER (mono_jit_icall_info_id (info)));
+				callee = get_callee (ctx, llvm_sig, MONO_PATCH_INFO_JIT_ICALL_ID, GUINT_TO_POINTER (jit_icall_id));
 				if (!callee) {
 					set_failure (ctx, "can't encode patch");
 					return;
 				}
 			} else {
-				callee = get_jit_callee (ctx, "", llvm_sig, MONO_PATCH_INFO_JIT_ICALL_ID, GUINT_TO_POINTER (mono_jit_icall_info_id (info)));
+				callee = get_jit_callee (ctx, "", llvm_sig, MONO_PATCH_INFO_JIT_ICALL_ID, GUINT_TO_POINTER (jit_icall_id));
 			}
 		} else {
 			if (cfg->compile_aot) {

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -629,10 +629,8 @@ mono_icall_get_wrapper_full (MonoJitICallInfo* callinfo, gboolean do_compile)
 	gconstpointer addr, trampoline;
 	MonoDomain *domain = mono_get_root_domain ();
 
-	if (callinfo->wrapper) {
-		// FIXME partial barrier needed here?
+	if (callinfo->wrapper)
 		return callinfo->wrapper;
-	}
 
 	wrapper = mono_icall_get_wrapper_method (callinfo);
 
@@ -643,10 +641,8 @@ mono_icall_get_wrapper_full (MonoJitICallInfo* callinfo, gboolean do_compile)
 		callinfo->wrapper = addr;
 		return addr;
 	} else {
-		if (callinfo->trampoline) {
-			// FIXME partial barrier needed here?
+		if (callinfo->trampoline)
 			return callinfo->trampoline;
-		}
 		trampoline = mono_create_jit_trampoline (domain, wrapper, error);
 		mono_error_assert_ok (error);
 		trampoline = mono_create_ftnptr (domain, (gpointer)trampoline);
@@ -2469,7 +2465,7 @@ lookup_start:
 
 	if (callinfo) {
 		// FIXME Locking here is somewhat historical due to mono_register_jit_icall_wrapper taking loader lock.
-		// atomic_compare_exchange should suffice, and partial barriers on the readers?
+		// atomic_compare_exchange should suffice.
 		mono_loader_lock ();
 		mono_jit_lock ();
 		if (!callinfo->wrapper) {

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -2641,8 +2641,9 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		}
 			break;
 		case OP_BREAK: {
-			mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_ABS, 
-					     mono_break);
+			mono_add_patch_info (cfg, code - cfg->native_code,
+					     MONO_PATCH_INFO_JIT_ICALL_ID,
+					     GUINT_TO_POINTER (MONO_JIT_ICALL_mono_break);
 			S390_CALL_TEMPLATE (code, s390_r14);
 		}
 			break;
@@ -3617,10 +3618,17 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				mono_add_patch_info (cfg, code-cfg->native_code,
 						     MONO_PATCH_INFO_METHOD, 
 						     call->method);
-			else
-				mono_add_patch_info (cfg, code-cfg->native_code,
-						     MONO_PATCH_INFO_ABS, 
-						     call->fptr);
+			else {
+				const MonoJitICallId jit_icall_id = call->jit_icall_id;
+				if (jit_icall_id)
+					mono_add_patch_info (cfg, code-cfg->native_code,
+							     MONO_PATCH_INFO_JIT_ICALL_ID,
+							     GUINT_TO_POINTER (jit_icall_id));
+				else
+					mono_add_patch_info (cfg, code-cfg->native_code,
+							     MONO_PATCH_INFO_ABS,
+							     call->fptr);
+			}
 			S390_CALL_TEMPLATE (code, s390_r14);
 			if (!cfg->r4fp && call->signature->ret->type == MONO_TYPE_R4)
 				s390_ldebr (code, s390_f0, s390_f0);
@@ -4637,8 +4645,8 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 
 			s390_ltg (code, s390_r0, 0, ins->sreg1, 0);	
 			s390_jz  (code, 0); CODEPTR(code, br);
-			mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_ABS,
-					     mono_threads_state_poll);
+			mono_add_patch_info (cfg, code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL_ID,
+					     GUINT_TO_POINTER (MONO_JIT_ICALL_mono_threads_state_poll));
 			S390_CALL_TEMPLATE (code, s390_r14);
 			PTRSLOT (code, br);
 			break;

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -3614,21 +3614,8 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			break;
 		case OP_FCALL: {
 			call = (MonoCallInst*)ins;
-			if (ins->flags & MONO_INST_HAS_METHOD)
-				mono_add_patch_info (cfg, code-cfg->native_code,
-						     MONO_PATCH_INFO_METHOD, 
-						     call->method);
-			else {
-				const MonoJitICallId jit_icall_id = call->jit_icall_id;
-				if (jit_icall_id)
-					mono_add_patch_info (cfg, code-cfg->native_code,
-							     MONO_PATCH_INFO_JIT_ICALL_ID,
-							     GUINT_TO_POINTER (jit_icall_id));
-				else
-					mono_add_patch_info (cfg, code-cfg->native_code,
-							     MONO_PATCH_INFO_ABS,
-							     call->fptr);
-			}
+
+			mono_call_add_patch_info (cfg, call, code - cfg->native_code);
 			S390_CALL_TEMPLATE (code, s390_r14);
 			if (!cfg->r4fp && call->signature->ret->type == MONO_TYPE_R4)
 				s390_ldebr (code, s390_f0, s390_f0);

--- a/mono/mini/mini-sparc.c
+++ b/mono/mini/mini-sparc.c
@@ -2871,22 +2871,17 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_VCALL:
 		case OP_VCALL2:
 		case OP_VOIDCALL:
-		case OP_CALL:
+		case OP_CALL: {
 			call = (MonoCallInst*)ins;
 			g_assert (!call->virtual);
 			code = emit_save_sp_to_lmf (cfg, code);
-			if (ins->flags & MONO_INST_HAS_METHOD)
-			    code = emit_call (cfg, code, MONO_PATCH_INFO_METHOD, call->method);
-			else {
-				const MonoJitICallId jit_icall_id = call->jit_icall_id;
-				if (jit_icall_id)
-					code = emit_call (cfg, code, MONO_PATCH_INFO_JIT_ICALL_ID, GUINT_TO_POINTER (jit_icall_id));
-				else
-					code = emit_call (cfg, code, MONO_PATCH_INFO_ABS, call->fptr);
-			}
+
+			const MonoJumpInfoPartial patch = mono_call_to_patch (call);
+			code = emit_call (cfg, code, patch.type, patch.target);
 			code = emit_vret_token (ins, code);
 			code = emit_move_return_value (ins, code);
 			break;
+		}
 		case OP_FCALL_REG:
 		case OP_LCALL_REG:
 		case OP_VCALL_REG:

--- a/mono/mini/mini-sparc.c
+++ b/mono/mini/mini-sparc.c
@@ -2558,7 +2558,8 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			 * breakpoint there.
 			 */
 			//sparc_ta (code, 1);
-			mono_add_patch_info (cfg, offset, MONO_PATCH_INFO_ABS, mono_break);
+			mono_add_patch_info (cfg, offset, MONO_PATCH_INFO_JIT_ICALL_ID,
+					     GUINT_TO_POINTER (MONO_JIT_ICALL_mono_break));
 			EMIT_CALL();
 			break;
 		case OP_ADDCC:
@@ -2876,9 +2877,13 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			code = emit_save_sp_to_lmf (cfg, code);
 			if (ins->flags & MONO_INST_HAS_METHOD)
 			    code = emit_call (cfg, code, MONO_PATCH_INFO_METHOD, call->method);
-			else
-			    code = emit_call (cfg, code, MONO_PATCH_INFO_ABS, call->fptr);
-
+			else {
+				const MonoJitICallId jit_icall_id = call->jit_icall_id;
+				if (jit_icall_id)
+					code = emit_call (cfg, code, MONO_PATCH_INFO_JIT_ICALL_ID, GUINT_TO_POINTER (jit_icall_id));
+				else
+					code = emit_call (cfg, code, MONO_PATCH_INFO_ABS, call->fptr);
+			}
 			code = emit_vret_token (ins, code);
 			code = emit_move_return_value (ins, code);
 			break;
@@ -3702,8 +3707,9 @@ mono_arch_patch_code (MonoCompile *cfg, MonoMethod *method, MonoDomain *domain, 
 	}
 }
 
+#error obsolete tracing?
 void*
-mono_arch_instrument_prolog (MonoCompile *cfg, void *func, void *p, gboolean enable_arguments)
+mono_arch_instrument_prolog (MonoCompile *cfg, MonoJitICallId func, void *p, gboolean enable_arguments)
 {
 	int i;
 	guint32 *code = (guint32*)p;
@@ -3737,7 +3743,7 @@ mono_arch_instrument_prolog (MonoCompile *cfg, void *func, void *p, gboolean ena
 	sparc_set (code, cfg->method, sparc_o0);
 	sparc_add_imm (code, FALSE, sparc_fp, MONO_SPARC_STACK_BIAS, sparc_o1);
 
-	mono_add_patch_info (cfg, (guint8*)code-cfg->native_code, MONO_PATCH_INFO_ABS, func);
+	mono_add_patch_info (cfg, (guint8*)code-cfg->native_code, MONO_PATCH_INFO_JIT_ICALL_ID, GUINT_TO_POINTER (func));
 	EMIT_CALL ();
 
 	/* Restore float regs on V9 */
@@ -3771,8 +3777,9 @@ enum {
 	SAVE_FP
 };
 
+#error obsolete tracing?
 void*
-mono_arch_instrument_epilog (MonoCompile *cfg, void *func, void *p, gboolean enable_arguments)
+mono_arch_instrument_epilog (MonoCompile *cfg, MonoJitICallId func, void *p, gboolean enable_arguments)
 {
 	guint32 *code = (guint32*)p;
 	int save_mode = SAVE_NONE;
@@ -3843,7 +3850,7 @@ mono_arch_instrument_epilog (MonoCompile *cfg, void *func, void *p, gboolean ena
 
 	sparc_set (code, cfg->method, sparc_o0);
 
-	mono_add_patch_info (cfg, (guint8*)code - cfg->native_code, MONO_PATCH_INFO_ABS, func);
+	mono_add_patch_info (cfg, (guint8*)code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL_ID, GUINT_TO_POINTER (func));
 	EMIT_CALL ();
 
 	/* Restore result */
@@ -3923,7 +3930,8 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 
 /*
 	if (strstr (cfg->method->name, "foo")) {
-		mono_add_patch_info (cfg, (guint8*)code - cfg->native_code, MONO_PATCH_INFO_ABS, mono_sparc_break);
+		mono_add_patch_info (cfg, (guint8*)code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL_ID,
+					     GUINT_TO_POINTER (MONO_JIT_ICALL_mono_sparc_break));
 		sparc_call_simple (code, 0);
 		sparc_nop (code);
 	}
@@ -4074,8 +4082,9 @@ mono_arch_emit_prolog (MonoCompile *cfg)
 		code = (guint32*)mono_sparc_emit_save_lmf (code, lmf_offset);
 	}
 
+#error obsolete tracing?
 	if (mono_jit_trace_calls != NULL && mono_trace_eval (method))
-		code = (guint32*)mono_arch_instrument_prolog (cfg, mono_trace_enter_method, code, TRUE);
+		code = (guint32*)mono_arch_instrument_prolog (cfg, MONO_JIT_ICALL_mono_trace_enter_method, code, TRUE);
 
 	set_code_cursor (cfg, code);
 
@@ -4098,6 +4107,7 @@ mono_arch_emit_epilog (MonoCompile *cfg)
 
 	code = (guint32 *)realloc_code (cfg, max_epilog_size);
 
+#error obsolete tracing?
 	if (mono_jit_trace_calls != NULL && mono_trace_eval (method))
 		code = (guint32*)mono_arch_instrument_epilog (cfg, mono_trace_leave_method, code, TRUE);
 
@@ -4227,7 +4237,8 @@ mono_arch_emit_exceptions (MonoCompile *cfg)
 				}
 
 				/*
-				mono_add_patch_info (cfg, (guint8*)code - cfg->native_code, MONO_PATCH_INFO_ABS, mono_sparc_break);
+				mono_add_patch_info (cfg, (guint8*)code - cfg->native_code, MONO_PATCH_INFO_JIT_ICALL_ID,
+					     GUINT_TO_POINTER (MONO_JIT_ICALL_mono_sparc_break));
 				EMIT_CALL();
 				*/
 

--- a/mono/mini/mini-sparc.c
+++ b/mono/mini/mini-sparc.c
@@ -2876,7 +2876,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			g_assert (!call->virtual);
 			code = emit_save_sp_to_lmf (cfg, code);
 
-			const MonoJumpInfoPartial patch = mono_call_to_patch (call);
+			const MonoJumpInfoTarget patch = mono_call_to_patch (call);
 			code = emit_call (cfg, code, patch.type, patch.target);
 			code = emit_vret_token (ins, code);
 			code = emit_move_return_value (ins, code);

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -3082,17 +3082,11 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			case OP_VCALL:
 			case OP_VCALL2:
 			case OP_VOIDCALL:
-			case OP_CALL:
-				if (ins->flags & MONO_INST_HAS_METHOD)
-					code = emit_call (cfg, code, MONO_PATCH_INFO_METHOD, call->method);
-				else {
-					const MonoJitICallId jit_icall_id = call->jit_icall_id;
-					if (jit_icall_id)
-						code = emit_call (cfg, code, MONO_PATCH_INFO_JIT_ICALL_ID, GUINT_TO_POINTER (jit_icall_id));
-					else
-						code = emit_call (cfg, code, MONO_PATCH_INFO_ABS, call->fptr);
-				}
+			case OP_CALL: {
+				const MonoJumpInfoPartial patch = mono_call_to_patch (call);
+				code = emit_call (cfg, code, patch.type, patch.target);
 				break;
+			}
 			case OP_FCALL_REG:
 			case OP_LCALL_REG:
 			case OP_VCALL_REG:

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -3083,7 +3083,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			case OP_VCALL2:
 			case OP_VOIDCALL:
 			case OP_CALL: {
-				const MonoJumpInfoPartial patch = mono_call_to_patch (call);
+				const MonoJumpInfoTarget patch = mono_call_to_patch (call);
 				code = emit_call (cfg, code, patch.type, patch.target);
 				break;
 			}

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -3085,8 +3085,13 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			case OP_CALL:
 				if (ins->flags & MONO_INST_HAS_METHOD)
 					code = emit_call (cfg, code, MONO_PATCH_INFO_METHOD, call->method);
-				else
-					code = emit_call (cfg, code, MONO_PATCH_INFO_ABS, call->fptr);
+				else {
+					const MonoJitICallId jit_icall_id = call->jit_icall_id;
+					if (jit_icall_id)
+						code = emit_call (cfg, code, MONO_PATCH_INFO_JIT_ICALL_ID, GUINT_TO_POINTER (jit_icall_id));
+					else
+						code = emit_call (cfg, code, MONO_PATCH_INFO_ABS, call->fptr);
+				}
 				break;
 			case OP_FCALL_REG:
 			case OP_LCALL_REG:

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -2090,6 +2090,7 @@ mono_postprocess_patches (MonoCompile *cfg)
 		switch (patch_info->type) {
 		case MONO_PATCH_INFO_ABS: {
 			MonoJitICallInfo *info = mono_find_jit_icall_by_addr (patch_info->data.target);
+			g_assertf (!info, "%s", info->name);
 
 			/*
 			 * Change patches of type MONO_PATCH_INFO_ABS into patches describing the 

--- a/mono/mini/mini.c
+++ b/mono/mini/mini.c
@@ -2089,28 +2089,17 @@ mono_postprocess_patches (MonoCompile *cfg)
 	for (patch_info = cfg->patch_info; patch_info; patch_info = patch_info->next) {
 		switch (patch_info->type) {
 		case MONO_PATCH_INFO_ABS: {
-			MonoJitICallInfo *info = mono_find_jit_icall_by_addr (patch_info->data.target);
-			g_assertf (!info, "%s", info->name);
-
 			/*
-			 * Change patches of type MONO_PATCH_INFO_ABS into patches describing the 
+			 * Change patches of type MONO_PATCH_INFO_ABS into patches describing the
 			 * absolute address.
 			 */
-			if (info) {
-				patch_info->type = MONO_PATCH_INFO_JIT_ICALL_ID;
-				patch_info->data.jit_icall_id = mono_jit_icall_info_id (info);
-			}
-
-			if (patch_info->type == MONO_PATCH_INFO_ABS) {
-				if (cfg->abs_patches) {
-					MonoJumpInfo *abs_ji = (MonoJumpInfo *)g_hash_table_lookup (cfg->abs_patches, patch_info->data.target);
-					if (abs_ji) {
-						patch_info->type = abs_ji->type;
-						patch_info->data.target = abs_ji->data.target;
-					}
+			if (cfg->abs_patches) {
+				MonoJumpInfo *abs_ji = (MonoJumpInfo *)g_hash_table_lookup (cfg->abs_patches, patch_info->data.target);
+				if (abs_ji) {
+					patch_info->type = abs_ji->type;
+					patch_info->data.target = abs_ji->data.target;
 				}
 			}
-
 			break;
 		}
 		case MONO_PATCH_INFO_SWITCH: {

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -787,6 +787,11 @@ struct MonoCallInst {
 	guint tailcall : 1;
 	/* If this is TRUE, 'fptr' points to a MonoJumpInfo instead of an address. */
 	guint fptr_is_patch : 1;
+#if __cplusplus
+	MonoJitICallId jit_icall_id : 9; // 9 is checked in jit-icall-reg.h mono_find_jit_icall_info
+#else
+	guint jit_icall_id : 9; // 9 is checked in jit-icall-reg.h mono_find_jit_icall_info
+#endif
 	/*
 	 * If this is true, then the call returns a vtype in a register using the same 
 	 * calling convention as OP_CALL.
@@ -2092,13 +2097,11 @@ gboolean mono_compile_is_broken (MonoCompile *cfg, MonoMethod *method, gboolean 
 MonoInst *mono_get_got_var (MonoCompile *cfg);
 void      mono_add_seq_point (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins, int native_offset);
 void      mono_add_var_location (MonoCompile *cfg, MonoInst *var, gboolean is_reg, int reg, int offset, int from, int to);
-MonoInst* mono_emit_jit_icall_info (MonoCompile *cfg, MonoJitICallInfo *jit_icall_info, MonoInst **args); // FIXME remove/reduce
 MonoInst* mono_emit_jit_icall_id (MonoCompile *cfg, MonoJitICallId jit_icall_id, MonoInst **args);
 #define mono_emit_jit_icall(cfg, name, args) (mono_emit_jit_icall_id ((cfg), MONO_JIT_ICALL_ ## name, (args)))
 
 MonoInst* mono_emit_jit_icall_by_info (MonoCompile *cfg, int il_offset, MonoJitICallInfo *info, MonoInst **args);
 MonoInst* mono_emit_method_call (MonoCompile *cfg, MonoMethod *method, MonoInst **args, MonoInst *this_ins);
-MonoInst* mono_emit_native_call (MonoCompile *cfg, gconstpointer func, MonoMethodSignature *sig, MonoInst **args);
 gboolean  mini_should_insert_breakpoint (MonoMethod *method);
 int mono_target_pagesize (void);
 

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2074,6 +2074,11 @@ guint     mini_type_to_stind                (MonoCompile* cfg, MonoType *type);
 MonoJitInfo* mini_lookup_method             (MonoDomain *domain, MonoMethod *method, MonoMethod *shared);
 guint32   mono_reverse_branch_op            (guint32 opcode);
 void      mono_disassemble_code             (MonoCompile *cfg, guint8 *code, int size, char *id);
+ typedef struct MonoJumpInfoPartial {
+	MonoJumpInfoType type;
+	gconstpointer   target;
+} MonoJumpInfoPartial;
+MonoJumpInfoPartial mono_call_to_patch      (MonoCallInst *call);
 void      mono_call_add_patch_info          (MonoCompile *cfg, MonoCallInst *call, int ip);
 void      mono_add_patch_info               (MonoCompile *cfg, int ip, MonoJumpInfoType type, gconstpointer target) MONO_LLVM_INTERNAL;
 void      mono_add_patch_info_rel           (MonoCompile *cfg, int ip, MonoJumpInfoType type, gconstpointer target, int relocation) MONO_LLVM_INTERNAL;

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -2074,11 +2074,12 @@ guint     mini_type_to_stind                (MonoCompile* cfg, MonoType *type);
 MonoJitInfo* mini_lookup_method             (MonoDomain *domain, MonoMethod *method, MonoMethod *shared);
 guint32   mono_reverse_branch_op            (guint32 opcode);
 void      mono_disassemble_code             (MonoCompile *cfg, guint8 *code, int size, char *id);
- typedef struct MonoJumpInfoPartial {
+// Subset of MonoJumpInfo.
+ typedef struct MonoJumpInfoTarget {
 	MonoJumpInfoType type;
 	gconstpointer   target;
-} MonoJumpInfoPartial;
-MonoJumpInfoPartial mono_call_to_patch      (MonoCallInst *call);
+} MonoJumpInfoTarget;
+MonoJumpInfoTarget mono_call_to_patch       (MonoCallInst *call);
 void      mono_call_add_patch_info          (MonoCompile *cfg, MonoCallInst *call, int ip);
 void      mono_add_patch_info               (MonoCompile *cfg, int ip, MonoJumpInfoType type, gconstpointer target) MONO_LLVM_INTERNAL;
 void      mono_add_patch_info_rel           (MonoCompile *cfg, int ip, MonoJumpInfoType type, gconstpointer target, int relocation) MONO_LLVM_INTERNAL;

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -787,11 +787,7 @@ struct MonoCallInst {
 	guint tailcall : 1;
 	/* If this is TRUE, 'fptr' points to a MonoJumpInfo instead of an address. */
 	guint fptr_is_patch : 1;
-#if __cplusplus
-	MonoJitICallId jit_icall_id : 9; // 9 is checked in jit-icall-reg.h mono_find_jit_icall_info
-#else
-	guint jit_icall_id : 9; // 9 is checked in jit-icall-reg.h mono_find_jit_icall_info
-#endif
+	MonoJitICallId jit_icall_id;
 	/*
 	 * If this is true, then the call returns a vtype in a register using the same 
 	 * calling convention as OP_CALL.

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -1132,6 +1132,12 @@ typedef struct MonoJumpInfoRgctxEntry MonoJumpInfoRgctxEntry;
 typedef struct MonoJumpInfo MonoJumpInfo;
 typedef struct MonoJumpInfoGSharedVtCall MonoJumpInfoGSharedVtCall;
 
+// Subset of MonoJumpInfo.
+ typedef struct MonoJumpInfoTarget {
+	MonoJumpInfoType type;
+	gconstpointer   target;
+} MonoJumpInfoTarget;
+
 // This ordering is mimiced in MONO_JIT_ICALLS.
 typedef enum {
 	MONO_TRAMPOLINE_JIT      = 0,
@@ -2074,11 +2080,6 @@ guint     mini_type_to_stind                (MonoCompile* cfg, MonoType *type);
 MonoJitInfo* mini_lookup_method             (MonoDomain *domain, MonoMethod *method, MonoMethod *shared);
 guint32   mono_reverse_branch_op            (guint32 opcode);
 void      mono_disassemble_code             (MonoCompile *cfg, guint8 *code, int size, char *id);
-// Subset of MonoJumpInfo.
- typedef struct MonoJumpInfoTarget {
-	MonoJumpInfoType type;
-	gconstpointer   target;
-} MonoJumpInfoTarget;
 MonoJumpInfoTarget mono_call_to_patch       (MonoCallInst *call);
 void      mono_call_add_patch_info          (MonoCompile *cfg, MonoCallInst *call, int ip);
 void      mono_add_patch_info               (MonoCompile *cfg, int ip, MonoJumpInfoType type, gconstpointer target) MONO_LLVM_INTERNAL;

--- a/mono/mini/tramp-wasm.c
+++ b/mono/mini/tramp-wasm.c
@@ -4,30 +4,34 @@
 void mono_wasm_interp_to_native_trampoline (void *target_func, InterpMethodArguments *margs);
 void mono_sdb_single_step_trampoline (void);
 
+static void
+mono_wasm_specific_trampoline (void)
+{
+	g_error (__func__);
+}
+
 gpointer
 mono_arch_create_specific_trampoline (gpointer arg1, MonoTrampolineType tramp_type, MonoDomain *domain, guint32 *code_len)
 {
-	//FUN FACT but this is a key used to do reverse lookups when resolving patch entries!
-	//it's seeded to mono_register_jit_icall_wrapper and then used to reverse that value in mini-llvm <o>
-	return g_malloc (1);
+	return (gpointer)mono_wasm_specific_trampoline;
 }
 
 guchar*
 mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInfo **info, gboolean aot)
 {
-	g_error ("mono_arch_create_generic_trampoline");
+	g_error (__func__);
 }
 
 gpointer
 mono_arch_create_rgctx_lazy_fetch_trampoline (guint32 slot, MonoTrampInfo **info, gboolean aot)
 {
-	g_error ("mono_arch_create_rgctx_lazy_fetch_trampoline");
+	g_error (__func__);
 }
 
 void
 mono_arch_patch_plt_entry (guint8 *code, gpointer *got, host_mgreg_t *regs, guint8 *addr)
 {
-	g_error ("mono_arch_patch_plt_entry");
+	g_error (__func__);
 }
 
 void
@@ -39,14 +43,14 @@ mono_arch_patch_callsite (guint8 *method_start, guint8 *orig_code, guint8 *addr)
 gpointer
 mono_arch_get_unbox_trampoline (MonoMethod *m, gpointer addr)
 {
-	g_error ("mono_arch_get_unbox_trampoline");
+	g_error (__func__);
 	return NULL;
 }
 
 gpointer
 mono_arch_get_static_rgctx_trampoline (gpointer arg, gpointer addr)
 {
-	g_error ("mono_arch_get_static_rgctx_trampoline");
+	g_error (__func__);
 	return NULL;
 }
 
@@ -91,20 +95,20 @@ mono_arch_get_call_target (guint8 *code)
 guint32
 mono_arch_get_plt_info_offset (guint8 *plt_entry, host_mgreg_t *regs, guint8 *code)
 {
-	g_error ("mono_arch_get_plt_info_offset");
+	g_error (__func__);
 	return *(guint32*)(plt_entry + 6);
 }
 
 gpointer
 mono_arch_get_gsharedvt_arg_trampoline (MonoDomain *domain, gpointer arg, gpointer addr)
 {
-	g_assert_not_reached ();
+	g_error (__func__);
 	return NULL;
 }
 
 gpointer
 mono_arch_get_gsharedvt_trampoline (MonoTrampInfo **info, gboolean aot)
 {
-	g_assert_not_reached ();
+	g_error (__func__);
 	return NULL;
 }


### PR DESCRIPTION
Due to https://github.com/mono/mono/pull/11941#issuecomment-449157323.

 -  Work toward removing JIT icall hashing by address.
Mostly remove it, assert it isn't needed/used.

 - Actually remove JIT icall hashing by address.