### PR TITLE
[2019-06] [sdks] Use @loader_path for mono and libmonosgen

### DIFF
--- a/sdks/builds/android.mk
+++ b/sdks/builds/android.mk
@@ -13,7 +13,7 @@ android_PLATFORM_BIN=$(XCODE_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/bin
 
 ifeq ($(UNAME),Darwin)
 android_ARCHIVE += android-sources
-ADDITIONAL_PACKAGE_DEPS += $(android_SOURCES_DIR) $(android_HOST_DARWIN_LIB_DIR)/loader_updated.flag
+ADDITIONAL_PACKAGE_DEPS += $(android_SOURCES_DIR) $(android_HOST_DARWIN_LIB_DIR)/.stamp-android-loader-path
 endif
 
 ##
@@ -488,9 +488,9 @@ $(android_SOURCES_DIR)/external/linker/README.md:  # we use this as a sentinel f
 
 $(android_SOURCES_DIR): $(android_SOURCES_DIR)/external/linker/README.md
 
-$(android_HOST_DARWIN_LIB_DIR): $(android_HOST_DARWIN_LIB_DIR)/loader_updated.flag
+$(android_HOST_DARWIN_LIB_DIR): $(android_HOST_DARWIN_LIB_DIR)/.stamp-android-loader-path
 
-$(android_HOST_DARWIN_LIB_DIR)/loader_updated.flag: package-android-host-Darwin
+$(android_HOST_DARWIN_LIB_DIR)/.stamp-android-loader-path: package-android-host-Darwin
 	$(android_PLATFORM_BIN)/install_name_tool -id @loader_path/libmonosgen-2.0.dylib $(android_HOST_DARWIN_LIB_DIR)/libmonosgen-2.0.dylib
 	$(android_PLATFORM_BIN)/install_name_tool -change $(android_HOST_DARWIN_LIB_DIR)/libmonosgen-2.0.1.dylib @loader_path/libmonosgen-2.0.dylib $(android_HOST_DARWIN_BIN_DIR)/mono
 	touch $@

--- a/sdks/builds/android.mk
+++ b/sdks/builds/android.mk
@@ -490,7 +490,7 @@ $(android_SOURCES_DIR): $(android_SOURCES_DIR)/external/linker/README.md
 
 $(android_HOST_DARWIN_LIB_DIR): $(android_HOST_DARWIN_LIB_DIR)/loader_updated.flag
 
-$(android_HOST_DARWIN_LIB_DIR)/loader_updated.flag: $(android_HOST_DARWIN_LIB_DIR)/libmonosgen-2.0.dylib
+$(android_HOST_DARWIN_LIB_DIR)/loader_updated.flag: package-android-host-Darwin
 	$(android_PLATFORM_BIN)/install_name_tool -id @loader_path/libmonosgen-2.0.dylib $(android_HOST_DARWIN_LIB_DIR)/libmonosgen-2.0.dylib
 	$(android_PLATFORM_BIN)/install_name_tool -change $(android_HOST_DARWIN_LIB_DIR)/libmonosgen-2.0.1.dylib @loader_path/libmonosgen-2.0.dylib $(android_HOST_DARWIN_BIN_DIR)/mono
 	touch $@


### PR DESCRIPTION
This way we are able to dynamically load libmonosgen and also use host
mono binary.

The library dependencies look like this after the change:
```
otool -L /Users/rodo/git/mono/sdks/out/android-host-Darwin-release/bin/mono
/Users/rodo/git/mono/sdks/out/android-host-Darwin-release/bin/mono:
	@loader_path/libmonosgen-2.0.dylib (compatibility version 2.0.0, current version 2.0.0)
	...

otool -L /Users/rodo/git/mono/sdks/out/android-host-Darwin-release/lib/libmonosgen-2.0.dylib
/Users/rodo/git/mono/sdks/out/android-host-Darwin-release/lib/libmonosgen-2.0.dylib:
	@loader_path/libmonosgen-2.0.dylib (compatibility version 2.0.0, current version 2.0.0)
	...
```



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->


Backport of #15580.

/cc @akoeplinger @radekdoulik