### PR TITLE
[api] Add a mono/metadata/profiler-legacy.h header

### DIFF
--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -477,7 +477,6 @@ libmonoruntimeinclude_HEADERS = \
 	opcodes.h		\
 	profiler.h		\
 	profiler-events.h	\
-	profiler-legacy.h	\
 	reflection.h		\
 	row-indexes.h		\
 	sgen-bridge.h		\

--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -348,6 +348,7 @@ common_sources = \
 	w32process-internals.h		\
 	profiler.c		\
 	profiler-private.h	\
+	profiler-legacy.h	\
 	rand.h			\
 	rand.c			\
 	remoting.h		\
@@ -476,6 +477,7 @@ libmonoruntimeinclude_HEADERS = \
 	opcodes.h		\
 	profiler.h		\
 	profiler-events.h	\
+	profiler-legacy.h	\
 	reflection.h		\
 	row-indexes.h		\
 	sgen-bridge.h		\

--- a/mono/metadata/profiler-legacy.h
+++ b/mono/metadata/profiler-legacy.h
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the .NET Foundation under one or more agreements.
+ * The .NET Foundation licenses this file to you under the MIT license.
+ * See the LICENSE file in the project root for more information.
+ */
+
+#ifndef __MONO_PROFILER_LEGACY_H__
+#define __MONO_PROFILER_LEGACY_H__
+
+#include <mono/utils/mono-publib.h>
+#include <mono/utils/mono-forward.h>
+#include <mono/metadata/object-forward.h>
+#include <mono/metadata/profiler.h>
+
+MONO_BEGIN_DECLS
+
+/*
+ * The following code is here to maintain compatibility with a few profiler API
+ * functions used by Xamarin.{Android,iOS,Mac} so that they keep working
+ * regardless of which system Mono version is used.
+ *
+ * TODO: Remove this some day if we're OK with breaking compatibility.
+ */
+
+typedef void *MonoLegacyProfiler;
+
+typedef void (*MonoLegacyProfileFunc) (MonoLegacyProfiler *prof);
+typedef void (*MonoLegacyProfileThreadFunc) (MonoLegacyProfiler *prof, uintptr_t tid);
+typedef void (*MonoLegacyProfileGCFunc) (MonoLegacyProfiler *prof, MonoProfilerGCEvent event, int generation);
+typedef void (*MonoLegacyProfileGCResizeFunc) (MonoLegacyProfiler *prof, int64_t new_size);
+typedef void (*MonoLegacyProfileJitResult) (MonoLegacyProfiler *prof, MonoMethod *method, MonoJitInfo *jinfo, int result);
+typedef void (*MonoLegacyProfileAllocFunc) (MonoLegacyProfiler *prof, MonoObject *obj, MonoClass *klass);
+typedef void (*MonoLegacyProfileMethodFunc) (MonoLegacyProfiler *prof, MonoMethod *method);
+typedef void (*MonoLegacyProfileExceptionFunc) (MonoLegacyProfiler *prof, MonoObject *object);
+typedef void (*MonoLegacyProfileExceptionClauseFunc) (MonoLegacyProfiler *prof, MonoMethod *method, int clause_type, int clause_num);
+
+MONO_API void mono_profiler_install (MonoLegacyProfiler *prof, MonoLegacyProfileFunc callback);
+MONO_API void mono_profiler_install_thread (MonoLegacyProfileThreadFunc start, MonoLegacyProfileThreadFunc end);
+MONO_API void mono_profiler_install_gc (MonoLegacyProfileGCFunc callback, MonoLegacyProfileGCResizeFunc heap_resize_callback);
+MONO_API void mono_profiler_install_jit_end (MonoLegacyProfileJitResult end);
+MONO_API void mono_profiler_set_events (int flags);
+MONO_API void mono_profiler_install_allocation (MonoLegacyProfileAllocFunc callback);
+MONO_API void mono_profiler_install_enter_leave (MonoLegacyProfileMethodFunc enter, MonoLegacyProfileMethodFunc fleave);
+MONO_API void mono_profiler_install_exception (MonoLegacyProfileExceptionFunc throw_callback, MonoLegacyProfileMethodFunc exc_method_leave, MonoLegacyProfileExceptionClauseFunc clause_callback);
+
+MONO_END_DECLS
+
+
+#endif // __MONO_PROFILER_LEGACY_H__

