### PR TITLE
[netcore] Fix missing nuget feeds

### DIFF
--- a/netcore/Directory.Build.props
+++ b/netcore/Directory.Build.props
@@ -15,6 +15,16 @@
     <IsSourceProject>$([System.Text.RegularExpressions.Regex]::IsMatch($(MSBuildProjectDirectory), 'src%24'))</IsSourceProject>
   </PropertyGroup>
   
+  <PropertyGroup>
+    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
+      https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
+      https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json;
+      https://api.nuget.org/v3/index.json;
+      $(OverridePackageSource);
+      $(RestoreSources)
+    </RestoreSources>
+  </PropertyGroup>
+
   <!-- Informs build tools to apply .NET Framework metadata if not a test project -->
   <PropertyGroup>
     <IsDotNetFrameworkProductAssembly>true</IsDotNetFrameworkProductAssembly>

--- a/netcore/corefx-restore.csproj
+++ b/netcore/corefx-restore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp30</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <EnableDefaultItems>false</EnableDefaultItems>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/netcore/roslyn-restore.csproj
+++ b/netcore/roslyn-restore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <EnableDefaultItems>false</EnableDefaultItems>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>


### PR DESCRIPTION
I couldn't build netcore from master and it turned out it ignored list of feeds in nuget.config. 
@ViktorHofer helped to figure out why.