### PR TITLE
Add the compiler server log to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,7 @@ llvm/build/
 llvm/usr/
 sdks/builds/llvm-*/
 sdks/builds/android-*/
+mcs/build/compiler-server.log
 
 
 ##############################################################################


### PR DESCRIPTION
I failed to do this when we first added it.