### PR TITLE
[JIT][amd64][x86] Partial single_imm_size support

### DIFF
--- a/mono/arch/amd64/amd64-codegen.h
+++ b/mono/arch/amd64/amd64-codegen.h
@@ -186,7 +186,7 @@ typedef union {
 
 #define amd64_alu_reg_imm_size_body(inst,opc,reg,imm,size) \
 	do {	\
-		if (x86_is_imm8((imm))) {	\
+		if (x86_use_imm8 ((imm))) {	\
 			amd64_emit_rex(inst, size, 0, 0, (reg)); \
 			*(inst)++ = (unsigned char)0x83;	\
 			x86_reg_emit ((inst), (opc), (reg));	\

--- a/mono/mini/cpu-amd64.md
+++ b/mono/mini/cpu-amd64.md
@@ -114,7 +114,7 @@ long_conv_to_r4: dest:f src1:i len:15
 long_conv_to_r8: dest:f src1:i len:9
 long_conv_to_u4: dest:i src1:i len:3
 long_conv_to_u8: dest:i src1:i len:3
-long_conv_to_r_un: dest:f src1:i len:64
+long_conv_to_r_un: dest:f src1:i len:75
 long_conv_to_ovf_i4_un: dest:i src1:i len:16
 long_conv_to_ovf_u4: dest:i src1:i len:15
 long_conv_to_u2: dest:i src1:i len:4
@@ -134,7 +134,7 @@ endfinally: len:9
 endfilter: src1:a len:9
 get_ex_obj: dest:a len:16
 
-ckfinite: dest:f src1:f len:43
+ckfinite: dest:f src1:f len:48
 ceq: dest:c len:8
 cgt: dest:c len:8
 cgt_un: dest:c len:8
@@ -149,7 +149,7 @@ icompare_imm: src1:i len:8
 fcompare: src1:f src2:f clob:a len:13
 rcompare: src1:f src2:f clob:a len:13
 arglist: src1:b len:11
-check_this: src1:b len:5
+check_this: src1:b len:11
 call: dest:a clob:c len:32
 voidcall: clob:c len:32
 voidcall_reg: src1:i clob:c len:32
@@ -317,7 +317,7 @@ move_f_to_i4: dest:i src1:f len:16
 move_i4_to_f: dest:f src1:i len:16
 move_f_to_i8: dest:i src1:f len:5
 move_i8_to_f: dest:f src1:i len:5
-call_handler: len:14 clob:c
+call_handler: len:19 clob:c
 aotconst: dest:i len:10
 gc_safe_point: clob:c src1:i len:40
 x86_test_null: src1:i len:5
@@ -359,8 +359,8 @@ tls_get: dest:i len:32
 tls_set: src1:i len:16
 atomic_add_i4: src1:b src2:i dest:i len:32
 atomic_add_i8: src1:b src2:i dest:i len:32
-atomic_exchange_i4: src1:b src2:i dest:i len:12
-atomic_exchange_i8: src1:b src2:i dest:i len:12
+atomic_exchange_i4: src1:b src2:i dest:i len:14
+atomic_exchange_i8: src1:b src2:i dest:i len:14
 atomic_cas_i4: src1:b src2:i src3:a dest:a len:24
 atomic_cas_i8: src1:b src2:i src3:a dest:a len:24
 memory_barrier: len:3
@@ -391,12 +391,12 @@ adc_imm: dest:i src1:i len:8 clob:1
 sbb: dest:i src1:i src2:i len:3 clob:1
 sbb_imm: dest:i src1:i len:8 clob:1
 br_reg: src1:i len:3
-sin: dest:f src1:f len:32
-cos: dest:f src1:f len:32
+sin: dest:f src1:f len:34
+cos: dest:f src1:f len:34
 abs: dest:f src1:f clob:1 len:32
 tan: dest:f src1:f len:59
 atan: dest:f src1:f len:9
-sqrt: dest:f src1:f len:32
+sqrt: dest:f src1:f len:34
 sext_i1: dest:i src1:i len:4
 sext_i2: dest:i src1:i len:4
 sext_i4: dest:i src1:i len:8
@@ -590,7 +590,7 @@ vcall2: len:64 clob:c
 vcall2_reg: src1:i len:64 clob:c
 vcall2_membase: src1:b len:64 clob:c
 
-dyn_call: src1:i src2:i len:192 clob:c
+dyn_call: src1:i src2:i len:240 clob:c
 
 localloc_imm: dest:i len:120
 
@@ -823,7 +823,7 @@ gc_liveness_use: len:0
 gc_spill_slot_liveness_def: len:0
 gc_param_slot_liveness_def: len:0
 
-generic_class_init: src1:A len:32 clob:c
+generic_class_init: src1:A len:33 clob:c
 get_last_error: dest:i len:32
 
 fill_prof_call_ctx: src1:i len:128

--- a/mono/mini/cpu-x86.md
+++ b/mono/mini/cpu-x86.md
@@ -137,7 +137,7 @@ int_mul_ovf: dest:i src1:i src2:i clob:1 len:9
 int_mul_ovf_un: dest:i src1:i src2:i len:16
 
 throw: src1:i len:13
-rethrow: src1:i len:13
+rethrow: src1:i len:15
 start_handler: len:16
 endfinally: len:16
 endfilter: src1:a len:16
@@ -250,7 +250,7 @@ float_not: dest:f src1:f len:2
 float_conv_to_i1: dest:y src1:f len:39
 float_conv_to_i2: dest:y src1:f len:39
 float_conv_to_i4: dest:i src1:f len:39
-float_conv_to_i8: dest:L src1:f len:39
+float_conv_to_i8: dest:L src1:f len:44
 float_conv_to_u4: dest:i src1:f len:39
 float_conv_to_u8: dest:L src1:f len:39
 float_conv_to_u2: dest:y src1:f len:39
@@ -268,7 +268,7 @@ float_cneq: dest:y src1:f src2:f len:25
 float_cge: dest:y src1:f src2:f len:37
 float_cle: dest:y src1:f src2:f len:37
 float_conv_to_u: dest:i src1:f len:36
-call_handler: len:11 clob:c
+call_handler: len:17 clob:c
 aotconst: dest:i len:5
 load_gotaddr: dest:i len:64
 got_entry: dest:i src1:b len:7

--- a/mono/mini/exceptions-x86.c
+++ b/mono/mini/exceptions-x86.c
@@ -85,8 +85,13 @@ mono_win32_get_handle_stackoverflow (void)
 	if (start)
 		return start;
 
+	int size = 128;
+
+	if (mini_debug_options.single_imm_size) // FIXME accurate number
+		size *= 2;
+
 	/* restore_contect (void *sigctx) */
-	start = code = mono_global_codeman_reserve (128);
+	start = code = mono_global_codeman_reserve (size);
 
 	/* load context into ebx */
 	x86_mov_reg_membase (code, X86_EBX, X86_ESP, 4, 4);
@@ -114,6 +119,8 @@ mono_win32_get_handle_stackoverflow (void)
 
 	/* return */
 	x86_ret (code);
+
+	g_assertf ((code - start) <= size, "%d %d", (int)(code - start), size);
 
 	mono_arch_flush_icache (start, code - start);
 	MONO_PROFILER_RAISE (jit_code_buffer, (start, code - start, MONO_PROFILER_CODE_BUFFER_EXCEPTION_HANDLING, NULL));
@@ -296,7 +303,12 @@ mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 
 	/* restore_contect (MonoContext *ctx) */
 
-	start = code = mono_global_codeman_reserve (128);
+	int size = 128;
+
+	if (mini_debug_options.single_imm_size) // FIXME accurate number
+		size *= 2;
+
+	start = code = mono_global_codeman_reserve (size);
 	
 	/* load ctx */
 	x86_mov_reg_membase (code, X86_EAX, X86_ESP, 4, 4);
@@ -361,6 +373,8 @@ mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 		g_slist_free (unwind_ops);
 	}
 
+	g_assertf ((code - start) <= size, "%d %d", (int)(code - start), size);
+
 	mono_arch_flush_icache (start, code - start);
 	MONO_PROFILER_RAISE (jit_code_buffer, (start, code - start, MONO_PROFILER_CODE_BUFFER_EXCEPTION_HANDLING, NULL));
 
@@ -381,7 +395,10 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 	guint8 *code;
 	MonoJumpInfo *ji = NULL;
 	GSList *unwind_ops = NULL;
-	guint kMaxCodeSize = 64;
+	int kMaxCodeSize = 64;
+
+	if (mini_debug_options.single_imm_size) // FIXME accurate number
+		kMaxCodeSize *= 2;
 
 	/* call_filter (MonoContext *ctx, unsigned long eip) */
 	start = code = mono_global_codeman_reserve (kMaxCodeSize);
@@ -442,7 +459,7 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 	mono_arch_flush_icache (start, code - start);
 	MONO_PROFILER_RAISE (jit_code_buffer, (start, code - start, MONO_PROFILER_CODE_BUFFER_EXCEPTION_HANDLING, NULL));
 
-	g_assert ((code - start) < kMaxCodeSize);
+	g_assertf ((code - start) <= kMaxCodeSize, "%d %d", (int)(code - start), kMaxCodeSize);
 	return start;
 }
 
@@ -545,7 +562,10 @@ get_throw_trampoline (const char *name, gboolean rethrow, gboolean llvm, gboolea
 	int i, stack_size, stack_offset, arg_offsets [5], regs_offset;
 	MonoJumpInfo *ji = NULL;
 	GSList *unwind_ops = NULL;
-	guint kMaxCodeSize = 192;
+	int kMaxCodeSize = 192;
+
+	if (mini_debug_options.single_imm_size) // FIXME accurate number
+		kMaxCodeSize *= 2;
 
 	start = code = mono_global_codeman_reserve (kMaxCodeSize);
 
@@ -671,7 +691,7 @@ get_throw_trampoline (const char *name, gboolean rethrow, gboolean llvm, gboolea
 	}
 	x86_breakpoint (code);
 
-	g_assert ((code - start) < kMaxCodeSize);
+	g_assertf ((code - start) <= kMaxCodeSize, "%d %d", (int)(code - start), kMaxCodeSize);
 
 	if (info)
 		*info = mono_tramp_info_create (name, start, code - start, ji, unwind_ops);
@@ -951,7 +971,12 @@ mono_x86_get_signal_exception_trampoline (MonoTrampInfo **info, gboolean aot)
 	GSList *unwind_ops = NULL;
 	int stack_size;
 
-	start = code = mono_global_codeman_reserve (128);
+	int size = 128;
+
+	if (mini_debug_options.single_imm_size) // FIXME accurate number
+		size *= 2;
+
+	start = code = mono_global_codeman_reserve (size);
 
 	/* FIXME no unwind before we push ip */
 	/* Caller ip */
@@ -971,7 +996,7 @@ mono_x86_get_signal_exception_trampoline (MonoTrampInfo **info, gboolean aot)
 	/* Branch to target */
 	x86_call_reg (code, X86_EDX);
 
-	g_assert ((code - start) < 128);
+	g_assertf ((code - start) <= size, "%d %d", (int)(code - start), size);
 
 	if (info)
 		*info = mono_tramp_info_create ("x86_signal_exception_trampoline", start, code - start, ji, unwind_ops);
@@ -982,6 +1007,8 @@ mono_x86_get_signal_exception_trampoline (MonoTrampInfo **info, gboolean aot)
 			g_free (l->data);
 		g_slist_free (unwind_ops);
 	}
+
+	g_assertf ((code - start) <= size, "%d %d", (int)(code - start), size);
 
 	mono_arch_flush_icache (start, code - start);
 	MONO_PROFILER_RAISE (jit_code_buffer, (start, code - start, MONO_PROFILER_CODE_BUFFER_EXCEPTION_HANDLING, NULL));
@@ -1172,7 +1199,13 @@ mono_tasklets_arch_restore (void)
 
 	if (saved)
 		return (MonoContinuationRestore)saved;
-	code = start = mono_global_codeman_reserve (48);
+
+	int size = 48;
+
+	if (mini_debug_options.single_imm_size) // FIXME accurate number
+		size *= 2;
+
+	code = start = mono_global_codeman_reserve (size);
 	/* the signature is: restore (MonoContinuation *cont, int state, MonoLMF **lmf_addr) */
 	/* put cont in edx */
 	x86_mov_reg_membase (code, X86_EDX, X86_ESP, 4, 4);
@@ -1200,6 +1233,8 @@ mono_tasklets_arch_restore (void)
 	x86_mov_membase_reg (code, X86_ECX, 0, X86_EDX, 4);*/
 
 	x86_jump_membase (code, X86_EDX, MONO_STRUCT_OFFSET (MonoContinuation, return_ip));
+
+	g_assertf ((code - start) <= size, "%d %d", (int)(code - start), size);
 
 	mono_arch_flush_icache (start, code - start);
 	MONO_PROFILER_RAISE (jit_code_buffer, (start, code - start, MONO_PROFILER_CODE_BUFFER_EXCEPTION_HANDLING, NULL));

--- a/mono/mini/tramp-x86-gsharedvt.c
+++ b/mono/mini/tramp-x86-gsharedvt.c
@@ -13,6 +13,8 @@
 
 #ifdef MONO_ARCH_GSHAREDVT_SUPPORTED
 
+#include "mini-runtime.h"
+
 gpointer
 mono_x86_start_gsharedvt_call (GSharedVtCallInfo *info, gpointer *caller, gpointer *callee, gpointer mrgctx_reg)
 {
@@ -89,6 +91,10 @@ mono_arch_get_gsharedvt_trampoline (MonoTrampInfo **info, gboolean aot)
 	int info_offset, mrgctx_offset;
 
 	buf_len = 320;
+
+	if (mini_debug_options.single_imm_size) // FIXME accurate number
+		buf_len *= 2;
+
 	buf = code = mono_global_codeman_reserve (buf_len);
 
 	/*
@@ -349,7 +355,7 @@ mono_arch_get_gsharedvt_trampoline (MonoTrampInfo **info, gboolean aot)
 	x86_leave (code);
 	x86_ret_imm (code, 4);
 
-	g_assert ((code - buf) < buf_len);
+	g_assertf (code - buf <= buf_len, "%d %d", (int)(code - buf), buf_len);
 
 	if (info)
 		*info = mono_tramp_info_create ("gsharedvt_trampoline", buf, code - buf, ji, unwind_ops);


### PR DESCRIPTION
This is a flag to stablilize codegen size, for test purposes.
It not being implemented makes the sequence point test not reliable.
Esp. with https://github.com/mono/mono/pull/15567.
For purposes of #15567 this could be less.

There are multiple other options if #15567 it is the only problem.
1. Don't do #15567.
2. Fill in nops dynamically if the value is zero, only in that path (it is probably zero/non-zero, not imm8/non-imm8).
3. Duplicate just the macro it uses.

But this PR does seem most correct as the design intends and could stave off future similar problems.