### PR TITLE
[2019-06] [System.Windows.Forms] Fix crash of DataGridView in case of assigning a custom Column Header.

### DIFF
--- a/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewColumn.cs
+++ b/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewColumn.cs
@@ -239,6 +239,8 @@ Example */
 			set {
 				if (headerCell != value) {
 					headerCell = value;
+					headerCell.SetDataGridView(DataGridView);
+					headerCell.SetColumnIndex(Index);
 					if (DataGridView != null) {
 						DataGridView.OnColumnHeaderCellChanged(new DataGridViewColumnEventArgs(this));
 					}

--- a/mcs/class/System.Windows.Forms/Test/System.Windows.Forms/DataGridViewColumnTest.cs
+++ b/mcs/class/System.Windows.Forms/Test/System.Windows.Forms/DataGridViewColumnTest.cs
@@ -262,5 +262,17 @@ namespace MonoTests.System.Windows.Forms
 			dgv.Columns.Add (dvc);
 			Assert.IsNull (dvc.CellTemplate.DataGridView, "#1");
 		}
+
+		[Test]
+		public void SetNewHeaderCell ()
+		{
+			var dgv = new DataGridView ();
+			var dvc = new DataGridViewTextBoxColumn ();
+			var dch = new DataGridViewColumnHeaderCell ();
+			dgv.Columns.Add (dvc);
+			dvc.HeaderCell = dch;
+			Assert.IsNotNull (dch.DataGridView, "#1");
+			Assert.True (dch.ColumnIndex >= 0, "#2");
+		}
 	}
 }


### PR DESCRIPTION
This PR fix crash of `DataGridView` in case of assigning a custom Column Header.

Backport of #15135 

/cc @marek-safar 