### PR TITLE
[wasm][bindings] Make sure that bindings are initialized in `mono_wasm_new`.

### DIFF
--- a/sdks/wasm/binding_support.js
+++ b/sdks/wasm/binding_support.js
@@ -1140,7 +1140,8 @@ var BindingSupportLib = {
 		return gc_handle;
 	},
 	mono_wasm_new: function (core_name, args, is_exception) {
-		
+		BINDING.bindings_lazy_init ();
+
 		var js_name = BINDING.conv_string (core_name);
 
 		if (!js_name) {


### PR DESCRIPTION
- Fixes `this.mono_string_get_utf8 is not a function`.

Closes https://github.com/mono/mono/issues/15273

Possibly this issue as well https://github.com/mono/mono/issues/14582 as it looks like the same error.