### PR TITLE
Make RemoteExecutor a no-op on all mobile profiles

### DIFF
--- a/mcs/build/tests.make
+++ b/mcs/build/tests.make
@@ -41,17 +41,13 @@ $(topdir)/../external/corefx/src/CoreFx.Private.TestUtilities/src/System/Diagnos
 $(topdir)/../external/corefx/src/Common/src/System/PasteArguments.cs \
 $(topdir)/../external/corefx/src/Common/src/System/PasteArguments.Unix.cs
 
-ifeq ($(PROFILE),monodroid)
+ifdef MOBILE_PROFILE
 xunit_src += $(topdir)/../mcs/class/test-helpers/RemoteExecutorTestBase.Mobile.cs
 else
-ifeq ($(PROFILE),monotouch_tv)
-xunit_src += $(topdir)/../mcs/class/test-helpers/RemoteExecutorTestBase.Mobile.cs
-else
-ifeq ($(PROFILE),monotouch_watch)
+ifeq ($(PROFILE), xammac_net_4_5)
 xunit_src += $(topdir)/../mcs/class/test-helpers/RemoteExecutorTestBase.Mobile.cs
 else
 xunit_src += $(topdir)/../mcs/class/test-helpers/RemoteExecutorTestBase.Mono.cs $(topdir)/../external/corefx/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.Process.cs
-endif
 endif
 endif
 


### PR DESCRIPTION
Starting another Mono process for the remote executor doesn't work on any of them.

Helps with https://github.com/mono/mono/issues/15328

