### PR TITLE
Interpreter PR builds run too many test suites.

### DIFF
--- a/scripts/ci/run-test-interpreter.sh
+++ b/scripts/ci/run-test-interpreter.sh
@@ -14,7 +14,21 @@ ${TESTCMD} --label=System.Core --timeout=160m make -w -C mcs/class/System.Core r
 ${TESTCMD} --label=mcs-tests --timeout=160m make -w -C mcs/tests run-test V=1;
 ${TESTCMD} --label=Mono.Debugger.Soft --timeout=5m make -w -C mcs/class/Mono.Debugger.Soft run-test V=1
 
-if [[ ${CI_TAGS} != *'pull-request'* ]] || [[ ${CI_TAGS} != *'arm'* ]]; then
+run_full_test_suite=1
+
+# Don't run full interpreter test suite on arm architectures during PR builds.
+# NOTE, full test suite will still be run on none PR builds.
+if [[ ${CI_TAGS} == *'pull-request'* ]] && [[ ${CI_TAGS} == *'arm'* ]]; then
+	run_full_test_suite=0
+fi
+
+# Don't run full interpreter test suite on Windows during PR builds.
+# NOTE, full test suite will still be run on none PR builds.
+if [[ ${CI_TAGS} == *'pull-request'* ]] && [[ ${CI_TAGS} == *'win-'* ]]; then
+	run_full_test_suite=0
+fi
+
+if [[ "$run_full_test_suite" -eq "1" ]]; then
 
 	${TESTCMD} --label=corlib-xunit --timeout=60m make -w -C mcs/class/corlib run-xunit-test
 	${TESTCMD} --label=System.XML --timeout=5m make -w -C mcs/class/System.XML run-test V=1


### PR DESCRIPTION
Fix makes sure we don't run full test suite on PR builds or when targeting arm architectures. Current implementation will always run full test suite on PR builds for Windows and Linux. Full test suites will be run on master CI builds for none arm architectures.
