### PR TITLE
[wasm][sdk] Fix generation of version.

### DIFF
--- a/sdks/wasm/sdk/Mono.WebAssembly.Sdk/Directory.Build.targets
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Sdk/Directory.Build.targets
@@ -14,7 +14,7 @@
     <_MonoWasmRuntimePackageVersion>$(SDKPackageVersion)</_MonoWasmRuntimePackageVersion>
     <_MonoWasmBindingsPackageVersion>$(SDKPackageVersion)</_MonoWasmBindingsPackageVersion>
     <_MonoWasmHttpHandlerPackageVersion>$(SDKPackageVersion)</_MonoWasmHttpHandlerPackageVersion>
-    <_MonoWasmClientWebSocketPackageVersion>$(SDKPackageVersion)1</_MonoWasmClientWebSocketPackageVersion>
+    <_MonoWasmClientWebSocketPackageVersion>$(SDKPackageVersion)</_MonoWasmClientWebSocketPackageVersion>
   </PropertyGroup>
 </Project>
       ]]>

--- a/sdks/wasm/sdk/Mono.WebAssembly.Sdk/sdk/Versions.props
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Sdk/sdk/Versions.props
@@ -8,6 +8,6 @@
     <_MonoWasmRuntimePackageVersion>0.1.0-preview1</_MonoWasmRuntimePackageVersion>
     <_MonoWasmBindingsPackageVersion>0.1.0-preview1</_MonoWasmBindingsPackageVersion>
     <_MonoWasmHttpHandlerPackageVersion>0.1.0-preview1</_MonoWasmHttpHandlerPackageVersion>
-    <_MonoWasmClientWebSocketPackageVersion>0.1.0-preview11</_MonoWasmClientWebSocketPackageVersion>
+    <_MonoWasmClientWebSocketPackageVersion>0.1.0-preview1</_MonoWasmClientWebSocketPackageVersion>
   </PropertyGroup>
 </Project>

--- a/sdks/wasm/sdk/global.json
+++ b/sdks/wasm/sdk/global.json
@@ -2,6 +2,6 @@
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.1",
     "Microsoft.Build.Traversal": "1.0.34",
-    "Mono.WebAssembly.Sdk": "0.1.0"
+    "Mono.WebAssembly.Sdk": "0.1.0-preview1"
   }
 }


### PR DESCRIPTION
The version is incorrectly generated.

- The package reference of `ClientWebSocketPackageVersion` is generated with an appended `1` causing an error being generated when restoring.