### PR TITLE
[loader] Add MonoAssemblyLoadContext; stop sharing MonoImages on netcore

### DIFF
--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -245,6 +245,7 @@ endif
 common_sources = \
 	$(platform_sources)	\
 	appdomain.c	\
+	assembly-load-context.c	\
 	domain.c	\
 	appdomain-icalls.h	\
 	assembly.c		\
@@ -299,6 +300,10 @@ common_sources = \
 	jit-info.c		\
 	loader.c		\
 	loader-internals.h	\
+	loaded-images.h		\
+	loaded-images.c		\
+	loaded-images-global.c	\
+	loaded-images-netcore.c	\
 	locales.c		\
 	locales.h		\
 	lock-tracer.c		\
@@ -420,6 +425,7 @@ common_sources = \
 	callspec.h	\
 	callspec.c	\
 	abi.c
+
 
 # These source files have compile time dependencies on GC code
 gc_dependent_sources = \

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2495,7 +2495,8 @@ ves_icall_System_AppDomain_LoadAssemblyRaw (MonoAppDomainHandle ad,
 	mono_gchandle_free_internal (gchandle); /* unpin */
 	MONO_HANDLE_ASSIGN (raw_assembly, NULL_HANDLE); /* don't reference the data anymore */
 	
-	MonoImage *image = mono_image_open_from_data_internal (assembly_data, raw_assembly_len, FALSE, NULL, refonly, FALSE, NULL);
+	MonoAssemblyLoadContext *alc = mono_domain_default_alc (domain);
+	MonoImage *image = mono_image_open_from_data_internal (alc, assembly_data, raw_assembly_len, FALSE, NULL, refonly, FALSE, NULL);
 
 	if (!image) {
 		mono_error_set_bad_image_by_name (error, "In memory assembly", "0x%p", raw_data);

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -3242,27 +3242,3 @@ mono_runtime_install_appctx_properties (void)
 
 #endif
 
-#ifdef ENABLE_NETCORE
-gpointer
-ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalInitializeNativeALC (gpointer this_gchandle_ptr, MonoBoolean is_default_alc, MonoBoolean collectible, MonoError *error)
-{
-	/* If the ALC is collectible, this_gchandle is weak, otherwise it's strong. */
-	uint32_t this_gchandle = (uint32_t)GPOINTER_TO_UINT (this_gchandle_ptr);
-	if (collectible) {
-		mono_error_set_execution_engine (error, "Collectible AssemblyLoadContexts are not yet supported by MonoVM");
-		return NULL;
-	}
-
-	MonoDomain *domain = mono_domain_get ();
-	MonoAssemblyLoadContext *alc = NULL;
-
-	if (is_default_alc) {
-		alc = mono_domain_default_alc (domain);
-		g_assert (alc);
-	} else {
-		/* create it */
-		alc = mono_domain_create_individual_alc (domain, this_gchandle, collectible, error);
-	}
-	return alc;
-}
-#endif

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2243,6 +2243,7 @@ mono_domain_assembly_preload (MonoAssemblyLoadContext *alc,
 	MonoDomain *domain = mono_domain_get ();
 	MonoAssembly *result = NULL;
 #ifdef ENABLE_NETCORE
+	g_assert (alc);
 	g_assert (mono_alc_domain (alc) == domain); /* should be true everywhere, not just on netcore */
 #endif
 
@@ -2366,8 +2367,13 @@ ves_icall_System_Reflection_Assembly_InternalLoad (MonoStringHandle name_handle,
 	gboolean parsed;
 	char *name;
 
+	MonoAssemblyLoadContext *alc = (MonoAssemblyLoadContext *)load_Context;
+	if (!alc)
+		alc = mono_domain_default_alc (domain);
+	g_assert (alc);
 	asmctx = MONO_ASMCTX_DEFAULT;
 	mono_assembly_request_prepare (&req.request, sizeof (req), asmctx);
+	req.request.alc = alc;
 	req.basedir = NULL;
 	req.no_postload_search = TRUE;
 

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -3235,3 +3235,28 @@ mono_runtime_install_appctx_properties (void)
 }
 
 #endif
+
+#ifdef ENABLE_NETCORE
+gpointer
+ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalInitializeNativeALC (gpointer this_gchandle_ptr, MonoBoolean is_default_alc, MonoBoolean collectible, MonoError *error)
+{
+	/* If the ALC is collectible, this_gchandle is weak, otherwise it's strong. */
+	uint32_t this_gchandle = (uint32_t)GPOINTER_TO_UINT (this_gchandle_ptr);
+	if (collectible) {
+		mono_error_set_execution_engine (error, "Collectible AssemblyLoadContexts are not yet supported by MonoVM");
+		return NULL;
+	}
+
+	MonoDomain *domain = mono_domain_get ();
+	MonoAssemblyLoadContext *alc = NULL;
+
+	if (is_default_alc) {
+		alc = mono_domain_default_alc (domain);
+		g_assert (alc);
+	} else {
+		/* create it */
+		alc = mono_domain_create_individual_alc (domain, this_gchandle, collectible, error);
+	}
+	return alc;
+}
+#endif

--- a/mono/metadata/appdomain.c
+++ b/mono/metadata/appdomain.c
@@ -2244,7 +2244,7 @@ mono_domain_assembly_preload (MonoAssemblyLoadContext *alc,
 	MonoAssembly *result = NULL;
 #ifdef ENABLE_NETCORE
 	g_assert (alc);
-	g_assert (mono_alc_domain (alc) == domain); /* should be true everywhere, not just on netcore */
+	g_assert (mono_alc_domain (alc) == domain);
 #endif
 
 	set_domain_search_path (domain);

--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -49,6 +49,10 @@ typedef gboolean (*MonoAssemblyAsmCtxFromPathFunc) (const char *absfname, MonoAs
 
 void mono_install_assembly_asmctx_from_path_hook (MonoAssemblyAsmCtxFromPathFunc func, gpointer user_data);
 
+typedef MonoAssembly * (*MonoAssemblyPreLoadFuncV2) (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, char **assemblies_path, gboolean refonly, gpointer user_data, MonoError *error);
+
+void mono_install_assembly_preload_hook_v2 (MonoAssemblyPreLoadFuncV2 func, void *user_data, gboolean refonly);
+
 /* If predicate returns true assembly should be loaded, if false ignore it. */
 typedef gboolean (*MonoAssemblyCandidatePredicate)(MonoAssembly *, gpointer);
 

--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -55,6 +55,7 @@ typedef gboolean (*MonoAssemblyCandidatePredicate)(MonoAssembly *, gpointer);
 typedef struct MonoAssemblyLoadRequest {
 	/* Assembly Load context that is requesting an assembly. */
 	MonoAssemblyContextKind asmctx;
+	MonoAssemblyLoadContext *alc;
 	/* Predicate to apply to candidate assemblies. Optional. */
 	MonoAssemblyCandidatePredicate predicate;
 	/* user_data for predicate. Optional. */

--- a/mono/metadata/assembly-load-context.c
+++ b/mono/metadata/assembly-load-context.c
@@ -9,7 +9,7 @@
 /* MonoAssemblyLoadContext support only in netcore Mono */
 
 void
-mono_alc_init (MonoAssemblyLoadContext *alc, MonoDomain *domain, gboolean default_alc)
+mono_alc_init (MonoAssemblyLoadContext *alc, MonoDomain *domain)
 {
 	MonoLoadedImages *li = g_new0 (MonoLoadedImages, 1);
 	mono_loaded_images_init (li, alc);

--- a/mono/metadata/assembly-load-context.c
+++ b/mono/metadata/assembly-load-context.c
@@ -1,6 +1,9 @@
 #include "config.h"
+#include "mono/metadata/domain-internals.h"
+#include "mono/metadata/icall-decl.h"
 #include "mono/metadata/loader-internals.h"
 #include "mono/metadata/loaded-images-internals.h"
+#include "mono/utils/mono-error-internals.h"
 
 #ifdef ENABLE_NETCORE
 /* MonoAssemblyLoadContext support only in netcore Mono */
@@ -20,5 +23,28 @@ mono_alc_cleanup (MonoAssemblyLoadContext *alc)
 	mono_loaded_images_free (alc->loaded_images);
 }
 
+
+gpointer
+ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalInitializeNativeALC (gpointer this_gchandle_ptr, MonoBoolean is_default_alc, MonoBoolean collectible, MonoError *error)
+{
+	/* If the ALC is collectible, this_gchandle is weak, otherwise it's strong. */
+	uint32_t this_gchandle = (uint32_t)GPOINTER_TO_UINT (this_gchandle_ptr);
+	if (collectible) {
+		mono_error_set_execution_engine (error, "Collectible AssemblyLoadContexts are not yet supported by MonoVM");
+		return NULL;
+	}
+
+	MonoDomain *domain = mono_domain_get ();
+	MonoAssemblyLoadContext *alc = NULL;
+
+	if (is_default_alc) {
+		alc = mono_domain_default_alc (domain);
+		g_assert (alc);
+	} else {
+		/* create it */
+		alc = mono_domain_create_individual_alc (domain, this_gchandle, collectible, error);
+	}
+	return alc;
+}
 
 #endif /* ENABLE_NETCORE */

--- a/mono/metadata/assembly-load-context.c
+++ b/mono/metadata/assembly-load-context.c
@@ -1,0 +1,24 @@
+#include "config.h"
+#include "mono/metadata/loader-internals.h"
+#include "mono/metadata/loaded-images-internals.h"
+
+#ifdef ENABLE_NETCORE
+/* MonoAssemblyLoadContext support only in netcore Mono */
+
+void
+mono_alc_init (MonoAssemblyLoadContext *alc, MonoDomain *domain, gboolean default_alc)
+{
+	MonoLoadedImages *li = g_new0 (MonoLoadedImages, 1);
+	mono_loaded_images_init (li, alc);
+	alc->domain = domain;
+	alc->loaded_images = li;
+}
+
+void
+mono_alc_cleanup (MonoAssemblyLoadContext *alc)
+{
+	mono_loaded_images_free (alc->loaded_images);
+}
+
+
+#endif /* ENABLE_NETCORE */

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -2339,7 +2339,7 @@ mono_assembly_request_open (const char *filename, const MonoAssemblyOpenRequest 
 	}
 
 	if (!image)
-		image = mono_image_open_a_lot (fname, status, refonly, load_from_context);
+		image = mono_image_open_a_lot (load_req.alc, fname, status, refonly, load_from_context);
 
 	if (!image){
 		if (*status == MONO_IMAGE_OK)

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -2149,7 +2149,7 @@ absolute_dir (const gchar *filename)
  * returns NULL
  */
 MonoImage *
-mono_assembly_open_from_bundle (const char *filename, MonoImageOpenStatus *status, gboolean refonly)
+mono_assembly_open_from_bundle (MonoAssemblyLoadContext *alc, const char *filename, MonoImageOpenStatus *status, gboolean refonly)
 {
 	int i;
 	char *name;
@@ -2170,7 +2170,7 @@ mono_assembly_open_from_bundle (const char *filename, MonoImageOpenStatus *statu
 	name = g_path_get_basename (filename);
 	for (i = 0; !image && bundles [i]; ++i) {
 		if (strcmp (bundles [i]->name, is_satellite ? filename : name) == 0) {
-			image = mono_image_open_from_data_internal ((char*)bundles [i]->data, bundles [i]->size, FALSE, status, refonly, FALSE, name);
+			image = mono_image_open_from_data_internal (alc, (char*)bundles [i]->data, bundles [i]->size, FALSE, status, refonly, FALSE, name);
 			break;
 		}
 	}
@@ -2334,7 +2334,7 @@ mono_assembly_request_open (const char *filename, const MonoAssemblyOpenRequest 
 	// If VM built with mkbundle
 	loaded_from_bundle = FALSE;
 	if (bundles != NULL) {
-		image = mono_assembly_open_from_bundle (fname, status, refonly);
+		image = mono_assembly_open_from_bundle (load_req.alc, fname, status, refonly);
 		loaded_from_bundle = image != NULL;
 	}
 

--- a/mono/metadata/coree.c
+++ b/mono/metadata/coree.c
@@ -89,7 +89,7 @@ BOOL STDMETHODCALLTYPE _CorDllMain(HINSTANCE hInst, DWORD dwReason, LPVOID lpRes
 		file_name = mono_get_module_file_name (hInst);
 
 		if (mono_get_root_domain ()) {
-			image = mono_image_open_from_module_handle (hInst, mono_path_resolve_symlinks (file_name), TRUE, NULL);
+			image = mono_image_open_from_module_handle (mono_domain_default_alc (mono_get_root_domain ()), hInst, mono_path_resolve_symlinks (file_name), TRUE, NULL);
 		} else {
 			init_from_coree = TRUE;
 			mono_runtime_load (file_name, NULL);

--- a/mono/metadata/coree.c
+++ b/mono/metadata/coree.c
@@ -133,7 +133,7 @@ BOOL STDMETHODCALLTYPE _CorDllMain(HINSTANCE hInst, DWORD dwReason, LPVOID lpRes
 			/* The process is terminating. */
 			return TRUE;
 		file_name = mono_get_module_file_name (hInst);
-		image = mono_image_loaded_internal (file_name, FALSE);
+		image = mono_image_loaded_internal (mono_domain_default_alc (mono_get_root_domain ()), file_name, FALSE);
 		if (image)
 			mono_image_close (image);
 

--- a/mono/metadata/coree.h
+++ b/mono/metadata/coree.h
@@ -20,6 +20,7 @@
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/w32api.h>
 #include "image.h"
+#include "image-internals.h"
 
 #define STATUS_SUCCESS 0x00000000L
 #define STATUS_INVALID_IMAGE_FORMAT 0xC000007BL
@@ -45,7 +46,7 @@ void mono_load_coree (const char* file_name);
 void mono_fixup_exe_image (MonoImage* image);
 
 /* Declared in image.c. */
-MonoImage* mono_image_open_from_module_handle (HMODULE module_handle, char* fname, gboolean has_entry_point, MonoImageOpenStatus* status);
+MonoImage* mono_image_open_from_module_handle (MonoAssemblyLoadContext *alc, HMODULE module_handle, char* fname, gboolean has_entry_point, MonoImageOpenStatus* status);
 
 #endif /* HOST_WIN32 */
 

--- a/mono/metadata/debug-mono-ppdb.c
+++ b/mono/metadata/debug-mono-ppdb.c
@@ -213,7 +213,7 @@ mono_ppdb_load_file (MonoImage *image, const guint8 *raw_contents, int size)
 			ppdb_filename = g_strdup_printf ("%s.pdb", filename);
 		}
 
-		ppdb_image = mono_image_open_metadata_only (ppdb_filename, &status);
+		ppdb_image = mono_image_open_metadata_only (alc, ppdb_filename, &status);
 		g_free (ppdb_filename);
 	}
 	g_free (to_free);

--- a/mono/metadata/debug-mono-ppdb.c
+++ b/mono/metadata/debug-mono-ppdb.c
@@ -197,9 +197,10 @@ mono_ppdb_load_file (MonoImage *image, const guint8 *raw_contents, int size)
 #endif
 	}
 
+	MonoAssemblyLoadContext *alc = mono_image_get_alc (image);
 	if (raw_contents) {
 		if (size > 4 && strncmp ((char*)raw_contents, "BSJB", 4) == 0)
-			ppdb_image = mono_image_open_from_data_internal ((char*)raw_contents, size, TRUE, &status, FALSE, TRUE, NULL);
+			ppdb_image = mono_image_open_from_data_internal (alc, (char*)raw_contents, size, TRUE, &status, FALSE, TRUE, NULL);
 	} else {
 		/* ppdb files drop the .exe/.dll extension */
 		filename = mono_image_get_filename (image);

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -17,6 +17,7 @@
 #include <mono/metadata/mono-conc-hash.h>
 #include <mono/utils/mono-compiler.h>
 #include <mono/utils/mono-internal-hash.h>
+#include <mono/metadata/loader-internals.h>
 #include <mono/metadata/mempool-internals.h>
 #include <mono/metadata/handle-decl.h>
 
@@ -454,6 +455,12 @@ struct _MonoDomain {
 	gboolean throw_unobserved_task_exceptions;
 
 	guint32 execution_context_field_offset;
+
+#ifdef ENABLE_NETCORE
+	GSList *alcs;
+	MonoAssemblyLoadContext *default_alc;
+	MonoCoopMutex alcs_lock; /* Used when accessing 'alcs' */
+#endif
 };
 
 typedef struct  {

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -623,7 +623,8 @@ mono_domain_parse_assembly_bindings (MonoDomain *domain, int amajor, int aminor,
 gboolean
 mono_assembly_name_parse (const char *name, MonoAssemblyName *aname);
 
-MonoImage *mono_assembly_open_from_bundle (const char *filename,
+MonoImage *mono_assembly_open_from_bundle (MonoAssemblyLoadContext *alc,
+					   const char *filename,
 					   MonoImageOpenStatus *status,
 					   gboolean refonly);
 

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -666,4 +666,7 @@ mono_runtime_install_appctx_properties (void);
 gboolean 
 mono_domain_set_fast (MonoDomain *domain, gboolean force);
 
+MonoAssemblyLoadContext *
+mono_domain_default_alc (MonoDomain *domain);
+
 #endif /* __MONO_METADATA_DOMAIN_INTERNALS_H__ */

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -670,4 +670,9 @@ mono_domain_set_fast (MonoDomain *domain, gboolean force);
 MonoAssemblyLoadContext *
 mono_domain_default_alc (MonoDomain *domain);
 
+#ifdef ENABLE_NETCORE
+MonoAssemblyLoadContext *
+mono_domain_create_individual_alc (MonoDomain *domain, uint32_t this_gchandle, gboolean collectible, MonoError *error);
+#endif
+
 #endif /* __MONO_METADATA_DOMAIN_INTERNALS_H__ */

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -565,7 +565,7 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 		runtimes = get_runtimes_from_exe (exe_filename, &exe_image);
 #ifdef HOST_WIN32
 		if (!exe_image) {
-			exe_image = mono_assembly_open_from_bundle (exe_filename, NULL, FALSE);
+			exe_image = mono_assembly_open_from_bundle (mono_domain_default_alc (domain), exe_filename, NULL, FALSE);
 			if (!exe_image)
 				exe_image = mono_image_open (exe_filename, NULL);
 		}
@@ -1914,7 +1914,7 @@ get_runtimes_from_exe (const char *file, MonoImage **out_image)
 	}
 	
 	/* Look for a runtime with the exact version */
-	image = mono_assembly_open_from_bundle (file, NULL, FALSE);
+	image = mono_assembly_open_from_bundle (mono_domain_default_alc (mono_domain_get ()), file, NULL, FALSE);
 
 	if (image == NULL)
 		image = mono_image_open (file, NULL);

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -2005,3 +2005,13 @@ mono_domain_get_assemblies (MonoDomain *domain, gboolean refonly)
 	mono_domain_assemblies_unlock (domain);
 	return assemblies;
 }
+
+MonoAssemblyLoadContext *
+mono_domain_default_alc (MonoDomain *domain)
+{
+#ifndef ENABLE_NETCORE
+	return NULL;
+#else
+	return domain->default_alc;
+#endif
+}

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -2069,7 +2069,7 @@ create_alc (MonoDomain *domain, gboolean is_default)
 		goto leave;
 
 	alc = g_new0 (MonoAssemblyLoadContext, 1);
-	mono_alc_init (alc, domain, is_default);
+	mono_alc_init (alc, domain);
 
 	domain->alcs = g_slist_prepend (domain->alcs, alc);
 	if (is_default)

--- a/mono/metadata/domain.c
+++ b/mono/metadata/domain.c
@@ -2092,6 +2092,16 @@ mono_domain_create_default_alc (MonoDomain *domain)
 #endif
 }
 
+#ifdef ENABLE_NETCORE
+MonoAssemblyLoadContext *
+mono_domain_create_individual_alc (MonoDomain *domain, uint32_t this_gchandle, gboolean collectible, MonoError *error)
+{
+	g_assert (!collectible); /* TODO: implement collectible ALCs */
+	MonoAssemblyLoadContext *alc = create_alc (domain, FALSE);
+	return alc;
+}
+#endif
+
 static void
 mono_alc_free (MonoAssemblyLoadContext *alc)
 {

--- a/mono/metadata/dynamic-image.c
+++ b/mono/metadata/dynamic-image.c
@@ -357,6 +357,12 @@ mono_dynamic_image_create (MonoDynamicAssembly *assembly, char *assembly_name, c
 	image->image.references = g_new0 (MonoAssembly*, 1);
 	image->image.references [0] = NULL;
 
+	/* HACK: only want to crerate modules_loaded_images in the initial image for this dynamic assembly, not in the added modules. */
+	if (!assembly->assembly.image) {
+		image->image.modules_loaded_images = g_new0 (MonoLoadedImages, 1);
+		mono_loaded_images_init (image->image.modules_loaded_images, MONO_LOADED_IMAGES_ASSEMBLY, image);
+	}
+
 	mono_image_init (&image->image);
 
 	image->token_fixups = mono_g_hash_table_new_type_internal ((GHashFunc)mono_object_hash_internal, NULL, MONO_HASH_KEY_GC, MONO_ROOT_SOURCE_REFLECTION, NULL, "Reflection Dynamic Image Token Fixup Table");

--- a/mono/metadata/dynamic-image.c
+++ b/mono/metadata/dynamic-image.c
@@ -357,11 +357,13 @@ mono_dynamic_image_create (MonoDynamicAssembly *assembly, char *assembly_name, c
 	image->image.references = g_new0 (MonoAssembly*, 1);
 	image->image.references [0] = NULL;
 
+#ifdef ENABLE_NETCORE
 	/* HACK: only want to crerate modules_loaded_images in the initial image for this dynamic assembly, not in the added modules. */
 	if (!assembly->assembly.image) {
 		image->image.modules_loaded_images = g_new0 (MonoLoadedImages, 1);
 		mono_loaded_images_init (image->image.modules_loaded_images, MONO_LOADED_IMAGES_ASSEMBLY, image);
 	}
+#endif
 
 	mono_image_init (&image->image);
 

--- a/mono/metadata/dynamic-image.c
+++ b/mono/metadata/dynamic-image.c
@@ -357,14 +357,6 @@ mono_dynamic_image_create (MonoDynamicAssembly *assembly, char *assembly_name, c
 	image->image.references = g_new0 (MonoAssembly*, 1);
 	image->image.references [0] = NULL;
 
-#ifdef ENABLE_NETCORE
-	/* HACK: only want to crerate modules_loaded_images in the initial image for this dynamic assembly, not in the added modules. */
-	if (!assembly->assembly.image) {
-		image->image.modules_loaded_images = g_new0 (MonoLoadedImages, 1);
-		mono_loaded_images_init (image->image.modules_loaded_images, MONO_LOADED_IMAGES_ASSEMBLY, image);
-	}
-#endif
-
 	mono_image_init (&image->image);
 
 	image->token_fixups = mono_g_hash_table_new_type_internal ((GHashFunc)mono_object_hash_internal, NULL, MONO_HASH_KEY_GC, MONO_ROOT_SOURCE_REFLECTION, NULL, "Reflection Dynamic Image Token Fixup Table");

--- a/mono/metadata/icall-def-netcore.h
+++ b/mono/metadata/icall-def-netcore.h
@@ -371,7 +371,7 @@ HANDLES(MARSHAL_41, "copy_from_unmanaged_fixed", ves_icall_System_Runtime_Intero
 HANDLES(MARSHAL_42, "copy_to_unmanaged_fixed", ves_icall_System_Runtime_InteropServices_Marshal_copy_to_unmanaged, void, 5, (MonoArray, gint32, gpointer, gint32, gconstpointer))
 
 ICALL_TYPE(ALC, "System.Runtime.Loader.AssemblyLoadContext", ALC_1)
-HANDLES(ALC_1, "InternalLoadFile", ves_icall_System_Reflection_Assembly_LoadFile_internal, MonoReflectionAssembly, 2, (MonoString, MonoStackCrawlMark_ptr))
+HANDLES(ALC_1, "InternalLoadFile", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalLoadFile, MonoReflectionAssembly, 3, (gpointer, MonoString, MonoStackCrawlMark_ptr))
 
 ICALL_TYPE(RUNIMPORT, "System.Runtime.RuntimeImports", RUNIMPORT_1)
 NOHANDLES(ICALL(RUNIMPORT_1, "RhBulkMoveWithWriteBarrier", ves_icall_System_Runtime_RuntimeImports_RhBulkMoveWithWriteBarrier))

--- a/mono/metadata/icall-def-netcore.h
+++ b/mono/metadata/icall-def-netcore.h
@@ -370,7 +370,8 @@ ICALL(MARSHAL_35, "UnsafeAddrOfPinnedArrayElement", ves_icall_System_Runtime_Int
 HANDLES(MARSHAL_41, "copy_from_unmanaged_fixed", ves_icall_System_Runtime_InteropServices_Marshal_copy_from_unmanaged, void, 5, (gconstpointer, gint32, MonoArray, gint32, gpointer))
 HANDLES(MARSHAL_42, "copy_to_unmanaged_fixed", ves_icall_System_Runtime_InteropServices_Marshal_copy_to_unmanaged, void, 5, (MonoArray, gint32, gpointer, gint32, gconstpointer))
 
-ICALL_TYPE(ALC, "System.Runtime.Loader.AssemblyLoadContext", ALC_1)
+ICALL_TYPE(ALC, "System.Runtime.Loader.AssemblyLoadContext", ALC_2)
+HANDLES(ALC_2, "InternalInitializeNativeALC", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalInitializeNativeALC, gpointer, 3, (gpointer, MonoBoolean, MonoBoolean))
 HANDLES(ALC_1, "InternalLoadFile", ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalLoadFile, MonoReflectionAssembly, 3, (gpointer, MonoString, MonoStackCrawlMark_ptr))
 
 ICALL_TYPE(RUNIMPORT, "System.Runtime.RuntimeImports", RUNIMPORT_1)

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -5833,6 +5833,7 @@ ves_icall_System_Reflection_Assembly_InternalGetAssemblyName (MonoStringHandle f
 
 	error_init (error);
 
+	MonoDomain *domain = MONO_HANDLE_DOMAIN (fname);
 	filename = mono_string_handle_to_utf8 (fname, error);
 	return_if_nok (error);
 
@@ -5842,7 +5843,8 @@ ves_icall_System_Reflection_Assembly_InternalGetAssemblyName (MonoStringHandle f
 
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "InternalGetAssemblyName (\"%s\")", filename);
 
-	image = mono_image_open_full (filename, &status, TRUE);
+	MonoAssemblyLoadContext *alc = mono_domain_default_alc (domain);
+	image = mono_image_open_a_lot (alc, filename, &status, TRUE, FALSE);
 
 	if (!image){
 		if (status == MONO_IMAGE_IMAGE_INVALID)

--- a/mono/metadata/image-internals.h
+++ b/mono/metadata/image-internals.h
@@ -12,9 +12,6 @@
 MonoImage*
 mono_image_loaded_internal (MonoAssemblyLoadContext *alc, const char *name, mono_bool refonly);
 
-MonoImage *
-mono_find_image_owner (void *ptr);
-
 MonoImage*
 mono_image_load_file_for_image_checked (MonoImage *image, int fileidx, MonoError *error);
 

--- a/mono/metadata/image-internals.h
+++ b/mono/metadata/image-internals.h
@@ -7,9 +7,10 @@
 #define __MONO_METADATA_IMAGE_INTERNALS_H__
 
 #include <mono/metadata/image.h>
+#include <mono/metadata/loader-internals.h>
 
 MonoImage*
-mono_image_loaded_internal (const char *name, mono_bool refonly);
+mono_image_loaded_internal (MonoAssemblyLoadContext *alc, const char *name, mono_bool refonly);
 
 MonoImage *
 mono_find_image_owner (void *ptr);

--- a/mono/metadata/image-internals.h
+++ b/mono/metadata/image-internals.h
@@ -22,7 +22,7 @@ MonoImage*
 mono_image_load_module_checked (MonoImage *image, int idx, MonoError *error);
 
 MonoImage *
-mono_image_open_a_lot (const char *fname, MonoImageOpenStatus *status, gboolean refonly, gboolean load_from_context);
+mono_image_open_a_lot (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status, gboolean refonly, gboolean load_from_context);
 
 gboolean
 mono_is_problematic_image (MonoImage *image);

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1898,7 +1898,7 @@ mono_image_storage_open_from_module_handle (HMODULE module_handle, const char *f
 
 /* fname is not duplicated. */
 MonoImage*
-mono_image_open_from_module_handle (HMODULE module_handle, char* fname, gboolean has_entry_point, MonoImageOpenStatus* status)
+mono_image_open_from_module_handle (MonoAssemblyLoadContext *alc, HMODULE module_handle, char* fname, gboolean has_entry_point, MonoImageOpenStatus* status)
 {
 	MonoImage* image;
 	MonoCLIImageInfo* iinfo;
@@ -1916,7 +1916,7 @@ mono_image_open_from_module_handle (HMODULE module_handle, char* fname, gboolean
 	if (image == NULL)
 		return NULL;
 
-	return register_image (get_global_loaded_images (), image, NULL);
+	return register_image (mono_alc_get_loaded_images (alc), image, NULL);
 }
 #endif
 

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1787,7 +1787,7 @@ register_image (MonoLoadedImages *li, MonoImage *image, gboolean *problematic)
 }
 
 MonoImage *
-mono_image_open_from_data_internal (char *data, guint32 data_len, gboolean need_copy, MonoImageOpenStatus *status, gboolean refonly, gboolean metadata_only, const char *name)
+mono_image_open_from_data_internal (MonoAssemblyLoadContext *alc, char *data, guint32 data_len, gboolean need_copy, MonoImageOpenStatus *status, gboolean refonly, gboolean metadata_only, const char *name)
 {
 	MonoCLIImageInfo *iinfo;
 	MonoImage *image;
@@ -1824,7 +1824,7 @@ mono_image_open_from_data_internal (char *data, guint32 data_len, gboolean need_
 	if (image == NULL)
 		return NULL;
 
-	return register_image (get_global_loaded_images (), image, NULL);
+	return register_image (mono_alc_get_loaded_images (alc), image, NULL);
 }
 
 /**
@@ -1835,7 +1835,8 @@ mono_image_open_from_data_with_name (char *data, guint32 data_len, gboolean need
 {
 	MonoImage *result;
 	MONO_ENTER_GC_UNSAFE;
-	result = mono_image_open_from_data_internal (data, data_len, need_copy, status, refonly, FALSE, name);
+	MonoDomain *domain = mono_domain_get ();
+	result = mono_image_open_from_data_internal (mono_domain_default_alc (domain), data, data_len, need_copy, status, refonly, FALSE, name);
 	MONO_EXIT_GC_UNSAFE;
 	return result;
 }
@@ -1848,7 +1849,8 @@ mono_image_open_from_data_full (char *data, guint32 data_len, gboolean need_copy
 {
 	MonoImage *result;
 	MONO_ENTER_GC_UNSAFE;
-	result = mono_image_open_from_data_internal (data, data_len, need_copy, status, refonly, FALSE, NULL);
+	MonoDomain *domain = mono_domain_get ();
+	result = mono_image_open_from_data_internal (mono_domain_default_alc (domain), data, data_len, need_copy, status, refonly, FALSE, NULL);
 	MONO_EXIT_GC_UNSAFE;
 	return result;
 }
@@ -1861,7 +1863,8 @@ mono_image_open_from_data (char *data, guint32 data_len, gboolean need_copy, Mon
 {
 	MonoImage *result;
 	MONO_ENTER_GC_UNSAFE;
-	result = mono_image_open_from_data_internal (data, data_len, need_copy, status, FALSE, FALSE, NULL);
+	MonoDomain *domain = mono_domain_get ();
+	result = mono_image_open_from_data_internal (mono_domain_default_alc (domain), data, data_len, need_copy, status, FALSE, FALSE, NULL);
 	MONO_EXIT_GC_UNSAFE;
 	return result;
 }

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -2163,7 +2163,7 @@ mono_pe_file_open (const char *fname, MonoImageOpenStatus *status)
  * Use mono_image_load_pe_data and mono_image_load_cli_data to load them.  
  */
 MonoImage *
-mono_image_open_raw (const char *fname, MonoImageOpenStatus *status)
+mono_image_open_raw (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status)
 {
 	g_return_val_if_fail (fname != NULL, NULL);
 	
@@ -2176,7 +2176,7 @@ mono_image_open_raw (const char *fname, MonoImageOpenStatus *status)
  *   Open an image which contains metadata only without a PE header.
  */
 MonoImage *
-mono_image_open_metadata_only (const char *fname, MonoImageOpenStatus *status)
+mono_image_open_metadata_only (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status)
 {
 	return do_mono_image_open (fname, status, TRUE, TRUE, FALSE, TRUE, FALSE);
 }

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1727,6 +1727,9 @@ mono_image_loaded_by_guid_internal (const char *guid, gboolean refonly);
 
 /**
  * mono_image_loaded_by_guid_full:
+ *
+ * Looks only in the global loaded images hash, will miss assemblies loaded
+ * into an AssemblyLoadContext.
  */
 MonoImage *
 mono_image_loaded_by_guid_full (const char *guid, gboolean refonly)
@@ -1761,6 +1764,9 @@ mono_image_loaded_by_guid_internal (const char *guid, gboolean refonly)
 
 /**
  * mono_image_loaded_by_guid:
+ *
+ * Looks only in the global loaded images hash, will miss assemblies loaded
+ * into an AssemblyLoadContext.
  */
 MonoImage *
 mono_image_loaded_by_guid (const char *guid)

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -3360,6 +3360,23 @@ loaded_images_remove_image (MonoImage *image)
 		g_hash_table_remove (loaded_images_by_name, (char *) image->assembly_name);
 }
 
+#ifdef ENABLE_NETCORE
+void
+mono_alc_init (MonoAssemblyLoadContext *alc, MonoDomain *domain, gboolean default_alc)
+{
+	MonoLoadedImages *li = g_new0 (MonoLoadedImages, 1);
+	mono_loaded_images_init (li, MONO_LOADED_IMAGES_ALC, alc);
+	alc->domain = domain;
+	alc->loaded_images = li;
+}
+
+void
+mono_alc_cleanup (MonoAssemblyLoadContext *alc)
+{
+	mono_loaded_images_free (alc->loaded_images);
+}
+#endif /* ENABLE_NETCORE */
+
 MonoLoadedImages *
 mono_alc_get_loaded_images (MonoAssemblyLoadContext *alc)
 {

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1926,7 +1926,9 @@ mono_image_open_from_module_handle (MonoAssemblyLoadContext *alc, HMODULE module
 MonoImage *
 mono_image_open_full (const char *fname, MonoImageOpenStatus *status, gboolean refonly)
 {
-	return mono_image_open_a_lot (fname, status, refonly, FALSE);
+	/* FIXME: runtime callers of mono_image_open_full should use mono_image_open_a_lot and pass an ALC */
+	MonoAssemblyLoadContext *alc = mono_domain_default_alc (mono_domain_get ());
+	return mono_image_open_a_lot (alc, fname, status, refonly, FALSE);
 }
 
 static MonoImage *
@@ -2070,9 +2072,9 @@ mono_image_open_a_lot_parameterized (MonoLoadedImages *li, const char *fname, Mo
 }
 
 MonoImage *
-mono_image_open_a_lot (const char *fname, MonoImageOpenStatus *status, gboolean refonly, gboolean load_from_context)
+mono_image_open_a_lot (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status, gboolean refonly, gboolean load_from_context)
 {
-	MonoLoadedImages *li = get_global_loaded_images ();
+	MonoLoadedImages *li = mono_alc_get_loaded_images (alc);
 	return mono_image_open_a_lot_parameterized (li, fname, status, refonly, load_from_context, NULL);
 }
 

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1736,11 +1736,26 @@ find_by_guid (gpointer key, gpointer val, gpointer user_data)
 		data->res = image;
 }
 
+static MonoImage *
+mono_image_loaded_by_guid_internal (const char *guid, gboolean refonly);
+
 /**
  * mono_image_loaded_by_guid_full:
  */
 MonoImage *
 mono_image_loaded_by_guid_full (const char *guid, gboolean refonly)
+{
+	return mono_image_loaded_by_guid_internal (guid, refonly);
+}
+
+/**
+ * mono_image_loaded_by_guid_internal:
+ *
+ * Do not use.  Looks only in the global loaded images hash, will miss Assembly
+ * Load Contexts.
+ */
+static MonoImage *
+mono_image_loaded_by_guid_internal (const char *guid, gboolean refonly)
 {
 	GuidData data;
 	GHashTable *loaded_images = get_loaded_images_hash (get_global_loaded_images (), refonly);
@@ -1759,7 +1774,7 @@ mono_image_loaded_by_guid_full (const char *guid, gboolean refonly)
 MonoImage *
 mono_image_loaded_by_guid (const char *guid)
 {
-	return mono_image_loaded_by_guid_full (guid, FALSE);
+	return mono_image_loaded_by_guid_internal (guid, FALSE);
 }
 
 static MonoImage *

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -1752,10 +1752,10 @@ mono_image_loaded_by_guid (const char *guid)
 }
 
 static MonoImage *
-register_image (MonoImage *image, gboolean *problematic)
+register_image (MonoLoadedImages *li, MonoImage *image, gboolean *problematic)
 {
 	MonoImage *image2;
-	GHashTable *loaded_images = get_loaded_images_hash (get_global_loaded_images (), image->ref_only);
+	GHashTable *loaded_images = get_loaded_images_hash (li, image->ref_only);
 
 	mono_images_lock ();
 	image2 = (MonoImage *)g_hash_table_lookup (loaded_images, image->name);
@@ -1768,7 +1768,7 @@ register_image (MonoImage *image, gboolean *problematic)
 		return image2;
 	}
 
-	GHashTable *loaded_images_by_name = get_loaded_images_by_name_hash (get_global_loaded_images (), image->ref_only);
+	GHashTable *loaded_images_by_name = get_loaded_images_by_name_hash (li, image->ref_only);
 	g_hash_table_insert (loaded_images, image->name, image);
 	if (image->assembly_name && (g_hash_table_lookup (loaded_images_by_name, image->assembly_name) == NULL))
 		g_hash_table_insert (loaded_images_by_name, (char *) image->assembly_name, image);
@@ -1820,7 +1820,7 @@ mono_image_open_from_data_internal (char *data, guint32 data_len, gboolean need_
 	if (image == NULL)
 		return NULL;
 
-	return register_image (image, NULL);
+	return register_image (get_global_loaded_images (), image, NULL);
 }
 
 /**
@@ -1909,7 +1909,7 @@ mono_image_open_from_module_handle (HMODULE module_handle, char* fname, gboolean
 	if (image == NULL)
 		return NULL;
 
-	return register_image (image, NULL);
+	return register_image (get_global_loaded_images (), image, NULL);
 }
 #endif
 
@@ -2059,7 +2059,7 @@ mono_image_open_a_lot_parameterized (const char *fname, MonoImageOpenStatus *sta
 	if (image == NULL)
 		return NULL;
 
-	return register_image (image, problematic);
+	return register_image (get_global_loaded_images (), image, problematic);
 }
 
 MonoImage *

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -3300,14 +3300,11 @@ mono_loaded_images_free (MonoLoadedImages *li)
 static MonoLoadedImages *
 loaded_images_get_owner (MonoImage *image)
 {
-#ifndef ENABLE_NETCORE
-	return get_global_loaded_images ();
-#else
 	/* image->alc could be NULL if we're closing an image that wasn't
 	 * registered yet (for example if two threads raced to open it and one
 	 * of them lost) */
-	return (image->alc && image->alc->loaded_images) ? image->alc->loaded_images : get_global_loaded_images ();
-#endif /* ENABLE_NETCORE */
+	MonoAssemblyLoadContext *alc = mono_image_get_alc (image);
+	return mono_alc_get_loaded_images (alc);
 }
 
 /* LOCKING: assumes the images lock is locked */

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -3328,3 +3328,13 @@ loaded_images_remove_image (MonoImage *image)
 	if (image->assembly_name && (g_hash_table_lookup (loaded_images_by_name, image->assembly_name) == image))
 		g_hash_table_remove (loaded_images_by_name, (char *) image->assembly_name);
 }
+
+MonoLoadedImages *
+mono_alc_get_loaded_images (MonoAssemblyLoadContext *alc)
+{
+#ifdef ENABLE_NETCORE
+	return (alc && alc->loaded_images) ? alc->loaded_images : get_global_loaded_images ();
+#else
+	return get_global_loaded_images ();
+#endif
+}

--- a/mono/metadata/image.c
+++ b/mono/metadata/image.c
@@ -2336,20 +2336,9 @@ mono_image_close_except_pools (MonoImage *image)
 
 	g_return_val_if_fail (image != NULL, FALSE);
 
-	/*
-	 * Atomically decrement the refcount and remove ourselves from the hash tables, so
-	 * register_image () can't grab an image which is being closed.
-	 */
-	mono_images_lock ();
 
-	if (mono_atomic_dec_i32 (&image->ref_count) > 0) {
-		mono_images_unlock ();
+	if (!mono_loaded_images_remove_image (image))
 		return FALSE;
-	}
-
-	mono_loaded_images_remove_image (image);
-
-	mono_images_unlock ();
 
 #ifdef HOST_WIN32
 	if (m_image_is_module_handle (image) && m_image_has_entry_point (image)) {

--- a/mono/metadata/image.h
+++ b/mono/metadata/image.h
@@ -28,7 +28,8 @@ MONO_API void          mono_images_cleanup (void);
 
 MONO_API MonoImage    *mono_image_open     (const char *fname,
 				   MonoImageOpenStatus *status);
-MONO_API MonoImage    *mono_image_open_full (const char *fname,
+MONO_API MONO_RT_EXTERNAL_ONLY
+MonoImage             *mono_image_open_full (const char *fname,
 				   MonoImageOpenStatus *status, mono_bool refonly);
 MONO_API MonoImage    *mono_pe_file_open     (const char *fname,
 				     MonoImageOpenStatus *status);

--- a/mono/metadata/image.h
+++ b/mono/metadata/image.h
@@ -31,7 +31,8 @@ MONO_API MonoImage    *mono_image_open     (const char *fname,
 MONO_API MONO_RT_EXTERNAL_ONLY
 MonoImage             *mono_image_open_full (const char *fname,
 				   MonoImageOpenStatus *status, mono_bool refonly);
-MONO_API MonoImage    *mono_pe_file_open     (const char *fname,
+MONO_API MONO_RT_EXTERNAL_ONLY
+MonoImage             *mono_pe_file_open     (const char *fname,
 				     MonoImageOpenStatus *status);
 MONO_API MONO_RT_EXTERNAL_ONLY
 MonoImage    *mono_image_open_from_data (char *data, uint32_t data_len, mono_bool need_copy,

--- a/mono/metadata/image.h
+++ b/mono/metadata/image.h
@@ -47,8 +47,10 @@ MONO_API MONO_RT_EXTERNAL_ONLY
 MonoImage             *mono_image_loaded   (const char *name);
 MONO_API MONO_RT_EXTERNAL_ONLY
 MonoImage             *mono_image_loaded_full   (const char *name, mono_bool refonly);
-MONO_API MonoImage    *mono_image_loaded_by_guid (const char *guid);
-MONO_API MonoImage    *mono_image_loaded_by_guid_full (const char *guid, mono_bool refonly);
+MONO_API MONO_RT_EXTERNAL_ONLY
+MonoImage             *mono_image_loaded_by_guid (const char *guid);
+MONO_API MONO_RT_EXTERNAL_ONLY
+MonoImage             *mono_image_loaded_by_guid_full (const char *guid, mono_bool refonly);
 MONO_API void          mono_image_init     (MonoImage *image);
 MONO_API void          mono_image_close    (MonoImage *image);
 MONO_API void          mono_image_addref   (MonoImage *image);

--- a/mono/metadata/loaded-images-global.c
+++ b/mono/metadata/loaded-images-global.c
@@ -1,0 +1,65 @@
+#include <config.h>
+
+#include "mono/metadata/loaded-images-internals.h"
+#include "mono/metadata/metadata-internals.h"
+
+#ifndef ENABLE_NETCORE
+/* Global image hashes should not be in netcore Mono */
+
+static MonoLoadedImages global_loaded_images; /* zero initalized is good enough */
+
+MonoLoadedImages*
+mono_get_global_loaded_images (void)
+{
+	return &global_loaded_images;
+}
+
+// This is support for the mempool reference tracking feature in checked-build,
+// but lives in loaded-images-global.c due to use of static variables of this
+// file.
+
+/**
+ * mono_find_image_owner:
+ *
+ * Find the image, if any, which a given pointer is located in the memory of.
+ */
+MonoImage *
+mono_find_image_owner (void *ptr)
+{
+	MonoLoadedImages *li = mono_get_global_loaded_images ();
+	mono_images_lock ();
+
+	MonoImage *owner = NULL;
+
+	// Iterate over both by-path image hashes
+	const int hash_candidates[] = {MONO_LOADED_IMAGES_HASH_PATH, MONO_LOADED_IMAGES_HASH_PATH_REFONLY};
+	int hash_idx;
+	for (hash_idx = 0; !owner && hash_idx < G_N_ELEMENTS (hash_candidates); hash_idx++)
+	{
+		GHashTable *target = li->loaded_images_hashes [hash_candidates [hash_idx]];
+		GHashTableIter iter;
+		MonoImage *image;
+
+		// Iterate over images within a hash
+		g_hash_table_iter_init (&iter, target);
+		while (!owner && g_hash_table_iter_next(&iter, NULL, (gpointer *)&image))
+		{
+			mono_image_lock (image);
+			if (mono_mempool_contains_addr (image->mempool, ptr))
+				owner = image;
+			mono_image_unlock (image);
+		}
+	}
+
+	mono_images_unlock ();
+
+	return owner;
+}
+
+MonoLoadedImages *
+mono_alc_get_loaded_images (MonoAssemblyLoadContext *alc)
+{
+	return mono_get_global_loaded_images ();
+}
+
+#endif /* ENABLE_NETCORE */

--- a/mono/metadata/loaded-images-internals.h
+++ b/mono/metadata/loaded-images-internals.h
@@ -1,0 +1,67 @@
+/**
+* \file
+*/
+
+#ifndef _MONO_METADATA_IMAGE_HASHES_H_
+#define _MONO_METADATA_IMAGE_HASHES_H_
+
+#include <glib.h>
+#include <mono/metadata/object-forward.h>
+#include <mono/metadata/loader-internals.h>
+#include <mono/utils/mono-forward.h>
+#include <mono/utils/mono-error.h>
+
+/*
+ * The "loaded images" hashes keep track of the various assemblies and netmodules loaded
+ * There are four, for all combinations of [look up by path or assembly name?]
+ * and [normal or reflection-only load?, as in Assembly.ReflectionOnlyLoad]
+ */
+enum {
+	MONO_LOADED_IMAGES_HASH_PATH = 0,
+	MONO_LOADED_IMAGES_HASH_PATH_REFONLY = 1,
+	MONO_LOADED_IMAGES_HASH_NAME = 2,
+	MONO_LOADED_IMAGES_HASH_NAME_REFONLY = 3,
+	MONO_LOADED_IMAGES_HASH_COUNT = 4
+};
+
+struct _MonoLoadedImages {
+	MonoAssemblyLoadContext *owner; /* NULL if global */
+	GHashTable *loaded_images_hashes [MONO_LOADED_IMAGES_HASH_COUNT];
+};
+
+void
+mono_loaded_images_init (MonoLoadedImages *li, MonoAssemblyLoadContext *owner);
+
+void
+mono_loaded_images_cleanup (MonoLoadedImages *li, gboolean shutdown);
+
+void
+mono_loaded_images_free (MonoLoadedImages *li);
+
+GHashTable *
+mono_loaded_images_get_hash (MonoLoadedImages *li, gboolean refonly);
+
+GHashTable *
+mono_loaded_images_get_by_name_hash (MonoLoadedImages *li, gboolean refonly);
+
+void
+mono_loaded_images_remove_image (MonoImage *image);
+
+MonoLoadedImages*
+mono_image_get_loaded_images_for_modules (MonoImage *image);
+
+#ifndef ENABLE_NETCORE
+MonoLoadedImages*
+mono_get_global_loaded_images (void);
+#endif
+
+MonoImage *
+mono_find_image_owner (void *ptr);
+
+void
+mono_images_lock (void);
+
+void
+mono_images_unlock (void);
+
+#endif

--- a/mono/metadata/loaded-images-internals.h
+++ b/mono/metadata/loaded-images-internals.h
@@ -44,7 +44,7 @@ mono_loaded_images_get_hash (MonoLoadedImages *li, gboolean refonly);
 GHashTable *
 mono_loaded_images_get_by_name_hash (MonoLoadedImages *li, gboolean refonly);
 
-void
+gboolean
 mono_loaded_images_remove_image (MonoImage *image);
 
 MonoLoadedImages*

--- a/mono/metadata/loaded-images-netcore.c
+++ b/mono/metadata/loaded-images-netcore.c
@@ -1,0 +1,34 @@
+#include "config.h"
+
+#include "mono/metadata/loaded-images-internals.h"
+
+#ifdef ENABLE_NETCORE
+/* Should be compiling loaded-images-netcore.c only for netcore Mono */
+
+// This is support for the mempool reference tracking feature in checked-build,
+// but lives in loaded-images-netcore.c due to use of static variables of this
+// file.
+
+/**
+ * mono_find_image_owner:
+ *
+ * Find the image, if any, which a given pointer is located in the memory of.
+ */
+MonoImage *
+mono_find_image_owner (void *ptr)
+{
+	/* FIXME: this function is a bit annoying to implement without a global
+	 * table of all the loaded images.  We need to traverse all the domains
+	 * and each ALC in each domain. */
+	return NULL;
+}
+
+MonoLoadedImages *
+mono_alc_get_loaded_images (MonoAssemblyLoadContext *alc)
+{
+	g_assert (alc);
+	g_assert (alc->loaded_images);
+	return alc->loaded_images;
+}
+
+#endif /* ENABLE_NETCORE */

--- a/mono/metadata/loaded-images.c
+++ b/mono/metadata/loaded-images.c
@@ -8,7 +8,7 @@ void
 mono_loaded_images_init (MonoLoadedImages *li, MonoAssemblyLoadContext *owner)
 {
 	li->owner = owner;
-	for(int hash_idx = 0; hash_idx < MONO_LOADED_IMAGES_HASH_COUNT; hash_idx++)
+	for (int hash_idx = 0; hash_idx < MONO_LOADED_IMAGES_HASH_COUNT; hash_idx++)
 		li->loaded_images_hashes [hash_idx] = g_hash_table_new (g_str_hash, g_str_equal);
 }
 
@@ -26,7 +26,7 @@ mono_loaded_images_cleanup (MonoLoadedImages *li, gboolean shutdown)
 			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Assembly image '%s' [%p] still loaded at shutdown.", image->name, image);
 	}
 
-	for(int hash_idx = 0; hash_idx < MONO_LOADED_IMAGES_HASH_COUNT; hash_idx++) {
+	for (int hash_idx = 0; hash_idx < MONO_LOADED_IMAGES_HASH_COUNT; hash_idx++) {
 		g_hash_table_destroy (li->loaded_images_hashes [hash_idx]);
 		li->loaded_images_hashes [hash_idx] = NULL;
 	}

--- a/mono/metadata/loaded-images.c
+++ b/mono/metadata/loaded-images.c
@@ -1,0 +1,101 @@
+#include "config.h"
+
+#include "mono/metadata/loaded-images-internals.h"
+#include "mono/metadata/metadata-internals.h"
+#include "mono/utils/mono-logger-internals.h"
+
+void
+mono_loaded_images_init (MonoLoadedImages *li, MonoAssemblyLoadContext *owner)
+{
+	li->owner = owner;
+	for(int hash_idx = 0; hash_idx < MONO_LOADED_IMAGES_HASH_COUNT; hash_idx++)
+		li->loaded_images_hashes [hash_idx] = g_hash_table_new (g_str_hash, g_str_equal);
+}
+
+void
+mono_loaded_images_cleanup (MonoLoadedImages *li, gboolean shutdown)
+{
+	if (shutdown) {
+		GHashTableIter iter;
+		MonoImage *image;
+
+		// If an assembly image is still loaded at shutdown, this could indicate managed code is still running.
+		// Reflection-only images being still loaded doesn't indicate anything as harmful, so we don't check for it.
+		g_hash_table_iter_init (&iter, mono_loaded_images_get_hash (li, FALSE));
+		while (g_hash_table_iter_next (&iter, NULL, (void**)&image))
+			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_ASSEMBLY, "Assembly image '%s' [%p] still loaded at shutdown.", image->name, image);
+	}
+
+	for(int hash_idx = 0; hash_idx < MONO_LOADED_IMAGES_HASH_COUNT; hash_idx++) {
+		g_hash_table_destroy (li->loaded_images_hashes [hash_idx]);
+		li->loaded_images_hashes [hash_idx] = NULL;
+	}
+}
+
+void
+mono_loaded_images_free (MonoLoadedImages *li)
+{
+	mono_loaded_images_cleanup (li, FALSE);
+	g_free (li);
+}
+
+GHashTable *
+mono_loaded_images_get_hash (MonoLoadedImages *li, gboolean refonly)
+{
+	g_assert (li != NULL);
+	GHashTable **loaded_images_hashes = &li->loaded_images_hashes[0];
+	int idx = refonly ? MONO_LOADED_IMAGES_HASH_PATH_REFONLY : MONO_LOADED_IMAGES_HASH_PATH;
+	return loaded_images_hashes [idx];
+}
+
+GHashTable *
+mono_loaded_images_get_by_name_hash (MonoLoadedImages *li, gboolean refonly)
+{
+	g_assert (li != NULL);
+	GHashTable **loaded_images_hashes = &li->loaded_images_hashes[0];
+	int idx = refonly ? MONO_LOADED_IMAGES_HASH_NAME_REFONLY : MONO_LOADED_IMAGES_HASH_NAME;
+	return loaded_images_hashes [idx];
+}
+
+static MonoLoadedImages *
+loaded_images_get_owner (MonoImage *image)
+{
+	/* image->alc could be NULL if we're closing an image that wasn't
+	 * registered yet (for example if two threads raced to open it and one
+	 * of them lost) */
+	MonoAssemblyLoadContext *alc = mono_image_get_alc (image);
+	return mono_alc_get_loaded_images (alc);
+}
+
+/* LOCKING: assumes the images lock is locked */
+void
+mono_loaded_images_remove_image (MonoImage *image)
+{
+	MonoLoadedImages *li = loaded_images_get_owner (image);
+	if (!li) {
+		/* we weren't registered; maybe lost to another image */
+		return;
+	}
+	GHashTable *loaded_images, *loaded_images_by_name;
+	MonoImage *image2;
+
+	loaded_images         = mono_loaded_images_get_hash (li, image->ref_only);
+	loaded_images_by_name = mono_loaded_images_get_by_name_hash (li, image->ref_only);
+	image2 = (MonoImage *)g_hash_table_lookup (loaded_images, image->name);
+	if (image == image2) {
+		/* This is not true if we are called from mono_image_open () */
+		g_hash_table_remove (loaded_images, image->name);
+	}
+	if (image->assembly_name && (g_hash_table_lookup (loaded_images_by_name, image->assembly_name) == image))
+		g_hash_table_remove (loaded_images_by_name, (char *) image->assembly_name);
+}
+
+MonoLoadedImages*
+mono_image_get_loaded_images_for_modules (MonoImage *image)
+{
+#ifndef ENABLE_NETCORE
+	return mono_get_global_loaded_images ();
+#else
+	g_assert_not_reached ();
+#endif
+}

--- a/mono/metadata/loader-internals.h
+++ b/mono/metadata/loader-internals.h
@@ -59,6 +59,14 @@ void
 mono_loaded_images_free (MonoLoadedImages *li);
 
 #ifdef ENABLE_NETCORE
+void
+mono_alc_init (MonoAssemblyLoadContext *alc, MonoDomain *domain, gboolean default_alc);
+
+void
+mono_alc_cleanup (MonoAssemblyLoadContext *alc);
+#endif /* ENABLE_NETCORE */
+
+#ifdef ENABLE_NETCORE
 static inline MonoDomain *
 mono_alc_domain (MonoAssemblyLoadContext *alc)
 {

--- a/mono/metadata/loader-internals.h
+++ b/mono/metadata/loader-internals.h
@@ -35,7 +35,7 @@ mono_set_pinvoke_search_directories (int dir_count, char **dirs);
 
 #ifdef ENABLE_NETCORE
 void
-mono_alc_init (MonoAssemblyLoadContext *alc, MonoDomain *domain, gboolean default_alc);
+mono_alc_init (MonoAssemblyLoadContext *alc, MonoDomain *domain);
 
 void
 mono_alc_cleanup (MonoAssemblyLoadContext *alc);

--- a/mono/metadata/loader-internals.h
+++ b/mono/metadata/loader-internals.h
@@ -33,7 +33,7 @@ enum {
 struct _MonoLoadedImages {
 	union {
 		MonoAssemblyLoadContext *alc; /* NULL if global */
-		MonoAssembly *assembly; /* for netmodules */
+		MonoImage *assembly_image; /* for netmodules and SRE dynamic images */
 	} owner;
 	guint8 owner_kind;
 	GHashTable *loaded_images_hashes [4];

--- a/mono/metadata/loader-internals.h
+++ b/mono/metadata/loader-internals.h
@@ -66,4 +66,7 @@ mono_alc_domain (MonoAssemblyLoadContext *alc)
 }
 #endif /* ENABLE_NETCORE */
 
+MonoLoadedImages *
+mono_alc_get_loaded_images (MonoAssemblyLoadContext *alc);
+
 #endif

--- a/mono/metadata/loader-internals.h
+++ b/mono/metadata/loader-internals.h
@@ -25,13 +25,6 @@ struct _MonoAssemblyLoadContext {
 };
 #endif /* ENABLE_NETCORE */
 
-struct _MonoLoadedImages {
-	MonoAssemblyLoadContext *owner; /* NULL if global */
-	GHashTable *loaded_images_hashes [4];
-};
-
-
-
 gpointer
 mono_lookup_pinvoke_call_internal (MonoMethod *method, MonoError *error);
 
@@ -40,24 +33,13 @@ void
 mono_set_pinvoke_search_directories (int dir_count, char **dirs);
 #endif
 
-void
-mono_loaded_images_init (MonoLoadedImages *li, MonoAssemblyLoadContext *owner);
-
-void
-mono_loaded_images_cleanup (MonoLoadedImages *li, gboolean shutdown);
-
-void
-mono_loaded_images_free (MonoLoadedImages *li);
-
 #ifdef ENABLE_NETCORE
 void
 mono_alc_init (MonoAssemblyLoadContext *alc, MonoDomain *domain, gboolean default_alc);
 
 void
 mono_alc_cleanup (MonoAssemblyLoadContext *alc);
-#endif /* ENABLE_NETCORE */
 
-#ifdef ENABLE_NETCORE
 static inline MonoDomain *
 mono_alc_domain (MonoAssemblyLoadContext *alc)
 {

--- a/mono/metadata/loader-internals.h
+++ b/mono/metadata/loader-internals.h
@@ -7,7 +7,39 @@
 
 #include <glib.h>
 #include <mono/metadata/object-forward.h>
+#include <mono/utils/mono-forward.h>
 #include <mono/utils/mono-error.h>
+
+typedef struct _MonoLoadedImages MonoLoadedImages;
+typedef struct _MonoAssemblyLoadContext MonoAssemblyLoadContext;
+
+#ifdef ENABLE_NETCORE
+/* FIXME: this probably belongs somewhere else */
+struct _MonoAssemblyLoadContext {
+	MonoDomain *domain;
+	MonoLoadedImages *loaded_images;
+#if 0
+	GSList *loaded_assemblies;
+	MonoCoopMutex assemblies_lock;
+#endif
+};
+#endif /* ENABLE_NETCORE */
+
+enum {
+	MONO_LOADED_IMAGES_ALC = 0,  /* For assemblies */
+	MONO_LOADED_IMAGES_ASSEMBLY = 1, /* for files & netmodules */
+};
+
+struct _MonoLoadedImages {
+	union {
+		MonoAssemblyLoadContext *alc; /* NULL if global */
+		MonoAssembly *assembly; /* for netmodules */
+	} owner;
+	guint8 owner_kind;
+	GHashTable *loaded_images_hashes [4];
+};
+
+
 
 gpointer
 mono_lookup_pinvoke_call_internal (MonoMethod *method, MonoError *error);
@@ -16,5 +48,22 @@ mono_lookup_pinvoke_call_internal (MonoMethod *method, MonoError *error);
 void
 mono_set_pinvoke_search_directories (int dir_count, char **dirs);
 #endif
+
+void
+mono_loaded_images_init (MonoLoadedImages *li, guint8 owner_kind, gpointer owner);
+
+void
+mono_loaded_images_cleanup (MonoLoadedImages *li, gboolean shutdown);
+
+void
+mono_loaded_images_free (MonoLoadedImages *li);
+
+#ifdef ENABLE_NETCORE
+static inline MonoDomain *
+mono_alc_domain (MonoAssemblyLoadContext *alc)
+{
+	return alc->domain;
+}
+#endif /* ENABLE_NETCORE */
 
 #endif

--- a/mono/metadata/loader-internals.h
+++ b/mono/metadata/loader-internals.h
@@ -25,17 +25,8 @@ struct _MonoAssemblyLoadContext {
 };
 #endif /* ENABLE_NETCORE */
 
-enum {
-	MONO_LOADED_IMAGES_ALC = 0,  /* For assemblies */
-	MONO_LOADED_IMAGES_ASSEMBLY = 1, /* for files & netmodules */
-};
-
 struct _MonoLoadedImages {
-	union {
-		MonoAssemblyLoadContext *alc; /* NULL if global */
-		MonoImage *assembly_image; /* for netmodules and SRE dynamic images */
-	} owner;
-	guint8 owner_kind;
+	MonoAssemblyLoadContext *owner; /* NULL if global */
 	GHashTable *loaded_images_hashes [4];
 };
 
@@ -50,7 +41,7 @@ mono_set_pinvoke_search_directories (int dir_count, char **dirs);
 #endif
 
 void
-mono_loaded_images_init (MonoLoadedImages *li, guint8 owner_kind, gpointer owner);
+mono_loaded_images_init (MonoLoadedImages *li, MonoAssemblyLoadContext *owner);
 
 void
 mono_loaded_images_cleanup (MonoLoadedImages *li, gboolean shutdown);

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -438,6 +438,7 @@ struct _MonoImage {
 	MonoImage **modules;
 	guint32 module_count;
 	gboolean *modules_loaded;
+	MonoLoadedImages *modules_loaded_images;
 
 	MonoImage **files;
 	guint32 file_count;

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -1183,4 +1183,15 @@ m_image_has_entry_point (MonoImage *image)
 
 #endif
 
+static inline
+MonoAssemblyLoadContext *
+mono_image_get_alc (MonoImage *image)
+{
+#ifndef ENABLE_NETCORE
+	return NULL;
+#else
+	return image->alc;
+#endif
+}
+
 #endif /* __MONO_METADATA_INTERNALS_H__ */

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -435,12 +435,10 @@ struct _MonoImage {
 	 * table, where the module table is a subset of the file table. We track both lists,
 	 * and because we can lazy-load them at different times we reference-increment both.
 	 */
+	/* No netmodules in netcore, but for System.Reflection.Emit support we still use modules */
 	MonoImage **modules;
 	guint32 module_count;
 	gboolean *modules_loaded;
-#ifdef ENABLE_NETCORE
-	MonoLoadedImages *modules_loaded_images;
-#endif
 
 	MonoImage **files;
 	guint32 file_count;

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -1083,7 +1083,7 @@ MonoImage *mono_image_open_raw (const char *fname, MonoImageOpenStatus *status);
 
 MonoImage *mono_image_open_metadata_only (const char *fname, MonoImageOpenStatus *status);
 
-MonoImage *mono_image_open_from_data_internal (char *data, guint32 data_len, gboolean need_copy, MonoImageOpenStatus *status, gboolean refonly, gboolean metadata_only, const char *name);
+MonoImage *mono_image_open_from_data_internal (MonoAssemblyLoadContext *alc, char *data, guint32 data_len, gboolean need_copy, MonoImageOpenStatus *status, gboolean refonly, gboolean metadata_only, const char *name);
 
 MonoException *mono_get_exception_field_access_msg (const char *msg);
 

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -451,6 +451,13 @@ struct _MonoImage {
 	 */
 	MonoAssembly *assembly;
 
+#ifdef ENABLE_NETCORE
+	/*
+	 * The AssemblyLoadContext that this image was loaded into.
+	 */
+	MonoAssemblyLoadContext *alc;
+#endif
+
 	/*
 	 * Indexed by method tokens and typedef tokens.
 	 */

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -1079,9 +1079,9 @@ gboolean mono_image_load_cli_data (MonoImage *image);
 
 void mono_image_load_names (MonoImage *image);
 
-MonoImage *mono_image_open_raw (const char *fname, MonoImageOpenStatus *status);
+MonoImage *mono_image_open_raw (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status);
 
-MonoImage *mono_image_open_metadata_only (const char *fname, MonoImageOpenStatus *status);
+MonoImage *mono_image_open_metadata_only (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status);
 
 MonoImage *mono_image_open_from_data_internal (MonoAssemblyLoadContext *alc, char *data, guint32 data_len, gboolean need_copy, MonoImageOpenStatus *status, gboolean refonly, gboolean metadata_only, const char *name);
 

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -438,7 +438,9 @@ struct _MonoImage {
 	MonoImage **modules;
 	guint32 module_count;
 	gboolean *modules_loaded;
+#ifdef ENABLE_NETCORE
 	MonoLoadedImages *modules_loaded_images;
+#endif
 
 	MonoImage **files;
 	guint32 file_count;

--- a/mono/metadata/mono-security.c
+++ b/mono/metadata/mono-security.c
@@ -613,8 +613,9 @@ mono_invoke_protected_memory_method (MonoArrayHandle data, MonoObjectHandle scop
 	const char *method_name, MonoMethod **method, MonoError *error)
 {
 	if (!*method) {
+		MonoDomain *domain = mono_domain_get ();
 		if (system_security_assembly == NULL) {
-			system_security_assembly = mono_image_loaded_internal ("System.Security", FALSE);
+			system_security_assembly = mono_image_loaded_internal (mono_domain_default_alc (domain), "System.Security", FALSE);
 			if (!system_security_assembly) {
 				MonoAssemblyOpenRequest req;
 				mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT);

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -722,7 +722,7 @@ get_socket_assembly (void)
 	if (domain->socket_assembly == NULL) {
 		MonoImage *socket_assembly;
 
-		socket_assembly = mono_image_loaded_internal ("System", FALSE);
+		socket_assembly = mono_image_loaded_internal (mono_domain_default_alc (domain), "System", FALSE);
 		if (!socket_assembly) {
 			MonoAssemblyOpenRequest req;
 			mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT);
@@ -1849,7 +1849,7 @@ ves_icall_System_Net_Sockets_Socket_GetSocketOption_obj_internal (gsize sock, gi
 		static MonoImage *mono_posix_image = NULL;
 		
 		if (mono_posix_image == NULL) {
-			mono_posix_image = mono_image_loaded_internal ("Mono.Posix", FALSE);
+			mono_posix_image = mono_image_loaded_internal (mono_domain_default_alc (domain), "Mono.Posix", FALSE);
 			if (!mono_posix_image) {
 				MonoAssemblyOpenRequest req;
 				mono_assembly_request_prepare (&req.request, sizeof (req), MONO_ASMCTX_DEFAULT);

--- a/mono/mini/driver.c
+++ b/mono/mini/driver.c
@@ -2584,6 +2584,7 @@ mono_main (int argc, char* argv[])
 
 	MonoAssemblyOpenRequest open_req;
 	mono_assembly_request_prepare (&open_req.request, sizeof (open_req), MONO_ASMCTX_DEFAULT);
+	open_req.request.alc = mono_domain_default_alc (mono_get_root_domain ());
 	assembly = mono_assembly_request_open (aname, &open_req, &open_status);
 	if (!assembly && !mono_compile_aot) {
 		fprintf (stderr, "Cannot open assembly '%s': %s.\n", aname, mono_image_strerror (open_status));

--- a/mono/mini/main-core.c
+++ b/mono/mini/main-core.c
@@ -139,6 +139,7 @@ mono_core_preload_hook (MonoAssemblyName *aname, char **unused_apaths, void *use
 		if (!strcmp (basename, a->basenames[i])) {
 			MonoAssemblyOpenRequest req;
 			mono_assembly_request_prepare (&req.request, sizeof (req), refonly ? MONO_ASMCTX_REFONLY : MONO_ASMCTX_DEFAULT);
+			req.request.alc = mono_domain_default_alc (mono_get_root_domain ());
 			req.request.predicate = predicate;
 			req.request.predicate_ud = predicate_ud;
 

--- a/mono/native/mono-native-platform.c
+++ b/mono/native/mono-native-platform.c
@@ -2,7 +2,6 @@
 #include <glib.h>
 #include "mono/utils/mono-threads-api.h"
 #include "mono/utils/atomic.h"
-#include "mono/metadata/loader-internals.h"
 #include "mono/metadata/icall-internals.h"
 
 #include "mono-native-platform.h"

--- a/mono/native/pal-icalls.c
+++ b/mono/native/pal-icalls.c
@@ -12,7 +12,6 @@
 #include <glib.h>
 #include "mono/utils/mono-threads-api.h"
 #include "mono/utils/atomic.h"
-#include "mono/metadata/loader-internals.h"
 #include "mono/metadata/icall-internals.h"
 #include "pal-icalls.h"
 

--- a/mono/tests/metadata-verifier/gen-md-tests.c
+++ b/mono/tests/metadata-verifier/gen-md-tests.c
@@ -272,7 +272,7 @@ init_test_set (test_set_t *test_set)
 	if (test_set->init)
 		return;
 	test_set->assembly_data = read_whole_file_and_close (test_set->assembly, &test_set->assembly_size);
-	test_set->image = mono_image_open_from_data_internal (test_set->assembly_data, test_set->assembly_size, FALSE, &status, FALSE, FALSE, NULL);
+	test_set->image = mono_image_open_from_data_internal (mono_domain_default_alc (mono_root_domain_get ()), test_set->assembly_data, test_set->assembly_size, FALSE, &status, FALSE, FALSE, NULL);
 	if (!test_set->image || status != MONO_IMAGE_OK) {
 		printf ("Could not parse image %s\n", test_set->assembly);
 		exit (INVALID_BAD_FILE);

--- a/mono/utils/checked-build.c
+++ b/mono/utils/checked-build.c
@@ -19,6 +19,7 @@
 #include <mono/metadata/mempool.h>
 #include <mono/metadata/metadata-internals.h>
 #include <mono/metadata/image-internals.h>
+#include <mono/metadata/loaded-images-internals.h>
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/reflection-internals.h>
 #include <glib.h>

--- a/msvc/libmonoruntime-common.targets
+++ b/msvc/libmonoruntime-common.targets
@@ -6,6 +6,7 @@
   <ItemGroup Label="common_sources">
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\abi.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\appdomain.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\assembly-load-context.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\domain.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\appdomain-icalls.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\assembly.c" />
@@ -54,6 +55,10 @@
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\image-internals.h" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\jit-icall-reg.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\jit-info.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\loaded-images.c" />
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\loaded-images.h" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\loaded-images-global.c" />
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\loaded-images-netcore.c" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\loader.c" />
     <ClInclude Include="$(MonoSourceLocation)\mono\metadata\loader-internals.h" />
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\locales.c" />

--- a/msvc/libmonoruntime-common.targets.filters
+++ b/msvc/libmonoruntime-common.targets.filters
@@ -7,6 +7,9 @@
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\appdomain.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common</Filter>
     </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\assembly-load-context.c">
+      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common</Filter>
+    </ClCompile>
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\domain.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common</Filter>
     </ClCompile>
@@ -149,6 +152,18 @@
       <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common</Filter>
     </ClInclude>
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\jit-info.c">
+      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\loaded-images.c">
+      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common</Filter>
+    </ClCompile>
+    <ClInclude Include="$(MonoSourceLocation)\mono\metadata\loaded-images.h">
+      <Filter>Header Files$(MonoRuntimeFilterSubFolder)\common</Filter>
+    </ClInclude>
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\loaded-images-global.c">
+      <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MonoSourceLocation)\mono\metadata\loaded-images-netcore.c">
       <Filter>Source Files$(MonoRuntimeFilterSubFolder)\common</Filter>
     </ClCompile>
     <ClCompile Include="$(MonoSourceLocation)\mono\metadata\loader.c">

--- a/netcore/System.Private.CoreLib/src/System.Reflection/Assembly.cs
+++ b/netcore/System.Private.CoreLib/src/System.Reflection/Assembly.cs
@@ -74,8 +74,7 @@ namespace System.Reflection
 		internal static Assembly Load (AssemblyName assemblyRef, ref StackCrawlMark stackMark, AssemblyLoadContext assemblyLoadContext)
 		{
 			// TODO: pass AssemblyName
-			// TODO: pass assemblyLoadContext
-			var assembly = InternalLoad (assemblyRef.FullName, ref stackMark, IntPtr.Zero);
+			var assembly = InternalLoad (assemblyRef.FullName, ref stackMark, assemblyLoadContext != null ? assemblyLoadContext.NativeALC : IntPtr.Zero);
 			if (assembly == null)
 				throw new FileNotFoundException (null, assemblyRef.Name);
 			return assembly;

--- a/netcore/System.Private.CoreLib/src/System.Runtime.Loader/AssemblyLoadContext.cs
+++ b/netcore/System.Private.CoreLib/src/System.Runtime.Loader/AssemblyLoadContext.cs
@@ -11,6 +11,12 @@ namespace System.Runtime.Loader
 {
 	partial class AssemblyLoadContext
 	{
+		internal IntPtr NativeALC {
+			get {
+				return _nativeAssemblyLoadContext;
+			}
+		}
+
 		static IntPtr InitializeAssemblyLoadContext (IntPtr assemblyLoadContext, bool representsTPALoadContext, bool isCollectible)
 		{
 			return IntPtr.Zero;
@@ -32,7 +38,7 @@ namespace System.Runtime.Loader
 
 			assemblyPath = assemblyPath.Replace ('\\', Path.DirectorySeparatorChar);
 			// TODO: Handle nativeImagePath
-			return InternalLoadFile (assemblyPath, ref stackMark);
+			return InternalLoadFile (NativeALC, assemblyPath, ref stackMark);
 		}
 
 		internal Assembly InternalLoad (byte[] arrAssembly, byte[] arrSymbols)
@@ -59,7 +65,7 @@ namespace System.Runtime.Loader
 		}
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
-		extern static Assembly InternalLoadFile (string assemblyFile, ref StackCrawlMark stackMark);
+		extern static Assembly InternalLoadFile (IntPtr nativeAssemblyLoadContext, string assemblyFile, ref StackCrawlMark stackMark);
 
 		internal static Assembly DoAssemblyResolve (string name)
 		{

--- a/netcore/System.Private.CoreLib/src/System.Runtime.Loader/AssemblyLoadContext.cs
+++ b/netcore/System.Private.CoreLib/src/System.Runtime.Loader/AssemblyLoadContext.cs
@@ -17,9 +17,9 @@ namespace System.Runtime.Loader
 			}
 		}
 
-		static IntPtr InitializeAssemblyLoadContext (IntPtr assemblyLoadContext, bool representsTPALoadContext, bool isCollectible)
+		static IntPtr InitializeAssemblyLoadContext (IntPtr thisHandlePtr, bool representsTPALoadContext, bool isCollectible)
 		{
-			return IntPtr.Zero;
+			return InternalInitializeNativeALC (thisHandlePtr, representsTPALoadContext, isCollectible);
 		}
 
 		static void PrepareForAssemblyLoadContextRelease (IntPtr nativeAssemblyLoadContext, IntPtr assemblyLoadContextStrong)
@@ -66,6 +66,9 @@ namespace System.Runtime.Loader
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		extern static Assembly InternalLoadFile (IntPtr nativeAssemblyLoadContext, string assemblyFile, ref StackCrawlMark stackMark);
+
+		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		extern static IntPtr InternalInitializeNativeALC (IntPtr thisHandlePtr, bool representsTPALoadContext, bool isCollectible);
 
 		internal static Assembly DoAssemblyResolve (string name)
 		{

--- a/tools/pedump/pedump.c
+++ b/tools/pedump/pedump.c
@@ -432,7 +432,7 @@ verify_image_file (const char *fname)
 	int i, count = 0;
 
 	if (!strstr (fname, "mscorlib.dll")) {
-		image = mono_image_open_raw (fname, &status);
+		image = mono_image_open_raw (mono_domain_default_alc (mono_get_root_domain ()), fname, &status);
 		if (!image) {
 			printf ("Could not open %s\n", fname);
 			return 1;


### PR DESCRIPTION
Implement a couple of things:

1. Add a `MonoAssemblyLoadContext` opaque struct
2. On netcore Mono, use it to keep track of  which `MonoImage`s are loaded.  (Addresses part of #13891) 

In a bit more detail:

- Add a `MonoLoadedImages` struct to hold the hash tables that we use for checking if a `MonoImage` is already loaded
- Add an opaque `MonoAssemblyLoadContext` typedef
- (Framework Mono) Add a `get_global_loaded_images()` function to get the shared `MonoLoadedImages`
- (netcore Mono) Add a `MonoAssemblyLoadContext` struct that owns a `MonoLoadedImages` and add a `default_alc` member to `MonoDomain
- Pass a `MonoAssemblyLoadContext*` to most `MonoImage`-loading functions - on Framework Mono its usually NULL and we fall back to the global loaded images, on netcore Mono it's usually `domain->default_alc->loaded_images`
- (netcore Mono) Create a default Assembly Load Context when a `MonoDomain` is created
- Add a `MonoAssemblyLoadContext*` field to `MonoAssemblyLoadRequest` and pass an ALC in a few places.

---

Remaining work:

(netcore Mono) There are still places where a `MonoAssemblyLoadRequest` or a `MonoAssemblyOpenRequest` has a `NULL` ALC - those will need to be tracked down and fixed.

(netcore Mono) Eventually `MonoAssemblyLoadContext` should keep track of the loaded `MonoAssembly`s, not just images.  One goal on netcore Mono is to ifdef out `MonoDomain:domain_assemblies`.

