### PR TITLE
[eglib] Don't escape chars in argv parsing enclosed in single quotes

### DIFF
--- a/mono/eglib/gshell.c
+++ b/mono/eglib/gshell.c
@@ -62,7 +62,7 @@ split_cmdline (const gchar *cmdline, GPtrArray *array, GError **gerror)
 					g_ptr_array_add (array, g_string_free (str, FALSE));
 					str = g_string_new ("");
 				}
-			} else if (c == '\\'){
+			} else if (c == '\\' && quote_char == '\"'){
 				escaped = TRUE;
 			} else 
 				g_string_append_c (str, c);


### PR DESCRIPTION
Fixes #14724 

This may need to be reverted if customers are relying on the existing behavior, but we can cross that bridge when we come to it.

The larger issue of incompatibility with .NET Core should probably be a separate issue that I'll open once I hear back from the Core folks, but I think I can mark the original issue closed once the single quote bug specifically is resolved.