### PR TITLE
[ios] Nil Check to Ensure Local TimeZone Id is Set For TimeZoneInfo.Local

### DIFF
--- a/sdks/ios/runtime/runtime.m
+++ b/sdks/ios/runtime/runtime.m
@@ -368,7 +368,7 @@ xamarin_timezone_get_local_name ()
 	NSTimeZone *tz = nil;
 	tz = [NSTimeZone localTimeZone];
 	NSString *name = [tz name];
-	return strdup ([name UTF8String]);
+	return (name != nil) ? strdup ([name UTF8String]) : strdup ("Local");
 }
 
 char**


### PR DESCRIPTION
In runtime.m added nil check in xamarin_timezone_get_local_name. Returns Local as the Id in the case of nil.