### PR TITLE
[netcore] AOT example

### DIFF
--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -108,6 +108,15 @@ bcl: update-roslyn System.Private.CoreLib/src/System/Environment.Mono.cs
 	-p:RoslynPropsFile="../roslyn/packages/microsoft.net.compilers.toolset/$(ROSLYN_VERSION)/build/Microsoft.Net.Compilers.Toolset.props" \
 	System.Private.CoreLib/System.Private.CoreLib.csproj
 
+aot-shared:
+	# TODO: parallelism
+	# TODO: let some tool figure out the relevant paths
+	for assembly in shared/Microsoft.NETCore.App/3.0.0-preview7-27804-03/*.dll corefx/packages/runtime.osx-x64.microsoft.private.corefx.netcoreapp/4.6.0-preview7.19305.1/runtimes/osx-x64/lib/netcoreapp3.0/*.dll; do \
+		echo "[AOT] $$assembly"; \
+		MONO_PATH=./shared/Microsoft.NETCore.App/3.0.0-preview7-27804-03/ ../mono/mini/mono-sgen --llvm --aot $$assembly ; \
+	done; \
+
+
 debug-bcl:
 	$(MAKE) bcl CORLIB_BUILD_FLAGS="-c Debug"
 


### PR DESCRIPTION
Needs https://github.com/mono/mono/pull/15483 to get the proper output.

```console
$ ./autogen.sh --enable-llvm --with-core=only ...   # make sure you enable LLVM
[...]
$ make -j
[...]
$ MONO_ENV_OPTIONS='--stats' make -C netcore run-tests-corefx-System.IO.Compression.Tests
[...]
Microsoft.DotNet.XUnitConsoleRunner v2.5.0 (64-bit .NET Core 3.0.0-preview7-27804-03)
  Discovering: System.IO.Compression.Tests (method display = ClassAndMethod, method display options = None)
  Discovered:  System.IO.Compression.Tests (found 139 of 150 test cases)
  Starting:    System.IO.Compression.Tests (parallel test collections = on, max threads = 16)
  Finished:    System.IO.Compression.Tests
=== TEST EXECUTION SUMMARY ===
   System.IO.Compression.Tests  Total: 319, Errors: 0, Failed: 0, Skipped: 0, Time: 6.100s
[...]
Compiled methods                    : 8444
Methods from AOT                    : 0
Methods from AOT+LLVM               : 0
Methods JITted using mono JIT       : 8444
Methods JITted using LLVM           : 0
[...]
$ make -C netcore aot-shared  # grab a ☕️
[...]
$ MONO_ENV_OPTIONS='--stats' make -C netcore run-tests-corefx-System.IO.Compression.Tests
[...]
Microsoft.DotNet.XUnitConsoleRunner v2.5.0 (64-bit .NET Core 3.0.0-preview7-27804-03)
  Discovering: System.IO.Compression.Tests (method display = ClassAndMethod, method display options = None)
  Discovered:  System.IO.Compression.Tests (found 139 of 150 test cases)
  Starting:    System.IO.Compression.Tests (parallel test collections = on, max threads = 16)
  Finished:    System.IO.Compression.Tests
=== TEST EXECUTION SUMMARY ===
   System.IO.Compression.Tests  Total: 319, Errors: 0, Failed: 0, Skipped: 0, Time: 5.706s
[...]
Compiled methods                    : 5815
Methods from AOT                    : 43
Methods from AOT+LLVM               : 1341
Methods JITted using mono JIT       : 5815
Methods JITted using LLVM           : 0
[...]
```

Most JIT methods in this example are from xunit and test assembly.

Some more diagnostic tips:
* `MONO_ENV_OPTIONS=-v` prints the name of each method that is JIT compiled.
* `MONO_LOG_LEVEL=info MONO_LOG_MASK=aot` prints for which DLLs a AOT image can/can't be found.
* remove `--llvm` in the AOT invocation for faster compilation times (I assume that will be useful when working on the tooling).



/cc @marek-safar @lambdageek @steveisok @SamMonoRT @lewing @vargaz 