### PR TITLE
Fix tarball builds wrt netcore/config.make.

### DIFF
--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -1,3 +1,5 @@
+ifneq ($(wildcard config.make),)
+
 include config.make
 
 #
@@ -170,5 +172,7 @@ build-test-corefx-%:
 	cd $(COREFX_ROOT)/src/$*/tests && $(DOTNET) msbuild /p:OutputPath=tmp
 	cp $(COREFX_ROOT)/src/$*/tests/tmp/$*.Tests.{dll,pdb} $(CURDIR)/corefx/tests/extracted/$*.Tests/
 	rm -rf $(COREFX_ROOT)/src/$*/tests/tmp
+
+endif
 
 distdir:


### PR DESCRIPTION
https://jenkins.mono-project.com/job/build-source-tarball-mono-pullrequest/601/console
```00:15:58.064      am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)
00:15:58.065 make[2]: Entering directory '/mnt/jenkins/workspace/build-source-tarball-mono-pullrequest/netcore'
00:15:58.065 Makefile:1: config.make: No such file or directory
00:15:58.065 
make[2]: *** No rule to make target 'config.make'.  Stop.
00:15:58.065 make[2]: Leaving directory '/mnt/jenkins/workspace/build-source-tarball-mono-pullrequest/netcore'
00:15:58.066 Makefile:695: recipe for target 'distdir' failed
00:15:58.066 make[1]: Leaving directory '/mnt/jenkins/workspace/build-source-tarball-mono-pullrequest'
00:15:58.066```