### PR TITLE
[2019-06] Fix marshalling bugs for StringBuilder parameters

### DIFF
--- a/mono/metadata/marshal-ilgen.c
+++ b/mono/metadata/marshal-ilgen.c
@@ -5483,7 +5483,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 				}
 
 				mono_mb_emit_byte (mb, CEE_STIND_REF);
-			} else {
+			} else if (t->attrs & PARAM_ATTRIBUTE_OUT || !(t->attrs & PARAM_ATTRIBUTE_IN)) {
 				mono_mb_emit_ldarg (mb, argnum);
 				mono_mb_emit_ldloc (mb, conv_arg);
 

--- a/mono/tests/libtest.c
+++ b/mono/tests/libtest.c
@@ -1253,6 +1253,14 @@ mono_test_marshal_stringbuilder_ref (char **s)
 	return 0;
 }
 
+LIBTEST_API void STDCALL  
+mono_test_marshal_stringbuilder_utf16_tolower (short *s, int n)
+{
+	for (int i = 0; i < n; i++)
+		s[i] = tolower(s[i]);
+}
+
+
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wc++-compat"

--- a/mono/tests/pinvoke2.cs
+++ b/mono/tests/pinvoke2.cs
@@ -335,6 +335,12 @@ public unsafe class Tests {
 	[DllImport ("libtest", EntryPoint="mono_test_marshal_stringbuilder_out_unicode", CharSet=CharSet.Unicode)]
 	public static extern void mono_test_marshal_stringbuilder_out_unicode (out StringBuilder sb);
 
+	[DllImport ("libtest", EntryPoint="mono_test_marshal_stringbuilder_utf16_tolower", CharSet=CharSet.Unicode)]
+	public static extern void mono_test_marshal_stringbuilder_utf16_tolower (StringBuilder sb, int len);
+
+	[DllImport ("libtest", EntryPoint="mono_test_marshal_stringbuilder_utf16_tolower", CharSet=CharSet.Unicode)]
+	public static extern void mono_test_marshal_stringbuilder_utf16_tolower_in ([In] StringBuilder sb, int len);
+
 	[DllImport ("libtest", EntryPoint="mono_test_asany")]
 	public static extern int mono_test_asany ([MarshalAs (UnmanagedType.AsAny)] object o, int what);
 
@@ -936,6 +942,28 @@ public unsafe class Tests {
 		
 		if (sb.ToString () != "This is my message.  Isn't it nice?")
 			return 2;  
+		return 0;
+	}
+
+	public static int test_0_marshal_stringbuilder_utf16_tolower () {
+		StringBuilder sb = new StringBuilder (3);
+		sb.Append ("ABC").Append ("DEF");
+		
+		mono_test_marshal_stringbuilder_utf16_tolower (sb, sb.Length);
+		if (sb.ToString () != "abcdef")
+			return 1;
+
+		return 0;
+	}
+
+	public static int test_0_marshal_stringbuilder_utf16_tolower_in () {
+		StringBuilder sb = new StringBuilder (3);
+		sb.Append ("ABC").Append ("DEF");
+		
+		mono_test_marshal_stringbuilder_utf16_tolower_in (sb, sb.Length);
+		if (sb.ToString () != "ABCDEF")
+			return 1;
+
 		return 0;
 	}
 


### PR DESCRIPTION
Fixes #15366 and #15306.

- Fixes NULL termination of `StringBuilder` to UTF-16 marshalling. Additionally an extra NULL is added as defense-in-depth protection for incorrect handling in native calls. This extra NULL adds protection when trying to marshal the NULL-terminated string back and the native function doesn't null-terminate at the size of the buffer.
- Fixes marshalling back from UTF-16/UTF-8 buffers into chunked `StringBuilder`.
- Fixes missing `mono_marshal_free` call causing a memory leak when marshalling `StringBuilder` to UTF-16 and back.
- Skips marshalling back to `StringBuilder` when the parameter doesn't have `[Out]` attribute.

Unit tests are still TBD. Not sure where to put them and how to structure them. Any help would be appreciated. /cc @vargaz @EgorBo 

Backport of #15392.

/cc @marek-safar @filipnavara