### PR TITLE
[wasm][bindings] WebAssembly.Core.Array.Pop should return null 

### DIFF
--- a/sdks/wasm/framework/src/WebAssembly.Bindings/Core/Array.cs
+++ b/sdks/wasm/framework/src/WebAssembly.Bindings/Core/Array.cs
@@ -27,7 +27,7 @@ namespace WebAssembly.Core {
 		/// Pop this instance.
 		/// </summary>
 		/// <returns>The element removed from the array or null if the array was empty</returns>
-		public int Pop () => (int)Invoke ("pop");
+		public object Pop () => (object)Invoke ("pop");
 		/// <summary>
 		/// Remove the first element of the Array and return that element
 		/// </summary>

--- a/sdks/wasm/tests/browser/src/BindingsTestSuite/BindingsTestSuite.cs
+++ b/sdks/wasm/tests/browser/src/BindingsTestSuite/BindingsTestSuite.cs
@@ -253,5 +253,10 @@ namespace BindingsTestSuite
             return x;
         }
 
+        public static object ArrayPop () 
+        {
+            var arr = new WebAssembly.Core.Array();
+            return arr.Pop();
+        }
     }
 }

--- a/sdks/wasm/tests/browser/src/BrowserTestSuite/core-bindings-spec.js
+++ b/sdks/wasm/tests/browser/src/BrowserTestSuite/core-bindings-spec.js
@@ -534,5 +534,13 @@ describe("The WebAssembly Core Bindings Test Suite",function(){
       assert.equal(view.getUint8(1), 123, "result does not match value 123.");
     }, DEFAULT_TIMEOUT);  
 
+    it('BindingTestSuite: Pop should return undefined if Array is empty.', () => {
+      //karmaHTML.corebindingsspec.document gives the access to the Document object of 'http-spec.html' file
+      var _document = karmaHTML.corebindingsspec.document;
+
+      var pop = _document.Module.BINDING.call_static_method("[BindingsTestSuite]BindingsTestSuite.Program:ArrayPop", []);
+      assert.equal(pop, undefined, "result does not match expected value unidentified.");
+      assert.equal(pop, null, "result does not match expected value null.");
+    }, DEFAULT_TIMEOUT);  
 
   });


### PR DESCRIPTION
if the WebAssembly.Core.Array is empty instead of throwing error.

- Add test to the BindingsTestSuite.

Fixes https://github.com/mono/mono/issues/15731