### PR TITLE
[2019-06] Add TypeForwards for FileSystemName & CryptographicOperations

### DIFF
--- a/mcs/class/System/Assembly/AssemblyInfo.cs
+++ b/mcs/class/System/Assembly/AssemblyInfo.cs
@@ -92,3 +92,5 @@ using System.Runtime.InteropServices;
 
 [assembly: TypeForwardedTo (typeof (System.Collections.Generic.Stack<>))]
 [assembly: TypeForwardedTo (typeof (System.Collections.Generic.Queue<>))]
+[assembly: TypeForwardedTo (typeof (System.IO.Enumeration.FileSystemName))]
+[assembly: TypeForwardedTo (typeof (System.Security.Cryptography.CryptographicOperations))]


### PR DESCRIPTION
Add TypeForwards for:

* System.IO.Enumeration.FileSystemName
* System.Security.Cryptography.CryptographicOperations

Since these were removed in NS 2.1


Backport of #15652.

/cc @akoeplinger @steveisok