### PR TITLE
Change MONO_PATCH_INFO_GET_TLS_TRAMP to MONO_PATCH_INFO_JIT_ICALL_ADDR_NOCALL.

### DIFF
--- a/mono/metadata/jit-icall-reg.h
+++ b/mono/metadata/jit-icall-reg.h
@@ -47,12 +47,12 @@ MONO_JIT_ICALL (generic_trampoline_delegate)	\
 MONO_JIT_ICALL (generic_trampoline_generic_virtual_remoting)	\
 MONO_JIT_ICALL (generic_trampoline_vcall)	\
 	\
-/* These must be ordered like MonoTlsKey. */ \
-MONO_JIT_ICALL (mono_tls_get_thread) \
-MONO_JIT_ICALL (mono_tls_get_jit_tls) \
+/* These must be ordered like MonoTlsKey (alphabetical). */ \
 MONO_JIT_ICALL (mono_tls_get_domain) \
-MONO_JIT_ICALL (mono_tls_get_sgen_thread_info) \
+MONO_JIT_ICALL (mono_tls_get_jit_tls) \
 MONO_JIT_ICALL (mono_tls_get_lmf_addr) \
+MONO_JIT_ICALL (mono_tls_get_sgen_thread_info) \
+MONO_JIT_ICALL (mono_tls_get_thread) \
 	\
 MONO_JIT_ICALL (__emul_fadd)	\
 MONO_JIT_ICALL (__emul_fcmp_ceq)	\

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -6481,7 +6481,6 @@ encode_patch (MonoAotCompile *acfg, MonoJumpInfo *patch_info, guint8 *buf, guint
 		encode_method_ref (acfg, patch_info->data.method, p, &p);
 		break;
 	case MONO_PATCH_INFO_AOT_JIT_INFO:
-	case MONO_PATCH_INFO_GET_TLS_TRAMP:
 	case MONO_PATCH_INFO_CASTCLASS_CACHE:
 		encode_value (patch_info->data.index, p, &p);
 		break;
@@ -6625,8 +6624,7 @@ encode_patch (MonoAotCompile *acfg, MonoJumpInfo *patch_info, guint8 *buf, guint
 	case MONO_PATCH_INFO_GC_SAFE_POINT_FLAG:
 		break;
 	default:
-		g_warning ("unable to handle jump info %d", patch_info->type);
-		g_assert_not_reached ();
+		g_error ("unable to handle jump info %d", patch_info->type);
 	}
 
 	*endbuf = p;
@@ -12898,8 +12896,8 @@ add_preinit_got_slots (MonoAotCompile *acfg)
 	if (!acfg->aot_opts.llvm_only) {
 		for (i = 0; i < TLS_KEY_NUM; i++) {
 			ji = (MonoJumpInfo *)mono_mempool_alloc0 (acfg->mempool, sizeof (MonoJumpInfo));
-			ji->type = MONO_PATCH_INFO_GET_TLS_TRAMP;
-			ji->data.index = i;
+			ji->type = MONO_PATCH_INFO_JIT_ICALL_ADDR_NOCALL;
+			ji->data.jit_icall_id = mono_get_tls_key_to_jit_icall_id (i);
 			add_preinit_slot (acfg, ji);
 		}
 	}

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -3992,7 +3992,6 @@ decode_patch (MonoAotModule *aot_module, MonoMemPool *mp, MonoJumpInfo *ji, guin
 	}
 	case MONO_PATCH_INFO_GC_SAFE_POINT_FLAG:
 		break;
-	case MONO_PATCH_INFO_GET_TLS_TRAMP:
 	case MONO_PATCH_INFO_AOT_JIT_INFO:
 		ji->data.index = decode_value (p, &p);
 		break;

--- a/mono/mini/aot-runtime.h
+++ b/mono/mini/aot-runtime.h
@@ -11,7 +11,7 @@
 #include "mini.h"
 
 /* Version number of the AOT file format */
-#define MONO_AOT_FILE_VERSION 165
+#define MONO_AOT_FILE_VERSION 166
 
 #define MONO_AOT_TRAMP_PAGE_SIZE 16384
 

--- a/mono/mini/interp/transform.c
+++ b/mono/mini/interp/transform.c
@@ -5283,13 +5283,13 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 					td->ip += 5;
 
 					CHECK_STACK (td, info->sig->param_count);
-					if (!strcmp (info->name, "mono_threads_attach_coop")) {
+					if (jit_icall_id == MONO_JIT_ICALL_mono_threads_attach_coop) {
 						rtm->needs_thread_attach = 1;
 
 						/* attach needs two arguments, and has one return value: leave one element on the stack */
 						interp_add_ins (td, MINT_POP);
 						td->last_ins->data [0] = 0;
-					} else if (!strcmp (info->name, "mono_threads_detach_coop")) {
+					} else if (jit_icall_id == MONO_JIT_ICALL_mono_threads_detach_coop) {
 						g_assert (rtm->needs_thread_attach);
 
 						/* detach consumes two arguments, and no return value: drop both of them */

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -1218,7 +1218,6 @@ mono_patch_info_hash (gconstpointer data)
 	case MONO_PATCH_INFO_SIGNATURE:
 	case MONO_PATCH_INFO_METHOD_CODE_SLOT:
 	case MONO_PATCH_INFO_AOT_JIT_INFO:
-	case MONO_PATCH_INFO_GET_TLS_TRAMP:
 		return hash | (gssize)ji->data.target;
 	case MONO_PATCH_INFO_GSHAREDVT_CALL:
 		return hash | (gssize)ji->data.gsharedvt->method;
@@ -1642,9 +1641,6 @@ mono_resolve_patch_target (MonoMethod *method, MonoDomain *domain, guint8 *code,
 	}
 	case MONO_PATCH_INFO_GSHAREDVT_IN_WRAPPER:
 		target = mini_get_gsharedvt_wrapper (TRUE, NULL, patch_info->data.sig, NULL, -1, FALSE);
-		break;
-	case MONO_PATCH_INFO_GET_TLS_TRAMP: // FIXME replace with MONO_PATCH_INFO_JIT_ICALL?
-		target = (gpointer)mono_tls_get_tls_getter ((MonoTlsKey)patch_info->data.index);
 		break;
 	case MONO_PATCH_INFO_PROFILER_ALLOCATION_COUNT: {
 		target = (gpointer) &mono_profiler_state.gc_allocation_count;

--- a/mono/mini/patch-info.h
+++ b/mono/mini/patch-info.h
@@ -54,7 +54,6 @@ PATCH_INFO(AOT_JIT_INFO, "aot_jit_info")
 PATCH_INFO(GC_NURSERY_BITS, "gc_nursery_bits")
 PATCH_INFO(GSHAREDVT_IN_WRAPPER, "gsharedvt_in_wrapper")
 PATCH_INFO(ICALL_ADDR_CALL, "icall_addr_call")
-PATCH_INFO(GET_TLS_TRAMP, "get_tls_tramp")
 /*
  * The address of a C function implementing a JIT icall.
  * Same as JIT_ICALL_ADDR, but not treated as a call.

--- a/mono/utils/mono-tls.c
+++ b/mono/utils/mono-tls.c
@@ -272,29 +272,6 @@ mono_tls_get_tls_offset (MonoTlsKey key)
 	return tls_offsets [key];
 }
 
-/*
- * Returns the getter (gpointer (*)(void)) for the mono tls key.
- * Managed code will always get the value by calling this getter.
- */
-MonoTlsGetter
-mono_tls_get_tls_getter (MonoTlsKey key)
-{
-	switch (key) {
-	case TLS_KEY_THREAD:
-		return (MonoTlsGetter)mono_tls_get_thread;
-	case TLS_KEY_JIT_TLS:
-		return (MonoTlsGetter)mono_tls_get_jit_tls;
-	case TLS_KEY_DOMAIN:
-		return (MonoTlsGetter)mono_tls_get_domain;
-	case TLS_KEY_SGEN_THREAD_INFO:
-		return (MonoTlsGetter)mono_tls_get_sgen_thread_info;
-	case TLS_KEY_LMF_ADDR:
-		return (MonoTlsGetter)mono_tls_get_lmf_addr;
-	}
-	g_assert_not_reached ();
-	return NULL;
-}
-
 // Casts on getters are for the !MONO_KEYWORD_THREAD case.
 
 /* Getters for each tls key */

--- a/mono/utils/mono-tls.h
+++ b/mono/utils/mono-tls.h
@@ -89,10 +89,6 @@ void mono_tls_init_runtime_keys (void);
 void mono_tls_free_keys (void);
 gint32 mono_tls_get_tls_offset (MonoTlsKey key);
 
-typedef gpointer (*MonoTlsGetter)(void);
-
-MonoTlsGetter mono_tls_get_tls_getter (MonoTlsKey key);
-
 G_EXTERN_C MonoInternalThread *mono_tls_get_thread (void);
 G_EXTERN_C MonoJitTlsData     *mono_tls_get_jit_tls (void);
 G_EXTERN_C MonoDomain *mono_tls_get_domain (void);

--- a/mono/utils/mono-tls.h
+++ b/mono/utils/mono-tls.h
@@ -18,17 +18,21 @@
 #include <mono/utils/mono-forward-internal.h>
 
 /* TLS entries used by the runtime */
-// This ordering is mimiced in MONO_JIT_ICALLS and will be in mono_create_tls_get.
+// This ordering is mimiced in MONO_JIT_ICALLS (alphabetical).
 typedef enum {
-	/* mono_thread_internal_current () */
-	TLS_KEY_THREAD = 0,
-	TLS_KEY_JIT_TLS = 1,
-	/* mono_domain_get () */
-	TLS_KEY_DOMAIN = 2,
+	TLS_KEY_DOMAIN		 = 0, // mono_domain_get ()
+	TLS_KEY_JIT_TLS		 = 1,
+	TLS_KEY_LMF_ADDR	 = 2,
 	TLS_KEY_SGEN_THREAD_INFO = 3,
-	TLS_KEY_LMF_ADDR = 4,
-	TLS_KEY_NUM = 5
+	TLS_KEY_THREAD		 = 4, // mono_thread_internal_current ()
+	TLS_KEY_NUM		 = 5
 } MonoTlsKey;
+
+#if __cplusplus
+g_static_assert (TLS_KEY_DOMAIN == 0);
+#endif
+// There are only JIT icalls to get TLS, not set TLS.
+#define mono_get_tls_key_to_jit_icall_id(a)	((MonoJitICallId)((a) + MONO_JIT_ICALL_mono_tls_get_domain))
 
 #ifdef HOST_WIN32
 
@@ -95,10 +99,10 @@ G_EXTERN_C MonoDomain *mono_tls_get_domain (void);
 G_EXTERN_C SgenThreadInfo     *mono_tls_get_sgen_thread_info (void);
 G_EXTERN_C MonoLMF           **mono_tls_get_lmf_addr (void);
 
-G_EXTERN_C void mono_tls_set_thread 	   (MonoInternalThread *value);
-G_EXTERN_C void mono_tls_set_jit_tls 	   (MonoJitTlsData     *value);
-G_EXTERN_C void mono_tls_set_domain 	   (MonoDomain         *value);
-G_EXTERN_C void mono_tls_set_sgen_thread_info (SgenThreadInfo     *value);
-G_EXTERN_C void mono_tls_set_lmf_addr 	   (MonoLMF           **value);
+void mono_tls_set_thread 	   (MonoInternalThread *value);
+void mono_tls_set_jit_tls 	   (MonoJitTlsData     *value);
+void mono_tls_set_domain 	   (MonoDomain         *value);
+void mono_tls_set_sgen_thread_info (SgenThreadInfo     *value);
+void mono_tls_set_lmf_addr 	   (MonoLMF           **value);
 
 #endif /* __MONO_TLS_H__ */


### PR DESCRIPTION
The goal being fewer patch types for slight simplicity and efficiency.
There are still plenty of patch types to reason over however.

It was structured like this before, presumably, either because:
1. MONO_PATCH_INFO_JIT_ICALL_ADDR_NOCALL was string-based instead of enum-based or
2. NOCALL variant did not exist.
3. Perhaps the "enum overlay" is considered inelegant but I think it is ok. It was only possible before by parsing integers out of the strings, which other icalls did do (but no longer). Now that it is free of string parsing, I think it is ok.