### PR TITLE
[debugger] Calling InvokeMethod on GC Finalizer thread

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -6012,7 +6012,9 @@ clear_types_for_assembly (MonoAssembly *assembly)
 static void
 add_thread (gpointer key, gpointer value, gpointer user_data)
 {
-	MonoInternalThread *thread = (MonoInternalThread *)value;
+	MonoThread *thread = (MonoThread *)value;
+	if (mono_gc_is_finalizer_internal_thread(thread->internal_thread))
+		return;
 	Buffer *buf = (Buffer *)user_data;
 
 	buffer_add_objid (buf, (MonoObject*)thread);
@@ -6576,7 +6578,7 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 	case CMD_VM_ALL_THREADS: {
 		// FIXME: Domains
 		mono_loader_lock ();
-		buffer_add_int (buf, mono_g_hash_table_size (tid_to_thread_obj));
+		buffer_add_int (buf, mono_g_hash_table_size (tid_to_thread_obj) - 1); // -1 to remove the Finalizer GC Thread
 		mono_g_hash_table_foreach (tid_to_thread_obj, add_thread, buf);
 		mono_loader_unlock ();
 		break;


### PR DESCRIPTION
The example that reproduces the bug does this:
var thread = vm.GetThreads()[0];
greetingValue = program.InvokeMethod(thread, greeting, new Value[0]) as StringMirror;

But sometimes the Thread[0] was the MainThread of the program and it works, and other times was the GC Finalizer, but when it tries to run something on GC Finalizer thread, the thread is not suspended and throws an exception.
In the fix I removed the Finalizer thread of the list that is returned when CMD_VM_ALL_THREADS is called.

Fixes #13311



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
