### PR TITLE
[windows] Ensure that mono_native_tls_get_value restores last error value

### DIFF
--- a/mono/utils/mono-tls.h
+++ b/mono/utils/mono-tls.h
@@ -55,7 +55,15 @@ g_static_assert (TLS_KEY_DOMAIN == 0);
 #define mono_native_tls_alloc(key,destructor) ((*(key) = TlsAlloc ()) != TLS_OUT_OF_INDEXES && destructor == NULL)
 #define mono_native_tls_free TlsFree
 #define mono_native_tls_set_value TlsSetValue
-#define mono_native_tls_get_value TlsGetValue
+
+static inline LPVOID mono_native_tls_get_value (MonoNativeTlsKey key)
+{
+	DWORD last_error = GetLastError ();
+	LPVOID result = TlsGetValue (key);
+	g_assert (GetLastError () == 0);
+	SetLastError (last_error);
+	return result;
+}
 
 #else
 

--- a/mono/utils/mono-tls.h
+++ b/mono/utils/mono-tls.h
@@ -58,10 +58,10 @@ g_static_assert (TLS_KEY_DOMAIN == 0);
 
 static inline LPVOID mono_native_tls_get_value (MonoNativeTlsKey key)
 {
-	DWORD last_error = GetLastError ();
+	W32_DEFINE_LAST_ERROR_RESTORE_POINT;
 	LPVOID result = TlsGetValue (key);
 	g_assert (GetLastError () == 0);
-	SetLastError (last_error);
+	W32_RESTORE_LAST_ERROR_FROM_RESTORE_POINT;
 	return result;
 }
 


### PR DESCRIPTION
On MinGW64 builds the interpreter is incorrectly overwriting last error values on P/Invoke calls. I traced it down to the usage of `TlsGetValue` which always overrides the last error value. The documentation states the following: 

> Functions that return indications of failure call SetLastError when they fail. They generally do not call SetLastError when they succeed. The TlsGetValue function is an exception to this general rule. The TlsGetValue function calls SetLastError to clear a thread's last error when it succeeds. That allows checking for the error-free retrieval of zero values.

The TLS code path is hit from the following line:

https://github.com/mono/mono/blob/112297ef5c076a2716c020ddb0bbf1e0a2da7703/mono/mini/interp/interp.c#L2003

Note that this is not a performance concern for official builds since the MSVC builds always use `__declspec(thread)` feature. MinGW should probably support `__thread` but configure script doesn't detect it.