### PR TITLE
[merp] Add API method that whitelists all native libraries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # This line is parsed by tools besides autoconf, such as msvc/mono.winconfig.targets.
 # It should remain in the format they expect.
 #
-MONO_CORLIB_VERSION=90c44d62-c1dd-4a52-bf0e-ac282fcc8be8
+MONO_CORLIB_VERSION=4FA4F5F2-3F97-4A19-9CEB-3AC7A9624CC7
 
 #
 # Put a quoted #define in config.h.

--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,7 @@ MONO_VERSION_BUILD=`echo $VERSION | cut -d . -f 3`
 # This line is parsed by tools besides autoconf, such as msvc/mono.winconfig.targets.
 # It should remain in the format they expect.
 #
-MONO_CORLIB_VERSION=4FA4F5F2-3F97-4A19-9CEB-3AC7A9624CC7
+MONO_CORLIB_VERSION=8E172F4D-82A3-4F55-8D7C-C8E8E0FA58AE
 
 #
 # Put a quoted #define in config.h.

--- a/mcs/class/corlib/Mono/Runtime.cs
+++ b/mcs/class/corlib/Mono/Runtime.cs
@@ -194,6 +194,14 @@ namespace Mono {
 		}
 
 		[MethodImplAttribute (MethodImplOptions.InternalCall)]
+		static extern void RegisterReportingForAllNativeLibs_internal ();
+
+		static void RegisterReportingForAllNativeLibs ()
+		{
+			RegisterReportingForAllNativeLibs_internal ();
+		}
+
+		[MethodImplAttribute (MethodImplOptions.InternalCall)]
 		static extern void RegisterReportingForNativeLib_internal (IntPtr modulePathSuffix, IntPtr moduleName);
 
 		static void RegisterReportingForNativeLib (string modulePathSuffix_str, string moduleName_str)

--- a/mono/metadata/icall-decl.h
+++ b/mono/metadata/icall-decl.h
@@ -171,6 +171,7 @@ ICALL_EXPORT gint64 ves_icall_System_GC_GetAllocatedBytesForCurrentThread (void)
 ICALL_EXPORT int ves_icall_System_Threading_Thread_SystemMaxStackSize (void);
 ICALL_EXPORT int ves_icall_get_method_attributes (MonoMethod* method);
 ICALL_EXPORT void ves_icall_Mono_Runtime_RegisterReportingForNativeLib (const char*, const char*);
+ICALL_EXPORT void ves_icall_Mono_Runtime_RegisterReportingForAllNativeLibs (void);
 ICALL_EXPORT void ves_icall_System_Array_GetGenericValueImpl (MonoArray*, guint32, gpointer);
 ICALL_EXPORT void ves_icall_System_Array_SetGenericValueImpl (MonoArray*, guint32, gpointer);
 ICALL_EXPORT void ves_icall_System_Buffer_MemcpyInternal (gpointer dest, gconstpointer src, gint32 count);

