### PR TITLE
Fix build on Autoconf 2.63

### DIFF
--- a/m4/ax_append_flag.m4
+++ b/m4/ax_append_flag.m4
@@ -51,6 +51,10 @@
 
 #serial 7
 
+m4_ifndef([AS_VAR_APPEND],
+  [m4_define([AS_VAR_APPEND],
+      [$1=$$1$2])])
+
 AC_DEFUN([AX_APPEND_FLAG],
 [dnl
 AC_PREREQ(2.63)dnl for _AC_LANG_PREFIX and AS_VAR_SET_IF

--- a/m4/rh6-compat.m4
+++ b/m4/rh6-compat.m4
@@ -1,0 +1,3 @@
+m4_ifndef([AS_VAR_APPEND],
+  [AC_DEFUN([AS_VAR_APPEND],[AC_PREREQ([2.63])dnl
+[$1=$$1$2]])])

--- a/m4/rh6-compat.m4
+++ b/m4/rh6-compat.m4
@@ -1,3 +1,0 @@
-m4_ifndef([AS_VAR_APPEND],
-  [AC_DEFUN([AS_VAR_APPEND],[AC_PREREQ([2.63])dnl
-[$1=$$1$2]])])


### PR DESCRIPTION
This was broken in e7f9dbe73c3344c96a13892a6c4c45f8e5c35aa3, because
AS_VAR_APPEND does not exist until v2.63b (?!)