### PR TITLE
Fix use after free.

### DIFF
--- a/mono/mini/mini-runtime.c
+++ b/mono/mini/mini-runtime.c
@@ -4749,8 +4749,6 @@ mini_cleanup (MonoDomain *domain)
 	if (profile_options)
 		g_ptr_array_free (profile_options, TRUE);
 
-	free_jit_tls_data (mono_tls_get_jit_tls ());
-
 	mono_icall_cleanup ();
 
 	mono_runtime_cleanup_handlers ();
@@ -4758,6 +4756,7 @@ mini_cleanup (MonoDomain *domain)
 #ifndef MONO_CROSS_COMPILE
 	mono_domain_free (domain, TRUE);
 #endif
+	free_jit_tls_data (mono_tls_get_jit_tls ());
 
 #ifdef ENABLE_LLVM
 	if (mono_use_llvm)


### PR DESCRIPTION
Fix use of freed memory.
Move the free later, on the assumption that the free itself doesn't use memory now freed before it.

valgrind:
    
    ==29462== Invalid read of size 8
    ==29462==    at 0x139078: mono_get_lmf (mini-runtime.c:748)
    ==29462==    by 0x1917E7: mono_thread_state_init (mini-exceptions.c:3626)
    ==29462==    by 0x63DA1B: mono_threads_enter_gc_safe_region_unbalanced_with_info (mono-threads-coop.c:333)
    ==29462==    by 0x63D8F6: mono_threads_enter_gc_safe_region_with_info (mono-threads-coop.c:293)
    ==29462==    by 0x638E8B: mono_thread_info_suspend_lock_with_info (mono-threads.c:1415)
    ==29462==    by 0x638F34: mono_thread_info_suspend_lock (mono-threads.c:1431)
    ==29462==    by 0x566FB7: acquire_gc_locks (sgen-stw.c:87)
    ==29462==    by 0x567036: sgen_client_stop_world (sgen-stw.c:111)
    ==29462==    by 0x5A083E: sgen_stop_world (sgen-gc.c:3824)
    ==29462==    by 0x56A65C: mono_gc_clear_domain (sgen-mono.c:842)
    ==29462==    by 0x3C57BD: mono_domain_free (domain.c:1131)
    ==29462==    by 0x143BFD: mini_cleanup (mini-runtime.c:4754)

    ==29462==  Address 0x5ee0610 is 16 bytes inside a block of size 2,152 free'd
    ==29462==    at 0x4C30D3B: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==29462==    by 0x64881B: monoeg_g_free (gmem.c:83)
    ==29462==    by 0x139451: free_jit_tls_data (mini-runtime.c:952)
    ==29462==    by 0x143BE2: mini_cleanup (mini-runtime.c:4747)
    ==29462==    by 0x14EDEE: mono_main (driver.c:2590)
    ==29462==    by 0x136225: mono_main_with_options (main.c:50)
    ==29462==    by 0x136FF5: main (main.c:410)

    ==29462==  Block was alloc'd at
    ==29462==    at 0x4C31B25: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==29462==    by 0x648976: monoeg_g_calloc (gmem.c:131)
    ==29462==    by 0x6489DD: monoeg_malloc0 (gmem.c:138)
    ==29462==    by 0x139388: setup_jit_tls_data (mini-runtime.c:916)
    ==29462==    by 0x139504: mono_thread_attach_cb (mini-runtime.c:982)
    ==29462==    by 0x4CFC66: mono_thread_attach (threads.c:1532)
    ==29462==    by 0x3B7AAB: mono_runtime_init_checked (appdomain.c:323)
    ==29462==    by 0x141BEF: mini_init (mini-runtime.c:4349)
    ==29462==    by 0x14EA71: mono_main (driver.c:2518)
    ==29462==    by 0x136225: mono_main_with_options (main.c:50)
    ==29462==    by 0x136FF5: main (main.c:410)