### PR TITLE
[System]: Allow reading fully buffered `HttpWebResponse` body after close.  #10645.

### DIFF
--- a/mcs/class/System/System.Net/WebRequestStream.cs
+++ b/mcs/class/System/System.Net/WebRequestStream.cs
@@ -406,6 +406,8 @@ namespace System.Net
 			return Task.FromException<int> (new NotSupportedException (SR.net_writeonlystream));
 		}
 
+		protected override bool TryReadFromBufferedContent (byte[] buffer, int offset, int count, out int result) => throw new InvalidOperationException ();
+
 		protected override void Close_internal (ref bool disposed)
 		{
 			WebConnection.Debug ($"{ME} CLOSE: {disposed} {requestWritten} {allowBuffering}");

--- a/mcs/class/System/System.Net/WebResponseStream.cs
+++ b/mcs/class/System/System.Net/WebResponseStream.cs
@@ -184,6 +184,15 @@ namespace System.Net
 				}, () => Operation.Aborted, cancellationToken);
 		}
 
+		protected override bool TryReadFromBufferedContent (byte[] buffer, int offset, int count, out int result)
+		{
+			if (bufferedEntireContent && innerStream is BufferedReadStream bufferedStream)
+				return bufferedStream.TryReadFromBuffer (buffer, offset, count, out result);
+
+			result = 0;
+			return false;
+		}
+
 		bool CheckAuthHeader (string headerName)
 		{
 			var authHeader = Headers[headerName];
@@ -372,6 +381,7 @@ namespace System.Net
 				var buffer = await ReadAllAsyncInner (cancellationToken).ConfigureAwait (false);
 				var bos = new BufferOffsetSize (buffer, 0, buffer.Length, false);
 				innerStream = new BufferedReadStream (Operation, null, bos);
+				bufferedEntireContent = true;
 
 				nextReadCalled = true;
 				completion.TrySetCompleted ();


### PR DESCRIPTION
[System]: Allow reading fully buffered `HttpWebResponse` body after close.

If we have already read the entire response body, then we should allow the
user to read it even after the request has been aborted.

* `WebConnectionStream.Read ()`: Move `Operation.ThrowIfClosedOrDisposed ()`
   call down after argument checks and call a new protected abstract method
   called `TryReadFromBufferedContent ()` prior to it.

* `WebResponseStream.TryReadFromBufferedContent ()`: Implement it here.
  If the entire response body has been buffered, then `bufferedEntireContent`
  is true and `innerStream is BufferedReadStream` and we can call the new
  `BufferedReadStream.TryReadFromBuffer ()`.

* `WebResponseStream.ReadAllAsync ()`: Set `bufferedEntireContent = true`
   after reading the entire response body.

* `BufferedReadStream.TryReadFromBuffer ()`: New internal method.

Fixes #10645.