### PR TITLE
[wasm] make extract_conn_url return null on unexpected data

### DIFF
--- a/sdks/wasm/ProxyDriver/TestHarnessStartup.cs
+++ b/sdks/wasm/ProxyDriver/TestHarnessStartup.cs
@@ -152,8 +152,14 @@ namespace WsProxy {
 						var client = new HttpClient ();
 						var res = client.GetStringAsync ("http://localhost:9333/json/list").Result;
 						Console.WriteLine ("res is {0}", res);
+						if (res == null)
+							return null;
+
 						var obj = JArray.Parse (res);
-						var wsURl = obj? [0]? ["webSocketDebuggerUrl"]?.Value<string> ();
+						if (obj == null || obj.Count < 1)
+							return null;
+
+						var wsURl = obj[0]? ["webSocketDebuggerUrl"]?.Value<string> ();
 						Console.WriteLine (">>> {0}", wsURl);
 
 						return wsURl;


### PR DESCRIPTION
We want to avoid throwing inside ErrorDataReceived on unexpected
input because tends to hang the process in a bad state.  Instead
we return null from extract_conn_url and let the normal cleanup
process happen.



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
