### PR TITLE
[corlib] Add missing Unsafe.Unbox () method.

### DIFF
--- a/mcs/class/corlib/System.Runtime.CompilerServices/Unsafe.il
+++ b/mcs/class/corlib/System.Runtime.CompilerServices/Unsafe.il
@@ -365,4 +365,12 @@
         clt.un
         ret
   }
+
+  .method public hidebysig static !!T& Unbox<valuetype .ctor ([mscorlib]System.ValueType) T> (object 'box') cil managed aggressiveinlining
+  {
+        .maxstack 1
+        ldarg.0
+        unbox !!T
+        ret
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/14871.