### PR TITLE
Fix compiler warnings.

### DIFF
--- a/mono/metadata/custom-attrs.c
+++ b/mono/metadata/custom-attrs.c
@@ -265,17 +265,6 @@ MONO_RESTORE_WARNING
 	return res;
 }
 
-static MonoReflectionType*
-load_cattr_type_object (MonoImage *image, MonoType *t, gboolean header, const char *p, const char *boundp, const char **end, MonoError *error, guint32 *slen)
-{
-	MonoType *type;
-
-	type = load_cattr_type (image, t, header, p, boundp, end, error, slen);
-	if (!type)
-		return NULL;
-	return mono_type_get_object_checked (mono_domain_get (), type, error);
-}
-
 /*
  * If OUT_OBJ is non-NULL, created objects are stored into it and NULL is returned.
  * If OUT_OBJ is NULL, assert if objects were to be created.

--- a/mono/metadata/exception.c
+++ b/mono/metadata/exception.c
@@ -743,12 +743,6 @@ mono_get_exception_argument_out_of_range (const char *arg)
 	return mono_get_exception_argument_internal ("ArgumentOutOfRangeException", arg, NULL);
 }
 
-static MonoExceptionHandle
-mono_new_exception_argument_out_of_range (const char *arg, MonoError *error)
-{
-	return mono_exception_new_argument_internal ("ArgumentOutOfRangeException", arg, NULL, error);
-}
-
 /**
  * mono_get_exception_thread_state:
  * \param msg the message to present to the user

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1348,7 +1348,6 @@ do_mono_image_load (MonoImage *image, MonoImageOpenStatus *status,
 {
 	ERROR_DECL (error);
 	MonoCLIImageInfo *iinfo;
-	MonoDotNetHeader *header;
 	GSList *l;
 
 	MONO_PROFILER_RAISE (image_loading, (image));
@@ -1356,7 +1355,6 @@ do_mono_image_load (MonoImage *image, MonoImageOpenStatus *status,
 	mono_image_init (image);
 
 	iinfo = image->image_info;
-	header = &iinfo->cli_header;
 
 	if (!image->metadata_only) {
 		for (l = image_loaders; l; l = l->next) {

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -2511,7 +2511,7 @@ mono_marshal_get_runtime_invoke_full (MonoMethod *method, gboolean virtual_, gbo
 {
 	MonoMethodSignature *sig, *csig, *callsig;
 	MonoMethodBuilder *mb;
-	GHashTable *method_cache = NULL, *sig_cache;
+	GHashTable *method_cache = NULL, *sig_cache = NULL;
 	GHashTable **cache_table = NULL;
 	MonoClass *target_klass;
 	MonoMethod *res = NULL;

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -2335,7 +2335,7 @@ mono_class_proxy_vtable (MonoDomain *domain, MonoRemoteClass *remote_class, Mono
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
-	MonoVTable *vt, *pvt;
+	MonoVTable *vt, *pvt = NULL;
 	int i, j, vtsize, extra_interface_vtsize = 0;
 	guint32 max_interface_id;
 	MonoClass *k;

--- a/mono/metadata/reflection-cache.h
+++ b/mono/metadata/reflection-cache.h
@@ -39,7 +39,7 @@ alloc_reflected_entry (MonoDomain *domain)
 		return (ReflectedEntry *)mono_mempool_alloc (domain->mp, sizeof (ReflectedEntry));
 }
 
-static void
+static inline void
 free_reflected_entry (ReflectedEntry *entry)
 {
 	if (!mono_gc_is_moving ())

--- a/mono/metadata/sgen-dynarray.h
+++ b/mono/metadata/sgen-dynarray.h
@@ -131,19 +131,19 @@ dyn_array_copy (DynArray *dst, DynArray *src, int elem_size)
 }
 
 /* int */
-static void
+static inline void
 dyn_array_int_init (DynIntArray *da)
 {
 	dyn_array_init (&da->array);
 }
 
-static void
+static inline void
 dyn_array_int_uninit (DynIntArray *da)
 {
 	dyn_array_uninit (&da->array, sizeof (int));
 }
 
-static int
+static inline int
 dyn_array_int_size (DynIntArray *da)
 {
 	return da->array.size;
@@ -157,14 +157,14 @@ dyn_array_int_empty (DynIntArray *da)
 }
 #endif
 
-static void
+static inline void
 dyn_array_int_add (DynIntArray *da, int x)
 {
 	int *p = (int *)dyn_array_add (&da->array, sizeof (int));
 	*p = x;
 }
 
-static int
+static inline int
 dyn_array_int_get (DynIntArray *da, int x)
 {
 	return ((int*)da->array.data)[x];
@@ -178,13 +178,13 @@ dyn_array_int_set (DynIntArray *da, int idx, int val)
 }
 #endif
 
