### PR TITLE
[ci] One more workaround for Git 2.22.0

### DIFF
--- a/scripts/ci/pipeline/sdks-archive.groovy
+++ b/scripts/ci/pipeline/sdks-archive.groovy
@@ -80,9 +80,12 @@ def archive (product, configuration, platform, chrootname = "", chrootadditional
 
                 // remove old stuff
                 sh 'git reset --hard HEAD'
-                sh 'git submodule foreach --recursive git reset --hard HEAD'
+                // homebrew Git 2.22.0 misparses the submodule command and passes arguments like --hard and -xdff
+                // to git-submodule instead of to git-reset or git-clean.  Passing the entire command as a single
+                // argument seems to help.
+                sh 'git submodule foreach --recursive "git reset --hard HEAD"'
                 sh 'git clean -xdff'
-                sh 'git submodule foreach --recursive git clean -xdff'
+                sh 'git submodule foreach --recursive "git clean -xdff"'
 
                 // get current commit sha
                 commitHash = sh (script: 'git rev-parse HEAD', returnStdout: true).trim()


### PR DESCRIPTION
Homebrew Git 2.22.0 misparses the submodule command and passes arguments like --hard and -xdff to git-submodule instead of to git-reset or git-clean.  Passing the entire command as a single argument seems to help.

Git mailing list bug report: https://public-inbox.org/git/pull.263.git.gitgitgadget@gmail.com/



Backport of #15325.

/cc @lambdageek 