### PR TITLE
[wasm] Make the runtime threading sample easier to setup and execute.

### DIFF
--- a/sdks/wasm/Makefile
+++ b/sdks/wasm/Makefile
@@ -299,7 +299,7 @@ build-threads-sample: packager.exe threads.exe
 
 # (cd bin/threads-sample && $(D8) --experimental-wasm-threads --stack-trace-limit=1000 runtime.js -- --run threads.exe)
 run-threads-sample: build-threads-sample
-	node tests/runtime/run.js bin/threads-sample/ --run threads.exe
+	(npm install --prefix tests/runtime/ && npm start --prefix tests/runtime)
 
 build-aot-mini: packager.exe mini_tests.dll main.exe runtime.js
 	mono --debug packager.exe --emscripten-sdkdir=$(EMSCRIPTEN_SDK_DIR) --mono-sdkdir=$(TOP)/sdks/out -appdir=bin/aot-mini --nobinding --builddir=obj/aot-mini --aot --template=runtime-tests.js mini_tests.dll

--- a/sdks/wasm/tests/runtime/package.json
+++ b/sdks/wasm/tests/runtime/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "runtime",
+  "version": "1.0.0",
+  "description": "",
+  "main": "run.js",
+  "scripts": {
+    "test": "node run.js ../../bin/threads-sample/ --run threads.exe",
+    "start": "node run.js ../../bin/threads-sample/ --run threads.exe"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "finalhandler": "^1.1.2",
+    "puppeteer": "^1.18.1",
+    "serve-static": "^1.14.1"
+  }
+}


### PR DESCRIPTION

- Add a `package.json` to the tests/runtime directory.
- Installs the required packages to run
- Modify make target `run-threads-sample` to use npm to install and run the test.
- There are two targets in the package.json file one for `test` and another 'start`

