### PR TITLE
Don't clobber last error in mono_set_lmf

### DIFF
--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -757,7 +757,14 @@ mono_get_lmf (void)
 void
 mono_set_lmf (MonoLMF *lmf)
 {
+	/*
+	 * TLS access resets the last error. This is called from several places
+	 * in the interpreter and debugger where we need to preserve the value (eg.
+	 * to record it for P/Invoke calls).
+	 */
+	W32_DEFINE_LAST_ERROR_RESTORE_POINT;
 	(*mono_get_lmf_addr ()) = lmf;
+	W32_RESTORE_LAST_ERROR_FROM_RESTORE_POINT;
 }
 
 static void

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -757,6 +757,9 @@ mono_get_lmf (void)
 void
 mono_set_lmf (MonoLMF *lmf)
 {
+#ifdef MONO_KEYWORD_THREAD
+	(*mono_get_lmf_addr ()) = lmf;
+#else
 	/*
 	 * TLS access resets the last error. This is called from several places
 	 * in the interpreter and debugger where we need to preserve the value (eg.
@@ -765,6 +768,7 @@ mono_set_lmf (MonoLMF *lmf)
 	W32_DEFINE_LAST_ERROR_RESTORE_POINT;
 	(*mono_get_lmf_addr ()) = lmf;
 	W32_RESTORE_LAST_ERROR_FROM_RESTORE_POINT;
+#endif
 }
 
 static void


### PR DESCRIPTION
Still not sure about the best layer where to place it. I can sprinkle it around `interp_pop_lmf` calls in `interp.c` and hope for the best or put it on this one place.