### PR TITLE
[exceptions] Fix crashes when getting generic info during EH

### DIFF
--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -7260,7 +7260,7 @@ MONO_RESTORE_WARNING
 				 * get_generic_info_from_stack_frame () needs this to properly look up
 				 * the argument value during the handling of async exceptions.
 				 */
-				if (ins == cfg->args [0]) {
+				if (i == 0 && sig->hasthis) {
 					mono_add_var_location (cfg, ins, TRUE, ainfo->reg, 0, 0, code - cfg->native_code);
 					mono_add_var_location (cfg, ins, FALSE, ins->inst_basereg, ins->inst_offset, code - cfg->native_code, 0);
 				}
@@ -7316,7 +7316,8 @@ MONO_RESTORE_WARNING
 				g_assert_not_reached ();
 			}
 
-			if (ins == cfg->args [0]) {
+			if (i == 0 && sig->hasthis) {
+				g_assert (ainfo->storage == ArgInIReg);
 				mono_add_var_location (cfg, ins, TRUE, ainfo->reg, 0, 0, code - cfg->native_code);
 				mono_add_var_location (cfg, ins, TRUE, ins->dreg, 0, code - cfg->native_code, 0);
 			}


### PR DESCRIPTION
On arm and arm64

>   0xf7e5d384 in __libc_do_syscall () from /lib/arm-linux-gnueabihf/libpthread.so.0
>   0xf7e5c126 in waitpid () from /lib/arm-linux-gnueabihf/libpthread.so.0
>   0x0068f3ac in dump_native_stacktrace (mctx=mctx@entry=0xef3fdee8, signal=0x8399ac "SIGSEGV") at mini-posix.c:1079
>   0x0068f4c2 in mono_dump_native_crash_info (signal=signal@entry=0x8399ac "SIGSEGV", > mctx=mctx@entry=0xef3fdee8, info=info@entry=0xef3fdfe0) at mini-posix.c:1125
>   0x0066ba90 in mono_handle_native_crash (signal=0x8399ac "SIGSEGV", mctx=0xef3fdee8, mctx@entry=0xef3fdef0, info=0xef3fdfe0, info@entry=0xef100f28) at mini-exceptions.c:3328
>   0x00643734 in mono_sigsegv_signal_handler_debug (_dummy=-274701152, _info=0x66952e <get_generic_info_from_stack_frame+158>, context=0xb, debug_fault_addr=0xef3fdfe0) at mini-runtime.c:3370
>   <signal handler called>
>   0x0066952e in get_generic_info_from_stack_frame (ji=ji@entry=0xef103cc0, ctx=ctx@entry=0xef3fe560) at mini-exceptions.c:839
>   0x0066cacc in handle_exception_first_pass (catch_frame=0xef3fe4e0, non_exception=0x0, out_prev_ji=<synthetic pointer>, out_ji=<synthetic pointer>, out_filter_idx=<synthetic pointer>, obj=0xf79c51e8, ctx=0xef3fe560) at mini-exceptions.c:2303
>   mono_handle_exception_internal (ctx=0xef3fe800, obj=0xf79c51e8, resume=resume@entry=0, out_ji=0x0) at mini-exceptions.c:2632
>  0x0066cfac in mono_handle_exception (ctx=ctx@entry=0xef3fe800, void_obj=<optimized out>) at mini-exceptions.c:3030
>  0x0066d128 in mono_raise_exception_with_ctx (exc=<optimized out>, ctx=0xef3fe800) at mini-exceptions.c:3670
>  0x0079df40 in self_interrupt_thread (_unused=<optimized out>) at threads.c:5464
>  0xf22a1ccc in string_GetHashCode (this=0xf7870020) at /home/builder/jenkins/workspace/test-mono-mainline-linux-stress/label/debian-9-armhf/external/corefx/src/Common/src/CoreLib/System/String.Comparison.cs:858
>  0xf79c51c8 in ?? ()
