### PR TITLE
[2019-02][System.Net.Http]: Add hack to the legacy HttpClient to pass down Timeout.  #14970

### DIFF
--- a/mcs/class/System.Net.Http/HttpClientHandler.cs
+++ b/mcs/class/System.Net.Http/HttpClientHandler.cs
@@ -188,6 +188,12 @@ namespace System.Net.Http
 
 		public IDictionary<string, object> Properties => _delegatingHandler.Properties;
 
+		// Only used in MonoWebRequestHandler and ignored by the other handlers.
+		internal void SetWebRequestTimeout (TimeSpan timeout)
+		{
+			_delegatingHandler.SetWebRequestTimeout (timeout);
+		}
+
 		protected internal override Task<HttpResponseMessage> SendAsync (HttpRequestMessage request, CancellationToken cancellationToken) =>
 		    _delegatingHandler.SendAsync (request, cancellationToken);
 	}

--- a/mcs/class/System.Net.Http/IMonoHttpClientHandler.cs
+++ b/mcs/class/System.Net.Http/IMonoHttpClientHandler.cs
@@ -78,5 +78,8 @@ namespace System.Net.Http
 		}
 
 		Task<HttpResponseMessage> SendAsync (HttpRequestMessage request, CancellationToken cancellationToken);
+
+		// Only used by MonoWebRequestHandler and ignored by the other handlers.
+		void SetWebRequestTimeout (TimeSpan timeout);
 	}
 }

--- a/mcs/class/System.Net.Http/MonoWebRequestHandler.cs
+++ b/mcs/class/System.Net.Http/MonoWebRequestHandler.cs
@@ -67,6 +67,7 @@ namespace System.Net.Http
 		bool unsafeAuthenticatedConnectionSharing;
 		bool sentRequest;
 		string connectionGroupName;
+		TimeSpan? timeout;
 		bool disposed;
 
 		internal MonoWebRequestHandler ()
@@ -368,6 +369,9 @@ namespace System.Net.Http
 
 			wr.ServicePoint.Expect100Continue = request.Headers.ExpectContinue == true;
 
+			if (timeout != null)
+				wr.Timeout = (int)timeout.Value.TotalMilliseconds;
+
 			// Add request headers
 			var headers = wr.Headers;
 			foreach (var header in request.Headers) {
@@ -532,6 +536,11 @@ namespace System.Net.Http
 			get {
 				throw new NotImplementedException ();
 			}
+		}
+
+		void IMonoHttpClientHandler.SetWebRequestTimeout (TimeSpan timeout)
+		{
+			this.timeout = timeout;
 		}
 	}
 }

--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClient.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClient.cs
@@ -269,6 +269,9 @@ namespace System.Net.Http
 		async Task<HttpResponseMessage> SendAsyncWorker (HttpRequestMessage request, HttpCompletionOption completionOption, CancellationToken cancellationToken)
 		{
 			using (var lcts = CancellationTokenSource.CreateLinkedTokenSource (cts.Token, cancellationToken)) {
+				// Hack to pass the timeout to the HttpWebRequest that's created by MonoWebRequestHandler; all other handlers ignore this.
+				if (handler is HttpClientHandler clientHandler)
+					clientHandler.SetWebRequestTimeout (timeout);
 				lcts.CancelAfter (timeout);
 
 				var task = base.SendAsync (request, lcts.Token);

--- a/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.platformnotsupported.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpClientHandler.platformnotsupported.cs
@@ -169,5 +169,8 @@ namespace System.Net.Http
 			get { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
 			set { throw new PlatformNotSupportedException (EXCEPTION_MESSAGE); }
 		}
+
+		// Only used in MonoWebRequestHandler and ignored by the other handlers.
+		internal void SetWebRequestTimeout (TimeSpan timeout) => throw new PlatformNotSupportedException (EXCEPTION_MESSAGE);
 	}
 }

--- a/mcs/class/System.Net.Http/System.Net.Http/HttpMessageInvoker.cs
+++ b/mcs/class/System.Net.Http/System.Net.Http/HttpMessageInvoker.cs
@@ -33,7 +33,7 @@ namespace System.Net.Http
 {
 	public class HttpMessageInvoker : IDisposable
 	{
-		HttpMessageHandler handler;
+		protected private HttpMessageHandler handler;
 		readonly bool disposeHandler;
 		
 		public HttpMessageInvoker (HttpMessageHandler handler)

--- a/mcs/class/System.Net.Http/corefx/SocketsHttpHandler.Mono.cs
+++ b/mcs/class/System.Net.Http/corefx/SocketsHttpHandler.Mono.cs
@@ -40,6 +40,11 @@ namespace System.Net.Http
 			}
 		}
 
+		// This is only used by MonoWebRequestHandler.
+		void IMonoHttpClientHandler.SetWebRequestTimeout (TimeSpan timeout)
+		{
+		}
+
 		Task<HttpResponseMessage> IMonoHttpClientHandler.SendAsync (HttpRequestMessage request, CancellationToken cancellationToken) => SendAsync (request, cancellationToken);
 	}
 }


### PR DESCRIPTION
_manual backport of #14970._

[System.Net.Http]: Add hack to the legacy HttpClient to pass down Timeout property. #12577. (#14970)

* [System.Net.Http]: Add hack to the legacy HttpClient to pass down Timeout property. #12577.

* `HttpClientHandler`, `IMonoHttpClientHandler`: add new internal `MonoSetTimeout (TimeSpan)` function.

* `HttpClient.SendAsyncWorker()`: if `handler` is `HttpClientHandler`, call the new internal
  `MonoSetTimeout()` function to pass down the timeout.

* `MonoWebRequestHandler.SendAsync()`: this is only used here to pass the timeout to the `HttpWebRequest`.

* Address feedback.

* Update HttpMessageInvoker.cs

* Make it build.

* Really make it build (forgot monotouch_watch).

(cherry picked from commit a44db72a1cf9a9d7d70270cefded64deb0c4b827)
