### PR TITLE
[2019-06] [arm] use target_mgreg_t instead of plain pointer type in sdb breakpoint

### DIFF
--- a/mono/mini/mini-arm.c
+++ b/mono/mini/mini-arm.c
@@ -4663,7 +4663,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				var = info_var;
 				code = emit_ldr_imm (code, dreg, var->inst_basereg, var->inst_offset);
 				/* Add the offset */
-				val = ((offset / 4) * sizeof (guint8*)) + MONO_STRUCT_OFFSET (SeqPointInfo, bp_addrs);
+				val = ((offset / 4) * sizeof (target_mgreg_t)) + MONO_STRUCT_OFFSET (SeqPointInfo, bp_addrs);
 				/* Load the info->bp_addrs [offset], which is either 0 or the address of a trigger page */
 				if (arm_is_imm12 ((int)val)) {
 					ARM_LDR_IMM (code, dreg, dreg, val);


### PR DESCRIPTION
Fixes Debug mode for iOS 32bit.

Contributes to https://github.com/mono/mono/issues/15058 & https://github.com/mono/mono/issues/9621

Diff before (left old cross32, right new cross32 running on amd64 host _before_ this fix):
<img width="1257" alt="Screenshot 2019-06-17 at 14 09 51" src="https://user-images.githubusercontent.com/75403/59603413-a9bd4f00-9109-11e9-8f18-aa7b4ca5817f.png">

/cc @mandel-macaque 

Backport of #15205.

/cc @lewurm 