### PR TITLE
[System.Net.Http]: Add hack to the legacy HttpClient to pass down Timeout property. #12577.

### DIFF
--- a/mcs/class/System.Net.Http/HttpClientHandler.cs
+++ b/mcs/class/System.Net.Http/HttpClientHandler.cs
@@ -188,6 +188,12 @@ namespace System.Net.Http
 
 		public IDictionary<string, object> Properties => _delegatingHandler.Properties;
 
+		// Only used in MonoWebRequestHandler and ignored by the other handlers.
+		internal void MonoSetTimeout (TimeSpan timeout)
+		{
+			_delegatingHandler.MonoSetTimeout(timeout);
+		}
+
 		protected internal override Task<HttpResponseMessage> SendAsync (HttpRequestMessage request, CancellationToken cancellationToken) =>
 		    _delegatingHandler.SendAsync (request, cancellationToken);
 	}

--- a/mcs/class/System.Net.Http/HttpClientHandler.cs
+++ b/mcs/class/System.Net.Http/HttpClientHandler.cs
@@ -189,9 +189,9 @@ namespace System.Net.Http
 		public IDictionary<string, object> Properties => _delegatingHandler.Properties;
 
 		// Only used in MonoWebRequestHandler and ignored by the other handlers.
-		internal void MonoSetTimeout (TimeSpan timeout)
+		internal void SetWebRequestTimeout (TimeSpan timeout)
 		{
-			_delegatingHandler.MonoSetTimeout(timeout);
+			_delegatingHandler.SetWebRequestTimeout (timeout);
 		}
 
 		protected internal override Task<HttpResponseMessage> SendAsync (HttpRequestMessage request, CancellationToken cancellationToken) =>

--- a/mcs/class/System.Net.Http/IMonoHttpClientHandler.cs
+++ b/mcs/class/System.Net.Http/IMonoHttpClientHandler.cs
@@ -80,6 +80,6 @@ namespace System.Net.Http
 		Task<HttpResponseMessage> SendAsync (HttpRequestMessage request, CancellationToken cancellationToken);
 
 		// Only used by MonoWebRequestHandler and ignored by the other handlers.
-		void MonoSetTimeout (TimeSpan timeout);
+		void SetWebRequestTimeout (TimeSpan timeout);
 	}
 }

--- a/mcs/class/System.Net.Http/IMonoHttpClientHandler.cs
+++ b/mcs/class/System.Net.Http/IMonoHttpClientHandler.cs
@@ -78,5 +78,8 @@ namespace System.Net.Http
 		}
 
 		Task<HttpResponseMessage> SendAsync (HttpRequestMessage request, CancellationToken cancellationToken);
+
+		// Only used by MonoWebRequestHandler and ignored by the other handlers.
+		void MonoSetTimeout (TimeSpan timeout);
 	}
 }

--- a/mcs/class/System.Net.Http/MonoWebRequestHandler.cs
+++ b/mcs/class/System.Net.Http/MonoWebRequestHandler.cs
@@ -67,6 +67,7 @@ namespace System.Net.Http
 		bool unsafeAuthenticatedConnectionSharing;
 		bool sentRequest;
 		string connectionGroupName;
+		TimeSpan? timeout;
 		bool disposed;
 
 		internal MonoWebRequestHandler ()
@@ -446,6 +447,9 @@ namespace System.Net.Http
 			var wrequest = CreateWebRequest (request);
 			HttpWebResponse wresponse = null;
 
+			if (timeout != null)
+				wrequest.Timeout = (int)timeout.Value.TotalMilliseconds;
+
 			try {
 				using (cancellationToken.Register (l => ((HttpWebRequest)l).Abort (), wrequest)) {
 					var content = request.Content;
@@ -528,6 +532,11 @@ namespace System.Net.Http
 			get {
 				throw new NotImplementedException ();
 			}
+		}
+
+		void IMonoHttpClientHandler.MonoSetTimeout (TimeSpan timeout)
+		{
+			this.timeout = timeout;
 		}
 	}
 }

--- a/mcs/class/System.Net.Http/MonoWebRequestHandler.cs
+++ b/mcs/class/System.Net.Http/MonoWebRequestHandler.cs
@@ -369,6 +369,9 @@ namespace System.Net.Http
 
 			wr.ServicePoint.Expect100Continue = request.Headers.ExpectContinue == true;
 
