### PR TITLE
[2019-06] Exclude a few tests on monotouch_watch/xammac

### DIFF
--- a/mcs/class/System.Core/monotouch_System.Core_xtest.dll.exclude.sources
+++ b/mcs/class/System.Core/monotouch_System.Core_xtest.dll.exclude.sources
@@ -1,1 +1,7 @@
 ../../../external/corefx/src/System.Linq.Expressions/tests/Dynamic/InvokeMemberBindingTests.cs
+../../../external/corefx/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.CreateClient.cs
+../../../external/corefx/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.CreateServer.cs
+../../../external/corefx/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.Read.cs
+../../../external/corefx/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.Specific.cs
+../../../external/corefx/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.Write.cs
+../../../external/corefx/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTestBase.cs

--- a/mcs/class/System/monotouch_watch_System_xtest.dll.exclude.sources
+++ b/mcs/class/System/monotouch_watch_System_xtest.dll.exclude.sources
@@ -15,3 +15,6 @@
 
 ../../../external/corefx/src/System.Net.Security/tests/FunctionalTests/*.cs
 
+../../../external/corefx/src/System.Net.WebClient/tests/WebClientTest.cs
+
+../../../external/corefx/src/Common/tests/System/Net/WebSockets/WebSocketCreateTest.cs


### PR DESCRIPTION
[System.Core] Exclude AnonymousPipe tests on monotouch/xammac profiles
[System] Exclude WebClient and WebSocket tests on monotouch_watch …

Fixes #15329
Fixes #15265

Backport of #15397.

/cc @akoeplinger 