-static void
+static inline void
 dyn_array_int_ensure_independent (DynIntArray *da)
 {
 	dyn_array_ensure_independent (&da->array, sizeof (int));
 }
 
-static void
+static inline void
 dyn_array_int_copy (DynIntArray *dst, DynIntArray *src)
 {
 	dyn_array_copy (&dst->array, &src->array, sizeof (int));
@@ -198,7 +198,7 @@ dyn_array_int_is_copy (DynIntArray *da)
 
 /* ptr */
 
-static void
+static inline void
 dyn_array_ptr_init (DynPtrArray *da)
 {
 	dyn_array_init (&da->array);
@@ -244,7 +244,7 @@ dyn_array_ptr_get (DynPtrArray *da, int x)
 	return ((void**)da->array.data)[x];
 }
 
-static void
+static inline void
 dyn_array_ptr_set (DynPtrArray *da, int x, void *ptr)
 {
 #ifdef OPTIMIZATION_SINGLETON_DYN_ARRAY

--- a/mono/metadata/sgen-dynarray.h
+++ b/mono/metadata/sgen-dynarray.h
@@ -327,7 +327,7 @@ dyn_array_ptr_ensure_capacity (DynPtrArray *da, int capacity)
 	}
 }
 
-static void
+static inline void
 dyn_array_ptr_set_all (DynPtrArray *dst, DynPtrArray *src)
 {
 	const int copysize = src->array.size;

--- a/mono/metadata/sgen-mono.c
+++ b/mono/metadata/sgen-mono.c
@@ -256,6 +256,8 @@ emit_managed_allocater_noilgen (MonoMethodBuilder *mb, gboolean slowpath, gboole
 {
 }
 
+#if !ENABLE_ILGEN
+
 static void
 install_noilgen (void)
 {
@@ -265,6 +267,8 @@ install_noilgen (void)
 	cb.emit_managed_allocater = emit_managed_allocater_noilgen;
 	mono_install_sgen_mono_callbacks (&cb);
 }
+
+#endif
 
 static MonoSgenMonoCallbacks *
 get_sgen_mono_cb (void)

--- a/mono/metadata/sre-save.c
+++ b/mono/metadata/sre-save.c
@@ -106,6 +106,7 @@ find_index_in_table (MonoDynamicImage *assembly, int table_idx, int col, guint32
 	return 0;
 }
 
+#if G_BYTE_ORDER != G_LITTLE_ENDIAN
 /*
  * Copy len * nelem bytes from val to dest, swapping bytes to LE if necessary.
  * dest may be misaligned.
@@ -151,6 +152,7 @@ swap_with_size (char *dest, const char* val, int len, int nelem) {
 	memcpy (dest, val, len * nelem);
 #endif
 }
+#endif
 
 static guint32
 add_mono_string_to_blob_cached (MonoDynamicImage *assembly, MonoString *str)

--- a/mono/metadata/sre.c
+++ b/mono/metadata/sre.c
@@ -77,7 +77,6 @@ static gboolean is_sre_field_builder (MonoClass *klass);
 static gboolean is_sre_gparam_builder (MonoClass *klass);
 static gboolean is_sre_enum_builder (MonoClass *klass);
 static gboolean is_sr_mono_method (MonoClass *klass);
-static gboolean is_sr_mono_field (MonoClass *klass);
 
 static guint32 mono_image_get_methodspec_token (MonoDynamicImage *assembly, MonoMethod *method);
 static guint32 mono_image_get_inflated_method_token (MonoDynamicImage *assembly, MonoMethod *m);
@@ -2061,13 +2060,6 @@ mono_is_sre_ctor_on_tb_inst (MonoClass *klass)
 }
 
 #endif /* !DISABLE_REFLECTION_EMIT */
-
-
-static gboolean
-is_sr_mono_field (MonoClass *klass)
-{
-	check_corlib_type_cached (klass, "System.Reflection", "RuntimeFieldInfo");
-}
 
 gboolean
 mono_is_sr_mono_property (MonoClass *klass)

--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -513,7 +513,7 @@ mono_threadpool_end_invoke (MonoAsyncResult *ares, MonoArray **out_args, MonoObj
 gboolean
 mono_threadpool_remove_domain_jobs (MonoDomain *domain, int timeout)
 {
-	gint64 end;
+	gint64 end = 0;
 	ThreadPoolDomain *tpdomain;
 	gboolean ret;
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -6373,6 +6373,7 @@ summarizer_supervisor_end (SummarizerSupervisorState *state)
 static gboolean
 summarizer_state_init (SummarizerGlobalState *state, MonoNativeThreadId current, int *my_index)
 {
+	*my_index = 0;
 	gint32 started_state = mono_atomic_cas_i32 (&state->has_owner, 1 /* set */, 0 /* compare */);
 	gboolean not_started = started_state == 0;
 	if (not_started) {
@@ -6546,7 +6547,7 @@ mono_threads_summarize_execute_internal (MonoContext *ctx, gchar **out, MonoStac
 {
 	static SummarizerGlobalState state;
 
-	int current_idx;
+	int current_idx = 0;
 	MonoNativeThreadId current = mono_native_thread_id_get ();
 	gboolean thread_given_control = summarizer_state_init (&state, current, &current_idx);
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -6373,7 +6373,6 @@ summarizer_supervisor_end (SummarizerSupervisorState *state)
 static gboolean
 summarizer_state_init (SummarizerGlobalState *state, MonoNativeThreadId current, int *my_index)
 {
-	*my_index = 0;
 	gint32 started_state = mono_atomic_cas_i32 (&state->has_owner, 1 /* set */, 0 /* compare */);
 	gboolean not_started = started_state == 0;
 	if (not_started) {
@@ -6547,7 +6546,7 @@ mono_threads_summarize_execute_internal (MonoContext *ctx, gchar **out, MonoStac
 {
 	static SummarizerGlobalState state;
 
-	int current_idx = 0;
+	int current_idx;
 	MonoNativeThreadId current = mono_native_thread_id_get ();
 	gboolean thread_given_control = summarizer_state_init (&state, current, &current_idx);
 

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -4972,9 +4972,7 @@ mono_w32file_copy (const gunichar2 *path, const gunichar2 *dest, gboolean overwr
 gboolean
 mono_w32file_replace (const gunichar2 *destination_file_name, const gunichar2 *source_file_name, const gunichar2 *destination_backup_file_name, guint32 flags, gint32 *error)
 {
-	gboolean result;
-
-	result = ReplaceFile (destination_file_name, source_file_name, destination_backup_file_name, flags, NULL, NULL);
+	const gboolean result = ReplaceFile (destination_file_name, source_file_name, destination_backup_file_name, flags, NULL, NULL);
 	if (!result)
 		*error = mono_w32error_get_last ();
 	return result;
@@ -4983,13 +4981,11 @@ mono_w32file_replace (const gunichar2 *destination_file_name, const gunichar2 *s
 gint64
 mono_w32file_get_file_size (gpointer handle, gint32 *error)
 {
-	gint64 length;
-	guint32 length_hi;
+	guint32 length_hi = 0;
 
-	length = GetFileSize (handle, &length_hi);
-	if(length==INVALID_FILE_SIZE) {
-		*error=mono_w32error_get_last ();
-	}
+	const gint64 length = GetFileSize (handle, &length_hi);
+	if (length == INVALID_FILE_SIZE)
+		*error = mono_w32error_get_last ();
 
 	return length | ((gint64)length_hi << 32);
 }

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -4972,7 +4972,9 @@ mono_w32file_copy (const gunichar2 *path, const gunichar2 *dest, gboolean overwr
 gboolean
 mono_w32file_replace (const gunichar2 *destination_file_name, const gunichar2 *source_file_name, const gunichar2 *destination_backup_file_name, guint32 flags, gint32 *error)
 {
-	const gboolean result = ReplaceFile (destination_file_name, source_file_name, destination_backup_file_name, flags, NULL, NULL);
+	gboolean result;
+
+	result = ReplaceFile (destination_file_name, source_file_name, destination_backup_file_name, flags, NULL, NULL);
 	if (!result)
 		*error = mono_w32error_get_last ();
 	return result;
@@ -4981,11 +4983,13 @@ mono_w32file_replace (const gunichar2 *destination_file_name, const gunichar2 *s
 gint64
 mono_w32file_get_file_size (gpointer handle, gint32 *error)
 {
+	gint64 length;
 	guint32 length_hi = 0;
 
-	const gint64 length = GetFileSize (handle, &length_hi);
-	if (length == INVALID_FILE_SIZE)
-		*error = mono_w32error_get_last ();
+	length = GetFileSize (handle, &length_hi);
+	if(length==INVALID_FILE_SIZE) {
+		*error=mono_w32error_get_last ();
+	}
 
 	return length | ((gint64)length_hi << 32);
 }

--- a/mono/metadata/w32handle.c
+++ b/mono/metadata/w32handle.c
@@ -828,7 +828,7 @@ mono_w32handle_wait_one (gpointer handle, guint32 timeout, gboolean alertable)
 	MonoW32Handle *handle_data;
 	MonoW32HandleWaitRet ret;
 	gboolean alerted;
-	gint64 start;
+	gint64 start = 0;
 	gboolean abandoned = FALSE;
 
 	alerted = FALSE;
@@ -991,7 +991,7 @@ mono_w32handle_wait_multiple (gpointer *handles, gsize nhandles, gboolean waital
 	MonoW32HandleWaitRet ret;
 	gboolean alerted, poll;
 	gint i;
-	gint64 start;
+	gint64 start = 0;
 	MonoW32Handle *handles_data [MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS];
 	gboolean abandoned [MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS] = {0};
 
@@ -1193,7 +1193,7 @@ mono_w32handle_signal_and_wait (gpointer signal_handle, gpointer wait_handle, gu
 {
 	MonoW32Handle *signal_handle_data, *wait_handle_data, *handles_data [2];
 	MonoW32HandleWaitRet ret;
-	gint64 start;
+	gint64 start = 0;
 	gboolean alerted;
 	gboolean abandoned = FALSE;
 

--- a/mono/mini/debugger-engine.c
+++ b/mono/mini/debugger-engine.c
@@ -351,13 +351,12 @@ mono_de_add_pending_breakpoints (MonoMethod *method, MonoJitInfo *ji)
 static void
 set_bp_in_method (MonoDomain *domain, MonoMethod *method, MonoSeqPointInfo *seq_points, MonoBreakpoint *bp, MonoError *error)
 {
-	gpointer code;
 	MonoJitInfo *ji;
 
 	if (error)
 		error_init (error);
 
-	code = mono_jit_search_all_backends_for_jit_info (domain, method, &ji);
+	(void)mono_jit_search_all_backends_for_jit_info (domain, method, &ji);
 	g_assert (ji);
 
 	insert_breakpoint (seq_points, domain, ji, bp, error);

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -1769,7 +1769,7 @@ interp_entry (InterpEntryData *data)
 	MonoMethod *method;
 	MonoMethodSignature *sig;
 	MonoType *type;
-	gpointer orig_domain, attach_cookie;
+	gpointer orig_domain = NULL, attach_cookie;
 	int i;
 
 	if ((gsize)data->rmethod & 1) {

--- a/mono/mini/interp/mintops.c
+++ b/mono/mini/interp/mintops.c
@@ -84,7 +84,7 @@ mono_interp_dis_mintop(const guint16 *base, const guint16 *ip)
 		g_string_append_printf (str, " %d", (gint32)READ32 (ip + 1));
 		break;
 	case MintOpLongInt:
-		g_string_append_printf (str, " %lld", (gint64)READ64 (ip + 1));
+		g_string_append_printf (str, " %lld", (long long)READ64 (ip + 1));
 		break;
 	case MintOpFloat: {
 		gint32 tmp = READ32 (ip + 1);

--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -1462,7 +1462,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 		 * we avoid folding constants that when computed would raise an error, in
 		 * case the user code was expecting to get that error raised
 		 */
-		if (fsig->param_count == 1 && args [0]->opcode == OP_R8CONST) {
+		if (fsig->param_count == 1 && args [0]->opcode == OP_R8CONST){
 			double source = *(double *)args [0]->inst_p0;
 			int opcode = 0;
 			const char *mname = cmethod->name;
@@ -1471,50 +1471,50 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 			if (c == 'A'){
 				if (strcmp (mname, "Abs") == 0 && fsig->params [0]->type == MONO_TYPE_R8) {
 					opcode = OP_ABS;
-				} else if (strcmp (mname, "Asin") == 0) {
+				} else if (strcmp (mname, "Asin") == 0){
 					if (fabs (source) <= 1)
 						opcode = OP_ASIN;
-				} else if (strcmp (mname, "Asinh") == 0) {
+				} else if (strcmp (mname, "Asinh") == 0){
 					opcode = OP_ASINH;
-				} else if (strcmp (mname, "Acos") == 0) {
+				} else if (strcmp (mname, "Acos") == 0){
 					if (fabs (source) <= 1)
 						opcode = OP_ACOS;
-				} else if (strcmp (mname, "Acosh") == 0) {
+				} else if (strcmp (mname, "Acosh") == 0){
 					if (source >= 1)
 						opcode = OP_ACOSH;
-				} else if (strcmp (mname, "Atan") == 0) {
+				} else if (strcmp (mname, "Atan") == 0){
 					opcode = OP_ATAN;
-				} else if (strcmp (mname, "Atanh") == 0) {
+				} else if (strcmp (mname, "Atanh") == 0){
 					if (fabs (source) < 1)
 						opcode = OP_ATANH;
 				} 
-			} else if (c == 'C') {
+			} else if (c == 'C'){
 				if (strcmp (mname, "Cos") == 0) {
 					if (!isinf (source))
 						opcode = OP_COS;
-				} else if (strcmp (mname, "Cbrt") == 0) {
+				} else if (strcmp (mname, "Cbrt") == 0){
 					opcode = OP_CBRT;
-				} else if (strcmp (mname, "Cosh") == 0) {
+				} else if (strcmp (mname, "Cosh") == 0){
 					opcode = OP_COSH;
 				}
-			} else if (c == 'R') {
+			} else if (c == 'R'){
 				if (strcmp (mname, "Round") == 0)
 					opcode = OP_ROUND;
-			} else if (c == 'S') {
+			} else if (c == 'S'){
 				if (strcmp (mname, "Sin") == 0) {
 					if (!isinf (source))
 						opcode = OP_SIN;
 				} else if (strcmp (mname, "Sqrt") == 0) {
 					if (source >= 0)
 						opcode = OP_SQRT;
-				} else if (strcmp (mname, "Sinh") == 0) {
+				} else if (strcmp (mname, "Sinh") == 0){
 					opcode = OP_SINH;
 				}
-			} else if (c == 'T') {
+			} else if (c == 'T'){
 				if (strcmp (mname, "Tan") == 0){
 					if (!isinf (source))
 						opcode = OP_TAN;
-				} else if (strcmp (mname, "Tanh") == 0) {
+				} else if (strcmp (mname, "Tanh") == 0){
 					opcode = OP_TANH;
 				}
 			}
@@ -1527,7 +1527,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 				ins->dreg = mono_alloc_dreg (cfg, (MonoStackType) ins->type);
 				ins->inst_p0 = dest;
 				
-				switch (opcode) {
+				switch (opcode){
 				case OP_ABS:
 					result = fabs (source);
 					break;

--- a/mono/mini/intrinsics.c
+++ b/mono/mini/intrinsics.c
@@ -1462,7 +1462,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 		 * we avoid folding constants that when computed would raise an error, in
 		 * case the user code was expecting to get that error raised
 		 */
-		if (fsig->param_count == 1 && args [0]->opcode == OP_R8CONST){
+		if (fsig->param_count == 1 && args [0]->opcode == OP_R8CONST) {
 			double source = *(double *)args [0]->inst_p0;
 			int opcode = 0;
 			const char *mname = cmethod->name;
@@ -1471,63 +1471,63 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 			if (c == 'A'){
 				if (strcmp (mname, "Abs") == 0 && fsig->params [0]->type == MONO_TYPE_R8) {
 					opcode = OP_ABS;
-				} else if (strcmp (mname, "Asin") == 0){
+				} else if (strcmp (mname, "Asin") == 0) {
 					if (fabs (source) <= 1)
 						opcode = OP_ASIN;
-				} else if (strcmp (mname, "Asinh") == 0){
+				} else if (strcmp (mname, "Asinh") == 0) {
 					opcode = OP_ASINH;
-				} else if (strcmp (mname, "Acos") == 0){
+				} else if (strcmp (mname, "Acos") == 0) {
 					if (fabs (source) <= 1)
 						opcode = OP_ACOS;
-				} else if (strcmp (mname, "Acosh") == 0){
+				} else if (strcmp (mname, "Acosh") == 0) {
 					if (source >= 1)
 						opcode = OP_ACOSH;
-				} else if (strcmp (mname, "Atan") == 0){
+				} else if (strcmp (mname, "Atan") == 0) {
 					opcode = OP_ATAN;
-				} else if (strcmp (mname, "Atanh") == 0){
+				} else if (strcmp (mname, "Atanh") == 0) {
 					if (fabs (source) < 1)
 						opcode = OP_ATANH;
 				} 
-			} else if (c == 'C'){
+			} else if (c == 'C') {
 				if (strcmp (mname, "Cos") == 0) {
 					if (!isinf (source))
 						opcode = OP_COS;
-				} else if (strcmp (mname, "Cbrt") == 0){
+				} else if (strcmp (mname, "Cbrt") == 0) {
 					opcode = OP_CBRT;
-				} else if (strcmp (mname, "Cosh") == 0){
+				} else if (strcmp (mname, "Cosh") == 0) {
 					opcode = OP_COSH;
 				}
-			} else if (c == 'R'){
+			} else if (c == 'R') {
 				if (strcmp (mname, "Round") == 0)
 					opcode = OP_ROUND;
-			} else if (c == 'S'){
+			} else if (c == 'S') {
 				if (strcmp (mname, "Sin") == 0) {
 					if (!isinf (source))
 						opcode = OP_SIN;
 				} else if (strcmp (mname, "Sqrt") == 0) {
 					if (source >= 0)
 						opcode = OP_SQRT;
-				} else if (strcmp (mname, "Sinh") == 0){
+				} else if (strcmp (mname, "Sinh") == 0) {
 					opcode = OP_SINH;
 				}
-			} else if (c == 'T'){
+			} else if (c == 'T') {
 				if (strcmp (mname, "Tan") == 0){
 					if (!isinf (source))
 						opcode = OP_TAN;
-				} else if (strcmp (mname, "Tanh") == 0){
+				} else if (strcmp (mname, "Tanh") == 0) {
 					opcode = OP_TANH;
 				}
 			}
 
 			if (opcode) {
 				double *dest = (double *) mono_domain_alloc (cfg->domain, sizeof (double));
-				double result;
+				double result = 0;
 				MONO_INST_NEW (cfg, ins, OP_R8CONST);
 				ins->type = STACK_R8;
 				ins->dreg = mono_alloc_dreg (cfg, (MonoStackType) ins->type);
 				ins->inst_p0 = dest;
 				
-				switch (opcode){
+				switch (opcode) {
 				case OP_ABS:
 					result = fabs (source);
 					break;
@@ -1576,6 +1576,8 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 				case OP_TANH:
 					result = tanh (source);
 					break;
+				default:
+					g_error ("invalid opcode %d", (int)opcode);
 				}
 				*dest = result;
 				MONO_ADD_INS (cfg->cbb, ins);

--- a/mono/mini/mini-amd64-gsharedvt.c
+++ b/mono/mini/mini-amd64-gsharedvt.c
@@ -268,7 +268,7 @@ mono_arch_get_gsharedvt_call_info (gpointer addr, MonoMethodSignature *normal_si
 	int aindex, i;
 	gboolean var_ret = FALSE;
 	CallInfo *cinfo, *gcinfo;
-	MonoMethodSignature *sig, *gsig;
+	MonoMethodSignature *sig;
 	GPtrArray *map;
 
 	if (gsharedvt_in) {
@@ -289,15 +289,13 @@ mono_arch_get_gsharedvt_call_info (gpointer addr, MonoMethodSignature *normal_si
 	 * If GSHAREDVT_IN is false, its the other way around.
 	 */
 
-	/* sig/cinfo describes the normal call, while gsig/gcinfo describes the gsharedvt call */
+	/* sig/cinfo describes the normal call, while gcinfo describes the gsharedvt call */
 	if (gsharedvt_in) {
 		sig = caller_sig;
-		gsig = callee_sig;
 		cinfo = caller_cinfo;
 		gcinfo = callee_cinfo;
 	} else {
 		sig = callee_sig;
-		gsig = caller_sig;
 		cinfo = callee_cinfo;
 		gcinfo = caller_cinfo;
 	}

--- a/mono/mini/tramp-arm64-gsharedvt.c
+++ b/mono/mini/tramp-arm64-gsharedvt.c
@@ -214,7 +214,7 @@ mono_arch_get_gsharedvt_trampoline (MonoTrampInfo **info, gboolean aot)
 	MonoJumpInfo *ji = NULL;
 	guint8 *br_out, *br [64], *br_ret [64], *bcc_ret [64];
 	int i, n_arg_regs, n_arg_fregs, offset, arg_reg, info_offset, rgctx_arg_reg_offset;
-	int caller_reg_area_offset, callee_reg_area_offset, callee_stack_area_offset;
+	int caller_reg_area_offset, callee_reg_area_offset;
 	int br_ret_index, bcc_ret_index;
 
 	buf_len = 2048;
@@ -277,7 +277,6 @@ mono_arch_get_gsharedvt_trampoline (MonoTrampInfo **info, gboolean aot)
 	/* Allocate callee register area just below the callee area so it can be accessed from start_gsharedvt_call using negative offsets */
 	/* The + 8 is for alignment */
 	callee_reg_area_offset = 8;
-	callee_stack_area_offset = callee_reg_area_offset + (n_arg_regs * sizeof (target_mgreg_t));
 	arm_subx_imm (code, ARMREG_SP, ARMREG_SP, ((n_arg_regs + n_arg_fregs) * sizeof (target_mgreg_t)) + 8);
 
 	/*

--- a/mono/utils/mono-mmap.c
+++ b/mono/utils/mono-mmap.c
@@ -399,7 +399,7 @@ mono_file_map_error (size_t length, int flags, int fd, guint64 offset, void **re
 	if (ptr == MAP_FAILED) {
 		if (error_message) {
 			*error_message = g_strdup_printf ("%s failed file:%s length:0x%zX offset:0x%lluX error:%s(0x%X)\n",
-				__func__, filepath ? filepath : "", length, offset, g_strerror (errno), errno);
+				__func__, filepath ? filepath : "", length, (unsigned long long)offset, g_strerror (errno), errno);
 		}
 		return NULL;
 	}

--- a/mono/utils/os-event-unix.c
+++ b/mono/utils/os-event-unix.c
@@ -102,7 +102,9 @@ typedef struct {
 static void
 signal_and_unref (gpointer user_data)
 {
-	OSEventWaitData *data = (OSEventWaitData*) user_data;
+	OSEventWaitData *data;
+
+	data = (OSEventWaitData*) user_data;
 
 	mono_os_event_set (&data->event);
 	if (mono_atomic_dec_i32 ((gint32*) &data->ref) == 0) {

--- a/mono/utils/os-event-unix.c
+++ b/mono/utils/os-event-unix.c
@@ -102,9 +102,7 @@ typedef struct {
 static void
 signal_and_unref (gpointer user_data)
 {
-	OSEventWaitData *data;
-
-	data = (OSEventWaitData*) user_data;
+	OSEventWaitData *data = (OSEventWaitData*) user_data;
 
 	mono_os_event_set (&data->event);
 	if (mono_atomic_dec_i32 ((gint32*) &data->ref) == 0) {
@@ -118,7 +116,7 @@ mono_os_event_wait_multiple (MonoOSEvent **events, gsize nevents, gboolean waita
 {
 	MonoOSEventWaitRet ret;
 	mono_cond_t signal_cond;
-	OSEventWaitData *data;
+	OSEventWaitData *data = NULL;
 	gboolean alerted;
 	gint64 start;
 	gint i;

--- a/mono/utils/os-event-unix.c
+++ b/mono/utils/os-event-unix.c
@@ -118,7 +118,7 @@ mono_os_event_wait_multiple (MonoOSEvent **events, gsize nevents, gboolean waita
 	mono_cond_t signal_cond;
 	OSEventWaitData *data = NULL;
 	gboolean alerted;
-	gint64 start;
+	gint64 start = 0;
 	gint i;
 
 	g_assert (mono_lazy_is_initialized (&status));


### PR DESCRIPTION
    intrinsics.c: In function 'mini_emit_inst_for_method':
    intrinsics.c:1580:11: warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
         *dest = result;
         ~~~~~~^~~~~~~~


    debugger-engine.c: In function 'set_bp_in_method':
    debugger-engine.c:354:11: warning: variable 'code' set but not used [-Wunused-but-set-variable]
      gpointer code;
               ^~~~


    tramp-arm64-gsharedvt.c: In function 'mono_arch_get_gsharedvt_trampoline':
    tramp-arm64-gsharedvt.c:217:54: warning: variable 'callee_stack_area_offset' set but not used [-Wunused-but-set-variable]
      int caller_reg_area_offset, callee_reg_area_offset, callee_stack_area_offset;
                                                          ^~~~~~~~~~~~~~~~~~~~~~~~


    mini-arm64-gsharedvt.c: In function 'mono_arch_get_gsharedvt_call_info':
    mini-arm64-gsharedvt.c:142:29: warning: variable 'gsig' set but not used [-Wunused-but-set-variable]
      MonoMethodSignature *sig, *gsig;
                                 ^~~~


    interp/mintops.c: In function 'mono_interp_dis_mintop':
    interp/mintops.c:87:37: warning: format '%lld' expects argument of type 'long long int', but argument 3 has type 'long int' [-Wformat=]
       g_string_append_printf (str, " %lld", (gint64)READ64 (ip + 1));


    In file included from object.c:40:0:
    object.c: In function 'mono_class_proxy_vtable':
    ../../mono/metadata/profiler-private.h:191:4: warning: 'pvt' may be used uninitialized in this function [-Wmaybe-uninitialized]
        mono_profiler_raise_ ## name args; \
        ^~~~~~~~~~~~~~~~~~~~
    object.c:2338:19: note: 'pvt' was declared here
      MonoVTable *vt, *pvt;
                       ^~~


    w32file-unix.c: In function 'mono_w32file_get_file_size':
    w32file-unix.c:4994:19: warning: 'length_hi' may be used uninitialized in this function [-Wmaybe-uninitialized]
      return length | ((gint64)length_hi << 32);
                       ^~~~~~~~~~~~~~~~~


    interp/interp.c: In function 'interp_entry.constprop':
    interp/interp.c:1847:3: warning: 'orig_domain' may be used uninitialized in this function [-Wmaybe-uninitialized]
       mono_threads_detach_coop (orig_domain, &attach_cookie);
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


    image.c:1351:20: warning: variable 'header' set but not used [-Wunused-but-set-variable]
      MonoDotNetHeader *header;
                        ^~~~~~


    exception.c:747:1: warning: 'mono_new_exception_argument_out_of_range' defined but not used [-Wunused-function]
     mono_new_exception_argument_out_of_range (const char *arg, MonoError *error)
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


    os-event-unix.c: In function 'mono_os_event_wait_multiple':
    os-event-unix.c:195:12: warning: 'start' may be used uninitialized in this function [-Wmaybe-uninitialized]
        elapsed = mono_msec_ticks () - start;
        ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~


    In file included from ../../mono/eglib/glib.h:45:0,
                     from os-event.h:9,
                     from os-event-unix.c:11:
    ../../mono/eglib/eglib-remap.h:146:25: warning: 'data' may be used uninitialized in this function [-Wmaybe-uninitialized]
     #define g_ptr_array_add monoeg_g_ptr_array_add
                             ^~~~~~~~~~~~~~~~~~~~~~
    os-event-unix.c:121:19: note: 'data' was declared here
      OSEventWaitData *data;
                       ^~~~

    marshal.c: In function 'mono_marshal_get_runtime_invoke_full':
    marshal.c:2662:8: warning: 'sig_cache' may be used uninitialized in this function [-Wmaybe-uninitialized]
        res = (MonoMethod *)g_hash_table_lookup (sig_cache, sig_key);
        ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


    sgen-mono.c:260:1: warning: 'install_noilgen' defined but not used [-Wunused-function]
     install_noilgen (void)


    In file included from sgen-new-bridge.c:31:0:
    sgen-dynarray.h:331:1: warning: 'dyn_array_ptr_set_all' defined but not used [-Wunused-function]
     dyn_array_ptr_set_all (DynPtrArray *dst, DynPtrArray *src)
     ^~~~~~~~~~~~~~~~~~~~~


    sgen-dynarray.h:248:1: warning: 'dyn_array_ptr_set' defined but not used [-Wunused-function]
     dyn_array_ptr_set (DynPtrArray *da, int x, void *ptr)
     ^~~~~~~~~~~~~~~~~
    
    sgen-dynarray.h:202:1: warning: 'dyn_array_ptr_init' defined but not used [-Wunused-function]
     dyn_array_ptr_init (DynPtrArray *da)
     ^~~~~~~~~~~~~~~~~~
    
    sgen-dynarray.h:194:1: warning: 'dyn_array_int_is_copy' defined but not used [-Wunused-function]
     dyn_array_int_is_copy (DynIntArray *da)
     ^~~~~~~~~~~~~~~~~~~~~
    
    sgen-dynarray.h:188:1: warning: 'dyn_array_int_copy' defined but not used [-Wunused-function]
     dyn_array_int_copy (DynIntArray *dst, DynIntArray *src)
     ^~~~~~~~~~~~~~~~~~
    
    sgen-dynarray.h:182:1: warning: 'dyn_array_int_ensure_independent' defined but not used [-Wunused-function]
     dyn_array_int_ensure_independent (DynIntArray *da)
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    sgen-dynarray.h:168:1: warning: 'dyn_array_int_get' defined but not used [-Wunused-function]
    dyn_array_int_get (DynIntArray *da, int x)
     ^~~~~~~~~~~~~~~~~
    
    sgen-dynarray.h:161:1: warning: 'dyn_array_int_add' defined but not used [-Wunused-function]
     dyn_array_int_add (DynIntArray *da, int x)
     ^~~~~~~~~~~~~~~~~
    
    sgen-dynarray.h:147:1: warning: 'dyn_array_int_size' defined but not used [-Wunused-function]
     dyn_array_int_size (DynIntArray *da)
     ^~~~~~~~~~~~~~~~~~
    sgen-dynarray.h:141:1: warning: 'dyn_array_int_uninit' defined but not used [-Wunused-function]
     dyn_array_int_uninit (DynIntArray *da)
     ^~~~~~~~~~~~~~~~~~~~
    sgen-dynarray.h:135:1: warning: 'dyn_array_int_init' defined but not used [-Wunused-function]
     dyn_array_int_init (DynIntArray *da)
     ^~~~~~~~~~~~~~~~~~

    In file included from sre.c:30:0:
    ../../mono/metadata/reflection-cache.h:43:1: warning: 'free_reflected_entry' defined but not used [-Wunused-function]
     free_reflected_entry (ReflectedEntry *entry)
     ^~~~~~~~~~~~~~~~~~~~

    sre.c:2067:1: warning: 'is_sr_mono_field' defined but not used [-Wunused-function]
     is_sr_mono_field (MonoClass *klass)
     ^~~~~~~~~~~~~~~~

    w32handle.c: In function 'mono_w32handle_wait_multiple':
    w32handle.c:1146:13: warning: 'start' may be used uninitialized in this function [-Wmaybe-uninitialized]
         elapsed = mono_msec_ticks () - start;
         ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~

    custom-attrs.c:269:1: warning: 'load_cattr_type_object' defined but not used [-Wunused-function]
     load_cattr_type_object (MonoImage *image, MonoType *t, gboolean header, const char *p, const char *boundp, const char **end, MonoError *error, guint32 *slen)
     ^~~~~~~~~~~~~~~~~~~~~~

    sre-save.c:114:1: warning: 'swap_with_size' defined but not used [-Wunused-function]
     swap_with_size (char *dest, const char* val, int len, int nelem) {


    mono-mmap.c: In function 'mono_file_map_error':
    mono-mmap.c:401:82: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 5 has type 'guint64 {aka long unsigned int}' [-Wformat=]
        *error_message = g_strdup_printf ("%s failed file:%s length:0x%zX offset:0x%lluX error:%s(0x%X)\n",

