### PR TITLE
[netcore] Fix csproj

### DIFF
--- a/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -28,8 +28,8 @@
 
   <!-- Compilation options -->
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">$(BuildType)</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">$(BuildArch)</Platform>
+    <Configuration Condition=" '$(BuildType)' != '' ">$(BuildType)</Configuration>
+    <Platform Condition=" '$(BuildArch)' != '' ">$(BuildArch)</Platform>
     <Platform Condition=" '$(Platform)' == 'armel' ">arm</Platform>
     <ProjectGuid>{DD18B4BA-3B49-437B-9E34-41EF8A640CE0}</ProjectGuid>
 

--- a/netcore/build.sh
+++ b/netcore/build.sh
@@ -83,6 +83,7 @@ while [[ $# > 0 ]]; do
   shift
 done
 
+CPU_COUNT=$(getconf _NPROCESSORS_ONLN || echo 4)
 
 # run .././autogen.sh only once or if "--rebuild" argument is provided
 if [[ "$force_rebuild" == "true" || ! -f .configured ]]; then
@@ -91,8 +92,6 @@ if [[ "$force_rebuild" == "true" || ! -f .configured ]]; then
   make -j$CPU_COUNT
   touch .configured
 fi
-
-CPU_COUNT=$(getconf _NPROCESSORS_ONLN || echo 4)
 
 # build mono runtime
 if [ "$skipnative" = "false" ]; then


### PR DESCRIPTION
Overwrite `Configuration` and `Platform` only when external variables are defined.
