### PR TITLE
[aot profiler] Listen for commands on given port

### DIFF
--- a/mono/profiler/Makefile.am
+++ b/mono/profiler/Makefile.am
@@ -113,13 +113,13 @@ endif
 # the shared version on those targets since it's useful for e.g. simulator
 # builds.
 
-libmono_profiler_aot_la_SOURCES = aot.c
+libmono_profiler_aot_la_SOURCES = aot.c helper.c
 libmono_profiler_aot_la_LIBADD =  $(libmono_dep) $(glib_libs)
 libmono_profiler_aot_la_LDFLAGS = $(prof_ldflags)
 libmono_profiler_aot_static_la_SOURCES = aot.c
 libmono_profiler_aot_static_la_LDFLAGS = -static
 
-libmono_profiler_log_la_SOURCES = log.c log-args.c
+libmono_profiler_log_la_SOURCES = log.c log-args.c helper.c
 libmono_profiler_log_la_LIBADD = $(libmono_dep) $(glib_libs) $(zlib_dep)
 libmono_profiler_log_la_LDFLAGS = $(prof_ldflags)
 libmono_profiler_log_static_la_SOURCES = log.c log-args.c

--- a/mono/profiler/aot.c
+++ b/mono/profiler/aot.c
@@ -9,6 +9,7 @@
 #include <config.h>
 
 #include "aot.h"
+#include "helper.h"
 
 #include <mono/metadata/object-internals.h>
 #include <mono/metadata/profiler.h>
@@ -24,19 +25,22 @@
 #include <string.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <sys/socket.h>
 #include <glib.h>
-#include <mono/utils/mono-error-internals.h>
 
 struct _MonoProfiler {
 	GHashTable *classes;
 	GHashTable *images;
 	GPtrArray *methods;
 	FILE *outfile;
+	FILE *savefile;
 	int id;
 	char *outfile_name;
 	mono_mutex_t mutex;
 	gboolean verbose;
 	int duration;
+	int command_port;
+	int server_socket;
 };
 
 static MonoProfiler aot_profiler;
@@ -67,6 +71,7 @@ usage (void)
 	mono_profiler_printf ("\tduration=NUM         profile only NUM seconds of runtime and write the data");
 	mono_profiler_printf ("\thelp                 show this usage info");
 	mono_profiler_printf ("\toutput=FILENAME      write the data to file FILENAME");
+	mono_profiler_printf ("\tport=PORT            use PORT to listen for command server connections");
 	mono_profiler_printf ("\tverbose              print diagnostic info");
 
 	exit (0);
@@ -104,6 +109,9 @@ parse_arg (const char *arg)
 		aot_profiler.duration = strtoul (val, &end, 10);
 	} else if (match_option (arg, "output", &val)) {
 		aot_profiler.outfile_name = g_strdup (val);
+	} else if (match_option (arg, "port", &val)) {
+		char *end;
+		aot_profiler.command_port = strtoul (val, &end, 10);
 	} else if (match_option (arg, "verbose", NULL)) {
 		aot_profiler.verbose = TRUE;
 	} else {
@@ -166,6 +174,8 @@ parse_args (const char *desc)
 	g_free (buffer);
 }
 
+static void prof_save (MonoProfiler *prof, FILE* file);
+
 static void *
 helper_thread (void *arg)
 {
@@ -182,7 +192,95 @@ helper_thread (void *arg)
 
 	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NO_GC | MONO_THREAD_INFO_FLAGS_NO_SAMPLE);
 
