### PR TITLE
Add support for TLS callbacks on Windows.

### DIFF
--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -384,6 +384,7 @@ darwin_sources = \
 
 windows_sources = \
 	mini-windows.c \
+	mini-windows-tls-callback.c \
 	mini-windows.h \
 	mini-windows-dllmain.c \
 	mini-windows-dlldac.c

--- a/mono/mini/mini-windows-dllmain.c
+++ b/mono/mini/mini-windows-dllmain.c
@@ -7,36 +7,18 @@
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
 
-#include <mono/metadata/coree.h>
-#include <mono/metadata/gc-internals.h>
-#include <mono/metadata/domain-internals.h>
-#include <mono/utils/mono-threads.h>
-#include "mini.h"
 #include "mini-runtime.h"
 
 #ifdef HOST_WIN32
+#include "mini-windows.h"
 #include <windows.h>
+
+MONO_EXTERN_C
+BOOL APIENTRY DllMain (HMODULE module_handle, DWORD reason, LPVOID reserved);
 
 MONO_EXTERN_C
 BOOL APIENTRY DllMain (HMODULE module_handle, DWORD reason, LPVOID reserved)
 {
-	if (!mono_gc_dllmain (module_handle, reason, reserved))
-		return FALSE;
-
-	switch (reason)
-	{
-	case DLL_PROCESS_ATTACH:
-		mono_install_runtime_load (mini_init);
-		break;
-	case DLL_PROCESS_DETACH:
-		if (coree_module_handle)
-			FreeLibrary (coree_module_handle);
-		break;
-	case DLL_THREAD_DETACH:
-		mono_thread_info_detach ();
-		break;
-	
-	}
-	return TRUE;
+	return mono_win32_runtime_tls_callback (module_handle, reason, reserved, MONO_WIN32_TLS_CALLBACK_TYPE_DLL);
 }
 #endif

--- a/mono/mini/mini-windows-tls-callback.c
+++ b/mono/mini/mini-windows-tls-callback.c
@@ -29,10 +29,8 @@ mono_win32_handle_tls_callback_type (MonoWin32TLSCallbackType callback_type)
 	return TRUE;
 }
 
-MONO_EXTERN_C
 VOID NTAPI mono_win32_tls_callback (PVOID module_handle, DWORD reason, PVOID reserved);
 
