### PR TITLE
[master] [2019-02][ci] Use a shell script to reset HEAD for submodules

### DIFF
--- a/scripts/ci/git-reset-hard.sh
+++ b/scripts/ci/git-reset-hard.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+# Git 2.22.0 in homebrew seems to have a bug:
+#  git submodule foreach --recursive git reset --hard HEAD
+# errors out with:
+#
+# error: unknown option `hard'
+# usage: git submodule--helper foreach [--quiet] [--recursive] [--] <command>
+
+# which is nonsense because `git foreach -h` says:
+# usage:
+#    ...
+#    or: git submodule [--quiet] foreach [--recursive] <command>
+
+exec git reset --hard "$@"

--- a/scripts/ci/pipeline/sdks-archive.groovy
+++ b/scripts/ci/pipeline/sdks-archive.groovy
@@ -80,7 +80,8 @@ def archive (product, configuration, platform, chrootname = "", chrootadditional
 
                 // remove old stuff
                 sh 'git reset --hard HEAD'
-                sh 'git submodule foreach --recursive git reset --hard HEAD'
+                // revert using the git-reset-hard shell script once all the bots have the git foreach bug fixed
+                sh 'git submodule foreach --recursive `pwd`/scripts/ci/git-reset-hard.sh HEAD'
                 sh 'git clean -xdff'
                 sh 'git submodule foreach --recursive git clean -xdff'
 


### PR DESCRIPTION
Work around a weird bug in Homebrew git 2.22.0



Backport of #15284.

/cc @lambdageek 