### PR TITLE
Fix suspend thread failure behavior on Windows.

### DIFF
--- a/mono/utils/mono-threads-windows.c
+++ b/mono/utils/mono-threads-windows.c
@@ -196,6 +196,8 @@ mono_threads_suspend_begin_async_suspend (MonoThreadInfo *info, gboolean interru
 	context.ContextFlags = CONTEXT_INTEGER | CONTEXT_CONTROL;
 	if (!GetThreadContext (handle, &context)) {
 		THREADS_SUSPEND_DEBUG ("SUSPEND FAILED (GetThreadContext), id=%p, err=%u\n", GUINT_TO_POINTER (id), GetLastError ());
+		result = ResumeThread (handle);
+		g_assert (result == 1);
 		return FALSE;
 	}
 

--- a/mono/utils/mono-threads-windows.c
+++ b/mono/utils/mono-threads-windows.c
@@ -209,7 +209,7 @@ mono_threads_suspend_begin_async_suspend (MonoThreadInfo *info, gboolean interru
 		result = ResumeThread (handle);
 		g_assert (result == 1);
 		info->suspend_can_continue = TRUE;
-		THREADS_SUSPEND_DEBUG ("\tlost race with self suspend %u\n", id);
+		THREADS_SUSPEND_DEBUG ("\tlost race with self suspend %p\n", GUINT_TO_POINTER (id));
 		g_assert (mono_threads_is_hybrid_suspension_enabled ());
 		//XXX interrupt_kernel doesn't make sense in this case as the target is not in a syscall
 		return TRUE;


### PR DESCRIPTION
According to documentation of mono_threads_suspend_begin_async_suspend:

"If begin suspend fails the thread must be left uninterrupted and resumed."

Current implementation on Windows didn't resume thread in case GetThreadContext fails, leaving a thread in suspended state on failure.

Fix is to resume thread if GetThreadContext fails.

PR also fix the use of THREAD_SUSPEND_DEBUG macro in the same file, since current implementation had both compile error and warnings (not used before).
