### PR TITLE
[aot] Save the number of locals into the aot debug info so the method header doesn't have to be decoded when its loaded.

### DIFF
--- a/mono/mini/aot-runtime.h
+++ b/mono/mini/aot-runtime.h
@@ -11,7 +11,7 @@
 #include "mini.h"
 
 /* Version number of the AOT file format */
-#define MONO_AOT_FILE_VERSION 164
+#define MONO_AOT_FILE_VERSION 165
 
 #define MONO_AOT_TRAMP_PAGE_SIZE 16384
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->