--- a/mono/metadata/icall-def-netcore.h
+++ b/mono/metadata/icall-def-netcore.h
@@ -12,6 +12,7 @@ HANDLES(RUNTIME_2, "EnableMicrosoftTelemetry_internal", ves_icall_Mono_Runtime_E
 HANDLES(RUNTIME_3, "ExceptionToState_internal", ves_icall_Mono_Runtime_ExceptionToState, MonoString, 3, (MonoException, guint64_ref, guint64_ref))
 HANDLES(RUNTIME_4, "GetDisplayName", ves_icall_Mono_Runtime_GetDisplayName, MonoString, 0, ())
 HANDLES(RUNTIME_12, "GetNativeStackTrace", ves_icall_Mono_Runtime_GetNativeStackTrace, MonoString, 1, (MonoException))
+NOHANDLES(ICALL(RUNTIME_21, "RegisterReportingForAllNativeLibs_internal", ves_icall_Mono_Runtime_RegisterReportingForAllNativeLibs))
 NOHANDLES(ICALL(RUNTIME_17, "RegisterReportingForNativeLib_internal", ves_icall_Mono_Runtime_RegisterReportingForNativeLib))
 HANDLES(RUNTIME_13, "SendMicrosoftTelemetry_internal", ves_icall_Mono_Runtime_SendMicrosoftTelemetry, void, 3, (const_char_ptr, guint64, guint64))
 HANDLES(RUNTIME_14, "WriteStateToFile_internal", ves_icall_Mono_Runtime_DumpTelemetry, void, 3, (const_char_ptr, guint64, guint64))

--- a/mono/metadata/icall-def.h
+++ b/mono/metadata/icall-def.h
@@ -148,6 +148,7 @@ HANDLES(RUNTIME_2, "EnableMicrosoftTelemetry_internal", ves_icall_Mono_Runtime_E
 HANDLES(RUNTIME_3, "ExceptionToState_internal", ves_icall_Mono_Runtime_ExceptionToState, MonoString, 3, (MonoException, guint64_ref, guint64_ref))
 HANDLES(RUNTIME_4, "GetDisplayName", ves_icall_Mono_Runtime_GetDisplayName, MonoString, 0, ())
 HANDLES(RUNTIME_12, "GetNativeStackTrace", ves_icall_Mono_Runtime_GetNativeStackTrace, MonoString, 1, (MonoException))
+NOHANDLES(ICALL(RUNTIME_21, "RegisterReportingForAllNativeLibs_internal", ves_icall_Mono_Runtime_RegisterReportingForAllNativeLibs))
 NOHANDLES(ICALL(RUNTIME_17, "RegisterReportingForNativeLib_internal", ves_icall_Mono_Runtime_RegisterReportingForNativeLib))
 HANDLES(RUNTIME_13, "SendMicrosoftTelemetry_internal", ves_icall_Mono_Runtime_SendMicrosoftTelemetry, void, 3, (const_char_ptr, guint64, guint64))
 HANDLES(RUNTIME_14, "WriteStateToFile_internal", ves_icall_Mono_Runtime_DumpTelemetry, void, 3, (const_char_ptr, guint64, guint64))

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -6380,6 +6380,15 @@ ves_icall_Mono_Runtime_RegisterReportingForNativeLib (const char *path_suffix, c
 }
 
 void
+ves_icall_Mono_Runtime_RegisterReportingForAllNativeLibs ()
+{
+#ifndef DISABLE_CRASH_REPORTING
+	if (mono_get_eh_callbacks ()->mono_allow_all_native_libraries)
+		mono_get_eh_callbacks ()->mono_allow_all_native_libraries ();
+#endif
+}
+
+void
 ves_icall_Mono_Runtime_EnableCrashReportingLog (const char *directory, MonoError *error)
 {
 #ifndef DISABLE_CRASH_REPORTING

--- a/mono/metadata/object-internals.h
+++ b/mono/metadata/object-internals.h
@@ -854,6 +854,7 @@ typedef struct {
 	void (*mono_summarize_unmanaged_stack) (MonoThreadSummary *out);
 	void (*mono_summarize_exception) (MonoException *exc, MonoThreadSummary *out);
 	void (*mono_register_native_library) (const char *module_path, const char *module_name);
+	void (*mono_allow_all_native_libraries) (void);
 } MonoRuntimeExceptionHandlingCallbacks;
 
 MONO_COLD void mono_set_pending_exception (MonoException *exc);

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -133,6 +133,7 @@ static void mono_summarize_managed_stack (MonoThreadSummary *out);
 static void mono_summarize_unmanaged_stack (MonoThreadSummary *out);
 static void mono_summarize_exception (MonoException *exc, MonoThreadSummary *out);
 static void mono_crash_reporting_register_native_library (const char *module_path, const char *module_name);
+static void mono_crash_reporting_allow_all_native_libraries (void);
 
 static gboolean
 first_managed (MonoStackFrameInfo *frame, MonoContext *ctx, gpointer addr)
@@ -244,6 +245,7 @@ mono_exceptions_init (void)
 	cbs.mono_summarize_unmanaged_stack = mono_summarize_unmanaged_stack;
 	cbs.mono_summarize_exception = mono_summarize_exception;
 	cbs.mono_register_native_library = mono_crash_reporting_register_native_library;
+	cbs.mono_allow_all_native_libraries = mono_crash_reporting_allow_all_native_libraries;
 
 	if (mono_llvm_only) {
 		cbs.mono_raise_exception = mono_llvm_raise_exception;
@@ -1433,6 +1435,7 @@ typedef struct {
 } MonoLibWhitelistEntry;
 
 static GList *native_library_whitelist;
+static gboolean allow_all_native_libraries = FALSE;
 
 static void
 mono_crash_reporting_register_native_library (const char *module_path, const char *module_name)
@@ -1446,12 +1449,20 @@ mono_crash_reporting_register_native_library (const char *module_path, const cha
 	native_library_whitelist = g_list_append (native_library_whitelist, entry);
 }
 
+static void
+mono_crash_reporting_allow_all_native_libraries ()
+{
+	allow_all_native_libraries = TRUE;
+}
+
 static gboolean
 check_whitelisted_module (const char *in_name, const char **out_module)
 {
 #ifndef MONO_PRIVATE_CRASHES
 		return TRUE;
 #else
+	if (allow_all_native_libraries)
+		return TRUE;
 	if (g_str_has_suffix (in_name, "mono-sgen")) {
 		if (out_module)
 			*out_module = "mono";

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1404,6 +1404,12 @@ mono_crash_reporting_register_native_library (const char *module_path, const cha
 	return;
 }
 
+static void
+mono_crash_reporting_allow_all_native_libraries ()
+{
+	return;
+}
+
 
 #else
 

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1464,11 +1464,11 @@ mono_crash_reporting_allow_all_native_libraries ()
 static gboolean
 check_whitelisted_module (const char *in_name, const char **out_module)
 {
+	g_async_safe_printf ("in_name: %s\n", in_name);
 #ifndef MONO_PRIVATE_CRASHES
 		return TRUE;
 #else
 	if (allow_all_native_libraries) {
-		g_async_safe_printf ("in_name: %s\n", in_name);
 		if (out_module)
 			*out_module = "<external module>";
 		return TRUE;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1468,8 +1468,9 @@ check_whitelisted_module (const char *in_name, const char **out_module)
 		return TRUE;
 #else
 	if (allow_all_native_libraries) {
+		g_async_safe_printf ("in_name: %s\n", in_name);
 		if (out_module)
-			*out_module = in_name;
+			*out_module = "<external module>";
 		return TRUE;
 	}
 	if (g_str_has_suffix (in_name, "mono-sgen")) {

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1461,8 +1461,10 @@ check_whitelisted_module (const char *in_name, const char **out_module)
 #ifndef MONO_PRIVATE_CRASHES
 		return TRUE;
 #else
-	if (allow_all_native_libraries)
+	if (allow_all_native_libraries) {
+		*out_module = in_name;
 		return TRUE;
+	}
 	if (g_str_has_suffix (in_name, "mono-sgen")) {
 		if (out_module)
 			*out_module = "mono";

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -1468,7 +1468,8 @@ check_whitelisted_module (const char *in_name, const char **out_module)
 		return TRUE;
 #else
 	if (allow_all_native_libraries) {
-		*out_module = in_name;
+		if (out_module)
+			*out_module = in_name;
 		return TRUE;
 	}
 	if (g_str_has_suffix (in_name, "mono-sgen")) {

--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -3248,7 +3248,6 @@ MONO_SIG_HANDLER_FUNC (, mono_sigill_signal_handler)
 		return;
 	}
 
-	g_assert_not_reached ();
 }
 
 #if defined(MONO_ARCH_USE_SIGACTION) || defined(HOST_WIN32)

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -454,12 +454,10 @@ mono_native_state_add_frame (MonoStateWriter *writer, MonoFrameSummary *frame)
 	mono_state_writer_printf(writer, "{\n");
 	writer->indent++;
 
-	if (frame->is_managed) {
-		assert_has_space (writer);
-		mono_state_writer_indent (writer);
-		mono_state_writer_object_key (writer, "is_managed");
-		mono_state_writer_printf(writer, "\"%s\",", frame->is_managed ? "true" : "false");
-	}
+	assert_has_space (writer);
+	mono_state_writer_indent (writer);
+	mono_state_writer_object_key (writer, "is_managed");
+	mono_state_writer_printf(writer, "\"%s\",", frame->is_managed ? "true" : "false");
 
 	if (frame->unmanaged_data.is_trampoline) {
 		mono_state_writer_printf(writer, "\n");


### PR DESCRIPTION
This is so that complex consumers such as Visual Studio for Mac can forego attempting to enumerate all loaded libraries, register them one at a time and potentially have to keep the whitelist updated.


<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
