### PR TITLE
Don't create a cycle when translating IL `break` to IR.

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -6539,8 +6539,8 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				ins = mono_emit_jit_icall (cfg, mono_debugger_agent_user_break, NULL);
 			} else {
 				MONO_INST_NEW (cfg, ins, OP_NOP);
+				MONO_ADD_INS (cfg->cbb, ins);
 			}
-			MONO_ADD_INS (cfg->cbb, ins);
 			break;
 		case MONO_CEE_LDARG_0:
 		case MONO_CEE_LDARG_1:

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1021,7 +1021,8 @@ TESTS_IL_SRC=			\
 	custom-modifiers-append.1.il \
 	gh-13056_mono_local_cprop_av.il \
 	gh-13057_mono_local_emulate_ops_av.il \
-	module-cctor-entrypoint.il
+	module-cctor-entrypoint.il \
+	bug-gh-9706.il
 
 # This test crashes the runtime, even with recent fixes.
 #	incorrect-ldvirtftn-read-behind-for-dup.il

--- a/mono/tests/bug-gh-9706.il
+++ b/mono/tests/bug-gh-9706.il
@@ -1,0 +1,46 @@
+.assembly extern mscorlib { }
+
+.assembly test
+{
+  .hash algorithm 0x00008004
+  .ver 0:0:0:0
+}
+
+.class private auto ansi beforefieldinit test.Test extends [mscorlib]System.Object
+{
+	.field private static int32 modreq([mscorlib]System.Runtime.CompilerServices.IsVolatile) non_constant
+
+	.method private hidebysig specialname rtspecialname static void '.cctor' () cil managed
+	{
+		.maxstack  8
+		ldc.i4.0
+		volatile.
+		stsfld     int32 modreq([mscorlib]System.Runtime.CompilerServices.IsVolatile) test.Test::non_constant
+		ret
+	}
+
+	.method public specialname rtspecialname instance default void '.ctor' () cil managed
+	{
+		.maxstack 8
+		ldarg.0
+		call instance void object::'.ctor'()
+		ret
+	}
+
+	// If this test succeeds, it should run to completion.
+	// If it fails, mono will hang in an infinite loop while doing DCE.
+	.method public static hidebysig default void Main () cil managed
+	{
+		.maxstack 8
+		.entrypoint
+		volatile.
+		ldsfld int32 modreq([mscorlib]System.Runtime.CompilerServices.IsVolatile) test.Test::non_constant
+		ldc.i4.0
+		cgt
+		brfalse.s end
+		break // Should not be executed; merely needs to be present in the instruction stream.
+		end:
+		ret
+	}
+}
+


### PR DESCRIPTION
`mono_emit_jit_icall` adds the instruction it generates to the current
basic block, and the redundant use of `MONO_ADD_INS` on an instruction
that has already been added to a BB will create a cycle in the `prev`
link chain.

Fixes #9706.