### PR TITLE
[wasm] Simplify AOT profiling initialization.

### DIFF
--- a/sdks/wasm/aot-profile/gen-profile.js
+++ b/sdks/wasm/aot-profile/gen-profile.js
@@ -29,7 +29,7 @@ server.listen(port);
 	page.on('console', msg => console.log('LOG:', msg.text()));
 	await page.goto ('http://localhost:' + port);
 	await page.waitFor(1000);
-	const data = await page.mainFrame ().evaluate('Array.from(AotProfileData.data)');
+	const data = await page.mainFrame ().evaluate('Array.from(Module.aot_profile_data)');
 	console.log (data.length);
 	fs.writeFile (output_file, Buffer.from (data), function(err) {
 		if (err)

--- a/sdks/wasm/aot-profile/main.cs
+++ b/sdks/wasm/aot-profile/main.cs
@@ -6,28 +6,8 @@ using WebAssembly.Core;
 
 public class HelloWorld
 {
-	public unsafe static void Dump (ref byte buf, int len, string s) {
-		var arr = new byte [len];
-		fixed (void *p = &buf) {
-			var span = new ReadOnlySpan<byte> (p, len);
-
-			// Send it to JS
-			try {
-				var js_dump = (JSObject)Runtime.GetGlobalObject ("AotProfileData");
-				js_dump.SetObjectProperty ("data", Uint8Array.From (span));
-			} catch (Exception ex) {
-				Console.WriteLine (ex);
-				Environment.Exit (1);
-			}
-		}
-	}
-
-	[MethodImplAttribute (MethodImplOptions.NoInlining)]
-	public static void StopProfile () {
-	}
-
 	public static void Main (String[] args) {
 		Console.WriteLine ("Hello, World!");
-		StopProfile ();
+		Runtime.StopProfile ();
 	}
 }

--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Runtime.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Runtime.cs
@@ -581,5 +581,23 @@ namespace WebAssembly {
 			return contractName;
 		}
 
+		//
+		// Can be called by the app to stop profiling
+		//
+		[MethodImplAttribute (MethodImplOptions.NoInlining)]
+		public static void StopProfile () {
+		}
+
+		// Called by the AOT profiler to save profile data into Module.aot_profile_data
+		internal unsafe static void DumpAotProfileData (ref byte buf, int len, string s) {
+			var arr = new byte [len];
+			fixed (void *p = &buf) {
+				var span = new ReadOnlySpan<byte> (p, len);
+
+				// Send it to JS
+				var js_dump = (JSObject)Runtime.GetGlobalObject ("Module");
+				js_dump.SetObjectProperty ("aot_profile_data", WebAssembly.Core.Uint8Array.From (span));
+			}
+		}
 	}
 }

--- a/sdks/wasm/library_mono.js
+++ b/sdks/wasm/library_mono.js
@@ -128,6 +128,26 @@ var MonoSupportLib = {
 			this.wasm_parse_runtime_options (options.length, argv);
 		},
 
+		//
+		// Initialize the AOT profiler with OPTIONS.
+		// Requires the AOT profiler to be linked into the app.
+		// options = { write_at: "<METHODNAME>", send_to: "<METHODNAME>" }
+		// <METHODNAME> should be in the format <CLASS>::<METHODNAME>.
+		// write_at defaults to 'WebAssembly.Runtime::StopProfile'.
+		// send_to defaults to 'WebAssembly.Runtime::DumpAotProfileData'.
+		// DumpAotProfileData stores the data into Module.aot_profile_data.
+		//
+		mono_wasm_init_aot_profiler: function (options) {
+			if (options == null)
+				options = {}
+			if (!('write_at' in options))
+				options.write_at = 'WebAssembly.Runtime::StopProfile';
+			if (!('send_to' in options))
+				options.send_to = 'WebAssembly.Runtime::DumpAotProfileData';
+			var arg = "aot:write-at-method=" + options.write_at + ",send-to-method=" + options.send_to;
+			Module.ccall ('mono_wasm_load_profiler_aot', 'void', ['string'], [arg]);
+		},
+
 		mono_load_runtime_and_bcl: function (vfs_prefix, deploy_prefix, enable_debugging, file_list, loaded_cb, fetch_file_cb) {
 			var pending = file_list.length;
 			var loaded_files = [];

--- a/sdks/wasm/packager.cs
+++ b/sdks/wasm/packager.cs
@@ -660,10 +660,10 @@ class Driver {
 				profiler_aot_args += " ";
 			profiler_aot_args += $"--profile={profiler}";
 		}
-		if (ee_mode == ExecMode.AotInterp) {
+		if (ee_mode == ExecMode.AotInterp)
 			aot_args += "interp,";
+		if (build_wasm)
 			enable_zlib = true;
-		}
 
 		runtime_dir = Path.GetFullPath (runtime_dir);
 		sdkdir = Path.GetFullPath (sdkdir);


### PR DESCRIPTION
Current steps:
- Call MONO.mono_wasm_init_aot_profiler (null) before calling MONO.mono_load_runtime_and_bcl ().
- Call WebAssembly.Runtime.StopProfile () from the c# code to stop profiling.
- The profile data will be in Module.aot_profile_data.