### PR TITLE
[2019-06] Disable compiler server on darwin. Add force-enable option.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6535,21 +6535,35 @@ if test x$host_darwin = xyes; then
    sed -e 's,lock_old_archive_extraction=yes,lock_old_archive_extraction=no,g' < libtool > libtool.new && mv libtool.new libtool && chmod +x libtool
 fi
 
+force_enable_compiler_server=no;
+
 AC_MSG_CHECKING([compiler server])
-AC_ARG_WITH(compiler-server, [  --with-compiler-server=yes,no,default      Enables or disables compiler server],[
+AC_ARG_WITH(compiler-server, [  --with-compiler-server=yes,no,default,force      Enables or disables compiler server],[
    if test x$withval = xyes; then
        enable_compiler_server=yes;
+   # force will bypass any automatic disables to allow you to test the compiler server
+   #  in scenarios where it is disabled
+   elif test x$withval = xforce; then
+       enable_compiler_server=yes;
+       force_enable_compiler_server=yes;
    elif test x$withval = xno; then
        enable_compiler_server=no;
    elif test x$withval = xdefault; then
        enable_compiler_server=no;
    else
-       AC_MSG_ERROR([You must supply one of "yes", "no" or "default" to the --with-compiler-server option])
+       AC_MSG_ERROR([You must supply one of "yes", "no", "default" or "force" to the --with-compiler-server option])
    fi
 ],[enable_compiler_server=no])
 
+AC_MSG_RESULT($enable_compiler_server)
+
 if test x$enable_compiler_server = xyes; then
-   if test x$csc_compiler = xmcs; then
+   if test x$force_enable_compiler_server = xyes; then
+       AC_MSG_WARN([forcing compiler server to stay enabled])
+   elif test x$host_darwin = xyes; then
+       AC_MSG_WARN([compiler server temporarily disabled on darwin])
+       enable_compiler_server=no;
+   elif test x$csc_compiler = xmcs; then
        AC_MSG_WARN([mcs does not support the compiler server])
        enable_compiler_server=no;
    fi


### PR DESCRIPTION


Backport of #15450.

/cc @lewing @kg