### PR TITLE
Fix race related to final event signaling in RegisteredWaitHandle.

### DIFF
--- a/mcs/class/corlib/System.Threading/RegisteredWaitHandle.cs
+++ b/mcs/class/corlib/System.Threading/RegisteredWaitHandle.cs
@@ -83,12 +83,14 @@ namespace System.Threading
 
 				lock (this) {
 					_unregistered = true;
-					if (_callsInProcess == 0 && _finalEvent != null)
+					if (_callsInProcess == 0 && _finalEvent != null) {
 #if NETCORE
 						throw new NotImplementedException ();
 #else
 						NativeEventCalls.SetEvent (_finalEvent.SafeWaitHandle);
+						_finalEvent = null;
 #endif
+					}
 				}
 			} catch (ObjectDisposedException) {
 				// Can happen if we called Unregister before we had time to execute Wait
@@ -109,12 +111,14 @@ namespace System.Threading
 				lock (this)
 				{
 					_callsInProcess--;
-					if (_unregistered && _callsInProcess == 0 && _finalEvent != null)
+					if (_unregistered && _callsInProcess == 0 && _finalEvent != null) {
 #if NETCORE
 						EventWaitHandle.Set (_finalEvent.SafeWaitHandle);
 #else					
 						NativeEventCalls.SetEvent (_finalEvent.SafeWaitHandle);
 #endif
+						_finalEvent = null;
+					}
 				}
 			}
 		}

--- a/netcore/System.Private.CoreLib/src/System.Threading/RegisteredWaitHandle.cs
+++ b/netcore/System.Private.CoreLib/src/System.Threading/RegisteredWaitHandle.cs
@@ -70,8 +70,10 @@ namespace System.Threading
 			} finally {
 				lock (this) {
 					_callsInProcess--;
-					if (_unregistered && _callsInProcess == 0 && _finalEvent != null)
+					if (_unregistered && _callsInProcess == 0 && _finalEvent != null) {
 						EventWaitHandle.Set (_finalEvent.SafeWaitHandle);
+						_finalEvent = null;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
We have seen sporadic failures in thread pool tests on CI related to test case:

```
System.Threading.ThreadPools.Tests.ThreadPoolTests.QueueRegisterPositiveAndFlowTest [FAIL]
      Assert.Equal() Failure
      Expected: 0
      Actual:   1
      Stack Trace:
          at System.Threading.ThreadPools.Tests.ThreadPoolTests.QueueRegisterPositiveAndFlowTest () [0x00143] in D:\j\workspace\z3\label\w64\external\corefx\src\System.Threading.ThreadPool\tests\ThreadPoolTests.cs:337
          at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
          at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in D:\j\workspace\z3\label\w64\mcs\class\corlib\System.Reflection\RuntimeMethodInfo.cs:395
```

Finally managed to track down the issue to a race when using the same final event in sequential calls to RegisterWaitForSingleObject. The event could, depending on timing, get signaled multiple times for the same RegisterWaitHandle instance causing a thread waiting for completion on another registerWaitHandle using same event to be signaled before that callback was completed. That will cause the race seen in the failing test above.

Fix make sure we only signal the final event one time per RegisterWaitHandle instance.
