### PR TITLE
AC_DEFINE instead of AC_SUBST MONO_DL_NEED_USCORE.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2153,11 +2153,8 @@ if test x$host_win32 = xno; then
 		  ])
 		fi
 		if test "x$mono_cv_uscore" = "xyes"; then
-			MONO_DL_NEED_USCORE=1
-		else
-			MONO_DL_NEED_USCORE=0
+			AC_DEFINE(MONO_DL_NEED_USCORE, 1, [Does dlsym require leading underscore.])
 		fi
-		AC_SUBST(MONO_DL_NEED_USCORE)
 		AC_CHECK_FUNC(dlerror)
 	fi
 


### PR DESCRIPTION
i.e. so it can be used in C instead of make.
i.e. so it can actually work.
Alternatively since it is not working, could remove it.

The lone use is here:
```
C:\s\mono2\mono\utils\mono-dl.c(271):#if MONO_DL_NEED_USCORE
```