+			if (timeout != null)
+				wr.Timeout = (int)timeout.Value.TotalMilliseconds;
+
 			// Add request headers
 			var headers = wr.Headers;
 			foreach (var header in request.Headers) {
@@ -446,9 +449,6 @@ namespace System.Net.Http
 			Volatile.Write (ref sentRequest, true);
 			var wrequest = CreateWebRequest (request);
 			HttpWebResponse wresponse = null;
-
-			if (timeout != null)
-				wrequest.Timeout = (int)timeout.Value.TotalMilliseconds;
 
 			try {
 				using (cancellationToken.Register (l => ((HttpWebRequest)l).Abort (), wrequest)) {
@@ -534,7 +534,7 @@ namespace System.Net.Http
 			}
 		}
 
-		void IMonoHttpClientHandler.MonoSetTimeout (TimeSpan timeout)
+		void IMonoHttpClientHandler.SetWebRequestTimeout (TimeSpan timeout)
 		{
 			this.timeout = timeout;
 		}

--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClient.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClient.cs
@@ -41,7 +41,6 @@ namespace System.Net.Http
 		CancellationTokenSource cts;
 		bool disposed;
 		HttpRequestHeaders headers;
-		HttpMessageHandler handler;
 		long buffer_size;
 		TimeSpan timeout;
 
@@ -60,7 +59,6 @@ namespace System.Net.Http
 		public HttpClient (HttpMessageHandler handler, bool disposeHandler)
 			: base (handler, disposeHandler)
 		{
-			this.handler = handler;
 			buffer_size = int.MaxValue;
 			timeout = TimeoutDefault;
 			cts = new CancellationTokenSource ();

--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClient.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClient.cs
@@ -271,7 +271,7 @@ namespace System.Net.Http
 			using (var lcts = CancellationTokenSource.CreateLinkedTokenSource (cts.Token, cancellationToken)) {
 				// Hack to pass the timeout to the HttpWebRequest that's created by MonoWebRequestHandler; all other handlers ignore this.
 				if (handler is HttpClientHandler clientHandler)
-					clientHandler.MonoSetTimeout (timeout);
+					clientHandler.SetWebRequestTimeout (timeout);
 				lcts.CancelAfter (timeout);
 
 				var task = base.SendAsync (request, lcts.Token);

--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.platformnotsupported.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.platformnotsupported.cs
@@ -170,6 +170,9 @@ namespace System.Net.Http
 			set { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
 		}
 
+		// Only used in MonoWebRequestHandler and ignored by the other handlers.
+		internal void SetWebRequestTimeout (TimeSpan timeout) => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
+
 		// NS2.1:
 		public static System.Func<System.Net.Http.HttpRequestMessage, System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.X509Certificates.X509Chain, System.Net.Security.SslPolicyErrors, bool> DangerousAcceptAnyServerCertificateValidator => throw new PlatformNotSupportedException ();
 	}

--- a/mcs/class/System.Net.Http/System.Net.Http/HttpMessageInvoker.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpMessageInvoker.cs
@@ -33,7 +33,7 @@ namespace System.Net.Http
 {
 	public class HttpMessageInvoker : IDisposable
 	{
-		protected readonly HttpMessageHandler handler;
+		protected private HttpMessageHandler handler;
 		readonly bool disposeHandler;
 		
 		public HttpMessageInvoker (HttpMessageHandler handler)

--- a/mcs/class/System.Net.Http/System.Net.Http/HttpMessageInvoker.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpMessageInvoker.cs
@@ -33,7 +33,7 @@ namespace System.Net.Http
 {
 	public class HttpMessageInvoker : IDisposable
 	{
-		HttpMessageHandler handler;
+		protected readonly HttpMessageHandler handler;
 		readonly bool disposeHandler;
 		
 		public HttpMessageInvoker (HttpMessageHandler handler)

--- a/mcs/class/System.Net.Http/corefx/SocketsHttpHandler.Mono.cs
+++ b/mcs/class/System.Net.Http/corefx/SocketsHttpHandler.Mono.cs
@@ -41,7 +41,7 @@ namespace System.Net.Http
 		}
 
 		// This is only used by MonoWebRequestHandler.
-		void IMonoHttpClientHandler.MonoSetTimeout (TimeSpan timeout)
+		void IMonoHttpClientHandler.SetWebRequestTimeout (TimeSpan timeout)
 		{
 		}
 

--- a/mcs/class/System.Net.Http/corefx/SocketsHttpHandler.Mono.cs
+++ b/mcs/class/System.Net.Http/corefx/SocketsHttpHandler.Mono.cs
@@ -40,6 +40,11 @@ namespace System.Net.Http
 			}
 		}
 
+		// This is only used by MonoWebRequestHandler.
+		void IMonoHttpClientHandler.MonoSetTimeout (TimeSpan timeout)
+		{
+		}
+
 		Task<HttpResponseMessage> IMonoHttpClientHandler.SendAsync (HttpRequestMessage request, CancellationToken cancellationToken) => SendAsync (request, cancellationToken);
 	}
 }


### PR DESCRIPTION
* `HttpClientHandler`, `IMonoHttpClientHandler`: add new internal `MonoSetTimeout (TimeSpan)` function.

* `HttpClient.SendAsyncWorker()`: if `handler` is `HttpClientHandler`, call the new internal
  `MonoSetTimeout()` function to pass down the timeout.

* `MonoWebRequestHandler.SendAsync()`: this is only used here to pass the timeout to the `HttpWebRequest`.
