### PR TITLE
Disable zlib on mingw Windows build to avoid dependency on zlib1.dll.

### DIFF
--- a/mono/metadata/debug-mono-ppdb.c
+++ b/mono/metadata/debug-mono-ppdb.c
@@ -29,7 +29,7 @@
 #include <mono/utils/bsearch.h>
 #include <mono/utils/mono-logger-internals.h>
 
-#if defined (HAVE_SYS_ZLIB)
+#if defined (HAVE_SYS_ZLIB) && !defined(HOST_WIN32)
 #include <zlib.h>
 #endif
 
@@ -172,7 +172,7 @@ mono_ppdb_load_file (MonoImage *image, const guint8 *raw_contents, int size)
 
 	if (ppdb_data) {
 		/* Embedded PPDB data */
-#if defined (HAVE_SYS_ZLIB)
+#if defined (HAVE_SYS_ZLIB) && !defined(HOST_WIN32)
 		/* ppdb_size is the uncompressed size */
 		guint8 *data = g_malloc0 (ppdb_size);
 		z_stream stream;

--- a/mono/mini/Makefile.am.in
+++ b/mono/mini/Makefile.am.in
@@ -243,8 +243,12 @@ else
 LLVMMONOF=$(LLVM_LIBS) $(LLVM_LDFLAGS)
 endif
 
+if !HOST_WIN32
 if HAVE_ZLIB
 Z_LIBS= -lz
+else
+Z_LIBS=
+endif
 else
 Z_LIBS=
 endif


### PR DESCRIPTION
https://github.com/mono/mono/pull/4484 broke Windows mingw build due to new dependency, zlib1.dll not available in PATH on build bots. Disabling for now until we know how this should be handled (and also fixed for MSVC build runtime).