### PR TITLE
experiment with single_imm_size

### DIFF
--- a/mono/arch/x86/x86-codegen.h
+++ b/mono/arch/x86/x86-codegen.h
@@ -289,39 +289,11 @@ typedef union {
 
 #define kMaxMembaseEmitPadding 6
 
-#define x86_membase_emit_body(inst,r,basereg,disp)	do {\
-	if ((basereg) == X86_ESP) {	\
-		if ((disp) == 0) {	\
-			x86_address_byte ((inst), 0, (r), X86_ESP);	\
-			x86_address_byte ((inst), 0, X86_ESP, X86_ESP);	\
-		} else if (x86_is_imm8((disp))) {	\
-			x86_address_byte ((inst), 1, (r), X86_ESP);	\
-			x86_address_byte ((inst), 0, X86_ESP, X86_ESP);	\
-			x86_imm_emit8 ((inst), (disp));	\
-		} else {	\
-			x86_address_byte ((inst), 2, (r), X86_ESP);	\
-			x86_address_byte ((inst), 0, X86_ESP, X86_ESP);	\
-			x86_imm_emit32 ((inst), (disp));	\
-		}	\
-		break;	\
-	}	\
-	if ((disp) == 0 && (basereg) != X86_EBP) {	\
-		x86_address_byte ((inst), 0, (r), (basereg));	\
-		break;	\
-	}	\
-	if (x86_is_imm8((disp))) {	\
-		x86_address_byte ((inst), 1, (r), (basereg));	\
-		x86_imm_emit8 ((inst), (disp));	\
-	} else {	\
-		x86_address_byte ((inst), 2, (r), (basereg));	\
-		x86_imm_emit32 ((inst), (disp));	\
-	}	\
-	} while (0)
-
-#define x86_membase_emit(inst,r,basereg,disp) \
-	do { \
-		x86_membase_emit_body((inst),(r),(basereg),(disp)); \
-	} while (0)
+#define x86_membase_emit(inst,r,basereg,disp) do {		\
+	x86_address_byte ((inst), 2, (r), X86_ESP);		\
+	x86_address_byte ((inst), 0, X86_ESP, (basereg));	\
+	x86_imm_emit32 ((inst), (disp));			\
+} while (0)
 
 #define kMaxMemindexEmitPadding 6
 

--- a/mono/mini/tramp-amd64.c
+++ b/mono/mini/tramp-amd64.c
@@ -293,7 +293,7 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 	orig_rsp_to_rbp_offset = 0;
 	r11_save_code = code;
 	/* Reserve space for the mov_membase_reg to save R11 */
-	code += 5;
+	code += 3 /* mini_debug_options.single_imm_size */ + 5;
 	after_r11_save_code = code;
 
 	/* Pop the return address off the stack */


### PR DESCRIPTION
Act as if single_imm_size is always true, to confirm my understanding.

This will not be commited to master.
Unless we want some gross simplification at the cost of larger code, i.e. 6 bytes when anywhere from 1-6 are required.