### PR TITLE
[2019-06] Fix offsets tool for Android NDK r20

### DIFF
--- a/tools/offsets-tool/MonoAotOffsetsDumper.cs
+++ b/tools/offsets-tool/MonoAotOffsetsDumper.cs
@@ -130,7 +130,8 @@ namespace CppSharp
 
             foreach (var target in AndroidTargets)
                 target.Defines.AddRange (new string[] { "HOST_ANDROID",
-                    "TARGET_ANDROID", "MONO_CROSS_COMPILE", "USE_MONO_CTX"
+                    "TARGET_ANDROID", "MONO_CROSS_COMPILE", "USE_MONO_CTX",
+                    "BIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD"
                 });
         }
 


### PR DESCRIPTION
**NOTE: please backport to 2019-06, it is required to allow Xamarin.Android to switch to that branc**

Context: https://github.com/xamarin/xamarin-android/pull/3155

Android NDK r20 contains a header file (`ioctl.h`) with this code:

    int ioctl(int __fd, int __request, ...);

    #if !defined(BIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD)
    /* enable_if(1) just exists to break overloading ties. */
    int ioctl(int __fd, unsigned __request, ...) __overloadable __enable_if(1, "") __RENAME(ioctl);
    #endif

The `_RENAME` macro is defined as `__asm__(x)` and serves the purpose of
replacing an existing symbol with the new one, decorated with the keyword.
Unfortunately, Mono's `offsets-tool` doesn't parse the header properly as
`CppSharp` doesn't understand `__asm__`:

    Processing triple: armv7-none-linux-androideabi
    Error parsing '/Users/rodo/git/xa2/external/mono/mono/metadata/metadata-cross-helpers.c'
    /Users/rodo/android-toolchain/ndk/sysroot/usr/include/bits/ioctl.h(60,5): error: conflicting types for 'ioctl'
    Error parsing '/Users/rodo/git/xa2/external/mono/mono/mini/mini-cross-helpers.c'
    /Users/rodo/android-toolchain/ndk/sysroot/usr/include/bits/ioctl.h(60,5): error: conflicting types for 'ioctl'
    make: *** [/Users/rodo/git/xa2/external/mono/sdks/builds/android-cross-arm-release/armv7-linux-android.h] Error 1

The workaround, implemented in this commit, is to define the
`BIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD` macro thus removing the "conflicting"
declaration from the picture, which changes nothing from the offset tool's point
of view and lets us process the headers in NDK r20 properly.
<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->


Backport of #15648.

/cc @lambdageek @grendello