### PR TITLE
[netcore] Throw ICE for Array.Copy(object[], enum[])

### DIFF
--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -23,14 +23,6 @@
 -noclass System.CodeDom.Compiler.Tests.ExecutorTests
 
 ####################################################################
-##  System.Collections.NonGeneric.Tests
-####################################################################
-
-# Mono currently supports Array.Copy from object[] array containing boxed ints to float[] array with primitive widening
-# https://github.com/mono/mono/issues/14857
--nomethod System.Collections.Tests.*.ICollection_NonGeneric_CopyTo_ArrayOfEnumType
-
-####################################################################
 ##  System.Collections.Specialized.Tests
 ####################################################################
 
@@ -105,6 +97,9 @@
 
 # TODO: Hangs
 -nomethod System.IO.Tests.Directory_SetCurrentDirectory+Directory_SetCurrentDirectory_SymLink.SetToPathContainingSymLink
+
+# flaky test (The process cannot access the file ...)
+-nomethod System.IO.Tests.File_Copy_str_str.CopyFileWithData_MemberData
 
 ####################################################################
 ##  System.Linq.Expressions.Tests
@@ -877,6 +872,23 @@
 -nomethod System.Data.SqlClient.Tests.DiagnosticTest.ExecuteNonQueryAsyncErrorTest
 -nomethod System.Data.SqlClient.Tests.DiagnosticTest.ExecuteScalarAsyncErrorTest
 -nomethod System.Data.SqlClient.Tests.DiagnosticTest.ExecuteScalarAsyncTest
+
+# System.InvalidProgramException : Invalid IL code in (wrapper dynamic-method) System.Text.RegularExpressions.CompiledRegexRunner:Go3 (System.Text.RegularExpressions.RegexRunner): IL_01af: nop
+-nomethod System.Data.SqlClient.Tests.SqlErrorCollectionTest.GetEnumerator_Success
+-nomethod System.Data.SqlClient.Tests.SqlErrorCollectionTest.CopyTo_NonGeneric_Success
+-nomethod System.Data.SqlClient.Tests.SqlErrorCollectionTest.Indexer_Success
+-nomethod System.Data.SqlClient.Tests.SqlErrorCollectionTest.Indexer_Throws
+-nomethod System.Data.SqlClient.Tests.SqlErrorCollectionTest.CopyTo_Throws
+-nomethod System.Data.SqlClient.Tests.SqlErrorCollectionTest.CopyTo_Success
+-nomethod System.Data.SqlClient.Tests.SqlErrorCollectionTest.SyncRoot_Success
+-nomethod System.Data.SqlClient.Tests.SqlErrorCollectionTest.IsSynchronized_Success
+-nomethod System.Data.SqlClient.Tests.SqlErrorCollectionTest.CopyTo_NonGeneric_Throws
+-nomethod System.Data.SqlClient.Tests.ExceptionTest.IndependentConnectionExceptionTestOpenConnection
+-nomethod System.Data.SqlClient.Tests.ExceptionTest.ExceptionTests
+-nomethod System.Data.SqlClient.Tests.ExceptionTest.IndependentConnectionExceptionTestExecuteReader
+-nomethod System.Data.SqlClient.Tests.ExceptionTest.NamedPipeInvalidConnStringTest_ManagedSNI
+-nomethod System.Data.SqlClient.Tests.SqlConnectionBasicTests.ConnectionTest
+-nomethod System.Data.SqlClient.Tests.CloneTests.CloneSqlConnection
 
 ####################################################################
 ##  System.Diagnostics.StackTrace.Tests

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -60,9 +60,6 @@
 ##  System.Diagnostics.TraceSource.Tests
 ####################################################################
 
-# requires precise gc (should be ignored in corefx)
--nomethod System.Diagnostics.TraceSourceTests.TraceSourceClassTests.PruneTest
-
 # Object reference not set to an instance of an object on DefaultTraceListenerClassTests.MakeAssemblyGetEntryAssemblyReturnNull
 # https://github.com/mono/mono/issues/14905
 -nomethod System.Diagnostics.TraceSourceTests.DefaultTraceListenerClassTests.EntryAssemblyName_Null_NotIncludedInTrace
