### PR TITLE
[2019-02] [install] Include .exe extension when symlinking the mono binary

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -132,7 +132,7 @@ mono.exe: mono-$(mono_bin_suffix).exe
 	ln -sf $< $@
 
 install-exec-hook:
-	(cd $(DESTDIR)$(bindir) && ln -sf mono-$(mono_bin_suffix) mono)
+	(cd $(DESTDIR)$(bindir) && ln -sf mono-$(mono_bin_suffix)$(EXEEXT) mono$(EXEEXT))
 	(cd $(DESTDIR)$(libdir); shopt -s nullglob 2>/dev/null; for i in libmono$(libmono_suffix)*; do ln -sf $$i `echo $$i | sed s/$(libmono_suffix)//` ; done)
 endif
 


### PR DESCRIPTION
Prevent the SDKs from making dangling symlinks when packaging the MXE
cross-compilers: should hav

    mono.exe -> mono-sgen.exe

rather than

    mono -> mono-sgen (dangling).



Backport of #14958.

/cc @lambdageek 