### PR TITLE
[netcore] Update the checks for ByRef return type in reflection invocation

### DIFF
--- a/mcs/tests/test-ref-07.cs
+++ b/mcs/tests/test-ref-07.cs
@@ -1,8 +1,13 @@
 // Compiler options: -langversion:latest
 
+public struct TestMain
+{
+	public static void Main () => Test.MainMethod();
+}
+
 public readonly ref partial struct Test
 {
-	public static void Main ()
+	public static void MainMethod ()
 	{
 		var m = new Test ();
 		m.Method ();

--- a/mcs/tests/ver-il-net_4_x.xml
+++ b/mcs/tests/ver-il-net_4_x.xml
@@ -73853,8 +73853,13 @@
     </type>
   </test>
   <test name="test-ref-07.cs">
-    <type name="Test">
+    <type name="TestMain">
       <method name="Void Main()" attrs="150">
+        <size>7</size>
+      </method>
+    </type>
+    <type name="Test">
+      <method name="Void MainMethod()" attrs="150">
         <size>18</size>
       </method>
       <method name="Test Method()" attrs="129">

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -3548,18 +3548,20 @@ ves_icall_InternalInvoke (MonoReflectionMethod *method, MonoObject *this_arg, Mo
 		}
 	}
 
-	if (sig->ret->byref) {
 #if ENABLE_NETCORE
+	if (sig->ret->byref || m_class_is_byreflike (mono_class_from_mono_type_internal (sig->ret))) {
 		MonoType* ret_byval = m_class_get_byval_arg (mono_class_from_mono_type_internal (sig->ret));
-		if (ret_byval->byref) {
+		if (ret_byval->byref || m_class_is_byreflike (mono_class_from_mono_type_internal (ret_byval))) {
 			mono_gc_wbarrier_generic_store_internal (exc, (MonoObject*) mono_exception_from_name_msg (mono_defaults.corlib, "System", "NotSupportedException", "Cannot invoke method returning ByRef to ByRefLike type via reflection"));
 			return NULL;
 		}
+	}
 #else
+	if (sig->ret->byref) {
 		mono_gc_wbarrier_generic_store_internal (exc, (MonoObject*) mono_exception_from_name_msg (mono_defaults.corlib, "System", "NotSupportedException", "Cannot invoke method returning ByRef type via reflection"));
 		return NULL;
-#endif
 	}
+#endif
 
 	pcount = params? mono_array_length_internal (params): 0;
 	if (pcount != sig->param_count) {

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -3555,6 +3555,10 @@ ves_icall_InternalInvoke (MonoReflectionMethod *method, MonoObject *this_arg, Mo
 #if ENABLE_NETCORE
 	if (sig->ret->byref) {
 		MonoType* ret_byval = m_class_get_byval_arg (mono_class_from_mono_type_internal (sig->ret));
+		if (ret_byval->type == MONO_TYPE_VOID) {
+			mono_gc_wbarrier_generic_store_internal (exc, (MonoObject*) mono_exception_from_name_msg (mono_defaults.corlib, "System", "NotSupportedException", "ByRef to void return values are not supported in reflection invocation"));
+			return NULL;
+		}	
 		if (m_class_is_byreflike (mono_class_from_mono_type_internal (ret_byval))) {
 			mono_gc_wbarrier_generic_store_internal (exc, (MonoObject*) mono_exception_from_name_msg (mono_defaults.corlib, "System", "NotSupportedException", "Cannot invoke method returning ByRef to ByRefLike type via reflection"));
 			return NULL;

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -3548,10 +3548,14 @@ ves_icall_InternalInvoke (MonoReflectionMethod *method, MonoObject *this_arg, Mo
 		}
 	}
 
+	if ((m->klass != NULL && m_class_is_byreflike (m->klass)) || m_class_is_byreflike (mono_class_from_mono_type_internal (sig->ret))) {
+		mono_gc_wbarrier_generic_store_internal (exc, (MonoObject*) mono_exception_from_name_msg (mono_defaults.corlib, "System", "NotSupportedException", "Cannot invoke method with stack pointers via reflection"));
+		return NULL;
+	}
 #if ENABLE_NETCORE
-	if (sig->ret->byref || m_class_is_byreflike (mono_class_from_mono_type_internal (sig->ret))) {
+	if (sig->ret->byref) {
 		MonoType* ret_byval = m_class_get_byval_arg (mono_class_from_mono_type_internal (sig->ret));
-		if (ret_byval->byref || m_class_is_byreflike (mono_class_from_mono_type_internal (ret_byval))) {
+		if (m_class_is_byreflike (mono_class_from_mono_type_internal (ret_byval))) {
 			mono_gc_wbarrier_generic_store_internal (exc, (MonoObject*) mono_exception_from_name_msg (mono_defaults.corlib, "System", "NotSupportedException", "Cannot invoke method returning ByRef to ByRefLike type via reflection"));
 			return NULL;
 		}

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -172,13 +172,8 @@
 -nomethod System.Buffers.Text.Tests.RealFormatterTests.TestFormatterDouble_P20
 -nomethod System.Buffers.Text.Tests.RealFormatterTests.TestFormatterSingle_F20
 
--nomethod System.SpanTests.SpanTests.MemoryMarshal_GenericStaticReturningSpan
--nomethod System.SpanTests.SpanTests.Span_Property
--nomethod System.SpanTests.SpanTests.ReadOnlySpan_Property
 -nomethod System.SpanTests.SpanTests.ReadOnlyMemory_PropertyReturningReadOnlySpan
--nomethod System.SpanTests.SpanTests.MemoryExtensions_StaticReturningReadOnlySpan
 -nomethod System.SpanTests.SpanTests.Span_StaticOperator
--nomethod System.SpanTests.SpanTests.MemoryManager_MethodReturningSpan
 -nomethod System.SpanTests.SpanTests.ReadOnlySpan_Constructor
 -nomethod System.SpanTests.SpanTests.ReadOnlySpan_Operator
 -nomethod System.SpanTests.SpanTests.Span_Constructor


### PR DESCRIPTION
Update the checks for ByRef return type in reflection invocation to also check for IsByRefLike types. This was missed as part of #13901 and noted in the description.

Fixes #14959, #14960, #14961, #14963
