### PR TITLE
[wasm][sdk] Fix the Mono.WebAssembly.Runtime package directory paths

### DIFF
--- a/sdks/wasm/sdk/Mono.WebAssembly.Runtime.Framework/Mono.WebAssembly.Runtime.csproj
+++ b/sdks/wasm/sdk/Mono.WebAssembly.Runtime.Framework/Mono.WebAssembly.Runtime.csproj
@@ -8,11 +8,18 @@
   </PropertyGroup>
   <ItemGroup>
     <None Update="build\netstandard2.0\Mono.WebAssembly.Runtime.props" Pack="True" />
-    <Content Include="..\..\..\wasm\debug\mono.js" PackagePath="mono-wasm-runtime\debug\%(Filename)%(Extension)" Link="mono-wasm-runtime\debug\mono.js" />
-    <Content Include="..\..\..\wasm\debug\mono.wasm" PackagePath="mono-wasm-runtime\debug\%(Filename)%(Extension)" Link="mono-wasm-runtime\debug\mono.wasm" />
-    <Content Include="..\..\..\wasm\debug\mono.wasm.map" PackagePath="mono-wasm-runtime\debug\%(Filename)%(Extension)" Link="mono-wasm-runtime\debug\mono.wasm.map" />
-    <Content Include="..\..\..\wasm\release\mono.js" PackagePath="mono-wasm-runtime\release\%(Filename)%(Extension)" Link="mono-wasm-runtime\release\mono.js" />
-    <Content Include="..\..\..\wasm\release\mono.wasm" PackagePath="mono-wasm-runtime\release\%(Filename)%(Extension)" Link="mono-wasm-runtime\release\mono.wasm" />
+    <Content Include="..\..\..\wasm\builds\debug\mono.js" PackagePath="mono-wasm-runtime\debug\%(Filename)%(Extension)" Link="mono-wasm-runtime\debug\mono.js" />
+    <Content Include="..\..\..\wasm\builds\debug\mono.wasm" PackagePath="mono-wasm-runtime\debug\%(Filename)%(Extension)" Link="mono-wasm-runtime\debug\mono.wasm" />
+    <Content Include="..\..\..\wasm\builds\debug\mono.wasm.map" PackagePath="mono-wasm-runtime\debug\%(Filename)%(Extension)" Link="mono-wasm-runtime\debug\mono.wasm.map" />
+    <Content Include="..\..\..\wasm\builds\threads-debug\mono.js" PackagePath="mono-wasm-runtime\threads-debug\%(Filename)%(Extension)" Link="mono-wasm-runtime\debug-threads\mono.js" />
+    <Content Include="..\..\..\wasm\builds\threads-debug\mono.worker.js" PackagePath="mono-wasm-runtime\threads-debug\%(Filename)%(Extension)" Link="mono-wasm-runtime\debug-threads\mono.worker.js" />
+    <Content Include="..\..\..\wasm\builds\threads-debug\mono.wasm" PackagePath="mono-wasm-runtime\debug-threads-debug\%(Filename)%(Extension)" Link="mono-wasm-runtime\debug-threads\mono.wasm" />
+    <Content Include="..\..\..\wasm\builds\threads-debug\mono.wasm.map" PackagePath="mono-wasm-runtime\debug-threads\%(Filename)%(Extension)" Link="mono-wasm-runtime\debugthreads\mono.wasm.map" />
+    <Content Include="..\..\..\wasm\builds\release\mono.js" PackagePath="mono-wasm-runtime\release\%(Filename)%(Extension)" Link="mono-wasm-runtime\release\mono.js" />
+    <Content Include="..\..\..\wasm\builds\release\mono.wasm" PackagePath="mono-wasm-runtime\release\%(Filename)%(Extension)" Link="mono-wasm-runtime\release\mono.wasm" />
+    <Content Include="..\..\..\wasm\builds\threads-release\mono.js" PackagePath="mono-wasm-runtime\threads-release\%(Filename)%(Extension)" Link="mono-wasm-runtime\release-threads\mono.js" />
+    <Content Include="..\..\..\wasm\builds\threads-release\mono.worker.js" PackagePath="mono-wasm-runtime\threads-release\%(Filename)%(Extension)" Link="mono-wasm-runtime\release-threads\mono.worker.js" />
+    <Content Include="..\..\..\wasm\builds\threads-release\mono.wasm" PackagePath="mono-wasm-runtime\threads-release\%(Filename)%(Extension)" Link="mono-wasm-runtime\release-threads\mono.wasm" />
     <None Update="build\netstandard2.0\Mono.WebAssembly.Runtime.props" PackagePath="build\netstandard2.0\Mono.WebAssembly.Runtime.props" Pack="True" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Fix the directory paths after threads commit
- Add threads build directories to the Runtime package.
