### PR TITLE
[2019-06] [llvm] avoid FP elimination on iOS/armv7

### DIFF
--- a/mono/mini/aot-compiler.c
+++ b/mono/mini/aot-compiler.c
@@ -1126,7 +1126,7 @@ arch_init (MonoAotCompile *acfg)
 		if (acfg->aot_opts.mtriple && strstr (acfg->aot_opts.mtriple, "ios")) {
 			g_string_append (acfg->llc_args, " -mattr=+v7");
 #ifdef LLVM_API_VERSION > 100
-			g_string_append (acfg->llc_args, " -exception-model=dwarf");
+			g_string_append (acfg->llc_args, " -exception-model=dwarf -disable-fp-elim");
 #endif
 		}
 


### PR DESCRIPTION
Instead of
```
push    {r4, r5, r6, r7, r10, r11, lr}
```

LLVM will generate
```
push    {r4, r5, r6, r7, lr}
add     r7, sp, #12
push    {r9, r10}
```

Seems like this https://github.com/mono/llvm/commit/a04e9e4a0af16f15ace258e81448b7eeca5ff599 assumes that `-disable-fp-elim` is passed for iOS targets. I wondered why this wouldn't break things for them, but when you run `clang` from Xcode with `-v`, you will discover that its driver passes `-mdisable-fp-elim`.

Together with https://github.com/mono/llvm/pull/48 this fixes crashes with FullAOT+LLVM on iOS 32bit.

Fixes https://github.com/mono/mono/issues/15058

Contributes to https://github.com/mono/mono/issues/9621



Backport of #15617.

/cc @lewurm 