### PR TITLE
[2019-06] [jit] Fix interface cast

### DIFF
--- a/mono/mini/objects.cs
+++ b/mono/mini/objects.cs
@@ -841,6 +841,29 @@ class Tests {
 		return 0;
 	}
 
+	public static string[] StringValues = { "Val1", "Val2", "Val3" };
+
+	public static IEnumerable<string> GetStringValues ()
+	{
+		foreach (string val in StringValues)
+			yield return val;
+	}
+
+	public static int test_0_cast_special_iface () {
+		try {
+			IEnumerable<string> strings = GetStringValues ();
+			IList<string> stringIList = (IList<string>) strings;
+
+			// No exception thrown. Maybe it's an actual IList ?
+			// Make sure it's not bluffing
+			if (!"Val2".Equals (stringIList [1]))
+				return 1;
+		} catch (InvalidCastException) {
+		}
+
+		return 0;
+	}
+
 	private static int[] daysmonthleap = { 0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
 
 	private static int AbsoluteDays (int year, int month, int day)


### PR DESCRIPTION
Fixes a scenario on platforms with remoting disabled, where casting something to a special interface (like 
IEnumerable<>, IList<> ..) would fail to throw InvalidCastException.

Fixes https://github.com/mono/mono/issues/14729

Backport of #14978.

/cc @marek-safar @BrzVlad