### PR TITLE
[interp] Use correctly-sized writes and reads in Unsafe.AddByteOffset and Unsafe.ByteOffset

### DIFF
--- a/mono/mini/interp/interp.c
+++ b/mono/mini/interp/interp.c
@@ -4534,14 +4534,14 @@ interp_exec_method_full (InterpFrame *frame, ThreadContext *context, FrameClause
 		}
 		MINT_IN_CASE(MINT_INTRINS_UNSAFE_ADD_BYTE_OFFSET) {
 			sp -= 2;
-			sp [0].data.p = (guint8*)sp [0].data.p + sp [1].data.i;
+			sp [0].data.p = (guint8*)sp [0].data.p + sp [1].data.nati;
 			sp ++;
 			++ip;
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_INTRINS_UNSAFE_BYTE_OFFSET) {
 			sp -= 2;
-			sp [0].data.i = (guint8*)sp [1].data.p - (guint8*)sp [0].data.p;
+			sp [0].data.nati = (guint8*)sp [1].data.p - (guint8*)sp [0].data.p;
 			sp ++;
 			++ip;
 			MINT_IN_BREAK;


### PR DESCRIPTION
The truncated store to the top of the stack in`MINT_INTRINS_UNSAFE_BYTE_OFFSET` could cause the upper bytes of the address used as the first argument to `ByteOffset` to linger, yielding inaccurate (and usually excessively large) offsets on systems where `sizeof(void *) > sizeof(guint32)`; this made
`System.Text.Unicode.Utf8Utility.GetPointerToFirstInvalidByte` return nonsense results.

The truncation in `MINT_INTRINS_UNSAFE_ADD_BYTE_OFFSET` hasn't, as far as I know, caused any test failures. But `AddByteOffset` takes an `IntPtr` as its second argument, not an `int`.

Fixes #14847.
