### PR TITLE
Small style cleanup.

### DIFF
--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -174,12 +174,12 @@ static GHashTable *aot_modules;
 #define mono_aot_unlock() mono_os_mutex_unlock (&aot_mutex)
 static mono_mutex_t aot_mutex;
 
-/* 
+/*
  * Maps assembly names to the mono_aot_module_<NAME>_info symbols in the
  * AOT modules registered by mono_aot_register_module ().
  */
 static GHashTable *static_aot_modules;
-/* 
+/*
  * Same as above, but tracks module that must be loaded before others are
  * This allows us to have a "container" module which contains resources for
  * other modules. Since it doesn't provide methods for a managed assembly,
@@ -1325,8 +1325,8 @@ decode_method_ref_with_target (MonoAotModule *module, MethodRef *ref, MonoMethod
 		MonoGenericContext ctx;
 		guint32 token_index;
 
-		/* 
-		 * These methods do not have a token which resolves them, so we 
+		/*
+		 * These methods do not have a token which resolves them, so we
 		 * resolve them immediately.
 		 */
 		klass = decode_klass_ref (module, p, &p, error);
@@ -1353,7 +1353,7 @@ decode_method_ref_with_target (MonoAotModule *module, MethodRef *ref, MonoMethod
 		if (FALSE && mono_class_is_ginst (klass)) {
 			ctx.class_inst = mono_class_get_generic_class (klass)->context.class_inst;
 			ctx.method_inst = NULL;
- 
+
 			ref->method = mono_class_inflate_generic_method_full_checked (ref->method, klass, &ctx, error);
 			if (!ref->method)
 				return FALSE;
@@ -5116,16 +5116,21 @@ mono_aot_plt_resolve (gpointer aot_module, guint32 plt_info_offset, guint8 *code
 	 * patches, so have to translate between the two.
 	 * FIXME: Clean this up, but how ?
 	 */
-	if (ji.type == MONO_PATCH_INFO_ABS || ji.type == MONO_PATCH_INFO_JIT_ICALL_ID
+	if (ji.type == MONO_PATCH_INFO_ABS
+		|| ji.type == MONO_PATCH_INFO_JIT_ICALL_ID
 		|| ji.type == MONO_PATCH_INFO_ICALL_ADDR
-		|| ji.type == MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR || ji.type == MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR
-		|| ji.type == MONO_PATCH_INFO_JIT_ICALL_ADDR || ji.type == MONO_PATCH_INFO_RGCTX_FETCH) {
+		|| ji.type == MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR
+		|| ji.type == MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR
+		|| ji.type == MONO_PATCH_INFO_JIT_ICALL_ADDR
+		|| ji.type == MONO_PATCH_INFO_RGCTX_FETCH) {
 		/* These should already have a function descriptor */
 #ifdef PPC_USES_FUNCTION_DESCRIPTOR
 		/* Our function descriptors have a 0 environment, gcc created ones don't */
 		if (ji.type != MONO_PATCH_INFO_JIT_ICALL_ID
-				&& ji.type != MONO_PATCH_INFO_JIT_ICALL_ADDR && ji.type != MONO_PATCH_INFO_ICALL_ADDR
-				&& ji.type != MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR && ji.type != MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR)
+				&& ji.type != MONO_PATCH_INFO_JIT_ICALL_ADDR
+				&& ji.type != MONO_PATCH_INFO_ICALL_ADDR
+				&& ji.type != MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR
+				&& ji.type != MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR)
 			g_assert (((gpointer*)target) [2] == 0);
 #endif
 		/* Empty */
@@ -5269,7 +5274,7 @@ mono_create_ftnptr_malloc (guint8 *code)
 /*
  * load_function_full:
  *
- *   Load the function named NAME from the aot image. 
+ *   Load the function named NAME from the aot image.
  */
 static gpointer
 load_function_full (MonoAotModule *amodule, const char *name, MonoTrampInfo **out_tinfo)

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -2856,8 +2856,7 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 	MonoClass *c;
 #if USE_COMPUTED_GOTO
 	static void *in_labels[] = {
-#define OPDEF(a,b,c,d) \
-	&&LAB_ ## a,
+#define OPDEF(a,b,c,d) &&LAB_ ## a,
 #include "mintops.def"
 	0 };
 #endif

--- a/mono/mini/interp/mintops.c
+++ b/mono/mini/interp/mintops.c
@@ -10,16 +10,14 @@
 #include <stdio.h>
 #include "mintops.h"
 
-#define OPDEF(a,b,c,d) \
-	b,
+#define OPDEF(a,b,c,d) b,
 const char *mono_interp_opname[] = {
 #include "mintops.def"
 	""
 };
 #undef OPDEF
 
-#define OPDEF(a,b,c,d) \
-	c,
+#define OPDEF(a,b,c,d) c,
 unsigned char mono_interp_oplen[] = {
 #include "mintops.def"
 	0
@@ -27,8 +25,7 @@ unsigned char mono_interp_oplen[] = {
 #undef OPDEF
 
 
-#define OPDEF(a,b,c,d) \
-	d,
+#define OPDEF(a,b,c,d) d,
 MintOpArgType mono_interp_opargtype[] = {
 #include "mintops.def"
 	(MintOpArgType)0

--- a/mono/mini/interp/mintops.h
+++ b/mono/mini/interp/mintops.h
@@ -26,8 +26,7 @@ typedef enum
 	MintOpShortAndInt
 } MintOpArgType;
 
-#define OPDEF(a,b,c,d) \
-	a,
+#define OPDEF(a,b,c,d) a,
 enum {
 #include "mintops.def"
 	MINT_LASTOP

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -1709,11 +1709,10 @@ mono_create_tls_get (MonoCompile *cfg, MonoTlsKey key)
 		 */
 		EMIT_NEW_AOTCONST (cfg, addr, MONO_PATCH_INFO_GET_TLS_TRAMP, GUINT_TO_POINTER(key));
 		return mini_emit_calli (cfg, mono_icall_sig_ptr, NULL, addr, NULL, NULL);
-	} else {
-		g_static_assert (TLS_KEY_THREAD == 0);
-		const MonoJitICallId jit_icall_id = (MonoJitICallId)(MONO_JIT_ICALL_mono_tls_get_thread + key);
-		return mono_emit_jit_icall_id (cfg, jit_icall_id, NULL);
 	}
+	g_static_assert (TLS_KEY_THREAD == 0);
+	const MonoJitICallId jit_icall_id = (MonoJitICallId)(MONO_JIT_ICALL_mono_tls_get_thread + key);
+	return mono_emit_jit_icall_id (cfg, jit_icall_id, NULL);
 }
 
 /*

--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -1815,12 +1815,11 @@ mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig,
 	 * the extra stack space would be left on the stack after the tailcall.
 	 */
 	gboolean res = IS_SUPPORTED_TAILCALL (callee_info->stack_usage <= caller_info->stack_usage)
-				&& IS_SUPPORTED_TAILCALL (caller_info->ret.storage == callee_info->ret.storage);
-
-	// FIXME The limit here is that moving the parameters requires addressing the parameters
-	// with 12bit (4K) immediate offsets. - 4 for TAILCALL_REG/MEMBASE
-	res &= IS_SUPPORTED_TAILCALL (callee_info->stack_usage < (4096 - 4));
-	res &= IS_SUPPORTED_TAILCALL (caller_info->stack_usage < (4096 - 4));
+		    && IS_SUPPORTED_TAILCALL (caller_info->ret.storage == callee_info->ret.storage)
+		    // FIXME The limit here is that moving the parameters requires addressing the parameters
+		    // with 12bit (4K) immediate offsets. - 4 for TAILCALL_REG/MEMBASE
+		    && IS_SUPPORTED_TAILCALL (callee_info->stack_usage < (4096 - 4))
+		    && IS_SUPPORTED_TAILCALL (caller_info->stack_usage < (4096 - 4));
 
 	g_free (caller_info);
 	g_free (callee_info);

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -2802,8 +2802,8 @@ mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig,
 	res &= IS_SUPPORTED_TAILCALL (caller_info->stack_usage < (1 << 30));
 
 	// valuetype parameters are the address of a local
-	const ArgInfo *ainfo;
-	ainfo = callee_info->args + callee_sig->hasthis;
+	// FIXME Why not check 'this'?
+	const ArgInfo *ainfo = callee_info->args + callee_sig->hasthis;
 	for (int i = 0; res && i < callee_sig->param_count; ++i) {
 		res = IS_SUPPORTED_TAILCALL (ainfo [i].storage != ArgVtypeByRef)
 			&& IS_SUPPORTED_TAILCALL (ainfo [i].storage != ArgVtypeByRefOnStack);

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -6798,6 +6798,7 @@ mono_arch_tailcall_supported (MonoCompile *cfg, MonoMethodSignature *caller_sig,
 	// valuetypes passed semantic-byvalue ABI-byref are often to a local.
 	// FIXME ABIs vary as to if this local is in the parameter area or not,
 	// so this check might not be needed.
+	// FIXME Why not check 'this'?
 	ArgInfo const * const ainfo = callee_info->args + callee_sig->hasthis;
 	for (int i = 0; res && i < callee_sig->param_count; ++i) {
 		res = IS_SUPPORTED_TAILCALL (ainfo [i].regtype != RegTypeStructByAddr)

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -143,9 +143,9 @@ mono_arch_xregname (int reg)
 }
 
 void 
-mono_x86_patch (unsigned char* code, gpointer target)
+mono_x86_patch (guint8* code, gpointer target)
 {
-	x86_patch (code, (unsigned char*)target);
+	x86_patch (code, (guint8*)target);
 }
 
 #define FLOAT_PARAM_REGS 0
@@ -1982,7 +1982,7 @@ cc_signed_table [] = {
 	FALSE, FALSE, FALSE, FALSE
 };
 
-static unsigned char*
+static guint8*
 emit_float_to_int (MonoCompile *cfg, guchar *code, int dreg, int size, gboolean is_signed)
 {
 #define XMM_TEMP_REG 0
@@ -2030,7 +2030,7 @@ emit_float_to_int (MonoCompile *cfg, guchar *code, int dreg, int size, gboolean 
 	return code;
 }
 
-static unsigned char*
+static guint8*
 mono_emit_stack_alloc (MonoCompile *cfg, guchar *code, MonoInst* tree)
 {
 	int sreg = tree->sreg1;
@@ -2041,7 +2041,7 @@ mono_emit_stack_alloc (MonoCompile *cfg, guchar *code, MonoInst* tree)
 #endif
 
 	if (need_touch) {
-		guint8* br[5];
+		guint8* br [5];
 
 		/*
 		 * Under Windows:
@@ -2058,9 +2058,9 @@ mono_emit_stack_alloc (MonoCompile *cfg, guchar *code, MonoInst* tree)
 		 * guard page and commits more pages when needed.
 		 */
 		x86_test_reg_imm (code, sreg, ~0xFFF);
-		br[0] = code; x86_branch8 (code, X86_CC_Z, 0, FALSE);
+		br [0] = code; x86_branch8 (code, X86_CC_Z, 0, FALSE);
 
-		br[2] = code; /* loop */
+		br [2] = code; /* loop */
 		x86_alu_reg_imm (code, X86_SUB, X86_ESP, 0x1000);
 		x86_test_membase_reg (code, X86_ESP, 0, X86_ESP);
 
@@ -2089,18 +2089,18 @@ mono_emit_stack_alloc (MonoCompile *cfg, guchar *code, MonoInst* tree)
 
 		x86_alu_reg_imm (code, X86_SUB, sreg, 0x1000);
 		x86_alu_reg_imm (code, X86_CMP, sreg, 0x1000);
-		br[3] = code; x86_branch8 (code, X86_CC_AE, 0, FALSE);
-		x86_patch (br[3], br[2]);
+		br [3] = code; x86_branch8 (code, X86_CC_AE, 0, FALSE);
+		x86_patch (br [3], br [2]);
 		x86_test_reg_reg (code, sreg, sreg);
-		br[4] = code; x86_branch8 (code, X86_CC_Z, 0, FALSE);
+		br [4] = code; x86_branch8 (code, X86_CC_Z, 0, FALSE);
 		x86_alu_reg_reg (code, X86_SUB, X86_ESP, sreg);
 
-		br[1] = code; x86_jump8 (code, 0);
+		br [1] = code; x86_jump8 (code, 0);
 
-		x86_patch (br[0], code);
+		x86_patch (br [0], code);
 		x86_alu_reg_reg (code, X86_SUB, X86_ESP, sreg);
-		x86_patch (br[1], code);
-		x86_patch (br[4], code);
+		x86_patch (br [1], code);
+		x86_patch (br [4], code);
 	}
 	else
 		x86_alu_reg_reg (code, X86_SUB, X86_ESP, tree->sreg1);
@@ -2549,7 +2549,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				x86_mov_reg_membase (code, X86_ECX, var->inst_basereg, var->inst_offset, sizeof (target_mgreg_t));
 				x86_mov_reg_membase (code, X86_ECX, X86_ECX, 0, sizeof (target_mgreg_t));
 				x86_alu_reg_imm (code, X86_CMP, X86_ECX, 0);
-				br[0] = code; x86_branch8 (code, X86_CC_EQ, 0, FALSE);
+				br [0] = code; x86_branch8 (code, X86_CC_EQ, 0, FALSE);
 				x86_call_reg (code, X86_ECX);
 				x86_patch (br [0], code);
 			}
@@ -4085,7 +4085,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			break;
 		}
 		case OP_ATOMIC_EXCHANGE_I4: {
-			guchar *br[2];
+			guchar *br [2];
 			int sreg2 = ins->sreg2;
 			int breg = ins->inst_basereg;
 
@@ -4830,7 +4830,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			guint8 *br [1];
 
 			x86_test_membase_imm (code, ins->sreg1, 0, 1);
-			br[0] = code; x86_branch8 (code, X86_CC_EQ, 0, FALSE);
+			br [0] = code; x86_branch8 (code, X86_CC_EQ, 0, FALSE);
 			code = emit_call (cfg, code, MONO_PATCH_INFO_JIT_ICALL_ID, GUINT_TO_POINTER (MONO_JIT_ICALL_mono_threads_state_poll));
 			x86_patch (br [0], code);
 
@@ -4885,7 +4885,7 @@ mono_arch_register_lowlevel_calls (void)
 void
 mono_arch_patch_code_new (MonoCompile *cfg, MonoDomain *domain, guint8 *code, MonoJumpInfo *ji, gpointer target)
 {
-	unsigned char *ip = ji->ip.i + code;
+	guint8 *ip = ji->ip.i + code;
 
 	switch (ji->type) {
 	case MONO_PATCH_INFO_IP:
@@ -4901,7 +4901,7 @@ mono_arch_patch_code_new (MonoCompile *cfg, MonoDomain *domain, guint8 *code, Mo
 	case MONO_PATCH_INFO_JIT_ICALL_ADDR:
 	case MONO_PATCH_INFO_TRAMPOLINE_FUNC_ADDR:
 	case MONO_PATCH_INFO_SPECIFIC_TRAMPOLINE_LAZY_FETCH_ADDR:
-		x86_patch (ip, (unsigned char*)target);
+		x86_patch (ip, (guint8*)target);
 		break;
 	case MONO_PATCH_INFO_NONE:
 		break;

--- a/mono/mini/mini.h
+++ b/mono/mini/mini.h
@@ -198,8 +198,7 @@ typedef MonoStackFrameInfo StackFrameInfo;
 /*
  * Pull the list of opcodes
  */
-#define OPDEF(a,b,c,d,e,f,g,h,i,j) \
-	a = i,
+#define OPDEF(a,b,c,d,e,f,g,h,i,j) a = i,
 
 enum {
 #include "mono/cil/opcode.def"


### PR DESCRIPTION
 - split long lines for readability (opcode == foo || opcode == bar...)
 - merge short lines for searchability (define opdef)
 - un-else after return
 - foo = abc && def vs. foo = abc; foo &= def;
 - unsigned char to guint8 (or guchar is just as good)
 - remove not needed cast
 - args [n]; args [0] = x; args [1] = y vs. args [ ] = { x, y}
   (which does likely remove sequence points between x and y, ok
 - space before [ as is usual Mono style
 - no space at end of line