### PR TITLE
[wasm] allow overriding the build command invocation

### DIFF
--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -25,6 +25,7 @@ CSC?= MONO_PATH=$(TOP)/mcs/class/lib/build $(TOP)/sdks/builds/bcl/runtime/mono-w
 CSC_FLAGS := /debug:portable /noconfig /nostdlib /nologo /langversion:latest
 API_REFS=$(TOP)/external/binary-reference-assemblies/v4.6
 MONO_SUPPORT=$(WASM_RUNTIME_DIR)/include/support
+DOTNET_BUILD?=dotnet build
 
 ZLIB_HEADERS = \
 	$(MONO_SUPPORT)/crc32.h		\
@@ -194,7 +195,7 @@ binding_tests.dll: $(WASM_FRAMEWORK)/.stamp-framework $(BINDING_TEST_SOURCES)
 	$(CSC) $(CSC_FLAGS) /unsafe -target:library -out:$@ $(WASM_FRAMEWORK_DEPS) $(BCL_DEPS) /r:$(WASM_BCL_DIR)/Facades/System.Memory.dll /r:$(WASM_BCL_DIR)/nunitlite.dll $(BINDING_TEST_SOURCES)
 
 $(WASM_FRAMEWORK)/.stamp-framework: $(WASM_FRAMEWORK_SOURCES)
-	dotnet build $(WASM_FRAMEWORK_SOURCE)/WebAssembly.Framework.sln
+	$(DOTNET_BUILD) $(WASM_FRAMEWORK_SOURCE)/WebAssembly.Framework.sln
 	cp -f $(WASM_FRAMEWORK)/netstandard2.0/* $(WASM_FRAMEWORK)
 	touch $@
 
@@ -370,10 +371,10 @@ build-debugger-test-app: .stamp-build-debugger-test-app
 build-managed: build-debug-sample build-test-suite
 
 build-dbg-proxy:
-	dotnet build ProxyDriver
+	$(DOTNET_BUILD) ProxyDriver
 
 build-dbg-testsuite:
-	dotnet build DebuggerTestSuite
+	$(DOTNET_BUILD) DebuggerTestSuite
 
 build: build-native build-managed build-debugger-test-app
 
@@ -511,4 +512,4 @@ clean-sdk:
 	$(RM) -r sdk/packages
 
 build-sdk: $(WASM_FRAMEWORK)/.stamp-framework
-	dotnet build sdk/MonoWasmSdkCLI.sln
+	$(DOTNET_BUILD) sdk/MonoWasmSdkCLI.sln


### PR DESCRIPTION
as we debug some 3.0.0-preview7 related build problems allow environment overrides of
the command used to build the projects
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
