### PR TITLE
[2019-06] Propagate error in mono_unicode_to_external

### DIFF
--- a/mono/metadata/mono-security.c
+++ b/mono/metadata/mono-security.c
@@ -19,6 +19,7 @@
 #include <mono/metadata/object-internals.h>
 #include <mono/metadata/metadata-internals.h>
 #include <mono/metadata/security.h>
+#include <mono/utils/strenc-internals.h>
 #include <mono/utils/strenc.h>
 #include "reflection-internals.h"
 #include "icall-decl.h"
@@ -500,7 +501,7 @@ static gboolean
 IsProtected (const gunichar2 *path, gint32 protection)
 {
 	gboolean result = FALSE;
-	gchar *utf8_name = mono_unicode_to_external (path);
+	gchar *utf8_name = mono_unicode_to_external (path); // TODO: add check here
 	if (utf8_name) {
 		struct stat st;
 		if (stat (utf8_name, &st) == 0) {
@@ -516,7 +517,7 @@ static gboolean
 Protect (const gunichar2 *path, gint32 file_mode, gint32 add_dir_mode)
 {
 	gboolean result = FALSE;
-	gchar *utf8_name = mono_unicode_to_external (path);
+	gchar *utf8_name = mono_unicode_to_external (path); // TODO: add check here
 	if (utf8_name) {
 		struct stat st;
 		if (stat (utf8_name, &st) == 0) {

--- a/mono/metadata/mono-security.c
+++ b/mono/metadata/mono-security.c
@@ -19,7 +19,6 @@
 #include <mono/metadata/object-internals.h>
 #include <mono/metadata/metadata-internals.h>
 #include <mono/metadata/security.h>
-#include <mono/utils/strenc-internals.h>
 #include <mono/utils/strenc.h>
 #include "reflection-internals.h"
 #include "icall-decl.h"
@@ -501,7 +500,7 @@ static gboolean
 IsProtected (const gunichar2 *path, gint32 protection)
 {
 	gboolean result = FALSE;
-	gchar *utf8_name = mono_unicode_to_external (path); // TODO: add check here
+	gchar *utf8_name = mono_unicode_to_external (path);
 	if (utf8_name) {
 		struct stat st;
 		if (stat (utf8_name, &st) == 0) {
@@ -517,7 +516,7 @@ static gboolean
 Protect (const gunichar2 *path, gint32 file_mode, gint32 add_dir_mode)
 {
 	gboolean result = FALSE;
-	gchar *utf8_name = mono_unicode_to_external (path); // TODO: add check here
+	gchar *utf8_name = mono_unicode_to_external (path);
 	if (utf8_name) {
 		struct stat st;
 		if (stat (utf8_name, &st) == 0) {

--- a/mono/metadata/w32file-unix.c
+++ b/mono/metadata/w32file-unix.c
@@ -1949,7 +1949,7 @@ mono_w32file_create(const gunichar2 *name, guint32 fileaccess, guint32 sharemode
 	gchar *filename;
 	gint fd, ret;
 	struct stat statbuf;
-	ERROR_DECL (err);
+	ERROR_DECL (error);
 
 	if (attrs & FILE_ATTRIBUTE_TEMPORARY)
 		perms = 0600;
@@ -1966,11 +1966,11 @@ mono_w32file_create(const gunichar2 *name, guint32 fileaccess, guint32 sharemode
 		return(INVALID_HANDLE_VALUE);
 	}
 
-	filename = mono_unicode_to_external_checked (name, err);
+	filename = mono_unicode_to_external_checked (name, error);
 	if (filename == NULL) {
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (err));
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (error));
 
-		mono_error_cleanup (err);
+		mono_error_cleanup (error);
 		mono_w32error_set_last (ERROR_INVALID_NAME);
 		return(INVALID_HANDLE_VALUE);
 	}
@@ -2101,7 +2101,7 @@ gboolean mono_w32file_delete(const gunichar2 *name)
 	gchar *filename;
 	gint retval;
 	gboolean ret = FALSE;
-	ERROR_DECL (err);
+	ERROR_DECL (error);
 #if 0
 	struct stat statbuf;
 	FileShare *shareinfo;
@@ -2114,11 +2114,11 @@ gboolean mono_w32file_delete(const gunichar2 *name)
 		return(FALSE);
 	}
 
-	filename = mono_unicode_to_external_checked (name, err);
+	filename = mono_unicode_to_external_checked (name, error);
 	if(filename==NULL) {
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (err));
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (error));
 
-		mono_error_cleanup (err);
+		mono_error_cleanup (error);
 		mono_w32error_set_last (ERROR_INVALID_NAME);
 		return(FALSE);
 	}
@@ -2181,7 +2181,7 @@ MoveFile (const gunichar2 *name, const gunichar2 *dest_name)
 	struct stat stat_src, stat_dest;
 	gboolean ret = FALSE;
 	FileShare *shareinfo;
-	ERROR_DECL (err);
+	ERROR_DECL (error);
 	
 	if(name==NULL) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: name is NULL", __func__);
@@ -2190,11 +2190,11 @@ MoveFile (const gunichar2 *name, const gunichar2 *dest_name)
 		return(FALSE);
 	}
 
-	utf8_name = mono_unicode_to_external_checked (name, err);
+	utf8_name = mono_unicode_to_external_checked (name, error);
 	if (utf8_name == NULL) {
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (err));
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (error));
 		
-		mono_error_cleanup (err);
+		mono_error_cleanup (error);
 		mono_w32error_set_last (ERROR_INVALID_NAME);
 		return FALSE;
 	}
@@ -2207,11 +2207,11 @@ MoveFile (const gunichar2 *name, const gunichar2 *dest_name)
 		return(FALSE);
 	}
 
-	utf8_dest_name = mono_unicode_to_external_checked (dest_name, err);
+	utf8_dest_name = mono_unicode_to_external_checked (dest_name, error);
 	if (utf8_dest_name == NULL) {
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (err));
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (error));
 
-		mono_error_cleanup (err);
+		mono_error_cleanup (error);
 		g_free (utf8_name);
 		mono_w32error_set_last (ERROR_INVALID_NAME);
 		return FALSE;
@@ -2392,7 +2392,7 @@ CopyFile (const gunichar2 *name, const gunichar2 *dest_name, gboolean fail_if_ex
 	gchar *utf8_src, *utf8_dest;
 	struct stat st, dest_st;
 	gboolean ret = TRUE;
-	ERROR_DECL (err);
+	ERROR_DECL (error);
 	
 	if(name==NULL) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: name is NULL", __func__);
@@ -2401,12 +2401,12 @@ CopyFile (const gunichar2 *name, const gunichar2 *dest_name, gboolean fail_if_ex
 		return(FALSE);
 	}
 	
-	utf8_src = mono_unicode_to_external_checked (name, err);
+	utf8_src = mono_unicode_to_external_checked (name, error);
 	if (utf8_src == NULL) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion of source returned NULL; %s",
-			   __func__, mono_error_get_message (err));
+			   __func__, mono_error_get_message (error));
 
-		mono_error_cleanup (err);
+		mono_error_cleanup (error);
 		mono_w32error_set_last (ERROR_INVALID_PARAMETER);
 		return(FALSE);
 	}
@@ -2419,14 +2419,14 @@ CopyFile (const gunichar2 *name, const gunichar2 *dest_name, gboolean fail_if_ex
 		return(FALSE);
 	}
 	
-	utf8_dest = mono_unicode_to_external_checked (dest_name, err);
+	utf8_dest = mono_unicode_to_external_checked (dest_name, error);
 	if (utf8_dest == NULL) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion of dest returned NULL; %s",
-			   __func__, mono_error_get_message (err));
+			   __func__, mono_error_get_message (error));
 
 		mono_w32error_set_last (ERROR_INVALID_PARAMETER);
 
