### PR TITLE
Misc AIX/PASE tweaks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -525,7 +525,9 @@ case "$host" in
 		with_gc=sgen
 		need_link_unlink=yes
 		use_sigposix=yes
-		dnl the valloc call to alloc the guard page bombs out, even with extending the data area
+		dnl Similar limitation to macOS about the first thread and the
+		dnl guard page, except sometimes the runtime hangs. Disable for
+		dnl now until cause can be determined or it seems OK enough.
 		with_sigaltstack=no
 		dnl use pthread TLS, __thread has issues with the compiler flags we use
 		with_tls=pthread

--- a/configure.ac
+++ b/configure.ac
@@ -3330,6 +3330,7 @@ if test x$host_win32 = xno; then
 	AC_CHECK_DECL(F_DUPFD_CLOEXEC,   [AC_DEFINE(HAVE_F_DUPFD_CLOEXEC, 1, [F_DUPFD_CLOEXEC])], [], [[#include <fcntl.h>]])
 
 	# AC_CHECK_FUNC(getifaddrs,           [AC_DEFINE(HAVE_GETIFADDRS, 1, [getifaddrs])]) # already done above
+	AC_CHECK_FUNC(Qp2getifaddrs,     [AC_DEFINE(HAVE_QP2GETIFADDRS, 1, [Qp2getifaddrs])])
 
 	AC_CHECK_FUNC(lseek64,           [AC_DEFINE(HAVE_LSEEK64, 1, [lseek64])])
 	AC_CHECK_FUNC(mmap64,            [AC_DEFINE(HAVE_MMAP64, 1, [mmap64])])

--- a/mono/metadata/w32socket.c
+++ b/mono/metadata/w32socket.c
@@ -97,6 +97,14 @@
 #ifdef HAVE_GETIFADDRS
 // <net/if.h> must be included before <ifaddrs.h>
 #include <ifaddrs.h>
+#elif defined(HAVE_QP2GETIFADDRS)
+/* Bizarrely, IBM i implements this, but AIX doesn't, so on i, it has a different name... */
+#include <as400_types.h>
+#include <as400_protos.h>
+/* Defines to just reuse ifaddrs code */
+#define ifaddrs ifaddrs_pase
+#define freeifaddrs Qp2freeifaddrs
+#define getifaddrs Qp2getifaddrs
 #endif
 
 #if defined(_MSC_VER) && G_HAVE_API_SUPPORT(HAVE_CLASSIC_WINAPI_SUPPORT | HAVE_UWP_WINAPI_SUPPORT)
@@ -1970,7 +1978,7 @@ ipaddress_handle_to_struct_in6_addr (MonoObjectHandle ipaddr)
 static int
 get_local_interface_id (int family)
 {
-#if !defined(HAVE_GETIFADDRS) || !defined(HAVE_IF_NAMETOINDEX)
+#if !(defined(HAVE_GETIFADDRS) || defined(HAVE_QP2GETIFADDRS)) || !defined(HAVE_IF_NAMETOINDEX)
 	return 0;
 #else
 	struct ifaddrs *ifap = NULL, *ptr;

--- a/mono/mini/mini-exceptions.c
+++ b/mono/mini/mini-exceptions.c
@@ -3046,10 +3046,14 @@ mono_setup_altstack (MonoJitTlsData *tls)
 	size_t stsize = 0;
 	stack_t sa;
 	guint8 *staddr = NULL;
-#ifdef TARGET_OSX
+#if defined(TARGET_OSX) || defined(_AIX)
 	/*
 	 * On macOS Mojave we are encountering a bug when changing mapping for main thread
 	 * stack pages. Stack overflow on main thread will kill the app.
+	 *
+	 * AIX seems problematic as well; it gives ENOMEM for mprotect and valloc, if we
+	 * do this for thread 1 with its stack at the top of memory. Other threads seem
+	 * fine for the altstack guard page, though.
 	 */
 	gboolean disable_stack_guard = mono_threads_platform_is_main_thread ();
 #else

--- a/mono/utils/mono-threads-aix.c
+++ b/mono/utils/mono-threads-aix.c
@@ -38,4 +38,11 @@ mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize)
 	*stsize = pi.__pi_stackend - pi.__pi_stackaddr;
 }
 
+gboolean
+mono_threads_platform_is_main_thread (void)
+{
+	/* returns 1 on main thread, even if the kernel tid is diff */
+	return pthread_self () == 1;
+}
+
 #endif

--- a/mono/utils/networking-posix.c
+++ b/mono/utils/networking-posix.c
@@ -29,6 +29,15 @@
 #ifdef HAVE_GETIFADDRS
 #include <ifaddrs.h>
 #endif
+#ifdef HAVE_QP2GETIFADDRS
+/* Bizarrely, IBM i implements this, but AIX doesn't, so on i, it has a different name... */
+#include <as400_types.h>
+#include <as400_protos.h>
+/* Defines to just reuse ifaddrs code */
+#define ifaddrs ifaddrs_pase
+#define freeifaddrs Qp2freeifaddrs
+#define getifaddrs Qp2getifaddrs
+#endif
 
 #include <mono/utils/networking.h>
 #include <mono/utils/mono-threads-coop.h>
@@ -276,7 +285,7 @@ done:
 	return result;
 }
 
-#elif defined(HAVE_GETIFADDRS)
+#elif defined(HAVE_GETIFADDRS) || defined(HAVE_QP2GETIFADDRS)
 
 void *
 mono_get_local_interfaces (int family, int *interface_count)


### PR DESCRIPTION
Minor changes/patches I had sitting around for a few weeks, mostly preparing for things to be done in the future. Basically:

1. Set up the infrastructure for sigaltstack. Turns out it had similar limitations to macOS. This is useful in the future, but don't enable it just yet. There's a few deadlocks in the crash reporter with it on that I'd want to look at before turning it on by default..

2. Set up stuff for i getifaddrs equivalent. This will be useful for NetworkInface when it gets converted to CoreFX. Unfortunately for me, none of the codepaths using this are actually compiled in out of the box, because SIOCGIFADDR is hoisted above getiffaddrs in `networking-posix`, which may not be preferred, and the other usage is only for macOS/FreeBSD (though I haven't determined if a similar problem exists for i too).