### PR TITLE
[merp] Use a separate program as the hang supervisor.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6061,6 +6061,7 @@ AC_CONFIG_FILES([po/mcs/Makefile.in])
 AC_CONFIG_FILES([acceptance-tests/microbench-perf.sh],[chmod +x acceptance-tests/microbench-perf.sh])
 AC_CONFIG_FILES([runtime/mono-wrapper],[chmod +x runtime/mono-wrapper])
 AC_CONFIG_FILES([runtime/monodis-wrapper],[chmod +x runtime/monodis-wrapper])
+AC_CONFIG_FILES([runtime/bin/mono-hang-watchdog],[chmod +x runtime/bin/mono-hang-watchdog])
 
 AC_CONFIG_COMMANDS([runtime/etc/mono/1.0/machine.config],
 [   depth=../../../..
@@ -6681,6 +6682,7 @@ tools/Makefile
 tools/locale-builder/Makefile
 tools/sgen/Makefile
 tools/pedump/Makefile
+tools/mono-hang-watchdog/Makefile
 runtime/Makefile
 msvc/Makefile
 po/Makefile

--- a/mono/metadata/icall.c
+++ b/mono/metadata/icall.c
@@ -6382,7 +6382,7 @@ void
 ves_icall_Mono_Runtime_EnableCrashReportingLog (const char *directory, MonoError *error)
 {
 #ifndef DISABLE_CRASH_REPORTING
-	mono_summarize_set_timeline_dir (directory);
+	mono_threads_summarize_init (directory);
 #endif
 }
 

--- a/mono/metadata/threads-types.h
+++ b/mono/metadata/threads-types.h
@@ -550,6 +550,9 @@ typedef struct {
 	MonoContext ctx_mem;
 } MonoThreadSummary;
 
+void
+mono_threads_summarize_init (const char *timeline_dir);
+
 gboolean
 mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gboolean silent, gboolean signal_handler_controller, gchar *mem, size_t provided_size);
 

--- a/mono/metadata/threads.c
+++ b/mono/metadata/threads.c
@@ -58,6 +58,7 @@
 #include <mono/metadata/exception-internals.h>
 #include <mono/utils/mono-state.h>
 #include <mono/metadata/w32subset.h>
+#include <mono/metadata/mono-config.h>
 
 #ifdef HAVE_SYS_WAIT_H
 #include <sys/wait.h>
@@ -6262,7 +6263,6 @@ mono_threads_summarize_one (MonoThreadSummary *out, MonoContext *ctx)
 	return success;
 }
 
-#define TIMEOUT_CRASH_REPORTER_FATAL 30
 #define MAX_NUM_THREADS 128
 typedef struct {
 	gint32 has_owner; // state of this memory
@@ -6278,7 +6278,7 @@ typedef struct {
 	gboolean silent; // print to stdout
 } SummarizerGlobalState;
 
-#if defined(HAVE_KILL) && !defined(HOST_ANDROID) && defined(HAVE_WAITPID) && ((!defined(HOST_DARWIN) && defined(SYS_fork)) || HAVE_FORK)
+#if defined(HAVE_KILL) && !defined(HOST_ANDROID) && defined(HAVE_WAITPID) && defined(HAVE_EXECVE) && ((!defined(HOST_DARWIN) && defined(SYS_fork)) || HAVE_FORK)
 #define HAVE_MONO_SUMMARIZER_SUPERVISOR 1
 #endif
 
@@ -6289,8 +6289,9 @@ typedef struct {
 } SummarizerSupervisorState;
 
 #ifndef HAVE_MONO_SUMMARIZER_SUPERVISOR
-static void
-summarizer_supervisor_wait (SummarizerSupervisorState *state)
+
+void
+mono_threads_summarize_init (const char *timeline_dir)
 {
 	return;
 }
@@ -6309,23 +6310,14 @@ summarizer_supervisor_end (SummarizerSupervisorState *state)
 }
 
 #else
-static void
-summarizer_supervisor_wait (SummarizerSupervisorState *state)
+static const char *hang_watchdog_path;
+
+void
+mono_threads_summarize_init (const char *timeline_dir)
 {
-	sleep (TIMEOUT_CRASH_REPORTER_FATAL);
-
-	// If we haven't been SIGKILL'ed yet, we signal our parent
-	// and then exit
-#ifdef HAVE_KILL
-	g_async_safe_printf("Crash Reporter has timed out, sending SIGSEGV\n");
-	kill (state->pid, SIGSEGV);
-#else
-	g_error ("kill () is not supported by this platform");
-#endif
-
-	exit (1);
+	hang_watchdog_path = g_build_filename (mono_get_config_dir (), "..", "bin", "mono-hang-watchdog", NULL);
+	mono_summarize_set_timeline_dir (timeline_dir);
 }
