### PR TITLE
Install `bc` as a Linux prerequisite

### DIFF
--- a/scripts/ci/pipeline-netcore-runtime.yml
+++ b/scripts/ci/pipeline-netcore-runtime.yml
@@ -37,7 +37,7 @@ jobs:
 
   - bash: |  
       sudo apt update
-      sudo apt -y install nuget libgdiplus build-essential libtool libtool-bin cmake gettext
+      sudo apt -y install nuget libgdiplus build-essential libtool libtool-bin cmake gettext bc
     displayName: 'Prepare Linux dependencies'
     condition: eq(variables['poolname'], 'Hosted Ubuntu 1604')
   


### PR DESCRIPTION
Our run-step logic uses `bc` to calculate step times, so `bc` is
needed to avoid ugly things on the console like:
```
../scripts/ci/./run-step.sh: line 59: echo: write error: Broken pipe
```