### PR TITLE
[2019-06] Fix Japan's new era fallback isn't reflected in Mono

### DIFF
--- a/mcs/class/corlib/Test/System.Globalization/CalendarTest.cs
+++ b/mcs/class/corlib/Test/System.Globalization/CalendarTest.cs
@@ -428,7 +428,7 @@ public class CalendarTest {
 			new Date(28,10,2038,1),
 			new Date(13,10,1460,1),
 			new Date(12,2,5799,1),
-			new Date(10,11,50,4),
+			new Date(10,11,20,5),
 			new Date(10,11,127,1),
 			new Date(10,11,4371,1),
 			new Date(10,11,2581,1));
@@ -436,7 +436,7 @@ public class CalendarTest {
 			new Date(5,7,2094,1),
 			new Date(6,3,1518,1),
 			new Date(5,11,5854,1),
-			new Date(18,7,106,4),
+			new Date(18,7,76,5),
 			new Date(18,7,183,1),
 			new Date(18,7,4427,1),
 			new Date(18,7,2637,1));
@@ -495,7 +495,7 @@ public class CalendarTest {
 		foreach (Calendar cal in acal) {
 			int check = 1;
 			if (cal is JapaneseCalendar)
-				check = 4;
+				check = 5;
 			Assert.AreEqual(check, cal.Eras.Length,
 						 String.Format("D01 {0}.Eras.Length", cal));
 			cal.Eras[0] = 29;
@@ -507,11 +507,12 @@ public class CalendarTest {
 	public void TestErasProperty2() {
 		Assert.AreEqual(1, clcal.Eras.Length, "cn");
 		Assert.AreEqual(1, tlcal.Eras.Length, "tw");
-		Assert.AreEqual(2, jlcal.Eras.Length, "jp");
+		Assert.AreEqual(3, jlcal.Eras.Length, "jp");
 		Assert.AreEqual(1, klcal.Eras.Length, "kr");
 
-		Assert.AreEqual(4, jlcal.Eras [0], "jp.1");
-		Assert.AreEqual(3, jlcal.Eras [1], "jp.2");
+		Assert.AreEqual(5, jlcal.Eras [0], "jp.1");
+		Assert.AreEqual(4, jlcal.Eras [1], "jp.2");
+		Assert.AreEqual(3, jlcal.Eras [2], "jp.3");
 	}
 
 	[Test]

--- a/mcs/class/corlib/Test/System.Globalization/EastAsianLunisolarCalendarTest.cs
+++ b/mcs/class/corlib/Test/System.Globalization/EastAsianLunisolarCalendarTest.cs
@@ -49,30 +49,30 @@ namespace MonoTests.System.Globalization
 		public void ToDateTime ()
 		{
 			Assert.AreEqual (new DateTime (2000, 2, 5), cn.ToDateTime (2000, 1, 1, 0, 0, 0, 0), "cn1");
-			Assert.AreEqual (new DateTime (2000, 2, 5), jp.ToDateTime (12, 1, 1, 0, 0, 0, 0, 1), "jp1"); // since 1988 (current epoch)
+			Assert.AreEqual (new DateTime (2000, 2, 5), jp.ToDateTime (12, 1, 1, 0, 0, 0, 0, 4), "jp1"); // since 1988 (current epoch)
 			Assert.AreEqual (new DateTime (2000, 2, 5), tw.ToDateTime (89, 1, 1, 0, 0, 0, 0), "tw1"); // since 1912 (current epoch)
 			Assert.AreEqual (new DateTime (2000, 2, 5), kr.ToDateTime (2000, 1, 1, 0, 0, 0, 0), "kr1");
 
 			Assert.AreEqual (new DateTime (2001, 1, 24), cn.ToDateTime (2001, 1, 1, 0, 0, 0, 0), "cn2");
-			Assert.AreEqual (new DateTime (2001, 1, 24), jp.ToDateTime (13, 1, 1, 0, 0, 0, 0, 1), "jp2");
+			Assert.AreEqual (new DateTime (2001, 1, 24), jp.ToDateTime (13, 1, 1, 0, 0, 0, 0, 4), "jp2");
 			Assert.AreEqual (new DateTime (2001, 1, 24), tw.ToDateTime (90, 1, 1, 0, 0, 0, 0), "tw2");
 			Assert.AreEqual (new DateTime (2001, 1, 24), kr.ToDateTime (2001, 1, 1, 0, 0, 0, 0), "kr2");
 
 			Assert.AreEqual (new DateTime (2002, 2, 12), cn.ToDateTime (2002, 1, 1, 0, 0, 0, 0), "cn3");
-			Assert.AreEqual (new DateTime (2002, 2, 12), jp.ToDateTime (14, 1, 1, 0, 0, 0, 0, 1), "jp3");
+			Assert.AreEqual (new DateTime (2002, 2, 12), jp.ToDateTime (14, 1, 1, 0, 0, 0, 0, 4), "jp3");
 			Assert.AreEqual (new DateTime (2002, 2, 12), tw.ToDateTime (91, 1, 1, 0, 0, 0, 0), "tw3");
 			Assert.AreEqual (new DateTime (2002, 2, 12), kr.ToDateTime (2002, 1, 1, 0, 0, 0, 0), "kr3");
 
 			// actually it is 5th month which is leap, but that
 			// does not afffect on resulting DateTime
 			Assert.AreEqual (new DateTime (2001, 5, 23), cn.ToDateTime (2001, 5, 1, 0, 0, 0, 0), "cn4");
-			Assert.AreEqual (new DateTime (2001, 5, 23), jp.ToDateTime (13, 5, 1, 0, 0, 0, 0, 1), "jp4");
+			Assert.AreEqual (new DateTime (2001, 5, 23), jp.ToDateTime (13, 5, 1, 0, 0, 0, 0, 4), "jp4");
 			Assert.AreEqual (new DateTime (2001, 5, 23), tw.ToDateTime (90, 5, 1, 0, 0, 0, 0), "tw4");
 			Assert.AreEqual (new DateTime (2001, 5, 23), kr.ToDateTime (2001, 5, 1, 0, 0, 0, 0), "kr4");
 
 			// here the leap month works.
 			Assert.AreEqual (new DateTime (2002, 2, 11), cn.ToDateTime (2001, 13, 30, 0, 0, 0, 0), "cn5");
-			Assert.AreEqual (new DateTime (2002, 2, 11), jp.ToDateTime (13, 13, 30, 0, 0, 0, 0, 1), "jp5");
+			Assert.AreEqual (new DateTime (2002, 2, 11), jp.ToDateTime (13, 13, 30, 0, 0, 0, 0, 4), "jp5");
 			Assert.AreEqual (new DateTime (2002, 2, 11), tw.ToDateTime (90, 13, 30, 0, 0, 0, 0), "tw5");
 			Assert.AreEqual (new DateTime (2002, 2, 11), kr.ToDateTime (2001, 13, 30, 0, 0, 0, 0), "kr5");
 
@@ -115,7 +115,7 @@ namespace MonoTests.System.Globalization
 			for (int i = 0; i < 60; i++)
 				Assert.AreEqual (leapYears [i % 19], cn.IsLeapYear (2000 + i), "cn" + i);
 			for (int i = 0; i < 48; i++) // only 1-to-61 are allowed
-				Assert.AreEqual (leapYears [i % 19], jp.IsLeapYear (12 + i, 1), "jp" + i);
+				Assert.AreEqual (leapYears [i % 19], jp.IsLeapYear (12 + i, 4), "jp" + i);
 			for (int i = 0; i < 50; i++)
 				Assert.AreEqual (leapYears [i % 19], tw.IsLeapYear (89 + i), "tw" + i);
 			for (int i = 0; i < 50; i++)
@@ -178,7 +178,7 @@ namespace MonoTests.System.Globalization
 			d [29] = 6;
 			for (int y = 12; y < 32; y++)
 				for (int m = 1; m <= 12; m++)
-					Assert.AreEqual (d.ContainsKey (y) && d [y] == m, jp.IsLeapMonth (y, m, 1), "jp" + y + "/" + m);
+					Assert.AreEqual (d.ContainsKey (y) && d [y] == m, jp.IsLeapMonth (y, m, 4), "jp" + y + "/" + m);
 
 			d = new Dictionary<int,int> ();
 			d [2001] = 5;

--- a/mcs/class/corlib/Test/System.Globalization/EastAsianLunisolarCalendarTest.cs
+++ b/mcs/class/corlib/Test/System.Globalization/EastAsianLunisolarCalendarTest.cs
@@ -49,35 +49,35 @@ namespace MonoTests.System.Globalization
 		public void ToDateTime ()
 		{
 			Assert.AreEqual (new DateTime (2000, 2, 5), cn.ToDateTime (2000, 1, 1, 0, 0, 0, 0), "cn1");
-			Assert.AreEqual (new DateTime (2000, 2, 5), jp.ToDateTime (12, 1, 1, 0, 0, 0, 0), "jp1"); // since 1988 (current epoch)
+			Assert.AreEqual (new DateTime (2000, 2, 5), jp.ToDateTime (12, 1, 1, 0, 0, 0, 0, 1), "jp1"); // since 1988 (current epoch)
 			Assert.AreEqual (new DateTime (2000, 2, 5), tw.ToDateTime (89, 1, 1, 0, 0, 0, 0), "tw1"); // since 1912 (current epoch)
 			Assert.AreEqual (new DateTime (2000, 2, 5), kr.ToDateTime (2000, 1, 1, 0, 0, 0, 0), "kr1");
 
 			Assert.AreEqual (new DateTime (2001, 1, 24), cn.ToDateTime (2001, 1, 1, 0, 0, 0, 0), "cn2");
-			Assert.AreEqual (new DateTime (2001, 1, 24), jp.ToDateTime (13, 1, 1, 0, 0, 0, 0), "jp2");
+			Assert.AreEqual (new DateTime (2001, 1, 24), jp.ToDateTime (13, 1, 1, 0, 0, 0, 0, 1), "jp2");
 			Assert.AreEqual (new DateTime (2001, 1, 24), tw.ToDateTime (90, 1, 1, 0, 0, 0, 0), "tw2");
 			Assert.AreEqual (new DateTime (2001, 1, 24), kr.ToDateTime (2001, 1, 1, 0, 0, 0, 0), "kr2");
 
 			Assert.AreEqual (new DateTime (2002, 2, 12), cn.ToDateTime (2002, 1, 1, 0, 0, 0, 0), "cn3");
-			Assert.AreEqual (new DateTime (2002, 2, 12), jp.ToDateTime (14, 1, 1, 0, 0, 0, 0), "jp3");
+			Assert.AreEqual (new DateTime (2002, 2, 12), jp.ToDateTime (14, 1, 1, 0, 0, 0, 0, 1), "jp3");
 			Assert.AreEqual (new DateTime (2002, 2, 12), tw.ToDateTime (91, 1, 1, 0, 0, 0, 0), "tw3");
 			Assert.AreEqual (new DateTime (2002, 2, 12), kr.ToDateTime (2002, 1, 1, 0, 0, 0, 0), "kr3");
 
 			// actually it is 5th month which is leap, but that
 			// does not afffect on resulting DateTime
 			Assert.AreEqual (new DateTime (2001, 5, 23), cn.ToDateTime (2001, 5, 1, 0, 0, 0, 0), "cn4");
-			Assert.AreEqual (new DateTime (2001, 5, 23), jp.ToDateTime (13, 5, 1, 0, 0, 0, 0), "jp4");
+			Assert.AreEqual (new DateTime (2001, 5, 23), jp.ToDateTime (13, 5, 1, 0, 0, 0, 0, 1), "jp4");
 			Assert.AreEqual (new DateTime (2001, 5, 23), tw.ToDateTime (90, 5, 1, 0, 0, 0, 0), "tw4");
 			Assert.AreEqual (new DateTime (2001, 5, 23), kr.ToDateTime (2001, 5, 1, 0, 0, 0, 0), "kr4");
 
 			// here the leap month works.
 			Assert.AreEqual (new DateTime (2002, 2, 11), cn.ToDateTime (2001, 13, 30, 0, 0, 0, 0), "cn5");
-			Assert.AreEqual (new DateTime (2002, 2, 11), jp.ToDateTime (13, 13, 30, 0, 0, 0, 0), "jp5");
+			Assert.AreEqual (new DateTime (2002, 2, 11), jp.ToDateTime (13, 13, 30, 0, 0, 0, 0, 1), "jp5");
 			Assert.AreEqual (new DateTime (2002, 2, 11), tw.ToDateTime (90, 13, 30, 0, 0, 0, 0), "tw5");
 			Assert.AreEqual (new DateTime (2002, 2, 11), kr.ToDateTime (2001, 13, 30, 0, 0, 0, 0), "kr5");
 
 			Assert.AreEqual (cn.MinSupportedDateTime, cn.ToDateTime (1901, 1, 1, 0, 0, 0, 0), "cn6");
-			Assert.AreEqual (jp.MinSupportedDateTime, jp.ToDateTime (35, 1, 1, 0, 0, 0, 0, 3), "jp6"); // 1960-1-1
+			Assert.AreEqual (jp.MinSupportedDateTime, jp.ToDateTime (35, 1, 1, 0, 0, 0, 0, 4), "jp6"); // 1960-1-1
 			Assert.AreEqual (tw.MinSupportedDateTime, tw.ToDateTime (1, 1, 1, 0, 0, 0, 0), "tw6"); // 1912
 			Assert.AreEqual (kr.MinSupportedDateTime, kr.ToDateTime (918, 1, 1, 0, 0, 0, 0), "kr6");
 
@@ -115,7 +115,7 @@ namespace MonoTests.System.Globalization
 			for (int i = 0; i < 60; i++)
 				Assert.AreEqual (leapYears [i % 19], cn.IsLeapYear (2000 + i), "cn" + i);
 			for (int i = 0; i < 48; i++) // only 1-to-61 are allowed
-				Assert.AreEqual (leapYears [i % 19], jp.IsLeapYear (12 + i), "jp" + i);
+				Assert.AreEqual (leapYears [i % 19], jp.IsLeapYear (12 + i, 1), "jp" + i);
 			for (int i = 0; i < 50; i++)
 				Assert.AreEqual (leapYears [i % 19], tw.IsLeapYear (89 + i), "tw" + i);
 			for (int i = 0; i < 50; i++)
@@ -178,7 +178,7 @@ namespace MonoTests.System.Globalization
 			d [29] = 6;
 			for (int y = 12; y < 32; y++)
 				for (int m = 1; m <= 12; m++)
-					Assert.AreEqual (d.ContainsKey (y) && d [y] == m, jp.IsLeapMonth (y, m), "jp" + y + "/" + m);
+					Assert.AreEqual (d.ContainsKey (y) && d [y] == m, jp.IsLeapMonth (y, m, 1), "jp" + y + "/" + m);
 
 			d = new Dictionary<int,int> ();
 			d [2001] = 5;

--- a/mcs/class/corlib/Test/System.Globalization/EastAsianLunisolarCalendarTest.cs
+++ b/mcs/class/corlib/Test/System.Globalization/EastAsianLunisolarCalendarTest.cs
@@ -77,7 +77,7 @@ namespace MonoTests.System.Globalization
 			Assert.AreEqual (new DateTime (2002, 2, 11), kr.ToDateTime (2001, 13, 30, 0, 0, 0, 0), "kr5");
 
 			Assert.AreEqual (cn.MinSupportedDateTime, cn.ToDateTime (1901, 1, 1, 0, 0, 0, 0), "cn6");
-			Assert.AreEqual (jp.MinSupportedDateTime, jp.ToDateTime (35, 1, 1, 0, 0, 0, 0, 4), "jp6"); // 1960-1-1
+			Assert.AreEqual (jp.MinSupportedDateTime, jp.ToDateTime (35, 1, 1, 0, 0, 0, 0, 3), "jp6"); // 1960-1-1
 			Assert.AreEqual (tw.MinSupportedDateTime, tw.ToDateTime (1, 1, 1, 0, 0, 0, 0), "tw6"); // 1912
 			Assert.AreEqual (kr.MinSupportedDateTime, kr.ToDateTime (918, 1, 1, 0, 0, 0, 0), "kr6");
 

--- a/mcs/class/referencesource/mscorlib/system/globalization/japanesecalendar.cs
+++ b/mcs/class/referencesource/mscorlib/system/globalization/japanesecalendar.cs
@@ -124,7 +124,7 @@ namespace System.Globalization {
                 if (japaneseEraInfo == null)
                 {
                     // We know about some built-in ranges
-                    EraInfo[] defaultEraRanges = new EraInfo[4];
+                    EraInfo[] defaultEraRanges = new EraInfo[5];
                     defaultEraRanges[0] = new EraInfo( 5, 2019,  5,  1, 2018, 1, GregorianCalendar.MaxYear - 2018,
                                                        "\x4ee4\x548c", "\x4ee4", "R");    // era #5 start year/month/day, yearOffset, minEraYear
                     defaultEraRanges[1] = new EraInfo( 4, 1989,  1,  8, 1988, 1, 2019-1988,

--- a/mcs/class/referencesource/mscorlib/system/globalization/japanesecalendar.cs
+++ b/mcs/class/referencesource/mscorlib/system/globalization/japanesecalendar.cs
@@ -22,14 +22,14 @@ namespace System.Globalization {
     ** year based on the era.
     **
     ** This system is adopted by Emperor Meiji in 1868. The year value is counted based on the reign of an emperor,
-    ** and the era begins on the day an emperor ascends the throne and continues until his death.
+    ** and the era begins on the day an emperor ascends the throne and continues until his death or his abdication.
     ** The era changes at 12:00AM.
     **
-    ** For example, the current era is Heisei.  It started on 1989/1/8 A.D.  Therefore, Gregorian year 1989 is also Heisei 1st.
-    ** 1989/1/8 A.D. is also Heisei 1st 1/8.
+    ** For example, the current era is Reiwa.  It started on 2019/5/1 A.D.  Therefore, Gregorian year 2019 is also Reiwa 1st.
+    ** 2019/5/1 A.D. is also Reiwa 1st 5/1.
     **
     ** Any date in the year during which era is changed can be reckoned in either era.  For example,
-    ** 1989/1/1 can be 1/1 Heisei 1st year or 1/1 Showa 64th year.
+    ** 2019/1/1 can be 1/1 Reiwa 1st year or 1/1 Heisei 31st year.
     **
     ** Note:
     **  The DateTime can be represented by the JapaneseCalendar are limited to two factors:
@@ -40,7 +40,7 @@ namespace System.Globalization {
     **      Calendar    Minimum     Maximum
     **      ==========  ==========  ==========
     **      Gregorian   1868/09/08  9999/12/31
-    **      Japanese    Meiji 01/01 Heisei 8011/12/31
+    **      Japanese    Meiji 01/01 Reiwa 7981/12/31
     ============================================================================*/
 
 
@@ -96,7 +96,7 @@ namespace System.Globalization {
         // should be the first element.
         // That is, m_EraInfo[0] contains the most recent era.
         //
-        // We know about 4 built-in eras, however users may add additional era(s) from the
+        // We know about 5 built-in eras, however users may add additional era(s) from the
         // registry, by adding values to HKLM\SYSTEM\CurrentControlSet\Control\Nls\Calendars\Japanese\Eras
         //
         // Registry values look like:
@@ -125,13 +125,15 @@ namespace System.Globalization {
                 {
                     // We know about some built-in ranges
                     EraInfo[] defaultEraRanges = new EraInfo[4];
-                    defaultEraRanges[0] = new EraInfo( 4, 1989,  1,  8, 1988, 1, GregorianCalendar.MaxYear - 1988,
+                    defaultEraRanges[0] = new EraInfo( 5, 2019,  5,  1, 2018, 1, GregorianCalendar.MaxYear - 2018,
+                                                       "\x4ee4\x548c", "\x4ee4", "R");    // era #5 start year/month/day, yearOffset, minEraYear
+                    defaultEraRanges[1] = new EraInfo( 4, 1989,  1,  8, 1988, 1, 2019-1988,
                                                        "\x5e73\x6210", "\x5e73", "H");    // era #4 start year/month/day, yearOffset, minEraYear
-                    defaultEraRanges[1] = new EraInfo( 3, 1926, 12, 25, 1925, 1, 1989-1925,
+                    defaultEraRanges[2] = new EraInfo( 3, 1926, 12, 25, 1925, 1, 1989-1925,
                                                        "\x662d\x548c", "\x662d", "S");    // era #3,start year/month/day, yearOffset, minEraYear
-                    defaultEraRanges[2] = new EraInfo( 2, 1912,  7, 30, 1911, 1, 1926-1911,
+                    defaultEraRanges[3] = new EraInfo( 2, 1912,  7, 30, 1911, 1, 1926-1911,
                                                        "\x5927\x6b63", "\x5927", "T");    // era #2,start year/month/day, yearOffset, minEraYear
-                    defaultEraRanges[3] = new EraInfo( 1, 1868,  1,  1, 1867, 1, 1912-1867,
+                    defaultEraRanges[4] = new EraInfo( 1, 1868,  1,  1, 1867, 1, 1912-1867,
                                                        "\x660e\x6cbb", "\x660e", "M");    // era #1,start year/month/day, yearOffset, minEraYear
 
                     // Remember the ranges we built
@@ -221,9 +223,9 @@ namespace System.Globalization {
 
             //
             // If we didn't have valid eras, then fail
-            // should have at least 4 eras
+            // should have at least 5 eras
             //
-            if (iFoundEras < 4) return null;
+            if (iFoundEras < 5) return null;
 
             //
             // Now we have eras, clean them up.

--- a/netcore/System.Private.CoreLib/shared/System/Globalization/JapaneseCalendar.Win32.cs
+++ b/netcore/System.Private.CoreLib/shared/System/Globalization/JapaneseCalendar.Win32.cs
@@ -12,7 +12,7 @@ namespace System.Globalization
     {
         private const string JapaneseErasHive = @"System\CurrentControlSet\Control\Nls\Calendars\Japanese\Eras";
 
-        // We know about 4 built-in eras, however users may add additional era(s) from the
+        // We know about 5 built-in eras, however users may add additional era(s) from the
         // registry, by adding values to HKLM\SYSTEM\CurrentControlSet\Control\Nls\Calendars\Japanese\Eras
         //
         // Registry values look like:
@@ -81,9 +81,9 @@ namespace System.Globalization
 
             //
             // If we didn't have valid eras, then fail
-            // should have at least 4 eras
+            // should have at least 5 eras
             //
-            if (iFoundEras < 4) return null;
+            if (iFoundEras < 5) return null;
 
             //
             // Now we have eras, clean them up.

--- a/netcore/System.Private.CoreLib/shared/System/Globalization/JapaneseCalendar.cs
+++ b/netcore/System.Private.CoreLib/shared/System/Globalization/JapaneseCalendar.cs
@@ -10,7 +10,7 @@ namespace System.Globalization
     /// year based on the era.
     ///
     /// This system is adopted by Emperor Meiji in 1868. The year value is counted based on the reign of an emperor,
-    /// and the era begins on the day an emperor ascends the throne and continues until his death.
+    /// and the era begins on the day an emperor ascends the throne and continues until his death or his abdication.
     /// The era changes at 12:00AM.
     ///
     /// For example, the current era is Reiwa.  It started on 2019/5/1 A.D.  Therefore, Gregorian year 2019 is also Reiwa 1st.


### PR DESCRIPTION
refs: <https://github.com/dotnet/coreclr/pull/23614>

mcs side of the hard coded tables seems referenced from Blazor (client-side), but it's not updated yet.

FYI: <https://qiita.com/jsakamoto/items/da68cee22bbca187f389> (an article which describes this problem, written in Japanese)


Backport of #14896.

/cc @marek-safar @acid-chicken