### PR TITLE
[debug] Refactor the code in mono-debug.c.

### DIFF
--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -419,7 +419,10 @@ struct _MonoDomain {
 
 	/* Information maintained by the JIT engine */
 	gpointer runtime_info;
-	
+
+	/* Information maintained by mono-debug.c */
+	gpointer debug_info;
+
 	/* Contains the compiled runtime invoke wrapper used by finalizers */
 	gpointer            finalize_runtime_invoke;
 

--- a/mono/metadata/mono-debug.c
+++ b/mono/metadata/mono-debug.c
@@ -670,10 +670,10 @@ find_method (MonoMethod *method, MonoDomain *domain, MonoDebugMethodJitInfo *jit
 MonoDebugMethodJitInfo *
 mono_debug_find_method (MonoMethod *method, MonoDomain *domain)
 {
-	MonoDebugMethodJitInfo *res = g_new0 (MonoDebugMethodJitInfo, 1);
-
 	if (mono_debug_format == MONO_DEBUG_FORMAT_NONE)
 		return NULL;
+
+	MonoDebugMethodJitInfo *res = g_new0 (MonoDebugMethodJitInfo, 1);
 
 	mono_debugger_lock ();
 	find_method (method, domain, res);
@@ -759,7 +759,6 @@ mono_debug_lookup_source_location (MonoMethod *method, guint32 address, MonoDoma
 		location = mono_ppdb_lookup_location (minfo, offset);
 	else
 		location = mono_debug_symfile_lookup_location (minfo, offset);
-	mono_debugger_unlock ();
 	return location;
 }
 

--- a/mono/metadata/mono-debug.c
+++ b/mono/metadata/mono-debug.c
@@ -160,7 +160,7 @@ mono_debug_domain_create (MonoDomain *domain)
 void
 mono_debug_domain_unload (MonoDomain *domain)
 {
-	DebugDomainInfo *info = domain->debug_info;
+	DebugDomainInfo *info = (DebugDomainInfo*)domain->debug_info;
 
 	if (!info)
 		return;

--- a/mono/metadata/mono-debug.c
+++ b/mono/metadata/mono-debug.c
@@ -41,13 +41,13 @@
 #endif
 
 /* This contains per-domain info */
-struct _MonoDebugDataTable {
+typedef struct {
 	MonoMemPool *mp;
-	GHashTable *method_address_hash;
-};
+	GHashTable *method_hash;
+} DebugDomainInfo;
 
 /* This contains JIT debugging information about a method in serialized format */
-struct _MonoDebugMethodAddress {
+typedef struct _MonoDebugMethodAddress {
 	const guint8 *code_start;
 	guint32 code_size;
 	guint8 data [MONO_ZERO_LEN_ARRAY];
@@ -58,8 +58,6 @@ static MonoDebugFormat mono_debug_format = MONO_DEBUG_FORMAT_NONE;
 static gboolean mono_debug_initialized = FALSE;
 /* Maps MonoImage -> MonoMonoDebugHandle */
 static GHashTable *mono_debug_handles;
-/* Maps MonoDomain -> MonoDataTable */
-static GHashTable *data_table_hash;
 
 static mono_mutex_t debugger_lock_mutex;
 
@@ -73,42 +71,12 @@ static void                 mono_debug_add_assembly    (MonoAssembly *assembly,
 
 static MonoDebugHandle     *open_symfile_from_bundle   (MonoImage *image);
 
-static MonoDebugDataTable *
-create_data_table (MonoDomain *domain)
+static inline DebugDomainInfo*
+get_domain_info (MonoDomain *domain)
 {
-	MonoDebugDataTable *table;
+	g_assert (domain->debug_info);
 
-	table = g_new0 (MonoDebugDataTable, 1);
-
-	table->mp = mono_mempool_new ();
-	table->method_address_hash = g_hash_table_new (NULL, NULL);
-
-	if (domain)
-		g_hash_table_insert (data_table_hash, domain, table);
-
-	return table;
-}
-
-static void
-free_data_table (MonoDebugDataTable *table)
-{
-	mono_mempool_destroy (table->mp);
-	g_hash_table_destroy (table->method_address_hash);
-
-	g_free (table);
-}
-
-static MonoDebugDataTable *
-lookup_data_table (MonoDomain *domain)
-{
-	MonoDebugDataTable *table;
-
-	table = (MonoDebugDataTable *)g_hash_table_lookup (data_table_hash, domain);
-	if (!table) {
-		g_error ("lookup_data_table () failed for %p\n", domain);
-		g_assert (table);
-	}
-	return table;
+	return (DebugDomainInfo*)domain->debug_info;
 }
 
 static void
@@ -147,9 +115,6 @@ mono_debug_init (MonoDebugFormat format)
 	mono_debug_handles = g_hash_table_new_full
 		(NULL, NULL, NULL, (GDestroyNotify) free_debug_handle);
 
-	data_table_hash = g_hash_table_new_full (
-		NULL, NULL, NULL, (GDestroyNotify) free_data_table);
-
 	mono_install_assembly_load_hook (mono_debug_add_assembly, NULL);
 
 	mono_debugger_unlock ();
@@ -173,11 +138,6 @@ mono_debug_cleanup (void)
 	if (mono_debug_handles)
 		g_hash_table_destroy (mono_debug_handles);
 	mono_debug_handles = NULL;
-
-	if (data_table_hash) {
-		g_hash_table_destroy (data_table_hash);
-		data_table_hash = NULL;
-	}
 }
 
 /**
@@ -186,37 +146,30 @@ mono_debug_cleanup (void)
 void
 mono_debug_domain_create (MonoDomain *domain)
 {
+	DebugDomainInfo *info;
+
 	if (!mono_debug_initialized)
 		return;
 
-	mono_debugger_lock ();
+	info = g_new0 (DebugDomainInfo, 1);
+	info->mp = mono_mempool_new ();
+	info->method_hash = g_hash_table_new (NULL, NULL);
 
-	create_data_table (domain);
-
-	mono_debugger_unlock ();
+	domain->debug_info = info;
 }
 
 void
 mono_debug_domain_unload (MonoDomain *domain)
 {
-	MonoDebugDataTable *table;
+	DebugDomainInfo *info = domain->debug_info;
 
-	if (!mono_debug_initialized)
+	if (!info)
 		return;
 
-	mono_debugger_lock ();
+	mono_mempool_destroy (info->mp);
+	g_hash_table_destroy (info->method_hash);
 
-	table = (MonoDebugDataTable *)g_hash_table_lookup (data_table_hash, domain);
-	if (!table) {
-		g_warning (G_STRLOC ": unloading unknown domain %p / %d",
-			   domain, mono_domain_get_id (domain));
-		mono_debugger_unlock ();
-		return;
-	}
-
-	g_hash_table_remove (data_table_hash, domain);
-
-	mono_debugger_unlock ();
+	g_free (info);
 }
 
 /*
@@ -455,15 +408,13 @@ write_variable (MonoDebugVarInfo *var, guint8 *ptr, guint8 **rptr)
 MonoDebugMethodAddress *
 mono_debug_add_method (MonoMethod *method, MonoDebugMethodJitInfo *jit, MonoDomain *domain)
 {
-	MonoDebugDataTable *table;
+	DebugDomainInfo *info;
 	MonoDebugMethodAddress *address;
 	guint8 buffer [BUFSIZ];
 	guint8 *ptr, *oldptr;
 	guint32 i, size, total_size, max_size;
 
-	mono_debugger_lock ();
-
-	table = lookup_data_table (domain);
+	info = get_domain_info (domain);
 
 	max_size = (5 * LEB128_MAX_SIZE) + 1 + (2 * LEB128_MAX_SIZE * jit->num_line_numbers);
 	if (jit->has_var_info) {
@@ -523,10 +474,12 @@ mono_debug_add_method (MonoMethod *method, MonoDebugMethodJitInfo *jit, MonoDoma
 	g_assert (size < max_size);
 	total_size = size + sizeof (MonoDebugMethodAddress);
 
+	mono_debugger_lock ();
+
 	if (method_is_dynamic (method)) {
 		address = (MonoDebugMethodAddress *)g_malloc0 (total_size);
 	} else {
-		address = (MonoDebugMethodAddress *)mono_mempool_alloc (table->mp, total_size);
+		address = (MonoDebugMethodAddress *)mono_mempool_alloc (info->mp, total_size);
 	}
 
 	address->code_start = jit->code_start;
@@ -536,7 +489,7 @@ mono_debug_add_method (MonoMethod *method, MonoDebugMethodJitInfo *jit, MonoDoma
 	if (max_size > BUFSIZ)
 		g_free (oldptr);
 
-	g_hash_table_insert (table->method_address_hash, method, address);
+	g_hash_table_insert (info->method_hash, method, address);
 
 	mono_debugger_unlock ();
 	return address;
@@ -545,7 +498,7 @@ mono_debug_add_method (MonoMethod *method, MonoDebugMethodJitInfo *jit, MonoDoma
 void
 mono_debug_remove_method (MonoMethod *method, MonoDomain *domain)
 {
-	MonoDebugDataTable *table;
+	DebugDomainInfo *info;
 	MonoDebugMethodAddress *address;
 
 	if (!mono_debug_initialized)
@@ -553,15 +506,15 @@ mono_debug_remove_method (MonoMethod *method, MonoDomain *domain)
 
 	g_assert (method_is_dynamic (method));
 
+	info = get_domain_info (domain);
+
 	mono_debugger_lock ();
 
-	table = lookup_data_table (domain);
-
-	address = (MonoDebugMethodAddress *)g_hash_table_lookup (table->method_address_hash, method);
+	address = (MonoDebugMethodAddress *)g_hash_table_lookup (info->method_hash, method);
 	if (address)
 		g_free (address);
 
-	g_hash_table_remove (table->method_address_hash, method);
+	g_hash_table_remove (info->method_hash, method);
 
 	mono_debugger_unlock ();
 }
@@ -704,11 +657,11 @@ mono_debug_read_method (MonoDebugMethodAddress *address, MonoDebugMethodJitInfo 
 static MonoDebugMethodJitInfo *
 find_method (MonoMethod *method, MonoDomain *domain, MonoDebugMethodJitInfo *jit)
 {
-	MonoDebugDataTable *table;
+	DebugDomainInfo *info;
 	MonoDebugMethodAddress *address;
 
-	table = lookup_data_table (domain);
-	address = (MonoDebugMethodAddress *)g_hash_table_lookup (table->method_address_hash, method);
+	info = get_domain_info (domain);
+	address = (MonoDebugMethodAddress *)g_hash_table_lookup (info->method_hash, method);
 
 	if (!address)
 		return NULL;


### PR DESCRIPTION
Store the domain->debug info table mapping in MonoDomain to avoid a hashtable lookup.
Rename MonoDebugDataTable to DebugDomainInfo to better reflect its meaning.