### PR TITLE
[2019-02] Improve robustness of post-install script

### DIFF
--- a/packaging/MacSDK/packaging/resources/postinstall
+++ b/packaging/MacSDK/packaging/resources/postinstall
@@ -61,15 +61,15 @@ if [ -d ${FW_CURRENT} ]; then
     # Make sure we run the files we lay down, and not other stuff installed on the system
     export PATH="${FW_CURRENT}/bin:$PATH"
     # gtk+ setup
-    gdk-pixbuf-query-loaders --update-cache
+    gdk-pixbuf-query-loaders --update-cache > "${FW_CURRENT}/postinstall-gdk-pixbuf-query-loaders.log" 2>&1 || true
     # pango setup
     mkdir -p pango
-    pango-querymodules >  pango/pango.modules
-    pango-querymodules --update-cache
-    fc-cache
+    pango-querymodules > pango/pango.modules 2> "${FW_CURRENT}/postinstall-pango-querymodules.log" || true
+    pango-querymodules --update-cache >> "${FW_CURRENT}/postinstall-pango-querymodules.log" 2>&1 || true
+    fc-cache > "${FW_CURRENT}/postinstall-fc-cache.log" 2>&1 || true
 
     cd ${FW_CURRENT}/lib/gtk-2.0/2.10.0
-    gtk-query-immodules-2.0 > immodules.cache
+    gtk-query-immodules-2.0 > immodules.cache 2> "${FW_CURRENT}/gtk-query-immodules-2.0.log" || true
 fi
 
 # Delete older Monos


### PR DESCRIPTION
We have several issues (e.g. https://github.com/mono/mono/issues/14181) where the installer occasionally fails in the postinstall script for unknown causes, on some hosts.

This seems to be sometimes the culpable section and this patch should help trace the issue or alleviate the common symptoms of it (see https://github.com/mono/mono/issues/14181)

Backport of #15213.

/cc @alexischr 