### PR TITLE
[netcore] Fix IsAssignableFrom

### DIFF
--- a/mono/metadata/class.c
+++ b/mono/metadata/class.c
@@ -3820,10 +3820,15 @@ mono_class_is_assignable_from_checked (MonoClass *klass, MonoClass *oklass, gboo
 		if (m_class_is_valuetype (eoclass)) {
 			if ((eclass == mono_defaults.enum_class) || 
 			    (eclass == m_class_get_parent (mono_defaults.enum_class)) ||
-			    (eclass == mono_defaults.object_class)) {
+			    (!m_class_is_valuetype (eclass))) {
 				*result = FALSE;
 				return;
 			}
+		}
+
+		if (mono_class_is_nullable (eclass) ^ mono_class_is_nullable (eoclass)) {
+			*result = FALSE;
+			return;
 		}
 
 		mono_class_is_assignable_from_checked (eclass, eoclass, result, error);

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -190,6 +190,7 @@
 -nomethod System.Linq.Expressions.Tests.LambdaMultiplyNullableTests.LambdaMultiplyNullableFloatTest
 -nomethod System.Linq.Expressions.Tests.LambdaMultiplyTests.LambdaMultiplyFloatTest
 -nomethod System.Linq.Expressions.Tests.LambdaDivideTests.LambdaDivideFloatTest
+-nomethod System.Linq.Expressions.Tests.OpAssign.AssignmentEquivalentsWithMemberAccess
 
 ####################################################################
 ##  System.Linq.Parallel.Tests

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -1068,10 +1068,6 @@
 # https://github.com/mono/mono/issues/15318
 -nomethod System.Reflection.Tests.ConstructorInfoInvokeArrayTests.Invoke_LargeDimensionalArrayConstructor
 
-# Assertion expects false, but we return true
-# https://github.com/mono/mono/issues/15080
--nomethod System.Reflection.Tests.TypeTests.IsAssignableFrom
-
 # Throws a lot of different exceptions
 # https://github.com/mono/mono/issues/15319
 -nomethod System.Reflection.Tests.PropertyInfoTests.GetGetMethod_GetSetMethod
@@ -1134,22 +1130,6 @@
 ##  System.Reflection.MetadataLoadContext.Tests
 ####################################################################
 
--nomethod System.Reflection.Tests.TypeTests_AmbiguityResolution_NoParameterBinding.*
--nomethod System.Reflection.Tests.TypeTests_GetInterface.*
-
-# System.InvalidOperationException : System.Reflection.Tests.IdentityTests is not a GenericTypeDefinition. MakeGenericType may only be called on a type for which Type.IsGenericTypeDefinition is true.
-# https://github.com/mono/mono/issues/15336
--nomethod System.Reflection.Tests.IdentityTests.*
-
-# Assertion... Expected: 1, Actual: 0
-# https://github.com/mono/mono/issues/15337
--nomethod System.Reflection.Tests.TypeTests_GetMember.*
-
-# Expected: Explicit
-# Actual:   Auto
-# https://github.com/mono/mono/issues/15338
--nomethod System.Reflection.Tests.TypeTests_StructLayoutAttribute.*
-
 # System.InvalidOperationException : Sequence contains no elements
 # https://github.com/mono/mono/issues/15339
 # 
@@ -1158,52 +1138,13 @@
 -nomethod System.Reflection.Tests.ParameterTests.TestPseudoCustomAttributes
 -nomethod System.Reflection.Tests.TypeTests.TestExplicitOffsetPseudoCustomAttribute
 
-# Assertion failure: Expected: 4, Actual: 0
-# https://github.com/mono/mono/issues/15341
--nomethod System.Reflection.Tests.TypeTests_HiddenEvents.GetEventHidesEventsBySimpleNameCompare
-
-# Multiple failures... 
-# System.Reflection.Tests.TypeInfoDeclaredNestedTypeTests.TestNestedTypes10 
-# Expected: typeof(System.Reflection.Tests.TestNestGeneric<>)
-# Actual:   typeof(System.Reflection.Tests.TestNestGeneric<>)
-# https://github.com/mono/mono/issues/15342
--nomethod System.Reflection.Tests.TypeInfoDeclaredNestedTypeTests.*
--nomethod System.Reflection.Tests.TypeInfoPropertyTests.TestIsNested
--nomethod System.Reflection.Tests.TypeInfoPropertyTests.TestIsNestedPublic
-
-# Assertion failure: Expected: 5, Actual: 0
-# https://github.com/mono/mono/issues/15343
--nomethod System.Reflection.Tests.TypeTests_PrefixingOnlyAllowedOnGetMember.TestGetMemberAll
-
 # Assertion failure: Expected: true, Actual: false
 # https://github.com/mono/mono/issues/15344
 -nomethod System.Reflection.Tests.TypeInvariants.TestInvariantCode
 
-# Assertion failure: Expected: 2, Actual: 1
-# https://github.com/mono/mono/issues/15345
--nomethod System.Reflection.Tests.TypeTests_HiddenMethods.GetMethodDoesNotHideHiddenMethods
-
-# Expected: String[] ["Item", "MyInstanceThenStaticProp", "MyStaticThenInstanceProp", "MyStringThenDoubleProp"]
-# Actual:   String[] []
-# https://github.com/mono/mono/issues/15346
--nomethod System.Reflection.Tests.TypeTests_HiddenProperties.GetPropertyHidesPropertiesByNameAndSigAndCallingConventionCompare
-
-# Expected: typeof(Outer+Inner)
-# Actual:   typeof(Outer+Inner+ReallyInner)
-# https://github.com/mono/mono/issues/15347
--nomethod System.Reflection.Tests.AssemblyTests.CrossAssemblyTypeRefToNestedType
-
-# Assertion failure: Expected: 4, Actual: 0
-# https://github.com/mono/mono/issues/15348
--nomethod System.Reflection.Tests.TypeTests_HiddenFields.GetFieldDoesNotHideHiddenFields
-
 # System.TypeLoadException : Could not find type 'Typ\\W\[t\]S\+r\*n\&e\,haracters' in assembly ''.
 # https://github.com/mono/mono/issues/15349
 -nomethod System.Reflection.Tests.TypeTests.TypesWithStrangeCharacters
-
-# Assertion failure: Expected: 1, Actual: 0
-# https://github.com/mono/mono/issues/15351
--nomethod System.Reflection.Tests.TypeTests_HiddenTestingOrder.HideDetectionHappensAfterPrivateInBaseClassChecks
 
 # flaky tests
 -nomethod System.Reflection.Tests.TypeInfoDeclaredImplementedInterfacesTests.*

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -1235,3 +1235,6 @@
 -nomethod System.Diagnostics.TraceSourceTests.SwitchClassTests.PruneTest
 -nomethod ManagedTests.DynamicCSharp.Conformance.dynamic.context.*
 -nomethod System.Net.Sockets.Tests.DisposedSocket.NonDisposedSocket_SafeHandlesCollected
+
+# Flaky tests https://github.com/mono/mono/issues/15238
+-nonamespace System.Security.Cryptography.Pkcs


### PR DESCRIPTION
Mono used to return `true` for these three cases (see System.Reflection.Tests.TypeTests.IsAssignableFrom tests):
```csharp
using System.Reflection;
using Xunit;

namespace ConsoleApp
{
    public static class Program
    {
        static void Main(string[] args)
        {
            Assert.False(typeof(TI_Interface1[]).GetTypeInfo().IsAssignableFrom(
                         typeof(TI_StructWithInterface[]).GetTypeInfo()));

            Assert.False(typeof(int?[]).GetTypeInfo().IsAssignableFrom(
                         typeof(int[]).GetTypeInfo()));

            Assert.False(typeof(int[]).GetTypeInfo().IsAssignableFrom(
                         typeof(int?[]).GetTypeInfo()));
            
        }
    }
    
    public interface TI_Interface1 { }
    public struct TI_StructWithInterface : TI_Interface1 { }
}
```
Fixes https://github.com/mono/mono/issues/10848
Fixes https://github.com/mono/mono/issues/15080

Unrelated  System.Reflection.MetadataLoadContext.Tests tests that don't fail anymore:
Close https://github.com/mono/mono/issues/15351
Close https://github.com/mono/mono/issues/15348
Close https://github.com/mono/mono/issues/15347
Close https://github.com/mono/mono/issues/15346
Close https://github.com/mono/mono/issues/15345
Close https://github.com/mono/mono/issues/15343
Close https://github.com/mono/mono/issues/15342
Close https://github.com/mono/mono/issues/15341
Close https://github.com/mono/mono/issues/15338
Close https://github.com/mono/mono/issues/15337
Close https://github.com/mono/mono/issues/15336