-	sleep (aot_profiler.duration);
+	if (aot_profiler.duration >= 0) {
+		sleep (aot_profiler.duration);
+	} else if (aot_profiler.command_port >= 0) {
+		GArray *command_sockets = g_array_new (FALSE, FALSE, sizeof (int));
+
+		while (1) {
+			fd_set rfds;
+			int max_fd = -1;
+			int quit_command_received = 0;
+
+			FD_ZERO (&rfds);
+
+			add_to_fd_set (&rfds, aot_profiler.server_socket, &max_fd);
+
+			for (gint i = 0; i < command_sockets->len; i++)
+				add_to_fd_set (&rfds, g_array_index (command_sockets, int, i), &max_fd);
+
+			struct timeval tv = { .tv_sec = 1, .tv_usec = 0 };
+
+			// Sleep for 1sec or until a file descriptor has data.
+			if (select (max_fd + 1, &rfds, NULL, NULL, &tv) == -1) {
+				if (errno == EINTR)
+					continue;
+
+				mono_profiler_printf_err ("Could not poll in aot profiler helper thread: %s", g_strerror (errno));
+				exit (1);
+			}
+
+			for (gint i = 0; i < command_sockets->len; i++) {
+				int fd = g_array_index (command_sockets, int, i);
+
+				if (!FD_ISSET (fd, &rfds))
+					continue;
+
+				char buf [64];
+				int len = read (fd, buf, sizeof (buf) - 1);
+
+				if (len == -1)
+					continue;
+
+				if (!len) {
+					// The other end disconnected.
+					g_array_remove_index (command_sockets, i);
+					i--;
+					close (fd);
+
+					continue;
+				}
+
+				buf [len] = 0;
+
+				if (!strcmp (buf, "save\n")) {
+					FILE* file = fdopen (fd, "w");
+
+					prof_save (&aot_profiler, file);
+
+					fclose (file);
+
+					mono_profiler_printf_err ("aot profiler data saved to the socket");
+
+					g_array_remove_index (command_sockets, i);
+					i--;
+
+					continue;
+				} else if (!strcmp (buf, "quit\n")) {
+					quit_command_received = 1;
+				}
+			}
+
+			if (quit_command_received)
+				break;
+
+			if (FD_ISSET (aot_profiler.server_socket, &rfds)) {
+				int fd = accept (aot_profiler.server_socket, NULL, NULL);
+
+				if (fd != -1) {
+					if (fd >= FD_SETSIZE)
+						close (fd);
+					else
+						g_array_append_val (command_sockets, fd);
+				}
+			}
+		}
+
+		for (gint i = 0; i < command_sockets->len; i++)
+			close (g_array_index (command_sockets, int, i));
+
+		g_array_free (command_sockets, TRUE);
+	}
 
 	prof_shutdown (&aot_profiler);
 
@@ -195,6 +293,9 @@ helper_thread (void *arg)
 static void
 start_helper_thread (void)
 {
+	if (aot_profiler.command_port >= 0)
+		setup_command_server (&aot_profiler.server_socket, &aot_profiler.command_port, "aot");
+
 	MonoNativeThreadId thread_id;
 
 	if (!mono_native_thread_create (&thread_id, helper_thread, NULL)) {
@@ -206,7 +307,7 @@ start_helper_thread (void)
 static void
 runtime_initialized (MonoProfiler *profiler)
 {
-	if (profiler->duration >= 0)
+	if (profiler->duration >= 0 || aot_profiler.command_port >= 0)
 		start_helper_thread ();
 }
 
@@ -226,6 +327,9 @@ mono_profiler_init_aot (const char *desc)
 	}
 
 	aot_profiler.duration = -1;
+	aot_profiler.command_port = -1;
+	aot_profiler.outfile_name = NULL;
+	aot_profiler.outfile = NULL;
 
 	parse_args (desc [strlen ("aot")] == ':' ? desc + strlen ("aot") + 1 : "");
 
@@ -241,7 +345,7 @@ mono_profiler_init_aot (const char *desc)
 	else
 		aot_profiler.outfile = fopen (aot_profiler.outfile_name, "w");
 
-	if (!aot_profiler.outfile) {
+	if (!aot_profiler.outfile && aot_profiler.outfile_name) {
 		mono_profiler_printf_err ("Could not create AOT profiler output file '%s': %s", aot_profiler.outfile_name, g_strerror (errno));
 		exit (1);
 	}
@@ -261,7 +365,7 @@ mono_profiler_init_aot (const char *desc)
 static void
 emit_byte (MonoProfiler *prof, guint8 value)
 {
-	fwrite (&value, sizeof (guint8), 1, prof->outfile);
+	fwrite (&value, sizeof (guint8), 1, prof->savefile);
 }
 
 static void
@@ -269,7 +373,7 @@ emit_int32 (MonoProfiler *prof, gint32 value)
 {
 	for (int i = 0; i < sizeof (gint32); ++i) {
 		guint8 b = value;
-		fwrite (&b, sizeof (guint8), 1, prof->outfile);
+		fwrite (&b, sizeof (guint8), 1, prof->savefile);
 		value >>= 8;
 	}
 }
@@ -280,7 +384,7 @@ emit_string (MonoProfiler *prof, const char *str)
 	int len = strlen (str);
 
 	emit_int32 (prof, len);
-	fwrite (str, len, 1, prof->outfile);
+	fwrite (str, len, 1, prof->savefile);
 }
 
 static void
@@ -453,9 +557,8 @@ add_method (MonoProfiler *prof, MonoMethod *m)
 		mono_profiler_printf ("%s %d", mono_method_full_name (m, 1), id);
 }
 
