### PR TITLE
Add read barrier to mono_lazy_initialize().

### DIFF
--- a/mono/utils/mono-lazy-init.h
+++ b/mono/utils/mono-lazy-init.h
@@ -62,8 +62,10 @@ mono_lazy_initialize (mono_lazy_init_t *lazy_init, void (*initialize) (void))
 
 	status = *lazy_init;
 
-	if (status >= MONO_LAZY_INIT_STATUS_INITIALIZED)
+	if (status >= MONO_LAZY_INIT_STATUS_INITIALIZED) {
+		mono_memory_read_barrier ();
 		return status == MONO_LAZY_INIT_STATUS_INITIALIZED;
+	}
 	if (status == MONO_LAZY_INIT_STATUS_INITIALIZING
 	     || mono_atomic_cas_i32 (lazy_init, MONO_LAZY_INIT_STATUS_INITIALIZING, MONO_LAZY_INIT_STATUS_NOT_INITIALIZED)
 	         != MONO_LAZY_INIT_STATUS_NOT_INITIALIZED


### PR DESCRIPTION
This is unfortunate.

The general pattern of:

```
if !initialized
  initialize the data, possibly with lots of locks and barriers
  initialized = TRUE
end
use the data
```
is racy, because "use the data" can be scheduled ahead of "if initialized".

"Barriers come in pairs" generally, and this was missing one.

It depends somewhat. If the data is all pointers, initialized
from null to non-null, and use includes dereferencing, which is a common
but not universal case, then it is ok on all non-Alpha processors, due
to "data dependency".

But if the data includes reading globals, then there is a race.

This is a bit of a slow down on fast paths on arm, and possibly
other architectures.

There are barrier-free ways to solve this, involving a thread local,
that should seriously be considered, and applied throughout the runtime.

The runtime has a lot of on-demand initialization and a lot looks racy.

See www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2660.htm (scroll all the way to the end).
Which would have to be adapted to be coop-friendly which should not be difficult.

Notice that the existing "lazy" mechanism is also not coop-friendly.
That is not changed by this PR.