### PR TITLE
Fix tarball build and refresh monolite due to memory model change

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # This line is parsed by tools besides autoconf, such as msvc/mono.winconfig.targets.
 # It should remain in the format they expect.
 #
-MONO_CORLIB_VERSION=62731146-81CF-4D61-826D-9A8DDED14432
+MONO_CORLIB_VERSION=a3d6fce2-2790-4089-9543-34eb239e2b04
 
 #
 # Put a quoted #define in config.h.

--- a/mcs/build/common/basic-profile-check.cs
+++ b/mcs/build/common/basic-profile-check.cs
@@ -41,9 +41,9 @@ class X
 
 		Version min_mono_version;
 #if __MonoCS__
-		min_mono_version = new Version (6, 2);
+		min_mono_version = new Version (6, 5);
 #else
-		min_mono_version = new Version (6, 2);
+		min_mono_version = new Version (6, 5);
 #endif
 
 		if (version < min_mono_version)

--- a/mcs/class/Makefile
+++ b/mcs/class/Makefile
@@ -429,7 +429,7 @@ wasm_PARALLEL_SUBDIRS := $(wasm_dirs_parallel)
 wasm_tools_SUBDIRS :=
 wasm_tools_PARALLEL_SUBDIRS := $(wasm_tools_dirs_parallel)
 
-netcore_SUBDIRS := System.Private.CoreLib
+netcore_SUBDIRS :=
 netcore_PARALLEL_SUBDIRS :=
 
 include ../build/rules.make

--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -1,3 +1,5 @@
+ifneq ($(wildcard config.make),)
+
 include config.make
 
 #
@@ -170,5 +172,7 @@ build-test-corefx-%:
 	cd $(COREFX_ROOT)/src/$*/tests && $(DOTNET) msbuild /p:OutputPath=tmp
 	cp $(COREFX_ROOT)/src/$*/tests/tmp/$*.Tests.{dll,pdb} $(CURDIR)/corefx/tests/extracted/$*.Tests/
 	rm -rf $(COREFX_ROOT)/src/$*/tests/tmp
+
+endif
 
 distdir:


### PR DESCRIPTION
Tarball build was broken by https://github.com/mono/mono/commit/9010d2f290d28dc97ac276e0c0d32a2932b7550f