### PR TITLE
[wasm][debugger] Adding support to debug local vars in async methods

### DIFF
--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -748,6 +748,7 @@ describe_array_values (guint64 objectId)
 	}
 	return TRUE;
 }
+
 static gboolean
 describe_async_method_locals (MonoStackFrameInfo *info, MonoContext *ctx, gpointer ud)
 {

--- a/mono/mini/mini-wasm-debugger.c
+++ b/mono/mini/mini-wasm-debugger.c
@@ -27,7 +27,7 @@ EMSCRIPTEN_KEEPALIVE int mono_wasm_set_breakpoint (const char *assembly_name, in
 EMSCRIPTEN_KEEPALIVE int mono_wasm_remove_breakpoint (int bp_id);
 EMSCRIPTEN_KEEPALIVE int mono_wasm_current_bp_id (void);
 EMSCRIPTEN_KEEPALIVE void mono_wasm_enum_frames (void);
-EMSCRIPTEN_KEEPALIVE void mono_wasm_get_var_info (int scope, int pos);
+EMSCRIPTEN_KEEPALIVE void mono_wasm_get_var_info (int scope, int* pos, int len);
 EMSCRIPTEN_KEEPALIVE void mono_wasm_clear_all_breakpoints (void);
 EMSCRIPTEN_KEEPALIVE void mono_wasm_setup_single_step (int kind);
 EMSCRIPTEN_KEEPALIVE void mono_wasm_get_object_properties (int object_id);
@@ -665,7 +665,7 @@ static gboolean describe_value(MonoType * type, gpointer addr)
 }
 
 static gboolean 
-describe_object_properties (guint64 objectId)
+describe_object_properties (guint64 objectId, gboolean isAsyncLocalThis)
 {
 	MonoClassField *f;
 	MonoProperty *p;
@@ -689,6 +689,9 @@ describe_object_properties (guint64 objectId)
 
 	while (obj && (f = mono_class_get_fields_internal (obj->vtable->klass, &iter))) {
 		DEBUG_PRINTF (2, "mono_class_get_fields_internal - %s - %x\n", f->name, f->type->type);
+		if (isAsyncLocalThis &&  (f->name[0] != '<' || (f->name[0] == '<' &&  f->name[1] == '>'))) {
+			continue;
+		}
 		if (f->type->attrs & FIELD_ATTRIBUTE_STATIC)
 			continue;
 		if (mono_field_is_deleted (f))
@@ -703,6 +706,9 @@ describe_object_properties (guint64 objectId)
 	while ((p = mono_class_get_properties (obj->vtable->klass, &iter))) {
 		DEBUG_PRINTF (2, "mono_class_get_properties - %s - %s\n", p->name, p->get->name);
 		if (p->get->name) { //if get doesn't have name means that doesn't have a getter implemented and we don't want to show value, like VS debug
+			if (isAsyncLocalThis &&  (p->name[0] != '<' || (p->name[0] == '<' &&  p->name[1] == '>'))) {
+				continue;
+			}
 			mono_wasm_add_properties_var(p->name); 
 			sig = mono_method_signature_internal (p->get);
 			res = mono_runtime_try_invoke (p->get, obj, NULL, &exc, error);
@@ -739,6 +745,34 @@ describe_array_values (guint64 objectId)
 		mono_wasm_add_array_item(i);
 		elem = (gpointer*)((char*)arr->vector + (i * esize));
 		describe_value(m_class_get_byval_arg (m_class_get_element_class (arr->obj.vtable->klass)), elem);
+	}
+	return TRUE;
+}
+static gboolean
+describe_async_method_locals (MonoStackFrameInfo *info, MonoContext *ctx, gpointer ud)
+{
+	//Async methods are special in the way that local variables can be lifted to generated class fields 
+	FrameDescData *data = (FrameDescData*)ud;
+
+	//skip wrappers
+	if (info->type != FRAME_TYPE_MANAGED && info->type != FRAME_TYPE_INTERP) {
+		return FALSE;
+	}
+
+	if (data->cur_frame < data->target_frame) {
+		++data->cur_frame;
+		return FALSE;
+	}
+
+	InterpFrame *frame = (InterpFrame*)info->interp_frame;
+	g_assert (frame);
+	MonoMethod *method = frame->imethod->method;
+	g_assert (method);
+	gpointer addr = NULL;
+	if (mono_debug_lookup_method_async_debug_info (method)) {
+		addr = mini_get_interp_callbacks ()->frame_get_this (frame);
+		MonoObject *obj = *(MonoObject**)addr;
+		describe_object_properties(get_object_id(obj), TRUE);		
 	}
 	return TRUE;
 }
@@ -792,16 +826,18 @@ describe_variable (MonoStackFrameInfo *info, MonoContext *ctx, gpointer ud)
 
 //FIXME this doesn't support getting the return value pseudo-var
 EMSCRIPTEN_KEEPALIVE void
-mono_wasm_get_var_info (int scope, int pos)
+mono_wasm_get_var_info (int scope, int* pos, int len)
 {
-	DEBUG_PRINTF (2, "getting var %d of scope %d\n", pos, scope);
-
 	FrameDescData data;
 	data.cur_frame = 0;
 	data.target_frame = scope;
-	data.variable = pos;
-
-	mono_walk_stack_with_ctx (describe_variable, NULL, MONO_UNWIND_NONE, &data);
+	for (int i = 0; i < len; i++)
+	{
+		DEBUG_PRINTF (2, "getting var %d of scope %d - %d\n", pos[i], scope, len);
+		data.variable = pos[i];
+		mono_walk_stack_with_ctx (describe_variable, NULL, MONO_UNWIND_NONE, &data);
+	}
+	mono_walk_stack_with_ctx (describe_async_method_locals, NULL, MONO_UNWIND_NONE, &data);
 }
 
 EMSCRIPTEN_KEEPALIVE void
@@ -809,7 +845,7 @@ mono_wasm_get_object_properties (int object_id)
 {
 	DEBUG_PRINTF (2, "getting properties of object %d\n", object_id);
 
-	describe_object_properties(object_id);
+	describe_object_properties(object_id, FALSE);
 }
 
 EMSCRIPTEN_KEEPALIVE void

--- a/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
+++ b/sdks/wasm/Mono.WebAssembly.DebuggerProxy/MonoProxy.cs
@@ -323,8 +323,7 @@ namespace WsProxy {
 									name = method.Name,
 									startLocation = method.StartLocation.ToJObject (),
 									endLocation = method.EndLocation.ToJObject (),
-								}},
-								@this = new { }
+								}}
 						}));
 
 						++frame_id;