-/* called at the end of the program */
 static void
-prof_shutdown (MonoProfiler *prof)
+prof_save (MonoProfiler *prof, FILE* file)
 {
 	mono_os_mutex_lock (&prof->mutex);
 	int already_shutdown = prof->methods == NULL;
@@ -467,9 +570,11 @@ prof_shutdown (MonoProfiler *prof)
 	int mindex;
 	char magic [32];
 
+	aot_profiler.savefile = file;
+
 	gint32 version = (AOT_PROFILER_MAJOR_VERSION << 16) | AOT_PROFILER_MINOR_VERSION;
 	sprintf (magic, AOT_PROFILER_MAGIC);
-	fwrite (magic, strlen (magic), 1, prof->outfile);
+	fwrite (magic, strlen (magic), 1, file);
 	emit_int32 (prof, version);
 
 	GHashTable *all_methods = g_hash_table_new (NULL, NULL);
@@ -488,11 +593,26 @@ prof_shutdown (MonoProfiler *prof)
 	}
 	emit_record (prof, AOTPROF_RECORD_NONE, 0);
 
-	fclose (prof->outfile);
-
-	mono_profiler_printf ("AOT profiler data written to '%s'", prof->outfile_name);
-
 	g_hash_table_destroy (all_methods);
+
+	g_hash_table_remove_all (prof->classes);
+	g_hash_table_remove_all (prof->images);
+
+	mono_os_mutex_unlock (&prof->mutex);
+}
+
+/* called at the end of the program */
+static void
+prof_shutdown (MonoProfiler *prof)
+{
+	if (aot_profiler.outfile) {
+		prof_save (prof, prof->outfile);
+		fclose (prof->outfile);
+		mono_profiler_printf ("AOT profiler data written to '%s'", prof->outfile_name);
+	}
+
+	mono_os_mutex_lock (&prof->mutex);
+
 	g_hash_table_destroy (prof->classes);
 	g_hash_table_destroy (prof->images);
 	g_ptr_array_free (prof->methods, TRUE);

--- a/mono/profiler/helper.c
+++ b/mono/profiler/helper.c
@@ -1,0 +1,81 @@
+/*
+ * helper.c: Helper code shared between various profilers
+ *
+ *
+ * Copyright 2019 Microsoft Corporation
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+#include <config.h>
+
+#include <mono/utils/mono-logger-internals.h>
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#include <errno.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <glib.h>
+
+#include "helper.h"
+
+void
+setup_command_server (int *server_socket, int *command_port, const char* profiler_name)
+{
+	*server_socket = socket (PF_INET, SOCK_STREAM, 0);
+
+	if (*server_socket == -1) {
+		mono_profiler_printf_err ("Could not create log profiler server socket: %s", g_strerror (errno));
+		exit (1);
+	}
+
+	struct sockaddr_in server_address;
+
+	memset (&server_address, 0, sizeof (server_address));
+	server_address.sin_family = AF_INET;
+	server_address.sin_addr.s_addr = INADDR_ANY;
+	server_address.sin_port = htons (*command_port);
+
+	if (bind (*server_socket, (struct sockaddr *) &server_address, sizeof (server_address)) == -1) {
+		mono_profiler_printf_err ("Could not bind %s profiler server socket on port %d: %s", profiler_name, *command_port, g_strerror (errno));
+		close (*server_socket);
+		exit (1);
+	}
+
+	if (listen (*server_socket, 1) == -1) {
+		mono_profiler_printf_err ("Could not listen on %s profiler server socket: %s", profiler_name, g_strerror (errno));
+		close (*server_socket);
+		exit (1);
+	}
+
+	socklen_t slen = sizeof (server_address);
+
+	if (getsockname (*server_socket, (struct sockaddr *) &server_address, &slen)) {
+		mono_profiler_printf_err ("Could not retrieve assigned port for %s profiler server socket: %s", profiler_name, g_strerror (errno));
+		close (*server_socket);
+		exit (1);
+	}
+
+	*command_port = ntohs (server_address.sin_port);
+}
+
+void
+add_to_fd_set (fd_set *set, int fd, int *max_fd)
+{
+	/*
+	 * This should only trigger for the basic FDs (server socket, pipes) at
+	 * startup if for some mysterious reason they're too large. In this case,
+	 * the profiler really can't function, and we're better off printing an
+	 * error and exiting.
+	 */
+	if (fd >= FD_SETSIZE) {
+		mono_profiler_printf_err ("File descriptor is out of bounds for fd_set: %d", fd);
+		exit (1);
+	}
+
+	FD_SET (fd, set);
+
+	if (*max_fd < fd)
+		*max_fd = fd;
+}

