### PR TITLE
[2019-06] Fix year+ old MIPS compile break.

### DIFF
--- a/mono/mini/mini-mips.c
+++ b/mono/mini/mini-mips.c
@@ -5095,7 +5095,7 @@ mono_arch_emit_epilog_sub (MonoCompile *cfg)
 		mips_load_const (code, mips_at, alloc2_size);
 		mips_addu (code, mips_sp, mips_sp, mips_at);
 	}
-	pos = cfg->arch.iregs_offset - alloc2_size;
+	int pos = cfg->arch.iregs_offset - alloc2_size;
 	iregs_to_restore = (cfg->used_int_regs & MONO_ARCH_CALLEE_SAVED_REGS);
 	if (iregs_to_restore) {
 		for (i = MONO_MAX_IREGS-1; i >= 0; --i) {


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/15441

Backport of #15459.

/cc @akoeplinger @jaykrell