-		mono_error_cleanup (err);
+		mono_error_cleanup (error);
 		g_free (utf8_src);
 		
 		return(FALSE);
@@ -2594,7 +2594,7 @@ static gchar*
 convert_arg_to_utf8 (const gunichar2 *arg, const gchar *arg_name)
 {
 	gchar *utf8_ret;
-	ERROR_DECL (err);
+	ERROR_DECL (error);
 
 	if (arg == NULL) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: %s is NULL", __func__, arg_name);
@@ -2602,12 +2602,12 @@ convert_arg_to_utf8 (const gunichar2 *arg, const gchar *arg_name)
 		return NULL;
 	}
 
-	utf8_ret = mono_unicode_to_external_checked (arg, err);
+	utf8_ret = mono_unicode_to_external_checked (arg, error);
 	if (utf8_ret == NULL) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion of %s returned NULL; %s",
-			   __func__, arg_name, mono_error_get_message (err));
+			   __func__, arg_name, mono_error_get_message (error));
 
-		mono_error_cleanup (err);
+		mono_error_cleanup (error);
 		mono_w32error_set_last (ERROR_INVALID_PARAMETER);
 		return NULL;
 	}
@@ -3210,7 +3210,7 @@ mono_w32file_find_first (const gunichar2 *pattern, WIN32_FIND_DATA *find_data)
 	FindHandle *findhandle;
 	gchar *utf8_pattern = NULL, *dir_part, *entry_part, **namelist;
 	gint result;