--- a/mono/profiler/helper.h
+++ b/mono/profiler/helper.h
@@ -1,0 +1,9 @@
+#ifndef __MONO_PROFHELPER_H__
+#define __MONO_PROFHELPER_H__
+
+#include <sys/select.h>
+
+void add_to_fd_set (fd_set *set, int fd, int *max_fd);
+void setup_command_server (int *server_socket, int *command_port, const char* profiler_name);
+
+#endif

--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -46,6 +46,7 @@
 #include <mono/utils/mono-error-internals.h>
 #include <mono/utils/os-event.h>
 #include "log.h"
+#include "helper.h"
 
 #ifdef HAVE_DLFCN_H
 #include <dlfcn.h>
@@ -3118,26 +3119,6 @@ profiler_thread_check_detach (MonoProfilerThread *thread)
 	}
 }
 
-static void
-add_to_fd_set (fd_set *set, int fd, int *max_fd)
-{
-	/*
-	 * This should only trigger for the basic FDs (server socket, pipes) at
-	 * startup if for some mysterious reason they're too large. In this case,
-	 * the profiler really can't function, and we're better off printing an
-	 * error and exiting.
-	 */
-	if (fd >= FD_SETSIZE) {
-		mono_profiler_printf_err ("File descriptor is out of bounds for fd_set: %d", fd);
-		exit (1);
-	}
-
-	FD_SET (fd, set);
-
-	if (*max_fd < fd)
-		*max_fd = fd;
-}
-
 static void *
 helper_thread (void *arg)
 {
@@ -3245,41 +3226,7 @@ start_helper_thread (void)
 		exit (1);
 	}
 
