### PR TITLE
Add cooperative suspend aware threads for hybrid suspend.

### DIFF
--- a/mono/utils/mono-threads-api.h
+++ b/mono/utils/mono-threads-api.h
@@ -156,4 +156,10 @@ mono_threads_exit_no_safepoints_region (const char *func);
 			mono_threads_exit_no_safepoints_region (__func__);	\
 	} while (0)
 
+MONO_API MONO_RT_EXTERNAL_ONLY void
+mono_thread_set_coop_aware (void);
+
+MONO_API MONO_RT_EXTERNAL_ONLY mono_bool
+mono_thread_get_coop_aware (void);
+
 #endif /* __MONO_LOGGER_H__ */

--- a/mono/utils/mono-threads-coop.c
+++ b/mono/utils/mono-threads-coop.c
@@ -763,3 +763,26 @@ mono_threads_exit_no_safepoints_region (const char *func)
 	MONO_REQ_GC_UNSAFE_MODE;
 	mono_threads_transition_end_no_safepoints (mono_thread_info_current (), func);
 }
+
+void
+mono_thread_set_coop_aware (void)
+{
+	MONO_ENTER_GC_UNSAFE;
+	MonoThreadInfo *info = mono_thread_info_current_unchecked ();
+	if (info)
+		mono_atomic_store_i32 (&(info->coop_aware_thread), TRUE);
+	MONO_EXIT_GC_UNSAFE;
+}
+
+mono_bool
+mono_thread_get_coop_aware (void)
+{
+	mono_bool result = FALSE;
+	MONO_ENTER_GC_UNSAFE;
+	MonoThreadInfo *info = mono_thread_info_current_unchecked ();
+	if (info)
+		result = (mono_bool)mono_atomic_load_i32 (&(info->coop_aware_thread));
+	MONO_EXIT_GC_UNSAFE;
+
+	return result;
+}

--- a/mono/utils/mono-threads-coop.c
+++ b/mono/utils/mono-threads-coop.c
@@ -770,6 +770,10 @@ mono_thread_set_coop_aware (void)
 	MONO_ENTER_GC_UNSAFE;
 	MonoThreadInfo *info = mono_thread_info_current_unchecked ();
 	if (info)
+		/* NOTE, this flag should only be changed while in unsafe mode. */
+		/* It will make sure we won't get an async preemptive suspend */
+		/* request against this thread while in the process of changing the flag */
+		/* affecting the threads suspend/resume behavior. */
 		mono_atomic_store_i32 (&(info->coop_aware_thread), TRUE);
 	MONO_EXIT_GC_UNSAFE;
 }

--- a/mono/utils/mono-threads-windows.c
+++ b/mono/utils/mono-threads-windows.c
@@ -485,6 +485,12 @@ mono_threads_platform_init (void)
 #endif
 }
 
+static gboolean
+thread_is_cooperative_suspend_aware (MonoThreadInfo *info)
+{
+	return (mono_threads_is_cooperative_suspension_enabled () || mono_atomic_load_i32 (&(info->coop_aware_thread)));
+}
+
 /*
  * When running x86 process under x64 system syscalls are done through WoW64. This
  * needs to do a transition from x86 mode to x64 so it can syscall into the x64 system.
@@ -500,7 +506,7 @@ mono_threads_platform_in_critical_region (THREAD_INFO_TYPE *info)
 #if SIZEOF_VOID_P == 4 && HAVE_API_SUPPORT_WIN32_OPEN_THREAD
 /* FIXME On cygwin these are not defined */
 #if defined(CONTEXT_EXCEPTION_REQUEST) && defined(CONTEXT_EXCEPTION_REPORTING) && defined(CONTEXT_EXCEPTION_ACTIVE)
