### PR TITLE
Fix compiler warnings.

### DIFF
--- a/mono/metadata/console-unix.c
+++ b/mono/metadata/console-unix.c
@@ -269,7 +269,11 @@ MONO_SIG_HANDLER_FUNC (static, sigint_handler)
 	in_sigint = FALSE;
 }
 
-static struct sigaction save_sigcont, save_sigint, save_sigwinch;
+static struct sigaction save_sigcont, save_sigwinch;
+
+#if HAVE_SIGACTION
+static struct sigaction save_sigint;
+#endif
 
 MONO_SIG_HANDLER_FUNC (static, sigcont_handler)
 {

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -2131,6 +2131,8 @@ leave:
 	return result;
 }
 
+#ifndef DISABLE_REMOTING
+
 /* mono_marshal_xdomain_copy_value
  * Makes a copy of "val" suitable for the current domain.
  */
@@ -2143,6 +2145,8 @@ mono_marshal_xdomain_copy_value (MonoObject* val_raw, MonoError *error)
 	MonoObjectHandle result = mono_marshal_xdomain_copy_value_handle (val, error);
 	HANDLE_FUNCTION_RETURN_OBJ (result);
 }
+
+#endif
 
 /* mono_marshal_xdomain_copy_value
  * Makes a copy of "val" suitable for the current domain.

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -590,9 +590,7 @@ mono_marshal_xdomain_copy_out_value (MonoObject *src, MonoObject *dst)
 	default:
 		break;
 	}
-
 }
-
 
 #if !defined (DISABLE_JIT)
 static void
@@ -2136,7 +2134,7 @@ leave:
 /* mono_marshal_xdomain_copy_value
  * Makes a copy of "val" suitable for the current domain.
  */
-MonoObject*
+static MonoObject*
 mono_marshal_xdomain_copy_value (MonoObject* val_raw, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -97,6 +97,7 @@
 /* define LOGDEBUG(...) g_message(__VA_ARGS__)  */
 
 /* The process' environment strings */
+#if defined (HAVE_FORK) && defined (HAVE_EXECVE)
 #if defined(__APPLE__)
 #if defined (TARGET_OSX)
 /* Apple defines this in crt_externs.h but doesn't provide that header for 
@@ -115,6 +116,7 @@ static char *mono_environ[1] = { NULL };
 G_BEGIN_DECLS
 extern char **environ;
 G_END_DECLS
+#endif
 #endif
 
 typedef enum {


### PR DESCRIPTION
 unused variable: save_sigint
 unused variable: mono_environ
 unprototyped function: mono_marshal_xdomain_copy_value