-	ERROR_DECL (err);
+	ERROR_DECL (error);
 	
 	if (pattern == NULL) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: pattern is NULL", __func__);
@@ -3219,11 +3219,11 @@ mono_w32file_find_first (const gunichar2 *pattern, WIN32_FIND_DATA *find_data)
 		return(INVALID_HANDLE_VALUE);
 	}
 
-	utf8_pattern = mono_unicode_to_external_checked (pattern, err);
+	utf8_pattern = mono_unicode_to_external_checked (pattern, error);
 	if (utf8_pattern == NULL) {
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (err));
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (error));
 		
-		mono_error_cleanup (err);
+		mono_error_cleanup (error);
 		mono_w32error_set_last (ERROR_INVALID_NAME);
 		return(INVALID_HANDLE_VALUE);
 	}
@@ -3457,7 +3457,7 @@ mono_w32file_create_directory (const gunichar2 *name)
 {
 	gchar *utf8_name;
 	gint result;
-	ERROR_DECL (err);
+	ERROR_DECL (error);
 
 	if (name == NULL) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: name is NULL", __func__);
@@ -3466,11 +3466,11 @@ mono_w32file_create_directory (const gunichar2 *name)
 		return(FALSE);
 	}
 	
-	utf8_name = mono_unicode_to_external_checked (name, err);
+	utf8_name = mono_unicode_to_external_checked (name, error);
 	if (utf8_name == NULL) {
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (err));
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (error));
 	
-		mono_error_cleanup (err);
+		mono_error_cleanup (error);
 		mono_w32error_set_last (ERROR_INVALID_NAME);
 		return FALSE;
 	}
@@ -3492,7 +3492,7 @@ mono_w32file_remove_directory (const gunichar2 *name)
 {
 	gchar *utf8_name;
 	gint result;
-	ERROR_DECL (err);
+	ERROR_DECL (error);
 	
 	if (name == NULL) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: name is NULL", __func__);
@@ -3501,11 +3501,11 @@ mono_w32file_remove_directory (const gunichar2 *name)
 		return(FALSE);
 	}
 
-	utf8_name = mono_unicode_to_external_checked (name, err);
+	utf8_name = mono_unicode_to_external_checked (name, error);
 	if (utf8_name == NULL) {
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (err));
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (error));
 		
-		mono_error_cleanup (err);
+		mono_error_cleanup (error);
 		mono_w32error_set_last (ERROR_INVALID_NAME);
 		return FALSE;
 	}
@@ -3529,7 +3529,7 @@ mono_w32file_get_attributes (const gunichar2 *name)
 	struct stat buf, linkbuf;
 	gint result;
 	guint32 ret;
