### PR TITLE
[2019-06] [sgen] Fix crashes in sgen due to xdomain refs

### DIFF
--- a/mcs/class/corlib/System.Runtime.Remoting.Messaging/CADMessages.cs
+++ b/mcs/class/corlib/System.Runtime.Remoting.Messaging/CADMessages.cs
@@ -431,7 +431,11 @@ namespace System.Runtime.Remoting.Messaging {
 			ArrayList ret = null;
 
 			if (null != _serializedArgs) {
-				object[] oret = (object[]) CADSerializer.DeserializeObject (new MemoryStream (_serializedArgs));
+				// Avoid cross domain refs between MemoryStream and _serializedArgs byte array
+				byte[] copyArray = new byte [_serializedArgs.Length];
+				Array.Copy (_serializedArgs, copyArray, _serializedArgs.Length);
+
+				object[] oret = (object[]) CADSerializer.DeserializeObject (new MemoryStream (copyArray));
 				ret = new ArrayList (oret);
 				_serializedArgs = null;
 			}
@@ -498,7 +502,11 @@ namespace System.Runtime.Remoting.Messaging {
 			ArrayList ret = null;
 
 			if (null != _serializedArgs) {
-				object[] oret = (object[]) CADSerializer.DeserializeObject (new MemoryStream (_serializedArgs));
+				// Avoid cross domain refs between MemoryStream and _serializedArgs byte array
+				byte[] copyArray = new byte [_serializedArgs.Length];
+				Array.Copy (_serializedArgs, copyArray, _serializedArgs.Length);
+
+				object[] oret = (object[]) CADSerializer.DeserializeObject (new MemoryStream (copyArray));
 				ret = new ArrayList (oret);
 				_serializedArgs = null;
 			}

--- a/mono/sgen/sgen-debug.c
+++ b/mono/sgen/sgen-debug.c
@@ -965,22 +965,6 @@ is_xdomain_ref_allowed (GCObject **ptr, GCObject *obj, MonoDomain *domain)
 			offset == G_STRUCT_OFFSET (MonoRealProxy, unwrapped_server))
 		return TRUE;
 #endif
-	/*
-	 *  at System.IO.MemoryStream.InternalConstructor (byte[],int,int,bool,bool) [0x0004d] in /home/schani/Work/novell/trunk/mcs/class/corlib/System.IO/MemoryStream.cs:121
-	 * at System.IO.MemoryStream..ctor (byte[]) [0x00017] in /home/schani/Work/novell/trunk/mcs/class/corlib/System.IO/MemoryStream.cs:81
-	 * at (wrapper remoting-invoke-with-check) System.IO.MemoryStream..ctor (byte[]) <IL 0x00020, 0xffffffff>
-	 * at System.Runtime.Remoting.Messaging.CADMethodCallMessage.GetArguments () [0x0000d] in /home/schani/Work/novell/trunk/mcs/class/corlib/System.Runtime.Remoting.Messaging/CADMessages.cs:327
-	 * at System.Runtime.Remoting.Messaging.MethodCall..ctor (System.Runtime.Remoting.Messaging.CADMethodCallMessage) [0x00017] in /home/schani/Work/novell/trunk/mcs/class/corlib/System.Runtime.Remoting.Messaging/MethodCall.cs:87
-	 * at System.AppDomain.ProcessMessageInDomain (byte[],System.Runtime.Remoting.Messaging.CADMethodCallMessage,byte[]&,System.Runtime.Remoting.Messaging.CADMethodReturnMessage&) [0x00018] in /home/schani/Work/novell/trunk/mcs/class/corlib/System/AppDomain.cs:1213
-	 * at (wrapper remoting-invoke-with-check) System.AppDomain.ProcessMessageInDomain (byte[],System.Runtime.Remoting.Messaging.CADMethodCallMessage,byte[]&,System.Runtime.Remoting.Messaging.CADMethodReturnMessage&) <IL 0x0003d, 0xffffffff>
-	 * at System.Runtime.Remoting.Channels.CrossAppDomainSink.ProcessMessageInDomain (byte[],System.Runtime.Remoting.Messaging.CADMethodCallMessage) [0x00008] in /home/schani/Work/novell/trunk/mcs/class/corlib/System.Runtime.Remoting.Channels/CrossAppDomainChannel.cs:198
-	 * at (wrapper runtime-invoke) object.runtime_invoke_CrossAppDomainSink/ProcessMessageRes_object_object (object,intptr,intptr,intptr) <IL 0x0004c, 0xffffffff>
-	 */
-	if (!strcmp (m_class_get_name_space (ref->vtable->klass), "System") &&
-		!strcmp (m_class_get_name (ref->vtable->klass), "Byte[]") &&
-		!strcmp (m_class_get_name_space (o->vtable->klass), "System.IO") &&
-		!strcmp (m_class_get_name (o->vtable->klass), "MemoryStream"))
-		return TRUE;
 	return FALSE;
 }
 


### PR DESCRIPTION
CADMessages are passed directly between appdomains. When using contained data, we need to make sure we don't create any cross domain references.

When domains are unloaded, all threads executing code in that appdomain are aborted and the entire heap is traversed and objects in that appdomain are cleared. If any objects in other domains are directly referencing objects in the unloaded domain, they will reference junk. If any, cross domain refs should only be allowed when the referenced object is in the root domain which is never unloaded.

Backport of #15390.

/cc @lambdageek @BrzVlad