### PR TITLE
[2019-06] [aot] Open AOT profile files using "rb" so it works on windows.

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -12147,7 +12147,7 @@ load_profile_file (MonoAotCompile *acfg, char *filename)
 	int res, len, version;
 	char magic [32];
 
-	infile = fopen (filename, "r");
+	infile = fopen (filename, "rb");
 	if (!infile) {
 		fprintf (stderr, "Unable to open file '%s': %s.\n", filename, strerror (errno));
 		exit (1);


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-android/issues/3168.

Backport of #14992.

/cc @lewing @vargaz