### PR TITLE
[netcore] Add xunit summary script

### DIFF
--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -148,7 +148,8 @@ corefx/.stamp-dl-corefx-tests-$(NETCORETESTS_VERSION):
 run-tests-corefx: update-tests-corefx
 	for testdir in corefx/tests/extracted/*; do \
 		$(MAKE) run-tests-corefx-$$(basename $${testdir}); \
-	done
+	done; \
+	$(MAKE) xunit-summary
 
 run-tests-corefx-%: prepare update-tests-corefx
 	echo -n "***************** $* *********************"
@@ -170,5 +171,8 @@ build-test-corefx-%:
 	cd $(COREFX_ROOT)/src/$*/tests && $(DOTNET) msbuild /p:OutputPath=tmp
 	cp $(COREFX_ROOT)/src/$*/tests/tmp/$*.Tests.{dll,pdb} $(CURDIR)/corefx/tests/extracted/$*.Tests/
 	rm -rf $(COREFX_ROOT)/src/$*/tests/tmp
+
+xunit-summary:
+	python xunit-summary.py "corefx/tests"
 
 distdir:

--- a/netcore/xunit-summary.py
+++ b/netcore/xunit-summary.py
@@ -1,0 +1,57 @@
+import xml.etree.ElementTree as ET
+import os
+import glob
+import ntpath
+import sys
+
+if len(sys.argv) < 1:
+    print("Usage: xunit-summary.py <path to xunit results (*.xml)>")
+    sys.exit(1)
+test_dir = sys.argv [1]
+
+class TestResults():
+    def __init__(self, name, total, passed, failed, skipped, errors, time):
+        self.name = name
+        self.total = total
+        self.passed = passed
+        self.failed = failed + errors
+        self.skipped = skipped
+        self.time = time
+
+print("")
+
+tests = []
+for testfile in glob.glob(test_dir + "/*-xunit.xml"):
+    assemblies = ET.parse(testfile).getroot()
+    for assembly in assemblies:
+        test_name = assembly.attrib.get("name")
+        if test_name is None:
+            print("WARNING: %s has no tests!" % ntpath.basename(testfile))
+            continue
+        tests.append(TestResults(test_name, 
+            int(assembly.attrib["total"]), 
+            int(assembly.attrib["passed"]), 
+            int(assembly.attrib["failed"]), 
+            int(assembly.attrib["skipped"]), 
+            int(assembly.attrib["errors"]), 
+            float(assembly.attrib["time"])))
+
+# sort by name
+tests.sort(key=lambda item: item.name)
+
+print("")
+print("=" * 105)
+for t in tests:
+    #if t.failed > 0: # uncomment to list only test suits with failures
+        print("{0:<60}  Total:{1:<6}  Failed:{2:<6}  Time:{3} sec".format(t.name, t.total, t.failed, round(t.time, 1)))
+print("=" * 105)
+
+print("")
+print("Total test suits:     %d" % len(tests))
+print("Total tests run:      %d" % sum(x.total for x in tests))
+print("Total tests passed:   %d" % sum(x.passed for x in tests))
+print("Total tests failed:   %d" % sum(x.failed for x in tests))
+print("Total tests skipped:  %d" % sum(x.skipped for x in tests))
+print("Total duration:       %d min" % (sum(x.time for x in tests) / 60))
+print("")
+


### PR DESCRIPTION
```
make xunit-summary
```
it prints some compact xunit report - a similar python script is used by coreclr (or corefx):
```
=========================================================================================================
Common.Tests.dll                                              Total:1144    Failed:0       Time:9.2 sec
CoreFx.Private.TestUtilities.Tests.dll                        Total:87      Failed:0       Time:0.2 sec
Invariant.Tests.dll                                           Total:296     Failed:0       Time:0.4 sec
Microsoft.Bcl.AsyncInterfaces.Tests.dll                       Total:10      Failed:0       Time:0.2 sec
Microsoft.CSharp.Tests.dll                                    Total:4796    Failed:0       Time:2.6 sec
Microsoft.VisualBasic.Core.Tests.dll                          Total:21748   Failed:0       Time:3.2 sec
Microsoft.Win32.Primitives.Tests.dll                          Total:1       Failed:0       Time:0.2 sec
Microsoft.XmlSerializer.Generator.Tests.dll                   Total:83      Failed:0       Time:0.7 sec
System.AppContext.Tests.dll                                   Total:15      Failed:0       Time:0.1 sec
System.Buffers.Tests.dll                                      Total:78      Failed:0       Time:1.9 sec
....
System.Xml.XmlSchema.XmlSchemaValidatorApi.Tests.dll          Total:362     Failed:0       Time:0.6 sec
System.Xml.XmlSchemaSet.Tests.dll                             Total:482     Failed:0       Time:0.9 sec
System.Xml.XmlSerializer.ReflectionOnly.Tests.dll             Total:228     Failed:0       Time:1.7 sec
System.Xml.XmlSerializer.Tests.dll                            Total:230     Failed:0       Time:1.8 sec
System.Xml.Xsl.XslCompiledTransformApi.Tests.dll              Total:1621    Failed:0       Time:7.8 sec
System.Xml.Xsl.XslTransformApi.Tests.dll                      Total:1593    Failed:0       Time:4.7 sec
XsltCompiler.Tests.dll                                        Total:1       Failed:0       Time:0.1 sec
=========================================================================================================

Total test suits:     205
Total tests run:      387451
Total tests passed:   384547
Total tests failed:   108
Total tests skipped:  2796
Total duration:       15 min
```