### PR TITLE
[crash] Print native module name when crash privacy disabled

### DIFF
--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1449,6 +1449,9 @@ mono_crash_reporting_register_native_library (const char *module_path, const cha
 static gboolean
 check_whitelisted_module (const char *in_name, const char **out_module)
 {
+#ifndef MONO_PRIVATE_CRASHES
+		return TRUE;
+#else
 	if (g_str_has_suffix (in_name, "mono-sgen")) {
 		if (out_module)
 			*out_module = "mono";
@@ -1465,6 +1468,7 @@ check_whitelisted_module (const char *in_name, const char **out_module)
 	}
 
 	return FALSE;
+#endif
 }
 
 static intptr_t


### PR DESCRIPTION
This makes it so that disabling crash privacy ensures we get the full native symbols printed regardless of allow and deny lists.

Before: https://gist.github.com/alexanderkyte/2b1f38a880c61ea15aa4c851e44af578

After: https://gist.github.com/alexanderkyte/ce80788a51761d91890d812874fa2da2