@@ -486,11 +485,11 @@ namespace WsProxy {
 			var values = res.Value? ["result"]? ["value"]?.Values<JObject> ().ToArray ();
 
 			var var_list = new List<JObject> ();
-
+			int i = 0;
 			// Trying to inspect the stack frame for DotNetDispatcher::InvokeSynchronously
 			// results in a "Memory access out of bounds", causing 'values' to be null,
 			// so skip returning variable values in that case.
-			for (int i = 0; values != null && i < vars.Length; ++i) {
+			while (values != null && i < var_ids.Length && i < values.Length) {
 				var value = values [i] ["value"];
 				if (((string)value ["description"]) == null)
 					value ["description"] = value ["value"]?.ToString();
@@ -499,12 +498,21 @@ namespace WsProxy {
 					name = vars [i].Name,
 					value = values [i] ["value"]
 				}));
-
+				i++;
+			}
+			//Async methods are special in the way that local variables can be lifted to generated class fields
+			while (i < values.Length) {
+				String name = values [i] ["name"].ToString ();
+				name = name.Substring (1, name.IndexOf (">", StringComparison.Ordinal)-1);
+				var_list.Add (JObject.FromObject (new {
+					name =  name,
+					value = values [i+1] ["value"]
+				}));
+				i = i + 2;
 			}
 			o = JObject.FromObject (new {
 				result = var_list
 			});
-
 			SendResponse (msg_id, Result.Ok (o), token);
 		}
 

--- a/sdks/wasm/library_mono.js
+++ b/sdks/wasm/library_mono.js
@@ -38,12 +38,15 @@ var MonoSupportLib = {
 
 		mono_wasm_get_variables: function(scope, var_list) {
 			if (!this.mono_wasm_get_var_info)
-				this.mono_wasm_get_var_info = Module.cwrap ("mono_wasm_get_var_info", 'void', [ 'number', 'number']);
+				this.mono_wasm_get_var_info = Module.cwrap ("mono_wasm_get_var_info", 'void', [ 'number', 'number', 'number']);
 
 			//FIXME it would be more efficient to do a single call passing an array with var_list as argument instead
 			this.var_info = [];
-			for (var i = 0; i <  var_list.length; ++i)
-				this.mono_wasm_get_var_info (scope, var_list [i]);
+			var typedArray = new Int32Array(var_list.length);
+			for (let i=0; i<var_list.length; i++) {
+				typedArray[i] = var_list[i]
+			}
+			this.mono_wasm_get_var_info (scope, typedArray, var_list.length);
 
 			var res = this.var_info;
 			this.var_info = []


### PR DESCRIPTION
- Improving performance calling only once mono_wasm_get_var_info.
- Adding support to debug local vars in async methods. They are special in the way that local variables can be lifted to generated class fields.

Fixes #14608
