### PR TITLE
Abort async suspend request on failure doing preemptive suspend.

### DIFF
--- a/mono/utils/mono-threads-posix.c
+++ b/mono/utils/mono-threads-posix.c
@@ -24,6 +24,7 @@
 #endif
 
 #include <mono/utils/mono-threads.h>
+#include <mono/utils/mono-threads-coop.h>
 #include <mono/utils/mono-coop-semaphore.h>
 #include <mono/metadata/gc-internals.h>
 #include <mono/utils/mono-threads-debug.h>
@@ -350,6 +351,13 @@ mono_threads_suspend_begin_async_suspend (MonoThreadInfo *info, gboolean interru
 
 	if (!mono_threads_pthread_kill (info, sig)) {
 		mono_threads_add_to_pending_operation_set (info);
+		return TRUE;
+	}
+	if (!mono_threads_transition_abort_async_suspend (info)) {
+		/* We raced with self suspend and lost so suspend can continue. */
+		g_assert (mono_threads_is_hybrid_suspension_enabled ());
+		info->suspend_can_continue = TRUE;
+		THREADS_SUSPEND_DEBUG ("\tlost race with self suspend %p\n", mono_thread_info_get_tid (info));
 		return TRUE;
 	}
 	return FALSE;

--- a/mono/utils/mono-threads.h
+++ b/mono/utils/mono-threads.h
@@ -563,7 +563,10 @@ This begins async suspend. This function must do the following:
 -Call mono_threads_transition_finish_async_suspend as part of its async suspend.
 -Register the thread for pending suspend with mono_threads_add_to_pending_operation_set if needed.
 
-If begin suspend fails the thread must be left uninterrupted and resumed.
+If begin suspend fails the following should be done:
+-The thread must be left uninterrupted and resumed.
+-Call mono_threads_transition_abort_async_suspend to make sure thread has correct state.
+-No pending suspend should be registered with mono_threads_add_to_pending_operation_set for this operation.
 */
 gboolean mono_threads_suspend_begin_async_suspend (THREAD_INFO_TYPE *info, gboolean interrupt_kernel);
 
@@ -707,6 +710,7 @@ MonoRequestSuspendResult mono_threads_transition_request_suspension (THREAD_INFO
 MonoSelfSupendResult mono_threads_transition_state_poll (THREAD_INFO_TYPE *info);
 MonoResumeResult mono_threads_transition_request_resume (THREAD_INFO_TYPE* info);
 MonoPulseResult mono_threads_transition_request_pulse (THREAD_INFO_TYPE* info);
+gboolean mono_threads_transition_abort_async_suspend (THREAD_INFO_TYPE* info);
 gboolean mono_threads_transition_finish_async_suspend (THREAD_INFO_TYPE* info);
 MonoDoBlockingResult mono_threads_transition_do_blocking (THREAD_INFO_TYPE* info, const char* func);
 MonoDoneBlockingResult mono_threads_transition_done_blocking (THREAD_INFO_TYPE* info, const char* func);


### PR DESCRIPTION
When a preemptive suspend fails, state machine will get into an invalid state and the thread is in an unknown state (running/self-suspended). In case of failure in mono_threads_suspend_begin_async_suspend, a new method should be called, mono_threads_transition_abort_async_suspend making sure state machine reflects correct thread state as well as reporting correct result to initial caller of mono_threads_suspend_begin_async_suspend.
