### PR TITLE
Fix 32-bit build error when using C++ compiler.

### DIFF
--- a/mono/mini/exceptions-x86.c
+++ b/mono/mini/exceptions-x86.c
@@ -664,7 +664,7 @@ get_throw_trampoline (const char *name, gboolean rethrow, gboolean llvm, gboolea
 		// ebx contains the got address.
 		// So emit the got address loading code too
 		code = mono_arch_emit_load_got_addr (start, code, NULL, &ji);
-		code = mono_arch_emit_load_aotconst (start, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, corlib ? MONO_JIT_ICALL_mono_x86_throw_corlib_exception : MONO_JIT_ICALL_mono_x86_throw_exception);
+		code = mono_arch_emit_load_aotconst (start, code, &ji, MONO_PATCH_INFO_JIT_ICALL_ADDR, GUINT_TO_POINTER (corlib ? MONO_JIT_ICALL_mono_x86_throw_corlib_exception : MONO_JIT_ICALL_mono_x86_throw_exception));
 		x86_call_reg (code, X86_EAX);
 	} else {
 		x86_call_code (code, resume_unwind ? (gpointer)(mono_x86_resume_unwind) : (corlib ? (gpointer)mono_x86_throw_corlib_exception : (gpointer)mono_x86_throw_exception));


### PR DESCRIPTION
32-bit build is broken when using C++ compiler:

https://jenkins.mono-project.com/view/All/job/test-mono-mainline-linux-cxx/label=debian-9-i386/
https://jenkins.mono-project.com/view/All/job/test-mono-mainline-cxx/
https://jenkins.mono-project.com/view/All/job/e/