### PR TITLE
Remove extra explicit dist.

### DIFF
--- a/mono/metadata/Makefile.am
+++ b/mono/metadata/Makefile.am
@@ -484,6 +484,6 @@ libmonoruntimeinclude_HEADERS = \
 	tokentype.h		\
 	verify.h		
 
-EXTRA_DIST = $(win32_sources) $(unix_sources) $(null_sources) runtime.h \
+EXTRA_DIST = $(null_sources) runtime.h \
 		external-only.c \
 		threadpool-io-poll.c threadpool-io-epoll.c threadpool-io-kqueue.c sgen-dynarray.h


### PR DESCRIPTION
Automake sees through the conditionals, right?