### PR TITLE
[sdb] Prevent runtime crash when accessing invalid pointer value

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest-app.cs
@@ -1984,7 +1984,18 @@ public class Tests : TestsBase, ITest2
 	}
 
 	public static unsafe void pointer_arguments (int* a, BlittableStruct* s) {
+		int i = 12;
+		int *j = &i;
+		int *p = (int*)0x00000007;
+		int *np = (int*)0;
 		*a = 0;
+
+		pointer_get_value ();
+	}
+
+	[MethodImplAttribute (MethodImplOptions.NoInlining)]
+	static void pointer_get_value ()
+	{
 	}
 
 	[MethodImplAttribute (MethodImplOptions.NoInlining)]

--- a/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
+++ b/mcs/class/Mono.Debugger.Soft/Test/dtest.cs
@@ -4833,7 +4833,6 @@ public class DebuggerTests
 
 		AssertValue(2, pointerValue2.Value);
 
-
 		param = frame.Method.GetParameters()[1];
 		Assert.AreEqual("BlittableStruct*", param.ParameterType.Name);
 
@@ -4848,6 +4847,33 @@ public class DebuggerTests
 		f = structValue.Fields[1];
 		AssertValue (3.0, f);
 
+		run_until ("pointer_get_value");
+		frame = e.Thread.GetFrames () [1];
+
+		var j = frame.Method.GetLocal ("j");
+		var p = frame.Method.GetLocal ("p");
+		var np = frame.Method.GetLocal ("np");
+
+		pointerValue = frame.GetValue (j) as PointerValue;
+		Assert.AreEqual ("Int32*", pointerValue.Type.Name);
+		AssertValue(12, pointerValue.Value);
+
+		void AccessProperty(Value v)
+		{
+		}
+
+		pointerValue = frame.GetValue (p) as PointerValue;
+		Assert.AreEqual ("Int32*", pointerValue.Type.Name);
+		AssertThrows<CommandException> (() => AccessProperty(pointerValue.Value));
+
+		pointerValue = frame.GetValue (np) as PointerValue;
+		Assert.AreEqual ("Int32*", pointerValue.Type.Name);
+		Assert.AreEqual (0L, pointerValue.Address);
+
+		// We should throw here, you can't dereference null, but we historically
+		// return null for a zero address.
+		// AssertThrows<CommandException> (() => AccessProperty(pointerValue.Value));
+		Assert.AreEqual (null, pointerValue.Value);
 	}
 
 	[Test]


### PR DESCRIPTION
Fix #15612