### PR TITLE
[2019-06] [mini] Runtime check if boxing is needed for DIM constrained calls

### DIFF
--- a/mono/mini/method-to-ir.c
+++ b/mono/mini/method-to-ir.c
@@ -5609,10 +5609,12 @@ handle_constrained_call (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignat
 		 * A simple solution would be to box always and make a normal virtual call, but that would
 		 * be bad performance wise.
 		 */
-		if (mono_class_is_interface (cmethod->klass) && mono_class_is_ginst (cmethod->klass)) {
+		if (mono_class_is_interface (cmethod->klass) && mono_class_is_ginst (cmethod->klass) &&
+		    (cmethod->flags & METHOD_ATTRIBUTE_ABSTRACT)) {
 			/*
 			 * The parent classes implement no generic interfaces, so the called method will be a vtype method, so no boxing neccessary.
 			 */
+			/* If the method is not abstract, it's a default interface method, and we need to box */
 			need_box = FALSE;
 		}
 

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -1726,7 +1726,6 @@ KNOWN_FAILING_TESTS = \
 	appdomain-marshalbyref-assemblyload.exe	\
 	abort-try-holes.exe \
 	threads-init.exe \
-	dim-constrainedcall.exe \
 	gptail1.exe \
 	itaili1.exe \
 	sirtail1.exe \


### PR DESCRIPTION
This supersedes #14166 - enable `dim-constrainedcall.exe` and also make a fix so it works with FullAOT. 

---

This is to handle the following example.  The issue is that in `Check()` we have
a constrained call where the called method is ``IAdder`1<!!U>::PlusPlus()`` which
is a default interface method, and we need to determine at runtime whether to
box the this argument.

```csharp
using System;

public interface IAdder<T> {
	int Add (int x);

	int PlusPlus () {
		return Add (1);
	}
}

interface IGen3<T> { }

struct Adder<T> : IAdder<IGen3<T>> {
	int _field;
	public int Add (int x) {
		_field = x + _field;
		return _field;
	}
}

public class P {
	public static int Check<T, U>(T t) where T : IAdder<U> {
		return t.PlusPlus () + t.PlusPlus ();
	}

	public static void Main () {
		var x = new Adder<object> ();
		int y = Check<Adder<object>, IGen3<object>> (x);
		Console.WriteLine ("expect 2, got {0}", y);
	}
}
```



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->


Backport of #15729.

/cc @lambdageek 