### PR TITLE
Remove unused Windows JIT TLS code.

### DIFF
--- a/mono/mini/mini-amd64.c
+++ b/mono/mini/mini-amd64.c
@@ -3781,22 +3781,8 @@ static guint8*
 mono_amd64_emit_tls_get (guint8* code, int dreg, int tls_offset)
 {
 #ifdef TARGET_WIN32
-	if (tls_offset < 64) {
-		x86_prefix (code, X86_GS_PREFIX);
-		amd64_mov_reg_mem (code, dreg, (tls_offset * 8) + 0x1480, 8);
-	} else {
-		guint8 *buf [16];
-
-		g_assert (tls_offset < 0x440);
-		/* Load TEB->TlsExpansionSlots */
-		x86_prefix (code, X86_GS_PREFIX);
-		amd64_mov_reg_mem (code, dreg, 0x1780, 8);
-		amd64_test_reg_reg (code, dreg, dreg);
-		buf [0] = code;
-		amd64_branch (code, X86_CC_EQ, code, TRUE);
-		amd64_mov_reg_membase (code, dreg, dreg, (tls_offset * 8) - 0x200, 8);
-		amd64_patch (buf [0], code);
-	}
+	// FIXME generate code like __declspec (thread) when runtime uses __declspec (thread).
+	g_assert_not_reached ();
 #elif defined(TARGET_MACH)
 	x86_prefix (code, X86_GS_PREFIX);
 	amd64_mov_reg_mem (code, dreg, tls_gs_offset + (tls_offset * 8), 8);

--- a/mono/mini/mini-x86.c
+++ b/mono/mini/mini-x86.c
@@ -2204,26 +2204,8 @@ mono_x86_emit_tls_get (guint8* code, int dreg, int tls_offset)
 	x86_prefix (code, X86_GS_PREFIX);
 	x86_mov_reg_mem (code, dreg, tls_gs_offset + (tls_offset * 4), 4);
 #elif defined (TARGET_WIN32)
-	/*
-	 * See the Under the Hood article in the May 1996 issue of Microsoft Systems
-	 * Journal and/or a disassembly of the TlsGet () function.
-	 */
-	x86_prefix (code, X86_FS_PREFIX);
-	x86_mov_reg_mem (code, dreg, 0x18, 4);
-	if (tls_offset < 64) {
-		x86_mov_reg_membase (code, dreg, dreg, 3600 + (tls_offset * 4), 4);
-	} else {
-		guint8 *buf [16];
-
-		g_assert (tls_offset < 0x440);
-		/* Load TEB->TlsExpansionSlots */
-		x86_mov_reg_membase (code, dreg, dreg, 0xf94, 4);
-		x86_test_reg_reg (code, dreg, dreg);
-		buf [0] = code;
-		x86_branch (code, X86_CC_EQ, code, TRUE);
-		x86_mov_reg_membase (code, dreg, dreg, (tls_offset * 4) - 0x100, 4);
-		x86_patch (buf [0], code);
-	}
+	// FIXME generate code like __declspec (thread) when runtime uses __declspec (thread).
+	g_assert_not_reached ();
 #else
 	if (optimize_for_xen) {
 		x86_prefix (code, X86_GS_PREFIX);

--- a/mono/utils/mono-tls.h
+++ b/mono/utils/mono-tls.h
@@ -39,10 +39,8 @@ g_static_assert (TLS_KEY_DOMAIN == 0);
 #include <windows.h>
 
 // Some Windows SDKs define TLS to be FLS.
-// That is presumably catastrophic when combined with mono_amd64_emit_tls_get / mono_x86_emit_tls_get.
-// It also is not consistent.
-// FLS is a reasonable idea perhaps, but we would need to be consistent and to adjust JIT.
-// And there is __declspec(fiber).
+// FLS is a reasonable idea, but be consistent.
+// And there is no __declspec (fiber).
 #undef TlsAlloc
 #undef TlsFree
 #undef TlsGetValue


### PR DESCRIPTION
It should be replaced with something different.