### PR TITLE
[corlib] Foward System.Type.GetTypeFromProgID() to the correct function.

### DIFF
--- a/mcs/class/corlib/Test/System/TypeTest.cs
+++ b/mcs/class/corlib/Test/System/TypeTest.cs
@@ -1950,6 +1950,29 @@ namespace MonoTests.System
 			else
 				throw new COMException ();
 		}
+
+		[Test]
+		public void TypeFromProgID ()
+		{
+			try {
+				Type t1 = Type.GetTypeFromProgID("file");
+
+				Type t2 = Type.GetTypeFromProgID("bogus_progid");
+
+				Assert.AreEqual (t1.FullName, "System.__ComObject");
+
+				if (!isMono && (Environment.OSVersion.Platform == PlatformID.Win32Windows ||
+					Environment.OSVersion.Platform == PlatformID.Win32NT))
+					Activator.CreateInstance(t1);
+
+				Assert.AreEqual (t2.FullName, "System.__ComObject");
+
+				Assert.AreNotEqual (t1, t2);
+			}
+			catch (NotImplementedException) {
+				// Currently fails on Mono (unmanaged activation is not supported)
+			}
+		}
 #endif
 		[Test]
 		public void ExerciseFilterName ()

--- a/mcs/class/corlib/corert/Type.cs
+++ b/mcs/class/corlib/corert/Type.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 namespace System {
 	partial class Type {
 		public static Type GetTypeFromCLSID (Guid clsid, string server, bool throwOnError) => RuntimeType.GetTypeFromCLSIDImpl (clsid, server, throwOnError);
-		public static Type GetTypeFromProgID (string progID, string server, bool throwOnError) => RuntimeType.GetTypeFromProgID (progID, server, throwOnError);
+		public static Type GetTypeFromProgID (string progID, string server, bool throwOnError) => RuntimeType.GetTypeFromProgIDImpl (progID, server, throwOnError);
 
 		internal const string DefaultTypeNameWhenMissingMetadata = "UnknownType";		
 		


### PR DESCRIPTION
Fixes a stack overflow when running Staxel under wine-mono.