-MONO_EXTERN_C
 VOID NTAPI mono_win32_tls_callback (PVOID module_handle, DWORD reason, PVOID reserved)
 {
 	mono_win32_runtime_tls_callback ((HMODULE)module_handle, reason, reserved, MONO_WIN32_TLS_CALLBACK_TYPE_LIB);
@@ -44,12 +42,12 @@ VOID NTAPI mono_win32_tls_callback (PVOID module_handle, DWORD reason, PVOID res
 /* by OS loader (part of TLS Directory PE header), regardless if runtime is used */
 /* as a static or dynamic library. */
 #if (_MSC_VER >= 1400)
-#pragma const_seg(".CRT$XLX")
-MONO_EXTERN_C const PIMAGE_TLS_CALLBACK __mono_win32_tls_callback = mono_win32_tls_callback;
-#pragma const_seg()
+#pragma const_seg (".CRT$XLX")
+extern const PIMAGE_TLS_CALLBACK __mono_win32_tls_callback = mono_win32_tls_callback;
+#pragma const_seg ()
 #elif defined(__MINGW64__) || (__MINGW32__)
-MONO_EXTERN_C const PIMAGE_TLS_CALLBACK __mono_win32_tls_callback __attribute__ ((section (".CRT$XLX"))) = mono_win32_tls_callback;
+extern const PIMAGE_TLS_CALLBACK __mono_win32_tls_callback __attribute__ ((section (".CRT$XLX"))) = mono_win32_tls_callback;
 #else
-#pragma message("TLS callback support not included in .CRT$XLX segment. Static linked runtime won't add callback into PE header.")
+#pragma message ("TLS callback support not included in .CRT$XLX segment. Static linked runtime won't add callback into PE header.")
 #endif
 #endif

--- a/mono/mini/mini-windows-tls-callback.c
+++ b/mono/mini/mini-windows-tls-callback.c
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2019 Microsoft Corporation
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+#include "mini-runtime.h"
+
+#if defined(HOST_WIN32)
+#include "mini-windows.h"
+#include <windows.h>
+
+/* Only reset by initial callback from OS loader with reason DLL_PROCESS_ATTACH */
+/* both for DLL and LIB callbacks, so no need to protect this variable. */
+static MonoWin32TLSCallbackType mono_win32_tls_callback_type = MONO_WIN32_TLS_CALLBACK_TYPE_NONE;
+
+/* NOTE, this function needs to be in this source file to make sure linker */
+/* resolve this symbol from mini-windows.c, picking up callback and */
+/* included it in TLS Directory PE header. Function makes sure we only activate */
+/* one of the supported mono callback types at runtime (if multiple one has been used) */
+gboolean
+mono_win32_handle_tls_callback_type (MonoWin32TLSCallbackType callback_type)
+{
+	if (mono_win32_tls_callback_type == MONO_WIN32_TLS_CALLBACK_TYPE_NONE)
+		mono_win32_tls_callback_type = callback_type;
+
+	if (callback_type != mono_win32_tls_callback_type)
+		return FALSE;
+
+	return TRUE;
+}
+
+MONO_EXTERN_C
+VOID NTAPI mono_win32_tls_callback (PVOID module_handle, DWORD reason, PVOID reserved);
+
+MONO_EXTERN_C
+VOID NTAPI mono_win32_tls_callback (PVOID module_handle, DWORD reason, PVOID reserved)
+{
+	mono_win32_runtime_tls_callback ((HMODULE)module_handle, reason, reserved, MONO_WIN32_TLS_CALLBACK_TYPE_LIB);
+}
+
+/* If we are building a static library that won't have access to DllMain we can't */
+/* correctly detach a thread before it terminates. The MSVC linker + runtime (also applies to MINGW) */
+/* uses a set of predefined segments/sections where callbacks can be stored and called */
+/* by OS loader (part of TLS Directory PE header), regardless if runtime is used */
+/* as a static or dynamic library. */
+#if (_MSC_VER >= 1400)
+#pragma const_seg(".CRT$XLX")
+MONO_EXTERN_C const PIMAGE_TLS_CALLBACK __mono_win32_tls_callback = mono_win32_tls_callback;
+#pragma const_seg()
+#elif defined(__MINGW64__) || (__MINGW32__)
+MONO_EXTERN_C const PIMAGE_TLS_CALLBACK __mono_win32_tls_callback __attribute__ ((section (".CRT$XLX"))) = mono_win32_tls_callback;
+#else
+#pragma message("TLS callback support not included in .CRT$XLX segment. Static linked runtime won't add callback into PE header.")
+#endif
+#endif

--- a/mono/mini/mini-windows-tls-callback.c
+++ b/mono/mini/mini-windows-tls-callback.c
@@ -20,6 +20,10 @@ static MonoWin32TLSCallbackType mono_win32_tls_callback_type = MONO_WIN32_TLS_CA
 gboolean
 mono_win32_handle_tls_callback_type (MonoWin32TLSCallbackType callback_type)
 {
+	/* Makes sure our tls callback doesn't get optimized away. */
+	extern const PIMAGE_TLS_CALLBACK __mono_win32_tls_callback;
+	const volatile PIMAGE_TLS_CALLBACK __tls_callback = __mono_win32_tls_callback;
+
 	if (mono_win32_tls_callback_type == MONO_WIN32_TLS_CALLBACK_TYPE_NONE)
 		mono_win32_tls_callback_type = callback_type;
 

--- a/mono/mini/mini-windows.h
+++ b/mono/mini/mini-windows.h
@@ -15,5 +15,18 @@
 
 gboolean
 mono_setup_thread_context(DWORD thread_id, MonoContext *mono_context);
+
+typedef enum {
+	MONO_WIN32_TLS_CALLBACK_TYPE_NONE,
+	MONO_WIN32_TLS_CALLBACK_TYPE_DLL,
+	MONO_WIN32_TLS_CALLBACK_TYPE_LIB
+} MonoWin32TLSCallbackType;
+
+gboolean
+mono_win32_handle_tls_callback_type (MonoWin32TLSCallbackType);
+
+BOOL
+mono_win32_runtime_tls_callback (HMODULE module_handle, DWORD reason, LPVOID reserved, MonoWin32TLSCallbackType callback_type);
+
 #endif /* HOST_WIN32 */
 #endif /* __MONO_MINI_WINDOWS_H__ */

--- a/msvc/libmini-win32.targets
+++ b/msvc/libmini-win32.targets
@@ -2,6 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="windows_sources">
     <ClCompile Include="$(MonoSourceLocation)\mono\mini\mini-windows.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\mini\mini-windows-tls-callback.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\mini\mini-windows.h" />
   </ItemGroup>
 </Project>

--- a/msvc/libmini-win32.targets.filters
+++ b/msvc/libmini-win32.targets.filters
@@ -4,6 +4,9 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\mini\mini-windows.c">
       <Filter>Source Files$(MonoMiniFilterSubFolder)\win32</Filter>
     </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\mono\mini\mini-windows-tls-callback.c">
+      <Filter>Source Files$(MonoMiniFilterSubFolder)\win32</Filter>
+    </ClCompile>
     <ClInclude Include="$(MonoSourceLocation)\mono\mini\mini-windows.h">
       <Filter>Header Files$(MonoMiniFilterSubFolder)\win32</Filter>
     </ClInclude>


### PR DESCRIPTION
Mono runtime depends on DllMain to be called by OS in order to correctly detach threads from the runtime. If this doesn't happen, threads from native thread pools (not owned by runtime) and attached
using native->managed callback, won't detach resulting in attached threads no longer running. Since threads are still attached to runtime, next GC will try to suspend the thread and that will fail and that in turn will put the state machine in an incorrect state, bringing down the runtime at next GC (when the thread state is revisited).

This problem is currently handled by DllMain, but since DllMain only exist in DLL's, statically link Mono runtime will get us into the above scenario.

This commit add support to hook up a TLS callback using the same mechanism used by MSVC linker and c-runtime (also available under MINGW). The callback will be included in a section/segment of an object file and included in final image (DLL or EXE) by linker and called by OS loader, solving the problem with static linked Mono runtime not being able to detach terminating threads.

The commit keeps current DllMain method when building a DLL but includes a mechanism making sure we only use one of the callback techniques at runtime, if both have been included in final image. This will simplify the build of libmini since we can always build the object including the callback, regardless
how the library will be consumed.