@@ -87,9 +84,6 @@
 # ambigous methods
 # https://github.com/mono/mono/issues/14906
 -nomethod ManagedTests.DynamicCSharp.Conformance.dynamic.overloadResolution.Methods.Oneclass2methods.twoprms004.twoprms004.Test.DynamicCSharpRunTest
-
-# requires precise gc (should be ignored in corefx)
--nomethod ManagedTests.DynamicCSharp.Conformance.dynamic.context.*
 
 ####################################################################
 ##  System.IO.Tests
@@ -283,9 +277,6 @@
 
 # flaky test
 -nomethod System.Net.Sockets.Tests.SocketOptionNameTest.MulticastInterface_Set_AnyInterface_Succeeds
-
-# requires precise GC (should be ignored in corefx)
--nomethod System.Net.Sockets.Tests.DisposedSocket.NonDisposedSocket_SafeHandlesCollected
 
 ####################################################################
 ##  System.Reflection.Emit.ILGeneration.Tests
@@ -1276,10 +1267,6 @@
 # disabled in CoreCLR too
 -noclass System.Security.Cryptography.X509Certificates.Tests.X509Certificate2UITests
 
-# requires precise gc (should be ignored in corefx)
--nomethod System.IO.Tests.FileStream_Dispose.FinalizeFlushesWriteBuffer
--nomethod System.IO.Tests.FileStream_Dispose.Dispose_CallsVirtualDispose_TrueArg
-
 -nomethod System.IO.Tests.File_Move_Tests.File_Move_From_Unwatched_To_Watched
 
 # unxpected non-breaking space in strings (char(160) - char(32))
@@ -1293,3 +1280,15 @@
 # Unexpected IntPtr.Zero from Interop.Mmap
 -nomethod System.IO.MemoryMappedFiles.Tests.MemoryMappedViewAccessorTests.ValidAccessLevelCombinations
 -nomethod System.IO.MemoryMappedFiles.Tests.MemoryMappedViewStreamTests.ValidAccessLevelCombinations
+
+# requires precise gc (to be ignored in dotnet/corefx, e.g. https://github.com/dotnet/corefx/pull/39176)
+-nomethod System.IO.Tests.FileStream_Dispose.FinalizeFlushesWriteBuffer
+-nomethod System.IO.Tests.FileStream_Dispose.Dispose_CallsVirtualDispose_TrueArg
+-nomethod System.Tests.GCTests.ReRegisterForFinalize
+-nomethod System.Runtime.CompilerServices.Tests.ConditionalWeakTableTests.GetEnumerator_CollectedItemsNotEnumerated
+-nomethod System.Runtime.CompilerServices.Tests.ConditionalWeakTableTests.AddRemove_DropValue
+-nomethod System.Tests.WeakReferenceTests.NonGeneric
+-nomethod System.Tests.WeakReferenceTests.Generic
+-nomethod System.Diagnostics.TraceSourceTests.TraceSourceClassTests.PruneTest
+-nomethod ManagedTests.DynamicCSharp.Conformance.dynamic.context.*
+-nomethod System.Net.Sockets.Tests.DisposedSocket.NonDisposedSocket_SafeHandlesCollected

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -802,6 +802,7 @@
 # flaky test - System.TypeLoadException : Could not load type '_proxy_System.ComponentModel.Composition.IStronglyTypedStructure_3b7f133d-79c7-449e-8f68-22aa093dbb8d' from assembly ''.
 -nomethod System.ComponentModel.Composition.MetadataAttributeTests.StronglyTypedStructureTest
 -nomethod System.ComponentModel.Composition.MetadataAttributeTests.StronglyTypedStructureTestWithTransparentViews
+-nomethod System.ComponentModel.Composition.MetadataViewProviderTests.GetMetadataView_IMetadataViewWithDefaultedInt64
 
 ####################################################################
 ##  System.Composition.TypedParts.Tests
@@ -1290,5 +1291,6 @@
 -nomethod System.Tests.WeakReferenceTests.NonGeneric
 -nomethod System.Tests.WeakReferenceTests.Generic
 -nomethod System.Diagnostics.TraceSourceTests.TraceSourceClassTests.PruneTest