-	ERROR_DECL (err);
+	ERROR_DECL (error);
 	
 	if (name == NULL) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: name is NULL", __func__);
@@ -3538,11 +3538,11 @@ mono_w32file_get_attributes (const gunichar2 *name)
 		return(FALSE);
 	}
 	
-	utf8_name = mono_unicode_to_external_checked (name, err);
+	utf8_name = mono_unicode_to_external_checked (name, error);
 	if (utf8_name == NULL) {
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (err));
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (error));
 
-		mono_error_cleanup (err);
+		mono_error_cleanup (error);
 		mono_w32error_set_last (ERROR_INVALID_PARAMETER);
 		return (INVALID_FILE_ATTRIBUTES);
 	}
@@ -3580,7 +3580,7 @@ mono_w32file_get_attributes_ex (const gunichar2 *name, MonoIOStat *stat)
 
 	struct stat buf, linkbuf;
 	gint result;
-	ERROR_DECL (err);
+	ERROR_DECL (error);
 	
 	if (name == NULL) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: name is NULL", __func__);
@@ -3589,11 +3589,11 @@ mono_w32file_get_attributes_ex (const gunichar2 *name, MonoIOStat *stat)
 		return(FALSE);
 	}
 
-	utf8_name = mono_unicode_to_external_checked (name, err);
+	utf8_name = mono_unicode_to_external_checked (name, error);
 	if (utf8_name == NULL) {
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (err));
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (error));
 
-		mono_error_cleanup (err);
+		mono_error_cleanup (error);
 		mono_w32error_set_last (ERROR_INVALID_PARAMETER);
 		return FALSE;
 	}
@@ -3655,7 +3655,7 @@ mono_w32file_set_attributes (const gunichar2 *name, guint32 attrs)
 	gchar *utf8_name;
 	struct stat buf;
 	gint result;
-	ERROR_DECL (err);
+	ERROR_DECL (error);
 
 	/*
 	 * Currently we only handle one *internal* case, with a value that is
@@ -3669,11 +3669,11 @@ mono_w32file_set_attributes (const gunichar2 *name, guint32 attrs)
 		return(FALSE);
 	}
 
-	utf8_name = mono_unicode_to_external_checked (name, err);
+	utf8_name = mono_unicode_to_external_checked (name, error);
 	if (utf8_name == NULL) {
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (err));
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (error));
 
-		mono_error_cleanup (err);
+		mono_error_cleanup (error);
 		mono_w32error_set_last (ERROR_INVALID_NAME);
 		return FALSE;
 	}
@@ -3770,18 +3770,18 @@ mono_w32file_set_cwd (const gunichar2 *path)
 {
 	gchar *utf8_path;
 	gboolean result;
-	ERROR_DECL (err);
+	ERROR_DECL (error);
 
 	if (path == NULL) {
 		mono_w32error_set_last (ERROR_INVALID_PARAMETER);
 		return(FALSE);
 	}
 	
-	utf8_path = mono_unicode_to_external_checked (path, err);
+	utf8_path = mono_unicode_to_external_checked (path, error);
 	if (utf8_path == NULL) {
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (err));
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (error));
 
-		mono_error_cleanup (err);
+		mono_error_cleanup (error);
 		mono_w32error_set_last (ERROR_INVALID_PARAMETER);
 		return FALSE;
 	}
@@ -4392,7 +4392,7 @@ mono_w32file_get_disk_free_space (const gunichar2 *path_name, guint64 *free_byte
 	gchar *utf8_path_name;
 	gint ret;
 	unsigned long block_size;
-	ERROR_DECL (err);
+	ERROR_DECL (error);
 
 	if (path_name == NULL) {
 		utf8_path_name = g_strdup (g_get_current_dir());
@@ -4402,11 +4402,11 @@ mono_w32file_get_disk_free_space (const gunichar2 *path_name, guint64 *free_byte
 		}
 	}
 	else {
-		utf8_path_name = mono_unicode_to_external_checked (path_name, err);
+		utf8_path_name = mono_unicode_to_external_checked (path_name, error);
 		if (utf8_path_name == NULL) {
-			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (err));
+			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (error));
 
-			mono_error_cleanup (err);
+			mono_error_cleanup (error);
 			mono_w32error_set_last (ERROR_INVALID_NAME);
 			return(FALSE);
 		}
@@ -4752,7 +4752,6 @@ ves_icall_System_IO_DriveInfo_GetDriveType (const gunichar2 *root_path_name, gin
 
 	gchar *utf8_root_path_name;
 	guint32 drive_type;
-	ERROR_DECL (err);
 
 	if (root_path_name == NULL) {
 		utf8_root_path_name = g_strdup (g_get_current_dir());
@@ -4761,10 +4760,9 @@ ves_icall_System_IO_DriveInfo_GetDriveType (const gunichar2 *root_path_name, gin
 		}
 	}
 	else {
-		utf8_root_path_name = mono_unicode_to_external_checked (root_path_name, err);
+		utf8_root_path_name = mono_unicode_to_external_checked (root_path_name, error);
 		if (utf8_root_path_name == NULL) {
-			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (err));
-			mono_error_cleanup (err);
+			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_FILE, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (error));
 			return(DRIVE_NO_ROOT_DIR);
 		}
 		

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -73,6 +73,7 @@
 #include <mono/metadata/w32file.h>
 #include <mono/utils/mono-membar.h>
 #include <mono/utils/mono-logger-internals.h>
+#include <mono/utils/strenc-internals.h>
 #include <mono/utils/strenc.h>
 #include <mono/utils/mono-proclib.h>
 #include <mono/utils/mono-path.h>
@@ -1536,11 +1537,12 @@ process_create (const gunichar2 *appname, const gunichar2 *cmdline,
 	 * so crap, with an API like this :-(
 	 */
 	if (appname != NULL) {
-		cmd = mono_unicode_to_external (appname);
+		cmd = mono_unicode_to_external_error (appname, &gerr);
 		if (cmd == NULL) {
-			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: unicode conversion returned NULL",
-				   __func__);
+			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: unicode conversion returned NULL; %s",
+				   __func__, gerr->message);
 
