### PR TITLE
Fix ambiguous time at the end of DST period on Windows

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.cs
@@ -919,8 +919,9 @@ namespace System
 			DateTime DST_end = TransitionPoint (rule.DaylightTransitionEnd, year + ((rule.DaylightTransitionStart.Month < rule.DaylightTransitionEnd.Month) ? 0 : 1));
 			if (dateTime.Kind == DateTimeKind.Utc) {
 				DST_start -= BaseUtcOffset;
-				DST_end -= (BaseUtcOffset + rule.DaylightDelta);
+				DST_end -= BaseUtcOffset;
 			}
+			DST_end -= rule.DaylightDelta;
 			return (dateTime >= DST_start && dateTime < DST_end);
 		}
 		


### PR DESCRIPTION
As an addition to https://github.com/mono/mono/pull/15401 it should resolve XA-related issue.

Fixes #9664 