### PR TITLE
Add configure flag to disable GAC support; disable GAC in netcore

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1721,7 +1721,7 @@ AM_CONDITIONAL(ENABLE_STATIC_GCC_LIBS, test "x$enable_static_gcc_libs" = "xyes")
 AC_ARG_ENABLE(minimal, [  --enable-minimal=LIST      drop support for LIST subsystems.
      LIST is a comma-separated list from: aot, profiler, decimal, pinvoke, debug, appdomains, verifier, 
      reflection_emit, reflection_emit_save, large_code, logging, com, ssa, generics, attach, jit, interpreter, simd, soft_debug, perfcounters, normalization, desktop_loader, shared_perfcounters, remoting,
-	 security, lldb, mdb, assert_messages, cleanup, sgen_marksweep_conc, sgen_split_nursery, sgen_gc_bridge, sgen_debug_helpers, sockets.],
+	 security, lldb, mdb, assert_messages, cleanup, sgen_marksweep_conc, sgen_split_nursery, sgen_gc_bridge, sgen_debug_helpers, sockets, gac.],
 [
 	for feature in `echo "$enable_minimal" | sed -e "s/,/ /g"`; do
 		eval "mono_feature_disable_$feature='yes'"
@@ -1926,6 +1926,11 @@ fi
 if test "x$mono_feature_disable_sockets" = "xyes"; then
 	AC_DEFINE(DISABLE_SOCKETS, 1, [Disable sockets])
 	AC_MSG_NOTICE([Disabled sockets])
+fi
+
+if test "x$mono_feature_disable_gac" = "xyes"; then
+	AC_DEFINE(DISABLE_GAC, 1, [Disable GAC])
+	AC_MSG_NOTICE([Disabled GAC support])
 fi
 
 AC_ARG_ENABLE(executables, [  --disable-executables disable the build of the runtime executables], enable_executables=$enableval, enable_executables=yes)

--- a/configure.ac
+++ b/configure.ac
@@ -1346,6 +1346,7 @@ elif test x$with_runtime_preset = xnetcore; then
    mono_feature_disable_security='yes'
    mono_feature_disable_mdb='yes'
    mono_feature_disable_com='yes'
+   mono_feature_disable_gac='yes'
    disable_mono_native=yes
    support_boehm=no
 elif test x$with_runtime_preset = xnet_4_x; then


### PR DESCRIPTION
netcore doesn't have a GAC.  Some other embedded Mono configurations could benefit from this, too.