### PR TITLE
Increase timeout for interpreter fullaotmixed regression.

### DIFF
--- a/scripts/ci/run-test-interpreter.sh
+++ b/scripts/ci/run-test-interpreter.sh
@@ -5,7 +5,7 @@ export TEST_WITH_INTERPRETER=1
 
 ${TESTCMD} --label=interpreter-regression --timeout=10m make -C mono/mini richeck
 ${TESTCMD} --label=mixedmode-regression --timeout=10m make -C mono/mini mixedcheck
-${TESTCMD} --label=fullaotmixed-regression --timeout=10m make -C mono/mini fullaotmixedcheck
+${TESTCMD} --label=fullaotmixed-regression --timeout=20m make -C mono/mini fullaotmixedcheck
 ${TESTCMD} --label=compile-runtime-tests --timeout=40m make -w -C mono/tests -j ${CI_CPU_COUNT} test
 ${TESTCMD} --label=runtime-interp --timeout=160m make -w -C mono/tests -k testinterp V=1
 ${TESTCMD} --label=corlib --timeout=160m make -w -C mcs/class/corlib run-test V=1


### PR DESCRIPTION
On Windows (partly due to slow shell execution) this test take longer to
complete than current given timeout.

https://jenkins.mono-project.com/job/z3/
