### PR TITLE
[mini] Move some MONO_API functions to public header

### DIFF
--- a/mono/mini/aot-runtime.h
+++ b/mono/mini/aot-runtime.h
@@ -268,9 +268,6 @@ gboolean mono_aot_init_llvmonly_method      (gpointer amodule, guint32 method_in
 GHashTable *mono_aot_get_weak_field_indexes (MonoImage *image);
 MonoAotMethodFlags mono_aot_get_method_flags (guint8 *code);
 
-/* This is an exported function */
-MONO_API void     mono_aot_register_module           (gpointer *aot_info);
-
 /* These are used to load the AOT data for aot images compiled with MONO_AOT_FILE_FLAG_SEPARATE_DATA */
 /*
  * Return the AOT data for ASSEMBLY. SIZE is the size of the data. OUT_HANDLE should be set to a handle which is later

--- a/mono/mini/jit.h
+++ b/mono/mini/jit.h
@@ -100,6 +100,16 @@ mono_jit_parse_options     (int argc, char * argv[]);
 
 MONO_API char*       mono_get_runtime_build_info    (void);
 
+MONO_API MONO_RT_EXTERNAL_ONLY void
+mono_set_use_llvm (mono_bool use_llvm);
+
+MONO_API MONO_RT_EXTERNAL_ONLY void
+mono_aot_register_module (gpointer *aot_info);
+
+MONO_API MONO_RT_EXTERNAL_ONLY
+MonoDomain* mono_jit_thread_attach (MonoDomain *domain);
+
+
 MONO_END_DECLS
 
 #endif

--- a/mono/mini/jit.h
+++ b/mono/mini/jit.h
@@ -104,7 +104,7 @@ MONO_API MONO_RT_EXTERNAL_ONLY void
 mono_set_use_llvm (mono_bool use_llvm);
 
 MONO_API MONO_RT_EXTERNAL_ONLY void
-mono_aot_register_module (gpointer *aot_info);
+mono_aot_register_module (void **aot_info);
 
 MONO_API MONO_RT_EXTERNAL_ONLY
 MonoDomain* mono_jit_thread_attach (MonoDomain *domain);

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -163,6 +163,13 @@ mono_running_on_valgrind (void)
 		return FALSE;
 }
 
+void
+mono_set_use_llvm (mono_bool use_llvm)
+{
+	mono_use_llvm = (gboolean)use_llvm;
+}
+
+
 typedef struct {
 	void *ip;
 	MonoMethod *method;

--- a/mono/mini/mini-runtime.h
+++ b/mono/mini/mini-runtime.h
@@ -451,8 +451,6 @@ void      mono_push_lmf                     (MonoLMFExt *ext);
 void      mono_pop_lmf                      (MonoLMF *lmf);
 #define mono_get_jit_tls mono_tls_get_jit_tls
 MonoJitTlsData* mono_get_jit_tls            (void);
-MONO_API MONO_RT_EXTERNAL_ONLY
-MonoDomain* mono_jit_thread_attach (MonoDomain *domain);
 MONO_API void      mono_jit_set_domain      (MonoDomain *domain);
 
 gboolean  mono_method_same_domain           (MonoJitInfo *caller, MonoJitInfo *callee);


### PR DESCRIPTION
And mark them all `MONO_RT_EXTERNAL_ONLY`.

`mono_set_use_llvm` is new - Xamarin.Android previously assigned to `mono_use_llvm` directly.

Fixes #15099