### PR TITLE
Make thread locals just always extern. Not worth ifdef.

### DIFF
--- a/mono/utils/mono-tls.c
+++ b/mono/utils/mono-tls.c
@@ -172,21 +172,14 @@
 
 #endif
 
-#ifdef __cplusplus
-// static and anonymous namespace both fail to link otherwise; Linux/amd64/gcc.
-#define MONO_TLS_STATIC /* nothing */
-#else
-#define MONO_TLS_STATIC static
-#endif
-
-/* Tls variables for each MonoTlsKey */
-MONO_TLS_STATIC MONO_KEYWORD_THREAD MonoInternalThread *mono_tls_thread MONO_TLS_FAST;
-MONO_TLS_STATIC MONO_KEYWORD_THREAD MonoJitTlsData     *mono_tls_jit_tls MONO_TLS_FAST;
-MONO_TLS_STATIC MONO_KEYWORD_THREAD MonoDomain         *mono_tls_domain MONO_TLS_FAST;
-MONO_TLS_STATIC MONO_KEYWORD_THREAD SgenThreadInfo     *mono_tls_sgen_thread_info MONO_TLS_FAST;
-MONO_TLS_STATIC MONO_KEYWORD_THREAD MonoLMF           **mono_tls_lmf_addr MONO_TLS_FAST;
-
-#undef MONO_TLS_STATIC // no further uses
+// Tls variables for each MonoTlsKey.
+// These are extern instead of static for inexplicable C++ compatibility.
+//
+MONO_KEYWORD_THREAD MonoInternalThread *mono_tls_thread MONO_TLS_FAST;
+MONO_KEYWORD_THREAD MonoJitTlsData     *mono_tls_jit_tls MONO_TLS_FAST;
+MONO_KEYWORD_THREAD MonoDomain         *mono_tls_domain MONO_TLS_FAST;
+MONO_KEYWORD_THREAD SgenThreadInfo     *mono_tls_sgen_thread_info MONO_TLS_FAST;
+MONO_KEYWORD_THREAD MonoLMF           **mono_tls_lmf_addr MONO_TLS_FAST;
 
 #else
 


### PR DESCRIPTION
Making them static for C is not worth the ifdef.