### PR TITLE
[2019-06] [debugger] Don't list finalizer gc thread if it's not executing managed code

### DIFF
--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -263,6 +263,8 @@ struct _DebuggerTlsData {
 	// The state that the debugger expects the thread to be in
 	MonoDebuggerThreadState thread_state;
 	MonoStopwatch step_time;
+
+	gboolean gc_finalizing;
 };
 
 typedef struct {
@@ -665,6 +667,10 @@ static void assembly_load (MonoProfiler *prof, MonoAssembly *assembly);
 
 static void assembly_unload (MonoProfiler *prof, MonoAssembly *assembly);
 
+static void gc_finalizing (MonoProfiler *prof);
+
+static void gc_finalized (MonoProfiler *prof);
+
 static void emit_assembly_load (gpointer assembly, gpointer user_data);
 
 static void emit_type_load (gpointer key, gpointer type, gpointer user_data);
@@ -974,7 +980,9 @@ debugger_agent_init (void)
 	mono_profiler_set_assembly_unloading_callback (prof, assembly_unload);
 	mono_profiler_set_jit_done_callback (prof, jit_done);
 	mono_profiler_set_jit_failed_callback (prof, jit_failed);
-
+	mono_profiler_set_gc_finalizing_callback (prof, gc_finalizing);
+	mono_profiler_set_gc_finalized_callback (prof, gc_finalized);
+	
 	mono_native_tls_alloc (&debugger_tls_id, NULL);
 
 	/* Needed by the hash_table_new_type () call below */
@@ -3361,6 +3369,32 @@ emit_type_load (gpointer key, gpointer value, gpointer user_data)
 {
 	process_profiler_event (EVENT_KIND_TYPE_LOAD, value);
 }
+
+
+static void gc_finalizing (MonoProfiler *prof)
+{
+	DebuggerTlsData *tls;
+
+	if (is_debugger_thread ())
+		return;
+
+	tls = (DebuggerTlsData *)mono_native_tls_get_value (debugger_tls_id);
+	g_assert (tls);
+	tls->gc_finalizing = TRUE;
+}
+
+static void gc_finalized (MonoProfiler *prof)
+{
+	DebuggerTlsData *tls;
+
+	if (is_debugger_thread ())
+		return;
+
+	tls = (DebuggerTlsData *)mono_native_tls_get_value (debugger_tls_id);
+	g_assert (tls);
+	tls->gc_finalizing = FALSE;
+}
+
 
 static char*
 strdup_tolower (char *s)
@@ -6011,24 +6045,17 @@ clear_types_for_assembly (MonoAssembly *assembly)
 	mono_loader_unlock ();
 }
 
-//Count threads removing the thread of finalizer GC if it is not executing a managed code
+
 static void
-count_thread_checking_finalizer_gc (gpointer key, gpointer value, gpointer remove_finalizer)
+count_thread_check_gc_finalizer (gpointer key, gpointer value, gpointer user_data)
 {
-	gboolean *ret = (gboolean *)remove_finalizer;
 	MonoThread *thread = (MonoThread *)value;
+	gboolean *ret = (gboolean *)user_data;
 	if (mono_gc_is_finalizer_internal_thread(thread->internal_thread)) {
 		DebuggerTlsData *tls = (DebuggerTlsData *)mono_g_hash_table_lookup (thread_to_tls, thread->internal_thread);
-		if (tls->frame_count == 0) {
+		if (!tls->gc_finalizing) { //GC Finalizer is not running some finalizer code, so ignore it
 			*ret = TRUE;
 			return;
-		}
-		if (tls->frame_count) {
-			StackFrame* frame = tls->frames [0];
-			if (!frame->managed) {
-				*ret = TRUE;
-				return;
-			}
 		}
 	}
 }
@@ -6038,18 +6065,14 @@ add_thread (gpointer key, gpointer value, gpointer user_data)
 {
 	MonoThread *thread = (MonoThread *)value;
 	Buffer *buf = (Buffer *)user_data;
+	if (mono_gc_is_finalizer_internal_thread(thread->internal_thread)) {
+		DebuggerTlsData *tls = (DebuggerTlsData *)mono_g_hash_table_lookup (thread_to_tls, thread->internal_thread);
+		if (!tls->gc_finalizing) //GC Finalizer is not running some finalizer code, so ignore it
+			return;
+	}
 	buffer_add_objid (buf, (MonoObject*)thread);
 }
 
-static void
-add_thread_without_finalizer_gc (gpointer key, gpointer value, gpointer user_data)
-{
-	MonoThread *thread = (MonoThread *)value;
-	if (mono_gc_is_finalizer_internal_thread(thread->internal_thread))
-		return;
-	Buffer *buf = (Buffer *)user_data;
-	buffer_add_objid (buf, (MonoObject*)thread);
-}
 
 static ErrorCode
 do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, guint8 *p, guint8 **endp)
