### PR TITLE
[2019-02] [runtime] Fix gshared support for BeginInvoke ()/EndInvoke () wrappers.

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -1879,12 +1879,15 @@ mono_marshal_get_delegate_begin_invoke (MonoMethod *method)
 
 	get_marshal_cb ()->emit_delegate_begin_invoke (mb, sig);
 
+	WrapperInfo *info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_NONE);
+	info->d.delegate_invoke.method = method;
+
 	if (ctx) {
 		MonoMethod *def;
-		def = mono_mb_create_and_cache (cache, method->klass, mb, sig, sig->param_count + 16);
+		def = mono_mb_create_and_cache_full (cache, method->klass, mb, sig, sig->param_count + 16, info, NULL);
 		res = cache_generic_delegate_wrapper (cache, orig_method, def, ctx);
 	} else {
-		res = mono_mb_create_and_cache (cache, sig, mb, sig, sig->param_count + 16);
+		res = mono_mb_create_and_cache_full (cache, sig, mb, sig, sig->param_count + 16, info, NULL);
 	}
 
 	mono_mb_free (mb);
@@ -2058,13 +2061,16 @@ mono_marshal_get_delegate_end_invoke (MonoMethod *method)
 
 	get_marshal_cb ()->emit_delegate_end_invoke (mb, sig);
 
+	WrapperInfo *info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_NONE);
+	info->d.delegate_invoke.method = method;
+
 	if (ctx) {
 		MonoMethod *def;
-		def = mono_mb_create_and_cache (cache, method->klass, mb, sig, sig->param_count + 16);
+		def = mono_mb_create_and_cache_full (cache, method->klass, mb, sig, sig->param_count + 16, info, NULL);
 		res = cache_generic_delegate_wrapper (cache, orig_method, def, ctx);
 	} else {
-		res = mono_mb_create_and_cache (cache, sig,
-										mb, sig, sig->param_count + 16);
+		res = mono_mb_create_and_cache_full (cache, sig,
+											 mb, sig, sig->param_count + 16, info, NULL);
 	}
 	mono_mb_free (mb);
 

--- a/mono/mini/gshared.cs
+++ b/mono/mini/gshared.cs
@@ -1348,8 +1348,6 @@ public class Tests
 		}
 	}
 
-	// FIXME: The runtime-invoke wrapper used by BeginInvoke is not found
-	[Category ("!FULLAOT")]
 	// FIXME: Wasm is single threaded and can't handle blocking waits
 	[Category ("!WASM")]
 	public static int test_0_begin_end_invoke () {

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -3972,6 +3972,7 @@ mini_get_shared_method_full (MonoMethod *method, GetSharedMethodFlags flags, Mon
 	MonoGenericContainer *class_container, *method_container = NULL;
 	MonoGenericContext *context = mono_method_get_context (method);
 	MonoGenericInst *inst;
+	WrapperInfo *info = NULL;
 
 	error_init (error);
 
@@ -3981,7 +3982,10 @@ mini_get_shared_method_full (MonoMethod *method, GetSharedMethodFlags flags, Mon
 	 * same wrapper, breaking AOT which assumes wrappers are unique.
 	 * FIXME: Add other cases.
 	 */
-	if (method->wrapper_type == MONO_WRAPPER_SYNCHRONIZED) {
+	if (method->wrapper_type)
+		info = mono_marshal_get_wrapper_info (method);
+	switch (method->wrapper_type) {
+	case MONO_WRAPPER_SYNCHRONIZED: {
 		MonoMethod *wrapper = mono_marshal_method_from_wrapper (method);
 
 		MonoMethod *gwrapper = mini_get_shared_method_full (wrapper, flags, error);
@@ -3989,16 +3993,27 @@ mini_get_shared_method_full (MonoMethod *method, GetSharedMethodFlags flags, Mon
 
 		return mono_marshal_get_synchronized_wrapper (gwrapper);
 	}
-	if (method->wrapper_type == MONO_WRAPPER_DELEGATE_INVOKE) {
-		WrapperInfo *info = mono_marshal_get_wrapper_info (method);
-
+	case MONO_WRAPPER_DELEGATE_INVOKE: {
 		if (info->subtype == WRAPPER_SUBTYPE_NONE) {
 			MonoMethod *ginvoke = mini_get_shared_method_full (info->d.delegate_invoke.method, flags, error);
 			return_val_if_nok (error, NULL);
 
-			MonoMethod *m = mono_marshal_get_delegate_invoke (ginvoke, NULL);
-			return m;
+			return mono_marshal_get_delegate_invoke (ginvoke, NULL);
 		}
+		break;
+	}
+	case MONO_WRAPPER_DELEGATE_BEGIN_INVOKE:
+	case MONO_WRAPPER_DELEGATE_END_INVOKE: {
+		MonoMethod *ginvoke = mini_get_shared_method_full (info->d.delegate_invoke.method, flags, error);
+		return_val_if_nok (error, NULL);
+
+		if (method->wrapper_type == MONO_WRAPPER_DELEGATE_BEGIN_INVOKE)
+			return mono_marshal_get_delegate_begin_invoke (ginvoke);
+		else
+			return mono_marshal_get_delegate_end_invoke (ginvoke);
+	}
+	default:
+		break;
 	}
 
 	if (method->is_generic || (mono_class_is_gtd (method->klass) && !method->is_inflated)) {


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/14972.

Backport of #14985.

/cc @marek-safar @vargaz