### PR TITLE
Zero threadpool updates before broadcast.

### DIFF
--- a/mono/metadata/threadpool-io.c
+++ b/mono/metadata/threadpool-io.c
@@ -440,7 +440,7 @@ selector_thread (gpointer data)
 
 		if (threadpool_io->updates_size > 0) {
 			threadpool_io->updates_size = 0;
-			memset (&threadpool_io->updates, 0, UPDATES_CAPACITY * sizeof (ThreadPoolIOUpdate));
+			memset (&threadpool_io->updates, 0, sizeof (threadpool_io->updates));
 		}
 
 		mono_coop_cond_broadcast (&threadpool_io->updates_cond);

--- a/mono/metadata/threadpool-io.c
+++ b/mono/metadata/threadpool-io.c
@@ -438,12 +438,12 @@ selector_thread (gpointer data)
 			}
 		}
 
-		mono_coop_cond_broadcast (&threadpool_io->updates_cond);
-
 		if (threadpool_io->updates_size > 0) {
 			threadpool_io->updates_size = 0;
 			memset (&threadpool_io->updates, 0, UPDATES_CAPACITY * sizeof (ThreadPoolIOUpdate));
 		}
+
+		mono_coop_cond_broadcast (&threadpool_io->updates_cond);
 
 		mono_coop_mutex_unlock (&threadpool_io->updates_lock);
 


### PR DESCRIPTION
This *seems* better, not sure it fixes anything.
It *seems* important, if the queue actually fills up.
Would the producers hang, or something else wake them?