### PR TITLE
[2019-06] Print two bytes at a time in mono_pe_file_map conversion error

### DIFF
--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -1032,7 +1032,9 @@ mono_pe_file_map (gunichar2 *filename, gint32 *map_size, void **handle)
 		GString *raw_bytes = g_string_new (NULL);
 		char *p = (char*)filename;
 		while (*p != 0) {
-			g_string_append_printf (raw_bytes, "%02X ", (int)*p);
+			g_string_append_printf (raw_bytes, "%02X ", (uint)*p);
+			p++;
+			g_string_append_printf (raw_bytes, "%02X ", (uint)*p);
 			p++;
 		}
 		g_assertf (filename_ext != NULL, "%s: unicode conversion returned NULL; %s; input was: %s", __func__, mono_error_get_message (error), raw_bytes->str);

--- a/mono/utils/mono-proclib.c
+++ b/mono/utils/mono-proclib.c
@@ -1030,13 +1030,9 @@ mono_pe_file_map (gunichar2 *filename, gint32 *map_size, void **handle)
 	// This block was added to diagnose https://github.com/mono/mono/issues/14730, remove after resolved
 	if (G_UNLIKELY (filename_ext == NULL)) {
 		GString *raw_bytes = g_string_new (NULL);
-		char *p = (char*)filename;
-		while (*p != 0) {
-			g_string_append_printf (raw_bytes, "%02X ", (uint)*p);
-			p++;
-			g_string_append_printf (raw_bytes, "%02X ", (uint)*p);
-			p++;
-		}
+		const gunichar2 *p = filename;
+		while (*p)
+			g_string_append_printf (raw_bytes, "%04X ", *p++);
 		g_assertf (filename_ext != NULL, "%s: unicode conversion returned NULL; %s; input was: %s", __func__, mono_error_get_message (error), raw_bytes->str);
 		g_string_free (raw_bytes, TRUE);
 	}


### PR DESCRIPTION
I didn't think this through with the initial attempt. Since this is UTF-16 the string comes in pairs of two-bytes, with one of them often being null when converted up from ASCII. This should print the string properly.

Backport of #15523.

/cc @CoffeeFlux 