+-nomethod System.Diagnostics.TraceSourceTests.SwitchClassTests.PruneTest
 -nomethod ManagedTests.DynamicCSharp.Conformance.dynamic.context.*
 -nomethod System.Net.Sockets.Tests.DisposedSocket.NonDisposedSocket_SafeHandlesCollected

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -731,6 +731,9 @@
 # GCSettings.LatencyMode is not implemented
 -nomethod System.Tests.GCTests.LatencyRoundtrips
 
+# GC.GetGCMemoryInfo is not implemented
+-nomethod System.Tests.GCTests.GetGCMemoryInfo
+
 # Could not load type 'System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]' from assembly 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
 # https://github.com/mono/mono/issues/15153
 -nomethod System.Tests.ActivatorTests.TestingCreateInstanceObjectHandleFullSignature
@@ -1278,4 +1281,3 @@
 # Unexpected IntPtr.Zero from Interop.Mmap
 -nomethod System.IO.MemoryMappedFiles.Tests.MemoryMappedViewAccessorTests.ValidAccessLevelCombinations
 -nomethod System.IO.MemoryMappedFiles.Tests.MemoryMappedViewStreamTests.ValidAccessLevelCombinations
-

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -1278,3 +1278,4 @@
 # Unexpected IntPtr.Zero from Interop.Mmap
 -nomethod System.IO.MemoryMappedFiles.Tests.MemoryMappedViewAccessorTests.ValidAccessLevelCombinations
 -nomethod System.IO.MemoryMappedFiles.Tests.MemoryMappedViewStreamTests.ValidAccessLevelCombinations
+

--- a/netcore/CoreFX.issues_windows.rsp
+++ b/netcore/CoreFX.issues_windows.rsp
@@ -1,10 +1,3 @@
-# requires precise gc
--nomethod System.Tests.GCTests.ReRegisterForFinalize
--nomethod System.Runtime.CompilerServices.Tests.ConditionalWeakTableTests.GetEnumerator_CollectedItemsNotEnumerated
--nomethod System.Runtime.CompilerServices.Tests.ConditionalWeakTableTests.AddRemove_DropValue
--nomethod System.Tests.WeakReferenceTests.NonGeneric
--nomethod System.Tests.WeakReferenceTests.Generic
-
 # GCSettings.SetGCLatencyMode is not implemented
 -nomethod System.Tests.GCTests.LatencyRoundtrips_LowLatency
 

--- a/netcore/System.Private.CoreLib/src/System/Array.cs
+++ b/netcore/System.Private.CoreLib/src/System/Array.cs
@@ -134,9 +134,12 @@ namespace System
 			Type dst_type = destinationArray.GetType ().GetElementType ()!;
 			var dst_type_vt = dst_type.IsValueType && Nullable.GetUnderlyingType (dst_type) == null;
 
-			if (src_type.IsEnum)
+			bool src_is_enum = src_type.IsEnum;
+			bool dst_is_enum = dst_type.IsEnum;
+			
+			if (src_is_enum)
 				src_type = Enum.GetUnderlyingType (src_type);
-			if (dst_type.IsEnum)
+			if (dst_is_enum)
 				dst_type = Enum.GetUnderlyingType (dst_type);
 
 			if (reliable) {
@@ -153,6 +156,9 @@ namespace System
 			if (!Object.ReferenceEquals (sourceArray, destinationArray) || source_pos > dest_pos) {
 				for (int i = 0; i < length; i++) {
 					Object srcval = sourceArray.GetValueImpl (source_pos + i);
+
+					if (!src_type.IsValueType && dst_is_enum)
+						throw new InvalidCastException (SR.InvalidCast_DownCastArrayElement);
 
 					if (dst_type_vt && (srcval == null || (src_type == typeof (object) && srcval.GetType () != dst_type)))
 						throw new InvalidCastException ();


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/14857
```csharp
Array src = new object[] { (object)1 };
Array dst = new DateTimeKind[] { DateTimeKind.Local };
src.CopyTo(dst, 0); // should throw InvalidCastException
```