### PR TITLE
[sdb] Fix TypeMirror.CSharpName computation

### DIFF
--- a/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/TypeMirror.cs
+++ b/mcs/class/Mono.Debugger.Soft/Mono.Debugger.Soft/TypeMirror.cs
@@ -357,20 +357,18 @@ namespace Mono.Debugger.Soft
 		public string CSharpName {
 			get {
 				if (IsArray) {
-					if (GetArrayRank () == 1)
+					var ranks = GetArrayRank ();
+
+					if (ranks == 1)
 						return GetElementType ().CSharpName + "[]";
-					else {
-						string ranks = "";
-						for (int i = 0; i < GetArrayRank (); ++i)
-							ranks += ',';
-						return GetElementType ().CSharpName + "[" + ranks + "]";
-					}
+
+					return GetElementType ().CSharpName + "[" + new string(',', ranks - 1) + "]";
 				}
 				if (IsPrimitive) {
 					switch (Name) {
 					case "Byte":
 						return "byte";
-					case "Sbyte":
+					case "SByte":
 						return "sbyte";
 					case "Char":
 						return "char";


### PR DESCRIPTION
Fixing two issues in TypeMirror.CSharpName computation (not sure if this property is actively used):
- there is a typo on S**B**yte primitive, preventing System.SByte -> sbyte.
- array rank display is wrong. For example System.Byte[,,,] has GetArrayRank() == 4, so the previous computation gave byte[,,,,] instead of byte[,,,]