+			g_error_free (gerr);
 			mono_w32error_set_last (ERROR_PATH_NOT_FOUND);
 			goto free_strings;
 		}
@@ -1549,20 +1551,22 @@ process_create (const gunichar2 *appname, const gunichar2 *cmdline,
 	}
 
 	if (cmdline != NULL) {
-		args = mono_unicode_to_external (cmdline);
+		args = mono_unicode_to_external_error (cmdline, &gerr);
 		if (args == NULL) {
-			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: unicode conversion returned NULL", __func__);
+			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: unicode conversion returned NULL; %s", __func__, gerr->message);
 
+			g_error_free (gerr);
 			mono_w32error_set_last (ERROR_PATH_NOT_FOUND);
 			goto free_strings;
 		}
 	}
 
 	if (cwd != NULL) {
-		dir = mono_unicode_to_external (cwd);
+		dir = mono_unicode_to_external_error (cwd, &gerr);
 		if (dir == NULL) {
-			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: unicode conversion returned NULL", __func__);
+			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: unicode conversion returned NULL; %s", __func__, gerr->message);
 
+			g_error_free (gerr);
 			mono_w32error_set_last (ERROR_PATH_NOT_FOUND);
 			goto free_strings;
 		}

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -1506,7 +1506,7 @@ process_create (const gunichar2 *appname, const gunichar2 *cmdline,
 	int startup_pipe [2] = {-1, -1};
 	int dummy;
 	Process *process;
-	ERROR_DECL (err);
+	ERROR_DECL (error);
 
 #if HAVE_SIGACTION
 	mono_lazy_initialize (&process_sig_chld_once, process_add_sigchld_handler);
@@ -1539,12 +1539,12 @@ process_create (const gunichar2 *appname, const gunichar2 *cmdline,
 	 * so crap, with an API like this :-(
 	 */
 	if (appname != NULL) {
-		cmd = mono_unicode_to_external_checked (appname, err);
+		cmd = mono_unicode_to_external_checked (appname, error);
 		if (cmd == NULL) {
 			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: unicode conversion returned NULL; %s",
-				   __func__, mono_error_get_message (err));
+				   __func__, mono_error_get_message (error));
 
-			mono_error_cleanup (err);
+			mono_error_cleanup (error);
 			mono_w32error_set_last (ERROR_PATH_NOT_FOUND);
 			goto free_strings;
 		}
@@ -1553,22 +1553,22 @@ process_create (const gunichar2 *appname, const gunichar2 *cmdline,
 	}
 
 	if (cmdline != NULL) {
-		args = mono_unicode_to_external_checked (cmdline, err);
+		args = mono_unicode_to_external_checked (cmdline, error);
 		if (args == NULL) {
-			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (err));
+			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (error));
 
-			mono_error_cleanup (err);
+			mono_error_cleanup (error);
 			mono_w32error_set_last (ERROR_PATH_NOT_FOUND);
 			goto free_strings;
 		}
 	}
 
 	if (cwd != NULL) {
-		dir = mono_unicode_to_external_checked (cwd, err);
+		dir = mono_unicode_to_external_checked (cwd, error);
 		if (dir == NULL) {
-			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (err));
+			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (error));
 
-			mono_error_cleanup (err);
+			mono_error_cleanup (error);
 			mono_w32error_set_last (ERROR_PATH_NOT_FOUND);
 			goto free_strings;
 		}

