### PR TITLE
[2019-06] [runtime] Don't do GC Unsafe transition in mono_gchandle_free

### DIFF
--- a/mono/metadata/external-only.c
+++ b/mono/metadata/external-only.c
@@ -95,7 +95,12 @@ mono_gchandle_get_target (uint32_t gchandle)
 void
 mono_gchandle_free (uint32_t gchandle)
 {
-	MONO_EXTERNAL_ONLY_GC_UNSAFE_VOID (mono_gchandle_free_internal (gchandle));
+	/* Xamarin.Mac and Xamarin.iOS can call this from a worker thread
+	 * that's not attached to the runtime. This is okay for SGen because
+	 * the gchandle code is lockfree.  SGen calls back into Mono which
+	 * fires a profiler event, so the profiler must be prepared to be
+	 * called from threads that aren't attached to Mono. */
+	MONO_EXTERNAL_ONLY_VOID (mono_gchandle_free_internal (gchandle));
 }
 
 /* GC write barriers support */

--- a/mono/utils/mono-threads-coop.h
+++ b/mono/utils/mono-threads-coop.h
@@ -116,11 +116,7 @@ void mono_threads_suspend_override_policy (MonoThreadsSuspendPolicy new_policy);
  * runtime assertion error when trying to switch the state of the current thread.
  */
 
-G_EXTERN_C // due to THREAD_INFO_TYPE varying
-gpointer
-mono_threads_enter_gc_safe_region_with_info (THREAD_INFO_TYPE *info, MonoStackData *stackdata);
-
-G_EXTERN_C // due to THREAD_INFO_TYPE varying
+MONO_PROFILER_API
 gpointer
 mono_threads_enter_gc_safe_region_with_info (THREAD_INFO_TYPE *info, MonoStackData *stackdata);
 

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -432,7 +432,7 @@ MONO_API void*
 mono_thread_info_get_tools_data (void);
 
 
-THREAD_INFO_TYPE*
+MONO_PROFILER_API THREAD_INFO_TYPE*
 mono_thread_info_current_unchecked (void);
 
 MONO_API int


### PR DESCRIPTION
Revert one part of #14979  - `mono_gchandle_free` can be called by Xamarin.Mac form [`xamarin_dispose_helper`](https://github.com/xamarin/xamarin-macios/blob/7f4a1db36fa0544020b73deefbac0ed0b1d5f0c8/runtime/shared.m#L244) which can run on a thread that's not attached to the runtime.

This is fine for SGen since the gchandle code is lockfree.

SGen also calls back into Mono, which fires a profiler event.  The profiler has its own mechanism for tracking threads, but in `buffer_lock()` we need to make sure that we don't do the Mono thread state transitions if the thread is attached to the profiler but not to Mono.

Follow-up PR for https://github.com/mono/mono/issues/14975

Backport of #15214.

/cc @lambdageek 