### PR TITLE
[System] Keep events from firing from a disposed 'DefaultWatcher' Fil…

### DIFF
--- a/mcs/class/System/System.IO/DefaultWatcher.cs
+++ b/mcs/class/System/System.IO/DefaultWatcher.cs
@@ -128,8 +128,10 @@ namespace System.IO {
 			lock (watches) {
 				data = (DefaultWatcherData) watches [fsw];
 				if (data != null) {
-					data.Enabled = false;
-					data.DisabledTime = DateTime.UtcNow;
+					lock (data.FilesLock) {
+						data.Enabled = false;
+						data.DisabledTime = DateTime.UtcNow;
+					}
 				}
 			}
 		}
@@ -221,7 +223,8 @@ namespace System.IO {
 			}
 
 			lock (data.FilesLock) {
-				IterateAndModifyFilesData (data, directory, dispatch, files);
+				if (data.Enabled)
+					IterateAndModifyFilesData (data, directory, dispatch, files);
 			}
 		}
 

--- a/mcs/class/System/System.IO/FileSystemWatcher.cs
+++ b/mcs/class/System/System.IO/FileSystemWatcher.cs
@@ -420,6 +420,8 @@ namespace System.IO {
 		}
 		private void RaiseEvent (Delegate ev, EventArgs arg, EventType evtype)
 		{
+			if (disposed)
+				return;
 			if (ev == null)
 				return;
 
@@ -497,11 +499,15 @@ namespace System.IO {
 
 		internal void DispatchErrorEvents (ErrorEventArgs args)
 		{
+			if (disposed)
+				return;
 			OnError (args);
 		}
 
 		internal void DispatchEvents (FileAction act, string filename, ref RenamedEventArgs renamed)
 		{
+			if (disposed)
+				return;
 			if (waiting) {
 				lastData = new WaitForChangedResult ();
 			}


### PR DESCRIPTION
…eSystemWatcher

Fixes https://github.com/mono/mono/issues/8747

Also try to stop other implementations from dispatching events past Dispose(), without guaranteeing it

Test is WIP: so far, could not reproduce