@@ -6608,19 +6631,14 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 	}
 	case CMD_VM_ALL_THREADS: {
 		// FIXME: Domains
-		gboolean removeFinalizerGC = FALSE;
+		gboolean remove_gc_finalizing;
 		mono_loader_lock ();
-		mono_g_hash_table_foreach (tid_to_thread_obj, count_thread_checking_finalizer_gc, &removeFinalizerGC);
 		int count = mono_g_hash_table_size (tid_to_thread_obj);
-		if (removeFinalizerGC) {
+		mono_g_hash_table_foreach (tid_to_thread_obj, count_thread_check_gc_finalizer, &remove_gc_finalizing);
+		if (remove_gc_finalizing)
 			count--;
-			buffer_add_int (buf,count);
-			mono_g_hash_table_foreach (tid_to_thread_obj, add_thread_without_finalizer_gc, buf);
-		}
-		else {
-			buffer_add_int (buf,count); 
-			mono_g_hash_table_foreach (tid_to_thread_obj, add_thread, buf);
-		}
+		buffer_add_int (buf, count);
+		mono_g_hash_table_foreach (tid_to_thread_obj, add_thread, buf);
 		
 		mono_loader_unlock ();
 		break;

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -6012,7 +6012,9 @@ clear_types_for_assembly (MonoAssembly *assembly)
 static void
 add_thread (gpointer key, gpointer value, gpointer user_data)
 {
-	MonoInternalThread *thread = (MonoInternalThread *)value;
+	MonoThread *thread = (MonoThread *)value;
+	if (mono_gc_is_finalizer_internal_thread(thread->internal_thread))
+		return;
 	Buffer *buf = (Buffer *)user_data;
 
 	buffer_add_objid (buf, (MonoObject*)thread);
@@ -6576,7 +6578,7 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 	case CMD_VM_ALL_THREADS: {
 		// FIXME: Domains
 		mono_loader_lock ();
-		buffer_add_int (buf, mono_g_hash_table_size (tid_to_thread_obj));
+		buffer_add_int (buf, mono_g_hash_table_size (tid_to_thread_obj) - 1); // -1 to remove the Finalizer GC Thread
 		mono_g_hash_table_foreach (tid_to_thread_obj, add_thread, buf);
 		mono_loader_unlock ();
 		break;

--- a/mono/mini/debugger-agent.c
+++ b/mono/mini/debugger-agent.c
@@ -149,7 +149,6 @@ typedef struct
 	 * the frame can become invalid.
 	 */
 	gboolean has_ctx;
-	gboolean managed;
 } StackFrame;
 
 typedef struct _InvokeData InvokeData;
@@ -3183,7 +3182,6 @@ process_frame (StackFrameInfo *info, MonoContext *ctx, gpointer user_data)
 	frame->flags = flags;
 	frame->interp_frame = info->interp_frame;
 	frame->frame_addr = info->frame_addr;
-	frame->managed = info->managed;
 	if (info->reg_locations)
 		memcpy (frame->reg_locations, info->reg_locations, MONO_MAX_IREGS * sizeof (host_mgreg_t*));
 	if (ctx) {


### PR DESCRIPTION
The example that reproduces the bug does this:
var thread = vm.GetThreads()[0];
greetingValue = program.InvokeMethod(thread, greeting, new Value[0]) as StringMirror;

But sometimes the Thread[0] was the MainThread of the program and it works, and other times was the GC Finalizer, but when it tries to run something on GC Finalizer thread, the thread is not suspended and throws an exception.
In the fix I removed the Finalizer thread of the list that is returned when CMD_VM_ALL_THREADS is called if the thread is not executing a managed code.

Fixes #13311

Backport of #15618.

/cc @marek-safar @thaystg