--- a/mono/metadata/profiler-legacy.h
+++ b/mono/metadata/profiler-legacy.h
@@ -34,14 +34,14 @@ typedef void (*MonoLegacyProfileMethodFunc) (MonoLegacyProfiler *prof, MonoMetho
 typedef void (*MonoLegacyProfileExceptionFunc) (MonoLegacyProfiler *prof, MonoObject *object);
 typedef void (*MonoLegacyProfileExceptionClauseFunc) (MonoLegacyProfiler *prof, MonoMethod *method, int clause_type, int clause_num);
 
-MONO_API void mono_profiler_install (MonoLegacyProfiler *prof, MonoLegacyProfileFunc callback);
-MONO_API void mono_profiler_install_thread (MonoLegacyProfileThreadFunc start, MonoLegacyProfileThreadFunc end);
-MONO_API void mono_profiler_install_gc (MonoLegacyProfileGCFunc callback, MonoLegacyProfileGCResizeFunc heap_resize_callback);
-MONO_API void mono_profiler_install_jit_end (MonoLegacyProfileJitResult end);
-MONO_API void mono_profiler_set_events (int flags);
-MONO_API void mono_profiler_install_allocation (MonoLegacyProfileAllocFunc callback);
-MONO_API void mono_profiler_install_enter_leave (MonoLegacyProfileMethodFunc enter, MonoLegacyProfileMethodFunc fleave);
-MONO_API void mono_profiler_install_exception (MonoLegacyProfileExceptionFunc throw_callback, MonoLegacyProfileMethodFunc exc_method_leave, MonoLegacyProfileExceptionClauseFunc clause_callback);
+MONO_DEPRECATED void mono_profiler_install (MonoLegacyProfiler *prof, MonoLegacyProfileFunc callback);
+MONO_DEPRECATED void mono_profiler_install_thread (MonoLegacyProfileThreadFunc start, MonoLegacyProfileThreadFunc end);
+MONO_DEPRECATED void mono_profiler_install_gc (MonoLegacyProfileGCFunc callback, MonoLegacyProfileGCResizeFunc heap_resize_callback);
+MONO_DEPRECATED void mono_profiler_install_jit_end (MonoLegacyProfileJitResult end);
+MONO_DEPRECATED void mono_profiler_set_events (int flags);
+MONO_DEPRECATED void mono_profiler_install_allocation (MonoLegacyProfileAllocFunc callback);
+MONO_DEPRECATED void mono_profiler_install_enter_leave (MonoLegacyProfileMethodFunc enter, MonoLegacyProfileMethodFunc fleave);
+MONO_DEPRECATED void mono_profiler_install_exception (MonoLegacyProfileExceptionFunc throw_callback, MonoLegacyProfileMethodFunc exc_method_leave, MonoLegacyProfileExceptionClauseFunc clause_callback);
 
 MONO_END_DECLS
 

--- a/mono/metadata/profiler.c
+++ b/mono/metadata/profiler.c
@@ -9,6 +9,7 @@
 #include <mono/metadata/gc-internals.h>
 #include <mono/metadata/mono-config-dirs.h>
 #include <mono/metadata/mono-debug.h>
+#include <mono/metadata/profiler-legacy.h>
 #include <mono/metadata/profiler-private.h>
 #include <mono/metadata/debug-internals.h>
 #include <mono/utils/mono-dl.h>
@@ -956,25 +957,6 @@ update_callback (volatile gpointer *location, gpointer new_, volatile gint32 *co
 #undef MONO_PROFILER_EVENT_5
 #undef _MONO_PROFILER_EVENT
 
-/*
- * The following code is here to maintain compatibility with a few profiler API
- * functions used by Xamarin.{Android,iOS,Mac} so that they keep working
- * regardless of which system Mono version is used.
- *
- * TODO: Remove this some day if we're OK with breaking compatibility.
- */
-
-typedef void *MonoLegacyProfiler;
-
-typedef void (*MonoLegacyProfileFunc) (MonoLegacyProfiler *prof);
-typedef void (*MonoLegacyProfileThreadFunc) (MonoLegacyProfiler *prof, uintptr_t tid);
-typedef void (*MonoLegacyProfileGCFunc) (MonoLegacyProfiler *prof, MonoProfilerGCEvent event, int generation);
-typedef void (*MonoLegacyProfileGCResizeFunc) (MonoLegacyProfiler *prof, int64_t new_size);
-typedef void (*MonoLegacyProfileJitResult) (MonoLegacyProfiler *prof, MonoMethod *method, MonoJitInfo *jinfo, int result);
-typedef void (*MonoLegacyProfileAllocFunc) (MonoLegacyProfiler *prof, MonoObject *obj, MonoClass *klass);
-typedef void (*MonoLegacyProfileMethodFunc) (MonoLegacyProfiler *prof, MonoMethod *method);
-typedef void (*MonoLegacyProfileExceptionFunc) (MonoLegacyProfiler *prof, MonoObject *object);
-typedef void (*MonoLegacyProfileExceptionClauseFunc) (MonoLegacyProfiler *prof, MonoMethod *method, int clause_type, int clause_num);
 
 struct _MonoProfiler {
 	MonoProfilerHandle handle;
@@ -993,15 +975,6 @@ struct _MonoProfiler {
 };
 
 static MonoProfiler *current;
-
-MONO_API void mono_profiler_install (MonoLegacyProfiler *prof, MonoLegacyProfileFunc callback);
-MONO_API void mono_profiler_install_thread (MonoLegacyProfileThreadFunc start, MonoLegacyProfileThreadFunc end);
-MONO_API void mono_profiler_install_gc (MonoLegacyProfileGCFunc callback, MonoLegacyProfileGCResizeFunc heap_resize_callback);
-MONO_API void mono_profiler_install_jit_end (MonoLegacyProfileJitResult end);
-MONO_API void mono_profiler_set_events (int flags);
-MONO_API void mono_profiler_install_allocation (MonoLegacyProfileAllocFunc callback);
-MONO_API void mono_profiler_install_enter_leave (MonoLegacyProfileMethodFunc enter, MonoLegacyProfileMethodFunc fleave);
-MONO_API void mono_profiler_install_exception (MonoLegacyProfileExceptionFunc throw_callback, MonoLegacyProfileMethodFunc exc_method_leave, MonoLegacyProfileExceptionClauseFunc clause_callback);
 
 static void
 shutdown_cb (MonoProfiler *prof)

--- a/msvc/libmonoruntime-common.targets
+++ b/msvc/libmonoruntime-common.targets
@@ -245,6 +245,7 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\opcodes.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\profiler.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\profiler-events.h" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\profiler-legacy.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\reflection.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\row-indexes.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\tokentype.h" />

--- a/msvc/libmonoruntime-common.targets.filters
+++ b/msvc/libmonoruntime-common.targets.filters
@@ -672,6 +672,9 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\profiler-events.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common\public</Filter>
     </ClInclude>
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\profiler-legacy.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common\public</Filter>
+    </ClInclude>
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\reflection.h">
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common\public</Filter>
     </ClInclude>


### PR DESCRIPTION
Add a header with the legacy Mono profiler API and mark every function in it with `MONO_DEPRECATED`.

New code should use the API from mono/metadata/profiler.h.

---
No functional change. All these symbols were already exported by mono/metadata/profiler.c.  Now we just have a proper header for them.