### PR TITLE
[2019-06] [ilasm] [System.Runtime]System.String wasn't generating string primitive type

### DIFF
--- a/mcs/ilasm/codegen/GenericArguments.cs
+++ b/mcs/ilasm/codegen/GenericArguments.cs
@@ -40,7 +40,11 @@ namespace Mono.ILASM {
 
 			if (type_list == null)
 				type_list = new ArrayList ();
-			type_list.Add (type);
+			var prim = PrimitiveTypeRef.GetPrimitiveType (type.FullName);
+			if (prim != null)
+				type_list.Add (prim);
+			else
+				type_list.Add (type);
 			type_str = null;
 			type_arr = null;
 		}

--- a/mcs/ilasm/codegen/PrimitiveTypeRef.cs
+++ b/mcs/ilasm/codegen/PrimitiveTypeRef.cs
@@ -64,7 +64,9 @@ namespace Mono.ILASM {
                 {
                         switch (full_name) {
                         case "System.String":
+                        case "[System.Runtime]System.String":
                                 return new PrimitiveTypeRef (PEAPI.PrimitiveType.String, full_name);
+                        case "[System.Runtime]System.Object":
                         case "System.Object":
                                 return new PrimitiveTypeRef (PEAPI.PrimitiveType.Object, full_name);
                         default:


### PR DESCRIPTION
Was crashing when was executing the boring.il test from coreclr, the problem was that using [System.Runtime]System.String the type was not understood as the primitive type string.

Using ilasm from coreclr and running on mono it works, because of that I decided to fix on ilasm and not on runtime.

Fixes #13923




Backport of #15552.

/cc @thaystg 