--- a/mono/utils/Makefile.am
+++ b/mono/utils/Makefile.am
@@ -115,6 +115,7 @@ monoutils_sources = \
 	mono-string.h		\
 	mono-time.c  		\
 	mono-time.h  		\
+	strenc-internals.h 	\
 	strenc.h		\
 	strenc.c		\
 	mono-uri.c		\

--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -1019,19 +1019,19 @@ mono_pe_file_map (gunichar2 *filename, gint32 *map_size, void **handle)
 	int fd = -1;
 	struct stat statbuf;
 	gpointer file_map = NULL;
-	ERROR_DECL (err);
+	ERROR_DECL (error);
 
 	/* According to the MSDN docs, a search path is applied to
 	 * filename.  FIXME: implement this, for now just pass it
 	 * straight to open
 	 */
 
-	filename_ext = mono_unicode_to_external_checked (filename, err);
+	filename_ext = mono_unicode_to_external_checked (filename, error);
 	// Assert added to diagnose https://github.com/mono/mono/issues/14730, remove after resolved
-	g_assertf (filename_ext != NULL, "%s: unicode conversion returned NULL; %s; 0x%hx", __func__, mono_error_get_message (err), filename);
+	g_assertf (filename_ext != NULL, "%s: unicode conversion returned NULL; %s; 0x%hx", __func__, mono_error_get_message (error), filename);
 	if (filename_ext == NULL) {
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (err));
-		mono_error_cleanup (err);
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: unicode conversion returned NULL; %s", __func__, mono_error_get_message (error));
+		mono_error_cleanup (error);
 		goto exit;
 	}
 

--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -1026,6 +1026,8 @@ mono_pe_file_map (gunichar2 *filename, gint32 *map_size, void **handle)
 	 */
 
 	filename_ext = mono_unicode_to_external_error (filename, &err);
+	// Added to diagnose https://github.com/mono/mono/issues/14730, remove after resolved
+	g_assertf (filename_ext != NULL, "%s: unicode conversion returned NULL; %s; 0x%hx", __func__, err->message, filename);
 	if (filename_ext == NULL) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: unicode conversion returned NULL; %s", __func__, err->message);
 

--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -1043,23 +1043,23 @@ mono_pe_file_map (gunichar2 *filename, gint32 *map_size, void **handle)
 			mono_set_errno (saved_errno);
 
 			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: Error opening file %s (3): %s", __func__, filename_ext, strerror (errno));
