### PR TITLE
[wasm] Fix generated warning in driver.c

### DIFF
--- a/sdks/wasm/driver.c
+++ b/sdks/wasm/driver.c
@@ -343,7 +343,7 @@ mono_wasm_load_runtime (const char *managed_path, int enable_debugging)
 #endif
 
 	if (assembly_count) {
-		const MonoBundledAssembly **bundle_array = g_new0 (MonoBundledAssembly*, assembly_count + 1);
+		MonoBundledAssembly **bundle_array = g_new0 (MonoBundledAssembly*, assembly_count + 1);
 		WasmAssembly *cur = assemblies;
 		int i = 0;
 		while (cur) {
@@ -351,7 +351,7 @@ mono_wasm_load_runtime (const char *managed_path, int enable_debugging)
 			cur = cur->next;
 			++i;
 		}
-		mono_register_bundled_assemblies (bundle_array);
+		mono_register_bundled_assemblies ((const MonoBundledAssembly **)bundle_array);
 	}
 
 	mono_trace_init ();


### PR DESCRIPTION
The following warning is generated when building master for interpreter as well as during `packager.exe` AOT build of driver.c

```
driver.c:346:31: warning: initializing 'const MonoBundledAssembly **' with an expression of type 'MonoBundledAssembly **' discards qualifiers in nested pointer types [-Wincompatible-pointer-types-discards-qualifiers]
                const MonoBundledAssembly **bundle_array = g_new0 (MonoBundledAssembly*, assembly_count + 1);
                                            ^              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The warning was introduced by PR: https://github.com/mono/mono/pull/14890


<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
