### PR TITLE
Add com.apple.security.cs.allow-unsigned-executable-memory exception to hardened runtime entitlements

### DIFF
--- a/mono/mini/mac-entitlements.plist
+++ b/mono/mini/mac-entitlements.plist
@@ -1,7 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
-		<key>com.apple.security.cs.allow-jit</key><true/>
-		<key>com.apple.security.cs.allow-dyld-environment-variables</key><true/>
-		<key>com.apple.security.cs.disable-library-validation</key><true/>
+		<key>com.apple.security.cs.allow-jit</key>
+		<true/>
+		<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+		<true/>
+		<key>com.apple.security.cs.allow-dyld-environment-variables</key>
+		<true/>
+		<key>com.apple.security.cs.disable-library-validation</key>
+		<true/>
 	</dict>
 </plist>


### PR DESCRIPTION
This avoids the issue from https://github.com/mono/mono/issues/13445 when hardened runtime is enabled.