-			goto error;
+			goto exit;
 		}
 
 		fd = open (located_filename, O_RDONLY, 0);
 		if (fd == -1) {
 			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: Error opening file %s (3): %s", __func__, filename_ext, strerror (errno));
-			goto error;
+			goto exit;
 		}
 	}
 	else if (fd == -1) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: Error opening file %s (3): %s", __func__, filename_ext, strerror (errno));
-		goto error;
+		goto exit;
 	}
 
 	if (fstat (fd, &statbuf) == -1) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: Error stat()ing file %s: %s", __func__, filename_ext, strerror (errno));
-		goto error;
+		goto exit;
 	}
 	*map_size = statbuf.st_size;
 
@@ -1073,7 +1073,7 @@ mono_pe_file_map (gunichar2 *filename, gint32 *map_size, void **handle)
 	file_map = mono_file_map (statbuf.st_size, MONO_MMAP_READ | MONO_MMAP_PRIVATE, fd, 0, handle);
 	if (file_map == NULL) {
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: Error mmap()int file %s: %s", __func__, filename_ext, strerror (errno));
-		goto error;
+		goto exit;
 	}
 exit:
 	if (fd != -1)
@@ -1081,8 +1081,6 @@ exit:
 	g_free (located_filename);
 	g_free (filename_ext);
 	return file_map;
-error:
-	goto exit;
 }
 
 void

--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -22,6 +22,7 @@
 #endif
 
 #include <utils/mono-mmap.h>
+#include <utils/strenc-internals.h>
 #include <utils/strenc.h>
 #include <utils/mono-io-portability.h>
 #include <utils/mono-logger-internals.h>
@@ -1017,16 +1018,19 @@ mono_pe_file_map (gunichar2 *filename, gint32 *map_size, void **handle)
 	int fd = -1;
 	struct stat statbuf;
 	gpointer file_map = NULL;
+	GError *err = NULL;
 
 	/* According to the MSDN docs, a search path is applied to
 	 * filename.  FIXME: implement this, for now just pass it
 	 * straight to open
 	 */
 
-	filename_ext = mono_unicode_to_external (filename);
+	filename_ext = mono_unicode_to_external_error (filename, &err);
 	if (filename_ext == NULL) {
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: unicode conversion returned NULL", __func__);
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_IO_LAYER_PROCESS, "%s: unicode conversion returned NULL; %s", __func__, err->message);
 
+		g_error_free (err);
+		
 		goto exit;
 	}
 

--- a/mono/utils/strenc-internals.h
+++ b/mono/utils/strenc-internals.h
@@ -2,7 +2,8 @@
 #define _MONO_STRENC_INTERNALS_H_
 
 #include <glib.h>
+#include <mono/utils/mono-error.h>
 
-gchar *mono_unicode_to_external_error (const gunichar2 *uni, GError **err);
+gchar *mono_unicode_to_external_checked (const gunichar2 *uni, MonoError *err);
 
 #endif /* _MONO_STRENC_INTERNALS_H_ */

--- a/mono/utils/strenc-internals.h
+++ b/mono/utils/strenc-internals.h
@@ -1,0 +1,8 @@
+#ifndef _MONO_STRENC_INTERNALS_H_
+#define _MONO_STRENC_INTERNALS_H_
+
+#include <glib.h>
+
+gchar *mono_unicode_to_external_error (const gunichar2 *uni, GError **err);
+
+#endif /* _MONO_STRENC_INTERNALS_H_ */

--- a/mono/utils/strenc.c
+++ b/mono/utils/strenc.c
@@ -14,6 +14,8 @@
 
 #include "strenc.h"
 #include "strenc-internals.h"
