### PR TITLE
Follow convention: "static inline" is for .h, "static" is for .c.

### DIFF
--- a/mono/arch/s390x/tramp.c
+++ b/mono/arch/s390x/tramp.c
@@ -309,7 +309,7 @@ enum_retvalue:
 /*                                                                  */
 /*------------------------------------------------------------------*/
 
-static inline guint8 *
+static guint8 *
 emit_prolog (guint8 *p, MonoMethodSignature *sig, size_data *sz)
 {
 	guint stack_size;
@@ -543,7 +543,7 @@ emit_save_parameters (guint8 *p, MonoMethodSignature *sig, size_data *sz)
 /*                                                                  */
 /*------------------------------------------------------------------*/
 
-static inline guint8 *
+static guint8 *
 alloc_code_memory (guint code_size)
 {
 	guint8 *p;
@@ -573,7 +573,7 @@ alloc_code_memory (guint code_size)
 /*                                                                  */
 /*------------------------------------------------------------------*/
 
-static inline guint8 *
+static guint8 *
 emit_call_and_store_retval (guint8 *p, MonoMethodSignature *sig, 
 			    size_data *sz, gboolean string_ctor)
 {
@@ -674,7 +674,7 @@ printf("Returning %d bytes for type %d (%d)\n",retSize,simpletype,sig->pinvoke);
 /*                                                                  */
 /*------------------------------------------------------------------*/
 
-static inline guint8 *
+static guint8 *
 emit_epilog (guint8 *p, MonoMethodSignature *sig, size_data *sz)
 {
 	/* function epilog */

--- a/mono/btls/btls-pkcs12.c
+++ b/mono/btls/btls-pkcs12.c
@@ -55,13 +55,13 @@ allocate_btls_password (const void *password)
 	return buffer;
 }
 #else
-static inline void
+static void
 deallocate_btls_password (char *password)
 {
 	return;
 }
 
-static inline char *
+static char *
 allocate_btls_password (const void *password)
 {
 	return (char *)password;

--- a/mono/eglib/glist.c
+++ b/mono/eglib/glist.c
@@ -36,7 +36,7 @@ g_list_alloc (void)
 	return g_new0 (GList, 1);
 }
 
-static inline GList*
+static GList*
 new_node (GList *prev, gpointer data, GList *next)
 {
 	GList *node = g_list_alloc ();
@@ -50,7 +50,7 @@ new_node (GList *prev, gpointer data, GList *next)
 	return node;
 }
 
-static inline GList*
+static GList*
 disconnect_node (GList *node)
 {
 	if (node->next)

--- a/mono/eglib/gmisc-win32.c
+++ b/mono/eglib/gmisc-win32.c
@@ -149,7 +149,7 @@ g_get_known_folder_path (void)
 
 #else
 
-static inline gchar *
+static gchar *
 g_get_known_folder_path (void)
 {
 	return NULL;

--- a/mono/eglib/gslist.c
+++ b/mono/eglib/gslist.c
@@ -63,7 +63,7 @@ g_slist_prepend (GSList *list, gpointer data)
  * Insert the given data in a new node after the current node. 
  * Return new node.
  */
-static inline GSList *
+static GSList *
 insert_after (GSList *list, gpointer data)
 {
 	list->next = g_slist_prepend (list->next, data);
@@ -75,7 +75,7 @@ insert_after (GSList *list, gpointer data)
  * If the list is empty, or the first node contains 'data', return NULL.
  * If no node contains 'data', return the last node.
  */
-static inline GSList*
+static GSList*
 find_prev (GSList *list, gconstpointer data)
 {
 	GSList *prev = NULL;
@@ -89,7 +89,7 @@ find_prev (GSList *list, gconstpointer data)
 }
 
 /* like 'find_prev', but searches for node 'link' */
-static inline GSList*
+static GSList*
 find_prev_link (GSList *list, GSList *link)
 {
 	GSList *prev = NULL;

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -4098,7 +4098,7 @@ search_binding_loaded (MonoAssemblyName *aname)
 	return NULL;
 }
 
-static inline gboolean
+static gboolean
 info_compare_versions (AssemblyVersionSet *left, AssemblyVersionSet *right)
 {
 	if (left->major != right->major || left->minor != right->minor ||
@@ -4108,7 +4108,7 @@ info_compare_versions (AssemblyVersionSet *left, AssemblyVersionSet *right)
 	return TRUE;
 }
 
-static inline gboolean
+static gboolean
 info_versions_equal (MonoAssemblyBindingInfo *left, MonoAssemblyBindingInfo *right)
 {
 	if (left->has_old_version_bottom != right->has_old_version_bottom)
@@ -4172,7 +4172,7 @@ get_version_number (int major, int minor)
 	return major * 256 + minor;
 }
 
-static inline gboolean
+static gboolean
 info_major_minor_in_range (MonoAssemblyBindingInfo *info, MonoAssemblyName *aname)
 {
 	int aname_version_number = get_version_number (aname->major, aname->minor);

--- a/mono/metadata/boehm-gc.c
+++ b/mono/metadata/boehm-gc.c
@@ -1683,17 +1683,17 @@ mono_gc_register_finalizer_callbacks (MonoGCFinalizerCallbacks *callbacks)
 
 #define BITMAP_SIZE (sizeof (*((HandleData *)NULL)->bitmap) * CHAR_BIT)
 
-static inline gboolean
+static gboolean
 slot_occupied (HandleData *handles, guint slot) {
 	return handles->bitmap [slot / BITMAP_SIZE] & (1 << (slot % BITMAP_SIZE));
 }
 
-static inline void
+static void
 vacate_slot (HandleData *handles, guint slot) {
 	handles->bitmap [slot / BITMAP_SIZE] &= ~(1 << (slot % BITMAP_SIZE));
 }
 
-static inline void
+static void
 occupy_slot (HandleData *handles, guint slot) {
 	handles->bitmap [slot / BITMAP_SIZE] |= 1 << (slot % BITMAP_SIZE);
 }

--- a/mono/metadata/class-init.c
+++ b/mono/metadata/class-init.c
@@ -64,13 +64,13 @@ static MonoNativeTlsKey setup_fields_tls_id;
 
 static MonoNativeTlsKey init_pending_tls_id;
 
-static inline void
+static void
 classes_lock (void)
 {
 	mono_locks_os_acquire (&classes_mutex, ClassesLock);
 }
 
-static inline void
+static void
 classes_unlock (void)
 {
 	mono_locks_os_release (&classes_mutex, ClassesLock);

--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -282,7 +282,7 @@ _mono_type_get_assembly_name (MonoClass *klass, GString *str)
 	g_free (name);
 }
 
-static inline void
+static void
 mono_type_name_check_byref (MonoType *type, GString *str)
 {
 	if (type->byref)

--- a/mono/metadata/dynamic-image.c
+++ b/mono/metadata/dynamic-image.c
@@ -33,13 +33,13 @@
 static GPtrArray *dynamic_images;
 static mono_mutex_t dynamic_images_mutex;
 
-static inline void
+static void
 dynamic_images_lock (void)
 {
 	mono_os_mutex_lock (&dynamic_images_mutex);
 }
 
-static inline void
+static void
 dynamic_images_unlock (void)
 {
 	mono_os_mutex_unlock (&dynamic_images_mutex);
@@ -122,7 +122,7 @@ mono_find_dynamic_image_owner (void *ptr)
 	return owner;
 }
 
-static inline void
+static void
 dynamic_image_lock (MonoDynamicImage *image)
 {
 	MONO_ENTER_GC_SAFE;
@@ -130,7 +130,7 @@ dynamic_image_lock (MonoDynamicImage *image)
 	MONO_EXIT_GC_SAFE;
 }
 
-static inline void
+static void
 dynamic_image_unlock (MonoDynamicImage *image)
 {
 	mono_image_unlock ((MonoImage*)image);

--- a/mono/metadata/gc.c
+++ b/mono/metadata/gc.c
@@ -114,7 +114,7 @@ typedef struct {
 	MonoCoopMutex *mutex;
 } BreakCoopAlertableWaitUD;
 
-static inline void
+static void
 break_coop_alertable_wait (gpointer user_data)
 {
 	BreakCoopAlertableWaitUD *ud = (BreakCoopAlertableWaitUD*)user_data;
@@ -132,7 +132,7 @@ break_coop_alertable_wait (gpointer user_data)
  *   Wait on COND/MUTEX. If ALERTABLE is non-null, the wait can be interrupted.
  * In that case, *ALERTABLE will be set to TRUE, and 0 is returned.
  */
-static inline gint
+static gint
 coop_cond_timedwait_alertable (MonoCoopCond *cond, MonoCoopMutex *mutex, guint32 timeout_ms, gboolean *alertable)
 {
 	BreakCoopAlertableWaitUD *ud;

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -2274,7 +2274,7 @@ mono_dynamic_stream_reset (MonoDynamicStream* stream)
 	}
 }
 
-static inline void
+static void
 free_hash (GHashTable *hash)
 {
 	if (hash)

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -5503,7 +5503,7 @@ ves_icall_System_Runtime_InteropServices_Marshal_AllocHGlobal (gsize size, MonoE
 }
 
 #ifndef HOST_WIN32
-static inline gpointer
+static gpointer
 mono_marshal_realloc_hglobal (gpointer ptr, size_t size)
 {
 	return g_try_realloc (ptr, size);
@@ -5527,7 +5527,7 @@ ves_icall_System_Runtime_InteropServices_Marshal_ReAllocHGlobal (gpointer ptr, g
 }
 
 #ifndef HOST_WIN32
-static inline void
+static void
 mono_marshal_free_hglobal (gpointer ptr)
 {
 	g_free (ptr);
@@ -5569,7 +5569,7 @@ ves_icall_System_Runtime_InteropServices_Marshal_FreeCoTaskMem (void *ptr)
 }
 
 #ifndef HOST_WIN32
-static inline gpointer
+static gpointer
 mono_marshal_realloc_co_task_mem (gpointer ptr, size_t size)
 {
 	return g_try_realloc (ptr, size);

--- a/mono/metadata/metadata.c
+++ b/mono/metadata/metadata.c
@@ -557,7 +557,7 @@ inverse of this mapping.
  */
 #define rtsize(meta,s,b) (((s) < (1 << (b)) ? 2 : 4))
 
-static inline int
+static int
 idx_size (MonoImage *meta, int idx)
 {
 	if (meta->referenced_tables && (meta->referenced_tables & ((guint64)1 << idx)))
@@ -566,7 +566,7 @@ idx_size (MonoImage *meta, int idx)
 		return meta->tables [idx].rows < 65536 ? 2 : 4;
 }
 
-static inline int
+static int
 get_nrows (MonoImage *meta, int idx)
 {
 	if (meta->referenced_tables && (meta->referenced_tables & ((guint64)1 << idx)))
@@ -2558,13 +2558,13 @@ aggregate_modifiers_in_image (MonoAggregateModContainer *amods, MonoImage *image
 	return FALSE;
 }
 
-static inline void
+static void
 image_sets_lock (void)
 {
 	mono_os_mutex_lock (&image_sets_mutex);
 }
 
-static inline void
+static void
 image_sets_unlock (void)
 {
 	mono_os_mutex_unlock (&image_sets_mutex);
@@ -2904,7 +2904,7 @@ enlarge_data (CollectData *data)
 	data->images_len = new_len;
 }
 
-static inline void
+static void
 add_image (MonoImage *image, CollectData *data)
 {
 	int i;

--- a/mono/metadata/monitor.c
+++ b/mono/metadata/monitor.c
@@ -90,19 +90,19 @@ static int array_size = 16;
 
 /* MonoThreadsSync status helpers */
 
-static inline guint32
+static guint32
 mon_status_get_owner (guint32 status)
 {
 	return status & OWNER_MASK;
 }
 
-static inline guint32
+static guint32
 mon_status_set_owner (guint32 status, guint32 owner)
 {
 	return (status & ENTRY_COUNT_MASK) | owner;
 }
 
-static inline gint32
+static gint32
 mon_status_get_entry_count (guint32 status)
 {
 	gint32 entry_count = (gint32)((status & ENTRY_COUNT_MASK) >> ENTRY_COUNT_SHIFT);
@@ -110,13 +110,13 @@ mon_status_get_entry_count (guint32 status)
 	return entry_count - zero;
 }
 
-static inline guint32
+static guint32
 mon_status_init_entry_count (guint32 status)
 {
 	return (status & OWNER_MASK) | ENTRY_COUNT_ZERO;
 }
 
-static inline guint32
+static guint32
 mon_status_add_entry_count (guint32 status, int val)
 {
 	if (val > 0)
@@ -125,7 +125,7 @@ mon_status_add_entry_count (guint32 status, int val)
 		return status - ((-val) << ENTRY_COUNT_SHIFT);
 }
 
-static inline gboolean
+static gboolean
 mon_status_have_waiters (guint32 status)
 {
 	return status & ENTRY_COUNT_WAITERS;
@@ -133,26 +133,26 @@ mon_status_have_waiters (guint32 status)
 
 /* LockWord helpers */
 
-static inline MonoThreadsSync*
+static MonoThreadsSync*
 lock_word_get_inflated_lock (LockWord lw)
 {
 	lw.lock_word &= (~LOCK_WORD_STATUS_MASK);
 	return lw.sync;
 }
 
-static inline gboolean
+static gboolean
 lock_word_is_inflated (LockWord lw)
 {
 	return lw.lock_word & LOCK_WORD_INFLATED;
 }
 
-static inline gboolean
+static gboolean
 lock_word_has_hash (LockWord lw)
 {
 	return lw.lock_word & LOCK_WORD_HAS_HASH;
 }
 
-static inline LockWord
+static LockWord
 lock_word_set_has_hash (LockWord lw)
 {
 	LockWord nlw;
@@ -160,26 +160,26 @@ lock_word_set_has_hash (LockWord lw)
 	return nlw;
 }
 
-static inline gboolean
+static gboolean
 lock_word_is_free (LockWord lw)
 {
 	return !lw.lock_word;
 }
 
-static inline gboolean
+static gboolean
 lock_word_is_flat (LockWord lw)
 {
 	/* Return whether the lock is flat or free */
 	return (lw.lock_word & LOCK_WORD_STATUS_MASK) == LOCK_WORD_FLAT;
 }
 
-static inline gint32
+static gint32
 lock_word_get_hash (LockWord lw)
 {
 	return (gint32) (lw.lock_word >> LOCK_WORD_HASH_SHIFT);
 }
 
-static inline gint32
+static gint32
 lock_word_get_nest (LockWord lw)
 {
 	if (lock_word_is_free (lw))
@@ -188,39 +188,39 @@ lock_word_get_nest (LockWord lw)
 	return ((lw.lock_word & LOCK_WORD_NEST_MASK) >> LOCK_WORD_NEST_SHIFT) + 1;
 }
 
-static inline gboolean
+static gboolean
 lock_word_is_nested (LockWord lw)
 {
 	return lw.lock_word & LOCK_WORD_NEST_MASK;
 }
 
-static inline gboolean
+static gboolean
 lock_word_is_max_nest (LockWord lw)
 {
 	return (lw.lock_word & LOCK_WORD_NEST_MASK) == LOCK_WORD_NEST_MASK;
 }
 
-static inline LockWord
+static LockWord
 lock_word_increment_nest (LockWord lw)
 {
 	lw.lock_word += 1 << LOCK_WORD_NEST_SHIFT;
 	return lw;
 }
 
-static inline LockWord
+static LockWord
 lock_word_decrement_nest (LockWord lw)
 {
 	lw.lock_word -= 1 << LOCK_WORD_NEST_SHIFT;
 	return lw;
 }
 
-static inline gint32
+static gint32
 lock_word_get_owner (LockWord lw)
 {
 	return lw.lock_word >> LOCK_WORD_OWNER_SHIFT;
 }
 
-static inline LockWord
+static LockWord
 lock_word_new_thin_hash (gint32 hash)
 {
 	LockWord lw;
@@ -229,7 +229,7 @@ lock_word_new_thin_hash (gint32 hash)
 	return lw;
 }
 
-static inline LockWord
+static LockWord
 lock_word_new_inflated (MonoThreadsSync *mon)
 {
 	LockWord lw;
@@ -238,7 +238,7 @@ lock_word_new_inflated (MonoThreadsSync *mon)
 	return lw;
 }
 
-static inline LockWord
+static LockWord
 lock_word_new_flat (gint32 owner)
 {
 	LockWord lw;
@@ -782,7 +782,7 @@ signal_monitor (gpointer mon_untyped)
 /* If allow_interruption==TRUE, the method will be interrupted if abort or suspend
  * is requested. In this case it returns -1.
  */ 
-static inline gint32 
+static gint32
 mono_monitor_try_enter_inflated (MonoObject *obj, guint32 ms, gboolean allow_interruption, guint32 id)
 {
 	LockWord lw;
@@ -969,7 +969,7 @@ retry_contended:
  * If allow_interruption == TRUE, the method will be interrupted if abort or suspend
  * is requested. In this case it returns -1.
  */
-static inline gint32
+static gint32
 mono_monitor_try_enter_internal (MonoObject *obj, guint32 ms, gboolean allow_interruption)
 {
 	LockWord lw;

--- a/mono/metadata/mono-conc-hash.c
+++ b/mono/metadata/mono-conc-hash.c
@@ -108,7 +108,7 @@ mix_hash (int hash)
 }
 
 
-static inline void
+static void
 set_key (conc_table *table, int slot, gpointer key)
 {
 	gpointer *key_addr = &table->keys [slot];
@@ -118,7 +118,7 @@ set_key (conc_table *table, int slot, gpointer key)
 		*key_addr = key;
 }
 
-static inline void
+static void
 set_key_to_tombstone (conc_table *table, int slot)
 {
 	gpointer *key_addr = &table->keys [slot];
@@ -128,7 +128,7 @@ set_key_to_tombstone (conc_table *table, int slot)
 		*key_addr = PTR_TOMBSTONE;
 }
 
-static inline void
+static void
 set_value (conc_table *table, int slot, gpointer value)
 {
 	gpointer *value_addr = &table->values [slot];

--- a/mono/metadata/mono-debug.c
+++ b/mono/metadata/mono-debug.c
@@ -70,7 +70,7 @@ static void                 add_assembly    (MonoAssemblyLoadContext *alc, MonoA
 
 static MonoDebugHandle     *open_symfile_from_bundle   (MonoImage *image);
 
-static inline DebugDomainInfo*
+static DebugDomainInfo*
 get_domain_info (MonoDomain *domain)
 {
 	g_assert (domain->debug_info);
@@ -351,7 +351,7 @@ mono_debug_image_has_debug_info (MonoImage *image)
 	return data.found;
 }
 
-static inline void
+static void
 write_leb128 (guint32 value, guint8 *ptr, guint8 **rptr)
 {
 	do {
@@ -365,7 +365,7 @@ write_leb128 (guint32 value, guint8 *ptr, guint8 **rptr)
 	*rptr = ptr;
 }
 
-static inline void
+static void
 write_sleb128 (gint32 value, guint8 *ptr, guint8 **rptr)
 {
 	gboolean more = 1;
@@ -526,7 +526,7 @@ mono_debug_add_delegate_trampoline (gpointer code, int size)
 {
 }
 
-static inline guint32
+static guint32
 read_leb128 (guint8 *ptr, guint8 **rptr)
 {
 	guint32 result = 0, shift = 0;
@@ -544,7 +544,7 @@ read_leb128 (guint8 *ptr, guint8 **rptr)
 	return result;
 }
 
-static inline gint32
+static gint32
 read_sleb128 (guint8 *ptr, guint8 **rptr)
 {
 	gint32 result = 0;

--- a/mono/metadata/mono-hash.c
+++ b/mono/metadata/mono-hash.c
@@ -91,7 +91,7 @@ calc_prime (int x)
 /* We triple the table size at rehash time, similar with previous implementation */
 #define HASH_TABLE_RESIZE_RATIO 3
 
-static inline void mono_g_hash_table_key_store (MonoGHashTable *hash, int slot, MonoObject* key)
+static void mono_g_hash_table_key_store (MonoGHashTable *hash, int slot, MonoObject* key)
 {
 	MonoObject **key_addr = &hash->keys [slot];
 	if (hash->gc_type & MONO_HASH_KEY_GC)
@@ -100,7 +100,7 @@ static inline void mono_g_hash_table_key_store (MonoGHashTable *hash, int slot, 
 		*key_addr = key;
 }
 
-static inline void mono_g_hash_table_value_store (MonoGHashTable *hash, int slot, MonoObject* value)
+static void mono_g_hash_table_value_store (MonoGHashTable *hash, int slot, MonoObject* value)
 {
 	MonoObject **value_addr = &hash->values [slot];
 	if (hash->gc_type & MONO_HASH_VALUE_GC)
@@ -110,7 +110,7 @@ static inline void mono_g_hash_table_value_store (MonoGHashTable *hash, int slot
 }
 
 /* Returns position of key or of an empty slot for it */
-static inline int mono_g_hash_table_find_slot (MonoGHashTable *hash, const MonoObject *key)
+static int mono_g_hash_table_find_slot (MonoGHashTable *hash, const MonoObject *key)
 {
 	guint start = ((*hash->hash_func) (key)) % hash->table_size;
 	guint i = start;

--- a/mono/metadata/null-gc-handles.c
+++ b/mono/metadata/null-gc-handles.c
@@ -82,17 +82,17 @@ mono_gc_weak_link_get (void **link_addr)
 	return obj;
 }
 
-static inline gboolean
+static gboolean
 slot_occupied (HandleData *handles, guint slot) {
 	return handles->bitmap [slot / BITMAP_SIZE] & (1 << (slot % BITMAP_SIZE));
 }
 
-static inline void
+static void
 vacate_slot (HandleData *handles, guint slot) {
 	handles->bitmap [slot / BITMAP_SIZE] &= ~(1 << (slot % BITMAP_SIZE));
 }
 
-static inline void
+static void
 occupy_slot (HandleData *handles, guint slot) {
 	handles->bitmap [slot / BITMAP_SIZE] |= 1 << (slot % BITMAP_SIZE);
 }

--- a/mono/metadata/object.c
+++ b/mono/metadata/object.c
@@ -201,14 +201,14 @@ typedef struct
 /* for locking access to type_initialization_hash and blocked_thread_hash */
 static MonoCoopMutex type_initialization_section;
 
-static inline void
+static void
 mono_type_initialization_lock (void)
 {
 	/* The critical sections protected by this lock in mono_runtime_class_init_full () can block */
 	mono_coop_mutex_lock (&type_initialization_section);
 }
 
-static inline void
+static void
 mono_type_initialization_unlock (void)
 {
 	mono_coop_mutex_unlock (&type_initialization_section);

--- a/mono/metadata/remoting.c
+++ b/mono/metadata/remoting.c
@@ -116,14 +116,14 @@ mono_compile_method_icall (MonoMethod *method);
 #define register_icall(func, sig, save) \
 	(mono_register_jit_icall_info (&mono_get_jit_icall_info ()->func, func, #func, (sig), (save), NULL))
 
-static inline void
+static void
 remoting_lock (void)
 {
 	g_assert (remoting_mutex_inited);
 	mono_os_mutex_lock (&remoting_mutex);
 }
 
-static inline void
+static void
 remoting_unlock (void)
 {
 	g_assert (remoting_mutex_inited);
@@ -306,7 +306,7 @@ mono_mb_emit_contextbound_check (MonoMethodBuilder *mb, int branch_code)
 }
 #endif /* !DISABLE_JIT */
 
-static inline MonoMethod*
+static MonoMethod*
 mono_marshal_remoting_find_in_cache (MonoMethod *method, int wrapper_type)
 {
 	MonoMethod *res = NULL;
@@ -334,7 +334,7 @@ mono_marshal_remoting_find_in_cache (MonoMethod *method, int wrapper_type)
 }
 
 /* Create the method from the builder and place it in the cache */
-static inline MonoMethod*
+static MonoMethod*
 mono_remoting_mb_create_and_cache (MonoMethod *key, MonoMethodBuilder *mb, 
 								   MonoMethodSignature *sig, int max_stack, WrapperInfo *info)
 {

--- a/mono/metadata/sgen-tarjan-bridge.c
+++ b/mono/metadata/sgen-tarjan-bridge.c
@@ -153,7 +153,7 @@ typedef struct _ScanData {
 /* Should color be made visible to client even though it has no bridges?
  * True if we predict the number of reduced edges to be enough to justify the extra node.
  */
-static inline gboolean
+static gboolean
 bridgeless_color_is_heavy (ColorData *data) {
 	int fanin = data->incoming_colors;
 	int fanout = dyn_array_ptr_size (&data->other_colors);
@@ -162,7 +162,7 @@ bridgeless_color_is_heavy (ColorData *data) {
 }
 
 // Should color be made visible to client?
-static inline gboolean
+static gboolean
 color_visible_to_client (ColorData *data) {
 	return dyn_array_ptr_size (&data->bridges) || bridgeless_color_is_heavy (data);
 }

--- a/mono/metadata/threadpool-io-poll.c
+++ b/mono/metadata/threadpool-io-poll.c
@@ -8,7 +8,7 @@ static mono_pollfd *poll_fds;
 static guint poll_fds_capacity;
 static guint poll_fds_size;
 
-static inline void
+static void
 POLL_INIT_FD (mono_pollfd *poll_fd, gint fd, gint events)
 {
 	poll_fd->fd = fd;
@@ -113,7 +113,7 @@ poll_remove_fd (gint fd)
 		poll_fds_size -= 1;
 }
 
-static inline gint
+static gint
 poll_mark_bad_fds (mono_pollfd *fds, gint size)
 {
 	gint i, ready = 0;

--- a/mono/metadata/threadpool-worker-default.c
+++ b/mono/metadata/threadpool-worker-default.c
@@ -184,7 +184,7 @@ static ThreadPoolWorker worker;
 		} while (mono_atomic_cas_i64 (&worker.counters.as_gint64, (var).as_gint64, __old.as_gint64) != __old.as_gint64); \
 	} while (0)
 
-static inline ThreadPoolWorkerCounter
+static ThreadPoolWorkerCounter
 COUNTER_READ (void)
 {
 	ThreadPoolWorkerCounter counter;

--- a/mono/metadata/threadpool.c
+++ b/mono/metadata/threadpool.c
@@ -102,7 +102,7 @@ static ThreadPool threadpool;
 		} while (mono_atomic_cas_i32 (&threadpool.counters.as_gint32, (var).as_gint32, __old.as_gint32) != __old.as_gint32); \
 	} while (0)
 
-static inline ThreadPoolCounter
+static ThreadPoolCounter
 COUNTER_READ (void)
 {
 	ThreadPoolCounter counter;
@@ -110,13 +110,13 @@ COUNTER_READ (void)
 	return counter;
 }
 
-static inline void
+static void
 domains_lock (void)
 {
 	mono_coop_mutex_lock (&threadpool.domains_lock);
 }
 
-static inline void
+static void
 domains_unlock (void)
 {
 	mono_coop_mutex_unlock (&threadpool.domains_lock);

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -470,7 +470,7 @@ mono_thread_set_interruption_requested_flags (MonoInternalThread *thread, gboole
 	return sync || !(new_state & ABORT_PROT_BLOCK_MASK);
 }
 
-static inline MonoNativeThreadId
+static MonoNativeThreadId
 thread_get_tid (MonoInternalThread *thread)
 {
 	/* We store the tid as a guint64 to keep the object layout constant between platforms */
@@ -515,7 +515,7 @@ dec_longlived_thread_data (MonoLongLivedThreadData *lltd)
 	mono_refcount_dec (lltd);
 }
 
-static inline void
+static void
 lock_thread (MonoInternalThread *thread)
 {
 	g_assert (thread->longlived);
@@ -524,7 +524,7 @@ lock_thread (MonoInternalThread *thread)
 	mono_coop_mutex_lock (thread->longlived->synch_cs);
 }
 
-static inline void
+static void
 unlock_thread (MonoInternalThread *thread)
 {
 	mono_coop_mutex_unlock (thread->longlived->synch_cs);
@@ -542,7 +542,7 @@ unlock_thread_handle (MonoInternalThreadHandle thread)
 	unlock_thread (mono_internal_thread_handle_ptr (thread));
 }
 
-static inline gboolean
+static gboolean
 is_appdomainunloaded_exception (MonoClass *klass)
 {
 #ifdef ENABLE_NETCORE
@@ -552,7 +552,7 @@ is_appdomainunloaded_exception (MonoClass *klass)
 #endif
 }
 
-static inline gboolean
+static gboolean
 is_threadabort_exception (MonoClass *klass)
 {
 	return klass == mono_defaults.threadabortexception_class;

--- a/mono/metadata/w32process-unix.c
+++ b/mono/metadata/w32process-unix.c
@@ -1381,7 +1381,7 @@ leave:
  * that, the system's file descriptor limit. This is called by the fork child
  * in close_my_fds.
  */
-static inline guint32
+static guint32
 max_fd_count (void)
 {
 #if defined (_AIX)

--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -453,7 +453,7 @@ add_gsharedvt_wrappers (MonoAotCompile *acfg, MonoMethodSignature *sig, gboolean
 static void
 add_profile_instances (MonoAotCompile *acfg, ProfileData *data);
 
-static inline gboolean
+static gboolean
 ignore_cfg (MonoCompile *cfg)
 {
 	return !cfg || cfg->skip;
@@ -520,7 +520,7 @@ report_loader_error (MonoAotCompile *acfg, MonoError *error, gboolean fatal, con
 
 #define MAX_SYMBOL_SIZE 256
 
-static inline const char *
+static const char *
 mangle_symbol (const char * symbol, char * mangled_symbol, gsize length)
 {
 	gsize needed_size = length;
@@ -543,7 +543,7 @@ mangle_symbol (const char * symbol, char * mangled_symbol, gsize length)
 	return mangled_symbol;
 }
 
-static inline char *
+static char *
 mangle_symbol_alloc (const char * symbol)
 {
 	g_assert (NULL != symbol);
@@ -560,7 +560,7 @@ mangle_symbol_alloc (const char * symbol)
 #endif
 }
 
-static inline void
+static void
 emit_section_change (MonoAotCompile *acfg, const char *section_name, int subsection_index)
 {
 	mono_img_writer_emit_section_change (acfg->w, section_name, subsection_index);
@@ -568,7 +568,7 @@ emit_section_change (MonoAotCompile *acfg, const char *section_name, int subsect
 
 #if defined(TARGET_WIN32) && defined(TARGET_X86)
 
-static inline void
+static void
 emit_local_symbol (MonoAotCompile *acfg, const char *name, const char *end_label, gboolean func)
 {
 	const char * mangled_symbol_name = name;
@@ -591,7 +591,7 @@ emit_local_symbol (MonoAotCompile *acfg, const char *name, const char *end_label
 
 #else
 
-static inline void
+static void
 emit_local_symbol (MonoAotCompile *acfg, const char *name, const char *end_label, gboolean func) 
 { 
 	mono_img_writer_emit_local_symbol (acfg->w, name, end_label, func);
@@ -599,37 +599,37 @@ emit_local_symbol (MonoAotCompile *acfg, const char *name, const char *end_label
 
 #endif
 
-static inline void
+static void
 emit_label (MonoAotCompile *acfg, const char *name) 
 { 
 	mono_img_writer_emit_label (acfg->w, name); 
 }
 
-static inline void
+static void
 emit_bytes (MonoAotCompile *acfg, const guint8* buf, int size) 
 { 
 	mono_img_writer_emit_bytes (acfg->w, buf, size); 
 }
 
-static inline void
+static void
 emit_string (MonoAotCompile *acfg, const char *value) 
 { 
 	mono_img_writer_emit_string (acfg->w, value); 
 }
 
-static inline void
+static void
 emit_line (MonoAotCompile *acfg) 
 { 
 	mono_img_writer_emit_line (acfg->w); 
 }
 
-static inline void
+static void
 emit_alignment (MonoAotCompile *acfg, int size)
 { 
 	mono_img_writer_emit_alignment (acfg->w, size);
 }
 
-static inline void
+static void
 emit_alignment_code (MonoAotCompile *acfg, int size)
 {
 	if (acfg->align_pad_value)
@@ -638,7 +638,7 @@ emit_alignment_code (MonoAotCompile *acfg, int size)
 		mono_img_writer_emit_alignment (acfg->w, size);
 }
 
-static inline void
+static void
 emit_padding (MonoAotCompile *acfg, int size)
 {
 	int i;
@@ -659,13 +659,13 @@ emit_padding (MonoAotCompile *acfg, int size)
 	}
 }
 
-static inline void
+static void
 emit_pointer (MonoAotCompile *acfg, const char *target) 
 { 
 	mono_img_writer_emit_pointer (acfg->w, target); 
 }
 
-static inline void
+static void
 emit_pointer_2 (MonoAotCompile *acfg, const char *prefix, const char *target) 
 { 
 	if (prefix [0] != '\0') {
@@ -677,31 +677,31 @@ emit_pointer_2 (MonoAotCompile *acfg, const char *prefix, const char *target)
 	}
 }
 
-static inline void
+static void
 emit_int16 (MonoAotCompile *acfg, int value) 
 { 
 	mono_img_writer_emit_int16 (acfg->w, value); 
 }
 
-static inline void
+static void
 emit_int32 (MonoAotCompile *acfg, int value) 
 { 
 	mono_img_writer_emit_int32 (acfg->w, value); 
 }
 
-static inline void
+static void
 emit_symbol_diff (MonoAotCompile *acfg, const char *end, const char* start, int offset) 
 { 
 	mono_img_writer_emit_symbol_diff (acfg->w, end, start, offset); 
 }
 
-static inline void
+static void
 emit_zero_bytes (MonoAotCompile *acfg, int num) 
 { 
 	mono_img_writer_emit_zero_bytes (acfg->w, num); 
 }
 
-static inline void
+static void
 emit_byte (MonoAotCompile *acfg, guint8 val) 
 { 
 	mono_img_writer_emit_byte (acfg->w, val); 
@@ -738,13 +738,13 @@ emit_global_inner (MonoAotCompile *acfg, const char *name, gboolean func)
 
 #endif
 
-static inline gboolean
+static gboolean
 link_shared_library (MonoAotCompile *acfg)
 {
 	return !acfg->aot_opts.static_link && !acfg->aot_opts.asm_only;
 }
 
-static inline gboolean
+static gboolean
 add_to_global_symbol_table (MonoAotCompile *acfg)
 {
 #ifdef TARGET_WIN32_MSVC
@@ -949,7 +949,7 @@ emit_set_arm_mode (MonoAotCompile *acfg)
 	fprintf (acfg->fp, ".code 32\n");
 }
 
-static inline void
+static void
 emit_code_bytes (MonoAotCompile *acfg, const guint8* buf, int size)
 {
 #ifdef TARGET_ARM64
@@ -2895,7 +2895,7 @@ mono_get_field_token (MonoClassField *field)
 	return 0;
 }
 
-static inline void
+static void
 encode_value (gint32 value, guint8 *buf, guint8 **endbuf)
 {
 	guint8 *p = buf;
@@ -3852,7 +3852,7 @@ patch_to_string (MonoJumpInfo *patch_info)
  *   Return whenever PATCH_INFO refers to a direct call, and thus requires a
  * PLT entry.
  */
-static inline gboolean
+static gboolean
 is_plt_patch (MonoJumpInfo *patch_info)
 {
 	switch (patch_info->type) {
@@ -10782,7 +10782,7 @@ emit_library_info (MonoAotCompile *acfg)
 
 #else
 
-static inline void
+static void
 emit_library_info (MonoAotCompile *acfg)
 {
 	return;

--- a/mono/mini/aot-runtime-wasm.c
+++ b/mono/mini/aot-runtime-wasm.c
@@ -79,7 +79,7 @@ typedef union {
 	} pair;
 } interp_pair;
 
-static inline gint64
+static gint64
 get_long_arg (InterpMethodArguments *margs, int idx)
 {
 	interp_pair p;

--- a/mono/mini/aot-runtime.c
+++ b/mono/mini/aot-runtime.c
@@ -249,13 +249,13 @@ init_method (MonoAotModule *amodule, guint32 method_index, MonoMethod *method, M
 static MonoJumpInfo*
 decode_patches (MonoAotModule *amodule, MonoMemPool *mp, int n_patches, gboolean llvm, guint32 *got_offsets);
 
-static inline void
+static void
 amodule_lock (MonoAotModule *amodule)
 {
 	mono_os_mutex_lock (&amodule->mutex);
 }
 
-static inline void
+static void
 amodule_unlock (MonoAotModule *amodule)
 {
 	mono_os_mutex_unlock (&amodule->mutex);
@@ -321,7 +321,7 @@ load_image (MonoAotModule *amodule, int index, MonoError *error)
 	return assembly->image;
 }
 
-static inline gint32
+static gint32
 decode_value (guint8 *ptr, guint8 **rptr)
 {
 	guint8 b = *ptr;
@@ -5003,7 +5003,7 @@ find_aot_module_cb (gpointer key, gpointer value, gpointer user_data)
 		data->module = aot_module;
 }
 
-static inline MonoAotModule*
+static MonoAotModule*
 find_aot_module (guint8 *code)
 {
 	FindAotModuleUserData user_data;

--- a/mono/mini/debug-mini.c
+++ b/mono/mini/debug-mini.c
@@ -35,7 +35,7 @@ typedef struct
 	guint32 breakpoint_id;
 } MiniDebugMethodInfo;
 
-static inline void
+static void
 record_line_number (MiniDebugMethodInfo *info, guint32 address, guint32 offset)
 {
 	MonoDebugLineNumberEntry lne;
@@ -352,7 +352,7 @@ mono_debug_open_block (MonoCompile *cfg, MonoBasicBlock *bb, guint32 address)
 	record_line_number (info, address, offset);
 }
 
-static inline void
+static void
 encode_value (gint32 value, guint8 *buf, guint8 **endbuf)
 {
 	guint8 *p = buf;
@@ -388,7 +388,7 @@ encode_value (gint32 value, guint8 *buf, guint8 **endbuf)
 		*endbuf = p;
 }
 
-static inline gint32
+static gint32
 decode_value (guint8 *ptr, guint8 **rptr)
 {
 	guint8 b = *ptr;

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -735,7 +735,7 @@ static void
 register_socket_transport (void);
 #endif
 
-static inline gboolean
+static gboolean
 is_debugger_thread (void)
 {
 	MonoInternalThread *internal;
@@ -1656,7 +1656,7 @@ start_debugger_thread (MonoError *error)
  * Functions to decode protocol data
  */
 
-static inline int
+static int
 decode_byte (guint8 *buf, guint8 **endbuf, guint8 *limit)
 {
 	*endbuf = buf + 1;
@@ -1664,7 +1664,7 @@ decode_byte (guint8 *buf, guint8 **endbuf, guint8 *limit)
 	return buf [0];
 }
 
-static inline int
+static int
 decode_int (guint8 *buf, guint8 **endbuf, guint8 *limit)
 {
 	*endbuf = buf + 4;
@@ -1673,7 +1673,7 @@ decode_int (guint8 *buf, guint8 **endbuf, guint8 *limit)
 	return (((int)buf [0]) << 24) | (((int)buf [1]) << 16) | (((int)buf [2]) << 8) | (((int)buf [3]) << 0);
 }
 
-static inline gint64
+static gint64
 decode_long (guint8 *buf, guint8 **endbuf, guint8 *limit)
 {
 	guint32 high = decode_int (buf, &buf, limit);
@@ -1684,13 +1684,13 @@ decode_long (guint8 *buf, guint8 **endbuf, guint8 *limit)
 	return ((((guint64)high) << 32) | ((guint64)low));
 }
 
-static inline int
+static int
 decode_id (guint8 *buf, guint8 **endbuf, guint8 *limit)
 {
 	return decode_int (buf, endbuf, limit);
 }
 
-static inline char*
+static char*
 decode_string (guint8 *buf, guint8 **endbuf, guint8 *limit)
 {
 	int len = decode_int (buf, &buf, limit);
@@ -1716,7 +1716,7 @@ decode_string (guint8 *buf, guint8 **endbuf, guint8 *limit)
  * Functions to encode protocol data
  */
 
-static inline void
+static void
 buffer_init (Buffer *buf, int size)
 {
 	buf->buf = (guint8 *)g_malloc (size);
@@ -1724,13 +1724,13 @@ buffer_init (Buffer *buf, int size)
 	buf->end = buf->buf + size;
 }
 
-static inline int
+static int
 buffer_len (Buffer *buf)
 {
 	return buf->p - buf->buf;
 }
 
-static inline void
+static void
 buffer_make_room (Buffer *buf, int size)
 {
 	if (buf->end - buf->p < size) {
@@ -1743,7 +1743,7 @@ buffer_make_room (Buffer *buf, int size)
 	}
 }
 
-static inline void
+static void
 buffer_add_byte (Buffer *buf, guint8 val)
 {
 	buffer_make_room (buf, 1);
@@ -1751,7 +1751,7 @@ buffer_add_byte (Buffer *buf, guint8 val)
 	buf->p++;
 }
 
-static inline void
+static void
 buffer_add_short (Buffer *buf, guint32 val)
 {
 	buffer_make_room (buf, 2);
@@ -1760,7 +1760,7 @@ buffer_add_short (Buffer *buf, guint32 val)
 	buf->p += 2;
 }
 
-static inline void
+static void
 buffer_add_int (Buffer *buf, guint32 val)
 {
 	buffer_make_room (buf, 4);
@@ -1771,20 +1771,20 @@ buffer_add_int (Buffer *buf, guint32 val)
 	buf->p += 4;
 }
 
-static inline void
+static void
 buffer_add_long (Buffer *buf, guint64 l)
 {
 	buffer_add_int (buf, (l >> 32) & 0xffffffff);
 	buffer_add_int (buf, (l >> 0) & 0xffffffff);
 }
 
-static inline void
+static void
 buffer_add_id (Buffer *buf, int id)
 {
 	buffer_add_int (buf, (guint64)id);
 }
 
-static inline void
+static void
 buffer_add_data (Buffer *buf, guint8 *data, int len)
 {
 	buffer_make_room (buf, len);
@@ -1792,7 +1792,7 @@ buffer_add_data (Buffer *buf, guint8 *data, int len)
 	buf->p += len;
 }
 
-static inline void
+static void
 buffer_add_string (Buffer *buf, const char *str)
 {
 	int len;
@@ -1806,20 +1806,20 @@ buffer_add_string (Buffer *buf, const char *str)
 	}
 }
 
-static inline void
+static void
 buffer_add_byte_array (Buffer *buf, guint8 *bytes, guint32 arr_len)
 {
     buffer_add_int (buf, arr_len);
     buffer_add_data (buf, bytes, arr_len);
 }
 
-static inline void
+static void
 buffer_add_buffer (Buffer *buf, Buffer *data)
 {
 	buffer_add_data (buf, data->buf, buffer_len (data));
 }
 
-static inline void
+static void
 buffer_free (Buffer *buf)
 {
 	g_free (buf->buf);
@@ -2028,7 +2028,7 @@ clear_suspended_objs (void)
 	dbg_unlock ();
 }
 
-static inline int
+static int
 get_objid (MonoObject *obj)
 {
 	if (!obj)
@@ -2083,13 +2083,13 @@ get_object (int objid, MonoObject **obj)
 	return ERR_NONE;
 }
 
-static inline int
+static int
 decode_objid (guint8 *buf, guint8 **endbuf, guint8 *limit)
 {
 	return decode_id (buf, endbuf, limit);
 }
 
-static inline void
+static void
 buffer_add_objid (Buffer *buf, MonoObject *o)
 {
 	buffer_add_id (buf, get_objid (o));
@@ -2298,7 +2298,7 @@ get_id (MonoDomain *domain, IdType type, gpointer val)
 	return id->id;
 }
 
-static inline gpointer
+static gpointer
 decode_ptr_id (guint8 *buf, guint8 **endbuf, guint8 *limit, IdType type, MonoDomain **domain, ErrorCode *err)
 {
 	Id *res;
@@ -2331,7 +2331,7 @@ decode_ptr_id (guint8 *buf, guint8 **endbuf, guint8 *limit, IdType type, MonoDom
 	return res->data.val;
 }
 
-static inline int
+static int
 buffer_add_ptr_id (Buffer *buf, MonoDomain *domain, IdType type, gpointer val)
 {
 	int id = get_id (domain, type, val);
@@ -2340,7 +2340,7 @@ buffer_add_ptr_id (Buffer *buf, MonoDomain *domain, IdType type, gpointer val)
 	return id;
 }
 
-static inline MonoClass*
+static MonoClass*
 decode_typeid (guint8 *buf, guint8 **endbuf, guint8 *limit, MonoDomain **domain, ErrorCode *err)
 {
 	MonoClass *klass;
@@ -2356,19 +2356,19 @@ decode_typeid (guint8 *buf, guint8 **endbuf, guint8 *limit, MonoDomain **domain,
 	return klass;
 }
 
-static inline MonoAssembly*
+static MonoAssembly*
 decode_assemblyid (guint8 *buf, guint8 **endbuf, guint8 *limit, MonoDomain **domain, ErrorCode *err)
 {
 	return (MonoAssembly *)decode_ptr_id (buf, endbuf, limit, ID_ASSEMBLY, domain, err);
 }
 
-static inline MonoImage*
+static MonoImage*
 decode_moduleid (guint8 *buf, guint8 **endbuf, guint8 *limit, MonoDomain **domain, ErrorCode *err)
 {
 	return (MonoImage *)decode_ptr_id (buf, endbuf, limit, ID_MODULE, domain, err);
 }
 
-static inline MonoMethod*
+static MonoMethod*
 decode_methodid (guint8 *buf, guint8 **endbuf, guint8 *limit, MonoDomain **domain, ErrorCode *err)
 {
 	MonoMethod *m;
@@ -2384,25 +2384,25 @@ decode_methodid (guint8 *buf, guint8 **endbuf, guint8 *limit, MonoDomain **domai
 	return m;
 }
 
-static inline MonoClassField*
+static MonoClassField*
 decode_fieldid (guint8 *buf, guint8 **endbuf, guint8 *limit, MonoDomain **domain, ErrorCode *err)
 {
 	return (MonoClassField *)decode_ptr_id (buf, endbuf, limit, ID_FIELD, domain, err);
 }
 
-static inline MonoDomain*
+static MonoDomain*
 decode_domainid (guint8 *buf, guint8 **endbuf, guint8 *limit, MonoDomain **domain, ErrorCode *err)
 {
 	return (MonoDomain *)decode_ptr_id (buf, endbuf, limit, ID_DOMAIN, domain, err);
 }
 
-static inline MonoProperty*
+static MonoProperty*
 decode_propertyid (guint8 *buf, guint8 **endbuf, guint8 *limit, MonoDomain **domain, ErrorCode *err)
 {
 	return (MonoProperty *)decode_ptr_id (buf, endbuf, limit, ID_PROPERTY, domain, err);
 }
 
-static inline void
+static void
 buffer_add_typeid (Buffer *buf, MonoDomain *domain, MonoClass *klass)
 {
 	buffer_add_ptr_id (buf, domain, ID_TYPE, klass);
@@ -2418,7 +2418,7 @@ buffer_add_typeid (Buffer *buf, MonoDomain *domain, MonoClass *klass)
 	}
 }
 
-static inline void
+static void
 buffer_add_methodid (Buffer *buf, MonoDomain *domain, MonoMethod *method)
 {
 	buffer_add_ptr_id (buf, domain, ID_METHOD, method);
@@ -2434,7 +2434,7 @@ buffer_add_methodid (Buffer *buf, MonoDomain *domain, MonoMethod *method)
 	}
 }
 
-static inline void
+static void
 buffer_add_assemblyid (Buffer *buf, MonoDomain *domain, MonoAssembly *assembly)
 {
 	int id;
@@ -2444,25 +2444,25 @@ buffer_add_assemblyid (Buffer *buf, MonoDomain *domain, MonoAssembly *assembly)
 		DEBUG_PRINTF (2, "[dbg]   send assembly [%s][%s][%d]\n", assembly->aname.name, domain->friendly_name, id);
 }
 
-static inline void
+static void
 buffer_add_moduleid (Buffer *buf, MonoDomain *domain, MonoImage *image)
 {
 	buffer_add_ptr_id (buf, domain, ID_MODULE, image);
 }
 
-static inline void
+static void
 buffer_add_fieldid (Buffer *buf, MonoDomain *domain, MonoClassField *field)
 {
 	buffer_add_ptr_id (buf, domain, ID_FIELD, field);
 }
 
-static inline void
+static void
 buffer_add_propertyid (Buffer *buf, MonoDomain *domain, MonoProperty *property)
 {
 	buffer_add_ptr_id (buf, domain, ID_PROPERTY, property);
 }
 
-static inline void
+static void
 buffer_add_domainid (Buffer *buf, MonoDomain *domain)
 {
 	buffer_add_ptr_id (buf, domain, ID_DOMAIN, domain);

--- a/mono/mini/debugger-engine.c
+++ b/mono/mini/debugger-engine.c
@@ -259,7 +259,7 @@ remove_breakpoint (BreakpointInstance *inst)
 /*
  * This doesn't take any locks.
  */
-static inline gboolean
+static gboolean
 bp_matches_method (MonoBreakpoint *bp, MonoMethod *method)
 {
 	int i;

--- a/mono/mini/dominators.c
+++ b/mono/mini/dominators.c
@@ -259,7 +259,7 @@ compute_dominance_frontier (MonoCompile *cfg)
 	cfg->comp_done |= MONO_COMP_DFRONTIER;
 }
 
-static inline void
+static void
 df_set (MonoCompile *m, MonoBitSet* dest, MonoBitSet *set) 
 {
 	int i;

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -3129,13 +3129,13 @@ mono_win32_parse_options (const char *options, int *ref_argc, char **ref_argv []
 	return NULL;
 }
 
-static inline char *
+static char *
 mono_parse_response_options (const char *options, int *ref_argc, char **ref_argv [], gboolean prepend)
 {
 	return mono_win32_parse_options (options, ref_argc, ref_argv, prepend);
 }
 #else
-static inline char *
+static char *
 mono_parse_response_options (const char *options, int *ref_argc, char **ref_argv [], gboolean prepend)
 {
 	return mono_parse_options (options, ref_argc, ref_argv, prepend);

--- a/mono/mini/dwarfwriter.c
+++ b/mono/mini/dwarfwriter.c
@@ -109,85 +109,85 @@ mono_dwarf_writer_get_il_file_line_index (MonoDwarfWriter *w)
 
 /* Wrappers around the image writer functions */
 
-static inline void
+static void
 emit_section_change (MonoDwarfWriter *w, const char *section_name, int subsection_index)
 {
 	mono_img_writer_emit_section_change (w->w, section_name, subsection_index);
 }
 
-static inline void
+static void
 emit_push_section (MonoDwarfWriter *w, const char *section_name, int subsection)
 {
 	mono_img_writer_emit_push_section (w->w, section_name, subsection);
 }
 
-static inline void
+static void
 emit_pop_section (MonoDwarfWriter *w)
 {
 	mono_img_writer_emit_pop_section (w->w);
 }
 
-static inline void
+static void
 emit_label (MonoDwarfWriter *w, const char *name) 
 { 
 	mono_img_writer_emit_label (w->w, name); 
 }
 
-static inline void
+static void
 emit_bytes (MonoDwarfWriter *w, const guint8* buf, int size) 
 { 
 	mono_img_writer_emit_bytes (w->w, buf, size); 
 }
 
-static inline void
+static void
 emit_string (MonoDwarfWriter *w, const char *value) 
 { 
 	mono_img_writer_emit_string (w->w, value); 
 }
 
-static inline void
+static void
 emit_line (MonoDwarfWriter *w) 
 { 
 	mono_img_writer_emit_line (w->w); 
 }
 
-static inline void
+static void
 emit_alignment (MonoDwarfWriter *w, int size) 
 { 
 	mono_img_writer_emit_alignment (w->w, size); 
 }
 
-static inline void
+static void
 emit_pointer_unaligned (MonoDwarfWriter *w, const char *target) 
 { 
 	mono_img_writer_emit_pointer_unaligned (w->w, target); 
 }
 
-static inline void
+static void
 emit_pointer (MonoDwarfWriter *w, const char *target) 
 { 
 	mono_img_writer_emit_pointer (w->w, target); 
 }
 
-static inline void
+static void
 emit_int16 (MonoDwarfWriter *w, int value) 
 { 
 	mono_img_writer_emit_int16 (w->w, value); 
 }
 
-static inline void
+static void
 emit_int32 (MonoDwarfWriter *w, int value) 
 { 
 	mono_img_writer_emit_int32 (w->w, value); 
 }
 
-static inline void
+static void
 emit_symbol_diff (MonoDwarfWriter *w, const char *end, const char* start, int offset) 
 { 
 	mono_img_writer_emit_symbol_diff (w->w, end, start, offset); 
 }
 
-static inline void
+static void
 emit_byte (MonoDwarfWriter *w, guint8 val) 
 { 
 	mono_img_writer_emit_byte (w->w, val); 
@@ -1444,7 +1444,7 @@ il_offset_from_address (MonoMethod *method, MonoDebugMethodJitInfo *jit,
 
 static int max_special_addr_diff = 0;
 
-static inline void
+static void
 emit_advance_op (MonoDwarfWriter *w, int line_diff, int addr_diff)
 {
 	gint64 opcode = 0;

--- a/mono/mini/exceptions-amd64.c
+++ b/mono/mini/exceptions-amd64.c
@@ -1256,7 +1256,7 @@ fast_find_range_in_table_no_lock_ex (gsize begin_range, gsize end_range, gboolea
 	return found_entry;
 }
 
-static inline DynamicFunctionTableEntry *
+static DynamicFunctionTableEntry *
 fast_find_range_in_table_no_lock (gsize begin_range, gsize end_range, gboolean *continue_search)
 {
 	GList *found_entry = fast_find_range_in_table_no_lock_ex (begin_range, end_range, continue_search);
@@ -1292,7 +1292,7 @@ find_range_in_table_no_lock_ex (const gpointer code_block, gsize block_size)
 	return found_entry;
 }
 
-static inline DynamicFunctionTableEntry *
+static DynamicFunctionTableEntry *
 find_range_in_table_no_lock (const gpointer code_block, gsize block_size)
 {
 	GList *found_entry = find_range_in_table_no_lock_ex (code_block, block_size);
@@ -1328,7 +1328,7 @@ find_pc_in_table_no_lock_ex (const gpointer pc)
 	return found_entry;
 }
 
-static inline DynamicFunctionTableEntry *
+static DynamicFunctionTableEntry *
 find_pc_in_table_no_lock (const gpointer pc)
 {
 	GList *found_entry = find_pc_in_table_no_lock_ex (pc);
@@ -1367,7 +1367,7 @@ validate_table_no_lock (void)
 
 #else
 
-static inline void
+static void
 validate_table_no_lock (void)
 {
 }
@@ -1574,7 +1574,7 @@ mono_arch_unwindinfo_find_rt_func_in_table (const gpointer code, gsize code_size
 	return found_rt_func;
 }
 
-static inline PRUNTIME_FUNCTION
+static PRUNTIME_FUNCTION
 mono_arch_unwindinfo_find_pc_rt_func_in_table (const gpointer pc)
 {
 	return mono_arch_unwindinfo_find_rt_func_in_table (pc, 0);
@@ -1612,7 +1612,7 @@ validate_rt_funcs_in_table_no_lock (DynamicFunctionTableEntry *entry)
 
 #else
 
-static inline void
+static void
 validate_rt_funcs_in_table_no_lock (DynamicFunctionTableEntry *entry)
 {
 }

--- a/mono/mini/image-writer.c
+++ b/mono/mini/image-writer.c
@@ -1696,7 +1696,7 @@ asm_writer_emit_section_change (MonoImageWriter *acfg, const char *section_name,
 #endif
 }
 
-static inline
+static
 const char *get_label (const char *s)
 {
 #ifdef TARGET_ASM_APPLE
@@ -1892,7 +1892,7 @@ asm_writer_emit_bytes (MonoImageWriter *acfg, const guint8* buf, int size)
 	}
 }
 
-static inline void
+static void
 asm_writer_emit_int16 (MonoImageWriter *acfg, int value)
 {
 	if (acfg->mode != EMIT_WORD) {
@@ -1906,7 +1906,7 @@ asm_writer_emit_int16 (MonoImageWriter *acfg, int value)
 	fprintf (acfg->fp, "%d", value);
 }
 
-static inline void
+static void
 asm_writer_emit_int32 (MonoImageWriter *acfg, int value)
 {
 	if (acfg->mode != EMIT_LONG) {

--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -98,7 +98,7 @@ typedef struct {
 	InterpFrame *base_frame;
 } FrameClauseArgs;
 
-static inline void
+static void
 init_frame (InterpFrame *frame, InterpFrame *parent_frame, InterpMethod *rmethod, stackval *method_args, stackval *method_retval)
 {
 	frame->parent = parent_frame;

--- a/mono/mini/linear-scan.c
+++ b/mono/mini/linear-scan.c
@@ -272,7 +272,7 @@ compare_by_interval_start_pos_func (gconstpointer a, gconstpointer b)
 #endif
 
 /* FIXME: This is x86 only */
-static inline guint32
+static guint32
 regalloc_cost (MonoCompile *cfg, MonoMethodVar *vmv)
 {
 	MonoInst *ins = cfg->varinfo [vmv->idx];

--- a/mono/mini/liveness.c
+++ b/mono/mini/liveness.c
@@ -103,14 +103,14 @@ optimize_initlocals (MonoCompile *cfg);
  * 
  * allocates a MonoBitSet inside a memory pool
  */
-static inline MonoBitSet* 
+static MonoBitSet*
 mono_bitset_mp_new (MonoMemPool *mp, guint32 size, guint32 max_size)
 {
 	guint8 *mem = (guint8 *)mono_mempool_alloc0 (mp, size);
 	return mono_bitset_mem_new (mem, max_size, MONO_BITSET_DONT_FREE);
 }
 
-static inline MonoBitSet* 
+static MonoBitSet*
 mono_bitset_mp_new_noinit (MonoMemPool *mp, guint32 size, guint32 max_size)
 {
 	guint8 *mem = (guint8 *)mono_mempool_alloc (mp, size);
@@ -266,7 +266,7 @@ mono_liveness_handle_exception_clauses (MonoCompile *cfg)
 	mono_ptrset_destroy (&visited);
 }
 
-static inline void
+static void
 update_live_range (MonoMethodVar *var, int abs_pos)
 {
 	if (var->range.first_use.abs_pos > abs_pos)
@@ -842,7 +842,7 @@ mono_linterval_split (MonoCompile *cfg, MonoLiveInterval *interval, MonoLiveInte
 
 #ifdef ENABLE_LIVENESS2
 
-static inline void
+static void
 update_liveness2 (MonoCompile *cfg, MonoInst *ins, gboolean set_volatile, int inst_num, gint32 *last_use)
 {
 	const char *spec = INS_INFO (ins->opcode);
@@ -1042,7 +1042,7 @@ mono_analyze_liveness2 (MonoCompile *cfg)
 
 #endif
 
-static inline void
+static void
 update_liveness_gc (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins, gint32 *last_use, MonoMethodVar **vreg_to_varinfo, GSList **callsites)
 {
 	if (ins->opcode == OP_GC_LIVENESS_DEF || ins->opcode == OP_GC_LIVENESS_USE) {
@@ -1092,7 +1092,7 @@ update_liveness_gc (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst *ins, gint32 
 	}
 }
 
-static inline int
+static int
 get_vreg_from_var (MonoCompile *cfg, MonoInst *var)
 {
 	if (var->opcode == OP_REGVAR)

--- a/mono/mini/lldb.c
+++ b/mono/mini/lldb.c
@@ -149,7 +149,7 @@ typedef struct {
 	guint8 *buf, *p, *end;
 } Buffer;
 
-static inline void
+static void
 buffer_init (Buffer *buf, int size)
 {
 	buf->buf = (guint8 *)g_malloc (size);
@@ -157,13 +157,13 @@ buffer_init (Buffer *buf, int size)
 	buf->end = buf->buf + size;
 }
 
-static inline int
+static int
 buffer_len (Buffer *buf)
 {
 	return buf->p - buf->buf;
 }
 
-static inline void
+static void
 buffer_make_room (Buffer *buf, int size)
 {
 	if (buf->end - buf->p < size) {
@@ -176,7 +176,7 @@ buffer_make_room (Buffer *buf, int size)
 	}
 }
 
-static inline void
+static void
 buffer_add_byte (Buffer *buf, guint8 val)
 {
 	buffer_make_room (buf, 1);
@@ -184,7 +184,7 @@ buffer_add_byte (Buffer *buf, guint8 val)
 	buf->p++;
 }
 
-static inline void
+static void
 buffer_add_short (Buffer *buf, guint32 val)
 {
 	buffer_make_room (buf, 2);
@@ -193,7 +193,7 @@ buffer_add_short (Buffer *buf, guint32 val)
 	buf->p += 2;
 }
 
-static inline void
+static void
 buffer_add_int (Buffer *buf, guint32 val)
 {
 	buffer_make_room (buf, 4);
@@ -204,20 +204,20 @@ buffer_add_int (Buffer *buf, guint32 val)
 	buf->p += 4;
 }
 
-static inline void
+static void
 buffer_add_long (Buffer *buf, guint64 l)
 {
 	buffer_add_int (buf, (l >> 32) & 0xffffffff);
 	buffer_add_int (buf, (l >> 0) & 0xffffffff);
 }
 
-static inline void
+static void
 buffer_add_id (Buffer *buf, int id)
 {
 	buffer_add_int (buf, (guint64)id);
 }
 
-static inline void
+static void
 buffer_add_data (Buffer *buf, guint8 *data, int len)
 {
 	buffer_make_room (buf, len);
@@ -225,7 +225,7 @@ buffer_add_data (Buffer *buf, guint8 *data, int len)
 	buf->p += len;
 }
 
-static inline void
+static void
 buffer_add_string (Buffer *buf, const char *str)
 {
 	int len;
@@ -239,13 +239,13 @@ buffer_add_string (Buffer *buf, const char *str)
 	}
 }
 
-static inline void
+static void
 buffer_add_buffer (Buffer *buf, Buffer *data)
 {
 	buffer_add_data (buf, data->buf, buffer_len (data));
 }
 
-static inline void
+static void
 buffer_free (Buffer *buf)
 {
 	g_free (buf->buf);

--- a/mono/mini/local-propagation.c
+++ b/mono/mini/local-propagation.c
@@ -36,7 +36,7 @@
 #define MONO_ARCH_IS_OP_MEMBASE(opcode) FALSE
 #endif
 
-static inline MonoBitSet* 
+static MonoBitSet*
 mono_bitset_mp_new_noinit (MonoMemPool *mp,  guint32 max_size)
 {
 	int size = mono_bitset_alloc_size (max_size, 0);
@@ -815,7 +815,7 @@ mono_local_cprop (MonoCompile *cfg)
 	}
 }
 
-static inline gboolean
+static gboolean
 reg_is_softreg_no_fpstack (int reg, const char spec)
 {
 	return (spec == 'i' && reg >= MONO_MAX_IREGS)
@@ -826,7 +826,7 @@ reg_is_softreg_no_fpstack (int reg, const char spec)
 		|| (spec == 'v');
 }
 		
-static inline gboolean
+static gboolean
 reg_is_softreg (int reg, const char spec)
 {
 	return (spec == 'i' && reg >= MONO_MAX_IREGS)
@@ -837,7 +837,7 @@ reg_is_softreg (int reg, const char spec)
 		|| (spec == 'v');
 }
 
-static inline gboolean
+static gboolean
 mono_is_simd_accessor (MonoInst *ins)
 {
 	switch (ins->opcode) {

--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -2497,7 +2497,7 @@ mono_patch_info_rgctx_entry_new (MonoMemPool *mp, MonoMethod *method, gboolean i
 	return res;
 }
 
-static inline MonoInst*
+static MonoInst*
 emit_rgctx_fetch_inline (MonoCompile *cfg, MonoInst *rgctx, MonoJumpInfoRgctxEntry *entry)
 {
 	MonoInst *args [16];
@@ -4791,7 +4791,7 @@ exception_exit:
 	return 1;
 }
 
-static inline MonoMethod *
+static MonoMethod *
 mini_get_method_allow_open (MonoMethod *m, guint32 token, MonoClass *klass, MonoGenericContext *context, MonoError *error)
 {
 	MonoMethod *method;
@@ -4810,7 +4810,7 @@ mini_get_method_allow_open (MonoMethod *m, guint32 token, MonoClass *klass, Mono
 	return method;
 }
 
-static inline MonoMethod *
+static MonoMethod *
 mini_get_method (MonoCompile *cfg, MonoMethod *m, guint32 token, MonoClass *klass, MonoGenericContext *context)
 {
 	ERROR_DECL (error);
@@ -4827,7 +4827,7 @@ mini_get_method (MonoCompile *cfg, MonoMethod *m, guint32 token, MonoClass *klas
 	return method;
 }
 
-static inline MonoMethodSignature*
+static MonoMethodSignature*
 mini_get_signature (MonoMethod *method, guint32 token, MonoGenericContext *context, MonoError *error)
 {
 	MonoMethodSignature *fsig;
@@ -5831,7 +5831,7 @@ typedef struct _MonoOpcodeInfo {
 	gint  pushes   : 3; // public -1 means variable
 } MonoOpcodeInfo;
 
-static inline const MonoOpcodeInfo*
+static const MonoOpcodeInfo*
 mono_opcode_decode (guchar *ip, guint op_size, MonoOpcodeEnum il_op, MonoOpcodeParameter *parameter)
 {
 #define Push0 (0)
@@ -11435,7 +11435,7 @@ mono_load_membase_to_load_mem (int opcode)
 	return -1;
 }
 
-static inline int
+static int
 op_to_op_dest_membase (int store_opcode, int opcode)
 {
 #if defined(TARGET_X86)
@@ -11531,7 +11531,7 @@ op_to_op_dest_membase (int store_opcode, int opcode)
 	return -1;
 }
 
-static inline int
+static int
 op_to_op_store_membase (int store_opcode, int opcode)
 {
 #if defined(TARGET_X86) || defined(TARGET_AMD64)
@@ -11548,7 +11548,7 @@ op_to_op_store_membase (int store_opcode, int opcode)
 	return -1;
 }
 
-static inline int
+static int
 op_to_op_src1_membase (MonoCompile *cfg, int load_opcode, int opcode)
 {
 #ifdef TARGET_X86
@@ -11612,7 +11612,7 @@ op_to_op_src1_membase (MonoCompile *cfg, int load_opcode, int opcode)
 	return -1;
 }
 
-static inline int
+static int
 op_to_op_src2_membase (MonoCompile *cfg, int load_opcode, int opcode)
 {
 #ifdef TARGET_X86

--- a/mono/mini/mini-amd64-gsharedvt.c
+++ b/mono/mini/mini-amd64-gsharedvt.c
@@ -73,7 +73,7 @@ arg_info_desc (ArgInfo *info)
 }
 #endif
 
-static inline void
+static void
 add_to_map (GPtrArray *map, int src, int dst)
 {
 	g_ptr_array_add (map, GUINT_TO_POINTER (src));
@@ -94,7 +94,7 @@ add_to_map (GPtrArray *map, int src, int dst)
  * 8..  - stack slots
  *
  */
-static inline int
+static int
 map_reg (int reg)
 {
 	int i = 0;
@@ -106,13 +106,13 @@ map_reg (int reg)
 	return -1;
 }
 
-static inline int
+static int
 map_freg (int reg)
 {
 	return reg + PARAM_REGS;
 }
 
-static inline int
+static int
 map_stack_slot (int slot)
 {
 	return slot + PARAM_REGS + FLOAT_PARAM_REGS;

--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -154,7 +154,7 @@ debug_omit_fp (void)
 #endif
 }
 
-static inline gboolean
+static gboolean
 amd64_is_near_call (guint8 *code)
 {
 	/* Skip REX */
@@ -164,7 +164,7 @@ amd64_is_near_call (guint8 *code)
 	return code [0] == 0xe8;
 }
 
-static inline gboolean
+static gboolean
 amd64_use_imm32 (gint64 val)
 {
 	if (mini_debug_options.single_imm_size)
@@ -452,13 +452,13 @@ allocate_register_for_valuetype_win64 (ArgInfo *arg_info, ArgumentClass arg_clas
 	return result;
 }
 
-static inline gboolean
+static gboolean
 allocate_parameter_register_for_valuetype_win64 (ArgInfo *arg_info, ArgumentClass arg_class, guint32 arg_size, guint32 *current_int_reg, guint32 *current_float_reg)
 {
 	return allocate_register_for_valuetype_win64 (arg_info, arg_class, arg_size, param_regs, PARAM_REGS, float_param_regs, FLOAT_PARAM_REGS, current_int_reg, current_float_reg);
 }
 
-static inline gboolean
+static gboolean
 allocate_return_register_for_valuetype_win64 (ArgInfo *arg_info, ArgumentClass arg_class, guint32 arg_size, guint32 *current_int_reg, guint32 *current_float_reg)
 {
 	return allocate_register_for_valuetype_win64 (arg_info, arg_class, arg_size, return_regs, RETURN_REGS, float_return_regs, FLOAT_RETURN_REGS, current_int_reg, current_float_reg);
@@ -2070,7 +2070,7 @@ emit_sig_cookie (MonoCompile *cfg, MonoCallInst *call, CallInfo *cinfo)
 }
 
 #ifdef ENABLE_LLVM
-static inline LLVMArgStorage
+static LLVMArgStorage
 arg_storage_to_llvm_arg_storage (MonoCompile *cfg, ArgStorage storage)
 {
 	switch (storage) {

--- a/mono/mini/mini-arm-gsharedvt.c
+++ b/mono/mini/mini-arm-gsharedvt.c
@@ -38,20 +38,20 @@ mono_arch_gsharedvt_sig_supported (MonoMethodSignature *sig)
 	return TRUE;
 }
 
-static inline void
+static void
 add_to_map (GPtrArray *map, int src, int dst)
 {
 	g_ptr_array_add (map, GUINT_TO_POINTER (src));
 	g_ptr_array_add (map, GUINT_TO_POINTER (dst));
 }
 
-static inline int
+static int
 map_reg (int reg)
 {
 	return reg;
 }
 
-static inline int
+static int
 map_stack_slot (int slot)
 {
 	return slot + 4;

--- a/mono/mini/mini-arm64-gsharedvt.c
+++ b/mono/mini/mini-arm64-gsharedvt.c
@@ -33,7 +33,7 @@ mono_arch_gsharedvt_sig_supported (MonoMethodSignature *sig)
 	return TRUE;
 }
 
-static inline void
+static void
 add_to_map (GPtrArray *map, int src, int dst)
 {
 	g_ptr_array_add (map, GUINT_TO_POINTER (src));
@@ -47,19 +47,19 @@ add_to_map (GPtrArray *map, int src, int dst)
  * 17..  - stack slots
  */
 
-static inline int
+static int
 map_reg (int reg)
 {
 	return reg;
 }
 
-static inline int
+static int
 map_freg (int reg)
 {
 	return reg + NUM_GSHAREDVT_ARG_GREGS;
 }
 
-static inline int
+static int
 map_stack_slot (int slot)
 {
 	return slot + NUM_GSHAREDVT_ARG_GREGS + NUM_GSHAREDVT_ARG_FREGS;

--- a/mono/mini/mini-arm64.c
+++ b/mono/mini/mini-arm64.c
@@ -330,7 +330,7 @@ emit_imm64_template (guint8 *code, int dreg)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_addw_imm (guint8 *code, int dreg, int sreg, int imm)
 {
 	if (!arm_is_arith_imm (imm)) {
@@ -342,7 +342,7 @@ emit_addw_imm (guint8 *code, int dreg, int sreg, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_addx_imm (guint8 *code, int dreg, int sreg, int imm)
 {
 	if (!arm_is_arith_imm (imm)) {
@@ -354,7 +354,7 @@ emit_addx_imm (guint8 *code, int dreg, int sreg, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_subw_imm (guint8 *code, int dreg, int sreg, int imm)
 {
 	if (!arm_is_arith_imm (imm)) {
@@ -366,7 +366,7 @@ emit_subw_imm (guint8 *code, int dreg, int sreg, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_subx_imm (guint8 *code, int dreg, int sreg, int imm)
 {
 	if (!arm_is_arith_imm (imm)) {
@@ -379,7 +379,7 @@ emit_subx_imm (guint8 *code, int dreg, int sreg, int imm)
 }
 
 /* Emit sp+=imm. Clobbers ip0/ip1 */
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_addx_sp_imm (guint8 *code, int imm)
 {
 	code = emit_imm (code, ARMREG_IP0, imm);
@@ -390,7 +390,7 @@ emit_addx_sp_imm (guint8 *code, int imm)
 }
 
 /* Emit sp-=imm. Clobbers ip0/ip1 */
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_subx_sp_imm (guint8 *code, int imm)
 {
 	code = emit_imm (code, ARMREG_IP0, imm);
@@ -400,7 +400,7 @@ emit_subx_sp_imm (guint8 *code, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_andw_imm (guint8 *code, int dreg, int sreg, int imm)
 {
 	// FIXME:
@@ -410,7 +410,7 @@ emit_andw_imm (guint8 *code, int dreg, int sreg, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_andx_imm (guint8 *code, int dreg, int sreg, int imm)
 {
 	// FIXME:
@@ -420,7 +420,7 @@ emit_andx_imm (guint8 *code, int dreg, int sreg, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_orrw_imm (guint8 *code, int dreg, int sreg, int imm)
 {
 	// FIXME:
@@ -430,7 +430,7 @@ emit_orrw_imm (guint8 *code, int dreg, int sreg, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_orrx_imm (guint8 *code, int dreg, int sreg, int imm)
 {
 	// FIXME:
@@ -440,7 +440,7 @@ emit_orrx_imm (guint8 *code, int dreg, int sreg, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_eorw_imm (guint8 *code, int dreg, int sreg, int imm)
 {
 	// FIXME:
@@ -450,7 +450,7 @@ emit_eorw_imm (guint8 *code, int dreg, int sreg, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_eorx_imm (guint8 *code, int dreg, int sreg, int imm)
 {
 	// FIXME:
@@ -460,7 +460,7 @@ emit_eorx_imm (guint8 *code, int dreg, int sreg, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_cmpw_imm (guint8 *code, int sreg, int imm)
 {
 	if (imm == 0) {
@@ -474,7 +474,7 @@ emit_cmpw_imm (guint8 *code, int sreg, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_cmpx_imm (guint8 *code, int sreg, int imm)
 {
 	if (imm == 0) {
@@ -488,7 +488,7 @@ emit_cmpx_imm (guint8 *code, int sreg, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_strb (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_strb_imm (imm)) {
@@ -502,7 +502,7 @@ emit_strb (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_strh (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_strh_imm (imm)) {
@@ -516,7 +516,7 @@ emit_strh (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_strw (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_strw_imm (imm)) {
@@ -530,7 +530,7 @@ emit_strw (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_strfpw (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_strw_imm (imm)) {
@@ -544,7 +544,7 @@ emit_strfpw (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_strfpx (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_strx_imm (imm)) {
@@ -558,7 +558,7 @@ emit_strfpx (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_strx (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_strx_imm (imm)) {
@@ -572,7 +572,7 @@ emit_strx (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_ldrb (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_pimm12_scaled (imm, 1)) {
@@ -586,7 +586,7 @@ emit_ldrb (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_ldrsbx (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_pimm12_scaled (imm, 1)) {
@@ -600,7 +600,7 @@ emit_ldrsbx (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_ldrh (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_pimm12_scaled (imm, 2)) {
@@ -614,7 +614,7 @@ emit_ldrh (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_ldrshx (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_pimm12_scaled (imm, 2)) {
@@ -628,7 +628,7 @@ emit_ldrshx (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_ldrswx (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_pimm12_scaled (imm, 4)) {
@@ -642,7 +642,7 @@ emit_ldrswx (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_ldrw (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_pimm12_scaled (imm, 4)) {
@@ -655,7 +655,7 @@ emit_ldrw (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_ldrx (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_pimm12_scaled (imm, 8)) {
@@ -668,7 +668,7 @@ emit_ldrx (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_ldrfpw (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_pimm12_scaled (imm, 4)) {
@@ -682,7 +682,7 @@ emit_ldrfpw (guint8 *code, int rt, int rn, int imm)
 	return code;
 }
 
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_ldrfpx (guint8 *code, int rt, int rn, int imm)
 {
 	if (arm_is_pimm12_scaled (imm, 8)) {
@@ -3077,7 +3077,7 @@ opcode_to_armcond (int opcode)
 }
 
 /* This clobbers LR */
-static inline __attribute__ ((__warn_unused_result__)) guint8*
+static __attribute__ ((__warn_unused_result__)) guint8*
 emit_cond_exc (MonoCompile *cfg, guint8 *code, int opcode, const char *exc_name)
 {
 	int cond;

--- a/mono/mini/mini-codegen.c
+++ b/mono/mini/mini-codegen.c
@@ -61,7 +61,7 @@
 /* If the bank is mirrored return the true logical bank that the register in the
  * physical register bank is allocated to.
  */
-static inline int translate_bank (MonoRegState *rs, int bank, int hreg) {
+static int translate_bank (MonoRegState *rs, int bank, int hreg) {
 	return is_hreg_mirrored (rs, bank, hreg) ? get_mirrored_bank (bank) : bank;
 }
 
@@ -134,7 +134,7 @@ static const int regbank_spill_var_size[] = {
 
 #define DEBUG(a) MINI_DEBUG(cfg->verbose_level, 3, a;)
 
-static inline void
+static void
 mono_regstate_assign (MonoRegState *rs)
 {
 #ifdef MONO_ARCH_USE_SHARED_FP_SIMD_BANK
@@ -164,7 +164,7 @@ mono_regstate_assign (MonoRegState *rs)
 #endif
 }
 
-static inline int
+static int
 mono_regstate_alloc_int (MonoRegState *rs, regmask_t allow)
 {
 	regmask_t mask = allow & rs->ifree_mask;
@@ -195,7 +195,7 @@ mono_regstate_alloc_int (MonoRegState *rs, regmask_t allow)
 #endif
 }
 
-static inline void
+static void
 mono_regstate_free_int (MonoRegState *rs, int reg)
 {
 	if (reg >= 0) {
@@ -204,7 +204,7 @@ mono_regstate_free_int (MonoRegState *rs, int reg)
 	}
 }
 
-static inline int
+static int
 mono_regstate_alloc_general (MonoRegState *rs, regmask_t allow, int bank)
 {
 	int i;
@@ -225,7 +225,7 @@ mono_regstate_alloc_general (MonoRegState *rs, regmask_t allow, int bank)
 	return -1;
 }
 
-static inline void
+static void
 mono_regstate_free_general (MonoRegState *rs, int reg, int bank)
 {
 	int mirrored_bank;
@@ -314,7 +314,7 @@ resize_spill_info (MonoCompile *cfg, int bank)
  * returns the offset used by spillvar. It allocates a new
  * spill variable if necessary. 
  */
-static inline int
+static int
 mono_spillvar_offset (MonoCompile *cfg, int spillvar, int bank)
 {
 	MonoSpillInfo *info;
@@ -767,7 +767,7 @@ mono_print_ins (MonoInst *ins)
 	mono_print_ins_index (-1, ins);
 }
 
-static inline void
+static void
 insert_before_ins (MonoBasicBlock *bb, MonoInst *ins, MonoInst* to_insert)
 {
 	/*
@@ -777,7 +777,7 @@ insert_before_ins (MonoBasicBlock *bb, MonoInst *ins, MonoInst* to_insert)
 	mono_bblock_insert_before_ins (bb, ins, to_insert);
 }
 
-static inline void
+static void
 insert_after_ins (MonoBasicBlock *bb, MonoInst *ins, MonoInst **last, MonoInst* to_insert)
 {
 	/*
@@ -789,7 +789,7 @@ insert_after_ins (MonoBasicBlock *bb, MonoInst *ins, MonoInst **last, MonoInst* 
 	*last = to_insert;
 }
 
-static inline int
+static int
 get_vreg_bank (MonoCompile *cfg, int reg, int bank)
 {
 	if (vreg_is_ref (cfg, reg))
@@ -965,7 +965,7 @@ create_copy_ins (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst **last, int dest
 	return copy;
 }
 
-static inline const char*
+static const char*
 regbank_to_string (int bank)
 {
 	if (bank == MONO_REG_INT_REF)
@@ -1013,7 +1013,7 @@ enum {
 	MONO_FP_NEEDS_LOAD			= regmask (2)
 };
 
-static inline int
+static int
 alloc_int_reg (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst **last, MonoInst *ins, regmask_t dest_mask, int sym_reg, RegTrack *info)
 {
 	int val;
@@ -1033,7 +1033,7 @@ alloc_int_reg (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst **last, MonoInst *
 	return val;
 }
 
-static inline int
+static int
 alloc_general_reg (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst **last, MonoInst *ins, regmask_t dest_mask, int sym_reg, int bank)
 {
 	int val;
@@ -1049,7 +1049,7 @@ alloc_general_reg (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst **last, MonoIn
 	return val;
 }
 
-static inline int
+static int
 alloc_reg (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst **last, MonoInst *ins, regmask_t dest_mask, int sym_reg, RegTrack *info, int bank)
 {
 	if (G_UNLIKELY (bank))
@@ -1058,7 +1058,7 @@ alloc_reg (MonoCompile *cfg, MonoBasicBlock *bb, MonoInst **last, MonoInst *ins,
 		return alloc_int_reg (cfg, bb, last, ins, dest_mask, sym_reg, info);
 }
 
-static inline void
+static void
 assign_reg (MonoCompile *cfg, MonoRegState *rs, int reg, int hreg, int bank)
 {
 	if (G_UNLIKELY (bank)) {
@@ -1102,7 +1102,7 @@ assign_reg (MonoCompile *cfg, MonoRegState *rs, int reg, int hreg, int bank)
 	}
 }
 
-static inline regmask_t
+static regmask_t
 get_callee_mask (const char spec)
 {
 	if (G_UNLIKELY (reg_bank (spec)))

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -161,14 +161,14 @@ mono_thread_get_managed_sp (void)
 	return addr;
 }
 
-static inline void
+static void
 mini_clear_abort_threshold (void)
 {
 	MonoJitTlsData *jit_tls = mono_get_jit_tls ();
 	jit_tls->abort_exc_stack_threshold = NULL;
 }
 
-static inline void
+static void
 mini_set_abort_threshold (StackFrameInfo *frame)
 {
 	gpointer sp = frame->frame_addr;
@@ -185,7 +185,7 @@ mini_set_abort_threshold (StackFrameInfo *frame)
 // Note: In the case that the frame is above where the thread abort
 // was set we bump the threshold so that functions called from the new,
 // higher threshold don't trigger the thread abort exception
-static inline gboolean
+static gboolean
 mini_above_abort_threshold (void)
 {
 	gpointer sp = mono_thread_get_managed_sp ();

--- a/mono/mini/mini-gc.c
+++ b/mono/mini/mini-gc.c
@@ -292,7 +292,7 @@ mini_gc_enable_gc_maps_for_aot (void)
 
 // FIXME: Move these to a shared place
 
-static inline void
+static void
 encode_uleb128 (guint32 value, guint8 *buf, guint8 **endbuf)
 {
 	guint8 *p = buf;
@@ -339,7 +339,7 @@ encode_sleb128 (gint32 value, guint8 *buf, guint8 **endbuf)
 	*endbuf = p;
 }
 
-static inline guint32
+static guint32
 decode_uleb128 (guint8 *buf, guint8 **endbuf)
 {
 	guint8 *p = buf;
@@ -361,7 +361,7 @@ decode_uleb128 (guint8 *buf, guint8 **endbuf)
 	return res;
 }
 
-static inline gint32
+static gint32
 decode_sleb128 (guint8 *buf, guint8 **endbuf)
 {
 	guint8 *p = buf;
@@ -676,19 +676,19 @@ thread_suspend_func (gpointer user_data, void *sigctx, MonoContext *ctx)
 
 #define DEAD_REF ((gpointer)(gssize)0x2a2a2a2a2a2a2a2aULL)
 
-static inline void
+static void
 set_bit (guint8 *bitmap, int width, int y, int x)
 {
 	bitmap [(width * y) + (x / 8)] |= (1 << (x % 8));
 }
 
-static inline void
+static void
 clear_bit (guint8 *bitmap, int width, int y, int x)
 {
 	bitmap [(width * y) + (x / 8)] &= ~(1 << (x % 8));
 }
 
-static inline int
+static int
 get_bit (guint8 *bitmap, int width, int y, int x)
 {
 	return bitmap [(width * y) + (x / 8)] & (1 << (x % 8));
@@ -710,7 +710,7 @@ slot_type_to_string (GCSlotType type)
 	}
 }
 
-static inline host_mgreg_t
+static host_mgreg_t
 get_frame_pointer (MonoContext *ctx, int frame_reg)
 {
 #if defined(TARGET_AMD64)
@@ -1362,7 +1362,7 @@ mini_gc_set_slot_type_from_cfa (MonoCompile *cfg, int slot_offset, GCSlotType ty
 	gcfg->stack_slots_from_cfa = g_slist_prepend_mempool (cfg->mempool, gcfg->stack_slots_from_cfa, GUINT_TO_POINTER (((slot) << 16) | type));
 }
 
-static inline int
+static int
 fp_offset_to_slot (MonoCompile *cfg, int offset)
 {
 	MonoCompileGC *gcfg = cfg->gc_info;
@@ -1370,7 +1370,7 @@ fp_offset_to_slot (MonoCompile *cfg, int offset)
 	return (offset - gcfg->min_offset) / SIZEOF_SLOT;
 }
 
-static inline int
+static int
 slot_to_fp_offset (MonoCompile *cfg, int slot)
 {
 	MonoCompileGC *gcfg = cfg->gc_info;
@@ -1378,7 +1378,7 @@ slot_to_fp_offset (MonoCompile *cfg, int slot)
 	return (slot * SIZEOF_SLOT) + gcfg->min_offset;
 }
 
-static inline MONO_ALWAYS_INLINE void
+static MONO_ALWAYS_INLINE void
 set_slot (MonoCompileGC *gcfg, int slot, int callsite_index, GCSlotType type)
 {
 	g_assert (slot >= 0 && slot < gcfg->nslots);
@@ -1395,7 +1395,7 @@ set_slot (MonoCompileGC *gcfg, int slot, int callsite_index, GCSlotType type)
 	}
 }
 
-static inline void
+static void
 set_slot_everywhere (MonoCompileGC *gcfg, int slot, GCSlotType type)
 {
 	int width, pos;
@@ -1424,7 +1424,7 @@ set_slot_everywhere (MonoCompileGC *gcfg, int slot, GCSlotType type)
 	}
 }
 
-static inline void
+static void
 set_slot_in_range (MonoCompileGC *gcfg, int slot, int from, int to, GCSlotType type)
 {
 	int cindex;
@@ -1436,7 +1436,7 @@ set_slot_in_range (MonoCompileGC *gcfg, int slot, int from, int to, GCSlotType t
 	}
 }
 
-static inline void
+static void
 set_reg_slot (MonoCompileGC *gcfg, int slot, int callsite_index, GCSlotType type)
 {
 	g_assert (slot >= 0 && slot < gcfg->nregs);
@@ -1453,7 +1453,7 @@ set_reg_slot (MonoCompileGC *gcfg, int slot, int callsite_index, GCSlotType type
 	}
 }
 
-static inline void
+static void
 set_reg_slot_everywhere (MonoCompileGC *gcfg, int slot, GCSlotType type)
 {
 	int cindex;
@@ -1462,7 +1462,7 @@ set_reg_slot_everywhere (MonoCompileGC *gcfg, int slot, GCSlotType type)
 		set_reg_slot (gcfg, slot, cindex, type);
 }
 
-static inline void
+static void
 set_reg_slot_in_range (MonoCompileGC *gcfg, int slot, int from, int to, GCSlotType type)
 {
 	int cindex;
@@ -1626,13 +1626,13 @@ get_vtype_bitmap (MonoType *t, int *numbits)
 	}
 }
 
-static inline const char*
+static const char*
 get_offset_sign (int offset)
 {
 	return offset < 0 ? "-" : "+";
 }
 
-static inline int
+static int
 get_offset_val (int offset)
 {
 	return offset < 0 ? (- offset) : offset;
@@ -2203,7 +2203,7 @@ init_gcfg (MonoCompile *cfg)
 	}
 }
 
-static inline gboolean
+static gboolean
 has_bit_set (guint8 *bitmap, int width, int slot)
 {
 	int i;

--- a/mono/mini/mini-generic-sharing.c
+++ b/mono/mini/mini-generic-sharing.c
@@ -60,7 +60,7 @@ static mono_mutex_t gshared_mutex;
 
 static gboolean partial_supported = FALSE;
 
-static inline gboolean
+static gboolean
 partial_sharing_supported (void)
 {
 	if (!ALLOW_PARTIAL_SHARING)

--- a/mono/mini/mini-native-types.c
+++ b/mono/mini/mini-native-types.c
@@ -368,7 +368,7 @@ mono_emit_native_types_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMe
 
 #endif /* !DISABLE_JIT */
 
-static inline gboolean
+static gboolean
 mono_class_is_magic_assembly (MonoClass *klass)
 {
 	const char *aname = m_class_get_image (klass)->assembly_name;

--- a/mono/mini/mini-s390x.c
+++ b/mono/mini/mini-s390x.c
@@ -418,9 +418,9 @@ typedef struct {
 
 static void indent (int);
 static guint8 * backUpStackPtr(MonoCompile *, guint8 *);
-static inline void add_general (guint *, size_data *, ArgInfo *);
-static inline void add_stackParm (guint *, size_data *, ArgInfo *, gint);
-static inline void add_float (guint *, size_data *, ArgInfo *, gboolean);
+static void add_general (guint *, size_data *, ArgInfo *);
+static void add_stackParm (guint *, size_data *, ArgInfo *, gint);
+static void add_float (guint *, size_data *, ArgInfo *, gboolean);
 static CallInfo * get_call_info (MonoMemPool *, MonoMethodSignature *);
 static guchar * emit_float_to_int (MonoCompile *, guchar *, int, int, int, gboolean);
 static __inline__ void emit_unwind_regs(MonoCompile *, guint8 *, int, int, long);
@@ -628,7 +628,7 @@ emit_unwind_regs(MonoCompile *cfg, guint8 *code, int start, int end, long offset
 /*                                                                  */
 /*------------------------------------------------------------------*/
 
-static inline gboolean
+static gboolean
 retFitsInReg(guint32 size)
 {
 	switch (size) {
@@ -654,7 +654,7 @@ retFitsInReg(guint32 size)
 /*                                                                  */
 /*------------------------------------------------------------------*/
 
-static inline guint8 *
+static guint8 *
 backUpStackPtr(MonoCompile *cfg, guint8 *code)
 {
 	int stackSize = cfg->stack_usage;

--- a/mono/mini/mini-sparc.c
+++ b/mono/mini/mini-sparc.c
@@ -1384,7 +1384,7 @@ int cond_to_sparc_cond [][3] = {
 };
 
 /* Map opcode to the sparc condition codes */
-static inline SparcCond
+static SparcCond
 opcode_to_sparc_cond (int opcode)
 {
 	CompRelation rel;

--- a/mono/mini/simd-intrinsics.c
+++ b/mono/mini/simd-intrinsics.c
@@ -607,7 +607,7 @@ mono_simd_intrinsics_init (void)
 	/*TODO log the supported flags*/
 }
 
-static inline gboolean
+static gboolean
 apply_vreg_first_block_interference (MonoCompile *cfg, MonoInst *ins, int reg, int max_vreg, char *vreg_flags)
 {
 	if (reg != -1 && reg <= max_vreg && vreg_flags [reg]) {
@@ -619,7 +619,7 @@ apply_vreg_first_block_interference (MonoCompile *cfg, MonoInst *ins, int reg, i
 	return FALSE;
 }
 
-static inline gboolean
+static gboolean
 apply_vreg_following_block_interference (MonoCompile *cfg, MonoInst *ins, int reg, MonoBasicBlock *bb, int max_vreg, char *vreg_flags, MonoBasicBlock **target_bb)
 {
 	if (reg == -1 || reg > max_vreg || !(vreg_flags [reg] & VREG_HAS_XZERO_BB0) || target_bb [reg] == bb)
@@ -1706,7 +1706,7 @@ simd_intrinsic_emit_shift (const SimdIntrinsic *intrinsic, MonoCompile *cfg, Mon
 	return ins;
 }
 
-static inline gboolean
+static gboolean
 mono_op_is_packed_compare (int op)
 {
 	return op >= OP_PCMPEQB && op <= OP_PCMPEQQ;

--- a/mono/mini/ssa.c
+++ b/mono/mini/ssa.c
@@ -122,7 +122,7 @@ remove_bb_from_phis (MonoCompile *cfg, MonoBasicBlock *bb, MonoBasicBlock *targe
 	}
 }
 
-static inline int
+static int
 op_phi_to_move (int opcode)
 {
 	switch (opcode) {
@@ -141,7 +141,7 @@ op_phi_to_move (int opcode)
 	return -1;
 }
 
-static inline void
+static void
 record_use (MonoCompile *cfg, MonoInst *var, MonoBasicBlock *bb, MonoInst *ins)
 {
 	MonoMethodVar *info;
@@ -877,7 +877,7 @@ evaluate_ins (MonoCompile *cfg, MonoInst *ins, MonoInst **res, MonoInst **carray
 	return 0;
 }
 
-static inline void
+static void
 change_varstate (MonoCompile *cfg, GList **cvars, MonoMethodVar *info, int state, MonoInst *c0, MonoInst **carray)
 {
 	if (info->cpstate >= state)
@@ -898,7 +898,7 @@ change_varstate (MonoCompile *cfg, GList **cvars, MonoMethodVar *info, int state
 	}
 }
 
-static inline void
+static void
 add_cprop_bb (MonoCompile *cfg, MonoBasicBlock *bb, GList **bblist)
 {
 	if (G_UNLIKELY (cfg->verbose_level > 1))
@@ -1308,7 +1308,7 @@ mono_ssa_cprop (MonoCompile *cfg)
 	}
 }
 
-static inline void
+static void
 add_to_dce_worklist (MonoCompile *cfg, MonoMethodVar *var, MonoMethodVar *use, GList **wl)
 {
 	GList *tmp;

--- a/mono/mini/tramp-arm-gsharedvt.c
+++ b/mono/mini/tramp-arm-gsharedvt.c
@@ -25,7 +25,7 @@
 
 #ifdef MONO_ARCH_GSHAREDVT_SUPPORTED
 
-static inline guint8*
+static guint8*
 emit_bx (guint8* code, int reg)
 {
 	if (mono_arm_thumb_supported ())

--- a/mono/mini/tramp-arm.c
+++ b/mono/mini/tramp-arm.c
@@ -112,7 +112,7 @@ branch_for_target_reachable (guint8 *branch, guint8 *target)
 	return 0;
 }
 
-static inline guint8*
+static guint8*
 emit_bx (guint8* code, int reg)
 {
 	if (mono_arm_thumb_supported ())

--- a/mono/mini/type-checking.c
+++ b/mono/mini/type-checking.c
@@ -87,7 +87,7 @@ emit_castclass_with_cache (MonoCompile *cfg, MonoInst *obj, MonoClass *klass, in
 	return res;
 }
 
-static inline void
+static void
 mini_emit_class_check_inst (MonoCompile *cfg, int klass_reg, MonoClass *klass, MonoInst *klass_inst)
 {
 	if (klass_inst) {
@@ -232,7 +232,7 @@ mini_emit_max_iid_check_class (MonoCompile *cfg, int klass_reg, MonoClass *klass
 	mini_emit_max_iid_check (cfg, max_iid_reg, klass, false_target);
 }
 
-static inline void
+static void
 mini_emit_class_check_branch (MonoCompile *cfg, int klass_reg, MonoClass *klass, int branch_op, MonoBasicBlock *target)
 {
 	if (cfg->compile_aot) {

--- a/mono/mini/unwind.c
+++ b/mono/mini/unwind.c
@@ -251,7 +251,7 @@ encode_sleb128 (gint32 value, guint8 *buf, guint8 **endbuf)
 	*endbuf = p;
 }
 
-static inline guint32
+static guint32
 decode_uleb128 (guint8 *buf, guint8 **endbuf)
 {
 	guint8 *p = buf;
@@ -273,7 +273,7 @@ decode_uleb128 (guint8 *buf, guint8 **endbuf)
 	return res;
 }
 
-static inline gint32
+static gint32
 decode_sleb128 (guint8 *buf, guint8 **endbuf)
 {
 	guint8 *p = buf;

--- a/mono/sgen/sgen-cardtable.c
+++ b/mono/sgen/sgen-cardtable.c
@@ -520,7 +520,7 @@ sgen_card_table_dump_obj_card (GCObject *object, size_t size, void *dummy)
 
 #define MWORD_MASK (sizeof (mword) - 1)
 
-static inline int
+static int
 find_card_offset (mword card)
 {
 /*XXX Use assembly as this generates some pretty bad code */

--- a/mono/sgen/sgen-fin-weak-hash.c
+++ b/mono/sgen/sgen-fin-weak-hash.c
@@ -42,19 +42,19 @@ static int no_finalize = 0;
 
 #define TAG_MASK ((mword)0x1)
 
-static inline GCObject*
+static GCObject*
 tagged_object_get_object (GCObject *object)
 {
 	return (GCObject*)(((mword)object) & ~TAG_MASK);
 }
 
-static inline int
+static int
 tagged_object_get_tag (GCObject *object)
 {
 	return ((mword)object) & TAG_MASK;
 }
 
-static inline GCObject*
+static GCObject*
 tagged_object_apply (void *object, int tag_bits)
 {
        return (GCObject*)((mword)object | (mword)tag_bits);

--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -2675,7 +2675,7 @@ report_internal_mem_usage (void)
  * current collection - major collections are full heap, so old gen objects
  * are never alive during a minor collection.
  */
-static inline int
+static int
 sgen_is_object_alive_and_on_current_collection (GCObject *object)
 {
 	if (ptr_in_nursery (object))

--- a/mono/sgen/sgen-gchandles.c
+++ b/mono/sgen/sgen-gchandles.c
@@ -56,7 +56,7 @@ protocol_gchandle_update (int handle_type, gpointer link, gpointer old_value, gp
 }
 
 /* Returns the new value in the slot, or NULL if the CAS failed. */
-static inline gpointer
+static gpointer
 try_set_slot (volatile gpointer *slot, GCObject *obj, gpointer old, GCHandleType type)
 {
 	gpointer new_;
@@ -72,7 +72,7 @@ try_set_slot (volatile gpointer *slot, GCObject *obj, gpointer old, GCHandleType
 	return NULL;
 }
 
-static inline gboolean
+static gboolean
 is_slot_set (volatile gpointer *slot)
 {
 	gpointer entry = *slot;
@@ -82,7 +82,7 @@ is_slot_set (volatile gpointer *slot)
 }
 
 /* Try to claim a slot by setting its occupied bit. */
-static inline gboolean
+static gboolean
 try_occupy_slot (volatile gpointer *slot, gpointer obj, int data)
 {
 	if (is_slot_set (slot))

--- a/mono/sgen/sgen-marksweep.c
+++ b/mono/sgen/sgen-marksweep.c
@@ -446,7 +446,7 @@ sweep_in_progress (void)
 		state == SWEEP_STATE_COMPACTING;
 }
 
-static inline gboolean
+static gboolean
 block_is_swept_or_marking (MSBlockInfo *block)
 {
 	gint32 state = block->state;
@@ -1126,7 +1126,7 @@ get_cardtable_mod_union_for_block (MSBlockInfo *block, gboolean allocate)
 	return other;
 }
 
-static inline guint8*
+static guint8*
 major_get_cardtable_mod_union_for_reference (char *ptr)
 {
 	MSBlockInfo *block = MS_BLOCK_FOR_OBJ (ptr);
@@ -1153,7 +1153,7 @@ mark_mod_union_card (GCObject *obj, void **ptr, GCObject *value_obj)
 	sgen_binary_protocol_mod_union_remset (obj, ptr, value_obj, SGEN_LOAD_VTABLE (value_obj));
 }
 
-static inline gboolean
+static gboolean
 major_block_is_evacuating (MSBlockInfo *block)
 {
 	if (evacuate_block_obj_sizes [block->obj_size_index] &&
@@ -1308,7 +1308,7 @@ static guint64 stat_drain_loops;
 #define DRAIN_GRAY_STACK_FUNCTION_NAME	drain_gray_stack_concurrent_par_with_evacuation
 #include "sgen-marksweep-drain-gray-stack.h"
 
-static inline gboolean
+static gboolean
 major_is_evacuating (void)
 {
 	int i;
@@ -1422,7 +1422,7 @@ mark_pinned_objects_in_block (MSBlockInfo *block, size_t first_entry, size_t las
 		block->has_pinned = TRUE;
 }
 
-static inline void
+static void
 sweep_block_for_size (MSBlockInfo *block, int count, int obj_size)
 {
 	int obj_index;
@@ -1452,7 +1452,7 @@ sweep_block_for_size (MSBlockInfo *block, int count, int obj_size)
 	}
 }
 
-static inline gboolean
+static gboolean
 try_set_block_state (MSBlockInfo *block, gint32 new_state, gint32 expected_state)
 {
 	gint32 old_state = SGEN_CAS (&block->state, new_state, expected_state);
@@ -1462,7 +1462,7 @@ try_set_block_state (MSBlockInfo *block, gint32 new_state, gint32 expected_state
 	return success;
 }
 
-static inline void
+static void
 set_block_state (MSBlockInfo *block, gint32 new_state, gint32 expected_state)
 {
 	SGEN_ASSERT (6, block->state == expected_state, "Block state incorrect before set");
@@ -1539,7 +1539,7 @@ sweep_block (MSBlockInfo *block)
 	return TRUE;
 }
 
-static inline int
+static int
 bitcount (mword d)
 {
 	int count = 0;

--- a/mono/sgen/sgen-memory-governor.c
+++ b/mono/sgen/sgen-memory-governor.c
@@ -130,7 +130,7 @@ sgen_memgov_calculate_minor_collection_allowance (void)
 	}
 }
 
-static inline size_t
+static size_t
 get_heap_size (void)
 {
 	return sgen_major_collector.get_num_major_sections () * sgen_major_collector.section_size + sgen_los_memory_usage;

--- a/mono/sgen/sgen-nursery-allocator.c
+++ b/mono/sgen/sgen-nursery-allocator.c
@@ -219,20 +219,19 @@ verify_alloc_records (void)
 
 /*********************************************************************************/
 
-
-static inline gpointer
+static gpointer
 mask (gpointer n, uintptr_t bit)
 {
 	return (gpointer)(((uintptr_t)n) | bit);
 }
 
-static inline gpointer
+static gpointer
 unmask (gpointer p)
 {
 	return (gpointer)((uintptr_t)p & ~(uintptr_t)0x3);
 }
 
-static inline uintptr_t
+static uintptr_t
 get_mark (gpointer n)
 {
 	return (uintptr_t)n & 0x1;

--- a/mono/sgen/sgen-simple-nursery.c
+++ b/mono/sgen/sgen-simple-nursery.c
@@ -23,14 +23,14 @@
 #include "mono/utils/mono-memory-model.h"
 #include "mono/utils/mono-proclib.h"
 
-static inline GCObject*
+static GCObject*
 alloc_for_promotion (GCVTable vtable, GCObject *obj, size_t objsize, gboolean has_references)
 {
 	sgen_total_promoted_size += objsize;
 	return sgen_major_collector.alloc_object (vtable, objsize, has_references);
 }
 
-static inline GCObject*
+static GCObject*
 alloc_for_promotion_par (GCVTable vtable, GCObject *obj, size_t objsize, gboolean has_references)
 {
 	/*

--- a/mono/sgen/sgen-split-nursery.c
+++ b/mono/sgen/sgen-split-nursery.c
@@ -139,7 +139,7 @@ static AgeAllocationBuffer age_alloc_buffers [MAX_AGE];
 /* The collector allocs from here. */
 static SgenFragmentAllocator collector_allocator;
 
-static inline int
+static int
 get_object_age (GCObject *object)
 {
 	size_t idx = ((char*)object - sgen_nursery_start) >> SGEN_TO_SPACE_GRANULE_BITS;
@@ -157,7 +157,7 @@ set_age_in_range (char *start, char *end, int age)
 	memset (region_start, age, length);
 }
 
-static inline void
+static void
 mark_bit (char *space_bitmap, char *pos)
 {
 	size_t idx = (pos - sgen_nursery_start) >> SGEN_TO_SPACE_GRANULE_BITS;
@@ -250,7 +250,7 @@ alloc_for_promotion_slow_path (int age, size_t objsize)
 	return p;
 }
 
-static inline GCObject*
+static GCObject*
 alloc_for_promotion (GCVTable vtable, GCObject *obj, size_t objsize, gboolean has_references)
 {
 	char *p = NULL;

--- a/mono/unit-tests/test-mono-linked-list-set.c
+++ b/mono/unit-tests/test-mono-linked-list-set.c
@@ -34,7 +34,7 @@ typedef struct {
 
 static node_t nodes [N];
 
-static inline void
+static void
 mono_hazard_pointer_clear_all (MonoThreadHazardPointers *hp, int retain)
 {
 	if (retain != 0)

--- a/mono/utils/checked-build.c
+++ b/mono/utils/checked-build.c
@@ -144,14 +144,14 @@ get_state (void)
 	return state;
 }
 
-static inline void
+static void
 ringbuf_unpack (gint32 ringbuf, guint16 *buf_start, guint16 *buf_end)
 {
 	*buf_start = (guint16) (ringbuf >> 16);
 	*buf_end = (guint16) (ringbuf & 0x00FF);
 }
 
-static inline gint32
+static gint32
 ringbuf_pack (guint16 buf_start, guint16 buf_end)
 {
 	return ((((gint32)buf_start) << 16) | ((gint32)buf_end));

--- a/mono/utils/mono-io-portability.c
+++ b/mono/utils/mono-io-portability.c
@@ -19,7 +19,7 @@
 
 int mono_io_portability_helpers = PORTABILITY_UNKNOWN;
 
-static inline gchar *mono_portability_find_file_internal (const gchar *pathname, gboolean last_exists);
+static gchar *mono_portability_find_file_internal (const gchar *pathname, gboolean last_exists);
 
 void mono_portability_helpers_init (void)
 {
@@ -109,7 +109,7 @@ gchar *mono_portability_find_file (const gchar *pathname, gboolean last_exists)
 }
 
 /* Returns newly-allocated string or NULL on failure */
-static inline gchar *mono_portability_find_file_internal (const gchar *pathname, gboolean last_exists)
+static gchar *mono_portability_find_file_internal (const gchar *pathname, gboolean last_exists)
 {
 	gchar *new_pathname, **components, **new_components;
 	int num_components = 0, component = 0;

--- a/mono/utils/mono-linked-list-set.c
+++ b/mono/utils/mono-linked-list-set.c
@@ -19,7 +19,7 @@
 
 #include <mono/utils/atomic.h>
 
-static inline gpointer
+static gpointer
 mask (gpointer n, uintptr_t bit)
 {
 	return (gpointer)(((uintptr_t)n) | bit);

--- a/mono/utils/mono-log-common.c
+++ b/mono/utils/mono-log-common.c
@@ -39,8 +39,8 @@ static void *logUserData = NULL;
  * 	@level - GLogLevelFlags value
  * 	@returns The equivalent character identifier
  */
-static inline char 
-mapLogFileLevel(GLogLevelFlags level) 
+static char
+mapLogFileLevel (GLogLevelFlags level)
 {
 	if (level & G_LOG_LEVEL_ERROR)
 		return ('E');

--- a/mono/utils/mono-log-windows.c
+++ b/mono/utils/mono-log-windows.c
@@ -38,8 +38,8 @@ static const wchar_t *logFileName = L".//mono.log"; // FIXME double slash
  * 	@level - GLogLevelFlags value
  * 	@returns The equivalent character identifier
  */
-static inline char 
-mapLogFileLevel(GLogLevelFlags level) 
+static char
+mapLogFileLevel (GLogLevelFlags level)
 {
 	if (level & G_LOG_LEVEL_ERROR)
 		return ('E');

--- a/mono/utils/mono-threads-state-machine.c
+++ b/mono/utils/mono-threads-state-machine.c
@@ -103,7 +103,7 @@ check_thread_state (MonoThreadInfo* info)
 	}
 }
 
-static inline void
+static void
 trace_state_change_with_func (const char *transition, MonoThreadInfo *info, int cur_raw_state, int next_state, gboolean next_no_safepoints, int suspend_count_delta, const char *func)
 {
 	check_thread_state (info);
@@ -121,7 +121,7 @@ trace_state_change_with_func (const char *transition, MonoThreadInfo *info, int 
 	CHECKED_BUILD_THREAD_TRANSITION (transition, info, get_thread_state (cur_raw_state), get_thread_suspend_count (cur_raw_state), next_state, suspend_count_delta);
 }
 
-static inline void
+static void
 trace_state_change_sigsafe (const char *transition, MonoThreadInfo *info, int cur_raw_state, int next_state, gboolean next_no_safepoints, int suspend_count_delta, const char *func)
 {
 	check_thread_state (info);
@@ -139,7 +139,7 @@ trace_state_change_sigsafe (const char *transition, MonoThreadInfo *info, int cu
 	CHECKED_BUILD_THREAD_TRANSITION_NOBT (transition, info, get_thread_state (cur_raw_state), get_thread_suspend_count (cur_raw_state), next_state, suspend_count_delta);
 }
 
-static inline void
+static void
 trace_state_change (const char *transition, MonoThreadInfo *info, int cur_raw_state, int next_state, gboolean next_no_safepoints, int suspend_count_delta)
 // FIXME migrate all uses
 {

--- a/mono/utils/mono-threads-windows.c
+++ b/mono/utils/mono-threads-windows.c
@@ -28,7 +28,7 @@ enum Win32APCInfo {
 	WIN32_APC_INFO_PENDING_ABORT_SLOT = 1 << 3
 };
 
-static inline void
+static void
 request_interrupt (gpointer thread_info, HANDLE native_thread_handle, gint32 pending_apc_slot, PAPCFUNC apc_callback, DWORD tid)
 {
 	/*
@@ -113,7 +113,7 @@ suspend_abort_syscall (PVOID thread_info, HANDLE native_thread_handle, DWORD tid
 	request_interrupt (thread_info, native_thread_handle, WIN32_APC_INFO_PENDING_ABORT_SLOT, abort_apc, tid);
 }
 
-static inline void
+static void
 enter_alertable_wait_ex (MonoThreadInfo *info, HANDLE io_handle)
 {
 	// Only loaded/stored by current thread, here or in APC (also running on current thread).
@@ -124,7 +124,7 @@ enter_alertable_wait_ex (MonoThreadInfo *info, HANDLE io_handle)
 	mono_atomic_xchg_i32 (&info->win32_apc_info, (io_handle == INVALID_HANDLE_VALUE) ? WIN32_APC_INFO_ALERTABLE_WAIT_SLOT : WIN32_APC_INFO_BLOCKING_IO_SLOT);
 }
 
-static inline void
+static void
 leave_alertable_wait_ex (MonoThreadInfo *info, HANDLE io_handle)
 {
 	// Clear any previous flags. Thread is exiting alertable wait region, and info around pending interrupt/abort APC's

--- a/mono/utils/mono-threads.c
+++ b/mono/utils/mono-threads.c
@@ -337,7 +337,7 @@ mono_threads_wait_pending_operations (void)
 
 //Thread initialization code
 
-static inline void
+static void
 mono_hazard_pointer_clear_all (MonoThreadHazardPointers *hp, int retain)
 {
 	if (retain != 0)
@@ -1604,7 +1604,7 @@ sleep_interrupt (gpointer data)
 	mono_coop_mutex_unlock (&sleep_mutex);
 }
 
-static inline guint32
+static guint32
 sleep_interruptable (guint32 ms, gboolean *alerted)
 {
 	gint64 now, end;

--- a/mono/utils/monobitset.c
+++ b/mono/utils/monobitset.c
@@ -269,7 +269,7 @@ bitstart_mask [] = {
 
 #else
 
-static inline gint
+static gint
 my_g_bit_nth_lsf (gsize mask, gint nth_bit)
 {
 	nth_bit ++;
@@ -304,7 +304,7 @@ my_g_bit_nth_lsf (gsize mask, gint nth_bit)
 #endif
 }
 
-static inline gint
+static gint
 my_g_bit_nth_lsf_nomask (gsize mask)
 {
 	/* Mask is expected to be != 0 */
@@ -334,7 +334,7 @@ my_g_bit_nth_lsf_nomask (gsize mask)
 
 #endif
 
-static inline int
+static int
 my_g_bit_nth_msf (gsize mask,
 	       gint   nth_bit)
 {

--- a/support/signal.c
+++ b/support/signal.c
@@ -177,7 +177,7 @@ static void release_mutex (pthread_mutex_t *mutex)
 	}
 }
 
-static inline int
+static int
 keep_trying (int r)
 {
 	return r == -1 && errno == EINTR;
@@ -199,7 +199,7 @@ keep_trying (int r)
 #define PIPELOCK_GET_COUNT(x)      ((x) & PIPELOCK_COUNT_MASK)
 #define PIPELOCK_INCR_COUNT(x, by) (((x) & PIPELOCK_TEARDOWN_BIT) | (PIPELOCK_GET_COUNT (PIPELOCK_GET_COUNT (x) + (by))))
 
-static inline void
+static void
 acquire_pipelock_teardown (int *lock)
 {
 	int lockvalue_draining;
@@ -220,7 +220,7 @@ acquire_pipelock_teardown (int *lock)
 	}
 }
 
-static inline void
+static void
 release_pipelock_teardown (int *lock)
 {
 	while (1) {
@@ -233,7 +233,7 @@ release_pipelock_teardown (int *lock)
 }
 
 // Return 1 for success
-static inline int
+static int
 acquire_pipelock_handler (int *lock)
 {
 	while (1) {
@@ -246,7 +246,7 @@ acquire_pipelock_handler (int *lock)
 	}
 }
 
-static inline void
+static void
 release_pipelock_handler (int *lock)
 {
 	while (1) {

--- a/support/sys-socket.c
+++ b/support/sys-socket.c
@@ -582,19 +582,19 @@ Mono_Posix_Syscall_sendmsg (int socket, struct Mono_Posix_Syscall__Msghdr* messa
 	return r;
 }
 
-static inline void make_msghdr (struct msghdr* hdr, unsigned char* msg_control, gint64 msg_controllen)
+static void make_msghdr (struct msghdr* hdr, unsigned char* msg_control, gint64 msg_controllen)
 {
 	memset (hdr, 0, sizeof (struct msghdr));
 	hdr->msg_control = msg_control;
 	hdr->msg_controllen = msg_controllen;
 }
-static inline struct cmsghdr* from_offset (unsigned char* msg_control, gint64 offset)
+static struct cmsghdr* from_offset (unsigned char* msg_control, gint64 offset)
 {
 	if (offset == -1)
 		return NULL;
 	return (struct cmsghdr*) (msg_control + offset);
 }
-static inline gint64 to_offset (unsigned char* msg_control, void* hdr)
+static gint64 to_offset (unsigned char* msg_control, void* hdr)
 {
 	if (!hdr)
 		return -1;

--- a/support/sys-stat.c
+++ b/support/sys-stat.c
@@ -227,7 +227,7 @@ Mono_Posix_Syscall_get_utime_omit ()
 }
 
 #if defined(HAVE_FUTIMENS) || defined(HAVE_UTIMENSAT)
-static inline struct timespec*
+static struct timespec*
 copy_utimens (struct timespec* to, struct Mono_Posix_Timespec *from)
 {
 	if (from) {

--- a/support/sys-time.c
+++ b/support/sys-time.c
@@ -77,7 +77,7 @@ Mono_Posix_Syscall_settimeofday (
 	return r;
 }
 
-static inline struct timeval*
+static struct timeval*
 copy_utimes (struct timeval* to, struct Mono_Posix_Timeval *from)
 {
 	if (from) {


### PR DESCRIPTION
inlining is up to the compiler to decide.
It is used in .h files for linkage/dedup, not to affect codegen.

Establishing the consistency is worth the "line damage" imho.