### PR TITLE
Remove configure cruft -- Interlocked and GetProcessId.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3943,13 +3943,6 @@ else
 	], [
 		AC_MSG_RESULT(no)
 	])
-
-	AC_CHECK_DECLS(InterlockedExchange64, [], [], [[#include <windows.h>]])
-	AC_CHECK_DECLS(InterlockedCompareExchange64, [], [], [[#include <windows.h>]])
-	AC_CHECK_DECLS(InterlockedDecrement64, [], [], [[#include <windows.h>]])
-	AC_CHECK_DECLS(InterlockedIncrement64, [], [], [[#include <windows.h>]])
-	AC_CHECK_DECLS(InterlockedAdd, [], [], [[#include <windows.h>]])
-	AC_CHECK_DECLS(InterlockedAdd64, [], [], [[#include <windows.h>]])
 fi
 
 dnl socklen_t check

--- a/winconfig.h
+++ b/winconfig.h
@@ -61,30 +61,6 @@
 /* Have /dev/random */
 #define HAVE_CRYPT_RNG 1
 
-/* Define to 1 if you have the declaration of `InterlockedAdd',
-   and to 0 if you don't. */
-#define HAVE_DECL_INTERLOCKEDADD 1
-
-/* Define to 1 if you have the declaration of `InterlockedAdd64',
-   and to 0 if you don't. */
-#define HAVE_DECL_INTERLOCKEDADD64 1
-
-/* Define to 1 if you have the declaration of `InterlockedCompareExchange64',
-   and to 0 if you don't. */
-#define HAVE_DECL_INTERLOCKEDCOMPAREEXCHANGE64 1
-
-/* Define to 1 if you have the declaration of `InterlockedDecrement64',
-   and to 0 if you don't. */
-#define HAVE_DECL_INTERLOCKEDDECREMENT64 1
-
-/* Define to 1 if you have the declaration of `InterlockedExchange64',
-   and to 0 if you don't. */
-#define HAVE_DECL_INTERLOCKEDEXCHANGE64 1
-
-/* Define to 1 if you have the declaration of `InterlockedIncrement64',
-   and to 0 if you don't. */
-#define HAVE_DECL_INTERLOCKEDINCREMENT64 1
-
 /* Define to 1 if you have the `getaddrinfo' function. */
 #define HAVE_GETADDRINFO 1
 
@@ -93,9 +69,6 @@
 
 /* Define to 1 if you have the `getprotobyname' function. */
 #define HAVE_GETPROTOBYNAME 1
-
-/* Define to 1 if you have the `GetProcessId' function. */
-#define HAVE_GETPROCESSID 1
 
 /* Have inet_ntop */
 #define HAVE_INET_NTOP 1


### PR DESCRIPTION
They are never checked and all relevant systems have all of them.