### PR TITLE
[Wasm] Fix memory override in mono_wasm_add_assembly

### DIFF
--- a/sdks/wasm/driver.c
+++ b/sdks/wasm/driver.c
@@ -149,7 +149,7 @@ mono_wasm_add_assembly (const char *name, const unsigned char *data, unsigned in
 		mono_register_symfile_for_assembly (new_name, data, size);
 		return;
 	}
-	WasmAssembly *entry = (WasmAssembly *)malloc(sizeof (MonoBundledAssembly));
+	WasmAssembly *entry = (WasmAssembly *)malloc(sizeof (WasmAssembly));
 	entry->assembly.name = m_strdup (name);
 	entry->assembly.data = data;
 	entry->assembly.size = size;


### PR DESCRIPTION
Fixed the real issue, where the malloc was not requesting the proper structure size.

~~This change avoids the inclusion of the emscripten `dlmalloc` library which seems to have stability issues (memory overwrite on allocation) using the release-dynamic configuration.~~