### PR TITLE
[2019-06] [Mono.Debugger.Soft] Properly close connections 

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/VirtualMachine.cs
@@ -150,8 +150,8 @@ namespace Mono.Debugger.Soft
 		}
 
 		public void Detach () {
-			conn.VM_Dispose ();
 			conn.Close ();
+			conn.VM_Dispose ();
 			notify_vm_event (EventType.VMDisconnect, SuspendPolicy.None, 0, 0, null, 0);
 		}
 


### PR DESCRIPTION
Trying to unrevert https://github.com/mono/mono/pull/7390.
Couldn't reproduce the same side effect as that caused before.

This PR fixes #7377




Backport of #14773.

/cc @thaystg 