### PR TITLE
Cleanup zlib-helper.c.

### DIFF
--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -7893,6 +7893,7 @@ ves_icall_System_IO_get_temp_path (MonoError *error)
 
 #if defined(ENABLE_MONODROID) || defined(ENABLE_MONOTOUCH) || defined(TARGET_WASM)
 
+// FIXME? Names should start "mono"?
 G_EXTERN_C gpointer CreateZStream (gint32 compress, MonoBoolean gzip, gpointer feeder, gpointer data);
 G_EXTERN_C gint32   CloseZStream (gpointer stream);
 G_EXTERN_C gint32   Flush (gpointer stream);

--- a/support/zlib-helper.c
+++ b/support/zlib-helper.c
@@ -31,10 +31,7 @@
 #define IO_ERROR -11
 #define MONO_EXCEPTION -12
 
-#define z_malloc(size)          ((gpointer) malloc(size))
-#define z_malloc0(size)         ((gpointer) calloc(1,size))
-#define z_new(type,size)        ((type *) z_malloc (sizeof (type) * (size)))
-#define z_new0(type,size)       ((type *) z_malloc0 (sizeof (type)* (size)))
+#define z_new0(type)  ((type *) calloc (sizeof (type), 1))
 
 typedef gint (*read_write_func) (guchar *buffer, gint length, void *gchandle);
 struct _ZStream {
@@ -48,6 +45,7 @@ struct _ZStream {
 };
 typedef struct _ZStream ZStream;
 
+// FIXME? Names should start "mono"?
 MONO_API ZStream *CreateZStream (gint compress, guchar gzip, read_write_func func, void *gchandle);
 MONO_API gint CloseZStream (ZStream *zstream);
 MONO_API gint Flush (ZStream *stream);
@@ -58,7 +56,7 @@ static gint flush_internal (ZStream *stream, gboolean is_final);
 static void *
 z_alloc (void *opaque, unsigned int nitems, unsigned int item_size)
 {
-	return z_malloc0 (nitems * item_size);
+	return calloc (nitems, item_size);
 }
 
 static void
@@ -77,12 +75,7 @@ CreateZStream (gint compress, guchar gzip, read_write_func func, void *gchandle)
 	if (func == NULL)
 		return NULL;
 
-#if !defined(ZLIB_VERNUM) || (ZLIB_VERNUM < 0x1204)
-	/* Older versions of zlib do not support raw deflate or gzip */
-	return NULL;
-#endif
-
-	z = z_new0 (z_stream, 1);
+	z = z_new0 (z_stream);
 	if (compress) {
 		retval = deflateInit2 (z, Z_DEFAULT_COMPRESSION, Z_DEFLATED, gzip ? 31 : -15, 8, Z_DEFAULT_STRATEGY);
 	} else {
@@ -95,12 +88,12 @@ CreateZStream (gint compress, guchar gzip, read_write_func func, void *gchandle)
 	}
 	z->zalloc = z_alloc;
 	z->zfree = z_free;
-	result = z_new0 (ZStream, 1);
+	result = z_new0 (ZStream);
 	result->stream = z;
 	result->func = func;
 	result->gchandle = gchandle;
 	result->compress = compress;
-	result->buffer = z_new (guchar, BUFFER_SIZE);
+	result->buffer = (guchar*)malloc (BUFFER_SIZE);
 	result->stream->next_out = result->buffer;
 	result->stream->avail_out = BUFFER_SIZE;
 	result->stream->total_in = 0;


### PR DESCRIPTION
 - Cleanup allocation -- leave integer overflow checks to `calloc`.
 - Assume "recent" zlib (10 years old is recent from this point of view).