-
 static pid_t
 summarizer_supervisor_start (SummarizerSupervisorState *state)
 {
@@ -6352,6 +6344,13 @@ summarizer_supervisor_start (SummarizerSupervisorState *state)
 
 	if (pid != 0)
 		state->supervisor_pid = pid;
+	else {
+		char pid_str[20]; // pid is a uint64_t, 20 digits max in decimal form
+		sprintf (pid_str, "%llu", (uint64_t)state->pid);
+		const char *const args[] = { hang_watchdog_path, pid_str, NULL };
+		execve (args[0], (char * const*)args, NULL); // run 'mono-hang-watchdog [pid]'
+		g_assert_not_reached ();
+	}
 
 	return pid;
 }
@@ -6665,8 +6664,6 @@ mono_threads_summarize (MonoContext *ctx, gchar **out, MonoStackHash *hashes, gb
 				g_assert (mem);
 				success = mono_threads_summarize_execute_internal (ctx, out, hashes, silent, mem, provided_size, TRUE);
 				summarizer_supervisor_end (&synch);
-			} else {
-				summarizer_supervisor_wait (&synch);
 			}
 
 			if (!already_async)

--- a/mono/utils/mono-state.c
+++ b/mono/utils/mono-state.c
@@ -15,6 +15,7 @@
 #include <mono/utils/mono-state.h>
 #include <mono/utils/mono-threads-coop.h>
 #include <mono/metadata/object-internals.h>
+#include <mono/metadata/mono-config-dirs.h>
 
 #include <sys/param.h>
 #include <fcntl.h>

--- a/runtime/bin/mono-hang-watchdog.in
+++ b/runtime/bin/mono-hang-watchdog.in
@@ -1,0 +1,3 @@
+#! /bin/sh
+r='@mono_build_root@'
+exec "$r/tools/mono-hang-watchdog/mono-hang-watchdog" "$@"

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,3 +1,3 @@
-SUBDIRS = locale-builder sgen pedump
+SUBDIRS = locale-builder sgen pedump mono-hang-watchdog
 
 

--- a/tools/mono-hang-watchdog/Makefile.am
+++ b/tools/mono-hang-watchdog/Makefile.am
@@ -1,0 +1,13 @@
+
+AM_CPPFLAGS = $(SHARED_CFLAGS)
+
+if DISABLE_EXECUTABLES
+bin_PROGRAMS =
+else
+bin_PROGRAMS = mono-hang-watchdog
+endif
+
+CFLAGS = $(filter-out @CXX_REMOVE_CFLAGS@, @CFLAGS@)
+mono_hang_watchdog_CFLAGS = @CXX_ADD_CFLAGS@
+
+mono_hang_watchdog_SOURCES = mono-hang-watchdog.c

--- a/tools/mono-hang-watchdog/Makefile.am
+++ b/tools/mono-hang-watchdog/Makefile.am
@@ -8,6 +8,5 @@ bin_PROGRAMS = mono-hang-watchdog
 endif
 
 CFLAGS = $(filter-out @CXX_REMOVE_CFLAGS@, @CFLAGS@)
-mono_hang_watchdog_CFLAGS = @CXX_ADD_CFLAGS@
 
 mono_hang_watchdog_SOURCES = mono-hang-watchdog.c

--- a/tools/mono-hang-watchdog/mono-hang-watchdog.c
+++ b/tools/mono-hang-watchdog/mono-hang-watchdog.c
@@ -1,0 +1,51 @@
+/* Given a external process' id as argument, the program waits for a set timeout then attempts to abort that process */
+/* Used by the Mono runtime's crash reporting. */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <errno.h>
+#include <unistd.h>
+
+#include "config.h"
+
+#ifdef HAVE_SIGNAL_H
+#include <signal.h>
+#endif
+
+#define TIMEOUT 30
+
+static char* program_name;
+void program_exit (int exit_code, const char* message);
+
+int main (int argc, char* argv[])
+{
+    program_name = argv [0];
+    if (argc != 2)
+        program_exit (1, "Please provide one argument (pid)");
+    errno = 0;
+    pid_t pid = (pid_t)strtoul (argv [1], NULL, 10);
+    if (errno)
+        program_exit (2, "Invalid pid");
+
+    sleep (TIMEOUT);
+
+    /* if we survived the timeout, we consider the Mono process as hung */
+
+#ifndef HAVE_KILL
+    /* just inform the user */
+    printf ("Mono process with pid %llu appears to be hung", (uint64_t)pid);
+    return 0;
+#else
+    printf ("Mono process hang detected, sending kill signal to pid %llu\n", (uint64_t)pid);
+    return kill (pid, SIGKILL);
+#endif
+}
+
+void program_exit (int exit_code, const char* message)
+{
+    if (message)
+        printf ("%s\n", message);
+    printf ("Usage: '%s [pid]'\t\t[pid]: The id for the Mono process\n", program_name);
+    exit (exit_code);
+}


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/15646

macOS does not like signals being sent from the forked supervisor process, possibly towards anywhere but definitely when sent to the parent process. The following message is currently spewed after the supervisor process attempting to send a SIGSEGV to a hanged Mono process:
"The process has forked and you cannot use this CoreFoundation functionality safely. You MUST exec()."

We follow that direction and introduce a new binary that, when available, is used to abort the parent process for us.