### PR TITLE
g_strnlen for portability.

### DIFF
--- a/mono/eglib/eglib-remap.h
+++ b/mono/eglib/eglib-remap.h
@@ -232,6 +232,7 @@
 #define g_strlcpy monoeg_g_strlcpy
 #define g_strndup monoeg_g_strndup
 #define g_strnfill monoeg_g_strnfill
+#define g_strnlen monoeg_g_strnlen
 #define g_strreverse monoeg_g_strreverse
 #define g_strsplit monoeg_g_strsplit
 #define g_strsplit_set monoeg_g_strsplit_set

--- a/mono/eglib/glib.h
+++ b/mono/eglib/glib.h
@@ -375,6 +375,7 @@ gchar       *g_strchug        (gchar *str);
 gchar       *g_strchomp       (gchar *str);
 void         g_strdown        (gchar *string);
 gchar       *g_strnfill       (gsize length, gchar fill_char);
+gsize        g_strnlen        (const char*, gsize);
 
 void	     g_strdelimit     (char *string, char delimiter, char new_delimiter);
 gchar       *g_strescape      (const gchar *source, const gchar *exceptions);

--- a/mono/eglib/gstr.c
+++ b/mono/eglib/gstr.c
@@ -1069,3 +1069,11 @@ g_utf16_len (const gunichar2 *a)
 	return length;
 #endif
 }
+
+gsize
+g_strnlen (const char* s, gsize n)
+{
+	gsize i;
+	for (i = 0; i < n && s [i]; ++i) ;
+	return i;
+}

--- a/mono/eglib/test/string.c
+++ b/mono/eglib/test/string.c
@@ -190,6 +190,18 @@ test_macros (void)
 	return NULL;
 }
 
+static RESULT
+test_strnlen (void)
+{
+	g_assert (g_strnlen ("abc", 0) == 0);
+	g_assert (g_strnlen ("abc", 1) == 1);
+	g_assert (g_strnlen ("abc", 2) == 2);
+	g_assert (g_strnlen ("abc", 3) == 3);
+	g_assert (g_strnlen ("abc", 4) == 3);
+	g_assert (g_strnlen ("abc", 5) == 3);
+	return NULL;
+}
+
 static Test string_tests [] = {
 	{"append-speed", test_append_speed},
 	{"append_c-speed", test_append_c_speed},
@@ -198,6 +210,7 @@ static Test string_tests [] = {
 	{"truncate", test_truncate },
 	{"append_len", test_appendlen },
 	{"macros", test_macros },
+	{"strnlen", test_strnlen },
 	{NULL, NULL}
 };
 

--- a/mono/mini/cfgdump.c
+++ b/mono/mini/cfgdump.c
@@ -103,7 +103,7 @@ write_int (MonoCompile *cfg, int v)
 static void
 write_string (MonoCompile *cfg, const char *str)
 {
-	size_t len = strnlen (str, 0x2000);
+	const size_t len = g_strnlen (str, 0x2000);
 	write_int (cfg, (int) len);
 
 	gunichar2 *u = u8to16 (str);
@@ -163,7 +163,7 @@ add_pool_entry (MonoCompile *cfg, ConstantPoolEntry *entry)
 
 			write_string (cfg, mono_inst_name (insn->opcode));
 			GString *insndesc = mono_print_ins_index_strbuf (-1, insn);
-			int len = strnlen (insndesc->str, 0x2000);
+			const int len = g_strnlen (insndesc->str, 0x2000);
 #define CUTOFF 40
 			if (len > CUTOFF) {
 				insndesc->str[CUTOFF] = '\0';


### PR DESCRIPTION
See https://github.com/mistydemeo/tigerbrew/issues/605.
See https://www.gnu.org/software/gnulib/manual/html_node/strnlen.html.

Note that the patch referred to using max and strlen isn't quite right.
strnlen is not supposed to scan past the specified number of bytes.