### PR TITLE
[netcore] Clean up rsp-file

### DIFF
--- a/netcore/CoreFX.issues.rsp
+++ b/netcore/CoreFX.issues.rsp
@@ -1119,11 +1119,9 @@
 ##  System.Reflection.MetadataLoadContext.Tests
 ####################################################################
 
-# System.InvalidOperationException : Sequence contains no elements
-# https://github.com/mono/mono/issues/15339
-# 
 # https://github.com/mono/mono/issues/15340
--nomethod System.Reflection.Tests.CustomAttributeTests.*
+-nomethod System.Reflection.Tests.CustomAttributeTests.TestDllImportPseudoCustomAttribute
+-nomethod System.Reflection.Tests.CustomAttributeTests.TestMarshalAsPseudoCustomAttribute
 -nomethod System.Reflection.Tests.ParameterTests.TestPseudoCustomAttributes
 -nomethod System.Reflection.Tests.TypeTests.TestExplicitOffsetPseudoCustomAttribute
 


### PR DESCRIPTION
`System.Reflection.Tests.CustomAttributeTests.CustomAttributeNamedArguments_Field` test from https://github.com/mono/mono/issues/15339 passes locally with latest master on macOS.

`System.Reflection.Tests.CustomAttributeTests.TestDllImportPseudoCustomAttribute` and 
`System.Reflection.Tests.CustomAttributeTests.TestMarshalAsPseudoCustomAttribute` fail with the same exception (see https://github.com/mono/mono/issues/15340).