### PR TITLE
[netcore] Make assembly name parsing and comparison case-insensitive

### DIFF
--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -428,7 +428,7 @@ encode_public_tok (const guchar *token, gint32 len)
 gboolean
 mono_public_tokens_are_equal (const unsigned char *pubt1, const unsigned char *pubt2)
 {
-	return memcmp (pubt1, pubt2, 16) == 0;
+	return g_ascii_strncasecmp ((const char*) pubt1, (const char*) pubt2, 16) == 0;
 }
 
 /**

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -1520,7 +1520,7 @@ assembly_name_to_aname (MonoAssemblyName *assembly, char *p) {
 	while (g_ascii_isspace (*p))
 		p++;
 	while (*p) {
-		if (*p == 'V' && g_ascii_strncasecmp (p, "Version=", 8) == 0) {
+		if ((*p == 'V' || *p == 'v') && g_ascii_strncasecmp (p, "Version=", 8) == 0) {
 			p += 8;
 			assembly->major = strtoul (p, &s, 10);
 			if (s == p || *s != '.')
@@ -1538,7 +1538,7 @@ assembly_name_to_aname (MonoAssemblyName *assembly, char *p) {
 			if (s == p)
 				return 1;
 			p = s;
-		} else if (*p == 'C' && g_ascii_strncasecmp (p, "Culture=", 8) == 0) {
+		} else if ((*p == 'C' || *p == 'c') && g_ascii_strncasecmp (p, "Culture=", 8) == 0) {
 			p += 8;
 			if (g_ascii_strncasecmp (p, "neutral", 7) == 0) {
 				assembly->culture = "";
@@ -1549,7 +1549,7 @@ assembly_name_to_aname (MonoAssemblyName *assembly, char *p) {
 					p++;
 				}
 			}
-		} else if (*p == 'P' && g_ascii_strncasecmp (p, "PublicKeyToken=", 15) == 0) {
+		} else if ((*p == 'P' || *p == 'p') && g_ascii_strncasecmp (p, "PublicKeyToken=", 15) == 0) {
 			p += 15;
 			if (strncmp (p, "null", 4) == 0) {
 				p += 4;

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -1562,7 +1562,9 @@ assembly_name_to_aname (MonoAssemblyName *assembly, char *p) {
 				len = (p - start + 1);
 				if (len > MONO_PUBLIC_KEY_TOKEN_LENGTH)
 					len = MONO_PUBLIC_KEY_TOKEN_LENGTH;
-				g_strlcpy ((char*)assembly->public_key_token, start, len);
+				char* pkt_lower = g_ascii_strdown ((char*) assembly->public_key_token, len);
+				g_strlcpy (pkt_lower, start, len);
+				g_free (pkt_lower);
 			}
 		} else {
 			while (*p && *p != ',')

--- a/mono/metadata/reflection.c
+++ b/mono/metadata/reflection.c
@@ -1562,8 +1562,8 @@ assembly_name_to_aname (MonoAssemblyName *assembly, char *p) {
 				len = (p - start + 1);
 				if (len > MONO_PUBLIC_KEY_TOKEN_LENGTH)
 					len = MONO_PUBLIC_KEY_TOKEN_LENGTH;
-				char* pkt_lower = g_ascii_strdown ((char*) assembly->public_key_token, len);
-				g_strlcpy (pkt_lower, start, len);
+				char* pkt_lower = g_ascii_strdown (start, len);
+				g_strlcpy ((char*) assembly->public_key_token, pkt_lower, len);
 				g_free (pkt_lower);
 			}
 		} else {

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -534,9 +534,6 @@
 # https://github.com/mono/mono/issues/15076
 -nomethod System.Reflection.Tests.AssemblyTests.LoadFrom_SameIdentityAsAssemblyWithDifferentPath_ReturnsEqualAssemblies
 
-# throws a NRE
-# https://github.com/mono/mono/issues/15077
--nomethod System.Reflection.Tests.GetTypeTests.GetType
 
 # Assertion expects false, but we return true
 # https://github.com/mono/mono/issues/15080


### PR DESCRIPTION
Fixes #15077
Fixes #11269
Possibly fixes other things?

I've broken this into separate commits to make clearer what's going on.

The first issue present is that the assembly info was parsed case-insensitively, so setting a lowercase 'p' in PublicKeyToken would result in it not being parsed. When fixing this, the test then consistently failed whether or not the first letter was capitalized.

The second issue, somewhat hidden by the first, is that the public key token is copied directly from the input string and then compared case-sensitively in the assembly lookup. I've added two commits to deal with this, one lowercasing the PKT on parse and one making the later comparison case-insensitive. Either of them individually solves the issue, but I think it's worth doing both for good measure.

Glancing through, the parsing and comparison of the culture also would appear to be case-sensitive for everything other than 'neutral'. I'm not sure if that is intended behavior or not, but if not a separate issue should be opened.