+#include "mono-error.h"
+#include "mono-error-internals.h"
 
 static const char trailingBytesForUTF8[256] = {
 	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
@@ -174,19 +176,22 @@ gchar *mono_utf8_from_external (const gchar *in)
  */
 gchar *mono_unicode_to_external (const gunichar2 *uni)
 {
-	return mono_unicode_to_external_error (uni, NULL);
+	return mono_unicode_to_external_checked (uni, NULL);
 }
 
-gchar *mono_unicode_to_external_error (const gunichar2 *uni, GError **err)
+gchar *mono_unicode_to_external_checked (const gunichar2 *uni, MonoError *err)
 {
 	gchar *utf8;
 	gchar *encoding_list;
+	GError *gerr = NULL;
 	
 	/* Turn the unicode into utf8 to start with, because its
 	 * easier to work with gchar * than gunichar2 *
 	 */
-	utf8=g_utf16_to_utf8 (uni, -1, NULL, NULL, err);
+	utf8=g_utf16_to_utf8 (uni, -1, NULL, NULL, &gerr);
 	if (utf8 == NULL) {
+		mono_error_set_argument (err, "uni", gerr->message);
+		g_error_free (gerr);
 		return utf8;
 	}
 	

--- a/mono/utils/strenc.c
+++ b/mono/utils/strenc.c
@@ -13,6 +13,7 @@
 #include <string.h>
 
 #include "strenc.h"
+#include "strenc-internals.h"
 
 static const char trailingBytesForUTF8[256] = {
 	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
@@ -40,8 +41,7 @@ static const char trailingBytesForUTF8[256] = {
  * Callers must free the returned string if not NULL. \p bytes holds the number
  * of bytes in the returned string, not including the terminator.
  */
-gunichar2 *
-mono_unicode_from_external (const gchar *in, gsize *bytes)
+gunichar2 *mono_unicode_from_external (const gchar *in, gsize *bytes)
 {
 	gchar *res=NULL;
 	gchar **encodings;
@@ -174,14 +174,21 @@ gchar *mono_utf8_from_external (const gchar *in)
  */
 gchar *mono_unicode_to_external (const gunichar2 *uni)
 {
+	return mono_unicode_to_external_error (uni, NULL);
+}
+
+gchar *mono_unicode_to_external_error (const gunichar2 *uni, GError **err)
+{
 	gchar *utf8;
 	gchar *encoding_list;
 	
 	/* Turn the unicode into utf8 to start with, because its
 	 * easier to work with gchar * than gunichar2 *
 	 */
-	utf8=g_utf16_to_utf8 (uni, -1, NULL, NULL, NULL);
-	g_assert (utf8!=NULL);
+	utf8=g_utf16_to_utf8 (uni, -1, NULL, NULL, err);
+	if (utf8 == NULL) {
+		return utf8;
+	}
 	
 	encoding_list=g_getenv ("MONO_EXTERNAL_ENCODINGS");
 	if(encoding_list==NULL) {

--- a/msvc/libmonoutils-common.targets
+++ b/msvc/libmonoutils-common.targets
@@ -68,6 +68,7 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-string.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-time.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-time.h" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\utils\strenc-internals.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\strenc.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\strenc.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\utils\mono-uri.c" />

--- a/msvc/libmonoutils-common.targets.filters
+++ b/msvc/libmonoutils-common.targets.filters
@@ -151,6 +151,9 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\mono-time.h">
       <Filter>Header Files$(MonoUtilsFilterSubFolder)\common</Filter>
     </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\mono\utils\strenc-internals.h">
+      <Filter>Header Files$(MonoUtilsFilterSubFolder)\common</Filter>
+    </ClInclude>
     <ClInclude Include="$(MonoSourceLocation)\mono\utils\strenc.h">
       <Filter>Header Files$(MonoUtilsFilterSubFolder)\common</Filter>
     </ClInclude>


### PR DESCRIPTION
The error propagation made sense in most places the function was called, and so they were updated accordingly. Notably, however, this removes the `g_assert` previous present in the function that was being hit as part of https://github.com/mono/mono/issues/14730. I've re-added it higher in the call stack along with a print of more diagnostic information to figure out exactly what's going on. It preserves existing behavior, so this is not going to cause additional new failures, and a later PR addressing the underlying cause of the bug will remove it.

Hopefully this time I've added the new file to the build system properly...

Backport of #14879.

/cc @lambdageek @CoffeeFlux