### PR TITLE
[netcore] decimal should have alignment=8

### DIFF
--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -5272,12 +5272,20 @@ ves_icall_System_Runtime_InteropServices_Marshal_OffsetOf (MonoReflectionTypeHan
 		return 0;
 	}
 	if (MONO_HANDLE_IS_NULL (field_name)) {
+#ifdef ENABLE_NETCORE
 		mono_error_set_argument_null (error, NULL, "");
+#else
+		mono_error_set_argument_null (error, "fieldName", "");
+#endif
 		return 0;
 	}
 
 	if (!m_class_is_runtime_type (MONO_HANDLE_GET_CLASS (ref_type))) {
+#ifdef ENABLE_NETCORE
 		mono_error_set_argument (error, "fieldName", "");
+#else
+		mono_error_set_argument (error, "type", "");
+#endif
 		return 0;
 	}
 
@@ -5693,7 +5701,6 @@ mono_marshal_load_type_info (MonoClass* klass)
 			size = mono_marshal_type_size (field->type, info->fields [j].mspec, 
 						       &align, TRUE, m_class_is_unicode (klass));
 			align = m_class_get_packing_size (klass) ? MIN (m_class_get_packing_size (klass), align): align;
-
 			min_align = MAX (align, min_align);
 			info->fields [j].offset = info->native_size;
 			info->fields [j].offset += align - 1;

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -5949,7 +5949,9 @@ mono_marshal_type_size (MonoType *type, MonoMarshalSpec *mspec, guint32 *align,
 #ifdef ENABLE_NETCORE
 		else if (strcmp (m_class_get_name_space (klass), "System") == 0 && 
 			strcmp (m_class_get_name (klass), "Decimal") == 0) {
-			// Special case: despite the fact Decimal consists of 4 int32 fields, the alignment should be 8 on x64
+			
+			// Special case: Managed Decimal consists of 4 int32 fields, the alignment should be 8 on x64 to follow 
+			// https://github.com/dotnet/coreclr/blob/4450e5ca663b9e66c20e6f9751c941efa3716fde/src/vm/methodtablebuilder.cpp#L9753
 			*align = MONO_ABI_ALIGNOF (gpointer);
 			return mono_class_native_size (klass, NULL);
 		}

--- a/mono/metadata/marshal.c
+++ b/mono/metadata/marshal.c
@@ -5946,7 +5946,7 @@ mono_marshal_type_size (MonoType *type, MonoMarshalSpec *mspec, guint32 *align,
 			*align = 16;
 			return 16;
 		} 
-#if ENABLE_NETCORE
+#ifdef ENABLE_NETCORE
 		else if (strcmp (m_class_get_name_space (klass), "System") == 0 && 
 			strcmp (m_class_get_name (klass), "Decimal") == 0) {
 			// Special case: despite the fact Decimal consists of 4 int32 fields, the alignment should be 8 on x64

--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -572,18 +572,6 @@
 -nomethod System.Runtime.InteropServices.Tests.OffsetOfTests.OffsetOf_NotMarshallable_ThrowsArgumentException
 -nomethod System.Runtime.InteropServices.Tests.SizeOfTests.SizeOf_InvalidType_ThrowsArgumentException
 
-# Check that the name in the argument exception is null or different
-# https://github.com/mono/mono/issues/15090
--nomethod System.Runtime.InteropServices.Tests.OffsetOfTests.OffsetOf_NullFieldName_ThrowsArgumentNullException
-
-# Returns type instead of expected fieldName 
-# https://github.com/mono/mono/issues/15091
--nomethod System.Runtime.InteropServices.Tests.OffsetOfTests.OffsetOf_NonRuntimeField_ThrowsArgumentException
-
-# Hardcodes offsets
-# https://github.com/mono/mono/issues/15092
--nomethod System.Runtime.InteropServices.Tests.OffsetOfTests.OffsetOf_Decimal_ReturnsExpected
-
 # Wants exception messages to be non-empty
 # https://github.com/mono/mono/issues/15093
 -nomethod System.Runtime.InteropServices.Tests.GetExceptionForHRTests.GetExceptionForHR_ErrorInfo_ReturnsValidException


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/15092 (see my comment there)
Fixes https://github.com/mono/mono/issues/15091
Fixes https://github.com/mono/mono/issues/15090

btw, do I need to wrap minor changes with `#if ENABLE_NETCORE`? such as different strings in exceptions.