### PR TITLE
[netcore] Make System.Linq.Expressions.Tests.BindTests.GlobalField Pass

### DIFF
--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -88,10 +88,6 @@
 # https://github.com/mono/mono/issues/14912
 -nomethod System.Linq.Expressions.Tests.ArrayBoundsTests.NewArrayBounds*
 
-# Expected exception to be thrown.  None is
-# https://github.com/mono/mono/issues/14917
--nomethod System.Linq.Expressions.Tests.BindTests.GlobalField
-
 # Exceptions are different.
 # https://github.com/mono/mono/issues/14918
 -nomethod System.Linq.Expressions.Tests.BindTests.ConstantField

--- a/netcore/System.Private.CoreLib/src/System.Reflection/RuntimeFieldInfo.cs
+++ b/netcore/System.Private.CoreLib/src/System.Reflection/RuntimeFieldInfo.cs
@@ -168,7 +168,8 @@ namespace System.Reflection
 		}
 		public override Type DeclaringType {
 			get {
-				return GetParentType (true);
+				Type parentType = GetParentType (true);
+				return parentType.Name != "<Module>" ? parentType : null;
 			}
 		}
 		public override string Name {

--- a/netcore/System.Private.CoreLib/src/System.Reflection/RuntimeFieldInfo.cs
+++ b/netcore/System.Private.CoreLib/src/System.Reflection/RuntimeFieldInfo.cs
@@ -261,7 +261,8 @@ namespace System.Reflection
 		}
 
 		void CheckGeneric () {
-			if (DeclaringType.ContainsGenericParameters)
+			Type declaringType = DeclaringType;
+			if (declaringType != null && declaringType.ContainsGenericParameters)
 				throw new InvalidOperationException ("Late bound operations cannot be performed on fields with types for which Type.ContainsGenericParameters is true.");
 	    }
 


### PR DESCRIPTION
`Expression.Bind` should throw `ArgumentException` if called with `FieldInfo` for a global field. The exception is thrown from validation of the (null) `DeclaringType` (see https://github.com/dotnet/corefx/pull/15318).
Mono returns `"<Module>"` in this case and doesn't throw so the test fails. 

Fixes #14917 .