### PR TITLE
[mini] Support tracing pointer return values.

### DIFF
--- a/mono/mini/trace.c
+++ b/mono/mini/trace.c
@@ -342,6 +342,7 @@ mono_trace_leave_method (MonoMethod *method, MonoProfilerCallContext *ctx)
 		printf ("result=%d", res);
 		break;
 	}
+	case MONO_TYPE_PTR:
 	case MONO_TYPE_I:
 	case MONO_TYPE_U: {
 		gpointer res = *arg_in_stack_slot (buf, gpointer);


### PR DESCRIPTION
Greetings; this is just a simple debugging fix, partially to improve a +wrapper trace I encountered, and partly to ensure I'm acquainted to the Mono patch submission process.