### PR TITLE
Cleanup mono_threads_platform_get_stack_bounds.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3950,7 +3950,6 @@ else
 	AC_CHECK_DECLS(InterlockedIncrement64, [], [], [[#include <windows.h>]])
 	AC_CHECK_DECLS(InterlockedAdd, [], [], [[#include <windows.h>]])
 	AC_CHECK_DECLS(InterlockedAdd64, [], [], [[#include <windows.h>]])
-	AC_CHECK_DECLS(__readfsdword, [], [], [[#include <windows.h>]])
 fi
 
 dnl socklen_t check

--- a/winconfig.h
+++ b/winconfig.h
@@ -85,10 +85,6 @@
    and to 0 if you don't. */
 #define HAVE_DECL_INTERLOCKEDINCREMENT64 1
 
-/* Define to 1 if you have the declaration of `__readfsdword',
-   and to 0 if you don't. */
-#define HAVE_DECL___READFSDWORD 1
-
 /* Define to 1 if you have the `getaddrinfo' function. */
 #define HAVE_GETADDRINFO 1
 


### PR DESCRIPTION
And fix mingw warning unused function __readfsdword.
Prepare for, but don't actually, bumping minimum from Windows 7 to Windows 8. If there is a UWP-specific build, it will use the Windows 8 version.