### PR TITLE
Encode "&" symbols in script for xml reading

### DIFF
--- a/mcs/class/System.Web.Extensions/System.Web.UI/ScriptManager.cs
+++ b/mcs/class/System.Web.Extensions/System.Web.UI/ScriptManager.cs
@@ -1450,7 +1450,8 @@ namespace System.Web.UI
 
 		static string SerializeScriptBlock (RegisteredScript scriptEntry) {
 			try {
-				XmlTextReader reader = new XmlTextReader (new StringReader (scriptEntry.Script));
+				string encodedScript = scriptEntry.Script.Replace ("&", "&#038;");
+				XmlTextReader reader = new XmlTextReader (new StringReader (encodedScript));
 				while (reader.Read ()) {
 					switch (reader.NodeType) {
 					case XmlNodeType.Element:


### PR DESCRIPTION
This allows to properly read "&" symbols in a script (more specifically, in a url, which is inside a script "src" attribute).



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
