### PR TITLE
[netcore] Use the strict loader

### DIFF
--- a/mono/mini/main-core.c
+++ b/mono/mini/main-core.c
@@ -227,6 +227,12 @@ int STDAPICALLTYPE coreclr_initialize (const char* exePath, const char* appDomai
 	if (native_lib_paths != NULL)
 		mono_set_pinvoke_search_directories (native_lib_paths->dir_count, native_lib_paths->dirs);
 
+	/*
+	 * Don't use Mono's legacy assembly name matching behavior - respect
+	 * the requested version and public key token.
+	 */
+	mono_loader_set_strict_strong_names (TRUE);
+
 	return 0;
 }
 


### PR DESCRIPTION
Mono historically was quite lax in how it resolved assembly references - it
would pick the first assembly with a matching simple name.  The "strict"
mode (available in framework Mono with `--assembly-loader=strict`) follows the
spec behavior: the version and public key token of the candidate assembly must
match what is requested.
