### PR TITLE
[ios] Ensure Local TimeZone Id is Set For TimeZoneInfo.Local

### DIFF
--- a/mcs/class/corlib/System/TimeZoneInfo.MonoTouch.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.MonoTouch.cs
@@ -71,7 +71,7 @@ namespace System {
 				}
 			}
 		}
-				
+
 		[DllImport ("__Internal")]
 		extern static IntPtr xamarin_timezone_get_names (ref int count);
 

--- a/mcs/class/corlib/System/TimeZoneInfo.MonoTouch.cs
+++ b/mcs/class/corlib/System/TimeZoneInfo.MonoTouch.cs
@@ -44,10 +44,13 @@ namespace System {
 
 	public partial class TimeZoneInfo {
 
+		[DllImport ("__Internal")]
+		extern static string xamarin_timezone_get_local_name ();
+
 		static TimeZoneInfo CreateLocal ()
 		{
 			using (Stream stream = GetMonoTouchData (null)) {
-				return BuildFromStream ("Local", stream);
+				return BuildFromStream (xamarin_timezone_get_local_name (), stream);
 			}
 		}
 
@@ -68,7 +71,7 @@ namespace System {
 				}
 			}
 		}
-		
+				
 		[DllImport ("__Internal")]
 		extern static IntPtr xamarin_timezone_get_names (ref int count);
 

--- a/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
@@ -115,6 +115,12 @@ namespace MonoTests.System
 				Assert.IsTrue (true);
 			}
 
+			[Test]
+			public void LocalIdCheck ()
+			{				
+				Assert.IsTrue (TimeZoneInfo.Local.Id != "Local", "Local timezone id should not be \"Local\"");				
+			}
+
 			[DllImport ("libc")]
 			private static extern int readlink (string path, byte[] buffer, int buflen);
 
@@ -131,10 +137,8 @@ namespace MonoTests.System
 				} catch (DllNotFoundException e) {
 					return;
 				}
-#if !MONOTOUCH && !XAMMAC
-				// this assumption is incorrect for the TimeZoneInfo.MonoTouch.cs implementation (iOS, tvOS, watchOS and XamMac Modern)
+				
 				Assert.IsTrue (TimeZoneInfo.Local.Id != "Local", "Local timezone id should not be \"Local\"");
-#endif
 			}
 		}
 

--- a/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
+++ b/mcs/class/corlib/Test/System/TimeZoneInfoTest.cs
@@ -115,18 +115,13 @@ namespace MonoTests.System
 				Assert.IsTrue (true);
 			}
 
-			[Test]
-			public void LocalIdCheck ()
-			{				
-				Assert.IsTrue (TimeZoneInfo.Local.Id != "Local", "Local timezone id should not be \"Local\"");				
-			}
-
 			[DllImport ("libc")]
 			private static extern int readlink (string path, byte[] buffer, int buflen);
 
 			[Test] // Covers #24958
 			public void LocalId ()
 			{
+#if !MONOTOUCH && !XAMMAC
 				byte[] buf = new byte [512];
 
 				var path = "/etc/localtime";
@@ -137,6 +132,7 @@ namespace MonoTests.System
 				} catch (DllNotFoundException e) {
 					return;
 				}
+#endif
 				
 				Assert.IsTrue (TimeZoneInfo.Local.Id != "Local", "Local timezone id should not be \"Local\"");
 			}

--- a/sdks/ios/runtime/runtime.m
+++ b/sdks/ios/runtime/runtime.m
@@ -367,8 +367,8 @@ xamarin_timezone_get_local_name ()
 {
 	NSTimeZone *tz = nil;
 	tz = [NSTimeZone localTimeZone];
-	NSString *name = [tz name];
-	return strdup ([name UTF8String]);
+	NSString *name = [tz name];	
+	return (name != nil) ? strdup ([name UTF8String]) : strdup ("Local");
 }
 
 char**

--- a/sdks/ios/runtime/runtime.m
+++ b/sdks/ios/runtime/runtime.m
@@ -337,6 +337,10 @@ mono_ios_runtime_init (void)
 //
 // ICALLS used by the mobile profile of mscorlib
 //
+// NOTE: The timezone functions are duplicated in XI, so if you're going to modify here, you have to 
+// modify there. 
+//
+// See in XI runtime/xamarin-support.m
 
 void*
 xamarin_timezone_get_data (const char *name, int *size)
@@ -353,6 +357,20 @@ xamarin_timezone_get_data (const char *name, int *size)
 	void* result = malloc (*size);
 	memcpy (result, data.bytes, *size);
 	return result;
+}
+
+//
+// Returns the geopolitical region ID of the local timezone.
+// Previously we just provided the data to TimeZoneInfo.MonoTouch.cs and that
+// defaulted the ID to "Local", which is incorrect. 
+
+const char *
+xamarin_timezone_get_local_name ()
+{
+	NSTimeZone *tz = nil;
+	tz = [NSTimeZone localTimeZone];
+	NSString *name = [tz name];
+	return strdup ([name UTF8String]);
 }
 
 char**

--- a/sdks/ios/runtime/runtime.m
+++ b/sdks/ios/runtime/runtime.m
@@ -361,8 +361,6 @@ xamarin_timezone_get_data (const char *name, int *size)
 
 //
 // Returns the geopolitical region ID of the local timezone.
-// Previously we just provided the data to TimeZoneInfo.MonoTouch.cs and that
-// defaulted the ID to "Local", which is incorrect. 
 
 const char *
 xamarin_timezone_get_local_name ()


### PR DESCRIPTION
Expands on https://github.com/mono/mono/pull/15667 by adding a null check on the name.