-	log_profiler.server_socket = socket (PF_INET, SOCK_STREAM, 0);
-
-	if (log_profiler.server_socket == -1) {
-		mono_profiler_printf_err ("Could not create log profiler server socket: %s", g_strerror (errno));
-		exit (1);
-	}
-
-	struct sockaddr_in server_address;
-
-	memset (&server_address, 0, sizeof (server_address));
-	server_address.sin_family = AF_INET;
-	server_address.sin_addr.s_addr = INADDR_ANY;
-	server_address.sin_port = htons (log_profiler.command_port);
-
-	if (bind (log_profiler.server_socket, (struct sockaddr *) &server_address, sizeof (server_address)) == -1) {
-		mono_profiler_printf_err ("Could not bind log profiler server socket on port %d: %s", log_profiler.command_port, g_strerror (errno));
-		close (log_profiler.server_socket);
-		exit (1);
-	}
-
-	if (listen (log_profiler.server_socket, 1) == -1) {
-		mono_profiler_printf_err ("Could not listen on log profiler server socket: %s", g_strerror (errno));
-		close (log_profiler.server_socket);
-		exit (1);
-	}
-
-	socklen_t slen = sizeof (server_address);
-
-	if (getsockname (log_profiler.server_socket, (struct sockaddr *) &server_address, &slen)) {
-		mono_profiler_printf_err ("Could not retrieve assigned port for log profiler server socket: %s", g_strerror (errno));
-		close (log_profiler.server_socket);
-		exit (1);
-	}
-
-	log_profiler.command_port = ntohs (server_address.sin_port);
+	setup_command_server (&log_profiler.server_socket, &log_profiler.command_port, "log");
 
 	if (!mono_native_thread_create (&log_profiler.helper_thread, helper_thread, NULL)) {
 		mono_profiler_printf_err ("Could not start log profiler helper thread");


### PR DESCRIPTION
Extended the aot profiler so, that it can receive commands over the network.

Added new option `port=PORT`, which enables command server and specifies
the port the server should listen at.

We have 2 commands so far.

    save ... save the profile data to socket and close it
    quit ... quit the profiler. it also saves the profile to the file
             in case the output option was specified.

It makes the aot profiling much easier to use on Android as we don't need to
save the profile to a file on the device. That means we don't need to set
`<application android:debuggable="true"/>` flag, which changes the Android
app behavior and thus influence the profile itself. It is also convenient way
for IDEs to retrieve the aot profiles.

Example use for Xamarin.Android. Save and receive the profile data:

	adb shell setprop debug.mono.profile aot:verbose,port=9999
	adb forward tcp:9999 tcp:9999
	nc -v 127.0.0.1 9999 > profile.aotprof
	found 0 associations
	found 1 connections:
	     1:	flags=82<CONNECTED,PREFERRED>
		outif lo0
		src 127.0.0.1 port 50398
		dst 127.0.0.1 port 9999
		rank info not available
		TCP aux info available

	Connection to 127.0.0.1 port 9999 [tcp/distinct] succeeded!
	save

Check what we received:

	aotprofile-tool -sd profile.aotprof
	Modules:
		132475FF-85AA-430D-913C-7642CBD8587E mscorlib
		F7BDCAB5-83D3-4A0A-A33D-BBE94284667D Mono.Android
		22897151-27C9-4064-B001-8A04F5847812 System
		AA3FC224-D486-4304-A8C9-EBF316556B26 Java.Interop
		00D98403-051B-4168-A391-F3F601637CBD System.Core
		FD06519A-C321-426C-BDD8-C97777452057 xat_latests_and_greatest_vsmac_8._1
		9ECB003E-D449-438B-BE35-58810DCBC917 Xamarin.Android.Support.v7.AppCompat
		11659962-EFAC-400D-9F8D-AF925B26AE41 Xamarin.Android.Support.Fragment
		48C436F7-611D-470D-9949-AC13FFDCF613 Xamarin.Essentials
		2792D10D-7E13-46E6-BB4A-933C25635F48 Xamarin.Android.Support.Design
	Summary:
		Modules:         10
		Types:          221
		Methods:        932



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
