### PR TITLE
[2019-06] [loader] remap only System.Threading.Tasks.Dataflow older than 4.0.0.0

### DIFF
--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -304,7 +304,7 @@ static const AssemblyVersionMap framework_assemblies [] = {
 	FACADE_ASSEMBLY ("System.Threading.AccessControl"),
 	FACADE_ASSEMBLY ("System.Threading.Overlapped"),
 	FACADE_ASSEMBLY ("System.Threading.Tasks"),
-	{"System.Threading.Tasks.Dataflow", 0},
+	{"System.Threading.Tasks.Dataflow", 0, NULL, TRUE},
 	FACADE_ASSEMBLY ("System.Threading.Tasks.Extensions"),
 	FACADE_ASSEMBLY ("System.Threading.Tasks.Parallel"),
 	FACADE_ASSEMBLY ("System.Threading.Thread"),


### PR DESCRIPTION
Allow through requests for newer versions unchanged.



Backport of #15266.

/cc @lewing @lambdageek