### PR TITLE
There is no need to zero static data, and it is racy.

### DIFF
--- a/mono/utils/mono-merp.c
+++ b/mono/utils/mono-merp.c
@@ -49,7 +49,9 @@ os_version_string (void)
 	static const char *version_string;
 
 	if (!version_string) {
-		memset (&name, 0, sizeof (name)); // WSL does not always nul terminate.
+		// WSL does not always nul terminate. WSL was fixed February 2018.
+		// Restore memset if variable made non-static.
+		//memset (&name, 0, sizeof (name));
 
 		if (uname (&name) >= 0)
 			version_string = name.release;


### PR DESCRIPTION
if there are multiple threads calling (unlikely).
This zeroing was made moot by 470354fa817716739615ff0c6cfefca42ec8b385 January 2019.