### PR TITLE
[2019-02] [runtime] Don't do GC Unsafe transition in mono_gchandle_free

### DIFF
--- a/mono/metadata/external-only.c
+++ b/mono/metadata/external-only.c
@@ -92,7 +92,12 @@ mono_gchandle_get_target (uint32_t gchandle)
 void
 mono_gchandle_free (uint32_t gchandle)
 {
-	MONO_EXTERNAL_ONLY_GC_UNSAFE_VOID (mono_gchandle_free_internal (gchandle));
+	/* Xamarin.Mac and Xamarin.iOS can call this from a worker thread
+	 * that's not attached to the runtime. This is okay for SGen because
+	 * the gchandle code is lockfree.  SGen calls back into Mono which
+	 * fires a profiler event, so the profiler must be prepared to be
+	 * called from threads that aren't attached to Mono. */
+	MONO_EXTERNAL_ONLY_VOID (mono_gchandle_free_internal (gchandle));
 }
 
 /* GC write barriers support */

--- a/mono/profiler/log.c
+++ b/mono/profiler/log.c
@@ -43,6 +43,7 @@
 #include <mono/utils/mono-os-semaphore.h>
 #include <mono/utils/mono-threads.h>
 #include <mono/utils/mono-threads-api.h>
+#include <mono/utils/mono-threads-coop.h>
 #include <mono/utils/mono-error-internals.h>
 #include <mono/utils/os-event.h>
 #include "log.h"
@@ -603,6 +604,8 @@ ensure_logbuf_unsafe (MonoProfilerThread *thread, int bytes)
  *
  * The lock does not support recursion.
  */
+static void
+buffer_lock_helper (void);
 
 static void
 buffer_lock (void)
@@ -618,31 +621,48 @@ buffer_lock (void)
 	 * is about to stop.
 	 */
 	if (mono_atomic_load_i32 (&log_profiler.buffer_lock_state) != get_thread ()->small_id << 16) {
-		MONO_ENTER_GC_SAFE;
+		/* We can get some sgen events (for example gc_handle_deleted)
+		 * from threads that are unattached to the runtime (but that
+		 * are attached to the profiler).  In that case, avoid mono
+		 * thread state transition to GC Safe around the loop, since
+		 * the thread won't be participating in Mono's suspension
+		 * mechianism anyway.
+		 */
+		MonoThreadInfo *info = mono_thread_info_current_unchecked ();
+		if (info) {
+			MONO_ENTER_GC_SAFE_WITH_INFO (info);
 
-		gint32 old, new_;
+			buffer_lock_helper ();
 
-		do {
-		restart:
-			// Hold off if a thread wants to take the exclusive lock.
-			while (mono_atomic_load_i32 (&log_profiler.buffer_lock_exclusive_intent))
-				mono_thread_info_yield ();
-
-			old = mono_atomic_load_i32 (&log_profiler.buffer_lock_state);
-
-			// Is a thread holding the exclusive lock?
-			if (old >> 16) {
-				mono_thread_info_yield ();
-				goto restart;
-			}
-
-			new_ = old + 1;
-		} while (mono_atomic_cas_i32 (&log_profiler.buffer_lock_state, new_, old) != old);
-
-		MONO_EXIT_GC_SAFE;
+			MONO_EXIT_GC_SAFE_WITH_INFO;
+		} else
+			buffer_lock_helper ();
 	}
 
 	mono_memory_barrier ();
+}
+
+static void
+buffer_lock_helper (void)
+{
+	gint32 old, new_;
+
+	do {
+	restart:
+		// Hold off if a thread wants to take the exclusive lock.
+		while (mono_atomic_load_i32 (&log_profiler.buffer_lock_exclusive_intent))
+			mono_thread_info_yield ();
+
+		old = mono_atomic_load_i32 (&log_profiler.buffer_lock_state);
+
+		// Is a thread holding the exclusive lock?
+		if (old >> 16) {
+			mono_thread_info_yield ();
+			goto restart;
+		}
+
+		new_ = old + 1;
+	} while (mono_atomic_cas_i32 (&log_profiler.buffer_lock_state, new_, old) != old);
 }
 
 static void

--- a/mono/utils/mono-threads-coop.h
+++ b/mono/utils/mono-threads-coop.h
@@ -116,11 +116,7 @@ void mono_threads_suspend_override_policy (MonoThreadsSuspendPolicy new_policy);
  * runtime assertion error when trying to switch the state of the current thread.
  */
 
-G_EXTERN_C // due to THREAD_INFO_TYPE varying
-gpointer
-mono_threads_enter_gc_safe_region_with_info (THREAD_INFO_TYPE *info, MonoStackData *stackdata);
-
-G_EXTERN_C // due to THREAD_INFO_TYPE varying
+MONO_PROFILER_API
 gpointer
 mono_threads_enter_gc_safe_region_with_info (THREAD_INFO_TYPE *info, MonoStackData *stackdata);
 

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -432,7 +432,7 @@ MONO_API void*
 mono_thread_info_get_tools_data (void);
 
 
-THREAD_INFO_TYPE*
+MONO_PROFILER_API THREAD_INFO_TYPE*
 mono_thread_info_current_unchecked (void);
 
 MONO_API int


### PR DESCRIPTION
Revert one part of #14979  - `mono_gchandle_free` can be called by Xamarin.Mac form [`xamarin_dispose_helper`](https://github.com/xamarin/xamarin-macios/blob/7f4a1db36fa0544020b73deefbac0ed0b1d5f0c8/runtime/shared.m#L244) which can run on a thread that's not attached to the runtime.

This is fine for SGen since the gchandle code is lockfree.

SGen also calls back into Mono, which fires a profiler event.  The profiler has its own mechanism for tracking threads, but in `buffer_lock()` we need to make sure that we don't do the Mono thread state transitions if the thread is attached to the profiler but not to Mono.

Follow-up PR for https://github.com/mono/mono/issues/14975

Backport of #15214.

/cc @lambdageek 