### PR TITLE
Make codeman not public.

### DIFF
--- a/mono/utils/mono-codeman.h
+++ b/mono/utils/mono-codeman.h
@@ -14,22 +14,22 @@ typedef struct {
 	void (*chunk_destroy) (void *chunk);
 } MonoCodeManagerCallbacks;
 
-MONO_API MonoCodeManager* mono_code_manager_new     (void);
-MONO_API MonoCodeManager* mono_code_manager_new_dynamic (void);
-MONO_API void             mono_code_manager_destroy (MonoCodeManager *cman);
-MONO_API void             mono_code_manager_invalidate (MonoCodeManager *cman);
-MONO_API void             mono_code_manager_set_read_only (MonoCodeManager *cman);
+MonoCodeManager* mono_code_manager_new     (void);
+MonoCodeManager* mono_code_manager_new_dynamic (void);
+void             mono_code_manager_destroy (MonoCodeManager *cman);
+void             mono_code_manager_invalidate (MonoCodeManager *cman);
+void             mono_code_manager_set_read_only (MonoCodeManager *cman);
 
-MONO_API void*            mono_code_manager_reserve_align (MonoCodeManager *cman, int size, int alignment);
+void*            mono_code_manager_reserve_align (MonoCodeManager *cman, int size, int alignment);
 #define mono_code_manager_reserve_align(cman, size, align) (g_cast (mono_code_manager_reserve_align ((cman), (size), (align))))
 
-MONO_API void*            mono_code_manager_reserve (MonoCodeManager *cman, int size);
+void*            mono_code_manager_reserve (MonoCodeManager *cman, int size);
 #define mono_code_manager_reserve(cman, size) (g_cast (mono_code_manager_reserve ((cman), (size))))
-MONO_API void             mono_code_manager_commit  (MonoCodeManager *cman, void *data, int size, int newsize);
-MONO_API int              mono_code_manager_size    (MonoCodeManager *cman, int *used_size);
-MONO_API void             mono_code_manager_init (void);
-MONO_API void             mono_code_manager_cleanup (void);
-MONO_API void             mono_code_manager_install_callbacks (MonoCodeManagerCallbacks* callbacks);
+void             mono_code_manager_commit  (MonoCodeManager *cman, void *data, int size, int newsize);
+int              mono_code_manager_size    (MonoCodeManager *cman, int *used_size);
+void             mono_code_manager_init (void);
+void             mono_code_manager_cleanup (void);
+void             mono_code_manager_install_callbacks (MonoCodeManagerCallbacks* callbacks);
 
 /* find the extra block allocated to resolve branches close to code */
 typedef int    (*MonoCodeManagerFunc)      (void *data, int csize, int size, void *user_data);


### PR DESCRIPTION
Seems a bit obscure to be public.
The header is not public --  could still dlsym + cast.