-	if (is_wow64 && mono_threads_is_cooperative_suspension_enabled ()) {
+	if (is_wow64 && thread_is_cooperative_suspend_aware (info)) {
 		/* Cooperative suspended threads will block at well-defined locations. */
 		return FALSE;
 	} else if (is_wow64 && mono_threads_is_hybrid_suspension_enabled ()) {

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -448,10 +448,6 @@ register_thread (MonoThreadInfo *info)
 	info->small_id = mono_thread_info_register_small_id ();
 	mono_thread_info_set_tid (info, mono_native_thread_id_get ());
 
-	// NOTE, JUST FOR TESTING ON CI, WILL BE REMOVED IN FINAL COMMIT.
-	if (info->small_id % 2 == 0)
-		info->coop_aware_thread = TRUE;
-
 	info->handle = g_new0 (MonoThreadHandle, 1);
 	mono_refcount_init (info->handle, thread_handle_destroy);
 	mono_os_event_init (&info->handle->event, FALSE);

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -152,15 +152,21 @@ begin_suspend_for_running_thread (MonoThreadInfo *info, gboolean interrupt_kerne
 		return begin_preemptive_suspend (info, interrupt_kernel);
 }
 
+static gboolean
+thread_is_cooperative_suspend_aware (MonoThreadInfo *info)
+{
+	return (mono_threads_is_cooperative_suspension_enabled () || mono_atomic_load_i32 (&(info->coop_aware_thread)));
+}
+
 static BeginSuspendResult
-begin_suspend_for_blocking_thread (MonoThreadInfo *info, gboolean interrupt_kernel, MonoThreadSuspendPhase phase, gboolean *did_interrupt)
+begin_suspend_for_blocking_thread (MonoThreadInfo *info, gboolean interrupt_kernel, MonoThreadSuspendPhase phase, gboolean coop_aware_thread, gboolean *did_interrupt)
 {
 	// if a thread can't transition to blocking, we certainly shouldn't be
 	// trying to suspend it like it's blocking.
 	g_assert (mono_threads_is_blocking_transition_enabled ());
-	// with hybrid suspend, preemptively suspend blocking threads,
+	// with hybrid suspend, preemptively suspend blocking threads (if thread is not coop aware),
 	// otherwise blocking already counts as suspended.
-	if (mono_threads_is_hybrid_suspension_enabled ()) {
+	if (mono_threads_is_hybrid_suspension_enabled () && !coop_aware_thread) {
 		if (did_interrupt) {
 			*did_interrupt = interrupt_kernel;
 		}
@@ -169,7 +175,7 @@ begin_suspend_for_blocking_thread (MonoThreadInfo *info, gboolean interrupt_kern
 			/* In hybrid suspend, in the first phase, a thread in
 			 * blocking can continue running (and possibly
 			 * self-suspend).  We'll preemptively suspend it in the
-			 * second phase. */
+			 * second phase, if thread is not coop aware. */
 			return BeginSuspendOkNoWait;
 		case MONO_THREAD_SUSPEND_PHASE_MOPUP:
 			return begin_preemptive_suspend (info, interrupt_kernel);
@@ -441,6 +447,10 @@ register_thread (MonoThreadInfo *info)
 
 	info->small_id = mono_thread_info_register_small_id ();
 	mono_thread_info_set_tid (info, mono_native_thread_id_get ());
+
+	// NOTE, JUST FOR TESTING ON CI, WILL BE REMOVED IN FINAL COMMIT.
+	if (info->small_id % 2 == 0)
+		info->coop_aware_thread = TRUE;
 
 	info->handle = g_new0 (MonoThreadHandle, 1);
 	mono_refcount_init (info->handle, thread_handle_destroy);
@@ -1050,6 +1060,8 @@ mono_thread_info_begin_suspend (MonoThreadInfo *info, MonoThreadSuspendPhase pha
 MonoThreadBeginSuspendResult
 begin_suspend_request_suspension_cordially (MonoThreadInfo *info)
 {
+	gboolean coop_aware_thread = FALSE;
+
 	/* Ask the thread nicely to suspend.  In hybrid suspend, blocking
 	 * threads are transitioned to blocking_suspend_requested, but not
 	 * preemptively suspend in the current phase.
@@ -1079,15 +1091,19 @@ begin_suspend_request_suspension_cordially (MonoThreadInfo *info)
 	case ReqSuspendInitSuspendBlocking:
 		// in full cooperative mode just leave BLOCKING
 		// threads running until they try to return to RUNNING, so
-		// nothing to do, in hybrid coop preempt the thread.
-		switch (begin_suspend_for_blocking_thread (info, FALSE, MONO_THREAD_SUSPEND_PHASE_INITIAL, NULL)) {
+		// nothing to do, in hybrid coop preempt the thread. If thread is coop aware,
+		// handle its as normal cooperative mode.
+		if (mono_threads_is_blocking_transition_enabled ())
+			coop_aware_thread = thread_is_cooperative_suspend_aware (info);
+
+		switch (begin_suspend_for_blocking_thread (info, FALSE, MONO_THREAD_SUSPEND_PHASE_INITIAL, coop_aware_thread, NULL)) {
 		case BeginSuspendFail:
 			return MONO_THREAD_BEGIN_SUSPEND_SKIP;
 		case BeginSuspendOkNoWait:
-			if (mono_threads_is_hybrid_suspension_enabled ())
+			if (mono_threads_is_hybrid_suspension_enabled () && !coop_aware_thread)
 				return MONO_THREAD_BEGIN_SUSPEND_NEXT_PHASE;
 			else {
-				g_assert (mono_threads_is_cooperative_suspension_enabled ());
+				g_assert (thread_is_cooperative_suspend_aware (info));
 				return MONO_THREAD_BEGIN_SUSPEND_SUSPENDED;
 			}
 		case BeginSuspendOkPreemptive:
@@ -1120,7 +1136,7 @@ begin_suspend_peek_and_preempt (MonoThreadInfo *info)
 		// in full cooperative mode just leave BLOCKING
 		// threads running until they try to return to RUNNING, so
 		// nothing to do, in hybrid coop preempt the thread.
-		switch (begin_suspend_for_blocking_thread (info, FALSE, MONO_THREAD_SUSPEND_PHASE_MOPUP, NULL)) {
+		switch (begin_suspend_for_blocking_thread (info, FALSE, MONO_THREAD_SUSPEND_PHASE_MOPUP, FALSE, NULL)) {
 		case BeginSuspendFail:
 			return MONO_THREAD_BEGIN_SUSPEND_SKIP;
 		case BeginSuspendOkNoWait:
@@ -1253,7 +1269,7 @@ suspend_sync (MonoNativeThreadId tid, gboolean interrupt_kernel)
 		return info;
 	case ReqSuspendInitSuspendBlocking: {
 		gboolean did_interrupt = FALSE;
-		suspend_result = begin_suspend_for_blocking_thread (info, interrupt_kernel, MONO_THREAD_SUSPEND_PHASE_MOPUP, &did_interrupt);
+		suspend_result = begin_suspend_for_blocking_thread (info, interrupt_kernel, MONO_THREAD_SUSPEND_PHASE_MOPUP, FALSE, &did_interrupt);
 		if (suspend_result == BeginSuspendFail) {
 			mono_hazard_pointer_clear (hp, 1);
 			return NULL;
@@ -1448,10 +1464,10 @@ mono_thread_info_get_suspend_state (MonoThreadInfo *info)
 	case STATE_BLOCKING_SELF_SUSPENDED:
 		return &info->thread_saved_state [SELF_SUSPEND_STATE_INDEX];
 	case STATE_BLOCKING_SUSPEND_REQUESTED:
-		// This state is only valid for full cooperative suspend.  If
-		// we're preemptively suspending blocking threads, this is not
-		// a valid suspend state.
-		if (mono_threads_is_cooperative_suspension_enabled () && !mono_threads_is_hybrid_suspension_enabled ())
+		// This state is only valid for full cooperative suspend or cooparative suspend
+		// aware threads. If we're preemptively suspending blocking threads,
+		// this is not a valid suspend state.
+		if ((mono_threads_is_cooperative_suspension_enabled () && !mono_threads_is_hybrid_suspension_enabled ()) || thread_is_cooperative_suspend_aware (info))
 			return &info->thread_saved_state [SELF_SUSPEND_STATE_INDEX];
 		break;
 	default:

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -272,6 +272,15 @@ typedef struct _MonoThreadInfo {
 	gpointer win32_apc_info_io_handle;
 #endif
 
+	/* When running hybrid suspend mode, a thread can explicitly flag */
+	/* itself to be cooperative suspend aware. If it does, it won't */
+	/* be preemptive suspended, so will behave as a cooperative suspended */
+	/* thread, continue to run when in safe mode. NOTE, threads setting */
+	/* this flag needs to correctly follow cooperative suspend rules. */
+	/* Flag can only be toggled for hybrid/cooperative suspend mode */
+	/* and is a onetime switch, FALSE -> TRUE. */
+	gboolean coop_aware_thread;
+
 	/*
 	 * This is where we store tools tls data so it follows our lifecycle and doesn't depends on posix tls cleanup ordering
 	 *

--- a/winconfig.h
+++ b/winconfig.h
@@ -37,7 +37,7 @@
 
 #if defined(ENABLE_HYBRID_SUSPEND)
 /* Windows MSVC builds defaults to preemptive suspend. Disable ENABLE_HYBRID_SUSPEND defines. */
-//#undef ENABLE_HYBRID_SUSPEND
+#undef ENABLE_HYBRID_SUSPEND
 #endif
 
 /* No ENABLE_DEFINES below this point */

--- a/winconfig.h
+++ b/winconfig.h
@@ -37,7 +37,7 @@
 
 #if defined(ENABLE_HYBRID_SUSPEND)
 /* Windows MSVC builds defaults to preemptive suspend. Disable ENABLE_HYBRID_SUSPEND defines. */
-#undef ENABLE_HYBRID_SUSPEND
+//#undef ENABLE_HYBRID_SUSPEND
 #endif
 
 /* No ENABLE_DEFINES below this point */


### PR DESCRIPTION
When running in hybrid suspend and having threads in blocking mode, GC Safe mode, threads will still be preemptive suspended. This is done to make sure compatibility is kept with embedders since current embedding API is not coop aware. If, however the external attached threads promise to follow the coop
rules for a thread in Safe mode, it could still be possible to have them running, making sure they won't be preempted when running STW. Unlocking this possibility could have large performance wins if embedding threads runs a lot of unrelated native code on threads attached to runtime (game engines as an example).

This commit adds support for a new pair of API's where an external thread can mark itself as cooperative suspend aware. Doing that guarantees the runtime that it will follow all rules as dictated by cooperative suspend when a thread is in safe mode. The change only goes one way since this is a lifetime commitment for a thread. Once’s set, thread will be kept running when in safe mode.
