### PR TITLE
[netcore] Read NETCORETESTS_VERSION and NETCOREAPP_VERSION from eng/Versions.props

### DIFF
--- a/netcore/Makefile
+++ b/netcore/Makefile
@@ -2,15 +2,8 @@ ifneq ($(wildcard config.make),)
 
 include config.make
 
-#
-# NETCORETESTS_VERSION and NETCOREAPP_VERSION must be updated in sync, we are using coreclr repo for that but that's fine for now
-#
-
-# Extracted MicrosoftPrivateCoreFxNETCoreAppVersion from https://github.com/dotnet/coreclr/blob/master/eng/Versions.props#L21
-NETCORETESTS_VERSION := 4.6.0-preview8.19352.1
-
-# Extracted MicrosoftNETCoreAppVersion from https://github.com/dotnet/coreclr/blob/master/eng/Versions.props#L25
-NETCOREAPP_VERSION := 3.0.0-preview7-27826-04
+NETCORETESTS_VERSION := $(shell cat ../eng/Versions.props | sed -n 's/.*MicrosoftPrivateCoreFxNETCoreAppVersion>\(.*\)<\/MicrosoftPrivateCoreFxNETCoreAppVersion.*/\1/p' )
+NETCOREAPP_VERSION := $(shell cat ../eng/Versions.props | sed -n 's/.*MicrosoftNETCoreAppVersion>\(.*\)<\/MicrosoftNETCoreAppVersion.*/\1/p' )
 
 # Extracted from https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/master/latest.version
 ASPNETCOREAPP_VERSION := 3.0.0-preview-18614-0151

--- a/scripts/ci/pipeline-netcore-runtime.yml
+++ b/scripts/ci/pipeline-netcore-runtime.yml
@@ -89,9 +89,8 @@ jobs:
     condition: eq(variables['poolname'], 'Hosted VS2017')
 
   - bash: |
-      ./autogen.sh --with-core=only
-      make -C mono -j4
-      make -C netcore bcl
+      cd netcore
+      ./build.sh
     displayName: 'Build (Make)'
     condition: ne(variables['poolname'], 'Hosted VS2017')
 


### PR DESCRIPTION
The Versions.props is auto-updated by Arcade so we automatically get new versions.

Also simplify CI build invocation a little bit.