### PR TITLE
[netcore] Remove IsByRef check on Reflection.Emit.DynamicMethod

### DIFF
--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -839,7 +839,6 @@
 -nomethod System.Reflection.Emit.Tests.DynamicMethodGetILGenerator1.GetILGenerator_Int_Module_CoreclrIgnoresSkipVisibility
 -nomethod System.Reflection.Emit.Tests.DynamicILInfoTests.Test_TwoDimTest
 -nomethod System.Reflection.Emit.Tests.DynamicMethodToString.ToStringTest
--nomethod System.Reflection.Emit.Tests.DynamicMethodctor1.ByRefReturnType_DoesNotThrow
 -nomethod System.Reflection.Emit.Tests.DynamicMethodGetILGenerator1.GetILGenerator_Module_CoreclrIgnoresSkipVisibility
 -nomethod System.Reflection.Emit.Tests.DynamicILInfoTests.Test_GenericMethod
 -nomethod System.Reflection.Emit.Tests.DynamicILInfoTests.GetTokenFor_IntGenerics_Success

--- a/netcore/System.Private.CoreLib/src/System.Reflection.Emit/DynamicMethod.cs
+++ b/netcore/System.Private.CoreLib/src/System.Reflection.Emit/DynamicMethod.cs
@@ -109,9 +109,7 @@ namespace System.Reflection.Emit {
 			if (owner == null && typeOwner)
 				throw new ArgumentNullException (nameof (owner));
 			if ((m == null) && !anonHosted)
-				throw new ArgumentNullException ("m");
-			if (returnType.IsByRef)
-				throw new ArgumentException ("Return type can't be a byref type", "returnType");
+				throw new ArgumentNullException ("m");			
 			if (parameterTypes != null) {
 				for (int i = 0; i < parameterTypes.Length; ++i)
 					if (parameterTypes [i] == null)


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/15324

Removed check on the return type being by ref.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
